### PR TITLE
Update chat inline references after late anchor resolution

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
@@ -32,7 +32,7 @@ import { AddDynamicVariableAction, IAddDynamicVariableContext } from '../../cont
 import { IChatAgentHistoryEntry, IChatAgentImplementation, IChatAgentRequest, IChatAgentService } from '../../contrib/chat/common/participants/chatAgents.js';
 import { IAgentSkill, IChatPromptSlashCommand, ICustomAgent, IInstructionFile, IPromptFileContext, IPromptPath, IPromptsService, PromptsStorage } from '../../contrib/chat/common/promptSyntax/service/promptsService.js';
 import { isValidPromptType, PromptsType } from '../../contrib/chat/common/promptSyntax/promptTypes.js';
-import { IChatModel } from '../../contrib/chat/common/model/chatModel.js';
+import { IChatModel, IChatResponseModel } from '../../contrib/chat/common/model/chatModel.js';
 import { ChatRequestAgentPart } from '../../contrib/chat/common/requestParser/chatParserTypes.js';
 import { ChatRequestParser, IChatParserContext } from '../../contrib/chat/common/requestParser/chatRequestParser.js';
 import { getDynamicVariablesForWidget, getSelectedToolAndToolSetsForWidget } from '../../contrib/chat/browser/attachments/chatVariables.js';
