### PR TITLE
Support workspace settings in Agents window

### DIFF
--- a/src/vs/platform/workspace/common/workspace.ts
+++ b/src/vs/platform/workspace/common/workspace.ts
@@ -287,6 +287,13 @@ export interface IWorkspace {
 	 */
 	readonly configuration?: URI | null;
 
+	/**
+	 * Optional display name for the workspace. When set, this
+	 * name is used by the label service instead of deriving a
+	 * name from the configuration path.
+	 */
+	readonly name?: string;
+
 }
 
 export function isWorkspace(thing: unknown): thing is IWorkspace {
@@ -350,6 +357,7 @@ export class Workspace implements IWorkspace {
 		private _transient: boolean,
 		private _configuration: URI | null,
 		private ignorePathCasing: (key: URI) => boolean,
+		private _workspaceName?: string,
 	) {
 		this.foldersMap = TernarySearchTree.forUris<WorkspaceFolder>(this.ignorePathCasing, () => true);
 		this.folders = folders;
@@ -359,6 +367,7 @@ export class Workspace implements IWorkspace {
 		this._id = workspace.id;
 		this._configuration = workspace.configuration;
 		this._transient = workspace.transient;
+		this._workspaceName = workspace.name;
 		this.ignorePathCasing = workspace.ignorePathCasing;
 		this.folders = workspace.folders;
 	}
@@ -379,6 +388,10 @@ export class Workspace implements IWorkspace {
 		this._configuration = configuration;
 	}
 
+	get name(): string | undefined {
+		return this._workspaceName;
+	}
+
 	getFolder(resource: URI): IWorkspaceFolder | null {
 		if (!resource) {
 			return null;
@@ -395,7 +408,7 @@ export class Workspace implements IWorkspace {
 	}
 
 	toJSON(): IWorkspace {
-		return { id: this.id, folders: this.folders, transient: this.transient, configuration: this.configuration };
+		return { id: this.id, folders: this.folders, transient: this.transient, configuration: this.configuration, name: this.name };
 	}
 }
 

--- a/src/vs/platform/workspace/common/workspace.ts
+++ b/src/vs/platform/workspace/common/workspace.ts
@@ -288,9 +288,7 @@ export interface IWorkspace {
 	readonly configuration?: URI | null;
 
 	/**
-	 * Optional display name for the workspace. When set, this
-	 * name is used by the label service instead of deriving a
-	 * name from the configuration path.
+	 * Optional display name for the workspace.
 	 */
 	readonly name?: string;
 

--- a/src/vs/sessions/services/configuration/browser/configurationService.ts
+++ b/src/vs/sessions/services/configuration/browser/configurationService.ts
@@ -8,7 +8,7 @@ import { Emitter, Event } from '../../../../base/common/event.js';
 import { Disposable, DisposableMap } from '../../../../base/common/lifecycle.js';
 import { ResourceMap } from '../../../../base/common/map.js';
 import { URI } from '../../../../base/common/uri.js';
-import { Queue } from '../../../../base/common/async.js';
+import { Promises, Queue } from '../../../../base/common/async.js';
 import { VSBuffer } from '../../../../base/common/buffer.js';
 import { JSONPath, ParseError, parse } from '../../../../base/common/json.js';
 import { applyEdits, setProperty } from '../../../../base/common/jsonEdit.js';
@@ -158,6 +158,7 @@ export class ConfigurationService extends Disposable implements IWorkbenchConfig
 		const overrides: IConfigurationUpdateOverrides | undefined = isConfigurationUpdateOverrides(arg3) ? arg3
 			: isConfigurationOverrides(arg3) ? { resource: arg3.resource, overrideIdentifiers: arg3.overrideIdentifier ? [arg3.overrideIdentifier] : undefined } : undefined;
 		const target: ConfigurationTarget | undefined = (overrides ? arg4 : arg3) as ConfigurationTarget | undefined;
+		const targets: ConfigurationTarget[] = target ? [target] : [];
 
 		if (overrides?.overrideIdentifiers) {
 			overrides.overrideIdentifiers = distinct(overrides.overrideIdentifiers);
@@ -173,9 +174,13 @@ export class ConfigurationService extends Disposable implements IWorkbenchConfig
 			throw new Error(`Unable to write ${key} because it is read-only in the Agents window.`);
 		}
 
-		// Remove the setting, if the value is same as default value
-		if (equals(value, inspect.defaultValue)) {
-			value = undefined;
+		if (!targets.length) {
+			targets.push(...this.deriveConfigurationTargets(key, value, inspect));
+
+			// Remove the setting, if the value is same as default value and is updated only in user target
+			if (equals(value, inspect.defaultValue) && targets.length === 1 && targets[0] === ConfigurationTarget.USER) {
+				value = undefined;
+			}
 		}
 
 		if (overrides?.overrideIdentifiers?.length && overrides.overrideIdentifiers.length > 1) {
@@ -186,6 +191,10 @@ export class ConfigurationService extends Disposable implements IWorkbenchConfig
 			}
 		}
 
+		await Promises.settled(targets.map(t => this.writeConfigurationValue(key, value, t, overrides)));
+	}
+
+	private async writeConfigurationValue(key: string, value: unknown, target: ConfigurationTarget, overrides: IConfigurationUpdateOverrides | undefined): Promise<void> {
 		let path = overrides?.overrideIdentifiers?.length ? [keyFromOverrideIdentifiers(overrides.overrideIdentifiers), key] : [key];
 
 		const settingsResource = this.getSettingsResource(target, overrides?.resource ?? undefined);
@@ -197,6 +206,30 @@ export class ConfigurationService extends Disposable implements IWorkbenchConfig
 
 		await this.configurationEditing.write(settingsResource, path, value);
 		await this.reloadConfiguration();
+	}
+
+	private deriveConfigurationTargets(_key: string, value: unknown, inspect: IConfigurationValue<unknown>): ConfigurationTarget[] {
+		if (equals(value, inspect.value)) {
+			return [];
+		}
+
+		const definedTargets: ConfigurationTarget[] = [];
+		if (inspect.workspaceFolderValue !== undefined) {
+			definedTargets.push(ConfigurationTarget.WORKSPACE_FOLDER);
+		}
+		if (inspect.workspaceValue !== undefined) {
+			definedTargets.push(ConfigurationTarget.WORKSPACE);
+		}
+		if (inspect.userValue !== undefined) {
+			definedTargets.push(ConfigurationTarget.USER);
+		}
+
+		if (value === undefined) {
+			// Remove the setting in all defined targets
+			return definedTargets;
+		}
+
+		return [definedTargets[0] || ConfigurationTarget.USER];
 	}
 
 	private isWorkspaceConfigurationResource(resource: URI): boolean {

--- a/src/vs/sessions/services/configuration/browser/configurationService.ts
+++ b/src/vs/sessions/services/configuration/browser/configurationService.ts
@@ -26,7 +26,7 @@ import { IPolicyService, NullPolicyService } from '../../../../platform/policy/c
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
 import { IWorkspaceContextService, IWorkspaceFoldersChangeEvent, IWorkspaceFolder, WorkbenchState, Workspace } from '../../../../platform/workspace/common/workspace.js';
-import { FolderConfiguration, UserConfiguration } from '../../../../workbench/services/configuration/browser/configuration.js';
+import { FolderConfiguration, UserConfiguration, WorkspaceConfiguration } from '../../../../workbench/services/configuration/browser/configuration.js';
 import { APPLICATION_SCOPES, APPLY_ALL_PROFILES_SETTING, FOLDER_CONFIG_FOLDER_NAME, FOLDER_SETTINGS_PATH, IWorkbenchConfigurationService, RestrictedSettings } from '../../../../workbench/services/configuration/common/configuration.js';
 import { Configuration } from '../../../../workbench/services/configuration/common/configurationModels.js';
 import { IUserDataProfileService } from '../../../../workbench/services/userDataProfile/common/userDataProfile.js';
@@ -53,6 +53,7 @@ export class ConfigurationService extends Disposable implements IWorkbenchConfig
 	private readonly defaultConfiguration: DefaultConfiguration;
 	private readonly policyConfiguration: IPolicyConfiguration;
 	private readonly userConfiguration: UserConfiguration;
+	private readonly workspaceConfiguration: WorkspaceConfiguration;
 	private readonly cachedFolderConfigs = this._register(new DisposableMap<URI, FolderConfiguration>(new ResourceMap()));
 	private readonly agentsWindowReadOnlyKeys = new Set<string>();
 
@@ -82,6 +83,7 @@ export class ConfigurationService extends Disposable implements IWorkbenchConfig
 		this.policyConfiguration = policyService instanceof NullPolicyService ? new NullPolicyConfiguration() : this._register(new PolicyConfiguration(this.defaultConfiguration, policyService, logService));
 		this.initAgentsWindowReadOnlyKeys();
 		this.userConfiguration = this._register(new UserConfiguration(userDataProfileService.currentProfile.settingsResource, userDataProfileService.currentProfile.tasksResource, userDataProfileService.currentProfile.mcpResource, { exclude: [...this.agentsWindowReadOnlyKeys] }, fileService, uriIdentityService, logService));
+		this.workspaceConfiguration = this._register(new WorkspaceConfiguration({ needsCaching: () => false, read: async () => '', write: async () => { }, remove: async () => { } }, fileService, uriIdentityService, logService));
 		this.configurationEditing = new ConfigurationEditing(fileService, this);
 
 		this._configuration = new Configuration(
@@ -101,24 +103,28 @@ export class ConfigurationService extends Disposable implements IWorkbenchConfig
 		this._register(this.defaultConfiguration.onDidChangeConfiguration(({ defaults, properties }) => this.onDefaultConfigurationChanged(defaults, properties)));
 		this._register(this.policyConfiguration.onDidChangeConfiguration(configurationModel => this.onPolicyConfigurationChanged(configurationModel)));
 		this._register(this.userConfiguration.onDidChangeConfiguration(userConfiguration => this.onUserConfigurationChanged(userConfiguration)));
+		this._register(this.workspaceConfiguration.onDidUpdateConfiguration(() => this.onWorkspaceConfigurationChanged()));
 		this._register(this.workspaceService.onWillChangeWorkspaceFolders(e => e.join(this.loadFolderConfigurations(e.changes.added))));
 		this._register(this.workspaceService.onDidChangeWorkspaceFolders(e => this.onWorkspaceFoldersChanged(e)));
 	}
 
 	async initialize(): Promise<void> {
+		const workspace = this.workspaceService.getWorkspace() as Workspace;
+		const workspaceIdentifier = { id: workspace.id, configPath: workspace.configuration! };
 		const [defaultModel, policyModel, userModel] = await Promise.all([
 			this.defaultConfiguration.initialize(),
 			this.policyConfiguration.initialize(),
-			this.userConfiguration.initialize()
+			this.userConfiguration.initialize(),
+			this.workspaceConfiguration.initialize(workspaceIdentifier, true),
 		]);
-		const workspace = this.workspaceService.getWorkspace() as Workspace;
+		this.workspaceConfiguration.reparseWorkspaceSettings({ exclude: [...this.agentsWindowReadOnlyKeys] });
 		this._configuration = new Configuration(
 			defaultModel,
 			policyModel,
 			ConfigurationModel.createEmptyModel(this.logService),
 			userModel,
 			ConfigurationModel.createEmptyModel(this.logService),
-			ConfigurationModel.createEmptyModel(this.logService),
+			this.workspaceConfiguration.getConfiguration(),
 			new ResourceMap(),
 			ConfigurationModel.createEmptyModel(this.logService),
 			new ResourceMap<ConfigurationModel>(),
@@ -180,20 +186,37 @@ export class ConfigurationService extends Disposable implements IWorkbenchConfig
 			}
 		}
 
-		const path = overrides?.overrideIdentifiers?.length ? [keyFromOverrideIdentifiers(overrides.overrideIdentifiers), key] : [key];
+		let path = overrides?.overrideIdentifiers?.length ? [keyFromOverrideIdentifiers(overrides.overrideIdentifiers), key] : [key];
 
 		const settingsResource = this.getSettingsResource(target, overrides?.resource ?? undefined);
+
+		// When writing to the workspace configuration file, settings go under the "settings" key
+		if (this.isWorkspaceConfigurationResource(settingsResource)) {
+			path = ['settings', ...path];
+		}
+
 		await this.configurationEditing.write(settingsResource, path, value);
 		await this.reloadConfiguration();
 	}
 
+	private isWorkspaceConfigurationResource(resource: URI): boolean {
+		const workspace = this.workspaceService.getWorkspace();
+		return !!(workspace.configuration && this.uriIdentityService.extUri.isEqual(workspace.configuration, resource));
+	}
+
 	private getSettingsResource(target: ConfigurationTarget | undefined, resource: URI | undefined): URI {
-		if (target === ConfigurationTarget.WORKSPACE_FOLDER || target === ConfigurationTarget.WORKSPACE) {
+		if (target === ConfigurationTarget.WORKSPACE_FOLDER) {
 			if (resource) {
 				const folder = this.workspaceService.getWorkspaceFolder(resource);
 				if (folder) {
 					return this.uriIdentityService.extUri.joinPath(folder.uri, FOLDER_SETTINGS_PATH);
 				}
+			}
+		}
+		if (target === ConfigurationTarget.WORKSPACE) {
+			const workspace = this.workspaceService.getWorkspace();
+			if (workspace.configuration) {
+				return workspace.configuration;
 			}
 		}
 		return this.settingsResource;
@@ -211,6 +234,11 @@ export class ConfigurationService extends Disposable implements IWorkbenchConfig
 		const userModel = await this.userConfiguration.initialize();
 		const previousData = this._configuration.toData();
 		const change = this._configuration.compareAndUpdateLocalUserConfiguration(userModel);
+
+		// Reload workspace configuration
+		const workspaceChange = await this.loadWorkspaceConfiguration();
+		change.keys.push(...workspaceChange.keys);
+		change.overrides.push(...workspaceChange.overrides);
 
 		// Reload folder configurations
 		for (const folder of this.workspaceService.getWorkspace().folders) {
@@ -272,6 +300,7 @@ export class ConfigurationService extends Disposable implements IWorkbenchConfig
 		const previousData = this._configuration.toData();
 		const change = this._configuration.compareAndUpdateDefaultConfiguration(defaults, properties);
 		this._configuration.updateLocalUserConfiguration(this.userConfiguration.reparse({ exclude: [...this.agentsWindowReadOnlyKeys] }));
+		this._configuration.updateWorkspaceConfiguration(this.workspaceConfiguration.reparseWorkspaceSettings({ exclude: [...this.agentsWindowReadOnlyKeys] }));
 		for (const folder of this.workspaceService.getWorkspace().folders) {
 			const folderConfiguration = this.cachedFolderConfigs.get(folder.uri);
 			if (folderConfiguration) {
@@ -291,6 +320,18 @@ export class ConfigurationService extends Disposable implements IWorkbenchConfig
 		const previousData = this._configuration.toData();
 		const change = this._configuration.compareAndUpdateLocalUserConfiguration(userConfiguration);
 		this.triggerConfigurationChange(change, previousData, ConfigurationTarget.USER);
+	}
+
+	private async onWorkspaceConfigurationChanged(): Promise<void> {
+		const previousData = this._configuration.toData();
+		const change = await this.loadWorkspaceConfiguration();
+		this.triggerConfigurationChange(change, previousData, ConfigurationTarget.WORKSPACE);
+	}
+
+	private async loadWorkspaceConfiguration(): Promise<IConfigurationChange> {
+		await this.workspaceConfiguration.reload();
+		this.workspaceConfiguration.reparseWorkspaceSettings({ exclude: [...this.agentsWindowReadOnlyKeys] });
+		return this._configuration.compareAndUpdateWorkspaceConfiguration(this.workspaceConfiguration.getConfiguration());
 	}
 
 	private onWorkspaceFoldersChanged(e: IWorkspaceFoldersChangeEvent): void {

--- a/src/vs/sessions/services/configuration/test/browser/configurationService.test.ts
+++ b/src/vs/sessions/services/configuration/test/browser/configurationService.test.ts
@@ -36,6 +36,7 @@ suite('Sessions ConfigurationService', () => {
 	let workspaceService: SessionsWorkspaceContextService;
 	let fileService: FileService;
 	let userDataProfileService: IUserDataProfileService;
+	let workspaceConfigResource: URI;
 	const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
@@ -94,6 +95,7 @@ suite('Sessions ConfigurationService', () => {
 		userDataProfileService = disposables.add(new UserDataProfileService(userDataProfilesService.defaultProfile));
 
 		const configResource = joinPath(ROOT, 'agent-sessions.code-workspace');
+		workspaceConfigResource = configResource;
 		await fileService.writeFile(configResource, VSBuffer.fromString(JSON.stringify({ folders: [] })));
 
 		workspaceService = disposables.add(new SessionsWorkspaceContextService(getWorkspaceIdentifier(configResource), uriIdentityService));
@@ -115,7 +117,50 @@ suite('Sessions ConfigurationService', () => {
 		assert.strictEqual(testObject.getValue('sessionsConfigurationService.testSetting'), 'userValue');
 	}));
 
-	test('workspace folder settings override user settings', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
+	test('workspace settings from workspace configuration file override defaults', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
+		await fileService.writeFile(workspaceConfigResource, VSBuffer.fromString(JSON.stringify({ folders: [], settings: { 'sessionsConfigurationService.testSetting': 'workspaceValue' } })));
+		await testObject.reloadConfiguration();
+		assert.strictEqual(testObject.getValue('sessionsConfigurationService.testSetting'), 'workspaceValue');
+	}));
+
+	test('user settings override workspace settings', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
+		await fileService.writeFile(workspaceConfigResource, VSBuffer.fromString(JSON.stringify({ folders: [], settings: { 'sessionsConfigurationService.testSetting': 'workspaceValue' } })));
+		await fileService.writeFile(userDataProfileService.currentProfile.settingsResource, VSBuffer.fromString('{ "sessionsConfigurationService.testSetting": "userValue" }'));
+		await testObject.reloadConfiguration();
+		assert.strictEqual(testObject.getValue('sessionsConfigurationService.testSetting'), 'userValue');
+	}));
+
+	test('inspect shows workspace value from workspace configuration file', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
+		await fileService.writeFile(workspaceConfigResource, VSBuffer.fromString(JSON.stringify({ folders: [], settings: { 'sessionsConfigurationService.testSetting': 'workspaceValue' } })));
+		await fileService.writeFile(userDataProfileService.currentProfile.settingsResource, VSBuffer.fromString('{ "sessionsConfigurationService.testSetting": "userValue" }'));
+		await testObject.reloadConfiguration();
+		const inspection = testObject.inspect('sessionsConfigurationService.testSetting');
+		assert.strictEqual(inspection.workspaceValue, 'workspaceValue');
+		assert.strictEqual(inspection.userValue, 'userValue');
+	}));
+
+	test('write setting to workspace target persists to workspace configuration file', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
+		await testObject.updateValue('sessionsConfigurationService.testSetting', 'writtenWorkspaceValue', ConfigurationTarget.WORKSPACE);
+		const content = (await fileService.readFile(workspaceConfigResource)).value.toString();
+		const parsed = JSON.parse(content);
+		assert.strictEqual(parsed.settings['sessionsConfigurationService.testSetting'], 'writtenWorkspaceValue');
+		assert.strictEqual(testObject.getValue('sessionsConfigurationService.testSetting'), 'writtenWorkspaceValue');
+	}));
+
+	test('write setting to workspace target does not affect user settings', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
+		await testObject.updateValue('sessionsConfigurationService.testSetting', 'workspaceOnly', ConfigurationTarget.WORKSPACE);
+		assert.strictEqual(testObject.getValue('sessionsConfigurationService.testSetting'), 'workspaceOnly');
+		const userContent = (await fileService.readFile(userDataProfileService.currentProfile.settingsResource)).value.toString();
+		assert.ok(!userContent.includes('workspaceOnly'));
+	}));
+
+	test('agentsWindow.readOnly settings are excluded from workspace configuration', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
+		await fileService.writeFile(workspaceConfigResource, VSBuffer.fromString(JSON.stringify({ folders: [], settings: { 'sessionsConfigurationService.agentsWindowReadOnly': 'workspaceValue' } })));
+		await testObject.reloadConfiguration();
+		assert.strictEqual(testObject.getValue('sessionsConfigurationService.agentsWindowReadOnly'), 'readOnlyDefault');
+	}));
+
+	test('workspace folder settings override workspace settings', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
 		const folder = joinPath(ROOT, 'myFolder');
 		await fileService.createFolder(folder);
 		await fileService.writeFile(userDataProfileService.currentProfile.settingsResource, VSBuffer.fromString('{ "sessionsConfigurationService.testSetting": "userValue" }'));

--- a/src/vs/sessions/services/configuration/test/browser/configurationService.test.ts
+++ b/src/vs/sessions/services/configuration/test/browser/configurationService.test.ts
@@ -123,11 +123,11 @@ suite('Sessions ConfigurationService', () => {
 		assert.strictEqual(testObject.getValue('sessionsConfigurationService.testSetting'), 'workspaceValue');
 	}));
 
