### PR TITLE
Compress tool output to reduce token usage

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -157,6 +157,8 @@ import './widget/input/editor/chatInputEditorContrib.js';
 import './widget/input/editor/chatInputEditorHover.js';
 import { LanguageModelToolsConfirmationService } from './tools/languageModelToolsConfirmationService.js';
 import { LanguageModelToolsService, globalAutoApproveDescription } from './tools/languageModelToolsService.js';
+import { IToolResultCompressor } from '../common/tools/toolResultCompressor.js';
+import { ToolResultCompressorService } from './tools/toolResultCompressorService.js';
 import { AgentPluginService, ConfiguredAgentPluginDiscovery, ExtensionAgentPluginDiscovery, MarketplaceAgentPluginDiscovery } from '../common/plugins/agentPluginServiceImpl.js';
 import { IAgentPluginRepositoryService } from '../common/plugins/agentPluginRepositoryService.js';
 import { IPluginInstallService } from '../common/plugins/pluginInstallService.js';
@@ -1491,6 +1493,15 @@ configurationRegistry.registerConfiguration({
 			markdownDescription: nls.localize('chat.tools.terminal.simpleCollapsible', "When enabled, terminal tool calls are always displayed in a collapsible container with a simplified view."),
 			tags: ['experimental'],
 		},
+		[ChatConfiguration.CompressOutputEnabled]: {
+			type: 'boolean',
+			default: false,
+			markdownDescription: nls.localize('chat.tools.compressOutput.enabled', "Post-process tool output (for example `git diff`, `ls -l`, or `npm install`) to reduce token usage before it is sent to the model."),
+			tags: ['preview'],
+			experiment: {
+				mode: 'auto'
+			}
+		},
 		'chat.tools.usagesTool.enabled': {
 			type: 'boolean',
 			default: true,
@@ -2286,6 +2297,7 @@ registerSingleton(IAgentPluginRepositoryService, AgentPluginRepositoryService, I
 registerSingleton(IPluginGitService, BrowserPluginGitCommandService, InstantiationType.Delayed);
 registerSingleton(IPluginInstallService, PluginInstallService, InstantiationType.Delayed);
 registerSingleton(ILanguageModelToolsService, LanguageModelToolsService, InstantiationType.Delayed);
+registerSingleton(IToolResultCompressor, ToolResultCompressorService, InstantiationType.Delayed);
 registerSingleton(ILanguageModelToolsConfirmationService, LanguageModelToolsConfirmationService, InstantiationType.Delayed);
 registerSingleton(IChatToolRiskAssessmentService, ChatToolRiskAssessmentService, InstantiationType.Delayed);
 registerSingleton(IVoiceChatService, VoiceChatService, InstantiationType.Delayed);

--- a/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsService.ts
@@ -50,6 +50,7 @@ import { chatSessionResourceToId, getChatSessionType } from '../../common/model/
 import { HookType } from '../../common/promptSyntax/hookTypes.js';
 import { ILanguageModelToolsConfirmationService } from '../../common/tools/languageModelToolsConfirmationService.js';
 import { CountTokensCallback, createToolSchemaUri, IBeginToolCallOptions, IExternalPreToolUseHookResult, ILanguageModelToolsService, IPreparedToolInvocation, isToolSet, IToolAndToolSetEnablementMap, IToolData, IToolImpl, IToolInvocation, IToolInvokedEvent, IToolResult, IToolResultInputOutputDetails, IToolSet, SpecedToolAliases, stringifyPromptTsxPart, ToolDataSource, ToolInvocationPresentation, toolMatchesModel, ToolSet, ToolSetForModel, VSCodeToolReference } from '../../common/tools/languageModelToolsService.js';
+import { IToolResultCompressor } from '../../common/tools/toolResultCompressor.js';
 import { getToolConfirmationAlert } from '../accessibility/chatAccessibilityProvider.js';
 import { IChatWidgetService } from '../chat.js';
 
@@ -136,6 +137,7 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 		@ILanguageModelToolsConfirmationService private readonly _confirmationService: ILanguageModelToolsConfirmationService,
 		@ICommandService private readonly _commandService: ICommandService,
 		@IChatWidgetService private readonly _chatWidgetService: IChatWidgetService,
+		@IToolResultCompressor private readonly _toolResultCompressor: IToolResultCompressor,
 	) {
 		super();
 
@@ -645,6 +647,13 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 				}
 			}, token);
 			invocationTimeWatch.stop();
