### PR TITLE
sessions: restore last active session on reload

### DIFF
--- a/src/vs/sessions/browser/workbench.ts
+++ b/src/vs/sessions/browser/workbench.ts
@@ -844,6 +844,9 @@ export class Workbench extends Disposable implements IAgentWorkbenchLayoutServic
 		// Restore parts (open default view containers)
 		this.restoreParts();
 
+		// Restore the last active session (progress is shown inside the service).
+		this.sessionsManagementService.restoreLastActiveSession();
+
 		// Set lifecycle phase to `Restored`
 		lifecycleService.phase = LifecyclePhase.Restored;
 

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -4,14 +4,16 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Emitter, Event } from '../../../../base/common/event.js';
-import { Disposable, DisposableMap, DisposableStore, IDisposable } from '../../../../base/common/lifecycle.js';
+import { CancellationToken, CancellationTokenSource } from '../../../../base/common/cancellation.js';
+import { Disposable, DisposableMap, DisposableStore, IDisposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { ResourceMap } from '../../../../base/common/map.js';
 import { IObservable, ISettableObservable, autorun, observableValue } from '../../../../base/common/observable.js';
 import { URI } from '../../../../base/common/uri.js';
 import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
-import { ChatViewPaneTarget, IChatWidgetService } from '../../../../workbench/contrib/chat/browser/chat.js';
+import { ChatViewId, ChatViewPaneTarget, IChatWidgetService } from '../../../../workbench/contrib/chat/browser/chat.js';
+import { IProgressService } from '../../../../platform/progress/common/progress.js';
 import { IAgentSessionsService } from '../../../../workbench/contrib/chat/browser/agentSessions/agentSessionsService.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
 import { ActiveSessionProviderIdContext, ActiveSessionTypeContext, IsActiveSessionArchivedContext, IsActiveSessionBackgroundProviderContext, IsNewChatInSessionContext, IsNewChatSessionContext } from '../../../common/contextkeys.js';
@@ -62,6 +64,9 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 	private readonly _isActiveSessionArchived: IContextKey<boolean>;
 	private readonly _supportsMultiChat: IContextKey<boolean>;
 	private _activeChatObservable: ISettableObservable<IChat> | undefined;
+	/** Cancelled on every navigation action so in-flight async opens bail out. */
+	private readonly _openSessionCts = this._register(new MutableDisposable<CancellationTokenSource>());
+	private readonly _onDidOpenNewSessionView = this._register(new Emitter<void>());
 	private _activeSessionDisposables = this._register(new DisposableStore());
 	private readonly _providerListeners = this._register(new DisposableMap<string, IDisposable>());
 	private readonly _sessionStates: ResourceMap<ISessionState>;
@@ -74,6 +79,7 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
 		@IChatWidgetService private readonly chatWidgetService: IChatWidgetService,
 		@IAgentSessionsService private readonly agentSessionsService: IAgentSessionsService,
+		@IProgressService private readonly progressService: IProgressService,
 	) {
 		super();
 
@@ -203,8 +209,19 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 		}
 	}
 
+	/**
+	 * Cancel any in-flight open-session/restore and return a fresh cancellation token.
+	 */
+	private _startOpenSession() {
+		this._openSessionCts.value?.cancel();
+		const cts = new CancellationTokenSource();
+		this._openSessionCts.value = cts;
+		return cts.token;
+	}
+
 	async openChat(session: ISession, chatUri: URI): Promise<void> {
 		const t0 = Date.now();
+		const token = this._startOpenSession();
 		this.logService.trace(`[SessionsManagement] openChat start uri=${chatUri.toString()} provider=${session.providerId}`);
 		this.isNewChatSessionContext.set(false);
 		this.setActiveSession(session);
@@ -229,11 +246,24 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 		}
 
 		this._isNewChatInSessionContext.set(false);
