### PR TITLE
Use SVG icon instead of codicon in Open in Agents titlebar widget

### DIFF
--- a/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts
@@ -104,7 +104,7 @@ class OpenWorkspaceInAgentsTitleBarWidget extends BaseActionViewItem {
 		container.setAttribute('aria-label', hoverText);
 		this._register(this.hoverService.setupManagedHover(getDefaultHoverDelegate('element'), container, hoverText));
 
-		const icon = append(container, $('span.open-in-agents-titlebar-widget-icon.codicon.codicon-agent'));
+		const icon = append(container, $('span.open-in-agents-titlebar-widget-icon'));
 		icon.setAttribute('aria-hidden', 'true');
 
 		const labelEl = append(container, $('span.open-in-agents-titlebar-widget-label'));

--- a/src/vs/workbench/contrib/chat/electron-browser/agentSessions/media/openInAgents.css
+++ b/src/vs/workbench/contrib/chat/electron-browser/agentSessions/media/openInAgents.css
@@ -34,10 +34,26 @@
 	width: 16px;
 	height: 16px;
 	flex: 0 0 auto;
-	font-size: 16px;
-	display: flex;
-	align-items: center;
-	justify-content: center;
+	background-image: url('../../../../../../sessions/browser/media/sessions-icon.svg');
+	background-repeat: no-repeat;
+	background-position: center center;
+	background-size: contain;
+	filter: grayscale(1);
+}
+
+.monaco-enable-motion .monaco-workbench .open-in-agents-titlebar-widget > .open-in-agents-titlebar-widget-icon,
+.monaco-workbench.monaco-enable-motion .open-in-agents-titlebar-widget > .open-in-agents-titlebar-widget-icon {
+	transition: filter 160ms ease;
+}
+
+.monaco-reduce-motion .monaco-workbench .open-in-agents-titlebar-widget > .open-in-agents-titlebar-widget-icon,
+.monaco-workbench.monaco-reduce-motion .open-in-agents-titlebar-widget > .open-in-agents-titlebar-widget-icon {
+	transition-duration: 0ms !important;
+}
+
+.monaco-workbench .open-in-agents-titlebar-widget:hover > .open-in-agents-titlebar-widget-icon,
+.monaco-workbench .open-in-agents-titlebar-widget:focus-visible > .open-in-agents-titlebar-widget-icon {
+	filter: none;
 }
 
 


### PR DESCRIPTION
Reverts the agents widget icon from `codicon-agent` back to the `sessions-icon.svg` background image with grayscale filter, matching the pattern used by the Open in VS Code widget.