### PR TITLE
fix tool call and progress part not rendering

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolProgressPart.ts
@@ -41,7 +41,7 @@ export class ChatToolProgressSubPart extends BaseChatToolInvocationSubPart {
 	private createProgressPart(): HTMLElement {
 		const isComplete = IChatToolInvocation.isComplete(this.toolInvocation);
 
-		if (isComplete && this.toolIsConfirmed && this.toolInvocation.pastTenseMessage) {
+		if (isComplete && this.toolIsConfirmed && (this.toolInvocation.pastTenseMessage || this.toolInvocation.invocationMessage)) {
 			const key = this.getAnnouncementKey('complete');
 			const completionContent = this.toolInvocation.pastTenseMessage ?? this.toolInvocation.invocationMessage;
 			// Don't render anything if there's no meaningful content
@@ -66,7 +66,7 @@ export class ChatToolProgressSubPart extends BaseChatToolInvocationSubPart {
 						progressContent = state.reasonMessage;
 					} else if (state.type === IChatToolInvocation.StateKind.Executing) {
 						const progress = state.progress.read(reader);
-						progressContent = progress?.message ?? this.toolInvocation.invocationMessage;
+						progressContent = (this.hasMeaningfulContent(progress?.message) ? progress?.message : undefined) ?? this.toolInvocation.invocationMessage;
 					} else {
 						progressContent = this.toolInvocation.invocationMessage;
 					}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolProgressPart.ts
@@ -49,7 +49,7 @@ export class ChatToolProgressSubPart extends BaseChatToolInvocationSubPart {
 				return document.createElement('div');
 			}
 			const shouldAnnounce = this.toolInvocation.kind === 'toolInvocation' && this.hasMeaningfulContent(completionContent) ? this.computeShouldAnnounce(key) : false;
-			const part = this.renderProgressContent(completionContent, shouldAnnounce);
+			const part = this.renderProgressContent(completionContent!, shouldAnnounce);
 			this._register(part);
 			return part.domNode;
 		} else {
@@ -65,8 +65,8 @@ export class ChatToolProgressSubPart extends BaseChatToolInvocationSubPart {
 					if (state.type === IChatToolInvocation.StateKind.Cancelled && state.reasonMessage) {
 						progressContent = state.reasonMessage;
 					} else if (state.type === IChatToolInvocation.StateKind.Executing) {
-						const progress = state.progress.read(reader);
-						progressContent = (this.hasMeaningfulContent(progress?.message) ? progress?.message : undefined) ?? this.toolInvocation.invocationMessage;
+						const progressMessage = state.progress.read(reader)?.message;
+						progressContent = this.hasMeaningfulContent(progressMessage) ? progressMessage : this.toolInvocation.invocationMessage;
 					} else {
 						progressContent = this.toolInvocation.invocationMessage;
 					}
@@ -80,7 +80,7 @@ export class ChatToolProgressSubPart extends BaseChatToolInvocationSubPart {
 					return;
 				}
 				const shouldAnnounce = this.toolInvocation.kind === 'toolInvocation' && this.hasMeaningfulContent(progressContent) ? this.computeShouldAnnounce(key) : false;
-				const part = reader.store.add(this.renderProgressContent(progressContent, shouldAnnounce));
+				const part = reader.store.add(this.renderProgressContent(progressContent!, shouldAnnounce));
 				dom.reset(container, part.domNode);
 			}));
 			return container;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -1237,6 +1237,14 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 	}
 
 	private updateWorkingProgressForPendingConfirmations(templateData: IChatListItemTemplate): void {
+		// Defer mutation of `templateData.renderedParts` (via `removeWorkingProgressContentPart`)
+		// to a microtask. This method is invoked from tool autoruns, which fire synchronously inside
+		// `renderChatContentDiff` while the array is being iterated — splicing it mid-render would
+		// orphan subsequent parts and leave detached DOM nodes referenced from `renderedParts`.
+		queueMicrotask(() => this.doUpdateWorkingProgressForPendingConfirmations(templateData));
+	}
+
+	private doUpdateWorkingProgressForPendingConfirmations(templateData: IChatListItemTemplate): void {
 		const element = templateData.currentElement;
 		if (!isResponseVM(element)) {
 			return;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -1241,7 +1241,14 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		// to a microtask. This method is invoked from tool autoruns, which fire synchronously inside
 		// `renderChatContentDiff` while the array is being iterated — splicing it mid-render would
 		// orphan subsequent parts and leave detached DOM nodes referenced from `renderedParts`.
-		queueMicrotask(() => this.doUpdateWorkingProgressForPendingConfirmations(templateData));
+		// Capture the originating element so we bail out if the template was recycled for a different one.
+		const originalElement = templateData.currentElement;
+		queueMicrotask(() => {
+			if (templateData.currentElement !== originalElement) {
+				return;
+			}
+			this.doUpdateWorkingProgressForPendingConfirmations(templateData);
+		});
 	}
 
 	private doUpdateWorkingProgressForPendingConfirmations(templateData: IChatListItemTemplate): void {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

fix https://github.com/microsoft/vscode/issues/313950

tested with the following extension contributed tool:

```ts
{
  kind: 'toolInvocation',
  toolId: 'test-lm-tool-313950_pokedex',
  toolCallId: 'toolu_01YbfDEUJM736xYH4xiBgKJn',
  source: { type: 'extension', extensionId: ... },
  state: { type: Executing /* 2 */, confirmed: { type: ConfirmationNotNeeded }, ... },

  invocationMessage: 'Looking up **pikachu** in the Pokédex…',
  pastTenseMessage: undefined,            
  presentation: undefined,
  confirmationMessages: { title: 'Confirm tool execution', ... }, 

  // alwaysDisplayInputOutput: true (set for ALL non-builtin tools):
  toolSpecificData: {
    kind: 'input',
    rawInput: { name: 'pikachu' }
  }
}
```