### PR TITLE
Support for RTL text in find decorations

### DIFF
--- a/src/vs/editor/contrib/find/browser/findDecorations.ts
+++ b/src/vs/editor/contrib/find/browser/findDecorations.ts
@@ -8,7 +8,7 @@ import { IDisposable } from '../../../../base/common/lifecycle.js';
 import { IActiveCodeEditor } from '../../../browser/editorBrowser.js';
 import { Position } from '../../../common/core/position.js';
 import { Range } from '../../../common/core/range.js';
-import { FindMatch, IModelDecorationsChangeAccessor, IModelDeltaDecoration, MinimapPosition, OverviewRulerLane, TrackedRangeStickiness } from '../../../common/model.js';
+import { FindMatch, IModelDecorationOptions, IModelDecorationsChangeAccessor, IModelDeltaDecoration, MinimapPosition, OverviewRulerLane, TrackedRangeStickiness } from '../../../common/model.js';
 import { ModelDecorationOptions } from '../../../common/model/textModel.js';
 import { minimapFindMatch, overviewRulerFindMatchForeground } from '../../../../platform/theme/common/colorRegistry.js';
 import { themeColorFromId } from '../../../../platform/theme/common/themeService.js';
@@ -336,85 +336,55 @@ export class FindDecorations implements IDisposable {
 		return result;
 	}
 
-	public static readonly _CURRENT_FIND_MATCH_DECORATION = ModelDecorationOptions.register({
-		description: 'current-find-match',
-		stickiness: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
-		zIndex: 13,
-		className: 'currentFindMatch',
-		inlineClassName: 'currentFindMatchInline',
-		showIfCollapsed: true,
-		overviewRuler: {
-			color: themeColorFromId(overviewRulerFindMatchForeground),
-			position: OverviewRulerLane.Center
-		},
-		minimap: {
-			color: themeColorFromId(minimapFindMatch),
-			position: MinimapPosition.Inline
-		}
-	});
+	private static _createCurrentFindMatchDecorationOptions(description: string, inlineClassName?: string): IModelDecorationOptions {
+		return {
+			description,
+			stickiness: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
+			zIndex: 13,
+			className: 'currentFindMatch',
+			inlineClassName,
+			showIfCollapsed: true,
+			overviewRuler: {
+				color: themeColorFromId(overviewRulerFindMatchForeground),
+				position: OverviewRulerLane.Center
+			},
+			minimap: {
+				color: themeColorFromId(minimapFindMatch),
+				position: MinimapPosition.Inline
+			}
+		};
+	}
 
-	public static readonly _CURRENT_FIND_MATCH_BIDI_DECORATION = ModelDecorationOptions.register({
-		description: 'current-find-match-bidi',
-		stickiness: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
-		zIndex: 13,
-		className: 'currentFindMatch',
-		showIfCollapsed: true,
-		overviewRuler: {
-			color: themeColorFromId(overviewRulerFindMatchForeground),
-			position: OverviewRulerLane.Center
-		},
-		minimap: {
-			color: themeColorFromId(minimapFindMatch),
-			position: MinimapPosition.Inline
-		}
-	});
+	private static _createFindMatchDecorationOptions(description: string, includeOverviewRuler: boolean, zIndex?: number, inlineClassName?: string): IModelDecorationOptions {
+		return {
+			description,
+			stickiness: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
+			zIndex,
+			className: 'findMatch',
+			inlineClassName,
+			showIfCollapsed: true,
+			overviewRuler: includeOverviewRuler ? {
+				color: themeColorFromId(overviewRulerFindMatchForeground),
+				position: OverviewRulerLane.Center
+			} : undefined,
+			minimap: includeOverviewRuler ? {
+				color: themeColorFromId(minimapFindMatch),
+				position: MinimapPosition.Inline
+			} : undefined
+		};
+	}
 
