### PR TITLE
agent test: warm tokenizer in beforeAll to fix summarization test flake

### DIFF
--- a/extensions/copilot/src/extension/prompts/node/agent/test/summarization.spec.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/summarization.spec.tsx
@@ -31,6 +31,7 @@ import { PromptRenderer } from '../../base/promptRenderer';
 import { AgentPrompt, AgentPromptProps } from '../agentPrompt';
 import { PromptRegistry } from '../promptRegistry';
 import { ISessionTranscriptService, NullSessionTranscriptService } from '../../../../../platform/chat/common/sessionTranscriptService';
+import { ITokenizerProvider } from '../../../../../platform/tokenizer/node/tokenizer';
 import { appendTranscriptHintToSummary, ConversationHistorySummarizationPrompt, extractSummary, stripToolSearchMessages, SummarizedConversationHistory, SummarizedConversationHistoryMetadata, SummarizedConversationHistoryPropsBuilder } from '../summarizedConversationHistory';
 
 suite('Agent Summarization', () => {
@@ -40,7 +41,7 @@ suite('Agent Summarization', () => {
 
 	let conversation: Conversation;
 
-	beforeAll(() => {
+	beforeAll(async () => {
 		const testDoc = createTextDocumentData(fileTsUri, 'line 1\nline 2\n\nline 4\nline 5', 'ts').document;
 
 		const services = createExtensionUnitTestingServices();
@@ -57,6 +58,12 @@ suite('Agent Summarization', () => {
 		accessor.get(IConfigurationService).setConfig(ConfigKey.CodeGenerationInstructions, [{
 			text: 'This is a test custom instruction file',
 		} satisfies CodeGenerationTextInstruction]);
+
+		// Warm up the tokenizer once so per-test timing is predictable. The first
+		// tokenizer use parses a ~3.6MB BPE file which can take seconds on slow CI
+		// machines and would otherwise be charged to whichever test runs first.
+		const endpoint = accessor.get(IInstantiationService).createInstance(MockEndpoint, undefined);
+		await accessor.get(ITokenizerProvider).acquireTokenizer(endpoint).tokenLength('warmup');
 	});
 
 	beforeEach(() => {


### PR DESCRIPTION
Fixes #314078

## Root cause

The first test in `summarization.spec.tsx` (`continuation turns are not rendered in conversation history`) was occasionally tripping vitest's default 5s test timeout on slow CI machines.

The first call to `tokenizer.tokenLength()` in a process parses the ~3.6MB `o200k_base.tiktoken` BPE file into a 200K-entry `Map<Uint8Array, number>`. Locally this takes ~225ms; on a slow/loaded CI agent it can easily take several seconds. Because `TikTokenImpl` is a process-wide singleton, this one-time cost is charged to whichever test calls `tokenLength` first — in this suite, the first `test(...)`. The other 33 tests are fast (<10ms each).

## Fix

Warm the tokenizer once in `beforeAll`. Two benefits:

- Per-test timing becomes predictable. The first test goes from **281ms → 36ms** locally.
- The cold-start cost is paid in suite setup, which has its own `hookTimeout` (default 10s) and would surface as a clear "Hook timed out" error rather than a misleading "Test timed out" on the unrelated first test.

(Written by Copilot)