### PR TITLE
Add trace logs around chat session opening

### DIFF
--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -201,7 +201,8 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 	}
 
 	async openChat(session: ISession, chatUri: URI): Promise<void> {
-		this.logService.info(`[SessionsManagement] openChat: ${chatUri.toString()} provider=${session.providerId}`);
+		const t0 = Date.now();
+		this.logService.trace(`[SessionsManagement] openChat start uri=${chatUri.toString()} provider=${session.providerId}`);
 		this.isNewChatSessionContext.set(false);
 		this.setActiveSession(session);
 
@@ -220,20 +221,23 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 		// If the chat is untitled (not yet sent), show the new-chat-in-session view
 		if (chat && chat.status.get() === SessionStatus.Untitled) {
 			this._isNewChatInSessionContext.set(true);
+			this.logService.trace(`[SessionsManagement] openChat done total=${Date.now() - t0}ms path=untitled`);
 			return;
 		}
 
 		this._isNewChatInSessionContext.set(false);
 		await this.chatWidgetService.openSession(chatUri, ChatViewPaneTarget);
+		this.logService.trace(`[SessionsManagement] openChat done total=${Date.now() - t0}ms`);
 	}
 
 	async openSession(sessionResource: URI, options?: { preserveFocus?: boolean }): Promise<void> {
+		const t0 = Date.now();
 		const sessionData = this.getSession(sessionResource);
 		if (!sessionData) {
-			this.logService.warn(`[SessionsManagement] openSession: session not found: ${sessionResource.toString()}`);
+			this.logService.warn(`[SessionsManagement] openSession: session not found uri=${sessionResource.toString()}`);
 			throw new Error(`Session with resource ${sessionResource.toString()} not found`);
 		}
-		this.logService.info(`[SessionsManagement] openSession: ${sessionResource.toString()} provider=${sessionData.providerId}`);
+		this.logService.trace(`[SessionsManagement] openSession start uri=${sessionResource.toString()} provider=${sessionData.providerId}`);
 		this.isNewChatSessionContext.set(false);
 		this._isNewChatInSessionContext.set(false);
 		this.setActiveSession(sessionData);
@@ -242,6 +246,7 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 		const activeChat = this._activeSession.get()?.activeChat.get();
 		const openUri = activeChat?.resource ?? sessionData.resource;
 		await this.chatWidgetService.openSession(openUri, ChatViewPaneTarget, { preserveFocus: options?.preserveFocus });
+		this.logService.trace(`[SessionsManagement] openSession done total=${Date.now() - t0}ms`);
 	}
 
 	unsetNewSession(): void {

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -206,28 +206,36 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 		this.isNewChatSessionContext.set(false);
 		this.setActiveSession(session);
 
-		// Find the chat and update active chat
-		let chat: IChat | undefined;
-		if (this._activeChatObservable) {
-			const activeSession = this._activeSession.get();
-			if (activeSession) {
-				chat = activeSession.chats.get().find(c => this.uriIdentityService.extUri.isEqual(c.resource, chatUri));
-				if (chat) {
-					this._activeChatObservable.set(chat, undefined);
+		let path = 'normal';
+		let error = false;
+		try {
+			// Find the chat and update active chat
+			let chat: IChat | undefined;
+			if (this._activeChatObservable) {
+				const activeSession = this._activeSession.get();
+				if (activeSession) {
+					chat = activeSession.chats.get().find(c => this.uriIdentityService.extUri.isEqual(c.resource, chatUri));
+					if (chat) {
+						this._activeChatObservable.set(chat, undefined);
+					}
 				}
 			}
-		}
 
-		// If the chat is untitled (not yet sent), show the new-chat-in-session view
-		if (chat && chat.status.get() === SessionStatus.Untitled) {
-			this._isNewChatInSessionContext.set(true);
-			this.logService.trace(`[SessionsManagement] openChat done total=${Date.now() - t0}ms path=untitled`);
-			return;
-		}
+			// If the chat is untitled (not yet sent), show the new-chat-in-session view
+			if (chat && chat.status.get() === SessionStatus.Untitled) {
+				this._isNewChatInSessionContext.set(true);
+				path = 'untitled';
+				return;
+			}
 
-		this._isNewChatInSessionContext.set(false);
-		await this.chatWidgetService.openSession(chatUri, ChatViewPaneTarget);
-		this.logService.trace(`[SessionsManagement] openChat done total=${Date.now() - t0}ms`);
+			this._isNewChatInSessionContext.set(false);
+			await this.chatWidgetService.openSession(chatUri, ChatViewPaneTarget);
+		} catch (err) {
+			error = true;
+			throw err;
+		} finally {
+			this.logService.trace(`[SessionsManagement] openChat done total=${Date.now() - t0}ms path=${path}${error ? ' error=true' : ''}`);
+		}
 	}
 
 	async openSession(sessionResource: URI, options?: { preserveFocus?: boolean }): Promise<void> {
@@ -242,11 +250,18 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 		this._isNewChatInSessionContext.set(false);
 		this.setActiveSession(sessionData);
 
-		// Open the active chat (which may have been restored to the last active chat)
-		const activeChat = this._activeSession.get()?.activeChat.get();
-		const openUri = activeChat?.resource ?? sessionData.resource;
-		await this.chatWidgetService.openSession(openUri, ChatViewPaneTarget, { preserveFocus: options?.preserveFocus });
-		this.logService.trace(`[SessionsManagement] openSession done total=${Date.now() - t0}ms`);
+		let error = false;
+		try {
+			// Open the active chat (which may have been restored to the last active chat)
+			const activeChat = this._activeSession.get()?.activeChat.get();
+			const openUri = activeChat?.resource ?? sessionData.resource;
+			await this.chatWidgetService.openSession(openUri, ChatViewPaneTarget, { preserveFocus: options?.preserveFocus });
+		} catch (err) {
+			error = true;
+			throw err;
+		} finally {
+			this.logService.trace(`[SessionsManagement] openSession done total=${Date.now() - t0}ms${error ? ' error=true' : ''}`);
+		}
 	}
 
 	unsetNewSession(): void {

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -207,7 +207,7 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 		this.setActiveSession(session);
 
 		let path = 'normal';
-		let error = false;
+		let error = true;
 		try {
 			// Find the chat and update active chat
 			let chat: IChat | undefined;
@@ -225,14 +225,13 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 			if (chat && chat.status.get() === SessionStatus.Untitled) {
 				this._isNewChatInSessionContext.set(true);
 				path = 'untitled';
+				error = false;
 				return;
 			}
 
 			this._isNewChatInSessionContext.set(false);
 			await this.chatWidgetService.openSession(chatUri, ChatViewPaneTarget);
-		} catch (err) {
-			error = true;
-			throw err;
+			error = false;
 		} finally {
 			this.logService.trace(`[SessionsManagement] openChat done total=${Date.now() - t0}ms path=${path}${error ? ' error=true' : ''}`);
 		}
@@ -250,15 +249,13 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 		this._isNewChatInSessionContext.set(false);
 		this.setActiveSession(sessionData);
 
-		let error = false;
+		let error = true;
 		try {
 			// Open the active chat (which may have been restored to the last active chat)
 			const activeChat = this._activeSession.get()?.activeChat.get();
 			const openUri = activeChat?.resource ?? sessionData.resource;
 			await this.chatWidgetService.openSession(openUri, ChatViewPaneTarget, { preserveFocus: options?.preserveFocus });
-		} catch (err) {
-			error = true;
-			throw err;
+			error = false;
 		} finally {
 			this.logService.trace(`[SessionsManagement] openSession done total=${Date.now() - t0}ms${error ? ' error=true' : ''}`);
 		}

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -206,35 +206,28 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 		this.isNewChatSessionContext.set(false);
 		this.setActiveSession(session);
 
-		let path = 'normal';
-		let error = true;
-		try {
-			// Find the chat and update active chat
-			let chat: IChat | undefined;
-			if (this._activeChatObservable) {
-				const activeSession = this._activeSession.get();
-				if (activeSession) {
-					chat = activeSession.chats.get().find(c => this.uriIdentityService.extUri.isEqual(c.resource, chatUri));
-					if (chat) {
-						this._activeChatObservable.set(chat, undefined);
-					}
+		// Find the chat and update active chat
+		let chat: IChat | undefined;
+		if (this._activeChatObservable) {
+			const activeSession = this._activeSession.get();
+			if (activeSession) {
+				chat = activeSession.chats.get().find(c => this.uriIdentityService.extUri.isEqual(c.resource, chatUri));
+				if (chat) {
+					this._activeChatObservable.set(chat, undefined);
 				}
 			}
-
-			// If the chat is untitled (not yet sent), show the new-chat-in-session view
-			if (chat && chat.status.get() === SessionStatus.Untitled) {
-				this._isNewChatInSessionContext.set(true);
-				path = 'untitled';
-				error = false;
-				return;
-			}
-
-			this._isNewChatInSessionContext.set(false);
-			await this.chatWidgetService.openSession(chatUri, ChatViewPaneTarget);
-			error = false;
-		} finally {
-			this.logService.trace(`[SessionsManagement] openChat done total=${Date.now() - t0}ms path=${path}${error ? ' error=true' : ''}`);
 		}
+
+		// If the chat is untitled (not yet sent), show the new-chat-in-session view
+		if (chat && chat.status.get() === SessionStatus.Untitled) {
+			this._isNewChatInSessionContext.set(true);
+			this.logService.trace(`[SessionsManagement] openChat done total=${Date.now() - t0}ms path=untitled`);
+			return;
+		}
+
+		this._isNewChatInSessionContext.set(false);
+		await this.chatWidgetService.openSession(chatUri, ChatViewPaneTarget);
+		this.logService.trace(`[SessionsManagement] openChat done total=${Date.now() - t0}ms`);
 	}
 
 	async openSession(sessionResource: URI, options?: { preserveFocus?: boolean }): Promise<void> {
@@ -249,16 +242,11 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 		this._isNewChatInSessionContext.set(false);
 		this.setActiveSession(sessionData);
 
-		let error = true;
-		try {
-			// Open the active chat (which may have been restored to the last active chat)
-			const activeChat = this._activeSession.get()?.activeChat.get();
-			const openUri = activeChat?.resource ?? sessionData.resource;
-			await this.chatWidgetService.openSession(openUri, ChatViewPaneTarget, { preserveFocus: options?.preserveFocus });
-			error = false;
-		} finally {
-			this.logService.trace(`[SessionsManagement] openSession done total=${Date.now() - t0}ms${error ? ' error=true' : ''}`);
-		}
+		// Open the active chat (which may have been restored to the last active chat)
+		const activeChat = this._activeSession.get()?.activeChat.get();
+		const openUri = activeChat?.resource ?? sessionData.resource;
+		await this.chatWidgetService.openSession(openUri, ChatViewPaneTarget, { preserveFocus: options?.preserveFocus });
+		this.logService.trace(`[SessionsManagement] openSession done total=${Date.now() - t0}ms`);
 	}
 
 	unsetNewSession(): void {

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -221,13 +221,13 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 		// If the chat is untitled (not yet sent), show the new-chat-in-session view
 		if (chat && chat.status.get() === SessionStatus.Untitled) {
 			this._isNewChatInSessionContext.set(true);
-			this.logService.trace(`[SessionsManagement] openChat done total=${Date.now() - t0}ms path=untitled`);
+			this.logService.trace(`[SessionsManagement] openChat done total=${Date.now() - t0}ms uri=${chatUri.toString()} path=untitled`);
 			return;
 		}
 
 		this._isNewChatInSessionContext.set(false);
 		await this.chatWidgetService.openSession(chatUri, ChatViewPaneTarget);
-		this.logService.trace(`[SessionsManagement] openChat done total=${Date.now() - t0}ms`);
+		this.logService.trace(`[SessionsManagement] openChat done total=${Date.now() - t0}ms uri=${chatUri.toString()}`);
 	}
 
 	async openSession(sessionResource: URI, options?: { preserveFocus?: boolean }): Promise<void> {
@@ -246,7 +246,7 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 		const activeChat = this._activeSession.get()?.activeChat.get();
 		const openUri = activeChat?.resource ?? sessionData.resource;
 		await this.chatWidgetService.openSession(openUri, ChatViewPaneTarget, { preserveFocus: options?.preserveFocus });
-		this.logService.trace(`[SessionsManagement] openSession done total=${Date.now() - t0}ms`);
+		this.logService.trace(`[SessionsManagement] openSession done total=${Date.now() - t0}ms uri=${sessionResource.toString()}`);
 	}
 
 	unsetNewSession(): void {

--- a/src/vs/workbench/api/browser/mainThreadChatSessions.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatSessions.ts
@@ -896,6 +896,8 @@ export class MainThreadChatSessions extends Disposable implements MainThreadChat
 	}
 
 	private async _provideChatSessionContent(providerHandle: number, sessionResource: URI, token: CancellationToken): Promise<IChatSession> {
+		const t0 = Date.now();
+		this._logService.trace(`[MainThreadChatSessions] _provideChatSessionContent start handle=${providerHandle} uri=${sessionResource.toString()}`);
 		warnOnUntitledSessionResource(sessionResource, this._logService);
 
 		let session = this._activeSessions.get(sessionResource);
@@ -932,6 +934,7 @@ export class MainThreadChatSessions extends Disposable implements MainThreadChat
 					}
 				}
 			}
+			this._logService.trace(`[MainThreadChatSessions] _provideChatSessionContent done total=${Date.now() - t0}ms handle=${providerHandle}`);
 			return session;
 		} catch (error) {
 			session.dispose();

--- a/src/vs/workbench/api/browser/mainThreadChatSessions.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatSessions.ts
@@ -934,7 +934,7 @@ export class MainThreadChatSessions extends Disposable implements MainThreadChat
 					}
 				}
 			}
