### PR TITLE
Use a broadcast channel for md preview diff scroll sync

### DIFF
--- a/extensions/markdown-language-features/preview-src/diffScrollSync.ts
+++ b/extensions/markdown-language-features/preview-src/diffScrollSync.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { DiffScrollSyncData } from '../types/previewMessaging';
+
+export class DiffScrollSyncManager {
+
+	readonly #previewId = Math.random().toString(36).slice(2, 10);
+	readonly #onIncomingScroll: (line: number) => void;
+
+	#syncData: DiffScrollSyncData;
+	readonly #channel: BroadcastChannel;
+	#ignoreIncomingScrollUntil = 0;
+
+	constructor(sync: DiffScrollSyncData, onIncomingScroll: (line: number) => void) {
+		this.#onIncomingScroll = onIncomingScroll;
+		this.#syncData = sync;
+		this.#channel = new BroadcastChannel(sync.channelName);
+		this.#channel.onmessage = (event) => {
+			const { line, sender } = event.data;
+			if (sender === this.#previewId) {
+				return;
+			}
+			if (typeof line !== 'number' || isNaN(line)) {
+				return;
+			}
+
+			const mappedLine = translateLineWithMappings(line, this.#syncData.lineMappings);
+			this.#ignoreIncomingScrollUntil = Date.now() + 100;
+			this.#onIncomingScroll(mappedLine);
+		};
+	}
+
+	update(sync: DiffScrollSyncData): void {
+		this.#syncData = sync;
+	}
+
+	broadcastScroll(line: number): void {
+		if (!this.#channel || Date.now() < this.#ignoreIncomingScrollUntil) {
+			return;
+		}
+		this.#channel.postMessage({ line, sender: this.#previewId });
+	}
+}
+
+function translateLineWithMappings(line: number, mappings: readonly number[] | undefined): number {
+	if (!mappings?.length) {
+		return line;
+	}
+	const sourceLine = Math.floor(line);
+	const progress = line - sourceLine;
+	const mappedLine = mappings[sourceLine] ?? line;
+	if (progress <= 0) {
+		return Math.max(0, mappedLine);
+	}
+	const nextMappedLine = mappings[sourceLine + 1];
+	if (typeof nextMappedLine !== 'number') {
+		return Math.max(0, mappedLine + progress);
+	}
+	return Math.max(0, mappedLine + ((nextMappedLine - mappedLine) * progress));
+}

--- a/extensions/markdown-language-features/preview-src/index.ts
+++ b/extensions/markdown-language-features/preview-src/index.ts
@@ -12,6 +12,7 @@ import throttle = require('lodash.throttle');
 import morphdom from 'morphdom';
 import type { MarkdownPreviewLineChanges, ToWebviewMessage } from '../types/previewMessaging';
 import { isOfScheme, Schemes } from '../src/util/schemes';
+import { DiffScrollSyncManager } from './diffScrollSync';
 
 let scrollDisabledCount = 0;
 let scrollDisabledTimer: number | undefined;
@@ -24,6 +25,18 @@ let documentResource = settings.settings.source;
 let lineChanges = settings.settings.lineChanges;
 
 const vscode = acquireVsCodeApi();
