### PR TITLE
plugins: use manifest `name` for direct-install plugin labels

### DIFF
--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
@@ -141,6 +141,16 @@ export class AgentPluginService extends Disposable implements IAgentPluginServic
 type PluginEntry = IAgentPlugin;
 
 /**
+ * Minimal shape of a parsed plugin manifest. Known fields are typed; unknown
+ * keys (e.g. `commands`, `skills`, `hooks`, `mcpServers`) remain `unknown` and
+ * are parsed by the component readers.
+ */
+interface IPluginManifest {
+	readonly name?: string;
+	readonly [key: string]: unknown;
+}
+
+/**
  * Describes a single discovered plugin source, before the shared
  * infrastructure builds the full {@link IAgentPlugin} from it.
  */
@@ -205,7 +215,7 @@ export abstract class AbstractAgentPluginDiscovery extends Disposable implements
 			if (!seenPluginUris.has(key)) {
 				seenPluginUris.add(key);
 				const format = await detectPluginFormat(source.uri, this._fileService);
-				plugins.push(this._toPlugin(source.uri, format, source.fromMarketplace, source.repositoryUri, () => source.remove()));
+				plugins.push(await this._toPlugin(source.uri, format, source.fromMarketplace, source.repositoryUri, () => source.remove()));
 			}
 		}
 
@@ -224,7 +234,7 @@ export abstract class AbstractAgentPluginDiscovery extends Disposable implements
 		}
 	}
 
