### PR TITLE
Fix window title in agent title bar status widget

### DIFF
--- a/src/vs/sessions/browser/parts/titlebarPart.ts
+++ b/src/vs/sessions/browser/parts/titlebarPart.ts
@@ -29,6 +29,7 @@ import { IEditorGroupsContainer } from '../../../workbench/services/editor/commo
 import { CodeWindow, mainWindow } from '../../../base/browser/window.js';
 import { safeIntl } from '../../../base/common/date.js';
 import { ITitlebarPart, ITitleProperties, ITitleVariable, IAuxiliaryTitlebarPart } from '../../../workbench/browser/parts/titlebar/titlebarPart.js';
+import { WindowTitle } from '../../../workbench/browser/parts/titlebar/windowTitle.js';
 import { Menus } from '../menus.js';
 import { IsNewChatSessionContext } from '../../common/contextkeys.js';
 
@@ -471,6 +472,18 @@ export class TitleService extends MultiWindowParts<TitlebarPart> implements ITit
 		for (const part of this.parts) {
 			part.registerVariables(variables);
 		}
+	}
+
+	private _windowTitle: WindowTitle | undefined;
+
+	get windowTitle(): WindowTitle {
+		// The Agents window title bar does not render `window.title`, so we
+		// lazily construct a `WindowTitle` only when a consumer (e.g. a custom
+		// command center widget) actually asks for one.
+		if (!this._windowTitle) {
+			this._windowTitle = this._register(this.instantiationService.createInstance(WindowTitle, mainWindow));
+		}
+		return this._windowTitle;
 	}
 
 	//#endregion

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -216,6 +216,10 @@ export class BrowserTitleService extends MultiWindowParts<BrowserTitlebarPart> i
 		}
 	}
 
+	get windowTitle(): WindowTitle {
+		return this.mainPart.windowTitle;
+	}
+
 	//#endregion
 }
 
@@ -292,7 +296,7 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 
 	private readonly isCompactContextKey: IContextKey<boolean>;
 
-	private readonly windowTitle: WindowTitle;
+	readonly windowTitle: WindowTitle;
 
 	protected readonly instantiationService: IInstantiationService;
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/experiments/agentTitleBarStatusWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/experiments/agentTitleBarStatusWidget.ts
@@ -43,6 +43,7 @@ import { ChatConfiguration } from '../../../common/constants.js';
 import { IChatEntitlementService } from '../../../../../services/chat/common/chatEntitlementService.js';
 import { IChatWidgetService } from '../../chat.js';
 import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
+import { ITitleService } from '../../../../../services/title/browser/titleService.js';
 
 // Telemetry types
 type AgentStatusClickAction =
@@ -146,11 +147,9 @@ export class AgentTitleBarStatusWidget extends BaseActionViewItem {
 	/** Menu for ChatTitleBarMenu items (same as chat controls dropdown) */
 	private readonly _chatTitleBarMenu;
 
-	/** WindowTitle instance for honoring the user's window.title setting */
-	private readonly _windowTitle: WindowTitle;
-
 	constructor(
 		action: IAction,
+		private readonly _windowTitle: WindowTitle,
 		options: IBaseActionViewItemOptions | undefined,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IAgentTitleBarStatusService private readonly agentTitleBarStatusService: IAgentTitleBarStatusService,
@@ -176,9 +175,6 @@ export class AgentTitleBarStatusWidget extends BaseActionViewItem {
 
 		// Create menu for ChatTitleBarMenu to show in sparkle section dropdown
 		this._chatTitleBarMenu = this._register(this.menuService.createMenu(MenuId.ChatTitleBarMenu, this.contextKeyService));
-
-		// Create WindowTitle to honor the user's window.title setting
-		this._windowTitle = this._register(this.instantiationService.createInstance(WindowTitle, mainWindow));
 
 		// Re-render when control mode or session info changes
 		this._register(this.agentTitleBarStatusService.onDidChangeMode(() => {
@@ -1400,7 +1396,8 @@ export class AgentTitleBarStatusRendering extends Disposable implements IWorkben
 		@IActionViewItemService actionViewItemService: IActionViewItemService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IConfigurationService configurationService: IConfigurationService,
-		@IContextKeyService contextKeyService: IContextKeyService
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@ITitleService titleService: ITitleService,
 	) {
 		super();
 
@@ -1408,7 +1405,7 @@ export class AgentTitleBarStatusRendering extends Disposable implements IWorkben
 			if (!(action instanceof SubmenuItemAction)) {
 				return undefined;
 			}
-			return instantiationService.createInstance(AgentTitleBarStatusWidget, action, options);
+			return instantiationService.createInstance(AgentTitleBarStatusWidget, action, titleService.windowTitle, options);
 		}, undefined));
 
 		// Add/remove CSS classes on workbench based on settings.

--- a/src/vs/workbench/services/title/browser/titleService.ts
+++ b/src/vs/workbench/services/title/browser/titleService.ts
@@ -5,6 +5,7 @@
 
 import { createDecorator, IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IAuxiliaryTitlebarPart, ITitlebarPart } from '../../../browser/parts/titlebar/titlebarPart.js';
+import { WindowTitle } from '../../../browser/parts/titlebar/windowTitle.js';
 import { IEditorGroupsContainer } from '../../editor/common/editorGroupsService.js';
 
 export const ITitleService = createDecorator<ITitleService>('titleService');
@@ -12,6 +13,13 @@ export const ITitleService = createDecorator<ITitleService>('titleService');
 export interface ITitleService extends ITitlebarPart {
 
 	readonly _serviceBrand: undefined;
+
+	/**
+	 * The shared {@link WindowTitle} instance for the main window. Used by
+	 * components that need to render or react to the resolved `window.title`
+	 * (template variables, decorations, etc.) without instantiating their own.
+	 */
+	readonly windowTitle: WindowTitle;
 
 	/**
 	 * Get the status bar part that is rooted in the provided container.


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce a `windowTitle` property in the `TitleService` and `BrowserTitleService` to manage the window title for the agent title bar status widget. Update the `AgentTitleBarStatusWidget` to utilize the shared `WindowTitle` instance for rendering the window title. This change centralizes window title management and ensures consistency across components.

fixes https://github.com/microsoft/vscode/issues/303429