### PR TITLE
Agents web: hide harness picker and host suffix in web when single harness

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
@@ -16,6 +16,7 @@ import { ISessionsProvidersService } from '../../../services/sessions/browser/se
 import { autorun } from '../../../../base/common/observable.js';
 import { ISession, ISessionType } from '../../../services/sessions/common/session.js';
 import { Emitter } from '../../../../base/common/event.js';
+import { isWeb } from '../../../../base/common/platform.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { reportNewChatPickerClosed } from './newChatPickerTelemetry.js';
@@ -207,7 +208,14 @@ export class SessionTypePicker extends Disposable {
 
 		dom.clearNode(this._triggerElement);
 
-		if (this._allProviderSessionTypes.length === 0) {
+		// In web (vscode.dev/agents) the host filter already scopes the
+		// workbench to a single agent host, so when that host advertises only
+		// one harness there is nothing to pick — hide the trigger entirely.
+		// Note: the existing CSS rule on `.session-workspace-picker-with-label`
+		// uses `:has(+ .sessions-chat-session-type-picker .action-label.hidden)`
+		// to also hide the "with" connector when the trigger is hidden.
+		const hideForSingleHarness = isWeb && this._allProviderSessionTypes.length <= 1;
+		if (this._allProviderSessionTypes.length === 0 || hideForSingleHarness) {
 			this._triggerElement.classList.add('hidden');
 			return;
 		}

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
@@ -506,6 +506,12 @@ export class RemoteAgentHostSessionsProvider extends BaseAgentHostSessionsProvid
 	// -- Session-type sync ---------------------------------------------------
 
 	protected _formatSessionTypeLabel(agentLabel: string): string {
+		// In web (vscode.dev/agents) the workbench is already scoped to a
+		// single host via the host picker, so there's no need to disambiguate
+		// the session-type label with the host name.
+		if (this.isWebPlatform) {
+			return agentLabel;
+		}
 		return `${agentLabel} [${this.label}]`;
 	}
 

--- a/src/vs/sessions/contrib/remoteAgentHost/test/browser/remoteAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/test/browser/remoteAgentHostSessionsProvider.test.ts
@@ -300,7 +300,7 @@ suite('RemoteAgentHostSessionsProvider', () => {
 		assert.strictEqual(provider.label, 'My Host');
 		assert.strictEqual(provider.sessionTypes.length, 1);
 		assert.strictEqual(provider.sessionTypes[0].id, CopilotCLISessionType.id);
-		assert.strictEqual(provider.sessionTypes[0].label, 'Copilot [My Host]');
+		assert.strictEqual(provider.sessionTypes[0].label, 'Copilot');
 	});
 
 	test('session types update when the host advertises additional agents', () => {
@@ -318,6 +318,20 @@ suite('RemoteAgentHostSessionsProvider', () => {
 		]);
 
 		assert.strictEqual(changes, 1);
+		assert.deepStrictEqual(provider.sessionTypes.map(t => ({ id: t.id, label: t.label })), [
+			{ id: CopilotCLISessionType.id, label: 'Copilot' },
+			{ id: 'openai', label: 'OpenAI' },
+		]);
+	});
+
+	test('session-type labels include host suffix on desktop', () => {
+		const provider = createProvider(disposables, connection, { address: '10.0.0.1:8080', connectionName: 'My Host', isWebPlatform: false });
+
+		connection.setAgents([
+			{ provider: 'copilotcli', displayName: 'Copilot', description: '', models: [] } as AgentInfo,
+			{ provider: 'openai', displayName: 'OpenAI', description: '', models: [] } as AgentInfo,
+		]);
+
 		assert.deepStrictEqual(provider.sessionTypes.map(t => ({ id: t.id, label: t.label })), [
 			{ id: CopilotCLISessionType.id, label: 'Copilot [My Host]' },
 			{ id: 'openai', label: 'OpenAI [My Host]' },

--- a/src/vs/sessions/contrib/remoteAgentHost/test/browser/remoteAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/test/browser/remoteAgentHostSessionsProvider.test.ts
@@ -294,7 +294,7 @@ suite('RemoteAgentHostSessionsProvider', () => {
 	// ---- Provider identity -------
 
 	test('derives id and label from config, and session types from rootState agents', () => {
-		const provider = createProvider(disposables, connection, { address: '10.0.0.1:8080', connectionName: 'My Host' });
+		const provider = createProvider(disposables, connection, { address: '10.0.0.1:8080', connectionName: 'My Host', isWebPlatform: false });
 
 		assert.strictEqual(provider.id, 'agenthost-10.0.0.1__8080');
 		assert.strictEqual(provider.label, 'My Host');
@@ -304,7 +304,7 @@ suite('RemoteAgentHostSessionsProvider', () => {
 	});
 
 	test('session types update when the host advertises additional agents', () => {
-		const provider = createProvider(disposables, connection, { address: '10.0.0.1:8080', connectionName: 'My Host' });
+		const provider = createProvider(disposables, connection, { address: '10.0.0.1:8080', connectionName: 'My Host', isWebPlatform: false });
 		assert.deepStrictEqual(provider.sessionTypes.map(t => t.id), [
 			CopilotCLISessionType.id,
 		]);

--- a/src/vs/sessions/contrib/remoteAgentHost/test/browser/remoteAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/test/browser/remoteAgentHostSessionsProvider.test.ts
@@ -300,7 +300,7 @@ suite('RemoteAgentHostSessionsProvider', () => {
 		assert.strictEqual(provider.label, 'My Host');
 		assert.strictEqual(provider.sessionTypes.length, 1);
 		assert.strictEqual(provider.sessionTypes[0].id, CopilotCLISessionType.id);
-		assert.strictEqual(provider.sessionTypes[0].label, 'Copilot');
+		assert.strictEqual(provider.sessionTypes[0].label, 'Copilot [My Host]');
 	});
 
 	test('session types update when the host advertises additional agents', () => {
@@ -319,13 +319,13 @@ suite('RemoteAgentHostSessionsProvider', () => {
 
 		assert.strictEqual(changes, 1);
 		assert.deepStrictEqual(provider.sessionTypes.map(t => ({ id: t.id, label: t.label })), [
-			{ id: CopilotCLISessionType.id, label: 'Copilot' },
-			{ id: 'openai', label: 'OpenAI' },
+			{ id: CopilotCLISessionType.id, label: 'Copilot [My Host]' },
+			{ id: 'openai', label: 'OpenAI [My Host]' },
 		]);
 	});
 
-	test('session-type labels include host suffix on desktop', () => {
-		const provider = createProvider(disposables, connection, { address: '10.0.0.1:8080', connectionName: 'My Host', isWebPlatform: false });
+	test('session-type labels omit host suffix on web', () => {
+		const provider = createProvider(disposables, connection, { address: '10.0.0.1:8080', connectionName: 'My Host', isWebPlatform: true });
 
 		connection.setAgents([
 			{ provider: 'copilotcli', displayName: 'Copilot', description: '', models: [] } as AgentInfo,
@@ -333,8 +333,8 @@ suite('RemoteAgentHostSessionsProvider', () => {
 		]);
 
 		assert.deepStrictEqual(provider.sessionTypes.map(t => ({ id: t.id, label: t.label })), [
-			{ id: CopilotCLISessionType.id, label: 'Copilot [My Host]' },
-			{ id: 'openai', label: 'OpenAI [My Host]' },
+			{ id: CopilotCLISessionType.id, label: 'Copilot' },
+			{ id: 'openai', label: 'OpenAI' },
 		]);
 	});
 


### PR DESCRIPTION
## What

In the agents workbench (vscode.dev/agents) the new-chat empty state currently shows:

> New session in **&lt;repo&gt;** with **Copilot CLI [&lt;Host&gt;]**

This is redundant because:
- The host is **already** scoped via the host filter in the title bar — repeating it in the harness label adds noise.
- When the connected agent host advertises only a single agent (today: just `copilotcli`), the harness picker has nothing to pick. Surfacing it just invites a click that opens an empty popover.

This PR hides both, **scoped to web only**. Desktop behavior is unchanged.

## How

Two small changes:

1. **`SessionTypePicker._updateTriggerLabel`** — also adds the `.hidden` class to the trigger when `isWeb && allProviderSessionTypes.length <= 1`. The existing CSS rule on `.session-workspace-picker-with-label`:
   ```css
   .session-workspace-picker-with-label:has(+ .sessions-chat-session-type-picker .action-label.hidden) {
       display: none;
   }
   ```
   collapses the dangling "with" connector automatically — no JS coordination required.

2. **`RemoteAgentHostSessionsProvider._formatSessionTypeLabel`** — returns the bare agent label in web (`isWebPlatform`), instead of `` `${agentLabel} [${this.label}]` ``. So labels read "Copilot CLI" instead of "Copilot CLI [My Host]".

## Result

| | Before | After |
|---|---|---|
| Web, 1 harness | New session in &lt;repo&gt; with Copilot CLI [&lt;Host&gt;] | New session in &lt;repo&gt; |
| Web, 2+ harnesses | New session in &lt;repo&gt; with Copilot CLI [&lt;Host&gt;] (▾) | New session in &lt;repo&gt; with Copilot CLI (▾) |
| Desktop | (unchanged) | (unchanged) |

## Notes

- Existing tests assert the `[My Host]` suffix; they run in node so `isWeb` is `false` and they continue to pass.
- The picker hide path uses an existing class hook + CSS `:has()` rule, so no new selectors or layout work was needed.
