### PR TITLE
Render apply_patch as an edit tool

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -31,7 +31,7 @@ import { IAgentConfigurationService } from '../agentConfigurationService.js';
 import type { IExitPlanModeRequestParams, IExitPlanModeResponse } from './copilotAgent.js';
 import { CopilotSessionWrapper } from './copilotSessionWrapper.js';
 import type { ShellManager } from './copilotShellTools.js';
-import { getEditFilePath, getInvocationMessage, getPastTenseMessage, getPermissionDisplay, getShellLanguage, getSubagentMetadata, getToolDisplayName, getToolInputString, getToolKind, isEditTool, isHiddenTool, isShellTool, synthesizeSkillToolCall, tryStringify, type ITypedPermissionRequest } from './copilotToolDisplay.js';
+import { getEditFilePaths, getInvocationMessage, getPastTenseMessage, getPermissionDisplay, getShellLanguage, getSubagentMetadata, getToolDisplayName, getToolInputString, getToolKind, isEditTool, isHiddenTool, isShellTool, synthesizeSkillToolCall, tryStringify, type ITypedPermissionRequest } from './copilotToolDisplay.js';
 import { FileEditTracker } from './fileEditTracker.js';
 import { mapSessionEvents } from './mapSessionEvents.js';
 import { buildPendingEditContentUri } from './pendingEditContentStore.js';
