### PR TITLE
Fix Pooled Entitlement UI exhaustion states and organisational warnings

### DIFF
--- a/extensions/copilot/src/extension/chatInputNotification/vscode-node/chatInputNotification.contribution.ts
+++ b/extensions/copilot/src/extension/chatInputNotification/vscode-node/chatInputNotification.contribution.ts
@@ -192,7 +192,11 @@ export class ChatInputNotificationContribution extends Disposable {
 				{ label: vscode.l10n.t('Upgrade'), commandId: 'workbench.action.chat.upgradePlan' },
 			];
 		} else if (isManagedPlan) {
-			notification.description = vscode.l10n.t('Contact your admin to increase your limits.');
+			if (this._authService.copilotToken?.isUsageBasedBilling) {
+				notification.description = vscode.l10n.t('Your organization has used all included credits. Contact your admin to enable overages or wait for your next billing cycle.');
+			} else {
+				notification.description = vscode.l10n.t('Contact your admin to increase your limits.');
+			}
 			notification.actions = [];
 		} else if (hadOverage) {
 			notification.description = vscode.l10n.t('Increase your budget to keep building.');

--- a/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
@@ -193,6 +193,7 @@ export class ChatSubmitAction extends SubmitAction {
 			ChatContextKeys.inputHasText,
 			ContextKeyExpr.or(whenNotInProgress, ChatContextKeys.editingRequestType.isEqualTo(ChatContextKeys.EditingRequestType.Sent)),
 			ChatContextKeys.chatSessionOptionsValid,
+			ChatContextKeys.chatQuotaExceeded.negate(),
 		);
 
 		super({
@@ -744,7 +745,8 @@ export class ChatEditingSessionSubmitAction extends SubmitAction {
 		const precondition = ContextKeyExpr.and(
 			ChatContextKeys.inputHasText,
 			notInProgressOrEditing,
-			ChatContextKeys.chatSessionOptionsValid
+			ChatContextKeys.chatSessionOptionsValid,
+			ChatContextKeys.chatQuotaExceeded.negate(),
 		);
 
 		super({

--- a/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.ts
@@ -677,6 +677,7 @@ export class ChatStatusDashboard extends DomWidget {
 	private createQuotaIndicator(container: HTMLElement, quota: IQuotaSnapshot | string, label: string, resetLabel?: string): (quota: IQuotaSnapshot | string) => void {
 		const quotaValue = $('span.quota-value');
 		const quotaValueSuffix = $('span.quota-value-suffix');
+		const quotaExhausted = $('span.quota-exhausted');
 		const quotaBit = $('div.quota-bit');
 		const resetValue = $('span.quota-reset');
 
@@ -686,7 +687,8 @@ export class ChatStatusDashboard extends DomWidget {
 
 		const quotaPercentage = $('div.quota-percentage', undefined,
 			quotaValue,
-			quotaValueSuffix
+			quotaValueSuffix,
+			quotaExhausted
 		);
 		quotaPercentage.tabIndex = 0;
 
@@ -735,16 +737,30 @@ export class ChatStatusDashboard extends DomWidget {
 			currentQuota = quota;
 
 			let usedPercentage: number;
+			let isExhausted = false;
 			if (typeof quota === 'string') {
 				usedPercentage = 0;
 			} else {
 				usedPercentage = Math.max(0, 100 - quota.percentRemaining);
+				isExhausted = quota.percentRemaining === 0 && !this.chatEntitlementService.quotas.additionalUsageEnabled;
 			}
 
-			if (isHovered) {
-				showCredits();
+			if (isExhausted) {
+				quotaValue.style.display = 'none';
+				quotaValueSuffix.style.display = 'none';
+				quotaExhausted.style.display = '';
+				quotaExhausted.textContent = localize('quotaExhausted', "Exhausted");
+				quotaBit.classList.add('exhausted');
 			} else {
-				showPercentage();
+				quotaValue.style.display = '';
+				quotaValueSuffix.style.display = '';
+				quotaExhausted.style.display = 'none';
+				quotaBit.classList.remove('exhausted');
+				if (isHovered) {
+					showCredits();
+				} else {
+					showPercentage();
+				}
 			}
 			quotaBit.style.width = `${usedPercentage}%`;
 		};
@@ -791,9 +807,13 @@ export class ChatStatusDashboard extends DomWidget {
 				quotaCallout.style.display = '';
 				quotaCallout.className = 'quota-callout info';
 				calloutIcon.className = `callout-icon ${ThemeIcon.asClassName(Codicon.info)}`;
-				calloutText.textContent = isEnterpriseUser
-					? localize('quotaPausedEnterprise', "Copilot is paused until the limit resets. Contact your administrator for more information.")
-					: localize('quotaPaused', "Copilot is paused until the limit resets.");
+				if (isUsageBasedBilling && isEnterpriseUser) {
+					calloutText.textContent = localize('quotaExhaustedTBBEnterprise', "Your organization has used all included credits. Contact your admin to enable overages or wait for your next billing cycle.");
+				} else {
+					calloutText.textContent = isEnterpriseUser
+						? localize('quotaPausedEnterprise', "Copilot is paused until the limit resets. Contact your administrator for more information.")
+						: localize('quotaPaused', "Copilot is paused until the limit resets.");
+				}
 			} else if (maxUsedPercentage >= 75 && !additionalUsageEnabled) {
 				quotaCallout.style.display = '';
 				quotaCallout.className = 'quota-callout info';

--- a/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusEntry.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusEntry.ts
@@ -189,20 +189,23 @@ export class ChatStatusBarEntry extends Disposable implements IWorkbenchContribu
 				return this.getSetupEntryProps();
 			}
 
-			// Free Quota Exceeded
-			else if (this.chatEntitlementService.entitlement === ChatEntitlement.Free && (chatQuotaExceeded || completionsQuotaExceeded)) {
-				let quotaWarning: string;
-				if (chatQuotaExceeded && !completionsQuotaExceeded) {
-					quotaWarning = localize('chatQuotaExceededStatus', "Chat quota reached");
-				} else if (completionsQuotaExceeded && !chatQuotaExceeded) {
-					quotaWarning = localize('completionsQuotaExceededStatus', "Inline suggestions quota reached");
-				} else {
-					quotaWarning = localize('chatAndCompletionsQuotaExceededStatus', "Quota reached");
-				}
+			// Quota Exceeded
+			else if ((this.chatEntitlementService.entitlement === ChatEntitlement.Free || isProUser(this.chatEntitlementService.entitlement)) && (chatQuotaExceeded || completionsQuotaExceeded)) {
+				const isExhausted = (chatQuotaExceeded || completionsQuotaExceeded) && !this.chatEntitlementService.quotas.additionalUsageEnabled;
+				if (isExhausted) {
+					let quotaWarning: string;
+					if (chatQuotaExceeded && !completionsQuotaExceeded) {
+						quotaWarning = localize('chatQuotaExceededStatus', "Chat quota reached");
+					} else if (completionsQuotaExceeded && !chatQuotaExceeded) {
+						quotaWarning = localize('completionsQuotaExceededStatus', "Inline suggestions quota reached");
+					} else {
+						quotaWarning = localize('chatAndCompletionsQuotaExceededStatus', "Quota reached");
+					}
 
-				text = `$(copilot-warning) ${quotaWarning}`;
-				ariaLabel = quotaWarning;
-				kind = 'prominent';
+					text = `$(copilot-warning) ${quotaWarning}`;
+					ariaLabel = quotaWarning;
+					kind = 'prominent';
+				}
 			}
 
 			// Completions Disabled

--- a/src/vs/workbench/contrib/chat/test/common/chatEntitlementService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatEntitlementService.test.ts
@@ -308,4 +308,50 @@ suite('parseQuotas', () => {
 		assert.strictEqual(quotas.completions?.entitlement, 4000);
 		assert.strictEqual(quotas.premiumChat, undefined);
 	});
+
+	test('isExhausted is true for pooled entitlements when premium_interactions is at 0% and overages are disabled', () => {
+		const data = makeEntitlementsData({
+			access_type_sku: 'copilot_enterprise_seat_multi_quota',
+			copilot_plan: 'enterprise',
+			token_based_billing: true,
+			quota_snapshots: {
+				premium_interactions: {
+					overage_count: 0,
+					overage_permitted: false,
+					percent_remaining: 0,
+					unlimited: false,
+					entitlement: '3900',
+					has_quota: false,
+				},
+			},
+		});
+
+		const quotas = parseQuotas(data);
+		assert.strictEqual(quotas.premiumChat?.percentRemaining, 0);
+		assert.strictEqual(quotas.additionalUsageEnabled, false);
+		assert.strictEqual(quotas.isExhausted, true);
+	});
+
+	test('isExhausted is false for pooled entitlements when premium_interactions is at 0% but overages are enabled', () => {
+		const data = makeEntitlementsData({
+			access_type_sku: 'copilot_enterprise_seat_multi_quota',
+			copilot_plan: 'enterprise',
+			token_based_billing: true,
+			quota_snapshots: {
+				premium_interactions: {
+					overage_count: 0,
+					overage_permitted: true,
+					percent_remaining: 0,
+					unlimited: false,
+					entitlement: '3900',
+					has_quota: false,
+				},
+			},
+		});
+
+		const quotas = parseQuotas(data);
+		assert.strictEqual(quotas.premiumChat?.percentRemaining, 0);
+		assert.strictEqual(quotas.additionalUsageEnabled, true);
+		assert.strictEqual(quotas.isExhausted, false);
+	});
 });

--- a/src/vs/workbench/services/chat/common/chatEntitlementService.ts
+++ b/src/vs/workbench/services/chat/common/chatEntitlementService.ts
@@ -571,13 +571,11 @@ export class ChatEntitlementService extends Disposable implements IChatEntitleme
 	}
 
 	private compareQuotas(oldQuota: IQuotaSnapshot | undefined, newQuota: IQuotaSnapshot | undefined): { changed: { exceeded: boolean; remaining: boolean } } {
-		return {
-			changed: {
-				exceeded: (oldQuota?.percentRemaining === 0) !== (newQuota?.percentRemaining === 0),
-				remaining: oldQuota?.percentRemaining !== newQuota?.percentRemaining
-					|| oldQuota?.usageBasedBilling !== newQuota?.usageBasedBilling
-			}
-		};
+		const exceeded = (oldQuota?.percentRemaining === 0) !== (newQuota?.percentRemaining === 0);
+		const remaining = oldQuota?.percentRemaining !== newQuota?.percentRemaining
+			|| oldQuota?.usageBasedBilling !== newQuota?.usageBasedBilling;
+
+		return { changed: { exceeded, remaining } };
 	}
 
 	clearQuotas(): void {
@@ -585,7 +583,11 @@ export class ChatEntitlementService extends Disposable implements IChatEntitleme
 	}
 
 	private updateContextKeys(): void {
-		this.chatQuotaExceededContextKey.set(this._quotas.chat?.percentRemaining === 0);
+		const chatExhausted = this._quotas.chat?.percentRemaining === 0;
+		const premiumChatExhausted = this._quotas.premiumChat?.percentRemaining === 0;
+		const additionalUsageEnabled = this._quotas.additionalUsageEnabled ?? false;
+
+		this.chatQuotaExceededContextKey.set(chatExhausted || (premiumChatExhausted && !additionalUsageEnabled));
 		this.completionsQuotaExceededContextKey.set(this._quotas.completions?.percentRemaining === 0);
 	}
 
@@ -713,6 +715,7 @@ interface IQuotas {
 	readonly premiumChat?: IQuotaSnapshot;
 	readonly additionalUsageEnabled?: boolean;
 	readonly additionalUsageCount?: number;
+	readonly isExhausted?: boolean;
 }
 
 export function parseQuotas(entitlementsData: IEntitlementsData): IQuotas {
@@ -778,6 +781,10 @@ export function parseQuotas(entitlementsData: IEntitlementsData): IQuotas {
 		const overageSource = entitlementsData.quota_snapshots['premium_interactions'];
 		quotas.additionalUsageEnabled = overageSource?.overage_permitted ?? false;
 		quotas.additionalUsageCount = overageSource?.overage_count ?? 0;
+
+		const isPremiumExhausted = !!quotas.premiumChat && !quotas.premiumChat.unlimited && quotas.premiumChat.percentRemaining === 0;
+		const isChatExhausted = !!quotas.chat && !quotas.chat.unlimited && quotas.chat.percentRemaining === 0;
+		quotas.isExhausted = (isPremiumExhausted || isChatExhausted) && !quotas.additionalUsageEnabled;
 	}
 	return quotas;
 }


### PR DESCRIPTION
Fixes #316086

When pooled entitlements are exhausted (no ULB, overages off), the in-chat message correctly tells the user their credits are gone but the status dashboard still says "included" and there's no warning banner above the input. Other SKUs already handle this, pooled just got missed.

This brings it in line with how we surface exhaustion everywhere else. The entitlement service now tracks `isExhausted` for pooled credits and sets `chatQuotaExceeded` accordingly. The dashboard shows the org warning and "Exhausted" styling like we do for other plans. Status bar picks up the warning icon and "Quota reached" for Business/Enterprise. Chat input banner shows the org-specific message above the input. Send button gets disabled so users aren't firing messages into a rejection. Change events fire both ways so everything clears on billing reset or overage enablement.

Per the discussion in the issue, no checkpoint or approaching-limit warnings here since we can't really predict per-user usage against a shared pool.

Tests added in `chatEntitlementService.test.ts` for the pooled exhaustion path.