### PR TITLE
chat: allow text selection in tool confirmation message

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatConfirmationWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatConfirmationWidget.css
@@ -22,6 +22,10 @@
 	font-size: var(--vscode-chat-font-size-body-s);
 }
 
+.chat-confirmation-widget-message {
+	user-select: text;
+}
+
 .chat-confirmation-widget-container .chat-confirmation-widget .chat-confirmation-widget-title {
 	width: 100%;
 	border-radius: 3px;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatConfirmationWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatConfirmationWidget.css
@@ -23,6 +23,7 @@
 }
 
 .chat-confirmation-widget-message {
+	-webkit-user-select: text;
 	user-select: text;
 }
 


### PR DESCRIPTION
The tool confirmation widget lives in the chat input area, which inherits `user-select: none` from the list widget. As a result, users couldn't select/copy text shown in tool confirmations (e.g. file paths in a "Read file?" confirmation).

This adds a `user-select: text` override on `.chat-confirmation-widget-message` so the message body is selectable. The title remains unselectable (it's a clickable button).

(Written by Copilot)