### PR TITLE
Use optional chaining in TextMate worker to prevent crash on out-of-order messages

### DIFF
--- a/src/vs/workbench/services/textMate/browser/backgroundTokenization/worker/textMateTokenizationWorker.worker.ts
+++ b/src/vs/workbench/services/textMate/browser/backgroundTokenization/worker/textMateTokenizationWorker.worker.ts
@@ -121,15 +121,15 @@ export class TextMateTokenizationWorker implements IWebWorkerServerRequestHandle
 	}
 
 	public $acceptModelChanged(controllerId: number, e: IModelChangedEvent): void {
-		this._models.get(controllerId)!.onEvents(e);
+		this._models.get(controllerId)?.onEvents(e);
 	}
 
 	public $retokenize(controllerId: number, startLineNumber: number, endLineNumberExclusive: number): void {
-		this._models.get(controllerId)!.retokenize(startLineNumber, endLineNumberExclusive);
+		this._models.get(controllerId)?.retokenize(startLineNumber, endLineNumberExclusive);
 	}
 
 	public $acceptModelLanguageChanged(controllerId: number, newLanguageId: string, newEncodedLanguageId: LanguageId): void {
-		this._models.get(controllerId)!.onLanguageId(newLanguageId, newEncodedLanguageId);
+		this._models.get(controllerId)?.onLanguageId(newLanguageId, newEncodedLanguageId);
 	}
 
 	public $acceptRemovedModel(controllerId: number): void {
@@ -146,7 +146,7 @@ export class TextMateTokenizationWorker implements IWebWorkerServerRequestHandle
 	}
 
 	public $acceptMaxTokenizationLineLength(controllerId: number, value: number): void {
-		this._models.get(controllerId)!.acceptMaxTokenizationLineLength(value);
+		this._models.get(controllerId)?.acceptMaxTokenizationLineLength(value);
 	}
 }
 


### PR DESCRIPTION
## Problem

In the TextMate tokenization web worker, four message handlers use non-null assertions (`!`) on `Map.get()` results:

- `$acceptModelChanged`
- `$retokenize`
- `$acceptModelLanguageChanged`
- `$acceptMaxTokenizationLineLength`

Meanwhile, the fifth handler (`$acceptRemovedModel`) correctly uses a null guard:
```typescript
const model = this._models.get(controllerId);
if (model) { ... }
```

If messages arrive out of order (e.g., `$acceptModelChanged` arriving after `$acceptRemovedModel` due to rapid model creation/destruction), the non-null assertion crashes the web worker. Since the worker handles tokenization for all open files, this crash breaks syntax highlighting globally until the worker is restarted.

## Fix

Replace the four non-null assertions (`!`) with optional chaining (`?.`) to silently skip messages for models that have already been removed, consistent with the existing `$acceptRemovedModel` pattern.


Fixes #315169