### PR TITLE
ssh agent host: accept `localhost` in startup banner regex

### DIFF
--- a/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
+++ b/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
@@ -203,7 +203,7 @@ function startRemoteAgentHost(
 				}
 
 				if (!resolved) {
-					const match = outputBuf.match(/ws:\/\/127\.0\.0\.1:(\d+)(?:\?tkn=([^\s&]+))?/);
+					const match = outputBuf.match(/ws:\/\/(?:127\.0\.0\.1|localhost):(\d+)(?:\?tkn=([^\s&]+))?/);
 					if (match) {
 						resolved = true;
 						clearTimeout(timeout);


### PR DESCRIPTION
SSH remote agent host startup was timing out after 60s because we couldn't parse the CLI's listening banner.

When we switched from the legacy `agent-host` command to the new `agent host` subcommand, the startup banner format changed. The CLI now prints its WebSocket URL via `print_network_lines` in `cli/src/commands/output.rs` as:

```
  ➜  Local:    ws://localhost:49415?tkn=<token>
```

…but `startRemoteAgentHost` in `sshRemoteAgentHostService.ts` was matching `/ws:\/\/127\.0\.0\.1:(\d+)(?:\?tkn=([^\s&]+))?/`, which never matched `localhost`. Result: the startup promise never resolved and the SSH agent host failed to come up.

Fix: broaden the host portion of the regex to accept either `127.0.0.1` or `localhost`.

(Written by Copilot)