### PR TITLE
Fix wrappingIndent in accessibility mode

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -5578,16 +5578,6 @@ class WrappingIndentOption extends BaseEditorOption<EditorOption.wrappingIndent,
 		}
 		return WrappingIndent.Same;
 	}
-
-	public override compute(env: IEnvironmentalOptions, options: IComputedEditorOptions, value: WrappingIndent): WrappingIndent {
-		const accessibilitySupport = options.get(EditorOption.accessibilitySupport);
-		if (accessibilitySupport === AccessibilitySupport.Enabled) {
-			// if we know for a fact that a screen reader is attached, we use no indent wrapping to
-			// help that the editor's wrapping points match the textarea's wrapping points
-			return WrappingIndent.None;
-		}
-		return value;
-	}
 }
 
 //#endregion

--- a/src/vs/editor/test/browser/config/editorConfiguration.test.ts
+++ b/src/vs/editor/test/browser/config/editorConfiguration.test.ts
@@ -7,7 +7,7 @@ import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { IEnvConfiguration } from '../../../browser/config/editorConfiguration.js';
 import { migrateOptions } from '../../../browser/config/migrateOptions.js';
-import { ConfigurationChangedEvent, EditorOption, IEditorHoverOptions, IQuickSuggestionsOptions } from '../../../common/config/editorOptions.js';
+import { ConfigurationChangedEvent, EditorOption, IEditorHoverOptions, IQuickSuggestionsOptions, WrappingIndent } from '../../../common/config/editorOptions.js';
 import { EditorZoom } from '../../../common/config/editorZoom.js';
 import { TestConfiguration } from './testConfiguration.js';
 import { AccessibilitySupport } from '../../../../platform/accessibility/common/accessibility.js';
@@ -197,6 +197,18 @@ suite('Common Editor Config', () => {
 			wordWrapColumn: -1
 		});
 		assertWrapping(config, true, 1);
+		config.dispose();
+	});
+
+	test('wrappingIndent is respected in accessibility mode', () => {
+		const config = new TestConfiguration({
+			wrappingIndent: 'indent',
+			envConfig: {
+				accessibilitySupport: AccessibilitySupport.Enabled
+			}
+		});
+
+		assert.strictEqual(config.options.get(EditorOption.wrappingIndent), WrappingIndent.Indent);
 		config.dispose();
 	});
 


### PR DESCRIPTION
Fixes #298865

This change removes the accessibility-specific override that forced `editor.wrappingIndent` to `none`, so the editor now respects the user-configured wrapping indent even when accessibility support is enabled.

It also adds a regression test covering `AccessibilitySupport.Enabled` together with `wrappingIndent: 'indent'`.

Validation:
- Editor diagnostics report no errors in the changed files.
- `VS Code - Build` could not run in this environment because `deemon` is missing.
- `npm run compile-check-ts-native` could not run in this environment because `tsgo` is missing.