### PR TITLE
fix(inline-edits): gate gutter animation on icon mount, not data state (fixes #305729)

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { n } from '../../../../../../../base/browser/dom.js';
+import { n, ObserverNodeWithElement } from '../../../../../../../base/browser/dom.js';
 import { renderIcon } from '../../../../../../../base/browser/ui/iconLabel/iconLabels.js';
 import { Codicon } from '../../../../../../../base/common/codicons.js';
 import { BugIndicatingError } from '../../../../../../../base/common/errors.js';
@@ -456,7 +456,16 @@ export class InlineEditsGutterIndicator extends Disposable {
 
 	protected readonly _iconRef = n.ref<HTMLDivElement>();
 
-	public readonly isVisible = this._layout.map(l => !!l);
+	// Tracks the actual mounting of the icon node. `_iconRef` is assigned
+	// synchronously when the inner `n.div` below is constructed, but that only
+	// happens when the parent indicator's render autorun has run. Consumers that
+	// need to interact with the icon DOM (animations, hover targets, geometry)
+	// must gate on this signal — not on `_layout` truthiness, which only
+	// reflects data state and can be true while the icon DOM does not yet exist
+	// (race when both autoruns are scheduled in the same outer transaction).
+	private readonly _iconNode = observableValue<ObserverNodeWithElement<HTMLDivElement> | null>(this, null);
+
+	public readonly isVisible = derived(this, reader => !!this._layout.read(reader) && this._iconNode.read(reader) !== null);
 
 	protected readonly _hoverVisible = observableValue(this, false);
 	public readonly isHoverVisible: IObservable<boolean> = this._hoverVisible;
@@ -530,6 +539,7 @@ export class InlineEditsGutterIndicator extends Disposable {
 		n.div({
 			class: 'icon',
 			ref: this._iconRef,
+			obsRef: (elem) => this._iconNode.set(elem, undefined),
 
 			tabIndex: 0,
 			onclick: () => {

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsNewUsers.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsNewUsers.ts
@@ -6,7 +6,7 @@
 import { timeout } from '../../../../../../base/common/async.js';
 import { BugIndicatingError } from '../../../../../../base/common/errors.js';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
-import { autorun, derived, IObservable, observableValue, runOnChange, runOnChangeWithCancellationToken } from '../../../../../../base/common/observable.js';
+import { autorun, derived, IObservable, runOnChange, runOnChangeWithCancellationToken } from '../../../../../../base/common/observable.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../../platform/storage/common/storage.js';
 import { InlineEditsGutterIndicator } from './components/gutterIndicatorView.js';
@@ -23,14 +23,16 @@ export class InlineEditsOnboardingExperience extends Disposable {
 
 	private readonly _disposables = this._register(new MutableDisposable());
 
-	private readonly _setupDone = observableValue({ name: 'setupDone' }, false);
-
 	private readonly _activeCompletionId = derived<string | undefined>(reader => {
 		const model = this._model.read(reader);
 		if (!model) { return undefined; }
 
-		if (!this._setupDone.read(reader)) { return undefined; }
-
+		// `indicator.isVisible` is true only when the gutter indicator's icon DOM
+		// has been mounted, so any animation triggered from this id is guaranteed
+		// to find a live `_iconRef.element`. Previously we also gated on a
+		// `_setupDone` flag set at the end of the constructor; that flag was a
+		// band-aid for a race where `isVisible` reflected only data state and
+		// could be true before the icon DOM existed (see #305729).
 		const indicator = this._indicator.read(reader);
 		if (!indicator || !indicator.isVisible.read(reader)) { return undefined; }
 
@@ -50,8 +52,6 @@ export class InlineEditsOnboardingExperience extends Disposable {
 
 		// Setup the onboarding experience for new users
 		this._disposables.value = this.setupNewUserExperience();
-
-		this._setupDone.set(true, undefined);
 	}
 
 	private setupNewUserExperience(): IDisposable | undefined {


### PR DESCRIPTION
### Summary

`InlineEditsGutterIndicator.triggerAnimation()` reads `this._iconRef.element`. The ref is assigned synchronously by the inner icon `n.div` constructor, but only when the parent indicator's render autorun has materialized the icon node. Previously, `isVisible` was defined as `this._layout.map(l => !!l)` — a pure data-state signal that could be true before the icon DOM existed. When `InlineEditsOnboardingExperience`'s constructor ran inside the same outer transaction that scheduled the indicator's render autorun, `_activeCompletionId` could fire `triggerAnimation()` before the inner `n.div` had been constructed, throwing `BugIndicatingError` from `n.ref().element`.

This makes icon-mount state observable (via `obsRef` on the icon node) and folds it into `isVisible`, so `isVisible: true` truly means "ready to interact with the icon DOM".

Telemetry impact: ~39M hits / ~4.1M users across 30+ buckets in error telemetry (top bucket [`3f54d6af`](https://errors.code.visualstudio.com/bucket/3f54d6af-0cea-1342-d0b1-ef0ec96d2c9a?product=VSCode) alone is 18.2M hits / 4.1M users), present in every release 1.110 through 1.119 — still firing in 1.119.0.

Fixes microsoft/vscode#305729
Recommended reviewer: @hediet (with @benibenj for the `_setupDone` removal in `inlineEditsNewUsers.ts` — original author of the band-aid in 6f39ba2a447a).

### Culprit Commit

**Pre-existing — not a regression.** `get_bucket_history` shows non-zero hits in every release the tool returns (first hit 2026-03-19 in 1.110.0-insider; ~2M hits/version since). `git blame` attributes `_setupDone.set(true, undefined)` to commit `6f39ba2a447a` (Apr 2025, PR #245245 "Cleanup first time experience"), authored well before the first telemetry hit — the bug pattern shipped quietly and only became visible at scale once the inline-edits feature reached general users.

### Code Flow

```mermaid
sequenceDiagram
    participant View as inlineSuggestionsView
    participant Onboard as InlineEditsOnboardingExperience
    participant ActiveId as _activeCompletionId
    participant RunOnChange as runOnChange handler
    participant Indicator as InlineEditsGutterIndicator
    participant IconRender as indicator render autorun
    participant Ref as _iconRef

    Note over View,IconRender: Both autoruns subscribe to overlapping state.<br/>Transaction propagation order is not guaranteed.

    View->>Onboard: createInstance (inside outer transaction)
    Onboard->>ActiveId: _setupDone.set(true) invalidates derived
    Note over ActiveId: reads isVisible (was _layout-only)<br/>returns true even though icon DOM not mounted yet
    ActiveId->>RunOnChange: emit completion id
    RunOnChange->>Indicator: triggerAnimation()
    Indicator->>Ref: this._iconRef.element
    Note over Ref: BugIndicatingError thrown<br/>icon n.div not yet constructed
    IconRender-->>Ref: would set ref next, but never reached
```

### Affected Files

| File | Role | Evidence |
|------|------|----------|
| `src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts` | crash site + producer of unsafe contract | L208-L226: `triggerAnimation()` reads `this._iconRef.element`; L457-L459 (pre-fix): `isVisible = this._layout.map(l => !!l)` lies — true before DOM mount |
| `src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsNewUsers.ts` | trigger / scheduler of unsafe call | L26-L37 (pre-fix): `_setupDone` + `_activeCompletionId`; L54 (pre-fix): `_setupDone.set(true)` synchronously inside outer transaction |
| `src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineSuggestionsView.ts` | scheduler context | L114-L122: `derived(reader => createInstance(InlineEditsOnboardingExperience, ...)).recomputeInitiallyAndOnChange(this._store)` schedules onboarding construction in same transaction as indicator updates |
| `src/vs/base/browser/dom.ts` | error origin (typed contract, unchanged) | L2526-L2543: `n.ref()` factory; `element` getter throws when `value` undefined; ref is set synchronously by `ObserverNode` constructor at L2614-L2617 |

### Repro Steps

Race condition — non-deterministic but reproducible:

1. Fresh user (or wipe storage key `inlineEditsGutterIndicatorUserKind` → `firstTime`).
2. Open VS Code with an inline-edit-capable provider active (Copilot Next Edit Suggestions).
3. Trigger an inline edit so the gutter indicator is requested for the first time in this editor's lifetime.
4. The `derived` in `inlineSuggestionsView.ts` schedules construction of `InlineEditsOnboardingExperience` in the same transaction in which `_layout` first becomes truthy.
5. If the outer derived runs **before** `InlineEditsGutterIndicator._indicator.keepUpdated` autorun: `_setupDone.set(true)` -> `_activeCompletionId` recomputes -> sees `isVisible=true` (because `_layout` is truthy) -> `runOnChangeWithCancellationToken` fires -> `triggerAnimation()` reads `_iconRef.element` -> throws.
6. If the indicator's render autorun runs first, the icon DOM is mounted and the call succeeds — explains the partial firing rate per release.

### How the Fix Works

**Chosen approach — make icon-mount state observable; fold it into `isVisible`.**

1. `gutterIndicatorView.ts`: introduce `_iconNode = observableValue<ObserverNodeWithElement<HTMLDivElement> | null>(this, null)` and attach `obsRef: (elem) => this._iconNode.set(elem, undefined)` to the icon `n.div`. The `obsRef` mechanism in `dom.ts` (the same one already used in `inlineEditsWordReplacementView.ts:286`) fires when the inner ObserverNode is constructed and disposed. Redefine `isVisible` as `derived(reader => !!this._layout.read(reader) && this._iconNode.read(reader) !== null)`. This converts an implicit timing assumption ("DOM is mounted by the time anyone reads `isVisible`") into an explicit observable dependency — fix at the data producer, per the workflow's Core Fix Principles.

2. `inlineEditsNewUsers.ts`: delete the `_setupDone` observable, its read in `_activeCompletionId`, and its `.set(true)` call in the constructor. With `isVisible` now truthful (icon-mount-aware), the existing `isVisible` gate is sufficient to prevent the crash — `_setupDone` was a band-aid added to swallow the first invalidation and is redundant once the underlying signal is correct.

The `BugIndicatingError` in `dom.ts` stays untouched — the contract "ref must be set before `.element` access" remains intentional and protects every other callsite in the codebase. Per the workflow's Core Fix Principles, the fix is at the data producer (`isVisible`), not at the crash site (`triggerAnimation`).

### Audit — does this hide other real issues?

`isVisible` has no consumers outside this file (verified via `git grep "indicator.isVisible"`). Other readers of `_iconRef.element` and other `triggerAnimation` callsites were audited:

| Surface | Status |
|---|---|
| `_activeCompletionId` (the only `isVisible` consumer) | now race-free |
| `triggerAnimation` self-callsite at L159 (hover-debounced 100ms) | unchanged — DOM long-mounted by the time hover fires |
| `triggerAnimation` callsites in `inlineEditsNewUsers.ts` L96/L102 | gated by `_activeCompletionId`, now race-free |
| `_iconRef.element` at L145 (`onMouseMove`) | unchanged — has a similar latent shape but is NOT in any telemetry bucket; separate fix if/when it surfaces |
| `_iconRef.element` at L499 (`_showHover`) | unchanged — called from icon `mouseenter`, so icon must exist |
| Removing `_setupDone` | new `isVisible` is **stricter** than `_setupDone` (also requires DOM mount), so the initial `runOnChange` emission is delayed *further*, never earlier — onboarding animation still fires correctly |

The `BugIndicatingError` in `dom.ts` is preserved, so any *other* misuse of `n.ref().element` anywhere in the codebase will still surface in telemetry.

**Alternatives considered**

- **Defensive guard at the crash site** (`if (!this._iconRef.isSet) return Animation.NONE.finished`): rejected — violates the workflow's Core Fix Principle two ("do NOT fix at the crash site"); silently skips the first onboarding pulse on the affected race; leaves the lying `isVisible` signal in place for the next caller to trip over.
- **`queueMicrotask(() => this._setupDone.set(true))` in the constructor**: rejected — works in practice today but relies on autorun ordering luck; future code that calls `triggerAnimation()` from a different observable graph would re-introduce the same race.
- **Move onboarding instantiation out of the outer derived into an `autorun` that reads `indicator.isVisible`**: rejected — same lying-signal problem; only re-orders the race.
- **Make `triggerAnimation()` async and `await` an `observableSignalFromEvent` on the icon's mount**: rejected — heavier; the existing `obsRef` infrastructure does this exact job already.

### Recommended Owner

@hediet (primary maintainer of inline-edits/gutter indicator system) for `gutterIndicatorView.ts`; @benibenj as the original author of the `_setupDone` band-aid in `inlineEditsNewUsers.ts`.
