### PR TITLE
fix: enable copilot-local ESLint rules in PR CI

### DIFF
--- a/extensions/copilot/.eslintplugin/index.ts
+++ b/extensions/copilot/.eslintplugin/index.ts
@@ -3,14 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import type { LooseRuleDefinition } from '@typescript-eslint/utils/ts-eslint';
-import * as glob from 'glob';
+import fs from 'fs';
 import path from 'path';
 
 // Re-export all .ts files as rules
 const rules: Record<string, LooseRuleDefinition> = {};
 await Promise.all(
-	glob.sync('*.ts', { cwd: import.meta.dirname })
-		.filter(file => !file.endsWith('index.ts') && !file.endsWith('utils.ts'))
+	fs.readdirSync(import.meta.dirname)
+		.filter(file => file.endsWith('.ts') && !file.endsWith('index.ts') && !file.endsWith('utils.ts'))
 		.map(async file => {
 			rules[path.basename(file, '.ts')] = (await import('./' + file)).default;
 		})

--- a/extensions/copilot/.eslintplugin/no-unlayered-files.ts
+++ b/extensions/copilot/.eslintplugin/no-unlayered-files.ts
@@ -19,7 +19,15 @@ export default new class NoUnlayeredFiles implements eslint.Rule.RuleModule {
 
 	create(context: eslint.Rule.RuleContext): eslint.Rule.RuleListener {
 
-		const filenameParts = context.filename.split(path.sep);
+		// Use only the path relative to extensions/copilot/ to avoid false positives
+		// from the repo directory name (e.g., "vscode" is both a layer name and the
+		// checkout directory, so absolute paths always contain it).
+		const copilotPrefix = `extensions${path.sep}copilot${path.sep}`;
+		const idx = context.filename.indexOf(copilotPrefix);
+		const relativePath = idx >= 0
+			? context.filename.slice(idx + copilotPrefix.length)
+			: context.filename;
+		const filenameParts = relativePath.split(path.sep);
 
 		if (!filenameParts.find(part => layers.has(part))) {
 			context.report({


### PR DESCRIPTION
🤖 AI Assisted PR

## Problem

The Copilot ESLint plugin (`.eslintplugin/`) has two bugs that prevent `copilot-local/*` rules from running in PR CI:

**Bug 1 — Plugin fails to load.** `index.ts` uses `import * as glob from 'glob'` + `glob.sync()`. In the root ESLint's ESM context, the namespace import on CJS `glob` v5 gives `{ default: [function] }` — no `sync` property. The plugin silently fails to load, registering zero rules.

**Bug 2 — Rule checks absolute paths.** `no-unlayered-files.ts` splits `context.filename` (an absolute path) and checks if ANY segment matches a layer name. Since `vscode` is both a valid layer name AND the repo checkout directory, every file's path matches → the rule never fires.

## Impact

Since the root ESLint integration was added on April 28 (`371c4a0a73c`), **no `copilot-local/*` rules have executed in PR CI**. This includes `no-unlayered-files`, `no-test-imports`, `no-runtime-import`, and 8+ other custom rules.

On May 7, PR #314783 added a test file to the wrong folder. PR CI passed (copilot rules were dead). The ADO build caught it post-merge, causing **6 consecutive build failures** across all platforms (~55 cascading task failures, 2-hour recovery window).

**Data:** `Download Copilot VSIX` is the #1 root-cause task in the 14-day OData dataset (81 of 479 root-cause failures). 68% of those were caused by Copilot Lint failures that escaped PR CI.

## Fix

Two changes in `extensions/copilot/.eslintplugin/`:

### 1. `index.ts` — Replace `glob.sync` with `fs.readdirSync`
The `glob` package (v5, CJS) doesn't export `sync` as an ESM named export. `fs.readdirSync` is a Node.js built-in — zero external dependency, works in both CJS and ESM.

### 2. `no-unlayered-files.ts` — Use relative path
Strip the absolute path to be relative to `extensions/copilot/` before checking for layer folders. This prevents the repo directory name (`vscode`) from being matched as a valid layer.

## Verification

### Local
```bash
# Create a misplaced file (same pattern as the May 7 incident)
echo "export const x = 1;" > extensions/copilot/src/platform/chat/test/repro.ts

# Before fix: no copilot-local warnings (plugin broken + path bug)
node build/eslint.ts  # → only header/semi errors, no copilot-local rules

# After fix: copilot-local/no-unlayered-files fires
node build/eslint.ts  # → "File should be inside a 'common, vscode, node...' folder"
```

Verified locally: bad files caught ✅, correctly layered files pass ✅, no regressions on existing codebase ✅

### CI verification PRs (now closed)

| PR | Fix? | Bad file? | CI result | ADO result |
|---|---|---|---|---|
| **#316122** (closed) | ✅ First fix only | ✅ | Passed — rule path bug prevented detection | N/A |
| **#316123** (closed) | ❌ | ✅ | ✅ **Passed** (the bug — CI doesn't catch it) | ❌ **Failed** ([build 438627](https://dev.azure.com/monacotools/a6d41577-0fa3-498e-af22-257312ff0545/_build/results?buildId=438627)) — 23 failed tasks, Copilot Lint caught it |

PR #316123 + ADO build 438627 prove the current state: **CI passes what ADO fails on**. This PR closes that gap.

## Root cause chain

1. Copilot extension migrated into vscode repo (~March 2026)
2. April 28: root `eslint.config.js` integrated Copilot ESLint plugin (`371c4a0a73c`)
3. Plugin's `import * as glob` doesn't work in ESM → plugin silently fails to load (Bug 1)
4. Even if loaded, `no-unlayered-files` checks absolute paths containing `vscode` dir → never fires (Bug 2)
5. May 7: misplaced file escapes CI → ADO Lint catches it post-merge → 6 builds fail → ~55 cascade task failures
6. May 8: PR #315368 added `npm run lint` step to Copilot CI jobs — but both bugs persist, so the step is ineffective

## References

- ADO build failure (control): [Build 438627](https://dev.azure.com/monacotools/a6d41577-0fa3-498e-af22-257312ff0545/_build/results?buildId=438627) — Copilot Lint fails, 23 tasks cascade
- Original incident: PR #314783 (May 7) → builds 436972–436990
- CI lint step added: PR #315368 (May 8)
- Root ESLint integration: commit `371c4a0a73c` (April 28)
- ESM/CJS interop proof: `import * as glob from 'glob'` → `glob.sync` is `undefined` (glob v5 is CJS, namespace import gives `{ default }` only)