### PR TITLE
Block auto-approved file writes with literal tilde

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineFileWriteAnalyzer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineFileWriteAnalyzer.ts
@@ -146,9 +146,9 @@ export class CommandLineFileWriteAnalyzer extends Disposable implements ICommand
 							const fileUri = URI.isUri(fileWrite) ? fileWrite : URI.file(fileWrite);
 							// TODO: Handle command substitutions/complex destinations properly https://github.com/microsoft/vscode/issues/274167
 							// TODO: Handle environment variables properly https://github.com/microsoft/vscode/issues/274166
-							if (fileUri.fsPath.match(/[$\(\){}`]/)) {
+							if (fileUri.fsPath.match(/[$\(\){}`~]/)) {
 								isAutoApproveAllowed = false;
-								this._log('File write blocked due to likely containing a variable or sub-command', fileUri.toString());
+								this._log('File write blocked due to likely containing a variable, sub-command, or tilde expansion', fileUri.toString());
 								break;
 							}
 


### PR DESCRIPTION
Add ~ to the variable/sub-command detection regex in commandLineFileWriteAnalyzer so paths like ~/foo that the shell will expand are not auto-approved based on a static path that does not match what bash will open.
