### PR TITLE
fix: race activateByEvent with provider registration to prevent auth deadlock

### DIFF
--- a/src/vs/workbench/services/authentication/browser/authenticationService.ts
+++ b/src/vs/workbench/services/authentication/browser/authenticationService.ts
@@ -418,33 +418,48 @@ export class AuthenticationService extends Disposable implements IAuthentication
 	}
 
 	private async tryActivateProvider(providerId: string, activateImmediate: boolean): Promise<IAuthenticationProvider> {
-		await this._extensionService.activateByEvent(getAuthenticationProviderActivationEvent(providerId), activateImmediate ? ActivationKind.Immediate : ActivationKind.Normal);
-		let provider = this._authenticationProviders.get(providerId);
-		if (provider) {
-			return provider;
-		}
-		if (this._disposedSource.token.isCancellationRequested) {
-			throw new Error('Authentication service is disposed.');
-		}
-
 		const store = new DisposableStore();
 		try {
-			// TODO: Remove this timeout and figure out a better way to ensure auth providers
-			// are registered _during_ extension activation.
-			const result = await raceTimeout(
-				raceCancellation(
-					Event.toPromise(
-						Event.filter(
-							this.onDidRegisterAuthenticationProvider,
-							e => e.id === providerId,
-							store
-						),
+			// Don't await activateByEvent exclusively — one or more extension
+			// hosts may be blocked (e.g. webworker waiting on remote authority),
+			// causing a deadlock. Instead, race with the provider being
+			// registered so we can proceed as soon as any host delivers it. (#315841)
+			const activationPromise = this._extensionService.activateByEvent(
+				getAuthenticationProviderActivationEvent(providerId),
+				activateImmediate ? ActivationKind.Immediate : ActivationKind.Normal
+			);
+
+			let provider = this._authenticationProviders.get(providerId);
+			if (provider) {
+				return provider;
+			}
+			if (this._disposedSource.token.isCancellationRequested) {
+				throw new Error('Authentication service is disposed.');
+			}
+
+			const providerRegistered = raceCancellation(
+				Event.toPromise(
+					Event.filter(
+						this.onDidRegisterAuthenticationProvider,
+						e => e.id === providerId,
 						store
 					),
-					this._disposedSource.token
+					store
 				),
-				5000
+				this._disposedSource.token
 			);
+
+			// Wait for either activation to complete or the provider to register.
+			await Promise.race([activationPromise, providerRegistered]);
+
+			provider = this._authenticationProviders.get(providerId);
+			if (provider) {
+				return provider;
+			}
+
+			// TODO: Remove this timeout and figure out a better way to ensure auth providers
+			// are registered _during_ extension activation.
+			const result = await raceTimeout(providerRegistered, 5000);
 			provider = this._authenticationProviders.get(providerId);
 			if (provider) {
 				return provider;

--- a/src/vs/workbench/services/authentication/test/browser/authenticationService.test.ts
+++ b/src/vs/workbench/services/authentication/test/browser/authenticationService.test.ts
@@ -13,6 +13,7 @@ import { AuthenticationProviderInformation, AuthenticationSessionsChangeEvent, I
 import { TestEnvironmentService } from '../../../../test/browser/workbenchTestServices.js';
 import { TestExtensionService, TestProductService, TestStorageService } from '../../../../test/common/workbenchTestServices.js';
 import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { ActivationKind } from '../../../extensions/common/extensions.js';
 
 function createSession() {
 	return { id: 'session1', accessToken: 'token1', account: { id: 'account', label: 'Account' }, scopes: ['test'] };
@@ -462,5 +463,60 @@ suite('AuthenticationService', () => {
 				event: { added: [], removed: [], changed: [session] }
 			});
 		});
+	});
+
+});
+
+suite('AuthenticationService - tryActivateProvider', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	let authenticationService: AuthenticationService;
+
+	setup(() => {
+		const storageService = disposables.add(new TestStorageService());
+		const authenticationAccessService = disposables.add(new AuthenticationAccessService(storageService, TestProductService));
+		authenticationService = disposables.add(new AuthenticationService(new TestExtensionService(), authenticationAccessService, TestEnvironmentService, new NullLogService()));
+	});
+
+	teardown(() => {
+		authenticationService.dispose();
+	});
+
+	test('should resolve when provider registers even if activateByEvent never resolves (#315841)', async () => {
+		// Dispose the service created in setup to release the extension point handler,
+		// so we can create a new one with a hanging activateByEvent.
+		authenticationService.dispose();
+
+		const storageService = disposables.add(new TestStorageService());
+		const authAccessService = disposables.add(new AuthenticationAccessService(storageService, TestProductService));
+		// Simulate a deadlocked extension host: activateByEvent never resolves.
+		const hangingExtService = new class extends TestExtensionService {
+			override activateByEvent(_activationEvent: string, _activationKind?: ActivationKind): Promise<void> {
+				return new Promise<void>(() => { /* never resolves */ });
+			}
+		};
+		authenticationService = disposables.add(new AuthenticationService(hangingExtService, authAccessService, TestEnvironmentService, new NullLogService()));
+
+		const provider = createProvider({ getSessions: async () => [createSession()] });
+
+		// Start getSessions — this calls tryActivateProvider which fires activateByEvent.
+		// Since activateByEvent never resolves, the old code would deadlock here.
+		const sessionsPromise = authenticationService.getSessions(provider.id);
+
+		// Simulate the local extension host registering the provider
+		// while the webworker host is still stuck.
+		authenticationService.registerAuthenticationProvider(provider.id, provider);
+
+		// The Promise.race in tryActivateProvider should unblock immediately.
+		const sessions = await sessionsPromise;
+		assert.strictEqual(sessions.length, 1);
+	});
+
+	test('should resolve when activateByEvent completes and provider is already registered', async () => {
+		const provider = createProvider({ getSessions: async () => [createSession()] });
+		authenticationService.registerAuthenticationProvider(provider.id, provider);
+
+		const sessions = await authenticationService.getSessions(provider.id);
+		assert.strictEqual(sessions.length, 1);
 	});
 });


### PR DESCRIPTION
Fixes #315841

When connecting to a remote tunnel, the webworker extension host can deadlock waiting for `_installedExtensionsReady` (which requires a remote connection), while the remote connection needs auth. Previously, `tryActivateProvider` exclusively awaited `activateByEvent`, blocking until all extension hosts responded.

Fix by `Promise.race`-ing `activateByEvent` against the auth provider registering itself. This allows the local process extension host to deliver the provider and unblock auth without waiting for a stuck webworker host.

fyi @TylerLeonhardt -- there is now a race between the `activateByEvent` promise and the provider registering. This avoids deadlocks in a certain scenario where there are web worker extensions installed on the desktop.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
