### PR TITLE
Refactor chat send button styles to use solid primary background

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/media/chatInput.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatInput.css
@@ -266,7 +266,7 @@
 /* Idle: solid primary button background. */
 .sessions-chat-send-button .monaco-button:not(.disabled) {
 	background: var(--vscode-button-background);
-	color: var(--vscode-button-foreground);
+	color: var(--vscode-button-foreground) !important;
 	transition: background-color 120ms ease;
 }
 

--- a/src/vs/sessions/contrib/chat/browser/media/chatInput.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatInput.css
@@ -196,53 +196,6 @@
 	gap: 4px;
 }
 
-/* Delightful gradient styling for the chat send (submit) button. The button
-	is filled at rest with a slowly rotating multi-color conic gradient using
-	the same palette as the working-state border, and emits a quick colorful
-	pulse on click. */
-@property --chat-send-button-anim-angle {
-	syntax: '<angle>';
-	inherits: false;
-	initial-value: 135deg;
-}
-
-@keyframes chat-send-button-spin {
-	from {
-		--chat-send-button-anim-angle: 135deg;
-	}
-
-	to {
-		--chat-send-button-anim-angle: 495deg;
-	}
-}
-
-@keyframes chat-send-button-color-cycle {
-	0%,
-	100% {
-		background-color: color-mix(in srgb, var(--vscode-chat-inputWorkingBorderColor1) 60%, var(--vscode-input-background));
-	}
-
-	33% {
-		background-color: color-mix(in srgb, var(--vscode-chat-inputWorkingBorderColor2) 60%, var(--vscode-input-background));
-	}
-
-	66% {
-		background-color: color-mix(in srgb, var(--vscode-chat-inputWorkingBorderColor3) 60%, var(--vscode-input-background));
-	}
-}
-
-@keyframes chat-send-button-pulse {
-	0% {
-		opacity: 0.7;
-		transform: scale(1);
-	}
-
-	100% {
-		opacity: 0;
-		transform: scale(1.3);
-	}
-}
-
 /* Send button - wraps a Button widget */
 .sessions-chat-send-button {
 	display: flex;
@@ -310,54 +263,16 @@
 	text-decoration: none !important;
 }
 
-/* Idle: fill the entire button with a slowly rotating conic gradient (no
-	border ring).
-
-	Colors are darkened (60% mixed with input background) so the gradient
-	reads as a calm fill rather than a saturated accent, and the conic stops
-	are asymmetric so the fill has a clear head and tail rather than
-	mirroring around the mid-point. */
+/* Idle: solid primary button background. */
 .sessions-chat-send-button .monaco-button:not(.disabled) {
-	background: conic-gradient(from var(--chat-send-button-anim-angle) at 0% 0%,
-			color-mix(in srgb, var(--vscode-chat-inputWorkingBorderColor1) 60%, var(--vscode-input-background)) 0deg,
-			color-mix(in srgb, var(--vscode-chat-inputWorkingBorderColor2) 60%, var(--vscode-input-background)) 90deg,
-			color-mix(in srgb, var(--vscode-chat-inputWorkingBorderColor3) 60%, var(--vscode-input-background)) 200deg,
-			color-mix(in srgb, var(--vscode-chat-inputWorkingBorderColor1) 60%, var(--vscode-input-background)) 360deg);
+	background: var(--vscode-button-background);
 	color: var(--vscode-button-foreground);
-	animation: chat-send-button-spin 8s linear infinite;
-	transition: box-shadow 120ms ease;
+	transition: background-color 120ms ease;
 }
 
