### PR TITLE
sessions: sync customizations harness with AHP session resource scheme

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts
@@ -19,7 +19,7 @@ import { defaultButtonStyles } from '../../../../platform/theme/browser/defaultS
 import { IMcpService } from '../../../../workbench/contrib/mcp/common/mcpTypes.js';
 import { IAICustomizationItemsModel } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemsModel.js';
 import { ICustomizationHarnessService } from '../../../../workbench/contrib/chat/common/customizationHarnessService.js';
-import { CUSTOMIZATION_ITEMS, SESSIONS_CUSTOMIZATIONS_SIDEBAR_MODE_SETTING, SessionsCustomizationsSidebarMode } from './customizationsToolbar.contribution.js';
+import { CUSTOMIZATION_ITEMS, findHarnessIdForSession, SESSIONS_CUSTOMIZATIONS_SIDEBAR_MODE_SETTING, SessionsCustomizationsSidebarMode } from './customizationsToolbar.contribution.js';
 import { Menus } from '../../../browser/menus.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IEditorService } from '../../../../workbench/services/editor/common/editorService.js';
@@ -167,9 +167,9 @@ export class AICustomizationShortcutsWidget extends Disposable {
 	}
 
 	private async _openWelcomePage(): Promise<void> {
-		const activeSessionType = this.sessionsManagementService.activeSession.get()?.sessionType;
-		if (activeSessionType && this.harnessService.findHarnessById(activeSessionType)) {
-			this.harnessService.setActiveHarness(activeSessionType);
+		const harnessId = findHarnessIdForSession(this.sessionsManagementService.activeSession.get(), this.harnessService);
+		if (harnessId) {
+			this.harnessService.setActiveHarness(harnessId);
 		}
 
 		const input = AICustomizationManagementEditorInput.getOrCreate();

--- a/src/vs/sessions/contrib/sessions/browser/customizationsToolbar.contribution.ts
+++ b/src/vs/sessions/contrib/sessions/browser/customizationsToolbar.contribution.ts
@@ -28,6 +28,7 @@ import { defaultButtonStyles } from '../../../../platform/theme/browser/defaultS
 import { IEditorService } from '../../../../workbench/services/editor/common/editorService.js';
 import { AICustomizationManagementSection } from '../../../../workbench/contrib/chat/common/aiCustomizationWorkspaceService.js';
 import { ICustomizationHarnessService } from '../../../../workbench/contrib/chat/common/customizationHarnessService.js';
+import { ISession } from '../../../services/sessions/common/session.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
@@ -287,9 +288,9 @@ export class CustomizationsToolbarContribution extends Disposable implements IWo
 					const harnessService = accessor.get(ICustomizationHarnessService);
 					const sessionsManagementService = accessor.get(ISessionsManagementService);
 					const configurationService = accessor.get(IConfigurationService);
-					const activeSessionType = sessionsManagementService.activeSession.get()?.sessionType;
-					if (activeSessionType && harnessService.findHarnessById(activeSessionType)) {
-						harnessService.setActiveHarness(activeSessionType);
+					const harnessId = findHarnessIdForSession(sessionsManagementService.activeSession.get(), harnessService);
+					if (harnessId) {
+						harnessService.setActiveHarness(harnessId);
 					}
 					const input = AICustomizationManagementEditorInput.getOrCreate();
 					const pane = await editorService.openEditor(input, { pinned: true });
@@ -311,10 +312,36 @@ export class CustomizationsToolbarContribution extends Disposable implements IWo
 registerWorkbenchContribution2(CustomizationsToolbarContribution.ID, CustomizationsToolbarContribution, WorkbenchPhase.AfterRestored);
 
 /**
+ * Returns the harness id that matches a given session, or `undefined` if no
+ * harness is registered for it.
+ *
+ * The session's `resource.scheme` is the per-host harness id (e.g. local AHP
+ * uses `agent-host-${provider}` and remote AHP uses `remote-${authority}-${provider}`),
+ * while {@link ISession.sessionType} is the agent provider name shared across
+ * hosts (e.g. `copilotcli`). Lookup therefore prefers the resource scheme so
+ * that an AHP remote session selects its remote harness rather than the local
+ * harness with the same `sessionType`. The `sessionType` is kept as a fallback
+ * for harnesses whose id matches it directly.
+ */
+export function findHarnessIdForSession(session: ISession | undefined, harnessService: ICustomizationHarnessService): string | undefined {
+	if (!session) {
+		return undefined;
+	}
+	const schemeId = session.resource.scheme;
+	if (harnessService.findHarnessById(schemeId)) {
+		return schemeId;
+	}
+	if (harnessService.findHarnessById(session.sessionType)) {
+		return session.sessionType;
+	}
+	return undefined;
+}
+
+/**
  * Keeps the active customization harness in sync with the currently active
- * session's `sessionType`. This drives the customizations sidebar (counts,
- * filtering) and the customizations editor so they reflect the harness that
- * matches the session the user is interacting with.
+ * session. This drives the customizations sidebar (counts, filtering) and the
+ * customizations editor so they reflect the harness that matches the session
+ * the user is interacting with.
  *
  * This covers two cases identically:
  *  - opening / navigating into an existing session
@@ -332,16 +359,17 @@ export class ActiveSessionHarnessSyncContribution extends Disposable implements 
 		super();
 
 		this._register(autorun(reader => {
-			const sessionType = sessionsManagementService.activeSession.read(reader)?.sessionType;
-			if (!sessionType) {
+			const session = sessionsManagementService.activeSession.read(reader);
+			if (!session) {
 				return;
 			}
 			// Re-read available harnesses so we re-run when an external harness
 			// (e.g. agent host, CLI) registers asynchronously after the session
 			// has already been selected.
 			harnessService.availableHarnesses.read(reader);
-			if (harnessService.findHarnessById(sessionType)) {
-				harnessService.setActiveHarness(sessionType);
+			const harnessId = findHarnessIdForSession(session, harnessService);
+			if (harnessId) {
+				harnessService.setActiveHarness(harnessId);
 			}
 		}));
 	}


### PR DESCRIPTION
### Problem

In the Agents window, when an AHP (Agent Host Protocol) session was selected, the customizations editor's harness selector dropdown stayed on the local CLI harness instead of switching to the matching remote.

### Root cause

All three places that sync the active customization harness to the active session looked up the harness by `session.sessionType`. For AHP sessions, `sessionType` is the agent provider name (e.g. `copilotcli`) and is shared across all hosts of the same agent. The harness id, on the other hand, is per-host and equals the session's `resource.scheme`:

- Local AHP harness id: `agent-host-${provider}`
- Remote AHP harness id: `remote-${authority}-${provider}`

So `findHarnessById('copilotcli')` always matched the local CLI extension harness rather than the per-host AHP harness for the active session.

### Fix

Add a small `findHarnessIdForSession()` helper in `customizationsToolbar.contribution.ts` that:

1. Prefers `session.resource.scheme` (which equals the AHP harness id), then
2. Falls back to `session.sessionType` for harnesses whose id matches it directly (e.g. CLI / Claude extension harnesses).

Use it from all three sync points:

- `ActiveSessionHarnessSyncContribution` autorun (drives the editor + sidebar counts when the active session changes).
- `CustomizationLinkViewItem.run` (the sidebar customization category links).
- `AICustomizationShortcutsWidget._openWelcomePage` (the sidebar header overview button).

### Validation

- `npm run compile-check-ts-native` — clean (no new errors)
- `node build/eslint.ts` — clean
- Pre-commit hygiene hook — passed