### PR TITLE
Add right click visibility toggle for sign in button

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -1560,6 +1560,11 @@ configurationRegistry.registerConfiguration({
 			default: false,
 			scope: ConfigurationScope.WINDOW,
 		},
+		[ChatConfiguration.TitleBarSignInEnabled]: {
+			type: 'boolean',
+			description: nls.localize('chat.titleBar.signIn.enabled', "Controls whether the Copilot Sign In button is shown in the title bar when signed out. When disabled, the Sign In affordance falls back to the status bar."),
+			default: true,
+		},
 		'chat.approvedAccountOrganizations': {
 			type: 'array',
 			items: { type: 'string' },

--- a/src/vs/workbench/contrib/chat/browser/chatSetup/chatSetupContributions.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSetup/chatSetupContributions.ts
@@ -33,6 +33,7 @@ import { IOpenerService } from '../../../../../platform/opener/common/opener.js'
 import product from '../../../../../platform/product/common/product.js';
 import { IProductService } from '../../../../../platform/product/common/productService.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { ToggleTitleBarConfigAction } from '../../../../browser/parts/titlebar/titlebarActions.js';
 import { IWorkbenchContribution } from '../../../../common/contributions.js';
 import { IViewDescriptorService, ViewContainerLocation } from '../../../../common/views.js';
 import { ChatEntitlement, ChatEntitlementContext, ChatEntitlementRequests, ChatEntitlementService, IChatEntitlementService, isProUser } from '../../../../services/chat/common/chatEntitlementService.js';
@@ -400,10 +401,10 @@ export class ChatSetupContribution extends Disposable implements IWorkbenchContr
 						order: 0, // same position as the update button
 						when: ContextKeyExpr.and(
 							IsWebContext.negate(),
-
 							ChatContextKeys.Entitlement.signedOut,
 							ChatContextKeys.Setup.hidden.negate(),
 							ChatContextKeys.Setup.disabledInWorkspace.negate(),
+							ContextKeyExpr.equals(`config.${ChatConfiguration.TitleBarSignInEnabled}`, true),
 							ContextKeyExpr.has('updateTitleBar').negate(),
 							InEditorZenModeContext.negate(),
 						),
@@ -418,6 +419,23 @@ export class ChatSetupContribution extends Disposable implements IWorkbenchContr
 				telemetryService.publicLog2<WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification>('workbenchActionExecuted', { id: CHAT_SETUP_ACTION_ID, from: 'titlebar' });
 
 				return commandService.executeCommand(CHAT_SETUP_ACTION_ID);
+			}
+		}
+
+		class ToggleSignInTitleBarAction extends ToggleTitleBarConfigAction {
+			constructor() {
+				super(
+					ChatConfiguration.TitleBarSignInEnabled,
+					localize('toggle.chatSignIn', 'Copilot Sign In'),
+					localize('toggle.chatSignInDescription', "Toggle visibility of the Copilot Sign In button in title bar"),
+					3,
+					ContextKeyExpr.and(
+						IsWebContext.negate(),
+						ChatContextKeys.Entitlement.signedOut,
+						ChatContextKeys.Setup.hidden.negate(),
+						ChatContextKeys.Setup.disabledInWorkspace.negate(),
+					)
+				);
 			}
 		}
 
@@ -530,6 +548,7 @@ export class ChatSetupContribution extends Disposable implements IWorkbenchContr
 		registerAction2(ChatSetupTriggerForceSignInDialogAction);
 		registerAction2(ChatSetupFromAccountsAction);
 		registerAction2(ChatSetupSignInTitleBarAction);
+		registerAction2(ToggleSignInTitleBarAction);
 		registerAction2(ChatSetupTriggerAnonymousWithoutDialogAction);
 		registerAction2(ChatSetupTriggerSupportAnonymousAction);
 		registerAction2(UpgradePlanAction);

--- a/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusEntry.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusEntry.ts
@@ -34,6 +34,8 @@ export class ChatStatusBarEntry extends Disposable implements IWorkbenchContribu
 
 	static readonly ID = 'workbench.contrib.chatStatusBarEntry';
 
+	private static readonly TITLE_BAR_CONTEXT_KEYS = new Set(['updateTitleBar', InEditorZenModeContext.key]);
+
 	private entry: IStatusbarEntryAccessor | undefined = undefined;
 
 	private readonly activeCodeEditorListener = this._register(new MutableDisposable());
