### PR TITLE
sessions: cache tunnel inside connect() so listSessions runs on first connect

### DIFF
--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostActions.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostActions.ts
@@ -917,6 +917,8 @@ async function promptToConnectViaTunnel(
 	});
 
 	try {
+		// `connect` caches the tunnel internally before wiring the live
+		// connection — no separate `cacheTunnel` call needed here.
 		await tunnelService.connect(picked.tunnel, authProvider);
 		handle.close();
 	} catch (err) {
@@ -924,9 +926,6 @@ async function promptToConnectViaTunnel(
 		notificationService.error(localize('tunnelConnectFailed', "Failed to connect to tunnel '{0}': {1}", picked.tunnel.name, err instanceof Error ? err.message : String(err)));
 		return;
 	}
-
-	// Cache the tunnel for future reconnections
-	tunnelService.cacheTunnel(picked.tunnel, authProvider);
 
 	// Step 5: Open folder picker (same pattern as SSH)
 	await instantiationService.invokeFunction(accessor => promptForTunnelFolder(accessor, picked.tunnel));

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/tunnelAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/tunnelAgentHost.contribution.ts
@@ -194,14 +194,7 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 
 	private _createProvider(address: string, name: string): void {
 		const store = new DisposableStore();
-		const provider = this._instantiationService.createInstance(
-			RemoteAgentHostSessionsProvider, {
-			address,
-			name,
-			connectOnDemand: () => this._connectTunnel(address, { userInitiated: true }),
-			disconnectOnDemand: () => this._disconnectTunnel(address),
-		},
-		);
+		const provider = this._instantiateProvider(address, name);
 		// Surface as "Connecting" until the first silent status check or an
 		// auto-connect attempt determines the real state; otherwise the picker
 		// flashes "Offline" for every cached tunnel on startup.
@@ -211,6 +204,17 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 		this._providerInstances.set(address, provider);
 		store.add(toDisposable(() => this._providerInstances.delete(address)));
 		this._providerStores.set(address, store);
+	}
+
+	protected _instantiateProvider(address: string, name: string): RemoteAgentHostSessionsProvider {
+		return this._instantiationService.createInstance(
+			RemoteAgentHostSessionsProvider, {
+			address,
+			name,
+			connectOnDemand: () => this._connectTunnel(address, { userInitiated: true }),
+			disconnectOnDemand: () => this._disconnectTunnel(address),
+		},
+		);
 	}
 
 	// -- Connection status --

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/webTunnelAgentHostService.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/webTunnelAgentHostService.ts
@@ -143,6 +143,12 @@ export class WebTunnelAgentHostService extends Disposable implements ITunnelAgen
 			await protocolClient.connect();
 			this._logService.info(`${LOG_PREFIX} Protocol handshake completed with ${address}`);
 
+			// Cache before announcing the live connection so the contribution's
+			// `onDidChangeTunnels` handler has created the provider by the time
+			// `onDidChangeConnections` fires from `addManagedConnection` and
+			// wires the connection. Also fires `onDidChangeTunnels`.
+			this.cacheTunnel(tunnel, authProvider);
+
 			await this._remoteAgentHostService.addManagedConnection({
 				name: tunnel.name,
 				connectionToken,
@@ -154,8 +160,6 @@ export class WebTunnelAgentHostService extends Disposable implements ITunnelAgen
 					authProvider,
 				},
 			}, protocolClient);
-
-			this._onDidChangeTunnels.fire();
 		} catch (err) {
 			protocolClient.dispose();
 			this._logService.error(`${LOG_PREFIX} Connection setup failed`, err);

--- a/src/vs/sessions/contrib/remoteAgentHost/electron-browser/tunnelAgentHostServiceImpl.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/electron-browser/tunnelAgentHostServiceImpl.ts
@@ -116,6 +116,8 @@ export class TunnelAgentHostService extends Disposable implements ITunnelAgentHo
 			await protocolClient.connect();
 			this._logService.info(`${LOG_PREFIX} Protocol handshake completed with ${result.address}`);
 
+			this.cacheTunnel(tunnel, auth.provider);
+
 			await this._remoteAgentHostService.addManagedConnection({
 				name: result.name,
 				connectionToken: result.connectionToken,
@@ -127,8 +129,6 @@ export class TunnelAgentHostService extends Disposable implements ITunnelAgentHo
 					authProvider: auth.provider,
 				},
 			}, protocolClient);
