### PR TITLE
Preserve CLI slash commands in delegated sessions

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/copilotcli/common/pendingRequestContext.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/common/pendingRequestContext.ts
@@ -8,6 +8,7 @@ import type { Attachment, SendOptions } from '@github/copilot/sdk';
 export interface ICopilotCLIPendingRequestContext {
 	readonly prompt: string;
 	readonly attachments: Attachment[];
+	readonly command?: string;
 	readonly source?: SendOptions['source'];
 }
 

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
@@ -358,6 +358,14 @@ function getRemoteControlArgs(input: CopilotCLISessionInput): string {
 	return prompt;
 }
 
+function isRemoteControlPrompt(input: CopilotCLISessionInput): boolean {
+	if ('command' in input) {
+		return input.command === 'remote';
+	}
+	const prompt = stripReminders(input.prompt).trim().toLowerCase();
+	return prompt === '/remote' || prompt.startsWith('/remote ');
+}
+
 const enum QrMaskPattern {
 	Pattern0 = 0,
 	Pattern1 = 1,
@@ -1609,7 +1617,9 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 		const prompt = getPromptLabel(input);
 		this._logRequest(prompt, this._lastUsedModel || '', attachments, logStartTime);
 
-		if ('command' in input && input.command !== 'plan') {
+		if (isRemoteControlPrompt(input)) {
+			await this._handleRemoteControl('command' in input ? input : { command: 'remote', prompt: input.prompt });
+		} else if ('command' in input && input.command !== 'plan') {
 			switch (input.command) {
 				case 'compact': {
 					this._stream?.progress(l10n.t('Compacting conversation...'));

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotcliSession.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotcliSession.spec.ts
@@ -1046,6 +1046,24 @@ describe('CopilotCLISession', () => {
 		expect(stream.output.join('\n')).toContain('Usage: /remote, /remote on, /remote off');
 	});
 
+	it('handles /remote arguments when command metadata is missing', async () => {
+		await configurationService.setConfig(ConfigKey.Advanced.CLIRemoteEnabled, true);
+		const session = await createSession();
+		const stream = new MockChatResponseStream();
+		session.attachStream(stream);
+
+		await session.handleRequest(
+			{ id: '', toolInvocationToken: undefined as never },
+			{ prompt: '/remote wat' },
+			[],
+			undefined,
+			authInfo,
+			CancellationToken.None
+		);
+
+		expect(stream.output.join('\n')).toContain('Usage: /remote, /remote on, /remote off');
+	});
+
 	it('accepts /remote arguments when the prompt includes the slash command text', async () => {
 		await configurationService.setConfig(ConfigKey.Advanced.CLIRemoteEnabled, true);
 		const session = await createSession();

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCLIChatSessions.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCLIChatSessions.ts
@@ -777,7 +777,10 @@ export class CopilotCLIChatSessionParticipant extends Disposable {
 		const contextForRequest = takePendingCopilotCLIRequestContext(session.sessionId);
 
 		if (contextForRequest) {
-			return { input: { prompt: contextForRequest.prompt, source: contextForRequest.source }, attachments: contextForRequest.attachments };
+			const input = contextForRequest.command && (copilotCLICommands as readonly string[]).includes(contextForRequest.command)
+				? { command: contextForRequest.command as CopilotCLICommand, prompt: contextForRequest.prompt, source: contextForRequest.source }
+				: { prompt: contextForRequest.prompt, source: contextForRequest.source };
+			return { input, attachments: contextForRequest.attachments };
 		}
 
 		if (request.command && !request.prompt && !isNewSession) {
@@ -981,7 +984,8 @@ export class CopilotCLIChatSessionParticipant extends Disposable {
 			}
 		}
 
-		setPendingCopilotCLIRequestContext(session.object.sessionId, { prompt, attachments });
+		const command = request.command && (copilotCLICommands as readonly string[]).includes(request.command) ? request.command : undefined;
+		setPendingCopilotCLIRequestContext(session.object.sessionId, { prompt, attachments, command });
 		void vscode.commands.executeCommand('workbench.action.chat.openSessionWithPrompt.copilotcli', {
 			resource: SessionIdForCLI.getResource(session.object.sessionId),
 			prompt: userPrompt || request.prompt,

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCLIChatSessionsContribution.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCLIChatSessionsContribution.ts
@@ -1279,7 +1279,7 @@ export class CopilotCLIChatSessionParticipant extends Disposable {
 	}
 
 	private readonly contextForRequest = new Map<string, {
-		prompt: string; attachments: Attachment[]; model?: {
+		prompt: string; attachments: Attachment[]; command?: CopilotCLICommand; model?: {
 			model: string;
 			reasoningEffort?: string | undefined;
 		};
@@ -1536,8 +1536,9 @@ export class CopilotCLIChatSessionParticipant extends Disposable {
 				await this.handleDelegationToCloud(session.object, request, context, stream, token);
 			} else if (contextForRequest) {
 				// This is a request that was created in createCLISessionAndSubmitRequest with attachments already resolved.
-				const { prompt, attachments } = contextForRequest;
-				await session.object.handleRequest(request, { prompt }, attachments, model, authInfo, token);
+				const { prompt, attachments, command } = contextForRequest;
+				const input = command ? { command, prompt } : { prompt };
+				await session.object.handleRequest(request, input, attachments, model, authInfo, token);
 				await this.commitWorktreeChangesIfNeeded(request, session.object, token);
 			} else if (isCopilotCLICommand && (!isUntitled || request.command === 'remote')) {
 				const { prompt, attachments } = request.prompt
@@ -2082,7 +2083,8 @@ export class CopilotCLIChatSessionParticipant extends Disposable {
 			void this.workspaceFolderService.trackSessionWorkspaceFolder(session.object.sessionId, workingDirectory.fsPath, workspaceInfo.repositoryProperties);
 		}
 
-		this.contextForRequest.set(session.object.sessionId, { prompt, attachments, model });
+		const command = request.command && (copilotCLICommands as readonly string[]).includes(request.command) ? request.command as CopilotCLICommand : undefined;
+		this.contextForRequest.set(session.object.sessionId, { prompt, attachments, model, command });
 		this.sessionItemProvider.notifySessionsChange();
 		// TODO @DonJayamanne I don't think we need to refresh the list of session here just yet, or perhaps we do,
 		// Same as getOrCreate session, we need a dummy title or the initial prompt to show in the sessions list.

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/test/copilotCLIChatSessionParticipant.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/test/copilotCLIChatSessionParticipant.spec.ts
@@ -2009,6 +2009,21 @@ describe('CopilotCLIChatSessionParticipant.handleRequest', () => {
 			expect((participant as any).contextForRequest.size).toBe(0);
 		});
 
+		it('preserves CLI command metadata through delegated request context', async () => {
+			const request = new TestChatRequest('on');
+			request.command = 'remote';
+			const context = { chatSessionContext: undefined } as vscode.ChatContext;
+			const stream = new MockChatResponseStream();
+			const token = disposables.add(new CancellationTokenSource()).token;
+
+			await participant.createHandler()(request, context, stream, token);
+			await callbackDone;
+
+			expect(cliSessions.length).toBe(1);
+			expect(cliSessions[0].requests.length).toBe(1);
+			expect(cliSessions[0].requests[0].input).toEqual({ command: 'remote', prompt: 'on' });
+		});
+
 		it('does not attempt workaround for non-copilotcli resource and proceeds with normal delegation', async () => {
 			const request = new TestChatRequest('do some work');
 			// Default sessionResource is test://session/... (not copilotcli scheme),


### PR DESCRIPTION
`/remote on` can still be sent to the model as a normal prompt when VS Code pre-resolves a request and opens it in a Copilot CLI session. The earlier fix covered direct legacy routing, but the delegated/pending-context path dropped the slash-command metadata.

This preserves Copilot CLI command metadata when requests are handed off through pending context in both session-controller and legacy paths. It also treats raw `/remote ...` prompts as local remote-control commands as a defensive fallback for cases where VS Code omits `request.command`.

Validation:
- `cd extensions/copilot && npm run typecheck`
- `cd extensions/copilot && npm run test:unit -- src/extension/chatSessions/copilotcli/node/test/copilotcliSession.spec.ts src/extension/chatSessions/vscode-node/test/copilotCLIChatSessionParticipant.spec.ts`
- `node --experimental-strip-types build/hygiene.ts extensions/copilot/src/extension/chatSessions/copilotcli/common/pendingRequestContext.ts extensions/copilot/src/extension/chatSessions/vscode-node/copilotCLIChatSessions.ts extensions/copilot/src/extension/chatSessions/vscode-node/copilotCLIChatSessionsContribution.ts extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotcliSession.spec.ts extensions/copilot/src/extension/chatSessions/vscode-node/test/copilotCLIChatSessionParticipant.spec.ts`
- `git diff --check`
- `npm run precommit`
