### PR TITLE
sessions: improve sub-session tab visibility with pill style

### DIFF
--- a/src/vs/sessions/browser/parts/media/chatCompositeBar.css
+++ b/src/vs/sessions/browser/parts/media/chatCompositeBar.css
@@ -53,7 +53,7 @@
 .chat-composite-bar-tab.active {
 	color: var(--chat-tab-active-foreground);
 	background-color: color-mix(in srgb, var(--vscode-agentsPanel-foreground, var(--vscode-foreground)) 10%, transparent);
-	border-color: color-mix(in srgb, var(--vscode-agentsPanel-foreground, var(--vscode-foreground)) 12%, transparent);
+	border-color: var(--chat-tab-active-border, var(--vscode-contrastActiveBorder));
 }
 
 /* Reduce right padding when close button is present to avoid excess spacing */

--- a/src/vs/sessions/browser/parts/media/chatCompositeBar.css
+++ b/src/vs/sessions/browser/parts/media/chatCompositeBar.css
@@ -7,7 +7,7 @@
 	display: flex;
 	align-items: center;
 	background-color: var(--chat-bar-background);
-	padding: 0 4px;
+	padding: 0 6px;
 	height: 35px;
 	flex-shrink: 0;
 	overflow: hidden;
@@ -17,7 +17,7 @@
 	display: flex;
 	align-items: center;
 	height: 100%;
-	gap: 0;
+	gap: 4px;
 	overflow-x: auto;
 	overflow-y: hidden;
 }
@@ -26,12 +26,12 @@
 	display: none;
 }
 
-/* Base tab: preserve chat title casing while keeping the same pill treatment */
+/* Base tab: pill-shaped with clear boundaries */
 .chat-composite-bar-tab {
 	display: flex;
 	align-items: center;
 	position: relative;
-	padding: 0 8px;
+	padding: 0 10px;
 	cursor: pointer;
 	white-space: nowrap;
 	color: var(--chat-tab-inactive-foreground);
@@ -39,18 +39,21 @@
 	font-size: 12px;
 	line-height: 22px;
 	height: 26px;
-	border-radius: 4px;
+	border-radius: 6px;
 	user-select: none;
+	border: 1px solid transparent;
 }
 
 .chat-composite-bar-tab:hover {
 	color: var(--chat-tab-active-foreground);
+	background-color: color-mix(in srgb, var(--vscode-agentsPanel-foreground, var(--vscode-foreground)) 5%, transparent);
 }
 
-/* Active state: background container instead of underline — mirrors auxiliarybar checked */
+/* Active state: prominent filled pill */
 .chat-composite-bar-tab.active {
 	color: var(--chat-tab-active-foreground);
-	background-color: color-mix(in srgb, var(--vscode-agentsPanel-foreground, var(--vscode-foreground)) 5%, transparent);
+	background-color: color-mix(in srgb, var(--vscode-agentsPanel-foreground, var(--vscode-foreground)) 10%, transparent);
+	border-color: color-mix(in srgb, var(--vscode-agentsPanel-foreground, var(--vscode-foreground)) 12%, transparent);
 }
 
 /* Reduce right padding when close button is present to avoid excess spacing */


### PR DESCRIPTION
## Summary

Sub-session tabs in the chat composite bar (the per-chat tab strip inside an active session) were hard to distinguish from each other. The active tab in particular only had a barely-visible 5% background tint, and adjacent tabs had no spatial separation.

This PR updates `chatCompositeBar.css` to give each tab a clear pill-shaped boundary and make the active tab stand out clearly.

## Changes

- Add a 4px gap between tabs for clear separation
- Slightly increase border radius (4px → 6px) and padding for a more pronounced pill shape
- Reserve a transparent border on inactive tabs so layout stays stable when the active border appears
- Show a subtle background tint on hover (previously only color changed)
- Strengthen the active tab background (5% → 10%) and add a visible border so the active tab stands out clearly

## Before / After

Before: tabs blend together; active tab nearly indistinguishable from inactive ones.
<img width="1564" height="118" alt="CleanShot 2026-05-04 at 16 25 28@2x" src="https://github.com/user-attachments/assets/fe2b0463-9566-4cde-b440-d520b6544ad7" />


After: each tab is a clearly bounded pill; active tab has a stronger fill and visible border.
<img width="992" height="158" alt="CleanShot 2026-05-04 at 16 25 04@2x" src="https://github.com/user-attachments/assets/9bd9a92c-1070-4cf5-8c05-70d4d02625f0" />
