### PR TITLE
Remove 'Del' button from session history window

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessions.contribution.ts
@@ -16,7 +16,7 @@ import { IAgentSessionsService, AgentSessionsService } from './agentSessionsServ
 import { LocalAgentsSessionsController } from './localAgentSessionsController.js';
 import { registerWorkbenchContribution2, WorkbenchPhase } from '../../../../common/contributions.js';
 import { ISubmenuItem, MenuId, MenuRegistry, registerAction2 } from '../../../../../platform/actions/common/actions.js';
-import { ArchiveAgentSessionAction, ArchiveAgentSessionSectionAction, UnarchiveAgentSessionAction, OpenAgentSessionInEditorGroupAction, OpenAgentSessionInNewEditorGroupAction, OpenAgentSessionInNewWindowAction, ShowAgentSessionsSidebar, HideAgentSessionsSidebar, ToggleAgentSessionsSidebar, RefreshAgentSessionsViewerAction, FindAgentSessionInViewerAction, MarkAgentSessionUnreadAction, MarkAgentSessionReadAction, FocusAgentSessionsAction, SetAgentSessionsOrientationStackedAction, SetAgentSessionsOrientationSideBySideAction, PickAgentSessionAction, ArchiveAllAgentSessionsAction, MarkAllAgentSessionsReadAction, RenameAgentSessionAction, DeleteAgentSessionAction, DeleteAgentSessionInlineAction, DeleteAllLocalSessionsAction, MarkAgentSessionSectionReadAction, ToggleShowAgentSessionsAction, UnarchiveAgentSessionSectionAction, PinAgentSessionAction, UnpinAgentSessionAction, CollapseAllAgentSessionSectionsAction } from './agentSessionsActions.js';
+import { ArchiveAgentSessionAction, ArchiveAgentSessionSectionAction, UnarchiveAgentSessionAction, OpenAgentSessionInEditorGroupAction, OpenAgentSessionInNewEditorGroupAction, OpenAgentSessionInNewWindowAction, ShowAgentSessionsSidebar, HideAgentSessionsSidebar, ToggleAgentSessionsSidebar, RefreshAgentSessionsViewerAction, FindAgentSessionInViewerAction, MarkAgentSessionUnreadAction, MarkAgentSessionReadAction, FocusAgentSessionsAction, SetAgentSessionsOrientationStackedAction, SetAgentSessionsOrientationSideBySideAction, PickAgentSessionAction, ArchiveAllAgentSessionsAction, MarkAllAgentSessionsReadAction, RenameAgentSessionAction, DeleteAgentSessionAction, DeleteAllLocalSessionsAction, MarkAgentSessionSectionReadAction, ToggleShowAgentSessionsAction, UnarchiveAgentSessionSectionAction, PinAgentSessionAction, UnpinAgentSessionAction, CollapseAllAgentSessionSectionsAction } from './agentSessionsActions.js';
 import { AgentSessionsQuickAccessProvider, AGENT_SESSIONS_QUICK_ACCESS_PREFIX } from './agentSessionsQuickAccess.js';
 
 //#region Actions and Menus
@@ -35,7 +35,6 @@ registerAction2(PinAgentSessionAction);
 registerAction2(UnpinAgentSessionAction);
 registerAction2(RenameAgentSessionAction);
 registerAction2(DeleteAgentSessionAction);
-registerAction2(DeleteAgentSessionInlineAction);
 registerAction2(DeleteAllLocalSessionsAction);
 registerAction2(MarkAgentSessionUnreadAction);
 registerAction2(MarkAgentSessionReadAction);

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsActions.ts
@@ -728,50 +728,6 @@ export class DeleteAgentSessionAction extends BaseAgentSessionAction {
 	}
 }
 
-export class DeleteAgentSessionInlineAction extends BaseAgentSessionAction {
-
-	constructor() {
-		super({
-			id: 'agentSession.deleteInline',
-			title: localize2('del', "Del"),
-			icon: Codicon.trash,
-			menu: {
-				id: MenuId.AgentSessionItemToolbar,
-				group: 'navigation',
-				order: 2,
-				when: ChatContextKeys.agentSessionType.isEqualTo(AgentSessionProviders.Local)
-			}
-		});
-	}
-
-	async runWithSessions(sessions: IAgentSession[], accessor: ServicesAccessor): Promise<void> {
-		if (sessions.length === 0) {
-			return;
-		}
-
-		const chatService = accessor.get(IChatService);
-		const widgetService = accessor.get(IChatWidgetService);
-		const commandService = accessor.get(ICommandService);
-
-		const deletedSessionIds: string[] = [];
-
-		for (const session of sessions) {
-			await widgetService.getWidgetBySessionResource(session.resource)?.clear();
-			await chatService.removeHistoryEntry(session.resource);
-
-			const sessionId = LocalChatSessionUri.parseLocalSessionId(session.resource);
-			if (sessionId) {
-				deletedSessionIds.push(sessionId);
-			}
-		}
-
-		// Notify extensions to clean up cloud data (best effort)
-		if (deletedSessionIds.length > 0) {
-			commandService.executeCommand('github.copilot.sessionSync.deleteSessionFromCloud', deletedSessionIds).catch(() => { /* best effort */ });
-		}
-	}
-}
-
 export class DeleteAllLocalSessionsAction extends Action2 {
 
 	constructor() {


### PR DESCRIPTION
Remove 'Del' button from session history window. This button was recently added and is not needed to be shown in the history window and we only show 'Archive'.