### PR TITLE
Forward RFC 8707 resource indicator through auth provider

### DIFF
--- a/extensions/microsoft-authentication/package-lock.json
+++ b/extensions/microsoft-authentication/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@azure/ms-rest-azure-env": "^2.0.0",
-        "@azure/msal-node": "^3.8.3",
-        "@azure/msal-node-extensions": "^1.5.25",
+        "@azure/msal-node": "^5.1.5",
+        "@azure/msal-node-extensions": "^5.1.5",
         "@vscode/extension-telemetry": "^0.9.8",
         "keytar": "file:./packageMocks/keytar",
         "vscode-tas-client": "^0.1.84"
@@ -33,41 +33,40 @@
       "integrity": "sha512-dG76W7ElfLi+fbTjnZVGj+M9e0BIEJmRxU6fHaUQ12bZBe8EJKYb2GV50YWNaP2uJiVQ5+7nXEVj1VN1UQtaEw=="
     },
     "node_modules/@azure/msal-common": {
-      "version": "15.13.2",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.13.2.tgz",
-      "integrity": "sha512-cNwUoCk3FF8VQ7Ln/MdcJVIv3sF73/OT86cRH81ECsydh7F4CNfIo2OAx6Cegtg8Yv75x4506wN4q+Emo6erOA==",
+      "version": "16.5.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.5.2.tgz",
+      "integrity": "sha512-GkDEL6TYo3HgT3UuqakdgE9PZfc1hMki6+Hwgy1uddb/EauvAKfu85vVhuofRSo22D1xTnWt8Ucwfg4vSCVwvA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.8.3.tgz",
-      "integrity": "sha512-Ul7A4gwmaHzYWj2Z5xBDly/W8JSC1vnKgJ898zPMZr0oSf1ah0tiL15sytjycU/PMhDZAlkWtEL1+MzNMU6uww==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.1.5.tgz",
+      "integrity": "sha512-ObTeMoNPmq19X3z40et9Xvs4ZoWVeJg43PZMRLG5iwVL+2nCtAerG3YTDItqPp1CfXNwmCXBbg8jn1DOx65c3g==",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "15.13.2",
-        "jsonwebtoken": "^9.0.0",
-        "uuid": "^8.3.0"
+        "@azure/msal-common": "16.5.2",
+        "jsonwebtoken": "^9.0.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=20"
       }
     },
     "node_modules/@azure/msal-node-extensions": {
-      "version": "1.5.25",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node-extensions/-/msal-node-extensions-1.5.25.tgz",
-      "integrity": "sha512-8UtOy6McoHQUbvi75Cx+ftpbTuOB471j4V4yZJmRM3KJ30bMO7forXrVV+/xArvWdgZ9VkBvq26OclFstJUo8Q==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node-extensions/-/msal-node-extensions-5.1.5.tgz",
+      "integrity": "sha512-ME26pDG81VlT75bBWhad8lf1egYqD5Mt/guP3ClN/Ol9htqQK1IYfQJFwa0FJyCdVwDvmsOyLy/WmK/RTLZuIQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "15.13.2",
+        "@azure/msal-common": "16.5.2",
         "@azure/msal-node-runtime": "^0.20.0",
         "keytar": "^7.8.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=20"
       }
     },
     "node_modules/@azure/msal-node-runtime": {
@@ -664,14 +663,6 @@
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/vscode-tas-client": {
       "version": "0.1.84",

--- a/extensions/microsoft-authentication/package.json
+++ b/extensions/microsoft-authentication/package.json
@@ -141,8 +141,8 @@
   },
   "dependencies": {
     "@azure/ms-rest-azure-env": "^2.0.0",
-    "@azure/msal-node": "^3.8.3",
-    "@azure/msal-node-extensions": "^1.5.25",
+    "@azure/msal-node": "^5.1.5",
+    "@azure/msal-node-extensions": "^5.1.5",
     "@vscode/extension-telemetry": "^0.9.8",
     "keytar": "file:./packageMocks/keytar",
     "vscode-tas-client": "^0.1.84"

--- a/extensions/microsoft-authentication/src/common/loopbackClientAndOpener.ts
+++ b/extensions/microsoft-authentication/src/common/loopbackClientAndOpener.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { ILoopbackClient, ServerAuthorizationCodeResponse } from '@azure/msal-node';
+import type { ILoopbackClient, AuthorizeResponse } from '@azure/msal-node';
 import type { UriEventHandler } from '../UriEventHandler';
 import { env, LogOutputChannel, Uri } from 'vscode';
 import { toPromise } from './async';
@@ -20,7 +20,7 @@ export class UriHandlerLoopbackClient implements ILoopbackClientAndOpener {
 		private readonly _logger: LogOutputChannel
 	) { }
 
-	async listenForAuthCode(): Promise<ServerAuthorizationCodeResponse> {
+	async listenForAuthCode(): Promise<AuthorizeResponse> {
 		const url = await toPromise(this._uriHandler.event);
 		this._logger.debug(`Received URL event. Authority: ${url.authority}`);
 		const result = new URL(url.toString(true));

--- a/extensions/microsoft-authentication/src/node/authProvider.ts
+++ b/extensions/microsoft-authentication/src/node/authProvider.ts
@@ -192,8 +192,9 @@ export class MsalAuthProvider implements AuthenticationProvider {
 			return allSessions;
 		}
 
+		const resource = options?.resource;
 		const cachedPca = await this._publicClientManager.getOrCreate(scopeData.clientId);
-		const sessions = await this.getAllSessionsForPca(cachedPca, scopeData, options?.account);
+		const sessions = await this.getAllSessionsForPca(cachedPca, scopeData, options?.account, resource);
 		this._logger.info(`[getSessions] [${scopeData.scopeStr}] returned ${sessions.length} session(s)`);
 		return sessions;
 
@@ -205,6 +206,7 @@ export class MsalAuthProvider implements AuthenticationProvider {
 
 		this._logger.info('[createSession]', `[${scopeData.scopeStr}]`, 'starting');
 		const cachedPca = await this._publicClientManager.getOrCreate(scopeData.clientId);
+		const resource = options.resource;
 
 		// Used for showing a friendlier message to the user when the explicitly cancel a flow.
 		let userCancelled: boolean | undefined;
@@ -251,6 +253,7 @@ export class MsalAuthProvider implements AuthenticationProvider {
 					windowHandle: window.nativeHandle ? Buffer.from(window.nativeHandle) : undefined,
 					logger: this._logger,
 					uriHandler: this._uriHandler,
+					resource,
 					callbackUri
 				});
 
@@ -448,7 +451,8 @@ export class MsalAuthProvider implements AuthenticationProvider {
 	private async getAllSessionsForPca(
 		cachedPca: ICachedPublicClientApplication,
 		scopeData: ScopeData,
-		accountFilter?: AuthenticationSessionAccountInformation
+		accountFilter?: AuthenticationSessionAccountInformation,
+		resource?: string
 	): Promise<AuthenticationSession[]> {
 		let filteredAccounts = accountFilter
 			? cachedPca.accounts.filter(a => a.homeAccountId === accountFilter.id)
@@ -512,12 +516,13 @@ export class MsalAuthProvider implements AuthenticationProvider {
 					if (cachedPca.isBrokerAvailable && process.platform === 'darwin') {
 						redirectUri = Config.macOSBrokerRedirectUri;
 					}
-					this._logger.trace(`[getAllSessionsForPca] [${scopeData.scopeStr}] [${account.environment}] [${account.username}] acquiring token silently with${forceRefresh ? ' ' : 'out '}force refresh${claims ? ' and claims' : ''}...`);
+					this._logger.trace(`[getAllSessionsForPca] [${scopeData.scopeStr}] [${account.environment}] [${account.username}] acquiring token silently with${forceRefresh ? ' ' : 'out '}force refresh${claims ? ' and claims' : ''}${resource ? ' and resource' : ''}...`);
 					const result = await cachedPca.acquireTokenSilent({
 						account,
 						authority,
 						scopes: scopeData.scopesToSend,
 						claims,
+						resource,
 						redirectUri,
 						forceRefresh
 					});

--- a/extensions/microsoft-authentication/src/node/cachedPublicClientApplication.ts
+++ b/extensions/microsoft-authentication/src/node/cachedPublicClientApplication.ts
@@ -321,7 +321,7 @@ export class CachedPublicClientApplication implements ICachedPublicClientApplica
 	private _verifyIfUsingBroker(result: AuthenticationResult): boolean {
 		// If we're not brokering, we don't need to verify the date
 		// the cache check will be sufficient
-		if (!result.fromNativeBroker) {
+		if (!result.fromPlatformBroker) {
 			return true;
 		}
 		// The nativeAccountId is what the broker uses to differenciate all

--- a/extensions/microsoft-authentication/src/node/flows.ts
+++ b/extensions/microsoft-authentication/src/node/flows.ts
@@ -35,6 +35,12 @@ interface IMsalFlowTriggerOptions {
 	logger: LogOutputChannel;
 	uriHandler: UriEventHandler;
 	claims?: string;
+	/**
+	 * Resource indicator (RFC 8707) for MCP-style flows. When provided, MSAL forwards
+	 * this as the `resource` parameter to the authorization & token endpoints so the
+	 * issued token is bound to the requested resource.
+	 */
+	resource?: string;
 }
 
 interface IMsalFlow {
@@ -52,7 +58,7 @@ class DefaultLoopbackFlow implements IMsalFlow {
 		supportsPortableMode: true
 	};
 
-	async trigger({ cachedPca, authority, scopes, claims, loginHint, windowHandle, logger }: IMsalFlowTriggerOptions): Promise<AuthenticationResult> {
+	async trigger({ cachedPca, authority, scopes, claims, resource, loginHint, windowHandle, logger }: IMsalFlowTriggerOptions): Promise<AuthenticationResult> {
 		logger.info('Trying default msal flow...');
 		let redirectUri: string | undefined;
 		if (cachedPca.isBrokerAvailable && process.platform === 'darwin') {
@@ -68,6 +74,7 @@ class DefaultLoopbackFlow implements IMsalFlow {
 			prompt: loginHint ? undefined : 'select_account',
 			windowHandle,
 			claims,
+			resource,
 			redirectUri
 		});
 	}
@@ -82,7 +89,7 @@ class UrlHandlerFlow implements IMsalFlow {
 		supportsPortableMode: false
 	};
 
-	async trigger({ cachedPca, authority, scopes, claims, loginHint, windowHandle, logger, uriHandler, callbackUri }: IMsalFlowTriggerOptions): Promise<AuthenticationResult> {
+	async trigger({ cachedPca, authority, scopes, claims, resource, loginHint, windowHandle, logger, uriHandler, callbackUri }: IMsalFlowTriggerOptions): Promise<AuthenticationResult> {
 		logger.info('Trying protocol handler flow...');
 		const loopbackClient = new UriHandlerLoopbackClient(uriHandler, DEFAULT_REDIRECT_URI, callbackUri, logger);
 		let redirectUri: string | undefined;
@@ -98,6 +105,7 @@ class UrlHandlerFlow implements IMsalFlow {
 			prompt: loginHint ? undefined : 'select_account',
 			windowHandle,
 			claims,
+			resource,
 			redirectUri
 		});
 	}
@@ -112,9 +120,9 @@ class DeviceCodeFlow implements IMsalFlow {
 		supportsPortableMode: true
 	};
 
-	async trigger({ cachedPca, authority, scopes, claims, logger }: IMsalFlowTriggerOptions): Promise<AuthenticationResult> {
+	async trigger({ cachedPca, authority, scopes, claims, resource, logger }: IMsalFlowTriggerOptions): Promise<AuthenticationResult> {
 		logger.info('Trying device code flow...');
-		const result = await cachedPca.acquireTokenByDeviceCode({ scopes, authority, claims });
+		const result = await cachedPca.acquireTokenByDeviceCode({ scopes, authority, claims, resource });
 		if (!result) {
 			throw new Error('Device code flow did not return a result');
 		}
@@ -122,7 +130,7 @@ class DeviceCodeFlow implements IMsalFlow {
 	}
 }
 
-const allFlows: IMsalFlow[] = [
+export const allFlows: IMsalFlow[] = [
 	new DefaultLoopbackFlow(),
 	new UrlHandlerFlow(),
 	new DeviceCodeFlow()

--- a/extensions/microsoft-authentication/src/node/test/flows.test.ts
+++ b/extensions/microsoft-authentication/src/node/test/flows.test.ts
@@ -4,7 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { getMsalFlows, ExtensionHost, IMsalFlowQuery } from '../flows';
+import type { AccountInfo, AuthenticationResult, DeviceCodeRequest, InteractiveRequest, RefreshTokenRequest, SilentFlowRequest } from '@azure/msal-node';
+import { EventEmitter, LogOutputChannel, Uri, window } from 'vscode';
+import { allFlows, ExtensionHost, getMsalFlows, IMsalFlowQuery } from '../flows';
+import { ICachedPublicClientApplication } from '../../common/publicClientCache';
+import { UriEventHandler } from '../../UriEventHandler';
 
 suite('getMsalFlows', () => {
 	test('should return all flows for local extension host with supported client and no broker', () => {
@@ -94,5 +98,134 @@ suite('getMsalFlows', () => {
 		assert.strictEqual(flows.length, 2);
 		assert.strictEqual(flows[0].label, 'default');
 		assert.strictEqual(flows[1].label, 'device code');
+	});
+});
+
+class RecordingCachedPca implements ICachedPublicClientApplication {
+	readonly interactiveRequests: InteractiveRequest[] = [];
+	readonly deviceCodeRequests: Array<Omit<DeviceCodeRequest, 'deviceCodeCallback'>> = [];
+
+	private readonly _accountsChange = new EventEmitter<{ added: AccountInfo[]; changed: AccountInfo[]; deleted: AccountInfo[] }>();
+	private readonly _removeLastAccount = new EventEmitter<void>();
+
+	readonly onDidAccountsChange = this._accountsChange.event;
+	readonly onDidRemoveLastAccount = this._removeLastAccount.event;
+	readonly accounts: AccountInfo[] = [];
+	readonly clientId = 'test-client';
+	readonly isBrokerAvailable = false;
+
+	async acquireTokenSilent(_request: SilentFlowRequest): Promise<AuthenticationResult> {
+		return makeAuthenticationResult();
+	}
+	async acquireTokenInteractive(request: InteractiveRequest): Promise<AuthenticationResult> {
+		this.interactiveRequests.push(request);
+		return makeAuthenticationResult();
+	}
+	async acquireTokenByDeviceCode(request: Omit<DeviceCodeRequest, 'deviceCodeCallback'>): Promise<AuthenticationResult | null> {
+		this.deviceCodeRequests.push(request);
+		return makeAuthenticationResult();
+	}
+	async acquireTokenByRefreshToken(_request: RefreshTokenRequest): Promise<AuthenticationResult | null> {
+		return null;
+	}
+	async removeAccount(_account: AccountInfo): Promise<void> { }
+
+	dispose(): void {
+		this._accountsChange.dispose();
+		this._removeLastAccount.dispose();
+	}
+}
+
+function makeAuthenticationResult(): AuthenticationResult {
+	return {
+		authority: '',
+		uniqueId: '',
+		tenantId: '',
+		scopes: [],
+		account: null,
+		idToken: '',
+		idTokenClaims: {},
+		accessToken: '',
+		fromCache: false,
+		expiresOn: null,
+		tokenType: 'Bearer',
+		correlationId: ''
+	};
+}
+
+suite('MSAL flow trigger', () => {
+	const RESOURCE = 'https://api.example.com/';
+	let cachedPca: RecordingCachedPca;
+	let uriHandler: UriEventHandler;
+	let logger: LogOutputChannel;
+	let callbackUri: Uri;
+
+	suiteSetup(() => {
+		logger = window.createOutputChannel('msal-flow-trigger-test', { log: true });
+	});
+
+	suiteTeardown(() => {
+		logger.dispose();
+	});
+
+	setup(() => {
+		cachedPca = new RecordingCachedPca();
+		uriHandler = new UriEventHandler();
+		callbackUri = Uri.parse('http://localhost:8080/callback');
+	});
+
+	teardown(() => {
+		cachedPca.dispose();
+		uriHandler.dispose();
+	});
+
+	function flowFor(label: string) {
+		const flow = allFlows.find(f => f.label === label);
+		if (!flow) {
+			throw new Error(`flow ${label} not found`);
+		}
+		return flow;
+	}
+
+	test('default flow forwards resource to acquireTokenInteractive', async () => {
+		await flowFor('default').trigger({
+			cachedPca,
+			authority: 'https://login.microsoftonline.com/common',
+			scopes: ['scope'],
+			callbackUri,
+			uriHandler,
+			logger,
+			resource: RESOURCE
+		});
+
+		assert.strictEqual(cachedPca.interactiveRequests[0]?.resource, RESOURCE);
+	});
+
+	test('protocol handler flow forwards resource to acquireTokenInteractive', async () => {
+		await flowFor('protocol handler').trigger({
+			cachedPca,
+			authority: 'https://login.microsoftonline.com/common',
+			scopes: ['scope'],
+			callbackUri,
+			uriHandler,
+			logger,
+			resource: RESOURCE
+		});
+
+		assert.strictEqual(cachedPca.interactiveRequests[0]?.resource, RESOURCE);
+	});
+
+	test('device code flow forwards resource to acquireTokenByDeviceCode', async () => {
+		await flowFor('device code').trigger({
+			cachedPca,
+			authority: 'https://login.microsoftonline.com/common',
+			scopes: ['scope'],
+			callbackUri,
+			uriHandler,
+			logger,
+			resource: RESOURCE
+		});
+
+		assert.strictEqual(cachedPca.deviceCodeRequests[0]?.resource, RESOURCE);
 	});
 });

--- a/src/vs/workbench/api/browser/mainThreadMcp.ts
+++ b/src/vs/workbench/api/browser/mainThreadMcp.ts
@@ -254,7 +254,7 @@ export class MainThreadMcp extends Disposable implements MainThreadMcpShape {
 			providerId = provider.id;
 		}
 
-		return this._getSessionForProvider(id, server, providerId, resolvedScopes, authorizationServer, errorOnUserInteraction, clientId ?? authDetails.clientId);
+		return this._getSessionForProvider(id, server, providerId, resolvedScopes, authorizationServer, errorOnUserInteraction, clientId ?? authDetails.clientId, authDetails.resourceMetadata?.resource);
 	}
 
 	private async _getSessionForProvider(
@@ -265,8 +265,9 @@ export class MainThreadMcp extends Disposable implements MainThreadMcpShape {
 		authorizationServer?: URI,
 		errorOnUserInteraction: boolean = false,
 		clientId?: string,
+		resource?: string,
 	): Promise<string | undefined> {
-		const sessions = await this._authenticationService.getSessions(providerId, scopes, { authorizationServer, clientId }, true);
+		const sessions = await this._authenticationService.getSessions(providerId, scopes, { authorizationServer, clientId, resource }, true);
 		const accountNamePreference = this.authenticationMcpServersService.getAccountPreference(server.id, providerId);
 		let matchingAccountPreferenceSession: AuthenticationSession | undefined;
 		if (accountNamePreference) {
@@ -319,7 +320,8 @@ export class MainThreadMcp extends Disposable implements MainThreadMcpShape {
 						activateImmediate: true,
 						account: accountToCreate,
 						authorizationServer,
-						clientId
+						clientId,
+						resource
 					});
 			} while (
 				accountToCreate

--- a/src/vs/workbench/services/authentication/common/authentication.ts
+++ b/src/vs/workbench/services/authentication/common/authentication.ts
@@ -54,6 +54,11 @@ export interface IAuthenticationCreateSessionOptions {
 	 */
 	authorizationServer?: URI;
 	/**
+	 * When specified, the authentication provider will request a token bound to this resource URI
+	 * (RFC 8707 resource indicator).
+	 */
+	resource?: string;
+	/**
 	 * Allows the authentication provider to take in additional parameters.
 	 * It is up to the provider to define what these parameters are and handle them.
 	 * This is useful for passing in additional information that is specific to the provider
@@ -116,6 +121,11 @@ export interface IAuthenticationGetSessionsOptions {
 	 * the provider can use this authorization server, then it is passed down to the auth provider.
 	 */
 	authorizationServer?: URI;
+	/**
+	 * When specified, the authentication provider will request a token bound to this resource URI
+	 * (RFC 8707 resource indicator).
+	 */
+	resource?: string;
 	/**
 	 * Allows the authentication provider to take in additional parameters.
 	 * It is up to the provider to define what these parameters are and handle them.
@@ -376,6 +386,11 @@ export interface IAuthenticationProviderSessionOptions {
 	 * attempt to return sessions that are only related to this authorization server.
 	 */
 	authorizationServer?: URI;
+	/**
+	 * When specified, the authentication provider will request a token bound to this resource URI
+	 * (RFC 8707 resource indicator).
+	 */
+	resource?: string;
 	/**
 	 * Allows the authentication provider to take in additional parameters.
 	 * It is up to the provider to define what these parameters are and handle them.

--- a/src/vs/workbench/services/authentication/test/browser/authenticationService.test.ts
+++ b/src/vs/workbench/services/authentication/test/browser/authenticationService.test.ts
@@ -396,6 +396,34 @@ suite('AuthenticationService', () => {
 			});
 		});
 
+		test('getSessions - forwards resource option to provider', async () => {
+			let receivedResource: string | undefined;
+			const provider = createProvider({
+				getSessions: async (_scopes, options) => {
+					receivedResource = options.resource;
+					return [createSession()];
+				},
+			});
+			authenticationService.registerAuthenticationProvider(provider.id, provider);
+			await authenticationService.getSessions(provider.id, ['scope'], { resource: 'https://api.example.com/' });
+
+			assert.strictEqual(receivedResource, 'https://api.example.com/');
+		});
+
+		test('createSession - forwards resource option to provider', async () => {
+			let receivedResource: string | undefined;
+			const provider = createProvider({
+				createSession: async (_scopes, options) => {
+					receivedResource = options.resource;
+					return createSession();
+				},
+			});
+			authenticationService.registerAuthenticationProvider(provider.id, provider);
+			await authenticationService.createSession(provider.id, ['scope'], { resource: 'https://api.example.com/' });
+
+			assert.strictEqual(receivedResource, 'https://api.example.com/');
+		});
+
 		test('removeSession', async () => {
 			const emitter = new Emitter<AuthenticationSessionsChangeEvent>();
 			const session = createSession();

--- a/src/vscode-dts/vscode.proposed.authIssuers.d.ts
+++ b/src/vscode-dts/vscode.proposed.authIssuers.d.ts
@@ -24,6 +24,13 @@ declare module 'vscode' {
 		 * instead of its default client ID.
 		 */
 		clientId?: string;
+
+		/**
+		 * When specified, the authentication provider will request a token bound to this resource URI
+		 * (RFC 8707 resource indicator). The provider should forward this to the authorization server
+		 * so the issued access token is audience-restricted to the given resource.
+		 */
+		resource?: string;
 	}
 
 	export interface AuthenticationGetSessionOptions {
@@ -38,5 +45,12 @@ declare module 'vscode' {
 		 * instead of its default client ID.
 		 */
 		clientId?: string;
+
+		/**
+		 * When specified, the authentication provider will request a token bound to this resource URI
+		 * (RFC 8707 resource indicator). The provider should forward this to the authorization server
+		 * so the issued access token is audience-restricted to the given resource.
+		 */
+		resource?: string;
 	}
 }


### PR DESCRIPTION
Plumbs an optional `resource` field (RFC 8707 resource indicator) through the authentication stack so MCP authentication can request audience-restricted access tokens.

## Workbench
- Added `resource?: string` to `IAuthenticationCreateSessionOptions`, `IAuthenticationGetSessionsOptions`, and `IAuthenticationProviderSessionOptions`.
- Exposed `resource?: string` on the proposed `AuthenticationGetSessionOptions` / `AuthenticationForceNewSessionOptions` in `vscode.proposed.authIssuers.d.ts`.
- `mainThreadMcp` now reads `authDetails.resourceMetadata?.resource` and forwards it into both `getSessions` and `createSession`.

## Microsoft authentication extension
- Threads `resource` through all three MSAL flows: `DefaultLoopbackFlow`, `UrlHandlerFlow`, and `DeviceCodeFlow`, plus the silent path in `getAllSessionsForPca`.
- Bumps `@azure/msal-node` and `@azure/msal-node-extensions` to `^5.1.5`. Adapts to upstream renames: `ServerAuthorizationCodeResponse` → `AuthorizeResponse`, and `fromNativeBroker` → `fromPlatformBroker`.

## Tests
- `authenticationService.test.ts`: added `getSessions` / `createSession` tests asserting `resource` is forwarded to the provider.
- `flows.test.ts`: new `MSAL flow trigger` suite verifying each MSAL flow forwards `resource` to the underlying `acquireTokenInteractive` / `acquireTokenByDeviceCode` call. Exports `allFlows` to enable label-based lookup in tests.