### PR TITLE
SCM - add `scm.diffDecorationsAlgorithm` setting

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/quickDiff.contribution.ts
+++ b/src/vs/workbench/contrib/scm/browser/quickDiff.contribution.ts
@@ -53,6 +53,16 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			default: 'all',
 			description: localize('diffDecorations', "Controls diff decorations in the editor.")
 		},
+		'scm.diffDecorationsAlgorithm': {
+			type: 'string',
+			enum: ['legacy', 'advanced'],
+			enumDescriptions: [
+				localize('scm.diffDecorationsAlgorithm.legacy', "Uses the legacy diffing algorithm."),
+				localize('scm.diffDecorationsAlgorithm.advanced', "Uses the advanced diffing algorithm.")
+			],
+			default: 'advanced',
+			description: localize('diffDecorationsAlgorithm', "Controls the diffing algorithm used for Source Control diff gutter decorations.")
+		},
 		'scm.diffDecorationsGutterWidth': {
 			type: 'number',
 			enum: [1, 2, 3, 4, 5],

--- a/src/vs/workbench/contrib/scm/browser/quickDiffModel.ts
+++ b/src/vs/workbench/contrib/scm/browser/quickDiffModel.ts
@@ -34,12 +34,11 @@ import { IWorkbenchEnvironmentService } from '../../../services/environment/comm
 export const IQuickDiffModelService = createDecorator<IQuickDiffModelService>('IQuickDiffModelService');
 
 export interface QuickDiffModelOptions {
-	readonly algorithm: DiffAlgorithmName;
+	readonly algorithm?: DiffAlgorithmName;
 	readonly maxComputationTimeMs?: number;
 }
 
 const decoratorQuickDiffModelOptions: QuickDiffModelOptions = {
-	algorithm: 'advanced',
 	maxComputationTimeMs: 1000
 };
 
@@ -142,7 +141,9 @@ export class QuickDiffModel extends Disposable {
 		this._register(textFileModel.textEditorModel.onDidChangeContent(() => this.triggerDiff()));
 		this._register(
 			Event.filter(configurationService.onDidChangeConfiguration,
-				e => e.affectsConfiguration('scm.diffDecorationsIgnoreTrimWhitespace') || e.affectsConfiguration('diffEditor.ignoreTrimWhitespace')
+				e => e.affectsConfiguration('scm.diffDecorationsAlgorithm') ||
+					e.affectsConfiguration('scm.diffDecorationsIgnoreTrimWhitespace') ||
+					e.affectsConfiguration('diffEditor.ignoreTrimWhitespace')
 			)(this.triggerDiff, this)
 		);
 		this._register(scmService.onDidAddRepository(this.onDidAddRepository, this));
@@ -266,12 +267,13 @@ export class QuickDiffModel extends Disposable {
 			const ignoreTrimWhitespace = ignoreTrimWhitespaceSetting === 'inherit'
 				? this.configurationService.getValue<boolean>('diffEditor.ignoreTrimWhitespace')
 				: ignoreTrimWhitespaceSetting !== 'false';
+			const algorithm = this.options.algorithm ?? this.configurationService.getValue<DiffAlgorithmName>('scm.diffDecorationsAlgorithm');
 
 			const diffs: QuickDiffChange[] = [];
 			const secondaryDiffs: QuickDiffChange[] = [];
 
 			for (const quickDiff of quickDiffs) {
-				const diff = await this._diff(quickDiff.originalResource, this._model.resource, ignoreTrimWhitespace);
+				const diff = await this._diff(quickDiff.originalResource, this._model.resource, algorithm, ignoreTrimWhitespace);
 				if (diff.changes && diff.changes2 && diff.changes.length === diff.changes2.length) {
 					for (let index = 0; index < diff.changes.length; index++) {
 						const change2 = diff.changes2[index];
@@ -335,12 +337,12 @@ export class QuickDiffModel extends Disposable {
 		});
 	}
 
-	private async _diff(original: URI, modified: URI, ignoreTrimWhitespace: boolean): Promise<{ changes: readonly IChange[] | null; changes2: readonly LineRangeMapping[] | null }> {
+	private async _diff(original: URI, modified: URI, algorithm: DiffAlgorithmName, ignoreTrimWhitespace: boolean): Promise<{ changes: readonly IChange[] | null; changes2: readonly LineRangeMapping[] | null }> {
 		const maxComputationTimeMs = this.options.maxComputationTimeMs ?? Number.MAX_SAFE_INTEGER;
 
 		const result = await this.editorWorkerService.computeDiff(original, modified, {
 			computeMoves: false, ignoreTrimWhitespace, maxComputationTimeMs
-		}, this.options.algorithm);
+		}, algorithm);
 
 		return { changes: result ? toLineChanges(DiffState.fromDiffResult(result)) : null, changes2: result?.changes ?? null };
 	}

--- a/src/vs/workbench/contrib/scm/browser/quickDiffWidget.ts
+++ b/src/vs/workbench/contrib/scm/browser/quickDiffWidget.ts
@@ -51,6 +51,7 @@ import { KeyChord, KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import { getOuterEditor } from '../../../../editor/browser/widget/codeEditor/embeddedCodeEditorWidget.js';
 import { quickDiffDecorationCount } from './quickDiffDecorator.js';
 import { hasNativeContextMenu } from '../../../../platform/window/common/window.js';
+import { DiffAlgorithmName } from '../../../../editor/common/services/editorWorker.js';
 
 export const isQuickDiffVisible = new RawContextKey<boolean>('dirtyDiffVisible', false);
 
@@ -163,7 +164,8 @@ class QuickDiffWidget extends PeekViewWidget {
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IMenuService private readonly menuService: IMenuService,
 		@IContextKeyService private contextKeyService: IContextKeyService,
-		@IQuickDiffService private readonly quickDiffService: IQuickDiffService
+		@IQuickDiffService private readonly quickDiffService: IQuickDiffService,
+		@IConfigurationService private readonly configurationService: IConfigurationService
 	) {
 		super(editor, { isResizeable: true, frameWidth: 1, keepEditorSelection: true, className: 'dirty-diff' }, instantiationService);
 
@@ -384,7 +386,7 @@ class QuickDiffWidget extends PeekViewWidget {
 
 	protected _fillBody(container: HTMLElement): void {
 		const options: IDiffEditorOptions = {
-			diffAlgorithm: 'advanced',
+			diffAlgorithm: this.configurationService.getValue<DiffAlgorithmName>('scm.diffDecorationsAlgorithm'),
 			fixedOverflowWidgets: true,
 			ignoreTrimWhitespace: false,
 			minimap: { enabled: false },

--- a/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
+++ b/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
@@ -182,6 +182,16 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			default: 'all',
 			description: localize('diffDecorations', "Controls diff decorations in the editor.")
 		},
+		'scm.diffDecorationsAlgorithm': {
+			type: 'string',
+			enum: ['legacy', 'advanced'],
+			enumDescriptions: [
+				localize('scm.diffDecorationsAlgorithm.legacy', "Uses the legacy diffing algorithm."),
+				localize('scm.diffDecorationsAlgorithm.advanced', "Uses the advanced diffing algorithm.")
+			],
+			default: 'advanced',
+			description: localize('diffDecorationsAlgorithm', "Controls the diffing algorithm used for Source Control diff decorations.")
+		},
 		'scm.diffDecorationsGutterWidth': {
 			type: 'number',
 			enum: [1, 2, 3, 4, 5],


### PR DESCRIPTION
Since #249106 changed the diffing algorithm from `legacy` to `advanced` for the quick diff, the quick diff got quite slow for large files (>400 lines), often marking all the lines as "modified" even when `git status` shows nothing (#253704).

To workaround this, this PR adds a new setting `scm.diffDecorationsAlgorithm` for the diffing algorithm used for quick diff. The default value is `advanced`.

Co-authored-by: Codex