### PR TITLE
sessions: remember tunnel disconnects

### DIFF
--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -108,7 +108,7 @@ export interface IActionListItem<T> {
 	 * Optional callback invoked when the item is removed via the built-in remove button.
 	 * When set, a close button is automatically added to the item toolbar.
 	 */
-	readonly onRemove?: () => void;
+	readonly onRemove?: () => void | Promise<void>;
 }
 
 interface IActionMenuTemplateData {
@@ -368,8 +368,8 @@ class ActionItemRenderer<T> implements IListRenderer<IActionListItem<T>, IAction
 				id: 'actionList.remove',
 				label: localize('actionList.remove', "Remove"),
 				class: ThemeIcon.asClassName(Codicon.close),
-				run: () => {
-					element.onRemove!();
+				run: async () => {
+					await element.onRemove!();
 					this._onRemoveItem?.(element);
 				},
 			}));

--- a/src/vs/platform/agentHost/common/tunnelAgentHost.ts
+++ b/src/vs/platform/agentHost/common/tunnelAgentHost.ts
@@ -207,6 +207,15 @@ export interface ITunnelAgentHostService {
 	/** Remove a tunnel from the cache. */
 	removeCachedTunnel(tunnelId: string): void;
 
+	/** Whether startup/background auto-connect should skip this tunnel because the user disconnected it. */
+	isAutoConnectSuppressed(tunnelId: string): boolean;
+
+	/** Remember that the user explicitly disconnected this tunnel, so startup/background auto-connect skips it. */
+	suppressAutoConnect(tunnelId: string): void;
+
+	/** Clear a previous user-disconnect marker after the user explicitly reconnects this tunnel. */
+	clearAutoConnectSuppression(tunnelId: string): void;
+
 	/**
 	 * Determine which auth provider has an existing cached session.
 	 * When {@link silent} is true, does not prompt the user.

--- a/src/vs/sessions/contrib/chat/browser/scopedWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/scopedWorkspacePicker.ts
@@ -8,7 +8,6 @@ import { localize } from '../../../../nls.js';
 import { IActionWidgetService } from '../../../../platform/actionWidget/browser/actionWidget.js';
 import { ActionListItemKind, IActionListItem } from '../../../../platform/actionWidget/browser/actionList.js';
 import { IMenuService } from '../../../../platform/actions/common/actions.js';
-import { IRemoteAgentHostService } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
@@ -39,7 +38,6 @@ export class ScopedWorkspacePicker extends WorkspacePicker {
 		@IStorageService storageService: IStorageService,
 		@IUriIdentityService uriIdentityService: IUriIdentityService,
 		@ISessionsProvidersService sessionsProvidersService: ISessionsProvidersService,
-		@IRemoteAgentHostService remoteAgentHostService: IRemoteAgentHostService,
 		@IConfigurationService configurationService: IConfigurationService,
 		@ICommandService commandService: ICommandService,
 		@IWorkspacesService workspacesService: IWorkspacesService,
@@ -55,7 +53,6 @@ export class ScopedWorkspacePicker extends WorkspacePicker {
 			storageService,
 			uriIdentityService,
 			sessionsProvidersService,
-			remoteAgentHostService,
 			configurationService,
 			commandService,
 			workspacesService,

--- a/src/vs/sessions/contrib/chat/browser/scopedWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/scopedWorkspacePicker.ts
@@ -8,6 +8,7 @@ import { localize } from '../../../../nls.js';
 import { IActionWidgetService } from '../../../../platform/actionWidget/browser/actionWidget.js';
 import { ActionListItemKind, IActionListItem } from '../../../../platform/actionWidget/browser/actionList.js';
 import { IMenuService } from '../../../../platform/actions/common/actions.js';
+import { IRemoteAgentHostService } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
@@ -38,6 +39,7 @@ export class ScopedWorkspacePicker extends WorkspacePicker {
 		@IStorageService storageService: IStorageService,
 		@IUriIdentityService uriIdentityService: IUriIdentityService,
 		@ISessionsProvidersService sessionsProvidersService: ISessionsProvidersService,
+		@IRemoteAgentHostService remoteAgentHostService: IRemoteAgentHostService,
 		@IConfigurationService configurationService: IConfigurationService,
 		@ICommandService commandService: ICommandService,
 		@IWorkspacesService workspacesService: IWorkspacesService,
@@ -53,6 +55,7 @@ export class ScopedWorkspacePicker extends WorkspacePicker {
 			storageService,
 			uriIdentityService,
 			sessionsProvidersService,
+			remoteAgentHostService,
 			configurationService,
 			commandService,
 			workspacesService,

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -18,7 +18,7 @@ import { IActionWidgetService } from '../../../../platform/actionWidget/browser/
 import { ActionListItemKind, IActionListDelegate, IActionListItem, IActionListOptions } from '../../../../platform/actionWidget/browser/actionList.js';
 import { TabbedActionListWidget } from '../../../../platform/actionWidget/browser/tabbedActionListWidget.js';
 import { IMenuService, MenuItemAction } from '../../../../platform/actions/common/actions.js';
-import { RemoteAgentHostConnectionStatus } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { IRemoteAgentHostService, RemoteAgentHostConnectionStatus } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { TUNNEL_ADDRESS_PREFIX } from '../../../../platform/agentHost/common/tunnelAgentHost.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
@@ -33,7 +33,7 @@ import { ISessionWorkspace, ISessionWorkspaceBrowseAction, SESSION_WORKSPACE_GRO
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
 import { IAgentHostSessionsProvider, isAgentHostProvider } from '../../../common/agentHostSessionsProvider.js';
 import { SessionWorkspacePickerGroupContext } from '../../../common/contextkeys.js';
-import { getStatusHover, getStatusLabel, showRemoteHostOptions } from '../../remoteAgentHost/browser/remoteHostOptions.js';
+import { getStatusHover, getStatusLabel, removeRemoteHost, showRemoteHostOptions } from '../../remoteAgentHost/browser/remoteHostOptions.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { COPILOT_PROVIDER_ID } from '../../copilotChatSessions/browser/copilotChatSessionsProvider.js';
 import { IWorkspacesService, isRecentFolder } from '../../../../platform/workspaces/common/workspaces.js';
@@ -156,6 +156,7 @@ export class WorkspacePicker extends Disposable {
 		@IStorageService private readonly storageService: IStorageService,
 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
 		@ISessionsProvidersService protected readonly sessionsProvidersService: ISessionsProvidersService,
+		@IRemoteAgentHostService private readonly remoteAgentHostService: IRemoteAgentHostService,
 		@IConfigurationService _configurationService: IConfigurationService,
 		@ICommandService private readonly commandService: ICommandService,
 		@IWorkspacesService private readonly workspacesService: IWorkspacesService,
@@ -687,7 +688,7 @@ export class WorkspacePicker extends Disposable {
 				extended.hoverContent = getStatusHover(status, provider.remoteAddress);
 				if (provider.remoteAddress) {
 					extended.onRemove = async () => {
-						await provider.disconnect?.();
+						await removeRemoteHost(provider, this.remoteAgentHostService);
 					};
 				}
 				manageActions.push(action);

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -18,7 +18,7 @@ import { IActionWidgetService } from '../../../../platform/actionWidget/browser/
 import { ActionListItemKind, IActionListDelegate, IActionListItem, IActionListOptions } from '../../../../platform/actionWidget/browser/actionList.js';
 import { TabbedActionListWidget } from '../../../../platform/actionWidget/browser/tabbedActionListWidget.js';
 import { IMenuService, MenuItemAction } from '../../../../platform/actions/common/actions.js';
-import { IRemoteAgentHostService, RemoteAgentHostConnectionStatus } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { RemoteAgentHostConnectionStatus } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { TUNNEL_ADDRESS_PREFIX } from '../../../../platform/agentHost/common/tunnelAgentHost.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
@@ -90,6 +90,8 @@ export interface IWorkspacePickerItem {
 	readonly run?: () => void;
 }
 
+type IWorkspacePickerAction = IAction & { icon?: ThemeIcon; hoverContent?: string; onRemove?: () => void };
+
 /**
  * A unified workspace picker that shows workspaces from all registered session
  * providers in a single dropdown.
@@ -154,7 +156,6 @@ export class WorkspacePicker extends Disposable {
 		@IStorageService private readonly storageService: IStorageService,
 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
 		@ISessionsProvidersService protected readonly sessionsProvidersService: ISessionsProvidersService,
-		@IRemoteAgentHostService private readonly remoteAgentHostService: IRemoteAgentHostService,
 		@IConfigurationService _configurationService: IConfigurationService,
 		@ICommandService private readonly commandService: ICommandService,
 		@IWorkspacesService private readonly workspacesService: IWorkspacesService,
@@ -681,13 +682,12 @@ export class WorkspacePicker extends Disposable {
 						this._showRemoteHostOptionsDelayed(provider);
 					},
 				});
-				const extended = action as IAction & { icon?: ThemeIcon; hoverContent?: string; onRemove?: () => void };
+				const extended = action as IWorkspacePickerAction;
 				extended.icon = isTunnel ? Codicon.cloud : Codicon.remote;
 				extended.hoverContent = getStatusHover(status, provider.remoteAddress);
-				if (!isTunnel && provider.remoteAddress) {
-					const address = provider.remoteAddress;
+				if (provider.remoteAddress) {
 					extended.onRemove = async () => {
-						await this.remoteAgentHostService.removeRemoteAgentHost(address);
+						await provider.disconnect?.();
 					};
 				}
 				manageActions.push(action);
@@ -709,12 +709,14 @@ export class WorkspacePicker extends Disposable {
 				items.push({ kind: ActionListItemKind.Separator, label: '' });
 			}
 			for (const action of manageActions) {
-				const icon = (action as IAction & { icon?: ThemeIcon }).icon;
+				const extended = action as IWorkspacePickerAction;
 				items.push({
 					kind: ActionListItemKind.Action,
 					label: action.label,
-					group: { title: '', icon: icon ?? Codicon.settingsGear },
+					description: extended.onRemove ? action.tooltip || undefined : undefined,
+					group: { title: '', icon: extended.icon ?? Codicon.settingsGear },
 					item: { run: () => action.run(), commandId: action.id },
+					onRemove: extended.onRemove,
 				});
 			}
 		}

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/manageRemoteAgentHosts.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/manageRemoteAgentHosts.ts
@@ -12,14 +12,14 @@ import { Action2, IMenuService, MenuItemAction, registerAction2 } from '../../..
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { ContextKeyExpr, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { ServicesAccessor, IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
-import { RemoteAgentHostsEnabledSettingId } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { IRemoteAgentHostService, RemoteAgentHostsEnabledSettingId } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { TUNNEL_ADDRESS_PREFIX } from '../../../../platform/agentHost/common/tunnelAgentHost.js';
 import { IQuickInputButton, IQuickInputService, IQuickPickItem, IQuickPickSeparator } from '../../../../platform/quickinput/common/quickInput.js';
 import { Menus } from '../../../browser/menus.js';
 import { SessionsCategories } from '../../../common/categories.js';
 import { IAgentHostSessionsProvider, isAgentHostProvider } from '../../../common/agentHostSessionsProvider.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
-import { getStatusLabel, showRemoteHostOptions } from './remoteHostOptions.js';
+import { getStatusLabel, removeRemoteHost, showRemoteHostOptions } from './remoteHostOptions.js';
 import { RemoteAgentHostCommandIds } from './remoteAgentHostActions.js';
 
 interface IRemoteHostQuickPickItem extends IQuickPickItem {
@@ -48,6 +48,7 @@ registerAction2(class extends Action2 {
 	override async run(accessor: ServicesAccessor): Promise<void> {
 		const quickInputService = accessor.get(IQuickInputService);
 		const sessionsProvidersService = accessor.get(ISessionsProvidersService);
+		const remoteAgentHostService = accessor.get(IRemoteAgentHostService);
 		const menuService = accessor.get(IMenuService);
 		const contextKeyService = accessor.get(IContextKeyService);
 		const commandService = accessor.get(ICommandService);
@@ -141,7 +142,7 @@ registerAction2(class extends Action2 {
 
 			store.add(picker.onDidTriggerItemButton(async e => {
 				if (e.item.kind === 'remote' && e.button === removeButton) {
-					await e.item.provider.disconnect?.();
+					await removeRemoteHost(e.item.provider, remoteAgentHostService);
 					// onDidChangeProviders will refresh
 				}
 			}));

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/manageRemoteAgentHosts.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/manageRemoteAgentHosts.ts
@@ -12,7 +12,7 @@ import { Action2, IMenuService, MenuItemAction, registerAction2 } from '../../..
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { ContextKeyExpr, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { ServicesAccessor, IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
-import { IRemoteAgentHostService, RemoteAgentHostsEnabledSettingId } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { RemoteAgentHostsEnabledSettingId } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { TUNNEL_ADDRESS_PREFIX } from '../../../../platform/agentHost/common/tunnelAgentHost.js';
 import { IQuickInputButton, IQuickInputService, IQuickPickItem, IQuickPickSeparator } from '../../../../platform/quickinput/common/quickInput.js';
 import { Menus } from '../../../browser/menus.js';
@@ -48,7 +48,6 @@ registerAction2(class extends Action2 {
 	override async run(accessor: ServicesAccessor): Promise<void> {
 		const quickInputService = accessor.get(IQuickInputService);
 		const sessionsProvidersService = accessor.get(ISessionsProvidersService);
-		const remoteAgentHostService = accessor.get(IRemoteAgentHostService);
 		const menuService = accessor.get(IMenuService);
 		const contextKeyService = accessor.get(IContextKeyService);
 		const commandService = accessor.get(ICommandService);
@@ -74,9 +73,7 @@ registerAction2(class extends Action2 {
 					description: status !== undefined ? getStatusLabel(status) : undefined,
 					detail: p.remoteAddress,
 				};
-				if (!isTunnel) {
-					(item as IRemoteHostQuickPickItem & { buttons?: IQuickInputButton[] }).buttons = [removeButton];
-				}
+				(item as IRemoteHostQuickPickItem & { buttons?: IQuickInputButton[] }).buttons = [removeButton];
 				return item;
 			});
 
@@ -144,11 +141,8 @@ registerAction2(class extends Action2 {
 
 			store.add(picker.onDidTriggerItemButton(async e => {
 				if (e.item.kind === 'remote' && e.button === removeButton) {
-					const address = e.item.provider.remoteAddress;
-					if (address) {
-						await remoteAgentHostService.removeRemoteAgentHost(address);
-						// onDidChangeProviders will refresh
-					}
+					await e.item.provider.disconnect?.();
+					// onDidChangeProviders will refresh
 				}
 			}));
 

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteHostOptions.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteHostOptions.ts
@@ -5,13 +5,29 @@
 
 import { localize } from '../../../../nls.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
-import { RemoteAgentHostConnectionStatus } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { IRemoteAgentHostService, RemoteAgentHostConnectionStatus } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { IQuickInputService, IQuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
 import { IOutputService } from '../../../../workbench/services/output/common/output.js';
 import { IPreferencesService } from '../../../../workbench/services/preferences/common/preferences.js';
 import { IAgentHostSessionsProvider } from '../../../common/agentHostSessionsProvider.js';
+
+export async function reconnectRemoteHost(provider: IAgentHostSessionsProvider, remoteAgentHostService: IRemoteAgentHostService): Promise<void> {
+	if (provider.connect) {
+		await provider.connect();
+	} else if (provider.remoteAddress) {
+		remoteAgentHostService.reconnect(provider.remoteAddress);
+	}
+}
+
+export async function removeRemoteHost(provider: IAgentHostSessionsProvider, remoteAgentHostService: IRemoteAgentHostService): Promise<void> {
+	if (provider.disconnect) {
+		await provider.disconnect();
+	} else if (provider.remoteAddress) {
+		await remoteAgentHostService.removeRemoteAgentHost(provider.remoteAddress);
+	}
+}
 
 export function getStatusLabel(status: RemoteAgentHostConnectionStatus): string {
 	switch (status) {
@@ -65,6 +81,7 @@ export async function showRemoteHostOptions(accessor: ServicesAccessor, provider
 	}
 
 	const quickInputService = accessor.get(IQuickInputService);
+	const remoteAgentHostService = accessor.get(IRemoteAgentHostService);
 	const clipboardService = accessor.get(IClipboardService);
 	const preferencesService = accessor.get(IPreferencesService);
 	const outputService = accessor.get(IOutputService);
@@ -120,10 +137,10 @@ export async function showRemoteHostOptions(accessor: ServicesAccessor, provider
 
 	switch (result.id) {
 		case 'reconnect':
-			await provider.connect?.();
+			await reconnectRemoteHost(provider, remoteAgentHostService);
 			break;
 		case 'remove':
-			await provider.disconnect?.();
+			await removeRemoteHost(provider, remoteAgentHostService);
 			break;
 		case 'copy':
 			await clipboardService.writeText(address);

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteHostOptions.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteHostOptions.ts
@@ -5,7 +5,7 @@
 
 import { localize } from '../../../../nls.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
-import { IRemoteAgentHostService, RemoteAgentHostConnectionStatus } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { RemoteAgentHostConnectionStatus } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { IQuickInputService, IQuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
@@ -65,7 +65,6 @@ export async function showRemoteHostOptions(accessor: ServicesAccessor, provider
 	}
 
 	const quickInputService = accessor.get(IQuickInputService);
-	const remoteAgentHostService = accessor.get(IRemoteAgentHostService);
 	const clipboardService = accessor.get(IClipboardService);
 	const preferencesService = accessor.get(IPreferencesService);
 	const outputService = accessor.get(IOutputService);
@@ -121,10 +120,10 @@ export async function showRemoteHostOptions(accessor: ServicesAccessor, provider
 
 	switch (result.id) {
 		case 'reconnect':
-			remoteAgentHostService.reconnect(address);
+			await provider.connect?.();
 			break;
 		case 'remove':
-			await remoteAgentHostService.removeRemoteAgentHost(address);
+			await provider.disconnect?.();
 			break;
 		case 'copy':
 			await clipboardService.writeText(address);
@@ -140,4 +139,3 @@ export async function showRemoteHostOptions(accessor: ServicesAccessor, provider
 	}
 	return undefined;
 }
-

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/tunnelAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/tunnelAgentHost.contribution.ts
@@ -261,6 +261,10 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 		if (!cached) {
 			return Promise.resolve();
 		}
+		if (!options.userInitiated && this._tunnelService.isAutoConnectSuppressed(tunnelId)) {
+			this._logService.info(`[TunnelAgentHost] Skipping background connect for user-disconnected tunnel ${address}`);
+			return Promise.resolve();
+		}
 
 		// A new attempt is starting — cancel any scheduled reconnect timer;
 		// success/failure of this attempt will drive the next decision.
@@ -292,6 +296,15 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 					hostConnectionCount: 0,
 				};
 				await this._tunnelService.connect(tunnelInfo, cached.authProvider);
+				if (!options.userInitiated && this._tunnelService.isAutoConnectSuppressed(cached.tunnelId)) {
+					this._logService.info(`[TunnelAgentHost] Disconnecting background connection for user-disconnected tunnel ${address}`);
+					await this._tunnelService.disconnect(address);
+					this._connectSessions.delete(address);
+					return;
+				}
+				if (options.userInitiated) {
+					this._tunnelService.clearAutoConnectSuppression(cached.tunnelId);
+				}
 				this._finishConnectAttempt(address, { success: true, attemptNumber, attemptStart, session, isReconnect });
 			} catch (err) {
 				this._logService.warn(`[TunnelAgentHost] Connect to ${cached.name} failed:`, err);
@@ -347,6 +360,7 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 	private async _disconnectTunnel(address: string): Promise<void> {
 		this._cancelReconnect(address);
 		this._resetReconnectState(address);
+		this._tunnelService.suppressAutoConnect(address.slice(TUNNEL_ADDRESS_PREFIX.length));
 		// Mark as explicitly disconnected so `_handleConnectionChanges` does
 		// not treat the impending Connected→(removed) transition as a
 		// reconnect-worthy drop.
@@ -803,6 +817,9 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 				for (const tunnel of onlineTunnels) {
 					if (tunnel.hostConnectionCount > 0) {
 						const address = `${TUNNEL_ADDRESS_PREFIX}${tunnel.tunnelId}`;
+						if (this._tunnelService.isAutoConnectSuppressed(tunnel.tunnelId)) {
+							continue;
+						}
 						const alreadyConnected = this._remoteAgentHostService.connections.some(
 							c => c.address === address && c.status === RemoteAgentHostConnectionStatus.Connected
 						);

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/tunnelAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/tunnelAgentHost.contribution.ts
@@ -167,7 +167,7 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 
 	private _reconcileProviders(): void {
 		const enabled = this._configurationService.getValue<boolean>(RemoteAgentHostsEnabledSettingId);
-		const cached = enabled ? this._tunnelService.getCachedTunnels() : [];
+		const cached = enabled ? this._getProviderTunnels() : [];
 		const desiredAddresses = new Set(cached.map(t => `${TUNNEL_ADDRESS_PREFIX}${t.tunnelId}`));
 
 		// Remove providers no longer cached
@@ -185,6 +185,10 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 				this._createProvider(address, tunnel.name);
 			}
 		}
+	}
+
+	private _getProviderTunnels() {
+		return this._tunnelService.getCachedTunnels().filter(tunnel => !this._tunnelService.isAutoConnectSuppressed(tunnel.tunnelId));
 	}
 
 	private _createProvider(address: string, name: string): void {
@@ -265,6 +269,9 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 			this._logService.info(`[TunnelAgentHost] Skipping background connect for user-disconnected tunnel ${address}`);
 			return Promise.resolve();
 		}
+		if (options.userInitiated) {
+			this._tunnelService.clearAutoConnectSuppression(tunnelId);
+		}
 
 		// A new attempt is starting — cancel any scheduled reconnect timer;
 		// success/failure of this attempt will drive the next decision.
@@ -296,14 +303,13 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 					hostConnectionCount: 0,
 				};
 				await this._tunnelService.connect(tunnelInfo, cached.authProvider);
+				// Re-check after the await: the user may have disconnected this
+				// tunnel while this background connect was already in flight.
 				if (!options.userInitiated && this._tunnelService.isAutoConnectSuppressed(cached.tunnelId)) {
 					this._logService.info(`[TunnelAgentHost] Disconnecting background connection for user-disconnected tunnel ${address}`);
 					await this._tunnelService.disconnect(address);
 					this._connectSessions.delete(address);
 					return;
-				}
-				if (options.userInitiated) {
-					this._tunnelService.clearAutoConnectSuppression(cached.tunnelId);
 				}
 				this._finishConnectAttempt(address, { success: true, attemptNumber, attemptStart, session, isReconnect });
 			} catch (err) {
@@ -382,9 +388,7 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 			return;
 		}
 
-		const cachedAddresses = new Set(
-			this._tunnelService.getCachedTunnels().map(t => `${TUNNEL_ADDRESS_PREFIX}${t.tunnelId}`)
-		);
+		const cachedAddresses = new Set(this._getProviderTunnels().map(t => `${TUNNEL_ADDRESS_PREFIX}${t.tunnelId}`));
 		const currentStatuses = new Map<string, RemoteAgentHostConnectionStatus>();
 		for (const conn of this._remoteAgentHostService.connections) {
 			currentStatuses.set(conn.address, conn.status);
@@ -683,7 +687,7 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 		}
 		this._lastResumeAt = now;
 
-		const cached = this._tunnelService.getCachedTunnels();
+		const cached = this._getProviderTunnels();
 		for (const tunnel of cached) {
 			const address = `${TUNNEL_ADDRESS_PREFIX}${tunnel.tunnelId}`;
 			if (this._pendingConnects.has(address)) {
@@ -708,9 +712,7 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 
 	/** Drop reconnect state for addresses whose tunnel is no longer cached. */
 	private _pruneReconnectState(): void {
-		const cachedAddresses = new Set(
-			this._tunnelService.getCachedTunnels().map(t => `${TUNNEL_ADDRESS_PREFIX}${t.tunnelId}`)
-		);
+		const cachedAddresses = new Set(this._getProviderTunnels().map(t => `${TUNNEL_ADDRESS_PREFIX}${t.tunnelId}`));
 		const tracked = new Set<string>([
 			...this._reconnectTimeouts.keys(),
 			...this._reconnectAttempts.keys(),

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/webTunnelAgentHostService.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/webTunnelAgentHostService.ts
@@ -30,6 +30,8 @@ const LOG_PREFIX = '[WebTunnelAgentHost]';
 
 /** Storage key for recently used tunnel cache. */
 const CACHED_TUNNELS_KEY = 'tunnelAgentHost.recentTunnels';
+/** Storage key for tunnels the user explicitly disconnected. */
+const AUTO_CONNECT_SUPPRESSED_TUNNELS_KEY = 'tunnelAgentHost.autoConnectSuppressedTunnels';
 
 /**
  * Web (browser) implementation of {@link ITunnelAgentHostService}.
@@ -201,6 +203,7 @@ export class WebTunnelAgentHostService extends Disposable implements ITunnelAgen
 			name: tunnel.name,
 			authProvider,
 		});
+		this.clearAutoConnectSuppression(tunnel.tunnelId);
 		this._storeCachedTunnels(filtered.slice(0, 20));
 		this._onDidChangeTunnels.fire();
 	}
@@ -208,7 +211,26 @@ export class WebTunnelAgentHostService extends Disposable implements ITunnelAgen
 	removeCachedTunnel(tunnelId: string): void {
 		const cached = this.getCachedTunnels();
 		this._storeCachedTunnels(cached.filter(t => t.tunnelId !== tunnelId));
+		this.clearAutoConnectSuppression(tunnelId);
 		this._onDidChangeTunnels.fire();
+	}
+
+	isAutoConnectSuppressed(tunnelId: string): boolean {
+		return this._getAutoConnectSuppressedTunnels().has(tunnelId);
+	}
+
+	suppressAutoConnect(tunnelId: string): void {
+		const suppressed = this._getAutoConnectSuppressedTunnels();
+		suppressed.add(tunnelId);
+		this._storeAutoConnectSuppressedTunnels(suppressed);
+	}
+
+	clearAutoConnectSuppression(tunnelId: string): void {
+		const suppressed = this._getAutoConnectSuppressedTunnels();
+		if (!suppressed.delete(tunnelId)) {
+			return;
+		}
+		this._storeAutoConnectSuppressedTunnels(suppressed);
 	}
 
 	private _storeCachedTunnels(tunnels: ICachedTunnel[]): void {
@@ -216,6 +238,30 @@ export class WebTunnelAgentHostService extends Disposable implements ITunnelAgen
 			this._storageService.remove(CACHED_TUNNELS_KEY, StorageScope.APPLICATION);
 		} else {
 			this._storageService.store(CACHED_TUNNELS_KEY, JSON.stringify(tunnels), StorageScope.APPLICATION, StorageTarget.USER);
+		}
+	}
+
+	private _getAutoConnectSuppressedTunnels(): Set<string> {
+		const raw = this._storageService.get(AUTO_CONNECT_SUPPRESSED_TUNNELS_KEY, StorageScope.APPLICATION);
+		if (!raw) {
+			return new Set();
+		}
+		try {
+			const parsed: unknown = JSON.parse(raw);
+			if (!Array.isArray(parsed)) {
+				return new Set();
+			}
+			return new Set(parsed.filter(item => typeof item === 'string'));
+		} catch {
+			return new Set();
+		}
+	}
+
+	private _storeAutoConnectSuppressedTunnels(tunnelIds: Set<string>): void {
+		if (tunnelIds.size === 0) {
+			this._storageService.remove(AUTO_CONNECT_SUPPRESSED_TUNNELS_KEY, StorageScope.APPLICATION);
+		} else {
+			this._storageService.store(AUTO_CONNECT_SUPPRESSED_TUNNELS_KEY, JSON.stringify([...tunnelIds]), StorageScope.APPLICATION, StorageTarget.USER);
 		}
 	}
 }

--- a/src/vs/sessions/contrib/remoteAgentHost/electron-browser/tunnelAgentHostServiceImpl.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/electron-browser/tunnelAgentHostServiceImpl.ts
@@ -29,6 +29,8 @@ const LOG_PREFIX = '[TunnelAgentHost]';
 
 /** Storage key for recently used tunnel cache. */
 const CACHED_TUNNELS_KEY = 'tunnelAgentHost.recentTunnels';
+/** Storage key for tunnels the user explicitly disconnected. */
+const AUTO_CONNECT_SUPPRESSED_TUNNELS_KEY = 'tunnelAgentHost.autoConnectSuppressedTunnels';
 
 /**
  * Renderer-side implementation of {@link ITunnelAgentHostService} that
@@ -256,6 +258,7 @@ export class TunnelAgentHostService extends Disposable implements ITunnelAgentHo
 			name: tunnel.name,
 			authProvider,
 		});
+		this.clearAutoConnectSuppression(tunnel.tunnelId);
 		this._storeCachedTunnels(filtered.slice(0, 20));
 		this._onDidChangeTunnels.fire();
 	}
@@ -263,7 +266,26 @@ export class TunnelAgentHostService extends Disposable implements ITunnelAgentHo
 	removeCachedTunnel(tunnelId: string): void {
 		const cached = this.getCachedTunnels();
 		this._storeCachedTunnels(cached.filter(t => t.tunnelId !== tunnelId));
+		this.clearAutoConnectSuppression(tunnelId);
 		this._onDidChangeTunnels.fire();
+	}
+
+	isAutoConnectSuppressed(tunnelId: string): boolean {
+		return this._getAutoConnectSuppressedTunnels().has(tunnelId);
+	}
+
+	suppressAutoConnect(tunnelId: string): void {
+		const suppressed = this._getAutoConnectSuppressedTunnels();
+		suppressed.add(tunnelId);
+		this._storeAutoConnectSuppressedTunnels(suppressed);
+	}
+
+	clearAutoConnectSuppression(tunnelId: string): void {
+		const suppressed = this._getAutoConnectSuppressedTunnels();
+		if (!suppressed.delete(tunnelId)) {
+			return;
+		}
+		this._storeAutoConnectSuppressedTunnels(suppressed);
 	}
 
 	private _storeCachedTunnels(tunnels: ICachedTunnel[]): void {
@@ -271,6 +293,30 @@ export class TunnelAgentHostService extends Disposable implements ITunnelAgentHo
 			this._storageService.remove(CACHED_TUNNELS_KEY, StorageScope.APPLICATION);
 		} else {
 			this._storageService.store(CACHED_TUNNELS_KEY, JSON.stringify(tunnels), StorageScope.APPLICATION, StorageTarget.USER);
+		}
+	}
+
+	private _getAutoConnectSuppressedTunnels(): Set<string> {
+		const raw = this._storageService.get(AUTO_CONNECT_SUPPRESSED_TUNNELS_KEY, StorageScope.APPLICATION);
+		if (!raw) {
+			return new Set();
+		}
+		try {
+			const parsed: unknown = JSON.parse(raw);
+			if (!Array.isArray(parsed)) {
+				return new Set();
+			}
+			return new Set(parsed.filter(item => typeof item === 'string'));
+		} catch {
+			return new Set();
+		}
+	}
+
+	private _storeAutoConnectSuppressedTunnels(tunnelIds: Set<string>): void {
+		if (tunnelIds.size === 0) {
+			this._storageService.remove(AUTO_CONNECT_SUPPRESSED_TUNNELS_KEY, StorageScope.APPLICATION);
+		} else {
+			this._storageService.store(AUTO_CONNECT_SUPPRESSED_TUNNELS_KEY, JSON.stringify([...tunnelIds]), StorageScope.APPLICATION, StorageTarget.USER);
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Add persisted tunnel auto-connect suppression for tunnels the user explicitly disconnects
- Skip startup/background tunnel auto-connect while that suppression is set
- Clear suppression when the user explicitly reconnects or picks the tunnel again
- Route tunnel remove/reconnect UI through provider lifecycle hooks so suppression state is updated consistently

## Notes for reviewers

`product.json` has unrelated local changes in my worktree and is intentionally not part of this PR. (Written by Copilot)