-			this._logService.trace(`[MainThreadChatSessions] _provideChatSessionContent done total=${Date.now() - t0}ms handle=${providerHandle}`);
+			this._logService.trace(`[MainThreadChatSessions] _provideChatSessionContent done total=${Date.now() - t0}ms handle=${providerHandle} uri=${sessionResource.toString()}`);
 			return session;
 		} catch (error) {
 			session.dispose();

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidgetService.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidgetService.ts
@@ -111,13 +111,14 @@ export class ChatWidgetService extends Disposable implements IChatWidgetService 
 		this.logService.trace(`[ChatWidgetService] openSession start uri=${sessionResource.toString()} target=${targetKind}`);
 
 		let path = 'unknown';
-		let error = false;
+		let error = true;
 		try {
 			// Reveal if already open unless instructed otherwise
 			if (typeof target === 'undefined' || options?.revealIfOpened) {
 				const alreadyOpenWidget = await this.revealSessionIfAlreadyOpen(sessionResource, options);
 				if (alreadyOpenWidget) {
 					path = 'reveal';
+					error = false;
 					return alreadyOpenWidget;
 				}
 			} else {
@@ -134,6 +135,7 @@ export class ChatWidgetService extends Disposable implements IChatWidgetService 
 						chatView.focusInput();
 					}
 				}
+				error = false;
 				return chatView?.widget;
 			}
 
