### PR TITLE
BYOK: support per-model reasoning_effort across OpenAI-compatible providers

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -1951,6 +1951,21 @@
 										"default": false,
 										"markdownDescription": "Whether Zero Data Retention (ZDR) is enabled for this endpoint. When `true`, `previous_response_id` will not be sent in requests via Responses API."
 									},
+									"supportsReasoningEffort": {
+										"type": "array",
+										"markdownDescription": "Reasoning effort levels the model accepts (e.g. `[\"low\", \"medium\", \"high\"]`). When set, a `Thinking Effort` picker is shown in the model picker and the chosen value is forwarded to the model. Levels supported by mainstream OpenAI-compatible servers are `minimal`, `low`, `medium`, `high`.",
+										"items": {
+											"type": "string"
+										}
+									},
+									"reasoningEffortFormat": {
+										"type": "string",
+										"enum": [
+											"chat-completions",
+											"responses"
+										],
+										"markdownDescription": "Body shape used to forward the reasoning effort to the model. `chat-completions` sends a top-level `reasoning_effort` string. `responses` sends a nested `reasoning.effort` object. When unset the format follows the URL: `/responses` \u2192 nested, otherwise top-level."
+									},
 									"requestHeaders": {
 										"type": "object",
 										"description": "Additional HTTP headers to include with requests to this model. These reserved headers are not allowed and ignored if present: forbidden request headers (https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_request_header), forwarding headers ('forwarded', 'x-forwarded-for', 'x-forwarded-host', 'x-forwarded-proto'), and others ('api-key', 'authorization', 'content-type', 'openai-intent', 'x-github-api-version', 'x-initiator', 'x-interaction-id', 'x-interaction-type', 'x-onbehalf-extension-id', 'x-request-id', 'x-vscode-user-agent-library-version'). Pattern-based forbidden headers ('proxy-*', 'sec-*', 'x-http-method*' with forbidden methods) are also blocked.",
@@ -2049,6 +2064,21 @@
 										"type": "boolean",
 										"default": false,
 										"markdownDescription": "Whether Zero Data Retention (ZDR) is enabled for this endpoint. When `true`, `previous_response_id` will not be sent in requests via Responses API."
+									},
+									"supportsReasoningEffort": {
+										"type": "array",
+										"markdownDescription": "Reasoning effort levels the model accepts (e.g. `[\"low\", \"medium\", \"high\"]`). When set, a `Thinking Effort` picker is shown in the model picker and the chosen value is forwarded to the model. Levels supported by mainstream OpenAI-compatible servers are `minimal`, `low`, `medium`, `high`.",
+										"items": {
+											"type": "string"
+										}
+									},
+									"reasoningEffortFormat": {
+										"type": "string",
+										"enum": [
+											"chat-completions",
+											"responses"
+										],
+										"markdownDescription": "Body shape used to forward the reasoning effort to the model. `chat-completions` sends a top-level `reasoning_effort` string. `responses` sends a nested `reasoning.effort` object. When unset the format follows the URL: `/responses` \u2192 nested, otherwise top-level."
 									},
 									"requestHeaders": {
 										"type": "object",

--- a/extensions/copilot/src/extension/byok/common/byokProvider.ts
+++ b/extensions/copilot/src/extension/byok/common/byokProvider.ts
@@ -61,6 +61,13 @@ export interface BYOKModelCapabilities {
 	supportedEndpoints?: ModelSupportedEndpoint[];
 	zeroDataRetentionEnabled?: boolean;
 	supportsReasoningEffort?: string[];
+	/**
+	 * Override the body shape used to forward the reasoning effort to the model.
+	 * - `'chat-completions'`: top-level `reasoning_effort` (default for `/chat/completions`).
+	 * - `'responses'`: nested `reasoning.effort` (default for `/responses`).
+	 * If unset the format is inferred from whether the endpoint uses the Responses API.
+	 */
+	reasoningEffortFormat?: 'chat-completions' | 'responses';
 }
 
 export interface BYOKModelRegistry {
@@ -108,7 +115,8 @@ export function resolveModelInfo(modelId: string, providerName: string, knownMod
 				tool_calls: !!knownModelInfo?.toolCalling,
 				vision: !!knownModelInfo?.vision,
 				thinking: !!knownModelInfo?.thinking,
-				adaptive_thinking: !!knownModelInfo?.adaptiveThinking
+				adaptive_thinking: !!knownModelInfo?.adaptiveThinking,
+				reasoning_effort: knownModelInfo?.supportsReasoningEffort
 			},
 			tokenizer: TokenizerType.O200K,
 			limits: {
@@ -121,7 +129,8 @@ export function resolveModelInfo(modelId: string, providerName: string, knownMod
 		is_chat_fallback: false,
 		model_picker_enabled: true,
 		supported_endpoints: knownModelInfo?.supportedEndpoints,
-		zeroDataRetentionEnabled: knownModelInfo?.zeroDataRetentionEnabled
+		zeroDataRetentionEnabled: knownModelInfo?.zeroDataRetentionEnabled,
+		reasoningEffortFormat: knownModelInfo?.reasoningEffortFormat
 	};
 	if (knownModelInfo?.requestHeaders && Object.keys(knownModelInfo.requestHeaders).length > 0) {
 		modelInfo.requestHeaders = { ...knownModelInfo.requestHeaders };

--- a/extensions/copilot/src/extension/byok/common/test/byokProvider.spec.ts
+++ b/extensions/copilot/src/extension/byok/common/test/byokProvider.spec.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { describe, expect, it } from 'vitest';
-import { byokKnownModelToAPIInfo, BYOKModelCapabilities } from '../byokProvider';
+import { byokKnownModelToAPIInfo, BYOKModelCapabilities, resolveModelInfo } from '../byokProvider';
 
 describe('byokKnownModelToAPIInfo', () => {
 	const baseCapabilities: BYOKModelCapabilities = {
@@ -41,5 +41,33 @@ describe('byokKnownModelToAPIInfo', () => {
 		const info = byokKnownModelToAPIInfo('TestProvider', 'm1', baseCapabilities);
 
 		expect(info.capabilities.editTools).toBeUndefined();
+	});
+});
+
+describe('resolveModelInfo', () => {
+	const baseCapabilities: BYOKModelCapabilities = {
+		name: 'TestModel',
+		maxInputTokens: 1000,
+		maxOutputTokens: 100,
+		toolCalling: true,
+		vision: false,
+	};
+
+	it('propagates supportsReasoningEffort and reasoningEffortFormat from BYOK capabilities into chat-endpoint inputs', () => {
+		const info = resolveModelInfo('m1', 'TestProvider', undefined, {
+			...baseCapabilities,
+			supportsReasoningEffort: ['low', 'medium', 'high'],
+			reasoningEffortFormat: 'responses',
+		});
+
+		expect(info.capabilities.supports.reasoning_effort).toEqual(['low', 'medium', 'high']);
+		expect(info.reasoningEffortFormat).toBe('responses');
+	});
+
+	it('omits the reasoning effort capability when the model does not declare it', () => {
+		const info = resolveModelInfo('m1', 'TestProvider', undefined, baseCapabilities);
+
+		expect(info.capabilities.supports.reasoning_effort).toBeUndefined();
+		expect(info.reasoningEffortFormat).toBeUndefined();
 	});
 });

--- a/extensions/copilot/src/extension/byok/node/openAIEndpoint.ts
+++ b/extensions/copilot/src/extension/byok/node/openAIEndpoint.ts
@@ -5,7 +5,7 @@
 import type { CancellationToken } from 'vscode';
 import { IChatMLFetcher } from '../../../platform/chat/common/chatMLFetcher';
 import { ChatFetchResponseType, ChatResponse } from '../../../platform/chat/common/commonTypes';
-import { IConfigurationService } from '../../../platform/configuration/common/configurationService';
+import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
 import { IDomainService } from '../../../platform/endpoint/common/domainService';
 import { IChatModelInformation } from '../../../platform/endpoint/common/endpointProvider';
 import { ChatEndpoint } from '../../../platform/endpoint/node/chatEndpoint';
@@ -250,6 +250,7 @@ export class OpenAIEndpoint extends ChatEndpoint {
 				// Don't use a response ID from CAPI or when zero data retention is enabled
 				body.previous_response_id = undefined;
 			}
+			this._applyReasoningEffort(body, options);
 			return body;
 		} else if (this.useMessagesApi) {
 			// Delegate to base ChatEndpoint for Messages API dispatch
@@ -263,7 +264,40 @@ export class OpenAIEndpoint extends ChatEndpoint {
 				}
 			};
 			const body = createCapiRequestBody(options, this.model, callback);
+			this._applyReasoningEffort(body, options);
 			return body;
+		}
+	}
+
+	/**
+	 * Forwards the per-request reasoning effort to the model body in the shape the endpoint expects.
+	 * Default shape mirrors the API path (`Responses` \u2192 nested `reasoning.effort`, `Chat Completions` \u2192 top-level `reasoning_effort`).
+	 * `IChatModelInformation.reasoningEffortFormat` overrides the default so users hosting OpenAI-compatible servers
+	 * with diverging conventions (e.g. nested `reasoning.effort` on `/chat/completions`) can opt in deterministically.
+	 */
+	private _applyReasoningEffort(body: IEndpointBody, options: ICreateEndpointBodyOptions): void {
+		const supports = this.supportsReasoningEffort;
+		if (!supports?.length) {
+			return;
+		}
+		const format = this.modelMetadata.reasoningEffortFormat
+			?? (this.useResponsesApi ? 'responses' : 'chat-completions');
+		const override = this._configurationService.getConfig(ConfigKey.Advanced.ReasoningEffortOverride);
+		const requested = override || options.modelCapabilities?.reasoningEffort || body.reasoning?.effort || body.reasoning_effort;
+		const effort = requested && supports.includes(requested) ? requested : undefined;
+		if (format === 'responses') {
+			if (effort) {
+				body.reasoning = { ...body.reasoning, effort };
+			}
+			body.reasoning_effort = undefined;
+		} else {
+			if (effort) {
+				body.reasoning_effort = effort;
+			}
+			if (body.reasoning) {
+				const { effort: _drop, ...rest } = body.reasoning;
+				body.reasoning = Object.keys(rest).length > 0 ? rest : undefined;
+			}
 		}
 	}
 

--- a/extensions/copilot/src/extension/byok/node/openAIEndpoint.ts
+++ b/extensions/copilot/src/extension/byok/node/openAIEndpoint.ts
@@ -285,18 +285,19 @@ export class OpenAIEndpoint extends ChatEndpoint {
 		const override = this._configurationService.getConfig(ConfigKey.Advanced.ReasoningEffortOverride);
 		const requested = override || options.modelCapabilities?.reasoningEffort || body.reasoning?.effort || body.reasoning_effort;
 		const effort = requested && supports.includes(requested) ? requested : undefined;
-		if (format === 'responses') {
-			if (effort) {
+		// Scrub any pre-populated effort first so unsupported values (e.g. the hard-coded `medium` default
+		// from `createResponsesRequestBody`) cannot leak through, then write the resolved value into the
+		// expected shape.
+		if (body.reasoning) {
+			const { effort: _drop, ...rest } = body.reasoning;
+			body.reasoning = Object.keys(rest).length > 0 ? rest : undefined;
+		}
+		body.reasoning_effort = undefined;
+		if (effort) {
+			if (format === 'responses') {
 				body.reasoning = { ...body.reasoning, effort };
-			}
-			body.reasoning_effort = undefined;
-		} else {
-			if (effort) {
+			} else {
 				body.reasoning_effort = effort;
-			}
-			if (body.reasoning) {
-				const { effort: _drop, ...rest } = body.reasoning;
-				body.reasoning = Object.keys(rest).length > 0 ? rest : undefined;
 			}
 		}
 	}

--- a/extensions/copilot/src/extension/byok/node/test/openAIEndpoint.spec.ts
+++ b/extensions/copilot/src/extension/byok/node/test/openAIEndpoint.spec.ts
@@ -184,4 +184,107 @@ describe('OpenAIEndpoint - Reasoning Properties', () => {
 			expect(body.reasoning).toBeUndefined(); // Should be removed
 		});
 	});
+
+	describe('reasoning effort forwarding', () => {
+		const userMessage: Raw.ChatMessage = {
+			role: Raw.ChatRole.User,
+			content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: 'Hello' }]
+		};
+
+		const buildOptions = (reasoningEffort?: string): ICreateEndpointBodyOptions => ({
+			...createTestOptions([userMessage]),
+			modelCapabilities: reasoningEffort ? { reasoningEffort } : undefined,
+		});
+
+		const buildModel = (overrides: Partial<IChatModelInformation>): IChatModelInformation => ({
+			...modelMetadata,
+			supported_endpoints: [ModelSupportedEndpoint.ChatCompletions],
+			capabilities: {
+				...modelMetadata.capabilities,
+				supports: {
+					...modelMetadata.capabilities.supports,
+					reasoning_effort: ['low', 'medium', 'high'],
+				},
+			},
+			...overrides,
+		});
+
+		it('places top-level `reasoning_effort` on Chat Completions when the model supports the requested level', () => {
+			const endpoint = instaService.createInstance(OpenAIEndpoint,
+				buildModel({}),
+				'test-api-key',
+				'https://api.openai.com/v1/chat/completions');
+
+			const body = endpoint.createRequestBody(buildOptions('high'));
+
+			expect(body.reasoning_effort).toBe('high');
+			expect(body.reasoning).toBeUndefined();
+		});
+
+		it('omits the field when the requested level is not in the supported list', () => {
+			const endpoint = instaService.createInstance(OpenAIEndpoint,
+				buildModel({}),
+				'test-api-key',
+				'https://api.openai.com/v1/chat/completions');
+
+			const body = endpoint.createRequestBody(buildOptions('minimal'));
+
+			expect(body.reasoning_effort).toBeUndefined();
+			expect(body.reasoning).toBeUndefined();
+		});
+
+		it('honors the `ReasoningEffortOverride` setting over the per-request value', () => {
+			accessor.get(IConfigurationService).setConfig(ConfigKey.Advanced.ReasoningEffortOverride, 'low');
+			const endpoint = instaService.createInstance(OpenAIEndpoint,
+				buildModel({}),
+				'test-api-key',
+				'https://api.openai.com/v1/chat/completions');
+
+			const body = endpoint.createRequestBody(buildOptions('high'));
+
+			expect(body.reasoning_effort).toBe('low');
+		});
+
+		it('emits nested `reasoning.effort` and scrubs top-level when `reasoningEffortFormat` is `responses` on Chat Completions URL', () => {
+			const endpoint = instaService.createInstance(OpenAIEndpoint,
+				buildModel({ reasoningEffortFormat: 'responses' }),
+				'test-api-key',
+				'https://api.openai.com/v1/chat/completions');
+
+			const body = endpoint.createRequestBody(buildOptions('medium'));
+
+			expect(body.reasoning).toEqual({ effort: 'medium' });
+			expect(body.reasoning_effort).toBeUndefined();
+		});
+
+		it('emits top-level `reasoning_effort` and scrubs nested when `reasoningEffortFormat` is `chat-completions` on a Responses URL', () => {
+			const endpoint = instaService.createInstance(OpenAIEndpoint,
+				buildModel({
+					reasoningEffortFormat: 'chat-completions',
+					supported_endpoints: [ModelSupportedEndpoint.Responses],
+				}),
+				'test-api-key',
+				'https://api.openai.com/v1/responses');
+
+			const body = endpoint.createRequestBody(buildOptions('high'));
+
+			expect(body.reasoning_effort).toBe('high');
+			expect(body.reasoning?.effort).toBeUndefined();
+		});
+
+		it('does not emit a reasoning field when the model declares no reasoning support', () => {
+			const endpoint = instaService.createInstance(OpenAIEndpoint,
+				{
+					...modelMetadata,
+					supported_endpoints: [ModelSupportedEndpoint.ChatCompletions],
+				},
+				'test-api-key',
+				'https://api.openai.com/v1/chat/completions');
+
+			const body = endpoint.createRequestBody(buildOptions('high'));
+
+			expect(body.reasoning_effort).toBeUndefined();
+			expect(body.reasoning).toBeUndefined();
+		});
+	});
 });

