### PR TITLE
scm: allow diffDecorationsGutterWidth up to 10px

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/quickDiffDecorator.ts
+++ b/src/vs/workbench/contrib/scm/browser/quickDiffDecorator.ts
@@ -274,7 +274,7 @@ export class QuickDiffWorkbenchController extends Disposable implements IWorkben
 	private onDidChangeDiffWidthConfiguration(): void {
 		let width = this.configurationService.getValue<number>('scm.diffDecorationsGutterWidth');
 
-		if (isNaN(width) || width <= 0 || width > 5) {
+		if (isNaN(width) || width <= 0 || width > 10) {
 			width = 3;
 		}
 

--- a/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
+++ b/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
@@ -184,7 +184,8 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 		},
 		'scm.diffDecorationsGutterWidth': {
 			type: 'number',
-			enum: [1, 2, 3, 4, 5],
+			minimum: 1,
+			maximum: 10,
 			default: 3,
 			description: localize('diffGutterWidth', "Controls the width(px) of diff decorations in gutter (added & modified).")
 		},


### PR DESCRIPTION
Closes #278083

## Problem

`scm.diffDecorationsGutterWidth` is constrained to the values `[1, 2, 3, 4, 5]` via a JSON Schema `enum`. This means:

- The Settings UI renders a **dropdown** instead of a number input, which feels wrong for a width value.
- Users who want a wider gutter (e.g. on HiDPI / high-resolution displays) are blocked at 5 px.

## Fix

Replace the `enum` array with `minimum: 1` / `maximum: 10` so the Settings UI shows a number input and any integer in that range is valid.

Also raise the runtime safety guard in `quickDiffDecorator.ts` from `width > 5` to `width > 10` to stay consistent — values outside `[1, 10]` still fall back to the default of `3`.

## Changes

| File | Change |
|---|---|
| `src/vs/workbench/contrib/scm/browser/scm.contribution.ts` | `enum: [1,2,3,4,5]` → `minimum: 1, maximum: 10` |
| `src/vs/workbench/contrib/scm/browser/quickDiffDecorator.ts` | `width > 5` → `width > 10` |