### PR TITLE
Add selected foreground and icon foreground colors for editor suggest widget

### DIFF
--- a/extensions/theme-defaults/themes/2026-light.json
+++ b/extensions/theme-defaults/themes/2026-light.json
@@ -143,6 +143,8 @@
 		"editorSuggestWidget.foreground": "#202020",
 		"editorSuggestWidget.highlightForeground": "#0069CC",
 		"editorSuggestWidget.selectedBackground": "#0069CC26",
+		"editorSuggestWidget.selectedForeground": "#202020",
+		"editorSuggestWidget.selectedIconForeground": "#202020",
 		"editorHoverWidget.background": "#FAFAFD",
 		"editorHoverWidget.border": "#E4E5E6FF",
 		"peekView.border": "#0069CC",


### PR DESCRIPTION
This pull request makes a minor update to the `2026-light.json` theme file, improving the appearance of the editor suggestion widget by setting the foreground colors for selected items and icons.

- Theme improvements:
  * Added `editorSuggestWidget.selectedForeground` and `editorSuggestWidget.selectedIconForeground` color settings to ensure selected suggestion text and icons are clearly visible in the editor suggestion widget.

**Before**
<img width="1030" height="412" alt="image" src="https://github.com/user-attachments/assets/e5ea2d73-9b66-4205-aea2-1d495a73cc8b" />

**After**
<img width="507" height="360" alt="image" src="https://github.com/user-attachments/assets/99e61747-019a-40da-906a-ea0f5b3a9f3e" />

Addresses: https://github.com/microsoft/vscode/issues/314519