### PR TITLE
Add SVG theme preview for light mode in 2026

### DIFF
--- a/src/vs/sessions/contrib/welcome/browser/media/themePreviews/agents-window-dark-2026.svg
+++ b/src/vs/sessions/contrib/welcome/browser/media/themePreviews/agents-window-dark-2026.svg
@@ -1,0 +1,142 @@
+<svg preserveAspectRatio="none" width="100%" height="100%" overflow="visible" style="display: block;" viewBox="0 0 320 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="theme-preview-v2-dark-2026">
+<g clip-path="url(#clip0_762_20660)">
+<rect width="320" height="220" rx="4" fill="var(--fill-0, #121314)"/>
+<rect id="Rectangle" width="70" height="220" fill="var(--fill-0, #191A1B)"/>
+<rect id="Rectangle_2" x="39.5" y="13.5" width="17" height="3" rx="0.5" fill="var(--fill-0, #121314)" stroke="var(--stroke-0, #636363)"/>
+<circle id="Ellipse" cx="61" cy="15" r="1" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.85"/>
+<circle id="Ellipse_2" cx="66" cy="15" r="1" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.85"/>
+<rect id="Rectangle_3" x="3" y="14" width="20" height="2" rx="1" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.7"/>
+<rect id="Rectangle_4" x="3" y="19" width="64" height="11" rx="2" fill="var(--fill-0, #2C2D2E)"/>
+<circle id="Ellipse_3" cx="7.25" cy="22.25" r="1.25" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.7"/>
+<rect id="Rectangle_5" x="11" y="21" width="52" height="1.8" rx="0.9" fill="var(--fill-0, #BFBFBF)"/>
+<rect id="Rectangle_6" x="11" y="25.5" width="8" height="1.6" rx="0.8" fill="var(--fill-0, #7EE787)" fill-opacity="0.9"/>
+<rect id="Rectangle_7" x="21" y="25.5" width="6" height="1.6" rx="0.8" fill="var(--fill-0, #F85149)" fill-opacity="0.9"/>
+<rect id="Rectangle_8" x="29" y="25.5" width="33" height="1.5" rx="0.75" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.8"/>
+<circle id="Ellipse_4" cx="7.25" cy="34.25" r="1.25" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.7"/>
+<rect id="Rectangle_9" x="11" y="33" width="52" height="1.8" rx="0.9" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.85"/>
+<rect id="Rectangle_10" x="11" y="37.5" width="8" height="1.6" rx="0.8" fill="var(--fill-0, #7EE787)" fill-opacity="0.9"/>
+<rect id="Rectangle_11" x="21" y="37.5" width="41" height="1.5" rx="0.75" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.8"/>
+<circle id="Ellipse_5" cx="7.25" cy="46.25" r="1.25" fill="var(--fill-0, #3994BC)"/>
+<rect id="Rectangle_12" x="11" y="45" width="52" height="1.8" rx="0.9" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.85"/>
+<rect id="Rectangle_13" x="11" y="49.5" width="51" height="1.5" rx="0.75" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.8"/>
+<rect id="Rectangle_14" x="3" y="64" width="28" height="2" rx="1" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.7"/>
+<circle id="Ellipse_6" cx="7.25" cy="72.25" r="1.25" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.7"/>
+<rect id="Rectangle_15" x="11" y="71" width="52" height="1.8" rx="0.9" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.85"/>
+<rect id="Rectangle_16" x="11" y="75.5" width="51" height="1.5" rx="0.75" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.8"/>
+<rect id="Rectangle_17" x="3" y="84" width="28" height="2" rx="1" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.7"/>
+<circle id="Ellipse_7" cx="7.25" cy="92.25" r="1.25" fill="var(--fill-0, #3994BC)"/>
+<rect id="Rectangle_18" x="11" y="91" width="52" height="1.8" rx="0.9" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.85"/>
+<rect id="Rectangle_19" x="11" y="95.5" width="51" height="1.5" rx="0.75" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.8"/>
+<circle id="Ellipse_8" cx="7.25" cy="104.25" r="1.25" fill="var(--fill-0, #3994BC)"/>
+<rect id="Rectangle_20" x="11" y="103" width="52" height="1.8" rx="0.9" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.85"/>
+<rect id="Rectangle_21" x="11" y="107.5" width="51" height="1.5" rx="0.75" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.8"/>
+<circle id="Ellipse_9" cx="7.25" cy="116.25" r="1.25" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.7"/>
+<rect id="Rectangle_22" x="11" y="115" width="52" height="1.8" rx="0.9" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.85"/>
+<rect id="Rectangle_23" x="11" y="119.5" width="8" height="1.6" rx="0.8" fill="var(--fill-0, #7EE787)" fill-opacity="0.9"/>
+<rect id="Rectangle_24" x="21" y="119.5" width="6" height="1.6" rx="0.8" fill="var(--fill-0, #F85149)" fill-opacity="0.9"/>
+<rect id="Rectangle_25" x="29" y="119.5" width="33" height="1.5" rx="0.75" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.8"/>
+<circle id="Ellipse_10" cx="7.25" cy="128.25" r="1.25" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.7"/>
+<rect id="Rectangle_26" x="11" y="127" width="52" height="1.8" rx="0.9" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.85"/>
+<rect id="Rectangle_27" x="11" y="131.5" width="8" height="1.6" rx="0.8" fill="var(--fill-0, #7EE787)" fill-opacity="0.9"/>
+<rect id="Rectangle_28" x="21" y="131.5" width="6" height="1.6" rx="0.8" fill="var(--fill-0, #F85149)" fill-opacity="0.9"/>
+<rect id="Rectangle_29" x="29" y="131.5" width="33" height="1.5" rx="0.75" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.8"/>
+<rect id="Rectangle_30" x="2" y="149" width="66" height="1" fill="var(--fill-0, #2A2B2C)"/>
+<rect id="Rectangle_31" x="5" y="157" width="36" height="2.2" rx="1.1" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.9"/>
+<rect id="Rectangle_32" x="5" y="164" width="3" height="3" rx="0.5" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.9"/>
+<rect id="Rectangle_33" x="11" y="164.6" width="44" height="1.8" rx="0.9" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.85"/>
+<rect id="Rectangle_34" x="62" y="164.7" width="3" height="1.6" rx="0.8" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.9"/>
+<rect id="Rectangle_35" x="5" y="173" width="3" height="3" rx="0.5" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.9"/>
+<rect id="Rectangle_36" x="11" y="173.6" width="44" height="1.8" rx="0.9" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.85"/>
+<rect id="Rectangle_37" x="60" y="173.7" width="5" height="1.6" rx="0.8" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.9"/>
+<rect id="Rectangle_38" x="5" y="182" width="3" height="3" rx="0.5" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.9"/>
+<rect id="Rectangle_39" x="11" y="182.6" width="44" height="1.8" rx="0.9" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.85"/>
+<rect id="Rectangle_40" x="5" y="191" width="3" height="3" rx="0.5" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.9"/>
+<rect id="Rectangle_41" x="11" y="191.6" width="44" height="1.8" rx="0.9" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.85"/>
+<rect id="Rectangle_42" x="5" y="200" width="3" height="3" rx="0.5" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.9"/>
+<rect id="Rectangle_43" x="11" y="200.6" width="44" height="1.8" rx="0.9" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.85"/>
+<rect id="Rectangle_44" x="62" y="200.7" width="3" height="1.6" rx="0.8" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.9"/>
+<rect id="Rectangle_45" x="5" y="209" width="3" height="3" rx="0.5" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.9"/>
+<rect id="Rectangle_46" x="11" y="209.6" width="44" height="1.8" rx="0.9" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.85"/>
+<rect id="Rectangle_47" x="70" width="250" height="10" fill="var(--fill-0, #191A1B)"/>
+<rect id="Rectangle_48" x="74" y="4" width="80" height="2.2" rx="1.1" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.9"/>
+<rect id="Rectangle_49" x="158" y="4.2" width="50" height="2" rx="1" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.8"/>
+<circle id="Ellipse_11" cx="315" cy="5" r="1" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.85"/>
+<circle id="Ellipse_12" cx="310" cy="5" r="1" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.85"/>
+<circle id="Ellipse_13" cx="305" cy="5" r="1" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.85"/>
+<circle id="Ellipse_14" cx="300" cy="5" r="1" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.85"/>
+<circle id="Ellipse_15" cx="295" cy="5" r="1" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.85"/>
+<rect id="Rectangle_50" x="187" y="20" width="61" height="8" rx="4" fill="var(--fill-0, #3994BC)" fill-opacity="0.2"/>
+<rect id="Rectangle_51" x="190" y="23" width="55" height="2" rx="1" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.9"/>
+<rect id="Rectangle_52" x="78" y="32" width="110.5" height="1.6" rx="0.8" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.85"/>
+<rect id="Rectangle_53" x="161" y="40" width="87" height="8" rx="4" fill="var(--fill-0, #3994BC)" fill-opacity="0.2"/>
+<rect id="Rectangle_54" x="164" y="43" width="81" height="2" rx="1" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.9"/>
+<rect id="Rectangle_55" x="78" y="54" width="119" height="1.6" rx="0.8" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.85"/>
+<rect id="Rectangle_56" x="78" y="59" width="144.5" height="1.6" rx="0.8" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.85"/>
+<circle id="Ellipse_16" cx="82.7" cy="66.1" r="0.7" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.85"/>
+<rect id="Rectangle_57" x="87" y="65" width="93.5" height="1.4" rx="0.7" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.85"/>
+<circle id="Ellipse_17" cx="82.7" cy="70.1" r="0.7" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.85"/>
+<rect id="Rectangle_58" x="87" y="69" width="86.7" height="1.4" rx="0.7" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.85"/>
+<circle id="Ellipse_18" cx="82.7" cy="74.1" r="0.7" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.85"/>
+<rect id="Rectangle_59" x="87" y="73" width="79.9" height="1.4" rx="0.7" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.85"/>
+<circle id="Ellipse_19" cx="82.7" cy="78.1" r="0.7" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.85"/>
+<rect id="Rectangle_60" x="87" y="77" width="73.1" height="1.4" rx="0.7" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.85"/>
+<circle id="Ellipse_20" cx="82.7" cy="82.1" r="0.7" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.85"/>
+<rect id="Rectangle_61" x="87" y="81" width="66.3" height="1.4" rx="0.7" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.85"/>
+<rect id="Rectangle_62" x="78" y="87" width="153" height="1.6" rx="0.8" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.85"/>
+<rect id="Rectangle_63" x="208" y="92.5" width="40" height="2" rx="1" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.8"/>
+<rect id="Rectangle_64" x="78.5" y="187.5" width="170" height="21" rx="2.5" fill="var(--fill-0, #191A1B)" stroke="var(--stroke-0, #333536)"/>
+<rect id="Rectangle_65" x="81" y="191" width="102" height="1.6" rx="0.8" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.85"/>
+<circle id="Ellipse_21" cx="82.5" cy="204.5" r="1.5" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.9"/>
+<rect id="Rectangle_66" x="87" y="203.5" width="14" height="2" rx="1" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.9"/>
+<rect id="Rectangle_67" x="104" y="203.5" width="28" height="2" rx="1" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.9"/>
+<rect id="Rectangle_68" x="138" y="203.5" width="12" height="2" rx="1" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.9"/>
+<circle id="Ellipse_22" cx="244.5" cy="204.5" r="1.5" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.9"/>
+<rect id="Rectangle_69" x="80" y="212" width="28" height="2" rx="1" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.9"/>
+<rect id="Rectangle_70" x="111" y="212" width="36" height="2" rx="1" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.9"/>
+<rect id="Rectangle_71" x="259.5" y="10.5" width="58" height="207" rx="2.5" fill="var(--fill-0, #121314)" stroke="var(--stroke-0, #2A2B2C)"/>
+<path id="Union" d="M254 10C255.657 10 257 11.3431 257 13V215C257 216.657 255.657 218 254 218H73C71.3431 218 70 216.657 70 215V13C70 11.3431 71.3431 10 73 10H254ZM73 11C71.8954 11 71 11.8954 71 13V215C71 216.105 71.8954 217 73 217H254C255.105 217 256 216.105 256 215V13C256 11.8954 255.105 11 254 11H73Z" fill="var(--fill-0, #2A2B2C)"/>
+<rect id="Rectangle_72" x="262" y="21" width="43" height="5" rx="1" fill="var(--fill-0, #297AA0)"/>
+<g id="Rectangle_73">
+</g>
+<rect id="Rectangle_74" x="262" y="30" width="34" height="2" rx="1" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.85"/>
+<rect id="Rectangle_75" x="304" y="30.2" width="10" height="1.6" rx="0.8" fill="var(--fill-0, #7EE787)" fill-opacity="0.9"/>
+<rect id="Rectangle_76" x="262" y="38" width="3" height="3" rx="0.3" fill="var(--fill-0, #3994BC)" fill-opacity="0.7"/>
+<rect id="Rectangle_77" x="267" y="38.6" width="28" height="1.8" rx="0.9" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.85"/>
+<rect id="Rectangle_78" x="298" y="38.8" width="12" height="1.4" rx="0.7" fill="var(--fill-0, #7EE787)" fill-opacity="0.9"/>
+<rect id="Rectangle_79" x="312" y="38.5" width="2" height="2" rx="0.4" fill="var(--fill-0, #7EE787)" fill-opacity="0.9"/>
+<rect id="Rectangle_80" x="262" y="47" width="3" height="3" rx="0.3" fill="var(--fill-0, #3994BC)" fill-opacity="0.7"/>
+<rect id="Rectangle_81" x="267" y="47.6" width="28" height="1.8" rx="0.9" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.85"/>
+<rect id="Rectangle_82" x="296" y="47.8" width="14" height="1.4" rx="0.7" fill="var(--fill-0, #7EE787)" fill-opacity="0.9"/>
+<rect id="Rectangle_83" x="312" y="47.5" width="2" height="2" rx="0.4" fill="var(--fill-0, #7EE787)" fill-opacity="0.9"/>
+<rect id="Rectangle_84" x="262" y="56" width="3" height="3" rx="0.3" fill="var(--fill-0, #3994BC)" fill-opacity="0.7"/>
+<rect id="Rectangle_85" x="267" y="56.6" width="28" height="1.8" rx="0.9" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.85"/>
+<rect id="Rectangle_86" x="298" y="56.8" width="12" height="1.4" rx="0.7" fill="var(--fill-0, #7EE787)" fill-opacity="0.9"/>
+<rect id="Rectangle_87" x="312" y="56.5" width="2" height="2" rx="0.4" fill="var(--fill-0, #7EE787)" fill-opacity="0.9"/>
+<rect id="Rectangle_88" x="262" y="65" width="3" height="3" rx="0.3" fill="var(--fill-0, #3994BC)" fill-opacity="0.7"/>
+<rect id="Rectangle_89" x="267" y="65.6" width="28" height="1.8" rx="0.9" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.85"/>
+<rect id="Rectangle_90" x="296" y="65.8" width="14" height="1.4" rx="0.7" fill="var(--fill-0, #7EE787)" fill-opacity="0.9"/>
+<rect id="Rectangle_91" x="312" y="65.5" width="2" height="2" rx="0.4" fill="var(--fill-0, #7EE787)" fill-opacity="0.9"/>
+<rect id="Rectangle_92" x="262" y="74" width="3" height="3" rx="0.3" fill="var(--fill-0, #3994BC)" fill-opacity="0.7"/>
+<rect id="Rectangle_93" x="267" y="74.6" width="28" height="1.8" rx="0.9" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.85"/>
+<rect id="Rectangle_94" x="304" y="74.8" width="6" height="1.4" rx="0.7" fill="var(--fill-0, #7EE787)" fill-opacity="0.9"/>
+<rect id="Rectangle_95" x="312" y="74.5" width="2" height="2" rx="0.4" fill="var(--fill-0, #F85149)" fill-opacity="0.9"/>
+<rect id="Rectangle_96" x="262" y="83" width="3" height="3" rx="0.3" fill="var(--fill-0, #3994BC)" fill-opacity="0.7"/>
+<rect id="Rectangle_97" x="267" y="83.6" width="28" height="1.8" rx="0.9" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.85"/>
+<rect id="Rectangle_98" x="296" y="83.8" width="14" height="1.4" rx="0.7" fill="var(--fill-0, #7EE787)" fill-opacity="0.9"/>
+<rect id="Rectangle_99" x="312" y="83.5" width="2" height="2" rx="0.4" fill="var(--fill-0, #7EE787)" fill-opacity="0.9"/>
+<rect id="Rectangle_100" x="262" y="92" width="3" height="3" rx="0.3" fill="var(--fill-0, #3994BC)" fill-opacity="0.7"/>
+<rect id="Rectangle_101" x="267" y="92.6" width="28" height="1.8" rx="0.9" fill="var(--fill-0, #BFBFBF)" fill-opacity="0.85"/>
+<rect id="Rectangle_102" x="298" y="92.8" width="12" height="1.4" rx="0.7" fill="var(--fill-0, #7EE787)" fill-opacity="0.9"/>
+<rect id="Rectangle_103" x="312" y="92.5" width="2" height="2" rx="0.4" fill="var(--fill-0, #F85149)" fill-opacity="0.9"/>
+<rect id="Rectangle_104" x="262" y="14" width="16" height="2" rx="1" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.7"/>
+<rect id="Rectangle_105" x="280" y="14" width="16" height="2" rx="1" fill="var(--fill-0, #8C8C8C)" fill-opacity="0.7"/>
+<rect id="Rectangle_106" x="307.5" y="21.5" width="6" height="4" rx="0.5" stroke="var(--stroke-0, #676868)"/>
+</g>
+</g>
+<defs>
+<clipPath id="clip0_762_20660">
+<rect width="320" height="220" rx="4" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/vs/sessions/contrib/welcome/browser/media/themePreviews/agents-window-light-2026.svg
+++ b/src/vs/sessions/contrib/welcome/browser/media/themePreviews/agents-window-light-2026.svg
@@ -1,0 +1,142 @@
+<svg preserveAspectRatio="none" width="100%" height="100%" overflow="visible" style="display: block;" viewBox="0 0 320 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="theme-preview-v2-light-2026">
+<g clip-path="url(#clip0_762_20791)">
+<rect width="320" height="220" rx="4" fill="var(--fill-0, white)"/>
+<rect id="Rectangle" width="70" height="220" fill="var(--fill-0, #FAFAFD)"/>
+<rect id="Rectangle_2" x="39.5" y="13.5" width="17" height="3" rx="0.5" fill="var(--fill-0, white)" stroke="var(--stroke-0, #636363)"/>
+<circle id="Ellipse" cx="61" cy="15" r="1" fill="var(--fill-0, #606060)" fill-opacity="0.85"/>
+<circle id="Ellipse_2" cx="66" cy="15" r="1" fill="var(--fill-0, #606060)" fill-opacity="0.85"/>
+<rect id="Rectangle_3" x="3" y="14" width="20" height="2" rx="1" fill="var(--fill-0, #606060)" fill-opacity="0.7"/>
+<rect id="Rectangle_4" x="3" y="19" width="64" height="11" rx="2" fill="var(--fill-0, #DADADA)"/>
+<circle id="Ellipse_3" cx="7.25" cy="22.25" r="1.25" fill="var(--fill-0, #606060)" fill-opacity="0.7"/>
+<rect id="Rectangle_5" x="11" y="21" width="52" height="1.8" rx="0.9" fill="var(--fill-0, #202020)"/>
+<rect id="Rectangle_6" x="11" y="25.5" width="8" height="1.6" rx="0.8" fill="var(--fill-0, #1A7F37)" fill-opacity="0.9"/>
+<rect id="Rectangle_7" x="21" y="25.5" width="6" height="1.6" rx="0.8" fill="var(--fill-0, #CF222E)" fill-opacity="0.9"/>
+<rect id="Rectangle_8" x="29" y="25.5" width="33" height="1.5" rx="0.75" fill="var(--fill-0, #606060)" fill-opacity="0.8"/>
+<circle id="Ellipse_4" cx="7.25" cy="34.25" r="1.25" fill="var(--fill-0, #606060)" fill-opacity="0.7"/>
+<rect id="Rectangle_9" x="11" y="33" width="52" height="1.8" rx="0.9" fill="var(--fill-0, #202020)" fill-opacity="0.85"/>
+<rect id="Rectangle_10" x="11" y="37.5" width="8" height="1.6" rx="0.8" fill="var(--fill-0, #1A7F37)" fill-opacity="0.9"/>
+<rect id="Rectangle_11" x="21" y="37.5" width="41" height="1.5" rx="0.75" fill="var(--fill-0, #606060)" fill-opacity="0.8"/>
+<circle id="Ellipse_5" cx="7.25" cy="46.25" r="1.25" fill="var(--fill-0, #0069CC)"/>
+<rect id="Rectangle_12" x="11" y="45" width="52" height="1.8" rx="0.9" fill="var(--fill-0, #202020)" fill-opacity="0.85"/>
+<rect id="Rectangle_13" x="11" y="49.5" width="51" height="1.5" rx="0.75" fill="var(--fill-0, #606060)" fill-opacity="0.8"/>
+<rect id="Rectangle_14" x="3" y="64" width="28" height="2" rx="1" fill="var(--fill-0, #606060)" fill-opacity="0.7"/>
+<circle id="Ellipse_6" cx="7.25" cy="72.25" r="1.25" fill="var(--fill-0, #606060)" fill-opacity="0.7"/>
+<rect id="Rectangle_15" x="11" y="71" width="52" height="1.8" rx="0.9" fill="var(--fill-0, #202020)" fill-opacity="0.85"/>
+<rect id="Rectangle_16" x="11" y="75.5" width="51" height="1.5" rx="0.75" fill="var(--fill-0, #606060)" fill-opacity="0.8"/>
+<rect id="Rectangle_17" x="3" y="84" width="28" height="2" rx="1" fill="var(--fill-0, #606060)" fill-opacity="0.7"/>
+<circle id="Ellipse_7" cx="7.25" cy="92.25" r="1.25" fill="var(--fill-0, #0069CC)"/>
+<rect id="Rectangle_18" x="11" y="91" width="52" height="1.8" rx="0.9" fill="var(--fill-0, #202020)" fill-opacity="0.85"/>
+<rect id="Rectangle_19" x="11" y="95.5" width="51" height="1.5" rx="0.75" fill="var(--fill-0, #606060)" fill-opacity="0.8"/>
+<circle id="Ellipse_8" cx="7.25" cy="104.25" r="1.25" fill="var(--fill-0, #0069CC)"/>
+<rect id="Rectangle_20" x="11" y="103" width="52" height="1.8" rx="0.9" fill="var(--fill-0, #202020)" fill-opacity="0.85"/>
+<rect id="Rectangle_21" x="11" y="107.5" width="51" height="1.5" rx="0.75" fill="var(--fill-0, #606060)" fill-opacity="0.8"/>
+<circle id="Ellipse_9" cx="7.25" cy="116.25" r="1.25" fill="var(--fill-0, #606060)" fill-opacity="0.7"/>
+<rect id="Rectangle_22" x="11" y="115" width="52" height="1.8" rx="0.9" fill="var(--fill-0, #202020)" fill-opacity="0.85"/>
+<rect id="Rectangle_23" x="11" y="119.5" width="8" height="1.6" rx="0.8" fill="var(--fill-0, #1A7F37)" fill-opacity="0.9"/>
+<rect id="Rectangle_24" x="21" y="119.5" width="6" height="1.6" rx="0.8" fill="var(--fill-0, #CF222E)" fill-opacity="0.9"/>
+<rect id="Rectangle_25" x="29" y="119.5" width="33" height="1.5" rx="0.75" fill="var(--fill-0, #606060)" fill-opacity="0.8"/>
+<circle id="Ellipse_10" cx="7.25" cy="128.25" r="1.25" fill="var(--fill-0, #606060)" fill-opacity="0.7"/>
+<rect id="Rectangle_26" x="11" y="127" width="52" height="1.8" rx="0.9" fill="var(--fill-0, #202020)" fill-opacity="0.85"/>
+<rect id="Rectangle_27" x="11" y="131.5" width="8" height="1.6" rx="0.8" fill="var(--fill-0, #1A7F37)" fill-opacity="0.9"/>
+<rect id="Rectangle_28" x="21" y="131.5" width="6" height="1.6" rx="0.8" fill="var(--fill-0, #CF222E)" fill-opacity="0.9"/>
+<rect id="Rectangle_29" x="29" y="131.5" width="33" height="1.5" rx="0.75" fill="var(--fill-0, #606060)" fill-opacity="0.8"/>
+<rect id="Rectangle_30" x="2" y="149" width="66" height="1" fill="var(--fill-0, #F0F1F2)"/>
+<rect id="Rectangle_31" x="5" y="157" width="36" height="2.2" rx="1.1" fill="var(--fill-0, #202020)" fill-opacity="0.9"/>
+<rect id="Rectangle_32" x="5" y="164" width="3" height="3" rx="0.5" fill="var(--fill-0, #606060)" fill-opacity="0.9"/>
+<rect id="Rectangle_33" x="11" y="164.6" width="44" height="1.8" rx="0.9" fill="var(--fill-0, #202020)" fill-opacity="0.85"/>
+<rect id="Rectangle_34" x="62" y="164.7" width="3" height="1.6" rx="0.8" fill="var(--fill-0, #606060)" fill-opacity="0.9"/>
+<rect id="Rectangle_35" x="5" y="173" width="3" height="3" rx="0.5" fill="var(--fill-0, #606060)" fill-opacity="0.9"/>
+<rect id="Rectangle_36" x="11" y="173.6" width="44" height="1.8" rx="0.9" fill="var(--fill-0, #202020)" fill-opacity="0.85"/>
+<rect id="Rectangle_37" x="60" y="173.7" width="5" height="1.6" rx="0.8" fill="var(--fill-0, #606060)" fill-opacity="0.9"/>
+<rect id="Rectangle_38" x="5" y="182" width="3" height="3" rx="0.5" fill="var(--fill-0, #606060)" fill-opacity="0.9"/>
+<rect id="Rectangle_39" x="11" y="182.6" width="44" height="1.8" rx="0.9" fill="var(--fill-0, #202020)" fill-opacity="0.85"/>
+<rect id="Rectangle_40" x="5" y="191" width="3" height="3" rx="0.5" fill="var(--fill-0, #606060)" fill-opacity="0.9"/>
+<rect id="Rectangle_41" x="11" y="191.6" width="44" height="1.8" rx="0.9" fill="var(--fill-0, #202020)" fill-opacity="0.85"/>
+<rect id="Rectangle_42" x="5" y="200" width="3" height="3" rx="0.5" fill="var(--fill-0, #606060)" fill-opacity="0.9"/>
+<rect id="Rectangle_43" x="11" y="200.6" width="44" height="1.8" rx="0.9" fill="var(--fill-0, #202020)" fill-opacity="0.85"/>
+<rect id="Rectangle_44" x="62" y="200.7" width="3" height="1.6" rx="0.8" fill="var(--fill-0, #606060)" fill-opacity="0.9"/>
+<rect id="Rectangle_45" x="5" y="209" width="3" height="3" rx="0.5" fill="var(--fill-0, #606060)" fill-opacity="0.9"/>
+<rect id="Rectangle_46" x="11" y="209.6" width="44" height="1.8" rx="0.9" fill="var(--fill-0, #202020)" fill-opacity="0.85"/>
+<rect id="Rectangle_47" x="70" width="250" height="10" fill="var(--fill-0, #FAFAFD)"/>
+<rect id="Rectangle_48" x="74" y="4" width="80" height="2.2" rx="1.1" fill="var(--fill-0, #202020)" fill-opacity="0.9"/>
+<rect id="Rectangle_49" x="158" y="4.2" width="50" height="2" rx="1" fill="var(--fill-0, #606060)" fill-opacity="0.8"/>
+<circle id="Ellipse_11" cx="315" cy="5" r="1" fill="var(--fill-0, #606060)" fill-opacity="0.85"/>
+<circle id="Ellipse_12" cx="310" cy="5" r="1" fill="var(--fill-0, #606060)" fill-opacity="0.85"/>
+<circle id="Ellipse_13" cx="305" cy="5" r="1" fill="var(--fill-0, #606060)" fill-opacity="0.85"/>
+<circle id="Ellipse_14" cx="300" cy="5" r="1" fill="var(--fill-0, #606060)" fill-opacity="0.85"/>
+<circle id="Ellipse_15" cx="295" cy="5" r="1" fill="var(--fill-0, #606060)" fill-opacity="0.85"/>
+<rect id="Rectangle_50" x="187" y="20" width="61" height="8" rx="4" fill="var(--fill-0, #0069CC)" fill-opacity="0.2"/>
+<rect id="Rectangle_51" x="190" y="23" width="55" height="2" rx="1" fill="var(--fill-0, #202020)" fill-opacity="0.9"/>
+<rect id="Rectangle_52" x="78" y="32" width="110.5" height="1.6" rx="0.8" fill="var(--fill-0, #202020)" fill-opacity="0.85"/>
+<rect id="Rectangle_53" x="161" y="40" width="87" height="8" rx="4" fill="var(--fill-0, #0069CC)" fill-opacity="0.2"/>
+<rect id="Rectangle_54" x="164" y="43" width="81" height="2" rx="1" fill="var(--fill-0, #202020)" fill-opacity="0.9"/>
+<rect id="Rectangle_55" x="78" y="54" width="119" height="1.6" rx="0.8" fill="var(--fill-0, #202020)" fill-opacity="0.85"/>
+<rect id="Rectangle_56" x="78" y="59" width="144.5" height="1.6" rx="0.8" fill="var(--fill-0, #202020)" fill-opacity="0.85"/>
+<circle id="Ellipse_16" cx="82.7" cy="66.1" r="0.7" fill="var(--fill-0, #202020)" fill-opacity="0.85"/>
+<rect id="Rectangle_57" x="87" y="65" width="93.5" height="1.4" rx="0.7" fill="var(--fill-0, #202020)" fill-opacity="0.85"/>
+<circle id="Ellipse_17" cx="82.7" cy="70.1" r="0.7" fill="var(--fill-0, #202020)" fill-opacity="0.85"/>
+<rect id="Rectangle_58" x="87" y="69" width="86.7" height="1.4" rx="0.7" fill="var(--fill-0, #202020)" fill-opacity="0.85"/>
+<circle id="Ellipse_18" cx="82.7" cy="74.1" r="0.7" fill="var(--fill-0, #202020)" fill-opacity="0.85"/>
+<rect id="Rectangle_59" x="87" y="73" width="79.9" height="1.4" rx="0.7" fill="var(--fill-0, #202020)" fill-opacity="0.85"/>
+<circle id="Ellipse_19" cx="82.7" cy="78.1" r="0.7" fill="var(--fill-0, #202020)" fill-opacity="0.85"/>
+<rect id="Rectangle_60" x="87" y="77" width="73.1" height="1.4" rx="0.7" fill="var(--fill-0, #202020)" fill-opacity="0.85"/>
+<circle id="Ellipse_20" cx="82.7" cy="82.1" r="0.7" fill="var(--fill-0, #202020)" fill-opacity="0.85"/>
+<rect id="Rectangle_61" x="87" y="81" width="66.3" height="1.4" rx="0.7" fill="var(--fill-0, #202020)" fill-opacity="0.85"/>
+<rect id="Rectangle_62" x="78" y="87" width="153" height="1.6" rx="0.8" fill="var(--fill-0, #202020)" fill-opacity="0.85"/>
+<rect id="Rectangle_63" x="208" y="92.5" width="40" height="2" rx="1" fill="var(--fill-0, #606060)" fill-opacity="0.8"/>
+<rect id="Rectangle_64" x="78.5" y="187.5" width="170" height="21" rx="2.5" fill="var(--fill-0, #FAFAFD)" stroke="var(--stroke-0, #D8D8D8)"/>
+<rect id="Rectangle_65" x="81" y="191" width="102" height="1.6" rx="0.8" fill="var(--fill-0, #606060)" fill-opacity="0.85"/>
+<circle id="Ellipse_21" cx="82.5" cy="204.5" r="1.5" fill="var(--fill-0, #606060)" fill-opacity="0.9"/>
+<rect id="Rectangle_66" x="87" y="203.5" width="14" height="2" rx="1" fill="var(--fill-0, #606060)" fill-opacity="0.9"/>
+<rect id="Rectangle_67" x="104" y="203.5" width="28" height="2" rx="1" fill="var(--fill-0, #606060)" fill-opacity="0.9"/>
+<rect id="Rectangle_68" x="138" y="203.5" width="12" height="2" rx="1" fill="var(--fill-0, #606060)" fill-opacity="0.9"/>
+<circle id="Ellipse_22" cx="244.5" cy="204.5" r="1.5" fill="var(--fill-0, #606060)" fill-opacity="0.9"/>
+<rect id="Rectangle_69" x="80" y="212" width="28" height="2" rx="1" fill="var(--fill-0, #606060)" fill-opacity="0.9"/>
+<rect id="Rectangle_70" x="111" y="212" width="36" height="2" rx="1" fill="var(--fill-0, #606060)" fill-opacity="0.9"/>
+<rect id="Rectangle_71" x="259.5" y="10.5" width="58" height="207" rx="2.5" fill="var(--fill-0, white)" stroke="var(--stroke-0, #F0F1F2)"/>
+<path id="Union" d="M254 10C255.657 10 257 11.3431 257 13V215C257 216.657 255.657 218 254 218H73C71.3431 218 70 216.657 70 215V13C70 11.3431 71.3431 10 73 10H254ZM73 11C71.8954 11 71 11.8954 71 13V215C71 216.105 71.8954 217 73 217H254C255.105 217 256 216.105 256 215V13C256 11.8954 255.105 11 254 11H73Z" fill="var(--fill-0, #F0F1F2)"/>
+<rect id="Rectangle_72" x="262" y="21" width="43" height="5" rx="1" fill="var(--fill-0, #0069CC)"/>
+<g id="Rectangle_73">
+</g>
+<rect id="Rectangle_74" x="262" y="30" width="34" height="2" rx="1" fill="var(--fill-0, #202020)" fill-opacity="0.85"/>
+<rect id="Rectangle_75" x="304" y="30.2" width="10" height="1.6" rx="0.8" fill="var(--fill-0, #1A7F37)" fill-opacity="0.9"/>
+<rect id="Rectangle_76" x="262" y="38" width="3" height="3" rx="0.3" fill="var(--fill-0, #0069CC)" fill-opacity="0.7"/>
+<rect id="Rectangle_77" x="267" y="38.6" width="28" height="1.8" rx="0.9" fill="var(--fill-0, #202020)" fill-opacity="0.85"/>
+<rect id="Rectangle_78" x="298" y="38.8" width="12" height="1.4" rx="0.7" fill="var(--fill-0, #1A7F37)" fill-opacity="0.9"/>
+<rect id="Rectangle_79" x="312" y="38.5" width="2" height="2" rx="0.4" fill="var(--fill-0, #1A7F37)" fill-opacity="0.9"/>
+<rect id="Rectangle_80" x="262" y="47" width="3" height="3" rx="0.3" fill="var(--fill-0, #0069CC)" fill-opacity="0.7"/>
+<rect id="Rectangle_81" x="267" y="47.6" width="28" height="1.8" rx="0.9" fill="var(--fill-0, #202020)" fill-opacity="0.85"/>
+<rect id="Rectangle_82" x="296" y="47.8" width="14" height="1.4" rx="0.7" fill="var(--fill-0, #1A7F37)" fill-opacity="0.9"/>
+<rect id="Rectangle_83" x="312" y="47.5" width="2" height="2" rx="0.4" fill="var(--fill-0, #1A7F37)" fill-opacity="0.9"/>
+<rect id="Rectangle_84" x="262" y="56" width="3" height="3" rx="0.3" fill="var(--fill-0, #0069CC)" fill-opacity="0.7"/>
+<rect id="Rectangle_85" x="267" y="56.6" width="28" height="1.8" rx="0.9" fill="var(--fill-0, #202020)" fill-opacity="0.85"/>
+<rect id="Rectangle_86" x="298" y="56.8" width="12" height="1.4" rx="0.7" fill="var(--fill-0, #1A7F37)" fill-opacity="0.9"/>
+<rect id="Rectangle_87" x="312" y="56.5" width="2" height="2" rx="0.4" fill="var(--fill-0, #1A7F37)" fill-opacity="0.9"/>
+<rect id="Rectangle_88" x="262" y="65" width="3" height="3" rx="0.3" fill="var(--fill-0, #0069CC)" fill-opacity="0.7"/>
+<rect id="Rectangle_89" x="267" y="65.6" width="28" height="1.8" rx="0.9" fill="var(--fill-0, #202020)" fill-opacity="0.85"/>
+<rect id="Rectangle_90" x="296" y="65.8" width="14" height="1.4" rx="0.7" fill="var(--fill-0, #1A7F37)" fill-opacity="0.9"/>
+<rect id="Rectangle_91" x="312" y="65.5" width="2" height="2" rx="0.4" fill="var(--fill-0, #1A7F37)" fill-opacity="0.9"/>
+<rect id="Rectangle_92" x="262" y="74" width="3" height="3" rx="0.3" fill="var(--fill-0, #0069CC)" fill-opacity="0.7"/>
+<rect id="Rectangle_93" x="267" y="74.6" width="28" height="1.8" rx="0.9" fill="var(--fill-0, #202020)" fill-opacity="0.85"/>
+<rect id="Rectangle_94" x="304" y="74.8" width="6" height="1.4" rx="0.7" fill="var(--fill-0, #1A7F37)" fill-opacity="0.9"/>
+<rect id="Rectangle_95" x="312" y="74.5" width="2" height="2" rx="0.4" fill="var(--fill-0, #CF222E)" fill-opacity="0.9"/>
+<rect id="Rectangle_96" x="262" y="83" width="3" height="3" rx="0.3" fill="var(--fill-0, #0069CC)" fill-opacity="0.7"/>
+<rect id="Rectangle_97" x="267" y="83.6" width="28" height="1.8" rx="0.9" fill="var(--fill-0, #202020)" fill-opacity="0.85"/>
+<rect id="Rectangle_98" x="296" y="83.8" width="14" height="1.4" rx="0.7" fill="var(--fill-0, #1A7F37)" fill-opacity="0.9"/>
+<rect id="Rectangle_99" x="312" y="83.5" width="2" height="2" rx="0.4" fill="var(--fill-0, #1A7F37)" fill-opacity="0.9"/>
+<rect id="Rectangle_100" x="262" y="92" width="3" height="3" rx="0.3" fill="var(--fill-0, #0069CC)" fill-opacity="0.7"/>
+<rect id="Rectangle_101" x="267" y="92.6" width="28" height="1.8" rx="0.9" fill="var(--fill-0, #202020)" fill-opacity="0.85"/>
+<rect id="Rectangle_102" x="298" y="92.8" width="12" height="1.4" rx="0.7" fill="var(--fill-0, #1A7F37)" fill-opacity="0.9"/>
+<rect id="Rectangle_103" x="312" y="92.5" width="2" height="2" rx="0.4" fill="var(--fill-0, #CF222E)" fill-opacity="0.9"/>
+<rect id="Rectangle_104" x="262" y="14" width="16" height="2" rx="1" fill="var(--fill-0, #606060)" fill-opacity="0.7"/>
+<rect id="Rectangle_105" x="280" y="14" width="16" height="2" rx="1" fill="var(--fill-0, #606060)" fill-opacity="0.7"/>
+<rect id="Rectangle_106" x="307.5" y="21.5" width="6" height="4" rx="0.5" stroke="var(--stroke-0, #676868)"/>
+</g>
+</g>
+<defs>
+<clipPath id="clip0_762_20791">
+<rect width="320" height="220" rx="4" fill="white"/>
+</clipPath>
+</defs>
+</svg>


### PR DESCRIPTION
Introduce an SVG theme preview specifically for light mode, enhancing the visual experience for users. Testing can be done by switching to light mode and verifying the appearance of the new theme preview.

