### PR TITLE
Fix initial editor part size

### DIFF
--- a/src/vs/sessions/browser/parts/editorPart.ts
+++ b/src/vs/sessions/browser/parts/editorPart.ts
@@ -14,6 +14,10 @@ export class MainEditorPart extends MainEditorPartBase {
 	static readonly MARGIN_LEFT = 5;
 	static readonly MARGIN_RIGHT = 5;
 
+	override get minimumWidth() {
+		return Math.max(300, super.minimumWidth);
+	}
+
 	override priority = LayoutPriority.High;
 
 	override layout(width: number, height: number, top: number, left: number): void {

--- a/src/vs/sessions/browser/workbench.ts
+++ b/src/vs/sessions/browser/workbench.ts
@@ -300,11 +300,13 @@ export class Workbench extends Disposable implements IAgentWorkbenchLayoutServic
 	readonly openedDefaultEditors = false;
 
 	private _savedPartSizes: IPartSizesState = {};
+	private _editorInitialSizeApplied = false;
 
 	//#endregion
 
 	private static readonly _PART_VISIBILITY_KEY = 'workbench.sessions.partVisibility';
 	private static readonly _PART_SIZES_KEY = 'workbench.sessions.partSizes';
+	private static readonly _EDITOR_INITIAL_SIZE_APPLIED_KEY = 'workbench.sessions.editorInitialSizeApplied';
 
 	//#region Services
 
@@ -721,6 +723,7 @@ export class Workbench extends Disposable implements IAgentWorkbenchLayoutServic
 		// grid descriptor so editor/sidebar/auxbar/panel restore to their previous
 		// dimensions across reloads.
 		this._savedPartSizes = this._loadPartSizes(storageService);
+		this._editorInitialSizeApplied = storageService.getBoolean(Workbench._EDITOR_INITIAL_SIZE_APPLIED_KEY, StorageScope.WORKSPACE, false);
 
 		// State specific classes
 		const platformClass = isWindows ? 'windows' : isLinux ? 'linux' : 'mac';
@@ -1663,9 +1666,36 @@ export class Workbench extends Disposable implements IAgentWorkbenchLayoutServic
 
 		if (this.editorPartView) {
 			this.workbenchGrid.setViewVisible(this.editorPartView, !hidden);
+
+			const shouldApplyInitialSize = !hidden && !this._editorInitialSizeApplied;
+			if (shouldApplyInitialSize) {
+				this._applyInitialEditorSize();
+			}
 		}
 
 		this._savePartVisibility();
+	}
+
+	/**
+	 * Sizes the editor part to half of the given chat bar width on its first
+	 * appearance in this workspace. The result is persisted so subsequent
+	 * show/hide cycles leave the user's chosen sizes untouched.
+	*/
+	private _applyInitialEditorSize(): void {
+		// On the very first time the editor becomes visible, capture the
+		// chat bar width before showing so we can size the editor to half
+		// of it afterwards. The editor is hidden by default, so without this
+		// initial split it would appear too small
+		const mainAreaWidth = this.workbenchGrid.getViewSize(this.chatBarPartView).width + this.workbenchGrid.getViewSize(this.editorPartView).width;
+		const targetEditorWidth = Math.max(300, Math.floor(mainAreaWidth / 2));
+		const currentEditorSize = this.workbenchGrid.getViewSize(this.editorPartView);
+		this.workbenchGrid.resizeView(this.editorPartView, {
+			width: targetEditorWidth,
+			height: currentEditorSize.height
+		});
+
+		this._editorInitialSizeApplied = true;
+		this.storageService.store(Workbench._EDITOR_INITIAL_SIZE_APPLIED_KEY, true, StorageScope.WORKSPACE, StorageTarget.MACHINE);
 	}
 
 	private setPanelHidden(hidden: boolean): void {


### PR DESCRIPTION
```Copilot Generated Description:``` Adjust the initial size of the editor part to be half of the chat bar width upon its first appearance, ensuring it does not appear too small. Store the state to prevent resizing on subsequent show/hide cycles.

