### PR TITLE
Preserve reasoning_content for BYOK DeepSeek thinking mode

### DIFF
--- a/extensions/copilot/src/extension/byok/node/openAIEndpoint.ts
+++ b/extensions/copilot/src/extension/byok/node/openAIEndpoint.ts
@@ -257,9 +257,16 @@ export class OpenAIEndpoint extends ChatEndpoint {
 		} else {
 			// Handle CAPI: provide callback for thinking data processing
 			const callback: RawMessageConversionCallback = (out, data) => {
-				if (data && data.id) {
+				if (!data) {
+					return;
+				}
+				const text = Array.isArray(data.text) ? data.text.join('') : data.text;
+				if (data.id) {
 					out.cot_id = data.id;
-					out.cot_summary = Array.isArray(data.text) ? data.text.join('') : data.text;
+					out.cot_summary = text;
+				}
+				if (text) {
+					out.reasoning_content = text;
 				}
 			};
 			const body = createCapiRequestBody(options, this.model, callback);

--- a/extensions/copilot/src/extension/byok/node/test/openAIEndpoint.spec.ts
+++ b/extensions/copilot/src/extension/byok/node/test/openAIEndpoint.spec.ts
@@ -15,17 +15,17 @@ import { createExtensionUnitTestingServices } from '../../../test/node/services'
 import { OpenAIEndpoint } from '../openAIEndpoint';
 
 // Test fixtures for thinking content
-const createThinkingMessage = (thinkingId: string, thinkingText: string): Raw.ChatMessage => ({
+const createThinkingMessage = (thinkingId: string, thinkingText: string): Raw.ChatMessage =>
+	createThinkingMessageRaw({ id: thinkingId, text: thinkingText });
+
+const createThinkingMessageRaw = (thinking: { id?: string; text?: string }): Raw.ChatMessage => ({
 	role: Raw.ChatRole.Assistant,
 	content: [
 		{
 			type: Raw.ChatCompletionContentPartKind.Opaque,
 			value: {
 				type: 'thinking',
-				thinking: {
-					id: thinkingId,
-					text: thinkingText
-				}
+				thinking
 			}
 		}
 	]
@@ -86,7 +86,7 @@ describe('OpenAIEndpoint - Reasoning Properties', () => {
 	});
 
 	describe('CAPI mode (useResponsesApi = false)', () => {
-		it('should set cot_id and cot_summary properties when processing thinking content', () => {
+		it('should set cot_id, cot_summary and reasoning_content when processing thinking content', () => {
 			const endpoint = instaService.createInstance(OpenAIEndpoint,
 				{
 					...modelMetadata,
@@ -105,6 +105,48 @@ describe('OpenAIEndpoint - Reasoning Properties', () => {
 			expect(messages).toHaveLength(1);
 			expect(messages[0].cot_id).toBe('test-thinking-123');
 			expect(messages[0].cot_summary).toBe('this is my reasoning');
+			expect(messages[0].reasoning_content).toBe('this is my reasoning');
+		});
+
+		it('should set reasoning_content but not cot_id/cot_summary when thinking has text but no id (DeepSeek-style)', () => {
+			const endpoint = instaService.createInstance(OpenAIEndpoint,
+				{
+					...modelMetadata,
+					supported_endpoints: [ModelSupportedEndpoint.ChatCompletions]
+				},
+				'test-api-key',
+				'https://api.openai.com/v1/chat/completions');
+
+			const thinkingMessage = createThinkingMessageRaw({ text: 'reasoning without id' });
+			const options = createTestOptions([thinkingMessage]);
+
+			const body = endpoint.createRequestBody(options);
+
+			const messages = body.messages as any[];
+			expect(messages).toHaveLength(1);
+			expect(messages[0].reasoning_content).toBe('reasoning without id');
+			expect(messages[0].cot_id).toBeUndefined();
+			expect(messages[0].cot_summary).toBeUndefined();
+		});
+
+		it('should not set reasoning_content when thinking text is empty', () => {
+			const endpoint = instaService.createInstance(OpenAIEndpoint,
+				{
+					...modelMetadata,
+					supported_endpoints: [ModelSupportedEndpoint.ChatCompletions]
+				},
+				'test-api-key',
+				'https://api.openai.com/v1/chat/completions');
+
+			const thinkingMessage = createThinkingMessage('id-only', '');
+			const options = createTestOptions([thinkingMessage]);
+
+			const body = endpoint.createRequestBody(options);
+
+			const messages = body.messages as any[];
+			expect(messages).toHaveLength(1);
+			expect(messages[0].cot_id).toBe('id-only');
+			expect(messages[0].reasoning_content).toBeUndefined();
 		});
 
 		it('should handle multiple messages with thinking content', () => {

--- a/extensions/copilot/src/extension/conversation/vscode-node/languageModelAccessPrompt.tsx
+++ b/extensions/copilot/src/extension/conversation/vscode-node/languageModelAccessPrompt.tsx
@@ -10,6 +10,7 @@ import { LanguageModelTextPart } from 'vscode';
 import { CustomDataPartMimeTypes } from '../../../platform/endpoint/common/endpointTypes';
 import { decodeStatefulMarker, StatefulMarkerContainer } from '../../../platform/endpoint/common/statefulMarkerContainer';
 import { ThinkingDataContainer } from '../../../platform/endpoint/common/thinkingDataContainer';
+import type { ThinkingData } from '../../../platform/thinking/common/thinking';
 import { SafetyRules } from '../../prompts/node/base/safetyRules';
 import { EditorIntegrationRules } from '../../prompts/node/panel/editorIntegrationRules';
 import { imageDataPartToTSX, ToolResult } from '../../prompts/node/panel/toolCalling';
@@ -41,10 +42,29 @@ export class LanguageModelAccessPrompt extends PromptElement<Props> {
 				// There should only be one string part per message
 				const content = filteredContent.find(part => part instanceof LanguageModelTextPart);
 				const toolCalls = filteredContent.filter(part => part instanceof vscode.LanguageModelToolCallPart);
-				const thinking = filteredContent.find(part => part instanceof vscode.LanguageModelThinkingPart);
+				const thinkingParts = filteredContent.filter((part): part is vscode.LanguageModelThinkingPart => part instanceof vscode.LanguageModelThinkingPart);
+				// Concatenate text across parts; id/metadata typically arrive in the final part, so last-wins.
+				let aggregatedThinking: ThinkingData | undefined;
+				if (thinkingParts.length > 0) {
+					let id = '';
+					let text = '';
+					let metadata: { readonly [key: string]: any } | undefined;
+					for (const part of thinkingParts) {
+						if (part.id) {
+							id = part.id;
+						}
+						text += Array.isArray(part.value) ? part.value.join('') : part.value;
+						if (part.metadata) {
+							metadata = part.metadata;
+						}
+					}
+					if (id || text || metadata) {
+						aggregatedThinking = { id, text, metadata: metadata ? { ...metadata } : undefined };
+					}
+				}
 
 				const statefulMarkerElement = statefulMarker && <StatefulMarkerContainer statefulMarker={statefulMarker} />;
-				const thinkingElement = thinking && thinking.id && <ThinkingDataContainer thinking={{ id: thinking.id, text: thinking.value, metadata: thinking.metadata }} />;
+				const thinkingElement = aggregatedThinking && <ThinkingDataContainer thinking={aggregatedThinking} />;
 				chatMessages.push(<AssistantMessage name={message.name} toolCalls={toolCalls.map(tc => ({ id: tc.callId, type: 'function', function: { name: tc.name, arguments: JSON.stringify(tc.input) } }))}>{statefulMarkerElement}{content?.value}{thinkingElement}</AssistantMessage>);
 			} else if (message.role === vscode.LanguageModelChatMessageRole.User) {
 				for (const part of message.content) {

--- a/extensions/copilot/src/platform/endpoint/test/node/stream.sseProcessor.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/test/node/stream.sseProcessor.spec.ts
@@ -648,6 +648,46 @@ data: [DONE]
 		expect(metadata).toBeUndefined();
 	});
 
+	test('stream containing DeepSeek reasoning_content', async function () {
+		// DeepSeek thinking-mode streams emit reasoning chunks via `delta.reasoning_content`
+		// without an id/signature. See https://api-docs.deepseek.com/guides/thinking_mode
+		const response = [
+			`data: {"choices":[{"delta":{"role":"assistant","content":null,"reasoning_content":"Let "},"index":0}],"created":1751057335,"id":"chatcmpl-deepseek-1","model":"deepseek-chat","object":"chat.completion.chunk"}\n`,
+			`data: {"choices":[{"delta":{"reasoning_content":"me "},"index":0}],"created":1751057335,"id":"chatcmpl-deepseek-1","model":"deepseek-chat","object":"chat.completion.chunk"}\n`,
+			`data: {"choices":[{"delta":{"reasoning_content":"think."},"index":0}],"created":1751057335,"id":"chatcmpl-deepseek-1","model":"deepseek-chat","object":"chat.completion.chunk"}\n`,
+			`data: {"choices":[{"delta":{"content":"Hello"},"index":0}],"created":1751057336,"id":"chatcmpl-deepseek-1","model":"deepseek-chat","object":"chat.completion.chunk"}\n`,
+			`data: {"choices":[{"delta":{},"finish_reason":"stop","index":0}],"created":1751057336,"id":"chatcmpl-deepseek-1","model":"deepseek-chat","object":"chat.completion.chunk"}\n`,
+			`data: [DONE]\n`,
+		];
+		const processor = await SSEProcessor.create(
+			logService,
+			telemetryService,
+			1,
+			createFakeStreamResponse(response),
+		);
+
+		let thinkingText: string | undefined = undefined;
+		let thinkingId: string | undefined = undefined;
+
+		await getAll(processor.processSSE((text: string, index: number, delta: IResponseDelta) => {
+			if (delta.thinking && !isEncryptedThinkingDelta(delta.thinking)) {
+				if (delta.thinking.text) {
+					if (thinkingText === undefined) {
+						thinkingText = '';
+					}
+					thinkingText += Array.isArray(delta.thinking.text) ? delta.thinking.text.join('') : delta.thinking.text;
+				}
+				if (delta.thinking.id) {
+					thinkingId = delta.thinking.id;
+				}
+			}
+			return Promise.resolve(undefined);
+		}));
+
+		expect(thinkingText).toBe('Let me think.');
+		expect(thinkingId).toBeUndefined();
+	});
+
 	suite('real world snapshots', () => {
 
 		async function processResponse(response: string[], expectedNumChoices = 1) {

--- a/extensions/copilot/src/platform/thinking/common/thinking.ts
+++ b/extensions/copilot/src/platform/thinking/common/thinking.ts
@@ -11,6 +11,9 @@ export interface ThinkingDataInMessage {
 	// Copilot API fields for Completions
 	reasoning_opaque?: string;
 	reasoning_text?: string;
+
+	// DeepSeek thinking-mode field
+	reasoning_content?: string;
 }
 
 export interface RawThinkingDelta {
@@ -25,6 +28,9 @@ export interface RawThinkingDelta {
 	// Anthropic fields
 	thinking?: string;
 	signature?: string;
+
+	// DeepSeek thinking-mode field
+	reasoning_content?: string;
 }
 
 export type ThinkingDelta = {

--- a/extensions/copilot/src/platform/thinking/common/thinkingUtils.ts
+++ b/extensions/copilot/src/platform/thinking/common/thinkingUtils.ts
@@ -15,6 +15,9 @@ function getThinkingDeltaText(thinking: RawThinkingDelta | undefined): string | 
 	if (thinking.reasoning_text) {
 		return thinking.reasoning_text;
 	}
+	if (thinking.reasoning_content) {
+		return thinking.reasoning_content;
+	}
 	if (thinking.thinking) {
 		return thinking.thinking;
 	}


### PR DESCRIPTION
## Problem
DeepSeek thinking-mode endpoints reject follow-up tool-call rounds with:

> "The reasoning_content in the thinking mode must be passed back to the API."

[DeepSeek thinking_mode](https://api-docs.deepseek.com/guides/thinking_mode)

The previous assistant turn's reasoning was being dropped between rounds.

Related reports: #312746, #313904.

## Cause
Two issues on the BYOK CAPI path:

1. `LanguageModelAccessPrompt` only kept the **first** `LanguageModelThinkingPart`
   in an assistant turn. Streaming providers emit reasoning across multiple
   parts and the `id` typically arrives in the final part (per
   `vscode.proposed.languageModelThinkingPart.d.ts`), so first-wins drops both
   trailing text and the id.
2. `OpenAIEndpoint.createRequestBody` only set `cot_id` / `cot_summary`
   (Copilot CAPI fields) and never emitted DeepSeek's `reasoning_content`.

## Fix
- Aggregate all `ThinkingPart`s in an assistant message: concatenate `text`,
  last-wins for `id` / `metadata`.
- Emit `reasoning_content` whenever the thinking callback receives non-empty
  text. Same assumption already made for `cot_id` / `cot_summary`: unknown
  JSON fields are tolerated by OpenAI-compatible endpoints.
- Plumb `reasoning_content` through the inbound SSE delta types
  (`RawThinkingDelta`, `getThinkingDeltaText`) so DeepSeek's reasoning chunks
  surface as `delta.thinking.text`.

## Tests
- New unit test in `stream.sseProcessor.spec.ts` covering DeepSeek-style
  `reasoning_content` SSE chunks.
- Manually verified against a DeepSeek thinking-mode endpoint with a
  multi-round tool-call conversation; the 400 no longer occurs.

## Known limitation
A single assistant turn may contain multiple independent thinking blocks
(e.g. Anthropic interleaved thinking around tool calls). They are currently
merged into one blob, which is correct for `reasoning_content` echo but loses
per-block signatures. Splitting requires a structural change to `ThinkingData`
and is out of scope.