### PR TITLE
chat: Discover plugins installed by Copilot CLI

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -159,7 +159,7 @@ import { LanguageModelToolsConfirmationService } from './tools/languageModelTool
 import { LanguageModelToolsService, globalAutoApproveDescription } from './tools/languageModelToolsService.js';
 import { IToolResultCompressor } from '../common/tools/toolResultCompressor.js';
 import { ToolResultCompressorService } from './tools/toolResultCompressorService.js';
-import { AgentPluginService, ConfiguredAgentPluginDiscovery, ExtensionAgentPluginDiscovery, MarketplaceAgentPluginDiscovery } from '../common/plugins/agentPluginServiceImpl.js';
+import { AgentPluginService, ConfiguredAgentPluginDiscovery, CopilotCliAgentPluginDiscovery, ExtensionAgentPluginDiscovery, MarketplaceAgentPluginDiscovery } from '../common/plugins/agentPluginServiceImpl.js';
 import { IAgentPluginRepositoryService } from '../common/plugins/agentPluginRepositoryService.js';
 import { IPluginInstallService } from '../common/plugins/pluginInstallService.js';
 import { IPluginMarketplaceService, PluginMarketplaceService } from '../common/plugins/pluginMarketplaceService.js';
@@ -2287,6 +2287,7 @@ registerEditorFeature(ChatPasteProvidersFeature);
 agentPluginDiscoveryRegistry.register(new SyncDescriptor(ConfiguredAgentPluginDiscovery));
 agentPluginDiscoveryRegistry.register(new SyncDescriptor(MarketplaceAgentPluginDiscovery));
 agentPluginDiscoveryRegistry.register(new SyncDescriptor(ExtensionAgentPluginDiscovery));
+agentPluginDiscoveryRegistry.register(new SyncDescriptor(CopilotCliAgentPluginDiscovery));
 
 registerSingleton(IChatResponseResourceFileSystemProvider, ChatResponseResourceFileSystemProvider, InstantiationType.Delayed);
 registerSingleton(IChatTransferService, ChatTransferService, InstantiationType.Delayed);

--- a/src/vs/workbench/contrib/chat/common/plugins/AGENTS_PLUGINS.md
+++ b/src/vs/workbench/contrib/chat/common/plugins/AGENTS_PLUGINS.md
@@ -84,6 +84,8 @@ Subclasses implement `_discoverPluginSources()` to determine *which* plugin URIs
 
 **MarketplaceAgentPluginDiscovery** — discovers plugins from `IPluginMarketplaceService.installedPlugins` and delegates to the install/repository services for on-disk availability.
 
+**CopilotCliAgentPluginDiscovery** — discovers plugins installed by the Copilot CLI under `~/.copilot/installed-plugins/<marketplace>/<plugin>/` (two levels deep; `_direct` is the marketplace segment for non-marketplace installs). The root directory is watched recursively for live install/uninstall changes.
+
 ### Plugin Formats
 
 Three format adapters implement `IAgentPluginFormatAdapter`:

--- a/src/vs/workbench/contrib/chat/common/plugins/AGENTS_PLUGINS.md
+++ b/src/vs/workbench/contrib/chat/common/plugins/AGENTS_PLUGINS.md
@@ -84,7 +84,7 @@ Subclasses implement `_discoverPluginSources()` to determine *which* plugin URIs
 
 **MarketplaceAgentPluginDiscovery** — discovers plugins from `IPluginMarketplaceService.installedPlugins` and delegates to the install/repository services for on-disk availability.
 
-**CopilotCliAgentPluginDiscovery** — discovers plugins installed by the Copilot CLI under `~/.copilot/installed-plugins/<marketplace>/<plugin>/` (two levels deep; `_direct` is the marketplace segment for non-marketplace installs). The root directory is watched recursively for live install/uninstall changes.
+**CopilotCliAgentPluginDiscovery** — discovers plugins installed by the Copilot CLI under `~/.copilot/installed-plugins/<marketplace>/<plugin>/` (two levels deep; `_direct` is the marketplace segment for non-marketplace installs). Watches the deepest existing ancestor (down to the install root) and each marketplace bucket non-recursively so the first-ever install is detected without a reload.
 
 ### Plugin Formats
 

--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
@@ -662,6 +662,156 @@ export class MarketplaceAgentPluginDiscovery extends AbstractAgentPluginDiscover
 }
 
 // ---------------------------------------------------------------------------
