### PR TITLE
Remember previously selected session type and isolation mode

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/mobileSessionTypePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/mobileSessionTypePicker.ts
@@ -5,10 +5,11 @@
 
 import { localize } from '../../../../nls.js';
 import { IActionWidgetService } from '../../../../platform/actionWidget/browser/actionWidget.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { IWorkbenchLayoutService } from '../../../../workbench/services/layout/browser/layoutService.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
-import { SessionTypePicker } from './sessionTypePicker.js';
+import { SessionTypePicker, STORAGE_KEY_LAST_SESSION_TYPE } from './sessionTypePicker.js';
 import { isPhoneLayout } from '../../../browser/parts/mobile/mobileLayout.js';
 import { IMobilePickerSheetItem, showMobilePickerSheet } from '../../../browser/parts/mobile/mobilePickerSheet.js';
 
@@ -29,9 +30,10 @@ export class MobileSessionTypePicker extends SessionTypePicker {
 		@IActionWidgetService actionWidgetService: IActionWidgetService,
 		@ISessionsManagementService sessionsManagementService: ISessionsManagementService,
 		@ISessionsProvidersService sessionsProvidersService: ISessionsProvidersService,
+		@IStorageService storageService: IStorageService,
 		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
 	) {
-		super(actionWidgetService, sessionsManagementService, sessionsProvidersService);
+		super(actionWidgetService, sessionsManagementService, sessionsProvidersService, storageService);
 	}
 
 	override render(container: HTMLElement): void {
@@ -76,6 +78,7 @@ export class MobileSessionTypePicker extends SessionTypePicker {
 			trigger.setAttribute('aria-expanded', 'false');
 			trigger.focus();
 			if (id !== undefined && id !== this._sessionType) {
+				this.storageService.store(STORAGE_KEY_LAST_SESSION_TYPE, id, StorageScope.PROFILE, StorageTarget.MACHINE);
 				this._onDidSelectSessionType.fire(id);
 			}
 		});

--- a/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
@@ -16,6 +16,9 @@ import { ISessionsProvidersService } from '../../../services/sessions/browser/se
 import { autorun } from '../../../../base/common/observable.js';
 import { ISession, ISessionType } from '../../../services/sessions/common/session.js';
 import { Emitter } from '../../../../base/common/event.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+
+export const STORAGE_KEY_LAST_SESSION_TYPE = 'sessions.lastSelectedSessionType';
 
 export class SessionTypePicker extends Disposable {
 
@@ -33,8 +36,12 @@ export class SessionTypePicker extends Disposable {
 		@IActionWidgetService private readonly actionWidgetService: IActionWidgetService,
 		@ISessionsManagementService private readonly sessionsManagementService: ISessionsManagementService,
 		@ISessionsProvidersService private readonly sessionsProvidersService: ISessionsProvidersService,
+		@IStorageService protected readonly storageService: IStorageService,
 	) {
 		super();
+
+		// Restore the previously selected session type from storage
+		this._sessionType = this.storageService.get(STORAGE_KEY_LAST_SESSION_TYPE, StorageScope.PROFILE);
 
 		const refresh = (session: ISession | undefined) => {
 			if (session) {
@@ -50,7 +57,9 @@ export class SessionTypePicker extends Disposable {
 			} else {
 				this._supportedSessionTypes = [];
 				this._allProviderSessionTypes = [];
-				this._sessionType = undefined;
+				// Preserve the stored session type when no active session exists,
+				// so it can be used as the default for the next new session.
+				this._sessionType = this.storageService.get(STORAGE_KEY_LAST_SESSION_TYPE, StorageScope.PROFILE);
 			}
 			this._updateTriggerLabel();
 		};
@@ -132,6 +141,7 @@ export class SessionTypePicker extends Disposable {
 			onSelect: (type) => {
 				this.actionWidgetService.hide();
 				if (type.id !== this._sessionType) {
+					this.storageService.store(STORAGE_KEY_LAST_SESSION_TYPE, type.id, StorageScope.PROFILE, StorageTarget.MACHINE);
 					this._onDidSelectSessionType.fire(type.id);
 				}
 			},

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -42,10 +42,12 @@ import { localize } from '../../../../nls.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { ILabelService } from '../../../../platform/label/common/label.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { IGitHubService } from '../../github/browser/githubService.js';
 import { computePullRequestIcon, GitHubPullRequestState } from '../../github/common/types.js';
 
 const SESSION_WORKSPACE_GROUP_GITHUB = localize('sessionWorkspaceGroup.github', "GitHub");
+const STORAGE_KEY_ISOLATION_MODE = 'sessions.isolationPicker.selectedMode';
 
 export interface ICopilotChatSession {
 	/** Globally unique session ID (`providerId:localId`). */
@@ -238,6 +240,7 @@ class CopilotCLISession extends Disposable implements ICopilotChatSession {
 		providerId: string,
 		@IChatSessionsService private readonly chatSessionsService: IChatSessionsService,
 		@IGitService private readonly gitService: IGitService,
+		@IStorageService private readonly storageService: IStorageService,
 	) {
 		super();
 		this.id = toSessionId(providerId, resource);
@@ -255,8 +258,11 @@ class CopilotCLISession extends Disposable implements ICopilotChatSession {
 		// Set ISessionData workspace observable
 		this._workspaceData.set(sessionWorkspace, undefined);
 
-		this._isolationMode = 'worktree';
-		this.setOption(ISOLATION_OPTION_ID, 'worktree');
+		const storedMode = storageService.get(STORAGE_KEY_ISOLATION_MODE, StorageScope.PROFILE);
+		const initialMode: IsolationMode = storedMode === 'workspace' ? 'workspace' : 'worktree';
+		this._isolationMode = initialMode;
+		this._isolationModeObservable.set(initialMode, undefined);
+		this.setOption(ISOLATION_OPTION_ID, initialMode);
 
 		// Resolve git repository asynchronously
 		this._resolveGitRepository();
@@ -354,6 +360,7 @@ class CopilotCLISession extends Disposable implements ICopilotChatSession {
 			this._isolationMode = mode;
 			this._isolationModeObservable.set(mode, undefined);
 			this.setOption(ISOLATION_OPTION_ID, mode);
+			this.storageService.store(STORAGE_KEY_ISOLATION_MODE, mode, StorageScope.PROFILE, StorageTarget.MACHINE);
 
 			if (mode === 'workspace') {
 				// When switching to workspace mode, update the branch


### PR DESCRIPTION
Fixes #313556

Persist the user's last-selected session type and isolation mode so they are restored when opening a new session, matching how the workspace picker retains its previously selected folder.

**Session type picker:**
- Add `IStorageService` to `SessionTypePicker` and `MobileSessionTypePicker`
- Store selected type on pick, restore from storage when no active session exists
- Uses storage key `sessions.lastSelectedSessionType` (profile/machine scope)

**Isolation mode:**
- `CopilotCLISession` reads stored isolation mode from storage as its initial value instead of hardcoding `'worktree'`
- `CopilotCLISession.setIsolationMode()` persists to storage whenever the mode changes
- The isolation picker remains a pure UI widget with no storage dependency
- Uses storage key `sessions.isolationPicker.selectedMode` (profile/machine scope)