### PR TITLE
Replace "Agents app" with "Agents window" in user-facing strings

### DIFF
--- a/src/vs/platform/windows/electron-main/windowsMainService.ts
+++ b/src/vs/platform/windows/electron-main/windowsMainService.ts
@@ -765,28 +765,31 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 		return window;
 	}
 
+	private resolveContextWindow(openConfig: IOpenConfiguration, forceNewWindow: boolean): { windowToUse: ICodeWindow | undefined; forceNewWindow: boolean } {
+		if (!forceNewWindow && typeof openConfig.contextWindowId === 'number') {
+			const contextWindow = this.getWindowById(openConfig.contextWindowId);
+			if (contextWindow?.config?.isSessionsWindow) {
+				return { windowToUse: undefined, forceNewWindow: true }; // do not replace the agents window
+			}
+			return { windowToUse: contextWindow, forceNewWindow };
+		}
+		return { windowToUse: undefined, forceNewWindow };
+	}
+
 	private doOpenEmpty(openConfig: IOpenConfiguration, forceNewWindow: boolean, remoteAuthority: string | undefined, filesToOpen: IFilesToOpen | undefined, emptyWindowBackupInfo?: IEmptyWindowBackupInfo): Promise<ICodeWindow> {
 		this.logService.trace('windowsManager#doOpenEmpty', { restore: !!emptyWindowBackupInfo, remoteAuthority, filesToOpen, forceNewWindow });
 
-		let windowToUse: ICodeWindow | undefined;
-		if (!forceNewWindow && typeof openConfig.contextWindowId === 'number') {
-			const contextWindow = this.getWindowById(openConfig.contextWindowId); // fix for https://github.com/microsoft/vscode/issues/97172
-			if (contextWindow?.config?.isSessionsWindow) {
-				forceNewWindow = true; // do not replace the agents window
-			} else {
-				windowToUse = contextWindow;
-			}
-		}
+		const resolved = this.resolveContextWindow(openConfig, forceNewWindow);
 
 		return this.openInBrowserWindow({
 			userEnv: openConfig.userEnv,
 			cli: openConfig.cli,
 			initialStartup: openConfig.initialStartup,
 			remoteAuthority,
-			forceNewWindow,
+			forceNewWindow: resolved.forceNewWindow,
 			forceNewTabbedWindow: openConfig.forceNewTabbedWindow,
 			filesToOpen,
-			windowToUse,
+			windowToUse: resolved.windowToUse,
 			emptyWindowBackupInfo,
 			forceProfile: openConfig.forceProfile,
 			forceTempProfile: openConfig.forceTempProfile
@@ -796,13 +799,10 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 	private doOpenFolderOrWorkspace(openConfig: IOpenConfiguration, folderOrWorkspace: IWorkspacePathToOpen | ISingleFolderWorkspacePathToOpen, forceNewWindow: boolean, filesToOpen: IFilesToOpen | undefined, windowToUse?: ICodeWindow): Promise<ICodeWindow> {
 		this.logService.trace('windowsManager#doOpenFolderOrWorkspace', { folderOrWorkspace, filesToOpen });
 
-		if (!forceNewWindow && !windowToUse && typeof openConfig.contextWindowId === 'number') {
-			const contextWindow = this.getWindowById(openConfig.contextWindowId); // fix for https://github.com/microsoft/vscode/issues/49587
-			if (contextWindow?.config?.isSessionsWindow) {
-				forceNewWindow = true; // do not replace the agents window
-			} else {
-				windowToUse = contextWindow;
-			}
+		if (!windowToUse) {
+			const resolved = this.resolveContextWindow(openConfig, forceNewWindow);
+			windowToUse = resolved.windowToUse;
+			forceNewWindow = resolved.forceNewWindow;
 		}
 
 		return this.openInBrowserWindow({

--- a/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
+++ b/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
@@ -110,8 +110,8 @@ registerAction2(class extends Action2 {
 		const accountLabel = defaultAccount.accountName;
 		const { confirmed } = await dialogService.confirm({
 			type: Severity.Info,
-			message: localize('agenticSignOutMessage', "Sign out of the Agents app?"),
-			detail: localize('agenticSignOutDetail', "This will sign out '{0}' from the Agents app.", accountLabel),
+			message: localize('agenticSignOutMessage', "Sign out of the Agents window?"),
+			detail: localize('agenticSignOutDetail', "This will sign out '{0}' from the Agents window.", accountLabel),
 			primaryButton: localize({ key: 'agenticSignOutButton', comment: ['&& denotes a mnemonic'] }, "&&Sign Out")
 		});
 

--- a/src/vs/sessions/contrib/aquarium/browser/aquarium.contribution.ts
+++ b/src/vs/sessions/contrib/aquarium/browser/aquarium.contribution.ts
@@ -17,7 +17,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 		[SESSIONS_DEVELOPER_JOY_ENABLED_SETTING]: {
 			type: 'boolean',
 			default: product.quality !== 'stable',
-			description: localize('sessions.developerJoy.enabled', "Adds an easter egg to the Agents application."),
+			description: localize('sessions.developerJoy.enabled', "Adds an easter egg to the Agents window."),
 			tags: ['experimental'],
 		},
 	},

--- a/src/vs/sessions/contrib/chat/browser/sessionsChatAccessibilityHelp.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionsChatAccessibilityHelp.ts
@@ -23,7 +23,7 @@ export class SessionsChatAccessibilityHelp implements IAccessibleViewImplementat
 		const viewsService = accessor.get(IViewsService);
 
 		const content: string[] = [];
-		content.push(localize('sessionsChat.overview', "You are in the Agents app. The Agents app is a dedicated workspace for working with AI agents. It provides a chat interface, a changes view for reviewing agent-generated changes, a file explorer, and customization options."));
+		content.push(localize('sessionsChat.overview', "You are in the Agents window. The Agents window is a dedicated workspace for working with AI agents. It provides a chat interface, a changes view for reviewing agent-generated changes, a file explorer, and customization options."));
 		content.push(localize('sessionsChat.input', "You are in the chat input. Type a message and press Enter to send it."));
 		content.push(localize('sessionsChat.workspace', "Shift+Tab to navigate to the workspace picker and choose a workspace for your session."));
 		content.push(localize('sessionsChat.mobileConfig', "On mobile, the mode and model pickers appear as tappable chips below the input. Tap a chip to open a bottom sheet where you can change the selection."));

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessions.contribution.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessions.contribution.ts
@@ -26,7 +26,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			type: 'boolean',
 			default: true,
 			experiment: { mode: 'startup' },
-			description: localize('sessions.chat.claudeAgent.enabled', "Enable Claude Agent sessions in the Agents app. Start and resume agentic coding sessions powered by Anthropic's Claude Agent SDK directly. Uses your existing Copilot subscription."),
+			description: localize('sessions.chat.claudeAgent.enabled', "Enable Claude Agent sessions in the Agents window. Start and resume agentic coding sessions powered by Anthropic's Claude Agent SDK directly. Uses your existing Copilot subscription."),
 		},
 	},
 });

--- a/src/vs/workbench/contrib/accessibility/browser/accessibilityConfiguration.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibilityConfiguration.ts
@@ -208,7 +208,7 @@ const configuration: IConfigurationNode = {
 			...baseVerbosityProperty
 		},
 		[AccessibilityVerbositySettingId.SessionsChat]: {
-			description: localize('verbosity.sessionsChat', 'Provide information about how to access the Agents app accessibility help menu when the chat input is focused.'),
+			description: localize('verbosity.sessionsChat', 'Provide information about how to access the Agents window accessibility help menu when the chat input is focused.'),
 			...baseVerbosityProperty
 		},
 		[AccessibilityVerbositySettingId.ChatQuestionCarousel]: {


### PR DESCRIPTION
Fixes #315270

Replace all user-facing occurrences of "Agents app" / "Agents application" with "Agents window" for consistent naming.

### Changes
- **account.contribution.ts** — Sign out dialog message & detail
- **aquarium.contribution.ts** — Easter egg setting description
- **sessionsChatAccessibilityHelp.ts** — Accessibility overview text
- **copilotChatSessions.contribution.ts** — Claude Agent setting description
- **accessibilityConfiguration.ts** — Verbosity setting description
- **windowsMainService.ts** — Extract `resolveContextWindow` helper to deduplicate context window resolution logic in `doOpenEmpty` and `doOpenFolderOrWorkspace`