### PR TITLE
sessions: enable Search Editor and Problems panel in Agents window

### DIFF
--- a/src/vs/sessions/browser/parts/media/panelPart.css
+++ b/src/vs/sessions/browser/parts/media/panelPart.css
@@ -62,6 +62,10 @@
 	background: var(--vscode-agentsPanel-background) !important;
 }
 
+.agent-sessions-workbench .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact .badge-content {
+	top: 11px;
+}
+
 /* Terminal body background */
 .agent-sessions-workbench .part.panel .terminal-wrapper {
 	background-color: var(--vscode-agentsPanel-background);

--- a/src/vs/sessions/contrib/search/browser/search.contribution.ts
+++ b/src/vs/sessions/contrib/search/browser/search.contribution.ts
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
+import { KeybindingWeight, KeybindingsRegistry } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
+import { OpenEditorCommandId } from '../../../../workbench/contrib/searchEditor/browser/constants.js';
+
+KeybindingsRegistry.registerKeybindingRule({
+	id: OpenEditorCommandId,
+	primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyF,
+	weight: KeybindingWeight.WorkbenchContrib,
+});

--- a/src/vs/sessions/sessions.common.main.ts
+++ b/src/vs/sessions/sessions.common.main.ts
@@ -251,6 +251,11 @@ import '../workbench/contrib/inlineCompletions/browser/renameSymbolTrackerServic
 // Search Quick Access (file picker only, not the full search contribution)
 import '../workbench/contrib/search/browser/searchQuickAccess.contribution.js';
 
+// Search Editor
+import '../workbench/contrib/searchEditor/browser/searchEditor.contribution.js';
+import '../workbench/contrib/search/browser/search.common.contribution.js';
+import './contrib/search/browser/search.contribution.js';
+
 // Sash
 import '../workbench/contrib/sash/browser/sash.contribution.js';
 
@@ -303,6 +308,9 @@ registerSingleton(IExtensionsWorkbenchService, ExtensionsWorkbenchService, Insta
 // Output View
 import '../workbench/contrib/output/browser/output.contribution.js';
 import '../workbench/contrib/output/browser/outputView.js';
+
+// Problems View
+import '../workbench/contrib/markers/browser/markers.contribution.js';
 
 // Terminal
 import '../workbench/contrib/terminal/terminal.all.js';

--- a/src/vs/workbench/contrib/markers/browser/markers.contribution.ts
+++ b/src/vs/workbench/contrib/markers/browser/markers.contribution.ts
@@ -23,7 +23,7 @@ import { IClipboardService } from '../../../../platform/clipboard/common/clipboa
 import { Disposable, IDisposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { IStatusbarEntryAccessor, IStatusbarService, StatusbarAlignment, IStatusbarEntry } from '../../../services/statusbar/browser/statusbar.js';
 import { IMarkerService, MarkerStatistics } from '../../../../platform/markers/common/markers.js';
-import { ViewContainer, IViewContainersRegistry, Extensions as ViewContainerExtensions, ViewContainerLocation, IViewsRegistry } from '../../../common/views.js';
+import { ViewContainer, IViewContainersRegistry, Extensions as ViewContainerExtensions, ViewContainerLocation, IViewsRegistry, WindowEnablement } from '../../../common/views.js';
 import { IViewsService } from '../../../services/views/common/viewsService.js';
 import { getVisbileViewContextKey, FocusedViewContext } from '../../../common/contextkeys.js';
 import { ViewPaneContainer } from '../../../browser/parts/views/viewPaneContainer.js';
@@ -137,6 +137,7 @@ const VIEW_CONTAINER: ViewContainer = Registry.as<IViewContainersRegistry>(ViewC
 	order: 0,
 	ctorDescriptor: new SyncDescriptor(ViewPaneContainer, [Markers.MARKERS_CONTAINER_ID, { mergeViewWithContainerWhenSingleView: true }]),
 	storageId: Markers.MARKERS_VIEW_STORAGE_ID,
+	windowEnablement: WindowEnablement.Both
 }, ViewContainerLocation.Panel, { doNotRegisterOpenCommand: true });
 
 Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).registerViews([{
@@ -151,7 +152,8 @@ Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).registerViews
 		mnemonicTitle: localize({ key: 'miMarker', comment: ['&& denotes a mnemonic'] }, "&&Problems"),
 		keybindings: { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyM },
 		order: 0,
-	}
+	},
+	windowEnablement: WindowEnablement.Both
 }], VIEW_CONTAINER);
 
 // workbench

