### PR TITLE
feat: add /cwd slash command for per-session working directory control

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -562,6 +562,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 				this._pendingMessageSubscriptions.deleteAndDispose(sessionResource);
 				this._serverTurnWatchers.deleteAndDispose(sessionResource);
 				this._pendingHistoryTurns.delete(sessionResource);
+				this._workingDirectoryResolver.clearSessionWorkingDirectory(sessionResource);
 				this._releaseSessionSubscription(resolvedSession.toString());
 			},
 			() => {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionWorkingDirectoryResolver.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionWorkingDirectoryResolver.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IDisposable, toDisposable } from '../../../../../../base/common/lifecycle.js';
+import { ResourceMap } from '../../../../../../base/common/map.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { createDecorator } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { InstantiationType, registerSingleton } from '../../../../../../platform/instantiation/common/extensions.js';
@@ -15,12 +16,16 @@ export interface IAgentHostSessionWorkingDirectoryResolver {
 	registerResolver(sessionType: string, resolver: (sessionResource: URI) => URI | undefined, isNewSession?: (sessionResource: URI) => boolean): IDisposable;
 	resolve(sessionResource: URI): URI | undefined;
 	isNewSession(sessionResource: URI): boolean;
+	setSessionWorkingDirectory(sessionResource: URI, cwd: URI): void;
+	getSessionWorkingDirectory(sessionResource: URI): URI | undefined;
+	clearSessionWorkingDirectory(sessionResource: URI): void;
 }
 
 class AgentHostSessionWorkingDirectoryResolver implements IAgentHostSessionWorkingDirectoryResolver {
 	declare readonly _serviceBrand: undefined;
 
 	private readonly _resolvers = new Map<string, { readonly resolve: (sessionResource: URI) => URI | undefined; readonly isNewSession?: (sessionResource: URI) => boolean }>();
+	private readonly _sessionOverrides = new ResourceMap<URI>();
 
 	registerResolver(sessionType: string, resolver: (sessionResource: URI) => URI | undefined, isNewSession?: (sessionResource: URI) => boolean): IDisposable {
 		const entry = { resolve: resolver, isNewSession };
@@ -33,11 +38,24 @@ class AgentHostSessionWorkingDirectoryResolver implements IAgentHostSessionWorki
 	}
 
 	resolve(sessionResource: URI): URI | undefined {
-		return this._resolvers.get(sessionResource.scheme)?.resolve(sessionResource);
+		return this._sessionOverrides.get(sessionResource)
+			?? this._resolvers.get(sessionResource.scheme)?.resolve(sessionResource);
 	}
 
 	isNewSession(sessionResource: URI): boolean {
 		return this._resolvers.get(sessionResource.scheme)?.isNewSession?.(sessionResource) ?? false;
+	}
+
+	setSessionWorkingDirectory(sessionResource: URI, cwd: URI): void {
+		this._sessionOverrides.set(sessionResource, cwd);
+	}
+
+	getSessionWorkingDirectory(sessionResource: URI): URI | undefined {
+		return this._sessionOverrides.get(sessionResource);
+	}
+
+	clearSessionWorkingDirectory(sessionResource: URI): void {
+		this._sessionOverrides.delete(sessionResource);
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/chatSlashCommands.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSlashCommands.ts
@@ -12,6 +12,7 @@ import * as nls from '../../../../nls.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { ILabelService } from '../../../../platform/label/common/label.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
 import { IChatAgentService } from '../common/participants/chatAgents.js';
@@ -50,6 +51,7 @@ export class ChatSlashCommandsContribution extends Disposable {
 		@IConfigurationService configurationService: IConfigurationService,
 		@IChatWidgetService chatWidgetService: IChatWidgetService,
 		@IWorkspaceContextService workspaceContextService: IWorkspaceContextService,
+		@ILabelService labelService: ILabelService,
 		@IWorkbenchEnvironmentService private readonly environmentService: IWorkbenchEnvironmentService,
 	) {
 		super();
@@ -88,7 +90,7 @@ export class ChatSlashCommandsContribution extends Disposable {
 				}
 
 				progress.report({
-					content: new MarkdownString(nls.localize('cwd.current', "Current working directory: `{0}`", cwd.fsPath)),
+					content: new MarkdownString(nls.localize('cwd.current', "Current working directory: `{0}`", labelService.getUriLabel(cwd))),
 					kind: 'markdownContent'
 				});
 				return;
@@ -96,7 +98,11 @@ export class ChatSlashCommandsContribution extends Disposable {
 
 			let resolvedUri: URI | undefined;
 			if (isAbsolute(requestedPath)) {
-				resolvedUri = URI.file(requestedPath);
+				if (workspaceFolder) {
+					resolvedUri = workspaceFolder.uri.with({ path: requestedPath });
+				} else {
+					resolvedUri = URI.file(requestedPath);
+				}
 			} else if (workspaceFolder) {
 				resolvedUri = workspaceFolder.toResource(requestedPath);
 			}
@@ -111,7 +117,7 @@ export class ChatSlashCommandsContribution extends Disposable {
 
 			workingDirectoryResolver.setSessionWorkingDirectory(sessionResource, resolvedUri);
 			progress.report({
-				content: new MarkdownString(nls.localize('cwd.updated', "Working directory set to `{0}`", resolvedUri.fsPath)),
+				content: new MarkdownString(nls.localize('cwd.updated', "Working directory set to `{0}`", labelService.getUriLabel(resolvedUri))),
 				kind: 'markdownContent'
 			});
 		}));

--- a/src/vs/workbench/contrib/chat/browser/chatSlashCommands.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSlashCommands.ts
@@ -6,12 +6,14 @@
 import { timeout } from '../../../../base/common/async.js';
 import { MarkdownString, isMarkdownString } from '../../../../base/common/htmlContent.js';
 import { Disposable, DisposableMap, DisposableStore } from '../../../../base/common/lifecycle.js';
+import { isAbsolute } from '../../../../base/common/path.js';
 import { URI } from '../../../../base/common/uri.js';
 import * as nls from '../../../../nls.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
+import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
 import { IChatAgentService } from '../common/participants/chatAgents.js';
 import { ChatContextKeys } from '../common/actions/chatContextKeys.js';
 import { IChatSlashCommandService } from '../common/participants/chatSlashCommands.js';
@@ -23,6 +25,7 @@ import { ChatSubmitAction, OpenModePickerAction, OpenModelPickerAction } from '.
 import { ManagePluginsAction } from './actions/chatPluginActions.js';
 import { ConfigureToolsAction } from './actions/chatToolActions.js';
 import { IAgentSessionsService } from './agentSessions/agentSessionsService.js';
+import { IAgentHostSessionWorkingDirectoryResolver } from './agentSessions/agentHost/agentHostSessionWorkingDirectoryResolver.js';
 import { CONFIGURE_INSTRUCTIONS_ACTION_ID } from './promptSyntax/attachInstructionsAction.js';
 import { showConfigureHooksQuickPick } from './promptSyntax/hookActions.js';
 import { CONFIGURE_PROMPTS_ACTION_ID } from './promptSyntax/runPromptAction.js';
@@ -42,9 +45,11 @@ export class ChatSlashCommandsContribution extends Disposable {
 		@IChatAgentService chatAgentService: IChatAgentService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IAgentSessionsService agentSessionsService: IAgentSessionsService,
+		@IAgentHostSessionWorkingDirectoryResolver workingDirectoryResolver: IAgentHostSessionWorkingDirectoryResolver,
 		@IChatService chatService: IChatService,
 		@IConfigurationService configurationService: IConfigurationService,
 		@IChatWidgetService chatWidgetService: IChatWidgetService,
+		@IWorkspaceContextService workspaceContextService: IWorkspaceContextService,
 		@IWorkbenchEnvironmentService private readonly environmentService: IWorkbenchEnvironmentService,
 	) {
 		super();
@@ -58,6 +63,57 @@ export class ChatSlashCommandsContribution extends Disposable {
 		}, async (_prompt, _progress, _history, _location, sessionResource) => {
 			agentSessionsService.getSession(sessionResource)?.setArchived(true);
 			commandService.executeCommand(ACTION_ID_NEW_CHAT);
+		}));
+		this._store.add(slashCommandService.registerSlashCommand({
+			command: 'cwd',
+			detail: nls.localize('cwd', "Display or change the working directory for this session"),
+			sortText: 'z3_cwd',
+			executeImmediately: false,
+			locations: [ChatAgentLocation.Chat],
+		}, async (prompt, progress, _history, _location, sessionResource) => {
+			const requestedPath = prompt.trim();
+			const workspaceFolder = workspaceContextService.getWorkspace().folders[0];
+
+			if (!requestedPath) {
+				const cwd = workingDirectoryResolver.getSessionWorkingDirectory(sessionResource)
+					?? workingDirectoryResolver.resolve(sessionResource)
+					?? workspaceFolder?.uri;
+
+				if (!cwd) {
+					progress.report({
+						content: new MarkdownString(nls.localize('cwd.none', "Current working directory is not set.")),
+						kind: 'markdownContent'
+					});
+					return;
+				}
+
+				progress.report({
+					content: new MarkdownString(nls.localize('cwd.current', "Current working directory: `{0}`", cwd.fsPath)),
+					kind: 'markdownContent'
+				});
+				return;
+			}
+
+			let resolvedUri: URI | undefined;
+			if (isAbsolute(requestedPath)) {
+				resolvedUri = URI.file(requestedPath);
+			} else if (workspaceFolder) {
+				resolvedUri = workspaceFolder.toResource(requestedPath);
+			}
+
+			if (!resolvedUri) {
+				progress.report({
+					content: new MarkdownString(nls.localize('cwd.cannotResolveRelative', "Cannot resolve relative path `{0}` because no workspace folder is open.", requestedPath)),
+					kind: 'markdownContent'
+				});
+				return;
+			}
+
+			workingDirectoryResolver.setSessionWorkingDirectory(sessionResource, resolvedUri);
+			progress.report({
+				content: new MarkdownString(nls.localize('cwd.updated', "Working directory set to `{0}`", resolvedUri.fsPath)),
+				kind: 'markdownContent'
+			});
 		}));
 		this._store.add(slashCommandService.registerSlashCommand({
 			command: 'hooks',

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -77,6 +77,7 @@ import { clamp } from '../../../../../../base/common/numbers.js';
 import { IOutputAnalyzer } from './outputAnalyzer.js';
 import { SandboxOutputAnalyzer, outputLooksSandboxBlocked } from './sandboxOutputAnalyzer.js';
 import { IAgentSessionsService } from '../../../../chat/browser/agentSessions/agentSessionsService.js';
+import { IAgentHostSessionWorkingDirectoryResolver } from '../../../../chat/browser/agentSessions/agentHost/agentHostSessionWorkingDirectoryResolver.js';
 import { ITerminalSandboxService, TerminalSandboxPrerequisiteCheck, type ITerminalSandboxResolvedNetworkDomains } from '../../common/terminalSandboxService.js';
 import { LanguageModelPartAudience } from '../../../../chat/common/languageModels.js';
 import { isSessionAutoApproveLevel, isTerminalAutoApproveAllowed, isToolEligibleForTerminalAutoApproval } from './terminalToolAutoApprove.js';
@@ -550,6 +551,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
 		@IChatWidgetService private readonly _chatWidgetService: IChatWidgetService,
 		@IAgentSessionsService private readonly _agentSessionsService: IAgentSessionsService,
+		@IAgentHostSessionWorkingDirectoryResolver private readonly _workingDirectoryResolver: IAgentHostSessionWorkingDirectoryResolver,
 	) {
 		super();
 
@@ -642,6 +644,12 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			this._osBackend,
 			this._profileFetcher.getCopilotShell(),
 			(async () => {
+				if (chatSessionResource) {
+					const sessionCwd = this._workingDirectoryResolver.getSessionWorkingDirectory(chatSessionResource);
+					if (sessionCwd) {
+						return sessionCwd;
+					}
+				}
 				let cwd = await instance?.getCwdResource();
 				if (!cwd) {
 					const activeWorkspaceRootUri = this._historyService.getLastActiveWorkspaceRoot();


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/313939

## Problem
In monorepo or multi-package setups, agent mode terminal commands always run from the workspace root. There is no way to scope a session to a specific subdirectory so that `git`, `npm`, build scripts, and other CWD-sensitive tools behave correctly.

## Solution
Add a `/cwd` slash command that allows users to view and change the working directory for their agent chat session.

### Usage
- `/cwd` — Display the current working directory for the session
- `/cwd packages/my-service` — Set the working directory (relative to workspace root)
- `/cwd /absolute/path` — Set the working directory (absolute path)

The override is per-session and affects all subsequent terminal tool invocations, including sandbox filesystem rules and command execution context.

## Changes

**`agentHostSessionWorkingDirectoryResolver.ts`** — Extended `IAgentHostSessionWorkingDirectoryResolver` with per-session CWD storage (`setSessionWorkingDirectory`/`getSessionWorkingDirectory`/`clearSessionWorkingDirectory`). The `resolve()` method checks per-session overrides before registered resolvers.

**`chatSlashCommands.ts`** — Registered `/cwd` slash command with view/change behavior. Resolves relative paths against the first workspace folder.

**`runInTerminalTool.ts`** — Modified `prepareToolInvocation()` CWD resolution to check per-session overrides first, ensuring terminal commands, sandbox, and hooks all respect the session's configured directory.