### PR TITLE
sessions: fix observable tracking and stale chat validation in navigation

### DIFF
--- a/src/vs/sessions/services/sessions/browser/sessionNavigation.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionNavigation.ts
@@ -78,10 +78,12 @@ export class SessionsNavigation extends Disposable {
 		this._register(autorun(reader => {
 			const activeSession = this._sessionsManagementService.activeSession.read(reader);
 			const activeChat = activeSession?.activeChat.read(reader);
+			const sessionStatus = activeSession?.status.read(reader);
+			const chatStatus = activeChat?.status.read(reader);
 			if (this._navigating) {
 				return;
 			}
-			if (!activeSession || activeSession.status.read(reader) === SessionStatus.Untitled) {
+			if (!activeSession || sessionStatus === SessionStatus.Untitled) {
 				// User navigated to new-session view: if we have history, remember we're
 				// beyond the stack so Back can return to the last real session.
 				if (this._history.length > 0) {
@@ -91,7 +93,7 @@ export class SessionsNavigation extends Disposable {
 			}
 
 			// Skip untitled chats (new-chat-in-session that hasn't been submitted)
-			const chatResource = activeChat && activeChat.status.read(reader) !== SessionStatus.Untitled
+			const chatResource = activeChat && chatStatus !== SessionStatus.Untitled
 				? activeChat.resource
 				: undefined;
 
@@ -185,7 +187,12 @@ export class SessionsNavigation extends Disposable {
 			const session = this._sessionsManagementService.getSession(entry.sessionResource);
 			if (session) {
 				if (entry.chatResource) {
-					await this._sessionsManagementService.openChat(session, entry.chatResource);
+					const chatExists = session.chats.get().some(c => c.resource.toString() === entry.chatResource!.toString());
+					if (chatExists) {
+						await this._sessionsManagementService.openChat(session, entry.chatResource);
+					} else {
+						await this._sessionsManagementService.openSession(entry.sessionResource);
+					}
 				} else {
 					await this._sessionsManagementService.openSession(entry.sessionResource);
 				}

--- a/src/vs/sessions/services/sessions/test/browser/sessionNavigation.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionNavigation.test.ts
@@ -463,4 +463,30 @@ suite('SessionsNavigation', () => {
 		store.setActiveSession(s1, chatUntitled);
 		assert.strictEqual(canGoBack(), false, 'untitled chat produces a session-only entry, no second entry');
 	});
+
+	test('goBack falls back to openSession when chat was deleted', async () => {
+		const chatA = stubChatWithId('a');
+		const chatB = stubChatWithId('b');
+		const chatsObs = observableValue<readonly IChat[]>('test.chats', [chatA, chatB]);
+		const s1: ISession = {
+			...stubSession('s1', SessionStatus.Completed, [chatA, chatB]),
+			chats: chatsObs,
+		};
+		const s2 = stubSession('s2');
+		store.addSession(s1);
+		store.addSession(s2);
+
+		// Record history: s1/chatA → s1/chatB → s2
+		store.setActiveSession(s1, chatA);
+		store.setActiveChat(chatB);
+		store.setActiveSession(s2);
+
+		// Remove chatB from the session
+		chatsObs.set([chatA], undefined);
+
+		// Go back — chatB is stale, should fall back to openSession(s1)
+		await nav.goBack();
+		assert.strictEqual(store.lastOpenedResource?.toString(), s1.resource.toString());
+		assert.strictEqual(store.lastOpenedChatResource, undefined, 'should not open a stale chat');
+	});
 });


### PR DESCRIPTION
Follow-up to #315626 — addresses two review comments.

## Fixes

### 1. Read all observables before `_navigating` guard
`activeSession.status` and `activeChat.status` were read after the `_navigating` early return. During navigation, the autorun would skip those reads and lose dependency tracking on status changes. Now `sessionStatus` and `chatStatus` are read upfront so the autorun keeps tracking status transitions (e.g. Untitled → Completed) even during navigation.

### 2. Validate chat still exists before opening
`_navigateTo` now checks that the `chatResource` still exists in `session.chats` before calling `openChat()`. If the chat was deleted after being recorded in history, it falls back to `openSession()` instead of trying to open a stale URI.