@@ -146,10 +148,8 @@ export class ChatWidgetService extends Disposable implements IChatWidgetService 
 					revealIfOpened: options?.revealIfOpened ?? true // always try to reveal if already opened unless explicitly told not to
 				}
 			}, target);
+			error = false;
 			return pane instanceof ChatEditor ? pane.widget : undefined;
-		} catch (err) {
-			error = true;
-			throw err;
 		} finally {
 			this.logService.trace(`[ChatWidgetService] openSession done total=${Date.now() - t0}ms path=${path}${error ? ' error=true' : ''}`);
 		}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidgetService.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidgetService.ts
@@ -10,6 +10,7 @@ import { combinedDisposable, Disposable, IDisposable, toDisposable } from '../..
 import { isEqual } from '../../../../../base/common/resources.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ILayoutService } from '../../../../../platform/layout/browser/layoutService.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
 import { ACTIVE_GROUP, IEditorService, type PreferredGroup } from '../../../../services/editor/common/editorService.js';
 import { IEditorGroup, IEditorGroupsService, isEditorGroup } from '../../../../services/editor/common/editorGroupsService.js';
 import { IViewsService } from '../../../../services/views/common/viewsService.js';
@@ -46,6 +47,7 @@ export class ChatWidgetService extends Disposable implements IChatWidgetService 
 		@ILayoutService private readonly layoutService: ILayoutService,
 		@IEditorService private readonly editorService: IEditorService,
 		@IChatService private readonly chatService: IChatService,
