### PR TITLE
agent: floor context-size estimate with server-reported prompt_tokens

### DIFF
--- a/extensions/copilot/src/extension/intents/node/agentIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/agentIntent.ts
@@ -31,6 +31,7 @@ import { ITelemetryService } from '../../../platform/telemetry/common/telemetry'
 import { ITestProvider } from '../../../platform/testing/common/testProvider';
 import { IWorkspaceService } from '../../../platform/workspace/common/workspaceService';
 
+import { findLast } from '../../../util/vs/base/common/arraysFind';
 import { isCancellationError } from '../../../util/vs/base/common/errors';
 import { Iterable } from '../../../util/vs/base/common/iterator';
 import { IInstantiationService, ServicesAccessor } from '../../../util/vs/platform/instantiation/common/instantiation';
@@ -39,7 +40,7 @@ import { ChatResponseProgressPart2 } from '../../../vscodeTypes';
 import { ICommandService } from '../../commands/node/commandService';
 import { Intent } from '../../common/constants';
 import { ChatVariablesCollection } from '../../prompt/common/chatVariablesCollection';
-import { Conversation, normalizeSummariesOnRounds, RenderedUserMessageMetadata, TurnStatus } from '../../prompt/common/conversation';
+import { Conversation, normalizeSummariesOnRounds, RenderedUserMessageMetadata, TurnStatus, TurnTokenUsageMetadata } from '../../prompt/common/conversation';
 import { IBuildPromptContext, InternalToolReference } from '../../prompt/common/intents';
 import { getRequestedToolCallIterationLimit, IContinueOnErrorConfirmation } from '../../prompt/common/specialRequestTypes';
 import { ChatTelemetryBuilder } from '../../prompt/node/chatParticipantTelemetry';
@@ -568,8 +569,14 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 		//                ready for a future turn.
 		//
 		const backgroundSummarizer = summarizationEnabled ? this._getOrCreateBackgroundSummarizer(promptContext.conversation?.sessionId) : undefined;
+		// Walk back through turns to find the most recent one with token usage
+		// metadata. On iteration 1 of a fresh user turn, the current turn has
+		// no fetch yet, so fall back to the previous turn — otherwise the floor
+		// would be 0 and offer no protection across user-turn boundaries.
+		const lastTurnPromptTokens = findLast(promptContext.conversation?.turns ?? [], turn => !!turn.getMetadata(TurnTokenUsageMetadata))
+			?.getMetadata(TurnTokenUsageMetadata)?.promptTokens;
 		const contextRatio = backgroundSummarizer && baseBudget > 0
-			? (this._lastRenderTokenCount + toolTokens) / baseBudget
+			? Math.max(this._lastRenderTokenCount + toolTokens, lastTurnPromptTokens ?? 0) / baseBudget
 			: 0;
 
 		// Track whether this iteration already performed compaction-related work
