### PR TITLE
Use DI-aware PromptRenderer in sendInvokedToolTelemetry

### DIFF
--- a/extensions/copilot/src/extension/prompts/node/panel/chatVariables.tsx
+++ b/extensions/copilot/src/extension/prompts/node/panel/chatVariables.tsx
@@ -443,7 +443,7 @@ export class ChatToolReferences extends PromptElement<ChatToolCallProps, void> {
 			const name = toolReference.range ? this.props.promptContext.query.slice(toolReference.range[0], toolReference.range[1]) : undefined;
 			try {
 				const result = await this.toolsService.invokeToolWithEndpoint(tool.name, { input: { ...toolArgs, ...internalToolArgs }, toolInvocationToken: tools.toolInvocationToken }, this.promptEndpoint, token || CancellationToken.None);
-				sendInvokedToolTelemetry(this.promptEndpoint.acquireTokenizer(), this.telemetryService, tool.name, result);
+				sendInvokedToolTelemetry(this.instantiationService, this.promptEndpoint, this.telemetryService, tool.name, result);
 				results.push({ name, value: result });
 			} catch (err) {
 				const errResult = toolCallErrorToResult(err);

--- a/extensions/copilot/src/extension/prompts/node/panel/test/toolCalling.spec.ts
+++ b/extensions/copilot/src/extension/prompts/node/panel/test/toolCalling.spec.ts
@@ -611,16 +611,20 @@ describe('ChatToolCalls (toolCalling.tsx)', () => {
 			LanguageModelDataPart.image(imageData, 'image/png'),
 		]);
 
-		// This should not throw or reject — the endpoint and all services must be properly injected
-		const renderPromise = sendInvokedToolTelemetry(
-			instantiationService,
-			endpoint as any, // endpoint satisfies IChatEndpoint
-			telemetryService,
-			'testTool',
-			toolResult,
-		);
+		// This should not throw — the endpoint and all services must be properly injected so that
+		// onImage() can read this.endpoint.supportsVision without crashing.
+		// The function is fire-and-forget (returns undefined), so we just verify it doesn't throw.
+		expect(() => {
+			sendInvokedToolTelemetry(
+				instantiationService,
+				endpoint as any, // endpoint satisfies IChatEndpoint
+				telemetryService,
+				'testTool',
+				toolResult,
+			);
+		}).not.toThrow();
 
-		// The render is fire-and-forget but should complete without error
-		await expect(renderPromise).resolves.toBeUndefined();
+		// Give async rendering a moment to complete without unhandled rejection
+		await new Promise(resolve => setTimeout(resolve, 100));
 	});
 });

--- a/extensions/copilot/src/extension/prompts/node/panel/test/toolCalling.spec.ts
+++ b/extensions/copilot/src/extension/prompts/node/panel/test/toolCalling.spec.ts
@@ -13,6 +13,7 @@ import { CancellationToken } from '../../../../../util/vs/base/common/cancellati
 import { Event } from '../../../../../util/vs/base/common/event';
 import { constObservable } from '../../../../../util/vs/base/common/observable';
 import { IInstantiationService } from '../../../../../util/vs/platform/instantiation/common/instantiation';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry';
 import { LanguageModelDataPart, LanguageModelTextPart, LanguageModelToolResult } from '../../../../../vscodeTypes';
 import { ChatVariablesCollection } from '../../../../prompt/common/chatVariablesCollection';
 import type { Conversation } from '../../../../prompt/common/conversation';
