### PR TITLE
chat: gate agent host input completions on trigger characters

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/agentHostInputCompletions.ts
+++ b/src/vs/sessions/contrib/chat/browser/agentHostInputCompletions.ts
@@ -3,17 +3,15 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CancellationToken } from '../../../../base/common/cancellation.js';
-import { Disposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { autorun } from '../../../../base/common/observable.js';
 import { themeColorFromId } from '../../../../base/common/themables.js';
 import { URI } from '../../../../base/common/uri.js';
 import { CodeEditorWidget } from '../../../../editor/browser/widget/codeEditor/codeEditorWidget.js';
 import { ICodeEditorService } from '../../../../editor/browser/services/codeEditorService.js';
 import { Position } from '../../../../editor/common/core/position.js';
-import { Range } from '../../../../editor/common/core/range.js';
 import { IDecorationOptions } from '../../../../editor/common/editorCommon.js';
-import { CompletionContext, CompletionItem, CompletionItemKind, CompletionList } from '../../../../editor/common/languages.js';
+import { CompletionItem, CompletionItemKind } from '../../../../editor/common/languages.js';
 import { ITextModel } from '../../../../editor/common/model.js';
 import { ILanguageFeaturesService } from '../../../../editor/common/services/languageFeatures.js';
 import { CommandsRegistry } from '../../../../platform/commands/common/commands.js';
@@ -21,6 +19,7 @@ import { IChatRequestVariableEntry } from '../../../../workbench/contrib/chat/co
 import { IChatInputCompletionItem, IChatSessionsService, isAgentHostTarget } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { getChatSessionType } from '../../../../workbench/contrib/chat/common/model/chatUri.js';
 import { chatSlashCommandBackground, chatSlashCommandForeground } from '../../../../workbench/contrib/chat/common/widget/chatColors.js';
+import { AgentHostInputCompletionsBase } from '../../../../workbench/contrib/chat/browser/widget/input/editor/agentHostInputCompletionsBase.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { NewChatContextAttachments } from './newChatContextAttachments.js';
 
@@ -54,7 +53,7 @@ CommandsRegistry.registerCommand(ADD_REFERENCE_COMMAND, (_accessor, arg: IRefere
  * picks a different session type, the registration is torn down and
  * re-built with the new host's trigger chars.
  */
-export class AgentHostInputCompletionHandler extends Disposable {
+export class AgentHostInputCompletionHandler extends AgentHostInputCompletionsBase<void> {
 
 	private static readonly _decoType = 'sessions-agent-host-reference';
 	private static _decosRegistered = false;
@@ -72,11 +71,11 @@ export class AgentHostInputCompletionHandler extends Disposable {
 		private readonly _editor: CodeEditorWidget,
 		private readonly _contextAttachments: NewChatContextAttachments,
 		@ICodeEditorService private readonly _codeEditorService: ICodeEditorService,
-		@ILanguageFeaturesService private readonly _languageFeaturesService: ILanguageFeaturesService,
+		@ILanguageFeaturesService languageFeaturesService: ILanguageFeaturesService,
 		@ISessionsManagementService private readonly _sessionsManagementService: ISessionsManagementService,
-		@IChatSessionsService private readonly _chatSessionsService: IChatSessionsService,
+		@IChatSessionsService chatSessionsService: IChatSessionsService,
 	) {
-		super();
+		super(languageFeaturesService, chatSessionsService);
 
 		this._registerDecorations();
 
@@ -124,39 +123,27 @@ export class AgentHostInputCompletionHandler extends Disposable {
 			return;
 		}
 
-		this._registration.value = this._languageFeaturesService.completionProvider.register({ scheme: editorUri.scheme, hasAccessToAllModels: true }, {
-			_debugDisplayName: `sessionsAgentHostInputCompletions[${scheme}]`,
-			triggerCharacters: [...triggerCharacters],
-			provideCompletionItems: (model, position, ctx, token) => this._provide(model, position, ctx, token),
-		});
+		this._registration.value = this._registerProvider(
+			{ scheme: editorUri.scheme, hasAccessToAllModels: true },
+			`sessionsAgentHostInputCompletions[${scheme}]`,
+			triggerCharacters,
+		);
 	}
 
-	private async _provide(model: ITextModel, position: Position, _context: CompletionContext, token: CancellationToken): Promise<CompletionList | null> {
+	protected override _resolveContext(_model: ITextModel): { sessionResource: URI; context: void } | undefined {
 		const session = this._sessionsManagementService.activeSession.get();
 		if (!session) {
-			return null;
+			return undefined;
 		}
 		const sessionResource = session.resource;
 		if (!isAgentHostTarget(getChatSessionType(sessionResource))) {
-			return null;
+			return undefined;
 		}
-
-		const text = model.getValue();
-		const offset = model.getOffsetAt(position);
-		const result = await this._chatSessionsService.provideChatInputCompletions(sessionResource, { text, offset }, token);
-		if (token.isCancellationRequested || !result) {
-			return null;
-		}
-
-		const suggestions: CompletionItem[] = [];
-		for (const item of result.items) {
-			suggestions.push(this._toMonacoItem(position, item));
-		}
-		return { suggestions };
+		return { sessionResource, context: undefined };
 	}
 
-	private _toMonacoItem(position: Position, item: IChatInputCompletionItem): CompletionItem {
-		const replaceRange = this._computeRange(position, item);
+	protected override _buildItem(position: Position, item: IChatInputCompletionItem): CompletionItem {
+		const replaceRange = AgentHostInputCompletionHandler.computeRange(position, item);
 		const label = item.attachment.displayName ?? item.insertText;
 		const description = item.attachment.uri.path;
 		const kind = item.attachment.isDirectory ? CompletionItemKind.Folder : CompletionItemKind.File;
@@ -179,18 +166,6 @@ export class AgentHostInputCompletionHandler extends Disposable {
 				arguments: [{ handler: this, entry, insertText: item.insertText } satisfies IReferenceArg],
 			},
 		};
-	}
-
-	private _computeRange(position: Position, item: IChatInputCompletionItem): { insert: Range; replace: Range } {
-		// Positions returned by the provider are already 1-based Monaco
-		// positions, so they can be used directly. When omitted, default
-		// to a zero-length range at the cursor (Monaco then inserts
-		// without replacing).
-		const start = item.start ?? position;
-		const end = item.end ?? position;
-		const replace = new Range(start.lineNumber, start.column, end.lineNumber, end.column);
-		const insert = new Range(start.lineNumber, start.column, position.lineNumber, position.column);
-		return { insert, replace };
 	}
 
 	private _basename(uri: URI): string {

--- a/src/vs/sessions/contrib/chat/browser/agentHostInputCompletions.ts
+++ b/src/vs/sessions/contrib/chat/browser/agentHostInputCompletions.ts
@@ -53,7 +53,7 @@ CommandsRegistry.registerCommand(ADD_REFERENCE_COMMAND, (_accessor, arg: IRefere
  * picks a different session type, the registration is torn down and
  * re-built with the new host's trigger chars.
  */
-export class AgentHostInputCompletionHandler extends AgentHostInputCompletionsBase<void> {
+export class AgentHostInputCompletionHandler extends AgentHostInputCompletionsBase<void, string> {
 
 	private static readonly _decoType = 'sessions-agent-host-reference';
 	private static _decosRegistered = false;
@@ -127,16 +127,21 @@ export class AgentHostInputCompletionHandler extends AgentHostInputCompletionsBa
 			{ scheme: editorUri.scheme, hasAccessToAllModels: true },
 			`sessionsAgentHostInputCompletions[${scheme}]`,
 			triggerCharacters,
+			scheme,
 		);
 	}
 
-	protected override _resolveContext(_model: ITextModel): { sessionResource: URI; context: void } | undefined {
+	protected override _resolveContext(_model: ITextModel, scheme: string): { sessionResource: URI; context: void } | undefined {
 		const session = this._sessionsManagementService.activeSession.get();
 		if (!session) {
 			return undefined;
 		}
 		const sessionResource = session.resource;
-		if (!isAgentHostTarget(getChatSessionType(sessionResource))) {
+		// Only respond when the currently-active session matches the
+		// scheme this registration was made for. Stale registrations
+		// (active session changed during the host RPC, etc.) are
+		// silently ignored.
+		if (getChatSessionType(sessionResource) !== scheme) {
 			return undefined;
 		}
 		return { sessionResource, context: undefined };

--- a/src/vs/workbench/contrib/chat/browser/widget/input/editor/agentHostInputCompletions.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/editor/agentHostInputCompletions.ts
@@ -3,14 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CancellationToken } from '../../../../../../../base/common/cancellation.js';
-import { Disposable, DisposableMap } from '../../../../../../../base/common/lifecycle.js';
+import { DisposableMap } from '../../../../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../../../../base/common/network.js';
 import { assertType } from '../../../../../../../base/common/types.js';
 import { URI } from '../../../../../../../base/common/uri.js';
 import { Position } from '../../../../../../../editor/common/core/position.js';
 import { Range } from '../../../../../../../editor/common/core/range.js';
-import { CompletionContext, CompletionItem, CompletionItemKind, CompletionList } from '../../../../../../../editor/common/languages.js';
+import { CompletionItem, CompletionItemKind } from '../../../../../../../editor/common/languages.js';
 import { ITextModel } from '../../../../../../../editor/common/model.js';
 import { ILanguageFeaturesService } from '../../../../../../../editor/common/services/languageFeatures.js';
 import { CommandsRegistry } from '../../../../../../../platform/commands/common/commands.js';
@@ -21,7 +20,7 @@ import { ChatDynamicVariableModel } from '../../../attachments/chatDynamicVariab
 import { IChatInputCompletionItem, IChatSessionsService, isAgentHostTarget } from '../../../../common/chatSessionsService.js';
 import { getChatSessionType } from '../../../../common/model/chatUri.js';
 import { IChatWidget, IChatWidgetService } from '../../../chat.js';
-
+import { AgentHostInputCompletionsBase } from './agentHostInputCompletionsBase.js';
 /**
  * Completion provider that delegates `@`-mention (and other server-defined)
  * completions to the agent host for AHP-backed chat sessions.
@@ -38,7 +37,7 @@ import { IChatWidget, IChatWidgetService } from '../../../chat.js';
  * that adds an {@link IDynamicVariable} entry to the widget's variable
  * model so the resource becomes part of the outgoing user message.
  */
-export class AgentHostInputCompletions extends Disposable {
+export class AgentHostInputCompletions extends AgentHostInputCompletionsBase<IChatWidget> {
 
 	private static readonly addReferenceCommand = '_chatAgentHostAddReferenceCmd';
 
@@ -46,11 +45,11 @@ export class AgentHostInputCompletions extends Disposable {
 	private readonly _registrations = this._register(new DisposableMap<string>());
 
 	constructor(
-		@ILanguageFeaturesService private readonly _languageFeaturesService: ILanguageFeaturesService,
+		@ILanguageFeaturesService languageFeaturesService: ILanguageFeaturesService,
 		@IChatWidgetService private readonly _chatWidgetService: IChatWidgetService,
-		@IChatSessionsService private readonly _chatSessionsService: IChatSessionsService,
+		@IChatSessionsService chatSessionsService: IChatSessionsService,
 	) {
-		super();
+		super(languageFeaturesService, chatSessionsService);
 
 		this._register(CommandsRegistry.registerCommand(AgentHostInputCompletions.addReferenceCommand, (_services, arg) => {
 			assertType(arg instanceof AgentHostReferenceArgument);
@@ -94,43 +93,29 @@ export class AgentHostInputCompletions extends Disposable {
 			return;
 		}
 
-		const registration = this._languageFeaturesService.completionProvider.register({ scheme: Schemas.vscodeChatInput, hasAccessToAllModels: true }, {
-			_debugDisplayName: `agentHostChatInputCompletions[${scheme}]`,
-			triggerCharacters: [...triggerCharacters],
-			provideCompletionItems: (model, position, context, token) => this._provide(model, position, context, token, scheme),
-		});
-		this._registrations.set(scheme, registration);
+		this._registrations.set(scheme, this._registerProvider(
+			{ scheme: Schemas.vscodeChatInput, hasAccessToAllModels: true },
+			`agentHostChatInputCompletions[${scheme}]`,
+			triggerCharacters,
+		));
 	}
 
-	private async _provide(model: ITextModel, position: Position, _context: CompletionContext, token: CancellationToken, scheme: string): Promise<CompletionList | null> {
+	protected override _resolveContext(model: ITextModel): { sessionResource: URI; context: IChatWidget } | undefined {
 		const widget = this._chatWidgetService.getWidgetByInputUri(model.uri);
 		if (!widget?.viewModel) {
-			return null;
+			return undefined;
 		}
-
 		const sessionResource = widget.viewModel.model.sessionResource;
-		// Only respond when the active session is handled by the same
-		// content provider that registered this Monaco provider.
-		if (getChatSessionType(sessionResource) !== scheme) {
-			return null;
+		// Only respond when the active session is handled by an
+		// agent-host content provider.
+		if (!isAgentHostTarget(getChatSessionType(sessionResource))) {
+			return undefined;
 		}
-
-		const text = model.getValue();
-		const offset = model.getOffsetAt(position);
-		const result = await this._chatSessionsService.provideChatInputCompletions(sessionResource, { text, offset }, token);
-		if (token.isCancellationRequested || !result) {
-			return null;
-		}
-
-		const suggestions: CompletionItem[] = [];
-		for (const item of result.items) {
-			suggestions.push(this._toMonacoItem(position, widget, item));
-		}
-		return { suggestions };
+		return { sessionResource, context: widget };
 	}
 
-	private _toMonacoItem(position: Position, widget: IChatWidget, item: IChatInputCompletionItem): CompletionItem {
-		const replaceRange = this._computeRange(position, item);
+	protected override _buildItem(position: Position, item: IChatInputCompletionItem, widget: IChatWidget): CompletionItem {
+		const replaceRange = AgentHostInputCompletions.computeRange(position, item);
 		const label = item.attachment.displayName ?? item.insertText;
 		const description = item.attachment.uri.path;
 		return {
@@ -145,18 +130,6 @@ export class AgentHostInputCompletions extends Disposable {
 				arguments: [new AgentHostReferenceArgument(widget, item.attachment.uri, item.attachment.displayName, !!item.attachment.isDirectory, replaceRange.replace.setEndPosition(replaceRange.replace.startLineNumber, replaceRange.replace.startColumn + item.insertText.length), item.attachment._meta)],
 			},
 		};
-	}
-
-	private _computeRange(position: Position, item: IChatInputCompletionItem): { insert: Range; replace: Range } {
-		// Positions returned by the provider are already 1-based Monaco
-		// positions, so they can be used directly. When omitted, default
-		// to a zero-length range at the cursor (Monaco then inserts
-		// without replacing).
-		const start = item.start ?? position;
-		const end = item.end ?? position;
-		const replace = new Range(start.lineNumber, start.column, end.lineNumber, end.column);
-		const insert = new Range(start.lineNumber, start.column, position.lineNumber, position.column);
-		return { insert, replace };
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/editor/agentHostInputCompletions.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/editor/agentHostInputCompletions.ts
@@ -37,7 +37,7 @@ import { AgentHostInputCompletionsBase } from './agentHostInputCompletionsBase.j
  * that adds an {@link IDynamicVariable} entry to the widget's variable
  * model so the resource becomes part of the outgoing user message.
  */
-export class AgentHostInputCompletions extends AgentHostInputCompletionsBase<IChatWidget> {
+export class AgentHostInputCompletions extends AgentHostInputCompletionsBase<IChatWidget, string> {
 
 	private static readonly addReferenceCommand = '_chatAgentHostAddReferenceCmd';
 
@@ -97,18 +97,22 @@ export class AgentHostInputCompletions extends AgentHostInputCompletionsBase<ICh
 			{ scheme: Schemas.vscodeChatInput, hasAccessToAllModels: true },
 			`agentHostChatInputCompletions[${scheme}]`,
 			triggerCharacters,
+			scheme,
 		));
 	}
 
-	protected override _resolveContext(model: ITextModel): { sessionResource: URI; context: IChatWidget } | undefined {
+	protected override _resolveContext(model: ITextModel, scheme: string): { sessionResource: URI; context: IChatWidget } | undefined {
 		const widget = this._chatWidgetService.getWidgetByInputUri(model.uri);
 		if (!widget?.viewModel) {
 			return undefined;
 		}
 		const sessionResource = widget.viewModel.model.sessionResource;
-		// Only respond when the active session is handled by an
-		// agent-host content provider.
-		if (!isAgentHostTarget(getChatSessionType(sessionResource))) {
+		// Only respond when the active session is handled by the same
+		// content provider that registered this Monaco provider.
+		// Without this check, two providers sharing trigger characters
+		// (e.g. both register `@`) would both fire and produce duplicate
+		// RPCs / suggestions.
+		if (getChatSessionType(sessionResource) !== scheme) {
 			return undefined;
 		}
 		return { sessionResource, context: widget };

--- a/src/vs/workbench/contrib/chat/browser/widget/input/editor/agentHostInputCompletionsBase.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/editor/agentHostInputCompletionsBase.ts
@@ -1,0 +1,115 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../../../../base/common/cancellation.js';
+import { Disposable, IDisposable } from '../../../../../../../base/common/lifecycle.js';
+import { URI } from '../../../../../../../base/common/uri.js';
+import { Position } from '../../../../../../../editor/common/core/position.js';
+import { Range } from '../../../../../../../editor/common/core/range.js';
+import { CompletionItem, CompletionList } from '../../../../../../../editor/common/languages.js';
+import { ITextModel } from '../../../../../../../editor/common/model.js';
+import { LanguageFilter } from '../../../../../../../editor/common/languageSelector.js';
+import { ILanguageFeaturesService } from '../../../../../../../editor/common/services/languageFeatures.js';
+import { IChatInputCompletionItem, IChatSessionsService } from '../../../../common/chatSessionsService.js';
+import { isAtTriggerCharacterToken } from './chatInputCompletionUtils.js';
+
+/**
+ * Shared plumbing for Monaco completion providers that delegate to an
+ * agent host's `provideChatInputCompletions` RPC.
+ *
+ * Subclasses own the registration lifecycle (per-scheme, per-active-
+ * session, etc.) and supply two pieces of behaviour:
+ *
+ *   - {@link _resolveContext}: how to find the session resource for a
+ *     given input model, plus any subclass-specific data ({@link TContext})
+ *     that needs to flow into the accept command.
+ *   - {@link _buildItem}: how to produce the final Monaco
+ *     {@link CompletionItem} including the command that runs when the
+ *     user accepts a suggestion.
+ *
+ * The base handles the cross-cutting concerns: gating on trigger
+ * characters, performing the host RPC, cancellation, and registering
+ * the Monaco provider with the host-announced trigger characters.
+ */
+export abstract class AgentHostInputCompletionsBase<TContext> extends Disposable {
+
+	constructor(
+		protected readonly _languageFeaturesService: ILanguageFeaturesService,
+		protected readonly _chatSessionsService: IChatSessionsService,
+	) {
+		super();
+	}
+
+	/**
+	 * Resolve the session resource whose host should answer completions
+	 * for `model`, along with any subclass-specific context that should
+	 * flow into {@link _buildItem}. Return `undefined` to skip.
+	 */
+	protected abstract _resolveContext(model: ITextModel): { sessionResource: URI; context: TContext } | undefined;
+
+	/**
+	 * Build the Monaco completion item — including the accept command —
+	 * for one item returned by the host.
+	 */
+	protected abstract _buildItem(position: Position, item: IChatInputCompletionItem, context: TContext): CompletionItem;
+
+	/**
+	 * Register a Monaco completion provider that delegates to this
+	 * instance. Subclasses call this once their lifecycle decides a
+	 * registration should exist (e.g. once a content provider becomes
+	 * available, or once the active session changes to an AHP-backed
+	 * one).
+	 */
+	protected _registerProvider(filter: LanguageFilter, debugName: string, triggerCharacters: readonly string[]): IDisposable {
+		return this._languageFeaturesService.completionProvider.register(filter, {
+			_debugDisplayName: debugName,
+			triggerCharacters: [...triggerCharacters],
+			provideCompletionItems: (model, position, _context, token) => this._provide(model, position, token, triggerCharacters),
+		});
+	}
+
+	private async _provide(model: ITextModel, position: Position, token: CancellationToken, triggerCharacters: readonly string[]): Promise<CompletionList | null> {
+		// Only consult the agent host when the cursor sits inside a token
+		// led by one of the host-announced trigger characters. Without
+		// this gate Monaco re-invokes the provider on every keystroke
+		// (for filtering / incomplete-result refresh), which would
+		// produce an RPC round-trip per character.
+		if (!isAtTriggerCharacterToken(model, position, triggerCharacters)) {
+			return null;
+		}
+
+		const ctx = this._resolveContext(model);
+		if (!ctx) {
+			return null;
+		}
+
+		const text = model.getValue();
+		const offset = model.getOffsetAt(position);
+		const result = await this._chatSessionsService.provideChatInputCompletions(ctx.sessionResource, { text, offset }, token);
+		if (token.isCancellationRequested || !result) {
+			return null;
+		}
+
+		const suggestions: CompletionItem[] = [];
+		for (const item of result.items) {
+			suggestions.push(this._buildItem(position, item, ctx.context));
+		}
+		return { suggestions };
+	}
+
+	/**
+	 * Compute the insert/replace ranges for an item. Positions returned
+	 * by the host are already 1-based Monaco positions, so they can be
+	 * used directly. When omitted, the ranges default to a zero-length
+	 * span at the cursor (Monaco then inserts without replacing).
+	 */
+	protected static computeRange(position: Position, item: IChatInputCompletionItem): { insert: Range; replace: Range } {
+		const start = item.start ?? position;
+		const end = item.end ?? position;
+		const replace = new Range(start.lineNumber, start.column, end.lineNumber, end.column);
+		const insert = new Range(start.lineNumber, start.column, position.lineNumber, position.column);
+		return { insert, replace };
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/widget/input/editor/agentHostInputCompletionsBase.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/editor/agentHostInputCompletionsBase.ts
@@ -24,7 +24,10 @@ import { isAtTriggerCharacterToken } from './chatInputCompletionUtils.js';
  *
  *   - {@link _resolveContext}: how to find the session resource for a
  *     given input model, plus any subclass-specific data ({@link TContext})
- *     that needs to flow into the accept command.
+ *     that needs to flow into the accept command. Receives the per-
+ *     registration data ({@link TRegData}) the subclass passed to
+ *     {@link _registerProvider} so it can short-circuit when the model
+ *     does not belong to *this* registration (e.g. a different scheme).
  *   - {@link _buildItem}: how to produce the final Monaco
  *     {@link CompletionItem} including the command that runs when the
  *     user accepts a suggestion.
@@ -33,7 +36,7 @@ import { isAtTriggerCharacterToken } from './chatInputCompletionUtils.js';
  * characters, performing the host RPC, cancellation, and registering
  * the Monaco provider with the host-announced trigger characters.
  */
-export abstract class AgentHostInputCompletionsBase<TContext> extends Disposable {
+export abstract class AgentHostInputCompletionsBase<TContext, TRegData = void> extends Disposable {
 
 	constructor(
 		protected readonly _languageFeaturesService: ILanguageFeaturesService,
@@ -47,7 +50,7 @@ export abstract class AgentHostInputCompletionsBase<TContext> extends Disposable
 	 * for `model`, along with any subclass-specific context that should
 	 * flow into {@link _buildItem}. Return `undefined` to skip.
 	 */
-	protected abstract _resolveContext(model: ITextModel): { sessionResource: URI; context: TContext } | undefined;
+	protected abstract _resolveContext(model: ITextModel, regData: TRegData): { sessionResource: URI; context: TContext } | undefined;
 
 	/**
 	 * Build the Monaco completion item — including the accept command —
@@ -60,17 +63,20 @@ export abstract class AgentHostInputCompletionsBase<TContext> extends Disposable
 	 * instance. Subclasses call this once their lifecycle decides a
 	 * registration should exist (e.g. once a content provider becomes
 	 * available, or once the active session changes to an AHP-backed
-	 * one).
+	 * one). The opaque {@link regData} is forwarded to
+	 * {@link _resolveContext} so the subclass can identify which
+	 * registration is firing (e.g. its scheme) and ignore models that
+	 * don't belong to it.
 	 */
-	protected _registerProvider(filter: LanguageFilter, debugName: string, triggerCharacters: readonly string[]): IDisposable {
+	protected _registerProvider(filter: LanguageFilter, debugName: string, triggerCharacters: readonly string[], regData: TRegData): IDisposable {
 		return this._languageFeaturesService.completionProvider.register(filter, {
 			_debugDisplayName: debugName,
 			triggerCharacters: [...triggerCharacters],
-			provideCompletionItems: (model, position, _context, token) => this._provide(model, position, token, triggerCharacters),
+			provideCompletionItems: (model, position, _context, token) => this._provide(model, position, token, triggerCharacters, regData),
 		});
 	}
 
-	private async _provide(model: ITextModel, position: Position, token: CancellationToken, triggerCharacters: readonly string[]): Promise<CompletionList | null> {
+	private async _provide(model: ITextModel, position: Position, token: CancellationToken, triggerCharacters: readonly string[], regData: TRegData): Promise<CompletionList | null> {
 		// Only consult the agent host when the cursor sits inside a token
 		// led by one of the host-announced trigger characters. Without
 		// this gate Monaco re-invokes the provider on every keystroke
@@ -80,7 +86,7 @@ export abstract class AgentHostInputCompletionsBase<TContext> extends Disposable
 			return null;
 		}
 
-		const ctx = this._resolveContext(model);
+		const ctx = this._resolveContext(model, regData);
 		if (!ctx) {
 			return null;
 		}

--- a/src/vs/workbench/contrib/chat/browser/widget/input/editor/chatInputCompletionUtils.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/editor/chatInputCompletionUtils.ts
@@ -56,3 +56,25 @@ export function isEmptyUpToCompletionWord(model: ITextModel, rangeResult: IChatC
 	const startToCompletionWordStart = new Range(1, 1, rangeResult.replace.startLineNumber, rangeResult.replace.startColumn);
 	return !!model.getValueInRange(startToCompletionWordStart).match(/^\s*$/);
 }
+
+/**
+ * Returns `true` when the cursor sits inside a non-empty token whose first
+ * character is one of the given trigger characters (or is positioned right
+ * after such a token). Used to gate completion providers so they only run
+ * when the user is actively editing a trigger-led token.
+ */
+export function isAtTriggerCharacterToken(model: ITextModel, position: Position, triggerCharacters: readonly string[]): boolean {
+	if (triggerCharacters.length === 0) {
+		return false;
+	}
+	const line = model.getLineContent(position.lineNumber);
+	const beforeCursor = line.slice(0, position.column - 1);
+	// The current token is everything from the last whitespace char (or
+	// start-of-line) up to the cursor.
+	const wsIdx = beforeCursor.search(/\s\S*$/);
+	const token = wsIdx >= 0 ? beforeCursor.slice(wsIdx + 1) : beforeCursor;
+	if (token.length === 0) {
+		return false;
+	}
+	return triggerCharacters.includes(token[0]);
+}

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/editor/chatInputCompletions.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/editor/chatInputCompletions.test.ts
@@ -10,7 +10,7 @@ import { Position } from '../../../../../../../../editor/common/core/position.js
 import { Range } from '../../../../../../../../editor/common/core/range.js';
 import { createTextModel } from '../../../../../../../../editor/test/common/testTextModel.js';
 import { DisposableStore } from '../../../../../../../../base/common/lifecycle.js';
-import { computeCompletionRanges, escapeForCharClass } from '../../../../../browser/widget/input/editor/chatInputCompletionUtils.js';
+import { computeCompletionRanges, escapeForCharClass, isAtTriggerCharacterToken } from '../../../../../browser/widget/input/editor/chatInputCompletionUtils.js';
 import { chatAgentLeader, chatVariableLeader } from '../../../../../common/requestParser/chatParserTypes.js';
 
 suite('escapeForCharClass', () => {
@@ -271,5 +271,81 @@ suite('computeCompletionRanges', () => {
 			assert.ok(result);
 			assert.strictEqual(result.varWord?.word, '@file');
 		});
+	});
+});
+
+suite('isAtTriggerCharacterToken', () => {
+
+	let store: DisposableStore;
+
+	setup(() => {
+		store = new DisposableStore();
+	});
+
+	teardown(() => {
+		store.dispose();
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const triggerChars = ['@', '#'];
+
+	function check(text: string, column: number, expected: boolean): void {
+		const model = store.add(createTextModel(text, null, undefined, URI.parse('test:input')));
+		assert.strictEqual(
+			isAtTriggerCharacterToken(model, new Position(1, column), triggerChars),
+			expected,
+			`text=${JSON.stringify(text)} column=${column}`,
+		);
+	}
+
+	test('cursor right after a trigger character at start of line', () => {
+		check('@', 2, true);
+	});
+
+	test('cursor inside a trigger-led token at start of line', () => {
+		check('@file', 4, true);
+	});
+
+	test('cursor at end of a trigger-led token at start of line', () => {
+		check('@file', 6, true);
+	});
+
+	test('cursor inside a trigger-led token mid-line', () => {
+		check('hello @file', 10, true);
+	});
+
+	test('cursor inside a # trigger-led token', () => {
+		check('hello #file', 10, true);
+	});
+
+	test('cursor inside a non-trigger-led word at start of line', () => {
+		check('hello', 4, false);
+	});
+
+	test('cursor inside a non-trigger-led word mid-line', () => {
+		check('say hello', 8, false);
+	});
+
+	test('cursor at start of empty line', () => {
+		check('', 1, false);
+	});
+
+	test('cursor right after whitespace, no token yet', () => {
+		check('hello ', 7, false);
+	});
+
+	test('cursor after a trigger-led token followed by space', () => {
+		// Cursor sits in the empty token after the space, not in the @file token.
+		check('@file ', 7, false);
+	});
+
+	test('cursor in token whose first char is not a trigger char', () => {
+		check('abc@def', 8, false); // first char of token is 'a', not '@'
+	});
+
+	test('returns false when no trigger characters are configured', () => {
+		const model = store.add(createTextModel('@file', null, undefined, URI.parse('test:input')));
+		assert.strictEqual(isAtTriggerCharacterToken(model, new Position(1, 4), []), false);
 	});
 });


### PR DESCRIPTION
chat: gate agent host input completions on trigger characters

Agent host completion providers were re-invoking `provideChatInputCompletions`
on every keystroke, producing one RPC round-trip per character typed because
Monaco still consults the provider for filtering / incomplete-result refresh
even when the user isn't editing a trigger-led token.

- Adds `isAtTriggerCharacterToken` helper in `chatInputCompletionUtils.ts`
  that returns true only when the cursor sits inside a non-empty token whose
  first char is one of the host-announced trigger characters.
- Wires the gate into both agent host completion providers (workbench chat
  widget + sessions new-chat input) so the host RPC is only dispatched when
  the user is actively editing a `@`/`#`/... led token.
- Extracts a small `AgentHostInputCompletionsBase` template-method base
  class that owns the shared plumbing (trigger-char gate, RPC dispatch,
  range computation, Monaco provider registration). Concrete subclasses
  now only supply `_resolveContext` (how to find the active session
  resource for a model) and `_buildItem` (how to build the Monaco
  completion item + accept command), keeping the registration lifecycle
  policy in each subclass.

(Commit message generated by Copilot)
