### PR TITLE
Fix listener leak when rerendering title file widgets in chat content parts

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatSubagentContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatSubagentContentPart.ts
@@ -132,6 +132,7 @@ export class ChatSubagentContentPart extends ChatCollapsibleContentPart implemen
 	private titleShimmerSpan: HTMLElement | undefined;
 	private titleDetailContainer: HTMLElement | undefined;
 	private readonly _titleDetailRendered = this._register(new MutableDisposable<IRenderedMarkdown>());
+	private readonly _titleFileWidgetStore = this._register(new DisposableStore());
 
 	/**
 	 * Check if a tool invocation is the parent subagent tool (the tool that spawns a subagent).
@@ -517,6 +518,7 @@ export class ChatSubagentContentPart extends ChatCollapsibleContentPart implemen
 
 		// Dispose previous detail rendering
 		this._titleDetailRendered.clear();
+		this._titleFileWidgetStore.clear();
 
 		if (!toolCallText) {
 			if (this.titleDetailContainer) {
@@ -526,7 +528,7 @@ export class ChatSubagentContentPart extends ChatCollapsibleContentPart implemen
 		} else {
 			const result = this.chatContentMarkdownRenderer.render(new MarkdownString(toolCallText));
 			result.element.classList.add('collapsible-title-content', 'chat-thinking-title-detail');
-			renderFileWidgets(result.element, this.instantiationService, this.chatMarkdownAnchorService, this._store);
+			renderFileWidgets(result.element, this.instantiationService, this.chatMarkdownAnchorService, this._titleFileWidgetStore);
 			this._titleDetailRendered.value = result;
 
 			if (this.titleDetailContainer) {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatThinkingContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatThinkingContentPart.ts
@@ -281,6 +281,7 @@ export class ChatThinkingContentPart extends ChatCollapsibleContentPart implemen
 	private titleDetailContainer: HTMLElement | undefined;
 	private readonly _externalResourceWidget: ChatThinkingExternalResourceWidget;
 	private readonly _titleDetailRendered = this._register(new MutableDisposable<IRenderedMarkdown>());
+	private readonly _titleFileWidgetStore = this._register(new DisposableStore());
 	private readonly diffStatsByPartId = new Map<string, IEditSessionDiffStats>();
 	private _aggregatedDiff: IEditSessionDiffStats = { added: 0, removed: 0 };
 
@@ -2087,10 +2088,11 @@ ${this.hookCount > 0 ? `EXAMPLES WITH BLOCKED CONTENT (from hooks):
 
 		// Dispose previous detail rendering
 		this._titleDetailRendered.clear();
+		this._titleFileWidgetStore.clear();
 
 		const result = this.chatContentMarkdownRenderer.render(new MarkdownString(title));
 		result.element.classList.add('collapsible-title-content', 'chat-thinking-title-detail');
-		renderFileWidgets(result.element, this.instantiationService, this.chatMarkdownAnchorService, this._store);
+		renderFileWidgets(result.element, this.instantiationService, this.chatMarkdownAnchorService, this._titleFileWidgetStore);
 		this._titleDetailRendered.value = result;
 
 		if (this.titleDetailContainer) {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatToolInputOutputContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatToolInputOutputContentPart.ts
@@ -7,7 +7,7 @@ import * as dom from '../../../../../../base/browser/dom.js';
 import { ButtonWithIcon } from '../../../../../../base/browser/ui/button/button.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { IMarkdownString } from '../../../../../../base/common/htmlContent.js';
-import { Disposable } from '../../../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore } from '../../../../../../base/common/lifecycle.js';
 import { autorun, ISettableObservable, observableValue } from '../../../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { URI } from '../../../../../../base/common/uri.js';
@@ -62,6 +62,8 @@ export interface IChatCollapsibleOutputData {
 export class ChatCollapsibleInputOutputContentPart extends Disposable {
 	private readonly _editorReferences: IDisposableReference<CodeBlockPart>[] = [];
 	private readonly _titlePart: ChatQueryTitlePart;
+	private readonly _titleFileWidgetStore = this._register(new DisposableStore());
+	private readonly _titleElement: HTMLElement;
 	private _outputSubPart: ChatToolOutputContentSubPart | undefined;
 	public readonly domNode: HTMLElement;
 	private _contentInitialized = false;
@@ -73,6 +75,7 @@ export class ChatCollapsibleInputOutputContentPart extends Disposable {
 
 	public set title(s: string | IMarkdownString) {
 		this._titlePart.title = s;
+		this.renderTitleWidgets();
 	}
 
 	public get title(): string | IMarkdownString {
@@ -106,6 +109,7 @@ export class ChatCollapsibleInputOutputContentPart extends Disposable {
 		const container = dom.h('.chat-confirmation-widget-container');
 		const titleEl = dom.h('.chat-confirmation-widget-title-inner');
 		const elements = dom.h('.chat-confirmation-widget');
+		this._titleElement = titleEl.root;
 		this.domNode = container.root;
 		container.root.appendChild(elements.root);
 
@@ -115,7 +119,7 @@ export class ChatCollapsibleInputOutputContentPart extends Disposable {
 			title,
 			subtitle,
 		));
-		renderFileWidgets(titleEl.root, this._instantiationService, this.chatMarkdownAnchorService, this._store);
+		this.renderTitleWidgets();
 		const spacer = document.createElement('span');
 		spacer.style.flexGrow = '1';
 
@@ -185,9 +189,14 @@ export class ChatCollapsibleInputOutputContentPart extends Disposable {
 			group.classList.add('chat-collapsible-top-level-resource-group');
 			container.root.appendChild(group);
 			this._register(autorun(r => {
-				group.style.display = expanded.read(r) ? 'none' : '';
-			}));
+			group.style.display = expanded.read(r) ? 'none' : '';
+		}));
 		}
+	}
+
+	private renderTitleWidgets(): void {
+		this._titleFileWidgetStore.clear();
+		renderFileWidgets(this._titleElement, this._instantiationService, this.chatMarkdownAnchorService, this._titleFileWidgetStore);
 	}
 
 	private createMessageContents() {

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatToolInputOutputContentPart.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatToolInputOutputContentPart.test.ts
@@ -1,0 +1,75 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { mainWindow } from '../../../../../../../base/browser/window.js';
+import { Event } from '../../../../../../../base/common/event.js';
+import { MarkdownString } from '../../../../../../../base/common/htmlContent.js';
+import { observableValue } from '../../../../../../../base/common/observable.js';
+import { URI } from '../../../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
+import { IChatMarkdownAnchorService } from '../../../../browser/widget/chatContentParts/chatMarkdownAnchorService.js';
+import { IChatContentPartRenderContext } from '../../../../browser/widget/chatContentParts/chatContentParts.js';
+import { ChatCollapsibleInputOutputContentPart } from '../../../../browser/widget/chatContentParts/chatToolInputOutputContentPart.js';
+import { workbenchInstantiationService } from '../../../../../../test/browser/workbenchTestServices.js';
+
+suite('ChatCollapsibleInputOutputContentPart', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('disposes title file widgets before rerendering title widgets', () => {
+		const instantiationService = workbenchInstantiationService(undefined, store);
+		let registerCalls = 0;
+		let disposeCalls = 0;
+
+		instantiationService.stub(IChatMarkdownAnchorService, {
+			_serviceBrand: undefined,
+			lastFocusedAnchor: undefined,
+			register: () => {
+				registerCalls++;
+				return {
+					dispose: () => {
+						disposeCalls++;
+					}
+				};
+			}
+		});
+
+		const context: IChatContentPartRenderContext = {
+			element: { sessionResource: URI.parse('vscode-chat://session/test') } as IChatContentPartRenderContext['element'],
+			elementIndex: 0,
+			container: mainWindow.document.createElement('div'),
+			content: [],
+			contentIndex: 0,
+			editorPool: {} as IChatContentPartRenderContext['editorPool'],
+			codeBlockStartIndex: 0,
+			treeStartIndex: 0,
+			diffEditorPool: {} as IChatContentPartRenderContext['diffEditorPool'],
+			currentWidth: observableValue('test', 300),
+			onDidChangeVisibility: Event.None,
+			inlineTextModels: {} as IChatContentPartRenderContext['inlineTextModels'],
+		};
+
+		const part = store.add(instantiationService.createInstance(
+			ChatCollapsibleInputOutputContentPart,
+			new MarkdownString('Reading [test.txt](file:///project/test.txt?vscodeLinkType=file)', { supportThemeIcons: true, isTrusted: { enabledCommands: [] } }),
+			undefined,
+			undefined,
+			context,
+			{ kind: 'code', data: '{}', languageId: 'json', codeBlockIndex: 0, ownerMarkdownPartId: 'test', options: {} },
+			undefined,
+			false,
+			false,
+			false,
+		));
+
+		assert.strictEqual(registerCalls, 1);
+		assert.strictEqual(disposeCalls, 0);
+
+		part.title = new MarkdownString('Reading [other.txt](file:///project/other.txt?vscodeLinkType=file)', { supportThemeIcons: true, isTrusted: { enabledCommands: [] } });
+
+		assert.strictEqual(registerCalls, 2);
+		assert.strictEqual(disposeCalls, 1);
+	});
+});


### PR DESCRIPTION
## Summary

When a chat content part's title changes and contains file links, `renderFileWidgets()` is called to render file link widgets. Previously, widgets registered during the previous render were not cleaned up before adding new ones, causing a listener leak that accumulated over time.

## Changes

- **ChatCollapsibleInputOutputContentPart**: Added `_titleFileWidgetStore` (a `DisposableStore`) that is cleared and repopulated when the title setter is called, ensuring previous widgets are properly disposed.

- **ChatSubagentContentPart**: Applied the same fix - added `_titleFileWidgetStore` to track title widgets and clear them before re-rendering.

- **Test**: Added regression test that verifies the fix by counting `register` and `dispose` calls on the markdown anchor service.

## Testing

- Added unit test that creates a `ChatCollapsibleInputOutputContentPart` with a title containing a file link, updates the title, and verifies that the previous widget's `dispose()` was called when the new title is set.

## Related Issues

- Follows the same pattern as the IPC server listener leak fix (#293913) and terminal execute strategy DisposableStore leak fix (#313369)