### PR TITLE
chat: gate structured customization preview behind a setting (default off)

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -630,6 +630,9 @@ export class AICustomizationManagementEditor extends EditorPane {
 					this.harnessService.setActiveHarness(SessionType.Local);
 				}
 			}
+			if (e.affectsConfiguration(ChatConfiguration.ChatCustomizationsStructuredPreviewEnabled)) {
+				this.onStructuredPreviewSettingChanged();
+			}
 		}));
 
 	}
@@ -1969,10 +1972,31 @@ export class AICustomizationManagementEditor extends EditorPane {
 	}
 
 	private isStructuredPreviewSupported(promptType: PromptsType | undefined): boolean {
+		if (this.configurationService.getValue<boolean>(ChatConfiguration.ChatCustomizationsStructuredPreviewEnabled) !== true) {
+			return false;
+		}
 		return promptType === PromptsType.agent
 			|| promptType === PromptsType.skill
 			|| promptType === PromptsType.instructions
 			|| promptType === PromptsType.prompt;
+	}
+
+	private onStructuredPreviewSettingChanged(): void {
+		if (this.viewMode !== 'editor') {
+			return;
+		}
+		const supportsStructuredPreview = this.isStructuredPreviewSupported(this.currentEditingPromptType);
+		if (!supportsStructuredPreview) {
+			this.editorDisplayMode = 'raw';
+			this.editorPreviewRenderScheduler.cancel();
+			this.clearEditorPreview();
+		} else if (this.editorDisplayMode === 'preview') {
+			this.editorPreviewRenderScheduler.schedule();
+		}
+		this.updateEditorDisplayMode();
+		if (this.dimension) {
+			this.layout(this.dimension);
+		}
 	}
 
 	private getCurrentEditingModel(): ITextModel | undefined {

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -1625,6 +1625,12 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.customizations.harnessSelector.enabled', "Controls whether the harness selector is shown in the Chat Customizations editor sidebar. When disabled, the editor always shows all customizations without filtering."),
 			default: true,
 		},
