### PR TITLE
chore: cleanup sub application from sanity test pipeline

### DIFF
--- a/test/sanity/src/context.ts
+++ b/test/sanity/src/context.ts
@@ -990,60 +990,6 @@ export class TestContext {
 	}
 
 	/**
-	 * Validates that the Agents app binary exists in the specified installation directory.
-	 * @param dir The directory of the VS Code installation.
-	 * @returns The path to the Agents entry point executable.
-	 */
-	public validateAgentsEntryPoint(dir: string): void {
-		let filePath: string = '';
-
-		switch (os.platform()) {
-			case 'darwin': {
-				let appName: string;
-				let agentsAppName: string;
-				switch (this.options.quality) {
-					case 'stable':
-						// Agents app is not included in stable yet.
-						// appName = 'Visual Studio Code.app';
-						// agentsAppName = 'Visual Studio Code Agents.app';
-						return;
-					case 'insider':
-						appName = 'Visual Studio Code - Insiders.app';
-						agentsAppName = 'Visual Studio Code Agents - Insiders.app';
-						break;
-					case 'exploration':
-						appName = 'Visual Studio Code - Exploration.app';
-						agentsAppName = 'Visual Studio Code Agents - Exploration.app';
-						break;
-				}
-				filePath = path.join(dir, appName, 'Contents', 'Applications', agentsAppName);
-				break;
-			}
-			case 'win32': {
-				let exeName: string;
-				switch (this.options.quality) {
-					case 'stable':
-						// Agents app is not included in stable yet.
-						// exeName = 'Agents.exe';
-						return;
-					case 'insider':
-						exeName = 'Agents - Insiders.exe';
-						break;
-					case 'exploration':
-						exeName = 'Agents - Exploration.exe';
-						break;
-				}
-				filePath = path.join(dir, exeName);
-				break;
-			}
-		}
-
-		if (!filePath || !fs.existsSync(filePath)) {
-			this.error(`Agents entry point does not exist: ${filePath}`);
-		}
-	}
-
-	/**
 	 * Returns the entry point executable for the VS Code CLI in the specified directory.
 	 * @param dir The directory containing unpacked CLI files.
 	 * @returns The path to the CLI entry point executable.

--- a/test/sanity/src/desktop.test.ts
+++ b/test/sanity/src/desktop.test.ts
@@ -12,7 +12,6 @@ export function setup(context: TestContext) {
 	context.test('desktop-darwin-x64', ['darwin', 'x64', 'desktop'], async () => {
 		const dir = await context.downloadAndUnpack('darwin');
 		context.validateAllCodesignSignatures(dir);
-		context.validateAgentsEntryPoint(dir);
 		if (!context.options.downloadOnly) {
 			const entryPoint = context.getDesktopEntryPoint(dir);
 			await testDesktopApp(entryPoint);
@@ -23,7 +22,6 @@ export function setup(context: TestContext) {
 	context.test('desktop-darwin-arm64', ['darwin', 'arm64', 'desktop'], async () => {
 		const dir = await context.downloadAndUnpack('darwin-arm64');
 		context.validateAllCodesignSignatures(dir);
-		context.validateAgentsEntryPoint(dir);
 		if (!context.options.downloadOnly) {
 			const entryPoint = context.getDesktopEntryPoint(dir);
 			await testDesktopApp(entryPoint);
@@ -34,7 +32,6 @@ export function setup(context: TestContext) {
 	context.test('desktop-darwin-universal', ['darwin', 'desktop'], async () => {
 		const dir = await context.downloadAndUnpack('darwin-universal');
 		context.validateAllCodesignSignatures(dir);
-		context.validateAgentsEntryPoint(dir);
 		if (!context.options.downloadOnly) {
 			const entryPoint = context.getDesktopEntryPoint(dir);
 			await testDesktopApp(entryPoint);
@@ -48,7 +45,6 @@ export function setup(context: TestContext) {
 		if (!context.options.downloadOnly) {
 			const dir = context.mountDmg(packagePath);
 			context.validateAllCodesignSignatures(dir);
-			context.validateAgentsEntryPoint(dir);
 			const entryPoint = context.getDesktopEntryPoint(dir);
 			await testDesktopApp(entryPoint);
 			await testAgentsApp(entryPoint);
@@ -62,7 +58,6 @@ export function setup(context: TestContext) {
 		if (!context.options.downloadOnly) {
 			const dir = context.mountDmg(packagePath);
 			context.validateAllCodesignSignatures(dir);
-			context.validateAgentsEntryPoint(dir);
 			const entryPoint = context.getDesktopEntryPoint(dir);
 			await testDesktopApp(entryPoint);
 			await testAgentsApp(entryPoint);
@@ -76,7 +71,6 @@ export function setup(context: TestContext) {
 		if (!context.options.downloadOnly) {
 			const dir = context.mountDmg(packagePath);
 			context.validateAllCodesignSignatures(dir);
-			context.validateAgentsEntryPoint(dir);
 			const entryPoint = context.getDesktopEntryPoint(dir);
 			await testDesktopApp(entryPoint);
 			await testAgentsApp(entryPoint);
@@ -185,7 +179,6 @@ export function setup(context: TestContext) {
 			const entryPoint = context.installWindowsApp('system', packagePath);
 			context.validateAllAuthenticodeSignatures(path.dirname(entryPoint));
 			context.validateAllVersionInfo(path.dirname(entryPoint));
-			context.validateAgentsEntryPoint(path.dirname(entryPoint));
 			await testDesktopApp(entryPoint);
 			await testAgentsApp(entryPoint);
 			await context.uninstallWindowsApp('system');
@@ -196,7 +189,6 @@ export function setup(context: TestContext) {
 		const dir = await context.downloadAndUnpack('win32-arm64-archive');
 		context.validateAllAuthenticodeSignatures(dir);
 		context.validateAllVersionInfo(dir);
-		context.validateAgentsEntryPoint(dir);
 		if (!context.options.downloadOnly) {
 			const entryPoint = context.getDesktopEntryPoint(dir);
 			const dataDir = context.createPortableDataDir(dir);
@@ -213,7 +205,6 @@ export function setup(context: TestContext) {
 			const entryPoint = context.installWindowsApp('user', packagePath);
 			context.validateAllAuthenticodeSignatures(path.dirname(entryPoint));
 			context.validateAllVersionInfo(path.dirname(entryPoint));
-			context.validateAgentsEntryPoint(path.dirname(entryPoint));
 			await testDesktopApp(entryPoint);
 			await testAgentsApp(entryPoint);
 			await context.uninstallWindowsApp('user');
@@ -228,7 +219,6 @@ export function setup(context: TestContext) {
 			const entryPoint = context.installWindowsApp('system', packagePath);
 			context.validateAllAuthenticodeSignatures(path.dirname(entryPoint));
 			context.validateAllVersionInfo(path.dirname(entryPoint));
-			context.validateAgentsEntryPoint(path.dirname(entryPoint));
 			await testDesktopApp(entryPoint);
 			await testAgentsApp(entryPoint);
 			await context.uninstallWindowsApp('system');
@@ -239,7 +229,6 @@ export function setup(context: TestContext) {
 		const dir = await context.downloadAndUnpack('win32-x64-archive');
 		context.validateAllAuthenticodeSignatures(dir);
 		context.validateAllVersionInfo(dir);
-		context.validateAgentsEntryPoint(dir);
 		if (!context.options.downloadOnly) {
 			const entryPoint = context.getDesktopEntryPoint(dir);
 			const dataDir = context.createPortableDataDir(dir);
@@ -256,7 +245,6 @@ export function setup(context: TestContext) {
 			const entryPoint = context.installWindowsApp('user', packagePath);
 			context.validateAllAuthenticodeSignatures(path.dirname(entryPoint));
 			context.validateAllVersionInfo(path.dirname(entryPoint));
-			context.validateAgentsEntryPoint(path.dirname(entryPoint));
 			await testDesktopApp(entryPoint);
 			await testAgentsApp(entryPoint);
 			await context.uninstallWindowsApp('user');
@@ -286,7 +274,7 @@ export function setup(context: TestContext) {
 
 	async function testAgentsApp(desktopEntryPoint: string, dataDir?: string) {
 		if (context.options.quality === 'stable') {
-			// Agents app is not included in stable builds yet.
+			// Agents window is not included in stable builds yet.
 			return;
 		}
 


### PR DESCRIPTION
Followup to https://github.com/microsoft/vscode/pull/314409

Refs https://monacotools.visualstudio.com/Monaco/_build/results?buildId=437007&view=results

Tests for `--agents` path is still kept around as it remains valid, there is just no app entrypoint.

cc @dmitrivMS 