### PR TITLE
Git: show staged typechanges in the index group

### DIFF
--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -3072,6 +3072,7 @@ export class Repository implements Disposable {
 				case 'D': indexGroup.push(new Resource(this.resourceCommandResolver, ResourceGroupType.Index, uri, Status.INDEX_DELETED, useIcons, undefined, this.kind)); break;
 				case 'R': indexGroup.push(new Resource(this.resourceCommandResolver, ResourceGroupType.Index, uri, Status.INDEX_RENAMED, useIcons, renameUri, this.kind)); break;
 				case 'C': indexGroup.push(new Resource(this.resourceCommandResolver, ResourceGroupType.Index, uri, Status.INDEX_COPIED, useIcons, renameUri, this.kind)); break;
+				case 'T': indexGroup.push(new Resource(this.resourceCommandResolver, ResourceGroupType.Index, uri, Status.TYPE_CHANGED, useIcons, undefined, this.kind)); break;
 			}
 
 			switch (raw.y) {


### PR DESCRIPTION
## Cause

`Repository.parseStatus` in [`extensions/git/src/repository.ts`](https://github.com/microsoft/vscode/blob/main/extensions/git/src/repository.ts) splits the porcelain status into two switches, one for the index column (`raw.x`) and one for the working-tree column (`raw.y`):

```ts
switch (raw.x) {
    case 'M': indexGroup.push(... Status.INDEX_MODIFIED ...); break;
    case 'A': indexGroup.push(... Status.INDEX_ADDED ...); break;
    case 'D': indexGroup.push(... Status.INDEX_DELETED ...); break;
    case 'R': indexGroup.push(... Status.INDEX_RENAMED ...); break;
    case 'C': indexGroup.push(... Status.INDEX_COPIED ...); break;
}

switch (raw.y) {
    case 'M': workingTreeGroup.push(... Status.MODIFIED ...); break;
    case 'D': workingTreeGroup.push(... Status.DELETED ...); break;
    case 'A': workingTreeGroup.push(... Status.INTENT_TO_ADD ...); break;
    case 'R': workingTreeGroup.push(... Status.INTENT_TO_RENAME ...); break;
    case 'T': workingTreeGroup.push(... Status.TYPE_CHANGED ...); break;
}
```

Git also emits `T` (typechange) in the **index** column when a staged change converts a path between regular file / symlink / submodule -- for example after `ln -s target CLAUDE.md && git add CLAUDE.md` against a previously-tracked regular file. Because the index switch has no `T` case, the file silently falls through and never enters any group, so it disappears from the SCM view despite being staged (this is what the issue's screenshot shows).

`git ls-files -s` confirms it is staged correctly; `git status` confirms the index column is `T`; the extension just doesn't render it.

## Fix

Add a `'T'` case to the index switch that mirrors the existing working-tree handling, pushing the resource into the index group with `Status.TYPE_CHANGED`. `TYPE_CHANGED` already has a localized label (`l10n.t('Type Changed')`), tooltip, icon, and decoration in this same file, so no new public `Status` enum value is introduced -- the existing one is reused for both index and working-tree variants, mirroring how `MODIFIED` / `INDEX_MODIFIED` differ in group but share the icon.

Fixes #291945