### PR TITLE
fix: restore protected modifier on relayCreationTimeoutMs in test helper

### DIFF
--- a/src/vs/platform/agentHost/test/node/sshRemoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/node/sshRemoteAgentHostService.test.ts
@@ -174,7 +174,7 @@ class TestableSSHRemoteAgentHostMainService extends SSHRemoteAgentHostMainServic
 	hangRelayCreationOnCall: number | undefined;
 
 	/** Public override so tests can shorten the relay creation timeout. */
-	override relayCreationTimeoutMs: number = 30_000;
+	protected override relayCreationTimeoutMs: number = 30_000;
 
 	/** Stored onMessage callbacks from relays, most recent last. */
 	private readonly _relayMessageCallbacks: Array<(data: string) => void> = [];

--- a/src/vs/platform/agentHost/test/node/sshRemoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/node/sshRemoteAgentHostService.test.ts
@@ -279,6 +279,11 @@ class TestableSSHRemoteAgentHostMainService extends SSHRemoteAgentHostMainServic
 			this._relayCloseCallbacks[this._relayCloseCallbacks.length - 1]();
 		}
 	}
+
+	/** Sets the relay creation timeout; exposed for tests only. */
+	setRelayCreationTimeoutForTest(ms: number): void {
+		this.relayCreationTimeoutMs = ms;
+	}
 }
 
 suite('SSHRemoteAgentHostMainService - connect flow', () => {
@@ -1017,7 +1022,7 @@ suite('SSHRemoteAgentHostMainService - connect flow', () => {
 		assert.strictEqual(originalClient.ended, false);
 
 		// Use a short timeout so the test completes quickly.
-		service.relayCreationTimeoutMs = 50;
+		service.setRelayCreationTimeoutForTest(50);
 		// Make the *reconnect* call's relay creation hang (the second relay).
 		service.hangRelayCreationOnCall = 2;
 


### PR DESCRIPTION
Same as https://github.com/microsoft/vscode/pull/310195 as we're running into:

```
[19:19:00] [mangler] Done collecting. Classes: 10966. Exported symbols: 13574
[19:19:01] [mangler] WARN: 'relayCreationTimeoutMs' from src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts:520 became PUBLIC because of: src/vs/platform/agentHost/test/node/sshRemoteAgentHostService.test.ts:177
[19:19:01] [mangler] ERROR: Protected fields have been made PUBLIC. This hurts minification and is therefore not allowed. Review the WARN messages further above
[19:19:01] Starting compilation...
[19:19:01] 'compile-build-with-mangling' errored after 14 s
[19:19:01] Error: Protected fields have been made PUBLIC. This hurts minification and is therefore not allowed. Review the WARN messages further above
    at Mangler.computeNewFileContents (file://build/lib/mangle/index.ts:568:10)
    at task (file://build/lib/compilation.ts:144:47)
    at file://build/lib/task.ts:62:22
    at new Promise (<anonymous>)
    at _doExecute (file://build/lib/task.ts:50:9)
    at _execute (file://build/lib/task.ts:40:8)
    at result (file://build/lib/task.ts:85:10)
    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
    at async _execute (file://build/lib/task.ts:40:2)
    at async result (file://build/lib/task.ts:85:4)
```

after `npm install` -> `npm run compile-build`