### PR TITLE
Add telemetry support for picker components

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/agentHost/agentHostModePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/agentHost/agentHostModePicker.ts
@@ -14,10 +14,12 @@ import { localize } from '../../../../../nls.js';
 import { ActionListItemKind, IActionListDelegate, IActionListItem } from '../../../../../platform/actionWidget/browser/actionList.js';
 import { IActionWidgetService } from '../../../../../platform/actionWidget/browser/actionWidget.js';
 import { SessionConfigKey } from '../../../../../platform/agentHost/common/sessionConfigKeys.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { type IAgentHostSessionsProvider, isAgentHostProvider } from '../../../../common/agentHostSessionsProvider.js';
 import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
 import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
 import { type ISessionsProvider } from '../../../../services/sessions/common/sessionsProvider.js';
+import { reportNewChatPickerClosed } from '../newChatPickerTelemetry.js';
 import { isWellKnownModeSchema } from './agentHostPermissionPickerDelegate.js';
 
 interface IModePickerItem {
@@ -58,6 +60,7 @@ export class AgentHostModePicker extends Disposable {
 		@IActionWidgetService private readonly _actionWidgetService: IActionWidgetService,
 		@ISessionsManagementService private readonly _sessionsManagementService: ISessionsManagementService,
 		@ISessionsProvidersService private readonly _sessionsProvidersService: ISessionsProvidersService,
+		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 	) {
 		super();
 
@@ -192,6 +195,15 @@ export class AgentHostModePicker extends Disposable {
 		const delegate: IActionListDelegate<IModePickerItem> = {
 			onSelect: item => {
 				this._actionWidgetService.hide();
+				const previousItem = ctx.items.find(i => i.value === ctx.currentValue);
+				reportNewChatPickerClosed(this._telemetryService, {
+					id: 'NewChatAgentHostModePicker',
+					optionIdBefore: ctx.currentValue,
+					optionIdAfter: item.value,
+					optionLabelBefore: previousItem?.label ?? ctx.currentValue,
+					optionLabelAfter: item.label,
+					isPII: false,
+				});
 				ctx.provider.setSessionConfigValue(ctx.sessionId, SessionConfigKey.Mode, item.value)
 					.catch(() => { /* best-effort */ });
 			},

--- a/src/vs/sessions/contrib/chat/browser/agentHost/agentHostModelPicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/agentHost/agentHostModelPicker.ts
@@ -12,6 +12,7 @@ import { Action2, registerAction2 } from '../../../../../platform/actions/common
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../../workbench/common/contributions.js';
 import { type ILanguageModelChatMetadataAndIdentifier, ILanguageModelsService } from '../../../../../workbench/contrib/chat/common/languageModels.js';
 import { type IChatInputPickerOptions } from '../../../../../workbench/contrib/chat/browser/widget/input/chatInputPickerActionItem.js';
@@ -22,6 +23,7 @@ import { ISessionsManagementService } from '../../../../services/sessions/common
 import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
 import { Menus } from '../../../../browser/menus.js';
 import { LOCAL_AGENT_HOST_PROVIDER_ID, REMOTE_AGENT_HOST_PROVIDER_RE } from '../../../../common/agentHostSessionsProvider.js';
+import { reportNewChatPickerClosed } from '../newChatPickerTelemetry.js';
 
 const IsActiveSessionAgentHost = ContextKeyExpr.or(
 	ContextKeyExpr.equals(ActiveSessionProviderIdContext.key, LOCAL_AGENT_HOST_PROVIDER_ID),
@@ -106,6 +108,7 @@ class AgentHostModelPickerContribution extends Disposable implements IWorkbenchC
 		@ISessionsManagementService sessionsManagementService: ISessionsManagementService,
 		@ISessionsProvidersService sessionsProvidersService: ISessionsProvidersService,
 		@IStorageService storageService: IStorageService,
+		@ITelemetryService telemetryService: ITelemetryService,
 	) {
 		super();
 
@@ -113,15 +116,27 @@ class AgentHostModelPickerContribution extends Disposable implements IWorkbenchC
 			Menus.NewSessionConfig, 'sessions.agentHost.modelPicker',
 			() => {
 				const currentModel = observableValue<ILanguageModelChatMetadataAndIdentifier | undefined>('currentModel', undefined);
+				let settingModelInternally = false;
 				const delegate: IModelPickerDelegate = {
 					currentModel,
 					setModel: (model: ILanguageModelChatMetadataAndIdentifier) => {
+						const previousModel = currentModel.get();
 						currentModel.set(model, undefined);
 						const session = sessionsManagementService.activeSession.get();
 						if (session) {
 							storageService.store(agentHostModelPickerStorageKey(session.resource.scheme), model.identifier, StorageScope.PROFILE, StorageTarget.MACHINE);
 							const provider = sessionsProvidersService.getProviders().find(p => p.id === session.providerId);
 							provider?.setModel(session.sessionId, model.identifier);
+						}
+						if (!settingModelInternally) {
+							reportNewChatPickerClosed(telemetryService, {
+								id: 'NewChatAgentHostModelPicker',
+								optionIdBefore: previousModel?.identifier,
+								optionIdAfter: model.identifier,
+								optionLabelBefore: previousModel?.metadata.name,
+								optionLabelAfter: model.metadata.name,
+								isPII: false,
+							});
 						}
 					},
 					getModels: () => getAgentHostModels(languageModelsService, sessionsManagementService.activeSession.get()),
@@ -151,7 +166,12 @@ class AgentHostModelPickerContribution extends Disposable implements IWorkbenchC
 					const resolvedModel = resolveAgentHostModel(models, sessionModelId, storedModelId);
 					currentModel.set(resolvedModel, undefined);
 					if (!sessionModelId && isUntitled && resolvedModel) {
-						delegate.setModel(resolvedModel);
+						settingModelInternally = true;
+						try {
+							delegate.setModel(resolvedModel);
+						} finally {
+							settingModelInternally = false;
+						}
 					}
 				};
 				const initModelFromActiveSession = () => {

--- a/src/vs/sessions/contrib/chat/browser/agentHost/agentHostSessionConfigPicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/agentHost/agentHostSessionConfigPicker.ts
@@ -24,6 +24,7 @@ import { IConfigurationService } from '../../../../../platform/configuration/com
 import { ContextKeyExpr, IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import type { SessionConfigPropertySchema, SessionConfigValueItem } from '../../../../../platform/agentHost/common/state/protocol/commands.js';
 import { ChatConfiguration } from '../../../../../workbench/contrib/chat/common/constants.js';
 import { ChatContextKeyExprs } from '../../../../../workbench/contrib/chat/common/actions/chatContextKeys.js';
@@ -32,6 +33,7 @@ import { type IChatInputPickerOptions } from '../../../../../workbench/contrib/c
 import { Menus } from '../../../../browser/menus.js';
 import { ActiveSessionProviderIdContext, IsPhoneLayoutContext } from '../../../../common/contextkeys.js';
 import { IWorkbenchLayoutService } from '../../../../../workbench/services/layout/browser/layoutService.js';
+import { reportNewChatPickerClosed } from '../newChatPickerTelemetry.js';
 import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
 import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
 import type { ISessionsProvider } from '../../../../services/sessions/common/sessionsProvider.js';
@@ -243,6 +245,7 @@ export class AgentHostSessionConfigPicker extends Disposable {
 		@IDialogService protected readonly _dialogService: IDialogService,
 		@ISessionsManagementService protected readonly _sessionsManagementService: ISessionsManagementService,
 		@ISessionsProvidersService protected readonly _sessionsProvidersService: ISessionsProvidersService,
+		@ITelemetryService protected readonly _telemetryService: ITelemetryService,
 		@IWorkbenchLayoutService protected readonly _layoutService: IWorkbenchLayoutService,
 	) {
 		super();
@@ -420,11 +423,22 @@ export class AgentHostSessionConfigPicker extends Disposable {
 
 		const isAutoApproveProperty = property === SessionConfigKey.AutoApprove;
 		const currentValue = provider.getSessionConfig(sessionId)?.values[property];
+		const currentItem = items.find(i => i.value === currentValue);
 		const actionItems = toActionItems(property, items, currentValue, policyRestricted);
 
 		const delegate: IActionListDelegate<IConfigPickerItem> = {
 			onSelect: async item => {
 				this._actionWidgetService.hide();
+
+				reportNewChatPickerClosed(this._telemetryService, {
+					id: 'NewChatAgentHostSessionConfigPicker',
+					name: `NewChatAgentHostSessionConfigPicker.${property}`,
+					optionIdBefore: typeof currentValue === 'string' ? currentValue : undefined,
+					optionIdAfter: item.value,
+					optionLabelBefore: currentItem?.label,
+					optionLabelAfter: item.label,
+					isPII: !!schema.enumDynamic,
+				});
 
 				if (isAutoApproveProperty && (item.value === 'autoApprove' || item.value === 'autopilot')) {
 					const confirmed = await confirmAutoApproveLevel(item.value, this._dialogService);
@@ -586,16 +600,16 @@ class MobileAgentHostSessionConfigPicker extends AgentHostSessionConfigPicker {
 		const branchValue = config.values[SessionConfigKey.Branch];
 		const sheetItems: IMobilePickerSheetItem[] = [];
 
-		const idToConfig = new Map<string, { property: string; value: string }>();
-		const registerId = (property: string, value: string): string => {
+		const idToConfig = new Map<string, { property: string; value: string; label: string; isPII: boolean }>();
+		const registerId = (property: string, value: string, label: string, isPII: boolean): string => {
 			const id = `repo-row-${idToConfig.size}`;
-			idToConfig.set(id, { property, value });
+			idToConfig.set(id, { property, value, label, isPII });
 			return id;
 		};
 
 		isolationItems.forEach((item, index) => {
 			sheetItems.push({
-				id: registerId(SessionConfigKey.Isolation, item.value),
+				id: registerId(SessionConfigKey.Isolation, item.value, item.label, !!isolationSchema?.enumDynamic),
 				label: item.label,
 				description: item.description,
 				icon: getConfigIcon(SessionConfigKey.Isolation, item.value),
@@ -608,7 +622,7 @@ class MobileAgentHostSessionConfigPicker extends AgentHostSessionConfigPicker {
 		if (!branchSchema?.enumDynamic) {
 			branchItems.forEach((item, index) => {
 				sheetItems.push({
-					id: registerId(SessionConfigKey.Branch, item.value),
+					id: registerId(SessionConfigKey.Branch, item.value, item.label, !!branchSchema?.enumDynamic),
 					label: item.label,
 					description: item.description,
 					icon: getConfigIcon(SessionConfigKey.Branch, item.value),
@@ -637,7 +651,7 @@ class MobileAgentHostSessionConfigPicker extends AgentHostSessionConfigPicker {
 						return [];
 					}
 					return items.map(item => ({
-						id: registerId(SessionConfigKey.Branch, item.value),
+						id: registerId(SessionConfigKey.Branch, item.value, item.label, !!branchSchema.enumDynamic),
 						label: item.label,
 						description: item.description,
 						icon: getConfigIcon(SessionConfigKey.Branch, item.value),
@@ -661,6 +675,16 @@ class MobileAgentHostSessionConfigPicker extends AgentHostSessionConfigPicker {
 				onDidSelect: (id) => {
 					const selection = idToConfig.get(id);
 					if (selection) {
+						const beforeValue = provider.getSessionConfig(sessionId)?.values[selection.property];
+						reportNewChatPickerClosed(this._telemetryService, {
+							id: 'NewChatAgentHostSessionConfigPicker',
+							name: `NewChatAgentHostSessionConfigPicker.${selection.property}`,
+							optionIdBefore: typeof beforeValue === 'string' ? beforeValue : undefined,
+							optionIdAfter: selection.value,
+							optionLabelBefore: undefined,
+							optionLabelAfter: selection.label,
+							isPII: selection.isPII,
+						});
 						provider.setSessionConfigValue(sessionId, selection.property, selection.value).catch(() => { /* best-effort */ });
 					}
 				},

--- a/src/vs/sessions/contrib/chat/browser/mobile/mobileAgentHostModePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/mobile/mobileAgentHostModePicker.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IActionWidgetService } from '../../../../../platform/actionWidget/browser/actionWidget.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { IChatPhoneInputPresenter } from '../../../../../workbench/contrib/chat/browser/widget/input/chatPhoneInputPresenter.js';
 import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
 import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
@@ -24,9 +25,10 @@ export class MobileAgentHostModePicker extends AgentHostModePicker {
 		@IActionWidgetService actionWidgetService: IActionWidgetService,
 		@ISessionsManagementService sessionsManagementService: ISessionsManagementService,
 		@ISessionsProvidersService sessionsProvidersService: ISessionsProvidersService,
+		@ITelemetryService telemetryService: ITelemetryService,
 		@IChatPhoneInputPresenter private readonly _phonePresenter: IChatPhoneInputPresenter,
 	) {
-		super(actionWidgetService, sessionsManagementService, sessionsProvidersService);
+		super(actionWidgetService, sessionsManagementService, sessionsProvidersService, telemetryService);
 	}
 
 	protected override _showPicker(): void {

--- a/src/vs/sessions/contrib/chat/browser/mobile/mobileChatInputConfigPicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/mobile/mobileChatInputConfigPicker.ts
@@ -18,6 +18,7 @@ import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contex
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IStorageService, StorageScope } from '../../../../../platform/storage/common/storage.js';
 import { SessionConfigKey } from '../../../../../platform/agentHost/common/sessionConfigKeys.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../../workbench/common/contributions.js';
 import { type ILanguageModelChatMetadataAndIdentifier, ILanguageModelsService } from '../../../../../workbench/contrib/chat/common/languageModels.js';
 import { IChatPhoneInputPresenter } from '../../../../../workbench/contrib/chat/browser/widget/input/chatPhoneInputPresenter.js';
@@ -29,6 +30,7 @@ import { ISessionsProvidersService } from '../../../../services/sessions/browser
 import { type ISession } from '../../../../services/sessions/common/session.js';
 import { isWellKnownModeSchema } from '../agentHost/agentHostPermissionPickerDelegate.js';
 import { agentHostModelPickerStorageKey } from '../agentHost/agentHostModelPicker.js';
+import { reportNewChatPickerClosed } from '../newChatPickerTelemetry.js';
 
 const IsActiveSessionAgentHost = ContextKeyExpr.or(
 	ContextKeyExpr.equals(ActiveSessionProviderIdContext.key, LOCAL_AGENT_HOST_PROVIDER_ID),
@@ -106,6 +108,7 @@ class MobileChatInputConfigPicker extends Disposable {
 		@ISessionsManagementService private readonly _sessionsManagementService: ISessionsManagementService,
 		@ISessionsProvidersService private readonly _sessionsProvidersService: ISessionsProvidersService,
 		@IStorageService private readonly _storageService: IStorageService,
+		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 		@IChatPhoneInputPresenter private readonly _phonePresenter: IChatPhoneInputPresenter,
 	) {
 		super();
@@ -309,9 +312,43 @@ class MobileChatInputConfigPicker extends Disposable {
 		// reads the active session's config + filtered models and
 		// handles the writes (provider mode/model + shared storage key).
 		const trigger = this._triggerElement;
+		const beforeCtx = this._getContext();
+		const beforeMode = beforeCtx?.currentMode;
+		const beforeModeItem = beforeCtx?.modeItems.find(i => i.value === beforeMode);
+		const beforeModelId = beforeCtx?.currentModelId;
+		const beforeModel = beforeModelId ? beforeCtx?.modelItems.find(m => m.identifier === beforeModelId) : undefined;
 		trigger.setAttribute('aria-expanded', 'true');
 		try {
 			await this._phonePresenter.showCombinedModeAndModelSheet(trigger, undefined, undefined);
+			const afterCtx = this._getContext();
+			if (beforeCtx && afterCtx) {
+				if (beforeCtx.modeItems.length > 0) {
+					const afterMode = afterCtx.currentMode;
+					const afterModeItem = afterCtx.modeItems.find(i => i.value === afterMode);
+					reportNewChatPickerClosed(this._telemetryService, {
+						id: 'NewChatMobileChatInputConfigPicker',
+						name: 'NewChatMobileChatInputConfigPicker.mode',
+						optionIdBefore: beforeMode,
+						optionIdAfter: afterMode,
+						optionLabelBefore: beforeModeItem?.label ?? beforeMode,
+						optionLabelAfter: afterModeItem?.label ?? afterMode,
+						isPII: false,
+					});
+				}
+				if (beforeCtx.modelItems.length > 0) {
+					const afterModelId = afterCtx.currentModelId;
+					const afterModel = afterModelId ? afterCtx.modelItems.find(m => m.identifier === afterModelId) : undefined;
+					reportNewChatPickerClosed(this._telemetryService, {
+						id: 'NewChatMobileChatInputConfigPicker',
+						name: 'NewChatMobileChatInputConfigPicker.model',
+						optionIdBefore: beforeModelId,
+						optionIdAfter: afterModelId,
+						optionLabelBefore: beforeModel?.metadata.name,
+						optionLabelAfter: afterModel?.metadata.name,
+						isPII: false,
+					});
+				}
+			}
 		} finally {
 			trigger.setAttribute('aria-expanded', 'false');
 			trigger.focus();

--- a/src/vs/sessions/contrib/chat/browser/mobile/mobileSessionTypePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/mobile/mobileSessionTypePicker.ts
@@ -5,11 +5,12 @@
 
 import { localize } from '../../../../../nls.js';
 import { IActionWidgetService } from '../../../../../platform/actionWidget/browser/actionWidget.js';
-import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
+import { IStorageService } from '../../../../../platform/storage/common/storage.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { IWorkbenchLayoutService } from '../../../../../workbench/services/layout/browser/layoutService.js';
 import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
-import { SessionTypePicker, STORAGE_KEY_LAST_SESSION_TYPE } from '../sessionTypePicker.js';
+import { SessionTypePicker } from '../sessionTypePicker.js';
 import { isPhoneLayout } from '../../../../browser/parts/mobile/mobileLayout.js';
 import { IMobilePickerSheetItem, showMobilePickerSheet } from '../../../../browser/parts/mobile/mobilePickerSheet.js';
 
@@ -31,9 +32,10 @@ export class MobileSessionTypePicker extends SessionTypePicker {
 		@ISessionsManagementService sessionsManagementService: ISessionsManagementService,
 		@ISessionsProvidersService sessionsProvidersService: ISessionsProvidersService,
 		@IStorageService storageService: IStorageService,
+		@ITelemetryService telemetryService: ITelemetryService,
 		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
 	) {
-		super(actionWidgetService, sessionsManagementService, sessionsProvidersService, storageService);
+		super(actionWidgetService, sessionsManagementService, sessionsProvidersService, storageService, telemetryService);
 	}
 
 	override render(container: HTMLElement, options?: { className?: string }): void {
@@ -77,9 +79,8 @@ export class MobileSessionTypePicker extends SessionTypePicker {
 		).then(id => {
 			trigger.setAttribute('aria-expanded', 'false');
 			trigger.focus();
-			if (id !== undefined && id !== this._sessionType) {
-				this.storageService.store(STORAGE_KEY_LAST_SESSION_TYPE, id, StorageScope.PROFILE, StorageTarget.MACHINE);
-				this._onDidSelectSessionType.fire(id);
+			if (id !== undefined) {
+				this._handleSelectedSessionType(id);
 			}
 		});
 	}

--- a/src/vs/sessions/contrib/chat/browser/newChatPickerTelemetry.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatPickerTelemetry.ts
@@ -1,0 +1,72 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
+
+/**
+ * Data emitted by a picker in the new chat view pane when the user selects
+ * an option. Mirrors the shape of the `actionWidgetDropdownClosed` event
+ * so the two can be analyzed with similar queries.
+ *
+ * The `selectionChanged` field is derived from comparing
+ * {@link optionIdBefore} and {@link optionIdAfter}.
+ */
+export interface INewChatPickerClosedData {
+	/** Identifier of the picker emitting the event (e.g. `NewChatWorkspacePicker`). */
+	readonly id: string;
+	/** Optional descriptive name of the picker. */
+	readonly name?: string;
+	/** Identifier of the option configured before the picker was opened. */
+	readonly optionIdBefore: string | undefined;
+	/** Identifier of the option selected when the picker was closed. */
+	readonly optionIdAfter: string | undefined;
+	/** Label of the option configured before the picker was opened. */
+	readonly optionLabelBefore: string | undefined;
+	/** Label of the option selected when the picker was closed. */
+	readonly optionLabelAfter: string | undefined;
+	/**
+	 * When `true`, the option id and label values are considered PII and
+	 * are omitted from the emitted telemetry event — only {@link id},
+	 * {@link name} and the derived `selectionChanged` flag are reported.
+	 */
+	readonly isPII: boolean;
+}
+
+export function reportNewChatPickerClosed(telemetryService: ITelemetryService, data: INewChatPickerClosedData): void {
+	telemetryService.publicLog2<NewChatPickerClosedEvent, NewChatPickerClosedClassification>(
+		'newChatPickerClosed',
+		{
+			id: data.id,
+			name: data.name,
+			selectionChanged: data.optionIdBefore !== data.optionIdAfter,
+			optionIdBefore: data.isPII ? undefined : data.optionIdBefore,
+			optionIdAfter: data.isPII ? undefined : data.optionIdAfter,
+			optionLabelBefore: data.isPII ? undefined : data.optionLabelBefore,
+			optionLabelAfter: data.isPII ? undefined : data.optionLabelAfter,
+		},
+	);
+}
+
+type NewChatPickerClosedEvent = {
+	id: string;
+	name: string | undefined;
+	selectionChanged: boolean;
+	optionIdBefore: string | undefined;
+	optionIdAfter: string | undefined;
+	optionLabelBefore: string | undefined;
+	optionLabelAfter: string | undefined;
+};
+
+type NewChatPickerClosedClassification = {
+	id: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The telemetry id of the picker.' };
+	name: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The telemetry name of the picker.' };
+	selectionChanged: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether the user changed the selected option.' };
+	optionIdBefore: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The option configured before opening the picker.' };
+	optionIdAfter: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The option selected when the picker was closed.' };
+	optionLabelBefore: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The label of the option configured before opening the picker.' };
+	optionLabelAfter: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The label of the option selected when the picker was closed.' };
+	owner: 'benibenj';
+	comment: 'Tracks new chat view pane picker usage and selection changes.';
+};

--- a/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
@@ -17,6 +17,8 @@ import { autorun } from '../../../../base/common/observable.js';
 import { ISession, ISessionType } from '../../../services/sessions/common/session.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
+import { reportNewChatPickerClosed } from './newChatPickerTelemetry.js';
 
 export const STORAGE_KEY_LAST_SESSION_TYPE = 'sessions.lastSelectedSessionType';
 
@@ -37,6 +39,7 @@ export class SessionTypePicker extends Disposable {
 		@ISessionsManagementService private readonly sessionsManagementService: ISessionsManagementService,
 		@ISessionsProvidersService private readonly sessionsProvidersService: ISessionsProvidersService,
 		@IStorageService protected readonly storageService: IStorageService,
+		@ITelemetryService private readonly telemetryService: ITelemetryService,
 	) {
 		super();
 
@@ -146,10 +149,7 @@ export class SessionTypePicker extends Disposable {
 		const delegate: IActionListDelegate<ISessionType> = {
 			onSelect: (type) => {
 				this.actionWidgetService.hide();
-				if (type.id !== this._sessionType) {
-					this.storageService.store(STORAGE_KEY_LAST_SESSION_TYPE, type.id, StorageScope.PROFILE, StorageTarget.MACHINE);
-					this._onDidSelectSessionType.fire(type.id);
-				}
+				this._handleSelectedSessionType(type.id);
 			},
 			onHide: () => { triggerElement.focus(); },
 		};
@@ -167,6 +167,37 @@ export class SessionTypePicker extends Disposable {
 				getWidgetAriaLabel: () => localize('sessionTypePicker.ariaLabel', "Session Type"),
 			},
 		);
+	}
+
+	/**
+	 * Handles the user picking a session type. Emits `newChatPickerClosed`
+	 * telemetry (with the previously selected type read from storage, or
+	 * the in-memory field when nothing is stored), and — when the
+	 * selection actually changed — persists the new type and fires
+	 * {@link onDidSelectSessionType}.
+	 *
+	 * Shared between desktop (action-widget popup) and mobile (bottom
+	 * sheet) presentations so both surfaces report identical telemetry.
+	 */
+	protected _handleSelectedSessionType(typeId: string): void {
+		const beforeId = this.storageService.get(STORAGE_KEY_LAST_SESSION_TYPE, StorageScope.PROFILE) ?? this._sessionType;
+		const beforeLabel = this._allProviderSessionTypes.find(t => t.id === beforeId)?.label;
+		const afterLabel = this._allProviderSessionTypes.find(t => t.id === typeId)?.label;
+
+		reportNewChatPickerClosed(this.telemetryService, {
+			id: 'NewChatSessionTypePicker',
+			name: 'NewChatSessionTypePicker',
+			optionIdBefore: beforeId,
+			optionIdAfter: typeId,
+			optionLabelBefore: beforeLabel,
+			optionLabelAfter: afterLabel,
+			isPII: false,
+		});
+
+		if (typeId !== this._sessionType) {
+			this.storageService.store(STORAGE_KEY_LAST_SESSION_TYPE, typeId, StorageScope.PROFILE, StorageTarget.MACHINE);
+			this._onDidSelectSessionType.fire(typeId);
+		}
 	}
 
 	private _updateTriggerLabel(): void {

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -479,10 +479,10 @@ export class WorkspacePicker extends Disposable {
 		reportNewChatPickerClosed(this.telemetryService, {
 			id: 'NewChatWorkspacePicker',
 			name: 'NewChatWorkspacePicker',
-			optionIdBefore: before?.workspace.repositories[0]?.uri.toString(),
-			optionIdAfter: after?.workspace.repositories[0]?.uri.toString(),
-			optionLabelBefore: before?.workspace.label,
-			optionLabelAfter: after?.workspace.label,
+			optionIdBefore: before?.workspace?.uri.toString(),
+			optionIdAfter: after?.workspace?.uri.toString(),
+			optionLabelBefore: before?.workspace?.label,
+			optionLabelAfter: after?.workspace?.label,
 			isPII: true,
 		});
 	}

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -37,6 +37,8 @@ import { getStatusHover, getStatusLabel, removeRemoteHost, showRemoteHostOptions
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { COPILOT_PROVIDER_ID } from '../../copilotChatSessions/browser/copilotChatSessionsProvider.js';
 import { IWorkspacesService, isRecentFolder } from '../../../../platform/workspaces/common/workspaces.js';
+import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
+import { reportNewChatPickerClosed } from './newChatPickerTelemetry.js';
 import { Menus } from '../../../browser/menus.js';
 
 const LEGACY_STORAGE_KEY_RECENT_PROJECTS = 'sessions.recentlyPickedProjects';
@@ -165,6 +167,7 @@ export class WorkspacePicker extends Disposable {
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IFileDialogService private readonly fileDialogService: IFileDialogService,
 		@IQuickInputService private readonly quickInputService: IQuickInputService,
+		@ITelemetryService private readonly telemetryService: ITelemetryService,
 	) {
 		super();
 
@@ -446,6 +449,7 @@ export class WorkspacePicker extends Disposable {
 	 * selection semantics. Treats unavailable workspaces as a no-op.
 	 */
 	protected _dispatchPickerItem(item: IWorkspacePickerItem): void {
+		this._reportPickerClosed(item);
 		if (item.run) {
 			item.run();
 		} else if (item.commandId) {
@@ -459,6 +463,28 @@ export class WorkspacePicker extends Disposable {
 		} else if (item.selection) {
 			this._selectProject(item.selection);
 		}
+	}
+
+	/**
+	 * Emits `newChatPickerClosed` telemetry on user selection. The
+	 * "before" value is read from storage (the currently-checked recent
+	 * workspace) if available, otherwise from the in-memory selection.
+	 * The "after" value comes from the item the user picked — undefined
+	 * when the item is a browse action or command rather than a workspace.
+	 */
+	private _reportPickerClosed(item: IWorkspacePickerItem): void {
+		const beforeFromStorage = this._restoreCheckedWorkspace();
+		const before = beforeFromStorage ?? this._selectedWorkspace;
+		const after = item.selection;
+		reportNewChatPickerClosed(this.telemetryService, {
+			id: 'NewChatWorkspacePicker',
+			name: 'NewChatWorkspacePicker',
+			optionIdBefore: before?.workspace.repositories[0]?.uri.toString(),
+			optionIdAfter: after?.workspace.repositories[0]?.uri.toString(),
+			optionLabelBefore: before?.workspace.label,
+			optionLabelAfter: after?.workspace.label,
+			isPII: true,
+		});
 	}
 
 	/**

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -479,8 +479,8 @@ export class WorkspacePicker extends Disposable {
 		reportNewChatPickerClosed(this.telemetryService, {
 			id: 'NewChatWorkspacePicker',
 			name: 'NewChatWorkspacePicker',
-			optionIdBefore: before?.workspace?.uri.toString(),
-			optionIdAfter: after?.workspace?.uri.toString(),
+			optionIdBefore: before?.workspace?.repositories?.[0]?.uri.toString(),
+			optionIdAfter: after?.workspace?.repositories?.[0]?.uri.toString(),
 			optionLabelBefore: before?.workspace?.label,
 			optionLabelAfter: after?.workspace?.label,
 			isPII: true,

--- a/src/vs/sessions/contrib/chat/browser/webWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/webWorkspacePicker.ts
@@ -16,6 +16,7 @@ import { IFileDialogService } from '../../../../platform/dialogs/common/dialogs.
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IQuickInputService } from '../../../../platform/quickinput/common/quickInput.js';
 import { IStorageService } from '../../../../platform/storage/common/storage.js';
+import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
 import { IWorkbenchLayoutService } from '../../../../workbench/services/layout/browser/layoutService.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
@@ -58,6 +59,7 @@ export class WebWorkspacePicker extends WorkspacePicker {
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IFileDialogService fileDialogService: IFileDialogService,
 		@IQuickInputService quickInputService: IQuickInputService,
+		@ITelemetryService telemetryService: ITelemetryService,
 		@IAgentHostFilterService private readonly _agentHostFilterService: IAgentHostFilterService,
 		@IWorkbenchLayoutService private readonly _layoutService: IWorkbenchLayoutService,
 	) {
@@ -75,6 +77,7 @@ export class WebWorkspacePicker extends WorkspacePicker {
 			instantiationService,
 			fileDialogService,
 			quickInputService,
+			telemetryService,
 		);
 
 		// When the scoped host changes, if the current selection no longer

--- a/src/vs/sessions/contrib/chat/test/browser/sessionWorkspacePicker.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionWorkspacePicker.test.ts
@@ -18,6 +18,8 @@ import { IClipboardService } from '../../../../../platform/clipboard/common/clip
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { IQuickInputService } from '../../../../../platform/quickinput/common/quickInput.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { NullTelemetryService } from '../../../../../platform/telemetry/common/telemetryUtils.js';
 import { TestStorageService } from '../../../../../workbench/test/common/workbenchTestServices.js';
 import { IPreferencesService } from '../../../../../workbench/services/preferences/common/preferences.js';
 import { IOutputService } from '../../../../../workbench/services/output/common/output.js';
@@ -159,6 +161,7 @@ function createTestPicker(
 		getRecentlyOpened: async () => ({ workspaces: [], files: [] }),
 		onDidChangeRecentlyOpened: Event.None,
 	});
+	instantiationService.stub(ITelemetryService, NullTelemetryService);
 
 	return disposables.add(instantiationService.createInstance(WorkspacePicker));
 }
@@ -554,6 +557,7 @@ function createTestablePicker(disposables: DisposableStore, providersService: Mo
 		getRecentlyOpened: async () => ({ workspaces: [], files: [] }),
 		onDidChangeRecentlyOpened: Event.None,
 	});
+	instantiationService.stub(ITelemetryService, NullTelemetryService);
 	return disposables.add(instantiationService.createInstance(TestablePicker));
 }
 
@@ -650,6 +654,7 @@ suite('WorkspacePicker - Tab discovery', () => {
 			getRecentlyOpened: async () => ({ workspaces: [], files: [] }),
 			onDidChangeRecentlyOpened: Event.None,
 		});
+		instantiationService.stub(ITelemetryService, NullTelemetryService);
 		const picker = disposables.add(instantiationService.createInstance(TestablePicker));
 		// Recent workspace group ('Cloud') is not added as a tab — only
 		// browse actions and the always-present Remote group contribute tabs.

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/branchPicker.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/branchPicker.ts
@@ -11,7 +11,9 @@ import { autorun } from '../../../../base/common/observable.js';
 import { localize } from '../../../../nls.js';
 import { IActionWidgetService } from '../../../../platform/actionWidget/browser/actionWidget.js';
 import { ActionListItemKind, IActionListDelegate, IActionListItem } from '../../../../platform/actionWidget/browser/actionList.js';
+import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { renderIcon } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
+import { reportNewChatPickerClosed } from '../../chat/browser/newChatPickerTelemetry.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
 import { CopilotChatSessionsProvider, ICopilotChatSession } from './copilotChatSessionsProvider.js';
@@ -37,6 +39,7 @@ export class BranchPicker extends Disposable {
 		@IActionWidgetService private readonly actionWidgetService: IActionWidgetService,
 		@ISessionsManagementService private readonly sessionsManagementService: ISessionsManagementService,
 		@ISessionsProvidersService private readonly sessionsProvidersService: ISessionsProvidersService,
+		@ITelemetryService private readonly telemetryService: ITelemetryService,
 	) {
 		super();
 
@@ -111,6 +114,15 @@ export class BranchPicker extends Disposable {
 		const delegate: IActionListDelegate<IBranchItem> = {
 			onSelect: (item) => {
 				this.actionWidgetService.hide();
+				reportNewChatPickerClosed(this.telemetryService, {
+					id: 'NewChatBranchPicker',
+					name: 'NewChatBranchPicker',
+					optionIdBefore: selectedBranch,
+					optionIdAfter: item.name,
+					optionLabelBefore: selectedBranch,
+					optionLabelAfter: item.name,
+					isPII: true,
+				});
 				session?.setBranch(item.name);
 			},
 			onHide: () => { triggerElement.focus(); },

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/claudePermissionModePicker.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/claudePermissionModePicker.ts
@@ -12,9 +12,11 @@ import { ThemeIcon } from '../../../../base/common/themables.js';
 import { localize } from '../../../../nls.js';
 import { IActionWidgetService } from '../../../../platform/actionWidget/browser/actionWidget.js';
 import { ActionListItemKind, IActionListDelegate, IActionListItem, IActionListOptions } from '../../../../platform/actionWidget/browser/actionList.js';
+import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
 import { CopilotChatSessionsProvider } from './copilotChatSessionsProvider.js';
+import { reportNewChatPickerClosed } from '../../chat/browser/newChatPickerTelemetry.js';
 import { IChatSessionsService } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
 
 const PERMISSION_MODE_OPTION_ID = 'permissionMode';
@@ -58,6 +60,7 @@ export class ClaudePermissionModePicker extends Disposable {
 		@ISessionsManagementService private readonly sessionsManagementService: ISessionsManagementService,
 		@ISessionsProvidersService private readonly sessionsProvidersService: ISessionsProvidersService,
 		@IChatSessionsService private readonly chatSessionsService: IChatSessionsService,
+		@ITelemetryService private readonly telemetryService: ITelemetryService,
 	) {
 		super();
 	}
@@ -133,6 +136,18 @@ export class ClaudePermissionModePicker extends Disposable {
 	}
 
 	private _selectMode(mode: IClaudePermissionModeItem): void {
+		const beforeId = this._currentModeId;
+		const beforeLabel = permissionModes.find(m => m.id === beforeId)?.label;
+		reportNewChatPickerClosed(this.telemetryService, {
+			id: 'NewChatClaudePermissionModePicker',
+			name: 'NewChatClaudePermissionModePicker',
+			optionIdBefore: beforeId,
+			optionIdAfter: mode.id,
+			optionLabelBefore: beforeLabel,
+			optionLabelAfter: mode.label,
+			isPII: false,
+		});
+
 		this._currentModeId = mode.id;
 		this._updateTriggerLabel(this._triggerElement);
 

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsActions.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsActions.ts
@@ -16,6 +16,7 @@ import { CommandsRegistry, ICommandService } from '../../../../platform/commands
 import { ContextKeyExpr, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { IWorkbenchContribution, WorkbenchPhase, registerWorkbenchContribution2 } from '../../../../workbench/common/contributions.js';
 import { IAgentSessionsService } from '../../../../workbench/contrib/chat/browser/agentSessions/agentSessionsService.js';
 import { IChatInputPickerOptions } from '../../../../workbench/contrib/chat/browser/widget/input/chatInputPickerActionItem.js';
@@ -35,6 +36,7 @@ import { ModePicker } from './modePicker.js';
 import { CloudModelPicker } from './modelPicker.js';
 import { CopilotPermissionPickerDelegate, PermissionPicker } from './permissionPicker.js';
 import { SessionType } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
+import { reportNewChatPickerClosed } from '../../chat/browser/newChatPickerTelemetry.js';
 
 const IsActiveSessionCopilotCLI = ContextKeyExpr.equals(ActiveSessionTypeContext.key, COPILOT_CLI_SESSION_TYPE);
 const IsActiveSessionCopilotCloud = ContextKeyExpr.equals(ActiveSessionTypeContext.key, COPILOT_CLOUD_SESSION_TYPE);
@@ -296,6 +298,7 @@ export class SessionModelPicker extends Disposable {
 	private readonly _modelPicker: ModelPickerActionItem;
 	private _lastSessionType: string | undefined;
 	private _lastPushedSessionId: string | undefined;
+	private _settingModelInternally = false;
 
 	constructor(
 		@IInstantiationService instantiationService: IInstantiationService,
@@ -303,18 +306,30 @@ export class SessionModelPicker extends Disposable {
 		@ISessionsManagementService private readonly _sessionsManagementService: ISessionsManagementService,
 		@ISessionsProvidersService private readonly _sessionsProvidersService: ISessionsProvidersService,
 		@IStorageService private readonly _storageService: IStorageService,
+		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 	) {
 		super();
 
 		this._delegate = {
 			currentModel: this._currentModel,
 			setModel: (model: ILanguageModelChatMetadataAndIdentifier) => {
+				const previousModel = this._currentModel.get();
 				this._currentModel.set(model, undefined);
 				const session = this._sessionsManagementService.activeSession.get();
 				if (session) {
 					this._storageService.store(modelPickerStorageKey(session.sessionType), model.identifier, StorageScope.PROFILE, StorageTarget.MACHINE);
 					const provider = this._sessionsProvidersService.getProviders().find(p => p.id === session.providerId);
 					provider?.setModel(session.sessionId, model.identifier);
+				}
+				if (!this._settingModelInternally) {
+					reportNewChatPickerClosed(this._telemetryService, {
+						id: 'NewChatLocalModelPicker',
+						optionIdBefore: previousModel?.identifier,
+						optionIdAfter: model.identifier,
+						optionLabelBefore: previousModel?.metadata.name,
+						optionLabelAfter: model.metadata.name,
+						isPII: false,
+					});
 				}
 			},
 			getModels: () => getAvailableModels(this._languageModelsService, this._sessionsManagementService),
@@ -362,23 +377,28 @@ export class SessionModelPicker extends Disposable {
 		}
 
 		const current = this._currentModel.get();
-		if (!current) {
-			const rememberedModelId = sessionType ? this._storageService.get(modelPickerStorageKey(sessionType), StorageScope.PROFILE) : undefined;
-			const remembered = rememberedModelId ? models.find(m => m.identifier === rememberedModelId) : undefined;
-			this._delegate.setModel(remembered ?? models[0]);
-			this._lastPushedSessionId = session?.sessionId;
-		} else if (session && session.sessionId !== this._lastPushedSessionId && models.some(m => m.identifier === current.identifier)) {
-			// Active session changed (e.g. user switched repository) but the
-			// previously selected model is still available. Re-push it so the
-			// new session's provider receives setModel — otherwise the request
-			// would be sent with the default model even though the picker UI
-			// still shows the user's selection. See #313385.
-			//
-			// Gated on sessionId so unrelated re-invocations of _initModel
-			// (e.g. from onDidChangeLanguageModels) don't redundantly write
-			// storage and dispatch provider.setModel for the same session.
-			this._delegate.setModel(current);
-			this._lastPushedSessionId = session.sessionId;
+		this._settingModelInternally = true;
+		try {
+			if (!current) {
+				const rememberedModelId = sessionType ? this._storageService.get(modelPickerStorageKey(sessionType), StorageScope.PROFILE) : undefined;
+				const remembered = rememberedModelId ? models.find(m => m.identifier === rememberedModelId) : undefined;
+				this._delegate.setModel(remembered ?? models[0]);
+				this._lastPushedSessionId = session?.sessionId;
+			} else if (session && session.sessionId !== this._lastPushedSessionId && models.some(m => m.identifier === current.identifier)) {
+				// Active session changed (e.g. user switched repository) but the
+				// previously selected model is still available. Re-push it so the
+				// new session's provider receives setModel — otherwise the request
+				// would be sent with the default model even though the picker UI
+				// still shows the user's selection. See #313385.
+				//
+				// Gated on sessionId so unrelated re-invocations of _initModel
+				// (e.g. from onDidChangeLanguageModels) don't redundantly write
+				// storage and dispatch provider.setModel for the same session.
+				this._delegate.setModel(current);
+				this._lastPushedSessionId = session.sessionId;
+			}
+		} finally {
+			this._settingModelInternally = false;
 		}
 	}
 

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/isolationPicker.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/isolationPicker.ts
@@ -13,6 +13,8 @@ import { localize } from '../../../../nls.js';
 import { IActionWidgetService } from '../../../../platform/actionWidget/browser/actionWidget.js';
 import { ActionListItemKind, IActionListDelegate, IActionListItem } from '../../../../platform/actionWidget/browser/actionList.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
+import { reportNewChatPickerClosed } from '../../chat/browser/newChatPickerTelemetry.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
 import { CopilotChatSessionsProvider } from './copilotChatSessionsProvider.js';
@@ -50,6 +52,7 @@ export class IsolationPicker extends Disposable {
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@ISessionsManagementService private readonly sessionsManagementService: ISessionsManagementService,
 		@ISessionsProvidersService private readonly sessionsProvidersService: ISessionsProvidersService,
+		@ITelemetryService private readonly telemetryService: ITelemetryService,
 	) {
 		super();
 		this._isolationOptionEnabled = this.configurationService.getValue<boolean>('github.copilot.chat.cli.isolationOption.enabled') !== false;
@@ -149,6 +152,15 @@ export class IsolationPicker extends Disposable {
 		const delegate: IActionListDelegate<IIsolationPickerItem> = {
 			onSelect: ({ mode }) => {
 				this.actionWidgetService.hide();
+				reportNewChatPickerClosed(this.telemetryService, {
+					id: 'NewChatIsolationPicker',
+					name: 'NewChatIsolationPicker',
+					optionIdBefore: currentIsolationMode,
+					optionIdAfter: mode,
+					optionLabelBefore: undefined,
+					optionLabelAfter: undefined,
+					isPII: false,
+				});
 				this._setModeOnSession(mode);
 			},
 			onHide: () => { triggerElement.focus(); },

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/mobilePermissionPicker.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/mobilePermissionPicker.ts
@@ -11,6 +11,7 @@ import { IConfigurationService } from '../../../../platform/configuration/common
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { IStorageService } from '../../../../platform/storage/common/storage.js';
+import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { IWorkbenchLayoutService } from '../../../../workbench/services/layout/browser/layoutService.js';
 import { ChatConfiguration, ChatPermissionLevel } from '../../../../workbench/contrib/chat/common/constants.js';
 import { IPermissionPickerDelegate, PermissionPicker } from './permissionPicker.js';
@@ -36,9 +37,10 @@ export class MobilePermissionPicker extends PermissionPicker {
 		@IDialogService dialogService: IDialogService,
 		@IOpenerService openerService: IOpenerService,
 		@IStorageService storageService: IStorageService,
+		@ITelemetryService telemetryService: ITelemetryService,
 		@IWorkbenchLayoutService private readonly _layoutService: IWorkbenchLayoutService,
 	) {
-		super(_delegate, actionWidgetService, configurationService, dialogService, openerService, storageService);
+		super(_delegate, actionWidgetService, configurationService, dialogService, openerService, storageService, telemetryService);
 	}
 
 	override showPicker(): void {

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/modePicker.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/modePicker.ts
@@ -12,6 +12,7 @@ import { localize } from '../../../../nls.js';
 import { IActionWidgetService } from '../../../../platform/actionWidget/browser/actionWidget.js';
 import { ActionListItemKind, IActionListDelegate, IActionListItem } from '../../../../platform/actionWidget/browser/actionList.js';
 import { renderIcon } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
+import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { ChatMode, IChatMode, IChatModes, IChatModeService } from '../../../../workbench/contrib/chat/common/chatModes.js';
 import { IChatSessionsService } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
@@ -22,6 +23,7 @@ import { ISessionsManagementService } from '../../../services/sessions/common/se
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
 import { CopilotChatSessionsProvider } from './copilotChatSessionsProvider.js';
 import { CopilotCLISessionType } from '../../../services/sessions/common/session.js';
+import { reportNewChatPickerClosed } from '../../chat/browser/newChatPickerTelemetry.js';
 
 interface IModePickerItem {
 	readonly kind: 'mode';
@@ -62,6 +64,7 @@ export class ModePicker extends Disposable {
 		@ICommandService private readonly commandService: ICommandService,
 		@ISessionsManagementService private readonly sessionsManagementService: ISessionsManagementService,
 		@ISessionsProvidersService private readonly sessionsProvidersService: ISessionsProvidersService,
+		@ITelemetryService private readonly telemetryService: ITelemetryService,
 	) {
 		super();
 
@@ -149,10 +152,19 @@ export class ModePicker extends Disposable {
 		const items = this._buildItems(modes);
 
 		const triggerElement = this._triggerElement;
+		const previousMode = this._selectedMode;
 		const delegate: IActionListDelegate<ModePickerItem> = {
 			onSelect: (item) => {
 				this.actionWidgetService.hide();
 				if (item.kind === 'mode') {
+					reportNewChatPickerClosed(this.telemetryService, {
+						id: 'NewChatModePicker',
+						optionIdBefore: previousMode.id,
+						optionIdAfter: item.mode.id,
+						optionLabelBefore: previousMode.label.get(),
+						optionLabelAfter: item.mode.label.get(),
+						isPII: true,
+					});
 					this._selectMode(item.mode);
 				} else {
 					this.commandService.executeCommand(AICustomizationManagementCommands.OpenEditor, AICustomizationManagementSection.Agents);

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/modelPicker.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/modelPicker.ts
@@ -13,10 +13,12 @@ import { localize } from '../../../../nls.js';
 import { IActionWidgetService } from '../../../../platform/actionWidget/browser/actionWidget.js';
 import { ActionListItemKind, IActionListDelegate, IActionListItem } from '../../../../platform/actionWidget/browser/actionList.js';
 import { renderIcon } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
+import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { IChatSessionProviderOptionItem, IChatSessionsService } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
 import { CopilotChatSessionsProvider, RemoteNewSession } from './copilotChatSessionsProvider.js';
+import { reportNewChatPickerClosed } from '../../chat/browser/newChatPickerTelemetry.js';
 
 const FILTER_THRESHOLD = 10;
 
@@ -54,6 +56,7 @@ export class CloudModelPicker extends Disposable {
 		@ISessionsManagementService sessionsManagementService: ISessionsManagementService,
 		@ISessionsProvidersService sessionsProvidersService: ISessionsProvidersService,
 		@IChatSessionsService chatSessionsService: IChatSessionsService,
+		@ITelemetryService private readonly telemetryService: ITelemetryService,
 	) {
 		super();
 
@@ -158,9 +161,18 @@ export class CloudModelPicker extends Disposable {
 		const showFilter = items.filter(i => i.kind === ActionListItemKind.Action).length > FILTER_THRESHOLD;
 
 		const triggerElement = this._triggerElement;
+		const previousModel = this._selectedModel;
 		const delegate: IActionListDelegate<IModelItem> = {
 			onSelect: (item) => {
 				this.actionWidgetService.hide();
+				reportNewChatPickerClosed(this.telemetryService, {
+					id: 'NewChatCloudModelPicker',
+					optionIdBefore: previousModel?.id,
+					optionIdAfter: item.id,
+					optionLabelBefore: previousModel?.name,
+					optionLabelAfter: item.name,
+					isPII: false,
+				});
 				this._selectModel(item);
 			},
 			onHide: () => { triggerElement.focus(); },

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/permissionPicker.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/permissionPicker.ts
@@ -18,9 +18,11 @@ import { IConfigurationService } from '../../../../platform/configuration/common
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { IStorageService } from '../../../../platform/storage/common/storage.js';
+import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { maybeConfirmElevatedPermissionLevel } from '../../../../workbench/contrib/chat/common/chatPermissionWarnings.js';
 import { IChatSessionsService } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { ChatConfiguration, ChatPermissionLevel, isChatPermissionLevel } from '../../../../workbench/contrib/chat/common/constants.js';
+import { reportNewChatPickerClosed } from '../../chat/browser/newChatPickerTelemetry.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { CopilotChatSessionsProvider } from '../../copilotChatSessions/browser/copilotChatSessionsProvider.js';
@@ -77,6 +79,7 @@ export class PermissionPicker extends Disposable {
 		@IDialogService protected readonly dialogService: IDialogService,
 		@IOpenerService protected readonly openerService: IOpenerService,
 		@IStorageService protected readonly storageService: IStorageService,
+		@ITelemetryService protected readonly telemetryService: ITelemetryService,
 	) {
 		super();
 	}
@@ -237,6 +240,16 @@ export class PermissionPicker extends Disposable {
 	}
 
 	protected async _selectLevel(level: ChatPermissionLevel): Promise<void> {
+		reportNewChatPickerClosed(this.telemetryService, {
+			id: 'NewChatPermissionPicker',
+			name: 'NewChatPermissionPicker',
+			optionIdBefore: this._currentLevel,
+			optionIdAfter: level,
+			optionLabelBefore: undefined,
+			optionLabelAfter: undefined,
+			isPII: false,
+		});
+
 		if (!await maybeConfirmElevatedPermissionLevel(level, this.dialogService, this.storageService)) {
 			return;
 		}

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/permissionPicker.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/permissionPicker.ts
@@ -250,6 +250,7 @@ export class PermissionPicker extends Disposable {
 				optionLabelAfter: undefined,
 				isPII: false,
 			});
+			return;
 		}
 
 		reportNewChatPickerClosed(this.telemetryService, {

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/permissionPicker.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/permissionPicker.ts
@@ -240,6 +240,18 @@ export class PermissionPicker extends Disposable {
 	}
 
 	protected async _selectLevel(level: ChatPermissionLevel): Promise<void> {
+		if (!await maybeConfirmElevatedPermissionLevel(level, this.dialogService, this.storageService)) {
+			reportNewChatPickerClosed(this.telemetryService, {
+				id: 'NewChatPermissionPicker',
+				name: 'NewChatPermissionPicker',
+				optionIdBefore: this._currentLevel,
+				optionIdAfter: this._currentLevel,
+				optionLabelBefore: undefined,
+				optionLabelAfter: undefined,
+				isPII: false,
+			});
+		}
+
 		reportNewChatPickerClosed(this.telemetryService, {
 			id: 'NewChatPermissionPicker',
 			name: 'NewChatPermissionPicker',
@@ -249,10 +261,6 @@ export class PermissionPicker extends Disposable {
 			optionLabelAfter: undefined,
 			isPII: false,
 		});
-
-		if (!await maybeConfirmElevatedPermissionLevel(level, this.dialogService, this.storageService)) {
-			return;
-		}
 
 		this._currentLevel = level;
 		this._updateTriggerLabel(this._triggerElement);

--- a/src/vs/sessions/contrib/copilotChatSessions/test/browser/claudePermissionModePicker.test.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/test/browser/claudePermissionModePicker.test.ts
@@ -11,6 +11,8 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/tes
 import { IActionWidgetService } from '../../../../../platform/actionWidget/browser/actionWidget.js';
 import { IActionListItem } from '../../../../../platform/actionWidget/browser/actionList.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { NullTelemetryService } from '../../../../../platform/telemetry/common/telemetryUtils.js';
 import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
 import { IActiveSession, ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
 import { CopilotChatSessionsProvider, ICopilotChatSession } from '../../browser/copilotChatSessionsProvider.js';
@@ -71,6 +73,7 @@ function createPicker(
 		getProviders: () => [],
 		getProvider: () => provider,
 	} as unknown as ISessionsProvidersService);
+	instantiationService.stub(ITelemetryService, NullTelemetryService);
 
 	const picker = disposables.add(instantiationService.createInstance(ClaudePermissionModePicker));
 

--- a/src/vs/sessions/contrib/copilotChatSessions/test/browser/isolationPicker.test.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/test/browser/isolationPicker.test.ts
@@ -13,6 +13,8 @@ import { IActionListItem } from '../../../../../platform/actionWidget/browser/ac
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { NullTelemetryService } from '../../../../../platform/telemetry/common/telemetryUtils.js';
 import { GitRefType } from '../../../../../workbench/contrib/git/common/gitService.js';
 import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
 import { IActiveSession, ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
@@ -73,6 +75,7 @@ function createPicker(
 		getProviders: () => [],
 		getProvider: () => provider,
 	} as unknown as ISessionsProvidersService);
+	instantiationService.stub(ITelemetryService, NullTelemetryService);
 
 	return disposables.add(instantiationService.createInstance(IsolationPicker));
 }

--- a/src/vs/sessions/contrib/copilotChatSessions/test/browser/modelPickerDelegate.test.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/test/browser/modelPickerDelegate.test.ts
@@ -11,6 +11,8 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/tes
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { NullTelemetryService } from '../../../../../platform/telemetry/common/telemetryUtils.js';
 import { ILanguageModelChatMetadata, ILanguageModelChatMetadataAndIdentifier, ILanguageModelsService } from '../../../../../workbench/contrib/chat/common/languageModels.js';
 import { IChatEntitlementService } from '../../../../../workbench/services/chat/common/chatEntitlementService.js';
 import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
@@ -80,6 +82,8 @@ function stubServices(
 		onDidChangeQuotaRemaining: Event.None,
 		onDidChangeEntitlement: Event.None,
 	} as Partial<IChatEntitlementService>);
+
+	instantiationService.stub(ITelemetryService, NullTelemetryService);
 
 	return { instantiationService, storage, activeSession, fireLanguageModelsChanged: () => onDidChangeLanguageModelsEmitter.fire({}) };
 }


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce telemetry integration for various picker components to track user interactions and selections. This includes stubbing the telemetry service in tests and reporting events when pickers are closed.

