### PR TITLE
Remove Agents app testing from sanity tests

### DIFF
--- a/test/sanity/src/desktop.test.ts
+++ b/test/sanity/src/desktop.test.ts
@@ -15,7 +15,6 @@ export function setup(context: TestContext) {
 		if (!context.options.downloadOnly) {
 			const entryPoint = context.getDesktopEntryPoint(dir);
 			await testDesktopApp(entryPoint);
-			await testAgentsApp(entryPoint);
 		}
 	});
 
@@ -25,7 +24,6 @@ export function setup(context: TestContext) {
 		if (!context.options.downloadOnly) {
 			const entryPoint = context.getDesktopEntryPoint(dir);
 			await testDesktopApp(entryPoint);
-			await testAgentsApp(entryPoint);
 		}
 	});
 
@@ -35,7 +33,6 @@ export function setup(context: TestContext) {
 		if (!context.options.downloadOnly) {
 			const entryPoint = context.getDesktopEntryPoint(dir);
 			await testDesktopApp(entryPoint);
-			await testAgentsApp(entryPoint);
 		}
 	});
 
@@ -47,7 +44,6 @@ export function setup(context: TestContext) {
 			context.validateAllCodesignSignatures(dir);
 			const entryPoint = context.getDesktopEntryPoint(dir);
 			await testDesktopApp(entryPoint);
-			await testAgentsApp(entryPoint);
 			context.unmountDmg(dir);
 		}
 	});
@@ -60,7 +56,6 @@ export function setup(context: TestContext) {
 			context.validateAllCodesignSignatures(dir);
 			const entryPoint = context.getDesktopEntryPoint(dir);
 			await testDesktopApp(entryPoint);
-			await testAgentsApp(entryPoint);
 			context.unmountDmg(dir);
 		}
 	});
@@ -73,7 +68,6 @@ export function setup(context: TestContext) {
 			context.validateAllCodesignSignatures(dir);
 			const entryPoint = context.getDesktopEntryPoint(dir);
 			await testDesktopApp(entryPoint);
-			await testAgentsApp(entryPoint);
 			context.unmountDmg(dir);
 		}
 	});
@@ -180,7 +174,6 @@ export function setup(context: TestContext) {
 			context.validateAllAuthenticodeSignatures(path.dirname(entryPoint));
 			context.validateAllVersionInfo(path.dirname(entryPoint));
 			await testDesktopApp(entryPoint);
-			await testAgentsApp(entryPoint);
 			await context.uninstallWindowsApp('system');
 		}
 	});
@@ -193,7 +186,6 @@ export function setup(context: TestContext) {
 			const entryPoint = context.getDesktopEntryPoint(dir);
 			const dataDir = context.createPortableDataDir(dir);
 			await testDesktopApp(entryPoint, dataDir);
-			await testAgentsApp(entryPoint, dataDir);
 		}
 	});
 
@@ -206,7 +198,6 @@ export function setup(context: TestContext) {
 			context.validateAllAuthenticodeSignatures(path.dirname(entryPoint));
 			context.validateAllVersionInfo(path.dirname(entryPoint));
 			await testDesktopApp(entryPoint);
-			await testAgentsApp(entryPoint);
 			await context.uninstallWindowsApp('user');
 		}
 	});
@@ -220,7 +211,6 @@ export function setup(context: TestContext) {
 			context.validateAllAuthenticodeSignatures(path.dirname(entryPoint));
 			context.validateAllVersionInfo(path.dirname(entryPoint));
 			await testDesktopApp(entryPoint);
-			await testAgentsApp(entryPoint);
 			await context.uninstallWindowsApp('system');
 		}
 	});
@@ -233,7 +223,6 @@ export function setup(context: TestContext) {
 			const entryPoint = context.getDesktopEntryPoint(dir);
 			const dataDir = context.createPortableDataDir(dir);
 			await testDesktopApp(entryPoint, dataDir);
-			await testAgentsApp(entryPoint, dataDir);
 		}
 	});
 
@@ -246,7 +235,6 @@ export function setup(context: TestContext) {
 			context.validateAllAuthenticodeSignatures(path.dirname(entryPoint));
 			context.validateAllVersionInfo(path.dirname(entryPoint));
 			await testDesktopApp(entryPoint);
-			await testAgentsApp(entryPoint);
 			await context.uninstallWindowsApp('user');
 		}
 	});
@@ -270,33 +258,5 @@ export function setup(context: TestContext) {
 		}
 
 		test.validate();
-	}
-
-	async function testAgentsApp(desktopEntryPoint: string, dataDir?: string) {
-		if (context.options.quality === 'stable') {
-			// Agents window is not included in stable builds yet.
-			return;
-		}
-
-		const test = new UITest(context, dataDir);
-		const args = ['--agents'];
-		if (!dataDir) {
-			args.push('--extensions-dir', test.extensionsDir);
-			args.push('--user-data-dir', test.userDataDir);
-		}
-
-		context.log(`Starting Agents app ${desktopEntryPoint} with args ${args.join(' ')}`);
-		const app = await _electron.launch({ executablePath: desktopEntryPoint, args });
-		try {
-			const window = await context.getPage(app.firstWindow());
-			await window.waitForSelector('.agent-sessions-workbench', { timeout: 60000 });
-
-			context.log('Clicking "Sign in with GitHub" button');
-			const button = await window.waitForSelector('button.provider-github');
-			await button.click();
-		} finally {
-			context.log('Closing the Agents app');
-			await app.close();
-		}
 	}
 }


### PR DESCRIPTION
Removes all Agents window/app testing from the release sanity tests.

Drops the `testAgentsApp` helper in `test/sanity/src/desktop.test.ts` and all 13 call sites across the desktop sanity scenarios (darwin, dmg, win32 system/user/archive).