### PR TITLE
sessions: retain attached editor maximize state

### DIFF
--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -259,6 +259,7 @@ setPartHidden(hidden: boolean, part: Parts): void
     - The main editor part is hidden by default but can be shown for explicit editor workflows that target the main editor part
     - Modal editor opens do not change the current main editor visibility state
     - The sessions **Maximize Editor** action temporarily hides the panel when the visible panel is the terminal view, and the matching **Restore Editor** action reopens that terminal panel if maximize hid it
+    - When a maximized main editor attached to the auxiliary bar closes, the next attached-editor reopen restores that maximized state; modal editor flows do not participate in this restore behavior
   - All editors open via `MODAL_GROUP` into the `ModalEditorPart` overlay, which manages its own lifecycle
 
 ### 6.2 Part Sizing
@@ -665,6 +666,7 @@ interface IPartVisibilityState {
 
 | Date | Change |
 |------|--------|
+| 2026-05-01 | Updated the sessions main-editor lifecycle so maximized editors attached to the auxiliary bar remember their maximized state across close/reopen, while modal editor flows continue to ignore that remembered state. |
 | 2026-04-28 | Updated the sessions "Open in VS Code" titlebar widget to match the core "Open in Agents" affordance more closely: the product icon is greyscale by default, animates back to full color on hover/focus when motion is enabled, uses secondary-button hover chrome instead of quality-tinted backgrounds, and draws a separator before the Run split button. |
 | 2026-04-27 | Made the sessions shell gradient background the default treatment by removing the `sessions.experimental.shellGradientBackground` opt-in, always applying the root shell gradient layer, and renaming the workbench CSS hook to `shell-gradient-background`. |
 | 2026-04-23 | Updated mobile layout policy platform detection to use shared `platform.isMobile`, and reduced phone-layout CSS `!important` usage where selector specificity already provides stable overrides. |

--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -259,7 +259,7 @@ setPartHidden(hidden: boolean, part: Parts): void
     - The main editor part is hidden by default but can be shown for explicit editor workflows that target the main editor part
     - Modal editor opens do not change the current main editor visibility state
     - The sessions **Maximize Editor** action temporarily hides the panel when the visible panel is the terminal view, and the matching **Restore Editor** action reopens that terminal panel if maximize hid it
-    - When a maximized main editor attached to the auxiliary bar closes, the next attached-editor reopen restores that maximized state; modal editor flows do not participate in this restore behavior
+    - When a maximized main editor attached to the auxiliary bar closes, the next attached-editor reopen restores that maximized state only if the auxiliary bar is visible at reopen time; hiding and later re-showing the auxiliary bar does not by itself clear this pending restore state. Modal editor flows do not participate in this restore behavior
   - All editors open via `MODAL_GROUP` into the `ModalEditorPart` overlay, which manages its own lifecycle
 
 ### 6.2 Part Sizing

--- a/src/vs/sessions/browser/workbench.ts
+++ b/src/vs/sessions/browser/workbench.ts
@@ -1502,6 +1502,10 @@ export class Workbench extends Disposable implements IAgentWorkbenchLayoutServic
 			return;
 		}
 
+		if (hidden) {
+			this._restoreAttachedEditorMaximizedOnShow = false;
+		}
+
 		this.partVisibility.auxiliaryBar = !hidden;
 		this.mainContainer.classList.toggle(LayoutClasses.AUXILIARYBAR_HIDDEN, hidden);
 

--- a/src/vs/sessions/browser/workbench.ts
+++ b/src/vs/sessions/browser/workbench.ts
@@ -282,6 +282,7 @@ export class Workbench extends Disposable implements IAgentWorkbenchLayoutServic
 
 	private _editorMaximized = false;
 	private _editorLastNonMaximizedVisibility: IPartVisibilityState | undefined;
+	private _restoreAttachedEditorMaximizedOnShow = false;
 
 	private readonly restoredPromise = new DeferredPromise<void>();
 	readonly whenRestored = this.restoredPromise.p;
@@ -903,12 +904,14 @@ export class Workbench extends Disposable implements IAgentWorkbenchLayoutServic
 
 			if (!this.partVisibility.editor) {
 				this.setEditorHidden(false);
+				this.restoreAttachedEditorMaximizedState();
 			}
 		}));
 
 		// Hide editor part when last editor closes
 		this._register(this.editorService.onDidCloseEditor(() => {
 			if (this.partVisibility.editor && this.areAllGroupsEmpty()) {
+				this.rememberAttachedEditorMaximizedState();
 				this.setEditorHidden(true);
 			}
 		}));
