### PR TITLE
fix(extension-mgmt): record concurrent install result so callers don't see "Unknown error"

### DIFF
--- a/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
+++ b/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
@@ -353,8 +353,34 @@ export abstract class AbstractExtensionManagementService extends CommontExtensio
 
 				const existingInstallExtensionTask = !URI.isUri(extension) ? this.installingExtensions.get(getInstallExtensionTaskKey(extension, installExtensionTaskOptions.profileLocation)) : undefined;
 				if (existingInstallExtensionTask) {
-					this.logService.info('Extension is already requested to install', existingInstallExtensionTask.task.identifier.id, installExtensionTaskOptions.profileLocation.toString());
-					alreadyRequestedInstallations.push(existingInstallExtensionTask.task.waitUntilTaskIsFinished());
+					const existingTask = existingInstallExtensionTask.task;
+					this.logService.info('Extension is already requested to install', existingTask.identifier.id, installExtensionTaskOptions.profileLocation.toString());
+					// Record the result of the in-flight install into our results map so callers
+					// (e.g. installFromGallery) can find the actual local extension or real error
+					// instead of falling through to a generic "Unknown error".
+					const resultKey = `${existingTask.identifier.id.toLowerCase()}-${installExtensionTaskOptions.profileLocation.toString()}`;
+					alreadyRequestedInstallations.push(existingTask.waitUntilTaskIsFinished().then(local => {
+						installExtensionResultsMap.set(resultKey, {
+							local,
+							identifier: existingTask.identifier,
+							operation: existingTask.operation,
+							source: existingTask.source,
+							context: installExtensionTaskOptions.context,
+							profileLocation: installExtensionTaskOptions.profileLocation,
+							applicationScoped: local.isApplicationScoped,
+						});
+						return local;
+					}, error => {
+						installExtensionResultsMap.set(resultKey, {
+							error: toExtensionManagementError(error),
+							identifier: existingTask.identifier,
+							operation: existingTask.operation,
+							source: existingTask.source,
+							context: installExtensionTaskOptions.context,
+							profileLocation: installExtensionTaskOptions.profileLocation,
+						});
+						throw error;
+					}));
 				} else {
 					createInstallExtensionTask(manifest, extension, installExtensionTaskOptions, undefined);
 				}

--- a/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
+++ b/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
@@ -359,7 +359,7 @@ export abstract class AbstractExtensionManagementService extends CommontExtensio
 					// (e.g. installFromGallery) can find the actual local extension or real error
 					// instead of falling through to a generic "Unknown error".
 					const resultKey = `${existingTask.identifier.id.toLowerCase()}-${installExtensionTaskOptions.profileLocation.toString()}`;
-					alreadyRequestedInstallations.push(existingTask.waitUntilTaskIsFinished().then(local => {
+					const waitForInstallation = existingTask.waitUntilTaskIsFinished().then(local => {
 						installExtensionResultsMap.set(resultKey, {
 							local,
 							identifier: existingTask.identifier,
@@ -380,7 +380,12 @@ export abstract class AbstractExtensionManagementService extends CommontExtensio
 							profileLocation: installExtensionTaskOptions.profileLocation,
 						});
 						throw error;
-					}));
+					});
+					alreadyRequestedInstallations.push(waitForInstallation);
+					// Attach a no-op rejection handler to prevent an unhandledRejection if the
+					// outer try throws before `alreadyRequestedInstallations` is awaited below.
+					// The original promise is still observed via `joinAllSettled` on the happy path.
+					waitForInstallation.catch(() => { });
 				} else {
 					createInstallExtensionTask(manifest, extension, installExtensionTaskOptions, undefined);
 				}


### PR DESCRIPTION
## Summary

