### PR TITLE
sessions: match panel tabs to auxiliary bar

### DIFF
--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -385,7 +385,7 @@ The Agent Sessions workbench uses specialized part implementations that extend t
 |---------|----------------|---------------------|
 | Activity Bar integration | Full support | No activity bar; account widget in the titlebar |
 | Composite bar position | Configurable (top/bottom/title/hidden) | Fixed: Title |
-| Composite bar visibility | Configurable | Sidebar: hidden (`shouldShowCompositeBar()` returns `false`); ChatBar: hidden; Auxiliary Bar & Panel: visible. Separately, the internal chat tab strip shown inside the Chat Bar preserves each chat title's original casing instead of forcing per-word capitalization via CSS. |
+| Composite bar visibility | Configurable | Sidebar: hidden (`shouldShowCompositeBar()` returns `false`); ChatBar: hidden; Auxiliary Bar & Panel: visible. The Auxiliary Bar and Panel title tabs share the same pill treatment: sentence-case labels, 500 font weight, compact horizontal padding, checked-state background, and no persistent active underline outside keyboard focus. Separately, the internal chat tab strip shown inside the Chat Bar preserves each chat title's original casing instead of forcing per-word capitalization via CSS. |
 | Auto-hide support | Configurable | Disabled |
 | Configuration listening | Many settings | Minimal |
 | Context menu actions | Full set | Simplified |
