### PR TITLE
fix: sessions terminal contribution should not manage hidden tool terminals

### DIFF
--- a/src/vs/sessions/contrib/terminal/browser/sessionsTerminalContribution.ts
+++ b/src/vs/sessions/contrib/terminal/browser/sessionsTerminalContribution.ts
@@ -140,6 +140,10 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 		// belong to the current active session. These arrive asynchronously
 		// during reconnection and would otherwise flash in the foreground.
 		this._register(this._terminalService.onDidCreateInstance(instance => {
+			// Skip hidden tool terminals — managed by the chat tool lifecycle
+			if (instance.shellLaunchConfig.hideFromUser) {
+				return;
+			}
 			if (instance.shellLaunchConfig.attachPersistentProcess && this._activeKey) {
 				instance.getInitialCwd().then(cwd => {
 					if (cwd.toLowerCase() !== this._activeKey) {
@@ -281,6 +285,10 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 	private async _findTerminalsForKey(key: string): Promise<ITerminalInstance[]> {
 		const result: ITerminalInstance[] = [];
 		for (const instance of this._terminalService.instances) {
+			// Skip hidden tool terminals — managed by the chat tool lifecycle
+			if (instance.shellLaunchConfig.hideFromUser) {
+				continue;
+			}
 			try {
 				const cwd = await instance.getInitialCwd();
 				if (cwd.toLowerCase() === key) {
@@ -311,6 +319,10 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 		const toHide: ITerminalInstance[] = [];
 
 		for (const instance of [...this._terminalService.instances]) {
+			// Skip hidden tool terminals — managed by the chat tool lifecycle
+			if (instance.shellLaunchConfig.hideFromUser) {
+				continue;
+			}
 			let cwd: string | undefined;
 			try {
 				cwd = (await instance.getInitialCwd()).toLowerCase();
@@ -365,6 +377,12 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 	private async _closeTerminalsForPath(fsPath: string): Promise<void> {
 		const key = fsPath.toLowerCase();
 		for (const instance of [...this._terminalService.instances]) {
+			// Skip hidden tool terminals (e.g. run_in_terminal) — those are
+			// managed by the chat tool lifecycle, not the session terminal
+			// contribution.
+			if (instance.shellLaunchConfig.hideFromUser) {
+				continue;
+			}
 			try {
 				const cwd = (await instance.getInitialCwd()).toLowerCase();
 				if (cwd === key) {

--- a/src/vs/sessions/contrib/terminal/test/browser/sessionsTerminalContribution.test.ts
+++ b/src/vs/sessions/contrib/terminal/test/browser/sessionsTerminalContribution.test.ts
@@ -818,6 +818,96 @@ suite('SessionsTerminalContribution', () => {
 		assert.strictEqual(createdTerminals.length, 1, 'should create a terminal at the unwrapped repository path');
 		assert.strictEqual(createdTerminals[0].cwd.fsPath, URI.file('/Users/user/repo').fsPath);
 	});
+
+	// --- Hidden tool terminals (hideFromUser) ---
+
+	test('does not dispose hidden tool terminals when session is archived', async () => {
+		const worktreeUri = URI.file('/worktree');
+		await contribution.ensureTerminal(worktreeUri, false);
+
+		// Simulate a hidden tool terminal (created by run_in_terminal) at the same cwd
+		const toolTerminal = makeTerminalInstance(nextInstanceId++, worktreeUri.fsPath);
+		toolTerminal._testSetShellLaunchConfig({ hideFromUser: true } as ITerminalInstance['shellLaunchConfig']);
+		terminalInstances.set(toolTerminal.instanceId, toolTerminal);
+
+		const session = makeAgentSession({
+			isArchived: true,
+			worktree: worktreeUri,
+			providerType: AgentSessionProviders.Background,
+		});
+		onDidChangeSessions.fire({ added: [], removed: [], changed: [session] });
+		await tick();
+
+		// The regular terminal should be disposed, but the tool terminal should survive
+		assert.strictEqual(disposedInstances.length, 1, 'should dispose exactly one terminal');
+		assert.notStrictEqual(disposedInstances[0].instanceId, toolTerminal.instanceId, 'should not dispose the tool terminal');
+	});
+
+	test('does not dispose hidden tool terminals when session is removed', async () => {
+		const worktreeUri = URI.file('/worktree');
+		await contribution.ensureTerminal(worktreeUri, false);
+
+		const toolTerminal = makeTerminalInstance(nextInstanceId++, worktreeUri.fsPath);
+		toolTerminal._testSetShellLaunchConfig({ hideFromUser: true } as ITerminalInstance['shellLaunchConfig']);
+		terminalInstances.set(toolTerminal.instanceId, toolTerminal);
+
+		const session = makeAgentSession({ worktree: worktreeUri, providerType: AgentSessionProviders.Background });
+		onDidChangeSessions.fire({ added: [], removed: [session], changed: [] });
+		await tick();
+
+		assert.strictEqual(disposedInstances.length, 1, 'should dispose exactly one terminal');
+		assert.notStrictEqual(disposedInstances[0].instanceId, toolTerminal.instanceId, 'should not dispose the tool terminal');
+	});
+
+	test('does not background hidden tool terminals during session switch', async () => {
+		const cwd1 = URI.file('/cwd1');
+		const cwd2 = URI.file('/cwd2');
+
+		activeSessionObs.set(makeAgentSession({ worktree: cwd1, providerType: AgentSessionProviders.Background }), undefined);
+		await tick();
+
+		// Add a hidden tool terminal at cwd1
+		const toolTerminal = makeTerminalInstance(nextInstanceId++, cwd1.fsPath);
+		toolTerminal._testSetShellLaunchConfig({ hideFromUser: true } as ITerminalInstance['shellLaunchConfig']);
+		terminalInstances.set(toolTerminal.instanceId, toolTerminal);
+
+		// Switch to cwd2
+		activeSessionObs.set(makeAgentSession({ worktree: cwd2, providerType: AgentSessionProviders.Background }), undefined);
+		await tick();
+
+		assert.ok(!moveToBackgroundCalls.includes(toolTerminal.instanceId), 'hidden tool terminal should not be moved to background');
+	});
+
+	test('does not include hidden tool terminals in ensureTerminal matches', async () => {
+		const cwd = URI.file('/worktree');
+
+		// Add a hidden tool terminal at the target cwd
+		const toolTerminal = makeTerminalInstance(nextInstanceId++, cwd.fsPath);
+		toolTerminal._testSetShellLaunchConfig({ hideFromUser: true } as ITerminalInstance['shellLaunchConfig']);
+		terminalInstances.set(toolTerminal.instanceId, toolTerminal);
+
+		// ensureTerminal should not find the tool terminal, so it creates a new one
+		await contribution.ensureTerminal(cwd, false);
+
+		assert.strictEqual(createdTerminals.length, 1, 'should create a new terminal since tool terminal is hidden');
+	});
+
+	test('does not hide restored hidden tool terminals on session create', async () => {
+		activeSessionObs.set(makeAgentSession({ worktree: URI.file('/active'), providerType: AgentSessionProviders.Background }), undefined);
+		await tick();
+
+		const toolTerminal = makeTerminalInstance(nextInstanceId++, '/other');
+		toolTerminal._testSetShellLaunchConfig({
+			hideFromUser: true,
+			attachPersistentProcess: {} as never,
+		} as ITerminalInstance['shellLaunchConfig']);
+		terminalInstances.set(toolTerminal.instanceId, toolTerminal);
+
+		onDidCreateInstance.fire(toolTerminal);
+		await tick();
+
+		assert.ok(!moveToBackgroundCalls.includes(toolTerminal.instanceId), 'hidden tool terminal should not be moved to background on restore');
+	});
 });
 
 function tick(): Promise<void> {


### PR DESCRIPTION
Fixes that terminals spawned by run_in_terminal were being immediately closed in the agents window cc @benibenj

SessionsTerminalContribution was iterating all terminal instances including hidden ones created by run_in_terminal (hideFromUser: true). When a session was archived or the active session changed, _closeTerminalsForPath and _updateTerminalVisibility would dispose or background these tool terminals, causing "The terminal was closed" errors in the chat agent tool pipeline.

Skip hideFromUser terminals in _closeTerminalsForPath, _updateTerminalVisibility, _findTerminalsForKey, and the onDidCreateInstance handler. These terminals are managed by the chat tool lifecycle (RunInTerminalTool), not the session terminal contribution.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
