### PR TITLE
Responses API: translate terminal events into typed completions

### DIFF
--- a/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
@@ -20,7 +20,7 @@ import { ILogService } from '../../log/common/logService';
 import { CUSTOM_TOOL_SEARCH_NAME } from '../../networking/common/anthropic';
 import { FinishedCallback, getRequestId, IResponseDelta, OpenAiFunctionTool, OpenAiResponsesFunctionTool, OpenAiToolSearchTool } from '../../networking/common/fetch';
 import { IChatEndpoint, ICreateEndpointBodyOptions, IEndpointBody } from '../../networking/common/networking';
-import { ChatCompletion, FinishedCompletionReason, modelsWithoutResponsesContextManagement, openAIContextManagementCompactionType, OpenAIContextManagementResponse, rawMessageToCAPI, TokenLogProb } from '../../networking/common/openai';
+import { ChatCompletion, FilterReason, FinishedCompletionReason, modelsWithoutResponsesContextManagement, openAIContextManagementCompactionType, OpenAIContextManagementResponse, rawMessageToCAPI, TokenLogProb } from '../../networking/common/openai';
 import { IToolDeferralService } from '../../networking/common/toolDeferralService';
 import { sendEngineMessagesTelemetry, sendResponsesApiCompactionTelemetry } from '../../networking/node/chatStream';
 import { IChatWebSocketManager } from '../../networking/node/chatWebSocketManager';
@@ -892,6 +892,73 @@ interface CapiResponseCompletedEvent extends OpenAI.Responses.ResponseCompletedE
 	};
 }
 
+/**
+ * Terminal Responses-API events (`response.completed`, `response.incomplete`,
+ * `response.failed`). CAPI extends the standard payload with a `content_filters`
+ * array that carries the actual block reason when a response is cut short by a
+ * content filter (e.g. `TextCopyright`). The OpenAI types don't include this
+ * field, so we narrow with a local interface.
+ */
+interface CapiResponseTerminalEvent {
+	response: OpenAI.Responses.Response & {
+		content_filters?: CapiContentFilterEntry[] | null;
+	};
+}
+
+interface CapiContentFilterEntry {
+	source_type?: 'prompt' | 'completion' | string;
+	blocked?: boolean;
+	content_filter_raw?: Array<{ action?: string; label?: string; result?: unknown }>;
+	content_filter_results?: Record<string, { filtered?: boolean; severity?: string } | undefined>;
+}
+
+/**
+ * Map CAPI's `content_filters` (sent on a terminal Responses event when a
+ * response is blocked) to a {@link FilterReason}. Returns `undefined` if no
+ * reason can be deduced; the caller defaults to {@link FilterReason.Copyright}.
+ */
+function extractFilterReasonFromContentFilters(filters: CapiContentFilterEntry[] | null | undefined): FilterReason | undefined {
+	if (!filters) {
+		return undefined;
+	}
+	// Prefer a completion-side block; if none, fall back to a prompt-side block.
+	const blocked = filters.filter(f => f.blocked);
+	const completion = blocked.find(f => f.source_type === 'completion') ?? blocked[0];
+	if (!completion) {
+		return undefined;
+	}
+	// Look for a definitive BLOCK action in content_filter_raw. The label
+	// `TextCopyright` maps to our Copyright filter; the multi-severity labels
+	// map to hate/self-harm/sexual/violence.
+	const blockingRule = completion.content_filter_raw?.find(r => r.action === 'BLOCK' && r.result === true);
+	const label = blockingRule?.label?.toLowerCase() ?? '';
+	if (label.includes('copyright')) {
+		return FilterReason.Copyright;
+	}
+	if (label.includes('selfharm') || label.includes('self_harm')) {
+		return FilterReason.SelfHarm;
+	}
+	if (label.includes('sexual')) {
+		return FilterReason.Sexual;
+	}
+	if (label.includes('violence')) {
+		return FilterReason.Violence;
+	}
+	if (label.includes('hate')) {
+		return FilterReason.Hate;
+	}
+	// Fall back to the Azure-style per-category result map.
+	const results = completion.content_filter_results ?? {};
+	if (results.hate?.filtered) { return FilterReason.Hate; }
+	if (results.self_harm?.filtered) { return FilterReason.SelfHarm; }
+	if (results.sexual?.filtered) { return FilterReason.Sexual; }
+	if (results.violence?.filtered) { return FilterReason.Violence; }
+	if (completion.source_type === 'prompt') {
+		return FilterReason.Prompt;
+	}
+	return undefined;
+}
+
 export class OpenAIResponsesProcessor {
 	private textAccumulator: string = '';
 	private hasReceivedReasoningSummary = false;
@@ -1174,7 +1241,82 @@ export class OpenAIResponsesProcessor {
 					}
 				};
 			}
