### PR TITLE
Fix custom diff editor restore and custom names

### DIFF
--- a/src/vs/workbench/contrib/customEditor/browser/customEditor.contribution.ts
+++ b/src/vs/workbench/contrib/customEditor/browser/customEditor.contribution.ts
@@ -9,10 +9,11 @@ import { Registry } from '../../../../platform/registry/common/platform.js';
 import { EditorPaneDescriptor, IEditorPaneRegistry } from '../../../browser/editor.js';
 import { WorkbenchPhase, registerWorkbenchContribution2 } from '../../../common/contributions.js';
 import { EditorExtensions, IEditorFactoryRegistry } from '../../../common/editor.js';
-import { ComplexCustomWorkingCopyEditorHandler, CustomEditorInputSerializer } from './customEditorInputFactory.js';
+import { ComplexCustomWorkingCopyEditorHandler, CustomEditorDiffInputSerializer, CustomEditorInputSerializer, CustomEditorSideBySideDiffInputSerializer } from './customEditorInputFactory.js';
 import { ICustomEditorService } from '../common/customEditor.js';
 import { WebviewEditor } from '../../webviewPanel/browser/webviewEditor.js';
 import { CustomEditorInput } from './customEditorInput.js';
+import { CustomEditorDiffInput, CustomEditorSideBySideDiffInput } from './customEditorDiffInput.js';
 import { CustomEditorService } from './customEditors.js';
 
 registerSingleton(ICustomEditorService, CustomEditorService, InstantiationType.Delayed);
@@ -24,10 +25,18 @@ Registry.as<IEditorPaneRegistry>(EditorExtensions.EditorPane)
 			WebviewEditor.ID,
 			'Webview Editor',
 		), [
-		new SyncDescriptor(CustomEditorInput)
+		new SyncDescriptor(CustomEditorInput),
+		new SyncDescriptor(CustomEditorDiffInput),
+		new SyncDescriptor(CustomEditorSideBySideDiffInput),
 	]);
 
 Registry.as<IEditorFactoryRegistry>(EditorExtensions.EditorFactory)
 	.registerEditorSerializer(CustomEditorInputSerializer.ID, CustomEditorInputSerializer);
+
+Registry.as<IEditorFactoryRegistry>(EditorExtensions.EditorFactory)
+	.registerEditorSerializer(CustomEditorDiffInputSerializer.ID, CustomEditorDiffInputSerializer);
+
+Registry.as<IEditorFactoryRegistry>(EditorExtensions.EditorFactory)
+	.registerEditorSerializer(CustomEditorSideBySideDiffInputSerializer.ID, CustomEditorSideBySideDiffInputSerializer);
 
 registerWorkbenchContribution2(ComplexCustomWorkingCopyEditorHandler.ID, ComplexCustomWorkingCopyEditorHandler, WorkbenchPhase.BlockStartup);

--- a/src/vs/workbench/contrib/customEditor/browser/customEditorInput.ts
+++ b/src/vs/workbench/contrib/customEditor/browser/customEditorInput.ts
@@ -39,6 +39,7 @@ interface CustomEditorInputInitInfo {
 	readonly resource: URI;
 	readonly viewType: string;
 	readonly webviewTitle: string | undefined;
+	readonly preferredName: string | undefined;
 	readonly iconPath: WebviewIconPath | undefined;
 }
 
