### PR TITLE
Add Cmd+Shift+A keybinding to switch between VS Code and Agents window

### DIFF
--- a/src/vs/sessions/electron-browser/actions/vscodeActions.ts
+++ b/src/vs/sessions/electron-browser/actions/vscodeActions.ts
@@ -4,6 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Codicon } from '../../../base/common/codicons.js';
+import { getWindowId } from '../../../base/browser/dom.js';
+import { mainWindow } from '../../../base/browser/window.js';
 import { Schemas } from '../../../base/common/network.js';
 import { URI } from '../../../base/common/uri.js';
 import { ServicesAccessor } from '../../../editor/browser/editorExtensions.js';
@@ -11,7 +13,9 @@ import { localize2 } from '../../../nls.js';
 import { Action2 } from '../../../platform/actions/common/actions.js';
 import { AGENT_HOST_SCHEME, fromAgentHostUri } from '../../../platform/agentHost/common/agentHostUri.js';
 import { IRemoteAgentHostService } from '../../../platform/agentHost/common/remoteAgentHostService.js';
+import { KeyCode, KeyMod } from '../../../base/common/keyCodes.js';
 import { ContextKeyExpr } from '../../../platform/contextkey/common/contextkey.js';
+import { KeybindingWeight } from '../../../platform/keybinding/common/keybindingsRegistry.js';
 import { ITelemetryService } from '../../../platform/telemetry/common/telemetry.js';
 import { IsAuxiliaryWindowContext } from '../../../workbench/common/contextkeys.js';
 import { IsPhoneLayoutContext, SessionsWelcomeVisibleContext } from '../../common/contextkeys.js';
@@ -27,12 +31,12 @@ import { Disposable } from '../../../base/common/lifecycle.js';
 import { resolveRemoteAuthority } from '../../browser/openInVSCodeUtils.js';
 import { INativeHostService } from '../../../platform/native/common/native.js';
 
