### PR TITLE
Add coverage for Copilot CLI node-pty shimming 

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/copilotcli/AGENTS.md
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/AGENTS.md
@@ -78,7 +78,7 @@ copilotcli/
 │   ├── copilotCLISkills.ts     # Skills location resolution
 │   ├── copilotCLIImageSupport.ts    # Image attachment handling
 │   ├── mcpHandler.ts           # MCP server configuration for SDK sessions
-│   ├── nodePtyShim.ts          # Copies VS Code's node-pty for SDK use
+│   ├── nodePtyShim.ts          # Runtime node-pty copy for separate extension installs
 │   ├── userInputHelpers.ts     # User question/input handling interface
 │   ├── exitPlanModeHandler.ts  # Plan mode exit flow with user choice
 │   ├── ripgrepShim.ts          # Copies VS Code's ripgrep for SDK use
@@ -313,7 +313,9 @@ Orchestrates the start and end of each chat request turn, coordinating worktree 
 
 ## Critical Pitfalls
 
-- **Shims before SDK import**: `ensureRipgrepShim()` and `ensureNodePtyShim()` in `node/ripgrepShim.ts` / `node/nodePtyShim.ts` MUST be called before any `import('@github/copilot/sdk')`. They copy VS Code's bundled native binaries to the SDK's expected locations. See `node/copilotCli.ts` for the initialization order.
+- **Shims before SDK import**: For separate Marketplace/VSIX extension installs, `CopilotCLISDK.ensureShims()` in `node/copilotCli.ts` MUST run before any `import('@github/copilot/sdk')`. That runtime path calls both `ensureRipgrepShim()` and `ensureNodePtyShim()` to copy VS Code's native binaries from `envService.appRoot` into the installed extension's SDK layout.
+
+- **Bundled/core shim path is different**: When Copilot Chat is bundled together with core VS Code, build-time packaging materializes only the ripgrep shim and writes `node_modules/@github/copilot/shims.txt`. That marker intentionally makes runtime `ensureShims()` return early, so node-pty is not copied in the bundled path; it is resolved from VS Code's own app tree instead.
 
 - **Delayed permission UI**: Tool invocation messages are held in `toolCallWaitingForPermissions` until permission resolves. `flushPendingInvocationMessageForToolCallId()` flushes only the specific approved tool, not all pending tools. This is intentional — don't bypass it.
 

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/AGENTS.md
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/AGENTS.md
@@ -78,6 +78,7 @@ copilotcli/
 │   ├── copilotCLISkills.ts     # Skills location resolution
 │   ├── copilotCLIImageSupport.ts    # Image attachment handling
 │   ├── mcpHandler.ts           # MCP server configuration for SDK sessions
+│   ├── nodePtyShim.ts          # Copies VS Code's node-pty for SDK use
 │   ├── userInputHelpers.ts     # User question/input handling interface
 │   ├── exitPlanModeHandler.ts  # Plan mode exit flow with user choice
 │   ├── ripgrepShim.ts          # Copies VS Code's ripgrep for SDK use
@@ -312,7 +313,7 @@ Orchestrates the start and end of each chat request turn, coordinating worktree 
 
 ## Critical Pitfalls
 
-- **Shims before SDK import**: `ensureRipgrepShim()` in `node/ripgrepShim.ts` MUST be called before any `import('@github/copilot/sdk')`. It copies VS Code's bundled ripgrep binary to the SDK's expected location. `node-pty` is no longer shimmed: the copilot CLI SDK resolves it from VS Code's own `node_modules` via `hostRequire`, falling back to its bundled copy only if that fails. See `node/copilotCli.ts` for the initialization order.
+- **Shims before SDK import**: `ensureRipgrepShim()` and `ensureNodePtyShim()` in `node/ripgrepShim.ts` / `node/nodePtyShim.ts` MUST be called before any `import('@github/copilot/sdk')`. They copy VS Code's bundled native binaries to the SDK's expected locations. See `node/copilotCli.ts` for the initialization order.
 
 - **Delayed permission UI**: Tool invocation messages are held in `toolCallWaitingForPermissions` until permission resolves. `flushPendingInvocationMessageForToolCallId()` flushes only the specific approved tool, not all pending tools. This is intentional — don't bypass it.
 

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotCliShims.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotCliShims.spec.ts
@@ -7,8 +7,52 @@ import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { IAuthenticationService } from '../../../../../platform/authentication/common/authentication';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configurationService';
+import { IEnvService } from '../../../../../platform/env/common/envService';
+import { IVSCodeExtensionContext } from '../../../../../platform/extContext/common/extensionContext';
 import { LogServiceImpl } from '../../../../../platform/log/common/logService';
