### PR TITLE
Fix Create on GitHub in Issue Reporter after extension bisect

### DIFF
--- a/src/vs/workbench/services/extensionManagement/browser/extensionBisect.ts
+++ b/src/vs/workbench/services/extensionManagement/browser/extensionBisect.ts
@@ -314,7 +314,17 @@ registerAction2(class extends Action2 {
 				await extensionEnablementService.disableExtension({ id: done.id }, undefined);
 			}
 			if (res.confirmed) {
+				// Skip the host reload here. The Issue Reporter is opened in an
+				// auxiliary window that depends on services living in the main
+				// window. Reloading the main window while the Issue Reporter is
+				// open orphans those services, causing buttons such as "Create
+				// on GitHub" to silently do nothing. The user can reload the
+				// window manually after reporting to re-enable any other
+				// extensions that bisect had temporarily disabled.
+				// See microsoft/vscode#248339.
+				await bisectService.reset();
 				await commandService.executeCommand('workbench.action.openIssueReporter', done.id);
+				return;
 			}
 		}
 		await bisectService.reset();


### PR DESCRIPTION
## Summary

After extension bisect identifies a bad extension, choosing "Report Issue & Continue" opens the Issue Reporter and then immediately reloads the main window. The Issue Reporter lives in an auxiliary window whose services are owned by the main window, so reloading orphans those service references and makes the "Create on GitHub" button (and other "show" buttons) silently do nothing.

This change skips the trailing `hostService.reload()` only on the report path. Bisect storage is still reset and the chosen "keep this extension disabled" choice is honored. The user can reload the window themselves once they're done with the issue report.

Fixes #248339

## Test plan
- [ ] Run `Extension Bisect: Start Extension Bisect` and complete bisect to identify a bad extension.
- [ ] In the final dialog, click "Report Issue & Continue".
- [ ] Issue Reporter opens; "Create on GitHub" / "Preview on GitHub" / `show` buttons all work.
- [ ] After closing the Issue Reporter, reloading the window restores the other (temporarily bisect-disabled) extensions.
- [ ] Bisect path that does not report (cancel button, "no extension identified" path) still reloads as before.