### PR TITLE
Enable extensions in sessions window

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -56,6 +56,7 @@ import { IEditorService } from '../../../services/editor/common/editorService.js
 import { EnablementState, IExtensionManagementServerService, IPublisherInfo, IWorkbenchExtensionEnablementService, IWorkbenchExtensionManagementService } from '../../../services/extensionManagement/common/extensionManagement.js';
 import { IExtensionIgnoredRecommendationsService, IExtensionRecommendationsService } from '../../../services/extensionRecommendations/common/extensionRecommendations.js';
 import { IWorkspaceExtensionsConfigService } from '../../../services/extensionRecommendations/common/workspaceExtensionsConfig.js';
+import { EXTENSIONS_SUPPORT_SESSIONS_WINDOW } from '../../../services/extensions/common/extensionManifestPropertiesService.js';
 import { IHostService } from '../../../services/host/browser/host.js';
 import { LifecyclePhase } from '../../../services/lifecycle/common/lifecycle.js';
 import { IPreferencesService } from '../../../services/preferences/common/preferences.js';
@@ -211,6 +212,24 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 				defaultSnippets: [{
 					'body': {
 						'pub.name': false
+					}
+				}]
+			},
+			[EXTENSIONS_SUPPORT_SESSIONS_WINDOW]: {
+				type: 'object',
+				scope: ConfigurationScope.APPLICATION,
+				markdownDescription: localize('extensions.supportSessionsWindow', "Override the Agents window support of an extension. Extensions using `true` will be enabled in the Agents window even when they would otherwise be disabled."),
+				patternProperties: {
+					'([a-z0-9A-Z][a-z0-9-A-Z]*)\\.([a-z0-9A-Z][a-z0-9-A-Z]*)$': {
+						type: 'boolean',
+						default: false
+					}
+				},
+				additionalProperties: false,
+				default: {},
+				defaultSnippets: [{
+					'body': {
+						'pub.name': true
 					}
 				}]
 			},

--- a/src/vs/workbench/services/extensionManagement/test/browser/extensionEnablementService.test.ts
+++ b/src/vs/workbench/services/extensionManagement/test/browser/extensionEnablementService.test.ts
@@ -30,7 +30,7 @@ import { IHostService } from '../../../host/browser/host.js';
 import { mock } from '../../../../../base/test/common/mock.js';
 import { IExtensionBisectService } from '../../browser/extensionBisect.js';
 import { IWorkspaceTrustManagementService, IWorkspaceTrustRequestService, WorkspaceTrustRequestOptions } from '../../../../../platform/workspace/common/workspaceTrust.js';
-import { ExtensionManifestPropertiesService, IExtensionManifestPropertiesService } from '../../../extensions/common/extensionManifestPropertiesService.js';
+import { EXTENSIONS_SUPPORT_SESSIONS_WINDOW, ExtensionManifestPropertiesService, IExtensionManifestPropertiesService } from '../../../extensions/common/extensionManifestPropertiesService.js';
 import { TestChatEntitlementService, TestContextService, TestProductService, TestWorkspaceTrustEnablementService, TestWorkspaceTrustManagementService } from '../../../../test/common/workbenchTestServices.js';
 import { TestWorkspace } from '../../../../../platform/workspace/test/common/testWorkspace.js';
 import { ExtensionManagementService } from '../../common/extensionManagementService.js';
@@ -98,7 +98,7 @@ export class TestExtensionEnablementService extends ExtensionEnablementService {
 			instantiationService.stub(IAllowedExtensionsService, disposables.add(new AllowedExtensionsService(instantiationService.get(IProductService), instantiationService.get(IConfigurationService)))),
 			workspaceTrustManagementService,
 			new class extends mock<IWorkspaceTrustRequestService>() { override requestWorkspaceTrust(options?: WorkspaceTrustRequestOptions): Promise<boolean> { return Promise.resolve(true); } },
-			instantiationService.get(IExtensionManifestPropertiesService) || instantiationService.stub(IExtensionManifestPropertiesService, disposables.add(new ExtensionManifestPropertiesService(TestProductService, new TestConfigurationService(), new TestWorkspaceTrustEnablementService(), new NullLogService()))),
+			instantiationService.get(IExtensionManifestPropertiesService) || instantiationService.stub(IExtensionManifestPropertiesService, disposables.add(new ExtensionManifestPropertiesService(TestProductService, instantiationService.get(IConfigurationService), new TestWorkspaceTrustEnablementService(), new NullLogService()))),
 			chatEntitlementService ?? new TestChatEntitlementService(),
 			instantiationService,
 			new NullLogService(),
@@ -1263,6 +1263,22 @@ suite('ExtensionEnablementService Test', () => {
 			EnablementState.DisabledByEnvironment,
 			EnablementState.DisabledByEnvironment,
 			EnablementState.EnabledGlobally,
+		]);
+	});
+
+	test('test configured extensions are enabled in sessions window', async () => {
+		await (instantiationService.get(IConfigurationService) as TestConfigurationService).setUserConfiguration(EXTENSIONS_SUPPORT_SESSIONS_WINDOW, { 'pub.withMain': true, 'pub.nonThemeContrib': true });
+		instantiationService.stub(IWorkbenchEnvironmentService, { isSessionsWindow: true });
+		testObject = disposableStore.add(new TestExtensionEnablementService(instantiationService));
+
+		const withMain = aLocalExtension2('pub.withMain', { main: 'main.js', contributes: aContributes('themes') });
+		const nonThemeContrib = aLocalExtension2('pub.nonThemeContrib', { contributes: aContributes('commands') });
+		const withBrowser = aLocalExtension2('pub.withBrowser', { browser: 'main.browser.js', contributes: aContributes('themes') });
+
+		assert.deepStrictEqual([withMain, nonThemeContrib, withBrowser].map(ext => testObject.getEnablementState(ext)), [
+			EnablementState.EnabledGlobally,
+			EnablementState.EnabledGlobally,
+			EnablementState.DisabledByEnvironment,
 		]);
 	});
 

