### PR TITLE
fix(copilot): populate Context Window indicator for BYOK chat providers

### DIFF
--- a/extensions/copilot/src/platform/endpoint/common/endpointTypes.ts
+++ b/extensions/copilot/src/platform/endpoint/common/endpointTypes.ts
@@ -13,10 +13,18 @@ export namespace CustomDataPartMimeTypes {
 	 * Mime type for an extension-contributed token-usage payload, emitted by a
 	 * `vscode.LanguageModelChatProvider` as a `LanguageModelDataPart` in its
 	 * response stream. The `data` is a UTF-8 JSON encoding of an `APIUsage`-shaped
-	 * object. All fields are optional — missing or non-finite numeric values
-	 * are treated as 0, and missing nested objects (`prompt_tokens_details`,
-	 * `completion_tokens_details`) are simply omitted from the parsed result.
-	 * A provider that only knows `prompt_tokens` is free to send just that.
+	 * object. Individual numeric fields are optional — missing or non-finite
+	 * values are treated as 0, negatives are clamped, and nested detail objects
+	 * that are themselves missing or malformed are omitted. The payload must
+	 * carry at least one positive numeric signal (a non-zero top-level counter
+	 * or a non-zero nested detail field) to be accepted; payloads that coerce
+	 * down to all zeros are rejected so a stray empty/malformed chunk can't
+	 * overwrite an earlier valid reading at the dispatch site. Fully-shaped
+	 * payloads (those that satisfy the strict `APIUsage` shape with all three
+	 * top-level counters as `number`) additionally carry a
+	 * `prompt_tokens_details: { cached_tokens: 0 }` placeholder when the
+	 * provider didn't supply that nested object, matching the historical
+	 * zero-fallback shape downstream consumers depend on.
 	 *
 	 * Consumed by `ExtensionContributedChatEndpoint.makeChatRequest2`. When no
 	 * Usage part is emitted, the host falls back to zero counts (which leaves

--- a/extensions/copilot/src/platform/endpoint/common/endpointTypes.ts
+++ b/extensions/copilot/src/platform/endpoint/common/endpointTypes.ts
@@ -9,6 +9,18 @@ export namespace CustomDataPartMimeTypes {
 	export const ThinkingData = 'thinking';
 	export const ContextManagement = 'context_management';
 	export const PhaseData = 'phase_data';
+	/**
+	 * Mime type for an extension-contributed token-usage payload, emitted by a
+	 * `vscode.LanguageModelChatProvider` as a `LanguageModelDataPart` in its
+	 * response stream. The `data` is a UTF-8 JSON encoding of an `APIUsage`
+	 * shape (at minimum `prompt_tokens`/`completion_tokens`/`total_tokens`,
+	 * with optional `prompt_tokens_details.cached_tokens`).
+	 *
+	 * Consumed by `ExtensionContributedChatEndpoint.makeChatRequest2`. When no
+	 * Usage part is emitted, the host falls back to zero counts (which leaves
+	 * the Context Window indicator stuck at 0 — see microsoft/vscode#314722).
+	 */
+	export const Usage = 'usage';
 }
 
 export const CacheType = 'ephemeral';

--- a/extensions/copilot/src/platform/endpoint/common/endpointTypes.ts
+++ b/extensions/copilot/src/platform/endpoint/common/endpointTypes.ts
@@ -12,9 +12,11 @@ export namespace CustomDataPartMimeTypes {
 	/**
 	 * Mime type for an extension-contributed token-usage payload, emitted by a
 	 * `vscode.LanguageModelChatProvider` as a `LanguageModelDataPart` in its
-	 * response stream. The `data` is a UTF-8 JSON encoding of an `APIUsage`
-	 * shape (at minimum `prompt_tokens`/`completion_tokens`/`total_tokens`,
-	 * with optional `prompt_tokens_details.cached_tokens`).
+	 * response stream. The `data` is a UTF-8 JSON encoding of an `APIUsage`-shaped
+	 * object. All fields are optional — missing or non-finite numeric values
+	 * are treated as 0, and missing nested objects (`prompt_tokens_details`,
+	 * `completion_tokens_details`) are simply omitted from the parsed result.
+	 * A provider that only knows `prompt_tokens` is free to send just that.
 	 *
 	 * Consumed by `ExtensionContributedChatEndpoint.makeChatRequest2`. When no
 	 * Usage part is emitted, the host falls back to zero counts (which leaves

--- a/extensions/copilot/src/platform/endpoint/vscode-node/extChatEndpoint.ts
+++ b/extensions/copilot/src/platform/endpoint/vscode-node/extChatEndpoint.ts
@@ -52,8 +52,15 @@ const ZERO_USAGE: APIUsage = {
  * interface; the parser is permissive and accepts any object whose
  * numeric fields can be coerced — missing fields default to 0 — so a
  * provider can emit a partial payload (e.g. only `prompt_tokens` and
- * `completion_tokens`) without breaking the host. Returns `undefined` on
- * `JSON.parse` failure or when the payload is not an object.
+ * `completion_tokens`) without breaking the host. Returns `undefined`
+ * when:
+ *   - `JSON.parse` throws,
+ *   - the payload is not a plain object (primitive, array, or `null`),
+ *   - or the coerced result carries no positive signal (every top-level
+ *     counter is 0 and no nested detail field is positive). The last
+ *     case prevents an empty / malformed-but-shaped payload from
+ *     overwriting an earlier valid reading at the last-valid-wins
+ *     dispatch site in `makeChatRequest2`.
  *
  * Defensive coercion: every numeric field — top-level and inside the
  * optional `prompt_tokens_details` / `completion_tokens_details` nested
@@ -158,6 +165,31 @@ export function parseExtensionContributedUsage(data: Uint8Array): APIUsage | und
 	const completionDetails = buildCompletionDetails(obj.completion_tokens_details);
 	if (completionDetails) {
 		result.completion_tokens_details = completionDetails;
+	}
+	// Reject payloads that produced an all-zero, detail-less `APIUsage`.
+	// Examples: `{}`, `{foo: 'bar'}`, `{prompt_tokens_details: 'oops'}`,
+	// `{completion_tokens: -3}` (clamped to 0), `{prompt_tokens_details: {}}`
+	// (which yields `{cached_tokens: 0}` — still no usable signal). A truthy
+	// return overwrites any earlier valid reading at the last-valid-wins
+	// dispatch site in `makeChatRequest2`, so we treat "no signal" as "this
+	// payload says nothing" rather than "all counts are zero". The strict-
+	// path back-compat shape (`prompt_tokens_details: {cached_tokens: 0}` on
+	// a fully-shaped `APIUsage`) does not count as a signal on its own — a
+	// strict zero-payload still has at least one explicit `0` top-level
+	// counter from the provider, but every counter being 0 with no nested
+	// data means the provider is saying nothing useful.
+	const hasMeaningfulData =
+		result.prompt_tokens > 0 ||
+		result.completion_tokens > 0 ||
+		result.total_tokens > 0 ||
+		(!!promptDetails && (promptDetails.cached_tokens > 0 || (promptDetails.cache_creation_input_tokens ?? 0) > 0)) ||
+		(!!completionDetails && (
+			completionDetails.reasoning_tokens > 0 ||
+			completionDetails.accepted_prediction_tokens > 0 ||
+			completionDetails.rejected_prediction_tokens > 0
+		));
+	if (!hasMeaningfulData) {
+		return undefined;
 	}
 	return result;
 }
@@ -354,8 +386,25 @@ export class ExtensionContributedChatEndpoint implements IChatEndpoint {
 						const decoded = decodeStatefulMarker(chunk.data);
 						await streamRecorder.callback?.(text, 0, { text: '', statefulMarker: decoded.marker });
 					} else if (chunk.mimeType === CustomDataPartMimeTypes.ContextManagement) {
-						const contextManagement = JSON.parse(new TextDecoder().decode(chunk.data)) as ContextManagementResponse;
-						await streamRecorder.callback?.(text, 0, { text: '', contextManagement });
+						// Tolerate malformed payloads: the data part is provider-
+						// supplied and shouldn't be able to abort the whole request
+						// stream just by emitting bad bytes or a non-object shape.
+						// Mirror the first-step shape rejection from
+						// `parseExtensionContributedUsage` (non-objects, arrays,
+						// `null`); content-shape validation of the `ContextManagementResponse`
+						// itself is left to the downstream consumer.
+						let contextManagement: ContextManagementResponse | undefined;
+						try {
+							const raw: unknown = JSON.parse(new TextDecoder().decode(chunk.data));
+							if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+								contextManagement = raw as ContextManagementResponse;
+							}
+						} catch {
+							// fall through with contextManagement === undefined
+						}
+						if (contextManagement) {
+							await streamRecorder.callback?.(text, 0, { text: '', contextManagement });
+						}
 					} else if (chunk.mimeType === CustomDataPartMimeTypes.Usage) {
 						// Last-valid-wins: if a provider emits multiple Usage parts
 						// the final *parseable* one is reported. This matches the

--- a/extensions/copilot/src/platform/endpoint/vscode-node/extChatEndpoint.ts
+++ b/extensions/copilot/src/platform/endpoint/vscode-node/extChatEndpoint.ts
@@ -18,7 +18,7 @@ import { ContextManagementResponse } from '../../networking/common/anthropic';
 import { FinishedCallback, OpenAiFunctionTool, OptionalChatRequestParams } from '../../networking/common/fetch';
 import { Response } from '../../networking/common/fetcherService';
 import { IChatEndpoint, ICreateEndpointBodyOptions, IEndpointBody, IMakeChatRequestOptions } from '../../networking/common/networking';
-import { ChatCompletion } from '../../networking/common/openai';
+import { APIUsage, ChatCompletion, isApiUsage } from '../../networking/common/openai';
 import { IOTelService } from '../../otel/common/otelService';
 import { retrieveCapturingTokenByCorrelation, storeCapturingTokenForCorrelation } from '../../requestLogger/node/requestLogger';
 import { ITelemetryService } from '../../telemetry/common/telemetry';
@@ -35,6 +35,92 @@ enum ChatImageMimeType {
 	GIF = 'image/gif',
 	WEBP = 'image/webp',
 	BMP = 'image/bmp',
+}
+
+const ZERO_USAGE: APIUsage = {
+	prompt_tokens: 0,
+	completion_tokens: 0,
+	total_tokens: 0,
+	prompt_tokens_details: { cached_tokens: 0 },
+};
+
+/**
+ * Parse a `LanguageModelDataPart` payload tagged with
+ * {@link CustomDataPartMimeTypes.Usage} into an {@link APIUsage} shape.
+ *
+ * The wire format is UTF-8 JSON. The full shape is the host's `APIUsage`
+ * interface; the parser is permissive and accepts any object whose
+ * numeric fields can be coerced — missing fields default to 0 — so a
+ * provider can emit a partial payload (e.g. only `prompt_tokens` and
+ * `completion_tokens`) without breaking the host. Returns `undefined` on
+ * `JSON.parse` failure or when the payload is not an object.
+ *
+ * Example: an extension `LanguageModelChatProvider` populates the
+ * Context Window indicator by emitting a final Usage part on its
+ * response stream:
+ *
+ * ```ts
+ * progress.report(new vscode.LanguageModelDataPart(
+ *     new TextEncoder().encode(JSON.stringify({
+ *         prompt_tokens: 12345,
+ *         completion_tokens: 678,
+ *         total_tokens: 13023,
+ *         prompt_tokens_details: { cached_tokens: 9000 }
+ *     })),
+ *     'usage' // CustomDataPartMimeTypes.Usage
+ * ));
+ * ```
+ */
+export function parseExtensionContributedUsage(data: Uint8Array): APIUsage | undefined {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(new TextDecoder().decode(data));
+	} catch {
+		return undefined;
+	}
+	if (!parsed || typeof parsed !== 'object') {
+		return undefined;
+	}
+	// Coerce to non-negative finite numbers. `isApiUsage` only checks
+	// that the three top-level fields are `typeof === 'number'`, so a
+	// provider could still emit negatives or NaN; the host's cumulative
+	// completion-token counter (`ChatResponseModel.setUsage`) treats
+	// these as monotonic, so a negative would silently corrupt it.
+	const num = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? Math.max(0, v) : 0);
+	const obj = parsed as Record<string, unknown>;
+	if (isApiUsage(parsed)) {
+		// Strict shape: preserve any extra fields the provider sent
+		// (e.g. `cache_creation_input_tokens`, `completion_tokens_details`)
+		// while still clamping the load-bearing counters that downstream
+		// monotonic accounting depends on.
+		const strict: APIUsage = {
+			...parsed,
+			prompt_tokens: num(parsed.prompt_tokens),
+			completion_tokens: num(parsed.completion_tokens),
+			total_tokens: num(parsed.total_tokens),
+		};
+		if (parsed.prompt_tokens_details) {
+			strict.prompt_tokens_details = {
+				...parsed.prompt_tokens_details,
+				cached_tokens: num(parsed.prompt_tokens_details.cached_tokens),
+			};
+		}
+		return strict;
+	}
+	// Permissive fallback: accept partial payloads, zero-fill missing
+	// numeric fields. A provider that only knows prompt_tokens shouldn't
+	// have to fabricate the rest.
+	const result: APIUsage = {
+		prompt_tokens: num(obj.prompt_tokens),
+		completion_tokens: num(obj.completion_tokens),
+		total_tokens: num(obj.total_tokens),
+	};
+	const detailsRaw = obj.prompt_tokens_details;
+	if (detailsRaw && typeof detailsRaw === 'object') {
+		const d = detailsRaw as Record<string, unknown>;
+		result.prompt_tokens_details = { cached_tokens: num(d.cached_tokens) };
+	}
+	return result;
 }
 
 export class ExtensionContributedChatEndpoint implements IChatEndpoint {
@@ -204,6 +290,7 @@ export class ExtensionContributedChatEndpoint implements IChatEndpoint {
 			const response = await this.languageModel.sendRequest(vscodeMessages, vscodeOptions, token);
 			let text = '';
 			let numToolsCalled = 0;
+			let extensionUsage: APIUsage | undefined;
 			const requestId = ourRequestId;
 
 			// consume stream
@@ -230,6 +317,14 @@ export class ExtensionContributedChatEndpoint implements IChatEndpoint {
 					} else if (chunk.mimeType === CustomDataPartMimeTypes.ContextManagement) {
 						const contextManagement = JSON.parse(new TextDecoder().decode(chunk.data)) as ContextManagementResponse;
 						await streamRecorder.callback?.(text, 0, { text: '', contextManagement });
+					} else if (chunk.mimeType === CustomDataPartMimeTypes.Usage) {
+						// Last-write-wins: if a provider emits multiple Usage parts the
+						// final one is reported, matching the OpenAI streaming convention
+						// where the terminating chunk carries the usage tally.
+						const parsed = parseExtensionContributedUsage(chunk.data);
+						if (parsed) {
+							extensionUsage = parsed;
+						}
 					}
 				} else if (chunk instanceof vscode.LanguageModelThinkingPart) {
 					if (streamRecorder.callback) {
@@ -250,7 +345,11 @@ export class ExtensionContributedChatEndpoint implements IChatEndpoint {
 					type: ChatFetchResponseType.Success,
 					requestId,
 					serverRequestId: requestId,
-					usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0, prompt_tokens_details: { cached_tokens: 0 } },
+					// Prefer the provider-supplied counts so the Context Window
+					// indicator and any token-usage telemetry reflect reality.
+					// When the provider doesn't emit a Usage data part we keep
+					// the historical zero-fallback behaviour.
+					usage: extensionUsage ?? ZERO_USAGE,
 					value: text,
 					resolvedModel: this.languageModel.id
 				};

--- a/extensions/copilot/src/platform/endpoint/vscode-node/extChatEndpoint.ts
+++ b/extensions/copilot/src/platform/endpoint/vscode-node/extChatEndpoint.ts
@@ -85,7 +85,12 @@ export function parseExtensionContributedUsage(data: Uint8Array): APIUsage | und
 	} catch {
 		return undefined;
 	}
-	if (!parsed || typeof parsed !== 'object') {
+	// Reject non-objects, arrays (`typeof [] === 'object'` in JS), and `null`
+	// (`typeof null === 'object'`). Only plain-object payloads are valid;
+	// otherwise a stray `[]` chunk would parse to a zero-filled `APIUsage`
+	// and could overwrite an earlier valid reading at the last-valid-wins
+	// dispatch site below.
+	if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
 		return undefined;
 	}
 	// Coerce to non-negative finite numbers. `isApiUsage` only checks

--- a/extensions/copilot/src/platform/endpoint/vscode-node/extChatEndpoint.ts
+++ b/extensions/copilot/src/platform/endpoint/vscode-node/extChatEndpoint.ts
@@ -55,6 +55,13 @@ const ZERO_USAGE: APIUsage = {
  * `completion_tokens`) without breaking the host. Returns `undefined` on
  * `JSON.parse` failure or when the payload is not an object.
  *
+ * Defensive coercion: every numeric field — top-level and inside the
+ * optional `prompt_tokens_details` / `completion_tokens_details` nested
+ * objects — is clamped to a non-negative finite number. Nested detail
+ * objects whose value is not a plain object (string, array, `null`,
+ * etc.) are dropped rather than passed through, so downstream
+ * telemetry / OTel attributes only ever see well-formed shapes.
+ *
  * Example: an extension `LanguageModelChatProvider` populates the
  * Context Window indicator by emitting a final Usage part on its
  * response stream:
@@ -83,42 +90,69 @@ export function parseExtensionContributedUsage(data: Uint8Array): APIUsage | und
 	}
 	// Coerce to non-negative finite numbers. `isApiUsage` only checks
 	// that the three top-level fields are `typeof === 'number'`, so a
-	// provider could still emit negatives or NaN; the host's cumulative
-	// completion-token counter (`ChatResponseModel.setUsage`) treats
-	// these as monotonic, so a negative would silently corrupt it.
+	// provider could still emit negatives or non-finite values; the
+	// host's cumulative completion-token counter (`ChatResponseModel.setUsage`)
+	// treats these as monotonic, so a negative would silently corrupt
+	// it, and `Infinity`/`NaN` would poison telemetry.
 	const num = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? Math.max(0, v) : 0);
 	const obj = parsed as Record<string, unknown>;
