### PR TITLE
Fix Copilot CLI compact no-op and context usage reporting

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { Attachment, LocalSession, SendOptions, Session, SessionOptions, ToolExecutionCompleteEvent } from '@github/copilot/sdk';
+import type { Attachment, CompactionResult, LocalSession, SendOptions, Session, SessionOptions, ToolExecutionCompleteEvent } from '@github/copilot/sdk';
 import * as l10n from '@vscode/l10n';
 import * as cp from 'child_process';
 import * as crypto from 'crypto';
@@ -453,6 +453,17 @@ function getPromptLabel(input: CopilotCLISessionInput): string {
 	return input.prompt;
 }
 
+function normalizeCopilotCLICommandInput(input: CopilotCLISessionInput): CopilotCLISessionInput {
+	if ('command' in input || !isCompactInput(input)) {
+		return input;
+	}
+	return { command: 'compact', prompt: '', source: input.source };
+}
+
+function isCompactInput(input: CopilotCLISessionInput): boolean {
+	return 'command' in input ? input.command === 'compact' : stripReminders(input.prompt).trim().toLowerCase() === '/compact';
+}
+
 function getRemoteControlArgs(input: CopilotCLISessionInput): string {
 	const prompt = stripReminders(('prompt' in input ? input.prompt : '') ?? '').trim().toLowerCase();
 	if (prompt === '/remote' || prompt === 'remote') {
@@ -884,6 +895,7 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 	private _lastResponseModelId: string | undefined;
 	private _pendingPrompt: string | undefined;
 	private _bridgeProcessor: CopilotCliBridgeSpanProcessor | undefined;
+	private _lastUsageInfo: UsageInfoData | undefined;
 	private readonly _todoSqlQuery = new TodoSqlQuery();
 	private readonly _missionControlApiClient: MissionControlApiClient;
 	private _cancelPendingCancellationAbort: (() => void) | undefined;
@@ -1214,22 +1226,42 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 
 		const chunkMessageIds = new Set<string>();
 		const assistantMessageChunks: string[] = [];
-		let lastUsageInfo: UsageInfoData | undefined;
-		const reportUsage = (promptTokens: number, completionTokens: number) => {
+		let requestUsageInfo: UsageInfoData | undefined;
+		const reportUsage = (promptTokens: number, completionTokens: number, usageInfo: UsageInfoData | undefined = requestUsageInfo) => {
 			if (token.isCancellationRequested || !requestStream) {
+				return;
+			}
+			if (promptTokens <= 0 && completionTokens <= 0) {
 				return;
 			}
 			requestStream.usage({
 				promptTokens,
 				completionTokens,
-				promptTokenDetails: buildPromptTokenDetails(lastUsageInfo),
+				promptTokenDetails: buildPromptTokenDetails(usageInfo),
 			});
 		};
-		const updateUsageInfo = (async () => {
+		const updateUsageInfo = async (useMetricsUsage: boolean) => {
+			if (!useMetricsUsage) {
+				const usageInfo = requestUsageInfo ?? this._lastUsageInfo;
+				if (usageInfo && usageInfo.currentTokens > 0) {
+					reportUsage(usageInfo.currentTokens, 0, usageInfo);
+				}
+				return;
+			}
 			const metrics = await this._sdkSession.usage.getMetrics();
-			const promptTokens = lastUsageInfo?.currentTokens || metrics.lastCallInputTokens;
-			reportUsage(promptTokens, metrics.lastCallOutputTokens);
-		})();
+			if (requestUsageInfo && requestUsageInfo.currentTokens > 0) {
+				reportUsage(requestUsageInfo.currentTokens, metrics.lastCallOutputTokens, requestUsageInfo);
+				return;
+			}
+			if (metrics.lastCallInputTokens > 0 || metrics.lastCallOutputTokens > 0) {
+				reportUsage(metrics.lastCallInputTokens, metrics.lastCallOutputTokens);
+			}
+		};
+		const updateRequestUsageInfo = (usageInfo: UsageInfoData) => {
+			requestUsageInfo = usageInfo;
+			this._lastUsageInfo = usageInfo;
+			reportUsage(usageInfo.currentTokens, 0, usageInfo);
+		};
 		try {
 			const shouldHandleExitPlanModeRequests = this.configurationService.getConfig(ConfigKey.Advanced.CLIPlanExitModeEnabled);
 			disposables.add(toDisposable(this._sdkSession.on('*', (event) => {
@@ -1390,7 +1422,7 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 			disposables.add(toDisposable(this._sdkSession.on('assistant.usage', (event) => {
 				this._lastResponseModelId = event.data.model;
 				if (requestStream && typeof event.data.outputTokens === 'number' && typeof event.data.inputTokens === 'number') {
-					reportUsage(event.data.inputTokens, event.data.outputTokens);
+					reportUsage(event.data.inputTokens, event.data.outputTokens, requestUsageInfo);
 				}
 				// Accumulate per-turn credits from SDK copilotUsage data
 				const copilotUsage = (event.data as Record<string, unknown>).copilotUsage;
@@ -1402,14 +1434,14 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 				}
 			})));
 			disposables.add(toDisposable(this._sdkSession.on('session.usage_info', (event) => {
-				lastUsageInfo = {
+				updateRequestUsageInfo({
 					currentTokens: event.data.currentTokens,
+					messagesLength: event.data.messagesLength,
 					systemTokens: event.data.systemTokens,
 					conversationTokens: event.data.conversationTokens,
 					toolDefinitionsTokens: event.data.toolDefinitionsTokens,
 					tokenLimit: event.data.tokenLimit,
-				};
-				reportUsage(lastUsageInfo.currentTokens, 0);
+				});
 			})));
 			disposables.add(toDisposable(this._sdkSession.on('assistant.message_delta', (event) => {
 				// Support for streaming delta messages.
@@ -1585,6 +1617,10 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 				);
 			})));
 
+			const useMetricsUsage = !isCompactInput(input);
+			if (useMetricsUsage) {
+				this._lastUsageInfo = undefined;
+			}
 			if (!token.isCancellationRequested) {
 				await this.sendRequestInternal(input, attachments, false, logStartTime);
 			}
@@ -1619,7 +1655,7 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 					this.logService.error(`[CopilotCLISession] Failed to update chat session metadata store for request ${request.id}`, error);
 				});
 			}
-			await updateUsageInfo.catch(error => {
+			await updateUsageInfo(useMetricsUsage).catch(error => {
 				this.logService.error(`[CopilotCLISession] Failed to update usage info after request ${request.id}`, error);
 			});
 			this._status = ChatSessionStatus.Completed;
@@ -1728,17 +1764,40 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 	 *   starting a new turn. This is the mechanism behind session steering.
 	 */
 	private async sendRequestInternal(input: CopilotCLISessionInput, attachments: Attachment[], steering = false, logStartTime: number): Promise<void> {
-		const prompt = getPromptLabel(input);
+		const effectiveInput = normalizeCopilotCLICommandInput(input);
+		const prompt = getPromptLabel(effectiveInput);
 		this._logRequest(prompt, this._lastUsedModel || '', attachments, logStartTime);
 
-		if ('command' in input && input.command !== 'plan') {
-			switch (input.command) {
+		if ('command' in effectiveInput && effectiveInput.command !== 'plan') {
+			switch (effectiveInput.command) {
 				case 'compact': {
+					const messages = await this._sdkSession.getChatMessages();
+					if (messages.length === 0) {
+						this._stream?.markdown(l10n.t('Nothing to compact.'));
+						break;
+					}
+					// Mirrors compactHistory's no-op precondition, but avoids surfacing the SDK error as a failed command.
+					if (messages.length < 2) {
+						this._stream?.markdown(l10n.t('Conversation already compacted.'));
+						break;
+					}
 					this._stream?.progress(l10n.t('Compacting conversation...'));
 					await this._sdkSession.initializeAndValidateTools();
 					this._sdkSession.currentMode = 'interactive';
-					const result = await this._sdkSession.compactHistory();
+					let result: Awaited<ReturnType<Session['compactHistory']>>;
+					try {
+						result = await this._sdkSession.compactHistory();
+					} catch (error) {
+						if (isNothingToCompactError(error)) {
+							this._stream?.markdown(l10n.t('Conversation already compacted.'));
+							break;
+						}
+						throw error;
+					}
 					if (result.success) {
+						if (result.contextWindow) {
+							this._lastUsageInfo = result.contextWindow;
+						}
 						this._stream?.markdown(l10n.t('Compacted conversation.'));
 					} else {
 						this._stream?.markdown(l10n.t('Unable to compact conversation.'));
@@ -1746,31 +1805,31 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 					break;
 				}
 				case 'fleet': {
-					await this._startFleetAndWaitForIdle(input);
+					await this._startFleetAndWaitForIdle(effectiveInput);
 					break;
 				}
 				case 'remote': {
-					await this._handleRemoteControl(input);
+					await this._handleRemoteControl(effectiveInput);
 					break;
 				}
 			}
 		} else {
-			const remoteMode = isMissionControlCommandSource(input.source) ? this._mcState?.mcMode : undefined;
+			const remoteMode = isMissionControlCommandSource(effectiveInput.source) ? this._mcState?.mcMode : undefined;
 			if (remoteMode) {
 				this._sdkSession.currentMode = remoteMode;
-			} else if ('command' in input && input.command === 'plan') {
+			} else if ('command' in effectiveInput && effectiveInput.command === 'plan') {
 				this._sdkSession.currentMode = 'plan';
 			} else if (this._permissionLevel === 'autopilot') {
 				this._sdkSession.currentMode = 'autopilot';
 			} else {
 				this._sdkSession.currentMode = 'interactive';
 			}
-			const sendOptions: SendOptions = { prompt: input.prompt ?? '', attachments, agentMode: this._sdkSession.currentMode };
+			const sendOptions: SendOptions = { prompt: effectiveInput.prompt ?? '', attachments, agentMode: this._sdkSession.currentMode };
 			if (steering) {
 				sendOptions.mode = 'immediate';
 			}
-			if (input.source) {
-				sendOptions.source = input.source;
+			if (effectiveInput.source) {
+				sendOptions.source = effectiveInput.source;
 			}
 			await this._sdkSession.send(sendOptions);
 
@@ -2825,12 +2884,12 @@ function isHttpUrl(value: string): boolean {
 	}
 }
 
-interface UsageInfoData {
-	readonly currentTokens: number;
-	readonly systemTokens?: number;
-	readonly conversationTokens?: number;
-	readonly toolDefinitionsTokens?: number;
-	readonly tokenLimit?: number;
+type UsageInfoData = NonNullable<CompactionResult['contextWindow']>;
+
+function isNothingToCompactError(error: unknown): boolean {
+	const message = error instanceof Error ? error.message : String(error);
+	// @github/copilot 1.0.39 throws this plain Error when compactHistory has fewer than two chat messages.
+	return /^(?:Error:\s*)?Nothing to compact\.?$/.test(message.trim());
 }
 
 function buildPromptTokenDetails(usageInfo: UsageInfoData | undefined): { category: string; label: string; percentageOfPrompt: number }[] | undefined {

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotcliSession.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotcliSession.spec.ts
@@ -137,6 +137,12 @@ class MockSdkSession {
 
 	async compactHistory() { return { success: true }; }
 
+	public chatMessages: Awaited<ReturnType<Session['getChatMessages']>> = [
+		{ role: 'user', content: 'hi' },
+		{ role: 'assistant', content: 'hello' },
+	];
+	async getChatMessages() { return this.chatMessages; }
+
 	async abort() {
 		this.aborted = true;
 	}
@@ -1712,6 +1718,157 @@ describe('CopilotCLISession', () => {
 			expect(sdkSession.currentMode).toBe('interactive');
 			expect(stream.output.join('\n')).toContain('Compacted conversation.');
 		});
+
+		it('reports nothing-to-compact on an empty session', async () => {
+			const session = await createSession();
+			const stream = new MockChatResponseStream();
+			session.attachStream(stream);
+			sdkSession.chatMessages = [];
+			let compactCalled = false;
+			sdkSession.compactHistory = async () => { compactCalled = true; return { success: true }; };
+
+			await session.handleRequest({ id: '', toolInvocationToken: undefined as never }, { command: 'compact', prompt: '' }, [], undefined, authInfo, CancellationToken.None);
+
+			expect(compactCalled).toBe(false);
+			expect(stream.output.join('\n')).toContain('Nothing to compact.');
+			expect(stream.output.join('\n')).not.toContain('Error: Nothing to compact.');
+		});
+
+		it('reports already-compacted when no new messages exist since last compaction', async () => {
+			const session = await createSession();
+			const stream = new MockChatResponseStream();
+			session.attachStream(stream);
+			sdkSession.chatMessages = [{ role: 'assistant', content: 'summary' }];
+			let compactCalled = false;
+			sdkSession.compactHistory = async () => { compactCalled = true; return { success: true }; };
+
+			await session.handleRequest({ id: '', toolInvocationToken: undefined as never }, { command: 'compact', prompt: '' }, [], undefined, authInfo, CancellationToken.None);
+
+			expect(compactCalled).toBe(false);
+			expect(stream.output.join('\n')).toContain('Conversation already compacted.');
+			expect(stream.output.join('\n')).not.toContain('Error: Nothing to compact.');
+		});
+
+		it('reports context usage from compact result', async () => {
+			const session = await createSession();
+			const stream = new UsageCapturingStream();
+			session.attachStream(stream);
+			sdkSession.compactHistory = async () => ({
+				success: true,
+				tokensRemoved: 380,
+				messagesRemoved: 2,
+				summaryContent: 'summary',
+				contextWindow: {
+					tokenLimit: 8000,
+					currentTokens: 120,
+					messagesLength: 1,
+					systemTokens: 80,
+					conversationTokens: 40,
+					toolDefinitionsTokens: 0,
+				},
+			});
+
+			await session.handleRequest({ id: '', toolInvocationToken: undefined as never }, { command: 'compact', prompt: '' }, [], undefined, authInfo, CancellationToken.None);
+
+			expect(stream.usages.at(-1)).toMatchObject({ promptTokens: 120, completionTokens: 0 });
+		});
+
+		it('preserves context usage after compacting twice in a row', async () => {
+			const session = await createSession();
+			const stream = new UsageCapturingStream();
+			session.attachStream(stream);
+			sdkSession.usage.getMetrics = async () => ({
+				lastCallInputTokens: 0,
+				lastCallOutputTokens: 0,
+				totalPremiumRequestCost: 0,
+				totalUserRequests: 1,
+				totalApiDurationMs: 0,
+				sessionStartTime: Date.now(),
+				codeChanges: { linesAdded: 0, linesRemoved: 0, filesModifiedCount: 0 },
+				modelMetrics: {},
+				currentModel: 'modelA',
+			});
+			sdkSession.compactHistory = async () => {
+				sdkSession.chatMessages = [{ role: 'assistant', content: 'summary' }];
+				return {
+					success: true,
+					tokensRemoved: 380,
+					messagesRemoved: 2,
+					summaryContent: 'summary',
+					contextWindow: {
+						tokenLimit: 8000,
+						currentTokens: 120,
+						messagesLength: 1,
+						systemTokens: 80,
+						conversationTokens: 40,
+						toolDefinitionsTokens: 0,
+					},
+				};
+			};
+
+			await session.handleRequest({ id: '', toolInvocationToken: undefined as never }, { command: 'compact', prompt: '' }, [], undefined, authInfo, CancellationToken.None);
+			await session.handleRequest({ id: '', toolInvocationToken: undefined as never }, { command: 'compact', prompt: '' }, [], undefined, authInfo, CancellationToken.None);
+
+			expect(stream.output.join('\n')).toContain('Conversation already compacted.');
+			expect(stream.usages.some(usage => usage.promptTokens === 0 && usage.completionTokens === 0)).toBe(false);
+			expect(stream.usages.at(-1)).toMatchObject({ promptTokens: 120, completionTokens: 0 });
+		});
+
+		it('handles SDK nothing-to-compact errors as compact no-ops', async () => {
+			const session = await createSession();
+			const stream = new UsageCapturingStream();
+			session.attachStream(stream);
+			sdkSession.send = async (options: { prompt: string; mode?: string; source?: string; agentMode?: string }) => {
+				sdkSession.emit('user.message', { content: options.prompt });
+				sdkSession.emit('session.usage_info', {
+					currentTokens: 220,
+					tokenLimit: 8000,
+					messagesLength: 2,
+					systemTokens: 120,
+					conversationTokens: 100,
+					toolDefinitionsTokens: 0,
+				});
+				sdkSession.emit('assistant.turn_end', {});
+			};
+			sdkSession.usage.getMetrics = async () => ({
+				lastCallInputTokens: 0,
+				lastCallOutputTokens: 0,
+				totalPremiumRequestCost: 0,
+				totalUserRequests: 1,
+				totalApiDurationMs: 0,
+				sessionStartTime: Date.now(),
+				codeChanges: { linesAdded: 0, linesRemoved: 0, filesModifiedCount: 0 },
+				modelMetrics: {},
+				currentModel: 'modelA',
+			});
+
+			await session.handleRequest({ id: 'req-1', toolInvocationToken: undefined as never }, { prompt: 'Hello' }, [], undefined, authInfo, CancellationToken.None);
+
+			sdkSession.chatMessages = [
+				{ role: 'user', content: 'hi' },
+				{ role: 'assistant', content: 'hello' },
+			];
+			sdkSession.compactHistory = async () => { throw new Error('Nothing to compact.'); };
+
+			await session.handleRequest({ id: 'req-2', toolInvocationToken: undefined as never }, { command: 'compact', prompt: '' }, [], undefined, authInfo, CancellationToken.None);
+
+			expect(stream.output.join('\n')).toContain('Conversation already compacted.');
+			expect(stream.output.join('\n')).not.toContain('Error: Nothing to compact.');
+			expect(stream.usages.at(-1)).toMatchObject({ promptTokens: 220, completionTokens: 0 });
+		});
+
+		it('handles literal slash compact prompts through the command path', async () => {
+			const session = await createSession();
+			const stream = new UsageCapturingStream();
+			session.attachStream(stream);
+			sdkSession.chatMessages = [{ role: 'assistant', content: 'summary' }];
+			sdkSession.send = async () => { throw new Error('send should not be called for /compact'); };
+
+			await session.handleRequest({ id: '', toolInvocationToken: undefined as never }, { prompt: '/compact' }, [], undefined, authInfo, CancellationToken.None);
+
+			expect(stream.output.join('\n')).toContain('Conversation already compacted.');
+			expect(stream.output.join('\n')).not.toContain('Error: Nothing to compact.');
+		});
 	});
 
 	describe('steering (sending messages to a busy session)', () => {
@@ -2444,6 +2601,46 @@ describe('CopilotCLISession', () => {
 			// Final usage should use currentTokens (120) not the stale lastCallInputTokens (0)
 			const finalUsage = stream.usages.at(-1);
 			expect(finalUsage!.promptTokens).toBe(120);
+		});
+
+		it('does not reuse stale context usage for a later turn without usage info', async () => {
+			let sendCount = 0;
+			sdkSession.send = async (options: { prompt: string; mode?: string; source?: string; agentMode?: string }) => {
+				sendCount++;
+				sdkSession.emit('user.message', { content: options.prompt });
+				if (sendCount === 1) {
+					sdkSession.emit('session.usage_info', {
+						currentTokens: 500,
+						tokenLimit: 8000,
+						messagesLength: 5,
+						systemTokens: 100,
+						conversationTokens: 350,
+						toolDefinitionsTokens: 50,
+					});
+				}
+				sdkSession.emit('assistant.turn_end', {});
+			};
+			sdkSession.usage.getMetrics = async () => ({
+				lastCallInputTokens: 0,
+				lastCallOutputTokens: 0,
+				totalPremiumRequestCost: 0,
+				totalUserRequests: 1,
+				totalApiDurationMs: 0,
+				sessionStartTime: Date.now(),
+				codeChanges: { linesAdded: 0, linesRemoved: 0, filesModifiedCount: 0 },
+				modelMetrics: {},
+				currentModel: 'modelA',
+			});
+
+			const session = await createSession();
+			const stream = new UsageCapturingStream();
+			session.attachStream(stream);
+
+			await session.handleRequest({ id: 'req-1', toolInvocationToken: undefined as never }, { prompt: 'Hello' }, [], undefined, authInfo, CancellationToken.None);
+			const usageCount = stream.usages.length;
+			await session.handleRequest({ id: 'req-2', toolInvocationToken: undefined as never }, { prompt: 'Tool-only turn' }, [], undefined, authInfo, CancellationToken.None);
+
+			expect(stream.usages).toHaveLength(usageCount);
 		});
 	});
 });

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCLIChatSessionsContribution.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCLIChatSessionsContribution.ts
@@ -1543,7 +1543,7 @@ export class CopilotCLIChatSessionParticipant extends Disposable {
 				const { prompt, attachments } = contextForRequest;
 				await session.object.handleRequest(request, { prompt }, attachments, model, authInfo, token);
 				await this.commitWorktreeChangesIfNeeded(request, session.object, token);
-			} else if (isCopilotCLICommand && (!isUntitled || request.command === 'remote')) {
+			} else if (isCopilotCLICommand && (!isUntitled || request.command === 'remote' || request.command === 'compact')) {
 				const { prompt, attachments } = request.prompt
 					? await this.promptResolver.resolvePrompt(request, undefined, [], session.object.workspace, [], token)
 					: { prompt: '', attachments: [] };

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/test/copilotCLIChatSessionParticipant.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/test/copilotCLIChatSessionParticipant.spec.ts
@@ -647,6 +647,22 @@ describe('CopilotCLIChatSessionParticipant.handleRequest', () => {
 		expect(promptResolver.resolvePrompt).not.toHaveBeenCalled();
 	});
 
+	it('maps /compact to CLI command input for untitled sessions', async () => {
+		const request = new TestChatRequest('');
+		request.command = 'compact';
+		const context = createChatContext('untitled-compact', true, request);
+		const stream = new MockChatResponseStream();
+		const token = disposables.add(new CancellationTokenSource()).token;
+
+		await participant.createHandler()(request, context, stream, token);
+		await waitForScheduledUntitledSwap();
+
+		expect(cliSessions.length).toBe(1);
+		expect(cliSessions[0].requests).toHaveLength(1);
+		expect(cliSessions[0].requests[0].input).toEqual({ command: 'compact', prompt: '' });
+		expect(promptResolver.resolvePrompt).not.toHaveBeenCalled();
+	});
+
 	it('maps /remote with arguments to CLI command input for untitled sessions', async () => {
 		const request = new TestChatRequest('on');
 		request.command = 'remote';


### PR DESCRIPTION
## Summary

Fixes two `/compact` issues in Copilot CLI chat sessions:

- Repeated or no-op `/compact` requests surfaced the SDK error `Nothing to compact.` as a failed chat response.
- After a second/no-op compact, the context usage widget could show `0%` even though the session still had context.

Related to https://github.com/microsoft/vscode/issues/311422

## Root Cause

Copilot CLI compact requests could reach different code paths depending on how the command was represented. A literal `/compact` prompt and a structured `command: 'compact'` request were not consistently funneled through the same wrapper command handling, and the V1 untitled-session path did not route `/compact` as a CLI command.

When `Session.compactHistory()` had fewer than two chat messages to compact, the SDK treated this as a no-op by throwing a plain `Error('Nothing to compact.')`. The wrapper allowed that SDK no-op to surface as a failed command.

Separately, usage reporting could fall back to SDK call metrics after compact/no-op compact. For no-op compact flows those metrics can be zero, which caused the UI to display an empty context window even though the session still had valid context usage.

<img width="426" height="416" alt="image" src="https://github.com/user-attachments/assets/414391b9-c60a-4ab7-9612-5be870135541" />


## Fix

- Normalize literal `/compact` prompts to the structured compact command path.
- Route `/compact` as a CLI command for untitled V1 sessions.
- Pre-check compactable chat message count before invoking SDK compaction, so empty/already-compacted sessions return normal user-facing messages.
- Catch the SDK’s compact no-op error and translate it into a normal `Conversation already compacted.` response.
- Preserve compact context-window usage from `compactHistory().contextWindow`.
- Avoid reporting `(0, 0)` usage payloads and avoid reusing stale compact context usage for later normal turns.
- Reuse the SDK `CompactionResult['contextWindow']` shape for usage details.


## Validation
1. Send a few messages to GitHub Copilot CLI.
2. Run `/compact` and confirm the Context Window shows valid token counts during compaction instead of `0%`.
3. Run `/compact` again and confirm it completes with `Conversation already compacted.` instead of surfacing `Error: Nothing to compact.`. After the second compact completes, confirm the Context Window still shows valid token usage instead of `0%`.
<img width="381" height="423.5" alt="image" src="https://github.com/user-attachments/assets/43fdd191-6196-4614-a162-bc98d9188fb7" />

<br>
<img width="383" height="543" alt="image" src="https://github.com/user-attachments/assets/4402a9e6-3877-4e77-9e5b-6336597c03e5" />

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
