### PR TITLE
Improve sessions list rendering on phone layout

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -442,14 +442,18 @@
 }
 
 /*
- * Phone layout: roomier rows, larger title that wraps to 2 lines, and a
- * slightly larger details row. The taller row height is reserved by
- * `SessionsTreeDelegate.ITEM_HEIGHT_PHONE` — keep these rules in sync if
- * paddings/font sizes change here.
+ * Phone layout: roomier rows with a centered, always-visible action
+ * toolbar that meets the 44px minimum touch target. The taller row
+ * height is reserved by `SessionsTreeDelegate.ITEM_HEIGHT_PHONE` —
+ * keep these rules in sync if paddings/font sizes change here.
  */
 .agent-sessions-workbench.phone-layout .sessions-list-control {
 	.monaco-list-row:has(.session-item) {
-		margin: 2px 8px;
+		/* Horizontal-only margin: virtual list rows are absolutely
+		 * positioned with JS-set `top`/`height`, so vertical margins
+		 * here would not produce reliable inter-row spacing. Any gap
+		 * lives inside the row via padding. */
+		margin: 0 8px;
 		width: calc(100% - 16px);
 		border-radius: 10px;
 	}

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -440,3 +440,85 @@
 	-webkit-touch-callout: none;
 	touch-action: manipulation;
 }
+
+/*
+ * Phone layout: roomier rows, larger title that wraps to 2 lines, and a
+ * slightly larger details row. The taller row height is reserved by
+ * `SessionsTreeDelegate.ITEM_HEIGHT_PHONE` — keep these rules in sync if
+ * paddings/font sizes change here.
+ */
+.agent-sessions-workbench.phone-layout .sessions-list-control {
+	.monaco-list-row:has(.session-item) {
+		margin: 2px 8px;
+		width: calc(100% - 16px);
+		border-radius: 10px;
+	}
+
+	.session-item {
+		padding: 10px 10px;
+		/* Vertically center the icon + main column inside the fixed phone row height. */
+		align-items: center;
+		/* Anchor for the absolutely positioned title toolbar (kept out
+		 * of the title-row flow so a 44px tap target doesn't inflate
+		 * the title line-height or shift the details row down). */
+		position: relative;
+	}
+
+	.session-item .session-icon {
+		line-height: 20px;
+
+		> .codicon {
+			font-size: 14px;
+			height: 20px;
+		}
+	}
+
+	.session-item .session-main {
+		padding-left: 10px;
+		/* Reserve space for the right-aligned toolbar so long titles
+		 * don't overlap the action icons. Sized to fit two 44px actions
+		 * (88px) plus a small gap. */
+		padding-right: 96px;
+	}
+
+	.session-item .session-title-row {
+		line-height: 20px;
+		padding-bottom: 4px;
+	}
+
+	.session-item .session-title {
+		font-size: 15px;
+		line-height: 20px;
+	}
+
+	.session-item .session-details-row {
+		font-size: 12.5px;
+		line-height: 16px;
+		max-height: 16px;
+	}
+
+	/*
+	 * Reveal the per-row action toolbar at rest. The default workbench
+	 * rule shows it on `:hover`/`:focus`, neither of which fire reliably
+	 * on touch. Pull the toolbar out of the title row flow and vertically
+	 * center it against the full row so 44px tap targets don't push the
+	 * details row down.
+	 */
+	.monaco-list-row .session-title-toolbar {
+		display: block;
+		position: absolute;
+		right: 6px;
+		top: 50%;
+		transform: translateY(-50%);
+		height: auto;
+	}
+
+	/* Center the codicon inside the 44x44 tap target. The base
+	 * `.action-label` is a flex container that defaults to start
+	 * alignment, so the icon sticks to the top-left of the square. */
+	.monaco-list-row .session-title-toolbar .action-item.menu-entry > .action-label {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+}

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -5,6 +5,7 @@
 
 import '../media/sessionsList.css';
 import * as DOM from '../../../../../base/browser/dom.js';
+import { Gesture } from '../../../../../base/browser/touch.js';
 import { IListVirtualDelegate } from '../../../../../base/browser/ui/list/list.js';
 import { IListStyles } from '../../../../../base/browser/ui/list/listWidget.js';
 import { IObjectTreeElement, ITreeNode, ITreeRenderer, ITreeContextMenuEvent, ObjectTreeElementCollapseState } from '../../../../../base/browser/ui/tree/tree.js';
@@ -98,10 +99,9 @@ class SessionsTreeDelegate implements IListVirtualDelegate<SessionListItem> {
 	private static readonly ITEM_HEIGHT = 54;
 	/**
 	 * Phone layout uses a taller row so the inline action toolbar can
-	 * meet the 44px minimum touch target without overflowing. Geometry:
-	 * 6px padding + 44px content (title row + details row, anchored to
-	 * a 44px toolbar) + 6px padding = 56px content + slack within 76px.
-	 * Keep in sync with `.phone-layout .session-item` rules in
+	 * meet the 44px minimum touch target without overflowing. Sized to
+	 * fit a 44px toolbar centered between the title and details rows.
+	 * Keep in sync with the `.phone-layout .session-item` rules in
 	 * `sessionsList.css`.
 	 */
 	private static readonly ITEM_HEIGHT_PHONE = 76;
@@ -208,9 +208,16 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 		const titleRow = DOM.append(mainCol, $('.session-title-row'));
 		const title = disposables.add(new HighlightedLabel(DOM.append(titleRow, $('.session-title'))));
 		const titleToolbarContainer = DOM.append(titleRow, $('.session-title-toolbar'));
+		// The list opens a session on click and on Gesture `tap` (touch).
+		// DOM event propagation stops only cover mouse/pointer events; the
+		// list's tap handler reads from `Gesture` directly, bypassing
+		// bubbling. Combine both: stop pointer/click for mouse, and
+		// register the toolbar with `Gesture.ignoreTarget` so synthesized
+		// tap events on touch never reach the list either.
 		for (const eventType of ['pointerdown', 'pointerup', 'click', 'dblclick'] as const) {
 			disposables.add(DOM.addDisposableListener(titleToolbarContainer, eventType, e => e.stopPropagation()));
 		}
+		disposables.add(Gesture.ignoreTarget(titleToolbarContainer));
 		const detailsRow = DOM.append(mainCol, $('.session-details-row'));
 
 		// Approval row
@@ -871,11 +878,13 @@ export class SessionsList extends Disposable implements ISessionsList {
 			}
 		}));
 
