### PR TITLE
sessions: fix duplicate session in list when new session is opened while another is active

### DIFF
--- a/src/vs/sessions/contrib/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -1401,12 +1401,18 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 				if (this._newSession === newSession) {
 					this._newSession = undefined;
 				}
+				// Clear the pending session before firing the replace event so
+				// that any synchronous listener calling getSessions() sees only
+				// the committed session and not both.
+				this._pendingSession = undefined;
 				this._onDidReplaceSession.fire({ from: skeleton, to: committedSession });
 				return committedSession;
 			}
 		} catch {
 			// Connection lost or timeout — fall through to the failure cleanup.
 		} finally {
+			// Defensive clear: covers the failure path where the try block
+			// never reached the explicit clear above.
 			this._pendingSession = undefined;
 		}
 

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -127,12 +127,15 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 	private onDidReplaceSession(from: ISession, to: ISession): void {
 		if (this._activeSession.get()?.sessionId === from.sessionId) {
 			this.setActiveSession(to);
-			this._onDidChangeSessions.fire({
-				added: [],
-				removed: from.sessionId === to.sessionId ? [] : [from],
-				changed: [to],
-			});
 		}
+		// Always fire the change event so the SessionsList refreshes even when
+		// the user navigated to a different session while the new one was
+		// being created (which is how duplicate rows appeared in the list).
+		this._onDidChangeSessions.fire({
+			added: [],
+			removed: from.sessionId === to.sessionId ? [] : [from],
+			changed: [to],
+		});
 	}
 
 	private onDidChangeSessionsFromSessionsProviders(e: ISessionChangeEvent): void {


### PR DESCRIPTION
## Problem

After creating a new CLI session (which starts running), opening another session causes the new session to appear **twice** in the sessions list.

**Steps to reproduce:**
1. Create a new CLI session
2. After it starts running, open another session
3. Look at the session list — there are two identical entries for the new session

## Root Cause

Two interacting bugs:

### Bug 1 — `baseAgentHostSessionsProvider.ts`: Race between `SessionAdded` and `_pendingSession`

`sendAndCreateChat` awaits `chatService.sendRequest(...)`. During that await the agent host materializes the session and fires `SessionAdded`, which runs `_handleSessionAdded` → inserts the committed session into `_sessionCache` → fires `_onDidChangeSessions { added: [committed] }`.

**After** the await returns, the code sets `_pendingSession = skeleton` and fires another `_onDidChangeSessions { added: [skeleton] }`.

From that point until the `finally` block runs, `getSessions()` returns `[...sessionCache.values(), _pendingSession]` — **two objects with the same session ID**. Any `getSessions()` call during that window sees the duplicate.

The `finally` block clears `_pendingSession` **after** `_onDidReplaceSession.fire(...)`, so any synchronous listener (e.g. `SessionsManagementService`) that calls `getSessions()` while handling the replace event still sees both.

### Bug 2 — `sessionsManagementService.ts`: Replace event not forwarded when active session differs

`SessionsManagementService.onDidReplaceSession` only forwarded a `_onDidChangeSessions` event **when the active session was the `from` session**. If the user navigated to a different session while the new one was being created, no refresh event fired → `SessionsList` never re-pulled `getSessions()` → the duplicate row stayed indefinitely.

## Fix

**`baseAgentHostSessionsProvider.ts`** — Clear `_pendingSession` *before* firing `_onDidReplaceSession` so any synchronous listener calling `getSessions()` sees only the committed session. The `finally` block still clears it as a defensive fallback for the failure path.

**`sessionsManagementService.ts`** — Always fire `_onDidChangeSessions` in `onDidReplaceSession` regardless of which session is active. Only the active-session *reassignment* (`setActiveSession`) remains conditional on matching the `from` session.