### PR TITLE
Add Ctrl+R keybinding for sessions picker in agents window

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
@@ -4,12 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { fromNow } from '../../../../base/common/date.js';
+import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { localize, localize2 } from '../../../../nls.js';
 import { Action2, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { IQuickInputService, IQuickPickItem, IQuickPickSeparator } from '../../../../platform/quickinput/common/quickInput.js';
+import { IsSessionsWindowContext } from '../../../../workbench/common/contextkeys.js';
 import { SessionsCategories } from '../../../common/categories.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ISession } from '../../../services/sessions/common/session.js';
@@ -25,6 +28,12 @@ registerAction2(class ShowSessionsPickerAction extends Action2 {
 			title: localize2('showSessionsPicker', "Show Sessions Picker"),
 			f1: true,
 			category: SessionsCategories.Sessions,
+			keybinding: {
+				primary: KeyMod.CtrlCmd | KeyCode.KeyR,
+				mac: { primary: KeyMod.WinCtrl | KeyCode.KeyR },
+				weight: KeybindingWeight.WorkbenchContrib + 1,
+				when: IsSessionsWindowContext,
+			},
 		});
 	}
 


### PR DESCRIPTION
Bind `Ctrl+R` (`Ctrl+R` on macOS) to the Show Sessions Picker command in the agents window. This overrides the Open Recent workspace picker keybinding so `Ctrl+R` opens the sessions picker instead, scoped via `IsSessionsWindowContext`.