### PR TITLE
Update @vscode/codicons version to 0.0.46-8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@microsoft/dev-tunnels-ssh-tcp": "^3.12.22",
         "@parcel/watcher": "^2.5.6",
         "@types/semver": "^7.5.8",
-        "@vscode/codicons": "^0.0.46-6",
+        "@vscode/codicons": "^0.0.46-8",
         "@vscode/copilot-api": "^0.3.0",
         "@vscode/deviceid": "^0.1.1",
         "@vscode/iconv-lite-umd": "0.7.1",
@@ -3565,9 +3565,9 @@
       }
     },
     "node_modules/@vscode/codicons": {
-      "version": "0.0.46-6",
-      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-6.tgz",
-      "integrity": "sha512-tuTuuWUmV5nJNCK4xEg7gZzj/3WDlkU4czFZ11UyDb/FetWaj1uvDB6xV9488F/ZY8won8OO3QYGaVif40LEWA==",
+      "version": "0.0.46-8",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-8.tgz",
+      "integrity": "sha512-/8S3lORaKFGHvCW/VmPFrMu0l4aoONqbpvR6Y1NWdY18c1qwYcp1pADdfFUawZNe8wXfKHNJBvmG8NHm67VyUA==",
       "license": "CC-BY-4.0"
     },
     "node_modules/@vscode/component-explorer": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@microsoft/dev-tunnels-ssh-tcp": "^3.12.22",
     "@parcel/watcher": "^2.5.6",
     "@types/semver": "^7.5.8",
-    "@vscode/codicons": "^0.0.46-6",
+    "@vscode/codicons": "^0.0.46-8",
     "@vscode/copilot-api": "^0.3.0",
     "@vscode/deviceid": "^0.1.1",
     "@vscode/iconv-lite-umd": "0.7.1",

--- a/remote/web/package-lock.json
+++ b/remote/web/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
-        "@vscode/codicons": "^0.0.46-6",
+        "@vscode/codicons": "^0.0.46-8",
         "@vscode/iconv-lite-umd": "0.7.1",
         "@vscode/tree-sitter-wasm": "^0.3.1",
         "@vscode/vscode-languagedetection": "1.0.23",
@@ -73,9 +73,9 @@
       "integrity": "sha512-n1VPsljTSkthsAFYdiWfC+DKzK2WwcRp83Y1YAqdX552BstvsDjft9YXppjUzp11BPsapDoO1LDgrDB0XVsfNQ=="
     },
     "node_modules/@vscode/codicons": {
-      "version": "0.0.46-6",
-      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-6.tgz",
-      "integrity": "sha512-tuTuuWUmV5nJNCK4xEg7gZzj/3WDlkU4czFZ11UyDb/FetWaj1uvDB6xV9488F/ZY8won8OO3QYGaVif40LEWA==",
+      "version": "0.0.46-8",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-8.tgz",
+      "integrity": "sha512-/8S3lORaKFGHvCW/VmPFrMu0l4aoONqbpvR6Y1NWdY18c1qwYcp1pADdfFUawZNe8wXfKHNJBvmG8NHm67VyUA==",
       "license": "CC-BY-4.0"
     },
     "node_modules/@vscode/iconv-lite-umd": {

--- a/remote/web/package.json
+++ b/remote/web/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",
-    "@vscode/codicons": "^0.0.46-6",
+    "@vscode/codicons": "^0.0.46-8",
     "@vscode/iconv-lite-umd": "0.7.1",
     "@vscode/tree-sitter-wasm": "^0.3.1",
     "@vscode/vscode-languagedetection": "1.0.23",


### PR DESCRIPTION
Upgrade the @vscode/codicons package to version 0.0.46-8 in both package.json and package-lock.json files to ensure compatibility and access to the latest features. No issues are associated with this update.

