### PR TITLE
Add document diff api proposal

### DIFF
--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -8,7 +8,8 @@
   "license": "MIT",
   "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
   "enabledApiProposals": [
-    "customEditorDiffs"
+    "customEditorDiffs",
+    "documentDiff"
   ],
   "engines": {
     "vscode": "^1.70.0"

--- a/extensions/markdown-language-features/src/preview/lineDiff.ts
+++ b/extensions/markdown-language-features/src/preview/lineDiff.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import type { API as GitAPI, GitExtension, Repository as GitRepository } from '../../../git/src/api/git';
 import type { MarkdownPreviewLineChanges } from '../../types/previewMessaging';
 
 interface LineChanges {
@@ -17,17 +16,6 @@ interface LineChanges {
 interface LineMappings {
 	readonly originalToModified: number[];
 	readonly modifiedToOriginal: number[];
-}
-
-interface GitUriParams {
-	readonly path: string;
-	readonly ref: string;
-	readonly submoduleOf?: string;
-}
-
-interface GitPatch {
-	readonly patch: string;
-	readonly isFullRepositoryDiff: boolean;
 }
 
 export class MarkdownPreviewLineDiffProvider {
@@ -77,346 +65,48 @@ export class MarkdownPreviewLineDiffProvider {
 }
 
 async function computeLineChanges(originalDocument: vscode.TextDocument, modifiedDocument: vscode.TextDocument): Promise<LineChanges> {
-	return await computeGitLineChanges(originalDocument, modifiedDocument)
-		?? computeContentLineChanges(getDocumentLines(originalDocument), getDocumentLines(modifiedDocument));
-}
+	const diff = vscode.workspace.getTextDiff(originalDocument, modifiedDocument, {
+		ignoreTrimWhitespace: false,
+		maxComputationTimeMs: 5000,
+	});
 
-async function computeGitLineChanges(originalDocument: vscode.TextDocument, modifiedDocument: vscode.TextDocument): Promise<LineChanges | undefined> {
-	const gitApi = await getGitApi();
-	if (!gitApi) {
-		return undefined;
-	}
-
-	const originalUri = originalDocument.uri;
-	const modifiedUri = modifiedDocument.uri;
-	const originalGitUri = fromGitUri(originalUri);
-	const modifiedGitUri = fromGitUri(modifiedUri);
-	const filePath = originalGitUri?.path ?? modifiedGitUri?.path ?? (modifiedUri.scheme === 'file' ? modifiedUri.fsPath : undefined);
-	if (!filePath || originalGitUri?.submoduleOf || modifiedGitUri?.submoduleOf) {
-		return undefined;
-	}
-
-	const repository = gitApi.getRepository(vscode.Uri.file(filePath));
-	if (!repository) {
-		return undefined;
-	}
-
-	const diff = await getGitPatch(repository, filePath, originalUri, originalGitUri, modifiedUri, modifiedGitUri);
-	if (!diff) {
-		return undefined;
-	}
-
-	const relativePath = diff.isFullRepositoryDiff ? getRepositoryRelativePath(repository.rootUri, filePath) : undefined;
-	return diff.isFullRepositoryDiff && relativePath === undefined ? undefined : parseGitPatchLineChanges(diff.patch, relativePath, originalDocument.lineCount, modifiedDocument.lineCount);
-}
-
-async function getGitApi(): Promise<GitAPI | undefined> {
-	const gitExtension = vscode.extensions.getExtension<GitExtension>('vscode.git');
-	if (!gitExtension) {
-		return undefined;
-	}
-
-	try {
-		return (gitExtension.isActive ? gitExtension.exports : await gitExtension.activate()).getAPI(1);
-	} catch {
-		return undefined;
-	}
-}
-
-async function getGitPatch(
-	repository: GitRepository,
-	filePath: string,
-	originalUri: vscode.Uri,
-	originalGitUri: GitUriParams | undefined,
-	modifiedUri: vscode.Uri,
-	modifiedGitUri: GitUriParams | undefined,
-): Promise<GitPatch | undefined> {
-	try {
-		if (originalGitUri && !modifiedGitUri && modifiedUri.scheme === 'file' && samePath(originalGitUri.path, modifiedUri.fsPath)) {
-			if (originalGitUri.ref === '~') {
-				return { patch: await repository.diff(false), isFullRepositoryDiff: true };
-			}
-			if (originalGitUri.ref === 'HEAD') {
-				return { patch: await repository.diffWithHEAD(filePath), isFullRepositoryDiff: false };
-			}
-			return { patch: await repository.diffWith(originalGitUri.ref, filePath), isFullRepositoryDiff: false };
-		}
-
-		if (originalGitUri && modifiedGitUri && samePath(originalGitUri.path, modifiedGitUri.path)) {
-			if (modifiedGitUri.ref === '') {
-				return {
-					patch: originalGitUri.ref === 'HEAD'
-						? await repository.diffIndexWithHEAD(filePath)
-						: await repository.diffIndexWith(originalGitUri.ref, filePath),
-					isFullRepositoryDiff: false
-				};
-			}
-
-			return { patch: await repository.diffBetween(originalGitUri.ref, modifiedGitUri.ref, filePath), isFullRepositoryDiff: false };
-		}
-
-		if (!originalGitUri && modifiedGitUri && originalUri.scheme === 'file' && samePath(originalUri.fsPath, modifiedGitUri.path)) {
-			return {
-				patch: modifiedGitUri.ref === 'HEAD'
-					? await repository.diffWithHEAD(filePath)
-					: await repository.diffWith(modifiedGitUri.ref, filePath),
-				isFullRepositoryDiff: false
-			};
-		}
-	} catch {
-		return undefined;
-	}
-
-	return undefined;
-}
-
-function fromGitUri(uri: vscode.Uri): GitUriParams | undefined {
-	if (uri.scheme !== 'git') {
-		return undefined;
-	}
-
-	try {
-		const value = JSON.parse(uri.query) as GitUriParams;
-		return typeof value.path === 'string' && typeof value.ref === 'string' ? value : undefined;
-	} catch {
-		return undefined;
-	}
-}
-
-function getRepositoryRelativePath(rootUri: vscode.Uri, filePath: string): string | undefined {
-	const root = normalizePath(rootUri.fsPath).replace(/\/+$/, '');
-	const file = normalizePath(filePath);
-	if (file === root) {
-		return '';
-	}
-
-	return file.toLowerCase().startsWith(`${root.toLowerCase()}/`) ? file.slice(root.length + 1) : undefined;
-}
-
-function samePath(a: string, b: string): boolean {
-	return normalizePath(a).toLowerCase() === normalizePath(b).toLowerCase();
-}
-
-function normalizePath(value: string): string {
-	return value.replace(/\\/g, '/');
-}
-
-function getDocumentLines(document: vscode.TextDocument): string[] {
-	const lines: string[] = [];
-	for (let i = 0; i < document.lineCount; ++i) {
-		lines.push(document.lineAt(i).text);
-	}
-	return lines;
-}
-
-function computeContentLineChanges(originalLines: readonly string[], modifiedLines: readonly string[]): LineChanges {
-	let start = 0;
-	while (start < originalLines.length && start < modifiedLines.length && originalLines[start] === modifiedLines[start]) {
-		++start;
-	}
-
-	let originalEnd = originalLines.length;
-	let modifiedEnd = modifiedLines.length;
-	while (originalEnd > start && modifiedEnd > start && originalLines[originalEnd - 1] === modifiedLines[modifiedEnd - 1]) {
-		--originalEnd;
-		--modifiedEnd;
-	}
-
-	const originalCount = originalEnd - start;
-	const modifiedCount = modifiedEnd - start;
-	if (!originalCount && !modifiedCount) {
-		return createIdentityLineChanges(originalLines.length, modifiedLines.length);
-	}
-
-	if (originalCount * modifiedCount > 500_000) {
-		return computeFallbackLineChanges(originalLines, modifiedLines, start, originalEnd, modifiedEnd);
-	}
-
-	return computeLcsLineChanges(originalLines, modifiedLines, start, originalEnd, modifiedEnd);
-}
-
-function parseGitPatchLineChanges(patch: string, relativePath: string | undefined, originalLineCount: number, modifiedLineCount: number): LineChanges {
+	const originalLineCount = originalDocument.lineCount;
+	const modifiedLineCount = modifiedDocument.lineCount;
 	const added: number[] = [];
 	const deleted: number[] = [];
 	const mappings = createEmptyLineMappings(originalLineCount, modifiedLineCount);
-	const lines = patch.split(/\r?\n/);
-	let originalLine = 0;
-	let modifiedLine = 0;
-	let inHunk = false;
-	let fileMatches = !relativePath;
-	let matchedFile = !relativePath;
-	let oldPath: string | undefined;
-	let deletedBlockStart: number | undefined;
 
-	const finishFile = () => {
-		if (fileMatches && matchedFile) {
-			fillUnchangedLineMappings(mappings, originalLine, originalLineCount, modifiedLine, modifiedLineCount);
+	let lastOriginalEnd = 0;
+	let lastModifiedEnd = 0;
+
+	for await (const change of diff.changes) {
+		const origStart = change.originalRange.start.line;
+		const origEnd = change.originalRange.end.line;
+		const modStart = change.modifiedRange.start.line;
+		const modEnd = change.modifiedRange.end.line;
+
+		// Map unchanged lines before this change
+		fillUnchangedLineMappings(mappings, lastOriginalEnd, origStart, lastModifiedEnd, modStart);
+
+		// Mark deleted and added lines within this change
+		for (let i = origStart; i < origEnd; ++i) {
+			deleted.push(i);
+			mappings.originalToModified[i] = clampLine(modStart, modifiedLineCount);
 		}
-	};
-
-	for (const line of lines) {
-		if (line.startsWith('diff --git ')) {
-			finishFile();
-			inHunk = false;
-			fileMatches = !relativePath;
-			matchedFile = !relativePath;
-			originalLine = 0;
-			modifiedLine = 0;
-			oldPath = undefined;
-			deletedBlockStart = undefined;
-			continue;
+		for (let i = modStart; i < modEnd; ++i) {
+			added.push(i);
+			mappings.modifiedToOriginal[i] = clampLine(origStart, originalLineCount);
 		}
 
-		if (!inHunk && line.startsWith('--- ')) {
-			oldPath = parseGitDiffPath(line.slice(4));
-			continue;
-		}
-
-		if (!inHunk && line.startsWith('+++ ')) {
-			const newPath = parseGitDiffPath(line.slice(4));
-			fileMatches = !relativePath || oldPath === relativePath || newPath === relativePath;
-			matchedFile = matchedFile || fileMatches;
-			continue;
-		}
-
-		const hunkMatch = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
-		if (hunkMatch) {
-			inHunk = true;
-			const nextOriginalLine = Math.max(0, Number(hunkMatch[1]) - 1);
-			const nextModifiedLine = Math.max(0, Number(hunkMatch[2]) - 1);
-			if (fileMatches) {
-				fillUnchangedLineMappings(mappings, originalLine, nextOriginalLine, modifiedLine, nextModifiedLine);
-			}
-			originalLine = nextOriginalLine;
-			modifiedLine = nextModifiedLine;
-			deletedBlockStart = undefined;
-			continue;
-		}
-
-		if (!inHunk || !fileMatches || !line) {
-			continue;
-		}
-
-		switch (line[0]) {
-			case ' ':
-				deletedBlockStart = undefined;
-				mappings.originalToModified[originalLine] = clampLine(modifiedLine, modifiedLineCount);
-				mappings.modifiedToOriginal[modifiedLine] = clampLine(originalLine, originalLineCount);
-				++originalLine;
-				++modifiedLine;
-				break;
-			case '-':
-				deletedBlockStart ??= originalLine;
-				mappings.originalToModified[originalLine] = clampLine(modifiedLine, modifiedLineCount);
-				deleted.push(originalLine++);
-				break;
-			case '+':
-				mappings.modifiedToOriginal[modifiedLine] = clampLine(deletedBlockStart ?? originalLine, originalLineCount);
-				added.push(modifiedLine++);
-				break;
-			case '\\':
-				break;
-		}
+		lastOriginalEnd = origEnd;
+		lastModifiedEnd = modEnd;
 	}
-	finishFile();
+
+	// Map unchanged lines after the last change
+	fillUnchangedLineMappings(mappings, lastOriginalEnd, originalLineCount, lastModifiedEnd, modifiedLineCount);
 	fillMissingLineMappings(mappings);
 
 	return { added, deleted, ...mappings };
-}
-
-function parseGitDiffPath(rawPath: string): string | undefined {
-	if (rawPath === '/dev/null') {
-		return undefined;
-	}
-
-	const path = rawPath.startsWith('"') && rawPath.endsWith('"') ? rawPath.slice(1, -1) : rawPath;
-	return path.startsWith('a/') || path.startsWith('b/') ? path.slice(2) : path;
-}
-
-function computeLcsLineChanges(originalLines: readonly string[], modifiedLines: readonly string[], start: number, originalEnd: number, modifiedEnd: number): LineChanges {
-	const originalCount = originalEnd - start;
-	const modifiedCount = modifiedEnd - start;
-	const mappings = createEmptyLineMappings(originalLines.length, modifiedLines.length);
-	fillUnchangedLineMappings(mappings, 0, start, 0, start);
-	fillUnchangedLineMappings(mappings, originalEnd, originalLines.length, modifiedEnd, modifiedLines.length);
-	const lcsLengths: Uint32Array[] = [];
-	for (let i = 0; i <= originalCount; ++i) {
-		lcsLengths.push(new Uint32Array(modifiedCount + 1));
-	}
-
-	for (let i = originalCount - 1; i >= 0; --i) {
-		for (let j = modifiedCount - 1; j >= 0; --j) {
-			lcsLengths[i][j] = originalLines[start + i] === modifiedLines[start + j]
-				? lcsLengths[i + 1][j + 1] + 1
-				: Math.max(lcsLengths[i + 1][j], lcsLengths[i][j + 1]);
-		}
-	}
-
-	const added: number[] = [];
-	const deleted: number[] = [];
-	let originalIndex = 0;
-	let modifiedIndex = 0;
-	let deletedBlockStart: number | undefined;
-	let addedBlockStart: number | undefined;
-	while (originalIndex < originalCount || modifiedIndex < modifiedCount) {
-		if (originalIndex < originalCount && modifiedIndex < modifiedCount && originalLines[start + originalIndex] === modifiedLines[start + modifiedIndex]) {
-			deletedBlockStart = undefined;
-			addedBlockStart = undefined;
-			mappings.originalToModified[start + originalIndex] = clampLine(start + modifiedIndex, modifiedLines.length);
-			mappings.modifiedToOriginal[start + modifiedIndex] = clampLine(start + originalIndex, originalLines.length);
-			++originalIndex;
-			++modifiedIndex;
-		} else if (modifiedIndex < modifiedCount && (originalIndex === originalCount || lcsLengths[originalIndex][modifiedIndex + 1] >= lcsLengths[originalIndex + 1][modifiedIndex])) {
-			added.push(start + modifiedIndex);
-			addedBlockStart ??= start + modifiedIndex;
-			mappings.modifiedToOriginal[start + modifiedIndex] = clampLine(deletedBlockStart ?? start + originalIndex, originalLines.length);
-			++modifiedIndex;
-		} else {
-			deleted.push(start + originalIndex);
-			deletedBlockStart ??= start + originalIndex;
-			mappings.originalToModified[start + originalIndex] = clampLine(addedBlockStart ?? start + modifiedIndex, modifiedLines.length);
-			++originalIndex;
-		}
-	}
-	fillMissingLineMappings(mappings);
-
-	return { added, deleted, ...mappings };
-}
-
-function computeFallbackLineChanges(originalLines: readonly string[], modifiedLines: readonly string[], start: number, originalEnd: number, modifiedEnd: number): LineChanges {
-	const added: number[] = [];
-	const deleted: number[] = [];
-	const mappings = createEmptyLineMappings(originalLines.length, modifiedLines.length);
-	fillUnchangedLineMappings(mappings, 0, start, 0, start);
-	fillUnchangedLineMappings(mappings, originalEnd, originalLines.length, modifiedEnd, modifiedLines.length);
-	const sharedCount = Math.min(originalEnd - start, modifiedEnd - start);
-	for (let i = 0; i < sharedCount; ++i) {
-		mappings.originalToModified[start + i] = clampLine(start + i, modifiedLines.length);
-		mappings.modifiedToOriginal[start + i] = clampLine(start + i, originalLines.length);
-		if (originalLines[start + i] !== modifiedLines[start + i]) {
-			deleted.push(start + i);
-			added.push(start + i);
-		}
-	}
-
-	for (let i = start + sharedCount; i < originalEnd; ++i) {
-		deleted.push(i);
-		mappings.originalToModified[i] = clampLine(modifiedEnd, modifiedLines.length);
-	}
-	for (let i = start + sharedCount; i < modifiedEnd; ++i) {
-		added.push(i);
-		mappings.modifiedToOriginal[i] = clampLine(originalEnd, originalLines.length);
-	}
-	fillMissingLineMappings(mappings);
-
-	return { added, deleted, ...mappings };
-}
-
-function createIdentityLineChanges(originalLineCount: number, modifiedLineCount: number): LineChanges {
-	const mappings = createEmptyLineMappings(originalLineCount, modifiedLineCount);
-	fillUnchangedLineMappings(mappings, 0, originalLineCount, 0, modifiedLineCount);
-	fillMissingLineMappings(mappings);
-	return { added: [], deleted: [], ...mappings };
 }
 
 function createEmptyLineMappings(originalLineCount: number, modifiedLineCount: number): LineMappings {

--- a/extensions/markdown-language-features/tsconfig.json
+++ b/extensions/markdown-language-features/tsconfig.json
@@ -11,6 +11,7 @@
 	"include": [
 		"src/**/*",
 		"../../src/vscode-dts/vscode.d.ts",
-		"../../src/vscode-dts/vscode.proposed.customEditorDiffs.d.ts"
+		"../../src/vscode-dts/vscode.proposed.customEditorDiffs.d.ts",
+		"../../src/vscode-dts/vscode.proposed.documentDiff.d.ts"
 	]
 }

--- a/src/vs/platform/extensions/common/extensionsApiProposals.ts
+++ b/src/vs/platform/extensions/common/extensionsApiProposals.ts
@@ -234,6 +234,9 @@ const _allApiProposals = {
 	diffContentOptions: {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.diffContentOptions.d.ts',
 	},
+	documentDiff: {
+		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.documentDiff.d.ts',
+	},
 	documentFiltersExclusive: {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.documentFiltersExclusive.d.ts',
 	},

--- a/src/vs/workbench/api/browser/extensionHost.contribution.ts
+++ b/src/vs/workbench/api/browser/extensionHost.contribution.ts
@@ -51,6 +51,7 @@ import './mainThreadManagedSockets.js';
 import './mainThreadOutputService.js';
 import './mainThreadProgress.js';
 import './mainThreadQuickDiff.js';
+import './mainThreadDocumentDiff.js';
 import './mainThreadQuickOpen.js';
 import './mainThreadRemoteConnectionData.js';
 import './mainThreadSaveParticipant.js';

--- a/src/vs/workbench/api/browser/mainThreadDocumentDiff.ts
+++ b/src/vs/workbench/api/browser/mainThreadDocumentDiff.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IRange } from '../../../editor/common/core/range.js';
+import { URI, UriComponents } from '../../../base/common/uri.js';
+import { IEditorWorkerService } from '../../../editor/common/services/editorWorker.js';
+import { IDocumentDiffLineChangeDto, IDocumentDiffResultDto, MainContext, MainThreadDocumentDiffShape } from '../common/extHost.protocol.js';
+import { extHostNamedCustomer, IExtHostContext } from '../../services/extensions/common/extHostCustomers.js';
+
+@extHostNamedCustomer(MainContext.MainThreadDocumentDiff)
+export class MainThreadDocumentDiff implements MainThreadDocumentDiffShape {
+
+	constructor(
+		_extHostContext: IExtHostContext,
+		@IEditorWorkerService private readonly _editorWorkerService: IEditorWorkerService,
+	) {
+	}
+
+	async $computeDocumentDiff(originalUri: UriComponents, modifiedUri: UriComponents, ignoreTrimWhitespace: boolean, maxComputationTimeMs: number, computeMoves: boolean): Promise<IDocumentDiffResultDto | null> {
+		const original = URI.revive(originalUri);
+		const modified = URI.revive(modifiedUri);
+		const result = await this._editorWorkerService.computeDiff(original, modified, {
+			ignoreTrimWhitespace,
+			maxComputationTimeMs,
+			computeMoves,
+		}, 'advanced');
+		if (!result) {
+			return null;
+		}
+		const toLineRange = (r: { startLineNumber: number; endLineNumberExclusive: number }): IRange => ({
+			startLineNumber: r.startLineNumber,
+			startColumn: 1,
+			endLineNumber: r.endLineNumberExclusive,
+			endColumn: 1,
+		});
+
+		const mapChange = (c: typeof result.changes[0]): IDocumentDiffLineChangeDto => ({
+			originalRange: toLineRange(c.original),
+			modifiedRange: toLineRange(c.modified),
+			innerChanges: c.innerChanges?.map(ic => ({
+				originalRange: ic.originalRange,
+				modifiedRange: ic.modifiedRange,
+			})),
+		});
+
+		return {
+			identical: result.identical,
+			quitEarly: result.quitEarly,
+			changes: result.changes.map(mapChange),
+			moves: result.moves.map(m => ({
+				originalRange: toLineRange(m.lineRangeMapping.original),
+				modifiedRange: toLineRange(m.lineRangeMapping.modified),
+				changes: m.changes.map(mapChange),
+			})),
+		};
+	}
+
+	dispose(): void {
+		// nothing to dispose
+	}
+}

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -5,6 +5,7 @@
 
 import type * as vscode from 'vscode';
 import { CancellationTokenSource } from '../../../base/common/cancellation.js';
+import { AsyncIterableObject, raceCancellationError } from '../../../base/common/async.js';
 import * as errors from '../../../base/common/errors.js';
 import { Emitter, Event } from '../../../base/common/event.js';
 import { combinedDisposable } from '../../../base/common/lifecycle.js';
@@ -29,7 +30,7 @@ import { UIKind } from '../../services/extensions/common/extensionHostProtocol.j
 import { checkProposedApiEnabled, isProposedApiEnabled } from '../../services/extensions/common/extensions.js';
 import { ProxyIdentifier } from '../../services/extensions/common/proxyIdentifier.js';
 import { AISearchKeyword, ExcludeSettingOptions, TextSearchCompleteMessageType, TextSearchContext2, TextSearchMatch2 } from '../../services/search/common/searchExtTypes.js';
-import { CandidatePortSource, ExtHostContext, ExtHostLogLevelServiceShape, MainContext } from './extHost.protocol.js';
+import { CandidatePortSource, ExtHostContext, ExtHostLogLevelServiceShape, IDocumentDiffLineChangeDto, MainContext } from './extHost.protocol.js';
 import { ExtHostRelatedInformation } from './extHostAiRelatedInformation.js';
 import { ExtHostAiSettingsSearch } from './extHostAiSettingsSearch.js';
 import { ExtHostApiCommands } from './extHostApiCommands.js';
@@ -1163,6 +1164,59 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 				checkProposedApiEnabled(extension, 'findTextInFiles2');
 				checkProposedApiEnabled(extension, 'textSearchProvider2');
 				return extHostWorkspace.findTextInFiles2(query, options, extension.identifier, token);
+			},
+			getTextDiff(originalDocument: vscode.TextDocument, modifiedDocument: vscode.TextDocument, options?: vscode.TextDiffOptions, token?: vscode.CancellationToken): vscode.TextDiffResponse {
+				checkProposedApiEnabled(extension, 'documentDiff');
+				const proxy = rpcProtocol.getProxy(MainContext.MainThreadDocumentDiff);
+				if (token?.isCancellationRequested) {
+					const error = new errors.CancellationError();
+					return {
+						changes: AsyncIterableObject.EMPTY,
+						complete: Promise.reject(error),
+					};
+				}
+				const resultPromise = proxy.$computeDocumentDiff(
+					originalDocument.uri,
+					modifiedDocument.uri,
+					options?.ignoreTrimWhitespace ?? false,
+					options?.maxComputationTimeMs ?? 5000,
+					options?.computeMoves ?? false,
+				);
+				const diffPromise = token ? raceCancellationError(resultPromise, token) : resultPromise;
+				const mappedPromise = diffPromise.then(result => {
+					if (!result) {
+						throw new Error('Could not compute diff. Make sure both documents are available.');
+					}
+					return result;
+				});
+
+				const mapChange = (c: IDocumentDiffLineChangeDto) => ({
+					originalRange: typeConverters.Range.to(c.originalRange),
+					modifiedRange: typeConverters.Range.to(c.modifiedRange),
+					innerChanges: c.innerChanges?.map(ic => ({
+						originalRange: typeConverters.Range.to(ic.originalRange),
+						modifiedRange: typeConverters.Range.to(ic.modifiedRange),
+					})),
+				});
+
+				// TODO@API currently the diff is computed in one shot and all changes are emitted at once.
+				// In the future, we may want to stream changes incrementally as they are computed
+				// (e.g. by having the worker yield partial results).
+				return {
+					changes: new AsyncIterableObject<vscode.TextDiffChange>(async emitter => {
+						const result = await mappedPromise;
+						emitter.emitMany(result.changes.map(mapChange));
+					}),
+					complete: mappedPromise.then(result => ({
+						identical: result.identical,
+						mayBeIncomplete: result.quitEarly,
+						moves: result.moves.map(m => ({
+							originalRange: typeConverters.Range.to(m.originalRange),
+							modifiedRange: typeConverters.Range.to(m.modifiedRange),
+							changes: m.changes.map(mapChange),
+						})),
+					})),
+				};
 			},
 			save: (uri) => {
 				return extHostWorkspace.save(uri);

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -2149,6 +2149,29 @@ export interface MainThreadQuickDiffShape extends IDisposable {
 	$unregisterQuickDiffProvider(handle: number): Promise<void>;
 }
 
+export interface IDocumentDiffLineChangeDto {
+	originalRange: IRange;
+	modifiedRange: IRange;
+	innerChanges: { originalRange: IRange; modifiedRange: IRange }[] | undefined;
+}
+
+export interface IDocumentDiffMoveDto {
+	originalRange: IRange;
+	modifiedRange: IRange;
+	changes: IDocumentDiffLineChangeDto[];
+}
+
+export interface IDocumentDiffResultDto {
+	identical: boolean;
+	quitEarly: boolean;
+	changes: IDocumentDiffLineChangeDto[];
+	moves: IDocumentDiffMoveDto[];
+}
+
+export interface MainThreadDocumentDiffShape extends IDisposable {
+	$computeDocumentDiff(originalUri: UriComponents, modifiedUri: UriComponents, ignoreTrimWhitespace: boolean, maxComputationTimeMs: number, computeMoves: boolean): Promise<IDocumentDiffResultDto | null>;
+}
+
 export type DebugSessionUUID = string;
 
 export interface IDebugConfiguration {
@@ -3920,6 +3943,7 @@ export const MainContext = {
 	MainThreadOutputService: createProxyIdentifier<MainThreadOutputServiceShape>('MainThreadOutputService'),
 	MainThreadProgress: createProxyIdentifier<MainThreadProgressShape>('MainThreadProgress'),
 	MainThreadQuickDiff: createProxyIdentifier<MainThreadQuickDiffShape>('MainThreadQuickDiff'),
+	MainThreadDocumentDiff: createProxyIdentifier<MainThreadDocumentDiffShape>('MainThreadDocumentDiff'),
 	MainThreadQuickOpen: createProxyIdentifier<MainThreadQuickOpenShape>('MainThreadQuickOpen'),
 	MainThreadStatusBar: createProxyIdentifier<MainThreadStatusBarShape>('MainThreadStatusBar'),
 	MainThreadSecretState: createProxyIdentifier<MainThreadSecretStateShape>('MainThreadSecretState'),

--- a/src/vscode-dts/vscode.proposed.documentDiff.d.ts
+++ b/src/vscode-dts/vscode.proposed.documentDiff.d.ts
@@ -1,0 +1,145 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'vscode' {
+
+	export namespace workspace {
+
+		/**
+		 * Compute the diff between two text documents.
+		 *
+		 * This uses the same diff algorithm that powers the built-in diff editor,
+		 * returning line-level and character-level change mappings.
+		 *
+		 * @param originalDocument The original (left-hand side) document.
+		 * @param modifiedDocument The modified (right-hand side) document.
+		 * @param options Options to control the diff computation.
+		 * @param token A cancellation token.
+		 *
+		 * @returns A response object with streaming changes and a completion promise.
+		 */
+		export function getTextDiff(originalDocument: TextDocument, modifiedDocument: TextDocument, options?: TextDiffOptions, token?: CancellationToken): TextDiffResponse;
+	}
+
+	/**
+	 * Options for computing a text diff.
+	 */
+	export interface TextDiffOptions {
+		/**
+		 * When `true`, the diff algorithm ignores changes in leading and trailing whitespace.
+		 * Defaults to `false`.
+		 */
+		readonly ignoreTrimWhitespace?: boolean;
+
+		/**
+		 * Maximum time in milliseconds to spend computing the diff.
+		 * `0` means no limit. Defaults to `5000`.
+		 */
+		readonly maxComputationTimeMs?: number;
+
+		/**
+		 * When `true`, the diff algorithm also computes moved text blocks.
+		 * Defaults to `false`.
+		 */
+		readonly computeMoves?: boolean;
+	}
+
+	/**
+	 * The response from {@link workspace.getTextDiff}.
+	 */
+	export interface TextDiffResponse {
+		/**
+		 * The line-level changes between the two documents, streamed as they are computed.
+		 */
+		readonly changes: AsyncIterable<TextDiffChange>;
+
+		/**
+		 * Resolves when the diff computation is complete, with summary information.
+		 */
+		readonly complete: Thenable<TextDiffComplete>;
+	}
+
+	/**
+	 * Completion information for a text diff computation.
+	 */
+	export interface TextDiffComplete {
+		/**
+		 * `true` if both documents are identical (byte-wise).
+		 *
+		 * A diff may return 0 changes but still have `identical` be `false`. This can happen if different diff options
+		 * are passed in for example.
+		 */
+		readonly identical: boolean;
+
+		/**
+		 * `true` if the diff computation timed out and the result may be inaccurate.
+		 */
+		readonly mayBeIncomplete: boolean;
+
+		/**
+		 * Detected text moves (blocks of text that were moved from one location to another).
+		 * Only populated when {@link DocumentDiffOptions.computeMoves} is `true`.
+		 */
+		readonly moves: readonly TextDiffMove[];
+	}
+
+	/**
+	 * Represents a line-level change between two documents, optionally
+	 * containing character-level (inner) changes.
+	 */
+	export interface TextDiffChange {
+		/**
+		 * The line range in the original document.
+		 */
+		readonly originalRange: Range;
+
+		/**
+		 * The line range in the modified document.
+		 */
+		readonly modifiedRange: Range;
+
+		/**
+		 * Character-level changes within this line range change.
+		 * May be `undefined` if inner changes were not computed.
+		 */
+		readonly innerChanges: readonly TextDiffInnerChange[] | undefined;
+	}
+
+	/**
+	 * Represents a character-level change within a {@link TextDiffChange}.
+	 */
+	export interface TextDiffInnerChange {
+		/**
+		 * The range in the original document.
+		 */
+		readonly originalRange: Range;
+
+		/**
+		 * The range in the modified document.
+		 */
+		readonly modifiedRange: Range;
+	}
+
+	/**
+	 * Represents a detected text move between two documents.
+	 */
+	export interface TextDiffMove {
+		/**
+		 * The line range in the original document that was moved.
+		 */
+		readonly originalRange: Range;
+
+		/**
+		 * The line range in the modified document where the text was moved to.
+		 */
+		readonly modifiedRange: Range;
+
+		/**
+		 * The changes within the moved text (differences between the original
+		 * and the moved copy).
+		 */
+		readonly changes: readonly TextDiffChange[];
+	}
+}


### PR DESCRIPTION
For #315174
For #315177

This adds a propose api for computing the diff between two files. Custom diff editors can use this to make sure they have the same diffs that VS Code would use in it's built-in diff editor

