### PR TITLE
Agents: hide sidebar description for hidden tool invocations

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessionDescription.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessionDescription.ts
@@ -41,6 +41,12 @@ export function getInProgressSessionDescription(chatModel: IChatModel): string |
 			description = part.message;
 		} else if (part.kind === 'toolInvocation') {
 			const toolInvocation = part as IChatToolInvocation;
+			// Skip hidden tool invocations — they are not shown in the chat
+			// view, so they shouldn't surface a description in the sidebar
+			// either (e.g. a no-op `manage_todo_list` write).
+			if (IChatToolInvocation.isEffectivelyHidden(toolInvocation)) {
+				continue;
+			}
 			const state = toolInvocation.state.get();
 			description = toolInvocation.generatedTitle || toolInvocation.pastTenseMessage || toolInvocation.invocationMessage;
 			if (state.type === IChatToolInvocation.StateKind.WaitingForConfirmation) {
@@ -52,6 +58,9 @@ export function getInProgressSessionDescription(chatModel: IChatModel): string |
 				description = titleMessage ?? localize('chat.sessions.description.waitingForConfirmation', "Waiting for confirmation: {0}", descriptionValue);
 			}
 		} else if (part.kind === 'toolInvocationSerialized') {
+			if (IChatToolInvocation.isEffectivelyHidden(part)) {
+				continue;
+			}
 			description = part.invocationMessage;
 		} else if (part.kind === 'progressMessage') {
 			description = part.content;

--- a/src/vs/workbench/contrib/chat/common/tools/builtinTools/manageTodoListTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/builtinTools/manageTodoListTool.ts
@@ -173,8 +173,10 @@ export class ManageTodoListTool extends Disposable implements IToolImpl {
 	}
 
 	private generatePastTenseMessage(currentTodos: IChatTodo[], newTodos: IManageTodoListToolInputParams['todoList']): string {
-		// If no current todos, this is creating new ones
-		if (currentTodos.length === 0) {
+		// If no current todos and we're adding new ones, this is creating new ones.
+		// When both lists are empty (a no-op write), fall through to the default
+		// "Updated todo list" message rather than showing "Created 0 todos".
+		if (currentTodos.length === 0 && newTodos.length > 0) {
 			return newTodos.length === 1
 				? localize('todo.created.single', "Created 1 todo")
 				: localize('todo.created.multiple', "Created {0} todos", newTodos.length);


### PR DESCRIPTION
The sidebar in the Agents app sometimes showed "Created 0 todos" or similar misleading text under a session title, like:

<img width="1196" height="254" alt="Google Chrome 2026-05-06 19 11 23" src="https://github.com/user-attachments/assets/52147daa-bad3-4288-abd4-29c29aea94d0" />


This came from the `manage_todo_list` tool's `pastTenseMessage` being surfaced via `getInProgressSessionDescription`, even though the tool invocation was already marked as `ToolInvocationPresentation.Hidden` (so it wasn't shown in the chat view at all).

### Changes

- **`getInProgressSessionDescription`**: skip tool invocations that are effectively hidden (`IChatToolInvocation.isEffectivelyHidden`), so the sidebar falls through to the previous meaningful part instead of leaking text from a hidden tool call. Applied to both `toolInvocation` and `toolInvocationSerialized` parts.

- **`manageTodoListTool.generatePastTenseMessage`**: don't generate "Created 0 todos" for a no-op write (no current and no new todos); fall through to the default "Updated todo list" message. This is correct independently of the sidebar fix — "Created 0 todos" is wrong wording in any context.

### Why two changes?

The sidebar fix alone is sufficient to fix the user-visible issue, but the `generatePastTenseMessage` fix is also worth keeping because the message could conceivably surface elsewhere (e.g. a11y) and "Created 0 todos" is just wrong.

### Validation

- Type check (`tsgo --project ./src/tsconfig.json --noEmit`) passes for the changed files.
- Existing tests in `manageTodoListTool.test.ts` (which assert on `presentation === Hidden` for empty lists) still pass — no observable behavior changed in those code paths.