@@ -178,7 +178,7 @@ export class CopilotAgentSession extends Disposable {
 	readonly sessionUri: URI;
 
 	/** Tracks active tool invocations so we can produce past-tense messages on completion. */
-	private readonly _activeToolCalls = new Map<string, { toolName: string; displayName: string; parameters: Record<string, unknown> | undefined; content: ToolResultContent[]; parentToolCallId: string | undefined }>();
+	private readonly _activeToolCalls = new Map<string, { toolName: string; displayName: string; parameters: Record<string, unknown> | undefined; content: ToolResultContent[]; parentToolCallId: string | undefined; editFilePaths: readonly string[] }>();
 	private readonly _parentToolCallIdsByAgentId = new Map<string, string>();
 	/** Pending permission requests awaiting a renderer-side decision. */
 	private readonly _pendingPermissions = new Map<string, DeferredPromise<boolean>>();
@@ -1074,8 +1074,7 @@ export class CopilotAgentSession extends Disposable {
 	private async _handlePreToolUse(input: PreToolUseHookInput): Promise<void> {
 		try {
 			if (isEditTool(input.toolName)) {
-				const filePath = getEditFilePath(input.toolArgs);
-				if (filePath) {
+				for (const filePath of getEditFilePaths(input.toolArgs, this._workingDirectory)) {
 					await this._editTracker.trackEditStart(filePath);
 				}
 			}
@@ -1088,8 +1087,7 @@ export class CopilotAgentSession extends Disposable {
 	private async _handlePostToolUse(input: PostToolUseHookInput): Promise<void> {
 		try {
 			if (isEditTool(input.toolName)) {
-				const filePath = getEditFilePath(input.toolArgs);
-				if (filePath) {
+				for (const filePath of getEditFilePaths(input.toolArgs, this._workingDirectory)) {
 					await this._editTracker.completeEdit(filePath);
 				}
 			}
@@ -1178,7 +1176,12 @@ export class CopilotAgentSession extends Disposable {
 			let toolArgs = e.data.arguments !== undefined ? tryStringify(e.data.arguments) : undefined;
 			let parameters: Record<string, unknown> | undefined;
 			if (toolArgs) {
-				try { parameters = JSON.parse(toolArgs) as Record<string, unknown>; } catch { /* ignore */ }
+				try {
+					const parsed = JSON.parse(toolArgs);
+					if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+						parameters = parsed as Record<string, unknown>;
+					}
+				} catch { /* ignore */ }
 			}
 			// Strip redundant `cd <workingDirectory> && …` prefixes from shell tool
 			// commands so clients see the simplified form. Mirrors the logic in
@@ -1191,7 +1194,8 @@ export class CopilotAgentSession extends Disposable {
 				return;
 			}
 			const parentToolCallId = this._parentToolCallIdForSubagentEvent(e);
-			this._activeToolCalls.set(e.data.toolCallId, { toolName: e.data.toolName, displayName, parameters, content: [], parentToolCallId });
+			const editFilePaths = isEditTool(e.data.toolName) ? getEditFilePaths(e.data.arguments, this._workingDirectory) : [];
+			this._activeToolCalls.set(e.data.toolCallId, { toolName: e.data.toolName, displayName, parameters, content: [], parentToolCallId, editFilePaths });
 			const toolKind = getToolKind(e.data.toolName);
 			const subagentMeta = toolKind === 'subagent' ? getSubagentMetadata(parameters) : undefined;
 			const toolClientId = this._clientToolNames.has(e.data.toolName) ? this._appliedSnapshot.clientId : undefined;
@@ -1271,8 +1275,7 @@ export class CopilotAgentSession extends Disposable {
 				content.push({ type: ToolResultContentType.Text, text: toolOutput });
 			}
 
-			const filePath = isEditTool(tracked.toolName) ? getEditFilePath(tracked.parameters) : undefined;
-			if (filePath) {
+			for (const filePath of tracked.editFilePaths) {
 				try {
 					const fileEdit = await this._editTracker.takeCompletedEdit(this._turnId, e.data.toolCallId, filePath);
 					if (fileEdit) {

--- a/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
@@ -13,6 +13,7 @@ import type { IAgentToolPendingConfirmationSignal } from '../../common/agentServ
 import { stripRedundantCdPrefix } from '../../common/commandLineHelpers.js';
 import { StringOrMarkdown } from '../../common/state/protocol/state.js';
 import { basename } from '../../../../base/common/resources.js';
+import { isAbsolute } from '../../../../base/common/path.js';
 
 // =============================================================================
 // Copilot CLI built-in tool interfaces
@@ -70,6 +71,12 @@ interface ICopilotShellToolArgs {
 /** Parameters for file tools (`view`, `edit`, `create`). */
 interface ICopilotFileToolArgs {
 	path: string;
+}
+
+/** Parameters for patch tools (`apply_patch`, `git_apply_patch`). */
+interface ICopilotPatchToolArgs {
+	input?: string;
+	patch?: string;
 }
 
 /**
@@ -169,16 +176,84 @@ export function isEditTool(toolName: string): boolean {
  * Extracts the target file path from an edit tool's parameters, if available.
  */
 export function getEditFilePath(parameters: unknown): string | undefined {
+	return getEditFilePaths(parameters)[0];
+}
+
+/**
+ * Extracts the target file paths from an edit tool's parameters, if available.
+ */
+export function getEditFilePaths(parameters: unknown, workingDirectory?: URI): string[] {
 	if (typeof parameters === 'string') {
 		try {
-			parameters = JSON.parse(parameters);
+			const parsed = JSON.parse(parameters);
+			if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+				parameters = parsed;
+			} else if (typeof parsed === 'string') {
+				return getPatchFilePaths(parsed, workingDirectory);
+			}
 		} catch {
-			return undefined;
+			return typeof parameters === 'string' ? getPatchFilePaths(parameters, workingDirectory) : [];
 		}
 	}
 
-	const args = parameters as ICopilotFileToolArgs | undefined;
-	return args?.path;
+	const args = parameters as ICopilotFileToolArgs | ICopilotPatchToolArgs | undefined;
+	if (typeof (args as ICopilotFileToolArgs | undefined)?.path === 'string') {
+		return [(args as ICopilotFileToolArgs).path];
+	}
+
+	const patch = typeof (args as ICopilotPatchToolArgs | undefined)?.input === 'string'
+		? (args as ICopilotPatchToolArgs).input
+		: typeof (args as ICopilotPatchToolArgs | undefined)?.patch === 'string'
+			? (args as ICopilotPatchToolArgs).patch
+			: undefined;
+	return getPatchFilePaths(patch, workingDirectory);
+}
+
+function getPatchFilePaths(patch: string | undefined, workingDirectory: URI | undefined): string[] {
+	if (!patch) {
+		return [];
+	}
+
+	const result: string[] = [];
+	const seen = new Set<string>();
+	const addPath = (filePath: string | undefined) => {
+		if (!filePath || filePath === '/dev/null') {
+			return;
+		}
+		const normalized = normalizePatchPath(filePath, workingDirectory);
+		if (!seen.has(normalized)) {
+			seen.add(normalized);
+			result.push(normalized);
+		}
+	};
+
+	for (const line of patch.split(/\r?\n/)) {
+		const applyPatchMatch = line.match(/^\*\*\* (?:Add|Update|Delete) File: (?<path>.+)$/) ?? line.match(/^\*\*\* Move to: (?<path>.+)$/);
+		if (applyPatchMatch?.groups?.path) {
+			addPath(applyPatchMatch.groups.path);
+			continue;
+		}
+
+		const gitDiffMatch = line.match(/^diff --git a\/(?<before>.+) b\/(?<after>.+)$/);
+		if (gitDiffMatch?.groups) {
+			addPath(gitDiffMatch.groups.after);
+			continue;
+		}
+
+		const gitFileMatch = line.match(/^\+\+\+ b\/(?<path>.+)$/);
+		if (gitFileMatch?.groups?.path) {
+			addPath(gitFileMatch.groups.path);
+		}
+	}
+
+	return result;
+}
+
+function normalizePatchPath(filePath: string, workingDirectory: URI | undefined): string {
+	if (!workingDirectory || isAbsolute(filePath)) {
+		return filePath;
+	}
+	return URI.joinPath(workingDirectory, ...filePath.split('/')).fsPath;
 }
 
 /** Set of tool names that execute shell commands (bash or powershell). */
@@ -352,6 +427,9 @@ export function getInvocationMessage(toolName: string, displayName: string, para
 			}
 			return localize('toolInvoke.create', "Creating file");
 		}
+		case CopilotToolName.ApplyPatch:
+		case CopilotToolName.GitApplyPatch:
+			return localize('toolInvoke.patch', "Applying patch to files");
 		case CopilotToolName.Grep: {
 			const args = parameters as ICopilotGrepToolArgs | undefined;
 			if (args?.pattern) {
@@ -440,6 +518,9 @@ export function getPastTenseMessage(toolName: string, displayName: string, param
 			}
 			return localize('toolComplete.create', "Created file");
 		}
+		case CopilotToolName.ApplyPatch:
+		case CopilotToolName.GitApplyPatch:
+			return localize('toolComplete.patch', "Applied patch to files");
 		case CopilotToolName.Grep: {
 			const args = parameters as ICopilotGrepToolArgs | undefined;
 			if (args?.pattern) {
@@ -581,6 +662,11 @@ export function getToolInputString(toolName: string, parameters: Record<string, 
 		case CopilotToolName.Rg: {
 			const args = parameters as ICopilotRgToolArgs | undefined;
 			return args?.pattern ?? rawArguments;
+		}
+		case CopilotToolName.ApplyPatch:
+		case CopilotToolName.GitApplyPatch: {
+			const args = parameters as ICopilotPatchToolArgs | undefined;
+			return args?.input ?? args?.patch ?? rawArguments;
 		}
 		default:
 			// For other tools, show the formatted JSON arguments

--- a/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
+++ b/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
@@ -216,7 +216,12 @@ export async function mapSessionEvents(
 		const rawArgs = d.arguments !== undefined ? tryStringify(d.arguments) : undefined;
 		let parameters: Record<string, unknown> | undefined;
 		if (rawArgs) {
-			try { parameters = JSON.parse(rawArgs) as Record<string, unknown>; } catch { /* ignore */ }
+			try {
+				const parsed = JSON.parse(rawArgs);
+				if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+					parameters = parsed as Record<string, unknown>;
+				}
+			} catch { /* ignore */ }
 		}
 		// stripRedundantCdPrefix mutates `parameters` and signals via its
 		// return value. We re-stringify only when it changed something so

--- a/src/vs/platform/agentHost/test/node/copilotToolDisplay.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotToolDisplay.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
-import { getInvocationMessage, getPastTenseMessage, getPermissionDisplay, getShellLanguage, getToolInputString, getToolKind, isHiddenTool, synthesizeSkillToolCall, type ITypedPermissionRequest } from '../../node/copilot/copilotToolDisplay.js';
+import { getEditFilePaths, getInvocationMessage, getPastTenseMessage, getPermissionDisplay, getShellLanguage, getToolInputString, getToolKind, isHiddenTool, synthesizeSkillToolCall, type ITypedPermissionRequest } from '../../node/copilot/copilotToolDisplay.js';
 
 suite('getPermissionDisplay — cd-prefix stripping', () => {
 
@@ -122,6 +122,72 @@ suite('view tool — view_range display', () => {
 		assert.ok(!invocation({ path: '/repo/file.ts', view_range: [10, 20, 30] }).includes(','));
 		// non-array
 		assert.ok(!invocation({ path: '/repo/file.ts', view_range: 'whatever' }).includes(','));
+	});
+});
+
+suite('apply_patch tool display', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const wd = URI.file('/repo/project');
+	const patch = [
+		'*** Begin Patch',
+		'*** Update File: src/foo.ts',
+		'@@',
+		'-old',
+		'+new',
+		'*** Add File: src/bar.ts',
+		'+content',
+		'*** End Patch',
+	].join('\n');
+
+	function text(msg: ReturnType<typeof getInvocationMessage>): string {
+		return typeof msg === 'string' ? msg : msg.markdown;
+	}
+
+	test('uses edit-style patch messages instead of the generic fallback', () => {
+		assert.deepStrictEqual({
+			displayNameInvocation: text(getInvocationMessage('apply_patch', 'Patch', { input: patch })),
+			displayNamePast: text(getPastTenseMessage('apply_patch', 'Patch', { input: patch }, true)),
+			gitPatchInvocation: text(getInvocationMessage('git_apply_patch', 'Patch', { patch })),
+			gitPatchPast: text(getPastTenseMessage('git_apply_patch', 'Patch', { patch }, true)),
+			toolInput: getToolInputString('apply_patch', { input: patch }, undefined),
+		}, {
+			displayNameInvocation: 'Applying patch to files',
+			displayNamePast: 'Applied patch to files',
+			gitPatchInvocation: 'Applying patch to files',
+			gitPatchPast: 'Applied patch to files',
+			toolInput: patch,
+		});
+	});
+
+	test('extracts affected files from apply_patch and git patch arguments', () => {
+		const gitPatch = [
+			'diff --git a/src/old.ts b/src/new.ts',
+			'--- a/src/old.ts',
+			'+++ b/src/new.ts',
+			'@@',
+			'-old',
+			'+new',
+		].join('\n');
+
+		assert.deepStrictEqual({
+			applyPatchInput: getEditFilePaths({ input: patch }, wd),
+			applyPatchRaw: getEditFilePaths(patch, wd),
+			gitPatch: getEditFilePaths({ patch: gitPatch }, wd),
+		}, {
+			applyPatchInput: [
+				URI.joinPath(wd, 'src/foo.ts').fsPath,
+				URI.joinPath(wd, 'src/bar.ts').fsPath,
+			],
+			applyPatchRaw: [
+				URI.joinPath(wd, 'src/foo.ts').fsPath,
+				URI.joinPath(wd, 'src/bar.ts').fsPath,
+			],
+			gitPatch: [
+				URI.joinPath(wd, 'src/new.ts').fsPath,
+			],
+		});
 	});
 });
 


### PR DESCRIPTION
## Summary
- render apply_patch/git_apply_patch with edit-style patch messages instead of the generic tool fallback
- extract affected paths from apply patch and git patch payloads so patch changes flow through file-edit tracking
- add focused coverage for apply_patch display and affected-file extraction

## Validation
- npm run compile-check-ts-native
- npm run gulp compile
- ./scripts/test.sh --run src/vs/platform/agentHost/test/node/copilotToolDisplay.test.ts
- npm run valid-layers-check