-/* Hover/focus: subtle dark overlay to match standard toolbar button hover
-	feedback. Uses an inset box-shadow so the rotating gradient background is
-	preserved underneath. */
 .sessions-chat-send-button:has(.monaco-button:not(.disabled):hover) .monaco-button,
 .sessions-chat-send-button:has(.monaco-button:not(.disabled):focus-visible) .monaco-button {
-	box-shadow: inset 0 0 0 100px rgba(0, 0, 0, 0.12);
-}
-
-/* Click: outward color pulse on the wrapper. */
-.sessions-chat-send-button:has(.monaco-button:not(.disabled):active)::after {
-	content: '';
-	position: absolute;
-	inset: -2px;
-	border-radius: 50%;
-	background: conic-gradient(from 135deg,
-			var(--vscode-chat-inputWorkingBorderColor1),
-			var(--vscode-chat-inputWorkingBorderColor2),
-			var(--vscode-chat-inputWorkingBorderColor3),
-			var(--vscode-chat-inputWorkingBorderColor2),
-			var(--vscode-chat-inputWorkingBorderColor1));
-	pointer-events: none;
-	animation: chat-send-button-pulse 400ms ease-out forwards;
-	z-index: 0;
-}
-
-@media (prefers-reduced-motion: reduce) {
-	.sessions-chat-send-button .monaco-button:not(.disabled),
-	.sessions-chat-send-button:has(.monaco-button:not(.disabled):active)::after {
-		animation: none;
-	}
+	background: var(--vscode-button-hoverBackground);
 }
 
 /* Loading spinner in toolbar */

--- a/src/vs/sessions/contrib/chat/browser/media/chatInputMobile.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatInputMobile.css
@@ -50,8 +50,3 @@
 	border-radius: 50%;
 	margin-bottom: 18px;
 }
-
-/* Keep the active-state pulse concentric with the larger phone button. */
-.agent-sessions-workbench.phone-layout .sessions-chat-send-button:has(.monaco-button:not(.disabled):active)::after {
-	border-radius: 50%;
-}

--- a/src/vs/sessions/contrib/chat/browser/media/chatInputMobile.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatInputMobile.css
@@ -32,8 +32,8 @@
 	padding-bottom: 6px;
 }
 
-/* The send button on phone grows to a 36×36 circle with the same accent
- * gradient fill as the desktop button. The wrapper and inner Button
+/* The send button on phone grows to a 36×36 circle with the same solid
+ * primary button fill as the desktop button. The wrapper and inner Button
  * widget both grow so the focus outline (drawn on the wrapper) and
  * the click target (the wrapper's `:has(...)` rules) align with the
  * circular pill. */

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -1042,43 +1042,6 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	order: 2;
 }
 
-/* ----------------------------------------------------------------------------
-	Delightful gradient styling for the chat send (submit) button. The arrow-up
-	action-item is filled at rest with a slowly rotating multi-color conic
-	gradient using the same palette as the working-state border, and emits a
-	quick colorful pulse on click. The gradient is naturally absent while a
-	request is in flight: `ChatSubmitAction.menu` is gated on
-	`whenNoActiveRequest`, so during an active request the arrow-up icon is
-	removed entirely from the toolbar and replaced by the Cancel/Stop action.
-	---------------------------------------------------------------------------- */
-@property --chat-send-button-anim-angle {
-	syntax: '<angle>';
-	inherits: false;
-	initial-value: 135deg;
-}
-
-@keyframes chat-send-button-spin {
-	from {
-		--chat-send-button-anim-angle: 135deg;
-	}
-
-	to {
-		--chat-send-button-anim-angle: 495deg;
-	}
-}
-
-@keyframes chat-send-button-pulse {
-	0% {
-		opacity: 0.7;
-		transform: scale(1);
-	}
-
-	100% {
-		opacity: 0;
-		transform: scale(1.3);
-	}
-}
-
 .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:has(> .action-label.codicon-arrow-up) {
 	position: relative;
 	border-radius: 5px;
@@ -1109,55 +1072,19 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	outline: none;
 }
 