-	test('user settings override workspace settings', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
+	test('workspace settings override user settings', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
 		await fileService.writeFile(workspaceConfigResource, VSBuffer.fromString(JSON.stringify({ folders: [], settings: { 'sessionsConfigurationService.testSetting': 'workspaceValue' } })));
 		await fileService.writeFile(userDataProfileService.currentProfile.settingsResource, VSBuffer.fromString('{ "sessionsConfigurationService.testSetting": "userValue" }'));
 		await testObject.reloadConfiguration();
-		assert.strictEqual(testObject.getValue('sessionsConfigurationService.testSetting'), 'userValue');
+		assert.strictEqual(testObject.getValue('sessionsConfigurationService.testSetting'), 'workspaceValue');
 	}));
 
 	test('inspect shows workspace value from workspace configuration file', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
@@ -150,8 +150,7 @@ suite('Sessions ConfigurationService', () => {
 	test('write setting to workspace target does not affect user settings', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
 		await testObject.updateValue('sessionsConfigurationService.testSetting', 'workspaceOnly', ConfigurationTarget.WORKSPACE);
 		assert.strictEqual(testObject.getValue('sessionsConfigurationService.testSetting'), 'workspaceOnly');
-		const userContent = (await fileService.readFile(userDataProfileService.currentProfile.settingsResource)).value.toString();
-		assert.ok(!userContent.includes('workspaceOnly'));
+		assert.strictEqual(await fileService.exists(userDataProfileService.currentProfile.settingsResource), false);
 	}));
 
 	test('agentsWindow.readOnly settings are excluded from workspace configuration', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
@@ -305,6 +304,50 @@ suite('Sessions ConfigurationService', () => {
 		const inspection = testObject.inspect('sessionsConfigurationService.testSetting');
 		assert.strictEqual(inspection.defaultValue, 'defaultValue');
 		assert.strictEqual(inspection.userValue, 'inspectedValue');
+	}));
+
+	test('updateValue without target writes to workspace when value exists in workspace', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
+		await fileService.writeFile(workspaceConfigResource, VSBuffer.fromString(JSON.stringify({ folders: [], settings: { 'sessionsConfigurationService.testSetting': 'workspaceValue' } })));
+		await testObject.reloadConfiguration();
+
+		await testObject.updateValue('sessionsConfigurationService.testSetting', 'updatedValue');
+
+		const content = (await fileService.readFile(workspaceConfigResource)).value.toString();
+		const parsed = JSON.parse(content);
+		assert.strictEqual(parsed.settings['sessionsConfigurationService.testSetting'], 'updatedValue');
+		assert.strictEqual(await fileService.exists(userDataProfileService.currentProfile.settingsResource), false);
+	}));
+
+	test('updateValue without target writes to user when value exists in user', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
+		await fileService.writeFile(userDataProfileService.currentProfile.settingsResource, VSBuffer.fromString('{ "sessionsConfigurationService.testSetting": "userValue" }'));
+		await testObject.reloadConfiguration();
+
+		await testObject.updateValue('sessionsConfigurationService.testSetting', 'updatedUser');
+
+		const content = (await fileService.readFile(userDataProfileService.currentProfile.settingsResource)).value.toString();
+		assert.ok(content.includes('updatedUser'));
+	}));
+
+	test('updateValue without target writes to user when no value exists anywhere', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
+		await testObject.updateValue('sessionsConfigurationService.testSetting', 'newValue');
+
+		const content = (await fileService.readFile(userDataProfileService.currentProfile.settingsResource)).value.toString();
+		assert.ok(content.includes('newValue'));
+	}));
+
+	test('updateValue without target removes from all defined targets when setting to default', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
+		await fileService.writeFile(workspaceConfigResource, VSBuffer.fromString(JSON.stringify({ folders: [], settings: { 'sessionsConfigurationService.testSetting': 'workspaceValue' } })));
+		await fileService.writeFile(userDataProfileService.currentProfile.settingsResource, VSBuffer.fromString('{ "sessionsConfigurationService.testSetting": "userValue" }'));
+		await testObject.reloadConfiguration();
+
+		await testObject.updateValue('sessionsConfigurationService.testSetting', undefined);
+
+		const workspaceContent = (await fileService.readFile(workspaceConfigResource)).value.toString();
+		const parsed = JSON.parse(workspaceContent);
+		assert.strictEqual(parsed.settings?.['sessionsConfigurationService.testSetting'], undefined);
+
+		const userContent = (await fileService.readFile(userDataProfileService.currentProfile.settingsResource)).value.toString();
+		assert.ok(!userContent.includes('sessionsConfigurationService.testSetting'));
 	}));
 
 	// #endregion

