### PR TITLE
Fix gap between radio buttons in tabbed action list

### DIFF
--- a/src/vs/platform/actionWidget/browser/tabbedActionListWidget.css
+++ b/src/vs/platform/actionWidget/browser/tabbedActionListWidget.css
@@ -15,7 +15,7 @@
 
 .action-widget .tabbed-action-list-tabbar .monaco-custom-radio {
 	width: 100%;
-	gap: 8px;
+	gap: 4px;
 }
 
 .action-widget .tabbed-action-list-tabbar .monaco-custom-radio > .monaco-button {


### PR DESCRIPTION
Reduce the gap between radio buttons in the tabbed action list for improved visual alignment. Test the changes by reviewing the appearance of the radio buttons in the action widget.

