### PR TITLE
issue: indicate agents window in issue reporter body

### DIFF
--- a/src/vs/workbench/contrib/issue/browser/issueReporterModel.ts
+++ b/src/vs/workbench/contrib/issue/browser/issueReporterModel.ts
@@ -45,6 +45,7 @@ export interface IssueReporterData {
 	experimentInfo?: string;
 	restrictedMode?: boolean;
 	isUnsupported?: boolean;
+	isSessionsWindow?: boolean;
 }
 
 export class IssueReporterModel {
@@ -92,7 +93,7 @@ export class IssueReporterModel {
 		}
 		return `
 Type: <b>${this.getIssueTypeTitle()}</b>
-
+${this._data.isSessionsWindow ? '\nWindow: Agents\n' : ''}
 ${this._data.issueDescription}
 ${this.getExtensionVersion()}
 VS Code version: ${this._data.versionInfo && this._data.versionInfo.vscodeVersion}

--- a/src/vs/workbench/contrib/issue/browser/issueService.ts
+++ b/src/vs/workbench/contrib/issue/browser/issueService.ts
@@ -21,6 +21,7 @@ import { IIssueFormService, IssueReporterData, IssueReporterExtensionData, Issue
 import { IWorkbenchAssignmentService } from '../../../services/assignment/common/assignmentService.js';
 import { IAuthenticationService } from '../../../services/authentication/common/authentication.js';
 import { IWorkbenchExtensionEnablementService } from '../../../services/extensionManagement/common/extensionManagement.js';
+import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
 import { IIntegrityService } from '../../../services/integrity/common/integrity.js';
 
@@ -40,7 +41,8 @@ export class BrowserIssueService implements IWorkbenchIssueService {
 		@IWorkbenchExtensionEnablementService private readonly extensionEnablementService: IWorkbenchExtensionEnablementService,
 		@IAuthenticationService private readonly authenticationService: IAuthenticationService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
-		@IOpenerService private readonly openerService: IOpenerService
+		@IOpenerService private readonly openerService: IOpenerService,
+		@IWorkbenchEnvironmentService private readonly environmentService: IWorkbenchEnvironmentService
 	) { }
 
 	async openReporter(options: Partial<IssueReporterData>): Promise<void> {
@@ -133,6 +135,7 @@ export class BrowserIssueService implements IWorkbenchIssueService {
 				experiments: experiments?.join('\n'),
 				restrictedMode: !this.workspaceTrustManagementService.isWorkspaceTrusted(),
 				isUnsupported,
+				isSessionsWindow: this.environmentService.isSessionsWindow,
 				githubAccessToken
 			}, options);
 

--- a/src/vs/workbench/contrib/issue/common/issue.ts
+++ b/src/vs/workbench/contrib/issue/common/issue.ts
@@ -73,6 +73,7 @@ export interface IssueReporterData extends WindowData {
 	experiments?: string;
 	restrictedMode: boolean;
 	isUnsupported: boolean;
+	isSessionsWindow: boolean;
 	githubAccessToken: string;
 	issueTitle?: string;
 	issueBody?: string;

--- a/src/vs/workbench/contrib/issue/electron-browser/issueService.ts
+++ b/src/vs/workbench/contrib/issue/electron-browser/issueService.ts
@@ -16,6 +16,7 @@ import { IIssueFormService, IssueReporterData, IssueReporterExtensionData, Issue
 import { IWorkbenchAssignmentService } from '../../../services/assignment/common/assignmentService.js';
 import { IAuthenticationService } from '../../../services/authentication/common/authentication.js';
 import { IWorkbenchExtensionEnablementService } from '../../../services/extensionManagement/common/extensionManagement.js';
+import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
 import { IIntegrityService } from '../../../services/integrity/common/integrity.js';
 
 export class NativeIssueService implements IWorkbenchIssueService {
@@ -30,6 +31,7 @@ export class NativeIssueService implements IWorkbenchIssueService {
 		@IWorkbenchAssignmentService private readonly experimentService: IWorkbenchAssignmentService,
 		@IAuthenticationService private readonly authenticationService: IAuthenticationService,
 		@IIntegrityService private readonly integrityService: IIntegrityService,
+		@IWorkbenchEnvironmentService private readonly environmentService: IWorkbenchEnvironmentService,
 	) { }
 
 	async openReporter(dataOverrides: Partial<IssueReporterData> = {}): Promise<void> {
@@ -98,6 +100,7 @@ export class NativeIssueService implements IWorkbenchIssueService {
 			experiments: experiments?.join('\n'),
 			restrictedMode: !this.workspaceTrustManagementService.isWorkspaceTrusted(),
 			isUnsupported,
+			isSessionsWindow: this.environmentService.isSessionsWindow,
 			githubAccessToken
 		}, dataOverrides);
 


### PR DESCRIPTION
Fixes - https://github.com/microsoft/vscode/issues/315062

When reporting an issue from the agents window, the generated issue body now includes a `Window: Agents` line right after the issue type. This helps triagers quickly identify that the issue originated from the agents window.

### Changes
- Added `isSessionsWindow` field to `IssueReporterData` interface
- Both `NativeIssueService` and `BrowserIssueService` read `isSessionsWindow` from `IWorkbenchEnvironmentService` and pass it through
- `IssueReporterModel.serialize()` includes `Window: Agents` in the body when the flag is set

### Example output
```
Type: Bug

Window: Agents

<issue description>
VS Code version: ...
```