### PR TITLE
Introduce proposed `agentsWindow` configuration extension point

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -89,6 +89,7 @@
 	"l10n": "./l10n",
 	"enabledApiProposals": [
 		"agentSessionsWorkspace",
+		"agentsWindowConfiguration",
 		"chatDebug",
 		"chatHooks",
 		"extensionsAny",
@@ -3137,7 +3138,13 @@
 						"additionalProperties": {
 							"type": "boolean"
 						},
-						"markdownDescription": "Enable or disable auto triggering of Copilot completions for specified [languages](https://code.visualstudio.com/docs/languages/identifiers). You can still trigger suggestions manually using `Alt + \\`"
+						"markdownDescription": "Enable or disable auto triggering of Copilot completions for specified [languages](https://code.visualstudio.com/docs/languages/identifiers). You can still trigger suggestions manually using `Alt + \\`",
+						"agentsWindow": {
+							"default": {
+								"markdown": true,
+								"plaintext": true
+							}
+						}
 					},
 					"github.copilot.selectedCompletionModel": {
 						"type": "string",
@@ -3306,7 +3313,10 @@
 						"markdownDescription": "%github.copilot.config.githubMcpServer.enabled%",
 						"tags": [
 							"experimental"
-						]
+						],
+						"agentsWindow": {
+							"default": true
+						}
 					},
 					"github.copilot.chat.githubMcpServer.toolsets": {
 						"type": "array",
@@ -3652,7 +3662,10 @@
 							"experimental",
 							"onExP"
 						],
