### PR TITLE
mcp: use chatStreamToolCallId for tool invocation permalinks

### DIFF
--- a/src/vs/workbench/contrib/mcp/common/mcpLanguageModelToolContribution.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpLanguageModelToolContribution.ts
@@ -377,7 +377,7 @@ class McpToolImplementation implements IToolImpl {
 					});
 
 					if (isForModel) {
-						const permalink = invocation.context && ChatResponseResource.createUri(invocation.context.sessionResource, invocation.callId, result.content.length, basename(uri));
+						const permalink = invocation.context && ChatResponseResource.createUri(invocation.context.sessionResource, invocation.chatStreamToolCallId || invocation.callId, result.content.length, basename(uri));
 						addAsLinkedResource(permalink || uri, item.resource.mimeType);
 					}
 				}


### PR DESCRIPTION
- Fixes tool invocation permalinks in MCP by using chatStreamToolCallId
  when available, with a fallback to callId for backward compatibility
- Ensures tool results in chat responses are correctly linked to their
  stream tool call context

Fixes #314706

(Commit message generated by Copilot)