### PR TITLE
Wait for sessions to load before opening

### DIFF
--- a/src/vs/sessions/contrib/terminal/browser/sessionsTerminalContribution.ts
+++ b/src/vs/sessions/contrib/terminal/browser/sessionsTerminalContribution.ts
@@ -120,6 +120,10 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 		// This is a little hacky but I don't see any better approach.
 		this._register(autorun(reader => {
 			const session = this._sessionsManagementService.activeSession.read(reader);
+			if (session?.loading.read(reader)) {
+				this._agentHostTerminalService.setDefaultCwd(undefined);
+				return;
+			}
 			const info = getSessionTerminalInfo(session, reader);
 			this._agentHostTerminalService.setDefaultCwd(info?.cwd);
 		}));
@@ -137,6 +141,10 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 		// React to active session changes — use worktree/repo for background sessions, home dir otherwise
 		this._register(autorun(reader => {
 			const session = this._sessionsManagementService.activeSession.read(reader);
+			if (session?.loading.read(reader)) {
+				this._activeKey = undefined;
+				return;
+			}
 			this._onActiveSessionChanged(session);
 		}));
 

--- a/src/vs/sessions/contrib/terminal/test/browser/sessionsTerminalContribution.test.ts
+++ b/src/vs/sessions/contrib/terminal/test/browser/sessionsTerminalContribution.test.ts
@@ -45,13 +45,18 @@ type TestTerminalInstance = ITerminalInstance & {
 	_testSetShellLaunchConfig(shellLaunchConfig: ITerminalInstance['shellLaunchConfig']): void;
 };
 
