### PR TITLE
Git - guard against undefined paths in parseGitChangesRaw (#287615)

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -1138,6 +1138,9 @@ function parseGitChangesRaw(repositoryRoot: string, raw: string): DiffChange[] {
 			// Parse --raw output
 			const [, , , , change] = segment.split(' ');
 			const filePath = segments[index++];
+			if (!filePath) {
+				break;
+			}
 			const originalUri = Uri.file(path.isAbsolute(filePath) ? filePath : path.join(repositoryRoot, filePath));
 
 			let uri = originalUri;
@@ -1185,6 +1188,9 @@ function parseGitChangesRaw(repositoryRoot: string, raw: string): DiffChange[] {
 				index++;
 
 				const renamePath = segments[index++];
+				if (!renamePath) {
+					break;
+				}
 				numstatPath = path.isAbsolute(renamePath) ? renamePath : path.join(repositoryRoot, renamePath);
 			} else {
 				numstatPath = path.isAbsolute(filePath) ? filePath : path.join(repositoryRoot, filePath);


### PR DESCRIPTION
@
Fixes #287615

## Root cause

`parseGitChangesRaw` in `extensions/git/src/git.ts` parses the null-delimited output of `git diff --raw --numstat -z`. The parser advances through the segments array using a manual `index++` counter and reads file paths via `segments[index++]` in two places:

1. The colon-prefixed `--raw` branch: the file path that immediately follows the metadata segment.
2. The `--numstat` rename branch: the new path that follows the empty filename and the skipped old path.

Neither read was guarded for the case where `index` runs past the end of `segments` (or yields an empty/undefined value). When that happens, the resulting `filePath` is `undefined`, and the subsequent `Uri.file(...)` call throws:

```
The "path" argument must be of type string. Received undefined
```

This bubbles up through `GitHistoryProvider.provideHistoryItemChanges` and is logged by `extHostSCM.ts` as `ExtHostSCM#$provideHistoryItemChanges The "path" argument must be of type string. Received undefined`, leaving the multi-file diff editor with no listed files.

## Fix

Add a defensive `if (!filePath) break;` / `if (!renamePath) break;` guard in both branches, mirroring the existing guard already present for the rename `newPath` segment a few lines below. If the segment stream is unexpectedly truncated, parsing stops cleanly instead of crashing the provider call.

Narrow change: 6 added lines in one file, no behavior change for well-formed input.

## Test plan

- [x] Build passes locally
- [ ] Open commit history for a commit with many changes (including renames) — no `path must be of type string` error in Extension Host log; changed files render in the multi-file diff editor.
@