### PR TITLE
run_in_terminal: detect shell continuation prompts and abort

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/basicExecuteStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/basicExecuteStrategy.ts
@@ -11,7 +11,7 @@ import { isNumber } from '../../../../../../base/common/types.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import type { ICommandDetectionCapability } from '../../../../../../platform/terminal/common/capabilities/capabilities.js';
 import { ITerminalLogService, type ITerminalLaunchError } from '../../../../../../platform/terminal/common/terminal.js';
-import { trackIdleOnPrompt, waitForIdle, type ITerminalExecuteStrategy, type ITerminalExecuteStrategyResult } from './executeStrategy.js';
+import { trackIdleOnPrompt, waitForContinuationPrompt, waitForIdle, type ITerminalExecuteStrategy, type ITerminalExecuteStrategyResult } from './executeStrategy.js';
 import type { IMarker as IXtermMarker } from '@xterm/xterm';
 import { ITerminalInstance } from '../../../../terminal/browser/terminal.js';
 import { createAltBufferPromise, setupRecreatingStartMarker, stripCommandEchoAndPrompt } from './strategyHelpers.js';
@@ -168,6 +168,12 @@ export class BasicExecuteStrategy extends Disposable implements ITerminalExecute
 				trackIdleOnPrompt(this._instance, idlePollInterval * 3, store, idlePollInterval, this._logService).then(() => {
 					this._log('onDone long idle prompt');
 				}),
+				// Detect shell continuation prompts (e.g. dquote>, quote>) that
+				// indicate unmatched quotes or brackets.
+				waitForContinuationPrompt(this._instance.onData, this._instance, idlePollInterval, store, this._logService).then(prompt => {
+					this._log(`onDone via continuation prompt: ${prompt}`);
+					return { type: 'continuationPrompt', prompt } as const;
+				}),
 			]);
 
 			// Ensure xterm is available
@@ -236,6 +242,16 @@ export class BasicExecuteStrategy extends Disposable implements ITerminalExecute
 					exitCode: undefined,
 					error: 'alternateBuffer',
 					didEnterAltBuffer: true
