### PR TITLE
Fall back to first known endpoint when no available_models match (auto-mode)

### DIFF
--- a/extensions/copilot/src/platform/endpoint/node/automodeService.ts
+++ b/extensions/copilot/src/platform/endpoint/node/automodeService.ts
@@ -368,12 +368,36 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 	private _selectDefaultModel(currentModelProvider: string | undefined, availableModels: string[], knownEndpoints: IChatEndpoint[]): IChatEndpoint {
 		const selectedModel = (currentModelProvider && this._findSameProviderModel(currentModelProvider, availableModels, knownEndpoints))
 			?? this._findFirstAvailableModel(availableModels, knownEndpoints);
-		if (!selectedModel) {
-			const errorMsg = 'Auto mode failed: no available model found in known endpoints.';
-			this._logService.error(errorMsg);
-			throw new Error(errorMsg);
+		if (selectedModel) {
+			return selectedModel;
 		}
-		return selectedModel;
+		// AutoModels (cached up to 6h in the CopilotToken) and the Models API
+		// (refreshed every 10min) are independent CAPI calls and can drift, so
+		// `available_models` may have zero overlap with `knownEndpoints` (e.g.
+		// a model was removed server-side after the token was minted). Rather
+		// than throwing "Auto mode failed: no available model found in known
+		// endpoints" and breaking the chat, fall back to the first known
+		// endpoint so the user can keep working. Emit telemetry so we can
+		// monitor how often this happens.
+		const fallbackEndpoint = knownEndpoints[0];
+		this._logService.warn(
+			`[AutomodeService] No available_models matched knownEndpoints; using fallback endpoint '${fallbackEndpoint.model}'. ` +
+			`available_models=[${availableModels.join(', ')}], knownEndpoints=[${knownEndpoints.map(e => e.model).join(', ')}]`,
+		);
+		/* __GDPR__
+			"automode.noEndpointFallback" : {
+				"owner": "aashnagarg",
+				"comment": "Reports when AutoModels available_models has no overlap with knownEndpoints and the client falls back to the first known endpoint instead of failing.",
+				"availableModelCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "comment": "Number of models in the AutoModels response" },
+				"knownEndpointCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "comment": "Number of known endpoints from the Models API" },
+				"fallbackModel": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "The model selected as the safe fallback" }
+			}
+		*/
+		this._telemetryService.sendMSFTTelemetryEvent('automode.noEndpointFallback',
+			{ fallbackModel: fallbackEndpoint.model },
+			{ availableModelCount: availableModels.length, knownEndpointCount: knownEndpoints.length },
+		);
+		return fallbackEndpoint;
 	}
 
 	private _isRouterEnabled(chatRequest: ChatRequest | undefined): boolean {

--- a/extensions/copilot/src/platform/endpoint/node/test/automodeService.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/automodeService.spec.ts
@@ -432,7 +432,7 @@ describe('AutomodeService', () => {
 			expect(secondResult).toBe(firstResult);
 		});
 
-		it('should throw when no available models match any known endpoint', async () => {
+		it('should fall back to first known endpoint when no available models match', async () => {
 			mockApiResponse(['unknown-model-1', 'unknown-model-2']);
 
 			automodeService = createService();
@@ -442,9 +442,11 @@ describe('AutomodeService', () => {
 				sessionId: 'session-no-match'
 			};
 
-			await expect(
-				automodeService.resolveAutoModeEndpoint(chatRequest as ChatRequest, [mockChatEndpoint])
-			).rejects.toThrow('no available model found');
+			const result = await automodeService.resolveAutoModeEndpoint(chatRequest as ChatRequest, [mockChatEndpoint]);
+			expect(result.model).toBe(mockChatEndpoint.model);
+			expect(mockLogService.warn).toHaveBeenCalledWith(
+				expect.stringContaining('No available_models matched knownEndpoints; using fallback endpoint')
+			);
 		});
 	});
 
@@ -1241,7 +1243,7 @@ describe('AutomodeService', () => {
 			expect(result.model).toBe('gpt-4.1');
 		});
 
-		it('should throw when all available_models are unknown to knownEndpoints', async () => {
+		it('should fall back to first known endpoint when all available_models are unknown', async () => {
 			enableRouter();
 			const gpt4oEndpoint = createEndpoint('gpt-4o', 'OpenAI');
 
@@ -1265,9 +1267,8 @@ describe('AutomodeService', () => {
 				sessionId: 'session-all-unknown'
 			};
 
-			await expect(
-				automodeService.resolveAutoModeEndpoint(chatRequest as ChatRequest, [gpt4oEndpoint])
-			).rejects.toThrow('no available model found');
+			const result = await automodeService.resolveAutoModeEndpoint(chatRequest as ChatRequest, [gpt4oEndpoint]);
+			expect(result.model).toBe('gpt-4o');
 			expect(mockLogService.warn).toHaveBeenCalledWith(
 				expect.stringContaining('No available_models matched knownEndpoints')
 			);


### PR DESCRIPTION
## Problem

Users on VS Code 1.119.0 are hitting `Auto mode failed: no available model found in known endpoints` on some queries (reported by @nhu-do in Slack; others affected too).

**Root cause:** `available_models` (from the AutoModels CAPI call, cached up to **6 hours** in the `CopilotToken`) and `knownEndpoints` (from the Models API, refreshed every 10 minutes) are independent CAPI calls and can drift. When `available_models` has zero overlap with `knownEndpoints` -- e.g. a model was removed server-side after the token was minted, or appears in the token before the Models API knows about it -- `_selectDefaultModel` throws and breaks auto-mode for the user.

The April 16 fix (2d68d33) handled this on the **router path** (filter `available_models` through `knownEndpoints` before sending to the router, fall back cleanly with `fallbackReason: 'noMatchingEndpoint'`). But the **non-router path** (`_selectDefaultModel`, used when the router is disabled, returns empty candidates, errors, or the request short-circuits via `emptyPrompt`/cached prompt) still throws.

## Fix

In `_selectDefaultModel`, when no `available_models` resolve to a known endpoint, fall back to `knownEndpoints[0]` instead of throwing. Log a warn and emit a new `automode.noEndpointFallback` telemetry event so we can monitor frequency.

The first known endpoint is the same selection `_findFirstAvailableModel` would return if `available_models` were a no-op pass-through, so this is the closest "safe default" available client-side. Vision fallback still runs after, so vision requests aren't broken.

## Tests

Updated two existing tests that asserted the throw to instead assert the graceful fallback. Both verify the warn log fires and the returned endpoint is the first known one.

## Telemetry

New `automode.noEndpointFallback` event:
- `fallbackModel` (string): the model used as fallback
- `availableModelCount` (measurement): number of models in the AutoModels response
- `knownEndpointCount` (measurement): number of known endpoints from the Models API
