### PR TITLE
Fix PHP highlighting for comment-like strings

### DIFF
--- a/extensions/php/build/update-grammar.mjs
+++ b/extensions/php/build/update-grammar.mjs
@@ -36,6 +36,28 @@ function fixBadRegex(grammar) {
 		throw new Error(`fixBadRegex callback couldn't patch ${msg}. It may be obsolete`);
 	}
 
+	function patchCommentLikeStringRegex(pattern, msg) {
+		if (!pattern) {
+			fail(msg);
+		}
+
+		const begin = pattern.begin;
+		if (typeof begin !== 'string') {
+			fail(`${msg}.begin`);
+		}
+
+		if (/^['"]\/\(\?!\\\*\)/.test(begin)) {
+			return;
+		}
+
+		const patchedBegin = begin.replace(/^(['"])\/(?=\(\?=)/, '$1/(?!\\*)');
+		if (patchedBegin === begin) {
+			fail(`${msg}.begin`);
+		}
+
+		pattern.begin = patchedBegin;
+	}
+
 	const scopeResolution = grammar.repository['scope-resolution'];
 	if (scopeResolution) {
 		const match = scopeResolution.patterns[0].match;
@@ -67,29 +89,8 @@ function fixBadRegex(grammar) {
 		fail('function-call');
 	}
 
-	const regexDoubleQuoted = grammar.repository['regex-double-quoted'];
-	if (regexDoubleQuoted) {
-		const begin = regexDoubleQuoted.begin;
-		if (begin === '"/(?=(\\\\.|[^"/])++/[imsxeADSUXu]*")') {
-			regexDoubleQuoted.begin = '"/(?!\\*)(?=(\\\\.|[^"/])++/[imsxeADSUXu]*")';
-		} else {
-			fail('regex-double-quoted.begin');
-		}
-	} else {
-		fail('regex-double-quoted');
-	}
-
-	const regexSingleQuoted = grammar.repository['regex-single-quoted'];
-	if (regexSingleQuoted) {
-		const begin = regexSingleQuoted.begin;
-		if (begin === `'/(?=(\\\\(?:\\\\(?:\\\\[\\\\']?|[^'])|.)|[^'/])++/[imsxeADSUXu]*')`) {
-			regexSingleQuoted.begin = `'/(?!\\*)(?=(\\\\(?:\\\\(?:\\\\[\\\\']?|[^'])|.)|[^'/])++/[imsxeADSUXu]*')`;
-		} else {
-			fail('regex-single-quoted.begin');
-		}
-	} else {
-		fail('regex-single-quoted');
-	}
+	patchCommentLikeStringRegex(grammar.repository['regex-double-quoted'], 'regex-double-quoted');
+	patchCommentLikeStringRegex(grammar.repository['regex-single-quoted'], 'regex-single-quoted');
 }
 
 vscodeGrammarUpdater.update('KapitanOczywisty/language-php', 'grammars/php.cson', './syntaxes/php.tmLanguage.json', fixBadRegex);

--- a/extensions/php/build/update-grammar.mjs
+++ b/extensions/php/build/update-grammar.mjs
@@ -66,6 +66,30 @@ function fixBadRegex(grammar) {
 	} else {
 		fail('function-call');
 	}
+
+	const regexDoubleQuoted = grammar.repository['regex-double-quoted'];
+	if (regexDoubleQuoted) {
+		const begin = regexDoubleQuoted.begin;
+		if (begin === '"/(?=(\\\\.|[^"/])++/[imsxeADSUXu]*")') {
+			regexDoubleQuoted.begin = '"/(?!\\*)(?=(\\\\.|[^"/])++/[imsxeADSUXu]*")';
+		} else {
+			fail('regex-double-quoted.begin');
+		}
+	} else {
+		fail('regex-double-quoted');
+	}
+
+	const regexSingleQuoted = grammar.repository['regex-single-quoted'];
+	if (regexSingleQuoted) {
+		const begin = regexSingleQuoted.begin;
+		if (begin === `'/(?=(\\\\(?:\\\\(?:\\\\[\\\\']?|[^'])|.)|[^'/])++/[imsxeADSUXu]*')`) {
+			regexSingleQuoted.begin = `'/(?!\\*)(?=(\\\\(?:\\\\(?:\\\\[\\\\']?|[^'])|.)|[^'/])++/[imsxeADSUXu]*')`;
+		} else {
+			fail('regex-single-quoted.begin');
+		}
+	} else {
+		fail('regex-single-quoted');
+	}
 }
 
 vscodeGrammarUpdater.update('KapitanOczywisty/language-php', 'grammars/php.cson', './syntaxes/php.tmLanguage.json', fixBadRegex);

--- a/extensions/php/syntaxes/php.tmLanguage.json
+++ b/extensions/php/syntaxes/php.tmLanguage.json
@@ -3046,7 +3046,7 @@
 			}
 		},
 		"regex-double-quoted": {
-			"begin": "\"/(?=(\\\\.|[^\"/])++/[imsxeADSUXu]*\")",
+			"begin": "\"/(?!\\*)(?=(\\\\.|[^\"/])++/[imsxeADSUXu]*\")",
 			"beginCaptures": {
 				"0": {
 					"name": "punctuation.definition.string.begin.php"
@@ -3101,7 +3101,7 @@
 			]
 		},
 		"regex-single-quoted": {
-			"begin": "'/(?=(\\\\(?:\\\\(?:\\\\[\\\\']?|[^'])|.)|[^'/])++/[imsxeADSUXu]*')",
+			"begin": "'/(?!\\*)(?=(\\\\(?:\\\\(?:\\\\[\\\\']?|[^'])|.)|[^'/])++/[imsxeADSUXu]*')",
 			"beginCaptures": {
 				"0": {
 					"name": "punctuation.definition.string.begin.php"


### PR DESCRIPTION
Fixes #204065

## Summary

PHP slash-delimited strings are highlighted as regex-like strings by the bundled PHP grammar. That works for common PCRE usages such as `preg_match("/foo/", $value)`, but it also causes normal strings that begin with a block-comment marker to be mis-tokenized.

For example, this valid PHP string currently starts a `string.regexp.double-quoted.php` scope:

```php
str_replace("/* <![CDATA[ */", '', $jsCode);
```

Because the regex rule sees the string as `"/.../"`, the `[` in `<![CDATA[` can leave the tokenizer inside a regex character class and break highlighting for the rest of the call or following code.

This change excludes strings beginning with `/*` from the regex-string rule, so comment-like string contents are treated as normal quoted strings. Regular slash-delimited regex strings continue to be highlighted as regex strings.

The same patch is also added to `extensions/php/build/update-grammar.mjs` so it is preserved when the PHP grammar is refreshed from upstream.

## Testing

- Ran `node --check extensions/php/build/update-grammar.mjs`
- Ran `git diff --check`
- Verified tokenization with `vscode-textmate` / `vscode-oniguruma`:
  - `str_replace("/* <![CDATA[ */", '', $jsCode)` is tokenized as `string.quoted.double.php`, not `string.regexp.double-quoted.php`
  - `str_replace("/* ]]> */", '', $jsCode)` is tokenized as `string.quoted.double.php`
  - `preg_match("/foo[bar]+/i", $jsCode)` still receives `string.regexp.double-quoted.php`
