### PR TITLE
agentHost: use URI helpers for subagent sessions

### DIFF
--- a/src/vs/platform/agentHost/common/state/sessionState.ts
+++ b/src/vs/platform/agentHost/common/state/sessionState.ts
@@ -11,6 +11,7 @@
 // helpers and re-exports.
 
 import { hasKey } from '../../../../base/common/types.js';
+import { URI as ResourceURI } from '../../../../base/common/uri.js';
 import {
 	SessionLifecycle,
 	ToolResultContentType,
@@ -26,6 +27,7 @@ import {
 	type ToolResultContent,
 	type ToolResultSubagentContent,
 	type ToolResultTextContent,
+	type URI as ProtocolURI,
 	type UserMessage,
 	TerminalState,
 } from './protocol/state.js';
@@ -193,40 +195,58 @@ export function getToolSubagentContent(result: { content?: readonly ToolResultCo
 
 // ---- Subagent URI helpers ---------------------------------------------------
 
+const SUBAGENT_URI_SEGMENT = 'subagent';
+const SUBAGENT_URI_MARKER = `/${SUBAGENT_URI_SEGMENT}/`;
+const SUBAGENT_URI_PATH_REGEX = /^(?<parentPath>.+)\/subagent\/(?<toolCallId>.+)$/;
+
+function asResourceUri(uri: ProtocolURI | ResourceURI): ResourceURI {
+	return typeof uri === 'string' ? ResourceURI.parse(uri) : uri;
+}
+
+function getSubagentBasePath(parentSession: ProtocolURI | ResourceURI): { parent: ResourceURI; path: string } {
+	const parent = asResourceUri(parentSession);
+	const parentPath = parent.path.endsWith('/') ? parent.path.slice(0, -1) : parent.path;
+	return { parent, path: `${parentPath}${SUBAGENT_URI_MARKER}` };
+}
+
 /**
  * Builds a subagent session URI from a parent session URI and tool call ID.
  * Convention: `{parentSessionUri}/subagent/{toolCallId}`
  */
-export function buildSubagentSessionUri(parentSession: string, toolCallId: string): string {
-	// Normalize: strip trailing slash from parent to avoid double-slash in URI
-	const parent = parentSession.endsWith('/') ? parentSession.slice(0, -1) : parentSession;
-	return `${parent}/subagent/${toolCallId}`;
+export function buildSubagentSessionUri(parentSession: ProtocolURI | ResourceURI, toolCallId: string): string {
+	const { parent, path } = getSubagentBasePath(parentSession);
+	return parent.with({ path: `${path}${toolCallId}` }).toString();
 }
 
 /**
  * Parses a subagent session URI into its parent session URI and tool call ID.
  * Returns `undefined` if the URI does not follow the subagent convention.
  */
-export function parseSubagentSessionUri(uri: string): { parentSession: string; toolCallId: string } | undefined {
-	const idx = uri.lastIndexOf('/subagent/');
-	if (idx < 0) {
-		return undefined;
-	}
-	const toolCallId = uri.substring(idx + '/subagent/'.length);
-	if (!toolCallId) {
+export function parseSubagentSessionUri(uri: ProtocolURI | ResourceURI): { parentSession: ResourceURI; toolCallId: string } | undefined {
+	const resource = asResourceUri(uri);
+	const match = SUBAGENT_URI_PATH_REGEX.exec(resource.path);
+	if (!match?.groups) {
 		return undefined;
 	}
 	return {
-		parentSession: uri.substring(0, idx),
-		toolCallId,
+		parentSession: resource.with({ path: match.groups.parentPath }),
+		toolCallId: match.groups.toolCallId,
 	};
 }
 
 /**
  * Returns whether a session URI represents a subagent session.
  */
-export function isSubagentSession(uri: string): boolean {
-	return uri.includes('/subagent/');
+export function isSubagentSession(uri: ProtocolURI | ResourceURI): boolean {
+	return parseSubagentSessionUri(uri) !== undefined;
+}
+
+/**
+ * Builds the string prefix used by the state manager for cached subagent sessions.
+ */
+export function buildSubagentSessionUriPrefix(parentSession: ProtocolURI | ResourceURI): string {
+	const { parent, path } = getSubagentBasePath(parentSession);
+	return parent.with({ path }).toString();
 }
 
 // ---- Factory helpers --------------------------------------------------------

--- a/src/vs/platform/agentHost/node/agentConfigurationService.ts
+++ b/src/vs/platform/agentHost/node/agentConfigurationService.ts
@@ -168,7 +168,7 @@ export class AgentConfigurationService extends Disposable implements IAgentConfi
 		}
 		const parentInfo = parseSubagentSessionUri(session);
 		if (parentInfo) {
-			return this._stateManager.getSessionState(parentInfo.parentSession)?.summary.workingDirectory;
+			return this._stateManager.getSessionState(parentInfo.parentSession.toString())?.summary.workingDirectory;
 		}
 		return undefined;
 	}
@@ -247,7 +247,7 @@ export class AgentConfigurationService extends Disposable implements IAgentConfi
 		}
 		const parentInfo = parseSubagentSessionUri(session);
 		if (parentInfo) {
-			const parent = this._stateManager.getSessionState(parentInfo.parentSession)?.config?.values;
+			const parent = this._stateManager.getSessionState(parentInfo.parentSession.toString())?.config?.values;
 			if (parent) {
 				yield parent;
 			}

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -11,6 +11,7 @@ import { Disposable, DisposableResourceMap, DisposableStore, IDisposable } from 
 import { ResourceMap } from '../../../base/common/map.js';
 import { equals as objectEquals } from '../../../base/common/objects.js';
 import { observableValue } from '../../../base/common/observable.js';
+import { isEqual } from '../../../base/common/resources.js';
 import { URI } from '../../../base/common/uri.js';
 import { generateUuid } from '../../../base/common/uuid.js';
 import { FileSystemProviderErrorCode, IFileService, toFileSystemProviderErrorCode } from '../../files/common/files.js';
@@ -22,7 +23,7 @@ import { ISessionDataService } from '../common/sessionDataService.js';
 import { ActionType, ActionEnvelope, INotification, type IRootConfigChangedAction, type SessionAction, type TerminalAction } from '../common/state/sessionActions.js';
 import type { CreateTerminalParams, ResolveSessionConfigResult, SessionConfigCompletionsResult } from '../common/state/protocol/commands.js';
 import { AhpErrorCodes, AHP_SESSION_NOT_FOUND, ContentEncoding, JSON_RPC_INTERNAL_ERROR, ProtocolError, type DirectoryEntry, type ResourceCopyParams, type ResourceCopyResult, type ResourceDeleteParams, type ResourceDeleteResult, type ResourceListResult, type ResourceMoveParams, type ResourceMoveResult, type ResourceReadResult, type ResourceWriteParams, type ResourceWriteResult, type IStateSnapshot } from '../common/state/sessionProtocol.js';
-import { ResponsePartKind, SessionStatus, ToolCallStatus, ToolResultContentType, parseSubagentSessionUri, readSessionGitState, withSessionGitState, type SessionConfigState, type ISessionFileDiff, type SessionSummary, type ToolResultSubagentContent, type Turn } from '../common/state/sessionState.js';
+import { ResponsePartKind, SessionStatus, ToolCallStatus, ToolResultContentType, buildSubagentSessionUriPrefix, parseSubagentSessionUri, readSessionGitState, withSessionGitState, type SessionConfigState, type ISessionFileDiff, type SessionSummary, type ToolResultSubagentContent, type Turn } from '../common/state/sessionState.js';
 import { IProductService } from '../../product/common/productService.js';
 import { AgentConfigurationService, IAgentConfigurationService } from './agentConfigurationService.js';
 import { AgentSideEffects } from './agentSideEffects.js';
@@ -545,7 +546,7 @@ export class AgentService extends Disposable implements IAgentService {
 			let snapshot = this._stateManager.getSnapshot(resourceStr);
 			if (!snapshot) {
 				// Try subagent restore before regular session restore
-				const parsed = parseSubagentSessionUri(resourceStr);
+				const parsed = parseSubagentSessionUri(resource);
 				if (parsed) {
 					await this._restoreSubagentSession(resourceStr, parsed.parentSession, parsed.toolCallId);
 				} else {
@@ -628,12 +629,12 @@ export class AgentService extends Disposable implements IAgentService {
 	 * so callers can skip alternative cleanup paths.
 	 */
 	private _maybeScheduleSessionGc(resource: URI): boolean {
-		const key = resource.toString();
 		// Subagent URIs are backed by the parent session; the parent's GC is
 		// scheduled when its own subscriber count reaches zero.
-		if (parseSubagentSessionUri(key)) {
+		if (parseSubagentSessionUri(resource)) {
 			return false;
 		}
+		const key = resource.toString();
 		const state = this._stateManager.getSessionState(key);
 		if (!state) {
 			return false;
@@ -688,41 +689,51 @@ export class AgentService extends Disposable implements IAgentService {
 		if (this._resourceSubscribers.has(resource)) {
 			return;
 		}
-		const parsed = parseSubagentSessionUri(key);
-		let evictionTarget: string;
+		const parsed = parseSubagentSessionUri(resource);
+		let evictionTarget: URI;
 		if (parsed) {
 			evictionTarget = parsed.parentSession;
-			if (this._resourceSubscribers.has(URI.parse(evictionTarget))) {
+			if (this._resourceSubscribers.has(evictionTarget)) {
 				return;
 			}
-			const parentPrefix = parsed.parentSession + '/subagent/';
 			for (const subscribedUri of this._resourceSubscribers.keys()) {
-				if (subscribedUri.toString().startsWith(parentPrefix)) {
+				if (this._isSubagentDescendantOf(subscribedUri, evictionTarget)) {
 					return;
 				}
 			}
 		} else {
-			evictionTarget = key;
-			const subagentPrefix = key + '/subagent/';
+			evictionTarget = resource;
 			for (const subscribedUri of this._resourceSubscribers.keys()) {
-				if (subscribedUri.toString().startsWith(subagentPrefix)) {
+				if (this._isSubagentDescendantOf(subscribedUri, evictionTarget)) {
 					return;
 				}
 			}
 		}
-		const targetState = this._stateManager.getSessionState(evictionTarget);
+		const evictionTargetKey = evictionTarget.toString();
+		const targetState = this._stateManager.getSessionState(evictionTargetKey);
 		if (!targetState || targetState.activeTurn !== undefined) {
 			return;
 		}
-		this._logService.trace(`[AgentService] Evicting idle session: ${evictionTarget} (triggered by unsubscribe of ${key})`);
+		this._logService.trace(`[AgentService] Evicting idle session: ${evictionTargetKey} (triggered by unsubscribe of ${key})`);
 		// Also evict any sibling subagent entries cached under the parent: their
 		// authoritative state is the parent's turn tree, and dropping the parent
 		// would leave them orphaned.
-		const subagentPrefix = evictionTarget + '/subagent/';
+		const subagentPrefix = buildSubagentSessionUriPrefix(evictionTarget);
 		for (const cachedKey of this._stateManager.getSessionUrisWithPrefix(subagentPrefix)) {
 			this._stateManager.removeSession(cachedKey);
 		}
-		this._stateManager.removeSession(evictionTarget);
+		this._stateManager.removeSession(evictionTargetKey);
+	}
+
+	private _isSubagentDescendantOf(resource: URI, parent: URI): boolean {
+		let parsed = parseSubagentSessionUri(resource);
+		while (parsed) {
+			if (isEqual(parsed.parentSession, parent)) {
+				return true;
+			}
+			parsed = parseSubagentSessionUri(parsed.parentSession);
+		}
+		return false;
 	}
 
 	dispatchAction(action: SessionAction | TerminalAction | IRootConfigChangedAction, clientId: string, clientSeq: number): void {
@@ -1087,19 +1098,19 @@ export class AgentService extends Disposable implements IAgentService {
 	 * the subagent (by `parentToolCallId`), and builds the child session's
 	 * turns from those events.
 	 */
-	private async _restoreSubagentSession(subagentUri: string, parentSession: string, toolCallId: string): Promise<void> {
+	private async _restoreSubagentSession(subagentUri: string, parentSession: URI, toolCallId: string): Promise<void> {
 		// Ensure the parent session is loaded first
-		const parentUri = URI.parse(parentSession);
-		if (!this._stateManager.getSessionState(parentSession)) {
+		const parentSessionKey = parentSession.toString();
+		if (!this._stateManager.getSessionState(parentSessionKey)) {
 			try {
-				await this.restoreSession(parentUri);
+				await this.restoreSession(parentSession);
 			} catch {
-				this._logService.warn(`[AgentService] Cannot restore parent session for subagent: ${parentSession}`);
+				this._logService.warn(`[AgentService] Cannot restore parent session for subagent: ${parentSessionKey}`);
 				return;
 			}
 		}
 
-		const parentState = this._stateManager.getSessionState(parentSession);
+		const parentState = this._stateManager.getSessionState(parentSessionKey);
 		if (!parentState) {
 			return;
 		}
@@ -1138,7 +1149,7 @@ export class AgentService extends Disposable implements IAgentService {
 		// Load the subagent's turns from the agent (which knows how to
 		// extract them from the parent session's event log).
 		let childTurns: readonly Turn[] = [];
-		const agent = this._findProviderForSession(parentUri);
+		const agent = this._findProviderForSession(parentSession);
 		if (agent) {
 			try {
 				childTurns = await agent.getSessionMessages(URI.parse(subagentUri));

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -689,24 +689,22 @@ export class AgentService extends Disposable implements IAgentService {
 		if (this._resourceSubscribers.has(resource)) {
 			return;
 		}
-		const parsed = parseSubagentSessionUri(resource);
-		let evictionTarget: URI;
-		if (parsed) {
-			evictionTarget = parsed.parentSession;
-			if (this._resourceSubscribers.has(evictionTarget)) {
+		// Walk up the subagent ancestry: the SDK session and its turn tree are
+		// owned by the root session, so eviction must target the root.
+		let evictionTarget = resource;
+		{
+			let parsed;
+			while ((parsed = parseSubagentSessionUri(evictionTarget))) {
+				evictionTarget = parsed.parentSession;
+			}
+		}
+		// Don't evict if the root or any of its subagent descendants still has subscribers.
+		if (this._resourceSubscribers.has(evictionTarget)) {
+			return;
+		}
+		for (const subscribedUri of this._resourceSubscribers.keys()) {
+			if (this._isSubagentDescendantOf(subscribedUri, evictionTarget)) {
 				return;
-			}
-			for (const subscribedUri of this._resourceSubscribers.keys()) {
-				if (this._isSubagentDescendantOf(subscribedUri, evictionTarget)) {
-					return;
-				}
-			}
-		} else {
-			evictionTarget = resource;
-			for (const subscribedUri of this._resourceSubscribers.keys()) {
-				if (this._isSubagentDescendantOf(subscribedUri, evictionTarget)) {
-					return;
-				}
 			}
 		}
 		const evictionTargetKey = evictionTarget.toString();

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -932,7 +932,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 	}
 
 	onClientToolCallComplete(session: URI, toolCallId: string, result: ToolCallResult): void {
-		const sessionId = AgentSession.id(parseSubagentSessionUri(session.toString())?.parentSession || session);
+		const sessionId = AgentSession.id(parseSubagentSessionUri(session)?.parentSession ?? session);
 		const entry = this._sessions.get(sessionId);
 		entry?.handleClientToolCallComplete(toolCallId, result);
 	}
@@ -1050,10 +1050,9 @@ export class CopilotAgent extends Disposable implements IAgent {
 	async getSessionMessages(session: URI): Promise<readonly Turn[]> {
 		// If the URI describes a subagent child session (`<parent>/subagent/<toolCallId>`),
 		// load the parent's events once and extract the child's filtered turns.
-		const subagentInfo = parseSubagentSessionUri(session.toString());
+		const subagentInfo = parseSubagentSessionUri(session);
 		if (subagentInfo) {
-			const parentUri = URI.parse(subagentInfo.parentSession);
-			const parentSessionId = AgentSession.id(parentUri);
+			const parentSessionId = AgentSession.id(subagentInfo.parentSession);
 			const parentEntry = this._sessions.get(parentSessionId) ?? await this._resumeSession(parentSessionId).catch(err => {
 				this._logService.warn(`[Copilot:${parentSessionId}] Failed to resume parent for subagent restore`, err);
 				return undefined;

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -932,7 +932,14 @@ export class CopilotAgent extends Disposable implements IAgent {
 	}
 
 	onClientToolCallComplete(session: URI, toolCallId: string, result: ToolCallResult): void {
-		const sessionId = AgentSession.id(parseSubagentSessionUri(session)?.parentSession ?? session);
+		// Walk up the subagent chain to reach the root SDK session entry;
+		// _sessions is keyed by root session IDs only.
+		let target = session;
+		let parsed;
+		while ((parsed = parseSubagentSessionUri(target))) {
+			target = parsed.parentSession;
+		}
+		const sessionId = AgentSession.id(target);
 		const entry = this._sessions.get(sessionId);
 		entry?.handleClientToolCallComplete(toolCallId, result);
 	}
@@ -1052,9 +1059,16 @@ export class CopilotAgent extends Disposable implements IAgent {
 		// load the parent's events once and extract the child's filtered turns.
 		const subagentInfo = parseSubagentSessionUri(session);
 		if (subagentInfo) {
-			const parentSessionId = AgentSession.id(subagentInfo.parentSession);
-			const parentEntry = this._sessions.get(parentSessionId) ?? await this._resumeSession(parentSessionId).catch(err => {
-				this._logService.warn(`[Copilot:${parentSessionId}] Failed to resume parent for subagent restore`, err);
+			// Walk up the subagent chain to find the root SDK session entry;
+			// _sessions is keyed by root session IDs only.
+			let rootSession = subagentInfo.parentSession;
+			let parentParsed;
+			while ((parentParsed = parseSubagentSessionUri(rootSession))) {
+				rootSession = parentParsed.parentSession;
+			}
+			const rootSessionId = AgentSession.id(rootSession);
+			const parentEntry = this._sessions.get(rootSessionId) ?? await this._resumeSession(rootSessionId).catch(err => {
+				this._logService.warn(`[Copilot:${rootSessionId}] Failed to resume root for subagent restore`, err);
 				return undefined;
 			});
 			if (!parentEntry) {

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -177,6 +177,7 @@ export class CopilotAgentSession extends Disposable {
 
 	/** Tracks active tool invocations so we can produce past-tense messages on completion. */
 	private readonly _activeToolCalls = new Map<string, { toolName: string; displayName: string; parameters: Record<string, unknown> | undefined; content: ToolResultContent[]; parentToolCallId: string | undefined }>();
+	private readonly _parentToolCallIdsByAgentId = new Map<string, string>();
 	/** Pending permission requests awaiting a renderer-side decision. */
 	private readonly _pendingPermissions = new Map<string, DeferredPromise<boolean>>();
 	/** Pending user input requests awaiting a renderer-side answer. */
@@ -224,14 +225,14 @@ export class CopilotAgentSession extends Disposable {
 	private readonly _customizationDirectory: URI | undefined;
 
 	/**
-	 * Current markdown response part ID for the active turn. Streaming text
-	 * deltas append to this part; the first delta of a turn allocates a new
-	 * part ID. Reset on each new turn (in {@link send}) and invalidated when
-	 * a tool call begins so subsequent text creates a fresh part.
+	 * Current markdown response part IDs for the active turn, keyed by
+	 * `parentToolCallId ?? ''`. Parent and subagent text stream through the
+	 * same SDK session but land in different AHP sessions, so their markdown
+	 * part state must not mask or append to each other.
 	 */
-	private _currentMarkdownPartId: string | undefined;
-	/** Current reasoning response part ID for the active turn. Reset on each new turn. */
-	private _currentReasoningPartId: string | undefined;
+	private readonly _currentMarkdownPartIds = new Map<string, string>();
+	/** Current reasoning response part IDs for the active turn, keyed by `parentToolCallId ?? ''`. */
+	private readonly _currentReasoningPartIds = new Map<string, string>();
 	/** Tracks whether a non-empty activity has been published, so we only emit a clear when needed. */
 	private _hasReportedActivity = false;
 
@@ -310,6 +311,19 @@ export class CopilotAgentSession extends Disposable {
 		});
 	}
 
+	private _parentToolCallIdForSubagentEvent(e: { readonly agentId?: string }): string | undefined {
+		return e.agentId ? this._parentToolCallIdsByAgentId.get(e.agentId) : undefined;
+	}
+
+	private _shouldDropUnmappedSubagentEvent(e: { readonly agentId?: string }, eventName: string): boolean {
+		const parentToolCallId = this._parentToolCallIdForSubagentEvent(e);
+		if (!parentToolCallId && e.agentId) {
+			this._logService.warn(`[Copilot:${this.sessionId}] Dropping ${eventName} for unknown subagent agentId=${e.agentId}`);
+			return true;
+		}
+		return false;
+	}
+
 	/**
 	 * Resets per-turn streaming state so the next text/reasoning chunk
 	 * allocates a fresh response part. Called by the agent when a new turn
@@ -317,8 +331,9 @@ export class CopilotAgentSession extends Disposable {
 	 */
 	resetTurnState(turnId: string): void {
 		this._turnId = turnId;
-		this._currentMarkdownPartId = undefined;
-		this._currentReasoningPartId = undefined;
+		this._currentMarkdownPartIds.clear();
+		this._currentReasoningPartIds.clear();
+		this._parentToolCallIdsByAgentId.clear();
 	}
 
 	/**
@@ -338,10 +353,11 @@ export class CopilotAgentSession extends Disposable {
 	 */
 	private _emitMarkdownDelta(content: string, parentToolCallId?: string): void {
 		const session = this._protocolSession();
-		let partId = this._currentMarkdownPartId;
+		const markdownScope = parentToolCallId ?? '';
+		let partId = this._currentMarkdownPartIds.get(markdownScope);
 		if (!partId) {
 			partId = generateUuid();
-			this._currentMarkdownPartId = partId;
+			this._currentMarkdownPartIds.set(markdownScope, partId);
 			this._emitAction({
 				type: ActionType.SessionResponsePart,
 				session,
@@ -360,18 +376,19 @@ export class CopilotAgentSession extends Disposable {
 	}
 
 	/** Emits a reasoning delta, similar to {@link _emitMarkdownDelta} but for reasoning parts. */
-	private _emitReasoningDelta(content: string): void {
+	private _emitReasoningDelta(content: string, parentToolCallId?: string): void {
 		const session = this._protocolSession();
-		let partId = this._currentReasoningPartId;
+		const reasoningScope = parentToolCallId ?? '';
+		let partId = this._currentReasoningPartIds.get(reasoningScope);
 		if (!partId) {
 			partId = generateUuid();
-			this._currentReasoningPartId = partId;
+			this._currentReasoningPartIds.set(reasoningScope, partId);
 			this._emitAction({
 				type: ActionType.SessionResponsePart,
 				session,
 				turnId: this._turnId,
 				part: { kind: ResponsePartKind.Reasoning, id: partId, content },
-			});
+			}, parentToolCallId);
 			return;
 		}
 		this._emitAction({
@@ -380,7 +397,7 @@ export class CopilotAgentSession extends Disposable {
 			turnId: this._turnId,
 			partId,
 			content,
-		});
+		}, parentToolCallId);
 	}
 
 	/**
@@ -1004,7 +1021,10 @@ export class CopilotAgentSession extends Disposable {
 
 		this._register(wrapper.onMessageDelta(e => {
 			this._logService.trace(`[Copilot:${sessionId}] delta: ${e.data.deltaContent}`);
-			this._emitMarkdownDelta(e.data.deltaContent, e.data.parentToolCallId);
+			if (this._shouldDropUnmappedSubagentEvent(e, 'assistant.message_delta')) {
+				return;
+			}
+			this._emitMarkdownDelta(e.data.deltaContent, this._parentToolCallIdForSubagentEvent(e));
 		}));
 
 		this._register(wrapper.onMessage(e => {
@@ -1021,17 +1041,22 @@ export class CopilotAgentSession extends Disposable {
 			if (!e.data.content) {
 				return;
 			}
-			if (this._currentMarkdownPartId) {
+			if (this._shouldDropUnmappedSubagentEvent(e, 'assistant.message')) {
+				return;
+			}
+			const parentToolCallId = this._parentToolCallIdForSubagentEvent(e);
+			const markdownScope = parentToolCallId ?? '';
+			if (this._currentMarkdownPartIds.has(markdownScope)) {
 				return;
 			}
 			const partId = generateUuid();
-			this._currentMarkdownPartId = partId;
+			this._currentMarkdownPartIds.set(markdownScope, partId);
 			this._emitAction({
 				type: ActionType.SessionResponsePart,
 				session: this._protocolSession(),
 				turnId: this._turnId,
 				part: { kind: ResponsePartKind.Markdown, id: partId, content: e.data.content },
-			}, e.data.parentToolCallId);
+			}, parentToolCallId);
 		}));
 
 		this._register(wrapper.onToolStart(e => {
@@ -1067,19 +1092,22 @@ export class CopilotAgentSession extends Disposable {
 				toolArgs = tryStringify(parameters);
 			}
 			const displayName = getToolDisplayName(e.data.toolName);
-			this._activeToolCalls.set(e.data.toolCallId, { toolName: e.data.toolName, displayName, parameters, content: [], parentToolCallId: e.data.parentToolCallId });
+			if (this._shouldDropUnmappedSubagentEvent(e, 'tool.execution_start')) {
+				return;
+			}
+			const parentToolCallId = this._parentToolCallIdForSubagentEvent(e);
+			this._activeToolCalls.set(e.data.toolCallId, { toolName: e.data.toolName, displayName, parameters, content: [], parentToolCallId });
 			const toolKind = getToolKind(e.data.toolName);
 			const subagentMeta = toolKind === 'subagent' ? getSubagentMetadata(parameters) : undefined;
 			const toolClientId = this._clientToolNames.has(e.data.toolName) ? this._appliedSnapshot.clientId : undefined;
-			const parentToolCallId = e.data.parentToolCallId;
 
 			// A new tool call invalidates the current markdown and reasoning
 			// parts so the next text/reasoning delta after the tool call
 			// starts a fresh part. Without invalidating reasoning here, a
 			// later round of reasoning (after tool_start/tool_complete)
 			// would silently append to the pre-tool-call reasoning block.
-			this._currentMarkdownPartId = undefined;
-			this._currentReasoningPartId = undefined;
+			this._currentMarkdownPartIds.delete(parentToolCallId ?? '');
+			this._currentReasoningPartIds.delete(parentToolCallId ?? '');
 
 			const meta: Record<string, unknown> = { toolKind, language: toolKind === 'terminal' ? getShellLanguage(e.data.toolName) : undefined };
 			if (subagentMeta?.description) {
@@ -1133,6 +1161,11 @@ export class CopilotAgentSession extends Disposable {
 			if (!tracked) {
 				return;
 			}
+			const parentToolCallId = tracked.parentToolCallId ?? this._parentToolCallIdForSubagentEvent(e);
+			if (!parentToolCallId && e.agentId) {
+				this._logService.warn(`[Copilot:${this.sessionId}] Dropping tool.execution_complete for unknown subagent agentId=${e.agentId}`);
+				return;
+			}
 			this._logService.info(`[Copilot:${sessionId}] Tool completed: ${e.data.toolCallId}`);
 			this._activeToolCalls.delete(e.data.toolCallId);
 			const displayName = tracked.displayName;
@@ -1179,7 +1212,7 @@ export class CopilotAgentSession extends Disposable {
 					content: content.length > 0 ? content : undefined,
 					error: e.data.error,
 				},
-			}, e.data.parentToolCallId);
+			}, parentToolCallId);
 		}));
 
 		this._register(wrapper.onIdle(() => {
@@ -1239,6 +1272,9 @@ export class CopilotAgentSession extends Disposable {
 		}));
 
 		this._register(wrapper.onSubagentStarted(e => {
+			if (e.agentId) {
+				this._parentToolCallIdsByAgentId.set(e.agentId, e.data.toolCallId);
+			}
 			this._logService.info(`[Copilot:${sessionId}] Subagent started: toolCallId=${e.data.toolCallId}, agent=${e.data.agentName}`);
 			this._onDidSessionProgress.fire({
 				kind: 'subagent_started',
@@ -1281,7 +1317,10 @@ export class CopilotAgentSession extends Disposable {
 
 		this._register(wrapper.onReasoningDelta(e => {
 			this._logService.trace(`[Copilot:${sessionId}] Reasoning delta: ${e.data.deltaContent.length} chars`);
-			this._emitReasoningDelta(e.data.deltaContent);
+			if (this._shouldDropUnmappedSubagentEvent(e, 'assistant.reasoning_delta')) {
+				return;
+			}
+			this._emitReasoningDelta(e.data.deltaContent, this._parentToolCallIdForSubagentEvent(e));
 		}));
 
 		// Sync the AHP session config when the SDK's `currentMode` changes
@@ -1521,10 +1560,16 @@ export class CopilotAgentSession extends Disposable {
 		}));
 
 		this._register(wrapper.onSubagentCompleted(e => {
+			if (e.agentId) {
+				this._parentToolCallIdsByAgentId.delete(e.agentId);
+			}
 			this._logService.trace(`[Copilot:${sessionId}] Subagent completed: ${e.data.agentName}`);
 		}));
 
 		this._register(wrapper.onSubagentFailed(e => {
+			if (e.agentId) {
+				this._parentToolCallIdsByAgentId.delete(e.agentId);
+			}
 			this._logService.error(`[Copilot:${sessionId}] Subagent failed: ${e.data.agentName} - ${e.data.error}`);
 		}));
 

--- a/src/vs/platform/agentHost/test/node/agentHostStateManager.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostStateManager.test.ts
@@ -10,7 +10,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/c
 import { runWithFakedTimers } from '../../../../base/test/common/timeTravelScheduler.js';
 import { NullLogService } from '../../../log/common/log.js';
 import { ActionType, NotificationType, type ActionEnvelope, type INotification } from '../../common/state/sessionActions.js';
-import { SessionSummary, ResponsePartKind, ROOT_STATE_URI, SessionLifecycle, SessionStatus, TurnState, buildSubagentSessionUri, isSubagentSession, parseSubagentSessionUri, type MarkdownResponsePart, type SessionState } from '../../common/state/sessionState.js';
+import { SessionSummary, ResponsePartKind, ROOT_STATE_URI, SessionLifecycle, SessionStatus, TurnState, buildSubagentSessionUri, buildSubagentSessionUriPrefix, isSubagentSession, parseSubagentSessionUri, type MarkdownResponsePart, type SessionState } from '../../common/state/sessionState.js';
 import { type SessionSummaryChangedNotification } from '../../common/state/protocol/notifications.js';
 import { AgentHostStateManager } from '../../node/agentHostStateManager.js';
 
@@ -395,11 +395,32 @@ suite('Subagent URI helpers', () => {
 		);
 	});
 
+	test('buildSubagentSessionUri preserves parent URI path shape', () => {
+		assert.strictEqual(
+			buildSubagentSessionUri('copilot:/session-1//nested/../kept', 'tc-1'),
+			'copilot:/session-1//nested/../kept/subagent/tc-1',
+		);
+	});
+
 	test('parseSubagentSessionUri extracts parent and toolCallId', () => {
 		const parsed = parseSubagentSessionUri('copilot:/session-1/subagent/tc-1');
-		assert.deepStrictEqual(parsed, {
+		assert.deepStrictEqual(parsed && {
+			parentSession: parsed.parentSession.toString(),
+			toolCallId: parsed.toolCallId,
+		}, {
 			parentSession: 'copilot:/session-1',
 			toolCallId: 'tc-1',
+		});
+	});
+
+	test('parseSubagentSessionUri handles nested subagent URIs', () => {
+		const parsed = parseSubagentSessionUri('copilot:/session-1/subagent/tc-1/subagent/tc-2');
+		assert.deepStrictEqual(parsed && {
+			parentSession: parsed.parentSession.toString(),
+			toolCallId: parsed.toolCallId,
+		}, {
+			parentSession: 'copilot:/session-1/subagent/tc-1',
+			toolCallId: 'tc-2',
 		});
 	});
 
@@ -410,5 +431,19 @@ suite('Subagent URI helpers', () => {
 	test('isSubagentSession identifies subagent URIs', () => {
 		assert.strictEqual(isSubagentSession('copilot:/session-1/subagent/tc-1'), true);
 		assert.strictEqual(isSubagentSession('copilot:/session-1'), false);
+	});
+
+	test('buildSubagentSessionUriPrefix creates state manager prefix', () => {
+		assert.strictEqual(
+			buildSubagentSessionUriPrefix('copilot:/session-1'),
+			'copilot:/session-1/subagent/',
+		);
+	});
+
+	test('buildSubagentSessionUriPrefix preserves parent URI path shape', () => {
+		assert.strictEqual(
+			buildSubagentSessionUriPrefix('copilot:/session-1//nested/../kept'),
+			'copilot:/session-1//nested/../kept/subagent/',
+		);
 	});
 });

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -987,6 +987,35 @@ suite('AgentService (node dispatcher)', () => {
 			assert.strictEqual(service.stateManager.getSessionState(sessionResource.toString()), undefined, 'parent evicted after subagent drops');
 			assert.strictEqual(service.stateManager.getSessionState(childUri.toString()), undefined, 'child also evicted with parent');
 		});
+
+		test('nested subagent subscriber pins ancestor session against eviction', async () => {
+			service.registerProvider(copilotAgent);
+			const { session } = await copilotAgent.createSession();
+			const sessions = await copilotAgent.listSessions();
+			const sessionResource = sessions[0].session;
+
+			copilotAgent.sessionMessages = [
+				{ type: 'message', session, role: 'user', messageId: 'msg-1', content: 'Review', toolRequests: [] },
+				{ type: 'message', session, role: 'assistant', messageId: 'msg-2', content: '', toolRequests: [{ toolCallId: 'tc-sub', name: 'task' }] },
+				{ type: 'tool_start', session, toolCallId: 'tc-sub', toolName: 'task', displayName: 'Task', invocationMessage: 'Delegating', toolKind: 'subagent' as const, subagentDescription: 'Find files', subagentAgentName: 'explore' },
+				{ type: 'subagent_started', session, toolCallId: 'tc-sub', agentName: 'explore', agentDisplayName: 'Explore', agentDescription: 'Explores' },
+				{ type: 'tool_start', session, toolCallId: 'tc-inner', toolName: 'bash', displayName: 'Bash', invocationMessage: 'ls', parentToolCallId: 'tc-sub' },
+				{ type: 'tool_complete', session, toolCallId: 'tc-inner', result: { success: true, pastTenseMessage: 'ran', content: [{ type: ToolResultContentType.Text, text: 'a' }] }, parentToolCallId: 'tc-sub' },
+				{ type: 'tool_complete', session, toolCallId: 'tc-sub', result: { success: true, pastTenseMessage: 'done', content: [{ type: ToolResultContentType.Text, text: 'ok' }] } },
+				{ type: 'message', session, role: 'assistant', messageId: 'msg-3', content: 'Done', toolRequests: [] },
+			];
+			await service.restoreSession(sessionResource);
+			const childUri = URI.parse(buildSubagentSessionUri(sessionResource, 'tc-sub'));
+			await service.subscribe(childUri, 'client-child');
+			const nestedChildUri = URI.parse(buildSubagentSessionUri(childUri, 'tc-nested'));
+
+			service.addSubscriber(sessionResource, 'client-parent');
+			service.addSubscriber(nestedChildUri, 'client-nested-child');
+			service.unsubscribe(sessionResource, 'client-parent');
+
+			assert.ok(service.stateManager.getSessionState(sessionResource.toString()), 'ancestor parent must stay while nested child is subscribed');
+			assert.ok(service.stateManager.getSessionState(childUri.toString()), 'intermediate child still present');
+		});
 	});
 
 	// ---- empty-session GC ----------------------------------------------

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -1016,6 +1016,30 @@ suite('AgentService (node dispatcher)', () => {
 			assert.ok(service.stateManager.getSessionState(sessionResource.toString()), 'ancestor parent must stay while nested child is subscribed');
 			assert.ok(service.stateManager.getSessionState(childUri.toString()), 'intermediate child still present');
 		});
+
+		test('depth-2 subagent eviction evicts the root session state', async () => {
+			// Regression: when a depth-2 subagent URI unsubscribes the eviction
+			// must reach all the way to the root, not stop at the intermediate
+			// parent and leave root state cached indefinitely.
+			service.registerProvider(copilotAgent);
+			const { session } = await copilotAgent.createSession();
+			const sessions = await copilotAgent.listSessions();
+			const sessionResource = sessions[0].session;
+
+			copilotAgent.sessionMessages = [
+				{ type: 'message', session, role: 'user', messageId: 'msg-1', content: 'hi', toolRequests: [] },
+				{ type: 'message', session, role: 'assistant', messageId: 'msg-2', content: 'done', toolRequests: [] },
+			];
+			await service.restoreSession(sessionResource);
+
+			// Simulate a client that only subscribed to the depth-2 URI.
+			const childUri = URI.parse(buildSubagentSessionUri(sessionResource, 'tc-sub'));
+			const nestedUri = URI.parse(buildSubagentSessionUri(childUri, 'tc-nested'));
+			service.addSubscriber(nestedUri, 'client-nested');
+			service.unsubscribe(nestedUri, 'client-nested');
+
+			assert.strictEqual(service.stateManager.getSessionState(sessionResource.toString()), undefined, 'root state must be evicted when no subscribers remain');
+		});
 	});
 
 	// ---- empty-session GC ----------------------------------------------

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -666,6 +666,27 @@ suite('CopilotAgent', () => {
 			}
 		});
 
+		test('routes a nested subagent session URI (depth > 1) to the root session entry', async () => {
+			// Regression for depth > 1: a nested subagent URI like
+			// `copilot:/root/subagent/tc1/subagent/tc2` must walk all the way
+			// to the root session entry in `_sessions`, not stop at the
+			// intermediate parent `copilot:/root/subagent/tc1`.
+			const agent = createTestAgent(disposables);
+			try {
+				const rootUri = AgentSession.uri('copilotcli', 'session-root');
+				const { calls } = installStubSession(agent, AgentSession.id(rootUri));
+
+				const subagentUri = URI.parse(buildSubagentSessionUri(rootUri.toString(), 'tc-parent'));
+				const nestedUri = URI.parse(buildSubagentSessionUri(subagentUri.toString(), 'tc-nested'));
+				const result: ToolCallResult = { success: true, pastTenseMessage: 'nested done' };
+				agent.onClientToolCallComplete(nestedUri, 'tc-inner', result);
+
+				assert.deepStrictEqual(calls, [{ toolCallId: 'tc-inner', result }]);
+			} finally {
+				await disposeAgent(agent);
+			}
+		});
+
 		test('is a no-op when no session entry exists for the resolved id', async () => {
 			const agent = createTestAgent(disposables);
 			try {

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -53,8 +53,8 @@ class MockCopilotSession {
 	}
 
 	/** Push an event through to all registered handlers of the given type. */
-	fire<K extends SessionEventType>(type: K, data: SessionEventPayload<K>['data']): void {
-		const event = { type, data, id: 'evt-1', timestamp: new Date().toISOString(), parentId: null } as SessionEventPayload<K>;
+	fire<K extends SessionEventType>(type: K, data: SessionEventPayload<K>['data'], overrides?: Partial<Omit<SessionEventPayload<K>, 'type' | 'data'>>): void {
+		const event = { type, data, id: 'evt-1', timestamp: new Date().toISOString(), parentId: null, ...overrides } as SessionEventPayload<K>;
 		const set = this._handlers.get(type);
 		if (set) {
 			for (const handler of set) {
@@ -895,6 +895,56 @@ suite('CopilotAgentSession', () => {
 			assert.ok(hasPart, 'should have surfaced the message content');
 		});
 
+		test('subagent message delta does not suppress final parent assistant message', async () => {
+			const { session, mockSession, signals } = await createAgentSession(disposables);
+			session.resetTurnState('turn-1');
+
+			mockSession.fire('tool.execution_start', {
+				toolCallId: 'tc-subagent',
+				toolName: 'task',
+				arguments: { description: 'Explore tests', agent_type: 'explore' },
+			} as SessionEventPayload<'tool.execution_start'>['data']);
+
+			mockSession.fire('subagent.started', {
+				toolCallId: 'tc-subagent',
+				agentName: 'explore',
+				agentDisplayName: 'Explore',
+				agentDescription: 'Explore tests',
+			} as SessionEventPayload<'subagent.started'>['data'], { agentId: 'agent-1' });
+
+			mockSession.fire('assistant.message_delta', {
+				messageId: 'msg-child',
+				deltaContent: 'Subagent found the answer.',
+			} as SessionEventPayload<'assistant.message_delta'>['data'], { agentId: 'agent-1' });
+
+			mockSession.fire('tool.execution_complete', {
+				toolCallId: 'tc-subagent',
+				success: true,
+				result: { content: 'done' },
+			} as SessionEventPayload<'tool.execution_complete'>['data']);
+
+			mockSession.fire('assistant.message', {
+				messageId: 'msg-parent-final',
+				content: 'Final parent answer.',
+			} as SessionEventPayload<'assistant.message'>['data']);
+
+			const markdownParts = signals.flatMap(signal => {
+				if (signal.kind !== 'action' || signal.action.type !== ActionType.SessionResponsePart) {
+					return [];
+				}
+				const part = (signal.action as SessionResponsePartAction).part;
+				if (part.kind !== ResponsePartKind.Markdown) {
+					return [];
+				}
+				return [{ parentToolCallId: signal.parentToolCallId, content: part.content }];
+			});
+
+			assert.deepStrictEqual(markdownParts, [
+				{ parentToolCallId: 'tc-subagent', content: 'Subagent found the answer.' },
+				{ parentToolCallId: undefined, content: 'Final parent answer.' },
+			]);
+		});
+
 		test('reasoning delta after tool_start starts a new reasoning response part', async () => {
 			const { mockSession, signals } = await createAgentSession(disposables);
 
@@ -940,6 +990,80 @@ suite('CopilotAgentSession', () => {
 				'second reasoning round should have a distinct part id');
 			assert.strictEqual(reasoningResponseParts[0].content, 'thinking step 1');
 			assert.strictEqual(reasoningResponseParts[1].content, 'thinking step 2');
+		});
+
+		test('subagent reasoning delta routes to the subagent session scope', async () => {
+			const { session, mockSession, signals } = await createAgentSession(disposables);
+			session.resetTurnState('turn-1');
+
+			mockSession.fire('subagent.started', {
+				toolCallId: 'tc-subagent',
+				agentName: 'explore',
+				agentDisplayName: 'Explore',
+				agentDescription: 'Explore tests',
+			} as SessionEventPayload<'subagent.started'>['data'], { agentId: 'agent-1' });
+
+			mockSession.fire('assistant.reasoning_delta', {
+				reasoningId: 'reasoning-child',
+				deltaContent: 'Subagent thinking.',
+			} as SessionEventPayload<'assistant.reasoning_delta'>['data'], { agentId: 'agent-1' });
+
+			mockSession.fire('assistant.reasoning_delta', {
+				reasoningId: 'reasoning-parent',
+				deltaContent: 'Parent thinking.',
+			} as SessionEventPayload<'assistant.reasoning_delta'>['data']);
+
+			const reasoningParts = signals.flatMap(signal => {
+				if (signal.kind !== 'action' || signal.action.type !== ActionType.SessionResponsePart) {
+					return [];
+				}
+				const part = (signal.action as SessionResponsePartAction).part;
+				if (part.kind !== ResponsePartKind.Reasoning) {
+					return [];
+				}
+				return [{ parentToolCallId: signal.parentToolCallId, content: part.content }];
+			});
+
+			assert.deepStrictEqual(reasoningParts, [
+				{ parentToolCallId: 'tc-subagent', content: 'Subagent thinking.' },
+				{ parentToolCallId: undefined, content: 'Parent thinking.' },
+			]);
+		});
+
+		test('subagent tool completion routes to the subagent session scope', async () => {
+			const { session, mockSession, signals } = await createAgentSession(disposables);
+			session.resetTurnState('turn-1');
+
+			mockSession.fire('subagent.started', {
+				toolCallId: 'tc-subagent',
+				agentName: 'explore',
+				agentDisplayName: 'Explore',
+				agentDescription: 'Explore tests',
+			} as SessionEventPayload<'subagent.started'>['data'], { agentId: 'agent-1' });
+
+			mockSession.fire('tool.execution_start', {
+				toolCallId: 'tc-child-tool',
+				toolName: 'bash',
+				arguments: { command: 'echo hi' },
+			} as SessionEventPayload<'tool.execution_start'>['data'], { agentId: 'agent-1' });
+
+			mockSession.fire('tool.execution_complete', {
+				toolCallId: 'tc-child-tool',
+				success: true,
+				result: { content: 'hi' },
+			} as SessionEventPayload<'tool.execution_complete'>['data'], { agentId: 'agent-1' });
+
+			const toolCompletions = signals.flatMap(signal => {
+				if (!isAction(signal, ActionType.SessionToolCallComplete)) {
+					return [];
+				}
+				const action = signal.action as SessionToolCallCompleteAction;
+				return [{ parentToolCallId: signal.parentToolCallId, toolCallId: action.toolCallId }];
+			});
+
+			assert.deepStrictEqual(toolCompletions, [
+				{ parentToolCallId: 'tc-subagent', toolCallId: 'tc-child-tool' },
+			]);
 		});
 	});
 
@@ -1290,12 +1414,18 @@ suite('CopilotAgentSession', () => {
 			// SessionToolCallStart).
 			const { session, mockSession, signals, waitForSignal } = await createAgentSession(disposables, { clientSnapshot: snapshot });
 
+			mockSession.fire('subagent.started', {
+				toolCallId: 'tc-parent-subagent',
+				agentName: 'helper',
+				agentDisplayName: 'Helper',
+				agentDescription: 'Helps',
+			} as SessionEventPayload<'subagent.started'>['data'], { agentId: 'agent-client-tool' });
+
 			mockSession.fire('tool.execution_start', {
 				toolCallId: 'tc-sub-client',
 				toolName: 'my_tool',
 				arguments: {},
-				parentToolCallId: 'tc-parent-subagent',
-			} as SessionEventPayload<'tool.execution_start'>['data']);
+			} as SessionEventPayload<'tool.execution_start'>['data'], { agentId: 'agent-client-tool' });
 
 			const resultPromise = session.handlePermissionRequest({
 				kind: 'custom-tool',

--- a/src/vs/platform/agentHost/test/node/mockAgent.ts
+++ b/src/vs/platform/agentHost/test/node/mockAgent.ts
@@ -132,7 +132,7 @@ export class MockAgent implements IAgent {
 	}
 
 	async getSessionMessages(session: URI): Promise<readonly Turn[]> {
-		const subagentInfo = parseSubagentSessionUri(session.toString());
+		const subagentInfo = parseSubagentSessionUri(session);
 		if (subagentInfo) {
 			return buildSubagentTurnsFromHistory(this.sessionMessages, subagentInfo.toolCallId, session.toString());
 		}
@@ -682,7 +682,7 @@ export class ScriptedMockAgent implements IAgent {
 	}
 
 	async getSessionMessages(session: URI): Promise<readonly Turn[]> {
-		const subagentInfo = parseSubagentSessionUri(session.toString());
+		const subagentInfo = parseSubagentSessionUri(session);
 		if (subagentInfo) {
 			return buildSubagentTurnsFromHistory(this._preExistingMessages, subagentInfo.toolCallId, session.toString());
 		}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -40,11 +40,12 @@ import { IChatEditingService } from '../../../common/editing/chatEditingService.
 import { ChatQuestionCarouselData } from '../../../common/model/chatProgressTypes/chatQuestionCarouselData.js';
 import { ChatToolInvocation } from '../../../common/model/chatProgressTypes/chatToolInvocation.js';
 import { IChatAgentData, IChatAgentImplementation, IChatAgentRequest, IChatAgentResult, IChatAgentService } from '../../../common/participants/chatAgents.js';
+import { ILanguageModelsService } from '../../../common/languageModels.js';
 import { ILanguageModelToolsService, IToolData, IToolInvocation, IToolResult, ToolInvocationPresentation } from '../../../common/tools/languageModelToolsService.js';
 import { getAgentHostIcon } from '../agentSessions.js';
 import { AgentHostEditingSession } from './agentHostEditingSession.js';
 import { IAgentHostSessionWorkingDirectoryResolver } from './agentHostSessionWorkingDirectoryResolver.js';
-import { activeTurnToProgress, completedToolCallToEditParts, completedToolCallToSerialized, finalizeToolInvocation, getTerminalContentUri, isSubagentTool, makeAhpTerminalToolSessionId, parseAhpTerminalToolSessionId, rawMarkdownToString, stringOrMarkdownToString, toolCallStateToInvocation, turnsToHistory, updateRunningToolSpecificData, type IToolCallFileEdit } from './stateToProgressAdapter.js';
+import { activeTurnToProgress, completedToolCallToEditParts, completedToolCallToSerialized, finalizeToolInvocation, getTerminalContentUri, isSubagentTool, makeAhpTerminalToolSessionId, parseAhpTerminalToolSessionId, rawMarkdownToString, stringOrMarkdownToString, toolCallStateToInvocation, turnsToHistory, updateRunningToolSpecificData, type IToolCallFileEdit, type TurnModelLookup } from './stateToProgressAdapter.js';
 
 // =============================================================================
 // AgentHostSessionHandler - renderer-side handler for a single agent host
@@ -377,6 +378,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		@ILanguageModelToolsService private readonly _toolsService: ILanguageModelToolsService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IChatWidgetService private readonly _chatWidgetService: IChatWidgetService,
+		@ILanguageModelsService private readonly _languageModelsService: ILanguageModelsService,
 	) {
 		super();
 		this._config = config;
@@ -494,8 +496,9 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 				}
 				const sessionState = this._getSessionState(resolvedSession.toString());
 				if (sessionState) {
-					const modelId = this._toLanguageModelId(sessionResource, sessionState.summary.model?.id);
-					history.push(...turnsToHistory(resolvedSession, sessionState.turns, this._config.agentId, this._config.connectionAuthority, modelId));
+					const fallbackRawModelId = sessionState.summary.model?.id;
+					const lookup = this._createTurnModelLookup(sessionResource, fallbackRawModelId);
+					history.push(...turnsToHistory(resolvedSession, sessionState.turns, this._config.agentId, this._config.connectionAuthority, lookup));
 
 					// Enrich history with inner tool calls from subagent
 					// child sessions. Subscribes to each child session so
@@ -518,11 +521,12 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 					// progressObs for live streaming.
 					if (sessionState.activeTurn) {
 						activeTurnId = sessionState.activeTurn.id;
+						const activeRawModelId = sessionState.activeTurn.usage?.model ?? fallbackRawModelId;
 						history.push({
 							type: 'request',
 							prompt: sessionState.activeTurn.userMessage.text,
 							participant: this._config.agentId,
-							modelId,
+							modelId: lookup.toLanguageModelId(activeRawModelId),
 						});
 						history.push({
 							type: 'response',
@@ -2361,6 +2365,29 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		}
 		const prefix = `${getChatSessionType(sessionResource)}:`;
 		return rawModelId.startsWith(prefix) ? rawModelId : `${prefix}${rawModelId}`;
+	}
+
+	/**
+	 * Builds a per-turn model lookup that namespaces raw AHP model ids into
+	 * chat-layer language-model ids and resolves human-readable display
+	 * names via the registered language-model providers (so the chat UI's
+	 * per-response footer can show e.g. "Claude Opus 4.7" instead of the
+	 * raw model id). `fallbackRawModelId` is used when a turn's
+	 * `usage?.model` is not yet set (e.g. older sessions or turns that
+	 * never reported usage).
+	 */
+	private _createTurnModelLookup(sessionResource: URI, fallbackRawModelId: string | undefined): TurnModelLookup {
+		const resolveRaw = (rawModelId: string | undefined): string | undefined => rawModelId ?? fallbackRawModelId;
+		return {
+			toLanguageModelId: (rawModelId) => this._toLanguageModelId(sessionResource, resolveRaw(rawModelId)),
+			toModelDisplayName: (rawModelId) => {
+				const modelId = this._toLanguageModelId(sessionResource, resolveRaw(rawModelId));
+				if (!modelId) {
+					return undefined;
+				}
+				return this._languageModelsService.lookupLanguageModel(modelId)?.name;
+			},
+		};
 	}
 
 	private _resolveRequestedWorkingDirectory(sessionResource: URI): URI | undefined {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
@@ -95,11 +95,35 @@ export function getTerminalContentUri(content: ToolResultContent[] | undefined):
 }
 
 /**
- * Converts completed turns from the protocol state into session history items.
+ * Resolves a raw per-turn model id (as it appears on `UsageInfo.model`) into
+ * the chat layer's namespaced language-model id and a human-readable display
+ * name. Both halves are independent: the id flows onto request history items
+ * (so the input picker shows the model that ran), while the display name
+ * flows onto response history items as `details` (so the response footer
+ * shows the model that produced it).
  */
-export function turnsToHistory(backendSession: URI, turns: readonly Turn[], participantId: string, connectionAuthority: string | undefined, modelId?: string): IChatSessionHistoryItem[] {
+export interface TurnModelLookup {
+	/** Returns the chat-layer namespaced model id for a raw AHP model id. */
+	toLanguageModelId(rawModelId: string | undefined): string | undefined;
+	/** Returns the human-readable display name, or undefined if unknown. */
+	toModelDisplayName(rawModelId: string | undefined): string | undefined;
+}
+
+/**
+ * Converts completed turns from the protocol state into session history items.
+ *
+ * Per turn, prefers `turn.usage?.model` so each request/response pair shows
+ * the model that actually ran, even if the user changed models mid-session.
+ * The `lookup` callback is responsible for any session-level fallback (e.g.
+ * `summary.model?.id` when usage hasn't reported a model yet).
+ */
+export function turnsToHistory(backendSession: URI, turns: readonly Turn[], participantId: string, connectionAuthority: string | undefined, lookup?: TurnModelLookup): IChatSessionHistoryItem[] {
 	const history: IChatSessionHistoryItem[] = [];
 	for (const turn of turns) {
+		const rawModelId = turn.usage?.model;
+		const modelId = lookup?.toLanguageModelId(rawModelId);
+		const modelName = lookup?.toModelDisplayName(rawModelId);
+
 		// Request
 		history.push({ id: turn.id, type: 'request', prompt: turn.userMessage.text, participant: participantId, modelId });
 
@@ -141,7 +165,7 @@ export function turnsToHistory(backendSession: URI, turns: readonly Turn[], part
 			parts.push({ kind: 'markdownContent', content: new MarkdownString(`\n\nError: (${turn.error.errorType}) ${turn.error.message}`) });
 		}
 
-		history.push({ type: 'response', parts, participant: participantId });
+		history.push({ type: 'response', parts, participant: participantId, details: modelName });
 	}
 	return history;
 }

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -28,7 +28,7 @@ import { ChatAgentLocation } from '../../../common/constants.js';
 import { IChatService, IChatMarkdownContent, IChatProgress, IChatTerminalToolInvocationData, IChatToolInputInvocationData, IChatToolInvocation, IChatToolInvocationSerialized, ToolConfirmKind } from '../../../common/chatService/chatService.js';
 import { IChatEditingService } from '../../../common/editing/chatEditingService.js';
 import { IMarkdownString } from '../../../../../../base/common/htmlContent.js';
-import { IChatSessionsService } from '../../../common/chatSessionsService.js';
+import { IChatSessionsService, type IChatSessionRequestHistoryItem } from '../../../common/chatSessionsService.js';
 import { ILanguageModelsService } from '../../../common/languageModels.js';
 import { IProductService } from '../../../../../../platform/product/common/productService.js';
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
@@ -376,6 +376,7 @@ function createTestServices(disposables: DisposableStore, workingDirectoryResolv
 	instantiationService.stub(ILanguageModelsService, {
 		deltaLanguageModelChatProviderDescriptors: () => { },
 		registerLanguageModelProvider: () => toDisposable(() => { }),
+		lookupLanguageModel: () => undefined,
 	});
 	instantiationService.stub(IConfigurationService, {
 		onDidChangeConfiguration: Event.None,
@@ -1732,6 +1733,62 @@ suite('AgentHostChatContribution', () => {
 			disposables.add(toDisposable(() => session.dispose()));
 
 			assert.strictEqual(session.history.length, 0);
+		});
+
+		test('history requests get per-turn modelId from usage, with active turn falling back to session model', async () => {
+			const { sessionHandler, agentHostService } = createContribution(disposables);
+
+			const sessionUri = AgentSession.uri('copilot', 'sess-models');
+			agentHostService.sessionStates.set(sessionUri.toString(), {
+				...createSessionState({
+					resource: sessionUri.toString(), provider: 'copilot', title: 'Test',
+					status: SessionStatus.Idle, createdAt: Date.now(), modifiedAt: Date.now(),
+					model: { id: 'sonnet-4.6' },
+				}),
+				lifecycle: SessionLifecycle.Ready,
+				turns: [
+					{
+						id: 'turn-1',
+						userMessage: { text: 'Q1' },
+						responseParts: [{ kind: ResponsePartKind.Markdown, id: 'md-1', content: 'A1' }],
+						usage: { model: 'opus-4.7' },
+						state: TurnState.Complete,
+					},
+					{
+						id: 'turn-2',
+						userMessage: { text: 'Q2' },
+						responseParts: [{ kind: ResponsePartKind.Markdown, id: 'md-2', content: 'A2' }],
+						usage: undefined,
+						state: TurnState.Complete,
+					},
+				],
+				activeTurn: {
+					id: 'turn-active',
+					userMessage: { text: 'Q3' },
+					responseParts: [],
+					usage: undefined,
+				},
+			});
+
+			const sessionResource = URI.from({ scheme: 'agent-host-copilot', path: '/sess-models' });
+			const session = await sessionHandler.provideChatSessionContent(sessionResource, CancellationToken.None);
+			disposables.add(toDisposable(() => session.dispose()));
+
+			const requests = session.history.filter((h): h is IChatSessionRequestHistoryItem => h.type === 'request');
+			assert.deepStrictEqual(
+				requests.map(r => ({ prompt: r.prompt, modelId: r.modelId })),
+				[
+					{ prompt: 'Q1', modelId: 'agent-host-copilot:opus-4.7' },
+					{ prompt: 'Q2', modelId: 'agent-host-copilot:sonnet-4.6' },
+					{ prompt: 'Q3', modelId: 'agent-host-copilot:sonnet-4.6' },
+				],
+			);
+
+			const activeResponse = session.history[session.history.length - 1];
+			assert.strictEqual(activeResponse.type, 'response');
+			if (activeResponse.type === 'response') {
+				assert.strictEqual(activeResponse.parts.length, 0);
+			}
 		});
 	});
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
@@ -59,8 +59,28 @@ function finalizeToolInvocation(invocation: Parameters<typeof rawFinalizeToolInv
 	return rawFinalizeToolInvocation(invocation, tc, URI.file('/'), undefined);
 }
 
-function turnsToHistory(backendSession: Parameters<typeof rawTurnsToHistory>[0], turns: Parameters<typeof rawTurnsToHistory>[1], participantId: Parameters<typeof rawTurnsToHistory>[2], modelId?: Parameters<typeof rawTurnsToHistory>[4]) {
-	return rawTurnsToHistory(backendSession, turns, participantId, undefined, modelId);
+function turnsToHistory(backendSession: Parameters<typeof rawTurnsToHistory>[0], turns: Parameters<typeof rawTurnsToHistory>[1], participantId: Parameters<typeof rawTurnsToHistory>[2], lookup?: Parameters<typeof rawTurnsToHistory>[4]) {
+	return rawTurnsToHistory(backendSession, turns, participantId, undefined, lookup);
+}
+
+/**
+ * Builds a fake {@link TurnModelLookup} that namespaces ids with a fixed
+ * prefix and returns display names from a static map. `fallbackRawModelId`
+ * mirrors the real handler's "use summary.model when usage hasn't reported
+ * yet" behavior.
+ */
+function makeLookup(prefix: string, displayNames: Record<string, string>, fallbackRawModelId?: string): Parameters<typeof rawTurnsToHistory>[4] {
+	const resolveRaw = (raw: string | undefined): string | undefined => raw ?? fallbackRawModelId;
+	return {
+		toLanguageModelId: (raw) => {
+			const r = resolveRaw(raw);
+			return r ? `${prefix}${r}` : undefined;
+		},
+		toModelDisplayName: (raw) => {
+			const r = resolveRaw(raw);
+			return r ? displayNames[r] : undefined;
+		},
+	};
 }
 
 function activeTurnToProgress(sessionResource: Parameters<typeof rawActiveTurnToProgress>[0], activeTurn: Parameters<typeof rawActiveTurnToProgress>[1], connectionAuthority?: Parameters<typeof rawActiveTurnToProgress>[2]) {
@@ -110,12 +130,57 @@ suite('stateToProgressAdapter', () => {
 			assert.strictEqual(serialized.isComplete, true);
 		});
 
+		test('per-turn model id and display name flow from usage.model', () => {
+			const turn1 = createTurn({
+				id: 'turn-1',
+				userMessage: { text: 'first' },
+				usage: { model: 'gpt-5' },
+			});
+			const turn2 = createTurn({
+				id: 'turn-2',
+				userMessage: { text: 'second' },
+				usage: { model: 'opus-4.7' },
+			});
+
+			const lookup = makeLookup('agent-host-copilot:', { 'gpt-5': 'GPT-5', 'opus-4.7': 'Claude Opus 4.7' });
+			const history = turnsToHistory(URI.file('/'), [turn1, turn2], 'p', lookup);
+
+			assert.deepStrictEqual(
+				history.map(h => h.type === 'request'
+					? { type: h.type, modelId: h.modelId }
+					: { type: h.type, details: h.details }),
+				[
+					{ type: 'request', modelId: 'agent-host-copilot:gpt-5' },
+					{ type: 'response', details: 'GPT-5' },
+					{ type: 'request', modelId: 'agent-host-copilot:opus-4.7' },
+					{ type: 'response', details: 'Claude Opus 4.7' },
+				],
+			);
+		});
+
+		test('falls back to session-level model when turn has no usage.model', () => {
+			const turn = createTurn({ userMessage: { text: 'first' } });
+			const lookup = makeLookup('agent-host-copilot:', { 'gpt-5': 'GPT-5' }, 'gpt-5');
+			const history = turnsToHistory(URI.file('/'), [turn], 'p', lookup);
+
+			assert.deepStrictEqual(
+				history.map(h => h.type === 'request'
+					? { type: h.type, modelId: h.modelId }
+					: { type: h.type, details: h.details }),
+				[
+					{ type: 'request', modelId: 'agent-host-copilot:gpt-5' },
+					{ type: 'response', details: 'GPT-5' },
+				],
+			);
+		});
+
 		test('request history includes restored model id', () => {
 			const turn = createTurn({
 				userMessage: { text: 'Use restored model' },
 			});
 
-			const history = turnsToHistory(URI.file('/'), [turn], 'participant-1', 'agent-host-copilot:gpt-5');
+			const lookup = makeLookup('agent-host-copilot:', {}, 'gpt-5');
+			const history = turnsToHistory(URI.file('/'), [turn], 'participant-1', lookup);
 
 			assert.deepStrictEqual(history[0], {
 				id: turn.id,


### PR DESCRIPTION
Three related fixes to Agent Host subagent handling:

## Commit 1: URI helpers for subagent sessions

Refactors `parseSubagentSessionUri` and related helpers to work with real `URI` objects instead of repeatedly round-tripping through `toString()` / `URI.parse()`:

- `parseSubagentSessionUri` uses a greedy named-capture regex over `resource.path` and returns `parentSession` as a `URI`
- `buildSubagentSessionUri` / prefix helpers preserve opaque path text with `URI.with({ path })` instead of string concatenation
- Call sites in `agentService.ts`, `copilotAgent.ts`, `agentConfigurationService.ts` avoid extra URI string round-trips
- Nested subagent subscriber pinning now correctly walks ancestry

## Commit 2: Fix live sync-subagent streaming routing

Subagent text, reasoning, and tool events were routing to the parent session during live streaming because the session used single global part IDs and relied on deprecated `data.parentToolCallId`.

- Track per-subagent markdown/reasoning part IDs in Maps keyed by `parentToolCallId` so parent and subagent text never share a response part
- Populate `agentId → toolCallId` map from `subagent.started` events; use event-level `agentId` for routing instead of deprecated field
- Drop events with an unmapped `agentId` with a warning log rather than silently routing them to the parent session
- Add regression tests for markdown delta, reasoning delta, and tool completion routing in subagent sessions

## Commit 3: Fix nested subagent routing for depth > 1

Two bugs that only manifest with depth-2+ subagents (subagent spawning a subagent):

- `onClientToolCallComplete` and `getSessionMessages` in `copilotAgent.ts` stopped after one `parseSubagentSessionUri` call, producing an intermediate URI that is never a key in `_sessions`. Client-tool completions and message restores were silently dropped.
- `_maybeEvictIdleSession` in `agentService.ts` targeted only the immediate parent when a nested subagent URI unsubscribed, leaving root session state leaked in the state manager.

Fix: both walk the full subagent ancestry to the root. Covered by new regression tests.

(Written by Copilot)