### PR TITLE
chat: avoid forced reflows in ChatThinkingContentPart during session restore

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatThinkingContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatThinkingContentPart.ts
@@ -278,6 +278,7 @@ export class ChatThinkingContentPart extends ChatCollapsibleContentPart implemen
 	private titleDetailContainer: HTMLElement | undefined;
 	private readonly _externalResourceWidget: ChatThinkingExternalResourceWidget;
 	private readonly _titleDetailRendered = this._register(new MutableDisposable<IRenderedMarkdown>());
+	private readonly _pendingAppendRefresh = this._register(new MutableDisposable<IDisposable>());
 	private readonly diffStatsByPartId = new Map<string, IEditSessionDiffStats>();
 	private _aggregatedDiff: IEditSessionDiffStats = { added: 0, removed: 0 };
 
@@ -849,8 +850,11 @@ export class ChatThinkingContentPart extends ChatCollapsibleContentPart implemen
 
 		// don't allow feedback on fixed scrolling before reaching max height.
 		if (allowExpansion && this.fixedScrollingMode && !this.streamingCompleted && !this.element.isComplete && this.wrapper) {
-			const contentHeight = knownContentHeight ?? (this.lastKnownContentHeight || this.wrapper.scrollHeight);
-			if (contentHeight <= THINKING_SCROLL_MAX_HEIGHT) {
+			// Use only the cached height — never read scrollHeight here to avoid forced reflows.
+			// If the cache is empty, conservatively disallow expansion; the ResizeObserver
+			// will populate lastKnownContentHeight and trigger another call once layout settles.
+			const contentHeight = knownContentHeight ?? this.lastKnownContentHeight;
+			if (!contentHeight || contentHeight <= THINKING_SCROLL_MAX_HEIGHT) {
 				allowExpansion = false;
 			}
 		}
@@ -1955,9 +1959,24 @@ ${this.hookCount > 0 ? `EXAMPLES WITH BLOCKED CONTENT (from hooks):
 				}
 			}
 
+			// Coalesce reads of scrollHeight to avoid forced reflows when many items
+			// are appended in the same tick (e.g. when restoring a session).
+			this.scheduleAppendRefresh();
+		}
+	}
+
+	private scheduleAppendRefresh(): void {
+		if (this._pendingAppendRefresh.value) {
+			return;
+		}
+		this._pendingAppendRefresh.value = scheduleAtNextAnimationFrame(getWindow(this.wrapper), () => {
+			this._pendingAppendRefresh.clear();
+			if (this._store.isDisposed) {
+				return;
+			}
 			this.refreshContentHeight();
 			this.updateScrollDimensionsFromCache();
-		}
+		});
 	}
 
 	private materializeLazyItem(item: ILazyItem): void {


### PR DESCRIPTION
fyi @justschen 

## Problem

Switching to a session with many tool calls (e.g. a long agentic session) took ~700ms. A CPU trace showed the main thread blocked in `UpdateLayoutTree` (~600ms, 109 calls) triggered by `ChatThinkingContentPart.appendItemToDOM`.

The root cause was two forced reflows:

1. **`appendItemToDOM`** called `refreshContentHeight()` (reads `wrapper.scrollHeight`) synchronously after each DOM append. With ~57 tool invocations replayed during session restore, this caused 57 consecutive forced reflows.

2. **`updateDropdownClickability`** had a `this.wrapper.scrollHeight` fallback when `lastKnownContentHeight` was not yet populated, causing additional forced reflows on each call during startup.

## Fix

**`appendItemToDOM`**: Instead of reading `scrollHeight` inline, schedule a single `refreshContentHeight` + `updateScrollDimensionsFromCache` via `scheduleAtNextAnimationFrame`. The `MutableDisposable` coalesces multiple appends in the same tick into a single deferred read — consistent with the existing MutationObserver path in the same class.

**`updateDropdownClickability`**: Remove the `scrollHeight` fallback. Use only the ResizeObserver-cached `lastKnownContentHeight`. If no cached height is available yet, conservatively keep the expand button disabled; the ResizeObserver fires after layout settles and triggers another call with the real height.

(Written by Copilot)