### PR TITLE
Show running extensions

### DIFF
--- a/src/vs/sessions/sessions.desktop.main.ts
+++ b/src/vs/sessions/sessions.desktop.main.ts
@@ -133,6 +133,9 @@ import '../workbench/contrib/debug/electron-browser/extensionHostDebugService.js
 // Extension devtools
 import '../workbench/contrib/extensions/electron-browser/devtoolsExtensionHost.contribution.js';
 
+// Extensions Management (runtime extensions editor, profiling, remote extensions, etc.)
+import '../workbench/contrib/extensions/electron-browser/extensions.contribution.js';
+
 
 // Issues
 import '../workbench/contrib/issue/electron-browser/issue.contribution.js';

--- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -73,7 +73,6 @@ import { ExtensionsConfigurationSchema, ExtensionsConfigurationSchemaId } from '
 import { ExtensionsInput } from '../common/extensionsInput.js';
 import { KeymapExtensions } from '../common/extensionsUtils.js';
 import { SearchExtensionsTool, SearchExtensionsToolData } from '../common/searchExtensionsTool.js';
-import { ShowRuntimeExtensionsAction } from './abstractRuntimeExtensionsEditor.js';
 import { ExtensionEditor } from './extensionEditor.js';
 import { ExtensionEnablementWorkspaceTrustTransitionParticipant } from './extensionEnablementWorkspaceTrustTransitionParticipant.js';
 import { ExtensionRecommendationNotificationService } from './extensionRecommendationNotificationService.js';
@@ -2081,10 +2080,6 @@ if (isWeb) {
 }
 
 registerWorkbenchContribution2(ExtensionToolsContribution.ID, ExtensionToolsContribution, WorkbenchPhase.AfterRestored);
-
-
-// Running Extensions
-registerAction2(ShowRuntimeExtensionsAction);
 
 registerAction2(class ExtensionsGallerySignInAction extends Action2 {
 	constructor() {

--- a/src/vs/workbench/contrib/extensions/browser/extensions.web.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensions.web.contribution.ts
@@ -6,13 +6,17 @@
 import { localize } from '../../../../nls.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { SyncDescriptor } from '../../../../platform/instantiation/common/descriptors.js';
+import { registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { EditorPaneDescriptor, IEditorPaneRegistry } from '../../../browser/editor.js';
 import { RuntimeExtensionsEditor } from './browserRuntimeExtensionsEditor.js';
 import { RuntimeExtensionsInput } from '../common/runtimeExtensionsInput.js';
 import { EditorExtensions } from '../../../common/editor.js';
+import { ShowRuntimeExtensionsAction } from './abstractRuntimeExtensionsEditor.js';
 
 // Running Extensions
 Registry.as<IEditorPaneRegistry>(EditorExtensions.EditorPane).registerEditorPane(
 	EditorPaneDescriptor.create(RuntimeExtensionsEditor, RuntimeExtensionsEditor.ID, localize('runtimeExtension', "Running Extensions")),
 	[new SyncDescriptor(RuntimeExtensionsInput)]
 );
+
+registerAction2(ShowRuntimeExtensionsAction);

--- a/src/vs/workbench/contrib/extensions/electron-browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/electron-browser/extensions.contribution.ts
@@ -25,6 +25,7 @@ import { CleanUpExtensionsFolderAction, OpenExtensionsFolderAction } from './ext
 import { ExtensionsAutoProfiler } from './extensionsAutoProfiler.js';
 import { InstallRemoteExtensionsContribution, RemoteExtensionsInitializerContribution } from './remoteExtensionsInit.js';
 import { IExtensionHostProfileService, OpenExtensionHostProfileACtion, RuntimeExtensionsEditor, SaveExtensionHostProfileAction, StartExtensionHostProfileAction, StopExtensionHostProfileAction } from './runtimeExtensionsEditor.js';
+import { ShowRuntimeExtensionsAction } from '../browser/abstractRuntimeExtensionsEditor.js';
 
 // Singletons
 registerSingleton(IExtensionHostProfileService, ExtensionHostProfileService, InstantiationType.Delayed);
@@ -83,3 +84,4 @@ registerAction2(StartExtensionHostProfileAction);
 registerAction2(StopExtensionHostProfileAction);
 registerAction2(SaveExtensionHostProfileAction);
 registerAction2(OpenExtensionHostProfileACtion);
+registerAction2(ShowRuntimeExtensionsAction);


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce a new action to display running extensions in the editor. This includes registering the action and updating the necessary contributions for both desktop and web environments.