+
+const onDiffScroll = (mappedLine: number) => {
+	scrollDisabledCount = 1;
+	if (scrollDisabledTimer) {
+		clearTimeout(scrollDisabledTimer);
+	}
+	scrollDisabledTimer = window.setTimeout(() => { scrollDisabledCount = 0; }, 100);
+	doAfterImagesLoaded(() => scrollToRevealSourceLine(mappedLine, documentVersion, settings));
+};
+const diffScrollSyncManager = settings.settings.diffScrollSync
+	? new DiffScrollSyncManager(settings.settings.diffScrollSync, onDiffScroll)
+	: undefined;
 
 interface State {
 	scrollProgress?: number;
@@ -248,6 +261,9 @@ window.addEventListener('message', async event => {
 
 		case 'updateContent': {
 			lineChanges = data.lineChanges;
+			if (data.diffScrollSync) {
+				diffScrollSyncManager?.update(data.diffScrollSync);
+			}
 			const root = document.querySelector('.markdown-body')!;
 
 			const parser = new DOMParser();
@@ -468,6 +484,7 @@ window.addEventListener('scroll', throttle(() => {
 		state.line = line;
 		vscode.setState(state);
 		messaging.postMessage('revealLine', { line });
+		diffScrollSyncManager?.broadcastScroll(line);
 	}
 }, 50));
 

--- a/extensions/markdown-language-features/preview-src/settings.ts
+++ b/extensions/markdown-language-features/preview-src/settings.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { MarkdownPreviewLineChanges } from '../types/previewMessaging';
+import type { DiffScrollSyncData, MarkdownPreviewLineChanges } from '../types/previewMessaging';
 
 export interface PreviewSettings {
 	readonly source: string;
@@ -11,6 +11,7 @@ export interface PreviewSettings {
 	readonly fragment?: string;
 	readonly selectedLine?: number;
 	readonly lineChanges?: MarkdownPreviewLineChanges;
+	readonly diffScrollSync?: DiffScrollSyncData;
 
 	readonly scrollPreviewWithEditor?: boolean;
 	readonly scrollEditorWithPreview: boolean;

--- a/extensions/markdown-language-features/src/preview/documentRenderer.ts
+++ b/extensions/markdown-language-features/src/preview/documentRenderer.ts
@@ -13,7 +13,7 @@ import { WebviewResourceProvider } from '../util/resources';
 import { generateUuid } from '../util/uuid';
 import { MarkdownPreviewConfiguration, MarkdownPreviewConfigurationManager } from './previewConfig';
 import { ContentSecurityPolicyArbiter, MarkdownPreviewSecurityLevel } from './security';
-import type { MarkdownPreviewInnerChange, MarkdownPreviewLineChanges } from '../../types/previewMessaging';
+import type { DiffScrollSyncData, MarkdownPreviewInnerChange, MarkdownPreviewLineChanges } from '../../types/previewMessaging';
 
 
 /**
@@ -78,6 +78,7 @@ export class MdDocumentRenderer {
 		state: any | undefined,
 		imageInfo: readonly ImageInfo[],
 		lineChanges: MarkdownPreviewLineChanges | undefined,
+		diffScrollSync: DiffScrollSyncData | undefined,
 		token: vscode.CancellationToken
 	): Promise<MarkdownContentProviderOutput> {
 		const sourceUri = markdownDocument.uri;
@@ -88,6 +89,7 @@ export class MdDocumentRenderer {
 			line: initialLine,
 			selectedLine,
 			lineChanges,
+			diffScrollSync,
 			scrollPreviewWithEditor: config.scrollPreviewWithEditor,
 			scrollEditorWithPreview: config.scrollEditorWithPreview,
 			doubleClickToSwitchToEditor: config.doubleClickToSwitchToEditor,

--- a/extensions/markdown-language-features/src/preview/lineDiff.ts
+++ b/extensions/markdown-language-features/src/preview/lineDiff.ts
@@ -59,6 +59,14 @@ export class MarkdownPreviewLineDiffProvider {
 		return translateLine(line, (await this.#getLineChanges()).modifiedToOriginal, this.#originalDocument.lineCount);
 	}
 
+	public async getOriginalToModifiedMappings(): Promise<readonly number[]> {
+		return (await this.#getLineChanges()).originalToModified;
+	}
+
+	public async getModifiedToOriginalMappings(): Promise<readonly number[]> {
+		return (await this.#getLineChanges()).modifiedToOriginal;
+	}
+
 	#getLineChanges(): Promise<LineChanges> {
 		if (!this.#cachedLineChanges || this.#cachedOriginalVersion !== this.#originalDocument.version || this.#cachedModifiedVersion !== this.#modifiedDocument.version) {
 			this.#cachedOriginalVersion = this.#originalDocument.version;

--- a/extensions/markdown-language-features/src/preview/preview.ts
+++ b/extensions/markdown-language-features/src/preview/preview.ts
@@ -16,7 +16,7 @@ import { ImageInfo, MdDocumentRenderer } from './documentRenderer';
 import { MarkdownPreviewConfigurationManager } from './previewConfig';
 import { scrollEditorToLine, StartingScrollFragment, StartingScrollLine, StartingScrollLocation } from './scrolling';
 import { getVisibleLine, LastScrollLocation, TopmostLineMonitor } from './topmostLineMonitor';
-import type { FromWebviewMessage, MarkdownPreviewLineChanges, ToWebviewMessage } from '../../types/previewMessaging';
+import type { DiffScrollSyncData, FromWebviewMessage, MarkdownPreviewLineChanges, ToWebviewMessage } from '../../types/previewMessaging';
 
 export class PreviewDocumentVersion {
 
@@ -38,6 +38,7 @@ interface MarkdownPreviewDelegate {
 	getTitle?(resource: vscode.Uri): string;
 	getAdditionalState(): {};
 	getLineChanges?(): MarkdownPreviewLineChanges | Promise<MarkdownPreviewLineChanges | undefined> | undefined;
+	getDiffScrollSync?(): DiffScrollSyncData | Promise<DiffScrollSyncData | undefined> | undefined;
 	openPreviewLinkToMarkdownFile(markdownLink: vscode.Uri, fragment: string | undefined): void;
 }
 
@@ -294,14 +295,15 @@ class MarkdownPreview extends Disposable implements WebviewResourceProvider {
 		}
 
 		const lineChanges = await this.#delegate.getLineChanges?.();
+		const diffScrollSync = await this.#delegate.getDiffScrollSync?.();
 		const content = await (shouldReloadPage
-			? this.#contentProvider.renderDocument(document, this, this.#previewConfigurations, this.#line, selectedLine, this.state, this.#imageInfo, lineChanges, this.#disposeCts.token)
+			? this.#contentProvider.renderDocument(document, this, this.#previewConfigurations, this.#line, selectedLine, this.state, this.#imageInfo, lineChanges, diffScrollSync, this.#disposeCts.token)
 			: this.#contentProvider.renderBody(document, this, lineChanges));
 
 		// Another call to `doUpdate` may have happened.
 		// Make sure we are still updating for the correct document
 		if (this.#currentVersion?.equals(pendingVersion)) {
-			this.#updateWebviewContent(content.html, shouldReloadPage, lineChanges);
+			this.#updateWebviewContent(content.html, shouldReloadPage, lineChanges, diffScrollSync);
 			this.#updateImageWatchers(content.containingImages);
 		}
 	}
@@ -362,7 +364,7 @@ class MarkdownPreview extends Disposable implements WebviewResourceProvider {
 		this.#webviewPanel.webview.html = this.#contentProvider.renderFileNotFoundDocument(this.#resource);
 	}
 
-	#updateWebviewContent(html: string, reloadPage: boolean, lineChanges: MarkdownPreviewLineChanges | undefined): void {
+	#updateWebviewContent(html: string, reloadPage: boolean, lineChanges: MarkdownPreviewLineChanges | undefined, diffScrollSync: DiffScrollSyncData | undefined): void {
 		if (this.#disposed) {
 			return;
 		}
@@ -379,6 +381,7 @@ class MarkdownPreview extends Disposable implements WebviewResourceProvider {
 				type: 'updateContent',
 				content: html,
 				lineChanges,
+				diffScrollSync,
 				source: this.#resource.toString(),
 			});
 		}
@@ -509,10 +512,11 @@ export class StaticMarkdownPreview extends Disposable implements IManagedMarkdow
 		opener: MdLinkOpener,
 		scrollLine?: number,
 		getLineChanges?: () => MarkdownPreviewLineChanges | Promise<MarkdownPreviewLineChanges | undefined> | undefined,
+		getDiffScrollSync?: () => DiffScrollSyncData | Promise<DiffScrollSyncData | undefined> | undefined,
 	): StaticMarkdownPreview {
 		webview.iconPath = contentProvider.iconPath;
 
-		return new StaticMarkdownPreview(webview, resource, contentProvider, previewConfigurations, topmostLineMonitor, logger, contributionProvider, opener, scrollLine, getLineChanges);
+		return new StaticMarkdownPreview(webview, resource, contentProvider, previewConfigurations, topmostLineMonitor, logger, contributionProvider, opener, scrollLine, getLineChanges, getDiffScrollSync);
 	}
 
 	readonly #preview: MarkdownPreview;
@@ -531,6 +535,7 @@ export class StaticMarkdownPreview extends Disposable implements IManagedMarkdow
 		opener: MdLinkOpener,
 		scrollLine?: number,
 		getLineChanges?: () => MarkdownPreviewLineChanges | Promise<MarkdownPreviewLineChanges | undefined> | undefined,
+		getDiffScrollSync?: () => DiffScrollSyncData | Promise<DiffScrollSyncData | undefined> | undefined,
 	) {
 		super();
 
@@ -541,6 +546,7 @@ export class StaticMarkdownPreview extends Disposable implements IManagedMarkdow
 		this.#preview = this._register(new MarkdownPreview(this.#webviewPanel, resource, topScrollLocation, {
 			getAdditionalState: () => { return {}; },
 			getLineChanges,
+			getDiffScrollSync,
 			openPreviewLinkToMarkdownFile: (markdownLink, fragment) => {
 				return vscode.commands.executeCommand('vscode.openWith', markdownLink.with({
 					fragment

--- a/extensions/markdown-language-features/src/preview/previewManager.ts
+++ b/extensions/markdown-language-features/src/preview/previewManager.ts
@@ -9,13 +9,14 @@ import { MarkdownContributionProvider } from '../markdownExtensions';
 import { Disposable, disposeAll } from '../util/dispose';
 import { isMarkdownFile } from '../util/file';
 import { MdLinkOpener } from '../util/openDocumentLink';
+import { generateUuid } from '../util/uuid';
 import { MdDocumentRenderer } from './documentRenderer';
 import { MarkdownPreviewLineDiffProvider } from './lineDiff';
 import { DynamicMarkdownPreview, IManagedMarkdownPreview, StaticMarkdownPreview } from './preview';
 import { MarkdownPreviewConfigurationManager } from './previewConfig';
 import { scrollEditorToLine, StartingScrollFragment, StartingScrollLine, StartingScrollLocation } from './scrolling';
 import { getVisibleLine, TopmostLineMonitor } from './topmostLineMonitor';
-import type { MarkdownPreviewLineChanges } from '../../types/previewMessaging';
+import type { DiffScrollSyncData, MarkdownPreviewLineChanges } from '../../types/previewMessaging';
 
 
 export interface DynamicPreviewSettings {
@@ -267,17 +268,32 @@ export class MarkdownPreviewManager extends Disposable implements vscode.Webview
 		webviewPanels: vscode.CustomEditorDiffWebviewPanels
 	): Promise<void> {
 		const lineDiffProvider = new MarkdownPreviewLineDiffProvider(documents.original, documents.modified);
-		const originalPreview = this.#resolveCustomTextEditor(documents.original, webviewPanels.original, () => lineDiffProvider.getOriginalLineChanges());
-		const modifiedPreview = this.#resolveCustomTextEditor(documents.modified, webviewPanels.modified, () => lineDiffProvider.getModifiedLineChanges());
+		const channelName = `md-diff-scroll-${generateUuid()}`;
+		const originalPreview = this.#resolveCustomTextEditor(
+			documents.original, webviewPanels.original,
+			() => lineDiffProvider.getOriginalLineChanges(),
+			async () => ({
+				channelName,
+				role: 'original' as const,
+				lineMappings: [...await lineDiffProvider.getModifiedToOriginalMappings()],
+			}));
+		const modifiedPreview = this.#resolveCustomTextEditor(
+			documents.modified, webviewPanels.modified,
+			() => lineDiffProvider.getModifiedLineChanges(),
+			async () => ({
+				channelName,
+				role: 'modified' as const,
+				lineMappings: [...await lineDiffProvider.getOriginalToModifiedMappings()],
+			}));
 		this.#refreshPreviewWhenDocumentChanges(originalPreview, documents.modified);
 		this.#refreshPreviewWhenDocumentChanges(modifiedPreview, documents.original);
-		this.#syncSideBySidePreviewScrolling(originalPreview, modifiedPreview, lineDiffProvider);
 	}
 
 	#resolveCustomTextEditor(
 		document: vscode.TextDocument,
 		webview: vscode.WebviewPanel,
 		getLineChanges?: () => MarkdownPreviewLineChanges | Promise<MarkdownPreviewLineChanges | undefined> | undefined,
+		getDiffScrollSync?: () => DiffScrollSyncData | Promise<DiffScrollSyncData | undefined> | undefined,
 	): StaticMarkdownPreview {
 		const lineNumber = this.#topmostLineMonitor.getPreviousTextEditorLineByUri(document.uri);
 		const preview = StaticMarkdownPreview.revive(
@@ -290,7 +306,8 @@ export class MarkdownPreviewManager extends Disposable implements vscode.Webview
 			this.#contributions,
 			this.#opener,
 			lineNumber,
-			getLineChanges
+			getLineChanges,
+			getDiffScrollSync
 		);
 		this.#registerStaticPreview(preview);
 		this.#activePreview = preview;
@@ -304,82 +321,6 @@ export class MarkdownPreviewManager extends Disposable implements vscode.Webview
 			}
 		});
 		preview.onDispose(() => listener.dispose());
-	}
-
-	#syncSideBySidePreviewScrolling(originalPreview: StaticMarkdownPreview, modifiedPreview: StaticMarkdownPreview, lineDiffProvider: MarkdownPreviewLineDiffProvider): void {
-		let disposed = false;
-		let ignoreOriginalScrollUntil = 0;
-		let ignoreModifiedScrollUntil = 0;
-		let originalToModifiedRequest = 0;
-		let modifiedToOriginalRequest = 0;
-
-		const syncScroll = async (
-			line: number,
-			targetPreview: StaticMarkdownPreview,
-			translateLine: (line: number) => Promise<number>,
-			request: number,
-			shouldApply: (request: number) => boolean,
-			ignoreTargetScroll: () => void,
-		) => {
-			if (disposed) {
-				return;
-			}
-
-			let targetLine: number;
-			try {
-				targetLine = await translateLine(line);
-			} catch {
-				targetLine = line;
-			}
-
-			if (!disposed && shouldApply(request)) {
-				ignoreTargetScroll();
-				targetPreview.scrollTo(targetLine);
-			}
-		};
-
-		const disposables = [
-			originalPreview.onScroll(({ line }) => {
-				if (Date.now() < ignoreOriginalScrollUntil) {
-					return;
-				}
-				const request = ++originalToModifiedRequest;
-				void syncScroll(
-					line,
-					modifiedPreview,
-					value => lineDiffProvider.translateOriginalLineToModified(value),
-					request,
-					value => value === originalToModifiedRequest,
-					() => { ignoreModifiedScrollUntil = Date.now() + 100; },
-				);
-			}),
-			modifiedPreview.onScroll(({ line }) => {
-				if (Date.now() < ignoreModifiedScrollUntil) {
-					return;
-				}
-				const request = ++modifiedToOriginalRequest;
-				void syncScroll(
-					line,
-					originalPreview,
-					value => lineDiffProvider.translateModifiedLineToOriginal(value),
-					request,
-					value => value === modifiedToOriginalRequest,
-					() => { ignoreOriginalScrollUntil = Date.now() + 100; },
-				);
-			}),
-		];
-
-		const dispose = () => {
-			if (disposed) {
-				return;
-			}
-			disposed = true;
-			++originalToModifiedRequest;
-			++modifiedToOriginalRequest;
-			disposeAll(disposables);
-		};
-		originalPreview.onDispose(dispose);
-		modifiedPreview.onDispose(dispose);
 	}
 
 	#createNewDynamicPreview(

--- a/extensions/markdown-language-features/types/previewMessaging.d.ts
+++ b/extensions/markdown-language-features/types/previewMessaging.d.ts
@@ -22,6 +22,15 @@ export interface MarkdownPreviewLineChanges {
 	readonly innerChanges?: readonly MarkdownPreviewInnerChange[];
 }
 
+export interface DiffScrollSyncData {
+	/** Shared BroadcastChannel name for this diff pair */
+	readonly channelName: string;
+	/** Which side of the diff this preview represents */
+	readonly role: 'original' | 'modified';
+	/** Mapping from the other side's line numbers to this side's line numbers */
+	readonly lineMappings: readonly number[];
+}
+
 export namespace FromWebviewMessage {
 
 	export interface CacheImageSizes extends BaseMessage {
@@ -79,6 +88,7 @@ export namespace ToWebviewMessage {
 		readonly type: 'updateContent';
 		readonly content: string;
 		readonly lineChanges?: MarkdownPreviewLineChanges;
+		readonly diffScrollSync?: DiffScrollSyncData;
 	}
 
 	export interface CopyImageContent extends BaseMessage {


### PR DESCRIPTION
For #315174


This makes scroll sync faster by using a broadcast channel instead of the normal vscode webview api. This means the two webviews can communicate with each other directly instead of having to go through the extension host and renderer each time

