### PR TITLE
Refine action list style and add detailItemHeight option

### DIFF
--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -480,6 +480,12 @@ export interface IActionListOptions {
 	readonly inlineDescription?: boolean;
 
 	/**
+	 * Height (in px) used for action items that have a `detail` line.
+	 * Defaults to 48.
+	 */
+	readonly detailItemHeight?: number;
+
+	/**
 	 * When true, the group title is shown on the first item of each group
 	 * in the description area (aligned to the right).
 	 */
@@ -983,7 +989,7 @@ export class ActionListWidget<T> extends Disposable {
 			case ActionListItemKind.Separator:
 				return this._separatorLineHeight;
 			default:
-				return item.detail ? 48 : this._actionLineHeight;
+				return item.detail ? (this._options?.detailItemHeight ?? 48) : this._actionLineHeight;
 		}
 	}
 

--- a/src/vs/platform/actionWidget/browser/actionWidget.css
+++ b/src/vs/platform/actionWidget/browser/actionWidget.css
@@ -55,7 +55,7 @@
 
 /** Styles for each row in the list element **/
 .action-widget .monaco-list .monaco-list-row {
-	padding: 0 12px 0 8px;
+	padding: 0 12px 0 6px;
 	white-space: nowrap;
 	cursor: pointer;
 	touch-action: none;

--- a/src/vs/platform/actionWidget/browser/actionWidget.css
+++ b/src/vs/platform/actionWidget/browser/actionWidget.css
@@ -151,7 +151,7 @@
 .action-widget .monaco-list-row.action .detail {
 	order: 99;
 	width: 100%;
-	padding-left: 20px;
+	padding-left: 18px;
 	font-size: 11px;
 	line-height: 14px;
 	color: var(--vscode-descriptionForeground);
@@ -242,8 +242,7 @@
 	&:has(.detail:not([style*="display: none"])) {
 		flex-wrap: wrap;
 		align-content: center;
-		padding-top: 6px;
-		padding-right: 2px;
+		padding-right: 6px;
 
 		.title {
 			line-height: 14px;

--- a/src/vs/sessions/contrib/changes/browser/changesView.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesView.ts
@@ -1352,7 +1352,7 @@ class ChangesPickerActionItem extends ActionWidgetDropdownActionViewItem {
 			},
 		};
 
-		super(action, { actionProvider, listOptions: {} }, actionWidgetService, keybindingService, contextKeyService, telemetryService);
+		super(action, { actionProvider, listOptions: { detailItemHeight: 44 } }, actionWidgetService, keybindingService, contextKeyService, telemetryService);
 
 		this._register(autorun(reader => {
 			viewModel.versionModeObs.read(reader);

--- a/src/vs/workbench/contrib/chat/browser/widget/input/permissionPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/permissionPickerActionItem.ts
@@ -283,7 +283,7 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 				}
 			}],
 			reporter: { id: 'ChatPermissionPicker', name: 'ChatPermissionPicker', includeOptions: true },
-			listOptions: { minWidth: 255 },
+			listOptions: { minWidth: 255, detailItemHeight: 44 },
 		}, pickerOptions, actionWidgetService, keybindingService, contextKeyService, telemetryService);
 	}
 


### PR DESCRIPTION
This pull request introduces improvements to the action widget's appearance and configurability, focusing on the layout and sizing of action items, especially those with detail lines. The main changes include making the detail item height customizable, updating default paddings, and applying these new options in the changes view.

**Customization and Layout Enhancements:**

* Added a new `detailItemHeight` option to the `IActionListOptions` interface, allowing the height for action items with a `detail` line to be customized (defaulting to 48px). (`src/vs/platform/actionWidget/browser/actionList.ts`)
* Updated the `ActionListWidget` to use the new `detailItemHeight` option when calculating item heights, enabling per-instance customization. (`src/vs/platform/actionWidget/browser/actionList.ts`)
* Applied the `detailItemHeight: 44` setting to the changes picker action item in the changes view, providing a more compact appearance for items with details. (`src/vs/sessions/contrib/changes/browser/changesView.ts`)

**Visual and Spacing Adjustments:**

* Reduced left padding for action widget list rows from 8px to 6px for a slightly tighter layout. (`src/vs/platform/actionWidget/browser/actionWidget.css`)
* Adjusted left padding for `.detail` elements from 20px to 18px, and tweaked group row padding to improve alignment and spacing. (`src/vs/platform/actionWidget/browser/actionWidget.css`) [[1]](diffhunk://#diff-ccde3eafe6f1bdf6802118d065818be5cada627f294ffad4af8696cb16015b90L154-R154) [[2]](diffhunk://#diff-ccde3eafe6f1bdf6802118d065818be5cada627f294ffad4af8696cb16015b90L245-R245)

Addresses: https://github.com/microsoft/vscode/issues/314487