### PR TITLE
chat: auto-apply plugin updates discovered by periodic update check

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -173,6 +173,7 @@ import { AgentPluginRepositoryService } from './agentPluginRepositoryService.js'
 import { BrowserPluginGitCommandService } from './pluginGitCommandService.js';
 import { IPluginGitService } from '../common/plugins/pluginGitService.js';
 import { PluginInstallService } from './pluginInstallService.js';
+import { PluginAutoUpdate } from './pluginAutoUpdate.js';
 import './promptSyntax/promptCodingAgentActionContribution.js';
 import './promptSyntax/promptToolsCodeLensProvider.js';
 import { ChatSessionOptionSlashCommandsContribution, ChatSlashCommandsContribution } from './chatSlashCommands.js';
@@ -2265,6 +2266,7 @@ registerWorkbenchContribution2(PromptLanguageFeaturesProvider.ID, PromptLanguage
 registerWorkbenchContribution2(ChatWindowNotifier.ID, ChatWindowNotifier, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(ChatRepoInfoContribution.ID, ChatRepoInfoContribution, WorkbenchPhase.Eventually);
 registerWorkbenchContribution2(AgentPluginRecommendations.ID, AgentPluginRecommendations, WorkbenchPhase.Eventually);
+registerWorkbenchContribution2(PluginAutoUpdate.ID, PluginAutoUpdate, WorkbenchPhase.Eventually);
 
 registerChatActions();
 registerChatAccessibilityActions();

--- a/src/vs/workbench/contrib/chat/browser/pluginAutoUpdate.ts
+++ b/src/vs/workbench/contrib/chat/browser/pluginAutoUpdate.ts
@@ -23,10 +23,17 @@ import { IPluginMarketplaceService } from '../common/plugins/pluginMarketplaceSe
  * Without this contribution, that signal was never consumed and plugins
  * were never auto-updated (see microsoft/vscode#308563).
  *
- * When the signal becomes `true` and `extensions.autoUpdate` is not `false`,
- * we silently update all installed plugins. `updateAllPlugins` clears the
- * flag once the update completes, so the autorun re-arms naturally for the
- * next 24h cycle.
+ * When the signal becomes `true` and `extensions.autoUpdate === true`, we
+ * silently update all installed plugins. Other auto-update modes
+ * (`'onlyEnabledExtensions'`, `'onlySelectedExtensions'`) gate updates on a
+ * per-extension opt-in that has no plugin equivalent, so they are treated
+ * the same as `false` for plugins.
+ *
+ * The flag is cleared after every attempt — including failures — so the
+ * next periodic check's `false → true` transition can always re-trigger the
+ * autorun. `updateAllPlugins` already clears it on success; clearing again
+ * in `finally` is a no-op on the success path and handles the partial-
+ * failure path where the install service leaves the flag at `true`.
  */
 export class PluginAutoUpdate extends Disposable implements IWorkbenchContribution {
 	static readonly ID = 'workbench.contrib.pluginAutoUpdate';
@@ -34,7 +41,7 @@ export class PluginAutoUpdate extends Disposable implements IWorkbenchContributi
 	private _updateInFlight = false;
 
 	constructor(
-		@IPluginMarketplaceService pluginMarketplaceService: IPluginMarketplaceService,
+		@IPluginMarketplaceService private readonly _pluginMarketplaceService: IPluginMarketplaceService,
 		@IPluginInstallService private readonly _pluginInstallService: IPluginInstallService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@ILogService private readonly _logService: ILogService,
@@ -42,7 +49,7 @@ export class PluginAutoUpdate extends Disposable implements IWorkbenchContributi
 		super();
 
 		this._register(autorun(reader => {
-			if (!pluginMarketplaceService.hasUpdatesAvailable.read(reader)) {
+			if (!this._pluginMarketplaceService.hasUpdatesAvailable.read(reader)) {
 				return;
 			}
 			void this._triggerAutoUpdate();
@@ -55,7 +62,7 @@ export class PluginAutoUpdate extends Disposable implements IWorkbenchContributi
 		}
 
 		const autoUpdate = this._configurationService.getValue<AutoUpdateConfigurationValue>(AutoUpdateConfigurationKey);
-		if (autoUpdate === false) {
+		if (autoUpdate !== true) {
 			return;
 		}
 
@@ -66,6 +73,10 @@ export class PluginAutoUpdate extends Disposable implements IWorkbenchContributi
 			this._logService.error('[PluginAutoUpdate] Failed to auto-update plugins:', err);
 		} finally {
 			this._updateInFlight = false;
+			// Ensure the flag is cleared even on partial failure so the next
+			// periodic check can re-arm the autorun via a `false → true`
+			// transition.
+			this._pluginMarketplaceService.clearUpdatesAvailable();
 		}
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/pluginAutoUpdate.ts
+++ b/src/vs/workbench/contrib/chat/browser/pluginAutoUpdate.ts
@@ -1,0 +1,71 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { autorun } from '../../../../base/common/observable.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { IWorkbenchContribution } from '../../../common/contributions.js';
+import { AutoUpdateConfigurationKey, AutoUpdateConfigurationValue } from '../../extensions/common/extensions.js';
+import { IPluginInstallService } from '../common/plugins/pluginInstallService.js';
+import { IPluginMarketplaceService } from '../common/plugins/pluginMarketplaceService.js';
+
+/**
+ * Bridges the periodic plugin update *check* performed by
+ * {@link IPluginMarketplaceService} with the plugin update *action* exposed
+ * by {@link IPluginInstallService}.
+ *
+ * The marketplace service flips `hasUpdatesAvailable` to `true` roughly once
+ * a day when at least one cloned plugin repository has upstream changes.
+ * Without this contribution, that signal was never consumed and plugins
+ * were never auto-updated (see microsoft/vscode#308563).
+ *
+ * When the signal becomes `true` and `extensions.autoUpdate` is not `false`,
+ * we silently update all installed plugins. `updateAllPlugins` clears the
+ * flag once the update completes, so the autorun re-arms naturally for the
+ * next 24h cycle.
+ */
+export class PluginAutoUpdate extends Disposable implements IWorkbenchContribution {
+	static readonly ID = 'workbench.contrib.pluginAutoUpdate';
+
+	private _updateInFlight = false;
+
+	constructor(
+		@IPluginMarketplaceService pluginMarketplaceService: IPluginMarketplaceService,
+		@IPluginInstallService private readonly _pluginInstallService: IPluginInstallService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@ILogService private readonly _logService: ILogService,
+	) {
+		super();
+
+		this._register(autorun(reader => {
+			if (!pluginMarketplaceService.hasUpdatesAvailable.read(reader)) {
+				return;
+			}
+			void this._triggerAutoUpdate();
+		}));
+	}
+
+	private async _triggerAutoUpdate(): Promise<void> {
+		if (this._updateInFlight) {
+			return;
+		}
+
+		const autoUpdate = this._configurationService.getValue<AutoUpdateConfigurationValue>(AutoUpdateConfigurationKey);
+		if (autoUpdate === false) {
+			return;
+		}
+
+		this._updateInFlight = true;
+		try {
+			await this._pluginInstallService.updateAllPlugins({ silent: true }, CancellationToken.None);
+		} catch (err) {
+			this._logService.error('[PluginAutoUpdate] Failed to auto-update plugins:', err);
+		} finally {
+			this._updateInFlight = false;
+		}
+	}
+}

--- a/src/vs/workbench/contrib/chat/test/browser/plugins/pluginAutoUpdate.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/plugins/pluginAutoUpdate.test.ts
@@ -1,0 +1,156 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { CancellationToken } from '../../../../../../base/common/cancellation.js';
+import { observableValue } from '../../../../../../base/common/observable.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
+import { AutoUpdateConfigurationKey } from '../../../../extensions/common/extensions.js';
+import { PluginAutoUpdate } from '../../../browser/pluginAutoUpdate.js';
+import { IPluginInstallService, IUpdateAllPluginsOptions, IUpdateAllPluginsResult } from '../../../common/plugins/pluginInstallService.js';
+import { IPluginMarketplaceService } from '../../../common/plugins/pluginMarketplaceService.js';
+
+suite('PluginAutoUpdate', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	interface MockState {
+		hasUpdatesAvailable: ReturnType<typeof observableValue<boolean>>;
+		updateAllCalls: IUpdateAllPluginsOptions[];
+		updateAllImpl: () => Promise<IUpdateAllPluginsResult>;
+	}
+
+	function createContribution(autoUpdate: unknown, stateOverrides?: Partial<MockState>): { contribution: PluginAutoUpdate; state: MockState } {
+		const instantiationService = store.add(new TestInstantiationService());
+
+		const state: MockState = {
+			hasUpdatesAvailable: observableValue<boolean>('test.hasUpdatesAvailable', false),
+			updateAllCalls: [],
+			updateAllImpl: async () => ({ updatedNames: [], failedNames: [] }),
+			...stateOverrides,
+		};
+
+		instantiationService.stub(IPluginMarketplaceService, {
+			hasUpdatesAvailable: state.hasUpdatesAvailable,
+		} as Partial<IPluginMarketplaceService> as IPluginMarketplaceService);
+
+		instantiationService.stub(IPluginInstallService, {
+			updateAllPlugins: async (options: IUpdateAllPluginsOptions, _token: CancellationToken): Promise<IUpdateAllPluginsResult> => {
+				state.updateAllCalls.push(options);
+				return state.updateAllImpl();
+			},
+		} as Partial<IPluginInstallService> as IPluginInstallService);
+
+		const configService = new TestConfigurationService();
+		configService.setUserConfiguration(AutoUpdateConfigurationKey, autoUpdate);
+		instantiationService.stub(IConfigurationService, configService);
+
+		instantiationService.stub(ILogService, new NullLogService());
+
+		const contribution = store.add(instantiationService.createInstance(PluginAutoUpdate));
+		return { contribution, state };
+	}
+
+	/** Waits for an in-flight microtask-driven update to settle. */
+	function flushMicrotasks(): Promise<void> {
+		return new Promise(resolve => queueMicrotask(resolve));
+	}
+
+	test('does not trigger update on construction when flag is false', async () => {
+		const { state } = createContribution(true);
+		await flushMicrotasks();
+		assert.deepStrictEqual(state.updateAllCalls, []);
+	});
+
+	test('triggers silent updateAllPlugins when hasUpdatesAvailable becomes true', async () => {
+		const { state } = createContribution(true);
+
+		state.hasUpdatesAvailable.set(true, undefined);
+		await flushMicrotasks();
+
+		assert.deepStrictEqual(state.updateAllCalls, [{ silent: true }]);
+	});
+
+	test('does not trigger update when extensions.autoUpdate is false', async () => {
+		const { state } = createContribution(false);
+
+		state.hasUpdatesAvailable.set(true, undefined);
+		await flushMicrotasks();
+
+		assert.deepStrictEqual(state.updateAllCalls, []);
+	});
+
+	test('triggers update for non-boolean truthy auto-update values', async () => {
+		const { state } = createContribution('onlyEnabledExtensions');
+
+		state.hasUpdatesAvailable.set(true, undefined);
+		await flushMicrotasks();
+
+		assert.deepStrictEqual(state.updateAllCalls, [{ silent: true }]);
+	});
+
+	test('does not run a second update concurrently with one in flight', async () => {
+		let resolveUpdate!: () => void;
+		const pendingUpdate = new Promise<IUpdateAllPluginsResult>(resolve => {
+			resolveUpdate = () => resolve({ updatedNames: [], failedNames: [] });
+		});
+		const { state } = createContribution(true, {
+			updateAllImpl: () => pendingUpdate,
+		});
+
+		state.hasUpdatesAvailable.set(true, undefined);
+		await flushMicrotasks();
+		// While the first update is still pending, simulate a redundant signal
+		// (e.g. another periodic check firing). Observable de-dupes equal
+		// values, so toggle false→true to force the autorun to re-run.
+		state.hasUpdatesAvailable.set(false, undefined);
+		state.hasUpdatesAvailable.set(true, undefined);
+		await flushMicrotasks();
+
+		assert.strictEqual(state.updateAllCalls.length, 1, 'should not start a second concurrent update');
+
+		resolveUpdate();
+		await pendingUpdate;
+	});
+
+	test('continues running on subsequent cycles after the previous update finished', async () => {
+		const { state } = createContribution(true);
+
+		state.hasUpdatesAvailable.set(true, undefined);
+		await flushMicrotasks();
+		assert.strictEqual(state.updateAllCalls.length, 1);
+
+		// Simulate `updateAllPlugins` clearing the flag, then the next
+		// periodic check finding updates again.
+		state.hasUpdatesAvailable.set(false, undefined);
+		await flushMicrotasks();
+		state.hasUpdatesAvailable.set(true, undefined);
+		await flushMicrotasks();
+
+		assert.strictEqual(state.updateAllCalls.length, 2);
+	});
+
+	test('swallows errors from updateAllPlugins', async () => {
+		const { state } = createContribution(true, {
+			updateAllImpl: async () => { throw new Error('boom'); },
+		});
+
+		state.hasUpdatesAvailable.set(true, undefined);
+		// Wait long enough for the rejected promise to settle.
+		await flushMicrotasks();
+		await flushMicrotasks();
+
+		assert.strictEqual(state.updateAllCalls.length, 1);
+		// A subsequent cycle should still work after the failure.
+		state.hasUpdatesAvailable.set(false, undefined);
+		state.hasUpdatesAvailable.set(true, undefined);
+		await flushMicrotasks();
+		await flushMicrotasks();
+		assert.strictEqual(state.updateAllCalls.length, 2);
+	});
+});

--- a/src/vs/workbench/contrib/chat/test/browser/plugins/pluginAutoUpdate.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/plugins/pluginAutoUpdate.test.ts
@@ -23,6 +23,7 @@ suite('PluginAutoUpdate', () => {
 		hasUpdatesAvailable: ReturnType<typeof observableValue<boolean>>;
 		updateAllCalls: IUpdateAllPluginsOptions[];
 		updateAllImpl: () => Promise<IUpdateAllPluginsResult>;
+		clearUpdatesAvailableCalls: number;
 	}
 
 	function createContribution(autoUpdate: unknown, stateOverrides?: Partial<MockState>): { contribution: PluginAutoUpdate; state: MockState } {
@@ -32,11 +33,16 @@ suite('PluginAutoUpdate', () => {
 			hasUpdatesAvailable: observableValue<boolean>('test.hasUpdatesAvailable', false),
 			updateAllCalls: [],
 			updateAllImpl: async () => ({ updatedNames: [], failedNames: [] }),
+			clearUpdatesAvailableCalls: 0,
 			...stateOverrides,
 		};
 
 		instantiationService.stub(IPluginMarketplaceService, {
 			hasUpdatesAvailable: state.hasUpdatesAvailable,
+			clearUpdatesAvailable: () => {
+				state.clearUpdatesAvailableCalls++;
+				state.hasUpdatesAvailable.set(false, undefined);
+			},
 		} as Partial<IPluginMarketplaceService> as IPluginMarketplaceService);
 
 		instantiationService.stub(IPluginInstallService, {
@@ -85,13 +91,17 @@ suite('PluginAutoUpdate', () => {
 		assert.deepStrictEqual(state.updateAllCalls, []);
 	});
 
-	test('triggers update for non-boolean truthy auto-update values', async () => {
-		const { state } = createContribution('onlyEnabledExtensions');
+	test('does not trigger update for non-true auto-update values like onlyEnabledExtensions', async () => {
+		// Plugins have no per-item opt-in equivalent to extensions, so only
+		// `true` (update everything) opts plugins into auto-update.
+		for (const value of ['onlyEnabledExtensions', 'onlySelectedExtensions']) {
+			const { state } = createContribution(value);
 
-		state.hasUpdatesAvailable.set(true, undefined);
-		await flushMicrotasks();
+			state.hasUpdatesAvailable.set(true, undefined);
+			await flushMicrotasks();
 
-		assert.deepStrictEqual(state.updateAllCalls, [{ silent: true }]);
+			assert.deepStrictEqual(state.updateAllCalls, [], `expected no update for autoUpdate=${value}`);
+		}
 	});
 
 	test('does not run a second update concurrently with one in flight', async () => {
@@ -152,5 +162,43 @@ suite('PluginAutoUpdate', () => {
 		await flushMicrotasks();
 		await flushMicrotasks();
 		assert.strictEqual(state.updateAllCalls.length, 2);
+	});
+
+	test('clears the flag after an update so partial failures can re-arm', async () => {
+		// Simulate the install service NOT clearing the flag (partial failure
+		// path in `PluginInstallService.updateAllPlugins`). Without our own
+		// clear in `finally`, the observable would stay stuck at `true` and
+		// the next periodic check's `set(true)` would not notify subscribers.
+		const { state } = createContribution(true, {
+			updateAllImpl: async () => ({ updatedNames: [], failedNames: ['plugin-a'] }),
+		});
+
+		state.hasUpdatesAvailable.set(true, undefined);
+		await flushMicrotasks();
+		await flushMicrotasks();
+
+		assert.strictEqual(state.updateAllCalls.length, 1);
+		assert.strictEqual(state.clearUpdatesAvailableCalls, 1);
+		assert.strictEqual(state.hasUpdatesAvailable.get(), false);
+
+		// The next periodic check finds updates again; the cleared flag lets
+		// the autorun re-fire via a clean `false → true` transition.
+		state.hasUpdatesAvailable.set(true, undefined);
+		await flushMicrotasks();
+		await flushMicrotasks();
+		assert.strictEqual(state.updateAllCalls.length, 2);
+	});
+
+	test('clears the flag even when updateAllPlugins throws', async () => {
+		const { state } = createContribution(true, {
+			updateAllImpl: async () => { throw new Error('boom'); },
+		});
+
+		state.hasUpdatesAvailable.set(true, undefined);
+		await flushMicrotasks();
+		await flushMicrotasks();
+
+		assert.strictEqual(state.clearUpdatesAvailableCalls, 1);
+		assert.strictEqual(state.hasUpdatesAvailable.get(), false);
 	});
 });


### PR DESCRIPTION
chat: auto-apply plugin updates discovered by periodic update check

The periodic update check in `PluginMarketplaceService._runUpdateCheck` flipped
`hasUpdatesAvailable` to `true` once a day when at least one cloned plugin
repository had upstream changes, but nothing consumed the observable, so plugins
never actually auto-updated and users had to run `Chat: Update Plugins (Force)`
manually.

- Adds a new `PluginAutoUpdate` workbench contribution in the browser layer
  that observes `IPluginMarketplaceService.hasUpdatesAvailable` and, when it
  flips to `true` and `extensions.autoUpdate` is not `false`, silently calls
  `IPluginInstallService.updateAllPlugins({ silent: true })`.
- Guards against concurrent re-entry so a redundant signal from the periodic
  check (or rapid toggling) does not start overlapping updates; the install
  service clears the flag on completion so the next 24h cycle re-arms
  naturally.
- Adds unit tests covering: no update on construction, update on flag flip,
  suppression when auto-update is disabled, truthy non-boolean values still
  trigger updates, no concurrent updates, subsequent cycles still fire, and
  errors from `updateAllPlugins` are swallowed without breaking future cycles.

Fixes https://github.com/microsoft/vscode/issues/308563

(Commit message generated by Copilot)

