### PR TITLE
Fix Changes view stuck empty after first message in new agent host session

### DIFF
--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -41,7 +41,7 @@ interface ISessionState {
 	isActive?: boolean;
 }
 
-class SessionsManagementService extends Disposable implements ISessionsManagementService {
+export class SessionsManagementService extends Disposable implements ISessionsManagementService {
 
 	declare readonly _serviceBrand: undefined;
 

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -55,21 +55,6 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 
 	private readonly _activeSession = observableValue<IActiveSession | undefined>(this, undefined);
 	readonly activeSession: IObservable<IActiveSession | undefined> = this._activeSession;
-	/**
-	 * The underlying {@link ISession} that backs the current
-	 * {@link _activeSession} (the latter is a spread copy with `activeChat`
-	 * tacked on, so it loses instance identity). Tracked so that
-	 * {@link setActiveSession} can detect a provider swapping the session
-	 * instance even when the new session shares the previous one's
-	 * `sessionId` — which happens when a new agent host session "graduates"
-	 * from its untitled skeleton to the committed adapter (both reuse the
-	 * skeleton's UUID so the chat URI stays stable). Without this, the
-	 * early-return based purely on `sessionId` would keep observers wired
-	 * to the skeleton's observables and updates from the live adapter
-	 * would never reach the view. Always updated alongside
-	 * {@link _activeSession}.
-	 */
-	private _activeUnderlyingSession: ISession | undefined;
 	/** Tracks the pending new session so it can be restored by {@link openNewSessionView}. */
 	private _pendingNewSession: ISession | undefined;
 	private readonly isNewChatSessionContext: IContextKey<boolean>;
@@ -446,15 +431,16 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 	}
 
 	private setActiveSession(session: ISession | undefined): void {
-		const previousSession = this._activeUnderlyingSession;
-		// Compare instance identity, not just sessionId: a provider can
-		// replace a session with a different instance that happens to share
-		// the same sessionId (e.g. an agent host skeleton being swapped for
-		// the committed adapter once the backend session is created). The
-		// new instance has its own observables, so a sessionId-only check
-		// would silently no-op the swap and leave observers wired to the
-		// stale instance.
-		if (previousSession === session) {
+		const previousSession = this._activeSession.get();
+		// Compare both the sessionId and an underlying observable reference
+		// (spread onto `_activeSession`): a provider can replace a session
+		// with a different instance that happens to share the same sessionId
+		// (e.g. an agent host skeleton being swapped for the committed
+		// adapter once the backend session is created). The new instance
+		// has its own `changes` observable, so reference-equality on it
+		// detects the swap. Without this the early-return would be a silent
+		// no-op and observers would stay wired to the skeleton's observables.
+		if (previousSession?.sessionId === session?.sessionId && previousSession?.changes === session?.changes) {
 			return;
 		}
 
@@ -505,7 +491,6 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 				activeChat: activeChatObs,
 			};
 
-			this._activeUnderlyingSession = session;
 			this._activeSession.set(activeSession, undefined);
 
 			// Track archived state changes for the active session
@@ -550,7 +535,6 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 			}));
 		} else {
 			this._activeChatObservable = undefined;
-			this._activeUnderlyingSession = undefined;
 			this._activeSession.set(undefined, undefined);
 		}
 	}

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -55,6 +55,21 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 
 	private readonly _activeSession = observableValue<IActiveSession | undefined>(this, undefined);
 	readonly activeSession: IObservable<IActiveSession | undefined> = this._activeSession;
+	/**
+	 * The underlying {@link ISession} that backs the current
+	 * {@link _activeSession} (the latter is a spread copy with `activeChat`
+	 * tacked on, so it loses instance identity). Tracked so that
+	 * {@link setActiveSession} can detect a provider swapping the session
+	 * instance even when the new session shares the previous one's
+	 * `sessionId` — which happens when a new agent host session "graduates"
+	 * from its untitled skeleton to the committed adapter (both reuse the
+	 * skeleton's UUID so the chat URI stays stable). Without this, the
+	 * early-return based purely on `sessionId` would keep observers wired
+	 * to the skeleton's observables and updates from the live adapter
+	 * would never reach the view. Always updated alongside
+	 * {@link _activeSession}.
+	 */
+	private _activeUnderlyingSession: ISession | undefined;
 	/** Tracks the pending new session so it can be restored by {@link openNewSessionView}. */
 	private _pendingNewSession: ISession | undefined;
 	private readonly isNewChatSessionContext: IContextKey<boolean>;
