### PR TITLE
sessions: fix theme import and refactor preview API

### DIFF
--- a/src/vs/sessions/contrib/welcome/browser/sessionsWalkthrough.ts
+++ b/src/vs/sessions/contrib/welcome/browser/sessionsWalkthrough.ts
@@ -5,7 +5,7 @@
 
 import './media/sessionsWalkthrough.css';
 import { disposableTimeout } from '../../../../base/common/async.js';
-import { Disposable, DisposableStore, IDisposable, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { $, addDisposableGenericMouseDownListener, append, EventType, addDisposableListener, getActiveElement, isHTMLElement } from '../../../../base/browser/dom.js';
 import { Gesture, EventType as TouchEventType } from '../../../../base/browser/touch.js';
 import { localize } from '../../../../nls.js';
@@ -24,7 +24,7 @@ import { CHAT_SETUP_SUPPORT_ANONYMOUS_ACTION_ID } from '../../../../workbench/co
 import { ChatSetupStrategy } from '../../../../workbench/contrib/chat/browser/chatSetup/chatSetup.js';
 import { IExtensionService } from '../../../../workbench/services/extensions/common/extensions.js';
 import { IWorkbenchThemeService } from '../../../../workbench/services/themes/common/workbenchThemeService.js';
-import { IThemeImporterService } from '../../../services/vscode/common/themeImporter.js';
+import { IThemeImporterService, IThemePreviewResult } from '../../../services/vscode/common/themeImporter.js';
 
 export type WalkthroughOutcome = 'completed' | 'dismissed';
 
@@ -223,12 +223,12 @@ export class SessionsWalkthroughOverlay extends Disposable {
 		// whether it's the first launch or a returning user who is signed out.
 		const titleEl = append(right, $('h2', undefined, localize('walkthrough.welcome.title', "Welcome to {0}", productName)));
 		const subtitleEl = append(right, $('p', undefined, localize('walkthrough.welcome.subtitle', "Your AI-powered application where agents explore, build, and iterate with you.")));
-		append(right, $('p.sessions-walkthrough-tagline', undefined, localize('walkthrough.welcome.tagline', "Happy Agentic Coding!")));
+		const taglineEl = append(right, $('p.sessions-walkthrough-tagline', undefined, localize('walkthrough.welcome.tagline', "Happy Agentic Coding!")));
 
-		this._renderSignInButtons(stepDisposables, right, titleEl, subtitleEl);
+		this._renderSignInButtons(stepDisposables, right, titleEl, subtitleEl, taglineEl);
 	}
 
-	private _renderSignInButtons(stepDisposables: DisposableStore, right: HTMLElement, titleEl: HTMLElement, subtitleEl: HTMLElement): void {
+	private _renderSignInButtons(stepDisposables: DisposableStore, right: HTMLElement, titleEl: HTMLElement, subtitleEl: HTMLElement, taglineEl: HTMLElement): void {
 		this._isShowingSignIn = true;
 		const signInActions = append(right, $('.sessions-walkthrough-sign-in-actions'));
 		const providerRow = append(signInActions, $('.sessions-walkthrough-providers-row'));
@@ -278,6 +278,7 @@ export class SessionsWalkthroughOverlay extends Disposable {
 				errorContainer,
 				titleEl,
 				subtitleEl,
+				taglineEl,
 				signInActions
 			)));
 		} else {
@@ -296,6 +297,7 @@ export class SessionsWalkthroughOverlay extends Disposable {
 					strategy,
 					titleEl,
 					subtitleEl,
+					taglineEl,
 					signInActions
 				)));
 			}
