### PR TITLE
Propagate stateful marker options to compaction

### DIFF
--- a/extensions/copilot/src/extension/intents/node/agentIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/agentIntent.ts
@@ -975,6 +975,8 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 					finishedCb: undefined,
 					location: ChatLocation.Agent,
 					conversationId,
+					useWebSocket: this.endpoint.apiType === 'responses' ? false : undefined,
+					ignoreStatefulMarker: this.endpoint.apiType === 'responses' ? false : undefined,
 					requestOptions: {
 						temperature: 0,
 						stream: false,

--- a/extensions/copilot/src/extension/intents/node/agentIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/agentIntent.ts
@@ -51,7 +51,7 @@ import { AgentPrompt, AgentPromptProps } from '../../prompts/node/agent/agentPro
 import { BackgroundSummarizationState, BackgroundSummarizer, IBackgroundSummarizationResult, shouldKickOffBackgroundSummarization } from '../../prompts/node/agent/backgroundSummarizer';
 import { BackgroundTodoDecision, BackgroundTodoProcessor } from '../../prompts/node/agent/backgroundTodoProcessor';
 import { AgentPromptCustomizations, PromptRegistry } from '../../prompts/node/agent/promptRegistry';
-import { extractSummary, SummarizationUserMessage, SummarizedConversationHistory, SummarizedConversationHistoryMetadata, SummarizedConversationHistoryPropsBuilder, appendTranscriptHintToSummary, computeSummarizationRoundCounts } from '../../prompts/node/agent/summarizedConversationHistory';
+import { extractSummary, SummarizationUserMessage, SummarizedConversationHistory, SummarizedConversationHistoryMetadata, SummarizedConversationHistoryPropsBuilder, appendTranscriptHintToSummary, computeSummarizationRoundCounts, shouldUseStatefulMarkerForResponsesCompaction } from '../../prompts/node/agent/summarizedConversationHistory';
 import { PromptRenderer, renderPromptElement } from '../../prompts/node/base/promptRenderer';
 import { ICodeMapperService } from '../../prompts/node/codeMapper/codeMapperService';
 import { EditCodePrompt2 } from '../../prompts/node/panel/editCodePrompt2';
@@ -956,6 +956,7 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 				// summary user message. The prompt prefix is byte-identical
 				// to the main agent loop for cache hits.
 				const strippedMainMessages = ToolCallingLoop.stripInternalToolCallIds(mainRenderMessages);
+				const useStatefulMarker = shouldUseStatefulMarkerForResponsesCompaction(this.endpoint, this.configurationService, this.expService);
 				const summaryMsgResult = await renderPromptElement(
 					this.instantiationService,
 					this.endpoint,
@@ -975,8 +976,8 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 					finishedCb: undefined,
 					location: ChatLocation.Agent,
 					conversationId,
-					useWebSocket: this.endpoint.apiType === 'responses' ? false : undefined,
-					ignoreStatefulMarker: this.endpoint.apiType === 'responses' ? false : undefined,
+					useWebSocket: useStatefulMarker ? false : undefined,
+					ignoreStatefulMarker: useStatefulMarker ? false : undefined,
 					requestOptions: {
 						temperature: 0,
 						stream: false,

--- a/extensions/copilot/src/extension/intents/node/test/agentSummarizeCommand.spec.ts
+++ b/extensions/copilot/src/extension/intents/node/test/agentSummarizeCommand.spec.ts
@@ -8,6 +8,9 @@ import { IChatMLFetcher } from '../../../../platform/chat/common/chatMLFetcher';
 import { ChatLocation } from '../../../../platform/chat/common/commonTypes';
 import { StaticChatMLFetcher } from '../../../../platform/chat/test/common/staticChatMLFetcher';
 import { ConfigKey, IConfigurationService } from '../../../../platform/configuration/common/configurationService';
+import { IEndpointProvider } from '../../../../platform/endpoint/common/endpointProvider';
+import { MockEndpoint } from '../../../../platform/endpoint/test/node/mockEndpoint';
+import { IChatEndpoint } from '../../../../platform/networking/common/networking';
 import { ITestingServicesAccessor } from '../../../../platform/test/node/services';
 import { TestWorkspaceService } from '../../../../platform/test/node/testWorkspaceService';
 import { IWorkspaceService } from '../../../../platform/workspace/common/workspaceService';
@@ -27,6 +30,27 @@ import { MockChatResponseStream, TestChatRequest } from '../../../test/node/test
 import { ToolName } from '../../../tools/common/toolNames';
 import { AgentIntent } from '../agentIntent';
 
+class MockEndpointProvider implements IEndpointProvider {
+	declare readonly _serviceBrand: undefined;
+	readonly onDidModelsRefresh = Event.None;
+	private endpoint: IChatEndpoint | undefined;
+
+	constructor(
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
+	) { }
+
+	async getChatEndpoint(): Promise<IChatEndpoint> {
+		return this.endpoint ??= this.instantiationService.createInstance(MockEndpoint, undefined);
+	}
+
+	async getAllChatEndpoints(): Promise<IChatEndpoint[]> {
+		return [await this.getChatEndpoint()];
+	}
+
+	async getAllCompletionModels(): Promise<never[]> { return []; }
+	async getEmbeddingsEndpoint(): Promise<never> { throw new Error('not implemented'); }
+}
+
 describe('AgentIntent /summarize command', () => {
 	let accessor: ITestingServicesAccessor;
 	let instantiationService: IInstantiationService;
@@ -35,6 +59,7 @@ describe('AgentIntent /summarize command', () => {
 
 	beforeAll(() => {
 		const services = createExtensionUnitTestingServices();
+		services.define(IEndpointProvider, new SyncDescriptor(MockEndpointProvider));
 		services.define(IWorkspaceFileIndex, new SyncDescriptor(NullWorkspaceFileIndex));
 		services.define(IWorkspaceService, new SyncDescriptor(
 			TestWorkspaceService,

--- a/extensions/copilot/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
@@ -19,6 +19,7 @@ import { CUSTOM_TOOL_SEARCH_NAME } from '../../../../platform/networking/common/
 import { IChatEndpoint } from '../../../../platform/networking/common/networking';
 import { APIUsage } from '../../../../platform/networking/common/openai';
 import { IPromptPathRepresentationService } from '../../../../platform/prompts/common/promptPathRepresentationService';
+import { IExperimentationService } from '../../../../platform/telemetry/common/nullExperimentationService';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry';
 import { ThinkingData } from '../../../../platform/thinking/common/thinking';
 import { computePromptTokenDetails } from '../../../../platform/tokenizer/node/promptTokenDetails';
@@ -42,6 +43,11 @@ import { ChatToolCalls } from '../panel/toolCalling';
 import { AgentUserMessage, AgentUserMessageCustomizations, getUserMessagePropsFromAgentProps, getUserMessagePropsFromTurn } from './agentPrompt';
 import { DefaultOpenAIKeepGoingReminder } from './openai/defaultOpenAIPrompt';
 import { SimpleSummarizedHistory } from './simpleSummarizedHistoryPrompt';
+
+export function shouldUseStatefulMarkerForResponsesCompaction(endpoint: IChatEndpoint, configurationService: IConfigurationService, experimentationService: IExperimentationService): boolean {
+	return endpoint.apiType === 'responses'
+		&& configurationService.getExperimentBasedConfig(ConfigKey.ResponsesApiCompactionStatefulMarkerEnabled, experimentationService);
+}
 
 export interface ConversationHistorySummarizationPromptProps extends SummarizedAgentHistoryProps {
 	readonly simpleMode?: boolean;
@@ -552,6 +558,7 @@ class ConversationHistorySummarizer {
 		@ILogService private readonly logService: ILogService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IExperimentationService private readonly experimentationService: IExperimentationService,
 		@IChatHookService private readonly chatHookService: IChatHookService,
 		@ISessionTranscriptService private readonly sessionTranscriptService: ISessionTranscriptService,
 	) { }
@@ -743,14 +750,15 @@ class ConversationHistorySummarizer {
 			}
 
 			promptTypes = messages.map(msg => `${msg.role}${'name' in msg && msg.name ? `-${msg.name}` : ''}:${getTextPart(msg.content).length}`).join(',');
+			const useStatefulMarker = shouldUseStatefulMarkerForResponsesCompaction(endpoint, this.configurationService, this.experimentationService);
 			summaryResponse = await endpoint.makeChatRequest2({
 				debugName: `summarizeConversationHistory-${mode}`,
 				messages,
 				finishedCb: undefined,
 				location: ChatLocation.Agent,
-				conversationId,
-				useWebSocket: endpoint.apiType === 'responses' ? false : undefined,
-				ignoreStatefulMarker: endpoint.apiType === 'responses' ? false : undefined,
+				conversationId: useStatefulMarker ? conversationId : undefined,
+				useWebSocket: useStatefulMarker ? false : undefined,
+				ignoreStatefulMarker: useStatefulMarker ? false : undefined,
 				requestOptions: {
 					temperature: 0,
 					stream: false,

--- a/extensions/copilot/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
@@ -668,6 +668,7 @@ class ConversationHistorySummarizer {
 
 		let summarizationPrompt: ChatMessage[];
 		const associatedRequestId = this.props.promptContext.conversation?.getLatestTurn().id;
+		const conversationId = this.props.promptContext.conversation?.sessionId;
 		try {
 			summarizationPrompt = (await renderPromptElement(this.instantiationService, endpoint, ConversationHistorySummarizationPrompt, { ...propsInfo.props, enableCacheBreakpoints: false, simpleMode: mode === SummaryMode.Simple }, undefined, this.token)).messages;
 			this.logInfo(`summarization prompt rendered in ${stopwatch.elapsed()}ms.`, mode);
@@ -747,6 +748,9 @@ class ConversationHistorySummarizer {
 				messages,
 				finishedCb: undefined,
 				location: ChatLocation.Agent,
+				conversationId,
+				useWebSocket: endpoint.apiType === 'responses' ? false : undefined,
+				ignoreStatefulMarker: endpoint.apiType === 'responses' ? false : undefined,
 				requestOptions: {
 					temperature: 0,
 					stream: false,

--- a/extensions/copilot/src/extension/prompts/node/agent/test/summarization.spec.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/summarization.spec.tsx
@@ -82,6 +82,7 @@ suite('Agent Summarization', () => {
 	beforeEach(() => {
 		const turn = new Turn('turnId', { type: 'user', message: 'hello' });
 		conversation = new Conversation('sessionId', [turn]);
+		accessor.get(IConfigurationService).setConfig(ConfigKey.ResponsesApiCompactionStatefulMarkerEnabled, false);
 	});
 
 	afterAll(() => {
@@ -450,6 +451,7 @@ suite('Agent Summarization', () => {
 	test('Responses API summarization keeps stateful marker reuse on HTTP', async () => {
 		const { instaService, endpoint, historyProps, testConversation } = createSummarizationTestContext();
 		Object.defineProperty(endpoint, 'apiType', { value: 'responses' });
+		accessor.get(IConfigurationService).setConfig(ConfigKey.ResponsesApiCompactionStatefulMarkerEnabled, true);
 
 		let capturedOptions: IMakeChatRequestOptions | undefined;
 		endpoint.makeChatRequest2 = async (options) => {
@@ -470,6 +472,31 @@ suite('Agent Summarization', () => {
 		expect(capturedOptions?.conversationId).toBe(testConversation.sessionId);
 		expect(capturedOptions?.useWebSocket).toBe(false);
 		expect(capturedOptions?.ignoreStatefulMarker).toBe(false);
+	});
+
+	test('Responses API summarization leaves stateful marker options unset when experiment is disabled', async () => {
+		const { instaService, endpoint, historyProps } = createSummarizationTestContext();
+		Object.defineProperty(endpoint, 'apiType', { value: 'responses' });
+
+		let capturedOptions: IMakeChatRequestOptions | undefined;
+		endpoint.makeChatRequest2 = async (options) => {
+			capturedOptions = options;
+			return {
+				type: ChatFetchResponseType.Success,
+				requestId: 'summary-request',
+				serverRequestId: 'summary-server-request',
+				usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0, prompt_tokens_details: { cached_tokens: 0 } },
+				value: 'summarized successfully!',
+				resolvedModel: endpoint.model,
+			};
+		};
+
+		const renderer = PromptRenderer.create(instaService, endpoint, SummarizedConversationHistory, historyProps);
+		await renderer.render();
+
+		expect(capturedOptions?.conversationId).toBeUndefined();
+		expect(capturedOptions?.useWebSocket).toBeUndefined();
+		expect(capturedOptions?.ignoreStatefulMarker).toBeUndefined();
 	});
 
 	test('failed summarization does not set round.summary', async () => {

--- a/extensions/copilot/src/extension/prompts/node/agent/test/summarization.spec.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/summarization.spec.tsx
@@ -6,16 +6,19 @@
 import { Raw } from '@vscode/prompt-tsx';
 import { afterAll, beforeAll, beforeEach, expect, suite, test } from 'vitest';
 import { IChatMLFetcher } from '../../../../../platform/chat/common/chatMLFetcher';
-import { ChatLocation } from '../../../../../platform/chat/common/commonTypes';
+import { ChatFetchResponseType, ChatLocation } from '../../../../../platform/chat/common/commonTypes';
 import { StaticChatMLFetcher } from '../../../../../platform/chat/test/common/staticChatMLFetcher';
 import { CodeGenerationTextInstruction, ConfigKey, IConfigurationService } from '../../../../../platform/configuration/common/configurationService';
+import { IEndpointProvider } from '../../../../../platform/endpoint/common/endpointProvider';
 import { MockEndpoint } from '../../../../../platform/endpoint/test/node/mockEndpoint';
 import { messageToMarkdown } from '../../../../../platform/log/common/messageStringify';
 import { IResponseDelta } from '../../../../../platform/networking/common/fetch';
+import { IMakeChatRequestOptions } from '../../../../../platform/networking/common/networking';
 import { ITestingServicesAccessor } from '../../../../../platform/test/node/services';
 import { TestWorkspaceService } from '../../../../../platform/test/node/testWorkspaceService';
 import { IWorkspaceService } from '../../../../../platform/workspace/common/workspaceService';
 import { createTextDocumentData } from '../../../../../util/common/test/shims/textDocument';
+import { Event } from '../../../../../util/vs/base/common/event';
 import { URI } from '../../../../../util/vs/base/common/uri';
 import { SyncDescriptor } from '../../../../../util/vs/platform/instantiation/common/descriptors';
 import { IInstantiationService } from '../../../../../util/vs/platform/instantiation/common/instantiation';
@@ -34,6 +37,15 @@ import { ISessionTranscriptService, NullSessionTranscriptService } from '../../.
 import { ITokenizerProvider } from '../../../../../platform/tokenizer/node/tokenizer';
 import { appendTranscriptHintToSummary, ConversationHistorySummarizationPrompt, extractSummary, stripToolSearchMessages, SummarizedConversationHistory, SummarizedConversationHistoryMetadata, SummarizedConversationHistoryPropsBuilder } from '../summarizedConversationHistory';
 
+class NullEndpointProvider implements IEndpointProvider {
+	declare readonly _serviceBrand: undefined;
+	readonly onDidModelsRefresh = Event.None;
+	async getAllCompletionModels(): Promise<[]> { return []; }
+	async getAllChatEndpoints(): Promise<[]> { return []; }
+	async getChatEndpoint(): Promise<never> { throw new Error('not implemented'); }
+	async getEmbeddingsEndpoint(): Promise<never> { throw new Error('not implemented'); }
+}
+
 suite('Agent Summarization', () => {
 	let accessor: ITestingServicesAccessor;
 	let chatResponse: (string | IResponseDelta[])[] = [];
@@ -45,6 +57,7 @@ suite('Agent Summarization', () => {
 		const testDoc = createTextDocumentData(fileTsUri, 'line 1\nline 2\n\nline 4\nline 5', 'ts').document;
 
 		const services = createExtensionUnitTestingServices();
+		services.define(IEndpointProvider, new NullEndpointProvider());
 		services.define(IWorkspaceService, new SyncDescriptor(
 			TestWorkspaceService,
 			[
@@ -432,6 +445,31 @@ suite('Agent Summarization', () => {
 		expect(summaryMeta).toBeDefined();
 		expect(summaryMeta!.text).toBe('summarized successfully!');
 		expect(summaryMeta!.toolCallRoundId).toBeTruthy();
+	});
+
+	test('Responses API summarization keeps stateful marker reuse on HTTP', async () => {
+		const { instaService, endpoint, historyProps, testConversation } = createSummarizationTestContext();
+		Object.defineProperty(endpoint, 'apiType', { value: 'responses' });
+
+		let capturedOptions: IMakeChatRequestOptions | undefined;
+		endpoint.makeChatRequest2 = async (options) => {
+			capturedOptions = options;
+			return {
+				type: ChatFetchResponseType.Success,
+				requestId: 'summary-request',
+				serverRequestId: 'summary-server-request',
+				usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0, prompt_tokens_details: { cached_tokens: 0 } },
+				value: 'summarized successfully!',
+				resolvedModel: endpoint.model,
+			};
+		};
+
+		const renderer = PromptRenderer.create(instaService, endpoint, SummarizedConversationHistory, historyProps);
+		await renderer.render();
+
+		expect(capturedOptions?.conversationId).toBe(testConversation.sessionId);
+		expect(capturedOptions?.useWebSocket).toBe(false);
+		expect(capturedOptions?.ignoreStatefulMarker).toBe(false);
 	});
 
 	test('failed summarization does not set round.summary', async () => {

--- a/extensions/copilot/src/platform/configuration/common/configurationService.ts
+++ b/extensions/copilot/src/platform/configuration/common/configurationService.ts
@@ -933,6 +933,8 @@ export namespace ConfigKey {
 	export const ResponsesApiContextManagementEnabled = defineSetting<boolean>('chat.responsesApiContextManagement.enabled', ConfigType.ExperimentBased, false);
 	/** Enable client-side prompt_cache_key (conversationId:modelFamily) sent to Responses API */
 	export const ResponsesApiPromptCacheKeyEnabled = defineSetting<boolean>('chat.responsesApi.promptCacheKey.enabled', ConfigType.ExperimentBased, false);
+	/** Enable stateful marker reuse for OpenAI Responses API compaction requests */
+	export const ResponsesApiCompactionStatefulMarkerEnabled = defineSetting<boolean>('chat.responsesApi.compactionStatefulMarker.enabled', ConfigType.ExperimentBased, false);
 	/** Enable tool search for Responses API (client-side deferred tool loading). */
 	export const ResponsesApiToolSearchEnabled = defineSetting<boolean>('chat.responsesApi.toolSearchTool.enabled', ConfigType.ExperimentBased, false);
 	/** Enable updated prompt for 5.3Codex model */


### PR DESCRIPTION
## Summary
- add an experiment-backed `chat.responsesApi.compactionStatefulMarker.enabled` flag, defaulting off
- keep OpenAI Responses conversation compaction requests on HTTP in both flag states; when the flag is enabled, explicitly opt out of the WebSocket path while passing `conversationId`
- when enabled, explicitly allow stateful marker reuse for foreground and background compaction so valid copied markers can produce `previous_response_id`
- add focused coverage for enabled and default-off Responses API summarization request options and isolate affected tests from endpoint metadata cache hydration