-	if (isApiUsage(parsed)) {
-		// Strict shape: preserve any extra fields the provider sent
-		// (e.g. `cache_creation_input_tokens`, `completion_tokens_details`)
-		// while still clamping the load-bearing counters that downstream
-		// monotonic accounting depends on.
-		const strict: APIUsage = {
-			...parsed,
-			prompt_tokens: num(parsed.prompt_tokens),
-			completion_tokens: num(parsed.completion_tokens),
-			total_tokens: num(parsed.total_tokens),
-		};
-		if (parsed.prompt_tokens_details) {
-			strict.prompt_tokens_details = {
-				...parsed.prompt_tokens_details,
-				cached_tokens: num(parsed.prompt_tokens_details.cached_tokens),
-			};
+
+	// Treat arrays and `null` as malformed for the nested-detail
+	// builders below, since `typeof [] === 'object'` and `typeof null
+	// === 'object'` are both true in JS.
+	const isPlainObject = (v: unknown): v is Record<string, unknown> =>
+		!!v && typeof v === 'object' && !Array.isArray(v);
+
+	// Build a clamped `prompt_tokens_details`. Drop the nested object
+	// entirely if the provider sent a non-object (string, array, etc.)
+	// so downstream consumers never see malformed shapes.
+	const buildPromptDetails = (raw: unknown): APIUsage['prompt_tokens_details'] => {
+		if (!isPlainObject(raw)) {
+			return undefined;
 		}
-		return strict;
-	}
-	// Permissive fallback: accept partial payloads, zero-fill missing
-	// numeric fields. A provider that only knows prompt_tokens shouldn't
-	// have to fabricate the rest.
+		const d = raw;
+		const out: NonNullable<APIUsage['prompt_tokens_details']> = {
+			cached_tokens: num(d.cached_tokens),
+		};
+		if ('cache_creation_input_tokens' in d) {
+			out.cache_creation_input_tokens = num(d.cache_creation_input_tokens);
+		}
+		return out;
+	};
+
+	// Build a clamped `completion_tokens_details`. Same drop-on-malformed
+	// policy. All three numeric fields are required by the type, so we
+	// zero-fill anything the provider omitted.
+	const buildCompletionDetails = (raw: unknown): APIUsage['completion_tokens_details'] => {
+		if (!isPlainObject(raw)) {
+			return undefined;
+		}
+		const d = raw;
+		return {
+			reasoning_tokens: num(d.reasoning_tokens),
+			accepted_prediction_tokens: num(d.accepted_prediction_tokens),
+			rejected_prediction_tokens: num(d.rejected_prediction_tokens),
+		};
+	};
+
 	const result: APIUsage = {
 		prompt_tokens: num(obj.prompt_tokens),
 		completion_tokens: num(obj.completion_tokens),
 		total_tokens: num(obj.total_tokens),
 	};
-	const detailsRaw = obj.prompt_tokens_details;
-	if (detailsRaw && typeof detailsRaw === 'object') {
-		const d = detailsRaw as Record<string, unknown>;
-		result.prompt_tokens_details = { cached_tokens: num(d.cached_tokens) };
+	const promptDetails = buildPromptDetails(obj.prompt_tokens_details);
+	if (promptDetails) {
+		result.prompt_tokens_details = promptDetails;
+	} else if (isApiUsage(parsed)) {
+		// `APIUsage` doesn't require `prompt_tokens_details`, but the
+		// historical `ZERO_USAGE` fallback always sets it. Preserve that
+		// invariant on the strict path so downstream consumers that read
+		// `usage.prompt_tokens_details?.cached_tokens` see a stable shape.
+		result.prompt_tokens_details = { cached_tokens: 0 };
+	}
+	const completionDetails = buildCompletionDetails(obj.completion_tokens_details);
+	if (completionDetails) {
+		result.completion_tokens_details = completionDetails;
 	}
 	return result;
 }
@@ -318,9 +352,11 @@ export class ExtensionContributedChatEndpoint implements IChatEndpoint {
 						const contextManagement = JSON.parse(new TextDecoder().decode(chunk.data)) as ContextManagementResponse;
 						await streamRecorder.callback?.(text, 0, { text: '', contextManagement });
 					} else if (chunk.mimeType === CustomDataPartMimeTypes.Usage) {
-						// Last-write-wins: if a provider emits multiple Usage parts the
-						// final one is reported, matching the OpenAI streaming convention
-						// where the terminating chunk carries the usage tally.
+						// Last-valid-wins: if a provider emits multiple Usage parts
+						// the final *parseable* one is reported. This matches the
+						// OpenAI streaming convention where the terminating chunk
+						// carries the tally, while ensuring a malformed trailing
+						// part can't blow away an earlier valid reading.
 						const parsed = parseExtensionContributedUsage(chunk.data);
 						if (parsed) {
 							extensionUsage = parsed;

--- a/extensions/copilot/src/platform/endpoint/vscode-node/test/extChatEndpoint.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/vscode-node/test/extChatEndpoint.spec.ts
@@ -141,11 +141,30 @@ describe('parseExtensionContributedUsage', () => {
 	});
 
 	it('coerces non-numeric fields to 0', () => {
+		// `JSON.stringify(NaN)` becomes `null`, so use only types that
+		// actually round-trip through the wire format. Non-finite handling
+		// is exercised separately below.
 		const bytes = new TextEncoder().encode(JSON.stringify({
-			prompt_tokens: 'oops', completion_tokens: null, total_tokens: NaN,
+			prompt_tokens: 'oops', completion_tokens: null, total_tokens: [],
 		}));
 		expect(parseExtensionContributedUsage(bytes)).toEqual({
 			prompt_tokens: 0, completion_tokens: 0, total_tokens: 0,
+		});
+	});
+
+	it('coerces non-finite numeric fields (Infinity) to 0', () => {
+		// `JSON.parse('1e999')` yields `Infinity` — a value `isApiUsage`
+		// accepts (it's `typeof === 'number'`) but that would poison any
+		// downstream arithmetic / OTel attribute. Hand-build the JSON
+		// because `JSON.stringify(Infinity)` lossily becomes `null`.
+		const bytes = new TextEncoder().encode(
+			'{"prompt_tokens":1e999,"completion_tokens":-1e999,"total_tokens":1}'
+		);
+		expect(parseExtensionContributedUsage(bytes)).toEqual({
+			prompt_tokens: 0,
+			completion_tokens: 0,
+			total_tokens: 1,
+			prompt_tokens_details: { cached_tokens: 0 },
 		});
 	});
 
@@ -181,6 +200,44 @@ describe('parseExtensionContributedUsage', () => {
 			prompt_tokens_details: { cached_tokens: 1, cache_creation_input_tokens: 2 },
 			completion_tokens_details: { reasoning_tokens: 3, accepted_prediction_tokens: 0, rejected_prediction_tokens: 0 },
 		});
+	});
+
+	it('clamps negative values inside nested detail objects', () => {
+		// Same defence as the top-level negative-clamp test, but for the
+		// optional nested details. Without this clamp a provider could
+		// leak negative `cache_creation_input_tokens` /
+		// `reasoning_tokens` into OTel attributes via the strict path.
+		const bytes = new TextEncoder().encode(JSON.stringify({
+			prompt_tokens: 10, completion_tokens: 5, total_tokens: 15,
+			prompt_tokens_details: { cached_tokens: -1, cache_creation_input_tokens: -2 },
+			completion_tokens_details: { reasoning_tokens: -3, accepted_prediction_tokens: -4, rejected_prediction_tokens: -5 },
+		}));
+		expect(parseExtensionContributedUsage(bytes)).toEqual({
+			prompt_tokens: 10, completion_tokens: 5, total_tokens: 15,
+			prompt_tokens_details: { cached_tokens: 0, cache_creation_input_tokens: 0 },
+			completion_tokens_details: { reasoning_tokens: 0, accepted_prediction_tokens: 0, rejected_prediction_tokens: 0 },
+		});
+	});
+
+	it('drops nested detail objects when the provider sends a non-object', () => {
+		// A provider that wires up `prompt_tokens_details` as a string or
+		// array would otherwise leak that malformed shape through to
+		// telemetry. Drop the nested object so downstream always sees
+		// either a well-formed object or nothing.
+		const bytes = new TextEncoder().encode(JSON.stringify({
+			prompt_tokens: 10, completion_tokens: 5, total_tokens: 15,
+			prompt_tokens_details: 'oops',
+			completion_tokens_details: [1, 2, 3],
+		}));
+		const result = parseExtensionContributedUsage(bytes);
+		expect(result).toBeDefined();
+		expect(result!.prompt_tokens).toBe(10);
+		expect(result!.completion_tokens).toBe(5);
+		expect(result!.total_tokens).toBe(15);
+		// Strict path falls back to the historical zero-shape so consumers
+		// reading `usage.prompt_tokens_details?.cached_tokens` see a stable value.
+		expect(result!.prompt_tokens_details).toEqual({ cached_tokens: 0 });
+		expect(result!.completion_tokens_details).toBeUndefined();
 	});
 
 	it('returns undefined on malformed JSON', () => {
@@ -277,7 +334,7 @@ describe('ExtensionContributedChatEndpoint.makeChatRequest2 – usage propagatio
 		}
 	});
 
-	it('uses the last Usage part when the provider emits more than one (last-write-wins)', async () => {
+	it('uses the last valid Usage part when the provider emits more than one (last-valid-wins)', async () => {
 		const endpoint = createEndpoint([
 			new vscode.LanguageModelTextPart('x'),
 			usagePart({ prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 }),
@@ -288,6 +345,23 @@ describe('ExtensionContributedChatEndpoint.makeChatRequest2 – usage propagatio
 		}, noToken);
 		if (result.type === ChatFetchResponseType.Success) {
 			expect(result.usage?.prompt_tokens).toBe(99);
+		}
+	});
+
+	it('keeps the previous valid Usage when a later part fails to parse', async () => {
+		// Pins the contract documented at the dispatch site: a malformed
+		// trailing Usage part must not blow away an earlier valid reading.
+		const endpoint = createEndpoint([
+			new vscode.LanguageModelTextPart('x'),
+			usagePart({ prompt_tokens: 42, completion_tokens: 7, total_tokens: 49 }),
+			new vscode.LanguageModelDataPart(new TextEncoder().encode('not json'), 'usage'),
+		]);
+		const result = await endpoint.makeChatRequest2({
+			debugName: 't', messages: [helloMessage], finishedCb: noopFinish, location: ChatLocation.Other,
+		}, noToken);
+		if (result.type === ChatFetchResponseType.Success) {
+			expect(result.usage?.prompt_tokens).toBe(42);
+			expect(result.usage?.completion_tokens).toBe(7);
 		}
 	});
 });

--- a/extensions/copilot/src/platform/endpoint/vscode-node/test/extChatEndpoint.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/vscode-node/test/extChatEndpoint.spec.ts
@@ -143,12 +143,14 @@ describe('parseExtensionContributedUsage', () => {
 	it('coerces non-numeric fields to 0', () => {
 		// `JSON.stringify(NaN)` becomes `null`, so use only types that
 		// actually round-trip through the wire format. Non-finite handling
-		// is exercised separately below.
+		// is exercised separately below. `total_tokens: 1` keeps the
+		// payload above the no-signal-rejection threshold so the coercion
+		// of the other two fields is observable.
 		const bytes = new TextEncoder().encode(JSON.stringify({
-			prompt_tokens: 'oops', completion_tokens: null, total_tokens: [],
+			prompt_tokens: 'oops', completion_tokens: null, total_tokens: 1,
 		}));
 		expect(parseExtensionContributedUsage(bytes)).toEqual({
-			prompt_tokens: 0, completion_tokens: 0, total_tokens: 0,
+			prompt_tokens: 0, completion_tokens: 0, total_tokens: 1,
 		});
 	});
 
@@ -170,19 +172,40 @@ describe('parseExtensionContributedUsage', () => {
 
 	it('clamps negative numeric fields to 0 even when isApiUsage is satisfied', () => {
 		// Defends ChatResponseModel.setUsage's monotonic completion-token
-		// counter against a misbehaving provider emitting negatives.
+		// counter against a misbehaving provider emitting negatives. The
+		// positive `total_tokens: 1` keeps the payload above the no-signal
+		// threshold so the negative-clamp on the other fields is observable.
 		const bytes = new TextEncoder().encode(JSON.stringify({
 			prompt_tokens: -100,
 			completion_tokens: -50,
-			total_tokens: -150,
+			total_tokens: 1,
 			prompt_tokens_details: { cached_tokens: -10 },
 		}));
 		expect(parseExtensionContributedUsage(bytes)).toEqual({
 			prompt_tokens: 0,
 			completion_tokens: 0,
-			total_tokens: 0,
+			total_tokens: 1,
 			prompt_tokens_details: { cached_tokens: 0 },
 		});
+	});
+
+	it('rejects payloads that produce an all-zero, detail-less result after coercion', () => {
+		// These all parse to JSON objects with at least one recognised key,
+		// but none survives coercion as a positive signal. Treating them as
+		// valid would let a misbehaving provider clobber an earlier valid
+		// reading at the last-valid-wins dispatch site in `makeChatRequest2`.
+		expect(parseExtensionContributedUsage(new TextEncoder().encode(
+			JSON.stringify({ prompt_tokens_details: 'oops' })
+		))).toBeUndefined();
+		expect(parseExtensionContributedUsage(new TextEncoder().encode(
+			JSON.stringify({ completion_tokens_details: null })
+		))).toBeUndefined();
+		expect(parseExtensionContributedUsage(new TextEncoder().encode(
+			JSON.stringify({ prompt_tokens_details: {} })
+		))).toBeUndefined();
+		expect(parseExtensionContributedUsage(new TextEncoder().encode(
+			JSON.stringify({ prompt_tokens: -3, completion_tokens: -5 })
+		))).toBeUndefined();
 	});
 
 	it('preserves provider-supplied extra fields on the strict path', () => {
@@ -254,6 +277,30 @@ describe('parseExtensionContributedUsage', () => {
 		// and could overwrite an earlier valid reading at the dispatch site.
 		expect(parseExtensionContributedUsage(new TextEncoder().encode('[]'))).toBeUndefined();
 		expect(parseExtensionContributedUsage(new TextEncoder().encode('[1,2,3]'))).toBeUndefined();
+	});
+
+	it('returns undefined for empty / keyless objects', () => {
+		// `{}` and `{foo:'bar'}` parse to all-zero `APIUsage` and would
+		// clobber an earlier valid reading at the last-valid-wins dispatch
+		// site. The Usage data-part is for *reporting* counts, so a payload
+		// with no recognised key (or no positive signal — see the
+		// adjacent all-zero-rejection test) is treated as "this payload
+		// says nothing" rather than "all counts are zero".
+		expect(parseExtensionContributedUsage(new TextEncoder().encode('{}'))).toBeUndefined();
+		expect(parseExtensionContributedUsage(new TextEncoder().encode('{"foo":"bar"}'))).toBeUndefined();
+	});
+
+	it('accepts a payload that carries only a non-zero nested-detail signal', () => {
+		// A provider that only meaningfully reports `cached_tokens` (e.g. a
+		// cache-hit scenario) without surfacing top-level counters is still
+		// communicating useful information and must be propagated.
+		const bytes = new TextEncoder().encode(JSON.stringify({ prompt_tokens_details: { cached_tokens: 5 } }));
+		expect(parseExtensionContributedUsage(bytes)).toEqual({
+			prompt_tokens: 0,
+			completion_tokens: 0,
+			total_tokens: 0,
+			prompt_tokens_details: { cached_tokens: 5 },
+		});
 	});
 });
 
@@ -367,6 +414,42 @@ describe('ExtensionContributedChatEndpoint.makeChatRequest2 – usage propagatio
 		if (result.type === ChatFetchResponseType.Success) {
 			expect(result.usage?.prompt_tokens).toBe(42);
 			expect(result.usage?.completion_tokens).toBe(7);
+		}
+	});
+
+	it('keeps the previous valid Usage when a later part is an empty object', async () => {
+		// `{}` parses to JSON successfully but carries no usage keys, so
+		// it must be treated as "this part says nothing" and not overwrite
+		// the earlier valid reading.
+		const endpoint = createEndpoint([
+			new vscode.LanguageModelTextPart('x'),
+			usagePart({ prompt_tokens: 42, completion_tokens: 7, total_tokens: 49 }),
+			usagePart({}),
+		]);
+		const result = await endpoint.makeChatRequest2({
+			debugName: 't', messages: [helloMessage], finishedCb: noopFinish, location: ChatLocation.Other,
+		}, noToken);
+		if (result.type === ChatFetchResponseType.Success) {
+			expect(result.usage?.prompt_tokens).toBe(42);
+			expect(result.usage?.completion_tokens).toBe(7);
+		}
+	});
+
+	it('tolerates malformed JSON on a ContextManagement data part without aborting the stream', async () => {
+		// `ContextManagement` is also extension-provided, so a bad payload
+		// shouldn't be able to throw out of the response loop. The endpoint
+		// should still emit the text and a fresh usage tally that follows.
+		const endpoint = createEndpoint([
+			new vscode.LanguageModelTextPart('x'),
+			new vscode.LanguageModelDataPart(new TextEncoder().encode('not json'), CustomDataPartMimeTypes.ContextManagement),
+			usagePart({ prompt_tokens: 5, completion_tokens: 2, total_tokens: 7 }),
+		]);
+		const result = await endpoint.makeChatRequest2({
+			debugName: 't', messages: [helloMessage], finishedCb: noopFinish, location: ChatLocation.Other,
+		}, noToken);
+		expect(result.type).toBe(ChatFetchResponseType.Success);
+		if (result.type === ChatFetchResponseType.Success) {
+			expect(result.usage?.prompt_tokens).toBe(5);
 		}
 	});
 });

--- a/extensions/copilot/src/platform/endpoint/vscode-node/test/extChatEndpoint.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/vscode-node/test/extChatEndpoint.spec.ts
@@ -1,0 +1,293 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Raw } from '@vscode/prompt-tsx';
+import { describe, expect, it, vi } from 'vitest';
+import type { CancellationToken, LanguageModelChat, LanguageModelChatRequestOptions } from 'vscode';
+import * as vscode from 'vscode';
+import { Event } from '../../../../util/vs/base/common/event';
+import { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
+import { ChatFetchResponseType, ChatLocation } from '../../../chat/common/commonTypes';
+import { resolveOTelConfig } from '../../../otel/common/otelConfig';
+import type { ICompletedSpanData, IOTelService } from '../../../otel/common/otelService';
+import { CustomDataPartMimeTypes } from '../../common/endpointTypes';
+import { ExtensionContributedChatEndpoint, parseExtensionContributedUsage } from '../extChatEndpoint';
+
+type StreamChunk =
+	| vscode.LanguageModelTextPart
+	| vscode.LanguageModelToolCallPart
+	| vscode.LanguageModelDataPart
+	| vscode.LanguageModelThinkingPart;
+
+/**
+ * Minimal `LanguageModelChat` stub. `sendRequest` returns a response whose
+ * `.stream` async-iterates the chunks the test wants the endpoint to see.
+ */
+class MockLanguageModelChat implements Partial<LanguageModelChat> {
+	readonly id = 'mock-model';
+	readonly name = 'Mock Model';
+	readonly vendor = 'mock-vendor';
+	readonly family = 'mock-family';
+	readonly version = '1.0.0';
+	readonly maxInputTokens = 100_000;
+	readonly capabilities = {} as LanguageModelChat['capabilities'];
+
+	constructor(private readonly chunks: StreamChunk[]) { }
+
+	countTokens(): Thenable<number> { return Promise.resolve(0); }
+
+	sendRequest(
+		_messages: Array<vscode.LanguageModelChatMessage | vscode.LanguageModelChatMessage2>,
+		_options: LanguageModelChatRequestOptions,
+		_token: CancellationToken,
+	): Thenable<vscode.LanguageModelChatResponse> {
+		const chunks = this.chunks;
+		const stream = (async function* () {
+			for (const c of chunks) { yield c; }
+		})();
+		const text = (async function* () { /* unused */ })();
+		return Promise.resolve({ stream, text } as unknown as vscode.LanguageModelChatResponse);
+	}
+}
+
+function createMockOTelService(): IOTelService {
+	const injectedSpans: ICompletedSpanData[] = [];
+	return {
+		_serviceBrand: undefined!,
+		config: resolveOTelConfig({ env: {}, extensionVersion: '1.0.0', sessionId: 'test' }),
+		startSpan: vi.fn() as never,
+		startActiveSpan: vi.fn() as never,
+		getActiveTraceContext: vi.fn(() => undefined),
+		storeTraceContext: vi.fn(),
+		getStoredTraceContext: vi.fn(),
+		runWithTraceContext: vi.fn((_ctx: unknown, fn: () => Promise<unknown>) => fn()) as never,
+		recordMetric: vi.fn(),
+		incrementCounter: vi.fn(),
+		emitLogRecord: vi.fn(),
+		flush: vi.fn(),
+		shutdown: vi.fn(),
+		injectCompletedSpan(span: ICompletedSpanData) { injectedSpans.push(span); },
+		onDidCompleteSpan: Event.None,
+		onDidEmitSpanEvent: Event.None,
+	};
+}
+
+function createEndpoint(chunks: StreamChunk[]): ExtensionContributedChatEndpoint {
+	const lm = new MockLanguageModelChat(chunks) as unknown as LanguageModelChat;
+	const otel = createMockOTelService();
+	const instantiation: Partial<IInstantiationService> = {
+		createInstance: vi.fn() as never,
+		invokeFunction: vi.fn() as never,
+	};
+	return new ExtensionContributedChatEndpoint(
+		lm,
+		instantiation as IInstantiationService,
+		otel,
+	);
+}
+
+function usagePart(payload: unknown): vscode.LanguageModelDataPart {
+	const bytes = new TextEncoder().encode(typeof payload === 'string' ? payload : JSON.stringify(payload));
+	return new vscode.LanguageModelDataPart(bytes, CustomDataPartMimeTypes.Usage);
+}
+
+const ZERO_USAGE = { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0, prompt_tokens_details: { cached_tokens: 0 } };
+
+const helloMessage: Raw.ChatMessage = {
+	role: Raw.ChatRole.User,
+	content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: 'hello' }],
+};
+
+describe('parseExtensionContributedUsage', () => {
+	it('returns the full payload when fully shaped', () => {
+		const bytes = new TextEncoder().encode(JSON.stringify({
+			prompt_tokens: 100,
+			completion_tokens: 200,
+			total_tokens: 300,
+			prompt_tokens_details: { cached_tokens: 50 },
+		}));
+		expect(parseExtensionContributedUsage(bytes)).toEqual({
+			prompt_tokens: 100,
+			completion_tokens: 200,
+			total_tokens: 300,
+			prompt_tokens_details: { cached_tokens: 50 },
+		});
+	});
+
+	it('zero-fills missing numeric fields on a partial payload', () => {
+		const bytes = new TextEncoder().encode(JSON.stringify({ prompt_tokens: 12 }));
+		expect(parseExtensionContributedUsage(bytes)).toEqual({
+			prompt_tokens: 12,
+			completion_tokens: 0,
+			total_tokens: 0,
+		});
+	});
+
+	it('zero-fills cached_tokens when a partial payload includes prompt_tokens_details', () => {
+		// Top-level shape is *not* a complete APIUsage (missing completion_tokens),
+		// so the permissive branch runs and zero-fills cached_tokens.
+		const bytes = new TextEncoder().encode(JSON.stringify({
+			prompt_tokens: 1,
+			prompt_tokens_details: {},
+		}));
+		expect(parseExtensionContributedUsage(bytes)).toEqual({
+			prompt_tokens: 1,
+			completion_tokens: 0,
+			total_tokens: 0,
+			prompt_tokens_details: { cached_tokens: 0 },
+		});
+	});
+
+	it('coerces non-numeric fields to 0', () => {
+		const bytes = new TextEncoder().encode(JSON.stringify({
+			prompt_tokens: 'oops', completion_tokens: null, total_tokens: NaN,
+		}));
+		expect(parseExtensionContributedUsage(bytes)).toEqual({
+			prompt_tokens: 0, completion_tokens: 0, total_tokens: 0,
+		});
+	});
+
+	it('clamps negative numeric fields to 0 even when isApiUsage is satisfied', () => {
+		// Defends ChatResponseModel.setUsage's monotonic completion-token
+		// counter against a misbehaving provider emitting negatives.
+		const bytes = new TextEncoder().encode(JSON.stringify({
+			prompt_tokens: -100,
+			completion_tokens: -50,
+			total_tokens: -150,
+			prompt_tokens_details: { cached_tokens: -10 },
+		}));
+		expect(parseExtensionContributedUsage(bytes)).toEqual({
+			prompt_tokens: 0,
+			completion_tokens: 0,
+			total_tokens: 0,
+			prompt_tokens_details: { cached_tokens: 0 },
+		});
+	});
+
+	it('preserves provider-supplied extra fields on the strict path', () => {
+		// `APIUsage` carries optional `completion_tokens_details` and
+		// `cache_creation_input_tokens` that the host doesn't read today
+		// but a provider may emit; surface them faithfully so future
+		// consumers (or telemetry) see the wire data unchanged.
+		const bytes = new TextEncoder().encode(JSON.stringify({
+			prompt_tokens: 10, completion_tokens: 5, total_tokens: 15,
+			prompt_tokens_details: { cached_tokens: 1, cache_creation_input_tokens: 2 },
+			completion_tokens_details: { reasoning_tokens: 3, accepted_prediction_tokens: 0, rejected_prediction_tokens: 0 },
+		}));
+		expect(parseExtensionContributedUsage(bytes)).toEqual({
+			prompt_tokens: 10, completion_tokens: 5, total_tokens: 15,
+			prompt_tokens_details: { cached_tokens: 1, cache_creation_input_tokens: 2 },
+			completion_tokens_details: { reasoning_tokens: 3, accepted_prediction_tokens: 0, rejected_prediction_tokens: 0 },
+		});
+	});
+
+	it('returns undefined on malformed JSON', () => {
+		const bytes = new TextEncoder().encode('not json');
+		expect(parseExtensionContributedUsage(bytes)).toBeUndefined();
+	});
+
+	it('returns undefined on a non-object JSON payload', () => {
+		expect(parseExtensionContributedUsage(new TextEncoder().encode('42'))).toBeUndefined();
+		expect(parseExtensionContributedUsage(new TextEncoder().encode('"a"'))).toBeUndefined();
+		expect(parseExtensionContributedUsage(new TextEncoder().encode('null'))).toBeUndefined();
+	});
+});
+
+describe('ExtensionContributedChatEndpoint.makeChatRequest2 – usage propagation', () => {
+	const noopFinish = async () => undefined;
+	const noToken = { isCancellationRequested: false, onCancellationRequested: Event.None } as unknown as CancellationToken;
+
+	it('falls back to zero usage when the provider emits no Usage part (regression for #314722)', async () => {
+		const endpoint = createEndpoint([new vscode.LanguageModelTextPart('hi')]);
+		const result = await endpoint.makeChatRequest2({
+			debugName: 't', messages: [helloMessage], finishedCb: noopFinish, location: ChatLocation.Other,
+		}, noToken);
+		expect(result.type).toBe(ChatFetchResponseType.Success);
+		if (result.type === ChatFetchResponseType.Success) {
+			expect(result.usage).toEqual(ZERO_USAGE);
+			expect(result.value).toBe('hi');
+		}
+	});
+
+	it('propagates a fully-shaped Usage data part', async () => {
+		const endpoint = createEndpoint([
+			new vscode.LanguageModelTextPart('answer'),
+			usagePart({
+				prompt_tokens: 12345,
+				completion_tokens: 678,
+				total_tokens: 13023,
+				prompt_tokens_details: { cached_tokens: 9000 },
+			}),
+		]);
+		const result = await endpoint.makeChatRequest2({
+			debugName: 't', messages: [helloMessage], finishedCb: noopFinish, location: ChatLocation.Other,
+		}, noToken);
+		expect(result.type).toBe(ChatFetchResponseType.Success);
+		if (result.type === ChatFetchResponseType.Success) {
+			expect(result.usage).toEqual({
+				prompt_tokens: 12345,
+				completion_tokens: 678,
+				total_tokens: 13023,
+				prompt_tokens_details: { cached_tokens: 9000 },
+			});
+		}
+	});
+
+	it('propagates cached_tokens through prompt_tokens_details', async () => {
+		const endpoint = createEndpoint([
+			new vscode.LanguageModelTextPart('x'),
+			usagePart({
+				prompt_tokens: 100, completion_tokens: 50, total_tokens: 150,
+				prompt_tokens_details: { cached_tokens: 80 },
+			}),
+		]);
+		const result = await endpoint.makeChatRequest2({
+			debugName: 't', messages: [helloMessage], finishedCb: noopFinish, location: ChatLocation.Other,
+		}, noToken);
+		if (result.type === ChatFetchResponseType.Success) {
+			expect(result.usage?.prompt_tokens_details?.cached_tokens).toBe(80);
+		}
+	});
+
+	it('falls back to zero usage when the Usage payload is malformed JSON', async () => {
+		const endpoint = createEndpoint([
+			new vscode.LanguageModelTextPart('x'),
+			usagePart('definitely-not-json'),
+		]);
+		const result = await endpoint.makeChatRequest2({
+			debugName: 't', messages: [helloMessage], finishedCb: noopFinish, location: ChatLocation.Other,
+		}, noToken);
+		if (result.type === ChatFetchResponseType.Success) {
+			expect(result.usage).toEqual(ZERO_USAGE);
+		}
+	});
+
+	it('zero-fills a partial Usage payload (only prompt_tokens) without crashing', async () => {
+		const endpoint = createEndpoint([
+			new vscode.LanguageModelTextPart('x'),
+			usagePart({ prompt_tokens: 7 }),
+		]);
+		const result = await endpoint.makeChatRequest2({
+			debugName: 't', messages: [helloMessage], finishedCb: noopFinish, location: ChatLocation.Other,
+		}, noToken);
+		if (result.type === ChatFetchResponseType.Success) {
+			expect(result.usage).toEqual({ prompt_tokens: 7, completion_tokens: 0, total_tokens: 0 });
+		}
+	});
+
+	it('uses the last Usage part when the provider emits more than one (last-write-wins)', async () => {
+		const endpoint = createEndpoint([
+			new vscode.LanguageModelTextPart('x'),
+			usagePart({ prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 }),
+			usagePart({ prompt_tokens: 99, completion_tokens: 1, total_tokens: 100 }),
+		]);
+		const result = await endpoint.makeChatRequest2({
+			debugName: 't', messages: [helloMessage], finishedCb: noopFinish, location: ChatLocation.Other,
+		}, noToken);
+		if (result.type === ChatFetchResponseType.Success) {
+			expect(result.usage?.prompt_tokens).toBe(99);
+		}
+	});
+});

--- a/extensions/copilot/src/platform/endpoint/vscode-node/test/extChatEndpoint.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/vscode-node/test/extChatEndpoint.spec.ts
@@ -249,6 +249,11 @@ describe('parseExtensionContributedUsage', () => {
 		expect(parseExtensionContributedUsage(new TextEncoder().encode('42'))).toBeUndefined();
 		expect(parseExtensionContributedUsage(new TextEncoder().encode('"a"'))).toBeUndefined();
 		expect(parseExtensionContributedUsage(new TextEncoder().encode('null'))).toBeUndefined();
+		// Top-level arrays must be rejected even though `typeof [] === 'object'`.
+		// Otherwise a stray `[]` chunk would parse to a zero-filled `APIUsage`
+		// and could overwrite an earlier valid reading at the dispatch site.
+		expect(parseExtensionContributedUsage(new TextEncoder().encode('[]'))).toBeUndefined();
+		expect(parseExtensionContributedUsage(new TextEncoder().encode('[1,2,3]'))).toBeUndefined();
 	});
 });
 


