### PR TITLE
BYOK: Add provideId static property to all providers

### DIFF
--- a/extensions/copilot/src/extension/byok/vscode-node/anthropicProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/anthropicProvider.ts
@@ -34,6 +34,7 @@ import { IBYOKStorageService } from './byokStorageService';
 export class AnthropicLMProvider extends AbstractLanguageModelChatProvider {
 
 	public static readonly providerName = 'Anthropic';
+	public static readonly providerId = this.providerName.toLowerCase();
 
 	constructor(
 		knownModels: BYOKKnownModels | undefined,
@@ -46,7 +47,7 @@ export class AnthropicLMProvider extends AbstractLanguageModelChatProvider {
 		@IOTelService private readonly _otelService: IOTelService,
 		@IToolDeferralService private readonly _toolDeferralService: IToolDeferralService,
 	) {
-		super(AnthropicLMProvider.providerName.toLowerCase(), AnthropicLMProvider.providerName, knownModels, byokStorageService, logService);
+		super(AnthropicLMProvider.providerId, AnthropicLMProvider.providerName, knownModels, byokStorageService, logService);
 
 	}
 
@@ -356,7 +357,7 @@ export class AnthropicLMProvider extends AbstractLanguageModelChatProvider {
 				// Record OTel metrics for this Anthropic LLM call
 				if (result.usage) {
 					const durationSec = (Date.now() - issuedTime) / 1000;
-					const metricAttrs = { operationName: GenAiOperationName.CHAT, providerName: 'anthropic', requestModel: model.id, responseModel: model.id };
+					const metricAttrs = { operationName: GenAiOperationName.CHAT, providerName: AnthropicLMProvider.providerId, requestModel: model.id, responseModel: model.id };
 					GenAiMetrics.recordOperationDuration(this._otelService, durationSec, metricAttrs);
 					if (result.usage.prompt_tokens) { GenAiMetrics.recordTokenUsage(this._otelService, result.usage.prompt_tokens, 'input', metricAttrs); }
 					if (result.usage.completion_tokens) { GenAiMetrics.recordTokenUsage(this._otelService, result.usage.completion_tokens, 'output', metricAttrs); }

--- a/extensions/copilot/src/extension/byok/vscode-node/azureProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/azureProvider.ts
@@ -47,7 +47,8 @@ export function resolveAzureUrl(modelId: string, url: string): string {
 
 export class AzureBYOKModelProvider extends AbstractCustomOAIBYOKModelProvider {
 
-	static readonly providerName = 'Azure';
+	public static readonly providerName = 'Azure';
+	public static readonly providerId = this.providerName.toLowerCase();
 
 	constructor(
 		byokStorageService: IBYOKStorageService,
@@ -59,7 +60,7 @@ export class AzureBYOKModelProvider extends AbstractCustomOAIBYOKModelProvider {
 		@IVSCodeExtensionContext extensionContext: IVSCodeExtensionContext
 	) {
 		super(
-			AzureBYOKModelProvider.providerName.toLowerCase(),
+			AzureBYOKModelProvider.providerId,
 			AzureBYOKModelProvider.providerName,
 			byokStorageService,
 			logService,

--- a/extensions/copilot/src/extension/byok/vscode-node/byokContribution.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/byokContribution.ts
@@ -74,8 +74,8 @@ export class BYOKContrib extends Disposable implements IExtensionContribution {
 			this._providers.set(AzureBYOKModelProvider.providerId, instantiationService.createInstance(AzureBYOKModelProvider, this._byokStorageService));
 			this._providers.set(CustomOAIBYOKModelProvider.providerId, instantiationService.createInstance(CustomOAIBYOKModelProvider, this._byokStorageService));
 
-			for (const [providerName, provider] of this._providers) {
-				this._byokRegistrations.add(lm.registerLanguageModelChatProvider(providerName, provider));
+			for (const [providerId, provider] of this._providers) {
+				this._byokRegistrations.add(lm.registerLanguageModelChatProvider(providerId, provider));
 			}
 			this._logService.info(`BYOK: registered ${this._providers.size} provider(s): ${Array.from(this._providers.keys()).join(', ')}`);
 		} else if (!this._byokProvidersRegistered) {

--- a/extensions/copilot/src/extension/byok/vscode-node/byokContribution.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/byokContribution.ts
@@ -65,14 +65,14 @@ export class BYOKContrib extends Disposable implements IExtensionContribution {
 			if (this._store.isDisposed) {
 				return;
 			}
-			this._providers.set(OllamaLMProvider.providerName.toLowerCase(), instantiationService.createInstance(OllamaLMProvider, this._byokStorageService));
-			this._providers.set(AnthropicLMProvider.providerName.toLowerCase(), instantiationService.createInstance(AnthropicLMProvider, knownModels[AnthropicLMProvider.providerName], this._byokStorageService));
-			this._providers.set(GeminiNativeBYOKLMProvider.providerName.toLowerCase(), instantiationService.createInstance(GeminiNativeBYOKLMProvider, knownModels[GeminiNativeBYOKLMProvider.providerName], this._byokStorageService));
-			this._providers.set(XAIBYOKLMProvider.providerName.toLowerCase(), instantiationService.createInstance(XAIBYOKLMProvider, knownModels[XAIBYOKLMProvider.providerName], this._byokStorageService));
-			this._providers.set(OAIBYOKLMProvider.providerName.toLowerCase(), instantiationService.createInstance(OAIBYOKLMProvider, knownModels[OAIBYOKLMProvider.providerName], this._byokStorageService));
-			this._providers.set(OpenRouterLMProvider.providerName.toLowerCase(), instantiationService.createInstance(OpenRouterLMProvider, this._byokStorageService));
-			this._providers.set(AzureBYOKModelProvider.providerName.toLowerCase(), instantiationService.createInstance(AzureBYOKModelProvider, this._byokStorageService));
-			this._providers.set(CustomOAIBYOKModelProvider.providerName.toLowerCase(), instantiationService.createInstance(CustomOAIBYOKModelProvider, this._byokStorageService));
+			this._providers.set(OllamaLMProvider.providerId, instantiationService.createInstance(OllamaLMProvider, this._byokStorageService));
+			this._providers.set(AnthropicLMProvider.providerId, instantiationService.createInstance(AnthropicLMProvider, knownModels[AnthropicLMProvider.providerName], this._byokStorageService));
+			this._providers.set(GeminiNativeBYOKLMProvider.providerId, instantiationService.createInstance(GeminiNativeBYOKLMProvider, knownModels[GeminiNativeBYOKLMProvider.providerName], this._byokStorageService));
+			this._providers.set(XAIBYOKLMProvider.providerId, instantiationService.createInstance(XAIBYOKLMProvider, knownModels[XAIBYOKLMProvider.providerName], this._byokStorageService));
+			this._providers.set(OAIBYOKLMProvider.providerId, instantiationService.createInstance(OAIBYOKLMProvider, knownModels[OAIBYOKLMProvider.providerName], this._byokStorageService));
+			this._providers.set(OpenRouterLMProvider.providerId, instantiationService.createInstance(OpenRouterLMProvider, this._byokStorageService));
+			this._providers.set(AzureBYOKModelProvider.providerId, instantiationService.createInstance(AzureBYOKModelProvider, this._byokStorageService));
+			this._providers.set(CustomOAIBYOKModelProvider.providerId, instantiationService.createInstance(CustomOAIBYOKModelProvider, this._byokStorageService));
 
 			for (const [providerName, provider] of this._providers) {
 				this._byokRegistrations.add(lm.registerLanguageModelChatProvider(providerName, provider));

--- a/extensions/copilot/src/extension/byok/vscode-node/customOAIProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/customOAIProvider.ts
@@ -163,8 +163,8 @@ export abstract class AbstractCustomOAIBYOKModelProvider extends AbstractOpenAIC
 
 export class CustomOAIBYOKModelProvider extends AbstractCustomOAIBYOKModelProvider {
 
-	static readonly providerName: string = 'CustomOAI';
-	private providerName: string = CustomOAIBYOKModelProvider.providerName;
+	public static readonly providerName = 'CustomOAI';
+	public static readonly providerId = this.providerName.toLowerCase();
 
 	constructor(
 		_byokStorageService: IBYOKStorageService,
@@ -175,13 +175,13 @@ export class CustomOAIBYOKModelProvider extends AbstractCustomOAIBYOKModelProvid
 		@IExperimentationService expService: IExperimentationService,
 		@IVSCodeExtensionContext extensionContext: IVSCodeExtensionContext
 	) {
-		super(CustomOAIBYOKModelProvider.providerName.toLowerCase(), CustomOAIBYOKModelProvider.providerName, _byokStorageService, logService, fetcherService, instantiationService, configurationService, expService, extensionContext);
+		super(CustomOAIBYOKModelProvider.providerId, CustomOAIBYOKModelProvider.providerName, _byokStorageService, logService, fetcherService, instantiationService, configurationService, expService, extensionContext);
 		this.migrateExistingConfigs();
 	}
 
 	// TODO: Remove this after 6 months
 	private async migrateExistingConfigs(): Promise<void> {
-		await this.migrateConfig(ConfigKey.Deprecated.CustomOAIModels, this.providerName, this.providerName);
+		await this.migrateConfig(ConfigKey.Deprecated.CustomOAIModels, CustomOAIBYOKModelProvider.providerName, CustomOAIBYOKModelProvider.providerName);
 	}
 
 	protected resolveUrl(modelId: string, url: string): string {

--- a/extensions/copilot/src/extension/byok/vscode-node/geminiNativeProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/geminiNativeProvider.ts
@@ -26,6 +26,7 @@ import { IBYOKStorageService } from './byokStorageService';
 export class GeminiNativeBYOKLMProvider extends AbstractLanguageModelChatProvider {
 
 	public static readonly providerName = 'Gemini';
+	public static readonly providerId = this.providerName.toLowerCase();
 
 	constructor(
 		knownModels: BYOKKnownModels | undefined,
@@ -35,7 +36,7 @@ export class GeminiNativeBYOKLMProvider extends AbstractLanguageModelChatProvide
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 		@IOTelService private readonly _otelService: IOTelService,
 	) {
-		super(GeminiNativeBYOKLMProvider.providerName.toLowerCase(), GeminiNativeBYOKLMProvider.providerName, knownModels, byokStorageService, logService);
+		super(GeminiNativeBYOKLMProvider.providerId, GeminiNativeBYOKLMProvider.providerName, knownModels, byokStorageService, logService);
 	}
 
 	protected async getAllModels(silent: boolean, apiKey: string | undefined): Promise<ExtendedLanguageModelChatInformation<LanguageModelChatConfiguration>[]> {

--- a/extensions/copilot/src/extension/byok/vscode-node/ollamaProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/ollamaProvider.ts
@@ -38,7 +38,10 @@ export interface OllamaConfig extends LanguageModelChatConfiguration {
 }
 
 export class OllamaLMProvider extends AbstractOpenAICompatibleLMProvider<OllamaConfig> {
+
 	public static readonly providerName = 'Ollama';
+	public static readonly providerId = this.providerName.toLowerCase();
+
 	private _modelCache = new Map<string, IChatModelInformation>();
 
 	constructor(
@@ -50,7 +53,7 @@ export class OllamaLMProvider extends AbstractOpenAICompatibleLMProvider<OllamaC
 		@IExperimentationService expService: IExperimentationService
 	) {
 		super(
-			OllamaLMProvider.providerName.toLowerCase(),
+			OllamaLMProvider.providerId,
 			OllamaLMProvider.providerName,
 			undefined,
 			byokStorageService,

--- a/extensions/copilot/src/extension/byok/vscode-node/openAIProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/openAIProvider.ts
@@ -13,7 +13,9 @@ import { AbstractOpenAICompatibleLMProvider } from './abstractLanguageModelChatP
 import { IBYOKStorageService } from './byokStorageService';
 
 export class OAIBYOKLMProvider extends AbstractOpenAICompatibleLMProvider {
+
 	public static readonly providerName = 'OpenAI';
+	public static readonly providerId = this.providerName.toLowerCase();
 
 	constructor(
 		knownModels: BYOKKnownModels,
@@ -25,7 +27,7 @@ export class OAIBYOKLMProvider extends AbstractOpenAICompatibleLMProvider {
 		@IExperimentationService expService: IExperimentationService
 	) {
 		super(
-			OAIBYOKLMProvider.providerName.toLowerCase(),
+			OAIBYOKLMProvider.providerId,
 			OAIBYOKLMProvider.providerName,
 			knownModels,
 			byokStorageService,

--- a/extensions/copilot/src/extension/byok/vscode-node/openRouterProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/openRouterProvider.ts
@@ -31,7 +31,10 @@ interface OpenRouterModelData {
 }
 
 export class OpenRouterLMProvider extends AbstractOpenAICompatibleLMProvider {
+
 	public static readonly providerName = 'OpenRouter';
+	public static readonly providerId = this.providerName.toLowerCase();
+
 	constructor(
 		byokStorageService: IBYOKStorageService,
 		@IFetcherService fetcherService: IFetcherService,
@@ -41,7 +44,7 @@ export class OpenRouterLMProvider extends AbstractOpenAICompatibleLMProvider {
 		@IExperimentationService expService: IExperimentationService
 	) {
 		super(
-			OpenRouterLMProvider.providerName.toLowerCase(),
+			OpenRouterLMProvider.providerId,
 			OpenRouterLMProvider.providerName,
 			undefined,
 			byokStorageService,

--- a/extensions/copilot/src/extension/byok/vscode-node/xAIProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/xAIProvider.ts
@@ -32,6 +32,7 @@ interface XAIModelData {
 export class XAIBYOKLMProvider extends AbstractOpenAICompatibleLMProvider {
 
 	public static readonly providerName = 'xAI';
+	public static readonly providerId = this.providerName.toLowerCase();
 
 	constructor(
 		knownModels: BYOKKnownModels,
@@ -43,7 +44,7 @@ export class XAIBYOKLMProvider extends AbstractOpenAICompatibleLMProvider {
 		@IExperimentationService expService: IExperimentationService
 	) {
 		super(
-			XAIBYOKLMProvider.providerName.toLowerCase(),
+			XAIBYOKLMProvider.providerId,
 			XAIBYOKLMProvider.providerName,
 			knownModels,
 			byokStorageService,


### PR DESCRIPTION
Introduce and reuse `providerId` static property on all BYOK providers.

(in preparation for auth-less BYOK implementation)