--- a/extensions/copilot/src/extension/byok/node/test/openAIEndpoint.spec.ts
+++ b/extensions/copilot/src/extension/byok/node/test/openAIEndpoint.spec.ts
@@ -7,7 +7,7 @@ import { Raw } from '@vscode/prompt-tsx';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { ConfigKey, IConfigurationService } from '../../../../platform/configuration/common/configurationService';
 import { IChatModelInformation, ModelSupportedEndpoint } from '../../../../platform/endpoint/common/endpointProvider';
-import { ICreateEndpointBodyOptions } from '../../../../platform/networking/common/networking';
+import { ICreateEndpointBodyOptions, IEndpointBody } from '../../../../platform/networking/common/networking';
 import { ITestingServicesAccessor } from '../../../../platform/test/node/services';
 import { DisposableStore } from '../../../../util/vs/base/common/lifecycle';
 import { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
@@ -285,6 +285,73 @@ describe('OpenAIEndpoint - Reasoning Properties', () => {
 
 			expect(body.reasoning_effort).toBeUndefined();
 			expect(body.reasoning).toBeUndefined();
+		});
+
+		it('scrubs an unsupported `reasoning.effort` pre-populated by `createResponsesRequestBody` on a Responses request', () => {
+			// `createResponsesRequestBody` hard-codes a `'medium'` default. If the model only supports
+			// e.g. `['low', 'high']`, that default must not leak through to the wire.
+			const endpoint = instaService.createInstance(OpenAIEndpoint,
+				buildModel({
+					supported_endpoints: [ModelSupportedEndpoint.Responses],
+					capabilities: {
+						...modelMetadata.capabilities,
+						supports: {
+							...modelMetadata.capabilities.supports,
+							reasoning_effort: ['low', 'high'],
+						},
+					},
+				}),
+				'test-api-key',
+				'https://api.openai.com/v1/responses');
+
+			const body = endpoint.createRequestBody(buildOptions());
+
+			expect(body.reasoning?.effort).toBeUndefined();
+		});
+
+		it('scrubs an unsupported pre-populated value while preserving other reasoning fields', () => {
+			// Direct invocation via the Chat Completions path: synthesize a body that already carries an
+			// unsupported effort plus a `summary` field, and verify only the effort is dropped.
+			const endpoint = instaService.createInstance(OpenAIEndpoint,
+				buildModel({
+					reasoningEffortFormat: 'responses',
+					capabilities: {
+						...modelMetadata.capabilities,
+						supports: {
+							...modelMetadata.capabilities.supports,
+							reasoning_effort: ['low', 'high'],
+						},
+					},
+				}),
+				'test-api-key',
+				'https://api.openai.com/v1/chat/completions');
+			const apply = (endpoint as unknown as { _applyReasoningEffort: (body: IEndpointBody, options: ICreateEndpointBodyOptions) => void })._applyReasoningEffort.bind(endpoint);
+
+			const body: IEndpointBody = { reasoning: { effort: 'medium', summary: 'auto' } };
+			apply(body, buildOptions());
+
+			expect(body).toEqual({ reasoning: { summary: 'auto' }, reasoning_effort: undefined });
+		});
+
+		it('scrubs an unsupported pre-populated top-level `reasoning_effort` on Chat Completions', () => {
+			const endpoint = instaService.createInstance(OpenAIEndpoint,
+				buildModel({
+					capabilities: {
+						...modelMetadata.capabilities,
+						supports: {
+							...modelMetadata.capabilities.supports,
+							reasoning_effort: ['low', 'high'],
+						},
+					},
+				}),
+				'test-api-key',
+				'https://api.openai.com/v1/chat/completions');
+			const apply = (endpoint as unknown as { _applyReasoningEffort: (body: IEndpointBody, options: ICreateEndpointBodyOptions) => void })._applyReasoningEffort.bind(endpoint);
+
+			const body: IEndpointBody = { reasoning_effort: 'medium' };
+			apply(body, buildOptions());
+
+			expect(body.reasoning_effort).toBeUndefined();
 		});
 	});
 });

