### PR TITLE
terminal: clip tab description text when panel is in text mode

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/terminal.css
+++ b/src/vs/workbench/contrib/terminal/browser/media/terminal.css
@@ -438,6 +438,16 @@
 	display: none;
 }
 
+.monaco-workbench .pane-body.integrated-terminal .tabs-container.has-text .tabs-list .terminal-tabs-entry .monaco-icon-label {
+	min-width: 0;
+}
+
+.monaco-workbench .pane-body.integrated-terminal .tabs-container.has-text .tabs-list .terminal-tabs-entry .monaco-icon-description-container {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
 .monaco-workbench .pane-body.integrated-terminal .tabs-list .codicon {
 	vertical-align: text-bottom;
 }


### PR DESCRIPTION
Closes #312970

## Problem

When the terminal tabs panel is in "text" mode (wide enough to show labels), the tab description (e.g. the current working directory or process name) can be wider than its container. This causes the text to overflow and overlap other elements in the panel.

The `not(.has-text)` case already hides the description with `display: none`, but there is no corresponding CSS rule that constrains the description when `has-text` **is** present.

## Root cause

`.monaco-icon-label` is a flex child without `min-width: 0`, so it cannot shrink below its intrinsic size. The description container has no overflow constraint, so text spills out of the flex row.

## Fix

Add two CSS rules to `terminal.css`:

1. `min-width: 0` on `.monaco-icon-label` inside a `has-text` terminal entry — lets the flex item actually shrink.
2. `overflow: hidden; text-overflow: ellipsis; white-space: nowrap` on `.monaco-icon-description-container` in `has-text` mode — clips and shows an ellipsis for long descriptions.

## Changes

`src/vs/workbench/contrib/terminal/browser/media/terminal.css` — two new CSS rule blocks appended after the existing `not(.has-text)` description rule.