--- a/src/vs/workbench/services/extensions/common/extensionManifestPropertiesService.ts
+++ b/src/vs/workbench/services/extensions/common/extensionManifestPropertiesService.ts
@@ -22,6 +22,8 @@ import { isWeb } from '../../../../base/common/platform.js';
 
 export const IExtensionManifestPropertiesService = createDecorator<IExtensionManifestPropertiesService>('extensionManifestPropertiesService');
 
+export const EXTENSIONS_SUPPORT_SESSIONS_WINDOW = 'extensions.supportSessionsWindow';
+
 const SESSIONS_WINDOW_ALLOWED_CONTRIBUTION_POINTS: ReadonlySet<keyof IExtensionContributions> = new Set([
 	'themes',
 	'iconThemes',
@@ -62,6 +64,7 @@ export class ExtensionManifestPropertiesService extends Disposable implements IE
 
 	private _productVirtualWorkspaceSupportMap: ExtensionIdentifierMap<{ default?: boolean; override?: boolean }> | null = null;
 	private _configuredVirtualWorkspaceSupportMap: ExtensionIdentifierMap<boolean> | null = null;
+	private _configuredSessionsWindowSupportMap: ExtensionIdentifierMap<boolean> | null = null;
 
 	private readonly _configuredExtensionWorkspaceTrustRequestMap: ExtensionIdentifierMap<{ supported: ExtensionUntrustedWorkspaceSupportType; version?: string }>;
 	private readonly _productExtensionWorkspaceTrustRequestMap: Map<string, ExtensionUntrustedWorkspaceSupport>;
@@ -91,6 +94,11 @@ export class ExtensionManifestPropertiesService extends Disposable implements IE
 	}
 
 	canExecuteOnSessionsWindow(manifest: IExtensionManifest): boolean {
+		const configuredSessionsWindowSupport = this.getConfiguredSessionsWindowSupport(manifest);
+		if (configuredSessionsWindowSupport !== undefined) {
+			return configuredSessionsWindowSupport;
+		}
+
 		// In the sessions window only extensions that have no code are currently allowed to run
 		if (manifest.main || manifest.browser) {
 			return false;
@@ -369,6 +377,22 @@ export class ExtensionManifestPropertiesService extends Disposable implements IE
 
 		const extensionId = getGalleryExtensionId(manifest.publisher, manifest.name);
 		return this._configuredVirtualWorkspaceSupportMap.get(extensionId);
+	}
+
+	private getConfiguredSessionsWindowSupport(manifest: IExtensionManifest): boolean | undefined {
+		if (this._configuredSessionsWindowSupportMap === null) {
+			const configuredSessionsWindowSupportMap = new ExtensionIdentifierMap<boolean>();
+			const configuredSessionsWindowSupport = this.configurationService.getValue<{ [key: string]: boolean }>(EXTENSIONS_SUPPORT_SESSIONS_WINDOW) || {};
+			for (const id of Object.keys(configuredSessionsWindowSupport)) {
+				if (configuredSessionsWindowSupport[id] !== undefined) {
+					configuredSessionsWindowSupportMap.set(id, configuredSessionsWindowSupport[id]);
+				}
+			}
+			this._configuredSessionsWindowSupportMap = configuredSessionsWindowSupportMap;
+		}
+
+		const extensionId = getGalleryExtensionId(manifest.publisher, manifest.name);
+		return this._configuredSessionsWindowSupportMap.get(extensionId);
 	}
 
 	private getConfiguredExtensionWorkspaceTrustRequest(manifest: IExtensionManifest): ExtensionUntrustedWorkspaceSupportType | undefined {

--- a/src/vs/workbench/services/extensions/test/common/extensionManifestPropertiesService.test.ts
+++ b/src/vs/workbench/services/extensions/test/common/extensionManifestPropertiesService.test.ts
@@ -14,7 +14,7 @@ import { TestInstantiationService } from '../../../../../platform/instantiation/
 import { NullLogService } from '../../../../../platform/log/common/log.js';
 import { IProductService } from '../../../../../platform/product/common/productService.js';
 import { IWorkspaceTrustEnablementService } from '../../../../../platform/workspace/common/workspaceTrust.js';
-import { ExtensionManifestPropertiesService } from '../../common/extensionManifestPropertiesService.js';
+import { EXTENSIONS_SUPPORT_SESSIONS_WINDOW, ExtensionManifestPropertiesService } from '../../common/extensionManifestPropertiesService.js';
 import { TestProductService, TestWorkspaceTrustEnablementService } from '../../../../test/common/workbenchTestServices.js';
 
 suite('ExtensionManifestPropertiesService - ExtensionKind', () => {
@@ -106,6 +106,53 @@ suite('ExtensionManifestPropertiesService - ExtensionKind', () => {
 	test('extension cannot opt into web only', () => {
 		// eslint-disable-next-line local/code-no-any-casts
 		assert.deepStrictEqual(testObject.getExtensionKind(<any>{ main: 'main.js', extensionKind: ['web'] }), ['workspace']);
+	});
+});
+
+suite('ExtensionManifestPropertiesService - SessionsWindowSupport', () => {
+
+	let disposables: DisposableStore;
+	let testConfigurationService: TestConfigurationService;
+	let testObject: ExtensionManifestPropertiesService;
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	setup(() => {
+		disposables = new DisposableStore();
+		testConfigurationService = new TestConfigurationService();
+	});
+
+	teardown(() => {
+		testObject.dispose();
+		disposables.dispose();
+	});
+
+	function getExtensionManifest(properties: Partial<IExtensionManifest> = {}): IExtensionManifest {
+		return Object.create({ name: 'a', publisher: 'pub', version: '1.0.0', ...properties }) as IExtensionManifest;
+	}
+
+	function createTestObject(): ExtensionManifestPropertiesService {
+		return disposables.add(new ExtensionManifestPropertiesService(TestProductService, testConfigurationService, new TestWorkspaceTrustEnablementService(), new NullLogService()));
+	}
+
+	test('defaults to declarative extensions without executable code and supported contributions', () => {
+		testObject = createTestObject();
+
+		assert.deepStrictEqual([
+			testObject.canExecuteOnSessionsWindow(getExtensionManifest({ contributes: { themes: [] } })),
+			testObject.canExecuteOnSessionsWindow(getExtensionManifest({ main: './out/extension.js', contributes: { themes: [] } })),
+			testObject.canExecuteOnSessionsWindow(getExtensionManifest({ contributes: { commands: [] } })),
+		], [true, false, false]);
+	});
+
+	test('uses configured sessions window support override', async () => {
+		await testConfigurationService.setUserConfiguration(EXTENSIONS_SUPPORT_SESSIONS_WINDOW, { 'pub.a': true, 'pub.b': false });
+		testObject = createTestObject();
+
+		assert.deepStrictEqual([
+			testObject.canExecuteOnSessionsWindow(getExtensionManifest({ main: './out/extension.js', contributes: { commands: [] } })),
+			testObject.canExecuteOnSessionsWindow(getExtensionManifest({ name: 'b', contributes: { themes: [] } })),
+		], [true, false]);
 	});
 });
 

--- a/src/vs/workbench/services/extensions/test/common/extensionManifestPropertiesService.test.ts
+++ b/src/vs/workbench/services/extensions/test/common/extensionManifestPropertiesService.test.ts
@@ -115,8 +115,6 @@ suite('ExtensionManifestPropertiesService - SessionsWindowSupport', () => {
 	let testConfigurationService: TestConfigurationService;
 	let testObject: ExtensionManifestPropertiesService;
 
-	ensureNoDisposablesAreLeakedInTestSuite();
-
 	setup(() => {
 		disposables = new DisposableStore();
 		testConfigurationService = new TestConfigurationService();
@@ -126,6 +124,8 @@ suite('ExtensionManifestPropertiesService - SessionsWindowSupport', () => {
 		testObject.dispose();
 		disposables.dispose();
 	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
 
 	function getExtensionManifest(properties: Partial<IExtensionManifest> = {}): IExtensionManifest {
 		return Object.create({ name: 'a', publisher: 'pub', version: '1.0.0', ...properties }) as IExtensionManifest;


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce a configuration option that allows extensions to be enabled in the sessions window, even if they would typically be disabled. This includes updates to the extension manifest properties and tests to verify the new behavior.

