### PR TITLE
Strip leading `<think>` blocks from cursor jump model output

### DIFF
--- a/extensions/copilot/src/extension/xtab/node/xtabNextCursorPredictor.ts
+++ b/extensions/copilot/src/extension/xtab/node/xtabNextCursorPredictor.ts
@@ -324,18 +324,16 @@ export class XtabNextCursorPredictor {
 }
 
 /**
- * Strip a leading `<think>...</think>` reasoning block emitted by thinking
- * models. Returns the input trimmed if there is no leading think block.
+ * Strip `<think>...</think>` reasoning blocks emitted by thinking models.
+ * Mirrors the post-processing logic specified by the model owners: remove
+ * any complete think blocks, and drop any unterminated leading `<think>`
+ * (which can happen when generation hits the max tokens limit).
  */
-export function stripThinkTags(text: string): string {
-	const leading = text.trimStart();
-	if (!leading.startsWith('<think>')) {
-		return text.trim();
+function stripThinkTags(text: string): string {
+	let result = text.replace(/<think>[\s\S]*?<\/think>\s*/g, '');
+	if (result.trimStart().startsWith('<think>')) {
+		result = '';
 	}
-	const closeIdx = leading.indexOf('</think>');
-	if (closeIdx === -1) {
-		return text.trim();
-	}
-	return leading.substring(closeIdx + '</think>'.length).trim();
+	return result.trim();
 }
 

--- a/extensions/copilot/src/extension/xtab/node/xtabNextCursorPredictor.ts
+++ b/extensions/copilot/src/extension/xtab/node/xtabNextCursorPredictor.ts
@@ -282,7 +282,9 @@ export class XtabNextCursorPredictor {
 		return DEFAULT_CURSOR_PREDICTION_LINT_OPTIONS;
 	}
 
-	public parseResponse(trimmed: string, keptRange: OffsetRange): Result<CursorJumpPrediction, Error> {
+	public parseResponse(rawResponse: string, keptRange: OffsetRange): Result<CursorJumpPrediction, Error> {
+		const trimmed = stripThinkTags(rawResponse);
+
 		// Try parsing as a plain line number (same-file jump)
 		const lineNumber = parseInt(trimmed, 10);
 		if (!isNaN(lineNumber) && String(lineNumber) === trimmed) {
@@ -319,5 +321,21 @@ export class XtabNextCursorPredictor {
 		}
 		return Result.ok({ kind: 'sameFile', lineNumber });
 	}
+}
+
+/**
+ * Strip a leading `<think>...</think>` reasoning block emitted by thinking
+ * models. Returns the input trimmed if there is no leading think block.
+ */
+export function stripThinkTags(text: string): string {
+	const leading = text.trimStart();
+	if (!leading.startsWith('<think>')) {
+		return text.trim();
+	}
+	const closeIdx = leading.indexOf('</think>');
+	if (closeIdx === -1) {
+		return text.trim();
+	}
+	return leading.substring(closeIdx + '</think>'.length).trim();
 }
 

--- a/extensions/copilot/src/extension/xtab/test/node/xtabNextCursorPredictor.spec.ts
+++ b/extensions/copilot/src/extension/xtab/test/node/xtabNextCursorPredictor.spec.ts
@@ -338,6 +338,35 @@ describe('XtabNextCursorPredictor', () => {
 				expect(result.val).toEqual({ kind: 'differentFile', filePath: 'src/file.ts', lineNumber: 0 });
 			}
 		});
+
+		it('should strip empty think tags before a same-file line number', () => {
+			const result = predictor.parseResponse('<think>\n\n</think>\n\n10', keptRange);
+			expect(result.isOk()).toBe(true);
+			if (result.isOk()) {
+				expect(result.val).toEqual({ kind: 'sameFile', lineNumber: 10 });
+			}
+		});
+
+		it('should strip think tags with reasoning content before a same-file line number', () => {
+			const result = predictor.parseResponse('<think>some reasoning\nacross lines</think>\n42', keptRange);
+			expect(result.isOk()).toBe(true);
+			if (result.isOk()) {
+				expect(result.val).toEqual({ kind: 'sameFile', lineNumber: 42 });
+			}
+		});
+
+		it('should strip think tags before a cross-file path', () => {
+			const result = predictor.parseResponse('<think>\n\n</think>\nsrc/utils/helpers.ts:42', keptRange);
+			expect(result.isOk()).toBe(true);
+			if (result.isOk()) {
+				expect(result.val).toEqual({ kind: 'differentFile', filePath: 'src/utils/helpers.ts', lineNumber: 42 });
+			}
+		});
+
+		it('should treat unterminated leading think tag as empty output', () => {
+			const result = predictor.parseResponse('<think>truncated reasoning never closed', keptRange);
+			expect(result.isError()).toBe(true);
+		});
 	});
 
 	describe('supportsNextCursorLinePrediction', () => {

--- a/extensions/copilot/src/extension/xtab/test/node/xtabNextCursorPredictor.spec.ts
+++ b/extensions/copilot/src/extension/xtab/test/node/xtabNextCursorPredictor.spec.ts
@@ -363,9 +363,12 @@ describe('XtabNextCursorPredictor', () => {
 			}
 		});
 
-		it('should treat unterminated leading think tag as empty output', () => {
+		it('should not strip an unterminated leading think tag and should fail to parse', () => {
 			const result = predictor.parseResponse('<think>truncated reasoning never closed', keptRange);
 			expect(result.isError()).toBe(true);
+			if (result.isError()) {
+				expect(result.err.message).toContain('gotNaN');
+			}
 		});
 	});
 


### PR DESCRIPTION
Newer cursor jump models can emit `<think>...</think>` reasoning blocks (often empty) even when thinking is disabled, e.g. `<think>\n\n</think>\n\n10` instead of `10`. This breaks the existing line-number / `path:line` parser.

Strip such blocks before parsing, mirroring the post-processing logic specified by the model owners in microsoft/vscode-internalbacklog#7619:

- Remove any complete `<think>...</think>` blocks.
- Drop any unterminated leading `<think>` (which can happen when generation hits the max tokens limit before the closing tag) and treat the response as empty.

Fixes microsoft/vscode-internalbacklog#7619