### PR TITLE
Switch back to using parcel's watcher for esbuild

### DIFF
--- a/extensions/esbuild-common.mts
+++ b/extensions/esbuild-common.mts
@@ -1,0 +1,80 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import path from 'node:path';
+import esbuild from 'esbuild';
+
+export interface RunConfig {
+	readonly srcDir: string;
+	readonly outdir: string;
+	readonly entryPoints: esbuild.BuildOptions['entryPoints'];
+	readonly additionalOptions?: Partial<esbuild.BuildOptions>;
+}
+
+/**
+ * Shared build/watch runner for extension esbuild scripts.
+ */
+export async function runBuild(
+	config: RunConfig,
+	baseOptions: esbuild.BuildOptions,
+	args: string[],
+	didBuild?: (outDir: string) => unknown,
+): Promise<void> {
+	let outdir = config.outdir;
+	const outputRootIndex = args.indexOf('--outputRoot');
+	if (outputRootIndex >= 0) {
+		const outputRoot = args[outputRootIndex + 1];
+		const outputDirName = path.basename(outdir);
+		outdir = path.join(outputRoot, outputDirName);
+	}
+
+	const resolvedOptions: esbuild.BuildOptions = {
+		...baseOptions,
+		entryPoints: config.entryPoints,
+		outdir,
+		...(config.additionalOptions || {}),
+	};
+
+	const isWatch = args.indexOf('--watch') >= 0;
+	if (isWatch) {
+		const ctx = await esbuild.context(resolvedOptions);
+		await watchWithParcel(ctx, config.srcDir, () => didBuild?.(outdir));
+	} else {
+		try {
+			await esbuild.build(resolvedOptions);
+			await didBuild?.(outdir);
+		} catch {
+			process.exit(1);
+		}
+	}
+}
+
+// We use @parcel/watcher as it has much lower cpu usage when idle compared to esbuild's watch mode
+async function watchWithParcel(ctx: esbuild.BuildContext, srcDir: string, didBuild?: () => Promise<unknown> | unknown): Promise<void> {
+	let debounce: ReturnType<typeof setTimeout> | undefined;
+	const rebuild = () => {
+		if (debounce) {
+			clearTimeout(debounce);
+		}
+		debounce = setTimeout(async () => {
+			try {
+				await ctx.cancel();
+				const result = await ctx.rebuild();
+				if (result.errors.length === 0) {
+					await didBuild?.();
+				}
+			} catch (error) {
+				console.error('[watch] build error:', error);
+			}
+		}, 100);
+	};
+
+	const watcher = await import('@parcel/watcher');
+	await watcher.subscribe(srcDir, (_err, _events) => {
+		rebuild();
+	}, {
+		ignore: ['**/node_modules/**', '**/dist/**', '**/out/**']
+	});
+	rebuild();
+}

--- a/extensions/esbuild-extension-common.mts
+++ b/extensions/esbuild-extension-common.mts
@@ -5,24 +5,16 @@
 /**
  * @fileoverview Common build script for extensions.
  */
-import path from 'node:path';
 import esbuild from 'esbuild';
+import { runBuild, type RunConfig } from './esbuild-common.mts';
 
