### PR TITLE
Show Agent Host session branch in title

### DIFF
--- a/src/vs/sessions/contrib/agentHost/browser/agentHostSessionBranchActions.ts
+++ b/src/vs/sessions/contrib/agentHost/browser/agentHostSessionBranchActions.ts
@@ -1,0 +1,42 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize2 } from '../../../../nls.js';
+import { Action2, registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
+import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
+import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+import { ANY_AGENT_HOST_PROVIDER_RE } from '../../../common/agentHostSessionsProvider.js';
+import { ChatSessionProviderIdContext } from '../../../common/contextkeys.js';
+import { getSessionBranchName, ISession } from '../../../services/sessions/common/session.js';
+import { SessionItemContextMenuId, SessionItemHasBranchNameContext } from '../../sessions/browser/views/sessionsList.js';
+
+registerAction2(class CopySessionBranchNameAction extends Action2 {
+	constructor() {
+		super({
+			id: 'sessionsViewPane.agentHost.copySessionBranchName',
+			title: localize2('copySessionBranchName', "Copy Session Branch Name"),
+			menu: [{
+				id: SessionItemContextMenuId,
+				group: '2_open',
+				order: 3,
+				when: ContextKeyExpr.and(
+					ContextKeyExpr.regex(ChatSessionProviderIdContext.key, ANY_AGENT_HOST_PROVIDER_RE),
+					SessionItemHasBranchNameContext,
+				),
+			}]
+		});
+	}
+
+	async run(accessor: ServicesAccessor, context?: ISession | ISession[]): Promise<void> {
+		const session = Array.isArray(context) ? context[0] : context;
+		const branchName = getSessionBranchName(session);
+		if (!branchName) {
+			return;
+		}
+
+		await accessor.get(IClipboardService).writeText(branchName);
+	}
+});

--- a/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
@@ -27,9 +27,10 @@ import { ChatSessionProviderIdContext, IsNewChatSessionContext, SessionsWelcomeV
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
 import { ISessionsListModelService } from './views/sessionsListModelService.js';
 import { SHOW_SESSIONS_PICKER_COMMAND_ID } from './sessionsActions.js';
-import { IsSessionArchivedContext, IsSessionPinnedContext, IsSessionReadContext, SessionItemContextMenuId } from './views/sessionsList.js';
+import { IsSessionArchivedContext, IsSessionPinnedContext, IsSessionReadContext, SessionItemContextMenuId, SessionItemHasBranchNameContext } from './views/sessionsList.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { renderLabelWithIcons } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
+import { getSessionBranchName } from '../../../services/sessions/common/session.js';
 
 const titleBarContextKeys = new Set([IsNewChatSessionContext.key]);
 
@@ -285,17 +286,11 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 	}
 
 	/**
-	 * Get the branch label for the active session (only when using a worktree).
+	 * Get the branch label for the active session.
 	 */
 	private _getRepositoryBranchLabel(): string | undefined {
 		const sessionData = this.sessionsManagementService.activeSession.get();
-		const workspace = sessionData?.workspace.get();
-		const repository = workspace?.repositories[0];
-		if (!workspace || !repository || !repository.workingDirectory) {
-			return undefined;
-		}
-
-		return repository.branchName ?? repository.detail;
+		return getSessionBranchName(sessionData);
 	}
 
 	private _showContextMenu(e: MouseEvent): void {
@@ -315,6 +310,7 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 			[IsSessionPinnedContext.key, isPinned],
 			[IsSessionArchivedContext.key, isArchived],
 			[IsSessionReadContext.key, isRead],
+			[SessionItemHasBranchNameContext.key, getSessionBranchName(sessionData) !== undefined],
 			['chatSessionType', sessionData.sessionType],
 			[ChatSessionProviderIdContext.key, sessionData.providerId],
 		];

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -33,7 +33,7 @@ import { WorkbenchObjectTree } from '../../../../../platform/list/browser/listSe
 import { IStyleOverride, defaultButtonStyles, defaultFindWidgetStyles, defaultToggleStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
 import { asCssVariable } from '../../../../../platform/theme/common/colorUtils.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
-import { CopilotCLISessionType, GITHUB_REMOTE_FILE_SCHEME, ISession, ISessionWorkspace, SessionStatus } from '../../../../services/sessions/common/session.js';
+import { CopilotCLISessionType, getSessionBranchName, GITHUB_REMOTE_FILE_SCHEME, ISession, ISessionWorkspace, SessionStatus } from '../../../../services/sessions/common/session.js';
 import { AgentSessionApprovalModel, IAgentSessionApprovalInfo } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentSessionApprovalModel.js';
 import { Button } from '../../../../../base/browser/ui/button/button.js';
 import { IMarkdownRendererService } from '../../../../../platform/markdown/browser/markdownRenderer.js';
@@ -55,6 +55,7 @@ export const SessionSectionToolbarMenuId = new MenuId('SessionSectionToolbar');
 export const IsSessionPinnedContext = new RawContextKey<boolean>('sessionItem.isPinned', false);
 export const IsSessionArchivedContext = new RawContextKey<boolean>('sessionItem.isArchived', false);
 export const IsSessionReadContext = new RawContextKey<boolean>('sessionItem.isRead', true);
+export const SessionItemHasBranchNameContext = new RawContextKey<boolean>('sessionItem.hasBranchName', false);
 export const SessionSectionTypeContext = new RawContextKey<string>('sessionSection.type', '');
 
 //#region Types
@@ -264,6 +265,7 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 		IsSessionPinnedContext.bindTo(template.contextKeyService).set(isPinned);
 		IsSessionArchivedContext.bindTo(template.contextKeyService).set(element.isArchived.get());
 		IsSessionReadContext.bindTo(template.contextKeyService).set(this.options.isRead(element));
+		SessionItemHasBranchNameContext.bindTo(template.contextKeyService).set(getSessionBranchName(element) !== undefined);
 
 		// Pinned & archived styling — reactive
 		template.elementDisposables.add(autorun(reader => {
@@ -1245,6 +1247,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 			[IsSessionPinnedContext.key, this.isSessionPinned(element)],
 			[IsSessionArchivedContext.key, element.isArchived.get()],
 			[IsSessionReadContext.key, this.isSessionRead(element)],
+			[SessionItemHasBranchNameContext.key, getSessionBranchName(element) !== undefined],
 			['chatSessionType', element.sessionType],
 			[ChatSessionProviderIdContext.key, element.providerId],
 		];

--- a/src/vs/sessions/services/sessions/common/session.ts
+++ b/src/vs/sessions/services/sessions/common/session.ts
@@ -289,6 +289,18 @@ export function toSessionId(providerId: string, resource: URI): string {
 }
 
 /**
+ * Returns the active repository branch name exposed by a session provider. The
+ * `detail` fallback preserves extension-host CLI sessions, which store their
+ * worktree branch there.
+ */
+export function getSessionBranchName(session: ISession | undefined): string | undefined {
+	const repository = session?.workspace.get()?.repositories[0];
+	const branchName = repository?.branchName ?? repository?.detail;
+	const trimmed = branchName?.trim();
+	return trimmed || undefined;
+}
+
+/**
  * Capabilities declared per session.
  * Consumers check these before surfacing session-specific features in the UI.
  */

--- a/src/vs/sessions/sessions.desktop.main.ts
+++ b/src/vs/sessions/sessions.desktop.main.ts
@@ -218,6 +218,7 @@ import './contrib/chat/electron-browser/chat.contribution.js';
 import './contrib/agentHost/browser/localAgentHost.contribution.js';
 import './contrib/agentHost/browser/agentSessionSettings.contribution.js';
 import './contrib/agentHost/browser/agentHostSettings.contribution.js';
+import './contrib/agentHost/browser/agentHostSessionBranchActions.js';
 import './contrib/agentHost/browser/agentHostSkillButtons.js';
 
 // Tunnel Host (allow remote connections to local agent host)

--- a/src/vs/sessions/sessions.web.main.ts
+++ b/src/vs/sessions/sessions.web.main.ts
@@ -154,6 +154,7 @@ import './contrib/remoteAgentHost/browser/remoteAgentHost.contribution.js';
 import './contrib/remoteAgentHost/browser/remoteAgentHostActions.js';
 import './contrib/agentHost/browser/agentSessionSettings.contribution.js';
 import './contrib/agentHost/browser/agentHostSettings.contribution.js';
+import './contrib/agentHost/browser/agentHostSessionBranchActions.js';
 import './contrib/agentHost/browser/agentHostSkillButtons.js';
 
 // Host filter dropdown in the titlebar (scopes the sessions list to a host)


### PR DESCRIPTION
## Summary
- show Agent Host session branch names prominently in the Agents titlebar
- add an Agent Host context menu action to copy the session branch name
- share branch-name lookup between titlebar and menu affordances

## Validation
- npm run compile-check-ts-native
- npm run valid-layers-check
- node --experimental-strip-types build/hygiene.ts src/vs/sessions/services/sessions/common/session.ts src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts src/vs/sessions/contrib/sessions/browser/media/sessionsTitleBarWidget.css src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts src/vs/sessions/contrib/agentHost/browser/agentHostSessionBranchActions.ts src/vs/sessions/sessions.desktop.main.ts src/vs/sessions/sessions.web.main.ts