### PR DESCRIPTION
Fixes #314722.

### Problem

The host-internal `ExtensionContributedChatEndpoint.makeChatRequest2` hardcoded a zero-filled `APIUsage` literal in its success envelope regardless of what the extension-contributed `LanguageModelChatProvider` actually streamed back. As a result, the Context Window indicator stayed pinned at 0 / max for every BYOK provider routed through this endpoint (Anthropic, Gemini-native, and any custom `registerLanguageModelChatProvider`).

### Fix

Add a new `CustomDataPartMimeTypes.Usage = 'usage'` branch on the existing `LanguageModelDataPart` switch in the response stream, plus a permissive `parseExtensionContributedUsage(data)` helper that decodes the UTF-8 JSON payload into the host's existing `APIUsage` shape. When the provider doesn't emit a Usage part the host keeps the historical zero-fallback behaviour, so this is purely additive — no behaviour change for existing extensions unless the provider opts in.

Last-write-wins on multiple Usage parts, matching the OpenAI streaming convention where the terminating chunk carries the final tally. The parser tolerates partial payloads (zero-fills missing fields) and malformed JSON (returns `undefined`, host falls back to zeros) so a misbehaving provider cannot break the host.

### Provider opt-in

One extra `progress.report` on the response stream:

```ts
progress.report(new vscode.LanguageModelDataPart(
    new TextEncoder().encode(JSON.stringify({
        prompt_tokens: 12345,
        completion_tokens: 678,
        total_tokens: 13023,
        prompt_tokens_details: { cached_tokens: 9000 }
    })),
    'usage' // CustomDataPartMimeTypes.Usage
));
```

