### PR TITLE
Set COPILOT_AGENT env var in agent terminals

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/toolTerminalCreator.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/toolTerminalCreator.ts
@@ -148,6 +148,11 @@ export class ToolTerminalCreator {
 		const shellPath = isString(shellOrProfile) ? shellOrProfile : shellOrProfile.path;
 
 		const env: Record<string, string> = {
+			// Let CLI tools detect that they are running inside an AI agent.
+			// This allows programs to adapt their output (e.g. JSON instead of
+			// ANSI, disable interactive prompts, skip animations).
+			// See https://github.com/microsoft/vscode/issues/311734
+			COPILOT_AGENT: '1',
 			// Avoid making `git diff` interactive when called from copilot
 			GIT_PAGER: 'cat',
 			// Prevent git from opening an editor for merge commits


### PR DESCRIPTION
Fixes #311734

Sets `COPILOT_AGENT=1` in agent terminal sessions so CLI tools can detect they are running inside an AI agent and adapt their output (e.g. JSON instead of ANSI, disable interactive prompts, skip animations).

This follows the same pattern as other agents:

| Agent | Environment Variable |
|-------|---------------------|
| Claude Code | `CLAUDE_CODE` |
| Cursor | `CURSOR_AGENT` |
| Codex | `CODEX_SANDBOX` |
| Gemini CLI | `GEMINI_CLI` |
| **VS Code Copilot** | **`COPILOT_AGENT`** |

### Changes
- **`toolTerminalCreator.ts`**: Added `COPILOT_AGENT: '1'` to the env vars set when creating agent terminals