+		@ILogService private readonly logService: ILogService,
 	) {
 		super();
 	}
@@ -104,10 +106,15 @@ export class ChatWidgetService extends Disposable implements IChatWidgetService 
 	openSession(sessionResource: URI, target?: typeof ChatViewPaneTarget): Promise<IChatWidget | undefined>;
 	openSession(sessionResource: URI, target?: PreferredGroup, options?: IChatEditorOptions): Promise<IChatWidget | undefined>;
 	async openSession(sessionResource: URI, target?: typeof ChatViewPaneTarget | PreferredGroup, options?: IChatEditorOptions): Promise<IChatWidget | undefined> {
+		const t0 = Date.now();
+		const targetKind = target === ChatViewPaneTarget ? 'view' : (typeof target === 'undefined' ? 'undefined' : 'editor');
+		this.logService.trace(`[ChatWidgetService] openSession start uri=${sessionResource.toString()} target=${targetKind}`);
+
 		// Reveal if already open unless instructed otherwise
 		if (typeof target === 'undefined' || options?.revealIfOpened) {
 			const alreadyOpenWidget = await this.revealSessionIfAlreadyOpen(sessionResource, options);
 			if (alreadyOpenWidget) {
+				this.logService.trace(`[ChatWidgetService] openSession done total=${Date.now() - t0}ms path=reveal`);
 				return alreadyOpenWidget;
 			}
 		} else {
@@ -123,6 +130,7 @@ export class ChatWidgetService extends Disposable implements IChatWidgetService 
 					chatView.focusInput();
 				}
 			}
