### PR TITLE
Ship stable symbol tool descriptions

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -401,15 +401,6 @@ configurationRegistry.registerConfiguration({
 			default: 'word',
 			tags: ['experimental'],
 		},
-		[ChatConfiguration.SymbolToolsCacheStable]: {
-			type: 'boolean',
-			description: nls.localize('chat.experimental.symbolTools.cacheStable', "When enabled, the rename and list-code-usages tools are always registered with a static description (no per-language list). Stabilizes the tools-array bytes across requests so prompt caches survive language-extension activations mid-turn. Tool behavior is unchanged: unsupported languages still produce an error at invocation time."),
-			default: false,
-			tags: ['experimental'],
-			experiment: {
-				mode: 'startup'
-			}
-		},
 		'chat.detectParticipant.enabled': {
 			type: 'boolean',
 			description: nls.localize('chat.detectParticipant.enabled', "Enables chat participant autodetection for panel chat."),

--- a/src/vs/workbench/contrib/chat/browser/tools/renameTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/renameTool.ts
@@ -5,9 +5,8 @@
 
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
-import { Emitter, Event } from '../../../../../base/common/event.js';
 import { MarkdownString } from '../../../../../base/common/htmlContent.js';
-import { Disposable, IDisposable } from '../../../../../base/common/lifecycle.js';
+import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { ResourceMap, ResourceSet } from '../../../../../base/common/map.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { Position } from '../../../../../editor/common/core/position.js';
@@ -15,16 +14,13 @@ import { TextEdit } from '../../../../../editor/common/languages.js';
 import { IBulkEditService, ResourceTextEdit } from '../../../../../editor/browser/services/bulkEditService.js';
 import { ILanguageFeaturesService } from '../../../../../editor/common/services/languageFeatures.js';
 import { ITextModelService } from '../../../../../editor/common/services/resolverService.js';
-import { ILanguageService } from '../../../../../editor/common/languages/language.js';
 import { rename } from '../../../../../editor/contrib/rename/browser/rename.js';
 import { localize } from '../../../../../nls.js';
-import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { IWorkbenchContribution } from '../../../../common/contributions.js';
 import { IChatService } from '../../common/chatService/chatService.js';
-import { ChatConfiguration } from '../../common/constants.js';
 import { ChatModel } from '../../common/model/chatModel.js';
 import { CountTokensCallback, ILanguageModelToolsService, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolInvocationPreparationContext, IToolResult, ToolDataSource, ToolProgress } from '../../common/tools/languageModelToolsService.js';
 import { createToolSimpleTextResult } from '../../common/tools/builtinTools/toolHelpers.js';
@@ -50,11 +46,9 @@ IMPORTANT: The file and line do NOT need to be the definition of the symbol. Any
 If the tool returns an error, retry with corrected input - ensure the file path is correct, the line content matches the actual file content, and the symbol name appears in that line.`;
 
 /**
- * Static description used when the {@link ChatConfiguration.SymbolToolsCacheStable}
- * experiment is enabled. Identical to {@link BaseModelDescription} plus a single
- * sentence describing the unsupported-language behavior. Crucially, this string
- * does NOT depend on the set of registered rename providers, so it stays
- * byte-stable across requests as language extensions activate during a turn.
+ * Static description that does not depend on the set of registered rename
+ * providers, so it stays byte-stable across requests as language extensions
+ * activate during a turn.
  */
 const StaticModelDescription = BaseModelDescription + `
 
@@ -62,63 +56,17 @@ If the file's language has no rename provider registered, the tool returns an er
 
 export class RenameTool extends Disposable implements IToolImpl {
 
-	private readonly _onDidUpdateToolData = this._store.add(new Emitter<void>());
-	readonly onDidUpdateToolData = this._onDidUpdateToolData.event;
-
 	constructor(
 		@ILanguageFeaturesService private readonly _languageFeaturesService: ILanguageFeaturesService,
-		@ILanguageService private readonly _languageService: ILanguageService,
 		@ITextModelService private readonly _textModelService: ITextModelService,
 		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
 		@IChatService private readonly _chatService: IChatService,
 		@IBulkEditService private readonly _bulkEditService: IBulkEditService,
-		@IConfigurationService private readonly _configurationService: IConfigurationService,
 	) {
 		super();
-
-		// In cache-stable mode the tool's wire bytes don't depend on the set
-		// of registered rename providers, so we don't need to re-fire the
-		// update event on provider changes. Skipping this subscription
-		// avoids unnecessary tool re-registration churn as well.
-		if (!this._isCacheStable()) {
-			this._store.add(Event.debounce(
-				this._languageFeaturesService.renameProvider.onDidChange,
-				() => { },
-				2000
-			)((() => this._onDidUpdateToolData.fire())));
-		}
 	}
 
-	private _isCacheStable(): boolean {
-		return this._configurationService.getValue<boolean>(ChatConfiguration.SymbolToolsCacheStable) === true;
-	}
-
-	getToolData(): IToolData | undefined {
-		if (this._isCacheStable()) {
-			return this._getStaticToolData();
-		}
-
-		const languageIds = this._languageFeaturesService.renameProvider.registeredLanguageIds;
-
-		if (languageIds.size === 0) {
-			return undefined;
-		}
-
-		let modelDescription = BaseModelDescription;
-		let userDescription: string;
-		if (languageIds.has('*')) {
-			modelDescription += '\n\nSupported for all languages.';
-			userDescription = localize('tool.rename.userDescription', 'Rename a symbol across the workspace');
-		} else {
-			const sorted = [...languageIds].sort();
-			modelDescription += `\n\nCurrently supported for: ${sorted.join(', ')}.`;
-			const niceNames = sorted.map(id => this._languageService.getLanguageName(id) ?? id);
-			userDescription = localize('tool.rename.userDescriptionWithLanguages', 'Rename a symbol across the workspace ({0})', niceNames.join(', '));
-		}
-		return this._buildToolData(modelDescription, userDescription);
-	}
-
-	private _getStaticToolData(): IToolData {
+	getToolData(): IToolData {
 		return this._buildToolData(
 			StaticModelDescription,
 			localize('tool.rename.userDescription', 'Rename a symbol across the workspace'),
@@ -293,23 +241,6 @@ export class RenameToolContribution extends Disposable implements IWorkbenchCont
 		super();
 
 		const renameTool = this._store.add(instantiationService.createInstance(RenameTool));
-
-		let registration: IDisposable | undefined;
-		const registerRenameTool = () => {
-			registration?.dispose();
-			registration = undefined;
-			toolsService.flushToolUpdates();
-			const toolData = renameTool.getToolData();
-			if (toolData) {
-				registration = toolsService.registerTool(toolData, renameTool);
-			}
-		};
-		registerRenameTool();
-		this._store.add(renameTool.onDidUpdateToolData(registerRenameTool));
-		this._store.add({
-			dispose: () => {
-				registration?.dispose();
-			}
-		});
+		this._store.add(toolsService.registerTool(renameTool.getToolData(), renameTool));
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/tools/usagesTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/usagesTool.ts
@@ -5,10 +5,9 @@
 
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
-import { Emitter, Event } from '../../../../../base/common/event.js';
 import { MarkdownString } from '../../../../../base/common/htmlContent.js';
 import { escapeRegExpCharacters } from '../../../../../base/common/strings.js';
-import { Disposable, IDisposable } from '../../../../../base/common/lifecycle.js';
+import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { ResourceSet } from '../../../../../base/common/map.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { isEqual, relativePath } from '../../../../../base/common/resources.js';
@@ -18,16 +17,13 @@ import { Location, LocationLink } from '../../../../../editor/common/languages.j
 import { IModelService } from '../../../../../editor/common/services/model.js';
 import { ILanguageFeaturesService } from '../../../../../editor/common/services/languageFeatures.js';
 import { ITextModelService } from '../../../../../editor/common/services/resolverService.js';
-import { ILanguageService } from '../../../../../editor/common/languages/language.js';
 import { getDefinitionsAtPosition, getImplementationsAtPosition, getReferencesAtPosition } from '../../../../../editor/contrib/gotoSymbol/browser/goToSymbol.js';
 import { localize } from '../../../../../nls.js';
-import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { IWorkbenchContribution } from '../../../../common/contributions.js';
 import { ISearchService, QueryType, resultIsMatch } from '../../../../services/search/common/search.js';
-import { ChatConfiguration } from '../../common/constants.js';
 import { CountTokensCallback, ILanguageModelToolsService, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolInvocationPreparationContext, IToolResult, ToolDataSource, ToolProgress, } from '../../common/tools/languageModelToolsService.js';
 import { createToolSimpleTextResult } from '../../common/tools/builtinTools/toolHelpers.js';
 import { errorResult, findLineNumber, findSymbolColumn, ISymbolToolInput, resolveToolUri } from './toolHelpers.js';
@@ -47,11 +43,9 @@ IMPORTANT: The file and line do NOT need to be the definition of the symbol. Any
 If the tool returns an error, retry with corrected input - ensure the file path is correct, the line content matches the actual file content, and the symbol name appears in that line.`;
 
 /**
- * Static description used when the {@link ChatConfiguration.SymbolToolsCacheStable}
- * experiment is enabled. Identical to {@link BaseModelDescription} plus a single
- * sentence describing the unsupported-language behavior. Crucially, this string
- * does NOT depend on the set of registered reference providers, so it stays
- * byte-stable across requests as language extensions activate during a turn.
+ * Static description that does not depend on the set of registered reference
+ * providers, so it stays byte-stable across requests as language extensions
+ * activate during a turn.
  */
 const StaticModelDescription = BaseModelDescription + `
 
@@ -59,64 +53,17 @@ If the file's language has no reference provider registered, the tool returns an
 
 export class UsagesTool extends Disposable implements IToolImpl {
 
-	private readonly _onDidUpdateToolData = this._store.add(new Emitter<void>());
-	readonly onDidUpdateToolData = this._onDidUpdateToolData.event;
-
 	constructor(
 		@ILanguageFeaturesService private readonly _languageFeaturesService: ILanguageFeaturesService,
-		@ILanguageService private readonly _languageService: ILanguageService,
 		@IModelService private readonly _modelService: IModelService,
 		@ISearchService private readonly _searchService: ISearchService,
 		@ITextModelService private readonly _textModelService: ITextModelService,
 		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
-		@IConfigurationService private readonly _configurationService: IConfigurationService,
 	) {
 		super();
-
-		// In cache-stable mode the tool's wire bytes don't depend on the set
-		// of registered reference providers, so we don't re-fire the update
-		// event on provider changes. Skipping this subscription also avoids
-		// unnecessary tool re-registration churn.
-		if (!this._isCacheStable()) {
-			this._store.add(Event.debounce(
-				this._languageFeaturesService.referenceProvider.onDidChange,
-				() => { },
-				2000
-			)((() => this._onDidUpdateToolData.fire())));
-		}
 	}
 
-	private _isCacheStable(): boolean {
-		return this._configurationService.getValue<boolean>(ChatConfiguration.SymbolToolsCacheStable) === true;
-	}
-
-	getToolData(): IToolData | undefined {
-		if (this._isCacheStable()) {
-			return this._getStaticToolData();
-		}
-
-		const languageIds = this._languageFeaturesService.referenceProvider.registeredLanguageIds;
-
-		if (languageIds.size === 0) {
-			return undefined;
-		}
-
-		let modelDescription = BaseModelDescription;
-		let userDescription: string;
-		if (languageIds.has('*')) {
-			modelDescription += '\n\nSupported for all languages.';
-			userDescription = localize('tool.usages.userDescription', 'Find references, definitions, and implementations of a symbol');
-		} else {
-			const sorted = [...languageIds].sort();
-			modelDescription += `\n\nCurrently supported for: ${sorted.join(', ')}.`;
-			const niceNames = sorted.map(id => this._languageService.getLanguageName(id) ?? id);
-			userDescription = localize('tool.usages.userDescriptionWithLanguages', 'Find references, definitions, and implementations of a symbol ({0})', niceNames.join(', '));
-		}
-
-		return this._buildToolData(modelDescription, userDescription);
-	}
-
-	private _getStaticToolData(): IToolData {
+	getToolData(): IToolData {
 		return this._buildToolData(
 			StaticModelDescription,
 			localize('tool.usages.userDescription', 'Find references, definitions, and implementations of a symbol'),
@@ -363,19 +310,6 @@ export class UsagesToolContribution extends Disposable implements IWorkbenchCont
 		super();
 
 		const usagesTool = this._store.add(instantiationService.createInstance(UsagesTool));
-
-		let registration: IDisposable | undefined;
-		const registerUsagesTool = () => {
-			registration?.dispose();
-			registration = undefined;
-			toolsService.flushToolUpdates();
-			const toolData = usagesTool.getToolData();
-			if (toolData) {
-				registration = toolsService.registerTool(toolData, usagesTool);
-			}
-		};
-		registerUsagesTool();
-		this._store.add(usagesTool.onDidUpdateToolData(registerUsagesTool));
-		this._store.add({ dispose: () => registration?.dispose() });
+		this._store.add(toolsService.registerTool(usagesTool.getToolData(), usagesTool));
 	}
 }

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -85,17 +85,6 @@ export enum ChatConfiguration {
 	IncrementalRendering = 'chat.experimental.incrementalRendering.enabled',
 	IncrementalRenderingStyle = 'chat.experimental.incrementalRendering.animationStyle',
 	IncrementalRenderingBuffering = 'chat.experimental.incrementalRendering.buffering',
-
-	/**
-	 * When enabled, `vscode_renameSymbol` and `vscode_listCodeUsages` are always
-	 * registered with a static, language-list-free description. This makes the
-	 * tools array byte-stable across rounds even as language extensions activate
-	 * mid-turn, which significantly improves prompt-cache hit rates on agent
-	 * conversations. Behavior is unchanged: the tools still error on
-	 * unsupported languages at invocation time. Behind an A/B flag for
-	 * controlled rollout.
-	 */
-	SymbolToolsCacheStable = 'chat.experimental.symbolTools.cacheStable',
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/test/browser/tools/renameTool.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/tools/renameTool.test.ts
@@ -12,13 +12,10 @@ import { RenameProvider, WorkspaceEdit, Rejection } from '../../../../../../edit
 import { IMarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { LanguageFeaturesService } from '../../../../../../editor/common/services/languageFeaturesService.js';
 import { ITextModelService } from '../../../../../../editor/common/services/resolverService.js';
-import { ILanguageService } from '../../../../../../editor/common/languages/language.js';
 import { createTextModel } from '../../../../../../editor/test/common/testTextModel.js';
 import { IWorkspaceContextService, IWorkspaceFolder } from '../../../../../../platform/workspace/common/workspace.js';
 import { IBulkEditService, IBulkEditResult } from '../../../../../../editor/browser/services/bulkEditService.js';
-import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { RenameTool } from '../../../browser/tools/renameTool.js';
-import { ChatConfiguration } from '../../../common/constants.js';
 import { IChatService } from '../../../common/chatService/chatService.js';
 import { IToolInvocation, IToolResult, IToolResultTextPart, ToolProgress } from '../../../common/tools/languageModelToolsService.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
@@ -103,19 +100,13 @@ suite('RenameTool', () => {
 	const noopCountTokens = async () => 0;
 	const noopProgress: ToolProgress = { report() { } };
 
-	function createMockLanguageService(): ILanguageService {
-		return { getLanguageName: (id: string) => id } as unknown as ILanguageService;
-	}
-
-	function createTool(textModelService: ITextModelService, options?: { bulkEditService?: IBulkEditService; configurationService?: TestConfigurationService }): RenameTool {
+	function createTool(textModelService: ITextModelService, options?: { bulkEditService?: IBulkEditService }): RenameTool {
 		return new RenameTool(
 			langFeatures,
-			createMockLanguageService(),
 			textModelService,
 			createMockWorkspaceService(),
 			createMockChatService(),
 			options?.bulkEditService ?? createMockBulkEditService(),
-			options?.configurationService ?? new TestConfigurationService(),
 		);
 	}
 
@@ -131,77 +122,42 @@ suite('RenameTool', () => {
 
 	suite('getToolData', () => {
 
-		test('reports no providers when none registered', () => {
+		test('returns tool data when no providers are registered', () => {
 			const tool = disposables.add(createTool(createMockTextModelService(null!)));
-			assert.strictEqual(tool.getToolData(), undefined);
+			assert.ok(tool.getToolData());
 		});
 
-		test('lists registered language ids', () => {
+		test('description does not include a per-language list', () => {
 			const model = disposables.add(createTextModel('', 'typescript', undefined, testUri));
 			const tool = disposables.add(createTool(createMockTextModelService(model)));
 			disposables.add(langFeatures.renameProvider.register('typescript', {
 				provideRenameEdits: () => ({ edits: [] }),
 			}));
 			const data = tool.getToolData();
-			assert.ok(data?.modelDescription.includes('typescript'));
+			assert.ok(!data.modelDescription.includes('Currently supported for'),
+				`expected modelDescription to not list languages, got: ${data.modelDescription}`);
+			assert.ok(!data.modelDescription.includes('typescript'),
+				'expected modelDescription to not include any specific language id');
+			assert.ok(!data.modelDescription.includes('all languages'),
+				'expected modelDescription to not mention "all languages"');
 		});
 
-		test('reports all languages for wildcard', () => {
-			const tool = disposables.add(createTool(createMockTextModelService(null!)));
-			disposables.add(langFeatures.renameProvider.register('*', {
+		test('description is identical regardless of which providers are registered', () => {
+			const tool1 = disposables.add(createTool(createMockTextModelService(null!)));
+			const data1 = tool1.getToolData();
+
+			const model = disposables.add(createTextModel('', 'typescript', undefined, testUri));
+			const tool2 = disposables.add(createTool(createMockTextModelService(model)));
+			disposables.add(langFeatures.renameProvider.register('typescript', {
 				provideRenameEdits: () => ({ edits: [] }),
 			}));
-			const data = tool.getToolData();
-			assert.ok(data?.modelDescription.includes('all languages'));
-		});
+			disposables.add(langFeatures.renameProvider.register('python', {
+				provideRenameEdits: () => ({ edits: [] }),
+			}));
+			const data2 = tool2.getToolData();
 
-		suite('cache-stable mode', () => {
-			function createCacheStableTool(textModelService: ITextModelService) {
-				const configurationService = new TestConfigurationService();
-				configurationService.setUserConfiguration(ChatConfiguration.SymbolToolsCacheStable, true);
-				return disposables.add(createTool(textModelService, { configurationService }));
-			}
-
-			test('returns tool data even when no providers are registered', () => {
-				const tool = createCacheStableTool(createMockTextModelService(null!));
-				const data = tool.getToolData();
-				assert.ok(data, 'expected getToolData() to return data with no providers registered');
-			});
-
-			test('description does not include a per-language list', () => {
-				const model = disposables.add(createTextModel('', 'typescript', undefined, testUri));
-				const tool = createCacheStableTool(createMockTextModelService(model));
-				disposables.add(langFeatures.renameProvider.register('typescript', {
-					provideRenameEdits: () => ({ edits: [] }),
-				}));
-				const data = tool.getToolData();
-				assert.ok(data, 'expected getToolData() to return data');
-				assert.ok(!data!.modelDescription.includes('Currently supported for'),
-					`expected modelDescription to not list languages, got: ${data!.modelDescription}`);
-				assert.ok(!data!.modelDescription.includes('typescript'),
-					'expected modelDescription to not include any specific language id');
-				assert.ok(!data!.modelDescription.includes('all languages'),
-					'expected modelDescription to not mention "all languages"');
-			});
-
-			test('description is identical regardless of which providers are registered', () => {
-				const tool1 = createCacheStableTool(createMockTextModelService(null!));
-				const data1 = tool1.getToolData();
-
-				const model = disposables.add(createTextModel('', 'typescript', undefined, testUri));
-				const tool2 = createCacheStableTool(createMockTextModelService(model));
-				disposables.add(langFeatures.renameProvider.register('typescript', {
-					provideRenameEdits: () => ({ edits: [] }),
-				}));
-				disposables.add(langFeatures.renameProvider.register('python', {
-					provideRenameEdits: () => ({ edits: [] }),
-				}));
-				const data2 = tool2.getToolData();
-
-				assert.ok(data1 && data2);
-				assert.strictEqual(data1!.modelDescription, data2!.modelDescription,
-					'expected modelDescription to be byte-stable across provider registrations');
-			});
+			assert.strictEqual(data1.modelDescription, data2.modelDescription,
+				'expected modelDescription to be byte-stable across provider registrations');
 		});
 	});
 

--- a/src/vs/workbench/contrib/chat/test/browser/tools/usagesTool.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/tools/usagesTool.test.ts
@@ -13,13 +13,10 @@ import { ITextModel } from '../../../../../../editor/common/model.js';
 import { LanguageFeaturesService } from '../../../../../../editor/common/services/languageFeaturesService.js';
 import { IModelService } from '../../../../../../editor/common/services/model.js';
 import { ITextModelService } from '../../../../../../editor/common/services/resolverService.js';
-import { ILanguageService } from '../../../../../../editor/common/languages/language.js';
 import { createTextModel } from '../../../../../../editor/test/common/testTextModel.js';
 import { IWorkspaceContextService, IWorkspaceFolder } from '../../../../../../platform/workspace/common/workspace.js';
 import { FileMatch, ISearchComplete, ISearchService, ITextQuery, OneLineRange, TextSearchMatch } from '../../../../../services/search/common/search.js';
-import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { UsagesTool } from '../../../browser/tools/usagesTool.js';
-import { ChatConfiguration } from '../../../common/constants.js';
 import { IToolInvocation, IToolResult, IToolResultTextPart, ToolProgress } from '../../../common/tools/languageModelToolsService.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 
@@ -94,12 +91,8 @@ suite('UsagesTool', () => {
 	const noopCountTokens = async () => 0;
 	const noopProgress: ToolProgress = { report() { } };
 
-	function createMockLanguageService(): ILanguageService {
-		return { getLanguageName: (id: string) => id } as unknown as ILanguageService;
-	}
-
-	function createTool(textModelService: ITextModelService, workspaceService: IWorkspaceContextService, options?: { modelService?: IModelService; searchService?: ISearchService; configurationService?: TestConfigurationService }): UsagesTool {
-		return new UsagesTool(langFeatures, createMockLanguageService(), options?.modelService ?? createMockModelService(), options?.searchService ?? createMockSearchService(), textModelService, workspaceService, options?.configurationService ?? new TestConfigurationService());
+	function createTool(textModelService: ITextModelService, workspaceService: IWorkspaceContextService, options?: { modelService?: IModelService; searchService?: ISearchService }): UsagesTool {
+		return new UsagesTool(langFeatures, options?.modelService ?? createMockModelService(), options?.searchService ?? createMockSearchService(), textModelService, workspaceService);
 	}
 
 	setup(() => {
@@ -114,67 +107,36 @@ suite('UsagesTool', () => {
 
 	suite('getToolData', () => {
 
-		test('reports no providers when none registered', () => {
+		test('returns tool data when no providers are registered', () => {
 			const tool = disposables.add(createTool(createMockTextModelService(null!), createMockWorkspaceService()));
-			assert.strictEqual(tool.getToolData(), undefined);
+			assert.ok(tool.getToolData());
 		});
 
-		test('lists registered language ids', () => {
+		test('description does not include a per-language list', () => {
 			const model = disposables.add(createTextModel('', 'typescript', undefined, testUri));
 			const tool = disposables.add(createTool(createMockTextModelService(model), createMockWorkspaceService()));
 			disposables.add(langFeatures.referenceProvider.register('typescript', { provideReferences: () => [] }));
 			const data = tool.getToolData();
-			assert.ok(data?.modelDescription.includes('typescript'));
+			assert.ok(!data.modelDescription.includes('Currently supported for'),
+				`expected modelDescription to not list languages, got: ${data.modelDescription}`);
+			assert.ok(!data.modelDescription.includes('typescript'),
+				'expected modelDescription to not include any specific language id');
+			assert.ok(!data.modelDescription.includes('all languages'),
+				'expected modelDescription to not mention "all languages"');
 		});
 
-		test('reports all languages for wildcard', () => {
-			const tool = disposables.add(createTool(createMockTextModelService(null!), createMockWorkspaceService()));
-			disposables.add(langFeatures.referenceProvider.register('*', { provideReferences: () => [] }));
-			const data = tool.getToolData();
-			assert.ok(data?.modelDescription.includes('all languages'));
-		});
+		test('description is identical regardless of which providers are registered', () => {
+			const tool1 = disposables.add(createTool(createMockTextModelService(null!), createMockWorkspaceService()));
+			const data1 = tool1.getToolData();
 
-		suite('cache-stable mode', () => {
-			function createCacheStableTool(textModelService: ITextModelService) {
-				const configurationService = new TestConfigurationService();
-				configurationService.setUserConfiguration(ChatConfiguration.SymbolToolsCacheStable, true);
-				return disposables.add(createTool(textModelService, createMockWorkspaceService(), { configurationService }));
-			}
+			const model = disposables.add(createTextModel('', 'typescript', undefined, testUri));
+			const tool2 = disposables.add(createTool(createMockTextModelService(model), createMockWorkspaceService()));
+			disposables.add(langFeatures.referenceProvider.register('typescript', { provideReferences: () => [] }));
+			disposables.add(langFeatures.referenceProvider.register('python', { provideReferences: () => [] }));
+			const data2 = tool2.getToolData();
 
-			test('returns tool data even when no providers are registered', () => {
-				const tool = createCacheStableTool(createMockTextModelService(null!));
-				const data = tool.getToolData();
-				assert.ok(data, 'expected getToolData() to return data with no providers registered');
-			});
-
-			test('description does not include a per-language list', () => {
-				const model = disposables.add(createTextModel('', 'typescript', undefined, testUri));
-				const tool = createCacheStableTool(createMockTextModelService(model));
-				disposables.add(langFeatures.referenceProvider.register('typescript', { provideReferences: () => [] }));
-				const data = tool.getToolData();
-				assert.ok(data, 'expected getToolData() to return data');
-				assert.ok(!data!.modelDescription.includes('Currently supported for'),
-					`expected modelDescription to not list languages, got: ${data!.modelDescription}`);
-				assert.ok(!data!.modelDescription.includes('typescript'),
-					'expected modelDescription to not include any specific language id');
-				assert.ok(!data!.modelDescription.includes('all languages'),
-					'expected modelDescription to not mention "all languages"');
-			});
-
-			test('description is identical regardless of which providers are registered', () => {
-				const tool1 = createCacheStableTool(createMockTextModelService(null!));
-				const data1 = tool1.getToolData();
-
-				const model = disposables.add(createTextModel('', 'typescript', undefined, testUri));
-				const tool2 = createCacheStableTool(createMockTextModelService(model));
-				disposables.add(langFeatures.referenceProvider.register('typescript', { provideReferences: () => [] }));
-				disposables.add(langFeatures.referenceProvider.register('python', { provideReferences: () => [] }));
-				const data2 = tool2.getToolData();
-
-				assert.ok(data1 && data2);
-				assert.strictEqual(data1!.modelDescription, data2!.modelDescription,
-					'expected modelDescription to be byte-stable across provider registrations');
-			});
+			assert.strictEqual(data1.modelDescription, data2.modelDescription,
+				'expected modelDescription to be byte-stable across provider registrations');
 		});
 	});
 


### PR DESCRIPTION
## Summary
We saw some nice cache improvements from freezing the tool description and keeping these symbol tools registered in our A/B. This is to ship the change. 

- make rename and list-code-usages tools always use static, language-list-free descriptions
- remove `chat.experimental.symbolTools.cacheStable` now that the treatment behavior is shipping
- keep unsupported-language handling at invocation time and update tests for default cache-stable behavior

