### PR TITLE
Prevent alt-buffer hang in agent host terminals

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostHeadlessTerminal.ts
+++ b/src/vs/platform/agentHost/node/agentHostHeadlessTerminal.ts
@@ -4,7 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Emitter, Event } from '../../../base/common/event.js';
-import { Disposable } from '../../../base/common/lifecycle.js';
+import { DeferredPromise } from '../../../base/common/async.js';
+import { Disposable, DisposableStore } from '../../../base/common/lifecycle.js';
 import type { ILogService } from '../../log/common/log.js';
 import pkg from '@xterm/headless';
 
@@ -89,6 +90,32 @@ export class AgentHostHeadlessTerminal extends Disposable {
 
 	isBracketedPasteMode(): boolean {
 		return this._terminal.modes.bracketedPasteMode;
+	}
+
+	isInAltBuffer(): boolean {
+		return this._terminal.buffer.active === this._terminal.buffer.alternate;
+	}
+
+	createAltBufferPromise(store: DisposableStore): Promise<void> {
+		const deferred = new DeferredPromise<void>();
+		const complete = () => {
+			if (!deferred.isSettled) {
+				this._logService.debug('[AgentHostHeadlessTerminal] Detected alternate buffer entry');
+				deferred.complete();
+			}
+		};
+
+		if (this.isInAltBuffer()) {
+			complete();
+		} else {
+			store.add(this._terminal.buffer.onBufferChange(() => {
+				if (this.isInAltBuffer()) {
+					complete();
+				}
+			}));
+		}
+
+		return deferred.p;
 	}
 
 	clear(): void {

--- a/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
+++ b/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
@@ -113,6 +113,7 @@ export interface IAgentHostTerminalManager {
 	onExit(uri: string, cb: (exitCode: number) => void): IDisposable;
 	onClaimChanged(uri: string, cb: (claim: TerminalClaim) => void): IDisposable;
 	onCommandFinished(uri: string, cb: (event: ICommandFinishedEvent) => void): IDisposable;
+	createAltBufferPromise(uri: string, store: DisposableStore): Promise<void>;
 	getContent(uri: string): string | undefined;
 	getClaim(uri: string): TerminalClaim | undefined;
 	hasTerminal(uri: string): boolean;
@@ -501,6 +502,14 @@ export class AgentHostTerminalManager extends Disposable implements IAgentHostTe
 			return toDisposable(() => { });
 		}
 		return terminal.onCommandFinishedEmitter.event(cb);
+	}
+
+	createAltBufferPromise(uri: string, store: DisposableStore): Promise<void> {
+		const terminal = this._terminals.get(uri);
+		if (!terminal?.headlessTerminal) {
+			return new Promise(() => { });
+		}
+		return terminal.headlessTerminal.createAltBufferPromise(store);
 	}
 
 	/** Get accumulated scrollback content for a terminal as raw text. */

--- a/src/vs/platform/agentHost/node/copilot/copilotShellTools.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotShellTools.ts
@@ -8,7 +8,7 @@ import { generateUuid } from '../../../../base/common/uuid.js';
 import { URI } from '../../../../base/common/uri.js';
 import { removeAnsiEscapeCodes } from '../../../../base/common/strings.js';
 import * as platform from '../../../../base/common/platform.js';
-import { Disposable, DisposableStore, type IDisposable, type IReference, toDisposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, type IReference, toDisposable } from '../../../../base/common/lifecycle.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { ILogService } from '../../../log/common/log.js';
 import { TerminalClaimKind, type TerminalSessionClaim } from '../../common/state/protocol/state.js';
@@ -102,7 +102,7 @@ export class ShellManager extends Disposable {
 	private _resolvedExecutable: Promise<string> | undefined;
 	/** Set of shell ids currently executing a command and unsafe to share. */
 	private readonly _busyShellIds = new Set<string>();
-	private readonly _busyShellReleaseListeners = new Map<string, IDisposable>();
+	private readonly _activeCommandListeners = new Map<string, DisposableStore>();
 
 	private readonly _onDidAssociateTerminal = this._register(new Emitter<{ toolCallId: string; terminalUri: string; displayName: string }>());
 	readonly onDidAssociateTerminal: Event<{ toolCallId: string; terminalUri: string; displayName: string }> = this._onDidAssociateTerminal.event;
@@ -116,10 +116,10 @@ export class ShellManager extends Disposable {
 		super();
 
 		this._register(toDisposable(() => {
-			for (const listener of this._busyShellReleaseListeners.values()) {
-				listener.dispose();
+			for (const store of this._activeCommandListeners.values()) {
+				store.dispose();
 			}
-			this._busyShellReleaseListeners.clear();
+			this._activeCommandListeners.clear();
 			for (const shell of this._shells.values()) {
 				if (this._terminalManager.hasTerminal(shell.terminalUri)) {
 					this._terminalManager.disposeTerminal(shell.terminalUri);
@@ -218,20 +218,20 @@ export class ShellManager extends Disposable {
 		};
 	}
 
-	keepBusyUntilTerminalSettles(shell: IManagedShell): void {
-		if (this._busyShellReleaseListeners.has(shell.id)) {
+	keepBusyUntilCommandFinishes(shell: IManagedShell): void {
+		if (this._activeCommandListeners.has(shell.id)) {
 			return;
 		}
 
 		const store = new DisposableStore();
 		const release = () => {
 			this._busyShellIds.delete(shell.id);
-			this._busyShellReleaseListeners.delete(shell.id);
+			this._activeCommandListeners.delete(shell.id);
 			store.dispose();
 		};
 		store.add(this._terminalManager.onCommandFinished(shell.terminalUri, release));
 		store.add(this._terminalManager.onExit(shell.terminalUri, release));
-		this._busyShellReleaseListeners.set(shell.id, store);
+		this._activeCommandListeners.set(shell.id, store);
 	}
 
 	private _trackToolCall(toolCallId: string, shellId: string): void {
@@ -270,8 +270,8 @@ export class ShellManager extends Disposable {
 		if (!shell) {
 			return false;
 		}
-		this._busyShellReleaseListeners.get(id)?.dispose();
-		this._busyShellReleaseListeners.delete(id);
+		this._activeCommandListeners.get(id)?.dispose();
+		this._activeCommandListeners.delete(id);
 		this._terminalManager.disposeTerminal(shell.terminalUri);
 		this._shells.delete(id);
 		this._busyShellIds.delete(id);
@@ -623,7 +623,7 @@ export async function createShellTools(
 				const result = await executeCommandInShell(ref.object, args.command, timeoutMs, terminalManager, logService);
 				if (result.error === 'alternateBuffer') {
 					shouldReleaseShell = false;
-					shellManager.keepBusyUntilTerminalSettles(ref.object);
+					shellManager.keepBusyUntilCommandFinishes(ref.object);
 				}
 				return result;
 			} finally {

--- a/src/vs/platform/agentHost/node/copilot/copilotShellTools.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotShellTools.ts
@@ -8,7 +8,7 @@ import { generateUuid } from '../../../../base/common/uuid.js';
 import { URI } from '../../../../base/common/uri.js';
 import { removeAnsiEscapeCodes } from '../../../../base/common/strings.js';
 import * as platform from '../../../../base/common/platform.js';
-import { Disposable, DisposableStore, type IReference, toDisposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, type IDisposable, type IReference, toDisposable } from '../../../../base/common/lifecycle.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { ILogService } from '../../../log/common/log.js';
 import { TerminalClaimKind, type TerminalSessionClaim } from '../../common/state/protocol/state.js';
@@ -29,6 +29,7 @@ const DEFAULT_TIMEOUT_MS = 120_000;
  * The full sentinel format is: `<<<COPILOT_SENTINEL_<uuid>_EXIT_<code>>>`.
  */
 const SENTINEL_PREFIX = '<<<COPILOT_SENTINEL_';
+const ALT_BUFFER_MESSAGE = 'The command opened the alternate buffer and is still running in the terminal. It likely launched an interactive terminal UI. Use write_bash/write_powershell to interact with it, or shutdown the shell to stop it.';
 
 /**
  * Tracks a single persistent shell instance backed by a managed PTY terminal.
@@ -101,6 +102,7 @@ export class ShellManager extends Disposable {
 	private _resolvedExecutable: Promise<string> | undefined;
 	/** Set of shell ids currently executing a command and unsafe to share. */
 	private readonly _busyShellIds = new Set<string>();
+	private readonly _busyShellReleaseListeners = new Map<string, IDisposable>();
 
 	private readonly _onDidAssociateTerminal = this._register(new Emitter<{ toolCallId: string; terminalUri: string; displayName: string }>());
 	readonly onDidAssociateTerminal: Event<{ toolCallId: string; terminalUri: string; displayName: string }> = this._onDidAssociateTerminal.event;
@@ -114,6 +116,10 @@ export class ShellManager extends Disposable {
 		super();
 
 		this._register(toDisposable(() => {
+			for (const listener of this._busyShellReleaseListeners.values()) {
+				listener.dispose();
+			}
+			this._busyShellReleaseListeners.clear();
 			for (const shell of this._shells.values()) {
 				if (this._terminalManager.hasTerminal(shell.terminalUri)) {
 					this._terminalManager.disposeTerminal(shell.terminalUri);
@@ -212,6 +218,22 @@ export class ShellManager extends Disposable {
 		};
 	}
 
+	keepBusyUntilTerminalSettles(shell: IManagedShell): void {
+		if (this._busyShellReleaseListeners.has(shell.id)) {
+			return;
+		}
+
+		const store = new DisposableStore();
+		const release = () => {
+			this._busyShellIds.delete(shell.id);
+			this._busyShellReleaseListeners.delete(shell.id);
+			store.dispose();
+		};
+		store.add(this._terminalManager.onCommandFinished(shell.terminalUri, release));
+		store.add(this._terminalManager.onExit(shell.terminalUri, release));
+		this._busyShellReleaseListeners.set(shell.id, store);
+	}
+
 	private _trackToolCall(toolCallId: string, shellId: string): void {
 		this._toolCallShells.set(toolCallId, shellId);
 		const shell = this._shells.get(shellId);
@@ -248,6 +270,8 @@ export class ShellManager extends Disposable {
 		if (!shell) {
 			return false;
 		}
+		this._busyShellReleaseListeners.get(id)?.dispose();
+		this._busyShellReleaseListeners.delete(id);
 		this._terminalManager.disposeTerminal(shell.terminalUri);
 		this._shells.delete(id);
 		this._busyShellIds.delete(id);
@@ -331,6 +355,23 @@ function makeFailureResult(text: string, error?: string): ToolResultObject {
 	return { textResultForLlm: text, resultType: 'failure', error };
 }
 
+function makeAltBufferResult(): ToolResultObject {
+	return makeFailureResult(ALT_BUFFER_MESSAGE, 'alternateBuffer');
+}
+
+function registerAltBufferHandler(
+	shell: IManagedShell,
+	terminalManager: IAgentHostTerminalManager,
+	logService: ILogService,
+	disposables: DisposableStore,
+	finish: (result: ToolResultObject) => void,
+): void {
+	void terminalManager.createAltBufferPromise(shell.terminalUri, disposables).then(() => {
+		logService.info('[ShellTool] Command entered alternate buffer');
+		finish(makeAltBufferResult());
+	});
+}
+
 async function executeCommandInShell(
 	shell: IManagedShell,
 	command: string,
@@ -361,12 +402,7 @@ async function executeCommandWithShellIntegration(
 ): Promise<ToolResultObject> {
 	const disposables = new DisposableStore();
 
-	await terminalManager.sendText(shell.terminalUri, `${prefixForHistorySuppression(shell.shellType)}${command}`, {
-		shouldExecute: true,
-		bracketedPasteMode: shouldUseBracketedPasteMode(command),
-	});
-
-	return new Promise<ToolResultObject>(resolve => {
+	const result = new Promise<ToolResultObject>(resolve => {
 		let resolved = false;
 		const finish = (result: ToolResultObject) => {
 			if (resolved) {
@@ -387,6 +423,8 @@ async function executeCommandWithShellIntegration(
 				finish(makeFailureResult(`Exit code: ${exitCode}\n${output}`));
 			}
 		}));
+
+		registerAltBufferHandler(shell, terminalManager, logService, disposables, finish);
 
 		disposables.add(terminalManager.onExit(shell.terminalUri, (exitCode: number) => {
 			logService.info(`[ShellTool] Shell exited unexpectedly with code ${exitCode}`);
@@ -412,7 +450,20 @@ async function executeCommandWithShellIntegration(
 			));
 		}, timeoutMs);
 		disposables.add(toDisposable(() => clearTimeout(timer)));
+
 	});
+
+	try {
+		await terminalManager.sendText(shell.terminalUri, `${prefixForHistorySuppression(shell.shellType)}${command}`, {
+			shouldExecute: true,
+			bracketedPasteMode: shouldUseBracketedPasteMode(command),
+		});
+	} catch (err) {
+		disposables.dispose();
+		throw err;
+	}
+
+	return result;
 }
 
 /**
@@ -433,13 +484,7 @@ async function executeCommandWithSentinel(
 	const contentBefore = terminalManager.getContent(shell.terminalUri) ?? '';
 	const offsetBefore = contentBefore.length;
 
-	await terminalManager.sendText(shell.terminalUri, `${prefixForHistorySuppression(shell.shellType)}${command}`, {
-		shouldExecute: true,
-		bracketedPasteMode: shouldUseBracketedPasteMode(command),
-	});
-	await terminalManager.sendText(shell.terminalUri, sentinelCmd, { shouldExecute: true });
-
-	return new Promise<ToolResultObject>(resolve => {
+	const result = new Promise<ToolResultObject>(resolve => {
 		let resolved = false;
 		const finish = (result: ToolResultObject) => {
 			if (resolved) {
@@ -473,6 +518,8 @@ async function executeCommandWithSentinel(
 			checkForSentinel();
 		}));
 
+		registerAltBufferHandler(shell, terminalManager, logService, disposables, finish);
+
 		disposables.add(terminalManager.onExit(shell.terminalUri, (exitCode: number) => {
 			logService.info(`[ShellTool] Shell exited unexpectedly with code ${exitCode}`);
 			const fullContent = terminalManager.getContent(shell.terminalUri) ?? '';
@@ -502,6 +549,19 @@ async function executeCommandWithSentinel(
 
 		checkForSentinel();
 	});
+
+	try {
+		await terminalManager.sendText(shell.terminalUri, `${prefixForHistorySuppression(shell.shellType)}${command}`, {
+			shouldExecute: true,
+			bracketedPasteMode: shouldUseBracketedPasteMode(command),
+		});
+		await terminalManager.sendText(shell.terminalUri, sentinelCmd, { shouldExecute: true });
+	} catch (err) {
+		disposables.dispose();
+		throw err;
+	}
+
+	return result;
 }
 
 // ---------------------------------------------------------------------------
@@ -558,10 +618,18 @@ export async function createShellTools(
 				invocation.toolCallId,
 				invocation.toolCallId,
 			);
+			let shouldReleaseShell = true;
 			try {
-				return await executeCommandInShell(ref.object, args.command, timeoutMs, terminalManager, logService);
+				const result = await executeCommandInShell(ref.object, args.command, timeoutMs, terminalManager, logService);
+				if (result.error === 'alternateBuffer') {
+					shouldReleaseShell = false;
+					shellManager.keepBusyUntilTerminalSettles(ref.object);
+				}
+				return result;
 			} finally {
-				ref.dispose();
+				if (shouldReleaseShell) {
+					ref.dispose();
+				}
 			}
 		},
 	};

--- a/src/vs/platform/agentHost/node/copilot/copilotShellTools.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotShellTools.ts
@@ -102,7 +102,8 @@ export class ShellManager extends Disposable {
 	private _resolvedExecutable: Promise<string> | undefined;
 	/** Set of shell ids currently executing a command and unsafe to share. */
 	private readonly _busyShellIds = new Set<string>();
-	private readonly _activeCommandListeners = new Map<string, DisposableStore>();
+	/** Release listeners for shells held after a tool returns while the command is still running. */
+	private readonly _heldShellReleaseListeners = new Map<string, DisposableStore>();
 
 	private readonly _onDidAssociateTerminal = this._register(new Emitter<{ toolCallId: string; terminalUri: string; displayName: string }>());
 	readonly onDidAssociateTerminal: Event<{ toolCallId: string; terminalUri: string; displayName: string }> = this._onDidAssociateTerminal.event;
@@ -116,10 +117,10 @@ export class ShellManager extends Disposable {
 		super();
 
 		this._register(toDisposable(() => {
-			for (const store of this._activeCommandListeners.values()) {
+			for (const store of this._heldShellReleaseListeners.values()) {
 				store.dispose();
 			}
-			this._activeCommandListeners.clear();
+			this._heldShellReleaseListeners.clear();
 			for (const shell of this._shells.values()) {
 				if (this._terminalManager.hasTerminal(shell.terminalUri)) {
 					this._terminalManager.disposeTerminal(shell.terminalUri);
@@ -218,20 +219,20 @@ export class ShellManager extends Disposable {
 		};
 	}
 
-	keepBusyUntilCommandFinishes(shell: IManagedShell): void {
-		if (this._activeCommandListeners.has(shell.id)) {
+	holdShellUntilCommandFinishes(shell: IManagedShell): void {
+		if (this._heldShellReleaseListeners.has(shell.id)) {
 			return;
 		}
 
 		const store = new DisposableStore();
 		const release = () => {
 			this._busyShellIds.delete(shell.id);
-			this._activeCommandListeners.delete(shell.id);
+			this._heldShellReleaseListeners.delete(shell.id);
 			store.dispose();
 		};
 		store.add(this._terminalManager.onCommandFinished(shell.terminalUri, release));
 		store.add(this._terminalManager.onExit(shell.terminalUri, release));
-		this._activeCommandListeners.set(shell.id, store);
+		this._heldShellReleaseListeners.set(shell.id, store);
 	}
 
 	private _trackToolCall(toolCallId: string, shellId: string): void {
@@ -270,8 +271,8 @@ export class ShellManager extends Disposable {
 		if (!shell) {
 			return false;
 		}
-		this._activeCommandListeners.get(id)?.dispose();
-		this._activeCommandListeners.delete(id);
+		this._heldShellReleaseListeners.get(id)?.dispose();
+		this._heldShellReleaseListeners.delete(id);
 		this._terminalManager.disposeTerminal(shell.terminalUri);
 		this._shells.delete(id);
 		this._busyShellIds.delete(id);
@@ -347,6 +348,11 @@ function prepareOutputForModel(rawOutput: string): string {
 // Tool implementations
 // ---------------------------------------------------------------------------
 
+interface IShellExecutionResult {
+	readonly toolResult: ToolResultObject;
+	readonly keepShellBusy?: boolean;
+}
+
 function makeSuccessResult(text: string): ToolResultObject {
 	return { textResultForLlm: text, resultType: 'success' };
 }
@@ -355,8 +361,16 @@ function makeFailureResult(text: string, error?: string): ToolResultObject {
 	return { textResultForLlm: text, resultType: 'failure', error };
 }
 
-function makeAltBufferResult(): ToolResultObject {
-	return makeFailureResult(ALT_BUFFER_MESSAGE, 'alternateBuffer');
+function makeExecutionResult(toolResult: ToolResultObject, options?: { keepShellBusy?: boolean }): IShellExecutionResult {
+	return { toolResult, keepShellBusy: options?.keepShellBusy };
+}
+
+function makeBackgroundExecutionResult(text: string): IShellExecutionResult {
+	return makeExecutionResult(makeSuccessResult(text), { keepShellBusy: true });
+}
+
+function makeAltBufferExecutionResult(): IShellExecutionResult {
+	return makeExecutionResult(makeFailureResult(ALT_BUFFER_MESSAGE, 'alternateBuffer'), { keepShellBusy: true });
 }
 
 function registerAltBufferHandler(
@@ -364,11 +378,11 @@ function registerAltBufferHandler(
 	terminalManager: IAgentHostTerminalManager,
 	logService: ILogService,
 	disposables: DisposableStore,
-	finish: (result: ToolResultObject) => void,
+	finish: (result: IShellExecutionResult) => void,
 ): void {
 	void terminalManager.createAltBufferPromise(shell.terminalUri, disposables).then(() => {
 		logService.info('[ShellTool] Command entered alternate buffer');
-		finish(makeAltBufferResult());
+		finish(makeAltBufferExecutionResult());
 	});
 }
 
@@ -378,13 +392,16 @@ async function executeCommandInShell(
 	timeoutMs: number,
 	terminalManager: IAgentHostTerminalManager,
 	logService: ILogService,
-): Promise<ToolResultObject> {
+): Promise<IShellExecutionResult> {
 	const result = terminalManager.supportsCommandDetection(shell.terminalUri)
 		? await executeCommandWithShellIntegration(shell, command, timeoutMs, terminalManager, logService)
 		: await executeCommandWithSentinel(shell, command, timeoutMs, terminalManager, logService);
 	return {
 		...result,
-		textResultForLlm: `Shell ID: ${shell.id}\n${result.textResultForLlm}`,
+		toolResult: {
+			...result.toolResult,
+			textResultForLlm: `Shell ID: ${shell.id}\n${result.toolResult.textResultForLlm}`,
+		},
 	};
 }
 
@@ -399,12 +416,12 @@ async function executeCommandWithShellIntegration(
 	timeoutMs: number,
 	terminalManager: IAgentHostTerminalManager,
 	logService: ILogService,
-): Promise<ToolResultObject> {
+): Promise<IShellExecutionResult> {
 	const disposables = new DisposableStore();
 
-	const result = new Promise<ToolResultObject>(resolve => {
+	const result = new Promise<IShellExecutionResult>(resolve => {
 		let resolved = false;
-		const finish = (result: ToolResultObject) => {
+		const finish = (result: IShellExecutionResult) => {
 			if (resolved) {
 				return;
 			}
@@ -418,9 +435,9 @@ async function executeCommandWithShellIntegration(
 			const exitCode = event.exitCode ?? 0;
 			logService.info(`[ShellTool] Command completed (shell integration) with exit code ${exitCode}`);
 			if (exitCode === 0) {
-				finish(makeSuccessResult(`Exit code: ${exitCode}\n${output}`));
+				finish(makeExecutionResult(makeSuccessResult(`Exit code: ${exitCode}\n${output}`)));
 			} else {
-				finish(makeFailureResult(`Exit code: ${exitCode}\n${output}`));
+				finish(makeExecutionResult(makeFailureResult(`Exit code: ${exitCode}\n${output}`)));
 			}
 		}));
 
@@ -430,13 +447,13 @@ async function executeCommandWithShellIntegration(
 			logService.info(`[ShellTool] Shell exited unexpectedly with code ${exitCode}`);
 			const fullContent = terminalManager.getContent(shell.terminalUri) ?? '';
 			const output = prepareOutputForModel(fullContent);
-			finish(makeFailureResult(`Shell exited with code ${exitCode}\n${output}`));
+			finish(makeExecutionResult(makeFailureResult(`Shell exited with code ${exitCode}\n${output}`)));
 		}));
 
 		disposables.add(terminalManager.onClaimChanged(shell.terminalUri, (claim) => {
 			if (claim.kind === TerminalClaimKind.Session && !claim.toolCallId) {
 				logService.info(`[ShellTool] Continuing in background (claim narrowed)`);
-				finish(makeSuccessResult('The user chose to continue this command in the background. The terminal is still running.'));
+				finish(makeBackgroundExecutionResult('The user chose to continue this command in the background. The terminal is still running.'));
 			}
 		}));
 
@@ -444,10 +461,10 @@ async function executeCommandWithShellIntegration(
 			logService.warn(`[ShellTool] Command timed out after ${timeoutMs}ms`);
 			const fullContent = terminalManager.getContent(shell.terminalUri) ?? '';
 			const output = prepareOutputForModel(fullContent);
-			finish(makeFailureResult(
+			finish(makeExecutionResult(makeFailureResult(
 				`Command timed out after ${Math.round(timeoutMs / 1000)}s. Partial output:\n${output}`,
 				'timeout',
-			));
+			)));
 		}, timeoutMs);
 		disposables.add(toDisposable(() => clearTimeout(timer)));
 
@@ -476,7 +493,7 @@ async function executeCommandWithSentinel(
 	timeoutMs: number,
 	terminalManager: IAgentHostTerminalManager,
 	logService: ILogService,
-): Promise<ToolResultObject> {
+): Promise<IShellExecutionResult> {
 	const sentinelId = makeSentinelId();
 	const sentinelCmd = buildSentinelCommand(sentinelId, shell.shellType);
 	const disposables = new DisposableStore();
@@ -484,9 +501,9 @@ async function executeCommandWithSentinel(
 	const contentBefore = terminalManager.getContent(shell.terminalUri) ?? '';
 	const offsetBefore = contentBefore.length;
 
-	const result = new Promise<ToolResultObject>(resolve => {
+	const result = new Promise<IShellExecutionResult>(resolve => {
 		let resolved = false;
-		const finish = (result: ToolResultObject) => {
+		const finish = (result: IShellExecutionResult) => {
 			if (resolved) {
 				return;
 			}
@@ -507,9 +524,9 @@ async function executeCommandWithSentinel(
 				const output = prepareOutputForModel(parsed.outputBeforeSentinel);
 				logService.info(`[ShellTool] Command completed with exit code ${parsed.exitCode}`);
 				if (parsed.exitCode === 0) {
-					finish(makeSuccessResult(`Exit code: ${parsed.exitCode}\n${output}`));
+					finish(makeExecutionResult(makeSuccessResult(`Exit code: ${parsed.exitCode}\n${output}`)));
 				} else {
-					finish(makeFailureResult(`Exit code: ${parsed.exitCode}\n${output}`));
+					finish(makeExecutionResult(makeFailureResult(`Exit code: ${parsed.exitCode}\n${output}`)));
 				}
 			}
 		};
@@ -525,13 +542,13 @@ async function executeCommandWithSentinel(
 			const fullContent = terminalManager.getContent(shell.terminalUri) ?? '';
 			const newContent = fullContent.substring(offsetBefore);
 			const output = prepareOutputForModel(newContent);
-			finish(makeFailureResult(`Shell exited with code ${exitCode}\n${output}`));
+			finish(makeExecutionResult(makeFailureResult(`Shell exited with code ${exitCode}\n${output}`)));
 		}));
 
 		disposables.add(terminalManager.onClaimChanged(shell.terminalUri, (claim) => {
 			if (claim.kind === TerminalClaimKind.Session && !claim.toolCallId) {
 				logService.info(`[ShellTool] Continuing in background (claim narrowed)`);
-				finish(makeSuccessResult('The user chose to continue this command in the background. The terminal is still running.'));
+				finish(makeBackgroundExecutionResult('The user chose to continue this command in the background. The terminal is still running.'));
 			}
 		}));
 
@@ -540,10 +557,10 @@ async function executeCommandWithSentinel(
 			const fullContent = terminalManager.getContent(shell.terminalUri) ?? '';
 			const newContent = fullContent.substring(offsetBefore);
 			const output = prepareOutputForModel(newContent);
-			finish(makeFailureResult(
+			finish(makeExecutionResult(makeFailureResult(
 				`Command timed out after ${Math.round(timeoutMs / 1000)}s. Partial output:\n${output}`,
 				'timeout',
-			));
+			)));
 		}, timeoutMs);
 		disposables.add(toDisposable(() => clearTimeout(timer)));
 
@@ -621,11 +638,11 @@ export async function createShellTools(
 			let shouldReleaseShell = true;
 			try {
 				const result = await executeCommandInShell(ref.object, args.command, timeoutMs, terminalManager, logService);
-				if (result.error === 'alternateBuffer') {
+				if (result.keepShellBusy) {
 					shouldReleaseShell = false;
-					shellManager.keepBusyUntilCommandFinishes(ref.object);
+					shellManager.holdShellUntilCommandFinishes(ref.object);
 				}
-				return result;
+				return result.toolResult;
 			} finally {
 				if (shouldReleaseShell) {
 					ref.dispose();

--- a/src/vs/platform/agentHost/test/node/agentHostHeadlessTerminal.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostHeadlessTerminal.test.ts
@@ -82,6 +82,26 @@ suite('AgentHostHeadlessTerminal', () => {
 		assert.strictEqual(terminal.isBracketedPasteMode(), false);
 	});
 
+	test('resolves alt-buffer promise on alternate buffer entry', async () => {
+		const terminal = createTerminal();
+		const altBufferStore = disposables.add(new DisposableStore());
+		const altBufferPromise = terminal.createAltBufferPromise(altBufferStore);
+		let resolved = false;
+		void altBufferPromise.then(() => resolved = true);
+
+		assert.strictEqual(terminal.isInAltBuffer(), false);
+		await terminal.writePtyData('\x1b[?1049h');
+		assert.strictEqual(terminal.isInAltBuffer(), true);
+		await altBufferPromise;
+		assert.strictEqual(resolved, true);
+
+		await terminal.writePtyData('\x1b[?1049h');
+		assert.strictEqual(terminal.isInAltBuffer(), true);
+
+		await terminal.writePtyData('\x1b[?1049l');
+		assert.strictEqual(terminal.isInAltBuffer(), false);
+	});
+
 	test('ignores writes after dispose', async () => {
 		const terminal = createTerminal();
 		const responses: string[] = [];

--- a/src/vs/platform/agentHost/test/node/agentHostTerminalManager.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTerminalManager.test.ts
@@ -361,6 +361,67 @@ suite('AgentHostTerminalManager – command detection integration', () => {
 		assert.deepStrictEqual(pty.writes, ['\x1b[1;4R']);
 	});
 
+	test('resolves alt-buffer promise from headless terminal data', async () => {
+		const logService = new NullLogService();
+		const stateManager = disposables.add(new AgentHostStateManager(logService));
+		const configurationService = disposables.add(new AgentConfigurationService(stateManager, logService));
+		const productService = { _serviceBrand: undefined, applicationName: 'vscode' } as IProductService;
+		const pty = new TestPty();
+		const manager = disposables.add(new TestAgentHostTerminalManager(stateManager, logService, productService, configurationService, pty));
+		const uri = 'agenthost-terminal://test/alt-buffer';
+
+		const createTerminal = manager.createTerminal({
+			terminal: uri,
+			claim: { kind: TerminalClaimKind.Client, clientId: 'test-client' },
+			cwd: process.cwd(),
+			cols: 80,
+			rows: 24,
+		}, { shell: '/bin/bash' });
+
+		await pty.dataListenerRegistered.p;
+		pty.fireData('prompt');
+		await createTerminal;
+
+		const altBufferStore = disposables.add(new DisposableStore());
+		const altBufferPromise = manager.createAltBufferPromise(uri, altBufferStore);
+
+		pty.fireData('\x1b[?1049h');
+
+		await altBufferPromise;
+	});
+
+	test('disposed alt-buffer promise listener does not resolve', async () => {
+		const logService = new NullLogService();
+		const stateManager = disposables.add(new AgentHostStateManager(logService));
+		const configurationService = disposables.add(new AgentConfigurationService(stateManager, logService));
+		const productService = { _serviceBrand: undefined, applicationName: 'vscode' } as IProductService;
+		const pty = new TestPty();
+		const manager = disposables.add(new TestAgentHostTerminalManager(stateManager, logService, productService, configurationService, pty));
+		const uri = 'agenthost-terminal://test/alt-buffer-disposed';
+
+		const createTerminal = manager.createTerminal({
+			terminal: uri,
+			claim: { kind: TerminalClaimKind.Client, clientId: 'test-client' },
+			cwd: process.cwd(),
+			cols: 80,
+			rows: 24,
+		}, { shell: '/bin/bash' });
+
+		await pty.dataListenerRegistered.p;
+		pty.fireData('prompt');
+		await createTerminal;
+
+		const altBufferStore = new DisposableStore();
+		const altBufferPromise = manager.createAltBufferPromise(uri, altBufferStore);
+		let didEnterAltBuffer = false;
+		void altBufferPromise.then(() => didEnterAltBuffer = true);
+		altBufferStore.dispose();
+		pty.fireData('\x1b[?1049h');
+		await timeout(10);
+
+		assert.strictEqual(didEnterAltBuffer, false);
+	});
+
 	test('server-handled CPR queries are stripped from client-facing data', () => {
 		function filter(data: string): string {
 			return removeServerHandledTerminalQueries(data, { pendingData: '' });

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -91,7 +91,7 @@ class TestAgentHostTerminalManager implements IAgentHostTerminalManager {
 	onExit(): IDisposable { return Disposable.None; }
 	onClaimChanged(): IDisposable { return Disposable.None; }
 	onCommandFinished(): IDisposable { return Disposable.None; }
-	createAltBufferPromise(): Promise<void> { return new Promise(() => { }); }
+	createAltBufferPromise(_uri: string, _store: DisposableStore): Promise<void> { return new Promise(() => { }); }
 	getContent(): string | undefined { return undefined; }
 	getClaim(): undefined { return undefined; }
 	hasTerminal(): boolean { return false; }

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -91,6 +91,7 @@ class TestAgentHostTerminalManager implements IAgentHostTerminalManager {
 	onExit(): IDisposable { return Disposable.None; }
 	onClaimChanged(): IDisposable { return Disposable.None; }
 	onCommandFinished(): IDisposable { return Disposable.None; }
+	createAltBufferPromise(): Promise<void> { return new Promise(() => { }); }
 	getContent(): string | undefined { return undefined; }
 	getClaim(): undefined { return undefined; }
 	hasTerminal(): boolean { return false; }

--- a/src/vs/platform/agentHost/test/node/copilotShellTools.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotShellTools.test.ts
@@ -16,7 +16,7 @@ import { InstantiationService } from '../../../instantiation/common/instantiatio
 import { ServiceCollection } from '../../../instantiation/common/serviceCollection.js';
 import { ILogService, NullLogService } from '../../../log/common/log.js';
 import type { CreateTerminalParams } from '../../common/state/protocol/commands.js';
-import type { TerminalClaim, TerminalInfo } from '../../common/state/protocol/state.js';
+import { TerminalClaimKind, type TerminalClaim, type TerminalInfo } from '../../common/state/protocol/state.js';
 import { formatTerminalText, IAgentHostTerminalManager, type ICommandFinishedEvent, type ISendTextOptions } from '../../node/agentHostTerminalManager.js';
 import { createShellTools, isMultilineCommand, ShellManager, prefixForHistorySuppression, shellTypeForExecutable } from '../../node/copilot/copilotShellTools.js';
 
@@ -31,6 +31,8 @@ class TestAgentHostTerminalManager implements IAgentHostTerminalManager {
 	commandDetectionSupported = false;
 	readonly commandFinishedListenerRegistered = new DeferredPromise<void>();
 	private readonly _onCommandFinished = new Emitter<ICommandFinishedEvent>();
+	private readonly _onExit = new Emitter<number>();
+	private readonly _onClaimChanged = new Emitter<TerminalClaim>();
 	private readonly _onDidSendText = new Emitter<void>();
 	readonly onDidSendText = this._onDidSendText.event;
 	private readonly _altBufferPromises: DeferredPromise<void>[] = [];
@@ -47,15 +49,23 @@ class TestAgentHostTerminalManager implements IAgentHostTerminalManager {
 		this._onDidSendText.fire();
 	}
 	onData(): IDisposable { return Disposable.None; }
-	onExit(): IDisposable { return Disposable.None; }
-	onClaimChanged(): IDisposable { return Disposable.None; }
+	onExit(_uri: string, cb: (exitCode: number) => void): IDisposable { return this._onExit.event(cb); }
+	onClaimChanged(_uri: string, cb: (claim: TerminalClaim) => void): IDisposable { return this._onClaimChanged.event(cb); }
 	onCommandFinished(_uri: string, cb: (event: ICommandFinishedEvent) => void): IDisposable {
 		this.commandFinishedListenerRegistered.complete();
 		return this._onCommandFinished.event(cb);
 	}
-	createAltBufferPromise(): Promise<void> {
+	createAltBufferPromise(_uri: string, store: DisposableStore): Promise<void> {
 		const deferred = new DeferredPromise<void>();
 		this._altBufferPromises.push(deferred);
+		store.add({
+			dispose: () => {
+				const index = this._altBufferPromises.indexOf(deferred);
+				if (index !== -1) {
+					this._altBufferPromises.splice(index, 1);
+				}
+			}
+		});
 		return deferred.p;
 	}
 	getContent(): string | undefined { return undefined; }
@@ -68,8 +78,10 @@ class TestAgentHostTerminalManager implements IAgentHostTerminalManager {
 	getTerminalState(): undefined { return undefined; }
 	async getDefaultShell(): Promise<string> { return this.defaultShell; }
 	fireCommandFinished(event: ICommandFinishedEvent): void { this._onCommandFinished.fire(event); }
+	fireExit(exitCode: number): void { this._onExit.fire(exitCode); }
+	fireClaimChanged(claim: TerminalClaim): void { this._onClaimChanged.fire(claim); }
 	fireDidEnterAltBuffer(): void {
-		for (const promise of this._altBufferPromises) {
+		for (const promise of [...this._altBufferPromises]) {
 			promise.complete();
 		}
 	}
@@ -94,7 +106,22 @@ suite('CopilotShellTools', () => {
 
 	async function waitForSentTexts(terminalManager: TestAgentHostTerminalManager, count: number): Promise<void> {
 		while (terminalManager.sentTexts.length < count) {
-			await Event.toPromise(terminalManager.onDidSendText);
+			const didTimeOut = await new Promise<boolean>(resolve => {
+				const disposables = new DisposableStore();
+				const listener = Event.once(terminalManager.onDidSendText)(() => {
+					disposables.dispose();
+					resolve(false);
+				});
+				disposables.add(listener);
+				const handle = setTimeout(() => {
+					disposables.dispose();
+					resolve(true);
+				}, 1000);
+				disposables.add({ dispose: () => clearTimeout(handle) });
+			});
+			if (didTimeOut) {
+				assert.fail(`Timed out waiting for ${count} sendText calls; saw ${terminalManager.sentTexts.length}`);
+			}
 		}
 	}
 
@@ -348,6 +375,96 @@ suite('CopilotShellTools', () => {
 
 		assert.notStrictEqual(next.object.id, shell.id);
 		assert.strictEqual(terminalManager.created.length, 2);
+		next.dispose();
+	});
+
+	test('backgrounded shell is not immediately reused', async () => {
+		const { instantiationService, terminalManager } = createServices();
+		terminalManager.commandDetectionSupported = true;
+		const shellManager = disposables.add(instantiationService.createInstance(ShellManager, URI.parse('copilot:/session-1'), undefined));
+		const tools = await createShellTools(shellManager, terminalManager, new NullLogService());
+		const bashTool = tools.find(tool => tool.name === 'bash');
+		assert.ok(bashTool);
+
+		const invocation: ToolInvocation = {
+			sessionId: 'session-1',
+			toolCallId: 'tool-1',
+			toolName: 'bash',
+			arguments: { command: 'sleep 100', timeout: 1000 },
+		};
+		const resultPromise = bashTool.handler({ command: 'sleep 100', timeout: 1000 }, invocation) as Promise<ToolResultObject>;
+		await waitForSentTexts(terminalManager, 1);
+		terminalManager.fireClaimChanged({ kind: TerminalClaimKind.Session, session: 'copilot:/session-1', turnId: 'turn-1' });
+		const result = await resultPromise;
+		assert.strictEqual(result.resultType, 'success');
+		assert.match(result.textResultForLlm, /continue this command in the background/);
+		markCreatedTerminalsExist(terminalManager);
+		const shell = shellManager.listShells()[0];
+
+		const next = await shellManager.getOrCreateShell('bash', 'turn-2', 'tool-2');
+
+		assert.notStrictEqual(next.object.id, shell.id);
+		assert.strictEqual(terminalManager.created.length, 2);
+		next.dispose();
+	});
+
+	test('backgrounded shell is released when command finishes', async () => {
+		const { instantiationService, terminalManager } = createServices();
+		terminalManager.commandDetectionSupported = true;
+		const shellManager = disposables.add(instantiationService.createInstance(ShellManager, URI.parse('copilot:/session-1'), undefined));
+		const tools = await createShellTools(shellManager, terminalManager, new NullLogService());
+		const bashTool = tools.find(tool => tool.name === 'bash');
+		assert.ok(bashTool);
+
+		const invocation: ToolInvocation = {
+			sessionId: 'session-1',
+			toolCallId: 'tool-1',
+			toolName: 'bash',
+			arguments: { command: 'sleep 100', timeout: 1000 },
+		};
+		const resultPromise = bashTool.handler({ command: 'sleep 100', timeout: 1000 }, invocation) as Promise<ToolResultObject>;
+		await waitForSentTexts(terminalManager, 1);
+		terminalManager.fireClaimChanged({ kind: TerminalClaimKind.Session, session: 'copilot:/session-1', turnId: 'turn-1' });
+		const result = await resultPromise;
+		assert.strictEqual(result.resultType, 'success');
+		markCreatedTerminalsExist(terminalManager);
+		const shell = shellManager.listShells()[0];
+
+		terminalManager.fireCommandFinished({ commandId: 'cmd-1', exitCode: 0, command: 'sleep 100', output: '' });
+		const next = await shellManager.getOrCreateShell('bash', 'turn-2', 'tool-2');
+
+		assert.strictEqual(next.object.id, shell.id);
+		assert.strictEqual(terminalManager.created.length, 1);
+		next.dispose();
+	});
+
+	test('backgrounded shell is released when terminal exits', async () => {
+		const { instantiationService, terminalManager } = createServices();
+		terminalManager.commandDetectionSupported = true;
+		const shellManager = disposables.add(instantiationService.createInstance(ShellManager, URI.parse('copilot:/session-1'), undefined));
+		const tools = await createShellTools(shellManager, terminalManager, new NullLogService());
+		const bashTool = tools.find(tool => tool.name === 'bash');
+		assert.ok(bashTool);
+
+		const invocation: ToolInvocation = {
+			sessionId: 'session-1',
+			toolCallId: 'tool-1',
+			toolName: 'bash',
+			arguments: { command: 'sleep 100', timeout: 1000 },
+		};
+		const resultPromise = bashTool.handler({ command: 'sleep 100', timeout: 1000 }, invocation) as Promise<ToolResultObject>;
+		await waitForSentTexts(terminalManager, 1);
+		terminalManager.fireClaimChanged({ kind: TerminalClaimKind.Session, session: 'copilot:/session-1', turnId: 'turn-1' });
+		const result = await resultPromise;
+		assert.strictEqual(result.resultType, 'success');
+		markCreatedTerminalsExist(terminalManager);
+		const shell = shellManager.listShells()[0];
+
+		terminalManager.fireExit(0);
+		const next = await shellManager.getOrCreateShell('bash', 'turn-2', 'tool-2');
+
+		assert.strictEqual(next.object.id, shell.id);
+		assert.strictEqual(terminalManager.created.length, 1);
 		next.dispose();
 	});
 

--- a/src/vs/platform/agentHost/test/node/copilotShellTools.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotShellTools.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import type { ToolInvocation, ToolResultObject } from '@github/copilot-sdk';
-import { DeferredPromise } from '../../../../base/common/async.js';
+import { DeferredPromise, timeout } from '../../../../base/common/async.js';
 import { URI } from '../../../../base/common/uri.js';
 import * as platform from '../../../../base/common/platform.js';
 import { Emitter } from '../../../../base/common/event.js';
@@ -31,6 +31,7 @@ class TestAgentHostTerminalManager implements IAgentHostTerminalManager {
 	commandDetectionSupported = false;
 	readonly commandFinishedListenerRegistered = new DeferredPromise<void>();
 	private readonly _onCommandFinished = new Emitter<ICommandFinishedEvent>();
+	private readonly _altBufferPromises: DeferredPromise<void>[] = [];
 
 	async createTerminal(params: CreateTerminalParams, options?: { shell?: string; preventShellHistory?: boolean; nonInteractive?: boolean }): Promise<void> {
 		this.created.push({ params, options: { ...options, shell: options?.shell ?? this.defaultShell } });
@@ -49,6 +50,11 @@ class TestAgentHostTerminalManager implements IAgentHostTerminalManager {
 		this.commandFinishedListenerRegistered.complete();
 		return this._onCommandFinished.event(cb);
 	}
+	createAltBufferPromise(): Promise<void> {
+		const deferred = new DeferredPromise<void>();
+		this._altBufferPromises.push(deferred);
+		return deferred.p;
+	}
 	getContent(): string | undefined { return undefined; }
 	getClaim(): TerminalClaim | undefined { return undefined; }
 	hasTerminal(uri: string): boolean { return this.existingTerminalUris.has(uri); }
@@ -59,6 +65,11 @@ class TestAgentHostTerminalManager implements IAgentHostTerminalManager {
 	getTerminalState(): undefined { return undefined; }
 	async getDefaultShell(): Promise<string> { return this.defaultShell; }
 	fireCommandFinished(event: ICommandFinishedEvent): void { this._onCommandFinished.fire(event); }
+	fireDidEnterAltBuffer(): void {
+		for (const promise of this._altBufferPromises) {
+			promise.complete();
+		}
+	}
 }
 
 suite('CopilotShellTools', () => {
@@ -76,6 +87,21 @@ suite('CopilotShellTools', () => {
 		const instantiationService: IInstantiationService = disposables.add(new InstantiationService(services));
 		services.set(IInstantiationService, instantiationService);
 		return { instantiationService, terminalManager };
+	}
+
+	async function waitForSentTexts(terminalManager: TestAgentHostTerminalManager, count: number): Promise<void> {
+		for (let i = 0; i < 20; i++) {
+			if (terminalManager.sentTexts.length >= count) {
+				return;
+			}
+			await timeout(10);
+		}
+	}
+
+	function markCreatedTerminalsExist(terminalManager: TestAgentHostTerminalManager): void {
+		for (const created of terminalManager.created) {
+			terminalManager.existingTerminalUris.add(created.params.terminal);
+		}
 	}
 
 	test('uses session working directory for created shells', async () => {
@@ -217,6 +243,112 @@ suite('CopilotShellTools', () => {
 		assert.strictEqual(terminalManager.sentTexts.length, 1);
 		assert.strictEqual(terminalManager.sentTexts[0].options.bracketedPasteMode, true);
 		assert.strictEqual(terminalManager.writes[0].data, ' echo first\recho second\r');
+	});
+
+	test('primary shell tool returns alternateBuffer when shell integration enters alt buffer', async () => {
+		const { instantiationService, terminalManager } = createServices();
+		terminalManager.commandDetectionSupported = true;
+		const shellManager = disposables.add(instantiationService.createInstance(ShellManager, URI.parse('copilot:/session-1'), undefined));
+		const tools = await createShellTools(shellManager, terminalManager, new NullLogService());
+		const bashTool = tools.find(tool => tool.name === 'bash');
+		assert.ok(bashTool);
+
+		const invocation: ToolInvocation = {
+			sessionId: 'session-1',
+			toolCallId: 'tool-1',
+			toolName: 'bash',
+			arguments: { command: 'vim README.md', timeout: 1000 },
+		};
+		const resultPromise = bashTool.handler({ command: 'vim README.md', timeout: 1000 }, invocation) as Promise<ToolResultObject>;
+		await waitForSentTexts(terminalManager, 1);
+		terminalManager.fireDidEnterAltBuffer();
+		const result = await resultPromise;
+
+		assert.strictEqual(result.resultType, 'failure');
+		assert.strictEqual(result.error, 'alternateBuffer');
+		assert.match(result.textResultForLlm, /opened the alternate buffer/);
+	});
+
+	test('primary shell tool returns alternateBuffer when sentinel fallback enters alt buffer', async () => {
+		const { instantiationService, terminalManager } = createServices();
+		const shellManager = disposables.add(instantiationService.createInstance(ShellManager, URI.parse('copilot:/session-1'), undefined));
+		const tools = await createShellTools(shellManager, terminalManager, new NullLogService());
+		const bashTool = tools.find(tool => tool.name === 'bash');
+		assert.ok(bashTool);
+
+		const invocation: ToolInvocation = {
+			sessionId: 'session-1',
+			toolCallId: 'tool-1',
+			toolName: 'bash',
+			arguments: { command: 'vim README.md', timeout: 1000 },
+		};
+		const resultPromise = bashTool.handler({ command: 'vim README.md', timeout: 1000 }, invocation) as Promise<ToolResultObject>;
+		await waitForSentTexts(terminalManager, 2);
+		terminalManager.fireDidEnterAltBuffer();
+		const result = await resultPromise;
+
+		assert.strictEqual(result.resultType, 'failure');
+		assert.strictEqual(result.error, 'alternateBuffer');
+		assert.match(result.textResultForLlm, /opened the alternate buffer/);
+	});
+
+	test('alt-buffer shell is released when command finishes', async () => {
+		const { instantiationService, terminalManager } = createServices();
+		terminalManager.commandDetectionSupported = true;
+		const shellManager = disposables.add(instantiationService.createInstance(ShellManager, URI.parse('copilot:/session-1'), undefined));
+		const tools = await createShellTools(shellManager, terminalManager, new NullLogService());
+		const bashTool = tools.find(tool => tool.name === 'bash');
+		assert.ok(bashTool);
+
+		const invocation: ToolInvocation = {
+			sessionId: 'session-1',
+			toolCallId: 'tool-1',
+			toolName: 'bash',
+			arguments: { command: 'vim README.md', timeout: 1000 },
+		};
+		const resultPromise = bashTool.handler({ command: 'vim README.md', timeout: 1000 }, invocation) as Promise<ToolResultObject>;
+		await waitForSentTexts(terminalManager, 1);
+		terminalManager.fireDidEnterAltBuffer();
+		const result = await resultPromise;
+		assert.strictEqual(result.error, 'alternateBuffer');
+		markCreatedTerminalsExist(terminalManager);
+		const shell = shellManager.listShells()[0];
+
+		terminalManager.fireCommandFinished({ commandId: 'cmd-1', exitCode: 0, command: 'vim README.md', output: '' });
+		const next = await shellManager.getOrCreateShell('bash', 'turn-2', 'tool-2');
+
+		assert.strictEqual(next.object.id, shell.id);
+		assert.strictEqual(terminalManager.created.length, 1);
+		next.dispose();
+	});
+
+	test('alt-buffer shell is not immediately reused', async () => {
+		const { instantiationService, terminalManager } = createServices();
+		terminalManager.commandDetectionSupported = true;
+		const shellManager = disposables.add(instantiationService.createInstance(ShellManager, URI.parse('copilot:/session-1'), undefined));
+		const tools = await createShellTools(shellManager, terminalManager, new NullLogService());
+		const bashTool = tools.find(tool => tool.name === 'bash');
+		assert.ok(bashTool);
+
+		const invocation: ToolInvocation = {
+			sessionId: 'session-1',
+			toolCallId: 'tool-1',
+			toolName: 'bash',
+			arguments: { command: 'vim README.md', timeout: 1000 },
+		};
+		const resultPromise = bashTool.handler({ command: 'vim README.md', timeout: 1000 }, invocation) as Promise<ToolResultObject>;
+		await waitForSentTexts(terminalManager, 1);
+		terminalManager.fireDidEnterAltBuffer();
+		const result = await resultPromise;
+		assert.strictEqual(result.error, 'alternateBuffer');
+		markCreatedTerminalsExist(terminalManager);
+		const shell = shellManager.listShells()[0];
+
+		const next = await shellManager.getOrCreateShell('bash', 'turn-2', 'tool-2');
+
+		assert.notStrictEqual(next.object.id, shell.id);
+		assert.strictEqual(terminalManager.created.length, 2);
+		next.dispose();
 	});
 
 	test('primary shell tool only forces bracketed paste for single-line commands on macOS', async () => {

--- a/src/vs/platform/agentHost/test/node/copilotShellTools.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotShellTools.test.ts
@@ -5,10 +5,10 @@
 
 import assert from 'assert';
 import type { ToolInvocation, ToolResultObject } from '@github/copilot-sdk';
-import { DeferredPromise, timeout } from '../../../../base/common/async.js';
+import { DeferredPromise } from '../../../../base/common/async.js';
 import { URI } from '../../../../base/common/uri.js';
 import * as platform from '../../../../base/common/platform.js';
-import { Emitter } from '../../../../base/common/event.js';
+import { Emitter, Event } from '../../../../base/common/event.js';
 import { Disposable, DisposableStore, type IDisposable } from '../../../../base/common/lifecycle.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { IInstantiationService } from '../../../instantiation/common/instantiation.js';
@@ -31,6 +31,8 @@ class TestAgentHostTerminalManager implements IAgentHostTerminalManager {
 	commandDetectionSupported = false;
 	readonly commandFinishedListenerRegistered = new DeferredPromise<void>();
 	private readonly _onCommandFinished = new Emitter<ICommandFinishedEvent>();
+	private readonly _onDidSendText = new Emitter<void>();
+	readonly onDidSendText = this._onDidSendText.event;
 	private readonly _altBufferPromises: DeferredPromise<void>[] = [];
 
 	async createTerminal(params: CreateTerminalParams, options?: { shell?: string; preventShellHistory?: boolean; nonInteractive?: boolean }): Promise<void> {
@@ -42,6 +44,7 @@ class TestAgentHostTerminalManager implements IAgentHostTerminalManager {
 	async sendText(uri: string, data: string, options: ISendTextOptions): Promise<void> {
 		this.sentTexts.push({ uri, data, options });
 		this.writeInput(uri, formatTerminalText(data, options));
+		this._onDidSendText.fire();
 	}
 	onData(): IDisposable { return Disposable.None; }
 	onExit(): IDisposable { return Disposable.None; }
@@ -90,11 +93,8 @@ suite('CopilotShellTools', () => {
 	}
 
 	async function waitForSentTexts(terminalManager: TestAgentHostTerminalManager, count: number): Promise<void> {
-		for (let i = 0; i < 20; i++) {
-			if (terminalManager.sentTexts.length >= count) {
-				return;
-			}
-			await timeout(10);
+		while (terminalManager.sentTexts.length < count) {
+			await Event.toPromise(terminalManager.onDidSendText);
 		}
 	}
 


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/314889
Part of: https://github.com/microsoft/vscode/issues/314189

- Add Agent Host detection for commands that enter xterm's alternate screen buffer.
- Return a structured `alternateBuffer` result when a shell command opens an interactive terminal UI such as `vim`.
- Keep that shell marked busy after the tool result returns, until the command finishes or the terminal exits.
- Prevent follow-up shell commands from being routed into the existing TUI buffer, for example `echo AFTER_VIM` being typed into Vim instead of a shell.
- Keep SDK-facing tool results separate from Agent Host shell lifecycle metadata via an internal shell execution result shape.
- Cover both shell-integration and sentinel fallback execution paths.


Expected with this PR:

- The first command returns with an `alternateBuffer` style result while Vim remains open.
- `SHOULD_NOT_REACH` is not printed.
- `echo AFTER_VIM` is not typed into the existing Vim buffer; Agent Host keeps that shell busy and uses another shell for unrelated commands.



Steps to manually validate:

A repro close to the original issue is a merge commit that opens Vim for the commit message, followed by another shell command:

```sh
tmp=$(mktemp -d); cd "$tmp" && git init -q && git config user.email a@b.c && git config user.name A && echo base > f && git add f && git commit -m base -q && git checkout -q -b feature && echo feature > feature.txt && git add feature.txt && git commit -m feature -q && git checkout -q - && echo main > main.txt && git add main.txt && git commit -m main -q && git merge --no-ff --no-commit feature -q && git status --short && if [[ -f .git/MERGE_HEAD || -f $(git rev-parse --git-path MERGE_HEAD) ]]; then TERM=xterm-256color GIT_EDITOR='vim -Nu NONE -n' git commit; fi && echo SHOULD_NOT_REACH
```

Then ask for:

```sh
echo AFTER_VIM
```



Follow-up:

- This follows the workbench execute-strategy signal: xterm alternate-buffer entry means the command likely launched an interactive terminal UI.
- Agent Host only implements the minimal handling for now: return `alternateBuffer`, keep the command running, and prevent the shell from being reused by unrelated tool calls.
- This can return before a command would have naturally completed if the command only enters the alternate buffer temporarily.
- Agent Host does not yet have the full workbench terminal tool flow around this signal, such as active terminal execution IDs, output monitoring, input-needed detection, idle-silence promotion, or richer follow-up terminal tools.
- Future work should bring more of that workbench flow to Agent Host for better parity.

-----------------------------------------
Inspirations from:

- Alternate-buffer detection comes from [`createAltBufferPromise`](https://github.com/microsoft/vscode/blob/d188e2d1096bc4c9251c5d293d013e12e44ffc48/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/strategyHelpers.ts#L54-L78), which checks whether xterm's active buffer is the alternate buffer and completes when that state is reached.
- Racing command completion against alternate-buffer entry comes from [`richExecuteStrategy`](https://github.com/microsoft/vscode/blob/d188e2d1096bc4c9251c5d293d013e12e44ffc48/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/richExecuteStrategy.ts#L160-L195) and [`basicExecuteStrategy`](https://github.com/microsoft/vscode/blob/d188e2d1096bc4c9251c5d293d013e12e44ffc48/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/basicExecuteStrategy.ts#L176-L240).
- The local `IShellExecutionResult` shape follows the same separation as [`ITerminalExecuteStrategyResult`](https://github.com/microsoft/vscode/blob/d188e2d1096bc4c9251c5d293d013e12e44ffc48/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/executeStrategy.ts#L31-L37): command execution returns terminal-specific metadata first, and the outer tool layer maps that into the final tool result.
- The `alternateBuffer` result shape and user-facing intent come from [`RunInTerminalTool`](https://github.com/microsoft/vscode/blob/d188e2d1096bc4c9251c5d293d013e12e44ffc48/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts#L468-L469) and its `didEnterAltBuffer` handling in [`RunInTerminalTool`](https://github.com/microsoft/vscode/blob/d188e2d1096bc4c9251c5d293d013e12e44ffc48/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts#L1758-L1768).
- The shell hold/release bookkeeping is Agent Host-specific: workbench has richer terminal execution ownership, while Agent Host has a reusable shell pool and needs to keep an early-returned alt-buffer/background shell unavailable until command finish or terminal exit.
