### PR TITLE
sessions: mark background sessions as unread when turn completes

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsListModelService.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsListModelService.ts
@@ -8,7 +8,7 @@ import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
 import { InstantiationType, registerSingleton } from '../../../../../platform/instantiation/common/extensions.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
-import { ISession } from '../../../../services/sessions/common/session.js';
+import { ISession, SessionStatus } from '../../../../services/sessions/common/session.js';
 import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
 
 export const enum SessionListModelChangeKind {
@@ -61,6 +61,7 @@ export class SessionsListModelService extends Disposable implements ISessionsLis
 
 	private readonly _pinnedSessionIds: Set<string>;
 	private readonly _readSessionIds: Set<string>;
+	private readonly _lastKnownStatus = new Map<string, SessionStatus>();
 
 	constructor(
 		@IStorageService private readonly storageService: IStorageService,
@@ -74,6 +75,29 @@ export class SessionsListModelService extends Disposable implements ISessionsLis
 		this._register(this.sessionsManagementService.onDidChangeSessions(e => {
 			for (const session of e.removed) {
 				this.deleteSession(session);
+			}
+
+			// When a session completes a turn in the background (transitions
+			// from InProgress to a terminal status) mark it as unread so the
+			// sessions list shows the indicator.
+			const activeSessionId = this.sessionsManagementService.activeSession.get()?.sessionId;
+			for (const session of e.changed) {
+				const previous = this._lastKnownStatus.get(session.sessionId);
+				const current = session.status.get();
+				this._lastKnownStatus.set(session.sessionId, current);
+
+				if (
+					previous === SessionStatus.InProgress &&
+					current !== SessionStatus.InProgress &&
+					current !== SessionStatus.Untitled &&
+					session.sessionId !== activeSessionId
+				) {
+					this.markUnread(session);
+				}
+			}
+
+			for (const session of e.added) {
+				this._lastKnownStatus.set(session.sessionId, session.status.get());
 			}
 		}));
 	}
@@ -143,6 +167,7 @@ export class SessionsListModelService extends Disposable implements ISessionsLis
 	// -- Cleanup --
 
 	private deleteSession(session: ISession): void {
+		this._lastKnownStatus.delete(session.sessionId);
 		const changes: { sessionId: string; kind: SessionListModelChangeKind }[] = [];
 		if (this._pinnedSessionIds.delete(session.sessionId)) {
 			this.saveSet(SessionsListModelService.PINNED_SESSIONS_KEY, this._pinnedSessionIds);

--- a/src/vs/sessions/contrib/sessions/test/browser/sessionsListModelService.test.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/sessionsListModelService.test.ts
@@ -6,17 +6,17 @@
 import assert from 'assert';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { Emitter } from '../../../../../base/common/event.js';
-import { observableValue } from '../../../../../base/common/observable.js';
+import { constObservable, ISettableObservable, observableValue } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { IStorageService, InMemoryStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
 import { IChat, ISession, SessionStatus } from '../../../../services/sessions/common/session.js';
-import { ISessionsChangeEvent, ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
+import { IActiveSession, ISessionsChangeEvent, ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
 import { ISessionListModelChangeEvent, SessionListModelChangeKind, SessionsListModelService } from '../../browser/views/sessionsListModelService.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { mock } from '../../../../../base/test/common/mock.js';
 
-function createSession(id: string): ISession {
+function createSession(id: string, status: SessionStatus = SessionStatus.Completed): ISession {
 	return {
 		sessionId: id,
 		resource: URI.parse(`session://${id}`),
@@ -27,7 +27,7 @@ function createSession(id: string): ISession {
 		workspace: observableValue(`workspace-${id}`, undefined),
 		title: observableValue(`title-${id}`, id),
 		updatedAt: observableValue(`updatedAt-${id}`, new Date()),
-		status: observableValue(`status-${id}`, SessionStatus.Completed),
+		status: observableValue(`status-${id}`, status),
 		changesets: observableValue(`changesets-${id}`, []),
 		changes: observableValue(`changes-${id}`, []),
 		modelId: observableValue(`modelId-${id}`, undefined),
@@ -49,14 +49,17 @@ suite('SessionsListModelService', () => {
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 	let service: SessionsListModelService;
 	let sessionsChangedEmitter: Emitter<ISessionsChangeEvent>;
+	let activeSession: ISettableObservable<IActiveSession | undefined>;
 
 	setup(() => {
 		const instantiationService = disposables.add(new TestInstantiationService());
 		instantiationService.stub(IStorageService, disposables.add(new InMemoryStorageService()));
 		sessionsChangedEmitter = disposables.add(new Emitter<ISessionsChangeEvent>());
+		activeSession = observableValue('activeSession', undefined);
 		instantiationService.stub(ISessionsManagementService, {
 			...mock<ISessionsManagementService>(),
 			onDidChangeSessions: sessionsChangedEmitter.event,
+			activeSession,
 		});
 		service = disposables.add(instantiationService.createInstance(SessionsListModelService));
 	});
@@ -291,6 +294,66 @@ suite('SessionsListModelService', () => {
 		assert.strictEqual(service.isSessionPinned(s2), true);
 	});
 
+	test('marks session unread when it transitions from InProgress to Completed in background', () => {
+		const session = createSession('s1', SessionStatus.InProgress);
+		service.markRead(session);
+
+		// Seed the last-known status as InProgress
+		sessionsChangedEmitter.fire({ added: [], removed: [], changed: [session] });
+		assert.strictEqual(service.isSessionRead(session), true);
+
+		// Turn completes while session is not active
+		(session.status as ISettableObservable<SessionStatus>).set(SessionStatus.Completed, undefined);
+		sessionsChangedEmitter.fire({ added: [], removed: [], changed: [session] });
+
+		assert.strictEqual(service.isSessionRead(session), false);
+	});
+
+	test('does not mark active session unread when it transitions from InProgress to Completed', () => {
+		const session = createSession('s1', SessionStatus.InProgress);
+		service.markRead(session);
+
+		// Make session the active one
+		activeSession.set({ ...session, activeChat: constObservable(session.mainChat) }, undefined);
+
+		// Seed the last-known status as InProgress
+		sessionsChangedEmitter.fire({ added: [], removed: [], changed: [session] });
+
+		// Turn completes while session IS active
+		(session.status as ISettableObservable<SessionStatus>).set(SessionStatus.Completed, undefined);
+		sessionsChangedEmitter.fire({ added: [], removed: [], changed: [session] });
+
+		assert.strictEqual(service.isSessionRead(session), true);
+	});
+
+	test('marks session unread when it transitions from InProgress to NeedsInput in background', () => {
+		const session = createSession('s1', SessionStatus.InProgress);
+		service.markRead(session);
+
+		// Seed the last-known status as InProgress
+		sessionsChangedEmitter.fire({ added: [], removed: [], changed: [session] });
+
+		// Session needs input while not active
+		(session.status as ISettableObservable<SessionStatus>).set(SessionStatus.NeedsInput, undefined);
+		sessionsChangedEmitter.fire({ added: [], removed: [], changed: [session] });
+
+		assert.strictEqual(service.isSessionRead(session), false);
+	});
+
+	test('does not mark session unread when status does not change from InProgress', () => {
+		const session = createSession('s1');
+		service.markRead(session);
+
+		let changeCount = 0;
+		disposables.add(service.onDidChange(() => changeCount++));
+
+		// Session was Completed and stays Completed (e.g. title changed)
+		sessionsChangedEmitter.fire({ added: [], removed: [], changed: [session] });
+
+		assert.strictEqual(service.isSessionRead(session), true);
+		assert.strictEqual(changeCount, 0);
+	});
+
 	// -- Storage persistence --
 
 	test('state is loaded from storage on construction', () => {
@@ -302,7 +365,7 @@ suite('SessionsListModelService', () => {
 
 		const instantiationService = disposables.add(new TestInstantiationService());
 		instantiationService.stub(IStorageService, storageService);
-		instantiationService.stub(ISessionsManagementService, { ...mock<ISessionsManagementService>(), onDidChangeSessions: disposables.add(new Emitter<ISessionsChangeEvent>()).event });
+		instantiationService.stub(ISessionsManagementService, { ...mock<ISessionsManagementService>(), onDidChangeSessions: disposables.add(new Emitter<ISessionsChangeEvent>()).event, activeSession: constObservable(undefined) });
 		const loadedService = disposables.add(instantiationService.createInstance(SessionsListModelService));
 
 		assert.strictEqual(loadedService.isSessionPinned(createSession('s1')), true);
@@ -317,7 +380,7 @@ suite('SessionsListModelService', () => {
 
 		const instantiationService = disposables.add(new TestInstantiationService());
 		instantiationService.stub(IStorageService, storageService);
-		instantiationService.stub(ISessionsManagementService, { ...mock<ISessionsManagementService>(), onDidChangeSessions: disposables.add(new Emitter<ISessionsChangeEvent>()).event });
+		instantiationService.stub(ISessionsManagementService, { ...mock<ISessionsManagementService>(), onDidChangeSessions: disposables.add(new Emitter<ISessionsChangeEvent>()).event, activeSession: constObservable(undefined) });
 		const loadedService = disposables.add(instantiationService.createInstance(SessionsListModelService));
 
 		// Should not throw and should return empty state


### PR DESCRIPTION
When a session transitions from InProgress to a terminal status (Completed, NeedsInput, Error) while it is not the active session, mark it as unread in the `SessionsListModelService` so the sessions list sidebar shows the unread indicator.

## Problem

The sessions list sidebar uses `SessionsListModelService` (a simple set-based model) to track read/unread state. Sessions were marked read when opened, but **never marked unread when a background turn completed**. This caused:

- **New sessions** → correctly showed as unread (never in the read set)
- **Existing sessions** → always appeared as read after opening, even when new turns completed in the background

## Fix

Track each session's last-known status in `SessionsListModelService`. When `onDidChangeSessions` fires with a changed session whose status transitioned from `InProgress` to a terminal state (`Completed`, `NeedsInput`, `Error`) and it's **not** the currently active session, call `markUnread()` to remove it from the read set.

Fixes #311985