### PR TITLE
Update chat tab indicators for 'needs-input' status

### DIFF
--- a/src/vs/sessions/browser/parts/chatCompositeBar.ts
+++ b/src/vs/sessions/browser/parts/chatCompositeBar.ts
@@ -132,15 +132,16 @@ export class ChatCompositeBar extends Disposable {
 			const status = chat.status.read(reader);
 			const isRead = chat.isRead.read(reader);
 
-			let mode: 'unread' | 'in-progress' | 'none' = 'none';
+			let mode: 'needs-input' | 'unread' | 'in-progress' | 'none' = 'none';
 			if (status === SessionStatus.NeedsInput) {
-				mode = 'unread';
+				mode = 'needs-input';
 			} else if (status === SessionStatus.InProgress) {
 				mode = 'in-progress';
 			} else if (!isRead && !isActive) {
 				mode = 'unread';
 			}
 
+			tab.classList.toggle('needs-input', mode === 'needs-input');
 			tab.classList.toggle('unread', mode === 'unread');
 			tab.classList.toggle('in-progress', mode === 'in-progress');
 

--- a/src/vs/sessions/browser/parts/media/chatCompositeBar.css
+++ b/src/vs/sessions/browser/parts/media/chatCompositeBar.css
@@ -61,12 +61,14 @@
 /* When an indicator is shown on a tab without a close button (e.g. the main chat),
 	reserve right-side space so the absolutely-positioned indicator doesn't overlap the label. */
 .chat-composite-bar-tab:not(:has(.chat-composite-bar-tab-actions)).unread,
+.chat-composite-bar-tab:not(:has(.chat-composite-bar-tab-actions)).needs-input,
 .chat-composite-bar-tab:not(:has(.chat-composite-bar-tab-actions)).in-progress {
 	padding-right: 22px;
 }
 
 /* Indicator: absolutely positioned over the close-action slot.
-	Shows a small yellow dot for unread, or a spinner for in-progress.
+	Shows a small blue dot for unread, a yellow dot when input is needed,
+	or a spinner for in-progress.
 	Only one mode is set on the element at a time (mutually exclusive in JS). */
 .chat-composite-bar-tab-indicator {
 	display: none;
@@ -82,6 +84,7 @@
 }
 
 .chat-composite-bar-tab.unread .chat-composite-bar-tab-indicator,
+.chat-composite-bar-tab.needs-input .chat-composite-bar-tab-indicator,
 .chat-composite-bar-tab.in-progress .chat-composite-bar-tab-indicator {
 	display: flex;
 }
@@ -92,11 +95,19 @@
 	justify-content: center;
 }
 
-.chat-composite-bar-tab.unread .chat-composite-bar-tab-indicator-icon::before {
+.chat-composite-bar-tab.unread .chat-composite-bar-tab-indicator-icon::before,
+.chat-composite-bar-tab.needs-input .chat-composite-bar-tab-indicator-icon::before {
 	content: '';
 	width: 6px;
 	height: 6px;
 	border-radius: 50%;
+}
+
+.chat-composite-bar-tab.unread .chat-composite-bar-tab-indicator-icon::before {
+	background-color: var(--vscode-textLink-foreground);
+}
+
+.chat-composite-bar-tab.needs-input .chat-composite-bar-tab-indicator-icon::before {
 	background-color: var(--vscode-list-warningForeground);
 }
 


### PR DESCRIPTION
```Copilot Generated Description:``` Update chat tab indicators to include a new 'needs-input' status, modifying both the JavaScript and CSS to reflect this change. The indicator now shows a yellow dot when input is needed, alongside existing indicators for unread and in-progress statuses.