### PR TITLE
Agents: Update line-height for agent feedback widget title

### DIFF
--- a/src/vs/sessions/contrib/agentFeedback/browser/media/agentFeedbackEditorWidget.css
+++ b/src/vs/sessions/contrib/agentFeedback/browser/media/agentFeedbackEditorWidget.css
@@ -85,7 +85,7 @@
 /* Title */
 .agent-feedback-widget-title {
 	font-weight: 500;
-	line-height: 12px;
+	line-height: 16px;
 	color: var(--vscode-foreground);
 	white-space: nowrap;
 	overflow: hidden;


### PR DESCRIPTION
Adjust the line-height of the agent feedback widget title for improved readability. No issues are associated with this change. Testing involves verifying the visual appearance of the title in the agent feedback widget.

