### PR TITLE
Run copilot extension lint in PR CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -309,6 +309,10 @@ jobs:
         working-directory: extensions/copilot
         run: npm run typecheck
 
+      - name: Lint
+        working-directory: extensions/copilot
+        run: npm run lint
+
       - name: Compile
         working-directory: extensions/copilot
         run: npm run compile
@@ -406,6 +410,10 @@ jobs:
       - name: TypeScript type checking
         working-directory: extensions/copilot
         run: npm run typecheck
+
+      - name: Lint
+        working-directory: extensions/copilot
+        run: npm run lint
 
       - name: Compile
         working-directory: extensions/copilot


### PR DESCRIPTION
## Why

The build break in https://dev.azure.com/monacotools/_build/results?buildId=436973, introduced by 639132100f6 ([#314783](https://github.com/microsoft/vscode/pull/314783)) and fixed by [#314934](https://github.com/microsoft/vscode/pull/314934), was a copilot-extension lint failure (`copilot-local/no-unlayered-files` — a `.spec.ts` was placed at `extensions/copilot/src/platform/chat/test/` instead of inside a layer folder like `test/common/`).

PR CI didn't catch it because the `copilot-linux-tests` and `copilot-windows-tests` jobs in `.github/workflows/pr.yml` ran typecheck, compile, unit tests, and simulation, but not `npm run lint`. The lint step only runs in the AzDO `product-build` pipeline, which is `pr: none` and only triggers on merges to `main`.

## What

Adds a `Lint` step (`npm run lint`) after typecheck in both `copilot-linux-tests` and `copilot-windows-tests` jobs.