### PR TITLE
Restore remote-row options picker in session workspace picker

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -345,17 +345,7 @@ export class WorkspacePicker extends Disposable {
 		return {
 			onSelect: (item) => {
 				hide();
-				if (item.commandId) {
-					this.commandService.executeCommand(item.commandId);
-				} else if (item.selection && this._isProviderUnavailable(item.selection.providerId)) {
-					// Workspace belongs to an unavailable remote — ignore selection
-					return;
-				}
-				if (item.browseActionIndex !== undefined) {
-					this._executeBrowseAction(item.browseActionIndex);
-				} else if (item.selection) {
-					this._selectProject(item.selection);
-				}
+				this._dispatchPickerItem(item);
 			},
 			onHide: () => {
 				triggerElement.setAttribute('aria-expanded', 'false');


### PR DESCRIPTION
Clicking a remote host row in the Remote tab of the session workspace picker no longer opened the per-remote options popup (Reconnect / Remove / Copy connection string / Open settings / Show output).

### Root cause

The remote rows in `_buildItems` are built with an inline `run` callback that invokes `_showRemoteHostOptionsDelayed`:

```ts
item: { run: () => action.run(), commandId: action.id }
```

A recent refactor extracted picker dispatch into a shared `_dispatchPickerItem` method so the mobile sheet (`webWorkspacePicker.ts`) could reuse it. However the desktop `_buildDelegate.onSelect` was rewritten inline at the same time and dropped the `item.run` branch. Clicks fell through to `commandService.executeCommand(item.commandId)` with a synthetic id like `workspacePicker.remote.<providerId>` that isn't a registered command, so nothing happened.

### Fix

Wire the desktop `onSelect` to `_dispatchPickerItem` so both desktop and mobile presentations share the single source of truth that already handles `item.run`. The doc comment on `_dispatchPickerItem` already calls this out as the intended shape.

Fixes https://github.com/microsoft/vscode/issues/315937