@@ -782,8 +789,10 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 		// warmed) and jitter the threshold around 0.80 to avoid firing at the
 		// same exact boundary every time.
 		if (summarizationEnabled && backgroundSummarizer && !didSummarizeThisIteration) {
+			const localPostRender = result.tokenCount + toolTokens;
+			const effectivePostRender = Math.max(localPostRender, lastTurnPromptTokens ?? 0);
 			const postRenderRatio = baseBudget > 0
-				? (result.tokenCount + toolTokens) / baseBudget
+				? effectivePostRender / baseBudget
 				: 0;
 
 			const idleOrFailed = backgroundSummarizer.state === BackgroundSummarizationState.Idle

--- a/extensions/copilot/src/extension/intents/node/toolCallingLoop.ts
+++ b/extensions/copilot/src/extension/intents/node/toolCallingLoop.ts
@@ -42,7 +42,7 @@ import { IInstantiationService } from '../../../util/vs/platform/instantiation/c
 import { ChatResponsePullRequestPart, LanguageModelDataPart2, LanguageModelPartAudience, LanguageModelToolResult2, MarkdownString } from '../../../vscodeTypes';
 import { InteractionOutcomeComputer } from '../../inlineChat/node/promptCraftingTypes';
 import { ChatVariablesCollection } from '../../prompt/common/chatVariablesCollection';
-import { AnthropicTokenUsageMetadata, Conversation, IResultMetadata, ResponseStreamParticipant, TurnStatus } from '../../prompt/common/conversation';
+import { Conversation, IResultMetadata, ResponseStreamParticipant, TurnStatus, TurnTokenUsageMetadata } from '../../prompt/common/conversation';
 import { IBuildPromptContext, InternalToolReference, IToolCall, IToolCallRound } from '../../prompt/common/intents';
 import { cancelText, IToolCallIterationIncrease } from '../../prompt/common/specialRequestTypes';
 import { ThinkingDataItem, ToolCallRound } from '../../prompt/common/toolCallRound';
@@ -1452,9 +1452,8 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 
 		const toolInputRetry = isToolInputFailure ? (this.toolCallRounds.at(-1)?.toolInputRetry || 0) + 1 : 0;
 		if (fetchResult.type === ChatFetchResponseType.Success) {
-			// Store token usage metadata for Anthropic models using Messages API
-			if (fetchResult.usage && isAnthropicFamily(endpoint)) {
-				this.turn.setMetadata(new AnthropicTokenUsageMetadata(
+			if (fetchResult.usage) {
+				this.turn.setMetadata(new TurnTokenUsageMetadata(
 					fetchResult.usage.prompt_tokens,
 					fetchResult.usage.completion_tokens
 				));

--- a/extensions/copilot/src/extension/prompt/common/conversation.ts
+++ b/extensions/copilot/src/extension/prompt/common/conversation.ts
@@ -446,15 +446,18 @@ export class GlobalContextMessageMetadata {
 }
 
 /**
- * Metadata capturing token usage information from Anthropic Messages API.
- * Stores prompt tokens and output tokens for each turn.
- * This metadata is used to trigger summarization when token usage exceeds thresholds.
+ * Captures `prompt_tokens` and `completion_tokens` from the most recent
+ * successful fetch on a turn. All providers return these values in their
+ * `usage` payload, so this metadata is the authoritative source for
+ * "how many tokens did we actually send last turn" — used by the agent
+ * loop to floor its local context-size estimate when deciding whether to
+ * trigger summarization.
  */
-export class AnthropicTokenUsageMetadata {
+export class TurnTokenUsageMetadata {
 	constructor(
-		/** Total number of prompt input tokens */
+		/** Total number of prompt input tokens reported by the server. */
 		readonly promptTokens: number,
-		/** Number of output/completion tokens */
+		/** Number of output/completion tokens reported by the server. */
 		readonly outputTokens: number,
 	) { }
 }

--- a/extensions/copilot/src/extension/prompt/node/chatParticipantRequestHandler.ts
+++ b/extensions/copilot/src/extension/prompt/node/chatParticipantRequestHandler.ts
@@ -35,7 +35,7 @@ import { IIntentService } from '../../intents/node/intentService';
 import { UnknownIntent } from '../../intents/node/unknownIntent';
 import { ContributedToolName } from '../../tools/common/toolNames';
 import { ChatVariablesCollection } from '../common/chatVariablesCollection';
-import { AnthropicTokenUsageMetadata, Conversation, getGlobalContextCacheKey, GlobalContextMessageMetadata, ICopilotChatResult, ICopilotChatResultIn, normalizeSummariesOnRounds, RenderedUserMessageMetadata, Turn, TurnStatus } from '../common/conversation';
+import { Conversation, getGlobalContextCacheKey, GlobalContextMessageMetadata, ICopilotChatResult, ICopilotChatResultIn, normalizeSummariesOnRounds, RenderedUserMessageMetadata, Turn, TurnStatus, TurnTokenUsageMetadata } from '../common/conversation';
 import { InternalToolReference } from '../common/intents';
 import { ChatTelemetryBuilder } from './chatParticipantTelemetry';
 import { DefaultIntentRequestHandler } from './defaultIntentRequestHandler';
@@ -454,7 +454,7 @@ function createTurnFromVSCodeChatHistoryTurns(
 		currentTurn.setMetadata(new RenderedUserMessageMetadata(turnMetadata.renderedUserMessage));
 	}
 	if (turnMetadata?.promptTokens && turnMetadata?.outputTokens) {
-		currentTurn.setMetadata(new AnthropicTokenUsageMetadata(turnMetadata.promptTokens, turnMetadata.outputTokens));
+		currentTurn.setMetadata(new TurnTokenUsageMetadata(turnMetadata.promptTokens, turnMetadata.outputTokens));
 	}
 
 	return currentTurn;

--- a/extensions/copilot/src/extension/prompt/node/defaultIntentRequestHandler.ts
+++ b/extensions/copilot/src/extension/prompt/node/defaultIntentRequestHandler.ts
@@ -50,7 +50,7 @@ import { normalizeToolSchema } from '../../tools/common/toolSchemaNormalizer';
 import { ToolCallCancelledError } from '../../tools/common/toolsService';
 import { IToolGrouping, IToolGroupingService } from '../../tools/common/virtualTools/virtualToolTypes';
 import { ChatVariablesCollection } from '../common/chatVariablesCollection';
-import { AnthropicTokenUsageMetadata, Conversation, getUniqueReferences, GlobalContextMessageMetadata, IResultMetadata, RenderedUserMessageMetadata, RequestDebugInformation, ResponseStreamParticipant, Turn, TurnStatus } from '../common/conversation';
+import { Conversation, getUniqueReferences, GlobalContextMessageMetadata, IResultMetadata, RenderedUserMessageMetadata, RequestDebugInformation, ResponseStreamParticipant, Turn, TurnStatus, TurnTokenUsageMetadata } from '../common/conversation';
 import { IBuildPromptContext, IToolCallRound } from '../common/intents';
 import { isToolCallLimitCancellation, ISwitchToAutoOnRateLimitConfirmation } from '../common/specialRequestTypes';
 import { ChatTelemetry, ChatTelemetryBuilder } from './chatParticipantTelemetry';
@@ -409,8 +409,8 @@ export class DefaultIntentRequestHandler {
 		const allSummarizedConversationHistory = this.turn.getAllMetadata(SummarizedConversationHistoryMetadata);
 		const renderedUserMessageMetadata = this.turn.getMetadata(RenderedUserMessageMetadata);
 		const globalContextMetadata = this.turn.getMetadata(GlobalContextMessageMetadata);
-		const anthropicTokenUsageMetadata = this.turn.getMetadata(AnthropicTokenUsageMetadata);
-		return codeBlocks || allSummarizedConversationHistory?.length || renderedUserMessageMetadata || globalContextMetadata || anthropicTokenUsageMetadata ?
+		const turnTokenUsageMetadata = this.turn.getMetadata(TurnTokenUsageMetadata);
+		return codeBlocks || allSummarizedConversationHistory?.length || renderedUserMessageMetadata || globalContextMetadata || turnTokenUsageMetadata ?
 			{
 				...chatResult,
 				metadata: {
@@ -419,7 +419,7 @@ export class DefaultIntentRequestHandler {
 					...allSummarizedConversationHistory && allSummarizedConversationHistory.length > 0 && { summaries: allSummarizedConversationHistory },
 					...renderedUserMessageMetadata,
 					...globalContextMetadata,
-					...anthropicTokenUsageMetadata,
+					...turnTokenUsageMetadata,
 				} satisfies Partial<IResultMetadata>,
 			} : chatResult;
 	}

--- a/extensions/copilot/src/extension/prompt/node/test/__snapshots__/defaultIntentRequestHandler.spec.ts.snap
+++ b/extensions/copilot/src/extension/prompt/node/test/__snapshots__/defaultIntentRequestHandler.spec.ts.snap
@@ -3,6 +3,8 @@
 exports[`defaultIntentRequestHandler > ChatResult metadata after multiple turns only has tool results from current turn 1`] = `
 {
   "codeBlocks": [],
+  "outputTokens": 0,
+  "promptTokens": 0,
   "resolvedModel": "",
   "toolCallResults": {
     "tool_call_id_0__vscode-0": LanguageModelToolResult {
@@ -79,6 +81,8 @@ exports[`defaultIntentRequestHandler > ChatResult metadata after multiple turns 
 exports[`defaultIntentRequestHandler > ChatResult metadata after multiple turns only has tool results from current turn 2`] = `
 {
   "codeBlocks": [],
+  "outputTokens": 0,
+  "promptTokens": 0,
   "resolvedModel": "",
   "toolCallResults": {
     "tool_call_id_2__vscode-2": LanguageModelToolResult {
@@ -184,6 +188,8 @@ exports[`defaultIntentRequestHandler > confirms on max tool call iterations, and
   "metadata": {
     "codeBlocks": [],
     "maxToolCallsExceeded": true,
+    "outputTokens": 0,
+    "promptTokens": 0,
     "resolvedModel": "",
     "toolCallResults": {
       "tool_call_id_0__vscode-0": LanguageModelToolResult {
@@ -302,6 +308,8 @@ exports[`defaultIntentRequestHandler > confirms on max tool call iterations, and
   "metadata": {
     "codeBlocks": [],
     "maxToolCallsExceeded": true,
+    "outputTokens": 0,
+    "promptTokens": 0,
     "resolvedModel": "",
     "toolCallResults": {
       "tool_call_id_4__vscode-4": LanguageModelToolResult {
@@ -2538,6 +2546,8 @@ exports[`defaultIntentRequestHandler > makes a successful request with a single 
 {
   "metadata": {
     "codeBlocks": [],
+    "outputTokens": 0,
+    "promptTokens": 0,
     "resolvedModel": "",
     "toolCallResults": undefined,
     "toolCallRounds": [
@@ -2863,6 +2873,8 @@ exports[`defaultIntentRequestHandler > makes a tool call turn 1`] = `
 {
   "metadata": {
     "codeBlocks": [],
+    "outputTokens": 0,
+    "promptTokens": 0,
     "resolvedModel": "",
     "toolCallResults": {
       "tool_call_id__vscode-0": LanguageModelToolResult {


### PR DESCRIPTION
The local tokenizer undercounts a few content kinds (Anthropic thinking
blocks, per-block JSON envelopes), so compaction can sit at ratio ~0.7
while server `prompt_tokens` is already over budget and kick-off never
fires.

Floor the local estimate with the previous fetch's `usage.prompt_tokens`
via a new `TurnTokenUsageMetadata` (renamed from `AnthropicTokenUsageMetadata`,
now recorded for all providers). `findLast` walks turns to cover both
within-turn iterations and iteration 1 of a fresh user turn.
