### PR TITLE
Disable unsupported built-in extensions in sessions window

### DIFF
--- a/src/vs/workbench/services/extensionManagement/browser/extensionEnablementService.ts
+++ b/src/vs/workbench/services/extensionManagement/browser/extensionEnablementService.ts
@@ -638,8 +638,17 @@ export class ExtensionEnablementService extends Disposable implements IWorkbench
 			return false;
 		}
 
-		// Built-in extensions are always enabled in the sessions window.
+		// Built-in extensions are enabled in sessions window except the chat extension and extensions that contribute not supported features.
 		if (extension.isBuiltin) {
+			if (extension.identifier.id.toLowerCase() === this._chatExtensionId) {
+				return false;
+			}
+
+			const contributes = extension.manifest.contributes;
+			if (contributes?.debuggers || contributes?.views || contributes?.viewsContainers || contributes?.walkthroughs) {
+				return true;
+			}
+
 			return false;
 		}
 


### PR DESCRIPTION
```Copilot Generated Description:``` Disable built-in extensions that contribute unsupported features in the sessions window, specifically excluding the chat extension.

