### PR TITLE
Enhance shimmer effect for in-progress session titles

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -370,44 +370,41 @@
 	}
 }
 
-/* Shimmer effect for in-progress session titles when not selected */
+/* Shimmer effect for in-progress session titles when not selected. */
+/* Gated behind @supports because some environments apply */
+/* `-webkit-text-fill-color: transparent` without honoring */
+/* `background-clip: text`, which renders gradient-filled blocks */
+/* instead of clipped text. Also disabled under reduced motion. */
 
-.monaco-list-row:not(.selected) .session-item.in-progress .session-title {
-	background: linear-gradient(
-		90deg,
-		var(--vscode-strongForeground) 0%,
-		var(--vscode-strongForeground) 30%,
-		var(--vscode-chat-thinkingShimmer) 50%,
-		var(--vscode-strongForeground) 70%,
-		var(--vscode-strongForeground) 100%
-	);
-	background-size: 400% 100%;
-	background-clip: text;
-	-webkit-background-clip: text;
-	-webkit-text-fill-color: transparent;
-	animation: session-title-shimmer 3s linear infinite;
-}
+@supports ((background-clip: text) or (-webkit-background-clip: text)) {
+	@media not (prefers-reduced-motion: reduce) {
+		.monaco-list-row:not(.selected) .session-item.in-progress .session-title {
+			background: linear-gradient(
+				90deg,
+				var(--vscode-strongForeground) 0%,
+				var(--vscode-strongForeground) 30%,
+				var(--vscode-chat-thinkingShimmer) 50%,
+				var(--vscode-strongForeground) 70%,
+				var(--vscode-strongForeground) 100%
+			);
+			background-size: 400% 100%;
+			background-clip: text;
+			-webkit-background-clip: text;
+			-webkit-text-fill-color: transparent;
+			animation: session-title-shimmer 3s linear infinite;
+		}
 
-.vs-dark .monaco-list-row:not(.selected) .session-item.in-progress .session-title,
-.hc-black .monaco-list-row:not(.selected) .session-item.in-progress .session-title {
-	background-image: linear-gradient(
-		90deg,
-		var(--vscode-strongForeground) 0%,
-		var(--vscode-strongForeground) 30%,
-		var(--vscode-descriptionForeground) 50%,
-		var(--vscode-strongForeground) 70%,
-		var(--vscode-strongForeground) 100%
-	);
-}
-
-@media (prefers-reduced-motion: reduce) {
-	.monaco-list-row:not(.selected) .session-item.in-progress .session-title {
-		animation: none;
-		background: none;
-		background-clip: border-box;
-		-webkit-background-clip: border-box;
-		color: var(--vscode-strongForeground);
-		-webkit-text-fill-color: var(--vscode-strongForeground);
+		.vs-dark .monaco-list-row:not(.selected) .session-item.in-progress .session-title,
+		.hc-black .monaco-list-row:not(.selected) .session-item.in-progress .session-title {
+			background-image: linear-gradient(
+				90deg,
+				var(--vscode-strongForeground) 0%,
+				var(--vscode-strongForeground) 30%,
+				var(--vscode-descriptionForeground) 50%,
+				var(--vscode-strongForeground) 70%,
+				var(--vscode-strongForeground) 100%
+			);
+		}
 	}
 }
 


### PR DESCRIPTION
This pull request improves the shimmer effect styling for in-progress session titles in the sessions list, making it more robust and accessible by addressing browser compatibility and accessibility concerns.

**Accessibility and compatibility improvements:**

* The shimmer effect for in-progress session titles is now gated behind a `@supports` check for `background-clip: text` (and its webkit variant), preventing rendering issues in browsers that do not fully support this feature.
* The shimmer effect is also disabled for users who have enabled reduced motion preferences, improving accessibility for those sensitive to animations. [[1]](diffhunk://#diff-fd9669576e99ab30bc76563f9128ed7eae19675968e6c1e7ba8f9119d4c858baL373-R380) [[2]](diffhunk://#diff-fd9669576e99ab30bc76563f9128ed7eae19675968e6c1e7ba8f9119d4c858baL402-L410)