### PR TITLE
Normalize agent host terminal text input

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
+++ b/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
@@ -45,6 +45,10 @@ export interface ITerminalQueryFilterState {
 	pendingData: string;
 }
 
+export interface ISendTextOptions {
+	shouldExecute: boolean;
+}
+
 export function removeServerHandledTerminalQueries(data: string, state: ITerminalQueryFilterState): string {
 	if (
 		!state.pendingData
@@ -76,6 +80,14 @@ function getServerHandledTerminalQueryPrefix(data: string): string {
 	return '';
 }
 
+export function formatTerminalText(data: string, options: ISendTextOptions): string {
+	data = data.replace(/\r?\n/g, '\r');
+	if (options.shouldExecute && !data.endsWith('\r')) {
+		data += '\r';
+	}
+	return data;
+}
+
 /**
  * Service interface for terminal management in the agent host.
  */
@@ -83,6 +95,7 @@ export interface IAgentHostTerminalManager {
 	readonly _serviceBrand: undefined;
 	createTerminal(params: CreateTerminalParams, options?: { shell?: string; preventShellHistory?: boolean; nonInteractive?: boolean }): Promise<void>;
 	writeInput(uri: string, data: string): void;
+	sendText(uri: string, data: string, options: ISendTextOptions): void;
 	onData(uri: string, cb: (data: string) => void): IDisposable;
 	onExit(uri: string, cb: (exitCode: number) => void): IDisposable;
 	onClaimChanged(uri: string, cb: (claim: TerminalClaim) => void): IDisposable;
@@ -428,6 +441,11 @@ export class AgentHostTerminalManager extends Disposable implements IAgentHostTe
 		if (terminal && terminal.exitCode === undefined) {
 			terminal.pty.write(data);
 		}
+	}
+
+	/** Send formatted text to a terminal's PTY process. */
+	sendText(uri: string, data: string, options: ISendTextOptions): void {
+		this.writeInput(uri, formatTerminalText(data, options));
 	}
 
 	/** Register a callback for PTY data events on a terminal. */

--- a/src/vs/platform/agentHost/node/copilot/copilotShellTools.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotShellTools.ts
@@ -352,7 +352,7 @@ async function executeCommandWithShellIntegration(
 ): Promise<ToolResultObject> {
 	const disposables = new DisposableStore();
 
-	terminalManager.writeInput(shell.terminalUri, `${prefixForHistorySuppression(shell.shellType)}${command}\r`);
+	terminalManager.sendText(shell.terminalUri, `${prefixForHistorySuppression(shell.shellType)}${command}`, { shouldExecute: true });
 
 	return new Promise<ToolResultObject>(resolve => {
 		let resolved = false;
@@ -421,9 +421,8 @@ async function executeCommandWithSentinel(
 	const contentBefore = terminalManager.getContent(shell.terminalUri) ?? '';
 	const offsetBefore = contentBefore.length;
 
-	// PTY input uses \r for line endings — the PTY translates to \r\n
-	const input = `${prefixForHistorySuppression(shell.shellType)}${command}\r${sentinelCmd}\r`;
-	terminalManager.writeInput(shell.terminalUri, input);
+	terminalManager.sendText(shell.terminalUri, `${prefixForHistorySuppression(shell.shellType)}${command}`, { shouldExecute: true });
+	terminalManager.sendText(shell.terminalUri, sentinelCmd, { shouldExecute: true });
 
 	return new Promise<ToolResultObject>(resolve => {
 		let resolved = false;
@@ -597,7 +596,7 @@ export async function createShellTools(
 			if (!shell) {
 				return makeFailureResult('No active shell found.', 'no_shell');
 			}
-			terminalManager.writeInput(shell.terminalUri, args.command);
+			terminalManager.sendText(shell.terminalUri, args.command, { shouldExecute: false });
 			return makeSuccessResult('Input sent to shell.');
 		},
 	};

--- a/src/vs/platform/agentHost/test/node/agentHostTerminalManager.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTerminalManager.test.ts
@@ -15,7 +15,7 @@ import { ActionType, StateAction } from '../../common/state/protocol/actions.js'
 import { TerminalClaimKind, TerminalContentPart } from '../../common/state/protocol/state.js';
 import { AgentConfigurationService } from '../../node/agentConfigurationService.js';
 import { AgentHostStateManager } from '../../node/agentHostStateManager.js';
-import { AgentHostTerminalManager, removeServerHandledTerminalQueries, type ITerminalQueryFilterState } from '../../node/agentHostTerminalManager.js';
+import { AgentHostTerminalManager, formatTerminalText, removeServerHandledTerminalQueries, type ITerminalQueryFilterState } from '../../node/agentHostTerminalManager.js';
 import { Osc633Event, Osc633EventType, Osc633Parser } from '../../node/osc633Parser.js';
 
 /**
@@ -251,6 +251,39 @@ suite('AgentHostTerminalManager – command detection integration', () => {
 	const disposables = new DisposableStore();
 	teardown(() => disposables.clear());
 	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('formats command input with terminal enter semantics', () => {
+		assert.strictEqual(formatTerminalText('echo first\necho second', { shouldExecute: true }), 'echo first\recho second\r');
+		assert.strictEqual(formatTerminalText('echo first\r\necho second', { shouldExecute: true }), 'echo first\recho second\r');
+		assert.strictEqual(formatTerminalText('echo first\r', { shouldExecute: true }), 'echo first\r');
+		assert.strictEqual(formatTerminalText('answer\n', { shouldExecute: false }), 'answer\r');
+		assert.strictEqual(formatTerminalText('/tmp/foo\npwd', { shouldExecute: true }), '/tmp/foo\rpwd\r');
+	});
+
+	test('writes formatted command input to the PTY', async () => {
+		const logService = new NullLogService();
+		const stateManager = disposables.add(new AgentHostStateManager(logService));
+		const configurationService = disposables.add(new AgentConfigurationService(stateManager, logService));
+		const productService = { _serviceBrand: undefined, applicationName: 'vscode' } as IProductService;
+		const pty = new TestPty();
+		const manager = disposables.add(new TestAgentHostTerminalManager(stateManager, logService, productService, configurationService, pty));
+
+		const createTerminal = manager.createTerminal({
+			terminal: 'agenthost-terminal://test/command-input',
+			claim: { kind: TerminalClaimKind.Client, clientId: 'test-client' },
+			cwd: process.cwd(),
+			cols: 80,
+			rows: 24,
+		}, { shell: '/bin/bash' });
+
+		await pty.dataListenerRegistered.p;
+		pty.fireData('prompt');
+		await createTerminal;
+
+		manager.sendText('agenthost-terminal://test/command-input', 'echo first\necho second', { shouldExecute: true });
+
+		assert.deepStrictEqual(pty.writes, ['echo first\recho second\r']);
+	});
 
 	test('writes headless DSR responses back to the PTY', async () => {
 		const logService = new NullLogService();

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -86,6 +86,7 @@ class TestAgentHostTerminalManager implements IAgentHostTerminalManager {
 
 	async createTerminal(): Promise<void> { }
 	writeInput(): void { }
+	sendText(): void { }
 	onData(): IDisposable { return Disposable.None; }
 	onExit(): IDisposable { return Disposable.None; }
 	onClaimChanged(): IDisposable { return Disposable.None; }

--- a/src/vs/platform/agentHost/test/node/copilotShellTools.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotShellTools.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import type { ToolInvocation, ToolResultObject } from '@github/copilot-sdk';
 import { URI } from '../../../../base/common/uri.js';
 import { Disposable, DisposableStore, type IDisposable } from '../../../../base/common/lifecycle.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
@@ -13,26 +14,33 @@ import { ServiceCollection } from '../../../instantiation/common/serviceCollecti
 import { ILogService, NullLogService } from '../../../log/common/log.js';
 import type { CreateTerminalParams } from '../../common/state/protocol/commands.js';
 import type { TerminalClaim, TerminalInfo } from '../../common/state/protocol/state.js';
-import { IAgentHostTerminalManager } from '../../node/agentHostTerminalManager.js';
-import { ShellManager, prefixForHistorySuppression, shellTypeForExecutable } from '../../node/copilot/copilotShellTools.js';
+import { formatTerminalText, IAgentHostTerminalManager, type ISendTextOptions } from '../../node/agentHostTerminalManager.js';
+import { createShellTools, ShellManager, prefixForHistorySuppression, shellTypeForExecutable } from '../../node/copilot/copilotShellTools.js';
 
 class TestAgentHostTerminalManager implements IAgentHostTerminalManager {
 	declare readonly _serviceBrand: undefined;
 
 	defaultShell = '/bin/bash';
 	readonly created: { params: CreateTerminalParams; options?: { shell?: string; preventShellHistory?: boolean; nonInteractive?: boolean } }[] = [];
+	readonly writes: { uri: string; data: string }[] = [];
+	readonly existingTerminalUris = new Set<string>();
 
 	async createTerminal(params: CreateTerminalParams, options?: { shell?: string; preventShellHistory?: boolean; nonInteractive?: boolean }): Promise<void> {
 		this.created.push({ params, options: { ...options, shell: options?.shell ?? this.defaultShell } });
 	}
-	writeInput(): void { }
+	writeInput(uri: string, data: string): void {
+		this.writes.push({ uri, data });
+	}
+	sendText(uri: string, data: string, options: ISendTextOptions): void {
+		this.writeInput(uri, formatTerminalText(data, options));
+	}
 	onData(): IDisposable { return Disposable.None; }
 	onExit(): IDisposable { return Disposable.None; }
 	onClaimChanged(): IDisposable { return Disposable.None; }
 	onCommandFinished(): IDisposable { return Disposable.None; }
 	getContent(): string | undefined { return undefined; }
 	getClaim(): TerminalClaim | undefined { return undefined; }
-	hasTerminal(): boolean { return false; }
+	hasTerminal(uri: string): boolean { return this.existingTerminalUris.has(uri); }
 	getExitCode(): number | undefined { return undefined; }
 	supportsCommandDetection(): boolean { return false; }
 	disposeTerminal(): void { }
@@ -150,5 +158,48 @@ suite('CopilotShellTools', () => {
 		assert.strictEqual(terminalManager.created.length, 2);
 		first.dispose();
 		second.dispose();
+	});
+
+	test('primary shell tool normalizes multiline command input', async () => {
+		const { instantiationService, terminalManager } = createServices();
+		const shellManager = disposables.add(instantiationService.createInstance(ShellManager, URI.parse('copilot:/session-1'), undefined));
+		const tools = await createShellTools(shellManager, terminalManager, new NullLogService());
+		const bashTool = tools.find(tool => tool.name === 'bash');
+		assert.ok(bashTool);
+
+		const invocation: ToolInvocation = {
+			sessionId: 'session-1',
+			toolCallId: 'tool-1',
+			toolName: 'bash',
+			arguments: { command: 'echo first\necho second', timeout: 1 },
+		};
+		const result = await bashTool.handler({ command: 'echo first\necho second', timeout: 1 }, invocation) as ToolResultObject;
+
+		assert.strictEqual(result.resultType, 'failure');
+		assert.strictEqual(terminalManager.writes[0].data, ' echo first\recho second\r');
+		assert.match(terminalManager.writes[1].data, /^echo "<<<COPILOT_SENTINEL_[a-f0-9]+_EXIT_\$\?>>>"\r$/);
+	});
+
+	test('write shell tool normalizes input without appending enter', async () => {
+		const { instantiationService, terminalManager } = createServices();
+		const shellManager = disposables.add(instantiationService.createInstance(ShellManager, URI.parse('copilot:/session-1'), undefined));
+		const shellRef = await shellManager.getOrCreateShell('bash', 'turn-1', 'tool-1');
+		terminalManager.existingTerminalUris.add(shellRef.object.terminalUri);
+		const tools = await createShellTools(shellManager, terminalManager, new NullLogService());
+		const writeTool = tools.find(tool => tool.name === 'write_bash');
+		assert.ok(writeTool);
+
+		const invocation: ToolInvocation = {
+			sessionId: 'session-1',
+			toolCallId: 'tool-2',
+			toolName: 'write_bash',
+			arguments: { command: 'answer\n' },
+		};
+		const result = writeTool.handler({ command: 'answer\n' }, invocation) as ToolResultObject;
+
+		assert.strictEqual(result.resultType, 'success');
+		assert.strictEqual(terminalManager.writes[0].uri, shellRef.object.terminalUri);
+		assert.strictEqual(terminalManager.writes[0].data, 'answer\r');
+		shellRef.dispose();
 	});
 });


### PR DESCRIPTION
Part of: https://github.com/microsoft/vscode/issues/314189#issuecomment-4408477824

Align Agent Host shell-tool text input with VS Code terminal `sendText` behavior.

- Add `sendText` to Agent Host terminal manager for semantic terminal text input.
- Keep `writeInput` as the raw PTY byte path.
- Normalize command text line endings from `\r?\n` to `\r`.
- Append a final `\r` only when the caller intends to execute the text.
- Route Copilot shell-tool text writes through `sendText`.

/cc @meganrogge @connor4312 