### PR TITLE
Log local agent host AHP traffic

### DIFF
--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -37,7 +37,7 @@ export const AgentHostEnabledSettingId = 'chat.agentHost.enabled';
 /** Configuration key that controls whether per-host IPC traffic output channels are created. */
 export const AgentHostIpcLoggingSettingId = 'chat.agentHost.ipcLoggingEnabled';
 
-/** Configuration key that controls whether AHP transport JSONL logs are written. */
+/** Configuration key that controls whether AHP JSONL logs are written for agent host transports. */
 export const AgentHostAhpJsonlLoggingSettingId = 'chat.agentHost.ahpJsonlLoggingEnabled';
 
 /**

--- a/src/vs/platform/agentHost/electron-browser/agentHostService.ts
+++ b/src/vs/platform/agentHost/electron-browser/agentHostService.ts
@@ -12,9 +12,13 @@ import { getDelayedChannel, ProxyChannel } from '../../../base/parts/ipc/common/
 import { Client as MessagePortClient } from '../../../base/parts/ipc/common/ipc.mp.js';
 import { acquirePort } from '../../../base/parts/ipc/electron-browser/ipc.mp.js';
 import { InstantiationType, registerSingleton } from '../../instantiation/common/extensions.js';
+import { IInstantiationService } from '../../instantiation/common/instantiation.js';
 import { IConfigurationService } from '../../configuration/common/configuration.js';
+import { IEnvironmentService } from '../../environment/common/environment.js';
 import { ILogService } from '../../log/common/log.js';
-import { AgentHostEnabledSettingId, AgentHostIpcChannels, IAgentCreateSessionConfig, IAgentHostInspectInfo, IAgentHostService, IAgentResolveSessionConfigParams, IAgentService, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, AuthenticateParams, AuthenticateResult, IAgentHostSocketInfo, IConnectionTrackerService } from '../common/agentService.js';
+import { AgentHostAhpJsonlLoggingSettingId, AgentHostEnabledSettingId, AgentHostIpcChannels, IAgentCreateSessionConfig, IAgentHostInspectInfo, IAgentHostService, IAgentResolveSessionConfigParams, IAgentService, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, AuthenticateParams, AuthenticateResult, IAgentHostSocketInfo, IConnectionTrackerService } from '../common/agentService.js';
+import { AhpJsonlLogger, getAhpLogByteLength } from '../common/ahpJsonlLogger.js';
+import { wrapAgentServiceWithAhpLogging } from './localAhpJsonlLogging.js';
 import { AgentSubscriptionManager, type IAgentSubscription } from '../common/state/agentSubscription.js';
 import type { CompletionsParams, CompletionsResult, CreateTerminalParams, ResolveSessionConfigResult, SessionConfigCompletionsResult } from '../common/state/protocol/commands.js';
 import type { ActionEnvelope, INotification, IRootConfigChangedAction, SessionAction, TerminalAction } from '../common/state/sessionActions.js';
@@ -39,6 +43,7 @@ class AgentHostServiceClient extends Disposable implements IAgentHostService {
 
 	private readonly _clientEventually = new DeferredPromise<MessagePortClient>();
 	private readonly _proxy: IAgentService;
+	private readonly _ahpLogger: AhpJsonlLogger | undefined;
 	private readonly _connectionTracker: IConnectionTrackerService;
 	private readonly _subscriptionManager: AgentSubscriptionManager;
 
@@ -74,14 +79,28 @@ class AgentHostServiceClient extends Disposable implements IAgentHostService {
 		@ILogService private readonly _logService: ILogService,
 		@IConfigurationService configurationService: IConfigurationService,
 		@IFileService private readonly _fileService: IFileService,
+		@IEnvironmentService environmentService: IEnvironmentService,
+		@IInstantiationService instantiationService: IInstantiationService,
 	) {
 		super();
 
 		// Create a proxy backed by a delayed channel - usable immediately,
 		// calls queue until the MessagePort connection is established.
-		this._proxy = ProxyChannel.toService<IAgentService>(
+		const rawProxy = ProxyChannel.toService<IAgentService>(
 			getDelayedChannel(this._clientEventually.p.then(client => client.getChannel(AgentHostIpcChannels.AgentHost)))
 		);
+
+		// Optionally wrap the proxy with a logging layer that synthesizes JSON-RPC
+		// frames for every request/response/notification on the in-process MessagePort
+		// channel, mirroring the AHP transport JSONL logs produced by remote agent hosts.
+		this._ahpLogger = configurationService.getValue<boolean>(AgentHostAhpJsonlLoggingSettingId)
+			? this._register(instantiationService.createInstance(AhpJsonlLogger, {
+				logsHome: environmentService.logsHome,
+				connectionId: this.clientId,
+				transport: 'local',
+			}))
+			: undefined;
+		this._proxy = this._ahpLogger ? wrapAgentServiceWithAhpLogging(rawProxy, this._ahpLogger) : rawProxy;
 
 		this._connectionTracker = ProxyChannel.toService<IConnectionTrackerService>(
 			getDelayedChannel(this._clientEventually.p.then(client => client.getChannel(AgentHostIpcChannels.ConnectionTracker)))
@@ -118,10 +137,18 @@ class AgentHostServiceClient extends Disposable implements IAgentHostService {
 
 		store.add(this._proxy.onDidAction(e => {
 			const revived = revive(e) as ActionEnvelope;
+			if (this._ahpLogger) {
+				const frame = { jsonrpc: '2.0' as const, method: 'action', params: e };
+				this._ahpLogger.log(frame, 's2c', getAhpLogByteLength(JSON.stringify(frame)));
+			}
 			this._subscriptionManager.receiveEnvelope(revived);
 			this._onDidAction.fire(revived);
 		}));
 		store.add(this._proxy.onDidNotification(e => {
+			if (this._ahpLogger) {
+				const frame = { jsonrpc: '2.0' as const, method: 'notification', params: { notification: e } };
+				this._ahpLogger.log(frame, 's2c', getAhpLogByteLength(JSON.stringify(frame)));
+			}
 			this._onDidNotification.fire(revive(e));
 		}));
 		this._logService.info('[AgentHost:renderer] Direct MessagePort connection established');

--- a/src/vs/platform/agentHost/electron-browser/localAhpJsonlLogging.ts
+++ b/src/vs/platform/agentHost/electron-browser/localAhpJsonlLogging.ts
@@ -1,0 +1,139 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AhpJsonlLogger, getAhpLogByteLength } from '../common/ahpJsonlLogger.js';
+import type { AuthenticateParams, IAgentService } from '../common/agentService.js';
+
+const REDACTED_VALUE = '<redacted>';
+
+/**
+ * IAgentService methods that semantically correspond to JSON-RPC requests
+ * (return a Promise of a result). Calls are logged as `c2s` request frames
+ * with a synthetic numeric id, and resolutions/rejections are logged as
+ * matching `s2c` response frames.
+ */
+const REQUEST_METHODS: ReadonlySet<string> = new Set<keyof IAgentService>([
+	'authenticate',
+	'listSessions',
+	'createSession',
+	'resolveSessionConfig',
+	'sessionConfigCompletions',
+	'completions',
+	'getCompletionTriggerCharacters',
+	'disposeSession',
+	'createTerminal',
+	'disposeTerminal',
+	'shutdown',
+	'subscribe',
+	'resourceList',
+	'resourceRead',
+	'resourceWrite',
+	'resourceCopy',
+	'resourceDelete',
+	'resourceMove',
+] satisfies (keyof IAgentService)[]);
+
+/**
+ * IAgentService methods that semantically correspond to JSON-RPC notifications
+ * (synchronous, no result). Calls are logged as `c2s` notification frames
+ * with no id.
+ */
+const NOTIFICATION_METHODS: ReadonlySet<string> = new Set<keyof IAgentService>([
+	'unsubscribe',
+	'addSubscriber',
+	'dispatchAction',
+] satisfies (keyof IAgentService)[]);
+
+/**
+ * Wraps an {@link IAgentService} proxy so that every method call and every
+ * resolved/rejected response is logged to the supplied {@link AhpJsonlLogger}
+ * as a synthetic JSON-RPC frame. This brings the local (in-process) agent host
+ * traffic into the same JSONL format used for remote agent host transports,
+ * even though the underlying channel is a structured MessagePort RPC rather
+ * than a JSON-RPC wire protocol.
+ *
+ * Event accessors (`onDidAction`, `onDidNotification`) are passed through
+ * untouched; their payloads should be logged separately by the caller as
+ * `s2c` `action` / `notification` frames.
+ */
+export function wrapAgentServiceWithAhpLogging(target: IAgentService, logger: AhpJsonlLogger): IAgentService {
+	let nextId = 1;
+	return new Proxy(target, {
+		get(t, prop, receiver) {
+			const value = Reflect.get(t, prop, receiver);
+			if (typeof prop !== 'string' || typeof value !== 'function') {
+				return value;
+			}
+			const isRequest = REQUEST_METHODS.has(prop);
+			const isNotification = !isRequest && NOTIFICATION_METHODS.has(prop);
+			if (!isRequest && !isNotification) {
+				return value;
+			}
+			const method = prop;
+			return function (this: unknown, ...args: unknown[]) {
+				const logArgs = redactParams(method, args);
+				if (isNotification) {
+					const frame = { jsonrpc: '2.0' as const, method, params: logArgs };
+					logger.log(frame, 'c2s', getAhpLogByteLength(safeStringify(frame)));
+					return value.apply(t, args);
+				}
+				const id = nextId++;
+				const requestFrame = { jsonrpc: '2.0' as const, id, method, params: logArgs };
+				logger.log(requestFrame, 'c2s', getAhpLogByteLength(safeStringify(requestFrame)));
+				const result = value.apply(t, args) as Promise<unknown> | unknown;
+				if (result && typeof (result as Promise<unknown>).then === 'function') {
+					return (result as Promise<unknown>).then(
+						res => {
+							const responseFrame = { jsonrpc: '2.0' as const, id, result: res ?? null };
+							logger.log(responseFrame, 's2c', getAhpLogByteLength(safeStringify(responseFrame)));
+							return res;
+						},
+						err => {
+							const errorFrame = {
+								jsonrpc: '2.0' as const,
+								id,
+								error: {
+									code: -32603,
+									message: err instanceof Error ? err.message : String(err),
+								},
+							};
+							logger.log(errorFrame, 's2c', getAhpLogByteLength(safeStringify(errorFrame)));
+							throw err;
+						},
+					);
+				}
+				return result;
+			};
+		},
+	});
+}
+
+function redactParams(method: string, args: readonly unknown[]): readonly unknown[] {
+	if (method !== 'authenticate') {
+		return args;
+	}
+	const [params, ...rest] = args;
+	if (!isAuthenticateParams(params)) {
+		return args;
+	}
+	return [{ ...params, token: REDACTED_VALUE }, ...rest];
+}
+
+function isAuthenticateParams(value: unknown): value is AuthenticateParams {
+	return typeof value === 'object'
+		&& value !== null
+		&& 'resource' in value
+		&& 'token' in value
+		&& typeof value.resource === 'string'
+		&& typeof value.token === 'string';
+}
+
+function safeStringify(value: unknown): string {
+	try {
+		return JSON.stringify(value);
+	} catch {
+		return '';
+	}
+}

