### PR TITLE
Skip passing folder URI to agents window for non-file schemes

### DIFF
--- a/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts
@@ -19,6 +19,7 @@ import { KeyCode, KeyMod } from '../../../../../base/common/keyCodes.js';
 import { KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { INativeHostService } from '../../../../../platform/native/common/native.js';
 import { IProductService } from '../../../../../platform/product/common/productService.js';
+import { Schemas } from '../../../../../base/common/network.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { IsSessionsWindowContext } from '../../../../common/contextkeys.js';
 import { TitleBarLeadingActionsGroup } from '../../../../browser/parts/titlebar/titlebarActions.js';
@@ -52,7 +53,7 @@ export class OpenWorkspaceInAgentsWindowAction extends Action2 {
 		const nativeHostService = accessor.get(INativeHostService);
 		const workspaceContextService = accessor.get(IWorkspaceContextService);
 		const folderUri = workspaceContextService.getWorkspace().folders[0]?.uri;
-		await nativeHostService.openAgentsWindow({ folderUri });
+		await nativeHostService.openAgentsWindow({ folderUri: folderUri?.scheme === Schemas.file ? folderUri : undefined });
 	}
 }
 


### PR DESCRIPTION
Follow-up to #314602. Only pass `file://` folder URIs to the agents window — remote workspace folders (`vscode-remote://`) can't be resolved by sessions providers.