### PR TITLE
Insert Final New Line: append EOL when last line is whitespace-only

### DIFF
--- a/src/vs/editor/contrib/insertFinalNewLine/browser/insertFinalNewLineCommand.ts
+++ b/src/vs/editor/contrib/insertFinalNewLine/browser/insertFinalNewLineCommand.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as strings from '../../../../base/common/strings.js';
 import { EditOperation, ISingleEditOperation } from '../../../common/core/editOperation.js';
 import { Position } from '../../../common/core/position.js';
 import { Selection } from '../../../common/core/selection.js';
@@ -40,10 +39,16 @@ export class InsertFinalNewLineCommand implements ICommand {
  */
 export function insertFinalNewLine(model: ITextModel): ISingleEditOperation | undefined {
 	const lineCount = model.getLineCount();
-	const lastLine = model.getLineContent(lineCount);
-	const lastLineIsEmptyOrWhitespace = strings.lastNonWhitespaceIndex(lastLine) === -1;
+	if (!lineCount) {
+		return;
+	}
 
-	if (!lineCount || lastLineIsEmptyOrWhitespace) {
+	// Only skip when the last line is genuinely empty: an empty trailing line
+	// indicates the buffer already ends with an EOL (e.g. "foo\n" has 2 lines,
+	// the second being ""). A whitespace-only last line still needs an EOL
+	// appended to be POSIX-conformant.
+	const lastLineLength = model.getLineLength(lineCount);
+	if (lastLineLength === 0) {
 		return;
 	}
 


### PR DESCRIPTION
## Cause

`Insert Final New Line` is implemented in [`insertFinalNewLineCommand.ts`](https://github.com/microsoft/vscode/blob/main/src/vs/editor/contrib/insertFinalNewLine/browser/insertFinalNewLineCommand.ts). The function bails out when the buffer's last line is empty *or* whitespace-only:

```ts
const lastLine = model.getLineContent(lineCount);
const lastLineIsEmptyOrWhitespace = strings.lastNonWhitespaceIndex(lastLine) === -1;

if (!lineCount || lastLineIsEmptyOrWhitespace) {
    return;
}
```

The two cases are not equivalent:

- **Empty last line** (`"foo\n"` is 2 lines, the second being `""`) — the file already ends with an EOL, so no insert is needed. Bailing here is correct.
- **Whitespace-only last line** (`"  "` with no trailing EOL) — this is content that does **not** end with a newline. The file is not POSIX-conformant and `Insert Final New Line` should append an EOL.

Conflating these two means whitespace-only trailing lines never get a newline, so the command (and `files.insertFinalNewline`) silently fails to make the file POSIX-conformant whenever trailing whitespace is present. The same root cause was independently identified in the issue: https://github.com/microsoft/vscode/blob/98a1eb8c97a0a44c13d8e2abc56a58f129da7645/src/vs/editor/contrib/insertFinalNewLine/browser/insertFinalNewLineCommand.ts#L44.

## Fix

Use a strict empty-length check (`getLineLength === 0`) for the bail-out, so only a genuinely empty trailing line is treated as already-terminated. Whitespace-only last lines fall through to the insert path and correctly receive an EOL.

This also drops the now-unused `strings` import.

Fixes #314720