### PR TITLE
agent host: drive subagent cleanup from SDK completion events

### DIFF
--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -277,6 +277,7 @@ export type AgentSignal =
 	| IAgentActionSignal
 	| IAgentToolPendingConfirmationSignal
 	| IAgentSubagentStartedSignal
+	| IAgentSubagentCompletedSignal
 	| IAgentSteeringConsumedSignal;
 
 /**
@@ -344,6 +345,19 @@ export interface IAgentSubagentStartedSignal {
 	readonly agentName: string;
 	readonly agentDisplayName: string;
 	readonly agentDescription?: string;
+}
+
+/**
+ * A subagent has finished — either successfully or with an error. The host
+ * uses this to tear down the child session after all of its events have been
+ * routed. The parent tool call completing is not a reliable signal for this
+ * because background subagents (e.g. Copilot's `mode: background` task) keep
+ * emitting events after their parent tool call returns immediately.
+ */
+export interface IAgentSubagentCompletedSignal {
+	readonly kind: 'subagent_completed';
+	readonly session: URI;
+	readonly toolCallId: string;
 }
 
 /** A steering message was consumed (sent to the model). */

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -264,6 +264,11 @@ export class AgentSideEffects extends Disposable {
 			return;
 		}
 
+		if (signal.kind === 'subagent_completed') {
+			this.completeSubagentSession(sessionKey, signal.toolCallId);
+			return;
+		}
+
 		if (signal.kind === 'steering_consumed') {
 			this._stateManager.dispatchServerAction({
 				type: ActionType.SessionPendingMessageRemoved,
@@ -395,7 +400,13 @@ export class AgentSideEffects extends Disposable {
 		this._stateManager.dispatchServerAction(action);
 
 		if (action.type === ActionType.SessionToolCallComplete) {
-			this.completeSubagentSession(sessionKey, action.toolCallId);
+			// Drop any events that were buffered for a subagent whose
+			// `subagent_started` never arrived (e.g. the parent tool failed
+			// before the subagent was created). The actual subagent session
+			// teardown is driven by the `subagent_completed` signal because
+			// background subagents (`mode: background`) continue running
+			// after the parent tool call returns.
+			this._pendingSubagentSignals.delete(`${sessionKey}:${action.toolCallId}`);
 			if (getToolFileEdits(action.result).length > 0) {
 				this._scheduleDebouncedDiffComputation(sessionKey, turnId);
 			}
@@ -561,8 +572,11 @@ export class AgentSideEffects extends Disposable {
 	}
 
 	/**
-	 * Completes all active subagent sessions for a given parent session.
-	 * Called when a parent tool call completes.
+	 * Completes the subagent session associated with a parent tool call.
+	 * Driven by the `subagent_completed` signal from the agent (which the
+	 * SDK fires on both `subagent.completed` and `subagent.failed`), not by
+	 * parent tool call completion — background subagents keep running after
+	 * their parent tool returns.
 	 */
 	completeSubagentSession(parentSession: ProtocolURI, toolCallId: string): void {
 		const key = `${parentSession}:${toolCallId}`;

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -1667,6 +1667,11 @@ export class CopilotAgentSession extends Disposable {
 				this._parentToolCallIdsByAgentId.delete(e.agentId);
 			}
 			this._logService.trace(`[Copilot:${sessionId}] Subagent completed: ${e.data.agentName}`);
+			this._onDidSessionProgress.fire({
+				kind: 'subagent_completed',
+				session: this.sessionUri,
+				toolCallId: e.data.toolCallId,
+			});
 		}));
 
 		this._register(wrapper.onSubagentFailed(e => {
@@ -1674,6 +1679,11 @@ export class CopilotAgentSession extends Disposable {
 				this._parentToolCallIdsByAgentId.delete(e.agentId);
 			}
 			this._logService.error(`[Copilot:${sessionId}] Subagent failed: ${e.data.agentName} - ${e.data.error}`);
+			this._onDidSessionProgress.fire({
+				kind: 'subagent_completed',
+				session: this.sessionUri,
+				toolCallId: e.data.toolCallId,
+			});
 		}));
 
 		this._register(wrapper.onSubagentSelected(e => {

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -1973,7 +1973,7 @@ suite('AgentSideEffects', () => {
 			assert.strictEqual(innerTool, undefined, 'stale buffered inner tool call must not be replayed');
 		});
 
-		test('completeSubagentSession completes the subagent turn when parent tool completes', () => {
+		test('subagent_completed signal completes the subagent turn', () => {
 			setupSession();
 			startTurn('turn-1');
 			disposables.add(sideEffects.registerProgressListener(agent));
@@ -1983,20 +1983,28 @@ suite('AgentSideEffects', () => {
 			agent.fireProgress({ kind: 'action', session: sessionUri, action: { type: ActionType.SessionToolCallReady, session: sessionUri.toString(), turnId: 'turn-1', toolCallId: 'tc-1', invocationMessage: 'Delegating...', toolInput: undefined, confirmed: ToolCallConfirmationReason.NotNeeded } });
 			agent.fireProgress({ kind: 'subagent_started', session: sessionUri, toolCallId: 'tc-1', agentName: 'helper', agentDisplayName: 'Helper', agentDescription: 'Helps' });
 
-			// Complete the parent tool call
+			// Completing the parent tool call must NOT tear down the
+			// subagent session — background subagents keep running after
+			// their parent tool call returns.
 			agent.fireProgress({
 				kind: 'action', session: sessionUri,
 				action: {
 					type: ActionType.SessionToolCallComplete, session: sessionUri.toString(), turnId: 'turn-1',
 					toolCallId: 'tc-1',
-					result: { success: true, pastTenseMessage: 'Done' },
+					result: { success: true, pastTenseMessage: 'Started in background' },
 				},
 			});
 
-			// Verify the subagent session's turn was completed
 			const subagentUri = `${sessionUri.toString()}/subagent/tc-1`;
-			const subState = stateManager.getSessionState(subagentUri);
+			let subState = stateManager.getSessionState(subagentUri);
 			assert.ok(subState);
+			assert.ok(subState!.activeTurn, 'subagent turn should still be active after parent tool completes');
+
+			// The SDK's `subagent.completed`/`subagent.failed` event is what
+			// actually closes the subagent session.
+			agent.fireProgress({ kind: 'subagent_completed', session: sessionUri, toolCallId: 'tc-1' });
+
+			subState = stateManager.getSessionState(subagentUri);
 			assert.strictEqual(subState!.activeTurn, undefined, 'subagent turn should be completed');
 			assert.strictEqual(subState!.turns.length, 1);
 		});

--- a/src/vs/platform/agentHost/test/node/mockAgent.ts
+++ b/src/vs/platform/agentHost/test/node/mockAgent.ts
@@ -603,6 +603,7 @@ export class ScriptedMockAgent implements IAgent {
 					{ kind: 'subagent_started', session, toolCallId: 'tc-task-1', agentName: 'explore', agentDisplayName: 'Explore', agentDescription: 'Exploration helper' },
 					..._toolStart(session, sessionStr, tid, 'tc-inner-1', 'echo_tool', 'Echo Tool', 'Inner tool running...', { parentToolCallId: 'tc-task-1' }),
 					_toolComplete(session, sessionStr, tid, 'tc-inner-1', { pastTenseMessage: 'Ran inner tool', content: [{ type: ToolResultContentType.Text, text: 'inner-ok' }], success: true }, 'tc-task-1'),
+					{ kind: 'subagent_completed', session, toolCallId: 'tc-task-1' },
 					_toolComplete(session, sessionStr, tid, 'tc-task-1', { pastTenseMessage: 'Subagent done', content: [{ type: ToolResultContentType.Text, text: 'task-ok' }], success: true }),
 					_markdown(session, sessionStr, tid, 'Subagent finished.'),
 					_idle(session, sessionStr, tid),


### PR DESCRIPTION
- Background subagents (e.g. Copilot's `task` tool with `mode: background`)
  continue running after their parent tool call returns. Previously we
  tore down the subagent session as soon as the parent tool's
  `SessionToolCallComplete` was dispatched, which dropped all later
  subagent events on the floor. Any `tool.execution_start` the subagent
  emitted afterwards (e.g. a `problems` call needing confirmation) got
  buffered indefinitely and never reached AHP, leaving the UI hung on
  confirmation.
- Introduces a `subagent_completed` agent signal fired from the SDK's
  `subagent.completed` and `subagent.failed` events, and routes that
  signal to `completeSubagentSession`. The parent tool completion path
  now only drops the pending pre-start signal buffer, which keeps the
  "subagent never started" cleanup path intact without prematurely
  closing a still-running subagent.

Fixes #314827

(Commit message generated by Copilot)