@@ -107,7 +109,7 @@ export class ChatStatusBarEntry extends Disposable implements IWorkbenchContribu
 		this._register(this.chatEntitlementService.onDidChangeSentiment(() => this.update()));
 		this._register(this.chatEntitlementService.onDidChangeEntitlement(() => this.update()));
 		this._register(this.contextKeyService.onDidChangeContext(e => {
-			if (e.affectsSome(new Set(['updateTitleBar', InEditorZenModeContext.key]))) {
+			if (e.affectsSome(ChatStatusBarEntry.TITLE_BAR_CONTEXT_KEYS)) {
 				this.update();
 			}
 		}));
@@ -262,6 +264,11 @@ export class ChatStatusBarEntry extends Disposable implements IWorkbenchContribu
 
 	private isSignInTitleBarAffordanceVisible(): boolean {
 		if (isWeb) {
+			return false;
+		}
+
+		// Title bar sign-in button only shows when user is signed out
+		if (this.chatEntitlementService.entitlement !== ChatEntitlement.Unknown) {
 			return false;
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusEntry.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusEntry.ts
@@ -25,6 +25,10 @@ import { isCompletionsEnabled } from '../../../../../editor/common/services/comp
 import { CommandsRegistry } from '../../../../../platform/commands/common/commands.js';
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 import { CHAT_SETUP_ACTION_ID } from '../actions/chatActions.js';
+import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { isWeb } from '../../../../../base/common/platform.js';
+import { InEditorZenModeContext } from '../../../../common/contextkeys.js';
+import { ChatConfiguration } from '../../common/constants.js';
 
 export class ChatStatusBarEntry extends Disposable implements IWorkbenchContribution {
 
@@ -46,6 +50,7 @@ export class ChatStatusBarEntry extends Disposable implements IWorkbenchContribu
 		@IInlineCompletionsService private readonly completionsService: IInlineCompletionsService,
 		@IChatSessionsService private readonly chatSessionsService: IChatSessionsService,
 		@IHoverService private readonly hoverService: IHoverService,
+		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 	) {
 		super();
 
@@ -101,6 +106,11 @@ export class ChatStatusBarEntry extends Disposable implements IWorkbenchContribu
 		this._register(this.chatEntitlementService.onDidChangeQuotaExceeded(() => this.update()));
 		this._register(this.chatEntitlementService.onDidChangeSentiment(() => this.update()));
 		this._register(this.chatEntitlementService.onDidChangeEntitlement(() => this.update()));
+		this._register(this.contextKeyService.onDidChangeContext(e => {
+			if (e.affectsSome(new Set(['updateTitleBar', InEditorZenModeContext.key]))) {
+				this.update();
+			}
+		}));
 
 		this._register(this.completionsService.onDidChangeIsSnoozing(() => this.update()));
 
@@ -115,7 +125,7 @@ export class ChatStatusBarEntry extends Disposable implements IWorkbenchContribu
 		this._register(this.editorService.onDidActiveEditorChange(() => this.onDidActiveEditorChange()));
 
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration(product.defaultChatAgent?.completionsEnablementSetting)) {
+			if (e.affectsConfiguration(product.defaultChatAgent?.completionsEnablementSetting) || e.affectsConfiguration(ChatConfiguration.TitleBarSignInEnabled)) {
 				this.update();
 			}
 		}));
@@ -238,15 +248,39 @@ export class ChatStatusBarEntry extends Disposable implements IWorkbenchContribu
 	}
 
 	private getSetupEntryProps(): IStatusbarEntry {
+		const showSignInLabel = !this.isSignInTitleBarAffordanceVisible();
 		const signInLabel = localize('signIn', "Sign In");
 		return {
 			name: localize('chatStatus', "Copilot Status"),
-			text: `$(copilot) ${signInLabel}`,
-			ariaLabel: signInLabel,
+			text: showSignInLabel ? `$(copilot) ${signInLabel}` : '$(copilot)',
+			ariaLabel: showSignInLabel ? signInLabel : localize('chatStatusAria', "Copilot status"),
 			command: CHAT_SETUP_ACTION_ID,
 			showInAllWindows: true,
 			kind: undefined,
 		};
+	}
+
+	private isSignInTitleBarAffordanceVisible(): boolean {
+		if (isWeb) {
+			return false;
+		}
+
+		if (this.chatEntitlementService.sentiment.hidden || this.chatEntitlementService.sentiment.disabledInWorkspace) {
+			return false;
+		}
+
+		const hasTitleBarUpdate = Boolean(this.contextKeyService.getContextKeyValue('updateTitleBar'));
+		if (hasTitleBarUpdate) {
+			return false;
+		}
+
+		const inZenMode = Boolean(this.contextKeyService.getContextKeyValue(InEditorZenModeContext.key));
+		if (inZenMode) {
+			return false;
+		}
+
+		const signInTitleBarEnabled = this.configurationService.getValue<boolean>(ChatConfiguration.TitleBarSignInEnabled) !== false;
+		return signInTitleBarEnabled;
 	}
 
 	override dispose(): void {

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -64,6 +64,7 @@ export enum ChatConfiguration {
 	ExplainChangesEnabled = 'chat.editing.explainChanges.enabled',
 	RevealNextChangeOnResolve = 'chat.editing.revealNextChangeOnResolve',
 	GrowthNotificationEnabled = 'chat.growthNotification.enabled',
+	TitleBarSignInEnabled = 'chat.titleBar.signIn.enabled',
 
 	ChatCustomizationHarnessSelectorEnabled = 'chat.customizations.harnessSelector.enabled',
 	ChatCustomizationsStructuredPreviewEnabled = 'chat.customizations.structuredPreview.enabled',


### PR DESCRIPTION
Adds right click toggle for Sign in button to align with other elements in the title bar. Currently this can be hidden by signing in or disabling AI features so we want to support right click hide / show as well 

<img width="751" height="524" alt="image" src="https://github.com/user-attachments/assets/7054b259-c465-4156-abb4-94abd69185b6" />

**Configuration and UI improvements:**

* Added new configuration option `chat.titleBar.signIn.enabled` to control whether the Copilot "Sign In" button appears in the title bar or falls back to the status bar when disabled. [[1]](diffhunk://#diff-63ebcc188cf5338e8b62aedeef03d66cb436e5a171d924d55de83edc65bb8568R1563-R1567) [[2]](diffhunk://#diff-f92851ad97eb17f27d267f36b103e8d831725fea8f46a2ae9252e80a4d2a8187R67)
* Introduced `ToggleSignInTitleBarAction`, which allows users to toggle the visibility of the title bar sign-in button via the command palette. [[1]](diffhunk://#diff-503b5a275763be885d53bfacc4e798e25a755849990ceb09c599dad5a8c9558cR36) [[2]](diffhunk://#diff-503b5a275763be885d53bfacc4e798e25a755849990ceb09c599dad5a8c9558cR425-R441) [[3]](diffhunk://#diff-503b5a275763be885d53bfacc4e798e25a755849990ceb09c599dad5a8c9558cR551)
* Updated the context expression for displaying the title bar sign-in button to respect the new configuration setting.
* Enhanced the status bar entry logic to only show the "Sign In" label if the title bar affordance is not visible, ensuring consistent and context-aware UI. [[1]](diffhunk://#diff-85a2c8a3b2aa02a2e8a7c5841692f46f5a72a603f89e76a494c6c5eb2cc7eec5R28-R31) [[2]](diffhunk://#diff-85a2c8a3b2aa02a2e8a7c5841692f46f5a72a603f89e76a494c6c5eb2cc7eec5R53) [[3]](diffhunk://#diff-85a2c8a3b2aa02a2e8a7c5841692f46f5a72a603f89e76a494c6c5eb2cc7eec5R109-R113) [[4]](diffhunk://#diff-85a2c8a3b2aa02a2e8a7c5841692f46f5a72a603f89e76a494c6c5eb2cc7eec5L118-R128) [[5]](diffhunk://#diff-85a2c8a3b2aa02a2e8a7c5841692f46f5a72a603f89e76a494c6c5eb2cc7eec5R251-R285)
* Implemented the `isSignInTitleBarAffordanceVisible` method to centralize the logic for determining when the title bar sign-in button should be shown, considering web context, workspace settings, Zen mode, and the new configuration.
