### PR TITLE
Keep historical user messages cache-safe

### DIFF
--- a/extensions/copilot/src/extension/prompts/node/agent/agentConversationHistory.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/agentConversationHistory.tsx
@@ -13,6 +13,8 @@ import { EditedFileEvents, renderedMessageToTsxChildren } from './agentPrompt';
 
 export interface AgentUserMessageInHistoryProps extends BasePromptElementProps {
 	readonly turn: Turn;
+	/** Tag name used to wrap the user query (e.g., 'userRequest' or 'user_query'). Defaults to 'userRequest'. */
+	readonly userQueryTagName?: string;
 }
 
 export class AgentUserMessageInHistory extends PromptElement<AgentUserMessageInHistoryProps> {
@@ -30,7 +32,7 @@ export class AgentUserMessageInHistory extends PromptElement<AgentUserMessageInH
 				<Tag name='context'>
 					<EditedFileEvents flexGrow={2} editedFileEvents={turn.editedFileEvents} />
 				</Tag>}
-			<Tag name='userRequest'>{turn.request.message}</Tag>
+			<Tag name={this.props.userQueryTagName ?? 'userRequest'}>{turn.request.message}</Tag>
 		</UserMessage>;
 	}
 }
@@ -38,6 +40,7 @@ export class AgentUserMessageInHistory extends PromptElement<AgentUserMessageInH
 export interface AgentConversationHistoryProps extends BasePromptElementProps {
 	readonly priority: number;
 	readonly promptContext: IBuildPromptContext;
+	readonly userQueryTagName?: string;
 }
 
 /**
@@ -53,7 +56,7 @@ export class AgentConversationHistory extends PromptElement<AgentConversationHis
 			if (metadata?.renderedUserMessage) {
 				history.push(<UserMessage><Chunk>{renderedMessageToTsxChildren(metadata.renderedUserMessage, false)}</Chunk></UserMessage>);
 			} else {
-				history.push(<AgentUserMessageInHistory turn={turn} />);
+				history.push(<AgentUserMessageInHistory turn={turn} userQueryTagName={this.props.userQueryTagName} />);
 			}
 
 			if (Array.isArray(metadata?.toolCallRounds) && metadata.toolCallRounds?.length > 0) {

--- a/extensions/copilot/src/extension/prompts/node/agent/agentPrompt.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/agentPrompt.tsx
@@ -44,7 +44,7 @@ import { NotebookSummaryChange } from '../panel/notebookSummaryChangePrompt';
 import { UserPreferences } from '../panel/preferences';
 import { ChatToolCalls } from '../panel/toolCalling';
 import { AgentMultirootWorkspaceStructure } from '../panel/workspace/workspaceStructure';
-import { AgentConversationHistory } from './agentConversationHistory';
+import { AgentConversationHistory, AgentUserMessageInHistory } from './agentConversationHistory';
 import './allAgentPrompts';
 import { AlternateGPTPrompt, DefaultReminderInstructions, DefaultToolReferencesHint, ReminderInstructionsProps, ToolReferencesHintProps } from './defaultAgentInstructions';
 import { AgentPromptCustomizations, ReminderInstructionsConstructor, ToolReferencesHintConstructor } from './promptRegistry';
@@ -163,7 +163,7 @@ export class AgentPrompt extends PromptElement<AgentPromptProps> {
 		} else {
 			return <>
 				{baseInstructions}
-				<AgentConversationHistory flexGrow={1} priority={700} promptContext={this.props.promptContext} />
+				<AgentConversationHistory flexGrow={1} priority={700} promptContext={this.props.promptContext} userQueryTagName={userQueryTagName} />
 				<AgentUserMessage flexGrow={2} priority={900} {...getUserMessagePropsFromAgentProps(this.props, { userQueryTagName, ReminderInstructionsClass, ToolReferencesHintClass })} />
 				<ChatToolCalls priority={899} flexGrow={2} promptContext={this.props.promptContext} toolCallRounds={this.props.promptContext.toolCallRounds} toolCallResults={this.props.promptContext.toolCallResults} truncateAt={maxToolResultLength} enableCacheBreakpoints={false} />
 			</>;
@@ -369,8 +369,17 @@ export class AgentUserMessage extends PromptElement<AgentUserMessageProps> {
 			return <FrozenContentUserMessage frozenContent={frozenContent} enableCacheBreakpoints={this.props.enableCacheBreakpoints} />;
 		}
 
-		if (this.props.isHistorical) {
-			this.logService.trace('Re-rendering historical user message');
+		// Historical turn without frozen content — this can happen when a session was
+		// persisted before RenderedUserMessageMetadata existed, when the freeze in
+		// agentIntent.runOne didn't fire (e.g. last message wasn't User), or after a
+		// re-render path that bypasses the freeze. Re-rendering the live user message
+		// body here would embed current workspace state (<editorContext>, terminal
+		// state, todos, reminders) into a *historical* user message and break the
+		// prompt cache for every preceding turn. Render the same minimal,
+		// cache-stable body that AgentUserMessageInHistory uses instead.
+		if (this.props.isHistorical && this.props.turn) {
+			this.logService.trace('Re-rendering historical user message without frozen content; using minimal body');
+			return <AgentUserMessageInHistory turn={this.props.turn} userQueryTagName={this.props.userQueryTagName} />;
 		}
 
 		// System-initiated messages (e.g. terminal completion notifications) are

--- a/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-haiku-4.5/cache_BPs_multi_round.spec.snap
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-haiku-4.5/cache_BPs_multi_round.spec.snap
@@ -152,13 +152,6 @@ I am working in a workspace with the following folders:
 
 ### User
 ~~~md
-<context>
-(Date removed from snapshot)
-</context>
-<reminderInstructions>
-Do NOT create a new markdown file to document each change or summarize your work unless specifically requested by the user.
-
-</reminderInstructions>
 <userRequest>
 previous turn
 </userRequest>

--- a/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-opus-4.5/cache_BPs_multi_round.spec.snap
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-opus-4.5/cache_BPs_multi_round.spec.snap
@@ -152,15 +152,6 @@ I am working in a workspace with the following folders:
 
 ### User
 ~~~md
-<context>
-(Date removed from snapshot)
-</context>
-<reminderInstructions>
-Do NOT create a new markdown file to document each change or summarize your work unless specifically requested by the user.
-
-IMPORTANT: Before calling any deferred tool that was not previously returned by tool_search, you MUST first use tool_search to load it. Calling a deferred tool without first loading it will fail. Tools returned by tool_search are automatically expanded and immediately available - do not search for them again.
-
-</reminderInstructions>
 <userRequest>
 previous turn
 </userRequest>

--- a/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-opus-4.6/cache_BPs_multi_round.spec.snap
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-opus-4.6/cache_BPs_multi_round.spec.snap
@@ -139,13 +139,6 @@ I am working in a workspace with the following folders:
 
 ### User
 ~~~md
-<context>
-(Date removed from snapshot)
-</context>
-<reminderInstructions>
-Do NOT create markdown files to document changes unless requested.
-
-</reminderInstructions>
 <userRequest>
 previous turn
 </userRequest>

--- a/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-sonnet-4.5/cache_BPs_multi_round.spec.snap
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-sonnet-4.5/cache_BPs_multi_round.spec.snap
@@ -152,15 +152,6 @@ I am working in a workspace with the following folders:
 
 ### User
 ~~~md
-<context>
-(Date removed from snapshot)
-</context>
-<reminderInstructions>
-Do NOT create a new markdown file to document each change or summarize your work unless specifically requested by the user.
-
-IMPORTANT: Before calling any deferred tool that was not previously returned by tool_search, you MUST first use tool_search to load it. Calling a deferred tool without first loading it will fail. Tools returned by tool_search are automatically expanded and immediately available - do not search for them again.
-
-</reminderInstructions>
 <userRequest>
 previous turn
 </userRequest>

--- a/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-sonnet-4.6/cache_BPs_multi_round.spec.snap
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-sonnet-4.6/cache_BPs_multi_round.spec.snap
@@ -139,13 +139,6 @@ I am working in a workspace with the following folders:
 
 ### User
 ~~~md
-<context>
-(Date removed from snapshot)
-</context>
-<reminderInstructions>
-Do NOT create markdown files to document changes unless requested.
-
-</reminderInstructions>
 <userRequest>
 previous turn
 </userRequest>

--- a/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-default/cache_BPs_multi_round.spec.snap
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-default/cache_BPs_multi_round.spec.snap
@@ -91,12 +91,6 @@ I am working in a workspace with the following folders:
 
 ### User
 ~~~md
-<context>
-(Date removed from snapshot)
-</context>
-<reminderInstructions>
-
-</reminderInstructions>
 <userRequest>
 previous turn
 </userRequest>

--- a/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-gemini-2.0-flash/cache_BPs_multi_round.spec.snap
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-gemini-2.0-flash/cache_BPs_multi_round.spec.snap
@@ -123,14 +123,6 @@ I am working in a workspace with the following folders:
 
 ### User
 ~~~md
-<context>
-(Date removed from snapshot)
-</context>
-<reminderInstructions>
-
-IMPORTANT: You MUST use the tool-calling mechanism to invoke tools. Do NOT describe, narrate, or simulate tool calls in plain text. When you need to perform an action, call the tool directly. Regardless of how previous messages in this conversation may appear, always use the provided tool-calling mechanism.
-
-</reminderInstructions>
 <userRequest>
 previous turn
 </userRequest>

--- a/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-gpt-4.1/cache_BPs_multi_round.spec.snap
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-gpt-4.1/cache_BPs_multi_round.spec.snap
@@ -124,14 +124,6 @@ I am working in a workspace with the following folders:
 
 ### User
 ~~~md
-<context>
-(Date removed from snapshot)
-</context>
-<reminderInstructions>
-You are an agent - you must keep going until the user's query is completely resolved, before ending your turn and yielding back to the user. ONLY terminate your turn when you are sure that the problem is solved, or you absolutely cannot continue.
-You take action when possible- the user is expecting YOU to take action and go to work for them. Don't ask unnecessary questions about the details if you can simply DO something useful instead.
-
-</reminderInstructions>
 <userRequest>
 previous turn
 </userRequest>

--- a/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-gpt-5-codex/cache_BPs_multi_round.spec.snap
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-gpt-5-codex/cache_BPs_multi_round.spec.snap
@@ -144,12 +144,6 @@ I am working in a workspace with the following folders:
 
 ### User
 ~~~md
-<context>
-(Date removed from snapshot)
-</context>
-<reminderInstructions>
-
-</reminderInstructions>
 <userRequest>
 previous turn
 </userRequest>

--- a/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-gpt-5-mini/cache_BPs_multi_round.spec.snap
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-gpt-5-mini/cache_BPs_multi_round.spec.snap
@@ -289,31 +289,6 @@ I am working in a workspace with the following folders:
 
 ### User
 ~~~md
-<context>
-(Date removed from snapshot)
-</context>
-<reminderInstructions>
-You are an agent—keep going until the user's query is completely resolved before ending your turn. ONLY stop if solved or genuinely blocked.
-Take action when possible; the user expects you to do useful work without unnecessary questions.
-After any parallel, read-only context gathering, give a concise progress update and what's next.
-Avoid repetition across turns: don't restate unchanged plans or sections (like the todo list) verbatim; provide delta updates or only the parts that changed.
-Tool batches: You MUST preface each batch with a one-sentence why/what/outcome preamble.
-Progress cadence: After 3 to 5 tool calls, or when you create/edit > ~3 files in a burst, report progress.
-Requirements coverage: Read the user's ask in full and think carefully. Do not omit a requirement. If something cannot be done with available tools, note why briefly and propose a viable alternative.
-Skip filler acknowledgements like "Sounds good" or "Okay, I will…". Open with a purposeful one-liner about what you're doing next.
-When sharing setup or run steps, present terminal commands in fenced code blocks with the correct language tag. Keep commands copyable and on separate lines.
-Avoid definitive claims about the build or runtime setup unless verified from the provided context (or quick tool checks). If uncertain, state what's known from attachments and proceed with minimal steps you can adapt later.
-When you create or edit runnable code, run a test yourself to confirm it works; then share optional fenced commands for more advanced runs.
-For non-trivial code generation, produce a complete, runnable solution: necessary source files, a tiny runner or test/benchmark harness, a minimal `README.md`, and updated dependency manifests (e.g., `package.json`, `requirements.txt`, `pyproject.toml`). Offer quick "try it" commands and optional platform-specific speed-ups when relevant.
-Your goal is to act like a pair programmer: be friendly and helpful. If you can do more, do more. Be proactive with your solutions, think about what the user needs and what they want, and implement it proactively.
-<importantReminders>
-Do NOT volunteer your model name unless the user explicitly asks you about it. 
-Break down the request into clear, actionable steps and present them at the beginning of your response before proceeding with implementation. This helps maintain visibility and ensures all requirements are addressed systematically.
-When referring to a filename or symbol in the user's workspace, wrap it in backticks.
-
-</importantReminders>
-
-</reminderInstructions>
 <userRequest>
 previous turn
 </userRequest>

--- a/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-gpt-5.1-codex-mini/cache_BPs_multi_round.spec.snap
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-gpt-5.1-codex-mini/cache_BPs_multi_round.spec.snap
@@ -177,12 +177,6 @@ I am working in a workspace with the following folders:
 
 ### User
 ~~~md
-<context>
-(Date removed from snapshot)
-</context>
-<reminderInstructions>
-
-</reminderInstructions>
 <userRequest>
 previous turn
 </userRequest>

--- a/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-gpt-5.1-codex/cache_BPs_multi_round.spec.snap
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-gpt-5.1-codex/cache_BPs_multi_round.spec.snap
@@ -177,12 +177,6 @@ I am working in a workspace with the following folders:
 
 ### User
 ~~~md
-<context>
-(Date removed from snapshot)
-</context>
-<reminderInstructions>
-
-</reminderInstructions>
 <userRequest>
 previous turn
 </userRequest>

--- a/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-gpt-5.1/cache_BPs_multi_round.spec.snap
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-gpt-5.1/cache_BPs_multi_round.spec.snap
@@ -323,19 +323,6 @@ I am working in a workspace with the following folders:
 
 ### User
 ~~~md
-<context>
-(Date removed from snapshot)
-</context>
-<reminderInstructions>
-You are an agent—keep going until the user's query is completely resolved before ending your turn. ONLY stop if solved or genuinely blocked.
-Take action when possible; the user expects you to do useful work without unnecessary questions.
-After any parallel, read-only context gathering, give a concise progress update and what's next.
-Avoid repetition across turns: don't restate unchanged plans or sections (like the todo list) verbatim; provide delta updates or only the parts that changed.
-Tool batches: You MUST preface each batch with a one-sentence why/what/outcome preamble.
-Progress cadence: After 3 to 5 tool calls, or when you create/edit > ~3 files in a burst, report progress.
-Requirements coverage: Read the user's ask in full and think carefully. Do not omit a requirement. If something cannot be done with available tools, note why briefly and propose a viable alternative.
-
-</reminderInstructions>
 <userRequest>
 previous turn
 </userRequest>

--- a/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-gpt-5/cache_BPs_multi_round.spec.snap
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-gpt-5/cache_BPs_multi_round.spec.snap
@@ -289,32 +289,6 @@ I am working in a workspace with the following folders:
 
 ### User
 ~~~md
-<context>
-(Date removed from snapshot)
-</context>
-<reminderInstructions>
-You are an agent—keep going until the user's query is completely resolved before ending your turn. ONLY stop if solved or genuinely blocked.
-Take action when possible; the user expects you to do useful work without unnecessary questions.
-After any parallel, read-only context gathering, give a concise progress update and what's next.
-Avoid repetition across turns: don't restate unchanged plans or sections (like the todo list) verbatim; provide delta updates or only the parts that changed.
-Tool batches: You MUST preface each batch with a one-sentence why/what/outcome preamble.
-Progress cadence: After 3 to 5 tool calls, or when you create/edit > ~3 files in a burst, report progress.
-Requirements coverage: Read the user's ask in full and think carefully. Do not omit a requirement. If something cannot be done with available tools, note why briefly and propose a viable alternative.
-Skip filler acknowledgements like "Sounds good" or "Okay, I will…". Open with a purposeful one-liner about what you're doing next.
-When sharing setup or run steps, present terminal commands in fenced code blocks with the correct language tag. Keep commands copyable and on separate lines.
-Avoid definitive claims about the build or runtime setup unless verified from the provided context (or quick tool checks). If uncertain, state what's known from attachments and proceed with minimal steps you can adapt later.
-When you create or edit runnable code, run a test yourself to confirm it works; then share optional fenced commands for more advanced runs.
-For non-trivial code generation, produce a complete, runnable solution: necessary source files, a tiny runner or test/benchmark harness, a minimal `README.md`, and updated dependency manifests (e.g., `package.json`, `requirements.txt`, `pyproject.toml`). Offer quick "try it" commands and optional platform-specific speed-ups when relevant.
-Your goal is to act like a pair programmer: be friendly and helpful. If you can do more, do more. Be proactive with your solutions, think about what the user needs and what they want, and implement it proactively.
-<importantReminders>
-Start your response with a brief acknowledgement, followed by a concise high-level plan outlining your approach.
-Do NOT volunteer your model name unless the user explicitly asks you about it. 
-Break down the request into clear, actionable steps and present them at the beginning of your response before proceeding with implementation. This helps maintain visibility and ensures all requirements are addressed systematically.
-When referring to a filename or symbol in the user's workspace, wrap it in backticks.
-
-</importantReminders>
-
-</reminderInstructions>
 <userRequest>
 previous turn
 </userRequest>

--- a/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-grok-code-fast-1/cache_BPs_multi_round.spec.snap
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-grok-code-fast-1/cache_BPs_multi_round.spec.snap
@@ -129,12 +129,6 @@ I am working in a workspace with the following folders:
 
 ### User
 ~~~md
-<context>
-(Date removed from snapshot)
-</context>
-<reminderInstructions>
-
-</reminderInstructions>
 <user_query>
 previous turn
 </user_query>

--- a/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/summarization-previousTurnNoRounds-Agent.spec.snap
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/summarization-previousTurnNoRounds-Agent.spec.snap
@@ -15,12 +15,6 @@ I am working in a workspace with the following folders:
 
 ### User
 ~~~md
-<context>
-(Date removed from snapshot)
-</context>
-<reminderInstructions>
-
-</reminderInstructions>
 <userRequest>
 previous turn 1
 </userRequest>
@@ -36,12 +30,6 @@ response
 
 ### User
 ~~~md
-<context>
-(Date removed from snapshot)
-</context>
-<reminderInstructions>
-
-</reminderInstructions>
 <userRequest>
 previous turn 2
 </userRequest>

--- a/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/summarization-previousTurnNoRounds-FullSumm.spec.snap
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/summarization-previousTurnNoRounds-FullSumm.spec.snap
@@ -1,11 +1,5 @@
 ### User
 ~~~md
-<context>
-(Date removed from snapshot)
-</context>
-<reminderInstructions>
-
-</reminderInstructions>
 <userRequest>
 previous turn 1
 </userRequest>
@@ -23,12 +17,6 @@ response
 
 ### User
 ~~~md
-<context>
-(Date removed from snapshot)
-</context>
-<reminderInstructions>
-
-</reminderInstructions>
 <userRequest>
 previous turn 2
 </userRequest>


### PR DESCRIPTION
Fixes a prompt-cache invalidation where historical user messages could be re-rendered with live workspace state (`<editorContext>`, terminal, todos, reminderInstructions), breaking the cache prefix on every request.

<img width="1686" height="2050" alt="image" src="https://github.com/user-attachments/assets/0481b3cb-a68a-4ab6-a8b8-dcad9f1d0c74" />

Snapshot updates verify: historical-turn user messages no longer carry live `<context>` / `<reminderInstructions>` blocks; current-turn rendering is unchanged.