### PR TITLE
Disable Copilot Memory and remove github.copilot.chat.copilotMemory.enabled setting

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -3282,14 +3282,6 @@
 						],
 						"markdownDescription": "%github.copilot.config.codesearch.enabled%"
 					},
-					"github.copilot.chat.copilotMemory.enabled": {
-						"type": "boolean",
-						"default": false,
-						"markdownDescription": "%github.copilot.config.copilotMemory.enabled%",
-						"tags": [
-							"preview"
-						]
-					},
 					"github.copilot.chat.tools.memory.enabled": {
 						"type": "boolean",
 						"default": true,

--- a/extensions/copilot/package.nls.json
+++ b/extensions/copilot/package.nls.json
@@ -422,7 +422,6 @@
 	"github.copilot.config.cli.remote.enabled": "Enable the /remote command for Copilot CLI sessions, allowing you to view and steer from GitHub.com and the GitHub mobile app.",
 	"github.copilot.config.backgroundAgent.enabled": "Enable the Copilot CLI. When disabled, the Copilot CLI will not be available in 'Continue In' context menus.",
 	"github.copilot.config.cloudAgent.enabled": "Enable the Cloud Agent. When disabled, the Cloud Agent will not be available in 'Continue In' context menus.",
-	"github.copilot.config.copilotMemory.enabled": "Enable agentic memory for GitHub Copilot. When enabled, Copilot can store repository-scoped facts about your codebase conventions, structure, and preferences remotely on GitHub, and recall them in future conversations to provide more contextually relevant assistance. [Learn more](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/copilot-memory).",
 	"github.copilot.config.tools.memory.enabled": "Enable the memory tool to let the agent save and recall notes during a conversation. Memories are stored locally in VS Code storage — user-scoped memories persist across workspaces and sessions, while session-scoped memories are cleared when the conversation ends.",
 	"github.copilot.config.gpt5AlternativePatch": "Enable GPT-5 alternative patch format.",
 	"github.copilot.config.inlineEdits.triggerOnEditorChangeAfterSeconds": "Trigger inline edits after editor has been idle for this many seconds.",

--- a/extensions/copilot/src/extension/tools/common/agentMemoryService.ts
+++ b/extensions/copilot/src/extension/tools/common/agentMemoryService.ts
@@ -5,11 +5,9 @@
 
 import { RequestType } from '@vscode/copilot-api';
 import { IAuthenticationService } from '../../../platform/authentication/common/authentication';
-import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
 import { ICAPIClientService } from '../../../platform/endpoint/common/capiClient';
 import { getGithubRepoIdFromFetchUrl, getOrderedRemoteUrlsFromContext, IGitService, toGithubNwo } from '../../../platform/git/common/gitService';
 import { ILogService } from '../../../platform/log/common/logService';
-import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
 import { IWorkspaceService } from '../../../platform/workspace/common/workspaceService';
 import { createServiceIdentifier } from '../../../util/common/services';
 import { Disposable } from '../../../util/vs/base/common/lifecycle';
@@ -112,8 +110,6 @@ export class AgentMemoryService extends Disposable implements IAgentMemoryServic
 		@ICAPIClientService private readonly capiClientService: ICAPIClientService,
 		@IGitService private readonly gitService: IGitService,
 		@IWorkspaceService private readonly workspaceService: IWorkspaceService,
-		@IConfigurationService private readonly configService: IConfigurationService,
-		@IExperimentationService private readonly experimentationService: IExperimentationService,
 		@IAuthenticationService private readonly authenticationService: IAuthenticationService
 	) {
 		super();
@@ -152,10 +148,9 @@ export class AgentMemoryService extends Disposable implements IAgentMemoryServic
 
 	/**
 	 * Check if the chat.copilotMemory.enabled config is enabled.
-	 * Uses experiment-based configuration for gradual rollout.
 	 */
 	private isCAPIMemorySyncConfigEnabled(): boolean {
-		return this.configService.getExperimentBasedConfig(ConfigKey.CopilotMemoryEnabled, this.experimentationService);
+		return false;
 	}
 
 	async checkMemoryEnabled(): Promise<boolean> {

--- a/extensions/copilot/src/extension/tools/node/memoryContextPrompt.tsx
+++ b/extensions/copilot/src/extension/tools/node/memoryContextPrompt.tsx
@@ -37,7 +37,7 @@ export class MemoryContextPrompt extends PromptElement<MemoryContextPromptProps>
 	}
 
 	async render() {
-		const enableCopilotMemory = this.configurationService.getExperimentBasedConfig(ConfigKey.CopilotMemoryEnabled, this.experimentationService);
+		const enableCopilotMemory = false;
 		const enableMemoryTool = this.configurationService.getExperimentBasedConfig(ConfigKey.MemoryToolEnabled, this.experimentationService);
 
 		const userMemoryContent = enableMemoryTool ? await this.getUserMemoryContent() : undefined;
@@ -257,7 +257,7 @@ export class MemoryInstructionsPrompt extends PromptElement<BasePromptElementPro
 	}
 
 	async render(state: void, sizing: PromptSizing) {
-		const enableCopilotMemory = this.configurationService.getExperimentBasedConfig(ConfigKey.CopilotMemoryEnabled, this.experimentationService);
+		const enableCopilotMemory = false;
 		const enableMemoryTool = this.configurationService.getExperimentBasedConfig(ConfigKey.MemoryToolEnabled, this.experimentationService);
 		if (!enableCopilotMemory && !enableMemoryTool) {
 			return null;

--- a/extensions/copilot/src/extension/tools/node/memoryTool.tsx
+++ b/extensions/copilot/src/extension/tools/node/memoryTool.tsx
@@ -541,34 +541,31 @@ export class MemoryTool implements ICopilotTool<MemoryToolParams> {
 			lines.push('/memories/session/');
 		}
 
-		// List local repo memory files under repo/ (only when CAPI is not enabled)
-		const capiEnabled = this.configurationService.getExperimentBasedConfig(ConfigKey.CopilotMemoryEnabled, this.experimentationService);
-		if (!capiEnabled) {
-			try {
-				const repoUri = this._resolveUri('/memories/repo/', 'repo');
-				const repoEntries = await this.fileSystemService.readDirectory(repoUri);
-				const repoFiles: string[] = [];
-				for (const [name, type] of repoEntries) {
-					if (name.startsWith('.')) {
-						continue;
-					}
-					if (type === FileType.Directory) {
-						repoFiles.push(`/memories/repo/${name}/`);
-					} else {
-						repoFiles.push(`/memories/repo/${name}`);
-					}
+		// List local repo memory files under repo/ (CAPI memory is disabled)
+		try {
+			const repoUri = this._resolveUri('/memories/repo/', 'repo');
+			const repoEntries = await this.fileSystemService.readDirectory(repoUri);
+			const repoFiles: string[] = [];
+			for (const [name, type] of repoEntries) {
+				if (name.startsWith('.')) {
+					continue;
 				}
-				if (repoFiles.length > 0) {
-					hasContent = true;
-					lines.push('/memories/repo/');
-					lines.push(...repoFiles);
+				if (type === FileType.Directory) {
+					repoFiles.push(`/memories/repo/${name}/`);
 				} else {
-					lines.push('/memories/repo/');
+					repoFiles.push(`/memories/repo/${name}`);
 				}
-			} catch {
-				// Repo storage may not exist yet, but still mention it
+			}
+			if (repoFiles.length > 0) {
+				hasContent = true;
+				lines.push('/memories/repo/');
+				lines.push(...repoFiles);
+			} else {
 				lines.push('/memories/repo/');
 			}
+		} catch {
+			// Repo storage may not exist yet, but still mention it
+			lines.push('/memories/repo/');
 		}
 
 		if (!hasContent) {

--- a/extensions/copilot/src/extension/tools/vscode-node/tools.ts
+++ b/extensions/copilot/src/extension/tools/vscode-node/tools.ts
@@ -5,11 +5,9 @@
 
 import * as vscode from 'vscode';
 import { l10n } from 'vscode';
-import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
 import { IVSCodeExtensionContext } from '../../../platform/extContext/common/extensionContext';
 import { IFileSystemService } from '../../../platform/filesystem/common/fileSystemService';
 import { FileType } from '../../../platform/filesystem/common/fileTypes';
-import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
 import { Disposable, DisposableMap } from '../../../util/vs/base/common/lifecycle';
 import { autorun, autorunIterableDelta } from '../../../util/vs/base/common/observableInternal';
 import { URI } from '../../../util/vs/base/common/uri';
@@ -27,8 +25,6 @@ export class ToolsContribution extends Disposable {
 		@IToolGroupingCache toolGrouping: IToolGroupingCache,
 		@IToolGroupingService toolGroupingService: IToolGroupingService,
 		@IVSCodeExtensionContext private readonly extensionContext: IVSCodeExtensionContext,
-		@IConfigurationService private readonly configurationService: IConfigurationService,
-		@IExperimentationService private readonly experimentationService: IExperimentationService,
 		@IFileSystemService private readonly fileSystemService: IFileSystemService,
 	) {
 		super();
@@ -91,9 +87,8 @@ export class ToolsContribution extends Disposable {
 				}
 			}
 
-			// Collect local repo-scoped memories only when CAPI memory is disabled
-			const capiMemoryEnabled = this.configurationService.getExperimentBasedConfig(ConfigKey.CopilotMemoryEnabled, this.experimentationService);
-			if (storageUri && !capiMemoryEnabled) {
+			// Collect local repo-scoped memories (CAPI memory is disabled)
+			if (storageUri) {
 				const repoMemoryUri = URI.joinPath(storageUri, 'memory-tool/memories/repo');
 				try {
 					const entries = await this.fileSystemService.readDirectory(repoMemoryUri);

--- a/extensions/copilot/src/platform/configuration/common/configurationService.ts
+++ b/extensions/copilot/src/platform/configuration/common/configurationService.ts
@@ -1044,7 +1044,6 @@ export namespace ConfigKey {
 	/** Model override for Explore (Code Research) agent — reads from core `chat.exploreAgent.defaultModel` */
 	export const ExploreAgentModel = defineSetting<string>('chat.exploreAgent.model', ConfigType.Simple, '');
 
-	export const CopilotMemoryEnabled = defineSetting<boolean>('chat.copilotMemory.enabled', ConfigType.ExperimentBased, false);
 	export const MemoryToolEnabled = defineSetting<boolean>('chat.tools.memory.enabled', ConfigType.ExperimentBased, true);
 	export const ViewImageToolEnabled = defineSetting<boolean>('chat.tools.viewImage.enabled', ConfigType.ExperimentBased, true);
 

--- a/extensions/copilot/test/base/extHostContext/simulationExtHostToolsService.ts
+++ b/extensions/copilot/test/base/extHostContext/simulationExtHostToolsService.ts
@@ -63,7 +63,7 @@ export class SimulationExtHostToolsService extends BaseToolsService implements I
 	}
 
 	private ensureToolsRegistered() {
-		this._lmToolRegistration ??= new ToolsContribution(this, {} as any, { threshold: observableValue(this, 128) } as any, {} as any, {} as any, {} as any, {} as any);
+		this._lmToolRegistration ??= new ToolsContribution(this, {} as any, { threshold: observableValue(this, 128) } as any, {} as any, {} as any);
 	}
 
 	getCopilotTool(name: string): ICopilotTool<any> | undefined {


### PR DESCRIPTION
Targets `release/1.120`. Minimal, surgical change to fully disable Copilot Memory (CAPI-backed repo memory) on the release branch. A broader cleanup will follow on `main`.

## Notes for users with the setting set

Users who set `github.copilot.chat.copilotMemory.enabled: true` in their settings will see an "Unknown configuration setting" warning. Functionally the setting is ignored.