--- a/src/vs/workbench/contrib/search/browser/search.common.contribution.ts
+++ b/src/vs/workbench/contrib/search/browser/search.common.contribution.ts
@@ -1,0 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Common search service registrations shared between the main workbench and the Agents window.
+
+import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { registerContributions as replaceContributions } from './replaceContributions.js';
+import { registerContributions as notebookSearchContributions } from './notebookSearch/notebookSearchContributions.js';
+import { ISearchHistoryService, SearchHistoryService } from '../common/searchHistoryService.js';
+
+replaceContributions();
+notebookSearchContributions();
+registerSingleton(ISearchHistoryService, SearchHistoryService, InstantiationType.Delayed);

--- a/src/vs/workbench/contrib/search/browser/search.contribution.ts
+++ b/src/vs/workbench/contrib/search/browser/search.contribution.ts
@@ -14,12 +14,9 @@ import { Extensions as QuickAccessExtensions, IQuickAccessRegistry } from '../..
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { ViewPaneContainer } from '../../../browser/parts/views/viewPaneContainer.js';
 import { Extensions as ViewExtensions, IViewContainersRegistry, IViewDescriptor, IViewsRegistry, ViewContainerLocation } from '../../../common/views.js';
-import { registerContributions as replaceContributions } from './replaceContributions.js';
-import { registerContributions as notebookSearchContributions } from './notebookSearch/notebookSearchContributions.js';
 import { searchViewIcon } from './searchIcons.js';
 import { SearchView } from './searchView.js';
 import { registerContributions as searchWidgetContributions } from './searchWidget.js';
-import { ISearchHistoryService, SearchHistoryService } from '../common/searchHistoryService.js';
 import { SearchViewModelWorkbenchService } from './searchTreeModel/searchModel.js';
 import { ISearchViewModelWorkbenchService } from './searchTreeModel/searchViewModelWorkbenchService.js';
 import { SearchSortOrder, SEARCH_EXCLUDE_CONFIG, VIEWLET_ID, ViewMode, VIEW_ID, DEFAULT_MAX_SEARCH_RESULTS, SemanticSearchBehavior } from '../../../services/search/common/search.js';
@@ -36,6 +33,7 @@ import './searchActionsRemoveReplace.js';
 import './searchActionsTopBar.js';
 import './searchActionsTextQuickAccess.js';
 import './searchQuickAccess.contribution.js';
+import './search.common.contribution.js';
 import { TEXT_SEARCH_QUICK_ACCESS_PREFIX, TextSearchQuickAccess } from './quickTextSearch/textSearchQuickAccess.js';
 import { Extensions, IConfigurationMigrationRegistry } from '../../../common/configuration.js';
 import { registerWorkbenchContribution2, WorkbenchPhase } from '../../../common/contributions.js';
@@ -43,10 +41,7 @@ import { AccessibleViewRegistry } from '../../../../platform/accessibility/brows
 import { SearchAccessibilityHelp } from './searchAccessibilityHelp.js';
 
 registerSingleton(ISearchViewModelWorkbenchService, SearchViewModelWorkbenchService, InstantiationType.Delayed);
-registerSingleton(ISearchHistoryService, SearchHistoryService, InstantiationType.Delayed);
 
-replaceContributions();
-notebookSearchContributions();
 searchWidgetContributions();
 
 registerWorkbenchContribution2(SearchChatContextContribution.ID, SearchChatContextContribution, WorkbenchPhase.AfterRestored);
