### PR TITLE
sessions: round chat send button

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/media/chatInput.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatInput.css
@@ -252,7 +252,7 @@
 	position: relative;
 	width: 22px;
 	height: 22px;
-	border-radius: 4px;
+	border-radius: 50%;
 }
 
 .sessions-chat-send-button .monaco-button {
@@ -263,7 +263,7 @@
 	height: 22px;
 	min-width: 22px;
 	padding: 0;
-	border-radius: 4px;
+	border-radius: 50%;
 	color: var(--vscode-icon-foreground);
 	background: transparent;
 	border: none;
@@ -341,7 +341,7 @@
 	content: '';
 	position: absolute;
 	inset: -2px;
-	border-radius: 6px;
+	border-radius: 50%;
 	background: conic-gradient(from 135deg,
 			var(--vscode-chat-inputWorkingBorderColor1),
 			var(--vscode-chat-inputWorkingBorderColor2),

--- a/src/vs/sessions/contrib/chat/browser/media/chatInputMobile.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatInputMobile.css
@@ -32,7 +32,7 @@
 	padding-bottom: 6px;
 }
 
-/* The send button on phone is a 36×36 circle with the same accent
+/* The send button on phone grows to a 36×36 circle with the same accent
  * gradient fill as the desktop button. The wrapper and inner Button
  * widget both grow so the focus outline (drawn on the wrapper) and
  * the click target (the wrapper's `:has(...)` rules) align with the
@@ -51,10 +51,7 @@
 	margin-bottom: 18px;
 }
 
-/* The active-state pulse pseudo-element in `chatInput.css` uses
- * `border-radius: 6px` (matching the desktop button's rounded square).
- * Round it to a circle on phone so the pulse animates concentrically
- * with the new shape. */
+/* Keep the active-state pulse concentric with the larger phone button. */
 .agent-sessions-workbench.phone-layout .sessions-chat-send-button:has(.monaco-button:not(.disabled):active)::after {
 	border-radius: 50%;
 }


### PR DESCRIPTION
## Summary
- Make the Agents chat send button circular on desktop by applying a 50% border radius to the wrapper, inner Monaco button, and active pulse
- Refresh mobile comments now that the desktop button is also round

<img width="943" height="218" alt="Screenshot 2026-05-08 at 2 22 49 PM" src="https://github.com/user-attachments/assets/856770bd-f9a9-47f0-9739-06760627fa63" />

## Validation
- `npm run compile-check-ts-native`
- `npm run precommit`