### PR TITLE
Fix stale BYOK models in model picker after API key removal

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -1178,8 +1178,16 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			.map(modelId => ({ identifier: modelId, metadata: this.languageModelsService.lookupLanguageModel(modelId)! }));
 
 		const contributedVendors = new Set(this.languageModelsService.getVendors().map(v => v.vendor));
-		const models = mergeModelsWithCache(liveModels, cachedModels, contributedVendors);
-		if (liveModels.length > 0) {
+		const resolvedVendors = new Set<string>();
+		for (const v of contributedVendors) {
+			if (this.languageModelsService.hasResolvedVendor(v)) {
+				resolvedVendors.add(v);
+			}
+		}
+		const models = mergeModelsWithCache(liveModels, cachedModels, contributedVendors, resolvedVendors);
+		// Persist whenever we have any authoritative information — either live
+		// models, or at least one resolved vendor (so cache eviction sticks).
+		if (liveModels.length > 0 || resolvedVendors.size > 0) {
 			this.storageService.store(CachedLanguageModelsKey, models, StorageScope.APPLICATION, StorageTarget.MACHINE);
 		}
 		return models;

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelSelectionLogic.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelSelectionLogic.ts
@@ -222,16 +222,15 @@ export function resolveModelFromSyncState(
 }
 
 /**
- * Merges live models with cached models per-vendor.
- * For vendors whose models have resolved, uses live data.
- * For vendors that are contributed but haven't resolved yet (startup race), keeps cached models.
- * Vendors no longer contributed are evicted from cache.
+ * Merges live models with cached models per-vendor, evicting cache for vendors
+ * no longer contributed.
  *
- * `resolvedVendors` lists vendors whose providers have completed at least one
- * resolution. Cached entries for those vendors are NOT used to bridge an empty
- * live result — an empty live result for a resolved vendor is authoritative
- * (e.g. user removed a BYOK provider group, so its models genuinely don't exist
- * anymore and should disappear from the picker).
+ * - `resolvedVendors`: vendors whose providers have produced at least one
+ *   result. An empty live list for these is authoritative (e.g. BYOK key
+ *   removed) and their cache entries are dropped.
+ * - When no contributor info is available yet and there are no live models
+ *   (startup / extension reload), the full cache is returned to avoid
+ *   flickering the picker to empty.
  */
 export function mergeModelsWithCache(
 	liveModels: ILanguageModelChatMetadataAndIdentifier[],
@@ -239,17 +238,15 @@ export function mergeModelsWithCache(
 	contributedVendors: Set<string>,
 	resolvedVendors?: ReadonlySet<string>,
 ): ILanguageModelChatMetadataAndIdentifier[] {
+	if (contributedVendors.size === 0 && liveModels.length === 0) {
+		return cachedModels;
+	}
 	const liveVendors = new Set(liveModels.map(m => m.metadata.vendor));
 	const usableCached = cachedModels.filter(m =>
 		contributedVendors.has(m.metadata.vendor) &&
 		!liveVendors.has(m.metadata.vendor) &&
-		!(resolvedVendors?.has(m.metadata.vendor))
+		!resolvedVendors?.has(m.metadata.vendor)
 	);
-	if (liveModels.length === 0 && !resolvedVendors) {
-		// Backwards-compat path: no resolution info, keep prior behavior of
-		// returning the entire cache during a global startup race.
-		return cachedModels;
-	}
 	return [...liveModels, ...usableCached];
 }
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelSelectionLogic.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelSelectionLogic.ts
@@ -226,20 +226,31 @@ export function resolveModelFromSyncState(
  * For vendors whose models have resolved, uses live data.
  * For vendors that are contributed but haven't resolved yet (startup race), keeps cached models.
  * Vendors no longer contributed are evicted from cache.
+ *
+ * `resolvedVendors` lists vendors whose providers have completed at least one
+ * resolution. Cached entries for those vendors are NOT used to bridge an empty
+ * live result — an empty live result for a resolved vendor is authoritative
+ * (e.g. user removed a BYOK provider group, so its models genuinely don't exist
+ * anymore and should disappear from the picker).
  */
 export function mergeModelsWithCache(
 	liveModels: ILanguageModelChatMetadataAndIdentifier[],
 	cachedModels: ILanguageModelChatMetadataAndIdentifier[],
 	contributedVendors: Set<string>,
+	resolvedVendors?: ReadonlySet<string>,
 ): ILanguageModelChatMetadataAndIdentifier[] {
-	if (liveModels.length > 0) {
-		const liveVendors = new Set(liveModels.map(m => m.metadata.vendor));
-		return [
-			...liveModels,
-			...cachedModels.filter(m => !liveVendors.has(m.metadata.vendor) && contributedVendors.has(m.metadata.vendor)),
-		];
+	const liveVendors = new Set(liveModels.map(m => m.metadata.vendor));
+	const usableCached = cachedModels.filter(m =>
+		contributedVendors.has(m.metadata.vendor) &&
+		!liveVendors.has(m.metadata.vendor) &&
+		!(resolvedVendors?.has(m.metadata.vendor))
+	);
+	if (liveModels.length === 0 && !resolvedVendors) {
+		// Backwards-compat path: no resolution info, keep prior behavior of
+		// returning the entire cache during a global startup race.
+		return cachedModels;
 	}
-	return cachedModels;
+	return [...liveModels, ...usableCached];
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/common/languageModels.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModels.ts
@@ -372,6 +372,14 @@ export interface ILanguageModelsService {
 	getLanguageModelGroups(vendor: string): ILanguageModelsGroup[];
 
 	/**
+	 * Returns true if the given vendor's provider has completed at least one
+	 * model resolution since registration. A `false` result indicates the
+	 * vendor is still in a startup/reload race where its model list isn't yet
+	 * authoritative — callers can fall back to a cached list in that case.
+	 */
+	hasResolvedVendor(vendor: string): boolean;
+
+	/**
 	 * Given a selector, returns a list of model identifiers
 	 * @param selector The selector to lookup for language models. If the selector is empty, all language models are returned.
 	 */
@@ -695,6 +703,7 @@ export class LanguageModelsService implements ILanguageModelsService {
 			this._vendors.delete(item.vendor);
 			this._providers.delete(item.vendor);
 			this._clearModelCache(item.vendor);
+			this._modelsGroups.delete(item.vendor);
 			removedVendorIds.push(item.vendor);
 		}
 
@@ -1006,6 +1015,10 @@ export class LanguageModelsService implements ILanguageModelsService {
 		return this._modelsGroups.get(vendor) ?? [];
 	}
 
+	hasResolvedVendor(vendor: string): boolean {
+		return this._modelsGroups.has(vendor);
+	}
+
 	async selectLanguageModels(selector: ILanguageModelChatSelector): Promise<string[]> {
 
 		if (selector.vendor) {
@@ -1054,6 +1067,7 @@ export class LanguageModelsService implements ILanguageModelsService {
 		return toDisposable(() => {
 			this._logService.trace('[LM] UNregistered language model provider', vendor);
 			this._clearModelCache(vendor);
+			this._modelsGroups.delete(vendor);
 			this._providers.delete(vendor);
 			modelChangeListener.dispose();
 		});

--- a/src/vs/workbench/contrib/chat/test/browser/chatManagement/chatModelsViewModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatManagement/chatModelsViewModel.test.ts
@@ -148,6 +148,10 @@ class MockLanguageModelsService implements ILanguageModelsService {
 		return this.modelGroups.get(vendor) || [];
 	}
 
+	hasResolvedVendor(vendor: string): boolean {
+		return this.modelGroups.has(vendor);
+	}
+
 	async removeLanguageModelsProviderGroup(vendorId: string, providerGroupName: string): Promise<void> {
 	}
 

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelSelectionLogic.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelSelectionLogic.test.ts
@@ -640,6 +640,51 @@ suite('ChatModelSelectionLogic', () => {
 			assert.strictEqual(result.length, 2);
 			assert.deepStrictEqual(result.map(m => m.metadata.vendor).sort(), ['vendor-a', 'vendor-b']);
 		});
+
+		test('evicts cached entries for a resolved vendor that returned zero models (BYOK delete)', () => {
+			// vendor-a is resolved with one live model; vendor-b is resolved with no live models
+			// (e.g. the user removed their BYOK API key). Cached vendor-b entries must NOT
+			// resurrect those models in the picker.
+			const liveA = createModel('a-model', 'A Model', { vendor: 'vendor-a' });
+			const staleB = createModel('b-model', 'B Model', { vendor: 'vendor-b' });
+			const result = mergeModelsWithCache(
+				[liveA],
+				[staleB],
+				new Set(['vendor-a', 'vendor-b']),
+				new Set(['vendor-a', 'vendor-b']),
+			);
+			assert.strictEqual(result.length, 1);
+			assert.strictEqual(result[0].metadata.vendor, 'vendor-a');
+		});
+
+		test('keeps cached entries for an unresolved vendor (extension reload race)', () => {
+			// vendor-b is contributed but its provider hasn't completed a resolution yet
+			// (e.g. extension is mid-reload). Cache must bridge the gap so the picker
+			// keeps showing the user's previously-seen models.
+			const liveA = createModel('a-model', 'A Model', { vendor: 'vendor-a' });
+			const cachedB = createModel('b-model', 'B Model', { vendor: 'vendor-b' });
+			const result = mergeModelsWithCache(
+				[liveA],
+				[cachedB],
+				new Set(['vendor-a', 'vendor-b']),
+				new Set(['vendor-a']), // vendor-b not yet resolved
+			);
+			assert.strictEqual(result.length, 2);
+			assert.deepStrictEqual(result.map(m => m.metadata.vendor).sort(), ['vendor-a', 'vendor-b']);
+		});
+
+		test('evicts cache for a resolved vendor even when all live models are zero', () => {
+			// Edge case: the only resolved vendor returns zero models (user deleted all
+			// configurations). Cache must be ignored — the picker should be empty.
+			const stale = createModel('b-model', 'B Model', { vendor: 'vendor-b' });
+			const result = mergeModelsWithCache(
+				[],
+				[stale],
+				new Set(['vendor-b']),
+				new Set(['vendor-b']),
+			);
+			assert.strictEqual(result.length, 0);
+		});
 	});
 
 	suite('model switching scenarios', () => {

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelSelectionLogic.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelSelectionLogic.test.ts
@@ -34,8 +34,9 @@ function computeAvailableModels(
 	sessionType: string | undefined,
 	currentModeKind: ChatModeKind,
 	location: ChatAgentLocation,
+	resolvedVendors?: ReadonlySet<string>,
 ): ILanguageModelChatMetadataAndIdentifier[] {
-	const merged = mergeModelsWithCache(liveModels, cachedModels, contributedVendors);
+	const merged = mergeModelsWithCache(liveModels, cachedModels, contributedVendors, resolvedVendors);
 	merged.sort((a, b) => a.metadata.name.localeCompare(b.metadata.name));
 	return filterModelsForSession(merged, sessionType, currentModeKind, location);
 }
@@ -685,6 +686,22 @@ suite('ChatModelSelectionLogic', () => {
 			);
 			assert.strictEqual(result.length, 0);
 		});
+
+		test('preserves full cache when no vendors are contributed yet (startup race)', () => {
+			// During startup or an extension reload, vendor descriptors may not be
+			// registered yet. contributedVendors is empty and so is resolvedVendors.
+			// We must NOT drop the cache — that would reset the user's selected model
+			// before the vendors come back.
+			const cachedA = createModel('a-model', 'A Model', { vendor: 'vendor-a' });
+			const cachedB = createModel('b-model', 'B Model', { vendor: 'vendor-b' });
+			const result = mergeModelsWithCache(
+				[],
+				[cachedA, cachedB],
+				new Set(),
+				new Set(),
+			);
+			assert.deepStrictEqual(result.map(m => m.metadata.id).sort(), ['a-model', 'b-model']);
+		});
 	});
 
 	suite('model switching scenarios', () => {
@@ -1090,6 +1107,25 @@ suite('ChatModelSelectionLogic', () => {
 				ChatAgentLocation.Chat,
 			);
 			assert.deepStrictEqual(result.map(m => m.metadata.id), ['tool']);
+		});
+
+		test('startup/extension reload with no contributors yet preserves cache (production path)', () => {
+			// Mirrors chatInputPart.getAllMergedModels at a moment when getVendors()
+			// is temporarily empty (extension host reloading). resolvedVendors is
+			// also empty because nothing has resolved. The picker must continue to
+			// show cached models so the user's selection isn't reset.
+			const cachedA = createModel('a-model', 'A Model', { vendor: 'vendor-a' });
+			const cachedB = createModel('b-model', 'B Model', { vendor: 'vendor-b' });
+			const result = computeAvailableModels(
+				[],
+				[cachedA, cachedB],
+				new Set(),
+				undefined,
+				ChatModeKind.Ask,
+				ChatAgentLocation.Chat,
+				new Set(),
+			);
+			assert.deepStrictEqual(result.map(m => m.metadata.id).sort(), ['a-model', 'b-model']);
 		});
 	});
 

--- a/src/vs/workbench/contrib/chat/test/common/languageModels.ts
+++ b/src/vs/workbench/contrib/chat/test/common/languageModels.ts
@@ -63,6 +63,10 @@ export class NullLanguageModelsService implements ILanguageModelsService {
 		return [];
 	}
 
+	hasResolvedVendor(vendor: string): boolean {
+		return false;
+	}
+
 	async selectLanguageModels(selector: ILanguageModelChatSelector): Promise<string[]> {
 		return [];
 	}


### PR DESCRIPTION
Fixes #312190, #265048, #265386.


When a BYOK provider's API key/config was removed, the model picker continued to show the deleted models because mergeModelsWithCache could not distinguish between two cases:

1. A vendor that hadn't been resolved yet (startup race / extension reload) — cache should be used.
2. A vendor that resolved with zero models (BYOK key deleted) — cache should be evicted.\

Both looked identical to the merge logic (no live models for that vendor), so stale cached entries were kept and the currently-selected model was never reset.