### PR TITLE
Use 4 cache_control breakpoints for Anthropic Messages API

### DIFF
--- a/extensions/copilot/src/platform/endpoint/node/messagesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/messagesApi.ts
@@ -513,14 +513,15 @@ export function addToolsAndSystemCacheControl(
  * Marks the last cacheable block of the two most recent cacheable messages.
  *
  * Anthropic's prompt cache matches on content prefix, so a single tail anchor
- * is sufficient under steady-state. The second (older) anchor provides a
- * fallback within Anthropic's 20-block lookback window: if the tail anchor
- * misses (TTL expiry on a slow tool call, or rare content drift), the older
- * anchor still serves a cache hit covering everything up to it, so we lose at
- * most one exchange instead of resetting the entire conversation cache.
+ * is sufficient under steady-state. The second (older) anchor is intended to
+ * improve the chance of retaining a useful fallback within Anthropic's
+ * lookback window: if the tail anchor misses (TTL expiry on a slow tool call,
+ * or rare content drift), the older anchor can still serve a cache hit
+ * covering everything up to it, so we typically lose at most one exchange
+ * instead of resetting the entire conversation cache.
  *
- * Combined with the tools + system breakpoints, this produces 4 cache_control
- * markers — exactly Anthropic's per-request limit.
+ * Combined with the tools + system breakpoints, this can produce up to 4
+ * cache_control markers, which matches Anthropic's per-request limit.
  */
 export function addMessagesApiCacheControl(
 	messagesResult: { messages: MessageParam[]; system?: TextBlockParam[] },

--- a/extensions/copilot/src/platform/endpoint/node/messagesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/messagesApi.ts
@@ -510,19 +510,28 @@ export function addToolsAndSystemCacheControl(
 }
 
 /**
- * Marks the last cacheable block of the latest cacheable message. Anthropic's
- * prompt cache matches on content prefix, so each iteration's write extends
- * the cached prefix forward without needing additional anchors.
+ * Marks the last cacheable block of the two most recent cacheable messages.
+ *
+ * Anthropic's prompt cache matches on content prefix, so a single tail anchor
+ * is sufficient under steady-state. The second (older) anchor provides a
+ * fallback within Anthropic's 20-block lookback window: if the tail anchor
+ * misses (TTL expiry on a slow tool call, or rare content drift), the older
+ * anchor still serves a cache hit covering everything up to it, so we lose at
+ * most one exchange instead of resetting the entire conversation cache.
+ *
+ * Combined with the tools + system breakpoints, this produces 4 cache_control
+ * markers — exactly Anthropic's per-request limit.
  */
 export function addMessagesApiCacheControl(
 	messagesResult: { messages: MessageParam[]; system?: TextBlockParam[] },
 ): void {
 	const messages = messagesResult.messages;
-	for (let i = messages.length - 1; i >= 0; i--) {
+	let marked = 0;
+	for (let i = messages.length - 1; i >= 0 && marked < 2; i--) {
 		const msg = messages[i];
 		if (Array.isArray(msg.content) && msg.content.some(b => typeof b === 'object' && contentBlockSupportsCacheControl(b))) {
 			markLastCacheableBlock(msg);
-			return;
+			marked++;
 		}
 	}
 }

--- a/extensions/copilot/src/platform/endpoint/test/node/messagesApi.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/test/node/messagesApi.spec.ts
@@ -568,23 +568,23 @@ suite('addMessagesApiCacheControl', function () {
 		return out;
 	}
 
-	test('marks the last cacheable block of the latest cacheable message', function () {
+	test('marks the last cacheable block of the two most recent cacheable messages', function () {
 		const messages: MessageParam[] = [
 			{ role: 'user', content: [{ type: 'text', text: 'do stuff' }] },
 			{ role: 'assistant', content: [{ type: 'text', text: 'calling tools' }, { type: 'tool_use', id: 'a', name: 't', input: {} }, { type: 'tool_use', id: 'b', name: 't', input: {} }] },
 			{ role: 'user', content: [{ type: 'tool_result', tool_use_id: 'a', content: 'ra' }, { type: 'tool_result', tool_use_id: 'b', content: 'rb' }] },
 		];
 		addMessagesApiCacheControl({ messages });
-		expect(ccPositions({ messages })).toEqual(['messages[2].block[1]']);
+		expect(ccPositions({ messages })).toEqual(['messages[1].block[2]', 'messages[2].block[1]']);
 	});
 
-	test('skips thinking-only blocks within the latest message', function () {
+	test('skips thinking-only blocks within recent messages', function () {
 		const messages: MessageParam[] = [
 			{ role: 'user', content: [{ type: 'text', text: 'hello' }] },
 			{ role: 'assistant', content: [{ type: 'thinking', thinking: 'hmm', signature: 'sig' }, { type: 'text', text: 'response' }] },
 		];
 		addMessagesApiCacheControl({ messages });
-		expect(ccPositions({ messages })).toEqual(['messages[1].block[1]']);
+		expect(ccPositions({ messages })).toEqual(['messages[0].block[0]', 'messages[1].block[1]']);
 	});
 
 	test('walks past trailing messages with no cacheable blocks', function () {
@@ -595,7 +595,7 @@ suite('addMessagesApiCacheControl', function () {
 			{ role: 'user', content: [] },
 		];
 		addMessagesApiCacheControl({ messages });
-		expect(ccPositions({ messages })).toEqual(['messages[1].block[0]']);
+		expect(ccPositions({ messages })).toEqual(['messages[0].block[0]', 'messages[1].block[0]']);
 	});
 
 	test('handles single message and empty array', function () {
@@ -608,7 +608,7 @@ suite('addMessagesApiCacheControl', function () {
 		expect(empty).toHaveLength(0);
 	});
 
-	test('combined with addToolsAndSystemCacheControl produces the 3-cc layout', function () {
+	test('combined with addToolsAndSystemCacheControl produces the 4-cc layout', function () {
 		const tools: AnthropicMessagesTool[] = [
 			{ name: 'read_file', description: '', input_schema: { type: 'object', properties: {}, required: [] } },
 			{ name: 'edit_file', description: '', input_schema: { type: 'object', properties: {}, required: [] } },
@@ -622,11 +622,11 @@ suite('addMessagesApiCacheControl', function () {
 		addMessagesApiCacheControl({ messages, system });
 		addToolsAndSystemCacheControl(tools, { messages, system });
 		expect(ccPositions({ messages, system, tools })).toEqual([
-			'tools[1]', 'system[0]', 'messages[2].block[0]',
+			'tools[1]', 'system[0]', 'messages[1].block[0]', 'messages[2].block[0]',
 		]);
 	});
 
-	test('cc shifts forward each iteration of an agent loop', function () {
+	test('cc anchors shift forward each iteration of an agent loop', function () {
 		const query: ContentBlockParam = { type: 'text', text: 'do work' };
 		const r1Use: ContentBlockParam = { type: 'tool_use', id: 'a', name: 't', input: {} };
 		const r1Res: ContentBlockParam = { type: 'tool_result', tool_use_id: 'a', content: 'r1' };
@@ -639,7 +639,8 @@ suite('addMessagesApiCacheControl', function () {
 			{ role: 'user', content: [r1Res] },
 		];
 		addMessagesApiCacheControl({ messages: iterA });
-		expect(ccPositions({ messages: iterA })).toEqual(['messages[2].block[0]']);
+		expect(ccPositions({ messages: iterA })).toEqual(['messages[1].block[0]', 'messages[2].block[0]']);
+		(r1Use as { cache_control?: unknown }).cache_control = undefined;
 		(r1Res as ToolResultBlockParam).cache_control = undefined;
 
 		const iterB: MessageParam[] = [
@@ -650,7 +651,7 @@ suite('addMessagesApiCacheControl', function () {
 			{ role: 'user', content: [r2Res] },
 		];
 		addMessagesApiCacheControl({ messages: iterB });
-		expect(ccPositions({ messages: iterB })).toEqual(['messages[4].block[0]']);
+		expect(ccPositions({ messages: iterB })).toEqual(['messages[3].block[0]', 'messages[4].block[0]']);
 	});
 });
 
@@ -683,11 +684,11 @@ suite('clearAllCacheControl', function () {
 		expect(ccPositions({ messages, system })).toEqual([]);
 	});
 
-	test('caps total cc count at 3 even when upstream loaded 4 markers', function () {
+	test('caps total cc count at 4 even when upstream loaded markers', function () {
 		// Repro: a prompt-tsx prompt (e.g. inlineChatPrompt) emits multiple
 		// <cacheBreakpoint> parts that rawContentToAnthropicContent translates
 		// into cache_control fields. Without clearAllCacheControl we'd add
-		// 3 more on top → exceed Anthropic's 4-cc limit → 400.
+		// our own on top → exceed Anthropic's 4-cc limit → 400.
 		const tools: AnthropicMessagesTool[] = [
 			{ name: 't', description: '', input_schema: { type: 'object', properties: {}, required: [] } },
 		];
@@ -702,12 +703,12 @@ suite('clearAllCacheControl', function () {
 		addMessagesApiCacheControl({ messages, system });
 		addToolsAndSystemCacheControl(tools, { messages, system });
 
-		// Exactly 3 ccs, all in the deterministic positions we own.
+		// Exactly 4 ccs, all in the deterministic positions we own.
 		expect([
 			...tools.flatMap((t, i) => t.cache_control ? [`tools[${i}]`] : []),
 			...ccPositions({ messages, system }),
 		]).toEqual([
-			'tools[0]', 'system[0]', 'messages[2].block[0]',
+			'tools[0]', 'system[0]', 'messages[1].block[0]', 'messages[2].block[0]',
 		]);
 	});
 


### PR DESCRIPTION
## Summary

Marks the last cacheable block of the **two most recent** cacheable messages instead of just one. Combined with the existing tools + system breakpoints, this produces 4 `cache_control` markers — exactly Anthropic's per-request limit.

## Background

The Messages API allows up to 4 `cache_control` breakpoints per request. We were previously using 3:

| Breakpoint | Status |
|---|---|
| Last non-deferred tool definition | fixed |
| Last system block | fixed |
| Last cacheable block of the most recent message | sliding |

Anthropic's prompt cache is prefix-based, so a single tail anchor *is* sufficient under steady-state — the cached prefix grows with each turn. But under failure modes (TTL expiry on a slow tool call, rare content drift, or eviction) the single anchor offers no fallback, and the next turn writes a fresh tail anchor with no nearby cached prefix to latch onto, effectively resetting the conversation cache.

## Change

Adds a second sliding anchor on the second-to-last cacheable message:

```
tools[last]   ← fixed
system[last]  ← fixed
messages[N-1] ← sliding (fallback)
messages[N]   ← sliding (tail)
```

The fallback anchor lives within Anthropic's 20-block lookback window so a single miss costs at most one exchange instead of the whole conversation.

## Validation

- `messagesApi.spec.ts` updated and passes (45 tests).
- TypeScript clean.
- The total of exactly 4 markers is asserted in the existing `caps total cc count at 4` test.