+			this.logService.trace(`[ChatWidgetService] openSession done total=${Date.now() - t0}ms path=view`);
 			return chatView?.widget;
 		}
 
@@ -134,6 +142,7 @@ export class ChatWidgetService extends Disposable implements IChatWidgetService 
 				revealIfOpened: options?.revealIfOpened ?? true // always try to reveal if already opened unless explicitly told not to
 			}
 		}, target);
+		this.logService.trace(`[ChatWidgetService] openSession done total=${Date.now() - t0}ms path=editor`);
 		return pane instanceof ChatEditor ? pane.widget : undefined;
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidgetService.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidgetService.ts
@@ -110,40 +110,49 @@ export class ChatWidgetService extends Disposable implements IChatWidgetService 
 		const targetKind = target === ChatViewPaneTarget ? 'view' : (typeof target === 'undefined' ? 'undefined' : 'editor');
 		this.logService.trace(`[ChatWidgetService] openSession start uri=${sessionResource.toString()} target=${targetKind}`);
 
-		// Reveal if already open unless instructed otherwise
-		if (typeof target === 'undefined' || options?.revealIfOpened) {
-			const alreadyOpenWidget = await this.revealSessionIfAlreadyOpen(sessionResource, options);
-			if (alreadyOpenWidget) {
-				this.logService.trace(`[ChatWidgetService] openSession done total=${Date.now() - t0}ms path=reveal`);
-				return alreadyOpenWidget;
-			}
-		} else {
-			await this.prepareSessionForMove(sessionResource, target);
-		}
-
-		// Load this session in chat view (preferred)
-		if (target === ChatViewPaneTarget || typeof target === 'undefined') {
-			const chatView = await this.viewsService.openView<ChatViewPane>(ChatViewId, !options?.preserveFocus);
-			if (chatView) {
-				await chatView.loadSession(sessionResource);
-				if (!options?.preserveFocus) {
-					chatView.focusInput();
+		let path = 'unknown';
+		let error = false;
+		try {
+			// Reveal if already open unless instructed otherwise
+			if (typeof target === 'undefined' || options?.revealIfOpened) {
+				const alreadyOpenWidget = await this.revealSessionIfAlreadyOpen(sessionResource, options);
+				if (alreadyOpenWidget) {
+					path = 'reveal';
+					return alreadyOpenWidget;
 				}
+			} else {
+				await this.prepareSessionForMove(sessionResource, target);
 			}
-			this.logService.trace(`[ChatWidgetService] openSession done total=${Date.now() - t0}ms path=view`);
-			return chatView?.widget;
-		}
 
-		// Open in chat editor
-		const pane = await this.editorService.openEditor({
-			resource: sessionResource,
-			options: {
-				...options,
-				revealIfOpened: options?.revealIfOpened ?? true // always try to reveal if already opened unless explicitly told not to
+			// Load this session in chat view (preferred)
+			if (target === ChatViewPaneTarget || typeof target === 'undefined') {
+				path = 'view';
+				const chatView = await this.viewsService.openView<ChatViewPane>(ChatViewId, !options?.preserveFocus);
+				if (chatView) {
+					await chatView.loadSession(sessionResource);
+					if (!options?.preserveFocus) {
+						chatView.focusInput();
+					}
+				}
+				return chatView?.widget;
 			}
-		}, target);
-		this.logService.trace(`[ChatWidgetService] openSession done total=${Date.now() - t0}ms path=editor`);
-		return pane instanceof ChatEditor ? pane.widget : undefined;
+
+			// Open in chat editor
+			path = 'editor';
+			const pane = await this.editorService.openEditor({
+				resource: sessionResource,
+				options: {
+					...options,
+					revealIfOpened: options?.revealIfOpened ?? true // always try to reveal if already opened unless explicitly told not to
+				}
+			}, target);
+			return pane instanceof ChatEditor ? pane.widget : undefined;
+		} catch (err) {
+			error = true;
+			throw err;
+		} finally {
+			this.logService.trace(`[ChatWidgetService] openSession done total=${Date.now() - t0}ms path=${path}${error ? ' error=true' : ''}`);
+		}
 	}
 
 	private async revealSessionIfAlreadyOpen(sessionResource: URI, options?: IChatEditorOptions): Promise<IChatWidget | undefined> {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidgetService.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidgetService.ts
@@ -114,7 +114,7 @@ export class ChatWidgetService extends Disposable implements IChatWidgetService 
 		if (typeof target === 'undefined' || options?.revealIfOpened) {
 			const alreadyOpenWidget = await this.revealSessionIfAlreadyOpen(sessionResource, options);
 			if (alreadyOpenWidget) {
-				this.logService.trace(`[ChatWidgetService] openSession done total=${Date.now() - t0}ms path=reveal`);
+				this.logService.trace(`[ChatWidgetService] openSession done total=${Date.now() - t0}ms uri=${sessionResource.toString()} path=reveal`);
 				return alreadyOpenWidget;
 			}
 		} else {
@@ -130,7 +130,7 @@ export class ChatWidgetService extends Disposable implements IChatWidgetService 
 					chatView.focusInput();
 				}
 			}
-			this.logService.trace(`[ChatWidgetService] openSession done total=${Date.now() - t0}ms path=view`);
+			this.logService.trace(`[ChatWidgetService] openSession done total=${Date.now() - t0}ms uri=${sessionResource.toString()} path=view`);
 			return chatView?.widget;
 		}
 
@@ -142,7 +142,7 @@ export class ChatWidgetService extends Disposable implements IChatWidgetService 
 				revealIfOpened: options?.revealIfOpened ?? true // always try to reveal if already opened unless explicitly told not to
 			}
 		}, target);
