### PR TITLE
chat: seed row height in renderElement to break ResizeObserver loop

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -657,10 +657,13 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 				return;
 			}
 			const blockSize = entry.borderBoxSize.at(0)?.blockSize;
-			if (typeof blockSize !== 'number') {
-				return;
+			// Track the latest measured size so we can coalesce bursts. If
+			// blockSize is unavailable in the current environment we still
+			// schedule a dispatch so `fireItemHeightChange` falls back to
+			// `getBoundingClientRect()` (preserving prior behavior).
+			if (typeof blockSize === 'number') {
+				pendingBlockSize = blockSize;
 			}
-			pendingBlockSize = blockSize;
 			if (pendingDispatchHandle !== undefined) {
 				return;
 			}
@@ -668,9 +671,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 				pendingDispatchHandle = undefined;
 				const size = pendingBlockSize;
 				pendingBlockSize = undefined;
-				if (size !== undefined) {
-					this.fireItemHeightChange(template, size);
-				}
+				this.fireItemHeightChange(template, size);
 			}, 0);
 		}));
 		templateDisposables.add(resizeObserver.observe(rowContainer));

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -636,43 +636,11 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			}
 		}));
 
-		// Chat rows can drive a `ResizeObserver loop completed with undelivered
-		// notifications` warning because dispatching a height change re-enters
-		// layout synchronously inside the observer callback, which causes the
-		// observer to fire again in the same animation frame. Defer the
-		// dispatch onto the next task with setTimeout(0) so the observer
-		// callback returns cleanly before the layout mutation runs. Coalesce
-		// repeated observations into a single dispatch using the latest size.
-		let pendingBlockSize: number | undefined;
-		let pendingDispatchHandle: ReturnType<typeof setTimeout> | undefined;
-		templateDisposables.add(toDisposable(() => {
-			if (pendingDispatchHandle !== undefined) {
-				clearTimeout(pendingDispatchHandle);
-				pendingDispatchHandle = undefined;
-			}
-		}));
 		const resizeObserver = templateDisposables.add(new dom.DisposableResizeObserver('ChatListItemRenderer.itemHeight', (entries) => {
 			const entry = entries[0];
-			if (!entry) {
-				return;
+			if (entry) {
+				this.fireItemHeightChange(template, entry.borderBoxSize.at(0)?.blockSize);
 			}
-			const blockSize = entry.borderBoxSize.at(0)?.blockSize;
-			// Track the latest measured size so we can coalesce bursts. If
-			// blockSize is unavailable in the current environment we still
-			// schedule a dispatch so `fireItemHeightChange` falls back to
-			// `getBoundingClientRect()` (preserving prior behavior).
-			if (typeof blockSize === 'number') {
-				pendingBlockSize = blockSize;
-			}
-			if (pendingDispatchHandle !== undefined) {
-				return;
-			}
-			pendingDispatchHandle = setTimeout(() => {
-				pendingDispatchHandle = undefined;
-				const size = pendingBlockSize;
-				pendingBlockSize = undefined;
-				this.fireItemHeightChange(template, size);
-			}, 0);
 		}));
 		templateDisposables.add(resizeObserver.observe(rowContainer));
 
@@ -683,6 +651,16 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		this._elementBeingRendered = node.element;
 		try {
 			this.renderChatTreeItem(node.element, index, templateData);
+
+			// Seed `currentRenderedHeight` from the row's mounted box now, while
+			// `_elementBeingRendered` is still set so `fireItemHeightChange`
+			// won't dispatch (it can't safely re-enter the in-flight tree splice).
+			// The ResizeObserver's first post-mount delivery will then hit the
+			// same-height guard and return without firing, avoiding
+			// `ResizeObserver loop completed with undelivered notifications`
+			// caused by the downstream `updateLastItemMinHeight` chain resizing
+			// a sibling row inside the observer callback.
+			this.fireItemHeightChange(templateData);
 		} finally {
 			this._elementBeingRendered = undefined;
 		}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -636,11 +636,42 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			}
 		}));
 
+		// Chat rows can drive a `ResizeObserver loop completed with undelivered
+		// notifications` warning because dispatching a height change re-enters
+		// layout synchronously inside the observer callback, which causes the
+		// observer to fire again in the same animation frame. Defer the
+		// dispatch onto the next task with setTimeout(0) so the observer
+		// callback returns cleanly before the layout mutation runs. Coalesce
+		// repeated observations into a single dispatch using the latest size.
+		let pendingBlockSize: number | undefined;
+		let pendingDispatchHandle: ReturnType<typeof setTimeout> | undefined;
+		templateDisposables.add(toDisposable(() => {
+			if (pendingDispatchHandle !== undefined) {
+				clearTimeout(pendingDispatchHandle);
+				pendingDispatchHandle = undefined;
+			}
+		}));
 		const resizeObserver = templateDisposables.add(new dom.DisposableResizeObserver('ChatListItemRenderer.itemHeight', (entries) => {
 			const entry = entries[0];
-			if (entry) {
-				this.fireItemHeightChange(template, entry.borderBoxSize.at(0)?.blockSize);
+			if (!entry) {
+				return;
 			}
+			const blockSize = entry.borderBoxSize.at(0)?.blockSize;
+			if (typeof blockSize !== 'number') {
+				return;
+			}
+			pendingBlockSize = blockSize;
+			if (pendingDispatchHandle !== undefined) {
+				return;
+			}
+			pendingDispatchHandle = setTimeout(() => {
+				pendingDispatchHandle = undefined;
+				const size = pendingBlockSize;
+				pendingBlockSize = undefined;
+				if (size !== undefined) {
+					this.fireItemHeightChange(template, size);
+				}
+			}, 0);
 		}));
 		templateDisposables.add(resizeObserver.observe(rowContainer));
 


### PR DESCRIPTION
The chat row `ResizeObserver` callback in `ChatListItemRenderer` dispatched `fireItemHeightChange` synchronously. The downstream `updateLastItemMinHeight` chain writes a CSS variable that resizes a sibling row, and Chromium's RO algorithm can't redeliver same-depth resize entries inside the in-flight observation phase — so the synthetic `ResizeObserver loop completed with undelivered notifications` warning fires.

Telemetry attribution shipped in #314411 confirms this row observer (named `ChatListItemRenderer.itemHeight`) is the dominant source of the loop warning across our error stream.

### Fix

Seed `currentRenderedHeight` synchronously at the end of `renderElement`, while `_elementBeingRendered` is still set. The existing dispatch guard in `fireItemHeightChange` (`template.currentElement !== this._elementBeingRendered`) suppresses the event fire — so the call records the row's actual mounted box size without re-entering the in-flight tree splice.

The ResizeObserver's first post-mount delivery then sees the same blockSize and hits the same-height short-circuit in `fireItemHeightChange`, returning without any layout-mutating work. The loop warning goes away, and `currentRenderedHeight` reflects the real measured height (rather than the 150-px estimate the original `setTimeout(0)` deferral left behind).

### Validation

- Reproduced via streaming chat responses against a long thread, captured the warning over CDP using a Playwright harness.
- Before: `ResizeObserver loop completed with undelivered notifications` fires on each new request row mount and during streaming.
- After: warning no longer fires; row heights still update during streaming with no perceptible lag.

### Notes

- This replaces the earlier `setTimeout(0)` + coalescing approach. That worked but had two downsides Rob flagged: it deferred the height update onto a macrotask (visible bounce), and it discarded the real first-mount measurement so `currentRenderedHeight` stayed pegged to the estimate.
- The seed call is one extra synchronous read of `borderBoxSize` per row mount. The RO callback itself is unchanged from `main`.
