### PR TITLE
sessions: default pre-cutoff sessions to read to avoid unread badge flood on upgrade

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsListModelService.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsListModelService.ts
@@ -56,6 +56,14 @@ export class SessionsListModelService extends Disposable implements ISessionsLis
 	private static readonly PINNED_SESSIONS_KEY = 'sessionsListControl.pinnedSessions';
 	private static readonly READ_SESSIONS_KEY = 'sessionsListControl.readSessions';
 
+	/**
+	 * Sessions created on or after this date start as unread by default.
+	 * Sessions created before this date are treated as read even if absent from
+	 * the read set, preserving the behaviour that existed before the unread
+	 * indicator was introduced.
+	 */
+	private static readonly UNREAD_DEFAULT_CUTOFF = new Date('2026-05-12T00:00:00.000Z');
+
 	private readonly _onDidChange = this._register(new Emitter<ISessionListModelChangeEvent>());
 	readonly onDidChange: Event<ISessionListModelChangeEvent> = this._onDidChange.event;
 
@@ -147,7 +155,15 @@ export class SessionsListModelService extends Disposable implements ISessionsLis
 	}
 
 	isSessionRead(session: ISession): boolean {
-		return this._readSessionIds.has(session.sessionId);
+		if (this._readSessionIds.has(session.sessionId)) {
+			return true;
+		}
+		// Sessions last updated before the cutoff date pre-date the unread
+		// indicator feature and are treated as read to avoid a flood of unread
+		// badges on upgrade. Once a session receives new activity (its updatedAt
+		// advances past the cutoff) it becomes unread again so the indicator
+		// works correctly.
+		return session.updatedAt.get() < SessionsListModelService.UNREAD_DEFAULT_CUTOFF;
 	}
 
 	markAllRead(sessions: ISession[]): void {

--- a/src/vs/sessions/contrib/sessions/test/browser/sessionsListModelService.test.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/sessionsListModelService.test.ts
@@ -16,7 +16,12 @@ import { ISessionListModelChangeEvent, SessionListModelChangeKind, SessionsListM
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { mock } from '../../../../../base/test/common/mock.js';
 
-function createSession(id: string, status: SessionStatus = SessionStatus.Completed): ISession {
+// A date clearly after the UNREAD_DEFAULT_CUTOFF (2026-05-12) so sessions are
+// unread by default in tests, matching real post-launch behaviour.
+const AFTER_CUTOFF = new Date('2026-06-01T00:00:00.000Z');
+const BEFORE_CUTOFF = new Date('2026-05-01T00:00:00.000Z');
+
+function createSession(id: string, status: SessionStatus = SessionStatus.Completed, updatedAt: Date = AFTER_CUTOFF): ISession {
 	return {
 		sessionId: id,
 		resource: URI.parse(`session://${id}`),
@@ -26,7 +31,7 @@ function createSession(id: string, status: SessionStatus = SessionStatus.Complet
 		createdAt: new Date(),
 		workspace: observableValue(`workspace-${id}`, undefined),
 		title: observableValue(`title-${id}`, id),
-		updatedAt: observableValue(`updatedAt-${id}`, new Date()),
+		updatedAt: observableValue(`updatedAt-${id}`, updatedAt),
 		status: observableValue(`status-${id}`, status),
 		changesets: observableValue(`changesets-${id}`, []),
 		changes: observableValue(`changes-${id}`, []),
@@ -154,6 +159,49 @@ suite('SessionsListModelService', () => {
 		service.markUnread(session);
 
 		assert.strictEqual(changeCount, 0);
+	});
+
+	// -- Cutoff date (pre-launch sessions default to read) --
+
+	test('session with updatedAt before cutoff is read by default without being in read set', () => {
+		const session = createSession('s1', SessionStatus.Completed, BEFORE_CUTOFF);
+		assert.strictEqual(service.isSessionRead(session), true);
+	});
+
+	test('session with updatedAt after cutoff is unread by default', () => {
+		const session = createSession('s1', SessionStatus.Completed, AFTER_CUTOFF);
+		assert.strictEqual(service.isSessionRead(session), false);
+	});
+
+	test('markUnread on pre-cutoff session is a no-op', () => {
+		const session = createSession('s1', SessionStatus.Completed, BEFORE_CUTOFF);
+		let changeCount = 0;
+		disposables.add(service.onDidChange(() => changeCount++));
+
+		service.markUnread(session);
+
+		assert.strictEqual(service.isSessionRead(session), true);
+		assert.strictEqual(changeCount, 0);
+	});
+
+	test('markRead on pre-cutoff session adds it to the read set and fires event', () => {
+		const session = createSession('s1', SessionStatus.Completed, BEFORE_CUTOFF);
+		let changeCount = 0;
+		disposables.add(service.onDidChange(() => changeCount++));
+
+		service.markRead(session);
+
+		assert.strictEqual(service.isSessionRead(session), true);
+		assert.strictEqual(changeCount, 1);
+	});
+
+	test('pre-cutoff session becomes unread when updatedAt advances past cutoff', () => {
+		const session = createSession('s1', SessionStatus.Completed, BEFORE_CUTOFF);
+		assert.strictEqual(service.isSessionRead(session), true);
+
+		(session.updatedAt as ISettableObservable<Date>).set(AFTER_CUTOFF, undefined);
+
+		assert.strictEqual(service.isSessionRead(session), false);
 	});
 
 	test('markAllRead marks multiple sessions as read', () => {


### PR DESCRIPTION
Fixes #315443

## Problem

When the unread indicator feature was introduced in the sessions list, all existing sessions (which had never been stored in the read set) would appear as unread on upgrade, causing a flood of unread badges for users with existing sessions.

## Solution

Add a cutoff date (`2026-05-12T00:00:00.000Z`) to `SessionsListModelService.isSessionRead()`. Sessions whose `updatedAt` is **before** the cutoff pre-date the unread indicator and are treated as read by default, even if they are not present in the `readSessions` storage set.

Using `updatedAt` (rather than `createdAt`) is intentional: if a pre-cutoff session receives new activity after upgrade (e.g. a background turn completes), its `updatedAt` advances past the cutoff and the session correctly becomes unread again, so the indicator still works for real new responses.

## Changes

- **`sessionsListModelService.ts`**: Added `UNREAD_DEFAULT_CUTOFF` static field. Updated `isSessionRead()` to return `true` for sessions whose `updatedAt` is before the cutoff even when absent from the read set.
- **`sessionsListModelService.test.ts`**: Updated `createSession()` helper to accept an optional `updatedAt` parameter (defaulting to a post-cutoff date so existing tests remain meaningful). Added explicit tests for cutoff behaviour: pre-cutoff sessions default to read, post-cutoff sessions default to unread, `markUnread` is a no-op on pre-cutoff sessions, and a session becomes unread once its `updatedAt` advances past the cutoff.
