### PR TITLE
sessions: add agent session navigation commands

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/sessionsChatAccessibilityHelp.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionsChatAccessibilityHelp.ts
@@ -30,6 +30,7 @@ export class SessionsChatAccessibilityHelp implements IAccessibleViewImplementat
 		content.push(localize('sessionsChat.changes', "Focus the Changes view{0}.", '<keybinding:workbench.action.agentSessions.focusChangesView>'));
 		content.push(localize('sessionsChat.filesView', "Focus the Files Explorer view{0}.", '<keybinding:workbench.action.agentSessions.focusChangesFileView>'));
 		content.push(localize('sessionsChat.sessionsView', "Focus the Chat Sessions view{0}.", '<keybinding:workbench.action.chat.focusAgentSessionsViewer>'));
+		content.push(localize('sessionsChat.switchSessions', "Switch to the next or previous agent session with {0} and {1}. When reviewing files in the modal editor, these keybindings navigate to the next or previous file instead.", '<keybinding:workbench.action.agentSessions.nextSession>', '<keybinding:workbench.action.agentSessions.previousSession>'));
 		content.push(localize('sessionsChat.customizations', "Focus the Chat Customizations view{0}.", `<keybinding:${FOCUS_AI_CUSTOMIZATION_VIEW_ID}>`));
 
 		return new AccessibleContentProvider(

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -68,6 +68,23 @@ export enum SessionsSorting {
 	Updated = 'updated',
 }
 
+export function getRelativeVisibleSession(visibleSessions: readonly ISession[], activeSession: ISession | undefined, next: boolean): ISession | undefined {
+	if (visibleSessions.length === 0) {
+		return undefined;
+	}
+	if (!activeSession) {
+		return next ? visibleSessions[0] : visibleSessions[visibleSessions.length - 1];
+	}
+
+	const activeIndex = visibleSessions.findIndex(session => session.sessionId === activeSession.sessionId);
+	if (activeIndex === -1) {
+		return next ? visibleSessions[0] : visibleSessions[visibleSessions.length - 1];
+	}
+
+	const offset = next ? 1 : -1;
+	return visibleSessions[(activeIndex + offset + visibleSessions.length) % visibleSessions.length];
+}
+
 export interface ISessionSection {
 	readonly id: string;
 	readonly label: string;

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
@@ -15,12 +15,13 @@ import { IQuickInputService } from '../../../../../platform/quickinput/common/qu
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
 import { KeybindingsRegistry, KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { IViewsService } from '../../../../../workbench/services/views/common/viewsService.js';
-import { EditorsVisibleContext, IsAuxiliaryWindowContext, IsSessionsWindowContext } from '../../../../../workbench/common/contextkeys.js';
+import { EditorPartModalContext, EditorPartModalNavigationContext, EditorsVisibleContext, IsAuxiliaryWindowContext, IsSessionsWindowContext } from '../../../../../workbench/common/contextkeys.js';
 import { IChatWidgetService } from '../../../../../workbench/contrib/chat/browser/chat.js';
 import { AUX_WINDOW_GROUP } from '../../../../../workbench/services/editor/common/editorService.js';
+import { NAVIGATE_MODAL_EDITOR_NEXT_COMMAND_ID, NAVIGATE_MODAL_EDITOR_PREVIOUS_COMMAND_ID } from '../../../../../workbench/browser/parts/editor/editorCommands.js';
 import { SessionsCategories } from '../../../../common/categories.js';
 import { ChatSessionProviderIdContext, IsActiveSessionArchivedContext, IsNewChatSessionContext, SessionsWelcomeVisibleContext } from '../../../../common/contextkeys.js';
-import { SessionItemToolbarMenuId, SessionItemContextMenuId, SessionSectionToolbarMenuId, SessionSectionTypeContext, IsSessionPinnedContext, IsSessionArchivedContext, IsSessionReadContext, SessionsGrouping, SessionsSorting, ISessionSection } from './sessionsList.js';
+import { SessionItemToolbarMenuId, SessionItemContextMenuId, SessionSectionToolbarMenuId, SessionSectionTypeContext, IsSessionPinnedContext, IsSessionArchivedContext, IsSessionReadContext, SessionsGrouping, SessionsSorting, ISessionSection, getRelativeVisibleSession } from './sessionsList.js';
 import { ISession, SessionStatus } from '../../../../services/sessions/common/session.js';
 import { IsWorkspaceGroupCappedContext, SessionsViewFilterOptionsSubMenu, SessionsViewFilterSubMenu, SessionsViewGroupingContext, SessionsViewId, SessionsView, SessionsViewSortingContext } from './sessionsView.js';
 import { SessionsViewId as NewChatViewId, NewChatViewPane } from '../../../chat/browser/newChatViewPane.js';
@@ -68,6 +69,10 @@ KeybindingsRegistry.registerKeybindingRule({
 //  Open Session at Index (Ctrl/Cmd+1..9)
 
 const OPEN_SESSION_AT_INDEX_COMMAND_ID = 'sessionsViewPane.openSessionAtIndex';
+const OPEN_NEXT_SESSION_COMMAND_ID = 'workbench.action.agentSessions.nextSession';
+const OPEN_PREVIOUS_SESSION_COMMAND_ID = 'workbench.action.agentSessions.previousSession';
+const sessionsWindowWithoutModalEditor = ContextKeyExpr.and(IsSessionsWindowContext, EditorPartModalContext.negate());
+const sessionsWindowModalEditorNavigation = ContextKeyExpr.and(IsSessionsWindowContext, EditorPartModalNavigationContext);
 
 function digitToKeyCode(digit: number): KeyCode {
 	switch (digit) {
@@ -108,6 +113,89 @@ const openSessionAtIndex = (accessor: ServicesAccessor, sessionIndex: unknown): 
 CommandsRegistry.registerCommand({
 	id: OPEN_SESSION_AT_INDEX_COMMAND_ID,
 	handler: openSessionAtIndex
+});
+
+const openRelativeSession = async (accessor: ServicesAccessor, next: boolean): Promise<void> => {
+	const viewsService = accessor.get(IViewsService);
+	const sessionsManagementService = accessor.get(ISessionsManagementService);
+	const view = viewsService.getViewWithId<SessionsView>(SessionsViewId) ?? await viewsService.openView<SessionsView>(SessionsViewId, false);
+	const visible = view?.sessionsControl?.getVisibleSessions() ?? [];
+	const target = getRelativeVisibleSession(visible, sessionsManagementService.activeSession.get(), next);
+	if (target) {
+		await sessionsManagementService.openSession(target.resource);
+	}
+};
+
+registerAction2(class OpenNextSessionAction extends Action2 {
+	constructor() {
+		super({
+			id: OPEN_NEXT_SESSION_COMMAND_ID,
+			title: localize2('openNextAgentSession', "Open Next Agent Session"),
+			f1: true,
+			category: SessionsCategories.Sessions,
+			precondition: IsSessionsWindowContext,
+			keybinding: {
+				weight: KeybindingWeight.WorkbenchContrib + 1,
+				primary: KeyMod.CtrlCmd | KeyCode.PageDown,
+				mac: {
+					primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.RightArrow,
+					secondary: [KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.BracketRight]
+				},
+				when: sessionsWindowWithoutModalEditor,
+			},
+		});
+	}
+
+	override run(accessor: ServicesAccessor): Promise<void> {
+		return openRelativeSession(accessor, true);
+	}
+});
+
+registerAction2(class OpenPreviousSessionAction extends Action2 {
+	constructor() {
+		super({
+			id: OPEN_PREVIOUS_SESSION_COMMAND_ID,
+			title: localize2('openPreviousAgentSession', "Open Previous Agent Session"),
+			f1: true,
+			category: SessionsCategories.Sessions,
+			precondition: IsSessionsWindowContext,
+			keybinding: {
+				weight: KeybindingWeight.WorkbenchContrib + 1,
+				primary: KeyMod.CtrlCmd | KeyCode.PageUp,
+				mac: {
+					primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.LeftArrow,
+					secondary: [KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.BracketLeft]
+				},
+				when: sessionsWindowWithoutModalEditor,
+			},
+		});
+	}
+
+	override run(accessor: ServicesAccessor): Promise<void> {
+		return openRelativeSession(accessor, false);
+	}
+});
+
+KeybindingsRegistry.registerKeybindingRule({
+	id: NAVIGATE_MODAL_EDITOR_NEXT_COMMAND_ID,
+	weight: KeybindingWeight.WorkbenchContrib + 20,
+	primary: KeyMod.CtrlCmd | KeyCode.PageDown,
+	mac: {
+		primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.RightArrow,
+		secondary: [KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.BracketRight]
+	},
+	when: sessionsWindowModalEditorNavigation,
+});
+
+KeybindingsRegistry.registerKeybindingRule({
+	id: NAVIGATE_MODAL_EDITOR_PREVIOUS_COMMAND_ID,
+	weight: KeybindingWeight.WorkbenchContrib + 20,
+	primary: KeyMod.CtrlCmd | KeyCode.PageUp,
+	mac: {
+		primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.LeftArrow,
+		secondary: [KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.BracketLeft]
+	},
+	when: sessionsWindowModalEditorNavigation,
 });
 
 // Ctrl/Cmd+1..8 open the Nth session, Ctrl/Cmd+9 opens the last session

--- a/src/vs/sessions/contrib/sessions/test/browser/sessionsList.test.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/sessionsList.test.ts
@@ -9,7 +9,7 @@ import { observableValue } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { IChat, ISession, SessionStatus } from '../../../../services/sessions/common/session.js';
-import { groupByWorkspace, groupSessionsForList, sortSessions, SessionsGrouping, SessionsSorting } from '../../browser/views/sessionsList.js';
+import { getRelativeVisibleSession, groupByWorkspace, groupSessionsForList, sortSessions, SessionsGrouping, SessionsSorting } from '../../browser/views/sessionsList.js';
 
 function createSession(id: string, opts: {
 	workspaceLabel?: string;
@@ -153,6 +153,39 @@ suite('Sessions - SessionsList Helpers', () => {
 			const sorted = sortSessions(sessions, SessionsSorting.Updated);
 
 			assert.deepStrictEqual(sorted.map(s => s.sessionId), ['b', 'c', 'a']);
+		});
+	});
+
+	suite('getRelativeVisibleSession', () => {
+
+		test('returns adjacent sessions and wraps around the visible list', () => {
+			const sessions = [
+				createSession('first', {}),
+				createSession('second', {}),
+				createSession('third', {}),
+			];
+
+			assert.deepStrictEqual([
+				getRelativeVisibleSession(sessions, sessions[0], true)?.sessionId,
+				getRelativeVisibleSession(sessions, sessions[1], false)?.sessionId,
+				getRelativeVisibleSession(sessions, sessions[2], true)?.sessionId,
+				getRelativeVisibleSession(sessions, sessions[0], false)?.sessionId,
+			], ['second', 'first', 'first', 'third']);
+		});
+
+		test('uses the list ends when there is no active visible session', () => {
+			const sessions = [
+				createSession('first', {}),
+				createSession('second', {}),
+			];
+
+			assert.deepStrictEqual([
+				getRelativeVisibleSession(sessions, undefined, true)?.sessionId,
+				getRelativeVisibleSession(sessions, undefined, false)?.sessionId,
+				getRelativeVisibleSession(sessions, createSession('missing', {}), true)?.sessionId,
+				getRelativeVisibleSession(sessions, createSession('missing', {}), false)?.sessionId,
+				getRelativeVisibleSession([], undefined, true)?.sessionId,
+			], ['first', 'second', 'first', 'second', undefined]);
 		});
 	});
 


### PR DESCRIPTION
## Summary
- Add next/previous agent session commands using editor-style keybindings in the Agents window.
- Route those same keybindings to existing modal editor item navigation while reviewing files in the modal.
- Document the context-sensitive keybindings in Agents chat accessibility help and cover visible-session navigation with tests.

## Validation
- npm run compile-check-ts-native
- node --experimental-strip-types build/hygiene.ts src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts src/vs/sessions/contrib/chat/browser/sessionsChatAccessibilityHelp.ts src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts src/vs/sessions/contrib/sessions/test/browser/sessionsList.test.ts
- npm run valid-layers-check
- ./scripts/test.sh --run src/vs/sessions/contrib/sessions/test/browser/sessionsList.test.ts

(Written by Copilot)