### PR TITLE
Enable window commands in Agents window

### DIFF
--- a/src/vs/platform/windows/electron-main/windowsMainService.ts
+++ b/src/vs/platform/windows/electron-main/windowsMainService.ts
@@ -770,7 +770,12 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 
 		let windowToUse: ICodeWindow | undefined;
 		if (!forceNewWindow && typeof openConfig.contextWindowId === 'number') {
-			windowToUse = this.getWindowById(openConfig.contextWindowId); // fix for https://github.com/microsoft/vscode/issues/97172
+			const contextWindow = this.getWindowById(openConfig.contextWindowId); // fix for https://github.com/microsoft/vscode/issues/97172
+			if (contextWindow?.config?.isSessionsWindow) {
+				forceNewWindow = true; // do not replace the agents window
+			} else {
+				windowToUse = contextWindow;
+			}
 		}
 
 		return this.openInBrowserWindow({
@@ -792,7 +797,12 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 		this.logService.trace('windowsManager#doOpenFolderOrWorkspace', { folderOrWorkspace, filesToOpen });
 
 		if (!forceNewWindow && !windowToUse && typeof openConfig.contextWindowId === 'number') {
-			windowToUse = this.getWindowById(openConfig.contextWindowId); // fix for https://github.com/microsoft/vscode/issues/49587
+			const contextWindow = this.getWindowById(openConfig.contextWindowId); // fix for https://github.com/microsoft/vscode/issues/49587
+			if (contextWindow?.config?.isSessionsWindow) {
+				forceNewWindow = true; // do not replace the agents window
+			} else {
+				windowToUse = contextWindow;
+			}
 		}
 
 		return this.openInBrowserWindow({
@@ -1506,7 +1516,7 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 
 		let window: ICodeWindow | undefined;
 		if (!options.forceNewWindow && !options.forceNewTabbedWindow) {
-			window = options.windowToUse || lastActiveWindow;
+			window = options.windowToUse || (lastActiveWindow?.config?.isSessionsWindow ? undefined : lastActiveWindow);
 			if (window) {
 				window.focus();
 			}

--- a/src/vs/workbench/browser/actions/windowActions.ts
+++ b/src/vs/workbench/browser/actions/windowActions.ts
@@ -8,7 +8,7 @@ import { IWindowOpenable } from '../../../platform/window/common/window.js';
 import { IDialogService } from '../../../platform/dialogs/common/dialogs.js';
 import { MenuRegistry, MenuId, Action2, registerAction2 } from '../../../platform/actions/common/actions.js';
 import { KeyChord, KeyCode, KeyMod } from '../../../base/common/keyCodes.js';
-import { IsMainWindowFullscreenContext, IsSessionsWindowContext } from '../../common/contextkeys.js';
+import { IsMainWindowFullscreenContext } from '../../common/contextkeys.js';
 import { IsMacNativeContext, IsDevelopmentContext, IsWebContext, IsIOSContext } from '../../../platform/contextkey/common/contextkeys.js';
 import { Categories } from '../../../platform/action/common/actionCommonCategories.js';
 import { KeybindingsRegistry, KeybindingWeight } from '../../../platform/keybinding/common/keybindingsRegistry.js';
@@ -290,7 +290,6 @@ export class OpenRecentAction extends BaseOpenRecentAction {
 			},
 			category: Categories.File,
 			f1: true,
-			precondition: IsSessionsWindowContext.negate(),
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
 				primary: KeyMod.CtrlCmd | KeyCode.KeyR,
@@ -422,7 +421,6 @@ class NewWindowAction extends Action2 {
 				mnemonicTitle: localize({ key: 'miNewWindow', comment: ['&& denotes a mnemonic'] }, "New &&Window"),
 			},
 			f1: true,
-			precondition: IsSessionsWindowContext.negate(),
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
 				primary: isWeb ? (isWindows ? KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.Shift | KeyCode.KeyN) : KeyMod.CtrlCmd | KeyMod.Alt | KeyMod.Shift | KeyCode.KeyN) : KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyN,
@@ -432,7 +430,6 @@ class NewWindowAction extends Action2 {
 				id: MenuId.MenubarFileMenu,
 				group: '1_new',
 				order: 3,
-				when: IsSessionsWindowContext.negate()
 			}
 		});
 	}
@@ -520,5 +517,4 @@ MenuRegistry.appendMenuItem(MenuId.MenubarFileMenu, {
 	submenu: MenuId.MenubarRecentMenu,
 	group: '2_open',
 	order: 4,
-	when: IsSessionsWindowContext.negate()
 });

--- a/src/vs/workbench/browser/actions/workspaceActions.ts
+++ b/src/vs/workbench/browser/actions/workspaceActions.ts
@@ -61,7 +61,7 @@ export class OpenFolderAction extends Action2 {
 			title: localize2('openFolder', 'Open Folder...'),
 			category: Categories.File,
 			f1: true,
-			precondition: ContextKeyExpr.and(OpenFolderWorkspaceSupportContext, IsSessionsWindowContext.negate()),
+			precondition: OpenFolderWorkspaceSupportContext,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
 				primary: undefined,
@@ -97,7 +97,7 @@ export class OpenFolderViaWorkspaceAction extends Action2 {
 			title: localize2('openFolder', 'Open Folder...'),
 			category: Categories.File,
 			f1: true,
-			precondition: ContextKeyExpr.and(OpenFolderWorkspaceSupportContext.toNegated(), WorkbenchStateContext.isEqualTo('workspace'), IsSessionsWindowContext.negate()),
+			precondition: ContextKeyExpr.and(OpenFolderWorkspaceSupportContext.toNegated(), WorkbenchStateContext.isEqualTo('workspace')),
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
 				primary: KeyMod.CtrlCmd | KeyCode.KeyO
@@ -123,7 +123,7 @@ export class OpenFileFolderAction extends Action2 {
 			title: OpenFileFolderAction.LABEL,
 			category: Categories.File,
 			f1: true,
-			precondition: ContextKeyExpr.and(IsMacNativeContext, OpenFolderWorkspaceSupportContext, IsSessionsWindowContext.negate()),
+			precondition: ContextKeyExpr.and(IsMacNativeContext, OpenFolderWorkspaceSupportContext),
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
 				primary: KeyMod.CtrlCmd | KeyCode.KeyO
@@ -148,7 +148,7 @@ class OpenWorkspaceAction extends Action2 {
 			title: localize2('openWorkspaceAction', 'Open Workspace from File...'),
 			category: Categories.File,
 			f1: true,
-			precondition: ContextKeyExpr.and(EnterMultiRootWorkspaceSupportContext, IsSessionsWindowContext.negate())
+			precondition: EnterMultiRootWorkspaceSupportContext
 		});
 	}
 
@@ -353,7 +353,7 @@ MenuRegistry.appendMenuItem(MenuId.MenubarFileMenu, {
 		title: localize({ key: 'miOpenFolder', comment: ['&& denotes a mnemonic'] }, "Open &&Folder...")
 	},
 	order: 2,
-	when: ContextKeyExpr.and(OpenFolderWorkspaceSupportContext, IsSessionsWindowContext.negate())
+	when: OpenFolderWorkspaceSupportContext
 });
 
 MenuRegistry.appendMenuItem(MenuId.MenubarFileMenu, {
@@ -363,7 +363,7 @@ MenuRegistry.appendMenuItem(MenuId.MenubarFileMenu, {
 		title: localize({ key: 'miOpenFolder', comment: ['&& denotes a mnemonic'] }, "Open &&Folder...")
 	},
 	order: 2,
-	when: ContextKeyExpr.and(OpenFolderWorkspaceSupportContext.toNegated(), WorkbenchStateContext.isEqualTo('workspace'), IsSessionsWindowContext.negate())
+	when: ContextKeyExpr.and(OpenFolderWorkspaceSupportContext.toNegated(), WorkbenchStateContext.isEqualTo('workspace'))
 });
 
 MenuRegistry.appendMenuItem(MenuId.MenubarFileMenu, {
@@ -373,7 +373,7 @@ MenuRegistry.appendMenuItem(MenuId.MenubarFileMenu, {
 		title: localize({ key: 'miOpen', comment: ['&& denotes a mnemonic'] }, "&&Open...")
 	},
 	order: 1,
-	when: ContextKeyExpr.and(IsMacNativeContext, OpenFolderWorkspaceSupportContext, IsSessionsWindowContext.negate())
+	when: ContextKeyExpr.and(IsMacNativeContext, OpenFolderWorkspaceSupportContext)
 });
 
 MenuRegistry.appendMenuItem(MenuId.MenubarFileMenu, {
@@ -383,7 +383,7 @@ MenuRegistry.appendMenuItem(MenuId.MenubarFileMenu, {
 		title: localize({ key: 'miOpenWorkspace', comment: ['&& denotes a mnemonic'] }, "Open Wor&&kspace from File...")
 	},
 	order: 3,
-	when: ContextKeyExpr.and(EnterMultiRootWorkspaceSupportContext, IsSessionsWindowContext.negate())
+	when: EnterMultiRootWorkspaceSupportContext
 });
 
 MenuRegistry.appendMenuItem(MenuId.MenubarFileMenu, {

--- a/src/vs/workbench/contrib/userDataProfile/browser/userDataProfile.ts
+++ b/src/vs/workbench/contrib/userDataProfile/browser/userDataProfile.ts
@@ -203,7 +203,6 @@ export class UserDataProfilesWorkbenchContribution extends Disposable implements
 			submenu: OpenProfileMenu,
 			group: '1_new',
 			order: 4,
-			when: IsSessionsWindowContext.negate()
 		});
 	}
 


### PR DESCRIPTION
This PR enables standard window commands (New Window, Open Folder, Open..., Open Workspace from File, Open Recent, New Window with Profile) in the Agents window.

**Changes:**

1. **Remove `IsSessionsWindowContext` guards** — Removed `precondition` and menu `when` clauses that blocked these commands from appearing/running in the Agents window.

2. **Prevent Agents window from being reused** — In `windowsMainService.ts`, when opening a folder or workspace:
   - `doOpenFolderOrWorkspace` / `doOpenEmpty`: If the context window is an Agents window, force opening in a new window instead of reusing it.
   - `openInBrowserWindow`: Skip the `lastActiveWindow` fallback when it's an Agents window (handles native macOS menu Open Recent items which don't set `contextWindowId`).