@@ -585,5 +586,41 @@ describe('ChatToolCalls (toolCalling.tsx)', () => {
 		// Both images exceed the 2.5MB shared budget and should be replaced with placeholders
 		expect(serialized).toContain('context image budget exceeded');
 		expect(serialized).not.toContain('image_url');
+	});
+
+	test('sendInvokedToolTelemetry handles tool results with images without crashing', async () => {
+		// Regression test for issue #312813: ensure sendInvokedToolTelemetry uses DI to instantiate
+		// PrimitiveToolResult so that @IPromptEndpoint is properly injected when rendering images.
+		// Previously, it used raw BasePromptRenderer which bypassed DI, causing 'Cannot read properties
+		// of undefined (reading "supportsVision")' when a tool result contained an image.
+
+		const testingServiceCollection = createExtensionUnitTestingServices();
+		const accessor = testingServiceCollection.createTestingAccessor();
+		const instantiationService = accessor.get(IInstantiationService);
+		const endpointProvider = accessor.get(IEndpointProvider);
+		const endpoint = await endpointProvider.getChatEndpoint('copilot-base');
+		const telemetryService = accessor.get(ITelemetryService);
+
+		// Import the function we're testing
+		const { sendInvokedToolTelemetry } = await import('../toolCalling');
+
+		// Create a tool result with an image
+		const imageData = new Uint8Array(1024);
+		const toolResult = new LanguageModelToolResult([
+			new LanguageModelTextPart('Tool executed successfully'),
+			LanguageModelDataPart.image(imageData, 'image/png'),
+		]);
+
+		// This should not throw or reject — the endpoint and all services must be properly injected
+		const renderPromise = sendInvokedToolTelemetry(
+			instantiationService,
+			endpoint as any, // endpoint satisfies IChatEndpoint
+			telemetryService,
+			'testTool',
+			toolResult,
+		);
+
+		// The render is fire-and-forget but should complete without error
+		await expect(renderPromise).resolves.toBeUndefined();
 	});
 });

