### PR TITLE
feat: wait for pending background tasks after SDK send in CopilotCLISession

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { Attachment, SendOptions, Session, SessionOptions } from '@github/copilot/sdk';
+import type { Attachment, LocalSession, SendOptions, Session, SessionOptions } from '@github/copilot/sdk';
 import * as l10n from '@vscode/l10n';
 import * as cp from 'child_process';
 import * as crypto from 'crypto';
@@ -1603,6 +1603,18 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 				sendOptions.source = input.source;
 			}
 			await this._sdkSession.send(sendOptions);
+
+			try {
+				const localSession = this._sdkSession as LocalSession;
+				if (localSession.waitForPendingBackgroundTasks) {
+					await localSession.waitForPendingBackgroundTasks();
+				}
+			}
+			catch (error) {
+				this.logService.error(error, '[CopilotCLISession] Error while waiting for pending background tasks');
+				// Don't fail the whole request if waiting for background tasks fails, as it's not critical to the main flow.
+				// Just log the error and continue.
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

After `_sdkSession.send()` completes, wait for any pending background tasks via `LocalSession.waitForPendingBackgroundTasks()` (if available).

Errors from waiting on background tasks are caught and logged but do not fail the main request flow.

## Changes

- `copilotcliSession.ts`: Added `LocalSession` to SDK imports; added `waitForPendingBackgroundTasks` call after `send()`, wrapped in try/catch

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>