### PR TITLE
[Bug Fix] Execution Subagent: Compare shell type with "pwsh" in addition to "powershell"

### DIFF
--- a/extensions/copilot/src/extension/prompt/node/executionSubagentToolCallingLoop.ts
+++ b/extensions/copilot/src/extension/prompt/node/executionSubagentToolCallingLoop.ts
@@ -119,7 +119,7 @@ export class ExecutionSubagentToolCallingLoop extends ToolCallingLoop<IExecution
 
 		if (useAgenticProxy) {
 			// Our custom models are not trained for PowerShell yet. Fall back to main agent endpoint.
-			if (shellType === 'powershell') {
+			if (shellType === 'powershell' || shellType === 'pwsh') {
 				return await this.endpointProvider.getChatEndpoint(this.options.request);
 			}
 			// Use agentic proxy with ExecutionSubagentModel or default to DEFAULT_AGENTIC_PROXY_MODEL


### PR DESCRIPTION
Addresses a bug in #313521 . `shellType` can be `powershell` or `pwsh` for Powershell, but the check in #313521 only checks for `powershell`.