### PR TITLE
Preserve custom HISTFILE in zsh shell integration

### DIFF
--- a/src/vs/platform/terminal/node/terminalEnvironment.ts
+++ b/src/vs/platform/terminal/node/terminalEnvironment.ts
@@ -255,6 +255,11 @@ export async function getShellIntegrationInjection(
 			envMixin['ZDOTDIR'] = zdotdir;
 			const userZdotdir = env?.ZDOTDIR ?? os.homedir() ?? `~`;
 			envMixin['USER_ZDOTDIR'] = userZdotdir;
+			// Record any custom HISTFILE so the shell integration script can restore it
+			// instead of overwriting it with the default location (see #169264).
+			if (env?.HISTFILE) {
+				envMixin['VSCODE_ZSH_HISTFILE_ORIG'] = env.HISTFILE;
+			}
 			const filesToCopy: IShellIntegrationConfigInjection['filesToCopy'] = [];
 			filesToCopy.push({
 				source: path.join(appRoot, 'out/vs/workbench/contrib/terminal/common/scripts/shellIntegration-rc.zsh'),

--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-rc.zsh
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-rc.zsh
@@ -17,9 +17,15 @@ VSCODE_SHELL_INTEGRATION=1
 # By default, zsh will set the $HISTFILE to the $ZDOTDIR location automatically. In the case of the
 # shell integration being injected, this means that the terminal will use a different history file
 # to other terminals. To fix this issue, set $HISTFILE back to the default location before ~/.zshrc
-# is called as that may depend upon the value.
+# is called as that may depend upon the value. If the user (or VS Code's terminal env settings) had
+# already set a custom $HISTFILE, restore that value instead so it is not clobbered (see #169264).
 if [[  "$VSCODE_INJECTION" == "1" ]]; then
-	HISTFILE=$USER_ZDOTDIR/.zsh_history
+	if [[ -n "$VSCODE_ZSH_HISTFILE_ORIG" ]]; then
+		HISTFILE="$VSCODE_ZSH_HISTFILE_ORIG"
+		builtin unset VSCODE_ZSH_HISTFILE_ORIG
+	else
+		HISTFILE=$USER_ZDOTDIR/.zsh_history
+	fi
 fi
 
 # Only fix up ZDOTDIR if shell integration was injected (not manually installed) and has not been called yet


### PR DESCRIPTION
Fixes #169264

## Summary

After #168396, the zsh shell integration rc script unconditionally resets `HISTFILE` to `$USER_ZDOTDIR/.zsh_history` before sourcing the user's `.zshrc`. This clobbers any `HISTFILE` value the user has set via `~/.zshenv` or via the `terminal.integrated.env.*` setting, even though `.zshrc` has not yet had a chance to override it back. As a result `env | grep HIST` always shows the default location.

This applies the plan @Tyriar outlined in the issue:

- In `getShellIntegrationInjection` (`terminalEnvironment.ts`) for the `zsh` case, if the incoming `env` already contains a `HISTFILE`, record it on `envMixin` as `VSCODE_ZSH_HISTFILE_ORIG`.
- In `shellIntegration-rc.zsh`, if `VSCODE_ZSH_HISTFILE_ORIG` is set, restore `HISTFILE` from it (and unset the helper var) instead of forcing the default. The previous behavior is preserved when no custom `HISTFILE` was set.

The chosen env var name `VSCODE_ZSH_HISTFILE_ORIG` is namespaced to avoid colliding with anything users may have in their environment.

## Test plan

- [ ] In `terminal.integrated.env.linux` / `.osx`, set `"HISTFILE": "${HOME}/something_else"`, open a new zsh terminal, and confirm `env | grep HIST` shows the custom path.
- [ ] In `~/.zshenv`, `export HISTFILE="$HOME/something_else"`, open a new zsh terminal, and confirm `env | grep HIST` shows the custom path.
- [ ] With no custom `HISTFILE` set, open a new zsh terminal and confirm `HISTFILE` still resolves to `$USER_ZDOTDIR/.zsh_history` (the prior default), so existing users are unaffected.
- [ ] Confirm `VSCODE_ZSH_HISTFILE_ORIG` is unset after the rc script runs.