### PR TITLE
Add unread/in-progress indicators to chat composite bar tabs

### DIFF
--- a/src/vs/sessions/browser/parts/chatCompositeBar.ts
+++ b/src/vs/sessions/browser/parts/chatCompositeBar.ts
@@ -119,6 +119,37 @@ export class ChatCompositeBar extends Disposable {
 			tab.classList.toggle('untitled', status === SessionStatus.Untitled);
 		}));
 
+		// Track unread / needs-input / in-progress state for the indicator.
+		// Precedence: needs-input (unread) > in-progress (spinner) > unread when not active.
+		// At most one indicator is shown at a time.
+		const indicator = $('.chat-composite-bar-tab-indicator');
+		const indicatorIcon = $('.chat-composite-bar-tab-indicator-icon');
+		indicator.appendChild(indicatorIcon);
+		this._tabDisposables.add(autorun(reader => {
+			const activeSession = this._sessionsManagementService.activeSession.read(reader);
+			const activeChat = activeSession?.activeChat.read(reader);
+			const isActive = activeChat?.resource.toString() === chat.resource.toString();
+			const status = chat.status.read(reader);
+			const isRead = chat.isRead.read(reader);
+
+			let mode: 'unread' | 'in-progress' | 'none' = 'none';
+			if (status === SessionStatus.NeedsInput) {
+				mode = 'unread';
+			} else if (status === SessionStatus.InProgress) {
+				mode = 'in-progress';
+			} else if (!isRead && !isActive) {
+				mode = 'unread';
+			}
+
+			tab.classList.toggle('unread', mode === 'unread');
+			tab.classList.toggle('in-progress', mode === 'in-progress');
+
+			indicatorIcon.className = 'chat-composite-bar-tab-indicator-icon';
+			if (mode === 'in-progress') {
+				indicatorIcon.classList.add(...ThemeIcon.asClassNameArray(ThemeIcon.modify(Codicon.loading, 'spin')));
+			}
+		}));
+
 		// Remove action bar — only for non-main chats, visible on hover
 		if (!isMainChat) {
 			const closeAction = this._tabDisposables.add(new Action(
@@ -138,7 +169,6 @@ export class ChatCompositeBar extends Disposable {
 			actionBar.getContainer().classList.add('chat-composite-bar-tab-actions');
 		}
 
-		const indicator = $('.chat-composite-bar-tab-indicator');
 		tab.appendChild(indicator);
 
 		this._tabsContainer.appendChild(tab);

--- a/src/vs/sessions/browser/parts/media/chatCompositeBar.css
+++ b/src/vs/sessions/browser/parts/media/chatCompositeBar.css
@@ -58,8 +58,58 @@
 	padding-right: 2px;
 }
 
-/* Hide the underline indicator — mirrors auxiliarybar active-item-indicator hiding */
+/* When an indicator is shown on a tab without a close button (e.g. the main chat),
+	reserve right-side space so the absolutely-positioned indicator doesn't overlap the label. */
+.chat-composite-bar-tab:not(:has(.chat-composite-bar-tab-actions)).unread,
+.chat-composite-bar-tab:not(:has(.chat-composite-bar-tab-actions)).in-progress {
+	padding-right: 22px;
+}
+
+/* Indicator: absolutely positioned over the close-action slot.
+	Shows a small yellow dot for unread, or a spinner for in-progress.
+	Only one mode is set on the element at a time (mutually exclusive in JS). */
 .chat-composite-bar-tab-indicator {
+	display: none;
+	position: absolute;
+	right: 4px;
+	top: 50%;
+	transform: translateY(-50%);
+	width: 16px;
+	height: 16px;
+	align-items: center;
+	justify-content: center;
+	pointer-events: none;
+}
+
+.chat-composite-bar-tab.unread .chat-composite-bar-tab-indicator,
+.chat-composite-bar-tab.in-progress .chat-composite-bar-tab-indicator {
+	display: flex;
+}
+
+.chat-composite-bar-tab-indicator-icon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.chat-composite-bar-tab.unread .chat-composite-bar-tab-indicator-icon::before {
+	content: '';
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	background-color: var(--vscode-list-warningForeground);
+}
+
+.chat-composite-bar-tab.in-progress .chat-composite-bar-tab-indicator-icon {
+	font-size: 12px;
+}
+
+/* When the close action is visible (hover / focus-within / active),
+	suppress the indicator so the two never render at the same time.
+	Only applies to tabs that actually have a close action. */
+.chat-composite-bar-tab.active:has(.chat-composite-bar-tab-actions) .chat-composite-bar-tab-indicator,
+.chat-composite-bar-tab:hover:has(.chat-composite-bar-tab-actions) .chat-composite-bar-tab-indicator,
+.chat-composite-bar-tab:focus-within:has(.chat-composite-bar-tab-actions) .chat-composite-bar-tab-indicator {
 	display: none;
 }
 
@@ -68,7 +118,7 @@
 	outline-offset: -1px;
 }
 
-/* Remove action bar — always occupies space; opacity toggled like editor tabs */
+/* Close action — visible on hover/focus/active, hidden by default so the indicator (if any) shows instead */
 .chat-composite-bar-tab-actions {
 	display: flex;
 	margin-left: 2px;


### PR DESCRIPTION
Adds per-tab indicators to the chat composite bar in the Agents window, mirroring the existing indicators in the sessions list.

## Behaviour

The indicator slot sits in the top-right corner of each tab and is mutually exclusive with the close button — the close button wins on hover/focus/active, otherwise the indicator is shown.

Priority (highest first):

| Condition | Indicator |
|---|---|
| `NeedsInput` | 🟡 yellow dot |
| `InProgress` | ⟳ spinning `loading` codicon (inherits tab font colour) |
| `!isRead` and tab is not the active chat | 🟡 yellow dot |
| otherwise | _(none)_ |

## Implementation notes

- Single `autorun` per tab computes the mode and toggles `.unread` / `.in-progress` CSS classes.
- The spinner codicon is wrapped in an inner `indicator-icon` element so the CSS `rotate` animation doesn't fight the parent's `translateY(-50%)` centering.
- Main-chat tabs (no close button) get extra `padding-right` to prevent the indicator from overlapping the label.
