### PR TITLE
CI: kill lingering Windows smoke-test processes before Publish Log Files

### DIFF
--- a/build/azure-pipelines/win32/steps/product-build-win32-test.yml
+++ b/build/azure-pipelines/win32/steps/product-build-win32-test.yml
@@ -159,3 +159,19 @@ steps:
       testResultsFiles: "*-results.xml"
       searchFolder: "$(Build.ArtifactStagingDirectory)/test-results"
     condition: succeededOrFailed()
+
+  # Force-kill any lingering test processes that still hold smoke-test log
+  # files open and would otherwise break the 1ES "Publish Log Files" output.
+  - powershell: |
+      $ErrorActionPreference = "Continue"
+      $testRoot = "$(agent.builddirectory)\test"
+      Get-CimInstance Win32_Process -Filter "ExecutablePath IS NOT NULL" -ErrorAction SilentlyContinue |
+        Where-Object { $_.ExecutablePath -like "$testRoot\*" } |
+        ForEach-Object {
+          Write-Host "Killing lingering test process: pid=$($_.ProcessId), name=$($_.Name), path=$($_.ExecutablePath)"
+          try { Stop-Process -Id $_.ProcessId -Force -ErrorAction Stop }
+          catch { Write-Host "  failed: $($_.Exception.Message)" }
+        }
+    displayName: Kill lingering test processes
+    continueOnError: true
+    condition: succeededOrFailed()


### PR DESCRIPTION
## Problem

The Windows `Electron Tests` job in build [438755](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=438755) failed on attempt #1 even though all tests passed. The only failing step was the 1ES auto-injected **Publish Log Files** output:

```
System.IO.IOException: The process cannot access the file
'D:\a\_work\1\s\.build\logs\smoke-tests-electron\16_suite_Task\main.log'
because it is being used by another process.
```

Same lock affected `ptyhost.log`, `network-shared.log`, `mcpGateway.log`, `sharedprocess.log`, `tunnelHostService.log`, `userDataSync.log` — all from the `Task` smoke suite.

## Root cause

On Windows, when the Electron main process exits, its utility processes (ptyHost, sharedProcess, network-shared, GPU, renderers) can outlive it briefly and keep log files open. The existing `Diagnostics after smoke test run` step (which runs `tasklist /V`) confirmed this — at `02:03:10`, one second after smoke tests finished, **six** `Code - Insiders.exe` processes were still alive from `\test\VSCode-win32-<arch>\`. They were still around ~2 minutes later when `Publish Log Files` ran and tried to hash the locked files.

The smoke-test runner's `code.exit()` only polls the main PID and uses plain `process.kill(pid)` (no tree-kill), so child processes are not guaranteed to be reaped on Windows.

## Fix

Add a defensive cleanup step right after `Publish Tests Results` (the last user-controllable step before 1ES auto-injected `Publish Log Files`) that force-kills any process whose `ExecutablePath` is under `$(agent.builddirectory)\test\`.

- Path-scoped — can only target test artifacts (Electron + remote server binaries copied into the test dir), never system processes or the agent worker.
- `continueOnError: true` + `condition: succeededOrFailed()` — never blocks the build.
- Runs after Copilot extension tests so it doesn't interfere with running test phases.
- ~30 1ES auto-injected SDL/Guardian tasks run between this step and `Publish Log Files`, giving the OS plenty of time to fully release file handles.
