### PR TITLE
Set main editor part layout priority to high

### DIFF
--- a/src/vs/sessions/browser/parts/editorPart.ts
+++ b/src/vs/sessions/browser/parts/editorPart.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { LayoutPriority } from '../../../base/browser/ui/splitview/splitview.js';
 import { mainWindow } from '../../../base/browser/window.js';
 import { MainEditorPart as MainEditorPartBase } from '../../../workbench/browser/parts/editor/editorPart.js';
 import { Parts } from '../../../workbench/services/layout/browser/layoutService.js';
@@ -12,6 +13,8 @@ export class MainEditorPart extends MainEditorPartBase {
 	static readonly MARGIN_BOTTOM = 5;
 	static readonly MARGIN_LEFT = 5;
 	static readonly MARGIN_RIGHT = 5;
+
+	override priority = LayoutPriority.High;
 
 	override layout(width: number, height: number, top: number, left: number): void {
 		if (!this.layoutService.isVisible(Parts.EDITOR_PART, mainWindow)) {


### PR DESCRIPTION
```Copilot Generated Description:``` Adjust the layout priority of the main editor part to high, ensuring it has the same layout priority as the chat bar.