@@ -391,10 +393,12 @@ export class SessionsWalkthroughOverlay extends Disposable {
 		const themeCards: HTMLElement[] = [];
 		let vscodeThemeBtn: HTMLElement | undefined;
 		let isVSCodeThemeSelected = false;
+		let previewResult: IThemePreviewResult | undefined;
 		for (const theme of themes) {
 			const card = this._createThemeCard(stepDisposables, themeGrid, theme, themeCards, selectedThemeId, id => {
 				selectedThemeId = id;
 				isVSCodeThemeSelected = false;
+				previewResult?.reset();
 				if (vscodeThemeBtn) {
 					vscodeThemeBtn.classList.remove('selected');
 					vscodeThemeBtn.setAttribute('aria-checked', 'false');
@@ -418,7 +422,6 @@ export class SessionsWalkthroughOverlay extends Disposable {
 				parentThemeSettingsId,
 			);
 			vscodeThemeBtn.textContent = labelText;
-			let previewDisposable: IDisposable | undefined;
 			const selectVSCodeTheme = async () => {
 				for (const c of themeCards) {
 					c.classList.remove('selected');
@@ -429,12 +432,11 @@ export class SessionsWalkthroughOverlay extends Disposable {
 				isVSCodeThemeSelected = true;
 
 				// Preview the theme (temporary install from host location)
-				previewDisposable?.dispose();
-				previewDisposable = await this.themeImporterService.previewVSCodeTheme();
+				previewResult = await this.themeImporterService.previewVSCodeTheme();
 				vscodeThemeBtn!.textContent = labelText;
 			};
-			// Dispose preview on step teardown (escape)
-			stepDisposables.add(toDisposable(() => previewDisposable?.dispose()));
+			// Reset preview on step teardown (escape)
+			stepDisposables.add(toDisposable(() => { previewResult?.reset(); }));
 			stepDisposables.add(Gesture.addTarget(vscodeThemeBtn));
 			for (const eventType of [EventType.CLICK, TouchEventType.Tap]) {
 				stepDisposables.add(addDisposableListener(vscodeThemeBtn, eventType, selectVSCodeTheme));
@@ -453,7 +455,7 @@ export class SessionsWalkthroughOverlay extends Disposable {
 		continueBtn.textContent = localize('walkthrough.theme.continue', "Continue");
 		stepDisposables.add(addDisposableListener(continueBtn, EventType.CLICK, async () => {
 			if (isVSCodeThemeSelected) {
-				await this.themeImporterService.importVSCodeTheme();
+				await previewResult?.apply();
 			}
 			this._isShowingWelcome = false;
 			this._isShowingThemeStep = false;
@@ -523,8 +525,8 @@ export class SessionsWalkthroughOverlay extends Disposable {
 		}
 	}
 
-	private async _runSignIn(providerButtons: HTMLButtonElement[], error: HTMLElement, strategy: ChatSetupStrategy, titleEl: HTMLElement, subtitleEl: HTMLElement, signInActions: HTMLElement): Promise<void> {
-		await this._fadeToProgress(providerButtons, error, titleEl, subtitleEl, signInActions);
+	private async _runSignIn(providerButtons: HTMLButtonElement[], error: HTMLElement, strategy: ChatSetupStrategy, titleEl: HTMLElement, subtitleEl: HTMLElement, taglineEl: HTMLElement, signInActions: HTMLElement): Promise<void> {
+		await this._fadeToProgress(providerButtons, error, titleEl, subtitleEl, taglineEl, signInActions);
 		if (this._shouldAbortUpdate(titleEl, subtitleEl)) {
 			return;
 		}
@@ -571,8 +573,8 @@ export class SessionsWalkthroughOverlay extends Disposable {
 	 * this triggers an OAuth popup. On localhost the embedder's
 	 * env-contributed auth provider handles the flow (e.g. device code).
 	 */
-	private async _runSignInWeb(providerButtons: HTMLButtonElement[], error: HTMLElement, titleEl: HTMLElement, subtitleEl: HTMLElement, signInActions: HTMLElement): Promise<void> {
-		await this._fadeToProgress(providerButtons, error, titleEl, subtitleEl, signInActions);
+	private async _runSignInWeb(providerButtons: HTMLButtonElement[], error: HTMLElement, titleEl: HTMLElement, subtitleEl: HTMLElement, taglineEl: HTMLElement, signInActions: HTMLElement): Promise<void> {
+		await this._fadeToProgress(providerButtons, error, titleEl, subtitleEl, taglineEl, signInActions);
 		if (this._shouldAbortUpdate(titleEl, subtitleEl)) {
 			return;
 		}
@@ -588,7 +590,7 @@ export class SessionsWalkthroughOverlay extends Disposable {
 		}
 	}
 
-	private async _fadeToProgress(providerButtons: HTMLButtonElement[], error: HTMLElement, titleEl: HTMLElement, subtitleEl: HTMLElement, signInActions: HTMLElement): Promise<void> {
+	private async _fadeToProgress(providerButtons: HTMLButtonElement[], error: HTMLElement, titleEl: HTMLElement, subtitleEl: HTMLElement, taglineEl: HTMLElement, signInActions: HTMLElement): Promise<void> {
 		// Disable all provider buttons
 		for (const btn of providerButtons) {
 			btn.disabled = true;
@@ -608,6 +610,7 @@ export class SessionsWalkthroughOverlay extends Disposable {
 		// Swap title and subtitle in-place
 		titleEl.textContent = localize('walkthrough.settingUp', "Signing in\u2026");
 		subtitleEl.textContent = localize('walkthrough.poweredBy', "Complete authorization in your browser.");
+		taglineEl.remove();
 
 		// Replace sign-in actions with progress bar
 		const heroText = signInActions.parentElement;
@@ -615,6 +618,7 @@ export class SessionsWalkthroughOverlay extends Disposable {
 			return;
 		}
 		signInActions.remove();
+
 		append(heroText, $('.sessions-walkthrough-progress-bar', undefined, $('.sessions-walkthrough-progress-bar-fill')));
 
 		// Fade back in

--- a/src/vs/sessions/services/vscode/common/themeImporter.ts
+++ b/src/vs/sessions/services/vscode/common/themeImporter.ts
@@ -3,13 +3,29 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IDisposable } from '../../../../base/common/lifecycle.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 
 /** The VS Code configuration key for the active color theme. */
 export const COLOR_THEME_SETTINGS_ID = 'workbench.colorTheme';
 
 export const IThemeImporterService = createDecorator<IThemeImporterService>('IThemeImporterService');
+
+/**
+ * Result of previewing the parent VS Code's color theme.
+ */
+export interface IThemePreviewResult {
+	/**
+	 * Permanently imports the previewed theme into the Agents app by
+	 * copying the providing extension and installing it from there.
+	 */
+	apply(): Promise<void>;
+
+	/**
+	 * Reverts the preview by uninstalling the temporarily installed
+	 * extension.
+	 */
+	reset(): Promise<void>;
+}
 
 /**
  * Service that reads the parent VS Code installation's active color theme
@@ -29,16 +45,9 @@ export interface IThemeImporterService {
 
 	/**
 	 * Temporarily installs the providing extension from the host's extensions
-	 * directory and applies the VS Code theme. Returns an `IDisposable` that
-	 * uninstalls the extension on dispose. Returns `undefined` if the theme
-	 * is already available or cannot be resolved.
+	 * directory and applies the VS Code theme. Returns a cached
+	 * {@link IThemePreviewResult} to apply or reset the preview. Returns
+	 * `undefined` if the theme is already available or cannot be resolved.
 	 */
-	previewVSCodeTheme(): Promise<IDisposable>;
-
-	/**
-	 * Permanently imports the VS Code theme into the Agents app by copying
-	 * the providing extension into the Agents app's extensions directory
-	 * and installing it from there.
-	 */
-	importVSCodeTheme(): Promise<void>;
+	previewVSCodeTheme(): Promise<IThemePreviewResult | undefined>;
 }

--- a/src/vs/sessions/services/vscode/electron-browser/themeImporterService.ts
+++ b/src/vs/sessions/services/vscode/electron-browser/themeImporterService.ts
@@ -5,7 +5,7 @@
 
 import { parse as parseJSONC } from '../../../../base/common/jsonc.js';
 import { getErrorMessage } from '../../../../base/common/errors.js';
-import { Disposable, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
 import { joinPath } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ConfigurationTarget } from '../../../../platform/configuration/common/configuration.js';
@@ -17,7 +17,7 @@ import { InstantiationType, registerSingleton } from '../../../../platform/insta
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IWorkbenchThemeService } from '../../../../workbench/services/themes/common/workbenchThemeService.js';
 import { IUserDataProfileService } from '../../../../workbench/services/userDataProfile/common/userDataProfile.js';
-import { IThemeImporterService, COLOR_THEME_SETTINGS_ID } from '../common/themeImporter.js';
+import { IThemeImporterService, IThemePreviewResult, COLOR_THEME_SETTINGS_ID } from '../common/themeImporter.js';
 import { INativeWorkbenchEnvironmentService } from '../../../../workbench/services/environment/electron-browser/environmentService.js';
 
 /**
@@ -38,6 +38,7 @@ class ThemeImporterService extends Disposable implements IThemeImporterService {
 	declare readonly _serviceBrand: undefined;
 
 	private _parentThemePromise: Promise<IParentThemeInfo | undefined> | undefined;
+	private _previewPromise: Promise<IThemePreviewResult | undefined> | undefined;
 
 	constructor(
 		@INativeWorkbenchEnvironmentService private readonly environmentService: INativeWorkbenchEnvironmentService,
@@ -59,60 +60,73 @@ class ThemeImporterService extends Disposable implements IThemeImporterService {
 		return themeInfo?.settingsId;
 	}
 
-	async previewVSCodeTheme(): Promise<IDisposable> {
+	async previewVSCodeTheme(): Promise<IThemePreviewResult | undefined> {
+		if (!this._previewPromise) {
+			this._previewPromise = this._doPreview();
+			// Clear cache if preview resolved to undefined so callers can retry
+			this._previewPromise.then(result => {
+				if (!result) {
+					this._previewPromise = undefined;
+				}
+			});
+		}
+		return this._previewPromise;
+	}
+
+	private async _doPreview(): Promise<IThemePreviewResult | undefined> {
 		try {
 			const theme = await this._getVSCodeTheme();
 			if (!theme) {
-				return Disposable.None;
+				return undefined;
 			}
 
 			const installed = await this._installFromHostLocation(theme);
+			await this._setTheme(theme.settingsId);
 
-			// Apply the theme regardless of whether an install was needed
-			await this._applyTheme(theme.settingsId);
-
-			if (!installed) {
-				return Disposable.None;
-			}
-
-			return toDisposable(() => {
-				const profileLocation = this.userDataProfileService.currentProfile.extensionsResource;
-				this.extensionManagementService.uninstall(installed, { profileLocation }).catch(err => {
-					this.logService.warn('[VSCodeThemeImporter] Failed to uninstall preview extension:', err);
-				});
-			});
+			return {
+				apply: () => this._apply(theme),
+				reset: () => {
+					this._previewPromise = undefined;
+					return this._reset(installed);
+				},
+			};
 		} catch (err) {
 			this.logService.error('[VSCodeThemeImporter] Failed to preview theme:', err);
-			return Disposable.None;
+			return undefined;
 		}
 	}
 
-	async importVSCodeTheme(): Promise<void> {
+	private async _apply(theme: IParentThemeInfo): Promise<void> {
 		try {
-			const theme = await this._getVSCodeTheme();
-			if (!theme) {
+			if (!theme.extensionLocation) {
 				return;
 			}
 
-			// Step 1: Install from host location (preview — immediate availability)
-			await this._installFromHostLocation(theme);
-			await this._applyTheme(theme.settingsId);
+			// Copy extension to Agents app's own extensions directory
+			const extensionsHome = URI.file(this.environmentService.extensionsPath);
+			const folderName = theme.extensionLocation.path.split('/').pop()!;
+			const targetLocation = joinPath(extensionsHome, folderName);
 
-			// Step 2: Copy extension to Agents app's own extensions directory
-			if (theme.extensionLocation) {
-				const extensionsHome = URI.file(this.environmentService.extensionsPath);
-				const folderName = theme.extensionLocation.path.split('/').pop()!;
-				const targetLocation = joinPath(extensionsHome, folderName);
+			this.logService.info(`[VSCodeThemeImporter] Copying extension to ${targetLocation.toString()}`);
+			await this.fileService.copy(theme.extensionLocation, targetLocation, true);
 
-				this.logService.info(`[VSCodeThemeImporter] Copying extension to ${targetLocation.toString()}`);
-				await this.fileService.copy(theme.extensionLocation, targetLocation, true);
-
-				// Step 3: Replace install from the copied location
-				const profileLocation = this.userDataProfileService.currentProfile.extensionsResource;
-				await this.extensionManagementService.installFromLocation(targetLocation, profileLocation);
-			}
+			// Replace install from the copied location
+			const profileLocation = this.userDataProfileService.currentProfile.extensionsResource;
+			await this.extensionManagementService.installFromLocation(targetLocation, profileLocation);
 		} catch (err) {
-			this.logService.error('[VSCodeThemeImporter] Failed to import theme:', err);
+			this.logService.error('[VSCodeThemeImporter] Failed to apply theme:', err);
+		}
+	}
+
+	private async _reset(installed: ILocalExtension | undefined): Promise<void> {
+		if (!installed) {
+			return;
+		}
+		try {
+			const profileLocation = this.userDataProfileService.currentProfile.extensionsResource;
+			await this.extensionManagementService.uninstall(installed, { profileLocation });
+		} catch (err) {
+			this.logService.warn('[VSCodeThemeImporter] Failed to uninstall preview extension:', err);
 		}
 	}
 
@@ -136,7 +150,7 @@ class ThemeImporterService extends Disposable implements IThemeImporterService {
 		return this.extensionManagementService.installFromLocation(theme.extensionLocation, profileLocation);
 	}
 
-	private async _applyTheme(themeSettingsId: string): Promise<void> {
+	private async _setTheme(themeSettingsId: string): Promise<void> {
 		const allThemes = await this.themeService.getColorThemes();
 		const match = allThemes.find(t => t.settingsId === themeSettingsId);
 		if (match) {
@@ -211,6 +225,7 @@ class ThemeImporterService extends Disposable implements IThemeImporterService {
 	private async _readVSCodeThemeId(): Promise<string | undefined> {
 		const hostDataHome = this.environmentService.parentAppUserRoamingDataHome;
 		if (!hostDataHome) {
+			this.logService.warn('[VSCodeThemeImporter] Host user data home is not available');
 			return undefined;
 		}
 
@@ -222,7 +237,7 @@ class ThemeImporterService extends Disposable implements IThemeImporterService {
 			if (typeof themeId === 'string') {
 				return themeId;
 			}
-			this.logService.warn('[VSCodeThemeImporter] workbench.colorTheme is not set in host settings.json', themeId);
+			this.logService.warn('[VSCodeThemeImporter] workbench.colorTheme is not set in host settings.json', themeId, settingsUri.toString());
 			return undefined;
 		} catch (e) {
 			this.logService.warn('[VSCodeThemeImporter] Failed to read host settings.json, falling back to default theme', getErrorMessage(e));


### PR DESCRIPTION
## Summary

Fixes an issue where importing a theme during onboarding would immediately uninstall the extension. The preview disposable was being triggered during step teardown, undoing the permanent import.

## Changes

### Theme importer service refactor
- Replaced `previewVSCodeTheme()` (returning `IDisposable`) and `importVSCodeTheme()` with a single `previewVSCodeTheme()` that returns `IThemePreviewResult`
- `IThemePreviewResult` exposes:
  - `apply()` — permanently imports the theme (copies extension, installs from local)
  - `reset()` — uninstalls the temporarily installed preview extension
- Preview result is cached so repeated calls reuse the same install
- Removed `importVSCodeTheme()` from the public API

### Walkthrough fixes
- Call `reset()` when user switches from VS Code theme to a built-in theme card (previously the temp extension was left installed)
- Use `apply()` on "Continue" instead of the old `importVSCodeTheme()`
- Remove "Happy Agentic Coding!" tagline during sign-in progress via direct element reference (no querySelector)