### PR TITLE
fix(debug): guard REPL tree.updateChildren against missing input

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -222,7 +222,12 @@ export class Repl extends FilterViewPane implements IHistoryNavigationWidget {
 
 			if (this.styleChangedWhenInvisible) {
 				this.styleChangedWhenInvisible = false;
-				this.tree?.updateChildren(undefined, true, false);
+				// Only update children when the tree has an input - it may not yet
+				// (no debug session has been focused since this view was created),
+				// in which case `_updateChildren` would throw `Tree input not set`.
+				if (this.tree?.getInput()) {
+					this.tree.updateChildren(undefined, true, false);
+				}
 				this.onDidStyleChange();
 			}
 		}));


### PR DESCRIPTION
Refs #248825

## Problem

`TreeError [DebugRepl] Tree input not set` is the dominant error in the "Tree input not set" family — **57 buckets, 56.3M hits (~91% of all "Tree input not set" reports)**, ahead of BreadcrumbsOutlinePicker (3.8%), FileExplorer (1.3%), and others. The umbrella tracking issue (#248825) has been re-pinged by `errors-triage` for every release since 1.115.0 (most recent in 1.120.0-insider, bucket [`b63c94c2`](https://errors.code.visualstudio.com/bucket/b63c94c2-ad82-f5fc-d917-eb71f9c73d8c?product=VSCode&commit=0aed0a9b6adcf8898b54afc1b9c28e3ac4e9c2d3) — 247 users on day 1).

## Root cause

The error is constructed in `asyncDataTree.ts` `_updateChildren` when `this.root.element === undefined`, i.e. `setInput` has never been called:

```ts
if (typeof this.root.element === 'undefined') {
    throw new TreeError(this.user, 'Tree input not set');
}
```

That guard is correct — it enforces the documented `setInput` → `updateChildren` ordering contract. The bug is at the **producer**.

Every other `tree.updateChildren(...)` call site in `repl.ts` already honors the contract by going through `refreshScheduler`, which bails when there's no input:

```ts
// repl.ts ~L588
if (!this.tree || !this.tree.getInput() || !this.isVisible()) { return; }
```

The single call site that bypasses this is in the `onDidChangeBodyVisibility` handler:

```ts
if (this.styleChangedWhenInvisible) {
    this.styleChangedWhenInvisible = false;
    this.tree?.updateChildren(undefined, true, false);   // ← throws when input never set
    this.onDidStyleChange();
}
```

This is reachable when:

1. The Debug Console view is created but no debug session has ever been focused → `selectSession()` never reached `tree.setInput(session)` → tree input is `undefined`.
2. A theme / font / `debug.console.wordWrap` change fires `onDidStyleChange()` while the panel is hidden → `styleChangedWhenInvisible = true`.
3. User toggles / opens the Debug Console panel → visibility handler fires → unguarded `updateChildren` throws.

The fresh raw event from bucket `b63c94c2` confirms exactly this stack:

```
asyncDataTree._updateChildren           ← crash site (correct guard)
asyncDataTree.updateChildren
[arrow fn] in repl.ts:225               ← producer
event.fire → viewPane.setVisible → viewPaneContainer.setVisible
paneCompositePart.setVisible
EG.openComposite … openPaneComposite
JYt.setPanelHidden                       ← user toggled the panel
keybinding dispatch
```

## Fix

Add a `getInput()` guard at the producer, mirroring the check `refreshScheduler` already uses for the same tree. This is a guard clause at the **producer of invalid data**, not the crash site, and it does not introduce a `try/catch` or remove any `logService.error()` call.

```ts
if (this.styleChangedWhenInvisible) {
    this.styleChangedWhenInvisible = false;
    if (this.tree?.getInput()) {
        this.tree.updateChildren(undefined, true, false);
    }
    this.onDidStyleChange();
}
```

Behavior when there is no input was already a no-op that ended in an unhandled error toast; with this change it is simply a no-op (the next `selectSession()` call sets the input and triggers a refresh anyway).

## Telemetry impact

Bucket family that should drop after this lands:

| Bucket | Versions | Hits | Users |
|---|---|---:|---:|
| `9ec2af8b` | 1.115.0 → 1.118.1 | 16.2M | 7.07M |
| `b63c94c2` | 1.120.0-insider | 301 | 247 |
| (50+ sibling buckets across older releases sharing message + file fingerprint) | | | |

DebugRepl share of all "Tree input not set" traffic is **~91%**, so this single producer fix should substantially deflate the entire bucket family.

## Test plan

Manual repro is hard to script (depends on theme/font change fired while panel is hidden), but follows from the trace:

1. Fresh window, no debug session.
2. Hide the panel.
3. Change `editor.fontSize` (or toggle a theme) — fires `onDidStyleChange` → `styleChangedWhenInvisible = true`.
4. Open the panel; ensure the Debug Console tab is selected.
5. **Before:** `TreeError [DebugRepl] Tree input not set` reported. **After:** no error.
