### PR TITLE
Allow shell integration in ConstrainedLanguage mode when lockdown policy is None

### DIFF
--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1
@@ -9,9 +9,17 @@ if ((Test-Path variable:global:__VSCodeState) -and $null -ne $Global:__VSCodeSta
 }
 
 # Disable shell integration when the language mode is restricted
-# Disable shell integration when the language mode is restricted
 $languageMode = $ExecutionContext.SessionState.LanguageMode
-$lockdownPolicy = [System.Management.Automation.Security.SystemPolicy]::GetSystemLockdownPolicy()
+$lockdownPolicy = $null
+
+if ($languageMode -eq "ConstrainedLanguage") {
+    try {
+        $lockdownPolicy = [System.Management.Automation.Security.SystemPolicy]::GetSystemLockdownPolicy()
+    }
+    catch {
+        $lockdownPolicy = $null
+    }
+}
 
 if (
     $languageMode -ne "FullLanguage" -and

--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1
@@ -9,8 +9,18 @@ if ((Test-Path variable:global:__VSCodeState) -and $null -ne $Global:__VSCodeSta
 }
 
 # Disable shell integration when the language mode is restricted
-if ($ExecutionContext.SessionState.LanguageMode -ne "FullLanguage") {
-	return;
+# Disable shell integration when the language mode is restricted
+$languageMode = $ExecutionContext.SessionState.LanguageMode
+$lockdownPolicy = [System.Management.Automation.Security.SystemPolicy]::GetSystemLockdownPolicy()
+
+if (
+    $languageMode -ne "FullLanguage" -and
+    !($languageMode -eq "ConstrainedLanguage" -and (
+        $lockdownPolicy -eq "Audit" -or
+        $lockdownPolicy -eq "None"
+    ))
+) {
+    return;
 }
 
 $Global:__VSCodeState = @{


### PR DESCRIPTION
Problem

Shell integration in PowerShell is currently disabled unless LanguageMode is `FullLanguage`.

However, on some systems PowerShell runs in `ConstrainedLanguage` mode while the system lockdown policy is `None`, meaning the environment is not actually restricted enough to require disabling shell integration.

This causes shell integration to be unnecessarily disabled.

Fix

Allow shell integration when:

* LanguageMode is `FullLanguage`
* OR LanguageMode is `ConstrainedLanguage` and lockdown policy is:

  * `Audit`
  * `None`

This preserves protection for genuinely restricted environments while avoiding unnecessary disablement.

