### PR TITLE
Enable bracketed paste mode for agent host terminal

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostHeadlessTerminal.ts
+++ b/src/vs/platform/agentHost/node/agentHostHeadlessTerminal.ts
@@ -83,6 +83,10 @@ export class AgentHostHeadlessTerminal extends Disposable {
 		this._terminal.resize(cols, rows);
 	}
 
+	isBracketedPasteMode(): boolean {
+		return this._terminal.modes.bracketedPasteMode;
+	}
+
 	clear(): void {
 		// xterm.clear() preserves the visible line content; emulate a terminal
 		// clear sequence so future terminal-state reads match a user-visible clear.

--- a/src/vs/platform/agentHost/node/agentHostHeadlessTerminal.ts
+++ b/src/vs/platform/agentHost/node/agentHostHeadlessTerminal.ts
@@ -79,6 +79,10 @@ export class AgentHostHeadlessTerminal extends Disposable {
 		return this._writeBarrier;
 	}
 
+	whenPtyDataFlushed(): Promise<void> {
+		return this._writeBarrier.catch(() => undefined);
+	}
+
 	resize(cols: number, rows: number): void {
 		this._terminal.resize(cols, rows);
 	}

--- a/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
+++ b/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
@@ -47,6 +47,15 @@ export interface ITerminalQueryFilterState {
 
 export interface ISendTextOptions {
 	shouldExecute: boolean;
+	/**
+	 * Match workbench terminal sendText: wrap in bracketed paste markers only
+	 * when requested by the caller and enabled by the terminal.
+	 */
+	bracketedPasteMode?: boolean;
+}
+
+export interface IFormatTerminalTextOptions extends ISendTextOptions {
+	shouldWrapWithBracketedPaste?: boolean;
 }
 
 export function removeServerHandledTerminalQueries(data: string, state: ITerminalQueryFilterState): string {
@@ -80,7 +89,10 @@ function getServerHandledTerminalQueryPrefix(data: string): string {
 	return '';
 }
 
-export function formatTerminalText(data: string, options: ISendTextOptions): string {
+export function formatTerminalText(data: string, options: IFormatTerminalTextOptions): string {
+	if (options.shouldWrapWithBracketedPaste) {
+		data = `\x1b[200~${data}\x1b[201~`;
+	}
 	data = data.replace(/\r?\n/g, '\r');
 	if (options.shouldExecute && !data.endsWith('\r')) {
 		data += '\r';
@@ -445,7 +457,9 @@ export class AgentHostTerminalManager extends Disposable implements IAgentHostTe
 
 	/** Send formatted text to a terminal's PTY process. */
 	sendText(uri: string, data: string, options: ISendTextOptions): void {
-		this.writeInput(uri, formatTerminalText(data, options));
+		const terminal = this._terminals.get(uri);
+		const shouldWrapWithBracketedPaste = !!(options.bracketedPasteMode && terminal?.headlessTerminal?.isBracketedPasteMode());
+		this.writeInput(uri, formatTerminalText(data, { ...options, shouldWrapWithBracketedPaste }));
 	}
 
 	/** Register a callback for PTY data events on a terminal. */

--- a/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
+++ b/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
@@ -459,8 +459,11 @@ export class AgentHostTerminalManager extends Disposable implements IAgentHostTe
 	/** Send formatted text to a terminal's PTY process. */
 	async sendText(uri: string, data: string, options: ISendTextOptions): Promise<void> {
 		const terminal = this._terminals.get(uri);
-		await terminal?.headlessTerminal?.whenPtyDataFlushed();
-		const forceBracketedPasteMode = !!(options.bracketedPasteMode && terminal?.headlessTerminal?.isBracketedPasteMode());
+		let forceBracketedPasteMode = false;
+		if (options.bracketedPasteMode) {
+			await terminal?.headlessTerminal?.whenPtyDataFlushed();
+			forceBracketedPasteMode = !!terminal?.headlessTerminal?.isBracketedPasteMode();
+		}
 		this.writeInput(uri, formatTerminalText(data, { shouldExecute: options.shouldExecute, forceBracketedPasteMode }));
 	}
 

--- a/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
+++ b/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
@@ -54,8 +54,9 @@ export interface ISendTextOptions {
 	bracketedPasteMode?: boolean;
 }
 
-export interface IFormatTerminalTextOptions extends ISendTextOptions {
-	shouldWrapWithBracketedPaste?: boolean;
+export interface IFormatTerminalTextOptions {
+	shouldExecute: boolean;
+	forceBracketedPasteMode?: boolean;
 }
 
 export function removeServerHandledTerminalQueries(data: string, state: ITerminalQueryFilterState): string {
@@ -90,7 +91,7 @@ function getServerHandledTerminalQueryPrefix(data: string): string {
 }
 
 export function formatTerminalText(data: string, options: IFormatTerminalTextOptions): string {
-	if (options.shouldWrapWithBracketedPaste) {
+	if (options.forceBracketedPasteMode) {
 		data = `\x1b[200~${data}\x1b[201~`;
 	}
 	data = data.replace(/\r?\n/g, '\r');
@@ -107,7 +108,7 @@ export interface IAgentHostTerminalManager {
 	readonly _serviceBrand: undefined;
 	createTerminal(params: CreateTerminalParams, options?: { shell?: string; preventShellHistory?: boolean; nonInteractive?: boolean }): Promise<void>;
 	writeInput(uri: string, data: string): void;
-	sendText(uri: string, data: string, options: ISendTextOptions): void;
+	sendText(uri: string, data: string, options: ISendTextOptions): Promise<void>;
 	onData(uri: string, cb: (data: string) => void): IDisposable;
 	onExit(uri: string, cb: (exitCode: number) => void): IDisposable;
 	onClaimChanged(uri: string, cb: (claim: TerminalClaim) => void): IDisposable;
@@ -456,10 +457,11 @@ export class AgentHostTerminalManager extends Disposable implements IAgentHostTe
 	}
 
 	/** Send formatted text to a terminal's PTY process. */
-	sendText(uri: string, data: string, options: ISendTextOptions): void {
+	async sendText(uri: string, data: string, options: ISendTextOptions): Promise<void> {
 		const terminal = this._terminals.get(uri);
-		const shouldWrapWithBracketedPaste = !!(options.bracketedPasteMode && terminal?.headlessTerminal?.isBracketedPasteMode());
-		this.writeInput(uri, formatTerminalText(data, { ...options, shouldWrapWithBracketedPaste }));
+		await terminal?.headlessTerminal?.whenPtyDataFlushed();
+		const forceBracketedPasteMode = !!(options.bracketedPasteMode && terminal?.headlessTerminal?.isBracketedPasteMode());
+		this.writeInput(uri, formatTerminalText(data, { shouldExecute: options.shouldExecute, forceBracketedPasteMode }));
 	}
 
 	/** Register a callback for PTY data events on a terminal. */

--- a/src/vs/platform/agentHost/node/copilot/copilotShellTools.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotShellTools.ts
@@ -283,6 +283,15 @@ export function prefixForHistorySuppression(shellType: ShellType): string {
 	return shellType === 'powershell' ? '' : ' ';
 }
 
+export function isMultilineCommand(command: string): boolean {
+	const normalized = command.replace(/\r\n|\r/g, '\n');
+	return /(?<!\\)\n/.test(normalized);
+}
+
+function shouldUseBracketedPasteMode(command: string): boolean {
+	return platform.isMacintosh || isMultilineCommand(command);
+}
+
 function parseSentinel(content: string, sentinelId: string): { found: boolean; exitCode: number; outputBeforeSentinel: string } {
 	const marker = `${SENTINEL_PREFIX}${sentinelId}_EXIT_`;
 	const idx = content.indexOf(marker);
@@ -352,7 +361,10 @@ async function executeCommandWithShellIntegration(
 ): Promise<ToolResultObject> {
 	const disposables = new DisposableStore();
 
-	terminalManager.sendText(shell.terminalUri, `${prefixForHistorySuppression(shell.shellType)}${command}`, { shouldExecute: true });
+	terminalManager.sendText(shell.terminalUri, `${prefixForHistorySuppression(shell.shellType)}${command}`, {
+		shouldExecute: true,
+		bracketedPasteMode: shouldUseBracketedPasteMode(command),
+	});
 
 	return new Promise<ToolResultObject>(resolve => {
 		let resolved = false;
@@ -421,7 +433,10 @@ async function executeCommandWithSentinel(
 	const contentBefore = terminalManager.getContent(shell.terminalUri) ?? '';
 	const offsetBefore = contentBefore.length;
 
-	terminalManager.sendText(shell.terminalUri, `${prefixForHistorySuppression(shell.shellType)}${command}`, { shouldExecute: true });
+	terminalManager.sendText(shell.terminalUri, `${prefixForHistorySuppression(shell.shellType)}${command}`, {
+		shouldExecute: true,
+		bracketedPasteMode: shouldUseBracketedPasteMode(command),
+	});
 	terminalManager.sendText(shell.terminalUri, sentinelCmd, { shouldExecute: true });
 
 	return new Promise<ToolResultObject>(resolve => {

--- a/src/vs/platform/agentHost/node/copilot/copilotShellTools.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotShellTools.ts
@@ -361,7 +361,7 @@ async function executeCommandWithShellIntegration(
 ): Promise<ToolResultObject> {
 	const disposables = new DisposableStore();
 
-	terminalManager.sendText(shell.terminalUri, `${prefixForHistorySuppression(shell.shellType)}${command}`, {
+	await terminalManager.sendText(shell.terminalUri, `${prefixForHistorySuppression(shell.shellType)}${command}`, {
 		shouldExecute: true,
 		bracketedPasteMode: shouldUseBracketedPasteMode(command),
 	});
@@ -433,11 +433,11 @@ async function executeCommandWithSentinel(
 	const contentBefore = terminalManager.getContent(shell.terminalUri) ?? '';
 	const offsetBefore = contentBefore.length;
 
-	terminalManager.sendText(shell.terminalUri, `${prefixForHistorySuppression(shell.shellType)}${command}`, {
+	await terminalManager.sendText(shell.terminalUri, `${prefixForHistorySuppression(shell.shellType)}${command}`, {
 		shouldExecute: true,
 		bracketedPasteMode: shouldUseBracketedPasteMode(command),
 	});
-	terminalManager.sendText(shell.terminalUri, sentinelCmd, { shouldExecute: true });
+	await terminalManager.sendText(shell.terminalUri, sentinelCmd, { shouldExecute: true });
 
 	return new Promise<ToolResultObject>(resolve => {
 		let resolved = false;
@@ -605,13 +605,13 @@ export async function createShellTools(
 		},
 		overridesBuiltInTool: true,
 		skipPermission: true,
-		handler: (args) => {
+		handler: async (args) => {
 			const shells = shellManager.listShells();
 			const shell = shells[shells.length - 1];
 			if (!shell) {
 				return makeFailureResult('No active shell found.', 'no_shell');
 			}
-			terminalManager.sendText(shell.terminalUri, args.command, { shouldExecute: false });
+			await terminalManager.sendText(shell.terminalUri, args.command, { shouldExecute: false });
 			return makeSuccessResult('Input sent to shell.');
 		},
 	};

--- a/src/vs/platform/agentHost/test/node/agentHostHeadlessTerminal.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostHeadlessTerminal.test.ts
@@ -72,6 +72,16 @@ suite('AgentHostHeadlessTerminal', () => {
 		assert.deepStrictEqual(responses, []);
 	});
 
+	test('tracks bracketed paste mode', async () => {
+		const terminal = createTerminal();
+
+		assert.strictEqual(terminal.isBracketedPasteMode(), false);
+		await terminal.writePtyData('\x1b[?2004h');
+		assert.strictEqual(terminal.isBracketedPasteMode(), true);
+		await terminal.writePtyData('\x1b[?2004l');
+		assert.strictEqual(terminal.isBracketedPasteMode(), false);
+	});
+
 	test('ignores writes after dispose', async () => {
 		const terminal = createTerminal();
 		const responses: string[] = [];

--- a/src/vs/platform/agentHost/test/node/agentHostTerminalManager.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTerminalManager.test.ts
@@ -258,8 +258,8 @@ suite('AgentHostTerminalManager – command detection integration', () => {
 		assert.strictEqual(formatTerminalText('echo first\r', { shouldExecute: true }), 'echo first\r');
 		assert.strictEqual(formatTerminalText('answer\n', { shouldExecute: false }), 'answer\r');
 		assert.strictEqual(formatTerminalText('/tmp/foo\npwd', { shouldExecute: true }), '/tmp/foo\rpwd\r');
-		assert.strictEqual(formatTerminalText('echo first\necho second', { shouldExecute: true, shouldWrapWithBracketedPaste: true }), '\x1b[200~echo first\recho second\x1b[201~\r');
-		assert.strictEqual(formatTerminalText('answer\n', { shouldExecute: false, shouldWrapWithBracketedPaste: true }), '\x1b[200~answer\r\x1b[201~');
+		assert.strictEqual(formatTerminalText('echo first\necho second', { shouldExecute: true, forceBracketedPasteMode: true }), '\x1b[200~echo first\recho second\x1b[201~\r');
+		assert.strictEqual(formatTerminalText('answer\n', { shouldExecute: false, forceBracketedPasteMode: true }), '\x1b[200~answer\r\x1b[201~');
 	});
 
 	test('writes formatted command input to the PTY', async () => {
@@ -282,7 +282,7 @@ suite('AgentHostTerminalManager – command detection integration', () => {
 		pty.fireData('prompt');
 		await createTerminal;
 
-		manager.sendText('agenthost-terminal://test/command-input', 'echo first\necho second', { shouldExecute: true });
+		await manager.sendText('agenthost-terminal://test/command-input', 'echo first\necho second', { shouldExecute: true });
 
 		assert.deepStrictEqual(pty.writes, ['echo first\recho second\r']);
 	});
@@ -306,9 +306,8 @@ suite('AgentHostTerminalManager – command detection integration', () => {
 		await pty.dataListenerRegistered.p;
 		pty.fireData('\x1b[?2004h');
 		await createTerminal;
-		await timeout(10);
 
-		manager.sendText('agenthost-terminal://test/bracketed-paste', 'echo first\necho second', { shouldExecute: true, bracketedPasteMode: true });
+		await manager.sendText('agenthost-terminal://test/bracketed-paste', 'echo first\necho second', { shouldExecute: true, bracketedPasteMode: true });
 
 		assert.deepStrictEqual(pty.writes, ['\x1b[200~echo first\recho second\x1b[201~\r']);
 	});
@@ -333,7 +332,7 @@ suite('AgentHostTerminalManager – command detection integration', () => {
 		pty.fireData('prompt');
 		await createTerminal;
 
-		manager.sendText('agenthost-terminal://test/bracketed-paste-disabled', 'echo first\necho second', { shouldExecute: true, bracketedPasteMode: true });
+		await manager.sendText('agenthost-terminal://test/bracketed-paste-disabled', 'echo first\necho second', { shouldExecute: true, bracketedPasteMode: true });
 
 		assert.deepStrictEqual(pty.writes, ['echo first\recho second\r']);
 	});

--- a/src/vs/platform/agentHost/test/node/agentHostTerminalManager.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTerminalManager.test.ts
@@ -258,6 +258,8 @@ suite('AgentHostTerminalManager – command detection integration', () => {
 		assert.strictEqual(formatTerminalText('echo first\r', { shouldExecute: true }), 'echo first\r');
 		assert.strictEqual(formatTerminalText('answer\n', { shouldExecute: false }), 'answer\r');
 		assert.strictEqual(formatTerminalText('/tmp/foo\npwd', { shouldExecute: true }), '/tmp/foo\rpwd\r');
+		assert.strictEqual(formatTerminalText('echo first\necho second', { shouldExecute: true, shouldWrapWithBracketedPaste: true }), '\x1b[200~echo first\recho second\x1b[201~\r');
+		assert.strictEqual(formatTerminalText('answer\n', { shouldExecute: false, shouldWrapWithBracketedPaste: true }), '\x1b[200~answer\r\x1b[201~');
 	});
 
 	test('writes formatted command input to the PTY', async () => {
@@ -281,6 +283,57 @@ suite('AgentHostTerminalManager – command detection integration', () => {
 		await createTerminal;
 
 		manager.sendText('agenthost-terminal://test/command-input', 'echo first\necho second', { shouldExecute: true });
+
+		assert.deepStrictEqual(pty.writes, ['echo first\recho second\r']);
+	});
+
+	test('writes bracketed paste command input when enabled by the terminal', async () => {
+		const logService = new NullLogService();
+		const stateManager = disposables.add(new AgentHostStateManager(logService));
+		const configurationService = disposables.add(new AgentConfigurationService(stateManager, logService));
+		const productService = { _serviceBrand: undefined, applicationName: 'vscode' } as IProductService;
+		const pty = new TestPty();
+		const manager = disposables.add(new TestAgentHostTerminalManager(stateManager, logService, productService, configurationService, pty));
+
+		const createTerminal = manager.createTerminal({
+			terminal: 'agenthost-terminal://test/bracketed-paste',
+			claim: { kind: TerminalClaimKind.Client, clientId: 'test-client' },
+			cwd: process.cwd(),
+			cols: 80,
+			rows: 24,
+		}, { shell: '/bin/bash' });
+
+		await pty.dataListenerRegistered.p;
+		pty.fireData('\x1b[?2004h');
+		await createTerminal;
+		await timeout(10);
+
+		manager.sendText('agenthost-terminal://test/bracketed-paste', 'echo first\necho second', { shouldExecute: true, bracketedPasteMode: true });
+
+		assert.deepStrictEqual(pty.writes, ['\x1b[200~echo first\recho second\x1b[201~\r']);
+	});
+
+	test('does not write bracketed paste command input when disabled by the terminal', async () => {
+		const logService = new NullLogService();
+		const stateManager = disposables.add(new AgentHostStateManager(logService));
+		const configurationService = disposables.add(new AgentConfigurationService(stateManager, logService));
+		const productService = { _serviceBrand: undefined, applicationName: 'vscode' } as IProductService;
+		const pty = new TestPty();
+		const manager = disposables.add(new TestAgentHostTerminalManager(stateManager, logService, productService, configurationService, pty));
+
+		const createTerminal = manager.createTerminal({
+			terminal: 'agenthost-terminal://test/bracketed-paste-disabled',
+			claim: { kind: TerminalClaimKind.Client, clientId: 'test-client' },
+			cwd: process.cwd(),
+			cols: 80,
+			rows: 24,
+		}, { shell: '/bin/bash' });
+
+		await pty.dataListenerRegistered.p;
+		pty.fireData('prompt');
+		await createTerminal;
+
+		manager.sendText('agenthost-terminal://test/bracketed-paste-disabled', 'echo first\necho second', { shouldExecute: true, bracketedPasteMode: true });
 
 		assert.deepStrictEqual(pty.writes, ['echo first\recho second\r']);
 	});

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -86,7 +86,7 @@ class TestAgentHostTerminalManager implements IAgentHostTerminalManager {
 
 	async createTerminal(): Promise<void> { }
 	writeInput(): void { }
-	sendText(): void { }
+	async sendText(): Promise<void> { }
 	onData(): IDisposable { return Disposable.None; }
 	onExit(): IDisposable { return Disposable.None; }
 	onClaimChanged(): IDisposable { return Disposable.None; }

--- a/src/vs/platform/agentHost/test/node/copilotShellTools.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotShellTools.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import type { ToolInvocation, ToolResultObject } from '@github/copilot-sdk';
-import { timeout } from '../../../../base/common/async.js';
+import { DeferredPromise } from '../../../../base/common/async.js';
 import { URI } from '../../../../base/common/uri.js';
 import * as platform from '../../../../base/common/platform.js';
 import { Emitter } from '../../../../base/common/event.js';
@@ -29,6 +29,7 @@ class TestAgentHostTerminalManager implements IAgentHostTerminalManager {
 	readonly sentTexts: { uri: string; data: string; options: ISendTextOptions }[] = [];
 	readonly existingTerminalUris = new Set<string>();
 	commandDetectionSupported = false;
+	readonly commandFinishedListenerRegistered = new DeferredPromise<void>();
 	private readonly _onCommandFinished = new Emitter<ICommandFinishedEvent>();
 
 	async createTerminal(params: CreateTerminalParams, options?: { shell?: string; preventShellHistory?: boolean; nonInteractive?: boolean }): Promise<void> {
@@ -37,14 +38,17 @@ class TestAgentHostTerminalManager implements IAgentHostTerminalManager {
 	writeInput(uri: string, data: string): void {
 		this.writes.push({ uri, data });
 	}
-	sendText(uri: string, data: string, options: ISendTextOptions): void {
+	async sendText(uri: string, data: string, options: ISendTextOptions): Promise<void> {
 		this.sentTexts.push({ uri, data, options });
 		this.writeInput(uri, formatTerminalText(data, options));
 	}
 	onData(): IDisposable { return Disposable.None; }
 	onExit(): IDisposable { return Disposable.None; }
 	onClaimChanged(): IDisposable { return Disposable.None; }
-	onCommandFinished(_uri: string, cb: (event: ICommandFinishedEvent) => void): IDisposable { return this._onCommandFinished.event(cb); }
+	onCommandFinished(_uri: string, cb: (event: ICommandFinishedEvent) => void): IDisposable {
+		this.commandFinishedListenerRegistered.complete();
+		return this._onCommandFinished.event(cb);
+	}
 	getContent(): string | undefined { return undefined; }
 	getClaim(): TerminalClaim | undefined { return undefined; }
 	hasTerminal(uri: string): boolean { return this.existingTerminalUris.has(uri); }
@@ -205,7 +209,7 @@ suite('CopilotShellTools', () => {
 			arguments: { command: 'echo first\necho second', timeout: 1000 },
 		};
 		const resultPromise = bashTool.handler({ command: 'echo first\necho second', timeout: 1000 }, invocation) as Promise<ToolResultObject>;
-		await timeout(10);
+		await terminalManager.commandFinishedListenerRegistered.p;
 		terminalManager.fireCommandFinished({ commandId: 'cmd-1', exitCode: 0, command: 'echo first\necho second', output: 'first\nsecond' });
 		const result = await resultPromise;
 
@@ -256,7 +260,7 @@ suite('CopilotShellTools', () => {
 			toolName: 'write_bash',
 			arguments: { command: 'answer\n' },
 		};
-		const result = writeTool.handler({ command: 'answer\n' }, invocation) as ToolResultObject;
+		const result = await writeTool.handler({ command: 'answer\n' }, invocation) as ToolResultObject;
 
 		assert.strictEqual(result.resultType, 'success');
 		assert.strictEqual(terminalManager.sentTexts[0].options.bracketedPasteMode, undefined);

--- a/src/vs/platform/agentHost/test/node/copilotShellTools.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotShellTools.test.ts
@@ -5,7 +5,10 @@
 
 import assert from 'assert';
 import type { ToolInvocation, ToolResultObject } from '@github/copilot-sdk';
+import { timeout } from '../../../../base/common/async.js';
 import { URI } from '../../../../base/common/uri.js';
+import * as platform from '../../../../base/common/platform.js';
+import { Emitter } from '../../../../base/common/event.js';
 import { Disposable, DisposableStore, type IDisposable } from '../../../../base/common/lifecycle.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { IInstantiationService } from '../../../instantiation/common/instantiation.js';
@@ -14,8 +17,8 @@ import { ServiceCollection } from '../../../instantiation/common/serviceCollecti
 import { ILogService, NullLogService } from '../../../log/common/log.js';
 import type { CreateTerminalParams } from '../../common/state/protocol/commands.js';
 import type { TerminalClaim, TerminalInfo } from '../../common/state/protocol/state.js';
-import { formatTerminalText, IAgentHostTerminalManager, type ISendTextOptions } from '../../node/agentHostTerminalManager.js';
-import { createShellTools, ShellManager, prefixForHistorySuppression, shellTypeForExecutable } from '../../node/copilot/copilotShellTools.js';
+import { formatTerminalText, IAgentHostTerminalManager, type ICommandFinishedEvent, type ISendTextOptions } from '../../node/agentHostTerminalManager.js';
+import { createShellTools, isMultilineCommand, ShellManager, prefixForHistorySuppression, shellTypeForExecutable } from '../../node/copilot/copilotShellTools.js';
 
 class TestAgentHostTerminalManager implements IAgentHostTerminalManager {
 	declare readonly _serviceBrand: undefined;
@@ -23,7 +26,10 @@ class TestAgentHostTerminalManager implements IAgentHostTerminalManager {
 	defaultShell = '/bin/bash';
 	readonly created: { params: CreateTerminalParams; options?: { shell?: string; preventShellHistory?: boolean; nonInteractive?: boolean } }[] = [];
 	readonly writes: { uri: string; data: string }[] = [];
+	readonly sentTexts: { uri: string; data: string; options: ISendTextOptions }[] = [];
 	readonly existingTerminalUris = new Set<string>();
+	commandDetectionSupported = false;
+	private readonly _onCommandFinished = new Emitter<ICommandFinishedEvent>();
 
 	async createTerminal(params: CreateTerminalParams, options?: { shell?: string; preventShellHistory?: boolean; nonInteractive?: boolean }): Promise<void> {
 		this.created.push({ params, options: { ...options, shell: options?.shell ?? this.defaultShell } });
@@ -32,21 +38,23 @@ class TestAgentHostTerminalManager implements IAgentHostTerminalManager {
 		this.writes.push({ uri, data });
 	}
 	sendText(uri: string, data: string, options: ISendTextOptions): void {
+		this.sentTexts.push({ uri, data, options });
 		this.writeInput(uri, formatTerminalText(data, options));
 	}
 	onData(): IDisposable { return Disposable.None; }
 	onExit(): IDisposable { return Disposable.None; }
 	onClaimChanged(): IDisposable { return Disposable.None; }
-	onCommandFinished(): IDisposable { return Disposable.None; }
+	onCommandFinished(_uri: string, cb: (event: ICommandFinishedEvent) => void): IDisposable { return this._onCommandFinished.event(cb); }
 	getContent(): string | undefined { return undefined; }
 	getClaim(): TerminalClaim | undefined { return undefined; }
 	hasTerminal(uri: string): boolean { return this.existingTerminalUris.has(uri); }
 	getExitCode(): number | undefined { return undefined; }
-	supportsCommandDetection(): boolean { return false; }
+	supportsCommandDetection(): boolean { return this.commandDetectionSupported; }
 	disposeTerminal(): void { }
 	getTerminalInfos(): TerminalInfo[] { return []; }
 	getTerminalState(): undefined { return undefined; }
 	async getDefaultShell(): Promise<string> { return this.defaultShell; }
+	fireCommandFinished(event: ICommandFinishedEvent): void { this._onCommandFinished.fire(event); }
 }
 
 suite('CopilotShellTools', () => {
@@ -176,8 +184,61 @@ suite('CopilotShellTools', () => {
 		const result = await bashTool.handler({ command: 'echo first\necho second', timeout: 1 }, invocation) as ToolResultObject;
 
 		assert.strictEqual(result.resultType, 'failure');
+		assert.strictEqual(terminalManager.sentTexts[0].options.bracketedPasteMode, true);
+		assert.strictEqual(terminalManager.sentTexts[1].options.bracketedPasteMode, undefined);
 		assert.strictEqual(terminalManager.writes[0].data, ' echo first\recho second\r');
 		assert.match(terminalManager.writes[1].data, /^echo "<<<COPILOT_SENTINEL_[a-f0-9]+_EXIT_\$\?>>>"\r$/);
+	});
+
+	test('primary shell tool forces bracketed paste with shell integration', async () => {
+		const { instantiationService, terminalManager } = createServices();
+		terminalManager.commandDetectionSupported = true;
+		const shellManager = disposables.add(instantiationService.createInstance(ShellManager, URI.parse('copilot:/session-1'), undefined));
+		const tools = await createShellTools(shellManager, terminalManager, new NullLogService());
+		const bashTool = tools.find(tool => tool.name === 'bash');
+		assert.ok(bashTool);
+
+		const invocation: ToolInvocation = {
+			sessionId: 'session-1',
+			toolCallId: 'tool-1',
+			toolName: 'bash',
+			arguments: { command: 'echo first\necho second', timeout: 1000 },
+		};
+		const resultPromise = bashTool.handler({ command: 'echo first\necho second', timeout: 1000 }, invocation) as Promise<ToolResultObject>;
+		await timeout(10);
+		terminalManager.fireCommandFinished({ commandId: 'cmd-1', exitCode: 0, command: 'echo first\necho second', output: 'first\nsecond' });
+		const result = await resultPromise;
+
+		assert.strictEqual(result.resultType, 'success');
+		assert.strictEqual(terminalManager.sentTexts.length, 1);
+		assert.strictEqual(terminalManager.sentTexts[0].options.bracketedPasteMode, true);
+		assert.strictEqual(terminalManager.writes[0].data, ' echo first\recho second\r');
+	});
+
+	test('primary shell tool only forces bracketed paste for single-line commands on macOS', async () => {
+		const { instantiationService, terminalManager } = createServices();
+		const shellManager = disposables.add(instantiationService.createInstance(ShellManager, URI.parse('copilot:/session-1'), undefined));
+		const tools = await createShellTools(shellManager, terminalManager, new NullLogService());
+		const bashTool = tools.find(tool => tool.name === 'bash');
+		assert.ok(bashTool);
+
+		const invocation: ToolInvocation = {
+			sessionId: 'session-1',
+			toolCallId: 'tool-1',
+			toolName: 'bash',
+			arguments: { command: 'echo first', timeout: 1 },
+		};
+		const result = await bashTool.handler({ command: 'echo first', timeout: 1 }, invocation) as ToolResultObject;
+
+		assert.strictEqual(result.resultType, 'failure');
+		assert.strictEqual(terminalManager.sentTexts[0].options.bracketedPasteMode, platform.isMacintosh);
+		assert.strictEqual(terminalManager.sentTexts[1].options.bracketedPasteMode, undefined);
+	});
+
+	test('detects multiline commands like the workbench terminal tool', () => {
+		assert.strictEqual(isMultilineCommand('echo first\necho second'), true);
+		assert.strictEqual(isMultilineCommand('echo first\r\necho second'), true);
+		assert.strictEqual(isMultilineCommand('echo first\\\necho second'), false);
 	});
 
 	test('write shell tool normalizes input without appending enter', async () => {
@@ -198,6 +259,7 @@ suite('CopilotShellTools', () => {
 		const result = writeTool.handler({ command: 'answer\n' }, invocation) as ToolResultObject;
 
 		assert.strictEqual(result.resultType, 'success');
+		assert.strictEqual(terminalManager.sentTexts[0].options.bracketedPasteMode, undefined);
 		assert.strictEqual(terminalManager.writes[0].uri, shellRef.object.terminalUri);
 		assert.strictEqual(terminalManager.writes[0].data, 'answer\r');
 		shellRef.dispose();


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/312922
Part of: https://github.com/microsoft/vscode/issues/314189
<img width="500" height="600" alt="Screenshot 2026-05-12 at 1 11 03 PM" src="https://github.com/user-attachments/assets/7fb399c5-8f22-48f7-88d5-47ace5f4be5a" />


- Add bracketed paste mode tracking to Agent Host's headless xterm mirror.
- Extend Agent Host `sendText` so callers can request bracketed paste wrapping.
- Wrap text with `\x1b[200~...\x1b[201~` only when requested and xterm/headless reports bracketed paste mode is enabled.
- Keep the existing `sendText` ordering: bracketed paste wrapping, then `\r?\n -> \r` normalization, then optional final Enter.
- Force bracketed paste for Agent Host shell commands when the command is multiline, or on macOS, matching workbench terminal command execution policy.
- Keep Agent Host `sendText` promise-shaped like workbench `TerminalInstance.sendText`, which awaits `_processManager.write(...)` before completing.

Notable: Agent Host updates its server-side headless xterm mirror asynchronously from PTY output, so `sendText` only waits on the bracketed-paste path for already-received PTY data to flush before checking `bracketedPasteMode`; otherwise it could miss a just-emitted `\x1b[?2004h` and send multiline input without bracketed paste wrapping.

-----------------------------------------
Inspirations from:

- `sendText` API naming and intent comes from [`ITerminalInstance.sendText(..., bracketedPasteMode?)`](https://github.com/microsoft/vscode/blob/6a252b13fe9094f9b0d6e8eafbdf50aa70e110c4/src/vs/workbench/contrib/terminal/browser/terminal.ts#L1164-L1175).
- Bracketed paste wrapping and formatting order comes from [`TerminalInstance.sendText`](https://github.com/microsoft/vscode/blob/6a252b13fe9094f9b0d6e8eafbdf50aa70e110c4/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts#L1372-L1383).
- The promise-shaped `sendText` behavior comes from [`TerminalInstance.sendText`](https://github.com/microsoft/vscode/blob/6a252b13fe9094f9b0d6e8eafbdf50aa70e110c4/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts#L1372-L1387), which returns `Promise<void>` and awaits `_processManager.write(text)`.
- The fallback `runCommand` behavior that opts into bracketed paste for non-executing text, or when explicitly requested, comes from [`TerminalInstance.runCommand`](https://github.com/microsoft/vscode/blob/6a252b13fe9094f9b0d6e8eafbdf50aa70e110c4/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts#L995-L1044).
- The multiline-command test is copied semantically from [`isMultilineCommand`](https://github.com/microsoft/vscode/blob/6a252b13fe9094f9b0d6e8eafbdf50aa70e110c4/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalHelpers.ts#L100-L105).
- The `isMacintosh || isMultilineCommand(commandLine)` policy comes from the terminal chat execute strategies: [`basicExecuteStrategy`](https://github.com/microsoft/vscode/blob/6a252b13fe9094f9b0d6e8eafbdf50aa70e110c4/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/basicExecuteStrategy.ts#L220-L223) and [`richExecuteStrategy`](https://github.com/microsoft/vscode/blob/6a252b13fe9094f9b0d6e8eafbdf50aa70e110c4/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/richExecuteStrategy.ts#L176-L179).

/cc @meganrogge @connor4312 
