### PR TITLE
Silence orphaned unhandledRejections from extension management

### DIFF
--- a/src/vs/code/electron-utility/sharedProcess/contrib/extensions.ts
+++ b/src/vs/code/electron-utility/sharedProcess/contrib/extensions.ts
@@ -24,9 +24,9 @@ export class ExtensionsContributions extends Disposable {
 	) {
 		super();
 
-		extensionManagementService.cleanUp();
+		extensionManagementService.cleanUp().catch(error => logService.error('Error while cleaning up extensions', error));
 
-		this.migrateUnsupportedExtensions();
+		this.migrateUnsupportedExtensions().catch(error => logService.error('Error while migrating unsupported extensions', error));
 		ExtensionStorageService.removeOutdatedExtensionVersions(extensionManagementService, storageService);
 	}
 

--- a/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
+++ b/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
@@ -302,18 +302,23 @@ export abstract class AbstractExtensionManagementService extends CommontExtensio
 						this.logService.info('Waiting for already requested installing extension', identifier.id, root.identifier.id, options.profileLocation.toString());
 						existingInstallingExtension.waitingTasks.push(root);
 						// add promise that waits until the extension is completely installed, ie., onDidInstallExtensions event is triggered for this extension
-						alreadyRequestedInstallations.push(
-							Event.toPromise(
-								Event.filter(this.onDidInstallExtensions, results => results.some(result => areSameExtensions(result.identifier, identifier)))
-							).then(results => {
-								this.logService.info('Finished waiting for already requested installing extension', identifier.id, root.identifier.id, options.profileLocation.toString());
-								const result = results.find(result => areSameExtensions(result.identifier, identifier));
-								if (!result?.local) {
-									// Extension failed to install
-									throw new Error(`Extension ${identifier.id} is not installed`);
-								}
-								return result.local;
-							}));
+						const waitForInstallation = Event.toPromise(
+							Event.filter(this.onDidInstallExtensions, results => results.some(result => areSameExtensions(result.identifier, identifier)))
+						).then(results => {
+							this.logService.info('Finished waiting for already requested installing extension', identifier.id, root.identifier.id, options.profileLocation.toString());
+							const result = results.find(result => areSameExtensions(result.identifier, identifier));
+							if (!result?.local) {
+								// Extension failed to install
+								throw new Error(`Extension ${identifier.id} is not installed`);
+							}
+							return result.local;
+						});
+						alreadyRequestedInstallations.push(waitForInstallation);
+						// Attach a no-op rejection handler to prevent an unhandledRejection if the
+						// outer try throws before `alreadyRequestedInstallations` is awaited below.
+						// The original promise is still observed via `joinAllSettled` on the happy path,
+						// and the underlying install failure is already reported by the primary task.
+						waitForInstallation.catch(() => { });
 					}
 					return;
 				}


### PR DESCRIPTION
## What

Silence two boot-time / race-condition paths in the shared-process extension management service that produce orphan `unhandledRejection` events, surfacing as `unhandlederror-Cannot read the extension from ...` telemetry buckets.

These rejections carry no new diagnostic information — the underlying install failure is already reported by the primary install task (`extensionGallery:install` event with the real error, stack, and extension id) or logged by the cleanup/migrate flows themselves.

## Two paths fixed

### 1. Duplicate-install wait promise — `abstractExtensionManagementService.ts`

When a second install request races for an extension that's already being installed (very common at boot for `github.copilot-chat` because it gets re-requested by auto-update + restore + sync), a sibling promise is created via `Event.toPromise(onDidInstallExtensions).then(...)` and pushed into `alreadyRequestedInstallations`.

It's awaited on the success path (line 451), but if the outer `try` throws first (e.g. another extension in the same batch fails) control jumps to `catch` and the sibling promise is never observed → Node fires `unhandledRejection`.

**Fix:** attach a no-op rejection handler on a separate handle so the rejection is always observed. The original promise is still awaited via `joinAllSettled` on the happy path, and the underlying failure is already surfaced through the primary task's `installExtensionResultsMap` entry.

### 2. Fire-and-forget startup tasks — `sharedProcess/contrib/extensions.ts`

```ts
extensionManagementService.cleanUp();        // not awaited, no .catch
this.migrateUnsupportedExtensions();          // not awaited, no .catch
```

Any rejection becomes an unhandled rejection at sharedProcess boot. Both functions already log their own internal failures (and `migrateUnsupportedExtensions` wraps each `installFromGallery` in its own try/catch), so the only thing missing is a top-level `.catch(logService.error)` to swallow the orphan.

## Why not just fix `scanLocalExtension`?

The throw inside `scanLocalExtension` is correct — the caller asked to read an extension that isn't where the caller said it would be (a separate path-construction bug producing `//ext-id`-style URIs that still needs investigation). Wrapping it would silently corrupt install state. The right fix is at the unawaited consumers.

## Impact

Removes the entire `unhandlederror-Cannot read the extension from ...` family from the top error buckets (~7M machines / ~120M hits in the 14d window) without losing any diagnostic signal — user-initiated install failures still produce notifications and `extensionGallery:install` telemetry as before.