@@ -56,6 +56,10 @@ interface AgentData {
 	id: string;
 	extensionId: ExtensionIdentifier;
 	hasFollowups?: boolean;
+}
+
+interface UnresolvedAnchor {
+	readonly response: IChatResponseModel;
 }
 
 export class MainThreadChatTask implements IChatTask {
@@ -117,7 +121,7 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 
 	private readonly _activeTasks = new Map<string, IChatTask>();
 
-	private readonly _unresolvedAnchors = new Map</* requestId */string, Map</* id */ string, IChatContentInlineReference>>();
+	private readonly _unresolvedAnchors = new Map</* requestId */string, Map</* id */ string, UnresolvedAnchor>>();
 
 	constructor(
 		extHostContext: IExtHostContext,
@@ -567,11 +571,11 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 				continue;
 			}
 
-			if (revivedProgress.kind === 'inlineReference' && revivedProgress.resolveId) {
+			if (revivedProgress.kind === 'inlineReference' && revivedProgress.resolveId && response) {
 				if (!this._unresolvedAnchors.has(requestId)) {
 					this._unresolvedAnchors.set(requestId, new Map());
 				}
-				this._unresolvedAnchors.get(requestId)?.set(revivedProgress.resolveId, revivedProgress);
+				this._unresolvedAnchors.get(requestId)?.set(revivedProgress.resolveId, { response });
 			}
 
 			chatProgressParts.push(revivedProgress);
@@ -581,15 +585,24 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 	}
 
 	$handleAnchorResolve(requestId: string, handle: string, resolveAnchor: Dto<IChatContentInlineReference> | undefined): void {
-		const anchor = this._unresolvedAnchors.get(requestId)?.get(handle);
-		if (!anchor) {
+		const unresolvedAnchorsForRequest = this._unresolvedAnchors.get(requestId);
+		if (!unresolvedAnchorsForRequest) {
 			return;
 		}
 
-		this._unresolvedAnchors.get(requestId)?.delete(handle);
+		const unresolvedAnchor = unresolvedAnchorsForRequest.get(handle);
+		if (!unresolvedAnchor) {
+			return;
+		}
+
+		unresolvedAnchorsForRequest.delete(handle);
+		if (unresolvedAnchorsForRequest.size === 0) {
+			this._unresolvedAnchors.delete(requestId);
+		}
+
 		if (resolveAnchor) {
 			const revivedAnchor = revive(resolveAnchor) as IChatContentInlineReference;
-			anchor.inlineReference = revivedAnchor.inlineReference;
+			unresolvedAnchor.response.resolveInlineReference(handle, revivedAnchor);
 		}
 	}
 

--- a/src/vs/workbench/api/common/extHostChatAgents2.ts
+++ b/src/vs/workbench/api/common/extHostChatAgents2.ts
@@ -420,7 +420,10 @@ export class ChatAgentResponseStream {
 							checkProposedApiEnabled(that._extension, 'chatParticipantAdditions');
 
 							dto.resolveId = generateUuid();
+						}
+						_report(dto);
 
+						if (part.resolve) {
 							const cts = new CancellationTokenSource();
 							part.resolve(cts.token)
 								.then(() => {
@@ -430,7 +433,6 @@ export class ChatAgentResponseStream {
 								.then(() => cts.dispose(), () => cts.dispose());
 							that._sessionDisposables.add(toDisposable(() => cts.dispose(true)));
 						}
-						_report(dto);
 					} else if (part instanceof extHostTypes.ChatResponseExternalEditPart) {
 						const p = this.externalEdit(part.uris, part.callback);
 						p.then((value) => part.didGetApplied(value));

--- a/src/vs/workbench/api/test/common/extHostChatAgents2.test.ts
+++ b/src/vs/workbench/api/test/common/extHostChatAgents2.test.ts
@@ -1,0 +1,72 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { DeferredPromise } from '../../../../base/common/async.js';
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { DisposableStore } from '../../../../base/common/lifecycle.js';
+import { URI } from '../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { ChatAgentLocation } from '../../../contrib/chat/common/constants.js';
+import { IChatAgentRequest } from '../../../contrib/chat/common/participants/chatAgents.js';
+import { nullExtensionDescription } from '../../../services/extensions/common/extensions.js';
+import { ChatAgentResponseStream } from '../../common/extHostChatAgents2.js';
+import { CommandsConverter } from '../../common/extHostCommands.js';
+import { IChatAgentProgressShape, IChatProgressDto } from '../../common/extHost.protocol.js';
+import { ChatResponseAnchorPart } from '../../common/extHostTypes.js';
+
+suite('ExtHostChatAgents2', function () {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('reports anchor before resolving it', async function () {
+		const sessionDisposables = disposables.add(new DisposableStore());
+		const events: string[] = [];
+		const progressChunks: IChatProgressDto[] = [];
+		let resolvedHandle: string | undefined;
+		const proxy: IChatAgentProgressShape = {
+			async $handleProgressChunk(_requestId, chunks) {
+				events.push('progress');
+				for (const chunk of chunks) {
+					progressChunks.push(Array.isArray(chunk) ? chunk[0] : chunk);
+				}
+			},
+			$handleAnchorResolve(_requestId, handle) {
+				events.push('resolve');
+				resolvedHandle = handle;
+			}
+		};
+		const request: IChatAgentRequest = {
+			sessionResource: URI.parse('chat-session:/test'),
+			requestId: 'requestId',
+			agentId: 'agentId',
+			message: '',
+			variables: { variables: [] },
+			location: ChatAgentLocation.Chat
+		};
+		const stream = new ChatAgentResponseStream(
+			{ ...nullExtensionDescription, enabledApiProposals: ['chatParticipantAdditions'] },
+			request,
+			proxy,
+			undefined as unknown as CommandsConverter,
+			sessionDisposables,
+			new Map<string, Map<string, DeferredPromise<Record<string, unknown> | undefined>>>(),
+			CancellationToken.None
+		);
+		const part = new ChatResponseAnchorPart(URI.file('/test/file.ts'), 'TestSymbol');
+		part.resolve = () => Promise.resolve();
+
+		stream.apiObject.push(part);
+
+		await Promise.resolve();
+		await Promise.resolve();
+
+		assert.deepStrictEqual(events, ['progress', 'resolve']);
+		assert.strictEqual(progressChunks.length, 1);
+		const progressChunk = progressChunks[0];
+		assert.strictEqual(progressChunk.kind, 'inlineReference');
+		assert.ok(progressChunk.resolveId);
+		assert.strictEqual(resolvedHandle, progressChunk.resolveId);
+	});
+});

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatInlineAnchorWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatInlineAnchorWidget.ts
@@ -161,8 +161,6 @@ export class InlineAnchorWidget extends Disposable {
 	) {
 		super();
 
-		// TODO: Make sure we handle updates from an inlineReference being `resolved` late
-
 		this.data = 'uri' in inlineReference.inlineReference
 			? inlineReference.inlineReference
 			: 'name' in inlineReference.inlineReference

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMarkdownContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMarkdownContentPart.ts
@@ -23,6 +23,8 @@ import { ScrollbarVisibility } from '../../../../../../base/common/scrollable.js
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { isEqual } from '../../../../../../base/common/resources.js';
 import { URI } from '../../../../../../base/common/uri.js';
+import { Range } from '../../../../../../editor/common/core/range.js';
+import { isLocation, type SymbolTag } from '../../../../../../editor/common/languages.js';
 import { ILanguageService } from '../../../../../../editor/common/languages/language.js';
 import { getIconClasses } from '../../../../../../editor/common/services/getIconClasses.js';
 import { IModelService } from '../../../../../../editor/common/services/model.js';
@@ -46,7 +48,7 @@ import { MarkedKatexSupport } from '../../../../markdown/browser/markedKatexSupp
 import { extractCodeblockUrisFromText, extractVulnerabilitiesFromText } from '../../../common/widget/annotations.js';
 import { IEditSessionDiffStats, IEditSessionEntryDiff } from '../../../common/editing/chatEditingService.js';
 import { IChatProgressRenderableResponseContent } from '../../../common/model/chatModel.js';
-import { IChatMarkdownContent, IChatService, IChatUndoStop } from '../../../common/chatService/chatService.js';
+import { IChatContentInlineReference, IChatMarkdownContent, IChatService, IChatUndoStop } from '../../../common/chatService/chatService.js';
 import { isRequestVM, isResponseVM } from '../../../common/model/chatViewModel.js';
 import { ChatConfiguration } from '../../../common/constants.js';
 import { IChatCodeBlockInfo } from '../../chat.js';
@@ -454,7 +456,7 @@ export class ChatMarkdownContentPart extends Disposable implements IChatContentP
 			return false;
 		}
 
-		if (other.content.value === this.markdown.content.value) {
+		if (other.content.value === this.markdown.content.value && equalsInlineReferences(other.inlineReferences, this.markdown.inlineReferences)) {
 			return true;
 		}
 
@@ -484,6 +486,10 @@ export class ChatMarkdownContentPart extends Disposable implements IChatContentP
 	 */
 	tryIncrementalUpdate(newMarkdown: IChatMarkdownContent): boolean {
 		if (!this._incrementalMorpher) {
+			return false;
+		}
+
+		if (!equalsInlineReferences(newMarkdown.inlineReferences, this.markdown.inlineReferences)) {
 			return false;
 		}
 
@@ -534,6 +540,72 @@ export class ChatMarkdownContentPart extends Disposable implements IChatContentP
 	addDisposable(disposable: IDisposable): void {
 		this._register(disposable);
 	}
+}
+
+function equalsInlineReferences(a: Record<string, IChatContentInlineReference> | undefined, b: Record<string, IChatContentInlineReference> | undefined): boolean {
+	if (a === b) {
+		return true;
+	}
+	if (!a || !b) {
+		return !a && !b;
+	}
+
+	const aKeys = Object.keys(a);
+	const bKeys = Object.keys(b);
+	if (aKeys.length !== bKeys.length) {
+		return false;
+	}
+
+	return aKeys.every(key => equalsInlineReference(a[key], b[key]));
+}
+
+function equalsInlineReference(a: IChatContentInlineReference | undefined, b: IChatContentInlineReference | undefined): boolean {
+	if (!a || !b) {
+		return !a && !b;
+	}
+
+	return a.resolveId === b.resolveId
+		&& a.name === b.name
+		&& equalsInlineReferenceValue(a.inlineReference, b.inlineReference);
+}
+
+type InlineReferenceValue = IChatContentInlineReference['inlineReference'];
+type WorkspaceSymbolInlineReference = Extract<InlineReferenceValue, { name: string; location: unknown }>;
+type WorkspaceSymbolComparer = (a: WorkspaceSymbolInlineReference, b: WorkspaceSymbolInlineReference) => boolean;
+
+const workspaceSymbolComparers: { readonly [K in keyof WorkspaceSymbolInlineReference]-?: WorkspaceSymbolComparer } = {
+	name: (a, b) => a.name === b.name,
+	containerName: (a, b) => a.containerName === b.containerName,
+	kind: (a, b) => a.kind === b.kind,
+	tags: (a, b) => equalsSymbolTags(a.tags, b.tags),
+	location: (a, b) => isEqual(a.location.uri, b.location.uri) && Range.equalsRange(a.location.range, b.location.range),
+};
+
+const workspaceSymbolComparerKeys = Object.keys(workspaceSymbolComparers) as (keyof WorkspaceSymbolInlineReference)[];
+
+function equalsInlineReferenceValue(a: InlineReferenceValue, b: InlineReferenceValue): boolean {
+	if (URI.isUri(a) || URI.isUri(b)) {
+		return URI.isUri(a) && URI.isUri(b) && isEqual(a, b);
+	}
+	if (isLocation(a) || isLocation(b)) {
+		return isLocation(a) && isLocation(b) && isEqual(a.uri, b.uri) && Range.equalsRange(a.range, b.range);
+	}
+
+	return equalsWorkspaceSymbol(a, b);
+}
+
+function equalsWorkspaceSymbol(a: WorkspaceSymbolInlineReference, b: WorkspaceSymbolInlineReference): boolean {
+	return workspaceSymbolComparerKeys.every(key => workspaceSymbolComparers[key](a, b));
+}
+
+function equalsSymbolTags(a: readonly SymbolTag[] | undefined, b: readonly SymbolTag[] | undefined): boolean {
+	if (a === b) {
+		return true;
+	}
+	if (!a || !b || a.length !== b.length) {
+		return false;
+	}
+	return a.every((tag, index) => tag === b[index]);
 }
 
 export function codeblockHasClosingBackticks(str: string): boolean {

--- a/src/vs/workbench/contrib/chat/common/model/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatModel.ts
@@ -310,6 +310,7 @@ export interface IChatResponseModel {
 	setVote(vote: ChatAgentVoteDirection): void;
 	setUsage(usage: IChatUsage): void;
 	setEditApplied(edit: IChatTextEditGroup, editCount: number): boolean;
+	resolveInlineReference(resolveId: string, resolvedReference: IChatContentInlineReference): boolean;
 	updateContent(progress: IChatProgressResponseContent | IChatTextEdit | IChatNotebookEdit | IChatTask | IChatExternalToolInvocationUpdate, quiet?: boolean): void;
 	/**
 	 * Adopts any partially-undo {@link response} as the {@link entireResponse}.
@@ -924,6 +925,25 @@ export class Response extends AbstractResponse implements IDisposable {
 		this._contentChanged();
 	}
 
+	public resolveInlineReference(resolveId: string, resolvedReference: IChatContentInlineReference): boolean {
+		for (let i = 0; i < this._responseParts.length; i++) {
+			const current = this._responseParts[i];
+			if (current.kind !== 'inlineReference' || current.resolveId !== resolveId) {
+				continue;
+			}
+
+			this._responseParts[i] = {
+				...current,
+				inlineReference: resolvedReference.inlineReference,
+				name: resolvedReference.name ?? current.name,
+			};
+			this._contentChanged();
+			return true;
+		}
+
+		return false;
+	}
+
 	private _mergeOrPushTextEditGroup(uri: URI, edits: TextEdit[], done: boolean | undefined, isExternalEdit: boolean | undefined): void {
 		for (const candidate of this._responseParts) {
 			if (candidate.kind === 'textEditGroup' && !candidate.done && isEqual(candidate.uri, uri)) {
@@ -1361,6 +1381,10 @@ export class ChatResponseModel extends Disposable implements IChatResponseModel 
 	 */
 	updateContent(responsePart: IChatProgressResponseContent | IChatTextEdit | IChatNotebookEdit | IChatExternalToolInvocationUpdate, quiet?: boolean) {
 		this._response.updateContent(responsePart, quiet);
+	}
+
+	resolveInlineReference(resolveId: string, resolvedReference: IChatContentInlineReference): boolean {
+		return this._response.resolveInlineReference(resolveId, resolvedReference);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatMarkdownContentPart.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatMarkdownContentPart.test.ts
@@ -11,8 +11,11 @@ import { observableValue } from '../../../../../../../base/common/observable.js'
 import { URI } from '../../../../../../../base/common/uri.js';
 import { mainWindow } from '../../../../../../../base/browser/window.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
+import { Range } from '../../../../../../../editor/common/core/range.js';
+import { SymbolKind, SymbolTag } from '../../../../../../../editor/common/languages.js';
 import { IHoverService } from '../../../../../../../platform/hover/browser/hover.js';
 import { IConfigurationService } from '../../../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { IMarkdownRenderer, IMarkdownRendererService } from '../../../../../../../platform/markdown/browser/markdownRenderer.js';
 import { workbenchInstantiationService } from '../../../../../../test/browser/workbenchTestServices.js';
 import { IChatContentPartRenderContext } from '../../../../browser/widget/chatContentParts/chatContentParts.js';
@@ -20,6 +23,8 @@ import { ChatMarkdownContentPart } from '../../../../browser/widget/chatContentP
 import { EditorPool, DiffEditorPool } from '../../../../browser/widget/chatContentParts/chatContentCodePools.js';
 import { CodeBlockPart, ICodeBlockData } from '../../../../browser/widget/chatContentParts/codeBlockPart.js';
 import { IChatResponseViewModel } from '../../../../common/model/chatViewModel.js';
+import { IChatContentInlineReference } from '../../../../common/chatService/chatService.js';
+import { ChatConfiguration } from '../../../../common/constants.js';
 import { IAiEditTelemetryService } from '../../../../../editTelemetry/browser/telemetry/aiEditTelemetry/aiEditTelemetryService.js';
 import { IViewDescriptorService } from '../../../../../../common/views.js';
 import { IDisposableReference } from '../../../../browser/widget/chatContentParts/chatCollections.js';
@@ -107,13 +112,29 @@ suite('ChatMarkdownContentPart', () => {
 		));
 	}
 
+	function createMarkdownPartWithInlineReferences(markdownText: string, inlineReferences: Record<string, IChatContentInlineReference>, context?: IChatContentPartRenderContext, fillInIncompleteTokens = false): ChatMarkdownContentPart {
+		const ctx = context ?? createRenderContext();
+		return store.add(instantiationService.createInstance(
+			ChatMarkdownContentPart,
+			{ kind: 'markdownContent', content: new MarkdownString(markdownText), inlineReferences },
+			ctx,
+			editorPool,
+			fillInIncompleteTokens,
+			ctx.codeBlockStartIndex,
+			renderer,
+			undefined,
+			500,
+			{},
+		));
+	}
+
 	setup(() => {
 		disposables = store.add(new DisposableStore());
 		instantiationService = workbenchInstantiationService(undefined, disposables);
 		renderedCodeBlocks.length = 0;
 
 		// Seed configuration values needed by ChatEditorOptions
-		const configService = instantiationService.get(IConfigurationService) as import('../../../../../../../platform/configuration/test/common/testConfigurationService.js').TestConfigurationService;
+		const configService = instantiationService.get(IConfigurationService) as TestConfigurationService;
 		configService.setUserConfiguration('chat', {
 			editor: {
 				fontSize: 13,
@@ -244,6 +265,174 @@ suite('ChatMarkdownContentPart', () => {
 	test('hasSameContent returns false for different markdown', () => {
 		const part = createMarkdownPart('Hello');
 		assert.ok(!part.hasSameContent({ kind: 'markdownContent', content: new MarkdownString('Goodbye') }));
+	});
+
+	test('hasSameContent compares inline reference metadata', () => {
+		const uri = URI.parse('file:///workspace/foo.ts');
+		const content = 'Foo';
+		const initialReference: IChatContentInlineReference = {
+			kind: 'inlineReference',
+			resolveId: 'resolve1',
+			inlineReference: { uri, range: new Range(1, 1, 1, 1) },
+			name: 'Foo',
+		};
+		const part = createMarkdownPartWithInlineReferences(content, { 0: initialReference });
+
+		assert.deepStrictEqual({
+			equivalentReference: part.hasSameContent({
+				kind: 'markdownContent',
+				content: new MarkdownString(content),
+				inlineReferences: {
+					0: {
+						kind: 'inlineReference',
+						resolveId: 'resolve1',
+						inlineReference: { uri, range: new Range(1, 1, 1, 1) },
+						name: 'Foo',
+					},
+				},
+			}),
+			resolvedReference: part.hasSameContent({
+				kind: 'markdownContent',
+				content: new MarkdownString(content),
+				inlineReferences: {
+					0: {
+						kind: 'inlineReference',
+						resolveId: 'resolve1',
+						inlineReference: {
+							name: 'Foo',
+							kind: SymbolKind.Class,
+							location: { uri, range: new Range(2, 7, 2, 10) },
+						},
+						name: 'Foo',
+					},
+				},
+			}),
+		}, {
+			equivalentReference: true,
+			resolvedReference: false,
+		});
+	});
+
+	test('hasSameContent compares workspace symbol metadata', () => {
+		const uri = URI.parse('file:///workspace/foo.ts');
+		const content = 'Foo';
+		const initialReference: IChatContentInlineReference = {
+			kind: 'inlineReference',
+			resolveId: 'resolve1',
+			inlineReference: {
+				name: 'Foo',
+				containerName: 'Bar',
+				kind: SymbolKind.Class,
+				tags: [SymbolTag.Deprecated],
+				location: { uri, range: new Range(2, 7, 2, 10) },
+			},
+			name: 'Foo',
+		};
+		const part = createMarkdownPartWithInlineReferences(content, { 0: initialReference });
+
+		assert.deepStrictEqual({
+			equivalentSymbol: part.hasSameContent({
+				kind: 'markdownContent',
+				content: new MarkdownString(content),
+				inlineReferences: {
+					0: {
+						kind: 'inlineReference',
+						resolveId: 'resolve1',
+						inlineReference: {
+							name: 'Foo',
+							containerName: 'Bar',
+							kind: SymbolKind.Class,
+							tags: [SymbolTag.Deprecated],
+							location: { uri, range: new Range(2, 7, 2, 10) },
+						},
+						name: 'Foo',
+					},
+				},
+			}),
+			differentContainer: part.hasSameContent({
+				kind: 'markdownContent',
+				content: new MarkdownString(content),
+				inlineReferences: {
+					0: {
+						kind: 'inlineReference',
+						resolveId: 'resolve1',
+						inlineReference: {
+							name: 'Foo',
+							containerName: 'Baz',
+							kind: SymbolKind.Class,
+							tags: [SymbolTag.Deprecated],
+							location: { uri, range: new Range(2, 7, 2, 10) },
+						},
+						name: 'Foo',
+					},
+				},
+			}),
+			differentTags: part.hasSameContent({
+				kind: 'markdownContent',
+				content: new MarkdownString(content),
+				inlineReferences: {
+					0: {
+						kind: 'inlineReference',
+						resolveId: 'resolve1',
+						inlineReference: {
+							name: 'Foo',
+							containerName: 'Bar',
+							kind: SymbolKind.Class,
+							tags: [],
+							location: { uri, range: new Range(2, 7, 2, 10) },
+						},
+						name: 'Foo',
+					},
+				},
+			}),
+		}, {
+			equivalentSymbol: true,
+			differentContainer: false,
+			differentTags: false,
+		});
+	});
+
+	test('tryIncrementalUpdate requires unchanged inline reference metadata', () => {
+		const configService = instantiationService.get(IConfigurationService) as TestConfigurationService;
+		configService.setUserConfiguration(ChatConfiguration.IncrementalRendering, true);
+
+		const uri = URI.parse('file:///workspace/foo.ts');
+		const content = 'Foo';
+		const initialReference: IChatContentInlineReference = {
+			kind: 'inlineReference',
+			resolveId: 'resolve1',
+			inlineReference: { uri, range: new Range(1, 1, 1, 1) },
+			name: 'Foo',
+		};
+		const context = createRenderContext(false);
+		const part = createMarkdownPartWithInlineReferences(content, { 0: initialReference }, context, true);
+
+		assert.deepStrictEqual({
+			unchangedReference: part.tryIncrementalUpdate({
+				kind: 'markdownContent',
+				content: new MarkdownString(content),
+				inlineReferences: { 0: initialReference },
+			}),
+			resolvedReference: part.tryIncrementalUpdate({
+				kind: 'markdownContent',
+				content: new MarkdownString(content),
+				inlineReferences: {
+					0: {
+						kind: 'inlineReference',
+						resolveId: 'resolve1',
+						inlineReference: {
+							name: 'Foo',
+							kind: SymbolKind.Class,
+							location: { uri, range: new Range(2, 7, 2, 10) },
+						},
+						name: 'Foo',
+					},
+				},
+			}),
+		}, {
+			unchangedReference: true,
+			resolvedReference: false,
+		});
 	});
 
 	test('php code blocks get php opening tag prepended', () => {

--- a/src/vs/workbench/contrib/chat/test/common/model/chatModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/model/chatModel.test.ts
@@ -13,6 +13,7 @@ import { assertSnapshot } from '../../../../../../base/test/common/snapshot.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { Range } from '../../../../../../editor/common/core/range.js';
 import { OffsetRange } from '../../../../../../editor/common/core/ranges/offsetRange.js';
+import { SymbolKind } from '../../../../../../editor/common/languages.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
@@ -354,6 +355,112 @@ suite('Response', () => {
 
 		assert.strictEqual(response.toString(), 'text before https://microsoft.com/ text after');
 
+	});
+
+	test('resolve inline reference updates existing response content', () => {
+		const uri = URI.parse('file:///workspace/foo.ts');
+		const response = store.add(new Response([]));
+		response.updateContent({
+			kind: 'inlineReference',
+			resolveId: 'resolve1',
+			inlineReference: { uri, range: new Range(1, 1, 1, 1) },
+			name: 'Foo',
+		});
+
+		let changes = 0;
+		store.add(response.onDidChangeValue(() => changes++));
+
+		const didResolve = response.resolveInlineReference('resolve1', {
+			kind: 'inlineReference',
+			inlineReference: {
+				name: 'Foo',
+				kind: SymbolKind.Class,
+				location: { uri, range: new Range(2, 7, 2, 10) },
+			},
+		});
+		const resolved = response.value[0];
+		const resolvedReference = resolved.kind === 'inlineReference' ? resolved.inlineReference : undefined;
+
+		assert.deepStrictEqual({
+			didResolve,
+			changes,
+			responseText: response.toString(),
+			resolvedReference,
+		}, {
+			didResolve: true,
+			changes: 1,
+			responseText: '`Foo`',
+			resolvedReference: {
+				name: 'Foo',
+				kind: SymbolKind.Class,
+				location: { uri, range: new Range(2, 7, 2, 10) },
+			},
+		});
+	});
+
+	test('resolve inline reference updates display name when provided', () => {
+		const uri = URI.parse('file:///workspace/foo.ts');
+		const response = store.add(new Response([]));
+		response.updateContent({
+			kind: 'inlineReference',
+			resolveId: 'resolve1',
+			inlineReference: { uri, range: new Range(1, 1, 1, 1) },
+			name: 'Foo',
+		});
+
+		const didResolve = response.resolveInlineReference('resolve1', {
+			kind: 'inlineReference',
+			inlineReference: {
+				name: 'Foo',
+				kind: SymbolKind.Class,
+				location: { uri, range: new Range(2, 7, 2, 10) },
+			},
+			name: 'Resolved Foo',
+		});
+		const resolved = response.value[0];
+
+		assert.deepStrictEqual({
+			didResolve,
+			displayName: resolved.kind === 'inlineReference' ? resolved.name : undefined,
+			responseText: response.toString(),
+		}, {
+			didResolve: true,
+			displayName: 'Resolved Foo',
+			responseText: '`Foo`',
+		});
+	});
+
+	test('resolve inline reference returns false for an unknown resolve id', () => {
+		const uri = URI.parse('file:///workspace/foo.ts');
+		const response = store.add(new Response([]));
+		response.updateContent({
+			kind: 'inlineReference',
+			resolveId: 'resolve1',
+			inlineReference: { uri, range: new Range(1, 1, 1, 1) },
+			name: 'Foo',
+		});
+
+		let changes = 0;
+		store.add(response.onDidChangeValue(() => changes++));
+
+		const didResolve = response.resolveInlineReference('missing', {
+			kind: 'inlineReference',
+			inlineReference: {
+				name: 'Foo',
+				kind: SymbolKind.Class,
+				location: { uri, range: new Range(2, 7, 2, 10) },
+			},
+		});
+
+		assert.deepStrictEqual({
+			didResolve,
+			changes,
+			responseText: response.toString(),
+		}, {
+			didResolve: false,
+			changes: 0,
+			responseText: 'foo.ts',
+		});
 	});
 
 	test('consolidated edit summary', () => {


### PR DESCRIPTION
Fixes late-resolved chat inline references so markdown link anchors can update after the extension host resolves richer symbol information, which is an outstanding TODO item. 

## Changes
- Add response-model support for resolving an existing inline reference by `resolveId`.
- Update main-thread chat anchor resolution to write resolved inline references back into the response model.
- Ensure markdown parts compare inline-reference metadata, not only markdown text.
- Prevent incremental markdown rendering from swallowing metadata-only inline-reference updates.
- Remove the stale TODO for late inline-reference resolution.
- Add coverage for response-model updates, markdown metadata comparison, workspace-symbol metadata, and incremental-rendering behavior.

## Testing
- `npm run compile-check-ts-native`
- `npm run test-browser-no-install -- --run src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatMarkdownContentPart.test.ts --grep "inline reference" --browser chromium`
- `npm run test-node -- --run src/vs/workbench/contrib/chat/test/common/model/chatModel.test.ts --grep "resolve inline reference"`

Part of #313533 