+			// Apply post-processing compression (e.g. for run_in_terminal output)
+			// before the result reaches the model. Returns undefined when no
+			// compression applied.
+			const compressed = this._toolResultCompressor.maybeCompress(tool.data.id, dto.parameters, toolResult);
+			if (compressed) {
+				toolResult = compressed;
+			}
 			this.ensureToolDetails(dto, toolResult, tool.data, toolInvocation);
 
 			const afterExecuteState = await toolInvocation?.didExecuteTool(toolResult, undefined, () =>

--- a/src/vs/workbench/contrib/chat/browser/tools/toolResultCompressorService.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/toolResultCompressorService.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { getErrorMessage } from '../../../../../base/common/errors.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
@@ -11,7 +12,7 @@ import { ChatConfiguration } from '../../common/constants.js';
 import { IToolResult, IToolResultTextPart } from '../../common/tools/languageModelToolsService.js';
 import { formatCompressionBanner, IToolResultCompressor, IToolResultFilter, MIN_COMPRESSIBLE_LENGTH } from '../../common/tools/toolResultCompressor.js';
 
-type LanguageModelToolInvokedClassification = {
+type ToolResultCompressedClassification = {
 	owner: 'meganrogge';
 	comment: 'Reports tool output compression savings.';
 	toolId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The tool whose output was compressed.' };
@@ -20,7 +21,7 @@ type LanguageModelToolInvokedClassification = {
 	afterChars: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Total text part length in UTF-16 code units after compression.' };
 };
 
-type LanguageModelToolInvokedEvent = {
+type ToolResultCompressedEvent = {
 	toolId: string;
 	filters: string;
 	beforeChars: number;
@@ -81,7 +82,9 @@ export class ToolResultCompressorService extends Disposable implements IToolResu
 				return part;
 			}
 			const original = part.value;
+			totalBefore += original.length;
 			if (original.length < MIN_COMPRESSIBLE_LENGTH) {
+				totalAfter += original.length;
 				return part;
 			}
 
@@ -104,12 +107,11 @@ export class ToolResultCompressorService extends Disposable implements IToolResu
 					activeFilters.splice(i, 1);
 					if (!disabledFilterIds.has(filter.id)) {
 						disabledFilterIds.add(filter.id);
-						this._logService.warn(`[ToolResultCompressor] filter ${filter.id} threw on tool ${toolId}; disabled for this pass: ${err}`);
+						this._logService.warn(`[ToolResultCompressor] filter ${filter.id} threw on tool ${toolId}; disabled for this pass: ${getErrorMessage(err)}`, err);
 					}
 				}
 			}
 
-			totalBefore += original.length;
 			totalAfter += current.length;
 			if (current !== original) {
 				anyCompressed = true;
@@ -143,7 +145,7 @@ export class ToolResultCompressorService extends Disposable implements IToolResu
 	}
 
 	private _sendTelemetry(toolId: string, filterIds: string[], beforeChars: number, afterChars: number) {
-		this._telemetryService.publicLog2<LanguageModelToolInvokedEvent, LanguageModelToolInvokedClassification>(
+		this._telemetryService.publicLog2<ToolResultCompressedEvent, ToolResultCompressedClassification>(
 			'toolResultCompressed',
 			{
 				toolId,

--- a/src/vs/workbench/contrib/chat/browser/tools/toolResultCompressorService.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/toolResultCompressorService.ts
@@ -1,0 +1,156 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { ChatConfiguration } from '../../common/constants.js';
+import { IToolResult, IToolResultTextPart } from '../../common/tools/languageModelToolsService.js';
+import { formatCompressionBanner, IToolResultCompressor, IToolResultFilter, MIN_COMPRESSIBLE_LENGTH } from '../../common/tools/toolResultCompressor.js';
+
+type LanguageModelToolInvokedClassification = {
+	owner: 'meganrogge';
+	comment: 'Reports tool output compression savings.';
+	toolId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The tool whose output was compressed.' };
+	filters: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Comma-separated filter ids that fired.' };
+	beforeChars: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Total text part length in UTF-16 code units before compression.' };
+	afterChars: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Total text part length in UTF-16 code units after compression.' };
+};
+
+type LanguageModelToolInvokedEvent = {
+	toolId: string;
+	filters: string;
+	beforeChars: number;
+	afterChars: number;
+};
+
+export class ToolResultCompressorService extends Disposable implements IToolResultCompressor {
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _filters = new Map<string, IToolResultFilter[]>();
+
+	constructor(
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@ITelemetryService private readonly _telemetryService: ITelemetryService,
+		@ILogService private readonly _logService: ILogService,
+	) {
+		super();
+	}
+
+	registerFilter(filter: IToolResultFilter): void {
+		for (const id of filter.toolIds) {
+			let bucket = this._filters.get(id);
+			if (!bucket) {
+				bucket = [];
+				this._filters.set(id, bucket);
+			}
+			bucket.push(filter);
+		}
+	}
+
+	maybeCompress(toolId: string, input: unknown, result: IToolResult): IToolResult | undefined {
+		if (!this._configurationService.getValue<boolean>(ChatConfiguration.CompressOutputEnabled)) {
+			return undefined;
+		}
+
+		const filters = this._filters.get(toolId);
+		if (!filters || filters.length === 0) {
+			return undefined;
+		}
+
+		const matchingFilters = filters.filter(f => f.matches(toolId, input));
+		if (matchingFilters.length === 0) {
+			return undefined;
+		}
+
+		// Mutable copy: filters that throw get spliced out so we don't repeatedly
+		// invoke a broken filter on every subsequent text part in this pass.
+		const activeFilters = matchingFilters.slice();
+		const disabledFilterIds = new Set<string>();
+
+		let totalBefore = 0;
+		let totalAfter = 0;
+		let anyCompressed = false;
+		const usedFilterIds = new Set<string>();
+
+		const newContent = result.content.map(part => {
+			if (part.kind !== 'text') {
+				return part;
+			}
+			const original = part.value;
+			if (original.length < MIN_COMPRESSIBLE_LENGTH) {
+				return part;
+			}
+
+			let current = original;
+			const partFilterIds: string[] = [];
+			for (let i = 0; i < activeFilters.length; /* manual increment */) {
+				const filter = activeFilters[i];
+				try {
+					const out = filter.apply(current, input);
+					if (out.compressed && out.text.length < current.length) {
+						current = out.text;
+						usedFilterIds.add(filter.id);
+						partFilterIds.push(filter.id);
+					}
+					i++;
+				} catch (err) {
+					// "Never make it worse." Disable the filter for the rest of this
+					// compression pass so it can't repeatedly throw on later text parts,
+					// and warn at most once per filter.
+					activeFilters.splice(i, 1);
+					if (!disabledFilterIds.has(filter.id)) {
+						disabledFilterIds.add(filter.id);
+						this._logService.warn(`[ToolResultCompressor] filter ${filter.id} threw on tool ${toolId}; disabled for this pass: ${err}`);
+					}
+				}
+			}
+
+			totalBefore += original.length;
+			totalAfter += current.length;
+			if (current !== original) {
+				anyCompressed = true;
+				// Prepend a banner so the model knows the output was filtered, by
+				// which filters, and how to disable compression. We only annotate
+				// the parts we actually changed — non-compressed parts pass through
+				// untouched.
+				const banner = formatCompressionBanner(partFilterIds, original.length, current.length);
+				const annotated = `${banner}\n${current}`;
+				const rewritten: IToolResultTextPart = {
+					kind: 'text',
+					value: annotated,
+					audience: part.audience,
+					title: part.title,
+				};
+				return rewritten;
+			}
+			return part;
+		});
+
+		if (!anyCompressed) {
+			return undefined;
+		}
+
+		this._sendTelemetry(toolId, [...usedFilterIds], totalBefore, totalAfter);
+
+		return {
+			...result,
+			content: newContent,
+		};
+	}
+
+	private _sendTelemetry(toolId: string, filterIds: string[], beforeChars: number, afterChars: number) {
+		this._telemetryService.publicLog2<LanguageModelToolInvokedEvent, LanguageModelToolInvokedClassification>(
+			'toolResultCompressed',
+			{
+				toolId,
+				filters: filterIds.join(','),
+				beforeChars,
+				afterChars,
+			},
+		);
+	}
+}

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -40,6 +40,7 @@ export enum ChatConfiguration {
 	ThinkingGenerateTitles = 'chat.agent.thinking.generateTitles',
 	TerminalToolsInThinking = 'chat.agent.thinking.terminalTools',
 	SimpleTerminalCollapsible = 'chat.tools.terminal.simpleCollapsible',
+	CompressOutputEnabled = 'chat.tools.compressOutput.enabled',
 	ThinkingPhrases = 'chat.agent.thinking.phrases',
 	AutoExpandToolFailures = 'chat.tools.autoExpandFailures',
 	TodosShowWidget = 'chat.tools.todos.showWidget',

--- a/src/vs/workbench/contrib/chat/common/tools/toolResultCompressor.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/toolResultCompressor.ts
@@ -1,0 +1,65 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
+import { IToolResult } from './languageModelToolsService.js';
+
+export const IToolResultCompressor = createDecorator<IToolResultCompressor>('IToolResultCompressor');
+
+/**
+ * Result of running a {@link IToolResultFilter}.
+ *
+ * `text` is the new text to substitute back into the corresponding text part.
+ * `compressed` is `true` if any compression actually happened — used purely
+ * for telemetry / accounting.
+ */
+export interface IToolResultFilterOutput {
+	readonly text: string;
+	readonly compressed: boolean;
+}
+
+/**
+ * A pure function that compresses a single text part of a tool result.
+ *
+ * Implementations MUST never make output worse than the input. If a filter
+ * cannot improve a piece of text, it should return the original `text` and
+ * `compressed: false`.
+ */
+export interface IToolResultFilter {
+	readonly id: string;
+	/** Tool ids this filter applies to. */
+	readonly toolIds: readonly string[];
+	/**
+	 * Decide whether this filter wants to handle the result. May inspect tool
+	 * input (e.g. for `run_in_terminal`, the command being run).
+	 */
+	matches(toolId: string, input: unknown): boolean;
+	apply(text: string, input: unknown): IToolResultFilterOutput;
+}
+
+export interface IToolResultCompressor {
+	readonly _serviceBrand: undefined;
+	registerFilter(filter: IToolResultFilter): void;
+	/**
+	 * Returns a possibly-compressed copy of `result`, or `undefined` if no
+	 * compression was applied (caller should pass through the original).
+	 */
+	maybeCompress(toolId: string, input: unknown, result: IToolResult): IToolResult | undefined;
+}
+
+/**
+ * Outputs at or below this many characters (UTF-16 code units, i.e.
+ * `string.length`) are not worth compressing.
+ */
+export const MIN_COMPRESSIBLE_LENGTH = 80;
+
+/**
+ * Format the banner that gets prepended to compressed text parts so the
+ * model knows compression happened, which filters fired, and how to opt out.
+ */
+export function formatCompressionBanner(filterIds: readonly string[], beforeChars: number, afterChars: number): string {
+	const ids = filterIds.length > 0 ? filterIds.join(', ') : 'unknown';
+	return `[Output compressed by ${ids} (${beforeChars} → ${afterChars} chars). To disable, set chat.tools.compressOutput.enabled to false.]`;
+}

--- a/src/vs/workbench/contrib/chat/test/browser/tools/languageModelToolsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/tools/languageModelToolsService.test.ts
@@ -32,10 +32,17 @@ import { ChatToolInvocation } from '../../../common/model/chatProgressTypes/chat
 import { LocalChatSessionUri } from '../../../common/model/chatUri.js';
 import { ILanguageModelToolsConfirmationService } from '../../../common/tools/languageModelToolsConfirmationService.js';
 import { MockLanguageModelToolsConfirmationService } from '../../common/tools/mockLanguageModelToolsConfirmationService.js';
+import { IToolResultCompressor } from '../../../common/tools/toolResultCompressor.js';
 import { runWithFakedTimers } from '../../../../../../base/test/common/timeTravelScheduler.js';
 import { ILanguageModelChatMetadata } from '../../../common/languageModels.js';
 
 // --- Test helpers to reduce repetition and improve readability ---
+
+const noopToolResultCompressor: IToolResultCompressor = {
+	_serviceBrand: undefined,
+	registerFilter: () => { },
+	maybeCompress: () => undefined,
+};
 
 class TestAccessibilitySignalService implements Partial<IAccessibilitySignalService> {
 	public signalPlayedCalls: { signal: AccessibilitySignal; options?: any }[] = [];
@@ -142,6 +149,7 @@ function createTestToolsService(store: ReturnType<typeof ensureNoDisposablesAreL
 	const chatService = new MockChatService();
 	instaService.stub(IChatService, chatService);
 	instaService.stub(ILanguageModelToolsConfirmationService, new MockLanguageModelToolsConfirmationService());
+	instaService.stub(IToolResultCompressor, noopToolResultCompressor);
 
 	if (options?.accessibilityService) {
 		instaService.stub(IAccessibilityService, options.accessibilityService);
@@ -2023,6 +2031,7 @@ suite('LanguageModelToolsService', () => {
 		instaService1.stub(IAccessibilityService, testAccessibilityService1);
 		instaService1.stub(IAccessibilitySignalService, testAccessibilitySignalService as unknown as IAccessibilitySignalService);
 		instaService1.stub(ILanguageModelToolsConfirmationService, new MockLanguageModelToolsConfirmationService());
+		instaService1.stub(IToolResultCompressor, noopToolResultCompressor);
 		const testService1 = store.add(instaService1.createInstance(LanguageModelToolsService));
 
 		const tool1 = registerToolForTest(testService1, store, 'soundOnlyTool', {
@@ -2064,6 +2073,7 @@ suite('LanguageModelToolsService', () => {
 		instaService2.stub(IAccessibilityService, testAccessibilityService2);
 		instaService2.stub(IAccessibilitySignalService, testAccessibilitySignalService as unknown as IAccessibilitySignalService);
 		instaService2.stub(ILanguageModelToolsConfirmationService, new MockLanguageModelToolsConfirmationService());
+		instaService2.stub(IToolResultCompressor, noopToolResultCompressor);
 		const testService2 = store.add(instaService2.createInstance(LanguageModelToolsService));
 
 		const tool2 = registerToolForTest(testService2, store, 'autoScreenReaderTool', {
@@ -2106,6 +2116,7 @@ suite('LanguageModelToolsService', () => {
 		instaService3.stub(IAccessibilityService, testAccessibilityService3);
 		instaService3.stub(IAccessibilitySignalService, testAccessibilitySignalService as unknown as IAccessibilitySignalService);
 		instaService3.stub(ILanguageModelToolsConfirmationService, new MockLanguageModelToolsConfirmationService());
+		instaService3.stub(IToolResultCompressor, noopToolResultCompressor);
 		const testService3 = store.add(instaService3.createInstance(LanguageModelToolsService));
 
 		const tool3 = registerToolForTest(testService3, store, 'offTool', {
@@ -2899,6 +2910,7 @@ suite('LanguageModelToolsService', () => {
 		}, store);
 		instaService.stub(IChatService, chatService);
 		instaService.stub(ILanguageModelToolsConfirmationService, new MockLanguageModelToolsConfirmationService());
+		instaService.stub(IToolResultCompressor, noopToolResultCompressor);
 		const testService = store.add(instaService.createInstance(LanguageModelToolsService));
 
 		const tool = registerToolForTest(testService, store, 'gitCommitTool', {
@@ -2937,6 +2949,7 @@ suite('LanguageModelToolsService', () => {
 		}, store);
 		instaService.stub(IChatService, chatService);
 		instaService.stub(ILanguageModelToolsConfirmationService, new MockLanguageModelToolsConfirmationService());
+		instaService.stub(IToolResultCompressor, noopToolResultCompressor);
 		const testService = store.add(instaService.createInstance(LanguageModelToolsService));
 
 		// Tool that was previously namespaced under extension but is now internal
@@ -2976,6 +2989,7 @@ suite('LanguageModelToolsService', () => {
 		}, store);
 		instaService.stub(IChatService, chatService);
 		instaService.stub(ILanguageModelToolsConfirmationService, new MockLanguageModelToolsConfirmationService());
+		instaService.stub(IToolResultCompressor, noopToolResultCompressor);
 		const testService = store.add(instaService.createInstance(LanguageModelToolsService));
 
 		// Tool that was previously namespaced under extension but is now internal
@@ -3018,6 +3032,7 @@ suite('LanguageModelToolsService', () => {
 		}, store);
 		instaService.stub(IChatService, chatService);
 		instaService.stub(ILanguageModelToolsConfirmationService, new MockLanguageModelToolsConfirmationService());
+		instaService.stub(IToolResultCompressor, noopToolResultCompressor);
 		const testService = store.add(instaService.createInstance(LanguageModelToolsService));
 
 		// Tool that was previously namespaced under extension but is now internal

--- a/src/vs/workbench/contrib/chat/test/browser/tools/toolResultCompressorService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/tools/toolResultCompressorService.test.ts
@@ -1,0 +1,134 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ok, strictEqual } from 'assert';
+import { VSBuffer } from '../../../../../../base/common/buffer.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
+import { NullTelemetryService } from '../../../../../../platform/telemetry/common/telemetryUtils.js';
+import { ToolResultCompressorService } from '../../../browser/tools/toolResultCompressorService.js';
+import { ChatConfiguration } from '../../../common/constants.js';
+import { LanguageModelPartAudience } from '../../../common/languageModels.js';
+import { IToolResult, IToolResultDataPart, IToolResultTextPart } from '../../../common/tools/languageModelToolsService.js';
+import { IToolResultFilter } from '../../../common/tools/toolResultCompressor.js';
+
+const TOOL = 'run_in_terminal';
+
+class CapturingLogService extends NullLogService {
+	public readonly warnings: string[] = [];
+	override warn(msg: string): void { this.warnings.push(msg); }
+}
+
+function makeService(opts: { enabled: boolean; log?: ILogService }): ToolResultCompressorService {
+	const config = new TestConfigurationService({ chat: { tools: { compressOutput: { enabled: opts.enabled } } } });
+	// Also register raw key so getValue<boolean>(key) returns the value.
+	config.setUserConfiguration(ChatConfiguration.CompressOutputEnabled, opts.enabled);
+	return new ToolResultCompressorService(config, NullTelemetryService, opts.log ?? new NullLogService());
+}
+
+function longText(prefix: string): string {
+	// Must exceed MIN_COMPRESSIBLE_LENGTH (80) so filters get a chance to run.
+	return prefix + ' ' + 'x'.repeat(200);
+}
+
+const replaceWithFooFilter: IToolResultFilter = {
+	id: 'test.replaceWithFoo',
+	toolIds: [TOOL],
+	matches: () => true,
+	apply: () => ({ text: 'foo', compressed: true }),
+};
+
+function textResult(...values: string[]): IToolResult {
+	return { content: values.map(value => ({ kind: 'text' as const, value })) };
+}
+
+suite('ToolResultCompressorService', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('returns undefined when disabled', () => {
+		const svc = makeService({ enabled: false });
+		svc.registerFilter(replaceWithFooFilter);
+		strictEqual(svc.maybeCompress(TOOL, {}, textResult(longText('hello'))), undefined);
+	});
+
+	test('returns undefined when no filters registered', () => {
+		const svc = makeService({ enabled: true });
+		strictEqual(svc.maybeCompress(TOOL, {}, textResult(longText('hello'))), undefined);
+	});
+
+	test('returns undefined when no filters match', () => {
+		const svc = makeService({ enabled: true });
+		svc.registerFilter({
+			id: 'no-match',
+			toolIds: [TOOL],
+			matches: () => false,
+			apply: () => ({ text: 'foo', compressed: true }),
+		});
+		strictEqual(svc.maybeCompress(TOOL, {}, textResult(longText('hello'))), undefined);
+	});
+
+	test('disables a throwing filter for the rest of the pass and warns once', () => {
+		const log = new CapturingLogService();
+		const svc = makeService({ enabled: true, log });
+		let calls = 0;
+		svc.registerFilter({
+			id: 'thrower',
+			toolIds: [TOOL],
+			matches: () => true,
+			apply: () => { calls++; throw new Error('boom'); },
+		});
+		svc.registerFilter(replaceWithFooFilter);
+		const out = svc.maybeCompress(TOOL, {}, textResult(longText('a'), longText('b'), longText('c')));
+		ok(out);
+		// Throwing filter is invoked exactly once on the first text part, then disabled.
+		strictEqual(calls, 1);
+		strictEqual(log.warnings.length, 1);
+		ok(log.warnings[0].includes('thrower'));
+		// The other filter still rewrites every text part. Each emitted part starts
+		// with the compression banner and ends with the filter's replacement text.
+		for (const part of out!.content) {
+			strictEqual(part.kind, 'text');
+			const value = (part as { value: string }).value;
+			ok(/^\[Output compressed by test\.replaceWithFoo /.test(value));
+			ok(value.endsWith('\nfoo'));
+		}
+	});
+
+	test('preserves non-text parts unchanged', () => {
+		const svc = makeService({ enabled: true });
+		svc.registerFilter(replaceWithFooFilter);
+		const dataPart: IToolResultDataPart = { kind: 'data', value: { mimeType: 'application/octet-stream', data: VSBuffer.wrap(new Uint8Array([1, 2, 3])) } };
+		const result: IToolResult = { content: [dataPart, { kind: 'text', value: longText('hello') }] };
+		const out = svc.maybeCompress(TOOL, {}, result);
+		ok(out);
+		strictEqual(out!.content[0], dataPart);
+		strictEqual(out!.content[1].kind, 'text');
+		const value = (out!.content[1] as IToolResultTextPart).value;
+		ok(/^\[Output compressed by test\.replaceWithFoo /.test(value));
+		ok(value.endsWith('\nfoo'));
+	});
+
+	test('preserves text part audience metadata when rewriting', () => {
+		const svc = makeService({ enabled: true });
+		svc.registerFilter(replaceWithFooFilter);
+		const audience = [LanguageModelPartAudience.Assistant, LanguageModelPartAudience.User];
+		const result: IToolResult = { content: [{ kind: 'text', value: longText('hello'), audience }] };
+		const out = svc.maybeCompress(TOOL, {}, result);
+		ok(out);
+		strictEqual(out!.content[0].kind, 'text');
+		const part = out!.content[0] as IToolResultTextPart;
+		ok(/^\[Output compressed by test\.replaceWithFoo /.test(part.value));
+		ok(part.value.endsWith('\nfoo'));
+		strictEqual(part.audience, audience);
+	});
+
+	test('skips text parts shorter than the minimum compressible length', () => {
+		const svc = makeService({ enabled: true });
+		svc.registerFilter(replaceWithFooFilter);
+		// Nothing was compressed because the part was below the threshold.
+		strictEqual(svc.maybeCompress(TOOL, {}, textResult('tiny')), undefined);
+	});
+});

--- a/src/vs/workbench/contrib/chat/test/browser/tools/toolResultCompressorService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/tools/toolResultCompressorService.test.ts
@@ -46,21 +46,23 @@ function textResult(...values: string[]): IToolResult {
 }
 
 suite('ToolResultCompressorService', () => {
-	ensureNoDisposablesAreLeakedInTestSuite();
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	const make = (opts: { enabled: boolean; log?: ILogService }) => store.add(makeService(opts));
 
 	test('returns undefined when disabled', () => {
-		const svc = makeService({ enabled: false });
+		const svc = make({ enabled: false });
 		svc.registerFilter(replaceWithFooFilter);
 		strictEqual(svc.maybeCompress(TOOL, {}, textResult(longText('hello'))), undefined);
 	});
 
 	test('returns undefined when no filters registered', () => {
-		const svc = makeService({ enabled: true });
+		const svc = make({ enabled: true });
 		strictEqual(svc.maybeCompress(TOOL, {}, textResult(longText('hello'))), undefined);
 	});
 
 	test('returns undefined when no filters match', () => {
-		const svc = makeService({ enabled: true });
+		const svc = make({ enabled: true });
 		svc.registerFilter({
 			id: 'no-match',
 			toolIds: [TOOL],
@@ -72,7 +74,7 @@ suite('ToolResultCompressorService', () => {
 
 	test('disables a throwing filter for the rest of the pass and warns once', () => {
 		const log = new CapturingLogService();
-		const svc = makeService({ enabled: true, log });
+		const svc = make({ enabled: true, log });
 		let calls = 0;
 		svc.registerFilter({
 			id: 'thrower',
@@ -98,7 +100,7 @@ suite('ToolResultCompressorService', () => {
 	});
 
 	test('preserves non-text parts unchanged', () => {
-		const svc = makeService({ enabled: true });
+		const svc = make({ enabled: true });
 		svc.registerFilter(replaceWithFooFilter);
 		const dataPart: IToolResultDataPart = { kind: 'data', value: { mimeType: 'application/octet-stream', data: VSBuffer.wrap(new Uint8Array([1, 2, 3])) } };
 		const result: IToolResult = { content: [dataPart, { kind: 'text', value: longText('hello') }] };
@@ -112,7 +114,7 @@ suite('ToolResultCompressorService', () => {
 	});
 
 	test('preserves text part audience metadata when rewriting', () => {
-		const svc = makeService({ enabled: true });
+		const svc = make({ enabled: true });
 		svc.registerFilter(replaceWithFooFilter);
 		const audience = [LanguageModelPartAudience.Assistant, LanguageModelPartAudience.User];
 		const result: IToolResult = { content: [{ kind: 'text', value: longText('hello'), audience }] };
@@ -126,7 +128,7 @@ suite('ToolResultCompressorService', () => {
 	});
 
 	test('skips text parts shorter than the minimum compressible length', () => {
-		const svc = makeService({ enabled: true });
+		const svc = make({ enabled: true });
 		svc.registerFilter(replaceWithFooFilter);
 		// Nothing was compressed because the part was below the threshold.
 		strictEqual(svc.maybeCompress(TOOL, {}, textResult('tiny')), undefined);

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/terminal.chatAgentTools.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/terminal.chatAgentTools.contribution.ts
@@ -16,6 +16,7 @@ import { registerWorkbenchContribution2, WorkbenchPhase, type IWorkbenchContribu
 import { IChatWidgetService } from '../../../chat/browser/chat.js';
 import { ChatContextKeys } from '../../../chat/common/actions/chatContextKeys.js';
 import { ILanguageModelToolsService } from '../../../chat/common/tools/languageModelToolsService.js';
+import { IToolResultCompressor } from '../../../chat/common/tools/toolResultCompressor.js';
 import { registerActiveInstanceAction, sharedWhenClause } from '../../../terminal/browser/terminalActions.js';
 import { TerminalContextMenuGroup } from '../../../terminal/browser/terminalMenus.js';
 import { TerminalContextKeys } from '../../../terminal/common/terminalContextKey.js';
@@ -32,6 +33,7 @@ import { RunInTerminalTool, createRunInTerminalToolData } from './tools/runInTer
 import { CreateAndRunTaskTool, CreateAndRunTaskToolData } from './tools/task/createAndRunTaskTool.js';
 import { GetTaskOutputTool, GetTaskOutputToolData } from './tools/task/getTaskOutputTool.js';
 import { RunTaskTool, RunTaskToolData } from './tools/task/runTaskTool.js';
+import { registerTerminalCompressors } from './tools/terminalOutputCompressor.js';
 import { InstantiationType, registerSingleton } from '../../../../../platform/instantiation/common/extensions.js';
 import { ITerminalSandboxService, TerminalSandboxService } from '../common/terminalSandboxService.js';
 import { isNumber } from '../../../../../base/common/types.js';
@@ -88,8 +90,11 @@ export class ChatAgentToolsContribution extends Disposable implements IWorkbench
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@ILanguageModelToolsService private readonly _toolsService: ILanguageModelToolsService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IToolResultCompressor toolResultCompressor: IToolResultCompressor,
 	) {
 		super();
+
+		registerTerminalCompressors(toolResultCompressor);
 
 		// #region Terminal
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/terminalOutputCompressor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/terminalOutputCompressor.ts
@@ -117,7 +117,7 @@ export const gitDiffFilter: IToolResultFilter = {
 			if (line.startsWith('diff --git')) {
 				flushContextRun();
 				flushHunk();
-				inBinaryOrLock = /package-lock\.json|yarn\.lock|pnpm-lock\.yaml|\.lockb?$|\.snap$/.test(line);
+				inBinaryOrLock = /package-lock\.json|yarn\.lock|pnpm-lock\.yaml|bun\.lockb|\.snap$/.test(line);
 				if (inBinaryOrLock) {
 					out.push(line);
 					out.push('... lockfile/snapshot diff omitted ...');
@@ -166,6 +166,12 @@ export const gitDiffFilter: IToolResultFilter = {
 				flushContextRun();
 				out.push(line);
 				pendingOldLines++;
+				continue;
+			}
+			// Hunk context lines start with a single space.
+			if (!line.startsWith(' ')) {
+				flushContextRun();
+				out.push(line);
 				continue;
 			}
 			// Unchanged context line: keep the first KEEP_CONTEXT lines of each run,
@@ -256,7 +262,12 @@ export const npmInstallFilter: IToolResultFilter = {
 			return true;
 		}
 		if ((parsed.head === 'yarn' || parsed.head === 'pnpm') && parsed.sub !== 'test') {
-			return /\binstall\b|\badd\b/.test(input.command ?? '') || parsed.sub === undefined;
+			if (/\binstall\b|\badd\b/.test(input.command ?? '')) {
+				return true;
+			}
+			if (parsed.sub === undefined) {
+				return /^\s*(?:[A-Z_][A-Z0-9_]*=\S+\s+)*(?:yarn|pnpm)\s*$/.test(input.command ?? '');
+			}
 		}
 		return false;
 	},

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/terminalOutputCompressor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/terminalOutputCompressor.ts
@@ -50,7 +50,11 @@ export function parseCommandHead(command: string | undefined): { head: string; s
 }
 
 function isTerminalInput(input: unknown): input is ITerminalInput {
-	return typeof input === 'object' && input !== null && 'command' in input;
+	if (typeof input !== 'object' || input === null) {
+		return false;
+	}
+	const terminalInput = input as { command?: unknown };
+	return terminalInput.command === undefined || typeof terminalInput.command === 'string';
 }
 
 /**

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/terminalOutputCompressor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/terminalOutputCompressor.ts
@@ -1,0 +1,291 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { TerminalToolId } from '../../../../chat/common/tools/terminalToolIds.js';
+import { IToolResultCompressor, IToolResultFilter, IToolResultFilterOutput } from '../../../../chat/common/tools/toolResultCompressor.js';
+
+/**
+ * Input shape used by the core `run_in_terminal` tool. We only depend on the
+ * `command` field; everything else is ignored.
+ */
+interface ITerminalInput {
+	command?: string;
+}
+
+/**
+ * Returns the "head" of a shell command — the first executable word, after
+ * skipping common env-var assignments like `FOO=bar baz`. `sub` is the first
+ * non-long-flag token after the head, so `git --no-pager diff` yields
+ * `{ head: 'git', sub: 'diff' }`. Returns `undefined` when the command can't
+ * be parsed.
+ */
+export function parseCommandHead(command: string | undefined): { head: string; sub: string | undefined } | undefined {
+	if (!command) {
+		return undefined;
+	}
+	// Take only the first pipeline segment so `git diff | cat` still routes to git.
+	const firstSegment = command.split(/[|;&]/)[0].trim();
+	if (!firstSegment) {
+		return undefined;
+	}
+	const tokens = firstSegment.split(/\s+/).filter(t => !/^[A-Z_][A-Z0-9_]*=/.test(t));
+	const head = tokens[0];
+	if (!head) {
+		return undefined;
+	}
+	// Skip leading long flags like `--no-pager` so `git --no-pager diff` parses
+	// as `{ head: 'git', sub: 'diff' }`. Short flags (`-la`) stay as the sub
+	// because for tools like `ls` they're the entire intent.
+	let sub: string | undefined;
+	for (let i = 1; i < tokens.length; i++) {
+		if (tokens[i].startsWith('--')) {
+			continue;
+		}
+		sub = tokens[i];
+		break;
+	}
+	return { head, sub };
+}
+
+function isTerminalInput(input: unknown): input is ITerminalInput {
+	return typeof input === 'object' && input !== null && 'command' in input;
+}
+
+/**
+ * Compresses `git diff` / `git show` output by reducing context lines to a
+ * tighter window and dropping the huge no-op chunks that diffs of generated
+ * files (lockfiles, snapshots) produce.
+ */
+export const gitDiffFilter: IToolResultFilter = {
+	id: 'terminal.git-diff',
+	toolIds: [TerminalToolId.RunInTerminal],
+	matches(_toolId, input) {
+		if (!isTerminalInput(input)) {
+			return false;
+		}
+		const parsed = parseCommandHead(input.command);
+		return parsed?.head === 'git' && (parsed.sub === 'diff' || parsed.sub === 'show');
+	},
+	apply(text): IToolResultFilterOutput {
+		const lines = text.split('\n');
+		const out: string[] = [];
+		// Number of context lines to keep at the start of each unchanged run before
+		// collapsing the rest into a single "... N omitted ..." marker.
+		const KEEP_CONTEXT = 1;
+		let contextRun = 0;
+		let inBinaryOrLock = false;
+
+		// Pending hunk: we buffer the body so we can rewrite the `@@` header to
+		// reflect the line counts we actually emit (otherwise the diff is no
+		// longer valid unified-diff syntax and tools/agents that count lines
+		// inside a hunk get confused).
+		let pendingHunkHeaderIndex = -1;
+		let pendingHunkOldStart = 0;
+		let pendingHunkNewStart = 0;
+		let pendingOldLines = 0;
+		let pendingNewLines = 0;
+
+		const HUNK_RE = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/;
+
+		const flushHunk = () => {
+			if (pendingHunkHeaderIndex < 0) {
+				return;
+			}
+			out[pendingHunkHeaderIndex] = `@@ -${pendingHunkOldStart},${pendingOldLines} +${pendingHunkNewStart},${pendingNewLines} @@`;
+			pendingHunkHeaderIndex = -1;
+		};
+
+		const flushContextRun = () => {
+			const omitted = contextRun - KEEP_CONTEXT;
+			if (omitted > 0) {
+				// Note: this marker is intentionally not valid unified-diff syntax,
+				// but the surrounding hunk header counts are kept consistent with
+				// the prefixed (' ', '+', '-') lines we actually emit, so a parser
+				// that ignores unknown lines still reads correct counts.
+				out.push(`... ${omitted} unchanged context line${omitted === 1 ? '' : 's'} omitted ...`);
+			}
+			contextRun = 0;
+		};
+
+		for (const line of lines) {
+			if (line.startsWith('diff --git')) {
+				flushContextRun();
+				flushHunk();
+				inBinaryOrLock = /package-lock\.json|yarn\.lock|pnpm-lock\.yaml|\.lockb?$|\.snap$/.test(line);
+				if (inBinaryOrLock) {
+					out.push(line);
+					out.push('... lockfile/snapshot diff omitted ...');
+					continue;
+				}
+				out.push(line);
+				continue;
+			}
+			if (inBinaryOrLock) {
+				continue;
+			}
+			// Drop noisy headers we don't need.
+			if (line.startsWith('index ') || line.startsWith('similarity index ') ||
+				line.startsWith('dissimilarity index ') || line.startsWith('rename from ') ||
+				line.startsWith('rename to ')) {
+				continue;
+			}
+			// Hunk header: start buffering a new hunk so we can rewrite counts on flush.
+			const hunkMatch = HUNK_RE.exec(line);
+			if (hunkMatch) {
+				flushContextRun();
+				flushHunk();
+				pendingHunkOldStart = parseInt(hunkMatch[1], 10);
+				pendingHunkNewStart = parseInt(hunkMatch[3], 10);
+				pendingOldLines = 0;
+				pendingNewLines = 0;
+				pendingHunkHeaderIndex = out.length;
+				out.push(line); // placeholder — overwritten by flushHunk()
+				continue;
+			}
+			// File-mode markers and binary notices pass through.
+			if (line.startsWith('+++ ') || line.startsWith('--- ') || line.startsWith('Binary files ')) {
+				flushContextRun();
+				flushHunk();
+				out.push(line);
+				continue;
+			}
+			// +/- lines: emit verbatim and account for them in the pending hunk.
+			if (line.startsWith('+')) {
+				flushContextRun();
+				out.push(line);
+				pendingNewLines++;
+				continue;
+			}
+			if (line.startsWith('-')) {
+				flushContextRun();
+				out.push(line);
+				pendingOldLines++;
+				continue;
+			}
+			// Unchanged context line: keep the first KEEP_CONTEXT lines of each run,
+			// then count the rest so the next non-context line can flush a single
+			// summary marker. Only the lines we actually emit count toward the hunk.
+			contextRun++;
+			if (contextRun <= KEEP_CONTEXT) {
+				out.push(line);
+				pendingOldLines++;
+				pendingNewLines++;
+			}
+		}
+		flushContextRun();
+		flushHunk();
+
+		const result = out.join('\n');
+		return {
+			text: result,
+			compressed: result.length < text.length,
+		};
+	},
+};
+
+/**
+ * Compresses `ls -l` / `ls -la` output by dropping permission/owner/size
+ * columns and keeping only the entry name. Plain `ls` is already terse and
+ * passes through.
+ */
+export const lsFilter: IToolResultFilter = {
+	id: 'terminal.ls',
+	toolIds: [TerminalToolId.RunInTerminal],
+	matches(_toolId, input) {
+		if (!isTerminalInput(input)) {
+			return false;
+		}
+		const parsed = parseCommandHead(input.command);
+		if (parsed?.head !== 'ls') {
+			return false;
+		}
+		// Only worth running on long-form listings.
+		return /\s-\w*l/.test(input.command ?? '');
+	},
+	apply(text): IToolResultFilterOutput {
+		const lines = text.split('\n');
+		const out: string[] = [];
+		// `ls -l` line: perms links owner group size date1 date2 date3 name
+		const longRe = /^[-dlcbpsDLCBPS][rwx\-tTsS@+.]{9,}\s+\d+\s+\S+\s+\S+\s+\d+\s+\S+\s+\S+\s+\S+\s+(.+)$/;
+		for (const line of lines) {
+			if (!line.trim()) {
+				continue;
+			}
+			if (line.startsWith('total ')) {
+				continue;
+			}
+			const m = longRe.exec(line);
+			if (m) {
+				const isDir = line.startsWith('d');
+				out.push(isDir ? m[1] + '/' : m[1]);
+			} else {
+				out.push(line);
+			}
+		}
+		const result = out.join('\n');
+		return {
+			text: result,
+			compressed: result.length < text.length,
+		};
+	},
+};
+
+/**
+ * Compresses `npm install` / `yarn` / `pnpm install` output by stripping
+ * progress lines and audit summary noise, keeping the package summary plus
+ * any error/warning lines.
+ */
+export const npmInstallFilter: IToolResultFilter = {
+	id: 'terminal.npm-install',
+	toolIds: [TerminalToolId.RunInTerminal],
+	matches(_toolId, input) {
+		if (!isTerminalInput(input)) {
+			return false;
+		}
+		const parsed = parseCommandHead(input.command);
+		if (!parsed) {
+			return false;
+		}
+		if (parsed.head === 'npm' && (parsed.sub === 'install' || parsed.sub === 'i' || parsed.sub === 'ci')) {
+			return true;
+		}
+		if ((parsed.head === 'yarn' || parsed.head === 'pnpm') && parsed.sub !== 'test') {
+			return /\binstall\b|\badd\b/.test(input.command ?? '') || parsed.sub === undefined;
+		}
+		return false;
+	},
+	apply(text): IToolResultFilterOutput {
+		const lines = text.split('\n');
+		const dropPatterns: RegExp[] = [
+			/^npm warn deprecated /i,
+			/^\s*\[#+>?\s*\] /, // progress bars
+			/^npm http /i,
+			/^npm timing /i,
+			/^npm sill /i,
+			/^npm verb /i,
+			/^\s*\d+ packages? are looking for funding/i,
+			/run `npm fund`/i,
+			/^Run `npm audit/i,
+		];
+		const out: string[] = [];
+		for (const line of lines) {
+			if (dropPatterns.some(re => re.test(line))) {
+				continue;
+			}
+			out.push(line);
+		}
+		const result = out.join('\n');
+		return {
+			text: result,
+			compressed: result.length < text.length,
+		};
+	},
+};
+
+export function registerTerminalCompressors(compressor: IToolResultCompressor): void {
+	compressor.registerFilter(gitDiffFilter);
+	compressor.registerFilter(lsFilter);
+	compressor.registerFilter(npmInstallFilter);
+}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalOutputCompressor.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalOutputCompressor.test.ts
@@ -111,6 +111,36 @@ suite('gitDiffFilter', () => {
 		strictEqual(out.compressed, true);
 	});
 
+	test('does not omit arbitrary .lock file diffs', () => {
+		const text = [
+			'diff --git a/custom.lock b/custom.lock',
+			'--- a/custom.lock',
+			'+++ b/custom.lock',
+			'@@ -1,2 +1,2 @@',
+			' unchanged',
+			'-old',
+			'+new',
+		].join('\n');
+		const out = gitDiffFilter.apply(text, input);
+		ok(!out.text.includes('lockfile/snapshot diff omitted'));
+		ok(out.text.includes('-old'));
+		ok(out.text.includes('+new'));
+	});
+
+	test('preserves non-context metadata lines', () => {
+		const text = [
+			'diff --git a/foo.ts b/foo.ts',
+			'new file mode 100644',
+			'--- /dev/null',
+			'+++ b/foo.ts',
+			'@@ -0,0 +2,2 @@',
+			'+line 1',
+			'+line 2',
+		].join('\n');
+		const out = gitDiffFilter.apply(text, input);
+		ok(out.text.includes('new file mode 100644'));
+	});
+
 	test('rewrites hunk header counts to match emitted body', () => {
 		const ctxLines = Array.from({ length: 20 }, (_, i) => ` ctx line ${i}`);
 		const text = [
@@ -159,6 +189,11 @@ suite('npmInstallFilter', () => {
 		ok(npmInstallFilter.matches('run_in_terminal', { command: 'npm install' }));
 		ok(npmInstallFilter.matches('run_in_terminal', { command: 'npm ci' }));
 		ok(!npmInstallFilter.matches('run_in_terminal', { command: 'npm test' }));
+	});
+
+	test('does not match flag-only yarn commands', () => {
+		ok(!npmInstallFilter.matches('run_in_terminal', { command: 'yarn --version' }));
+		ok(!npmInstallFilter.matches('run_in_terminal', { command: 'FOO=1 yarn --help' }));
 	});
 
 	test('drops audit and funding noise', () => {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalOutputCompressor.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalOutputCompressor.test.ts
@@ -1,0 +1,181 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { deepStrictEqual, ok, strictEqual } from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { gitDiffFilter, lsFilter, npmInstallFilter, parseCommandHead } from '../../browser/tools/terminalOutputCompressor.js';
+
+suite('parseCommandHead', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('returns undefined for empty input', () => {
+		strictEqual(parseCommandHead(undefined), undefined);
+		strictEqual(parseCommandHead(''), undefined);
+		strictEqual(parseCommandHead('   '), undefined);
+	});
+
+	test('parses simple commands', () => {
+		deepStrictEqual(parseCommandHead('git diff HEAD~5'), { head: 'git', sub: 'diff' });
+		deepStrictEqual(parseCommandHead('ls -la'), { head: 'ls', sub: '-la' });
+	});
+
+	test('skips env-var prefixes', () => {
+		deepStrictEqual(parseCommandHead('CI=1 NODE_ENV=test npm install'), { head: 'npm', sub: 'install' });
+	});
+
+	test('uses only first pipeline segment', () => {
+		deepStrictEqual(parseCommandHead('git diff | cat'), { head: 'git', sub: 'diff' });
+	});
+
+	test('skips leading long flags before the subcommand', () => {
+		deepStrictEqual(parseCommandHead('git --no-pager diff src/foo.ts'), { head: 'git', sub: 'diff' });
+	});
+
+	test('does not skip short-flag values before the subcommand', () => {
+		deepStrictEqual(parseCommandHead('git -C /tmp/repo diff'), { head: 'git', sub: '-C' });
+	});
+});
+
+suite('gitDiffFilter', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const input = { command: 'git diff HEAD~1' };
+
+	test('matches git diff', () => {
+		ok(gitDiffFilter.matches('run_in_terminal', input));
+	});
+
+	test('matches git --no-pager diff', () => {
+		ok(gitDiffFilter.matches('run_in_terminal', { command: 'git --no-pager diff src/foo.ts' }));
+	});
+
+	test('does not match git status', () => {
+		ok(!gitDiffFilter.matches('run_in_terminal', { command: 'git status' }));
+	});
+
+	test('preserves +/- and hunk headers verbatim', () => {
+		const text = [
+			'diff --git a/foo.ts b/foo.ts',
+			'index abc..def 100644',
+			'--- a/foo.ts',
+			'+++ b/foo.ts',
+			'@@ -1,3 +1,3 @@',
+			' unchanged',
+			'-old',
+			'+new',
+			' unchanged',
+		].join('\n');
+		const out = gitDiffFilter.apply(text, input);
+		ok(out.text.includes('-old'));
+		ok(out.text.includes('+new'));
+		ok(out.text.includes('@@ -1,3 +1,3 @@'));
+		ok(!out.text.includes('index abc..def'));
+	});
+
+	test('collapses long unchanged-context runs into a single marker', () => {
+		const ctxLines = Array.from({ length: 20 }, (_, i) => ` this is context line number ${i}`);
+		const text = [
+			'diff --git a/foo.ts b/foo.ts',
+			'--- a/foo.ts',
+			'+++ b/foo.ts',
+			'@@ -1,22 +1,22 @@',
+			...ctxLines,
+			'-old',
+			'+new',
+		].join('\n');
+		const out = gitDiffFilter.apply(text, input);
+		ok(out.text.includes(' this is context line number 0'));
+		ok(!out.text.includes(' this is context line number 5'));
+		ok(!out.text.includes(' this is context line number 19'));
+		ok(out.text.includes('19 unchanged context lines omitted'));
+		ok(out.text.includes('-old'));
+		ok(out.text.includes('+new'));
+		strictEqual(out.compressed, true);
+	});
+
+	test('omits lockfile diffs', () => {
+		const text = [
+			'diff --git a/package-lock.json b/package-lock.json',
+			'index 1..2 100644',
+			'--- a/package-lock.json',
+			'+++ b/package-lock.json',
+			'@@ -1,3 +1,3 @@',
+			'-old',
+			'+new',
+		].join('\n');
+		const out = gitDiffFilter.apply(text, input);
+		ok(out.text.includes('lockfile/snapshot diff omitted'));
+		ok(!out.text.includes('-old'));
+		strictEqual(out.compressed, true);
+	});
+
+	test('rewrites hunk header counts to match emitted body', () => {
+		const ctxLines = Array.from({ length: 20 }, (_, i) => ` ctx line ${i}`);
+		const text = [
+			'diff --git a/foo.ts b/foo.ts',
+			'--- a/foo.ts',
+			'+++ b/foo.ts',
+			'@@ -10,22 +10,22 @@',
+			...ctxLines,
+			'-old',
+			'+new',
+		].join('\n');
+		const out = gitDiffFilter.apply(text, input);
+		ok(out.text.includes('@@ -10,2 +10,2 @@'));
+		ok(!out.text.includes('@@ -10,22 +10,22 @@'));
+	});
+});
+
+suite('lsFilter', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('matches only when -l flag present', () => {
+		ok(!lsFilter.matches('run_in_terminal', { command: 'ls' }));
+		ok(lsFilter.matches('run_in_terminal', { command: 'ls -la' }));
+		ok(lsFilter.matches('run_in_terminal', { command: 'ls -al src/' }));
+	});
+
+	test('strips long-form columns and keeps file names', () => {
+		const text = [
+			'total 24',
+			'-rw-r--r--   1 user  staff   123 Jan 01 12:34 README.md',
+			'drwxr-xr-x   5 user  staff   160 Jan 01 12:34 src',
+		].join('\n');
+		const out = lsFilter.apply(text, { command: 'ls -la' });
+		ok(out.text.includes('README.md'));
+		ok(out.text.includes('src/'));
+		ok(!out.text.includes('user  staff'));
+		ok(!out.text.includes('total 24'));
+		strictEqual(out.compressed, true);
+	});
+});
+
+suite('npmInstallFilter', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('matches npm install', () => {
+		ok(npmInstallFilter.matches('run_in_terminal', { command: 'npm install' }));
+		ok(npmInstallFilter.matches('run_in_terminal', { command: 'npm ci' }));
+		ok(!npmInstallFilter.matches('run_in_terminal', { command: 'npm test' }));
+	});
+
+	test('drops audit and funding noise', () => {
+		const text = [
+			'added 250 packages in 12s',
+			'npm warn deprecated foo@1.0.0: please update',
+			'42 packages are looking for funding',
+			'  run `npm fund` for details',
+			'',
+			'3 vulnerabilities (1 low, 2 moderate)',
+			'Run `npm audit` for details.',
+		].join('\n');
+		const out = npmInstallFilter.apply(text, { command: 'npm install' });
+		ok(out.text.includes('added 250 packages'));
+		ok(!out.text.includes('deprecated foo'));
+		ok(!out.text.includes('looking for funding'));
+		ok(!out.text.includes('npm audit'));
+		strictEqual(out.compressed, true);
+	});
+});

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -42,6 +42,7 @@ import { LocalChatSessionUri } from '../../../../chat/common/model/chatUri.js';
 import { ChatRequestTextPart } from '../../../../chat/common/requestParser/chatParserTypes.js';
 import { ITerminalSandboxService, TerminalSandboxPrerequisiteCheck, type ITerminalSandboxPrerequisiteCheckResult } from '../../common/terminalSandboxService.js';
 import { ILanguageModelToolsService, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocationPreparationContext, ToolDataSource, ToolSet, type ToolConfirmationAction } from '../../../../chat/common/tools/languageModelToolsService.js';
+import { IToolResultCompressor } from '../../../../chat/common/tools/toolResultCompressor.js';
 import { ITerminalChatService, ITerminalService, type ITerminalInstance } from '../../../../terminal/browser/terminal.js';
 import { ITerminalProfileResolverService } from '../../../../terminal/common/terminal.js';
 import type { ICommandLinePresenter } from '../../browser/tools/commandLinePresenter/commandLinePresenter.js';
@@ -2520,6 +2521,12 @@ suite('ChatAgentToolsContribution - tool registration refresh', () => {
 			readToolSet: new ToolSet('read', 'read', Codicon.book, ToolDataSource.Internal, undefined, undefined, contextKeyService),
 		};
 		instantiationService.stub(ILanguageModelToolsService, mockToolsService as ILanguageModelToolsService);
+
+		instantiationService.stub(IToolResultCompressor, {
+			_serviceBrand: undefined,
+			registerFilter: () => { },
+			maybeCompress: () => undefined,
+		});
 	});
 
 	async function flushAsync(): Promise<void> {


### PR DESCRIPTION
Ports https://github.com/microsoft/vscode-copilot-chat/pull/5106 into vscode core, since the chat extension code now lives here.

Adds a post-processing compression layer for tool results, inspired by [ztk](https://github.com/codejunkie99/ztk). When the model invokes a tool, we now have a chance to filter the result text before it reaches the model — same information, fewer tokens.

## What

- New `IToolResultCompressor` service in `src/vs/workbench/contrib/chat/common/tools/toolResultCompressor.ts` with a per-tool filter registry. Filters are pure functions over text parts. The service skips outputs under 80 bytes and drops any filter that throws (ztk's "never make it worse" rule).
- Three initial filters for `run_in_terminal` in `src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/terminalOutputCompressor.ts`:
  - **`git diff` / `git show`** — collapses unchanged context, drops `index`/`similarity index` headers, omits lockfile and snapshot diff bodies, preserves `+`/`-`/`@@` lines verbatim.
  - **`ls -l` / `ls -la`** — keeps just file names (with `/` for dirs), drops perm/owner/size columns and `total N`.
  - **`npm install` / `yarn` / `pnpm install`** — drops progress bars, `npm warn deprecated`, funding/audit nag lines.
- Wired into `LanguageModelToolsService.invokeTool` as a single post-process step right after `tool.impl.invoke` resolves.
- New setting `chat.tools.compressOutput.enabled`, **off by default**, with `experiment: { mode: 'auto' }`.
- New telemetry event `toolResultCompressed` reporting `{ toolName, filters, beforeBytes, afterBytes }` so we can quantify savings.

## Why

The terminal tool routinely dumps tens of thousands of raw tokens (a single `git diff HEAD~5` can be 90KB+). Most of that is metadata, unchanged context, lockfile churn, or progress noise. Compressing this client-side before it hits the model is a cheap, predictable token win that doesn't change tool semantics.

## Tests

Unit tests cover the service (filter registration, throwing filter handling, audience preservation, min-length skip) and each terminal filter's parse/match/apply logic.

## Scope notes

- Default off; opt-in via setting (experiment-driven).
- Easy to extend: add a new `IToolResultFilter` and register it.

<img width="1512" height="1590" alt="image" src="https://github.com/user-attachments/assets/9c806835-99fb-411f-8cba-4935ece27eff" />
<img width="1488" height="1428" alt="image" src="https://github.com/user-attachments/assets/03fe4c61-6431-42ca-83f7-8bd613006b7d" />