@@ -431,16 +446,15 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 	}
 
 	private setActiveSession(session: ISession | undefined): void {
-		const previousSession = this._activeSession.get();
-		// Compare both the sessionId and an underlying observable reference
-		// (spread onto `_activeSession`): a provider can replace a session
-		// with a different instance that happens to share the same sessionId
-		// (e.g. an agent host skeleton being swapped for the committed
-		// adapter once the backend session is created). The new instance
-		// has its own `changes` observable, so reference-equality on it
-		// detects the swap. Without this the early-return would be a silent
-		// no-op and observers would stay wired to the skeleton's observables.
-		if (previousSession?.sessionId === session?.sessionId && previousSession?.changes === session?.changes) {
+		const previousSession = this._activeUnderlyingSession;
+		// Compare instance identity, not just sessionId: a provider can
+		// replace a session with a different instance that happens to share
+		// the same sessionId (e.g. an agent host skeleton being swapped for
+		// the committed adapter once the backend session is created). The
+		// new instance has its own observables, so a sessionId-only check
+		// would silently no-op the swap and leave observers wired to the
+		// stale instance.
+		if (previousSession === session) {
 			return;
 		}
 
@@ -491,6 +505,7 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 				activeChat: activeChatObs,
 			};
 
+			this._activeUnderlyingSession = session;
 			this._activeSession.set(activeSession, undefined);
 
 			// Track archived state changes for the active session
@@ -535,6 +550,7 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 			}));
 		} else {
 			this._activeChatObservable = undefined;
+			this._activeUnderlyingSession = undefined;
 			this._activeSession.set(undefined, undefined);
 		}
 	}

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -55,19 +55,6 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 
 	private readonly _activeSession = observableValue<IActiveSession | undefined>(this, undefined);
 	readonly activeSession: IObservable<IActiveSession | undefined> = this._activeSession;
-	/**
-	 * The underlying {@link ISession} that produced the current
-	 * {@link _activeSession} (the latter is a spread copy with `activeChat`
-	 * tacked on). Tracked so that {@link setActiveSession} can detect a
-	 * provider swapping the session instance even when the new session
-	 * shares the previous one's `sessionId` — which happens when a new
-	 * agent host session "graduates" from its untitled skeleton to the
-	 * committed adapter (both reuse the skeleton's UUID so the chat URI
-	 * stays stable). Without this, the early-return based purely on
-	 * `sessionId` keeps observers subscribed to the skeleton's `changes`
-	 * observable and diffs from the live adapter never reach the view.
-	 */
-	private _activeUnderlyingSession: ISession | undefined;
 	/** Tracks the pending new session so it can be restored by {@link openNewSessionView}. */
 	private _pendingNewSession: ISession | undefined;
 	private readonly isNewChatSessionContext: IContextKey<boolean>;