-						"markdownDescription": "%github.copilot.chat.languageContext.typescript.enabled%"
+						"markdownDescription": "%github.copilot.chat.languageContext.typescript.enabled%",
+						"agentsWindow": {
+							"default": true
+						}
 					},
 					"github.copilot.chat.languageContext.typescript.items": {
 						"type": "string",
@@ -4648,7 +4661,10 @@
 						"tags": [
 							"advanced",
 							"experimental"
-						]
+						],
+						"agentsWindow": {
+							"default": true
+						}
 					},
 					"github.copilot.chat.cli.branchSupport.enabled": {
 						"type": "boolean",
@@ -4656,7 +4672,10 @@
 						"markdownDescription": "%github.copilot.config.cli.branchSupport.enabled%",
 						"tags": [
 							"advanced"
-						]
+						],
+						"agentsWindow": {
+							"default": true
+						}
 					},
 					"github.copilot.chat.cli.showExternalSessions": {
 						"type": "boolean",
@@ -4664,7 +4683,10 @@
 						"markdownDescription": "%github.copilot.config.cli.showExternalSessions%",
 						"tags": [
 							"advanced"
-						]
+						],
+						"agentsWindow": {
+							"default": false
+						}
 					},
 					"github.copilot.chat.cli.planExitMode.enabled": {
 						"type": "boolean",
@@ -4704,7 +4726,10 @@
 						"markdownDescription": "%github.copilot.config.cli.lazyLoadSessionItem.enabled%",
 						"tags": [
 							"advanced"
-						]
+						],
+						"agentsWindow": {
+							"default": false
+						}
 					},
 					"github.copilot.chat.cli.aiGenerateBranchNames.enabled": {
 						"type": "boolean",
@@ -4728,7 +4753,10 @@
 						"markdownDescription": "%github.copilot.config.cli.isolationOption.enabled%",
 						"tags": [
 							"advanced"
-						]
+						],
+						"agentsWindow": {
+							"default": true
+						}
 					},
 					"github.copilot.chat.cli.autoCommit.enabled": {
 						"type": "boolean",
@@ -4737,7 +4765,10 @@
 						"tags": [
 							"advanced",
 							"experimental"
-						]
+						],
+						"agentsWindow": {
+							"default": false
+						}
 					},
 					"github.copilot.chat.cli.sessionController.enabled": {
 						"type": "boolean",
@@ -4745,7 +4776,11 @@
 						"markdownDescription": "%github.copilot.config.cli.sessionController.enabled%",
 						"tags": [
 							"advanced"
-						]
+						],
+						"agentsWindow": {
+							"default": false,
+							"readOnly": true
+						}
 					},
 					"github.copilot.chat.cli.thinkingEffort.enabled": {
 						"type": "boolean",
@@ -4777,7 +4812,10 @@
 						"markdownDescription": "%github.copilot.config.cli.remote.enabled%",
 						"tags": [
 							"advanced"
-						]
+						],
+						"agentsWindow": {
+							"default": false
+						}
 					},
 					"github.copilot.chat.searchSubagent.enabled": {
 						"type": "boolean",

--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -3787,7 +3787,7 @@
           "scope": "resource",
           "agentsWindow": {
             "default": false,
-            "readonly": true
+            "readOnly": true
           }
         },
         "git.rebaseWhenSync": {

--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -11,6 +11,7 @@
   "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
   "enabledApiProposals": [
     "agentSessionsWorkspace",
+    "agentsWindowConfiguration",
     "canonicalUriProvider",
     "contribEditSessions",
     "contribEditorContentMenu",
@@ -3321,7 +3322,10 @@
         "git.autorefresh": {
           "type": "boolean",
           "description": "%config.autorefresh%",
-          "default": true
+          "default": true,
+          "agentsWindow": {
+            "default": true
+          }
         },
         "git.autofetch": {
           "type": [
@@ -3338,7 +3342,10 @@
           "default": false,
           "tags": [
             "usesOnlineServices"
-          ]
+          ],
+          "agentsWindow": {
+            "default": true
+          }
         },
         "git.autofetchPeriod": {
           "type": "number",
@@ -3397,7 +3404,10 @@
           "type": "boolean",
           "description": "%config.branchRandomNameEnable%",
           "default": false,
-          "scope": "resource"
+          "scope": "resource",
+          "agentsWindow": {
+            "default": true
+          }
         },
         "git.branchRandomName.dictionary": {
           "type": "array",
@@ -3695,7 +3705,10 @@
           "type": "boolean",
           "scope": "resource",
           "default": false,
-          "description": "%config.detectWorktrees%"
+          "description": "%config.detectWorktrees%",
+          "agentsWindow": {
+            "default": false
+          }
         },
         "git.detectWorktreesLimit": {
           "type": "number",
@@ -3771,7 +3784,11 @@
           "type": "boolean",
           "description": "%config.showProgress%",
           "default": true,
-          "scope": "resource"
+          "scope": "resource",
+          "agentsWindow": {
+            "default": false,
+            "readonly": true
+          }
         },
         "git.rebaseWhenSync": {
           "type": "boolean",

--- a/src/vs/editor/common/config/editorConfigurationSchema.ts
+++ b/src/vs/editor/common/config/editorConfigurationSchema.ts
@@ -207,7 +207,8 @@ const editorConfiguration: IConfigurationNode = {
 		'diffEditor.renderSideBySide': {
 			type: 'boolean',
 			default: diffEditorDefaultOptions.renderSideBySide,
-			description: nls.localize('sideBySide', "Controls whether the diff editor shows the diff side by side or inline.")
+			description: nls.localize('sideBySide', "Controls whether the diff editor shows the diff side by side or inline."),
+			agentsWindow: { default: true },
 		},
 		'diffEditor.renderSideBySideInlineBreakpoint': {
 			type: 'number',
@@ -217,17 +218,20 @@ const editorConfiguration: IConfigurationNode = {
 		'diffEditor.useInlineViewWhenSpaceIsLimited': {
 			type: 'boolean',
 			default: diffEditorDefaultOptions.useInlineViewWhenSpaceIsLimited,
-			description: nls.localize('useInlineViewWhenSpaceIsLimited', "If enabled and the editor width is too small, the inline view is used.")
+			description: nls.localize('useInlineViewWhenSpaceIsLimited', "If enabled and the editor width is too small, the inline view is used."),
+			agentsWindow: { default: true },
 		},
 		'diffEditor.renderMarginRevertIcon': {
 			type: 'boolean',
 			default: diffEditorDefaultOptions.renderMarginRevertIcon,
-			description: nls.localize('renderMarginRevertIcon', "When enabled, the diff editor shows arrows in its glyph margin to revert changes.")
+			description: nls.localize('renderMarginRevertIcon', "When enabled, the diff editor shows arrows in its glyph margin to revert changes."),
+			agentsWindow: { default: false },
 		},
 		'diffEditor.renderGutterMenu': {
 			type: 'boolean',
 			default: diffEditorDefaultOptions.renderGutterMenu,
-			description: nls.localize('renderGutterMenu', "When enabled, the diff editor shows a special gutter for revert and stage actions.")
+			description: nls.localize('renderGutterMenu', "When enabled, the diff editor shows a special gutter for revert and stage actions."),
+			agentsWindow: { default: false },
 		},
 		'diffEditor.ignoreTrimWhitespace': {
 			type: 'boolean',
@@ -237,7 +241,8 @@ const editorConfiguration: IConfigurationNode = {
 		'diffEditor.renderIndicators': {
 			type: 'boolean',
 			default: diffEditorDefaultOptions.renderIndicators,
-			description: nls.localize('renderIndicators', "Controls whether the diff editor shows +/- indicators for added/removed changes.")
+			description: nls.localize('renderIndicators', "Controls whether the diff editor shows +/- indicators for added/removed changes."),
+			agentsWindow: { default: false },
 		},
 		'diffEditor.codeLens': {
 			type: 'boolean',
@@ -267,6 +272,7 @@ const editorConfiguration: IConfigurationNode = {
 			type: 'boolean',
 			default: diffEditorDefaultOptions.hideUnchangedRegions.enabled,
 			markdownDescription: nls.localize('hideUnchangedRegions.enabled', "Controls whether the diff editor shows unchanged regions."),
+			agentsWindow: { default: true },
 		},
 		'diffEditor.hideUnchangedRegions.revealLineCount': {
 			type: 'integer',

--- a/src/vs/platform/configuration/common/configurationRegistry.ts
+++ b/src/vs/platform/configuration/common/configurationRegistry.ts
@@ -240,6 +240,22 @@ export interface IConfigurationPropertySchema extends IJSONSchema {
 		 */
 		name?: string;
 	};
+
+	/**
+	 * When specified, provides configuration overrides for the Agents window.
+	 */
+	agentsWindow?: {
+		/**
+		 * Override default value for this setting in the Agents window.
+		 */
+		default?: unknown;
+
+		/**
+		 * When `true`, this setting is read-only in the Agents window
+		 * and cannot be changed by the user.
+		 */
+		readOnly?: boolean;
+	};
 }
 
 export interface IExtensionInfo {

--- a/src/vs/platform/configuration/common/configurations.ts
+++ b/src/vs/platform/configuration/common/configurations.ts
@@ -67,11 +67,15 @@ export class DefaultConfiguration extends Disposable {
 			if (defaultOverrideValue !== undefined) {
 				this._configurationModel.setValue(key, defaultOverrideValue);
 			} else if (propertySchema) {
-				this._configurationModel.setValue(key, deepClone(propertySchema.default));
+				this._configurationModel.setValue(key, this.getDefaultValue(key, propertySchema));
 			} else {
 				this._configurationModel.removeValue(key);
 			}
 		}
+	}
+
+	protected getDefaultValue(_key: string, propertySchema: IRegisteredConfigurationPropertySchema): unknown {
+		return deepClone(propertySchema.default);
 	}
 
 }

--- a/src/vs/platform/extensions/common/extensionsApiProposals.ts
+++ b/src/vs/platform/extensions/common/extensionsApiProposals.ts
@@ -12,6 +12,9 @@ const _allApiProposals = {
 	agentSessionsWorkspace: {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.agentSessionsWorkspace.d.ts',
 	},
+	agentsWindowConfiguration: {
+		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.agentsWindowConfiguration.d.ts',
+	},
 	aiRelatedInformation: {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.aiRelatedInformation.d.ts',
 	},

--- a/src/vs/platform/update/common/update.config.contribution.ts
+++ b/src/vs/platform/update/common/update.config.contribution.ts
@@ -76,7 +76,8 @@ configurationRegistry.registerConfiguration({
 			default: true,
 			scope: ConfigurationScope.APPLICATION,
 			description: localize('showReleaseNotes', "Show Release Notes after an update. The Release Notes are fetched from a Microsoft online service."),
-			tags: ['usesOnlineServices']
+			tags: ['usesOnlineServices'],
+			agentsWindow: { default: false, readOnly: true },
 		},
 		'update.showPostInstallInfo': {
 			type: 'boolean',

--- a/src/vs/sessions/contrib/configuration/browser/configuration.contribution.ts
+++ b/src/vs/sessions/contrib/configuration/browser/configuration.contribution.ts
@@ -5,82 +5,11 @@
 
 import { Extensions, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
-import { ThemeSettingDefaults } from '../../../../workbench/services/themes/common/workbenchThemeService.js';
 
 Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerDefaultConfigurations([{
 	overrides: {
-		'breadcrumbs.enabled': false,
-
-		'chat.experimentalSessionsWindowOverride': true,
-		'chat.hookFilesLocations': {
-			'.claude/settings.local.json': false,
-			'.claude/settings.json': false,
-			'~/.claude/settings.json': false,
-		},
-		'chat.agent.maxRequests': 1000,
 		'chat.customizationsMenu.userStoragePath': '~/.copilot',
-		'chat.viewSessions.enabled': false,
-		'chat.implicitContext.suggestedContext': false,
-		'chat.implicitContext.enabled': { 'panel': 'never' },
-		'chat.tools.terminal.enableAutoApprove': true,
-
-		'diffEditor.hideUnchangedRegions.enabled': true,
-		'diffEditor.renderGutterMenu': false,
-		'diffEditor.renderIndicators': false,
-		'diffEditor.renderMarginRevertIcon': false,
-		'diffEditor.renderSideBySide': true,
-		'diffEditor.useInlineViewWhenSpaceIsLimited': true,
-
-		'extensions.ignoreRecommendations': true,
-
-		'files.autoSave': 'afterDelay',
-
-		'git.autofetch': true,
-		'git.autorefresh': true,
-		'git.branchRandomName.enable': true,
-		'git.detectWorktrees': false,
-		'git.showProgress': false,
-
-		'github.copilot.enable': {
-			'markdown': true,
-			'plaintext': true,
-		},
 		'github.copilot.chat.claudeCode.enabled': true,
-		'github.copilot.chat.cli.autoCommit.enabled': false,
-		'github.copilot.chat.cli.branchSupport.enabled': true,
-		'github.copilot.chat.cli.isolationOption.enabled': true,
-		'github.copilot.chat.cli.sessionController.enabled': false,
-		'github.copilot.chat.cli.lazyLoadSessionItem.enabled': false,
-		'github.copilot.chat.cli.mcp.enabled': true,
-		'github.copilot.chat.cli.remote.enabled': false,
-		'github.copilot.chat.githubMcpServer.enabled': true,
-		'github.copilot.chat.languageContext.typescript.enabled': true,
-		'github.copilot.chat.cli.showExternalSessions': false,
-
-		'inlineChat.affordance': 'editor',
-
-		'search.quickOpen.includeHistory': false,
-
-		'task.notifyWindowOnTaskCompletion': -1,
-
-		'terminal.integrated.initialHint': false,
-
-		'workbench.browser.openLocalhostLinks': true,
-		'workbench.browser.enableChatTools': true,
-
-		'workbench.editor.doubleClickTabToToggleEditorGroupSizes': 'maximize',
-		'workbench.editor.restoreEditors': false,
-		'update.showReleaseNotes': false,
-		'workbench.notifications.position': 'bottom-right',
-		'workbench.startupEditor': 'none',
-		'workbench.tips.enabled': false,
-		'workbench.layoutControl.type': 'toggles',
-		'workbench.editor.useModal': 'all',
-		'workbench.panel.showLabels': false,
-		'workbench.colorTheme': ThemeSettingDefaults.COLOR_THEME_DARK,
-
-		'window.menuStyle': 'custom',
-		'window.dialogStyle': 'custom',
 	},
 	donotCache: true,
 	preventExperimentOverride: true,

--- a/src/vs/sessions/services/configuration/browser/configurationService.ts
+++ b/src/vs/sessions/services/configuration/browser/configurationService.ts
@@ -13,13 +13,13 @@ import { VSBuffer } from '../../../../base/common/buffer.js';
 import { JSONPath, ParseError, parse } from '../../../../base/common/json.js';
 import { applyEdits, setProperty } from '../../../../base/common/jsonEdit.js';
 import { Edit, FormattingOptions } from '../../../../base/common/jsonFormatter.js';
-import { equals } from '../../../../base/common/objects.js';
+import { deepClone, equals } from '../../../../base/common/objects.js';
 import { distinct, equals as arrayEquals } from '../../../../base/common/arrays.js';
 import { OS, OperatingSystem } from '../../../../base/common/platform.js';
 import { IConfigurationChange, IConfigurationChangeEvent, IConfigurationData, IConfigurationOverrides, IConfigurationUpdateOptions, IConfigurationUpdateOverrides, IConfigurationValue, ConfigurationTarget, isConfigurationOverrides, isConfigurationUpdateOverrides } from '../../../../platform/configuration/common/configuration.js';
 import { ConfigurationChangeEvent, ConfigurationModel } from '../../../../platform/configuration/common/configurationModels.js';
 import { DefaultConfiguration, IPolicyConfiguration, NullPolicyConfiguration, PolicyConfiguration } from '../../../../platform/configuration/common/configurations.js';
-import { Extensions, IConfigurationRegistry, keyFromOverrideIdentifiers } from '../../../../platform/configuration/common/configurationRegistry.js';
+import { Extensions, IConfigurationRegistry, IRegisteredConfigurationPropertySchema, keyFromOverrideIdentifiers } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { IFileService, FileOperationError, FileOperationResult } from '../../../../platform/files/common/files.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IPolicyService, NullPolicyService } from '../../../../platform/policy/common/policy.js';
@@ -34,6 +34,17 @@ import { IUserDataProfileService } from '../../../../workbench/services/userData
 // Import to register configuration contributions
 import '../../../../workbench/services/configuration/browser/configurationService.js';
 
+class SessionsDefaultConfiguration extends DefaultConfiguration {
+
+	protected override getDefaultValue(_key: string, propertySchema: IRegisteredConfigurationPropertySchema): unknown {
+		if (propertySchema.agentsWindow) {
+			return deepClone(propertySchema.agentsWindow.default);
+		}
+		return super.getDefaultValue(_key, propertySchema);
+	}
+
+}
+
 export class ConfigurationService extends Disposable implements IWorkbenchConfigurationService {
 
 	declare readonly _serviceBrand: undefined;
@@ -43,6 +54,7 @@ export class ConfigurationService extends Disposable implements IWorkbenchConfig
 	private readonly policyConfiguration: IPolicyConfiguration;
 	private readonly userConfiguration: UserConfiguration;
 	private readonly cachedFolderConfigs = this._register(new DisposableMap<URI, FolderConfiguration>(new ResourceMap()));
+	private readonly agentsWindowReadOnlyKeys = new Set<string>();
 
 	private readonly _onDidChangeConfiguration = this._register(new Emitter<IConfigurationChangeEvent>());
 	readonly onDidChangeConfiguration = this._onDidChangeConfiguration.event;
@@ -66,9 +78,10 @@ export class ConfigurationService extends Disposable implements IWorkbenchConfig
 		super();
 
 		this.settingsResource = userDataProfileService.currentProfile.settingsResource;
-		this.defaultConfiguration = this._register(new DefaultConfiguration(logService));
+		this.defaultConfiguration = this._register(new SessionsDefaultConfiguration(logService));
 		this.policyConfiguration = policyService instanceof NullPolicyService ? new NullPolicyConfiguration() : this._register(new PolicyConfiguration(this.defaultConfiguration, policyService, logService));
-		this.userConfiguration = this._register(new UserConfiguration(userDataProfileService.currentProfile.settingsResource, userDataProfileService.currentProfile.tasksResource, userDataProfileService.currentProfile.mcpResource, {}, fileService, uriIdentityService, logService));
+		this.initAgentsWindowReadOnlyKeys();
+		this.userConfiguration = this._register(new UserConfiguration(userDataProfileService.currentProfile.settingsResource, userDataProfileService.currentProfile.tasksResource, userDataProfileService.currentProfile.mcpResource, { exclude: [...this.agentsWindowReadOnlyKeys] }, fileService, uriIdentityService, logService));
 		this.configurationEditing = new ConfigurationEditing(fileService, this);
 
 		this._configuration = new Configuration(
@@ -150,6 +163,10 @@ export class ConfigurationService extends Disposable implements IWorkbenchConfig
 			throw new Error(`Unable to write ${key} because it is configured in system policy.`);
 		}
 
+		if (this.agentsWindowReadOnlyKeys.has(key)) {
+			throw new Error(`Unable to write ${key} because it is read-only in the Agents window.`);
+		}
+
 		// Remove the setting, if the value is same as default value
 		if (equals(value, inspect.defaultValue)) {
 			value = undefined;
@@ -226,12 +243,35 @@ export class ConfigurationService extends Disposable implements IWorkbenchConfig
 
 	// #endregion
 
+	private initAgentsWindowReadOnlyKeys(): void {
+		const properties = this.configurationRegistry.getConfigurationProperties();
+		for (const key in properties) {
+			if (properties[key].agentsWindow?.readOnly) {
+				this.agentsWindowReadOnlyKeys.add(key);
+			}
+		}
+	}
+
+	private updateAgentsWindowReadOnlyKeys(changedProperties: string[]): void {
+		const properties = this.configurationRegistry.getConfigurationProperties();
+		for (const key of changedProperties) {
+			if (properties[key]?.agentsWindow?.readOnly) {
+				this.agentsWindowReadOnlyKeys.add(key);
+			} else {
+				this.agentsWindowReadOnlyKeys.delete(key);
+			}
+		}
+	}
+
 	// #region Configuration change handlers
 
 	private onDefaultConfigurationChanged(defaults: ConfigurationModel, properties?: string[]): void {
+		if (properties) {
+			this.updateAgentsWindowReadOnlyKeys(properties);
+		}
 		const previousData = this._configuration.toData();
 		const change = this._configuration.compareAndUpdateDefaultConfiguration(defaults, properties);
-		this._configuration.updateLocalUserConfiguration(this.userConfiguration.reparse());
+		this._configuration.updateLocalUserConfiguration(this.userConfiguration.reparse({ exclude: [...this.agentsWindowReadOnlyKeys] }));
 		for (const folder of this.workspaceService.getWorkspace().folders) {
 			const folderConfiguration = this.cachedFolderConfigs.get(folder.uri);
 			if (folderConfiguration) {

--- a/src/vs/sessions/services/configuration/test/browser/configurationService.test.ts
+++ b/src/vs/sessions/services/configuration/test/browser/configurationService.test.ts
@@ -59,6 +59,24 @@ suite('Sessions ConfigurationService', () => {
 					'default': 'defaultValue',
 					scope: ConfigurationScope.APPLICATION
 				},
+				'sessionsConfigurationService.agentsWindowDefault': {
+					'type': 'string',
+					'default': 'originalDefault',
+					scope: ConfigurationScope.RESOURCE,
+					agentsWindow: { default: 'agentsDefault' }
+				},
+				'sessionsConfigurationService.agentsWindowReadOnly': {
+					'type': 'string',
+					'default': 'originalDefault',
+					scope: ConfigurationScope.RESOURCE,
+					agentsWindow: { default: 'readOnlyDefault', readOnly: true }
+				},
+				'sessionsConfigurationService.agentsWindowDefaultOnly': {
+					'type': 'boolean',
+					'default': false,
+					scope: ConfigurationScope.RESOURCE,
+					agentsWindow: { default: true }
+				},
 			}
 		});
 	});
@@ -333,6 +351,66 @@ suite('Sessions ConfigurationService', () => {
 
 		await workspaceService.removeFolders([folder]);
 		assert.strictEqual(testObject.getValue('sessionsConfigurationService.testSetting', { resource: folder }), 'defaultValue');
+	}));
+
+	// #endregion
+
+	// #region Agents Window Configuration
+
+	test('agentsWindow.default overrides the default value', () => {
+		assert.strictEqual(testObject.getValue('sessionsConfigurationService.agentsWindowDefault'), 'agentsDefault');
+	});
+
+	test('agentsWindow.default is reflected in inspect', () => {
+		const inspection = testObject.inspect('sessionsConfigurationService.agentsWindowDefault');
+		assert.strictEqual(inspection.defaultValue, 'agentsDefault');
+	});
+
+	test('agentsWindow.default with boolean value', () => {
+		assert.strictEqual(testObject.getValue('sessionsConfigurationService.agentsWindowDefaultOnly'), true);
+	});
+
+	test('agentsWindow.readOnly setting uses overridden default', () => {
+		assert.strictEqual(testObject.getValue('sessionsConfigurationService.agentsWindowReadOnly'), 'readOnlyDefault');
+	});
+
+	test('agentsWindow.readOnly setting rejects writes', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
+		await assert.rejects(
+			() => testObject.updateValue('sessionsConfigurationService.agentsWindowReadOnly', 'newValue'),
+			/read-only in the Agents window/
+		);
+	}));
+
+	test('agentsWindow.readOnly setting ignores user settings file values', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
+		await fileService.writeFile(userDataProfileService.currentProfile.settingsResource, VSBuffer.fromString('{ "sessionsConfigurationService.agentsWindowReadOnly": "userValue" }'));
+		await testObject.reloadConfiguration();
+		assert.strictEqual(testObject.getValue('sessionsConfigurationService.agentsWindowReadOnly'), 'readOnlyDefault');
+	}));
+
+	test('user settings override agentsWindow.default when not readOnly', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
+		await fileService.writeFile(userDataProfileService.currentProfile.settingsResource, VSBuffer.fromString('{ "sessionsConfigurationService.agentsWindowDefault": "userValue" }'));
+		await testObject.reloadConfiguration();
+		assert.strictEqual(testObject.getValue('sessionsConfigurationService.agentsWindowDefault'), 'userValue');
+	}));
+
+	test('agentsWindow.readOnly setting added dynamically is picked up', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
+		configurationRegistry.registerConfiguration({
+			'id': '_test_sessions_dynamic',
+			'type': 'object',
+			'properties': {
+				'sessionsConfigurationService.dynamicReadOnly': {
+					'type': 'string',
+					'default': 'originalDefault',
+					scope: ConfigurationScope.RESOURCE,
+					agentsWindow: { default: 'dynamicDefault', readOnly: true }
+				},
+			}
+		});
+		assert.strictEqual(testObject.getValue('sessionsConfigurationService.dynamicReadOnly'), 'dynamicDefault');
+		await assert.rejects(
+			() => testObject.updateValue('sessionsConfigurationService.dynamicReadOnly', 'newValue'),
+			/read-only in the Agents window/
+		);
 	}));
 
 	// #endregion

--- a/src/vs/sessions/sessions.common.main.ts
+++ b/src/vs/sessions/sessions.common.main.ts
@@ -251,9 +251,6 @@ import '../workbench/contrib/inlineCompletions/browser/renameSymbolTrackerServic
 // Search Quick Access (file picker only, not the full search contribution)
 import '../workbench/contrib/search/browser/searchQuickAccess.contribution.js';
 
-// Search Editor
-import '../workbench/contrib/searchEditor/browser/searchEditor.contribution.js';
-
 // Sash
 import '../workbench/contrib/sash/browser/sash.contribution.js';
 
@@ -306,9 +303,6 @@ registerSingleton(IExtensionsWorkbenchService, ExtensionsWorkbenchService, Insta
 // Output View
 import '../workbench/contrib/output/browser/output.contribution.js';
 import '../workbench/contrib/output/browser/outputView.js';
-
-// Problems View
-import '../workbench/contrib/markers/browser/markers.contribution.js';
 
 // Terminal
 import '../workbench/contrib/terminal/terminal.all.js';
@@ -456,7 +450,6 @@ import './contrib/github/browser/github.contribution.js';
 import './contrib/applyCommitsToParentRepo/browser/applyChangesToParentRepo.js';
 import './contrib/fileTreeView/browser/fileTreeView.contribution.js'; // view registration disabled; filesystem provider still needed
 import './contrib/configuration/browser/configuration.contribution.js';
-
 import './contrib/workingSet/browser/workingSet.contribution.js';
 import './contrib/browserView/browser/sessionBrowserView.contribution.js';
 import './contrib/editor/browser/editor.contribution.js';

--- a/src/vs/sessions/sessions.common.main.ts
+++ b/src/vs/sessions/sessions.common.main.ts
@@ -251,6 +251,9 @@ import '../workbench/contrib/inlineCompletions/browser/renameSymbolTrackerServic
 // Search Quick Access (file picker only, not the full search contribution)
 import '../workbench/contrib/search/browser/searchQuickAccess.contribution.js';
 
+// Search Editor
+import '../workbench/contrib/searchEditor/browser/searchEditor.contribution.js';
+
 // Sash
 import '../workbench/contrib/sash/browser/sash.contribution.js';
 
@@ -303,6 +306,9 @@ registerSingleton(IExtensionsWorkbenchService, ExtensionsWorkbenchService, Insta
 // Output View
 import '../workbench/contrib/output/browser/output.contribution.js';
 import '../workbench/contrib/output/browser/outputView.js';
+
+// Problems View
+import '../workbench/contrib/markers/browser/markers.contribution.js';
 
 // Terminal
 import '../workbench/contrib/terminal/terminal.all.js';
@@ -450,6 +456,7 @@ import './contrib/github/browser/github.contribution.js';
 import './contrib/applyCommitsToParentRepo/browser/applyChangesToParentRepo.js';
 import './contrib/fileTreeView/browser/fileTreeView.contribution.js'; // view registration disabled; filesystem provider still needed
 import './contrib/configuration/browser/configuration.contribution.js';
+
 import './contrib/workingSet/browser/workingSet.contribution.js';
 import './contrib/browserView/browser/sessionBrowserView.contribution.js';
 import './contrib/editor/browser/editor.contribution.js';

--- a/src/vs/workbench/api/common/configurationExtensionPoint.ts
+++ b/src/vs/workbench/api/common/configurationExtensionPoint.ts
@@ -19,6 +19,7 @@ import { Disposable } from '../../../base/common/lifecycle.js';
 import { SyncDescriptor } from '../../../platform/instantiation/common/descriptors.js';
 import { MarkdownString } from '../../../base/common/htmlContent.js';
 import product from '../../../platform/product/common/product.js';
+import { isProposedApiEnabled } from '../../services/extensions/common/extensions.js';
 
 const jsonRegistry = Registry.as<IJSONContributionRegistry>(JSONExtensions.JSONContribution);
 const configurationRegistry = Registry.as<IConfigurationRegistry>(Extensions.Configuration);
@@ -145,6 +146,21 @@ const configurationEntrySchema: IJSONSchema = {
 								},
 								additionalItems: true,
 								markdownDescription: nls.localize('scope.tags', 'A list of tags under which to place the setting. The tag can then be searched up in the Settings editor. For example, specifying the `experimental` tag allows one to find the setting by searching `@tag:experimental`.'),
+							},
+							agentsWindow: {
+								type: 'object',
+								markdownDescription: nls.localize('scope.agentsWindow', "Configuration overrides for the Agents window. Allows specifying a different default value and read-only behavior for this setting when running in the Agents window.\n\n**Note**: This is a proposed API. To use it, extensions must include `agentsWindowConfiguration` in their `enabledApiProposals`."),
+								properties: {
+									'default': {
+										description: nls.localize('scope.agentsWindow.default', 'The default value for this setting in the Agents window.'),
+									},
+									readOnly: {
+										type: 'boolean',
+										description: nls.localize('scope.agentsWindow.readOnly', 'When true, this setting cannot be changed by the user in the Agents window.'),
+										default: false,
+									}
+								},
+								additionalProperties: false
 							}
 						}
 					}
@@ -298,6 +314,10 @@ configurationExtPoint.setHandler((extensions, { added, removed }) => {
 					propertyConfiguration.experiment = {
 						mode: 'startup'
 					};
+				}
+				if (propertyConfiguration.agentsWindow && !isProposedApiEnabled(extension.description, 'agentsWindowConfiguration')) {
+					extension.collector.error(nls.localize('config.property.agentsWindow.proposed', "Extension '{0}' CANNOT use 'agentsWindow' property on configuration '{1}' without enabling the 'agentsWindowConfiguration' API proposal.", extension.description.identifier.value, key));
+					delete propertyConfiguration.agentsWindow;
 				}
 				seenProperties.add(key);
 				propertyConfiguration.scope = propertyConfiguration.scope ? parseScope(propertyConfiguration.scope.toString()) : ConfigurationScope.WINDOW;

--- a/src/vs/workbench/browser/parts/editor/breadcrumbs.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbs.ts
@@ -125,7 +125,8 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 		'breadcrumbs.enabled': {
 			description: localize('enabled', "Enable/disable navigation breadcrumbs."),
 			type: 'boolean',
-			default: true
+			default: true,
+			agentsWindow: { default: false },
 		},
 		'breadcrumbs.filePath': {
 			description: localize('filepath', "Controls whether and how file paths are shown in the breadcrumbs view."),

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -362,7 +362,8 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 					localize('useModal.all', "All editors open in a centered modal overlay."),
 				],
 				'description': localize('useModal', "Controls whether editors open in a modal overlay."),
-				'default': 'some'
+				'default': 'some',
+				agentsWindow: { default: 'all' },
 			},
 			'workbench.editor.swipeToNavigate': {
 				'type': 'boolean',
@@ -400,7 +401,8 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 			'workbench.editor.restoreEditors': {
 				'type': 'boolean',
 				'description': localize('restoreOnStartup', "Controls whether editors are restored on startup. When disabled, only dirty editors will be restored from the previous session."),
-				'default': true
+				'default': true,
+				agentsWindow: { default: false, readOnly: true },
 			},
 			'workbench.editor.splitInGroupLayout': {
 				'type': 'string',
@@ -431,7 +433,8 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 					localize('workbench.editor.doubleClickTabToToggleEditorGroupSizes.maximize', "All other editor groups are hidden and the current editor group is maximized to take up the entire editor area."),
 					localize('workbench.editor.doubleClickTabToToggleEditorGroupSizes.expand', "The editor group takes as much space as possible by making all other editor groups as small as possible."),
 					localize('workbench.editor.doubleClickTabToToggleEditorGroupSizes.off', "No editor group is resized when double clicking on a tab.")
-				]
+				],
+				agentsWindow: { default: 'maximize' },
 			},
 			'workbench.editor.limit.enabled': {
 				'type': 'boolean',
@@ -569,6 +572,7 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'type': 'boolean',
 				'default': true,
 				'description': localize('panelShowLabels', "Controls whether activity items in the panel title are shown as label or icon."),
+				agentsWindow: { default: false },
 			},
 			'workbench.panel.defaultLocation': {
 				'type': 'string',
@@ -777,11 +781,13 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				],
 				'default': 'both',
 				'description': localize('layoutControlType', "Controls whether the layout control in the custom title bar is displayed as a single menu button or with multiple UI toggles."),
+				agentsWindow: { default: 'toggles' },
 			},
 			'workbench.tips.enabled': {
 				'type': 'boolean',
 				'default': true,
-				'description': localize('tips.enabled', "When enabled, will show the watermark tips when no editor is open.")
+				'description': localize('tips.enabled', "When enabled, will show the watermark tips when no editor is open."),
+				agentsWindow: { default: false },
 			},
 			[LayoutSettings.SHADOWS]: {
 				'type': 'boolean',

--- a/src/vs/workbench/contrib/browserView/electron-browser/features/browserEditorChatFeatures.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/features/browserEditorChatFeatures.ts
@@ -562,7 +562,8 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 						value: localize('browser.enableChatTools', 'When enabled, chat agents can use browser tools to open and interact with pages in the Integrated Browser.')
 					}
 				},
-			}
+			},
+			agentsWindow: { default: true },
 		},
 		[AgentHostChatToolsEnabledSettingId]: {
 			type: 'boolean',

--- a/src/vs/workbench/contrib/browserView/electron-browser/features/browserTabManagementFeatures.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/features/browserTabManagementFeatures.ts
@@ -697,7 +697,8 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			markdownDescription: localize(
 				{ comment: ['This is the description for a setting.'], key: 'browser.openLocalhostLinks' },
 				'When enabled, localhost links (`localhost`, `127.0.0.1`, `[::1]`) and all-interfaces links (`0.0.0.0`, `[0:0:0:0:0:0:0:0]`, `[::]`) from the terminal, chat, and other sources will open in the Integrated Browser instead of the system browser.'
-			)
+			),
+			agentsWindow: { default: true },
 		}
 	}
 });

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -216,6 +216,7 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.experimentalSessionsWindowOverride', "When true, enables sessions-window-specific behavior for extensions."),
 			default: false,
 			tags: ['experimental'],
