### PR TITLE
chat tools: raise MIN_COMPRESSIBLE_LENGTH from 80 to 1024

### DIFF
--- a/src/vs/workbench/contrib/chat/common/tools/toolResultCompressor.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/toolResultCompressor.ts
@@ -51,9 +51,12 @@ export interface IToolResultCompressor {
 
 /**
  * Outputs at or below this many characters (UTF-16 code units, i.e.
- * `string.length`) are not worth compressing.
+ * `string.length`) are not worth compressing: filter savings on short
+ * outputs rarely outweigh the banner overhead, and skipping them avoids
+ * the agent issuing redundant `read_file` / `get_terminal_output` calls
+ * to recover content that would have fit uncompressed.
  */
-export const MIN_COMPRESSIBLE_LENGTH = 80;
+export const MIN_COMPRESSIBLE_LENGTH = 1024;
 
 /**
  * Format the banner that gets prepended to compressed text parts so the

--- a/src/vs/workbench/contrib/chat/common/tools/toolResultCompressor.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/toolResultCompressor.ts
@@ -50,7 +50,7 @@ export interface IToolResultCompressor {
 }
 
 /**
- * Outputs at or below this many characters (UTF-16 code units, i.e.
+ * Outputs below this many characters (UTF-16 code units, i.e.
  * `string.length`) are not worth compressing: filter savings on short
  * outputs rarely outweigh the banner overhead, and skipping them avoids
  * the agent issuing redundant `read_file` / `get_terminal_output` calls

--- a/src/vs/workbench/contrib/chat/test/browser/tools/toolResultCompressorService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/tools/toolResultCompressorService.test.ts
@@ -13,7 +13,7 @@ import { ToolResultCompressorService } from '../../../browser/tools/toolResultCo
 import { ChatConfiguration } from '../../../common/constants.js';
 import { LanguageModelPartAudience } from '../../../common/languageModels.js';
 import { IToolResult, IToolResultDataPart, IToolResultTextPart } from '../../../common/tools/languageModelToolsService.js';
-import { IToolResultFilter } from '../../../common/tools/toolResultCompressor.js';
+import { IToolResultFilter, MIN_COMPRESSIBLE_LENGTH } from '../../../common/tools/toolResultCompressor.js';
 
 const TOOL = 'run_in_terminal';
 
@@ -30,8 +30,8 @@ function makeService(opts: { enabled: boolean; log?: ILogService }): ToolResultC
 }
 
 function longText(prefix: string): string {
-	// Must exceed MIN_COMPRESSIBLE_LENGTH (80) so filters get a chance to run.
-	return prefix + ' ' + 'x'.repeat(200);
+	// Must exceed MIN_COMPRESSIBLE_LENGTH so filters get a chance to run.
+	return prefix + ' ' + 'x'.repeat(MIN_COMPRESSIBLE_LENGTH + 100);
 }
 
 const replaceWithFooFilter: IToolResultFilter = {


### PR DESCRIPTION
Raises `MIN_COMPRESSIBLE_LENGTH` (terminal output compression's skip threshold) from **80 → 1024** characters.

Refs microsoft/vscode-copilot-evaluation#3857

### Why

Paired benchmark comparison on `terminalbench2` (85 runs, compression ON vs OFF) showed compression regressed effective token cost on two of three models with quality flat:

| Model | Δ Resolved | Δ Effective tokens (ON vs OFF) |
|---|---:|---:|
| claude-opus-4.6 | −0.6 pp | **−8.6%** ✅ |
| claude-opus-4.7 | −1.1 pp | **+7.5%** 🔴 |
| gpt-5.4 | +1.1 pp | **+6.5%** 🔴 |

Trajectory inspection across 6 worst-pair extracts (315 `run_in_terminal` calls total) revealed the regression mechanism on small outputs: when compression strips bytes from a 200–800 char output, gpt-5.4 issues redundant `read_file` / `get_terminal_output` calls to recover content that would have fit uncompressed. On `compile-compcert` (gpt-5.4):

| Tool | ON | OFF |
|---|---:|---:|
| `run_in_terminal` | 42 | 53 |
| `read_file` | **17** | 6 |
| `get_terminal_output` | **4** | 2 |

The banner alone is ~120 chars — for outputs under ~500 chars, compression is always net-negative before even considering downstream agent behavior.

### Impact of the threshold change

Across the 6 worst-pair trajectories:

| Threshold | Compressions skipped |
|---|---:|
| 80 (current) | 11.1% |
| 1024 (this PR) | **66.3%** |

Large-output filters (`gitDiff`, `buildOutput`, `npmInstall`, `linter`, `find`, `tree`, …) are **unaffected** — they continue to fire on outputs ≥1KB, which is where the net win on opus-4.6 comes from.

### Expected effect on regressed models

Conservative estimates; to be confirmed by rerunning the same 7 evald issues against this branch:

| Model | Pre-fix | Estimated post-fix |
|---|---:|---:|
| claude-opus-4.6 | −8.6% | ≈ unchanged or slight improvement |
| claude-opus-4.7 | +7.5% | +3% to +5% |
| gpt-5.4 | +6.5% | +1% to +3% |

Full root-cause analysis and savings tables are in microsoft/vscode-copilot-evaluation#3857.

### Changes

- `src/vs/workbench/contrib/chat/common/tools/toolResultCompressor.ts` — change constant from 80 to 1024 and expand the doc comment with the rationale.
- `src/vs/workbench/contrib/chat/test/browser/tools/toolResultCompressorService.test.ts` — import `MIN_COMPRESSIBLE_LENGTH` and use it in the `longText` helper so future threshold tweaks don't quietly break tests.
