### PR TITLE
chat: remove redundant 'Enabled' badge from installed plugin items

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget.ts
@@ -119,7 +119,6 @@ interface IPluginInstalledItemTemplateData {
 	readonly typeIcon: HTMLElement;
 	readonly name: HTMLElement;
 	readonly description: HTMLElement;
-	readonly status: HTMLElement;
 	readonly disposables: DisposableStore;
 }
 
@@ -140,9 +139,8 @@ class PluginInstalledItemRenderer implements IListRenderer<IPluginInstalledItemE
 		const details = DOM.append(container, $('.mcp-server-details'));
 		const name = DOM.append(details, $('.mcp-server-name'));
 		const description = DOM.append(details, $('.mcp-server-description'));
-		const status = DOM.append(container, $('.mcp-server-status'));
 
-		return { container, syncCheckboxContainer, typeIcon, name, description, status, disposables: new DisposableStore() };
+		return { container, syncCheckboxContainer, typeIcon, name, description, disposables: new DisposableStore() };
 	}
 
 	renderElement(element: IPluginInstalledItemEntry, _index: number, templateData: IPluginInstalledItemTemplateData): void {
@@ -157,18 +155,13 @@ class PluginInstalledItemRenderer implements IListRenderer<IPluginInstalledItemE
 			templateData.description.style.display = 'none';
 		}
 
-		// Show enabled/disabled status
+		// Reflect enabled/disabled state on the container for visual styling. The
+		// inline status badge ("Enabled"/"Disabled") is intentionally omitted —
+		// items are already grouped under "Enabled Locally" / "Disabled Locally"
+		// section headers, and the row's aria-label conveys state to screen readers.
 		templateData.disposables.add(autorun(reader => {
 			const enabled = isContributionEnabled(element.item.plugin.enablement.read(reader));
 			templateData.container.classList.toggle('disabled', !enabled);
-			templateData.status.className = 'mcp-server-status';
-			if (enabled) {
-				templateData.status.textContent = localize('enabled', "Enabled");
-				templateData.status.classList.add('running');
-			} else {
-				templateData.status.textContent = localize('disabled', "Disabled");
-				templateData.status.classList.add('disabled');
-			}
 		}));
 
 		// Disable checkbox: shown when the active harness has a disable provider


### PR DESCRIPTION
Fixes #314156

cc @meganrogge 

## What changed

Installed plugins in the AI Customization editor had an inline green "Enabled" / grey "Disabled" badge rendered on the right side of each row (via `.mcp-server-status`).

## Why it was wrong

The badge was redundant in two ways:
- **Visually**: Items are already grouped under "Enabled Locally" / "Disabled Locally" section headers, so the badge just repeats information the user already has from the section they're in.
- **For screen readers**: VoiceOver was announcing "Enabled" at the end of the row, which was confusing since the grouping already conveys that. The row's `aria-label` (via `getAriaLabel`) already appends ". Enabled" / ". Disabled" for screen readers, so accessibility is fully preserved.

## What was kept

- The `.disabled` CSS class toggle on the container row is retained — it drives the `opacity: 0.5` fade on disabled items.
- The `PluginRemoteItemRenderer` status badge is **untouched** — it shows statuses like "Loading", "Error", "Warning" which are not conveyed by section headers and are genuinely useful.
- The `aria-label` for installed items still includes the enabled state for screen reader users.