### PR TITLE
Make Agent Host debug log export work in web

### DIFF
--- a/src/vs/sessions/contrib/providers/agentHost/browser/exportDebugLogsAction.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/exportDebugLogsAction.ts
@@ -5,17 +5,17 @@
 
 import { localize2 } from '../../../../../nls.js';
 import { Categories } from '../../../../../platform/action/common/actionCommonCategories.js';
-import { Action2 } from '../../../../../platform/actions/common/actions.js';
+import { Action2, registerAction2 } from '../../../../../platform/actions/common/actions.js';
 import { AgentHostEnabledSettingId } from '../../../../../platform/agentHost/common/agentService.js';
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IsSessionsWindowContext } from '../../../../../workbench/common/contextkeys.js';
+import { exportAgentHostDebugLogs, IActiveAgentHostSessionForExport } from '../../../../../workbench/contrib/chat/browser/actions/exportAgentHostDebugLogsAction.js';
 import { ChatContextKeys } from '../../../../../workbench/contrib/chat/common/actions/chatContextKeys.js';
-import { exportAgentHostDebugLogs, IActiveAgentHostSessionForExport } from '../../../../../workbench/contrib/chat/electron-browser/actions/exportAgentHostDebugLogsAction.js';
 import { type ISession } from '../../../../services/sessions/common/session.js';
 import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
-import { BaseAgentHostSessionsProvider } from '../browser/baseAgentHostSessionsProvider.js';
+import { BaseAgentHostSessionsProvider } from './baseAgentHostSessionsProvider.js';
 
 export class ExportAgentHostDebugLogsAction extends Action2 {
 
@@ -70,3 +70,5 @@ function getMostRecentAgentHostSession(sessions: readonly ISession[], sessionsPr
 	}
 	return mostRecent;
 }
+
+registerAction2(ExportAgentHostDebugLogsAction);

--- a/src/vs/sessions/contrib/providers/agentHost/electron-browser/agentHost.contribution.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/electron-browser/agentHost.contribution.ts
@@ -5,7 +5,6 @@
 
 import { registerAction2 } from '../../../../../platform/actions/common/actions.js';
 import { DebugAgentHostInDevToolsAction } from '../../../../../workbench/contrib/chat/electron-browser/actions/debugAgentHostAction.js';
-import { ExportAgentHostDebugLogsAction } from './exportDebugLogsAction.js';
+import '../../../../../workbench/contrib/chat/electron-browser/actions/exportAgentHostDebugLogsService.js';
 
 registerAction2(DebugAgentHostInDevToolsAction);
-registerAction2(ExportAgentHostDebugLogsAction);

--- a/src/vs/sessions/sessions.common.main.ts
+++ b/src/vs/sessions/sessions.common.main.ts
@@ -449,6 +449,7 @@ import './browser/layoutActions.js';
 import './contrib/accountMenu/browser/account.contribution.js';
 import './contrib/aiCustomizationTreeView/browser/aiCustomizationTreeView.contribution.js';
 import './contrib/chat/browser/chat.contribution.js';
+import './contrib/providers/agentHost/browser/exportDebugLogsAction.js';
 import './contrib/providers/agentHost/browser/agentHostSessionConfigPicker.js';
 import './contrib/chat/browser/customizationsDebugLog.contribution.js';
 import './contrib/providers/copilotChatSessions/browser/copilotChatSessions.contribution.js';

--- a/src/vs/sessions/sessions.web.main.ts
+++ b/src/vs/sessions/sessions.web.main.ts
@@ -105,6 +105,7 @@ import { ISSHRemoteAgentHostService } from '../platform/agentHost/common/sshRemo
 import { NullSSHRemoteAgentHostService } from '../platform/agentHost/browser/nullSshRemoteAgentHostService.js';
 import { IAgentHostService } from '../platform/agentHost/common/agentService.js';
 import { NullAgentHostService } from '../platform/agentHost/browser/nullAgentHostService.js';
