### PR TITLE
telemetry: send common.isAgentsWindow instead of overriding product name

### DIFF
--- a/.eslint-plugin-local/code-no-telemetry-common-property.ts
+++ b/.eslint-plugin-local/code-no-telemetry-common-property.ts
@@ -47,6 +47,7 @@ const commonTelemetryProperties = new Set([
 	'common.useragent',
 	'common.istouchdevice',
 	'common.copilottrackingid',
+	'common.isagentswindow',
 ]);
 
 export default new class NoTelemetryCommonProperty implements eslint.Rule.RuleModule {

--- a/src/vs/workbench/services/telemetry/browser/telemetryService.ts
+++ b/src/vs/workbench/services/telemetry/browser/telemetryService.ts
@@ -115,7 +115,7 @@ export class TelemetryService extends Disposable implements ITelemetryService {
 			appenders.push(new TelemetryLogAppender('', false, loggerService, environmentService, productService));
 			const config: ITelemetryServiceConfig = {
 				appenders,
-				commonProperties: resolveWorkbenchCommonProperties(storageService, productService, isInternal, environmentService.remoteAuthority, environmentService.options && environmentService.options.resolveCommonTelemetryProperties),
+				commonProperties: resolveWorkbenchCommonProperties(storageService, productService, environmentService, isInternal, environmentService.options && environmentService.options.resolveCommonTelemetryProperties),
 				// Use the web origin as a cleanup pattern (analogous to appRoot on desktop).
 				// This strips the origin from web URLs in stack traces so the useful
 				// relative path (e.g. /static/build/bundle.js:1:200953) is preserved

--- a/src/vs/workbench/services/telemetry/browser/workbenchCommonProperties.ts
+++ b/src/vs/workbench/services/telemetry/browser/workbenchCommonProperties.ts
@@ -11,6 +11,7 @@ import { mixin } from '../../../../base/common/objects.js';
 import { ICommonProperties, firstSessionDateStorageKey, lastSessionDateStorageKey, machineIdKey } from '../../../../platform/telemetry/common/telemetry.js';
 import { Gesture } from '../../../../base/browser/touch.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
+import { IWorkbenchEnvironmentService } from '../../environment/common/environmentService.js';
 
 /**
  * General function to help reduce the individuality of user agents
@@ -24,9 +25,9 @@ function cleanUserAgent(userAgent: string): string {
 export function resolveWorkbenchCommonProperties(
 	storageService: IStorageService,
 	productService: IProductService,
+	environmentService: IWorkbenchEnvironmentService,
 	isInternalTelemetry: boolean,
-	remoteAuthority?: string,
-	resolveAdditionalProperties?: () => { [key: string]: unknown }
+	resolveAdditionalProperties?: () => { [key: string]: unknown },
 ): ICommonProperties {
 	const { commit, version, embedderIdentifier: productIdentifier, removeTelemetryMachineId: removeMachineId } = productService ?? {};
 	const result: ICommonProperties = Object.create(null);
@@ -56,7 +57,7 @@ export function resolveWorkbenchCommonProperties(
 	// __GDPR__COMMON__ "common.isNewSession" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
 	result['common.isNewSession'] = !lastSessionDate ? '1' : '0';
 	// __GDPR__COMMON__ "common.remoteAuthority" : { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth" }
-	result['common.remoteAuthority'] = cleanRemoteAuthority(remoteAuthority, productService);
+	result['common.remoteAuthority'] = cleanRemoteAuthority(environmentService.remoteAuthority, productService);
 
 	// __GDPR__COMMON__ "common.machineId" : { "endPoint": "MacAddressHash", "classification": "EndUserPseudonymizedInformation", "purpose": "FeatureInsight" }
 	result['common.machineId'] = machineId;
@@ -103,6 +104,11 @@ export function resolveWorkbenchCommonProperties(
 
 	if (resolveAdditionalProperties) {
 		mixin(result, resolveAdditionalProperties());
+	}
+
+	if (environmentService.isSessionsWindow) {
+		// __GDPR__COMMON__ "common.isAgentsWindow" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+		result['common.isAgentsWindow'] = true;
 	}
 
 	return result;

--- a/src/vs/workbench/services/telemetry/common/workbenchCommonProperties.ts
+++ b/src/vs/workbench/services/telemetry/common/workbenchCommonProperties.ts
@@ -9,10 +9,12 @@ import { ICommonProperties, firstSessionDateStorageKey, lastSessionDateStorageKe
 import { cleanRemoteAuthority } from '../../../../platform/telemetry/common/telemetryUtils.js';
 import { INodeProcess } from '../../../../base/common/platform.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
+import { IWorkbenchEnvironmentService } from '../../environment/common/environmentService.js';
 
 export function resolveWorkbenchCommonProperties(
 	storageService: IStorageService,
 	productService: IProductService,
+	environmentService: IWorkbenchEnvironmentService,
 	release: string,
 	hostname: string,
 	machineId: string,
@@ -20,11 +22,9 @@ export function resolveWorkbenchCommonProperties(
 	devDeviceId: string,
 	isInternalTelemetry: boolean,
 	process: INodeProcess,
-	remoteAuthority?: string,
-	telemetryAppName?: string,
 ): ICommonProperties {
 	const { commit, version, date: releaseDate } = productService ?? {};
-	const result = resolveCommonProperties(release, hostname, process.arch, commit, version, machineId, sqmId, devDeviceId, isInternalTelemetry, releaseDate, telemetryAppName);
+	const result = resolveCommonProperties(release, hostname, process.arch, commit, version, machineId, sqmId, devDeviceId, isInternalTelemetry, releaseDate);
 	const firstSessionDate = storageService.get(firstSessionDateStorageKey, StorageScope.APPLICATION)!;
 	const lastSessionDate = storageService.get(lastSessionDateStorageKey, StorageScope.APPLICATION)!;
 
@@ -39,9 +39,14 @@ export function resolveWorkbenchCommonProperties(
 	// __GDPR__COMMON__ "common.isNewSession" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
 	result['common.isNewSession'] = !lastSessionDate ? '1' : '0';
 	// __GDPR__COMMON__ "common.remoteAuthority" : { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth" }
-	result['common.remoteAuthority'] = cleanRemoteAuthority(remoteAuthority, productService);
+	result['common.remoteAuthority'] = cleanRemoteAuthority(environmentService.remoteAuthority, productService);
 	// __GDPR__COMMON__ "common.cli" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
 	result['common.cli'] = !!process.env['VSCODE_CLI'];
+
+	if (environmentService.isSessionsWindow) {
+		// __GDPR__COMMON__ "common.isAgentsWindow" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+		result['common.isAgentsWindow'] = true;
+	}
 
 	return result;
 }

--- a/src/vs/workbench/services/telemetry/electron-browser/telemetryService.ts
+++ b/src/vs/workbench/services/telemetry/electron-browser/telemetryService.ts
@@ -52,6 +52,7 @@ export class TelemetryService extends Disposable implements ITelemetryService {
 				commonProperties: resolveWorkbenchCommonProperties(
 					storageService,
 					productService,
+					environmentService,
 					environmentService.os.release,
 					environmentService.os.hostname,
 					environmentService.machineId,
@@ -59,8 +60,6 @@ export class TelemetryService extends Disposable implements ITelemetryService {
 					environmentService.devDeviceId,
 					isInternal,
 					process,
-					environmentService.remoteAuthority,
-					environmentService.isSessionsWindow ? productService.agentsTelemetryAppName : undefined
 				),
 				piiPaths: getPiiPathsFromEnvironment(environmentService),
 				sendErrorTelemetry: true,

--- a/src/vs/workbench/services/telemetry/test/browser/commonProperties.test.ts
+++ b/src/vs/workbench/services/telemetry/test/browser/commonProperties.test.ts
@@ -7,6 +7,7 @@ import { resolveWorkbenchCommonProperties } from '../../browser/workbenchCommonP
 import { InMemoryStorageService } from '../../../../../platform/storage/common/storage.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { hasKey } from '../../../../../base/common/types.js';
+import { IWorkbenchEnvironmentService } from '../../../environment/common/environmentService.js';
 
 suite('Browser Telemetry - common properties', function () {
 	let testStorageService: InMemoryStorageService;
@@ -28,7 +29,7 @@ suite('Browser Telemetry - common properties', function () {
 			};
 		};
 
-		const props = resolveWorkbenchCommonProperties(testStorageService, undefined!, false, undefined, resolveCommonTelemetryProperties);
+		const props = resolveWorkbenchCommonProperties(testStorageService, undefined!, { isSessionsWindow: false } as IWorkbenchEnvironmentService, false, resolveCommonTelemetryProperties);
 
 		assert.ok(hasKey(props, {
 			commitHash: true,
@@ -59,10 +60,10 @@ suite('Browser Telemetry - common properties', function () {
 			});
 		};
 
-		const props = resolveWorkbenchCommonProperties(testStorageService, undefined!, false, undefined, resolveCommonTelemetryProperties);
+		const props = resolveWorkbenchCommonProperties(testStorageService, undefined!, { isSessionsWindow: false } as IWorkbenchEnvironmentService, false, resolveCommonTelemetryProperties);
 		assert.strictEqual(props['userId'], 1);
 
-		const props2 = resolveWorkbenchCommonProperties(testStorageService, undefined!, false, undefined, resolveCommonTelemetryProperties);
+		const props2 = resolveWorkbenchCommonProperties(testStorageService, undefined!, { isSessionsWindow: false } as IWorkbenchEnvironmentService, false, resolveCommonTelemetryProperties);
 		assert.strictEqual(props2['userId'], 2);
 	});
 });

--- a/src/vs/workbench/services/telemetry/test/node/commonProperties.test.ts
+++ b/src/vs/workbench/services/telemetry/test/node/commonProperties.test.ts
@@ -10,6 +10,7 @@ import { StorageScope, InMemoryStorageService, StorageTarget } from '../../../..
 import { timeout } from '../../../../../base/common/async.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { hasKey } from '../../../../../base/common/types.js';
+import { IWorkbenchEnvironmentService } from '../../../environment/common/environmentService.js';
 
 suite('Telemetry - common properties', function () {
 	let testStorageService: InMemoryStorageService;
@@ -25,7 +26,7 @@ suite('Telemetry - common properties', function () {
 	});
 
 	test('default', function () {
-		const props = resolveWorkbenchCommonProperties(testStorageService, undefined!, release(), hostname(), 'someMachineId', 'someSqmId', 'somedevDeviceId', false, process);
+		const props = resolveWorkbenchCommonProperties(testStorageService, undefined!, { isSessionsWindow: false } as IWorkbenchEnvironmentService, release(), hostname(), 'someMachineId', 'someSqmId', 'somedevDeviceId', false, process);
 		assert.ok(hasKey(props, {
 			commitHash: true,
 			sessionID: true,
@@ -51,14 +52,14 @@ suite('Telemetry - common properties', function () {
 
 		testStorageService.store('telemetry.lastSessionDate', new Date().toUTCString(), StorageScope.APPLICATION, StorageTarget.MACHINE);
 
-		const props = resolveWorkbenchCommonProperties(testStorageService, undefined!, release(), hostname(), 'someMachineId', 'someSqmId', 'somedevDeviceId', false, process);
+		const props = resolveWorkbenchCommonProperties(testStorageService, undefined!, { isSessionsWindow: false } as IWorkbenchEnvironmentService, release(), hostname(), 'someMachineId', 'someSqmId', 'somedevDeviceId', false, process);
 		assert.ok(props['common.lastSessionDate']); // conditional, see below
 		assert.ok(props['common.isNewSession']);
 		assert.strictEqual(props['common.isNewSession'], '0');
 	});
 
 	test('values chance on ask', async function () {
-		const props = resolveWorkbenchCommonProperties(testStorageService, undefined!, release(), hostname(), 'someMachineId', 'someSqmId', 'somedevDeviceId', false, process);
+		const props = resolveWorkbenchCommonProperties(testStorageService, undefined!, { isSessionsWindow: false } as IWorkbenchEnvironmentService, release(), hostname(), 'someMachineId', 'someSqmId', 'somedevDeviceId', false, process);
 		let value1 = props['common.sequence'];
 		let value2 = props['common.sequence'];
 		assert.ok(value1 !== value2, 'seq');


### PR DESCRIPTION
## Summary

The Agents window previously overrode `common.product` via `agentsTelemetryAppName` to distinguish its telemetry from the main workbench. This approach is problematic because it changes the product identity in all events rather than adding a distinguishing signal.

## Changes

- **Add `common.isAgentsWindow` common property** — a dedicated boolean telemetry property sent only when the window is an Agents window, keeping `common.product` unchanged.
- **Refactor `resolveWorkbenchCommonProperties`** — both desktop and browser variants now accept `IWorkbenchEnvironmentService` directly, reading `isSessionsWindow` and `remoteAuthority` from it instead of receiving them as individual parameters.
- **Update ESLint rule** — added `common.isagentswindow` to the reserved common telemetry properties set to prevent collisions.
- **Update tests** — pass mock environment service in both browser and node common properties tests.

Note: `agentsTelemetryAppName` is still used for the extension host `appHost` (extension API `env.appHost`), which is a separate concern.