### PR TITLE
Always set X-Model-Provider-Preference to anthropic for Messages API

### DIFF
--- a/extensions/copilot/src/platform/endpoint/node/chatEndpoint.ts
+++ b/extensions/copilot/src/platform/endpoint/node/chatEndpoint.ts
@@ -214,10 +214,7 @@ export class ChatEndpoint implements IChatEndpoint {
 		const headers: Record<string, string> = { ...this.modelMetadata.requestHeaders };
 
 		if (this.useMessagesApi) {
-			const modelProviderPreference = this._configurationService.getConfig(ConfigKey.TeamInternal.ModelProviderPreference);
-			if (modelProviderPreference) {
-				headers['X-Model-Provider-Preference'] = modelProviderPreference;
-			}
+			headers['X-Model-Provider-Preference'] = 'anthropic';
 		}
 
 		Object.assign(headers, this.getAnthropicBetaHeader());


### PR DESCRIPTION
Small tweak to the Messages API request headers.