### PR TITLE
Remove empty diffs in legacy diff algorithm

### DIFF
--- a/src/vs/base/common/diff/diff.ts
+++ b/src/vs/base/common/diff/diff.ts
@@ -954,7 +954,8 @@ export class LcsDiff {
 			}
 		}
 
-		return changes;
+		// filter out empty-to-empty changes
+		return changes.filter(change => change.originalLength > 0 || change.modifiedLength > 0);
 	}
 
 	private _findBetterContiguousSequence(originalStart: number, originalLength: number, modifiedStart: number, modifiedLength: number, desiredLength: number): [number, number] | null {

--- a/src/vs/editor/test/common/diff/diffComputer.test.ts
+++ b/src/vs/editor/test/common/diff/diffComputer.test.ts
@@ -1088,4 +1088,59 @@ suite('Editor Diff - DiffComputer', () => {
 		];
 		assertDiff(original, modified, expected, true, false, false);
 	});
+
+	test('issue #248612: Empty-to-empty diffs', () => {
+		const original = [
+			'!Equal and impossible',
+			'11                          6',
+			'0                           XXXXXX',
+			'',
+			'!Equal and impossible',
+			'11                          6',
+			'X                           XXXXXXX',
+			'',
+			'!Equal and impossible',
+			'11                          6',
+			'X                           XXX',
+			'',
+			'Equal and impossible',
+			'4                           5',
+			'XX                          0',
+		];
+		const modified = [
+			'!Equal and impossible',
+			'11                          6',
+			'0                           XXXXXX',
+			'',
+			'possible',
+			'11                          6',
+			'X                           XXXXXXX',
+			'',
+			'possible',
+			'11                          6',
+			'X                           XXX',
+			'',
+			'!Equal and impossible',
+			'11                          10',
+			'X                           XXX',
+			'',
+			'!Equal and impossible',
+			'11                          10',
+			'0                           0',
+			'',
+			'Equal and impossible',
+			'4                           5',
+			'XX                          0',
+		];
+		const expected = [
+			createLineChange(5, 5, 5, 5,
+				[createCharChange(5, 1, 5, 14, 5, 1, 5, 1)]
+			),
+			createLineChange(9, 9, 9, 9,
+				[createCharChange(9, 1, 9, 14, 9, 1, 9, 1)]
+			),
+			createLineChange(12, 0, 13, 20),
+		];
+		assertDiff(original, modified, expected, true, false, false);
+	});
 });


### PR DESCRIPTION
This prevents reintroducing #248612 when #314348 is merged and `legacy` algorithm is used for quick diff.