### PR TITLE
agentHost: forward parent --user-data-dir to spawned host

### DIFF
--- a/src/vs/platform/agentHost/electron-main/electronAgentHostStarter.ts
+++ b/src/vs/platform/agentHost/electron-main/electronAgentHostStarter.ts
@@ -75,7 +75,10 @@ export class ElectronAgentHostStarter extends Disposable implements IAgentHostSt
 			name: 'agent-host',
 			entryPoint: 'vs/platform/agentHost/node/agentHostMain',
 			execArgv,
-			args: ['--logsPath', this._environmentMainService.logsHome.with({ scheme: Schemas.file }).fsPath],
+			args: [
+				'--logsPath', this._environmentMainService.logsHome.with({ scheme: Schemas.file }).fsPath,
+				'--user-data-dir', this._environmentMainService.userDataPath,
+			],
 			env: {
 				...deepClone(process.env),
 				...shellEnv,

--- a/src/vs/platform/agentHost/node/nodeAgentHostStarter.ts
+++ b/src/vs/platform/agentHost/node/nodeAgentHostStarter.ts
@@ -99,7 +99,11 @@ export class NodeAgentHostStarter extends Disposable implements IAgentHostStarte
 
 		const opts: IIPCOptions = {
 			serverName: 'Agent Host',
-			args: ['--type=agentHost', '--logsPath', this._environmentService.logsHome.with({ scheme: Schemas.file }).fsPath],
+			args: [
+				'--type=agentHost',
+				'--logsPath', this._environmentService.logsHome.with({ scheme: Schemas.file }).fsPath,
+				'--user-data-dir', this._environmentService.userDataPath,
+			],
 			env,
 		};
 


### PR DESCRIPTION
### What

The local agent host starters — `ElectronAgentHostStarter` (utility process) and `NodeAgentHostStarter` (child process fallback) — only forwarded `--logsPath` to the spawned host. They now also forward the parent's resolved `userDataPath` as `--user-data-dir`.

### Why

Inside `agentHostMain.ts`, the agent host builds its own `NativeEnvironmentService` from `parseArgs(process.argv, OPTIONS)`. Without `--user-data-dir` on the command line, that resolves to the platform default for the build's quality (e.g. `~/Library/Application Support/agents-oss-dev`) regardless of what the parent app was launched with.

That meant all agent host state was being written to the wrong place when the parent was started with a custom `--user-data-dir`:

- `SessionDataService` → `{userData}/agentSessionData/{sessionId}/`
- `AgentPluginManager` → `{userData}/agentPlugins/{key}/`
- Root agent host config → `{userData}/User/globalStorage/agent-host-config.json`

Note: Electron propagates `--user-data-dir` to its own child processes for `app.getPath('userData')`, but our `parseArgs`-derived `userDataPath` is independent of that and needs the arg explicitly.

### Notes for reviewers

- This matches the existing convention in both starters of forwarding flags via argv (alongside `--logsPath`), rather than introducing a new payload-style config (as `SharedProcess` and `localProcessExtensionHost` do).
- No change to behavior when the parent is launched without `--user-data-dir` — the resolved path is the same default the child would have picked on its own.

(Written by Copilot)