-import { ensureCopilotCLIShims } from '../copilotCli';
+import { mock } from '../../../../../util/common/test/simpleMock';
+import { IInstantiationService } from '../../../../../util/vs/platform/instantiation/common/instantiation';
+import { CopilotCLISDK } from '../copilotCli';
+
+type CopilotSdkModule = typeof import('@github/copilot/sdk');
+
+class TestExtensionContext extends mock<IVSCodeExtensionContext>() {
+	public override readonly workspaceState = {
+		get: () => ({}),
+		update: async () => { },
+		keys: () => []
+	};
+
+	constructor(public override readonly extensionPath: string) {
+		super();
+	}
+}
+
+class TestEnvService extends mock<IEnvService>() {
+	constructor(public override readonly appRoot: string) {
+		super();
+	}
+}
+
+class TestAuthenticationService extends mock<IAuthenticationService>() { }
+class TestConfigurationService extends mock<IConfigurationService>() { }
+class TestInstantiationService extends mock<IInstantiationService>() { }
+
+class TestCopilotCLISDK extends CopilotCLISDK {
+	protected override async ensureShims(): Promise<void> {
+		return;
+	}
+
+	public runEnsureShims(): Promise<void> {
+		return super.ensureShims();
+	}
+
+	public override async getPackage(): Promise<CopilotSdkModule> {
+		throw new Error('SDK import is disabled in shim tests');
+	}
+}
 
 describe('Copilot CLI shims', () => {
 	let testDir: string;
@@ -22,6 +66,17 @@ describe('Copilot CLI shims', () => {
 		await rm(testDir, { recursive: true, force: true });
 	});
 
+	function createSdk(extensionPath: string, vscodeAppRoot: string): TestCopilotCLISDK {
+		return new TestCopilotCLISDK(
+			new TestExtensionContext(extensionPath),
+			new TestEnvService(vscodeAppRoot),
+			logService,
+			new TestInstantiationService(),
+			new TestAuthenticationService(),
+			new TestConfigurationService()
+		);
+	}
+
 	it('creates ripgrep and node-pty shims before SDK import', async () => {
 		const extensionPath = join(testDir, 'extension');
 		const vscodeAppRoot = join(testDir, 'app');
@@ -33,7 +88,7 @@ describe('Copilot CLI shims', () => {
 		await writeFile(join(nodePtySourceDir, 'pty.node'), 'native-binary');
 		await writeFile(join(nodePtySourceDir, 'spawn-helper'), 'spawn-helper');
 
-		await ensureCopilotCLIShims(extensionPath, vscodeAppRoot, logService);
+		await createSdk(extensionPath, vscodeAppRoot).runEnsureShims();
 
 		await expect(readFile(join(extensionPath, 'node_modules', '@github', 'copilot', 'shims.txt'), 'utf8')).resolves.toBe('Shims created successfully');
 		const sdkRipgrepDir = join(extensionPath, 'node_modules', '@github', 'copilot', 'sdk', 'ripgrep', 'bin', process.platform + '-' + process.arch);
@@ -50,9 +105,9 @@ describe('Copilot CLI shims', () => {
 		await mkdir(join(extensionPath, 'node_modules', '@github', 'copilot'), { recursive: true });
 		await writeFile(placeholder, 'already created');
 
-		await ensureCopilotCLIShims(extensionPath, vscodeAppRoot, logService);
+		await createSdk(extensionPath, vscodeAppRoot).runEnsureShims();
 
 		await expect(readFile(placeholder, 'utf8')).resolves.toBe('already created');
-		await expect(stat(join(extensionPath, 'node_modules', '@github', 'copilot', 'sdk'))).rejects.toThrow();
+		await expect(stat(join(extensionPath, 'node_modules', '@github', 'copilot', 'sdk'))).rejects.toMatchObject({ code: 'ENOENT' });
 	});
 });

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotCliShims.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotCliShims.spec.ts
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { LogServiceImpl } from '../../../../../platform/log/common/logService';
+import { ensureCopilotCLIShims } from '../copilotCli';
+
+describe('Copilot CLI shims', () => {
+	let testDir: string;
+	const logService = new LogServiceImpl([]);
+
+	beforeEach(async () => {
+		testDir = await mkdtemp(join(tmpdir(), 'copilot-cli-shims-'));
+	});
+
+	afterEach(async () => {
+		await rm(testDir, { recursive: true, force: true });
+	});
+
+	it('creates ripgrep and node-pty shims before SDK import', async () => {
+		const extensionPath = join(testDir, 'extension');
+		const vscodeAppRoot = join(testDir, 'app');
+		const ripgrepSourceDir = join(vscodeAppRoot, 'node_modules', '@vscode', 'ripgrep', 'bin');
+		const nodePtySourceDir = join(vscodeAppRoot, 'node_modules', 'node-pty', 'prebuilds', process.platform + '-' + process.arch);
+		await mkdir(ripgrepSourceDir, { recursive: true });
+		await mkdir(nodePtySourceDir, { recursive: true });
+		await writeFile(join(ripgrepSourceDir, 'rg'), 'ripgrep');
+		await writeFile(join(nodePtySourceDir, 'pty.node'), 'native-binary');
+		await writeFile(join(nodePtySourceDir, 'spawn-helper'), 'spawn-helper');
+
+		await ensureCopilotCLIShims(extensionPath, vscodeAppRoot, logService);
+
+		await expect(readFile(join(extensionPath, 'node_modules', '@github', 'copilot', 'shims.txt'), 'utf8')).resolves.toBe('Shims created successfully');
+		const sdkRipgrepDir = join(extensionPath, 'node_modules', '@github', 'copilot', 'sdk', 'ripgrep', 'bin', process.platform + '-' + process.arch);
+		await expect(readFile(join(sdkRipgrepDir, 'rg'), 'utf8')).resolves.toBe('ripgrep');
+		const sdkNodePtyDir = join(extensionPath, 'node_modules', '@github', 'copilot', 'sdk', 'prebuilds', process.platform + '-' + process.arch);
+		await expect(readFile(join(sdkNodePtyDir, 'pty.node'), 'utf8')).resolves.toBe('native-binary');
+		await expect(readFile(join(sdkNodePtyDir, 'spawn-helper'), 'utf8')).resolves.toBe('spawn-helper');
+	});
+
+	it('skips shim creation for bundled installs when shims.txt already exists', async () => {
+		const extensionPath = join(testDir, 'extension');
+		const vscodeAppRoot = join(testDir, 'app');
+		const placeholder = join(extensionPath, 'node_modules', '@github', 'copilot', 'shims.txt');
+		await mkdir(join(extensionPath, 'node_modules', '@github', 'copilot'), { recursive: true });
+		await writeFile(placeholder, 'already created');
+
+		await ensureCopilotCLIShims(extensionPath, vscodeAppRoot, logService);
+
+		await expect(readFile(placeholder, 'utf8')).resolves.toBe('already created');
+		await expect(stat(join(extensionPath, 'node_modules', '@github', 'copilot', 'sdk'))).rejects.toThrow();
+	});
+});

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotCliShims.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotCliShims.spec.ts
@@ -77,9 +77,12 @@ describe('Copilot CLI shims', () => {
 		);
 	}
 
-	it('creates ripgrep and node-pty shims before SDK import', async () => {
+	it('creates runtime ripgrep and node-pty shims for separate extension installs before SDK import', async () => {
 		const extensionPath = join(testDir, 'extension');
 		const vscodeAppRoot = join(testDir, 'app');
+		// Marketplace/VSIX installs live outside VS Code's app tree. In that route the SDK
+		// cannot rely on the built-in extension packaging marker, so runtime setup copies
+		// both native dependencies from VS Code's appRoot into the extension's SDK layout.
 		const ripgrepSourceDir = join(vscodeAppRoot, 'node_modules', '@vscode', 'ripgrep', 'bin');
 		const nodePtySourceDir = join(vscodeAppRoot, 'node_modules', 'node-pty', 'prebuilds', process.platform + '-' + process.arch);
 		await mkdir(ripgrepSourceDir, { recursive: true });
@@ -98,10 +101,13 @@ describe('Copilot CLI shims', () => {
 		await expect(readFile(join(sdkNodePtyDir, 'spawn-helper'), 'utf8')).resolves.toBe('spawn-helper');
 	});
 
-	it('skips shim creation for bundled installs when shims.txt already exists', async () => {
+	it('skips runtime node-pty shimming for bundled installs when shims.txt already exists', async () => {
 		const extensionPath = join(testDir, 'extension');
 		const vscodeAppRoot = join(testDir, 'app');
 		const placeholder = join(extensionPath, 'node_modules', '@github', 'copilot', 'shims.txt');
+		// Built-in packaging materializes only the ripgrep shim and writes this marker.
+		// Runtime ensureShims then returns before copying node-pty; the bundled/core route
+		// resolves node-pty from VS Code's own app tree instead of an SDK prebuild copy.
 		await mkdir(join(extensionPath, 'node_modules', '@github', 'copilot'), { recursive: true });
 		await writeFile(placeholder, 'already created');
 

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/nodePtyShim.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/nodePtyShim.spec.ts
@@ -3,12 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { LogServiceImpl } from '../../../../../platform/log/common/logService';
-import { resolveNodePtySourcePath } from '../nodePtyShim';
+import { copyNodePtyFiles, resolveNodePtySourcePath } from '../nodePtyShim';
 
 describe('nodePtyShim', () => {
 	let testDir: string;
@@ -40,5 +40,19 @@ describe('nodePtyShim', () => {
 
 	it('throws when node-pty binaries are missing', async () => {
 		await expect(resolveNodePtySourcePath(testDir, logService)).rejects.toThrow('Unable to find node-pty binaries');
+	});
+
+	it('copies node-pty files into the SDK prebuilds folder', async () => {
+		const extensionPath = join(testDir, 'extension');
+		const sourceDir = join(testDir, 'source');
+		await mkdir(sourceDir, { recursive: true });
+		await writeFile(join(sourceDir, 'pty.node'), 'native-binary');
+		await writeFile(join(sourceDir, 'spawn-helper'), 'spawn-helper');
+
+		await copyNodePtyFiles(extensionPath, sourceDir, logService);
+
+		const sdkNodePtyDir = join(extensionPath, 'node_modules', '@github', 'copilot', 'sdk', 'prebuilds', process.platform + '-' + process.arch);
+		await expect(readFile(join(sdkNodePtyDir, 'pty.node'), 'utf8')).resolves.toBe('native-binary');
+		await expect(readFile(join(sdkNodePtyDir, 'spawn-helper'), 'utf8')).resolves.toBe('spawn-helper');
 	});
 });


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/314128

This adds targeted coverage for the runtime node-pty shim regression from https://github.com/microsoft/vscode/issues/313609 / https://github.com/microsoft/vscode/pull/313550. The goal is to make PR checks catch the practical VSIX/Marketplace failure mode that blocked Copilot CLI shell commands in 1.118.x.

Coverage added:
- `CopilotCLISDK.ensureShims()` is exercised through the real production path before SDK import.
- The test uses a synthetic Marketplace-style layout by separating the Copilot extension `extensionPath` from VS Code `appRoot`.
- Runtime shim materialization is asserted for both ripgrep and node-pty under the SDK expected locations.
- `copyNodePtyFiles()` directly verifies `pty.node` and `spawn-helper` land in `node_modules/@github/copilot/sdk/prebuilds/<platform>-<arch>`.
- The existing `shims.txt` skip behavior is covered without changing marker semantics.

This intentionally stays lighter than installing an actual VSIX in CI: it runs in the existing Copilot Vitest/unit PR checks (`Copilot - Test`) while still covering the runtime copy path that broke the marketplace-installed extension route.