### PR TITLE
Add agent host terminal override setting

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostCustomizationConfig.ts
+++ b/src/vs/platform/agentHost/common/agentHostCustomizationConfig.ts
@@ -19,6 +19,8 @@ export const enum AgentHostConfigKey {
 	 * TODO: revisit magic key in config; refine into a dedicated typed channel. https://github.com/microsoft/vscode/issues/313812
 	 */
 	DefaultShell = 'defaultShell',
+	/** When true, Copilot SDK sessions use the SDK's default terminal behavior instead of Agent Host's terminal tool override. */
+	DisableCustomTerminalTool = 'disableCustomTerminalTool',
 }
 
 export const agentHostCustomizationConfigSchema = createSchema({
@@ -51,6 +53,12 @@ export const agentHostCustomizationConfigSchema = createSchema({
 		type: 'string',
 		title: localize('agentHost.config.defaultShell.title', "Default Shell"),
 		description: localize('agentHost.config.defaultShell.description', "Absolute path to the shell executable used by host-managed terminals. Normally pushed by the connected VS Code client from `terminal.integrated.agentHostProfile.<os>` (falling back to `terminal.integrated.defaultProfile.<os>`); when unset, the agent host falls back to the system shell. Only the path is supported; `args` and `env` from the workbench profile are not piped through yet. The workbench only pushes this for the local agent host — remote agent host operators should set this directly in the remote machine's `agent-host-config.json`."),
+	}),
+	[AgentHostConfigKey.DisableCustomTerminalTool]: schemaProperty<boolean>({
+		type: 'boolean',
+		title: localize('agentHost.config.disableCustomTerminalTool.title', "Use SDK Terminal Tool"),
+		description: localize('agentHost.config.disableCustomTerminalTool.description', "When enabled, Copilot SDK sessions use the SDK's default terminal behavior instead of Agent Host's terminal tool override."),
+		default: false,
 	}),
 });
 

--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -40,6 +40,9 @@ export const AgentHostIpcLoggingSettingId = 'chat.agentHost.ipcLoggingEnabled';
 /** Configuration key that controls whether AHP JSONL logs are written for agent host transports. */
 export const AgentHostAhpJsonlLoggingSettingId = 'chat.agentHost.ahpJsonlLoggingEnabled';
 
+/** Configuration key that controls whether Copilot SDK terminal tools should use the SDK defaults instead of Agent Host's terminal override. */
+export const AgentHostDisableCustomTerminalToolSettingId = 'chat.agentHost.disableCustomTerminalTool';
+
 /**
  * Configuration key that holds the absolute path to a locally-installed
  * `@anthropic-ai/claude-agent-sdk` package. When non-empty, the Claude agent

--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -40,8 +40,8 @@ export const AgentHostIpcLoggingSettingId = 'chat.agentHost.ipcLoggingEnabled';
 /** Configuration key that controls whether AHP JSONL logs are written for agent host transports. */
 export const AgentHostAhpJsonlLoggingSettingId = 'chat.agentHost.ahpJsonlLoggingEnabled';
 
