### PR TITLE
search: fix search-on-type not working in agents window search editor

### DIFF
--- a/src/vs/workbench/contrib/search/browser/search.common.contribution.ts
+++ b/src/vs/workbench/contrib/search/browser/search.common.contribution.ts
@@ -5,11 +5,31 @@
 
 // Common search service registrations shared between the main workbench and the Agents window.
 
+import * as nls from '../../../../nls.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
+import { Registry } from '../../../../platform/registry/common/platform.js';
 import { registerContributions as replaceContributions } from './replaceContributions.js';
 import { registerContributions as notebookSearchContributions } from './notebookSearch/notebookSearchContributions.js';
 import { ISearchHistoryService, SearchHistoryService } from '../common/searchHistoryService.js';
+import { searchConfigurationNode } from '../common/search.js';
 
 replaceContributions();
 notebookSearchContributions();
 registerSingleton(ISearchHistoryService, SearchHistoryService, InstantiationType.Delayed);
+
+Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
+	...searchConfigurationNode,
+	properties: {
+		'search.searchOnType': {
+			type: 'boolean',
+			default: true,
+			description: nls.localize('search.searchOnType', "Search all files as you type.")
+		},
+		'search.searchOnTypeDebouncePeriod': {
+			type: 'number',
+			default: 300,
+			markdownDescription: nls.localize('search.searchOnTypeDebouncePeriod', "When {0} is enabled, controls the timeout in milliseconds between a character being typed and the search starting. Has no effect when {0} is disabled.", '`#search.searchOnType#`')
+		},
+	}
+});

--- a/src/vs/workbench/contrib/search/browser/search.contribution.ts
+++ b/src/vs/workbench/contrib/search/browser/search.contribution.ts
@@ -22,7 +22,7 @@ import { ISearchViewModelWorkbenchService } from './searchTreeModel/searchViewMo
 import { SearchSortOrder, SEARCH_EXCLUDE_CONFIG, VIEWLET_ID, ViewMode, VIEW_ID, DEFAULT_MAX_SEARCH_RESULTS, SemanticSearchBehavior } from '../../../services/search/common/search.js';
 import { CommandsRegistry } from '../../../../platform/commands/common/commands.js';
 import { assertType } from '../../../../base/common/types.js';
-import { getWorkspaceSymbols, IWorkspaceSymbol } from '../common/search.js';
+import { getWorkspaceSymbols, IWorkspaceSymbol, searchConfigurationNode } from '../common/search.js';
 import * as Constants from '../common/constants.js';
 import { SearchChatContextContribution } from './searchChatContext.js';
 
