### PR TITLE
agentHost: derive active-session count from authoritative session state

### DIFF
--- a/cli/src/commands/serve_web.rs
+++ b/cli/src/commands/serve_web.rs
@@ -348,7 +348,9 @@ async fn forward_ws_req_to_server(
 			Err(e) => return response::connection_err(e),
 		};
 
-	tokio::spawn(connection);
+	// `.with_upgrades()` is required so that `hyper::upgrade::on` can later
+	// take over the connection for websocket traffic.
+	tokio::spawn(connection.with_upgrades());
 
 	let mut proxied_req = Request::builder().uri(req.uri());
 	for (k, v) in req.headers() {

--- a/src/vs/platform/agentHost/node/agentHostStateManager.ts
+++ b/src/vs/platform/agentHost/node/agentHostStateManager.ts
@@ -29,8 +29,15 @@ export class AgentHostStateManager extends Disposable {
 	private _rootState: RootState;
 	private readonly _sessionStates = new Map<string, SessionState>();
 
-	/** Tracks which session URI each active turn belongs to, keyed by turnId. */
-	private readonly _activeTurnToSession = new Map<string, string>();
+	/**
+	 * Sessions whose authoritative state has an active turn. Derived from
+	 * `state.activeTurn` (the source of truth maintained by the session
+	 * reducer) — never from raw action turn-ids — so that mismatched or
+	 * out-of-order turn lifecycle actions can't desync the count from
+	 * reality. Drives `RootActiveSessionsChanged` and `hasActiveSessions`,
+	 * which together gate `--enable-remote-auto-shutdown`.
+	 */
+	private readonly _sessionsWithActiveTurn = new Set<string>();
 
 	/** Last summary sent to clients (via sessionAdded or sessionSummaryChanged). */
 	private readonly _lastNotifiedSummaries = new Map<string, SessionSummary>();
@@ -67,7 +74,7 @@ export class AgentHostStateManager extends Disposable {
 	private readonly _log = (msg: string) => this._logService.warn(`[AgentHostStateManager] ${msg}`);
 
 	get hasActiveSessions(): boolean {
-		return this._activeTurnToSession.size > 0;
+		return this._sessionsWithActiveTurn.size > 0;
 	}
 
 	// ---- State accessors ----------------------------------------------------
@@ -262,9 +269,14 @@ export class AgentHostStateManager extends Disposable {
 			this._flushSummaryNotificationFor(session);
 		}
 
-		// Clean up active turn tracking
-		if (state.activeTurn) {
-			this._activeTurnToSession.delete(state.activeTurn.id);
+		// Clean up active turn tracking. We must dispatch
+		// `RootActiveSessionsChanged` if the count actually changes so that
+		// downstream consumers (e.g. the server lifetime tracker driving
+		// `--enable-remote-auto-shutdown`) release their hold on the process.
+		// Without this, evicting a session that still has an active turn
+		// silently strands the active-sessions count above zero forever.
+		if (this._sessionsWithActiveTurn.delete(session)) {
+			this.dispatchServerAction({ type: ActionType.RootActiveSessionsChanged, activeSessions: this._sessionsWithActiveTurn.size });
 		}
 
 		this._sessionStates.delete(session);
@@ -386,17 +398,21 @@ export class AgentHostStateManager extends Disposable {
 					this._summaryNotifyScheduler.schedule();
 				}
 
-				// Track active turn for turn lifecycle
-				if (sessionAction.type === ActionType.SessionTurnStarted) {
-					this._activeTurnToSession.set(sessionAction.turnId, key);
-					this.dispatchServerAction({ type: ActionType.RootActiveSessionsChanged, activeSessions: this._activeTurnToSession.size });
-				} else if (
-					sessionAction.type === ActionType.SessionTurnComplete ||
-					sessionAction.type === ActionType.SessionTurnCancelled ||
-					sessionAction.type === ActionType.SessionError
-				) {
-					this._activeTurnToSession.delete(sessionAction.turnId);
-					this.dispatchServerAction({ type: ActionType.RootActiveSessionsChanged, activeSessions: this._activeTurnToSession.size });
+				// Track active turn transitions off the reducer's view of state,
+				// not off the raw action's turn-ids. The reducer's `endTurn`
+				// no-ops on a stale turn-id and `SessionTurnStarted` overwrites
+				// a still-running turn, so deriving the count from `activeTurn`
+				// is the only way to keep `RootActiveSessionsChanged` in sync
+				// with reality.
+				const hadActive = !!state.activeTurn;
+				const hasActive = !!newState.activeTurn;
+				if (hadActive !== hasActive) {
+					if (hasActive) {
+						this._sessionsWithActiveTurn.add(key);
+					} else {
+						this._sessionsWithActiveTurn.delete(key);
+					}
+					this.dispatchServerAction({ type: ActionType.RootActiveSessionsChanged, activeSessions: this._sessionsWithActiveTurn.size });
 				}
 
 				resultingState = newState;

--- a/src/vs/platform/agentHost/test/node/agentHostStateManager.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostStateManager.test.ts
@@ -314,6 +314,100 @@ suite('AgentHostStateManager', () => {
 		assert.strictEqual(manager.rootState.activeSessions, 0);
 	});
 
+	test('removeSession decrements active sessions when an active turn is stranded', () => {
+		manager.createSession(makeSessionSummary());
+		manager.dispatchServerAction({ type: ActionType.SessionReady, session: sessionUri });
+		manager.dispatchServerAction({
+			type: ActionType.SessionTurnStarted,
+			session: sessionUri,
+			turnId: 'turn-1',
+			userMessage: { text: 'hello' },
+		});
+		assert.strictEqual(manager.rootState.activeSessions, 1);
+
+		const envelopes: ActionEnvelope[] = [];
+		disposables.add(manager.onDidEmitEnvelope(e => envelopes.push(e)));
+
+		// Evict the session while a turn is still active. The active-sessions
+		// count must drop to zero so that the server lifetime tracker (driving
+		// `--enable-remote-auto-shutdown`) releases its hold.
+		manager.removeSession(sessionUri);
+
+		assert.strictEqual(manager.rootState.activeSessions, 0);
+		const activeChanged = envelopes.filter(e => e.action.type === ActionType.RootActiveSessionsChanged);
+		assert.strictEqual(activeChanged.length, 1);
+		assert.strictEqual((activeChanged[0].action as { activeSessions: number }).activeSessions, 0);
+	});
+
+	test('removeSession does not dispatch active-sessions change when no turn is active', () => {
+		manager.createSession(makeSessionSummary());
+		manager.dispatchServerAction({ type: ActionType.SessionReady, session: sessionUri });
+
+		const envelopes: ActionEnvelope[] = [];
+		disposables.add(manager.onDidEmitEnvelope(e => envelopes.push(e)));
+
+		manager.removeSession(sessionUri);
+
+		const activeChanged = envelopes.filter(e => e.action.type === ActionType.RootActiveSessionsChanged);
+		assert.strictEqual(activeChanged.length, 0);
+	});
+
+	test('stale SessionTurnComplete (wrong turnId) does not decrement active sessions', () => {
+		// The reducer's `endTurn` no-ops when the action's turnId doesn't match
+		// `state.activeTurn.id`. The active-session count must follow suit so
+		// the lifetime tracker doesn't release its hold while a turn is still
+		// genuinely running.
+		manager.createSession(makeSessionSummary());
+		manager.dispatchServerAction({ type: ActionType.SessionReady, session: sessionUri });
+		manager.dispatchServerAction({
+			type: ActionType.SessionTurnStarted,
+			session: sessionUri,
+			turnId: 'turn-1',
+			userMessage: { text: 'hello' },
+		});
+		assert.strictEqual(manager.rootState.activeSessions, 1);
+
+		manager.dispatchServerAction({
+			type: ActionType.SessionTurnComplete,
+			session: sessionUri,
+			turnId: 'stale-turn',
+		});
+
+		assert.strictEqual(manager.rootState.activeSessions, 1);
+		assert.strictEqual(manager.hasActiveSessions, true);
+	});
+
+	test('concurrent SessionTurnStarted on same session keeps active count at one', () => {
+		// The reducer unconditionally overwrites `activeTurn`, so two starts
+		// without an intervening complete still represent a single active turn
+		// from state's point of view. The count must mirror that.
+		manager.createSession(makeSessionSummary());
+		manager.dispatchServerAction({ type: ActionType.SessionReady, session: sessionUri });
+		manager.dispatchServerAction({
+			type: ActionType.SessionTurnStarted,
+			session: sessionUri,
+			turnId: 'turn-1',
+			userMessage: { text: 'a' },
+		});
+		manager.dispatchServerAction({
+			type: ActionType.SessionTurnStarted,
+			session: sessionUri,
+			turnId: 'turn-2',
+			userMessage: { text: 'b' },
+		});
+
+		assert.strictEqual(manager.rootState.activeSessions, 1);
+
+		manager.dispatchServerAction({
+			type: ActionType.SessionTurnComplete,
+			session: sessionUri,
+			turnId: 'turn-2',
+		});
+
+		assert.strictEqual(manager.rootState.activeSessions, 0);
+		assert.strictEqual(manager.hasActiveSessions, false);
+	});
+
 	test('restoreSession creates session in Ready state with pre-populated turns', () => {
 		const turns = [
 			{


### PR DESCRIPTION
The CLI agent host wasn't auto-updating because `--enable-remote-auto-shutdown` never
fired: the active-session count in `AgentHostStateManager` could drift above zero and
stay stuck there, keeping `ServerAgentHostManager`'s lifetime token held forever.

The drift came from `_activeTurnToSession`, a parallel `Map<turnId, sessionUri>` that
ran alongside the reducer's authoritative `state.activeTurn`. The two could diverge:

- A `SessionTurnComplete` with a stale turn-id no-ops in `endTurn` but still
  decremented the map, under-counting active turns.
- A second `SessionTurnStarted` on a session whose previous turn never completed
  added a new map entry while the reducer just overwrote `activeTurn`, leaving the
  count permanently above the true number of active turns.
- `removeSession()` deleted from the map but never dispatched
  `RootActiveSessionsChanged`, so any eviction-with-active-turn path (e.g.
  `agentSideEffects.removeSubagentSessions`) silently stranded the count.

- Replace `_activeTurnToSession` with `_sessionsWithActiveTurn: Set<sessionUri>`,
  maintained by comparing `state.activeTurn` before/after the reducer runs. The
  count now only moves when the reducer actually transitions a session
  between "has active turn" and "no active turn", so mismatched-id and
  overwrite cases stay in sync with reality by construction.
- Have `removeSession` clean up the set and dispatch `RootActiveSessionsChanged`
  if it actually removed an entry, so eviction paths release the lifetime token.
- Regression tests for: stranded-on-eviction, stale `SessionTurnComplete`, and
  concurrent `SessionTurnStarted` on the same session.

Fixes https://github.com/microsoft/vscode/issues/315587

(Commit message generated by Copilot)
