### PR TITLE
Register IRemoteAgentHostService in workbench.desktop.main

### DIFF
--- a/src/vs/workbench/workbench.desktop.main.ts
+++ b/src/vs/workbench/workbench.desktop.main.ts
@@ -92,6 +92,7 @@ import '../platform/extensionManagement/electron-browser/extensionsProfileScanne
 import '../platform/sandbox/electron-browser/sandboxHelperService.js';
 import '../platform/webContentExtractor/electron-browser/webContentExtractorService.js';
 import '../platform/agentHost/electron-browser/agentHostService.js';
+import '../platform/agentHost/electron-browser/remoteAgentHostService.js';
 import './services/browserView/electron-browser/playwrightWorkbenchService.js';
 import './services/process/electron-browser/processService.js';
 import './services/power/electron-browser/powerService.js';


### PR DESCRIPTION
Follow-up to #314526.

## Problem

`AgentHostPermissionUiContribution` is registered as a regular workbench contribution in [`agentSessions.contribution.ts`](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessions.contribution.ts), but it has **two** service dependencies that were both only registered through the Agents Window layer (`src/vs/sessions/sessions.*.main.ts`):

1. `IAgentHostPermissionService` — fixed by #314526.
2. `IRemoteAgentHostService` — still missing.

So in any non-sessions desktop workbench (regular VS Code, the evaluation harness, headless Insiders builds), the contribution still fails to construct:

```
ERR Unable to create workbench contribution 'workbench.contrib.agentHostPermissionUi'.
    Error: [createInstance] Xq depends on UNKNOWN service remoteAgentHostService.
```

Hit while running an MSBench eval (`runtest local --benchmark vscbench.say_hello --config assets-agent-host/user-overrides.yaml`) against `vscodeVersion: insiders-unreleased` with `sessionTarget: agent-host-copilot`. `workbench.action.chat.open` reaches `[AgentHost] _invokeAgent called for resource: agent-host-copilotcli:/...` and then hangs indefinitely.

## Fix

Add the singleton import to `src/vs/workbench/workbench.desktop.main.ts` next to the existing `agentHostService` import. The existing sessions desktop import (`src/vs/sessions/sessions.desktop.main.ts`) is left in place; `registerSingleton` is idempotent.

The web entry already imports `browser/remoteAgentHostServiceImpl` directly via `src/vs/sessions/sessions.web.main.ts`. If the same contribution needs to load in the regular web workbench, a parallel registration in the web common/desktop entry would be a follow-up.