### PR TITLE
Fix locale separator in Copilot title prompt

### DIFF
--- a/extensions/copilot/src/extension/prompts/node/base/responseTranslationRules.tsx
+++ b/extensions/copilot/src/extension/prompts/node/base/responseTranslationRules.tsx
@@ -47,7 +47,7 @@ export class ResponseTranslationRules extends PromptElement {
 
 		return (
 			<>
-				Respond in the following locale: {languageConfiguration}
+				Respond in the following locale: {languageConfiguration}<br />
 			</>
 		);
 	}

--- a/extensions/copilot/src/extension/prompts/node/panel/test/__snapshots__/title.spec.ts.snap
+++ b/extensions/copilot/src/extension/prompts/node/panel/test/__snapshots__/title.spec.ts.snap
@@ -1,0 +1,52 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`TitlePrompt > does not include locale instruction when language is en 1`] = `
+{
+  "system": "You are an expert in crafting ultra-compact titles for chatbot conversations. You are presented with a chat request, and you reply with only a brief title that captures the main topic of that request.
+Follow Microsoft content policies.
+Avoid content that violates copyrights.
+If you are asked to generate content that is harmful, hateful, racist, sexist, lewd, or violent, only respond with "Sorry, I can't assist with that."
+Keep your answers short and impersonal.
+Write the title in sentence case, not title case. Preserve product names, abbreviations, code symbols, and proper nouns.
+Aim for 3-6 words. Prefer the shortest accurate title.
+Drop articles like "a", "an", and "the" unless needed for clarity.
+Drop filler and generic framing like "help with", "question about", "request for", or "issue with".
+Prefer short, concrete synonyms and omit unnecessary words.
+Do not wrap the title in quotes or add trailing punctuation.
+Here are some examples of good titles:
+- Git rebase question
+- Install Python packages
+- LinkedList implementation location
+- Add VS Code tree view
+- React useState usage",
+  "user": "Please write a brief title for the following request:
+
+How do I sort an array?",
+}
+`;
+
+exports[`TitlePrompt > includes locale instructions 1`] = `
+{
+  "system": "You are an expert in crafting ultra-compact titles for chatbot conversations. You are presented with a chat request, and you reply with only a brief title that captures the main topic of that request.
+Follow Microsoft content policies.
+Avoid content that violates copyrights.
+If you are asked to generate content that is harmful, hateful, racist, sexist, lewd, or violent, only respond with "Sorry, I can't assist with that."
+Keep your answers short and impersonal.
+Respond in the following locale: zh-CN
+Write the title in sentence case, not title case. Preserve product names, abbreviations, code symbols, and proper nouns.
+Aim for 3-6 words. Prefer the shortest accurate title.
+Drop articles like "a", "an", and "the" unless needed for clarity.
+Drop filler and generic framing like "help with", "question about", "request for", or "issue with".
+Prefer short, concrete synonyms and omit unnecessary words.
+Do not wrap the title in quotes or add trailing punctuation.
+Here are some examples of good titles:
+- Git rebase question
+- Install Python packages
+- LinkedList implementation location
+- Add VS Code tree view
+- React useState usage",
+  "user": "Please write a brief title for the following request:
+
+请你分析该脚本有何优化空间",
+}
+`;

--- a/extensions/copilot/src/extension/prompts/node/panel/test/title.spec.ts
+++ b/extensions/copilot/src/extension/prompts/node/panel/test/title.spec.ts
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Raw } from '@vscode/prompt-tsx';
+import { beforeEach, describe, expect, test } from 'vitest';
+import { IChatMLFetcher } from '../../../../../platform/chat/common/chatMLFetcher';
+import { StaticChatMLFetcher } from '../../../../../platform/chat/test/common/staticChatMLFetcher';
+import { ConfigKey, IConfigurationService } from '../../../../../platform/configuration/common/configurationService';
+import { MockEndpoint } from '../../../../../platform/endpoint/test/node/mockEndpoint';
+import { ITestingServicesAccessor } from '../../../../../platform/test/node/services';
+import { IInstantiationService } from '../../../../../util/vs/platform/instantiation/common/instantiation';
+import { createExtensionUnitTestingServices } from '../../../../test/node/services';
+import { renderPromptElement } from '../../base/promptRenderer';
+import { TitlePrompt } from '../title';
+
+function messageText(message: Raw.ChatMessage | undefined): string | undefined {
+	return message?.content
+		.filter(part => part.type === Raw.ChatCompletionContentPartKind.Text)
+		.map(part => (part as Raw.ChatCompletionContentPartText).text)
+		.join('\n');
+}
+
+function promptText(messages: Raw.ChatMessage[]): { system: string | undefined; user: string | undefined } {
+	return {
+		system: messageText(messages.find(msg => msg.role === Raw.ChatRole.System)),
+		user: messageText(messages.find(msg => msg.role === Raw.ChatRole.User)),
+	};
+}
+
+describe('TitlePrompt', () => {
+	let accessor: ITestingServicesAccessor;
+
+	beforeEach(() => {
+		const services = createExtensionUnitTestingServices();
+		services.define(IChatMLFetcher, new StaticChatMLFetcher([]));
+		accessor = services.createTestingAccessor();
+	});
+
+	test('includes locale instructions', async () => {
+		await accessor.get(IConfigurationService).setConfig(ConfigKey.LocaleOverride, 'zh-CN');
+
+		const endpoint = accessor.get(IInstantiationService).createInstance(MockEndpoint, 'gpt-4.1');
+		const { messages } = await renderPromptElement(
+			accessor.get(IInstantiationService),
+			endpoint,
+			TitlePrompt,
+			{ userRequest: '请你分析该脚本有何优化空间' });
+
+		expect(promptText(messages)).toMatchSnapshot();
+	});
+
+	test('does not include locale instruction when language is en', async () => {
+		await accessor.get(IConfigurationService).setConfig(ConfigKey.LocaleOverride, 'en');
+
+		const endpoint = accessor.get(IInstantiationService).createInstance(MockEndpoint, 'gpt-4.1');
+		const { messages } = await renderPromptElement(
+			accessor.get(IInstantiationService),
+			endpoint,
+			TitlePrompt,
+			{ userRequest: 'How do I sort an array?' });
+
+		expect(promptText(messages)).toMatchSnapshot();
+	});
+});


### PR DESCRIPTION
Fixes #315289

This adds a line break after the locale instruction emitted by `ResponseTranslationRules`, preventing the following prompt text from being concatenated with locale values such as `zh-CN`.

Also adds snapshot coverage for `TitlePrompt` with a non-English locale override and the English no-locale path.

Validation:
- `npx vitest --run --pool=forks src/extension/prompts/node/panel/test/title.spec.ts`
- `npm run typecheck -- --pretty false` was attempted but blocked because `tsgo` was unavailable from npm in this environment.