### PR TITLE
fix: restore word wrap after diff editor inline to split-view transition

### DIFF
--- a/src/vs/editor/browser/widget/diffEditor/components/diffEditorEditors.ts
+++ b/src/vs/editor/browser/widget/diffEditor/components/diffEditorEditors.ts
@@ -148,7 +148,9 @@ export class DiffEditorEditors extends Disposable {
 		} else {
 			result.unicodeHighlight = this._options.editorOptions.get().unicodeHighlight || {};
 			result.wordWrapOverride1 = this._options.diffWordWrap.get();
-			result.wordWrapOverride2 = 'inherit';
+			result.wordWrapOverride2 =
+				this._options.editorOptions.get().wordWrapOverride2
+				?? EditorOptions.wordWrapOverride2.defaultValue;
 		}
 		result.glyphMargin = this._options.renderSideBySide.get();
 
@@ -169,7 +171,9 @@ export class DiffEditorEditors extends Disposable {
 		}
 		result.ariaLabel = this._updateAriaLabel(result.ariaLabel);
 		result.wordWrapOverride1 = this._options.diffWordWrap.get();
-		result.wordWrapOverride2 = 'inherit';
+		result.wordWrapOverride2 =
+			this._options.editorOptions.get().wordWrapOverride2
+			?? EditorOptions.wordWrapOverride2.defaultValue;
 		result.revealHorizontalRightPadding = EditorOptions.revealHorizontalRightPadding.defaultValue + OverviewRulerFeature.ENTIRE_DIFF_OVERVIEW_WIDTH;
 		result.scrollbar!.verticalHasArrows = false;
 		result.extraEditorClassName = 'modified-in-monaco-diff-editor';

--- a/src/vs/editor/browser/widget/diffEditor/components/diffEditorEditors.ts
+++ b/src/vs/editor/browser/widget/diffEditor/components/diffEditorEditors.ts
@@ -148,6 +148,7 @@ export class DiffEditorEditors extends Disposable {
 		} else {
 			result.unicodeHighlight = this._options.editorOptions.get().unicodeHighlight || {};
 			result.wordWrapOverride1 = this._options.diffWordWrap.get();
+			result.wordWrapOverride2 = 'inherit';
 		}
 		result.glyphMargin = this._options.renderSideBySide.get();
 
@@ -168,6 +169,7 @@ export class DiffEditorEditors extends Disposable {
 		}
 		result.ariaLabel = this._updateAriaLabel(result.ariaLabel);
 		result.wordWrapOverride1 = this._options.diffWordWrap.get();
+		result.wordWrapOverride2 = 'inherit';
 		result.revealHorizontalRightPadding = EditorOptions.revealHorizontalRightPadding.defaultValue + OverviewRulerFeature.ENTIRE_DIFF_OVERVIEW_WIDTH;
 		result.scrollbar!.verticalHasArrows = false;
 		result.extraEditorClassName = 'modified-in-monaco-diff-editor';


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes #314898

# Summary
Fixes diff editor word wrap when resizing from inline to side-by-side mode by clearing the stale wordWrapOverride2 override so `diffEditor.wordWrap` is honored.