@@ -665,6 +665,7 @@ interface IPartVisibilityState {
 
 | Date | Change |
 |------|--------|
+| 2026-05-06 | Updated the sessions panel title tabs to reuse the same styling as the auxiliary bar's Changes/Files tabs: sentence-case labels, 500 font weight, tighter pill padding, and checked-state background without a persistent active underline. |
 | 2026-04-28 | Updated the sessions "Open in VS Code" titlebar widget to match the core "Open in Agents" affordance more closely: the product icon is greyscale by default, animates back to full color on hover/focus when motion is enabled, uses secondary-button hover chrome instead of quality-tinted backgrounds, and draws a separator before the Run split button. |
 | 2026-04-27 | Made the sessions shell gradient background the default treatment by removing the `sessions.experimental.shellGradientBackground` opt-in, always applying the root shell gradient layer, and renaming the workbench CSS hook to `shell-gradient-background`. |
 | 2026-04-23 | Updated mobile layout policy platform detection to use shared `platform.isMobile`, and reduced phone-layout CSS `!important` usage where selector specificity already provides stable overrides. |

--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -385,7 +385,7 @@ The Agent Sessions workbench uses specialized part implementations that extend t
 |---------|----------------|---------------------|
 | Activity Bar integration | Full support | No activity bar; account widget in the titlebar |
 | Composite bar position | Configurable (top/bottom/title/hidden) | Fixed: Title |
-| Composite bar visibility | Configurable | Sidebar: hidden (`shouldShowCompositeBar()` returns `false`); ChatBar: hidden; Auxiliary Bar & Panel: visible. The Auxiliary Bar and Panel title tabs share the same pill treatment: sentence-case labels, 500 font weight, compact horizontal padding, checked-state background, and no persistent active underline outside keyboard focus. Separately, the internal chat tab strip shown inside the Chat Bar preserves each chat title's original casing instead of forcing per-word capitalization via CSS. |
+| Composite bar visibility | Configurable | Sidebar: hidden (`shouldShowCompositeBar()` returns `false`); ChatBar: hidden; Auxiliary Bar & Panel: visible. The Auxiliary Bar and Panel title tabs share the same pill treatment: title-case labels, 500 font weight, compact horizontal padding, checked-state background, and no persistent active underline outside keyboard focus. Separately, the internal chat tab strip shown inside the Chat Bar preserves each chat title's original casing instead of forcing per-word capitalization via CSS. |
 | Auto-hide support | Configurable | Disabled |
 | Configuration listening | Many settings | Minimal |
 | Context menu actions | Full set | Simplified |
@@ -665,7 +665,7 @@ interface IPartVisibilityState {
 
 | Date | Change |
 |------|--------|
-| 2026-05-06 | Updated the sessions panel title tabs to reuse the same styling as the auxiliary bar's Changes/Files tabs: sentence-case labels, 500 font weight, tighter pill padding, and checked-state background without a persistent active underline. |
+| 2026-05-06 | Updated the sessions panel title tabs to reuse the same styling as the auxiliary bar's Changes/Files tabs: title-case labels, 500 font weight, tighter pill padding, and checked-state background without a persistent active underline. |
 | 2026-04-28 | Updated the sessions "Open in VS Code" titlebar widget to match the core "Open in Agents" affordance more closely: the product icon is greyscale by default, animates back to full color on hover/focus when motion is enabled, uses secondary-button hover chrome instead of quality-tinted backgrounds, and draws a separator before the Run split button. |
 | 2026-04-27 | Made the sessions shell gradient background the default treatment by removing the `sessions.experimental.shellGradientBackground` opt-in, always applying the root shell gradient layer, and renaming the workbench CSS hook to `shell-gradient-background`. |
 | 2026-04-23 | Updated mobile layout policy platform detection to use shared `platform.isMobile`, and reduced phone-layout CSS `!important` usage where selector specificity already provides stable overrides. |

--- a/src/vs/sessions/browser/parts/media/panelPart.css
+++ b/src/vs/sessions/browser/parts/media/panelPart.css
@@ -10,14 +10,26 @@
 
 /* ===== Modern action label styling for sessions panel ===== */
 
-/* Hide the underline indicator for non-focused, non-checked items; keep it for focus-visible and checked */
-.agent-sessions-workbench .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(:focus-visible):not(.checked) .active-item-indicator:before {
+/* Base label: lowercase text + heavier weight + pill padding */
+.agent-sessions-workbench .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon) .action-label {
+	text-transform: capitalize;
+	font-weight: 500;
+	border-radius: 4px;
+	padding: 0px 8px;
+	font-size: 12px;
+	line-height: 22px;
+}
+
+.agent-sessions-workbench .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item {
+	padding-left: 0;
+	padding-right: 0;
+}
+
+/* Hide the underline indicator for non-focused items, but keep it for keyboard focus */
+.agent-sessions-workbench .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(:focus-visible) .active-item-indicator:before {
 	display: none !important;
 }
 .agent-sessions-workbench .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus-visible .active-item-indicator:before {
-	display: block !important;
-}
-.agent-sessions-workbench .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .active-item-indicator:before {
 	display: block !important;
 }
 
@@ -27,8 +39,8 @@
 }
 
 .agent-sessions-workbench .part.panel > .title {
-	padding-left: 6px;
-	padding-right: 6px;
+	padding-left: 4px;
+	padding-right: 2px;
 	background-color: var(--vscode-agentsPanel-background);
 }
 


### PR DESCRIPTION
## Summary
- reuse the auxiliary bar tab treatment for the sessions panel title tabs
- switch panel tab labels to sentence case with 500 weight and tighter pill padding
- remove the persistent active underline in favor of the checked pill background and document the shared styling in `LAYOUT.md`

Before:

<img width="439" height="164" alt="Screenshot 2026-05-06 at 4 08 08 PM" src="https://github.com/user-attachments/assets/448b053f-292e-46d4-8b2c-15c4c03f6d2c" />

After:

<img width="1429" height="953" alt="Screenshot 2026-05-06 at 4 55 54 PM" src="https://github.com/user-attachments/assets/2c18f85b-d22c-4833-a403-3f730a0b707d" />

## Why
The terminal panel tabs in the sessions app looked visually different from the Changes/Files tabs in the auxiliary bar. This aligns the bottom panel with the established sessions tab styling so the chrome feels consistent across both surfaces.