### PR TITLE
Rename sessionsConfigurationService to sessionsTasksService

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
@@ -21,7 +21,7 @@ import './openInVSCodeWidget.js';
 import './nullChatTipService.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
-import { ISessionsConfigurationService, SessionsConfigurationService } from './sessionsConfigurationService.js';
+import { ISessionsTasksService, SessionsTasksService } from './sessionsTasksService.js';
 import { AgenticPromptsService } from './promptsService.js';
 import { IPromptsService } from '../../../../workbench/contrib/chat/common/promptSyntax/service/promptsService.js';
 import { IAICustomizationWorkspaceService } from '../../../../workbench/contrib/chat/common/aiCustomizationWorkspaceService.js';
@@ -154,7 +154,7 @@ registerWorkbenchContribution2(SessionsOpenerParticipantContribution.ID, Session
 
 // register services
 registerSingleton(IPromptsService, AgenticPromptsService, InstantiationType.Delayed);
-registerSingleton(ISessionsConfigurationService, SessionsConfigurationService, InstantiationType.Delayed);
+registerSingleton(ISessionsTasksService, SessionsTasksService, InstantiationType.Delayed);
 registerSingleton(IAICustomizationWorkspaceService, SessionsAICustomizationWorkspaceService, InstantiationType.Delayed);
 registerSingleton(ICustomizationHarnessService, SessionsCustomizationHarnessService, InstantiationType.Delayed);
 

--- a/src/vs/sessions/contrib/chat/browser/runScriptAction.ts
+++ b/src/vs/sessions/contrib/chat/browser/runScriptAction.ts
@@ -34,7 +34,7 @@ import { IsActiveSessionBackgroundProviderContext, SessionsWelcomeVisibleContext
 import { ISession } from '../../../services/sessions/common/session.js';
 import { IChatWidgetService } from '../../../../workbench/contrib/chat/browser/chat.js';
 import { Menus } from '../../../browser/menus.js';
-import { INonSessionTaskEntry, ISessionsConfigurationService, ISessionTaskWithTarget, ITaskEntry, TaskStorageTarget } from './sessionsConfigurationService.js';
+import { INonSessionTaskEntry, ISessionsTasksService, ISessionTaskWithTarget, ITaskEntry, TaskStorageTarget } from './sessionsTasksService.js';
 import { IsAuxiliaryWindowContext } from '../../../../workbench/common/contextkeys.js';
 import { IRunScriptCustomTaskWidgetResult, RunScriptCustomTaskWidget } from './runScriptCustomTaskWidget.js';
 
@@ -119,7 +119,7 @@ export class RunScriptContribution extends Disposable implements IWorkbenchContr
 		@ISessionsManagementService private readonly _sessionManagementService: ISessionsManagementService,
 		@IKeybindingService _keybindingService: IKeybindingService,
 		@IQuickInputService private readonly _quickInputService: IQuickInputService,
-		@ISessionsConfigurationService private readonly _sessionsConfigService: ISessionsConfigurationService,
+		@ISessionsTasksService private readonly _sessionsConfigService: ISessionsTasksService,
 		@IActionViewItemService private readonly _actionViewItemService: IActionViewItemService,
 		@IWorkbenchLayoutService private readonly _layoutService: IWorkbenchLayoutService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
@@ -496,7 +496,7 @@ class RunScriptActionViewItem extends BaseActionViewItem {
 		private readonly _showCustomCommandInput: (session: ISession, existingTask: INonSessionTaskEntry, mode?: TaskConfigurationMode) => Promise<ITaskEntry | undefined>,
 		private readonly _generateNewTask: (session: ISession) => Promise<void>,
 		@ICommandService private readonly _commandService: ICommandService,
-		@ISessionsConfigurationService private readonly _sessionsConfigService: ISessionsConfigurationService,
+		@ISessionsTasksService private readonly _sessionsConfigService: ISessionsTasksService,
 		@IKeybindingService private readonly _keybindingService: IKeybindingService,
 		@IActionWidgetService private readonly _actionWidgetService: IActionWidgetService,
 		@IContextKeyService contextKeyService: IContextKeyService,

--- a/src/vs/sessions/contrib/chat/browser/runScriptCustomTaskWidget.ts
+++ b/src/vs/sessions/contrib/chat/browser/runScriptCustomTaskWidget.ts
@@ -16,7 +16,7 @@ import { Disposable } from '../../../../base/common/lifecycle.js';
 import { KeyCode } from '../../../../base/common/keyCodes.js';
 import { localize } from '../../../../nls.js';
 import { defaultButtonStyles, defaultCheckboxStyles, defaultInputBoxStyles } from '../../../../platform/theme/browser/defaultStyles.js';
-import { TaskStorageTarget } from './sessionsConfigurationService.js';
+import { TaskStorageTarget } from './sessionsTasksService.js';
 
 export const WORKTREE_CREATED_RUN_ON = 'worktreeCreated' as const;
 

--- a/src/vs/sessions/contrib/chat/browser/sessionsTasksService.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionsTasksService.ts
@@ -62,7 +62,7 @@ interface ITasksJson {
 	tasks?: ITaskEntry[];
 }
 
-export interface ISessionsConfigurationService {
+export interface ISessionsTasksService {
 	readonly _serviceBrand: undefined;
 
 	/**
@@ -118,9 +118,9 @@ export interface ISessionsConfigurationService {
 	setPinnedTaskLabel(repository: URI | undefined, taskLabel: string | undefined): void;
 }
 
-export const ISessionsConfigurationService = createDecorator<ISessionsConfigurationService>('sessionsConfigurationService');
+export const ISessionsTasksService = createDecorator<ISessionsTasksService>('sessionsTasksService');
 
-export class SessionsConfigurationService extends Disposable implements ISessionsConfigurationService {
+export class SessionsTasksService extends Disposable implements ISessionsTasksService {
 
 	declare readonly _serviceBrand: undefined;
 
@@ -146,11 +146,8 @@ export class SessionsConfigurationService extends Disposable implements ISession
 	}
 
 	getSessionTasks(session: ISession): IObservable<readonly ISessionTaskWithTarget[]> {
-		const repo = this._getSessionRepo(session);
-		const folder = repo?.workingDirectory ?? repo?.uri;
-		if (folder) {
-			this._ensureFileWatch(folder);
-		}
+		const folder = this._getSessionFolder(session);
+		this._ensureFileWatch(folder);
 		// Trigger initial read only when the folder changes; the file watcher handles subsequent updates
 		if (!isEqual(this._lastRefreshedFolder, folder)) {
 			this._lastRefreshedFolder = folder;
@@ -353,13 +350,30 @@ export class SessionsConfigurationService extends Disposable implements ISession
 		return session.workspace.get()?.repositories[0];
 	}
 
+	private _getSessionFolder(session: ISession): URI | undefined {
+		const repo = this._getSessionRepo(session);
+		return repo?.workingDirectory ?? repo?.uri;
+	}
+
 	private _getTasksJsonUri(session: ISession, target: TaskStorageTarget): URI | undefined {
 		if (target === 'workspace') {
-			const repo = this._getSessionRepo(session);
-			const folder = repo?.workingDirectory ?? repo?.uri;
-			return folder ? joinPath(folder, '.vscode', 'tasks.json') : undefined;
+			return this._getWorkspaceTasksJsonUri(this._getSessionFolder(session));
 		}
-		return joinPath(dirname(this._preferencesService.userSettingsResource), 'tasks.json');
+		return this._getUserTasksJsonUri();
+	}
+
+	private _getWorkspaceTasksJsonUri(folder: URI | undefined): URI | undefined {
+		return folder?.path ? joinPath(folder, '.vscode', 'tasks.json') : undefined;
+	}
+
+	private _getUserTasksJsonUri(): URI | undefined {
+		const userSettingsResource = this._preferencesService.userSettingsResource;
+		if (!userSettingsResource.path) {
+			return undefined;
+		}
+
+		const userSettingsFolder = dirname(userSettingsResource);
+		return userSettingsFolder.path ? joinPath(userSettingsFolder, 'tasks.json') : undefined;
 	}
 
 	private async _readTasksJson(uri: URI): Promise<ITasksJson> {
@@ -375,8 +389,14 @@ export class SessionsConfigurationService extends Disposable implements ISession
 		return !!task.label;
 	}
 
-	private _ensureFileWatch(folder: URI): void {
-		const tasksUri = joinPath(folder, '.vscode', 'tasks.json');
+	private _ensureFileWatch(folder: URI | undefined): void {
+		const tasksUri = this._getWorkspaceTasksJsonUri(folder);
+		if (!tasksUri) {
+			this._watchedResource = undefined;
+			this._fileWatcher.clear();
+			return;
+		}
+
 		if (this._watchedResource && this._watchedResource.toString() === tasksUri.toString()) {
 			return;
 		}
@@ -388,11 +408,13 @@ export class SessionsConfigurationService extends Disposable implements ISession
 		disposables.add(this._fileService.watch(tasksUri));
 
 		// Also watch user-level tasks.json so that user session tasks changes refresh the observable
-		const userUri = joinPath(dirname(this._preferencesService.userSettingsResource), 'tasks.json');
-		disposables.add(this._fileService.watch(userUri));
+		const userUri = this._getUserTasksJsonUri();
+		if (userUri) {
+			disposables.add(this._fileService.watch(userUri));
+		}
 
 		disposables.add(this._fileService.onDidFilesChange(e => {
-			if (e.affects(tasksUri) || e.affects(userUri)) {
+			if (e.affects(tasksUri) || (userUri && e.affects(userUri))) {
 				this._refreshSessionTasks(folder);
 			}
 		}));
@@ -406,15 +428,15 @@ export class SessionsConfigurationService extends Disposable implements ISession
 			return;
 		}
 
-		const tasksUri = joinPath(folder, '.vscode', 'tasks.json');
-		const tasksJson = await this._readTasksJson(tasksUri);
+		const tasksUri = this._getWorkspaceTasksJsonUri(folder);
+		const tasksJson = tasksUri ? await this._readTasksJson(tasksUri) : {};
 		const sessionTasks: ISessionTaskWithTarget[] = (tasksJson.tasks ?? [])
 			.filter(t => t.inAgents && this._isSupportedTask(t))
 			.map(t => ({ task: t, target: 'workspace' as TaskStorageTarget }));
 
 		// Also include user-level session tasks
-		const userUri = joinPath(dirname(this._preferencesService.userSettingsResource), 'tasks.json');
-		const userJson = await this._readTasksJson(userUri);
+		const userUri = this._getUserTasksJsonUri();
+		const userJson = userUri ? await this._readTasksJson(userUri) : {};
 		const userSessionTasks: ISessionTaskWithTarget[] = (userJson.tasks ?? [])
 			.filter(t => t.inAgents && this._isSupportedTask(t))
 			.map(t => ({ task: t, target: 'user' as TaskStorageTarget }));
@@ -423,7 +445,7 @@ export class SessionsConfigurationService extends Disposable implements ISession
 	}
 
 	private _loadPinnedTaskLabels(): Map<string, string> {
-		const raw = this._storageService.get(SessionsConfigurationService._PINNED_TASK_LABELS_KEY, StorageScope.APPLICATION);
+		const raw = this._storageService.get(SessionsTasksService._PINNED_TASK_LABELS_KEY, StorageScope.APPLICATION);
 		if (raw) {
 			try {
 				return new Map(Object.entries(JSON.parse(raw)));
@@ -436,7 +458,7 @@ export class SessionsConfigurationService extends Disposable implements ISession
 
 	private _savePinnedTaskLabels(): void {
 		this._storageService.store(
-			SessionsConfigurationService._PINNED_TASK_LABELS_KEY,
+			SessionsTasksService._PINNED_TASK_LABELS_KEY,
 			JSON.stringify(Object.fromEntries(this._pinnedTaskLabels)),
 			StorageScope.APPLICATION,
 			StorageTarget.USER

--- a/src/vs/sessions/contrib/chat/test/browser/sessionsTaskService.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionsTaskService.test.ts
@@ -14,7 +14,7 @@ import { InMemoryStorageService, IStorageService } from '../../../../../platform
 import { IJSONEditingService, IJSONValue } from '../../../../../workbench/services/configuration/common/jsonEditing.js';
 import { IPreferencesService } from '../../../../../workbench/services/preferences/common/preferences.js';
 import { IWorkspaceContextService, IWorkspaceFolder } from '../../../../../platform/workspace/common/workspace.js';
-import { INonSessionTaskEntry, ISessionsConfigurationService, SessionsConfigurationService, ITaskEntry } from '../../browser/sessionsConfigurationService.js';
+import { INonSessionTaskEntry, ISessionsTasksService, SessionsTasksService, ITaskEntry } from '../../browser/sessionsTasksService.js';
 import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { observableValue } from '../../../../../base/common/observable.js';
 import { Task } from '../../../../../workbench/contrib/tasks/common/tasks.js';
@@ -94,10 +94,10 @@ function tasksJsonContent(tasks: ITaskEntry[]): string {
 	return JSON.stringify({ version: '2.0.0', tasks });
 }
 
-suite('SessionsConfigurationService', () => {
+suite('SessionsTasksService', () => {
 
 	const store = new DisposableStore();
-	let service: ISessionsConfigurationService;
+	let service: ISessionsTasksService;
 	let fileContents: Map<string, string>;
 	let jsonEdits: { uri: URI; values: IJSONValue[] }[];
 	let ranTasks: { label: string }[];
@@ -106,6 +106,7 @@ suite('SessionsConfigurationService', () => {
 	let activeSessionObs: ReturnType<typeof observableValue<IActiveSession | undefined>>;
 	let tasksByLabel: Map<string, Task>;
 	let workspaceFoldersByUri: Map<string, IWorkspaceFolder>;
+	let preferencesService: IPreferencesService & { userSettingsResource: URI };
 
 	const userSettingsUri = URI.parse('file:///user/settings.json');
 	const repoUri = URI.parse('file:///repo');
@@ -141,9 +142,10 @@ suite('SessionsConfigurationService', () => {
 			}
 		});
 
-		instantiationService.stub(IPreferencesService, new class extends mock<IPreferencesService>() {
+		preferencesService = new class extends mock<IPreferencesService>() {
 			override userSettingsResource = userSettingsUri;
-		});
+		};
+		instantiationService.stub(IPreferencesService, preferencesService);
 
 		instantiationService.stub(ITaskService, new class extends mock<ITaskService>() {
 			override async getTask(_workspaceFolder: any, alias: string | any) {
@@ -171,7 +173,7 @@ suite('SessionsConfigurationService', () => {
 		storageService = store.add(new InMemoryStorageService());
 		instantiationService.stub(IStorageService, storageService);
 
-		service = store.add(instantiationService.createInstance(SessionsConfigurationService));
+		service = store.add(instantiationService.createInstance(SessionsTasksService));
 	});
 
 	teardown(() => {
@@ -251,6 +253,19 @@ suite('SessionsConfigurationService', () => {
 		assert.strictEqual(readFileCalls.length, 2, 'should read files only once (no duplicate refresh)');
 	});
 
+	test('getSessionTasks skips workspace tasks when repository URI has no path', async () => {
+		const userTasksUri = URI.from({ scheme: userSettingsUri.scheme, path: '/user/tasks.json' });
+		fileContents.set(userTasksUri.toString(), tasksJsonContent([
+			makeTask('userTask', 'npm run user', true),
+		]));
+
+		const session = makeSession({ repository: URI.parse('unknown://workspace') });
+		const obs = service.getSessionTasks(session);
+
+		await new Promise(r => setTimeout(r, 10));
+		assert.deepStrictEqual(obs.get(), [{ task: makeTask('userTask', 'npm run user', true), target: 'user' }]);
+	});
+
 	// --- getNonSessionTasks ---
 
 	test('getNonSessionTasks returns only tasks without inAgents', async () => {
@@ -303,6 +318,30 @@ suite('SessionsConfigurationService', () => {
 			{ task: { label: 'workspaceTask', type: 'shell', command: 'npm run workspace' }, target: 'workspace' },
 			{ task: { label: 'userTask', type: 'shell', command: 'npm run user' }, target: 'user' },
 		] satisfies INonSessionTaskEntry[]);
+	});
+
+	test('getNonSessionTasks skips workspace tasks when repository URI has no path', async () => {
+		const userTasksUri = URI.from({ scheme: userSettingsUri.scheme, path: '/user/tasks.json' });
+		fileContents.set(userTasksUri.toString(), tasksJsonContent([
+			makeTask('userTask', 'npm run user'),
+		]));
+
+		const session = makeSession({ repository: URI.parse('unknown://workspace') });
+		const nonSessionTasks = await service.getNonSessionTasks(session);
+
+		assert.deepStrictEqual(nonSessionTasks, [
+			{ task: { label: 'userTask', type: 'shell', command: 'npm run user' }, target: 'user' },
+		] satisfies INonSessionTaskEntry[]);
+	});
+
+	test('user task operations are skipped when user settings URI has no path', async () => {
+		preferencesService.userSettingsResource = URI.parse('test://settings');
+
+		const session = makeSession({ repository: repoUri });
+		const task = await service.createAndAddTask(undefined, 'npm run dev', session, 'user');
+		const nonSessionTasks = await service.getNonSessionTasks(session);
+
+		assert.deepStrictEqual({ task, nonSessionTasks, jsonEdits }, { task: undefined, nonSessionTasks: [], jsonEdits: [] });
 	});
 
 	// --- addTaskToSessions ---


### PR DESCRIPTION
```Copilot Generated Description:``` Update the service name from `sessionsConfigurationService` to `sessionsTasksService` across relevant imports and registrations. This change ensures consistency in naming conventions within the codebase.

fixes https://github.com/microsoft/vscode/issues/310368