### PR TITLE
Poll GitHub PR metadata for agent sessions

### DIFF
--- a/src/vs/sessions/README.md
+++ b/src/vs/sessions/README.md
@@ -360,7 +360,7 @@ CopilotChatSessionsProvider._refreshSessionCache()
          └── Context keys updated (hasChanges, isBackground, etc.)
 ```
 
-The shared GitHub contribution observes non-archived sessions and starts pull-request metadata polling when a session exposes a pull request number. Polling uses the shared pull request model, keeps its ETag, and refreshes only pull request metadata for list icons; active-session CI and review-thread details are polled separately.
+The shared GitHub contribution observes non-archived sessions and starts pull-request metadata polling when a session exposes a pull request number. Agent Host providers briefly hydrate session state for non-archived listed sessions so `_meta.git` can flow into `gitHubInfo` before the user opens the session. Polling uses the shared pull request model, keeps its ETag, and refreshes only pull request metadata for list icons; active-session CI and review-thread details are polled separately.
 
 ### Key Files
 

--- a/src/vs/sessions/README.md
+++ b/src/vs/sessions/README.md
@@ -360,6 +360,8 @@ CopilotChatSessionsProvider._refreshSessionCache()
          └── Context keys updated (hasChanges, isBackground, etc.)
 ```
 
+The shared GitHub contribution observes non-archived sessions and starts pull-request metadata polling when a session exposes a pull request number. Polling uses the shared pull request model, keeps its ETag, and refreshes only pull request metadata for list icons; active-session CI and review-thread details are polled separately.
+
 ### Key Files
 
 | File | Purpose |

--- a/src/vs/sessions/contrib/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -1496,6 +1496,12 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 		);
 	}
 
