### PR TITLE
Agents web: auto-detect OS color scheme by default

### DIFF
--- a/src/vs/workbench/services/themes/common/themeConfiguration.ts
+++ b/src/vs/workbench/services/themes/common/themeConfiguration.ts
@@ -85,6 +85,7 @@ const detectColorSchemeSettingSchema: IConfigurationPropertySchema = {
 	type: 'boolean',
 	markdownDescription: nls.localize({ key: 'detectColorScheme', comment: ['{0} and {1} will become links to other settings.'] }, 'If enabled, will automatically select a color theme based on the system color mode. If the system color mode is dark, {0} is used, else {1}.', formatSettingAsLink(ThemeSettings.PREFERRED_DARK_THEME), formatSettingAsLink(ThemeSettings.PREFERRED_LIGHT_THEME)),
 	default: false,
+	...(isWeb ? { agentsWindow: { default: true } } : {}),
 	tags: [COLOR_THEME_CONFIGURATION_SETTINGS_TAG],
 };
 


### PR DESCRIPTION
## What

For the **agents window on web** (vscode.dev/agents) only, default `window.autoDetectColorScheme` to `true` so the workbench picks Dark 2026 / Light 2026 based on the user's `prefers-color-scheme` media query instead of always loading Light 2026.

## Why

After #314551 removed the welcome theme picker, vscode.dev/agents had no path to set a theme during onboarding, so users always landed on the web default theme (`Light 2026` — see `themeConfiguration.ts` line 37).

`BrowserHostColorSchemeService` is already registered in `sessions.web.main.ts` and the auto-detect machinery already exists, so flipping the default for the agents web target is the minimal change to get OS-aware theming back.

## How

`agentsWindow.default` overrides are only consumed by the sessions `ConfigurationService` (`SessionsDefaultConfiguration.getDefaultValue` in `src/vs/sessions/services/configuration/browser/configurationService.ts`), so this affects only the agents window. The override is gated on `isWeb` so the desktop agents window and regular VS Code keep their existing defaults.

| Surface | `window.autoDetectColorScheme` default |
|---|---|
| Regular VS Code (desktop & web) | `false` (unchanged) |
| Agents window — desktop | `false` (unchanged) |
| Agents window — web | **`true`** (auto-detects) |

Users can still override via settings; this only changes the default, not `readOnly`.

## Test plan

- [ ] vscode.dev/agents with OS in dark mode → loads Dark 2026
- [ ] vscode.dev/agents with OS in light mode → loads Light 2026
- [ ] OS color-scheme toggle live-switches the theme
- [ ] Regular VS Code (web and desktop) still defaults to `false` (no auto-switching unless user opts in)
- [ ] Desktop agents window still defaults to `false`