+import { BrowserAgentHostDebugLogsExportService, IAgentHostDebugLogsExportService } from '../workbench/contrib/chat/browser/actions/exportAgentHostDebugLogsAction.js';
 
 registerSingleton(IWorkbenchExtensionManagementService, ExtensionManagementService, InstantiationType.Delayed);
 registerSingleton(IAccessibilityService, AccessibilityService, InstantiationType.Delayed);
@@ -127,6 +128,7 @@ registerSingleton(IMcpGalleryManifestService, WorkbenchMcpGalleryManifestService
 registerSingleton(IRemoteAgentHostService, RemoteAgentHostService, InstantiationType.Delayed);
 registerSingleton(ISSHRemoteAgentHostService, NullSSHRemoteAgentHostService, InstantiationType.Delayed);
 registerSingleton(IAgentHostService, NullAgentHostService, InstantiationType.Delayed);
+registerSingleton(IAgentHostDebugLogsExportService, BrowserAgentHostDebugLogsExportService, InstantiationType.Delayed);
 
 //#endregion
 

--- a/src/vs/workbench/contrib/chat/browser/actions/chatDeveloperActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatDeveloperActions.ts
@@ -20,6 +20,7 @@ import { IChatWidgetService } from '../chat.js';
 import { IStorageService, StorageScope } from '../../../../../platform/storage/common/storage.js';
 import { AUTOPILOT_DONT_SHOW_AGAIN_KEY, AUTO_APPROVE_DONT_SHOW_AGAIN_KEY } from '../../common/chatPermissionStorageKeys.js';
 import { resetShownWarnings } from '../../common/chatPermissionWarnings.js';
+import { ExportAgentHostDebugLogsAction } from './exportAgentHostDebugLogsAction.js';
 import { OpenCopilotCliStateFileAction } from './openCopilotCliStateFileAction.js';
 
 function uriReplacer(_key: string, value: unknown): unknown {
@@ -43,6 +44,7 @@ export function registerChatDeveloperActions() {
 	registerAction2(ClearRecentlyUsedLanguageModelsAction);
 	registerAction2(ResetChatPermissionWarningDialogsAction);
 	registerAction2(OpenCopilotCliStateFileAction);
+	registerAction2(ExportAgentHostDebugLogsAction);
 }
 
 function formatChatModelReferenceInspection(accessor: ServicesAccessor): string {

--- a/src/vs/workbench/contrib/chat/browser/actions/exportAgentHostDebugLogsAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/exportAgentHostDebugLogsAction.ts
@@ -3,6 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { VSBuffer } from '../../../../../base/common/buffer.js';
+import { Schemas } from '../../../../../base/common/network.js';
 import { joinPath } from '../../../../../base/common/resources.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { localize, localize2 } from '../../../../../nls.js';
@@ -15,17 +17,16 @@ import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contex
 import { IFileDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
 import { IEnvironmentService } from '../../../../../platform/environment/common/environment.js';
 import { IFileService } from '../../../../../platform/files/common/files.js';
-import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
+import { createDecorator, ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
-import { INativeHostService } from '../../../../../platform/native/common/native.js';
 import { INotificationService, Severity } from '../../../../../platform/notification/common/notification.js';
 import { IProductService } from '../../../../../platform/product/common/productService.js';
 import { ITextModelService } from '../../../../../editor/common/services/resolverService.js';
 import { IOutputService } from '../../../../services/output/common/output.js';
 import { IPathService } from '../../../../services/path/common/pathService.js';
-import { IChatWidgetService } from '../../browser/chat.js';
+import { IChatWidgetService } from '../chat.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
-import { COPILOT_CLI_LOCAL_AH_SCHEME, parseRemoteAuthorityFromScheme, resolveEventsUri } from '../../browser/copilotCliEventsUri.js';
+import { COPILOT_CLI_LOCAL_AH_SCHEME, parseRemoteAuthorityFromScheme, resolveEventsUri } from '../copilotCliEventsUri.js';
 
 /** Output channel ID for the agent host process logger (forwarded via RemoteLoggerChannelClient). */
 const AGENT_HOST_LOGGER_CHANNEL_ID = 'agenthost';
@@ -48,27 +49,49 @@ export interface IActiveAgentHostSessionForExport {
 	readonly isLocal: boolean;
 }
 
+export interface IAgentHostDebugLogsExport {
+	readonly files: { path: string; contents: string }[];
+	readonly exportName: string;
+}
+
+export const IAgentHostDebugLogsExportService = createDecorator<IAgentHostDebugLogsExportService>('agentHostDebugLogsExportService');
+
+export interface IAgentHostDebugLogsExportService {
+	readonly _serviceBrand: undefined;
+	save(exportName: string, files: readonly { path: string; contents: string }[]): Promise<void>;
+}
+
+export class BrowserAgentHostDebugLogsExportService implements IAgentHostDebugLogsExportService {
+	declare readonly _serviceBrand: undefined;
+
+	constructor(
+		@IFileDialogService private readonly fileDialogService: IFileDialogService,
+		@IFileService private readonly fileService: IFileService,
+	) { }
+
+	async save(exportName: string, files: readonly { path: string; contents: string }[]): Promise<void> {
+		await exportFilesToLocalFolder(this.fileDialogService, this.fileService, exportName, files);
+	}
+}
+
 /**
  * Shared implementation of "Export Agent Host Debug Logs". Collects the
  * Copilot CLI session events file (if available), the window/shared/agent-host
- * output channel logs, and the AHP transport JSONL logs into a single zip file
- * chosen by the user via a save dialog.
+ * output channel logs, and the AHP transport JSONL logs.
  *
  * Both the workbench-side action (resolves the active session via
  * `IChatWidgetService`) and the sessions-app-side action (resolves it via
  * `ISessionsManagementService`) call into this helper.
  */
-export async function exportAgentHostDebugLogs(
+export async function collectAgentHostDebugLogs(
 	accessor: ServicesAccessor,
 	activeSession: IActiveAgentHostSessionForExport | undefined,
-): Promise<void> {
+): Promise<IAgentHostDebugLogsExport | undefined> {
 	const pathService = accessor.get(IPathService);
 	const agentHostService = accessor.get(IAgentHostService);
 	const remoteAgentHostService = accessor.get(IRemoteAgentHostService);
 	const outputService = accessor.get(IOutputService);
 	const fileService = accessor.get(IFileService);
-	const fileDialogService = accessor.get(IFileDialogService);
-	const nativeHostService = accessor.get(INativeHostService);
 	const notificationService = accessor.get(INotificationService);
 	const textModelService = accessor.get(ITextModelService);
 	const productService = accessor.get(IProductService);
@@ -184,25 +207,27 @@ export async function exportAgentHostDebugLogs(
 				? localize('exportDebugLogs.noFiles.activeSession', "No log files were found for the active Agent Host session.")
 				: localize('exportDebugLogs.noFiles.currentWindow', "No Agent Host log files were found for the current window."),
 		});
-		return;
+		return undefined;
 	}
 
 	const titleSlug = activeSession?.title
 		? `-${activeSession.title.replace(/[/\\:*?"<>|\s]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 40)}`
 		: '';
-	const defaultUri = joinPath(await fileDialogService.defaultFilePath(), `ah-logs${titleSlug}.zip`);
-	const saveUri = await fileDialogService.showSaveDialog({
-		title: localize('exportDebugLogs.saveDialogTitle', "Export Agent Host Debug Logs"),
-		defaultUri,
-		filters: [{ name: localize('exportDebugLogs.zipFilter', "Zip Archive"), extensions: ['zip'] }],
-	});
+	return { files, exportName: `ah-logs${titleSlug}` };
+}
 
-	if (!saveUri) {
+export async function exportAgentHostDebugLogs(
+	accessor: ServicesAccessor,
+	activeSession: IActiveAgentHostSessionForExport | undefined,
+): Promise<void> {
+	const exportService = accessor.get(IAgentHostDebugLogsExportService);
+	const notificationService = accessor.get(INotificationService);
+	const logs = await collectAgentHostDebugLogs(accessor, activeSession);
+	if (!logs) {
 		return;
 	}
-
 	try {
-		await nativeHostService.createZipFile(saveUri, files);
+		await exportService.save(logs.exportName, logs.files);
 	} catch (error) {
 		notificationService.notify({
 			severity: Severity.Error,
@@ -248,7 +273,7 @@ export class ExportAgentHostDebugLogsAction extends Action2 {
  * session (i.e. local AH or remote AH; the EH CLI extension's own
  * `copilotcli:` sessions are excluded).
  */
-function toActiveAgentHostSession(resource: URI, title: string | undefined): IActiveAgentHostSessionForExport | undefined {
+export function toActiveAgentHostSession(resource: URI, title: string | undefined): IActiveAgentHostSessionForExport | undefined {
 	if (resource.scheme === COPILOT_CLI_LOCAL_AH_SCHEME) {
 		return { resource, title, isLocal: true };
 	}
@@ -264,6 +289,52 @@ function getRemoteConnectionForSession(sessionResource: URI, connections: readon
 
 function sanitizeFilePart(value: string): string {
 	return value.replace(/[\\/:\*\?"<>|\s]+/g, '-').replace(/^-+|-+$/g, '') || 'connection';
+}
+
+async function exportFilesToLocalFolder(
+	fileDialogService: IFileDialogService,
+	fileService: IFileService,
+	exportName: string,
+	files: readonly { path: string; contents: string }[],
+): Promise<void> {
+	const folders = await fileDialogService.showOpenDialog({
+		title: localize('exportDebugLogs.folderDialogTitle', "Select Folder for Agent Host Debug Logs"),
+		canSelectFiles: false,
+		canSelectFolders: true,
+		canSelectMany: false,
+		availableFileSystems: [Schemas.file],
+	});
+
+	const parentFolder = folders?.[0];
+	if (!parentFolder) {
+		return;
+	}
+
+	const exportFolder = joinPath(parentFolder, exportName);
+	await fileService.createFolder(exportFolder);
+	for (const file of files) {
+		const segments = toSafeRelativePathSegments(file.path);
+		if (segments.length === 0) {
+			continue;
+		}
+
+		let folder = exportFolder;
+		for (const segment of segments.slice(0, -1)) {
+			folder = joinPath(folder, segment);
+			await fileService.createFolder(folder);
+		}
+		await fileService.writeFile(joinPath(folder, segments[segments.length - 1]), VSBuffer.fromString(file.contents));
+	}
+}
+
+function toSafeRelativePathSegments(path: string): string[] {
+	return path
+		.replace(/\\/g, '/')
+		.split('/')
+		.filter(segment => {
+			return segment.length > 0 && segment !== '.' && segment !== '..';
+		})
+		.map(segment => segment.replace(/[/\\:*?"<>|]/g, '-'));
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/electron-browser/actions/chatDeveloperActions.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/actions/chatDeveloperActions.ts
@@ -11,12 +11,11 @@ import { INativeHostService } from '../../../../../platform/native/common/native
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
 import { IChatService } from '../../common/chatService/chatService.js';
 import { DebugAgentHostInDevToolsAction } from './debugAgentHostAction.js';
-import { ExportAgentHostDebugLogsAction } from './exportAgentHostDebugLogsAction.js';
+import './exportAgentHostDebugLogsService.js';
 
 export function registerChatDeveloperActions() {
 	registerAction2(OpenChatStorageFolderAction);
 	registerAction2(DebugAgentHostInDevToolsAction);
-	registerAction2(ExportAgentHostDebugLogsAction);
 }
 
 class OpenChatStorageFolderAction extends Action2 {

--- a/src/vs/workbench/contrib/chat/electron-browser/actions/exportAgentHostDebugLogsService.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/actions/exportAgentHostDebugLogsService.ts
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Schemas } from '../../../../../base/common/network.js';
+import { joinPath } from '../../../../../base/common/resources.js';
+import { localize } from '../../../../../nls.js';
+import { IFileDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
+import { InstantiationType, registerSingleton } from '../../../../../platform/instantiation/common/extensions.js';
+import { INativeHostService } from '../../../../../platform/native/common/native.js';
+import { IAgentHostDebugLogsExportService } from '../../browser/actions/exportAgentHostDebugLogsAction.js';
+
+class NativeAgentHostDebugLogsExportService implements IAgentHostDebugLogsExportService {
+	declare readonly _serviceBrand: undefined;
+
+	constructor(
+		@IFileDialogService private readonly fileDialogService: IFileDialogService,
+		@INativeHostService private readonly nativeHostService: INativeHostService,
+	) { }
+
+	async save(exportName: string, files: readonly { path: string; contents: string }[]): Promise<void> {
+		const defaultUri = joinPath(await this.fileDialogService.defaultFilePath(Schemas.file), `${exportName}.zip`);
+		const saveUri = await this.fileDialogService.showSaveDialog({
+			title: localize('exportDebugLogs.saveDialogTitle', "Export Agent Host Debug Logs"),
+			defaultUri,
+			filters: [{ name: localize('exportDebugLogs.zipFilter', "Zip Archive"), extensions: ['zip'] }],
+			availableFileSystems: [Schemas.file],
+		});
+
+		if (!saveUri) {
+			return;
+		}
+
+		await this.nativeHostService.createZipFile(saveUri, [...files]);
+	}
+}
+
+registerSingleton(IAgentHostDebugLogsExportService, NativeAgentHostDebugLogsExportService, InstantiationType.Delayed);

--- a/src/vs/workbench/workbench.web.main.ts
+++ b/src/vs/workbench/workbench.web.main.ts
@@ -101,6 +101,10 @@ import { IWebContentExtractorService, NullWebContentExtractorService, ISharedWeb
 import { IMcpGalleryManifestService } from '../platform/mcp/common/mcpGalleryManifest.js';
 import { WorkbenchMcpGalleryManifestService } from './services/mcp/browser/mcpGalleryManifestService.js';
 import { UserDataSyncResourceProviderService } from '../platform/userDataSync/common/userDataSyncResourceProvider.js';
+import { IAgentHostService } from '../platform/agentHost/common/agentService.js';
+import { NullAgentHostService } from '../platform/agentHost/browser/nullAgentHostService.js';
+import { IRemoteAgentHostService, NullRemoteAgentHostService } from '../platform/agentHost/common/remoteAgentHostService.js';
+import { BrowserAgentHostDebugLogsExportService, IAgentHostDebugLogsExportService } from './contrib/chat/browser/actions/exportAgentHostDebugLogsAction.js';
 
 registerSingleton(IWorkbenchExtensionManagementService, ExtensionManagementService, InstantiationType.Delayed);
 registerSingleton(IAccessibilityService, AccessibilityService, InstantiationType.Delayed);
@@ -121,6 +125,9 @@ registerSingleton(ILanguagePackService, WebLanguagePacksService, InstantiationTy
 registerSingleton(IWebContentExtractorService, NullWebContentExtractorService, InstantiationType.Delayed);
 registerSingleton(ISharedWebContentExtractorService, NullSharedWebContentExtractorService, InstantiationType.Delayed);
 registerSingleton(IMcpGalleryManifestService, WorkbenchMcpGalleryManifestService, InstantiationType.Delayed);
+registerSingleton(IAgentHostService, NullAgentHostService, InstantiationType.Delayed);
+registerSingleton(IRemoteAgentHostService, NullRemoteAgentHostService, InstantiationType.Delayed);
+registerSingleton(IAgentHostDebugLogsExportService, BrowserAgentHostDebugLogsExportService, InstantiationType.Delayed);
 
 //#endregion
 


### PR DESCRIPTION
This makes the Export Agent Host Debug Logs command available from browser-registered actions and delegates persistence to a platform-specific export service.

- Desktop keeps exporting a ZIP via the native host service, with the save picker restricted to the local file system.
- Web exports the collected log files into a user-selected local folder.
- The workbench web entrypoints register null Agent Host services and the browser export service.

Validation:
- npm run compile-check-ts-native -- --pretty false
- npm run valid-layers-check
- node --experimental-strip-types build/hygiene.ts <changed files>