+	private _keepSessionStateAliveIfUnarchived(session: AgentHostSessionAdapter): void {
+		if (!session.isArchived.get()) {
+			this._keepSessionStateAlive(session.sessionId);
+		}
+	}
+
 	/**
 	 * Lazily acquire a session-state subscription for `sessionId` so that
 	 * `_runningSessionConfigs` is seeded from the AHP `SessionState.config`
@@ -1605,7 +1611,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 		try {
 			const sessions = await connection.listSessions();
 			const currentKeys = new Set<string>();
-			const added: ISession[] = [];
+			const added: AgentHostSessionAdapter[] = [];
 			const changed: ISession[] = [];
 
 			for (const meta of sessions) {
@@ -1617,6 +1623,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 					if (existing.update(meta)) {
 						changed.push(existing);
 					}
+					this._keepSessionStateAliveIfUnarchived(existing);
 				} else {
 					const cached = this.createAdapter(meta);
 					this._sessionCache.set(rawId, cached);
@@ -1635,6 +1642,9 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 
 			if (added.length > 0 || removed.length > 0 || changed.length > 0) {
 				this._onDidChangeSessions.fire({ added, removed, changed });
+			}
+			for (const session of added) {
+				this._keepSessionStateAliveIfUnarchived(session);
 			}
 		} catch {
 			// Connection may not be ready yet
@@ -1732,6 +1742,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 		const cached = this.createAdapter(meta);
 		this._sessionCache.set(rawId, cached);
 		this._onDidChangeSessions.fire({ added: [cached], removed: [], changed: [] });
+		this._keepSessionStateAliveIfUnarchived(cached);
 	}
 
 	private _handleSessionRemoved(session: URI | string): void {
@@ -1782,6 +1793,9 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 		const cached = this._sessionCache.get(rawId);
 		if (cached) {
 			cached.isArchived.set(isArchived, undefined);
+			if (!isArchived) {
+				this._keepSessionStateAlive(cached.sessionId);
+			}
 			this._onDidChangeSessions.fire({ added: [], removed: [], changed: [cached] });
 		}
 	}
@@ -1820,6 +1834,9 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			const isArchived = !!(changes.status & ProtocolSessionStatus.IsArchived);
 			if (isArchived !== cached.isArchived.get()) {
 				cached.isArchived.set(isArchived, undefined);
+				if (!isArchived) {
+					this._keepSessionStateAlive(cached.sessionId);
+				}
 				didChange = true;
 			}
 		}

--- a/src/vs/sessions/contrib/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
@@ -6,8 +6,8 @@
 import assert from 'assert';
 import { DeferredPromise, timeout } from '../../../../../base/common/async.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
-import { DisposableStore, toDisposable, type IReference } from '../../../../../base/common/lifecycle.js';
-import { ISettableObservable, observableValue, type IObservable } from '../../../../../base/common/observable.js';
+import { DisposableStore, ImmortalReference, toDisposable, type IReference } from '../../../../../base/common/lifecycle.js';
+import { autorun, ISettableObservable, observableValue, type IObservable } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { mock } from '../../../../../base/test/common/mock.js';
 import { runWithFakedTimers } from '../../../../../base/test/common/timeTravelScheduler.js';
@@ -33,6 +33,7 @@ import { LocalAgentHostSessionsProvider } from '../../browser/localAgentHostSess
 import { ILabelService } from '../../../../../platform/label/common/label.js';
 import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
 import { IGitHubService } from '../../../github/browser/githubService.js';
+import { GitHubPullRequestModel } from '../../../github/browser/models/githubPullRequestModel.js';
 
 // ---- Mock IAgentHostService -------------------------------------------------
 
@@ -221,9 +222,11 @@ function createSession(id: string, opts?: { provider?: string; summary?: string;
 	};
 }
 
-function createProvider(disposables: DisposableStore, agentHostService: MockAgentHostService, contributions = [
+const defaultContributions = [
 	{ type: 'agent-host-copilotcli', name: 'copilot', displayName: 'Copilot', description: 'test', icon: undefined },
-], options?: { sendRequest?: (resource: URI, message: string, options?: IChatSendRequestOptions) => Promise<ChatSendResult>; openSession?: boolean; configurationService?: IConfigurationService }): LocalAgentHostSessionsProvider {
+];
+
+function createProvider(disposables: DisposableStore, agentHostService: MockAgentHostService, contributions = defaultContributions, options?: { sendRequest?: (resource: URI, message: string, options?: IChatSendRequestOptions) => Promise<ChatSendResult>; openSession?: boolean; configurationService?: IConfigurationService; gitHubService?: IGitHubService }): LocalAgentHostSessionsProvider {
 	const instantiationService = disposables.add(new TestInstantiationService());
 
 	instantiationService.stub(IAgentHostService, agentHostService);
@@ -248,7 +251,7 @@ function createProvider(disposables: DisposableStore, agentHostService: MockAgen
 		getUriLabel: (uri: URI) => uri.path,
 	});
 	instantiationService.stub(ILogService, new NullLogService());
-	instantiationService.stub(IGitHubService, new class extends mock<IGitHubService>() {
+	instantiationService.stub(IGitHubService, options?.gitHubService ?? new class extends mock<IGitHubService>() {
 		override findPullRequestNumberByHeadBranch = async () => undefined;
 	}());
 
@@ -503,6 +506,64 @@ suite('LocalAgentHostSessionsProvider', () => {
 			removed: 0,
 			changed: 0,
 			cachedTitles: ['First', 'Second'],
+		});
+	}));
+
+	test('hydrates gitHubInfo for listed sessions before they are opened', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
+		agentHost.addSession(createSession('github-1', { summary: 'GitHub Session' }));
+		const sessionUri = AgentSession.uri('copilotcli', 'github-1');
+		agentHost.setSessionState('github-1', 'copilotcli', {
+			summary: { resource: sessionUri.toString(), provider: 'copilotcli', title: 'GitHub Session', status: ProtocolSessionStatus.Idle, createdAt: 0, modifiedAt: 0 },
+			lifecycle: SessionLifecycle.Ready,
+			turns: [],
+			config: { schema: { type: 'object', properties: {} }, values: {} },
+			_meta: {
+				git: {
+					githubOwner: 'owner',
+					githubRepo: 'repo',
+					branchName: 'feature',
+				},
+			},
+		});
+		const lookups: string[] = [];
+		const gitHubService = new class extends mock<IGitHubService>() {
+			override findPullRequestNumberByHeadBranch(owner: string, repo: string, branch: string): Promise<number | undefined> {
+				lookups.push(`${owner}/${repo}#${branch}`);
+				return Promise.resolve(123);
+			}
+
+			override createPullRequestModelReference(_owner: string, _repo: string, _prNumber: number): IReference<GitHubPullRequestModel> {
+				return new ImmortalReference({ pullRequest: observableValue('test.pullRequest', undefined) } as unknown as GitHubPullRequestModel);
+			}
+		}();
+		const provider = createProvider(disposables, agentHost, defaultContributions, { gitHubService });
+
+		await timeout(0);
+		const session = provider.getSessions().find(s => s.title.get() === 'GitHub Session');
+		assert.ok(session);
+
+		let gitHubInfo: unknown;
+		disposables.add(autorun(reader => {
+			gitHubInfo = session.gitHubInfo.read(reader);
+		}));
+		await timeout(0);
+
+		assert.deepStrictEqual({
+			subscribeCount: agentHost.sessionSubscribeCounts.get(sessionUri.toString()),
+			lookups,
+			gitHubInfo,
+		}, {
+			subscribeCount: 1,
+			lookups: ['owner/repo#feature'],
+			gitHubInfo: {
+				owner: 'owner',
+				repo: 'repo',
+				pullRequest: {
+					number: 123,
+					uri: URI.parse('https://github.com/owner/repo/pull/123'),
+					icon: undefined,
+				},
+			},
 		});
 	}));
 

--- a/src/vs/sessions/contrib/github/browser/github.contribution.ts
+++ b/src/vs/sessions/contrib/github/browser/github.contribution.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Disposable, DisposableMap, DisposableStore } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableMap, DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
 import { autorun, derivedOpts } from '../../../../base/common/observable.js';
 import { isEqual } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -19,6 +19,8 @@ export class GitHubPullRequestPollingContribution extends Disposable implements 
 	static readonly ID = 'sessions.contrib.githubPullRequestPolling';
 
 	private readonly _pullRequests = new DisposableMap<string>();
+	private readonly _pullRequestSessions = new Map<string, Set<string>>();
+	private readonly _sessions = new DisposableMap<string>();
 
 	constructor(
 		@IGitHubService private readonly _gitHubService: IGitHubService,
@@ -83,65 +85,111 @@ export class GitHubPullRequestPollingContribution extends Disposable implements 
 	}
 
 	private _onDidChangeSessions(e: ISessionsChangeEvent): void {
-		// Added sessions
 		for (const session of e.added) {
-			// Archived
 			if (session.isArchived.get()) {
 				continue;
 			}
 
-			this._startPolling(session);
+			this._observeSession(session);
 		}
 
-		// Changes sessions
 		for (const session of e.changed) {
-			// Archived
 			if (session.isArchived.get()) {
-				this._disposePolling(session);
+				this._disposeSession(session);
 				continue;
 			}
 
-			this._startPolling(session);
+			this._observeSession(session);
 		}
 
-		// Removed sessions
 		for (const session of e.removed) {
-			this._disposePolling(session);
+			this._disposeSession(session);
 		}
 	}
 
-	private _startPolling(session: ISession): void {
-		const gitHubInfo = session.gitHubInfo.get();
-		if (!gitHubInfo || !gitHubInfo.pullRequest) {
+	private _observeSession(session: ISession): void {
+		if (this._sessions.has(session.sessionId)) {
 			return;
 		}
 
-		const key = getPullRequestKey(gitHubInfo.owner, gitHubInfo.repo, gitHubInfo.pullRequest.number);
-		if (this._pullRequests.has(key)) {
+		let pullRequestKey: string | undefined;
+		const disposables = new DisposableStore();
+		disposables.add(autorun(reader => {
+			if (session.isArchived.read(reader)) {
+				if (pullRequestKey) {
+					this._releasePullRequest(pullRequestKey, session.sessionId);
+					pullRequestKey = undefined;
+				}
+				return;
+			}
+
+			const gitHubInfo = session.gitHubInfo.read(reader);
+			const nextPullRequestKey = gitHubInfo?.pullRequest
+				? getPullRequestKey(gitHubInfo.owner, gitHubInfo.repo, gitHubInfo.pullRequest.number)
+				: undefined;
+			if (nextPullRequestKey === pullRequestKey) {
+				return;
+			}
+
+			if (pullRequestKey) {
+				this._releasePullRequest(pullRequestKey, session.sessionId);
+			}
+			pullRequestKey = nextPullRequestKey;
+
+			if (gitHubInfo?.pullRequest) {
+				this._retainPullRequest(session.sessionId, gitHubInfo.owner, gitHubInfo.repo, gitHubInfo.pullRequest.number);
+			}
+		}));
+		disposables.add(toDisposable(() => {
+			if (pullRequestKey) {
+				this._releasePullRequest(pullRequestKey, session.sessionId);
+				pullRequestKey = undefined;
+			}
+		}));
+
+		this._sessions.set(session.sessionId, disposables);
+	}
+
+	private _retainPullRequest(sessionId: string, owner: string, repo: string, prNumber: number): void {
+		const key = getPullRequestKey(owner, repo, prNumber);
+		let sessions = this._pullRequestSessions.get(key);
+		if (sessions) {
+			sessions.add(sessionId);
 			return;
 		}
+
+		sessions = new Set([sessionId]);
+		this._pullRequestSessions.set(key, sessions);
 
 		const disposables = new DisposableStore();
-		const modelRef = this._gitHubService.createPullRequestModelReference(gitHubInfo.owner, gitHubInfo.repo, gitHubInfo.pullRequest.number);
-
+		const modelRef = this._gitHubService.createPullRequestModelReference(owner, repo, prNumber);
 		disposables.add(modelRef);
-		disposables.add(modelRef.object.startPolling());
-
+		void modelRef.object.refreshPullRequest();
+		disposables.add(modelRef.object.startPullRequestPolling());
 		this._pullRequests.set(key, disposables);
 	}
 
-	private _disposePolling(session: ISession): void {
-		const gitHubInfo = session.gitHubInfo.get();
-		if (!gitHubInfo || !gitHubInfo.pullRequest) {
+	private _releasePullRequest(key: string, sessionId: string): void {
+		const sessions = this._pullRequestSessions.get(key);
+		if (!sessions) {
 			return;
 		}
 
-		const key = getPullRequestKey(gitHubInfo.owner, gitHubInfo.repo, gitHubInfo.pullRequest.number);
-		this._pullRequests.deleteAndDispose(key);
+		sessions.delete(sessionId);
+		if (sessions.size === 0) {
+			this._pullRequestSessions.delete(key);
+			this._pullRequests.deleteAndDispose(key);
+		}
+	}
+
+	private _disposeSession(session: ISession): void {
+		this._sessions.deleteAndDispose(session.sessionId);
 	}
 
 	override dispose(): void {
+		this._sessions.dispose();
 		this._pullRequests.dispose();
+		this._pullRequestSessions.clear();
 
 		super.dispose();
 	}

--- a/src/vs/sessions/contrib/github/browser/models/githubPullRequestModel.ts
+++ b/src/vs/sessions/contrib/github/browser/models/githubPullRequestModel.ts
@@ -54,9 +54,12 @@ export class GitHubPullRequestModel extends Disposable {
 	readonly mergeability: IObservable<IGitHubPullRequestMergeability | undefined> = this._mergeability;
 
 	private _refreshPromise: Promise<void> | undefined = undefined;
+	private _pullRequestRefreshPromise: Promise<void> | undefined = undefined;
 
 	private readonly _pollScheduler: RunOnceScheduler;
 	private readonly _pollingDisposables = this._register(new DisposableSet());
+	private readonly _pullRequestPollScheduler: RunOnceScheduler;
+	private readonly _pullRequestPollingDisposables = this._register(new DisposableSet());
 
 	constructor(
 		readonly owner: string,
@@ -68,6 +71,7 @@ export class GitHubPullRequestModel extends Disposable {
 		super();
 
 		this._pollScheduler = this._register(new RunOnceScheduler(() => this._poll(), DEFAULT_POLL_INTERVAL_MS));
+		this._pullRequestPollScheduler = this._register(new RunOnceScheduler(() => this._pollPullRequest(), DEFAULT_POLL_INTERVAL_MS));
 	}
 
 	/**
@@ -82,6 +86,22 @@ export class GitHubPullRequestModel extends Disposable {
 		}
 
 		return this._refreshPromise;
+	}
+
+	/**
+	 * Refresh only the pull request metadata. Use this when a caller only needs
+	 * lightweight state such as open/closed/merged/draft and does not need
+	 * reviews or mergeability.
+	 */
+	refreshPullRequest(): Promise<void> {
+		if (!this._pullRequestRefreshPromise) {
+			this._pullRequestRefreshPromise = this._refreshPullRequest()
+				.finally(() => {
+					this._pullRequestRefreshPromise = undefined;
+				});
+		}
+
+		return this._pullRequestRefreshPromise;
 	}
 
 	/**
@@ -111,11 +131,41 @@ export class GitHubPullRequestModel extends Disposable {
 		return disposable;
 	}
 
+	/**
+	 * Start periodic polling for pull request metadata only. This is used for
+	 * background session-list icons; richer active-session data uses the full
+	 * model refresh and the dedicated CI/review-thread models.
+	 */
+	startPullRequestPolling(intervalMs: number = DEFAULT_POLL_INTERVAL_MS): IDisposable {
+		const disposable = toDisposable(() => {
+			this._pullRequestPollingDisposables.deleteAndDispose(disposable);
+
+			if (this._pullRequestPollingDisposables.size === 0) {
+				this._pullRequestPollScheduler.cancel();
+			}
+		});
+		this._pullRequestPollingDisposables.add(disposable);
+
+		if (this._pullRequestPollingDisposables.size === 1) {
+			this._pullRequestPollScheduler.schedule(intervalMs);
+		}
+
+		return disposable;
+	}
+
 	private async _poll(): Promise<void> {
 		await this.refresh();
 		// Re-schedule for next poll cycle (RunOnceScheduler is one-shot)
 		if (!this._store.isDisposed && this._pollingDisposables.size > 0) {
 			this._pollScheduler.schedule();
+		}
+	}
+
+	private async _pollPullRequest(): Promise<void> {
+		await this.refreshPullRequest();
+		// Re-schedule for next poll cycle (RunOnceScheduler is one-shot)
+		if (!this._store.isDisposed && this._pullRequestPollingDisposables.size > 0) {
+			this._pullRequestPollScheduler.schedule();
 		}
 	}
 