@@ -933,6 +936,19 @@ export class Workbench extends Disposable implements IAgentWorkbenchLayoutServic
 			}
 		}
 		return true;
+	}
+
+	private rememberAttachedEditorMaximizedState(): void {
+		this._restoreAttachedEditorMaximizedOnShow = this._editorMaximized && this.partVisibility.auxiliaryBar;
+	}
+
+	private restoreAttachedEditorMaximizedState(): void {
+		const shouldRestore = this._restoreAttachedEditorMaximizedOnShow && this.partVisibility.auxiliaryBar;
+		this._restoreAttachedEditorMaximizedOnShow = false;
+
+		if (shouldRestore) {
+			this.setEditorMaximized(true);
+		}
 	}
 
 	private registerLayoutListeners(): void {

--- a/src/vs/sessions/test/browser/workbench.test.ts
+++ b/src/vs/sessions/test/browser/workbench.test.ts
@@ -18,6 +18,7 @@ interface IWorkbenchTestHarness {
 	_editorMaximized: boolean;
 	_restoreAttachedEditorMaximizedOnShow: boolean;
 	setEditorMaximized(maximized: boolean): void;
+	setAuxiliaryBarHidden(hidden: boolean): void;
 }
 
 suite('Sessions - Workbench', () => {
@@ -25,6 +26,7 @@ suite('Sessions - Workbench', () => {
 
 	const rememberAttachedEditorMaximizedState = Reflect.get(Workbench.prototype, 'rememberAttachedEditorMaximizedState') as (this: IWorkbenchTestHarness) => void;
 	const restoreAttachedEditorMaximizedState = Reflect.get(Workbench.prototype, 'restoreAttachedEditorMaximizedState') as (this: IWorkbenchTestHarness) => void;
+	const setAuxiliaryBarHidden = Reflect.get(Workbench.prototype, 'setAuxiliaryBarHidden') as (this: IWorkbenchTestHarness, hidden: boolean) => void;
 
 	function createWorkbenchHarness(): IWorkbenchTestHarness {
 		return {
@@ -38,6 +40,7 @@ suite('Sessions - Workbench', () => {
 			_editorMaximized: false,
 			_restoreAttachedEditorMaximizedOnShow: false,
 			setEditorMaximized: () => { },
+			setAuxiliaryBarHidden: () => { },
 		};
 	}
 
@@ -66,6 +69,51 @@ suite('Sessions - Workbench', () => {
 
 		workbench._editorMaximized = false;
 		workbench.partVisibility.auxiliaryBar = false;
+		restoreAttachedEditorMaximizedState.call(workbench);
+
+		assert.deepStrictEqual(maximizedStates, []);
+		assert.strictEqual(workbench._restoreAttachedEditorMaximizedOnShow, false);
+	});
+
+	test('does not restore after the auxiliary bar is hidden and shown again before reopen', () => {
+		const maximizedStates: boolean[] = [];
+		const workbench = createWorkbenchHarness();
+		workbench._editorMaximized = true;
+		workbench.setEditorMaximized = maximized => maximizedStates.push(maximized);
+		workbench.setAuxiliaryBarHidden = hidden => {
+			workbench.partVisibility.auxiliaryBar = !hidden;
+		};
+		(workbench as IWorkbenchTestHarness & {
+			mainContainer: { classList: { toggle(): void } };
+			workbenchGrid: { setViewVisible(): void };
+			auxiliaryBarPartView: {};
+			paneCompositeService: { getActivePaneComposite(): undefined; hideActivePaneComposite(): void; openPaneComposite(): void; getLastActivePaneCompositeId(): undefined };
+			viewDescriptorService: { getDefaultViewContainer(): undefined };
+		}).mainContainer = { classList: { toggle: () => { } } };
+		(workbench as IWorkbenchTestHarness & {
+			workbenchGrid: { setViewVisible(): void };
+			auxiliaryBarPartView: {};
+		}).workbenchGrid = { setViewVisible: () => { } };
+		(workbench as IWorkbenchTestHarness & { auxiliaryBarPartView: {} }).auxiliaryBarPartView = {};
+		(workbench as IWorkbenchTestHarness & {
+			paneCompositeService: { getActivePaneComposite(): undefined; hideActivePaneComposite(): void; openPaneComposite(): void; getLastActivePaneCompositeId(): undefined };
+		}).paneCompositeService = {
+			getActivePaneComposite: () => undefined,
+			hideActivePaneComposite: () => { },
+			openPaneComposite: () => { },
+			getLastActivePaneCompositeId: () => undefined,
+		};
+		(workbench as IWorkbenchTestHarness & {
+			viewDescriptorService: { getDefaultViewContainer(): undefined };
+		}).viewDescriptorService = {
+			getDefaultViewContainer: () => undefined,
+		};
+
+		rememberAttachedEditorMaximizedState.call(workbench);
+		setAuxiliaryBarHidden.call(workbench, true);
+		setAuxiliaryBarHidden.call(workbench, false);
+
+		workbench._editorMaximized = false;
 		restoreAttachedEditorMaximizedState.call(workbench);
 
 		assert.deepStrictEqual(maximizedStates, []);

--- a/src/vs/sessions/test/browser/workbench.test.ts
+++ b/src/vs/sessions/test/browser/workbench.test.ts
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../base/test/common/utils.js';
+import { Workbench } from '../../browser/workbench.js';
+
+interface IWorkbenchTestHarness {
+	partVisibility: {
+		sidebar: boolean;
+		auxiliaryBar: boolean;
+		editor: boolean;
+		panel: boolean;
+		chatBar: boolean;
+	};
+	_editorMaximized: boolean;
+	_restoreAttachedEditorMaximizedOnShow: boolean;
+	setEditorMaximized(maximized: boolean): void;
+}
+
+suite('Sessions - Workbench', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const rememberAttachedEditorMaximizedState = Reflect.get(Workbench.prototype, 'rememberAttachedEditorMaximizedState') as (this: IWorkbenchTestHarness) => void;
+	const restoreAttachedEditorMaximizedState = Reflect.get(Workbench.prototype, 'restoreAttachedEditorMaximizedState') as (this: IWorkbenchTestHarness) => void;
+
+	function createWorkbenchHarness(): IWorkbenchTestHarness {
+		return {
+			partVisibility: {
+				sidebar: true,
+				auxiliaryBar: true,
+				editor: true,
+				panel: false,
+				chatBar: true,
+			},
+			_editorMaximized: false,
+			_restoreAttachedEditorMaximizedOnShow: false,
+			setEditorMaximized: () => { },
+		};
+	}
+
+	test('restores attached editor maximized state when the auxiliary bar stays visible', () => {
+		const maximizedStates: boolean[] = [];
+		const workbench = createWorkbenchHarness();
+		workbench._editorMaximized = true;
+		workbench.setEditorMaximized = maximized => maximizedStates.push(maximized);
+
+		rememberAttachedEditorMaximizedState.call(workbench);
+
+		workbench._editorMaximized = false;
+		restoreAttachedEditorMaximizedState.call(workbench);
+
+		assert.deepStrictEqual(maximizedStates, [true]);
+		assert.strictEqual(workbench._restoreAttachedEditorMaximizedOnShow, false);
+	});
+
+	test('does not restore attached editor maximized state once the auxiliary bar is hidden', () => {
+		const maximizedStates: boolean[] = [];
+		const workbench = createWorkbenchHarness();
+		workbench._editorMaximized = true;
+		workbench.setEditorMaximized = maximized => maximizedStates.push(maximized);
+
+		rememberAttachedEditorMaximizedState.call(workbench);
+
+		workbench._editorMaximized = false;
+		workbench.partVisibility.auxiliaryBar = false;
+		restoreAttachedEditorMaximizedState.call(workbench);
+
+		assert.deepStrictEqual(maximizedStates, []);
+		assert.strictEqual(workbench._restoreAttachedEditorMaximizedOnShow, false);
+	});
+});


### PR DESCRIPTION
## Summary
- retain the maximized state of sessions main editors reopened from the auxiliary-bar-attached flow
- keep modal editor flows unchanged so reopening modal editors does not inherit attached-editor maximize state
- document the behavior in the sessions layout spec and add workbench coverage for the restore logic

## Validation
- `npm run compile-check-ts-native` *(currently fails on `main` due to unrelated errors in `src/vs/workbench/test/browser/componentFixtures/fixtureUtils.ts` referencing `context.host`)*
- `node --experimental-strip-types build/hygiene.ts src/vs/sessions/browser/workbench.ts src/vs/sessions/test/browser/workbench.test.ts src/vs/sessions/LAYOUT.md`
- `./scripts/test.sh --run src/vs/sessions/test/browser/workbench.test.ts --grep "Sessions - Workbench"` *(currently fails in this environment with `app.setPath` undefined in `test/unit/electron/index.js` after Electron launch)*