### PR TITLE
sessions: add back/forward session navigation

### DIFF
--- a/src/vs/sessions/browser/menus.ts
+++ b/src/vs/sessions/browser/menus.ts
@@ -26,6 +26,7 @@ export const Menus = {
 	SidebarCustomizations: new MenuId('SessionsSidebarCustomizations'),
 	SidebarAgentHost: new MenuId('SessionsSidebarAgentHost'),
 	AccountMenu: new MenuId('SessionsAccountMenu'),
+	GoMenu: new MenuId('SessionsGoMenu'),
 	AgentFeedbackEditorContent: new MenuId('AgentFeedbackEditorContent'),
 
 	NewSessionConfig: new MenuId('NewSessions.SessionConfigMenu'),

--- a/src/vs/sessions/browser/parts/menubar.contribution.ts
+++ b/src/vs/sessions/browser/parts/menubar.contribution.ts
@@ -6,6 +6,7 @@
 import { localize } from '../../../nls.js';
 import { MenuId, MenuRegistry } from '../../../platform/actions/common/actions.js';
 import { IsMacNativeContext } from '../../../platform/contextkey/common/contextkeys.js';
+import { Menus } from '../menus.js';
 
 MenuRegistry.appendMenuItem(MenuId.MenubarMainMenu, {
 	submenu: MenuId.MenubarFileMenu,
@@ -35,6 +36,16 @@ MenuRegistry.appendMenuItem(MenuId.MenubarMainMenu, {
 		mnemonicTitle: localize({ key: 'mView', comment: ['&& denotes a mnemonic'] }, "&&View")
 	},
 	order: 4
+});
+
+MenuRegistry.appendMenuItem(MenuId.MenubarMainMenu, {
+	submenu: Menus.GoMenu,
+	title: {
+		value: 'Go',
+		original: 'Go',
+		mnemonicTitle: localize({ key: 'mGo', comment: ['&& denotes a mnemonic'] }, "&&Go")
+	},
+	order: 5
 });
 
 MenuRegistry.appendMenuItem(MenuId.MenubarMainMenu, {

--- a/src/vs/sessions/common/contextkeys.ts
+++ b/src/vs/sessions/common/contextkeys.ts
@@ -46,6 +46,13 @@ export const SessionsAquariumActiveContext = new RawContextKey<boolean>('session
 
 //#endregion
 
+//#region < --- Session Navigation --- >
+
+export const CanGoBackContext = new RawContextKey<boolean>('sessionsCanGoBack', false, localize('sessionsCanGoBack', "Whether there is a previous session in the navigation history"));
+export const CanGoForwardContext = new RawContextKey<boolean>('sessionsCanGoForward', false, localize('sessionsCanGoForward', "Whether there is a next session in the navigation history"));
+
+//#endregion
+
 //#region < --- Editor --- >
 
 export const EditorMaximizedContext = new RawContextKey<boolean>('editorMaximized', false, localize('editorMaximized', "Whether the editor area is maximized"));

--- a/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
@@ -3,17 +3,21 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Codicon } from '../../../../base/common/codicons.js';
 import { fromNow } from '../../../../base/common/date.js';
 import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { localize, localize2 } from '../../../../nls.js';
 import { Action2, registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { IQuickInputService, IQuickPickItem, IQuickPickSeparator } from '../../../../platform/quickinput/common/quickInput.js';
-import { IsSessionsWindowContext } from '../../../../workbench/common/contextkeys.js';
+import { IsAuxiliaryWindowContext, IsSessionsWindowContext } from '../../../../workbench/common/contextkeys.js';
+import { Menus } from '../../../browser/menus.js';
 import { SessionsCategories } from '../../../common/categories.js';
+import { CanGoBackContext, CanGoForwardContext, SessionsWelcomeVisibleContext } from '../../../common/contextkeys.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ISession } from '../../../services/sessions/common/session.js';
 
@@ -103,5 +107,85 @@ registerAction2(class ShowSessionsPickerAction extends Action2 {
 		disposables.add(picker.onDidHide(() => disposables.dispose()));
 
 		picker.show();
+	}
+});
+
+// -- Go Back --
+
+registerAction2(class GoBackAction extends Action2 {
+	constructor() {
+		super({
+			id: 'sessions.goBack',
+			title: {
+				...localize2('sessionsGoBack', "Go Back"),
+				mnemonicTitle: localize({ key: 'miSessionsBack', comment: ['&& denotes a mnemonic'] }, "&&Back")
+			},
+			f1: true,
+			icon: Codicon.arrowLeft,
+			category: SessionsCategories.Sessions,
+			precondition: CanGoBackContext,
+			keybinding: {
+				weight: KeybindingWeight.WorkbenchContrib,
+				win: { primary: KeyMod.Alt | KeyCode.LeftArrow },
+				mac: { primary: KeyMod.WinCtrl | KeyCode.Minus },
+				linux: { primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.Minus },
+				when: IsSessionsWindowContext,
+			},
+			menu: [{
+				id: Menus.TitleBarLeftLayout,
+				group: 'navigation',
+				order: 1,
+				when: ContextKeyExpr.and(IsAuxiliaryWindowContext.toNegated(), SessionsWelcomeVisibleContext.toNegated()),
+			}, {
+				id: Menus.GoMenu,
+				group: '1_history_nav',
+				order: 1,
+			}]
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		const sessionsManagementService = accessor.get(ISessionsManagementService);
+		await sessionsManagementService.openPreviousSession();
+	}
+});
+
+// -- Go Forward --
+
+registerAction2(class GoForwardAction extends Action2 {
+	constructor() {
+		super({
+			id: 'sessions.goForward',
+			title: {
+				...localize2('sessionsGoForward', "Go Forward"),
+				mnemonicTitle: localize({ key: 'miSessionsForward', comment: ['&& denotes a mnemonic'] }, "&&Forward")
+			},
+			f1: true,
+			icon: Codicon.arrowRight,
+			category: SessionsCategories.Sessions,
+			precondition: CanGoForwardContext,
+			keybinding: {
+				weight: KeybindingWeight.WorkbenchContrib,
+				win: { primary: KeyMod.Alt | KeyCode.RightArrow },
+				mac: { primary: KeyMod.WinCtrl | KeyMod.Shift | KeyCode.Minus },
+				linux: { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Minus },
+				when: IsSessionsWindowContext,
+			},
+			menu: [{
+				id: Menus.TitleBarLeftLayout,
+				group: 'navigation',
+				order: 2,
+				when: ContextKeyExpr.and(IsAuxiliaryWindowContext.toNegated(), SessionsWelcomeVisibleContext.toNegated()),
+			}, {
+				id: Menus.GoMenu,
+				group: '1_history_nav',
+				order: 2,
+			}]
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		const sessionsManagementService = accessor.get(ISessionsManagementService);
+		await sessionsManagementService.openNextSession();
 	}
 });

--- a/src/vs/sessions/services/sessions/browser/sessionNavigation.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionNavigation.ts
@@ -1,0 +1,217 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { autorun, derived, IObservable, observableValue } from '../../../../base/common/observable.js';
+import { URI } from '../../../../base/common/uri.js';
+import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { CanGoBackContext, CanGoForwardContext } from '../../../common/contextkeys.js';
+import { SessionStatus } from '../common/session.js';
+import { ISessionsChangeEvent, ISessionsManagementService } from '../common/sessionsManagement.js';
+
+const MAX_HISTORY_SIZE = 50;
+
+/**
+ * A navigation history entry. Stores the session resource URI.
+ */
+interface INavigationEntry {
+	readonly sessionResource: URI;
+}
+
+/**
+ * Tracks session navigation history and provides back/forward navigation.
+ * Created and owned by {@link SessionsManagementService}.
+ */
+export class SessionsNavigation extends Disposable {
+
+	private readonly _history: INavigationEntry[] = [];
+	private readonly _currentIndex = observableValue<number>(this, -1);
+
+	/** Guard: true while we are performing a back/forward navigation. */
+	private _navigating = false;
+
+	/**
+	 * True when the user has explicitly navigated to the new-session view after
+	 * having been on a real session. Enables going back to the last real session
+	 * without storing a new-session view entry in the history stack.
+	 */
+	private readonly _beyondHistory = observableValue<boolean>(this, false);
+
+	private readonly _canGoBackCtx: IContextKey<boolean>;
+	private readonly _canGoForwardCtx: IContextKey<boolean>;
+
+	private readonly _canGoBack: IObservable<boolean> = derived(this, reader => {
+		const idx = this._currentIndex.read(reader);
+		const beyond = this._beyondHistory.read(reader);
+		return idx > 0 || (beyond && idx >= 0);
+	});
+
+	private readonly _canGoForward: IObservable<boolean> = derived(this, reader => {
+		if (this._beyondHistory.read(reader)) {
+			return false;
+		}
+		return this._currentIndex.read(reader) < this._history.length - 1;
+	});
+
+	constructor(
+		private readonly _sessionsManagementService: ISessionsManagementService,
+		contextKeyService: IContextKeyService,
+		private readonly _logService: ILogService,
+	) {
+		super();
+
+		this._canGoBackCtx = CanGoBackContext.bindTo(contextKeyService);
+		this._canGoForwardCtx = CanGoForwardContext.bindTo(contextKeyService);
+
+		// Track active session changes to record history entries.
+		// Skip undefined (new-session view) and Untitled sessions — only record
+		// sessions that have been saved/submitted.
+		// NOTE: activeSession.read(reader) must always be called first to keep the
+		// subscription alive even during navigation, otherwise the autorun loses its
+		// dependency and stops firing after goBack/goForward completes.
+		this._register(autorun(reader => {
+			const activeSession = this._sessionsManagementService.activeSession.read(reader);
+			if (this._navigating) {
+				return;
+			}
+			if (!activeSession || activeSession.status.read(reader) === SessionStatus.Untitled) {
+				// User navigated to new-session view: if we have history, remember we're
+				// beyond the stack so Back can return to the last real session.
+				if (this._history.length > 0) {
+					this._beyondHistory.set(true, undefined);
+				}
+				return;
+			}
+
+			this._beyondHistory.set(false, undefined);
+			this._pushEntry({ sessionResource: activeSession.resource });
+		}));
+
+		// Sync context keys with observables
+		this._register(autorun(reader => {
+			this._canGoBackCtx.set(this._canGoBack.read(reader));
+			this._canGoForwardCtx.set(this._canGoForward.read(reader));
+		}));
+	}
+
+	onDidRemoveSessions(e: ISessionsChangeEvent): void {
+		if (e.removed.length === 0) {
+			return;
+		}
+		const removedUris = new Set(e.removed.map(s => s.resource.toString()));
+		this._removeEntriesMatching(uri => removedUris.has(uri.toString()));
+	}
+
+	async goBack(): Promise<void> {
+		if (this._beyondHistory.get()) {
+			// User is on new-session view — go back to the last real session
+			this._beyondHistory.set(false, undefined);
+			await this._navigateTo(this._currentIndex.get());
+			return;
+		}
+		const idx = this._currentIndex.get();
+		if (idx <= 0) {
+			return;
+		}
+		await this._navigateTo(idx - 1);
+	}
+
+	async goForward(): Promise<void> {
+		const idx = this._currentIndex.get();
+		if (idx >= this._history.length - 1) {
+			return;
+		}
+		await this._navigateTo(idx + 1);
+	}
+
+	private _pushEntry(entry: INavigationEntry): void {
+		const currentIdx = this._currentIndex.get();
+
+		// Check if the new entry is the same as the current one
+		if (currentIdx >= 0 && currentIdx < this._history.length) {
+			const current = this._history[currentIdx];
+			if (this._isSameEntry(current, entry)) {
+				return;
+			}
+		}
+
+		// Truncate forward history
+		if (currentIdx < this._history.length - 1) {
+			this._history.splice(currentIdx + 1);
+		}
+
+		// Remove any existing entry for the same session to avoid duplicates
+		const existingIdx = this._history.findIndex(e => this._isSameEntry(e, entry));
+		if (existingIdx >= 0) {
+			this._history.splice(existingIdx, 1);
+		}
+
+		// Enforce max size by removing oldest entries
+		if (this._history.length >= MAX_HISTORY_SIZE) {
+			this._history.splice(0, this._history.length - MAX_HISTORY_SIZE + 1);
+		}
+
+		this._history.push(entry);
+		this._currentIndex.set(this._history.length - 1, undefined);
+
+		this._logService.trace(`[SessionNavigation] pushed entry idx=${this._history.length - 1} uri=${entry.sessionResource.toString()} historySize=${this._history.length}`);
+	}
+
+	private async _navigateTo(targetIdx: number): Promise<void> {
+		const entry = this._history[targetIdx];
+		if (!entry) {
+			return;
+		}
+
+		this._logService.trace(`[SessionNavigation] navigating to idx=${targetIdx} uri=${entry.sessionResource.toString()}`);
+
+		this._navigating = true;
+		try {
+			this._currentIndex.set(targetIdx, undefined);
+
+			const session = this._sessionsManagementService.getSession(entry.sessionResource);
+			if (session) {
+				await this._sessionsManagementService.openSession(entry.sessionResource);
+			} else {
+				// Session no longer exists, remove it and try again
+				this._history.splice(targetIdx, 1);
+				if (targetIdx <= this._currentIndex.get()) {
+					this._currentIndex.set(Math.max(0, this._currentIndex.get() - 1), undefined);
+				}
+			}
+		} finally {
+			this._navigating = false;
+		}
+	}
+
+	private _isSameEntry(a: INavigationEntry, b: INavigationEntry): boolean {
+		return a.sessionResource.toString() === b.sessionResource.toString();
+	}
+
+	private _removeEntriesMatching(predicate: (uri: URI) => boolean): void {
+		const currentIdx = this._currentIndex.get();
+		let newCurrentIdx = currentIdx;
+		let i = 0;
+
+		while (i < this._history.length) {
+			const entry = this._history[i];
+			if (predicate(entry.sessionResource)) {
+				this._history.splice(i, 1);
+				if (i < newCurrentIdx) {
+					newCurrentIdx--;
+				} else if (i === newCurrentIdx) {
+					newCurrentIdx = Math.min(newCurrentIdx, this._history.length - 1);
+				}
+			} else {
+				i++;
+			}
+		}
+
+		if (newCurrentIdx !== currentIdx) {
+			this._currentIndex.set(Math.max(0, newCurrentIdx), undefined);
+		}
+	}
+}

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -23,6 +23,7 @@ import { ISendRequestOptions, ISessionChangeEvent, ISessionsProvider } from '../
 import { IChat, ISession, isWorkspaceAgentSessionType, SessionStatus, ISessionType } from '../common/session.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { LOCAL_AGENT_HOST_PROVIDER_ID } from '../../../common/agentHostSessionsProvider.js';
+import { SessionsNavigation } from './sessionNavigation.js';
 
 const ACTIVE_SESSION_STATES_KEY = 'agentSessions.activeSessionStates';
 
@@ -70,6 +71,7 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 	private _activeSessionDisposables = this._register(new DisposableStore());
 	private readonly _providerListeners = this._register(new DisposableMap<string, IDisposable>());
 	private readonly _sessionStates: ResourceMap<ISessionState>;
+	private readonly _navigation: SessionsNavigation;
 
 	constructor(
 		@IStorageService private readonly storageService: IStorageService,
@@ -105,6 +107,14 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 			this._updateSessionTypes();
 		}));
 		this._subscribeToProviders(this.sessionsProvidersService.getProviders());
+
+		// Session navigation history
+		this._navigation = this._register(new SessionsNavigation(
+			this,
+			contextKeyService,
+			this.logService,
+		));
+		this._register(this.onDidChangeSessions(e => this._navigation.onDidRemoveSessions(e)));
 	}
 
 	private _onProvidersChanged(e: ISessionsProvidersChangeEvent): void {
@@ -650,6 +660,16 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 		} finally {
 			onDidOpenNewSessionViewListener?.dispose();
 		}
+	}
+
+	// -- Session Navigation --
+
+	async openPreviousSession(): Promise<void> {
+		await this._navigation.goBack();
+	}
+
+	async openNextSession(): Promise<void> {
+		await this._navigation.goForward();
 	}
 
 	// -- Session Actions --

--- a/src/vs/sessions/services/sessions/common/sessionsManagement.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsManagement.ts
@@ -126,6 +126,12 @@ export interface ISessionsManagementService {
 	 */
 	openNewChatInSession(session: ISession): void;
 
+	/** Navigate to the previous session in the navigation history. */
+	openPreviousSession(): Promise<void>;
+
+	/** Navigate to the next session in the navigation history. */
+	openNextSession(): Promise<void>;
+
 	// -- Session Actions --
 
 	/** Archive a session. */

--- a/src/vs/sessions/services/sessions/test/browser/sessionNavigation.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionNavigation.test.ts
@@ -1,0 +1,360 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { constObservable, observableValue } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { MockContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
+import { IActiveSession, ISessionsManagementService } from '../../common/sessionsManagement.js';
+import { IChat, ISession, ISessionType, SessionStatus } from '../../common/session.js';
+import { SessionsNavigation } from '../../browser/sessionNavigation.js';
+import { Event } from '../../../../../base/common/event.js';
+import { ISendRequestOptions } from '../../common/sessionsProvider.js';
+
+const stubChat: IChat = {
+	resource: URI.parse('test:///chat'),
+	createdAt: new Date(),
+	title: constObservable('Chat'),
+	updatedAt: constObservable(new Date()),
+	status: constObservable(0),
+	changesets: constObservable([]),
+	changes: constObservable([]),
+	modelId: constObservable(undefined),
+	mode: constObservable(undefined),
+	isArchived: constObservable(false),
+	isRead: constObservable(true),
+	description: constObservable(undefined),
+	lastTurnEnd: constObservable(undefined),
+};
+
+function stubSession(id: string, status: SessionStatus = SessionStatus.Completed): ISession {
+	return {
+		sessionId: id,
+		resource: URI.parse(`test:///${id}`),
+		providerId: 'test',
+		sessionType: 'test',
+		icon: Codicon.vm,
+		createdAt: new Date(),
+		workspace: constObservable(undefined),
+		title: constObservable(`Session ${id}`),
+		updatedAt: constObservable(new Date()),
+		status: constObservable(status),
+		changesets: constObservable([]),
+		changes: constObservable([]),
+		modelId: constObservable(undefined),
+		mode: constObservable(undefined),
+		loading: constObservable(false),
+		isArchived: constObservable(false),
+		isRead: constObservable(true),
+		description: constObservable(undefined),
+		lastTurnEnd: constObservable(undefined),
+		gitHubInfo: constObservable(undefined),
+		chats: constObservable([stubChat]),
+		mainChat: stubChat,
+		capabilities: { supportsMultipleChats: false },
+	};
+}
+
+class MockSessionStore implements ISessionsManagementService {
+
+	readonly _serviceBrand: undefined;
+
+	readonly activeSession = observableValue<IActiveSession | undefined>('test.activeSession', undefined);
+	readonly onDidChangeSessions = Event.None;
+	readonly onDidChangeSessionTypes = Event.None;
+
+	private readonly _sessions = new Map<string, ISession>();
+	private _openedResource: URI | undefined;
+	private _openedNewSession = false;
+
+	get lastOpenedResource(): URI | undefined { return this._openedResource; }
+	get lastOpenedNewSession(): boolean { return this._openedNewSession; }
+
+	setActiveSession(session: ISession | undefined): void {
+		if (session) {
+			const active: IActiveSession = {
+				...session,
+				activeChat: constObservable(stubChat),
+			};
+			this.activeSession.set(active, undefined);
+		} else {
+			this.activeSession.set(undefined, undefined);
+		}
+	}
+
+	addSession(session: ISession): void {
+		this._sessions.set(session.resource.toString(), session);
+	}
+
+	getSessions(): ISession[] { return [...this._sessions.values()]; }
+
+	getSession(resource: URI): ISession | undefined {
+		return this._sessions.get(resource.toString());
+	}
+
+	getAllSessionTypes(): ISessionType[] { return []; }
+
+	async openSession(sessionResource: URI): Promise<void> {
+		this._openedResource = sessionResource;
+		this._openedNewSession = false;
+		const session = this._sessions.get(sessionResource.toString());
+		if (session) {
+			this.setActiveSession(session);
+		}
+	}
+
+	openNewSessionView(): void {
+		this._openedNewSession = true;
+		this._openedResource = undefined;
+		this.setActiveSession(undefined);
+	}
+
+	openChat(_session: ISession, _chatUri: URI): Promise<void> { throw new Error('not implemented'); }
+	restoreLastActiveSession(): Promise<void> { throw new Error('not implemented'); }
+	createNewSession(_providerId: string, _workspaceUri: URI, _sessionTypeId?: string): ISession { throw new Error('not implemented'); }
+	unsetNewSession(): void { throw new Error('not implemented'); }
+	sendAndCreateChat(_session: ISession, _options: ISendRequestOptions): Promise<void> { throw new Error('not implemented'); }
+	sendRequest(_session: ISession, _chat: IChat, _options: ISendRequestOptions): Promise<void> { throw new Error('not implemented'); }
+	openNewChatInSession(_session: ISession): void { throw new Error('not implemented'); }
+	openPreviousSession(): Promise<void> { throw new Error('not implemented'); }
+	openNextSession(): Promise<void> { throw new Error('not implemented'); }
+	archiveSession(_session: ISession): Promise<void> { throw new Error('not implemented'); }
+	unarchiveSession(_session: ISession): Promise<void> { throw new Error('not implemented'); }
+	deleteSession(_session: ISession): Promise<void> { throw new Error('not implemented'); }
+	deleteChat(_session: ISession, _chatUri: URI): Promise<void> { throw new Error('not implemented'); }
+	renameChat(_session: ISession, _chatUri: URI, _title: string): Promise<void> { throw new Error('not implemented'); }
+}
+
+suite('SessionsNavigation', () => {
+
+	const ds = ensureNoDisposablesAreLeakedInTestSuite();
+	let store: MockSessionStore;
+	let nav: SessionsNavigation;
+	let contextKeyService: MockContextKeyService;
+
+	setup(() => {
+		const disposables = ds.add(new DisposableStore());
+		store = new MockSessionStore();
+
+		contextKeyService = disposables.add(new MockContextKeyService());
+
+		nav = disposables.add(new SessionsNavigation(
+			store,
+			contextKeyService,
+			new NullLogService(),
+		));
+	});
+
+	function canGoBack(): boolean {
+		return contextKeyService.getContextKeyValue('sessionsCanGoBack') ?? false;
+	}
+
+	function canGoForward(): boolean {
+		return contextKeyService.getContextKeyValue('sessionsCanGoForward') ?? false;
+	}
+
+	test('initially cannot go back or forward', () => {
+		assert.strictEqual(canGoBack(), false);
+		assert.strictEqual(canGoForward(), false);
+	});
+
+	test('can go back after navigating to two sessions', () => {
+		const s1 = stubSession('s1');
+		const s2 = stubSession('s2');
+		store.addSession(s1);
+		store.addSession(s2);
+
+		store.setActiveSession(s1);
+		store.setActiveSession(s2);
+
+		assert.strictEqual(canGoBack(), true);
+		assert.strictEqual(canGoForward(), false);
+	});
+
+	test('goBack restores previous session', async () => {
+		const s1 = stubSession('s1');
+		const s2 = stubSession('s2');
+		store.addSession(s1);
+		store.addSession(s2);
+
+		store.setActiveSession(s1);
+		store.setActiveSession(s2);
+
+		await nav.goBack();
+
+		assert.strictEqual(store.lastOpenedResource?.toString(), s1.resource.toString());
+		assert.strictEqual(canGoBack(), false);
+		assert.strictEqual(canGoForward(), true);
+	});
+
+	test('goForward restores next session after goBack', async () => {
+		const s1 = stubSession('s1');
+		const s2 = stubSession('s2');
+		store.addSession(s1);
+		store.addSession(s2);
+
+		store.setActiveSession(s1);
+		store.setActiveSession(s2);
+
+		await nav.goBack();
+		await nav.goForward();
+
+		assert.strictEqual(store.lastOpenedResource?.toString(), s2.resource.toString());
+		assert.strictEqual(canGoBack(), true);
+		assert.strictEqual(canGoForward(), false);
+	});
+
+	test('navigating to a new session after goBack clears forward history', async () => {
+		const s1 = stubSession('s1');
+		const s2 = stubSession('s2');
+		const s3 = stubSession('s3');
+		store.addSession(s1);
+		store.addSession(s2);
+		store.addSession(s3);
+
+		store.setActiveSession(s1);
+		store.setActiveSession(s2);
+
+		await nav.goBack();
+		// Now navigate to s3 instead of going forward
+		store.setActiveSession(s3);
+
+		assert.strictEqual(canGoBack(), true);
+		assert.strictEqual(canGoForward(), false);
+
+		// Going back should go to s1 (s2 is no longer in forward history)
+		await nav.goBack();
+		assert.strictEqual(store.lastOpenedResource?.toString(), s1.resource.toString());
+	});
+
+	test('reopening an earlier session removes it from history and appends at end (no duplicates)', async () => {
+		// Regression: A→B→C, back→back→fwd→fwd, open A again
+		// should produce history [B,C,A] not [A,B,C,A]
+		const s1 = stubSession('s1');
+		const s2 = stubSession('s2');
+		const s3 = stubSession('s3');
+		store.addSession(s1);
+		store.addSession(s2);
+		store.addSession(s3);
+
+		store.setActiveSession(s1); // history=[s1], idx=0
+		store.setActiveSession(s2); // history=[s1,s2], idx=1
+		store.setActiveSession(s3); // history=[s1,s2,s3], idx=2
+
+		await nav.goBack();  // idx=1
+		await nav.goBack();  // idx=0
+		await nav.goForward(); // idx=1
+		await nav.goForward(); // idx=2
+
+		// Now open s1 again — should deduplicate: history=[s2,s3,s1]
+		store.setActiveSession(s1);
+
+		// Back once: s3
+		await nav.goBack();
+		assert.strictEqual(store.lastOpenedResource?.toString(), s3.resource.toString());
+
+		// Back once more: s2
+		await nav.goBack();
+		assert.strictEqual(store.lastOpenedResource?.toString(), s2.resource.toString());
+
+		// No further back
+		assert.strictEqual(canGoBack(), false);
+	});
+
+	test('navigating to new-session view after a session enables go back', async () => {
+		const s1 = stubSession('s1');
+		store.addSession(s1);
+
+		store.setActiveSession(s1);
+		store.setActiveSession(undefined); // user explicitly went to new-session view
+
+		assert.strictEqual(canGoBack(), true);
+		assert.strictEqual(canGoForward(), false);
+
+		await nav.goBack();
+		assert.strictEqual(store.lastOpenedResource?.toString(), s1.resource.toString());
+	});
+
+	test('navigating to new-session view with no history does not enable go back', () => {
+		store.setActiveSession(undefined); // new-session view with empty history
+
+		assert.strictEqual(canGoBack(), false);
+	});
+
+	test('duplicate consecutive session is not added to history', () => {
+		const s1 = stubSession('s1');
+		store.addSession(s1);
+
+		store.setActiveSession(s1);
+		store.setActiveSession(s1); // duplicate
+
+		// Only one entry for s1, cannot go back
+		assert.strictEqual(canGoBack(), false);
+	});
+
+	test('removed sessions are cleaned from history', async () => {
+		const s1 = stubSession('s1');
+		const s2 = stubSession('s2');
+		const s3 = stubSession('s3');
+		store.addSession(s1);
+		store.addSession(s2);
+		store.addSession(s3);
+
+		store.setActiveSession(s1);
+		store.setActiveSession(s2);
+		store.setActiveSession(s3);
+
+		// Remove s2 from history
+		nav.onDidRemoveSessions({ added: [], removed: [s2], changed: [] });
+
+		// Going back from s3 should skip s2 and go to s1
+		await nav.goBack();
+		assert.strictEqual(store.lastOpenedResource?.toString(), s1.resource.toString());
+	});
+
+	test('untitled (new) session is not recorded in history and does not enable go back', () => {
+		const pending = stubSession('pending', SessionStatus.Untitled);
+		store.addSession(pending);
+		store.setActiveSession(pending); // untitled on startup — must not be recorded or set beyondHistory
+
+		assert.strictEqual(canGoBack(), false);
+
+		// Opening a real session: history is [s1], cannot go back
+		const s1 = stubSession('s1');
+		store.addSession(s1);
+		store.setActiveSession(s1);
+
+		assert.strictEqual(canGoBack(), false);
+
+		// Opening a second real session: history is [s1, s2], can go back
+		const s2 = stubSession('s2');
+		store.addSession(s2);
+		store.setActiveSession(s2);
+
+		assert.strictEqual(canGoBack(), true);
+	});
+
+	test('go to new-session, goBack, go to new-session again still enables back', async () => {
+		// Regression: after goBack from new-session view, going to new-session again
+		// must still enable back. The autorun must keep activeSession tracked even
+		// when it returns early during navigation (_navigating=true).
+		const s1 = stubSession('s1');
+		store.addSession(s1);
+		store.setActiveSession(s1); // history=[s1], idx=0
+
+		store.setActiveSession(undefined); // go to new-session view
+		assert.strictEqual(canGoBack(), true, 'back enabled after first new-session view');
+
+		await nav.goBack(); // back to s1
+		assert.strictEqual(canGoBack(), false, 'back disabled on s1');
+
+		store.setActiveSession(undefined); // go to new-session view again
+		assert.strictEqual(canGoBack(), true, 'back enabled after second new-session view');
+	});
+});


### PR DESCRIPTION
## Summary

Adds browser-style back/forward navigation between sessions in the Agents window, similar to how VS Code navigates between editor locations.

## Changes

### New: `SessionsNavigation` class (`sessionNavigation.ts`)
- Owned and created by `SessionsManagementService`
- Tracks a history stack of opened sessions (max 50 entries)
- Observes `activeSession` to automatically record history entries
- Skips `Untitled` sessions (startup/restore artefacts) and the new-session view from being recorded
- Deduplicates history on push: reopening a session that already exists in history moves it to the end instead of duplicating it
- Handles the "beyond history" case: navigating to the new-session view from a real session enables Back to return to the last real session
- Correctly maintains observable subscriptions during navigation (reads `activeSession` before the `_navigating` guard so the autorun never loses its dependency)

### `ISessionsManagementService` / `SessionsManagementService`
- Added `openPreviousSession()` / `openNextSession()` to the interface and implementation, delegating to `SessionsNavigation`

### Context keys (`contextkeys.ts`)
- `CanGoBackContext` / `CanGoForwardContext` — kept in sync with the navigation stack

### Actions (`sessionsActions.ts`)
- `GoBackAction` — `Alt+Left` / `Ctrl+Alt+-`
- `GoForwardAction` — `Alt+Right` / `Shift+Ctrl+Alt+-`
- Registered in the agents-specific `Menus.GoMenu` to avoid polluting the shared workbench Go menu

### Menus / Menubar
- Added `Menus.GoMenu` (`SessionsGoMenu`) in `menus.ts`
- Wired into the menubar Go menu in `menubar.contribution.ts`

## Behaviour notes

- History is only recorded for real (non-Untitled) sessions
- Navigating to the new-session view from a non-empty history sets a `_beyondHistory` flag; Back from there re-opens the last real session
- Reloading with an open session and then visiting the new-session view correctly leaves Back disabled until a prior real session exists
- Opening an existing session that already appears earlier in history deduplicates it (moves to end)

## Tests

`sessionNavigation.test.ts` covers:
- Basic back/forward navigation
- Forward history truncation when branching
- Untitled session filtering
- Reload scenario (Untitled skipped on startup restore)
- New-session view / beyondHistory transitions
- Observable subscription survival across navigation
- History deduplication on push
