### PR TITLE
Add borders for agents new session button and chat input in light theme

### DIFF
--- a/extensions/theme-defaults/themes/light_vs.json
+++ b/extensions/theme-defaults/themes/light_vs.json
@@ -34,7 +34,9 @@
 		"terminal.inactiveSelectionBackground": "#E5EBF1",
 		"widget.border": "#d4d4d4",
 		"actionBar.toggledBackground": "#dddddd",
-		"diffEditor.unchangedRegionBackground": "#f8f8f8"
+		"diffEditor.unchangedRegionBackground": "#f8f8f8",
+		"agentsNewSessionButton.border": "#D8D8D8",
+		"agentsChatInput.border": "#D8D8D8"
 	},
 	"tokenColors": [
 		{


### PR DESCRIPTION
Introduce borders for the agents new session button and chat input in the light theme to enhance visual clarity.

Addresses: #314950

<img width="1552" height="1131" alt="image" src="https://github.com/user-attachments/assets/8e320172-c7f1-409e-9aa2-33f392eb330a" />
