### PR TITLE
Resolve webview id for worker clients in service worker

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/pre/service-worker.js
+++ b/src/vs/workbench/contrib/webview/browser/pre/service-worker.js
@@ -537,6 +537,14 @@ function getWebviewIdForClient(client) {
 }
 
 /**
+ * @param {URL} url
+ * @returns {boolean}
+ */
+function isWebviewIframe(url) {
+	return (url.pathname === `${rootPath}/` || url.pathname === `${rootPath}/index.html` || url.pathname === `${rootPath}/index-no-csp.html`);
+}
+
+/**
  * @param {string} webviewId
  * @returns {Promise<Client[]>}
  */
@@ -544,8 +552,7 @@ async function getOuterIframeClient(webviewId) {
 	const allClients = await sw.clients.matchAll({ includeUncontrolled: true });
 	return allClients.filter(client => {
 		const clientUrl = new URL(client.url);
-		const hasExpectedPathName = (clientUrl.pathname === `${rootPath}/` || clientUrl.pathname === `${rootPath}/index.html` || clientUrl.pathname === `${rootPath}/index-no-csp.html`);
-		return hasExpectedPathName && clientUrl.searchParams.get('id') === webviewId;
+		return isWebviewIframe(clientUrl) && clientUrl.searchParams.get('id') === webviewId;
 	});
 }
 
@@ -565,8 +572,7 @@ async function getWebviewIdForWorkerClient(workerClient) {
 	let matchedId = null;
 	for (const c of allClients) {
 		const cUrl = new URL(c.url);
-		const isWebviewIframe = (cUrl.pathname === `${rootPath}/` || cUrl.pathname === `${rootPath}/index.html` || cUrl.pathname === `${rootPath}/index-no-csp.html`);
-		if (isWebviewIframe && cUrl.origin === workerUrl.origin) {
+		if (isWebviewIframe(cUrl) && cUrl.origin === workerUrl.origin) {
 			const id = cUrl.searchParams.get('id');
 			if (id) {
 				if (matchedId && matchedId !== id) {

--- a/src/vs/workbench/contrib/webview/browser/pre/service-worker.js
+++ b/src/vs/workbench/contrib/webview/browser/pre/service-worker.js
@@ -302,12 +302,18 @@ async function processResourceRequest(
 		}
 	}
 
-	const webviewId = getWebviewIdForClient(client);
+	let webviewId = getWebviewIdForClient(client);
 
 	// Refs https://github.com/microsoft/vscode/issues/244143
-	// With PlzDedicatedWorker, worker subresources and blob workers
-	// will use clients different from the window client.
-	if (!webviewId && client.type !== 'worker' && client.type !== 'sharedworker') {
+	// With PlzDedicatedWorker, worker subresources and blob workers use
+	// clients different from the window client and don't have an `id`
+	// search param of their own. Resolve the owning iframe by origin
+	// so the request can still be routed.
+	if (!webviewId && (client.type === 'worker' || client.type === 'sharedworker')) {
+		webviewId = await getWebviewIdForWorkerClient(client);
+	}
+
+	if (!webviewId) {
 		console.error('Could not resolve webview id');
 		return notFound();
 	}
@@ -467,11 +473,16 @@ async function processLocalhostRequest(
 		// that are not spawned by vs code
 		return fetch(event.request);
 	}
-	const webviewId = getWebviewIdForClient(client);
+	let webviewId = getWebviewIdForClient(client);
 	// Refs https://github.com/microsoft/vscode/issues/244143
-	// With PlzDedicatedWorker, worker subresources and blob workers
-	// will use clients different from the window client.
-	if (!webviewId && client.type !== 'worker' && client.type !== 'sharedworker') {
+	// With PlzDedicatedWorker, worker subresources and blob workers use
+	// clients different from the window client and don't have an `id`
+	// search param of their own. Resolve the owning iframe by origin
+	// so the request can still be routed.
+	if (!webviewId && (client.type === 'worker' || client.type === 'sharedworker')) {
+		webviewId = await getWebviewIdForWorkerClient(client);
+	}
+	if (!webviewId) {
 		console.error('Could not resolve webview id');
 		return fetch(event.request);
 	}
@@ -536,6 +547,36 @@ async function getOuterIframeClient(webviewId) {
 		const hasExpectedPathName = (clientUrl.pathname === `${rootPath}/` || clientUrl.pathname === `${rootPath}/index.html` || clientUrl.pathname === `${rootPath}/index-no-csp.html`);
 		return hasExpectedPathName && clientUrl.searchParams.get('id') === webviewId;
 	});
+}
+
+/**
+ * Find the webview id for a worker client by matching the worker's URL
+ * origin against window clients that look like a webview iframe. Blob
+ * workers inherit their parent iframe's origin. Some webviews can share
+ * an origin, so only resolve when the origin maps to a single webview id.
+ *
+ * @param {Client} workerClient
+ * @returns {Promise<string|null>}
+ */
+async function getWebviewIdForWorkerClient(workerClient) {
+	const workerUrl = new URL(workerClient.url);
+	const allClients = await sw.clients.matchAll({ type: 'window', includeUncontrolled: true });
+	/** @type {string|null} */
+	let matchedId = null;
+	for (const c of allClients) {
+		const cUrl = new URL(c.url);
+		const isWebviewIframe = (cUrl.pathname === `${rootPath}/` || cUrl.pathname === `${rootPath}/index.html` || cUrl.pathname === `${rootPath}/index-no-csp.html`);
+		if (isWebviewIframe && cUrl.origin === workerUrl.origin) {
+			const id = cUrl.searchParams.get('id');
+			if (id) {
+				if (matchedId && matchedId !== id) {
+					return null;
+				}
+				matchedId = id;
+			}
+		}
+	}
+	return matchedId;
 }
 
 /**


### PR DESCRIPTION

Fixes #315494. This appears to be a regression from #311844.

`processResourceRequest` and `processLocalhostRequest` allow
`worker` / `sharedworker` clients past the guard, but neither function
routes them: the dispatch block runs only when `webviewId` is non-null,
and a worker client's `client.url` (typically
`blob:https://<webview-origin>/<uuid>`) has no `id` searchParam. The
request store entry is never resolved and the fetch hangs until
`requestTimeout()` fires; in the renderer this surfaces as
`TypeError: Failed to fetch dynamically imported module`.

This patch resolves the owning iframe for a worker client by matching
the worker URL's origin against window clients whose pathname is one of
the webview entry points, then reading `id` from that iframe's
searchParams. Because some webviews can intentionally share an origin,
the match is only accepted when that origin maps to a single webview id.
The relaxed `worker / sharedworker` exception in the guard is replaced:
a worker client whose owning iframe cannot be resolved unambiguously is
treated the same as a window client without a webview id (`notFound()`
for resource requests, `fetch(event.request)` for localhost), preserving
pre-#311844 behavior for that edge.

### Validation

- `node --check src/vs/workbench/contrib/webview/browser/pre/service-worker.js`
- `git diff --check`
- Local service-worker VM mock:
  - upstream worker resource request sends no `load-resource` message
  - patched worker resource request sends `load-resource`
  - patched ambiguous shared-origin case fails closed
  - patched worker localhost request sends `load-localhost`

I did not run the full VS Code browser test suite from this sparse checkout.
