### PR TITLE
Fix Firefox selection crash in Monaco: handle shadow DOM + null hit result in _doHitTestWithCaretPositionFromPoint

### DIFF
--- a/src/vs/editor/browser/controller/mouseTarget.ts
+++ b/src/vs/editor/browser/controller/mouseTarget.ts
@@ -1041,8 +1041,27 @@ export class MouseTargetFactory {
 	 * Most probably Gecko
 	 */
 	private static _doHitTestWithCaretPositionFromPoint(ctx: HitTestContext, coords: ClientCoordinates): HitTestResult {
+		// Firefox 131+ changed `caretPositionFromPoint` so that, when the page uses
+		// shadow DOM, the third options argument must include `shadowRoots: [...]`
+		// for the call to return the actual hit position inside the shadow tree.
+		// Without it, Firefox returns the shadow host (or null), which crashes the
+		// caller's `hitResult.offsetNode` access on Monaco selections.
+		// See https://github.com/microsoft/monaco-editor/issues/4679 and
+		// https://drafts.csswg.org/cssom-view/#dom-document-caretpositionfrompoint
+		const shadowRoot = dom.getShadowRoot(ctx.viewDomNode);
 		// eslint-disable-next-line local/code-no-any-casts, @typescript-eslint/no-explicit-any
-		const hitResult: { offsetNode: Node; offset: number } = (<any>ctx.viewDomNode.ownerDocument).caretPositionFromPoint(coords.clientX, coords.clientY);
+		const hitResult: { offsetNode: Node; offset: number } | null = shadowRoot
+			// eslint-disable-next-line local/code-no-any-casts, @typescript-eslint/no-explicit-any
+			? (<any>ctx.viewDomNode.ownerDocument).caretPositionFromPoint(coords.clientX, coords.clientY, { shadowRoots: [shadowRoot] })
+			// eslint-disable-next-line local/code-no-any-casts, @typescript-eslint/no-explicit-any
+			: (<any>ctx.viewDomNode.ownerDocument).caretPositionFromPoint(coords.clientX, coords.clientY);
+
+		// `caretPositionFromPoint` can return null when the point falls outside any
+		// addressable text node (e.g. the user drags a multi-line selection past
+		// the end of the editor). Bail out instead of dereferencing offsetNode.
+		if (!hitResult) {
+			return new UnknownHitTestResult();
+		}
 
 		if (hitResult.offsetNode.nodeType === hitResult.offsetNode.TEXT_NODE) {
 			// offsetNode is expected to be the token text


### PR DESCRIPTION
### Refs

- microsoft/monaco-editor#4679 — open since 2024-09-12, label `bug` + `firefox`
- Mozilla bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1914596
- CSSOM spec: https://drafts.csswg.org/cssom-view/#dom-document-caretpositionfrompoint

### What

Two related defensive changes in `_doHitTestWithCaretPositionFromPoint` (`src/vs/editor/browser/controller/mouseTarget.ts`):

1. **Pass the host's shadow root to `caretPositionFromPoint`** so Firefox can resolve hits inside a shadow tree (parallels the `_doHitTestWithCaretRangeFromPoint` sibling at line ~990, which already calls `dom.getShadowRoot`).
2. **Null-check the hit result** before dereferencing `hitResult.offsetNode` — the API legitimately returns `null` for points that don't fall on an addressable text node (e.g. dragging a multi-line selection past the end of the editor).

### Why

Firefox 131 changed [`document.caretPositionFromPoint`](https://developer.mozilla.org/en-US/docs/Web/API/Document/caretPositionFromPoint) so that, when the page uses shadow DOM, the third options argument must include `{shadowRoots: [...]}` to return the actual hit position. Without it, Firefox returns the shadow host (or `null`). This crashes the editor's selection logic with:

```
Uncaught Error: can't access property "offsetNode", i is null
  _doHitTestWithCaretPositionFromPoint@editor.api…
  doHitTest@editor.api…
```

The error is fired through Monaco's `unexpectedErrorHandler`, surfaces in the console, and pollutes any error-monitoring tool (Sentry, Datadog RUM) listening on `window.onerror`. The selection still works — it's a hit-test miss after the fact — but every multi-line drag triggers it.

The bug is not just a shadow-DOM concern: contributors have reported the same `offsetNode is null` crash on the [Monaco playground](https://microsoft.github.io/monaco-editor/playground.html) in Firefox 145+ by simply selecting all text. That suggests Firefox's `caretPositionFromPoint` can return `null` even without shadow DOM in some drag scenarios, hence the explicit `if (!hitResult) return new UnknownHitTestResult();` guard.

### Reproduction

> [silverwind in microsoft/monaco-editor#4679 (Nov 2025)](https://github.com/microsoft/monaco-editor/issues/4679#issuecomment-3564090288):
> > text selection causes a JS error \`can't access property \"offsetNode\", hitResult is null\` to be thrown in Firefox (currently on v145), and this issue seems to be the root cause. I can reproduce on https://microsoft.github.io/monaco-editor/playground.html?source=v0.55.1#example-creating-the-editor-hello-world by just selecting all text in Monaco

> [erosman in microsoft/monaco-editor#4679 (Dec 2025)](https://github.com/microsoft/monaco-editor/issues/4679#issuecomment-3649022792):
> > Uncaught Error: can't access property \"offsetNode\", i is null — happens when selecting text with mouse in the editor and the mouse moves out of the \`<div class=\"monaco-scrollable-element editor-scrollable vs\">\`

### Fix attribution

The shadow-root passthrough was originally proposed in the issue thread by [@nate-bow-db (Oct 2024)](https://github.com/microsoft/monaco-editor/issues/4679#issuecomment-2406284453). The community has been shipping it as a [postinstall monkey-patch](https://github.com/microsoft/monaco-editor/issues/4679#issuecomment-2468965180) for over a year. This PR lands the same change in the source plus adds the explicit null-guard for the non-shadow-DOM crash path that surfaced more recently.

### Risk / scope

- Scoped to one private static method in `mouseTarget.ts`.
- The shadow-root branch only fires when `dom.getShadowRoot(ctx.viewDomNode)` returns non-null — so existing non-shadow-DOM consumers (the standard Monaco bundle) hit the same code path as before.
- The null-guard returns `new UnknownHitTestResult()`, which is the same fallback the function already returns on its other failure path (line ~1080 today). No new return shape.
- `dom.getShadowRoot` is already imported and used in the sibling `_doHitTestWithCaretRangeFromPoint` method, so no new import is needed.