-
-			this._onDidChangeTunnels.fire();
 		} catch (err) {
 			this._logService.error(`${LOG_PREFIX} Connection setup failed`, err);
 			this._mainService.disconnect(result.connectionId).catch(() => { /* best effort */ });

--- a/src/vs/sessions/contrib/remoteAgentHost/test/browser/tunnelAgentHost.contribution.test.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/test/browser/tunnelAgentHost.contribution.test.ts
@@ -1,0 +1,196 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Emitter, Event } from '../../../../../base/common/event.js';
+import { Disposable, IDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
+import { observableValue } from '../../../../../base/common/observable.js';
+import { mock } from '../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IAgentConnection } from '../../../../../platform/agentHost/common/agentService.js';
+import {
+	IRemoteAgentHostConnectionInfo,
+	IRemoteAgentHostService,
+	RemoteAgentHostConnectionStatus,
+	RemoteAgentHostsEnabledSettingId,
+} from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
+import {
+	ICachedTunnel,
+	ITunnelAgentHostService,
+	TUNNEL_ADDRESS_PREFIX,
+} from '../../../../../platform/agentHost/common/tunnelAgentHost.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
+import { INotificationService } from '../../../../../platform/notification/common/notification.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { IAuthenticationService } from '../../../../../workbench/services/authentication/common/authentication.js';
+import { ISessionsProvider } from '../../../../services/sessions/common/sessionsProvider.js';
+import { ISessionsProvidersChangeEvent, ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
+import { IAgentHostFilterService } from '../../common/agentHostFilter.js';
+import { RemoteAgentHostSessionsProvider } from '../../browser/remoteAgentHostSessionsProvider.js';
+import { TunnelAgentHostContribution } from '../../browser/tunnelAgentHost.contribution.js';
+
+class StubProvider extends mock<RemoteAgentHostSessionsProvider>() {
+	readonly setConnectionCalls: Array<{ connection: IAgentConnection; defaultDirectory: string | undefined }> = [];
+
+	override readonly id: string;
+	override readonly remoteAddress: string;
+	override readonly label: string;
+
+	private readonly _status = observableValue<RemoteAgentHostConnectionStatus>('status', RemoteAgentHostConnectionStatus.connecting);
+	override readonly connectionStatus = this._status;
+
+	constructor(address: string, name: string) {
+		super();
+		this.id = `agenthost-${address}`;
+		this.remoteAddress = address;
+		this.label = name;
+	}
+
+	override setConnectionStatus(status: RemoteAgentHostConnectionStatus): void {
+		this._status.set(status, undefined);
+	}
+
+	override setConnection(connection: IAgentConnection, defaultDirectory?: string): void {
+		this.setConnectionCalls.push({ connection, defaultDirectory });
+	}
+
+	override unpublishCachedSessions(): void { /* noop */ }
+
+	override dispose(): void { /* noop */ }
+}
+
+class StubTunnelService extends Disposable {
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _onDidChangeTunnels = this._register(new Emitter<void>());
+	readonly onDidChangeTunnels = this._onDidChangeTunnels.event;
+
+	private _cached: ICachedTunnel[] = [];
+	private readonly _suppressed = new Set<string>();
+
+	setCached(tunnels: ICachedTunnel[]): void {
+		this._cached = tunnels;
+		this._onDidChangeTunnels.fire();
+	}
+
+	getCachedTunnels(): ICachedTunnel[] { return this._cached; }
+	isAutoConnectSuppressed(id: string): boolean { return this._suppressed.has(id); }
+	suppressAutoConnect(id: string): void { this._suppressed.add(id); }
+	clearAutoConnectSuppression(id: string): void { this._suppressed.delete(id); }
+}
+
+class StubRemoteAgentHostService extends Disposable {
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _onDidChangeConnections = this._register(new Emitter<void>());
+	readonly onDidChangeConnections = this._onDidChangeConnections.event;
+
+	private readonly _connections: IRemoteAgentHostConnectionInfo[] = [];
+	private readonly _agentConnections = new Map<string, IAgentConnection>();
+
+	get connections(): readonly IRemoteAgentHostConnectionInfo[] { return this._connections; }
+
+	getConnection(address: string): IAgentConnection | undefined {
+		return this._agentConnections.get(address);
+	}
+
+	addConnection(info: IRemoteAgentHostConnectionInfo, connection: IAgentConnection): void {
+		this._connections.push(info);
+		this._agentConnections.set(info.address, connection);
+		this._onDidChangeConnections.fire();
+	}
+}
+
+class StubSessionsProvidersService extends Disposable {
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _onDidChange = this._register(new Emitter<ISessionsProvidersChangeEvent>());
+	readonly onDidChangeProviders = this._onDidChange.event;
+
+	private readonly _providers = new Map<string, ISessionsProvider>();
+
+	registerProvider(provider: ISessionsProvider): IDisposable {
+		this._providers.set(provider.id, provider);
+		this._onDidChange.fire({ added: [provider], removed: [] });
+		return toDisposable(() => {
+			if (this._providers.delete(provider.id)) {
+				this._onDidChange.fire({ added: [], removed: [provider] });
+			}
+		});
+	}
+
+	getProviders(): ISessionsProvider[] {
+		return [...this._providers.values()];
+	}
+}
+
+class StubFilterService {
+	declare readonly _serviceBrand: undefined;
+	registerDiscoveryHandler(_handler: () => Promise<void>): IDisposable { return toDisposable(() => { }); }
+	async rediscover(): Promise<void> { /* noop — production routes through the discovery handler */ }
+}
+
+class TestTunnelContribution extends TunnelAgentHostContribution {
+	readonly stubProviders = new Map<string, StubProvider>();
+
+	protected override _instantiateProvider(address: string, name: string): RemoteAgentHostSessionsProvider {
+		const stub = new StubProvider(address, name);
+		this.stubProviders.set(address, stub);
+		return stub as unknown as RemoteAgentHostSessionsProvider;
+	}
+}
+
+suite('TunnelAgentHostContribution', () => {
+
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('newly-cached tunnel binds to subsequent live connection', () => {
+		// Regression guard for the picker flow: `tunnelService.connect()` is
+		// contractually obligated to cache the tunnel BEFORE announcing the
+		// live connection via `addManagedConnection`. That ordering lets the
+		// `onDidChangeTunnels` handler create the provider first, so the
+		// `onDidChangeConnections` handler can wire it. Both halves are
+		// exercised here.
+		const tunnelService = store.add(new StubTunnelService());
+		const remoteService = store.add(new StubRemoteAgentHostService());
+		const providersService = store.add(new StubSessionsProvidersService());
+
+		const instantiationService = store.add(new TestInstantiationService());
+		instantiationService.stub(ITunnelAgentHostService, tunnelService as unknown as ITunnelAgentHostService);
+		instantiationService.stub(IRemoteAgentHostService, remoteService as unknown as IRemoteAgentHostService);
+		instantiationService.stub(ISessionsProvidersService, providersService as unknown as ISessionsProvidersService);
+		instantiationService.stub(IConfigurationService, new TestConfigurationService({ [RemoteAgentHostsEnabledSettingId]: true }));
+		instantiationService.stub(INotificationService, { notify: () => ({ close() { } }) } as unknown as INotificationService);
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(IAuthenticationService, { onDidChangeSessions: Event.None } as unknown as IAuthenticationService);
+		instantiationService.stub(ITelemetryService, { publicLog2: () => { } } as unknown as ITelemetryService);
+		instantiationService.stub(IAgentHostFilterService, new StubFilterService() as unknown as IAgentHostFilterService);
+
+		const contribution = store.add(instantiationService.createInstance(TestTunnelContribution));
+
+		const tunnelId = 'tunnel-abc';
+		const address = `${TUNNEL_ADDRESS_PREFIX}${tunnelId}`;
+		const fakeConnection = {} as IAgentConnection;
+
+		// Step 1: cache the tunnel — creates the provider via `_reconcileProviders`.
+		tunnelService.setCached([{ tunnelId, clusterId: 'use', name: 'My Tunnel' }]);
+		const provider = contribution.stubProviders.get(address);
+		assert.ok(provider, 'provider should be created for the cached tunnel');
+		assert.strictEqual(provider!.setConnectionCalls.length, 0, 'no live connection yet — wire-up must wait');
+
+		// Step 2: announce the live connection — `_wireConnections` should bind it.
+		remoteService.addConnection({
+			address,
+			name: 'My Tunnel',
+			clientId: 'client-1',
+			status: RemoteAgentHostConnectionStatus.connected,
+		}, fakeConnection);
+
+		assert.deepStrictEqual(provider!.setConnectionCalls.map(c => c.connection), [fakeConnection]);
+	});
+});


### PR DESCRIPTION
- The tunnel picker flow called `connect()` (which fired `onDidChangeConnections`) before `cacheTunnel()` (which fired `onDidChangeTunnels` and created the provider). The wire-up handler therefore ran with no provider, so the new connection was never bound and `listSessions` was never issued — tunnel sessions only appeared after the user started a new session on the tunnel.
- Move `cacheTunnel()` inside `connect()` (desktop + web) so the cache → provider creation → `addManagedConnection` → wire-up ordering is invariant regardless of caller, removing the need for defensive re-wiring in the contribution.
- Drop the now-redundant explicit `cacheTunnel` call from the picker action and the trailing `_onDidChangeTunnels.fire()` from both service impls (cacheTunnel already fires it).
- Add a regression test that asserts a freshly-cached tunnel binds to a subsequent live connection through the standard wire-up path.

Fixes #315059

(Commit message generated by Copilot)