### PR TITLE
Retry browser-test page.goto on connection-refused

### DIFF
--- a/test/integration/browser/src/index.ts
+++ b/test/integration/browser/src/index.ts
@@ -134,10 +134,32 @@ async function runTestsInBrowser(browserType: BrowserType, browserChannel: Brows
 
 	const payloadParam = `[["extensionDevelopmentPath","${testExtensionUri}"],["extensionTestsPath","${testFilesUri}"],["enableProposedApi",""],["webviewExternalEndpointCommit","ef65ac1ba57f57f2a3961bfe94aa20481caca4c6"],["skipWelcome","true"]]`;
 
-	if (path.extname(testWorkspacePath) === '.code-workspace') {
-		await page.goto(`${endpoint.href}&workspace=${testWorkspacePath}&payload=${payloadParam}`);
-	} else {
-		await page.goto(`${endpoint.href}&folder=${testWorkspacePath}&payload=${payloadParam}`);
+	const targetUrl = path.extname(testWorkspacePath) === '.code-workspace'
+		? `${endpoint.href}&workspace=${testWorkspacePath}&payload=${payloadParam}`
+		: `${endpoint.href}&folder=${testWorkspacePath}&payload=${payloadParam}`;
+
+	// The server prints "Web UI available at" before its HTTP listener is fully ready to
+	// accept connections on some platforms (notably Windows + Firefox). Retry the initial
+	// navigation a few times on connection-refused errors to avoid spurious test failures.
+	await gotoWithRetry(page, targetUrl);
+}
+
+async function gotoWithRetry(page: playwright.Page, targetUrl: string): Promise<void> {
+	const maxAttempts = 5;
+	for (let attempt = 1; ; attempt++) {
+		try {
+			await page.goto(targetUrl);
+			return;
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			const isConnectionRefused = /NS_ERROR_CONNECTION_REFUSED|net::ERR_CONNECTION_REFUSED|ECONNREFUSED/i.test(message);
+			if (!isConnectionRefused || attempt >= maxAttempts) {
+				throw error;
+			}
+			const delayMs = 500 * attempt;
+			console.log(`page.goto failed with connection refused (attempt ${attempt}/${maxAttempts}), retrying in ${delayMs}ms...`);
+			await new Promise(resolve => setTimeout(resolve, delayMs));
+		}
 	}
 }
 


### PR DESCRIPTION
## Why

The Windows + Firefox leg of `🧪 Run integration tests (Browser, Firefox)` (e.g. [build 437726](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=437726)) intermittently fails right after a sub-suite boundary with:

```
Request Failed http://localhost:8000/?... NS_ERROR_CONNECTION_REFUSED
page.goto: NS_ERROR_CONNECTION_REFUSED
    at runTestsInBrowser (test/integration/browser/out/index.js:160:20)
```

In `test-web-integration.bat` each sub-suite (API folder, API workspace, TypeScript, Markdown, Emmet, **Git**, Ipynb, Configuration editing) launches a fresh code-server. `launchServer` in [`test/integration/browser/src/index.ts`](https://github.com/microsoft/vscode/blob/main/test/integration/browser/src/index.ts) resolves as soon as it sees `Web UI available at <url>` on stdout, then `runTestsInBrowser` immediately calls `page.goto`. On Windows + Firefox the server prints the banner before its HTTP listener is fully accepting connections after the previous server was killed via `tree-kill` and port `8000` was reused, so the very first navigation can race and get `NS_ERROR_CONNECTION_REFUSED`.

In the failing build all earlier suites passed (Emmet `176 passing`); the failure occurred exactly at the start of `### Git tests` after the new server came up. There is no related code change in the diff range — flaky test, not a regression.

## What

Wrap the initial `page.goto` in a small retry loop:

- Up to 5 attempts, 0.5s/1s/1.5s/... linear backoff.
- Only retries on `NS_ERROR_CONNECTION_REFUSED` / `net::ERR_CONNECTION_REFUSED` / `ECONNREFUSED`, so any real test/page error still fails fast.
- Logs each retry attempt for visibility in CI.

No production code is touched; this only affects the integration test runner.