### PR TITLE
Bump auto-mode router decision timeout from 1s to 2.5s

### DIFF
--- a/extensions/copilot/src/platform/endpoint/node/routerDecisionFetcher.ts
+++ b/extensions/copilot/src/platform/endpoint/node/routerDecisionFetcher.ts
@@ -82,7 +82,7 @@ export class RouterDecisionFetcher {
 		const copilotToken = copilotTokenObj.token;
 		requestBody.copilot_plan = copilotTokenObj.rawCopilotPlan;
 		const abortController = new AbortController();
-		const timeout = setTimeout(() => abortController.abort(), 1000);
+		const timeout = setTimeout(() => abortController.abort(), 2500);
 		let response: Response;
 		try {
 			response = await this._capiClientService.makeRequest<Response>({

--- a/extensions/copilot/src/platform/endpoint/node/test/automodeService.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/automodeService.spec.ts
@@ -553,8 +553,8 @@ describe('AutomodeService', () => {
 			};
 
 			const resultPromise = automodeService.resolveAutoModeEndpoint(chatRequest as ChatRequest, [claudeEndpoint, gpt4oEndpoint]);
-			// Advance past the 1-second router timeout to trigger the abort
-			await vi.advanceTimersByTimeAsync(1000);
+			// Advance past the 2.5-second router timeout to trigger the abort
+			await vi.advanceTimersByTimeAsync(2500);
 
 			const result = await resultPromise;
 			// Should fall back to first available model (claude-sonnet)


### PR DESCRIPTION
Server p95 for the auto-intent-service is ~600ms, leaving the 1s client timeout almost no margin for network RTT and the p99 tail. Telemetry shows `routerTimeout` fallbacks growing from ~6K/day to ~50K/day after the recent Hydra rollout — driven entirely by tail amplification at higher traffic, not by any server-side latency regression (server p95 is flat across the rollout).%0A%0ABumping to 2.5s gives ~4x headroom over server p95 and should drop `routerTimeout` back near the noise floor without any server-side scaling.