### PR TITLE
sessions: move harness picker into new chat header

### DIFF
--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -667,6 +667,7 @@ interface IPartVisibilityState {
 
 | Date | Change |
 |------|--------|
+| 2026-05-07 | Updated the sessions new-chat empty state so the workspace title row now reads `New session in {workspace} with {coding agent harness}` by rendering the session type picker inline above the input, leaving the bottom control row for approvals and repository controls. |
 | 2026-05-06 | Polished the sessions command-center title widget hide/show behavior: the command-center toolbar now refreshes explicitly on new-chat context changes so adjacent actions disappear together, and the title widget uses a reduced-motion-aware subtle fade only when entering or leaving the new chat view. |
 | 2026-05-06 | Hid the sessions command-center title widget while the new chat view is visible (`isNewChatSession`), so titlebar session chrome only appears for existing or newly created chat threads. |
 | 2026-05-06 | Changed the default sessions shell gradient from a diagonal linear gradient to a bottom-right radial gradient so the accent tint stays behind the chat surface while the window-controls corner and sidebar footer return to the base shell color. |

--- a/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
@@ -198,8 +198,13 @@
 	white-space: nowrap;
 }
 
+.session-workspace-picker-with-label:has(+ .sessions-chat-session-type-picker .action-label.hidden) {
+	display: none;
+}
+
 /* Project picker in inline title row */
