### PR TITLE
sessions: fix Customizations single-entry width overflow

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/media/customizationsToolbar.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/customizationsToolbar.css
@@ -173,14 +173,9 @@
 	padding: 6px 0 10px 0;
 }
 
-/* Override the shared `flex: 1` on the link-button container so the single
-	entry sizes to its content height instead of stretching to fill the
-	flex-column toolbar. */
+/* Disable the shared `flex: 1` so the single entry doesn't stretch to fill
+	the flex-column toolbar. Width is handled by the inherited `margin: 0 10px`
+	and the parent's default `align-items: stretch`. */
 .ai-customization-toolbar.single-entry .customization-link-button-container {
 	flex: none;
-	width: 100%;
-}
-
-.ai-customization-toolbar.single-entry .customization-link-button {
-	width: 100%;
 }


### PR DESCRIPTION
## What

Fixes the keyboard-focus outline on the single-entry "Customizations" sidebar button being misaligned — extending past the panel's right edge.

| Before | After |
| --- | --- |
| Outline overflows the panel (visible 20px past the right edge) | Outline hugs the button, matching the per-section items |

## Why

In single-entry mode, `.ai-customization-toolbar.single-entry .customization-link-button-container` had `width: 100%` set, which combined with the inherited `margin: 0 10px` from the base rule (line 84) to lay out the container at `parent.width + 20px`. The button inside also had `width: 100%`, so it inherited the overflow. The focus outline traces the button's actual bounding box, making the overflow immediately visible whenever the button received keyboard focus.

## Fix

Drop the explicit `width: 100%` declarations. The flex-column toolbar's default `align-items: stretch` plus the inherited `margin: 0 10px` already size the container correctly — the same way the per-section link rows are sized. `flex: none` is kept so the entry doesn't stretch vertically inside the column.

## Testing

CSS-only change; verified hygiene passes. Component fixture in `aiCustomizationShortcutsWidget.fixture.ts` (`ModeSingle*`) covers this layout.