--- a/extensions/copilot/src/extension/prompts/node/panel/test/toolCalling.spec.ts
+++ b/extensions/copilot/src/extension/prompts/node/panel/test/toolCalling.spec.ts
@@ -600,6 +600,10 @@ describe('ChatToolCalls (toolCalling.tsx)', () => {
 		const endpointProvider = accessor.get(IEndpointProvider);
 		const endpoint = await endpointProvider.getChatEndpoint('copilot-base');
 		const telemetryService = accessor.get(ITelemetryService);
+		const configService = accessor.get(IConfigurationService);
+
+		// Disable image uploads in test environment to avoid auth requirement
+		await configService.setConfig(ConfigKey.EnableChatImageUpload, false);
 
 		// Import the function we're testing
 		const { sendInvokedToolTelemetry } = await import('../toolCalling');

--- a/extensions/copilot/src/extension/prompts/node/panel/toolCalling.tsx
+++ b/extensions/copilot/src/extension/prompts/node/panel/toolCalling.tsx
@@ -485,9 +485,16 @@ class ToolResultElement extends PromptElement<IToolResultElementActualProps & Ba
 }
 
 export function sendInvokedToolTelemetry(instantiationService: IInstantiationService, endpoint: IChatEndpoint, telemetry: ITelemetryService, toolName: string, toolResult: LanguageModelToolResult2) {
+	// Override the token budget to Infinity for telemetry counting to avoid truncation,
+	// matching the prior behavior with modelMaxPromptTokens: Infinity
+	const endpointWithUnlimitedBudget: IChatEndpoint = {
+		...endpoint,
+		modelMaxPromptTokens: Infinity,
+	};
+
 	PromptRenderer.create(
 		instantiationService,
-		endpoint,
+		endpointWithUnlimitedBudget,
 		class extends PromptElement {
 			render() {
 				return <UserMessage><PrimitiveToolResult content={toolResult.content} /></UserMessage>;

--- a/extensions/copilot/src/extension/prompts/node/panel/toolCalling.tsx
+++ b/extensions/copilot/src/extension/prompts/node/panel/toolCalling.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { RequestMetadata, RequestType } from '@vscode/copilot-api';
-import { AssistantMessage, BasePromptElementProps, PromptRenderer as BasePromptRenderer, Chunk, IfEmpty, Image, JSONTree, PromptElement, PromptElementProps, PromptMetadata, PromptPiece, PromptSizing, TokenLimit, ToolCall, ToolMessage, useKeepWith, UserMessage } from '@vscode/prompt-tsx';
+import { AssistantMessage, BasePromptElementProps, Chunk, IfEmpty, Image, JSONTree, PromptElement, PromptElementProps, PromptMetadata, PromptPiece, PromptSizing, TokenLimit, ToolCall, ToolMessage, useKeepWith, UserMessage } from '@vscode/prompt-tsx';
 import type { ChatParticipantToolToken, LanguageModelToolInvocationOptions, LanguageModelToolResult2, LanguageModelToolTokenizationOptions } from 'vscode';
 import { IAuthenticationService } from '../../../../platform/authentication/common/authentication';
 import { IChatHookService, IPreToolUseHookResult } from '../../../../platform/chat/common/chatHookService';
@@ -21,11 +21,11 @@ import { IFileSystemService } from '../../../../platform/filesystem/common/fileS
 import { IIgnoreService } from '../../../../platform/ignore/common/ignoreService';
 import { IImageService } from '../../../../platform/image/common/imageService';
 import { ILogService } from '../../../../platform/log/common/logService';
+import { IChatEndpoint } from '../../../../platform/networking/common/networking';
 import { IOTelService } from '../../../../platform/otel/common/otelService';
 import { IExperimentationService } from '../../../../platform/telemetry/common/nullExperimentationService';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry';
 import { toErrorMessage } from '../../../../util/common/errorMessage';
-import { ITokenizer } from '../../../../util/common/tokenizer';
 import { CancellationToken } from '../../../../util/vs/base/common/cancellation';
 import { isCancellationError } from '../../../../util/vs/base/common/errors';
 import { getExtensionForMimeType } from '../../../../util/vs/base/common/mime';
@@ -41,7 +41,7 @@ import { ToolName } from '../../../tools/common/toolNames';
 import { CopilotToolMode } from '../../../tools/common/toolsRegistry';
 import { IToolsService } from '../../../tools/common/toolsService';
 import { IChatDiskSessionResources } from '../../common/chatDiskSessionResources';
-import { IPromptEndpoint } from '../base/promptRenderer';
+import { IPromptEndpoint, PromptRenderer } from '../base/promptRenderer';
 import { Tag } from '../base/tag';
 
 export interface ChatToolCallsProps extends BasePromptElementProps {
@@ -222,6 +222,7 @@ function buildToolResultElement(accessor: ServicesAccessor, props: ToolResultOpt
 	const sessionTranscriptService = accessor.get(ISessionTranscriptService);
 	const chatHookService = accessor.get(IChatHookService);
 	const otelService = accessor.get(IOTelService);
+	const instantiationService = accessor.get(IInstantiationService);
 	const tool = toolsService.getTool(props.toolCall.name);
 
 	async function getToolResult(sizing: PromptSizing) {
@@ -311,7 +312,7 @@ function buildToolResultElement(accessor: ServicesAccessor, props: ToolResultOpt
 					}
 
 					toolResult = await toolsService.invokeToolWithEndpoint(props.toolCall.name, invocationOptions, promptEndpoint, props.token);
-					sendInvokedToolTelemetry(promptEndpoint.acquireTokenizer(), telemetryService, props.toolCall.name, toolResult);
+					sendInvokedToolTelemetry(instantiationService, promptEndpoint, telemetryService, props.toolCall.name, toolResult);
 
 					// Run hook context handling after tool execution
 					appendHookContext(toolResult, hookResult, chatHookService, props, inputObj, promptContext);
@@ -483,16 +484,16 @@ class ToolResultElement extends PromptElement<IToolResultElementActualProps & Ba
 	}
 }
 
-export function sendInvokedToolTelemetry(tokenizer: ITokenizer, telemetry: ITelemetryService, toolName: string, toolResult: LanguageModelToolResult2) {
-	new BasePromptRenderer(
-		{ modelMaxPromptTokens: Infinity },
+export function sendInvokedToolTelemetry(instantiationService: IInstantiationService, endpoint: IChatEndpoint, telemetry: ITelemetryService, toolName: string, toolResult: LanguageModelToolResult2) {
+	PromptRenderer.create(
+		instantiationService,
+		endpoint,
 		class extends PromptElement {
 			render() {
 				return <UserMessage><PrimitiveToolResult content={toolResult.content} /></UserMessage>;
 			}
 		},
 		{},
-		tokenizer,
 	).render().then(({ tokenCount }) => {
 		/* __GDPR__
 			"agent.tool.responseLength" : {


### PR DESCRIPTION
Fix #312813

Use PromptRenderer.create() instead of raw BasePromptRenderer so that @IPromptEndpoint is properly injected when rendering images.

Regression: sendInvokedToolTelemetry was the only code path constructing PrimitiveToolResult via raw BasePromptRenderer, causing this.endpoint to be undefined when onImage() reads this.endpoint.supportsVision.

Changes:
- Updated sendInvokedToolTelemetry to take (instantiationService, endpoint, ...)
- Updated both callers to pass instantiationService and endpoint
- Added unit test for image content rendering without crash

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