-		await this.chatWidgetService.openSession(chatUri, ChatViewPaneTarget);
+		try {
+			await this.chatWidgetService.openSession(chatUri, ChatViewPaneTarget);
+		} catch (e) {
+			if (token.isCancellationRequested) {
+				this.logService.trace('[SessionsManagement] openChat: suppressed error because user navigated away');
+				return;
+			}
+			throw e;
+		}
 		this.logService.trace(`[SessionsManagement] openChat done total=${Date.now() - t0}ms uri=${chatUri.toString()}`);
 	}
 
 	async openSession(sessionResource: URI, options?: { preserveFocus?: boolean }): Promise<void> {
+		const token = this._startOpenSession();
+		await this._doOpenSession(sessionResource, token, options);
+	}
+
+	private async _doOpenSession(sessionResource: URI, token: CancellationToken, options?: { preserveFocus?: boolean }): Promise<void> {
 		const t0 = Date.now();
 		const sessionData = this.getSession(sessionResource);
 		if (!sessionData) {
@@ -248,7 +278,15 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 		// Open the active chat (which may have been restored to the last active chat)
 		const activeChat = this._activeSession.get()?.activeChat.get();
 		const openUri = activeChat?.resource ?? sessionData.resource;
-		await this.chatWidgetService.openSession(openUri, ChatViewPaneTarget, { preserveFocus: options?.preserveFocus });
+		try {
+			await this.chatWidgetService.openSession(openUri, ChatViewPaneTarget, { preserveFocus: options?.preserveFocus });
+		} catch (e) {
+			if (token.isCancellationRequested) {
+				this.logService.trace('[SessionsManagement] openSession: suppressed error because user navigated away');
+				return;
+			}
+			throw e;
+		}
 		this.logService.trace(`[SessionsManagement] openSession done total=${Date.now() - t0}ms uri=${sessionResource.toString()}`);
 	}
 
@@ -258,6 +296,7 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 	}
 
 	createNewSession(providerId: string, repositoryUri: URI, sessionTypeId?: string): ISession {
+		this._startOpenSession();
 		if (!this.isNewChatSessionContext.get()) {
 			this.isNewChatSessionContext.set(true);
 		}
@@ -344,15 +383,23 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 		if (this.isNewChatSessionContext.get()) {
 			return;
 		}
+		this._startOpenSession();
 		// Restore the pending new session if one exists, so pickers
 		// re-derive their state from the still-alive session object.
 		// Otherwise clear active session (first time / after send).
 		this.setActiveSession(this._pendingNewSession ?? undefined);
 		this.isNewChatSessionContext.set(true);
 		this._isNewChatInSessionContext.set(false);
+		this._onDidOpenNewSessionView.fire();
+
+		// Clear isActive so the new-session view is restored on reload
+		for (const [, state] of this._sessionStates) {
+			state.isActive = false;
+		}
 	}
 
 	openNewChatInSession(session: ISession): void {
+		this._startOpenSession();
 		const provider = this._getProvider(session);
 		if (!provider) {
 			this.logService.warn(`[SessionsManagement] openNewChatInSession: provider '${session.providerId}' not found`);
@@ -498,6 +545,93 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 			entries.push(state);
 		}
 		this.storageService.store(ACTIVE_SESSION_STATES_KEY, JSON.stringify(entries), StorageScope.WORKSPACE, StorageTarget.MACHINE);
+	}
+
+	private _getLastActiveSessionState(): ISessionState | undefined {
+		for (const [, state] of this._sessionStates) {
+			if (state.isActive) {
+				return state;
+			}
+		}
+		return undefined;
+	}
+
+	async restoreLastActiveSession(): Promise<void> {
+		const lastActive = this._getLastActiveSessionState();
+		if (!lastActive) {
+			return;
+		}
+
+		// Synchronously switch away from the new-session view before any await so
+		// that NewChatViewPane never renders and cannot call createNewSession()
+		// which would cancel our restore token.
+		this.isNewChatSessionContext.set(false);
+		this._isNewChatInSessionContext.set(false);
+
+		const sessionResource = URI.parse(lastActive.sessionResource);
+		const token = this._startOpenSession();
+
+		const doRestore = async () => {
+			// Session may already be available if the provider registered early
+			const existing = this.getSession(sessionResource);
+			if (existing) {
+				try {
+					await this._doOpenSession(sessionResource, token);
+				} catch {
+					if (!token.isCancellationRequested) {
+						this.openNewSessionView();
+					}
+				}
+				return;
+			}
+
+			// Wait for the session to become available via provider registration.
+			// Cancel if the user navigates while we are waiting.
+			await new Promise<void>(resolve => {
+				const disposables = new DisposableStore();
+
+				const cancel = () => {
+					disposables.dispose();
+					resolve();
+				};
+
+				disposables.add(token.onCancellationRequested(cancel));
+
+				const tryRestore = () => {
+					if (token.isCancellationRequested) {
+						cancel();
+						return;
+					}
+
+					const session = this.getSession(sessionResource);
+					if (session) {
+						disposables.dispose();
+						this._doOpenSession(sessionResource, token).then(resolve, () => {
+							if (!token.isCancellationRequested) {
+								this.openNewSessionView();
+							}
+							resolve();
+						});
+					}
+				};
+
+				disposables.add(this.onDidChangeSessions(() => tryRestore()));
+				disposables.add(this.sessionsProvidersService.onDidChangeProviders(() => tryRestore()));
+			});
+		};
+
+		const restorePromise = doRestore();
+		if (!this.isNewChatSessionContext.get()) {
+			// Race against new-session navigation so progress stops immediately
+			// when the user opens the new session view, but not when they open
+			// another existing session (which should show its own progress).
+			const progressPromise = Promise.race([
+				restorePromise,
+				new Promise<void>(resolve => this._onDidOpenNewSessionView.event(() => resolve()))
+			]);
+			this.progressService.withProgress({ location: ChatViewId, delay: 200 }, () => progressPromise);
+		}
+		await restorePromise;
 	}
 
 	// -- Session Actions --

