### PR TITLE
Remove github.copilot.chat.responsesApi.toolSearchTool.enabled setting

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -3834,15 +3834,6 @@
 							"onExp"
 						]
 					},
-					"github.copilot.chat.responsesApi.toolSearchTool.enabled": {
-						"type": "boolean",
-						"default": false,
-						"markdownDescription": "%github.copilot.config.responsesApi.toolSearchTool.enabled%",
-						"tags": [
-							"experimental",
-							"onExp"
-						]
-					},
 					"github.copilot.chat.updated53CodexPrompt.enabled": {
 						"type": "boolean",
 						"default": true,

--- a/extensions/copilot/package.nls.json
+++ b/extensions/copilot/package.nls.json
@@ -343,7 +343,6 @@
 	"github.copilot.config.responsesApiReasoningSummary": "Sets the reasoning summary style used for the Responses API. Requires `#github.copilot.chat.useResponsesApi#`.",
 	"github.copilot.config.responsesApiContextManagement.enabled": "Enables context management for the Responses API. Requires `#github.copilot.chat.useResponsesApi#`.",
 	"github.copilot.config.responsesApi.promptCacheKey.enabled": "Enables prompt cache key being set for the Responses API.",
-	"github.copilot.config.responsesApi.toolSearchTool.enabled": "Enable tool search for OpenAI Responses API models. When enabled, tools are dynamically discovered and loaded on-demand using embeddings-based search, reducing context window usage when many tools are available.",
 	"github.copilot.config.updated53CodexPrompt.enabled": "Enables the updated prompt for gpt-5.3-codex model.",
 	"github.copilot.config.claude47OpusPrompt.enabled": "Enables the updated system prompt tuned for the Claude Opus 4.7 model.",
 	"github.copilot.config.gpt54ConcisePrompt.enabled": "Enables the concise prompt experiment for gpt-5.4 model.",

--- a/extensions/copilot/src/extension/tools/node/toolSearchTool.ts
+++ b/extensions/copilot/src/extension/tools/node/toolSearchTool.ts
@@ -75,6 +75,8 @@ ToolRegistry.registerModelSpecificTool(
 			required: ['query'],
 		},
 		models: [
+			{ family: 'gpt-5.4' },
+			{ family: 'gpt-5.5' },
 			{ family: 'claude-sonnet-4.5' },
 			{ family: 'claude-sonnet-4.6' },
 			{ family: 'claude-opus-4.5' },
@@ -82,6 +84,9 @@ ToolRegistry.registerModelSpecificTool(
 			{ family: 'claude-opus-4.6-1m' },
 			{ family: 'claude-opus-4.7' },
 			{ family: 'claude-opus-4.7-1m' },
+			{ family: 'claude-opus-4.7-1m-internal' },
+			{ family: 'claude-opus-4.7-high' },
+			{ family: 'claude-opus-4.7-xhigh' },
 		],
 	},
 	ToolSearchTool,

--- a/extensions/copilot/src/platform/configuration/common/configurationService.ts
+++ b/extensions/copilot/src/platform/configuration/common/configurationService.ts
@@ -933,8 +933,6 @@ export namespace ConfigKey {
 	export const ResponsesApiContextManagementEnabled = defineSetting<boolean>('chat.responsesApiContextManagement.enabled', ConfigType.ExperimentBased, false);
 	/** Enable client-side prompt_cache_key (conversationId:modelFamily) sent to Responses API */
 	export const ResponsesApiPromptCacheKeyEnabled = defineSetting<boolean>('chat.responsesApi.promptCacheKey.enabled', ConfigType.ExperimentBased, false);
-	/** Enable tool search for Responses API (client-side deferred tool loading). */
-	export const ResponsesApiToolSearchEnabled = defineSetting<boolean>('chat.responsesApi.toolSearchTool.enabled', ConfigType.ExperimentBased, false);
 	/** Enable updated prompt for 5.3Codex model */
 	export const Updated53CodexPromptEnabled = defineSetting<boolean>('chat.updated53CodexPrompt.enabled', ConfigType.ExperimentBased, true);
 	/** Enable updated prompt for Claude Opus 4.7 model */

--- a/extensions/copilot/src/platform/endpoint/common/chatModelCapabilities.ts
+++ b/extensions/copilot/src/platform/endpoint/common/chatModelCapabilities.ts
@@ -421,34 +421,18 @@ export function getVerbosityForModelSync(model: IChatEndpoint): 'low' | 'medium'
  * - Claude Opus 4.5 (claude-opus-4-5-* or claude-opus-4.5-*)
  * - Claude Opus 4.6 (claude-opus-4-6-* or claude-opus-4.6-*)
  * - Claude Opus 4.7 (claude-opus-4-7-* or claude-opus-4.7-*)
- * - OpenAI gpt-5.4/gpt-5.5, but only when the `ResponsesApiToolSearchEnabled` setting is enabled
+ * - OpenAI gpt-5.4 and gpt-5.5 (via Responses API client-side tool search)
  */
-export function modelSupportsToolSearch(modelId: string, configurationService?: IConfigurationService, experimentationService?: IExperimentationService): boolean {
+export function modelSupportsToolSearch(modelId: string): boolean {
 	const normalized = modelId.toLowerCase().replace(/\./g, '-');
-	if (isResponsesApiToolSearchModelId(normalized)) {
-		return !!configurationService && !!experimentationService && isResponsesApiToolSearchEnabled(modelId, configurationService, experimentationService);
-	}
-
-	return normalized.startsWith('claude-sonnet-4-5') ||
+	return normalized === 'gpt-5-4' ||
+		normalized === 'gpt-5-5' ||
+		normalized.startsWith('claude-sonnet-4-5') ||
 		normalized.startsWith('claude-sonnet-4-6') ||
 		normalized.startsWith('claude-opus-4-5') ||
 		normalized.startsWith('claude-opus-4-6') ||
 		normalized.startsWith('claude-opus-4-7') ||
 		isHiddenModelG(modelId);
-}
-
-function isResponsesApiToolSearchModelId(normalizedModelId: string): boolean {
-	return normalizedModelId === 'gpt-5-4' || normalizedModelId === 'gpt-5-5';
-}
-
-export function isResponsesApiToolSearchEnabled(
-	endpoint: IChatEndpoint | string,
-	configurationService: IConfigurationService,
-	experimentationService: IExperimentationService,
-): boolean {
-	const modelId = typeof endpoint === 'string' ? endpoint : endpoint.model;
-	const normalized = modelId.toLowerCase().replace(/\./g, '-');
-	return isResponsesApiToolSearchModelId(normalized) && configurationService.getExperimentBasedConfig(ConfigKey.ResponsesApiToolSearchEnabled, experimentationService);
 }
 
 /**

--- a/extensions/copilot/src/platform/endpoint/node/chatEndpoint.ts
+++ b/extensions/copilot/src/platform/endpoint/node/chatEndpoint.ts
@@ -199,7 +199,7 @@ export class ChatEndpoint implements IChatEndpoint {
 		this.minThinkingBudget = modelMetadata.capabilities.supports.min_thinking_budget;
 		this.maxThinkingBudget = modelMetadata.capabilities.supports.max_thinking_budget;
 		this.supportsReasoningEffort = modelMetadata.capabilities.supports.reasoning_effort;
-		this.supportsToolSearch = modelMetadata.capabilities.supports.tool_search ?? modelSupportsToolSearch(this.model, this._configurationService, this._expService);
+		this.supportsToolSearch = modelMetadata.capabilities.supports.tool_search ?? modelSupportsToolSearch(this.model);
 		this.supportsContextEditing = modelMetadata.capabilities.supports.context_editing ?? modelSupportsContextEditing(this.model);
 		this._supportsStreaming = !!modelMetadata.capabilities.supports.streaming;
 		this.customModel = modelMetadata.custom_model;

--- a/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
@@ -27,7 +27,7 @@ import { IChatWebSocketManager } from '../../networking/node/chatWebSocketManage
 import { IExperimentationService } from '../../telemetry/common/nullExperimentationService';
 import { ITelemetryService } from '../../telemetry/common/telemetry';
 import { TelemetryData } from '../../telemetry/common/telemetryData';
-import { getVerbosityForModelSync, isResponsesApiToolSearchEnabled } from '../common/chatModelCapabilities';
+import { getVerbosityForModelSync } from '../common/chatModelCapabilities';
 import { rawPartAsCompactionData } from '../common/compactionDataContainer';
 import { rawPartAsPhaseData } from '../common/phaseDataContainer';
 import { getIndexOfStatefulMarker, getStatefulMarkerAndIndex } from '../common/statefulMarkerContainer';
@@ -63,11 +63,11 @@ export function createResponsesRequestBody(accessor: ServicesAccessor, options: 
 	// (excluded from the request entirely). Uses OpenAI's client-executed tool search protocol: we add
 	// { type: 'tool_search', execution: 'client' }. The model emits tool_search_call, which we handle via
 	// our ToolSearchTool embeddings search, then round-trip as tool_search_output in the next request.
-	const toolSearchEnabled = isResponsesApiToolSearchEnabled(endpoint, configService, expService);
+	const toolSearchEnabled = !!endpoint.supportsToolSearch
+		&& !!options.requestOptions?.tools?.some(t => t.function.name === CUSTOM_TOOL_SEARCH_NAME);
 	const isAllowedConversationAgent = options.location === ChatLocation.Agent || options.location === ChatLocation.MessagesProxy;
 	const isSubagent = options.telemetryProperties?.subType?.startsWith('subagent') ?? false;
-	const toolSearchInRequest = !!options.requestOptions?.tools?.some(t => t.function.name === CUSTOM_TOOL_SEARCH_NAME);
-	const shouldDeferTools = toolSearchEnabled && isAllowedConversationAgent && !isSubagent && toolSearchInRequest;
+	const shouldDeferTools = toolSearchEnabled && isAllowedConversationAgent && !isSubagent;
 	const toolDeferralService = shouldDeferTools ? accessor.get(IToolDeferralService) : undefined;
 
 	type ResponsesFunctionTool = OpenAI.Responses.FunctionTool & OpenAiResponsesFunctionTool;

--- a/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
@@ -9,8 +9,6 @@ import { describe, expect, it } from 'vitest';
 import { TokenizerType } from '../../../../util/common/tokenizer';
 import { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
 import { ChatLocation } from '../../../chat/common/commonTypes';
-import { ConfigKey, IConfigurationService } from '../../../configuration/common/configurationService';
-import { InMemoryConfigurationService } from '../../../configuration/test/common/inMemoryConfigurationService';
 import { ILogService } from '../../../log/common/logService';
 import { isOpenAIContextManagementResponse } from '../../../networking/common/fetch';
 import { IChatEndpoint, ICreateEndpointBodyOptions } from '../../../networking/common/networking';
@@ -773,9 +771,7 @@ describe('createResponsesRequestBody', () => {
 		services.define(IToolDeferralService, { _serviceBrand: undefined, isNonDeferredTool: (name: string) => name === 'read_file' || name === 'tool_search' });
 		const accessor = services.createTestingAccessor();
 		const instantiationService = accessor.get(IInstantiationService);
-		const configService = accessor.get(IConfigurationService) as InMemoryConfigurationService;
-		configService.setConfig(ConfigKey.ResponsesApiToolSearchEnabled, true);
-		const endpoint = { ...testEndpoint, model: 'gpt-5.4', family: 'gpt-5.4' };
+		const endpoint = { ...testEndpoint, model: 'gpt-5.4', family: 'gpt-5.4', supportsToolSearch: true };
 		const tools = [
 			{ type: 'function' as const, function: { name: 'tool_search', description: 'Search tools', parameters: {} } },
 			{ type: 'function' as const, function: { name: 'some_mcp_tool', description: 'MCP tool', parameters: {} } },

--- a/extensions/copilot/src/platform/endpoint/node/test/responsesApiToolSearch.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/responsesApiToolSearch.spec.ts
@@ -8,8 +8,6 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { DisposableStore } from '../../../../util/vs/base/common/lifecycle';
 import { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
 import { ChatLocation } from '../../../chat/common/commonTypes';
-import { ConfigKey, IConfigurationService } from '../../../configuration/common/configurationService';
-import { InMemoryConfigurationService } from '../../../configuration/test/common/inMemoryConfigurationService';
 import { IResponseDelta, OpenAiFunctionTool } from '../../../networking/common/fetch';
 import { IChatEndpoint, ICreateEndpointBodyOptions } from '../../../networking/common/networking';
 import { IToolDeferralService } from '../../../networking/common/toolDeferralService';
@@ -24,6 +22,7 @@ function createMockEndpoint(model: string): IChatEndpoint {
 		family: model,
 		modelProvider: 'openai',
 		supportsToolCalls: true,
+		supportsToolSearch: model === 'gpt-5.4' || model === 'gpt-5.5',
 		supportsVision: false,
 		supportsPrediction: false,
 		showInModelPicker: true,
@@ -93,8 +92,6 @@ describe('createResponsesRequestBody tools', () => {
 
 	function createToolSearchScenario(messages: Raw.ChatMessage[]) {
 		const endpoint = createMockEndpoint('gpt-5.4');
-		const configService = accessor.get(IConfigurationService) as InMemoryConfigurationService;
-		configService.setConfig(ConfigKey.ResponsesApiToolSearchEnabled, true);
 
 		const options = createMockOptions({
 			messages,
@@ -113,10 +110,8 @@ describe('createResponsesRequestBody tools', () => {
 		);
 	}
 
-	it('passes tools through without defer_loading when tool search disabled', () => {
-		const endpoint = createMockEndpoint('gpt-5.4');
-		const configService = accessor.get(IConfigurationService) as InMemoryConfigurationService;
-		configService.setConfig(ConfigKey.ResponsesApiToolSearchEnabled, false);
+	it('passes tools through without defer_loading for unsupported models', () => {
+		const endpoint = createMockEndpoint('gpt-4o');
 
 		const body = accessor.get(IInstantiationService).invokeFunction(
 			createResponsesRequestBody, createMockOptions(), endpoint.model, endpoint
@@ -128,10 +123,8 @@ describe('createResponsesRequestBody tools', () => {
 		expect(tools.every(t => !t.defer_loading)).toBe(true);
 	});
 
-	it('adds client tool_search and defer_loading when enabled', () => {
+	it('adds client tool_search and defer_loading for supported models', () => {
 		const endpoint = createMockEndpoint('gpt-5.4');
-		const configService = accessor.get(IConfigurationService) as InMemoryConfigurationService;
-		configService.setConfig(ConfigKey.ResponsesApiToolSearchEnabled, true);
 
 		const body = accessor.get(IInstantiationService).invokeFunction(
 			createResponsesRequestBody, createMockOptions(), endpoint.model, endpoint
@@ -156,8 +149,6 @@ describe('createResponsesRequestBody tools', () => {
 
 	it('does not defer tools for unsupported models', () => {
 		const endpoint = createMockEndpoint('gpt-4o');
-		const configService = accessor.get(IConfigurationService) as InMemoryConfigurationService;
-		configService.setConfig(ConfigKey.ResponsesApiToolSearchEnabled, true);
 
 		const body = accessor.get(IInstantiationService).invokeFunction(
 			createResponsesRequestBody, createMockOptions(), endpoint.model, endpoint
@@ -170,8 +161,6 @@ describe('createResponsesRequestBody tools', () => {
 
 	it('does not defer tools for non-Agent locations', () => {
 		const endpoint = createMockEndpoint('gpt-5.4');
-		const configService = accessor.get(IConfigurationService) as InMemoryConfigurationService;
-		configService.setConfig(ConfigKey.ResponsesApiToolSearchEnabled, true);
 
 		const options = createMockOptions({ location: ChatLocation.Panel });
 		const body = accessor.get(IInstantiationService).invokeFunction(
@@ -189,8 +178,6 @@ describe('createResponsesRequestBody tools', () => {
 		// MCP tool would be marked deferred and stripped from the request, leaving the
 		// agent with nothing to call.
 		const endpoint = createMockEndpoint('gpt-5.4');
-		const configService = accessor.get(IConfigurationService) as InMemoryConfigurationService;
-		configService.setConfig(ConfigKey.ResponsesApiToolSearchEnabled, true);
 
 		const options = createMockOptions({
 			requestOptions: {
@@ -213,9 +200,7 @@ describe('createResponsesRequestBody tools', () => {
 	});
 
 	it('always filters tool_search function tool from tools array', () => {
-		const endpoint = createMockEndpoint('gpt-5.4');
-		const configService = accessor.get(IConfigurationService) as InMemoryConfigurationService;
-		configService.setConfig(ConfigKey.ResponsesApiToolSearchEnabled, false);
+		const endpoint = createMockEndpoint('gpt-4o');
 
 		const options = createMockOptions({
 			requestOptions: {
@@ -234,10 +219,8 @@ describe('createResponsesRequestBody tools', () => {
 		expect(tools.find(t => t.name === 'read_file')).toBeDefined();
 	});
 
-	it('converts tool_search history even when feature flag is off', () => {
-		const endpoint = createMockEndpoint('gpt-5.4');
-		const configService = accessor.get(IConfigurationService) as InMemoryConfigurationService;
-		configService.setConfig(ConfigKey.ResponsesApiToolSearchEnabled, false);
+	it('converts tool_search history for unsupported models', () => {
+		const endpoint = createMockEndpoint('gpt-4o');
 
 		const messages: Raw.ChatMessage[] = [
 			{ role: Raw.ChatRole.User, content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: 'Hello' }] },

--- a/extensions/copilot/src/platform/endpoint/test/node/chatModelCapabilities.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/test/node/chatModelCapabilities.spec.ts
@@ -4,9 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { describe, expect, test } from 'vitest';
-import { ConfigKey, IConfigurationService } from '../../../configuration/common/configurationService';
 import type { IChatEndpoint } from '../../../networking/common/networking';
-import { IExperimentationService } from '../../../telemetry/common/nullExperimentationService';
 import { modelSupportsPDFDocuments, modelSupportsToolSearch } from '../../common/chatModelCapabilities';
 
 function fakeModel(family: string) {
@@ -66,28 +64,16 @@ describe('modelSupportsToolSearch', () => {
 		expect(modelSupportsToolSearch('claude-3-opus')).toBe(false);
 	});
 
-	test('supports OpenAI gpt-5.4 and gpt-5.5 models when the setting is enabled', () => {
-		const configurationService = {
-			getExperimentBasedConfig: (key: unknown) => key === ConfigKey.ResponsesApiToolSearchEnabled,
-		} as unknown as IConfigurationService;
-		const experimentationService = {} as IExperimentationService;
-
-		expect(modelSupportsToolSearch('gpt-5.4', configurationService, experimentationService)).toBe(true);
-		expect(modelSupportsToolSearch('gpt-5.5', configurationService, experimentationService)).toBe(true);
-		expect(modelSupportsToolSearch('gpt-5.4')).toBe(false);
-		expect(modelSupportsToolSearch('gpt-5.5')).toBe(false);
+	test('supports OpenAI gpt-5.4 and gpt-5.5 models', () => {
+		expect(modelSupportsToolSearch('gpt-5.4')).toBe(true);
+		expect(modelSupportsToolSearch('gpt-5.5')).toBe(true);
 	});
 
 	test('rejects suffixed gpt-5.4/5.5 variants (exact match only)', () => {
-		const configurationService = {
-			getExperimentBasedConfig: (key: unknown) => key === ConfigKey.ResponsesApiToolSearchEnabled,
-		} as unknown as IConfigurationService;
-		const experimentationService = {} as IExperimentationService;
-
-		expect(modelSupportsToolSearch('gpt-5.4-mini', configurationService, experimentationService)).toBe(false);
-		expect(modelSupportsToolSearch('gpt-5.4-preview', configurationService, experimentationService)).toBe(false);
-		expect(modelSupportsToolSearch('gpt-5.5-preview', configurationService, experimentationService)).toBe(false);
-		expect(modelSupportsToolSearch('gpt5.5-preview', configurationService, experimentationService)).toBe(false);
+		expect(modelSupportsToolSearch('gpt-5.4-mini')).toBe(false);
+		expect(modelSupportsToolSearch('gpt-5.4-preview')).toBe(false);
+		expect(modelSupportsToolSearch('gpt-5.5-preview')).toBe(false);
+		expect(modelSupportsToolSearch('gpt5.5-preview')).toBe(false);
 	});
 
 	test('rejects other non-Claude models', () => {


### PR DESCRIPTION
Tool search is now always enabled for gpt-5.4/gpt-5.5, matching the messages API path via the shared `endpoint.supportsToolSearch` capability flag.

Also registers `ToolSearchTool` for gpt-5.4/gpt-5.5 and the claude-opus-4.7 variants so model-specific tool gating matches the supported endpoints.