### PR TITLE
chat: use ILabelService for remote agent host names in permission UI

### DIFF
--- a/src/vs/platform/agentHost/browser/remoteAgentHostServiceImpl.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostServiceImpl.ts
@@ -12,6 +12,7 @@ import { Disposable, DisposableStore, IDisposable } from '../../../base/common/l
 import { DeferredPromise, raceTimeout } from '../../../base/common/async.js';
 import { ConfigurationTarget, IConfigurationService } from '../../configuration/common/configuration.js';
 import { IInstantiationService } from '../../instantiation/common/instantiation.js';
+import { ILabelService } from '../../label/common/label.js';
 import { ILogService } from '../../log/common/log.js';
 
 import type { IAgentConnection } from '../common/agentService.js';
@@ -30,7 +31,7 @@ import {
 } from '../common/remoteAgentHostService.js';
 import { RemoteAgentHostProtocolClient } from './remoteAgentHostProtocolClient.js';
 import { WebSocketClientTransport } from './webSocketClientTransport.js';
-import { normalizeRemoteAgentHostAddress } from '../common/agentHostUri.js';
+import { AGENT_HOST_SCHEME, agentHostAuthority, normalizeRemoteAgentHostAddress } from '../common/agentHostUri.js';
 import { isDefined } from '../../../base/common/types.js';
 import { PROTOCOL_VERSION } from '../common/state/protocol/version/registry.js';
 
@@ -70,11 +71,19 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 	private readonly _reconnectTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
 	/** Current reconnect attempt count per address for exponential backoff. */
 	private readonly _reconnectAttempts = new Map<string, number>();
+	/**
+	 * Per-address {@link ILabelService} formatter handles for the
+	 * {@link AGENT_HOST_SCHEME}. The formatter advertises the entry's
+	 * human-readable name as the host label so any UI looking up the host
+	 * label for an agent host URI gets the friendly name.
+	 */
+	private readonly _labelFormatters = new Map<string, IDisposable>();
 
 	constructor(
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@ILogService private readonly _logService: ILogService,
+		@ILabelService private readonly _labelService: ILabelService,
 	) {
 		super();
 
@@ -233,6 +242,7 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 		this._entries.set(address, connEntry);
 		this._names.set(address, entry.name);
 		this._registeredEntries.set(address, entry);
+		this._updateHostLabelFormatter(address, entry.name);
 		if (entry.connectionToken) {
 			this._tokens.set(address, entry.connectionToken);
 		}
@@ -275,6 +285,7 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 		this._names.delete(normalized);
 		this._tokens.delete(normalized);
 		this._registeredEntries.delete(normalized);
+		this._clearHostLabelFormatter(normalized);
 		this._cancelReconnect(normalized);
 		this._reconnectAttempts.delete(normalized);
 		this._removeConnection(normalized);
@@ -300,6 +311,15 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 			this._names.clear();
 			this._tokens.clear();
 			this._reconnectAttempts.clear();
+			// Drop label formatters for entries no longer represented by an
+			// active connection or a dynamically registered entry. Connections
+			// added via {@link addManagedConnection} (e.g. tunnels) live outside
+			// the configured-entries set and must keep their formatter.
+			for (const address of [...this._labelFormatters.keys()]) {
+				if (!this._registeredEntries.has(address)) {
+					this._clearHostLabelFormatter(address);
+				}
+			}
 			return;
 		}
 
@@ -317,8 +337,17 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 		for (const { entry, address } of entriesWithAddress) {
 			this._names.set(address, entry.name);
 			this._tokens.set(address, entry.connectionToken);
+			this._updateHostLabelFormatter(address, entry.name);
 			if (this._entries.has(address) && oldNames.get(address) !== entry.name) {
 				namesChanged = true;
+			}
+		}
+
+		// Drop formatters for addresses that are no longer configured and
+		// not dynamically registered.
+		for (const address of [...this._labelFormatters.keys()]) {
+			if (!desired.has(address) && !this._registeredEntries.has(address)) {
+				this._clearHostLabelFormatter(address);
 			}
 		}
 
@@ -565,6 +594,35 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 		void wait.error(err);
 	}
 
