### PR TITLE
Fix case-insensitive aggregated basename glob matching

### DIFF
--- a/src/vs/base/common/glob.ts
+++ b/src/vs/base/common/glob.ts
@@ -462,7 +462,7 @@ function trivia3(pattern: string, options: IGlobOptionsInternal): ParsedStringPa
 	const parsedPatterns = aggregateBasenameMatches(pattern.slice(1, -1)
 		.split(',')
 		.map(pattern => parsePattern(pattern, options))
-		.filter(pattern => pattern !== NULL), pattern);
+		.filter(pattern => pattern !== NULL), pattern, options.ignoreCase);
 
 	const patternsLength = parsedPatterns.length;
 	if (!patternsLength) {
@@ -617,7 +617,7 @@ export function getPathTerms(patternOrExpression: ParsedPattern | ParsedExpressi
 function parsedExpression(expression: IExpression, options: IGlobOptions): ParsedExpression {
 	const parsedPatterns = aggregateBasenameMatches(Object.getOwnPropertyNames(expression)
 		.map(pattern => parseExpressionPattern(pattern, expression[pattern], options))
-		.filter(pattern => pattern !== NULL));
+		.filter(pattern => pattern !== NULL), undefined, options.ignoreCase);
 
 	const patternsLength = parsedPatterns.length;
 	if (!patternsLength) {
@@ -786,7 +786,7 @@ function parseExpressionPattern(pattern: string, value: boolean | SiblingClause,
 	return parsedPattern;
 }
 
-function aggregateBasenameMatches(parsedPatterns: Array<ParsedStringPattern | ParsedExpressionPattern>, result?: string): Array<ParsedStringPattern | ParsedExpressionPattern> {
+function aggregateBasenameMatches(parsedPatterns: Array<ParsedStringPattern | ParsedExpressionPattern>, result?: string, ignoreCase?: boolean): Array<ParsedStringPattern | ParsedExpressionPattern> {
 	const basenamePatterns = parsedPatterns.filter(parsedPattern => !!(<ParsedStringPattern>parsedPattern).basenames);
 	if (basenamePatterns.length < 2) {
 		return parsedPatterns;
@@ -830,7 +830,7 @@ function aggregateBasenameMatches(parsedPatterns: Array<ParsedStringPattern | Pa
 			basename = path.substring(i);
 		}
 
-		const index = basenames.indexOf(basename);
+		const index = ignoreCase ? basenames.findIndex(candidate => equalsIgnoreCase(candidate, basename)) : basenames.indexOf(basename);
 		return index !== -1 ? patterns[index] : null;
 	};
 

--- a/src/vs/base/test/common/glob.test.ts
+++ b/src/vs/base/test/common/glob.test.ts
@@ -779,6 +779,18 @@ suite('Glob', () => {
 		assert.strictEqual(glob.match(expr, 'foo/foo'), null);
 	});
 
+	test('expression with two basename globs ignores case', function () {
+		const expr = {
+			'**/BAR': true,
+			'**/BAZ': true
+		};
+
+		assert.strictEqual(glob.match(expr, 'bar', { ignoreCase: true }), '**/BAR');
+		assert.strictEqual(glob.match(expr, 'baz', { ignoreCase: true }), '**/BAZ');
+		assert.strictEqual(glob.match(expr, 'src/bar', { ignoreCase: true }), '**/BAR');
+		assert.strictEqual(glob.match(expr, 'bar'), null);
+	});
+
 	test('expression with two basename globs and a siblings expression', function () {
 		const expr = {
 			'**/bar': true,


### PR DESCRIPTION
## Summary

Fixes a glob matching edge case where basename-only glob expressions did not honor `ignoreCase: true` after being combined by the basename aggregation fast path.

For example, matching multiple basename-only patterns such as `**/BAR` and `**/BAZ` against `bar` with `ignoreCase: true` returned `null`, while the equivalent single-pattern case honored `ignoreCase`.

The aggregate path now preserves case-insensitive matching semantics while keeping case-sensitive behavior unchanged.

## Validation

Added regression coverage for aggregated basename-only glob expressions with `ignoreCase: true`.

Ran:

- `git diff --check`
- `npm run compile-check-ts-native` - failed before typechecking because `tsgo` is unavailable in this checkout
