### PR TITLE
sessions: show Rename action for local agent host sessions

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
@@ -18,6 +18,7 @@ import { IViewsService } from '../../../../../workbench/services/views/common/vi
 import { EditorsVisibleContext, IsAuxiliaryWindowContext, IsSessionsWindowContext } from '../../../../../workbench/common/contextkeys.js';
 import { IChatWidgetService } from '../../../../../workbench/contrib/chat/browser/chat.js';
 import { AUX_WINDOW_GROUP } from '../../../../../workbench/services/editor/common/editorService.js';
+import { ANY_AGENT_HOST_PROVIDER_RE } from '../../../../common/agentHostSessionsProvider.js';
 import { SessionsCategories } from '../../../../common/categories.js';
 import { ChatSessionProviderIdContext, IsActiveSessionArchivedContext, IsNewChatSessionContext, SessionsWelcomeVisibleContext } from '../../../../common/contextkeys.js';
 import { SessionItemToolbarMenuId, SessionItemContextMenuId, SessionSectionToolbarMenuId, SessionSectionTypeContext, IsSessionPinnedContext, IsSessionArchivedContext, IsSessionReadContext, SessionsGrouping, SessionsSorting, ISessionSection } from './sessionsList.js';
@@ -634,7 +635,7 @@ registerAction2(class RenameSessionAction extends Action2 {
 				id: SessionItemContextMenuId,
 				group: '1_edit',
 				order: 1,
-				when: ContextKeyExpr.regex(ChatSessionProviderIdContext.key, /^agenthost-/),
+				when: ContextKeyExpr.regex(ChatSessionProviderIdContext.key, ANY_AGENT_HOST_PROVIDER_RE),
 			}]
 		});
 	}


### PR DESCRIPTION
The Rename action in the sessions list context menu disappeared for local agent host sessions.

## Root cause

The rename action (`sessionsViewPane.renameSession`) was gated on the regex `/^agenthost-/` against `ChatSessionProviderIdContext`. The local agent host provider id is `local-agent-host`, so the action was hidden for those sessions.

The action was originally added in #306204 when all agent host providers shared the `agenthost-` prefix. When the local agent host was later split out under its own `local-agent-host` provider id, other call sites moved to the shared `ANY_AGENT_HOST_PROVIDER_RE` helper (`/^(local-agent-host|agenthost-)/`), but the rename action's inline regex was missed.

## Fix

Use `ANY_AGENT_HOST_PROVIDER_RE` from `src/vs/sessions/common/agentHostSessionsProvider.ts` so rename shows for both local and remote agent host sessions, matching the pattern already used by `agentSessionSettings.contribution.ts` and `agentHostSettings.contribution.ts`.

(Written by Copilot)