+			case 'response.incomplete': {
+				const incomplete = chunk.response as CapiResponseTerminalEvent['response'];
+				const reason = incomplete.incomplete_details?.reason;
+				let finishReason: FinishedCompletionReason;
+				let filterReason: FilterReason | undefined;
+				if (reason === 'max_output_tokens') {
+					finishReason = FinishedCompletionReason.Length;
+				} else if (reason === 'content_filter') {
+					finishReason = FinishedCompletionReason.ContentFilter;
+					filterReason = extractFilterReasonFromContentFilters(incomplete.content_filters);
+				} else {
+					// Unknown incomplete reason — treat as a server-side stream termination so the
+					// caller surfaces a "request failed" message instead of the generic flake.
+					finishReason = FinishedCompletionReason.ServerError;
+				}
+				return this.buildTerminalCompletion(incomplete, finishReason, { filterReason });
+			}
+			case 'response.failed': {
+				const failed = chunk.response as CapiResponseTerminalEvent['response'];
+				return this.buildTerminalCompletion(failed, FinishedCompletionReason.ServerError);
+			}
 		}
+	}
+
+	/**
+	 * Build a {@link ChatCompletion} for a terminal Responses API event other than
+	 * `response.completed` (i.e. `response.incomplete` or `response.failed`). The
+	 * resulting completion is fed into the same downstream switch as a normal
+	 * completion so callers can map it to the appropriate user-facing error.
+	 */
+	private buildTerminalCompletion(
+		response: CapiResponseTerminalEvent['response'],
+		finishReason: FinishedCompletionReason,
+		opts: { filterReason?: FilterReason } = {}
+	): ChatCompletion {
+		const output = response.output ?? [];
+		return {
+			blockFinished: true,
+			choiceIndex: 0,
+			model: response.model,
+			tokens: [],
+			telemetryData: this.telemetryData,
+			requestId: {
+				headerRequestId: this.requestId,
+				gitHubRequestId: this.ghRequestId,
+				completionId: response.id,
+				created: response.created_at,
+				deploymentId: '',
+				serverExperiments: this.serverExperiments,
+			},
+			usage: response.usage ? {
+				prompt_tokens: response.usage.input_tokens ?? 0,
+				completion_tokens: response.usage.output_tokens ?? 0,
+				total_tokens: response.usage.total_tokens ?? 0,
+				prompt_tokens_details: {
+					cached_tokens: response.usage.input_tokens_details?.cached_tokens ?? 0,
+				},
+				completion_tokens_details: {
+					reasoning_tokens: response.usage.output_tokens_details?.reasoning_tokens ?? 0,
+					accepted_prediction_tokens: 0,
+					rejected_prediction_tokens: 0,
+				},
+			} : undefined,
+			finishReason,
+			filterReason: opts.filterReason,
+			message: {
+				role: Raw.ChatRole.Assistant,
+				content: output.map((item): Raw.ChatCompletionContentPart | undefined => {
+					if (item.type === 'message') {
+						return { type: Raw.ChatCompletionContentPartKind.Text, text: item.content.map(c => c.type === 'output_text' ? c.text : c.refusal).join('') };
+					} else if (item.type === 'image_generation_call' && item.result) {
+						return { type: Raw.ChatCompletionContentPartKind.Image, imageUrl: { url: item.result } };
+					}
+				}).filter(isDefined),
+			},
+		};
 	}
 }
 

--- a/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
@@ -20,7 +20,7 @@ import { ILogService } from '../../log/common/logService';
 import { CUSTOM_TOOL_SEARCH_NAME } from '../../networking/common/anthropic';
 import { FinishedCallback, getRequestId, IResponseDelta, OpenAiFunctionTool, OpenAiResponsesFunctionTool, OpenAiToolSearchTool } from '../../networking/common/fetch';
 import { IChatEndpoint, ICreateEndpointBodyOptions, IEndpointBody } from '../../networking/common/networking';
-import { ChatCompletion, FilterReason, FinishedCompletionReason, modelsWithoutResponsesContextManagement, openAIContextManagementCompactionType, OpenAIContextManagementResponse, rawMessageToCAPI, TokenLogProb } from '../../networking/common/openai';
+import { APIErrorResponse, ChatCompletion, FilterReason, FinishedCompletionReason, modelsWithoutResponsesContextManagement, openAIContextManagementCompactionType, OpenAIContextManagementResponse, rawMessageToCAPI, TokenLogProb } from '../../networking/common/openai';
 import { IToolDeferralService } from '../../networking/common/toolDeferralService';
 import { sendEngineMessagesTelemetry, sendResponsesApiCompactionTelemetry } from '../../networking/node/chatStream';
 import { IChatWebSocketManager } from '../../networking/node/chatWebSocketManager';
