### PR TITLE
cli: enable upgrades on proxied websocket client connection

### DIFF
--- a/cli/src/commands/serve_web.rs
+++ b/cli/src/commands/serve_web.rs
@@ -348,7 +348,9 @@ async fn forward_ws_req_to_server(
 			Err(e) => return response::connection_err(e),
 		};
 
-	tokio::spawn(connection);
+	// `.with_upgrades()` is required so that `hyper::upgrade::on` can later
+	// take over the connection for websocket traffic.
+	tokio::spawn(connection.with_upgrades());
 
 	let mut proxied_req = Request::builder().uri(req.uri());
 	for (k, v) in req.headers() {


### PR DESCRIPTION
cli: enable upgrades on proxied websocket client connection

The serve-web command's websocket proxy spawned the client-side hyper connection without `.with_upgrades()`, so `hyper::upgrade::on(&mut res)` rejected the upgrade with ""upgrade expected but low level API in use"" and the websocket failed to establish.

- Spawn `connection.with_upgrades()` in `forward_ws_req_to_server` to mirror the server side and the equivalent agent-host proxy.

Fixes https://github.com/microsoft/vscode/issues/315448

(Commit message generated by Copilot)