### PR TITLE
Fixed tokenizer bug for customOAI models

### DIFF
--- a/extensions/copilot/src/extension/prompts/node/panel/toolCalling.tsx
+++ b/extensions/copilot/src/extension/prompts/node/panel/toolCalling.tsx
@@ -492,6 +492,7 @@ export function sendInvokedToolTelemetry(instantiationService: IInstantiationSer
 	// matching the prior behavior with modelMaxPromptTokens: Infinity
 	const endpointWithUnlimitedBudget: IChatEndpoint = {
 		...endpoint,
+		tokenizer: endpoint.tokenizer,
 		modelMaxPromptTokens: Infinity,
 	};
 


### PR DESCRIPTION
[This](https://github.com/microsoft/vscode/commit/44ffe22e115) commit introduced a bug where evals with a customOAI model endpoint would fail with `Unknown tokenizer: undefined` for any tool call. This fixes that issue.