### PR TITLE
sessions: use fewer in workspace toggle

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -649,7 +649,7 @@ class SessionShowMoreRenderer implements ITreeRenderer<SessionListItem, FuzzySco
 		container?.classList.toggle('session-show-more-folders', element.kind === 'folders');
 		if (element.mode === 'less') {
 			template.textContent = element.kind === 'folders'
-				? localize('showLessWorkspacesCompact', "Show less workspaces")
+				? localize('showLessWorkspacesCompact', "Show fewer workspaces")
 				: localize('showLessCompact', "Show less");
 		} else {
 			template.textContent = element.kind === 'folders'
@@ -675,7 +675,7 @@ class SessionsAccessibilityProvider {
 		if (isSessionShowMore(element)) {
 			if (element.mode === 'less') {
 				return element.kind === 'folders'
-					? localize('showLessWorkspacesAria', "Show less workspaces")
+					? localize('showLessWorkspacesAria', "Show fewer workspaces")
 					: localize('showLessAria', "Show less sessions");
 			}
 			return element.kind === 'folders'

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -676,7 +676,7 @@ class SessionsAccessibilityProvider {
 			if (element.mode === 'less') {
 				return element.kind === 'folders'
 					? localize('showLessWorkspacesAria', "Show fewer workspaces")
-					: localize('showLessAria', "Show less sessions");
+					: localize('showLessAria', "Show fewer sessions");
 			}
 			return element.kind === 'folders'
 				? localize('showMoreWorkspacesAria', "Show {0} more workspaces", element.remainingCount)


### PR DESCRIPTION
## Summary

- Update the Sessions sidebar workspace collapse toggle from "Show less workspaces" to "Show fewer workspaces"
- Keep the matching ARIA label in sync with the visible text

<img width="375" height="366" alt="Screenshot 2026-05-12 at 11 23 48 AM" src="https://github.com/user-attachments/assets/6cdbb532-4cf6-4e6b-8264-503822bdf15a" />

## Validation

- `node --experimental-strip-types build/hygiene.ts src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts`
- `git commit` pre-commit hygiene hook

`npm run compile-check-ts-native` and `npm run valid-layers-check` are currently blocked by an unrelated existing TypeScript error in `src/vs/workbench/contrib/chat/browser/widget/input/chatInputNotificationService.ts:177`, where `status(text)` receives `string | IMarkdownString` instead of `string`.