### PR TITLE
themes: fix match highlight contrast in focused quick pick rows (2026 themes)

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -621,6 +621,7 @@
 		"--vscode-quickInput-list-focusBackground",
 		"--vscode-quickInputList-focusBackground",
 		"--vscode-quickInputList-focusForeground",
+		"--vscode-quickInputList-focusHighlightForeground",
 		"--vscode-quickInputList-focusIconForeground",
 		"--vscode-quickInputTitle-background",
 		"--vscode-radio-activeBackground",

--- a/extensions/theme-defaults/themes/2026-dark.json
+++ b/extensions/theme-defaults/themes/2026-dark.json
@@ -231,7 +231,7 @@
 		"quickInputList.focusBackground": "#297AA0",
 		"quickInputList.focusForeground": "#FFFFFF",
 		"quickInputList.focusIconForeground": "#FFFFFF",
-		"list.focusHighlightForeground": "#FFFFFF",
+		"quickInputList.focusHighlightForeground": "#FFFFFF",
 		"quickInputList.hoverBackground": "#262728",
 		"terminal.selectionBackground": "#3994BC33",
 		"terminal.background": "#191A1B",

--- a/extensions/theme-defaults/themes/2026-dark.json
+++ b/extensions/theme-defaults/themes/2026-dark.json
@@ -231,6 +231,7 @@
 		"quickInputList.focusBackground": "#297AA0",
 		"quickInputList.focusForeground": "#FFFFFF",
 		"quickInputList.focusIconForeground": "#FFFFFF",
+		"list.focusHighlightForeground": "#FFFFFF",
 		"quickInputList.hoverBackground": "#262728",
 		"terminal.selectionBackground": "#3994BC33",
 		"terminal.background": "#191A1B",

--- a/extensions/theme-defaults/themes/2026-light.json
+++ b/extensions/theme-defaults/themes/2026-light.json
@@ -235,7 +235,7 @@
 		"quickInputList.focusBackground": "#0069CC",
 		"quickInputList.focusForeground": "#FFFFFF",
 		"quickInputList.focusIconForeground": "#FFFFFF",
-		"list.focusHighlightForeground": "#FFFFFF",
+		"quickInputList.focusHighlightForeground": "#FFFFFF",
 		"quickInputList.hoverBackground": "#EDF0F5",
 		"terminal.selectionBackground": "#0069CC26",
 		"terminalCursor.foreground": "#202020",

--- a/extensions/theme-defaults/themes/2026-light.json
+++ b/extensions/theme-defaults/themes/2026-light.json
@@ -235,6 +235,7 @@
 		"quickInputList.focusBackground": "#0069CC",
 		"quickInputList.focusForeground": "#FFFFFF",
 		"quickInputList.focusIconForeground": "#FFFFFF",
+		"list.focusHighlightForeground": "#FFFFFF",
 		"quickInputList.hoverBackground": "#EDF0F5",
 		"terminal.selectionBackground": "#0069CC26",
 		"terminalCursor.foreground": "#202020",

--- a/src/vs/platform/quickinput/browser/media/quickInput.css
+++ b/src/vs/platform/quickinput/browser/media/quickInput.css
@@ -303,7 +303,7 @@
 
 /* preserve list-like styling instead of tree-like styling */
 .quick-input-list .monaco-list .monaco-list-row.focused .monaco-highlighted-label .highlight {
-	color: var(--vscode-list-focusHighlightForeground) !important;
+	color: var(--vscode-quickInputList-focusHighlightForeground) !important;
 }
 
 .quick-input-list .quick-input-list-entry .quick-input-list-separator {

--- a/src/vs/platform/theme/common/colors/quickpickColors.ts
+++ b/src/vs/platform/theme/common/colors/quickpickColors.ts
@@ -11,7 +11,7 @@ import { registerColor, oneOf } from '../colorUtils.js';
 
 // Import the colors we need
 import { editorWidgetBackground, editorWidgetForeground } from './editorColors.js';
-import { listActiveSelectionBackground, listActiveSelectionForeground, listActiveSelectionIconForeground } from './listColors.js';
+import { listActiveSelectionBackground, listActiveSelectionForeground, listActiveSelectionIconForeground, listFocusHighlightForeground } from './listColors.js';
 
 
 export const quickInputBackground = registerColor('quickInput.background',
@@ -49,3 +49,7 @@ export const quickInputListFocusIconForeground = registerColor('quickInputList.f
 export const quickInputListFocusBackground = registerColor('quickInputList.focusBackground',
 	{ dark: oneOf(_deprecatedQuickInputListFocusBackground, listActiveSelectionBackground), light: oneOf(_deprecatedQuickInputListFocusBackground, listActiveSelectionBackground), hcDark: null, hcLight: null },
 	nls.localize('quickInput.listFocusBackground', "Quick picker background color for the focused item."));
+
+export const quickInputListFocusHighlightForeground = registerColor('quickInputList.focusHighlightForeground',
+	listFocusHighlightForeground,
+	nls.localize('quickInput.listFocusHighlightForeground', "Quick picker foreground color of the match highlights on the focused item."));


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/314035

#313740 increased the contrast of the focused quick pick row in the 2026 Dark and 2026 Light themes by switching the focus background to a saturated blue and the row foreground/icon foreground to white. This unfortunately caused a regression for search match highlights on the focused row: the matched substring still rendered using `list.highlightForeground` (blue), producing blue text on a blue background.

This PR adds `list.focusHighlightForeground: #FFFFFF` to both 2026 themes so match highlights on the focused row are rendered in white — matching the focused row's foreground/icon colors. The original `list.highlightForeground` (blue) is preserved for unfocused rows, retaining the prior accessibility fix.

Fix:

<img width="749" height="462" alt="Screenshot 2026-05-04 at 10 52 42 AM" src="https://github.com/user-attachments/assets/fe0667f1-042d-4b71-864b-25944a846036" />
<img width="754" height="470" alt="Screenshot 2026-05-04 at 10 52 23 AM" src="https://github.com/user-attachments/assets/8d7f3191-df17-4c9e-9a0c-2fe3b52d8a1c" />

Before:

<img width="749" height="514" alt="Screenshot 2026-05-04 at 10 53 35 AM" src="https://github.com/user-attachments/assets/6a8dc8a7-96ea-4f70-a62f-f099319aee94" />

### Verified against
1. Quick pick background (unfocused rows) — blue match highlight remains legible ✓
2. Focused quick pick row — white match highlight is legible against the saturated blue focus background ✓

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>