### PR TITLE
⚠️ TEST: verify copilot ESLint fix catches misplaced files

### DIFF
--- a/extensions/copilot/.eslintplugin/index.ts
+++ b/extensions/copilot/.eslintplugin/index.ts
@@ -3,14 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import type { LooseRuleDefinition } from '@typescript-eslint/utils/ts-eslint';
-import * as glob from 'glob';
+import fs from 'fs';
 import path from 'path';
 
 // Re-export all .ts files as rules
 const rules: Record<string, LooseRuleDefinition> = {};
 await Promise.all(
-	glob.sync('*.ts', { cwd: import.meta.dirname })
-		.filter(file => !file.endsWith('index.ts') && !file.endsWith('utils.ts'))
+	fs.readdirSync(import.meta.dirname)
+		.filter(file => file.endsWith('.ts') && !file.endsWith('index.ts') && !file.endsWith('utils.ts'))
 		.map(async file => {
 			rules[path.basename(file, '.ts')] = (await import('./' + file)).default;
 		})

--- a/extensions/copilot/.eslintplugin/no-unlayered-files.ts
+++ b/extensions/copilot/.eslintplugin/no-unlayered-files.ts
@@ -19,7 +19,15 @@ export default new class NoUnlayeredFiles implements eslint.Rule.RuleModule {
 
 	create(context: eslint.Rule.RuleContext): eslint.Rule.RuleListener {
 
-		const filenameParts = context.filename.split(path.sep);
+		// Use only the path relative to extensions/copilot/ to avoid false positives
+		// from the repo directory name (e.g., "vscode" is both a layer name and the
+		// checkout directory, so absolute paths always contain it).
+		const copilotPrefix = `extensions${path.sep}copilot${path.sep}`;
+		const idx = context.filename.indexOf(copilotPrefix);
+		const relativePath = idx >= 0
+			? context.filename.slice(idx + copilotPrefix.length)
+			: context.filename;
+		const filenameParts = relativePath.split(path.sep);
 
 		if (!filenameParts.find(part => layers.has(part))) {
 			context.report({

--- a/extensions/copilot/src/platform/chat/test/eslintCatchTest.ts
+++ b/extensions/copilot/src/platform/chat/test/eslintCatchTest.ts
@@ -1,0 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// This file intentionally placed in the wrong folder to test copilot-local/no-unlayered-files.
+// It should be in a layer subfolder like test/common/ instead of test/.
+// This PR exists to prove the ESLint fix catches this class of error in CI.
+export const testValue = 1;


### PR DESCRIPTION
🤖 AI Assisted PR

## ⚠️ DO NOT MERGE — Test PR

This PR exists to prove that the ESLint plugin fix (PR #316121) correctly catches misplaced files in CI.

### What this contains

1. **The glob import fix** (from PR #316121) — `fs.readdirSync` replacing `glob.sync`
2. **A deliberately misplaced test file** at `extensions/copilot/src/platform/chat/test/eslintCatchTest.ts` — this file has no layer subfolder (`common/`, `node/`, etc.)

### Expected behavior

**CI should FAIL** on this PR with a `copilot-local/no-unlayered-files` warning.

If CI passes, the fix isn't working. If CI fails with the expected lint error, the fix is proven.

### Context

This reproduces the exact pattern from PR #314783 (May 6) that escaped PR CI and caused 6 consecutive ADO build failures. See PR #316121 for the full investigation.

### After verification

This branch will be deleted. Do not merge.