### PR TITLE
Fix TreeError in AgentSessionsView

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsControl.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsControl.ts
@@ -837,8 +837,13 @@ export class AgentSessionsControl extends Disposable implements IAgentSessionsCo
 			return false;
 		}
 
-		if (this.sessionsList.getRelativeTop(session) === null) {
-			this.sessionsList.reveal(session, 0.5); // only reveal when not already visible
+		try {
+			if (this.sessionsList.getRelativeTop(session) === null) {
+				this.sessionsList.reveal(session, 0.5); // only reveal when not already visible
+			}
+		} catch {
+			// Tree model may be temporarily inconsistent during async refresh.
+			return false;
 		}
 
 		this.sessionsList.setFocus([session]);


### PR DESCRIPTION
```Copilot Generated Description:``` Catch potential errors when revealing a session in the Agent Sessions view to handle cases where the tree model may be temporarily inconsistent during async refresh. This change prevents unhandled errors from occurring when attempting to access the relative position of a session.
Fixes microsoft/vscode#309891

