### PR TITLE
Add IChatInputNotificationService mock to chat input fixture

### DIFF
--- a/src/vs/workbench/test/browser/componentFixtures/chat/chatInput.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/chat/chatInput.fixture.ts
@@ -31,6 +31,7 @@ import { IChatAttachmentResolveService } from '../../../../contrib/chat/browser/
 import { IChatAttachmentWidgetRegistry } from '../../../../contrib/chat/browser/attachments/chatAttachmentWidgetRegistry.js';
 import { IChatContextService } from '../../../../contrib/chat/browser/contextContrib/chatContextService.js';
 import { IChatImageCarouselService } from '../../../../contrib/chat/browser/chatImageCarouselService.js';
+import { IChatInputNotificationService } from '../../../../contrib/chat/browser/widget/input/chatInputNotificationService.js';
 import { ChatInputPart, IChatInputPartOptions, IChatInputStyles } from '../../../../contrib/chat/browser/widget/input/chatInputPart.js';
 import { IArtifactSourceGroup, IChatArtifacts, IChatArtifactsService } from '../../../../contrib/chat/common/tools/chatArtifactsService.js';
 import { ChatEditingSessionState, IChatEditingSession, IModifiedFileEntry, ModifiedFileEntryState } from '../../../../contrib/chat/common/editing/chatEditingService.js';
@@ -133,6 +134,10 @@ async function renderChatInput(context: ComponentFixtureContext, fixtureOptions:
 			reg.defineInstance(IExtensionService, new class extends mock<IExtensionService>() { override readonly onDidChangeExtensions = Event.None; }());
 			reg.defineInstance(IPathService, new class extends mock<IPathService>() { }());
 			reg.defineInstance(IChatWidgetHistoryService, new class extends mock<IChatWidgetHistoryService>() { override getHistory() { return []; } override readonly onDidChangeHistory = Event.None; }());
+			reg.defineInstance(IChatInputNotificationService, new class extends mock<IChatInputNotificationService>() {
+				override readonly onDidChange = Event.None;
+				override getActiveNotification() { return undefined; }
+			}());
 			reg.defineInstance(IChatContextPickService, new class extends mock<IChatContextPickService>() { }());
 			reg.defineInstance(IListService, new ListService());
 			reg.defineInstance(INotebookDocumentService, new class extends mock<INotebookDocumentService>() { }());


### PR DESCRIPTION
Fixes 
```
Fixtures that failed to render — no screenshot was produced.
  
  <details open><summary><code>chat/input/chatInput/Default/Dark</code> — [createInstance] ChatInputPart depends on UNKNOWN service chatInputNotificationService.</summary>
  
  ```
  Error: [createInstance] ChatInputPart depends on UNKNOWN service chatInputNotificationService.
      at TestInstantiationService._throwIfStrict (file:///home/runner/work/vscode/vscode/src/vs/platform/instantiation/common/instantiationService.ts:392:10)
      at TestInstantiationService._createInstance (file:///home/runner/work/vscode/vscode/src/vs/platform/instantiation/common/instantiationService.ts:142:10)
      at TestInstantiationService.createInstance (file:///home/runner/work/vscode/vscode/src/vs/platform/instantiation/common/instantiationService.ts:128:18)
      at TestInstantiationService.createInstance (file:///home/runner/work/vscode/vscode/src/vs/platform/instantiation/test/common/instantiationServiceMock.ts:62:16)
      at renderChatInput (file:///home/runner/work/vscode/vscode/src/vs/workbench/test/browser/componentFixtures/chat/chatInput.fixture.ts:207:61)
```