### PR TITLE
Fix for using `reopen with` on dirty untitled doc incorrectly dropping file data

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadCustomEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadCustomEditors.ts
@@ -46,6 +46,7 @@ import { IWorkingCopy, IWorkingCopyBackup, IWorkingCopySaveEvent, NO_TYPE_ID, Wo
 import { IWorkingCopyFileService, WorkingCopyFileEvent } from '../../services/workingCopy/common/workingCopyFileService.js';
 import { IWorkingCopyService } from '../../services/workingCopy/common/workingCopyService.js';
 import { IUriIdentityService } from '../../../platform/uriIdentity/common/uriIdentity.js';
+import { IUntitledTextEditorService } from '../../services/untitled/common/untitledTextEditorService.js';
 
 const enum CustomEditorModelType {
 	Custom,
@@ -100,6 +101,7 @@ export class MainThreadCustomEditors extends Disposable implements extHostProtoc
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@IWebviewWorkbenchService private readonly _webviewWorkbenchService: IWebviewWorkbenchService,
 		@IUriIdentityService private readonly _uriIdentityService: IUriIdentityService,
+		@IUntitledTextEditorService private readonly _untitledTextEditorService: IUntitledTextEditorService,
 	) {
 		super();
 
@@ -419,7 +421,7 @@ export class MainThreadCustomEditors extends Disposable implements extHostProtoc
 				}
 			case CustomEditorModelType.Custom:
 				{
-					const model = MainThreadCustomEditorModel.create(this._instantiationService, this._proxyCustomEditors, viewType, resource, options, () => {
+					const model = MainThreadCustomEditorModel.create(this._instantiationService, this._proxyCustomEditors, viewType, resource, options, this._untitledTextEditorService, () => {
 						return Array.from(this.mainThreadWebviewPanels.webviewInputs)
 							.filter(editor =>
 								(editor instanceof CustomEditorInput && isEqual(editor.resource, resource))
@@ -529,6 +531,7 @@ class MainThreadCustomEditorModel extends ResourceWorkingCopy implements ICustom
 		viewType: string,
 		resource: URI,
 		options: { backupId?: string },
+		untitledTextEditorService: IUntitledTextEditorService,
 		getEditors: () => CustomEditorWebviewInput[],
 		cancellation: CancellationToken,
 	): Promise<MainThreadCustomEditorModel> {
@@ -539,6 +542,14 @@ class MainThreadCustomEditorModel extends ResourceWorkingCopy implements ICustom
 			untitledDocumentData = primaryCustomEditorInput.untitledDocumentData;
 		}
 		const { editable } = await proxy.$createCustomDocument(resource, viewType, options.backupId, untitledDocumentData, cancellation);
+
+		// Now that the extension has received the untitledDocumentData, revert
+		// the untitled text model so it is no longer tracked as a separate dirty
+		// working copy (avoids double-dirty prompts, see #125293).
+		if (untitledDocumentData && resource.scheme === Schemas.untitled) {
+			untitledTextEditorService.get(resource)?.revert();
+		}
+
 		return instantiationService.createInstance(MainThreadCustomEditorModel, proxy, viewType, resource, !!options.backupId, editable, !!untitledDocumentData, getEditors);
 	}
 

--- a/src/vs/workbench/contrib/customEditor/browser/customEditorInput.ts
+++ b/src/vs/workbench/contrib/customEditor/browser/customEditorInput.ts
@@ -58,10 +58,6 @@ export class CustomEditorInput extends LazilyResolvedWebviewEditorInput {
 			const untitledString = untitledTextModel?.textEditorModel?.getValue();
 			const untitledDocumentData = untitledString ? VSBuffer.fromString(untitledString) : undefined;
 
-			// If we're taking over an untitled text editor, revert it so it's no longer
-			// tracked as a dirty working copy (fixes #125293).
-			untitledTextModel?.revert();
-
 			const webview = accessor.get(IWebviewService).createWebviewOverlay({
 				providedViewType: init.viewType,
 				title: init.webviewTitle,

--- a/src/vs/workbench/services/untitled/common/untitledTextEditorHandler.ts
+++ b/src/vs/workbench/services/untitled/common/untitledTextEditorHandler.ts
@@ -109,7 +109,11 @@ export class UntitledTextEditorWorkingCopyEditorHandler extends Disposable imple
 			return false;
 		}
 
-		return editor instanceof UntitledTextEditorInput && isEqual(workingCopy.resource, editor.resource);
+		// Also match editors that are not UntitledTextEditorInput but share the
+		// same untitled resource (e.g. a text-based custom editor that wraps the
+		// same underlying text model). Without this, the backup restorer would
+		// create a duplicate UntitledTextEditorInput alongside the custom editor.
+		return isEqual(workingCopy.resource, editor.resource);
 	}
 
 	createEditor(workingCopy: IWorkingCopyIdentifier): EditorInput {

--- a/src/vs/workbench/services/untitled/test/browser/untitledTextEditor.test.ts
+++ b/src/vs/workbench/services/untitled/test/browser/untitledTextEditor.test.ts
@@ -8,7 +8,7 @@ import { URI } from '../../../../../base/common/uri.js';
 import { join } from '../../../../../base/common/path.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IUntitledTextEditorService, UntitledTextEditorService } from '../../common/untitledTextEditorService.js';
-import { workbenchInstantiationService, TestServiceAccessor } from '../../../../test/browser/workbenchTestServices.js';
+import { workbenchInstantiationService, TestServiceAccessor, TestEditorInput } from '../../../../test/browser/workbenchTestServices.js';
 import { snapshotToString } from '../../../textfile/common/textfiles.js';
 import { PLAINTEXT_LANGUAGE_ID } from '../../../../../editor/common/languages/modesRegistry.js';
 import { ISingleEditOperation } from '../../../../../editor/common/core/editOperation.js';
@@ -21,6 +21,9 @@ import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { isReadable, isReadableStream } from '../../../../../base/common/stream.js';
 import { readableToBuffer, streamToBuffer, VSBufferReadable, VSBufferReadableStream } from '../../../../../base/common/buffer.js';
 import { LanguageDetectionLanguageEventSource } from '../../../languageDetection/common/languageDetectionWorkerService.js';
+import { Schemas } from '../../../../../base/common/network.js';
+import { UntitledTextEditorWorkingCopyEditorHandler } from '../../common/untitledTextEditorHandler.js';
+import { NO_TYPE_ID } from '../../../workingCopy/common/workingCopy.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { timeout } from '../../../../../base/common/async.js';
 
@@ -618,6 +621,70 @@ suite('Untitled text editors', () => {
 
 		const canDispose2 = service.canDispose(model as UntitledTextEditorModel);
 		assert.strictEqual(canDispose2, true);
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+});
+
+suite('UntitledTextEditorWorkingCopyEditorHandler', () => {
+
+	const disposables = new DisposableStore();
+	let instantiationService: IInstantiationService;
+	let handler: UntitledTextEditorWorkingCopyEditorHandler;
+
+	setup(() => {
+		instantiationService = workbenchInstantiationService(undefined, disposables);
+		const accessor = instantiationService.createInstance(TestServiceAccessor);
+		disposables.add(accessor.untitledTextEditorService as UntitledTextEditorService);
+		handler = disposables.add(instantiationService.createInstance(UntitledTextEditorWorkingCopyEditorHandler));
+	});
+
+	teardown(() => {
+		disposables.clear();
+	});
+
+	test('handles only untitled working copies with no type id', () => {
+		const untitledResource = URI.from({ scheme: Schemas.untitled, path: 'Untitled-1' });
+
+		assert.strictEqual(handler.handles({ resource: untitledResource, typeId: NO_TYPE_ID }), true);
+		assert.strictEqual(handler.handles({ resource: untitledResource, typeId: 'someTypeId' }), false);
+		assert.strictEqual(handler.handles({ resource: URI.file('/test.txt'), typeId: NO_TYPE_ID }), false);
+	});
+
+	test('isOpen matches UntitledTextEditorInput with same resource', () => {
+		const untitledResource = URI.from({ scheme: Schemas.untitled, path: 'Untitled-1' });
+		const workingCopy = { resource: untitledResource, typeId: NO_TYPE_ID };
+
+		const untitledInput = disposables.add(instantiationService.createInstance(UntitledTextEditorInput, instantiationService.createInstance(TestServiceAccessor).untitledTextEditorService.create({ untitledResource })));
+		assert.strictEqual(handler.isOpen(workingCopy, untitledInput), true);
+	});
+
+	test('isOpen matches non-UntitledTextEditorInput editors with same untitled resource', () => {
+		const untitledResource = URI.from({ scheme: Schemas.untitled, path: 'Untitled-1' });
+		const workingCopy = { resource: untitledResource, typeId: NO_TYPE_ID };
+
+		// A custom editor (or any other editor type) sharing the same untitled resource
+		// should be recognized as representing this working copy to prevent duplicate
+		// tabs on backup restoration.
+		const customEditorInput = disposables.add(new TestEditorInput(untitledResource, 'customEditorType'));
+		assert.strictEqual(handler.isOpen(workingCopy, customEditorInput), true);
+	});
+
+	test('isOpen does not match editors with different resource', () => {
+		const untitledResource1 = URI.from({ scheme: Schemas.untitled, path: 'Untitled-1' });
+		const untitledResource2 = URI.from({ scheme: Schemas.untitled, path: 'Untitled-2' });
+		const workingCopy = { resource: untitledResource1, typeId: NO_TYPE_ID };
+
+		const otherInput = disposables.add(new TestEditorInput(untitledResource2, 'customEditorType'));
+		assert.strictEqual(handler.isOpen(workingCopy, otherInput), false);
+	});
+
+	test('isOpen returns false for non-untitled working copies', () => {
+		const fileResource = URI.file('/test.txt');
+		const workingCopy = { resource: fileResource, typeId: NO_TYPE_ID };
+
+		const editor = disposables.add(new TestEditorInput(fileResource, 'testType'));
+		assert.strictEqual(handler.isOpen(workingCopy, editor), false);
 	});
 
 	ensureNoDisposablesAreLeakedInTestSuite();


### PR DESCRIPTION
Fixes #315243

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