@@ -109,7 +110,7 @@ export class CustomEditorInput extends LazilyResolvedWebviewEditorInput {
 		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
 		@ICustomEditorLabelService private readonly customEditorLabelService: ICustomEditorLabelService,
 	) {
-		super({ providedId: init.viewType, viewType: init.viewType, name: '', iconPath: init.iconPath }, webview, themeService, webviewWorkbenchService);
+		super({ providedId: init.viewType, viewType: init.viewType, name: init.preferredName ?? '', iconPath: init.iconPath }, webview, themeService, webviewWorkbenchService);
 		this._editorResource = init.resource;
 		this.oldResource = options.oldResource;
 		this._defaultDirtyState = options.startsDirty;
@@ -166,14 +167,8 @@ export class CustomEditorInput extends LazilyResolvedWebviewEditorInput {
 			capabilities |= EditorInputCapabilities.Singleton;
 		}
 
-		if (this._modelRef) {
-			if (this._modelRef.object.isReadonly()) {
-				capabilities |= EditorInputCapabilities.Readonly;
-			}
-		} else {
-			if (this.filesConfigurationService.isReadonly(this.resource)) {
-				capabilities |= EditorInputCapabilities.Readonly;
-			}
+		if (this.isReadonly()) {
+			capabilities |= EditorInputCapabilities.Readonly;
 		}
 
 		if (this.resource.scheme === Schemas.untitled) {
@@ -269,7 +264,7 @@ export class CustomEditorInput extends LazilyResolvedWebviewEditorInput {
 
 	public override copy(): EditorInput {
 		return CustomEditorInput.create(this.instantiationService,
-			{ resource: this.resource, viewType: this.viewType, webviewTitle: this.getWebviewTitle(), iconPath: this.iconPath, },
+			{ resource: this.resource, viewType: this.viewType, webviewTitle: this.getWebviewTitle(), preferredName: undefined, iconPath: this.iconPath, },
 			this.group,
 			this.webview.options);
 	}

--- a/src/vs/workbench/contrib/customEditor/browser/customEditorInputFactory.ts
+++ b/src/vs/workbench/contrib/customEditor/browser/customEditorInputFactory.ts
@@ -9,8 +9,10 @@ import { isEqual } from '../../../../base/common/resources.js';
 import { URI, UriComponents } from '../../../../base/common/uri.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IWorkbenchContribution } from '../../../common/contributions.js';
+import { IEditorSerializer } from '../../../common/editor.js';
 import { EditorInput } from '../../../common/editor/editorInput.js';
 import { CustomEditorInput } from './customEditorInput.js';
+import { CustomEditorDiffInput, CustomEditorSideBySideDiffInput, CustomEditorSideBySideDiffSide } from './customEditorDiffInput.js';
 import { ICustomEditorService } from '../common/customEditor.js';
 import { NotebookEditorInput } from '../../notebook/common/notebookEditorInput.js';
 import { IWebviewService, WebviewContentOptions, WebviewContentPurpose, WebviewExtensionDescription, WebviewOptions } from '../../webview/browser/webview.js';
@@ -101,12 +103,113 @@ export class CustomEditorInputSerializer extends WebviewEditorInputSerializer {
 			resource: data.editorResource,
 			viewType: data.viewType,
 			webviewTitle: data.title,
+			preferredName: undefined,
 			iconPath: data.iconPath,
 		}, webview, { startsDirty: data.dirty, backupId: data.backupId });
 		if (typeof data.group === 'number') {
 			customInput.updateGroup(data.group);
 		}
 		return customInput;
+	}
+}
+
+interface SerializedCustomEditorDiff {
+	readonly originalResource: UriComponents;
+	readonly modifiedResource: UriComponents;
+	readonly viewType: string;
+	readonly label: string | undefined;
+	readonly description: string | undefined;
+	readonly dirty: boolean;
+}
+
+export class CustomEditorDiffInputSerializer implements IEditorSerializer {
+
+	public static readonly ID = CustomEditorDiffInput.typeId;
+
+	public constructor(
+		@IInstantiationService private readonly _instantiationService: IInstantiationService,
+	) { }
+
+	canSerialize(input: EditorInput): boolean {
+		return input instanceof CustomEditorDiffInput;
+	}
+
+	serialize(input: CustomEditorDiffInput): string | undefined {
+		const data: SerializedCustomEditorDiff = {
+			originalResource: input.originalResource.toJSON(),
+			modifiedResource: input.modifiedResource.toJSON(),
+			viewType: input.viewType,
+			label: input.getName(),
+			description: input.getDescription(),
+			dirty: input.isDirty(),
+		};
+		try {
+			return JSON.stringify(data);
+		} catch {
+			return undefined;
+		}
+	}
+
+	deserialize(_instantiationService: IInstantiationService, serializedEditorInput: string): EditorInput {
+		const data: SerializedCustomEditorDiff = JSON.parse(serializedEditorInput);
+		return CustomEditorDiffInput.create(this._instantiationService, {
+			originalResource: URI.revive(data.originalResource),
+			modifiedResource: URI.revive(data.modifiedResource),
+			viewType: data.viewType,
+			label: data.label,
+			description: data.description,
+			iconPath: undefined,
+		}, undefined);
+	}
+}
+
+interface SerializedCustomEditorSideBySideDiff extends SerializedCustomEditorDiff {
+	readonly diffId: string;
+	readonly side: CustomEditorSideBySideDiffSide;
+}
+
+export class CustomEditorSideBySideDiffInputSerializer implements IEditorSerializer {
+
+	public static readonly ID = CustomEditorSideBySideDiffInput.typeId;
+
+	public constructor(
+		@IInstantiationService private readonly _instantiationService: IInstantiationService,
+	) { }
+
+	canSerialize(input: EditorInput): boolean {
+		return input instanceof CustomEditorSideBySideDiffInput;
+	}
+
+	serialize(input: CustomEditorSideBySideDiffInput): string | undefined {
+		const data: SerializedCustomEditorSideBySideDiff = {
+			originalResource: input.originalResource.toJSON(),
+			modifiedResource: input.modifiedResource.toJSON(),
+			viewType: input.viewType,
+			label: input.getName(),
+			description: input.getDescription(),
+			dirty: input.isDirty(),
+			diffId: input.diffId,
+			side: input.side,
+		};
+		try {
+			return JSON.stringify(data);
+		} catch {
+			return undefined;
+		}
+	}
+
+	deserialize(_instantiationService: IInstantiationService, serializedEditorInput: string): EditorInput {
+		const data: SerializedCustomEditorSideBySideDiff = JSON.parse(serializedEditorInput);
+		return CustomEditorSideBySideDiffInput.create(this._instantiationService, {
+			originalResource: URI.revive(data.originalResource),
+			modifiedResource: URI.revive(data.modifiedResource),
+			viewType: data.viewType,
+			label: data.label,
+			description: data.description,
+			iconPath: undefined,
+			diffId: data.diffId,
+			side: data.side,
+		}, undefined);
 	}
 }
 
@@ -202,6 +305,7 @@ export class ComplexCustomWorkingCopyEditorHandler extends Disposable implements
 			resource: URI.revive(backupData.editorResource),
 			viewType: backupData.viewType,
 			webviewTitle: backupData.customTitle,
+			preferredName: undefined,
 			iconPath: reviveWebviewIconPath(backupData.iconPath)
 		}, webview, { backupId: backupData.backupId });
 		editor.updateGroup(0);

