### PR TITLE
sessions: round active chat send button

### DIFF
--- a/src/vs/sessions/browser/parts/media/chatBarPart.css
+++ b/src/vs/sessions/browser/parts/media/chatBarPart.css
@@ -87,17 +87,16 @@
 	max-width: 150px;
 }
 
-.monaco-workbench .part.chatbar .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:has(> .action-label.codicon-arrow-up),
-.monaco-workbench .part.chatbar .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:not(.disabled):has(> .action-label.codicon-arrow-up:focus-visible) {
+.monaco-workbench .part.chatbar .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:has(> .action-label.codicon-arrow-up) {
 	border-radius: 50%;
 }
 
-.monaco-workbench .part.chatbar .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:not(.disabled) > .action-label.codicon-arrow-up,
-.monaco-workbench .part.chatbar .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:has(> .action-label.codicon-arrow-up) > .action-label.codicon-arrow-up {
+.monaco-workbench .part.chatbar .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item > .action-label.codicon-arrow-up {
 	border-radius: 50%;
 }
 
 /* Nudge icon position to ensure it looks optically aligned within the button */
 .monaco-workbench .part.chatbar .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item > .action-label.codicon-arrow-up::before {
+	display: inline-block;
 	transform: translateX(-0.5px);
 }

--- a/src/vs/sessions/browser/parts/media/chatBarPart.css
+++ b/src/vs/sessions/browser/parts/media/chatBarPart.css
@@ -86,3 +86,18 @@
 .monaco-workbench .chatbar.pane-composite-part > .title.has-composite-bar > .title-actions .monaco-action-bar .action-item {
 	max-width: 150px;
 }
+
+.monaco-workbench .part.chatbar .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:has(> .action-label.codicon-arrow-up),
+.monaco-workbench .part.chatbar .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:not(.disabled):has(> .action-label.codicon-arrow-up:focus-visible) {
+	border-radius: 50%;
+}
+
+.monaco-workbench .part.chatbar .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:not(.disabled) > .action-label.codicon-arrow-up,
+.monaco-workbench .part.chatbar .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:has(> .action-label.codicon-arrow-up) > .action-label.codicon-arrow-up {
+	border-radius: 50%;
+}
+
+/* Nudge icon position to ensure it looks optically aligned within the button */
+.monaco-workbench .part.chatbar .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item > .action-label.codicon-arrow-up::before {
+	transform: translateX(-0.5px);
+}

--- a/src/vs/sessions/browser/widget/AGENTS_CHAT_WIDGET.md
+++ b/src/vs/sessions/browser/widget/AGENTS_CHAT_WIDGET.md
@@ -77,6 +77,7 @@ The main wrapper around `ChatWidget`. It:
 4. **Gathers initial options** — collects all option selections and attaches them to the session context
 5. **Hides duplicate pickers** — uses `hiddenPickerIds` and `excludeOptionGroup` to avoid showing pickers in both the welcome view and input toolbar
 6. **Caches option groups** — persists extension-contributed option groups to `StorageService` so pickers render immediately on next load before extensions activate
+7. **Aligns input controls** — the active chat input's send action keeps the same circular primary-button shape as the new-session chat input
 
 #### Submission Interception: Two Mechanisms
 


### PR DESCRIPTION
## Summary

Follow up to: https://github.com/microsoft/vscode/pull/315330

- Make the active Sessions chat input send button circular to match the new chat input
- Keep the override scoped to the Sessions chatbar so regular VS Code chat styling is unchanged
- Nudge the arrow icon for better optical alignment
- Document the input-control alignment in the Sessions chat widget architecture notes

<img width="624" height="165" alt="Screenshot 2026-05-12 at 2 52 09 PM" src="https://github.com/user-attachments/assets/c0826b89-c334-4165-8b61-541c2bfc98bf" />

## Validation

- `npm run compile-check-ts-native`
- `npm run hygiene` (after removing ignored `extensions/**/tsconfig.tsbuildinfo` build artifacts)
- `npm run valid-layers-check -- --quiet`