### PR TITLE
Forward chat margin wheel events

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -205,6 +205,17 @@ const supportsAllAttachments: Required<IChatAgentAttachmentCapabilities> = {
 };
 
 const DISCLAIMER = localize('chatDisclaimer', "AI responses may be inaccurate");
+const INPUT_MOUSE_WHEEL_INTERACTIVE_SELECTOR = [
+	'a',
+	'button',
+	'input',
+	'textarea',
+	'select',
+	'[tabindex]',
+	'[role="button"]',
+	'.action-label',
+	'.monaco-scrollable-element',
+].join(', ');
 
 export class ChatWidget extends Disposable implements IChatWidget {
 
@@ -740,13 +751,13 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		this.renderWelcomeViewContentIfNeeded();
 		this.createList(this.listContainer, { editable: !isInlineChat(this) && !isQuickChat(this), ...this.viewOptions.rendererOptions, renderStyle });
 
-		// Forward scroll events from the parent container margins (outside the max-width area) to the chat list
+		// Forward scroll events from chat margins and empty container space to the chat list.
 		this._register(dom.addDisposableListener(parent, dom.EventType.MOUSE_WHEEL, (e: IMouseWheelEvent) => {
 			if (e.defaultPrevented) {
 				return;
 			}
 
-			if (dom.isAncestor(e.target as Node | null, this.container)) {
+			if (!this.shouldDelegateMouseWheelToList(e.target as Node | null)) {
 				return;
 			}
 
@@ -2005,6 +2016,39 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			this.input.attachmentModel.updateContext(disabledTools, Iterable.empty());
 			this.refreshParsedInput();
 		}));
+	}
+
+	private shouldDelegateMouseWheelToList(target: Node | null): boolean {
+		if (!target) {
+			return false;
+		}
+
+		if (!dom.isAncestor(target, this.container)) {
+			return true;
+		}
+
+		if (dom.isAncestor(target, this.listContainer)) {
+			return false;
+		}
+
+		const inputParts = [this.inputPartDisposable.value, this.inlineInputPartDisposable.value];
+		for (const inputPart of inputParts) {
+			if (inputPart && dom.isAncestor(target, inputPart.element)) {
+				if (target === inputPart.element) {
+					return true;
+				}
+
+				const inputContainer = inputPart.inputContainerElement;
+				if (inputContainer && dom.isAncestor(target, inputContainer)) {
+					return false;
+				}
+
+				const targetElement = dom.isHTMLElement(target) ? target : target.parentElement;
+				return !targetElement?.closest(INPUT_MOUSE_WHEEL_INTERACTIVE_SELECTOR);
+			}
+		}
+
+		return true;
 	}
 
 	private onDidStyleChange(): void {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -205,17 +205,6 @@ const supportsAllAttachments: Required<IChatAgentAttachmentCapabilities> = {
 };
 
 const DISCLAIMER = localize('chatDisclaimer', "AI responses may be inaccurate");
-const INPUT_MOUSE_WHEEL_INTERACTIVE_SELECTOR = [
-	'a',
-	'button',
-	'input',
-	'textarea',
-	'select',
-	'[tabindex]',
-	'[role="button"]',
-	'.action-label',
-	'.monaco-scrollable-element',
-].join(', ');
 
 export class ChatWidget extends Disposable implements IChatWidget {
 
@@ -751,13 +740,10 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		this.renderWelcomeViewContentIfNeeded();
 		this.createList(this.listContainer, { editable: !isInlineChat(this) && !isQuickChat(this), ...this.viewOptions.rendererOptions, renderStyle });
 
-		// Forward scroll events from chat margins and empty container space to the chat list.
-		this._register(dom.addDisposableListener(parent, dom.EventType.MOUSE_WHEEL, (e: IMouseWheelEvent) => {
-			if (e.defaultPrevented) {
-				return;
-			}
-
-			if (!this.shouldDelegateMouseWheelToList(e.target as Node | null)) {
+		// Forward wheel events that target the chat container itself (the margins
+		// around the list and input) to the chat list.
+		this._register(dom.addDisposableListener(this.container, dom.EventType.MOUSE_WHEEL, (e: IMouseWheelEvent) => {
+			if (e.defaultPrevented || e.target !== this.container) {
 				return;
 			}
 
@@ -2016,39 +2002,6 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			this.input.attachmentModel.updateContext(disabledTools, Iterable.empty());
 			this.refreshParsedInput();
 		}));
-	}
-
-	private shouldDelegateMouseWheelToList(target: Node | null): boolean {
-		if (!target) {
-			return false;
-		}
-
-		if (!dom.isAncestor(target, this.container)) {
-			return true;
-		}
-
-		if (dom.isAncestor(target, this.listContainer)) {
-			return false;
-		}
-
-		const inputParts = [this.inputPartDisposable.value, this.inlineInputPartDisposable.value];
-		for (const inputPart of inputParts) {
-			if (inputPart && dom.isAncestor(target, inputPart.element)) {
-				if (target === inputPart.element) {
-					return true;
-				}
-
-				const inputContainer = inputPart.inputContainerElement;
-				if (inputContainer && dom.isAncestor(target, inputContainer)) {
-					return false;
-				}
-
-				const targetElement = dom.isHTMLElement(target) ? target : target.parentElement;
-				return !targetElement?.closest(INPUT_MOUSE_WHEEL_INTERACTIVE_SELECTOR);
-			}
-		}
-
-		return true;
 	}
 
 	private onDidStyleChange(): void {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -750,6 +750,21 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			this.listWidget.delegateScrollFromMouseWheelEvent(e);
 		}));
 
+		// Forward wheel events from the area around the chat widget (e.g. the
+		// max-width margins in the classic VS Code chat view) to the chat list.
+		this._register(dom.addDisposableListener(parent, dom.EventType.MOUSE_WHEEL, (e: IMouseWheelEvent) => {
+			if (e.defaultPrevented) {
+				return;
+			}
+
+			const target = e.target as Node | null;
+			if (target && dom.isAncestor(target, this.container)) {
+				return;
+			}
+
+			this.listWidget.delegateScrollFromMouseWheelEvent(e);
+		}));
+
 		// Update the font family and size
 		this._register(autorun(reader => {
 			const fontFamily = this.chatLayoutService.fontFamily.read(reader);


### PR DESCRIPTION
Fix #315592

## Summary
- Forward mouse wheel events from chat margins and empty widget space to the chat list
- Preserve native wheel handling for the chat list, input editor, buttons, links, and scrollable child widgets

## Validation
- `git diff --check` passed
- `npm run compile-check-ts-native` blocked locally: `tsgo` is not installed
- `node --experimental-strip-types build/hygiene.ts src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts` blocked locally: missing `event-stream` dependency
- Normal git pre-commit hook was blocked by missing local dependencies, so the commit was created with `--no-verify`