### PR TITLE
Adjust padding for tabbed action list tab bar

### DIFF
--- a/src/vs/platform/actionWidget/browser/tabbedActionListWidget.css
+++ b/src/vs/platform/actionWidget/browser/tabbedActionListWidget.css
@@ -10,7 +10,7 @@
 .action-widget .tabbed-action-list-tabbar {
 	display: flex;
 	align-items: center;
-	padding: 4px 4px 8px;
+	padding: 0 0 4px;
 }
 
 .action-widget .tabbed-action-list-tabbar .monaco-custom-radio {


### PR DESCRIPTION
This pull request makes a minor UI adjustment to the `tabbedActionListWidget.css` file, specifically changing the padding for the `.tabbed-action-list-tabbar` class to improve alignment. The tab bar now has a consistent `4px` margin around the element.

<img width="396" height="161" alt="image" src="https://github.com/user-attachments/assets/20490da8-498f-405a-b3b6-b8875984408a" />


UI update: Adjusted the padding of `.tabbed-action-list-tabbar` from `4px 4px 8px` to `0 0 4px` for better layout consistency.

Addresses: https://github.com/microsoft/vscode/issues/314458