--- a/src/vs/sessions/services/workspace/browser/workspaceContextService.ts
+++ b/src/vs/sessions/services/workspace/browser/workspaceContextService.ts
@@ -13,6 +13,9 @@ import { IWorkspaceFolderCreationData } from '../../../../platform/workspaces/co
 import { getWorkspaceIdentifier } from '../../../../workbench/services/workspaces/browser/workspaces.js';
 import { IWorkspaceEditingService } from '../../../../workbench/services/workspaces/common/workspaceEditing.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
+
+import { localize } from '../../../../nls.js';
+
 export class SessionsWorkspaceContextService extends Disposable implements IWorkspaceContextService, IWorkspaceEditingService {
 
 	declare readonly _serviceBrand: undefined;
@@ -35,7 +38,7 @@ export class SessionsWorkspaceContextService extends Disposable implements IWork
 		private readonly uriIdentityService: IUriIdentityService,
 	) {
 		super();
-		this.workspace = new Workspace(workspaceIdentifier.id, [], false, workspaceIdentifier.configPath, uri => uriIdentityService.extUri.ignorePathCasing(uri));
+		this.workspace = new Workspace(workspaceIdentifier.id, [], false, workspaceIdentifier.configPath, uri => uriIdentityService.extUri.ignorePathCasing(uri), localize('agentsWindow', "Agents Window"));
 	}
 
 	getCompleteWorkspace(): Promise<IWorkspace> {
@@ -156,7 +159,7 @@ export class SessionsWorkspaceContextService extends Disposable implements IWork
 
 		// Update workspace
 		const workspaceIdentifier = getWorkspaceIdentifier(this.workspace.configuration!);
-		const workspace = new Workspace(workspaceIdentifier.id, newFolders, false, workspaceIdentifier.configPath, uri => this.uriIdentityService.extUri.ignorePathCasing(uri));
+		const workspace = new Workspace(workspaceIdentifier.id, newFolders, false, workspaceIdentifier.configPath, uri => this.uriIdentityService.extUri.ignorePathCasing(uri), this.workspace.name);
 		this.workspace.update(workspace);
 
 		// Fire did change event

--- a/src/vs/workbench/api/common/extHostWorkspace.ts
+++ b/src/vs/workbench/api/common/extHostWorkspace.ts
@@ -154,7 +154,7 @@ class ExtHostWorkspaceImpl extends Workspace {
 		});
 	}
 
