### PR TITLE
sessions: skip slash command expansion in agent host sessions

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/newChatInSessionViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInSessionViewPane.ts
@@ -28,6 +28,7 @@ import { IViewDescriptorService } from '../../../../workbench/common/views.js';
 import { IViewPaneOptions, ViewPane } from '../../../../workbench/browser/parts/views/viewPane.js';
 import { NewChatInputWidget } from './newChatInput.js';
 import { IChatRequestVariableEntry } from '../../../../workbench/contrib/chat/common/attachments/chatVariableEntries.js';
+import { ANY_AGENT_HOST_PROVIDER_RE } from '../../../common/agentHostSessionsProvider.js';
 
 // #region --- New Chat In Session Widget ---
 
@@ -65,6 +66,10 @@ class NewChatInSessionWidget extends Disposable {
 			loading,
 			minEditorHeight: 64,
 			placeholder: localize('newChatInSessionPlaceholder', 'Ask a follow-up question or start a new topic within this session...'),
+			shouldExpandPromptSlashCommand: () => {
+				const providerId = this.sessionsManagementService.activeSession.get()?.providerId;
+				return !providerId || !ANY_AGENT_HOST_PROVIDER_RE.test(providerId);
+			},
 		}));
 	}
 

--- a/src/vs/sessions/contrib/chat/browser/newChatInput.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInput.ts
@@ -143,6 +143,13 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 			loading: IObservable<boolean>;
 			minEditorHeight?: number;
 			placeholder?: string;
+			/**
+			 * If provided and returns `false`, prompt/skill slash commands are sent
+			 * verbatim instead of being expanded into a CLI-friendly markdown
+			 * reference. Agent host sessions support slash commands natively, so
+			 * the expansion should be skipped for them.
+			 */
+			shouldExpandPromptSlashCommand?: () => boolean;
 		},
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IModelService private readonly modelService: IModelService,
@@ -500,10 +507,13 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 			return;
 		}
 
-		// Expand prompt/skill slash commands into a CLI-friendly reference
-		const expanded = this._slashCommandHandler?.tryExpandPromptSlashCommand(query);
-		if (expanded) {
-			query = expanded;
+		// Expand prompt/skill slash commands into a CLI-friendly reference,
+		// unless the target session natively supports slash commands.
+		if (this.options.shouldExpandPromptSlashCommand?.() ?? true) {
+			const expanded = this._slashCommandHandler?.tryExpandPromptSlashCommand(query);
+			if (expanded) {
+				query = expanded;
+			}
 		}
 
 		const attachedContext = this._contextAttachments.attachments.length > 0

--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -73,7 +73,10 @@ class NewChatWidget extends Disposable {
 			canSendRequest,
 			loading,
 			shouldExpandPromptSlashCommand: () => {
-				const providerId = this._workspacePicker.selectedProject?.providerId;
+				// Mirror what `_send()` does: it sends to the current active
+				// session, which can lag behind the workspace picker selection
+				// while trust approval or session-type discovery is in flight.
+				const providerId = this.sessionsManagementService.activeSession.get()?.providerId;
 				return !providerId || !ANY_AGENT_HOST_PROVIDER_RE.test(providerId);
 			},
 		}));

--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -29,6 +29,7 @@ import { WorkspacePicker, IWorkspaceSelection } from './sessionWorkspacePicker.j
 import { ScopedWorkspacePicker } from './scopedWorkspacePicker.js';
 import { NewChatInputWidget } from './newChatInput.js';
 import { IChatRequestVariableEntry } from '../../../../workbench/contrib/chat/common/attachments/chatVariableEntries.js';
+import { ANY_AGENT_HOST_PROVIDER_RE } from '../../../common/agentHostSessionsProvider.js';
 
 // #region --- New Chat Widget ---
 
@@ -71,6 +72,10 @@ class NewChatWidget extends Disposable {
 			sendRequest: async (text: string, attachedContext?: IChatRequestVariableEntry[]) => this._send(text, attachedContext),
 			canSendRequest,
 			loading,
+			shouldExpandPromptSlashCommand: () => {
+				const providerId = this._workspacePicker.selectedProject?.providerId;
+				return !providerId || !ANY_AGENT_HOST_PROVIDER_RE.test(providerId);
+			},
 		}));
 
 		this._register(this._workspacePicker.onDidSelectWorkspace(async workspace => {


### PR DESCRIPTION
Agent host sessions support prompt/skill slash commands natively, so they shouldn't get the CLI-friendly markdown reference (`Use the skill located at [name](file://...)`) appended to the message. That expansion was originally added to help non-native agents (e.g. Copilot CLI) locate the file.

This change makes the expansion opt-in via a new `shouldExpandPromptSlashCommand` callback on `NewChatInputWidget`. Both placements of that widget — `NewChatViewPane` (the new-session page) and `NewChatInSessionViewPane` (the in-session sub-chat composer) — now check the target provider against `ANY_AGENT_HOST_PROVIDER_RE` and skip expansion for agent hosts. Copilot CLI / other providers are unchanged.

(Written by Copilot)
