### PR TITLE
chat: skip local sync items when itemProvider is present in ProviderCustomizationItemSource

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemSource.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemSource.ts
@@ -333,6 +333,12 @@ export class ProviderCustomizationItemSource implements IAICustomizationItemSour
 		if (!this.syncProvider) {
 			return remoteItems;
 		}
+		// If there's an itemProvider, it is the single source of truth for items.
+		// The provider is responsible for enumerating all items, including synced
+		// ones, so we don't need to add local synced items separately.
+		if (this.itemProvider) {
+			return remoteItems;
+		}
 		const localItems = await this.fetchLocalSyncableItems(promptType, this.syncProvider);
 		return [...remoteItems, ...localItems];
 	}


### PR DESCRIPTION
## Summary

In `ProviderCustomizationItemSource.fetchItems`, when both an `itemProvider` and a `syncProvider` are configured, `fetchLocalSyncableItems` was unconditionally called — causing items to be double-counted. Provider items would appear once from the provider and again from the local file enumeration.

### Change

Added an early-return guard after the existing `!syncProvider` check:

```ts
// If there's an itemProvider, it is the single source of truth for items.
// The provider is responsible for enumerating all items, including synced
// ones, so we don't need to add local synced items separately.
if (this.itemProvider) {
    return remoteItems;
}
```

When an `itemProvider` is present, it is treated as the single source of truth. The local sync item fetch is only performed in the legacy path where there is no `itemProvider` but there is a `syncProvider` (i.e., the prompts-service-only path that computes sync overlays locally).

### Caveat for reviewers

This assumes the `itemProvider` already populates `syncable`/`synced` fields on its returned items, or that sync-toggle UI is intentionally not shown in provider-driven views. If neither is true, the source would need to merge sync state onto provider items rather than skipping the local fetch entirely.