@@ -896,8 +896,17 @@ interface CapiResponseCompletedEvent extends OpenAI.Responses.ResponseCompletedE
  * Terminal Responses-API events (`response.completed`, `response.incomplete`,
  * `response.failed`). CAPI extends the standard payload with a `content_filters`
  * array that carries the actual block reason when a response is cut short by a
- * content filter (e.g. `TextCopyright`). The OpenAI types don't include this
- * field, so we narrow with a local interface.
+ * content filter. The OpenAI types don't include this field, so we narrow with
+ * a local interface.
+ *
+ * Two shapes are observed on the wire and we handle both:
+ *  - `content_filter_results` is the per-category structured map defined by the
+ *    Azure REST spec ({@link https://learn.microsoft.com/azure/ai-services/openai/concepts/content-filter | docs});
+ *    e.g. `{ hate: { filtered: true, severity: 'high' }, protected_material_text: { filtered: true } }`.
+ *  - `content_filter_raw` is a CAPI-internal/legacy passthrough that carries the
+ *    raw RAI rule decisions (`{ action: 'BLOCK', label: 'TextCopyright', result: true }`)
+ *    and is not in the Azure spec. It's currently what production emits, so we
+ *    match it first and only fall back to the structured map.
  */
 interface CapiResponseTerminalEvent {
 	response: OpenAI.Responses.Response & {
@@ -909,7 +918,7 @@ interface CapiContentFilterEntry {
 	source_type?: 'prompt' | 'completion' | string;
 	blocked?: boolean;
 	content_filter_raw?: Array<{ action?: string; label?: string; result?: unknown }>;
-	content_filter_results?: Record<string, { filtered?: boolean; severity?: string } | undefined>;
+	content_filter_results?: Record<string, { filtered?: boolean; severity?: string; detected?: boolean } | undefined>;
 }
 
 /**
@@ -947,16 +956,36 @@ function extractFilterReasonFromContentFilters(filters: CapiContentFilterEntry[]
 	if (label.includes('hate')) {
 		return FilterReason.Hate;
 	}
-	// Fall back to the Azure-style per-category result map.
+	// Fall back to the Azure-spec'd per-category result map (`AzureContentFilterResultsForResponsesAPI`).
 	const results = completion.content_filter_results ?? {};
 	if (results.hate?.filtered) { return FilterReason.Hate; }
 	if (results.self_harm?.filtered) { return FilterReason.SelfHarm; }
 	if (results.sexual?.filtered) { return FilterReason.Sexual; }
 	if (results.violence?.filtered) { return FilterReason.Violence; }
+	if (results.protected_material_text?.filtered || results.protected_material_code?.filtered) {
+		return FilterReason.Copyright;
+	}
 	if (completion.source_type === 'prompt') {
 		return FilterReason.Prompt;
 	}
 	return undefined;
+}
+
+/**
+ * Map a Responses-API `response.error` (string-coded per the OpenAI SDK) onto
+ * our {@link APIErrorResponse} shape (numeric `code`). We can't preserve the
+ * string code in `code`, so we stash it in `metadata.code` for BYOK diagnostics
+ * (which `JSON.stringify` the whole struct).
+ */
+function mapResponsesApiError(err: OpenAI.Responses.ResponseError | null | undefined): APIErrorResponse | undefined {
+	if (!err) {
+		return undefined;
+	}
+	return {
+		code: 0,
+		message: err.message ?? '',
+		metadata: { code: err.code },
+	};
 }
 
 export class OpenAIResponsesProcessor {
@@ -1256,11 +1285,16 @@ export class OpenAIResponsesProcessor {
 					// caller surfaces a "request failed" message instead of the generic flake.
 					finishReason = FinishedCompletionReason.ServerError;
 				}
-				return this.buildTerminalCompletion(incomplete, finishReason, { filterReason });
+				return this.buildTerminalCompletion(incomplete, finishReason, {
+					filterReason,
+					error: mapResponsesApiError(incomplete.error),
+				});
 			}
 			case 'response.failed': {
 				const failed = chunk.response as CapiResponseTerminalEvent['response'];
-				return this.buildTerminalCompletion(failed, FinishedCompletionReason.ServerError);
+				return this.buildTerminalCompletion(failed, FinishedCompletionReason.ServerError, {
+					error: mapResponsesApiError(failed.error),
+				});
 			}
 		}
 	}
@@ -1274,7 +1308,7 @@ export class OpenAIResponsesProcessor {
 	private buildTerminalCompletion(
 		response: CapiResponseTerminalEvent['response'],
 		finishReason: FinishedCompletionReason,
-		opts: { filterReason?: FilterReason } = {}
+		opts: { filterReason?: FilterReason; error?: APIErrorResponse } = {}
 	): ChatCompletion {
 		const output = response.output ?? [];
 		return {
@@ -1306,6 +1340,7 @@ export class OpenAIResponsesProcessor {
 			} : undefined,
 			finishReason,
 			filterReason: opts.filterReason,
+			error: opts.error,
 			message: {
 				role: Raw.ChatRole.Assistant,
 				content: output.map((item): Raw.ChatCompletionContentPart | undefined => {

--- a/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
@@ -1542,7 +1542,7 @@ describe('processResponseFromChatEndpoint terminal events', () => {
 					},
 				],
 				output: [
-					{ type: 'message', content: [{ type: 'output_text', text: "Got it — I'll do that now." }] },
+					{ type: 'message', content: [{ type: 'output_text', text: 'Got it — I\'ll do that now.' }] },
 				],
 			},
 		};

--- a/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
@@ -14,7 +14,7 @@ import { InMemoryConfigurationService } from '../../../configuration/test/common
 import { ILogService } from '../../../log/common/logService';
 import { isOpenAIContextManagementResponse } from '../../../networking/common/fetch';
 import { IChatEndpoint, ICreateEndpointBodyOptions } from '../../../networking/common/networking';
-import { openAIContextManagementCompactionType, OpenAIContextManagementResponse } from '../../../networking/common/openai';
+import { openAIContextManagementCompactionType, OpenAIContextManagementResponse, FilterReason, FinishedCompletionReason } from '../../../networking/common/openai';
 import { IToolDeferralService } from '../../../networking/common/toolDeferralService';
 import { IChatWebSocketManager, NullChatWebSocketManager } from '../../../networking/node/chatWebSocketManager';
 import { TelemetryData } from '../../../telemetry/common/telemetryData';
@@ -1492,5 +1492,104 @@ describe('phase commentary followed by phase final_answer', () => {
 
 		accessor.dispose();
 		services.dispose();
+	});
+});
+
+describe('processResponseFromChatEndpoint terminal events', () => {
+	async function runStream(sseBody: string) {
+		const services = createPlatformServices();
+		const accessor = services.createTestingAccessor();
+		const instantiationService = accessor.get(IInstantiationService);
+		const logService = accessor.get(ILogService);
+		const telemetryService = new SpyingTelemetryService();
+		const telemetryData = TelemetryData.createAndMarkAsIssued({ modelCallId: 'model-call-terminal' }, {});
+		const response = createFakeStreamResponse(sseBody);
+		const stream = await processResponseFromChatEndpoint(
+			instantiationService,
+			telemetryService,
+			logService,
+			response,
+			1,
+			async () => undefined,
+			telemetryData
+		);
+		const completions = [];
+		for await (const completion of stream) {
+			completions.push(completion);
+		}
+		accessor.dispose();
+		services.dispose();
+		return completions;
+	}
+
+	it('maps response.incomplete with reason=content_filter to ContentFilter + Copyright', async () => {
+		const incompleteEvent = {
+			type: 'response.incomplete',
+			response: {
+				id: 'resp_blocked',
+				model: 'gpt-5-mini',
+				created_at: 123,
+				incomplete_details: { reason: 'content_filter' },
+				content_filters: [
+					{ source_type: 'prompt', blocked: false },
+					{
+						source_type: 'completion',
+						blocked: true,
+						content_filter_raw: [
+							{ action: 'ANNOTATE', label: 'MultiSeverity_Sexual', result: { '0': 1 } },
+							{ action: 'BLOCK', label: 'TextCopyright', result: true },
+						],
+					},
+				],
+				output: [
+					{ type: 'message', content: [{ type: 'output_text', text: "Got it — I'll do that now." }] },
+				],
+			},
+		};
+
+		const [completion] = await runStream(`data: ${JSON.stringify(incompleteEvent)}\n\n`);
+
+		expect(completion).toBeDefined();
+		expect(completion.finishReason).toBe(FinishedCompletionReason.ContentFilter);
+		expect(completion.filterReason).toBe(FilterReason.Copyright);
+	});
+
+	it('maps response.incomplete with reason=max_output_tokens to Length', async () => {
+		const incompleteEvent = {
+			type: 'response.incomplete',
+			response: {
+				id: 'resp_length',
+				model: 'gpt-5-mini',
+				created_at: 123,
+				incomplete_details: { reason: 'max_output_tokens' },
+				output: [
+					{ type: 'message', content: [{ type: 'output_text', text: 'partial output' }] },
+				],
+			},
+		};
+
+		const [completion] = await runStream(`data: ${JSON.stringify(incompleteEvent)}\n\n`);
+
+		expect(completion).toBeDefined();
+		expect(completion.finishReason).toBe(FinishedCompletionReason.Length);
+		expect(completion.filterReason).toBeUndefined();
+	});
+
+	it('maps response.failed to ServerError', async () => {
+		const failedEvent = {
+			type: 'response.failed',
+			response: {
+				id: 'resp_failed',
+				model: 'gpt-5-mini',
+				created_at: 123,
+				error: { code: 'internal_error', message: 'something broke' },
+				output: [],
+			},
+		};
+
+		const [completion] = await runStream(`data: ${JSON.stringify(failedEvent)}\n\n`);
+
+		expect(completion).toBeDefined();
+		expect(completion.finishReason).toBe(FinishedCompletionReason.ServerError);
 	});
 });

--- a/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
@@ -14,7 +14,7 @@ import { InMemoryConfigurationService } from '../../../configuration/test/common
 import { ILogService } from '../../../log/common/logService';
 import { isOpenAIContextManagementResponse } from '../../../networking/common/fetch';
 import { IChatEndpoint, ICreateEndpointBodyOptions } from '../../../networking/common/networking';
-import { openAIContextManagementCompactionType, OpenAIContextManagementResponse, FilterReason, FinishedCompletionReason } from '../../../networking/common/openai';
+import { ChatCompletion, openAIContextManagementCompactionType, OpenAIContextManagementResponse, FilterReason, FinishedCompletionReason } from '../../../networking/common/openai';
 import { IToolDeferralService } from '../../../networking/common/toolDeferralService';
 import { IChatWebSocketManager, NullChatWebSocketManager } from '../../../networking/node/chatWebSocketManager';
 import { TelemetryData } from '../../../telemetry/common/telemetryData';
@@ -1513,7 +1513,7 @@ describe('processResponseFromChatEndpoint terminal events', () => {
 			async () => undefined,
 			telemetryData
 		);
-		const completions = [];
+		const completions: ChatCompletion[] = [];
 		for await (const completion of stream) {
 			completions.push(completion);
 		}
@@ -1591,5 +1591,10 @@ describe('processResponseFromChatEndpoint terminal events', () => {
 
 		expect(completion).toBeDefined();
 		expect(completion.finishReason).toBe(FinishedCompletionReason.ServerError);
+		expect(completion.error).toEqual({
+			code: 0,
+			message: 'something broke',
+			metadata: { code: 'internal_error' },
+		});
 	});
 });


### PR DESCRIPTION
## What

When CAPI ends a Responses-API stream with `response.incomplete` or `response.failed`, our SSE parser previously returned `undefined`. The downstream `chatMLFetcher.processSuccessfulResponse` then saw zero completions and fell to `ChatFetchResponseType.Unknown` → **"Sorry, no response was returned."** with a Try Again button.

For the common `incomplete_details.reason: "content_filter"` case this is misleading: the model's output was actually blocked by an Azure content filter (e.g. `TextCopyright`), and we should surface that instead of a generic flake.

## How

Translate terminal events into typed `ChatCompletion`s in `responsesApi.ts` so the existing `chatMLFetcher` switch can route them correctly — no fetcher changes.

| Terminal event                                       | `FinishedCompletionReason` | Notes                                                                          |
| ---------------------------------------------------- | -------------------------- | ------------------------------------------------------------------------------ |
| `response.incomplete` + `reason: 'content_filter'`   | `ContentFilter`            | Extracts `FilterReason` from CAPI `content_filters[].content_filter_raw` BLOCK labels (`TextCopyright` → Copyright, etc.) |
| `response.incomplete` + `reason: 'max_output_tokens'`| `Length`                   |                                                                                |
| `response.failed`                                    | `ServerError`              |                                                                                |

This routes through `chatMLFetcher`'s existing mapping:
- `ContentFilter` → `FilteredRetry` (renders the proper Copyright/etc. message)
- `Length` → `Length`
- `ServerError` → `Failed`

## Tests

Three new Vitest cases in `responsesApi.spec.ts` covering each branch. Full file: 38/38 pass.
