### PR TITLE
Add agent-sessions font size and weight tokens

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -1075,6 +1075,18 @@
 		"--slide-from-y"
 	],
 	"sizes": [
+		"--vscode-agents-fontWeight-medium",
+		"--vscode-agents-fontWeight-regular",
+		"--vscode-agents-fontWeight-semiBold",
+		"--vscode-agents-fontSize-body1",
+		"--vscode-agents-fontSize-body2",
+		"--vscode-agents-fontSize-heading1",
+		"--vscode-agents-fontSize-heading2",
+		"--vscode-agents-fontSize-heading3",
+		"--vscode-agents-fontSize-label1",
+		"--vscode-agents-fontSize-label2",
+		"--vscode-agents-fontSize-label3",
+		"--vscode-agents-fontSize-label4",
 		"--vscode-bodyFontSize",
 		"--vscode-bodyFontSize-small",
 		"--vscode-bodyFontSize-xSmall",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1920,7 +1920,8 @@ export default tseslint.config(
 						'vs/workbench/services/*/~',
 						'vs/workbench/contrib/*/~',
 						'vs/workbench/contrib/terminal/terminal.all.js',
-						'vs/sessions/common/theme.js' // side-effect import for color registry
+						'vs/sessions/common/theme.js', // side-effect import for color registry
+						'vs/sessions/common/sizes.js' // side-effect import for size registry
 					]
 				},
 				{

--- a/src/vs/platform/theme/common/sizeUtils.ts
+++ b/src/vs/platform/theme/common/sizeUtils.ts
@@ -16,9 +16,10 @@ import { RunOnceScheduler } from '../../../base/common/async.js';
 export type SizeIdentifier = string;
 
 /**
- * Size value unit types supported by the registry
+ * Size value unit types supported by the registry.
+ * Use `''` for unitless values such as font weights.
  */
-export type SizeUnit = 'px' | 'rem' | 'em' | '%';
+export type SizeUnit = 'px' | 'rem' | 'em' | '%' | '';
 
 /**
  * A size value with a numeric amount and unit
@@ -85,10 +86,11 @@ export function sizeForAllThemes(value: number, unit: SizeUnit = 'px'): SizeDefa
 }
 
 /**
- * Convert a size value to a CSS string
+ * Convert a size value to a CSS string.
+ * When the unit is `''` the raw numeric value is returned (e.g. font weights).
  */
 export function sizeValueToCss(sizeValue: SizeValue): string {
-	return `${sizeValue.value}${sizeValue.unit}`;
+	return sizeValue.unit === '' ? `${sizeValue.value}` : `${sizeValue.value}${sizeValue.unit}`;
 }
 
 // size registry
@@ -174,8 +176,8 @@ class SizeRegistry extends Disposable implements ISizeRegistry {
 
 		const propertySchema: IJSONSchema = {
 			type: 'string',
-			pattern: '^(\\d+(\\.\\d+)?(px|rem|em|%))|default$',
-			patternErrorMessage: 'Size must be a number followed by px, rem, em, or % (e.g., "12px", "1.5rem") or "default"'
+			pattern: '^(\\d+(\\.\\d+)?(px|rem|em|%)?)|default$',
+			patternErrorMessage: 'Size must be a number optionally followed by px, rem, em, or % (e.g., "12px", "1.5rem", "600") or "default"'
 		};
 
 		if (deprecationMessage) {

--- a/src/vs/platform/theme/common/sizeUtils.ts
+++ b/src/vs/platform/theme/common/sizeUtils.ts
@@ -174,11 +174,28 @@ class SizeRegistry extends Disposable implements ISizeRegistry {
 		const sizeContribution: SizeContribution = { id, description, defaults, deprecationMessage };
 		this.sizesById[id] = sizeContribution;
 
-		const propertySchema: IJSONSchema = {
-			type: 'string',
-			pattern: '^(\\d+(\\.\\d+)?(px|rem|em|%)?)|default$',
-			patternErrorMessage: 'Size must be a number optionally followed by px, rem, em, or % (e.g., "12px", "1.5rem", "600") or "default"'
-		};
+		// Determine whether this token uses unitless values (e.g. font weights).
+		// The pattern is chosen per-token so that length tokens still require a unit.
+		const isUnitless = (() => {
+			if (!defaults) { return false; }
+			if (isSizeDefaults(defaults)) {
+				const sample = defaults.dark ?? defaults.light ?? defaults.hcDark ?? defaults.hcLight;
+				return sample?.unit === '';
+			}
+			return defaults.unit === '';
+		})();
+
+		const propertySchema: IJSONSchema = isUnitless
+			? {
+				type: 'string',
+				pattern: '^(?:\\d+|default)$',
+				patternErrorMessage: 'Value must be an integer (e.g., "400") or "default"'
+			}
+			: {
+				type: 'string',
+				pattern: '^(?:\\d+(\\.\\d+)?(px|rem|em|%)|default)$',
+				patternErrorMessage: 'Size must be a number followed by px, rem, em, or % (e.g., "12px", "1.5rem") or "default"'
+			};
 
 		if (deprecationMessage) {
 			propertySchema.deprecationMessage = deprecationMessage;

--- a/src/vs/sessions/common/sizes.ts
+++ b/src/vs/sessions/common/sizes.ts
@@ -1,0 +1,106 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Agent-sessions font-ramp size tokens.
+//
+// Registrations live here in the sessions layer. The workbench entry point
+// (`workbench.common.main.ts`) imports this file as a side-effect so the
+// tokens are present in the global size registry and JSON schema for both
+// the main workbench and the sessions workbench.
+
+import { localize } from '../../nls.js';
+import { registerSize, sizeForAllThemes } from '../../platform/theme/common/sizeUtils.js';
+
+// ============================================================================
+// Agents window — font ramp
+// ============================================================================
+
+/** 26 px · SemiBold (600) — Welcome screen title */
+export const agentsFontSizeHeading1 = registerSize(
+	'agents.fontSize.heading1',
+	sizeForAllThemes(26, 'px'),
+	localize('agents.fontSize.heading1', "Heading 1 font size for the agents window (welcome screen title).")
+);
+
+/** 18 px · SemiBold (600) — Title */
+export const agentsFontSizeHeading2 = registerSize(
+	'agents.fontSize.heading2',
+	sizeForAllThemes(18, 'px'),
+	localize('agents.fontSize.heading2', "Heading 2 font size for the agents window (title).")
+);
+
+/** 13 px · SemiBold (600) — Subtitle */
+export const agentsFontSizeHeading3 = registerSize(
+	'agents.fontSize.heading3',
+	sizeForAllThemes(13, 'px'),
+	localize('agents.fontSize.heading3', "Heading 3 font size for the agents window (subtitle).")
+);
+
+/** 13 px · Regular (400) — Primary body text */
+export const agentsFontSizeBody1 = registerSize(
+	'agents.fontSize.body1',
+	sizeForAllThemes(13, 'px'),
+	localize('agents.fontSize.body1', "Primary body font size for the agents window.")
+);
+
+/** 11 px · Regular (400) — Secondary body text */
+export const agentsFontSizeBody2 = registerSize(
+	'agents.fontSize.body2',
+	sizeForAllThemes(11, 'px'),
+	localize('agents.fontSize.body2', "Secondary body font size for the agents window.")
+);
+
+/** 12 px · Medium (500) — Interactive tabs */
+export const agentsFontSizeLabel1 = registerSize(
+	'agents.fontSize.label1',
+	sizeForAllThemes(12, 'px'),
+	localize('agents.fontSize.label1', "Label 1 font size for the agents window (interactive tabs).")
+);
+
+/** 11 px · Medium (500) — Metadata emphasis */
+export const agentsFontSizeLabel2 = registerSize(
+	'agents.fontSize.label2',
+	sizeForAllThemes(11, 'px'),
+	localize('agents.fontSize.label2', "Label 2 font size for the agents window (metadata emphasis).")
+);
+
+/** 11 px · Regular (400) — Metadata primary */
+export const agentsFontSizeLabel3 = registerSize(
+	'agents.fontSize.label3',
+	sizeForAllThemes(11, 'px'),
+	localize('agents.fontSize.label3', "Label 3 font size for the agents window (metadata primary).")
+);
+
+/** 10 px · Regular (400) — Badge */
+export const agentsFontSizeLabel4 = registerSize(
+	'agents.fontSize.label4',
+	sizeForAllThemes(10, 'px'),
+	localize('agents.fontSize.label4', "Label 4 font size for the agents window (badge).")
+);
+
+// ============================================================================
+// Agents window — font weights
+// ============================================================================
+
+/** Regular — 400 */
+export const agentsFontWeightRegular = registerSize(
+	'agents.fontWeight.regular',
+	sizeForAllThemes(400, ''),
+	localize('agents.fontWeight.regular', "Regular font weight (400) for the agents window.")
+);
+
+/** Medium — 500 */
+export const agentsFontWeightMedium = registerSize(
+	'agents.fontWeight.medium',
+	sizeForAllThemes(500, ''),
+	localize('agents.fontWeight.medium', "Medium font weight (500) for the agents window.")
+);
+
+/** SemiBold — 600 */
+export const agentsFontWeightSemiBold = registerSize(
+	'agents.fontWeight.semiBold',
+	sizeForAllThemes(600, ''),
+	localize('agents.fontWeight.semiBold', "SemiBold font weight (600) for the agents window.")
+);

--- a/src/vs/sessions/sessions.common.main.ts
+++ b/src/vs/sessions/sessions.common.main.ts
@@ -13,6 +13,7 @@ import { TERMINAL_BACKGROUND_COLOR } from '../workbench/contrib/terminal/common/
 import '../workbench/api/browser/extensionHost.contribution.js';
 import '../workbench/browser/workbench.contribution.js';
 import { agentsPanelBackground } from './common/theme.js';
+import './common/sizes.js';
 
 getColorRegistry().updateDefaultColor(PANEL_BACKGROUND, agentsPanelBackground);
 getColorRegistry().updateDefaultColor(TERMINAL_BACKGROUND_COLOR, agentsPanelBackground);

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -15,6 +15,10 @@ import './browser/workbench.zenMode.contribution.js';
 // global color registry and appear in the color-theme JSON schema.
 import '../sessions/common/theme.js';
 
+// Agent-sessions size tokens (font ramp) — side-effect import so they register
+// in the global size registry and appear in the workbench-sizes JSON schema.
+import '../sessions/common/sizes.js';
+
 //#endregion
 
 


### PR DESCRIPTION
This pull request introduces a new set of size tokens for the agents window, specifically defining a font ramp (font sizes and weights) for consistent typography. It also updates the size registry system to support unitless values (for font weights), ensures these tokens are registered globally by adding side-effect imports, and updates related schemas and configuration files to recognize the new tokens and units.

**Font Sizes**

Token ID | CSS Variable | Value | Usage
-- | -- | -- | --
agents.fontSize.heading1 | --vscode-agents-fontSize-heading1 | 26px | Welcome screen title
agents.fontSize.heading2 | --vscode-agents-fontSize-heading2 | 18px | Title
agents.fontSize.heading3 | --vscode-agents-fontSize-heading3 | 13px | Subtitle
agents.fontSize.body1 | --vscode-agents-fontSize-body1 | 13px | Primary body
agents.fontSize.body2 | --vscode-agents-fontSize-body2 | 11px | Secondary body
agents.fontSize.label1 | --vscode-agents-fontSize-label1 | 12px | Interactive tabs
agents.fontSize.label2 | --vscode-agents-fontSize-label2 | 11px | Metadata emphasis
agents.fontSize.label3 | --vscode-agents-fontSize-label3 | 11px | Metadata primary
agents.fontSize.label4 | --vscode-agents-fontSize-label4 | 10px | Badge

**Font Weights**


Token ID | CSS Variable | Value | Usage
-- | -- | -- | --
agents.fontWeight.regular | --vscode-agents-fontWeight-regular | 400 | Body 1, Body 2, Label 3, Label 4
agents.fontWeight.medium | --vscode-agents-fontWeight-medium | 500 | Label 1, Label 2
agents.fontWeight.semiBold | --vscode-agents-fontWeight-semiBold | 600 | Heading 1, Heading 2, Heading 3

**Agents window font ramp and weights:**

* Added `src/vs/sessions/common/sizes.ts` to register new font size and font weight tokens (e.g., `agents.fontSize.heading1`, `agents.fontWeight.medium`) for the agents window, with appropriate descriptions and values.
* Updated `build/lib/stylelint/vscode-known-variables.json` to include the new agents font size and weight CSS variables in the known list.

**Size registry and utilities enhancements:**

* Updated `SizeUnit` in `src/vs/platform/theme/common/sizeUtils.ts` to support unitless values (`''`) for font weights, and adjusted the `sizeValueToCss` function and JSON schema validation to handle these cases. [[1]](diffhunk://#diff-303dd6dd4058100c2d902c9f8ae2bda2ee94a273007936cd8d5d726f7f89275bL19-R22) [[2]](diffhunk://#diff-303dd6dd4058100c2d902c9f8ae2bda2ee94a273007936cd8d5d726f7f89275bL88-R93) [[3]](diffhunk://#diff-303dd6dd4058100c2d902c9f8ae2bda2ee94a273007936cd8d5d726f7f89275bL177-R180)

**Global registration and configuration:**

* Added side-effect imports for `sizes.ts` in both the main workbench (`src/vs/workbench/workbench.common.main.ts`) and sessions workbench (`src/vs/sessions/sessions.common.main.ts`) entry points to ensure the new tokens are registered in the global size registry and included in the JSON schema. [[1]](diffhunk://#diff-fbe76ba1e5f770dddb2126d52a32e8fdaf09a0723c5028aa7b62034d0f22a559R18-R21) [[2]](diffhunk://#diff-332a4c6d949b86e4f3d0867cf79011486bdc5dcf9c69d367c98aeff85b44fed8R16)
* Updated ESLint configuration in `eslint.config.js` to recognize `sizes.js` as a side-effect import for the size registry.