### PR TITLE
sessions: Move session type objects from shared session.ts to provider

### DIFF
--- a/src/vs/sessions/contrib/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -33,7 +33,7 @@ import { ILanguageModelsService } from '../../../../workbench/contrib/chat/commo
 import { buildMutableConfigSchema, IAgentHostSessionsProvider, resolvedConfigsEqual } from '../../../common/agentHostSessionsProvider.js';
 import { agentHostSessionWorkspaceKey } from '../../../common/agentHostSessionWorkspace.js';
 import { isSessionConfigComplete } from '../../../common/sessionConfig.js';
-import { CopilotCLISessionType, IChat, IGitHubInfo, ISession, ISessionChangeset, ISessionType, ISessionWorkspace, ISessionWorkspaceBrowseAction, sessionFileChangesEqual, SessionStatus, toSessionId } from '../../../services/sessions/common/session.js';
+import { COPILOT_CLI_SESSION_TYPE, IChat, IGitHubInfo, ISession, ISessionChangeset, ISessionType, ISessionWorkspace, ISessionWorkspaceBrowseAction, sessionFileChangesEqual, SessionStatus, toSessionId } from '../../../services/sessions/common/session.js';
 import { ISendRequestOptions, ISessionChangeEvent } from '../../../services/sessions/common/sessionsProvider.js';
 import { computePullRequestIcon } from '../../github/common/types.js';
 import { IGitHubService } from '../../github/browser/githubService.js';
