### PR TITLE
Fix empty chat response when first message exceeds budget

### DIFF
--- a/extensions/copilot/src/extension/intents/node/agentIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/agentIntent.ts
@@ -368,6 +368,10 @@ export class AgentIntent extends EditCodeIntent {
 				tools: availableTools,
 				maxToolResultLength: Infinity,
 			});
+			if (!propsInfo) {
+				stream.markdown(l10n.t('Nothing to compact yet.'));
+				return {};
+			}
 
 			stream.progress(l10n.t('Compacting conversation...'));
 

--- a/extensions/copilot/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
@@ -556,12 +556,16 @@ class ConversationHistorySummarizer {
 		@ISessionTranscriptService private readonly sessionTranscriptService: ISessionTranscriptService,
 	) { }
 
-	async summarizeHistory(): Promise<{ summary: string; toolCallRoundId: string; thinking?: ThinkingData; usage?: APIUsage; promptTokenDetails?: readonly ChatResultPromptTokenDetail[]; model?: string; summarizationMode?: string; numRounds?: number; numRoundsSinceLastSummarization?: number; durationMs?: number }> {
+	async summarizeHistory(): Promise<{ summary: string; toolCallRoundId: string; thinking?: ThinkingData; usage?: APIUsage; promptTokenDetails?: readonly ChatResultPromptTokenDetail[]; model?: string; summarizationMode?: string; numRounds?: number; numRoundsSinceLastSummarization?: number; durationMs?: number } | undefined> {
 		// Execute pre-compact hook before summarization to allow hooks to archive transcripts or perform cleanup
 		await this.executePreCompactHook();
 
 		// Just a function for test to create props and call this
 		const propsInfo = this.instantiationService.createInstance(SummarizedConversationHistoryPropsBuilder).getProps(this.props);
+		if (!propsInfo) {
+			this.logService.info('[ConversationHistorySummarizer] no prior content to summarize, skipping');
+			return undefined;
+		}
 
 		const summaryPromise = this.getSummaryWithFallback(propsInfo);
 		this.progress?.report(new ChatResponseProgressPart2(l10n.t('Compacting conversation...'), async () => {
@@ -1009,7 +1013,7 @@ export class SummarizedConversationHistoryPropsBuilder {
 
 	getProps(
 		props: SummarizedAgentHistoryProps
-	): ISummarizedConversationHistoryInfo {
+	): ISummarizedConversationHistoryInfo | undefined {
 		let toolCallRounds = props.promptContext.toolCallRounds;
 		let isContinuation = props.promptContext.isContinuation;
 		let summarizedToolCallRoundId = '';
@@ -1026,7 +1030,7 @@ export class SummarizedConversationHistoryPropsBuilder {
 			toolCallRounds = [];
 			summarizedToolCallRoundId = props.promptContext.history.at(-1)!.rounds.at(-1)!.id;
 		} else {
-			throw new Error('Nothing to summarize');
+			return undefined;
 		}
 
 		// For Anthropic models with thinking enabled, find the last assistant message with thinking

--- a/extensions/copilot/src/extension/prompts/node/agent/test/summarization.spec.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/summarization.spec.tsx
@@ -106,8 +106,9 @@ suite('Agent Summarization', () => {
 			renderer = PromptRenderer.create(instaService, endpoint, AgentPrompt, props);
 		} else {
 			const propsInfo = instaService.createInstance(SummarizedConversationHistoryPropsBuilder).getProps(baseProps);
+			expect(propsInfo, 'expected propsInfo to be defined for test scenario').toBeDefined();
 			const simpleMode = promptType === TestPromptType.SimpleSummarization;
-			renderer = PromptRenderer.create(instaService, endpoint, ConversationHistorySummarizationPrompt, { ...propsInfo.props, simpleMode });
+			renderer = PromptRenderer.create(instaService, endpoint, ConversationHistorySummarizationPrompt, { ...propsInfo!.props, simpleMode });
 		}
 
 		const r = await renderer.render();
@@ -489,7 +490,8 @@ suite('Agent Summarization', () => {
 		};
 
 		const propsInfo = instaService.createInstance(SummarizedConversationHistoryPropsBuilder).getProps(baseProps);
-		const renderer = PromptRenderer.create(instaService, endpoint, ConversationHistorySummarizationPrompt, { ...propsInfo.props, simpleMode: true });
+		expect(propsInfo, 'expected propsInfo to be defined for test scenario').toBeDefined();
+		const renderer = PromptRenderer.create(instaService, endpoint, ConversationHistorySummarizationPrompt, { ...propsInfo!.props, simpleMode: true });
 		const result = await renderer.render();
 
 		// prompt-tsx prunes all content and silently drops empty messages → 0 messages


### PR DESCRIPTION
Fixes #314000.

## Problem

When the budget is exceeded on the first user message of a brand-new conversation (no history, no tool-call rounds), `SummarizedConversationHistoryPropsBuilder.getProps()` threw `'Nothing to summarize'`. That:

1. Bubbled up as a generic `[ConversationHistorySummarizer] summarization failed` error in logs (with a confusing stack trace).
2. Was misclassified in telemetry as `errorKind: 'error'` instead of `'budgetExceeded'`.
3. Triggered the fallback `renderWithoutSummarization` path which produced a degraded prompt that the model responded to with empty text — the user saw a silent empty assistant turn.

## Fix

Return `undefined` from `getProps()` instead of throwing when there is nothing to summarize. The natural `BudgetExceededError` flow then runs and:

- Properly classifies telemetry as `budgetExceeded`.
- Produces the explicit user-facing `Unable to build prompt, modelMaxPromptTokens = N` error if the prompt truly cannot fit.
