### PR TITLE
Open Workspace In Agents Window: select folder in new chat view

### DIFF
--- a/src/vs/platform/native/common/native.ts
+++ b/src/vs/platform/native/common/native.ts
@@ -5,7 +5,7 @@
 
 import { VSBuffer } from '../../../base/common/buffer.js';
 import { Event } from '../../../base/common/event.js';
-import { URI } from '../../../base/common/uri.js';
+import { URI, UriComponents } from '../../../base/common/uri.js';
 import { MessageBoxOptions, MessageBoxReturnValue, OpenDevToolsOptions, OpenDialogOptions, OpenDialogReturnValue, SaveDialogOptions, SaveDialogReturnValue } from '../../../base/parts/sandbox/common/electronTypes.js';
 import { ISerializableCommandAction } from '../../action/common/action.js';
 import { INativeOpenDialogOptions } from '../../dialogs/common/dialogs.js';
@@ -129,7 +129,7 @@ export interface ICommonNativeHostService {
 	openWindow(options?: IOpenEmptyWindowOptions): Promise<void>;
 	openWindow(toOpen: IWindowOpenable[], options?: IOpenWindowOptions): Promise<void>;
 
-	openAgentsWindow(): Promise<void>;
+	openAgentsWindow(options?: { folderUri?: UriComponents }): Promise<void>;
 
 	/**
 	 * Launches the sibling application (host ↔ embedded).

--- a/src/vs/platform/native/electron-main/nativeHostMainService.ts
+++ b/src/vs/platform/native/electron-main/nativeHostMainService.ts
@@ -15,7 +15,7 @@ import { matchesSomeScheme, Schemas } from '../../../base/common/network.js';
 import { dirname, join, posix, resolve, win32 } from '../../../base/common/path.js';
 import { isLinux, isMacintosh, isWindows } from '../../../base/common/platform.js';
 import { AddFirstParameterToFunctions } from '../../../base/common/types.js';
-import { URI } from '../../../base/common/uri.js';
+import { URI, UriComponents } from '../../../base/common/uri.js';
 import { virtualMachineHint } from '../../../base/node/id.js';
 import { Promises, SymlinkSupport } from '../../../base/node/pfs.js';
 import { launchSiblingApp } from '../node/siblingApp.js';
@@ -305,12 +305,15 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
 		}, options);
 	}
 
-	async openAgentsWindow(windowId: number | undefined): Promise<void> {
-		await this.windowsMainService.openAgentsWindow({
+	async openAgentsWindow(windowId: number | undefined, options?: { folderUri?: UriComponents }): Promise<void> {
+		const windows = await this.windowsMainService.openAgentsWindow({
 			context: OpenContext.API,
 			contextWindowId: windowId,
 			cli: this.environmentMainService.args,
-		});
+		}, options?.folderUri ? URI.revive(options.folderUri) : undefined);
+		if (windows.length > 0) {
+			windows[0].focus();
+		}
 	}
 
 	async launchSiblingApp(_windowId: number | undefined, args?: string[]): Promise<void> {

--- a/src/vs/platform/windows/electron-main/windows.ts
+++ b/src/vs/platform/windows/electron-main/windows.ts
@@ -41,7 +41,7 @@ export interface IWindowsMainService {
 	openExtensionDevelopmentHostWindow(extensionDevelopmentPath: string[], openConfig: IOpenConfiguration): Promise<ICodeWindow[]>;
 	openExistingWindow(window: ICodeWindow, openConfig: IOpenConfiguration): void;
 
-	openAgentsWindow(openConfig: IOpenConfiguration): Promise<ICodeWindow[]>;
+	openAgentsWindow(openConfig: IOpenConfiguration, folderUri?: URI): Promise<ICodeWindow[]>;
 
 	sendToFocused(channel: string, ...args: unknown[]): void;
 	sendToOpeningWindow(channel: string, ...args: unknown[]): void;

--- a/src/vs/platform/windows/electron-main/windowsMainService.ts
+++ b/src/vs/platform/windows/electron-main/windowsMainService.ts
@@ -292,11 +292,18 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 		this.handleChatRequest(openConfig, [window]);
 	}
 
-	async openAgentsWindow(openConfig: IOpenConfiguration): Promise<ICodeWindow[]> {
+	async openAgentsWindow(openConfig: IOpenConfiguration, folderUri?: URI): Promise<ICodeWindow[]> {
 		this.logService.trace('windowsManager#openAgentsWindow');
 
 		// Open in a new browser window with the agent sessions workspace
-		return this.open(await this.ensureAgentsWindow(openConfig));
+		const windows = await this.open(await this.ensureAgentsWindow(openConfig));
+
+		// Tell the agents window to select the given folder in the new chat workspace picker
+		if (folderUri && windows.length > 0) {
+			windows[0].sendWhenReady('vscode:selectAgentsFolder', CancellationToken.None, folderUri.toJSON());
+		}
+
+		return windows;
 	}
 
 	private async ensureAgentsWindow(openConfig: IOpenConfiguration): Promise<IOpenConfiguration> {

--- a/src/vs/sessions/contrib/chat/electron-browser/chat.contribution.ts
+++ b/src/vs/sessions/contrib/chat/electron-browser/chat.contribution.ts
@@ -3,7 +3,65 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { ipcRenderer } from '../../../../base/parts/sandbox/electron-browser/globals.js';
+import { URI, UriComponents } from '../../../../base/common/uri.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
 import { registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
+import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
+import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
+import { IViewsService } from '../../../../workbench/services/views/common/viewsService.js';
+import { ILifecycleService, LifecyclePhase } from '../../../../workbench/services/lifecycle/common/lifecycle.js';
+import { NewChatViewPane, SessionsViewId } from '../browser/newChatViewPane.js';
 import { DebugAgentHostInDevToolsAction } from '../../../../workbench/contrib/chat/electron-browser/actions/debugAgentHostAction.js';
 
 registerAction2(DebugAgentHostInDevToolsAction);
+
+class SelectAgentsFolderContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'sessions.selectAgentsFolder';
+
+	constructor(
+		@ISessionsManagementService private readonly sessionsManagementService: ISessionsManagementService,
+		@ISessionsProvidersService private readonly sessionsProvidersService: ISessionsProvidersService,
+		@IViewsService private readonly viewsService: IViewsService,
+		@ILifecycleService private readonly lifecycleService: ILifecycleService,
+	) {
+		super();
+		ipcRenderer.on('vscode:selectAgentsFolder', (_: unknown, ...args: unknown[]) => {
+			const folderUri = URI.revive(args[0] as UriComponents);
+			this.selectFolder(folderUri);
+		});
+	}
+
+	private async selectFolder(folderUri: URI): Promise<void> {
+		this.sessionsManagementService.openNewSessionView();
+
+		if (this.tryResolveAndSelect(folderUri)) {
+			return;
+		}
+
+		// Provider not registered yet — wait for it, but give up at Eventually phase
+		const disposable = this.sessionsProvidersService.onDidChangeProviders(() => {
+			if (this.tryResolveAndSelect(folderUri)) {
+				disposable.dispose();
+			}
+		});
+		this.lifecycleService.when(LifecyclePhase.Eventually).then(() => disposable.dispose());
+	}
+
+	private tryResolveAndSelect(folderUri: URI): boolean {
+		for (const provider of this.sessionsProvidersService.getProviders()) {
+			const workspace = provider.resolveWorkspace(folderUri);
+			if (workspace) {
+				this.viewsService.openView<NewChatViewPane>(SessionsViewId).then(view => {
+					view?.selectWorkspace({ providerId: provider.id, workspace });
+				});
+				return true;
+			}
+		}
+		return false;
+	}
+}
+
+registerWorkbenchContribution2(SelectAgentsFolderContribution.ID, SelectAgentsFolderContribution, WorkbenchPhase.BlockStartup);

--- a/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts
@@ -19,6 +19,7 @@ import { KeyCode, KeyMod } from '../../../../../base/common/keyCodes.js';
 import { KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { INativeHostService } from '../../../../../platform/native/common/native.js';
 import { IProductService } from '../../../../../platform/product/common/productService.js';
+import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { IsSessionsWindowContext } from '../../../../common/contextkeys.js';
 import { TitleBarLeadingActionsGroup } from '../../../../browser/parts/titlebar/titlebarActions.js';
 import { IWorkbenchContribution } from '../../../../common/contributions.js';
@@ -49,7 +50,9 @@ export class OpenWorkspaceInAgentsWindowAction extends Action2 {
 
 	async run(accessor: ServicesAccessor) {
 		const nativeHostService = accessor.get(INativeHostService);
-		await nativeHostService.openAgentsWindow();
+		const workspaceContextService = accessor.get(IWorkspaceContextService);
+		const folderUri = workspaceContextService.getWorkspace().folders[0]?.uri;
+		await nativeHostService.openAgentsWindow({ folderUri });
 	}
 }
 

--- a/src/vs/workbench/test/electron-browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/electron-browser/workbenchTestServices.ts
@@ -9,7 +9,7 @@ import { CancellationToken } from '../../../base/common/cancellation.js';
 import { Event } from '../../../base/common/event.js';
 import { DisposableStore, IDisposable } from '../../../base/common/lifecycle.js';
 import { Schemas } from '../../../base/common/network.js';
-import { URI } from '../../../base/common/uri.js';
+import { URI, UriComponents } from '../../../base/common/uri.js';
 import { IModelService } from '../../../editor/common/services/model.js';
 import { ModelService } from '../../../editor/common/services/modelService.js';
 import { TestConfigurationService } from '../../../platform/configuration/test/common/testConfigurationService.js';
@@ -103,7 +103,7 @@ export class TestNativeHostService implements INativeHostService {
 		throw new Error('Method not implemented.');
 	}
 
-	async openAgentsWindow(): Promise<void> { }
+	async openAgentsWindow(_options?: { folderUri?: UriComponents }): Promise<void> { }
 
 	async launchSiblingApp(_args?: string[]): Promise<void> { }
 


### PR DESCRIPTION
When "Open in Agents Window" is triggered from the workbench, pass the current workspace folder URI to the agents window and pre-select it in the new chat workspace picker.

**Flow:**
- `OpenWorkspaceInAgentsWindowAction` passes the first workspace folder URI via `openAgentsWindow({ folderUri })`
- Main process sends `vscode:selectAgentsFolder` IPC to the agents window
- Sessions `SelectAgentsFolderContribution` handles the IPC:
  - Opens the new session view
  - Resolves the folder URI via session providers
  - Selects it in the `NewChatViewPane` workspace picker
  - If no provider is registered yet, waits for `onDidChangeProviders` with a timeout at `LifecyclePhase.Eventually`