-.sessions-chat-picker-slot.sessions-chat-workspace-picker .action-label {
+.sessions-chat-picker-slot.sessions-chat-workspace-picker .action-label,
+.sessions-chat-picker-slot.sessions-chat-session-type-picker .action-label {
 	height: auto;
 	padding: 4px;
 	font-size: 18px;
@@ -211,21 +216,25 @@
 	touch-action: manipulation;
 }
 
-.sessions-chat-picker-slot.sessions-chat-workspace-picker .action-label:hover {
+.sessions-chat-picker-slot.sessions-chat-workspace-picker .action-label:hover,
+.sessions-chat-picker-slot.sessions-chat-session-type-picker .action-label:hover {
 	background-color: var(--vscode-toolbar-hoverBackground);
 	color: var(--vscode-foreground);
 }
 
-.sessions-chat-picker-slot.sessions-chat-workspace-picker .action-label .sessions-chat-dropdown-label {
+.sessions-chat-picker-slot.sessions-chat-workspace-picker .action-label .sessions-chat-dropdown-label,
+.sessions-chat-picker-slot.sessions-chat-session-type-picker .action-label .sessions-chat-dropdown-label {
 	font-size: 18px;
 }
 
-.sessions-chat-picker-slot.sessions-chat-workspace-picker .action-label > .codicon:not(.sessions-chat-dropdown-chevron) {
+.sessions-chat-picker-slot.sessions-chat-workspace-picker .action-label > .codicon:not(.sessions-chat-dropdown-chevron),
+.sessions-chat-picker-slot.sessions-chat-session-type-picker .action-label > .codicon:not(.codicon-chevron-down) {
 	font-size: 16px;
 	margin: 0;
 }
 
-.sessions-chat-picker-slot.sessions-chat-workspace-picker .action-label .sessions-chat-dropdown-chevron {
+.sessions-chat-picker-slot.sessions-chat-workspace-picker .action-label .sessions-chat-dropdown-chevron,
+.sessions-chat-picker-slot.sessions-chat-session-type-picker .action-label .sessions-chat-dropdown-chevron {
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;

--- a/src/vs/sessions/contrib/chat/browser/mobile/mobileSessionTypePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/mobile/mobileSessionTypePicker.ts
@@ -36,7 +36,7 @@ export class MobileSessionTypePicker extends SessionTypePicker {
 		super(actionWidgetService, sessionsManagementService, sessionsProvidersService, storageService);
 	}
 
-	override render(container: HTMLElement): void {
+	override render(container: HTMLElement, options?: { className?: string }): void {
 		// Always render so the session-type chip is visible in the chip
 		// row on phone. The base class renders a trigger that the mobile
 		// `_showPicker` override routes to a bottom sheet, while desktop
@@ -44,7 +44,7 @@ export class MobileSessionTypePicker extends SessionTypePicker {
 		// viewports also means rotation across the phone breakpoint
 		// keeps the trigger alive — consistent with MOBILE.md's
 		// principle of same functionality, different presentation.
-		super.render(container);
+		super.render(container, options);
 	}
 
 	protected override _showPicker(): void {

--- a/src/vs/sessions/contrib/chat/browser/newChatInput.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInput.ts
@@ -148,6 +148,7 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 			loading: IObservable<boolean>;
 			minEditorHeight?: number;
 			placeholder?: string;
+			renderSessionTypePickerInControls?: boolean;
 		},
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IModelService private readonly modelService: IModelService,
@@ -211,7 +212,9 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 
 		const newChatBottomContainer = dom.append(parent, dom.$('.new-chat-bottom-container'));
 		const newChatControlsContainer = dom.append(newChatBottomContainer, dom.$('.new-chat-controls-container'));
-		this.sessionTypePicker.render(newChatControlsContainer);
+		if (this.options.renderSessionTypePickerInControls !== false) {
+			this.sessionTypePicker.render(newChatControlsContainer);
+		}
 		this._register(this.instantiationService.createInstance(MenuWorkbenchToolBar, dom.append(newChatControlsContainer, dom.$('')), Menus.NewSessionControl, {
 			hiddenItemStrategy: HiddenItemStrategy.NoHide,
 		}));

--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -76,6 +76,7 @@ class NewChatWidget extends Disposable {
 			sendRequest: async (text: string, attachedContext?: IChatRequestVariableEntry[]) => this._send(text, attachedContext),
 			canSendRequest,
 			loading,
+			renderSessionTypePickerInControls: false,
 		}));
 
 		this._register(this._workspacePicker.onDidSelectWorkspace(async workspace => {
@@ -203,6 +204,9 @@ class NewChatWidget extends Disposable {
 			: localize('newSessionChooseWorkspace', "Start by picking a");
 
 		this._workspacePicker.render(pickersRow);
+		const withLabel = dom.append(pickersRow, dom.$('.session-workspace-picker-label.session-workspace-picker-with-label'));
+		withLabel.textContent = localize('newSessionWith', "with");
+		this._newChatInput.sessionTypePicker.render(pickersRow, { className: 'sessions-chat-session-type-picker' });
 		return this._workspacePicker.onDidSelectWorkspace(() => {
 			const workspace = this._workspacePicker.selectedProject;
 			pickersLabel.textContent = workspace ? localize('newSessionIn', "New session in") : localize('newSessionChooseWorkspace', "Start by picking a");

--- a/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
@@ -79,10 +79,13 @@ export class SessionTypePicker extends Disposable {
 		return this._sessionType;
 	}
 
-	render(container: HTMLElement): void {
+	render(container: HTMLElement, options?: { className?: string }): void {
 		this._renderDisposables.clear();
 
 		const slot = dom.append(container, dom.$('.sessions-chat-picker-slot'));
+		if (options?.className) {
+			slot.classList.add(...options.className.split(' '));
+		}
 		this._renderDisposables.add({ dispose: () => slot.remove() });
 
 		const trigger = dom.append(slot, dom.$('a.action-label'));
@@ -184,7 +187,8 @@ export class SessionTypePicker extends Disposable {
 		const labelSpan = dom.append(this._triggerElement, dom.$('span.sessions-chat-dropdown-label'));
 		labelSpan.textContent = modeLabel;
 
-		dom.append(this._triggerElement, renderIcon(Codicon.chevronDown));
+		const chevron = dom.append(this._triggerElement, renderIcon(Codicon.chevronDown));
+		chevron.classList.add('sessions-chat-dropdown-chevron');
 
 		this._triggerElement.ariaLabel = localize('sessionTypePicker.triggerAriaLabel', "Pick Session Type, {0}", modeLabel);
 	}

--- a/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
@@ -84,7 +84,10 @@ export class SessionTypePicker extends Disposable {
 
 		const slot = dom.append(container, dom.$('.sessions-chat-picker-slot'));
 		if (options?.className) {
-			slot.classList.add(...options.className.split(' '));
+			const classNames = options.className.split(/\s+/).filter(className => className.length > 0);
+			if (classNames.length > 0) {
+				slot.classList.add(...classNames);
+			}
 		}
 		this._renderDisposables.add({ dispose: () => slot.remove() });
 


### PR DESCRIPTION
Fixes #314819

This updates the Sessions new chat empty state so the header reads as `New session in {workspace} with {coding agent harness}`.

<img width="1840" height="1196" alt="Screenshot 2026-05-07 at 3 49 51 PM" src="https://github.com/user-attachments/assets/0c9e170b-d7b8-4bbe-a0dc-065767e9324e" />
<img width="1840" height="1196" alt="Screenshot 2026-05-07 at 3 49 58 PM" src="https://github.com/user-attachments/assets/53fda951-0a7c-4e2d-a899-3586383135be" />

Changes include:
- Rendering the harness/session type picker inline with the workspace picker on the standalone new chat screen.
- Removing that picker from the new chat bottom controls so approvals and repository controls can occupy the control row.
- Preserving the existing active chat and new-chat-in-session input behavior.
- Updating the Sessions layout spec revision history.