### PR TITLE
Fix subagent detection in responsesApi.ts (`startsWith('subagent')` regression)

### DIFF
--- a/extensions/copilot/src/platform/endpoint/node/messagesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/messagesApi.ts
@@ -15,7 +15,7 @@ import { ConfigKey, IConfigurationService } from '../../configuration/common/con
 import { ILogService } from '../../log/common/logService';
 import { AnthropicMessagesTool, ContextManagementResponse, CUSTOM_TOOL_SEARCH_NAME, getContextManagementFromConfig, isAnthropicContextEditingEnabled, isExtendedCacheTtlEnabled } from '../../networking/common/anthropic';
 import { FinishedCallback, getRequestId, IIPCodeCitation, IResponseDelta } from '../../networking/common/fetch';
-import { IChatEndpoint, ICreateEndpointBodyOptions, IEndpointBody } from '../../networking/common/networking';
+import { IChatEndpoint, ICreateEndpointBodyOptions, IEndpointBody, isSubagentRequest } from '../../networking/common/networking';
 import { ChatCompletion, FinishedCompletionReason, rawMessageToCAPI } from '../../networking/common/openai';
 import { IToolDeferralService } from '../../networking/common/toolDeferralService';
 import { sendEngineMessagesTelemetry } from '../../networking/node/chatStream';
