### PR TITLE
Allow more extensions to be enabled in the sessions window

### DIFF
--- a/src/vs/workbench/services/extensionManagement/browser/extensionEnablementService.ts
+++ b/src/vs/workbench/services/extensionManagement/browser/extensionEnablementService.ts
@@ -34,6 +34,7 @@ import { Delayer } from '../../../../base/common/async.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
 import { isWeb } from '../../../../base/common/platform.js';
 import { ChatEntitlementService, IChatEntitlementService } from '../../chat/common/chatEntitlementService.js';
+import { SESSIONS_WINDOW_ALLOWED_EXTENSIONS } from './sessionsWindowAllowedExtensions.js';
 
 const SOURCE = 'IWorkbenchExtensionEnablementService';
 
@@ -635,6 +636,11 @@ export class ExtensionEnablementService extends Disposable implements IWorkbench
 
 	private _isDisabledBySessionsWindow(extension: IExtension): boolean {
 		if (!this.environmentService.isSessionsWindow) {
+			return false;
+		}
+
+		// Allow-listed extensions are always enabled in the sessions window.
+		if (SESSIONS_WINDOW_ALLOWED_EXTENSIONS.has(extension.identifier.id.toLowerCase())) {
 			return false;
 		}
 

--- a/src/vs/workbench/services/extensionManagement/browser/sessionsWindowAllowedExtensions.ts
+++ b/src/vs/workbench/services/extensionManagement/browser/sessionsWindowAllowedExtensions.ts
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * List of extension ids (lowercased) that are allowed to run in the sessions window
+ * even if they would otherwise be disabled by the sessions window environment check.
+ */
+export const SESSIONS_WINDOW_ALLOWED_EXTENSIONS: ReadonlySet<string> = new Set<string>([
+	'pkief.material-icon-theme',
+	'zhuangtongfa.material-theme',
+	'vscode-icons-team.vscode-icons',
+	'oderwat.indent-rainbow',
+	'formulahendry.auto-close-tag',
+	'pranaygp.vscode-css-peek',
+	'codezombiech.gitignore',
+	'usernamehw.errorlens',
+	'wayou.vscode-todo-highlight',
+	'bierner.markdown-mermaid',
+	'kisstkondoros.vscode-gutter-preview',
+	'tomoki1207.pdf',
+].map(id => id.toLowerCase()));


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce a set of allowed extensions that can run in the sessions window, overriding the default environment checks.