@@ -286,42 +281,6 @@ configurationRegistry.registerConfiguration({
 			type: 'number',
 			default: 300,
 			markdownDescription: nls.localize('search.searchOnTypeDebouncePeriod', "When {0} is enabled, controls the timeout in milliseconds between a character being typed and the search starting. Has no effect when {0} is disabled.", '`#search.searchOnType#`')
-		},
-		'search.searchEditor.doubleClickBehaviour': {
-			type: 'string',
-			enum: ['selectWord', 'goToLocation', 'openLocationToSide'],
-			default: 'goToLocation',
-			enumDescriptions: [
-				nls.localize('search.searchEditor.doubleClickBehaviour.selectWord', "Double-clicking selects the word under the cursor."),
-				nls.localize('search.searchEditor.doubleClickBehaviour.goToLocation', "Double-clicking opens the result in the active editor group."),
-				nls.localize('search.searchEditor.doubleClickBehaviour.openLocationToSide', "Double-clicking opens the result in the editor group to the side, creating one if it does not yet exist."),
-			],
-			markdownDescription: nls.localize('search.searchEditor.doubleClickBehaviour', "Configure effect of double-clicking a result in a search editor.")
-		},
-		'search.searchEditor.singleClickBehaviour': {
-			type: 'string',
-			enum: ['default', 'peekDefinition',],
-			default: 'default',
-			enumDescriptions: [
-				nls.localize('search.searchEditor.singleClickBehaviour.default', "Single-clicking does nothing."),
-				nls.localize('search.searchEditor.singleClickBehaviour.peekDefinition', "Single-clicking opens a Peek Definition window."),
-			],
-			markdownDescription: nls.localize('search.searchEditor.singleClickBehaviour', "Configure effect of single-clicking a result in a search editor.")
-		},
-		'search.searchEditor.reusePriorSearchConfiguration': {
-			type: 'boolean',
-			default: false,
-			markdownDescription: nls.localize({ key: 'search.searchEditor.reusePriorSearchConfiguration', comment: ['"Search Editor" is a type of editor that can display search results. "includes, excludes, and flags" refers to the "files to include" and "files to exclude" input boxes, and the flags that control whether a query is case-sensitive or a regex.'] }, "When enabled, new Search Editors will reuse the includes, excludes, and flags of the previously opened Search Editor.")
-		},
-		'search.searchEditor.defaultNumberOfContextLines': {
-			type: ['number', 'null'],
-			default: 1,
-			markdownDescription: nls.localize('search.searchEditor.defaultNumberOfContextLines', "The default number of surrounding context lines to use when creating new Search Editors. If using `#search.searchEditor.reusePriorSearchConfiguration#`, this can be set to `null` (empty) to use the prior Search Editor's configuration.")
-		},
-		'search.searchEditor.focusResultsOnSearch': {
-			type: 'boolean',
-			default: false,
-			markdownDescription: nls.localize('search.searchEditor.focusResultsOnSearch', "When a search is triggered, focus the Search Editor results instead of the Search Editor input.")
 		},
 		'search.sortOrder': {
 			type: 'string',

--- a/src/vs/workbench/contrib/searchEditor/browser/searchEditor.contribution.ts
+++ b/src/vs/workbench/contrib/searchEditor/browser/searchEditor.contribution.ts
@@ -37,6 +37,8 @@ import { Disposable } from '../../../../base/common/lifecycle.js';
 import { IWorkingCopyIdentifier } from '../../../services/workingCopy/common/workingCopy.js';
 import { EditorInput } from '../../../common/editor/editorInput.js';
 import { getActiveElement } from '../../../../base/browser/dom.js';
+import * as nls from '../../../../nls.js';
+import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
 
 
 const OpenInEditorCommandId = 'search.action.openInEditor';
@@ -56,6 +58,52 @@ const CleanSearchEditorStateCommandId = 'cleanSearchEditorState';
 const SelectAllSearchEditorMatchesCommandId = 'selectAllSearchEditorMatches';
 
 
+//#region Search Editor Configuration
+Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
+	id: 'search',
+	order: 13,
+	title: nls.localize('searchConfigurationTitle', "Search"),
+	type: 'object',
+	properties: {
+		'search.searchEditor.doubleClickBehaviour': {
+			type: 'string',
+			enum: ['selectWord', 'goToLocation', 'openLocationToSide'],
+			default: 'goToLocation',
+			enumDescriptions: [
+				nls.localize('search.searchEditor.doubleClickBehaviour.selectWord', "Double-clicking selects the word under the cursor."),
+				nls.localize('search.searchEditor.doubleClickBehaviour.goToLocation', "Double-clicking opens the result in the active editor group."),
+				nls.localize('search.searchEditor.doubleClickBehaviour.openLocationToSide', "Double-clicking opens the result in the editor group to the side, creating one if it does not yet exist."),
+			],
+			markdownDescription: nls.localize('search.searchEditor.doubleClickBehaviour', "Configure effect of double-clicking a result in a search editor.")
+		},
+		'search.searchEditor.singleClickBehaviour': {
+			type: 'string',
+			enum: ['default', 'peekDefinition'],
+			default: 'default',
+			enumDescriptions: [
+				nls.localize('search.searchEditor.singleClickBehaviour.default', "Single-clicking does nothing."),
+				nls.localize('search.searchEditor.singleClickBehaviour.peekDefinition', "Single-clicking opens a Peek Definition window."),
+			],
+			markdownDescription: nls.localize('search.searchEditor.singleClickBehaviour', "Configure effect of single-clicking a result in a search editor.")
+		},
+		'search.searchEditor.reusePriorSearchConfiguration': {
+			type: 'boolean',
+			default: false,
+			markdownDescription: nls.localize({ key: 'search.searchEditor.reusePriorSearchConfiguration', comment: ['"Search Editor" is a type of editor that can display search results. "includes, excludes, and flags" refers to the "files to include" and "files to exclude" input boxes, and the flags that control whether a query is case-sensitive or a regex.'] }, "When enabled, new Search Editors will reuse the includes, excludes, and flags of the previously opened Search Editor.")
+		},
+		'search.searchEditor.defaultNumberOfContextLines': {
+			type: ['number', 'null'],
+			default: 1,
+			markdownDescription: nls.localize('search.searchEditor.defaultNumberOfContextLines', "The default number of surrounding context lines to use when creating new Search Editors. If using `#search.searchEditor.reusePriorSearchConfiguration#`, this can be set to `null` (empty) to use the prior Search Editor's configuration.")
+		},
+		'search.searchEditor.focusResultsOnSearch': {
+			type: 'boolean',
+			default: false,
+			markdownDescription: nls.localize('search.searchEditor.focusResultsOnSearch', "When a search is triggered, focus the Search Editor results instead of the Search Editor input.")
+		},
+	}
+});
+//#endregion
 
 //#region Editor Descriptior
 Registry.as<IEditorPaneRegistry>(EditorExtensions.EditorPane).registerEditorPane(


### PR DESCRIPTION
## Summary

Enables the Search Editor and Problems panel in the Agents window.

## Changes

### Search Editor
- Import `searchEditor.contribution.js` in `sessions.common.main.ts` to enable the Search Editor
- Extract `search.searchEditor.*` configuration properties from `search.contribution.ts` into `searchEditor.contribution.ts` so they're registered without pulling in the full search contribution
- Create `search.common.contribution.ts` for shared service registrations (`ISearchHistoryService`, `IReplaceService`, `INotebookSearchService`) needed by both the main workbench and the Agents window
- Add `Cmd+Shift+F` keybinding to open Search Editor in the Agents window (via `sessions/contrib/search/`)

### Problems Panel
- Enable the markers (Problems) view container and view in the Agents window with `WindowEnablement.Both`

### Panel Part CSS
- Fix compact badge positioning in the Agents window panel part
