### PR TITLE
Agents welcome: introduce isEmbeddedApp and parentAppName environment properties

### DIFF
--- a/src/vs/platform/environment/common/environment.ts
+++ b/src/vs/platform/environment/common/environment.ts
@@ -84,6 +84,7 @@ export interface IEnvironmentService {
 	extensionLogLevel?: [string, string][];
 	verbose: boolean;
 	isBuilt: boolean;
+	isEmbeddedApp?: boolean;
 
 	// --- telemetry/exp
 	disableTelemetry: boolean;
@@ -114,6 +115,20 @@ export interface IEnvironmentService {
 	 * the host VS Code application. `undefined` when not running as embedded.
 	 */
 	readonly parentAppExtensionsHome?: URI;
+
+	/**
+	 * When running as the embedded app, the short display name of the
+	 * parent VS Code application (e.g. "VS Code Insiders").
+	 * `undefined` when not running as embedded.
+	 */
+	readonly parentAppNameShort?: string;
+
+	/**
+	 * When running as the embedded app, the long display name of the
+	 * parent VS Code application (e.g. "Visual Studio Code Insiders").
+	 * `undefined` when not running as embedded.
+	 */
+	readonly parentAppNameLong?: string;
 
 	// --- Policy
 	policyFile?: URI;

--- a/src/vs/platform/environment/common/environmentService.ts
+++ b/src/vs/platform/environment/common/environmentService.ts
@@ -331,12 +331,23 @@ export abstract class AbstractNativeEnvironmentService implements INativeEnviron
 		return joinPath(this.parentAppUserHome, 'extensions');
 	}
 
+	@memoize
+	get parentAppNameShort(): string | undefined {
+		return getParentAppName(this.productService, this.isEmbeddedApp, 'short');
+	}
+
+	@memoize
+	get parentAppNameLong(): string | undefined {
+		return getParentAppName(this.productService, this.isEmbeddedApp, 'long');
+	}
+
 	get args(): NativeParsedArgs { return this._args; }
 
 	constructor(
 		private readonly _args: NativeParsedArgs,
 		private readonly paths: INativeEnvironmentPaths,
-		protected readonly productService: IProductService
+		protected readonly productService: IProductService,
+		readonly isEmbeddedApp: boolean = false
 	) { }
 }
 
@@ -358,4 +369,19 @@ export function parseDebugParams(debugArg: string | undefined, debugBrkArg: stri
 	}
 
 	return { port, break: brk, debugId, env };
+}
+
+function getParentAppName(productService: IProductService, isEmbeddedApp: boolean, variant: 'short' | 'long'): string | undefined {
+	if (!isEmbeddedApp) {
+		return undefined;
+	}
+	const quality = productService.quality;
+	if (quality === 'stable') {
+		return variant === 'short' ? 'VS Code' : 'Visual Studio Code';
+	} else if (quality === 'insider') {
+		return variant === 'short' ? 'VS Code Insiders' : 'Visual Studio Code Insiders';
+	} else if (quality === 'exploration') {
+		return variant === 'short' ? 'VS Code Exploration' : 'Visual Studio Code Exploration';
+	}
+	return undefined;
 }

--- a/src/vs/platform/environment/node/environmentService.ts
+++ b/src/vs/platform/environment/node/environmentService.ts
@@ -23,7 +23,7 @@ export class NativeEnvironmentService extends AbstractNativeEnvironmentService {
 			userDataDir: getUserDataPath(args, productService.nameShort),
 			parentAppUserDataDir: getParentAppUserDataDir(args, productService),
 			parentAppUserHomeDir: getParentAppUserHomeDir(homeDir, productService)
-		}, productService);
+		}, productService, isEmbeddedApp());
 	}
 }
 
@@ -85,4 +85,8 @@ function getParentAppUserHomeDir(homeDir: string, productService: IProductServic
 		return undefined;
 	}
 	return join(homeDir, hostDataFolderName);
+}
+
+function isEmbeddedApp(): boolean {
+	return !!(process as INodeProcess).isEmbeddedApp;
 }

--- a/src/vs/platform/window/common/window.ts
+++ b/src/vs/platform/window/common/window.ts
@@ -442,6 +442,7 @@ export interface INativeWindowConfiguration extends IWindowConfiguration, Native
 	homeDir: string;
 	tmpDir: string;
 	userDataDir: string;
