### PR TITLE
Honor explicit subagent frontmatter opt-in for the todo tool

### DIFF
--- a/src/vs/workbench/contrib/chat/common/tools/builtinTools/runSubagentTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/builtinTools/runSubagentTool.ts
@@ -294,7 +294,9 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 				modeTools[RunSubagentTool.Id] = depthAllowed; // only enable the Run Subagent tool if we are under the max depth limit
 			}
 
-			modeTools[ManageTodoListToolToolId] = false;
+			if (modeTools[ManageTodoListToolToolId] !== true) {
+				modeTools[ManageTodoListToolToolId] = false;
+			}
 			modeTools['copilot_askQuestions'] = false;
 
 			if (maxDepth > 0) {


### PR DESCRIPTION
Fixes #313520

The `runSubagent` tool was unconditionally disabling `manage_todo_list` for all subagents, even when the subagent's frontmatter explicitly listed it in `tools:`. This blocked the legitimate workflow described in the issue — a parent agent populating a todo list, dispatching one subagent per task, and having each subagent mark its task done in the shared list.

This change respects an explicit `true` from the subagent's frontmatter while preserving the existing safe default (the tool remains off for subagents that don't opt in). `copilot_askQuestions` continues to be unconditionally disabled for subagents (unchanged).

### Before vs. after

| Subagent frontmatter | Before | After |
|---|---|---|
| (no `tools:`, or omits todo) | todo disabled | todo disabled (unchanged) |
| `tools: ['manage_todo_list']` | **silently disabled** | **enabled** |

### Notes

- Mirrors the existing pattern just above for `RunSubagentTool.Id`, which already respects an explicit `false` from frontmatter.
- The unconditional disable was added in #276553 to prevent recursive subagents; the todo disable was bundled defensively without a specific harm scenario. An explicit opt-in via frontmatter is a clear signal of user intent.
- No test added: the mutation lives inside `invoke()`, which is not exercised by the existing `runSubagentTool.test.ts`. Prior changes to these lines (#276553, #291780, #302944) also shipped without tests.