### PR TITLE
plugins: support installing single-plugin source repos

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/pluginInstallService.ts
+++ b/src/vs/workbench/contrib/chat/browser/pluginInstallService.ts
@@ -164,6 +164,25 @@ export class PluginInstallService implements IPluginInstallService {
 		const discoveredPlugins = await this._pluginMarketplaceService.readPluginsFromDirectory(repoDir, reference);
 
 		if (discoveredPlugins.length === 0) {
+			// Fall back to a single-plugin manifest at the repo root
+			// (e.g. `.claude-plugin/plugin.json`). Such repos are not
+			// marketplaces, so we do NOT register the reference under the
+			// `chat.plugins.marketplaces` config — updates flow through
+			// `updatePluginSource` via the plugin's git source descriptor.
+			const singlePlugin = await this._pluginMarketplaceService.readSinglePluginManifest(repoDir, reference);
+			if (singlePlugin) {
+				if (options?.plugin && options.plugin !== singlePlugin.name) {
+					return {
+						success: false,
+						message: localize('pluginNotFound', "Plugin '{0}' not found in '{1}'.", options.plugin, reference.displayLabel),
+					};
+				}
+				await this.installPlugin(singlePlugin);
+				return options?.plugin
+					? { success: true, matchedPlugin: singlePlugin }
+					: { success: true };
+			}
+
 			void this._pluginRepositoryService.cleanupPluginSource(tempPlugin);
 			return {
 				success: false,

--- a/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
@@ -179,6 +179,17 @@ export interface IPluginMarketplaceService {
 	 * that clone a repo first, then need to discover its plugins.
 	 */
 	readPluginsFromDirectory(repoDir: URI, reference: IMarketplaceReference): Promise<IMarketplacePlugin[]>;
+	/**
+	 * Reads a single-plugin manifest (e.g. `.claude-plugin/plugin.json`) at the
+	 * root of an already-cloned repository directory and returns a synthesised
+	 * {@link IMarketplacePlugin} describing the repository as a single plugin.
+	 * Used by direct-install flows when {@link readPluginsFromDirectory} finds
+	 * no marketplace index.
+	 *
+	 * Returns `undefined` when no recognised manifest is present at the repo
+	 * root.
+	 */
+	readSinglePluginManifest(repoDir: URI, reference: IMarketplaceReference): Promise<IMarketplacePlugin | undefined>;
 }
 
 /**
@@ -190,6 +201,18 @@ const MARKETPLACE_DEFINITIONS: { type: MarketplaceType; path: string }[] = [
 	{ type: MarketplaceType.OpenPlugin, path: '.plugin/marketplace.json' },
 	{ type: MarketplaceType.Copilot, path: '.github/plugin/marketplace.json' },
 	{ type: MarketplaceType.Claude, path: '.claude-plugin/marketplace.json' },
+];
+
+/**
+ * Single-plugin manifest files by type, checked in order. Used when a cloned
+ * source repository has no marketplace index — the repository itself is the
+ * plugin. Order matches {@link detectPluginFormat} so that runtime format
+ * detection later agrees with the marketplace type chosen here.
+ */
+const SINGLE_PLUGIN_MANIFEST_DEFINITIONS: { type: MarketplaceType; path: string }[] = [
+	{ type: MarketplaceType.OpenPlugin, path: '.plugin/plugin.json' },
+	{ type: MarketplaceType.Claude, path: '.claude-plugin/plugin.json' },
+	{ type: MarketplaceType.Copilot, path: 'plugin.json' },
 ];
 
 const GITHUB_MARKETPLACE_CACHE_TTL_MS = 8 * 60 * 60 * 1000;
@@ -607,7 +630,18 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 
 			try {
 				const repoDir = this._pluginRepositoryService.getRepositoryUri(reference);
-				const plugins = await this._readPluginsFromDirectory(repoDir, reference);
+				let plugins = await this._readPluginsFromDirectory(repoDir, reference);
+				if (plugins.length === 0) {
+					// The entry may have come from a single-plugin repo
+					// installed via `installPluginFromSource` (no
+					// marketplace.json). Try the plugin manifest at the
+					// repo root — its synthesised install URI matches what
+					// `addInstalledPlugin` recorded.
+					const single = await this.readSinglePluginManifest(repoDir, reference);
+					if (single) {
+						plugins = [single];
+					}
+				}
 				const match = plugins.find(p => {
 					const installUri = this._pluginRepositoryService.getPluginInstallUri(p);
 					return isEqual(installUri, entry.pluginUri);
@@ -767,6 +801,53 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 
 	async readPluginsFromDirectory(repoDir: URI, reference: IMarketplaceReference): Promise<IMarketplacePlugin[]> {
 		return this._readPluginsFromDirectory(repoDir, reference);
+	}
+
+	async readSinglePluginManifest(repoDir: URI, reference: IMarketplaceReference): Promise<IMarketplacePlugin | undefined> {
+		// Single-plugin repos are only meaningful for direct git clones —
+		// there's no synthetic relative-path source to fall back on.
+		if (reference.kind !== MarketplaceReferenceKind.GitHubShorthand && reference.kind !== MarketplaceReferenceKind.GitUri) {
+			return undefined;
+		}
+
+		for (const def of SINGLE_PLUGIN_MANIFEST_DEFINITIONS) {
+			const manifestUri = joinPath(repoDir, def.path);
+			let manifest: Record<string, unknown> | undefined;
+			try {
+				const contents = await this._fileService.readFile(manifestUri);
+				const parsed = parseJSONC(contents.value.toString());
+				if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+					manifest = parsed as Record<string, unknown>;
+				}
+			} catch {
+				continue;
+			}
+			if (!manifest) {
+				continue;
+			}
+
+			const sourceDescriptor: IPluginSourceDescriptor = reference.kind === MarketplaceReferenceKind.GitHubShorthand
+				? { kind: PluginSourceKind.GitHub, repo: reference.githubRepo! }
+				: { kind: PluginSourceKind.GitUrl, url: reference.cloneUrl };
+
+			const manifestName = typeof manifest['name'] === 'string' && manifest['name'] ? manifest['name'] as string : reference.displayLabel;
+			const manifestDescription = typeof manifest['description'] === 'string' ? manifest['description'] as string : '';
+			const manifestVersion = typeof manifest['version'] === 'string' ? manifest['version'] as string : '';
+
+			return {
+				name: manifestName,
+				description: manifestDescription,
+				version: manifestVersion,
+				source: '',
+				sourceDescriptor,
+				marketplace: reference.displayLabel,
+				marketplaceReference: reference,
+				marketplaceType: def.type,
+			};
+		}
+
+		this._logService.debug(`[PluginMarketplaceService] No single-plugin manifest found in ${reference.rawValue}`);
+		return undefined;
 	}
 
 	private async _readPluginsFromDirectory(repoDir: URI, reference: IMarketplaceReference, token?: CancellationToken): Promise<IMarketplacePlugin[]> {

--- a/src/vs/workbench/contrib/chat/test/browser/plugins/pluginInstallService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/plugins/pluginInstallService.test.ts
@@ -72,6 +72,8 @@ suite('PluginInstallService', () => {
 		trustedMarketplaces: string[];
 		/** Plugins returned by readPluginsFromDirectory */
 		readPluginsResult: IMarketplacePlugin[];
+		/** Plugin returned by readSinglePluginManifest (single-plugin repo fallback) */
+		singlePluginManifestResult: IMarketplacePlugin | undefined;
 		/** Result of the quick pick dialog */
 		quickPickResult: { label: string } | undefined;
 		/** Result of the quick input dialog */
@@ -99,6 +101,7 @@ suite('PluginInstallService', () => {
 			marketplaceTrusted: true,
 			trustedMarketplaces: [],
 			readPluginsResult: [],
+			singlePluginManifestResult: undefined,
 			quickPickResult: undefined,
 			quickInputResult: undefined,
 			configuredMarketplaces: [],
@@ -267,6 +270,7 @@ suite('PluginInstallService', () => {
 				state.trustedMarketplaces.push(ref.canonicalId);
 			},
 			readPluginsFromDirectory: async () => state.readPluginsResult,
+			readSinglePluginManifest: async () => state.singlePluginManifestResult,
 		} as unknown as IPluginMarketplaceService);
 
 		// IConfigurationService
@@ -1037,6 +1041,66 @@ suite('PluginInstallService', () => {
 			await service.installPluginFromSource('owner/my-plugin');
 
 			assert.strictEqual(state.updatedMarketplaces, undefined);
+		});
+
+		test('falls back to single-plugin manifest when no marketplace.json exists', async () => {
+			const ref = makeMarketplaceRef('owner/single-plugin-repo');
+			const singlePlugin = createPlugin({
+				name: 'single-plugin-repo',
+				sourceDescriptor: { kind: PluginSourceKind.GitHub, repo: 'owner/single-plugin-repo' },
+				marketplace: ref.displayLabel,
+				marketplaceReference: ref,
+				marketplaceType: MarketplaceType.Claude,
+			});
+			const { service, state } = createService({
+				ensurePluginSourceResult: URI.file('/cache/agentPlugins/github.com/owner/single-plugin-repo'),
+				readPluginsResult: [],
+				singlePluginManifestResult: singlePlugin,
+			});
+
+			await service.installPluginFromSource('owner/single-plugin-repo');
+
+			assert.strictEqual(state.addedPlugins.length, 1);
+			assert.strictEqual(state.addedPlugins[0].plugin.name, 'single-plugin-repo');
+			assert.strictEqual(state.notifications.length, 0);
+			// Single-plugin repos are not marketplaces — config must NOT be touched.
+			assert.strictEqual(state.updatedMarketplaces, undefined);
+		});
+
+		test('reports error when single-plugin manifest name does not match options.plugin', async () => {
+			const ref = makeMarketplaceRef('owner/single-plugin-repo');
+			const singlePlugin = createPlugin({
+				name: 'actual-name',
+				sourceDescriptor: { kind: PluginSourceKind.GitHub, repo: 'owner/single-plugin-repo' },
+				marketplace: ref.displayLabel,
+				marketplaceReference: ref,
+				marketplaceType: MarketplaceType.Claude,
+			});
+			const { service, state } = createService({
+				ensurePluginSourceResult: URI.file('/cache/agentPlugins/github.com/owner/single-plugin-repo'),
+				readPluginsResult: [],
+				singlePluginManifestResult: singlePlugin,
+			});
+
+			const result = await service.installPluginFromValidatedSource('owner/single-plugin-repo', { plugin: 'requested-name' });
+
+			assert.strictEqual(result.success, false);
+			assert.ok(result.message?.includes('not found'));
+			assert.strictEqual(state.addedPlugins.length, 0);
+		});
+
+		test('still reports "no plugins found" when neither marketplace.json nor single-plugin manifest exists', async () => {
+			const { service, state } = createService({
+				ensurePluginSourceResult: URI.file('/cache/agentPlugins/github.com/owner/empty-repo'),
+				readPluginsResult: [],
+				singlePluginManifestResult: undefined,
+			});
+
+			await service.installPluginFromSource('owner/empty-repo');
+
+			assert.strictEqual(state.addedPlugins.length, 0);
+			assert.strictEqual(state.notifications.length, 1);
+			assert.ok(state.notifications[0].message.includes('No plugins found'));
 		});
 	});
 });


### PR DESCRIPTION
plugins: support installing single-plugin source reposAllow `installPluginFromSource` to install repositories that ship a single plugin manifest at theroot (e.g. `.claude-plugin/plugin.json`) instead of requiring a `marketplace.json` index. When themarketplace scan returns no plugins, we now fall back to detecting a plugin manifest at the reporoot, treating the cloned repo itself as one plugin.- Adds `readSinglePluginManifest` to `IPluginMarketplaceService`, mirroring the existing  `MARKETPLACE_DEFINITIONS` table with `.plugin/plugin.json`, `.claude-plugin/plugin.json`, and  root `plugin.json` candidates (order matches `detectPluginFormat`).- Wires the fallback into `_doInstallFromSource`: on a hit we install via the existing git-source  path so the temp clone is reused. Single-plugin repos are not added to  `chat.plugins.marketplaces` config since they are not marketplaces.- Honors `options.plugin` name matching for parity with the marketplace path.- Updates `_hydratePluginMetadata` to fall back to the same single-plugin lookup so installed  entries survive a window reload.- Adds install-service tests covering the success, name-mismatch, and no-manifest-found paths.(Commit message generated by Copilot)