### PR TITLE
Cache node_modules for sanity tests job

### DIFF
--- a/build/azure-pipelines/common/sanity-tests.yml
+++ b/build/azure-pipelines/common/sanity-tests.yml
@@ -94,18 +94,28 @@ jobs:
             version: '22.22.0'
           displayName: Install Node.js
 
+      - task: Cache@2
+        inputs:
+          key: '"sanity-node_modules" | "$(Agent.OS)" | "${{ parameters.arch }}" | $(TEST_DIR)/package-lock.json'
+          path: $(TEST_DIR)/node_modules
+          cacheHitVar: SANITY_NODE_MODULES_RESTORED
+        displayName: Restore node_modules cache
+
       - script: npm config set registry "$(NPM_REGISTRY)" --location=project
         workingDirectory: $(TEST_DIR)
         displayName: Configure NPM Registry
+        condition: and(succeeded(), ne(variables.SANITY_NODE_MODULES_RESTORED, 'true'))
 
       - task: npmAuthenticate@0
         inputs:
           workingFile: $(TEST_DIR)/.npmrc
         displayName: Authenticate with NPM Registry
+        condition: and(succeeded(), ne(variables.SANITY_NODE_MODULES_RESTORED, 'true'))
 
       - script: npm ci
         workingDirectory: $(TEST_DIR)
         displayName: Install NPM Dependencies
+        condition: and(succeeded(), ne(variables.SANITY_NODE_MODULES_RESTORED, 'true'))
 
       - script: npm run compile
         workingDirectory: $(TEST_DIR)


### PR DESCRIPTION
Adds a `Cache@2` step to the sanity tests pipeline (`build/azure-pipelines/common/sanity-tests.yml`) that caches `test/sanity/node_modules` keyed on:

- `Agent.OS`
- the job `arch` parameter
- `test/sanity/package-lock.json`

On a cache hit, the NPM registry config, `npmAuthenticate@0`, and `npm ci` steps are skipped (gated on `SANITY_NODE_MODULES_RESTORED != 'true'`).

`Agent.OS` and `arch` are part of the key because `node_modules` can contain platform-specific binaries — without them a Linux cache could be restored on the Windows ARM64 leg.

The `npm run compile` step remains unconditional since its output lives outside `node_modules`.
