### PR TITLE
Add Agent Host setting for Copilot terminal tools

### DIFF
--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -53,6 +53,14 @@ export const AgentHostAhpJsonlLoggingSettingId = 'chat.agentHost.ahpJsonlLogging
 export const AgentHostClaudeAgentSdkPathSettingId = 'chat.agentHost.claudeAgent.path';
 
 /**
+ * Configuration key that disables Agent Host's Copilot-specific terminal tool
+ * override. When enabled, Copilot SDK sessions use the SDK's built-in terminal
+ * support instead of the PTY-backed tools registered by VS Code.
+ * The agent host process must be restarted for changes to take effect.
+ */
+export const AgentHostCopilotDisableCustomTerminalToolsSettingId = 'chat.agentHost.copilot.disableCustomTerminalTools';
+
+/**
  * Environment variable that holds the absolute path to a locally-installed
  * `@anthropic-ai/claude-agent-sdk` package. When set to a non-empty value,
  * the agent host process registers the Claude agent provider and loads the
@@ -61,6 +69,14 @@ export const AgentHostClaudeAgentSdkPathSettingId = 'chat.agentHost.claudeAgent.
  * by developers as an override.
  */
 export const AgentHostClaudeSdkPathEnvVar = 'VSCODE_AGENT_HOST_CLAUDE_SDK_PATH';
