### PR TITLE
Add es5-ext to .moduleignore to exclude quarantined module

### DIFF
--- a/build/.moduleignore
+++ b/build/.moduleignore
@@ -238,3 +238,8 @@ zone.js/dist/**
 @github/copilot-sdk/node_modules/@github/copilot-linux-x64/**
 @github/copilot-sdk/node_modules/@github/copilot-win32-arm64/**
 @github/copilot-sdk/node_modules/@github/copilot-win32-x64/**
+
+# es5-ext is quarantined protestware (sonatype-2022-2248). It is only consumed
+# in websocket's browser.js inside a try/catch with a globalThis fallback,
+# so it is unnecessary in the browsers/runtimes VS Code supports.
+es5-ext/**


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode/pull/315063