### PR TITLE
Strip NODE_OPTIONS in removeDangerousEnvVariables

### DIFF
--- a/src/vs/base/common/processes.ts
+++ b/src/vs/base/common/processes.ts
@@ -140,6 +140,11 @@ export function removeDangerousEnvVariables(env: IProcessEnvironment | undefined
 	// See https://github.com/microsoft/vscode/issues/130072
 	delete env['DEBUG'];
 
+	// Unset `NODE_OPTIONS`, as it can be used to inject arbitrary flags
+	// (e.g. `--require`, `--inspect`) into forked Node processes, which
+	// has caused crashes and unexpected behavior.
+	delete env['NODE_OPTIONS'];
+
 	if (isLinux) {
 		// Unset `LD_PRELOAD`, as it might lead to process crashes
 		// See https://github.com/microsoft/vscode/issues/134177


### PR DESCRIPTION
NODE_OPTIONS can inject arbitrary flags (--require, --inspect, etc.) into forked Node processes, which can lead to crashes and unexpected behavior in the extension host and other forked processes (similar reasoning to the existing DEBUG and LD_PRELOAD\cleanups). Add it to the list of variables stripped by removeDangerousEnvVariables