### PR TITLE
agentHost: auto-approve reads of Copilot SDK tool-output temp files

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -92,6 +92,32 @@ function getCopilotCLISessionStateDir(userHome: string): string {
 }
 
 /**
+ * Matches the temp file names the Copilot SDK uses when spilling large tool
+ * results to disk. The SDK writes these into `os.tmpdir()` and references the
+ * path back to the model so it can read the output in a follow-up turn.
+ *
+ * Two layouts are emitted by the SDK depending on the codepath:
+ *  - `<timestamp>-copilot-tool-output-<6-char-id>.txt` (large tool result)
+ *  - `copilot-tool-output-<timestamp>-<6-char-id>.txt` (streaming output buffer)
+ *
+ * Both live directly inside `os.tmpdir()`, so we additionally require the
+ * file's parent directory to be the OS temp directory before auto-approving.
+ */
+const COPILOT_SDK_TOOL_OUTPUT_BASENAME_RE = /^(?:\d+-copilot-tool-output-[a-z0-9]+|copilot-tool-output-\d+-[a-z0-9]+)\.txt$/i;
+
+export function isCopilotSdkToolOutputTempFile(filePath: string, tmpDir: string): boolean {
+	const fileUri = normalizePath(URI.file(filePath));
+	const tmpDirUri = normalizePath(URI.file(tmpDir));
+	const parentUri = normalizePath(URI.joinPath(fileUri, '..'));
+	if (!extUriBiasedIgnorePathCase.isEqual(parentUri, tmpDirUri)) {
+		return false;
+	}
+	const lastSlash = Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\'));
+	const basename = lastSlash >= 0 ? filePath.substring(lastSlash + 1) : filePath;
+	return COPILOT_SDK_TOOL_OUTPUT_BASENAME_RE.test(basename);
+}
+
+/**
  * Immutable snapshot of the active client's contributions at session creation
  * time. Used to detect when the session needs to be refreshed.
  */
