### PR TITLE
Update Agents welcome banner wording (1.120)

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsBanner.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsBanner.ts
@@ -65,7 +65,7 @@ export function createAgentsBanner(
 	telemetryService: ITelemetryService,
 ): IAgentsBannerResult {
 	const disposables = new DisposableStore();
-	const label = options.label ?? localize('agentsBanner.tryAgentsAppLabel', "Try out the new Agents");
+	const label = options.label ?? localize('agentsBanner.tryAgentsAppLabel', "Try out the new Agents window");
 
 	const button = $('button.agents-banner-button', {
 		title: label,


### PR DESCRIPTION
Backport of #316059 to `release/1.120`.

Updates the welcome-page Agents entry point copy to match the requested wording. Per issue discussion, this keeps the existing codicon-based icon unchanged and only adjusts the text.

- **Description**
  - Changes the shared Agents banner label from `Try out the new Agents` to `Try out the new Agents window`.
  - Uses the shared banner helper, so the wording stays consistent anywhere this welcome-page banner is rendered.

- **Scope**
  - No behavior changes.
  - No icon changes.