### PR TITLE
agents: render Copilot CLI 'rg' search tool

### DIFF
--- a/src/vs/platform/agentHost/common/state/sessionReducers.ts
+++ b/src/vs/platform/agentHost/common/state/sessionReducers.ts
@@ -16,6 +16,6 @@ import type { ICompletedToolCall, ToolCallState } from './sessionState.js';
  * bag. This is not part of the protocol and is injected by the agent adapter
  * (e.g. `copilotEventMapper`).
  */
-export function getToolKind(tc: ToolCallState | ICompletedToolCall): 'terminal' | 'subagent' | undefined {
-	return tc._meta?.toolKind as 'terminal' | 'subagent' | undefined;
+export function getToolKind(tc: ToolCallState | ICompletedToolCall): 'terminal' | 'subagent' | 'search' | undefined {
+	return tc._meta?.toolKind as 'terminal' | 'subagent' | 'search' | undefined;
 }

--- a/src/vs/platform/agentHost/common/state/sessionReducers.ts
+++ b/src/vs/platform/agentHost/common/state/sessionReducers.ts
@@ -16,6 +16,6 @@ import type { ICompletedToolCall, ToolCallState } from './sessionState.js';
  * bag. This is not part of the protocol and is injected by the agent adapter
  * (e.g. `copilotEventMapper`).
  */
-export function getToolKind(tc: ToolCallState | ICompletedToolCall): 'terminal' | 'subagent' | 'search' | undefined {
-	return tc._meta?.toolKind as 'terminal' | 'subagent' | 'search' | undefined;
+export function getToolKind(tc: ToolCallState | ICompletedToolCall): 'terminal' | 'subagent' | undefined {
+	return tc._meta?.toolKind as 'terminal' | 'subagent' | undefined;
 }

--- a/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
@@ -204,6 +204,12 @@ const SUBAGENT_TOOL_NAMES: ReadonlySet<string> = new Set([
 	'task',
 ]);
 
+/** Set of tool names that perform file/text search. */
+const SEARCH_TOOL_NAMES: ReadonlySet<string> = new Set([
+	CopilotToolName.Grep,
+	CopilotToolName.Rg,
+]);
+
 /**
  * Tools that should not be shown to the user. These are internal tools
  * used by the CLI for its own purposes (e.g., reporting intent to the model).
@@ -590,16 +596,19 @@ export function getToolInputString(toolName: string, parameters: Record<string, 
 }
 
 /**
- * Returns a rendering hint for the given tool. Currently only 'terminal' is
- * supported, which tells the renderer to display the tool as a terminal command
- * block.
+ * Returns a rendering hint for the given tool. Currently 'terminal', 'subagent',
+ * and 'search' are supported, which tell the renderer to display the tool with
+ * a terminal command block, a subagent widget, or a search icon respectively.
  */
-export function getToolKind(toolName: string): 'terminal' | 'subagent' | undefined {
+export function getToolKind(toolName: string): 'terminal' | 'subagent' | 'search' | undefined {
 	if (SHELL_TOOL_NAMES.has(toolName)) {
 		return 'terminal';
 	}
 	if (SUBAGENT_TOOL_NAMES.has(toolName)) {
 		return 'subagent';
+	}
+	if (SEARCH_TOOL_NAMES.has(toolName)) {
+		return 'search';
 	}
 	return undefined;
 }

--- a/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
@@ -49,6 +49,7 @@ const enum CopilotToolName {
 	Edit = 'edit',
 	Create = 'create',
 	Grep = 'grep',
+	Rg = 'rg',
 	Glob = 'glob',
 	ApplyPatch = 'apply_patch',
 	GitApplyPatch = 'git_apply_patch',
@@ -103,11 +104,44 @@ function formatViewRange(view_range: number[] | undefined): { startLine: number;
 	return { startLine, endLine };
 }
 
-/** Parameters for the `grep` tool. */
+/**
+ * Parameters for the `grep` tool. Per the extension-host CLI parity reference
+ * (`copilotCLITools.ts`), the Copilot CLI's `grep` accepts the same rich rg-flag
+ * schema as `rg`; the older narrower shape (e.g. `include`) is no longer used.
+ */
 interface ICopilotGrepToolArgs {
 	pattern: string;
 	path?: string;
-	include?: string;
+	output_mode?: 'content' | 'files_with_matches' | 'count';
+	glob?: string;
+	type?: string;
+	'-i'?: boolean;
+	'-A'?: number;
+	'-B'?: number;
+	'-C'?: number;
+	'-n'?: boolean;
+	head_limit?: number;
+	multiline?: boolean;
+}
+
+/**
+ * Parameters for the `rg` tool. Mirrors {@link ICopilotGrepToolArgs} today but
+ * is kept as a distinct interface so the two tools can drift independently if
+ * the SDK ever differentiates them.
+ */
+interface ICopilotRgToolArgs {
+	pattern: string;
+	path?: string;
+	output_mode?: 'content' | 'files_with_matches' | 'count';
+	glob?: string;
+	type?: string;
+	'-i'?: boolean;
+	'-A'?: number;
+	'-B'?: number;
+	'-C'?: number;
+	'-n'?: boolean;
+	head_limit?: number;
+	multiline?: boolean;
 }
 
 /** Parameters for the `glob` tool. */
@@ -243,7 +277,8 @@ export function getToolDisplayName(toolName: string): string {
 		case CopilotToolName.View: return localize('toolName.view', "View File");
 		case CopilotToolName.Edit: return localize('toolName.edit', "Edit File");
 		case CopilotToolName.Create: return localize('toolName.create', "Create File");
-		case CopilotToolName.Grep: return localize('toolName.grep', "Search");
+		case CopilotToolName.Grep:
+		case CopilotToolName.Rg: return localize('toolName.grep', "Search");
 		case CopilotToolName.Glob: return localize('toolName.glob', "Find Files");
 		case CopilotToolName.ApplyPatch:
 		case CopilotToolName.GitApplyPatch: return localize('toolName.patch', "Patch");
@@ -317,6 +352,13 @@ export function getInvocationMessage(toolName: string, displayName: string, para
 				return md(localize('toolInvoke.grepPattern', "Searching for {0}", appendEscapedMarkdownInlineCode(truncate(args.pattern, 80))));
 			}
 			return localize('toolInvoke.grep', "Searching files");
+		}
+		case CopilotToolName.Rg: {
+			const args = parameters as ICopilotRgToolArgs | undefined;
+			if (args?.pattern) {
+				return md(localize('toolInvoke.rgPattern', "Searching for {0}", appendEscapedMarkdownInlineCode(truncate(args.pattern, 80))));
+			}
+			return localize('toolInvoke.rg', "Searching files");
 		}
 		case CopilotToolName.Glob: {
 			const args = parameters as ICopilotGlobToolArgs | undefined;
@@ -398,6 +440,13 @@ export function getPastTenseMessage(toolName: string, displayName: string, param
 				return md(localize('toolComplete.grepPattern', "Searched for {0}", appendEscapedMarkdownInlineCode(truncate(args.pattern, 80))));
 			}
 			return localize('toolComplete.grep', "Searched files");
+		}
+		case CopilotToolName.Rg: {
+			const args = parameters as ICopilotRgToolArgs | undefined;
+			if (args?.pattern) {
+				return md(localize('toolComplete.rgPattern', "Searched for {0}", appendEscapedMarkdownInlineCode(truncate(args.pattern, 80))));
+			}
+			return localize('toolComplete.rg', "Searched files");
 		}
 		case CopilotToolName.Glob: {
 			const args = parameters as ICopilotGlobToolArgs | undefined;
@@ -521,6 +570,10 @@ export function getToolInputString(toolName: string, parameters: Record<string, 
 	switch (toolName) {
 		case CopilotToolName.Grep: {
 			const args = parameters as ICopilotGrepToolArgs | undefined;
+			return args?.pattern ?? rawArguments;
+		}
+		case CopilotToolName.Rg: {
+			const args = parameters as ICopilotRgToolArgs | undefined;
 			return args?.pattern ?? rawArguments;
 		}
 		default:

--- a/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
@@ -105,9 +105,9 @@ function formatViewRange(view_range: number[] | undefined): { startLine: number;
 }
 
 /**
- * Parameters for the `grep` tool. Per the extension-host CLI parity reference
- * (`copilotCLITools.ts`), the Copilot CLI's `grep` accepts the same rich rg-flag
- * schema as `rg`; the older narrower shape (e.g. `include`) is no longer used.
+ * Parameters for the `grep` tool. The Copilot CLI's `grep` accepts the same
+ * rich rg-flag schema as `rg`; the older narrower shape (e.g. `include`) is
+ * no longer used.
  */
 interface ICopilotGrepToolArgs {
 	pattern: string;
@@ -356,9 +356,9 @@ export function getInvocationMessage(toolName: string, displayName: string, para
 		case CopilotToolName.Rg: {
 			const args = parameters as ICopilotRgToolArgs | undefined;
 			if (args?.pattern) {
-				return md(localize('toolInvoke.rgPattern', "Searching for {0}", appendEscapedMarkdownInlineCode(truncate(args.pattern, 80))));
+				return md(localize('toolInvoke.grepPattern', "Searching for {0}", appendEscapedMarkdownInlineCode(truncate(args.pattern, 80))));
 			}
-			return localize('toolInvoke.rg', "Searching files");
+			return localize('toolInvoke.grep', "Searching files");
 		}
 		case CopilotToolName.Glob: {
 			const args = parameters as ICopilotGlobToolArgs | undefined;
@@ -444,9 +444,9 @@ export function getPastTenseMessage(toolName: string, displayName: string, param
 		case CopilotToolName.Rg: {
 			const args = parameters as ICopilotRgToolArgs | undefined;
 			if (args?.pattern) {
-				return md(localize('toolComplete.rgPattern', "Searched for {0}", appendEscapedMarkdownInlineCode(truncate(args.pattern, 80))));
+				return md(localize('toolComplete.grepPattern', "Searched for {0}", appendEscapedMarkdownInlineCode(truncate(args.pattern, 80))));
 			}
-			return localize('toolComplete.rg', "Searched files");
+			return localize('toolComplete.grep', "Searched files");
 		}
 		case CopilotToolName.Glob: {
 			const args = parameters as ICopilotGlobToolArgs | undefined;

--- a/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
@@ -204,12 +204,6 @@ const SUBAGENT_TOOL_NAMES: ReadonlySet<string> = new Set([
 	'task',
 ]);
 
-/** Set of tool names that perform file/text search. */
-const SEARCH_TOOL_NAMES: ReadonlySet<string> = new Set([
-	CopilotToolName.Grep,
-	CopilotToolName.Rg,
-]);
-
 /**
  * Tools that should not be shown to the user. These are internal tools
  * used by the CLI for its own purposes (e.g., reporting intent to the model).
@@ -596,19 +590,16 @@ export function getToolInputString(toolName: string, parameters: Record<string, 
 }
 
 /**
- * Returns a rendering hint for the given tool. Currently 'terminal', 'subagent',
- * and 'search' are supported, which tell the renderer to display the tool with
- * a terminal command block, a subagent widget, or a search icon respectively.
+ * Returns a rendering hint for the given tool. Currently only 'terminal' is
+ * supported, which tells the renderer to display the tool as a terminal command
+ * block.
  */
-export function getToolKind(toolName: string): 'terminal' | 'subagent' | 'search' | undefined {
+export function getToolKind(toolName: string): 'terminal' | 'subagent' | undefined {
 	if (SHELL_TOOL_NAMES.has(toolName)) {
 		return 'terminal';
 	}
 	if (SUBAGENT_TOOL_NAMES.has(toolName)) {
 		return 'subagent';
-	}
-	if (SEARCH_TOOL_NAMES.has(toolName)) {
-		return 'search';
 	}
 	return undefined;
 }

--- a/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
+++ b/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
@@ -124,7 +124,7 @@ interface IToolStartInfo {
 	readonly displayName: string;
 	readonly invocationMessage: StringOrMarkdown;
 	readonly toolInput?: string;
-	readonly toolKind?: 'terminal' | 'subagent' | 'search';
+	readonly toolKind?: 'terminal' | 'subagent';
 	readonly language?: string;
 	readonly subagentAgentName?: string;
 	readonly subagentDescription?: string;

--- a/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
+++ b/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
@@ -124,7 +124,7 @@ interface IToolStartInfo {
 	readonly displayName: string;
 	readonly invocationMessage: StringOrMarkdown;
 	readonly toolInput?: string;
-	readonly toolKind?: 'terminal' | 'subagent';
+	readonly toolKind?: 'terminal' | 'subagent' | 'search';
 	readonly language?: string;
 	readonly subagentAgentName?: string;
 	readonly subagentDescription?: string;

--- a/src/vs/platform/agentHost/test/node/copilotToolDisplay.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotToolDisplay.test.ts
@@ -331,3 +331,40 @@ suite('skill events', () => {
 		});
 	});
 });
+
+suite('rg / grep search tool display', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function text(msg: ReturnType<typeof getInvocationMessage>): string {
+		return typeof msg === 'string' ? msg : msg.markdown;
+	}
+
+	test('rg invocation/past tense use "Searching for {pattern}" wording', () => {
+		const inv = text(getInvocationMessage('rg', 'Search', { pattern: 'foo' }));
+		const past = text(getPastTenseMessage('rg', 'Search', { pattern: 'foo' }, true));
+		assert.deepStrictEqual({ inv, past }, {
+			inv: 'Searching for `foo`',
+			past: 'Searched for `foo`',
+		});
+	});
+
+	test('rg without a pattern falls back to a generic search message (not the raw tool name)', () => {
+		const inv = text(getInvocationMessage('rg', 'Search', undefined));
+		assert.strictEqual(inv, 'Searching files');
+	});
+
+	test('grep keeps "Searching for {pattern}" wording', () => {
+		const inv = text(getInvocationMessage('grep', 'Search', { pattern: 'bar' }));
+		const past = text(getPastTenseMessage('grep', 'Search', { pattern: 'bar' }, true));
+		assert.deepStrictEqual({ inv, past }, {
+			inv: 'Searching for `bar`',
+			past: 'Searched for `bar`',
+		});
+	});
+
+	test('getToolInputString returns pattern for both grep and rg', () => {
+		assert.strictEqual(getToolInputString('grep', { pattern: 'abc' }, undefined), 'abc');
+		assert.strictEqual(getToolInputString('rg', { pattern: 'abc' }, undefined), 'abc');
+	});
+});

--- a/src/vs/platform/agentHost/test/node/historyRecordFixtures.ts
+++ b/src/vs/platform/agentHost/test/node/historyRecordFixtures.ts
@@ -54,7 +54,7 @@ export interface IHistoryToolStartRecord extends IHistoryRecordBase {
 	readonly displayName: string;
 	readonly invocationMessage: StringOrMarkdown;
 	readonly toolInput?: string;
-	readonly toolKind?: 'terminal' | 'subagent' | 'search';
+	readonly toolKind?: 'terminal' | 'subagent';
 	readonly language?: string;
 	readonly toolArguments?: string;
 	readonly subagentAgentName?: string;

--- a/src/vs/platform/agentHost/test/node/historyRecordFixtures.ts
+++ b/src/vs/platform/agentHost/test/node/historyRecordFixtures.ts
@@ -54,7 +54,7 @@ export interface IHistoryToolStartRecord extends IHistoryRecordBase {
 	readonly displayName: string;
 	readonly invocationMessage: StringOrMarkdown;
 	readonly toolInput?: string;
-	readonly toolKind?: 'terminal' | 'subagent';
+	readonly toolKind?: 'terminal' | 'subagent' | 'search';
 	readonly language?: string;
 	readonly toolArguments?: string;
 	readonly subagentAgentName?: string;

--- a/src/vs/workbench/contrib/chat/browser/accessibility/chatResponseAccessibleView.ts
+++ b/src/vs/workbench/contrib/chat/browser/accessibility/chatResponseAccessibleView.ts
@@ -18,7 +18,7 @@ import { IStorageService, StorageScope } from '../../../../../platform/storage/c
 import { AccessibilityVerbositySettingId } from '../../../accessibility/browser/accessibilityConfiguration.js';
 import { migrateLegacyTerminalToolSpecificData } from '../../common/chat.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
-import { IChatExtensionsContent, IChatModifiedFilesConfirmationData, IChatPullRequestContent, IChatSimpleToolInvocationData, IChatSubagentToolInvocationData, IChatTerminalToolInvocationData, IChatTodoListContent, IChatToolInputInvocationData, IChatToolInvocation, IChatToolResourcesInvocationData, ILegacyChatTerminalToolInvocationData, IToolResultOutputDetailsSerialized, isLegacyChatTerminalToolInvocationData } from '../../common/chatService/chatService.js';
+import { IChatExtensionsContent, IChatModifiedFilesConfirmationData, IChatPullRequestContent, IChatSearchToolInvocationData, IChatSimpleToolInvocationData, IChatSubagentToolInvocationData, IChatTerminalToolInvocationData, IChatTodoListContent, IChatToolInputInvocationData, IChatToolInvocation, IChatToolResourcesInvocationData, ILegacyChatTerminalToolInvocationData, IToolResultOutputDetailsSerialized, isLegacyChatTerminalToolInvocationData } from '../../common/chatService/chatService.js';
 import { isResponseVM } from '../../common/model/chatViewModel.js';
 import { IToolResultInputOutputDetails, IToolResultOutputDetails, isToolResultInputOutputDetails, isToolResultOutputDetails, toolContentToA11yString } from '../../common/tools/languageModelToolsService.js';
 import { ChatTreeItem, IChatWidget, IChatWidgetService } from '../chat.js';
@@ -60,7 +60,7 @@ export class ChatResponseAccessibleView implements IAccessibleViewImplementation
 	}
 }
 
-type ToolSpecificData = IChatTerminalToolInvocationData | ILegacyChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatPullRequestContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatToolResourcesInvocationData | IChatModifiedFilesConfirmationData;
+type ToolSpecificData = IChatTerminalToolInvocationData | ILegacyChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatPullRequestContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatSearchToolInvocationData | IChatToolResourcesInvocationData | IChatModifiedFilesConfirmationData;
 type ResultDetails = Array<URI | Location> | IToolResultInputOutputDetails | IToolResultOutputDetails | IToolResultOutputDetailsSerialized;
 
 export const CHAT_ACCESSIBLE_VIEW_INCLUDE_THINKING_STORAGE_KEY = 'chat.accessibleView.includeThinking';

--- a/src/vs/workbench/contrib/chat/browser/accessibility/chatResponseAccessibleView.ts
+++ b/src/vs/workbench/contrib/chat/browser/accessibility/chatResponseAccessibleView.ts
@@ -18,7 +18,7 @@ import { IStorageService, StorageScope } from '../../../../../platform/storage/c
 import { AccessibilityVerbositySettingId } from '../../../accessibility/browser/accessibilityConfiguration.js';
 import { migrateLegacyTerminalToolSpecificData } from '../../common/chat.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
-import { IChatExtensionsContent, IChatModifiedFilesConfirmationData, IChatPullRequestContent, IChatSearchToolInvocationData, IChatSimpleToolInvocationData, IChatSubagentToolInvocationData, IChatTerminalToolInvocationData, IChatTodoListContent, IChatToolInputInvocationData, IChatToolInvocation, IChatToolResourcesInvocationData, ILegacyChatTerminalToolInvocationData, IToolResultOutputDetailsSerialized, isLegacyChatTerminalToolInvocationData } from '../../common/chatService/chatService.js';
+import { IChatExtensionsContent, IChatModifiedFilesConfirmationData, IChatPullRequestContent, IChatSimpleToolInvocationData, IChatSubagentToolInvocationData, IChatTerminalToolInvocationData, IChatTodoListContent, IChatToolInputInvocationData, IChatToolInvocation, IChatToolResourcesInvocationData, ILegacyChatTerminalToolInvocationData, IToolResultOutputDetailsSerialized, isLegacyChatTerminalToolInvocationData } from '../../common/chatService/chatService.js';
 import { isResponseVM } from '../../common/model/chatViewModel.js';
 import { IToolResultInputOutputDetails, IToolResultOutputDetails, isToolResultInputOutputDetails, isToolResultOutputDetails, toolContentToA11yString } from '../../common/tools/languageModelToolsService.js';
 import { ChatTreeItem, IChatWidget, IChatWidgetService } from '../chat.js';
@@ -60,7 +60,7 @@ export class ChatResponseAccessibleView implements IAccessibleViewImplementation
 	}
 }
 
-type ToolSpecificData = IChatTerminalToolInvocationData | ILegacyChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatPullRequestContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatSearchToolInvocationData | IChatToolResourcesInvocationData | IChatModifiedFilesConfirmationData;
+type ToolSpecificData = IChatTerminalToolInvocationData | ILegacyChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatPullRequestContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatToolResourcesInvocationData | IChatModifiedFilesConfirmationData;
 type ResultDetails = Array<URI | Location> | IToolResultInputOutputDetails | IToolResultOutputDetails | IToolResultOutputDetailsSerialized;
 
 export const CHAT_ACCESSIBLE_VIEW_INCLUDE_THINKING_STORAGE_KEY = 'chat.accessibleView.includeThinking';

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
@@ -10,7 +10,7 @@ import { ToolCallStatus, TurnState, ResponsePartKind, getToolFileEdits, getToolO
 import { getToolKind } from '../../../../../../platform/agentHost/common/state/sessionReducers.js';
 import { AGENT_HOST_SCHEME, toAgentHostUri } from '../../../../../../platform/agentHost/common/agentHostUri.js';
 import { StringOrMarkdown, type FileEdit } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
-import { type IChatModifiedFilesConfirmationData, type IChatProgress, type IChatSearchToolInvocationData, type IChatTerminalToolInvocationData, type IChatToolInputInvocationData, type IChatToolInvocationSerialized, ToolConfirmKind } from '../../../common/chatService/chatService.js';
+import { type IChatModifiedFilesConfirmationData, type IChatProgress, type IChatTerminalToolInvocationData, type IChatToolInputInvocationData, type IChatToolInvocationSerialized, ToolConfirmKind } from '../../../common/chatService/chatService.js';
 import { type IChatSessionHistoryItem } from '../../../common/chatSessionsService.js';
 import { ChatToolInvocation } from '../../../common/model/chatProgressTypes/chatToolInvocation.js';
 import { type IToolConfirmationMessages, type IToolData, ToolDataSource, ToolInvocationPresentation } from '../../../common/tools/languageModelToolsService.js';
@@ -248,7 +248,7 @@ export function completedToolCallToSerialized(tc: ICompletedToolCall, subAgentIn
 		};
 	}
 
-	let toolSpecificData: IChatTerminalToolInvocationData | IChatSearchToolInvocationData | undefined;
+	let toolSpecificData: IChatTerminalToolInvocationData | undefined;
 	if (isTerminal || getToolKind(tc) === 'terminal') {
 		toolSpecificData = {
 			kind: 'terminal',
@@ -259,8 +259,6 @@ export function completedToolCallToSerialized(tc: ICompletedToolCall, subAgentIn
 			terminalCommandOutput: getTerminalOutput(tc),
 			terminalCommandState: { exitCode: isSuccess ? 0 : 1 },
 		};
-	} else if (getToolKind(tc) === 'search') {
-		toolSpecificData = { kind: 'search' };
 	}
 
 	const pastTenseMsg = isSuccess
@@ -608,8 +606,6 @@ export function toolCallStateToInvocation(tc: ToolCallState, subAgentInvocationI
 			description: getSubagentTaskDescription(tc),
 			agentName: subagentContent?.agentName ?? getSubagentAgentName(tc),
 		};
-	} else if (getToolKind(tc) === 'search') {
-		invocation.toolSpecificData = { kind: 'search' };
 	}
 
 	return invocation;

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
@@ -10,7 +10,7 @@ import { ToolCallStatus, TurnState, ResponsePartKind, getToolFileEdits, getToolO
 import { getToolKind } from '../../../../../../platform/agentHost/common/state/sessionReducers.js';
 import { AGENT_HOST_SCHEME, toAgentHostUri } from '../../../../../../platform/agentHost/common/agentHostUri.js';
 import { StringOrMarkdown, type FileEdit } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
-import { type IChatModifiedFilesConfirmationData, type IChatProgress, type IChatTerminalToolInvocationData, type IChatToolInputInvocationData, type IChatToolInvocationSerialized, ToolConfirmKind } from '../../../common/chatService/chatService.js';
+import { type IChatModifiedFilesConfirmationData, type IChatProgress, type IChatSearchToolInvocationData, type IChatTerminalToolInvocationData, type IChatToolInputInvocationData, type IChatToolInvocationSerialized, ToolConfirmKind } from '../../../common/chatService/chatService.js';
 import { type IChatSessionHistoryItem } from '../../../common/chatSessionsService.js';
 import { ChatToolInvocation } from '../../../common/model/chatProgressTypes/chatToolInvocation.js';
 import { type IToolConfirmationMessages, type IToolData, ToolDataSource, ToolInvocationPresentation } from '../../../common/tools/languageModelToolsService.js';
@@ -248,7 +248,7 @@ export function completedToolCallToSerialized(tc: ICompletedToolCall, subAgentIn
 		};
 	}
 
-	let toolSpecificData: IChatTerminalToolInvocationData | undefined;
+	let toolSpecificData: IChatTerminalToolInvocationData | IChatSearchToolInvocationData | undefined;
 	if (isTerminal || getToolKind(tc) === 'terminal') {
 		toolSpecificData = {
 			kind: 'terminal',
@@ -259,6 +259,8 @@ export function completedToolCallToSerialized(tc: ICompletedToolCall, subAgentIn
 			terminalCommandOutput: getTerminalOutput(tc),
 			terminalCommandState: { exitCode: isSuccess ? 0 : 1 },
 		};
+	} else if (getToolKind(tc) === 'search') {
+		toolSpecificData = { kind: 'search' };
 	}
 
 	const pastTenseMsg = isSuccess
@@ -606,6 +608,8 @@ export function toolCallStateToInvocation(tc: ToolCallState, subAgentInvocationI
 			description: getSubagentTaskDescription(tc),
 			agentName: subagentContent?.agentName ?? getSubagentAgentName(tc),
 		};
+	} else if (getToolKind(tc) === 'search') {
+		invocation.toolSpecificData = { kind: 'search' };
 	}
 
 	return invocation;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatThinkingContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatThinkingContentPart.ts
@@ -83,7 +83,6 @@ export function getToolInvocationIcon(toolId: string, registeredIcon?: ThemeIcon
 	if (
 		lowerToolId.includes('search') ||
 		lowerToolId.includes('grep') ||
-		lowerToolId === 'rg' ||
 		lowerToolId.includes('find') ||
 		lowerToolId.includes('list') ||
 		lowerToolId.includes('semantic') ||

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatThinkingContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatThinkingContentPart.ts
@@ -1902,11 +1902,14 @@ ${this.hookCount > 0 ? `EXAMPLES WITH BLOCKED CONTENT (from hooks):
 		const itemWrapper = $('.chat-thinking-tool-wrapper');
 		const isMarkdownEdit = toolInvocationOrMarkdown?.kind === 'markdownContent';
 		const isTerminalTool = toolInvocationOrMarkdown && (toolInvocationOrMarkdown.kind === 'toolInvocation' || toolInvocationOrMarkdown.kind === 'toolInvocationSerialized') && toolInvocationOrMarkdown.toolSpecificData?.kind === 'terminal';
+		const isSearchTool = toolInvocationOrMarkdown && (toolInvocationOrMarkdown.kind === 'toolInvocation' || toolInvocationOrMarkdown.kind === 'toolInvocationSerialized') && toolInvocationOrMarkdown.toolSpecificData?.kind === 'search';
 		const toolInvocationIcon = toolInvocationOrMarkdown && (toolInvocationOrMarkdown.kind === 'toolInvocation' || toolInvocationOrMarkdown.kind === 'toolInvocationSerialized') ? toolInvocationOrMarkdown.icon : undefined;
 
 		let icon: ThemeIcon;
 		if (isMarkdownEdit) {
 			icon = Codicon.pencil;
+		} else if (isSearchTool) {
+			icon = Codicon.search;
 		} else if (isTerminalTool) {
 			const terminalData = (toolInvocationOrMarkdown as IChatToolInvocation | IChatToolInvocationSerialized).toolSpecificData as { kind: 'terminal'; terminalCommandState?: { exitCode?: number }; commandLine?: { isSandboxWrapped?: boolean } };
 			const exitCode = terminalData?.terminalCommandState?.exitCode;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatThinkingContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatThinkingContentPart.ts
@@ -83,6 +83,7 @@ export function getToolInvocationIcon(toolId: string, registeredIcon?: ThemeIcon
 	if (
 		lowerToolId.includes('search') ||
 		lowerToolId.includes('grep') ||
+		lowerToolId === 'rg' ||
 		lowerToolId.includes('find') ||
 		lowerToolId.includes('list') ||
 		lowerToolId.includes('semantic') ||

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolInvocationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolInvocationSubPart.ts
@@ -40,9 +40,7 @@ export abstract class BaseChatToolInvocationSubPart extends Disposable {
 		}
 
 		if (toolInvocation.toolSpecificData?.kind === 'search') {
-			return IChatToolInvocation.isComplete(toolInvocation)
-				? Codicon.search
-				: ThemeIcon.modify(Codicon.search, 'spin');
+			return Codicon.search;
 		}
 
 		return confirmState?.type === ToolConfirmKind.Denied ?

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolInvocationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolInvocationSubPart.ts
@@ -39,6 +39,12 @@ export abstract class BaseChatToolInvocationSubPart extends Disposable {
 			return Codicon.circleSlash;
 		}
 
+		if (toolInvocation.toolSpecificData?.kind === 'search') {
+			return IChatToolInvocation.isComplete(toolInvocation)
+				? Codicon.search
+				: ThemeIcon.modify(Codicon.search, 'spin');
+		}
+
 		return confirmState?.type === ToolConfirmKind.Denied ?
 			Codicon.error :
 			IChatToolInvocation.isComplete(toolInvocation) ?

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolInvocationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolInvocationSubPart.ts
@@ -9,6 +9,7 @@ import { Disposable } from '../../../../../../../base/common/lifecycle.js';
 import { ThemeIcon } from '../../../../../../../base/common/themables.js';
 import { IChatToolInvocation, IChatToolInvocationSerialized, ToolConfirmKind } from '../../../../common/chatService/chatService.js';
 import { IChatCodeBlockInfo } from '../../../chat.js';
+import { getToolInvocationIcon } from '../chatThinkingContentPart.js';
 
 export abstract class BaseChatToolInvocationSubPart extends Disposable {
 	protected static idPool = 0;
@@ -39,15 +40,13 @@ export abstract class BaseChatToolInvocationSubPart extends Disposable {
 			return Codicon.circleSlash;
 		}
 
-		if (toolInvocation.toolSpecificData?.kind === 'search') {
-			return IChatToolInvocation.isComplete(toolInvocation)
-				? Codicon.search
-				: ThemeIcon.modify(Codicon.search, 'spin');
+		if (confirmState?.type === ToolConfirmKind.Denied) {
+			return Codicon.error;
 		}
 
-		return confirmState?.type === ToolConfirmKind.Denied ?
-			Codicon.error :
-			IChatToolInvocation.isComplete(toolInvocation) ?
-				Codicon.check : ThemeIcon.modify(Codicon.loading, 'spin');
+		const icon = getToolInvocationIcon(toolInvocation.toolId, toolInvocation.icon ?? undefined);
+		return IChatToolInvocation.isComplete(toolInvocation)
+			? icon
+			: ThemeIcon.modify(icon, 'spin');
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolInvocationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolInvocationSubPart.ts
@@ -9,7 +9,6 @@ import { Disposable } from '../../../../../../../base/common/lifecycle.js';
 import { ThemeIcon } from '../../../../../../../base/common/themables.js';
 import { IChatToolInvocation, IChatToolInvocationSerialized, ToolConfirmKind } from '../../../../common/chatService/chatService.js';
 import { IChatCodeBlockInfo } from '../../../chat.js';
-import { getToolInvocationIcon } from '../chatThinkingContentPart.js';
 
 export abstract class BaseChatToolInvocationSubPart extends Disposable {
 	protected static idPool = 0;
@@ -40,13 +39,15 @@ export abstract class BaseChatToolInvocationSubPart extends Disposable {
 			return Codicon.circleSlash;
 		}
 
-		if (confirmState?.type === ToolConfirmKind.Denied) {
-			return Codicon.error;
+		if (toolInvocation.toolSpecificData?.kind === 'search') {
+			return IChatToolInvocation.isComplete(toolInvocation)
+				? Codicon.search
+				: ThemeIcon.modify(Codicon.search, 'spin');
 		}
 
-		const icon = getToolInvocationIcon(toolInvocation.toolId, toolInvocation.icon ?? undefined);
-		return IChatToolInvocation.isComplete(toolInvocation)
-			? icon
-			: ThemeIcon.modify(icon, 'spin');
+		return confirmState?.type === ToolConfirmKind.Denied ?
+			Codicon.error :
+			IChatToolInvocation.isComplete(toolInvocation) ?
+				Codicon.check : ThemeIcon.modify(Codicon.loading, 'spin');
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolInvocationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolInvocationSubPart.ts
@@ -39,10 +39,6 @@ export abstract class BaseChatToolInvocationSubPart extends Disposable {
 			return Codicon.circleSlash;
 		}
 
-		if (toolInvocation.toolSpecificData?.kind === 'search') {
-			return Codicon.search;
-		}
-
 		return confirmState?.type === ToolConfirmKind.Denied ?
 			Codicon.error :
 			IChatToolInvocation.isComplete(toolInvocation) ?

--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -628,7 +628,7 @@ export type ConfirmedReason =
 
 export interface IChatToolInvocation {
 	readonly presentation: IPreparedToolInvocation['presentation'];
-	readonly toolSpecificData?: IChatTerminalToolInvocationData | ILegacyChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatPullRequestContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatToolResourcesInvocationData | IChatModifiedFilesConfirmationData;
+	readonly toolSpecificData?: IChatTerminalToolInvocationData | ILegacyChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatPullRequestContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatSearchToolInvocationData | IChatToolResourcesInvocationData | IChatModifiedFilesConfirmationData;
 	/**
 	 * Observable that tracks the `kind` of `toolSpecificData`. Used by the
 	 * tool invocation part to re-render when the kind changes (e.g. from
@@ -906,7 +906,7 @@ export interface IToolResultOutputDetailsSerialized {
  */
 export interface IChatToolInvocationSerialized {
 	presentation: IPreparedToolInvocation['presentation'];
-	toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatPullRequestContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatToolResourcesInvocationData | IChatModifiedFilesConfirmationData;
+	toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatPullRequestContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatSearchToolInvocationData | IChatToolResourcesInvocationData | IChatModifiedFilesConfirmationData;
 	invocationMessage: string | IMarkdownString;
 	originMessage: string | IMarkdownString | undefined;
 	pastTenseMessage: string | IMarkdownString | undefined;
@@ -982,6 +982,10 @@ export interface IChatSimpleToolInvocationData {
 	kind: 'simpleToolInvocation';
 	input: string;
 	output: string;
+}
+
+export interface IChatSearchToolInvocationData {
+	readonly kind: 'search';
 }
 
 export interface IChatToolResourcesInvocationData {

--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -628,7 +628,7 @@ export type ConfirmedReason =
 
 export interface IChatToolInvocation {
 	readonly presentation: IPreparedToolInvocation['presentation'];
-	readonly toolSpecificData?: IChatTerminalToolInvocationData | ILegacyChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatPullRequestContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatSearchToolInvocationData | IChatToolResourcesInvocationData | IChatModifiedFilesConfirmationData;
+	readonly toolSpecificData?: IChatTerminalToolInvocationData | ILegacyChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatPullRequestContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatToolResourcesInvocationData | IChatModifiedFilesConfirmationData;
 	/**
 	 * Observable that tracks the `kind` of `toolSpecificData`. Used by the
 	 * tool invocation part to re-render when the kind changes (e.g. from
@@ -906,7 +906,7 @@ export interface IToolResultOutputDetailsSerialized {
  */
 export interface IChatToolInvocationSerialized {
 	presentation: IPreparedToolInvocation['presentation'];
-	toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatPullRequestContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatSearchToolInvocationData | IChatToolResourcesInvocationData | IChatModifiedFilesConfirmationData;
+	toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatPullRequestContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatToolResourcesInvocationData | IChatModifiedFilesConfirmationData;
 	invocationMessage: string | IMarkdownString;
 	originMessage: string | IMarkdownString | undefined;
 	pastTenseMessage: string | IMarkdownString | undefined;
@@ -982,10 +982,6 @@ export interface IChatSimpleToolInvocationData {
 	kind: 'simpleToolInvocation';
 	input: string;
 	output: string;
-}
-
-export interface IChatSearchToolInvocationData {
-	readonly kind: 'search';
 }
 
 export interface IChatToolResourcesInvocationData {

--- a/src/vs/workbench/contrib/chat/common/model/chatProgressTypes/chatToolInvocation.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatProgressTypes/chatToolInvocation.ts
@@ -8,7 +8,7 @@ import { IMarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { IObservable, ISettableObservable, observableValue } from '../../../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { localize } from '../../../../../../nls.js';
-import { ConfirmedReason, IChatExtensionsContent, IChatModifiedFilesConfirmationData, IChatSimpleToolInvocationData, IChatSubagentToolInvocationData, IChatTodoListContent, IChatToolInputInvocationData, IChatToolInvocation, IChatToolInvocationSerialized, ToolConfirmKind, type IChatTerminalToolInvocationData } from '../../chatService/chatService.js';
+import { ConfirmedReason, IChatExtensionsContent, IChatModifiedFilesConfirmationData, IChatSearchToolInvocationData, IChatSimpleToolInvocationData, IChatSubagentToolInvocationData, IChatTodoListContent, IChatToolInputInvocationData, IChatToolInvocation, IChatToolInvocationSerialized, ToolConfirmKind, type IChatTerminalToolInvocationData } from '../../chatService/chatService.js';
 import { IPreparedToolInvocation, isToolResultOutputDetails, IToolConfirmationMessages, IToolData, IToolProgressStep, IToolResult, ToolDataSource } from '../../tools/languageModelToolsService.js';
 
 export interface IStreamingToolCallOptions {
@@ -36,7 +36,7 @@ export class ChatToolInvocation implements IChatToolInvocation {
 	public readonly chatRequestId?: string;
 	public isAttachedToThinking: boolean = false;
 
-	private _toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatModifiedFilesConfirmationData;
+	private _toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatSearchToolInvocationData | IChatModifiedFilesConfirmationData;
 	private readonly _toolSpecificDataKind = observableValue<string | undefined>(this, undefined);
 	public readonly toolSpecificDataKind: IObservable<string | undefined> = this._toolSpecificDataKind;
 

--- a/src/vs/workbench/contrib/chat/common/model/chatProgressTypes/chatToolInvocation.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatProgressTypes/chatToolInvocation.ts
@@ -8,7 +8,7 @@ import { IMarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { IObservable, ISettableObservable, observableValue } from '../../../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { localize } from '../../../../../../nls.js';
-import { ConfirmedReason, IChatExtensionsContent, IChatModifiedFilesConfirmationData, IChatSearchToolInvocationData, IChatSimpleToolInvocationData, IChatSubagentToolInvocationData, IChatTodoListContent, IChatToolInputInvocationData, IChatToolInvocation, IChatToolInvocationSerialized, ToolConfirmKind, type IChatTerminalToolInvocationData } from '../../chatService/chatService.js';
+import { ConfirmedReason, IChatExtensionsContent, IChatModifiedFilesConfirmationData, IChatSimpleToolInvocationData, IChatSubagentToolInvocationData, IChatTodoListContent, IChatToolInputInvocationData, IChatToolInvocation, IChatToolInvocationSerialized, ToolConfirmKind, type IChatTerminalToolInvocationData } from '../../chatService/chatService.js';
 import { IPreparedToolInvocation, isToolResultOutputDetails, IToolConfirmationMessages, IToolData, IToolProgressStep, IToolResult, ToolDataSource } from '../../tools/languageModelToolsService.js';
 
 export interface IStreamingToolCallOptions {
@@ -36,7 +36,7 @@ export class ChatToolInvocation implements IChatToolInvocation {
 	public readonly chatRequestId?: string;
 	public isAttachedToThinking: boolean = false;
 
-	private _toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatSearchToolInvocationData | IChatModifiedFilesConfirmationData;
+	private _toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatModifiedFilesConfirmationData;
 	private readonly _toolSpecificDataKind = observableValue<string | undefined>(this, undefined);
 	public readonly toolSpecificDataKind: IObservable<string | undefined> = this._toolSpecificDataKind;
 

--- a/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
@@ -25,7 +25,7 @@ import { createDecorator } from '../../../../../platform/instantiation/common/in
 import { IProgress } from '../../../../../platform/progress/common/progress.js';
 import { ChatRequestToolReferenceEntry } from '../attachments/chatVariableEntries.js';
 import { IVariableReference } from '../chatModes.js';
-import { IChatExtensionsContent, IChatModifiedFilesConfirmationData, IChatSearchToolInvocationData, IChatSimpleToolInvocationData, IChatSubagentToolInvocationData, IChatTodoListContent, IChatToolInputInvocationData, IChatToolInvocation, type IChatTerminalToolInvocationData } from '../chatService/chatService.js';
+import { IChatExtensionsContent, IChatModifiedFilesConfirmationData, IChatSimpleToolInvocationData, IChatSubagentToolInvocationData, IChatTodoListContent, IChatToolInputInvocationData, IChatToolInvocation, type IChatTerminalToolInvocationData } from '../chatService/chatService.js';
 import { ILanguageModelChatMetadata, LanguageModelPartAudience } from '../languageModels.js';
 import { UserSelectedTools } from '../participants/chatAgents.js';
 import { PromptElementJSON, stringifyPromptElementJSON } from './promptTsxTypes.js';
@@ -190,7 +190,7 @@ export interface IToolInvocation {
 	 * Lets us add some nicer UI to toolcalls that came from a sub-agent, but in the long run, this should probably just be rendered in a similar way to thinking text + tool call groups
 	 */
 	subAgentInvocationId?: string;
-	toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatSearchToolInvocationData | IChatModifiedFilesConfirmationData;
+	toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatModifiedFilesConfirmationData;
 	modelId?: string;
 	userSelectedTools?: UserSelectedTools;
 	/** The label of the custom button selected by the user during confirmation, if custom buttons were used. */
@@ -384,7 +384,7 @@ export interface IPreparedToolInvocation {
 	confirmationMessages?: IToolConfirmationMessages;
 	presentation?: ToolInvocationPresentation;
 	icon?: ThemeIcon;
-	toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatSearchToolInvocationData | IChatModifiedFilesConfirmationData;
+	toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatModifiedFilesConfirmationData;
 }
 
 export interface IToolImpl {

--- a/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
@@ -25,7 +25,7 @@ import { createDecorator } from '../../../../../platform/instantiation/common/in
 import { IProgress } from '../../../../../platform/progress/common/progress.js';
 import { ChatRequestToolReferenceEntry } from '../attachments/chatVariableEntries.js';
 import { IVariableReference } from '../chatModes.js';
-import { IChatExtensionsContent, IChatModifiedFilesConfirmationData, IChatSimpleToolInvocationData, IChatSubagentToolInvocationData, IChatTodoListContent, IChatToolInputInvocationData, IChatToolInvocation, type IChatTerminalToolInvocationData } from '../chatService/chatService.js';
+import { IChatExtensionsContent, IChatModifiedFilesConfirmationData, IChatSearchToolInvocationData, IChatSimpleToolInvocationData, IChatSubagentToolInvocationData, IChatTodoListContent, IChatToolInputInvocationData, IChatToolInvocation, type IChatTerminalToolInvocationData } from '../chatService/chatService.js';
 import { ILanguageModelChatMetadata, LanguageModelPartAudience } from '../languageModels.js';
 import { UserSelectedTools } from '../participants/chatAgents.js';
 import { PromptElementJSON, stringifyPromptElementJSON } from './promptTsxTypes.js';
@@ -190,7 +190,7 @@ export interface IToolInvocation {
 	 * Lets us add some nicer UI to toolcalls that came from a sub-agent, but in the long run, this should probably just be rendered in a similar way to thinking text + tool call groups
 	 */
 	subAgentInvocationId?: string;
-	toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatModifiedFilesConfirmationData;
+	toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatSearchToolInvocationData | IChatModifiedFilesConfirmationData;
 	modelId?: string;
 	userSelectedTools?: UserSelectedTools;
 	/** The label of the custom button selected by the user during confirmation, if custom buttons were used. */
@@ -384,7 +384,7 @@ export interface IPreparedToolInvocation {
 	confirmationMessages?: IToolConfirmationMessages;
 	presentation?: ToolInvocationPresentation;
 	icon?: ThemeIcon;
-	toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatModifiedFilesConfirmationData;
+	toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatSearchToolInvocationData | IChatModifiedFilesConfirmationData;
 }
 
 export interface IToolImpl {


### PR DESCRIPTION
Adds first-class rendering for the Copilot CLI `rg` and `grep` search tools in VS Code's agent host.

## Changes

### Tool display (`copilotToolDisplay.ts`)
- Recognizes `rg` as a first-class tool alongside `grep`
- Shows `Searching for "{pattern}"` while running and `Searched for "{pattern}"` when complete
- Separate `ICopilotGrepToolArgs` / `ICopilotRgToolArgs` interfaces matching the EH-CLI `GrepTool` schema
- `rg` reuses the `grep` l10n keys to avoid duplicate strings for translators

### Search icon pipeline
- Added `IChatSearchToolInvocationData { kind: 'search' }` to the `toolSpecificData` discriminated union
- `getToolKind()` in `copilotToolDisplay.ts` returns `'search'` for grep/rg tools
- `stateToProgressAdapter.ts` sets `toolSpecificData = { kind: 'search' }` for running and completed search tools
- **Icon rendering**: `chatThinkingContentPart.ts` detects `toolSpecificData.kind === 'search'` and shows `Codicon.search` as the outer type-icon — consistent with how terminal tools use `isTerminalTool` to show `Codicon.terminal`
- The inner status icon (check / spinner) comes from `getIcon()` in `BaseChatToolInvocationSubPart` as normal

### Tests
- 4 unit tests in `copilotToolDisplay.test.ts` covering rg/grep invocation and past-tense messages

(Written by Copilot)