### PR TITLE
sessions: use agent-specific codicons for session type icons

### DIFF
--- a/src/vs/sessions/contrib/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -32,7 +32,7 @@ import { diffsEqual, diffsToChanges, mapProtocolStatus } from './agentHostDiffs.
 import { buildMutableConfigSchema, IAgentHostSessionsProvider, resolvedConfigsEqual } from '../../../common/agentHostSessionsProvider.js';
 import { agentHostSessionWorkspaceKey } from '../../../common/agentHostSessionWorkspace.js';
 import { isSessionConfigComplete } from '../../../common/sessionConfig.js';
-import { IChat, IGitHubInfo, ISession, ISessionChangeset, ISessionType, ISessionWorkspace, ISessionWorkspaceBrowseAction, SessionStatus, toSessionId } from '../../../services/sessions/common/session.js';
+import { IChat, iconForAgentProvider, IGitHubInfo, ISession, ISessionChangeset, ISessionType, ISessionWorkspace, ISessionWorkspaceBrowseAction, SessionStatus, toSessionId } from '../../../services/sessions/common/session.js';
 import { ISendRequestOptions, ISessionChangeEvent } from '../../../services/sessions/common/sessionsProvider.js';
 
 // ============================================================================
@@ -761,7 +761,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 		const next = rootState.agents.map((agent): ISessionType => ({
 			id: agent.provider,
 			label: this._formatSessionTypeLabel(agent.displayName?.trim() || agent.provider),
-			icon: this.icon,
+			icon: iconForAgentProvider(agent.provider) ?? this.icon,
 		}));
 
 		const prev = this._sessionTypes;

--- a/src/vs/sessions/contrib/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
@@ -369,6 +369,25 @@ suite('LocalAgentHostSessionsProvider', () => {
 		assert.deepStrictEqual(provider.sessionTypes, []);
 	});
 
+	test('session type icons use per-agent codicons', () => {
+		agentHost.setAgents([
+			{ provider: 'copilotcli', displayName: 'Copilot', description: '', models: [] } as AgentInfo,
+			{ provider: 'claude-code', displayName: 'Claude', description: '', models: [] } as AgentInfo,
+			{ provider: 'openai', displayName: 'OpenAI', description: '', models: [] } as AgentInfo,
+			{ provider: 'unknown-agent', displayName: 'Unknown', description: '', models: [] } as AgentInfo,
+		]);
+		const provider = createProvider(disposables, agentHost);
+		assert.deepStrictEqual(
+			provider.sessionTypes.map(t => ({ id: t.id, icon: t.icon.id })),
+			[
+				{ id: 'copilotcli', icon: 'copilot' },
+				{ id: 'claude-code', icon: 'claude' },
+				{ id: 'openai', icon: 'openai' },
+				{ id: 'unknown-agent', icon: 'vm' },
+			],
+		);
+	});
+
 	// ---- Workspace resolution -------
 
 	test('resolveWorkspace builds workspace from URI with [Local] tag', () => {

--- a/src/vs/sessions/contrib/remoteAgentHost/test/browser/remoteAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/test/browser/remoteAgentHostSessionsProvider.test.ts
@@ -325,6 +325,25 @@ suite('RemoteAgentHostSessionsProvider', () => {
 		assert.strictEqual(provider.label, 'myhost:9999');
 	});
 
+	test('session type icons use per-agent codicons', () => {
+		connection.setAgents([
+			{ provider: 'copilotcli', displayName: 'Copilot', description: '', models: [] } as AgentInfo,
+			{ provider: 'claude-code', displayName: 'Claude', description: '', models: [] } as AgentInfo,
+			{ provider: 'openai', displayName: 'OpenAI', description: '', models: [] } as AgentInfo,
+			{ provider: 'unknown-agent', displayName: 'Unknown', description: '', models: [] } as AgentInfo,
+		]);
+		const provider = createProvider(disposables, connection, { address: '10.0.0.1:8080', connectionName: 'My Host' });
+		assert.deepStrictEqual(
+			provider.sessionTypes.map(t => ({ id: t.id, icon: t.icon.id })),
+			[
+				{ id: COPILOT_CLI_SESSION_TYPE, icon: 'copilot' },
+				{ id: 'claude-code', icon: 'claude' },
+				{ id: 'openai', icon: 'openai' },
+				{ id: 'unknown-agent', icon: 'remote' },
+			],
+		);
+	});
+
 	// ---- Workspace resolution -------
 
 	test('resolveWorkspace builds workspace from URI', () => {

--- a/src/vs/sessions/services/sessions/common/session.ts
+++ b/src/vs/sessions/services/sessions/common/session.ts
@@ -51,6 +51,27 @@ export const ClaudeCodeSessionType: ISessionType = {
 };
 
 /**
+ * Returns the {@link ThemeIcon} associated with a known agent provider, or
+ * `undefined` when the provider is not recognised.
+ *
+ * - Any provider whose ID contains `'copilot'` → {@link Codicon.copilot}
+ * - Any provider whose ID contains `'claude'` → {@link Codicon.claude}
+ * - `'openai'` or any provider whose ID contains `'codex'` → {@link Codicon.openai}
+ */
+export function iconForAgentProvider(provider: string): ThemeIcon | undefined {
+	if (provider.includes('copilot')) {
+		return Codicon.copilot;
+	}
+	if (provider.includes('claude')) {
+		return Codicon.claude;
+	}
+	if (provider === 'openai' || provider.includes('codex')) {
+		return Codicon.openai;
+	}
+	return undefined;
+}
+
+/**
  * Returns whether the given session type represents a workspace-backed
  * agent (e.g. Copilot CLI, Claude Code) that operates on a worktree or
  * repository — regardless of whether the agent runs locally or remotely.


### PR DESCRIPTION
## Summary

When the agent host publishes its root state, each advertised agent now gets a branded icon in its session type entry rather than always inheriting the generic host icon.

### Mapping (`iconForAgentProvider`)

| Provider ID pattern | Icon |
|---|---|
| contains `copilot` | `$(copilot)` |
| contains `claude` | `$(claude)` |
| `openai` or contains `codex` | `$(openai)` |
| anything else | host fallback (`$(vm)` local / `$(remote)` remote) |

The provider-level icon (`vm` / `remote`) is unchanged — it represents the host, not a specific agent.

### Changes

- **`session.ts`** — adds `iconForAgentProvider(provider)` helper
- **`baseAgentHostSessionsProvider.ts`** — `_syncSessionTypesFromRootState` uses `iconForAgentProvider` per agent when building session types
- Tests covering the new icon mapping in both local and remote provider suites