### PR TITLE
Lazily load non-critical contribution modules

### DIFF
--- a/src/vs/workbench/browser/workbench.contribution.lazy.ts
+++ b/src/vs/workbench/browser/workbench.contribution.lazy.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../base/common/lifecycle.js';
+import { onUnexpectedError } from '../../base/common/errors.js';
+import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../common/contributions.js';
+
+class LazyWorkbenchContributionsLoader extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'workbench.contrib.lazyContributions';
+
+	constructor() {
+		super();
+
+		const load = (loader: () => Promise<unknown>) => loader().catch(onUnexpectedError);
+
+		load(() => import('../contrib/chat/browser/chat.view.contribution.js'));
+		load(() => import('../contrib/mcp/browser/mcp.view.contribution.js'));
+		load(() => import('../contrib/chat/browser/promptSyntax/promptCodingAgentActionContribution.js'));
+		load(() => import('../contrib/chat/browser/promptSyntax/promptToolsCodeLensProvider.js'));
+		load(() => import('../contrib/chat/browser/planReviewFeedback/planReviewFeedbackEditorContribution.js'));
+
+		load(() => import('../services/policies/browser/accountPolicyGate.contribution.js'));
+		load(() => import('../contrib/meteredConnection/browser/meteredConnection.contribution.js'));
+		load(() => import('../contrib/welcomeOnboarding/browser/welcomeOnboarding.contribution.js'));
+		load(() => import('../contrib/surveys/browser/nps.contribution.js'));
+		load(() => import('../contrib/surveys/browser/languageSurveys.contribution.js'));
+	}
+}
+
+registerWorkbenchContribution2(LazyWorkbenchContributionsLoader.ID, LazyWorkbenchContributionsLoader, WorkbenchPhase.Eventually);

--- a/src/vs/workbench/browser/workbench.contribution.lazy.ts
+++ b/src/vs/workbench/browser/workbench.contribution.lazy.ts
@@ -18,15 +18,21 @@ class LazyWorkbenchContributionsLoader extends Disposable implements IWorkbenchC
 
 		load(() => import('../contrib/chat/browser/chat.view.contribution.js'));
 		load(() => import('../contrib/mcp/browser/mcp.view.contribution.js'));
-		load(() => import('../contrib/chat/browser/promptSyntax/promptCodingAgentActionContribution.js'));
-		load(() => import('../contrib/chat/browser/promptSyntax/promptToolsCodeLensProvider.js'));
-		load(() => import('../contrib/chat/browser/planReviewFeedback/planReviewFeedbackEditorContribution.js'));
 
 		load(() => import('../services/policies/browser/accountPolicyGate.contribution.js'));
 		load(() => import('../contrib/meteredConnection/browser/meteredConnection.contribution.js'));
 		load(() => import('../contrib/welcomeOnboarding/browser/welcomeOnboarding.contribution.js'));
 		load(() => import('../contrib/surveys/browser/nps.contribution.js'));
 		load(() => import('../contrib/surveys/browser/languageSurveys.contribution.js'));
+
+		load(() => import('../contrib/bracketPairColorizer2Telemetry/browser/bracketPairColorizer2Telemetry.contribution.js'));
+		load(() => import('../contrib/scrollLocking/browser/scrollLocking.contribution.js'));
+		load(() => import('../contrib/dropOrPasteInto/browser/dropOrPasteInto.contribution.js'));
+		load(() => import('../contrib/opener/browser/opener.contribution.js'));
+		load(() => import('../contrib/relauncher/browser/relauncher.contribution.js'));
+		load(() => import('../contrib/update/browser/update.contribution.js'));
+		load(() => import('../contrib/sash/browser/sash.contribution.js'));
+		load(() => import('../contrib/languageDetection/browser/languageDetection.contribution.js'));
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -172,7 +172,10 @@ import { AgentPluginRepositoryService } from './agentPluginRepositoryService.js'
 import { BrowserPluginGitCommandService } from './pluginGitCommandService.js';
 import { IPluginGitService } from '../common/plugins/pluginGitService.js';
 import { PluginInstallService } from './pluginInstallService.js';