+	/**
+	 * Register (or re-register) the {@link AGENT_HOST_SCHEME} label formatter
+	 * for the given address so that {@link ILabelService.getHostLabel} resolves
+	 * to the entry's human-readable name. Called when an entry is added or its
+	 * name changes.
+	 */
+	private _updateHostLabelFormatter(address: string, name: string): void {
+		this._clearHostLabelFormatter(address);
+		const handle = this._labelService.registerFormatter({
+			scheme: AGENT_HOST_SCHEME,
+			authority: agentHostAuthority(address),
+			priority: true,
+			formatting: {
+				label: '${path}',
+				separator: '/',
+				workspaceSuffix: name,
+			},
+		});
+		this._labelFormatters.set(address, handle);
+	}
+
+	private _clearHostLabelFormatter(address: string): void {
+		const existing = this._labelFormatters.get(address);
+		if (existing) {
+			existing.dispose();
+			this._labelFormatters.delete(address);
+		}
+	}
+
 	override dispose(): void {
 		for (const timeout of this._reconnectTimeouts.values()) {
 			clearTimeout(timeout);
@@ -579,6 +637,10 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 			entry.store.dispose();
 		}
 		this._entries.clear();
+		for (const handle of this._labelFormatters.values()) {
+			handle.dispose();
+		}
+		this._labelFormatters.clear();
 		super.dispose();
 	}
 }

--- a/src/vs/platform/agentHost/browser/remoteAgentHostServiceImpl.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostServiceImpl.ts
@@ -31,7 +31,7 @@ import {
 } from '../common/remoteAgentHostService.js';
 import { RemoteAgentHostProtocolClient } from './remoteAgentHostProtocolClient.js';
 import { WebSocketClientTransport } from './webSocketClientTransport.js';
-import { AGENT_HOST_SCHEME, agentHostAuthority, normalizeRemoteAgentHostAddress } from '../common/agentHostUri.js';
+import { AGENT_HOST_LABEL_FORMATTER, AGENT_HOST_SCHEME, agentHostAuthority, normalizeRemoteAgentHostAddress } from '../common/agentHostUri.js';
 import { isDefined } from '../../../base/common/types.js';
 import { PROTOCOL_VERSION } from '../common/state/protocol/version/registry.js';
 
@@ -607,8 +607,7 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 			authority: agentHostAuthority(address),
 			priority: true,
 			formatting: {
-				label: '${path}',
-				separator: '/',
+				...AGENT_HOST_LABEL_FORMATTER.formatting,
 				workspaceSuffix: name,
 			},
 		});

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostService.test.ts
@@ -11,6 +11,7 @@ import { ILogService, NullLogService } from '../../../log/common/log.js';
 import { TestInstantiationService } from '../../../instantiation/test/common/instantiationServiceMock.js';
 import { IConfigurationService, type IConfigurationChangeEvent } from '../../../configuration/common/configuration.js';
 import { IInstantiationService } from '../../../instantiation/common/instantiation.js';
+import { ILabelService, type ResourceLabelFormatter } from '../../../label/common/label.js';
 import { RemoteAgentHostService } from '../../browser/remoteAgentHostServiceImpl.js';
 import { parseRemoteAgentHostInput, RemoteAgentHostConnectionStatus, RemoteAgentHostEntryType, RemoteAgentHostsEnabledSettingId, RemoteAgentHostsSettingId, entryToRawEntry, type IRawRemoteAgentHostEntry, type IRemoteAgentHostEntry } from '../../common/remoteAgentHostService.js';
 import { DeferredPromise } from '../../../../base/common/async.js';