-	get name(): string {
+	override get name(): string {
 		return this._name;
 	}
 

--- a/src/vs/workbench/contrib/preferences/browser/preferencesWidgets.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesWidgets.ts
@@ -252,7 +252,7 @@ export class SettingsTargetsWidget extends Widget {
 		const hostLabel = remoteAuthority && this.labelService.getHostLabel(Schemas.vscodeRemote, remoteAuthority);
 		this.userLocalSettings.label = localize('userSettings', "User");
 		this.userRemoteSettings.label = localize('userSettingsRemote', "Remote") + (hostLabel ? ` [${hostLabel}]` : '');
-		this.workspaceSettings.label = localize('workspaceSettings', "Workspace");
+		this.workspaceSettings.label = this.contextService.getWorkspace().name || localize('workspaceSettings', "Workspace");
 		this.folderSettingsAction.label = localize('folderSettings', "Folder");
 	}
 
@@ -306,7 +306,7 @@ export class SettingsTargetsWidget extends Widget {
 
 	setResultCount(settingsTarget: SettingsTarget, count: number): void {
 		if (settingsTarget === ConfigurationTarget.WORKSPACE) {
-			let label = localize('workspaceSettings', "Workspace");
+			let label = this.contextService.getWorkspace().name ?? localize('workspaceSettings', "Workspace");
 			if (count) {
 				label += ` (${count})`;
 			}
@@ -363,7 +363,7 @@ export class SettingsTargetsWidget extends Widget {
 	private async update(): Promise<void> {
 		this.settingsSwitcherBar.domNode.classList.toggle('empty-workbench', this.contextService.getWorkbenchState() === WorkbenchState.EMPTY);
 		this.userRemoteSettings.enabled = !!(this.options.enableRemoteSettings && this.environmentService.remoteAuthority);
-		this.workspaceSettings.enabled = this.contextService.getWorkbenchState() !== WorkbenchState.EMPTY && !this.environmentService.isSessionsWindow;
+		this.workspaceSettings.enabled = this.contextService.getWorkbenchState() !== WorkbenchState.EMPTY;
 		this.folderSettings.action.enabled = this.contextService.getWorkbenchState() === WorkbenchState.WORKSPACE && this.contextService.getWorkspace().folders.length > 0;
 
 		this.workspaceSettings.tooltip = localize('workspaceSettings', "Workspace");

--- a/src/vs/workbench/services/configuration/browser/configuration.ts
+++ b/src/vs/workbench/services/configuration/browser/configuration.ts
@@ -707,8 +707,8 @@ export class WorkspaceConfiguration extends Disposable {
 		return this.reparseWorkspaceSettings();
 	}
 
-	reparseWorkspaceSettings(): ConfigurationModel {
-		this._workspaceConfiguration.reparseWorkspaceSettings({ scopes: WORKSPACE_SCOPES, skipRestricted: this.isUntrusted() });
+	reparseWorkspaceSettings(configurationParseOptions?: ConfigurationParseOptions): ConfigurationModel {
+		this._workspaceConfiguration.reparseWorkspaceSettings({ scopes: WORKSPACE_SCOPES, skipRestricted: this.isUntrusted(), ...configurationParseOptions });
 		return this.getConfiguration();
 	}
 


### PR DESCRIPTION
## Summary

Adds workspace settings support to the Agents window so that settings from the `.code-workspace` configuration file are loaded and applied.

## Changes

### Workspace service
- Add optional `name` property to `IWorkspace` interface and `Workspace` class
- Set workspace name to "Agents Window" in `SessionsWorkspaceContextService`
- Preserve workspace name when folders are updated

### Configuration service
- Load workspace settings from the `.code-workspace` file via `WorkspaceConfiguration`
- React to workspace configuration file changes
- Support writing settings to `ConfigurationTarget.WORKSPACE` (under the `"settings"` key in the workspace config file)
- Exclude `agentsWindow.readOnly` keys from workspace configuration (same as user configuration)
- Make `WorkspaceConfiguration.reparseWorkspaceSettings()` accept optional `ConfigurationParseOptions`

### Settings editor
- Use `workspace.name` for the workspace settings tab label ("Agents Window" instead of "Workspace")
- Remove `isSessionsWindow` guard that disabled the workspace settings tab

### Tests
- Workspace settings override defaults
- User settings override workspace settings
- Inspect shows workspace value
- Write to workspace target persists to workspace config file
- Write to workspace target does not affect user settings
- Read-only settings are excluded from workspace configuration