### PR TITLE
sessions: use codicon spinner in new chat input

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/media/chatInput.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatInput.css
@@ -363,25 +363,20 @@
 /* Loading spinner in toolbar */
 .sessions-chat-loading-spinner {
 	display: none;
-	width: 12px;
-	height: 12px;
+	align-items: center;
+	justify-content: center;
 	margin-right: 4px;
-	border: 1.5px solid var(--vscode-icon-foreground);
-	border-top-color: transparent;
-	border-radius: 50%;
-	animation: sessions-chat-spin 0.8s linear infinite;
 	opacity: 0.6;
 	flex-shrink: 0;
+	color: var(--vscode-icon-foreground);
 }
 
 .sessions-chat-loading-spinner.visible {
-	display: block;
+	display: flex;
 }
 
-@keyframes sessions-chat-spin {
-	to {
-		transform: rotate(360deg);
-	}
+.sessions-chat-loading-spinner .codicon {
+	font-size: 14px;
 }
 
 /* Attach row (pills only, above editor, inside input area) */

--- a/src/vs/sessions/contrib/chat/browser/newChatInput.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInput.ts
@@ -32,6 +32,7 @@ import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { getDefaultHoverDelegate } from '../../../../base/browser/ui/hover/hoverDelegateFactory.js';
 import { HoverPosition } from '../../../../base/browser/ui/hover/hoverWidget.js';
 import { renderIcon } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
+import { ThemeIcon } from '../../../../base/common/themables.js';
 import { localize } from '../../../../nls.js';
 import * as aria from '../../../../base/browser/ui/aria/aria.js';
 import { ContextMenuController } from '../../../../editor/contrib/contextmenu/browser/contextmenu.js';
@@ -442,6 +443,8 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 		dom.append(toolbar, dom.$('.sessions-chat-toolbar-spacer'));
 
 		this._loadingSpinner = dom.append(toolbar, dom.$('.sessions-chat-loading-spinner'));
+		const loadingIcon = dom.append(this._loadingSpinner, renderIcon(ThemeIcon.modify(Codicon.loading, 'spin')));
+		loadingIcon.setAttribute('aria-hidden', 'true');
 		this._register(this.hoverService.setupManagedHover(getDefaultHoverDelegate('mouse'), this._loadingSpinner, localize('loading', "Loading...")));
 
 		const sendButtonContainer = dom.append(toolbar, dom.$('.sessions-chat-send-button'));


### PR DESCRIPTION
## Summary

Fixes https://github.com/microsoft/vscode/issues/315322

- Replace the custom CSS border-based loading spinner in the Sessions new-chat input toolbar with the standard codicon loading spinner.
- Keep the spinner decorative for assistive technologies while preserving the existing hover label.
- Remove the custom spinner keyframes and border styling.

https://github.com/user-attachments/assets/14cd69cd-e23a-474e-a065-d756ebc87a83

## Validation
- `npm run compile-check-ts-native`
- `npm run valid-layers-check`
- `node --experimental-strip-types build/hygiene.ts src/vs/sessions/contrib/chat/browser/newChatInput.ts src/vs/sessions/contrib/chat/browser/media/chatInput.css`