-/* Idle: fill the entire action-label with a slowly rotating conic gradient.
-	Colors darkened (60% mixed with input background) for a calm fill, with
-	asymmetric conic stops. */
+/* Idle: solid primary button background. */
 .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:not(.disabled) > .action-label.codicon-arrow-up {
-	background: conic-gradient(from var(--chat-send-button-anim-angle) at 0% 0%,
-			color-mix(in srgb, var(--vscode-chat-inputWorkingBorderColor1) 60%, var(--vscode-input-background)) 0deg,
-			color-mix(in srgb, var(--vscode-chat-inputWorkingBorderColor2) 60%, var(--vscode-input-background)) 90deg,
-			color-mix(in srgb, var(--vscode-chat-inputWorkingBorderColor3) 60%, var(--vscode-input-background)) 200deg,
-			color-mix(in srgb, var(--vscode-chat-inputWorkingBorderColor1) 60%, var(--vscode-input-background)) 360deg) !important;
+	background: var(--vscode-button-background) !important;
 	color: var(--vscode-button-foreground) !important;
 	border-radius: 5px;
-	animation: chat-send-button-spin 8s linear infinite;
-	transition: box-shadow 120ms ease;
-	/* Lift the label above the click pulse `::after` on the action-item parent
-		so the pulse appears to expand from behind the button, not on top of it. */
+	transition: background-color 120ms ease;
 	position: relative;
 	z-index: 1;
 }
 
-/* Hover/focus: subtle dark overlay to match standard toolbar button hover
-	feedback. Uses an inset box-shadow so the rotating gradient background is
-	preserved underneath. */
 .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:not(.disabled) > .action-label.codicon-arrow-up:hover,
 .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:not(.disabled) > .action-label.codicon-arrow-up:focus-visible {
-	box-shadow: inset 0 0 0 100px rgba(0, 0, 0, 0.12);
-}
-
-.interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:not(.disabled):has(> .action-label.codicon-arrow-up:active)::after {
-	content: '';
-	position: absolute;
-	inset: -2px;
-	border-radius: 7px;
-	background: conic-gradient(from 135deg,
-			var(--vscode-chat-inputWorkingBorderColor1),
-			var(--vscode-chat-inputWorkingBorderColor2),
-			var(--vscode-chat-inputWorkingBorderColor3),
-			var(--vscode-chat-inputWorkingBorderColor2),
-			var(--vscode-chat-inputWorkingBorderColor1));
-	pointer-events: none;
-	animation: chat-send-button-pulse 400ms ease-out forwards;
-	z-index: 0;
-}
-
-@media (prefers-reduced-motion: reduce) {
-
-	.interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:not(.disabled) > .action-label.codicon-arrow-up,
-	.interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:not(.disabled):has(> .action-label.codicon-arrow-up:active)::after {
-		animation: none;
-	}
+	background: var(--vscode-button-hoverBackground) !important;
 }
 
 .interactive-input-part:has(.chat-editing-session > .chat-editing-session-container) .chat-input-container,

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -1074,17 +1074,15 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 /* Idle: solid primary button background. */
 .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:not(.disabled) > .action-label.codicon-arrow-up {
-	background: var(--vscode-button-background) !important;
+	background: var(--vscode-button-background);
 	color: var(--vscode-button-foreground) !important;
 	border-radius: 5px;
 	transition: background-color 120ms ease;
-	position: relative;
-	z-index: 1;
 }
 
 .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:not(.disabled) > .action-label.codicon-arrow-up:hover,
 .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:not(.disabled) > .action-label.codicon-arrow-up:focus-visible {
-	background: var(--vscode-button-hoverBackground) !important;
+	background: var(--vscode-button-hoverBackground);
 }
 
 .interactive-input-part:has(.chat-editing-session > .chat-editing-session-container) .chat-input-container,


### PR DESCRIPTION
Update chat send button styles to replace the gradient background with a solid primary color for a more consistent appearance across platforms. This change enhances the visual clarity and usability of the button.

Addresses: https://github.com/microsoft/vscode/issues/315229, https://github.com/microsoft/vscode/issues/315038

