### PR TITLE
chat: fix customizations list cut off when switching sections and in sidebar

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -454,7 +454,11 @@ export class AICustomizationManagementEditor extends EditorPane {
 			layout: (width, _, height) => {
 				this.sidebarContainer.style.width = `${width}px`;
 				if (height !== undefined) {
-					this.sectionsList.layout(height - 8, width);
+					// Subtract sidebar-content padding (4px each side = 8px) and the
+					// header row height. Without subtracting the header the sections
+					// list overflows and the bottom items are clipped.
+					const headerHeight = this.sidebarHeaderContainer?.offsetHeight ?? 0;
+					this.sectionsList.layout(Math.max(0, height - 8 - headerHeight), width);
 				}
 			},
 		}, savedWidth, undefined, true);
@@ -1059,6 +1063,14 @@ export class AICustomizationManagementEditor extends EditorPane {
 		// Load items for the new section (only for prompts-based sections)
 		if (this.isPromptsSection(section)) {
 			void this.listWidget.setSection(section);
+		}
+
+		// Re-layout after visibility change so the newly-visible widget can
+		// measure its flex-computed container height correctly. Without this,
+		// a widget that was previously hidden (offsetHeight === 0) keeps its
+		// stale listContainer height and clips items at the bottom.
+		if (this.dimension) {
+			this.layout(this.dimension);
 		}
 
 		this.ensureSectionsListReflectsActiveSection(section);


### PR DESCRIPTION
## Problem

The customizations list was getting cut off in two distinct ways:

1. **Content list clipped after switching sections** — Clicking a section in the sidebar would sometimes show only a handful of rows in a tall container, with the rest of the list hidden below the clipped edge.

2. **Sidebar section list clips bottom entries** — The last few section labels (e.g. Plugins, Models) were not visible in the sidebar even when there was enough vertical space.

## Root Cause

**Fix 1 — Section switch:** `selectSection()` called `updateContentVisibility()` to show/hide widget containers (via `display:none → display:''`) but never called `this.layout(this.dimension)` afterward. When a widget had previously been hidden, its last `layout()` call happened with `offsetHeight === 0`. The `_layoutDeferred` guard correctly deferred one rAF, but because `display:none` was set, the rAF still measured 0 — so `listContainer.style.height` was left at whatever stale value it had, clipping items at the bottom. `selectSectionById()` already did the post-visibility re-layout; `selectSection()` was missing it.

**Fix 2 — Sidebar:** `sectionsList.layout(height - 8, width)` subtracted only the 8 px of sidebar-content padding, ignoring the sidebar header row (home button + harness dropdown). Recent commits added `min-height: 26px` and adjusted padding on the harness dropdown button, making the header taller. The sections list therefore overflowed its container and bottom items were clipped. Fix: subtract `sidebarHeaderContainer.offsetHeight` from the available height.

## Changes

`src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts`

- In `selectSection()`: add `this.layout(this.dimension)` after `updateContentVisibility()` so the newly-visible widget gets a real measurement pass.
- In the sidebar split-view `layout` callback: subtract the actual header row height (`sidebarHeaderContainer.offsetHeight`) in addition to the padding, so `sectionsList` is always sized to the true remaining space.