--- a/src/vs/sessions/services/sessions/common/sessionsManagement.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsManagement.ts
@@ -86,6 +86,13 @@ export interface ISessionsManagementService {
 	openChat(session: ISession, chatUri: URI): Promise<void>;
 
 	/**
+	 * Restore the last active session from persisted state.
+	 * Waits until the session provider is available and then opens the session.
+	 * Falls back to the new-session view if the session is not found.
+	 */
+	restoreLastActiveSession(): Promise<void>;
+
+	/**
 	 * Switch to the new-session view.
 	 * No-op if the current session is already a new session.
 	 */


### PR DESCRIPTION
## Summary

On reload, the agents window now restores the last active session instead of flashing the new-session view.

## Changes

### `ISessionsManagementService` / `SessionsManagementService`
- Add `restoreLastActiveSession()` to the service interface and implementation.
- Introduce `_startOpenSession()` — cancels any in-flight open/restore and returns a fresh `CancellationToken`. All navigation paths (`openSession`, `openChat`, `createNewSession`, `openNewSessionView`, `openNewChatInSession`) now call it so concurrent operations are safely cancelled.
- Refactor `openSession` into a public entry point + private `_doOpenSession(token)` so restore can reuse the same logic.
- Fire `_onDidOpenNewSessionView` in `openNewSessionView` so the restore progress promise can race against it and dismiss early.
- Show a progress indicator on `ChatViewId` during restore (200 ms delay to avoid flicker on fast restores); cancel it immediately if the user navigates to the new-session view.

### `Workbench.restore()`
- Call `sessionsManagementService.restoreLastActiveSession()` during startup (fire-and-forget — progress is managed inside the service).

## Behaviour

| Scenario | Before | After |
|---|---|---|
| Reload with active session | New-session view flashes, then nothing | Session is restored; progress shown on chat view while loading |
| Reload with no prior session | New-session view shown | New-session view shown (unchanged) |
| Navigate away during restore | — | Restore cancelled; new destination shown |
| Navigate to new session during restore | — | Progress bar dismissed immediately |