Fixes a race in `installFromGallery` that surfaces in telemetry as `Unknown error while installing extension <id>` for ~1,484 unique users in the last 14 days (bucket [`810ac6ce…`](https://errors.code.visualstudio.com/bucket/810ac6ce-7474-cbb8-6b61-a246a32dd242), `github.copilot-chat`), plus three other extension-specific buckets.

Linked issues: #310858 (open, currently auto-triaged with the same root-cause analysis), #293368 (closed for "not enough information" — this PR explains the missing piece).

## Root cause

`AbstractExtensionManagementService.installExtensions(...)` keeps a class-level map `installingExtensions` of in-flight installs keyed by `(extensionId, profileLocation)`. When a second `installFromGallery(extA)` arrives while a first is still running, the top-level loop takes the "wait for existing task" branch:

```ts
const existingInstallExtensionTask = ...this.installingExtensions.get(...);
if (existingInstallExtensionTask) {
    alreadyRequestedInstallations.push(existingInstallExtensionTask.task.waitUntilTaskIsFinished());
} else {
    createInstallExtensionTask(...);
}
```

Only `createInstallExtensionTask` populates the local `installingExtensionsMap`, so the parallel-install loop and the deps loop both iterate over an empty map and **nothing writes into `installExtensionResultsMap`**.

After the awaited tasks complete, the function does:

```ts
if (alreadyRequestedInstallations.length) {
    await this.joinAllSettled(alreadyRequestedInstallations);   // result discarded
}
...
return [...installExtensionResultsMap.values()];                // → []
```

Back in `installFromGallery`:

```ts
const results = await this.installGalleryExtensions([{ extension, options }]);
const result = results.find(...);                       // undefined
if (result?.local)  return result.local;                // miss
if (result?.error)  throw result.error;                 // miss
const redirectedResult = results[0];                    // undefined
if (redirectedResult?.local) return redirectedResult.local;     // miss
if (redirectedResult?.error) throw redirectedResult.error;      // miss
throw new ExtensionManagementError(`Unknown error while installing extension ${extension.identifier.id}`, ExtensionManagementErrorCode.Unknown);
```

Two failure modes, one symptom:
- In-flight install **succeeded** → caller throws "Unknown error" even though the extension is installed.
- In-flight install **failed** → `joinAllSettled` rethrows; the outer `catch` only iterates the (empty) `installingExtensionsMap` so no real error is recorded; control falls through and `return []` → caller throws the generic message instead of the underlying cause. (This is why #293368 had no actionable info.)

## Fix

When the existing-task branch is taken, attach `.then(...)` / `.catch(...)` to `waitUntilTaskIsFinished()` and write the resolved `ILocalExtension` (or rejection reason, normalized via `toExtensionManagementError`) into `installExtensionResultsMap` keyed identically to primary tasks (`${identifier.id.toLowerCase()}-${profileLocation.toString()}`). On the failure path we still re-throw so the existing `joinAllSettled` rejection / outer `catch` semantics are preserved.

After the fix:
- Concurrent install succeeded → `installFromGallery`'s `results.find(...)` returns the real `ILocalExtension`. ✅
- Concurrent install failed → `installFromGallery` throws the **real** error (e.g. network / signature / disk-full), which is what `sandy081` needs to investigate. ✅

No public API changes. ~28 lines net.

## Telemetry context

| Bucket | Extension | Hits / 14d | Users / 14d | Versions |
|---|---|---:|---:|---|
| `810ac6ce…` | `github.copilot-chat` | 3,525 | 1,484 | 1.116, 1.117 |
| `33a063ed…` | `anthropic.claude-code` | 432 | 144 | 1.116–1.118.1 |
| `fad68ea2…` | `ms-ceintl.vscode-language-pack-zh-hans` | 240 | 144 | 1.116–1.118.1 |
| `09e28363…` | `ms-python.python` | 385 | 121 | 1.116–1.118.1 |

All four buckets share the exact stack frame at `abstractExtensionManagementService.ts:184` (the `throw new ExtensionManagementError("Unknown error...")` line).