-		this.logService.trace(`[ChatWidgetService] openSession done total=${Date.now() - t0}ms path=editor`);
+		this.logService.trace(`[ChatWidgetService] openSession done total=${Date.now() - t0}ms uri=${sessionResource.toString()} path=editor`);
 		return pane instanceof ChatEditor ? pane.widget : undefined;
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidgetService.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidgetService.ts
@@ -110,49 +110,40 @@ export class ChatWidgetService extends Disposable implements IChatWidgetService 
 		const targetKind = target === ChatViewPaneTarget ? 'view' : (typeof target === 'undefined' ? 'undefined' : 'editor');
 		this.logService.trace(`[ChatWidgetService] openSession start uri=${sessionResource.toString()} target=${targetKind}`);
 
-		let path = 'unknown';
-		let error = true;
-		try {
-			// Reveal if already open unless instructed otherwise
-			if (typeof target === 'undefined' || options?.revealIfOpened) {
-				const alreadyOpenWidget = await this.revealSessionIfAlreadyOpen(sessionResource, options);
-				if (alreadyOpenWidget) {
-					path = 'reveal';
-					error = false;
-					return alreadyOpenWidget;
-				}
-			} else {
-				await this.prepareSessionForMove(sessionResource, target);
+		// Reveal if already open unless instructed otherwise
+		if (typeof target === 'undefined' || options?.revealIfOpened) {
+			const alreadyOpenWidget = await this.revealSessionIfAlreadyOpen(sessionResource, options);
+			if (alreadyOpenWidget) {
+				this.logService.trace(`[ChatWidgetService] openSession done total=${Date.now() - t0}ms path=reveal`);
+				return alreadyOpenWidget;
 			}
-
-			// Load this session in chat view (preferred)
-			if (target === ChatViewPaneTarget || typeof target === 'undefined') {
-				path = 'view';
-				const chatView = await this.viewsService.openView<ChatViewPane>(ChatViewId, !options?.preserveFocus);
-				if (chatView) {
-					await chatView.loadSession(sessionResource);
-					if (!options?.preserveFocus) {
-						chatView.focusInput();
-					}
-				}
-				error = false;
-				return chatView?.widget;
-			}
-
-			// Open in chat editor
-			path = 'editor';
-			const pane = await this.editorService.openEditor({
-				resource: sessionResource,
-				options: {
-					...options,
-					revealIfOpened: options?.revealIfOpened ?? true // always try to reveal if already opened unless explicitly told not to
-				}
-			}, target);
-			error = false;
-			return pane instanceof ChatEditor ? pane.widget : undefined;
-		} finally {
-			this.logService.trace(`[ChatWidgetService] openSession done total=${Date.now() - t0}ms path=${path}${error ? ' error=true' : ''}`);
+		} else {
+			await this.prepareSessionForMove(sessionResource, target);
 		}
+
+		// Load this session in chat view (preferred)
+		if (target === ChatViewPaneTarget || typeof target === 'undefined') {
+			const chatView = await this.viewsService.openView<ChatViewPane>(ChatViewId, !options?.preserveFocus);
+			if (chatView) {
+				await chatView.loadSession(sessionResource);
+				if (!options?.preserveFocus) {
+					chatView.focusInput();
+				}
+			}
+			this.logService.trace(`[ChatWidgetService] openSession done total=${Date.now() - t0}ms path=view`);
+			return chatView?.widget;
+		}
+
+		// Open in chat editor
+		const pane = await this.editorService.openEditor({
+			resource: sessionResource,
+			options: {
+				...options,
+				revealIfOpened: options?.revealIfOpened ?? true // always try to reveal if already opened unless explicitly told not to
+			}
+		}, target);
+		this.logService.trace(`[ChatWidgetService] openSession done total=${Date.now() - t0}ms path=editor`);
+		return pane instanceof ChatEditor ? pane.widget : undefined;
 	}
 
 	private async revealSessionIfAlreadyOpen(sessionResource: URI, options?: IChatEditorOptions): Promise<IChatWidget | undefined> {

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
@@ -815,6 +815,9 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 	}
 
 	async loadSession(sessionResource: URI): Promise<IChatModel | undefined> {
+		const t0 = Date.now();
+		this.logService.trace(`[ChatViewPane] loadSession start uri=${sessionResource.toString()}`);
+
 		// Cancel any in-flight loadSession call so the last one always wins
 		this.loadSessionCts.value?.cancel();
 		const cts = this.loadSessionCts.value = new CancellationTokenSource();
@@ -827,6 +830,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 		}
 
 		if (token.isCancellationRequested) {
+			this.logService.trace(`[ChatViewPane] loadSession done total=${Date.now() - t0}ms cancelled=true phase=preAcquire`);
 			return undefined;
 		}
 
@@ -852,15 +856,19 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 
 				if (token.isCancellationRequested) {
 					newModelRef?.dispose();
+					this.logService.trace(`[ChatViewPane] loadSession done total=${Date.now() - t0}ms cancelled=true phase=postAcquire`);
 					return undefined;
 				}
 
-				return this.showModel(token, newModelRef);
+				const result = await this.showModel(token, newModelRef);
+				this.logService.trace(`[ChatViewPane] loadSession done total=${Date.now() - t0}ms`);
+				return result;
 			} catch (err) {
 				clearWidget.dispose();
 				await queue;
 
 				if (token.isCancellationRequested) {
+					this.logService.trace(`[ChatViewPane] loadSession done total=${Date.now() - t0}ms cancelled=true phase=error`);
 					return undefined;
 				}
 
@@ -868,7 +876,9 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 				// is not left in a broken state without title or back button.
 				this.logService.error(`Failed to load chat session '${sessionResource.toString()}'`, err);
 				this.notificationService.error(localize('chat.loadSessionFailed', "Failed to open chat session: {0}", toErrorMessage(err)));
-				return this.showModel(token, undefined);
+				const result = await this.showModel(token, undefined);
+				this.logService.trace(`[ChatViewPane] loadSession done total=${Date.now() - t0}ms error=true`);
+				return result;
 			} finally {
 				clearWidgetCancellationListener.dispose();
 			}

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
@@ -830,7 +830,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 		}
 
 		if (token.isCancellationRequested) {
-			this.logService.trace(`[ChatViewPane] loadSession done total=${Date.now() - t0}ms cancelled=true phase=preAcquire`);
+			this.logService.trace(`[ChatViewPane] loadSession done total=${Date.now() - t0}ms uri=${sessionResource.toString()} cancelled=true phase=preAcquire`);
 			return undefined;
 		}
 