@@ -101,10 +101,7 @@ quickAccessRegistry.registerQuickAccessProvider({
 // Configuration
 const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
 configurationRegistry.registerConfiguration({
-	id: 'search',
-	order: 13,
-	title: nls.localize('searchConfigurationTitle', "Search"),
-	type: 'object',
+	...searchConfigurationNode,
 	properties: {
 		[SEARCH_EXCLUDE_CONFIG]: {
 			type: 'object',
@@ -263,11 +260,6 @@ configurationRegistry.registerConfiguration({
 			default: 'right',
 			description: nls.localize('search.actionsPosition', "Controls the positioning of the actionbar on rows in the Search view.")
 		},
-		'search.searchOnType': {
-			type: 'boolean',
-			default: true,
-			description: nls.localize('search.searchOnType', "Search all files as you type.")
-		},
 		'search.seedWithNearestWord': {
 			type: 'boolean',
 			default: false,
@@ -277,11 +269,6 @@ configurationRegistry.registerConfiguration({
 			type: 'boolean',
 			default: false,
 			markdownDescription: nls.localize('search.seedOnFocus', "Update the search query to the editor's selected text when focusing the Search view. This happens either on click or when triggering the `workbench.views.search.focus` command.")
-		},
-		'search.searchOnTypeDebouncePeriod': {
-			type: 'number',
-			default: 300,
-			markdownDescription: nls.localize('search.searchOnTypeDebouncePeriod', "When {0} is enabled, controls the timeout in milliseconds between a character being typed and the search starting. Has no effect when {0} is disabled.", '`#search.searchOnType#`')
 		},
 		'search.sortOrder': {
 			type: 'string',

--- a/src/vs/workbench/contrib/search/common/search.ts
+++ b/src/vs/workbench/contrib/search/common/search.ts
@@ -19,6 +19,8 @@ import { isNumber } from '../../../../base/common/types.js';
 import { RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { compare } from '../../../../base/common/strings.js';
 import { groupBy } from '../../../../base/common/arrays.js';
+import * as nls from '../../../../nls.js';
+import { IConfigurationNode } from '../../../../platform/configuration/common/configurationRegistry.js';
 
 export interface IWorkspaceSymbol {
 	name: string;
@@ -227,3 +229,11 @@ export interface NotebookPriorityInfo {
 	isFromSettings: boolean;
 	filenamePatterns: string[];
 }
+
+export const searchConfigurationNode: IConfigurationNode = {
+	id: 'search',
+	order: 13,
+	title: nls.localize('searchConfigurationTitle', "Search"),
+	type: 'object',
+	properties: {}
+};

--- a/src/vs/workbench/contrib/search/common/search.ts
+++ b/src/vs/workbench/contrib/search/common/search.ts
@@ -20,7 +20,7 @@ import { RawContextKey } from '../../../../platform/contextkey/common/contextkey
 import { compare } from '../../../../base/common/strings.js';
 import { groupBy } from '../../../../base/common/arrays.js';
 import * as nls from '../../../../nls.js';
-import { IConfigurationNode } from '../../../../platform/configuration/common/configurationRegistry.js';
+import type { IConfigurationNode } from '../../../../platform/configuration/common/configurationRegistry.js';
 
 export interface IWorkspaceSymbol {
 	name: string;

--- a/src/vs/workbench/contrib/searchEditor/browser/searchEditor.contribution.ts
+++ b/src/vs/workbench/contrib/searchEditor/browser/searchEditor.contribution.ts
@@ -31,6 +31,7 @@ import { createEditorFromSearchResult, modifySearchEditorContextLinesCommand, op
 import { getOrMakeSearchEditorInput, SearchEditorInput, SEARCH_EDITOR_EXT } from './searchEditorInput.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { VIEW_ID } from '../../../services/search/common/search.js';
+import { searchConfigurationNode } from '../../search/common/search.js';
 import { RegisteredEditorPriority, IEditorResolverService } from '../../../services/editor/common/editorResolverService.js';
 import { IWorkingCopyEditorHandler, IWorkingCopyEditorService } from '../../../services/workingCopy/common/workingCopyEditorService.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
@@ -60,10 +61,7 @@ const SelectAllSearchEditorMatchesCommandId = 'selectAllSearchEditorMatches';
 
 //#region Search Editor Configuration
 Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
-	id: 'search',
-	order: 13,
-	title: nls.localize('searchConfigurationTitle', "Search"),
-	type: 'object',
+	...searchConfigurationNode,
 	properties: {
 		'search.searchEditor.doubleClickBehaviour': {
 			type: 'string',


### PR DESCRIPTION
## Problem

In the agents window, the search editor does not show results as you type — you have to press Enter to trigger a search.

**Root cause:** `search.searchOnType` and `search.searchOnTypeDebouncePeriod` were only registered in `search.contribution.ts`, which is the full workbench-only search contribution. The agents window does not import this file, so `configurationService.getValue('search').searchOnType` returned `undefined` (falsy). The `SearchWidget.onSearchInputChanged()` guard `if (this.searchConfiguration.searchOnType)` then never fired, silently disabling search-as-you-type.

## Fix

- Move `search.searchOnType` and `search.searchOnTypeDebouncePeriod` into `search.common.contribution.ts`, which is imported by both the main workbench and the agents window.
- Introduce `searchConfigurationNode` in `search.ts` (common) — a shared constant for the configuration node metadata (`id`, `order`, `title`, `type`) — and use it with spread syntax in all three registration sites (`search.common.contribution.ts`, `search.contribution.ts`, `searchEditor.contribution.ts`) to avoid duplicating this boilerplate.