### PR TITLE
Preserve unresolved variables in process task command path (fixes #160891)

### DIFF
--- a/src/vs/workbench/api/node/extHostTask.ts
+++ b/src/vs/workbench/api/node/extHostTask.ts
@@ -173,13 +173,26 @@ export class ExtHostTask extends ExtHostTaskBase {
 			}
 			const processName = await resolver.resolveAsync(ws, toResolve.process.name);
 			const cwd = toResolve.process.cwd !== undefined ? await resolver.resolveAsync(ws, toResolve.process.cwd) : undefined;
-			const foundExecutable = await findExecutable(processName, cwd, paths);
-			if (foundExecutable) {
-				result.process = foundExecutable;
-			} else if (path.isAbsolute(processName)) {
+			// If the process name still contains a `${...}` placeholder it is a
+			// variable that the extension host's resolver cannot expand (for
+			// example `${command:...}` or `${input:...}`). In that case, do not
+			// run `findExecutable` against the literal placeholder and do not
+			// prefix it with the cwd, otherwise the resulting string contains a
+			// concatenation of the cwd and the (later) resolved path
+			// (microsoft/vscode#160891). Pass the unresolved name through so it
+			// can be resolved later by the task system, which has access to the
+			// command/input value mappings.
+			if (/\$\{.+?\}/.test(processName)) {
 				result.process = processName;
 			} else {
-				result.process = path.join(cwd ?? '', processName);
+				const foundExecutable = await findExecutable(processName, cwd, paths);
+				if (foundExecutable) {
+					result.process = foundExecutable;
+				} else if (path.isAbsolute(processName)) {
+					result.process = processName;
+				} else {
+					result.process = path.join(cwd ?? '', processName);
+				}
 			}
 		}
 		return result;

--- a/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
@@ -687,6 +687,14 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 	private async _resolveAndFindExecutable(systemInfo: ITaskSystemInfo | undefined, workspaceFolder: IWorkspaceFolder | undefined, task: CustomTask | ContributedTask, cwd: string | undefined, envPath: string | undefined): Promise<string> {
 		const command = await this._configurationResolverService.resolveAsync(workspaceFolder, CommandString.value(task.command.name!));
 		cwd = cwd ? await this._configurationResolverService.resolveAsync(workspaceFolder, cwd) : undefined;
+		// If the command still contains a `${...}` placeholder, it is a variable
+		// (for example `${command:...}` or `${input:...}`) that this resolver
+		// cannot expand on its own. Returning it as-is lets the variable be
+		// substituted later by the task system instead of producing a malformed
+		// path like `<cwd>\${command:python.interpreterPath}` (microsoft/vscode#160891).
+		if (/\$\{.+?\}/.test(command)) {
+			return command;
+		}
 		const delimiter = (await this._pathService.path).delimiter;
 		const paths = envPath ? await Promise.all(envPath.split(delimiter).map(p => this._configurationResolverService.resolveAsync(workspaceFolder, p))) : undefined;
 		const foundExecutable = await systemInfo?.findExecutable(command, cwd, paths);


### PR DESCRIPTION
### Problem

A `process`-type task that uses a command-backed variable produces a corrupted executable path on Windows:

```jsonc
{
  "version": "2.0.0",
  "tasks": [{
    "label": "python: run",
    "type": "process",
    "command": "${command:python.interpreterPath}"
  }]
}
```

Running it currently fails with:

```
The terminal process failed to launch: Path to shell executable
"C:\projects\foo\C:\Python310\python.exe" does not exist.
```

The original report (#160891) already pinpointed the location: `findExecutable` is fed the literal `${command:python.interpreterPath}` and falls back to `path.join(cwd, command)`. The resulting concatenation later has the placeholder expanded *inside it* and the workspace path is left in front of the real interpreter path.

### Root cause

Two code paths share the same "resolve, then `findExecutable`, otherwise prefix with cwd" logic and both run before the command/input variables can be expanded:

- `extHostTask.$resolveVariables` (extension host, Node)
- `_resolveAndFindExecutable` in `terminalTaskSystem.ts` (main thread on Windows)

Neither of these resolvers can expand `${command:...}` or `${input:...}` on its own — those variables require an interaction step that runs later in the pipeline. After that interaction step the task system performs a second pass over the `__process__` variable when assembling the shell launch config (`_createShellLaunchConfig` calls `_resolveVariable` twice). It is at that point that command/input values are known and the path can be substituted correctly.

The fix is to recognize when the local resolve step left a `${...}` placeholder behind and return the value as-is, instead of pushing it through `findExecutable` and the cwd-prefix fallback. The downstream resolve pass then produces the correct path.

### Fix

`src/vs/workbench/api/node/extHostTask.ts` — `$resolveVariables`:
- After `resolver.resolveAsync` runs over `process.name`, check for a remaining `${...}` placeholder and, if found, return the unmodified `processName` so the task system can resolve it later.

`src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts` — `_resolveAndFindExecutable`:
- After `IConfigurationResolverService.resolveAsync`, the same placeholder check; return the value directly when unresolved variables remain.

Both changes are guarded by `/\$\{.+?\}/.test(...)` so behavior is unchanged for any command name that fully resolves in the local scope.

### Why not resolve the command earlier?

Resolving `${command:...}` happens on the main thread via `IConfigurationResolverService.resolveWithInteraction`. The extension host has no command service, and `_resolveAndFindExecutable` runs before that interaction. Reordering would need the wider pipeline rework discussed in the issue. The minimal, targeted fix here lets the existing later resolve step do its job by simply not corrupting the value first.

### Testing

- Verified both files have no diagnostics after the change.
- The placeholder check is purely additive: when no `${...}` remains the original branches (`findExecutable` → `path.isAbsolute` → `path.join(cwd, ...)`) are taken unchanged.

Fixes #160891