### PR TITLE
Cache Explorer: handle Responses API continuations and tool definitions

### DIFF
--- a/extensions/copilot/src/extension/chat/vscode-node/chatDebugFileLoggerService.ts
+++ b/extensions/copilot/src/extension/chat/vscode-node/chatDebugFileLoggerService.ts
@@ -962,6 +962,9 @@ export class ChatDebugFileLoggerService extends Disposable implements IChatDebug
 						...(span.attributes[CopilotChatAttr.REQUEST_OPTIONS] !== undefined
 							? { requestOptions: String(span.attributes[CopilotChatAttr.REQUEST_OPTIONS]) }
 							: {}),
+						...(span.attributes[CopilotChatAttr.REQUEST_SHAPE] !== undefined
+							? { requestShape: String(span.attributes[CopilotChatAttr.REQUEST_SHAPE]) }
+							: {}),
 						...(isError && span.status.message ? { error: span.status.message } : {}),
 					},
 				};

--- a/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
+++ b/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
@@ -315,6 +315,10 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 					if (requestOptions) {
 						otelInferenceSpan.setAttribute(CopilotChatAttr.REQUEST_OPTIONS, truncateForOTel(JSON.stringify(requestOptions), this._otelService.config.maxAttributeSizeChars));
 					}
+					const requestShape = pickRequestShapeMetadata(requestBody);
+					if (requestShape) {
+						otelInferenceSpan.setAttribute(CopilotChatAttr.REQUEST_SHAPE, truncateForOTel(JSON.stringify(requestShape), this._otelService.config.maxAttributeSizeChars));
+					}
 				}
 				tokenCount = await countTokens();
 				const extensionId = source?.extensionId ?? EXTENSION_ID;
@@ -2285,6 +2289,36 @@ function pickCacheRelevantRequestOptions(body: IEndpointBody): Record<string, un
 		if (value !== undefined) {
 			out[key] = value;
 		}
+	}
+	return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/**
+ * Sanitized request-shape metadata for debug views. This intentionally omits
+ * identifiers such as `previous_response_id` itself and never includes message
+ * or tool contents; it only records whether a Responses API continuation marker
+ * was present and which top-level input item kinds were sent on the wire.
+ */
+function pickRequestShapeMetadata(body: IEndpointBody): Record<string, unknown> | undefined {
+	const out: Record<string, unknown> = {};
+	if (Array.isArray(body.input)) {
+		out.api = 'responses';
+		out.inputItemCount = body.input.length;
+		out.inputItemTypes = body.input.map(item => {
+			if (item && typeof item === 'object') {
+				const type = (item as Record<string, unknown>).type;
+				if (typeof type === 'string') {
+					return type;
+				}
+			}
+			return 'unknown';
+		});
+	} else if (Array.isArray(body.messages)) {
+		out.api = 'messages';
+		out.messageCount = body.messages.length;
+	}
+	if (typeof body.previous_response_id === 'string') {
+		out.hasPreviousResponseId = true;
 	}
 	return Object.keys(out).length > 0 ? out : undefined;
 }

--- a/extensions/copilot/src/extension/trajectory/vscode-node/otelSpanToChatDebugEvent.ts
+++ b/extensions/copilot/src/extension/trajectory/vscode-node/otelSpanToChatDebugEvent.ts
@@ -498,6 +498,14 @@ function resolveModelTurnContent(span: ICompletedSpanData): vscode.ChatDebugEven
 	if (inputMessages) {
 		sections.push(new vscode.ChatDebugMessageSection('Input Messages', inputMessages));
 	}
