### PR TITLE
Make the decoration option fontSize a number

### DIFF
--- a/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContext.ts
+++ b/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContext.ts
@@ -874,7 +874,7 @@ interface IRenderData {
 	height: number;
 	useCover: boolean;
 
-	fontSize?: string | null;
+	fontSize?: number | null;
 	color?: Color | null;
 	italic?: boolean;
 	bold?: boolean;

--- a/src/vs/editor/browser/editorBrowser.ts
+++ b/src/vs/editor/browser/editorBrowser.ts
@@ -1066,7 +1066,7 @@ export interface ICodeEditor extends editorCommon.IEditor {
 	 * Get the font size at a given position
 	 * @param position the position for which to fetch the font size
 	 */
-	getFontSizeAtPosition(position: IPosition): string | null;
+	getFontSizeAtPosition(position: IPosition): number | null;
 
 	/**
 	 * All decorations added through this call will get the ownerId of this editor.

--- a/src/vs/editor/browser/services/abstractCodeEditorService.ts
+++ b/src/vs/editor/browser/services/abstractCodeEditorService.ts
@@ -461,7 +461,7 @@ class DecorationTypeOptionsProvider implements IModelDecorationOptionsProvider {
 	public glyphMarginClassName: string | undefined;
 	public isWholeLine: boolean;
 	public lineHeight: number | undefined;
-	public fontSize: string | undefined;
+	public fontSize: number | undefined;
 	public fontFamily: string | undefined;
 	public fontWeight: string | undefined;
 	public fontStyle: string | undefined;

--- a/src/vs/editor/browser/widget/codeEditor/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditor/codeEditorWidget.ts
@@ -1355,7 +1355,7 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 		return this._modelData.model.getDecorationsInRange(range, this._id, filterValidationDecorations(options), filterFontDecorations(options));
 	}
 
-	public getFontSizeAtPosition(position: IPosition): string | null {
+	public getFontSizeAtPosition(position: IPosition): number | null {
 		if (!this._modelData) {
 			return null;
 		}

--- a/src/vs/editor/common/editorCommon.ts
+++ b/src/vs/editor/common/editorCommon.ts
@@ -634,7 +634,7 @@ export interface IThemeDecorationRenderOptions {
 	fontStyle?: string;
 	fontWeight?: string;
 	fontFamily?: string;
-	fontSize?: string;
+	fontSize?: number;
 	lineHeight?: number;
 	textDecoration?: string;
 	cursor?: string;

--- a/src/vs/editor/common/model.ts
+++ b/src/vs/editor/common/model.ts
@@ -233,7 +233,7 @@ export interface IModelDecorationOptions {
 	/**
 	 * Font size
 	 */
-	fontSize?: string | null;
+	fontSize?: number | null;
 	/**
 	 * Font weight
 	 */

--- a/src/vs/editor/common/model/textModel.ts
+++ b/src/vs/editor/common/model/textModel.ts
@@ -2500,7 +2500,7 @@ export class ModelDecorationOptions implements model.IModelDecorationOptions {
 	readonly glyphMarginHoverMessage: IMarkdownString | IMarkdownString[] | null;
 	readonly isWholeLine: boolean;
 	readonly lineHeight: number | null;
-	readonly fontSize: string | null;
+	readonly fontSize: number | null;
 	readonly showIfCollapsed: boolean;
 	readonly collapseOnReplaceEdit: boolean;
 	readonly overviewRuler: ModelDecorationOverviewRulerOptions | null;

--- a/src/vs/editor/common/viewModel.ts
+++ b/src/vs/editor/common/viewModel.ts
@@ -51,7 +51,7 @@ export interface IViewModel extends ICursorSimpleModel, ISimpleModel {
 	onCompositionStart(): void;
 	onCompositionEnd(): void;
 
-	getFontSizeAtPosition(position: IPosition): string | null;
+	getFontSizeAtPosition(position: IPosition): number | null;
 	getMinimapDecorationsInRange(range: Range): ViewModelDecoration[];
 	getDecorationsInViewport(visibleRange: Range): ViewModelDecoration[];
 	getTextDirection(lineNumber: number): TextDirection;

--- a/src/vs/editor/common/viewModel/viewModelImpl.ts
+++ b/src/vs/editor/common/viewModel/viewModelImpl.ts
@@ -568,13 +568,13 @@ export class ViewModel extends Disposable implements IViewModel {
 	private readonly hiddenAreasModel = new HiddenAreasModel();
 	private previousHiddenAreas: readonly Range[] = [];
 
-	public getFontSizeAtPosition(position: IPosition): string | null {
+	public getFontSizeAtPosition(position: IPosition): number | null {
 		const allowVariableFonts = this._configuration.options.get(EditorOption.effectiveAllowVariableFonts);
 		if (!allowVariableFonts) {
 			return null;
 		}
 		const fontDecorations = this.model.getFontDecorationsInRange(Range.fromPositions(position), this._editorId);
-		let fontSize: string = this._configuration.options.get(EditorOption.fontInfo).fontSize + 'px';
+		let fontSize = this._configuration.options.get(EditorOption.fontInfo).fontSize;
 		for (const fontDecoration of fontDecorations) {
 			if (fontDecoration.options.fontSize) {
 				fontSize = fontDecoration.options.fontSize;

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -1757,7 +1757,7 @@ declare namespace monaco.editor {
 		/**
 		 * Font size
 		 */
-		fontSize?: string | null;
+		fontSize?: number | null;
 		/**
 		 * Font weight
 		 */
@@ -6309,7 +6309,7 @@ declare namespace monaco.editor {
 		 * Get the font size at a given position
 		 * @param position the position for which to fetch the font size
 		 */
-		getFontSizeAtPosition(position: IPosition): string | null;
+		getFontSizeAtPosition(position: IPosition): number | null;
 		/**
 		 * All decorations added through this call will get the ownerId of this editor.
 		 * @deprecated Use `createDecorationsCollection`


### PR DESCRIPTION
This options took a numeric string. This number is a ratio by which the font size will be multiplied. This was once an absolute value, but this is no longer the case.

This value is currently used in `ViewModel.getFontSizeAtPosition()`, where it is incorrectly used as an absolute value. This number is currently only used in `TextAreaEditContext`, but I don’t believe it’s really needed there.

Besides that, the number is currently unused inside Monaco. But its numerical value is needed to fix some bugs. E.g. this is a prerequisite for fixing #305658.