### PR TITLE
Fix disposable leaks and cancellation handling across editor, chat, and menu components

### DIFF
--- a/src/vs/base/common/async.ts
+++ b/src/vs/base/common/async.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { CancellationToken, CancellationTokenSource } from './cancellation.js';
-import { BugIndicatingError, CancellationError } from './errors.js';
+import { BugIndicatingError, CancellationError, isCancellationError } from './errors.js';
 import { Emitter, Event } from './event.js';
 import { Disposable, DisposableMap, DisposableStore, IDisposable, isDisposable, MutableDisposable, toDisposable } from './lifecycle.js';
 import { extUri as defaultExtUri, IExtUri } from './resources.js';
@@ -114,6 +114,13 @@ export function raceCancellationError<T>(promise: Promise<T>, token: Cancellatio
 		});
 		promise.then(resolve, reject).finally(() => ref.dispose());
 	});
+}
+
+export function rejectIfNotCanceled(err: unknown): undefined {
+	if (isCancellationError(err)) {
+		return undefined;
+	}
+	return Promise.reject(err) as never;
 }
 
 /**

--- a/src/vs/base/common/observableInternal/index.ts
+++ b/src/vs/base/common/observableInternal/index.ts
@@ -6,7 +6,7 @@
 // This is a facade for the observable implementation. Only import from here!
 
 export { observableValueOpts } from './observables/observableValueOpts.js';
-export { autorun, autorunDelta, autorunHandleChanges, autorunOpts, autorunWithStore, autorunWithStoreHandleChanges, autorunIterableDelta, autorunPerKeyedItem, autorunSelfDisposable } from './reactions/autorun.js';
+export { autorun, autorunDelta, autorunHandleChanges, autorunOpts, autorunWithStore, autorunWithStoreHandleChanges, autorunIterableDelta, autorunPerKeyedItem, autorunSelfDisposable, registerAutorunSelfDisposable } from './reactions/autorun.js';
 export { type IObservable, type IObservableWithChange, type IObserver, type IReader, type ISettable, type IReaderWithStore, type ISettableObservable, type ITransaction } from './base.js';
 export { disposableObservableValue } from './observables/observableValue.js';
 export { derived, derivedDisposable, derivedHandleChanges, derivedOpts, derivedWithSetter, derivedWithStore } from './observables/derived.js';

--- a/src/vs/base/common/observableInternal/reactions/autorun.ts
+++ b/src/vs/base/common/observableInternal/reactions/autorun.ts
@@ -232,6 +232,7 @@ export interface IReaderWithDispose extends IReaderWithStore, IDisposable { }
 /**
  * An autorun with a `dispose()` method on its `reader` which cancels the autorun.
  * It it safe to call `dispose()` synchronously.
+ * @deprecated Use autorunSelfDisposable2
  */
 export function autorunSelfDisposable(fn: (reader: IReaderWithDispose) => void, debugLocation = DebugLocation.ofCaller()): IDisposable {
 	let ar: IDisposable | undefined;
@@ -255,4 +256,39 @@ export function autorunSelfDisposable(fn: (reader: IReaderWithDispose) => void, 
 	}
 
 	return ar;
+}
+
+
+/**
+ * An autorun with a `dispose()` method on its `reader` which cancels the autorun.
+ * It it safe to call `dispose()` synchronously.
+ * TODO@hediet/copilot: rename to delete autorunSelfDisposable, and rename autorunSelfDisposable2 to autorunSelfDisposable.
+ */
+export function registerAutorunSelfDisposable(store: DisposableStore, fn: (reader: IReaderWithDispose) => void, debugLocation = DebugLocation.ofCaller()): void {
+	let ar: IDisposable | undefined;
+	let disposeSync = false;
+
+	// eslint-disable-next-line prefer-const
+	ar = autorun(reader => {
+		fn({
+			delayedStore: reader.delayedStore,
+			store: reader.store,
+			readObservable: reader.readObservable.bind(reader),
+			dispose: () => {
+				if (!ar) {
+					// dispose on first run, ar is not initialized yet.
+					disposeSync = true;
+				} else {
+					// dispose on reaction, ar is already registered.
+					store.delete(ar);
+				}
+			}
+		});
+	}, debugLocation);
+
+	if (disposeSync) {
+		ar.dispose();
+	} else {
+		store.add(ar);
+	}
 }

