### PR TITLE
Fix Customizations view a11y: Home button focus + tile aria labels

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -689,9 +689,11 @@ export class AICustomizationListWidget extends Disposable {
 						if (entry.type === 'group-header') {
 							return localize('groupAriaLabel', "{0}, {1} items, {2}", entry.label, entry.count, entry.collapsed ? localize('collapsed', "collapsed") : localize('expanded', "expanded"));
 						}
-						const nameAndDesc = entry.item.description
-							? localize('itemAriaLabel', "{0}. {1}", entry.item.name, entry.item.description)
-							: entry.item.name;
+						const displayName = entry.item.displayName ?? formatDisplayName(entry.item.name);
+						const secondaryText = getCustomizationSecondaryText(entry.item);
+						const nameAndDesc = secondaryText
+							? localize('itemAriaLabel', "{0}. {1}", displayName, secondaryText)
+							: displayName;
 						return entry.item.disabled
 							? localize('itemAriaLabelDisabled', "{0}, disabled", nameAndDesc)
 							: nameAndDesc;

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -690,7 +690,7 @@ export class AICustomizationListWidget extends Disposable {
 							return localize('groupAriaLabel', "{0}, {1} items, {2}", entry.label, entry.count, entry.collapsed ? localize('collapsed', "collapsed") : localize('expanded', "expanded"));
 						}
 						const displayName = entry.item.displayName ?? formatDisplayName(entry.item.name);
-						const secondaryText = getCustomizationSecondaryText(entry.item);
+						const secondaryText = getCustomizationSecondaryText(entry.item.description, entry.item.filename, entry.item.promptType);
 						const nameAndDesc = secondaryText
 							? localize('itemAriaLabel', "{0}. {1}", displayName, secondaryText)
 							: displayName;

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -690,7 +690,7 @@ export class AICustomizationListWidget extends Disposable {
 							return localize('groupAriaLabel', "{0}, {1} items, {2}", entry.label, entry.count, entry.collapsed ? localize('collapsed', "collapsed") : localize('expanded', "expanded"));
 						}
 						const nameAndDesc = entry.item.description
-							? localize('itemAriaLabel', "{0}, {1}", entry.item.name, entry.item.description)
+							? localize('itemAriaLabel', "{0}. {1}", entry.item.name, entry.item.description)
 							: entry.item.name;
 						return entry.item.disabled
 							? localize('itemAriaLabelDisabled', "{0}, disabled", nameAndDesc)

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -1022,6 +1022,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 		this.welcomePage?.reset();
 		this.updateContentVisibility();
 		this.ensureSectionsListReflectsActiveSection(undefined);
+		this.welcomePage?.focus();
 	}
 
 	private selectSection(section: AICustomizationManagementSection, options?: { showMarketplace?: boolean }): void {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
@@ -531,7 +531,7 @@ export class McpListWidget extends Disposable {
 						const label = element.type === 'builtin-item' ? element.label : element.server.label;
 						return derived(reader => {
 							const isBridged = this.harnessService.activeHarness.read(reader) !== SessionType.Local;
-							return isBridged ? localize('mcpServerBridgedAriaLabel', "{0}, {1}", label, localize('bridged', "Bridged")) : label;
+							return isBridged ? localize('mcpServerBridgedAriaLabel', "{0}. {1}", label, localize('bridged', "Bridged")) : label;
 						});
 					},
 					getWidgetAriaLabel() {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget.ts
@@ -602,7 +602,7 @@ export class PluginListWidget extends Disposable {
 							return localize('pluginGroupAriaLabel', "{0}, {1} items, {2}", element.label, element.count, element.collapsed ? localize('collapsed', "collapsed") : localize('expanded', "expanded"));
 						}
 						const name = formatDisplayName(element.item.name);
-						const description = truncateToFirstLine(element.item.description);
+						const description = element.item.description ? truncateToFirstLine(element.item.description) : undefined;
 						return description
 							? localize('pluginItemAriaLabel', "{0}. {1}", name, description)
 							: name;

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget.ts
@@ -601,10 +601,11 @@ export class PluginListWidget extends Disposable {
 						if (element.type === 'group-header') {
 							return localize('pluginGroupAriaLabel', "{0}, {1} items, {2}", element.label, element.count, element.collapsed ? localize('collapsed', "collapsed") : localize('expanded', "expanded"));
 						}
-						const description = element.item.description;
+						const name = formatDisplayName(element.item.name);
+						const description = truncateToFirstLine(element.item.description);
 						return description
-							? localize('pluginItemAriaLabel', "{0}. {1}", element.item.name, description)
-							: element.item.name;
+							? localize('pluginItemAriaLabel', "{0}. {1}", name, description)
+							: name;
 					},
 					getWidgetAriaLabel() {
 						return localize('pluginsListAriaLabel', "Plugins");

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget.ts
@@ -601,13 +601,10 @@ export class PluginListWidget extends Disposable {
 						if (element.type === 'group-header') {
 							return localize('pluginGroupAriaLabel', "{0}, {1} items, {2}", element.label, element.count, element.collapsed ? localize('collapsed', "collapsed") : localize('expanded', "expanded"));
 						}
-						if (element.type === 'marketplace-item') {
-							return element.item.name;
-						}
-						if (element.type === 'remote-item') {
-							return element.item.name;
-						}
-						return element.item.name;
+						const description = element.item.description;
+						return description
+							? localize('pluginItemAriaLabel', "{0}. {1}", element.item.name, description)
+							: element.item.name;
 					},
 					getWidgetAriaLabel() {
 						return localize('pluginsListAriaLabel', "Plugins");


### PR DESCRIPTION
Fixes #314173 and #314089.

## #314173 — Home button doesn't focus content
`showWelcomePage()` now calls `welcomePage.focus()` after navigating, so activating the 🏠 Home button moves focus into the welcome page (the prompt input) instead of leaving focus on the button.

## #314089 — Screen reader: title vs. description unclear
For list tiles in the agents/skills/instructions, MCP, and plugins lists, the aria label joined name and description with a comma — screen readers (e.g. Narrator) read "Ask answers questions without making changes" with no clear pause between title and description.

- Replaced the `,` separator with `.` in the aria labels to produce a longer screen-reader pause.
- Added the description to plugin list tile aria labels (previously only the name was announced).