+type TestActiveSession = IActiveSession & {
+	loading: ReturnType<typeof observableValue<boolean>>;
+};
+
 function makeAgentSession(opts: {
 	repository?: URI;
 	worktree?: URI;
 	providerType?: string;
 	isArchived?: boolean;
+	loading?: boolean;
 	sessionId?: string;
-}): IActiveSession {
+}): TestActiveSession {
 	const folder = opts.repository || opts.worktree ? {
 		root: opts.repository ?? opts.worktree!,
 		workingDirectory: opts.worktree ?? opts.repository!,
@@ -99,7 +104,7 @@ function makeAgentSession(opts: {
 		changes: chat.changes,
 		modelId: chat.modelId,
 		mode: chat.mode,
-		loading: observableValue('test.loading', false),
+		loading: observableValue('test.loading', opts.loading ?? false),
 		isArchived: chat.isArchived,
 		isRead: chat.isRead,
 		lastTurnEnd: chat.lastTurnEnd,
@@ -108,7 +113,7 @@ function makeAgentSession(opts: {
 		activeChat: observableValue('test.activeChat', chat),
 		mainChat: chat,
 		capabilities: { supportsMultipleChats: false },
-	} satisfies IActiveSession;
+	} satisfies TestActiveSession;
 	return session;
 }
 
@@ -220,6 +225,7 @@ suite('SessionsTerminalContribution', () => {
 	let moveToBackgroundCalls: number[];
 	let showBackgroundCalls: number[];
 	let disposeOnCreatePaths: Set<string>;
+	let defaultCwdCalls: (URI | undefined)[];
 	let logService: TestLogService;
 	let allSessions: ISession[];
 
@@ -234,6 +240,7 @@ suite('SessionsTerminalContribution', () => {
 		moveToBackgroundCalls = [];
 		showBackgroundCalls = [];
 		disposeOnCreatePaths = new Set();
+		defaultCwdCalls = [];
 		logService = new TestLogService();
 		allSessions = [];
 
@@ -302,7 +309,7 @@ suite('SessionsTerminalContribution', () => {
 		instantiationService.stub(IAgentHostTerminalService, new class extends mock<IAgentHostTerminalService>() {
 			override readonly profiles = constObservable<never[]>([]);
 			override getProfileForConnection() { return undefined; }
-			override setDefaultCwd(): void { /* noop */ }
+			override setDefaultCwd(cwd: URI | undefined): void { defaultCwdCalls.push(cwd); }
 			override async createTerminalForEntry() { return undefined; }
 		});
 
@@ -421,6 +428,24 @@ suite('SessionsTerminalContribution', () => {
 		await tick();
 
 		assert.strictEqual(createdTerminals.length, 0);
+	});
+
+	test('waits for a loading session before creating a terminal', async () => {
+		const worktreeUri = URI.file('/worktree');
+		const session = makeAgentSession({ worktree: worktreeUri, providerType: AgentSessionProviders.Background, loading: true });
+
+		activeSessionObs.set(session, undefined);
+		await tick();
+
+		assert.strictEqual(createdTerminals.length, 0, 'should not create a terminal while session is loading');
+		assert.strictEqual(defaultCwdCalls.at(-1), undefined, 'should not set the default cwd while session is loading');
+
+		session.loading.set(false, undefined);
+		await tick();
+
+		assert.strictEqual(createdTerminals.length, 1);
+		assert.strictEqual(createdTerminals[0].cwd.fsPath, worktreeUri.fsPath);
+		assert.strictEqual(defaultCwdCalls.at(-1)?.fsPath, worktreeUri.fsPath);
 	});
 
 	test('does not recreate terminal for the same path', async () => {

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -41,7 +41,7 @@ interface ISessionState {
 	isActive?: boolean;
 }
 
-class SessionsManagementService extends Disposable implements ISessionsManagementService {
+export class SessionsManagementService extends Disposable implements ISessionsManagementService {
 
 	declare readonly _serviceBrand: undefined;
 
@@ -235,6 +235,10 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 		this.logService.trace(`[SessionsManagement] openChat start uri=${chatUri.toString()} provider=${session.providerId}`);
 		this.isNewChatSessionContext.set(false);
 		this.setActiveSession(session);
+		if (!await this._waitForSessionToLoad(session, token)) {
+			this.logService.trace(`[SessionsManagement] openChat cancelled while waiting for session to load uri=${chatUri.toString()}`);
+			return;
+		}
 
 		// Find the chat and update active chat
 		let chat: IChat | undefined;
@@ -284,6 +288,10 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 		this.isNewChatSessionContext.set(false);
 		this._isNewChatInSessionContext.set(false);
 		this.setActiveSession(sessionData);
+		if (!await this._waitForSessionToLoad(sessionData, token)) {
+			this.logService.trace(`[SessionsManagement] openSession cancelled while waiting for session to load uri=${sessionResource.toString()}`);
+			return;
+		}
 
 		// Open the active chat (which may have been restored to the last active chat)
 		const activeChat = this._activeSession.get()?.activeChat.get();
@@ -445,13 +453,6 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 
 		if (session) {
 			this.logService.info(`[ActiveSessionService] Active session changed: ${session.resource.toString()}`);
-
-			// Trigger lazy resolve for expensive session properties (e.g. changes,
-			// badge). This is fire-and-forget — the resolve result flows back through
-			// the model's onDidChangeSessions → _refreshSessionCache → adapter.update()
-			// chain, updating observables reactively. Safe for providers without a
-			// resolve handler (returns undefined).
-			this.agentSessionsService.model.observeSession(session.resource);
 		} else {
 			this.logService.trace('[ActiveSessionService] Active session cleared');
 		}
@@ -459,6 +460,20 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 		this._activeSessionDisposables.clear();
 
 		if (session) {
+			let observedSession = false;
+			this._activeSessionDisposables.add(autorun(reader => {
+				if (observedSession || session.loading.read(reader)) {
+					return;
+				}
+				observedSession = true;
+				// Trigger lazy resolve for expensive session properties (e.g. changes,
+				// badge). This is fire-and-forget — the resolve result flows back through
+				// the model's onDidChangeSessions → _refreshSessionCache → adapter.update()
+				// chain, updating observables reactively. Safe for providers without a
+				// resolve handler (returns undefined).
+				this.agentSessionsService.model.observeSession(session.resource);
+			}));
+
 			// Restore the last active chat for this session, or default to the first chat
 			const chats = session.chats.get();
 			const sessionState = this._sessionStates.get(session.resource);
@@ -532,6 +547,37 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 			this._activeChatObservable = undefined;
 			this._activeSession.set(undefined, undefined);
 		}
+	}
+
+	private async _waitForSessionToLoad(session: ISession, token: CancellationToken): Promise<boolean> {
+		if (!session.loading.get()) {
+			return true;
+		}
+		if (token.isCancellationRequested) {
+			return false;
+		}
+
+		await new Promise<void>(resolve => {
+			const disposables = new DisposableStore();
+			let resolved = false;
+			const finish = () => {
+				if (resolved) {
+					return;
+				}
+				resolved = true;
+				disposables.dispose();
+				resolve();
+			};
+
+			disposables.add(token.onCancellationRequested(finish));
+			disposables.add(autorun(reader => {
+				if (!session.loading.read(reader)) {
+					finish();
+				}
+			}));
+		});
+
+		return !token.isCancellationRequested;
 	}
 
 	private _loadSessionStates(): ResourceMap<ISessionState> {

--- a/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
@@ -4,13 +4,31 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { constObservable } from '../../../../../base/common/observable.js';
+import { Event } from '../../../../../base/common/event.js';
+import { constObservable, observableValue } from '../../../../../base/common/observable.js';
+import { extUriBiasedIgnorePathCase } from '../../../../../base/common/resources.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
+import { mock } from '../../../../../base/test/common/mock.js';
 import { LOCAL_AGENT_HOST_PROVIDER_ID } from '../../../../common/agentHostSessionsProvider.js';
-import { IChat, ISession } from '../../common/session.js';
-import { deduplicateSessions } from '../../browser/sessionsManagementService.js';
+import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { MockContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
+import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
+import { IProgress, IProgressService, IProgressStep } from '../../../../../platform/progress/common/progress.js';
+import { InMemoryStorageService, IStorageService } from '../../../../../platform/storage/common/storage.js';
+import { IUriIdentityService } from '../../../../../platform/uriIdentity/common/uriIdentity.js';
+import { ChatViewPaneTarget, IChatWidget, IChatWidgetService } from '../../../../../workbench/contrib/chat/browser/chat.js';
+import { IAgentSession, IAgentSessionsModel } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentSessionsModel.js';
+import { IAgentSessionsService } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentSessionsService.js';
+import { IChatEditorOptions } from '../../../../../workbench/contrib/chat/browser/widgetHosts/editor/chatEditor.js';
+import { PreferredGroup } from '../../../../../workbench/services/editor/common/editorService.js';
+import { IChat, ISession, ISessionType, ISessionWorkspace } from '../../common/session.js';
+import { ISendRequestOptions, ISessionsProvider } from '../../common/sessionsProvider.js';
+import { deduplicateSessions, SessionsManagementService } from '../../browser/sessionsManagementService.js';
+import { ISessionsManagementService } from '../../common/sessionsManagement.js';
+import { ISessionsProvidersService } from '../../browser/sessionsProvidersService.js';
 
 const stubChat = {
 	resource: URI.parse('test:///chat'),
@@ -53,6 +71,111 @@ function stubSession(overrides: Partial<ISession> & Pick<ISession, 'sessionId' |
 		capabilities: { supportsMultipleChats: false },
 		...overrides,
 	};
+}
+
+class TestChatWidgetService extends mock<IChatWidgetService>() {
+	readonly opened: URI[] = [];
+
+	override async openSession(sessionResource: URI, _target?: typeof ChatViewPaneTarget | PreferredGroup, _options?: IChatEditorOptions): Promise<IChatWidget | undefined> {
+		this.opened.push(sessionResource);
+		return undefined;
+	}
+}
+
+class TestAgentSessionsService extends mock<IAgentSessionsService>() {
+	readonly observed: URI[] = [];
+
+	override readonly onDidChangeSessionArchivedState = Event.None;
+	override readonly model: IAgentSessionsModel = {
+		onWillResolve: Event.None,
+		onDidResolve: Event.None,
+		onDidChangeSessions: Event.None,
+		onDidChangeSessionArchivedState: Event.None,
+		resolved: true,
+		sessions: [],
+		getSession: () => undefined,
+		observeSession: resource => {
+			this.observed.push(resource);
+			return constObservable<IAgentSession | undefined>(undefined);
+		},
+		resolve: async () => { },
+	};
+
+	override getSession(): IAgentSession | undefined {
+		return undefined;
+	}
+}
+
+class TestProgressService extends mock<IProgressService>() {
+	override async withProgress<R>(_options: Parameters<IProgressService['withProgress']>[0], task: (progress: IProgress<IProgressStep>) => Promise<R>): Promise<R> {
+		return task({ report() { } });
+	}
+}
+
+class TestSessionsProvidersService extends mock<ISessionsProvidersService>() {
+	override readonly onDidChangeProviders = Event.None;
+
+	constructor(private readonly _providers: readonly ISessionsProvider[]) {
+		super();
+	}
+
+	override registerProvider(): never {
+		throw new Error('not implemented');
+	}
+
+	override getProviders(): ISessionsProvider[] {
+		return [...this._providers];
+	}
+
+	override getProvider<T extends ISessionsProvider>(providerId: string): T | undefined {
+		return this._providers.find(provider => provider.id === providerId) as T | undefined;
+	}
+}
+
+class TestSessionsProvider extends mock<ISessionsProvider>() {
+	override readonly id = 'test';
+	override readonly label = 'Test';
+	override readonly icon = Codicon.vm;
+	override readonly sessionTypes: readonly ISessionType[] = [{ id: 'test', label: 'Test', icon: Codicon.vm }];
+	override readonly onDidChangeSessionTypes = Event.None;
+	override readonly onDidChangeSessions = Event.None;
+	override readonly browseActions = [];
+
+	constructor(private readonly _session: ISession) {
+		super();
+	}
+
+	override getSessions(): ISession[] { return [this._session]; }
+	override resolveWorkspace(): ISessionWorkspace | undefined { return undefined; }
+	override createNewSession(): ISession { return this._session; }
+	override getSessionTypes(): ISessionType[] { return [...this.sessionTypes]; }
+	override async renameChat(): Promise<void> { }
+	override setModel(): void { }
+	override async archiveSession(): Promise<void> { }
+	override async unarchiveSession(): Promise<void> { }
+	override async deleteSession(): Promise<void> { }
+	override async deleteChat(): Promise<void> { }
+	override async sendAndCreateChat(): Promise<ISession> { return this._session; }
+	override addChat(): IChat { return this._session.mainChat; }
+	override async sendRequest(_sessionId: string, _chatResource: URI, _options: ISendRequestOptions): Promise<ISession> { return this._session; }
+}
+
+function createSessionsManagementService(session: ISession, disposables: ReturnType<typeof ensureNoDisposablesAreLeakedInTestSuite>): { service: ISessionsManagementService; chatWidgetService: TestChatWidgetService; agentSessionsService: TestAgentSessionsService } {
+	const instantiationService = disposables.add(new TestInstantiationService());
+	const chatWidgetService = new TestChatWidgetService();
+	const agentSessionsService = new TestAgentSessionsService();
+
+	instantiationService.stub(IStorageService, disposables.add(new InMemoryStorageService()));
+	instantiationService.stub(ILogService, new NullLogService());
+	instantiationService.stub(IContextKeyService, disposables.add(new MockContextKeyService()));
+	instantiationService.stub(ISessionsProvidersService, new TestSessionsProvidersService([new TestSessionsProvider(session)]));
+	instantiationService.stub(IUriIdentityService, { extUri: extUriBiasedIgnorePathCase });
+	instantiationService.stub(IChatWidgetService, chatWidgetService);
+	instantiationService.stub(IAgentSessionsService, agentSessionsService);
+	instantiationService.stub(IProgressService, new TestProgressService());
+
+	const service = disposables.add(instantiationService.createInstance(SessionsManagementService));
+	return { service, chatWidgetService, agentSessionsService };
 }
 
 suite('deduplicateSessions', () => {
@@ -103,5 +226,26 @@ suite('deduplicateSessions', () => {
 		const noKey = stubSession({ sessionId: 'nk', providerId: 'copilot-chat' });
 		const result = deduplicateSessions([keyed2, noKey, keyed1]);
 		assert.deepStrictEqual(result, [noKey, keyed1]);
+	});
+});
+
+suite('SessionsManagementService', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('openSession waits for a loading session before opening chat content', async () => {
+		const loading = observableValue('loading', true);
+		const session = stubSession({ sessionId: 'loading', providerId: 'test', loading });
+		const { service, chatWidgetService, agentSessionsService } = createSessionsManagementService(session, disposables);
+
+		const openPromise = service.openSession(session.resource);
+		await Promise.resolve();
+
+		assert.deepStrictEqual({ opened: chatWidgetService.opened.map(uri => uri.toString()), observed: agentSessionsService.observed.map(uri => uri.toString()) }, { opened: [], observed: [] });
+
+		loading.set(false, undefined);
+		await openPromise;
+
+		assert.deepStrictEqual({ opened: chatWidgetService.opened.map(uri => uri.toString()), observed: agentSessionsService.observed.map(uri => uri.toString()) }, { opened: [session.resource.toString()], observed: [session.resource.toString()] });
 	});
 });


### PR DESCRIPTION
## Summary
- wait for loading sessions before opening chat content in the Agents window
- defer lazy agent-session observation until session loading is complete
- add coverage for delayed session opening

## Validation
- npm run compile-check-ts-native
- npm run valid-layers-check
- node --experimental-strip-types build/hygiene.ts src/vs/sessions/services/sessions/browser/sessionsManagementService.ts src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
- ./scripts/test.sh --run src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts