### PR TITLE
Open markdown files by default in the Agents window

### DIFF
--- a/src/vs/sessions/services/configuration/test/browser/configurationService.test.ts
+++ b/src/vs/sessions/services/configuration/test/browser/configurationService.test.ts
@@ -78,6 +78,12 @@ suite('Sessions ConfigurationService', () => {
 					scope: ConfigurationScope.RESOURCE,
 					agentsWindow: { default: true }
 				},
+				'sessionsConfigurationService.agentsWindowObjectDefault': {
+					'type': 'object',
+					'default': {},
+					scope: ConfigurationScope.RESOURCE,
+					agentsWindow: { default: { '*.md': 'vscode.markdown.preview.editor' } }
+				},
 			}
 		});
 	});
@@ -456,6 +462,27 @@ suite('Sessions ConfigurationService', () => {
 
 	test('agentsWindow.default with boolean value', () => {
 		assert.strictEqual(testObject.getValue('sessionsConfigurationService.agentsWindowDefaultOnly'), true);
+	});
+
+	test('agentsWindow.default with object value', () => {
+		assert.deepStrictEqual(testObject.getValue('sessionsConfigurationService.agentsWindowObjectDefault'), { '*.md': 'vscode.markdown.preview.editor' });
+	});
+
+	test('agentsWindow.default with object value survives schema re-registration', () => {
+		const node = {
+			'id': '_test_sessions_object_reregister',
+			'type': 'object' as const,
+			'properties': {
+				'sessionsConfigurationService.agentsWindowObjectDefault': {
+					'type': 'object' as const,
+					'default': {},
+					scope: ConfigurationScope.RESOURCE,
+					agentsWindow: { default: { '*.md': 'vscode.markdown.preview.editor' } }
+				},
+			}
+		};
+		configurationRegistry.updateConfigurations({ add: [node], remove: [node] });
+		assert.deepStrictEqual(testObject.getValue('sessionsConfigurationService.agentsWindowObjectDefault'), { '*.md': 'vscode.markdown.preview.editor' });
 	});
 
 	test('agentsWindow.readOnly setting uses overridden default', () => {

--- a/src/vs/workbench/browser/parts/editor/editorConfiguration.ts
+++ b/src/vs/workbench/browser/parts/editor/editorConfiguration.ts
@@ -9,7 +9,7 @@ import { IWorkbenchContribution } from '../../../common/contributions.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { IConfigurationRegistry, Extensions as ConfigurationExtensions, IConfigurationNode, ConfigurationScope } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { workbenchConfigurationNodeBase } from '../../../common/configuration.js';
-import { diffEditorsAssociationsSettingId, editorsAssociationsSettingId, IEditorResolverService, RegisteredEditorInfo, RegisteredEditorPriority } from '../../../services/editor/common/editorResolverService.js';
+import { diffEditorsAssociationsSettingId, editorsAssociationsAgentsWindowDefault, editorsAssociationsSettingId, IEditorResolverService, RegisteredEditorInfo, RegisteredEditorPriority } from '../../../services/editor/common/editorResolverService.js';
 import { IJSONSchemaMap } from '../../../../base/common/jsonSchema.js';
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
 import { coalesce } from '../../../../base/common/arrays.js';
@@ -161,6 +161,9 @@ export class DynamicEditorConfigurations extends Disposable implements IWorkbenc
 							type: 'string',
 							enum: binaryEditorCandidates,
 						}
+					},
+					agentsWindow: {
+						default: editorsAssociationsAgentsWindowDefault
 					}
 				}
 			}

--- a/src/vs/workbench/services/editor/common/editorResolverService.ts
+++ b/src/vs/workbench/services/editor/common/editorResolverService.ts
@@ -37,6 +37,14 @@ export type EditorAssociations = readonly EditorAssociation[];
 export const editorsAssociationsSettingId = 'workbench.editorAssociations';
 export const diffEditorsAssociationsSettingId = 'workbench.diffEditorAssociations';
 
+/**
+ * Default value for `workbench.editorAssociations` in the Agents window.
+ * Shared so that dynamic re-registrations of the setting preserve the override.
+ */
+export const editorsAssociationsAgentsWindowDefault: Readonly<Record<string, string>> = Object.freeze({
+	'*.md': 'vscode.markdown.preview.editor'
+});
+
 const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
 
 const editorAssociationsConfigurationNode: IConfigurationNode = {
@@ -47,6 +55,9 @@ const editorAssociationsConfigurationNode: IConfigurationNode = {
 			markdownDescription: localize('editor.editorAssociations', "Configure [glob patterns](https://aka.ms/vscode-glob-patterns) to editors (for example `\"*.hex\": \"hexEditor.hexedit\"`). These have precedence over the default behavior."),
 			additionalProperties: {
 				type: 'string'
+			},
+			agentsWindow: {
+				default: editorsAssociationsAgentsWindowDefault
 			}
 		},
 		[diffEditorsAssociationsSettingId]: {


### PR DESCRIPTION
```Copilot Generated Description:``` Configure the Agents window to open markdown files by default using the `vscode.markdown.preview.editor`. This change includes updates to the configuration service and editor resolver to support this default behavior.

