### PR TITLE
Log local AHP reverse resource RPCs

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostClientResourceChannel.ts
+++ b/src/vs/platform/agentHost/common/agentHostClientResourceChannel.ts
@@ -8,6 +8,7 @@ import { Event } from '../../../base/common/event.js';
 import { URI } from '../../../base/common/uri.js';
 import { IChannel, IServerChannel } from '../../../base/parts/ipc/common/ipc.js';
 import { IFileService } from '../../files/common/files.js';
+import { AhpJsonlLogger, getAhpLogByteLength } from './ahpJsonlLogger.js';
 import { IRemoteFilesystemConnection } from './agentHostFileSystemProvider.js';
 import {
 	ContentEncoding, type DirectoryEntry, type ResourceDeleteParams, type ResourceDeleteResult,
@@ -32,13 +33,45 @@ export const AGENT_HOST_CLIENT_RESOURCE_CHANNEL = 'agentHostClientResource';
  */
 export class AgentHostClientResourceChannel implements IServerChannel {
 
-	constructor(private readonly _fileService: IFileService) { }
+	private _nextReverseRequestId = 1;
+
+	constructor(
+		private readonly _fileService: IFileService,
+		private readonly _ahpLogger?: AhpJsonlLogger,
+	) { }
 
 	listen<T>(_ctx: unknown, event: string): Event<T> {
 		throw new Error(`No event '${event}' on AgentHostClientResourceChannel`);
 	}
 
-	async call<T>(_ctx: unknown, command: string, arg?: unknown): Promise<T> {
+	async call<T>(ctx: unknown, command: string, arg?: unknown): Promise<T> {
+		const id = `local-reverse-${this._nextReverseRequestId++}`;
+		const requestFrame = { jsonrpc: '2.0' as const, id, method: command, params: arg };
+		this._logReverseFrame(requestFrame, 's2c');
+		try {
+			const result = await this._call<T>(ctx, command, arg);
+			const responseFrame = { jsonrpc: '2.0' as const, id, result: result ?? null };
+			this._logReverseFrame(responseFrame, 'c2s');
+			return result;
+		} catch (err) {
+			const errorFrame = {
+				jsonrpc: '2.0' as const,
+				id,
+				error: {
+					code: -32603,
+					message: err instanceof Error ? err.message : String(err),
+				},
+			};
+			this._logReverseFrame(errorFrame, 'c2s');
+			throw err;
+		}
+	}
+
+	private _logReverseFrame(frame: object, dir: 'c2s' | 's2c'): void {
+		this._ahpLogger?.log(frame, dir, getAhpLogByteLength(safeStringify(frame)));
+	}
+
+	private async _call<T>(_ctx: unknown, command: string, arg?: unknown): Promise<T> {
 		const a = (arg ?? {}) as Record<string, unknown>;
 		switch (command) {
 			case 'resourceList': {
@@ -106,4 +139,12 @@ export function createAgentHostClientResourceConnection(channel: IChannel): IRem
 		resourceDelete: (params) => channel.call('resourceDelete', { ...params, uri: params.uri.toString() }) as Promise<ResourceDeleteResult>,
 		resourceMove: (params) => channel.call('resourceMove', { ...params, source: params.source.toString(), destination: params.destination.toString() }) as Promise<ResourceMoveResult>,
 	};
+}
+
+function safeStringify(value: unknown): string {
+	try {
+		return JSON.stringify(value);
+	} catch {
+		return '';
+	}
 }

--- a/src/vs/platform/agentHost/common/agentHostClientResourceChannel.ts
+++ b/src/vs/platform/agentHost/common/agentHostClientResourceChannel.ts
@@ -33,8 +33,6 @@ export const AGENT_HOST_CLIENT_RESOURCE_CHANNEL = 'agentHostClientResource';
  */
 export class AgentHostClientResourceChannel implements IServerChannel {
 
-	private _nextReverseRequestId = 1;
-
 	constructor(
 		private readonly _fileService: IFileService,
 		private readonly _ahpLogger?: AhpJsonlLogger,
@@ -45,18 +43,17 @@ export class AgentHostClientResourceChannel implements IServerChannel {
 	}
 
 	async call<T>(ctx: unknown, command: string, arg?: unknown): Promise<T> {
-		const id = `local-reverse-${this._nextReverseRequestId++}`;
-		const requestFrame = { jsonrpc: '2.0' as const, id, method: command, params: arg };
+		const requestFrame = { jsonrpc: '2.0' as const, method: command, params: arg };
 		this._logReverseFrame(requestFrame, 's2c');
 		try {
 			const result = await this._call<T>(ctx, command, arg);
-			const responseFrame = { jsonrpc: '2.0' as const, id, result: result ?? null };
+			const responseFrame = { jsonrpc: '2.0' as const, method: command, result: result ?? null };
 			this._logReverseFrame(responseFrame, 'c2s');
 			return result;
 		} catch (err) {
 			const errorFrame = {
 				jsonrpc: '2.0' as const,
-				id,
+				method: command,
 				error: {
 					code: -32603,
 					message: err instanceof Error ? err.message : String(err),

--- a/src/vs/platform/agentHost/electron-browser/agentHostService.ts
+++ b/src/vs/platform/agentHost/electron-browser/agentHostService.ts
@@ -132,7 +132,7 @@ class AgentHostServiceClient extends Disposable implements IAgentHostService {
 		// Serve filesystem reverse-RPCs from the local file service. The
 		// agent host registers an authority on its
 		// AgentHostClientFileSystemProvider that calls back through this channel.
-		client.registerChannel(AGENT_HOST_CLIENT_RESOURCE_CHANNEL, new AgentHostClientResourceChannel(this._fileService));
+		client.registerChannel(AGENT_HOST_CLIENT_RESOURCE_CHANNEL, new AgentHostClientResourceChannel(this._fileService, this._ahpLogger));
 		this._clientEventually.complete(client);
 
 		store.add(this._proxy.onDidAction(e => {

--- a/src/vs/platform/agentHost/test/electron-browser/localAhpJsonlLogging.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/localAhpJsonlLogging.test.ts
@@ -10,8 +10,10 @@ import { FileService } from '../../../files/common/fileService.js';
 import { InMemoryFileSystemProvider } from '../../../files/common/inMemoryFilesystemProvider.js';
 import { NullLogService } from '../../../log/common/log.js';
 import { AhpJsonlLogger } from '../../common/ahpJsonlLogger.js';
+import { AgentHostClientResourceChannel } from '../../common/agentHostClientResourceChannel.js';
 import { wrapAgentServiceWithAhpLogging } from '../../electron-browser/localAhpJsonlLogging.js';
 import type { IAgentService } from '../../common/agentService.js';
+import { ContentEncoding } from '../../common/state/protocol/commands.js';
 
 suite('localAhpJsonlLogging', () => {
 
@@ -85,5 +87,35 @@ suite('localAhpJsonlLogging', () => {
 
 		assert.deepStrictEqual(entries[0].params, [{ resource: 'https://example.com', token: '<redacted>' }]);
 		assert.strictEqual(entries[7].result, null);
+	});
+
+	test('logs reverse resource channel requests and responses', async () => {
+		const { fileService, logger } = makeLogger();
+		const channel = new AgentHostClientResourceChannel(fileService, logger);
+		const uri = URI.file('/from-client.txt').toString();
+
+		await channel.call(undefined, 'resourceWrite', { uri, data: 'hello', encoding: ContentEncoding.Utf8, createOnly: true });
+		await channel.call(undefined, 'resourceRead', { uri });
+		await assert.rejects(() => channel.call(undefined, 'resourceRead', { uri: URI.file('/missing.txt').toString() }));
+
+		const entries = await readEntries(fileService, logger);
+		const summary = entries.map(e => ({
+			dir: e._ahpLog.dir,
+			id: e.id,
+			method: e.method,
+			hasResult: Object.hasOwn(e, 'result'),
+			hasError: Object.hasOwn(e, 'error'),
+		}));
+
+		assert.deepStrictEqual(summary, [
+			{ dir: 's2c', id: 'local-reverse-1', method: 'resourceWrite', hasResult: false, hasError: false },
+			{ dir: 'c2s', id: 'local-reverse-1', method: undefined, hasResult: true, hasError: false },
+			{ dir: 's2c', id: 'local-reverse-2', method: 'resourceRead', hasResult: false, hasError: false },
+			{ dir: 'c2s', id: 'local-reverse-2', method: undefined, hasResult: true, hasError: false },
+			{ dir: 's2c', id: 'local-reverse-3', method: 'resourceRead', hasResult: false, hasError: false },
+			{ dir: 'c2s', id: 'local-reverse-3', method: undefined, hasResult: false, hasError: true },
+		]);
+		assert.deepStrictEqual(entries[0].params, { uri, data: 'hello', encoding: ContentEncoding.Utf8, createOnly: true });
+		assert.deepStrictEqual(entries[1].result, {});
 	});
 });

--- a/src/vs/platform/agentHost/test/electron-browser/localAhpJsonlLogging.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/localAhpJsonlLogging.test.ts
@@ -108,12 +108,12 @@ suite('localAhpJsonlLogging', () => {
 		}));
 
 		assert.deepStrictEqual(summary, [
-			{ dir: 's2c', id: 'local-reverse-1', method: 'resourceWrite', hasResult: false, hasError: false },
-			{ dir: 'c2s', id: 'local-reverse-1', method: undefined, hasResult: true, hasError: false },
-			{ dir: 's2c', id: 'local-reverse-2', method: 'resourceRead', hasResult: false, hasError: false },
-			{ dir: 'c2s', id: 'local-reverse-2', method: undefined, hasResult: true, hasError: false },
-			{ dir: 's2c', id: 'local-reverse-3', method: 'resourceRead', hasResult: false, hasError: false },
-			{ dir: 'c2s', id: 'local-reverse-3', method: undefined, hasResult: false, hasError: true },
+			{ dir: 's2c', id: undefined, method: 'resourceWrite', hasResult: false, hasError: false },
+			{ dir: 'c2s', id: undefined, method: 'resourceWrite', hasResult: true, hasError: false },
+			{ dir: 's2c', id: undefined, method: 'resourceRead', hasResult: false, hasError: false },
+			{ dir: 'c2s', id: undefined, method: 'resourceRead', hasResult: true, hasError: false },
+			{ dir: 's2c', id: undefined, method: 'resourceRead', hasResult: false, hasError: false },
+			{ dir: 'c2s', id: undefined, method: 'resourceRead', hasResult: false, hasError: true },
 		]);
 		assert.deepStrictEqual(entries[0].params, { uri, data: 'hello', encoding: ContentEncoding.Utf8, createOnly: true });
 		assert.deepStrictEqual(entries[1].result, {});


### PR DESCRIPTION
## Summary
- Log local agent-host reverse filesystem resource RPC requests, responses, and errors to the AHP JSONL logger
- Wire the existing local AHP logger into the renderer resource channel
- Add coverage for reverse resource logging

## Validation
- npm run compile-check-ts-native
- node --experimental-strip-types build/hygiene.ts src/vs/platform/agentHost/common/agentHostClientResourceChannel.ts src/vs/platform/agentHost/electron-browser/agentHostService.ts src/vs/platform/agentHost/test/electron-browser/localAhpJsonlLogging.test.ts
- npm run valid-layers-check
- ./scripts/test.sh --run src/vs/platform/agentHost/test/electron-browser/localAhpJsonlLogging.test.ts