+import './promptSyntax/promptCodingAgentActionContribution.js';
+import './promptSyntax/promptToolsCodeLensProvider.js';
 import { ChatSessionOptionSlashCommandsContribution, ChatSlashCommandsContribution } from './chatSlashCommands.js';
+import './planReviewFeedback/planReviewFeedbackEditorContribution.js';
 import { registerPlanReviewFeedbackEditorActions } from './planReviewFeedback/planReviewFeedbackEditorActions.js';
 import { IPlanReviewFeedbackService, PlanReviewFeedbackService } from './planReviewFeedback/planReviewFeedbackService.js';
 import { PluginUrlHandler } from './pluginUrlHandler.js';

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -172,10 +172,7 @@ import { AgentPluginRepositoryService } from './agentPluginRepositoryService.js'
 import { BrowserPluginGitCommandService } from './pluginGitCommandService.js';
 import { IPluginGitService } from '../common/plugins/pluginGitService.js';
 import { PluginInstallService } from './pluginInstallService.js';
-import './promptSyntax/promptCodingAgentActionContribution.js';
-import './promptSyntax/promptToolsCodeLensProvider.js';
 import { ChatSessionOptionSlashCommandsContribution, ChatSlashCommandsContribution } from './chatSlashCommands.js';
-import './planReviewFeedback/planReviewFeedbackEditorContribution.js';
 import { registerPlanReviewFeedbackEditorActions } from './planReviewFeedback/planReviewFeedbackEditorActions.js';
 import { IPlanReviewFeedbackService, PlanReviewFeedbackService } from './planReviewFeedback/planReviewFeedbackService.js';
 import { PluginUrlHandler } from './pluginUrlHandler.js';

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -260,9 +260,6 @@ import './contrib/search/browser/searchView.js';
 // Search Editor
 import './contrib/searchEditor/browser/searchEditor.contribution.js';
 
-// Sash
-import './contrib/sash/browser/sash.contribution.js';
-
 // Git
 import './contrib/git/browser/git.contributions.js';
 
@@ -323,9 +320,6 @@ import './contrib/terminal/terminal.all.js';
 // External terminal
 import './contrib/externalTerminal/browser/externalTerminal.contribution.js';
 
-// Relauncher
-import './contrib/relauncher/browser/relauncher.contribution.js';
-
 // Tasks
 import './contrib/tasks/browser/task.contribution.js';
 
@@ -363,9 +357,6 @@ import './contrib/inlayHints/browser/inlayHintsAccessibilty.js';
 // Themes
 import './contrib/themes/browser/themes.contribution.js';
 
-// Update
-import './contrib/update/browser/update.contribution.js';
-
 // Welcome
 import './contrib/welcomeGettingStarted/browser/gettingStarted.contribution.js';
 import './contrib/welcomeAgentSessions/browser/agentSessionsWelcome.contribution.js';
@@ -382,9 +373,6 @@ import './contrib/typeHierarchy/browser/typeHierarchy.contribution.js';
 // Outline
 import './contrib/codeEditor/browser/outline/documentSymbolsOutline.js';
 import './contrib/outline/browser/outline.contribution.js';
-
-// Language Detection
-import './contrib/languageDetection/browser/languageDetection.contribution.js';
 
 // Language Status
 import './contrib/languageStatus/browser/languageStatus.contribution.js';
@@ -426,28 +414,16 @@ import './contrib/list/browser/list.contribution.js';
 // Accessibility Signals
 import './contrib/accessibilitySignals/browser/accessibilitySignal.contribution.js';
 
-// Bracket Pair Colorizer 2 Telemetry
-import './contrib/bracketPairColorizer2Telemetry/browser/bracketPairColorizer2Telemetry.contribution.js';
-
 // Accessibility
 import './contrib/accessibility/browser/accessibility.contribution.js';
 
 // Share
 import './contrib/share/browser/share.contribution.js';
 
