### PR TITLE
Force-kill Electron app if close hangs in sanity tests

### DIFF
--- a/test/sanity/src/context.ts
+++ b/test/sanity/src/context.ts
@@ -1130,18 +1130,29 @@ export class TestContext {
 	public async closeElectronApp(app: ElectronApplication, timeoutMs = 60_000): Promise<void> {
 		this.log('Closing the application');
 		const pid = app.process().pid;
+		let timeoutHandle: NodeJS.Timeout | undefined;
 		try {
 			await Promise.race([
 				app.close(),
-				new Promise<never>((_, reject) => setTimeout(
-					() => reject(new Error(`app.close() did not complete within ${timeoutMs}ms`)),
-					timeoutMs,
-				)),
+				new Promise<never>((_, reject) => {
+					timeoutHandle = setTimeout(
+						() => reject(new Error(`app.close() did not complete within ${timeoutMs}ms`)),
+						timeoutMs,
+					);
+				}),
 			]);
 		} catch (error) {
 			this.warn(`Failed to close application gracefully: ${error instanceof Error ? error.message : String(error)}`);
 			if (pid) {
-				this.killProcessTree(pid);
+				try {
+					this.killProcessTree(pid);
+				} catch (killError) {
+					this.warn(`Failed to force-kill application process tree: ${killError instanceof Error ? killError.message : String(killError)}`);
+				}
+			}
+		} finally {
+			if (timeoutHandle) {
+				clearTimeout(timeoutHandle);
 			}
 		}
 	}

--- a/test/sanity/src/context.ts
+++ b/test/sanity/src/context.ts
@@ -10,7 +10,7 @@ import { test } from 'mocha';
 import fetch, { Response } from 'node-fetch';
 import os from 'os';
 import path from 'path';
-import { Browser, chromium, Page, webkit } from 'playwright';
+import { Browser, chromium, ElectronApplication, Page, webkit } from 'playwright';
 import { Capability, detectCapabilities } from './detectors.js';
 
 /**
@@ -1121,6 +1121,29 @@ export class TestContext {
 		const page = await pagePromise;
 		page.setDefaultTimeout(3 * 60 * 1000);
 		return page;
+	}
+
+	/**
+	 * Closes a Playwright Electron application gracefully, falling back to a forced
+	 * kill of the process tree if the close hangs (for example after a renderer crash).
+	 */
+	public async closeElectronApp(app: ElectronApplication, timeoutMs = 60_000): Promise<void> {
+		this.log('Closing the application');
+		const pid = app.process().pid;
+		try {
+			await Promise.race([
+				app.close(),
+				new Promise<never>((_, reject) => setTimeout(
+					() => reject(new Error(`app.close() did not complete within ${timeoutMs}ms`)),
+					timeoutMs,
+				)),
+			]);
+		} catch (error) {
+			this.warn(`Failed to close application gracefully: ${error instanceof Error ? error.message : String(error)}`);
+			if (pid) {
+				this.killProcessTree(pid);
+			}
+		}
 	}
 
 	/**

--- a/test/sanity/src/desktop.test.ts
+++ b/test/sanity/src/desktop.test.ts
@@ -253,8 +253,7 @@ export function setup(context: TestContext) {
 			const window = await context.getPage(app.firstWindow());
 			await test.run(window);
 		} finally {
-			context.log('Closing the application');
-			await app.close();
+			await context.closeElectronApp(app);
 		}
 
 		test.validate();

--- a/test/sanity/src/wsl.test.ts
+++ b/test/sanity/src/wsl.test.ts
@@ -172,8 +172,7 @@ export function setup(context: TestContext) {
 
 			await test.run(window);
 		} finally {
-			context.log('Closing the application');
-			await app.close();
+			await context.closeElectronApp(app);
 		}
 
 		test.validate();


### PR DESCRIPTION
When the renderer crashes mid-test (observed during the marketplace "No extensions found" → Refresh retry loop on `desktop-linux-x64`), the `finally` block's `app.close()` call hangs against the crashed process for the entire mocha 10‑minute timeout. The whole sanity test job ends up failing with a single test timeout, e.g. build [437484](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=437484).

Add a `closeElectronApp` helper on `TestContext` that races `app.close()` with a 60s timeout and falls back to `killProcessTree` if it does not complete. Update the desktop and WSL test entry points to use it.

This makes the test fail fast (~60s) on a stuck close instead of consuming the full mocha timeout, so subsequent tests still run and the screenshots artifact gets a chance to be published.