### PR TITLE
Disable doubleClickToSwitchToEditor and markEditorSelection by default

### DIFF
--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -741,7 +741,7 @@
           },
           "markdown.preview.markEditorSelection": {
             "type": "boolean",
-            "default": true,
+            "default": false,
             "description": "%markdown.preview.markEditorSelection.desc%",
             "scope": "resource"
           },
@@ -753,7 +753,7 @@
           },
           "markdown.preview.doubleClickToSwitchToEditor": {
             "type": "boolean",
-            "default": true,
+            "default": false,
             "description": "%markdown.preview.doubleClickToSwitchToEditor.desc%",
             "scope": "resource"
           },


### PR DESCRIPTION
For #315174
Fixes #314587
