### PR TITLE
chat: lowercase 'artifacts' in artifacts widget header

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatArtifactsWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatArtifactsWidget.ts
@@ -194,8 +194,8 @@ export class ChatArtifactsWidget extends Disposable {
 				this.domNode.style.display = '';
 
 				titleElement.textContent = data.totalCount === 1
-					? localize('chat.artifacts.one', "1 Artifact")
-					: localize('chat.artifacts.count', "{0} Artifacts", data.totalCount);
+					? localize('chat.artifacts.one', "1 artifact")
+					: localize('chat.artifacts.count', "{0} artifacts", data.totalCount);
 
 				tree.layout(data.treeHeight);
 				tree.getHTMLElement().style.height = `${data.treeHeight}px`;


### PR DESCRIPTION
<!--
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Lowercases the artifacts count label in the chat artifacts widget header so it visually aligns with the adjacent lowercase "file change" label.

Per @roblourens in #309415: *"I would probably go lowercase on artifacts"*.

### Change

`src/vs/workbench/contrib/chat/browser/widget/chatArtifactsWidget.ts`

```diff
-    ? localize('chat.artifacts.one', "1 Artifact")
-    : localize('chat.artifacts.count', "{0} Artifacts", data.totalCount);
+    ? localize('chat.artifacts.one', "1 artifact")
+    : localize('chat.artifacts.count', "{0} artifacts", data.totalCount);
```

The `localize` keys are unchanged; only the source English strings change.

### How to test

1. Open a chat session that produces multiple artifacts (e.g. via an agent that emits files).
2. Confirm the artifacts widget header now reads `N artifacts` (or `1 artifact`) instead of `N Artifacts`.
3. Confirm the header still aligns visually with the lowercase "file change" badge.

Closes #309415
