### PR TITLE
Fix Agents welcome theme import cleanup

### DIFF
--- a/src/vs/sessions/contrib/welcome/browser/sessionsWalkthrough.ts
+++ b/src/vs/sessions/contrib/welcome/browser/sessionsWalkthrough.ts
@@ -394,11 +394,15 @@ export class SessionsWalkthroughOverlay extends Disposable {
 		let vscodeThemeBtn: HTMLElement | undefined;
 		let isVSCodeThemeSelected = false;
 		let previewResult: IThemePreviewResult | undefined;
+		const disposePreview = () => {
+			previewResult?.dispose();
+			previewResult = undefined;
+		};
 		for (const theme of themes) {
 			const card = this._createThemeCard(stepDisposables, themeGrid, theme, themeCards, selectedThemeId, id => {
 				selectedThemeId = id;
 				isVSCodeThemeSelected = false;
-				previewResult?.reset();
+				disposePreview();
 				if (vscodeThemeBtn) {
 					vscodeThemeBtn.classList.remove('selected');
 					vscodeThemeBtn.setAttribute('aria-checked', 'false');
@@ -435,8 +439,8 @@ export class SessionsWalkthroughOverlay extends Disposable {
 				previewResult = await this.themeImporterService.previewVSCodeTheme();
 				vscodeThemeBtn!.textContent = labelText;
 			};
-			// Reset preview on step teardown (escape)
-			stepDisposables.add(toDisposable(() => { previewResult?.reset(); }));
+			// Dispose preview on step teardown (escape)
+			stepDisposables.add(toDisposable(disposePreview));
 			stepDisposables.add(Gesture.addTarget(vscodeThemeBtn));
 			for (const eventType of [EventType.CLICK, TouchEventType.Tap]) {
 				stepDisposables.add(addDisposableListener(vscodeThemeBtn, eventType, selectVSCodeTheme));

--- a/src/vs/sessions/services/vscode/common/themeImporter.ts
+++ b/src/vs/sessions/services/vscode/common/themeImporter.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { IDisposable } from '../../../../base/common/lifecycle.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 
 /** The VS Code configuration key for the active color theme. */
@@ -13,18 +14,12 @@ export const IThemeImporterService = createDecorator<IThemeImporterService>('ITh
 /**
  * Result of previewing the parent VS Code's color theme.
  */
-export interface IThemePreviewResult {
+export interface IThemePreviewResult extends IDisposable {
 	/**
 	 * Permanently imports the previewed theme into the Agents app by
 	 * copying the providing extension and installing it from there.
 	 */
 	apply(): Promise<void>;
-
-	/**
-	 * Reverts the preview by uninstalling the temporarily installed
-	 * extension.
-	 */
-	reset(): Promise<void>;
 }
 
 /**
@@ -46,7 +41,7 @@ export interface IThemeImporterService {
 	/**
 	 * Temporarily installs the providing extension from the host's extensions
 	 * directory and applies the VS Code theme. Returns a cached
-	 * {@link IThemePreviewResult} to apply or reset the preview. Returns
+	 * {@link IThemePreviewResult} to apply or dispose the preview. Returns
 	 * `undefined` if the theme is already available or cannot be resolved.
 	 */
 	previewVSCodeTheme(): Promise<IThemePreviewResult | undefined>;

--- a/src/vs/sessions/services/vscode/electron-browser/themeImporterService.ts
+++ b/src/vs/sessions/services/vscode/electron-browser/themeImporterService.ts
@@ -82,12 +82,20 @@ class ThemeImporterService extends Disposable implements IThemeImporterService {
 
 			const installed = await this._installFromHostLocation(theme);
 			await this._setTheme(theme.settingsId);
+			let applied = false;
 
 			return {
-				apply: () => this._apply(theme),
-				reset: () => {
+				apply: async () => {
+					applied = true;
 					this._previewPromise = undefined;
-					return this._reset(installed);
+					await this._apply(theme);
+				},
+				dispose: () => {
+					this._previewPromise = undefined;
+					if (applied) {
+						return;
+					}
+					void this._disposePreview(installed);
 				},
 			};
 		} catch (err) {
@@ -118,7 +126,7 @@ class ThemeImporterService extends Disposable implements IThemeImporterService {
 		}
 	}
 
-	private async _reset(installed: ILocalExtension | undefined): Promise<void> {
+	private async _disposePreview(installed: ILocalExtension | undefined): Promise<void> {
 		if (!installed) {
 			return;
 		}


### PR DESCRIPTION
Fixes #314052

This fixes the Agents welcome theme picker so applying a parent VS Code custom theme is not undone by the preview cleanup when the walkthrough finishes.

## Changes

- Make the theme preview result extend `IDisposable` and use `dispose()` for preview cleanup.
- Mark the preview as applied as soon as `apply()` is called, so later disposal does not uninstall the imported theme extension.
- Dispose the preview when switching back to an onboarding theme or tearing down the welcome theme step.