### PR TITLE
chat: avoid Open Agents Window keybinding conflict in screen reader mode

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatAccessibilityActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatAccessibilityActions.ts
@@ -53,15 +53,23 @@ class AnnounceChatConfirmationAction extends Action2 {
 			return;
 		}
 
-		// Check for active confirmations in the chat responses
+		// Check for active confirmations in the chat responses. The
+		// `.chat-confirmation-widget-container` class is reused by several
+		// non-focusable parts (e.g. the tool input/output collapsible and the
+		// plan review part), so filter to the focusable instances by looking
+		// for an explicit tabindex which is only set on real confirmation
+		// dialogs (via `configureAccessibilityContainer`).
 		let firstConfirmationElement: HTMLElement | undefined;
 
 		const lastResponse = viewModel.getItems()[viewModel.getItems().length - 1];
 		if (isResponseVM(lastResponse)) {
+			// Reveal the response so its confirmation widget is rendered (the
+			// chat list is virtualized — querying before reveal can miss it).
+			pendingWidget.reveal(lastResponse);
 			// eslint-disable-next-line no-restricted-syntax
-			const confirmationWidgets = pendingWidget.domNode.querySelectorAll('.chat-confirmation-widget-container');
+			const confirmationWidgets = pendingWidget.domNode.querySelectorAll<HTMLElement>('.chat-confirmation-widget-container[tabindex]');
 			if (confirmationWidgets.length > 0) {
-				firstConfirmationElement = confirmationWidgets[0] as HTMLElement;
+				firstConfirmationElement = confirmationWidgets[confirmationWidgets.length - 1];
 			}
 		}
 
@@ -70,6 +78,7 @@ class AnnounceChatConfirmationAction extends Action2 {
 			if (firstConfirmationElement.contains(pendingWidget.domNode.ownerDocument.activeElement)) {
 				pendingWidget.focusInput();
 			} else {
+				firstConfirmationElement.scrollIntoView({ block: 'nearest' });
 				firstConfirmationElement.focus();
 			}
 		} else {

--- a/src/vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp.ts
@@ -71,6 +71,7 @@ export function getAccessibilityHelpText(type: 'panelChat' | 'inlineChat' | 'age
 			content.push(localize('workbench.action.chat.newChat', 'To create a new chat session, invoke the New Chat command{0}.', '<keybinding:workbench.action.chat.newChat>'));
 			content.push(localize('workbench.action.chat.history', 'To view all chat sessions, invoke the Show Chats command{0}.', '<keybinding:workbench.action.chat.history>'));
 			content.push(localize('workbench.action.chat.focusAgentSessionsViewer', 'You can focus the agent sessions list by invoking the Focus Agent Sessions command{0}.', `<keybinding:${FocusAgentSessionsAction.id}>`));
+			content.push(localize('workbench.action.openAgentsWindow', 'To open the Agents Window, invoke the Open Agents Window command{0}. In screen reader mode, this keybinding includes Alt to avoid conflicts with screen reader shortcuts.', '<keybinding:workbench.action.openAgentsWindow>'));
 		}
 		content.push(localize('chat.requestHistory', 'In the input box, use up and down arrows to navigate your request history. Edit input and use enter or the submit button to run a new request.'));
 		content.push(localize('chat.attachments.removal', 'To remove attached contexts, focus an attachment and press Delete or Backspace.'));

--- a/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts
@@ -12,7 +12,8 @@ import { ServicesAccessor } from '../../../../../editor/browser/editorExtensions
 import { localize, localize2 } from '../../../../../nls.js';
 import { IActionViewItemService } from '../../../../../platform/actions/browser/actionViewItemService.js';
 import { Action2, MenuId } from '../../../../../platform/actions/common/actions.js';
-import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { ContextKeyExpr, IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { CONTEXT_ACCESSIBILITY_MODE_ENABLED } from '../../../../../platform/accessibility/common/accessibility.js';
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { KeyCode, KeyMod } from '../../../../../base/common/keyCodes.js';
@@ -65,11 +66,17 @@ export class OpenAgentsWindowAction extends Action2 {
 			category: CHAT_CATEGORY,
 			precondition: OPEN_AGENTS_WINDOW_PRECONDITION,
 			f1: true,
-			keybinding: {
+			keybinding: [{
 				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyA,
 				weight: KeybindingWeight.WorkbenchContrib,
-				when: IsSessionsWindowContext.toNegated(),
-			},
+				when: ContextKeyExpr.and(IsSessionsWindowContext.toNegated(), CONTEXT_ACCESSIBILITY_MODE_ENABLED.toNegated()),
+			}, {
+				// In screen reader mode, Cmd/Ctrl+Shift+A conflicts with many screen reader keybindings,
+				// so require an additional Alt modifier.
+				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyMod.Alt | KeyCode.KeyA,
+				weight: KeybindingWeight.WorkbenchContrib,
+				when: ContextKeyExpr.and(IsSessionsWindowContext.toNegated(), CONTEXT_ACCESSIBILITY_MODE_ENABLED),
+			}],
 		});
 	}
 


### PR DESCRIPTION
`Cmd/Ctrl+Shift+A` (the default keybinding for `workbench.action.openAgentsWindow`) conflicts with many screen reader shortcuts (NVDA, JAWS, VoiceOver pass-through / selection chords).

When `accessibilityModeEnabled` is true, register the keybinding as `Cmd/Ctrl+Shift+Alt+A` instead. Also document the command (and the Alt variant) in the Chat Accessibility Help dialog so screen reader users can discover it.

Fixes #315340