-	private _toPlugin(uri: URI, format: IPluginFormatConfig, fromMarketplace: IMarketplacePlugin | undefined, repositoryUri: URI | undefined, removeCallback: () => void): IAgentPlugin {
+	private async _toPlugin(uri: URI, format: IPluginFormatConfig, fromMarketplace: IMarketplacePlugin | undefined, repositoryUri: URI | undefined, removeCallback: () => void): Promise<IAgentPlugin> {
 		const key = uri.toString();
 		const existing = this._pluginEntries.get(key);
 		if (existing) {
@@ -239,9 +249,12 @@ export abstract class AbstractAgentPluginDiscovery extends Disposable implements
 		const store = new DisposableStore();
 		const enablement = derived(r => this._enablementModel.readEnabled(key, r));
 
-		// Track current component directories for the file watcher. These are
-		// updated whenever the manifest is read (inside each component reader).
-		const manifest = observableValue<Record<string, unknown> | undefined>('agentPluginManifest', undefined);
+		// Read the manifest up front so its `name` field can be used in the
+		// plugin label (for direct installs that have no marketplace metadata).
+		// Component directories are tracked via observers downstream and
+		// re-read whenever the manifest changes on disk.
+		const initialManifest = await this._readManifest(uri, format);
+		const manifest = observableValue<IPluginManifest | undefined>('agentPluginManifest', initialManifest);
 
 		const observeComponent = <T>(
 			prop: string,
@@ -311,7 +324,8 @@ export abstract class AbstractAgentPluginDiscovery extends Disposable implements
 			'.mcp.json',
 		);
 
-		// Read the manifest initially and re-read whenever manifest files change.
+		// Re-read the manifest whenever it changes on disk. The initial value
+		// was already populated above before constructing the observable.
 		const readManifest = async () => {
 			manifest.set(await this._readManifest(uri, format), undefined);
 		};
@@ -323,11 +337,11 @@ export abstract class AbstractAgentPluginDiscovery extends Disposable implements
 		store.add(manifestWatcher);
 		store.add(manifestWatcher.onDidChange(() => readManifest()));
 
-		readManifest();
+		const manifestName = initialManifest?.name?.trim() || undefined;
 
 		const plugin: PluginEntry = {
 			uri,
-			label: fromMarketplace?.name ?? basename(uri),
+			label: fromMarketplace?.name ?? manifestName ?? basename(uri),
 			enablement,
 			remove: removeCallback,
 			hooks,
@@ -344,10 +358,10 @@ export abstract class AbstractAgentPluginDiscovery extends Disposable implements
 		return plugin;
 	}
 
-	private async _readManifest(pluginUri: URI, format: IPluginFormatConfig): Promise<Record<string, unknown> | undefined> {
+	private async _readManifest(pluginUri: URI, format: IPluginFormatConfig): Promise<IPluginManifest | undefined> {
 		const json = await this._readJsonFile(joinPath(pluginUri, format.manifestPath));
-		if (json && typeof json === 'object') {
-			return json as Record<string, unknown>;
+		if (json && typeof json === 'object' && !Array.isArray(json)) {
+			return json as IPluginManifest;
 		}
 		return undefined;
 	}

--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
@@ -144,6 +144,9 @@ type PluginEntry = IAgentPlugin;
  * Minimal shape of a parsed plugin manifest. Known fields are typed; unknown
  * keys (e.g. `commands`, `skills`, `hooks`, `mcpServers`) remain `unknown` and
  * are parsed by the component readers.
+ *
+ * NOTE: `name` is typed as `string | undefined` to express intent, but
+ * consumers must still runtime-validate it (manifests are untrusted JSON).
  */
 interface IPluginManifest {
 	readonly name?: string;
@@ -337,7 +340,9 @@ export abstract class AbstractAgentPluginDiscovery extends Disposable implements
 		store.add(manifestWatcher);
 		store.add(manifestWatcher.onDidChange(() => readManifest()));
 
-		const manifestName = initialManifest?.name?.trim() || undefined;
+		const manifestName = typeof initialManifest?.name === 'string' && initialManifest.name.trim()
+			? initialManifest.name.trim()
+			: undefined;
 
 		const plugin: PluginEntry = {
 			uri,

--- a/src/vs/workbench/contrib/chat/test/common/plugins/agentPluginFormatDetection.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/plugins/agentPluginFormatDetection.test.ts
@@ -153,6 +153,44 @@ suite('AgentPlugin format detection', () => {
 		assert.strictEqual(plugins[0].commands.get()[0].name, 'run');
 	}));
 
+	test('plugin label uses manifest `name` when no marketplace metadata is present', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+		// Direct-installed plugin (no marketplace metadata) with a `name` in
+		// its manifest — the label should use the manifest name, not the
+		// uglier directory basename.
+		const uri = pluginUri('/plugins/_direct/sukumarp2022--slide-creator-plugin');
+		await writeFile('/plugins/_direct/sukumarp2022--slide-creator-plugin/plugin.json', JSON.stringify({
+			name: 'Slide Creator',
+		}));
+
+		const discovery = createDiscovery();
+		discovery.start(mockEnablementModel);
+		await discovery.setSourcesAndRefresh([uri]);
+
+		const plugins = discovery.plugins.get();
+		assert.deepStrictEqual(plugins.map(p => p.label), ['Slide Creator']);
+	}));
+
+	test('plugin label falls back to basename when manifest `name` is missing or invalid', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+		const missingUri = pluginUri('/plugins/missing-name');
+		await writeFile('/plugins/missing-name/plugin.json', JSON.stringify({}));
+
+		const blankUri = pluginUri('/plugins/blank-name');
+		await writeFile('/plugins/blank-name/plugin.json', JSON.stringify({ name: '   ' }));
+
+		const nonStringUri = pluginUri('/plugins/non-string-name');
+		await writeFile('/plugins/non-string-name/plugin.json', JSON.stringify({ name: 42 }));
+
+		const discovery = createDiscovery();
+		discovery.start(mockEnablementModel);
+		await discovery.setSourcesAndRefresh([missingUri, blankUri, nonStringUri]);
+
+		const plugins = discovery.plugins.get();
+		assert.deepStrictEqual(
+			plugins.map(p => p.label).sort(),
+			['blank-name', 'missing-name', 'non-string-name'],
+		);
+	}));
+
 	test('Open Plugin format takes priority over Claude format', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 		// Plugin has both .plugin/plugin.json and .claude-plugin/plugin.json —
 		// the open plugin manifest should be detected first.


### PR DESCRIPTION
Fixes #315855

## Problem

Direct-installed `.copilot` plugins (those with no marketplace metadata, e.g. installed straight from a Git repo and landing under `_direct/<slug>`) were displayed using their filesystem basename — for example `sukumarp2022--slide-creator-plugin` — instead of the human-readable `name` declared in the plugin's `plugin.json` manifest.

<img src="https://github.com/user-attachments/assets/ab07a633-e556-42d1-9a30-488d465b18a2" alt="Before" width="600" />

## Cause

In `AbstractAgentPluginDiscovery._toPlugin`, the label was computed as:

```ts
label: fromMarketplace?.name ?? basename(uri)
```

Direct installs have no `fromMarketplace` metadata, so it fell back to the directory basename. The manifest was being read asynchronously *after* the plugin was constructed (via `readManifest()` fire-and-forget), so its `name` field wasn't available at label-creation time.

## Fix

- Pre-read the manifest synchronously at plugin construction (`_toPlugin` is now `async`) and seed the manifest observable's initial value with it. This also eliminates a redundant initial read that the file watcher used to do via `readManifest()`.
- Extend the label fallback chain to `fromMarketplace?.name ?? manifestName ?? basename(uri)`. This mirrors the same pattern already used in `PluginMarketplaceService.readSinglePluginManifest`.
- Introduce a tighter `IPluginManifest` interface (`readonly name?: string` + index signature for unknown keys) to replace the loose `Record<string, unknown>` type. The new `_readManifest` also rejects arrays, which `typeof === 'object'` previously let through.

## Validation

- `npm run compile-check-ts-native` ✅
- `npm run valid-layers-check` ✅
- Hygiene errors (`tsbuildinfo` copyright) in the worktree are pre-existing and unrelated to this change.
