### PR TITLE
agent-host: restore sessions without listing catalog

### DIFF
--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -403,6 +403,9 @@ export interface IAgent {
 	/** List persisted sessions from this provider. */
 	listSessions(): Promise<IAgentSessionMetadata[]>;
 
+	/** Retrieve metadata for a single persisted session, without enumerating the provider catalog. */
+	getSessionMetadata?(session: URI): Promise<IAgentSessionMetadata | undefined>;
+
 	/** Declare protected resources this agent requires auth for (RFC 9728). */
 	getProtectedResources(): ProtectedResourceMetadata[];
 

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -632,7 +632,7 @@ export class AgentService extends Disposable implements IAgentService {
 				} catch (fallbackErr) {
 					if (fallbackErr instanceof ProtocolError) {
 						const message = err instanceof Error ? err.message : String(err);
-						throw new ProtocolError(fallbackErr.code, `Failed to get session metadata for ${sessionStr}: ${message}; ${fallbackErr.message}`);
+						throw new ProtocolError(fallbackErr.code, `Failed to get session metadata for ${sessionStr}: ${message}; ${fallbackErr.message}`, fallbackErr.data);
 					}
 					throw fallbackErr;
 				}

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -506,19 +506,7 @@ export class AgentService extends Disposable implements IAgentService {
 			throw new ProtocolError(AHP_SESSION_NOT_FOUND, `No agent for session: ${sessionStr}`);
 		}
 
-		// Verify the session actually exists on the backend to avoid
-		// creating phantom sessions for made-up URIs.
-		let allSessions;
-		try {
-			allSessions = await agent.listSessions();
-		} catch (err) {
-			if (err instanceof ProtocolError) {
-				throw err;
-			}
-			const message = err instanceof Error ? err.message : String(err);
-			throw new ProtocolError(JSON_RPC_INTERNAL_ERROR, `Failed to list sessions for ${sessionStr}: ${message}`);
-		}
-		const meta = allSessions.find(s => s.session.toString() === sessionStr);
+		const meta = await this._getSessionMetadataForRestore(agent, session);
 		if (!meta) {
 			throw new ProtocolError(AHP_SESSION_NOT_FOUND, `Session not found on backend: ${sessionStr}`);
 		}
@@ -628,6 +616,48 @@ export class AgentService extends Disposable implements IAgentService {
 		// Lazily compute git state for sessions with a working directory;
 		// attaches under `state._meta.git` once ready.
 		this._attachGitState(session, meta.workingDirectory);
+	}
+
+	private async _getSessionMetadataForRestore(agent: IAgent, session: URI): Promise<IAgentSessionMetadata | undefined> {
+		const sessionStr = session.toString();
+		if (agent.getSessionMetadata) {
+			try {
+				return await agent.getSessionMetadata(session);
+			} catch (err) {
+				if (err instanceof ProtocolError) {
+					throw err;
+				}
+				try {
+					return await this._getSessionMetadataFromCatalog(agent, session);
+				} catch (fallbackErr) {
+					if (fallbackErr instanceof ProtocolError) {
+						const message = err instanceof Error ? err.message : String(err);
+						throw new ProtocolError(fallbackErr.code, `Failed to get session metadata for ${sessionStr}: ${message}; ${fallbackErr.message}`);
+					}
+					throw fallbackErr;
+				}
+			}
+		}
+
+		// Older providers only expose catalog enumeration. Keep the fallback so
+		// restore remains compatible, but providers with a direct lookup avoid
+		// blocking session open on a full catalog refresh.
+		return this._getSessionMetadataFromCatalog(agent, session);
+	}
+
+	private async _getSessionMetadataFromCatalog(agent: IAgent, session: URI): Promise<IAgentSessionMetadata | undefined> {
+		const sessionStr = session.toString();
+		let allSessions;
+		try {
+			allSessions = await agent.listSessions();
+		} catch (err) {
+			if (err instanceof ProtocolError) {
+				throw err;
+			}
+			const message = err instanceof Error ? err.message : String(err);
+			throw new ProtocolError(JSON_RPC_INTERNAL_ERROR, `Failed to list sessions for ${sessionStr}: ${message}`);
+		}
+		return allSessions.find(s => s.session.toString() === sessionStr);
 	}
 
 	async resourceRead(uri: URI): Promise<ResourceReadResult> {

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -551,6 +551,39 @@ export class CopilotAgent extends Disposable implements IAgent {
 		return result;
 	}
 
+	async getSessionMetadata(session: URI): Promise<IAgentSessionMetadata | undefined> {
+		const sessionId = AgentSession.id(session);
+		const storedMetadata = await this._readStoredSessionMetadata(session);
+		if (!storedMetadata) {
+			return undefined;
+		}
+
+		const client = await this._ensureClient();
+		const sessionMetadata = await client.getSessionMetadata(sessionId);
+		if (!sessionMetadata) {
+			return undefined;
+		}
+
+		let project = storedMetadata?.project;
+		if (storedMetadata && !storedMetadata.resolved) {
+			const projectLimiter = new Limiter<IAgentSessionProjectInfo | undefined>(1);
+			project = await this._resolveSessionProject(sessionMetadata?.context, projectLimiter, new Map<string, Promise<IAgentSessionProjectInfo | undefined>>());
+			void this._storeSessionProjectResolution(session, project);
+		}
+
+		const workingDirectory = storedMetadata?.workingDirectory ?? (typeof sessionMetadata?.context?.cwd === 'string' ? URI.file(sessionMetadata.context.cwd) : undefined);
+		return {
+			session,
+			startTime: sessionMetadata?.startTime.getTime() ?? Date.now(),
+			modifiedTime: sessionMetadata?.modifiedTime.getTime() ?? Date.now(),
+			project,
+			summary: sessionMetadata?.summary,
+			model: storedMetadata?.model,
+			workingDirectory,
+			customizationDirectory: storedMetadata?.customizationDirectory,
+		};
+	}
+
 	private async _listModels(): Promise<IAgentModelInfo[]> {
 		this._logService.info('[Copilot] Listing models...');
 		const client = await this._ensureClient();

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -649,6 +649,59 @@ suite('AgentService (node dispatcher)', () => {
 			);
 		});
 
+		test('restores known session without listing all provider sessions', async () => {
+			service.registerProvider(copilotAgent);
+			const { session } = await copilotAgent.createSession();
+			service.stateManager.deleteSession(session.toString());
+
+			copilotAgent.sessionMessages = [
+				{ type: 'message', session, role: 'user', messageId: 'msg-1', content: 'Hello', toolRequests: [] },
+				{ type: 'message', session, role: 'assistant', messageId: 'msg-2', content: 'Hi', toolRequests: [] },
+			];
+
+			let listSessionsCalled = false;
+			copilotAgent.listSessions = async () => {
+				listSessionsCalled = true;
+				throw new Error('restoreSession should not enumerate sessions');
+			};
+
+			await service.restoreSession(session);
+
+			assert.strictEqual(listSessionsCalled, false);
+			assert.ok(service.stateManager.getSessionState(session.toString()));
+		});
+
+		test('falls back to listing sessions when direct metadata restore fails', async () => {
+			service.registerProvider(copilotAgent);
+			const { session } = await copilotAgent.createSession();
+			service.stateManager.deleteSession(session.toString());
+
+			copilotAgent.sessionMessages = [
+				{ type: 'message', session, role: 'user', messageId: 'msg-1', content: 'Hello', toolRequests: [] },
+				{ type: 'message', session, role: 'assistant', messageId: 'msg-2', content: 'Hi', toolRequests: [] },
+			];
+
+			copilotAgent.getSessionMetadata = async () => {
+				throw new Error('direct metadata unavailable');
+			};
+			const originalListSessions = copilotAgent.listSessions.bind(copilotAgent);
+			let listSessionsCalled = false;
+			copilotAgent.listSessions = async () => {
+				listSessionsCalled = true;
+				return originalListSessions();
+			};
+
+			await service.restoreSession(session);
+
+			assert.deepStrictEqual({
+				listSessionsCalled,
+				restored: !!service.stateManager.getSessionState(session.toString()),
+			}, {
+				listSessionsCalled: true,
+				restored: true,
+			});
+		});
+
 		test('restores a session with subagent tool calls', async () => {
 			service.registerProvider(copilotAgent);
 			const { session } = await copilotAgent.createSession();

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -131,6 +131,8 @@ class TestSessionDataService extends Disposable implements ISessionDataService {
 
 class TestCopilotClient implements ICopilotClient {
 	readonly rpc: ICopilotClient['rpc'] = { sessions: { fork: async () => ({ sessionId: 'forked-session' }) } };
+	listSessionCallCount = 0;
+	readonly getSessionMetadataCalls: string[] = [];
 
 	constructor(
 		private readonly _sessions: Awaited<ReturnType<ICopilotClient['listSessions']>>,
@@ -138,9 +140,15 @@ class TestCopilotClient implements ICopilotClient {
 
 	async start(): Promise<void> { }
 	async stop(): ReturnType<ICopilotClient['stop']> { return []; }
-	async listSessions(): ReturnType<ICopilotClient['listSessions']> { return this._sessions; }
+	async listSessions(): ReturnType<ICopilotClient['listSessions']> {
+		this.listSessionCallCount++;
+		return this._sessions;
+	}
 	async listModels(): ReturnType<ICopilotClient['listModels']> { return []; }
-	async getSessionMetadata(): ReturnType<ICopilotClient['getSessionMetadata']> { return undefined; }
+	async getSessionMetadata(sessionId: string): ReturnType<ICopilotClient['getSessionMetadata']> {
+		this.getSessionMetadataCalls.push(sessionId);
+		return this._sessions.find(s => s.sessionId === sessionId);
+	}
 	createSession: ICopilotClient['createSession'] = async () => { throw new Error('not implemented'); };
 	resumeSession: ICopilotClient['resumeSession'] = async () => { throw new Error('not implemented'); };
 }
@@ -413,6 +421,51 @@ suite('CopilotAgent', () => {
 				summary: 'SDK legacy',
 				workingDirectory: URI.file('/workspace'),
 			}]);
+		} finally {
+			await disposeAgent(agent);
+		}
+	});
+
+	test('getSessionMetadata reads one SDK session and stored metadata without listing sessions', async () => {
+		const sessionDataService = disposables.add(new TestSessionDataService());
+		const session = AgentSession.uri('copilotcli', 'target');
+		const db = sessionDataService.openDatabase(session);
+		await db.object.setMetadata('copilot.workingDirectory', URI.file('/workspace').toString());
+		db.dispose();
+
+		const client = new TestCopilotClient([sdkSession('target')]);
+		const agent = createTestAgent(disposables, { sessionDataService, copilotClient: client });
+		try {
+			await agent.authenticate('https://api.github.com', 'token');
+
+			const metadata = await agent.getSessionMetadata(session);
+			assert.ok(metadata);
+			assert.deepStrictEqual(withoutUndefinedProperties(metadata), {
+				session,
+				startTime: 1000,
+				modifiedTime: 2000,
+				summary: 'SDK target',
+				workingDirectory: URI.file('/workspace'),
+			});
+			assert.deepStrictEqual(client.getSessionMetadataCalls, ['target']);
+			assert.strictEqual(client.listSessionCallCount, 0);
+		} finally {
+			await disposeAgent(agent);
+		}
+	});
+
+	test('getSessionMetadata only returns sessions with a database', async () => {
+		const sessionDataService = disposables.add(new TestSessionDataService());
+		const session = AgentSession.uri('copilotcli', 'external');
+		const client = new TestCopilotClient([sdkSession('external', '/workspace')]);
+		const agent = createTestAgent(disposables, { sessionDataService, copilotClient: client });
+		try {
+			await agent.authenticate('https://api.github.com', 'token');
+
+			assert.strictEqual(await agent.getSessionMetadata(session), undefined);
+			assert.deepStrictEqual(client.getSessionMetadataCalls, []);
+			assert.strictEqual(client.listSessionCallCount, 0);
+			assert.deepStrictEqual(sessionDataService.openedSessions, []);
 		} finally {
 			await disposeAgent(agent);
 		}

--- a/src/vs/platform/agentHost/test/node/mockAgent.ts
+++ b/src/vs/platform/agentHost/test/node/mockAgent.ts
@@ -95,6 +95,13 @@ export class MockAgent implements IAgent {
 		return [...this._sessions.values()].map(s => ({ session: s, startTime: Date.now(), modifiedTime: Date.now(), project: mockProject(this.id), ...this.sessionMetadataOverrides }));
 	}
 
+	async getSessionMetadata(session: URI): Promise<IAgentSessionMetadata | undefined> {
+		if (!this._sessions.has(AgentSession.id(session))) {
+			return undefined;
+		}
+		return { session, startTime: Date.now(), modifiedTime: Date.now(), project: mockProject(this.id), ...this.sessionMetadataOverrides };
+	}
+
 	/** Optional override for the working directory returned by createSession. */
 	resolvedWorkingDirectory: URI | undefined;
 
@@ -286,6 +293,19 @@ export class ScriptedMockAgent implements IAgent {
 			project: mockProject(this.id),
 			summary: s.toString() === PRE_EXISTING_SESSION_URI.toString() ? 'Pre-existing session' : undefined,
 		}));
+	}
+
+	async getSessionMetadata(session: URI): Promise<IAgentSessionMetadata | undefined> {
+		if (!this._sessions.has(AgentSession.id(session))) {
+			return undefined;
+		}
+		return {
+			session,
+			startTime: Date.now(),
+			modifiedTime: Date.now(),
+			project: mockProject(this.id),
+			summary: session.toString() === PRE_EXISTING_SESSION_URI.toString() ? 'Pre-existing session' : undefined,
+		};
 	}
 
 	async createSession(config?: IAgentCreateSessionConfig): Promise<IAgentCreateSessionResult> {


### PR DESCRIPTION
## Summary
- Add an optional direct `IAgent.getSessionMetadata` lookup for restoring a single persisted session.
- Use the direct path from `AgentService.restoreSession`, while preserving the catalog fallback for older providers and direct lookup failures.
- Implement the Copilot Agent Host lookup with the local session DB ownership gate and focused regression tests.

## Notes
This avoids blocking local Agent Host session restore on a full Copilot session catalog enumeration when opening an existing session. Runtime investigation showed the restored session hydrate path dropping to sub-second timing once the restore path no longer enumerated the full catalog. (Written by Copilot)

## Validation
- `npm run compile-check-ts-native`
- `npm run valid-layers-check`
- `node --experimental-strip-types build/hygiene.ts src/vs/platform/agentHost/common/agentService.ts src/vs/platform/agentHost/node/agentService.ts src/vs/platform/agentHost/node/copilot/copilotAgent.ts src/vs/platform/agentHost/test/node/agentService.test.ts src/vs/platform/agentHost/test/node/copilotAgent.test.ts src/vs/platform/agentHost/test/node/mockAgent.ts`
- `env -u ELECTRON_RUN_AS_NODE npm run test-node -- --run src/vs/platform/agentHost/test/node/agentService.test.ts`
- `env -u ELECTRON_RUN_AS_NODE npm run test-node -- --run src/vs/platform/agentHost/test/node/copilotAgent.test.ts`