### PR TITLE
chat: hide plugin actions for synced customization items

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
@@ -30,6 +30,7 @@ import { EditorPaneDescriptor, IEditorPaneRegistry } from '../../../../browser/e
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../common/contributions.js';
 import { EditorExtensions, IEditorFactoryRegistry, IEditorSerializer } from '../../../../common/editor.js';
 import { EditorInput } from '../../../../common/editor/editorInput.js';
+import { SYNCED_CUSTOMIZATION_SCHEME } from '../../../../services/agentHost/common/agentHostFileSystemService.js';
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
 import { IWorkbenchExtensionManagementService } from '../../../../services/extensionManagement/common/extensionManagement.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
@@ -44,6 +45,7 @@ import { IChatWidgetService } from '../chat.js';
 import { AgentPluginItemKind } from '../agentPluginEditor/agentPluginItems.js';
 import {
 	AI_CUSTOMIZATION_ITEM_DISABLED_KEY,
+	AI_CUSTOMIZATION_ITEM_PLUGIN_URI_KEY,
 	AI_CUSTOMIZATION_ITEM_STORAGE_KEY,
 	AI_CUSTOMIZATION_ITEM_TYPE_KEY,
 	AI_CUSTOMIZATION_ITEM_URI_KEY,
@@ -449,8 +451,16 @@ const WHEN_ITEM_IS_DELETABLE = ContextKeyExpr.and(
 
 /**
  * When clause that shows an action only for plugin items.
+ *
+ * Synced customizations are bundled into a synthetic plugin (under the
+ * `vscode-synced-customization:` scheme) as an implementation detail of the
+ * sync mechanism. Their plugin identity is not user-facing, so we hide
+ * plugin-related actions ("Show Plugin", "Uninstall Plugin") for them.
  */
-const WHEN_ITEM_IS_PLUGIN = ContextKeyExpr.equals(AI_CUSTOMIZATION_ITEM_STORAGE_KEY, PromptsStorage.plugin);
+const WHEN_ITEM_IS_PLUGIN = ContextKeyExpr.and(
+	ContextKeyExpr.equals(AI_CUSTOMIZATION_ITEM_STORAGE_KEY, PromptsStorage.plugin),
+	ContextKeyExpr.regex(AI_CUSTOMIZATION_ITEM_PLUGIN_URI_KEY, new RegExp(`^${SYNCED_CUSTOMIZATION_SCHEME}:`)).negate(),
+);
 
 // Register context menu items
 


### PR DESCRIPTION
Fixes #314879

## What

Items from the `vscode-synced-customization:` scheme are backed by a synthetic plugin — purely an implementation detail of the sync mechanism. Surfacing "Show Plugin" and "Uninstall Plugin" context menu actions for those items is confusing because the plugin concept is not user-facing in this context.

## How

Tightened `WHEN_ITEM_IS_PLUGIN` to also require that the item's plugin URI does **not** match the `vscode-synced-customization:` scheme. Since all three plugin-related menu registrations (`inline` trash icon, `4_modify` "Uninstall Plugin", `1_open` "Show Plugin") use this single constant, the suppression is automatic for synced customization entries.

```ts
const WHEN_ITEM_IS_PLUGIN = ContextKeyExpr.and(
	ContextKeyExpr.equals(AI_CUSTOMIZATION_ITEM_STORAGE_KEY, PromptsStorage.plugin),
	ContextKeyExpr.regex(AI_CUSTOMIZATION_ITEM_PLUGIN_URI_KEY, new RegExp(`^${SYNCED_CUSTOMIZATION_SCHEME}:`)).negate(),
);
```

Regular (non-synced) plugin items are unaffected.