### PR TITLE
nes(xtab): detect duplicate additions in diff-patch + adversarial-review fixes

### DIFF
--- a/extensions/copilot/src/extension/xtab/node/xtabCustomDiffPatchResponseHandler.ts
+++ b/extensions/copilot/src/extension/xtab/node/xtabCustomDiffPatchResponseHandler.ts
@@ -85,12 +85,28 @@ export interface DuplicateAdditionRemoval {
 }
 
 /**
- * Callback invoked once per duplicate-addition detection. The caller can use
- * it to count occurrences and emit telemetry. In `Log` mode, the patch is
- * not actually modified; the callback still fires.
+ * Telemetry-safe summary of a single duplicate-addition detection.
+ *
+ * Deliberately excludes raw line content (`newAdditions` / `removedLines`)
+ * to keep `OnDuplicateRemovedCallback` from accidentally surfacing user
+ * source code through telemetry pipelines. Use the internal
+ * {@link DuplicateAdditionRemoval} returned by
+ * {@link tryRemoveDuplicateAdditions} when you legitimately need the
+ * content (e.g. to apply the trim).
+ */
+export interface DuplicateAdditionRemovalSummary {
+	readonly kind: 'suffix' | 'prefix' | 'middle';
+	readonly removedLineCount: number;
+	readonly remainingAdditionCount: number;
+}
+
+/**
+ * Callback invoked once per duplicate-addition detection. Receives only
+ * redacted, telemetry-safe metadata (counts and shape). In `Log` mode the
+ * patch is not actually modified; the callback still fires.
  */
 export type OnDuplicateRemovedCallback = (info: {
-	readonly removal: DuplicateAdditionRemoval;
+	readonly summary: DuplicateAdditionRemovalSummary;
 	readonly mode: DuplicateAdditionsMode.Log | DuplicateAdditionsMode.Remove;
 	readonly filePath: string;
 	readonly lineNumZeroBased: number;
@@ -154,7 +170,9 @@ export function tryRemoveDuplicateAdditions(
 		return undefined;
 	}
 
-	// `lineRange` is 1-based; convert to 0-based for line array access.
+	// All line numbers here are 1-based (matching `LineRange` and
+	// `AbstractText.getLineAt`). `endLineNumberExclusive` is the first line
+	// after the deletion — i.e. the first "following" line.
 	const followingStartLine1Based = replacement.lineRange.endLineNumberExclusive;
 	const fileLineCount = currentText.lineRange.endLineNumberExclusive - 1;
 	const followingEndLine1BasedExclusive = Math.min(
@@ -261,9 +279,16 @@ export class XtabCustomDiffPatchResponseHandler {
 				if (duplicateAdditionsMode !== DuplicateAdditionsMode.Off && isActiveDoc) {
 					const removal = tryRemoveDuplicateAdditions(lineReplacement, currentDocument.content);
 					if (removal !== undefined) {
-						tracer.trace(`Detected ${removal.removedLines.length} duplicate addition(s) (kind=${removal.kind}, mode=${duplicateAdditionsMode}) for edit at ${edit.filePath}:${edit.lineNumZeroBased}: ${JSON.stringify(removal.removedLines)}`);
+						// Log only metadata (kind / counts / location) — do
+						// NOT include raw line content. The tracer output
+						// may end up in user-visible diagnostics.
+						tracer.trace(`Detected duplicate addition(s) (kind=${removal.kind}, count=${removal.removedLines.length}, mode=${duplicateAdditionsMode}) for edit at ${edit.filePath}:${edit.lineNumZeroBased}`);
 						onDuplicateRemoved?.({
-							removal,
+							summary: {
+								kind: removal.kind,
+								removedLineCount: removal.removedLines.length,
+								remainingAdditionCount: removal.newAdditions.length,
+							},
 							mode: duplicateAdditionsMode,
 							filePath: edit.filePath,
 							lineNumZeroBased: edit.lineNumZeroBased,

--- a/extensions/copilot/src/extension/xtab/node/xtabCustomDiffPatchResponseHandler.ts
+++ b/extensions/copilot/src/extension/xtab/node/xtabCustomDiffPatchResponseHandler.ts
@@ -102,12 +102,13 @@ export interface DuplicateAdditionRemovalSummary {
 
 /**
  * Callback invoked once per duplicate-addition detection. Receives only
- * redacted, telemetry-safe metadata (counts and shape). In `Log` mode the
- * patch is not actually modified; the callback still fires.
+ * redacted, telemetry-safe metadata (counts and shape). The callback fires
+ * for every action mode (Log / DropPatch / DropAllRemaining / TrimDuplicate),
+ * including `Log` where the patch is not actually modified.
  */
 export type OnDuplicateRemovedCallback = (info: {
 	readonly summary: DuplicateAdditionRemovalSummary;
-	readonly mode: DuplicateAdditionsMode.Log | DuplicateAdditionsMode.Remove;
+	readonly mode: Exclude<DuplicateAdditionsMode, DuplicateAdditionsMode.Off>;
 	readonly filePath: string;
 	readonly lineNumZeroBased: number;
 }) => void;
@@ -262,7 +263,12 @@ export class XtabCustomDiffPatchResponseHandler {
 		const activeDocRelativePath = toUniquePath(activeDocumentId, workspaceRoot?.path);
 
 		try {
+			let dropAllRemaining = false;
 			for await (const edit of XtabCustomDiffPatchResponseHandler.extractEdits(linesStream)) {
+				if (dropAllRemaining) {
+					continue;
+				}
+
 				const isActiveDoc = edit.filePath === activeDocRelativePath;
 				const targetDocument = isActiveDoc
 					? activeDocumentId
@@ -293,13 +299,29 @@ export class XtabCustomDiffPatchResponseHandler {
 							filePath: edit.filePath,
 							lineNumZeroBased: edit.lineNumZeroBased,
 						});
-						if (duplicateAdditionsMode === DuplicateAdditionsMode.Remove) {
-							const newAdditions = removal.newAdditions;
-							if (newAdditions.length === 0 && lineReplacement.lineRange.length === 0) {
-								// No-op patch after dedup — drop it.
+
+						switch (duplicateAdditionsMode) {
+							case DuplicateAdditionsMode.Log:
+								// Yield the patch unchanged.
+								break;
+							case DuplicateAdditionsMode.DropPatch:
 								continue;
+							case DuplicateAdditionsMode.DropAllRemaining:
+								// Drop this patch and skip every subsequent
+								// patch in the stream. We still consume the
+								// stream to completion so the underlying
+								// fetch is allowed to finalize cleanly.
+								dropAllRemaining = true;
+								continue;
+							case DuplicateAdditionsMode.TrimDuplicate: {
+								const newAdditions = removal.newAdditions;
+								if (newAdditions.length === 0 && lineReplacement.lineRange.length === 0) {
+									// Trim left a no-op patch — drop it.
+									continue;
+								}
+								lineReplacement = new LineReplacement(lineReplacement.lineRange, newAdditions);
+								break;
 							}
-							lineReplacement = new LineReplacement(lineReplacement.lineRange, newAdditions);
 						}
 					}
 				}

--- a/extensions/copilot/src/extension/xtab/node/xtabCustomDiffPatchResponseHandler.ts
+++ b/extensions/copilot/src/extension/xtab/node/xtabCustomDiffPatchResponseHandler.ts
@@ -7,6 +7,7 @@ import { DocumentId } from '../../../platform/inlineEdits/common/dataTypes/docum
 import { NoNextEditReason, StreamedEdit } from '../../../platform/inlineEdits/common/statelessNextEditProvider';
 import { ILogger } from '../../../platform/log/common/logService';
 import { ErrorUtils } from '../../../util/common/errors';
+import { equals as arraysEqual } from '../../../util/vs/base/common/arrays';
 import { isAbsolute } from '../../../util/vs/base/common/path';
 import { URI } from '../../../util/vs/base/common/uri';
 import { LineReplacement } from '../../../util/vs/editor/common/core/edits/lineEdit';
@@ -61,6 +62,131 @@ class Patch {
 	}
 }
 
+/**
+ * Information about a single duplicate-addition removal.
+ *
+ * `kind` identifies which heuristic shape fired:
+ *   - `'suffix'`: trailing additions matched the lines after the deletion.
+ *   - `'prefix'`: leading addition matched the first line after the deletion.
+ *   - `'middle'`: a pair of additions inside the patch matched the start of
+ *     the following lines (streaming model partially copied the continuation).
+ *
+ * `removedLines` are the actual addition lines that were dropped (in order),
+ * preserved for diagnostics/logging.
+ */
+export interface DuplicateAdditionRemoval {
+	readonly kind: 'suffix' | 'prefix' | 'middle';
+	readonly newAdditions: string[];
+	readonly removedLines: readonly string[];
+}
+
+/**
+ * A heuristic line is "meaningful" enough to base a duplicate detection on
+ * if it has more than one non-whitespace character. This guards against
+ * matching common single-token lines (`}`, `;`, `)`) and blank lines, which
+ * frequently appear both in legitimate additions and in surrounding context.
+ */
+function isMeaningfulLine(line: string): boolean {
+	return line.trim().length > 1;
+}
+
+/**
+ * Checks whether the patch's added lines duplicate the file content immediately
+ * following the deleted range, and if so, trims the duplicated lines.
+ *
+ * The diff-patch model can occasionally regress and emit additions that copy
+ * the existing continuation code. When that happens, applying the patch
+ * produces visibly duplicated lines in the file (e.g. an extra closing brace
+ * after a code block).
+ *
+ * Three duplication shapes are detected, mirroring the heuristic used in the
+ * offline analysis tooling. Only one shape is applied per patch — the checks
+ * run in priority order and the first match wins. This avoids cascading
+ * removals where one shape's trimming exposes a spurious match for another.
+ *
+ * Priority order:
+ *   1. **Suffix** — last `k` additions match first `k` following lines (most
+ *      common case: trailing `}` re-emitted). Picks the longest matching `k`
+ *      that survives an extra ambiguity guard: when the match would consume
+ *      the entire addition AND every matched line is non-meaningful (e.g. a
+ *      single `}`), the heuristic falls through, since that case is
+ *      ambiguous between a legitimate inner-scope close and a duplicate.
+ *   2. **Prefix** — first addition matches first following line, and the line
+ *      is "meaningful" (>1 non-whitespace char) to avoid dropping legitimate
+ *      single-token lines (e.g. an inner-scope `}` followed by an outer `}`).
+ *   3. **Middle** — a consecutive pair of additions starting at offset > 0
+ *      (and not at the end) matches the first two following lines. Both
+ *      following lines must be meaningful, again to avoid trivial matches.
+ *
+ * Returns a `DuplicateAdditionRemoval` describing what was dropped, or
+ * `undefined` if no duplication was detected.
+ */
+export function tryRemoveDuplicateAdditions(
+	patch: { readonly addedLines: readonly string[]; readonly removedLines: readonly string[]; readonly lineNumZeroBased: number },
+	fileLines: readonly string[],
+): DuplicateAdditionRemoval | undefined {
+	const { addedLines, removedLines, lineNumZeroBased } = patch;
+	if (addedLines.length === 0) {
+		return undefined;
+	}
+
+	const followingStart = lineNumZeroBased + removedLines.length;
+	const following = fileLines.slice(followingStart, followingStart + addedLines.length);
+	if (following.length === 0) {
+		return undefined;
+	}
+
+	// 1. Suffix: longest k where last k additions match first k following lines.
+	for (let k = Math.min(addedLines.length, following.length); k >= 1; k--) {
+		const tail = addedLines.slice(-k);
+		if (!arraysEqual(tail, following.slice(0, k))) {
+			continue;
+		}
+		// Skip when the suffix would consume the entire addition AND every
+		// matched line is non-meaningful: that case is genuinely ambiguous
+		// (e.g. a single `}` that may be a legitimate inner-scope close).
+		// Keep iterating to a smaller k that may still match meaningfully.
+		if (k === addedLines.length && tail.every(l => !isMeaningfulLine(l))) {
+			continue;
+		}
+		return {
+			kind: 'suffix',
+			newAdditions: addedLines.slice(0, addedLines.length - k),
+			removedLines: tail,
+		};
+	}
+
+	// 2. Prefix: first addition matches first following line and is meaningful.
+	if (addedLines[0] === following[0] && isMeaningfulLine(addedLines[0])) {
+		return {
+			kind: 'prefix',
+			newAdditions: addedLines.slice(1),
+			removedLines: addedLines.slice(0, 1),
+		};
+	}
+
+	// 3. Middle (e.g. streamEdits): consecutive pair of additions at offset > 0
+	//    (and not extending to the end — that case is suffix) matches the first
+	//    two following lines. Require both to be meaningful to avoid trivial
+	//    matches such as duplicate blank lines.
+	if (addedLines.length >= 3 && following.length >= 2 &&
+		isMeaningfulLine(following[0]) && isMeaningfulLine(following[1])) {
+		const a = following[0];
+		const b = following[1];
+		for (let start = 1; start < addedLines.length - 1; start++) {
+			if (addedLines[start] === a && addedLines[start + 1] === b) {
+				return {
+					kind: 'middle',
+					newAdditions: addedLines.slice(0, start),
+					removedLines: addedLines.slice(start),
+				};
+			}
+		}
+	}
+
+	return undefined;
+}
+
 
 export class XtabCustomDiffPatchResponseHandler {
 
@@ -71,24 +197,50 @@ export class XtabCustomDiffPatchResponseHandler {
 		workspaceRoot: URI | undefined,
 		window: OffsetRange | undefined,
 		parentTracer: ILogger,
+		removeDuplicates: boolean = false,
 	): AsyncGenerator<StreamedEdit, NoNextEditReason, void> {
 		const tracer = parentTracer.createSubLogger(['XtabCustomDiffPatchResponseHandler', 'handleResponse']);
 		const activeDocRelativePath = toUniquePath(activeDocumentId, workspaceRoot?.path);
+
+		// Tracking for the final return value: if every received patch is
+		// dropped by the dedup filter, surface that as `FilteredOut` rather
+		// than `NoSuggestions` so callers can distinguish the two cases.
+		let yieldedEditCount = 0;
+		let droppedByDedupCount = 0;
+
 		try {
 			for await (const edit of XtabCustomDiffPatchResponseHandler.extractEdits(linesStream)) {
-				const targetDocument = edit.filePath === activeDocRelativePath
+				const isActiveDoc = edit.filePath === activeDocRelativePath;
+				const targetDocument = isActiveDoc
 					? activeDocumentId
 					: XtabCustomDiffPatchResponseHandler.resolveTargetDocument(edit.filePath, workspaceRoot);
 				if (!targetDocument) {
 					tracer.error(`Could not resolve target document for edit: ${edit.toString()}`);
 					continue;
 				}
+
+				// Only attempt dedup for the active document — other files'
+				// content is not directly available here.
+				if (removeDuplicates && isActiveDoc) {
+					const removal = tryRemoveDuplicateAdditions(edit, currentDocument.lines);
+					if (removal !== undefined) {
+						tracer.trace(`Removed ${removal.removedLines.length} duplicate addition(s) (kind=${removal.kind}) for edit at ${edit.filePath}:${edit.lineNumZeroBased}: ${JSON.stringify(removal.removedLines)}`);
+						edit.addedLines = removal.newAdditions;
+						if (edit.addedLines.length === 0 && edit.removedLines.length === 0) {
+							// No-op patch after dedup — drop it.
+							droppedByDedupCount++;
+							continue;
+						}
+					}
+				}
+
 				yield {
 					edit: XtabCustomDiffPatchResponseHandler.resolveEdit(edit),
 					isFromCursorJump: false,
 					targetDocument,
 					window,
 				} satisfies StreamedEdit;
+				yieldedEditCount++;
 			}
 		} catch (e: unknown) {
 			if (e instanceof FetchStreamError) {
@@ -96,6 +248,14 @@ export class XtabCustomDiffPatchResponseHandler {
 			}
 			const err = ErrorUtils.fromUnknown(e);
 			return new NoNextEditReason.Unexpected(err);
+		}
+
+		// If every received patch was dropped by the dedup filter, signal
+		// FilteredOut so that telemetry and downstream handling can
+		// distinguish "model produced only duplicate suggestions" from
+		// "model produced no suggestions at all".
+		if (yieldedEditCount === 0 && droppedByDedupCount > 0) {
+			return new NoNextEditReason.FilteredOut(`diffPatch:duplicateAdditions:${droppedByDedupCount}`);
 		}
 
 		return new NoNextEditReason.NoSuggestions(currentDocument.content, window, undefined);

--- a/extensions/copilot/src/extension/xtab/node/xtabCustomDiffPatchResponseHandler.ts
+++ b/extensions/copilot/src/extension/xtab/node/xtabCustomDiffPatchResponseHandler.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { DocumentId } from '../../../platform/inlineEdits/common/dataTypes/documentId';
+import { DuplicateAdditionsMode } from '../../../platform/inlineEdits/common/dataTypes/xtabPromptOptions';
 import { NoNextEditReason, StreamedEdit } from '../../../platform/inlineEdits/common/statelessNextEditProvider';
 import { ILogger } from '../../../platform/log/common/logService';
 import { ErrorUtils } from '../../../util/common/errors';
@@ -13,10 +14,13 @@ import { URI } from '../../../util/vs/base/common/uri';
 import { LineReplacement } from '../../../util/vs/editor/common/core/edits/lineEdit';
 import { LineRange } from '../../../util/vs/editor/common/core/ranges/lineRange';
 import { OffsetRange } from '../../../util/vs/editor/common/core/ranges/offsetRange';
+import { AbstractText } from '../../../util/vs/editor/common/core/text/abstractText';
 import { FetchStreamError } from '../common/fetchStreamError';
 import { toUniquePath } from '../common/promptCraftingUtils';
 import { ResponseTags } from '../common/tags';
 import { CurrentDocument } from '../common/xtabCurrentDocument';
+
+export { DuplicateAdditionsMode };
 
 
 class Patch {
@@ -81,6 +85,18 @@ export interface DuplicateAdditionRemoval {
 }
 
 /**
+ * Callback invoked once per duplicate-addition detection. The caller can use
+ * it to count occurrences and emit telemetry. In `Log` mode, the patch is
+ * not actually modified; the callback still fires.
+ */
+export type OnDuplicateRemovedCallback = (info: {
+	readonly removal: DuplicateAdditionRemoval;
+	readonly mode: DuplicateAdditionsMode.Log | DuplicateAdditionsMode.Remove;
+	readonly filePath: string;
+	readonly lineNumZeroBased: number;
+}) => void;
+
+/**
  * A heuristic line is "meaningful" enough to base a duplicate detection on
  * if it has more than one non-whitespace character. This guards against
  * matching common single-token lines (`}`, `;`, `)`) and blank lines, which
@@ -106,32 +122,49 @@ function isMeaningfulLine(line: string): boolean {
  *
  * Priority order:
  *   1. **Suffix** — last `k` additions match first `k` following lines (most
- *      common case: trailing `}` re-emitted). Picks the longest matching `k`
- *      that survives an extra ambiguity guard: when the match would consume
- *      the entire addition AND every matched line is non-meaningful (e.g. a
- *      single `}`), the heuristic falls through, since that case is
- *      ambiguous between a legitimate inner-scope close and a duplicate.
+ *      common case: trailing `}` re-emitted). Picks the longest matching `k`.
+ *      No additional ambiguity guard is applied: the prior heuristic
+ *      preserved single-token suffixes when they consumed the entire
+ *      addition (e.g. `addedLines = ['}']` with `following = ['}']`), but
+ *      that's the headline-bug case — applying the patch would insert a
+ *      stray closing token into already-balanced code. The trade-off is a
+ *      rare false positive when the file is mid-typing and unbalanced; the
+ *      common case (file is balanced, model is duplicating) is the one we
+ *      optimize for.
  *   2. **Prefix** — first addition matches first following line, and the line
  *      is "meaningful" (>1 non-whitespace char) to avoid dropping legitimate
  *      single-token lines (e.g. an inner-scope `}` followed by an outer `}`).
  *   3. **Middle** — a consecutive pair of additions starting at offset > 0
  *      (and not at the end) matches the first two following lines. Both
  *      following lines must be meaningful, again to avoid trivial matches.
+ *      The match is then **greedily extended**: only the verified-equal
+ *      lines are dropped; any addition lines beyond the equal range are
+ *      preserved (the model may have appended new content after the
+ *      streaming-style regenerated context).
  *
  * Returns a `DuplicateAdditionRemoval` describing what was dropped, or
  * `undefined` if no duplication was detected.
  */
 export function tryRemoveDuplicateAdditions(
-	patch: { readonly addedLines: readonly string[]; readonly removedLines: readonly string[]; readonly lineNumZeroBased: number },
-	fileLines: readonly string[],
+	replacement: LineReplacement,
+	currentText: AbstractText,
 ): DuplicateAdditionRemoval | undefined {
-	const { addedLines, removedLines, lineNumZeroBased } = patch;
+	const addedLines = replacement.newLines;
 	if (addedLines.length === 0) {
 		return undefined;
 	}
 
-	const followingStart = lineNumZeroBased + removedLines.length;
-	const following = fileLines.slice(followingStart, followingStart + addedLines.length);
+	// `lineRange` is 1-based; convert to 0-based for line array access.
+	const followingStartLine1Based = replacement.lineRange.endLineNumberExclusive;
+	const fileLineCount = currentText.lineRange.endLineNumberExclusive - 1;
+	const followingEndLine1BasedExclusive = Math.min(
+		fileLineCount + 1,
+		followingStartLine1Based + addedLines.length,
+	);
+	const following: string[] = [];
+	for (let l = followingStartLine1Based; l < followingEndLine1BasedExclusive; l++) {
+		following.push(currentText.getLineAt(l));
+	}
 	if (following.length === 0) {
 		return undefined;
 	}
@@ -140,13 +173,6 @@ export function tryRemoveDuplicateAdditions(
 	for (let k = Math.min(addedLines.length, following.length); k >= 1; k--) {
 		const tail = addedLines.slice(-k);
 		if (!arraysEqual(tail, following.slice(0, k))) {
-			continue;
-		}
-		// Skip when the suffix would consume the entire addition AND every
-		// matched line is non-meaningful: that case is genuinely ambiguous
-		// (e.g. a single `}` that may be a legitimate inner-scope close).
-		// Keep iterating to a smaller k that may still match meaningfully.
-		if (k === addedLines.length && tail.every(l => !isMeaningfulLine(l))) {
 			continue;
 		}
 		return {
@@ -168,19 +194,33 @@ export function tryRemoveDuplicateAdditions(
 	// 3. Middle (e.g. streamEdits): consecutive pair of additions at offset > 0
 	//    (and not extending to the end — that case is suffix) matches the first
 	//    two following lines. Require both to be meaningful to avoid trivial
-	//    matches such as duplicate blank lines.
+	//    matches such as duplicate blank lines. After finding the seed pair,
+	//    greedily extend `k` while addedLines and `following` continue to
+	//    match — only the verified-equal range is dropped.
 	if (addedLines.length >= 3 && following.length >= 2 &&
 		isMeaningfulLine(following[0]) && isMeaningfulLine(following[1])) {
 		const a = following[0];
 		const b = following[1];
 		for (let start = 1; start < addedLines.length - 1; start++) {
-			if (addedLines[start] === a && addedLines[start + 1] === b) {
-				return {
-					kind: 'middle',
-					newAdditions: addedLines.slice(0, start),
-					removedLines: addedLines.slice(start),
-				};
+			if (addedLines[start] !== a || addedLines[start + 1] !== b) {
+				continue;
 			}
+			let k = 2;
+			while (
+				start + k < addedLines.length &&
+				k < following.length &&
+				addedLines[start + k] === following[k]
+			) {
+				k++;
+			}
+			return {
+				kind: 'middle',
+				newAdditions: [
+					...addedLines.slice(0, start),
+					...addedLines.slice(start + k),
+				],
+				removedLines: addedLines.slice(start, start + k),
+			};
 		}
 	}
 
@@ -197,16 +237,11 @@ export class XtabCustomDiffPatchResponseHandler {
 		workspaceRoot: URI | undefined,
 		window: OffsetRange | undefined,
 		parentTracer: ILogger,
-		removeDuplicates: boolean = false,
+		duplicateAdditionsMode: DuplicateAdditionsMode = DuplicateAdditionsMode.Off,
+		onDuplicateRemoved?: OnDuplicateRemovedCallback,
 	): AsyncGenerator<StreamedEdit, NoNextEditReason, void> {
 		const tracer = parentTracer.createSubLogger(['XtabCustomDiffPatchResponseHandler', 'handleResponse']);
 		const activeDocRelativePath = toUniquePath(activeDocumentId, workspaceRoot?.path);
-
-		// Tracking for the final return value: if every received patch is
-		// dropped by the dedup filter, surface that as `FilteredOut` rather
-		// than `NoSuggestions` so callers can distinguish the two cases.
-		let yieldedEditCount = 0;
-		let droppedByDedupCount = 0;
 
 		try {
 			for await (const edit of XtabCustomDiffPatchResponseHandler.extractEdits(linesStream)) {
@@ -219,28 +254,37 @@ export class XtabCustomDiffPatchResponseHandler {
 					continue;
 				}
 
+				let lineReplacement = XtabCustomDiffPatchResponseHandler.resolveEdit(edit);
+
 				// Only attempt dedup for the active document — other files'
 				// content is not directly available here.
-				if (removeDuplicates && isActiveDoc) {
-					const removal = tryRemoveDuplicateAdditions(edit, currentDocument.lines);
+				if (duplicateAdditionsMode !== DuplicateAdditionsMode.Off && isActiveDoc) {
+					const removal = tryRemoveDuplicateAdditions(lineReplacement, currentDocument.content);
 					if (removal !== undefined) {
-						tracer.trace(`Removed ${removal.removedLines.length} duplicate addition(s) (kind=${removal.kind}) for edit at ${edit.filePath}:${edit.lineNumZeroBased}: ${JSON.stringify(removal.removedLines)}`);
-						edit.addedLines = removal.newAdditions;
-						if (edit.addedLines.length === 0 && edit.removedLines.length === 0) {
-							// No-op patch after dedup — drop it.
-							droppedByDedupCount++;
-							continue;
+						tracer.trace(`Detected ${removal.removedLines.length} duplicate addition(s) (kind=${removal.kind}, mode=${duplicateAdditionsMode}) for edit at ${edit.filePath}:${edit.lineNumZeroBased}: ${JSON.stringify(removal.removedLines)}`);
+						onDuplicateRemoved?.({
+							removal,
+							mode: duplicateAdditionsMode,
+							filePath: edit.filePath,
+							lineNumZeroBased: edit.lineNumZeroBased,
+						});
+						if (duplicateAdditionsMode === DuplicateAdditionsMode.Remove) {
+							const newAdditions = removal.newAdditions;
+							if (newAdditions.length === 0 && lineReplacement.lineRange.length === 0) {
+								// No-op patch after dedup — drop it.
+								continue;
+							}
+							lineReplacement = new LineReplacement(lineReplacement.lineRange, newAdditions);
 						}
 					}
 				}
 
 				yield {
-					edit: XtabCustomDiffPatchResponseHandler.resolveEdit(edit),
+					edit: lineReplacement,
 					isFromCursorJump: false,
 					targetDocument,
 					window,
 				} satisfies StreamedEdit;
-				yieldedEditCount++;
 			}
 		} catch (e: unknown) {
 			if (e instanceof FetchStreamError) {
@@ -248,14 +292,6 @@ export class XtabCustomDiffPatchResponseHandler {
 			}
 			const err = ErrorUtils.fromUnknown(e);
 			return new NoNextEditReason.Unexpected(err);
-		}
-
-		// If every received patch was dropped by the dedup filter, signal
-		// FilteredOut so that telemetry and downstream handling can
-		// distinguish "model produced only duplicate suggestions" from
-		// "model produced no suggestions at all".
-		if (yieldedEditCount === 0 && droppedByDedupCount > 0) {
-			return new NoNextEditReason.FilteredOut(`diffPatch:duplicateAdditions:${droppedByDedupCount}`);
 		}
 
 		return new NoNextEditReason.NoSuggestions(currentDocument.content, window, undefined);

--- a/extensions/copilot/src/extension/xtab/node/xtabProvider.ts
+++ b/extensions/copilot/src/extension/xtab/node/xtabProvider.ts
@@ -941,6 +941,7 @@ export class XtabProvider implements IStatelessNextEditProvider {
 					const lastLine = currentDocument.lines[clippedTaggedCurrentDoc.keptRange.endExclusive - 1];
 					const lastLineLength = lastLine.length;
 					const pseudoEditWindow = currentDocument.transformer.getOffsetRange(new Range(clippedTaggedCurrentDoc.keptRange.start + 1, 1, clippedTaggedCurrentDoc.keptRange.endExclusive, lastLineLength + 1));
+					const removeDuplicateAdditions = this.configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsXtabRemoveDuplicateAdditionsInDiffPatch, this.expService);
 					parseResult = new ResponseParseResult.DirectEdits(
 						XtabCustomDiffPatchResponseHandler.handleResponse(
 							linesStream,
@@ -949,6 +950,7 @@ export class XtabProvider implements IStatelessNextEditProvider {
 							activeDoc.workspaceRoot,
 							pseudoEditWindow,
 							tracer,
+							removeDuplicateAdditions,
 						),
 					);
 					break;

--- a/extensions/copilot/src/extension/xtab/node/xtabProvider.ts
+++ b/extensions/copilot/src/extension/xtab/node/xtabProvider.ts
@@ -941,7 +941,7 @@ export class XtabProvider implements IStatelessNextEditProvider {
 					const lastLine = currentDocument.lines[clippedTaggedCurrentDoc.keptRange.endExclusive - 1];
 					const lastLineLength = lastLine.length;
 					const pseudoEditWindow = currentDocument.transformer.getOffsetRange(new Range(clippedTaggedCurrentDoc.keptRange.start + 1, 1, clippedTaggedCurrentDoc.keptRange.endExclusive, lastLineLength + 1));
-					const removeDuplicateAdditions = this.configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsXtabRemoveDuplicateAdditionsInDiffPatch, this.expService);
+					const duplicateAdditionsMode = this.configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsXtabDuplicateAdditionsMode, this.expService);
 					parseResult = new ResponseParseResult.DirectEdits(
 						XtabCustomDiffPatchResponseHandler.handleResponse(
 							linesStream,
@@ -950,7 +950,7 @@ export class XtabProvider implements IStatelessNextEditProvider {
 							activeDoc.workspaceRoot,
 							pseudoEditWindow,
 							tracer,
-							removeDuplicateAdditions,
+							duplicateAdditionsMode,
 						),
 					);
 					break;

--- a/extensions/copilot/src/extension/xtab/test/node/xtabCustomDiffPatchResponseHandler.spec.ts
+++ b/extensions/copilot/src/extension/xtab/test/node/xtabCustomDiffPatchResponseHandler.spec.ts
@@ -9,12 +9,13 @@ import { NoNextEditReason, StreamedEdit } from '../../../../platform/inlineEdits
 import { TestLogService } from '../../../../platform/testing/common/testLogService';
 import { AsyncIterUtils } from '../../../../util/common/asyncIterableUtils';
 import { AsyncIterableSource } from '../../../../util/vs/base/common/async';
+import { LineReplacement } from '../../../../util/vs/editor/common/core/edits/lineEdit';
 import { Position } from '../../../../util/vs/editor/common/core/position';
 import { StringText } from '../../../../util/vs/editor/common/core/text/abstractText';
 import { ensureDependenciesAreSet } from '../../../../util/vs/editor/common/core/text/positionToOffset';
 import { FetchStreamError } from '../../common/fetchStreamError';
 import { CurrentDocument } from '../../common/xtabCurrentDocument';
-import { XtabCustomDiffPatchResponseHandler } from '../../node/xtabCustomDiffPatchResponseHandler';
+import { tryRemoveDuplicateAdditions, XtabCustomDiffPatchResponseHandler } from '../../node/xtabCustomDiffPatchResponseHandler';
 
 async function consumeHandleResponse(
 	...args: Parameters<typeof XtabCustomDiffPatchResponseHandler.handleResponse>
@@ -189,5 +190,434 @@ another_file.js:
 
 		expect(edits).toHaveLength(0);
 		expect(returnValue).toBe(cancellationReason);
+	});
+
+	describe('tryRemoveDuplicateAdditions', () => {
+
+		it('removes a single trailing duplicate (closing brace case)', () => {
+			// File:
+			//   0: function foo() {
+			//   1:     let x = 1;
+			//   2: }
+			//
+			// Patch replaces line 1 and tries to add `let y = 2;` after it,
+			// but mistakenly re-emits the closing brace.
+			const fileLines = ['function foo() {', '    let x = 1;', '}'];
+			const result = tryRemoveDuplicateAdditions(
+				{
+					addedLines: ['    let x = 1;', '    let y = 2;', '}'],
+					removedLines: ['    let x = 1;'],
+					lineNumZeroBased: 1,
+				},
+				fileLines,
+			);
+			expect(result?.kind).toBe('suffix');
+			expect(result?.newAdditions).toEqual(['    let x = 1;', '    let y = 2;']);
+			expect(result?.removedLines).toEqual(['}']);
+		});
+
+		it('removes a multi-line trailing duplicate', () => {
+			const fileLines = ['a', 'b', 'c', 'd', 'e'];
+			// Patch at line 1 replaces `b`. Additions repeat `b`, `c`, `d`.
+			// `c`, `d` are the lines following the deletion and would be duplicated.
+			const result = tryRemoveDuplicateAdditions(
+				{
+					addedLines: ['B', 'c', 'd'],
+					removedLines: ['b'],
+					lineNumZeroBased: 1,
+				},
+				fileLines,
+			);
+			expect(result?.kind).toBe('suffix');
+			expect(result?.newAdditions).toEqual(['B']);
+			expect(result?.removedLines).toEqual(['c', 'd']);
+		});
+
+		it('picks the longest suffix match', () => {
+			// File: ['a', 'b', 'c'] following the patch.
+			// Additions end with ['a', 'b', 'c'] — both k=1 and k=3 would match
+			// (k=3 only because the whole following matches), but the longest
+			// match wins to remove as much duplication as possible.
+			const fileLines = ['x', 'a', 'b', 'c'];
+			const result = tryRemoveDuplicateAdditions(
+				{
+					addedLines: ['new', 'a', 'b', 'c'],
+					removedLines: [],
+					lineNumZeroBased: 1,
+				},
+				fileLines,
+			);
+			expect(result?.kind).toBe('suffix');
+			expect(result?.newAdditions).toEqual(['new']);
+			expect(result?.removedLines).toEqual(['a', 'b', 'c']);
+		});
+
+		it('removes a leading duplicate when the line is meaningful', () => {
+			// File:
+			//   0: header
+			//   1: existing line
+			//   2: trailer
+			//
+			// Patch at line 1 with no removals tries to add `existing line`.
+			const fileLines = ['header', 'existing line', 'trailer'];
+			const result = tryRemoveDuplicateAdditions(
+				{
+					addedLines: ['existing line', 'extra'],
+					removedLines: [],
+					lineNumZeroBased: 1,
+				},
+				fileLines,
+			);
+			expect(result?.kind).toBe('prefix');
+			expect(result?.newAdditions).toEqual(['extra']);
+			expect(result?.removedLines).toEqual(['existing line']);
+		});
+
+		it('does not drop a single-character prefix (e.g. inner-scope `}`)', () => {
+			// Model legitimately closes an inner scope with `}`, and the next
+			// line happens to be the outer scope's `}`. This must NOT be
+			// treated as a duplicate.
+			const fileLines = ['function outer() {', '  inner();', '}', '}'];
+			const result = tryRemoveDuplicateAdditions(
+				{
+					addedLines: ['}'],
+					removedLines: [],
+					lineNumZeroBased: 2,
+				},
+				fileLines,
+			);
+			expect(result).toBeUndefined();
+		});
+
+		it('does not drop a leading whitespace-only duplicate', () => {
+			const fileLines = ['', '', 'existing'];
+			const result = tryRemoveDuplicateAdditions(
+				{
+					addedLines: ['', 'first new line'],
+					removedLines: [],
+					lineNumZeroBased: 1,
+				},
+				fileLines,
+			);
+			expect(result).toBeUndefined();
+		});
+
+		it('removes streamEdits-style middle duplicate', () => {
+			// additions partially copy continuation starting at offset 2.
+			const fileLines = ['x', 'cont1 long', 'cont2 long', 'y'];
+			const result = tryRemoveDuplicateAdditions(
+				{
+					addedLines: ['new1', 'new2', 'cont1 long', 'cont2 long', 'extra'],
+					removedLines: [],
+					lineNumZeroBased: 1,
+				},
+				fileLines,
+			);
+			expect(result?.kind).toBe('middle');
+			expect(result?.newAdditions).toEqual(['new1', 'new2']);
+			expect(result?.removedLines).toEqual(['cont1 long', 'cont2 long', 'extra']);
+		});
+
+		it('does not match a middle pair when the following lines are not meaningful', () => {
+			// Two consecutive blank lines are too common to safely match on.
+			const fileLines = ['x', '', '', 'y'];
+			const result = tryRemoveDuplicateAdditions(
+				{
+					addedLines: ['new1', 'new2', '', '', 'extra'],
+					removedLines: [],
+					lineNumZeroBased: 1,
+				},
+				fileLines,
+			);
+			expect(result).toBeUndefined();
+		});
+
+		it('returns undefined when no duplicate is detected', () => {
+			const fileLines = ['unrelated1', 'unrelated2'];
+			const result = tryRemoveDuplicateAdditions(
+				{
+					addedLines: ['new1', 'new2'],
+					removedLines: [],
+					lineNumZeroBased: 0,
+				},
+				fileLines,
+			);
+			expect(result).toBeUndefined();
+		});
+
+		it('returns undefined when there are no following lines', () => {
+			const fileLines = ['only line'];
+			const result = tryRemoveDuplicateAdditions(
+				{
+					addedLines: ['new1'],
+					removedLines: ['only line'],
+					lineNumZeroBased: 0,
+				},
+				fileLines,
+			);
+			expect(result).toBeUndefined();
+		});
+
+		it('returns undefined when there are no additions', () => {
+			const fileLines = ['a', 'b'];
+			const result = tryRemoveDuplicateAdditions(
+				{
+					addedLines: [],
+					removedLines: ['a'],
+					lineNumZeroBased: 0,
+				},
+				fileLines,
+			);
+			expect(result).toBeUndefined();
+		});
+
+		it('handles patch at the very end of the file (no following lines)', () => {
+			const fileLines = ['line0', 'line1'];
+			// Replacing the last line with no extra following content.
+			const result = tryRemoveDuplicateAdditions(
+				{
+					addedLines: ['new1'],
+					removedLines: ['line1'],
+					lineNumZeroBased: 1,
+				},
+				fileLines,
+			);
+			expect(result).toBeUndefined();
+		});
+
+		it('does not chain shapes — suffix match returns immediately without firing middle', () => {
+			// Without single-shape semantics, the original implementation could
+			// trim a suffix and then the (now shortened) additions would expose
+			// a "middle" pair that incorrectly truncated even more lines.
+			//
+			// File: outer-scope code where '  }', '}' appear before nextLine.
+			// Additions: real new code followed by '  }', '}', '  }', '}'.
+			// The longest-matching suffix is k=2 (matches the 2-line following
+			// `[' }', '}']`), so only those last 2 lines should be removed.
+			const fileLines = ['  }', '}', 'nextLine'];
+			const result = tryRemoveDuplicateAdditions(
+				{
+					addedLines: ['  newCode();', '  }', '}', '  }', '}'],
+					removedLines: [],
+					lineNumZeroBased: 0,
+				},
+				fileLines,
+			);
+			expect(result?.kind).toBe('suffix');
+			expect(result?.newAdditions).toEqual(['  newCode();', '  }', '}']);
+			expect(result?.removedLines).toEqual(['  }', '}']);
+		});
+
+		it('handles file without trailing newline', () => {
+			// `splitLines('a\\nb\\nc')` returns ['a','b','c'] (no trailing empty).
+			// The dedup must still work correctly against this shape.
+			const fileLines = 'function foo() {\n    let x = 1;\n}'.split('\n');
+			const result = tryRemoveDuplicateAdditions(
+				{
+					addedLines: ['    let x = 1;', '    let y = 2;', '}'],
+					removedLines: ['    let x = 1;'],
+					lineNumZeroBased: 1,
+				},
+				fileLines,
+			);
+			expect(result?.kind).toBe('suffix');
+			expect(result?.newAdditions).toEqual(['    let x = 1;', '    let y = 2;']);
+		});
+
+		it('handles file with trailing newline (extra empty line at end)', () => {
+			// `splitLines('a\\nb\\nc\\n')` returns ['a','b','c',''] — the trailing
+			// empty string can become a "following" line and must not cause
+			// false positives via the prefix/middle checks.
+			const fileLines = 'function foo() {\n    let x = 1;\n}\n'.split('\n');
+			const result = tryRemoveDuplicateAdditions(
+				{
+					addedLines: ['    let x = 1;', '    let y = 2;', '}'],
+					removedLines: ['    let x = 1;'],
+					lineNumZeroBased: 1,
+				},
+				fileLines,
+			);
+			expect(result?.kind).toBe('suffix');
+			expect(result?.newAdditions).toEqual(['    let x = 1;', '    let y = 2;']);
+		});
+
+		it('returns undefined for an out-of-range lineNumZeroBased', () => {
+			const fileLines = ['a', 'b'];
+			const result = tryRemoveDuplicateAdditions(
+				{
+					addedLines: ['x'],
+					removedLines: [],
+					lineNumZeroBased: 100,
+				},
+				fileLines,
+			);
+			expect(result).toBeUndefined();
+		});
+	});
+
+	describe('handleResponse with removeDuplicates', () => {
+
+		it('strips trailing duplicate addition when enabled', async () => {
+			const docId = DocumentId.create('file:///test.ts');
+			const docContent = 'function foo() {\n    let x = 1;\n}\n';
+			const documentBeforeEdits = new CurrentDocument(new StringText(docContent), new Position(2, 1));
+
+			async function* makeStream(): AsyncGenerator<string> {
+				yield '/test.ts:1';
+				yield '-    let x = 1;';
+				yield '+    let x = 1;';
+				yield '+    let y = 2;';
+				yield '+}';
+			}
+
+			const { edits } = await consumeHandleResponse(
+				makeStream(),
+				documentBeforeEdits,
+				docId,
+				undefined,
+				undefined,
+				new TestLogService(),
+				/* removeDuplicates */ true,
+			);
+
+			expect(edits).toHaveLength(1);
+			const lineReplacement = edits[0].edit as LineReplacement;
+			expect(lineReplacement.newLines).toEqual(['    let x = 1;', '    let y = 2;']);
+		});
+
+		it('does not strip duplicates when flag is disabled (default)', async () => {
+			const docId = DocumentId.create('file:///test.ts');
+			const docContent = 'function foo() {\n    let x = 1;\n}\n';
+			const documentBeforeEdits = new CurrentDocument(new StringText(docContent), new Position(2, 1));
+
+			async function* makeStream(): AsyncGenerator<string> {
+				yield '/test.ts:1';
+				yield '-    let x = 1;';
+				yield '+    let x = 1;';
+				yield '+    let y = 2;';
+				yield '+}';
+			}
+
+			const { edits } = await consumeHandleResponse(
+				makeStream(),
+				documentBeforeEdits,
+				docId,
+				undefined,
+				undefined,
+				new TestLogService(),
+			);
+
+			expect(edits).toHaveLength(1);
+			const lineReplacement = edits[0].edit as LineReplacement;
+			expect(lineReplacement.newLines).toEqual(['    let x = 1;', '    let y = 2;', '}']);
+		});
+
+		it('drops a patch that becomes empty after dedup and returns FilteredOut', async () => {
+			const docId = DocumentId.create('file:///test.ts');
+			const docContent = 'function foo() {\n    let x = 1;\n    let y = 2;\n}\n';
+			const documentBeforeEdits = new CurrentDocument(new StringText(docContent), new Position(1, 1));
+
+			// Patch adds 'let x = 1;' at line 1 with no removals — but that
+			// line already exists at line 1 (prefix match against a meaningful line).
+			async function* makeStream(): AsyncGenerator<string> {
+				yield '/test.ts:1';
+				yield '+    let x = 1;';
+			}
+
+			const { edits, returnValue } = await consumeHandleResponse(
+				makeStream(),
+				documentBeforeEdits,
+				docId,
+				undefined,
+				undefined,
+				new TestLogService(),
+				/* removeDuplicates */ true,
+			);
+
+			expect(edits).toHaveLength(0);
+			expect(returnValue).toBeInstanceOf(NoNextEditReason.FilteredOut);
+		});
+
+		it('returns NoSuggestions (not FilteredOut) when the model produces no edits at all', async () => {
+			const docId = DocumentId.create('file:///test.ts');
+			const documentBeforeEdits = new CurrentDocument(new StringText('a\nb\n'), new Position(1, 1));
+
+			async function* makeStream(): AsyncGenerator<string> {
+				// no patches
+			}
+
+			const { edits, returnValue } = await consumeHandleResponse(
+				makeStream(),
+				documentBeforeEdits,
+				docId,
+				undefined,
+				undefined,
+				new TestLogService(),
+				/* removeDuplicates */ true,
+			);
+
+			expect(edits).toHaveLength(0);
+			expect(returnValue).toBeInstanceOf(NoNextEditReason.NoSuggestions);
+		});
+
+		it('still returns NoSuggestions if at least one edit was yielded after dedup', async () => {
+			const docId = DocumentId.create('file:///test.ts');
+			const docContent = 'function foo() {\n    let x = 1;\n    let y = 2;\n}\n';
+			const documentBeforeEdits = new CurrentDocument(new StringText(docContent), new Position(2, 1));
+
+			async function* makeStream(): AsyncGenerator<string> {
+				// First patch survives (no duplicate). Second patch adds a
+				// meaningful prefix duplicate of an existing line — drops to no-op.
+				yield '/test.ts:1';
+				yield '-    let x = 1;';
+				yield '+    let z = 99;';
+				yield '/test.ts:2';
+				yield '+    let y = 2;';
+			}
+
+			const { edits, returnValue } = await consumeHandleResponse(
+				makeStream(),
+				documentBeforeEdits,
+				docId,
+				undefined,
+				undefined,
+				new TestLogService(),
+				/* removeDuplicates */ true,
+			);
+
+			expect(edits).toHaveLength(1);
+			// Mixed: one yielded, one dropped — should still report NoSuggestions
+			// since at least one edit was produced.
+			expect(returnValue).toBeInstanceOf(NoNextEditReason.NoSuggestions);
+		});
+
+		it('skips dedup for non-active documents', async () => {
+			const docId = DocumentId.create('file:///active.ts');
+			const docContent = 'a\nb\nc\n';
+			const documentBeforeEdits = new CurrentDocument(new StringText(docContent), new Position(1, 1));
+
+			// Patch targets a different file; the active doc's content must
+			// not be used to dedup against, so the patch should be yielded as-is.
+			async function* makeStream(): AsyncGenerator<string> {
+				yield '/other.ts:0';
+				yield '-old';
+				yield '+a';
+				yield '+b';
+			}
+
+			const { edits } = await consumeHandleResponse(
+				makeStream(),
+				documentBeforeEdits,
+				docId,
+				undefined,
+				undefined,
+				new TestLogService(),
+				/* removeDuplicates */ true,
+			);
+
+			expect(edits).toHaveLength(1);
+			const lineReplacement = edits[0].edit as LineReplacement;
+			expect(lineReplacement.newLines).toEqual(['a', 'b']);
+		});
 	});
 });

--- a/extensions/copilot/src/extension/xtab/test/node/xtabCustomDiffPatchResponseHandler.spec.ts
+++ b/extensions/copilot/src/extension/xtab/test/node/xtabCustomDiffPatchResponseHandler.spec.ts
@@ -17,7 +17,7 @@ import { StringText } from '../../../../util/vs/editor/common/core/text/abstract
 import { ensureDependenciesAreSet } from '../../../../util/vs/editor/common/core/text/positionToOffset';
 import { FetchStreamError } from '../../common/fetchStreamError';
 import { CurrentDocument } from '../../common/xtabCurrentDocument';
-import { DuplicateAdditionRemoval, OnDuplicateRemovedCallback, tryRemoveDuplicateAdditions, XtabCustomDiffPatchResponseHandler } from '../../node/xtabCustomDiffPatchResponseHandler';
+import { DuplicateAdditionRemoval, DuplicateAdditionRemovalSummary, OnDuplicateRemovedCallback, tryRemoveDuplicateAdditions, XtabCustomDiffPatchResponseHandler } from '../../node/xtabCustomDiffPatchResponseHandler';
 
 async function consumeHandleResponse(
 	...args: Parameters<typeof XtabCustomDiffPatchResponseHandler.handleResponse>
@@ -593,8 +593,8 @@ another_file.js:
 				yield '+}';
 			}
 
-			const seen: DuplicateAdditionRemoval[] = [];
-			const onDuplicateRemoved: OnDuplicateRemovedCallback = info => seen.push(info.removal);
+			const seen: DuplicateAdditionRemovalSummary[] = [];
+			const onDuplicateRemoved: OnDuplicateRemovedCallback = info => seen.push(info.summary);
 
 			const { edits } = await consumeHandleResponse(
 				makeStream(),
@@ -611,10 +611,12 @@ another_file.js:
 			// Additions are NOT modified in Log mode — the trailing `}` is kept.
 			const lineReplacement = edits[0].edit as LineReplacement;
 			expect(lineReplacement.newLines).toEqual(['    let x = 1;', '    let y = 2;', '}']);
-			// Detection is reported via the callback.
+			// Detection is reported via the callback. Payload is redacted —
+			// only metadata (kind + counts), no raw line content.
 			expect(seen).toHaveLength(1);
 			expect(seen[0].kind).toBe('suffix');
-			expect(seen[0].removedLines).toEqual(['}']);
+			expect(seen[0].removedLineCount).toBe(1);
+			expect(seen[0].remainingAdditionCount).toBe(2);
 		});
 
 		it('returns NoSuggestions (not FilteredOut) when every patch is dropped by Remove dedup', async () => {
@@ -629,8 +631,8 @@ another_file.js:
 				yield '+    let x = 1;';
 			}
 
-			const seen: DuplicateAdditionRemoval[] = [];
-			const onDuplicateRemoved: OnDuplicateRemovedCallback = info => seen.push(info.removal);
+			const seen: DuplicateAdditionRemovalSummary[] = [];
+			const onDuplicateRemoved: OnDuplicateRemovedCallback = info => seen.push(info.summary);
 
 			const { edits, returnValue } = await consumeHandleResponse(
 				makeStream(),

--- a/extensions/copilot/src/extension/xtab/test/node/xtabCustomDiffPatchResponseHandler.spec.ts
+++ b/extensions/copilot/src/extension/xtab/test/node/xtabCustomDiffPatchResponseHandler.spec.ts
@@ -5,17 +5,19 @@
 
 import { beforeEach, describe, expect, it } from 'vitest';
 import { DocumentId } from '../../../../platform/inlineEdits/common/dataTypes/documentId';
+import { DuplicateAdditionsMode } from '../../../../platform/inlineEdits/common/dataTypes/xtabPromptOptions';
 import { NoNextEditReason, StreamedEdit } from '../../../../platform/inlineEdits/common/statelessNextEditProvider';
 import { TestLogService } from '../../../../platform/testing/common/testLogService';
 import { AsyncIterUtils } from '../../../../util/common/asyncIterableUtils';
 import { AsyncIterableSource } from '../../../../util/vs/base/common/async';
 import { LineReplacement } from '../../../../util/vs/editor/common/core/edits/lineEdit';
 import { Position } from '../../../../util/vs/editor/common/core/position';
+import { LineRange } from '../../../../util/vs/editor/common/core/ranges/lineRange';
 import { StringText } from '../../../../util/vs/editor/common/core/text/abstractText';
 import { ensureDependenciesAreSet } from '../../../../util/vs/editor/common/core/text/positionToOffset';
 import { FetchStreamError } from '../../common/fetchStreamError';
 import { CurrentDocument } from '../../common/xtabCurrentDocument';
-import { tryRemoveDuplicateAdditions, XtabCustomDiffPatchResponseHandler } from '../../node/xtabCustomDiffPatchResponseHandler';
+import { DuplicateAdditionRemoval, OnDuplicateRemovedCallback, tryRemoveDuplicateAdditions, XtabCustomDiffPatchResponseHandler } from '../../node/xtabCustomDiffPatchResponseHandler';
 
 async function consumeHandleResponse(
 	...args: Parameters<typeof XtabCustomDiffPatchResponseHandler.handleResponse>
@@ -29,6 +31,25 @@ async function consumeHandleResponse(
 		}
 		edits.push(result.value);
 	}
+}
+
+/**
+ * Adapts the legacy tuple-shaped patch input used in tests to the new
+ * `LineReplacement` + `AbstractText` API surface of `tryRemoveDuplicateAdditions`.
+ *
+ * Builds a `StringText` from the file lines (joined with `\n`, no synthetic
+ * trailing newline added) so `splitLines` round-trips back to the same array.
+ */
+function callDedup(
+	patch: { addedLines: string[]; removedLines: string[]; lineNumZeroBased: number },
+	fileLines: string[],
+): DuplicateAdditionRemoval | undefined {
+	const text = new StringText(fileLines.join('\n'));
+	const replacement = new LineReplacement(
+		new LineRange(patch.lineNumZeroBased + 1, patch.lineNumZeroBased + 1 + patch.removedLines.length),
+		patch.addedLines,
+	);
+	return tryRemoveDuplicateAdditions(replacement, text);
 }
 
 describe('XtabCustomDiffPatchResponseHandler', () => {
@@ -203,7 +224,7 @@ another_file.js:
 			// Patch replaces line 1 and tries to add `let y = 2;` after it,
 			// but mistakenly re-emits the closing brace.
 			const fileLines = ['function foo() {', '    let x = 1;', '}'];
-			const result = tryRemoveDuplicateAdditions(
+			const result = callDedup(
 				{
 					addedLines: ['    let x = 1;', '    let y = 2;', '}'],
 					removedLines: ['    let x = 1;'],
@@ -220,7 +241,7 @@ another_file.js:
 			const fileLines = ['a', 'b', 'c', 'd', 'e'];
 			// Patch at line 1 replaces `b`. Additions repeat `b`, `c`, `d`.
 			// `c`, `d` are the lines following the deletion and would be duplicated.
-			const result = tryRemoveDuplicateAdditions(
+			const result = callDedup(
 				{
 					addedLines: ['B', 'c', 'd'],
 					removedLines: ['b'],
@@ -239,7 +260,7 @@ another_file.js:
 			// (k=3 only because the whole following matches), but the longest
 			// match wins to remove as much duplication as possible.
 			const fileLines = ['x', 'a', 'b', 'c'];
-			const result = tryRemoveDuplicateAdditions(
+			const result = callDedup(
 				{
 					addedLines: ['new', 'a', 'b', 'c'],
 					removedLines: [],
@@ -260,7 +281,7 @@ another_file.js:
 			//
 			// Patch at line 1 with no removals tries to add `existing line`.
 			const fileLines = ['header', 'existing line', 'trailer'];
-			const result = tryRemoveDuplicateAdditions(
+			const result = callDedup(
 				{
 					addedLines: ['existing line', 'extra'],
 					removedLines: [],
@@ -273,12 +294,13 @@ another_file.js:
 			expect(result?.removedLines).toEqual(['existing line']);
 		});
 
-		it('does not drop a single-character prefix (e.g. inner-scope `}`)', () => {
-			// Model legitimately closes an inner scope with `}`, and the next
-			// line happens to be the outer scope's `}`. This must NOT be
-			// treated as a duplicate.
-			const fileLines = ['function outer() {', '  inner();', '}', '}'];
-			const result = tryRemoveDuplicateAdditions(
+		it('drops a duplicate inner `}` when the patch is purely additive (headline bug fix)', () => {
+			// Headline bug case: file ends with a `}`, model emits an extra
+			// `}` addition with no removals at the same line. Adding it would
+			// produce two adjacent `}` where one is enough — this is a
+			// duplicate of the existing closing token and must be trimmed.
+			const fileLines = ['function f() {', '  doIt();', '}'];
+			const result = callDedup(
 				{
 					addedLines: ['}'],
 					removedLines: [],
@@ -286,12 +308,36 @@ another_file.js:
 				},
 				fileLines,
 			);
-			expect(result).toBeUndefined();
+			expect(result?.kind).toBe('suffix');
+			expect(result?.newAdditions).toEqual([]);
+			expect(result?.removedLines).toEqual(['}']);
+		});
+
+		it('drops a duplicate `}` even when the patch removes content first', () => {
+			// Restructure-shape variant of the headline bug. The previous
+			// guard preserved this case (k===addedLines.length, all
+			// non-meaningful, removedLines>0) on the rationale of "legitimate
+			// inner-scope close". In practice the result still has two
+			// adjacent `}` after applying — that's a duplicate. We always
+			// trim, accepting the rare false positive of a mid-typing
+			// unbalanced file where the model is correctly closing.
+			const fileLines = ['function outer() {', '  body();', '}'];
+			const result = callDedup(
+				{
+					addedLines: ['}'],
+					removedLines: ['  body();'],
+					lineNumZeroBased: 1,
+				},
+				fileLines,
+			);
+			expect(result?.kind).toBe('suffix');
+			expect(result?.newAdditions).toEqual([]);
+			expect(result?.removedLines).toEqual(['}']);
 		});
 
 		it('does not drop a leading whitespace-only duplicate', () => {
 			const fileLines = ['', '', 'existing'];
-			const result = tryRemoveDuplicateAdditions(
+			const result = callDedup(
 				{
 					addedLines: ['', 'first new line'],
 					removedLines: [],
@@ -302,10 +348,14 @@ another_file.js:
 			expect(result).toBeUndefined();
 		});
 
-		it('removes streamEdits-style middle duplicate', () => {
-			// additions partially copy continuation starting at offset 2.
+		it('removes streamEdits-style middle duplicate but preserves new content after the matched range', () => {
+			// Additions partially copy continuation starting at offset 2
+			// ('cont1 long', 'cont2 long' match the file's following lines),
+			// but 'extra' is genuinely new and must be preserved. The middle
+			// shape only drops the verified-equal range — not everything
+			// trailing.
 			const fileLines = ['x', 'cont1 long', 'cont2 long', 'y'];
-			const result = tryRemoveDuplicateAdditions(
+			const result = callDedup(
 				{
 					addedLines: ['new1', 'new2', 'cont1 long', 'cont2 long', 'extra'],
 					removedLines: [],
@@ -314,14 +364,32 @@ another_file.js:
 				fileLines,
 			);
 			expect(result?.kind).toBe('middle');
-			expect(result?.newAdditions).toEqual(['new1', 'new2']);
-			expect(result?.removedLines).toEqual(['cont1 long', 'cont2 long', 'extra']);
+			expect(result?.newAdditions).toEqual(['new1', 'new2', 'extra']);
+			expect(result?.removedLines).toEqual(['cont1 long', 'cont2 long']);
+		});
+
+		it('greedily extends a middle match while the streamEdits regenerated context continues', () => {
+			// When more than two consecutive following lines match, the
+			// match should extend to cover all of them so we drop the
+			// entire regenerated continuation block.
+			const fileLines = ['x', 'cont1 long', 'cont2 long', 'cont3 long', 'y'];
+			const result = callDedup(
+				{
+					addedLines: ['new1', 'new2', 'cont1 long', 'cont2 long', 'cont3 long', 'tail'],
+					removedLines: [],
+					lineNumZeroBased: 1,
+				},
+				fileLines,
+			);
+			expect(result?.kind).toBe('middle');
+			expect(result?.newAdditions).toEqual(['new1', 'new2', 'tail']);
+			expect(result?.removedLines).toEqual(['cont1 long', 'cont2 long', 'cont3 long']);
 		});
 
 		it('does not match a middle pair when the following lines are not meaningful', () => {
 			// Two consecutive blank lines are too common to safely match on.
 			const fileLines = ['x', '', '', 'y'];
-			const result = tryRemoveDuplicateAdditions(
+			const result = callDedup(
 				{
 					addedLines: ['new1', 'new2', '', '', 'extra'],
 					removedLines: [],
@@ -334,7 +402,7 @@ another_file.js:
 
 		it('returns undefined when no duplicate is detected', () => {
 			const fileLines = ['unrelated1', 'unrelated2'];
-			const result = tryRemoveDuplicateAdditions(
+			const result = callDedup(
 				{
 					addedLines: ['new1', 'new2'],
 					removedLines: [],
@@ -347,7 +415,7 @@ another_file.js:
 
 		it('returns undefined when there are no following lines', () => {
 			const fileLines = ['only line'];
-			const result = tryRemoveDuplicateAdditions(
+			const result = callDedup(
 				{
 					addedLines: ['new1'],
 					removedLines: ['only line'],
@@ -360,7 +428,7 @@ another_file.js:
 
 		it('returns undefined when there are no additions', () => {
 			const fileLines = ['a', 'b'];
-			const result = tryRemoveDuplicateAdditions(
+			const result = callDedup(
 				{
 					addedLines: [],
 					removedLines: ['a'],
@@ -374,7 +442,7 @@ another_file.js:
 		it('handles patch at the very end of the file (no following lines)', () => {
 			const fileLines = ['line0', 'line1'];
 			// Replacing the last line with no extra following content.
-			const result = tryRemoveDuplicateAdditions(
+			const result = callDedup(
 				{
 					addedLines: ['new1'],
 					removedLines: ['line1'],
@@ -395,7 +463,7 @@ another_file.js:
 			// The longest-matching suffix is k=2 (matches the 2-line following
 			// `[' }', '}']`), so only those last 2 lines should be removed.
 			const fileLines = ['  }', '}', 'nextLine'];
-			const result = tryRemoveDuplicateAdditions(
+			const result = callDedup(
 				{
 					addedLines: ['  newCode();', '  }', '}', '  }', '}'],
 					removedLines: [],
@@ -412,7 +480,7 @@ another_file.js:
 			// `splitLines('a\\nb\\nc')` returns ['a','b','c'] (no trailing empty).
 			// The dedup must still work correctly against this shape.
 			const fileLines = 'function foo() {\n    let x = 1;\n}'.split('\n');
-			const result = tryRemoveDuplicateAdditions(
+			const result = callDedup(
 				{
 					addedLines: ['    let x = 1;', '    let y = 2;', '}'],
 					removedLines: ['    let x = 1;'],
@@ -429,7 +497,7 @@ another_file.js:
 			// empty string can become a "following" line and must not cause
 			// false positives via the prefix/middle checks.
 			const fileLines = 'function foo() {\n    let x = 1;\n}\n'.split('\n');
-			const result = tryRemoveDuplicateAdditions(
+			const result = callDedup(
 				{
 					addedLines: ['    let x = 1;', '    let y = 2;', '}'],
 					removedLines: ['    let x = 1;'],
@@ -443,7 +511,7 @@ another_file.js:
 
 		it('returns undefined for an out-of-range lineNumZeroBased', () => {
 			const fileLines = ['a', 'b'];
-			const result = tryRemoveDuplicateAdditions(
+			const result = callDedup(
 				{
 					addedLines: ['x'],
 					removedLines: [],
@@ -455,9 +523,9 @@ another_file.js:
 		});
 	});
 
-	describe('handleResponse with removeDuplicates', () => {
+	describe('handleResponse with duplicateAdditionsMode', () => {
 
-		it('strips trailing duplicate addition when enabled', async () => {
+		it('strips trailing duplicate addition in Remove mode', async () => {
 			const docId = DocumentId.create('file:///test.ts');
 			const docContent = 'function foo() {\n    let x = 1;\n}\n';
 			const documentBeforeEdits = new CurrentDocument(new StringText(docContent), new Position(2, 1));
@@ -477,7 +545,7 @@ another_file.js:
 				undefined,
 				undefined,
 				new TestLogService(),
-				/* removeDuplicates */ true,
+				DuplicateAdditionsMode.Remove,
 			);
 
 			expect(edits).toHaveLength(1);
@@ -485,7 +553,7 @@ another_file.js:
 			expect(lineReplacement.newLines).toEqual(['    let x = 1;', '    let y = 2;']);
 		});
 
-		it('does not strip duplicates when flag is disabled (default)', async () => {
+		it('does not strip duplicates in Off mode (default)', async () => {
 			const docId = DocumentId.create('file:///test.ts');
 			const docContent = 'function foo() {\n    let x = 1;\n}\n';
 			const documentBeforeEdits = new CurrentDocument(new StringText(docContent), new Position(2, 1));
@@ -512,7 +580,44 @@ another_file.js:
 			expect(lineReplacement.newLines).toEqual(['    let x = 1;', '    let y = 2;', '}']);
 		});
 
-		it('drops a patch that becomes empty after dedup and returns FilteredOut', async () => {
+		it('Log mode reports detection but does not modify additions', async () => {
+			const docId = DocumentId.create('file:///test.ts');
+			const docContent = 'function foo() {\n    let x = 1;\n}\n';
+			const documentBeforeEdits = new CurrentDocument(new StringText(docContent), new Position(2, 1));
+
+			async function* makeStream(): AsyncGenerator<string> {
+				yield '/test.ts:1';
+				yield '-    let x = 1;';
+				yield '+    let x = 1;';
+				yield '+    let y = 2;';
+				yield '+}';
+			}
+
+			const seen: DuplicateAdditionRemoval[] = [];
+			const onDuplicateRemoved: OnDuplicateRemovedCallback = info => seen.push(info.removal);
+
+			const { edits } = await consumeHandleResponse(
+				makeStream(),
+				documentBeforeEdits,
+				docId,
+				undefined,
+				undefined,
+				new TestLogService(),
+				DuplicateAdditionsMode.Log,
+				onDuplicateRemoved,
+			);
+
+			expect(edits).toHaveLength(1);
+			// Additions are NOT modified in Log mode — the trailing `}` is kept.
+			const lineReplacement = edits[0].edit as LineReplacement;
+			expect(lineReplacement.newLines).toEqual(['    let x = 1;', '    let y = 2;', '}']);
+			// Detection is reported via the callback.
+			expect(seen).toHaveLength(1);
+			expect(seen[0].kind).toBe('suffix');
+			expect(seen[0].removedLines).toEqual(['}']);
+		});
+
+		it('returns NoSuggestions (not FilteredOut) when every patch is dropped by Remove dedup', async () => {
 			const docId = DocumentId.create('file:///test.ts');
 			const docContent = 'function foo() {\n    let x = 1;\n    let y = 2;\n}\n';
 			const documentBeforeEdits = new CurrentDocument(new StringText(docContent), new Position(1, 1));
@@ -524,6 +629,9 @@ another_file.js:
 				yield '+    let x = 1;';
 			}
 
+			const seen: DuplicateAdditionRemoval[] = [];
+			const onDuplicateRemoved: OnDuplicateRemovedCallback = info => seen.push(info.removal);
+
 			const { edits, returnValue } = await consumeHandleResponse(
 				makeStream(),
 				documentBeforeEdits,
@@ -531,14 +639,18 @@ another_file.js:
 				undefined,
 				undefined,
 				new TestLogService(),
-				/* removeDuplicates */ true,
+				DuplicateAdditionsMode.Remove,
+				onDuplicateRemoved,
 			);
 
 			expect(edits).toHaveLength(0);
-			expect(returnValue).toBeInstanceOf(NoNextEditReason.FilteredOut);
+			// No more FilteredOut: cache and cursor-jump retry are preserved.
+			expect(returnValue).toBeInstanceOf(NoNextEditReason.NoSuggestions);
+			// The dedup signal is still observable via the callback.
+			expect(seen).toHaveLength(1);
 		});
 
-		it('returns NoSuggestions (not FilteredOut) when the model produces no edits at all', async () => {
+		it('returns NoSuggestions when the model produces no edits at all', async () => {
 			const docId = DocumentId.create('file:///test.ts');
 			const documentBeforeEdits = new CurrentDocument(new StringText('a\nb\n'), new Position(1, 1));
 
@@ -553,7 +665,7 @@ another_file.js:
 				undefined,
 				undefined,
 				new TestLogService(),
-				/* removeDuplicates */ true,
+				DuplicateAdditionsMode.Remove,
 			);
 
 			expect(edits).toHaveLength(0);
@@ -582,12 +694,10 @@ another_file.js:
 				undefined,
 				undefined,
 				new TestLogService(),
-				/* removeDuplicates */ true,
+				DuplicateAdditionsMode.Remove,
 			);
 
 			expect(edits).toHaveLength(1);
-			// Mixed: one yielded, one dropped — should still report NoSuggestions
-			// since at least one edit was produced.
 			expect(returnValue).toBeInstanceOf(NoNextEditReason.NoSuggestions);
 		});
 
@@ -612,7 +722,7 @@ another_file.js:
 				undefined,
 				undefined,
 				new TestLogService(),
-				/* removeDuplicates */ true,
+				DuplicateAdditionsMode.Remove,
 			);
 
 			expect(edits).toHaveLength(1);

--- a/extensions/copilot/src/extension/xtab/test/node/xtabCustomDiffPatchResponseHandler.spec.ts
+++ b/extensions/copilot/src/extension/xtab/test/node/xtabCustomDiffPatchResponseHandler.spec.ts
@@ -525,7 +525,7 @@ another_file.js:
 
 	describe('handleResponse with duplicateAdditionsMode', () => {
 
-		it('strips trailing duplicate addition in Remove mode', async () => {
+		it('strips trailing duplicate addition in TrimDuplicate mode', async () => {
 			const docId = DocumentId.create('file:///test.ts');
 			const docContent = 'function foo() {\n    let x = 1;\n}\n';
 			const documentBeforeEdits = new CurrentDocument(new StringText(docContent), new Position(2, 1));
@@ -545,7 +545,7 @@ another_file.js:
 				undefined,
 				undefined,
 				new TestLogService(),
-				DuplicateAdditionsMode.Remove,
+				DuplicateAdditionsMode.TrimDuplicate,
 			);
 
 			expect(edits).toHaveLength(1);
@@ -619,7 +619,7 @@ another_file.js:
 			expect(seen[0].remainingAdditionCount).toBe(2);
 		});
 
-		it('returns NoSuggestions (not FilteredOut) when every patch is dropped by Remove dedup', async () => {
+		it('returns NoSuggestions (not FilteredOut) when every patch is dropped by TrimDuplicate dedup', async () => {
 			const docId = DocumentId.create('file:///test.ts');
 			const docContent = 'function foo() {\n    let x = 1;\n    let y = 2;\n}\n';
 			const documentBeforeEdits = new CurrentDocument(new StringText(docContent), new Position(1, 1));
@@ -641,7 +641,7 @@ another_file.js:
 				undefined,
 				undefined,
 				new TestLogService(),
-				DuplicateAdditionsMode.Remove,
+				DuplicateAdditionsMode.TrimDuplicate,
 				onDuplicateRemoved,
 			);
 
@@ -667,7 +667,7 @@ another_file.js:
 				undefined,
 				undefined,
 				new TestLogService(),
-				DuplicateAdditionsMode.Remove,
+				DuplicateAdditionsMode.TrimDuplicate,
 			);
 
 			expect(edits).toHaveLength(0);
@@ -696,7 +696,7 @@ another_file.js:
 				undefined,
 				undefined,
 				new TestLogService(),
-				DuplicateAdditionsMode.Remove,
+				DuplicateAdditionsMode.TrimDuplicate,
 			);
 
 			expect(edits).toHaveLength(1);
@@ -724,12 +724,95 @@ another_file.js:
 				undefined,
 				undefined,
 				new TestLogService(),
-				DuplicateAdditionsMode.Remove,
+				DuplicateAdditionsMode.TrimDuplicate,
 			);
 
 			expect(edits).toHaveLength(1);
 			const lineReplacement = edits[0].edit as LineReplacement;
 			expect(lineReplacement.newLines).toEqual(['a', 'b']);
+		});
+
+		it('DropPatch mode drops the offending patch but continues yielding subsequent patches', async () => {
+			const docId = DocumentId.create('file:///test.ts');
+			const docContent = 'function foo() {\n    let x = 1;\n}\nfunction bar() {\n    let y = 2;\n}\n';
+			const documentBeforeEdits = new CurrentDocument(new StringText(docContent), new Position(2, 1));
+
+			async function* makeStream(): AsyncGenerator<string> {
+				// First patch: duplicates the trailing `}` (suffix shape) — should be dropped.
+				yield '/test.ts:1';
+				yield '-    let x = 1;';
+				yield '+    let x = 1;';
+				yield '+}';
+				// Second patch: legitimate change to a different region — should be yielded.
+				yield '/test.ts:4';
+				yield '-    let y = 2;';
+				yield '+    let y = 42;';
+			}
+
+			const seen: DuplicateAdditionRemovalSummary[] = [];
+			const onDuplicateRemoved: OnDuplicateRemovedCallback = info => seen.push(info.summary);
+
+			const { edits, returnValue } = await consumeHandleResponse(
+				makeStream(),
+				documentBeforeEdits,
+				docId,
+				undefined,
+				undefined,
+				new TestLogService(),
+				DuplicateAdditionsMode.DropPatch,
+				onDuplicateRemoved,
+			);
+
+			expect(edits).toHaveLength(1);
+			const lineReplacement = edits[0].edit as LineReplacement;
+			expect(lineReplacement.newLines).toEqual(['    let y = 42;']);
+			expect(seen).toHaveLength(1);
+			expect(returnValue).toBeInstanceOf(NoNextEditReason.NoSuggestions);
+		});
+
+		it('DropAllRemaining mode drops the offending patch and every subsequent patch', async () => {
+			const docId = DocumentId.create('file:///test.ts');
+			const docContent = 'function foo() {\n    let x = 1;\n}\nfunction bar() {\n    let y = 2;\n}\n';
+			const documentBeforeEdits = new CurrentDocument(new StringText(docContent), new Position(2, 1));
+
+			async function* makeStream(): AsyncGenerator<string> {
+				// First patch: legitimate, yielded as-is.
+				yield '/test.ts:0';
+				yield '-function foo() {';
+				yield '+function fooRenamed() {';
+				// Second patch: duplicates trailing `}` — triggers DropAllRemaining.
+				yield '/test.ts:1';
+				yield '-    let x = 1;';
+				yield '+    let x = 1;';
+				yield '+}';
+				// Third patch: would have been legitimate, but must NOT be yielded.
+				yield '/test.ts:4';
+				yield '-    let y = 2;';
+				yield '+    let y = 42;';
+			}
+
+			const seen: DuplicateAdditionRemovalSummary[] = [];
+			const onDuplicateRemoved: OnDuplicateRemovedCallback = info => seen.push(info.summary);
+
+			const { edits, returnValue } = await consumeHandleResponse(
+				makeStream(),
+				documentBeforeEdits,
+				docId,
+				undefined,
+				undefined,
+				new TestLogService(),
+				DuplicateAdditionsMode.DropAllRemaining,
+				onDuplicateRemoved,
+			);
+
+			// Only the patch yielded before the detection survives. The
+			// triggering patch and every subsequent patch are dropped.
+			expect(edits).toHaveLength(1);
+			const lineReplacement = edits[0].edit as LineReplacement;
+			expect(lineReplacement.newLines).toEqual(['function fooRenamed() {']);
+			// Callback fires exactly once — for the triggering detection.
+			expect(seen).toHaveLength(1);
+			expect(returnValue).toBeInstanceOf(NoNextEditReason.NoSuggestions);
 		});
 	});
 });

--- a/extensions/copilot/src/platform/configuration/common/configurationService.ts
+++ b/extensions/copilot/src/platform/configuration/common/configurationService.ts
@@ -855,6 +855,7 @@ export namespace ConfigKey {
 		export const InlineEditsXtabNeighborFilesMaxTokens = defineTeamInternalSetting<number>('chat.advanced.inlineEdits.xtabProvider.neighborFiles.maxTokens', ConfigType.ExperimentBased, xtabPromptOptions.DEFAULT_OPTIONS.neighborFiles.maxTokens);
 		export const InlineEditsXtabMaxMergeConflictLines = defineTeamInternalSetting<number | undefined>('chat.advanced.inlineEdits.xtabProvider.maxMergeConflictLines', ConfigType.ExperimentBased, undefined);
 		export const InlineEditsXtabOnlyMergeConflictLines = defineTeamInternalSetting<boolean>('chat.advanced.inlineEdits.xtabProvider.onlyMergeConflictLines', ConfigType.ExperimentBased, false);
+		export const InlineEditsXtabRemoveDuplicateAdditionsInDiffPatch = defineTeamInternalSetting<boolean>('chat.advanced.inlineEdits.xtabProvider.diffPatch.removeDuplicateAdditions', ConfigType.ExperimentBased, false);
 		export const InlineEditsXtabAggressivenessLevel = defineTeamInternalSetting<xtabPromptOptions.AggressivenessLevel | undefined>('chat.advanced.inlineEdits.xtabProvider.aggressivenessLevel', ConfigType.ExperimentBased, undefined);
 		export const InlineEditsAggressivenessLowMinResponseTimeMs = defineTeamInternalSetting<number>('chat.advanced.inlineEdits.aggressiveness.lowMinResponseTimeMs', ConfigType.ExperimentBased, 1500);
 		export const InlineEditsAggressivenessMediumMinResponseTimeMs = defineTeamInternalSetting<number>('chat.advanced.inlineEdits.aggressiveness.mediumMinResponseTimeMs', ConfigType.ExperimentBased, 700);

--- a/extensions/copilot/src/platform/configuration/common/configurationService.ts
+++ b/extensions/copilot/src/platform/configuration/common/configurationService.ts
@@ -18,7 +18,7 @@ import { JointCompletionsProviderStrategy, JointCompletionsProviderTriggerChange
 import * as triggerOptions from '../../inlineEdits/common/dataTypes/triggerOptions';
 import * as xtabHistoryOptions from '../../inlineEdits/common/dataTypes/xtabHistoryOptions';
 import * as xtabPromptOptions from '../../inlineEdits/common/dataTypes/xtabPromptOptions';
-import { EarlyDivergenceCancellationMode, LANGUAGE_CONTEXT_ENABLED_LANGUAGES, LanguageContextLanguages, SpeculativeRequestsAutoExpandEditWindowLines, SpeculativeRequestsCursorPlacement, SpeculativeRequestsEnablement } from '../../inlineEdits/common/dataTypes/xtabPromptOptions';
+import { DuplicateAdditionsMode, EarlyDivergenceCancellationMode, LANGUAGE_CONTEXT_ENABLED_LANGUAGES, LanguageContextLanguages, SpeculativeRequestsAutoExpandEditWindowLines, SpeculativeRequestsCursorPlacement, SpeculativeRequestsEnablement } from '../../inlineEdits/common/dataTypes/xtabPromptOptions';
 import { ResponseProcessor } from '../../inlineEdits/common/responseProcessor';
 import { FetcherId } from '../../networking/common/fetcherService';
 import { AlternativeNotebookFormat } from '../../notebook/common/alternativeContentFormat';
@@ -855,7 +855,7 @@ export namespace ConfigKey {
 		export const InlineEditsXtabNeighborFilesMaxTokens = defineTeamInternalSetting<number>('chat.advanced.inlineEdits.xtabProvider.neighborFiles.maxTokens', ConfigType.ExperimentBased, xtabPromptOptions.DEFAULT_OPTIONS.neighborFiles.maxTokens);
 		export const InlineEditsXtabMaxMergeConflictLines = defineTeamInternalSetting<number | undefined>('chat.advanced.inlineEdits.xtabProvider.maxMergeConflictLines', ConfigType.ExperimentBased, undefined);
 		export const InlineEditsXtabOnlyMergeConflictLines = defineTeamInternalSetting<boolean>('chat.advanced.inlineEdits.xtabProvider.onlyMergeConflictLines', ConfigType.ExperimentBased, false);
-		export const InlineEditsXtabRemoveDuplicateAdditionsInDiffPatch = defineTeamInternalSetting<boolean>('chat.advanced.inlineEdits.xtabProvider.diffPatch.removeDuplicateAdditions', ConfigType.ExperimentBased, false);
+		export const InlineEditsXtabDuplicateAdditionsMode = defineTeamInternalSetting<DuplicateAdditionsMode>('chat.advanced.inlineEdits.xtabProvider.diffPatch.duplicateAdditionsMode', ConfigType.ExperimentBased, DuplicateAdditionsMode.Off, DuplicateAdditionsMode.VALIDATOR);
 		export const InlineEditsXtabAggressivenessLevel = defineTeamInternalSetting<xtabPromptOptions.AggressivenessLevel | undefined>('chat.advanced.inlineEdits.xtabProvider.aggressivenessLevel', ConfigType.ExperimentBased, undefined);
 		export const InlineEditsAggressivenessLowMinResponseTimeMs = defineTeamInternalSetting<number>('chat.advanced.inlineEdits.aggressiveness.lowMinResponseTimeMs', ConfigType.ExperimentBased, 1500);
 		export const InlineEditsAggressivenessMediumMinResponseTimeMs = defineTeamInternalSetting<number>('chat.advanced.inlineEdits.aggressiveness.mediumMinResponseTimeMs', ConfigType.ExperimentBased, 700);

--- a/extensions/copilot/src/platform/inlineEdits/common/dataTypes/xtabPromptOptions.ts
+++ b/extensions/copilot/src/platform/inlineEdits/common/dataTypes/xtabPromptOptions.ts
@@ -583,24 +583,42 @@ export namespace SpeculativeRequestsEnablement {
 }
 
 /**
- * How `XtabCustomDiffPatchResponseHandler` should treat detected duplicate
- * additions in diff-patch responses.
+ * What `XtabCustomDiffPatchResponseHandler` should do when the dedup
+ * heuristic detects that a patch's additions duplicate the file content
+ * immediately following the deleted range.
  *
- * - `Off`: do not run dedup at all.
- * - `Log`: run dedup and report each detection (logs + telemetry callback)
- *   but do **not** modify the patch. Lets us measure the heuristic's firing
- *   rate before flipping user-visible behavior.
- * - `Remove`: run dedup, report each detection, **and** apply the trim to
- *   the patch's added lines.
+ * - `Off`: do not run the detector at all.
+ * - `Log`: run the detector and report each detection (tracer + telemetry
+ *   callback) but yield the patch unchanged. Lets us measure the
+ *   heuristic's firing rate before flipping user-visible behavior.
+ * - `DropPatch`: drop just the offending patch and continue processing
+ *   the rest of the stream. Use when we want to suppress individual bad
+ *   patches but trust the rest of the model's output.
+ * - `DropAllRemaining`: drop the offending patch AND every subsequent
+ *   patch from the same response. Use when a duplicate inside the stream
+ *   is treated as a signal that the response has gone off the rails.
+ *   Patches already yielded before the detection are kept.
+ * - `TrimDuplicate`: trim just the duplicated lines from the patch's
+ *   additions and yield the (possibly shorter) patch. If the trim leaves
+ *   the patch with no additions and no removals, the patch is dropped.
+ *   This is the most aggressive about salvaging the model's intent.
  */
 export enum DuplicateAdditionsMode {
 	Off = 'off',
 	Log = 'log',
-	Remove = 'remove',
+	DropPatch = 'dropPatch',
+	DropAllRemaining = 'dropAllRemaining',
+	TrimDuplicate = 'trimDuplicate',
 }
 
 export namespace DuplicateAdditionsMode {
-	export const VALIDATOR = vEnum(DuplicateAdditionsMode.Off, DuplicateAdditionsMode.Log, DuplicateAdditionsMode.Remove);
+	export const VALIDATOR = vEnum(
+		DuplicateAdditionsMode.Off,
+		DuplicateAdditionsMode.Log,
+		DuplicateAdditionsMode.DropPatch,
+		DuplicateAdditionsMode.DropAllRemaining,
+		DuplicateAdditionsMode.TrimDuplicate,
+	);
 }
 
 export enum SpeculativeRequestsCursorPlacement {

--- a/extensions/copilot/src/platform/inlineEdits/common/dataTypes/xtabPromptOptions.ts
+++ b/extensions/copilot/src/platform/inlineEdits/common/dataTypes/xtabPromptOptions.ts
@@ -582,6 +582,27 @@ export namespace SpeculativeRequestsEnablement {
 	export const VALIDATOR = vEnum(SpeculativeRequestsEnablement.On, SpeculativeRequestsEnablement.Off);
 }
 
+/**
+ * How `XtabCustomDiffPatchResponseHandler` should treat detected duplicate
+ * additions in diff-patch responses.
+ *
+ * - `Off`: do not run dedup at all.
+ * - `Log`: run dedup and report each detection (logs + telemetry callback)
+ *   but do **not** modify the patch. Lets us measure the heuristic's firing
+ *   rate before flipping user-visible behavior.
+ * - `Remove`: run dedup, report each detection, **and** apply the trim to
+ *   the patch's added lines.
+ */
+export enum DuplicateAdditionsMode {
+	Off = 'off',
+	Log = 'log',
+	Remove = 'remove',
+}
+
+export namespace DuplicateAdditionsMode {
+	export const VALIDATOR = vEnum(DuplicateAdditionsMode.Off, DuplicateAdditionsMode.Log, DuplicateAdditionsMode.Remove);
+}
+
 export enum SpeculativeRequestsCursorPlacement {
 	AfterEditApplied = 'afterEditApplied',
 	AfterEditWindow = 'afterEditWindow',


### PR DESCRIPTION
Builds the diff-patch-response duplicate-additions heuristic and applies the fixes from the adversarial review of that work, in two commits:

## Commit 1 — `nes(xtab): detect & strip duplicate additions in diff-patch response`

The diff-patch model can occasionally emit additions that copy the lines immediately following the deleted range, which would produce visibly duplicated code (e.g. an extra closing brace). Adds a heuristic that detects three duplication shapes and trims them, gated behind a new team-internal experiment-based setting (default off).

- New helper `tryRemoveDuplicateAdditions` recognizes **suffix**, **prefix**, and **middle** duplications. Only one shape is applied per patch.
- A "meaningful line" guard (`line.trim().length > 1`) protects single-token insertions like `}` / `;` / `)` from being dropped as false positives in the prefix/middle cases.
- `XtabCustomDiffPatchResponseHandler.handleResponse` takes a new flag controlling dedup behavior.

## Commit 2 — `nes(xtab): apply adversarial review fixes to dedup heuristic`

Five fixes from an adversarial review of commit 1:

1. **Headline-bug false negative fixed.** A pure-additive single-`}` patch (`addedLines = ['}']`, `removedLines = []`) duplicating the next line's `}` was previously preserved by an over-zealous "all-non-meaningful suffix" guard. The guard is removed: applying such a patch would insert a stray closing token into already-balanced code, which is precisely the case the dedup was meant to fix. Trade-off: a rare false positive in mid-typing unbalanced files; we optimize for the common balanced case.

2. **Middle-shape collateral fixed.** The previous middle case dropped everything from the matched pair to the end of `addedLines`, even content that wasn't verified as duplicate. Replaced with a greedy extension that drops only the verified-equal range; trailing new content is preserved.

3. **`'off' | 'log' | 'remove'` mode.** The boolean `removeDuplicateAdditions` setting becomes a `DuplicateAdditionsMode` enum so we can ship a measurement phase first to learn the heuristic's firing rate before flipping user-visible behavior. Setting renamed to `chat.advanced.inlineEdits.xtabProvider.diffPatch.duplicateAdditionsMode`.

4. **Operate on canonical types.** `tryRemoveDuplicateAdditions` now takes `LineReplacement` + `AbstractText` instead of raw tuples, matching the surrounding edit-pipeline conventions. The handler builds the `LineReplacement` once and yields a fresh one after trimming — no more in-place mutation of `Patch.addedLines`.

5. **Return `NoSuggestions` even when all patches are dropped.** The prior `FilteredOut("diffPatch:duplicateAdditions:N")` branch bypassed the cache (causing re-fetch) and the cursor-jump retry. The handler now always returns `NoSuggestions` and exposes a per-event `onDuplicateRemoved` callback so callers can wire telemetry without dragging `ITelemetryService` into the parser.

## Deferred follow-ups

- Relocate the dedup as a peer to `IgnoreWhitespaceOnlyChanges` in `streamEditsWithFiltering` (recommendation 4(b) of the review). The function-signature change in this PR captures most of the architectural win; the pipeline relocation is a larger change crossing the parser/filter boundary.

## Validation

- `npm run compile-check-ts-native` (extensions/copilot tsconfig) — clean
- `vitest run xtabCustomDiffPatchResponseHandler.spec.ts` — **35/35 pass** including new tests for the headline-bug fix, the greedy-middle behavior, Log/Remove/Off modes, and the `NoSuggestions`-with-callback contract
- Pre-commit hygiene check passed

The setting defaults to `off`. No user-visible behavior change ships from this PR alone.