### PR TITLE
sessions: fix customization harness layer violation by using session types

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/customizationHarnessService.ts
+++ b/src/vs/sessions/contrib/chat/browser/customizationHarnessService.ts
@@ -4,20 +4,25 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IDisposable } from '../../../../base/common/lifecycle.js';
-import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { CustomizationHarnessServiceBase, createVSCodeHarnessDescriptor, IHarnessDescriptor } from '../../../../workbench/contrib/chat/common/customizationHarnessService.js';
 import { IPromptsService, PromptsStorage } from '../../../../workbench/contrib/chat/common/promptSyntax/service/promptsService.js';
 import { BUILTIN_STORAGE } from '../common/builtinPromptsStorage.js';
 import { SessionType } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
-// eslint-disable-next-line local/code-import-patterns
-import { LOCAL_SESSION_ENABLED_SETTING } from '../../providers/copilotChatSessions/browser/copilotChatSessionsProvider.js';
+import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
+
+/**
+ * The session type that supports local harness customization.
+ * Hardcoded for now — ideally providers would declare harness support explicitly.
+ */
+const LOCAL_HARNESS_SESSION_TYPE = 'local';
 
 /**
  * Sessions-window override of the customization harness service.
  *
- * The Local harness is registered when the `sessions.chat.localAgent.enabled`
- * setting is true (the default). When the setting is toggled, the harness is
- * dynamically added or removed so that the Customizations editor reflects the
+ * The Local harness is registered when a provider offers a session type
+ * matching {@link LOCAL_HARNESS_SESSION_TYPE}. When providers are added or
+ * removed (or their session types change), the harness is dynamically
+ * added or removed so that the Customizations editor reflects the
  * current state.
  *
  * The Copilot CLI extension provides its harness (with `itemProvider`) via
@@ -30,7 +35,7 @@ export class SessionsCustomizationHarnessService extends CustomizationHarnessSer
 
 	constructor(
 		@IPromptsService promptsService: IPromptsService,
-		@IConfigurationService configurationService: IConfigurationService,
+		@ISessionsManagementService private readonly sessionsManagementService: ISessionsManagementService,
 	) {
 		const localExtras = [PromptsStorage.extension, BUILTIN_STORAGE];
 		const localHarness = createVSCodeHarnessDescriptor(localExtras);
@@ -41,17 +46,18 @@ export class SessionsCustomizationHarnessService extends CustomizationHarnessSer
 			promptsService,
 		);
 
-		// Register the local harness dynamically so it can be toggled
-		// when the `sessions.chat.localAgent.enabled` setting changes.
-		if (configurationService.getValue<boolean>(LOCAL_SESSION_ENABLED_SETTING) !== false) {
-			this._localHarnessRegistration = this.registerExternalHarness(localHarness);
-		}
+		const sync = () => this._syncLocalHarness(localHarness, this._hasLocalSessionType());
 
-		configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration(LOCAL_SESSION_ENABLED_SETTING)) {
-				this._syncLocalHarness(localHarness, configurationService.getValue<boolean>(LOCAL_SESSION_ENABLED_SETTING) !== false);
-			}
-		});
+		this.sessionsManagementService.onDidChangeSessionTypes(sync);
+
+		// Initial sync
+		sync();
+	}
+
+	private _hasLocalSessionType(): boolean {
+		return this.sessionsManagementService.getAllSessionTypes().some(
+			t => t.id === LOCAL_HARNESS_SESSION_TYPE
+		);
 	}
 
 	private _syncLocalHarness(descriptor: IHarnessDescriptor, enabled: boolean): void {


### PR DESCRIPTION
## Summary

Fixes a layer violation in `SessionsCustomizationHarnessService` where it imported `LOCAL_SESSION_ENABLED_SETTING` from the providers layer (`contrib/providers/copilotChatSessions/`), bypassing the ESLint isolation rule with an `eslint-disable` comment.

## Changes

**`src/vs/sessions/contrib/chat/browser/customizationHarnessService.ts`**

- **Removed**: Import of `LOCAL_SESSION_ENABLED_SETTING` from providers (layer violation)
- **Removed**: `IConfigurationService` dependency (only used for that setting)
- **Added**: `ISessionsManagementService` dependency — uses `getAllSessionTypes()` and `onDidChangeSessionTypes` to detect when a provider offers the `'local'` session type
- **Added**: `LOCAL_HARNESS_SESSION_TYPE = 'local'` hardcoded constant (with TODO comment noting providers should ideally declare harness support explicitly)

### Before
The service read a config setting owned by the copilotChatSessions provider to decide whether to register the local harness. This created a direct dependency from `contrib/chat/` → `contrib/providers/`.

### After
The service queries `ISessionsManagementService.getAllSessionTypes()` and listens to `onDidChangeSessionTypes`. When any provider registers a session type with id `'local'`, the local harness is added; when it disappears, the harness is removed. No provider internals are accessed.