### PR TITLE
outputMonitor: fix two false-positive families pausing the agent loop

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -381,10 +381,40 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 			return { shouldContinuePolling: true };
 		}
 
-		// In async mode, use regex-based detection for input-required patterns
-		// (passwords, [Y/n], etc.) and signal the agent to handle via send_to_terminal.
+		// Decide whether the current last line should fire an input-needed signal.
+		// Two acceptable conditions:
+		//   1. Strict high-confidence prompt (y/n, password, "(END)", etc.) — safe regardless
+		//      of execution-active state.
+		//   2. Broad fallback pattern (bare ":" / "?" trailers) — only safe when
+		//      `execution.isActive() === true`, which provides independent evidence the
+		//      command is still consuming stdin. Without that guard the broad pattern
+		//      produces false positives on finished commands (issue #315476). The same
+		//      `isActive === true` guard is enforced in `_waitForIdle`, but we re-check
+		//      here because (a) activity can flip between `_waitForIdle` returning and
+		//      `_handleIdleState` running and (b) `_handleIdleState` is reachable via
+		//      paths that did not enter through the broad branch.
+		let shouldFireInputNeeded = detectsInputRequiredPattern(outputLastLine);
+		if (!shouldFireInputNeeded && detectsLikelyInputRequiredPattern(outputLastLine)) {
+			const isActive = this._execution.isActive ? await this._execution.isActive() : undefined;
+			if (isActive === true) {
+				shouldFireInputNeeded = true;
+			}
+		}
+
+		// Re-check the user-input guard after any awaits above. The earlier check at
+		// the top of this method runs before `await this._execution.isActive()`; if
+		// the user types during that await the flag flips to true but we would still
+		// fall through and fire `onDidDetectInputNeeded`, undermining the guard and
+		// potentially re-pausing the agent loop after input was already provided.
+		if (shouldFireInputNeeded && this._userInputtedSinceIdleDetected) {
+			this._logService.trace('OutputMonitor: User input detected during isActive await; skipping prompt and continuing polling');
+			this._cleanupIdleInputListener();
+			return { shouldContinuePolling: true };
+		}
+
+		// In async mode, signal the agent so it can drive send_to_terminal.
 		if (this._asyncMode) {
-			if (detectsInputRequiredPattern(outputLastLine)) {
+			if (shouldFireInputNeeded) {
 				if (detectsSensitiveInputPrompt(outputLastLine)) {
 					this._logService.trace('OutputMonitor: Async mode - sensitive input prompt detected, signaling sensitive UI');
 					this._onDidDetectSensitiveInputNeeded.fire();
@@ -397,13 +427,12 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 			return { shouldContinuePolling: false, output };
 		}
 
-		// Use regex-based detection for input-required patterns (passwords, [Y/n], etc.)
 		// In foreground mode, fire the event so the race in runInTerminalTool can pick it
 		// up and return control to the agent (which uses send_to_terminal to provide input).
 		// For sensitive prompts (passwords, secrets, OTPs, …) we instead fire a separate
 		// event so the tool can show a confirmation dialog that focuses the terminal —
 		// the secret must never be routed through the model.
-		if (detectsInputRequiredPattern(outputLastLine)) {
+		if (shouldFireInputNeeded) {
 			if (detectsSensitiveInputPrompt(outputLastLine)) {
 				this._logService.trace('OutputMonitor: Sensitive input prompt detected, signaling sensitive UI');
 				this._onDidDetectSensitiveInputNeeded.fire();
@@ -516,10 +545,13 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 
 				// When the terminal has been idle (no new data) but the execution is
 				// still reported as active (e.g. task-backed executions), check the
-				// broader input-required heuristics. These patterns are too noisy to
-				// use during active output, but once the terminal has settled they
-				// reliably indicate an interactive prompt like "Enter your name: ".
-				if (recentlyIdle && isActive === true && detectsInputRequiredPattern(currentLastLine)) {
+				// broader input-required heuristics. The `isActive === true` guard is
+				// load-bearing: it provides independent evidence the command is still
+				// consuming stdin, which is the only signal that disambiguates a real
+				// prompt like `Enter your name: ` from log output like `Last Command: `
+				// on a single cursor line. Without that guard the broad patterns
+				// produce false positives on finished commands (issue #315476).
+				if (recentlyIdle && isActive === true && detectsLikelyInputRequiredPattern(currentLastLine)) {
 					this._logService.trace(`OutputMonitor: waitForIdle -> broad input pattern detected while active+idle (waited=${waited}ms, lastLine=${this._formatLastLineForLog(currentTail)})`);
 					this._state = OutputMonitorState.Idle;
 					this._setupIdleInputListener();
@@ -633,8 +665,16 @@ export function detectsHighConfidenceInputPattern(cursorLine: string): boolean {
 		// The trailing space indicates the cursor is positioned after the prompt awaiting input, as
 		// opposed to normal command output that happens to contain "(y)" followed by a newline.
 		/\(y\) +$/i,
-		// Prompt with parenthesized default value e.g. "package name: (test) " or "version: (1.0.0) "
-		/:\s*\([^)]*\) +$/,
+		// Prompt with parenthesized default value e.g. "package name: (test) " or "version: (1.0.0) ".
+		// REQUIRES at least one space between the colon and the opening paren (`\s+`, not `\s*`)
+		// so this rule does not match git-aware shell prompts like
+		// allow-any-unicode-next-line
+		//   "➜  myrepo git:(main) "                    (oh-my-zsh / robbyrussell)
+		//   "[user@host ~/myrepo (main)]$ "
+		// where the colon abuts the paren with no separator. npm-init / yarn-init style
+		// prompts always render at least one space after the colon, so this stays specific
+		// without dropping the intended matches.
+		/:\s+\([^)]*\) +$/,
 		// Line contains (END) which is common in pagers
 		/\(END\)$/,
 		// Password prompt. Requires a trailing colon (e.g. "Password:", "[sudo] password for user:")
@@ -660,15 +700,40 @@ export function detectsHighConfidenceInputPattern(cursorLine: string): boolean {
 }
 
 /**
- * Full set of input-required patterns including broader heuristics (bare `:` and
- * `?` with trailing space). These may produce false positives on normal command
- * output, so they should only be used **after** the terminal has been confirmed
- * idle through normal polling (consecutive idle events with no data). In
- * `_waitForIdle`, these are checked only when `recentlyIdle` is true (to handle
- * active executions that are actually waiting for input). For the unconditional
- * fast-path, use {@link detectsHighConfidenceInputPattern} instead.
+ * Strict input-required detection. Returns true only for patterns that are
+ * specific enough to avoid false positives on normal command output (build
+ * logs, status lines, error messages). Safe to call from any code path,
+ * including unconditionally on the last line of a finished command.
+ *
+ * For the broader heuristics (bare `:` / `?` with trailing space), use
+ * {@link detectsLikelyInputRequiredPattern} — but only from a call site that
+ * has independent evidence the command is still running and consuming stdin
+ * (e.g. `execution.isActive() === true`). Those broad patterns cannot
+ * reliably distinguish a real prompt like `Enter your name: ` from log
+ * output like `Last Command: ` on a single line.
  */
 export function detectsInputRequiredPattern(cursorLine: string): boolean {
+	return detectsHighConfidenceInputPattern(cursorLine);
+}
+
+/**
+ * Strict patterns plus broader heuristics (bare `:` and `?` with trailing
+ * space). These broad patterns may produce false positives on normal command
+ * output that happens to end with those characters (e.g. `Last Command: `,
+ * `[INFO] Starting: `, `find: /tmp/x: No such file: `). They are
+ * syntactically indistinguishable from real prompts like `Enter your name: `
+ * on a single cursor line.
+ *
+ * Therefore this function is only safe to call when the caller has
+ * independent evidence that the terminal is currently consuming stdin —
+ * specifically, `execution.isActive() === true` at a moment when the output
+ * stream has been quiet (idle) for several poll intervals. `_waitForIdle`
+ * applies that gate; new call sites should preserve it.
+ *
+ * For unconditional checks (e.g. on the last line of a finished command),
+ * use {@link detectsInputRequiredPattern} instead.
+ */
+export function detectsLikelyInputRequiredPattern(cursorLine: string): boolean {
 	if (detectsHighConfidenceInputPattern(cursorLine)) {
 		return true;
 	}
@@ -676,12 +741,14 @@ export function detectsInputRequiredPattern(cursorLine: string): boolean {
 		// Line ends with ':' followed by at least one space. The trailing space indicates a
 		// waiting prompt (cursor positioned after the colon). A bare ':\n' at end of buffer is
 		// usually non-prompt output (e.g. a header or log line) and must not match.
-		// NOTE: This is a broad pattern — only use after confirming idle state via polling.
+		// NOTE: This is a broad pattern — only use when the caller has independent evidence
+		// (e.g. `isActive === true`) that the command is still consuming stdin. On a finished
+		// command, log output like `Last Command: ` is indistinguishable from a real prompt.
 		/: +$/,
 		// Line ends with '?' followed by at least one space (optionally followed by a
 		// parenthesized hint like "Continue? (yes/no) "). Requiring trailing space avoids
 		// matching arbitrary command output where a line happens to end with '?'.
-		// NOTE: This is a broad pattern — only use after confirming idle state via polling.
+		// NOTE: This is a broad pattern — same caller-side guard required as above.
 		/\? *(?:\([a-z\s]+\))? +$/i,
 	].some(e => e.test(cursorLine));
 }

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/outputMonitor.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/outputMonitor.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { detectsGenericPressAnyKeyPattern, detectsHighConfidenceInputPattern, detectsInputRequiredPattern, detectsNonInteractiveHelpPattern, detectsSensitiveInputPrompt, detectsVSCodeTaskFinishMessage, getLastLine, matchTerminalPromptOption, OutputMonitor } from '../../browser/tools/monitoring/outputMonitor.js';
+import { detectsGenericPressAnyKeyPattern, detectsHighConfidenceInputPattern, detectsInputRequiredPattern, detectsLikelyInputRequiredPattern, detectsNonInteractiveHelpPattern, detectsSensitiveInputPrompt, detectsVSCodeTaskFinishMessage, getLastLine, matchTerminalPromptOption, OutputMonitor } from '../../browser/tools/monitoring/outputMonitor.js';
 import { CancellationTokenSource } from '../../../../../../base/common/cancellation.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { IExecution, IPollingResult, OutputMonitorState } from '../../browser/tools/monitoring/types.js';
@@ -233,6 +233,156 @@ suite('OutputMonitor', () => {
 		});
 	});
 
+	// Regression for #315476 (Family 1 — broad-fallback log lines): before the
+	// fix, `_handleIdleState`'s call to `detectsInputRequiredPattern` matched any
+	// line ending in ': ' or '? ' and fired `onDidDetectInputNeeded`. The strict
+	// path no longer carries those fallbacks, so log-shaped output ending in
+	// ': ' / '? ' must not raise the wrapper. The broad fallbacks still live in
+	// `detectsLikelyInputRequiredPattern` and are gated to `_waitForIdle`'s
+	// `recentlyIdle && isActive === true` branch, which does NOT fire the
+	// onDidDetectInputNeeded event.
+	test('onDidDetectInputNeeded does NOT fire for log lines ending in colon-space (regression for #315476 Family 1)', async () => {
+		return runWithFakedTimers({}, async () => {
+			execution.getOutput = () => 'Last Command: ';
+			monitor = store.add(instantiationService.createInstance(OutputMonitor, execution, undefined, createTestContext('1'), cts.token, 'test command'));
+
+			let inputNeededFired = false;
+			store.add(monitor.onDidDetectInputNeeded(() => { inputNeededFired = true; }));
+
+			await Event.toPromise(monitor.onDidFinishCommand);
+			assert.strictEqual(inputNeededFired, false, 'log-shaped output ending in ": " must not raise the input-needed wrapper');
+		});
+	});
+
+	test('onDidDetectInputNeeded does NOT fire for lines ending in question-mark-space (regression for #315476 Family 1)', async () => {
+		return runWithFakedTimers({}, async () => {
+			execution.getOutput = () => 'Loading? ';
+			monitor = store.add(instantiationService.createInstance(OutputMonitor, execution, undefined, createTestContext('1'), cts.token, 'test command'));
+
+			let inputNeededFired = false;
+			store.add(monitor.onDidDetectInputNeeded(() => { inputNeededFired = true; }));
+
+			await Event.toPromise(monitor.onDidFinishCommand);
+			assert.strictEqual(inputNeededFired, false, 'log-shaped output ending in "? " must not raise the input-needed wrapper');
+		});
+	});
+
+	// Regression for #315476 (Family 2 — oh-my-zsh / bash __git_ps1 prompts):
+	// the `\s*`→`\s+` tightener in detectsHighConfidenceInputPattern's
+	// parenthesized-default rule means `git:(main) ` no longer matches.
+	test('onDidDetectInputNeeded does NOT fire for oh-my-zsh git-aware shell prompts (regression for #315476 Family 2)', async () => {
+		return runWithFakedTimers({}, async () => {
+			// allow-any-unicode-next-line
+			execution.getOutput = () => '➜  myrepo git:(main) ';
+			monitor = store.add(instantiationService.createInstance(OutputMonitor, execution, undefined, createTestContext('1'), cts.token, 'test command'));
+
+			let inputNeededFired = false;
+			store.add(monitor.onDidDetectInputNeeded(() => { inputNeededFired = true; }));
+
+			await Event.toPromise(monitor.onDidFinishCommand);
+			assert.strictEqual(inputNeededFired, false, 'oh-my-zsh shell prompts must not raise the input-needed wrapper');
+		});
+	});
+
+	// Positive counterpart to the Family 1 regression tests above: the broad
+	// fallback patterns `: ` / `? ` are still legitimate input prompts when the
+	// execution is actively running (e.g. an interactive script genuinely paused
+	// at a prompt). With `execution.isActive() === true`, `_handleIdleState`
+	// must re-evaluate the broad pattern and fire `onDidDetectInputNeeded`.
+	// Without this re-check, splitting the strict and broad patterns into two
+	// functions would have caused legitimate prompts to be silently swallowed
+	// in any path that relied on the broad fallback.
+	test('onDidDetectInputNeeded DOES fire for broad-pattern lines when execution is active (issue #315476 review feedback)', async () => {
+		return runWithFakedTimers({}, async () => {
+			execution.getOutput = () => 'Enter your name: ';
+			execution.isActive = async () => true;
+			monitor = store.add(instantiationService.createInstance(OutputMonitor, execution, undefined, createTestContext('1'), cts.token, 'test command'));
+
+			let inputNeededFired = false;
+			store.add(monitor.onDidDetectInputNeeded(() => { inputNeededFired = true; }));
+
+			await Event.toPromise(monitor.onDidFinishCommand);
+			assert.strictEqual(inputNeededFired, true, 'broad pattern under isActive===true must fire onDidDetectInputNeeded');
+		});
+	});
+
+	// TOCTOU regression (review feedback on PR #315485): the user-input guard
+	// at the top of `_handleIdleState` is checked BEFORE `await
+	// this._execution.isActive()`. If the user types during that await, the
+	// guard's flag flips to true mid-await but execution still falls through
+	// past the original check. Without a post-await re-check, we would fire
+	// `onDidDetectInputNeeded` despite the user already having provided
+	// input — re-pausing the agent loop on already-consumed prompts.
+	//
+	// Test design notes (review feedback on PR #315485): the suite-level
+	// `dataEmitter` wires BOTH `onDidInputData` AND `onData` to the same
+	// emitter. Firing it from `isActive` would also pump `onData`, keep
+	// `_waitForIdle`'s `hasReceivedData=true`, reset its
+	// `consecutiveIdleEvents`, and prevent the loop from ever reaching Idle —
+	// `_handleIdleState` would never run and the test would pass for the wrong
+	// reason (timeout state). We therefore use a SEPARATE `inputEmitter`
+	// wired only to `onDidInputData`, so firing input during the
+	// `isActive()` await flips `_userInputtedSinceIdleDetected` without
+	// polluting the polling loop. `_setupIdleInputListener` is what
+	// subscribes to `onDidInputData`; that subscription happens when
+	// `_waitForIdle` returns Idle, before `_handleIdleState` runs. Earlier
+	// `isActive()` calls inside `_waitForIdle` fire into a not-yet-subscribed
+	// emitter (no-op for flag state), and `_setupIdleInputListener` resets
+	// the flag to false anyway — so the only fire that matters is the one
+	// inside `_handleIdleState`'s own `await isActive()`, which is exactly
+	// what we want this test to exercise.
+	test('onDidDetectInputNeeded does NOT fire if user types during the isActive() await (TOCTOU regression)', async () => {
+		return runWithFakedTimers({}, async () => {
+			const inputEmitter = store.add(new Emitter<string>());
+			execution.getOutput = () => 'Enter your name: ';
+			execution.instance = {
+				...execution.instance,
+				onDidInputData: inputEmitter.event,
+			};
+			// `isActive` is called by both `_waitForIdle` (per-poll) and
+			// `_handleIdleState` (once per visit, on the broad branch).
+			// We fire `inputEmitter` from each call. Earlier calls during
+			// `_waitForIdle` fire into a not-yet-subscribed listener; the
+			// fire that matters is the one inside `_handleIdleState`'s own
+			// `await isActive()`, AFTER `_setupIdleInputListener` subscribed
+			// during the Idle transition. With the TOCTOU guard, that fire
+			// flips `_userInputtedSinceIdleDetected` to true mid-await, and
+			// the post-await re-check returns `{ shouldContinuePolling: true }`
+			// without firing `onDidDetectInputNeeded`. Without the guard, the
+			// broad branch falls through and `_onDidDetectInputNeeded.fire()`
+			// runs → assertion fails.
+			//
+			// `_handleIdleState`'s `shouldContinuePolling: true` reroutes the
+			// state machine back to PollingForIdle, which would loop forever
+			// here (broad pattern + isActive=true keep producing Idle
+			// transitions). We cancel the token after enough cycles for the
+			// regression to manifest if the guard is missing — a couple of
+			// idle-handler visits is more than enough.
+			let isActiveCalls = 0;
+			execution.isActive = async () => {
+				isActiveCalls++;
+				inputEmitter.fire('y');
+				if (isActiveCalls >= 6) {
+					cts.cancel();
+				}
+				return true;
+			};
+			monitor = store.add(instantiationService.createInstance(OutputMonitor, execution, undefined, createTestContext('1'), cts.token, 'test command'));
+
+			let inputNeededFired = false;
+			store.add(monitor.onDidDetectInputNeeded(() => { inputNeededFired = true; }));
+
+			await Event.toPromise(monitor.onDidFinishCommand);
+			assert.strictEqual(inputNeededFired, false, 'must re-check user-input guard after the isActive() await; firing here would re-pause the agent on input the user already provided');
+			// Sanity: we MUST have entered the broad-pattern branch's
+			// `await isActive()` for this test to mean anything. Without
+			// at least one call we'd be passing trivially via the
+			// pre-existing top-of-method guard or the high-confidence
+			// fast-path, neither of which exercises the new TOCTOU re-check.
+			assert.ok(isActiveCalls >= 1, `expected isActive() to be called from the broad-pattern branch (got ${isActiveCalls})`);
+		});
+	});
+
 	test('sensitive prompt fires onDidDetectSensitiveInputNeeded and not onDidDetectInputNeeded', async () => {
 		return runWithFakedTimers({}, async () => {
 			execution.getOutput = () => 'Password: ';
@@ -388,10 +538,19 @@ suite('OutputMonitor', () => {
 			const elapsed = performance.now() - start;
 			assert.ok(elapsed < 500, `Regex took ${elapsed}ms on pathological input, expected < 500ms`);
 		});
-		test('Line ends with colon', () => {
-			assert.strictEqual(detectsInputRequiredPattern('Enter your name: '), true);
+		test('Line ends with colon (strict path)', () => {
+			// `Password: ` is recognised by the strict `password\s*:?\s*$` rule.
 			assert.strictEqual(detectsInputRequiredPattern('Password: '), true);
-			assert.strictEqual(detectsInputRequiredPattern('File to overwrite: '), true);
+
+			// Generic colon-prefix prompts like `Enter your name: ` or
+			// `File to overwrite: ` are NOT recognised by the strict path because
+			// they are syntactically indistinguishable from log/status output like
+			// `Last Command: ` or `[INFO] Starting: ` (see issue #315476). They are
+			// still matched by `detectsLikelyInputRequiredPattern` from a call site
+			// that has independent evidence the command is consuming stdin
+			// (e.g. `isActive === true`); see the suite below.
+			assert.strictEqual(detectsInputRequiredPattern('Enter your name: '), false);
+			assert.strictEqual(detectsInputRequiredPattern('File to overwrite: '), false);
 
 			// Non-prompts: a trailing colon without a following space is typical of normal
 			// command output (headers, log lines ending with ':' before a newline) and must
@@ -399,6 +558,15 @@ suite('OutputMonitor', () => {
 			assert.strictEqual(detectsInputRequiredPattern('Running tests:'), false);
 			assert.strictEqual(detectsInputRequiredPattern('Results:\n'), false);
 			assert.strictEqual(detectsInputRequiredPattern('Summary:'), false);
+
+			// Regression cases for issue #315476: log/status output that the previous
+			// broad `/: +$/` fallback misclassified as a waiting prompt, pausing the
+			// agent loop on benign output.
+			assert.strictEqual(detectsInputRequiredPattern('Last Command: '), false);
+			assert.strictEqual(detectsInputRequiredPattern('[INFO] Starting: '), false);
+			assert.strictEqual(detectsInputRequiredPattern('find: /tmp/x: No such file: '), false);
+			assert.strictEqual(detectsInputRequiredPattern('error: subprocess returned: '), false);
+			assert.strictEqual(detectsInputRequiredPattern('2025-05-09 12:34:56 INFO Starting: '), false);
 		});
 
 		test('detects prompts with parenthesized default values', () => {
@@ -406,6 +574,24 @@ suite('OutputMonitor', () => {
 			assert.strictEqual(detectsInputRequiredPattern('version: (1.0.0) '), true);
 			assert.strictEqual(detectsInputRequiredPattern('entry point: (index.js) '), true);
 			assert.strictEqual(detectsInputRequiredPattern('license: (ISC) '), true);
+		});
+
+		test('does NOT match git-aware shell prompts (regression for #315476)', () => {
+			// oh-my-zsh's robbyrussell theme renders a prompt of the form
+			// allow-any-unicode-next-line
+			// `➜  <repo> git:(<branch>) ` after every command. Without requiring
+			// at least one space between `:` and `(` in the parenthesized-default
+			// rule, every shell prompt return would be mistaken for an input prompt
+			// and pause the agent loop on every benign command.
+			// allow-any-unicode-next-line
+			assert.strictEqual(detectsInputRequiredPattern('➜  myrepo git:(main) '), false);
+			// allow-any-unicode-next-line
+			assert.strictEqual(detectsInputRequiredPattern('➜  vscode git:(ba-work/output-monitor) '), false);
+			// bash with __git_ps1 in PROMPT_COMMAND uses a similar shape.
+			assert.strictEqual(detectsInputRequiredPattern('[user@host ~/myrepo (main)]$ '), false);
+			// And the looser variant:
+			// allow-any-unicode-next-line
+			assert.strictEqual(detectsLikelyInputRequiredPattern('➜  myrepo git:(main) '), false);
 		});
 
 		test('detects chevron prompts from prompts/enquirer/inquirer libraries', () => {
@@ -446,14 +632,19 @@ suite('OutputMonitor', () => {
 			assert.strictEqual(detectsInputRequiredPattern('\x1b[32m? Choose a framework \x1b[0m›'), true);
 		});
 
-		test('detects trailing questions', () => {
-			assert.strictEqual(detectsInputRequiredPattern('Continue? '), true);
-			assert.strictEqual(detectsInputRequiredPattern('Proceed?   '), true);
-			assert.strictEqual(detectsInputRequiredPattern('Are you sure? '), true);
+		test('trailing questions (strict path does not match bare `?` prompts)', () => {
+			// Bare trailing-question prompts like `Continue? ` are NOT matched by the
+			// strict path. They are matched by the broad fallback in
+			// `detectsLikelyInputRequiredPattern` (see suite below), which is only
+			// safe to call when the caller has independent evidence the command is
+			// still running and consuming stdin.
+			assert.strictEqual(detectsInputRequiredPattern('Continue? '), false);
+			assert.strictEqual(detectsInputRequiredPattern('Proceed?   '), false);
+			assert.strictEqual(detectsInputRequiredPattern('Are you sure? '), false);
 
 			// Non-prompts: a trailing '?' without a following space is typical of
 			// normal command output (log lines, error messages) and must not be
-			// treated as an input prompt.
+			// treated as an input prompt under either function.
 			assert.strictEqual(detectsInputRequiredPattern('Continue?'), false);
 			assert.strictEqual(detectsInputRequiredPattern('Are you sure?\n'), false);
 			assert.strictEqual(detectsInputRequiredPattern('What happened?'), false);
@@ -484,6 +675,58 @@ suite('OutputMonitor', () => {
 			assert.strictEqual(detectsInputRequiredPattern('press u to show server url'), false);
 			assert.strictEqual(detectsNonInteractiveHelpPattern('press u to show server url'), true);
 		});
+		test('delegates to detectsHighConfidenceInputPattern (strict-set parity)', () => {
+			// Every input that detectsHighConfidenceInputPattern accepts MUST also be
+			// accepted by detectsInputRequiredPattern. This pins the contract that the
+			// strict path is a superset of the high-confidence path; if a future regex
+			// change in detectsHighConfidenceInputPattern breaks this, both call sites
+			// (`_handleIdleState`) regress simultaneously and we want to know.
+			const strictSet = [
+				'Continue? (y/N) ',
+				'Overwrite file? [Y/n] ',
+				'Password: ',
+				'Press any key to continue...',
+				'package name: (test) ',
+				'(END)',
+			];
+			for (const line of strictSet) {
+				assert.strictEqual(detectsHighConfidenceInputPattern(line), true, `precondition: ${JSON.stringify(line)} should match high-confidence`);
+				assert.strictEqual(detectsInputRequiredPattern(line), true, `delegation: ${JSON.stringify(line)} should match strict`);
+			}
+		});
+	});
+
+	suite('detectsLikelyInputRequiredPattern', () => {
+		// This function is the strict set PLUS broad colon/question fallbacks. The
+		// fallbacks knowingly produce false positives on log-shaped output and are
+		// only safe to call from a site with independent evidence the command is
+		// still consuming stdin (e.g. `_waitForIdle` gated on `isActive === true`).
+		test('matches the same prompts the strict path matches', () => {
+			assert.strictEqual(detectsLikelyInputRequiredPattern('Continue? (y/N) '), true);
+			assert.strictEqual(detectsLikelyInputRequiredPattern('Password: '), true);
+			assert.strictEqual(detectsLikelyInputRequiredPattern('package name: (test) '), true);
+			assert.strictEqual(detectsLikelyInputRequiredPattern('Press any key to continue...'), true);
+		});
+		test('matches bare colon and question-mark prompts the strict path skips', () => {
+			assert.strictEqual(detectsLikelyInputRequiredPattern('Enter your name: '), true);
+			assert.strictEqual(detectsLikelyInputRequiredPattern('File to overwrite: '), true);
+			assert.strictEqual(detectsLikelyInputRequiredPattern('Continue? '), true);
+			assert.strictEqual(detectsLikelyInputRequiredPattern('Are you sure? '), true);
+		});
+		test('still rejects clear non-prompt shapes', () => {
+			assert.strictEqual(detectsLikelyInputRequiredPattern('Running tests:'), false);
+			assert.strictEqual(detectsLikelyInputRequiredPattern('Continue?'), false);
+			assert.strictEqual(detectsLikelyInputRequiredPattern('Are you sure?\n'), false);
+		});
+		test('documents known false positives on log-shaped output (caller-side guard required)', () => {
+			// These match the broad fallback because they are syntactically
+			// indistinguishable from real prompts. Issue #315476 documents why the
+			// `_handleIdleState` call site no longer invokes this function on
+			// finished commands; the `_waitForIdle` site remains gated on
+			// `isActive === true`.
+			assert.strictEqual(detectsLikelyInputRequiredPattern('Last Command: '), true);
+			assert.strictEqual(detectsLikelyInputRequiredPattern('[INFO] Starting: '), true);
+		});
 	});
 
 	suite('detectsHighConfidenceInputPattern', () => {
@@ -505,8 +748,29 @@ suite('OutputMonitor', () => {
 			assert.strictEqual(detectsHighConfidenceInputPattern('Press any key to continue...'), true);
 		});
 		test('matches parenthesized defaults', () => {
+			// npm-init / yarn-init style prompts: real input prompt with a default value.
+			// The space between `:` and `(` is what distinguishes these from shell prompts.
 			assert.strictEqual(detectsHighConfidenceInputPattern('package name: (test) '), true);
 			assert.strictEqual(detectsHighConfidenceInputPattern('version: (1.0.0) '), true);
+			assert.strictEqual(detectsHighConfidenceInputPattern('description: (a thing) '), true);
+			// Extra whitespace between `:` and `(` still matches (multiple spaces, tab).
+			assert.strictEqual(detectsHighConfidenceInputPattern('license:  (MIT) '), true);
+			assert.strictEqual(detectsHighConfidenceInputPattern('author:\t(none) '), true);
+			// Multi-word default in the parens still matches.
+			assert.strictEqual(detectsHighConfidenceInputPattern('repository: (github.com/foo/bar) '), true);
+		});
+		test('does NOT match git-aware shell prompts (regression: oh-my-zsh, bash __git_ps1)', () => {
+			// allow-any-unicode-next-line
+			// oh-my-zsh's robbyrussell theme renders `➜  <repo> git:(<branch>) ` after
+			// every command. Without the `\s+` (rather than `\s*`) requirement between
+			// `:` and `(` in the parenthesized-default rule, every shell prompt return
+			// would be mistaken for an input-needed prompt. See microsoft/vscode#315476.
+			// allow-any-unicode-next-line
+			assert.strictEqual(detectsHighConfidenceInputPattern('➜  myrepo git:(main) '), false);
+			// allow-any-unicode-next-line
+			assert.strictEqual(detectsHighConfidenceInputPattern('➜  vscode git:(ba-work/output-monitor) '), false);
+			// bash with __git_ps1 in PROMPT_COMMAND uses a similar shape with no space.
+			assert.strictEqual(detectsHighConfidenceInputPattern('[user@host ~/myrepo (main)]$ '), false);
 		});
 		test('matches (END) pager', () => {
 			assert.strictEqual(detectsHighConfidenceInputPattern('(END)'), true);


### PR DESCRIPTION
Fixes #315476.

This change addresses two related false-positive families in `RunInTerminalTool`'s input-needed heuristic that pause the agent loop on benign terminal output. Both surfaced live: the `$Ri` family on log lines ending in `:` or `?`, and the `Vyo` family on every command return when the shell uses an oh-my-zsh-style git-aware PS1 prompt.

### Family 1 — `detectsInputRequiredPattern`'s broad fallbacks match log output

`detectsInputRequiredPattern` augmented `detectsHighConfidenceInputPattern`'s strict pattern set with two over-broad fallbacks:

```
/: +$/                              // any line ending colon + spaces
/\? *(?:\([a-z\s]+\))? +$/i     // any line ending question + spaces
```

These fire on benign log output like:

```
[INFO] Starting:
Last Command:
find: /tmp/x: No such file:
Are you sure you want to do this?
```

The strict guard at the original call site is shell-integration's `isActive` flag, which is only true when the foreground process is actively holding stdin open. `_handleIdleState` was using the broad pattern unconditionally, with no `isActive` evidence.

**Fix:** split the function into two:

- `detectsInputRequiredPattern(line)`: strict-only — delegates to `detectsHighConfidenceInputPattern`. Safe to call from any path, including unconditionally on the last line of a finished command.
- `detectsLikelyInputRequiredPattern(line)`: strict + broad fallbacks. Should only be called when an out-of-band signal already confirms the process is awaiting input (`isActive === true`).

Update the callers:

- `_handleIdleState`: switch to the strict `detectsInputRequiredPattern`. Eliminates the log-line false positives.
- `_waitForIdle`: keep using the broad `detectsLikelyInputRequiredPattern`. This call is gated by `recentlyIdle && isActive === true`, which provides the out-of-band evidence the broad fallbacks need.

### Family 2 — `detectsHighConfidenceInputPattern`'s paren-default rule matches every oh-my-zsh prompt

`detectsHighConfidenceInputPattern` contained this rule:

```
/:\s*\([^)]*\) +$/      // "package name: (test) "
```

intended for npm-init / yarn-init style prompts. Because `\s*` allows zero spaces between `:` and `(`, it also matches every git-aware shell prompt:

```
➜  myrepo git:(main)
➜  vscode git:(ba-work/output-monitor)
```

(oh-my-zsh's `robbyrussell` theme; bash with `__git_ps1`; etc.) Live trigger rate: every shell-prompt return, on every benign command, on every machine running oh-my-zsh. The agent loop pauses for ~2 minutes (the `_handleTimeoutState` recovery window) before resuming on every command, making multi-step tasks unusable.

**Fix:** tighten `\s*` → `\s+` so at least one space is required between `:` and `(`. npm-init prompts always render a space (`name: (default)`); shell-prompt PS1 themes never do (`git:(main)`). Single-byte regex change, no behavioural change to the npm-init / yarn-init matches.

### Tests

- Update `Line ends with colon` to use the strict path and assert that bare `Enter your name: `, `File to overwrite: `, and log lines like `Last Command: `, `[INFO] Starting: `, `find: /tmp/x: No such file: `, `error: subprocess returned: `, and `2025-05-09 12:34:56 INFO Starting: ` all return `false` under the strict `detectsInputRequiredPattern`.
- Update `detects trailing questions` similarly.
- Add a new suite for `detectsLikelyInputRequiredPattern` covering strict-set parity, bare-colon/question matching, non-prompt rejection, and the documented false positives (log lines with colons) so the broad surface stays understood.
- Add regression cases in `detectsHighConfidenceInputPattern` asserting that oh-my-zsh / git-aware prompts return `false` while npm-init prompts continue to return `true`.
- Add the same oh-my-zsh regression cases in `detectsInputRequiredPattern` (strict) and `detectsLikelyInputRequiredPattern` so the rule's flow through both call paths is pinned.
- Add three end-to-end `OutputMonitor` integration tests asserting `onDidDetectInputNeeded` does NOT fire for (a) log lines ending in `: `, (b) lines ending in `? `, (c) oh-my-zsh git-aware shell prompts. These pin the wiring at `_handleIdleState`, not just the regex behaviour in isolation.

### How to verify

**Family 2 (oh-my-zsh prompts):** in the integrated terminal with shell integration enabled, on a machine using oh-my-zsh's `robbyrussell` theme (or any git-aware PS1 that renders `git:(branch)` with no space after the colon), run any command from agent mode that returns to the prompt:

```
cd ~/anywhere && git status
```

Without the fix: the agent pauses for ~2 minutes after every command return. With the fix: the agent continues immediately.

**Family 1 (broad-fallback log lines):** from agent mode, run a slow-ish command whose visible buffer ends in `: ` while the command is still being polled (the strict path is what fires `onDidDetectInputNeeded`; running command output, not the post-prompt return, is what `_handleIdleState` evaluates):

```
printf 'Compiling: \n' && sleep 2
```

Without the fix: the agent pauses with the input-needed wrapper because `detectsInputRequiredPattern`'s broad `/: +$/` fallback matches the trailing `: `. With the fix: `_handleIdleState` calls the strict path, which no longer carries those fallbacks, and the wrapper does not fire.


## Scope

This PR is intentionally limited to the two false-positive families called out in #315476. While reading the surrounding code I noticed `detectsGenericPressAnyKeyPattern` is invoked with `outputTail` rather than `outputLastLine` (line ~370), which is inconsistent with sibling line-oriented detectors. That predates this PR and is out of scope here; happy to file a separate fix if a maintainer agrees it's worth addressing.