### PR TITLE
Fix TreeError in AgentSessionsControl focus method

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsControl.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsControl.ts
@@ -801,8 +801,12 @@ export class AgentSessionsControl extends Disposable implements IAgentSessionsCo
 	focus(): void {
 		this.sessionsList?.domFocus();
 
-		if ((this.sessionsList?.getFocus().length ?? 0) === 0) {
-			this.sessionsList?.focusFirst();
+		try {
+			if ((this.sessionsList?.getFocus().length ?? 0) === 0) {
+				this.sessionsList?.focusFirst();
+			}
+		} catch {
+			// Tree model may be temporarily inconsistent during async refresh.
 		}
 	}
 


### PR DESCRIPTION
```Copilot Generated Description:``` Add a try-catch block in the `focus` method of `AgentSessionsControl` to handle potential TreeErrors when the tree model is temporarily inconsistent during async refresh. This prevents the application from crashing when attempting to focus on sessions. 
Fixes microsoft/vscode#313042

