### PR TITLE
sessions editor group actions

### DIFF
--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -90,6 +90,7 @@ export class MenuId {
 	static readonly EditorTitle = new MenuId('EditorTitle');
 	static readonly EditorTitleLayout = new MenuId('EditorTitleLayout');
 	static readonly ModalEditorTitle = new MenuId('ModalEditorTitle');
+	static readonly ModalEditorTitleContext = new MenuId('ModalEditorTitleContext');
 	static readonly ModalEditorEditorTitle = new MenuId('ModalEditorEditorTitle');
 	static readonly CompactWindowEditorTitle = new MenuId('CompactWindowEditorTitle');
 	static readonly EditorTitleRun = new MenuId('EditorTitleRun');

--- a/src/vs/sessions/contrib/editor/browser/editor.contribution.ts
+++ b/src/vs/sessions/contrib/editor/browser/editor.contribution.ts
@@ -9,7 +9,7 @@ import { ServicesAccessor } from '../../../../editor/browser/editorExtensions.js
 import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
-import { EditorPartModalContext, IsSessionsWindowContext } from '../../../../workbench/common/contextkeys.js';
+import { EditorPartModalContext, IsSessionsWindowContext, IsTopRightEditorGroupContext } from '../../../../workbench/common/contextkeys.js';
 import { IAgentWorkbenchLayoutService } from '../../../browser/workbench.js';
 import { EditorMaximizedContext } from '../../../common/contextkeys.js';
 import { IViewsService } from '../../../../workbench/services/views/common/viewsService.js';
@@ -31,7 +31,7 @@ class MaximizeMainEditorPartAction extends Action2 {
 	constructor() {
 		super({
 			id: MaximizeMainEditorPartAction.ID,
-			title: localize2('maximizeMainEditorPart', "Maximize Editor"),
+			title: localize2('maximizeMainEditorPart', "Maximize Editor Area"),
 			icon: Codicon.screenFull,
 			f1: false,
 			menu: {
@@ -40,6 +40,7 @@ class MaximizeMainEditorPartAction extends Action2 {
 				order: 99,
 				when: ContextKeyExpr.and(
 					IsSessionsWindowContext,
+					IsTopRightEditorGroupContext,
 					EditorMaximizedContext.negate())
 			}
 		});
@@ -73,7 +74,7 @@ class RestoreMainEditorPartAction extends Action2 {
 	constructor() {
 		super({
 			id: RestoreMainEditorPartAction.ID,
-			title: localize2('restoreMainEditorPart', "Restore Editor"),
+			title: localize2('restoreMainEditorPart', "Restore Editor Area"),
 			icon: Codicon.screenNormal,
 			f1: false,
 			menu: {
@@ -82,6 +83,7 @@ class RestoreMainEditorPartAction extends Action2 {
 				order: 99,
 				when: ContextKeyExpr.and(
 					IsSessionsWindowContext,
+					IsTopRightEditorGroupContext,
 					EditorMaximizedContext)
 			}
 		});
@@ -109,14 +111,16 @@ class CloseMainEditorPartAction extends Action2 {
 	constructor() {
 		super({
 			id: CloseMainEditorPartAction.ID,
-			title: localize2('closeMainEditorPart', "Close Editor"),
+			title: localize2('closeMainEditorPart', "Close Editor Area"),
 			icon: Codicon.close,
 			f1: false,
 			menu: {
 				id: MenuId.EditorTitleLayout,
 				group: 'navigation',
 				order: 100,
-				when: IsSessionsWindowContext
+				when: ContextKeyExpr.and(
+					IsSessionsWindowContext,
+					IsTopRightEditorGroupContext)
 			}
 		});
 	}
@@ -142,7 +146,9 @@ class OpenEditorInModalEditorAction extends Action2 {
 				id: MenuId.EditorTitleLayout,
 				group: 'navigation',
 				order: 1,
-				when: IsSessionsWindowContext
+				when: ContextKeyExpr.and(
+					IsSessionsWindowContext
+				)
 			}
 		});
 	}
@@ -180,7 +186,7 @@ class OpenEditorInModalEditorAction extends Action2 {
 		activeGroup.moveEditors(editorsToMove, modalPart.activeGroup);
 
 		// Maximize
-		if (isMaximized) {
+		if (isMaximized && !modalPart.maximized) {
 			modalPart.toggleMaximized();
 		}
 
@@ -197,7 +203,7 @@ class OpenModalEditorInEditorAction extends Action2 {
 	constructor() {
 		super({
 			id: OpenModalEditorInEditorAction.ID,
-			title: localize2('openModalEditorInEditor', "Open in Editor"),
+			title: localize2('openModalEditorInEditor', "Open in Editor Area"),
 			icon: Codicon.openInWindow,
 			f1: false,
 			menu: {

--- a/src/vs/workbench/browser/parts/editor/editorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommands.ts
@@ -1486,12 +1486,12 @@ function registerModalEditorCommands(): void {
 				f1: true,
 				icon: Codicon.emptyWindow,
 				precondition: EditorPartModalContext,
-				menu: {
-					id: MenuId.ModalEditorTitle,
-					group: 'navigation',
+				menu: [{
+					id: MenuId.ModalEditorTitleContext,
+					group: '1_window',
 					order: 0,
 					when: IsSessionsWindowContext
-				}
+				}]
 			});
 		}
 		async run(accessor: ServicesAccessor): Promise<void> {

--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -34,7 +34,7 @@ import { IBoundarySashes } from '../../../../base/browser/ui/sash/sash.js';
 import { IHostService } from '../../../services/host/browser/host.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { ServiceCollection } from '../../../../platform/instantiation/common/serviceCollection.js';
-import { EditorPartMaximizedEditorGroupContext, EditorPartMultipleEditorGroupsContext, EditorTabsVisibleContext } from '../../../common/contextkeys.js';
+import { EditorPartMaximizedEditorGroupContext, EditorPartMultipleEditorGroupsContext, EditorTabsVisibleContext, IsTopRightEditorGroupContext } from '../../../common/contextkeys.js';
 import { mainWindow } from '../../../../base/browser/window.js';
 
 export interface IEditorPartUIState {
@@ -1065,13 +1065,43 @@ export class EditorPart extends Part<IEditorPartMemento> implements IEditorPart,
 			editorTabsVisibleContext.set(this.partOptions.showTabs === 'multiple');
 		};
 
+		const updateTopRightGroupContextKey = () => {
+			if (!this.gridWidget || !this._contentDimension) {
+				return;
+			}
+
+			let topRightGroup: IEditorGroupView | undefined;
+			for (const group of this.groups) {
+				if (
+					this.gridWidget.getNeighborViews(group, Direction.Up).length === 0 &&
+					this.gridWidget.getNeighborViews(group, Direction.Right).length === 0
+				) {
+					topRightGroup = group;
+					break;
+				}
+			}
+
+			for (const group of this.groups) {
+				const contextKey = this.editorPartsView.bind(IsTopRightEditorGroupContext, group);
+				contextKey.set(group === topRightGroup);
+			}
+		};
+
 		updateContextKeys();
 		updateEditorTabsVisibleContext();
 
-		this._register(this.onDidAddGroup(() => updateContextKeys()));
-		this._register(this.onDidRemoveGroup(() => updateContextKeys()));
+		this._register(this.onDidAddGroup(() => {
+			updateContextKeys();
+			updateTopRightGroupContextKey();
+		}));
+		this._register(this.onDidRemoveGroup(() => {
+			updateContextKeys();
+			updateTopRightGroupContextKey();
+		}));
 		this._register(this.onDidChangeGroupMaximized(() => updateContextKeys()));
 		this._register(this.onDidChangeEditorPartOptions(() => updateEditorTabsVisibleContext()));
+		this._register(this.onDidMoveGroup(() => updateTopRightGroupContextKey()));
+		this._register(this.onDidLayout(() => updateTopRightGroupContextKey()));
 	}
 
 	private setupDragAndDropSupport(parent: HTMLElement, container: HTMLElement): void {

--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -1089,6 +1089,7 @@ export class EditorPart extends Part<IEditorPartMemento> implements IEditorPart,
 
 		updateContextKeys();
 		updateEditorTabsVisibleContext();
+		updateTopRightGroupContextKey();
 
 		this._register(this.onDidAddGroup(() => {
 			updateContextKeys();

--- a/src/vs/workbench/browser/parts/editor/modalEditorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/modalEditorPart.ts
@@ -19,10 +19,10 @@ import { MenuId } from '../../../../platform/actions/common/actions.js';
 import { HiddenItemStrategy, MenuWorkbenchToolBar, WorkbenchToolBar } from '../../../../platform/actions/browser/toolbar.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { ServiceCollection } from '../../../../platform/instantiation/common/serviceCollection.js';
-import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
-import { ResultKind } from '../../../../platform/keybinding/common/keybindingResolver.js';
+import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js'; import { ResultKind } from '../../../../platform/keybinding/common/keybindingResolver.js';
 import { IStorageService } from '../../../../platform/storage/common/storage.js';
 import { IThemeService } from '../../../../platform/theme/common/themeService.js';
 import { IEditorGroupView, IEditorPartsView } from './editor.js';
@@ -147,6 +147,7 @@ export class ModalEditorPart {
 		@IKeybindingService private readonly keybindingService: IKeybindingService,
 		@IHostService private readonly hostService: IHostService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IContextMenuService private readonly contextMenuService: IContextMenuService,
 	) {
 	}
 
@@ -382,6 +383,21 @@ export class ModalEditorPart {
 			EventHelper.stop(e);
 
 			editorPart.handleHeaderDoubleClick();
+		}));
+
+		// Handle right-click on header to open context menu
+		disposables.add(addDisposableListener(headerElement, EventType.CONTEXT_MENU, e => {
+			const target = e.target;
+			if (isHTMLElement(target) && (target.closest('.monaco-button') || target.closest('.action-item'))) {
+				return; // do not show our context menu over header buttons / actions
+			}
+
+			EventHelper.stop(e, true);
+
+			this.contextMenuService.showContextMenu({
+				menuId: MenuId.ModalEditorTitleContext,
+				getAnchor: () => ({ x: e.clientX, y: e.clientY })
+			});
 		}));
 
 		const layout = (sizeChanged: boolean) => {

--- a/src/vs/workbench/browser/parts/editor/modalEditorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/modalEditorPart.ts
@@ -22,7 +22,8 @@ import { IContextKeyService } from '../../../../platform/contextkey/common/conte
 import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { ServiceCollection } from '../../../../platform/instantiation/common/serviceCollection.js';
-import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js'; import { ResultKind } from '../../../../platform/keybinding/common/keybindingResolver.js';
+import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
+import { ResultKind } from '../../../../platform/keybinding/common/keybindingResolver.js';
 import { IStorageService } from '../../../../platform/storage/common/storage.js';
 import { IThemeService } from '../../../../platform/theme/common/themeService.js';
 import { IEditorGroupView, IEditorPartsView } from './editor.js';

--- a/src/vs/workbench/common/contextkeys.ts
+++ b/src/vs/workbench/common/contextkeys.ts
@@ -80,6 +80,7 @@ export const ActiveCustomEditorTextDiffContext = new RawContextKey<boolean>('act
 
 // Editor Group Context Keys
 export const EditorGroupEditorsCountContext = new RawContextKey<number>('groupEditorsCount', 0, localize('groupEditorsCount', "The number of opened editor groups"));
+export const IsTopRightEditorGroupContext = new RawContextKey<boolean>('isTopRightEditorGroup', false, localize('isTopRightEditorGroup', "Whether the editor group is the top right editor group in the editor part"));
 export const ActiveEditorGroupEmptyContext = new RawContextKey<boolean>('activeEditorGroupEmpty', false, localize('activeEditorGroupEmpty', "Whether the active editor group is empty"));
 export const ActiveEditorGroupIndexContext = new RawContextKey<number>('activeEditorGroupIndex', 0, localize('activeEditorGroupIndex', "The index of the active editor group"));
 export const ActiveEditorGroupLastContext = new RawContextKey<boolean>('activeEditorGroupLast', false, localize('activeEditorGroupLast', "Whether the active editor group is the last group"));


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce a new context key for identifying the top right editor group and update related actions and menus to utilize this context. Adjust titles for clarity and implement context menu support for the modal editor header.

