### PR TITLE
agent-host: log subscribe + state replay in IPC output channel

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/loggingAgentConnection.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/loggingAgentConnection.ts
@@ -104,6 +104,14 @@ export class LoggingAgentConnection extends Disposable implements IAgentConnecti
 	 * terminal); we only want each event to appear once in the channel.
 	 */
 	private static readonly _sharedEventLog = new Map<string, IDisposable>();
+	/**
+	 * Per-inner-subscription log refcount. The inner connection refcounts
+	 * subscriptions internally (multiple `getSubscription` calls for the same
+	 * resource share an `IAgentSubscription` instance), so we attach a single
+	 * onDidChange logger per inner subscription and dispose it when the last
+	 * wrapper goes away.
+	 */
+	private static readonly _subscriptionLoggers = new WeakMap<IAgentSubscription<unknown>, { refCount: number; store: DisposableStore }>();
 
 	private _outputChannel: IOutputChannel | undefined;
 	private readonly _enabled: boolean;
@@ -213,7 +221,44 @@ export class LoggingAgentConnection extends Disposable implements IAgentConnecti
 	}
 
 	getSubscription<T extends StateComponents>(kind: T, resource: URI): IReference<IAgentSubscription<ComponentToState[T]>> {
-		return this._inner.getSubscription(kind, resource);
+		const innerRef = this._inner.getSubscription(kind, resource);
+		if (!this._enabled) {
+			return innerRef;
+		}
+		this._log('>>', 'subscribe', { kind, resource });
+		const sub = innerRef.object;
+		let entry = LoggingAgentConnection._subscriptionLoggers.get(sub);
+		if (!entry) {
+			const store = new DisposableStore();
+			const label = `${kind}(${resource.toString()})`;
+			if (sub.value !== undefined) {
+				this._log('**', `${label}.current`, sub.value);
+			}
+			store.add(sub.onDidChange(value => this._log('**', `${label}.onDidChange`, value)));
+			entry = { refCount: 0, store };
+			LoggingAgentConnection._subscriptionLoggers.set(sub, entry);
+		}
+		entry.refCount++;
+		let disposed = false;
+		return {
+			object: sub,
+			dispose: () => {
+				if (disposed) {
+					return;
+				}
+				disposed = true;
+				this._log('>>', 'unsubscribe', { kind, resource });
+				const e = LoggingAgentConnection._subscriptionLoggers.get(sub);
+				if (e) {
+					e.refCount--;
+					if (e.refCount <= 0) {
+						e.store.dispose();
+						LoggingAgentConnection._subscriptionLoggers.delete(sub);
+					}
+				}
+				innerRef.dispose();
+			},
+		};
 	}
 
 	getSubscriptionUnmanaged<T extends StateComponents>(kind: T, resource: URI): IAgentSubscription<ComponentToState[T]> | undefined {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/loggingAgentConnection.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/loggingAgentConnection.ts
@@ -111,7 +111,13 @@ export class LoggingAgentConnection extends Disposable implements IAgentConnecti
 	 * onDidChange logger per inner subscription and dispose it when the last
 	 * wrapper goes away.
 	 */
-	private static readonly _subscriptionLoggers = new WeakMap<IAgentSubscription<unknown>, { refCount: number; store: DisposableStore }>();
+	private static readonly _subscriptionLoggers = new WeakMap<object, { refCount: number; store: DisposableStore }>();
+
+	private static readonly _kindNames: Record<StateComponents, string> = {
+		[StateComponents.Root]: 'root',
+		[StateComponents.Session]: 'session',
+		[StateComponents.Terminal]: 'terminal',
+	};
 
 	private _outputChannel: IOutputChannel | undefined;
 	private readonly _enabled: boolean;
@@ -225,12 +231,13 @@ export class LoggingAgentConnection extends Disposable implements IAgentConnecti
 		if (!this._enabled) {
 			return innerRef;
 		}
-		this._log('>>', 'subscribe', { kind, resource });
+		const kindName = LoggingAgentConnection._kindNames[kind];
+		this._log('>>', 'subscribe', { kind: kindName, resource });
 		const sub = innerRef.object;
 		let entry = LoggingAgentConnection._subscriptionLoggers.get(sub);
 		if (!entry) {
 			const store = new DisposableStore();
-			const label = `${kind}(${resource.toString()})`;
+			const label = `${kindName}(${resource.toString()})`;
 			if (sub.value !== undefined) {
 				this._log('**', `${label}.current`, sub.value);
 			}
@@ -247,7 +254,7 @@ export class LoggingAgentConnection extends Disposable implements IAgentConnecti
 					return;
 				}
 				disposed = true;
-				this._log('>>', 'unsubscribe', { kind, resource });
+				this._log('>>', 'unsubscribe', { kind: kindName, resource });
 				const e = LoggingAgentConnection._subscriptionLoggers.get(sub);
 				if (e) {
 					e.refCount--;


### PR DESCRIPTION
The `LoggingAgentConnection` wrapper was passing `getSubscription` through unwrapped, so neither the subscribe call nor the snapshot/state replay the server sends back surfaced in the per-host output channel. When opening a session, the channel showed nothing for the subscription handshake.

Wrap the returned subscription with a logger that emits:
- `>> subscribe { kind, resource }` when `getSubscription` is called
- `** <kind>(<resource>).current` if the inner sub is already hydrated
- `** <kind>(<resource>).onDidChange` on each value change (this is what surfaces the server snapshot / state replay)
- `>> unsubscribe { kind, resource }` on ref dispose

Refcount the logger per inner `IAgentSubscription` instance via a static `WeakMap` so multiple wrappers (e.g. chat + terminal) sharing the same underlying sub still only log once, and the listener is torn down with the last ref.

No-op when `agentHost.ipcLogging` is disabled.
