### PR TITLE
run_in_terminal: fix zsh pitfalls with shell options and steering text

### DIFF
--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-rc.zsh
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-rc.zsh
@@ -106,6 +106,15 @@ if [ "${VSCODE_PREVENT_SHELL_HISTORY:-}" = "1" ]; then
 	builtin unset VSCODE_PREVENT_SHELL_HISTORY
 fi
 
+# Agent terminal zsh fixups: disable bang history expansion so ! in double
+# quotes does not hang on dquote>, and enable inline # comments so the
+# agent can annotate commands.
+if [ "${VSCODE_AGENT_ZSH_FIXUPS:-}" = "1" ]; then
+	builtin setopt NO_BANG_HIST
+	builtin setopt INTERACTIVE_COMMENTS
+	builtin unset VSCODE_AGENT_ZSH_FIXUPS
+fi
+
 # The property (P) and command (E) codes embed values which require escaping.
 # Backslashes are doubled. Non-alphanumeric characters are converted to escaped hex.
 __vsc_escape_value() {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/toolTerminalCreator.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/toolTerminalCreator.ts
@@ -171,6 +171,13 @@ export class ToolTerminalCreator {
 			}
 		}
 
+		// Zsh-specific fixups for agent terminals: disable bang history
+		// expansion (prevents ! in double quotes from hanging on dquote>)
+		// and enable inline # comments (lets the agent annotate commands).
+		if (isZsh(shellPath, os)) {
+			env['VSCODE_AGENT_ZSH_FIXUPS'] = '1';
+		}
+
 		const config: IShellLaunchConfig = {
 			icon: ThemeIcon.fromId(Codicon.chatSparkle.id),
 			hideFromUser: true,

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -263,9 +263,7 @@ function createZshModelDescription(isSandboxEnabled: boolean, allowToRunUnsandbo
 		'- Take advantage of zsh globbing features (**, extended globs)',
 		'',
 		'zsh pitfalls — these WILL cause errors or hangs:',
-		'- NEVER use ! inside double quotes (e.g. echo "hello!" hangs on dquote>). Use single quotes: echo \'hello!\'',
 		'- NEVER use bare == or === as separators (e.g. echo === triggers zsh equals expansion). Quote them: echo \'===\'',
-		'- NEVER include comment-only lines starting with # in tool commands (zsh: command not found: #). Remove the comment line or make it part of the surrounding prose instead',
 		'- NEVER use status as a variable name (it is read-only in zsh). Use exit_code or ret instead',
 		'- Unmatched globs fail by default (zsh: no matches found). Use a zsh-safe pattern like *(N) or quote the glob if it should be literal; do not rely on 2>/dev/null',
 	].join('\n');

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -260,7 +260,17 @@ function createZshModelDescription(isSandboxEnabled: boolean, allowToRunUnsandbo
 		'- Use jobs, fg, bg for job control',
 		'- Use [[ ]] for conditional tests instead of [ ]',
 		'- Prefer $() over backticks for command substitution',
-		'- Take advantage of zsh globbing features (**, extended globs)'
+		'- Take advantage of zsh globbing features (**, extended globs)',
+		'',
+		'zsh pitfalls — these WILL cause errors or hangs:',
+		'- NEVER use ! inside double quotes (e.g. echo "hello!" hangs on dquote>). Use single quotes: echo \'hello!\'',
+		'- NEVER use bare == or === as separators (e.g. echo === triggers zsh equals expansion). Quote them: echo \'===\'',
+		'- NEVER use # comments inline in single-line commands (zsh: command not found: #). Chain with && instead or use a single command',
+		'- NEVER use status as a variable name (it is read-only in zsh). Use exit_code or ret instead',
+		'- Unmatched globs fail by default (zsh: no matches found). Use 2>/dev/null or test existence first',
+		'- Do not store multi-word commands in a scalar variable and then expand it (e.g. cmd="node file.js"; $cmd). Use an array or call directly',
+		'- The timeout command is not available on macOS by default. Do not use it',
+		'- Avoid passing very large inline arguments (argument list too long). Write to a temp file instead',
 	].join('\n');
 }
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -260,12 +260,11 @@ function createZshModelDescription(isSandboxEnabled: boolean, allowToRunUnsandbo
 		'- Use jobs, fg, bg for job control',
 		'- Use [[ ]] for conditional tests instead of [ ]',
 		'- Prefer $() over backticks for command substitution',
-		'- Take advantage of zsh globbing features (**, extended globs)',
+		'- Take advantage of zsh globbing features (**, extended globs). Note: unmatched globs fail by default (zsh: no matches found) — use a glob qualifier like *(N) or quote the glob if it should be literal',
 		'',
 		'zsh pitfalls — these WILL cause errors or hangs:',
 		'- NEVER use bare == or === as separators (e.g. echo === triggers zsh equals expansion). Quote them: echo \'===\'',
 		'- NEVER use status as a variable name (it is read-only in zsh). Use exit_code or ret instead',
-		'- Unmatched globs fail by default (zsh: no matches found). Use a zsh-safe pattern like *(N) or quote the glob if it should be literal; do not rely on 2>/dev/null',
 	].join('\n');
 }
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -265,12 +265,9 @@ function createZshModelDescription(isSandboxEnabled: boolean, allowToRunUnsandbo
 		'zsh pitfalls — these WILL cause errors or hangs:',
 		'- NEVER use ! inside double quotes (e.g. echo "hello!" hangs on dquote>). Use single quotes: echo \'hello!\'',
 		'- NEVER use bare == or === as separators (e.g. echo === triggers zsh equals expansion). Quote them: echo \'===\'',
-		'- NEVER use # comments inline in single-line commands (zsh: command not found: #). Chain with && instead or use a single command',
+		'- NEVER include comment-only lines starting with # in tool commands (zsh: command not found: #). Remove the comment line or make it part of the surrounding prose instead',
 		'- NEVER use status as a variable name (it is read-only in zsh). Use exit_code or ret instead',
-		'- Unmatched globs fail by default (zsh: no matches found). Use 2>/dev/null or test existence first',
-		'- Do not store multi-word commands in a scalar variable and then expand it (e.g. cmd="node file.js"; $cmd). Use an array or call directly',
-		'- The timeout command is not available on macOS by default. Do not use it',
-		'- Avoid passing very large inline arguments (argument list too long). Write to a temp file instead',
+		'- Unmatched globs fail by default (zsh: no matches found). Use a zsh-safe pattern like *(N) or quote the glob if it should be literal; do not rely on 2>/dev/null',
 	].join('\n');
 }
 


### PR DESCRIPTION
fixes #316129
fixes https://github.com/microsoft/vscode/issues/312009

### Shell-level fixes
Sets two `setopt` options in agent zsh terminals via `VSCODE_AGENT_ZSH_FIXUPS` env var (same pattern as `VSCODE_PREVENT_SHELL_HISTORY`):

- **`INTERACTIVE_COMMENTS`**: Enables `#` comments in interactive zsh — lets the agent annotate commands naturally

These fix the two most common zsh pitfalls at the shell level (zero token cost, impossible to violate).

### Steering text (2 remaining warnings)
Down from 8 to 2 pitfalls that can't be fixed via shell options:

- Bare `==` / `===` separators (zsh equals expansion)
- Read-only `status` variable

The unmatched-glob caveat is folded into the existing globbing features tip.

### Files changed
- **`shellIntegration-rc.zsh`**: `setopt NO_BANG_HIST` + `INTERACTIVE_COMMENTS` when `VSCODE_AGENT_ZSH_FIXUPS=1`
- **`toolTerminalCreator.ts`**: Sets `VSCODE_AGENT_ZSH_FIXUPS=1` env var for zsh agent terminals
- **`runInTerminalTool.ts`**: Trimmed zsh pitfall warnings; glob note merged into globbing features line