+			agentsWindow: { default: true },
 		},
 		'chat.fontSize': {
 			type: 'number',
@@ -298,12 +299,14 @@ configurationRegistry.registerConfiguration({
 			tags: ['experimental'],
 			experiment: {
 				mode: 'startup'
-			}
+			},
+			agentsWindow: { default: { 'panel': 'never' } },
 		},
 		'chat.implicitContext.suggestedContext': {
 			type: 'boolean',
 			markdownDescription: nls.localize('chat.implicitContext.suggestedContext', "Controls whether the new implicit context flow is shown. In Ask and Edit modes, the context will automatically be included. When using an agent, context will be suggested as an attachment. Selections are always included as context."),
 			default: true,
+			agentsWindow: { default: false },
 		},
 		'chat.editing.autoAcceptDelay': {
 			type: 'number',
@@ -655,6 +658,7 @@ configurationRegistry.registerConfiguration({
 			type: 'boolean',
 			default: true,
 			description: nls.localize('chat.viewSessions.enabled', "Show chat agent sessions when chat is empty or to the side when chat view is wide enough."),
+			agentsWindow: { default: false },
 		},
 		[ChatConfiguration.ChatViewSessionsOrientation]: {
 			type: 'string',
@@ -1388,6 +1392,7 @@ configurationRegistry.registerConfiguration({
 					'custom-hooks/hooks.json': true,
 				},
 			],
+			agentsWindow: { default: { '.claude/settings.local.json': false, '.claude/settings.json': false, '~/.claude/settings.json': false } },
 		},
 		[PromptsConfig.USE_CHAT_HOOKS]: {
 			type: 'boolean',
@@ -1927,6 +1932,7 @@ class ChatAgentSettingContribution extends Disposable implements IWorkbenchContr
 							markdownDescription: nls.localize('chat.agent.maxRequests', "The maximum number of requests to allow per-turn when using an agent. When the limit is reached, will ask to confirm to continue."),
 							default: value ?? 50,
 							order: 2,
+							agentsWindow: { default: 1000 },
 						},
 					}
 				};

--- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -163,7 +163,8 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 			'extensions.ignoreRecommendations': {
 				type: 'boolean',
 				description: localize('extensionsIgnoreRecommendations', "When enabled, the notifications for extension recommendations will not be shown."),
-				default: false
+				default: false,
+				agentsWindow: { default: true, readOnly: true },
 			},
 			'extensions.showRecommendationsOnlyOnDemand': {
 				type: 'boolean',

--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -269,7 +269,8 @@ configurationRegistry.registerConfiguration({
 			],
 			'default': isWeb ? AutoSaveConfiguration.AFTER_DELAY : AutoSaveConfiguration.OFF,
 			'markdownDescription': nls.localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'autoSave' }, "Controls [auto save](https://code.visualstudio.com/docs/editor/codebasics#_save-auto-save) of editors that have unsaved changes.", AutoSaveConfiguration.OFF, AutoSaveConfiguration.AFTER_DELAY, AutoSaveConfiguration.ON_FOCUS_CHANGE, AutoSaveConfiguration.ON_WINDOW_CHANGE, AutoSaveConfiguration.AFTER_DELAY),
-			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE
+			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
+			agentsWindow: { default: 'afterDelay' },
 		},
 		'files.autoSaveDelay': {
 			'type': 'number',

--- a/src/vs/workbench/contrib/inlineChat/common/inlineChat.ts
+++ b/src/vs/workbench/contrib/inlineChat/common/inlineChat.ts
@@ -45,7 +45,8 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 			experiment: {
 				mode: 'auto'
 			},
-			tags: ['experimental']
+			tags: ['experimental'],
+			agentsWindow: { default: 'editor' },
 		},
 		[InlineChatConfigKeys.FixDiagnostics]: {
 			description: localize('fixDiagnostics', "Controls whether the Fix action is shown for diagnostics in the editor."),

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -61,8 +61,9 @@ import { nullRange, Settings2EditorModel } from '../../../services/preferences/c
 import { IUserDataProfileService } from '../../../services/userDataProfile/common/userDataProfile.js';
 import { IUserDataSyncWorkbenchService } from '../../../services/userDataSync/common/userDataSync.js';
 import { SuggestEnabledInput } from '../../codeEditor/browser/suggestEnabledInput/suggestEnabledInput.js';
-import { ADVANCED_SETTING_TAG, CONTEXT_AI_SETTING_RESULTS_AVAILABLE, CONTEXT_SETTINGS_EDITOR, CONTEXT_SETTINGS_ROW_FOCUS, CONTEXT_SETTINGS_SEARCH_FOCUS, CONTEXT_TOC_ROW_FOCUS, EMBEDDINGS_SEARCH_PROVIDER_NAME, ENABLE_LANGUAGE_FILTER, EXTENSION_FETCH_TIMEOUT_MS, EXTENSION_SETTING_TAG, FEATURE_SETTING_TAG, FILTER_MODEL_SEARCH_PROVIDER_NAME, getExperimentalExtensionToggleData, ID_SETTING_TAG, IPreferencesSearchService, ISearchProvider, LANGUAGE_SETTING_TAG, LLM_RANKED_SEARCH_PROVIDER_NAME, MODIFIED_SETTING_TAG, POLICY_SETTING_TAG, REQUIRE_TRUSTED_WORKSPACE_SETTING_TAG, SETTINGS_EDITOR_COMMAND_CLEAR_SEARCH_RESULTS, SETTINGS_EDITOR_COMMAND_SHOW_AI_RESULTS, SETTINGS_EDITOR_COMMAND_SUGGEST_FILTERS, SETTINGS_EDITOR_COMMAND_TOGGLE_AI_SEARCH, STRING_MATCH_SEARCH_PROVIDER_NAME, TF_IDF_SEARCH_PROVIDER_NAME, WorkbenchSettingsEditorSettings, WORKSPACE_TRUST_SETTING_TAG } from '../common/preferences.js';
+import { ADVANCED_SETTING_TAG, AGENTS_WINDOW_SETTING_TAG, CONTEXT_AI_SETTING_RESULTS_AVAILABLE, CONTEXT_SETTINGS_EDITOR, CONTEXT_SETTINGS_ROW_FOCUS, CONTEXT_SETTINGS_SEARCH_FOCUS, CONTEXT_TOC_ROW_FOCUS, EMBEDDINGS_SEARCH_PROVIDER_NAME, ENABLE_LANGUAGE_FILTER, EXTENSION_FETCH_TIMEOUT_MS, EXTENSION_SETTING_TAG, FEATURE_SETTING_TAG, FILTER_MODEL_SEARCH_PROVIDER_NAME, getExperimentalExtensionToggleData, ID_SETTING_TAG, IPreferencesSearchService, ISearchProvider, LANGUAGE_SETTING_TAG, LLM_RANKED_SEARCH_PROVIDER_NAME, MODIFIED_SETTING_TAG, POLICY_SETTING_TAG, REQUIRE_TRUSTED_WORKSPACE_SETTING_TAG, SETTINGS_EDITOR_COMMAND_CLEAR_SEARCH_RESULTS, SETTINGS_EDITOR_COMMAND_SHOW_AI_RESULTS, SETTINGS_EDITOR_COMMAND_SUGGEST_FILTERS, SETTINGS_EDITOR_COMMAND_TOGGLE_AI_SEARCH, STRING_MATCH_SEARCH_PROVIDER_NAME, TF_IDF_SEARCH_PROVIDER_NAME, WorkbenchSettingsEditorSettings, WORKSPACE_TRUST_SETTING_TAG } from '../common/preferences.js';
 import { settingsHeaderBorder, settingsSashBorder, settingsTextInputBorder } from '../common/settingsEditorColorRegistry.js';
+import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
 import './media/settingsEditor2.css';
 import { preferencesAiResultsIcon, preferencesClearInputIcon, preferencesFilterIcon } from './preferencesIcons.js';
 import { SettingsTarget, SettingsTargetsWidget } from './preferencesWidgets.js';
@@ -262,7 +263,8 @@ export class SettingsEditor2 extends EditorPane {
 		@IEditorProgressService private readonly editorProgressService: IEditorProgressService,
 		@IUserDataProfileService userDataProfileService: IUserDataProfileService,
 		@IKeybindingService private readonly keybindingService: IKeybindingService,
-		@IChatEntitlementService private readonly chatEntitlementService: IChatEntitlementService
+		@IChatEntitlementService private readonly chatEntitlementService: IChatEntitlementService,
+		@IWorkbenchEnvironmentService private readonly environmentService: IWorkbenchEnvironmentService,
 	) {
 		super(SettingsEditor2.ID, group, telemetryService, themeService, storageService);
 		this.searchDelayer = this._register(new Delayer(200));
@@ -335,6 +337,9 @@ export class SettingsEditor2 extends EditorPane {
 
 		if (ENABLE_LANGUAGE_FILTER && !SettingsEditor2.SUGGESTIONS.includes(`@${LANGUAGE_SETTING_TAG}`)) {
 			SettingsEditor2.SUGGESTIONS.push(`@${LANGUAGE_SETTING_TAG}`);
+		}
+		if (this.environmentService.isSessionsWindow && !SettingsEditor2.SUGGESTIONS.includes(`@${AGENTS_WINDOW_SETTING_TAG}`)) {
+			SettingsEditor2.SUGGESTIONS.push(`@${AGENTS_WINDOW_SETTING_TAG}`);
 		}
 		this.inputChangeListener = this._register(new MutableDisposable());
 	}

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
@@ -369,6 +369,16 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 					}
 				}],
 			}), { setupKeyboardEvents: true }));
