### PR TITLE
Reduce token usage of "add element to chat"

### DIFF
--- a/src/vs/platform/browserView/common/cssHelpers.ts
+++ b/src/vs/platform/browserView/common/cssHelpers.ts
@@ -1,0 +1,610 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// -- CDP matched-styles types (subset used by formatAuthorStyles) --
+
+export interface ICSSStyle {
+	cssText?: string;
+	cssProperties: Array<{ name: string; value: string; disabled?: boolean }>;
+}
+
+interface ISelectorList {
+	selectors: Array<{ text: string }>;
+}
+
+interface ICSSRule {
+	selectorList: ISelectorList;
+	origin: string;
+	style: ICSSStyle;
+}
+
+interface IRuleMatch {
+	rule: ICSSRule;
+}
+
+interface IInheritedStyleEntry {
+	inlineStyle?: ICSSStyle;
+	matchedCSSRules: IRuleMatch[];
+}
+
+interface IPseudoElementMatches {
+	pseudoType: string;
+	matches: IRuleMatch[];
+}
+
+export interface IMatchedStyles {
+	inlineStyle?: ICSSStyle;
+	matchedCSSRules?: IRuleMatch[];
+	inherited?: IInheritedStyleEntry[];
+	pseudoElements?: IPseudoElementMatches[];
+}
+
+export interface IFormattedStyles {
+	/** Compact CSS text for the agent prompt (rules only, without resolved values). */
+	rulesText: string;
+	/** Set of CSS variable names referenced by the element's rules. */
+	referencedVars: Set<string>;
+	/** Set of CSS property names that were explicitly set by author rules. */
+	authorPropertyNames: Set<string>;
+}
+
+// -- Constants --
+
+/**
+ * CSS properties that are inherited by child elements.
+ */
+const inheritableCSSProperties = new Set([
+	'color', 'cursor', 'direction', 'font', 'font-family', 'font-feature-settings',
+	'font-kerning', 'font-size', 'font-size-adjust', 'font-stretch', 'font-style',
+	'font-variant', 'font-weight', 'letter-spacing', 'line-height', 'list-style',
+	'list-style-image', 'list-style-position', 'list-style-type', 'orphans',
+	'overflow-wrap', 'quotes', 'tab-size', 'text-align', 'text-align-last',
+	'text-indent', 'text-transform', 'visibility', 'white-space', 'widows',
+	'word-break', 'word-spacing', 'writing-mode',
+]);
+
+const varReferenceRegex = /var\(\s*(--[a-zA-Z0-9_-]+)/g;
+
+/**
+ * Key computed properties included for hover display in the UI.
+ */
+export const keyComputedProperties = new Set([
+	'display', 'position', 'margin', 'margin-top', 'margin-right', 'margin-bottom', 'margin-left',
+	'padding', 'padding-top', 'padding-right', 'padding-bottom', 'padding-left',
+	'font-size', 'font-family', 'color', 'background-color',
+]);
+
+/**
+ * Properties always included in resolved values even if only set by user-agent rules,
+ * matching Chrome DevTools' `alwaysShownComputedProperties`.
+ */
+const alwaysResolvedProperties = new Set(['display', 'height', 'width']);
+
+// -- Helper functions --
+
+/**
+ * Collects var(--name) references from a CSS value string.
+ */
+function collectVarReferences(value: string, into: Set<string>): void {
+	for (const m of value.matchAll(varReferenceRegex)) {
+		into.add(m[1]);
+	}
+}
+
+/**
+ * Collects longhand property names from the `cssProperties` array of a matched rule.
+ * Skips variable definitions and disabled properties.
+ */
+function collectAuthorPropertyNames(cssProperties: Array<{ name: string; value: string; disabled?: boolean }>, into: Set<string>, inheritableOnly?: boolean): void {
+	for (const prop of cssProperties) {
+		if (!prop.name || !prop.value || prop.disabled || prop.name.startsWith('--')) {
+			continue;
+		}
+		if (inheritableOnly && !inheritableCSSProperties.has(prop.name)) {
+			continue;
+		}
+		into.add(prop.name);
+	}
+}
+
+/**
+ * Filters CSS declarations to only inheritable properties (not variable definitions).
+ */
+export function filterInheritableDeclarations(cssText: string): string | undefined {
+	const declarations = cssText.split(';').map(d => d.trim()).filter(Boolean);
+	const filtered = declarations.filter(decl => {
+		const colonIdx = decl.indexOf(':');
+		if (colonIdx === -1) {
+			return false;
+		}
+		const propName = decl.substring(0, colonIdx).trim();
+		return inheritableCSSProperties.has(propName);
+	});
+	return filtered.length > 0 ? filtered.join('; ') : undefined;
+}
+
+/**
+ * Formats matched styles into a compact representation for agent prompts.
+ *
+ * Only includes author-origin rules (not browser defaults), uses the raw
+ * `cssText` instead of expanded longhand properties, and for inherited
+ * rules only keeps inheritable CSS properties.
+ *
+ * Also includes pseudo-element styles (::before, ::after, etc.) when present.
+ *
+ * Uses `cssProperties` (the longhand array) from matched rules to determine
+ * which computed properties are author-affected, matching Chrome DevTools'
+ * `computePropertyTraces` approach.
+ */
+export function formatAuthorStyles(matched: IMatchedStyles): IFormattedStyles {
+	const referencedVars = new Set<string>();
+	const authorPropertyNames = new Set<string>();
+	const seenCssTexts = new Set<string>();
+	const lines: string[] = [];
+
+	// Inline styles on the element itself
+	if (matched.inlineStyle?.cssText?.trim()) {
+		const cssText = matched.inlineStyle.cssText.trim();
+		collectVarReferences(cssText, referencedVars);
+		collectAuthorPropertyNames(matched.inlineStyle.cssProperties, authorPropertyNames);
+		lines.push(`element { ${cssText} }`);
+	}
+
+	// Direct author rules: use cssText for display, cssProperties for property tracking
+	for (const ruleEntry of matched.matchedCSSRules ?? []) {
+		if (ruleEntry.rule.origin === 'user-agent') {
+			continue;
+		}
+		const cssText = ruleEntry.rule.style.cssText?.trim();
+		if (!cssText || seenCssTexts.has(cssText)) {
+			continue;
+		}
+		seenCssTexts.add(cssText);
+		collectVarReferences(cssText, referencedVars);
+		collectAuthorPropertyNames(ruleEntry.rule.style.cssProperties, authorPropertyNames);
+		const selectors = ruleEntry.rule.selectorList.selectors.map(s => s.text).join(', ');
+		lines.push(`${selectors} { ${cssText} }`);
+	}
+
+	// Pseudo-element styles (::before, ::after, etc.)
+	if (matched.pseudoElements?.length) {
+		const pseudoLines: string[] = [];
+		for (const pseudo of matched.pseudoElements) {
+			for (const ruleEntry of pseudo.matches ?? []) {
+				if (ruleEntry.rule.origin === 'user-agent') {
+					continue;
+				}
+				const cssText = ruleEntry.rule.style.cssText?.trim();
+				if (!cssText || seenCssTexts.has(cssText)) {
+					continue;
+				}
+				seenCssTexts.add(cssText);
+				collectVarReferences(cssText, referencedVars);
+				collectAuthorPropertyNames(ruleEntry.rule.style.cssProperties, authorPropertyNames);
+				const selectors = ruleEntry.rule.selectorList.selectors.map(s => s.text).join(', ');
+				pseudoLines.push(`${selectors} { ${cssText} }`);
+			}
+		}
+		if (pseudoLines.length > 0) {
+			lines.push('');
+			lines.push('/* Pseudo-elements */');
+			lines.push(...pseudoLines);
+		}
+	}
+
+	// Inherited author rules — only inheritable properties
+	const inheritedLines: string[] = [];
+	for (const entry of matched.inherited ?? []) {
+		for (const ruleEntry of entry.matchedCSSRules ?? []) {
+			if (ruleEntry.rule.origin === 'user-agent') {
+				continue;
+			}
+			const cssText = ruleEntry.rule.style.cssText?.trim();
+			if (!cssText) {
+				continue;
+			}
+			// Display: keep only inheritable properties from cssText
+			const filtered = filterInheritableDeclarations(cssText);
+			if (!filtered || seenCssTexts.has(filtered)) {
+				continue;
+			}
+			seenCssTexts.add(filtered);
+			// Track: use cssProperties longhands, inheritable only
+			collectVarReferences(filtered, referencedVars);
+			collectAuthorPropertyNames(ruleEntry.rule.style.cssProperties, authorPropertyNames, true);
+			const selectors = ruleEntry.rule.selectorList.selectors.map(s => s.text).join(', ');
+			inheritedLines.push(`${selectors} { ${filtered} }`);
+		}
+	}
+
+	if (inheritedLines.length > 0) {
+		lines.push('');
+		lines.push('/* Inherited */');
+		lines.push(...inheritedLines);
+	}
+
+	// Always include DevTools' alwaysShownComputedProperties
+	for (const prop of alwaysResolvedProperties) {
+		authorPropertyNames.add(prop);
+	}
+
+	return { rulesText: lines.join('\n'), referencedVars, authorPropertyNames };
+}
+
+/**
+ * -- Shorthand collapsing configuration ----------------------------------
+ *
+ * Each constant below describes one kind of CSS shorthand that can be
+ * reconstituted from computed longhand values.  The `collapseToShorthands`
+ * function walks these lists in declaration order and produces compact
+ * output for the agent prompt.
+ *
+ * Sources:
+ *  • MDN "Formal definition → Initial value" tables
+ *  • CSS Backgrounds & Borders 3, CSS Transitions 1, CSS Animations 1,
+ *    CSS Text Decoration 4, CSS Text 4
+ */
+
+// -- Box model (T R B L) shorthands --
+// Collapsed with 1-4-value syntax per CSS spec section 8.3.
+
+interface IBoxShorthand {
+	shorthand: string;
+	sides: [string, string, string, string]; // top/TL, right/TR, bottom/BR, left/BL
+}
+
+const boxShorthands: IBoxShorthand[] = [
+	// margin: <margin-top> <margin-right> <margin-bottom> <margin-left>
+	{ shorthand: 'margin', sides: ['margin-top', 'margin-right', 'margin-bottom', 'margin-left'] },
+	// padding: <padding-top> <padding-right> <padding-bottom> <padding-left>
+	{ shorthand: 'padding', sides: ['padding-top', 'padding-right', 'padding-bottom', 'padding-left'] },
+	// border-radius: <TL> <TR> <BR> <BL>   (clockwise from top-left)
+	{ shorthand: 'border-radius', sides: ['border-top-left-radius', 'border-top-right-radius', 'border-bottom-right-radius', 'border-bottom-left-radius'] },
+];
+
+// -- Border per-side groups (collapse to border: W S C when uniform) --
+
+const borderSideGroups: IBoxShorthand[] = [
+	// border-width: initial medium per MDN (but computed is always an absolute length)
+	{ shorthand: 'border-width', sides: ['border-top-width', 'border-right-width', 'border-bottom-width', 'border-left-width'] },
+	// border-style: initial none per MDN
+	{ shorthand: 'border-style', sides: ['border-top-style', 'border-right-style', 'border-bottom-style', 'border-left-style'] },
+	// border-color: initial currentcolor per MDN
+	{ shorthand: 'border-color', sides: ['border-top-color', 'border-right-color', 'border-bottom-color', 'border-left-color'] },
+];
+
+// -- Longhands that are dropped entirely when all at their initial values --
+
+interface IDefaultsGroup {
+	/** Longhands to check and remove. */
+	longhands: Record<string, string>;
+}
+
+const dropWhenAllDefault: IDefaultsGroup[] = [
+	// border-image  (CSS Backgrounds & Borders 3 section 6.8)
+	{
+		longhands: {
+			'border-image-source': 'none',
+			'border-image-slice': '100%',
+			'border-image-width': '1',
+			'border-image-outset': '0',
+			'border-image-repeat': 'stretch',
+		},
+	},
+	// animation-range  (CSS Scroll-driven Animations section 5.2)  initial: normal
+	{
+		longhands: {
+			'animation-range-start': 'normal',
+			'animation-range-end': 'normal',
+		},
+	},
+];
+
+// -- Background collapse (color-only shorthand when images/position/etc. default) --
+
+interface IBackgroundCollapseGroup {
+	/** background-color longhand  */
+	colorLonghand: string;
+	/** Other background longhands that must all be at their initial value. */
+	otherLonghands: Record<string, string>;
+}
+
+const backgroundCollapse: IBackgroundCollapseGroup = {
+	colorLonghand: 'background-color',
+	otherLonghands: {
+		// MDN background formal definition initial values:
+		'background-image': 'none',            // initial: none
+		'background-position-x': '0px',        // initial: 0% (computed as 0px)
+		'background-position-y': '0px',        // initial: 0%
+		'background-size': 'auto',             // initial: auto auto
+		'background-repeat': 'repeat',         // initial: repeat
+		'background-attachment': 'scroll',     // initial: scroll
+		'background-origin': 'padding-box',    // initial: padding-box
+		'background-clip': 'border-box',       // initial: border-box
+	},
+};
+
+// -- Simple shorthand collapse (longhands → single shorthand, omit defaults) --
+
+interface ISimpleShorthand {
+	shorthand: string;
+	longhands: Array<{ name: string; initial: string }>;
+}
+
+const simpleShorthands: ISimpleShorthand[] = [
+	// text-decoration (CSS Text Decoration 4 section 3)
+	// Constituents: text-decoration-line || text-decoration-style || text-decoration-color || text-decoration-thickness
+	{
+		shorthand: 'text-decoration',
+		longhands: [
+			{ name: 'text-decoration-line', initial: 'none' },
+			{ name: 'text-decoration-style', initial: 'solid' },
+			{ name: 'text-decoration-color', initial: 'currentcolor' },
+			{ name: 'text-decoration-thickness', initial: 'auto' },
+		],
+	},
+];
+
+// -- white-space (CSS Text 4 section 3) --
+// Shorthand for white-space-collapse || text-wrap-mode.
+// Named keyword mappings for the well-known combinations:
+
+const whiteSpaceKeywords: Array<{ collapse: string; wrap: string; keyword: string }> = [
+	{ collapse: 'collapse', wrap: 'wrap', keyword: 'normal' },
+	{ collapse: 'collapse', wrap: 'nowrap', keyword: 'nowrap' },
+	{ collapse: 'preserve', wrap: 'nowrap', keyword: 'pre' },
+	{ collapse: 'preserve', wrap: 'wrap', keyword: 'pre-wrap' },
+	{ collapse: 'preserve-breaks', wrap: 'wrap', keyword: 'pre-line' },
+	{ collapse: 'break-spaces', wrap: 'wrap', keyword: 'break-spaces' },
+];
+
+// -- Comma-separated list shorthands (transition, animation) --
+
+interface IListShorthand {
+	shorthand: string;
+	longhands: Array<{ name: string; initial: string }>;
+}
+
+const listShorthands: IListShorthand[] = [
+	// transition (CSS Transitions 1 section 2.1)
+	// Constituents: transition-property || transition-duration || transition-timing-function || transition-delay || transition-behavior
+	{
+		shorthand: 'transition',
+		longhands: [
+			{ name: 'transition-property', initial: 'all' },
+			{ name: 'transition-duration', initial: '0s' },
+			{ name: 'transition-timing-function', initial: 'ease' },
+			{ name: 'transition-delay', initial: '0s' },
+			{ name: 'transition-behavior', initial: 'normal' },
+		],
+	},
+	// animation (CSS Animations 1 section 3 + Scroll-driven Animations section 5)
+	// Constituents: animation-name || animation-duration || animation-timing-function || animation-delay
+	//             || animation-iteration-count || animation-direction || animation-fill-mode
+	//             || animation-play-state || animation-timeline
+	{
+		shorthand: 'animation',
+		longhands: [
+			{ name: 'animation-name', initial: 'none' },
+			{ name: 'animation-duration', initial: '0s' },
+			{ name: 'animation-timing-function', initial: 'ease' },
+			{ name: 'animation-delay', initial: '0s' },
+			{ name: 'animation-iteration-count', initial: '1' },
+			{ name: 'animation-direction', initial: 'normal' },
+			{ name: 'animation-fill-mode', initial: 'none' },
+			{ name: 'animation-play-state', initial: 'running' },
+			{ name: 'animation-timeline', initial: 'auto' },
+		],
+	},
+];
+
+// -- Helper functions --
+
+/**
+ * Tries to collapse a box shorthand (4 sides → 1-4 value shorthand).
+ * Returns the collapsed value or undefined if not all sides are present.
+ */
+function collapseBoxValues(entries: Map<string, string>, sides: [string, string, string, string]): string | undefined {
+	const [topKey, rightKey, bottomKey, leftKey] = sides;
+	const top = entries.get(topKey);
+	const right = entries.get(rightKey);
+	const bottom = entries.get(bottomKey);
+	const left = entries.get(leftKey);
+
+	if (top === undefined || right === undefined || bottom === undefined || left === undefined) {
+		return undefined;
+	}
+
+	entries.delete(topKey);
+	entries.delete(rightKey);
+	entries.delete(bottomKey);
+	entries.delete(leftKey);
+
+	if (top === right && right === bottom && bottom === left) {
+		return top;
+	}
+	if (top === bottom && right === left) {
+		return `${top} ${right}`;
+	}
+	if (right === left) {
+		return `${top} ${right} ${bottom}`;
+	}
+	return `${top} ${right} ${bottom} ${left}`;
+}
+
+/**
+ * Splits a CSS value by top-level commas, respecting parenthesized groups
+ * like `cubic-bezier(0.16, 1, 0.3, 1)`.
+ */
+function splitCSSList(value: string): string[] {
+	const items: string[] = [];
+	let depth = 0;
+	let start = 0;
+	for (let i = 0; i < value.length; i++) {
+		const ch = value[i];
+		if (ch === '(') {
+			depth++;
+		} else if (ch === ')') {
+			depth--;
+		} else if (ch === ',' && depth === 0) {
+			items.push(value.substring(start, i).trim());
+			start = i + 1;
+		}
+	}
+	items.push(value.substring(start).trim());
+	return items;
+}
+
+/**
+ * Collapses comma-separated list longhands into a single shorthand declaration.
+ */
+function collapseListShorthand(
+	entries: Map<string, string>,
+	output: string[],
+	shorthand: string,
+	longhands: Array<{ name: string; initial: string }>,
+): void {
+	const values = longhands.map(({ name }) => entries.get(name));
+	if (!values.every(v => v !== undefined)) {
+		return;
+	}
+
+	const lists = values.map(v => splitCSSList(v as string));
+	const itemCount = lists[0].length;
+	if (!lists.every(l => l.length === itemCount)) {
+		return;
+	}
+
+	for (const { name } of longhands) {
+		entries.delete(name);
+	}
+
+	const items: string[] = [];
+	for (let i = 0; i < itemCount; i++) {
+		const parts: string[] = [];
+		for (let j = 0; j < longhands.length; j++) {
+			const val = lists[j][i];
+			if (val !== longhands[j].initial) {
+				parts.push(val);
+			}
+		}
+		items.push(parts.length > 0 ? parts.join(' ') : longhands[0].initial);
+	}
+
+	output.push(`${shorthand}: ${items.join(', ')};`);
+}
+
+// -- Main entry point --
+
+/**
+ * Collapses resolved computed properties into shorthands where possible,
+ * then returns sorted CSS declaration lines.  Driven entirely by the
+ * constant shorthand configuration tables above.
+ */
+export function collapseToShorthands(entries: Map<string, string>): string[] {
+	const shorthandLines: string[] = [];
+
+	// 1. Box shorthands (margin, padding, border-radius)
+	for (const { shorthand, sides } of boxShorthands) {
+		const collapsed = collapseBoxValues(entries, sides);
+		if (collapsed !== undefined) {
+			shorthandLines.push(`${shorthand}: ${collapsed};`);
+		}
+	}
+
+	// 2. Border: try full `border: W S C` when all four sides are uniform,
+	//    otherwise collapse each group (border-width, border-style, border-color).
+	const borderVals = borderSideGroups.map(g => g.sides.map(s => entries.get(s)));
+	const hasAllBorderProps = borderVals.every(group => group.every(v => v !== undefined));
+	if (hasAllBorderProps) {
+		const allUniform = borderVals.every(group => group.every(v => v === group[0]));
+		if (allUniform) {
+			for (const group of borderSideGroups) {
+				for (const side of group.sides) {
+					entries.delete(side);
+				}
+			}
+			shorthandLines.push(`border: ${borderVals[0][0]} ${borderVals[1][0]} ${borderVals[2][0]};`);
+		} else {
+			for (const group of borderSideGroups) {
+				const collapsed = collapseBoxValues(entries, group.sides);
+				if (collapsed !== undefined) {
+					shorthandLines.push(`${group.shorthand}: ${collapsed};`);
+				}
+			}
+		}
+	}
+
+	// 3. Drop-when-all-default groups (border-image, etc.)
+	for (const { longhands } of dropWhenAllDefault) {
+		const allDefault = Object.entries(longhands).every(([k, v]) => entries.get(k) === v);
+		if (allDefault && Object.keys(longhands).some(k => entries.has(k))) {
+			for (const key of Object.keys(longhands)) {
+				entries.delete(key);
+			}
+		}
+	}
+
+	// 4. Background collapse (→ `background: <color>` when other props at default)
+	{
+		const { colorLonghand, otherLonghands } = backgroundCollapse;
+		const bgColor = entries.get(colorLonghand);
+		const allOthersDefault = Object.entries(otherLonghands).every(([k, v]) => entries.get(k) === v);
+		if (allOthersDefault && bgColor !== undefined) {
+			entries.delete(colorLonghand);
+			for (const key of Object.keys(otherLonghands)) {
+				entries.delete(key);
+			}
+			shorthandLines.push(`background: ${bgColor};`);
+		}
+	}
+
+	// 5. Simple shorthands (text-decoration, etc.) — combine longhands, omit defaults
+	for (const { shorthand, longhands } of simpleShorthands) {
+		const first = entries.get(longhands[0].name);
+		if (first === undefined) {
+			continue;
+		}
+		// Snapshot values before deleting
+		const values = longhands.map(({ name }) => entries.get(name));
+		for (const { name } of longhands) {
+			entries.delete(name);
+		}
+		// Build shorthand value, omitting longhands at their initial value
+		const parts: string[] = [];
+		for (let i = 0; i < longhands.length; i++) {
+			const val = values[i] ?? longhands[i].initial;
+			if (val !== longhands[i].initial) {
+				parts.push(val);
+			}
+		}
+		shorthandLines.push(`${shorthand}: ${parts.length > 0 ? parts.join(' ') : longhands[0].initial};`);
+	}
+
+	// 6. white-space (CSS Text 4) — map longhand pair to named keyword
+	{
+		const wsCollapse = entries.get('white-space-collapse');
+		const textWrap = entries.get('text-wrap-mode');
+		if (wsCollapse !== undefined && textWrap !== undefined) {
+			entries.delete('white-space-collapse');
+			entries.delete('text-wrap-mode');
+			const match = whiteSpaceKeywords.find(k => k.collapse === wsCollapse && k.wrap === textWrap);
+			shorthandLines.push(`white-space: ${match ? match.keyword : `${wsCollapse} ${textWrap}`};`);
+		}
+	}
+
+	// 7. Comma-separated list shorthands (transition, animation)
+	for (const { shorthand, longhands } of listShorthands) {
+		collapseListShorthand(entries, shorthandLines, shorthand, longhands);
+	}
+
+	// 8. Remaining properties as individual lines, sorted
+	const remainingLines: string[] = [];
+	for (const [name, value] of Array.from(entries.entries()).sort(([a], [b]) => a.localeCompare(b))) {
+		remainingLines.push(`${name}: ${value};`);
+	}
+
+	return [...shorthandLines, ...remainingLines];
+}

--- a/src/vs/platform/browserView/electron-main/browserViewElementInspector.ts
+++ b/src/vs/platform/browserView/electron-main/browserViewElementInspector.ts
@@ -6,6 +6,7 @@
 import { CancellationToken } from '../../../base/common/cancellation.js';
 import { Disposable, DisposableStore } from '../../../base/common/lifecycle.js';
 import { IElementData, IElementAncestor } from '../common/browserView.js';
+import { collapseToShorthands, formatAuthorStyles, keyComputedProperties, type IMatchedStyles } from '../common/cssHelpers.js';
 import { ICDPConnection } from '../common/cdp/types.js';
 import type { BrowserView } from './browserView.js';
 
@@ -18,36 +19,6 @@ interface IBoxModel {
 	margin: Quad;
 	width: number;
 	height: number;
-}
-
-interface ICSSStyle {
-	cssText?: string;
-	cssProperties: Array<{ name: string; value: string }>;
-}
-
-interface ISelectorList {
-	selectors: Array<{ text: string }>;
-}
-
-interface ICSSRule {
-	selectorList: ISelectorList;
-	origin: string;
-	style: ICSSStyle;
-}
-
-interface IRuleMatch {
-	rule: ICSSRule;
-}
-
-interface IInheritedStyleEntry {
-	inlineStyle?: ICSSStyle;
-	matchedCSSRules: IRuleMatch[];
-}
-
-interface IMatchedStyles {
-	inlineStyle?: ICSSStyle;
-	matchedCSSRules?: IRuleMatch[];
-	inherited?: IInheritedStyleEntry[];
 }
 
 interface INode {
@@ -268,7 +239,7 @@ async function extractNodeData(connection: ICDPConnection, id: { backendNodeId?:
 		throw new Error('Failed to get matched css.');
 	}
 
-	const computedStyle = formatMatchedStyles(matched as IMatchedStyles);
+	const { rulesText, referencedVars, authorPropertyNames } = formatAuthorStyles(matched as IMatchedStyles);
 	const { outerHTML } = await connection.sendCommand('DOM.getOuterHTML', { nodeId }) as { outerHTML: string };
 	if (!outerHTML) {
 		throw new Error('Failed to get outerHTML.');
@@ -288,15 +259,45 @@ async function extractNodeData(connection: ICDPConnection, id: { backendNodeId?:
 		currentNode = currentNode.parentId ? discoveredNodesByNodeId[currentNode.parentId] : undefined;
 	}
 
+	// Build the computed style string and filtered computedStyles record
+	let computedStyle = rulesText;
 	let computedStyles: Record<string, string> | undefined;
 	try {
 		const { computedStyle: computedStyleArray } = await connection.sendCommand('CSS.getComputedStyleForNode', { nodeId }) as { computedStyle?: Array<{ name: string; value: string }> };
 		if (computedStyleArray) {
 			computedStyles = {};
+
+			// Collect resolved property values into a map for shorthand collapsing
+			const resolvedMap = new Map<string, string>();
+			const varLines: string[] = [];
+
 			for (const prop of computedStyleArray) {
-				if (prop.name && typeof prop.value === 'string') {
+				if (!prop.name || typeof prop.value !== 'string') {
+					continue;
+				}
+
+				// Include in computedStyles record: referenced vars + key UI properties
+				if (referencedVars.has(prop.name) || keyComputedProperties.has(prop.name)) {
 					computedStyles[prop.name] = prop.value;
 				}
+
+				// Include in resolved values: any property explicitly set by author rules
+				if (authorPropertyNames.has(prop.name)) {
+					resolvedMap.set(prop.name, prop.value);
+				}
+
+				// Include referenced CSS variable values
+				if (referencedVars.has(prop.name)) {
+					varLines.push(`${prop.name}: ${prop.value};`);
+				}
+			}
+
+			if (resolvedMap.size > 0) {
+				const resolvedLines = collapseToShorthands(resolvedMap);
+				computedStyle += '\n\n/* Resolved values */\n' + resolvedLines.join('\n');
+			}
+			if (varLines.length > 0) {
+				computedStyle += '\n\n/* CSS variables */\n' + varLines.join('\n');
 			}
 		}
 	} catch { }
@@ -310,65 +311,6 @@ async function extractNodeData(connection: ICDPConnection, id: { backendNodeId?:
 		computedStyles,
 		dimensions: { top: y, left: x, width, height }
 	};
-}
-
-function formatMatchedStyles(matched: IMatchedStyles): string {
-	const lines: string[] = [];
-
-	if (matched.inlineStyle?.cssProperties?.length) {
-		lines.push('/* Inline style */');
-		lines.push('element {');
-		for (const prop of matched.inlineStyle.cssProperties) {
-			if (prop.name && prop.value) {
-				lines.push(`  ${prop.name}: ${prop.value};`);
-			}
-		}
-		lines.push('}\n');
-	}
-
-	if (matched.matchedCSSRules?.length) {
-		for (const ruleEntry of matched.matchedCSSRules) {
-			const rule = ruleEntry.rule;
-			const selectors = rule.selectorList.selectors.map((s: { text: string }) => s.text).join(', ');
-			lines.push(`/* Matched Rule from ${rule.origin} */`);
-			lines.push(`${selectors} {`);
-			for (const prop of rule.style.cssProperties) {
-				if (prop.name && prop.value) {
-					lines.push(`  ${prop.name}: ${prop.value};`);
-				}
-			}
-			lines.push('}\n');
-		}
-	}
-
-	if (matched.inherited?.length) {
-		let level = 1;
-		for (const inherited of matched.inherited) {
-			if (inherited.inlineStyle) {
-				lines.push(`/* Inherited from ancestor level ${level} (inline) */`);
-				lines.push('element {');
-				lines.push(inherited.inlineStyle.cssText || '');
-				lines.push('}\n');
-			}
-
-			const rules = inherited.matchedCSSRules || [];
-			for (const ruleEntry of rules) {
-				const rule = ruleEntry.rule;
-				const selectors = rule.selectorList.selectors.map((s: { text: string }) => s.text).join(', ');
-				lines.push(`/* Inherited from ancestor level ${level} (${rule.origin}) */`);
-				lines.push(`${selectors} {`);
-				for (const prop of rule.style.cssProperties) {
-					if (prop.name && prop.value) {
-						lines.push(`  ${prop.name}: ${prop.value};`);
-					}
-				}
-				lines.push('}\n');
-			}
-			level++;
-		}
-	}
-
-	return '\n' + lines.join('\n');
 }
 
 function attributeArrayToRecord(attributes: string[]): Record<string, string> {

--- a/src/vs/platform/browserView/test/common/cssHelpers.test.ts
+++ b/src/vs/platform/browserView/test/common/cssHelpers.test.ts
@@ -1,0 +1,337 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { collapseToShorthands, formatAuthorStyles, type IMatchedStyles } from '../../common/cssHelpers.js';
+
+/** Helper: build a Map from an object literal and run collapseToShorthands. */
+function collapse(props: Record<string, string>): string[] {
+	return collapseToShorthands(new Map(Object.entries(props)));
+}
+
+suite('collapseToShorthands', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	// ── Box shorthands ──
+
+	test('margin: all sides equal → 1-value', () => {
+		assert.deepStrictEqual(collapse({
+			'margin-top': '10px', 'margin-right': '10px', 'margin-bottom': '10px', 'margin-left': '10px',
+		}), ['margin: 10px;']);
+	});
+
+	test('padding: vertical/horizontal → 2-value', () => {
+		assert.deepStrictEqual(collapse({
+			'padding-top': '4px', 'padding-right': '12px', 'padding-bottom': '4px', 'padding-left': '12px',
+		}), ['padding: 4px 12px;']);
+	});
+
+	test('margin: 3-value when left === right', () => {
+		assert.deepStrictEqual(collapse({
+			'margin-top': '10px', 'margin-right': '5px', 'margin-bottom': '20px', 'margin-left': '5px',
+		}), ['margin: 10px 5px 20px;']);
+	});
+
+	test('margin: 4-value when all differ', () => {
+		assert.deepStrictEqual(collapse({
+			'margin-top': '1px', 'margin-right': '2px', 'margin-bottom': '3px', 'margin-left': '4px',
+		}), ['margin: 1px 2px 3px 4px;']);
+	});
+
+	test('border-radius: uniform', () => {
+		assert.deepStrictEqual(collapse({
+			'border-top-left-radius': '6px', 'border-top-right-radius': '6px',
+			'border-bottom-right-radius': '6px', 'border-bottom-left-radius': '6px',
+		}), ['border-radius: 6px;']);
+	});
+
+	// ── Border ──
+
+	test('border: uniform sides → single shorthand', () => {
+		assert.deepStrictEqual(collapse({
+			'border-top-width': '1px', 'border-right-width': '1px', 'border-bottom-width': '1px', 'border-left-width': '1px',
+			'border-top-style': 'solid', 'border-right-style': 'solid', 'border-bottom-style': 'solid', 'border-left-style': 'solid',
+			'border-top-color': 'red', 'border-right-color': 'red', 'border-bottom-color': 'red', 'border-left-color': 'red',
+		}), ['border: 1px solid red;']);
+	});
+
+	test('border: non-uniform → per-group shorthands', () => {
+		const result = collapse({
+			'border-top-width': '1px', 'border-right-width': '2px', 'border-bottom-width': '1px', 'border-left-width': '2px',
+			'border-top-style': 'solid', 'border-right-style': 'solid', 'border-bottom-style': 'solid', 'border-left-style': 'solid',
+			'border-top-color': 'red', 'border-right-color': 'red', 'border-bottom-color': 'red', 'border-left-color': 'red',
+		});
+		assert.deepStrictEqual(result, [
+			'border-width: 1px 2px;',
+			'border-style: solid;',
+			'border-color: red;',
+		]);
+	});
+
+	// ── Drop-when-all-default ──
+
+	test('border-image at defaults → dropped entirely', () => {
+		assert.deepStrictEqual(collapse({
+			'border-image-source': 'none', 'border-image-slice': '100%',
+			'border-image-width': '1', 'border-image-outset': '0', 'border-image-repeat': 'stretch',
+			'color': 'red',
+		}), ['color: red;']);
+	});
+
+	test('animation-range at defaults → dropped', () => {
+		assert.deepStrictEqual(collapse({
+			'animation-range-start': 'normal', 'animation-range-end': 'normal',
+			'display': 'block',
+		}), ['display: block;']);
+	});
+
+	// ── Background ──
+
+	test('background: color-only when others at default', () => {
+		assert.deepStrictEqual(collapse({
+			'background-color': 'rgb(255, 0, 0)',
+			'background-image': 'none', 'background-position-x': '0px', 'background-position-y': '0px',
+			'background-size': 'auto', 'background-repeat': 'repeat', 'background-attachment': 'scroll',
+			'background-origin': 'padding-box', 'background-clip': 'border-box',
+		}), ['background: rgb(255, 0, 0);']);
+	});
+
+	// ── Text-decoration ──
+
+	test('text-decoration: none', () => {
+		assert.deepStrictEqual(collapse({
+			'text-decoration-line': 'none', 'text-decoration-style': 'solid',
+			'text-decoration-color': 'currentcolor', 'text-decoration-thickness': 'auto',
+		}), ['text-decoration: none;']);
+	});
+
+	test('text-decoration: underline with non-default style', () => {
+		assert.deepStrictEqual(collapse({
+			'text-decoration-line': 'underline', 'text-decoration-style': 'wavy',
+			'text-decoration-color': 'currentcolor', 'text-decoration-thickness': 'auto',
+		}), ['text-decoration: underline wavy;']);
+	});
+
+	// ── White-space ──
+
+	test('white-space: nowrap', () => {
+		assert.deepStrictEqual(collapse({
+			'white-space-collapse': 'collapse', 'text-wrap-mode': 'nowrap',
+		}), ['white-space: nowrap;']);
+	});
+
+	test('white-space: pre-wrap', () => {
+		assert.deepStrictEqual(collapse({
+			'white-space-collapse': 'preserve', 'text-wrap-mode': 'wrap',
+		}), ['white-space: pre-wrap;']);
+	});
+
+	// ── Transition ──
+
+	test('transition: single property with cubic-bezier', () => {
+		assert.deepStrictEqual(collapse({
+			'transition-property': 'opacity',
+			'transition-duration': '0.5s',
+			'transition-timing-function': 'cubic-bezier(0.16, 1, 0.3, 1)',
+			'transition-delay': '0s',
+			'transition-behavior': 'normal',
+		}), ['transition: opacity 0.5s cubic-bezier(0.16, 1, 0.3, 1);']);
+	});
+
+	test('transition: multi-property comma-separated', () => {
+		assert.deepStrictEqual(collapse({
+			'transition-property': 'opacity, transform',
+			'transition-duration': '0.5s, 0.3s',
+			'transition-timing-function': 'ease, ease',
+			'transition-delay': '0s, 0s',
+			'transition-behavior': 'normal, normal',
+		}), ['transition: opacity 0.5s, transform 0.3s;']);
+	});
+
+	// ── Animation ──
+
+	test('animation: name and duration only', () => {
+		assert.deepStrictEqual(collapse({
+			'animation-name': 'fadeIn', 'animation-duration': '0.3s',
+			'animation-timing-function': 'ease', 'animation-delay': '0s',
+			'animation-iteration-count': '1', 'animation-direction': 'normal',
+			'animation-fill-mode': 'none', 'animation-play-state': 'running',
+			'animation-timeline': 'auto',
+		}), ['animation: fadeIn 0.3s;']);
+	});
+
+	test('animation: with fill-mode and custom easing', () => {
+		assert.deepStrictEqual(collapse({
+			'animation-name': 'slideIn', 'animation-duration': '0.5s',
+			'animation-timing-function': 'ease-in-out', 'animation-delay': '0s',
+			'animation-iteration-count': '1', 'animation-direction': 'normal',
+			'animation-fill-mode': 'forwards', 'animation-play-state': 'running',
+			'animation-timeline': 'auto',
+		}), ['animation: slideIn 0.5s ease-in-out forwards;']);
+	});
+
+	// ── Remaining properties pass through sorted ──
+
+	test('unknown properties pass through alphabetically', () => {
+		assert.deepStrictEqual(collapse({
+			'z-index': '1', 'color': 'red', 'display': 'flex',
+		}), ['color: red;', 'display: flex;', 'z-index: 1;']);
+	});
+
+	// ── Mixed: realistic GitHub-like element ──
+
+	test('realistic element with multiple shorthand groups', () => {
+		const result = collapse({
+			'padding-top': '4px', 'padding-right': '12px', 'padding-bottom': '4px', 'padding-left': '12px',
+			'border-top-left-radius': '6px', 'border-top-right-radius': '6px',
+			'border-bottom-right-radius': '6px', 'border-bottom-left-radius': '6px',
+			'border-top-width': '1px', 'border-right-width': '1px', 'border-bottom-width': '1px', 'border-left-width': '1px',
+			'border-top-style': 'solid', 'border-right-style': 'solid', 'border-bottom-style': 'solid', 'border-left-style': 'solid',
+			'border-top-color': 'rgb(209, 217, 224)', 'border-right-color': 'rgb(209, 217, 224)',
+			'border-bottom-color': 'rgb(209, 217, 224)', 'border-left-color': 'rgb(209, 217, 224)',
+			'border-image-source': 'none', 'border-image-slice': '100%',
+			'border-image-width': '1', 'border-image-outset': '0', 'border-image-repeat': 'stretch',
+			'background-color': 'rgba(0, 0, 0, 0)',
+			'background-image': 'none', 'background-position-x': '0px', 'background-position-y': '0px',
+			'background-size': 'auto', 'background-repeat': 'repeat', 'background-attachment': 'scroll',
+			'background-origin': 'padding-box', 'background-clip': 'border-box',
+			'text-decoration-line': 'none', 'text-decoration-style': 'solid',
+			'text-decoration-color': 'currentcolor', 'text-decoration-thickness': 'auto',
+			'white-space-collapse': 'collapse', 'text-wrap-mode': 'nowrap',
+			'transition-property': 'opacity, transform',
+			'transition-duration': '0.5s, 0.5s',
+			'transition-timing-function': 'cubic-bezier(0.16, 1, 0.3, 1), cubic-bezier(0.16, 1, 0.3, 1)',
+			'transition-delay': '0s, 0s',
+			'transition-behavior': 'normal, normal',
+			'color': 'rgb(255, 255, 255)',
+			'display': 'inline-flex',
+			'font-size': '14px',
+		});
+		assert.deepStrictEqual(result, [
+			'padding: 4px 12px;',
+			'border-radius: 6px;',
+			'border: 1px solid rgb(209, 217, 224);',
+			'background: rgba(0, 0, 0, 0);',
+			'text-decoration: none;',
+			'white-space: nowrap;',
+			'transition: opacity 0.5s cubic-bezier(0.16, 1, 0.3, 1), transform 0.5s cubic-bezier(0.16, 1, 0.3, 1);',
+			'color: rgb(255, 255, 255);',
+			'display: inline-flex;',
+			'font-size: 14px;',
+		]);
+	});
+});
+
+// ── Helper to build CDP-like rule matches ──
+
+function rule(selector: string, cssText: string, origin = 'regular'): { rule: { selectorList: { selectors: { text: string }[] }; origin: string; style: { cssText: string; cssProperties: { name: string; value: string }[] } } } {
+	const props = cssText.split(';').map(d => d.trim()).filter(Boolean).map(d => {
+		const [name, ...rest] = d.split(':');
+		return { name: name.trim(), value: rest.join(':').trim() };
+	});
+	return { rule: { selectorList: { selectors: [{ text: selector }] }, origin, style: { cssText, cssProperties: props } } };
+}
+
+suite('formatAuthorStyles', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('includes direct author rules and skips user-agent', () => {
+		const matched: IMatchedStyles = {
+			matchedCSSRules: [
+				rule('.btn', 'padding: 8px; color: white;'),
+				rule('button', 'display: inline-block;', 'user-agent'),
+			],
+		};
+		const { rulesText } = formatAuthorStyles(matched);
+		assert.ok(rulesText.includes('.btn'));
+		assert.ok(rulesText.includes('padding: 8px'));
+		assert.ok(!rulesText.includes('display: inline-block'));
+	});
+
+	test('includes pseudo-element styles', () => {
+		const matched: IMatchedStyles = {
+			matchedCSSRules: [rule('.btn', 'color: white;')],
+			pseudoElements: [
+				{
+					pseudoType: 'before',
+					matches: [rule('.btn::before', 'content: "→"; color: red;')],
+				},
+				{
+					pseudoType: 'after',
+					matches: [rule('.btn::after', 'content: "✓"; color: green;')],
+				},
+			],
+		};
+		const { rulesText } = formatAuthorStyles(matched);
+		assert.ok(rulesText.includes('/* Pseudo-elements */'));
+		assert.ok(rulesText.includes('.btn::before'));
+		assert.ok(rulesText.includes('.btn::after'));
+		assert.ok(rulesText.includes('content: "→"'));
+	});
+
+	test('skips user-agent pseudo-element rules', () => {
+		const matched: IMatchedStyles = {
+			matchedCSSRules: [rule('.x', 'color: red;')],
+			pseudoElements: [
+				{
+					pseudoType: 'before',
+					matches: [rule('input::before', 'content: "";', 'user-agent')],
+				},
+			],
+		};
+		const { rulesText } = formatAuthorStyles(matched);
+		assert.ok(!rulesText.includes('Pseudo-elements'));
+	});
+
+	test('filters inherited rules to inheritable properties only', () => {
+		const matched: IMatchedStyles = {
+			matchedCSSRules: [rule('.child', 'display: flex;')],
+			inherited: [{
+				matchedCSSRules: [rule('body', 'font-family: sans-serif; background: red; margin: 0;')],
+			}],
+		};
+		const { rulesText } = formatAuthorStyles(matched);
+		assert.ok(rulesText.includes('font-family: sans-serif'));
+		assert.ok(!rulesText.includes('background'));
+		assert.ok(!rulesText.includes('margin'));
+	});
+
+	test('collects var references from rules', () => {
+		const matched: IMatchedStyles = {
+			matchedCSSRules: [rule('.x', 'color: var(--fg-color); border: var(--border-width) solid;')],
+		};
+		const { referencedVars } = formatAuthorStyles(matched);
+		assert.ok(referencedVars.has('--fg-color'));
+		assert.ok(referencedVars.has('--border-width'));
+	});
+
+	test('tracks author property names from cssProperties longhands', () => {
+		const matched: IMatchedStyles = {
+			matchedCSSRules: [{
+				rule: {
+					selectorList: { selectors: [{ text: '.x' }] },
+					origin: 'regular',
+					style: {
+						cssText: 'border: 1px solid red;',
+						cssProperties: [
+							{ name: 'border-top-width', value: '1px' },
+							{ name: 'border-top-style', value: 'solid' },
+							{ name: 'border-top-color', value: 'red' },
+						],
+					},
+				},
+			}],
+		};
+		const { authorPropertyNames } = formatAuthorStyles(matched);
+		assert.ok(authorPropertyNames.has('border-top-width'));
+		assert.ok(authorPropertyNames.has('border-top-style'));
+		// Always-shown properties
+		assert.ok(authorPropertyNames.has('display'));
+		assert.ok(authorPropertyNames.has('width'));
+	});
+});

--- a/src/vs/workbench/contrib/browserView/electron-browser/features/browserEditorChatFeatures.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/features/browserEditorChatFeatures.ts
@@ -62,55 +62,7 @@ function formatElementPath(ancestors: readonly IElementAncestor[] | undefined): 
 		.join(' > ');
 }
 
-function createBoxShorthand(entries: Map<string, string>, propertyName: 'margin' | 'padding'): string | undefined {
-	const topKey = `${propertyName}-top`;
-	const rightKey = `${propertyName}-right`;
-	const bottomKey = `${propertyName}-bottom`;
-	const leftKey = `${propertyName}-left`;
-
-	const top = entries.get(topKey);
-	const right = entries.get(rightKey);
-	const bottom = entries.get(bottomKey);
-	const left = entries.get(leftKey);
-
-	if (top === undefined || right === undefined || bottom === undefined || left === undefined) {
-		return undefined;
-	}
-
-	entries.delete(topKey);
-	entries.delete(rightKey);
-	entries.delete(bottomKey);
-	entries.delete(leftKey);
-
-	return `${top} ${right} ${bottom} ${left}`;
-}
-
-function formatElementMap(entries: Readonly<Record<string, string>> | undefined): string | undefined {
-	if (!entries || Object.keys(entries).length === 0) {
-		return undefined;
-	}
-
-	const normalizedEntries = new Map(Object.entries(entries));
-	const lines: string[] = [];
-
-	const marginShorthand = createBoxShorthand(normalizedEntries, 'margin');
-	if (marginShorthand) {
-		lines.push(`- margin: ${marginShorthand}`);
-	}
-
-	const paddingShorthand = createBoxShorthand(normalizedEntries, 'padding');
-	if (paddingShorthand) {
-		lines.push(`- padding: ${paddingShorthand}`);
-	}
-
-	for (const [name, value] of Array.from(normalizedEntries.entries()).sort(([a], [b]) => a.localeCompare(b))) {
-		lines.push(`- ${name}: ${value}`);
-	}
-
-	return lines.join('\n');
-}
-
-function createElementContextValue(elementData: IElementData, displayName: string, attachCss: boolean): string {
+function createElementContextValue(elementData: IElementData, displayName: string): string {
 	const sections: string[] = [];
 	sections.push('Attached Element Context from Integrated Browser');
 	sections.push(`Element: ${displayName}`);
@@ -121,18 +73,10 @@ function createElementContextValue(elementData: IElementData, displayName: strin
 
 	const htmlPath = formatElementPath(elementData.ancestors);
 	if (htmlPath) {
-		sections.push(`HTML Path:\n${htmlPath}`);
+		sections.push(`HTML Path: ${htmlPath}`);
 	}
 
-	const attributeTable = formatElementMap(elementData.attributes);
-	if (attributeTable) {
-		sections.push(`Attributes:\n${attributeTable}`);
-	}
-
-	const innerText = elementData.innerText?.trim();
-	if (innerText) {
-		sections.push(`Inner Text:\n\`\`\`text\n${innerText}\n\`\`\``);
-	}
+	sections.push(`Outer HTML:\n\`\`\`html\n${elementData.outerHTML}\n\`\`\``);
 
 	if (elementData.dimensions) {
 		const { top, left, width, height } = elementData.dimensions;
@@ -141,15 +85,7 @@ function createElementContextValue(elementData: IElementData, displayName: strin
 		);
 	}
 
-	sections.push(`Outer HTML:\n\`\`\`html\n${elementData.outerHTML}\n\`\`\``);
-
-	if (attachCss) {
-		const computedStyleTable = formatElementMap(elementData.computedStyles);
-		if (computedStyleTable) {
-			sections.push(`Computed Styles:\n${computedStyleTable}`);
-		}
-		sections.push(`Full Computed CSS:\n\`\`\`css\n${elementData.computedStyle}\n\`\`\``);
-	}
+	sections.push(`CSS:\n\`\`\`css\n${elementData.computedStyle}\n\`\`\``);
 
 	return sections.join('\n\n');
 }
@@ -412,22 +348,19 @@ export class BrowserEditorChatIntegration extends BrowserEditorContribution {
 			displayNameFull = `${last.tagName.toLowerCase()}${last.id ? `#${last.id}` : ''}${last.classNames && last.classNames.length ? `.${last.classNames.join('.')}` : ''}${pseudo}`;
 		}
 
-		const attachCss = this.configurationService.getValue<boolean>('chat.sendElementsToChat.attachCSS');
-		const value = createElementContextValue(elementData, displayNameFull, attachCss);
+		const value = createElementContextValue(elementData, displayNameFull);
 
 		toAttach.push({
 			id: 'element-' + Date.now(),
 			name: displayNameShort,
 			fullName: displayNameFull,
 			value: value,
-			modelDescription: attachCss
-				? 'Structured browser element context with HTML path, attributes, and computed styles.'
-				: 'Structured browser element context with HTML path and attributes.',
+			modelDescription: 'Structured browser element context with HTML path, attributes, and computed styles.',
 			kind: 'element',
 			icon: ThemeIcon.fromId(Codicon.layout.id),
 			ancestors: elementData.ancestors,
 			attributes: elementData.attributes,
-			computedStyles: attachCss ? elementData.computedStyles : undefined,
+			computedStyles: elementData.computedStyles,
 			dimensions: elementData.dimensions,
 			innerText,
 		});
@@ -468,7 +401,7 @@ export class BrowserEditorChatIntegration extends BrowserEditorContribution {
 		};
 
 		this.telemetryService.publicLog2<IntegratedBrowserAddElementToChatAddedEvent, IntegratedBrowserAddElementToChatAddedClassification>('integratedBrowser.addElementToChat.added', {
-			attachCss,
+			attachCss: true,
 			attachImages
 		});
 	}

--- a/src/vs/workbench/contrib/browserView/electron-browser/features/browserEditorChatFeatures.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/features/browserEditorChatFeatures.ts
@@ -355,7 +355,7 @@ export class BrowserEditorChatIntegration extends BrowserEditorContribution {
 			name: displayNameShort,
 			fullName: displayNameFull,
 			value: value,
-			modelDescription: 'Structured browser element context with HTML path, attributes, and computed styles.',
+			modelDescription: 'Structured browser element context with HTML path, outer HTML, dimensions, and computed styles.',
 			kind: 'element',
 			icon: ThemeIcon.fromId(Codicon.layout.id),
 			ancestors: elementData.ancestors,
@@ -389,19 +389,16 @@ export class BrowserEditorChatIntegration extends BrowserEditorContribution {
 		widget?.attachmentModel?.addContext(...toAttach);
 
 		type IntegratedBrowserAddElementToChatAddedEvent = {
-			attachCss: boolean;
 			attachImages: boolean;
 		};
 
 		type IntegratedBrowserAddElementToChatAddedClassification = {
-			attachCss: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether chat.sendElementsToChat.attachCSS was enabled.' };
 			attachImages: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether chat.sendElementsToChat.attachImages was enabled.' };
 			owner: 'jruales';
 			comment: 'An element was successfully added to chat from Integrated Browser.';
 		};
 
 		this.telemetryService.publicLog2<IntegratedBrowserAddElementToChatAddedEvent, IntegratedBrowserAddElementToChatAddedClassification>('integratedBrowser.addElementToChat.added', {
-			attachCss: true,
 			attachImages
 		});
 	}

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -578,12 +578,6 @@ configurationRegistry.registerConfiguration({
 				},
 			}
 		},
-		'chat.sendElementsToChat.attachCSS': {
-			default: true,
-			markdownDescription: nls.localize('chat.sendElementsToChat.attachCSS', "Controls whether CSS of the selected element will be added to the chat."),
-			type: 'boolean',
-			tags: ['preview']
-		},
 		'chat.sendElementsToChat.attachImages': {
 			default: true,
 			markdownDescription: nls.localize('chat.sendElementsToChat.attachImages', "Controls whether a screenshot of the selected element will be added to the chat."),


### PR DESCRIPTION
Closes #314188
Fixes https://github.com/microsoft/vscode/issues/291005

Reduces the attachment size by ~97-99% or more on some sites. This is mostly by eliding CSS properties that have not been changed, as well as rules and variables that do not apply to the element.

Also removes the `chat.sendElementsToChat.attachCSS` setting as it shouldn't be necessary to toggle anymore.