### PR TITLE
Fix build break in chatInputNotificationService announce

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputNotificationService.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputNotificationService.ts
@@ -168,12 +168,13 @@ class ChatInputNotificationService extends Disposable implements IChatInputNotif
 			this._lastAnnouncedSignature = undefined;
 			return;
 		}
-		const signature = `${active.id}\u0000${active.message}\u0000${active.description ?? ''}`;
+		const message = typeof active.message === 'string' ? active.message : active.message.value;
+		const signature = `${active.id}\u0000${message}\u0000${active.description ?? ''}`;
 		if (signature === this._lastAnnouncedSignature) {
 			return;
 		}
 		this._lastAnnouncedSignature = signature;
-		const text = active.description ? `${active.message}. ${active.description}` : active.message;
+		const text = active.description ? `${message}. ${active.description}` : message;
 		status(text);
 	}
 }


### PR DESCRIPTION
## What

`IChatInputNotification.message` is typed `string | IMarkdownString`, but the new ARIA-announce code in #313787 fed it directly into `aria.status(...)` and a template literal, which require `string`. The internal Azure DevOps build broke immediately after the merge with:

```
src/vs/workbench/contrib/chat/browser/widget/input/chatInputNotificationService.ts(177,10):
  error TS2345: Argument of type 'string | IMarkdownString' is not assignable to parameter of type 'string'.
```

Fix: coerce `message` to a string by reading `.value` when it's an `IMarkdownString` before building the signature and the announced text.

## Why CI didn't catch it (semantic merge conflict)

- #313787 last ran CI on its branch head on **2026-05-04**, when `IChatInputNotification.message` was still typed `string`. The new code type-checked.
- On **2026-05-07**, #315170 ("Clear details on sign out") widened `message` to `string | IMarkdownString`.
- On **2026-05-08**, #313787 merged into `main` without being rebased and without re-running CI on the merged tree. The post-merge Azure pipeline ([build 437556](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=437556)) was the first job to compile the merge commit, so it surfaced the error.

`.github/workflows/pr.yml` (and the other `pr-*.yml` workflows) only trigger on `pull_request:`. There is no `merge_group:` trigger and no required-up-to-date branch protection, so GitHub never recompiles the merge commit before/after merging. Suggest enabling either:
- **GitHub merge queue** for `main` + add `merge_group:` to the gating workflows, or
- branch-protection setting **"Require branches to be up to date before merging"**.

Both require repo-admin settings, so I haven't changed YAML here — happy to follow up with a workflow PR once a direction is picked.

## Verification

`Core - Typecheck` watch task: `Finished compilation with 0 errors`.