-/** Configuration key that controls whether Copilot SDK terminal tools should use the SDK defaults instead of Agent Host's terminal override. */
-export const AgentHostDisableCustomTerminalToolSettingId = 'chat.agentHost.disableCustomTerminalTool';
+/** Configuration key that controls whether Agent Host uses its terminal tool override for Copilot SDK sessions. */
+export const AgentHostCustomTerminalToolEnabledSettingId = 'chat.agentHost.customTerminalTool.enabled';
 
 /**
  * Configuration key that holds the absolute path to a locally-installed

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -1365,7 +1365,8 @@ export class CopilotAgent extends Disposable implements IAgent {
 		const plugins = snapshot?.plugins ?? [];
 
 		return async (callbacks: Parameters<SessionWrapperFactory>[0]) => {
-			const shellTools = await createShellTools(shellManager, this._terminalManager, this._logService);
+			const disableCustomTerminalTool = this._configurationService.getRootValue(agentHostCustomizationConfigSchema, AgentHostConfigKey.DisableCustomTerminalTool) === true;
+			const shellTools = disableCustomTerminalTool ? [] : await createShellTools(shellManager, this._terminalManager, this._logService);
 			const customAgents = await toSdkCustomAgents(plugins.flatMap(p => p.agents), this._fileService);
 			return {
 				onPermissionRequest: callbacks.onPermissionRequest,

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -18,6 +18,7 @@ import { IInstantiationService } from '../../../instantiation/common/instantiati
 import { InstantiationService } from '../../../instantiation/common/instantiationService.js';
 import { ServiceCollection } from '../../../instantiation/common/serviceCollection.js';
 import { ILogService, NullLogService } from '../../../log/common/log.js';
+import { AgentHostConfigKey } from '../../common/agentHostCustomizationConfig.js';
 import { IAgentPluginManager, ISyncedCustomization } from '../../common/agentPluginManager.js';
 import { AgentSession, type AgentSignal, type IAgentActionSignal, type IAgentSessionMetadata } from '../../common/agentService.js';
 import { ISessionDataService } from '../../common/sessionDataService.js';
@@ -280,7 +281,7 @@ class TestableCopilotAgent extends CopilotAgent {
 	}
 }
 
-function createTestAgentContext(disposables: Pick<DisposableStore, 'add'>, options?: { sessionDataService?: ISessionDataService; copilotClient?: ITestCopilotClient; gitService?: TestAgentHostGitService; environmentServiceRegistration?: 'native' | 'none'; pluginManager?: IAgentPluginManager }): { agent: CopilotAgent; instantiationService: IInstantiationService } {
+function createTestAgentContext(disposables: Pick<DisposableStore, 'add'>, options?: { sessionDataService?: ISessionDataService; copilotClient?: ITestCopilotClient; gitService?: TestAgentHostGitService; environmentServiceRegistration?: 'native' | 'none'; pluginManager?: IAgentPluginManager }): { agent: CopilotAgent; instantiationService: IInstantiationService; configurationService: IAgentConfigurationService } {
 	const services = new ServiceCollection();
 	const logService = new NullLogService();
 	const fileService = disposables.add(new FileService(logService));
@@ -305,7 +306,7 @@ function createTestAgentContext(disposables: Pick<DisposableStore, 'add'>, optio
 	const agent = options?.copilotClient
 		? instantiationService.createInstance(TestableCopilotAgent, options.copilotClient)
 		: instantiationService.createInstance(CopilotAgent);
-	return { agent, instantiationService };
+	return { agent, instantiationService, configurationService: configService };
 }
 
 function createTestAgent(disposables: Pick<DisposableStore, 'add'>, options?: { sessionDataService?: ISessionDataService; copilotClient?: ITestCopilotClient; gitService?: TestAgentHostGitService; environmentServiceRegistration?: 'native' | 'none'; pluginManager?: IAgentPluginManager }): CopilotAgent {
@@ -721,6 +722,34 @@ suite('CopilotAgent', () => {
 					systemMessage.sections?.identity?.content,
 					'You are an AI assistant using Copilot CLI runtime in VS Code. You help users with software engineering tasks. When asked about your identity, you must state that you are an AI assistant using Copilot CLI runtime in VS Code.'
 				);
+			} finally {
+				await disposeAgent(agent);
+			}
+		});
+
+		test('materialization skips managed shell tools when root config disables the custom terminal tool', async () => {
+			const sessionDataService = disposables.add(new TestSessionDataService());
+			const client = new TestCopilotClient([]);
+			let capturedConfig: Parameters<ITestCopilotClient['createSession']>[0] | undefined;
+			client.createSession = async config => {
+				capturedConfig = config;
+				return new MockCopilotSession() as unknown as CopilotSession;
+			};
+
+			const { agent, configurationService } = createTestAgentContext(disposables, { sessionDataService, copilotClient: client });
+			try {
+				await agent.authenticate('https://api.github.com', 'token');
+				configurationService.updateRootConfig({ [AgentHostConfigKey.DisableCustomTerminalTool]: true });
+
+				const result = await agent.createSession({
+					session: AgentSession.uri('copilotcli', 'sdk-terminal-defaults'),
+					workingDirectory: URI.file('/workspace'),
+				});
+				assert.strictEqual(result.provisional, true);
+
+				await agent.sendMessage(result.session, 'hello');
+
+				assert.deepStrictEqual(capturedConfig?.tools?.map(tool => tool.name), []);
 			} finally {
 				await disposeAgent(agent);
 			}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostTerminalContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostTerminalContribution.ts
@@ -6,7 +6,7 @@
 import { OS } from '../../../../../../base/common/platform.js';
 import { Disposable, DisposableStore, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
 import { localize } from '../../../../../../nls.js';
-import { AgentHostEnabledSettingId, IAgentHostService } from '../../../../../../platform/agentHost/common/agentService.js';
+import { AgentHostDisableCustomTerminalToolSettingId, AgentHostEnabledSettingId, IAgentHostService } from '../../../../../../platform/agentHost/common/agentService.js';
 import { AgentHostConfigKey } from '../../../../../../platform/agentHost/common/agentHostCustomizationConfig.js';
 import { ActionType } from '../../../../../../platform/agentHost/common/state/protocol/actions.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
@@ -70,13 +70,19 @@ export class AgentHostTerminalContribution extends Disposable implements IWorkbe
 					if (AGENT_HOST_SHELL_DEPENDENT_SETTINGS.some(s => e.affectsConfiguration(s))) {
 						this._pushDefaultShell();
 					}
+					if (e.affectsConfiguration(AgentHostDisableCustomTerminalToolSettingId)) {
+						this._pushDisableCustomTerminalTool();
+					}
 				}));
 				store.add(this._terminalProfileService.onDidChangeAvailableProfiles(() => this._pushDefaultShell()));
 				// Retry the push when the host's root state hydrates or its schema
 				// changes - the initial push from `_reconcile()` may have raced an
 				// undefined `rootState.value`, in which case the schema gate below
 				// in `_pushDefaultShell` returned early.
-				store.add(this._agentHostService.rootState.onDidChange(() => this._pushDefaultShell()));
+				store.add(this._agentHostService.rootState.onDidChange(() => {
+					this._pushDefaultShell();
+					this._pushDisableCustomTerminalTool();
+				}));
 				this._conditionalListeners.value = store;
 				this._reconcile();
 			}
@@ -100,6 +106,7 @@ export class AgentHostTerminalContribution extends Disposable implements IWorkbe
 			});
 		}
 		this._pushDefaultShell();
+		this._pushDisableCustomTerminalTool();
 	}
 
 	/**
@@ -156,6 +163,26 @@ export class AgentHostTerminalContribution extends Disposable implements IWorkbe
 		this._agentHostService.dispatch({
 			type: ActionType.RootConfigChanged,
 			config: { [AgentHostConfigKey.DefaultShell]: profile.path },
+		});
+	}
+
+	private _pushDisableCustomTerminalTool(): void {
+		const rootState = this._agentHostService.rootState.value;
+		if (!rootState || rootState instanceof Error) {
+			return;
+		}
+		if (!rootState.config?.schema.properties[AgentHostConfigKey.DisableCustomTerminalTool]) {
+			return;
+		}
+
+		const disableCustomTerminalTool = this._configurationService.getValue<boolean>(AgentHostDisableCustomTerminalToolSettingId);
+		if (rootState.config.values[AgentHostConfigKey.DisableCustomTerminalTool] === disableCustomTerminalTool) {
+			return;
+		}
+
+		this._agentHostService.dispatch({
+			type: ActionType.RootConfigChanged,
+			config: { [AgentHostConfigKey.DisableCustomTerminalTool]: disableCustomTerminalTool },
 		});
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostTerminalContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostTerminalContribution.ts
@@ -6,7 +6,7 @@
 import { OS } from '../../../../../../base/common/platform.js';
 import { Disposable, DisposableStore, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
 import { localize } from '../../../../../../nls.js';
-import { AgentHostDisableCustomTerminalToolSettingId, AgentHostEnabledSettingId, IAgentHostService } from '../../../../../../platform/agentHost/common/agentService.js';
+import { AgentHostCustomTerminalToolEnabledSettingId, AgentHostEnabledSettingId, IAgentHostService } from '../../../../../../platform/agentHost/common/agentService.js';
 import { AgentHostConfigKey } from '../../../../../../platform/agentHost/common/agentHostCustomizationConfig.js';
 import { ActionType } from '../../../../../../platform/agentHost/common/state/protocol/actions.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
@@ -70,8 +70,8 @@ export class AgentHostTerminalContribution extends Disposable implements IWorkbe
 					if (AGENT_HOST_SHELL_DEPENDENT_SETTINGS.some(s => e.affectsConfiguration(s))) {
 						this._pushDefaultShell();
 					}
-					if (e.affectsConfiguration(AgentHostDisableCustomTerminalToolSettingId)) {
-						this._pushDisableCustomTerminalTool();
+					if (e.affectsConfiguration(AgentHostCustomTerminalToolEnabledSettingId)) {
+						this._pushCustomTerminalToolEnabled();
 					}
 				}));
 				store.add(this._terminalProfileService.onDidChangeAvailableProfiles(() => this._pushDefaultShell()));
@@ -81,7 +81,7 @@ export class AgentHostTerminalContribution extends Disposable implements IWorkbe
 				// in `_pushDefaultShell` returned early.
 				store.add(this._agentHostService.rootState.onDidChange(() => {
 					this._pushDefaultShell();
-					this._pushDisableCustomTerminalTool();
+					this._pushCustomTerminalToolEnabled();
 				}));
 				this._conditionalListeners.value = store;
 				this._reconcile();
@@ -106,7 +106,7 @@ export class AgentHostTerminalContribution extends Disposable implements IWorkbe
 			});
 		}
 		this._pushDefaultShell();
-		this._pushDisableCustomTerminalTool();
+		this._pushCustomTerminalToolEnabled();
 	}
 
 	/**
@@ -166,7 +166,7 @@ export class AgentHostTerminalContribution extends Disposable implements IWorkbe
 		});
 	}
 
-	private _pushDisableCustomTerminalTool(): void {
+	private _pushCustomTerminalToolEnabled(): void {
 		const rootState = this._agentHostService.rootState.value;
 		if (!rootState || rootState instanceof Error) {
 			return;
@@ -175,7 +175,7 @@ export class AgentHostTerminalContribution extends Disposable implements IWorkbe
 			return;
 		}
 
-		const disableCustomTerminalTool = this._configurationService.getValue<boolean>(AgentHostDisableCustomTerminalToolSettingId);
+		const disableCustomTerminalTool = !this._configurationService.getValue<boolean>(AgentHostCustomTerminalToolEnabledSettingId);
 		if (rootState.config.values[AgentHostConfigKey.DisableCustomTerminalTool] === disableCustomTerminalTool) {
 			return;
 		}

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -10,7 +10,7 @@ import { autorun, observableFromEvent } from '../../../../base/common/observable
 import { isMacintosh } from '../../../../base/common/platform.js';
 import { PolicyCategory } from '../../../../base/common/policy.js';
 import { CopilotSessionSearchPolicy } from '../../../../base/common/defaultAccount.js';
-import { AgentHostAhpJsonlLoggingSettingId, AgentHostClaudeAgentSdkPathSettingId, AgentHostEnabledSettingId, AgentHostIpcLoggingSettingId } from '../../../../platform/agentHost/common/agentService.js';
+import { AgentHostAhpJsonlLoggingSettingId, AgentHostClaudeAgentSdkPathSettingId, AgentHostDisableCustomTerminalToolSettingId, AgentHostEnabledSettingId, AgentHostIpcLoggingSettingId } from '../../../../platform/agentHost/common/agentService.js';
 import { AgentNetworkFilterService, IAgentNetworkFilterService } from '../../../../platform/networkFilter/common/networkFilterService.js';
 import { AgentNetworkDomainSettingId } from '../../../../platform/networkFilter/common/settings.js';
 import { AgentSandboxEnabledValue, AgentSandboxSettingId } from '../../../../platform/sandbox/common/settings.js';
@@ -1002,6 +1002,13 @@ configurationRegistry.registerConfiguration({
 			type: 'boolean',
 			description: nls.localize('chat.agentHost.ahpJsonlLogging', "When enabled, logs all AHP transport messages for agent host connections to JSONL files under the window's log directory."),
 			default: product.quality !== 'stable',
+			tags: ['experimental', 'advanced'],
+			included: product.quality !== 'stable',
+		},
+		[AgentHostDisableCustomTerminalToolSettingId]: {
+			type: 'boolean',
+			description: nls.localize('chat.agentHost.disableCustomTerminalTool', "When enabled, Copilot SDK sessions use the SDK's default terminal behavior instead of the Agent Host terminal tool override."),
+			default: false,
 			tags: ['experimental', 'advanced'],
 			included: product.quality !== 'stable',
 		},

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -10,7 +10,7 @@ import { autorun, observableFromEvent } from '../../../../base/common/observable
 import { isMacintosh } from '../../../../base/common/platform.js';
 import { PolicyCategory } from '../../../../base/common/policy.js';
 import { CopilotSessionSearchPolicy } from '../../../../base/common/defaultAccount.js';
-import { AgentHostAhpJsonlLoggingSettingId, AgentHostClaudeAgentSdkPathSettingId, AgentHostDisableCustomTerminalToolSettingId, AgentHostEnabledSettingId, AgentHostIpcLoggingSettingId } from '../../../../platform/agentHost/common/agentService.js';
+import { AgentHostAhpJsonlLoggingSettingId, AgentHostClaudeAgentSdkPathSettingId, AgentHostCustomTerminalToolEnabledSettingId, AgentHostEnabledSettingId, AgentHostIpcLoggingSettingId } from '../../../../platform/agentHost/common/agentService.js';
 import { AgentNetworkFilterService, IAgentNetworkFilterService } from '../../../../platform/networkFilter/common/networkFilterService.js';
 import { AgentNetworkDomainSettingId } from '../../../../platform/networkFilter/common/settings.js';
 import { AgentSandboxEnabledValue, AgentSandboxSettingId } from '../../../../platform/sandbox/common/settings.js';
@@ -1005,10 +1005,10 @@ configurationRegistry.registerConfiguration({
 			tags: ['experimental', 'advanced'],
 			included: product.quality !== 'stable',
 		},
-		[AgentHostDisableCustomTerminalToolSettingId]: {
+		[AgentHostCustomTerminalToolEnabledSettingId]: {
 			type: 'boolean',
-			description: nls.localize('chat.agentHost.disableCustomTerminalTool', "When enabled, Copilot SDK sessions use the SDK's default terminal behavior instead of the Agent Host terminal tool override."),
-			default: false,
+			description: nls.localize('chat.agentHost.customTerminalTool.enabled', "When enabled, Copilot SDK sessions use the Agent Host terminal tool override instead of the SDK's default terminal behavior."),
+			default: true,
 			tags: ['experimental', 'advanced'],
 			included: product.quality !== 'stable',
 		},

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostTerminalContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostTerminalContribution.test.ts
@@ -13,7 +13,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/
 import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
-import { AgentHostEnabledSettingId, IAgentHostService } from '../../../../../../platform/agentHost/common/agentService.js';
+import { AgentHostDisableCustomTerminalToolSettingId, AgentHostEnabledSettingId, IAgentHostService } from '../../../../../../platform/agentHost/common/agentService.js';
 import { AgentHostConfigKey } from '../../../../../../platform/agentHost/common/agentHostCustomizationConfig.js';
 import { ActionType } from '../../../../../../platform/agentHost/common/state/protocol/actions.js';
 import { IAgentSubscription } from '../../../../../../platform/agentHost/common/state/agentSubscription.js';
@@ -143,6 +143,12 @@ function rootStateWithoutDefaultShellKey(): RootState {
 	});
 }
 
+function rootStateWithDisableCustomTerminalToolKey(): RootState {
+	return makeRootStateWithSchema({
+		[AgentHostConfigKey.DisableCustomTerminalTool]: { type: 'boolean', title: 'Use SDK Terminal Tool' },
+	});
+}
+
 interface ITestSetup {
 	contribution: AgentHostTerminalContribution;
 	agentHostService: MockAgentHostService;
@@ -160,6 +166,7 @@ function setup(disposables: DisposableStore, agentHostEnabled: boolean = true): 
 	disposables.add({ dispose: () => profileService.dispose() });
 	const configurationService = new TestConfigurationService({
 		[AgentHostEnabledSettingId]: agentHostEnabled,
+		[AgentHostDisableCustomTerminalToolSettingId]: false,
 	});
 
 	instantiationService.stub(IAgentHostService, agentHostService);
@@ -324,5 +331,40 @@ suite('AgentHostTerminalContribution', () => {
 
 		assert.strictEqual(resolver.lastOptions?.os, OS as OperatingSystem);
 		assert.strictEqual(resolver.lastOptions?.remoteAuthority, undefined);
+	});
+
+	test('dispatches disableCustomTerminalTool from the VS Code setting', async () => {
+		const { agentHostService, configurationService } = setup(disposables);
+		configurationService.setUserConfiguration(AgentHostDisableCustomTerminalToolSettingId, true);
+
+		agentHostService.setRootState(rootStateWithDisableCustomTerminalToolKey());
+		await flush();
+
+		assert.strictEqual(agentHostService.dispatchedActions.length, 1);
+		assert.deepStrictEqual((agentHostService.dispatchedActions[0] as IRootConfigChangedAction).config, {
+			[AgentHostConfigKey.DisableCustomTerminalTool]: true,
+		});
+	});
+
+	test('re-dispatches disableCustomTerminalTool when the setting changes', async () => {
+		const { agentHostService, configurationService } = setup(disposables);
+		const rootState = rootStateWithDisableCustomTerminalToolKey();
+		rootState.config!.values[AgentHostConfigKey.DisableCustomTerminalTool] = false;
+		agentHostService.setRootState(rootState);
+		await flush();
+		assert.deepStrictEqual(agentHostService.dispatchedActions, []);
+
+		configurationService.setUserConfiguration(AgentHostDisableCustomTerminalToolSettingId, true);
+		configurationService.onDidChangeConfigurationEmitter.fire({
+			affectedKeys: new Set([AgentHostDisableCustomTerminalToolSettingId]),
+			affectsConfiguration: (key: string) => key === AgentHostDisableCustomTerminalToolSettingId,
+			source: 1, // ConfigurationTarget.USER
+			change: { keys: [AgentHostDisableCustomTerminalToolSettingId], overrides: [] },
+		});
+
+		assert.strictEqual(agentHostService.dispatchedActions.length, 1);
+		assert.deepStrictEqual((agentHostService.dispatchedActions[0] as IRootConfigChangedAction).config, {
+			[AgentHostConfigKey.DisableCustomTerminalTool]: true,
+		});
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostTerminalContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostTerminalContribution.test.ts
@@ -13,7 +13,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/
 import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
-import { AgentHostDisableCustomTerminalToolSettingId, AgentHostEnabledSettingId, IAgentHostService } from '../../../../../../platform/agentHost/common/agentService.js';
+import { AgentHostCustomTerminalToolEnabledSettingId, AgentHostEnabledSettingId, IAgentHostService } from '../../../../../../platform/agentHost/common/agentService.js';
 import { AgentHostConfigKey } from '../../../../../../platform/agentHost/common/agentHostCustomizationConfig.js';
 import { ActionType } from '../../../../../../platform/agentHost/common/state/protocol/actions.js';
 import { IAgentSubscription } from '../../../../../../platform/agentHost/common/state/agentSubscription.js';
@@ -166,7 +166,7 @@ function setup(disposables: DisposableStore, agentHostEnabled: boolean = true): 
 	disposables.add({ dispose: () => profileService.dispose() });
 	const configurationService = new TestConfigurationService({
 		[AgentHostEnabledSettingId]: agentHostEnabled,
-		[AgentHostDisableCustomTerminalToolSettingId]: false,
+		[AgentHostCustomTerminalToolEnabledSettingId]: true,
 	});
 
 	instantiationService.stub(IAgentHostService, agentHostService);
@@ -333,9 +333,9 @@ suite('AgentHostTerminalContribution', () => {
 		assert.strictEqual(resolver.lastOptions?.remoteAuthority, undefined);
 	});
 
-	test('dispatches disableCustomTerminalTool from the VS Code setting', async () => {
+	test('dispatches inverted disableCustomTerminalTool from the VS Code setting', async () => {
 		const { agentHostService, configurationService } = setup(disposables);
-		configurationService.setUserConfiguration(AgentHostDisableCustomTerminalToolSettingId, true);
+		configurationService.setUserConfiguration(AgentHostCustomTerminalToolEnabledSettingId, false);
 
 		agentHostService.setRootState(rootStateWithDisableCustomTerminalToolKey());
 		await flush();
@@ -346,7 +346,19 @@ suite('AgentHostTerminalContribution', () => {
 		});
 	});
 
-	test('re-dispatches disableCustomTerminalTool when the setting changes', async () => {
+	test('dispatches disableCustomTerminalTool false by default', async () => {
+		const { agentHostService } = setup(disposables);
+
+		agentHostService.setRootState(rootStateWithDisableCustomTerminalToolKey());
+		await flush();
+
+		assert.strictEqual(agentHostService.dispatchedActions.length, 1);
+		assert.deepStrictEqual((agentHostService.dispatchedActions[0] as IRootConfigChangedAction).config, {
+			[AgentHostConfigKey.DisableCustomTerminalTool]: false,
+		});
+	});
+
+	test('re-dispatches disableCustomTerminalTool when the enabled setting changes', async () => {
 		const { agentHostService, configurationService } = setup(disposables);
 		const rootState = rootStateWithDisableCustomTerminalToolKey();
 		rootState.config!.values[AgentHostConfigKey.DisableCustomTerminalTool] = false;
@@ -354,12 +366,12 @@ suite('AgentHostTerminalContribution', () => {
 		await flush();
 		assert.deepStrictEqual(agentHostService.dispatchedActions, []);
 
-		configurationService.setUserConfiguration(AgentHostDisableCustomTerminalToolSettingId, true);
+		configurationService.setUserConfiguration(AgentHostCustomTerminalToolEnabledSettingId, false);
 		configurationService.onDidChangeConfigurationEmitter.fire({
-			affectedKeys: new Set([AgentHostDisableCustomTerminalToolSettingId]),
-			affectsConfiguration: (key: string) => key === AgentHostDisableCustomTerminalToolSettingId,
+			affectedKeys: new Set([AgentHostCustomTerminalToolEnabledSettingId]),
+			affectsConfiguration: (key: string) => key === AgentHostCustomTerminalToolEnabledSettingId,
 			source: 1, // ConfigurationTarget.USER
-			change: { keys: [AgentHostDisableCustomTerminalToolSettingId], overrides: [] },
+			change: { keys: [AgentHostCustomTerminalToolEnabledSettingId], overrides: [] },
 		});
 
 		assert.strictEqual(agentHostService.dispatchedActions.length, 1);


### PR DESCRIPTION
Adds a root Agent Host config value, `disableCustomTerminalTool`, and a VS Code setting, `chat.agentHost.customTerminalTool.enabled`, that writes the inverse value to it. The VS Code setting is enabled by default; when disabled, Copilot Agent Host sessions skip VS Code's managed terminal tool override and allow the Copilot SDK default terminal behavior.

Validation:
- `npm run compile-check-ts-native`
- `npm run test-node -- --grep "materialization skips managed shell tools"`
- `npm run transpile-client && ./scripts/test.sh --run src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostTerminalContribution.test.ts --grep "disableCustomTerminalTool"`
- `node --experimental-strip-types build/hygiene.ts src/vs/platform/agentHost/common/agentService.ts src/vs/platform/agentHost/common/agentHostCustomizationConfig.ts src/vs/platform/agentHost/node/copilot/copilotAgent.ts src/vs/platform/agentHost/test/node/copilotAgent.test.ts src/vs/workbench/contrib/chat/browser/chat.contribution.ts src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostTerminalContribution.ts src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostTerminalContribution.test.ts`