+		} else if (element.isAgentsWindowReadOnly) {
+			this.scopeOverridesIndicator.element.style.display = 'inline';
+			this.scopeOverridesIndicator.element.classList.add('setting-indicator');
+
+			this.scopeOverridesIndicator.label.text = '$(lock) ' + localize('agentsWindowReadOnlyLabelText', "Cannot be changed in Agents window");
+			const content = localize('agentsWindowReadOnlyDescription', "This setting cannot be changed in the Agents window.");
+			this.scopeOverridesIndicator.disposables.add(this.hoverService.setupDelayedHover(this.scopeOverridesIndicator.element, {
+				...this.defaultHoverOptions,
+				content,
+			}, { setupKeyboardEvents: true }));
 		} else if (element.settingsTarget === ConfigurationTarget.USER_LOCAL && this.configurationService.isSettingAppliedForAllProfiles(element.setting.key)) {
 			this.scopeOverridesIndicator.element.style.display = 'inline';
 			this.scopeOverridesIndicator.element.classList.add('setting-indicator');
@@ -564,6 +574,8 @@ export function getIndicatorsLabelAriaLabel(element: SettingsTreeSettingElement,
 
 	if (element.hasPolicyValue) {
 		ariaLabelSections.push(localize('policyDescriptionAccessible', "Managed by organization policy; setting value not applied"));
+	} else if (element.isAgentsWindowReadOnly) {
+		ariaLabelSections.push(localize('agentsWindowReadOnlyAccessible', "Cannot be changed in Agents window"));
 	} else if (element.settingsTarget === ConfigurationTarget.USER_LOCAL && configurationService.isSettingAppliedForAllProfiles(element.setting.key)) {
 		ariaLabelSections.push(localize('applicationSettingDescriptionAccessible', "Setting value retained when switching profiles"));
 	} else {

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -176,7 +176,7 @@ function getObjectDisplayValue(element: SettingsTreeSettingElement): IObjectData
 
 	const data = element.isConfigured ?
 		{ ...elementDefaultValue, ...elementScopeValue } :
-		element.hasPolicyValue ? element.scopeValue :
+		element.hasPolicyValue || element.isAgentsWindowReadOnly ? element.scopeValue :
 			elementDefaultValue;
 
 	const { objectProperties, objectPatternProperties, objectAdditionalProperties } = element.setting;
@@ -1313,7 +1313,7 @@ class SettingComplexObjectRenderer extends SettingComplexRenderer implements ITr
 			showAddButton: false,
 			isReadOnly: true,
 		});
-		template.button.parentElement?.classList.toggle('hide', dataElement.hasPolicyValue);
+		template.button.parentElement?.classList.toggle('hide', dataElement.hasPolicyValue || dataElement.isAgentsWindowReadOnly);
 		super.renderValue(dataElement, template, onChange);
 	}
 }
