### PR TITLE
Add logging for unexpected InstancePolicy.prompt in sessions window

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -2132,7 +2132,10 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 				this._notificationService.warn(nls.localize('TaskSystem.InstancePolicy.warn', 'The instance limit for this task has been reached.'));
 				break;
 			case InstancePolicy.prompt:
-			default:
+			default: {
+				if (this._environmentService.isSessionsWindow) {
+					this._logService.warn(`[tasks] InstancePolicy.prompt hit in sessions window for task '${task._label}'\n${new Error().stack}`);
+				}
 				this._showQuickPick(this._taskSystem!.getActiveTasks().filter(t => task._id === t._id),
 					nls.localize('TaskService.instanceToTerminate', 'Select an instance to terminate'),
 					{
@@ -2148,6 +2151,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 					}
 					this._restart(task);
 				});
+			}
 		}
 	}
 


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce logging for when the `InstancePolicy.prompt` is encountered in the sessions window, capturing the task label and stack trace for debugging purposes.