@@ -856,19 +856,19 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 
 				if (token.isCancellationRequested) {
 					newModelRef?.dispose();
-					this.logService.trace(`[ChatViewPane] loadSession done total=${Date.now() - t0}ms cancelled=true phase=postAcquire`);
+					this.logService.trace(`[ChatViewPane] loadSession done total=${Date.now() - t0}ms uri=${sessionResource.toString()} cancelled=true phase=postAcquire`);
 					return undefined;
 				}
 
 				const result = await this.showModel(token, newModelRef);
-				this.logService.trace(`[ChatViewPane] loadSession done total=${Date.now() - t0}ms`);
+				this.logService.trace(`[ChatViewPane] loadSession done total=${Date.now() - t0}ms uri=${sessionResource.toString()}`);
 				return result;
 			} catch (err) {
 				clearWidget.dispose();
 				await queue;
 
 				if (token.isCancellationRequested) {
-					this.logService.trace(`[ChatViewPane] loadSession done total=${Date.now() - t0}ms cancelled=true phase=error`);
+					this.logService.trace(`[ChatViewPane] loadSession done total=${Date.now() - t0}ms uri=${sessionResource.toString()} cancelled=true phase=error`);
 					return undefined;
 				}
 
@@ -877,7 +877,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 				this.logService.error(`Failed to load chat session '${sessionResource.toString()}'`, err);
 				this.notificationService.error(localize('chat.loadSessionFailed', "Failed to open chat session: {0}", toErrorMessage(err)));
 				const result = await this.showModel(token, undefined);
-				this.logService.trace(`[ChatViewPane] loadSession done total=${Date.now() - t0}ms error=true`);
+				this.logService.trace(`[ChatViewPane] loadSession done total=${Date.now() - t0}ms uri=${sessionResource.toString()} error=true`);
 				return result;
 			} finally {
 				clearWidgetCancellationListener.dispose();


### PR DESCRIPTION
Adds tracing logs to help diagnose chat session opening performance.

Instrumented call path:
- `SessionsManagementService.openChat` / `openSession`
- `ChatWidgetService.openSession`
- `ChatViewPane.loadSession`
- `MainThreadChatSessions._provideChatSessionContent`

Each entry logs a `start` and `done total=Xms` at `trace` level so timings can be correlated end-to-end when investigating slow open scenarios.