### PR TITLE
Enable agents window in stable

### DIFF
--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -1337,7 +1337,7 @@ export class CodeApplication extends Disposable {
 		const args = this.environmentMainService.args;
 
 		// Handle agents window first based on context
-		if ((args['agents'] && this.productService.quality !== 'stable')) {
+		if (args['agents']) {
 			return windowsMainService.openAgentsWindow({
 				context,
 				cli: args,
@@ -1345,9 +1345,7 @@ export class CodeApplication extends Disposable {
 			});
 		}
 
-		const agentsLastRunning = this.productService.quality !== 'stable'
-			? await tryConsumeAgentsLastRunningMarker(this.environmentMainService.userRoamingDataHome, this.fileService, this.logService)
-			: undefined;
+		const agentsLastRunning = await tryConsumeAgentsLastRunningMarker(this.environmentMainService.userRoamingDataHome, this.fileService, this.logService);
 		if (agentsLastRunning?.agentsRunning) {
 			const agentsWindows = await windowsMainService.openAgentsWindow({
 				context,

--- a/src/vs/platform/launch/electron-main/launchMainService.ts
+++ b/src/vs/platform/launch/electron-main/launchMainService.ts
@@ -18,7 +18,6 @@ import { ICodeWindow } from '../../window/electron-main/window.js';
 import { IWindowSettings } from '../../window/common/window.js';
 import { IOpenConfiguration, IWindowsMainService, OpenContext } from '../../windows/electron-main/windows.js';
 import { IProtocolUrl } from '../../url/electron-main/url.js';
-import { IProductService } from '../../product/common/productService.js';
 
 export const ID = 'launchMainService';
 export const ILaunchMainService = createDecorator<ILaunchMainService>(ID);
@@ -46,7 +45,6 @@ export class LaunchMainService implements ILaunchMainService {
 		@IWindowsMainService private readonly windowsMainService: IWindowsMainService,
 		@IURLService private readonly urlService: IURLService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
-		@IProductService private readonly productService: IProductService,
 	) { }
 
 	async start(args: NativeParsedArgs, userEnv: IProcessEnvironment): Promise<void> {
@@ -146,7 +144,7 @@ export class LaunchMainService implements ILaunchMainService {
 		}
 
 		// Agents window
-		else if (args['agents'] && this.productService.quality !== 'stable') {
+		else if (args['agents']) {
 			usedWindows = await this.windowsMainService.openAgentsWindow(baseConfig);
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsBanner.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsBanner.ts
@@ -7,7 +7,6 @@ import { $, addDisposableListener } from '../../../../../base/browser/dom.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { localize } from '../../../../../nls.js';
 import { ICommandService, CommandsRegistry } from '../../../../../platform/commands/common/commands.js';
-import { IProductService } from '../../../../../platform/product/common/productService.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { IChatEntitlementService } from '../../../../services/chat/common/chatEntitlementService.js';
 
@@ -37,13 +36,12 @@ export interface IAgentsBannerResult {
  * to be registered (desktop builds only) and is limited to Insiders quality.
  * It is also hidden when AI features are disabled.
  */
-export function canShowAgentsBanner(productService: IProductService, chatEntitlementService: IChatEntitlementService): boolean {
+export function canShowAgentsBanner(chatEntitlementService: IChatEntitlementService): boolean {
 	const sentiment = chatEntitlementService.sentiment;
 	if (sentiment.hidden || sentiment.disabled) {
 		return false;
 	}
-	return productService.quality !== 'stable'
-		&& !!CommandsRegistry.getCommand(OPEN_WORKSPACE_IN_AGENTS_WINDOW_COMMAND_ID);
+	return !!CommandsRegistry.getCommand(OPEN_WORKSPACE_IN_AGENTS_WINDOW_COMMAND_ID);
 }
 
 export interface IAgentsBannerOptions {

--- a/src/vs/workbench/contrib/chat/browser/chatTipCatalog.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatTipCatalog.ts
@@ -8,7 +8,7 @@ import { localize } from '../../../../nls.js';
 import { ContextKeyExpr, ContextKeyExpression } from '../../../../platform/contextkey/common/contextkey.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
 import { MenuRegistry } from '../../../../platform/actions/common/actions.js';
-import { OPEN_WORKSPACE_IN_AGENTS_WINDOW_COMMAND_ID, OPEN_AGENTS_WINDOW_PRECONDITION, ChatConfiguration, ChatModeKind } from '../common/constants.js';
+import { ChatConfiguration, ChatModeKind } from '../common/constants.js';
 import { ChatContextKeys } from '../common/actions/chatContextKeys.js';
 import { IsSessionsWindowContext } from '../../../common/contextkeys.js';
 import { localChatSessionType } from '../common/chatSessionsService.js';
@@ -410,25 +410,6 @@ export const TIP_CATALOG: readonly ITipDefinition[] = [
 		},
 		when: ChatContextKeys.chatSessionType.isEqualTo(localChatSessionType),
 		excludeWhenToolsInvoked: ['listDebugEvents'],
-	},
-	{
-		id: 'tip.openAgentsWindow',
-		tier: ChatTipTier.Qol,
-		buildMessage() {
-			return new MarkdownString(
-				localize(
-					'tip.openAgentsWindow',
-					"Try the [Agents Application](command:{0} \"Open Agents Window\") to run multiple agents simultaneously and manage your coding sessions.",
-					OPEN_WORKSPACE_IN_AGENTS_WINDOW_COMMAND_ID
-				)
-			);
-		},
-		when: ContextKeyExpr.and(
-			OPEN_AGENTS_WINDOW_PRECONDITION,
-			ChatContextKeys.chatModeKind.isEqualTo(ChatModeKind.Agent),
-		),
-		excludeWhenCommandsExecuted: [OPEN_WORKSPACE_IN_AGENTS_WINDOW_COMMAND_ID],
-		dismissWhenCommandsClicked: [OPEN_WORKSPACE_IN_AGENTS_WINDOW_COMMAND_ID],
 	},
 	{
 		id: 'tip.copilotCli',

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -7,7 +7,6 @@ import { Schemas } from '../../../../base/common/network.js';
 import { IChatSessionsService } from './chatSessionsService.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { ContextKeyExpr, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
-import { ProductQualityContext } from '../../../../platform/contextkey/common/contextkeys.js';
 import { ChatEntitlementContextKeys } from '../../../services/chat/common/chatEntitlementService.js';
 import { IsSessionsWindowContext } from '../../../common/contextkeys.js';
 
@@ -216,7 +215,6 @@ export const MANAGE_CHAT_COMMAND_ID = 'workbench.action.chat.manage';
 export const OPEN_WORKSPACE_IN_AGENTS_WINDOW_COMMAND_ID = 'workbench.action.openWorkspaceInAgentsWindow';
 export const OPEN_AGENTS_WINDOW_COMMAND_ID = 'workbench.action.openAgentsWindow';
 export const OPEN_AGENTS_WINDOW_PRECONDITION = ContextKeyExpr.and(
-	ProductQualityContext.notEqualsTo('stable'),
 	ChatEntitlementContextKeys.Setup.hidden.negate(),
 	ChatEntitlementContextKeys.Setup.disabledInWorkspace.negate(),
 	IsSessionsWindowContext.negate(),

--- a/src/vs/workbench/contrib/welcomeAgentSessions/browser/agentSessionsWelcome.ts
+++ b/src/vs/workbench/contrib/welcomeAgentSessions/browser/agentSessionsWelcome.ts
@@ -595,7 +595,7 @@ export class AgentSessionsWelcomePage extends EditorPane {
 		}));
 
 		// "Try out the new Agents app" banner
-		if (canShowAgentsBanner(this.productService, this.chatEntitlementService)) {
+		if (canShowAgentsBanner(this.chatEntitlementService)) {
 			const agentsBanner = createAgentsBanner(
 				{
 					cssClass: 'agentSessionsWelcome-agentsBanner',

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -935,7 +935,7 @@ export class GettingStartedPage extends EditorPane {
 		const gettingStartedList = this.buildGettingStartedWalkthroughsList();
 
 		const footerChildren: HTMLElement[] = [];
-		if (canShowAgentsBanner(this.productService, this.chatEntitlementService)) {
+		if (canShowAgentsBanner(this.chatEntitlementService)) {
 			const agentsBanner = createAgentsBanner(
 				{
 					cssClass: 'getting-started-category.agents-banner',


### PR DESCRIPTION
Removes all `quality !== 'stable'` guards that were blocking the agents window from being accessible in stable builds.

## Changes

- **`app.ts`** — Remove quality check from `--agents` CLI flag and from `tryConsumeAgentsLastRunningMarker` (agents window now restores on startup in stable too)
- **`launchMainService.ts`** — Remove quality check when re-launching with `--agents` flag; remove now-unused `IProductService` dependency
- **`constants.ts`** — Remove `ProductQualityContext.notEqualsTo('stable')` from `OPEN_AGENTS_WINDOW_PRECONDITION`, enabling the "Open Agents Window" action in stable
- **`agentSessionsBanner.ts`** — Remove quality check from `canShowAgentsBanner` so the "Try out the new Agents" banner shows in stable (for users with Copilot access); remove now-unused `productService` parameter
- **`chatTipCatalog.ts`** — Remove the `tip.openAgentsWindow` chat tip shown above the chat input — already enough promotion via the banner and actions

## Not changed
- `agentsAppMergedBanner.contribution.ts` — Kept gated to non-stable (migration notice for users of the old standalone Agents app, which never existed in stable)
- `agentSessionsBanner.ts` (`canShowAgentsBanner`) — The banner itself still respects AI entitlement (`sentiment.hidden`, `sentiment.disabled`), just no longer requires non-stable
- `agentSessionsExperiments.contribution.ts` — "Agent Quick Input" toggle kept as Insiders-only experimental feature
