### PR TITLE
chat: disable agents window actions when agent mode is disabled

### DIFF
--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -209,6 +209,7 @@ export const OPEN_AGENTS_WINDOW_PRECONDITION = ContextKeyExpr.and(
 	ChatEntitlementContextKeys.Setup.hidden.negate(),
 	ChatEntitlementContextKeys.Setup.disabledInWorkspace.negate(),
 	IsSessionsWindowContext.negate(),
+	ContextKeyExpr.has(`config.${ChatConfiguration.AgentEnabled}`),
 );
 
 export const ChatEditorTitleMaxLength = 30;


### PR DESCRIPTION
When `chat.agent.enabled` is `false`, the "Open in Agents" and "Open Agents Window" actions are now disabled and hidden from menus.

## Changes

- Added `ContextKeyExpr.has(`config.${ChatConfiguration.AgentEnabled}`)` to `OPEN_AGENTS_WINDOW_PRECONDITION` in `constants.ts`. This precondition is already used by both `OpenWorkspaceInAgentsWindowAction` and `OpenAgentsWindowAction`, so both actions are disabled when agent mode is off.