### PR TITLE
sessions: Agents window UI polish and chat setup API

### DIFF
--- a/src/vs/sessions/browser/actions/vscodeActions.ts
+++ b/src/vs/sessions/browser/actions/vscodeActions.ts
@@ -35,7 +35,7 @@ export class OpenInVSCodeAction extends Action2 {
 	constructor() {
 		super({
 			id: OpenInVSCodeAction.ID,
-			title: localize2('openInVSCode', 'Open in VS Code'),
+			title: localize2('openInVSCode', 'Open in Editor'),
 			icon: Codicon.vscodeInsiders,
 			precondition: ContextKeyExpr.and(IsAuxiliaryWindowContext.toNegated(), SessionsWelcomeVisibleContext.toNegated()),
 			menu: [{

--- a/src/vs/sessions/browser/widget/openInVSCodeWidget.ts
+++ b/src/vs/sessions/browser/widget/openInVSCodeWidget.ts
@@ -40,9 +40,10 @@ export class OpenInVSCodeTitleBarWidget extends BaseActionViewItem {
 			container.setAttribute('data-product-quality', quality);
 		}
 
-		const label = this.action.label || localize('openInVSCodeLabel', "Open in VS Code");
-		container.setAttribute('aria-label', label);
-		this._register(this.hoverService.setupManagedHover(getDefaultHoverDelegate('element'), container, label));
+		const label = this.action.label;
+		const hoverText = localize('openInVSCodeHover', "Open in VS Code Editor Window");
+		container.setAttribute('aria-label', hoverText);
+		this._register(this.hoverService.setupManagedHover(getDefaultHoverDelegate('element'), container, hoverText));
 
 		const icon = append(container, $('span.open-in-vscode-titlebar-widget-icon'));
 		icon.setAttribute('aria-hidden', 'true');

--- a/src/vs/sessions/common/sessionsChatSetupState.ts
+++ b/src/vs/sessions/common/sessionsChatSetupState.ts
@@ -1,0 +1,86 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../base/common/lifecycle.js';
+import { createDecorator, IInstantiationService } from '../../platform/instantiation/common/instantiation.js';
+import { ILogService } from '../../platform/log/common/log.js';
+import { IStorageService } from '../../platform/storage/common/storage.js';
+import { IUserDataProfileStorageService } from '../../platform/userDataProfile/common/userDataProfileStorageService.js';
+import { IUserDataProfilesService } from '../../platform/userDataProfile/common/userDataProfile.js';
+import { ServiceCollection } from '../../platform/instantiation/common/serviceCollection.js';
+import { ChatEntitlementContext, IChatEntitlementService } from '../../workbench/services/chat/common/chatEntitlementService.js';
+
+export const ISessionsChatSetupStateService = createDecorator<ISessionsChatSetupStateService>('sessionsChatSetupStateService');
+
+export interface ISessionsChatSetupStateService {
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * Resolves to whether the chat setup has been completed — either
+	 * locally in this sessions window or in the main VS Code window
+	 * (default profile).
+	 */
+	whenSetupDone(): Promise<boolean>;
+
+	/**
+	 * Mark the setup as completed by updating the current profile's
+	 * chat entitlement context. Listeners can observe the change via
+	 * `IChatEntitlementService.onDidChangeSentiment`.
+	 */
+	markDone(): void;
+}
+
+export class SessionsChatSetupStateService extends Disposable implements ISessionsChatSetupStateService {
+
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _initPromise: Promise<void>;
+
+	constructor(
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
+		@IUserDataProfileStorageService private readonly userDataProfileStorageService: IUserDataProfileStorageService,
+		@IUserDataProfilesService private readonly userDataProfilesService: IUserDataProfilesService,
+		@IChatEntitlementService private readonly chatEntitlementService: IChatEntitlementService,
+		@ILogService private readonly logService: ILogService,
+	) {
+		super();
+
+		this._initPromise = this.initialize();
+	}
+
+	async whenSetupDone(): Promise<boolean> {
+		await this._initPromise;
+		return this.chatEntitlementService.sentiment.completed === true;
+	}
+
+	markDone(): void {
+		this.chatEntitlementService.markSetupCompleted();
+	}
+
+	private async initialize(): Promise<void> {
+		if (this.chatEntitlementService.sentiment.completed) {
+			return; // already done on current profile
+		}
+
+		try {
+			const defaultProfile = this.userDataProfilesService.defaultProfile;
+			await this.userDataProfileStorageService.withProfileScopedStorageService(defaultProfile, async storageService => {
+				const defaultContext = this.instantiationService
+					.createChild(new ServiceCollection([IStorageService, storageService]))
+					.createInstance(ChatEntitlementContext);
+				try {
+					if (defaultContext.state.completed) {
+						this.logService.info('[sessions chat setup] Setup already completed in default profile, marking done locally');
+						this.markDone();
+					}
+				} finally {
+					defaultContext.dispose();
+				}
+			});
+		} catch (error) {
+			this.logService.error('[sessions chat setup] Failed to read setup state from default profile:', error);
+		}
+	}
+}

--- a/src/vs/sessions/contrib/welcome/browser/media/sessionsWalkthrough.css
+++ b/src/vs/sessions/contrib/welcome/browser/media/sessionsWalkthrough.css
@@ -246,12 +246,13 @@
 	display: none;
 }
 
-/* ---- Hero layout (icon left, text right) ---- */
+/* ---- Hero layout (image top, text bottom) ---- */
 
 .sessions-walkthrough-hero {
 	display: flex;
-	align-items: stretch;
-	gap: 24px;
+	flex-direction: column;
+	align-items: center;
+	gap: 40px;
 }
 
 .sessions-walkthrough-hero .sessions-walkthrough-icon {
@@ -262,7 +263,7 @@
 .sessions-walkthrough-hero-text {
 	display: flex;
 	flex-direction: column;
-	justify-content: center;
+	align-items: center;
 	gap: 6px;
 }
 
@@ -289,16 +290,28 @@
 	font-size: 112px;
 }
 
-/* Sessions logo for sign-in screen */
+/* Sessions logo for sign-in screen — theme-aware editor preview */
 .sessions-walkthrough-logo {
-	width: 112px;
-	height: 112px;
-	background-image: url('../../../../browser/media/sessions-icon.svg');
+	width: 280px;
+	height: 182px;
+	background-image: url('./themePreviews/theme-preview-dark-2026.svg');
 	background-size: contain;
 	background-repeat: no-repeat;
 	background-position: center;
 	flex-shrink: 0;
 	align-self: center;
+}
+
+.vs .sessions-walkthrough-logo {
+	background-image: url('./themePreviews/theme-preview-light-2026.svg');
+}
+
+.hc-black .sessions-walkthrough-logo {
+	background-image: url('./themePreviews/theme-preview-hc-dark.svg');
+}
+
+.hc-light .sessions-walkthrough-logo {
+	background-image: url('./themePreviews/theme-preview-hc-light.svg');
 }
 
 /* ---- Action area (used inside content for sign-in step spinner) ---- */
@@ -402,7 +415,9 @@
 	min-height: 200px;
 }
 
-.sessions-walkthrough-loading-icon {
+.sessions-walkthrough-loading-indicator .sessions-walkthrough-loading-icon.codicon {
+	font-size: 112px;
+	color: var(--vscode-foreground);
 	animation: sessions-walkthrough-pulse 1.4s ease-in-out infinite;
 }
 
@@ -415,12 +430,6 @@
 .agent-sessions-workbench.monaco-reduce-motion .sessions-walkthrough-loading-icon {
 	animation: none;
 	opacity: 0.7;
-}
-
-.sessions-walkthrough-tagline {
-	font-style: italic;
-	opacity: 0.85;
-	margin-top: 4px;
 }
 
 /* ---- Theme step ---- */

--- a/src/vs/sessions/contrib/welcome/browser/sessionsWalkthrough.ts
+++ b/src/vs/sessions/contrib/welcome/browser/sessionsWalkthrough.ts
@@ -19,6 +19,7 @@ import { URI } from '../../../../base/common/uri.js';
 import { CHAT_SETUP_SUPPORT_ANONYMOUS_ACTION_ID } from '../../../../workbench/contrib/chat/browser/actions/chatActions.js';
 import { ChatSetupStrategy } from '../../../../workbench/contrib/chat/browser/chatSetup/chatSetup.js';
 import { IExtensionService } from '../../../../workbench/services/extensions/common/extensions.js';
+import { ISessionsChatSetupStateService } from '../../../common/sessionsChatSetupState.js';
 
 
 export type WalkthroughOutcome = 'completed' | 'dismissed';
@@ -82,6 +83,7 @@ export class SessionsWalkthroughOverlay extends Disposable {
 		@IOpenerService private readonly openerService: IOpenerService,
 		@IProductService private readonly productService: IProductService,
 		@ILogService private readonly logService: ILogService,
+		@ISessionsChatSetupStateService private readonly chatSetupStateService: ISessionsChatSetupStateService,
 	) {
 		super();
 
@@ -164,7 +166,7 @@ export class SessionsWalkthroughOverlay extends Disposable {
 		loadingIndicator.setAttribute('role', 'status');
 		loadingIndicator.setAttribute('aria-busy', 'true');
 		loadingIndicator.setAttribute('aria-label', localize('walkthrough.loading', "Loading"));
-		append(loadingIndicator, $('div.sessions-walkthrough-logo.sessions-walkthrough-loading-icon'));
+		append(loadingIndicator, $('div.sessions-walkthrough-loading-icon.codicon.codicon-agent'));
 	}
 
 	// ------------------------------------------------------------------
@@ -175,7 +177,7 @@ export class SessionsWalkthroughOverlay extends Disposable {
 
 		this.contentContainer.textContent = '';
 		this.footerContainer.textContent = '';
-		this.disclaimerElement.classList.toggle('hidden', this.disclaimerLinks.length === 0);
+		this._updateDisclaimerVisibility();
 
 		const productName = localize('walkthrough.productName', "{0} - Agents", this.productService.nameLong);
 
@@ -196,12 +198,11 @@ export class SessionsWalkthroughOverlay extends Disposable {
 		// whether it's the first launch or a returning user who is signed out.
 		const titleEl = append(right, $('h2', undefined, localize('walkthrough.welcome.title', "Welcome to {0}", productName)));
 		const subtitleEl = append(right, $('p', undefined, localize('walkthrough.welcome.subtitle', "Your AI-powered coding experience where agents explore, build, and iterate with you.")));
-		const taglineEl = append(right, $('p.sessions-walkthrough-tagline', undefined, localize('walkthrough.welcome.tagline', "Happy Agentic Coding!")));
 
-		this._renderSignInButtons(stepDisposables, right, titleEl, subtitleEl, taglineEl);
+		this._renderSignInButtons(stepDisposables, right, titleEl, subtitleEl);
 	}
 
-	private _renderSignInButtons(stepDisposables: DisposableStore, right: HTMLElement, titleEl: HTMLElement, subtitleEl: HTMLElement, taglineEl: HTMLElement): void {
+	private _renderSignInButtons(stepDisposables: DisposableStore, right: HTMLElement, titleEl: HTMLElement, subtitleEl: HTMLElement): void {
 		this._isShowingSignIn = true;
 		const signInActions = append(right, $('.sessions-walkthrough-sign-in-actions'));
 		const providerRow = append(signInActions, $('.sessions-walkthrough-providers-row'));
@@ -251,7 +252,6 @@ export class SessionsWalkthroughOverlay extends Disposable {
 				errorContainer,
 				titleEl,
 				subtitleEl,
-				taglineEl,
 				signInActions
 			)));
 		} else {
@@ -270,7 +270,6 @@ export class SessionsWalkthroughOverlay extends Disposable {
 					strategy,
 					titleEl,
 					subtitleEl,
-					taglineEl,
 					signInActions
 				)));
 			}
@@ -282,11 +281,10 @@ export class SessionsWalkthroughOverlay extends Disposable {
 
 	private _renderWelcome(stepDisposables: DisposableStore, right: HTMLElement, productName: string): void {
 		this._isShowingWelcome = true;
-		this.disclaimerElement.classList.toggle('hidden', this.disclaimerLinks.length === 0);
+		this._updateDisclaimerVisibility();
 
 		append(right, $('h2', undefined, localize('walkthrough.welcome.title', "Welcome to {0}", productName)));
 		append(right, $('p', undefined, localize('walkthrough.welcome.subtitle', "Your AI-powered coding experience where agents explore, build, and iterate with you.")));
-		append(right, $('p.sessions-walkthrough-tagline', undefined, localize('walkthrough.welcome.tagline', "Happy Agentic Coding!")));
 
 		const actions = append(right, $('.sessions-walkthrough-welcome-actions'));
 		const getStartedBtn = append(actions, $('button.sessions-walkthrough-get-started-btn')) as HTMLButtonElement;
@@ -309,8 +307,8 @@ export class SessionsWalkthroughOverlay extends Disposable {
 		return this.defaultAccountService.currentDefaultAccount !== null;
 	}
 
-	private async _runSignIn(providerButtons: HTMLButtonElement[], error: HTMLElement, strategy: ChatSetupStrategy, titleEl: HTMLElement, subtitleEl: HTMLElement, taglineEl: HTMLElement, signInActions: HTMLElement): Promise<void> {
-		await this._fadeToProgress(providerButtons, error, titleEl, subtitleEl, taglineEl, signInActions);
+	private async _runSignIn(providerButtons: HTMLButtonElement[], error: HTMLElement, strategy: ChatSetupStrategy, titleEl: HTMLElement, subtitleEl: HTMLElement, signInActions: HTMLElement): Promise<void> {
+		await this._fadeToProgress(providerButtons, error, titleEl, subtitleEl, signInActions);
 		if (this._shouldAbortUpdate(titleEl, subtitleEl)) {
 			return;
 		}
@@ -357,8 +355,8 @@ export class SessionsWalkthroughOverlay extends Disposable {
 	 * this triggers an OAuth popup. On localhost the embedder's
 	 * env-contributed auth provider handles the flow (e.g. device code).
 	 */
-	private async _runSignInWeb(providerButtons: HTMLButtonElement[], error: HTMLElement, titleEl: HTMLElement, subtitleEl: HTMLElement, taglineEl: HTMLElement, signInActions: HTMLElement): Promise<void> {
-		await this._fadeToProgress(providerButtons, error, titleEl, subtitleEl, taglineEl, signInActions);
+	private async _runSignInWeb(providerButtons: HTMLButtonElement[], error: HTMLElement, titleEl: HTMLElement, subtitleEl: HTMLElement, signInActions: HTMLElement): Promise<void> {
+		await this._fadeToProgress(providerButtons, error, titleEl, subtitleEl, signInActions);
 		if (this._shouldAbortUpdate(titleEl, subtitleEl)) {
 			return;
 		}
@@ -374,7 +372,7 @@ export class SessionsWalkthroughOverlay extends Disposable {
 		}
 	}
 
-	private async _fadeToProgress(providerButtons: HTMLButtonElement[], error: HTMLElement, titleEl: HTMLElement, subtitleEl: HTMLElement, taglineEl: HTMLElement, signInActions: HTMLElement): Promise<void> {
+	private async _fadeToProgress(providerButtons: HTMLButtonElement[], error: HTMLElement, titleEl: HTMLElement, subtitleEl: HTMLElement, signInActions: HTMLElement): Promise<void> {
 		// Disable all provider buttons
 		for (const btn of providerButtons) {
 			btn.disabled = true;
@@ -394,7 +392,6 @@ export class SessionsWalkthroughOverlay extends Disposable {
 		// Swap title and subtitle in-place
 		titleEl.textContent = localize('walkthrough.settingUp', "Signing in\u2026");
 		subtitleEl.textContent = localize('walkthrough.poweredBy', "Complete authorization in your browser.");
-		taglineEl.remove();
 
 		// Replace sign-in actions with progress bar
 		const heroText = signInActions.parentElement;
@@ -516,6 +513,18 @@ export class SessionsWalkthroughOverlay extends Disposable {
 
 	private _shouldAbortUpdate(...elements: HTMLElement[]): boolean {
 		return !this.overlay.isConnected || elements.some(element => !element.isConnected);
+	}
+
+	private _updateDisclaimerVisibility(): void {
+		const hidden = this.disclaimerLinks.length === 0;
+		this.disclaimerElement.classList.toggle('hidden', hidden);
+		if (!hidden) {
+			this.chatSetupStateService.whenSetupDone().then(done => {
+				if (done) {
+					this.disclaimerElement.classList.add('hidden');
+				}
+			});
+		}
 	}
 
 	private _createDisclaimer(): { element: HTMLElement; links: readonly HTMLAnchorElement[] } {

--- a/src/vs/sessions/contrib/welcome/browser/welcome.contribution.ts
+++ b/src/vs/sessions/contrib/welcome/browser/welcome.contribution.ts
@@ -21,6 +21,7 @@ import { IWorkbenchEnvironmentService } from '../../../../workbench/services/env
 import { IAuthenticationService } from '../../../../workbench/services/authentication/common/authentication.js';
 import { SessionsWalkthroughOverlay, WalkthroughOutcome } from './sessionsWalkthrough.js';
 import { WELCOME_COMPLETE_KEY } from '../../../common/welcome.js';
+import { ISessionsChatSetupStateService } from '../../../common/sessionsChatSetupState.js';
 
 function shouldSkipSessionsWelcome(environmentService: IWorkbenchEnvironmentService): boolean {
 	const envArgs = (environmentService as IWorkbenchEnvironmentService & { args?: Record<string, unknown> }).args;
@@ -99,6 +100,7 @@ export class SessionsWelcomeContribution extends Disposable implements IWorkbenc
 		@IWorkbenchEnvironmentService private readonly environmentService: IWorkbenchEnvironmentService,
 		@IAuthenticationService private readonly authenticationService: IAuthenticationService,
 		@ILogService private readonly logService: ILogService,
+		@ISessionsChatSetupStateService private readonly chatSetupStateService: ISessionsChatSetupStateService,
 	) {
 		super();
 
@@ -239,6 +241,7 @@ export class SessionsWelcomeContribution extends Disposable implements IWorkbenc
 			if (!welcomeCompletionStored && !walkthrough.isShowingWelcome && walkthrough.isShowingSignIn && account !== null) {
 				welcomeCompletionStored = true;
 				this.storageService.store(WELCOME_COMPLETE_KEY, true, StorageScope.APPLICATION, StorageTarget.MACHINE);
+				this.chatSetupStateService.markDone();
 				walkthrough.complete();
 			}
 		}));
@@ -252,6 +255,7 @@ export class SessionsWelcomeContribution extends Disposable implements IWorkbenc
 			if (!welcomeCompletionStored && shouldPersistWelcomeCompletion(outcome, this.defaultAccountService)) {
 				welcomeCompletionStored = true;
 				this.storageService.store(WELCOME_COMPLETE_KEY, true, StorageScope.APPLICATION, StorageTarget.MACHINE);
+				this.chatSetupStateService.markDone();
 			}
 			this.overlayRef.clear();
 			this.watchSignInState();

--- a/src/vs/sessions/electron-browser/actions/vscodeActions.ts
+++ b/src/vs/sessions/electron-browser/actions/vscodeActions.ts
@@ -37,7 +37,7 @@ export class OpenSessionInVSCodeAction extends Action2 {
 	constructor() {
 		super({
 			id: OpenSessionInVSCodeAction.ID,
-			title: localize2('openInVSCode', 'Open in VS Code'),
+			title: localize2('openInVSCode', 'Open in Editor'),
 			icon: Codicon.vscodeInsiders,
 			precondition: ContextKeyExpr.and(IsAuxiliaryWindowContext.toNegated(), SessionsWelcomeVisibleContext.toNegated()),
 			menu: [{

--- a/src/vs/sessions/sessions.common.main.ts
+++ b/src/vs/sessions/sessions.common.main.ts
@@ -170,6 +170,7 @@ import { McpGalleryService } from '../platform/mcp/common/mcpGalleryService.js';
 import { AllowedMcpServersService } from '../platform/mcp/common/allowedMcpServersService.js';
 import { IWebWorkerService } from '../platform/webWorker/browser/webWorkerService.js';
 import { WebWorkerService } from '../platform/webWorker/browser/webWorkerServiceImpl.js';
+import { ISessionsChatSetupStateService, SessionsChatSetupStateService } from './common/sessionsChatSetupState.js';
 
 registerSingleton(IUserDataSyncLogService, UserDataSyncLogService, InstantiationType.Delayed);
 registerSingleton(IAllowedExtensionsService, AllowedExtensionsService, InstantiationType.Delayed);
@@ -187,6 +188,7 @@ registerSingleton(IOpenerService, OpenerService, InstantiationType.Delayed);
 registerSingleton(IWebWorkerService, WebWorkerService, InstantiationType.Delayed);
 registerSingleton(IMcpGalleryService, McpGalleryService, InstantiationType.Delayed);
 registerSingleton(IAllowedMcpServersService, AllowedMcpServersService, InstantiationType.Delayed);
+registerSingleton(ISessionsChatSetupStateService, SessionsChatSetupStateService, InstantiationType.Delayed);
 
 //#endregion
 

--- a/src/vs/sessions/test/web.test.ts
+++ b/src/vs/sessions/test/web.test.ts
@@ -108,6 +108,7 @@ class MockChatEntitlementService implements IChatEntitlementService {
 	readonly anonymousObs: IObservable<boolean> = observableValue('anonymous', false);
 
 	markAnonymousRateLimited(): void { }
+	markSetupCompleted(): void { }
 	setForceHidden(_hidden: boolean): void { }
 	async update(_token: CancellationToken): Promise<void> { }
 }

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsBanner.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsBanner.ts
@@ -67,7 +67,7 @@ export function createAgentsBanner(
 	telemetryService: ITelemetryService,
 ): IAgentsBannerResult {
 	const disposables = new DisposableStore();
-	const label = options.label ?? localize('agentsBanner.tryAgentsAppLabel', "Try out the new Agents app");
+	const label = options.label ?? localize('agentsBanner.tryAgentsAppLabel', "Try out the new Agents");
 
 	const button = $('button.agents-banner-button', {
 		title: label,

--- a/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts
@@ -31,7 +31,7 @@ export class OpenWorkspaceInAgentsWindowAction extends Action2 {
 	constructor() {
 		super({
 			id: OPEN_WORKSPACE_IN_AGENTS_WINDOW_COMMAND_ID,
-			title: localize2('openWorkspaceInAgentsWindow', "Open in Agents Window"),
+			title: localize2('openWorkspaceInAgentsWindow', "Open in Agents"),
 			category: CHAT_CATEGORY,
 			precondition: OPEN_AGENTS_WINDOW_PRECONDITION,
 			f1: true,
@@ -99,11 +99,12 @@ class OpenWorkspaceInAgentsTitleBarWidget extends BaseActionViewItem {
 		container.classList.add('open-in-agents-titlebar-widget');
 		container.setAttribute('role', 'button');
 
-		const label = this.action.label || localize('openInAgentsLabel', "Open in Agents");
-		container.setAttribute('aria-label', label);
-		this._register(this.hoverService.setupManagedHover(getDefaultHoverDelegate('element'), container, label));
+		const label = this.action.label;
+		const hoverText = localize('openInAgentsHover', "Open in Agents Window");
+		container.setAttribute('aria-label', hoverText);
+		this._register(this.hoverService.setupManagedHover(getDefaultHoverDelegate('element'), container, hoverText));
 
-		const icon = append(container, $('span.open-in-agents-titlebar-widget-icon'));
+		const icon = append(container, $('span.open-in-agents-titlebar-widget-icon.codicon.codicon-agent'));
 		icon.setAttribute('aria-hidden', 'true');
 
 		const labelEl = append(container, $('span.open-in-agents-titlebar-widget-label'));

--- a/src/vs/workbench/contrib/chat/electron-browser/agentSessions/media/openInAgents.css
+++ b/src/vs/workbench/contrib/chat/electron-browser/agentSessions/media/openInAgents.css
@@ -34,23 +34,12 @@
 	width: 16px;
 	height: 16px;
 	flex: 0 0 auto;
-	background-image: url('../../../../../../sessions/browser/media/sessions-icon.svg');
-	background-repeat: no-repeat;
-	background-position: center center;
-	background-size: contain;
-	/* Keep desaturated for legibility against light/dark titlebar backgrounds; brighten on hover/focus. */
-	filter: grayscale(1);
+	font-size: 16px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
-.monaco-enable-motion .monaco-workbench .open-in-agents-titlebar-widget > .open-in-agents-titlebar-widget-icon,
-.monaco-workbench.monaco-enable-motion .open-in-agents-titlebar-widget > .open-in-agents-titlebar-widget-icon {
-	transition: filter 160ms ease;
-}
-
-.monaco-workbench .open-in-agents-titlebar-widget:hover > .open-in-agents-titlebar-widget-icon,
-.monaco-workbench .open-in-agents-titlebar-widget:focus-visible > .open-in-agents-titlebar-widget-icon {
-	filter: none;
-}
 
 .monaco-workbench .open-in-agents-titlebar-widget > .open-in-agents-titlebar-widget-label {
 	display: inline-block;

--- a/src/vs/workbench/contrib/chat/test/browser/chatStatusDashboard.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatStatusDashboard.test.ts
@@ -60,6 +60,7 @@ function createEntitlementService(opts: {
 		onDidChangeAnonymous: Event.None,
 		anonymousObs: observableValue({}, false),
 		markAnonymousRateLimited: () => { },
+		markSetupCompleted: () => { },
 		setForceHidden: () => { },
 		previewFeaturesDisabled: false,
 		clientByokEnabled: false,

--- a/src/vs/workbench/services/chat/common/chatEntitlementService.ts
+++ b/src/vs/workbench/services/chat/common/chatEntitlementService.ts
@@ -190,6 +190,11 @@ export interface IChatEntitlementService {
 	markAnonymousRateLimited(): void;
 
 	/**
+	 * Mark the chat setup flow as completed.
+	 */
+	markSetupCompleted(): void;
+
+	/**
 	 * Force the hidden state on or off, overriding the normal entitlement logic.
 	 * Used by the account policy gate to hide all AI features when the gate is
 	 * active and unsatisfied.
@@ -609,6 +614,10 @@ export class ChatEntitlementService extends Disposable implements IChatEntitleme
 
 		this.chatQuotaExceededContextKey.set(true);
 		this._onDidChangeQuotaExceeded.fire();
+	}
+
+	markSetupCompleted(): void {
+		this.context?.value.update({ completed: true });
 	}
 
 	setForceHidden(hidden: boolean): void {

--- a/src/vs/workbench/test/common/workbenchTestServices.ts
+++ b/src/vs/workbench/test/common/workbenchTestServices.ts
@@ -815,6 +815,7 @@ export class TestChatEntitlementService implements IChatEntitlementService {
 	readonly anonymousObs = observableValue({}, false);
 
 	markAnonymousRateLimited(): void { }
+	markSetupCompleted(): void { }
 	setForceHidden(_hidden: boolean): void { }
 
 	readonly previewFeaturesDisabled = false;


### PR DESCRIPTION
## Summary

UI polish for the Agents window and API cleanup for chat setup state.

### Welcome Screen
- Replace agents logo SVG with theme-aware editor preview SVG (dark/light/HC variants)
- Use `codicon-agent` for loading state instead of `codicon-copilot-large`
- Change layout from horizontal (icon left, text right) to vertical (image top, text bottom)
- Increase spacing between preview image and text

### Titlebar Actions
- **Open in Agents**: Label shortened from "Open in Agents Window" → "Open in Agents", hover tooltip shows full "Open in Agents Window"
- **Open in Editor**: Label changed from "Open in VS Code" → "Open in Editor", hover shows "Open in VS Code Editor Window"
- Agents Window button now uses `codicon-agent` instead of `sessions-icon.svg`

### Banner
- Renamed "Try out the new Agents app" → "Try out the new Agents"

### Chat Setup API
- Added `markSetupCompleted()` to `IChatEntitlementService` interface
- `SessionsChatSetupStateService` now uses the public API (`sentiment.completed` for reading, `markSetupCompleted()` for writing) instead of type-casting to `ChatEntitlementService`