### PR TITLE
sessions: add Cmd+Shift+N to open new window in agents app

### DIFF
--- a/src/vs/sessions/electron-browser/actions/vscodeActions.ts
+++ b/src/vs/sessions/electron-browser/actions/vscodeActions.ts
@@ -9,8 +9,8 @@ import { mainWindow } from '../../../base/browser/window.js';
 import { Schemas } from '../../../base/common/network.js';
 import { URI } from '../../../base/common/uri.js';
 import { ServicesAccessor } from '../../../editor/browser/editorExtensions.js';
-import { localize2 } from '../../../nls.js';
-import { Action2 } from '../../../platform/actions/common/actions.js';
+import { localize, localize2 } from '../../../nls.js';
+import { Action2, MenuId } from '../../../platform/actions/common/actions.js';
 import { AGENT_HOST_SCHEME, fromAgentHostUri } from '../../../platform/agentHost/common/agentHostUri.js';
 import { IRemoteAgentHostService } from '../../../platform/agentHost/common/remoteAgentHostService.js';
 import { KeyCode, KeyMod } from '../../../base/common/keyCodes.js';
@@ -30,6 +30,7 @@ import { IInstantiationService } from '../../../platform/instantiation/common/in
 import { Disposable } from '../../../base/common/lifecycle.js';
 import { resolveRemoteAuthority } from '../../browser/openInVSCodeUtils.js';
 import { INativeHostService } from '../../../platform/native/common/native.js';
+import product from '../../../platform/product/common/product.js';
 
 export class OpenSessionInVSCodeAction extends Action2 {
 	static readonly ID = 'agents.openSessionInVSCode';
@@ -98,7 +99,7 @@ export class OpenVSCodeWindowAction extends Action2 {
 	constructor() {
 		super({
 			id: OpenVSCodeWindowAction.ID,
-			title: localize2('openVSCodeWindow', 'Open VS Code Window'),
+			title: localize2('openVSCodeWindow', 'Open {0} Window', product.nameLong),
 			f1: true,
 			keybinding: {
 				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyA,
@@ -119,6 +120,35 @@ export class OpenVSCodeWindowAction extends Action2 {
 		} else {
 			await nativeHostService.openWindow();
 		}
+	}
+}
+
+export class OpenNewVSCodeWindowAction extends Action2 {
+	static readonly ID = 'agents.openNewVSCodeWindow';
+
+	constructor() {
+		super({
+			id: OpenNewVSCodeWindowAction.ID,
+			title: {
+				...localize2('newVSCodeWindow', 'New {0} Window', product.nameLong),
+				mnemonicTitle: localize({ key: 'miNewVSCodeWindow', comment: ['&& denotes a mnemonic'] }, "New {0} &&Window", product.nameLong),
+			},
+			f1: true,
+			keybinding: {
+				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyN,
+				weight: KeybindingWeight.WorkbenchContrib,
+			},
+			menu: {
+				id: MenuId.MenubarFileMenu,
+				group: '1_new',
+				order: 3,
+			},
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		const nativeHostService = accessor.get(INativeHostService);
+		await nativeHostService.openWindow({ remoteAuthority: null });
 	}
 }
 

--- a/src/vs/sessions/electron-browser/sessions.desktop.contribution.ts
+++ b/src/vs/sessions/electron-browser/sessions.desktop.contribution.ts
@@ -5,12 +5,13 @@
 
 import { registerAction2 } from '../../platform/actions/common/actions.js';
 import { registerWorkbenchContribution2, WorkbenchPhase } from '../../workbench/common/contributions.js';
-import { OpenSessionInVSCodeAction, OpenInVSCodeWidgetContribution, OpenVSCodeWindowAction } from './actions/vscodeActions.js';
+import { OpenSessionInVSCodeAction, OpenInVSCodeWidgetContribution, OpenVSCodeWindowAction, OpenNewVSCodeWindowAction } from './actions/vscodeActions.js';
 
 // Actions
 (function registerActions(): void {
 	registerAction2(OpenSessionInVSCodeAction);
 	registerAction2(OpenVSCodeWindowAction);
+	registerAction2(OpenNewVSCodeWindowAction);
 })();
 
 (function registerWorkbenchContributions(): void {


### PR DESCRIPTION
## Summary

The standard `workbench.action.newWindow` (Cmd+Shift+N) is disabled in the sessions/agents window via `IsSessionsWindowContext.negate()`. This PR adds a sessions-specific equivalent so the familiar shortcut works there too.

## Changes

- **New action** `agents.openNewVSCodeWindow` in `vscodeActions.ts`:
  - Keybinding: Cmd+Shift+N (Ctrl+Shift+N on Windows/Linux)
  - Opens a new empty local window (`nativeHostService.openWindow({ remoteAuthority: null })`)
  - Title uses `product.nameLong` — no hardcoded "VS Code"
  - Appears in **File menu** (`1_new` group, order 3) alongside the existing "New Text File" item
  - Also available via Command Palette (`f1: true`)

- **Existing `OpenVSCodeWindowAction`** (Cmd+Shift+A — focus/open existing VS Code window) also updated to use `product.nameLong` in its title.

- Registered in `sessions.desktop.contribution.ts`.