+	isEmbeddedApp?: boolean;
 	parentAppUserDataDir?: string;
 	parentAppUserHomeDir?: string;
 

--- a/src/vs/platform/windows/electron-main/windowsMainService.ts
+++ b/src/vs/platform/windows/electron-main/windowsMainService.ts
@@ -1571,6 +1571,7 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 			homeDir: this.environmentMainService.userHome.with({ scheme: Schemas.file }).fsPath,
 			tmpDir: this.environmentMainService.tmpDir.with({ scheme: Schemas.file }).fsPath,
 			userDataDir: this.environmentMainService.userDataPath,
+			isEmbeddedApp: this.environmentMainService.isEmbeddedApp,
 			parentAppUserDataDir: this.environmentMainService.parentAppUserRoamingDataHome?.with({ scheme: Schemas.file }).fsPath,
 			parentAppUserHomeDir: this.environmentMainService.parentAppUserHome?.with({ scheme: Schemas.file }).fsPath,
 

--- a/src/vs/sessions/contrib/welcome/browser/sessionsWalkthrough.ts
+++ b/src/vs/sessions/contrib/welcome/browser/sessionsWalkthrough.ts
@@ -14,6 +14,7 @@ import { IProductOnboardingTheme } from '../../../../base/common/product.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { ConfigurationTarget } from '../../../../platform/configuration/common/configuration.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
+import { IEnvironmentService } from '../../../../platform/environment/common/environment.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
 import { isWeb } from '../../../../base/common/platform.js';
@@ -96,6 +97,7 @@ export class SessionsWalkthroughOverlay extends Disposable {
 		@IDefaultAccountService private readonly defaultAccountService: IDefaultAccountService,
 		@IAuthenticationService private readonly authenticationService: IAuthenticationService,
 		@ICommandService private readonly commandService: ICommandService,
+		@IEnvironmentService private readonly environmentService: IEnvironmentService,
 		@IExtensionService private readonly extensionService: IExtensionService,
 		@IOpenerService private readonly openerService: IOpenerService,
 		@IProductService private readonly productService: IProductService,
@@ -409,7 +411,7 @@ export class SessionsWalkthroughOverlay extends Disposable {
 
 		// Show a VS Code theme option as a radio-style button inside the radiogroup
 		if (parentThemeSettingsId) {
-			const parentName = this.productService.embedded?.nameShort ?? 'VS Code';
+			const parentName = this.environmentService.parentAppNameShort ?? 'VS Code';
 			const option = append(themeGrid, $('.sessions-walkthrough-vscode-theme-option'));
 			vscodeThemeBtn = append(option, $('div.sessions-walkthrough-vscode-theme-radio'));
 			vscodeThemeBtn.setAttribute('role', 'radio');

--- a/src/vs/workbench/services/environment/electron-browser/environmentService.ts
+++ b/src/vs/workbench/services/environment/electron-browser/environmentService.ts
@@ -167,6 +167,7 @@ export class NativeWorkbenchEnvironmentService extends AbstractNativeEnvironment
 				parentAppUserDataDir: configuration.parentAppUserDataDir,
 				parentAppUserHomeDir: configuration.parentAppUserHomeDir
 			},
-			productService);
+			productService,
+			!!configuration.isEmbeddedApp);
 	}
 }


### PR DESCRIPTION
Introduces proper environment service properties for the embedded (Agents) app to identify its parent VS Code installation by name.

## Changes

- Add `isEmbeddedApp?: boolean` to `IEnvironmentService` — set from `process.isEmbeddedApp` in native environments
- Add `@memoize`d `parentAppNameShort` and `parentAppNameLong` getters to `AbstractNativeEnvironmentService`, computed from `isEmbeddedApp` + product quality:
  - `stable` → "VS Code" / "Visual Studio Code"
  - `insider` → "VS Code Insiders" / "Visual Studio Code Insiders"
  - `exploration` → "VS Code Exploration" / "Visual Studio Code Exploration"
- Thread `isEmbeddedApp` through `INativeWindowConfiguration` so the renderer picks it up
- Use `environmentService.parentAppNameShort` in the welcome theme step to correctly label the "Use My VS Code Insiders Theme" button (previously showed "Use My Agents - Insiders Theme" because it used `productService.embedded?.nameShort`)

## Follow-up to
- #313333 (theme selection step)
- #313454 (preview/import API)