### PR TITLE
ci: run component fixtures on release/* branches

### DIFF
--- a/.github/workflows/component-fixtures.yml
+++ b/.github/workflows/component-fixtures.yml
@@ -2,7 +2,9 @@ name: Component Fixtures
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'release/*'
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Trigger the Component Fixtures workflow on pushes to `release/*` branches in addition to `main`. The `pull_request` trigger already covered these branches; this aligns the `push` trigger.