### PR TITLE
sessions: align sub-session tip content

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/media/newChatInSession.css
+++ b/src/vs/sessions/contrib/chat/browser/media/newChatInSession.css
@@ -129,7 +129,7 @@
 
 .new-chat-in-session .sub-session-tip-widget {
 	display: flex;
-	align-items: center;
+	align-items: flex-start;
 	gap: 6px;
 	width: 100%;
 	max-width: 100%;
@@ -147,6 +147,7 @@
 .new-chat-in-session .sub-session-tip-icon {
 	flex-shrink: 0;
 	color: var(--vscode-descriptionForeground);
+	transform: translateY(2px);
 }
 
 .new-chat-in-session .sub-session-tip-text {


### PR DESCRIPTION
Fixes #314247.

## What Changed
- top-align the sub-session tip banner content when the tip text wraps
- nudge the lightbulb icon down 2px for better optical alignment with the first line of text

## Why
The previous centered layout made the icon and dismiss button sit too low next to multi-line tip text. This keeps the row visually aligned with the proposed issue layout.