### PR TITLE
fix: provide quotas mock for IChatEntitlementService in fixtures

### DIFF
--- a/src/vs/workbench/test/browser/componentFixtures/chat/chatFixtureUtils.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/chat/chatFixtureUtils.ts
@@ -174,7 +174,7 @@ export function registerChatFixtureServices(reg: ServiceRegistration, options: I
 		override readonly isSessionsWindow = false;
 	}());
 	reg.defineInstance(IChatSessionsService, new class extends mock<IChatSessionsService>() { override getAllChatSessionContributions() { return []; } override readonly onDidChangeSessionOptions = Event.None; override readonly onDidChangeOptionGroups = Event.None; override readonly onDidChangeAvailability = Event.None; override getCustomAgentTargetForSessionType() { return Target.Undefined; } override requiresCustomModelsForSessionType() { return false; } override getOptionGroupsForSessionType() { return []; } }());
-	reg.defineInstance(IChatEntitlementService, new class extends mock<IChatEntitlementService>() { }());
+	reg.defineInstance(IChatEntitlementService, new class extends mock<IChatEntitlementService>() { override readonly quotas = {}; override readonly onDidChangeQuotaRemaining = Event.None; }());
 	reg.defineInstance(IChatModeService, new MockChatModeService());
 	reg.defineInstance(ILanguageModelsService, new class extends mock<ILanguageModelsService>() { override onDidChangeLanguageModels = Event.None; override getLanguageModelIds() { return []; } override getVendors() { return []; } override hasResolvedVendor() { return false; } }());
 	reg.defineInstance(ILanguageModelToolsService, new class extends mock<ILanguageModelToolsService>() { override onDidChangeTools = Event.None; override onDidPrepareToolCallBecomeUnresponsive = Event.None; override getTools() { return []; } }());

--- a/src/vs/workbench/test/browser/componentFixtures/editor/inlineChatZoneWidget.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/editor/inlineChatZoneWidget.fixture.ts
@@ -223,6 +223,8 @@ function renderInlineChatZoneWidget({ container, disposableStore, theme }: Compo
 				override readonly sentimentObs = observableValue('sentiment', { completed: true });
 				override readonly anonymousObs = observableValue('anonymous', false);
 				override readonly onDidChangeAnonymous = Event.None;
+				override readonly quotas = {};
+				override readonly onDidChangeQuotaRemaining = Event.None;
 			}());
 			reg.defineInstance(IChatModeService, new MockChatModeService());
 			reg.defineInstance(IChatSessionsService, new class extends mock<IChatSessionsService>() {


### PR DESCRIPTION
PR #315372 added `quotas.usageBasedBilling` access in the `ModelPickerWidget` constructor, but the fixture mock for `IChatEntitlementService` didn't provide a `quotas` property, causing 52 component fixture screenshots to fail with:

```
Cannot read properties of undefined (reading 'usageBasedBilling')
```

This adds `quotas: {}` and `onDidChangeQuotaRemaining: Event.None` to the mock, matching the default empty state of the real service.