@@ -445,17 +432,17 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 
 	private setActiveSession(session: ISession | undefined): void {
 		const previousSession = this._activeSession.get();
-		// Compare both the sessionId and the underlying session instance: a
-		// provider can replace a session with a different instance that
-		// happens to share the same sessionId (e.g. an agent host skeleton
-		// being swapped for the committed adapter once the backend session
-		// is created). Without the instance check the swap would be a
-		// silent no-op and observers would stay wired to the skeleton's
-		// observables.
-		if (previousSession?.sessionId === session?.sessionId && this._activeUnderlyingSession === session) {
+		// Compare both the sessionId and an underlying observable reference
+		// (spread onto `_activeSession`): a provider can replace a session
+		// with a different instance that happens to share the same sessionId
+		// (e.g. an agent host skeleton being swapped for the committed
+		// adapter once the backend session is created). The new instance
+		// has its own `changes` observable, so reference-equality on it
+		// detects the swap. Without this the early-return would be a silent
+		// no-op and observers would stay wired to the skeleton's observables.
+		if (previousSession?.sessionId === session?.sessionId && previousSession?.changes === session?.changes) {
 			return;
 		}
-		this._activeUnderlyingSession = session;
 
 		// Update context keys from session data
 		this._activeSessionProviderId.set(session?.providerId ?? '');

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -55,6 +55,19 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 
 	private readonly _activeSession = observableValue<IActiveSession | undefined>(this, undefined);
 	readonly activeSession: IObservable<IActiveSession | undefined> = this._activeSession;
+	/**
+	 * The underlying {@link ISession} that produced the current
+	 * {@link _activeSession} (the latter is a spread copy with `activeChat`
+	 * tacked on). Tracked so that {@link setActiveSession} can detect a
+	 * provider swapping the session instance even when the new session
+	 * shares the previous one's `sessionId` — which happens when a new
+	 * agent host session "graduates" from its untitled skeleton to the
+	 * committed adapter (both reuse the skeleton's UUID so the chat URI
+	 * stays stable). Without this, the early-return based purely on
+	 * `sessionId` keeps observers subscribed to the skeleton's `changes`
+	 * observable and diffs from the live adapter never reach the view.
+	 */
+	private _activeUnderlyingSession: ISession | undefined;
 	/** Tracks the pending new session so it can be restored by {@link openNewSessionView}. */
 	private _pendingNewSession: ISession | undefined;
 	private readonly isNewChatSessionContext: IContextKey<boolean>;
@@ -432,9 +445,17 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 
 	private setActiveSession(session: ISession | undefined): void {
 		const previousSession = this._activeSession.get();
-		if (previousSession?.sessionId === session?.sessionId) {
+		// Compare both the sessionId and the underlying session instance: a
+		// provider can replace a session with a different instance that
+		// happens to share the same sessionId (e.g. an agent host skeleton
+		// being swapped for the committed adapter once the backend session
+		// is created). Without the instance check the swap would be a
+		// silent no-op and observers would stay wired to the skeleton's
+		// observables.
+		if (previousSession?.sessionId === session?.sessionId && this._activeUnderlyingSession === session) {
 			return;
 		}
+		this._activeUnderlyingSession = session;
 
 		// Update context keys from session data
 		this._activeSessionProviderId.set(session?.providerId ?? '');

--- a/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
@@ -4,13 +4,20 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { Emitter, Event } from '../../../../../base/common/event.js';
+import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { constObservable } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { IAgentSessionsService } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentSessionsService.js';
+import { workbenchInstantiationService } from '../../../../../workbench/test/browser/workbenchTestServices.js';
 import { LOCAL_AGENT_HOST_PROVIDER_ID } from '../../../../common/agentHostSessionsProvider.js';
 import { IChat, ISession } from '../../common/session.js';
-import { deduplicateSessions } from '../../browser/sessionsManagementService.js';
+import { ISessionChangeEvent, ISessionsProvider } from '../../common/sessionsProvider.js';
+import { deduplicateSessions, SessionsManagementService } from '../../browser/sessionsManagementService.js';
+import { ISessionsProvidersChangeEvent, ISessionsProvidersService } from '../../browser/sessionsProvidersService.js';
 
 const stubChat = {
 	resource: URI.parse('test:///chat'),
@@ -104,5 +111,96 @@ suite('deduplicateSessions', () => {
 		const noKey = stubSession({ sessionId: 'nk', providerId: 'copilot-chat' });
 		const result = deduplicateSessions([keyed2, noKey, keyed1]);
 		assert.deepStrictEqual(result, [noKey, keyed1]);
+	});
+});
+
+class StubSessionsProvider extends Disposable {
+	readonly id = 'stub-provider';
+	readonly label = 'Stub';
+	readonly icon = Codicon.vm;
+	readonly sessionTypes = [];
+	readonly browseActions = [];
+
+	private readonly _onDidChangeSessions = this._register(new Emitter<ISessionChangeEvent>());
+	readonly onDidChangeSessions = this._onDidChangeSessions.event;
+
+	private readonly _onDidChangeSessionTypes = this._register(new Emitter<void>());
+	readonly onDidChangeSessionTypes = this._onDidChangeSessionTypes.event;
+
+	private readonly _onDidReplaceSession = this._register(new Emitter<{ readonly from: ISession; readonly to: ISession }>());
+	readonly onDidReplaceSession = this._onDidReplaceSession.event;
+
+	private _sessions: ISession[] = [];
+
+	getSessions(): ISession[] { return this._sessions; }
+	setSessions(sessions: ISession[]): void { this._sessions = sessions; }
+	fireReplace(from: ISession, to: ISession): void { this._onDidReplaceSession.fire({ from, to }); }
+
+	asProvider(): ISessionsProvider { return this as unknown as ISessionsProvider; }
+}
+
+class StubSessionsProvidersService extends Disposable {
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _providers = new Map<string, ISessionsProvider>();
+	private readonly _onDidChangeProviders = this._register(new Emitter<ISessionsProvidersChangeEvent>());
+	readonly onDidChangeProviders: Event<ISessionsProvidersChangeEvent> = this._onDidChangeProviders.event;
+
+	register(provider: ISessionsProvider): void {
+		this._providers.set(provider.id, provider);
+		this._onDidChangeProviders.fire({ added: [provider], removed: [] });
+	}
+
+	getProviders(): ISessionsProvider[] { return Array.from(this._providers.values()); }
+	getProvider<T extends ISessionsProvider>(id: string): T | undefined { return this._providers.get(id) as T | undefined; }
+
+	asService(): ISessionsProvidersService { return this as unknown as ISessionsProvidersService; }
+}
+
+class StubAgentSessionsService {
+	declare readonly _serviceBrand: undefined;
+	readonly model = { observeSession: () => constObservable(undefined) } as unknown as IAgentSessionsService['model'];
+	readonly onDidChangeSessionArchivedState = Event.None;
+	getSession() { return undefined; }
+
+	asService(): IAgentSessionsService { return this as unknown as IAgentSessionsService; }
+}
+
+suite('SessionsManagementService - setActiveSession', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('rewires active session when provider replaces with a new instance sharing the same sessionId', () => {
+		const instantiationService: TestInstantiationService = workbenchInstantiationService({}, disposables);
+		const providersService = disposables.add(new StubSessionsProvidersService());
+		instantiationService.stub(ISessionsProvidersService, providersService.asService());
+		instantiationService.stub(IAgentSessionsService, new StubAgentSessionsService().asService());
+
+		const provider = disposables.add(new StubSessionsProvider());
+		providersService.register(provider.asProvider());
+
+		const service = disposables.add(instantiationService.createInstance(SessionsManagementService));
+
+		// Two separate instances that share the same sessionId — modeling the
+		// agent host skeleton/adapter swap that produced #315936.
+		const skeleton = stubSession({ sessionId: 'shared-id', providerId: provider.id });
+		const adapter = stubSession({ sessionId: 'shared-id', providerId: provider.id });
+		assert.notStrictEqual(skeleton, adapter);
+
+		// Seed the active session with the skeleton via the public openChat
+		// entry point (which calls setActiveSession internally).
+		void service.openChat(skeleton, skeleton.resource);
+		assert.strictEqual(service.activeSession.get()?.sessionId, 'shared-id');
+		const before = service.activeSession.get();
+
+		// Provider swaps in the committed instance with the same sessionId.
+		provider.fireReplace(skeleton, adapter);
+
+		const after = service.activeSession.get();
+		assert.strictEqual(after?.sessionId, 'shared-id');
+		// The IActiveSession is a fresh object spread from the new underlying
+		// session, so the wrapper changes identity even though the sessionId is
+		// the same. This confirms the rewire happened (regression guard for
+		// the early-return that previously skipped same-sessionId swaps).
+		assert.notStrictEqual(after, before);
 	});
 });


### PR DESCRIPTION
## Fix

In the agents/sessions code, the "New Session" picker (`NewSession.session` in `baseAgentHostSessionsProvider.ts`) and the `AgentHostSessionAdapter` that the AHP server eventually creates for the same chat URI are two distinct `ISession` instances that share the same `sessionId`. The skeleton's UUID is intentionally reused as the committed session's URI path so the chat URI stays stable across the swap and the chat widget doesn't have to be re-opened against a different URI.

When `sendAndCreateChat` fired `_onDidReplaceSession({from: skeleton, to: adapter})`, `SessionsManagementService.setActiveSession(adapter)` hit this early-return:

```ts
if (previousSession?.sessionId === session?.sessionId) return;
```

…and silently skipped the swap. The active session kept holding the spread-copy of the skeleton, whose `changes` observable is a separate instance from the adapter's, so diffs that landed in the adapter (`AgentHostSessionAdapter.changes`) never reached subscribers — notably the Changes view, which stayed empty after the first message.

Switching to a different session and back was the only workaround, because the intermediate session has a different `sessionId`, breaking the early-return both times.

This change tracks the underlying `ISession` instance alongside `_activeSession` and requires **both** `sessionId` equality AND instance identity to early-return, so a same-id replace actually rewires the active session to the new instance.

A more invasive follow-up would unify `NewSession` and `AgentHostSessionAdapter` so a single instance gets "promoted" instead of replaced, but this fix is contained to the management service and addresses the symptom.

## Validation

- Reproduced #315936 with a fresh new local agent host session and an "append a single line to README.md" message — Changes view stayed empty.
- Confirmed the trace matches the diagnosis: `_handleDiffsChanged` writes diffs into `cached.changes`, `sessionFileChangesEqual` returns `false`, `_onDidReplaceSession` fires with `from.sessionId === to.sessionId`, and `setActiveSession` early-returns.
- After the fix the active session is rewired on replace and the view derived re-evaluates against the adapter's `changes` observable.
- `npm run compile-check-ts-native` passes.
- Existing `SessionsManagementService` unit tests pass (`./scripts/test.sh --grep deduplicateSessions`).

Fixes #315936
