### PR TITLE
Don't dispose background terminals the user revealed

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -2643,7 +2643,10 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			const exitCode = command.exitCode;
 			const exitCodeText = exitCode !== undefined ? ` with exit code ${exitCode}` : '';
 			const currentOutput = execution.getOutput();
-			const willDispose = terminalInstance.shellLaunchConfig.hideFromUser;
+			// Only dispose if the terminal is still hidden from the user. Once the
+			// user reveals it (via the "Show" link), it joins `foregroundInstances`
+			// and should persist so they can inspect/interact with it.
+			const willDispose = !this._terminalService.foregroundInstances.includes(terminalInstance);
 			const message = willDispose
 				? `[Terminal ${termId} notification: command completed${exitCodeText}. The terminal has been cleaned up.]\nTerminal output:\n${currentOutput}`
 				: `[Terminal ${termId} notification: command completed${exitCodeText}. Use send_to_terminal to send another command or kill_terminal to stop it.]\nTerminal output:\n${currentOutput}`;
@@ -2662,11 +2665,12 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 
 			// Background terminals are not reused, so dispose them once their
 			// command completes to prevent terminal accumulation across turns.
-			// Only dispose if the user hasn't revealed the terminal — if they
-			// have, they may want to inspect its output or interact with it.
+			// Only dispose if the user hasn't revealed the terminal — once revealed
+			// it joins `foregroundInstances` and they may want to inspect its
+			// output or interact with it.
 			// Capture the output snapshot first so the progress part can still
 			// display output after the terminal instance is gone.
-			if (terminalInstance.shellLaunchConfig.hideFromUser) {
+			if (willDispose) {
 				this._commandArtifactCollector.capture(toolSpecificData, terminalInstance, command.id).then(() => {
 					this._logService.debug(`RunInTerminalTool: Disposing finished background terminal ${termId}`);
 					// Mark as killed so the onDisposed handler below does not

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -2646,10 +2646,10 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			// Only dispose if the terminal is still hidden from the user. Once the
 			// user reveals it (via the "Show" link), it joins `foregroundInstances`
 			// and should persist so they can inspect/interact with it.
-			const willDispose = !this._terminalService.foregroundInstances.includes(terminalInstance);
-			const message = willDispose
-				? `[Terminal ${termId} notification: command completed${exitCodeText}. The terminal has been cleaned up.]\nTerminal output:\n${currentOutput}`
-				: `[Terminal ${termId} notification: command completed${exitCodeText}. Use send_to_terminal to send another command or kill_terminal to stop it.]\nTerminal output:\n${currentOutput}`;
+			const isUserVisible = this._terminalService.foregroundInstances.includes(terminalInstance);
+			const message = isUserVisible
+				? `[Terminal ${termId} notification: command completed${exitCodeText}. Use send_to_terminal to send another command or kill_terminal to stop it.]\nTerminal output:\n${currentOutput}`
+				: `[Terminal ${termId} notification: command completed${exitCodeText}. The terminal has been cleaned up.]\nTerminal output:\n${currentOutput}`;
 
 			this._logService.debug(`RunInTerminalTool: Command completed in background terminal ${termId}, notifying chat session`);
 
@@ -2670,17 +2670,21 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			// output or interact with it.
 			// Capture the output snapshot first so the progress part can still
 			// display output after the terminal instance is gone.
-			if (willDispose) {
-				this._commandArtifactCollector.capture(toolSpecificData, terminalInstance, command.id).then(() => {
-					this._logService.debug(`RunInTerminalTool: Disposing finished background terminal ${termId}`);
-					// Mark as killed so the onDisposed handler below does not
-					// send a redundant "terminal exited" steering message.
-					RunInTerminalTool._killedByTool.add(termId);
-					execution.dispose();
-					RunInTerminalTool._activeExecutions.delete(termId);
-					terminalInstance.dispose();
-				});
-			}
+			// Re-check foregroundInstances inside the callback because the user
+			// may click the "Show" link while capture is in progress.
+			this._commandArtifactCollector.capture(toolSpecificData, terminalInstance, command.id).then(() => {
+				if (this._terminalService.foregroundInstances.includes(terminalInstance)) {
+					this._logService.debug(`RunInTerminalTool: Background terminal ${termId} was revealed by user, skipping disposal`);
+					return;
+				}
+				this._logService.debug(`RunInTerminalTool: Disposing finished background terminal ${termId}`);
+				// Mark as killed so the onDisposed handler below does not
+				// send a redundant "terminal exited" steering message.
+				RunInTerminalTool._killedByTool.add(termId);
+				execution.dispose();
+				RunInTerminalTool._activeExecutions.delete(termId);
+				terminalInstance.dispose();
+			});
 		}));
 
 		// Clean up all background resources when the terminal is disposed

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -180,6 +180,7 @@ suite('RunInTerminalTool', () => {
 				createTerminalCallCount++;
 				return createdTerminalInstance;
 			},
+			foregroundInstances: [],
 			onDidDisposeInstance: terminalServiceDisposeEmitter.event,
 			onDidChangeInstances: Event.None,
 			revealTerminal: async () => { },
@@ -2016,6 +2017,7 @@ suite('RunInTerminalTool', () => {
 			instantiationService.stub(ITerminalService, {
 				onDidDisposeInstance: terminalServiceDisposeEmitter.event,
 				instances: [mockTerminal1, mockTerminal2],
+				foregroundInstances: [],
 				setNextCommandId: async () => { }
 			});
 
@@ -2774,6 +2776,7 @@ suite('ChatAgentToolsContribution - tool registration refresh', () => {
 		instantiationService.stub(ITerminalService, {
 			onDidDisposeInstance: terminalServiceDisposeEmitter.event,
 			onDidChangeInstances: terminalInstancesChangedEmitter.event,
+			foregroundInstances: [],
 			setNextCommandId: async () => { }
 		});
 		instantiationService.stub(ITerminalChatService, store.add(instantiationService.createInstance(TerminalChatService)));

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -2360,6 +2360,9 @@ suite('RunInTerminalTool', () => {
 
 		const toolSpecificData = { kind: 'terminal', commandLine: { original: 'ssh host' }, language: 'bash' } as IChatTerminalToolInvocationData;
 
+		// This is a foreground terminal, so it should be in foregroundInstances
+		(instantiationService.get(ITerminalService).foregroundInstances as ITerminalInstance[]).push(terminalInstance);
+
 		// Set up fg terminal association and active execution
 		runInTerminalTool.sessionTerminalAssociations.set(sessionResource, {
 			instance: terminalInstance,
@@ -2367,8 +2370,9 @@ suite('RunInTerminalTool', () => {
 			isBackground: false,
 		});
 
-		(runInTerminalTool.constructor as unknown as { _activeExecutions: Map<string, { getOutput(): string }> })._activeExecutions.set(termId, {
+		(runInTerminalTool.constructor as unknown as { _activeExecutions: Map<string, { getOutput(): string; dispose(): void }> })._activeExecutions.set(termId, {
 			getOutput: () => 'Password:',
+			dispose: () => { },
 		});
 
 		// eslint-disable-next-line @typescript-eslint/naming-convention


### PR DESCRIPTION
The post-completion auto-disposal added in #316278 used `shellLaunchConfig.hideFromUser` to decide whether to clean up a finished background terminal. That flag is set once at terminal creation and never flipped when the user clicks the 'Show' link, so revealed terminals were still being disposed.

Use `ITerminalService.foregroundInstances` membership instead — `showBackgroundTerminal` moves the instance into a group/editor, putting it in `foregroundInstances`, which correctly reflects 'user has surfaced this terminal'.

Follow-up to #316278.