--- a/extensions/copilot/src/extension/byok/vscode-node/abstractLanguageModelChatProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/abstractLanguageModelChatProvider.ts
@@ -12,8 +12,9 @@ import { IExperimentationService } from '../../../platform/telemetry/common/null
 import { IStringDictionary } from '../../../util/vs/base/common/collections';
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
 import { CopilotLanguageModelWrapper } from '../../conversation/vscode-node/languageModelAccess';
-import { BYOKAuthType, BYOKKnownModels, byokKnownModelsToAPIInfo, BYOKModelCapabilities, resolveModelInfo } from '../common/byokProvider';
+import { BYOKAuthType, BYOKKnownModels, BYOKModelCapabilities, resolveModelInfo } from '../common/byokProvider';
 import { OpenAIEndpoint } from '../node/openAIEndpoint';
+import { byokKnownModelsToAPIInfoWithEffort } from './byokModelInfo';
 import { IBYOKStorageService } from './byokStorageService';
 
 export interface LanguageModelChatConfiguration {
@@ -105,7 +106,7 @@ export abstract class AbstractOpenAICompatibleLMProvider<T extends LanguageModel
 		const modelsUrl = this.getModelsBaseUrl(configuration);
 		if (modelsUrl) {
 			const models = await this.getModelsFromEndpoint(modelsUrl, silent, apiKey);
-			return byokKnownModelsToAPIInfo(this._name, models).map(model => ({
+			return byokKnownModelsToAPIInfoWithEffort(this._name, models).map(model => ({
 				...model,
 				url: modelsUrl
 			}));

--- a/extensions/copilot/src/extension/byok/vscode-node/byokModelInfo.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/byokModelInfo.ts
@@ -3,30 +3,33 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { l10n, type LanguageModelChatInformation, type LanguageModelConfigurationSchema } from 'vscode';
-import { BYOKKnownModels, byokKnownModelsToAPIInfo } from '../common/byokProvider';
+import { BYOKKnownModels, BYOKModelCapabilities, byokKnownModelToAPIInfo } from '../common/byokProvider';
 
 /**
- * Wraps {@link byokKnownModelsToAPIInfo} and enriches each model entry with
+ * Wraps {@link byokKnownModelToAPIInfo} and enriches the model entry with
  * a localized configurationSchema for the "Thinking Effort" picker when the
  * model's capabilities include `supportsReasoningEffort`.
  */
-export function byokKnownModelsToAPIInfoWithEffort(providerName: string, knownModels: BYOKKnownModels | undefined): LanguageModelChatInformation[] {
-	const models = byokKnownModelsToAPIInfo(providerName, knownModels);
-	if (!knownModels) {
-		return models;
+export function byokKnownModelToAPIInfoWithEffort(providerName: string, id: string, capabilities: BYOKModelCapabilities): LanguageModelChatInformation {
+	const model = byokKnownModelToAPIInfo(providerName, id, capabilities);
+	const effortLevels = capabilities.supportsReasoningEffort;
+	if (!effortLevels || effortLevels.length === 0) {
+		return model;
 	}
+	return {
+		...model,
+		...buildEffortConfigurationSchema(effortLevels, model.family),
+	};
+}
 
-	return models.map(model => {
-		const capabilities = knownModels[model.id];
-		const effortLevels = capabilities?.supportsReasoningEffort;
-		if (!effortLevels || effortLevels.length === 0) {
-			return model;
-		}
-		return {
-			...model,
-			...buildEffortConfigurationSchema(effortLevels, model.family),
-		};
-	});
+/**
+ * Like {@link byokKnownModelToAPIInfoWithEffort} but for a map of known models.
+ */
+export function byokKnownModelsToAPIInfoWithEffort(providerName: string, knownModels: BYOKKnownModels | undefined): LanguageModelChatInformation[] {
+	if (!knownModels) {
+		return [];
+	}
+	return Object.entries(knownModels).map(([id, capabilities]) => byokKnownModelToAPIInfoWithEffort(providerName, id, capabilities));
 }
 
 function buildEffortConfigurationSchema(effortLevels: readonly string[], family: string): { configurationSchema?: LanguageModelConfigurationSchema } {
@@ -45,6 +48,7 @@ function buildEffortConfigurationSchema(effortLevels: readonly string[], family:
 					enumDescriptions: effortLevels.map(level => {
 						switch (level) {
 							case 'none': return l10n.t('No reasoning applied');
+							case 'minimal': return l10n.t('Minimal reasoning for fastest responses');
 							case 'low': return l10n.t('Faster responses with less reasoning');
 							case 'medium': return l10n.t('Balanced reasoning and speed');
 							case 'high': return l10n.t('Maximum reasoning depth');

--- a/extensions/copilot/src/extension/byok/vscode-node/customOAIProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/customOAIProvider.ts
@@ -11,9 +11,10 @@ import { IFetcherService } from '../../../platform/networking/common/fetcherServ
 import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
 import { IStringDictionary } from '../../../util/vs/base/common/collections';
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
-import { byokKnownModelToAPIInfo, resolveModelInfo } from '../common/byokProvider';
+import { resolveModelInfo } from '../common/byokProvider';
 import { OpenAIEndpoint } from '../node/openAIEndpoint';
 import { AbstractOpenAICompatibleLMProvider, LanguageModelChatConfiguration, OpenAICompatibleLanguageModelChatInformation } from './abstractLanguageModelChatProvider';
+import { byokKnownModelToAPIInfoWithEffort } from './byokModelInfo';
 import { IBYOKStorageService } from './byokStorageService';
 
 export function resolveCustomOAIUrl(modelId: string, url: string): string {
@@ -61,6 +62,8 @@ interface _CustomOAIModelConfig {
 	editTools?: EndpointEditToolName[];
 	requestHeaders?: Record<string, string>;
 	zeroDataRetentionEnabled?: boolean;
+	supportsReasoningEffort?: string[];
+	reasoningEffortFormat?: 'chat-completions' | 'responses';
 }
 
 export interface CustomOAIModelConfig extends _CustomOAIModelConfig {
@@ -121,7 +124,7 @@ export abstract class AbstractCustomOAIBYOKModelProvider extends AbstractOpenAIC
 		if (Array.isArray(configuration?.models)) {
 			for (const modelConfig of configuration.models) {
 				models.push({
-					...byokKnownModelToAPIInfo(this._name, modelConfig.id, modelConfig),
+					...byokKnownModelToAPIInfoWithEffort(this._name, modelConfig.id, modelConfig),
 					url: modelConfig.url
 				});
 			}
@@ -142,7 +145,9 @@ export abstract class AbstractCustomOAIBYOKModelProvider extends AbstractOpenAIC
 			thinking: modelConfiguration?.thinking ?? false,
 			streaming: modelConfiguration?.streaming,
 			requestHeaders: modelConfiguration?.requestHeaders,
-			zeroDataRetentionEnabled: modelConfiguration?.zeroDataRetentionEnabled
+			zeroDataRetentionEnabled: modelConfiguration?.zeroDataRetentionEnabled,
+			supportsReasoningEffort: modelConfiguration?.supportsReasoningEffort,
+			reasoningEffortFormat: modelConfiguration?.reasoningEffortFormat
 		};
 		const modelInfo = resolveModelInfo(model.id, this._name, undefined, modelCapabilities);
 		if (modelCapabilities?.url?.includes('/responses')) {

--- a/extensions/copilot/src/extension/byok/vscode-node/ollamaProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/ollamaProvider.ts
@@ -9,9 +9,10 @@ import { IFetcherService } from '../../../platform/networking/common/fetcherServ
 import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
 import { ErrorUtils } from '../../../util/common/errors';
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
-import { byokKnownModelsToAPIInfo, resolveModelInfo } from '../common/byokProvider';
+import { resolveModelInfo } from '../common/byokProvider';
 import { OpenAIEndpoint } from '../node/openAIEndpoint';
 import { AbstractOpenAICompatibleLMProvider, LanguageModelChatConfiguration, OpenAICompatibleLanguageModelChatInformation } from './abstractLanguageModelChatProvider';
+import { byokKnownModelsToAPIInfoWithEffort } from './byokModelInfo';
 import { IBYOKStorageService } from './byokStorageService';
 
 interface OllamaModelInfoAPIResponse {
@@ -119,7 +120,7 @@ export class OllamaLMProvider extends AbstractOpenAICompatibleLMProvider<OllamaC
 				};
 			}
 
-			return byokKnownModelsToAPIInfo(this._name, this._knownModels).map(model => ({
+			return byokKnownModelsToAPIInfoWithEffort(this._name, this._knownModels).map(model => ({
 				...model,
 				url: ollamaBaseUrl
 			}));

--- a/extensions/copilot/src/extension/byok/vscode-node/openRouterProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/openRouterProvider.ts
@@ -66,12 +66,20 @@ export class OpenRouterLMProvider extends AbstractOpenAICompatibleLMProvider {
 
 	protected override resolveModelCapabilities(modelData: unknown): BYOKModelCapabilities | undefined {
 		const openRouterModelData = modelData as OpenRouterModelData;
+		const supportedParameters = openRouterModelData.supported_parameters ?? [];
+		// OpenRouter reports reasoning support per model via `supported_parameters`. The unified `reasoning` parameter and
+		// the OpenAI-style `reasoning_effort` alias both indicate the model accepts an effort level.
+		// See https://openrouter.ai/docs/use-cases/reasoning-tokens
+		const supportsReasoningEffort = supportedParameters.includes('reasoning') || supportedParameters.includes('reasoning_effort')
+			? ['low', 'medium', 'high']
+			: undefined;
 		return {
 			name: openRouterModelData.name,
-			toolCalling: openRouterModelData.supported_parameters?.includes('tools') ?? false,
+			toolCalling: supportedParameters.includes('tools'),
 			vision: openRouterModelData.architecture?.input_modalities?.includes('image') ?? false,
 			maxInputTokens: openRouterModelData.top_provider.context_length - 16000,
-			maxOutputTokens: 16000
+			maxOutputTokens: 16000,
+			supportsReasoningEffort
 		};
 	}
 

--- a/extensions/copilot/src/extension/byok/vscode-node/test/byokModelInfo.spec.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/test/byokModelInfo.spec.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it } from 'vitest';
+import { BYOKModelCapabilities } from '../../common/byokProvider';
+import { byokKnownModelToAPIInfoWithEffort } from '../byokModelInfo';
+
+describe('byokKnownModelToAPIInfoWithEffort', () => {
+	const baseCapabilities: BYOKModelCapabilities = {
+		name: 'TestModel',
+		maxInputTokens: 1000,
+		maxOutputTokens: 100,
+		toolCalling: true,
+		vision: false,
+	};
+
+	it('omits the configurationSchema when the model does not declare reasoning effort levels', () => {
+		const info = byokKnownModelToAPIInfoWithEffort('TestProvider', 'm1', baseCapabilities);
+
+		expect((info as { configurationSchema?: unknown }).configurationSchema).toBeUndefined();
+	});
+
+	it('builds a Thinking Effort picker with non-Claude default `medium` for non-Claude families', () => {
+		const info = byokKnownModelToAPIInfoWithEffort('TestProvider', 'gpt-5', {
+			...baseCapabilities,
+			supportsReasoningEffort: ['minimal', 'low', 'medium', 'high'],
+		});
+
+		expect(info).toMatchObject({
+			id: 'gpt-5',
+			configurationSchema: {
+				properties: {
+					reasoningEffort: {
+						type: 'string',
+						enum: ['minimal', 'low', 'medium', 'high'],
+						default: 'medium',
+						group: 'navigation',
+					},
+				},
+			},
+		});
+	});
+
+	it('uses Claude-family default `high` when the family begins with `claude`', () => {
+		const info = byokKnownModelToAPIInfoWithEffort('TestProvider', 'claude-sonnet-4', {
+			...baseCapabilities,
+			supportsReasoningEffort: ['low', 'medium', 'high'],
+		});
+
+		expect((info as { configurationSchema?: { properties: { reasoningEffort: { default?: string } } } }).configurationSchema?.properties.reasoningEffort.default).toBe('high');
+	});
+
+	it('falls back to no default when the preferred level is not in the supported list', () => {
+		const info = byokKnownModelToAPIInfoWithEffort('TestProvider', 'grok-4', {
+			...baseCapabilities,
+			supportsReasoningEffort: ['low', 'high'],
+		});
+
+		expect((info as { configurationSchema?: { properties: { reasoningEffort: { default?: string } } } }).configurationSchema?.properties.reasoningEffort.default).toBeUndefined();
+	});
+});

--- a/extensions/copilot/src/extension/prompt/vscode-node/requestLoggerImpl.ts
+++ b/extensions/copilot/src/extension/prompt/vscode-node/requestLoggerImpl.ts
@@ -605,7 +605,7 @@ export class RequestLogger extends AbstractRequestLogger {
 		// Just some other options to track
 		// TODO Probably we should just extract every item on the body and format it as below, instead of doing this one-by-one
 		const otherOptions: Record<string, string | number | boolean> = {};
-		for (const opt of ['temperature', 'stream', 'store'] satisfies (keyof IEndpointBody)[]) {
+		for (const opt of ['temperature', 'stream', 'store', 'reasoning_effort'] satisfies (keyof IEndpointBody)[]) {
 			if (entry.chatParams.body?.[opt] !== undefined) {
 				otherOptions[opt] = entry.chatParams.body[opt];
 			}

--- a/extensions/copilot/src/platform/endpoint/common/endpointProvider.ts
+++ b/extensions/copilot/src/platform/endpoint/common/endpointProvider.ts
@@ -116,6 +116,12 @@ export type IChatModelInformation = IModelAPIResponse & {
 	urlOrRequestMetadata?: string | RequestMetadata;
 	requestHeaders?: Readonly<Record<string, string>>;
 	zeroDataRetentionEnabled?: boolean;
+	/**
+	 * BYOK-only override that forces the body shape used when forwarding the reasoning effort to the model.
+	 * Honored by `OpenAIEndpoint`. Unset — the body shape follows the API path (Responses API → nested `reasoning.effort`,
+	 * Chat Completions → top-level `reasoning_effort`).
+	 */
+	reasoningEffortFormat?: 'chat-completions' | 'responses';
 };
 
 export function isChatModelInformation(model: IModelAPIResponse): model is IChatModelInformation {

--- a/extensions/copilot/src/platform/networking/common/networking.ts
+++ b/extensions/copilot/src/platform/networking/common/networking.ts
@@ -84,6 +84,8 @@ export interface IEndpointBody {
 	snippy?: { enabled: boolean };
 	stream_options?: { include_usage?: boolean };
 	prompt?: string;
+	/** OpenAI Chat Completions API top-level reasoning effort (BYOK chat-completions shape). Mirrors the nested `reasoning.effort` used by the Responses API. */
+	reasoning_effort?: string;
 	/** Embeddings endpoints only: */
 	dimensions?: number;
 	embed?: boolean;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/262187

Adds first-class support for forwarding a model's reasoning effort to BYOK OpenAI-compatible endpoints (OpenAI, xAI, OpenRouter,  CustomOAI/Azure). When a BYOK model declares a list of supported effort levels, the model picker exposes a "Thinking Effort" control and the chosen value is normalized into the body shape the model's API expects.

Anthropic Messages API already had effort plumbing — this PR fills the gap for the Chat Completions and Responses code paths.

TODO: Gemini will be addressed in separate PR since it requires google sdk update.