### PR TITLE
Guard terminal resize/dispose race against xterm.js dimension getters

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -816,14 +816,23 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 			() => this._isVisible,
 			() => xterm,
 			async (cols, rows) => {
+				if (this.isDisposed) {
+					return;
+				}
 				xterm.resize(cols, rows);
 				await this._updatePtyDimensions(xterm.raw);
 			},
 			async (cols) => {
+				if (this.isDisposed) {
+					return;
+				}
 				xterm.resize(cols, xterm.raw.rows);
 				await this._updatePtyDimensions(xterm.raw);
 			},
 			async (rows) => {
+				if (this.isDisposed) {
+					return;
+				}
 				xterm.resize(xterm.raw.cols, rows);
 				await this._updatePtyDimensions(xterm.raw);
 			}
@@ -2047,8 +2056,22 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 	}
 
 	private async _updatePtyDimensions(rawXterm: XTermTerminal): Promise<void> {
-		const pixelWidth = rawXterm.dimensions?.css.canvas.width;
-		const pixelHeight = rawXterm.dimensions?.css.canvas.height;
+		if (this.isDisposed) {
+			return;
+		}
+		// `rawXterm.dimensions` proxies to xterm.js' RenderService which throws
+		// `Cannot read properties of undefined (reading 'dimensions')` if the
+		// renderer was disposed between scheduling and invocation (debounced or
+		// idle resize callbacks racing with terminal teardown). Guard against
+		// that here so the optional chaining short-circuits to undefined.
+		let pixelWidth: number | undefined;
+		let pixelHeight: number | undefined;
+		try {
+			pixelWidth = rawXterm.dimensions?.css.canvas.width;
+			pixelHeight = rawXterm.dimensions?.css.canvas.height;
+		} catch {
+			// Renderer disposed mid-flight; fall through with undefined dimensions.
+		}
 		const roundedPixelWidth = pixelWidth ? Math.round(pixelWidth) : undefined;
 		const roundedPixelHeight = pixelHeight ? Math.round(pixelHeight) : undefined;
 		await this._processManager.setDimensions(rawXterm.cols, rawXterm.rows, undefined, roundedPixelWidth, roundedPixelHeight);

--- a/src/vs/workbench/contrib/terminal/browser/terminalResizeDebouncer.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalResizeDebouncer.ts
@@ -33,6 +33,9 @@ export class TerminalResizeDebouncer extends Disposable {
 	}
 
 	async resize(cols: number, rows: number, immediate: boolean): Promise<void> {
+		if (this._store.isDisposed) {
+			return;
+		}
 		this._latestX = cols;
 		this._latestY = rows;
 
@@ -49,12 +52,18 @@ export class TerminalResizeDebouncer extends Disposable {
 		if (win && !this._isVisible()) {
 			if (!this._resizeXJob.value) {
 				this._resizeXJob.value = runWhenWindowIdle(win, async () => {
+					if (this._store.isDisposed) {
+						return;
+					}
 					this._resizeXCallback(this._latestX);
 					this._resizeXJob.clear();
 				});
 			}
 			if (!this._resizeYJob.value) {
 				this._resizeYJob.value = runWhenWindowIdle(win, async () => {
+					if (this._store.isDisposed) {
+						return;
+					}
 					this._resizeYCallback(this._latestY);
 					this._resizeYJob.clear();
 				});
@@ -70,6 +79,9 @@ export class TerminalResizeDebouncer extends Disposable {
 	}
 
 	flush(): void {
+		if (this._store.isDisposed) {
+			return;
+		}
 		if (this._resizeXJob.value || this._resizeYJob.value) {
 			this._resizeXJob.clear();
 			this._resizeYJob.clear();
@@ -79,6 +91,12 @@ export class TerminalResizeDebouncer extends Disposable {
 
 	@debounce(100)
 	private _debounceResizeX(cols: number) {
+		// The @debounce decorator schedules a setTimeout that is not tied to the
+		// disposable store, so this can fire after the terminal/xterm renderer is
+		// disposed. Bail out to avoid throwing from xterm.js dimension getters.
+		if (this._store.isDisposed) {
+			return;
+		}
 		this._resizeXCallback(cols);
 	}
 }


### PR DESCRIPTION
## What

Guards three terminal resize/dispose race paths that throw `Cannot read properties of undefined (reading 'dimensions')` from xterm.js' `RenderService.get dimensions()` after the renderer is disposed.

## Why

PR #313817 bumped `@xterm/*` to `beta.213` and resolved the `OverviewRulerRenderer` dispose race (bucket `8612c55d`, ✅ zero hits on post-fix insider builds). However three sibling buckets keep firing on the latest insiders (1.120.0-insider `79d6cea3` / `0aed0a9b`):

| Bucket | Caller | First seen on post-fix insider |
|---|---|---|
| `aaa283a2` | `_resizeYCallback` from configChange → `setVisible` → `_resize` | 161 hits / 98 users |
| `4826565b` | debounced `_debounceResizeX` timer | 909 hits / 497 users |
| `1e83a096` | `_resizeBothCallback` from `_onProcessExit` → `dispose` → `setVisible(false)` → `_resize` | 291 hits / 98 users |

All three reach `RenderService.get dimensions()` inside xterm.js, which dereferences `this._renderer.value` (undefined post-dispose) and throws synchronously. The optional chaining on `rawXterm.dimensions?.css.canvas.width` doesn't help because the **getter itself** throws before the `?.` short-circuits.

The upstream `08ae141` patch added `isDisposed` guards at the `OverviewRuler` call sites — not inside the getter — so the symmetrical fix here is to guard the call sites VS Code owns.

## Changes

### `terminalInstance.ts`
- Bail out of the three resize closures passed to `TerminalResizeDebouncer` when `this.isDisposed`.
- `_updatePtyDimensions`: early-return when disposed; defensively `try/catch` around `rawXterm.dimensions` so a future renderer-dispose race fails silently with `undefined` dimensions instead of bubbling as an unhandled error.

### `terminalResizeDebouncer.ts`
- `resize` / `flush`: bail out when `this._store.isDisposed`.
- `runWhenWindowIdle` callbacks: re-check disposed state before invoking the resize callback (the idle callback can fire after `MutableDisposable.clear` for a different timing reason).
- `_debounceResizeX`: re-check disposed state. The `@debounce(100)` decorator schedules a `setTimeout` that is **not** tied to the disposable store, so it can fire after the terminal/xterm is gone — this is the direct cause of bucket `4826565b`.

## How to test

1. Open a terminal, type or generate >200 lines of output.
2. Trigger the dispose-during-resize patterns:
   - Quickly close (`Ctrl+Shift+W`) a terminal while resizing the window.
   - Run a config change (e.g. toggle `terminal.integrated.fontFamily`) immediately after killing a terminal.
   - Kill a long-running shell from within the terminal (`exit`) while the panel is mid-resize.
3. Verify no unhandled `dimensions` TypeErrors in DevTools console.
4. Telemetry: monitor buckets `aaa283a2`, `4826565b`, `1e83a096` over the next two insider builds — expect zero new occurrences.

## Risk

- All guards are early-returns / try-catch around accessors — no behavior change in the live (non-disposed) path.
- Defensive `try/catch` in `_updatePtyDimensions` accepts a single missed dimension update if the renderer is mid-dispose; this is preferable to throwing and losing the entire reconnect/restore flow.
- No test changes; the races are timing-dependent and hard to reproduce deterministically. Telemetry will be the verification signal.

Refs #303546, #313817
