### PR TITLE
Agents web: config picker order on mobile-aware subclass

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/agentHost/agentHostSessionConfigPicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/agentHost/agentHostSessionConfigPicker.ts
@@ -530,8 +530,17 @@ class MobileAgentHostSessionConfigPicker extends AgentHostSessionConfigPicker {
 	 * then Worktree. Sort the known repo-config properties to that
 	 * order; unknown properties fall through to schema-declared order
 	 * after the known ones.
+	 *
+	 * On desktop viewports this subclass is also instantiated (see the
+	 * factory in `AgentHostSessionConfigPickersContribution` — it always
+	 * picks the mobile-aware subclass so `_showPicker` can route to the
+	 * bottom sheet on phones), so we must defer to the base ordering
+	 * (Isolation first, Branch second) when not on a phone layout.
 	 */
 	protected override _orderProperties(properties: ReadonlyArray<[string, SessionConfigPropertySchema]>): ReadonlyArray<[string, SessionConfigPropertySchema]> {
+		if (!isPhoneLayout(this._layoutService)) {
+			return super._orderProperties(properties);
+		}
 		const order = new Map<string, number>([
 			[SessionConfigKey.Branch, 0],
 			[SessionConfigKey.Isolation, 1],


### PR DESCRIPTION
## Problem

On vscode.dev/agents desktop viewports, the new-chat repo-config picker row renders **Branch then Worktree** instead of the intended **Worktree then Branch**.

## Root cause

`MobileAgentHostSessionConfigPicker` is always instantiated for the `sessions.agentHost.sessionConfigPicker` action view item, regardless of viewport — by design, so its `_showPicker` override can route to the mobile bottom sheet on phones while falling back to the desktop popup elsewhere via an `isPhoneLayout` guard.

The sibling `_orderProperties` override added in #314571 has no such guard, so it unconditionally returns the mobile chip-lane order (Branch first, Isolation second) on every viewport — overriding the desktop ordering installed by #314871.

## Fix

Mirror the `isPhoneLayout` guard from `_showPicker` in `_orderProperties` so desktop viewports defer to `super._orderProperties` (Isolation then Branch).

## Validation

- `tsc --noEmit` clean.
- No tests cover this path today; behavior verified by inspection against the picker render flow.
