### PR TITLE
Force-close lingering connections in request test teardown

### DIFF
--- a/src/vs/base/parts/request/test/electron-main/request.test.ts
+++ b/src/vs/base/parts/request/test/electron-main/request.test.ts
@@ -49,6 +49,7 @@ suite('Request', () => {
 
 	teardown(async () => {
 		await new Promise<void>((resolve, reject) => {
+			server.closeAllConnections();
 			server.close(err => err ? reject(err) : resolve());
 		});
 	});


### PR DESCRIPTION
## Summary

Fixes a flaky `Timeout of 30000ms exceeded` failure in the `"after each" hook for "cancel"` of `vs/base/parts/request/test/electron-main/request.test`, observed on Linux CI.

The `cancel` and `timeout` tests open a request to a `/noreply` endpoint that the test server intentionally never responds to. After the client aborts/times out, the server-side socket can remain open when teardown runs, causing `server.close()` to wait until all connections drain — which never happens, and the hook hits the 30s mocha timeout.

Calling `server.closeAllConnections()` (Node 18.2+) before `server.close()` destroys those lingering sockets so `close()` resolves promptly.

<details>
<summary>Session Context</summary>

- **Diagnosis**: The failure is in the `after each` hook for `cancel`, not the test body. `server.close()` keeps existing connections alive by design, so any socket from `/noreply` that hasn't fully torn down on the server side blocks teardown until the mocha timeout.
- **Fix scope**: Limited to the test teardown. No production code changes; the `request` implementation is unaffected.
- **Why `closeAllConnections()`**: Available since Node 18.2 (well within VS Code's supported range) and is the documented way to force in-flight server-side sockets closed.

</details>