+
+/**
+ * Environment variable set by the agent host starters from
+ * {@link AgentHostCopilotDisableCustomTerminalToolsSettingId}. A value of `1`
+ * disables Agent Host's Copilot terminal tool override for the lifetime of the
+ * host process.
+ */
+export const AgentHostCopilotDisableCustomTerminalToolsEnvVar = 'VSCODE_AGENT_HOST_COPILOT_DISABLE_CUSTOM_TERMINAL_TOOLS';
 
 /** Result of starting the agent host WebSocket server on-demand. */
 export interface IAgentHostSocketInfo {

--- a/src/vs/platform/agentHost/electron-main/electronAgentHostStarter.ts
+++ b/src/vs/platform/agentHost/electron-main/electronAgentHostStarter.ts
@@ -19,7 +19,7 @@ import { getResolvedShellEnv } from '../../shell/node/shellEnv.js';
 import { NullTelemetryService } from '../../telemetry/common/telemetryUtils.js';
 import { UtilityProcess } from '../../utilityProcess/electron-main/utilityProcess.js';
 import { IAgentHostConnection, IAgentHostStarter } from '../common/agent.js';
-import { AgentHostClaudeAgentSdkPathSettingId, AgentHostClaudeSdkPathEnvVar } from '../common/agentService.js';
+import { AgentHostClaudeAgentSdkPathSettingId, AgentHostClaudeSdkPathEnvVar, AgentHostCopilotDisableCustomTerminalToolsEnvVar, AgentHostCopilotDisableCustomTerminalToolsSettingId } from '../common/agentService.js';
 import { deepClone } from '../../../base/common/objects.js';
 
 export class ElectronAgentHostStarter extends Disposable implements IAgentHostStarter {
@@ -72,6 +72,8 @@ export class ElectronAgentHostStarter extends Disposable implements IAgentHostSt
 		const claudeSdkPath = this._configurationService.getValue<string>(AgentHostClaudeAgentSdkPathSettingId)
 			|| process.env[AgentHostClaudeSdkPathEnvVar]
 			|| '';
+		const disableCopilotCustomTerminalTools = this._configurationService.getValue<boolean>(AgentHostCopilotDisableCustomTerminalToolsSettingId)
+			|| process.env[AgentHostCopilotDisableCustomTerminalToolsEnvVar] === '1';
 
 		this.utilityProcess.start({
 			type: 'agentHost',
@@ -89,6 +91,7 @@ export class ElectronAgentHostStarter extends Disposable implements IAgentHostSt
 				VSCODE_PIPE_LOGGING: 'true',
 				VSCODE_VERBOSE_LOGGING: 'true',
 				...(claudeSdkPath ? { [AgentHostClaudeSdkPathEnvVar]: claudeSdkPath } : {}),
+				...(disableCopilotCustomTerminalTools ? { [AgentHostCopilotDisableCustomTerminalToolsEnvVar]: '1' } : {}),
 			}
 		});
 

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -25,7 +25,7 @@ import { ILogService } from '../../../log/common/log.js';
 import { AgentHostConfigKey, agentHostCustomizationConfigSchema } from '../../common/agentHostCustomizationConfig.js';
 import { AutoApproveLevel, ISchemaProperty, SessionMode, createSchema, platformSessionSchema, schemaProperty } from '../../common/agentHostSchema.js';
 import { IAgentPluginManager, ISyncedCustomization } from '../../common/agentPluginManager.js';
-import { AgentSession, AgentSignal, GITHUB_COPILOT_PROTECTED_RESOURCE, IAgent, IAgentCreateSessionConfig, IAgentCreateSessionResult, IAgentDescriptor, IAgentMaterializeSessionEvent, IAgentModelInfo, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, IAgentSessionProjectInfo } from '../../common/agentService.js';
+import { AgentHostCopilotDisableCustomTerminalToolsEnvVar, AgentSession, AgentSignal, GITHUB_COPILOT_PROTECTED_RESOURCE, IAgent, IAgentCreateSessionConfig, IAgentCreateSessionResult, IAgentDescriptor, IAgentMaterializeSessionEvent, IAgentModelInfo, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, IAgentSessionProjectInfo } from '../../common/agentService.js';
 import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
 import { ISessionDataService, SESSION_DB_FILENAME } from '../../common/sessionDataService.js';
 import type { ResolveSessionConfigResult, SessionConfigCompletionsResult } from '../../common/state/protocol/commands.js';
@@ -264,6 +264,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 	readonly onDidCustomizationsChange: Event<void>;
 	/** Per-session active client state for tools + plugin snapshot tracking. */
 	private readonly _activeClients = new ResourceMap<ActiveClient>();
+	private readonly _disableCustomTerminalTools = process.env[AgentHostCopilotDisableCustomTerminalToolsEnvVar] === '1';
 
 	constructor(
 		@ILogService private readonly _logService: ILogService,
@@ -814,7 +815,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 		const activeClient = this._activeClients.get(sessionUri);
 		const snapshot = activeClient ? await activeClient.snapshot(customizationDirectory) : undefined;
 		const workingDirectory = await this._resolveSessionWorkingDirectory(materializedConfig, sessionId, prompt);
-		const shellManager = this._instantiationService.createInstance(ShellManager, sessionUri, workingDirectory);
+		const shellManager = this._disableCustomTerminalTools ? undefined : this._instantiationService.createInstance(ShellManager, sessionUri, workingDirectory);
 		const sessionConfigBuilder = this._buildSessionConfig(snapshot, shellManager);
 
 		const factory: SessionWrapperFactory = async callbacks => {
@@ -1311,7 +1312,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 	 * and returns it. The caller must call {@link CopilotAgentSession.initializeSession}
 	 * to wire up the SDK session.
 	 */
-	private _createAgentSession(wrapperFactory: SessionWrapperFactory, sessionId: string, shellManager: ShellManager, workingDirectory: URI | undefined, customizationDirectory: URI | undefined, snapshot?: IActiveClientSnapshot): CopilotAgentSession {
+	private _createAgentSession(wrapperFactory: SessionWrapperFactory, sessionId: string, shellManager: ShellManager | undefined, workingDirectory: URI | undefined, customizationDirectory: URI | undefined, snapshot?: IActiveClientSnapshot): CopilotAgentSession {
 		const sessionUri = AgentSession.uri(this.id, sessionId);
 
 		const agentSession = this._instantiationService.createInstance(
@@ -1363,11 +1364,13 @@ export class CopilotAgent extends Disposable implements IAgent {
 	 * session's permission/hook callbacks, so it can be called lazily
 	 * inside the {@link SessionWrapperFactory}.
 	 */
-	private _buildSessionConfig(snapshot: IActiveClientSnapshot | undefined, shellManager: ShellManager): (args: Parameters<SessionWrapperFactory>[0]) => Promise<ResumeSessionConfig> {
+	private _buildSessionConfig(snapshot: IActiveClientSnapshot | undefined, shellManager: ShellManager | undefined): (args: Parameters<SessionWrapperFactory>[0]) => Promise<ResumeSessionConfig> {
 		const plugins = snapshot?.plugins ?? [];
 
 		return async (callbacks: Parameters<SessionWrapperFactory>[0]) => {
-			const shellTools = await createShellTools(shellManager, this._terminalManager, this._logService);
+			const shellTools = shellManager
+				? await createShellTools(shellManager, this._terminalManager, this._logService)
+				: [];
 			const customAgents = await toSdkCustomAgents(plugins.flatMap(p => p.agents), this._fileService);
 			return {
 				onPermissionRequest: callbacks.onPermissionRequest,
@@ -1406,7 +1409,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 			throw new Error(`workingDirectory is required to resume Copilot session '${sessionId}'`);
 		}
 
-		const shellManager = this._instantiationService.createInstance(ShellManager, sessionUri, workingDirectory);
+		const shellManager = this._disableCustomTerminalTools ? undefined : this._instantiationService.createInstance(ShellManager, sessionUri, workingDirectory);
 		const sessionConfig = this._buildSessionConfig(snapshot, shellManager);
 
 		const factory: SessionWrapperFactory = async callbacks => {

--- a/src/vs/platform/agentHost/node/nodeAgentHostStarter.ts
+++ b/src/vs/platform/agentHost/node/nodeAgentHostStarter.ts
@@ -13,7 +13,7 @@ import { parseAgentHostDebugPort } from '../../environment/node/environmentServi
 import { ILogService } from '../../log/common/log.js';
 import { getResolvedShellEnv } from '../../shell/node/shellEnv.js';
 import { IAgentHostConnection, IAgentHostStarter } from '../common/agent.js';
-import { AgentHostClaudeAgentSdkPathSettingId, AgentHostClaudeSdkPathEnvVar } from '../common/agentService.js';
+import { AgentHostClaudeAgentSdkPathSettingId, AgentHostClaudeSdkPathEnvVar, AgentHostCopilotDisableCustomTerminalToolsEnvVar, AgentHostCopilotDisableCustomTerminalToolsSettingId } from '../common/agentService.js';
 
 /**
  * Options for configuring the agent host WebSocket server in the child process.
@@ -83,6 +83,9 @@ export class NodeAgentHostStarter extends Disposable implements IAgentHostStarte
 			|| '';
 		if (claudeSdkPath) {
 			env[AgentHostClaudeSdkPathEnvVar] = claudeSdkPath;
+		}
+		if (this._configurationService.getValue<boolean>(AgentHostCopilotDisableCustomTerminalToolsSettingId) || process.env[AgentHostCopilotDisableCustomTerminalToolsEnvVar] === '1') {
+			env[AgentHostCopilotDisableCustomTerminalToolsEnvVar] = '1';
 		}
 
 		// Forward WebSocket server configuration to the child process via env vars

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -19,7 +19,7 @@ import { InstantiationService } from '../../../instantiation/common/instantiatio
 import { ServiceCollection } from '../../../instantiation/common/serviceCollection.js';
 import { ILogService, NullLogService } from '../../../log/common/log.js';
 import { IAgentPluginManager, ISyncedCustomization } from '../../common/agentPluginManager.js';
-import { AgentSession, type AgentSignal, type IAgentActionSignal, type IAgentSessionMetadata } from '../../common/agentService.js';
+import { AgentHostCopilotDisableCustomTerminalToolsEnvVar, AgentSession, type AgentSignal, type IAgentActionSignal, type IAgentSessionMetadata } from '../../common/agentService.js';
 import { ISessionDataService } from '../../common/sessionDataService.js';
 import { AHP_AUTH_REQUIRED, ProtocolError } from '../../common/state/sessionProtocol.js';
 import { buildSubagentSessionUri, ResponsePartKind, SessionCustomization, TurnState, type CustomizationRef, type MarkdownResponsePart, type ToolCallResult, type Turn } from '../../common/state/sessionState.js';
@@ -315,8 +315,8 @@ function createAgentSessionThroughAgent(agent: CopilotAgent, instantiationServic
 	const shellManager = instantiationService.createInstance(ShellManager, sessionUri, undefined);
 	const wrapperFactory: SessionWrapperFactory = async () => new CopilotSessionWrapper(new MockCopilotSession() as unknown as CopilotSession);
 	return (agent as unknown as {
-		_createAgentSession: (wrapperFactory: SessionWrapperFactory, sessionId: string, shellManager: ShellManager) => CopilotAgentSession;
-	})._createAgentSession(wrapperFactory, 'test-session-1', shellManager);
+		_createAgentSession: (wrapperFactory: SessionWrapperFactory, sessionId: string, shellManager: ShellManager, workingDirectory: URI | undefined, customizationDirectory: URI | undefined) => CopilotAgentSession;
+	})._createAgentSession(wrapperFactory, 'test-session-1', shellManager, undefined, undefined);
 }
 
 function withoutUndefinedProperties(metadata: IAgentSessionMetadata): Record<string, unknown> {
@@ -721,6 +721,44 @@ suite('CopilotAgent', () => {
 				);
 			} finally {
 				await disposeAgent(agent);
+			}
+		});
+
+		test('materialization omits VS Code terminal tools when custom terminal tools are disabled', async () => {
+			const previousDisableCustomTerminalTools = process.env[AgentHostCopilotDisableCustomTerminalToolsEnvVar];
+			process.env[AgentHostCopilotDisableCustomTerminalToolsEnvVar] = '1';
+			const sessionDataService = disposables.add(new TestSessionDataService());
+			const client = new TestCopilotClient([]);
+			let capturedConfig: Parameters<ITestCopilotClient['createSession']>[0] | undefined;
+			client.createSession = async config => {
+				capturedConfig = config;
+				return new MockCopilotSession() as unknown as CopilotSession;
+			};
+
+			const agent = createTestAgent(disposables, { sessionDataService, copilotClient: client });
+			try {
+				await agent.authenticate('https://api.github.com', 'token');
+
+				const result = await agent.createSession({
+					session: AgentSession.uri('copilotcli', 'sdk-terminal-session'),
+					workingDirectory: URI.file('/workspace'),
+					activeClient: {
+						clientId: 'client-1',
+						tools: [{ name: 'client_tool', description: 'Client tool', inputSchema: { type: 'object' } }],
+						customizations: [],
+					},
+				});
+
+				await agent.sendMessage(result.session, 'hello');
+
+				assert.deepStrictEqual(capturedConfig?.tools?.map(tool => tool.name), ['client_tool']);
+			} finally {
+				await disposeAgent(agent);
+				if (previousDisableCustomTerminalTools === undefined) {
+					delete process.env[AgentHostCopilotDisableCustomTerminalToolsEnvVar];
+				} else {
+					process.env[AgentHostCopilotDisableCustomTerminalToolsEnvVar] = previousDisableCustomTerminalTools;
+				}
 			}
 		});
 	});

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -9,7 +9,7 @@ import { Schemas } from '../../../../base/common/network.js';
 import { isMacintosh } from '../../../../base/common/platform.js';
 import { PolicyCategory } from '../../../../base/common/policy.js';
 import { CopilotSessionSearchPolicy } from '../../../../base/common/defaultAccount.js';
-import { AgentHostAhpJsonlLoggingSettingId, AgentHostClaudeAgentSdkPathSettingId, AgentHostEnabledSettingId, AgentHostIpcLoggingSettingId } from '../../../../platform/agentHost/common/agentService.js';
+import { AgentHostAhpJsonlLoggingSettingId, AgentHostClaudeAgentSdkPathSettingId, AgentHostCopilotDisableCustomTerminalToolsSettingId, AgentHostEnabledSettingId, AgentHostIpcLoggingSettingId } from '../../../../platform/agentHost/common/agentService.js';
 import { AgentNetworkFilterService, IAgentNetworkFilterService } from '../../../../platform/networkFilter/common/networkFilterService.js';
 import { AgentNetworkDomainSettingId } from '../../../../platform/networkFilter/common/settings.js';
 import { AgentSandboxEnabledValue, AgentSandboxSettingId } from '../../../../platform/sandbox/common/settings.js';
@@ -991,6 +991,13 @@ configurationRegistry.registerConfiguration({
 			type: 'string',
 			description: nls.localize('chat.agentHost.claudeAgent.path', "Experimental, for local testing only. Absolute path to a locally-installed `@anthropic-ai/claude-agent-sdk` package. When set, the Claude agent provider is registered inside the agent host and the SDK is loaded from this path. Requires `#chat.agentHost.enabled#`. The agent host process must be restarted for changes to take effect. This setting will be removed once the SDK is delivered through the Extension Marketplace."),
 			default: '',
+			tags: ['experimental', 'advanced'],
+			included: product.quality !== 'stable',
+		},
+		[AgentHostCopilotDisableCustomTerminalToolsSettingId]: {
+			type: 'boolean',
+			description: nls.localize('chat.agentHost.copilot.disableCustomTerminalTools', "When enabled, Copilot agent host sessions use the Copilot SDK's built-in terminal support instead of VS Code's custom terminal tool implementation. Requires `#chat.agentHost.enabled#`. The agent host process must be restarted for changes to take effect."),
+			default: false,
 			tags: ['experimental', 'advanced'],
 			included: product.quality !== 'stable',
 		},


### PR DESCRIPTION
## Summary
- add `chat.agentHost.copilot.disableCustomTerminalTools` to disable VS Code's custom Copilot terminal tool override
- forward the setting into the Agent Host process via `VSCODE_AGENT_HOST_COPILOT_DISABLE_CUSTOM_TERMINAL_TOOLS`
- omit Agent Host shell tools from Copilot SDK session config when disabled so SDK built-in terminal support is used

## Validation
- `npm run compile-check-ts-native`
- `npm run valid-layers-check`
- `./scripts/test.sh --run src/vs/platform/agentHost/test/node/copilotAgent.test.ts --grep "materialization omits VS Code terminal tools"`
- `node --experimental-strip-types build/hygiene.ts src/vs/platform/agentHost/common/agentService.ts src/vs/platform/agentHost/electron-main/electronAgentHostStarter.ts src/vs/platform/agentHost/node/copilot/copilotAgent.ts src/vs/platform/agentHost/node/nodeAgentHostStarter.ts src/vs/platform/agentHost/test/node/copilotAgent.test.ts src/vs/workbench/contrib/chat/browser/chat.contribution.ts`
