### PR TITLE
telemetry: add compressOutputEnabled to toolUse.runInTerminal

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalToolTelemetry.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalToolTelemetry.ts
@@ -3,14 +3,17 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { TelemetryTrustedValue } from '../../../../../platform/telemetry/common/telemetryUtils.js';
+import { ChatConfiguration } from '../../../chat/common/constants.js';
 import type { ITerminalInstance } from '../../../terminal/browser/terminal.js';
 import { ShellIntegrationQuality } from './toolTerminalCreator.js';
 
 export class RunInTerminalToolTelemetry {
 	constructor(
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
 	) {
 	}
 
@@ -142,6 +145,8 @@ export class RunInTerminalToolTelemetry {
 			inputToolManualShownCount: number;
 			inputToolFreeFormInputShownCount: number;
 			inputToolFreeFormInputCount: number;
+
+			compressOutputEnabled: boolean;
 		};
 		type TelemetryClassification = {
 			owner: 'meganrogge';
@@ -174,6 +179,8 @@ export class RunInTerminalToolTelemetry {
 			inputToolManualShownCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The number of times the user was prompted to manually accept an input suggestion' };
 			inputToolFreeFormInputShownCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The number of times the user was prompted to provide free form input' };
 			inputToolFreeFormInputCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The number of times the user entered free form input after prompting' };
+
+			compressOutputEnabled: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether the chat.tools.compressOutput.enabled setting is on for this invocation.' };
 		};
 		this._telemetryService.publicLog2<TelemetryEvent, TelemetryClassification>('toolUse.runInTerminal', {
 			terminalSessionId: instance.sessionId,
@@ -203,6 +210,8 @@ export class RunInTerminalToolTelemetry {
 			inputToolManualShownCount: state.inputToolManualShownCount ?? 0,
 			inputToolFreeFormInputShownCount: state.inputToolFreeFormInputShownCount ?? 0,
 			inputToolFreeFormInputCount: state.inputToolFreeFormInputCount ?? 0,
+
+			compressOutputEnabled: this._configurationService.getValue<boolean>(ChatConfiguration.CompressOutputEnabled) === true,
 		});
 	}
 }


### PR DESCRIPTION
Adds a `compressOutputEnabled` boolean (reading `chat.tools.compressOutput.enabled`) to every `toolUse.runInTerminal` telemetry event.

This lets dashboards scope run_in_terminal invocation counts to sessions where compression is on, so the compression rate can be computed accurately as:

    compressed events / run_in_terminal invocations with compressOutputEnabled == true

Without this, the denominator includes invocations where the setting is off and no `toolResultCompressed` event could ever have fired, which makes the rate look artificially low.