--- a/src/vs/platform/agentHost/test/electron-browser/localAhpJsonlLogging.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/localAhpJsonlLogging.test.ts
@@ -1,0 +1,89 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { URI } from '../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { FileService } from '../../../files/common/fileService.js';
+import { InMemoryFileSystemProvider } from '../../../files/common/inMemoryFilesystemProvider.js';
+import { NullLogService } from '../../../log/common/log.js';
+import { AhpJsonlLogger } from '../../common/ahpJsonlLogger.js';
+import { wrapAgentServiceWithAhpLogging } from '../../electron-browser/localAhpJsonlLogging.js';
+import type { IAgentService } from '../../common/agentService.js';
+
+suite('localAhpJsonlLogging', () => {
+
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	function makeLogger() {
+		const fileService = store.add(new FileService(new NullLogService()));
+		store.add(fileService.registerProvider('file', store.add(new InMemoryFileSystemProvider())));
+		const logger = store.add(new AhpJsonlLogger(
+			{ logsHome: URI.file('/logs'), connectionId: 'local-1', transport: 'local' },
+			fileService,
+			new NullLogService(),
+		));
+		return { fileService, logger };
+	}
+
+	async function readEntries(fileService: FileService, logger: AhpJsonlLogger) {
+		await logger.flush();
+		const content = (await fileService.readFile(logger.resource)).value.toString();
+		return content.split('\n').filter(Boolean).map(line => JSON.parse(line));
+	}
+
+	test('logs request/response/notification frames around proxied calls', async () => {
+		const { fileService, logger } = makeLogger();
+
+		const target = {
+			async authenticate(params: { resource: string; token: string }) { return { authenticated: params.token.length > 0 }; },
+			async listSessions() { return ['a', 'b']; },
+			async createSession(config: unknown) { return URI.parse(`agent-host://session/1?cfg=${JSON.stringify(config)}`); },
+			async disposeTerminal() { return undefined; },
+			async resourceRead(uri: URI) { throw new Error('boom: ' + uri.toString()); },
+			dispatchAction(action: unknown, clientId: string, clientSeq: number) { void action; void clientId; void clientSeq; },
+			get onDidAction() { return () => ({ dispose() { } }); },
+		} as unknown as IAgentService;
+
+		const wrapped = wrapAgentServiceWithAhpLogging(target, logger);
+
+		await wrapped.authenticate({ resource: 'https://example.com', token: 'secret' });
+		await wrapped.listSessions();
+		await wrapped.createSession({ kind: 'demo' } as never);
+		await wrapped.disposeTerminal(URI.parse('agent-host://terminal/1'));
+		await assert.rejects(() => wrapped.resourceRead(URI.parse('agent-host://x/y')));
+		wrapped.dispatchAction({ type: 'noop' } as never, 'client-1', 7);
+
+		// Event accessors must pass through untouched (no log emitted, no wrapping).
+		const eventFn = wrapped.onDidAction;
+		assert.strictEqual(typeof eventFn, 'function');
+
+		const entries = await readEntries(fileService, logger);
+		const summary = entries.map(e => ({
+			dir: e._ahpLog.dir,
+			id: e.id,
+			method: e.method,
+			hasResult: Object.hasOwn(e, 'result'),
+			hasError: Object.hasOwn(e, 'error'),
+		}));
+
+		assert.deepStrictEqual(summary, [
+			{ dir: 'c2s', id: 1, method: 'authenticate', hasResult: false, hasError: false },
+			{ dir: 's2c', id: 1, method: undefined, hasResult: true, hasError: false },
+			{ dir: 'c2s', id: 2, method: 'listSessions', hasResult: false, hasError: false },
+			{ dir: 's2c', id: 2, method: undefined, hasResult: true, hasError: false },
+			{ dir: 'c2s', id: 3, method: 'createSession', hasResult: false, hasError: false },
+			{ dir: 's2c', id: 3, method: undefined, hasResult: true, hasError: false },
+			{ dir: 'c2s', id: 4, method: 'disposeTerminal', hasResult: false, hasError: false },
+			{ dir: 's2c', id: 4, method: undefined, hasResult: true, hasError: false },
+			{ dir: 'c2s', id: 5, method: 'resourceRead', hasResult: false, hasError: false },
+			{ dir: 's2c', id: 5, method: undefined, hasResult: false, hasError: true },
+			{ dir: 'c2s', id: undefined, method: 'dispatchAction', hasResult: false, hasError: false },
+		]);
+
+		assert.deepStrictEqual(entries[0].params, [{ resource: 'https://example.com', token: '<redacted>' }]);
+		assert.strictEqual(entries[7].result, null);
+	});
+});

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -1003,7 +1003,7 @@ configurationRegistry.registerConfiguration({
 		},
 		[AgentHostAhpJsonlLoggingSettingId]: {
 			type: 'boolean',
-			description: nls.localize('chat.agentHost.ahpJsonlLogging', "When enabled, logs all AHP transport messages for remote agent host connections to JSONL files under the window's log directory."),
+			description: nls.localize('chat.agentHost.ahpJsonlLogging', "When enabled, logs all AHP transport messages for agent host connections to JSONL files under the window's log directory."),
 			default: product.quality !== 'stable',
 			tags: ['experimental', 'advanced'],
 			included: product.quality !== 'stable',


### PR DESCRIPTION
## Summary
- add local agent host JSONL traffic logging behind `chat.agentHost.ahpJsonlLoggingEnabled`
- synthesize JSON-RPC-shaped frames for local MessagePort service calls, responses, errors, and notifications
- log local server action/notification events as `s2c` frames and update the setting description to cover all agent host connections

## Validation
- `npm run precommit`
- `npx tsc -p ./src/tsconfig.json --noEmit --skipLibCheck`

Note: targeted unit tests could not run locally because this worktree has no compiled `out/` and `gulp compile` ran out of memory on this host.