### PR TITLE
Add agent host xterm/headless 

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostHeadlessTerminal.ts
+++ b/src/vs/platform/agentHost/node/agentHostHeadlessTerminal.ts
@@ -48,7 +48,7 @@ export class AgentHostHeadlessTerminal extends Disposable {
 		this._terminal = options.terminalFactory?.(terminalOptions) ?? new XtermTerminal(terminalOptions);
 
 		this._register(this._terminal.onData(data => {
-			if (this._isAllowedResponseData(data)) {
+			if (this._isCursorPositionReportResponse(data)) {
 				this._logService.debug(`[AgentHostHeadlessTerminal] Forwarding terminal response ${JSON.stringify(data)}`);
 				this._onResponseData.fire(data);
 			} else {
@@ -94,7 +94,7 @@ export class AgentHostHeadlessTerminal extends Disposable {
 		super.dispose();
 	}
 
-	private _isAllowedResponseData(data: string): boolean {
+	private _isCursorPositionReportResponse(data: string): boolean {
 		// Only forward cursor position reports for now. xterm can also answer
 		// device attribute queries, but workbench only forwards those in narrow
 		// ConPTY-specific cases; keep Agent Host conservative until needed.

--- a/src/vs/platform/agentHost/node/agentHostHeadlessTerminal.ts
+++ b/src/vs/platform/agentHost/node/agentHostHeadlessTerminal.ts
@@ -1,0 +1,110 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Emitter, Event } from '../../../base/common/event.js';
+import { Disposable } from '../../../base/common/lifecycle.js';
+import type { ILogService } from '../../log/common/log.js';
+import pkg from '@xterm/headless';
+
+type XtermTerminal = pkg.Terminal;
+const { Terminal: XtermTerminal } = pkg;
+
+export interface IAgentHostHeadlessTerminalOptions {
+	cols: number;
+	rows: number;
+	scrollback: number;
+	logService: ILogService;
+	terminalFactory?: (options: IXtermTerminalOptions) => XtermTerminal;
+}
+
+/**
+ * Mirrors an agent-host PTY into xterm's interpreted terminal model.
+ *
+ * The mirror is intentionally internal to the agent host. Protocol-visible
+ * terminal data still flows through the existing OSC 633 parser and content
+ * model; this class provides terminal responses for programs that query
+ * terminal state.
+ */
+export class AgentHostHeadlessTerminal extends Disposable {
+
+	private readonly _terminal: XtermTerminal;
+	private readonly _logService: ILogService;
+	private readonly _onResponseData = this._register(new Emitter<string>());
+	readonly onResponseData: Event<string> = this._onResponseData.event;
+	private _writeBarrier: Promise<void> = Promise.resolve();
+	private _isDisposed = false;
+
+	constructor(options: IAgentHostHeadlessTerminalOptions) {
+		super();
+		this._logService = options.logService;
+		const terminalOptions: IXtermTerminalOptions = {
+			cols: options.cols,
+			rows: options.rows,
+			scrollback: options.scrollback,
+			allowProposedApi: true,
+		};
+		this._terminal = options.terminalFactory?.(terminalOptions) ?? new XtermTerminal(terminalOptions);
+
+		this._register(this._terminal.onData(data => {
+			if (this._isAllowedResponseData(data)) {
+				this._logService.debug(`[AgentHostHeadlessTerminal] Forwarding terminal response ${JSON.stringify(data)}`);
+				this._onResponseData.fire(data);
+			} else {
+				this._logService.debug(`[AgentHostHeadlessTerminal] Dropping terminal response ${JSON.stringify(data)}`);
+			}
+		}));
+		this._register({
+			dispose: () => {
+				this._isDisposed = true;
+				this._terminal.dispose();
+			}
+		});
+	}
+
+	writePtyData(data: string): Promise<void> {
+		this._writeBarrier = this._writeBarrier.catch(() => undefined).then(() => {
+			if (this._isDisposed) {
+				return;
+			}
+			return new Promise<void>(resolve => {
+				try {
+					this._terminal.write(data, resolve);
+				} catch {
+					resolve();
+				}
+			});
+		});
+		return this._writeBarrier;
+	}
+
+	resize(cols: number, rows: number): void {
+		this._terminal.resize(cols, rows);
+	}
+
+	clear(): void {
+		// xterm.clear() preserves the visible line content; emulate a terminal
+		// clear sequence so future terminal-state reads match a user-visible clear.
+		void this.writePtyData('\x1b[2J\x1b[3J\x1b[H');
+	}
+
+	override dispose(): void {
+		this._isDisposed = true;
+		super.dispose();
+	}
+
+	private _isAllowedResponseData(data: string): boolean {
+		// Only forward cursor position reports for now. xterm can also answer
+		// device attribute queries, but workbench only forwards those in narrow
+		// ConPTY-specific cases; keep Agent Host conservative until needed.
+		return /^(?:\x1b\[\??\d+;\d+R)+$/.test(data);
+	}
+}
+
+interface IXtermTerminalOptions {
+	cols: number;
+	rows: number;
+	scrollback: number;
+	allowProposedApi: boolean;
+}

--- a/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
+++ b/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
@@ -28,6 +28,9 @@ import { Osc633Event, Osc633EventType, Osc633Parser } from './osc633Parser.js';
 
 const WAIT_FOR_PROMPT_TIMEOUT = 10_000;
 const HEADLESS_TERMINAL_SCROLLBACK = 0;
+const DSR_CURSOR_POSITION_QUERY = '\x1b[6n';
+const DEC_DSR_CURSOR_POSITION_QUERY = '\x1b[?6n';
+const SERVER_HANDLED_QUERY_PREFIXES = ['\x1b[?6', '\x1b[?', '\x1b[6', '\x1b[', '\x1b'];
 
 export const IAgentHostTerminalManager = createDecorator<IAgentHostTerminalManager>('agentHostTerminalManager');
 
@@ -36,6 +39,41 @@ export interface ICommandFinishedEvent {
 	exitCode: number | undefined;
 	command: string;
 	output: string;
+}
+
+export interface ITerminalQueryFilterState {
+	pendingData: string;
+}
+
+export function removeServerHandledTerminalQueries(data: string, state: ITerminalQueryFilterState): string {
+	if (
+		!state.pendingData
+		&& !data.includes(DSR_CURSOR_POSITION_QUERY)
+		&& !data.includes(DEC_DSR_CURSOR_POSITION_QUERY)
+		&& !getServerHandledTerminalQueryPrefix(data)
+	) {
+		return data;
+	}
+
+	const combinedData = state.pendingData + data;
+	const pendingData = getServerHandledTerminalQueryPrefix(combinedData);
+	const dataToFilter = pendingData ? combinedData.substring(0, combinedData.length - pendingData.length) : combinedData;
+	state.pendingData = pendingData;
+	if (!dataToFilter.includes(DSR_CURSOR_POSITION_QUERY) && !dataToFilter.includes(DEC_DSR_CURSOR_POSITION_QUERY)) {
+		return dataToFilter;
+	}
+	return dataToFilter
+		.replaceAll(DEC_DSR_CURSOR_POSITION_QUERY, '')
+		.replaceAll(DSR_CURSOR_POSITION_QUERY, '');
+}
+
+function getServerHandledTerminalQueryPrefix(data: string): string {
+	for (const prefix of SERVER_HANDLED_QUERY_PREFIXES) {
+		if (data.endsWith(prefix)) {
+			return prefix;
+		}
+	}
+	return '';
 }
 
 /**
@@ -99,6 +137,7 @@ interface IManagedTerminal {
 	exitCode?: number;
 	commandTracker?: ICommandTracker;
 	headlessTerminal?: AgentHostHeadlessTerminal;
+	terminalQueryFilterState: ITerminalQueryFilterState;
 }
 
 /**
@@ -314,6 +353,7 @@ export class AgentHostTerminalManager extends Disposable implements IAgentHostTe
 			claim,
 			commandTracker,
 			headlessTerminal,
+			terminalQueryFilterState: { pendingData: '' },
 		};
 
 		this._terminals.set(uri, managed);
@@ -508,6 +548,11 @@ export class AgentHostTerminalManager extends Disposable implements IAgentHostTe
 		} else {
 			cleanedData = rawData;
 		}
+
+		// Agent Host's server-side headless terminal answers CPR so terminals
+		// work without an attached client. Hide those queries from client xterms
+		// to avoid a second CPR response flowing back through AgentHostPty.input.
+		cleanedData = removeServerHandledTerminalQueries(cleanedData, managed.terminalQueryFilterState);
 
 		// Append to structured content
 		if (cleanedData.length > 0) {

--- a/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
+++ b/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
@@ -225,8 +225,6 @@ export class AgentHostTerminalManager extends Disposable implements IAgentHostTe
 			throw new Error(`Terminal already exists: ${uri}`);
 		}
 
-		const nodePty = await getNodePty();
-
 		const cwd = await this._resolveCwd(params.cwd, uri);
 		const cols = params.cols ?? 80;
 		const rows = params.rows ?? 24;
@@ -314,7 +312,7 @@ export class AgentHostTerminalManager extends Disposable implements IAgentHostTe
 			this._logService.info(`[TerminalManager] Shell integration not available for ${uri}: ${injection.reason}`);
 		}
 
-		const ptyProcess = nodePty.spawn(shell, shellArgs, {
+		const ptyProcess = await this._spawnPty(shell, shellArgs, {
 			name,
 			cwd,
 			env,
@@ -412,6 +410,11 @@ export class AgentHostTerminalManager extends Disposable implements IAgentHostTe
 		await raceCancellablePromises([onFirstData.p, timeout(WAIT_FOR_PROMPT_TIMEOUT)]);
 
 		this._broadcastTerminalList();
+	}
+
+	protected async _spawnPty(file: string, args: string[], options: import('node-pty').IPtyForkOptions | import('node-pty').IWindowsPtyForkOptions): Promise<import('node-pty').IPty> {
+		const nodePty = await getNodePty();
+		return nodePty.spawn(file, args, options);
 	}
 
 	/** Send input data to a terminal's PTY process (from client-dispatched actions). */

--- a/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
+++ b/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
@@ -22,10 +22,12 @@ import type { CreateTerminalParams } from '../common/state/protocol/commands.js'
 import { TerminalClaim, TerminalContentPart, TerminalInfo, TerminalState, TerminalClaimKind } from '../common/state/protocol/state.js';
 import { isTerminalAction } from '../common/state/sessionActions.js';
 import { IAgentConfigurationService } from './agentConfigurationService.js';
+import { AgentHostHeadlessTerminal } from './agentHostHeadlessTerminal.js';
 import type { AgentHostStateManager } from './agentHostStateManager.js';
 import { Osc633Event, Osc633EventType, Osc633Parser } from './osc633Parser.js';
 
 const WAIT_FOR_PROMPT_TIMEOUT = 10_000;
+const HEADLESS_TERMINAL_SCROLLBACK = 0;
 
 export const IAgentHostTerminalManager = createDecorator<IAgentHostTerminalManager>('agentHostTerminalManager');
 
@@ -96,6 +98,7 @@ interface IManagedTerminal {
 	claim: TerminalClaim;
 	exitCode?: number;
 	commandTracker?: ICommandTracker;
+	headlessTerminal?: AgentHostHeadlessTerminal;
 }
 
 /**
@@ -287,6 +290,12 @@ export class AgentHostTerminalManager extends Disposable implements IAgentHostTe
 		const onExitEmitter = store.add(new Emitter<number>());
 		const onClaimChangedEmitter = store.add(new Emitter<TerminalClaim>());
 		const onCommandFinishedEmitter = store.add(new Emitter<ICommandFinishedEvent>());
+		const headlessTerminal = store.add(new AgentHostHeadlessTerminal({
+			cols,
+			rows,
+			scrollback: HEADLESS_TERMINAL_SCROLLBACK,
+			logService: this._logService,
+		}));
 
 		const managed: IManagedTerminal = {
 			uri,
@@ -304,9 +313,18 @@ export class AgentHostTerminalManager extends Disposable implements IAgentHostTe
 			contentSize: 0,
 			claim,
 			commandTracker,
+			headlessTerminal,
 		};
 
 		this._terminals.set(uri, managed);
+		store.add(headlessTerminal.onResponseData(data => {
+			this._logService.debug(`[TerminalManager] Writing headless terminal response for ${uri}: ${JSON.stringify(data)}`);
+			try {
+				ptyProcess.write(data);
+			} catch (err) {
+				this._logService.debug(`[TerminalManager] Failed to write headless terminal response for ${uri}: ${err instanceof Error ? err.message : String(err)}`);
+			}
+		}));
 
 		// Wire PTY events → protocol events
 		store.add(toDisposable(() => {
@@ -315,6 +333,7 @@ export class AgentHostTerminalManager extends Disposable implements IAgentHostTe
 
 		const onFirstData = new DeferredPromise<void>();
 		const dataListener = ptyProcess.onData(rawData => {
+			void managed.headlessTerminal?.writePtyData(rawData);
 			this._handlePtyData(managed, rawData);
 			onFirstData.complete();
 		});
@@ -441,6 +460,7 @@ export class AgentHostTerminalManager extends Disposable implements IAgentHostTe
 			terminal.cols = cols;
 			terminal.rows = rows;
 			terminal.pty.resize(cols, rows);
+			terminal.headlessTerminal?.resize(cols, rows);
 		}
 	}
 
@@ -469,6 +489,7 @@ export class AgentHostTerminalManager extends Disposable implements IAgentHostTe
 		if (terminal) {
 			terminal.content = [];
 			terminal.contentSize = 0;
+			terminal.headlessTerminal?.clear();
 		}
 	}
 

--- a/src/vs/platform/agentHost/test/node/agentHostHeadlessTerminal.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostHeadlessTerminal.test.ts
@@ -1,0 +1,138 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { DisposableStore } from '../../../../base/common/lifecycle.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { NullLogService } from '../../../log/common/log.js';
+import { AgentHostHeadlessTerminal } from '../../node/agentHostHeadlessTerminal.js';
+import pkg from '@xterm/headless';
+
+type XtermTerminal = pkg.Terminal;
+const { Terminal: XtermTerminal } = pkg;
+
+suite('AgentHostHeadlessTerminal', () => {
+	const disposables = new DisposableStore();
+
+	teardown(() => disposables.clear());
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createTerminal(cols = 80, rows = 24): AgentHostHeadlessTerminal {
+		return disposables.add(new AgentHostHeadlessTerminal({
+			cols,
+			rows,
+			scrollback: 100,
+			logService: new NullLogService(),
+		}));
+	}
+
+	test('responds to DSR cursor position queries', async () => {
+		const terminal = createTerminal();
+		const responses: string[] = [];
+		disposables.add(terminal.onResponseData(data => responses.push(data)));
+
+		await terminal.writePtyData('abc\x1b[6n');
+
+		assert.strictEqual(responses.join(''), '\x1b[1;4R');
+	});
+
+	test('responds to DEC DSR cursor position queries', async () => {
+		const terminal = createTerminal();
+		const responses: string[] = [];
+		disposables.add(terminal.onResponseData(data => responses.push(data)));
+
+		await terminal.writePtyData('\x1b[?6n');
+
+		assert.strictEqual(responses.join(''), '\x1b[?1;1R');
+	});
+
+	test('filters non-cursor terminal responses', async () => {
+		const terminal = createTerminal();
+		const responses: string[] = [];
+		disposables.add(terminal.onResponseData(data => responses.push(data)));
+
+		await terminal.writePtyData('\x1b[5n'); // status report
+		await terminal.writePtyData('\x1b[c'); // DA1
+		await terminal.writePtyData('\x1b[0c'); // DA1
+		await terminal.writePtyData('\x1b[>c'); // DA2
+		await terminal.writePtyData('\x1b[>0c'); // DA2
+
+		assert.deepStrictEqual(responses, []);
+	});
+
+	test('does not emit response data for normal terminal output', async () => {
+		const terminal = createTerminal();
+		const responses: string[] = [];
+		disposables.add(terminal.onResponseData(data => responses.push(data)));
+
+		await terminal.writePtyData('normal output\r\n');
+
+		assert.deepStrictEqual(responses, []);
+	});
+
+	test('ignores writes after dispose', async () => {
+		const terminal = createTerminal();
+		const responses: string[] = [];
+		disposables.add(terminal.onResponseData(data => responses.push(data)));
+
+		terminal.dispose();
+		await terminal.writePtyData('abc\x1b[6n');
+
+		assert.deepStrictEqual(responses, []);
+	});
+
+	test('write failure does not poison later writes', async () => {
+		let xterm: XtermTerminal | undefined;
+		let shouldThrow = true;
+		const terminal = disposables.add(new AgentHostHeadlessTerminal({
+			cols: 80,
+			rows: 24,
+			scrollback: 0,
+			logService: new NullLogService(),
+			terminalFactory: options => {
+				xterm = new XtermTerminal(options);
+				const originalWrite = xterm.write.bind(xterm);
+				xterm.write = (data, callback) => {
+					if (shouldThrow) {
+						shouldThrow = false;
+						throw new Error('synthetic write failure');
+					}
+					originalWrite(data, callback);
+				};
+				return xterm;
+			}
+		}));
+		const responses: string[] = [];
+		disposables.add(terminal.onResponseData(data => responses.push(data)));
+
+		await terminal.writePtyData('\x1b[6n');
+		await terminal.writePtyData('\x1b[6n');
+
+		assert.deepStrictEqual(responses, ['\x1b[1;1R']);
+	});
+
+	test('resize updates the cursor position reported by the mirror', async () => {
+		const terminal = createTerminal();
+		const responses: string[] = [];
+		disposables.add(terminal.onResponseData(data => responses.push(data)));
+
+		terminal.resize(5, 4);
+		await terminal.writePtyData('\x1b[999;999H\x1b[6n');
+
+		assert.strictEqual(responses.join(''), '\x1b[4;5R');
+	});
+
+	test('clear resets the cursor position', async () => {
+		const terminal = createTerminal();
+		const responses: string[] = [];
+		disposables.add(terminal.onResponseData(data => responses.push(data)));
+
+		await terminal.writePtyData('\x1b[10;10H');
+		terminal.clear();
+		await terminal.writePtyData('\x1b[6n');
+
+		assert.strictEqual(responses.join(''), '\x1b[1;1R');
+	});
+});

--- a/src/vs/platform/agentHost/test/node/agentHostTerminalManager.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTerminalManager.test.ts
@@ -4,11 +4,18 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import type { IPty, IPtyForkOptions, IWindowsPtyForkOptions } from 'node-pty';
+import { DeferredPromise, timeout } from '../../../../base/common/async.js';
+import { Emitter } from '../../../../base/common/event.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { NullLogService } from '../../../log/common/log.js';
+import { IProductService } from '../../../product/common/productService.js';
 import { ActionType, StateAction } from '../../common/state/protocol/actions.js';
-import { TerminalContentPart } from '../../common/state/protocol/state.js';
-import { removeServerHandledTerminalQueries, type ITerminalQueryFilterState } from '../../node/agentHostTerminalManager.js';
+import { TerminalClaimKind, TerminalContentPart } from '../../common/state/protocol/state.js';
+import { AgentConfigurationService } from '../../node/agentConfigurationService.js';
+import { AgentHostStateManager } from '../../node/agentHostStateManager.js';
+import { AgentHostTerminalManager, removeServerHandledTerminalQueries, type ITerminalQueryFilterState } from '../../node/agentHostTerminalManager.js';
 import { Osc633Event, Osc633EventType, Osc633Parser } from '../../node/osc633Parser.js';
 
 /**
@@ -161,6 +168,62 @@ class TestTerminalDataHandler {
 	}
 }
 
+class TestPty implements IPty {
+	readonly pid = 1;
+	cols = 80;
+	rows = 24;
+	process = 'test-shell';
+	handleFlowControl = false;
+	readonly writes: string[] = [];
+	readonly dataListenerRegistered = new DeferredPromise<void>();
+
+	private readonly _onData = new Emitter<string>();
+	readonly onData: IPty['onData'] = listener => {
+		this.dataListenerRegistered.complete();
+		return this._onData.event(data => listener(data));
+	};
+
+	private readonly _onExit = new Emitter<{ exitCode: number; signal?: number }>();
+	readonly onExit: IPty['onExit'] = listener => this._onExit.event(data => listener(data));
+
+	fireData(data: string): void {
+		this._onData.fire(data);
+	}
+
+	resize(columns: number, rows: number): void {
+		this.cols = columns;
+		this.rows = rows;
+	}
+
+	clear(): void { }
+
+	write(data: string | Buffer): void {
+		this.writes.push(typeof data === 'string' ? data : data.toString());
+	}
+
+	kill(): void { }
+	pause(): void { }
+	resume(): void { }
+}
+
+class TestAgentHostTerminalManager extends AgentHostTerminalManager {
+	constructor(
+		stateManager: AgentHostStateManager,
+		logService: NullLogService,
+		productService: IProductService,
+		configurationService: AgentConfigurationService,
+		private readonly _pty: TestPty,
+	) {
+		super(stateManager, logService, productService, configurationService);
+	}
+
+	protected override async _spawnPty(_file: string, _args: string[], options: IPtyForkOptions | IWindowsPtyForkOptions): Promise<IPty> {
+		this._pty.cols = options.cols ?? this._pty.cols;
+		this._pty.rows = options.rows ?? this._pty.rows;
+		return this._pty;
+	}
+}
+
 function osc633(payload: string): string {
 	return `\x1b]633;${payload}\x07`;
 }
@@ -174,11 +237,44 @@ function createHandler(nonce = 'test-nonce'): TestTerminalDataHandler {
 	});
 }
 
+async function waitForWrites(pty: TestPty, count: number): Promise<void> {
+	for (let i = 0; i < 20; i++) {
+		if (pty.writes.length >= count) {
+			return;
+		}
+		await timeout(10);
+	}
+}
+
 suite('AgentHostTerminalManager – command detection integration', () => {
 
 	const disposables = new DisposableStore();
 	teardown(() => disposables.clear());
 	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('writes headless DSR responses back to the PTY', async () => {
+		const logService = new NullLogService();
+		const stateManager = disposables.add(new AgentHostStateManager(logService));
+		const configurationService = disposables.add(new AgentConfigurationService(stateManager, logService));
+		const productService = { _serviceBrand: undefined, applicationName: 'vscode' } as IProductService;
+		const pty = new TestPty();
+		const manager = disposables.add(new TestAgentHostTerminalManager(stateManager, logService, productService, configurationService, pty));
+
+		const createTerminal = manager.createTerminal({
+			terminal: 'agenthost-terminal://test/dsr',
+			claim: { kind: TerminalClaimKind.Client, clientId: 'test-client' },
+			cwd: process.cwd(),
+			cols: 80,
+			rows: 24,
+		}, { shell: '/bin/bash' });
+
+		await pty.dataListenerRegistered.p;
+		pty.fireData('abc\x1b[6n');
+		await createTerminal;
+		await waitForWrites(pty, 1);
+
+		assert.deepStrictEqual(pty.writes, ['\x1b[1;4R']);
+	});
 
 	test('server-handled CPR queries are stripped from client-facing data', () => {
 		function filter(data: string): string {

--- a/src/vs/platform/agentHost/test/node/agentHostTerminalManager.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTerminalManager.test.ts
@@ -8,6 +8,7 @@ import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { ActionType, StateAction } from '../../common/state/protocol/actions.js';
 import { TerminalContentPart } from '../../common/state/protocol/state.js';
+import { removeServerHandledTerminalQueries, type ITerminalQueryFilterState } from '../../node/agentHostTerminalManager.js';
 import { Osc633Event, Osc633EventType, Osc633Parser } from '../../node/osc633Parser.js';
 
 /**
@@ -39,6 +40,7 @@ class TestTerminalDataHandler {
 	readonly dispatched: StateAction[] = [];
 	content: TerminalContentPart[] = [];
 	cwd = '/home/user';
+	private readonly _terminalQueryFilterState: ITerminalQueryFilterState = { pendingData: '' };
 
 	constructor(
 		readonly uri: string,
@@ -48,7 +50,7 @@ class TestTerminalDataHandler {
 	/** Simulates AgentHostTerminalManager._handlePtyData */
 	handlePtyData(rawData: string): string {
 		const parseResult = this.tracker.parser.parse(rawData);
-		const cleanedData = parseResult.cleanedData;
+		const cleanedData = removeServerHandledTerminalQueries(parseResult.cleanedData, this._terminalQueryFilterState);
 
 		for (const event of parseResult.events) {
 			this._handleOsc633Event(event);
@@ -177,6 +179,41 @@ suite('AgentHostTerminalManager – command detection integration', () => {
 	const disposables = new DisposableStore();
 	teardown(() => disposables.clear());
 	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('server-handled CPR queries are stripped from client-facing data', () => {
+		function filter(data: string): string {
+			return removeServerHandledTerminalQueries(data, { pendingData: '' });
+		}
+
+		assert.strictEqual(filter('before \x1b[6n after'), 'before  after');
+		assert.strictEqual(filter('before \x1b[?6n after'), 'before  after');
+		assert.strictEqual(filter('\x1b[5n\x1b[c\x1b[0c\x1b[>c\x1b[>0c'), '\x1b[5n\x1b[c\x1b[0c\x1b[>c\x1b[>0c');
+		assert.strictEqual(filter('normal output\r\n'), 'normal output\r\n');
+	});
+
+	test('server-handled CPR queries are stripped across data chunks', () => {
+		let state: ITerminalQueryFilterState = { pendingData: '' };
+		assert.strictEqual(removeServerHandledTerminalQueries('before \x1b[', state), 'before ');
+		assert.strictEqual(removeServerHandledTerminalQueries('6n after', state), ' after');
+
+		state = { pendingData: '' };
+		assert.strictEqual(removeServerHandledTerminalQueries('before \x1b[?', state), 'before ');
+		assert.strictEqual(removeServerHandledTerminalQueries('6n after', state), ' after');
+
+		state = { pendingData: '' };
+		assert.strictEqual(removeServerHandledTerminalQueries('before \x1b[', state), 'before ');
+		assert.strictEqual(removeServerHandledTerminalQueries('K after', state), '\x1b[K after');
+	});
+
+	test('manager data path strips CPR queries while preserving surrounding output', () => {
+		const handler = createHandler();
+
+		const cleaned = handler.handlePtyData(`before${osc633('A')}\x1b[6nmid\x1b[?6nafter`);
+
+		assert.strictEqual(cleaned, 'beforemidafter');
+		assert.deepStrictEqual(handler.content, [{ type: 'unclassified', value: 'beforemidafter' }]);
+		assert.strictEqual(handler.dispatched[0].type, ActionType.TerminalCommandDetectionAvailable);
+	});
 
 	test('TerminalCommandDetectionAvailable is dispatched on first OSC 633', () => {
 		const handler = createHandler();


### PR DESCRIPTION
Refs #314189

This is PR 1 for the Agent Host xterm/headless terminal work.

Covers:

- Adds an internal `AgentHostHeadlessTerminal` backed by `@xterm/headless`.
- Mirrors Agent Host PTY output into the headless terminal.
- Uses xterm/headless to answer cursor-position DSR queries:
  - `ESC [ 6 n`
  - `ESC [ ? 6 n`
- Forwards only CPR responses back to the PTY:
  - `ESC [ row ; col R`
  - `ESC [ ? row ; col R`
- Strips server-handled CPR queries from client-facing terminal data to avoid duplicate answers from an attached visible xterm.
- Keeps resize and clear state in sync enough for CPR responses to stay accurate.
- Adds manager-level test coverage for the PTY output -> headless response -> `pty.write(...)` loopback.

Does not cover:

- Does not expose rendered text, cursor-line text, bracketed-paste mode, or alt-buffer state yet.
- Does not change `read_shell`, multiline command writing, prompt/idle detection, or TUI handling yet.
- Does not forward DA1/DA2/status responses from headless xterm.

Manual validation:

Normal CPR/DSR. This puts stdin in raw mode so the CPR bytes are read by Python instead of being buffered by the shell line discipline. The `abc` prefix moves the cursor to column 4, so the response should end in `;4R`:

```sh
python3 -c "import os,sys,select,termios,tty;fd=sys.stdin.fileno();old=termios.tcgetattr(fd);tty.setraw(fd);sys.stdout.write('abc\x1b[6n');sys.stdout.flush();r,_,_=select.select([sys.stdin],[],[],2);b=os.read(fd,64) if r else b'';termios.tcsetattr(fd,termios.TCSADRAIN,old);print(repr(b))"
```

Expected, with row depending on the current cursor line:

```text
b'\x1b[<row>;4R'
```

DEC private CPR/DSR. This also uses `abc`, so the response should end in `;4R`:

```sh
python3 -c "import os,sys,select,termios,tty;fd=sys.stdin.fileno();old=termios.tcgetattr(fd);tty.setraw(fd);sys.stdout.write('abc\x1b[?6n');sys.stdout.flush();r,_,_=select.select([sys.stdin],[],[],2);b=os.read(fd,64) if r else b'';termios.tcsetattr(fd,termios.TCSADRAIN,old);print(repr(b))"
```

Expected, with row depending on the current cursor line:

```text
b'\x1b[?<row>;4R'
```

/cc @meganrogge @connor4312