### PR TITLE
sessions: use hover service for New Session button tooltip

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsView.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsView.ts
@@ -22,6 +22,7 @@ import { IViewPaneOptions, IViewPaneLocationColors, ViewPane } from '../../../..
 import { IViewDescriptorService } from '../../../../../workbench/common/views.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
+import { getDefaultHoverDelegate } from '../../../../../base/browser/ui/hover/hoverDelegateFactory.js';
 import { localize } from '../../../../../nls.js';
 import { SessionsList, SessionsGrouping, SessionsSorting } from './sessionsList.js';
 import { SessionStatus } from '../../../../services/sessions/common/session.js';
@@ -332,6 +333,16 @@ export class SessionsView extends ViewPane {
 			return primaryKeybinding ?? resolvedKeybindings[0];
 		};
 
+		const getTooltipLabel = (keybindingLabel: string | undefined) => keybindingLabel
+			? localize('newSessionButtonTitle', "New Session ({0})", keybindingLabel)
+			: localize('newSessionButtonTitleWithoutKeybinding', "New Session");
+
+		const newSessionButtonHover = this._register(this.hoverService.setupManagedHover(
+			getDefaultHoverDelegate('mouse'),
+			newSessionButton.element,
+			getTooltipLabel(getNewSessionKeybinding()?.getLabel() ?? undefined),
+		));
+
 		let lastRenderedKeybindingLabel: string | undefined | null = null;
 		let lastRenderedKeybindingAriaLabel: string | undefined | null = null;
 		const updateNewSessionButton = () => {
@@ -354,9 +365,7 @@ export class SessionsView extends ViewPane {
 				keybindingHint.remove();
 			}
 
-			newSessionButton.element.title = keybindingLabel
-				? localize('newSessionButtonTitle', "New Session ({0})", keybindingLabel)
-				: localize('newSessionButtonTitleWithoutKeybinding', "New Session");
+			newSessionButtonHover.update(getTooltipLabel(keybindingLabel));
 			newSessionButton.element.setAttribute('aria-label', keybindingAriaLabel
 				? localize('newSessionButtonAriaLabel', "New Session ({0})", keybindingAriaLabel)
 				: localize('newSessionButtonAriaLabelWithoutKeybinding', "New Session"));

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsView.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsView.ts
@@ -22,7 +22,6 @@ import { IViewPaneOptions, IViewPaneLocationColors, ViewPane } from '../../../..
 import { IViewDescriptorService } from '../../../../../workbench/common/views.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
-import { getDefaultHoverDelegate } from '../../../../../base/browser/ui/hover/hoverDelegateFactory.js';
 import { localize } from '../../../../../nls.js';
 import { SessionsList, SessionsGrouping, SessionsSorting } from './sessionsList.js';
 import { SessionStatus } from '../../../../services/sessions/common/session.js';
@@ -333,15 +332,14 @@ export class SessionsView extends ViewPane {
 			return primaryKeybinding ?? resolvedKeybindings[0];
 		};
 
-		const getTooltipLabel = (keybindingLabel: string | undefined) => keybindingLabel
-			? localize('newSessionButtonTitle', "New Session ({0})", keybindingLabel)
-			: localize('newSessionButtonTitleWithoutKeybinding', "New Session");
-
-		const newSessionButtonHover = this._register(this.hoverService.setupManagedHover(
-			getDefaultHoverDelegate('mouse'),
-			newSessionButton.element,
-			getTooltipLabel(getNewSessionKeybinding()?.getLabel() ?? undefined),
-		));
+		this._register(this.hoverService.setupDelayedHoverAtMouse(newSessionButton.element, () => {
+			const keybindingLabel = getNewSessionKeybinding()?.getLabel() ?? undefined;
+			return {
+				content: keybindingLabel
+					? localize('newSessionButtonTitle', "New Session ({0})", keybindingLabel)
+					: localize('newSessionButtonTitleWithoutKeybinding', "New Session"),
+			};
+		}));
 
 		let lastRenderedKeybindingLabel: string | undefined | null = null;
 		let lastRenderedKeybindingAriaLabel: string | undefined | null = null;
@@ -365,7 +363,6 @@ export class SessionsView extends ViewPane {
 				keybindingHint.remove();
 			}
 
-			newSessionButtonHover.update(getTooltipLabel(keybindingLabel));
 			newSessionButton.element.setAttribute('aria-label', keybindingAriaLabel
 				? localize('newSessionButtonAriaLabel', "New Session ({0})", keybindingAriaLabel)
 				: localize('newSessionButtonAriaLabelWithoutKeybinding', "New Session"));


### PR DESCRIPTION
## Summary

Replace the native `title` attribute on the **New Session** button in the sessions sidebar view with a managed hover via `IHoverService.setupManagedHover`, consistent with how other VS Code UI elements (e.g. view pane titles, icons) render custom tooltips.

## Changes

- **`sessionsView.ts`**: Added import for `getDefaultHoverDelegate`. Replaced `newSessionButton.element.title = ...` with `this.hoverService.setupManagedHover(getDefaultHoverDelegate('mouse'), ...)`. The managed hover is updated via `IManagedHover.update()` whenever keybindings change (same update path as before).

## Why

Using the native `title` attribute produces a plain browser tooltip with no styling or delay control. The `IHoverService` hover delegate provides the standard VS Code custom hover experience (styled, keyboard-accessible, configurable delay) and is the preferred approach per the coding guidelines.