### PR TITLE
Fix explorer.excludeGitIgnore negated directory traversal

### DIFF
--- a/src/vs/workbench/services/search/common/ignoreFile.ts
+++ b/src/vs/workbench/services/search/common/ignoreFile.ts
@@ -117,8 +117,11 @@ export class IgnoreFile {
 		const isPathIgnored = (path: string, isDir: boolean) => {
 			if (!(this.ignoreCase ? startsWithIgnoreCase(path, dirPath) : path.startsWith(dirPath))) { return false; }
 
+			// Directory negations must keep traversal open before file-style patterns like `*` can match.
 			const dirIncluded = isDir && isDirIncluded(path);
-			if (isDir && isDirIgnored(path) && !dirIncluded) { return true; }
+			if (dirIncluded) { return false; }
+
+			if (isDir && isDirIgnored(path)) { return true; }
 
 			const fileIncluded = isFileIncluded(path);
 			if (isFileIgnored(path) && !fileIncluded) { return true; }
@@ -127,7 +130,7 @@ export class IgnoreFile {
 			// (e.g., `!.myconfig/`), do not delegate to the parent. In git, a
 			// negation in a child .gitignore overrides a positive pattern in a
 			// parent or global .gitignore.
-			if (dirIncluded || fileIncluded) { return false; }
+			if (fileIncluded) { return false; }
 
 			if (parent) { return parent.isPathIgnored(path, isDir); }
 

--- a/src/vs/workbench/services/search/test/common/ignoreFile.test.ts
+++ b/src/vs/workbench/services/search/test/common/ignoreFile.test.ts
@@ -567,6 +567,25 @@ suite('Parsing .gitignore files', () => {
 
 	});
 
+	test('directory negation traverses directory ignored by file wildcard', () => {
+		const i = '*\n!d/\n!d/a\n!b\n';
+
+		assertTraverses(i, '/', '/b');
+		assertTraverses(i, '/', '/d/');
+		assertTraverses(i, '/', '/d/a');
+
+		assertNoIgnoreMatch(i, '/', '/b');
+		assertNoIgnoreMatch(i, '/', '/d/a');
+	});
+
+	test('directory negation does not include all children', () => {
+		const i = '*\n!d/\n';
+
+		assertTraverses(i, '/', '/d/');
+		assertNoTraverses(i, '/', '/d/a');
+		assertIgnoreMatch(i, '/', '/d/a');
+	});
+
 	test('child negation overrides parent ignore', () => {
 		// Simulates: global gitignore has `.myconfig`, project .gitignore has `!.myconfig/`
 		// The child negation should override the parent positive pattern.


### PR DESCRIPTION
## Summary

Fixes #156077.

When `explorer.excludeGitIgnore` is enabled, Explorer could fail to traverse a directory that is unignored by a `.gitignore` negation ending in `/`.

For example:

```gitignore
*
!d/
!d/a
!b
```
Explorer showed b, but did not traverse d, so d/a remained hidden even though it is explicitly unignored.

This updates the internal .gitignore matching logic so directory negations such as !d/ can keep traversal open when the directory path is checked without a trailing slash.

Validation

Added regression coverage for:
```
*
!d/
!d/a
!b
```
and:
```
*
!d/
```
Verified that the first case includes b, traverses d, and includes d/a, while the second case traverses d without incorrectly including every child under d.

Ran:

- git diff --check

Also ran lightweight targeted sanity checks for the updated ignore parser tests.