### PR TITLE
Adjust archived section placement in "more workspaces" group

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -311,6 +311,12 @@
 .session-show-more.session-show-more-folders {
 	font-weight: 500;
 	text-transform: uppercase;
+
+	/* No surrounding separator lines for the folders show-more/less item */
+	&::before,
+	&::after {
+		content: none;
+	}
 }
 
 /* Section Header */

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -1119,9 +1119,16 @@ export class SessionsList extends Disposable implements ISessionsList {
 		};
 
 		const moreFolderSections: ISessionSection[] = [];
+		// When expanding the "more workspaces" group, the archived ("Done")
+		// section is moved to sit right above the "Show less" action so that
+		// the additional workspaces appear contiguously with the primary ones.
+		const deferArchived = partitionFolders && this.expandedMoreFolders;
+		let archivedSection: ISessionSection | undefined;
 		for (const section of sections) {
 			if (moreFolderSectionIds.has(section.id)) {
 				moreFolderSections.push(section);
+			} else if (deferArchived && section.id === 'archived') {
+				archivedSection = section;
 			} else {
 				children.push(renderSection(section));
 			}
@@ -1132,6 +1139,9 @@ export class SessionsList extends Disposable implements ISessionsList {
 				for (const section of moreFolderSections) {
 					children.push(renderSection(section));
 				}
+				if (archivedSection) {
+					children.push(renderSection(archivedSection));
+				}
 				children.push({
 					element: { showMore: true as const, kind: 'folders' as const, mode: 'less' as const, sectionLabel: SHOW_MORE_FOLDERS_LABEL, remainingCount: 0 },
 				});
@@ -1140,6 +1150,8 @@ export class SessionsList extends Disposable implements ISessionsList {
 					element: { showMore: true as const, kind: 'folders' as const, mode: 'more' as const, sectionLabel: SHOW_MORE_FOLDERS_LABEL, remainingCount: moreFolderSections.length },
 				});
 			}
+		} else if (archivedSection) {
+			children.push(renderSection(archivedSection));
 		}
 
 		this.tree.setChildren(null, children);


### PR DESCRIPTION
```Copilot Generated Description:``` Move the archived ("Done") section to sit above the "Show less" action when expanding the "more workspaces" group for better organization. Update CSS to remove surrounding separator lines for the folders show-more/less item.