### PR TITLE
sessions: use delegation for active session and force replace on session swap

### DIFF
--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -142,7 +142,7 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 
 	private onDidReplaceSession(from: ISession, to: ISession): void {
 		if (this._activeSession.get()?.sessionId === from.sessionId) {
-			this.setActiveSession(to);
+			this.setActiveSession(to, /* force */ true);
 		}
 		// Always fire the change event so the SessionsList refreshes even when
 		// the user navigated to a different session while the new one was
@@ -430,9 +430,9 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 		this._isNewChatInSessionContext.set(true);
 	}
 
-	private setActiveSession(session: ISession | undefined): void {
+	private setActiveSession(session: ISession | undefined, force?: boolean): void {
 		const previousSession = this._activeSession.get();
-		if (previousSession?.sessionId === session?.sessionId) {
+		if (!force && previousSession?.sessionId === session?.sessionId) {
 			return;
 		}
 
@@ -478,10 +478,7 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 			// Create the active chat observable
 			const activeChatObs = observableValue<IChat>(`activeChat-${session.sessionId}`, initialChat);
 			this._activeChatObservable = activeChatObs;
-			const activeSession: IActiveSession = {
-				...session,
-				activeChat: activeChatObs,
-			};
+			const activeSession = new ActiveSession(session, activeChatObs);
 
 			this._activeSession.set(activeSession, undefined);
 
@@ -703,6 +700,43 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 	async renameChat(session: ISession, chatUri: URI, title: string): Promise<void> {
 		await this._getProvider(session)?.renameChat(session.sessionId, chatUri, title);
 	}
+}
+
+/**
+ * Wraps an {@link ISession} with an active chat observable to form an
+ * {@link IActiveSession}. Delegates all {@link ISession} property accesses
+ * to the wrapped session so the active session always reflects the latest
+ * session state without a stale shallow copy.
+ */
+class ActiveSession implements IActiveSession {
+	constructor(
+		private readonly _session: ISession,
+		readonly activeChat: IObservable<IChat>,
+	) { }
+
+	get sessionId() { return this._session.sessionId; }
+	get resource() { return this._session.resource; }
+	get providerId() { return this._session.providerId; }
+	get sessionType() { return this._session.sessionType; }
+	get icon() { return this._session.icon; }
+	get createdAt() { return this._session.createdAt; }
+	get workspace() { return this._session.workspace; }
+	get title() { return this._session.title; }
+	get updatedAt() { return this._session.updatedAt; }
+	get status() { return this._session.status; }
+	get changes() { return this._session.changes; }
+	get changesets() { return this._session.changesets; }
+	get modelId() { return this._session.modelId; }
+	get mode() { return this._session.mode; }
+	get loading() { return this._session.loading; }
+	get isArchived() { return this._session.isArchived; }
+	get isRead() { return this._session.isRead; }
+	get description() { return this._session.description; }
+	get lastTurnEnd() { return this._session.lastTurnEnd; }
+	get chats() { return this._session.chats; }
+	get mainChat() { return this._session.mainChat; }
+	get capabilities() { return this._session.capabilities; }
+	get deduplicationKey() { return this._session.deduplicationKey; }
 }
 
 registerSingleton(ISessionsManagementService, SessionsManagementService, InstantiationType.Delayed);


### PR DESCRIPTION
## Summary

Two improvements to `SessionsManagementService`:

### 1. Replace spread with `ActiveSession` delegation class

The active session was previously built by spreading an `ISession` into a new object (`{ ...session, activeChat }`). This creates a shallow copy that becomes stale — any properties that are later updated on the original session won't be reflected on the active session.

The new `ActiveSession` class implements `IActiveSession` by delegating all `ISession` property accesses to the underlying session via getters, keeping the active session always in sync with the live session state.

### 2. Force replace active session on `onDidReplaceSession`

When a session is replaced (e.g. a pending session transitions to a real one), `setActiveSession` was skipped if the session ID remained the same due to the early-return equality check. Now `onDidReplaceSession` passes `force: true` to bypass the check and fully rebuild the active session tracking (disposables, autoruns, context keys).