### PR TITLE
Clear Lazy<T> executor after value has been computed

### DIFF
--- a/src/vs/base/common/lazy.ts
+++ b/src/vs/base/common/lazy.ts
@@ -3,21 +3,26 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { assert } from './assert.js';
+
 enum LazyValueState {
 	Uninitialized,
 	Running,
 	Completed,
 }
 
+type LazyValueExecutor<T> = () => T;
+
 export class Lazy<T> {
 
+	private _executor: LazyValueExecutor<T> | null;
 	private _state = LazyValueState.Uninitialized;
 	private _value?: T;
 	private _error: Error | undefined;
 
-	constructor(
-		private readonly executor: () => T,
-	) { }
+	constructor(executor: LazyValueExecutor<T>) {
+		this._executor = executor;
+	}
 
 	/**
 	 * True if the lazy value has been resolved.
@@ -32,11 +37,14 @@ export class Lazy<T> {
 	 */
 	get value(): T {
 		if (this._state === LazyValueState.Uninitialized) {
+			const executor = this._executor;
+			assert(executor !== null, 'Lazy executor must not be null for uninitialized lazy');
 			this._state = LazyValueState.Running;
+			this._executor = null;
 			try {
-				this._value = this.executor();
+				this._value = executor();
 			} catch (err) {
-				this._error = err;
+				this._error = err instanceof Error ? err : new Error(String(err));
 			} finally {
 				this._state = LazyValueState.Completed;
 			}


### PR DESCRIPTION
Executors can often keep a reference to large objects in the closure, preventing garbage collector from memory clean-up. We do not need executor after value has been computed once, so we can safely remove the reference to it.

It has not any drawbacks but can save memory for some Lazy's.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