@@ -1735,7 +1735,7 @@ abstract class SettingIncludeExcludeRenderer extends AbstractSettingRenderer imp
 
 	protected renderValue(dataElement: SettingsTreeSettingElement, template: ISettingIncludeExcludeItemTemplate, onChange: (value: string) => void): void {
 		const value = getIncludeExcludeDisplayValue(dataElement);
-		template.includeExcludeWidget.setValue(value, { isReadOnly: dataElement.hasPolicyValue });
+		template.includeExcludeWidget.setValue(value, { isReadOnly: dataElement.hasPolicyValue || dataElement.isAgentsWindowReadOnly });
 		template.context = dataElement;
 		template.elementDisposables.add(toDisposable(() => {
 			template.includeExcludeWidget.cancelEdit();
@@ -1806,7 +1806,7 @@ abstract class AbstractSettingTextRenderer extends AbstractSettingRenderer imple
 	protected renderValue(dataElement: SettingsTreeSettingElement, template: ISettingTextItemTemplate, onChange: (value: string) => void): void {
 		template.onChange = undefined;
 		template.inputBox.value = dataElement.value;
-		template.inputBox.setEnabled(!dataElement.hasPolicyValue);
+		template.inputBox.setEnabled(!dataElement.hasPolicyValue && !dataElement.isAgentsWindowReadOnly);
 		template.inputBox.setAriaLabel(dataElement.setting.key);
 		template.onChange = value => {
 			if (!renderValidations(dataElement, template, false)) {
@@ -1956,7 +1956,7 @@ class SettingEnumRenderer extends AbstractSettingRenderer implements ITreeRender
 
 		template.selectBox.setOptions(displayOptions);
 		template.selectBox.setAriaLabel(dataElement.setting.key);
-		template.selectBox.setEnabled(!dataElement.hasPolicyValue);
+		template.selectBox.setEnabled(!dataElement.hasPolicyValue && !dataElement.isAgentsWindowReadOnly);
 
 		let idx = settingEnum.indexOf(dataElement.value);
 		if (idx === -1) {
@@ -2027,7 +2027,7 @@ class SettingNumberRenderer extends AbstractSettingRenderer implements ITreeRend
 			dataElement.value.toString() : '';
 		template.inputBox.step = dataElement.valueType.includes('integer') ? '1' : 'any';
 		template.inputBox.setAriaLabel(dataElement.setting.key);
-		template.inputBox.setEnabled(!dataElement.hasPolicyValue);
+		template.inputBox.setEnabled(!dataElement.hasPolicyValue && !dataElement.isAgentsWindowReadOnly);
 		template.onChange = value => {
 			if (!renderValidations(dataElement, template, false)) {
 				onChange(nullNumParseFn(value));
@@ -2110,7 +2110,7 @@ class SettingBoolRenderer extends AbstractSettingRenderer implements ITreeRender
 	protected renderValue(dataElement: SettingsTreeSettingElement, template: ISettingBoolItemTemplate, onChange: (value: boolean) => void): void {
 		template.onChange = undefined;
 		template.checkbox.checked = dataElement.value;
-		if (dataElement.hasPolicyValue) {
+		if (dataElement.hasPolicyValue || dataElement.isAgentsWindowReadOnly) {
 			template.checkbox.disable();
 			template.descriptionElement.classList.add('disabled');
 		} else {

--- a/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
@@ -377,12 +377,10 @@ export class SettingsTreeSettingElement extends SettingsTreeElement {
 		let hasAgentsWindowOverride = false;
 		if (this.isSessionsWindow) {
 			const property = Registry.as<IConfigurationRegistry>(Extensions.Configuration).getConfigurationProperties()[this.setting.key];
-			if (property?.agentsWindow) {
-				hasAgentsWindowOverride = true;
-				if (property.agentsWindow.readOnly) {
-					this.isAgentsWindowReadOnly = true;
-					isConfigured = false;
-				}
+			hasAgentsWindowOverride = !!property?.agentsWindow;
+			this.isAgentsWindowReadOnly = !!property?.agentsWindow?.readOnly;
+			if (this.isAgentsWindowReadOnly) {
+				isConfigured = false;
 			}
 		}
 

--- a/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
@@ -20,7 +20,7 @@ import { APPLICATION_SCOPES, FOLDER_SCOPES, IWorkbenchConfigurationService, LOCA
 import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
 import { IExtensionSetting, ISearchResult, ISetting, ISettingMatch, SettingMatchType, SettingValueType } from '../../../services/preferences/common/preferences.js';
 import { IUserDataProfileService } from '../../../services/userDataProfile/common/userDataProfile.js';
-import { ENABLE_EXTENSION_TOGGLE_SETTINGS, ENABLE_LANGUAGE_FILTER, MODIFIED_SETTING_TAG, POLICY_SETTING_TAG, REQUIRE_TRUSTED_WORKSPACE_SETTING_TAG, compareTwoNullableNumbers, wordifyKey } from '../common/preferences.js';
+import { AGENTS_WINDOW_SETTING_TAG, ENABLE_EXTENSION_TOGGLE_SETTINGS, ENABLE_LANGUAGE_FILTER, MODIFIED_SETTING_TAG, POLICY_SETTING_TAG, REQUIRE_TRUSTED_WORKSPACE_SETTING_TAG, compareTwoNullableNumbers, wordifyKey } from '../common/preferences.js';
 import { SettingsTarget } from './preferencesWidgets.js';
 import { ITOCEntry, tocData } from './settingsLayout.js';
 
@@ -154,6 +154,11 @@ export class SettingsTreeSettingElement extends SettingsTreeElement {
 	 */
 	hasPolicyValue = false;
 
+	/**
+	 * Whether the setting is read-only in the Agents window.
+	 */
+	isAgentsWindowReadOnly = false;
+
 	tags?: Set<string>;
 	overriddenScopeList: string[] = [];
 	overriddenDefaultsLanguageList: string[] = [];
@@ -176,6 +181,7 @@ export class SettingsTreeSettingElement extends SettingsTreeElement {
 		private readonly productService: IProductService,
 		private readonly userDataProfileService: IUserDataProfileService,
 		private readonly configurationService: IWorkbenchConfigurationService,
+		private readonly isSessionsWindow: boolean,
 	) {
 		super(sanitizeId(parent.id + '_' + setting.key));
 		this.setting = setting;
@@ -368,9 +374,21 @@ export class SettingsTreeSettingElement extends SettingsTreeElement {
 			this.defaultValue = inspected.defaultValue;
 		}
 
+		let hasAgentsWindowOverride = false;
+		if (this.isSessionsWindow) {
+			const property = Registry.as<IConfigurationRegistry>(Extensions.Configuration).getConfigurationProperties()[this.setting.key];
+			if (property?.agentsWindow) {
+				hasAgentsWindowOverride = true;
+				if (property.agentsWindow.readOnly) {
+					this.isAgentsWindowReadOnly = true;
+					isConfigured = false;
+				}
+			}
+		}
+
 		this.value = displayValue;
 		this.isConfigured = isConfigured;
-		if (isConfigured || this.setting.tags || this.tags || this.setting.restricted || this.hasPolicyValue) {
+		if (isConfigured || this.setting.tags || this.tags || this.setting.restricted || this.hasPolicyValue || hasAgentsWindowOverride) {
 			// Don't create an empty Set for all 1000 settings, only if needed
 			this.tags = new Set<string>();
 			if (isConfigured) {
@@ -385,6 +403,10 @@ export class SettingsTreeSettingElement extends SettingsTreeElement {
 
 			if (this.hasPolicyValue) {
 				this.tags.add(POLICY_SETTING_TAG);
+			}
+
+			if (hasAgentsWindowOverride) {
+				this.tags.add(AGENTS_WINDOW_SETTING_TAG);
 			}
 		}
 	}
@@ -570,7 +592,8 @@ export class SettingsTreeModel implements IDisposable {
 		@IWorkbenchConfigurationService private readonly _configurationService: IWorkbenchConfigurationService,
 		@ILanguageService private readonly _languageService: ILanguageService,
 		@IUserDataProfileService private readonly _userDataProfileService: IUserDataProfileService,
-		@IProductService private readonly _productService: IProductService
+		@IProductService private readonly _productService: IProductService,
+		@IWorkbenchEnvironmentService private readonly _environmentService: IWorkbenchEnvironmentService,
 	) {
 	}
 
@@ -686,7 +709,8 @@ export class SettingsTreeModel implements IDisposable {
 			this._languageService,
 			this._productService,
 			this._userDataProfileService,
-			this._configurationService);
+			this._configurationService,
+			this._environmentService.isSessionsWindow);
 
 		const nameElements = this._treeElementsBySettingName.get(setting.key) ?? [];
 		nameElements.push(element);
@@ -986,7 +1010,7 @@ export class SearchResultModel extends SettingsTreeModel {
 		@IUserDataProfileService userDataProfileService: IUserDataProfileService,
 		@IProductService productService: IProductService
 	) {
-		super(viewState, isWorkspaceTrusted, configurationService, languageService, userDataProfileService, productService);
+		super(viewState, isWorkspaceTrusted, configurationService, languageService, userDataProfileService, productService, environmentService);
 		this.settingsOrderByTocIndex = settingsOrderByTocIndex;
 		this.cachedUniqueSearchResults = new Map();
 		this.update({ id: 'searchResultModel', label: '' });
@@ -1214,6 +1238,11 @@ export function parseQuery(query: string): IParsedQuery {
 
 	query = query.replace(`@${POLICY_SETTING_TAG}`, () => {
 		tags.push(POLICY_SETTING_TAG);
+		return '';
+	});
+
+	query = query.replace(`@${AGENTS_WINDOW_SETTING_TAG}`, () => {
+		tags.push(AGENTS_WINDOW_SETTING_TAG);
 		return '';
 	});
 

--- a/src/vs/workbench/contrib/preferences/common/preferences.ts
+++ b/src/vs/workbench/contrib/preferences/common/preferences.ts
@@ -105,6 +105,7 @@ export const ID_SETTING_TAG = 'id:';
 export const LANGUAGE_SETTING_TAG = 'lang:';
 export const GENERAL_TAG_SETTING_TAG = 'tag:';
 export const POLICY_SETTING_TAG = 'hasPolicy';
+export const AGENTS_WINDOW_SETTING_TAG = 'override:agentsWindow';
 export const WORKSPACE_TRUST_SETTING_TAG = 'workspaceTrust';
 export const REQUIRE_TRUSTED_WORKSPACE_SETTING_TAG = 'requireTrustedWorkspace';
 export const ADVANCED_SETTING_TAG = 'advanced';

--- a/src/vs/workbench/contrib/search/browser/search.contribution.ts
+++ b/src/vs/workbench/contrib/search/browser/search.contribution.ts
@@ -190,7 +190,8 @@ configurationRegistry.registerConfiguration({
 		'search.quickOpen.includeHistory': {
 			type: 'boolean',
 			description: nls.localize('search.quickOpen.includeHistory', "Whether to include results from recently opened files in the file results for Quick Open."),
-			default: true
+			default: true,
+			agentsWindow: { default: false },
 		},
 		'search.quickOpen.history.filterSortOrder': {
 			type: 'string',

--- a/src/vs/workbench/contrib/tasks/browser/task.contribution.ts
+++ b/src/vs/workbench/contrib/tasks/browser/task.contribution.ts
@@ -569,7 +569,8 @@ configurationRegistry.registerConfiguration({
 			type: 'integer',
 			markdownDescription: nls.localize('task.NotifyWindowOnTaskCompletion', 'Controls the minimum task runtime in milliseconds before showing an OS notification when the task finishes while the window is not in focus. Set to -1 to disable notifications. Set to 0 to always show notifications. This includes a window badge as well as notification toast.'),
 			default: 60000,
-			minimum: -1
+			minimum: -1,
+			agentsWindow: { default: -1 },
 		},
 		[TaskSettingId.VerboseLogging]: {
 			type: 'boolean',

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
@@ -88,7 +88,8 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 					value: localize('autoApproveMode.description', "Controls whether to allow auto approval in the run in terminal tool."),
 				}
 			}
-		}
+		},
+		agentsWindow: { default: true },
 	},
 	[TerminalChatAgentToolsSettingId.AutoApprove]: {
 		markdownDescription: [

--- a/src/vs/workbench/contrib/terminalContrib/inlineHint/common/terminalInitialHintConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/inlineHint/common/terminalInitialHintConfiguration.ts
@@ -18,7 +18,8 @@ export const terminalInitialHintConfiguration: IStringDictionary<IConfigurationP
 		restricted: true,
 		markdownDescription: localize('terminal.integrated.initialHint', "Controls if the first terminal without input will show a hint about available actions when it is focused. This will only show when {0} is disabled.", `\`#${TerminalSettingId.SendKeybindingsToShell}#\``),
 		type: 'boolean',
-		default: true
+		default: true,
+		agentsWindow: { default: false },
 	},
 	[TerminalInitialHintSettingId.CopilotCli]: {
 		restricted: true,

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
@@ -329,7 +329,8 @@ configurationRegistry.registerConfiguration({
 			],
 			'default': 'welcomePage',
 			'description': localize('workbench.startupEditor', "Controls which editor is shown at startup, if none are restored from the previous session."),
-			'experiment': { mode: 'auto' }
+			'experiment': { mode: 'auto' },
+			agentsWindow: { default: 'none', readOnly: true },
 		},
 		'workbench.welcomePage.preferReducedMotion': {
 			scope: ConfigurationScope.APPLICATION,

--- a/src/vs/workbench/electron-browser/desktop.contribution.ts
+++ b/src/vs/workbench/electron-browser/desktop.contribution.ts
@@ -284,13 +284,15 @@ import product from '../../platform/product/common/product.js';
 				'markdownDescription': isMacintosh ?
 					localize('window.menuStyle.mac', "Adjust the context menu appearances to either be native by the OS, custom, or inherited from the title bar style defined in {0}.", '`#window.titleBarStyle#`') :
 					localize('window.menuStyle', "Adjust the menu style to either be native by the OS, custom, or inherited from the title bar style defined in {0}. This also affects the context menu appearance. Changes require a full restart to apply.", '`#window.titleBarStyle#`'),
+				agentsWindow: { default: 'custom' },
 			},
 			'window.dialogStyle': {
 				'type': 'string',
 				'enum': ['native', 'custom'],
 				'default': 'native',
 				'scope': ConfigurationScope.APPLICATION,
-				'description': localize('dialogStyle', "Adjust the appearance of dialogs to be native by the OS or custom.")
+				'description': localize('dialogStyle', "Adjust the appearance of dialogs to be native by the OS or custom."),
+				agentsWindow: { default: 'custom' },
 			},
 			'window.nativeTabs': {
 				'type': 'boolean',

--- a/src/vscode-dts/vscode.proposed.agentsWindowConfiguration.d.ts
+++ b/src/vscode-dts/vscode.proposed.agentsWindowConfiguration.d.ts
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Empty module declaration — this proposed API enables the `agentsWindow`
+// property in `contributes.configuration` property schemas (package.json).
+// No TypeScript API surface is added.


### PR DESCRIPTION
## Summary

Introduces a new `agentsWindow` property on the `contributes.configuration` extension point, gated behind the `agentsWindowConfiguration` proposed API. This allows extensions to declare per-setting default value overrides and read-only behavior for the Agents window.

### Shape

```json
"myExtension.someSetting": {
  "type": "boolean",
  "default": true,
  "agentsWindow": {
    "default": false,
    "readOnly": true
  }
}
```

- **`default`** — Override the default value for this setting in the Agents window
- **`readOnly`** — When `true`, the setting cannot be changed by the user in the Agents window

### What's included

**Proposed API infrastructure:**
- `vscode.proposed.agentsWindowConfiguration.d.ts` — API proposal declaration
- `IConfigurationPropertySchema.agentsWindow` — Schema property on configuration registry
- Extension point validation gated behind `isProposedApiEnabled`
- `DefaultConfiguration.getDefaultValue()` hook for subclass override

**Sessions configuration service:**
- `SessionsDefaultConfiguration` — Overrides `getDefaultValue()` to use `agentsWindow.default`
- ReadOnly settings excluded from user configuration parsing via `ConfigurationParseOptions.exclude`
- `updateValue()` rejects writes to readOnly settings
- Dynamic tracking of readOnly keys as extensions load

**Settings editor:**
- ReadOnly settings shown disabled (like policy-managed) with indicator: *"🔒 Cannot be changed in Agents window"*
- `@override:agentsWindow` filter available in search box suggestions (agents window only)

**Adopted settings:**
- All existing hardcoded session defaults from `configuration.contribution.ts` migrated to use `agentsWindow.default` on their property schemas (~30 core settings + git/copilot extensions)
- Only 2 runtime-only settings remain as hardcoded default overrides

**Tests:**
- 7 new tests covering default overrides, readOnly enforcement, user config exclusion, and dynamic registration