@@ -150,6 +200,18 @@ export class GitHubPullRequestModel extends Disposable {
 					}
 				}
 			});
+		} catch (err) {
+			this._logService.error(`${LOG_PREFIX} Failed to refresh PR #${this.prNumber}:`, err);
+		}
+	}
+
+	private async _refreshPullRequest(): Promise<void> {
+		try {
+			const pr = await this._fetcher.getPullRequest(this.owner, this.repo, this.prNumber, this._pullRequestEtag);
+			if (pr.statusCode === 200 && pr.data) {
+				this._pullRequestEtag = pr.etag;
+				this._pullRequest.set(pr.data, undefined);
+			}
 		} catch (err) {
 			this._logService.error(`${LOG_PREFIX} Failed to refresh PR #${this.prNumber}:`, err);
 		}

--- a/src/vs/sessions/contrib/github/browser/models/githubPullRequestModel.ts
+++ b/src/vs/sessions/contrib/github/browser/models/githubPullRequestModel.ts
@@ -209,8 +209,16 @@ export class GitHubPullRequestModel extends Disposable {
 		try {
 			const pr = await this._fetcher.getPullRequest(this.owner, this.repo, this.prNumber, this._pullRequestEtag);
 			if (pr.statusCode === 200 && pr.data) {
-				this._pullRequestEtag = pr.etag;
-				this._pullRequest.set(pr.data, undefined);
+				const pullRequest = pr.data;
+				transaction(tx => {
+					this._pullRequestEtag = pr.etag;
+					this._pullRequest.set(pullRequest, tx);
+
+					const reviews = this._reviews.get();
+					if (reviews) {
+						this._mergeability.set(computeMergeability(pullRequest, reviews), tx);
+					}
+				});
 			}
 		} catch (err) {
 			this._logService.error(`${LOG_PREFIX} Failed to refresh PR #${this.prNumber}:`, err);

--- a/src/vs/sessions/contrib/github/test/browser/githubContribution.test.ts
+++ b/src/vs/sessions/contrib/github/test/browser/githubContribution.test.ts
@@ -42,10 +42,23 @@ suite('GitHubPullRequestPollingContribution', () => {
 		sessionsManagementService.fireSessionsChanged({ added: [addedSession] });
 
 		assert.deepStrictEqual(gitHubService.snapshot(), {
-			'owner/repo/1': { startPollingCalls: 1, stopPollingCalls: 0, disposeCalls: 0 },
-			'owner/repo/2': { startPollingCalls: 1, stopPollingCalls: 0, disposeCalls: 0 },
+			'owner/repo/1': { refreshPullRequestCalls: 1, startPullRequestPollingCalls: 1, stopPullRequestPollingCalls: 0, disposeCalls: 0 },
+			'owner/repo/2': { refreshPullRequestCalls: 1, startPullRequestPollingCalls: 1, stopPullRequestPollingCalls: 0, disposeCalls: 0 },
 		});
 		assert.strictEqual(existingSession.isArchived.get(), false);
+	});
+
+	test('starts polling when pull request info becomes available after session observation', () => {
+		const session = sessionsManagementService.addSession('session', undefined);
+		store.add(new GitHubPullRequestPollingContribution(gitHubService, sessionsManagementService));
+
+		assert.deepStrictEqual(gitHubService.snapshot(), {});
+
+		sessionsManagementService.setGitHubInfo(session, makeGitHubInfo(1));
+
+		assert.deepStrictEqual(gitHubService.snapshot(), {
+			'owner/repo/1': { refreshPullRequestCalls: 1, startPullRequestPollingCalls: 1, stopPullRequestPollingCalls: 0, disposeCalls: 0 },
+		});
 	});
 
 	test('stops polling when a session is archived, then resumes when unarchived', () => {
@@ -56,14 +69,14 @@ suite('GitHubPullRequestPollingContribution', () => {
 		sessionsManagementService.fireSessionsChanged({ changed: [session] });
 
 		assert.deepStrictEqual(gitHubService.snapshot(), {
-			'owner/repo/1': { startPollingCalls: 1, stopPollingCalls: 1, disposeCalls: 0 },
+			'owner/repo/1': { refreshPullRequestCalls: 1, startPullRequestPollingCalls: 1, stopPullRequestPollingCalls: 1, disposeCalls: 0 },
 		});
 
 		sessionsManagementService.setArchived(session, false);
 		sessionsManagementService.fireSessionsChanged({ changed: [session] });
 
 		assert.deepStrictEqual(gitHubService.snapshot(), {
-			'owner/repo/1': { startPollingCalls: 2, stopPollingCalls: 1, disposeCalls: 0 },
+			'owner/repo/1': { refreshPullRequestCalls: 2, startPullRequestPollingCalls: 2, stopPullRequestPollingCalls: 1, disposeCalls: 0 },
 		});
 	});
 
@@ -77,7 +90,7 @@ suite('GitHubPullRequestPollingContribution', () => {
 		sessionsManagementService.fireSessionsChanged({ changed: [session] });
 
 		assert.deepStrictEqual(gitHubService.snapshot(), {
-			'owner/repo/1': { startPollingCalls: 1, stopPollingCalls: 0, disposeCalls: 0 },
+			'owner/repo/1': { refreshPullRequestCalls: 1, startPullRequestPollingCalls: 1, stopPullRequestPollingCalls: 0, disposeCalls: 0 },
 		});
 	});
 
@@ -88,7 +101,7 @@ suite('GitHubPullRequestPollingContribution', () => {
 		contribution.dispose();
 
 		assert.deepStrictEqual(gitHubService.snapshot(), {
-			'owner/repo/1': { startPollingCalls: 1, stopPollingCalls: 1, disposeCalls: 0 },
+			'owner/repo/1': { refreshPullRequestCalls: 1, startPullRequestPollingCalls: 1, stopPullRequestPollingCalls: 1, disposeCalls: 0 },
 		});
 		assert.strictEqual(session.isArchived.get(), false);
 	});
@@ -221,10 +234,11 @@ class TestGitHubService extends mock<IGitHubService>() {
 		return new ImmortalReference(model as unknown as GitHubPullRequestModel);
 	}
 
-	snapshot(): Record<string, { startPollingCalls: number; stopPollingCalls: number; disposeCalls: number }> {
+	snapshot(): Record<string, { refreshPullRequestCalls: number; startPullRequestPollingCalls: number; stopPullRequestPollingCalls: number; disposeCalls: number }> {
 		const entries = [...this._models.entries()].map(([key, model]) => [key, {
-			startPollingCalls: model.startPollingCalls,
-			stopPollingCalls: model.stopPollingCalls,
+			refreshPullRequestCalls: model.refreshPullRequestCalls,
+			startPullRequestPollingCalls: model.startPullRequestPollingCalls,
+			stopPullRequestPollingCalls: model.stopPullRequestPollingCalls,
 			disposeCalls: model.disposeCalls,
 		}] as const);
 		return Object.fromEntries(entries);
@@ -233,16 +247,18 @@ class TestGitHubService extends mock<IGitHubService>() {
 
 class TestPullRequestModel implements IDisposable {
 
-	startPollingCalls = 0;
-	stopPollingCalls = 0;
+	refreshPullRequestCalls = 0;
+	startPullRequestPollingCalls = 0;
+	stopPullRequestPollingCalls = 0;
 	disposeCalls = 0;
 
-	startPolling(): IDisposable {
-		this.startPollingCalls++;
-		return toDisposable(() => this.stopPollingCalls++);
+	startPullRequestPolling(): IDisposable {
+		this.startPullRequestPollingCalls++;
+		return toDisposable(() => this.stopPullRequestPollingCalls++);
 	}
 
-	refresh(): Promise<void> {
+	refreshPullRequest(): Promise<void> {
+		this.refreshPullRequestCalls++;
 		return Promise.resolve();
 	}
 

--- a/src/vs/sessions/contrib/github/test/browser/githubModels.test.ts
+++ b/src/vs/sessions/contrib/github/test/browser/githubModels.test.ts
@@ -255,6 +255,59 @@ suite('GitHubPullRequestModel', () => {
 		});
 	});
 
+	test('refreshPullRequest refreshes only pull request metadata', async () => {
+		const model = store.add(new GitHubPullRequestModel('owner', 'repo', 1, mockFetcher as unknown as GitHubPRFetcher, logService));
+		mockFetcher.nextPR = makePR();
+
+		await model.refreshPullRequest();
+
+		assert.deepStrictEqual({
+			prNumber: model.pullRequest.get()?.number,
+			mergeability: model.mergeability.get(),
+			getPullRequestCalls: mockFetcher.getPullRequestCalls,
+			getReviewsCalls: mockFetcher.getReviewsCalls,
+		}, {
+			prNumber: 1,
+			mergeability: undefined,
+			getPullRequestCalls: 1,
+			getReviewsCalls: 0,
+		});
+	});
+
+	test('refreshPullRequest shares an in-progress request', async () => {
+		const model = store.add(new GitHubPullRequestModel('owner', 'repo', 1, mockFetcher as unknown as GitHubPRFetcher, logService));
+		mockFetcher.nextPR = makePR();
+		mockFetcher.getPullRequestGate = new DeferredPromise<void>();
+
+		const firstRefresh = model.refreshPullRequest();
+		const secondRefresh = model.refreshPullRequest();
+
+		try {
+			assert.deepStrictEqual({
+				samePromise: firstRefresh === secondRefresh,
+				getPullRequestCalls: mockFetcher.getPullRequestCalls,
+				getReviewsCalls: mockFetcher.getReviewsCalls,
+			}, {
+				samePromise: true,
+				getPullRequestCalls: 1,
+				getReviewsCalls: 0,
+			});
+		} finally {
+			await mockFetcher.getPullRequestGate.complete(undefined);
+		}
+
+		await firstRefresh;
+		assert.deepStrictEqual({
+			prNumber: model.pullRequest.get()?.number,
+			getPullRequestCalls: mockFetcher.getPullRequestCalls,
+			getReviewsCalls: mockFetcher.getReviewsCalls,
+		}, {
+			prNumber: 1,
+			getPullRequestCalls: 1,
+			getReviewsCalls: 0,
+		});
+	});
+
 	test('postIssueComment calls fetcher', async () => {
 		const model = store.add(new GitHubPullRequestModel('owner', 'repo', 1, mockFetcher as unknown as GitHubPRFetcher, logService));
 
@@ -270,6 +323,24 @@ suite('GitHubPullRequestModel', () => {
 		polling.dispose();
 		polling.dispose();
 	});
+
+	test('pull request polling refreshes only pull request metadata', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
+		const model = store.add(new GitHubPullRequestModel('owner', 'repo', 1, mockFetcher as unknown as GitHubPRFetcher, logService));
+		mockFetcher.nextPR = makePR();
+
+		const polling = model.startPullRequestPolling(10);
+
+		await timeout(10);
+		assert.deepStrictEqual({
+			getPullRequestCalls: mockFetcher.getPullRequestCalls,
+			getReviewsCalls: mockFetcher.getReviewsCalls,
+		}, {
+			getPullRequestCalls: 1,
+			getReviewsCalls: 0,
+		});
+
+		polling.dispose();
+	}));
 
 	test('polling stops when the last client stops polling', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
 		const model = store.add(new GitHubPullRequestModel('owner', 'repo', 1, mockFetcher as unknown as GitHubPRFetcher, logService));

--- a/src/vs/sessions/contrib/github/test/browser/githubModels.test.ts
+++ b/src/vs/sessions/contrib/github/test/browser/githubModels.test.ts
@@ -16,7 +16,7 @@ import { GitHubRepositoryModel } from '../../browser/models/githubRepositoryMode
 import { GitHubPRFetcher } from '../../browser/fetchers/githubPRFetcher.js';
 import { GitHubPRCIFetcher } from '../../browser/fetchers/githubPRCIFetcher.js';
 import { GitHubRepositoryFetcher } from '../../browser/fetchers/githubRepositoryFetcher.js';
-import { GitHubCIOverallStatus, GitHubCheckConclusion, GitHubCheckStatus, GitHubPullRequestState, IGitHubCICheck, IGitHubPRComment, IGitHubPullRequestReview, IGitHubPullRequest, IGitHubRepository, IGitHubPullRequestReviewThread } from '../../common/types.js';
+import { GitHubCIOverallStatus, GitHubCheckConclusion, GitHubCheckStatus, GitHubPullRequestState, IGitHubCICheck, IGitHubPRComment, IGitHubPullRequestReview, IGitHubPullRequest, IGitHubRepository, IGitHubPullRequestReviewThread, MergeBlockerKind } from '../../common/types.js';
 
 //#region Mock Fetchers
 
@@ -271,6 +271,28 @@ suite('GitHubPullRequestModel', () => {
 			mergeability: undefined,
 			getPullRequestCalls: 1,
 			getReviewsCalls: 0,
+		});
+	});
+
+	test('refreshPullRequest recomputes mergeability with cached reviews', async () => {
+		const model = store.add(new GitHubPullRequestModel('owner', 'repo', 1, mockFetcher as unknown as GitHubPRFetcher, logService));
+		mockFetcher.nextPR = makePR();
+		mockFetcher.nextReviews = [makeReview('APPROVED')];
+		await model.refresh();
+
+		mockFetcher.nextPR = { ...makePR(), isDraft: true };
+		await model.refreshPullRequest();
+
+		assert.deepStrictEqual({
+			canMerge: model.mergeability.get()?.canMerge,
+			blockers: model.mergeability.get()?.blockers.map(blocker => blocker.kind),
+			getPullRequestCalls: mockFetcher.getPullRequestCalls,
+			getReviewsCalls: mockFetcher.getReviewsCalls,
+		}, {
+			canMerge: false,
+			blockers: [MergeBlockerKind.Draft],
+			getPullRequestCalls: 2,
+			getReviewsCalls: 1,
 		});
 	});
 
@@ -775,6 +797,15 @@ function makePR(): IGitHubPullRequest {
 		mergedAt: undefined,
 		mergeable: true,
 		mergeableState: 'clean',
+	};
+}
+
+function makeReview(state: string): IGitHubPullRequestReview {
+	return {
+		id: 1,
+		author: { login: 'reviewer', avatarUrl: '' },
+		state,
+		submittedAt: '2024-01-02T00:00:00Z',
 	};
 }
 


### PR DESCRIPTION
## Summary
- add PR-metadata-only refresh/polling on the shared GitHub pull request model
- have the GitHub contribution observe non-archived sessions and start PR metadata polling when PR info appears
- cover delayed PR info, archive/unarchive, and metadata-only polling behavior

## Validation
- npm run compile-check-ts-native
- npm run valid-layers-check
- hygiene check on touched files
- GitHubPullRequest unit tests