@@ -185,7 +185,7 @@ export function createMessagesRequestBody(accessor: ServicesAccessor, options: I
 	// `interactionTypeOverride: 'conversation-subagent'`, which is also the
 	// source of truth for the `X-Interaction-Type` wire header. The rolling
 	// breakpoints on messages always use the default 5m TTL.
-	const isSubagent = options.interactionTypeOverride === 'conversation-subagent';
+	const isSubagent = isSubagentRequest(options);
 	const useExtendedCacheTtl = isExtendedCacheTtlEnabled(endpoint, configurationService, experimentationService, options.location, isSubagent);
 	const cacheTtl = useExtendedCacheTtl ? '1h' : undefined;
 

--- a/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
@@ -19,7 +19,7 @@ import { ConfigKey, IConfigurationService } from '../../configuration/common/con
 import { ILogService } from '../../log/common/logService';
 import { CUSTOM_TOOL_SEARCH_NAME } from '../../networking/common/anthropic';
 import { FinishedCallback, getRequestId, IResponseDelta, OpenAiFunctionTool, OpenAiResponsesFunctionTool, OpenAiToolSearchTool } from '../../networking/common/fetch';
-import { IChatEndpoint, ICreateEndpointBodyOptions, IEndpointBody } from '../../networking/common/networking';
+import { IChatEndpoint, ICreateEndpointBodyOptions, IEndpointBody, isSubagentRequest } from '../../networking/common/networking';
 import { APIErrorResponse, ChatCompletion, FilterReason, FinishedCompletionReason, modelsWithoutResponsesContextManagement, openAIContextManagementCompactionType, OpenAIContextManagementResponse, rawMessageToCAPI, TokenLogProb } from '../../networking/common/openai';
 import { IToolDeferralService } from '../../networking/common/toolDeferralService';
 import { sendEngineMessagesTelemetry, sendResponsesApiCompactionTelemetry } from '../../networking/node/chatStream';
@@ -66,7 +66,7 @@ export function createResponsesRequestBody(accessor: ServicesAccessor, options: 
 	const toolSearchEnabled = !!endpoint.supportsToolSearch
 		&& !!options.requestOptions?.tools?.some(t => t.function.name === CUSTOM_TOOL_SEARCH_NAME);
 	const isAllowedConversationAgent = options.location === ChatLocation.Agent || options.location === ChatLocation.MessagesProxy;
-	const isSubagent = options.telemetryProperties?.subType?.startsWith('subagent') ?? false;
+	const isSubagent = isSubagentRequest(options);
 	const shouldDeferTools = toolSearchEnabled && isAllowedConversationAgent && !isSubagent;
 	const toolDeferralService = shouldDeferTools ? accessor.get(IToolDeferralService) : undefined;
 

--- a/extensions/copilot/src/platform/endpoint/node/test/responsesApiToolSearch.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/responsesApiToolSearch.spec.ts
@@ -172,6 +172,70 @@ describe('createResponsesRequestBody tools', () => {
 		expect(tools.every(t => !t.defer_loading)).toBe(true);
 	});
 
+	// Regression coverage for https://github.com/microsoft/vscode/issues/316154:
+	// the original gate used `subType?.startsWith('subagent')`, which never matched
+	// the producer values `'execution_subagent'` and `'search_subagent'` (subagent
+	// is a suffix, not a prefix). All three subagent shapes must skip client tool
+	// deferral so the subagent loop receives its full toolset directly.
+	describe('subagent gate (issue #316154)', () => {
+		function getToolNames(overrides: Partial<ICreateEndpointBodyOptions>): string[] {
+			const endpoint = createMockEndpoint('gpt-5.4');
+			const body = accessor.get(IInstantiationService).invokeFunction(
+				createResponsesRequestBody, createMockOptions(overrides), endpoint.model, endpoint
+			);
+			return (body.tools as any[]).map(t => t.name ?? t.type);
+		}
+
+		// All deferred tools from the default mock options should be present (not
+		// stripped) and the client `tool_search` entry should NOT be added.
+		const expectedNonDeferredToolNames = [
+			'read_file', 'grep_search', 'some_mcp_tool', 'another_deferred_tool',
+		];
+
+		it('execution_subagent (subType from executionSubagentToolCallingLoop) skips deferral', () => {
+			expect(getToolNames({
+				telemetryProperties: { subType: 'execution_subagent' },
+				interactionTypeOverride: 'conversation-subagent',
+			}).sort()).toEqual(expectedNonDeferredToolNames.sort());
+		});
+
+		it('search_subagent (subType from searchSubagentToolCallingLoop) skips deferral', () => {
+			expect(getToolNames({
+				telemetryProperties: { subType: 'search_subagent' },
+				interactionTypeOverride: 'conversation-subagent',
+			}).sort()).toEqual(expectedNonDeferredToolNames.sort());
+		});
+
+		it('literal "subagent" subType (from defaultIntentRequestHandler) skips deferral', () => {
+			expect(getToolNames({
+				telemetryProperties: { subType: 'subagent' },
+				interactionTypeOverride: 'conversation-subagent',
+			}).sort()).toEqual(expectedNonDeferredToolNames.sort());
+		});
+
+		it('interactionTypeOverride alone is sufficient to skip deferral', () => {
+			expect(getToolNames({
+				interactionTypeOverride: 'conversation-subagent',
+			}).sort()).toEqual(expectedNonDeferredToolNames.sort());
+		});
+
+		it('hypothetical future subagent name (e.g. explore_subagent) skips deferral', () => {
+			expect(getToolNames({
+				telemetryProperties: { subType: 'explore_subagent' },
+			}).sort()).toEqual(expectedNonDeferredToolNames.sort());
+		});
+
+		it('non-subagent agent request still defers MCP tools', () => {
+			const names = getToolNames({
+				telemetryProperties: { subType: 'system-initiated' },
+			});
+			expect(names).toContain('tool_search');
+			expect(names).toContain('read_file');
+			expect(names).not.toContain('some_mcp_tool');
+			expect(names).not.toContain('another_deferred_tool');
+		});
+	});
+
 	it('does not defer tools when tool_search is not in the request tool list', () => {
 		// Repro for https://github.com/microsoft/vscode/issues/311946: a custom agent with
 		// `tools: ['my-mcp-server/*']` filters out tool_search. Without this gate, every

--- a/extensions/copilot/src/platform/networking/common/networking.ts
+++ b/extensions/copilot/src/platform/networking/common/networking.ts
@@ -255,6 +255,35 @@ export type IChatRequestTelemetryProperties = {
 	iterationNumber?: string;
 };
 
+/**
+ * Returns `true` when the given chat request is a subagent invocation.
+ *
+ * All three subagent call sites — the search loop, the execution loop, and
+ * the Task-tool-spawned agent in the panel — set BOTH:
+ * - `interactionTypeOverride: 'conversation-subagent'` (the source of truth
+ *   for the `X-Interaction-Type` wire header), and
+ * - `telemetryProperties.subType` containing `'subagent'` (currently one of
+ *   `'execution_subagent'`, `'search_subagent'`, or the literal `'subagent'`).
+ *
+ * The structured `interactionTypeOverride` check is the primary signal; the
+ * `subType` substring check is a robust fallback that stays correct if either
+ * signal is missed at a call site and matches future subagent names like
+ * `'explore_subagent'` automatically (using `includes` rather than
+ * `startsWith`).
+ *
+ * Keep both API paths (Messages, Responses) in sync by going through this
+ * helper instead of duplicating the check inline — see issue #316154 for the
+ * `startsWith('subagent')` regression that motivated this helper.
+ */
+export function isSubagentRequest(
+	options: Pick<IMakeChatRequestOptions, 'interactionTypeOverride' | 'telemetryProperties'>,
+): boolean {
+	if (options.interactionTypeOverride === 'conversation-subagent') {
+		return true;
+	}
+	return options.telemetryProperties?.subType?.includes('subagent') ?? false;
+}
+
 export interface ICreateEndpointBodyOptions extends IMakeChatRequestOptions {
 	requestId: string;
 	postOptions: OptionalChatRequestParams;


### PR DESCRIPTION
Fixes #316154.

## Problem

The gate at [`responsesApi.ts:69`](https://github.com/microsoft/vscode/blob/main/extensions/copilot/src/platform/endpoint/node/responsesApi.ts#L69) used `subType?.startsWith('subagent')`, which never matched in practice. Producers set `subType` to:

| File | Value |
|---|---|
| `executionSubagentToolCallingLoop.ts:366` | `'execution_subagent'` |
| `searchSubagentToolCallingLoop.ts:172` | `'search_subagent'` |
| `defaultIntentRequestHandler.ts:728` | literal `'subagent'` |

Commit `5e01ed5de06` (*"rename agent type so it doesn't get redacted"*) moved `subagent` from prefix to suffix on the first two values but didn't update the consumer. As a result, `shouldDeferTools` was incorrectly `true` for every subagent request, causing client-executed tool search to defer tools even though the gate was intended to exclude subagents.

## Fix

Extract a shared `isSubagentRequest(options)` helper next to the `IChatRequestTelemetryProperties` declaration in `networking.ts` that:

1. Primarily checks `interactionTypeOverride === 'conversation-subagent'` — the structured signal that all three subagent call sites set today, and which is also the source of truth for the `X-Interaction-Type` wire header.
2. Falls back to `telemetryProperties.subType.includes('subagent')` (note: `includes`, not `startsWith`) so the detection stays correct if either signal regresses and so that future subagent subTypes like `'explore_subagent'` are matched automatically.

Use the helper in both `responsesApi.ts` (the actual bug fix) **and** `messagesApi.ts` (replaces the manual `interactionTypeOverride` check) so the two API paths stay in sync. `chatEndpoint.ts` only has access to the `interactionTypeOverride` primitive so its existing check is left as-is.

## Tests

Added a `subagent gate (issue #316154)` `describe` block in `responsesApiToolSearch.spec.ts` that asserts client tool deferral is skipped for:
- `execution_subagent` subType
- `search_subagent` subType
- literal `'subagent'` subType (panel handler)
- `interactionTypeOverride: 'conversation-subagent'` alone
- hypothetical future names like `'explore_subagent'`

…and that **non-subagent** agent requests still defer MCP tools as before.

```
✓ src/platform/endpoint/node/test/responsesApiToolSearch.spec.ts (19 tests) 9ms
✓ src/platform/endpoint/test/node/messagesApi.spec.ts (65 tests) 24ms
```

## Acceptance

- [x] `responsesApi.ts` correctly identifies `execution_subagent` and `search_subagent` requests as subagents
- [x] Shared helper used by both Messages and Responses API code paths