@@ -852,8 +852,8 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 	 * `undefined` when the provider is not recognised.
 	 */
 	private iconForAgentProvider(provider: string): ThemeIcon | undefined {
-		if (provider === CopilotCLISessionType.id) {
-			return CopilotCLISessionType.icon;
+		if (provider === COPILOT_CLI_SESSION_TYPE) {
+			return Codicon.copilot;
 		}
 
 		if (provider.includes('claude')) {

--- a/src/vs/sessions/contrib/codeReview/browser/codeReview.contributions.ts
+++ b/src/vs/sessions/contrib/codeReview/browser/codeReview.contributions.ts
@@ -22,7 +22,7 @@ import { ThemeIcon } from '../../../../base/common/themables.js';
 import { IAgentFeedbackService } from '../../agentFeedback/browser/agentFeedbackService.js';
 import { getSessionEditorComments } from '../../agentFeedback/browser/sessionEditorComments.js';
 import { CodeReviewService, CodeReviewStateKind, getCodeReviewFilesFromSessionChanges, getCodeReviewVersion, ICodeReviewService, MAX_CODE_REVIEWS_PER_SESSION_VERSION, PRReviewStateKind } from './codeReviewService.js';
-import { CopilotCloudSessionType } from '../../../services/sessions/common/session.js';
+import { COPILOT_CLOUD_SESSION_TYPE } from '../../../services/sessions/common/session.js';
 
 registerSingleton(ICodeReviewService, CodeReviewService, InstantiationType.Delayed);
 
@@ -52,7 +52,7 @@ function registerSessionCodeReviewAction(tooltip: string, icon: ThemeIcon): Disp
 						order: 7,
 						when: ContextKeyExpr.and(
 							IsSessionsWindowContext,
-							ChatContextKeys.agentSessionType.notEqualsTo(CopilotCloudSessionType.id),
+							ChatContextKeys.agentSessionType.notEqualsTo(COPILOT_CLOUD_SESSION_TYPE),
 							IsPhoneLayoutContext.negate(),
 						),
 					},

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -23,7 +23,7 @@ import { AgentSessionProviders, AgentSessionTarget } from '../../../../workbench
 import { IChatService, IChatSendRequestOptions } from '../../../../workbench/contrib/chat/common/chatService/chatService.js';
 import { IChatResponseModel } from '../../../../workbench/contrib/chat/common/model/chatModel.js';
 import { ChatSessionStatus, IChatSessionsService, IChatSessionProviderOptionGroup, IChatSessionProviderOptionItem, SessionType } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
-import { ISession, IChat, ISessionRepository, ISessionWorkspace, SessionStatus, GITHUB_REMOTE_FILE_SCHEME, IGitHubInfo, CopilotCLISessionType, CopilotCloudSessionType, ClaudeCodeSessionType, ISessionType, ISessionWorkspaceBrowseAction, ISessionFileChange, sessionFileChangesEqual, toSessionId, SESSION_WORKSPACE_GROUP_LOCAL, ISessionChangeset } from '../../../services/sessions/common/session.js';
+import { ISession, IChat, ISessionRepository, ISessionWorkspace, SessionStatus, GITHUB_REMOTE_FILE_SCHEME, IGitHubInfo, COPILOT_CLI_SESSION_TYPE, COPILOT_CLOUD_SESSION_TYPE, CLAUDE_CODE_SESSION_TYPE, ISessionType, ISessionWorkspaceBrowseAction, ISessionFileChange, sessionFileChangesEqual, toSessionId, SESSION_WORKSPACE_GROUP_LOCAL, ISessionChangeset } from '../../../services/sessions/common/session.js';
 import { ChatAgentLocation, ChatConfiguration, ChatModeKind, ChatPermissionLevel, isChatPermissionLevel } from '../../../../workbench/contrib/chat/common/constants.js';
 import { basename, dirname, isEqual } from '../../../../base/common/resources.js';
 import { ISendRequestOptions, ISessionChangeEvent, ISessionsProvider } from '../../../services/sessions/common/sessionsProvider.js';
@@ -48,6 +48,27 @@ import { computePullRequestIcon, GitHubPullRequestState } from '../../github/com
 
 const SESSION_WORKSPACE_GROUP_GITHUB = localize('sessionWorkspaceGroup.github', "GitHub");
 const STORAGE_KEY_ISOLATION_MODE = 'sessions.isolationPicker.selectedMode';
+
+/** Copilot CLI session type — local background agent running in a Git worktree. */
+const CopilotCLISessionType: ISessionType = {
+	id: COPILOT_CLI_SESSION_TYPE,
+	label: localize('copilotCLI', "Copilot CLI"),
+	icon: Codicon.copilot,
+};
+
+/** Copilot Cloud session type - cloud-hosted agent. */
+const CopilotCloudSessionType: ISessionType = {
+	id: COPILOT_CLOUD_SESSION_TYPE,
+	label: localize('copilotCloud', "Cloud"),
+	icon: Codicon.cloud,
+};
+
+/** Claude Code session type — local agent powered by Claude. */
+const ClaudeCodeSessionType: ISessionType = {
+	id: CLAUDE_CODE_SESSION_TYPE,
+	label: localize('claudeCode', "Claude"),
+	icon: Codicon.claude,
+};
 
 export interface ICopilotChatSession {
 	/** Globally unique session ID (`providerId:localId`). */

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/modePicker.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/modePicker.ts
@@ -21,7 +21,7 @@ import { AICustomizationManagementSection } from '../../../../workbench/contrib/
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
 import { CopilotChatSessionsProvider } from './copilotChatSessionsProvider.js';
-import { CopilotCLISessionType } from '../../../services/sessions/common/session.js';
+import { COPILOT_CLI_SESSION_TYPE } from '../../../services/sessions/common/session.js';
 
 interface IModePickerItem {
 	readonly kind: 'mode';
@@ -65,7 +65,7 @@ export class ModePicker extends Disposable {
 	) {
 		super();
 
-		this._chatModes = this.chatModeService.getModes(CopilotCLISessionType.id);
+		this._chatModes = this.chatModeService.getModes(COPILOT_CLI_SESSION_TYPE);
 
 		this._register(this._chatModes.onDidChange(() => {
 			// Refresh the trigger label when available chat modes change
@@ -118,7 +118,7 @@ export class ModePicker extends Disposable {
 	}
 
 	private _getAvailableModes(): IChatMode[] {
-		const customAgentTarget = this.chatSessionsService.getCustomAgentTargetForSessionType(CopilotCLISessionType.id);
+		const customAgentTarget = this.chatSessionsService.getCustomAgentTargetForSessionType(COPILOT_CLI_SESSION_TYPE);
 		const effectiveTarget = customAgentTarget && customAgentTarget !== Target.Undefined ? customAgentTarget : Target.GitHubCopilot;
 
 		// Always include the default Agent mode

--- a/src/vs/sessions/contrib/copilotChatSessions/test/browser/copilotChatSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/test/browser/copilotChatSessionsProvider.test.ts
@@ -30,7 +30,7 @@ import { IChatResponseModel } from '../../../../../workbench/contrib/chat/common
 import { IChatAgentData } from '../../../../../workbench/contrib/chat/common/participants/chatAgents.js';
 import { IGitService } from '../../../../../workbench/contrib/git/common/gitService.js';
 import { ISessionChangeEvent } from '../../../../services/sessions/common/sessionsProvider.js';
-import { ClaudeCodeSessionType, CopilotCLISessionType, GITHUB_REMOTE_FILE_SCHEME, SessionStatus } from '../../../../services/sessions/common/session.js';
+import { CLAUDE_CODE_SESSION_TYPE, COPILOT_CLI_SESSION_TYPE, GITHUB_REMOTE_FILE_SCHEME, SessionStatus } from '../../../../services/sessions/common/session.js';
 import { CLAUDE_CODE_ENABLED_SETTING, CopilotChatSessionsProvider, COPILOT_PROVIDER_ID } from '../../browser/copilotChatSessionsProvider.js';
 import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
 import { ILabelService } from '../../../../../platform/label/common/label.js';
@@ -285,7 +285,7 @@ suite('CopilotChatSessionsProvider', () => {
 	test('sessionTypes excludes Claude when setting is disabled', () => {
 		const provider = createProvider(disposables, model, { claudeEnabled: false });
 		assert.strictEqual(provider.sessionTypes.length, 2);
-		assert.ok(!provider.sessionTypes.some(t => t.id === ClaudeCodeSessionType.id));
+		assert.ok(!provider.sessionTypes.some(t => t.id === CLAUDE_CODE_SESSION_TYPE));
 	});
 
 	test('onDidChangeSessionTypes fires when claude setting changes', () => {
@@ -343,20 +343,20 @@ suite('CopilotChatSessionsProvider', () => {
 	test('getSessionTypes returns Claude for local workspace when enabled', () => {
 		const provider = createProvider(disposables, model, { claudeEnabled: true });
 		const types = provider.getSessionTypes(URI.file('/test/project'));
-		assert.ok(types.some(t => t.id === ClaudeCodeSessionType.id));
+		assert.ok(types.some(t => t.id === CLAUDE_CODE_SESSION_TYPE));
 	});
 
 	test('getSessionTypes does not return Claude for local workspace when disabled', () => {
 		const provider = createProvider(disposables, model, { claudeEnabled: false });
 		const types = provider.getSessionTypes(URI.file('/test/project'));
-		assert.ok(!types.some(t => t.id === ClaudeCodeSessionType.id));
+		assert.ok(!types.some(t => t.id === CLAUDE_CODE_SESSION_TYPE));
 	});
 
 	test('getSessionTypes returns only Cloud for remote workspace regardless of claude setting', () => {
 		const provider = createProvider(disposables, model, { claudeEnabled: true });
 		const types = provider.getSessionTypes(URI.from({ scheme: GITHUB_REMOTE_FILE_SCHEME, path: '/owner/repo' }));
 		assert.strictEqual(types.length, 1);
-		assert.ok(!types.some(t => t.id === ClaudeCodeSessionType.id));
+		assert.ok(!types.some(t => t.id === CLAUDE_CODE_SESSION_TYPE));
 	});
 
 	// ---- Session listing -------
@@ -943,10 +943,10 @@ suite('CopilotChatSessionsProvider', () => {
 		const { provider, commitSession } = makeClaudeInFlightProvider();
 		const workspace = URI.file('/test/project');
 
-		const session = provider.createNewSession(workspace, ClaudeCodeSessionType.id);
+		const session = provider.createNewSession(workspace, CLAUDE_CODE_SESSION_TYPE);
 
 		assert.ok(session);
-		assert.strictEqual(session.sessionType, ClaudeCodeSessionType.id);
+		assert.strictEqual(session.sessionType, CLAUDE_CODE_SESSION_TYPE);
 		assert.strictEqual(session.status.get(), SessionStatus.Untitled);
 
 		// Send and commit so the session enters the cache and can be disposed
@@ -960,7 +960,7 @@ suite('CopilotChatSessionsProvider', () => {
 	test('archiveSession archives a Claude temp session', async () => {
 		const { provider, cancelRequest } = makeClaudeInFlightProvider();
 		const workspace = URI.file('/test/project');
-		const session = provider.createNewSession(workspace, ClaudeCodeSessionType.id);
+		const session = provider.createNewSession(workspace, CLAUDE_CODE_SESSION_TYPE);
 
 		const added = waitForSessionAdded(provider);
 		const sendPromise = provider.sendAndCreateChat(session.sessionId, { query: 'test' });
@@ -979,7 +979,7 @@ suite('CopilotChatSessionsProvider', () => {
 	test('unarchiveSession unarchives a Claude temp session', async () => {
 		const { provider, cancelRequest } = makeClaudeInFlightProvider();
 		const workspace = URI.file('/test/project');
-		const session = provider.createNewSession(workspace, ClaudeCodeSessionType.id);
+		const session = provider.createNewSession(workspace, CLAUDE_CODE_SESSION_TYPE);
 
 		const added = waitForSessionAdded(provider);
 		const sendPromise = provider.sendAndCreateChat(session.sessionId, { query: 'test' });
@@ -1003,7 +1003,7 @@ suite('CopilotChatSessionsProvider', () => {
 	test('sendAndCreateChat replaces temp session with committed session on success', async () => {
 		const { provider, commitSession } = makeClaudeInFlightProvider();
 		const workspace = URI.file('/test/project');
-		const session = provider.createNewSession(workspace, ClaudeCodeSessionType.id);
+		const session = provider.createNewSession(workspace, CLAUDE_CODE_SESSION_TYPE);
 
 		const replacements: { from: unknown; to: unknown }[] = [];
 		disposables.add(provider.onDidReplaceSession(e => replacements.push(e)));
@@ -1025,7 +1025,7 @@ suite('CopilotChatSessionsProvider', () => {
 	test('sendAndCreateChat uses the query as the temp session title', async () => {
 		const { provider, cancelRequest } = makeClaudeInFlightProvider();
 		const workspace = URI.file('/test/project');
-		const session = provider.createNewSession(workspace, ClaudeCodeSessionType.id);
+		const session = provider.createNewSession(workspace, CLAUDE_CODE_SESSION_TYPE);
 
 		const added = waitForSessionAdded(provider);
 		const sendPromise = provider.sendAndCreateChat(session.sessionId, { query: 'fix the login bug' });
@@ -1042,7 +1042,7 @@ suite('CopilotChatSessionsProvider', () => {
 	test('sendAndCreateChat keeps temp session on cancellation', async () => {
 		const { provider, cancelRequest } = makeClaudeInFlightProvider();
 		const workspace = URI.file('/test/project');
-		const session = provider.createNewSession(workspace, ClaudeCodeSessionType.id);
+		const session = provider.createNewSession(workspace, CLAUDE_CODE_SESSION_TYPE);
 
 		const added = waitForSessionAdded(provider);
 		const sendPromise = provider.sendAndCreateChat(session.sessionId, { query: 'test' });
@@ -1137,7 +1137,7 @@ suite('CopilotChatSessionsProvider', () => {
 		test('deleteSession removes a temp session that is awaiting commit', async () => {
 			const { provider, cancelRequest } = makeInFlightProvider();
 
-			const newSession = provider.createNewSession(workspace, CopilotCLISessionType.id);
+			const newSession = provider.createNewSession(workspace, COPILOT_CLI_SESSION_TYPE);
 			const sessionId = newSession.sessionId;
 
 			const added = waitForSessionAdded(provider);
@@ -1157,7 +1157,7 @@ suite('CopilotChatSessionsProvider', () => {
 		test('archiveSession archives a temp session that is awaiting commit', async () => {
 			const { provider, cancelRequest } = makeInFlightProvider();
 
-			const newSession = provider.createNewSession(workspace, CopilotCLISessionType.id);
+			const newSession = provider.createNewSession(workspace, COPILOT_CLI_SESSION_TYPE);
 			const sessionId = newSession.sessionId;
 
 			const added = waitForSessionAdded(provider);
@@ -1181,7 +1181,7 @@ suite('CopilotChatSessionsProvider', () => {
 		test('archiveSession archives a stopped session that was never committed', async () => {
 			const { provider, cancelRequest } = makeInFlightProvider();
 
-			const newSession = provider.createNewSession(workspace, CopilotCLISessionType.id);
+			const newSession = provider.createNewSession(workspace, COPILOT_CLI_SESSION_TYPE);
 			const sessionId = newSession.sessionId;
 
 			const added = waitForSessionAdded(provider);
@@ -1247,7 +1247,7 @@ suite('CopilotChatSessionsProvider', () => {
 		test('stopping a committed session keeps it in the list', async () => {
 			const { provider, commitSession, cancelRequest } = makeCommittableProvider();
 
-			const newSession = provider.createNewSession(workspace, CopilotCLISessionType.id);
+			const newSession = provider.createNewSession(workspace, COPILOT_CLI_SESSION_TYPE);
 			const sessionId = newSession.sessionId;
 
 			const added = waitForSessionAdded(provider);
@@ -1284,7 +1284,7 @@ suite('CopilotChatSessionsProvider', () => {
 			const changes: ISessionChangeEvent[] = [];
 			disposables.add(provider.onDidChangeSessions(e => changes.push(e)));
 
-			const newSession = provider.createNewSession(workspace, CopilotCLISessionType.id);
+			const newSession = provider.createNewSession(workspace, COPILOT_CLI_SESSION_TYPE);
 			const sessionId = newSession.sessionId;
 
 			const added = waitForSessionAdded(provider);

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -33,7 +33,7 @@ import { WorkbenchObjectTree } from '../../../../../platform/list/browser/listSe
 import { IStyleOverride, defaultButtonStyles, defaultFindWidgetStyles, defaultToggleStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
 import { asCssVariable } from '../../../../../platform/theme/common/colorUtils.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
-import { CopilotCLISessionType, GITHUB_REMOTE_FILE_SCHEME, ISession, ISessionWorkspace, SessionStatus } from '../../../../services/sessions/common/session.js';
+import { COPILOT_CLI_SESSION_TYPE, GITHUB_REMOTE_FILE_SCHEME, ISession, ISessionWorkspace, SessionStatus } from '../../../../services/sessions/common/session.js';
 import { AgentSessionApprovalModel, IAgentSessionApprovalInfo } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentSessionApprovalModel.js';
 import { Button } from '../../../../../base/browser/ui/button/button.js';
 import { IMarkdownRendererService } from '../../../../../platform/markdown/browser/markdownRenderer.js';
@@ -337,12 +337,12 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 
 			// Session type icon in details row
 			// Disabling background icon - hacky but couldn't figure out how to do it from the new provider
-			if (element.sessionType !== CopilotCLISessionType.id) {
+			if (element.sessionType !== COPILOT_CLI_SESSION_TYPE) {
 				const typeIconEl = DOM.append(template.detailsRow, $('span.session-details-icon'));
 				DOM.append(typeIconEl, $(`span${ThemeIcon.asCSSSelector(element.icon)}`));
 				parts.push(typeIconEl);
 			} else if (
-				element.sessionType === CopilotCLISessionType.id &&
+				element.sessionType === COPILOT_CLI_SESSION_TYPE &&
 				sessionStatus !== SessionStatus.InProgress
 			) {
 				const icon = isWorkspaceSession ? Codicon.folder : Codicon.worktree;

--- a/src/vs/sessions/services/sessions/common/session.ts
+++ b/src/vs/sessions/services/sessions/common/session.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { CancellationToken } from '../../../../base/common/cancellation.js';
-import { Codicon } from '../../../../base/common/codicons.js';
 import { IMarkdownString } from '../../../../base/common/htmlContent.js';
 import { IObservable } from '../../../../base/common/observable.js';
 import { isEqual } from '../../../../base/common/resources.js';
@@ -28,29 +27,8 @@ export const COPILOT_CLI_SESSION_TYPE = 'copilotcli';
 /** Session type ID for Copilot Cloud sessions. */
 export const COPILOT_CLOUD_SESSION_TYPE = 'copilot-cloud-agent';
 
-/** Copilot CLI session type — local background agent running in a Git worktree. */
-export const CopilotCLISessionType: ISessionType = {
-	id: COPILOT_CLI_SESSION_TYPE,
-	label: localize('copilotCLI', "Copilot CLI"),
-	icon: Codicon.copilot,
-};
-
-/** Copilot Cloud session type - cloud-hosted agent. */
-export const CopilotCloudSessionType: ISessionType = {
-	id: COPILOT_CLOUD_SESSION_TYPE,
-	label: localize('copilotCloud', "Cloud"),
-	icon: Codicon.cloud,
-};
-
 /** Session type ID for Claude Code sessions. */
 export const CLAUDE_CODE_SESSION_TYPE = 'claude-code';
-
-/** Claude Code session type — local agent powered by Claude. */
-export const ClaudeCodeSessionType: ISessionType = {
-	id: CLAUDE_CODE_SESSION_TYPE,
-	label: localize('claudeCode', "Claude"),
-	icon: Codicon.claude,
-};
 
 /**
  * Returns whether the given session type represents a workspace-backed


### PR DESCRIPTION
Move `CopilotCLISessionType`, `CopilotCloudSessionType`, and `ClaudeCodeSessionType` `ISessionType` objects out of the shared session model (`session.ts`) into `copilotChatSessionsProvider.ts` where they belong.

The shared layer keeps only:
- The string ID constants (`COPILOT_CLI_SESSION_TYPE`, `COPILOT_CLOUD_SESSION_TYPE`, `CLAUDE_CODE_SESSION_TYPE`)
- The `ISessionType` interface

All other consumers now reference the ID constants directly instead of importing the full session type objects just to access `.id`.