### PR TITLE
Enable chat.freezeCustomizationsIndex by default

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -4272,7 +4272,7 @@
 					},
 					"github.copilot.chat.freezeCustomizationsIndex": {
 						"type": "boolean",
-						"default": false,
+						"default": true,
 						"tags": [
 							"advanced",
 							"experimental",

--- a/extensions/copilot/src/platform/configuration/common/configurationService.ts
+++ b/extensions/copilot/src/platform/configuration/common/configurationService.ts
@@ -731,7 +731,7 @@ export namespace ConfigKey {
 		export const AnthropicExtendedCacheTtl = defineSetting<boolean>('chat.anthropic.promptCaching.extendedTtl', ConfigType.ExperimentBased, false);
 
 		/** Freeze the customizations-index variable (the `<instructions>`/`<skills>`/`<agents>` block) at the first turn of a conversation and reuse it on subsequent turns. Prevents the system prompt cache from being invalidated by per-turn churn — e.g. the active mode swapping which subagent entry appears in `<agents>`, or async experimentation flipping a `when`-gated skill. */
-		export const FreezeCustomizationsIndex = defineSetting<boolean>('chat.freezeCustomizationsIndex', ConfigType.ExperimentBased, false);
+		export const FreezeCustomizationsIndex = defineSetting<boolean>('chat.freezeCustomizationsIndex', ConfigType.ExperimentBased, true);
 
 		export const InlineEditsXtabProviderModelConfiguration = (() => {
 			const oldKey = 'chat.advanced.inlineEdits.xtabProvider.modelConfiguration';


### PR DESCRIPTION
Flips the default for `chat.freezeCustomizationsIndex` from `false` to `true`.

When enabled, the chat customizations payload (the `<instructions>` / `<skills>` / `<agents>` block) is captured at the first turn of a conversation and reused verbatim on subsequent turns. This prevents the system-prompt cache from being invalidated mid-conversation by:

- file-system changes to instruction files,
- newly discovered skills/agents from extensions or `<agents>` sources, or
- async experimentation flipping a `when`-gated skill.

Result: the system-prompt prefix stays stable across turns, so prompt-cache reuse goes up and per-turn latency / token cost drop on long conversations.

The setting was introduced in #316191 (off by default) so it could bake; this PR makes the on-by-default change.

### Changes
- `extensions/copilot/package.json` — flip the contributed setting default to `true`.
- `extensions/copilot/src/platform/configuration/common/configurationService.ts` — flip the `defineSetting` default for `FreezeCustomizationsIndex` to `true`.

### Risk / rollback
- Behavior gated entirely behind this single setting; users / experimentation can flip it back to `false` if needed.
- No code-path changes — only a default value flip.
