### PR TITLE
Skip redundant steering message when kill_terminal disposes terminal

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/killTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/killTerminalTool.ts
@@ -61,6 +61,11 @@ export class KillTerminalTool extends Disposable implements IToolImpl {
 		// Get the final output before killing
 		const finalOutput = execution.getOutput();
 
+		// Mark as killed by this tool so the onDisposed handler in
+		// _registerCompletionNotification skips the redundant steering
+		// message (the agent receives output through this tool result).
+		RunInTerminalTool.markKilledByTool(args.id);
+
 		// Dispose the terminal instance (this kills the process)
 		execution.instance.dispose();
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -484,6 +484,14 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 	protected readonly _osBackend: Promise<OperatingSystem>;
 
 	private static readonly _activeExecutions = new Map<string, IActiveTerminalExecution & { dispose(): void }>();
+
+	/**
+	 * Terminal IDs currently being disposed by `kill_terminal`. Used to
+	 * suppress redundant steering messages in `_registerCompletionNotification`'s
+	 * `onDisposed` handler — the agent already receives the output through the
+	 * `kill_terminal` tool result.
+	 */
+	private static readonly _killedByTool = new Set<string>();
 	public static getBackgroundOutput(id: string): string {
 		const execution = RunInTerminalTool._activeExecutions.get(id);
 		if (!execution) {
@@ -512,6 +520,15 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		execution.dispose();
 		RunInTerminalTool._activeExecutions.delete(id);
 		return true;
+	}
+
+	/**
+	 * Marks a terminal ID as being killed by the `kill_terminal` tool so that
+	 * the `onDisposed` handler in `_registerCompletionNotification` skips the
+	 * redundant steering message.
+	 */
+	public static markKilledByTool(id: string): void {
+		RunInTerminalTool._killedByTool.add(id);
 	}
 
 	private _resolveExecutionOptions(args: IRunInTerminalInputParams): IResolvedExecutionOptions {
@@ -2320,6 +2337,13 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		// _activeExecutions.
 		const executionForDisposal = RunInTerminalTool._activeExecutions.get(termId);
 		store.add(terminalInstance.onDisposed(() => {
+			// If kill_terminal is disposing this terminal, the agent will
+			// receive the output through the normal tool-result flow —
+			// skip the redundant steering message.
+			if (RunInTerminalTool._killedByTool.has(termId)) {
+				disposeNotification();
+				return;
+			}
 			if (handleSessionCancelled()) {
 				return;
 			}


### PR DESCRIPTION
When the agent calls `kill_terminal` on a backgrounded terminal, the `onDisposed` handler in `_registerCompletionNotification` fires and sends a redundant "terminal exited" steering message. This disrupts the tool-result processing loop, causing the agent to stop responding — found in 5/89 terminalbench2 eval tests.

Fixes microsoft/vscode-internalbacklog#7606