@@ -109,6 +110,18 @@ suite('RemoteAgentHostService', () => {
 		const instantiationService = disposables.add(new TestInstantiationService());
 		instantiationService.stub(ILogService, new NullLogService());
 		instantiationService.stub(IConfigurationService, configService as Partial<IConfigurationService>);
+		instantiationService.stub(ILabelService, {
+			registeredFormatters: [] as ResourceLabelFormatter[],
+			registerFormatter(formatter: ResourceLabelFormatter) {
+				this.registeredFormatters.push(formatter);
+				return toDisposable(() => {
+					const idx = this.registeredFormatters.indexOf(formatter);
+					if (idx >= 0) {
+						this.registeredFormatters.splice(idx, 1);
+					}
+				});
+			},
+		} as Partial<ILabelService>);
 
 		// Mock the instantiation service to capture created protocol clients
 		const mockInstantiationService: Partial<IInstantiationService> = {

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostService.test.ts
@@ -14,6 +14,7 @@ import { IInstantiationService } from '../../../instantiation/common/instantiati
 import { ILabelService, type ResourceLabelFormatter } from '../../../label/common/label.js';
 import { RemoteAgentHostService } from '../../browser/remoteAgentHostServiceImpl.js';
 import { parseRemoteAgentHostInput, RemoteAgentHostConnectionStatus, RemoteAgentHostEntryType, RemoteAgentHostsEnabledSettingId, RemoteAgentHostsSettingId, entryToRawEntry, type IRawRemoteAgentHostEntry, type IRemoteAgentHostEntry } from '../../common/remoteAgentHostService.js';
+import { AGENT_HOST_SCHEME, agentHostAuthority } from '../../common/agentHostUri.js';
 import { DeferredPromise } from '../../../../base/common/async.js';
 
 // ---- Mock protocol client ---------------------------------------------------
@@ -99,6 +100,7 @@ suite('RemoteAgentHostService', () => {
 	const disposables = new DisposableStore();
 	let configService: TestConfigurationService;
 	let createdClients: MockProtocolClient[];
+	let registeredFormatters: ResourceLabelFormatter[];
 	let service: RemoteAgentHostService;
 
 	setup(() => {
@@ -110,14 +112,14 @@ suite('RemoteAgentHostService', () => {
 		const instantiationService = disposables.add(new TestInstantiationService());
 		instantiationService.stub(ILogService, new NullLogService());
 		instantiationService.stub(IConfigurationService, configService as Partial<IConfigurationService>);
+		registeredFormatters = [];
 		instantiationService.stub(ILabelService, {
-			registeredFormatters: [] as ResourceLabelFormatter[],
 			registerFormatter(formatter: ResourceLabelFormatter) {
-				this.registeredFormatters.push(formatter);
+				registeredFormatters.push(formatter);
 				return toDisposable(() => {
-					const idx = this.registeredFormatters.indexOf(formatter);
+					const idx = registeredFormatters.indexOf(formatter);
 					if (idx >= 0) {
-						this.registeredFormatters.splice(idx, 1);
+						registeredFormatters.splice(idx, 1);
 					}
 				});
 			},
@@ -501,6 +503,49 @@ suite('RemoteAgentHostService', () => {
 			service.dispose();
 
 			assert.strictEqual(t.disposed(), true, 'transport disposable runs when service is disposed');
+		});
+	});
+
+	suite('host label formatter', () => {
+
+		function formatterFor(address: string): ResourceLabelFormatter | undefined {
+			const authority = agentHostAuthority(address);
+			return registeredFormatters.find(f => f.scheme === AGENT_HOST_SCHEME && f.authority === authority);
+		}
+
+		test('registers formatter when an entry is added', async () => {
+			configService.setEntries([{ name: 'Host 1', connection: { type: RemoteAgentHostEntryType.WebSocket, address: 'ws://host1:8080' } }]);
+
+			const formatter = formatterFor('host1:8080');
+			assert.ok(formatter, 'formatter is registered');
+			assert.strictEqual(formatter.formatting.workspaceSuffix, 'Host 1');
+		});
+
+		test('refreshes formatter when an entry name changes', async () => {
+			configService.setEntries([{ name: 'Host 1', connection: { type: RemoteAgentHostEntryType.WebSocket, address: 'ws://host1:8080' } }]);
+			configService.setEntries([{ name: 'Renamed', connection: { type: RemoteAgentHostEntryType.WebSocket, address: 'ws://host1:8080' } }]);
+
+			const matching = registeredFormatters.filter(f => f.authority === agentHostAuthority('host1:8080'));
+			assert.strictEqual(matching.length, 1, 'old formatter is replaced, not duplicated');
+			assert.strictEqual(matching[0].formatting.workspaceSuffix, 'Renamed');
+		});
+
+		test('removes formatter when an entry is removed', async () => {
+			configService.setEntries([{ name: 'Host 1', connection: { type: RemoteAgentHostEntryType.WebSocket, address: 'ws://host1:8080' } }]);
+			assert.ok(formatterFor('host1:8080'));
+
+			configService.setEntries([]);
+
+			assert.strictEqual(formatterFor('host1:8080'), undefined);
+		});
+
+		test('removes formatters when the service is disabled', async () => {
+			configService.setEntries([{ name: 'Host 1', connection: { type: RemoteAgentHostEntryType.WebSocket, address: 'ws://host1:8080' } }]);
+			assert.ok(formatterFor('host1:8080'));
+
+			configService.setEnabled(false);
+
+			assert.strictEqual(formatterFor('host1:8080'), undefined);
 		});
 	});
 });

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostPermissionUiContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostPermissionUiContribution.ts
@@ -13,8 +13,9 @@ import {
 	IAgentHostPermissionService,
 	IPendingResourceRequest,
 } from '../../../../../../platform/agentHost/common/agentHostPermissionService.js';
-import { IRemoteAgentHostService } from '../../../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { AGENT_HOST_SCHEME, agentHostAuthority } from '../../../../../../platform/agentHost/common/agentHostUri.js';
 import { CommandsRegistry } from '../../../../../../platform/commands/common/commands.js';
+import { ILabelService } from '../../../../../../platform/label/common/label.js';
 import { ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { IWorkbenchContribution } from '../../../../../common/contributions.js';
 import {
@@ -61,7 +62,7 @@ export class AgentHostPermissionUiContribution extends Disposable implements IWo
 	constructor(
 		@IAgentHostPermissionService private readonly _permissionService: IAgentHostPermissionService,
 		@IChatInputNotificationService private readonly _chatInputNotificationService: IChatInputNotificationService,
-		@IRemoteAgentHostService private readonly _remoteAgentHostService: IRemoteAgentHostService,
+		@ILabelService private readonly _labelService: ILabelService,
 	) {
 		super();
 
@@ -147,6 +148,8 @@ export class AgentHostPermissionUiContribution extends Disposable implements IWo
 	}
 
 	private _resolveHostName(address: string): string {
-		return this._remoteAgentHostService.getEntryByAddress(address)?.name ?? address;
+		const authority = agentHostAuthority(address);
+		const label = this._labelService.getHostLabel(AGENT_HOST_SCHEME, authority);
+		return label && label !== authority ? label : address;
 	}
 }

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostPermissionUiContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostPermissionUiContribution.test.ts
@@ -14,14 +14,11 @@ import {
 	IAgentHostPermissionService,
 	IPendingResourceRequest,
 } from '../../../../../../platform/agentHost/common/agentHostPermissionService.js';
-import {
-	IRemoteAgentHostConnectionInfo,
-	IRemoteAgentHostEntry,
-	IRemoteAgentHostService,
-	RemoteAgentHostEntryType,
-} from '../../../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { AGENT_HOST_SCHEME, agentHostAuthority } from '../../../../../../platform/agentHost/common/agentHostUri.js';
+import { ILabelService } from '../../../../../../platform/label/common/label.js';
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { Event } from '../../../../../../base/common/event.js';
+import { MockLabelService } from '../../../../../services/label/test/common/mockLabelService.js';
 import { AgentHostPermissionUiContribution } from '../../../browser/agentSessions/agentHost/agentHostPermissionUiContribution.js';
 import {
 	IChatInputNotification,
@@ -58,25 +55,22 @@ class FakeNotificationService implements IChatInputNotificationService {
 	handleMessageSent(): void { /* */ }
 }
 
-class FakeRemoteAgentHostService implements IRemoteAgentHostService {
-	declare readonly _serviceBrand: undefined;
-	readonly onDidChangeConnections: Event<void> = Event.None;
-	readonly connections: readonly IRemoteAgentHostConnectionInfo[] = [];
-	readonly configuredEntries: readonly IRemoteAgentHostEntry[] = [];
+/**
+ * Mock label service that resolves host labels for the {@link AGENT_HOST_SCHEME}
+ * by stripping the authority encoding produced by {@link agentHostAuthority}.
+ */
+class StubLabelService extends MockLabelService {
+	private readonly _hostLabels = new Map<string, string>();
 
-	private readonly _entries = new Map<string, IRemoteAgentHostEntry>();
-
-	setEntry(address: string, name: string): void {
-		this._entries.set(address, { name, connection: { type: RemoteAgentHostEntryType.WebSocket, address } });
+	setHostName(address: string, name: string): void {
+		this._hostLabels.set(agentHostAuthority(address), name);
 	}
 
-	getConnection() { return undefined; }
-	async addRemoteAgentHost(): Promise<IRemoteAgentHostConnectionInfo> { throw new Error('not used'); }
-	async removeRemoteAgentHost(): Promise<void> { /* */ }
-	reconnect(): void { /* */ }
-	async addManagedConnection(): Promise<IRemoteAgentHostConnectionInfo> { throw new Error('not used'); }
-	getEntryByAddress(address: string): IRemoteAgentHostEntry | undefined {
-		return this._entries.get(address);
+	override getHostLabel(scheme: string, authority?: string): string {
+		if (scheme === AGENT_HOST_SCHEME && authority && this._hostLabels.has(authority)) {
+			return this._hostLabels.get(authority)!;
+		}
+		return authority ?? '';
 	}
 }
 
@@ -101,20 +95,20 @@ suite('AgentHostPermissionUiContribution', () => {
 
 	let permissionService: FakePermissionService;
 	let notificationService: FakeNotificationService;
-	let remoteAgentHostService: FakeRemoteAgentHostService;
+	let labelService: StubLabelService;
 
 	setup(() => {
 		permissionService = disposables.add(new FakePermissionService());
 		notificationService = new FakeNotificationService();
-		remoteAgentHostService = new FakeRemoteAgentHostService();
-		remoteAgentHostService.setEntry('host:1234', 'My Host');
+		labelService = new StubLabelService();
+		labelService.setHostName('host:1234', 'My Host');
 	});
 
 	function createContribution(): AgentHostPermissionUiContribution {
 		const instantiationService = disposables.add(new TestInstantiationService());
 		instantiationService.stub(IAgentHostPermissionService, permissionService);
 		instantiationService.stub(IChatInputNotificationService, notificationService);
-		instantiationService.stub(IRemoteAgentHostService, remoteAgentHostService);
+		instantiationService.stub(ILabelService, labelService);
 		const contribution = instantiationService.createInstance(AgentHostPermissionUiContribution);
 		disposables.add(contribution as unknown as IDisposable);
 		return contribution;

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostPermissionUiContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostPermissionUiContribution.test.ts
@@ -57,7 +57,9 @@ class FakeNotificationService implements IChatInputNotificationService {
 
 /**
  * Mock label service that resolves host labels for the {@link AGENT_HOST_SCHEME}
- * by stripping the authority encoding produced by {@link agentHostAuthority}.
+ * by mapping authorities encoded via {@link agentHostAuthority} to the
+ * friendly name registered through {@link StubLabelService.setHostName}.
+ * Unknown authorities are returned unchanged.
  */
 class StubLabelService extends MockLabelService {
 	private readonly _hostLabels = new Map<string, string>();


### PR DESCRIPTION
chat: use ILabelService for remote agent host names in permission UI

`AgentHostPermissionUiContribution` is registered for VS Code proper, but in VS Code we cannot
depend directly on `IRemoteAgentHostService` since that service is only registered in the Agents
window / sessions layer. Route the human-readable host name lookup through `ILabelService`
instead.

- `RemoteAgentHostService` now registers a per-host `ResourceLabelFormatter` for the
  `vscode-agent-host` scheme, with the entry name as the formatter's `workspaceSuffix`. The
  formatter is refreshed on entry add / name change and disposed on removal.
- `AgentHostPermissionUiContribution` drops the `IRemoteAgentHostService` dependency and
  resolves the host name via `ILabelService.getHostLabel(AGENT_HOST_SCHEME,
  agentHostAuthority(address))`, falling back to the raw address when no formatter is
  registered (e.g. in regular VS Code workbench).
- Updates the contribution and service tests accordingly.

(Commit message generated by Copilot)

