### PR TITLE
Improve ahp copilot cli tool display via matching tool names

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -1304,7 +1304,7 @@ export class CopilotAgentSession extends Disposable {
 
 	private async _handlePreToolUse(input: PreToolUseHookInput): Promise<void> {
 		try {
-			if (isEditTool(input.toolName)) {
+			if (isEditTool(input.toolName, input.toolArgs)) {
 				const filePaths = this._getEditFilePaths(input.toolArgs);
 				await Promise.all(filePaths.map(p => this._editTracker.trackEditStart(p)));
 			}
@@ -1316,7 +1316,7 @@ export class CopilotAgentSession extends Disposable {
 
 	private async _handlePostToolUse(input: PostToolUseHookInput): Promise<void> {
 		try {
-			if (isEditTool(input.toolName)) {
+			if (isEditTool(input.toolName, input.toolArgs)) {
 				const filePaths = this._getEditFilePaths(input.toolArgs);
 				await Promise.all(filePaths.map(p => this._editTracker.completeEdit(p)));
 			}
@@ -1498,7 +1498,7 @@ export class CopilotAgentSession extends Disposable {
 				content.push({ type: ToolResultContentType.Text, text: toolOutput });
 			}
 
-			const filePaths = isEditTool(tracked.toolName) ? this._getEditFilePaths(tracked.parameters) : [];
+			const filePaths = isEditTool(tracked.toolName, tracked.parameters) ? this._getEditFilePaths(tracked.parameters) : [];
 			for (const filePath of filePaths) {
 				try {
 					const fileEdit = await this._editTracker.takeCompletedEdit(this._turnId, e.data.toolCallId, filePath);

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -12,7 +12,7 @@ import { Schemas } from '../../../../base/common/network.js';
 import { isAbsolute, join } from '../../../../base/common/path.js';
 import { extUriBiasedIgnorePathCase, normalizePath } from '../../../../base/common/resources.js';
 import { splitLinesIncludeSeparators } from '../../../../base/common/strings.js';
-import { hasKey } from '../../../../base/common/types.js';
+import { hasKey, isObject, isString } from '../../../../base/common/types.js';
 import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { localize } from '../../../../nls.js';
@@ -95,6 +95,12 @@ type ElicitationFieldValue = NonNullable<ElicitationResult['content']>[string];
 type SessionHooks = NonNullable<SessionConfig['hooks']>;
 type PreToolUseHookInput = Parameters<NonNullable<SessionHooks['onPreToolUse']>>[0];
 type PostToolUseHookInput = Parameters<NonNullable<SessionHooks['onPostToolUse']>>[0];
+type ToolUseHookInput = PreToolUseHookInput | PostToolUseHookInput;
+
+function getToolCommand(input: ToolUseHookInput): string | undefined {
+	const command = isObject(input.toolArgs) ? Reflect.get(input.toolArgs, 'command') : undefined;
+	return isString(command) ? command : undefined;
+}
 
 /**
  * Projects an {@link ElicitationSchema} field into a
@@ -1304,7 +1310,7 @@ export class CopilotAgentSession extends Disposable {
 
 	private async _handlePreToolUse(input: PreToolUseHookInput): Promise<void> {
 		try {
-			if (isEditTool(input.toolName, input.toolArgs)) {
+			if (isEditTool(input.toolName, getToolCommand(input))) {
 				const filePaths = this._getEditFilePaths(input.toolArgs);
 				await Promise.all(filePaths.map(p => this._editTracker.trackEditStart(p)));
 			}
@@ -1316,7 +1322,7 @@ export class CopilotAgentSession extends Disposable {
 
 	private async _handlePostToolUse(input: PostToolUseHookInput): Promise<void> {
 		try {
-			if (isEditTool(input.toolName, input.toolArgs)) {
+			if (isEditTool(input.toolName, getToolCommand(input))) {
 				const filePaths = this._getEditFilePaths(input.toolArgs);
 				await Promise.all(filePaths.map(p => this._editTracker.completeEdit(p)));
 			}
@@ -1498,7 +1504,8 @@ export class CopilotAgentSession extends Disposable {
 				content.push({ type: ToolResultContentType.Text, text: toolOutput });
 			}
 
-			const filePaths = isEditTool(tracked.toolName, tracked.parameters) ? this._getEditFilePaths(tracked.parameters) : [];
+			const command = isString(tracked.parameters?.command) ? tracked.parameters.command : undefined;
+			const filePaths = isEditTool(tracked.toolName, command) ? this._getEditFilePaths(tracked.parameters) : [];
 			for (const filePath of filePaths) {
 				try {
 					const fileEdit = await this._editTracker.takeCompletedEdit(this._turnId, e.data.toolCallId, filePath);

--- a/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
@@ -17,16 +17,13 @@ import { basename } from '../../../../base/common/resources.js';
 // =============================================================================
 // Copilot CLI built-in tool interfaces
 //
-// The Copilot CLI (via @github/copilot) exposes these built-in tools. Tool names
-// and parameter shapes are not typed in the SDK -- they come from the CLI server
-// as plain strings. These interfaces are derived from observing the CLI's actual
-// tool events and the ShellConfig class in @github/copilot.
+// Mirrors the Copilot Chat CLI display labels for SDK tool event names.
 //
 // Shell tool names follow a pattern per ShellConfig:
 //   shellToolName, readShellToolName, writeShellToolName,
 //   stopShellToolName, listShellsToolName
-// For bash: bash, read_bash, write_bash, bash_shutdown, list_bash
-// For powershell: powershell, read_powershell, write_powershell, list_powershell
+// For bash: bash, read_bash, write_bash, stop_bash/bash_shutdown, list_bash
+// For powershell: powershell, read_powershell, write_powershell, stop_powershell/powershell_shutdown, list_powershell
 // =============================================================================
 
 /**
@@ -34,15 +31,22 @@ import { basename } from '../../../../base/common/resources.js';
  * in `tool.execution_start` events from the SDK.
  */
 const enum CopilotToolName {
+	StrReplaceEditor = 'str_replace_editor',
+	StrReplace = 'str_replace',
+	Insert = 'insert',
+
 	Bash = 'bash',
 	ReadBash = 'read_bash',
 	WriteBash = 'write_bash',
+	StopBash = 'stop_bash',
 	BashShutdown = 'bash_shutdown',
 	ListBash = 'list_bash',
 
 	PowerShell = 'powershell',
 	ReadPowerShell = 'read_powershell',
 	WritePowerShell = 'write_powershell',
+	StopPowerShell = 'stop_powershell',
+	PowerShellShutdown = 'powershell_shutdown',
 	ListPowerShell = 'list_powershell',
 
 	View = 'view',
@@ -51,14 +55,38 @@ const enum CopilotToolName {
 	Grep = 'grep',
 	Rg = 'rg',
 	Glob = 'glob',
+	SearchCodeSubagent = 'search_code_subagent',
+	ReplyToComment = 'reply_to_comment',
+	CodeReview = 'code_review',
 	ApplyPatch = 'apply_patch',
 	GitApplyPatch = 'git_apply_patch',
 	WebSearch = 'web_search',
 	WebFetch = 'web_fetch',
 	AskUser = 'ask_user',
 	ReportIntent = 'report_intent',
+	Think = 'think',
+	ReportProgress = 'report_progress',
+	UpdateTodo = 'update_todo',
+	ShowFile = 'show_file',
+	FetchCopilotCliDocumentation = 'fetch_copilot_cli_documentation',
+	ProposeWork = 'propose_work',
+	TaskComplete = 'task_complete',
 	Skill = 'skill',
+	Task = 'task',
+	ListAgents = 'list_agents',
+	ReadAgent = 'read_agent',
 	ExitPlanMode = 'exit_plan_mode',
+	Sql = 'sql',
+	Lsp = 'lsp',
+	CreatePullRequest = 'create_pull_request',
+	GhAdvisoryDatabase = 'gh-advisory-database',
+	StoreMemory = 'store_memory',
+	ParallelValidation = 'parallel_validation',
+	WriteAgent = 'write_agent',
+	McpReload = 'mcp_reload',
+	McpValidate = 'mcp_validate',
+	ToolSearchToolRegex = 'tool_search_tool_regex',
+	CodeqlChecker = 'codeql_checker',
 }
 
 /** Parameters for the `bash` / `powershell` shell tools. */
@@ -148,6 +176,12 @@ interface ICopilotRgToolArgs {
 interface ICopilotGlobToolArgs {
 	pattern: string;
 	path?: string;
+}
+
+/** Parameters for the `sql` tool. */
+interface ICopilotSqlToolArgs {
+	description?: string;
+	query?: string;
 }
 
 /**
@@ -360,27 +394,59 @@ function md(value: string): StringOrMarkdown {
 
 export function getToolDisplayName(toolName: string): string {
 	switch (toolName) {
-		case CopilotToolName.Bash: return localize('toolName.bash', "Bash");
-		case CopilotToolName.PowerShell: return localize('toolName.powershell', "PowerShell");
-		case CopilotToolName.ReadBash:
-		case CopilotToolName.ReadPowerShell: return localize('toolName.readShell', "Read Shell Output");
-		case CopilotToolName.WriteBash:
-		case CopilotToolName.WritePowerShell: return localize('toolName.writeShell', "Write Shell Input");
-		case CopilotToolName.BashShutdown: return localize('toolName.bashShutdown', "Stop Shell");
-		case CopilotToolName.ListBash:
-		case CopilotToolName.ListPowerShell: return localize('toolName.listShells', "List Shells");
-		case CopilotToolName.View: return localize('toolName.view', "View File");
-		case CopilotToolName.Edit: return localize('toolName.edit', "Edit File");
+		case CopilotToolName.StrReplaceEditor:
+		case CopilotToolName.Edit:
+		case CopilotToolName.StrReplace:
+		case CopilotToolName.Insert: return localize('toolName.edit', "Edit File");
 		case CopilotToolName.Create: return localize('toolName.create', "Create File");
+		case CopilotToolName.View: return localize('toolName.view', "Read");
+		case CopilotToolName.Bash:
+		case CopilotToolName.PowerShell: return localize('toolName.shell', "Run Shell Command");
+		case CopilotToolName.ReadBash:
+		case CopilotToolName.ReadPowerShell: return localize('toolName.readShell', "Read Terminal");
+		case CopilotToolName.WriteBash: return localize('toolName.writeBash', "Write to Bash");
+		case CopilotToolName.WritePowerShell: return localize('toolName.writePowerShell', "Write to PowerShell");
+		case CopilotToolName.StopBash:
+		case CopilotToolName.StopPowerShell:
+		case CopilotToolName.BashShutdown:
+		case CopilotToolName.PowerShellShutdown: return localize('toolName.stopShell', "Stop Terminal Session");
+		case CopilotToolName.ListBash:
+		case CopilotToolName.ListPowerShell: return localize('toolName.listShells', "List Shell Sessions");
 		case CopilotToolName.Grep:
-		case CopilotToolName.Rg: return localize('toolName.grep', "Search");
-		case CopilotToolName.Glob: return localize('toolName.glob', "Find Files");
-		case CopilotToolName.ApplyPatch:
+		case CopilotToolName.Rg:
+		case CopilotToolName.Glob: return localize('toolName.search', "Search");
+		case CopilotToolName.SearchCodeSubagent: return localize('toolName.searchCode', "Search Code");
+		case CopilotToolName.ApplyPatch: return localize('toolName.applyPatch', "Apply Patch");
 		case CopilotToolName.GitApplyPatch: return localize('toolName.patch', "Patch");
+		case CopilotToolName.CodeqlChecker: return localize('toolName.codeqlChecker', "CodeQL Security Scan");
+		case CopilotToolName.CodeReview: return localize('toolName.codeReview', "Code Review");
+		case CopilotToolName.ReplyToComment: return localize('toolName.replyToComment', "Reply to Comment");
+		case CopilotToolName.Think: return localize('toolName.think', "Thinking");
+		case CopilotToolName.ReportIntent: return localize('toolName.reportIntent', "Report Intent");
+		case CopilotToolName.ReportProgress: return localize('toolName.reportProgress', "Progress update");
 		case CopilotToolName.WebSearch: return localize('toolName.webSearch', "Web Search");
-		case CopilotToolName.WebFetch: return localize('toolName.webFetch', "Web Fetch");
+		case CopilotToolName.WebFetch: return localize('toolName.webFetch', "Fetch Web Content");
+		case CopilotToolName.UpdateTodo: return localize('toolName.updateTodo', "Update Todo");
+		case CopilotToolName.ShowFile: return localize('toolName.showFile', "Show File");
+		case CopilotToolName.FetchCopilotCliDocumentation: return localize('toolName.fetchCopilotCliDocumentation', "Fetch Documentation");
+		case CopilotToolName.ProposeWork: return localize('toolName.proposeWork', "Propose Work");
+		case CopilotToolName.TaskComplete: return localize('toolName.taskComplete', "Task Complete");
 		case CopilotToolName.AskUser: return localize('toolName.askUser', "Ask User");
-		case CopilotToolName.ExitPlanMode: return localize('toolName.exitPlanMode', "Plan");
+		case CopilotToolName.Skill: return localize('toolName.skill', "Invoke Skill");
+		case CopilotToolName.Task: return localize('toolName.task', "Delegate Task");
+		case CopilotToolName.ListAgents: return localize('toolName.listAgents', "List Agents");
+		case CopilotToolName.ReadAgent: return localize('toolName.readAgent', "Read Agent");
+		case CopilotToolName.ExitPlanMode: return localize('toolName.exitPlanMode', "Exit Plan Mode");
+		case CopilotToolName.Sql: return localize('toolName.sql', "Execute SQL");
+		case CopilotToolName.Lsp: return localize('toolName.lsp', "Language Server");
+		case CopilotToolName.CreatePullRequest: return localize('toolName.createPullRequest', "Create Pull Request");
+		case CopilotToolName.GhAdvisoryDatabase: return localize('toolName.ghAdvisoryDatabase', "Check Dependencies");
+		case CopilotToolName.StoreMemory: return localize('toolName.storeMemory', "Store Memory");
+		case CopilotToolName.ParallelValidation: return localize('toolName.parallelValidation', "Validate Changes");
+		case CopilotToolName.WriteAgent: return localize('toolName.writeAgent', "Write to Agent");
+		case CopilotToolName.McpReload: return localize('toolName.mcpReload', "Reload MCP Config");
+		case CopilotToolName.McpValidate: return localize('toolName.mcpValidate', "Validate MCP Config");
+		case CopilotToolName.ToolSearchToolRegex: return localize('toolName.toolSearchToolRegex', "Search Tools");
 		default: return toolName;
 	}
 }
@@ -405,7 +471,7 @@ export function getInvocationMessage(toolName: string, displayName: string, para
 	}
 
 	if (READ_SHELL_TOOL_NAMES.has(toolName)) {
-		return localize('toolInvoke.readShell', "Reading shell output");
+		return localize('toolInvoke.readShell', "Reading Terminal");
 	}
 
 	switch (toolName) {
@@ -473,6 +539,10 @@ export function getInvocationMessage(toolName: string, displayName: string, para
 			}
 			return localize('toolInvoke.patch', "Editing files");
 		}
+		case CopilotToolName.Sql: {
+			const args = parameters as ICopilotSqlToolArgs | undefined;
+			return args?.description || localize('toolInvoke.sql', "Executing SQL query");
+		}
 		case CopilotToolName.ExitPlanMode:
 			return localize('toolInvoke.exitPlanMode', "Presenting plan");
 		default:
@@ -504,7 +574,7 @@ export function getPastTenseMessage(toolName: string, displayName: string, param
 	}
 
 	if (READ_SHELL_TOOL_NAMES.has(toolName)) {
-		return localize('toolComplete.readShell', "Read shell output");
+		return localize('toolComplete.readShell', "Read Terminal");
 	}
 
 	switch (toolName) {
@@ -572,6 +642,10 @@ export function getPastTenseMessage(toolName: string, displayName: string, param
 			}
 			return localize('toolComplete.patch', "Edited files");
 		}
+		case CopilotToolName.Sql: {
+			const args = parameters as ICopilotSqlToolArgs | undefined;
+			return args?.description || localize('toolComplete.sql', "Executed SQL query");
+		}
 		case CopilotToolName.ExitPlanMode:
 			return localize('toolComplete.exitPlanMode', "Exited plan mode");
 		default:
@@ -638,7 +712,7 @@ export function synthesizeSkillToolCall(
 	eventId: string | undefined,
 ): ISynthesizedSkillToolCall {
 	const toolCallId = getSkillSyntheticToolCallId(eventId, data);
-	const displayName = localize('toolName.skill', "Read Skill");
+	const displayName = localize('toolName.readSkill', "Read Skill");
 	// Use the skill name as the link text rather than the basename: every skill
 	// file is named SKILL.md, so `Reading skill [plan]` reads better than the
 	// always-identical `Reading skill [SKILL.md]`. The client may further upgrade

--- a/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
@@ -103,10 +103,6 @@ interface ICopilotFileToolArgs {
 	path: string;
 }
 
-interface ICopilotStrReplaceEditorToolArgs extends ICopilotFileToolArgs {
-	command?: string;
-}
-
 /**
  * Parameters for the `view` tool. The Copilot CLI accepts an optional
  * `view_range: [startLine, endLine]` (1-based, inclusive). `endLine` may be
@@ -266,27 +262,15 @@ const STR_REPLACE_EDITOR_EDIT_COMMANDS: ReadonlySet<string> = new Set([
 	CopilotToolName.Create,
 ]);
 
-function getObjectParameters(parameters: unknown): Record<string, unknown> | undefined {
-	if (typeof parameters === 'string') {
-		try {
-			parameters = JSON.parse(parameters);
-		} catch {
-			return undefined;
-		}
-	}
-	return parameters && typeof parameters === 'object' ? parameters as Record<string, unknown> : undefined;
-}
-
 /**
  * Returns true if the tool modifies files on disk.
  */
-export function isEditTool(toolName: string, parameters?: unknown): boolean {
+export function isEditTool(toolName: string, command?: string): boolean {
 	if (EDIT_TOOL_NAMES.has(toolName)) {
 		return true;
 	}
 	if (toolName === CopilotToolName.StrReplaceEditor) {
-		const args = getObjectParameters(parameters) as ICopilotStrReplaceEditorToolArgs | undefined;
-		return typeof args?.command === 'string' && STR_REPLACE_EDITOR_EDIT_COMMANDS.has(args.command);
+		return command !== undefined && STR_REPLACE_EDITOR_EDIT_COMMANDS.has(command);
 	}
 	return false;
 }

--- a/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
@@ -17,7 +17,10 @@ import { basename } from '../../../../base/common/resources.js';
 // =============================================================================
 // Copilot CLI built-in tool interfaces
 //
-// Mirrors the Copilot Chat CLI display labels for SDK tool event names.
+// The Copilot CLI (via @github/copilot-sdk) exposes these built-in tools. Tool names
+// and parameter shapes are not typed in the SDK -- they come from the CLI server
+// as plain strings. These interfaces are derived from observing the CLI's actual
+// tool events and the Copilot Chat extension's CLI display table.
 //
 // Shell tool names follow a pattern per ShellConfig:
 //   shellToolName, readShellToolName, writeShellToolName,

--- a/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
@@ -103,6 +103,10 @@ interface ICopilotFileToolArgs {
 	path: string;
 }
 
+interface ICopilotStrReplaceEditorToolArgs extends ICopilotFileToolArgs {
+	command?: string;
+}
+
 /**
  * Parameters for the `view` tool. The Copilot CLI accepts an optional
  * `view_range: [startLine, endLine]` (1-based, inclusive). `endLine` may be
@@ -248,16 +252,43 @@ function getApplyPatchFiles(args: string | ICopilotApplyPatchToolArgs | undefine
 /** Set of tool names that perform file edits. */
 const EDIT_TOOL_NAMES: ReadonlySet<string> = new Set([
 	CopilotToolName.Edit,
+	CopilotToolName.StrReplace,
+	CopilotToolName.Insert,
 	CopilotToolName.Create,
 	CopilotToolName.ApplyPatch,
 	CopilotToolName.GitApplyPatch,
 ]);
 
+const STR_REPLACE_EDITOR_EDIT_COMMANDS: ReadonlySet<string> = new Set([
+	CopilotToolName.Edit,
+	CopilotToolName.StrReplace,
+	CopilotToolName.Insert,
+	CopilotToolName.Create,
+]);
+
+function getObjectParameters(parameters: unknown): Record<string, unknown> | undefined {
+	if (typeof parameters === 'string') {
+		try {
+			parameters = JSON.parse(parameters);
+		} catch {
+			return undefined;
+		}
+	}
+	return parameters && typeof parameters === 'object' ? parameters as Record<string, unknown> : undefined;
+}
+
 /**
  * Returns true if the tool modifies files on disk.
  */
-export function isEditTool(toolName: string): boolean {
-	return EDIT_TOOL_NAMES.has(toolName);
+export function isEditTool(toolName: string, parameters?: unknown): boolean {
+	if (EDIT_TOOL_NAMES.has(toolName)) {
+		return true;
+	}
+	if (toolName === CopilotToolName.StrReplaceEditor) {
+		const args = getObjectParameters(parameters) as ICopilotStrReplaceEditorToolArgs | undefined;
+		return typeof args?.command === 'string' && STR_REPLACE_EDITOR_EDIT_COMMANDS.has(args.command);
+	}
+	return false;
 }
 
 /**
@@ -334,6 +365,7 @@ const SUBAGENT_TOOL_NAMES: ReadonlySet<string> = new Set([
 const SEARCH_TOOL_NAMES: ReadonlySet<string> = new Set([
 	CopilotToolName.Grep,
 	CopilotToolName.Rg,
+	CopilotToolName.Glob,
 ]);
 
 /**
@@ -402,11 +434,11 @@ export function getToolDisplayName(toolName: string): string {
 		case CopilotToolName.StrReplace:
 		case CopilotToolName.Insert: return localize('toolName.edit', "Edit File");
 		case CopilotToolName.Create: return localize('toolName.create', "Create File");
-		case CopilotToolName.View: return localize('toolName.view', "Read");
+		case CopilotToolName.View: return localize('toolName.read', "Read");
 		case CopilotToolName.Bash:
 		case CopilotToolName.PowerShell: return localize('toolName.shell', "Run Shell Command");
 		case CopilotToolName.ReadBash:
-		case CopilotToolName.ReadPowerShell: return localize('toolName.readShell', "Read Terminal");
+		case CopilotToolName.ReadPowerShell: return localize('toolName.readTerminal', "Read Terminal");
 		case CopilotToolName.WriteBash: return localize('toolName.writeBash', "Write to Bash");
 		case CopilotToolName.WritePowerShell: return localize('toolName.writePowerShell', "Write to PowerShell");
 		case CopilotToolName.StopBash:
@@ -414,7 +446,7 @@ export function getToolDisplayName(toolName: string): string {
 		case CopilotToolName.BashShutdown:
 		case CopilotToolName.PowerShellShutdown: return localize('toolName.stopShell', "Stop Terminal Session");
 		case CopilotToolName.ListBash:
-		case CopilotToolName.ListPowerShell: return localize('toolName.listShells', "List Shell Sessions");
+		case CopilotToolName.ListPowerShell: return localize('toolName.listShellSessions', "List Shell Sessions");
 		case CopilotToolName.Grep:
 		case CopilotToolName.Rg:
 		case CopilotToolName.Glob: return localize('toolName.search', "Search");
@@ -428,18 +460,18 @@ export function getToolDisplayName(toolName: string): string {
 		case CopilotToolName.ReportIntent: return localize('toolName.reportIntent', "Report Intent");
 		case CopilotToolName.ReportProgress: return localize('toolName.reportProgress', "Progress update");
 		case CopilotToolName.WebSearch: return localize('toolName.webSearch', "Web Search");
-		case CopilotToolName.WebFetch: return localize('toolName.webFetch', "Fetch Web Content");
+		case CopilotToolName.WebFetch: return localize('toolName.fetchWebContent', "Fetch Web Content");
 		case CopilotToolName.UpdateTodo: return localize('toolName.updateTodo', "Update Todo");
 		case CopilotToolName.ShowFile: return localize('toolName.showFile', "Show File");
 		case CopilotToolName.FetchCopilotCliDocumentation: return localize('toolName.fetchCopilotCliDocumentation', "Fetch Documentation");
 		case CopilotToolName.ProposeWork: return localize('toolName.proposeWork', "Propose Work");
 		case CopilotToolName.TaskComplete: return localize('toolName.taskComplete', "Task Complete");
 		case CopilotToolName.AskUser: return localize('toolName.askUser', "Ask User");
-		case CopilotToolName.Skill: return localize('toolName.skill', "Invoke Skill");
+		case CopilotToolName.Skill: return localize('toolName.invokeSkill', "Invoke Skill");
 		case CopilotToolName.Task: return localize('toolName.task', "Delegate Task");
 		case CopilotToolName.ListAgents: return localize('toolName.listAgents', "List Agents");
 		case CopilotToolName.ReadAgent: return localize('toolName.readAgent', "Read Agent");
-		case CopilotToolName.ExitPlanMode: return localize('toolName.exitPlanMode', "Exit Plan Mode");
+		case CopilotToolName.ExitPlanMode: return localize('toolName.exitPlanModeFull', "Exit Plan Mode");
 		case CopilotToolName.Sql: return localize('toolName.sql', "Execute SQL");
 		case CopilotToolName.Lsp: return localize('toolName.lsp', "Language Server");
 		case CopilotToolName.CreatePullRequest: return localize('toolName.createPullRequest', "Create Pull Request");
@@ -474,7 +506,7 @@ export function getInvocationMessage(toolName: string, displayName: string, para
 	}
 
 	if (READ_SHELL_TOOL_NAMES.has(toolName)) {
-		return localize('toolInvoke.readShell', "Reading Terminal");
+		return localize('toolInvoke.readTerminal', "Reading Terminal");
 	}
 
 	switch (toolName) {
@@ -577,7 +609,7 @@ export function getPastTenseMessage(toolName: string, displayName: string, param
 	}
 
 	if (READ_SHELL_TOOL_NAMES.has(toolName)) {
-		return localize('toolComplete.readShell', "Read Terminal");
+		return localize('toolComplete.readTerminal', "Read Terminal");
 	}
 
 	switch (toolName) {
@@ -715,7 +747,7 @@ export function synthesizeSkillToolCall(
 	eventId: string | undefined,
 ): ISynthesizedSkillToolCall {
 	const toolCallId = getSkillSyntheticToolCallId(eventId, data);
-	const displayName = localize('toolName.readSkill', "Read Skill");
+	const displayName = localize('toolName.skill', "Read Skill");
 	// Use the skill name as the link text rather than the basename: every skill
 	// file is named SKILL.md, so `Reading skill [plan]` reads better than the
 	// always-identical `Reading skill [SKILL.md]`. The client may further upgrade

--- a/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
+++ b/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
@@ -251,7 +251,7 @@ export async function mapSessionEvents(
 				continue;
 			}
 			toolInfoByCallId.set(d.toolCallId, info);
-			if (isEditTool(d.toolName)) {
+			if (isEditTool(d.toolName, d.arguments)) {
 				editToolCallIds.push(d.toolCallId);
 			}
 		}

--- a/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
+++ b/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
@@ -5,6 +5,7 @@
 
 import { MessageOptions } from '@github/copilot-sdk';
 import { basename } from '../../../../base/common/path.js';
+import { isString } from '../../../../base/common/types.js';
 import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { stripRedundantCdPrefix } from '../../common/commandLineHelpers.js';
@@ -251,7 +252,8 @@ export async function mapSessionEvents(
 				continue;
 			}
 			toolInfoByCallId.set(d.toolCallId, info);
-			if (isEditTool(d.toolName, d.arguments)) {
+			const command = isString(info.parameters?.command) ? info.parameters.command : undefined;
+			if (isEditTool(d.toolName, command)) {
 				editToolCallIds.push(d.toolCallId);
 			}
 		}

--- a/src/vs/platform/agentHost/test/node/copilotToolDisplay.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotToolDisplay.test.ts
@@ -6,7 +6,77 @@
 import assert from 'assert';
 import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
-import { getEditFilePath, getEditFilePaths, getInvocationMessage, getPastTenseMessage, getPermissionDisplay, getShellLanguage, getToolInputString, getToolKind, isHiddenTool, synthesizeSkillToolCall, type ITypedPermissionRequest } from '../../node/copilot/copilotToolDisplay.js';
+import { getEditFilePath, getEditFilePaths, getInvocationMessage, getPastTenseMessage, getPermissionDisplay, getShellLanguage, getToolDisplayName, getToolInputString, getToolKind, isHiddenTool, synthesizeSkillToolCall, type ITypedPermissionRequest } from '../../node/copilot/copilotToolDisplay.js';
+
+suite('copilotToolDisplay — friendly tool names', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('mirrors internal Copilot CLI friendly labels for representative tools', () => {
+		const cases: Array<[toolName: string, displayName: string]> = [
+			['bash', 'Run Shell Command'],
+			['powershell', 'Run Shell Command'],
+			['read_bash', 'Read Terminal'],
+			['read_powershell', 'Read Terminal'],
+			['write_bash', 'Write to Bash'],
+			['write_powershell', 'Write to PowerShell'],
+			['stop_bash', 'Stop Terminal Session'],
+			['stop_powershell', 'Stop Terminal Session'],
+			['bash_shutdown', 'Stop Terminal Session'],
+			['powershell_shutdown', 'Stop Terminal Session'],
+			['list_bash', 'List Shell Sessions'],
+			['list_powershell', 'List Shell Sessions'],
+			['view', 'Read'],
+			['edit', 'Edit File'],
+			['str_replace_editor', 'Edit File'],
+			['str_replace', 'Edit File'],
+			['insert', 'Edit File'],
+			['create', 'Create File'],
+			['grep', 'Search'],
+			['rg', 'Search'],
+			['glob', 'Search'],
+			['search_code_subagent', 'Search Code'],
+			['reply_to_comment', 'Reply to Comment'],
+			['code_review', 'Code Review'],
+			['think', 'Thinking'],
+			['report_intent', 'Report Intent'],
+			['report_progress', 'Progress update'],
+			['web_fetch', 'Fetch Web Content'],
+			['web_search', 'Web Search'],
+			['update_todo', 'Update Todo'],
+			['show_file', 'Show File'],
+			['fetch_copilot_cli_documentation', 'Fetch Documentation'],
+			['propose_work', 'Propose Work'],
+			['task_complete', 'Task Complete'],
+			['ask_user', 'Ask User'],
+			['skill', 'Invoke Skill'],
+			['task', 'Delegate Task'],
+			['list_agents', 'List Agents'],
+			['read_agent', 'Read Agent'],
+			['exit_plan_mode', 'Exit Plan Mode'],
+			['sql', 'Execute SQL'],
+			['lsp', 'Language Server'],
+			['create_pull_request', 'Create Pull Request'],
+			['gh-advisory-database', 'Check Dependencies'],
+			['store_memory', 'Store Memory'],
+			['apply_patch', 'Apply Patch'],
+			['write_agent', 'Write to Agent'],
+			['mcp_reload', 'Reload MCP Config'],
+			['mcp_validate', 'Validate MCP Config'],
+			['tool_search_tool_regex', 'Search Tools'],
+			['parallel_validation', 'Validate Changes'],
+			['codeql_checker', 'CodeQL Security Scan'],
+		];
+
+		for (const [toolName, displayName] of cases) {
+			assert.strictEqual(getToolDisplayName(toolName), displayName, toolName);
+		}
+	});
+
+	test('falls back to the raw tool name for unknown tools', () => {
+		assert.strictEqual(getToolDisplayName('some_new_tool'), 'some_new_tool');
+	});
+});
 
 suite('getPermissionDisplay — cd-prefix stripping', () => {
 
@@ -222,12 +292,12 @@ suite('copilotToolDisplay — write_/read_ shell tools', () => {
 
 		test('read_bash returns a non-empty message', () => {
 			const msg = getInvocationMessage('read_bash', 'Read Shell Output', undefined);
-			assert.ok(getText(msg).length > 0);
+			assert.strictEqual(getText(msg), 'Reading Terminal');
 		});
 
 		test('read_powershell returns a non-empty message', () => {
 			const msg = getInvocationMessage('read_powershell', 'Read Shell Output', undefined);
-			assert.ok(getText(msg).length > 0);
+			assert.strictEqual(getText(msg), 'Reading Terminal');
 		});
 
 		test('write_bash message differs from bash message (distinct wording)', () => {
@@ -261,7 +331,7 @@ suite('copilotToolDisplay — write_/read_ shell tools', () => {
 
 		test('read_bash success returns a non-empty message', () => {
 			const msg = getPastTenseMessage('read_bash', 'Read Shell Output', undefined, true);
-			assert.ok(getText(msg).length > 0);
+			assert.strictEqual(getText(msg), 'Read Terminal');
 		});
 
 		test('write_bash failure returns a non-empty error message', () => {
@@ -366,6 +436,26 @@ suite('rg / grep search tool display', () => {
 	test('getToolInputString returns pattern for both grep and rg', () => {
 		assert.strictEqual(getToolInputString('grep', { pattern: 'abc' }, undefined), 'abc');
 		assert.strictEqual(getToolInputString('rg', { pattern: 'abc' }, undefined), 'abc');
+	});
+});
+
+suite('sql tool display', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function text(msg: ReturnType<typeof getInvocationMessage> | ReturnType<typeof getPastTenseMessage>): string {
+		return typeof msg === 'string' ? msg : msg.markdown;
+	}
+
+	test('uses the SQL description for invocation and completion messages', () => {
+		const parameters = { description: 'Insert agent host study todos', query: 'INSERT INTO todos (title) VALUES (\'Read terminal activation docs\')' };
+		assert.strictEqual(text(getInvocationMessage('sql', 'Execute SQL', parameters)), 'Insert agent host study todos');
+		assert.strictEqual(text(getPastTenseMessage('sql', 'Execute SQL', parameters, true)), 'Insert agent host study todos');
+	});
+
+	test('falls back to generic SQL wording when description is absent', () => {
+		assert.strictEqual(text(getInvocationMessage('sql', 'Execute SQL', { query: 'SELECT 1' })), 'Executing SQL query');
+		assert.strictEqual(text(getPastTenseMessage('sql', 'Execute SQL', { query: 'SELECT 1' }, true)), 'Executed SQL query');
 	});
 });
 

--- a/src/vs/platform/agentHost/test/node/copilotToolDisplay.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotToolDisplay.test.ts
@@ -90,16 +90,11 @@ suite('copilotToolDisplay — edit tool classification', () => {
 
 	test('classifies str_replace_editor by command', () => {
 		for (const command of ['edit', 'str_replace', 'insert', 'create']) {
-			assert.strictEqual(isEditTool('str_replace_editor', { command, path: '/repo/file.ts' }), true, command);
+			assert.strictEqual(isEditTool('str_replace_editor', command), true, command);
 		}
-		assert.strictEqual(isEditTool('str_replace_editor', { command: 'view', path: '/repo/file.ts' }), false);
-		assert.strictEqual(isEditTool('str_replace_editor', { command: 'unknown', path: '/repo/file.ts' }), false);
+		assert.strictEqual(isEditTool('str_replace_editor', 'view'), false);
+		assert.strictEqual(isEditTool('str_replace_editor', 'unknown'), false);
 		assert.strictEqual(isEditTool('str_replace_editor'), false);
-	});
-
-	test('classifies str_replace_editor from JSON-encoded arguments', () => {
-		assert.strictEqual(isEditTool('str_replace_editor', JSON.stringify({ command: 'edit', path: '/repo/file.ts' })), true);
-		assert.strictEqual(isEditTool('str_replace_editor', JSON.stringify({ command: 'view', path: '/repo/file.ts' })), false);
 	});
 });
 

--- a/src/vs/platform/agentHost/test/node/copilotToolDisplay.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotToolDisplay.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
-import { getEditFilePath, getEditFilePaths, getInvocationMessage, getPastTenseMessage, getPermissionDisplay, getShellLanguage, getToolDisplayName, getToolInputString, getToolKind, isHiddenTool, synthesizeSkillToolCall, type ITypedPermissionRequest } from '../../node/copilot/copilotToolDisplay.js';
+import { getEditFilePath, getEditFilePaths, getInvocationMessage, getPastTenseMessage, getPermissionDisplay, getShellLanguage, getToolDisplayName, getToolInputString, getToolKind, isEditTool, isHiddenTool, synthesizeSkillToolCall, type ITypedPermissionRequest } from '../../node/copilot/copilotToolDisplay.js';
 
 suite('copilotToolDisplay — friendly tool names', () => {
 
@@ -75,6 +75,31 @@ suite('copilotToolDisplay — friendly tool names', () => {
 
 	test('falls back to the raw tool name for unknown tools', () => {
 		assert.strictEqual(getToolDisplayName('some_new_tool'), 'some_new_tool');
+	});
+});
+
+suite('copilotToolDisplay — edit tool classification', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('classifies direct file edit tools', () => {
+		for (const toolName of ['edit', 'str_replace', 'insert', 'create', 'apply_patch', 'git_apply_patch']) {
+			assert.strictEqual(isEditTool(toolName), true, toolName);
+		}
+	});
+
+	test('classifies str_replace_editor by command', () => {
+		for (const command of ['edit', 'str_replace', 'insert', 'create']) {
+			assert.strictEqual(isEditTool('str_replace_editor', { command, path: '/repo/file.ts' }), true, command);
+		}
+		assert.strictEqual(isEditTool('str_replace_editor', { command: 'view', path: '/repo/file.ts' }), false);
+		assert.strictEqual(isEditTool('str_replace_editor', { command: 'unknown', path: '/repo/file.ts' }), false);
+		assert.strictEqual(isEditTool('str_replace_editor'), false);
+	});
+
+	test('classifies str_replace_editor from JSON-encoded arguments', () => {
+		assert.strictEqual(isEditTool('str_replace_editor', JSON.stringify({ command: 'edit', path: '/repo/file.ts' })), true);
+		assert.strictEqual(isEditTool('str_replace_editor', JSON.stringify({ command: 'view', path: '/repo/file.ts' })), false);
 	});
 });
 
@@ -238,6 +263,10 @@ suite('copilotToolDisplay — write_/read_ shell tools', () => {
 
 		test('returns undefined for view', () => {
 			assert.strictEqual(getToolKind('view'), undefined);
+		});
+
+		test('returns search for glob', () => {
+			assert.strictEqual(getToolKind('glob'), 'search');
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/historyRecordFixtures.ts
+++ b/src/vs/platform/agentHost/test/node/historyRecordFixtures.ts
@@ -5,6 +5,7 @@
 
 import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
+import { isString } from '../../../../base/common/types.js';
 import { stripRedundantCdPrefix } from '../../common/commandLineHelpers.js';
 import { IFileEditRecord, ISessionDatabase } from '../../common/sessionDataService.js';
 import { ResponsePartKind, ToolCallConfirmationReason, ToolCallStatus, ToolResultContentType, TurnState, buildSubagentSessionUri, type ResponsePart, type StringOrMarkdown, type ToolCallCompletedState, type ToolResultContent, type Turn } from '../../common/state/sessionState.js';
@@ -398,7 +399,8 @@ export async function mapSessionEventsToHistoryRecords(
 			}
 			const rewrittenArgs = stripRedundantCdPrefix(d.toolName, parameters, workingDirectory) ? tryStringify(parameters) : undefined;
 			toolInfoByCallId.set(d.toolCallId, { toolName: d.toolName, parameters, rewrittenArgs });
-			if (isEditTool(d.toolName, parameters ?? d.arguments)) {
+			const command = isString(parameters?.command) ? parameters.command : undefined;
+			if (isEditTool(d.toolName, command)) {
 				editToolCallIds.push(d.toolCallId);
 			}
 		}

--- a/src/vs/platform/agentHost/test/node/historyRecordFixtures.ts
+++ b/src/vs/platform/agentHost/test/node/historyRecordFixtures.ts
@@ -398,7 +398,7 @@ export async function mapSessionEventsToHistoryRecords(
 			}
 			const rewrittenArgs = stripRedundantCdPrefix(d.toolName, parameters, workingDirectory) ? tryStringify(parameters) : undefined;
 			toolInfoByCallId.set(d.toolCallId, { toolName: d.toolName, parameters, rewrittenArgs });
-			if (isEditTool(d.toolName)) {
+			if (isEditTool(d.toolName, parameters ?? d.arguments)) {
 				editToolCallIds.push(d.toolCallId);
 			}
 		}


### PR DESCRIPTION
Part of: https://github.com/microsoft/vscode/issues/315182

- Align Agent Host Copilot CLI tool display names with the Copilot Chat CLI integration for known built-in tools.
- Cover shell, file/edit, search, agent/task, PR, MCP, validation, and CodeQL tool names while keeping the raw `toolName` unchanged for protocol identity.


Expected with this PR:

- Agent Host Copilot CLI chat shows friendly labels such as `Read Terminal`, `Edit File`, `Create Pull Request`, and instead of raw tool IDs.
- `glob` renders with the same search-style hint as `grep` / `rg`.
- File edits made through `str_replace`, `insert`, or editing `str_replace_editor` commands can still produce file-edit/diff content.
- `str_replace_editor` view/read usage does not get treated as a file edit.
<img width="700" height="200" alt="readTerminalAlignments" src="https://github.com/user-attachments/assets/5364d2d0-1fe1-4b27-9e14-f48829e36068" />
<img width="600" height="350" alt="todoAlignments" src="https://github.com/user-attachments/assets/2f334e3f-cf81-4e34-ac35-00f5085fda1e" />



<details>
<summary>Steps to manually validate</summary>

Ask Copilot CLI - Agent Host to run and read shell output:

```text
Run ls in terminal, then read the terminal output.
```

Expected: the read helper row says `Read Terminal`.

Ask it to use glob search:

```text
Find all package.json files in this repo using glob.
```

Expected: the tool displays as `Search` and uses search-style rendering.

Ask it to make a tiny scratch-file edit with an edit tool such as `str_replace` / `insert` / editing `str_replace_editor`:

```text
Create a scratch file, make a tiny edit to it, then show me the change.
```

Expected: the edit tool displays as `Edit File` and the changed file can appear in the file-change summary/diff UI.

</details>

Follow-up:

- This PR is scoped to AHP tool display naming, rendering hints, localization-key hygiene, and edit tracking for the aligned edit tools.
- Expandable tool input/output UI and the SQL-backed todo widget bridge remain separate follow-up work.

-----------------------------------------
Inspirations from:

- The friendly label set comes from the Copilot Chat CLI integration's [`ToolFriendlyNameAndHandlers`](https://github.com/microsoft/vscode/blob/40fdd83c1374b6368e38a12e0cb99843aea4871a/extensions/copilot/src/extension/chatSessions/copilotcli/common/copilotCLITools.ts#L1107-L1158).
- `str_replace_editor` edit-vs-view classification follows [`isCopilotCliEditToolCall`](https://github.com/microsoft/vscode/blob/40fdd83c1374b6368e38a12e0cb99843aea4871a/extensions/copilot/src/extension/chatSessions/copilotcli/common/copilotCLITools.ts#L430-L436) and affected-file detection in [`getAffectedUrisForEditTool`](https://github.com/microsoft/vscode/blob/40fdd83c1374b6368e38a12e0cb99843aea4871a/extensions/copilot/src/extension/chatSessions/copilotcli/common/copilotCLITools.ts#L455-L466).
- The `str_replace_editor` command split between `view`, `edit`, `insert`, and `create` comes from [`formatStrReplaceEditorInvocation`](https://github.com/microsoft/vscode/blob/40fdd83c1374b6368e38a12e0cb99843aea4871a/extensions/copilot/src/extension/chatSessions/copilotcli/common/copilotCLITools.ts#L1194-L1216).
- The `glob` search-kind update extends the existing Agent Host search rendering hook in [`SEARCH_TOOL_NAMES`](https://github.com/microsoft/vscode/blob/40fdd83c1374b6368e38a12e0cb99843aea4871a/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts#L296-L300).
