### PR TITLE
actionWidget: keep dynamic lists aligned with anchor

### DIFF
--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -142,6 +142,10 @@ export const enum ActionListItemKind {
 	Separator = 'separator'
 }
 
+// Matches the .action-widget vertical padding and border so the context view
+// does not overlap its anchor and trigger horizontal anchor avoidance.
+const ACTION_WIDGET_VERTICAL_CHROME_HEIGHT = 10;
+
 interface IHeaderTemplateData {
 	readonly container: HTMLElement;
 	readonly text: HTMLElement;
@@ -1875,7 +1879,7 @@ export class ActionList<T> extends Disposable {
 				const fullHeight = chromeHeight + this._widget.computeFullHeight();
 				this._showAbove = fullHeight > spaceBelow && spaceAbove > spaceBelow;
 			}
-			availableHeight = this._showAbove ? spaceAbove : spaceBelow;
+			availableHeight = Math.max(0, (this._showAbove ? spaceAbove : spaceBelow) - ACTION_WIDGET_VERTICAL_CHROME_HEIGHT);
 		} else {
 			const padding = 10;
 			const windowHeight = this._layoutService.getContainer(targetWindow).clientHeight;

--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -142,10 +142,6 @@ export const enum ActionListItemKind {
 	Separator = 'separator'
 }
 
-// Matches the .action-widget vertical padding and border so the context view
-// does not overlap its anchor and trigger horizontal anchor avoidance.
-const ACTION_WIDGET_VERTICAL_CHROME_HEIGHT = 10;
-
 interface IHeaderTemplateData {
 	readonly container: HTMLElement;
 	readonly text: HTMLElement;
@@ -1855,6 +1851,17 @@ export class ActionList<T> extends Disposable {
 		return this._widget.hasDynamicHeight;
 	}
 
+	private computeActionWidgetVerticalChromeHeight(): number {
+		const widgetContainer = this.domNode.parentElement?.closest('.action-widget');
+		if (!widgetContainer) {
+			return 0;
+		}
+
+		const style = dom.getWindow(widgetContainer).getComputedStyle(widgetContainer);
+		const toPixels = (value: string): number => Number.parseFloat(value) || 0;
+		return toPixels(style.paddingTop) + toPixels(style.paddingBottom) + toPixels(style.borderTopWidth) + toPixels(style.borderBottomWidth);
+	}
+
 	private computeHeight(): number {
 		const listHeight = this._widget.computeListHeight();
 
@@ -1879,7 +1886,7 @@ export class ActionList<T> extends Disposable {
 				const fullHeight = chromeHeight + this._widget.computeFullHeight();
 				this._showAbove = fullHeight > spaceBelow && spaceAbove > spaceBelow;
 			}
-			availableHeight = Math.max(0, (this._showAbove ? spaceAbove : spaceBelow) - ACTION_WIDGET_VERTICAL_CHROME_HEIGHT);
+			availableHeight = Math.max(0, (this._showAbove ? spaceAbove : spaceBelow) - this.computeActionWidgetVerticalChromeHeight());
 		} else {
 			const padding = 10;
 			const windowHeight = this._layoutService.getContainer(targetWindow).clientHeight;

--- a/src/vs/platform/actionWidget/test/browser/actionList.test.ts
+++ b/src/vs/platform/actionWidget/test/browser/actionList.test.ts
@@ -4,18 +4,22 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { mainWindow } from '../../../../base/browser/window.js';
 import { DeferredPromise, timeout } from '../../../../base/common/async.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { Event as CommonEvent } from '../../../../base/common/event.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { runWithFakedTimers } from '../../../../base/test/common/timeTravelScheduler.js';
+import { IContextViewService } from '../../../contextview/browser/contextView.js';
 import { IHoverService } from '../../../hover/browser/hover.js';
 import { NullHoverService } from '../../../hover/test/browser/nullHoverService.js';
 import { TestInstantiationService } from '../../../instantiation/test/common/instantiationServiceMock.js';
 import { MockKeybindingService } from '../../../keybinding/test/common/mockKeybindingService.js';
 import { IKeybindingService } from '../../../keybinding/common/keybinding.js';
+import { ILayoutService } from '../../../layout/browser/layoutService.js';
 import { IOpenerService } from '../../../opener/common/opener.js';
 import { NullOpenerService } from '../../../opener/test/common/nullOpenerService.js';
-import { ActionListItemKind, ActionListWidget, IActionListItem } from '../../browser/actionList.js';
+import { ActionList, ActionListItemKind, ActionListWidget, IActionListItem } from '../../browser/actionList.js';
 
 interface ITestActionItem {
 	readonly id: string;
@@ -79,6 +83,63 @@ function getVisibleRowText(widget: ActionListWidget<ITestActionItem>): string[] 
 	return Array.from(widget.domNode.querySelectorAll<HTMLElement>('.monaco-list-row'))
 		.map(row => row.textContent ?? '')
 		.filter(text => text.length > 0);
+}
+
+function withWindowInnerHeight<T>(height: number, callback: () => T): T {
+	const originalInnerHeight = mainWindow.innerHeight;
+	Object.defineProperty(mainWindow, 'innerHeight', { configurable: true, value: height });
+	try {
+		return callback();
+	} finally {
+		Object.defineProperty(mainWindow, 'innerHeight', { configurable: true, value: originalInnerHeight });
+	}
+}
+
+function createActionList(disposables: ReturnType<typeof ensureNoDisposablesAreLeakedInTestSuite>, items: readonly IActionListItem<ITestActionItem>[]): ActionList<ITestActionItem> {
+	const instantiationService = disposables.add(new TestInstantiationService());
+	instantiationService.set(IKeybindingService, new MockKeybindingService());
+	instantiationService.set(IHoverService, NullHoverService);
+	instantiationService.set(IOpenerService, NullOpenerService);
+	instantiationService.stub(IContextViewService, {
+		layout: () => { },
+		hideContextView: () => { },
+		getContextViewElement: () => document.body,
+	} as Partial<IContextViewService> as IContextViewService);
+	instantiationService.stub(ILayoutService, {
+		getContainer: () => document.body,
+		mainContainer: document.body,
+		activeContainer: document.body,
+		onDidLayoutMainContainer: CommonEvent.None,
+		onDidLayoutContainer: CommonEvent.None,
+		onDidLayoutActiveContainer: CommonEvent.None,
+		onDidAddContainer: CommonEvent.None,
+		onDidChangeActiveContainer: CommonEvent.None,
+	} as Partial<ILayoutService> as ILayoutService);
+
+	const list = disposables.add(instantiationService.createInstance(
+		ActionList<ITestActionItem>,
+		'testActionList',
+		false,
+		items,
+		{
+			onHide: () => { },
+			onSelect: () => { },
+		},
+		undefined,
+		{ showFilter: true },
+		{ x: 10, y: 150, width: 20, height: 20 },
+	));
+
+	const widget = document.createElement('div');
+	widget.classList.add('action-widget');
+	document.body.appendChild(widget);
+	disposables.add({ dispose: () => widget.remove() });
+	if (list.filterContainer) {
+		widget.appendChild(list.filterContainer);
+	}
+	widget.appendChild(list.domNode);
+
+	return list;
 }
 
 suite('ActionListWidget', () => {
@@ -155,4 +216,16 @@ suite('ActionListWidget', () => {
 
 		assert.deepStrictEqual(getVisibleRowText(widget), ['Provider B', 'beta']);
 	});
+
+	test('leaves room for action widget chrome when clamping dynamic height', () => withWindowInnerHeight(300, () => {
+		const list = createActionList(disposables, Array.from({ length: 50 }, (_, i) => action(`item-${i}`)));
+
+		list.layout(200);
+
+		const filterHeight = 36;
+		const actionWidgetVerticalChromeHeight = 10;
+		const availableSpaceAboveAnchor = 150;
+		const listHeight = parseFloat(list.domNode.style.height);
+		assert.ok(listHeight + filterHeight + actionWidgetVerticalChromeHeight <= availableSpaceAboveAnchor);
+	}));
 });

--- a/src/vs/platform/actionWidget/test/browser/actionList.test.ts
+++ b/src/vs/platform/actionWidget/test/browser/actionList.test.ts
@@ -86,12 +86,16 @@ function getVisibleRowText(widget: ActionListWidget<ITestActionItem>): string[] 
 }
 
 function withWindowInnerHeight<T>(height: number, callback: () => T): T {
-	const originalInnerHeight = mainWindow.innerHeight;
+	const originalDescriptor = Object.getOwnPropertyDescriptor(mainWindow, 'innerHeight');
 	Object.defineProperty(mainWindow, 'innerHeight', { configurable: true, value: height });
 	try {
 		return callback();
 	} finally {
-		Object.defineProperty(mainWindow, 'innerHeight', { configurable: true, value: originalInnerHeight });
+		if (originalDescriptor) {
+			Object.defineProperty(mainWindow, 'innerHeight', originalDescriptor);
+		} else {
+			Reflect.deleteProperty(mainWindow, 'innerHeight');
+		}
 	}
 }
 
@@ -223,7 +227,10 @@ suite('ActionListWidget', () => {
 		list.layout(200);
 
 		const filterHeight = 36;
-		const actionWidgetVerticalChromeHeight = 10;
+		const widget = list.domNode.parentElement!;
+		const style = mainWindow.getComputedStyle(widget);
+		const toPixels = (value: string): number => Number.parseFloat(value) || 0;
+		const actionWidgetVerticalChromeHeight = toPixels(style.paddingTop) + toPixels(style.paddingBottom) + toPixels(style.borderTopWidth) + toPixels(style.borderBottomWidth);
 		const availableSpaceAboveAnchor = 150;
 		const listHeight = parseFloat(list.domNode.style.height);
 		assert.ok(listHeight + filterHeight + actionWidgetVerticalChromeHeight <= availableSpaceAboveAnchor);


### PR DESCRIPTION
## Summary

Fixes https://github.com/microsoft/vscode/issues/314460

Fixes dynamic action widget lists so expanding collapsible sections, such as the chat model picker&#39;s &#34;Other Models&#34; section, does not shift the context menu horizontally away from its anchor.

The action list now accounts for the rendered action widget&#39;s vertical padding and border when clamping available height. This prevents the context view from seeing the popup as overlapping its anchor and applying horizontal anchor avoidance.

This was first visible in the Agents new-chat view because of its geometry: the new-chat card is vertically centered, and the model picker sits in the bottom controls row of that centered card. That places the picker anchor around mid-window, where the expanded menu often chooses to open above but only has roughly half the viewport available. Regular VS Code chat usually anchors the same picker low enough that the popup fits above the button, so it does not commonly hit this overlap/avoidance path. The underlying issue is still in the shared popup height math, so the fix lives in the shared action widget and derives the widget chrome from computed styles instead of hard-coding CSS values.

Before:

https://github.com/user-attachments/assets/53426d1d-6e15-4147-9faf-c193cca1d6ea

After:

Menu does not shift to the right when Other Models are toggled to be visible

## Validation

- `npm run compile-check-ts-native`
- `node --experimental-strip-types build/hygiene.ts src/vs/platform/actionWidget/browser/actionList.ts src/vs/platform/actionWidget/test/browser/actionList.test.ts`
- `env -u ELECTRON_RUN_AS_NODE ./scripts/test.sh --run src/vs/platform/actionWidget/test/browser/actionList.test.ts`