### PR TITLE
Fix cmd.exe argument escaping in MCP and debug adapter subprocess launch

### DIFF
--- a/src/vs/base/common/processes.ts
+++ b/src/vs/base/common/processes.ts
@@ -99,6 +99,25 @@ export interface ProcessItem {
 }
 
 /**
+ * Escapes an argument for safe use in a `cmd.exe` command line.
+ *
+ * When spawning `.bat`/`.cmd` files on Windows with `shell: true`,
+ * arguments are interpreted by `cmd.exe` which treats characters like
+ * `&`, `|`, `>`, `<`, `^` as command separators/operators. This
+ * function escapes those metacharacters and wraps the argument in
+ * double quotes to prevent command injection.
+ *
+ * See CVE-2024-27980 (BatBadBut) for background on this class of
+ * vulnerability.
+ */
+export function escapeCmdExeArg(s: string): string {
+	s = s.replace(/"/g, '""');
+	s = s.replace(/([><!^&|])/g, '^$1');
+	s = s.replace(/%/g, '%%');
+	return `"${s}"`;
+}
+
+/**
  * Sanitizes a VS Code process environment by removing all Electron/VS Code-related values.
  */
 export function sanitizeProcessEnvironment(env: IProcessEnvironment, ...preserve: string[]): void {

--- a/src/vs/base/common/processes.ts
+++ b/src/vs/base/common/processes.ts
@@ -103,9 +103,10 @@ export interface ProcessItem {
  *
  * When spawning `.bat`/`.cmd` files on Windows with `shell: true`,
  * arguments are interpreted by `cmd.exe` which treats characters like
- * `&`, `|`, `>`, `<`, `^` as command separators/operators. This
- * function escapes those metacharacters and wraps the argument in
- * double quotes to prevent command injection.
+ * `&`, `|`, `>`, `<`, `^` as command separators/operators, `!` for
+ * delayed variable expansion, and `%` for environment variable
+ * expansion (`%PATH%`). This function escapes all of these and wraps
+ * the argument in double quotes to prevent command injection.
  *
  * See CVE-2024-27980 (BatBadBut) for background on this class of
  * vulnerability.

--- a/src/vs/base/test/common/processes.test.ts
+++ b/src/vs/base/test/common/processes.test.ts
@@ -10,6 +10,21 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from './utils.js';
 suite('Processes', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
 
+	test('escapeCmdExeArg', () => {
+		assert.strictEqual(processes.escapeCmdExeArg('simple'), '"simple"');
+		assert.strictEqual(processes.escapeCmdExeArg('with space'), '"with space"');
+		assert.strictEqual(processes.escapeCmdExeArg('has"quote'), '"has""quote"');
+		assert.strictEqual(processes.escapeCmdExeArg('foo&bar'), '"foo^&bar"');
+		assert.strictEqual(processes.escapeCmdExeArg('a|b'), '"a^|b"');
+		assert.strictEqual(processes.escapeCmdExeArg('a>b'), '"a^>b"');
+		assert.strictEqual(processes.escapeCmdExeArg('a<b'), '"a^<b"');
+		assert.strictEqual(processes.escapeCmdExeArg('a^b'), '"a^^b"');
+		assert.strictEqual(processes.escapeCmdExeArg('a!b'), '"a^!b"');
+		assert.strictEqual(processes.escapeCmdExeArg('%PATH%'), '"%%PATH%%"');
+		assert.strictEqual(processes.escapeCmdExeArg('foo&calc'), '"foo^&calc"');
+		assert.strictEqual(processes.escapeCmdExeArg(''), '""');
+	});
+
 	test('sanitizeProcessEnvironment', () => {
 		const env = {
 			FOO: 'bar',

--- a/src/vs/workbench/api/node/extHostMcpNode.ts
+++ b/src/vs/workbench/api/node/extHostMcpNode.ts
@@ -12,6 +12,7 @@ import { untildify } from '../../../base/common/labels.js';
 import { Lazy } from '../../../base/common/lazy.js';
 import { DisposableMap } from '../../../base/common/lifecycle.js';
 import * as path from '../../../base/common/path.js';
+import { escapeCmdExeArg } from '../../../base/common/processes.js';
 import { URI } from '../../../base/common/uri.js';
 import { StreamSplitter } from '../../../base/node/nodeStreams.js';
 import { findExecutable } from '../../../base/node/processes.js';
@@ -204,10 +205,9 @@ export const formatSubprocessArguments = async (
 
 	const found = await findExecutable(executable, cwd, undefined, env);
 	if (found && windowsShellScriptRe.test(found)) {
-		const quote = (s: string) => s.includes(' ') ? `"${s}"` : s;
 		return {
-			executable: quote(found),
-			args: args.map(quote),
+			executable: escapeCmdExeArg(found),
+			args: args.map(escapeCmdExeArg),
 			shell: true,
 		};
 	}

--- a/src/vs/workbench/contrib/debug/node/debugAdapter.ts
+++ b/src/vs/workbench/contrib/debug/node/debugAdapter.ts
@@ -237,7 +237,7 @@ export class ExecutableDebugAdapter extends StreamDebugAdapter {
 				if (options.cwd) {
 					spawnOptions.cwd = options.cwd;
 				}
-				if (platform.isWindows && (command.endsWith('.bat') || command.endsWith('.cmd'))) {
+				if (platform.isWindows && /\.(bat|cmd)$/i.test(command)) {
 					// https://github.com/microsoft/vscode/issues/224184
 					spawnOptions.shell = true;
 					spawnCommand = escapeCmdExeArg(command);

--- a/src/vs/workbench/contrib/debug/node/debugAdapter.ts
+++ b/src/vs/workbench/contrib/debug/node/debugAdapter.ts
@@ -9,6 +9,7 @@ import * as stream from 'stream';
 import * as objects from '../../../../base/common/objects.js';
 import * as path from '../../../../base/common/path.js';
 import * as platform from '../../../../base/common/platform.js';
+import { escapeCmdExeArg } from '../../../../base/common/processes.js';
 import * as strings from '../../../../base/common/strings.js';
 import { Promises } from '../../../../base/node/pfs.js';
 import * as nls from '../../../../nls.js';
@@ -239,12 +240,8 @@ export class ExecutableDebugAdapter extends StreamDebugAdapter {
 				if (platform.isWindows && (command.endsWith('.bat') || command.endsWith('.cmd'))) {
 					// https://github.com/microsoft/vscode/issues/224184
 					spawnOptions.shell = true;
-					spawnCommand = `"${command}"`;
-					spawnArgs = args.map(a => {
-						a = a.replace(/"/g, '\\"'); // Escape existing double quotes with \
-						// Wrap in double quotes
-						return `"${a}"`;
-					});
+					spawnCommand = escapeCmdExeArg(command);
+					spawnArgs = args.map(escapeCmdExeArg);
 				}
 
 				this.serverProcess = cp.spawn(spawnCommand, spawnArgs, spawnOptions);


### PR DESCRIPTION
## Problem

When spawning `.bat`/`.cmd` files on Windows with `shell: true`, arguments are interpreted by `cmd.exe` which treats characters like `&`, `|`, `>`, `<`, `^` as command separators/operators. Two locations in the codebase use insufficient escaping:

**`extHostMcpNode.ts` (MCP server launch)**:
```typescript
const quote = (s: string) => s.includes(' ') ? `"${s}"` : s;
```
Only handles spaces. An MCP arg like `foo&calc` passes `&calc` as a separate command to `cmd.exe`. MCP server configs can come from workspace `.vscode/mcp.json` files, which are attacker-controllable in malicious repositories (though workspace trust provides a gate since CVE-2026-21518).

**`debugAdapter.ts` (debug adapter launch)**:
```typescript
a = a.replace(/"/g, '\\"');
return `"${a}"`;
```
Only escapes double quotes. Metacharacters like `&`, `|` are not handled.

This is the same class of vulnerability as CVE-2024-27980 (BatBadBut) and CVE-2025-64340 (fastmcp).

## Fix

Introduce a shared `escapeCmdExeArg()` utility in `base/common/processes.ts` that properly handles `cmd.exe` argument escaping:
- `"` is doubled (`""`) per `cmd.exe` convention
- Metacharacters (`>`, `<`, `!`, `^`, `&`, `|`) are caret-escaped (`^&`, `^|`, etc.)
- `%` is doubled (`%%`) to prevent `%VAR%` environment variable expansion
- Arguments are always wrapped in double quotes

This follows the same escaping pattern already used in `debug/node/terminals.ts:123-131` for the `cmd.exe` shell type.

Both `formatSubprocessArguments` (MCP) and the debug adapter spawn logic now use this shared utility.

Unit tests are included for the escaping function.

Fixes #308890