@@ -587,6 +613,17 @@ export class CopilotAgentSession extends Disposable {
 			if (sessionResourcePath) {
 				this._logService.info(`[Copilot:${this.sessionId}] Auto-approving internal session resource ${sessionResourcePath}`);
 				return { kind: 'approve-once' };
+			}
+
+			// Auto-approve reads of large-tool-output temp files written by the
+			// Copilot SDK itself. The SDK spills oversized tool results to
+			// `os.tmpdir()/copilot-tool-output-…txt` and then asks the model
+			// to read them back in a follow-up turn — no need to confirm.
+			if (request.kind === 'read' && typeof request.path === 'string') {
+				if (isCopilotSdkToolOutputTempFile(request.path, this._environmentService.tmpDir.fsPath)) {
+					this._logService.info(`[Copilot:${this.sessionId}] Auto-approving Copilot SDK tool-output temp file ${request.path}`);
+					return { kind: 'approve-once' };
+				}
 			}
 
 			this._logService.info(`[Copilot:${this.sessionId}] Requesting confirmation for tool call: ${toolCallId}`);

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -103,9 +103,9 @@ function getCopilotCLISessionStateDir(userHome: string): string {
  * Both live directly inside `os.tmpdir()`, so we additionally require the
  * file's parent directory to be the OS temp directory before auto-approving.
  */
-const COPILOT_SDK_TOOL_OUTPUT_BASENAME_RE = /^(?:\d+-copilot-tool-output-[a-z0-9]+|copilot-tool-output-\d+-[a-z0-9]+)\.txt$/i;
+const COPILOT_SDK_TOOL_OUTPUT_BASENAME_RE = /^(?:\d{10,}-copilot-tool-output-[a-z0-9]{6}|copilot-tool-output-\d{10,}-[a-z0-9]{6})\.txt$/i;
 
-export function isCopilotSdkToolOutputTempFile(filePath: string, tmpDir: string): boolean {
+function isCopilotSdkToolOutputTempFile(filePath: string, tmpDir: string): boolean {
 	const fileUri = normalizePath(URI.file(filePath));
 	const tmpDirUri = normalizePath(URI.file(tmpDir));
 	const parentUri = normalizePath(URI.joinPath(fileUri, '..'));

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -210,6 +210,7 @@ async function createAgentSession(disposables: DisposableStore, options?: {
 	const environmentService = {
 		_serviceBrand: undefined,
 		userHome: URI.file('/mock-home'),
+		tmpDir: URI.file('/mock-tmp'),
 	} as INativeEnvironmentService;
 	if (options?.environmentServiceRegistration !== 'none') {
 		services.set(INativeEnvironmentService, environmentService);
@@ -446,6 +447,76 @@ suite('CopilotAgentSession', () => {
 					process.env['XDG_STATE_HOME'] = previousXdgStateHome;
 				}
 			}
+		});
+
+		test('auto-approves read of Copilot SDK large-tool-output temp files', async () => {
+			const { session, signals } = await createAgentSession(disposables);
+
+			// Layout 1: <timestamp>-copilot-tool-output-<id>.txt
+			const result1 = await session.handlePermissionRequest({
+				kind: 'read',
+				path: join('/mock-tmp', '1730000000000-copilot-tool-output-abc123.txt'),
+				toolCallId: 'tc-tool-output-1',
+			});
+			assert.strictEqual(result1.kind, 'approve-once');
+
+			// Layout 2: copilot-tool-output-<timestamp>-<id>.txt
+			const result2 = await session.handlePermissionRequest({
+				kind: 'read',
+				path: join('/mock-tmp', 'copilot-tool-output-1730000000000-abc123.txt'),
+				toolCallId: 'tc-tool-output-2',
+			});
+			assert.strictEqual(result2.kind, 'approve-once');
+
+			assert.strictEqual(signals.length, 0);
+		});
+
+		test('does not auto-approve tool-output-named files outside tmpdir', async () => {
+			const { session, signals, waitForSignal } = await createAgentSession(disposables);
+			const resultPromise = session.handlePermissionRequest({
+				kind: 'read',
+				path: join('/some/other/dir', 'copilot-tool-output-1730000000000-abc123.txt'),
+				toolCallId: 'tc-tool-output-outside',
+			});
+
+			await waitForSignal(s => s.kind === 'pending_confirmation');
+			assert.strictEqual(signals.length, 1);
+
+			assert.ok(session.respondToPermissionRequest('tc-tool-output-outside', true));
+			const result = await resultPromise;
+			assert.strictEqual(result.kind, 'approve-once');
+		});
+
+		test('does not auto-approve unrelated files inside tmpdir', async () => {
+			const { session, signals, waitForSignal } = await createAgentSession(disposables);
+			const resultPromise = session.handlePermissionRequest({
+				kind: 'read',
+				path: join('/mock-tmp', 'something-else.txt'),
+				toolCallId: 'tc-tmp-other',
+			});
+
+			await waitForSignal(s => s.kind === 'pending_confirmation');
+			assert.strictEqual(signals.length, 1);
+
+			assert.ok(session.respondToPermissionRequest('tc-tmp-other', true));
+			const result = await resultPromise;
+			assert.strictEqual(result.kind, 'approve-once');
+		});
+
+		test('does not auto-approve write to a tool-output temp path', async () => {
+			const { session, signals, waitForSignal } = await createAgentSession(disposables);
+			const resultPromise = session.handlePermissionRequest({
+				kind: 'write',
+				fileName: join('/mock-tmp', 'copilot-tool-output-1730000000000-abc123.txt'),
+				toolCallId: 'tc-tool-output-write',
+			});
+
+			await waitForSignal(s => s.kind === 'pending_confirmation');
+			assert.strictEqual(signals.length, 1);
+
+			assert.ok(session.respondToPermissionRequest('tc-tool-output-write', true));
+			const result = await resultPromise;
+			assert.strictEqual(result.kind, 'approve-once');
 		});
 
 		test('write permission outside working directory fires tool_ready', async () => {


### PR DESCRIPTION
## What

When a tool result is too large to fit inline, the Copilot SDK spills it to a temp file under `os.tmpdir()` (named like `copilot-tool-output-<…>.txt` or `<ts>-copilot-tool-output-<…>.txt`) and then asks the model to `read` that file back in a follow-up turn. Today the agent host prompts the user for permission on every one of those reads, even though the file was just written by the SDK on our behalf.

This change auto-approves those `read` permission requests, mirroring the existing session-state auto-approval pattern in `CopilotAgentSession`.

## How

- New helper `isCopilotSdkToolOutputTempFile(filePath, tmpDir)` in `copilotAgentSession.ts`:
  - Requires the file's parent directory to be exactly `os.tmpdir()` (no nested subdirs)
  - Requires the basename to match one of the two SDK naming layouts:
    - `<timestamp>-copilot-tool-output-<6-char-id>.txt`
    - `copilot-tool-output-<timestamp>-<6-char-id>.txt`
- In `handlePermissionRequest`, after the existing session-state branch, auto-approve when `request.kind === 'read'` and the path matches the helper.
- Intentionally read-only — writes to these paths still confirm.

## How to repro the original prompt

Ask the agent something like:

> Run `find /usr -type f` and then tell me how many of the results contain "lib". Don't summarize — actually look at the full output.

The shell tool result spills to `os.tmpdir()/…copilot-tool-output-….txt`, and the follow-up `read` of that file is what was prompting before this change.

## Tests

Added 4 unit tests in `copilotAgentSession.test.ts` covering:
- positive case for both SDK filename layouts
- tool-output-named files outside `tmpDir` are not auto-approved
- unrelated files inside `tmpDir` are not auto-approved
- `write` to a tool-output path is not auto-approved

All 78 tests in the suite pass; `compile-check-ts-native` is clean.

## Notes for reviewers

- The EH CLI (`extensions/copilot/src/extension/chatSessions/copilotcli/node/permissionHelpers.ts`) does **not** currently have parity for this. Out of scope for this PR — happy to follow up.

(Written by Copilot)