### PR TITLE
Harden snippet session against null decorations and selection/placeholder cardinality drift

### DIFF
--- a/src/vs/editor/contrib/snippet/browser/snippetSession.ts
+++ b/src/vs/editor/contrib/snippet/browser/snippetSession.ts
@@ -97,6 +97,8 @@ export class OneSnippet {
 
 		this._initDecorations();
 
+		const model = this._editor.getModel();
+
 		// Transform placeholder text if necessary
 		if (this._placeholderGroupsIdx >= 0) {
 			const operations: ISingleEditOperation[] = [];
@@ -104,20 +106,23 @@ export class OneSnippet {
 			for (const placeholder of this._placeholderGroups[this._placeholderGroupsIdx]) {
 				// Check if the placeholder has a transformation
 				if (placeholder.transform) {
-					const id = this._placeholderDecorations!.get(placeholder)!;
-					const range = this._editor.getModel().getDecorationRange(id)!;
-					const currentValue = this._editor.getModel().getValueInRange(range);
-					const transformedValueLines = placeholder.transform.resolve(currentValue).split(/\r\n|\r|\n/);
-					// fix indentation for transformed lines
-					for (let i = 1; i < transformedValueLines.length; i++) {
-						transformedValueLines[i] = this._editor.getModel().normalizeIndentation(this._snippetLineLeadingWhitespace + transformedValueLines[i]);
+					const id = this._placeholderDecorations!.get(placeholder);
+					const range = id ? model.getDecorationRange(id) : null;
+					if (range) {
+						const currentValue = model.getValueInRange(range);
+						const transformedValueLines = placeholder.transform.resolve(currentValue).split(/\r\n|\r|\n/);
+						// fix indentation for transformed lines
+						for (let i = 1; i < transformedValueLines.length; i++) {
+							transformedValueLines[i] = model.normalizeIndentation(this._snippetLineLeadingWhitespace + transformedValueLines[i]);
+						}
+						operations.push(EditOperation.replace(range, transformedValueLines.join(model.getEOL())));
 					}
-					operations.push(EditOperation.replace(range, transformedValueLines.join(this._editor.getModel().getEOL())));
 				}
 			}
 			if (operations.length > 0) {
 				this._editor.executeEdits('snippet.placeholderTransform', operations);
 			}
+
 		}
 
 		let couldSkipThisPlaceholder = false;
@@ -134,7 +139,7 @@ export class OneSnippet {
 			// not acurate any more -> simply restore it
 		}
 
-		const newSelections = this._editor.getModel().changeDecorations(accessor => {
+		const newSelections = model.changeDecorations(accessor => {
 
 			const activePlaceholders = new Set<Placeholder>();
 
@@ -145,22 +150,28 @@ export class OneSnippet {
 			// Special case #2: placeholders enclosing active placeholders
 			const selections: Selection[] = [];
 			for (const placeholder of this._placeholderGroups[this._placeholderGroupsIdx]) {
-				const id = this._placeholderDecorations!.get(placeholder)!;
-				const range = this._editor.getModel().getDecorationRange(id)!;
-				selections.push(new Selection(range.startLineNumber, range.startColumn, range.endLineNumber, range.endColumn));
+				const id = this._placeholderDecorations!.get(placeholder);
+				const range = id ? model.getDecorationRange(id) : null;
 
 				// consider to skip this placeholder index when the decoration
 				// range is empty but when the placeholder wasn't. that's a strong
 				// hint that the placeholder has been deleted. (all placeholder must match this)
 				couldSkipThisPlaceholder = couldSkipThisPlaceholder && this._hasPlaceholderBeenCollapsed(placeholder);
 
+				if (!id || !range) {
+					continue;
+				}
+				selections.push(new Selection(range.startLineNumber, range.startColumn, range.endLineNumber, range.endColumn));
+
 				accessor.changeDecorationOptions(id, placeholder.isFinalTabstop ? OneSnippet._decor.activeFinal : OneSnippet._decor.active);
 				activePlaceholders.add(placeholder);
 
 				for (const enclosingPlaceholder of this._snippet.enclosingPlaceholders(placeholder)) {
-					const id = this._placeholderDecorations!.get(enclosingPlaceholder)!;
-					accessor.changeDecorationOptions(id, enclosingPlaceholder.isFinalTabstop ? OneSnippet._decor.activeFinal : OneSnippet._decor.active);
-					activePlaceholders.add(enclosingPlaceholder);
+					const id = this._placeholderDecorations!.get(enclosingPlaceholder);
+					if (id) {
+						accessor.changeDecorationOptions(id, enclosingPlaceholder.isFinalTabstop ? OneSnippet._decor.activeFinal : OneSnippet._decor.active);
+						activePlaceholders.add(enclosingPlaceholder);
+					}
 				}
 			}
 
@@ -182,12 +193,13 @@ export class OneSnippet {
 		// A placeholder is empty when it wasn't empty when authored but
 		// when its tracking decoration is empty. This also applies to all
 		// potential parent placeholders
+		const model = this._editor.getModel();
 		let marker: Marker | undefined = placeholder;
 		while (marker) {
 			if (marker instanceof Placeholder) {
-				const id = this._placeholderDecorations!.get(marker)!;
-				const range = this._editor.getModel().getDecorationRange(id)!;
-				if (range.isEmpty() && marker.toString().length > 0) {
+				const id = this._placeholderDecorations!.get(marker);
+				const range = id ? model.getDecorationRange(id) : null;
+				if ((!range || range.isEmpty()) && marker.toString().length > 0) {
 					return true;
 				}
 			}
@@ -285,6 +297,10 @@ export class OneSnippet {
 			return !result;
 		});
 		return result;
+	}
+
+	get activePlaceholderCount(): number {
+		return this._placeholderGroupsIdx < 0 ? 0 : this._placeholderGroups[this._placeholderGroupsIdx].length;
 	}
 
 	merge(others: OneSnippet[]): void {
@@ -676,14 +692,18 @@ export class SnippetSession {
 			// are just text insertions and we don't need to merge the nested snippet into the existing
 			// snippet
 			const isTrivialSnippet = snippets[0].isTrivialSnippet;
-			if (!isTrivialSnippet) {
+			// Only merge when each active placeholder occurrence has a matching nested snippet.
+			// Cursor normalization or external selection changes can collapse selections, leaving
+			// fewer nested snippets than placeholder occurrences and previously crashing the merge.
+			const canMergeSnippets = snippets.length === this._snippets.reduce((count, snippet) => count + snippet.activePlaceholderCount, 0);
+			if (!isTrivialSnippet && canMergeSnippets) {
 				for (const snippet of this._snippets) {
 					snippet.merge(snippets);
 				}
 				console.assert(snippets.length === 0);
 			}
 
-			if (this._snippets[0].hasPlaceholder && !isTrivialSnippet) {
+			if (this._snippets[0].hasPlaceholder && !isTrivialSnippet && canMergeSnippets) {
 				return this._move(undefined);
 			} else {
 				return undoEdits.map(edit => Selection.fromPositions(edit.range.getEndPosition()));
@@ -693,14 +713,18 @@ export class SnippetSession {
 
 	next(): void {
 		const newSelections = this._move(true);
-		this._editor.setSelections(newSelections);
-		this._editor.revealPositionInCenterIfOutsideViewport(newSelections[0].getPosition());
+		if (newSelections.length > 0) {
+			this._editor.setSelections(newSelections);
+			this._editor.revealPositionInCenterIfOutsideViewport(newSelections[0].getPosition());
+		}
 	}
 
 	prev(): void {
 		const newSelections = this._move(false);
-		this._editor.setSelections(newSelections);
-		this._editor.revealPositionInCenterIfOutsideViewport(newSelections[0].getPosition());
+		if (newSelections.length > 0) {
+			this._editor.setSelections(newSelections);
+			this._editor.revealPositionInCenterIfOutsideViewport(newSelections[0].getPosition());
+		}
 	}
 
 	private _move(fwd: boolean | undefined): Selection[] {

--- a/src/vs/editor/contrib/snippet/test/browser/snippetSession.test.ts
+++ b/src/vs/editor/contrib/snippet/test/browser/snippetSession.test.ts
@@ -469,6 +469,37 @@ suite('SnippetSession', function () {
 		assertSelections(editor, new Selection(1, 6, 1, 25));
 	});
 
+	test('snippets, next does not throw when placeholder decorations are missing', function () {
+		editor.getModel().setValue('');
+		editor.setSelection(new Selection(1, 1, 1, 1));
+
+		const session = new SnippetSession(editor, '${1:foo}$0', undefined, languageConfigurationService);
+		session.insert();
+
+		const decorationIds = editor.getModel().getAllDecorations().map(decoration => decoration.id);
+		assert.ok(decorationIds.length > 0);
+		editor.getModel().changeDecorations(accessor => {
+			for (const decorationId of decorationIds) {
+				accessor.removeDecoration(decorationId);
+			}
+		});
+
+		assert.doesNotThrow(() => session.next());
+	});
+
+	test('snippets, merge does not throw when placeholder occurrences collapse to same position', function () {
+		// $1$1 places two zero-width occurrences of the same placeholder at the same position;
+		// the editor's cursor normalization collapses these into one selection. Previously this
+		// caused merge() to crash because there were more placeholder occurrences than nested snippets.
+		editor.getModel().setValue('');
+		editor.setSelection(new Selection(1, 1, 1, 1));
+		const session = new SnippetSession(editor, '$1$1$0', undefined, languageConfigurationService);
+		session.insert();
+
+		assert.doesNotThrow(() => session.merge('${1:nested}$0'));
+		assert.strictEqual(editor.getModel().getValue(), 'nested');
+	});
+
 	test('snippets, transform', function () {
 		editor.getModel()!.setValue('');
 		editor.setSelection(new Selection(1, 1, 1, 1));


### PR DESCRIPTION
Reconciles four telemetry-reported snippet crashes into a single set of defensive guards in `OneSnippet` / `SnippetSession`. The underlying root cause for some of these is broader (lack of editor transactions / re-entrant model edits during `changeDecorations`), which is out of scope here — this change just protects the snippet code without hiding errors or hacking around the model.

Closes #233164
Closes #233163
Closes #196664
Closes #193172

## Changes

**`OneSnippet.move()`**
- Capture `_editor.getModel()` into a local `model` once (instead of repeated `this._editor.getModel()` calls).
- Null-guard `_placeholderDecorations.get(...)` and `model.getDecorationRange(id)` in:
  - the placeholder transform path,
  - the active-placeholder selection path,
  - the enclosing-placeholder loop.
- A missing decoration is silently skipped instead of dereferencing `null`/`undefined`.

**`OneSnippet._hasPlaceholderBeenCollapsed()`**
- Capture `model` into a local.
- Treat a missing decoration range on a non-empty placeholder as collapsed (matches the original `range.isEmpty() && marker.toString().length > 0` semantics, but tolerant of `null`).

**`SnippetSession.merge()`**
- Add `OneSnippet.activePlaceholderCount` getter.
- Add a cardinality precondition: only run structural merge and follow-on `_move(undefined)` when `snippets.length === sum(activePlaceholderCount)`. When cursor normalization or external selection changes collapse mirrored placeholder selections (e.g. `$1$1` at the same position), we now skip the structural merge instead of crashing on `others.shift()` returning `undefined`. Text edits still apply.

**`SnippetSession.next()` / `prev()`**
- No-op when `_move()` returns no selections, instead of crashing on `newSelections[0]`.

## Tests

Added two regression tests in `snippetSession.test.ts`:

- `'snippets, next does not throw when placeholder decorations are missing'` — covers the null-decoration crashes (#233164, #196664). Inserts a snippet, removes its decorations, calls `session.next()` and asserts it doesn't throw.
- `'snippets, merge does not throw when placeholder occurrences collapse to same position'` — covers the merge-collapse crashes (#233163, #193172). Inserts `$1$1$0` (cursor normalization collapses two empty placeholder cursors into one), then calls `session.merge('${1:nested}$0')` and asserts it doesn't throw with correct document content afterward.

All 40 tests in `snippetSession.test.ts` and the surrounding 38 in the snippet test directory pass.

## Manual repro (merge-collapse class)

User snippets:
```json
{
  "test": { "prefix": "test", "body": "$1$1$0" },
  "nest": { "prefix": "nest", "body": "${1:nested}$0" }
}
```

1. Type `test`, accept the suggestion. Buffer is empty, one cursor at column 1 (the two `$1` cursors collapsed via normalization).
2. Without leaving the snippet session, type `nest` and accept the second snippet from the suggestion list.

**Pre-fix:** `TypeError: Cannot read properties of undefined (reading '_offset')` logged to the Window output channel; buffer/navigation left in inconsistent state.

**Post-fix:** No crash. Text edit is applied; structural merge is skipped because the cardinality precondition fails.

The null-decoration class (#233164, #196664) is the result of re-entrant model edits during snippet navigation (e.g. format-on-type / extension edits firing inside `changeDecorations`) and is not reliably hand-reproducible. Coverage is via the unit test.

## Notes on rejected approaches

- An earlier draft (#315148) handled the merge-collapse case by deleting the excess placeholder decoration and calling `_snippet.replace(placeholder, [])` mid-loop. That mutates the snippet model during merge — exactly the kind of hack we want to avoid. The cardinality precondition fixes the same crash without touching the snippet model mid-merge.
- An earlier draft (#315153) added a "fall back to current editor selections" path inside `move()` when no valid snippet selection could be produced. That hides errors rather than just preventing the crash; replaced with the simpler "no selections → no-op" guard in `next()` / `prev()`.