--- a/src/vs/workbench/contrib/customEditor/browser/customEditors.ts
+++ b/src/vs/workbench/contrib/customEditor/browser/customEditors.ts
@@ -182,11 +182,11 @@ export class CustomEditorService extends Disposable implements ICustomEditorServ
 						singlePerResource: () => !(this.getCustomEditorCapabilities(contributedEditor.id)?.supportsMultipleEditorsPerDocument ?? false)
 					},
 					{
-						createEditorInput: ({ resource }, group) => {
-							return { editor: CustomEditorInput.create(this.instantiationService, { resource, viewType: contributedEditor.id, webviewTitle: undefined, iconPath: undefined }, group.id) };
+						createEditorInput: ({ resource, label }, group) => {
+							return { editor: CustomEditorInput.create(this.instantiationService, { resource, viewType: contributedEditor.id, webviewTitle: undefined, preferredName: label, iconPath: undefined }, group.id) };
 						},
 						createUntitledEditorInput: ({ resource }, group) => {
-							return { editor: CustomEditorInput.create(this.instantiationService, { resource: resource ?? URI.from({ scheme: Schemas.untitled, authority: `Untitled-${this._untitledCounter++}` }), viewType: contributedEditor.id, webviewTitle: undefined, iconPath: undefined }, group.id) };
+							return { editor: CustomEditorInput.create(this.instantiationService, { resource: resource ?? URI.from({ scheme: Schemas.untitled, authority: `Untitled-${this._untitledCounter++}` }), viewType: contributedEditor.id, webviewTitle: undefined, preferredName: undefined, iconPath: undefined }, group.id) };
 						},
 						createDiffEditorInput: async (diffEditorInput, group) => {
 							await this.extensionService.activateByEvent(`onCustomEditor:${contributedEditor.id}`);
@@ -243,8 +243,8 @@ export class CustomEditorService extends Disposable implements ICustomEditorServ
 			return this.instantiationService.createInstance(DiffEditorInput, editor.label, editor.description, originalOverride, modifiedOverride, true);
 		}
 
-		const modifiedOverride = CustomEditorInput.create(this.instantiationService, { resource: modifiedResource, viewType: contributedEditor.id, webviewTitle: undefined, iconPath: undefined }, group.id, { customClasses: 'modified' });
-		const originalOverride = CustomEditorInput.create(this.instantiationService, { resource: originalResource, viewType: contributedEditor.id, webviewTitle: undefined, iconPath: undefined }, group.id, { customClasses: 'original' });
+		const modifiedOverride = CustomEditorInput.create(this.instantiationService, { resource: modifiedResource, viewType: contributedEditor.id, webviewTitle: undefined, preferredName: undefined, iconPath: undefined }, group.id, { customClasses: 'modified' });
+		const originalOverride = CustomEditorInput.create(this.instantiationService, { resource: originalResource, viewType: contributedEditor.id, webviewTitle: undefined, preferredName: undefined, iconPath: undefined }, group.id, { customClasses: 'original' });
 		return this.instantiationService.createInstance(DiffEditorInput, editor.label, editor.description, originalOverride, modifiedOverride, true);
 	}
 
@@ -437,7 +437,7 @@ export class CustomEditorService extends Disposable implements ICustomEditorServ
 				let replacement: EditorInput | IResourceEditorInput;
 				if (possibleEditors.defaultEditor) {
 					const viewType = possibleEditors.defaultEditor.id;
-					replacement = CustomEditorInput.create(this.instantiationService, { resource: newResource, viewType, webviewTitle: undefined, iconPath: undefined }, group);
+					replacement = CustomEditorInput.create(this.instantiationService, { resource: newResource, viewType, webviewTitle: undefined, preferredName: undefined, iconPath: undefined }, group);
 				} else {
 					replacement = { resource: newResource, options: { override: DEFAULT_EDITOR_ASSOCIATION.id } };
 				}


### PR DESCRIPTION
For #315174

Make sure that custom diff editors show custom names such as the `(Indexed)` title that git provides

Also makes sure custom diff editors are restored on reload by creating serializers for them

