### PR TITLE
Register IAgentHostPermissionService in workbench.common.main

### DIFF
--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -138,6 +138,7 @@ import './services/editor/common/customEditorLabelService.js';
 import './services/dataChannel/browser/dataChannelService.js';
 import './services/inlineCompletions/common/inlineCompletionsUnification.js';
 import './services/chat/common/chatEntitlementService.js';
+import './services/agentHost/common/agentHostPermissionService.js';
 import './services/log/common/defaultLogLevels.js';
 
 import { InstantiationType, registerSingleton } from '../platform/instantiation/common/extensions.js';


### PR DESCRIPTION
Register `IAgentHostPermissionService` in the regular workbench so it is available outside the Agents window.

## Problem

`AgentHostPermissionUiContribution` is registered as a regular workbench contribution in `src/vs/workbench/contrib/chat/browser/agentSessions/agentSessions.contribution.ts`, but its dependency `IAgentHostPermissionService` was only registered through `src/vs/sessions/sessions.common.main.ts` — the Agents Window layer. Any non-sessions workbench (regular VS Code, the evaluation harness, headless Insiders builds) failed to construct the contribution:

```
ERR Unable to create workbench contribution 'workbench.contrib.agentHostPermissionUi'.
    Error: [createInstance] Xq depends on UNKNOWN service agentHostPermissionService.
```

This was discovered while running an MSBench eval (`runtest local --benchmark vscbench.say_hello --config doc/examples/configs/agent-host.vscode.agent.yaml`) against `vscodeVersion: insiders-unreleased` with `sessionTarget: agent-host-copilot`. The Insiders build downloaded into the eval container hit the missing-service error at workbench startup, and `_invokeAgent` for `agent-host-copilotcli:/...` then hung indefinitely (related: `this.octoKitService.getCurrentAuthedUser is not a function` warning, which is downstream of this).

## Fix

Add the service registration to `src/vs/workbench/workbench.common.main.ts` next to `chatEntitlementService`. The existing sessions import is left in place (idempotent) to preserve any sessions-window load-order assumptions.