-		// React to phone <-> desktop viewport transitions: refresh heights for
-		// all known sessions so the virtual list reserves the correct space
-		// for the new layout. Cheap O(visible) call; relies on the existing
-		// `IsPhoneLayoutContext` reactive signal already maintained by the
-		// agents workbench.
+		// React to phone <-> desktop viewport transitions: refresh heights
+		// for all known sessions so the virtual list reserves the correct
+		// space for the new layout. Iterates `this.sessions` (all known
+		// sessions) — a phone/desktop transition is a rare event so the
+		// extra work over filtered-out sessions is negligible. Relies on
+		// the `IsPhoneLayoutContext` reactive signal already maintained by
+		// the agents workbench.
 		const phoneKeys = new Set<string>([IsPhoneLayoutContext.key]);
 		this._register(this.contextKeyService.onDidChangeContext(e => {
 			if (!e.affectsSome(phoneKeys)) {

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -23,7 +23,7 @@ import { localize } from '../../../../../nls.js';
 import { MenuId, IMenuService } from '../../../../../platform/actions/common/actions.js';
 import { MenuWorkbenchToolBar } from '../../../../../platform/actions/browser/toolbar.js';
 import { IContextKeyService, RawContextKey } from '../../../../../platform/contextkey/common/contextkey.js';
-import { ChatSessionProviderIdContext } from '../../../../common/contextkeys.js';
+import { ChatSessionProviderIdContext, IsPhoneLayoutContext } from '../../../../common/contextkeys.js';
 import { IContextMenuService } from '../../../../../platform/contextview/browser/contextView.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IKeybindingService } from '../../../../../platform/keybinding/common/keybinding.js';
@@ -96,10 +96,22 @@ function isSessionShowMore(item: SessionListItem): item is ISessionShowMore {
 
 class SessionsTreeDelegate implements IListVirtualDelegate<SessionListItem> {
 	private static readonly ITEM_HEIGHT = 54;
+	/**
+	 * Phone layout uses a taller row so the inline action toolbar can
+	 * meet the 44px minimum touch target without overflowing. Geometry:
+	 * 6px padding + 44px content (title row + details row, anchored to
+	 * a 44px toolbar) + 6px padding = 56px content + slack within 76px.
+	 * Keep in sync with `.phone-layout .session-item` rules in
+	 * `sessionsList.css`.
+	 */
+	private static readonly ITEM_HEIGHT_PHONE = 76;
 	private static readonly SECTION_HEIGHT = 26;
 	private static readonly SHOW_MORE_HEIGHT = 26;
 
-	constructor(private readonly _approvalModel?: AgentSessionApprovalModel) { }
+	constructor(
+		private readonly _approvalModel: AgentSessionApprovalModel | undefined,
+		private readonly _isPhone: () => boolean,
+	) { }
 
 	getHeight(element: SessionListItem): number {
 		if (isSessionSection(element)) {
@@ -109,7 +121,7 @@ class SessionsTreeDelegate implements IListVirtualDelegate<SessionListItem> {
 			return SessionsTreeDelegate.SHOW_MORE_HEIGHT;
 		}
 
-		let height = SessionsTreeDelegate.ITEM_HEIGHT;
+		let height = this._isPhone() ? SessionsTreeDelegate.ITEM_HEIGHT_PHONE : SessionsTreeDelegate.ITEM_HEIGHT;
 		if (this._approvalModel) {
 			const approval = getFirstApprovalAcrossChats(this._approvalModel, element as ISession, undefined);
 			if (approval) {
@@ -196,6 +208,9 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 		const titleRow = DOM.append(mainCol, $('.session-title-row'));
 		const title = disposables.add(new HighlightedLabel(DOM.append(titleRow, $('.session-title'))));
 		const titleToolbarContainer = DOM.append(titleRow, $('.session-title-toolbar'));
+		for (const eventType of ['pointerdown', 'pointerup', 'click', 'dblclick'] as const) {
+			disposables.add(DOM.addDisposableListener(titleToolbarContainer, eventType, e => e.stopPropagation()));
+		}
 		const detailsRow = DOM.append(mainCol, $('.session-details-row'));
 
 		// Approval row
@@ -775,7 +790,11 @@ export class SessionsList extends Disposable implements ISessionsList {
 
 		const showMoreRenderer = new SessionShowMoreRenderer();
 
-		const delegate = new SessionsTreeDelegate(approvalModel);
+		// Read (don't bind) `IsPhoneLayoutContext` from the parent context so we
+		// observe the workbench's value rather than shadowing it with a fresh
+		// scoped default of `false`. The reactive height refresh below listens
+		// on the same scoped service for changes.
+		const delegate = new SessionsTreeDelegate(approvalModel, () => !!IsPhoneLayoutContext.getValue(contextKeyService));
 
 		this.tree = this._register(instantiationService.createInstance(
 			WorkbenchObjectTree<SessionListItem, FuzzyScore>,
@@ -849,6 +868,23 @@ export class SessionsList extends Disposable implements ISessionsList {
 		this._register(sessionRenderer.onDidChangeItemHeight(session => {
 			if (this.tree.hasElement(session)) {
 				this.tree.updateElementHeight(session, delegate.getHeight(session));
+			}
+		}));
+
+		// React to phone <-> desktop viewport transitions: refresh heights for
+		// all known sessions so the virtual list reserves the correct space
+		// for the new layout. Cheap O(visible) call; relies on the existing
+		// `IsPhoneLayoutContext` reactive signal already maintained by the
+		// agents workbench.
+		const phoneKeys = new Set<string>([IsPhoneLayoutContext.key]);
+		this._register(this.contextKeyService.onDidChangeContext(e => {
+			if (!e.affectsSome(phoneKeys)) {
+				return;
+			}
+			for (const session of this.sessions) {
+				if (this.tree.hasElement(session)) {
+					this.tree.updateElementHeight(session, delegate.getHeight(session));
+				}
 			}
 		}));
 


### PR DESCRIPTION
Improves the readability and tap-friendliness of the agent sessions list under the phone layout. No new components, no new data — only a phone-aware row height and CSS changes scoped to `.agent-sessions-workbench.phone-layout`.

### Changes

- **Phone-aware row height** (`SessionsTreeDelegate`): 76px on phone vs 54px on desktop. Heights refresh reactively when `IsPhoneLayoutContext` changes.
- **Larger fonts and roomier rows**: 15px title / 12.5px details, 10px padding, vertically centered icon + main column.
- **Card-style rows**: `margin: 2px 8px`, 10px border radius for a phone-native press feel.
- **Inline actions on touch**: the per-row toolbar is always visible (no hover/focus dependency), pulled out of the title-row flow with `position: absolute; right: 6px; top: 50%` so 44px tap targets don't inflate the title line-height or push the details row down. `.session-main` reserves `padding-right: 96px` to keep titles from sliding under the icons. Action labels are flex-centered so the icon sits in the middle of the 44×44 tap area.
- **Action taps no longer collapse the list**: the toolbar container stops `pointerdown` / `pointerup` / `click` / `dblclick` propagation, so the row's `onDidOpen` handler doesn't fire when a tap lands on an action. This applies on desktop and mobile — semantically actions on the row toolbar are not "open the row".

### Architecture notes

- All visual changes live behind `.agent-sessions-workbench.phone-layout` ancestor selectors, so desktop rendering is byte-identical.
- Phone branching uses the existing `IsPhoneLayoutContext` reactive signal (per `MOBILE.md` guidance) for the height refresh — no new branching infrastructure.
- The propagation fix is unconditional. Actions never imply "open the row", on any platform.

### Out of scope

The HTML mock that inspired this also showed colored status pills, a filter chip row, a FAB, and a bottom tab bar. Those are not implemented here — this PR is strictly about making the existing list readable and tappable on a phone.

### Verification

- `npm run compile-check-ts-native` clean.
- Manually verified in vscode.dev/agents at iPhone 14 Pro viewport: rows render at 76px, actions tap correctly, list does not collapse on action tap, desktop layout unchanged above the phone breakpoint.