+		[ChatConfiguration.ChatCustomizationsStructuredPreviewEnabled]: {
+			type: 'boolean',
+			tags: ['preview'],
+			description: nls.localize('chat.customizations.structuredPreview.enabled', "Controls whether the Chat Customizations editor shows a structured preview for markdown customization files (agents, skills, instructions, prompts). When disabled, the editor always opens the raw markdown in the embedded code editor."),
+			default: false,
+		},
 		[ChatConfiguration.UseChatSessionCustomizationsForCustomAgents]: {
 			type: 'boolean',
 			description: nls.localize('chat.customizations.useChatSessionCustomizationsForCustomAgents', "When enabled, custom agents shown in the chat mode picker are sourced from the customization harness service (scoped per session type) instead of the prompts service."),

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -65,6 +65,7 @@ export enum ChatConfiguration {
 	GrowthNotificationEnabled = 'chat.growthNotification.enabled',
 
 	ChatCustomizationHarnessSelectorEnabled = 'chat.customizations.harnessSelector.enabled',
+	ChatCustomizationsStructuredPreviewEnabled = 'chat.customizations.structuredPreview.enabled',
 	UseChatSessionCustomizationsForCustomAgents = 'chat.customizations.useChatSessionCustomizationsForCustomAgents',
 	AutopilotEnabled = 'chat.autopilot.enabled',
 	DefaultPermissionLevel = 'chat.permissions.default',

--- a/src/vs/workbench/contrib/chat/test/browser/aiCustomization/aiCustomizationManagementEditor.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/aiCustomization/aiCustomizationManagementEditor.test.ts
@@ -25,11 +25,15 @@ suite('aiCustomizationManagementEditor', () => {
 		editorDisplayMode: 'preview' | 'raw';
 		editorPreviewFrontMatterContainer: HTMLElement | undefined;
 		editorPreviewDisposables: { add<T>(value: T): T; dispose(): void };
+		editorPreviewRenderScheduler: { cancel(): void; schedule(): void };
+		viewMode: 'list' | 'editor' | 'mcpDetail' | 'pluginDetail';
+		dimension: undefined;
 		hoverService: IHoverService;
 		configurationService: IConfigurationService;
 		getEditorModeButtonLabel(): string;
 		getEditorModeButtonTooltip(): string;
 		renderPreviewAttribute(attribute: IHeaderAttribute, promptType: PromptsType, target: Target): void;
+		onStructuredPreviewSettingChanged(): void;
 	};
 
 	function createConfigurationServiceStub(values: Record<string, unknown> = {}): IConfigurationService {
@@ -40,7 +44,8 @@ suite('aiCustomizationManagementEditor', () => {
 		};
 		return {
 			getValue: (key: string) => merged[key],
-		} as unknown as IConfigurationService;
+			setValue: (key: string, value: unknown) => { merged[key] = value; },
+		} as unknown as IConfigurationService & { setValue(key: string, value: unknown): void };
 	}
 
 	function createTestEditor(hoverService?: IHoverService, configurationService?: IConfigurationService): TestableEditor {
@@ -65,6 +70,12 @@ suite('aiCustomizationManagementEditor', () => {
 			}),
 		} as unknown as IHoverService;
 		editor.configurationService = configurationService ?? createConfigurationServiceStub();
+		editor.editorPreviewRenderScheduler = {
+			cancel(): void { },
+			schedule(): void { },
+		};
+		editor.viewMode = 'list';
+		editor.dimension = undefined;
 		return editor;
 	}
 
@@ -149,6 +160,26 @@ suite('aiCustomizationManagementEditor', () => {
 
 		assert.strictEqual(editor.getEditorModeButtonLabel(), '');
 		assert.strictEqual(editor.getEditorModeButtonTooltip(), '');
+
+		editor.editorPreviewDisposables.dispose();
+	});
+
+	test('disabling the setting at runtime forces the editor back to raw mode', () => {
+		const configurationService = createConfigurationServiceStub() as IConfigurationService & { setValue(key: string, value: unknown): void };
+		const editor = createTestEditor(undefined, configurationService);
+		editor.viewMode = 'editor';
+		editor.currentEditingPromptType = PromptsType.agent;
+		editor.editorDisplayMode = 'preview';
+
+		// Sanity: setting is on, so preview is supported.
+		assert.strictEqual(editor.getEditorModeButtonLabel(), 'View Raw');
+
+		// Flip the setting off and run the change handler.
+		configurationService.setValue(ChatConfiguration.ChatCustomizationsStructuredPreviewEnabled, false);
+		editor.onStructuredPreviewSettingChanged();
+
+		assert.strictEqual(editor.editorDisplayMode, 'raw');
+		assert.strictEqual(editor.getEditorModeButtonLabel(), '');
 
 		editor.editorPreviewDisposables.dispose();
 	});

--- a/src/vs/workbench/contrib/chat/test/browser/aiCustomization/aiCustomizationManagementEditor.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/aiCustomization/aiCustomizationManagementEditor.test.ts
@@ -8,8 +8,10 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/
 import { Range } from '../../../../../../editor/common/core/range.js';
 import type { IManagedHover } from '../../../../../../base/browser/ui/hover/hover.js';
 import { IHoverService } from '../../../../../../platform/hover/browser/hover.js';
+import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { AICustomizationManagementEditor } from '../../../browser/aiCustomization/aiCustomizationManagementEditor.js';
 import { BUILTIN_STORAGE } from '../../../browser/aiCustomization/aiCustomizationManagement.js';
+import { ChatConfiguration } from '../../../common/constants.js';
 import { IHeaderAttribute } from '../../../common/promptSyntax/promptFileParser.js';
 import { PromptsType, Target } from '../../../common/promptSyntax/promptTypes.js';
 
@@ -24,12 +26,24 @@ suite('aiCustomizationManagementEditor', () => {
 		editorPreviewFrontMatterContainer: HTMLElement | undefined;
 		editorPreviewDisposables: { add<T>(value: T): T; dispose(): void };
 		hoverService: IHoverService;
+		configurationService: IConfigurationService;
 		getEditorModeButtonLabel(): string;
 		getEditorModeButtonTooltip(): string;
 		renderPreviewAttribute(attribute: IHeaderAttribute, promptType: PromptsType, target: Target): void;
 	};
 
-	function createTestEditor(hoverService?: IHoverService): TestableEditor {
+	function createConfigurationServiceStub(values: Record<string, unknown> = {}): IConfigurationService {
+		// Default to enabling the structured preview so existing assertions exercise the preview path.
+		const merged: Record<string, unknown> = {
+			[ChatConfiguration.ChatCustomizationsStructuredPreviewEnabled]: true,
+			...values,
+		};
+		return {
+			getValue: (key: string) => merged[key],
+		} as unknown as IConfigurationService;
+	}
+
+	function createTestEditor(hoverService?: IHoverService, configurationService?: IConfigurationService): TestableEditor {
 		const editor = Object.create(AICustomizationManagementEditor.prototype) as unknown as TestableEditor;
 		editor.currentEditingPromptType = undefined;
 		editor.currentEditingStorage = undefined;
@@ -50,6 +64,7 @@ suite('aiCustomizationManagementEditor', () => {
 				update() { },
 			}),
 		} as unknown as IHoverService;
+		editor.configurationService = configurationService ?? createConfigurationServiceStub();
 		return editor;
 	}
 
@@ -121,5 +136,20 @@ suite('aiCustomizationManagementEditor', () => {
 			container.remove();
 			editor.editorPreviewDisposables.dispose();
 		}
+	});
+
+	test('hides preview button when structured preview setting is disabled', () => {
+		const editor = createTestEditor(undefined, createConfigurationServiceStub({
+			[ChatConfiguration.ChatCustomizationsStructuredPreviewEnabled]: false,
+		}));
+		editor.currentEditingPromptType = PromptsType.agent;
+		editor.currentEditingStorage = BUILTIN_STORAGE;
+		editor.currentEditingReadOnly = false;
+		editor.editorDisplayMode = 'preview';
+
+		assert.strictEqual(editor.getEditorModeButtonLabel(), '');
+		assert.strictEqual(editor.getEditorModeButtonTooltip(), '');
+
+		editor.editorPreviewDisposables.dispose();
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/browser/aiCustomization/aiCustomizationManagementEditor.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/aiCustomization/aiCustomizationManagementEditor.test.ts
@@ -24,7 +24,7 @@ suite('aiCustomizationManagementEditor', () => {
 		currentEditingReadOnly: boolean;
 		editorDisplayMode: 'preview' | 'raw';
 		editorPreviewFrontMatterContainer: HTMLElement | undefined;
-		editorPreviewDisposables: { add<T>(value: T): T; dispose(): void };
+		editorPreviewDisposables: { add<T>(value: T): T; clear(): void; dispose(): void };
 		editorPreviewRenderScheduler: { cancel(): void; schedule(): void };
 		viewMode: 'list' | 'editor' | 'mcpDetail' | 'pluginDetail';
 		dimension: undefined;
@@ -59,6 +59,7 @@ suite('aiCustomizationManagementEditor', () => {
 			add<T>(value: T): T {
 				return value;
 			},
+			clear(): void { },
 			dispose(): void { },
 		};
 		editor.hoverService = hoverService ?? {

--- a/src/vs/workbench/contrib/chat/test/browser/aiCustomization/aiCustomizationManagementEditor.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/aiCustomization/aiCustomizationManagementEditor.test.ts
@@ -171,8 +171,8 @@ suite('aiCustomizationManagementEditor', () => {
 		editor.currentEditingPromptType = PromptsType.agent;
 		editor.editorDisplayMode = 'preview';
 
-		// Sanity: setting is on, so preview is supported.
-		assert.strictEqual(editor.getEditorModeButtonLabel(), 'View Raw');
+		// Sanity: setting is on and file is editable, so label is "Edit" (preview mode).
+		assert.strictEqual(editor.getEditorModeButtonLabel(), 'Edit');
 
 		// Flip the setting off and run the change handler.
 		configurationService.setValue(ChatConfiguration.ChatCustomizationsStructuredPreviewEnabled, false);

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts
@@ -52,6 +52,7 @@ import { AgentPluginItemKind, IAgentPluginItem } from '../../../../contrib/chat/
 import { ContributionEnablementState } from '../../../../contrib/chat/common/enablement.js';
 import { AICustomizationManagementEditorInput } from '../../../../contrib/chat/browser/aiCustomization/aiCustomizationManagementEditorInput.js';
 import { IConfigurationService, IConfigurationValue } from '../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { mcpAccessConfig, McpAccessValue } from '../../../../../platform/mcp/common/mcpManagement.js';
 import { McpServerType } from '../../../../../platform/mcp/common/mcpPlatformTypes.js';
 import { ChatConfiguration } from '../../../../contrib/chat/common/constants.js';
@@ -527,6 +528,11 @@ async function renderEditor(ctx: ComponentFixtureContext, options: IRenderEditor
 			const agentFeedbackService = createMockAgentFeedbackService();
 			const codeReviewService = createMockCodeReviewService();
 			registerWorkbenchServices(reg);
+			// Enable the structured customization preview setting so the
+			// editor exercises the preview-first behavior in fixtures.
+			reg.defineInstance(IConfigurationService, new TestConfigurationService({
+				[ChatConfiguration.ChatCustomizationsStructuredPreviewEnabled]: true,
+			}));
 			reg.define(IListService, ListService);
 			reg.defineInstance(ITextModelService, new class extends mock<ITextModelService>() {
 				declare readonly _serviceBrand: undefined;


### PR DESCRIPTION
Adds a new setting `chat.customizations.structuredPreview.enabled` (boolean, **default `false`**, tag `preview`) to gate the structured markdown preview introduced in #312545.

## What changed

- **New setting** `chat.customizations.structuredPreview.enabled` registered in `ChatConfiguration` and `chat.contribution.ts`.
- The single chokepoint `isStructuredPreviewSupported()` in `AICustomizationManagementEditor` now also checks the setting — when it's off the Preview/Raw toggle button is hidden and the editor opens directly in the raw embedded code editor.
- A new `onStructuredPreviewSettingChanged()` handler wired into the existing `onDidChangeConfiguration` listener handles runtime toggling: snaps the mode back to raw and clears the preview when disabled; re-schedules a preview render when re-enabled with a file already open.
- Unit tests updated to provide a `configurationService` stub (default-on so existing assertions keep exercising the preview path) and a new regression test confirms the button is hidden when the setting is off.
- Component fixtures updated to opt-in to the setting so `AgentsItemPreview`, `AgentsItemRaw`, `BuiltinSkillItemPreview`, and `BuiltinSkillItemRaw` screenshot fixtures remain stable.

## Why

The structured preview is a new feature that should be rolled out gradually. Defaulting to off lets us keep the code in main while giving users and teams control over when they adopt it.

## Testing
- `npm run compile-check-ts-native` ✅
- `npm run valid-layers-check` ✅
- Pre-commit hygiene hook ✅