+// Copilot CLI plugin discovery
+// ---------------------------------------------------------------------------
+
+/**
+ * Directory under the Copilot CLI home where installed plugins are cached.
+ * Layout is two levels deep: `<marketplace>/<plugin>/`. Direct (non-marketplace)
+ * installs use the reserved marketplace segment `_direct`.
+ *
+ * See `src/plugins/manager.ts` in the copilot-agent-runtime repo.
+ */
+const COPILOT_CLI_INSTALLED_PLUGINS_DIR = '.copilot/installed-plugins';
+
+/**
+ * Discovers plugins installed by the Copilot CLI under
+ * `~/.copilot/installed-plugins/<marketplace>/<plugin>/`. Each leaf directory
+ * is treated as a plugin root, allowing CLI-installed plugins (both
+ * marketplace and direct) to surface in VS Code without a separate install.
+ */
+export class CopilotCliAgentPluginDiscovery extends AbstractAgentPluginDiscovery {
+
+	constructor(
+		@IFileService fileService: IFileService,
+		@IPathService pathService: IPathService,
+		@ILogService logService: ILogService,
+		@IWorkspaceContextService workspaceContextService: IWorkspaceContextService,
+		@IDialogService private readonly _dialogService: IDialogService,
+	) {
+		super(fileService, pathService, logService, workspaceContextService);
+	}
+
+	public override start(enablementModel: IEnablementModel): void {
+		this._enablementModel = enablementModel;
+		const scheduler = this._register(new RunOnceScheduler(() => this._refreshPlugins(), 0));
+
+		const watcherStore = this._register(new DisposableStore());
+		const setupWatchers = async () => {
+			watcherStore.clear();
+			if (this._store.isDisposed) {
+				return;
+			}
+
+			const root = await this._getInstalledPluginsDir();
+			// Watch the top-level installed-plugins directory so we notice when
+			// new marketplace buckets appear/disappear (e.g. first-ever install).
+			const rootWatcher = this._fileService.createWatcher(root, { recursive: false, excludes: [] });
+			watcherStore.add(rootWatcher);
+			watcherStore.add(rootWatcher.onDidChange(() => {
+				scheduler.schedule();
+				setupWatchers();
+			}));
+
+			// Watch each marketplace bucket non-recursively for plugin
+			// install/uninstall events.
+			let rootStat;
+			try {
+				rootStat = await this._fileService.resolve(root);
+			} catch {
+				return;
+			}
+			if (!rootStat.children) {
+				return;
+			}
+			for (const marketplaceDir of rootStat.children) {
+				if (!marketplaceDir.isDirectory) {
+					continue;
+				}
+				const watcher = this._fileService.createWatcher(marketplaceDir.resource, { recursive: false, excludes: [] });
+				watcherStore.add(watcher);
+				watcherStore.add(watcher.onDidChange(() => scheduler.schedule()));
+			}
+		};
+
+		setupWatchers().catch(() => { /* watchers are best-effort */ });
+		scheduler.schedule();
+	}
+
+	private async _getInstalledPluginsDir(): Promise<URI> {
+		const userHome = await this._pathService.userHome();
+		return joinPath(userHome, COPILOT_CLI_INSTALLED_PLUGINS_DIR);
+	}
+
+	protected override async _discoverPluginSources(): Promise<readonly IPluginSource[]> {
+		const root = await this._getInstalledPluginsDir();
+
+		let rootStat;
+		try {
+			rootStat = await this._fileService.resolve(root);
+		} catch {
+			// Directory doesn't exist — Copilot CLI hasn't installed any plugins.
+			return [];
+		}
+
+		if (!rootStat.isDirectory || !rootStat.children) {
+			return [];
+		}
+
+		const sources: IPluginSource[] = [];
+		// Each immediate child is a marketplace bucket (e.g. `_direct`,
+		// `<marketplace-name>`); each grandchild is a plugin root.
+		for (const marketplaceDir of rootStat.children) {
+			if (!marketplaceDir.isDirectory) {
+				continue;
+			}
+
+			let marketplaceStat;
+			try {
+				marketplaceStat = await this._fileService.resolve(marketplaceDir.resource);
+			} catch {
+				continue;
+			}
+
+			if (!marketplaceStat.children) {
+				continue;
+			}
+
+			for (const pluginDir of marketplaceStat.children) {
+				if (!pluginDir.isDirectory) {
+					continue;
+				}
+				sources.push({
+					uri: pluginDir.resource,
+					fromMarketplace: undefined,
+					remove: () => this._promptRemove(pluginDir.resource),
+				});
+			}
+		}
+
+		return sources;
+	}
+
+	private async _promptRemove(resource: URI): Promise<void> {
+		const { confirmed } = await this._dialogService.confirm({
+			message: localize('copilotCliPlugin.remove.confirm', "This plugin was installed by the Copilot CLI. Remove it from disk?"),
+			detail: localize('copilotCliPlugin.remove.detail', "The plugin directory '{0}' will be deleted. You can reinstall it later via the Copilot CLI.", resource.fsPath),
+			primaryButton: localize('copilotCliPlugin.remove.primary', "Remove"),
+		});
+		if (!confirmed) {
+			return;
+		}
+
+		try {
+			await this._fileService.del(resource, { recursive: true, useTrash: false });
+			this._enablementModel.remove(resource.toString());
+		} catch (error) {
+			this._logService.error('[CopilotCliAgentPluginDiscovery] Failed to remove plugin', error);
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Extension-contributed plugin discovery
 // ---------------------------------------------------------------------------
 

--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
@@ -704,14 +704,38 @@ export class CopilotCliAgentPluginDiscovery extends AbstractAgentPluginDiscovery
 			}
 
 			const root = await this._getInstalledPluginsDir();
-			// Watch the top-level installed-plugins directory so we notice when
-			// new marketplace buckets appear/disappear (e.g. first-ever install).
-			const rootWatcher = this._fileService.createWatcher(root, { recursive: false, excludes: [] });
-			watcherStore.add(rootWatcher);
-			watcherStore.add(rootWatcher.onDidChange(() => {
-				scheduler.schedule();
-				setupWatchers();
-			}));
+
+			// Walk up to the deepest existing ancestor and watch each directory
+			// from there down. Non-recursive watchers fail if the target doesn't
+			// exist, so we need to watch an existing parent (e.g. ~/.copilot or
+			// userHome) to detect the first-ever plugin install.
+			const dirsToWatch: URI[] = [];
+			let candidate: URI | undefined = root;
+			while (candidate) {
+				dirsToWatch.unshift(candidate);
+				const parent = joinPath(candidate, '..');
+				if (parent.toString() === candidate.toString()) {
+					break;
+				}
+				if (await this._pathExists(parent)) {
+					dirsToWatch.unshift(parent);
+					break;
+				}
+				candidate = parent;
+			}
+
+			for (const dir of dirsToWatch) {
+				if (!(await this._pathExists(dir))) {
+					continue;
+				}
+				const watcher = this._fileService.createWatcher(dir, { recursive: false, excludes: [] });
+				watcherStore.add(watcher);
+				watcherStore.add(watcher.onDidChange(() => {
+					scheduler.schedule();
+					// Re-attach watchers in case directories appeared/disappeared.
+					setupWatchers().catch(() => { /* watchers are best-effort */ });
+				}));
+			}
 
 			// Watch each marketplace bucket non-recursively for plugin
 			// install/uninstall events.
@@ -795,7 +819,7 @@ export class CopilotCliAgentPluginDiscovery extends AbstractAgentPluginDiscovery
 	private async _promptRemove(resource: URI): Promise<void> {
 		const { confirmed } = await this._dialogService.confirm({
 			message: localize('copilotCliPlugin.remove.confirm', "This plugin was installed by the Copilot CLI. Remove it from disk?"),
-			detail: localize('copilotCliPlugin.remove.detail', "The plugin directory '{0}' will be deleted. You can reinstall it later via the Copilot CLI.", resource.fsPath),
+			detail: localize('copilotCliPlugin.remove.detail', "The plugin directory '{0}' will be moved to the trash. You can reinstall it later via the Copilot CLI.", resource.fsPath),
 			primaryButton: localize('copilotCliPlugin.remove.primary', "Remove"),
 		});
 		if (!confirmed) {
@@ -803,7 +827,7 @@ export class CopilotCliAgentPluginDiscovery extends AbstractAgentPluginDiscovery
 		}
 
 		try {
-			await this._fileService.del(resource, { recursive: true, useTrash: false });
+			await this._fileService.del(resource, { recursive: true, useTrash: true });
 			this._enablementModel.remove(resource.toString());
 		} catch (error) {
 			this._logService.error('[CopilotCliAgentPluginDiscovery] Failed to remove plugin', error);


### PR DESCRIPTION
Fixes #302152

## What

Adds `CopilotCliAgentPluginDiscovery` — a new `IAgentPluginDiscovery` implementation that scans the Copilot CLI's installed-plugins directory and surfaces those plugins in VS Code automatically.

## How

The Copilot CLI stores installed plugins at `~/.copilot/installed-plugins/<marketplace>/<plugin>/` (two levels deep; non-marketplace / direct installs use `_direct` as the marketplace segment). The new discovery class:

1. Resolves the root via `IPathService.userHome()` (consistent with how other discoveries resolve `~`).
2. Enumerates marketplace buckets, then plugin directories within each, yielding one `IPluginSource` per leaf directory.
3. Sets up non-recursive `IFileService` watchers on the root and each marketplace bucket so CLI installs/uninstalls are reflected live without a reload.
4. Implements `remove()` by prompting the user before deleting the directory from disk (since the CLI manages this location).

The discovery is registered alongside the existing three (`ConfiguredAgentPluginDiscovery`, `MarketplaceAgentPluginDiscovery`, `ExtensionAgentPluginDiscovery`) in `chat.contribution.ts`. Deduplication in `AgentPluginService` handles any overlap with manually-configured paths.

## Testing

- Install a plugin via `gh copilot plugin install <repo>` and verify it appears in **Chat Customizations**.
- Uninstall it via the CLI and verify VS Code reflects the change without a reload.
- Verify that removing via VS Code's UI prompts before deleting.