-// Synchronized Scrolling
-import './contrib/scrollLocking/browser/scrollLocking.contribution.js';
-
 // Inline Completions
 import './contrib/inlineCompletions/browser/inlineCompletions.contribution.js';
 
-// Drop or paste into
-import './contrib/dropOrPasteInto/browser/dropOrPasteInto.contribution.js';
-
 // Edit Telemetry
 import './contrib/editTelemetry/browser/editTelemetry.contribution.js';
-
-// Opener
-import './contrib/opener/browser/opener.contribution.js';
 
 //#endregion

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -200,9 +200,6 @@ registerSingleton(IAllowedMcpServersService, AllowedMcpServersService, Instantia
 // Default Account
 import './services/accounts/browser/defaultAccount.js';
 
-// Account Policy Gate
-import './services/policies/browser/accountPolicyGate.contribution.js';
-
 // Telemetry
 import './contrib/telemetry/browser/telemetry.contribution.js';
 
@@ -222,13 +219,12 @@ import './contrib/speech/browser/speech.contribution.js';
 
 // Chat
 import './contrib/chat/browser/chat.contribution.js';
-import './contrib/chat/browser/chat.view.contribution.js';
 import './contrib/inlineChat/browser/inlineChat.contribution.js';
 import './contrib/mcp/browser/mcp.contribution.js';
-import './contrib/mcp/browser/mcp.view.contribution.js';
 import './contrib/chat/browser/chatSessions/chatSessions.contribution.js';
 import './contrib/chat/browser/contextContrib/chatContext.contribution.js';
 import './contrib/imageCarousel/browser/imageCarousel.contribution.js';
+import './browser/workbench.contribution.lazy.js';
 
 // Interactive
 import './contrib/interactive/browser/interactive.contribution.js';
@@ -370,19 +366,12 @@ import './contrib/themes/browser/themes.contribution.js';
 // Update
 import './contrib/update/browser/update.contribution.js';
 
-// Surveys
-import './contrib/surveys/browser/nps.contribution.js';
-import './contrib/surveys/browser/languageSurveys.contribution.js';
-
 // Welcome
 import './contrib/welcomeGettingStarted/browser/gettingStarted.contribution.js';
 import './contrib/welcomeAgentSessions/browser/agentSessionsWelcome.contribution.js';
 import './contrib/welcomeWalkthrough/browser/walkThrough.contribution.js';
 import './contrib/welcomeViews/common/viewsWelcome.contribution.js';
 import './contrib/welcomeViews/common/newFile.contribution.js';
-
-// Welcome Onboarding
-import './contrib/welcomeOnboarding/browser/welcomeOnboarding.contribution.js';
 
 // Call Hierarchy
 import './contrib/callHierarchy/browser/callHierarchy.contribution.js';
@@ -442,9 +431,6 @@ import './contrib/bracketPairColorizer2Telemetry/browser/bracketPairColorizer2Te
 
 // Accessibility
 import './contrib/accessibility/browser/accessibility.contribution.js';
-
-// Metered Connection
-import './contrib/meteredConnection/browser/meteredConnection.contribution.js';
 
 // Share
 import './contrib/share/browser/share.contribution.js';


### PR DESCRIPTION
## What

Defers fifteen contribution modules off the eager workbench bundle parse path. A new loader at [`src/vs/workbench/browser/workbench.contribution.lazy.ts`](src/vs/workbench/browser/workbench.contribution.lazy.ts) registers a single workbench contribution at `WorkbenchPhase.Eventually` that dynamic-`import()`s the deferred modules after the workbench has fully restored.

| Module | Side effect | Phase |
|---|---|---|
| `chat/browser/chat.view.contribution.ts` | Agent-plugins views | AfterRestored |
| `mcp/browser/mcp.view.contribution.ts` | MCP-servers views | AfterRestored |
| `services/policies/browser/accountPolicyGate.contribution.ts` | gate contrib | AfterRestored |
| `meteredConnection/browser/meteredConnection.contribution.ts` | status contrib + 1 action | AfterRestored |
| `welcomeOnboarding/browser/welcomeOnboarding.contribution.ts` | `IOnboardingService` Delayed + 1 action | (Delayed) |
| `surveys/browser/nps.contribution.ts` | NPS survey (en-only) | Restored |
| `surveys/browser/languageSurveys.contribution.ts` | language surveys (en-only) | Restored |
| `bracketPairColorizer2Telemetry/browser/bracketPairColorizer2Telemetry.contribution.ts` | telemetry | Restored |
| `scrollLocking/browser/scrollLocking.contribution.ts` | scroll-lock action | Eventually |
| `dropOrPasteInto/browser/dropOrPasteInto.contribution.ts` | commands + schema | Eventually ×2 |
| `opener/browser/opener.contribution.ts` | opener contrib | Eventually |
| `relauncher/browser/relauncher.contribution.ts` | 2 settings/workspace relaunchers | Restored ×2 |
| `update/browser/update.contribution.ts` | 6 update widgets | Restored ×5 + Eventually |
| `sash/browser/sash.contribution.ts` | sash settings controller | AfterRestored |
| `languageDetection/browser/languageDetection.contribution.ts` | status contrib | Restored |

## Why this is safe

The workbench contributions registry instantiates a contribution immediately if it is registered after its target phase has already fired ([`contributions.ts:170–180`](src/vs/workbench/common/contributions.ts#L170-L180)). All fifteen deferred modules register only via `registerWorkbenchContribution2`, which **is** retroactive.

Modules that use **non-retroactive** mechanisms were deliberately **not** included (or reverted, see review thread):

- `registerEditorFeature(...)` — snapshot taken once by `EditorFeaturesInstantiator` at `BlockRestore` on first editor creation; not re-read.
- `registerEditorContribution(...)` — `CodeEditorWidget` snapshots `EditorExtensionsRegistry` at editor construction time.
- `registerEditorPane` / `registerEditorSerializer` / `registerExtensionPoint` — consumed during workspace/editor restore or extension activation, which happen before `Eventually`.

That's why `chatContext.contribution.ts`, `imageCarousel.contribution.ts`, `chatSessions.contribution.ts`, `agentSessions.contribution.ts`, `chatManagement.contribution.ts`, `aiCustomizationManagement.contribution.ts`, the three prompt/plan-review editor contributions, and modules whose services are consumed by `mainThread*` bridges (`share`, `editTelemetry`, `accessibilitySignals`) are kept eager.

## Impact

Transitive-closure analysis on the previous (18-module) variant of this set showed **~200 KB of TS source** uniquely leaves the eager parse graph — most transitive imports are shared with other eager paths and cost nothing extra to dynamic-import. The current (15-module) set is similar in net size: the three reverted modules together accounted for ~30 KB of direct source plus minor transitive surface.

Estimated cold-start savings:
- V8 parse + ignition compile: ~10–15 ms
- Top-level registration work across 15 modules: ~5–15 ms
- **Total: ~15–30 ms on Windows, ~20–40 ms on Linux**

First in a planned series of lazy-loading changes (tracked locally in `perf-changes.md`).

## Trade-offs

- Views (Agent Plugins, MCP Servers): appear in their view containers a few hundred ms later — not first-paint surfaces.
- NPS / language surveys / update notifications / post-update widget: fire after `Eventually` instead of during `Restored`. All gated and rare.
- Onboarding action / metered-connection status / drop-or-paste commands / opener / scroll-locking / sash settings / language-detection status: registered slightly later; no user-visible impact.
- `SettingsChangeRelauncher` / `WorkspaceChangeExtHostRelauncher`: settings changes made in the first ~2.5 s of session won't be observed. Users do not normally change settings that early.

No functionality removed.

## Validation

- `npm run compile-check-ts-native` — clean
- `npm run valid-layers-check` — clean
- No external module references any of the deferred files by name (grep)
- Pre-commit hygiene hook passed