### PR TITLE
Port zsh terminal fixes: zsh pitfalls with shell options and steering text

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostShellUtils.ts
+++ b/src/vs/platform/agentHost/node/agentHostShellUtils.ts
@@ -6,7 +6,7 @@
 import { posix as pathPosix, win32 as pathWin32 } from '../../../base/common/path.js';
 import * as platform from '../../../base/common/platform.js';
 
-export function isZshExecutable(shell: string): boolean {
+export function isZsh(shell: string): boolean {
 	if (platform.OS === platform.OperatingSystem.Windows) {
 		return /^zsh(?:\.exe)?$/i.test(pathWin32.basename(shell));
 	}

--- a/src/vs/platform/agentHost/node/agentHostShellUtils.ts
+++ b/src/vs/platform/agentHost/node/agentHostShellUtils.ts
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { posix as pathPosix, win32 as pathWin32 } from '../../../base/common/path.js';
+import * as platform from '../../../base/common/platform.js';
+
+export function isZshExecutable(shell: string): boolean {
+	if (platform.OS === platform.OperatingSystem.Windows) {
+		return /^zsh(?:\.exe)?$/i.test(pathWin32.basename(shell));
+	}
+	return /^zsh$/.test(pathPosix.basename(shell));
+}

--- a/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
+++ b/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
@@ -23,6 +23,7 @@ import { TerminalClaim, TerminalContentPart, TerminalInfo, TerminalState, Termin
 import { isTerminalAction } from '../common/state/sessionActions.js';
 import { IAgentConfigurationService } from './agentConfigurationService.js';
 import { AgentHostHeadlessTerminal } from './agentHostHeadlessTerminal.js';
+import { isZshExecutable } from './agentHostShellUtils.js';
 import type { AgentHostStateManager } from './agentHostStateManager.js';
 import { Osc633Event, Osc633EventType, Osc633Parser } from './osc633Parser.js';
 
@@ -270,6 +271,11 @@ export class AgentHostTerminalManager extends Disposable implements IAgentHostTe
 			// Combined with the leading-space prefix applied at command-write time, this
 			// prevents agent-executed commands from polluting the user's shell history.
 			env['VSCODE_PREVENT_SHELL_HISTORY'] = '1';
+		}
+		// Zsh-specific fixups for agent terminals: disable bang history
+		// expansion and enable inline # comments.
+		if (isZshExecutable(shell)) {
+			env['VSCODE_AGENT_ZSH_FIXUPS'] = '1';
 		}
 		if (options?.nonInteractive) {
 			// Suppress paging and interactive prompts so that tool-spawned

--- a/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
+++ b/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
@@ -272,9 +272,9 @@ export class AgentHostTerminalManager extends Disposable implements IAgentHostTe
 			// prevents agent-executed commands from polluting the user's shell history.
 			env['VSCODE_PREVENT_SHELL_HISTORY'] = '1';
 		}
-		// Zsh-specific fixups for agent terminals: disable bang history
+		// Zsh-specific fixups for agent tool terminals: disable bang history
 		// expansion and enable inline # comments.
-		if (isZsh(shell)) {
+		if (params.claim?.kind === TerminalClaimKind.Session && isZsh(shell)) {
 			env['VSCODE_AGENT_ZSH_FIXUPS'] = '1';
 		}
 		if (options?.nonInteractive) {

--- a/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
+++ b/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
@@ -23,7 +23,7 @@ import { TerminalClaim, TerminalContentPart, TerminalInfo, TerminalState, Termin
 import { isTerminalAction } from '../common/state/sessionActions.js';
 import { IAgentConfigurationService } from './agentConfigurationService.js';
 import { AgentHostHeadlessTerminal } from './agentHostHeadlessTerminal.js';
-import { isZshExecutable } from './agentHostShellUtils.js';
+import { isZsh } from './agentHostShellUtils.js';
 import type { AgentHostStateManager } from './agentHostStateManager.js';
 import { Osc633Event, Osc633EventType, Osc633Parser } from './osc633Parser.js';
 
@@ -274,7 +274,7 @@ export class AgentHostTerminalManager extends Disposable implements IAgentHostTe
 		}
 		// Zsh-specific fixups for agent terminals: disable bang history
 		// expansion and enable inline # comments.
-		if (isZshExecutable(shell)) {
+		if (isZsh(shell)) {
 			env['VSCODE_AGENT_ZSH_FIXUPS'] = '1';
 		}
 		if (options?.nonInteractive) {

--- a/src/vs/platform/agentHost/node/copilot/copilotShellTools.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotShellTools.ts
@@ -12,7 +12,7 @@ import { Disposable, DisposableStore, type IReference, toDisposable } from '../.
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { ILogService } from '../../../log/common/log.js';
 import { TerminalClaimKind, type TerminalSessionClaim } from '../../common/state/protocol/state.js';
-import { isZshExecutable } from '../agentHostShellUtils.js';
+import { isZsh } from '../agentHostShellUtils.js';
 import { IAgentHostTerminalManager } from '../agentHostTerminalManager.js';
 
 /**
@@ -620,7 +620,7 @@ export async function createShellTools(
 	const primaryTool: Tool<IShellToolArgs> = {
 		name: shellType,
 		description: shellType === 'bash'
-			? (isZshExecutable(executable) ? createZshModelDescription(false) : createBashModelDescription(false))
+			? (isZsh(executable) ? createZshModelDescription(false) : createBashModelDescription(false))
 			: createPowerShellModelDescription(shellType, executable, false),
 		parameters: {
 			type: 'object',

--- a/src/vs/platform/agentHost/node/copilot/copilotShellTools.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotShellTools.ts
@@ -12,6 +12,7 @@ import { Disposable, DisposableStore, type IReference, toDisposable } from '../.
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { ILogService } from '../../../log/common/log.js';
 import { TerminalClaimKind, type TerminalSessionClaim } from '../../common/state/protocol/state.js';
+import { isZshExecutable } from '../agentHostShellUtils.js';
 import { IAgentHostTerminalManager } from '../agentHostTerminalManager.js';
 
 /**
@@ -618,7 +619,9 @@ export async function createShellTools(
 
 	const primaryTool: Tool<IShellToolArgs> = {
 		name: shellType,
-		description: shellType === 'bash' ? createBashModelDescription(false) : createPowerShellModelDescription(shellType, executable, false),
+		description: shellType === 'bash'
+			? (isZshExecutable(executable) ? createZshModelDescription(false) : createBashModelDescription(false))
+			: createPowerShellModelDescription(shellType, executable, false),
 		parameters: {
 			type: 'object',
 			properties: {
@@ -931,5 +934,21 @@ function createBashModelDescription(isSandboxEnabled: boolean, networkDomains?: 
 		'- Use [[ ]] for conditional tests instead of [ ]',
 		'- Prefer $() over backticks for command substitution',
 		'- Use set -e at start of complex commands to exit on errors'
+	].join('\n');
+}
+
+function createZshModelDescription(isSandboxEnabled: boolean, networkDomains?: ITerminalSandboxResolvedNetworkDomains): string {
+	return [
+		'This tool allows you to execute shell commands in a persistent zsh terminal session, preserving environment variables, working directory, and other context across multiple commands.',
+		createGenericDescription('bash', isSandboxEnabled, networkDomains),
+		'- Use type to check command type (builtin, function, alias)',
+		'- Use jobs, fg, bg for job control',
+		'- Use [[ ]] for conditional tests instead of [ ]',
+		'- Prefer $() over backticks for command substitution',
+		'- Take advantage of zsh globbing features (**, extended globs). Note: unmatched globs fail by default (zsh: no matches found) - use a glob qualifier like *(N) or quote the glob if it should be literal',
+		'',
+		'zsh pitfalls - these WILL cause errors or hangs:',
+		'- NEVER use bare == or === as separators (e.g. echo === triggers zsh equals expansion). Quote them: echo \'===\'',
+		'- NEVER use status as a variable name (it is read-only in zsh). Use exit_code or ret instead',
 	].join('\n');
 }

--- a/src/vs/platform/agentHost/test/node/agentHostTerminalManager.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTerminalManager.test.ts
@@ -12,7 +12,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/c
 import { NullLogService } from '../../../log/common/log.js';
 import { IProductService } from '../../../product/common/productService.js';
 import { ActionType, StateAction } from '../../common/state/protocol/actions.js';
-import { TerminalClaimKind, TerminalContentPart } from '../../common/state/protocol/state.js';
+import { TerminalClaimKind, TerminalContentPart, type TerminalClaim } from '../../common/state/protocol/state.js';
 import { AgentConfigurationService } from '../../node/agentConfigurationService.js';
 import { AgentHostStateManager } from '../../node/agentHostStateManager.js';
 import { AgentHostTerminalManager, formatTerminalText, removeServerHandledTerminalQueries, type ITerminalQueryFilterState } from '../../node/agentHostTerminalManager.js';
@@ -340,43 +340,56 @@ suite('AgentHostTerminalManager – command detection integration', () => {
 		assert.deepStrictEqual(pty.writes, ['echo first\recho second\r']);
 	});
 
-	test('sets zsh agent fixups only for zsh terminals', async () => {
+	test('sets zsh agent fixups only for session zsh terminals', async () => {
 		const logService = new NullLogService();
 		const stateManager = disposables.add(new AgentHostStateManager(logService));
 		const configurationService = disposables.add(new AgentConfigurationService(stateManager, logService));
 		const productService = { _serviceBrand: undefined, applicationName: 'vscode' } as IProductService;
 
-		const zshPty = new TestPty();
-		const zshManager = disposables.add(new TestAgentHostTerminalManager(stateManager, logService, productService, configurationService, zshPty));
-		const createZshTerminal = zshManager.createTerminal({
-			terminal: 'agenthost-terminal://test/zsh-fixups',
-			claim: { kind: TerminalClaimKind.Client, clientId: 'test-client' },
-			cwd: process.cwd(),
-			cols: 80,
-			rows: 24,
-		}, { shell: '/bin/zsh' });
-		await zshPty.dataListenerRegistered.p;
-		zshPty.fireData('prompt');
-		await createZshTerminal;
+		async function createTestTerminal(
+			id: string,
+			shell: string,
+			claim: TerminalClaim,
+			options?: { preventShellHistory?: boolean; nonInteractive?: boolean }
+		): Promise<TestAgentHostTerminalManager> {
+			const pty = new TestPty();
+			const manager = disposables.add(new TestAgentHostTerminalManager(stateManager, logService, productService, configurationService, pty));
+			const createTerminal = manager.createTerminal({
+				terminal: `agenthost-terminal://test/${id}`,
+				claim,
+				cwd: process.cwd(),
+				cols: 80,
+				rows: 24,
+			}, { shell, ...options });
+			await pty.dataListenerRegistered.p;
+			pty.fireData('prompt');
+			await createTerminal;
+			return manager;
+		}
 
-		assert.strictEqual(zshManager.spawnOptions?.env?.VSCODE_AGENT_ZSH_FIXUPS, '1');
-		assert.strictEqual(zshManager.spawnOptions?.env?.VSCODE_PREVENT_SHELL_HISTORY, undefined);
+		const zshSessionManager = await createTestTerminal('zsh-session-fixups', '/bin/zsh', {
+			kind: TerminalClaimKind.Session,
+			session: 'copilot:/session-1',
+			turnId: 'turn-1',
+			toolCallId: 'tool-1',
+		}, { preventShellHistory: true });
+		assert.strictEqual(zshSessionManager.spawnOptions?.env?.VSCODE_AGENT_ZSH_FIXUPS, '1');
+		assert.strictEqual(zshSessionManager.spawnOptions?.env?.VSCODE_PREVENT_SHELL_HISTORY, '1');
 
-		const bashPty = new TestPty();
-		const bashManager = disposables.add(new TestAgentHostTerminalManager(stateManager, logService, productService, configurationService, bashPty));
-		const createBashTerminal = bashManager.createTerminal({
-			terminal: 'agenthost-terminal://test/bash-history',
-			claim: { kind: TerminalClaimKind.Client, clientId: 'test-client' },
-			cwd: process.cwd(),
-			cols: 80,
-			rows: 24,
-		}, { shell: '/bin/bash', preventShellHistory: true });
-		await bashPty.dataListenerRegistered.p;
-		bashPty.fireData('prompt');
-		await createBashTerminal;
+		const zshClientManager = await createTestTerminal('zsh-client', '/bin/zsh', {
+			kind: TerminalClaimKind.Client,
+			clientId: 'test-client',
+		});
+		assert.strictEqual(zshClientManager.spawnOptions?.env?.VSCODE_AGENT_ZSH_FIXUPS, undefined);
 
-		assert.strictEqual(bashManager.spawnOptions?.env?.VSCODE_AGENT_ZSH_FIXUPS, undefined);
-		assert.strictEqual(bashManager.spawnOptions?.env?.VSCODE_PREVENT_SHELL_HISTORY, '1');
+		const bashSessionManager = await createTestTerminal('bash-session-history', '/bin/bash', {
+			kind: TerminalClaimKind.Session,
+			session: 'copilot:/session-1',
+			turnId: 'turn-1',
+			toolCallId: 'tool-2',
+		}, { preventShellHistory: true, nonInteractive: true });
+		assert.strictEqual(bashSessionManager.spawnOptions?.env?.VSCODE_AGENT_ZSH_FIXUPS, undefined);
+		assert.strictEqual(bashSessionManager.spawnOptions?.env?.VSCODE_PREVENT_SHELL_HISTORY, '1');
 	});
 
 	test('writes headless DSR responses back to the PTY', async () => {

--- a/src/vs/platform/agentHost/test/node/agentHostTerminalManager.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTerminalManager.test.ts
@@ -207,6 +207,8 @@ class TestPty implements IPty {
 }
 
 class TestAgentHostTerminalManager extends AgentHostTerminalManager {
+	spawnOptions: IPtyForkOptions | IWindowsPtyForkOptions | undefined;
+
 	constructor(
 		stateManager: AgentHostStateManager,
 		logService: NullLogService,
@@ -218,6 +220,7 @@ class TestAgentHostTerminalManager extends AgentHostTerminalManager {
 	}
 
 	protected override async _spawnPty(_file: string, _args: string[], options: IPtyForkOptions | IWindowsPtyForkOptions): Promise<IPty> {
+		this.spawnOptions = options;
 		this._pty.cols = options.cols ?? this._pty.cols;
 		this._pty.rows = options.rows ?? this._pty.rows;
 		return this._pty;
@@ -335,6 +338,45 @@ suite('AgentHostTerminalManager – command detection integration', () => {
 		await manager.sendText('agenthost-terminal://test/bracketed-paste-disabled', 'echo first\necho second', { shouldExecute: true, bracketedPasteMode: true });
 
 		assert.deepStrictEqual(pty.writes, ['echo first\recho second\r']);
+	});
+
+	test('sets zsh agent fixups only for zsh terminals', async () => {
+		const logService = new NullLogService();
+		const stateManager = disposables.add(new AgentHostStateManager(logService));
+		const configurationService = disposables.add(new AgentConfigurationService(stateManager, logService));
+		const productService = { _serviceBrand: undefined, applicationName: 'vscode' } as IProductService;
+
+		const zshPty = new TestPty();
+		const zshManager = disposables.add(new TestAgentHostTerminalManager(stateManager, logService, productService, configurationService, zshPty));
+		const createZshTerminal = zshManager.createTerminal({
+			terminal: 'agenthost-terminal://test/zsh-fixups',
+			claim: { kind: TerminalClaimKind.Client, clientId: 'test-client' },
+			cwd: process.cwd(),
+			cols: 80,
+			rows: 24,
+		}, { shell: '/bin/zsh' });
+		await zshPty.dataListenerRegistered.p;
+		zshPty.fireData('prompt');
+		await createZshTerminal;
+
+		assert.strictEqual(zshManager.spawnOptions?.env?.VSCODE_AGENT_ZSH_FIXUPS, '1');
+		assert.strictEqual(zshManager.spawnOptions?.env?.VSCODE_PREVENT_SHELL_HISTORY, undefined);
+
+		const bashPty = new TestPty();
+		const bashManager = disposables.add(new TestAgentHostTerminalManager(stateManager, logService, productService, configurationService, bashPty));
+		const createBashTerminal = bashManager.createTerminal({
+			terminal: 'agenthost-terminal://test/bash-history',
+			claim: { kind: TerminalClaimKind.Client, clientId: 'test-client' },
+			cwd: process.cwd(),
+			cols: 80,
+			rows: 24,
+		}, { shell: '/bin/bash', preventShellHistory: true });
+		await bashPty.dataListenerRegistered.p;
+		bashPty.fireData('prompt');
+		await createBashTerminal;
+
+		assert.strictEqual(bashManager.spawnOptions?.env?.VSCODE_AGENT_ZSH_FIXUPS, undefined);
+		assert.strictEqual(bashManager.spawnOptions?.env?.VSCODE_PREVENT_SHELL_HISTORY, '1');
 	});
 
 	test('writes headless DSR responses back to the PTY', async () => {

--- a/src/vs/platform/agentHost/test/node/copilotShellTools.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotShellTools.test.ts
@@ -195,12 +195,14 @@ suite('CopilotShellTools', () => {
 
 		assert.ok(bashTool);
 		assert.strictEqual(bashTool.name, 'bash');
-		assert.match(bashTool.description, /persistent zsh terminal session/);
-		assert.match(bashTool.description, /zsh globbing features/);
-		assert.match(bashTool.description, /bare == or ===/);
-		assert.match(bashTool.description, /status as a variable name/);
-		assert.doesNotMatch(bashTool.description, /bang history/);
-		assert.doesNotMatch(bashTool.description, /# comments/);
+		assert.ok(bashTool.description);
+		const description = bashTool.description;
+		assert.match(description, /persistent zsh terminal session/);
+		assert.match(description, /zsh globbing features/);
+		assert.match(description, /bare == or ===/);
+		assert.match(description, /status as a variable name/);
+		assert.doesNotMatch(description, /bang history/);
+		assert.doesNotMatch(description, /# comments/);
 	});
 
 	test('getOrCreateShell reuses an idle shell after the reference is disposed', async () => {

--- a/src/vs/platform/agentHost/test/node/copilotShellTools.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotShellTools.test.ts
@@ -186,6 +186,23 @@ suite('CopilotShellTools', () => {
 		assert.ok(unknownDefault === 'bash' || unknownDefault === 'powershell');
 	});
 
+	test('zsh executable keeps bash tool name but uses zsh-specific guidance', async () => {
+		const { instantiationService, terminalManager } = createServices();
+		terminalManager.defaultShell = '/bin/zsh';
+		const shellManager = disposables.add(instantiationService.createInstance(ShellManager, URI.parse('copilot:/session-1'), undefined));
+		const tools = await createShellTools(shellManager, terminalManager, new NullLogService());
+		const bashTool = tools.find(tool => tool.name === 'bash');
+
+		assert.ok(bashTool);
+		assert.strictEqual(bashTool.name, 'bash');
+		assert.match(bashTool.description, /persistent zsh terminal session/);
+		assert.match(bashTool.description, /zsh globbing features/);
+		assert.match(bashTool.description, /bare == or ===/);
+		assert.match(bashTool.description, /status as a variable name/);
+		assert.doesNotMatch(bashTool.description, /bang history/);
+		assert.doesNotMatch(bashTool.description, /# comments/);
+	});
+
 	test('getOrCreateShell reuses an idle shell after the reference is disposed', async () => {
 		const terminalManager = new TestAgentHostTerminalManager();
 		// Pretend created terminals exist and are still running.


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/316347
Related: https://github.com/microsoft/vscode/issues/312009 

Porting: https://github.com/microsoft/vscode/pull/316134 

- Set `VSCODE_AGENT_ZSH_FIXUPS` for Agent Host shell-tool zsh terminals, matching workbench Copilot terminal behavior.
- Add an Agent Host-local `isZsh` helper that mirrors workbench zsh executable detection.
- Reuse the shared zsh shell integration script to apply `NO_BANG_HIST` and `INTERACTIVE_COMMENTS`.
- Keep zsh routed through the SDK `bash` tool while showing zsh-specific shell guidance.
- Add focused tests for session-scoped zsh env fixups and zsh-specific shell tool descriptions.

-----------------------------------------
Inspirations from:

- Zsh executable detection comes from [`isZsh`](https://github.com/microsoft/vscode/blob/0d2147edf72ddd14bcc7e838b1e60889f7422157/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalHelpers.ts#L29-L34).
- The `VSCODE_AGENT_ZSH_FIXUPS` trigger comes from [`ToolTerminalCreator`](https://github.com/microsoft/vscode/blob/0d2147edf72ddd14bcc7e838b1e60889f7422157/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/toolTerminalCreator.ts#L179-L184).
- The zsh fixup behavior comes from [`shellIntegration-rc.zsh`](https://github.com/microsoft/vscode/blob/0d2147edf72ddd14bcc7e838b1e60889f7422157/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-rc.zsh#L109-L116).
- Zsh shell-tool guidance comes from [`createZshModelDescription`](https://github.com/microsoft/vscode/blob/0d2147edf72ddd14bcc7e838b1e60889f7422157/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts#L256-L268).


After: 
<img width="1468" height="1011" alt="portZshFixes" src="https://github.com/user-attachments/assets/d79b5e50-a090-4c78-842d-70585455059c" />