-type BuildOptions = Partial<esbuild.BuildOptions> & {
-	outdir: string;
-};
-
-interface RunConfig {
+interface ExtensionRunConfig extends RunConfig {
 	readonly platform: 'node' | 'browser';
 	readonly format?: 'cjs' | 'esm';
-	readonly srcDir: string;
-	readonly outdir: string;
-	readonly entryPoints: string[] | Record<string, string> | { in: string; out: string }[];
-	readonly additionalOptions?: Partial<esbuild.BuildOptions>;
 }
 
-function resolveOptions(config: RunConfig, outdir: string): BuildOptions {
-	const options: BuildOptions = {
+function resolveBaseOptions(config: ExtensionRunConfig): esbuild.BuildOptions {
+	const options: esbuild.BuildOptions = {
 		platform: config.platform,
 		bundle: true,
 		minify: true,
@@ -31,12 +23,9 @@ function resolveOptions(config: RunConfig, outdir: string): BuildOptions {
 		target: ['es2024'],
 		external: ['vscode'],
 		format: config.format ?? 'cjs',
-		entryPoints: config.entryPoints,
-		outdir,
 		logOverride: {
 			'import-is-undefined': 'error',
 		},
-		...(config.additionalOptions || {}),
 	};
 
 	if (config.platform === 'node') {
@@ -56,47 +45,6 @@ function resolveOptions(config: RunConfig, outdir: string): BuildOptions {
 	return options;
 }
 
-export async function run(config: RunConfig, args: string[], didBuild?: (outDir: string) => unknown): Promise<void> {
-	let outdir = config.outdir;
-	const outputRootIndex = args.indexOf('--outputRoot');
-	if (outputRootIndex >= 0) {
-		const outputRoot = args[outputRootIndex + 1];
-		const outputDirName = path.basename(outdir);
-		outdir = path.join(outputRoot, outputDirName);
-	}
-
-	const resolvedOptions = resolveOptions(config, outdir);
-
-	const isWatch = args.indexOf('--watch') >= 0;
-	if (isWatch) {
-		if (didBuild) {
-			resolvedOptions.plugins = [
-				...(resolvedOptions.plugins || []),
-				{
-					name: 'did-build', setup(pluginBuild) {
-						pluginBuild.onEnd(async result => {
-							if (result.errors.length > 0) {
-								return;
-							}
-
-							try {
-								await didBuild(outdir);
-							} catch (error) {
-								console.error('didBuild failed:', error);
-							}
-						});
-					},
-				}
-			];
-		}
-		const ctx = await esbuild.context(resolvedOptions);
-		await ctx.watch();
-	} else {
-		try {
-			await esbuild.build(resolvedOptions);
-			await didBuild?.(outdir);
-		} catch {
-			process.exit(1);
-		}
-	}
+export async function run(config: ExtensionRunConfig, args: string[], didBuild?: (outDir: string) => unknown): Promise<void> {
+	return runBuild(config, resolveBaseOptions(config), args, didBuild);
 }

--- a/extensions/esbuild-webview-common.mts
+++ b/extensions/esbuild-webview-common.mts
@@ -6,77 +6,24 @@
 /**
  * Common build script for extension scripts used in in webviews.
  */
-import path from 'node:path';
-import esbuild from 'esbuild';
+import { runBuild, type RunConfig } from './esbuild-common.mts';
 
-export type BuildOptions = Partial<esbuild.BuildOptions> & {
-	readonly entryPoints: esbuild.BuildOptions['entryPoints'];
-	readonly outdir: string;
+const baseOptions = {
+	bundle: true,
+	minify: true,
+	sourcemap: false,
+	format: 'esm' as const,
+	platform: 'browser' as const,
+	target: ['es2024'],
+	logOverride: {
+		'import-is-undefined': 'error',
+	},
 };
 
 export async function run(
-	config: {
-		srcDir: string;
-		outdir: string;
-		entryPoints: BuildOptions['entryPoints'];
-		additionalOptions?: Partial<esbuild.BuildOptions>;
-	},
+	config: RunConfig,
 	args: string[],
 	didBuild?: (outDir: string) => unknown
 ): Promise<void> {
-	let outdir = config.outdir;
-	const outputRootIndex = args.indexOf('--outputRoot');
-	if (outputRootIndex >= 0) {
-		const outputRoot = args[outputRootIndex + 1];
-		const outputDirName = path.basename(outdir);
-		outdir = path.join(outputRoot, outputDirName);
-	}
-
-	const resolvedOptions: BuildOptions = {
-		bundle: true,
-		minify: true,
-		sourcemap: false,
-		format: 'esm',
-		platform: 'browser',
-		target: ['es2024'],
-		entryPoints: config.entryPoints,
-		outdir,
-		logOverride: {
-			'import-is-undefined': 'error',
-		},
-		...(config.additionalOptions || {}),
-	};
-
-	const isWatch = args.indexOf('--watch') >= 0;
-	if (isWatch) {
-		if (didBuild) {
-			resolvedOptions.plugins = [
-				...(resolvedOptions.plugins || []),
-				{
-					name: 'did-build', setup(pluginBuild) {
-						pluginBuild.onEnd(async result => {
-							if (result.errors.length > 0) {
-								return;
-							}
-
-							try {
-								await didBuild(outdir);
-							} catch (error) {
-								console.error('didBuild failed:', error);
-							}
-						});
-					},
-				}
-			];
-		}
-		const ctx = await esbuild.context(resolvedOptions);
-		await ctx.watch();
-	} else {
-		try {
-			await esbuild.build(resolvedOptions);
-			await didBuild?.(outdir);
-		} catch {
-			process.exit(1);
-		}
-	}
+	return runBuild(config, baseOptions, args, didBuild);
 }


### PR DESCRIPTION
Esbuild's watcher (maybe go's?) is having continual 2-5% cpu usage even when nothing is happening. With 15 extensions, this is causing too much load compared to parcel

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