-	public static readonly _FIND_MATCH_DECORATION = ModelDecorationOptions.register({
-		description: 'find-match',
-		stickiness: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
-		zIndex: 10,
-		className: 'findMatch',
-		inlineClassName: 'findMatchInline',
-		showIfCollapsed: true,
-		overviewRuler: {
-			color: themeColorFromId(overviewRulerFindMatchForeground),
-			position: OverviewRulerLane.Center
-		},
-		minimap: {
-			color: themeColorFromId(minimapFindMatch),
-			position: MinimapPosition.Inline
-		}
-	});
+	public static readonly _CURRENT_FIND_MATCH_DECORATION = ModelDecorationOptions.register(FindDecorations._createCurrentFindMatchDecorationOptions('current-find-match', 'currentFindMatchInline'));
 
-	public static readonly _FIND_MATCH_BIDI_DECORATION = ModelDecorationOptions.register({
-		description: 'find-match-bidi',
-		stickiness: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
-		zIndex: 10,
-		className: 'findMatch',
-		showIfCollapsed: true,
-		overviewRuler: {
-			color: themeColorFromId(overviewRulerFindMatchForeground),
-			position: OverviewRulerLane.Center
-		},
-		minimap: {
-			color: themeColorFromId(minimapFindMatch),
-			position: MinimapPosition.Inline
-		}
-	});
+	public static readonly _CURRENT_FIND_MATCH_BIDI_DECORATION = ModelDecorationOptions.register(FindDecorations._createCurrentFindMatchDecorationOptions('current-find-match-bidi'));
 
-	public static readonly _FIND_MATCH_NO_OVERVIEW_DECORATION = ModelDecorationOptions.register({
-		description: 'find-match-no-overview',
-		stickiness: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
-		className: 'findMatch',
-		showIfCollapsed: true
-	});
+	public static readonly _FIND_MATCH_DECORATION = ModelDecorationOptions.register(FindDecorations._createFindMatchDecorationOptions('find-match', true, 10, 'findMatchInline'));
 