+				};
+			}
+			if (onDoneResult && onDoneResult.type === 'continuationPrompt') {
+				this._log(`Aborting command due to continuation prompt: ${onDoneResult.prompt}`);
+				await this._instance.sendText('\x03', false);
+				await waitForIdle(this._instance.onData, 200);
+				return {
+					output: undefined,
+					exitCode: undefined,
+					error: `The command has a syntax error — the shell showed a "${onDoneResult.prompt}" continuation prompt, indicating unmatched quotes or brackets. Fix the quoting and retry.`,
 				};
 			}
 			const finishedCommand = onDoneResult && onDoneResult.type === 'success' ? onDoneResult.command : undefined;

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/executeStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/executeStrategy.ts
@@ -85,6 +85,10 @@ export function isContinuationPrompt(cursorLine: string): boolean {
  * Monitors the terminal for shell continuation prompts (e.g. `dquote>`, `quote>`)
  * which indicate that a command has unmatched quotes or brackets. Returns a promise
  * that resolves with the prompt text when a continuation prompt is detected.
+ *
+ * Uses a longer idle window (2x the normal interval) and verifies the cursor is
+ * positioned right after the prompt text to reduce false positives from commands
+ * that happen to print continuation-prompt-like text in their output.
  */
 export function waitForContinuationPrompt(
 	onData: Event<unknown>,
@@ -94,6 +98,9 @@ export function waitForContinuationPrompt(
 	logService?: ITerminalLogService,
 ): Promise<string> {
 	const deferred = new DeferredPromise<string>();
+	// Require a longer idle period than normal prompt detection to reduce
+	// false positives from commands that briefly print prompt-like text.
+	const conservativeIdleMs = idleDurationMs * 2;
 
 	const checkForContinuationPrompt = async () => {
 		try {
@@ -102,12 +109,20 @@ export function waitForContinuationPrompt(
 				return;
 			}
 			const buffer = xterm.raw.buffer.active;
-			const line = buffer.getLine?.(buffer.baseY + buffer.cursorY);
+			const cursorY = buffer.baseY + buffer.cursorY;
+			const line = buffer.getLine?.(cursorY);
 			if (line) {
 				const content = line.translateToString(true);
 				if (isContinuationPrompt(content)) {
-					logService?.debug(`waitForContinuationPrompt: Detected continuation prompt "${content.trim()}"`);
-					deferred.complete(content.trim());
+					// Verify the cursor is positioned at the end of the prompt
+					// (i.e. the shell is awaiting input), not mid-line in command output.
+					const trimmedLen = content.trimEnd().length;
+					if (buffer.cursorX <= trimmedLen) {
+						logService?.debug(`waitForContinuationPrompt: Detected continuation prompt "${content.trim()}"`);
+						deferred.complete(content.trim());
+					} else {
+						logService?.debug(`waitForContinuationPrompt: Cursor at column ${buffer.cursorX} beyond prompt end ${trimmedLen}, ignoring`);
+					}
 				}
 			}
 		} catch {
@@ -117,7 +132,7 @@ export function waitForContinuationPrompt(
 
 	const scheduler = store.add(new RunOnceScheduler(() => {
 		void checkForContinuationPrompt();
-	}, idleDurationMs));
+	}, conservativeIdleMs));
 
 	store.add(onData(() => scheduler.schedule()));
 	scheduler.schedule();

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/executeStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/executeStrategy.ts
@@ -59,11 +59,84 @@ export interface IPromptDetectionResult {
 }
 
 /**
+ * Known shell continuation prompt patterns that indicate a command has
+ * unmatched quotes, brackets, or other syntax issues. These prompts appear
+ * when the shell is waiting for additional input to complete a construct.
+ */
+const continuationPromptPatterns: RegExp[] = [
+	/^dquote>\s*$/,    // zsh: unmatched double quote
+	/^quote>\s*$/,     // zsh: unmatched single quote
+	/^bquote>\s*$/,    // zsh: unmatched backtick
+	/^pipe>\s*$/,      // zsh: pipe continuation
+	/^cmdsubst>\s*$/,  // zsh: command substitution
+	/^heredoc>\s*$/,   // zsh: heredoc
+];
+
+/**
+ * Detects if the given text looks like a shell continuation prompt, indicating
+ * that a command has unmatched quotes or other syntax issues.
+ */
+export function isContinuationPrompt(cursorLine: string): boolean {
+	const trimmed = cursorLine.trim();
+	return continuationPromptPatterns.some(p => p.test(trimmed));
+}
+
+/**
+ * Monitors the terminal for shell continuation prompts (e.g. `dquote>`, `quote>`)
+ * which indicate that a command has unmatched quotes or brackets. Returns a promise
+ * that resolves with the prompt text when a continuation prompt is detected.
+ */
+export function waitForContinuationPrompt(
+	onData: Event<unknown>,
+	instance: ITerminalInstance,
+	idleDurationMs: number,
+	store: DisposableStore,
+	logService?: ITerminalLogService,
+): Promise<string> {
+	const deferred = new DeferredPromise<string>();
+
+	const checkForContinuationPrompt = async () => {
+		try {
+			const xterm = await instance.xtermReadyPromise;
+			if (!xterm) {
+				return;
+			}
+			const buffer = xterm.raw.buffer.active;
+			const line = buffer.getLine?.(buffer.baseY + buffer.cursorY);
+			if (line) {
+				const content = line.translateToString(true);
+				if (isContinuationPrompt(content)) {
+					logService?.debug(`waitForContinuationPrompt: Detected continuation prompt "${content.trim()}"`);
+					deferred.complete(content.trim());
+				}
+			}
+		} catch {
+			// Ignore errors reading terminal content
+		}
+	};
+
+	const scheduler = store.add(new RunOnceScheduler(() => {
+		void checkForContinuationPrompt();
+	}, idleDurationMs));
+
+	store.add(onData(() => scheduler.schedule()));
+	scheduler.schedule();
+
+	return deferred.p;
+}
+
+/**
  * Detects if the given text content appears to end with a common prompt pattern.
  */
 export function detectsCommonPromptPattern(cursorLine: string): IPromptDetectionResult {
 	if (cursorLine.trim().length === 0) {
 		return { detected: false, reason: 'Content is empty or contains only whitespace' };
+	}
+
+	// Exclude shell continuation prompts (e.g. dquote>, quote>) — these
+	// indicate unmatched quotes, not a ready prompt.
+	if (isContinuationPrompt(cursorLine)) {
+		return { detected: false, reason: `Shell continuation prompt detected (not a ready prompt): "${cursorLine}"` };
 	}
 
 	// PowerShell prompt: PS C:\> or similar patterns

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/noneExecuteStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/noneExecuteStrategy.ts
@@ -9,7 +9,7 @@ import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { Disposable, DisposableStore, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { ITerminalLogService } from '../../../../../../platform/terminal/common/terminal.js';
-import { waitForIdle, waitForIdleWithPromptHeuristics, type ITerminalExecuteStrategy, type ITerminalExecuteStrategyResult } from './executeStrategy.js';
+import { waitForContinuationPrompt, waitForIdle, waitForIdleWithPromptHeuristics, type ITerminalExecuteStrategy, type ITerminalExecuteStrategyResult } from './executeStrategy.js';
 import type { IMarker as IXtermMarker } from '@xterm/xterm';
 import { ITerminalInstance } from '../../../../terminal/browser/terminal.js';
 import { createAltBufferPromise, setupRecreatingStartMarker, stripCommandEchoAndPrompt } from './strategyHelpers.js';
@@ -128,11 +128,18 @@ export class NoneExecuteStrategy extends Disposable implements ITerminalExecuteS
 
 			// Assume the command is done when it's idle
 			this._log('Waiting for idle with prompt heuristics');
-			const promptResultOrAltBuffer = await Promise.race([
-				waitForIdleWithPromptHeuristics(this._instance.onData, this._instance, idlePollInterval, idlePollInterval * 10),
-				alternateBufferPromise.then(() => 'alternateBuffer' as const)
+			const continuationPromptPromise = waitForContinuationPrompt(this._instance.onData, this._instance, idlePollInterval, store, this._logService);
+			const promptResultOrAltBufferOrContinuation = await Promise.race([
+				waitForIdleWithPromptHeuristics(this._instance.onData, this._instance, idlePollInterval, idlePollInterval * 10).then(result => ({ type: 'prompt' as const, result })),
+				alternateBufferPromise.then(() => ({ type: 'alternateBuffer' as const })),
+				// Detect shell continuation prompts (e.g. dquote>, quote>) that
+				// indicate unmatched quotes or brackets.
+				continuationPromptPromise.then(prompt => {
+					this._log(`Detected continuation prompt: ${prompt}`);
+					return { type: 'continuationPrompt' as const, prompt };
+				}),
 			]);
-			if (promptResultOrAltBuffer === 'alternateBuffer') {
+			if (promptResultOrAltBufferOrContinuation.type === 'alternateBuffer') {
 				this._log('Detected alternate buffer entry, skipping output capture');
 				return {
 					output: undefined,
@@ -142,7 +149,17 @@ export class NoneExecuteStrategy extends Disposable implements ITerminalExecuteS
 					didEnterAltBuffer: true,
 				};
 			}
-			const promptResult = promptResultOrAltBuffer;
+			if (promptResultOrAltBufferOrContinuation.type === 'continuationPrompt') {
+				this._log(`Aborting command due to continuation prompt: ${promptResultOrAltBufferOrContinuation.prompt}`);
+				this._instance.sendText('\x03', false);
+				await waitForIdle(this._instance.onData, 200);
+				return {
+					output: undefined,
+					exitCode: undefined,
+					error: `The command has a syntax error — the shell showed a "${promptResultOrAltBufferOrContinuation.prompt}" continuation prompt, indicating unmatched quotes or brackets. Fix the quoting and retry.`,
+				};
+			}
+			const promptResult = promptResultOrAltBufferOrContinuation.result;
 			this._log(`Prompt detection result: ${promptResult.detected ? 'detected' : 'not detected'} - ${promptResult.reason}`);
 
 			if (token.isCancellationRequested) {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/noneExecuteStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/noneExecuteStrategy.ts
@@ -151,7 +151,7 @@ export class NoneExecuteStrategy extends Disposable implements ITerminalExecuteS
 			}
 			if (promptResultOrAltBufferOrContinuation.type === 'continuationPrompt') {
 				this._log(`Aborting command due to continuation prompt: ${promptResultOrAltBufferOrContinuation.prompt}`);
-				this._instance.sendText('\x03', false);
+				await this._instance.sendText('\x03', false);
 				await waitForIdle(this._instance.onData, 200);
 				return {
 					output: undefined,

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/richExecuteStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/richExecuteStrategy.ts
@@ -13,7 +13,7 @@ import { isCI, isMacintosh } from '../../../../../../base/common/platform.js';
 import type { ICommandDetectionCapability } from '../../../../../../platform/terminal/common/capabilities/capabilities.js';
 import { ITerminalLogService, type ITerminalLaunchError } from '../../../../../../platform/terminal/common/terminal.js';
 import type { ITerminalInstance } from '../../../../terminal/browser/terminal.js';
-import { trackIdleOnPrompt, type ITerminalExecuteStrategy, type ITerminalExecuteStrategyResult } from './executeStrategy.js';
+import { trackIdleOnPrompt, waitForContinuationPrompt, waitForIdle, type ITerminalExecuteStrategy, type ITerminalExecuteStrategyResult } from './executeStrategy.js';
 import type { IMarker as IXtermMarker } from '@xterm/xterm';
 import { createAltBufferPromise, setupRecreatingStartMarker, stripCommandEchoAndPrompt } from './strategyHelpers.js';
 import { TerminalChatAgentToolsSettingId } from '../../common/terminalChatAgentToolsConfiguration.js';
@@ -154,6 +154,13 @@ export class RichExecuteStrategy extends Disposable implements ITerminalExecuteS
 						this._log('onDone via idle prompt');
 					}),
 				] : []),
+				// Detect shell continuation prompts (e.g. dquote>, quote>) that
+				// indicate unmatched quotes or brackets. Without this, the terminal
+				// hangs indefinitely because no command-finished event fires.
+				waitForContinuationPrompt(this._instance.onData, this._instance, idlePollInterval, store, this._logService).then(prompt => {
+					this._log(`onDone via continuation prompt: ${prompt}`);
+					return { type: 'continuationPrompt', prompt } as const;
+				}),
 			]);
 
 			// Ensure xterm is available
@@ -191,6 +198,16 @@ export class RichExecuteStrategy extends Disposable implements ITerminalExecuteS
 					exitCode: undefined,
 					error: 'alternateBuffer',
 					didEnterAltBuffer: true
+				};
+			}
+			if (onDoneResult && onDoneResult.type === 'continuationPrompt') {
+				this._log(`Aborting command due to continuation prompt: ${onDoneResult.prompt}`);
+				await this._instance.sendText('\x03', false);
+				await waitForIdle(this._instance.onData, 200);
+				return {
+					output: undefined,
+					exitCode: undefined,
+					error: `The command has a syntax error — the shell showed a "${onDoneResult.prompt}" continuation prompt, indicating unmatched quotes or brackets. Fix the quoting and retry.`,
 				};
 			}
 			const finishedCommand = onDoneResult && onDoneResult.type === 'success' ? onDoneResult.command : undefined;

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/executeStrategy.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/executeStrategy.test.ts
@@ -5,7 +5,7 @@
 
 import { strictEqual } from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
-import { detectsCommonPromptPattern } from '../../browser/executeStrategy/executeStrategy.js';
+import { detectsCommonPromptPattern, isContinuationPrompt } from '../../browser/executeStrategy/executeStrategy.js';
 
 suite('Execute Strategy - Prompt Detection', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
@@ -67,5 +67,53 @@ user@host:~$ `;
 		strictEqual(detectsCommonPromptPattern('output\n\n\n').detected, false);
 		strictEqual(detectsCommonPromptPattern('\n\n$ \n\n').detected, true); // prompt with surrounding whitespace
 		strictEqual(detectsCommonPromptPattern('output\nPS C:\\> ').detected, true); // prompt at end after output
+	});
+
+	test('detectsCommonPromptPattern should reject shell continuation prompts', () => {
+		strictEqual(detectsCommonPromptPattern('dquote>').detected, false);
+		strictEqual(detectsCommonPromptPattern('dquote> ').detected, false);
+		strictEqual(detectsCommonPromptPattern('quote>').detected, false);
+		strictEqual(detectsCommonPromptPattern('bquote>').detected, false);
+		strictEqual(detectsCommonPromptPattern('pipe>').detected, false);
+		strictEqual(detectsCommonPromptPattern('heredoc>').detected, false);
+		strictEqual(detectsCommonPromptPattern('cmdsubst>').detected, false);
+	});
+});
+
+suite('Execute Strategy - Continuation Prompt Detection', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('isContinuationPrompt should detect zsh continuation prompts', () => {
+		strictEqual(isContinuationPrompt('dquote>'), true);
+		strictEqual(isContinuationPrompt('dquote> '), true);
+		strictEqual(isContinuationPrompt('quote>'), true);
+		strictEqual(isContinuationPrompt('bquote>'), true);
+		strictEqual(isContinuationPrompt('pipe>'), true);
+		strictEqual(isContinuationPrompt('heredoc>'), true);
+		strictEqual(isContinuationPrompt('cmdsubst>'), true);
+	});
+
+	test('isContinuationPrompt should handle whitespace', () => {
+		strictEqual(isContinuationPrompt('  dquote>  '), true);
+		strictEqual(isContinuationPrompt('\tdquote>\t'), true);
+	});
+
+	test('isContinuationPrompt should reject normal prompts', () => {
+		strictEqual(isContinuationPrompt('$ '), false);
+		strictEqual(isContinuationPrompt('# '), false);
+		strictEqual(isContinuationPrompt('user@host:~$ '), false);
+		strictEqual(isContinuationPrompt('PS C:\\>'), false);
+	});
+
+	test('isContinuationPrompt should reject command output', () => {
+		strictEqual(isContinuationPrompt('some output'), false);
+		strictEqual(isContinuationPrompt('error: command not found'), false);
+		strictEqual(isContinuationPrompt(''), false);
+		strictEqual(isContinuationPrompt('   '), false);
+	});
+
+	test('isContinuationPrompt should reject partial matches', () => {
+		strictEqual(isContinuationPrompt('some dquote>'), false);
+		strictEqual(isContinuationPrompt('dquote> some text'), false);
 	});
 });


### PR DESCRIPTION
Fixes #315694

When a command with unmatched quotes is sent to the terminal, the shell enters a continuation prompt (e.g. `dquote>`, `quote>`) and waits for more input. Previously this caused the terminal tool to hang indefinitely because no command-finished event ever fires.

### Changes

**`executeStrategy.ts`**:
- Adds `isContinuationPrompt()` to detect known shell continuation prompts (`dquote>`, `quote>`, `bquote>`, `pipe>`, `cmdsubst>`, `heredoc>`)
- Adds `waitForContinuationPrompt()` that monitors terminal idle state and checks for continuation prompt patterns on the cursor line
- Fixes `detectsCommonPromptPattern()` to exclude continuation prompts so they are not falsely detected as ready prompts (previously `dquote>` matched the generic `[>%]` pattern)

**All three execute strategies** (rich, basic, none):
- Integrates `waitForContinuationPrompt()` as a race candidate alongside existing completion signals
- When a continuation prompt is detected, sends Ctrl+C to abort the malformed command and returns an error message explaining the quoting issue

### How it works

The fix monitors the terminal data stream for idle periods. When the terminal goes idle, it checks if the cursor line matches a known continuation prompt pattern. If so, it:
1. Sends Ctrl+C to abort the stuck command
2. Returns an error to the agent: _"The command has a syntax error — the shell showed a \"dquote>\" continuation prompt, indicating unmatched quotes or brackets. Fix the quoting and retry."_

This prevents the hang and gives the agent actionable feedback to fix the command.