-export class OpenInVSCodeAction extends Action2 {
-	static readonly ID = 'agents.openInVSCode';
+export class OpenSessionInVSCodeAction extends Action2 {
+	static readonly ID = 'agents.openSessionInVSCode';
 
 	constructor() {
 		super({
-			id: OpenInVSCodeAction.ID,
+			id: OpenSessionInVSCodeAction.ID,
 			title: localize2('openInVSCode', 'Open in VS Code'),
 			icon: Codicon.vscodeInsiders,
 			precondition: ContextKeyExpr.and(IsAuxiliaryWindowContext.toNegated(), SessionsWelcomeVisibleContext.toNegated()),
@@ -88,6 +92,36 @@ export class OpenInVSCodeAction extends Action2 {
 	}
 }
 
+export class OpenVSCodeWindowAction extends Action2 {
+	static readonly ID = 'agents.openVSCodeWindow';
+
+	constructor() {
+		super({
+			id: OpenVSCodeWindowAction.ID,
+			title: localize2('openVSCodeWindow', 'Open VS Code Window'),
+			f1: true,
+			keybinding: {
+				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyA,
+				weight: KeybindingWeight.WorkbenchContrib,
+			},
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		const nativeHostService = accessor.get(INativeHostService);
+
+		const windows = await nativeHostService.getWindows({ includeAuxiliaryWindows: false });
+		const currentWindowId = getWindowId(mainWindow);
+		const vscodeWindow = windows.find(w => w.id !== currentWindowId);
+
+		if (vscodeWindow) {
+			await nativeHostService.focusWindow({ targetWindowId: vscodeWindow.id });
+		} else {
+			await nativeHostService.openWindow();
+		}
+	}
+}
+
 export class OpenInVSCodeWidgetContribution extends Disposable implements IWorkbenchContribution {
 
 	static readonly ID = 'workbench.contrib.openInVSCode.widget';
@@ -97,7 +131,7 @@ export class OpenInVSCodeWidgetContribution extends Disposable implements IWorkb
 		@IInstantiationService instantiationService: IInstantiationService,
 	) {
 		super();
-		this._register(actionViewItemService.register(Menus.TitleBarSessionMenu, OpenInVSCodeAction.ID, (action, options) => {
+		this._register(actionViewItemService.register(Menus.TitleBarSessionMenu, OpenSessionInVSCodeAction.ID, (action, options) => {
 			return instantiationService.createInstance(OpenInVSCodeTitleBarWidget, action, options);
 		}, undefined));
 	}

--- a/src/vs/sessions/electron-browser/sessions.desktop.contribution.ts
+++ b/src/vs/sessions/electron-browser/sessions.desktop.contribution.ts
@@ -5,11 +5,12 @@
 
 import { registerAction2 } from '../../platform/actions/common/actions.js';
 import { registerWorkbenchContribution2, WorkbenchPhase } from '../../workbench/common/contributions.js';
-import { OpenInVSCodeAction, OpenInVSCodeWidgetContribution } from './actions/vscodeActions.js';
+import { OpenSessionInVSCodeAction, OpenInVSCodeWidgetContribution, OpenVSCodeWindowAction } from './actions/vscodeActions.js';
 
 // Actions
 (function registerActions(): void {
-	registerAction2(OpenInVSCodeAction);
+	registerAction2(OpenSessionInVSCodeAction);
+	registerAction2(OpenVSCodeWindowAction);
 })();
 
 (function registerWorkbenchContributions(): void {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsBanner.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsBanner.ts
@@ -11,7 +11,7 @@ import { IProductService } from '../../../../../platform/product/common/productS
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { IChatEntitlementService } from '../../../../services/chat/common/chatEntitlementService.js';
 
-import { OPEN_AGENTS_WINDOW_COMMAND_ID } from '../../common/constants.js';
+import { OPEN_WORKSPACE_IN_AGENTS_WINDOW_COMMAND_ID } from '../../common/constants.js';
 
 
 type AgentsBannerClickedEvent = {
@@ -33,7 +33,7 @@ export interface IAgentsBannerResult {
 
 /**
  * Returns whether the agents banner can be shown.
- * The banner requires the `workbench.action.openAgentsWindow` command
+ * The banner requires the open agents window command
  * to be registered (desktop builds only) and is limited to Insiders quality.
  * It is also hidden when AI features are disabled.
  */
@@ -43,7 +43,7 @@ export function canShowAgentsBanner(productService: IProductService, chatEntitle
 		return false;
 	}
 	return productService.quality !== 'stable'
-		&& !!CommandsRegistry.getCommand(OPEN_AGENTS_WINDOW_COMMAND_ID);
+		&& !!CommandsRegistry.getCommand(OPEN_WORKSPACE_IN_AGENTS_WINDOW_COMMAND_ID);
 }
 
 export interface IAgentsBannerOptions {
@@ -78,7 +78,7 @@ export function createAgentsBanner(
 	disposables.add(addDisposableListener(button, 'click', () => {
 		options.onButtonClick?.();
 		telemetryService.publicLog2<AgentsBannerClickedEvent, AgentsBannerClickedClassification>('agentsBanner.clicked', { source: options.source, action: 'openAgentsWindow' });
-		commandService.executeCommand(OPEN_AGENTS_WINDOW_COMMAND_ID, { forceNewWindow: true });
+		commandService.executeCommand(OPEN_WORKSPACE_IN_AGENTS_WINDOW_COMMAND_ID, { forceNewWindow: true });
 	}));
 
 	const element = $(`.${options.cssClass}`, {}, button);

--- a/src/vs/workbench/contrib/chat/browser/chatTipCatalog.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatTipCatalog.ts
@@ -8,7 +8,7 @@ import { localize } from '../../../../nls.js';
 import { ContextKeyExpr, ContextKeyExpression } from '../../../../platform/contextkey/common/contextkey.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
 import { MenuRegistry } from '../../../../platform/actions/common/actions.js';
-import { OPEN_AGENTS_WINDOW_COMMAND_ID, OPEN_AGENTS_WINDOW_PRECONDITION, ChatConfiguration, ChatModeKind } from '../common/constants.js';
+import { OPEN_WORKSPACE_IN_AGENTS_WINDOW_COMMAND_ID, OPEN_AGENTS_WINDOW_PRECONDITION, ChatConfiguration, ChatModeKind } from '../common/constants.js';
 import { ChatContextKeys } from '../common/actions/chatContextKeys.js';
 import { IsSessionsWindowContext } from '../../../common/contextkeys.js';
 import { localChatSessionType } from '../common/chatSessionsService.js';
@@ -419,7 +419,7 @@ export const TIP_CATALOG: readonly ITipDefinition[] = [
 				localize(
 					'tip.openAgentsWindow',
 					"Try the [Agents Application](command:{0} \"Open Agents Window\") to run multiple agents simultaneously and manage your coding sessions.",
-					OPEN_AGENTS_WINDOW_COMMAND_ID
+					OPEN_WORKSPACE_IN_AGENTS_WINDOW_COMMAND_ID
 				)
 			);
 		},
@@ -427,8 +427,8 @@ export const TIP_CATALOG: readonly ITipDefinition[] = [
 			OPEN_AGENTS_WINDOW_PRECONDITION,
 			ChatContextKeys.chatModeKind.isEqualTo(ChatModeKind.Agent),
 		),
-		excludeWhenCommandsExecuted: [OPEN_AGENTS_WINDOW_COMMAND_ID],
-		dismissWhenCommandsClicked: [OPEN_AGENTS_WINDOW_COMMAND_ID],
+		excludeWhenCommandsExecuted: [OPEN_WORKSPACE_IN_AGENTS_WINDOW_COMMAND_ID],
+		dismissWhenCommandsClicked: [OPEN_WORKSPACE_IN_AGENTS_WINDOW_COMMAND_ID],
 	},
 	{
 		id: 'tip.copilotCli',

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -213,6 +213,7 @@ export function isSupportedChatFileScheme(accessor: ServicesAccessor, scheme: st
 
 export const MANAGE_CHAT_COMMAND_ID = 'workbench.action.chat.manage';
 
+export const OPEN_WORKSPACE_IN_AGENTS_WINDOW_COMMAND_ID = 'workbench.action.openWorkspaceInAgentsWindow';
 export const OPEN_AGENTS_WINDOW_COMMAND_ID = 'workbench.action.openAgentsWindow';
 export const OPEN_AGENTS_WINDOW_PRECONDITION = ContextKeyExpr.and(
 	ProductQualityContext.notEqualsTo('stable'),

--- a/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts
@@ -15,18 +15,21 @@ import { Action2, MenuId } from '../../../../../platform/actions/common/actions.
 import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { KeyCode, KeyMod } from '../../../../../base/common/keyCodes.js';
+import { KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { INativeHostService } from '../../../../../platform/native/common/native.js';
 import { IProductService } from '../../../../../platform/product/common/productService.js';
+import { IsSessionsWindowContext } from '../../../../common/contextkeys.js';
 import { TitleBarLeadingActionsGroup } from '../../../../browser/parts/titlebar/titlebarActions.js';
 import { IWorkbenchContribution } from '../../../../common/contributions.js';
 import { CHAT_CATEGORY } from '../../browser/actions/chatActions.js';
-import { OPEN_AGENTS_WINDOW_COMMAND_ID, OPEN_AGENTS_WINDOW_PRECONDITION } from '../../common/constants.js';
+import { OPEN_WORKSPACE_IN_AGENTS_WINDOW_COMMAND_ID, OPEN_AGENTS_WINDOW_PRECONDITION, OPEN_AGENTS_WINDOW_COMMAND_ID } from '../../common/constants.js';
 
-export class OpenAgentsWindowAction extends Action2 {
+export class OpenWorkspaceInAgentsWindowAction extends Action2 {
 	constructor() {
 		super({
-			id: OPEN_AGENTS_WINDOW_COMMAND_ID,
-			title: localize2('openAgentsWindow', "Open Agents Window"),
+			id: OPEN_WORKSPACE_IN_AGENTS_WINDOW_COMMAND_ID,
+			title: localize2('openWorkspaceInAgentsWindow', "Open in Agents Window"),
 			category: CHAT_CATEGORY,
 			precondition: OPEN_AGENTS_WINDOW_PRECONDITION,
 			f1: true,
@@ -50,11 +53,33 @@ export class OpenAgentsWindowAction extends Action2 {
 	}
 }
 
+export class OpenAgentsWindowAction extends Action2 {
+	constructor() {
+		super({
+			id: OPEN_AGENTS_WINDOW_COMMAND_ID,
+			title: localize2('openAgentsWindow', "Open Agents Window"),
+			category: CHAT_CATEGORY,
+			precondition: OPEN_AGENTS_WINDOW_PRECONDITION,
+			f1: true,
+			keybinding: {
+				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyA,
+				weight: KeybindingWeight.WorkbenchContrib,
+				when: IsSessionsWindowContext.toNegated(),
+			},
+		});
+	}
+
+	async run(accessor: ServicesAccessor) {
+		const nativeHostService = accessor.get(INativeHostService);
+		await nativeHostService.openAgentsWindow();
+	}
+}
+
 /**
  * Renders the "Open in Agents" titlebar entry as an icon-only button that
  * expands to reveal a label on hover / keyboard focus.
  */
-class OpenInAgentsTitleBarWidget extends BaseActionViewItem {
+class OpenWorkspaceInAgentsTitleBarWidget extends BaseActionViewItem {
 
 	constructor(
 		action: IAction,
@@ -82,9 +107,9 @@ class OpenInAgentsTitleBarWidget extends BaseActionViewItem {
 	}
 }
 
-export class OpenInAgentsContribution extends Disposable implements IWorkbenchContribution {
+export class OpenWorkspaceInAgentsContribution extends Disposable implements IWorkbenchContribution {
 
-	static readonly ID = 'workbench.contrib.openInAgents.desktop';
+	static readonly ID = 'workbench.contrib.openWorkspaceInAgents.desktop';
 
 	constructor(
 		@IActionViewItemService actionViewItemService: IActionViewItemService,
@@ -93,8 +118,8 @@ export class OpenInAgentsContribution extends Disposable implements IWorkbenchCo
 		@IProductService productService: IProductService,
 	) {
 		super();
-		this._register(actionViewItemService.register(MenuId.TitleBar, OPEN_AGENTS_WINDOW_COMMAND_ID, (action, options) => {
-			return instantiationService.createInstance(OpenInAgentsTitleBarWidget, action, options);
+		this._register(actionViewItemService.register(MenuId.TitleBar, OPEN_WORKSPACE_IN_AGENTS_WINDOW_COMMAND_ID, (action, options) => {
+			return instantiationService.createInstance(OpenWorkspaceInAgentsTitleBarWidget, action, options);
 		}, undefined));
 	}
 }

--- a/src/vs/workbench/contrib/chat/electron-browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/chat.contribution.ts
@@ -47,7 +47,7 @@ import { IPluginGitService } from '../common/plugins/pluginGitService.js';
 import { registerChatDeveloperActions } from './actions/chatDeveloperActions.js';
 import { registerChatExportZipAction } from './actions/chatExportZip.js';
 import { HoldToVoiceChatInChatViewAction, InlineVoiceChatAction, KeywordActivationContribution, QuickVoiceChatAction, ReadChatResponseAloud, StartVoiceChatAction, StopListeningAction, StopListeningAndSubmitAction, StopReadAloud, StopReadChatItemAloud, VoiceChatInChatViewAction } from './actions/voiceChatActions.js';
-import { OpenAgentsWindowAction, OpenInAgentsContribution } from './agentSessions/agentSessionsActions.js';
+import { OpenWorkspaceInAgentsWindowAction, OpenWorkspaceInAgentsContribution, OpenAgentsWindowAction } from './agentSessions/agentSessionsActions.js';
 import { NativeBuiltinToolsContribution } from './builtInTools/tools.js';
 import { NativePluginGitCommandService } from './pluginGitCommandService.js';
 
@@ -230,6 +230,7 @@ class ChatLifecycleHandler extends Disposable {
 	}
 }
 
+registerAction2(OpenWorkspaceInAgentsWindowAction);
 registerAction2(OpenAgentsWindowAction);
 registerAction2(StartVoiceChatAction);
 
@@ -255,7 +256,7 @@ registerWorkbenchContribution2(ChatSuspendThrottlingHandler.ID, ChatSuspendThrot
 registerWorkbenchContribution2(ChatLifecycleHandler.ID, ChatLifecycleHandler, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(AgentHostContribution.ID, AgentHostContribution, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(AgentHostTerminalContribution.ID, AgentHostTerminalContribution, WorkbenchPhase.AfterRestored);
-registerWorkbenchContribution2(OpenInAgentsContribution.ID, OpenInAgentsContribution, WorkbenchPhase.BlockRestore);
+registerWorkbenchContribution2(OpenWorkspaceInAgentsContribution.ID, OpenWorkspaceInAgentsContribution, WorkbenchPhase.BlockRestore);
 
 // How long to wait for the agent host to surface an AgentInfo before
 // throwing an error. Long enough for normal startup, short enough to avoid


### PR DESCRIPTION
Register new `SwitchToAgentsWindowAction` and `SwitchToVSCodeWindowAction` with `Cmd+Shift+A` (`Ctrl+Shift+A` on Win/Linux) as the default keybinding.

- **SwitchToAgentsWindowAction** (`workbench.action.switchToAgentsWindow`): opens/focuses the Agents window from VS Code
- **SwitchToVSCodeWindowAction** (`agents.switchToVSCode`): focuses the most recent VS Code window from the Agents window, or opens a new one if none exists

These complement the existing `OpenAgentsWindowAction` and `OpenInVSCodeAction` which transfer the active folder context.