-	public static readonly _FIND_MATCH_NO_OVERVIEW_BIDI_DECORATION = ModelDecorationOptions.register({
-		description: 'find-match-no-overview-bidi',
-		stickiness: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
-		className: 'findMatch',
-		showIfCollapsed: true
-	});
+	public static readonly _FIND_MATCH_BIDI_DECORATION = ModelDecorationOptions.register(FindDecorations._createFindMatchDecorationOptions('find-match-bidi', true, 10));
+
+	public static readonly _FIND_MATCH_NO_OVERVIEW_DECORATION = ModelDecorationOptions.register(FindDecorations._createFindMatchDecorationOptions('find-match-no-overview', false));
+
+	public static readonly _FIND_MATCH_NO_OVERVIEW_BIDI_DECORATION = FindDecorations._FIND_MATCH_NO_OVERVIEW_DECORATION;
 
 	private static readonly _FIND_MATCH_ONLY_OVERVIEW_DECORATION = ModelDecorationOptions.register({
 		description: 'find-match-only-overview',

--- a/src/vs/editor/contrib/find/browser/findDecorations.ts
+++ b/src/vs/editor/contrib/find/browser/findDecorations.ts
@@ -174,6 +174,8 @@ export class FindDecorations implements IDisposable {
 
 	public set(findMatches: FindMatch[], findScopes: Range[] | null): void {
 		this._editor.changeDecorations((accessor) => {
+			const model = this._editor.getModel();
+			const lineContainsRTLCache = model.mightContainRTL() ? new Map<number, boolean>() : undefined;
 
 			this._useFindMatchOverviewRuler = true;
 			const newOverviewRulerApproximateDecorations: IModelDeltaDecoration[] = [];
@@ -184,7 +186,7 @@ export class FindDecorations implements IDisposable {
 				this._useFindMatchOverviewRuler = false;
 
 				// approximate a distance in lines where matches should be merged
-				const lineCount = this._editor.getModel().getLineCount();
+				const lineCount = model.getLineCount();
 				const height = this._editor.getLayoutInfo().height;
 				const approxPixelsPerLine = height / lineCount;
 				const mergeLinesDelta = Math.max(2, Math.ceil(3 / approxPixelsPerLine));
@@ -219,7 +221,7 @@ export class FindDecorations implements IDisposable {
 			for (let i = 0, len = findMatches.length; i < len; i++) {
 				newFindMatchesDecorations[i] = {
 					range: findMatches[i].range,
-					options: this._getFindMatchDecorationOptions(findMatches[i].range, this._useFindMatchOverviewRuler)
+					options: this._getFindMatchDecorationOptions(findMatches[i].range, this._useFindMatchOverviewRuler, lineContainsRTLCache)
 				};
 			}
 			this._decorations = accessor.deltaDecorations(this._decorations, newFindMatchesDecorations);
@@ -244,8 +246,8 @@ export class FindDecorations implements IDisposable {
 		});
 	}
 
-	private _getFindMatchDecorationOptions(range: Range, includeOverviewRuler: boolean): ModelDecorationOptions {
-		if (this._rangeContainsRTL(range)) {
+	private _getFindMatchDecorationOptions(range: Range, includeOverviewRuler: boolean, lineContainsRTLCache?: Map<number, boolean>): ModelDecorationOptions {
+		if (this._rangeContainsRTL(range, lineContainsRTLCache)) {
 			return includeOverviewRuler ? FindDecorations._FIND_MATCH_BIDI_DECORATION : FindDecorations._FIND_MATCH_NO_OVERVIEW_BIDI_DECORATION;
 		}
 
@@ -256,10 +258,20 @@ export class FindDecorations implements IDisposable {
 		return this._rangeContainsRTL(range) ? FindDecorations._CURRENT_FIND_MATCH_BIDI_DECORATION : FindDecorations._CURRENT_FIND_MATCH_DECORATION;
 	}
 
-	private _rangeContainsRTL(range: Range): boolean {
+	private _rangeContainsRTL(range: Range, lineContainsRTLCache?: Map<number, boolean>): boolean {
 		const model = this._editor.getModel();
+		if (!model.mightContainRTL()) {
+			return false;
+		}
+
 		for (let lineNumber = range.startLineNumber; lineNumber <= range.endLineNumber; lineNumber++) {
-			if (strings.containsRTL(model.getLineContent(lineNumber))) {
+			let containsRTL = lineContainsRTLCache?.get(lineNumber);
+			if (containsRTL === undefined) {
+				containsRTL = strings.containsRTL(model.getLineContent(lineNumber));
+				lineContainsRTLCache?.set(lineNumber, containsRTL);
+			}
+
+			if (containsRTL) {
 				return true;
 			}
 		}

--- a/src/vs/editor/contrib/find/browser/findDecorations.ts
+++ b/src/vs/editor/contrib/find/browser/findDecorations.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as strings from '../../../../base/common/strings.js';
 import { IDisposable } from '../../../../base/common/lifecycle.js';
 import { IActiveCodeEditor } from '../../../browser/editorBrowser.js';
 import { Position } from '../../../common/core/position.js';
@@ -20,6 +21,7 @@ export class FindDecorations implements IDisposable {
 	private _findScopeDecorationIds: string[];
 	private _rangeHighlightDecorationId: string | null;
 	private _highlightedDecorationId: string | null;
+	private _useFindMatchOverviewRuler: boolean;
 	private _startPosition: Position;
 
 	constructor(editor: IActiveCodeEditor) {
@@ -29,6 +31,7 @@ export class FindDecorations implements IDisposable {
 		this._findScopeDecorationIds = [];
 		this._rangeHighlightDecorationId = null;
 		this._highlightedDecorationId = null;
+		this._useFindMatchOverviewRuler = true;
 		this._startPosition = this._editor.getPosition();
 	}
 
@@ -40,6 +43,7 @@ export class FindDecorations implements IDisposable {
 		this._findScopeDecorationIds = [];
 		this._rangeHighlightDecorationId = null;
 		this._highlightedDecorationId = null;
+		this._useFindMatchOverviewRuler = true;
 	}
 
 	public reset(): void {
@@ -48,6 +52,7 @@ export class FindDecorations implements IDisposable {
 		this._findScopeDecorationIds = [];
 		this._rangeHighlightDecorationId = null;
 		this._highlightedDecorationId = null;
+		this._useFindMatchOverviewRuler = true;
 	}
 
 	public getCount(): number {
@@ -103,7 +108,14 @@ export class FindDecorations implements IDisposable {
 		const candidates = this._editor.getModel().getDecorationsInRange(desiredRange);
 		for (const candidate of candidates) {
 			const candidateOpts = candidate.options;
-			if (candidateOpts === FindDecorations._FIND_MATCH_DECORATION || candidateOpts === FindDecorations._FIND_MATCH_NO_OVERVIEW_DECORATION || candidateOpts === FindDecorations._CURRENT_FIND_MATCH_DECORATION) {
+			if (
+				candidateOpts === FindDecorations._FIND_MATCH_DECORATION
+				|| candidateOpts === FindDecorations._FIND_MATCH_BIDI_DECORATION
+				|| candidateOpts === FindDecorations._FIND_MATCH_NO_OVERVIEW_DECORATION
+				|| candidateOpts === FindDecorations._FIND_MATCH_NO_OVERVIEW_BIDI_DECORATION
+				|| candidateOpts === FindDecorations._CURRENT_FIND_MATCH_DECORATION
+				|| candidateOpts === FindDecorations._CURRENT_FIND_MATCH_BIDI_DECORATION
+			) {
 				return this._getDecorationIndex(candidate.id);
 			}
 		}
@@ -128,12 +140,18 @@ export class FindDecorations implements IDisposable {
 		if (this._highlightedDecorationId !== null || newCurrentDecorationId !== null) {
 			this._editor.changeDecorations((changeAccessor: IModelDecorationsChangeAccessor) => {
 				if (this._highlightedDecorationId !== null) {
-					changeAccessor.changeDecorationOptions(this._highlightedDecorationId, FindDecorations._FIND_MATCH_DECORATION);
+					const highlightedRange = this._editor.getModel().getDecorationRange(this._highlightedDecorationId);
+					if (highlightedRange) {
+						changeAccessor.changeDecorationOptions(this._highlightedDecorationId, this._getFindMatchDecorationOptions(highlightedRange, this._useFindMatchOverviewRuler));
+					}
 					this._highlightedDecorationId = null;
 				}
 				if (newCurrentDecorationId !== null) {
 					this._highlightedDecorationId = newCurrentDecorationId;
-					changeAccessor.changeDecorationOptions(this._highlightedDecorationId, FindDecorations._CURRENT_FIND_MATCH_DECORATION);
+					const newCurrentRange = this._editor.getModel().getDecorationRange(this._highlightedDecorationId);
+					if (newCurrentRange) {
+						changeAccessor.changeDecorationOptions(this._highlightedDecorationId, this._getCurrentFindMatchDecorationOptions(newCurrentRange));
+					}
 				}
 				if (this._rangeHighlightDecorationId !== null) {
 					changeAccessor.removeDecoration(this._rangeHighlightDecorationId);
@@ -157,13 +175,13 @@ export class FindDecorations implements IDisposable {
 	public set(findMatches: FindMatch[], findScopes: Range[] | null): void {
 		this._editor.changeDecorations((accessor) => {
 
-			let findMatchesOptions: ModelDecorationOptions = FindDecorations._FIND_MATCH_DECORATION;
+			this._useFindMatchOverviewRuler = true;
 			const newOverviewRulerApproximateDecorations: IModelDeltaDecoration[] = [];
 
 			if (findMatches.length > 1000) {
 				// we go into a mode where the overview ruler gets "approximate" decorations
 				// the reason is that the overview ruler paints all the decorations in the file and we don't want to cause freezes
-				findMatchesOptions = FindDecorations._FIND_MATCH_NO_OVERVIEW_DECORATION;
+				this._useFindMatchOverviewRuler = false;
 
 				// approximate a distance in lines where matches should be merged
 				const lineCount = this._editor.getModel().getLineCount();
@@ -201,7 +219,7 @@ export class FindDecorations implements IDisposable {
 			for (let i = 0, len = findMatches.length; i < len; i++) {
 				newFindMatchesDecorations[i] = {
 					range: findMatches[i].range,
-					options: findMatchesOptions
+					options: this._getFindMatchDecorationOptions(findMatches[i].range, this._useFindMatchOverviewRuler)
 				};
 			}
 			this._decorations = accessor.deltaDecorations(this._decorations, newFindMatchesDecorations);
@@ -224,6 +242,29 @@ export class FindDecorations implements IDisposable {
 				this._findScopeDecorationIds = findScopes.map(findScope => accessor.addDecoration(findScope, FindDecorations._FIND_SCOPE_DECORATION));
 			}
 		});
+	}
+
+	private _getFindMatchDecorationOptions(range: Range, includeOverviewRuler: boolean): ModelDecorationOptions {
+		if (this._rangeContainsRTL(range)) {
+			return includeOverviewRuler ? FindDecorations._FIND_MATCH_BIDI_DECORATION : FindDecorations._FIND_MATCH_NO_OVERVIEW_BIDI_DECORATION;
+		}
+
+		return includeOverviewRuler ? FindDecorations._FIND_MATCH_DECORATION : FindDecorations._FIND_MATCH_NO_OVERVIEW_DECORATION;
+	}
+
+	private _getCurrentFindMatchDecorationOptions(range: Range): ModelDecorationOptions {
+		return this._rangeContainsRTL(range) ? FindDecorations._CURRENT_FIND_MATCH_BIDI_DECORATION : FindDecorations._CURRENT_FIND_MATCH_DECORATION;
+	}
+
+	private _rangeContainsRTL(range: Range): boolean {
+		const model = this._editor.getModel();
+		for (let lineNumber = range.startLineNumber; lineNumber <= range.endLineNumber; lineNumber++) {
+			if (strings.containsRTL(model.getLineContent(lineNumber))) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	public matchBeforePosition(position: Position): Range | null {
@@ -300,6 +341,22 @@ export class FindDecorations implements IDisposable {
 		}
 	});
 
+	public static readonly _CURRENT_FIND_MATCH_BIDI_DECORATION = ModelDecorationOptions.register({
+		description: 'current-find-match-bidi',
+		stickiness: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
+		zIndex: 13,
+		className: 'currentFindMatch',
+		showIfCollapsed: true,
+		overviewRuler: {
+			color: themeColorFromId(overviewRulerFindMatchForeground),
+			position: OverviewRulerLane.Center
+		},
+		minimap: {
+			color: themeColorFromId(minimapFindMatch),
+			position: MinimapPosition.Inline
+		}
+	});
+
 	public static readonly _FIND_MATCH_DECORATION = ModelDecorationOptions.register({
 		description: 'find-match',
 		stickiness: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
@@ -317,8 +374,31 @@ export class FindDecorations implements IDisposable {
 		}
 	});
 
+	public static readonly _FIND_MATCH_BIDI_DECORATION = ModelDecorationOptions.register({
+		description: 'find-match-bidi',
+		stickiness: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
+		zIndex: 10,
+		className: 'findMatch',
+		showIfCollapsed: true,
+		overviewRuler: {
+			color: themeColorFromId(overviewRulerFindMatchForeground),
+			position: OverviewRulerLane.Center
+		},
+		minimap: {
+			color: themeColorFromId(minimapFindMatch),
+			position: MinimapPosition.Inline
+		}
+	});
+
 	public static readonly _FIND_MATCH_NO_OVERVIEW_DECORATION = ModelDecorationOptions.register({
 		description: 'find-match-no-overview',
+		stickiness: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
+		className: 'findMatch',
+		showIfCollapsed: true
+	});
+
+	public static readonly _FIND_MATCH_NO_OVERVIEW_BIDI_DECORATION = ModelDecorationOptions.register({
+		description: 'find-match-no-overview-bidi',
 		stickiness: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
 		className: 'findMatch',
 		showIfCollapsed: true

--- a/src/vs/editor/contrib/find/test/browser/findModel.test.ts
+++ b/src/vs/editor/contrib/find/test/browser/findModel.test.ts
@@ -279,6 +279,30 @@ suite('FindModel', () => {
 		);
 	});
 
+	test('find decorations avoid inline styling on lines containing RTL text', () => {
+		withTestCodeEditor([
+			'const title = "بنی Adam بکد گر"',
+			'const subtitle = "Adam only"'
+		], {}, (editor) => {
+			editor.setPosition({ lineNumber: 1, column: 1 });
+			const findState = disposables.add(new FindReplaceState());
+			disposables.add(new FindModelBoundToEditorModel(editor as IActiveCodeEditor, findState));
+
+			findState.change({ searchString: 'Adam' }, true);
+
+			const decorations = editor.getModel()!.getAllDecorations().filter(decoration => decoration.options.className === 'currentFindMatch' || decoration.options.className === 'findMatch');
+			assert.strictEqual(decorations.length, 2);
+
+			const mixedLineDecoration = decorations.find(decoration => decoration.range.startLineNumber === 1);
+			assert.ok(mixedLineDecoration);
+			assert.strictEqual(mixedLineDecoration.options.inlineClassName, undefined);
+
+			const ltrLineDecoration = decorations.find(decoration => decoration.range.startLineNumber === 2);
+			assert.ok(ltrLineDecoration);
+			assert.strictEqual(ltrLineDecoration.options.inlineClassName, 'findMatchInline');
+		});
+	});
+
 	findTest('find model updates state matchesCount', (editor) => {
 		const findState = disposables.add(new FindReplaceState());
 		findState.change({ searchString: 'hello' }, false);

--- a/src/vs/editor/contrib/find/test/browser/findModel.test.ts
+++ b/src/vs/editor/contrib/find/test/browser/findModel.test.ts
@@ -295,7 +295,7 @@ suite('FindModel', () => {
 
 			const mixedLineDecoration = decorations.find(decoration => decoration.range.startLineNumber === 1);
 			assert.ok(mixedLineDecoration);
-			assert.strictEqual(mixedLineDecoration.options.inlineClassName, undefined);
+			assert.strictEqual(mixedLineDecoration.options.inlineClassName, null);
 
 			const ltrLineDecoration = decorations.find(decoration => decoration.range.startLineNumber === 2);
 			assert.ok(ltrLineDecoration);


### PR DESCRIPTION
## Summary

Fixes incorrect visual ordering when Find highlights matches inside mixed LTR/RTL text.

In lines containing RTL text, Find no longer applies inline styling that splits the rendered content into multiple bidi runs. Instead, it uses decorations that preserve the correct visual ordering of highlighted text.

Fixes #233573.

## Problem

When Find highlights a match inside a line containing mixed LTR and RTL text, the highlight can split the rendered content into multiple inline segments.

In some cases, this changes the visual ordering of the RTL portion of the line, causing highlighted matches to appear with characters in the wrong order even though the underlying text is correct.

## Root Cause

Find match decorations relied on inline text styling.

While this works correctly for normal LTR text, applying inline styling inside mixed bidi content can split a visual bidi run into separate segments. Once split, browser bidi layout may reorder the segments visually, making the highlighted substring appear incorrect.

## Fix

This change makes Find match decorations aware of RTL content.

- Lines containing RTL text now use decorations that avoid inline text styling.
- LTR-only lines continue using the existing rendering behavior.
- Current match and regular match decorations now share the same RTL-aware decoration selection logic.

This preserves Find highlighting while avoiding the bidi run splitting that caused incorrect visual ordering.

## Screenshots

### Original Text

<img width="623" height="144" alt="Screenshot From 2026-05-07 02-05-35" src="https://github.com/user-attachments/assets/5ad809c5-f59a-4436-9f3f-67cb5bc2c30c" />

### Before

<img width="623" height="144" alt="Screenshot From 2026-05-07 02-11-49" src="https://github.com/user-attachments/assets/38f47687-9f60-4827-b1ae-13ff4f023819" />

### After

<img width="623" height="144" alt="Screenshot From 2026-05-07 02-13-07" src="https://github.com/user-attachments/assets/b14dd2f1-556d-4ccc-904c-b7e700ba188d" />

## How to Test

1. Open a file containing mixed LTR/RTL text on the same line.
2. Search for a substring inside the RTL portion of the line.
3. Verify that the highlighted match preserves the correct visual character order.
4. Repeat the same test on an LTR-only line and verify that Find highlighting still behaves normally.