### PR TITLE
Fix BYOK model picker grouping

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -85,7 +85,7 @@ function getVendorDisplayName(languageModelsService: ILanguageModelsService, ven
  * Identifies a provider group bucket in the model picker. A bucket is
  * defined by `(vendor, groupName)` so that BYOK setups with multiple
  * user-configured groups under the same vendor (e.g. two `customoai`
- * entries named "OpenAI Compatible" and "AWS Bedrock") are surfaced as
+ * entries named "Provider 1" and "Provider 2") are surfaced as
  * distinct sections — matching what the model configuration view shows.
  */
 type ProviderGroupKey = string;

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -81,6 +81,67 @@ function getVendorDisplayName(languageModelsService: ILanguageModelsService, ven
 	return vendor.charAt(0).toUpperCase() + vendor.slice(1);
 }
 
+/**
+ * Identifies a provider group bucket in the model picker. A bucket is
+ * defined by `(vendor, groupName)` so that BYOK setups with multiple
+ * user-configured groups under the same vendor (e.g. two `customoai`
+ * entries named "OpenAI Compatible" and "AWS Bedrock") are surfaced as
+ * distinct sections — matching what the model configuration view shows.
+ */
+type ProviderGroupKey = string;
+
+function getProviderGroupKey(vendor: string, groupName: string): ProviderGroupKey {
+	return `${vendor}\u0000${groupName}`;
+}
+
+interface IProviderGroupInfo {
+	readonly vendor: string;
+	readonly groupName: string;
+}
+
+/**
+ * Builds a `modelIdentifier -> { vendor, groupName }` lookup by walking
+ * `getLanguageModelGroups()` for every registered vendor. Mirrors the
+ * grouping used by `chatModelsViewModel.ts` so the picker and the model
+ * configuration view stay aligned.
+ */
+function buildModelToProviderGroupMap(languageModelsService: ILanguageModelsService): Map<string, IProviderGroupInfo> {
+	const map = new Map<string, IProviderGroupInfo>();
+	for (const vendor of languageModelsService.getVendors()) {
+		const groups = languageModelsService.getLanguageModelGroups(vendor.vendor);
+		for (const group of groups) {
+			// `group.group` is undefined for built-in vendors that have no
+			// user configuration; fall back to the vendor display name so
+			// the bucket key matches the single-section render path.
+			const groupName = group.group?.name ?? vendor.displayName;
+			for (const identifier of group.modelIdentifiers) {
+				map.set(identifier, { vendor: vendor.vendor, groupName });
+			}
+		}
+	}
+	return map;
+}
+
+/**
+ * Resolves the provider group for a model, falling back to the vendor
+ * display name when no group entry is registered (e.g. legacy vendors or
+ * tests that stub out `getLanguageModelGroups`).
+ */
+function getProviderGroupForModel(
+	model: ILanguageModelChatMetadataAndIdentifier,
+	modelToGroup: Map<string, IProviderGroupInfo>,
+	languageModelsService: ILanguageModelsService,
+): IProviderGroupInfo {
+	const info = modelToGroup.get(model.identifier);
+	if (info) {
+		return info;
+	}
+	return {
+		vendor: model.metadata.vendor,
+		groupName: getVendorDisplayName(languageModelsService, model.metadata.vendor),
+	};
+}
+
 type ChatModelChangeClassification = {
 	owner: 'lramos15';
 	comment: 'Reporting when the model picker is switched';
@@ -297,9 +358,15 @@ function createManageModelsAction(commandService: ICommandService): IActionWidge
  * 2. Promoted section (selected + recently used + featured models from control manifest)
  *    - Available models sorted alphabetically, followed by unavailable models
  *    - Unavailable models show upgrade/update/admin status
- *    - Promoted models show an inline source label next to the model name
- * 3. Other Models (collapsible toggle) - models grouped by vendor with separator headers
- *    - Each vendor group has a titled separator header
+ *    - Promoted models show an inline source label (the provider group
+ *      name) when more than one group is configured.
+ * 3. Other Models (collapsible toggle) - models grouped by provider group
+ *    (vendor + user-configured group name) with separator headers
+ *    - Each provider group has a titled separator header. This matches
+ *      the buckets shown in the model configuration view, so a BYOK setup
+ *      with several groups under a single vendor (e.g. an "OpenAI
+ *      Compatible" group and an "AWS Bedrock" group both registered to
+ *      the `customoai` vendor) renders as distinct sections.
  * 4. Optional "Manage Models..." action shown in Other Models after a separator
  */
 export function buildModelPickerItems(
@@ -335,6 +402,13 @@ export function buildModelPickerItems(
 
 	if (useGroupedModelPicker) {
 		let otherModels: ILanguageModelChatMetadataAndIdentifier[] = [];
+		// Build a lookup so each model can be assigned to its provider group
+		// (vendor + user-configured group name). This must happen before both
+		// the promoted-section badge logic and the Other Models grouping so
+		// that both surfaces use the same notion of "distinct provider".
+		const modelToGroup = languageModelsService
+			? buildModelToProviderGroupMap(languageModelsService)
+			: new Map<string, IProviderGroupInfo>();
 		if (models.length) {
 			// Collect all available models into lookup maps
 			const allModelsMap = new Map<string, ILanguageModelChatMetadataAndIdentifier>();
@@ -445,7 +519,8 @@ export function buildModelPickerItems(
 			}
 
 			// Render promoted section: available first, then sorted alphabetically by name.
-			// Promoted models show their vendor name inline only when multiple vendors are present.
+			// Promoted models show their provider group name inline only when more
+			// than one provider group is configured across all models.
 			if (promotedItems.length > 0) {
 				promotedItems.sort((a, b) => {
 					const aAvail = a.kind === 'available' ? 0 : 1;
@@ -458,21 +533,28 @@ export function buildModelPickerItems(
 					return aName.localeCompare(bName);
 				});
 
-				const allVendors = new Set(models.map(m => m.metadata.vendor));
-				const showPromotedVendorLabel = allVendors.size > 1;
+				const allGroupKeys = new Set(
+					models.map(m => {
+						const info = getProviderGroupForModel(m, modelToGroup, languageModelsService!);
+						return getProviderGroupKey(info.vendor, info.groupName);
+					})
+				);
+				const showPromotedGroupLabel = allGroupKeys.size > 1;
 
 				for (const item of promotedItems) {
 					if (item.kind === 'available') {
-						const vendorLabel = showPromotedVendorLabel ? getVendorDisplayName(languageModelsService!, item.model.metadata.vendor) : undefined;
-						const { action: promotedAction, descriptionOverride: promotedDesc } = createModelAction(item.model, selectedModelId, onSelect, languageModelsService!, undefined, showPromotedVendorLabel, isUBB);
-						items.push(createModelItem(promotedAction, item.model, promotedDesc, openerService, vendorLabel, isUBB));
+						const groupLabel = showPromotedGroupLabel
+							? getProviderGroupForModel(item.model, modelToGroup, languageModelsService!).groupName
+							: undefined;
+						const { action: promotedAction, descriptionOverride: promotedDesc } = createModelAction(item.model, selectedModelId, onSelect, languageModelsService!, undefined, showPromotedGroupLabel, isUBB);
+						items.push(createModelItem(promotedAction, item.model, promotedDesc, openerService, groupLabel, isUBB));
 					} else {
 						items.push(createUnavailableModelItem(item.id, item.entry, item.reason, manageSettingsUrl, updateStateType, chatEntitlementService));
 					}
 				}
 			}
 
-			// --- 3. Other Models (collapsible, grouped by vendor) ---
+			// --- 3. Other Models (collapsible, grouped by provider group) ---
 			otherModels = models.filter(m => !placed.has(m.identifier) && !placed.has(m.metadata.id));
 
 			if (otherModels.length > 0) {
@@ -502,42 +584,47 @@ export function buildModelPickerItems(
 					className: 'chat-model-picker-section-toggle',
 				});
 
-				// Group remaining models by vendor and create collapsible vendor sub-sections
-				const vendorGroups = new Map<string, ILanguageModelChatMetadataAndIdentifier[]>();
+				// Group remaining models by provider group (vendor + user-configured
+				// group name). This matches `chatModelsViewModel.getProviderGroupId`,
+				// so that BYOK setups with several groups under a single vendor
+				// (e.g. multiple `customoai` entries) render as distinct sections.
+				interface IProviderGroupBucket {
+					vendor: string;
+					groupName: string;
+					models: ILanguageModelChatMetadataAndIdentifier[];
+				}
+				const providerGroups = new Map<ProviderGroupKey, IProviderGroupBucket>();
 				for (const model of otherModels) {
-					const vendor = model.metadata.vendor;
-					let group = vendorGroups.get(vendor);
-					if (!group) {
-						group = [];
-						vendorGroups.set(vendor, group);
+					const info = getProviderGroupForModel(model, modelToGroup, languageModelsService!);
+					const key = getProviderGroupKey(info.vendor, info.groupName);
+					let bucket = providerGroups.get(key);
+					if (!bucket) {
+						bucket = { vendor: info.vendor, groupName: info.groupName, models: [] };
+						providerGroups.set(key, bucket);
 					}
-					group.push(model);
+					bucket.models.push(model);
 				}
 
-				// Sort vendors: copilot first, then alphabetically by display name
-				const sortedVendors = [...vendorGroups.keys()].sort((a, b) => {
-					if (a === 'copilot') { return -1; }
-					if (b === 'copilot') { return 1; }
-					return getVendorDisplayName(languageModelsService!, a).localeCompare(getVendorDisplayName(languageModelsService!, b));
+				// Sort buckets: copilot vendor first, then alphabetically by group name
+				const sortedBuckets = [...providerGroups.values()].sort((a, b) => {
+					if (a.vendor === 'copilot' && b.vendor !== 'copilot') { return -1; }
+					if (b.vendor === 'copilot' && a.vendor !== 'copilot') { return 1; }
+					return a.groupName.localeCompare(b.groupName);
 				});
 
-				const showVendorHeaders = sortedVendors.length > 1;
+				const showGroupHeaders = sortedBuckets.length > 1;
 
-				for (const vendor of sortedVendors) {
-					const vendorModels = vendorGroups.get(vendor)!;
-
-					if (showVendorHeaders) {
-						const vendorDisplayName = getVendorDisplayName(languageModelsService!, vendor);
-						// Vendor separator header
+				for (const bucket of sortedBuckets) {
+					if (showGroupHeaders) {
 						items.push({
 							kind: ActionListItemKind.Separator,
-							label: vendorDisplayName,
+							label: bucket.groupName,
 							section: ModelPickerSection.Other,
 						});
 					}
 
-					// Vendor models sorted: available first, then alphabetically by name
-					const sortedVendorModels = [...vendorModels].sort((a, b) => {
+					// Models within a bucket sorted: available first, then alphabetically by name
+					const sortedBucketModels = [...bucket.models].sort((a, b) => {
 						const aEntry = controlModels[a.metadata.id] ?? controlModels[a.identifier];
 						const bEntry = controlModels[b.metadata.id] ?? controlModels[b.identifier];
 						const aAvail = aEntry?.minVSCodeVersion && !isVersionAtLeast(currentVSCodeVersion, aEntry.minVSCodeVersion) ? 1 : 0;
@@ -546,13 +633,13 @@ export function buildModelPickerItems(
 						return a.metadata.name.localeCompare(b.metadata.name);
 					});
 
-					for (const model of sortedVendorModels) {
+					for (const model of sortedBucketModels) {
 						const entry = controlModels[model.metadata.id] ?? controlModels[model.identifier];
 						if (entry?.minVSCodeVersion && !isVersionAtLeast(currentVSCodeVersion, entry.minVSCodeVersion)) {
 							items.push(createUnavailableModelItem(model.metadata.id, entry, 'update', manageSettingsUrl, updateStateType, chatEntitlementService, ModelPickerSection.Other));
 						} else {
-							const { action: vendorAction, descriptionOverride: vendorDesc } = createModelAction(model, selectedModelId, onSelect, languageModelsService!, ModelPickerSection.Other, showVendorHeaders, isUBB);
-							items.push(createModelItem(vendorAction, model, vendorDesc, openerService, undefined, isUBB));
+							const { action: bucketAction, descriptionOverride: bucketDesc } = createModelAction(model, selectedModelId, onSelect, languageModelsService!, ModelPickerSection.Other, showGroupHeaders, isUBB);
+							items.push(createModelItem(bucketAction, model, bucketDesc, openerService, undefined, isUBB));
 						}
 					}
 				}

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelPicker.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelPicker.test.ts
@@ -69,7 +69,32 @@ const stubManageModelsAction: IActionWidgetDropdownAction = {
 	run: () => { }
 };
 
-const stubLanguageModelsService = { getModelConfigurationActions: () => [], getModelConfiguration: () => undefined, getVendors: () => [] } as unknown as ILanguageModelsService;
+const stubLanguageModelsService = { getModelConfigurationActions: () => [], getModelConfiguration: () => undefined, getVendors: () => [], getLanguageModelGroups: () => [] } as unknown as ILanguageModelsService;
+
+/**
+ * Builds a `ILanguageModelsService` stub that simulates BYOK provider
+ * groups: each `vendors` entry advertises one or more user-configured
+ * groups (mapping group name to model identifiers). Used to exercise the
+ * picker's `(vendor, groupName)` bucketing without spinning up the real
+ * service.
+ */
+function createLanguageModelsServiceStub(vendors: { vendor: string; displayName: string; groups: { name: string; modelIdentifiers: string[] }[] }[]): ILanguageModelsService {
+	return {
+		getModelConfigurationActions: () => [],
+		getModelConfiguration: () => undefined,
+		getVendors: () => vendors.map(v => ({ vendor: v.vendor, displayName: v.displayName })),
+		getLanguageModelGroups: (vendor: string) => {
+			const v = vendors.find(x => x.vendor === vendor);
+			if (!v) {
+				return [];
+			}
+			return v.groups.map(g => ({
+				group: { vendor: v.vendor, name: g.name },
+				modelIdentifiers: g.modelIdentifiers,
+			}));
+		},
+	} as unknown as ILanguageModelsService;
+}
 
 function callBuild(
 	models: ILanguageModelChatMetadataAndIdentifier[],
@@ -85,6 +110,7 @@ function callBuild(
 		showUnavailableFeatured?: boolean;
 		showFeatured?: boolean;
 		isUBB?: boolean;
+		languageModelsService?: ILanguageModelsService;
 	} = {},
 ): IActionListItem<IActionWidgetDropdownAction>[] {
 	const onSelect = () => { };
@@ -106,7 +132,7 @@ function callBuild(
 		entitlementService,
 		opts.showUnavailableFeatured ?? true,
 		opts.showFeatured ?? true,
-		stubLanguageModelsService,
+		opts.languageModelsService ?? stubLanguageModelsService,
 		undefined,
 		opts.isUBB,
 	);
@@ -492,6 +518,68 @@ suite('buildModelPickerItems', () => {
 		// No vendor separators when all models share the same vendor
 		const vendorSeparators = items.filter(i => i.kind === ActionListItemKind.Separator && i.label);
 		assert.strictEqual(vendorSeparators.length, 0);
+	});
+
+	test('Other Models splits a single vendor into per-group sections (BYOK)', () => {
+		// Simulates a BYOK setup where one vendor (`customoai`) advertises
+		// two user-configured provider groups. The picker should mirror the
+		// model configuration view and render one section per group rather
+		// than collapsing them under the vendor display name.
+		const auto = createAutoModel();
+		const gpt41 = createModel('gpt-4.1', 'gpt-4.1', 'customoai');
+		const ossModel = createModel('openai.gpt-oss-120b', 'gpt-oss-120b', 'customoai');
+		const lmService = createLanguageModelsServiceStub([
+			{
+				vendor: 'customoai',
+				displayName: 'OpenAI Compatible',
+				groups: [
+					{ name: 'OpenAI Compatible', modelIdentifiers: [gpt41.identifier] },
+					{ name: 'AWS Bedrock', modelIdentifiers: [ossModel.identifier] },
+				],
+			},
+		]);
+		const items = callBuild([auto, gpt41, ossModel], { languageModelsService: lmService });
+		const labelledSeparators = items.filter(i => i.kind === ActionListItemKind.Separator && i.label);
+		assert.deepStrictEqual(labelledSeparators.map(s => s.label), ['AWS Bedrock', 'OpenAI Compatible']);
+	});
+
+	test('Other Models keeps a single section when a vendor has only one group (BYOK)', () => {
+		const auto = createAutoModel();
+		const gpt41 = createModel('gpt-4.1', 'gpt-4.1', 'customoai');
+		const lmService = createLanguageModelsServiceStub([
+			{
+				vendor: 'customoai',
+				displayName: 'OpenAI Compatible',
+				groups: [{ name: 'OpenAI Compatible', modelIdentifiers: [gpt41.identifier] }],
+			},
+		]);
+		const items = callBuild([auto, gpt41], { languageModelsService: lmService });
+		const labelledSeparators = items.filter(i => i.kind === ActionListItemKind.Separator && i.label);
+		assert.strictEqual(labelledSeparators.length, 0);
+	});
+
+	test('promoted models show provider group name when groups disambiguate a single vendor (BYOK)', () => {
+		const auto = createAutoModel();
+		const gpt41 = createModel('gpt-4.1', 'gpt-4.1', 'customoai');
+		const ossModel = createModel('openai.gpt-oss-120b', 'gpt-oss-120b', 'customoai');
+		const lmService = createLanguageModelsServiceStub([
+			{
+				vendor: 'customoai',
+				displayName: 'OpenAI Compatible',
+				groups: [
+					{ name: 'OpenAI Compatible', modelIdentifiers: [gpt41.identifier] },
+					{ name: 'AWS Bedrock', modelIdentifiers: [ossModel.identifier] },
+				],
+			},
+		]);
+		const items = callBuild([auto, gpt41, ossModel], {
+			recentModelIds: [gpt41.identifier],
+			languageModelsService: lmService,
+		});
+		const promoted = getActionItems(items).find(a => a.label === 'gpt-4.1');
+		assert.ok(promoted);
+		// Badge should carry the user-configured group name, not the vendor displayName.
+		assert.strictEqual(promoted.badge, 'OpenAI Compatible');
 	});
 
 	test('onSelect callback is wired into action items', () => {


### PR DESCRIPTION
## Fix BYOK model picker grouping

The chat model picker grouped "Other Models" by **vendor** alone, so a BYOK setup with multiple user-configured groups under one vendor (e.g. two `customoai` entries named "OpenAI Compatible" and "AWS Bedrock") collapsed into a single section under the vendor's display name. The model configuration view already keys buckets on `(vendor, group.name)` via `getProviderGroupId`, so the two surfaces disagreed.

### Before / After

| Before (broken) | After (fixed) |
|---|---|
| One "OpenAI Compatible" header containing both `gpt-4.1` and `gpt-oss-120b` | Two headers — "OpenAI Compatible" with `gpt-4.1`, and "AWS Bedrock" with `gpt-oss-120b` — matching the model configuration view |