### PR TITLE
Add IntelliSense suggestions for `group` in menu contributions (fixes #42475)

### DIFF
--- a/src/vs/workbench/services/actions/common/menusExtensionPoint.ts
+++ b/src/vs/workbench/services/actions/common/menusExtensionPoint.ts
@@ -669,6 +669,23 @@ namespace schema {
 		return true;
 	}
 
+	// Common group identifiers used throughout the workbench. Exposed as
+	// completion suggestions for the `group` property so extension authors can
+	// discover valid values while retaining the freedom to use custom groups.
+	const groupDefaultSnippets: NonNullable<IJSONSchema['defaultSnippets']> = [
+		{ label: 'navigation', bodyText: '"navigation"', description: localize('vscode.extension.contributes.menuItem.group.navigation', "Primary toolbar group. Items are rendered inline (e.g. editor/title, view/title).") },
+		{ label: 'inline', bodyText: '"inline"', description: localize('vscode.extension.contributes.menuItem.group.inline', "Items are rendered inline in tree/list rows (e.g. view/item/context, scm/resourceState/context).") },
+		{ label: '1_modification', bodyText: '"1_modification"', description: localize('vscode.extension.contributes.menuItem.group.modification1', "Common group for modification actions, typically shown first (e.g. editor/context).") },
+		{ label: '2_workspace', bodyText: '"2_workspace"', description: localize('vscode.extension.contributes.menuItem.group.workspace', "Common group for workspace-related actions (e.g. explorer/context).") },
+		{ label: '3_compare', bodyText: '"3_compare"', description: localize('vscode.extension.contributes.menuItem.group.compare', "Common group for compare actions (e.g. explorer/context).") },
+		{ label: '4_search', bodyText: '"4_search"', description: localize('vscode.extension.contributes.menuItem.group.search', "Common group for search actions (e.g. explorer/context).") },
+		{ label: '5_cutcopypaste', bodyText: '"5_cutcopypaste"', description: localize('vscode.extension.contributes.menuItem.group.cutcopypaste5', "Common group for cut/copy/paste actions (e.g. explorer/context).") },
+		{ label: '6_copypath', bodyText: '"6_copypath"', description: localize('vscode.extension.contributes.menuItem.group.copypath', "Common group for copy path actions (e.g. explorer/context).") },
+		{ label: '7_modification', bodyText: '"7_modification"', description: localize('vscode.extension.contributes.menuItem.group.modification7', "Common group for modification actions shown after cut/copy/paste (e.g. explorer/context).") },
+		{ label: '9_cutcopypaste', bodyText: '"9_cutcopypaste"', description: localize('vscode.extension.contributes.menuItem.group.cutcopypaste9', "Common group for cut/copy/paste actions shown later (e.g. editor/context).") },
+		{ label: 'z_commands', bodyText: '"z_commands"', description: localize('vscode.extension.contributes.menuItem.group.commands', "Common group for generic commands, typically shown last.") },
+	];
+
 	const menuItem: IJSONSchema = {
 		type: 'object',
 		required: ['command'],
@@ -686,8 +703,9 @@ namespace schema {
 				type: 'string'
 			},
 			group: {
-				description: localize('vscode.extension.contributes.menuItem.group', 'Group into which this item belongs'),
-				type: 'string'
+				description: localize('vscode.extension.contributes.menuItem.group', 'Group into which this item belongs. Groups determine how items are sorted and visually separated. Any string can be used; common values are suggested via IntelliSense.'),
+				type: 'string',
+				defaultSnippets: groupDefaultSnippets
 			}
 		}
 	};
@@ -705,8 +723,9 @@ namespace schema {
 				type: 'string'
 			},
 			group: {
-				description: localize('vscode.extension.contributes.menuItem.group', 'Group into which this item belongs'),
-				type: 'string'
+				description: localize('vscode.extension.contributes.menuItem.group', 'Group into which this item belongs. Groups determine how items are sorted and visually separated. Any string can be used; common values are suggested via IntelliSense.'),
+				type: 'string',
+				defaultSnippets: groupDefaultSnippets
 			}
 		}
 	};


### PR DESCRIPTION
### What this PR does

Extension authors have no guidance on which values to use for the `group` field when contributing menu items via `contributes.menus`. Today the schema types `group` as a bare `string`, so IntelliSense offers nothing.

This PR adds `defaultSnippets` to the `group` property of both `menuItem` and `submenuItem` JSON schemas, surfacing the common group identifiers used across VS Code's own menus. The `description` is also clarified to reflect that completions are suggestions, not a closed set.

### Before / After

**Before**
```jsonc
"menus": {
  "editor/context": [
    {
      "command": "my.command",
      "group": "" // no suggestions
    }
  ]
}
```

**After**: typing in `group` suggests: `navigation`, `inline`, `1_modification`, `2_workspace`, `3_compare`, `4_search`, `5_cutcopypaste`, `6_copypath`, `7_modification`, `9_cutcopypaste`, `z_commands`, each with a short description of where it is conventionally used. Authors are still free to type any custom group name.

### Why `defaultSnippets` and not `enum`

Menu group identifiers are an open set by design — extensions may invent their own group names to visually group related items. Using `enum` would reject custom groups and break existing extensions. `defaultSnippets` matches the existing pattern used elsewhere in the workbench (see `colorThemeSchema.ts`, `snippetsService.ts`, etc.) and keeps the schema permissive.

### Choice of suggested values

The suggestions were picked from the identifiers most frequently used in `src/vs/workbench/**`:
- `navigation`, `inline` — primary toolbar / inline row group conventions
- numbered `N_*` groups — used pervasively in explorer/context, editor/context, debug context menus
- `z_commands` — the "sink" group rendered last

### Testing

- `defaultSnippets` is consumed by the existing JSON language service used for `package.json` validation in VS Code; no new runtime code is introduced.
- Verified the file compiles cleanly (no new diagnostics).

Fixes #42475