### PR TITLE
Experiment with terminal output deltas for repeated polls

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/getTerminalOutputTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/getTerminalOutputTool.ts
@@ -5,10 +5,12 @@
 
 import type { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
+import { StringSHA1 } from '../../../../../../base/common/hash.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
 import { localize } from '../../../../../../nls.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { ToolDataSource, type CountTokensCallback, type IPreparedToolInvocation, type IToolData, type IToolImpl, type IToolInvocation, type IToolInvocationPreparationContext, type IToolResult, type ToolProgress } from '../../../../chat/common/tools/languageModelToolsService.js';
+import { ITerminalService } from '../../../../terminal/browser/terminal.js';
 import { TerminalChatAgentToolsSettingId } from '../../common/terminalChatAgentToolsConfiguration.js';
 import { RunInTerminalTool } from './runInTerminalTool.js';
 import { TerminalToolId } from './toolIds.js';
@@ -38,15 +40,24 @@ export interface IGetTerminalOutputInputParams {
 	id?: string;
 }
 
+interface IOutputSnapshot {
+	readonly terminalInstanceId: number;
+	readonly length: number;
+	readonly hash: string;
+}
+
 export class GetTerminalOutputTool extends Disposable implements IToolImpl {
 
 	private static readonly _maxOutputSnapshots = 100;
-	private readonly _lastOutputByTerminalId = new Map<string, string>();
+	private readonly _lastOutputSnapshotByExecutionId = new Map<string, IOutputSnapshot>();
 
 	constructor(
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@ITerminalService terminalService: ITerminalService,
 	) {
 		super();
+
+		this._register(terminalService.onDidDisposeInstance(instance => this._forgetTerminalInstance(instance.instanceId)));
 	}
 
 	async prepareToolInvocation(context: IToolInvocationPreparationContext, token: CancellationToken): Promise<IPreparedToolInvocation | undefined> {
@@ -70,7 +81,7 @@ export class GetTerminalOutputTool extends Disposable implements IToolImpl {
 
 		const execution = RunInTerminalTool.getExecution(args.id);
 		if (!execution) {
-			this._lastOutputByTerminalId.delete(args.id);
+			this._lastOutputSnapshotByExecutionId.delete(args.id);
 			return {
 				content: [{
 					kind: 'text',
@@ -82,40 +93,69 @@ export class GetTerminalOutputTool extends Disposable implements IToolImpl {
 		return {
 			content: [{
 				kind: 'text',
-				value: this._formatOutput(args.id, execution.getOutput())
+				value: this._formatOutput(args.id, execution.instance.instanceId, execution.getOutput())
 			}]
 		};
 	}
 
-	private _formatOutput(id: string, output: string): string {
+	private _formatOutput(id: string, terminalInstanceId: number, output: string): string {
 		if (!this._configurationService.getValue<boolean>(TerminalChatAgentToolsSettingId.OutputDeltas)) {
-			this._lastOutputByTerminalId.clear();
+			this._lastOutputSnapshotByExecutionId.clear();
 			return `Output of terminal ${id}:\n${output}`;
 		}
 
-		const previousOutput = this._lastOutputByTerminalId.get(id);
-		this._rememberOutput(id, output);
+		const previousOutputSnapshot = this._lastOutputSnapshotByExecutionId.get(id);
+		const currentOutputSnapshot = this._createOutputSnapshot(terminalInstanceId, output);
+		this._rememberOutput(id, currentOutputSnapshot);
 
-		if (previousOutput === undefined) {
+		if (previousOutputSnapshot === undefined) {
 			return `Output of terminal ${id}:\n${output}`;
 		}
-		if (output === previousOutput) {
+		if (currentOutputSnapshot.length === previousOutputSnapshot.length && currentOutputSnapshot.hash === previousOutputSnapshot.hash) {
 			return `Output of terminal ${id} unchanged since previous poll (${output.length} characters already shown). No new output.`;
 		}
-		if (output.startsWith(previousOutput)) {
-			const delta = output.slice(previousOutput.length);
+
+		if (output.length > previousOutputSnapshot.length && this._hashOutput(output, previousOutputSnapshot.length) === previousOutputSnapshot.hash) {
+			const delta = output.slice(previousOutputSnapshot.length);
 			return `Output of terminal ${id} since previous poll (${delta.length} new characters, ${output.length} total characters):\n${delta}`;
 		}
 		return `Output of terminal ${id} changed since previous poll; returning current output (${output.length} characters):\n${output}`;
 	}
 
-	private _rememberOutput(id: string, output: string): void {
-		if (!this._lastOutputByTerminalId.has(id) && this._lastOutputByTerminalId.size >= GetTerminalOutputTool._maxOutputSnapshots) {
-			const oldestId = this._lastOutputByTerminalId.keys().next().value;
+	private _rememberOutput(id: string, snapshot: IOutputSnapshot): void {
+		if (!this._lastOutputSnapshotByExecutionId.has(id) && this._lastOutputSnapshotByExecutionId.size >= GetTerminalOutputTool._maxOutputSnapshots) {
+			const oldestId = this._lastOutputSnapshotByExecutionId.keys().next().value;
 			if (oldestId !== undefined) {
-				this._lastOutputByTerminalId.delete(oldestId);
+				this._lastOutputSnapshotByExecutionId.delete(oldestId);
 			}
 		}
-		this._lastOutputByTerminalId.set(id, output);
+		this._lastOutputSnapshotByExecutionId.set(id, snapshot);
+	}
+
+	private _createOutputSnapshot(terminalInstanceId: number, output: string): IOutputSnapshot {
+		return {
+			terminalInstanceId,
+			length: output.length,
+			hash: this._hashOutput(output),
+		};
+	}
+
+	private _forgetTerminalInstance(terminalInstanceId: number): void {
+		for (const [id, snapshot] of this._lastOutputSnapshotByExecutionId) {
+			if (snapshot.terminalInstanceId === terminalInstanceId) {
+				this._lastOutputSnapshotByExecutionId.delete(id);
+			}
+		}
+	}
+
+	private _hashOutput(output: string, length = output.length): string {
+		const sha = new StringSHA1();
+		sha.update(length === output.length ? output : output.slice(0, length));
+		return sha.digest();
+	}
+
+	override dispose(): void {
+		this._lastOutputSnapshotByExecutionId.clear();
+		super.dispose();
 	}
 }

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/getTerminalOutputTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/getTerminalOutputTool.ts
@@ -7,7 +7,9 @@ import type { CancellationToken } from '../../../../../../base/common/cancellati
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
 import { localize } from '../../../../../../nls.js';
+import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { ToolDataSource, type CountTokensCallback, type IPreparedToolInvocation, type IToolData, type IToolImpl, type IToolInvocation, type IToolInvocationPreparationContext, type IToolResult, type ToolProgress } from '../../../../chat/common/tools/languageModelToolsService.js';
+import { TerminalChatAgentToolsSettingId } from '../../common/terminalChatAgentToolsConfiguration.js';
 import { RunInTerminalTool } from './runInTerminalTool.js';
 import { TerminalToolId } from './toolIds.js';
 
@@ -38,7 +40,12 @@ export interface IGetTerminalOutputInputParams {
 
 export class GetTerminalOutputTool extends Disposable implements IToolImpl {
 
-	constructor() {
+	private static readonly _maxOutputSnapshots = 100;
+	private readonly _lastOutputByTerminalId = new Map<string, string>();
+
+	constructor(
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+	) {
 		super();
 	}
 
@@ -63,6 +70,7 @@ export class GetTerminalOutputTool extends Disposable implements IToolImpl {
 
 		const execution = RunInTerminalTool.getExecution(args.id);
 		if (!execution) {
+			this._lastOutputByTerminalId.delete(args.id);
 			return {
 				content: [{
 					kind: 'text',
@@ -74,8 +82,40 @@ export class GetTerminalOutputTool extends Disposable implements IToolImpl {
 		return {
 			content: [{
 				kind: 'text',
-				value: `Output of terminal ${args.id}:\n${execution.getOutput()}`
+				value: this._formatOutput(args.id, execution.getOutput())
 			}]
 		};
+	}
+
+	private _formatOutput(id: string, output: string): string {
+		if (!this._configurationService.getValue<boolean>(TerminalChatAgentToolsSettingId.OutputDeltas)) {
+			this._lastOutputByTerminalId.clear();
+			return `Output of terminal ${id}:\n${output}`;
+		}
+
+		const previousOutput = this._lastOutputByTerminalId.get(id);
+		this._rememberOutput(id, output);
+
+		if (previousOutput === undefined) {
+			return `Output of terminal ${id}:\n${output}`;
+		}
+		if (output === previousOutput) {
+			return `Output of terminal ${id} unchanged since previous poll (${output.length} characters already shown). No new output.`;
+		}
+		if (output.startsWith(previousOutput)) {
+			const delta = output.slice(previousOutput.length);
+			return `Output of terminal ${id} since previous poll (${delta.length} new characters, ${output.length} total characters):\n${delta}`;
+		}
+		return `Output of terminal ${id} changed since previous poll; returning current output (${output.length} characters):\n${output}`;
+	}
+
+	private _rememberOutput(id: string, output: string): void {
+		if (!this._lastOutputByTerminalId.has(id) && this._lastOutputByTerminalId.size >= GetTerminalOutputTool._maxOutputSnapshots) {
+			const oldestId = this._lastOutputByTerminalId.keys().next().value;
+			if (oldestId !== undefined) {
+				this._lastOutputByTerminalId.delete(oldestId);
+			}
+		}
+		this._lastOutputByTerminalId.set(id, output);
 	}
 }

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
@@ -27,6 +27,7 @@ export const enum TerminalChatAgentToolsSettingId {
 	EnforceTimeoutFromModel = 'chat.tools.terminal.enforceTimeoutFromModel',
 	DetachBackgroundProcesses = 'chat.tools.terminal.detachBackgroundProcesses',
 	BackgroundNotifications = 'chat.tools.terminal.backgroundNotifications',
+	OutputDeltas = 'chat.tools.terminal.outputDeltas',
 	IdlePollInterval = 'chat.tools.terminal.idlePollInterval',
 
 	TerminalProfileLinux = 'chat.tools.terminal.terminalProfile.linux',
@@ -682,6 +683,16 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 		deprecated: true,
 		markdownDeprecationMessage: localize('backgroundNotifications.deprecated', "This setting is deprecated. Terminal completion and input-needed notifications are now always enabled."),
 		markdownDescription: localize('backgroundNotifications.description', "This setting is deprecated and no longer has any effect. Terminal completion and input-needed notifications are now always enabled for any command that continues running after the tool returns."),
+	},
+	[TerminalChatAgentToolsSettingId.OutputDeltas]: {
+		restricted: true,
+		type: 'boolean',
+		default: false,
+		tags: ['experimental'],
+		experiment: {
+			mode: 'auto'
+		},
+		markdownDescription: localize('outputDeltas.description', "When enabled, repeated get terminal output tool calls return only output added since the previous poll for the same terminal execution, or a short unchanged-output message when there is no new output."),
 	}
 };
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/getTerminalOutputTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/getTerminalOutputTool.test.ts
@@ -10,8 +10,11 @@ import { GetTerminalOutputTool, GetTerminalOutputToolData } from '../../browser/
 import { RunInTerminalTool, type IActiveTerminalExecution } from '../../browser/tools/runInTerminalTool.js';
 import type { IToolInvocation } from '../../../../chat/common/tools/languageModelToolsService.js';
 import type { ITerminalExecuteStrategyResult } from '../../browser/executeStrategy/executeStrategy.js';
+import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { ITerminalService, type ITerminalInstance } from '../../../../terminal/browser/terminal.js';
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { TerminalChatAgentToolsSettingId } from '../../common/terminalChatAgentToolsConfiguration.js';
 
 suite('GetTerminalOutputTool', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
@@ -20,11 +23,14 @@ suite('GetTerminalOutputTool', () => {
 	let tool: GetTerminalOutputTool;
 	let originalGetExecution: typeof RunInTerminalTool.getExecution;
 	let instantiationService: TestInstantiationService;
+	let configurationService: TestConfigurationService;
 	let mockTerminalInstances: Map<number, Partial<ITerminalInstance>>;
 
 	setup(() => {
 		mockTerminalInstances = new Map();
 		instantiationService = store.add(new TestInstantiationService());
+		configurationService = new TestConfigurationService();
+		instantiationService.stub(IConfigurationService, configurationService);
 		instantiationService.stub(ITerminalService, {
 			getInstanceFromId: (id: number) => mockTerminalInstances.get(id) as ITerminalInstance | undefined,
 		});
@@ -53,6 +59,16 @@ suite('GetTerminalOutputTool', () => {
 			completionPromise: Promise.resolve({ output } as ITerminalExecuteStrategyResult),
 			instance: {} as ITerminalInstance,
 			getOutput: () => output,
+		};
+	}
+
+	function createMutableMockExecution(output: string): IActiveTerminalExecution & { setOutput(value: string): void } {
+		let currentOutput = output;
+		return {
+			completionPromise: Promise.resolve({ output } as ITerminalExecuteStrategyResult),
+			instance: {} as ITerminalInstance,
+			getOutput: () => currentOutput,
+			setOutput: value => currentOutput = value,
 		};
 	}
 
@@ -105,5 +121,78 @@ suite('GetTerminalOutputTool', () => {
 		const value = (result.content[0] as { value: string }).value;
 		assert.ok(value.includes(`Output of terminal ${KNOWN_TERMINAL_ID}:`));
 		assert.ok(value.includes('line1\nline2'));
+	});
+
+	test('returns unchanged marker for repeated output when output deltas experiment is enabled', async () => {
+		configurationService.setUserConfiguration(TerminalChatAgentToolsSettingId.OutputDeltas, true);
+		RunInTerminalTool.getExecution = () => createMockExecution('line1\nline2');
+
+		await tool.invoke(
+			createInvocation(KNOWN_TERMINAL_ID),
+			async () => 0,
+			{ report: () => { } },
+			CancellationToken.None,
+		);
+		const result = await tool.invoke(
+			createInvocation(KNOWN_TERMINAL_ID),
+			async () => 0,
+			{ report: () => { } },
+			CancellationToken.None,
+		);
+
+		assert.strictEqual(result.content.length, 1);
+		assert.strictEqual(result.content[0].kind, 'text');
+		const value = (result.content[0] as { value: string }).value;
+		assert.strictEqual(value, `Output of terminal ${KNOWN_TERMINAL_ID} unchanged since previous poll (11 characters already shown). No new output.`);
+	});
+
+	test('returns only new output when output deltas experiment is enabled', async () => {
+		configurationService.setUserConfiguration(TerminalChatAgentToolsSettingId.OutputDeltas, true);
+		const execution = createMutableMockExecution('line1');
+		RunInTerminalTool.getExecution = () => execution;
+
+		await tool.invoke(
+			createInvocation(KNOWN_TERMINAL_ID),
+			async () => 0,
+			{ report: () => { } },
+			CancellationToken.None,
+		);
+		execution.setOutput('line1\nline2');
+		const result = await tool.invoke(
+			createInvocation(KNOWN_TERMINAL_ID),
+			async () => 0,
+			{ report: () => { } },
+			CancellationToken.None,
+		);
+
+		const value = (result.content[0] as { value: string }).value;
+		assert.ok(value.includes(`Output of terminal ${KNOWN_TERMINAL_ID} since previous poll`));
+		assert.ok(value.includes('6 new characters'));
+		assert.ok(value.endsWith('\nline2'));
+		assert.ok(!value.endsWith('line1\nline2'));
+	});
+
+	test('returns current output when output delta base no longer matches', async () => {
+		configurationService.setUserConfiguration(TerminalChatAgentToolsSettingId.OutputDeltas, true);
+		const execution = createMutableMockExecution('line1\nline2');
+		RunInTerminalTool.getExecution = () => execution;
+
+		await tool.invoke(
+			createInvocation(KNOWN_TERMINAL_ID),
+			async () => 0,
+			{ report: () => { } },
+			CancellationToken.None,
+		);
+		execution.setOutput('new screen');
+		const result = await tool.invoke(
+			createInvocation(KNOWN_TERMINAL_ID),
+			async () => 0,
+			{ report: () => { } },
+			CancellationToken.None,
+		);
+
+		const value = (result.content[0] as { value: string }).value;
+		assert.ok(value.includes('changed since previous poll'));
+		assert.ok(value.endsWith('\nnew screen'));
 	});
 });

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/getTerminalOutputTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/getTerminalOutputTool.test.ts
@@ -5,6 +5,7 @@
 
 import * as assert from 'assert';
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
+import { Emitter } from '../../../../../../base/common/event.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { GetTerminalOutputTool, GetTerminalOutputToolData } from '../../browser/tools/getTerminalOutputTool.js';
 import { RunInTerminalTool, type IActiveTerminalExecution } from '../../browser/tools/runInTerminalTool.js';
@@ -20,19 +21,20 @@ suite('GetTerminalOutputTool', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
 	const UNKNOWN_TERMINAL_ID = '123e4567-e89b-12d3-a456-426614174000';
 	const KNOWN_TERMINAL_ID = '123e4567-e89b-12d3-a456-426614174001';
+	const KNOWN_TERMINAL_INSTANCE_ID = 1;
 	let tool: GetTerminalOutputTool;
 	let originalGetExecution: typeof RunInTerminalTool.getExecution;
 	let instantiationService: TestInstantiationService;
 	let configurationService: TestConfigurationService;
-	let mockTerminalInstances: Map<number, Partial<ITerminalInstance>>;
+	let terminalServiceDisposeEmitter: Emitter<ITerminalInstance>;
 
 	setup(() => {
-		mockTerminalInstances = new Map();
 		instantiationService = store.add(new TestInstantiationService());
 		configurationService = new TestConfigurationService();
+		terminalServiceDisposeEmitter = store.add(new Emitter<ITerminalInstance>());
 		instantiationService.stub(IConfigurationService, configurationService);
 		instantiationService.stub(ITerminalService, {
-			getInstanceFromId: (id: number) => mockTerminalInstances.get(id) as ITerminalInstance | undefined,
+			onDidDisposeInstance: terminalServiceDisposeEmitter.event,
 		});
 		tool = store.add(instantiationService.createInstance(GetTerminalOutputTool));
 		originalGetExecution = RunInTerminalTool.getExecution;
@@ -54,19 +56,19 @@ suite('GetTerminalOutputTool', () => {
 		} as unknown as IToolInvocation;
 	}
 
-	function createMockExecution(output: string): IActiveTerminalExecution {
+	function createMockExecution(output: string, instanceId = KNOWN_TERMINAL_INSTANCE_ID): IActiveTerminalExecution {
 		return {
 			completionPromise: Promise.resolve({ output } as ITerminalExecuteStrategyResult),
-			instance: {} as ITerminalInstance,
+			instance: { instanceId } as ITerminalInstance,
 			getOutput: () => output,
 		};
 	}
 
-	function createMutableMockExecution(output: string): IActiveTerminalExecution & { setOutput(value: string): void } {
+	function createMutableMockExecution(output: string, instanceId = KNOWN_TERMINAL_INSTANCE_ID): IActiveTerminalExecution & { setOutput(value: string): void } {
 		let currentOutput = output;
 		return {
 			completionPromise: Promise.resolve({ output } as ITerminalExecuteStrategyResult),
-			instance: {} as ITerminalInstance,
+			instance: { instanceId } as ITerminalInstance,
 			getOutput: () => currentOutput,
 			setOutput: value => currentOutput = value,
 		};
@@ -170,6 +172,54 @@ suite('GetTerminalOutputTool', () => {
 		assert.ok(value.includes('6 new characters'));
 		assert.ok(value.endsWith('\nline2'));
 		assert.ok(!value.endsWith('line1\nline2'));
+	});
+
+	test('clears output snapshot when terminal instance is disposed', async () => {
+		configurationService.setUserConfiguration(TerminalChatAgentToolsSettingId.OutputDeltas, true);
+		const execution = createMutableMockExecution('line1');
+		RunInTerminalTool.getExecution = () => execution;
+
+		await tool.invoke(
+			createInvocation(KNOWN_TERMINAL_ID),
+			async () => 0,
+			{ report: () => { } },
+			CancellationToken.None,
+		);
+		terminalServiceDisposeEmitter.fire(execution.instance);
+		execution.setOutput('line1\nline2');
+		const result = await tool.invoke(
+			createInvocation(KNOWN_TERMINAL_ID),
+			async () => 0,
+			{ report: () => { } },
+			CancellationToken.None,
+		);
+
+		const value = (result.content[0] as { value: string }).value;
+		assert.strictEqual(value, `Output of terminal ${KNOWN_TERMINAL_ID}:\nline1\nline2`);
+	});
+
+	test('clears output snapshot when tool is disposed', async () => {
+		configurationService.setUserConfiguration(TerminalChatAgentToolsSettingId.OutputDeltas, true);
+		const execution = createMutableMockExecution('line1');
+		RunInTerminalTool.getExecution = () => execution;
+
+		await tool.invoke(
+			createInvocation(KNOWN_TERMINAL_ID),
+			async () => 0,
+			{ report: () => { } },
+			CancellationToken.None,
+		);
+		tool.dispose();
+		execution.setOutput('line1\nline2');
+		const result = await tool.invoke(
+			createInvocation(KNOWN_TERMINAL_ID),
+			async () => 0,
+			{ report: () => { } },
+			CancellationToken.None,
+		);
+
+		const value = (result.content[0] as { value: string }).value;
+		assert.strictEqual(value, `Output of terminal ${KNOWN_TERMINAL_ID}:\nline1\nline2`);
 	});
 
 	test('returns current output when output delta base no longer matches', async () => {


### PR DESCRIPTION
This adds an experimental `chat.tools.terminal.outputDeltas` setting for repeated `get_terminal_output` polling.

When the experiment is enabled:
- The first poll for a terminal execution returns the full output, preserving current context.
- Repeated polls with identical output return a short unchanged marker instead of replaying the full terminal buffer.
- Polls with appended output return only the new suffix.
- Non-prefix changes, such as screen rewrites or truncated scrollback, fall back to returning the current full output.

This change is stateful across explicit `get_terminal_output` calls and targets prompt/tool-result replay from terminal polling loops.