### PR TITLE
Add ChatPluginMarketplaces enterprise policy

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -879,6 +879,17 @@ configurationRegistry.registerConfiguration({
 			default: ['github/copilot-plugins', 'github/awesome-copilot'],
 			scope: ConfigurationScope.APPLICATION,
 			tags: ['experimental'],
+			policy: {
+				name: 'ChatPluginMarketplaces',
+				category: PolicyCategory.InteractiveSession,
+				minimumVersion: '1.NNN',
+				localization: {
+					description: {
+						key: 'chat.plugins.marketplaces.policy.description',
+						value: nls.localize('chat.plugins.marketplaces.policy.description', "Restricts the list of plugin marketplaces queried by chat. When set, the user setting `#chat.plugins.marketplaces#` is overridden and only the marketplaces specified here are used. Entries may be GitHub shorthand (`owner/repo`), direct Git repository URIs (`https://...git`, `ssh://...git`, `git@host:path.git`), or local repository URIs (`file:///...`). Use this to point an organization at a curated, internally-vetted plugin marketplace.")
+					}
+				}
+			}
 		},
 		[ChatConfiguration.AgentEnabled]: {
 			type: 'boolean',


### PR DESCRIPTION
# Add `ChatPluginMarketplaces` enterprise policy

## Summary

Adds a `policy` block to the existing `chat.plugins.marketplaces` configuration so that the list of plugin marketplaces queried by chat (Agent Customizations) can be locked down by enterprise admins via Group Policy / Intune / `.plist`, per the [enterprise policies docs](https://code.visualstudio.com/docs/enterprise/policies).

## Motivation

Today, `chat.plugins.marketplaces` ([chat.contribution.ts#L873-L882](https://github.com/microsoft/vscode/blob/00ece6e638c9d3da24f27c0b90feade09f870834/src/vs/workbench/contrib/chat/browser/chat.contribution.ts#L873-L882)) defaults to:

```json
["github/copilot-plugins", "github/awesome-copilot"]
```

…and is freely overridable in user settings. Enterprises that want their developers to only consume plugins from an internal, vetted marketplace (e.g. a curated repo on GitHub Enterprise or a private org) currently have no way to enforce this. Any user can point chat at an arbitrary repo by editing `settings.json`.

Adding a `policy` block exposes the setting through the same managed-config channels as `ChatApprovedAccountOrganizations`, `ChatAgentMode`, `ExtensionGalleryServiceUrl`, etc. — making this safe to deploy in regulated/compliance-sensitive environments.

## Change

Single change: extend the existing schema entry with a `policy` block (mirrors the pattern used by [`chat.approvedAccountOrganizations`](https://github.com/microsoft/vscode/blob/00ece6e638c9d3da24f27c0b90feade09f870834/src/vs/workbench/contrib/chat/browser/chat.contribution.ts#L1569-L1585), which is also a `type: 'array'` policy):

```ts
[ChatConfiguration.PluginMarketplaces]: {
    type: 'array',
    items: { type: 'string' },
    markdownDescription: nls.localize('chat.plugins.marketplaces', "..."),
    default: ['github/copilot-plugins', 'github/awesome-copilot'],
    scope: ConfigurationScope.APPLICATION,
    tags: ['experimental'],
    policy: {
        name: 'ChatPluginMarketplaces',
        category: PolicyCategory.InteractiveSession,
        minimumVersion: '1.NNN',  // <-- to be set by VS Code maintainers
        localization: {
            description: { ... }
        }
    }
}
```

When the policy is set, the list is locked: `accountPolicyService` / `multiplexPolicyService` will override the user setting and only the policy-supplied marketplaces are queried.

## Open questions for maintainers

1. **`minimumVersion`** — placeholder `1.NNN` needs to be replaced with the target Insiders/stable version.
2. **`policyData.jsonc` entry** — once `minimumVersion` is fixed, a corresponding entry should be added to [`build/lib/policies/policyData.jsonc`](https://github.com/microsoft/vscode/blob/main/build/lib/policies/policyData.jsonc) so the ADMX/`.plist` artifacts pick it up.
3. **Stability** — the setting is currently `tags: ['experimental']`. Adding a policy implies some commitment to schema stability; happy to defer if the team would rather wait for GA.
4. **Workspace-level `extraKnownMarketplaces`** ([workspacePluginSettingsService.ts](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/chat/common/plugins/workspacePluginSettingsService.ts)) — should the policy also override these, or is it acceptable for workspace JSON to add additional marketplaces on top of policy-pinned ones? My read: policy should be the floor (always present) but workspace `extraKnownMarketplaces` should still be additive. Open to either interpretation.

## Testing

- [ ] Schema change compiles (`npm run compile`).
- [ ] Manual: set `ChatPluginMarketplaces` via registry / `defaults write`, confirm user setting is overridden.
- [ ] `policyData.jsonc` regeneration once `minimumVersion` is finalized.

## Notes

Filed as a draft to start the conversation. Happy to address the open questions above and follow up with the `policyData.jsonc` entry once version is settled.
