### PR TITLE
send_to_terminal: steer the model to keep going after a cancel signal

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/sendToTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/sendToTerminalTool.ts
@@ -60,6 +60,15 @@ export interface ISendToTerminalInputParams {
 	waitForOutput?: boolean;
 }
 
+/**
+ * Cancel/EOF signals: Ctrl-C (ETX, 0x03), Ctrl-D (EOT, 0x04), Ctrl-\ (FS, 0x1c).
+ * When sent on their own these interrupt or close the foreground process rather
+ * than completing it, so the model needs an extra nudge that the turn is not done.
+ */
+function isCancelSignal(command: string): boolean {
+	return /^[\u0003\u0004\u001c]$/.test(command);
+}
+
 const FocusTerminalByIdCommandId = 'workbench.action.terminal.chat.focusTerminalById';
 CommandsRegistry.registerCommand(FocusTerminalByIdCommandId, async (accessor, instanceId: number) => {
 	const terminalService = accessor.get(ITerminalService);
@@ -372,10 +381,14 @@ export class SendToTerminalTool extends Disposable implements IToolImpl {
 			recentOutput = getOutput(execution.instance, startMarker ?? undefined, { lastNLines: 20 });
 		}
 
+		const steering = isCancelSignal(args.command)
+			? `\n\nNote: The input you sent was a cancel signal (Ctrl-C / Ctrl-D / Ctrl-\\). The previously running command was interrupted, not completed. This is not a signal to end the turn — if you intend to run a recovery or follow-up command, issue it now in this same turn. Call ${TerminalToolId.GetTerminalOutput} first if you need to verify the shell is back at a prompt.`
+			: '';
+
 		return {
 			content: [{
 				kind: 'text',
-				value: `Successfully sent command to terminal ${args.id}.${recentOutput ? `\n\nTerminal output:\n${recentOutput}` : ''}`
+				value: `Successfully sent command to terminal ${args.id}.${recentOutput ? `\n\nTerminal output:\n${recentOutput}` : ''}${steering}`
 			}]
 		};
 	}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/sendToTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/sendToTerminalTool.ts
@@ -66,7 +66,7 @@ export interface ISendToTerminalInputParams {
  * than completing it, so the model needs an extra nudge that the turn is not done.
  */
 function isCancelSignal(command: string): boolean {
-	return /^[\u0003\u0004\u001c]$/.test(command);
+	return /^[\u0003\u0004\u001c]$/.test(command.trim());
 }
 
 const FocusTerminalByIdCommandId = 'workbench.action.terminal.chat.focusTerminalById';

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/sendToTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/sendToTerminalTool.test.ts
@@ -137,6 +137,37 @@ suite('SendToTerminalTool', () => {
 		assert.strictEqual(mockExecution.sentTexts[0].shouldExecute, true);
 	});
 
+	test('appends cancel-signal steering when input is Ctrl-C', async () => {
+		const mockExecution = createMockExecution('npm error canceled\n$ ');
+		RunInTerminalTool.getExecution = () => mockExecution;
+
+		const result = await tool.invoke(
+			createInvocation(KNOWN_TERMINAL_ID, '\u0003'),
+			async () => 0,
+			{ report: () => { } },
+			CancellationToken.None,
+		);
+
+		const value = (result.content[0] as { value: string }).value;
+		assert.ok(value.includes('cancel signal'), 'should mention cancel signal');
+		assert.ok(value.includes('not a signal to end the turn'), 'should remind the model the turn is not done');
+	});
+
+	test('does not append cancel-signal steering for ordinary input', async () => {
+		const mockExecution = createMockExecution('hello');
+		RunInTerminalTool.getExecution = () => mockExecution;
+
+		const result = await tool.invoke(
+			createInvocation(KNOWN_TERMINAL_ID, 'y'),
+			async () => 0,
+			{ report: () => { } },
+			CancellationToken.None,
+		);
+
+		const value = (result.content[0] as { value: string }).value;
+		assert.ok(!value.includes('cancel signal'), 'should not mention cancel signal for ordinary input');
+	});
+
 	function createPreparationContext(id: string, command: string, chatSessionResource?: URI): IToolInvocationPreparationContext {
 		return {
 			parameters: { id, command },

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/sendToTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/sendToTerminalTool.test.ts
@@ -81,91 +81,101 @@ suite('SendToTerminalTool', () => {
 		assert.ok(idProperty?.pattern?.includes('[0-9a-fA-F]{8}'));
 	});
 
-	test('returns error for unknown terminal id', async () => {
-		RunInTerminalTool.getExecution = () => undefined;
+	test('returns error for unknown terminal id', () => {
+		return runWithFakedTimers({}, async () => {
+			RunInTerminalTool.getExecution = () => undefined;
 
-		const result = await tool.invoke(
-			createInvocation(UNKNOWN_TERMINAL_ID, 'ls'),
-			async () => 0,
-			{ report: () => { } },
-			CancellationToken.None,
-		);
+			const result = await tool.invoke(
+				createInvocation(UNKNOWN_TERMINAL_ID, 'ls'),
+				async () => 0,
+				{ report: () => { } },
+				CancellationToken.None,
+			);
 
-		assert.strictEqual(result.content.length, 1);
-		assert.strictEqual(result.content[0].kind, 'text');
-		const value = (result.content[0] as { value: string }).value;
-		assert.ok(value.includes('No active terminal execution found'));
-		assert.ok(value.includes(UNKNOWN_TERMINAL_ID));
+			assert.strictEqual(result.content.length, 1);
+			assert.strictEqual(result.content[0].kind, 'text');
+			const value = (result.content[0] as { value: string }).value;
+			assert.ok(value.includes('No active terminal execution found'));
+			assert.ok(value.includes(UNKNOWN_TERMINAL_ID));
+		});
 	});
 
-	test('sends command to terminal and returns acknowledgment', async () => {
-		const mockExecution = createMockExecution('$ ls\nfile1.txt\nfile2.txt');
-		RunInTerminalTool.getExecution = () => mockExecution;
+	test('sends command to terminal and returns acknowledgment', () => {
+		return runWithFakedTimers({}, async () => {
+			const mockExecution = createMockExecution('$ ls\nfile1.txt\nfile2.txt');
+			RunInTerminalTool.getExecution = () => mockExecution;
 
-		const result = await tool.invoke(
-			createInvocation(KNOWN_TERMINAL_ID, 'ls'),
-			async () => 0,
-			{ report: () => { } },
-			CancellationToken.None,
-		);
+			const result = await tool.invoke(
+				createInvocation(KNOWN_TERMINAL_ID, 'ls'),
+				async () => 0,
+				{ report: () => { } },
+				CancellationToken.None,
+			);
 
-		assert.strictEqual(result.content.length, 1);
-		assert.strictEqual(result.content[0].kind, 'text');
-		const value = (result.content[0] as { value: string }).value;
-		assert.ok(value.includes('Successfully sent command'));
-		assert.ok(value.includes(KNOWN_TERMINAL_ID));
+			assert.strictEqual(result.content.length, 1);
+			assert.strictEqual(result.content[0].kind, 'text');
+			const value = (result.content[0] as { value: string }).value;
+			assert.ok(value.includes('Successfully sent command'));
+			assert.ok(value.includes(KNOWN_TERMINAL_ID));
 
-		// Verify sendText was called with shouldExecute=true
-		assert.strictEqual(mockExecution.sentTexts.length, 1);
-		assert.strictEqual(mockExecution.sentTexts[0].text, 'ls');
-		assert.strictEqual(mockExecution.sentTexts[0].shouldExecute, true);
+			// Verify sendText was called with shouldExecute=true
+			assert.strictEqual(mockExecution.sentTexts.length, 1);
+			assert.strictEqual(mockExecution.sentTexts[0].text, 'ls');
+			assert.strictEqual(mockExecution.sentTexts[0].shouldExecute, true);
+		});
 	});
 
-	test('sends multi-word command correctly', async () => {
-		const mockExecution = createMockExecution('output');
-		RunInTerminalTool.getExecution = () => mockExecution;
+	test('sends multi-word command correctly', () => {
+		return runWithFakedTimers({}, async () => {
+			const mockExecution = createMockExecution('output');
+			RunInTerminalTool.getExecution = () => mockExecution;
 
-		await tool.invoke(
-			createInvocation(KNOWN_TERMINAL_ID, 'echo hello world'),
-			async () => 0,
-			{ report: () => { } },
-			CancellationToken.None,
-		);
+			await tool.invoke(
+				createInvocation(KNOWN_TERMINAL_ID, 'echo hello world'),
+				async () => 0,
+				{ report: () => { } },
+				CancellationToken.None,
+			);
 
-		assert.strictEqual(mockExecution.sentTexts.length, 1);
-		assert.strictEqual(mockExecution.sentTexts[0].text, 'echo hello world');
-		assert.strictEqual(mockExecution.sentTexts[0].shouldExecute, true);
+			assert.strictEqual(mockExecution.sentTexts.length, 1);
+			assert.strictEqual(mockExecution.sentTexts[0].text, 'echo hello world');
+			assert.strictEqual(mockExecution.sentTexts[0].shouldExecute, true);
+		});
 	});
 
-	test('appends cancel-signal steering when input is Ctrl-C', async () => {
-		const mockExecution = createMockExecution('npm error canceled\n$ ');
-		RunInTerminalTool.getExecution = () => mockExecution;
+	test('appends cancel-signal steering when input is Ctrl-C', () => {
+		return runWithFakedTimers({}, async () => {
+			const mockExecution = createMockExecution('npm error canceled\n$ ');
+			RunInTerminalTool.getExecution = () => mockExecution;
 
-		const result = await tool.invoke(
-			createInvocation(KNOWN_TERMINAL_ID, '\u0003'),
-			async () => 0,
-			{ report: () => { } },
-			CancellationToken.None,
-		);
+			const result = await tool.invoke(
+				createInvocation(KNOWN_TERMINAL_ID, '\u0003'),
+				async () => 0,
+				{ report: () => { } },
+				CancellationToken.None,
+			);
 
-		const value = (result.content[0] as { value: string }).value;
-		assert.ok(value.includes('cancel signal'), 'should mention cancel signal');
-		assert.ok(value.includes('not a signal to end the turn'), 'should remind the model the turn is not done');
+			const value = (result.content[0] as { value: string }).value;
+			assert.ok(value.includes('cancel signal'), 'should mention cancel signal');
+			assert.ok(value.includes('not a signal to end the turn'), 'should remind the model the turn is not done');
+		});
 	});
 
-	test('does not append cancel-signal steering for ordinary input', async () => {
-		const mockExecution = createMockExecution('hello');
-		RunInTerminalTool.getExecution = () => mockExecution;
+	test('does not append cancel-signal steering for ordinary input', () => {
+		return runWithFakedTimers({}, async () => {
+			const mockExecution = createMockExecution('hello');
+			RunInTerminalTool.getExecution = () => mockExecution;
 
-		const result = await tool.invoke(
-			createInvocation(KNOWN_TERMINAL_ID, 'y'),
-			async () => 0,
-			{ report: () => { } },
-			CancellationToken.None,
-		);
+			const result = await tool.invoke(
+				createInvocation(KNOWN_TERMINAL_ID, 'y'),
+				async () => 0,
+				{ report: () => { } },
+				CancellationToken.None,
+			);
 
-		const value = (result.content[0] as { value: string }).value;
-		assert.ok(!value.includes('cancel signal'), 'should not mention cancel signal for ordinary input');
+			const value = (result.content[0] as { value: string }).value;
+			assert.ok(!value.includes('cancel signal'), 'should not mention cancel signal for ordinary input');
+		});
 	});
 
 	function createPreparationContext(id: string, command: string, chatSessionResource?: URI): IToolInvocationPreparationContext {
@@ -471,69 +481,77 @@ suite('SendToTerminalTool', () => {
 		});
 	});
 
-	test('preserves newlines for heredoc commands and uses bracketed paste mode', async () => {
-		const mockExecution = createMockExecution('output');
-		RunInTerminalTool.getExecution = () => mockExecution;
+	test('preserves newlines for heredoc commands and uses bracketed paste mode', () => {
+		return runWithFakedTimers({}, async () => {
+			const mockExecution = createMockExecution('output');
+			RunInTerminalTool.getExecution = () => mockExecution;
 
-		const heredocCommand = 'cat > file.txt << \'EOF\'\nhello world\nEOF';
-		await tool.invoke(
-			createInvocation(KNOWN_TERMINAL_ID, heredocCommand),
-			async () => 0,
-			{ report: () => { } },
-			CancellationToken.None,
-		);
+			const heredocCommand = 'cat > file.txt << \'EOF\'\nhello world\nEOF';
+			await tool.invoke(
+				createInvocation(KNOWN_TERMINAL_ID, heredocCommand),
+				async () => 0,
+				{ report: () => { } },
+				CancellationToken.None,
+			);
 
-		assert.strictEqual(mockExecution.sentTexts.length, 1);
-		assert.strictEqual(mockExecution.sentTexts[0].text, heredocCommand, 'heredoc command should preserve newlines');
-		assert.strictEqual(mockExecution.sentTexts[0].forceBracketedPasteMode, true, 'multiline commands should use bracketed paste mode');
+			assert.strictEqual(mockExecution.sentTexts.length, 1);
+			assert.strictEqual(mockExecution.sentTexts[0].text, heredocCommand, 'heredoc command should preserve newlines');
+			assert.strictEqual(mockExecution.sentTexts[0].forceBracketedPasteMode, true, 'multiline commands should use bracketed paste mode');
+		});
 	});
 
-	test('preserves newlines for multiline commands with \\r\\n', async () => {
-		const mockExecution = createMockExecution('output');
-		RunInTerminalTool.getExecution = () => mockExecution;
+	test('preserves newlines for multiline commands with \\r\\n', () => {
+		return runWithFakedTimers({}, async () => {
+			const mockExecution = createMockExecution('output');
+			RunInTerminalTool.getExecution = () => mockExecution;
 
-		const multilineCommand = 'cat > file.txt << EOF\r\ncontent\r\nEOF';
-		await tool.invoke(
-			createInvocation(KNOWN_TERMINAL_ID, multilineCommand),
-			async () => 0,
-			{ report: () => { } },
-			CancellationToken.None,
-		);
+			const multilineCommand = 'cat > file.txt << EOF\r\ncontent\r\nEOF';
+			await tool.invoke(
+				createInvocation(KNOWN_TERMINAL_ID, multilineCommand),
+				async () => 0,
+				{ report: () => { } },
+				CancellationToken.None,
+			);
 
-		assert.strictEqual(mockExecution.sentTexts.length, 1);
-		assert.strictEqual(mockExecution.sentTexts[0].text, multilineCommand, 'multiline command with \\r\\n should preserve newlines');
-		assert.strictEqual(mockExecution.sentTexts[0].forceBracketedPasteMode, true, 'multiline commands should use bracketed paste mode');
+			assert.strictEqual(mockExecution.sentTexts.length, 1);
+			assert.strictEqual(mockExecution.sentTexts[0].text, multilineCommand, 'multiline command with \\r\\n should preserve newlines');
+			assert.strictEqual(mockExecution.sentTexts[0].forceBracketedPasteMode, true, 'multiline commands should use bracketed paste mode');
+		});
 	});
 
-	test('single-line commands still get normalized', async () => {
-		const mockExecution = createMockExecution('output');
-		RunInTerminalTool.getExecution = () => mockExecution;
+	test('single-line commands still get normalized', () => {
+		return runWithFakedTimers({}, async () => {
+			const mockExecution = createMockExecution('output');
+			RunInTerminalTool.getExecution = () => mockExecution;
 
-		await tool.invoke(
-			createInvocation(KNOWN_TERMINAL_ID, '  echo hello  '),
-			async () => 0,
-			{ report: () => { } },
-			CancellationToken.None,
-		);
+			await tool.invoke(
+				createInvocation(KNOWN_TERMINAL_ID, '  echo hello  '),
+				async () => 0,
+				{ report: () => { } },
+				CancellationToken.None,
+			);
 
-		assert.strictEqual(mockExecution.sentTexts.length, 1);
-		assert.strictEqual(mockExecution.sentTexts[0].text, 'echo hello', 'single-line command should be trimmed');
+			assert.strictEqual(mockExecution.sentTexts.length, 1);
+			assert.strictEqual(mockExecution.sentTexts[0].text, 'echo hello', 'single-line command should be trimmed');
+		});
 	});
 
-	test('line continuation commands are normalized, not treated as multiline', async () => {
-		const mockExecution = createMockExecution('output');
-		RunInTerminalTool.getExecution = () => mockExecution;
+	test('line continuation commands are normalized, not treated as multiline', () => {
+		return runWithFakedTimers({}, async () => {
+			const mockExecution = createMockExecution('output');
+			RunInTerminalTool.getExecution = () => mockExecution;
 
-		const continuationCommand = 'echo hello \\\n  world';
-		await tool.invoke(
-			createInvocation(KNOWN_TERMINAL_ID, continuationCommand),
-			async () => 0,
-			{ report: () => { } },
-			CancellationToken.None,
-		);
+			const continuationCommand = 'echo hello \\\n  world';
+			await tool.invoke(
+				createInvocation(KNOWN_TERMINAL_ID, continuationCommand),
+				async () => 0,
+				{ report: () => { } },
+				CancellationToken.None,
+			);
 
-		assert.strictEqual(mockExecution.sentTexts.length, 1);
-		assert.strictEqual(mockExecution.sentTexts[0].text, 'echo hello \\   world', 'line continuation should be normalized to single line');
-		assert.strictEqual(mockExecution.sentTexts[0].forceBracketedPasteMode, undefined, 'line continuation should not force bracketed paste mode');
+			assert.strictEqual(mockExecution.sentTexts.length, 1);
+			assert.strictEqual(mockExecution.sentTexts[0].text, 'echo hello \\   world', 'line continuation should be normalized to single line');
+			assert.strictEqual(mockExecution.sentTexts[0].forceBracketedPasteMode, undefined, 'line continuation should not force bracketed paste mode');
+		});
 	});
 });


### PR DESCRIPTION
Related to microsoft/vscode-copilot-evaluation#3850.

When the agent sends a cancel/EOF signal (Ctrl-C, Ctrl-D, Ctrl-\) to a running terminal via `send_to_terminal`, the tool currently returns:

```
Successfully sent command to terminal <id>.

Terminal output:
npm error canceled
$
```

The shell prompt at the bottom looks superficially like a clean done-state, and in 7/10 samples of [vscode-copilot-evaluation#3850](https://github.com/microsoft/vscode-copilot-evaluation/issues/3850) the model yielded here even though its own prose announced a follow-up `npm install`.

The original `run_in_terminal` "may be waiting for input — this is not a signal to end the turn" steering only fires once, two tool-calls earlier. This change appends a short reminder to the `send_to_terminal` response when the input was a cancel/EOF signal, telling the model the previous command was interrupted (not completed) and to issue any follow-up command in the same turn.

### Honest framing

This is a mitigation, not a fix. The underlying issue is model behavior — the model announces a recovery plan and then issues zero tool calls, which more steering text cannot guarantee to repair. But the post-cancel response on `send_to_terminal` is a real thin spot in the tool surface (no continuation hint at all) and tightening it is cheap and local.

### Scope

- Cancel signals detected: `\u0003` (Ctrl-C / ETX), `\u0004` (Ctrl-D / EOT), `\u001c` (Ctrl-\\ / FS).
- No new setting; the text is short.
- No execution semantics change. Only the text returned to the model differs.
- Tests added for both the cancel and non-cancel paths.