--- a/src/vs/editor/browser/widget/diffEditor/diffEditorViewModel.ts
+++ b/src/vs/editor/browser/widget/diffEditor/diffEditorViewModel.ts
@@ -3,10 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { RunOnceScheduler } from '../../../../base/common/async.js';
+import { rejectIfNotCanceled, RunOnceScheduler } from '../../../../base/common/async.js';
 import { CancellationTokenSource } from '../../../../base/common/cancellation.js';
 import { Disposable, toDisposable } from '../../../../base/common/lifecycle.js';
-import { IObservable, IReader, ISettableObservable, ITransaction, autorun, autorunWithStore, derived, observableSignal, observableSignalFromEvent, observableValue, transaction, waitForState } from '../../../../base/common/observable.js';
+import { IObservable, IReader, ISettableObservable, ITransaction, autorun, derived, observableSignal, observableSignalFromEvent, observableValue, transaction, waitForState } from '../../../../base/common/observable.js';
 import { IDiffProviderFactoryService } from './diffProviderFactoryService.js';
 import { filterWithPrevious } from './utils.js';
 import { readHotReloadableExport } from '../../../../base/common/hotReloadHelpers.js';
@@ -261,8 +261,9 @@ export class DiffEditorViewModel extends Disposable implements IDiffEditorViewMo
 			debouncer.schedule();
 		}));
 