+	const requestShape = asString(span.attributes[CopilotChatAttr.REQUEST_SHAPE]);
+	if (requestShape) {
+		sections.push(new vscode.ChatDebugMessageSection('Request Shape', requestShape));
+	}
+	const toolDefinitions = asString(span.attributes[GenAiAttr.TOOL_DEFINITIONS]);
+	if (toolDefinitions) {
+		sections.push(new vscode.ChatDebugMessageSection('Tools', toolDefinitions));
+	}
 	const outputMessages = asString(span.attributes[GenAiAttr.OUTPUT_MESSAGES]);
 	if (outputMessages) {
 		sections.push(new vscode.ChatDebugMessageSection('Output Messages', outputMessages));
@@ -832,6 +840,10 @@ async function resolveModelTurnEntry(
 	const inputMessages = entry.attrs.inputMessages as string | undefined;
 	if (inputMessages) {
 		sections.push(new vscode.ChatDebugMessageSection('Input Messages', inputMessages));
+	}
+	const requestShape = entry.attrs.requestShape as string | undefined;
+	if (requestShape) {
+		sections.push(new vscode.ChatDebugMessageSection('Request Shape', requestShape));
 	}
 
 	// Read tools from companion file

--- a/extensions/copilot/src/platform/otel/common/genAiAttributes.ts
+++ b/extensions/copilot/src/platform/otel/common/genAiAttributes.ts
@@ -120,6 +120,8 @@ export const CopilotChatAttr = {
 	USER_REQUEST: 'copilot_chat.user_request',
 	/** Cache-relevant request options as a JSON blob (tool_choice, reasoning_effort, thinking, response_format, etc.). Used by Cache Explorer. */
 	REQUEST_OPTIONS: 'copilot_chat.request.options',
+	/** Request-shape metadata as a JSON blob (e.g. Responses API previous-response continuation and input item types). Used by Cache Explorer. */
+	REQUEST_SHAPE: 'copilot_chat.request.shape',
 	/** Resolved context section (code snippets, file contents, etc.) */
 	PROMPT_CONTEXT: 'copilot_chat.prompt_context',
 	/** Custom instructions section */

--- a/extensions/copilot/src/platform/otel/common/messageFormatters.ts
+++ b/extensions/copilot/src/platform/otel/common/messageFormatters.ts
@@ -47,6 +47,7 @@ export type OTelMessagePart =
 	| { type: 'text'; content: string }
 	| { type: 'tool_call'; id: string; name: string; arguments: unknown }
 	| { type: 'tool_call_response'; id: string; response: unknown }
+	| { type: 'tool_search_output'; id: string; tools?: unknown; status?: string }
 	| { type: 'reasoning'; content: string };
 
 export type OTelSystemInstruction = Array<{ type: 'text'; content: string }>;
@@ -140,16 +141,43 @@ export function toSystemInstructions(systemMessage: string | undefined): OTelSys
 }
 
 /**
- * Normalize provider-specific messages (Anthropic content blocks, OpenAI tool messages)
- * to OTel GenAI semantic convention format.
+ * Normalize provider-specific messages (Anthropic content blocks, OpenAI
+ * Chat Completions, OpenAI Responses API) to OTel GenAI semantic
+ * convention format.
  *
  * Handles:
- * - Anthropic content block arrays: tool_use → tool_call, tool_result → tool_call_response
- * - OpenAI format: tool_calls, role=tool with tool_call_id
+ * - Anthropic content block arrays: tool_use → tool_call, tool_result → tool_call_response, thinking → reasoning
+ * - OpenAI Chat Completions: tool_calls, role=tool with tool_call_id
+ * - OpenAI Responses API items: `type: 'message'` with `input_text` /
+ *   `output_text` content blocks; `type: 'function_call'` →
+ *   role=assistant + tool_call; `type: 'function_call_output'` →
+ *   role=tool + tool_call_response; `type: 'tool_search_output'` →
+ *   role=tool_search + tool_search_output; `type: 'reasoning'` →
+ *   role=assistant + reasoning part
  * - Plain string content
  */
 export function normalizeProviderMessages(messages: ReadonlyArray<Record<string, unknown>>): OTelChatMessage[] {
 	return messages.map(msg => {
+		// OpenAI Responses API items use `type` rather than (or in addition
+		// to) `role` to distinguish item kinds. Handle them up front so we
+		// always emit a populated `role` and `parts` array — otherwise the
+		// downstream cache-explorer diff sees `{role: undefined, parts: []}`
+		// for every item and reports the prompt as empty/unknown.
+		const itemType = msg.type as string | undefined;
+		switch (itemType) {
+			case 'function_call':
+				return normalizeResponsesFunctionCall(msg);
+			case 'function_call_output':
+				return normalizeResponsesFunctionCallOutput(msg);
+			case 'tool_search_output':
+				return normalizeResponsesToolSearchOutput(msg);
+			case 'reasoning':
+				return normalizeResponsesReasoning(msg);
+			// `type: 'message'` falls through — its `role` and `content` are
+			// handled by the regular branch below, with the addition that
+			// content blocks may be `input_text` / `output_text`.
+		}
+
 		const role = msg.role as string | undefined;
 		const parts: OTelMessagePart[] = [];
 		const content = msg.content;
@@ -163,12 +191,16 @@ export function normalizeProviderMessages(messages: ReadonlyArray<Record<string,
 		if (typeof content === 'string' && content.length > 0) {
 			parts.push({ type: 'text', content });
 		} else if (Array.isArray(content)) {
-			// Anthropic content block array
+			// Anthropic content block array — and also OpenAI Responses API
+			// `message` content arrays, which use `input_text` / `output_text`
+			// instead of `text` for the block type.
 			for (const block of content) {
 				if (!block || typeof block !== 'object') { continue; }
 				const b = block as Record<string, unknown>;
 				switch (b.type) {
 					case 'text':
+					case 'input_text':
+					case 'output_text':
 						if (typeof b.text === 'string') {
 							parts.push({ type: 'text', content: b.text });
 						}
@@ -223,6 +255,106 @@ export function normalizeProviderMessages(messages: ReadonlyArray<Record<string,
 
 		return { role, parts };
 	});
+}
+
+/**
+ * Normalize an OpenAI Responses API `function_call` item into a synthetic
+ * assistant message carrying a single `tool_call` part. The Responses API
+ * separates these from the conversation message stream; we re-attach them
+ * to a synthetic role so downstream consumers (cache explorer, telemetry
+ * viewers) can treat them uniformly with Chat Completions tool calls.
+ */
+function normalizeResponsesFunctionCall(msg: Record<string, unknown>): OTelChatMessage {
+	let args: unknown = msg.arguments;
+	if (typeof args === 'string') {
+		try { args = JSON.parse(args); } catch { /* keep raw string */ }
+	}
+	return {
+		role: 'assistant',
+		parts: [{
+			type: 'tool_call',
+			id: String(msg.call_id ?? msg.id ?? ''),
+			name: String(msg.name ?? ''),
+			arguments: args,
+		}],
+	};
+}
+
+/**
+ * Normalize an OpenAI Responses API `function_call_output` item into a
+ * synthetic tool message carrying a `tool_call_response` part. Mirrors how
+ * Chat Completions surfaces tool results via `role: 'tool'` messages.
+ */
+function normalizeResponsesFunctionCallOutput(msg: Record<string, unknown>): OTelChatMessage {
+	const output = msg.output;
+	let response: unknown;
+	if (typeof output === 'string') {
+		response = output;
+	} else if (Array.isArray(output)) {
+		// Output may be an array of `{ type: 'output_text', text }` blocks.
+		response = output
+			.map(b => (b && typeof b === 'object' && typeof (b as Record<string, unknown>).text === 'string') ? (b as Record<string, unknown>).text as string : JSON.stringify(b))
+			.join('');
+	} else {
+		response = output ?? '';
+	}
+	return {
+		role: 'tool',
+		parts: [{
+			type: 'tool_call_response',
+			id: String(msg.call_id ?? msg.id ?? ''),
+			response,
+		}],
+	};
+}
+
+/**
+ * Normalize an OpenAI Responses API `tool_search_output` item. This is a
+ * client-executed deferred-tool continuation: the request body only carries
+ * the newly resolved tool definitions, while the provider reconstructs the
+ * prior conversation from `previous_response_id`. Keep it distinct from a
+ * normal tool result so the Cache Explorer can label this request shape.
+ */
+function normalizeResponsesToolSearchOutput(msg: Record<string, unknown>): OTelChatMessage {
+	// Preserve the absent-vs-empty distinction: a request that omits `tools`
+	// is byte-different from one that sends `tools: []`, and that distinction
+	// can affect cache-key matching downstream. Build the part conditionally
+	// so the `tools` key is fully absent when the source request omits it.
+	const hasTools = Object.prototype.hasOwnProperty.call(msg, 'tools') && msg.tools !== undefined;
+	const part: { type: 'tool_search_output'; id: string; tools?: unknown; status?: string } = {
+		type: 'tool_search_output',
+		id: String(msg.call_id ?? msg.id ?? ''),
+		status: typeof msg.status === 'string' ? msg.status : undefined,
+	};
+	if (hasTools) {
+		part.tools = msg.tools;
+	}
+	return { role: 'tool_search', parts: [part] };
+}
+
+/**
+ * Normalize an OpenAI Responses API `reasoning` item. The Responses API
+ * doesn't expose plaintext reasoning unless `reasoning.summary` is enabled;
+ * when only `encrypted_content` is present, we still emit a non-empty part
+ * carrying the encrypted blob so the cache-explorer prefix diff includes
+ * its byte length (which IS part of the cache key).
+ */
+function normalizeResponsesReasoning(msg: Record<string, unknown>): OTelChatMessage {
+	const parts: OTelMessagePart[] = [];
+	const summary = msg.summary;
+	if (Array.isArray(summary)) {
+		for (const s of summary) {
+			if (s && typeof s === 'object' && typeof (s as Record<string, unknown>).text === 'string') {
+				parts.push({ type: 'reasoning', content: (s as Record<string, unknown>).text as string });
+			}
+		}
+	} else if (typeof summary === 'string') {
+		parts.push({ type: 'reasoning', content: summary });
+	}
+	if (typeof msg.encrypted_content === 'string') {
+		parts.push({ type: 'reasoning', content: msg.encrypted_content });
+	}
+	return { role: 'assistant', parts };
 }
 
 /**

--- a/extensions/copilot/src/platform/otel/common/test/messageFormatters.spec.ts
+++ b/extensions/copilot/src/platform/otel/common/test/messageFormatters.spec.ts
@@ -159,6 +159,79 @@ describe('normalizeProviderMessages', () => {
 			parts: [{ type: 'reasoning', content: 'Let me consider...' }],
 		}]);
 	});
+
+	it('converts OpenAI Responses API tool_search_output items', () => {
+		const result = normalizeProviderMessages([{
+			type: 'tool_search_output',
+			call_id: 'call_123',
+			status: 'completed',
+			tools: [{ type: 'function', name: 'read_file' }],
+		}]);
+		expect(result).toEqual([{
+			role: 'tool_search',
+			parts: [{
+				type: 'tool_search_output',
+				id: 'call_123',
+				status: 'completed',
+				tools: [{ type: 'function', name: 'read_file' }],
+			}],
+		}]);
+	});
+
+	it('preserves the absent-vs-empty tools distinction on tool_search_output', () => {
+		// Absent `tools` field is meaningfully different from `tools: []` for
+		// cache-key purposes; the normalizer must not coerce the two together.
+		const absent = normalizeProviderMessages([{ type: 'tool_search_output', call_id: 'a' }]);
+		const empty = normalizeProviderMessages([{ type: 'tool_search_output', call_id: 'a', tools: [] }]);
+		expect(absent[0].parts[0]).not.toHaveProperty('tools');
+		expect(empty[0].parts[0]).toHaveProperty('tools', []);
+	});
+
+	it('converts OpenAI Responses API function_call items into synthetic assistant tool_call', () => {
+		const result = normalizeProviderMessages([{
+			type: 'function_call',
+			call_id: 'call_abc',
+			name: 'apply_patch',
+			arguments: '{"path":"foo.ts"}',
+		}]);
+		expect(result).toEqual([{
+			role: 'assistant',
+			parts: [{
+				type: 'tool_call',
+				id: 'call_abc',
+				name: 'apply_patch',
+				arguments: { path: 'foo.ts' },
+			}],
+		}]);
+	});
+
+	it('falls back to id when function_call has no call_id and keeps raw arguments on parse failure', () => {
+		const result = normalizeProviderMessages([{
+			type: 'function_call',
+			id: 'fc_1',
+			name: 'run',
+			arguments: 'not-json',
+		}]);
+		expect(result).toEqual([{
+			role: 'assistant',
+			parts: [{ type: 'tool_call', id: 'fc_1', name: 'run', arguments: 'not-json' }],
+		}]);
+	});
+
+	it('converts OpenAI Responses API function_call_output (string and array output)', () => {
+		const result = normalizeProviderMessages([
+			{ type: 'function_call_output', call_id: 'call_1', output: 'plain result' },
+			{
+				type: 'function_call_output',
+				call_id: 'call_2',
+				output: [{ type: 'output_text', text: 'a' }, { type: 'output_text', text: 'b' }],
+			},
+		]);
+		expect(result).toEqual([
+			{ role: 'tool', parts: [{ type: 'tool_call_response', id: 'call_1', response: 'plain result' }] },
+			{ role: 'tool', parts: [{ type: 'tool_call_response', id: 'call_2', response: 'ab' }] },
+		]);
+	});
 });
 
 describe('toOutputMessages', () => {

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheDiff.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheDiff.ts
@@ -113,6 +113,8 @@ interface IRawPart {
 	readonly id?: string;
 	readonly arguments?: unknown;
 	readonly response?: unknown;
+	readonly tools?: unknown;
+	readonly status?: string;
 }
 
 interface IRawMessage {
@@ -151,6 +153,7 @@ export function parseInputMessages(inputMessagesJson: string | undefined): reado
 		let text = '';
 		let hasToolResponse = false;
 		let hasToolCall = false;
+		let hasToolSearchOutput = false;
 		let hasText = false;
 		if (Array.isArray(m.parts)) {
 			for (const p of m.parts) {
@@ -187,16 +190,37 @@ export function parseInputMessages(inputMessagesJson: string | undefined): reado
 						if (p.arguments !== undefined) { text += stableStringify(p.arguments); }
 						hasToolCall = true;
 						break;
+					case 'tool_search_output':
+						text += stableStringify({
+							id: p.id,
+							status: p.status,
+							tools: p.tools,
+						});
+						hasToolSearchOutput = true;
+						break;
 				}
 			}
 		}
 		// If a message is dominated by tool I/O, label its role accordingly
 		// so the visualization labels it as `tool` rather than as a `user`
 		// or `assistant` message with mysterious empty content.
-		if (hasToolResponse && !hasText) {
+		if (hasToolSearchOutput && !hasText) {
+			role = 'tool_search';
+		} else if (hasToolResponse && !hasText) {
 			role = 'tool';
 		} else if (hasToolCall && !hasText && role === 'assistant') {
 			role = 'assistant';
+		}
+		// Defensive fallback: if we recognized neither a role nor any
+		// content, dump the whole raw message as text so the diff still
+		// has *something* to compare. This catches provider-specific
+		// shapes that the upstream normalizer hasn't been taught about
+		// yet (e.g. a new `type: '...'` item type added to the OpenAI
+		// Responses API). Without this fallback the message reads as
+		// `unknown / 0 chars` and silently matches every other empty
+		// message, hiding real drift from the user.
+		if (text.length === 0 && role === 'unknown') {
+			text = stableStringify(m);
 		}
 		out.push({ role, name, text, charLength: text.length });
 	}
@@ -313,28 +337,105 @@ export function diffPromptSignature(a: readonly INormalizedMessage[], b: readonl
 }
 
 /**
- * Add a leading "system" drift entry to the report when the system
- * instructions differ between the two requests.
+ * Names of the synthetic "prefix" components that live alongside the message
+ * array in a request: the system instructions and the tool catalog. These
+ * are part of the cache key but not in `inputMessages`, so we surface them
+ * as named drift entries via {@link appendSystemDrift} / {@link appendToolsDrift}.
+ *
+ * Order matters: the helpers below preserve this order so the rendered
+ * Components accordion always reads `[system, tools, ...messages]`,
+ * regardless of which helper was called first or whether other entries
+ * were inserted in between.
+ */
+const PREFIX_COMPONENT_ORDER: readonly string[] = ['system', 'tools'];
+
+/**
+ * Insert a single prefix-component drift entry into a drift list while
+ * preserving the canonical order defined by {@link PREFIX_COMPONENT_ORDER}.
+ *
+ * Splits the input into "known-prefix entries" (those with a name in
+ * {@link PREFIX_COMPONENT_ORDER}) and "everything else", merges in the new
+ * entry, sorts the prefix bucket by its declared order, and concatenates.
+ * This means callers can append in any order and still get the same shape.
+ */
+function insertPrefixComponent(drift: readonly IComponentDrift[], entry: IComponentDrift): IComponentDrift[] {
+	const prefixEntries: IComponentDrift[] = [];
+	const rest: IComponentDrift[] = [];
+	for (const d of drift) {
+		if (PREFIX_COMPONENT_ORDER.includes(d.name)) {
+			// Defensive dedupe: if a caller already inserted an entry for the
+			// same prefix component (e.g. a refactor accidentally double-calls
+			// `appendToolsDrift`), keep only the latest one to avoid silently
+			// rendering two `tools` rows in the Components accordion.
+			if (d.name !== entry.name) {
+				prefixEntries.push(d);
+			}
+		} else {
+			rest.push(d);
+		}
+	}
+	prefixEntries.push(entry);
+	prefixEntries.sort((a, b) => PREFIX_COMPONENT_ORDER.indexOf(a.name) - PREFIX_COMPONENT_ORDER.indexOf(b.name));
+	return [...prefixEntries, ...rest];
+}
+
+/**
+ * Classify a string-pair drift. Returns `undefined` when both sides match
+ * (caller should skip emitting an entry).
+ */
+function classifyStringDrift(a: string | undefined, b: string | undefined): CacheDiffKind | undefined {
+	if (a === b) {
+		return undefined;
+	}
+	if (!a) {
+		return CacheDiffKind.OnlyInB;
+	}
+	if (!b) {
+		return CacheDiffKind.OnlyInA;
+	}
+	return a.length === b.length ? CacheDiffKind.ContentDrift : CacheDiffKind.LengthChange;
+}
+
+/**
+ * Add a "system" drift entry to the report when the system instructions
+ * differ between the two requests. Inserted at the canonical
+ * {@link PREFIX_COMPONENT_ORDER} position regardless of what's already in
+ * the drift list.
  */
 export function appendSystemDrift(
 	drift: IComponentDrift[],
 	aSystem: string | undefined,
 	bSystem: string | undefined,
 ): IComponentDrift[] {
-	if (aSystem === bSystem) {
+	const status = classifyStringDrift(aSystem, bSystem);
+	if (status === undefined) {
 		return drift;
 	}
-	const aSize = aSystem?.length ?? 0;
-	const bSize = bSystem?.length ?? 0;
-	let status: CacheDiffKind;
-	if (!aSystem) {
-		status = CacheDiffKind.OnlyInB;
-	} else if (!bSystem) {
-		status = CacheDiffKind.OnlyInA;
-	} else {
-		status = aSize === bSize ? CacheDiffKind.ContentDrift : CacheDiffKind.LengthChange;
+	return insertPrefixComponent(drift, { name: 'system', status, aSize: aSystem?.length ?? 0, bSize: bSystem?.length ?? 0 });
+}
+
+/**
+ * Add a "tools" drift entry to the report when the tool definitions catalog
+ * differs between the two requests. The catalog is part of the cache key on
+ * every model provider, so a change here \u2014 even a pure reorder \u2014 can break
+ * the prompt cache. We intentionally do not normalize (sort, hash, parse)
+ * the JSON: providers vary in how they hash the catalog, so the safest
+ * stance is to surface any byte-level change and let the user judge.
+ *
+ * Inserted at the canonical {@link PREFIX_COMPONENT_ORDER} position so the
+ * order is always `[system, tools, ...messages]` regardless of call order
+ * relative to {@link appendSystemDrift}.
+ */
+export function appendToolsDrift(
+	drift: IComponentDrift[],
+	aTools: string | undefined,
+	bTools: string | undefined,
+): IComponentDrift[] {
+	const status = classifyStringDrift(aTools, bTools);
+	if (status === undefined) {
+		return drift;
 	}
-	return [{ name: 'system', status, aSize, bSize }, ...drift];
+	return insertPrefixComponent(drift, { name: 'tools', status, aSize: aTools?.length ?? 0, bSize: bTools?.length ?? 0 });
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheExplorerView.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheExplorerView.ts
@@ -20,7 +20,7 @@ import { RangeMapping } from '../../../../../editor/common/diff/rangeMapping.js'
 import { IChatDebugEventModelTurnContent, IChatDebugMessageSection, IChatDebugModelTurnEvent, IChatDebugService, IChatDebugUserMessageEvent } from '../../common/chatDebugService.js';
 import { IChatService } from '../../common/chatService/chatService.js';
 import { LocalChatSessionUri } from '../../common/model/chatUri.js';
-import { appendSystemDrift, CacheDiffKind, diffPromptSignature, ICacheDiffResult, IComponentDrift, INormalizedMessage, parseInputMessages } from './chatDebugCacheDiff.js';
+import { appendSystemDrift, appendToolsDrift, CacheDiffKind, diffPromptSignature, ICacheDiffResult, IComponentDrift, INormalizedMessage, parseInputMessages } from './chatDebugCacheDiff.js';
 import { setupBreadcrumbKeyboardNavigation, TextBreadcrumbItem } from './chatDebugTypes.js';
 
 const $ = DOM.$;
@@ -31,6 +31,7 @@ const timeFormatter = safeIntl.DateTimeFormat(undefined, { hour: 'numeric', minu
 const RAIL_DEFAULT_WIDTH = 280;
 const RAIL_MIN_WIDTH = 180;
 const RAIL_MAX_WIDTH = 600;
+const CURRENT_CONTINUATION_DELTA_COMPONENT = 'current continuation delta';
 
 /**
  * Navigation events fired by the Cache Explorer breadcrumb.
@@ -45,7 +46,17 @@ interface ISideData {
 	readonly event: IChatDebugModelTurnEvent;
 	readonly content: IChatDebugEventModelTurnContent | undefined;
 	readonly system: string | undefined;
+	readonly tools: string | undefined;
 	readonly inputMessages: readonly INormalizedMessage[];
+	readonly requestShape: IRequestShapeInfo;
+}
+
+interface IRequestShapeInfo {
+	readonly label: string;
+	readonly description: string | undefined;
+	readonly isContinuation: boolean;
+	readonly api: string | undefined;
+	readonly inputItemTypes: readonly string[];
 }
 
 /** A grouping of model turns sharing the same parent (one user request). */
@@ -98,7 +109,7 @@ export class ChatDebugCacheExplorerView extends Disposable {
 	private readonly resolvedCache = new Map<string, IChatDebugEventModelTurnContent | undefined>();
 
 	/** Components currently expanded (by component name). */
-	private readonly openComponents = new Set<string>(['system']);
+	private readonly openComponents = new Set<string>(['system', 'tools']);
 
 	/** Rail groups currently collapsed (by group key — the parent event id). */
 	private readonly collapsedGroups = new Set<string>();
@@ -166,6 +177,7 @@ export class ChatDebugCacheExplorerView extends Disposable {
 			this.collapsedGroups.clear();
 			this.openComponents.clear();
 			this.openComponents.add('system');
+			this.openComponents.add('tools');
 			this.selectedIndex = -1;
 		}
 		this.currentSessionResource = sessionResource;
@@ -257,13 +269,16 @@ export class ChatDebugCacheExplorerView extends Disposable {
 			return;
 		}
 
-		const diff = diffPromptSignature(a.inputMessages, b.inputMessages);
-		const drift = appendSystemDrift([...diff.drift], a.system, b.system);
+		const compareInputMessages = shouldCompareInputMessages(a, b);
+		const diff = compareInputMessages
+			? diffPromptSignature(a.inputMessages, b.inputMessages)
+			: diffPromptSignature([], []);
+		const drift = appendToolsDrift(appendSystemDrift([...diff.drift], a.system, b.system), a.tools, b.tools);
 
 		this.renderSummary(a, b, diff);
-		this.renderSignature(a, b, diff);
+		this.renderSignature(a, b, diff, compareInputMessages);
 		this.renderRequestOptions(a, b);
-		this.renderComponents(drift, a, b);
+		this.renderComponents(drift, a, b, compareInputMessages);
 	}
 
 	private async resolveSide(event: IChatDebugModelTurnEvent): Promise<ISideData> {
@@ -278,9 +293,36 @@ export class ChatDebugCacheExplorerView extends Disposable {
 			}
 		}
 		const system = findSection(content?.sections, 'System');
+		const tools = findSection(content?.sections, 'Tools');
+		const requestShapeJson = findSection(content?.sections, 'Request Shape');
 		const inputMessagesJson = findSection(content?.sections, 'Input Messages');
-		const inputMessages = parseInputMessages(inputMessagesJson);
-		return { event, content, system, inputMessages };
+		const rawMessages = parseInputMessages(inputMessagesJson);
+		// `chatMLFetcher.ts` extracts the system prompt from the messages
+		// array AND emits it separately as `gen_ai.system_instructions`.
+		// That double-counts the system prompt: once as the synthetic
+		// `system` segment we already render, and a second time as
+		// messages[0]. Strip leading system-role messages here so the
+		// signature lane reads `[system, tools, ...userMessages]`
+		// regardless of how the provider chose to ferry the system prompt
+		// (in-band as messages[0], or out-of-band via `instructions` /
+		// top-level `system`). The synthetic `system` component still
+		// diffs the system content faithfully because both sides go
+		// through the same dedup.
+		// Strip leading system-role messages here so the signature lane reads
+		// `[system, tools, ...userMessages]` regardless of how the provider
+		// chose to ferry the system prompt (in-band as messages[0], or
+		// out-of-band via `instructions` / top-level `system`). Loop in case a
+		// provider prepends multiple system-role messages; the synthetic
+		// `system` component still diffs the system content faithfully because
+		// both sides go through the same dedup.
+		let stripFrom = 0;
+		if (system) {
+			while (stripFrom < rawMessages.length && rawMessages[stripFrom].role === 'system') {
+				stripFrom++;
+			}
+		}
+		const inputMessages = stripFrom > 0 ? rawMessages.slice(stripFrom) : rawMessages;
+		return { event, content, system, tools, inputMessages, requestShape: describeRequestShape(inputMessages, requestShapeJson) };
 	}
 
 	private renderRail(groups: readonly ITurnGroup[]): void {
@@ -399,7 +441,15 @@ export class ChatDebugCacheExplorerView extends Disposable {
 		const cachedTokens = b.event.cachedTokens ?? 0;
 		const lostTokens = Math.max(0, inputTokens - cachedTokens);
 		const optionsDiff = computeOptionsDiff(a, b);
-		const expiration = isLikelyCacheExpiration(hit, diff, optionsDiff);
+		const systemChanged = (a.system ?? '') !== (b.system ?? '');
+		const toolsChanged = (a.tools ?? '') !== (b.tools ?? '');
+		// Treat the comparison as a continuation only when the *current* request
+		// is a continuation. The previous turn's shape doesn't change how the
+		// current request was sent on the wire, so labeling a normal full-input
+		// current request as "continuation" just because the prior turn was
+		// would be misleading. Keep this in sync with `shouldCompareInputMessages`.
+		const continuationComparison = b.requestShape.isContinuation;
+		const expiration = !continuationComparison && isLikelyCacheExpiration(hit, diff, optionsDiff, systemChanged, toolsChanged);
 
 		const headline = DOM.append(breakCard, $('.chat-debug-cache-card-headline'));
 		if (expiration) {
@@ -416,21 +466,63 @@ export class ChatDebugCacheExplorerView extends Disposable {
 			numberFormatter.value.format(cachedTokens),
 			numberFormatter.value.format(inputTokens),
 		);
+		if (b.requestShape.description) {
+			const shapeLine = DOM.append(breakCard, $('.chat-debug-cache-perf-line.chat-debug-cache-request-shape-note'));
+			shapeLine.textContent = b.requestShape.description;
+		}
 
 		// Section 2: where the cache broke
 		DOM.append(breakCard, $('.chat-debug-cache-perf-rule'));
-		DOM.append(breakCard, $('.chat-debug-cache-perf-section-h', undefined, localize('chatDebug.cache.whereBroke', "Where the cache broke")));
+		DOM.append(breakCard, $('.chat-debug-cache-perf-section-h', undefined, continuationComparison
+			? localize('chatDebug.cache.visibleWireInput', "Visible wire input")
+			: localize('chatDebug.cache.whereBroke', "Where the cache broke")));
 		const breakLine = DOM.append(breakCard, $('.chat-debug-cache-perf-line'));
 		if (expiration) {
 			breakLine.textContent = localize('chatDebug.cache.expirationNote',
 				"The prompt prefix matches but the model still treated this as a fresh request. Most likely the cached entry expired between requests.",
 			);
+		} else if (systemChanged) {
+			breakLine.textContent = localize('chatDebug.cache.systemBroke',
+				"System instructions changed — the cache was invalidated even though the message prefix matches.",
+			);
+		} else if (toolsChanged) {
+			breakLine.textContent = localize('chatDebug.cache.toolsBroke',
+				"Tool definitions changed — the catalog of available tools differs between requests, which invalidates the cache even though the message prefix matches.",
+			);
+			if (continuationComparison && diff.break) {
+				const deltaName = diff.break.index === 0
+					? localize('chatDebug.cache.firstMessage', "the first message")
+					: `messages[${diff.break.index}]`;
+				const deltaLine = DOM.append(breakCard, $('.chat-debug-cache-perf-line'));
+				deltaLine.textContent = localize('chatDebug.cache.continuationDeltaAlsoChanged',
+					"The visible wire delta also changed at {0}. That is expected when comparing consecutive continuation requests of different kinds, such as tool_search_output followed by a new user input.",
+					deltaName,
+				);
+			}
+		} else if (continuationComparison && diff.break) {
+			const componentName = diff.break.index === 0
+				? localize('chatDebug.cache.firstMessage', "the first message")
+				: `messages[${diff.break.index}]`;
+			breakLine.textContent = localize('chatDebug.cache.continuationDeltaBreak',
+				"The captured wire delta changed at {0} — {1}. This is a delta-to-delta comparison between consecutive Responses API requests, not the full reconstructed prompt prefix.",
+				componentName,
+				describeBreakKind(diff.break.kind, diff, b),
+			);
+			if (lostTokens > 0 && inputTokens > 0) {
+				const lostPct = (lostTokens / inputTokens) * 100;
+				const lossLine = DOM.append(breakCard, $('.chat-debug-cache-perf-line'));
+				lossLine.textContent = localize('chatDebug.cache.uncachedLine',
+					"Uncached in this request: {0} tokens ({1}% of this request)",
+					numberFormatter.value.format(lostTokens),
+					formatCachePct(lostPct),
+				);
+			}
 		} else if (diff.break) {
 			const componentName = diff.break.index === 0
 				? localize('chatDebug.cache.firstMessage', "the first message")
 				: `messages[${diff.break.index}]`;
 			breakLine.textContent = localize('chatDebug.cache.breakAt',
-				"At {0} \u2014 {1}",
+				"At {0} — {1}",
 				componentName,
 				describeBreakKind(diff.break.kind, diff, b),
 			);
@@ -445,8 +537,10 @@ export class ChatDebugCacheExplorerView extends Disposable {
 			}
 		} else if (optionsDiff.length > 0) {
 			breakLine.textContent = localize('chatDebug.cache.optionsBroke',
-				"Request options changed \u2014 the cache was invalidated even though the message prefix matches.",
+				"Request options changed — the cache was invalidated even though the message prefix matches.",
 			);
+		} else if (continuationComparison) {
+			breakLine.textContent = localize('chatDebug.cache.continuationNoDeltaBreak', "No divergence detected in the captured wire delta. The full reconstructed prompt prefix is provider-side for this continuation request.");
 		} else {
 			breakLine.textContent = localize('chatDebug.cache.noBreak', "No prefix divergence detected.");
 		}
@@ -492,6 +586,7 @@ export class ChatDebugCacheExplorerView extends Disposable {
 		this.appendKv(card, localize('chatDebug.cache.inputTok', "input tok"), formatTokens(data.event.inputTokens));
 		this.appendKv(card, localize('chatDebug.cache.cachedTok', "cached tok"), formatTokens(data.event.cachedTokens));
 		this.appendKv(card, localize('chatDebug.cache.cacheHit', "cache hit"), `${formatCachePct(computeCacheHit(data.event))}%`);
+		this.appendKv(card, localize('chatDebug.cache.requestShape', "shape"), data.requestShape.label);
 
 		const startTime = data.event.created;
 		const endTime = data.event.durationInMillis !== undefined
@@ -531,6 +626,10 @@ export class ChatDebugCacheExplorerView extends Disposable {
 		headline.textContent = `${formatCachePct(computeCacheHit(b.event))}%`;
 		const sub = DOM.append(note, $('.chat-debug-cache-card-sub'));
 		sub.textContent = localize('chatDebug.cache.firstRequestNote', "OTel-reported cache hit. Nothing earlier in this session to diff against \u2014 the system prompt and tools may still match a previous session's cache.");
+		if (b.requestShape.description) {
+			const shapeLine = DOM.append(note, $('.chat-debug-cache-perf-line.chat-debug-cache-request-shape-note'));
+			shapeLine.textContent = b.requestShape.description;
+		}
 	}
 
 	private appendKv(parent: HTMLElement, key: string, value: string, copyable: boolean = false): void {
@@ -543,45 +642,70 @@ export class ChatDebugCacheExplorerView extends Disposable {
 		}
 	}
 
-	private renderSignature(a: ISideData, b: ISideData, diff: ICacheDiffResult): void {
+	private renderSignature(a: ISideData, b: ISideData, diff: ICacheDiffResult, compareInputMessages: boolean): void {
+		// See note next to `continuationComparison` in `renderSummary`: only the
+		// current request's shape determines whether this is a continuation view.
+		const continuationComparison = b.requestShape.isContinuation;
 		const section = DOM.append(this.content, $('.chat-debug-cache-section'));
 		const heading = DOM.append(section, $('h3.chat-debug-cache-section-h'));
-		heading.textContent = localize('chatDebug.cache.signatureHeading', "Prompt Signature");
+		heading.textContent = continuationComparison
+			? localize('chatDebug.cache.visibleSignatureHeading', "Visible Request Signature")
+			: localize('chatDebug.cache.signatureHeading', "Prompt Signature");
+		if (continuationComparison) {
+			const note = DOM.append(section, $('.chat-debug-cache-sig-summary.chat-debug-cache-request-shape-note'));
+			note.textContent = localize('chatDebug.cache.visibleSignatureNote', "For Responses API continuations, this shows the captured request inputs: system instructions, tools sent on this request, and the visible input delta. Earlier conversation state is referenced by previous response id and is not expanded here.");
+		}
 
 		const legend = DOM.append(section, $('.chat-debug-cache-sig-legend'));
-		for (const role of ['system', 'user', 'assistant', 'tool']) {
+		// Order matters: keep `tools` (orange, the catalog of available tools)
+		// far from `tool` (yellow, individual tool result messages) so they
+		// aren't read as the same thing.
+		for (const role of ['system', 'user', 'assistant', 'tool', 'tool_search', 'tools']) {
 			const entry = DOM.append(legend, $('span.chat-debug-cache-sig-legend-entry'));
-			DOM.append(entry, $(`span.chat-debug-cache-sig-swatch.role-${role}`));
-			DOM.append(entry, DOM.$('span', undefined, role));
+			DOM.append(entry, $(`span.chat-debug-cache-sig-swatch.role-${roleClass(role)}`));
+			DOM.append(entry, DOM.$('span', undefined, role === 'tools'
+				? localize('chatDebug.cache.legend.tools', "tools (catalog)")
+				: role === 'tool_search'
+					? localize('chatDebug.cache.legend.toolSearch', "tool search")
+					: role));
 		}
 		const driftEntry = DOM.append(legend, $('span.chat-debug-cache-sig-legend-entry'));
 		DOM.append(driftEntry, $('span.chat-debug-cache-sig-swatch.role-drift'));
 		DOM.append(driftEntry, DOM.$('span', undefined, localize('chatDebug.cache.driftLegend', "drift")));
 
-		// Per-side char-length sequences. We prepend a synthetic 'system' segment for
-		// the system prompt so it shows up in the bar even though it's not in
-		// the inputMessages array.
+		// Per-side char-length sequences. We prepend synthetic 'system' and
+		// 'tools' segments (when present) so they show up in the bar even
+		// though they are not part of the inputMessages array. The synthetic
+		// segments share the cache-key role with the messages: a change in
+		// either also breaks the prefix.
 		interface ISegment {
 			readonly role: string;
 			readonly chars: number;
 			readonly drift: boolean;
 			readonly label: string;
+			/** True if this is one of the synthetic prefix segments (system/tools). */
+			readonly synthetic: boolean;
 		}
 		const toSegments = (side: ISideData, isA: boolean): ISegment[] => {
 			const segs: ISegment[] = [];
 			const sys = side.system;
 			if (sys) {
 				const other = isA ? b.system : a.system;
-				segs.push({ role: 'system', chars: sys.length, drift: sys !== (other ?? ''), label: 'system' });
+				segs.push({ role: 'system', chars: sys.length, drift: sys !== (other ?? ''), label: 'system', synthetic: true });
+			}
+			const tools = side.tools;
+			if (tools) {
+				const other = isA ? b.tools : a.tools;
+				segs.push({ role: 'tools', chars: tools.length, drift: tools !== (other ?? ''), label: 'tools', synthetic: true });
 			}
 			side.inputMessages.forEach((m, i) => {
 				const tok = diff.signature[i];
 				const kind = tok?.kind;
-				const drift = kind === CacheDiffKind.ContentDrift
+				const drift = compareInputMessages && (kind === CacheDiffKind.ContentDrift
 					|| kind === CacheDiffKind.LengthChange
 					|| (isA && kind === CacheDiffKind.OnlyInA)
-					|| (!isA && kind === CacheDiffKind.OnlyInB);
-				segs.push({ role: m.role, chars: m.charLength, drift, label: m.name ? `${m.role}-${m.name}` : m.role });
+					|| (!isA && kind === CacheDiffKind.OnlyInB));
+				segs.push({ role: m.role, chars: m.charLength, drift, label: m.name ? `${m.role}-${m.name}` : m.role, synthetic: false });
 			});
 			return segs;
 		};
@@ -601,14 +725,13 @@ export class ChatDebugCacheExplorerView extends Disposable {
 			if (!diff.break) {
 				return undefined;
 			}
-			// Skip the synthetic system segment when matching diff.break.index.
+			// Skip the synthetic system / tools segments when matching
+			// diff.break.index, which is an index into the messages array.
 			let cumulative = 0;
-			let skipSystem = segs[0]?.role === 'system';
 			let idx = 0;
 			for (const s of segs) {
-				if (skipSystem) {
+				if (s.synthetic) {
 					cumulative += s.chars;
-					skipSystem = false;
 					continue;
 				}
 				if (idx === diff.break.index) {
@@ -660,32 +783,45 @@ export class ChatDebugCacheExplorerView extends Disposable {
 		lanes.appendChild(buildLane(localize('chatDebug.cache.lanePrevious', "Previous"), aSegs, breakCharPos(aSegs)));
 		lanes.appendChild(buildLane(localize('chatDebug.cache.laneCurrent', "Current"), bSegs, breakCharPos(bSegs)));
 
-		// Single-line text summary below the bars.
+		// Single-line text summary below the bars. Compute this in the
+		// same order the provider sees cache-keying inputs: system, tools,
+		// then captured input messages. This avoids reporting messages[0] as
+		// the first break when the tool catalog changed earlier.
 		let shared = 0;
-		for (const tok of diff.signature) {
-			if (tok.kind === CacheDiffKind.Identical) {
-				shared += tok.bCharLength ?? 0;
+		let firstDrift: string | undefined;
+		if (a.system || b.system) {
+			if ((a.system ?? '') === (b.system ?? '')) {
+				shared += b.system?.length ?? 0;
 			} else {
-				break;
+				firstDrift = localize('chatDebug.cache.systemComponent', "system");
 			}
 		}
-		if (a.system && a.system === b.system) {
-			shared += a.system.length;
+		if (!firstDrift && (a.tools || b.tools)) {
+			if ((a.tools ?? '') === (b.tools ?? '')) {
+				shared += b.tools?.length ?? 0;
+			} else {
+				firstDrift = localize('chatDebug.cache.toolsComponent', "tools catalog");
+			}
+		}
+		if (!firstDrift) {
+			for (const tok of diff.signature) {
+				if (tok.kind === CacheDiffKind.Identical) {
+					shared += tok.bCharLength ?? 0;
+				} else {
+					firstDrift = `messages[${tok.index}]`;
+					break;
+				}
+			}
 		}
 		const summary = DOM.append(section, $('.chat-debug-cache-sig-summary'));
-		if (diff.break) {
-			summary.textContent = localize('chatDebug.cache.signatureSummaryBreak',
-				"{0} of {1} chars reused \u00b7 break at messages[{2}]",
-				numberFormatter.value.format(shared),
-				numberFormatter.value.format(totalB),
-				diff.break.index,
-			);
+		if (firstDrift) {
+			summary.textContent = continuationComparison
+				? localize('chatDebug.cache.visibleSignatureSummaryBreak', "{0} of {1} captured request chars match before first captured drift: {2}", numberFormatter.value.format(shared), numberFormatter.value.format(totalB), firstDrift)
+				: localize('chatDebug.cache.signatureSummaryBreakComponent', "{0} of {1} chars reused · break at {2}", numberFormatter.value.format(shared), numberFormatter.value.format(totalB), firstDrift);
 		} else {
-			summary.textContent = localize('chatDebug.cache.signatureSummaryClean',
-				"{0} of {1} chars reused \u00b7 no divergence detected",
-				numberFormatter.value.format(shared),
-				numberFormatter.value.format(totalB),
-			);
+			summary.textContent = continuationComparison
+				? localize('chatDebug.cache.visibleSignatureSummaryClean', "{0} of {1} captured request chars match · no captured divergence detected", numberFormatter.value.format(shared), numberFormatter.value.format(totalB))
+				: localize('chatDebug.cache.signatureSummaryClean', "{0} of {1} chars reused · no divergence detected", numberFormatter.value.format(shared), numberFormatter.value.format(totalB));
 		}
 	}
 
@@ -727,19 +863,28 @@ export class ChatDebugCacheExplorerView extends Disposable {
 		}
 	}
 
-	private renderComponents(drift: readonly IComponentDrift[], a: ISideData, b: ISideData): void {
+	private renderComponents(drift: readonly IComponentDrift[], a: ISideData, b: ISideData, compareInputMessages: boolean): void {
 		const section = DOM.append(this.content, $('.chat-debug-cache-section'));
 		DOM.append(section, $('h3.chat-debug-cache-section-h', undefined, localize('chatDebug.cache.componentsHeading', "Components")));
+		if (!compareInputMessages && b.requestShape.isContinuation) {
+			const note = DOM.append(section, $('.chat-debug-cache-sig-summary.chat-debug-cache-request-shape-note'));
+			note.textContent = localize('chatDebug.cache.continuationComponentsNote', "This request uses previous_response_id, so input messages are not positionally diffed against the previous request. Components below show cache-key shape changes; the current continuation delta is shown separately.");
+		}
 		const acc = DOM.append(section, $('.chat-debug-cache-acc'));
 
-		if (drift.length === 0) {
+		const effectiveDrift = !compareInputMessages && b.requestShape.isContinuation && b.inputMessages.length > 0
+			? [...drift, currentDeltaComponent(b)]
+			: drift;
+
+		if (effectiveDrift.length === 0) {
 			const empty = DOM.append(acc, $('.chat-debug-cache-acc-empty'));
 			empty.textContent = localize('chatDebug.cache.allComponentsIdentical', "All components are identical between A and B.");
 			return;
 		}
 
-		for (const c of drift) {
+		for (const c of effectiveDrift) {
 			const item = DOM.append(acc, $('.chat-debug-cache-acc-item'));
+			item.classList.add(c.status);
 			if (this.openComponents.has(c.name)) { item.classList.add('open'); }
 			const head = DOM.append(item, $('.chat-debug-cache-acc-head'));
 			DOM.append(head, $('span.chat-debug-cache-chev'));
@@ -749,11 +894,22 @@ export class ChatDebugCacheExplorerView extends Disposable {
 			const badge = DOM.append(head, $(`span.chat-debug-cache-acc-badge.${c.status}`));
 			badge.textContent = badgeLabel(c.status);
 			const sizes = DOM.append(head, $('span.chat-debug-cache-acc-sizes'));
-			sizes.textContent = `${formatTokens(c.aSize)} → ${formatTokens(c.bSize)} B`;
+			sizes.textContent = localize('chatDebug.cache.componentSizes', "{0} → {1} chars", formatTokens(c.aSize), formatTokens(c.bSize));
 
 			const body = DOM.append(item, $('.chat-debug-cache-acc-body'));
-			const aText = textForComponent(c, a);
-			const bText = textForComponent(c, b);
+			const aText = c.name === CURRENT_CONTINUATION_DELTA_COMPONENT ? '' : textForComponent(c, a);
+			const bText = c.name === CURRENT_CONTINUATION_DELTA_COMPONENT ? continuationDeltaText(b) : textForComponent(c, b);
+			// Surface OTel-side truncation: when either side ends with the
+			// truncation marker emitted by `truncateForOTel`, the diff below
+			// will only reflect the surviving prefix. Most likely on `tools`
+			// (large MCP catalogs) and very long messages.
+			const truncationNote = describeTruncation(aText, bText);
+			if (truncationNote) {
+				const note = DOM.append(item, $('.chat-debug-cache-acc-truncated'));
+				note.textContent = truncationNote;
+				note.title = truncationNote;
+				head.title = truncationNote;
+			}
 			body.appendChild(this.renderComponentDiff(aText, bText, c.aSize, c.bSize));
 
 			this.loadDisposables.add(DOM.addDisposableListener(head, DOM.EventType.CLICK, () => {
@@ -837,12 +993,35 @@ function textForComponent(c: IComponentDrift, side: ISideData): string {
 	if (c.name === 'system') {
 		return side.system ?? '';
 	}
+	if (c.name === 'tools') {
+		return side.tools ?? '';
+	}
+	if (c.name === CURRENT_CONTINUATION_DELTA_COMPONENT) {
+		return continuationDeltaText(side);
+	}
 	const m = /^messages\[(\d+)\]$/.exec(c.name);
 	if (m) {
 		const idx = parseInt(m[1], 10);
 		return side.inputMessages[idx]?.text ?? '';
 	}
 	return '';
+}
+
+function continuationDeltaText(side: ISideData): string {
+	return side.requestShape.isContinuation
+		? side.inputMessages.map((m, index) => `input[${index}] ${m.role}\n${m.text}`).join('\n\n')
+		: '';
+}
+
+function currentDeltaComponent(side: ISideData): IComponentDrift {
+	const size = side.inputMessages.reduce((sum, m) => sum + m.charLength, 0);
+	return {
+		name: CURRENT_CONTINUATION_DELTA_COMPONENT,
+		role: side.requestShape.inputItemTypes.join(', ') || side.inputMessages.map(m => m.role).join(', ') || undefined,
+		status: CacheDiffKind.OnlyInB,
+		aSize: 0,
+		bSize: size,
+	};
 }
 
 function badgeLabel(status: CacheDiffKind): string {
@@ -853,6 +1032,41 @@ function badgeLabel(status: CacheDiffKind): string {
 		case CacheDiffKind.OnlyInA: return localize('chatDebug.cache.badge.onlyA', "only in A");
 		case CacheDiffKind.OnlyInB: return localize('chatDebug.cache.badge.onlyB', "only in B");
 	}
+}
+
+/**
+ * Detect the OTel truncation marker that `truncateForOTel` appends to large
+ * attribute values: `...[truncated, original N chars]`. When either side of
+ * a component carries it, the diff below only reflects the surviving
+ * prefix \u2014 differences past the cap are invisible. We surface that as a
+ * one-line note above the diff so users don't read a partial diff as
+ * authoritative.
+ *
+ * Returns `undefined` when neither side is truncated.
+ */
+function describeTruncation(aText: string, bText: string): string | undefined {
+	const re = /\.\.\.\[truncated, original (\d+) chars\]$/;
+	const aMatch = re.exec(aText);
+	const bMatch = re.exec(bText);
+	if (!aMatch && !bMatch) {
+		return undefined;
+	}
+	if (aMatch && bMatch) {
+		return localize('chatDebug.cache.truncatedBoth',
+			"Both sides truncated by the OTel attribute cap (originals were {0} and {1} chars) \u2014 diff may be partial.",
+			numberFormatter.value.format(parseInt(aMatch[1], 10)),
+			numberFormatter.value.format(parseInt(bMatch[1], 10)),
+		);
+	}
+	const match = (aMatch ?? bMatch)!;
+	const side = aMatch
+		? localize('chatDebug.cache.truncatedSidePrev', "Previous")
+		: localize('chatDebug.cache.truncatedSideCurr', "Current");
+	return localize('chatDebug.cache.truncatedOne',
+		"{0} side truncated by the OTel attribute cap (original was {1} chars) \u2014 diff may be partial.",
+		side,
+		numberFormatter.value.format(parseInt(match[1], 10)),
+	);
 }
 
 /**
@@ -889,6 +1103,99 @@ function computeCacheHit(event: IChatDebugModelTurnEvent): number {
 	return Math.min(100, (event.cachedTokens / event.inputTokens) * 100);
 }
 
+function shouldCompareInputMessages(a: ISideData, b: ISideData): boolean {
+	// A Responses API continuation (`previous_response_id`) sends only the
+	// current wire delta. Positionally diffing that delta against the other
+	// side's input array makes it look as if previous context disappeared,
+	// when it is actually provider-side state. Suppress message-level diffing
+	// when *either* side is a continuation — the comparison would be
+	// asymmetric (delta vs. full input). Still compare system/tools and
+	// request options; show the current delta as a separate component.
+	return !a.requestShape.isContinuation && !b.requestShape.isContinuation;
+}
+
+interface IRequestShapeMetadata {
+	readonly api?: string;
+	readonly hasPreviousResponseId?: boolean;
+	readonly inputItemTypes?: readonly string[];
+}
+
+function describeRequestShape(inputMessages: readonly INormalizedMessage[], requestShapeJson: string | undefined): IRequestShapeInfo {
+	const metadata = parseRequestShapeMetadata(requestShapeJson);
+	// Defensive: a malformed log entry could deserialize `inputItemTypes` as
+	// something other than an array, which would crash `.includes(...)` below.
+	const inputItemTypes = Array.isArray(metadata?.inputItemTypes)
+		? metadata.inputItemTypes.filter((x): x is string => typeof x === 'string')
+		: [];
+	const common = { api: typeof metadata?.api === 'string' ? metadata.api : undefined, inputItemTypes };
+	const hasPreviousResponseId = metadata?.hasPreviousResponseId === true;
+	const hasToolSearchOutput = inputItemTypes.includes('tool_search_output') || inputMessages.some(m => m.role === 'tool_search');
+	const hasOnlyToolOutput = inputMessages.length > 0 && inputMessages.every(m => m.role === 'tool');
+
+	if (hasPreviousResponseId && hasToolSearchOutput) {
+		return {
+			label: localize('chatDebug.cache.requestShape.toolSearch', "tool_search_output continuation"),
+			description: localize('chatDebug.cache.requestShape.toolSearchDescription', "Responses API continuation: the displayed input is only the tool-search delta sent over the wire. The provider reconstructs prior context from the previous response id."),
+			isContinuation: true,
+			...common,
+		};
+	}
+	if (hasPreviousResponseId && hasOnlyToolOutput) {
+		return {
+			label: localize('chatDebug.cache.requestShape.toolOutput', "tool output continuation"),
+			description: localize('chatDebug.cache.requestShape.toolOutputDescription', "Responses API continuation: the displayed input is only the tool-output delta sent over the wire. The provider reconstructs prior context from the previous response id."),
+			isContinuation: true,
+			...common,
+		};
+	}
+	if (hasPreviousResponseId) {
+		return {
+			label: localize('chatDebug.cache.requestShape.continuation', "Responses API continuation"),
+			description: localize('chatDebug.cache.requestShape.continuationDescription', "Responses API continuation: the displayed input is only the delta sent over the wire. The provider reconstructs prior context from the previous response id."),
+			isContinuation: true,
+			...common,
+		};
+	}
+	if (hasToolSearchOutput) {
+		return {
+			label: localize('chatDebug.cache.requestShape.toolSearchRequest', "tool_search_output request"),
+			description: localize('chatDebug.cache.requestShape.toolSearchRequestDescription', "This request contains a Responses API tool_search_output item. No previous-response continuation marker was captured, so the displayed input may be a full or history-sliced request rather than only a continuation delta."),
+			isContinuation: false,
+			...common,
+		};
+	}
+	if (hasOnlyToolOutput) {
+		return {
+			label: localize('chatDebug.cache.requestShape.toolOutputRequest', "tool output request"),
+			description: undefined,
+			isContinuation: false,
+			...common,
+		};
+	}
+	return {
+		label: localize('chatDebug.cache.requestShape.fullInput', "full input request"),
+		description: undefined,
+		isContinuation: false,
+		...common,
+	};
+}
+
+function parseRequestShapeMetadata(requestShapeJson: string | undefined): IRequestShapeMetadata | undefined {
+	if (!requestShapeJson) {
+		return undefined;
+	}
+	try {
+		const parsed = JSON.parse(requestShapeJson) as IRequestShapeMetadata;
+		if (parsed && typeof parsed === 'object') {
+			return parsed;
+		}
+	} catch {
+		// Ignore malformed metadata. The input-message role fallback still
+		// provides a conservative label for older or partially captured logs.
+	}
+	return undefined;
+}
+
 /**
  * Maps a normalized message role onto the small set of CSS color classes
  * the prompt-signature visualization recognizes. Unknown roles fall through
@@ -897,10 +1204,16 @@ function computeCacheHit(event: IChatDebugModelTurnEvent): number {
 function roleClass(role: string): string {
 	switch (role) {
 		case 'system':
+		case 'tools':
 		case 'user':
 		case 'assistant':
 		case 'tool':
 			return role;
+		case 'tool_search':
+			// Use a hyphenated CSS class for consistency with the rest of the
+			// `role-*` swatch/segment classes; the underlying data role keeps
+			// `tool_search` to match the OTel-emitted role string.
+			return 'tool-search';
 		default:
 			return 'tool';
 	}
@@ -1024,13 +1337,14 @@ function formatOptionValue(value: unknown): string {
  * Cache "expiration" heuristic. The provider doesn't tell us *why* it
  * invalidated a cache entry, so this is a best-effort guess: if the
  * structural diff says the prompt prefix is byte-identical AND the
+ * system instructions match AND the tool catalog matches AND the
  * request options match AND the model still reports 0 cached input
  * tokens, expiration is the most likely cause. Other causes we cannot
  * distinguish from this signal alone include provider-side eviction
  * under cache pressure, server-side restarts, and per-tenant quota
  * resets. The headline copy in the UI says "likely" for that reason.
  */
-function isLikelyCacheExpiration(hitPct: number, diff: ICacheDiffResult, optionsDiff: readonly IOptionDelta[]): boolean {
+function isLikelyCacheExpiration(hitPct: number, diff: ICacheDiffResult, optionsDiff: readonly IOptionDelta[], systemChanged: boolean, toolsChanged: boolean): boolean {
 	if (hitPct >= 1) {
 		return false;
 	}
@@ -1038,6 +1352,9 @@ function isLikelyCacheExpiration(hitPct: number, diff: ICacheDiffResult, options
 		return false;
 	}
 	if (optionsDiff.length > 0) {
+		return false;
+	}
+	if (systemChanged || toolsChanged) {
 		return false;
 	}
 	return true;

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/media/chatDebug.css
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/media/chatDebug.css
@@ -1048,6 +1048,10 @@
 	color: var(--vscode-foreground);
 	line-height: 1.5;
 }
+.chat-debug-cache-request-shape-note {
+	margin-top: 6px;
+	color: var(--vscode-descriptionForeground);
+}
 .chat-debug-cache-options-banner {
 	font-family: var(--monaco-monospace-font);
 	font-size: 11.5px;
@@ -1140,6 +1144,9 @@
 .chat-debug-cache-sig-swatch.role-system {
 	background: var(--vscode-charts-purple, #b292ff);
 }
+.chat-debug-cache-sig-swatch.role-tools {
+	background: var(--vscode-charts-orange, #d9822b);
+}
 .chat-debug-cache-sig-swatch.role-user {
 	background: var(--vscode-charts-blue);
 }
@@ -1148,6 +1155,9 @@
 }
 .chat-debug-cache-sig-swatch.role-tool {
 	background: var(--vscode-charts-yellow);
+}
+.chat-debug-cache-sig-swatch.role-tool-search {
+	background: var(--vscode-charts-foreground, #56b6c2);
 }
 .chat-debug-cache-sig-swatch.role-drift {
 	background: transparent;
@@ -1209,6 +1219,10 @@
 	background: var(--vscode-charts-purple, #b292ff);
 	color: #1a0e30;
 }
+.chat-debug-cache-sig-seg.role-tools {
+	background: var(--vscode-charts-orange, #d9822b);
+	color: #2a1500;
+}
 .chat-debug-cache-sig-seg.role-user {
 	background: var(--vscode-charts-blue);
 	color: #06243d;
@@ -1220,6 +1234,10 @@
 .chat-debug-cache-sig-seg.role-tool {
 	background: var(--vscode-charts-yellow);
 	color: #2a1d00;
+}
+.chat-debug-cache-sig-seg.role-tool-search {
+	background: var(--vscode-charts-foreground, #56b6c2);
+	color: #102326;
 }
 .chat-debug-cache-sig-seg.role-empty {
 	background: transparent;
@@ -1255,8 +1273,19 @@
 .chat-debug-cache-acc-item {
 	background: var(--vscode-editorWidget-background);
 	border: 1px solid var(--vscode-widget-border, var(--vscode-editorWidget-border));
+	border-left-width: 3px;
 	border-radius: 6px;
 	overflow: hidden;
+}
+.chat-debug-cache-acc-item.contentDrift,
+.chat-debug-cache-acc-item.lengthChange {
+	border-left-color: var(--vscode-charts-red);
+}
+.chat-debug-cache-acc-item.onlyInA {
+	border-left-color: var(--vscode-charts-yellow);
+}
+.chat-debug-cache-acc-item.onlyInB {
+	border-left-color: var(--vscode-charts-blue);
 }
 .chat-debug-cache-acc-head {
 	display: grid;
@@ -1333,6 +1362,23 @@
 }
 .chat-debug-cache-acc-item.open .chat-debug-cache-acc-body {
 	display: block;
+}
+.chat-debug-cache-acc-truncated {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 6px 12px;
+	font-size: 11px;
+	line-height: 1.4;
+	color: var(--vscode-notificationsWarningIcon-foreground, var(--vscode-charts-orange));
+	background: var(--vscode-inputValidation-warningBackground, transparent);
+	border-top: 1px solid var(--vscode-widget-border, var(--vscode-editorWidget-border));
+}
+.chat-debug-cache-acc-truncated::before {
+	content: "\26A0";
+	flex-shrink: 0;
+	font-size: 12px;
+	line-height: 1;
 }
 .chat-debug-cache-diff {
 	display: grid;

--- a/src/vs/workbench/contrib/chat/test/browser/chatDebugCacheDiff.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatDebugCacheDiff.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { appendSystemDrift, CacheDiffKind, diffPromptSignature, formatSignatureToken, parseInputMessages } from '../../browser/chatDebug/chatDebugCacheDiff.js';
+import { appendSystemDrift, appendToolsDrift, CacheDiffKind, diffPromptSignature, formatSignatureToken, parseInputMessages } from '../../browser/chatDebug/chatDebugCacheDiff.js';
 
 function msg(role: string, content: string, name?: string) {
 	const part: { type: string; content: string; name?: string } = { type: 'text', content };
@@ -52,6 +52,17 @@ suite('chatDebugCacheDiff', () => {
 			const expected = `call:fs_read${JSON.stringify({ path: '/etc/hosts' })}`;
 			assert.deepStrictEqual(parseInputMessages(json), [
 				{ role: 'assistant', name: undefined, text: expected, charLength: expected.length },
+			]);
+		});
+
+		test('extracts tool_search_output content and labels role distinctly', () => {
+			const payload = { id: 'call_1', status: 'completed', tools: [{ type: 'function', name: 'read_file' }] };
+			const json = JSON.stringify([
+				{ role: 'tool_search', parts: [{ type: 'tool_search_output', ...payload }] },
+			]);
+			const expected = JSON.stringify(payload);
+			assert.deepStrictEqual(parseInputMessages(json), [
+				{ role: 'tool_search', name: undefined, text: expected, charLength: expected.length },
 			]);
 		});
 	});
@@ -156,6 +167,33 @@ suite('chatDebugCacheDiff', () => {
 		test('appendSystemDrift returns input unchanged when system matches', () => {
 			const existing = [{ name: 'messages[0]', role: 'user', status: CacheDiffKind.ContentDrift, aSize: 4, bSize: 4 }];
 			assert.deepStrictEqual(appendSystemDrift(existing, 'sys', 'sys'), existing);
+		});
+
+		test('appendToolsDrift returns input unchanged when tools match', () => {
+			const existing = [{ name: 'messages[0]', role: 'user', status: CacheDiffKind.ContentDrift, aSize: 4, bSize: 4 }];
+			assert.deepStrictEqual(appendToolsDrift(existing, '[tools]', '[tools]'), existing);
+			assert.deepStrictEqual(appendToolsDrift(existing, undefined, undefined), existing);
+		});
+
+		test('appendToolsDrift classifies all kinds and inserts after a leading system entry', () => {
+			const sys = { name: 'system', status: CacheDiffKind.LengthChange, aSize: 4, bSize: 6 };
+			const msg = { name: 'messages[0]', role: 'user', status: CacheDiffKind.ContentDrift, aSize: 4, bSize: 4 };
+			assert.deepStrictEqual(
+				{
+					onlyInA: appendToolsDrift([msg], '[a]', undefined),
+					onlyInB: appendToolsDrift([msg], undefined, '[b]'),
+					contentDrift: appendToolsDrift([msg], '[ab]', '[cd]'),
+					lengthChange: appendToolsDrift([msg], '[a]', '[abc]'),
+					afterSystem: appendToolsDrift([sys, msg], '[a]', '[abc]'),
+				},
+				{
+					onlyInA: [{ name: 'tools', status: CacheDiffKind.OnlyInA, aSize: 3, bSize: 0 }, msg],
+					onlyInB: [{ name: 'tools', status: CacheDiffKind.OnlyInB, aSize: 0, bSize: 3 }, msg],
+					contentDrift: [{ name: 'tools', status: CacheDiffKind.ContentDrift, aSize: 4, bSize: 4 }, msg],
+					lengthChange: [{ name: 'tools', status: CacheDiffKind.LengthChange, aSize: 3, bSize: 5 }, msg],
+					afterSystem: [sys, { name: 'tools', status: CacheDiffKind.LengthChange, aSize: 3, bSize: 5 }, msg],
+				},
+			);
 		});
 	});
 


### PR DESCRIPTION
## What's the problem?

The Cache Explorer in Agent Debug Logs was misleading on requests that use the OpenAI Responses API with `previous_response_id`. Examples seen in real sessions:

- `tool_search_output` continuation requests were rendered as `unknown / 0 chars` because the OTel normalizer dropped `type: 'tool_search_output'` items into `{role: undefined, parts: []}`.
- A `tools` catalog change was reported as "break at messages[0]" because the prompt signature one-liner walked input messages before checking the synthetic system/tools prefix components.
- Components positionally diffed previous full-input request `messages[0]` against current continuation delta `messages[0]`, making it look like prior context was deleted when in reality it lives provider-side behind `previous_response_id`.
- Cache-expiration heuristic could fire on continuations even though we cannot prove the full provider-reconstructed prompt prefix matches.

## What's the fix?

### OTel pipeline

- Capture tool definitions per chat span as `gen_ai.tool.definitions`.
- Add a sanitized `copilot_chat.request.shape` attribute carrying `{api, hasPreviousResponseId, inputItemCount, inputItemTypes}`. **No IDs or content** are captured.
- Persist both attributes through the file logger and surface them in resolved model-turn debug content for live and replayed sessions.

### Provider message normalization

- Treat `tool_search_output` as a distinct `tool_search` role with a `tool_search_output` part instead of dropping it through the generic fallback.
- Add explicit normalization for `function_call`, `function_call_output`, and `tool_search_output` Responses API item types.
- Preserve the absent-vs-empty `tools` distinction on `tool_search_output` so cache-key-relevant byte-level differences are not flattened.

### Cache Explorer UI

- Add a `tools` (catalog) component diff alongside `system`.
- Add a `tool search` color/legend role distinct from `tool` results, with a hyphenated CSS class for consistency.
- Re-frame the prompt signature one-liner in prefix order (system, tools, messages) so a tools-catalog change is no longer misreported as `break at messages[0]`.
- For Responses API continuation requests:
  - Suppress positional message diffing against the previous request — the wire delta is asymmetric with the previous full input, so positional diffs are misleading.
  - Render the current continuation delta as its own component (Current side only).
  - Label the comparison as **Visible Request Signature** instead of **Prompt Signature**.
  - Skip the cache-expiration heuristic since the full provider-reconstructed prompt cannot be inferred from the wire delta.
- Strip multiple leading system messages on dedup, harden prefix component insertion against double-insertion, and guard against malformed `inputItemTypes` metadata.
