### PR TITLE
Terminate URL detection at CJK full-width ! and ?

### DIFF
--- a/src/vs/editor/common/languages/linkComputer.ts
+++ b/src/vs/editor/common/languages/linkComputer.ts
@@ -155,7 +155,7 @@ function getClassifier(): CharacterClassifier<CharacterClass> {
 		_classifier = new CharacterClassifier<CharacterClass>(CharacterClass.None);
 
 		// allow-any-unicode-next-line
-		const FORCE_TERMINATION_CHARACTERS = ' \t<>\'\"、。｡､，．：；‘〈「『〔（［｛｢｣｝］）〕』」〉’｀～…|';
+		const FORCE_TERMINATION_CHARACTERS = ' \t<>\'\"、。｡､，．：；！？‘〈「『〔（［｛｢｣｝］）〕』」〉’｀～…|';
 		for (let i = 0; i < FORCE_TERMINATION_CHARACTERS.length; i++) {
 			_classifier.set(FORCE_TERMINATION_CHARACTERS.charCodeAt(i), CharacterClass.ForceTermination);
 		}

--- a/src/vs/editor/test/common/modes/linkComputer.test.ts
+++ b/src/vs/editor/test/common/modes/linkComputer.test.ts
@@ -283,4 +283,18 @@ suite('Editor Modes - Link Computer', () => {
 			`          https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers                       `,
 		);
 	});
+
+	test('issue #303101: CJK full-width exclamation mark terminates URL', () => {
+		assertLink(
+			'請訪問 https://github.com/lobehub/lobehub/pull/13120！點擊此處',
+			'    https://github.com/lobehub/lobehub/pull/13120          '
+		);
+	});
+
+	test('issue #303101: CJK full-width question mark terminates URL', () => {
+		assertLink(
+			'請訪問 https://github.com/lobehub/lobehub/pull/13120？點擊此處',
+			'    https://github.com/lobehub/lobehub/pull/13120          '
+		);
+	});
 });

--- a/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalUriLinkDetector.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalUriLinkDetector.test.ts
@@ -94,6 +94,8 @@ suite('Workbench - TerminalUriLinkDetector', () => {
 			[TerminalBuiltinLinkType.Url, 'x = "https://en.wikipedia.org/wiki/Zürich";', [{ range: [[6, 1], [41, 1]], uri: URI.parse('https://en.wikipedia.org/wiki/Zürich') }]],
 			[TerminalBuiltinLinkType.Url, '請參閱 http://go.microsoft.com/fwlink/?LinkId=761051。', [{ range: [[8, 1], [53, 1]], uri: URI.parse('http://go.microsoft.com/fwlink/?LinkId=761051') }]],
 			[TerminalBuiltinLinkType.Url, '（請參閱 http://go.microsoft.com/fwlink/?LinkId=761051）', [{ range: [[10, 1], [55, 1]], uri: URI.parse('http://go.microsoft.com/fwlink/?LinkId=761051') }]],
+			[TerminalBuiltinLinkType.Url, '請訪問 https://github.com/lobehub/lobehub/pull/13120！', [{ range: [[8, 1], [53, 1]], uri: URI.parse('https://github.com/lobehub/lobehub/pull/13120') }]],
+			[TerminalBuiltinLinkType.Url, '請訪問 https://github.com/lobehub/lobehub/pull/13120？', [{ range: [[8, 1], [53, 1]], uri: URI.parse('https://github.com/lobehub/lobehub/pull/13120') }]],
 			[TerminalBuiltinLinkType.LocalFile, 'x = "file:///foo.bar";', [{ range: [[6, 1], [20, 1]], uri: URI.parse('file:///foo.bar') }], URI.parse('file:///foo.bar')],
 			[TerminalBuiltinLinkType.LocalFile, 'x = "file://c:/foo.bar";', [{ range: [[6, 1], [22, 1]], uri: URI.parse('file://c:/foo.bar') }], URI.parse('file://c:/foo.bar')],
 			[TerminalBuiltinLinkType.LocalFile, 'x = "file://shares/foo.bar";', [{ range: [[6, 1], [26, 1]], uri: URI.parse('file://shares/foo.bar') }], URI.parse('file://shares/foo.bar')],


### PR DESCRIPTION
## Summary

In CJK contexts, when a URL was followed by a full-width exclamation mark (`！`, U+FF01) or full-width question mark (`？`, U+FF1F), the punctuation was incorrectly absorbed into the detected link, producing a broken URL.

The link computer's `FORCE_TERMINATION_CHARACTERS` already includes the full-width period (`。`), comma (`，`), and other CJK sentence-enders, but omitted these two. Adding them as force-termination characters fixes the issue while preserving existing CJK URL behavior (e.g. Wikipedia URLs that legitimately contain `【】`, `《》`, `""`).

Fixes #303101

## Test plan

- [x] New unit tests in `linkComputer.test.ts` covering `！` and `？` after URLs in CJK text
- [x] New cases in `terminalUriLinkDetector.test.ts` mirroring the issue's exact reproduction (`https://github.com/lobehub/lobehub/pull/13120！`)
- [x] Existing tests for issues #100353, #121438 (CJK characters legitimately inside URLs) continue to pass