-		this._register(autorunWithStore(async (reader, store) => {
+		this._register(autorun(async (reader) => {
 			/** @description compute diff */
+			const store = reader.store;
 
 			// So that they get recomputed when these settings change
 			this._options.hideUnchangedRegionsMinimumLineCount.read(reader);
@@ -294,9 +295,9 @@ export class DiffEditorViewModel extends Disposable implements IDiffEditorViewMo
 				ignoreTrimWhitespace: this._options.ignoreTrimWhitespace.read(reader),
 				maxComputationTimeMs: this._options.maxComputationTimeMs.read(reader),
 				computeMoves: this._options.showMoves.read(reader),
-			}, this._cancellationTokenSource.token);
+			}, this._cancellationTokenSource.token).catch(rejectIfNotCanceled);
 
-			if (this._cancellationTokenSource.token.isCancellationRequested) {
+			if (!result || this._cancellationTokenSource.token.isCancellationRequested) {
 				return;
 			}
 			if (model.original.isDisposed() || model.modified.isDisposed()) {
@@ -348,7 +349,7 @@ export class DiffEditorViewModel extends Disposable implements IDiffEditorViewMo
 	}
 
 	public async waitForDiff(): Promise<void> {
-		await waitForState(this.isDiffUpToDate, s => s);
+		await waitForState(this.isDiffUpToDate, s => s, undefined, this._cancellationTokenSource.token).catch(rejectIfNotCanceled);
 	}
 
 	public serializeState(): SerializedState {

--- a/src/vs/editor/browser/widget/multiDiffEditor/diffEditorItemTemplate.ts
+++ b/src/vs/editor/browser/widget/multiDiffEditor/diffEditorItemTemplate.ts
@@ -129,7 +129,7 @@ export class DiffEditorItemTemplate extends Disposable implements IPooledObject<
 		this._lastScrollTop = -1;
 		this._isSettingScrollTop = false;
 
-		const btn = new Button(this._elements.collapseButton, {});
+		const btn = this._register(new Button(this._elements.collapseButton, {}));
 
 		this._register(autorun(reader => {
 			btn.element.className = '';

--- a/src/vs/editor/browser/widget/multiDiffEditor/multiDiffEditorViewModel.ts
+++ b/src/vs/editor/browser/widget/multiDiffEditor/multiDiffEditorViewModel.ts
@@ -5,7 +5,7 @@
 
 import { Disposable, DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
 import { IObservable, ITransaction, ObservablePromise, ObservableResolvedPromise, constObservable, derived, derivedObservableWithWritableCache, mapObservableArrayCached, observableFromValueWithChangeEvent, observableValue, transaction, waitForState } from '../../../../base/common/observable.js';
-import { timeout } from '../../../../base/common/async.js';
+import { rejectIfNotCanceled, timeout } from '../../../../base/common/async.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ContextKeyValue } from '../../../../platform/contextkey/common/contextkey.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
@@ -17,6 +17,7 @@ import { DiffEditorOptions } from '../diffEditor/diffEditorOptions.js';
 import { DiffEditorViewModel } from '../diffEditor/diffEditorViewModel.js';
 import { RefCounted } from '../diffEditor/utils.js';
 import { IDocumentDiffItem, IMultiDiffEditorModel } from './model.js';
+import { cancelOnDispose } from '../../../../base/common/cancellation.js';
 
 export class MultiDiffEditorViewModel extends Disposable {
 	private readonly _documents: IObservable<readonly RefCounted<IDocumentDiffItem>[] | 'loading'>;
@@ -186,8 +187,8 @@ export class DocumentDiffItemViewModel extends Disposable {
 
 		this.waitForInitialDiffOr1s = new ObservablePromise(
 			Promise.race([
-				this.diffEditorViewModel.waitForDiff(),
-				timeout(1000),
+				this.diffEditorViewModel.waitForDiff().catch(rejectIfNotCanceled),
+				timeout(1000, cancelOnDispose(this._store)).catch(rejectIfNotCanceled),
 			])
 		);
 	}

--- a/src/vs/platform/actions/common/menuService.ts
+++ b/src/vs/platform/actions/common/menuService.ts
@@ -5,7 +5,7 @@
 
 import { RunOnceScheduler } from '../../../base/common/async.js';
 import { DebounceEmitter, Emitter, Event } from '../../../base/common/event.js';
-import { DisposableStore } from '../../../base/common/lifecycle.js';
+import { DisposableStore, Disposable, IDisposable } from '../../../base/common/lifecycle.js';
 import { IMenu, IMenuActionOptions, IMenuChangeEvent, IMenuCreateOptions, IMenuItem, IMenuItemHide, IMenuService, isIMenuItem, isISubmenuItem, ISubmenuItem, MenuId, MenuItemAction, MenuRegistry, SubmenuItemAction } from './actions.js';
 import { ICommandAction, ILocalizedString } from '../../action/common/action.js';
 import { ICommandService } from '../../commands/common/commands.js';
@@ -16,7 +16,7 @@ import { removeFastWithoutKeepingOrder } from '../../../base/common/arrays.js';
 import { localize } from '../../../nls.js';
 import { IKeybindingService } from '../../keybinding/common/keybinding.js';
 
-export class MenuService implements IMenuService {
+export class MenuService extends Disposable implements IMenuService {
 
 	declare readonly _serviceBrand: undefined;
 
@@ -27,7 +27,8 @@ export class MenuService implements IMenuService {
 		@IKeybindingService private readonly _keybindingService: IKeybindingService,
 		@IStorageService storageService: IStorageService,
 	) {
-		this._hiddenStates = new PersistedMenuHideState(storageService);
+		super();
+		this._hiddenStates = this._register(new PersistedMenuHideState(storageService));
 	}
 
 	createMenu(id: MenuId, contextKeyService: IContextKeyService, options?: IMenuCreateOptions): IMenu {
@@ -51,7 +52,7 @@ export class MenuService implements IMenuService {
 	}
 }
 
-class PersistedMenuHideState {
+class PersistedMenuHideState implements IDisposable {
 
 	private static readonly _key = 'menu.hiddenCommands';
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatReferencesContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatReferencesContentPart.ts
@@ -215,7 +215,7 @@ export class CollapsibleListPool extends Disposable {
 		const container = $('.chat-used-context-list');
 		store.add(createFileIconThemableTreeContainerScope(container, this.themeService));
 
-		const list = this.instantiationService.createInstance(
+		const list = store.add(this.instantiationService.createInstance(
 			WorkbenchList<IChatCollapsibleListItem>,
 			'ChatListRenderer',
 			container,
@@ -268,7 +268,7 @@ export class CollapsibleListPool extends Disposable {
 						}
 					},
 				},
-			});
+			}));
 
 		return {
 			list,

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -2644,7 +2644,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 		let inputModel = this.modelService.getModel(this.inputUri);
 		if (!inputModel) {
-			inputModel = this.modelService.createModel('', null, this.inputUri, true);
+			inputModel = this._register(this.modelService.createModel('', null, this.inputUri, true));
 		}
 
 		this.textModelResolverService.createModelReference(this.inputUri).then(ref => {
@@ -3164,13 +3164,13 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		this.updateToolConfirmationCarouselMaxHeight();
 
 		const capturedKey = key;
-		Event.once(part.onDidEmpty)(() => {
+		this._register(Event.once(part.onDidEmpty)(() => {
 			this._chatToolConfirmationCarousels.deleteAndDispose(capturedKey);
 			if (this._currentSessionKey === capturedKey) {
 				dom.clearNode(this.chatToolConfirmationCarouselContainer);
 				dom.hide(this.chatToolConfirmationCarouselContainer);
 			}
-		});
+		}));
 
 		return part;
 	}

--- a/src/vs/workbench/contrib/chat/common/model/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatModel.ts
@@ -9,12 +9,12 @@ import { VSBuffer, decodeHex, encodeHex } from '../../../../../base/common/buffe
 import { BugIndicatingError } from '../../../../../base/common/errors.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { IMarkdownString, MarkdownString, isMarkdownString } from '../../../../../base/common/htmlContent.js';
-import { Disposable, IDisposable, MutableDisposable } from '../../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, IDisposable, MutableDisposable } from '../../../../../base/common/lifecycle.js';
 import { ResourceMap } from '../../../../../base/common/map.js';
 import { revive } from '../../../../../base/common/marshalling.js';
 import { Schemas } from '../../../../../base/common/network.js';
 import { equals } from '../../../../../base/common/objects.js';
-import { IObservable, autorun, autorunSelfDisposable, constObservable, derived, observableFromEvent, observableSignalFromEvent, observableValue, observableValueOpts } from '../../../../../base/common/observable.js';
+import { IObservable, autorun, constObservable, derived, observableFromEvent, observableSignalFromEvent, observableValue, observableValueOpts, registerAutorunSelfDisposable } from '../../../../../base/common/observable.js';
 import { basename, isEqual } from '../../../../../base/common/resources.js';
 import { hasKey, WithDefinedProps } from '../../../../../base/common/types.js';
 import { URI, UriDto } from '../../../../../base/common/uri.js';
@@ -761,7 +761,8 @@ class ResponseView extends AbstractResponse {
 }
 
 export class Response extends AbstractResponse implements IDisposable {
-	private _onDidChangeValue = new Emitter<void>();
+	private readonly _store = new DisposableStore();
+	private _onDidChangeValue = this._store.add(new Emitter<void>());
 	public get onDidChangeValue() {
 		return this._onDidChangeValue.event;
 	}
@@ -778,7 +779,7 @@ export class Response extends AbstractResponse implements IDisposable {
 	}
 
 	dispose(): void {
-		this._onDidChangeValue.dispose();
+		this._store.dispose();
 	}
 
 
@@ -902,7 +903,7 @@ export class Response extends AbstractResponse implements IDisposable {
 			});
 
 		} else if (progress.kind === 'toolInvocation') {
-			autorunSelfDisposable(reader => {
+			registerAutorunSelfDisposable(this._store, reader => {
 				progress.state.read(reader); // update repr when state changes
 				this._contentChanged(false);
 


### PR DESCRIPTION
Stacked on #314953

Fixes disposable leaks and improves cancellation handling:

- **async.ts**: Add `rejectIfNotCanceled` helper to swallow cancellation errors in async autoruns
- **autorun.ts**: Add `registerAutorunSelfDisposable` that registers with a `DisposableStore` instead of returning a disposable (avoids leak when callers forget to register)
- **diffEditorViewModel.ts**: Switch from `autorunWithStore` to `autorun` with `reader.store`, use `rejectIfNotCanceled` for diff computation and `waitForDiff`
- **diffEditorItemTemplate.ts**: Register `Button` with `_register`
- **multiDiffEditorViewModel.ts**: Use `rejectIfNotCanceled` and `cancelOnDispose` for timeout
- **menuService.ts**: Make `MenuService` extend `Disposable`, register `PersistedMenuHideState`
- **chatReferencesContentPart.ts**: Register `WorkbenchList` with `store.add`
- **chatInputPart.ts**: Register model and `Event.once` listener with `_register`
- **chatModel.ts**: Use `DisposableStore` in `Response`, switch to `registerAutorunSelfDisposable`

@roblourens @justschen @connor4312