### PR TITLE
Resolve webview viewColumn after creating ViewColumn.Beside panel

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadWebviewPanels.ts
+++ b/src/vs/workbench/api/browser/mainThreadWebviewPanels.ts
@@ -174,6 +174,11 @@ export class MainThreadWebviewPanels extends Disposable implements extHostProtoc
 		}, this.webviewPanelViewType.fromExternal(viewType), initData.title, undefined, mainThreadShowOptions);
 
 		this.addWebviewInput(handle, webview, { serializeBuffersForPostMessage: initData.serializeBuffersForPostMessage });
+
+		// Editor events fired during openWebview run before the handle is registered above,
+		// so the resolved viewColumn never reaches the extension host. Push it now so symbolic
+		// columns (e.g. ViewColumn.Beside) resolve to a concrete column right after creation.
+		this.updateWebviewViewStates(this._editorService.activeEditor);
 	}
 
 	public $disposeWebview(handle: extHostProtocol.WebviewHandle): void {


### PR DESCRIPTION
Fixes #233448

When an extension calls `vscode.window.createWebviewPanel(id, title, vscode.ViewColumn.Beside)`, `webviewPanel.viewColumn` keeps returning `undefined` instead of resolving to the concrete column the panel was placed in.

### Cause

`MainThreadWebviewPanels.$createWebviewPanel` does:

1. `_webviewWorkbenchService.openWebview(...)` — actually creates and places the webview, which fires editor-service events.
2. `addWebviewInput(handle, webview, ...)` — registers the handle for the new input.

The events from step 1 trigger `updateWebviewViewStates`, but at that moment the new webview is not yet in `_webviewInputs`, so `getHandleForInput` returns `undefined` and the resolved view state is never pushed to the extension host. The ext-host getter therefore continues to see the symbolic value (`-2` for `Beside`) and returns `undefined`.

### Fix

After registering the handle, explicitly call `updateWebviewViewStates(activeEditor)` once. This causes the resolved column to be pushed back to the extension host immediately, so symbolic columns (`ViewColumn.Beside`, `ViewColumn.Active`) resolve to a concrete column right after creation. This matches the documented behavior of `TextEditor.viewColumn`, which the user explicitly compared against in the issue.

The change is a one-call addition; existing event-driven updates remain in place for subsequent group/visibility changes.