### PR TITLE
Clip terminal single-tab label so it does not overflow a narrow pane header (fixes #312970)

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/terminal.css
+++ b/src/vs/workbench/contrib/terminal/browser/media/terminal.css
@@ -477,15 +477,25 @@
 .monaco-action-bar .action-item .single-terminal-tab {
 	display: flex !important;
 	align-items: center;
+	/* Allow the tab label to shrink below its content size so that long
+	   titles + status icons do not overflow the pane header when the view
+	   is narrow (e.g. terminal moved to the side). */
+	min-width: 0;
+	max-width: 100%;
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
 }
 
 .monaco-action-bar .action-item .single-terminal-tab .codicon:first-child {
 	margin-right: 4px;
+	flex-shrink: 0;
 }
 
 .monaco-action-bar .action-item .single-terminal-tab .codicon:nth-child(2) {
 	margin-left: 4px;
 	color: inherit;
+	flex-shrink: 0;
 }
 
 .monaco-workbench .pane-body.integrated-terminal .tabs-container.has-text .tabs-list .terminal-tabs-entry .uri-icon {


### PR DESCRIPTION
### Problem

When the terminal view is moved to a narrow container (e.g. side bar, auxiliary bar, or a narrow panel split), the label rendered by `SingleTerminalTabActionViewItem` can exceed the width of the pane header. The label is a flex container (`.single-terminal-tab`) holding a leading codicon, the terminal title (plus optional description and `${progress}` variable), and an optional trailing status codicon. Because that container had no overflow handling, long content spilled out horizontally instead of being clipped.

Reported as: microsoft/vscode#312970.

### Fix

Constrain `.single-terminal-tab` so it can shrink and clip inside its pane header:

- `min-width: 0; max-width: 100%; overflow: hidden;` — the flex item respects the pane header bounds instead of growing to its content size.
- `white-space: nowrap; text-overflow: ellipsis;` — the text portion between the icons clips with an ellipsis rather than wrapping or overflowing.
- `flex-shrink: 0` on the leading icon (`codicon:first-child`) and the optional trailing status icon (`codicon:nth-child(2)`) so they remain fully visible; only the title text in the middle shrinks.

The full title is still reported by `updateTooltip()` on hover, so no information is lost when truncation kicks in.

### Before / After

Before: the label extends past the right edge of the pane header and can visually collide with neighboring UI when the view is narrow.

After: the label is clipped at the pane header edge. The leading terminal icon and the status icon stay visible; only the title text is truncated with an ellipsis.

### Scope

CSS-only change in `src/vs/workbench/contrib/terminal/browser/media/terminal.css`. No runtime logic changes, no new settings, no localization impact.

### Testing

- Verified the file has no diagnostics.
- Manual sanity check: selectors target the existing `.single-terminal-tab` class (added in `terminalView.ts` for the `TerminalCommandId.Focus` action item) and the two codicon children produced by `renderLabelWithIcons`.

Fixes #312970