### Defensive coercion

All numeric fields are clamped to non-negative finite numbers via `Math.max(0, ...)` on both the strict and permissive paths. `isApiUsage` only validates `typeof === 'number'`, so without this clamp a provider could emit negatives that would silently corrupt the host's monotonic completion-token counter in `ChatResponseModel.setUsage`. The strict path also preserves any extra fields the provider sent (`cache_creation_input_tokens`, `completion_tokens_details`) for telemetry / future consumers.

### Tests

14 new specs in `extensions/copilot/src/platform/endpoint/vscode-node/test/extChatEndpoint.spec.ts` covering:

- **Parse helper**: full / partial / malformed / non-object / type-coerced / negative-clamp / strict-path-extras payloads
- **End-to-end stream**: zero-fallback regression for #314722, full usage propagation, `cached_tokens` path, malformed-JSON fallback, partial payload, last-write-wins

All 241 specs in `extensions/copilot/src/platform/endpoint/` pass. Lint and `tsc --noEmit` are clean on the three changed files.

### How to verify

1. Install the build with the patched `extChatEndpoint.ts`.
2. Use any extension-contributed BYOK provider (e.g. an Anthropic / Gemini-native `LanguageModelChatProvider`) and have it report usage via the snippet above.
3. Open the **Context Window** widget in the chat side-panel — the bar should now reflect real prompt/completion tokens and (if the provider also reports it) the hatched output-buffer band.

<img width="219" height="344" alt="image" src="https://github.com/user-attachments/assets/7a74497f-1085-4063-9603-56e7cb18cde7" />

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->