### PR TITLE
Honor BYOK editTools configuration in chat model picker

### DIFF
--- a/extensions/copilot/src/extension/byok/common/byokProvider.ts
+++ b/extensions/copilot/src/extension/byok/common/byokProvider.ts
@@ -154,7 +154,8 @@ export function byokKnownModelToAPIInfo(providerName: string, id: string, capabi
 		isUserSelectable: true,
 		capabilities: {
 			toolCalling: capabilities.toolCalling,
-			imageInput: capabilities.vision
+			imageInput: capabilities.vision,
+			editTools: capabilities.editTools,
 		},
 	};
 }

--- a/extensions/copilot/src/extension/byok/common/test/byokProvider.spec.ts
+++ b/extensions/copilot/src/extension/byok/common/test/byokProvider.spec.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it } from 'vitest';
+import { byokKnownModelToAPIInfo, BYOKModelCapabilities } from '../byokProvider';
+
+describe('byokKnownModelToAPIInfo', () => {
+	const baseCapabilities: BYOKModelCapabilities = {
+		name: 'TestModel',
+		maxInputTokens: 1000,
+		maxOutputTokens: 100,
+		toolCalling: true,
+		vision: false,
+	};
+
+	it('forwards editTools into capabilities so VS Code core can populate editToolsHint', () => {
+		const info = byokKnownModelToAPIInfo('TestProvider', 'm1', {
+			...baseCapabilities,
+			editTools: ['apply-patch'],
+		});
+
+		expect(info.capabilities).toMatchObject({
+			toolCalling: true,
+			imageInput: false,
+			editTools: ['apply-patch'],
+		});
+	});
+
+	it('forwards a restricted list of editTools verbatim', () => {
+		const info = byokKnownModelToAPIInfo('TestProvider', 'm1', {
+			...baseCapabilities,
+			editTools: ['find-replace', 'multi-find-replace'],
+		});
+
+		expect(info.capabilities.editTools).toEqual(['find-replace', 'multi-find-replace']);
+	});
+
+	it('omits editTools when not configured', () => {
+		const info = byokKnownModelToAPIInfo('TestProvider', 'm1', baseCapabilities);
+
+		expect(info.capabilities.editTools).toBeUndefined();
+	});
+});

--- a/extensions/copilot/src/extension/tools/node/test/editToolLearningService.spec.ts
+++ b/extensions/copilot/src/extension/tools/node/test/editToolLearningService.spec.ts
@@ -35,7 +35,7 @@ describe('EditToolLearningService', () => {
 	});
 
 	// Helper to create mock endpoint
-	const createMockEndpoint = (isExtensionContributed: boolean, family = 'test-family', model: LanguageModelChat): IChatEndpoint => ({
+	const createMockEndpoint = (isExtensionContributed: boolean, family = 'test-family', model: LanguageModelChat, supportedEditTools?: readonly string[]): IChatEndpoint => ({
 		family,
 		model: model.id,
 		maxOutputTokens: 1000,
@@ -52,6 +52,7 @@ describe('EditToolLearningService', () => {
 		name: model.id,
 		version: '1.0',
 		tokenizer: 'gpt',
+		supportedEditTools,
 		acceptChatPolicy: vi.fn().mockResolvedValue(true),
 		processResponseFromChatEndpoint: vi.fn(),
 		acquireTokenizer: vi.fn(),
@@ -134,6 +135,40 @@ describe('EditToolLearningService', () => {
 			const result = await service.getPreferredEditTool(model);
 
 			expect(result).toEqual([ToolName.EditFile, ToolName.ReplaceString]);
+		});
+
+		it('should honor BYOK editTools (apply-patch) for an unknown family', async () => {
+			const model = createMockModel('byok-edittools-repro');
+			vi.mocked(mockEndpointProvider.getChatEndpoint).mockResolvedValue(
+				createMockEndpoint(true, 'byok-family', model, ['apply-patch'])
+			);
+
+			const result = await service.getPreferredEditTool(model);
+
+			expect(result).toEqual([ToolName.ApplyPatch]);
+		});
+
+		it('should honor a restricted BYOK editTools list (find-replace + multi-find-replace)', async () => {
+			const model = createMockModel('byok-find-replace');
+			vi.mocked(mockEndpointProvider.getChatEndpoint).mockResolvedValue(
+				createMockEndpoint(true, 'byok-family', model, ['find-replace', 'multi-find-replace'])
+			);
+
+			const result = await service.getPreferredEditTool(model);
+
+			expect(result).toEqual([ToolName.ReplaceString, ToolName.MultiReplaceString]);
+		});
+
+		it('should honor BYOK editTools over hardcoded family preference', async () => {
+			// Model name would otherwise trigger the hardcoded gpt -> ApplyPatch preference.
+			const model = createMockModel('gpt-byok');
+			vi.mocked(mockEndpointProvider.getChatEndpoint).mockResolvedValue(
+				createMockEndpoint(true, 'gpt', model, ['code-rewrite'])
+			);
+
+			const result = await service.getPreferredEditTool(model);
+
+			expect(result).toEqual([ToolName.EditFile]);
 		});
 	});
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/297178

The editTools field in BYOK model configuration (e.g. editTools: ['apply-patch']) was accepted by the schema but had no effect on which edit tools the chat agent exposed to the model.