### PR TITLE
Terminal: validate nonce on shell integration CWD updates

### DIFF
--- a/src/vs/platform/terminal/common/capabilities/capabilities.ts
+++ b/src/vs/platform/terminal/common/capabilities/capabilities.ts
@@ -139,8 +139,14 @@ export interface ICwdDetectionCapability {
 	readonly type: TerminalCapability.CwdDetection;
 	readonly onDidChangeCwd: Event<string>;
 	readonly cwds: string[];
+	/**
+	 * Whether the current cwd came from a trusted source. This is `true` only when the cwd was
+	 * reported by the VS Code shell integration with a valid nonce. OSC 7, OSC 9;9 and OSC 1337
+	 * cwd updates are always considered untrusted because their protocols have no nonce.
+	 */
+	readonly isTrusted: boolean;
 	getCwd(): string;
-	updateCwd(cwd: string): void;
+	updateCwd(cwd: string, isTrusted?: boolean): void;
 }
 
 export interface IShellEnvDetectionCapability {
@@ -224,7 +230,7 @@ export interface ICommandDetectionCapability {
 	readonly onSetRichCommandDetection: Event<boolean>;
 	setContinuationPrompt(value: string): void;
 	setPromptTerminator(value: string, lastPromptLine: string): void;
-	setCwd(value: string): void;
+	setCwd(value: string, isTrusted?: boolean): void;
 	setIsWindowsPty(value: boolean): void;
 	setIsCommandStorageDisabled(): void;
 	/**

--- a/src/vs/platform/terminal/common/capabilities/capabilities.ts
+++ b/src/vs/platform/terminal/common/capabilities/capabilities.ts
@@ -230,7 +230,7 @@ export interface ICommandDetectionCapability {
 	readonly onSetRichCommandDetection: Event<boolean>;
 	setContinuationPrompt(value: string): void;
 	setPromptTerminator(value: string, lastPromptLine: string): void;
-	setCwd(value: string, isTrusted?: boolean): void;
+	setCwd(value: string): void;
 	setIsWindowsPty(value: boolean): void;
 	setIsCommandStorageDisabled(): void;
 	/**

--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -28,6 +28,7 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 
 	protected _commands: TerminalCommand[] = [];
 	private _cwd: string | undefined;
+	private _cwdIsTrusted = true;
 	private _promptTerminator: string | undefined;
 	private _currentCommand: PartialTerminalCommand;
 	private _commandMarkers: IMarker[] = [];
@@ -213,8 +214,9 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 		this._promptInputModel.setLastPromptLine(lastPromptLine);
 	}
 
-	setCwd(value: string) {
+	setCwd(value: string, isTrusted: boolean = true) {
 		this._cwd = value;
+		this._cwdIsTrusted = isTrusted;
 	}
 
 	setIsWindowsPty(value: boolean) {

--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -28,7 +28,6 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 
 	protected _commands: TerminalCommand[] = [];
 	private _cwd: string | undefined;
-	private _cwdIsTrusted = true;
 	private _promptTerminator: string | undefined;
 	private _currentCommand: PartialTerminalCommand;
 	private _commandMarkers: IMarker[] = [];
@@ -214,9 +213,8 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 		this._promptInputModel.setLastPromptLine(lastPromptLine);
 	}
 
-	setCwd(value: string, isTrusted: boolean = true) {
+	setCwd(value: string) {
 		this._cwd = value;
-		this._cwdIsTrusted = isTrusted;
 	}
 
 	setIsWindowsPty(value: boolean) {

--- a/src/vs/platform/terminal/common/capabilities/cwdDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/cwdDetectionCapability.ts
@@ -10,6 +10,7 @@ import { ICwdDetectionCapability, TerminalCapability } from './capabilities.js';
 export class CwdDetectionCapability extends Disposable implements ICwdDetectionCapability {
 	readonly type = TerminalCapability.CwdDetection;
 	private _cwd = '';
+	private _isTrusted = true;
 	private _cwds = new Map</*cwd*/string, /*frequency*/number>();
 
 	/**
@@ -19,6 +20,10 @@ export class CwdDetectionCapability extends Disposable implements ICwdDetectionC
 		return Array.from(this._cwds.keys());
 	}
 
+	get isTrusted(): boolean {
+		return this._isTrusted;
+	}
+
 	private readonly _onDidChangeCwd = this._register(new Emitter<string>());
 	readonly onDidChangeCwd = this._onDidChangeCwd.event;
 
@@ -26,9 +31,10 @@ export class CwdDetectionCapability extends Disposable implements ICwdDetectionC
 		return this._cwd;
 	}
 
-	updateCwd(cwd: string): void {
+	updateCwd(cwd: string, isTrusted: boolean = true): void {
 		const didChange = this._cwd !== cwd;
 		this._cwd = cwd;
+		this._isTrusted = isTrusted;
 		const count = this._cwds.get(this._cwd) || 0;
 		this._cwds.delete(this._cwd); // Delete to put it at the bottom of the iterable
 		this._cwds.set(this._cwd, count + 1);

--- a/src/vs/platform/terminal/common/capabilities/cwdDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/cwdDetectionCapability.ts
@@ -32,7 +32,7 @@ export class CwdDetectionCapability extends Disposable implements ICwdDetectionC
 	}
 
 	updateCwd(cwd: string, isTrusted: boolean = true): void {
-		const didChange = this._cwd !== cwd;
+		const didChange = this._cwd !== cwd || this._isTrusted !== isTrusted;
 		this._cwd = cwd;
 		this._isTrusted = isTrusted;
 		const count = this._cwds.get(this._cwd) || 0;

--- a/src/vs/platform/terminal/common/xterm/shellIntegrationAddon.ts
+++ b/src/vs/platform/terminal/common/xterm/shellIntegrationAddon.ts
@@ -653,7 +653,7 @@ export class ShellIntegrationAddon extends Disposable implements IShellIntegrati
 		value = sanitizeCwd(value);
 		this._createOrGetCwdDetection().updateCwd(value, isTrusted);
 		const commandDetection = this.capabilities.get(TerminalCapability.CommandDetection);
-		commandDetection?.setCwd(value, isTrusted);
+		commandDetection?.setCwd(value);
 	}
 
 	private _doHandleITermSequence(data: string): boolean {
@@ -759,7 +759,7 @@ export class ShellIntegrationAddon extends Disposable implements IShellIntegrati
 		commandDetection.deserialize(serialized);
 		if (commandDetection.cwd) {
 			// Cwd gets set when the command is deserialized, so we need to update it here
-			this._updateCwd(commandDetection.cwd);
+			this._updateCwd(commandDetection.cwd, false);
 		}
 	}
 

--- a/src/vs/platform/terminal/common/xterm/shellIntegrationAddon.ts
+++ b/src/vs/platform/terminal/common/xterm/shellIntegrationAddon.ts
@@ -581,7 +581,12 @@ export class ShellIntegrationAddon extends Disposable implements IShellIntegrati
 						return true;
 					}
 					case 'Cwd': {
-						this._updateCwd(value);
+						// OSC 633 ; P ; Cwd=<value> ; <nonce> ST — the nonce is optional and only
+						// present when emitted by a trusted shell integration script. CWD updates
+						// without a matching nonce are treated as untrusted to mitigate spoofing
+						// via OSC sequences injected through arbitrary terminal output.
+						const nonce = args[1];
+						this._updateCwd(value, nonce !== undefined && nonce === this._nonce);
 						return true;
 					}
 					case 'IsWindows': {
@@ -644,11 +649,11 @@ export class ShellIntegrationAddon extends Disposable implements IShellIntegrati
 		}
 	}
 
-	private _updateCwd(value: string) {
+	private _updateCwd(value: string, isTrusted: boolean = true) {
 		value = sanitizeCwd(value);
-		this._createOrGetCwdDetection().updateCwd(value);
+		this._createOrGetCwdDetection().updateCwd(value, isTrusted);
 		const commandDetection = this.capabilities.get(TerminalCapability.CommandDetection);
-		commandDetection?.setCwd(value);
+		commandDetection?.setCwd(value, isTrusted);
 	}
 
 	private _doHandleITermSequence(data: string): boolean {
@@ -675,8 +680,9 @@ export class ShellIntegrationAddon extends Disposable implements IShellIntegrati
 
 				switch (key) {
 					case ITermOscPt.CurrentDir:
-						// Encountered: `OSC 1337 ; CurrentDir=<Cwd> ST`
-						this._updateCwd(value);
+						// Encountered: `OSC 1337 ; CurrentDir=<Cwd> ST`. The iTerm2 protocol has no
+						// nonce, so cwd updates received this way are always considered untrusted.
+						this._updateCwd(value, false);
 						return true;
 				}
 			}
@@ -695,9 +701,10 @@ export class ShellIntegrationAddon extends Disposable implements IShellIntegrati
 		this._markSequenceSeen(`${ShellIntegrationOscPs.SetWindowsFriendlyCwd};${command}`);
 		switch (command) {
 			case '9':
-				// Encountered `OSC 9 ; 9 ; <cwd> ST`
+				// Encountered `OSC 9 ; 9 ; <cwd> ST`. The ConEmu/Windows-friendly cwd protocol
+				// has no nonce, so cwd updates received this way are always considered untrusted.
 				if (args.length) {
-					this._updateCwd(args[0]);
+					this._updateCwd(args[0], false);
 				}
 				return true;
 		}
@@ -720,7 +727,9 @@ export class ShellIntegrationAddon extends Disposable implements IShellIntegrati
 		if (command.match(/^file:\/\/.*\//)) {
 			const uri = URI.parse(command);
 			if (uri.path && uri.path.length > 0) {
-				this._updateCwd(uri.path);
+				// The `OSC 7 ; scheme://cwd ST` protocol has no nonce, so cwd updates received
+				// this way are always considered untrusted.
+				this._updateCwd(uri.path, false);
 				return true;
 			}
 		}

--- a/src/vs/workbench/contrib/terminal/test/browser/terminalEvents.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/terminalEvents.test.ts
@@ -16,6 +16,7 @@ import { ITerminalInstance } from '../../browser/terminal.js';
 class MockCwdDetectionCapability implements ICwdDetectionCapability {
 	readonly type = TerminalCapability.CwdDetection;
 	readonly cwds: string[] = [];
+	readonly isTrusted = true;
 
 	private readonly _onDidChangeCwd = new Emitter<string>();
 	readonly onDidChangeCwd = this._onDidChangeCwd.event;

--- a/src/vs/workbench/contrib/terminal/test/browser/xterm/shellIntegrationAddon.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/xterm/shellIntegrationAddon.test.ts
@@ -225,7 +225,7 @@ suite('ShellIntegrationAddon', () => {
 		});
 		test('should pass cwd sequence to the capability if it\'s initialized', async () => {
 			const mock = shellIntegrationAddon.getCommandDetectionMock(xterm);
-			mock.expects('setCwd').once().withExactArgs('/foo', false);
+			mock.expects('setCwd').once().withExactArgs('/foo');
 			await writeP(xterm, '\x1b]633;P;Cwd=/foo\x07');
 			mock.verify();
 		});

--- a/src/vs/workbench/contrib/terminal/test/browser/xterm/shellIntegrationAddon.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/xterm/shellIntegrationAddon.test.ts
@@ -53,8 +53,22 @@ suite('ShellIntegrationAddon', () => {
 
 		test('should pass cwd sequence to the capability', async () => {
 			const mock = shellIntegrationAddon.getCwdDectionMock();
-			mock.expects('updateCwd').once().withExactArgs('/foo');
+			mock.expects('updateCwd').once().withExactArgs('/foo', false);
 			await writeP(xterm, '\x1b]633;P;Cwd=/foo\x07');
+			mock.verify();
+		});
+
+		test('should treat cwd sequence as untrusted when nonce is missing', async () => {
+			const mock = shellIntegrationAddon.getCwdDectionMock();
+			mock.expects('updateCwd').once().withExactArgs('/foo', false);
+			await writeP(xterm, '\x1b]633;P;Cwd=/foo\x07');
+			mock.verify();
+		});
+
+		test('should treat cwd sequence as untrusted when nonce does not match', async () => {
+			const mock = shellIntegrationAddon.getCwdDectionMock();
+			mock.expects('updateCwd').once().withExactArgs('/foo', false);
+			await writeP(xterm, '\x1b]633;P;Cwd=/foo;invalid-nonce\x07');
 			mock.verify();
 		});
 
@@ -67,7 +81,7 @@ suite('ShellIntegrationAddon', () => {
 			for (const x of cases) {
 				const [title, input, expected] = x;
 				const mock = shellIntegrationAddon.getCwdDectionMock();
-				mock.expects('updateCwd').once().withExactArgs(expected).named(title);
+				mock.expects('updateCwd').once().withExactArgs(expected, false).named(title);
 				await writeP(xterm, `\x1b]1337;CurrentDir=${input}\x07`);
 				mock.verify();
 			}
@@ -89,7 +103,7 @@ suite('ShellIntegrationAddon', () => {
 				for (const x of cases) {
 					const [title, input, expected] = x;
 					const mock = shellIntegrationAddon.getCwdDectionMock();
-					mock.expects('updateCwd').once().withExactArgs(expected).named(title);
+					mock.expects('updateCwd').once().withExactArgs(expected, false).named(title);
 					await writeP(xterm, `\x1b]7;${input}\x07`);
 					mock.verify();
 				}
@@ -129,7 +143,7 @@ suite('ShellIntegrationAddon', () => {
 			for (const x of cases) {
 				const [title, input, expected] = x;
 				const mock = shellIntegrationAddon.getCwdDectionMock();
-				mock.expects('updateCwd').once().withExactArgs(expected).named(title);
+				mock.expects('updateCwd').once().withExactArgs(expected, false).named(title);
 				await writeP(xterm, `\x1b]9;9;${input}\x07`);
 				mock.verify();
 			}
@@ -210,7 +224,7 @@ suite('ShellIntegrationAddon', () => {
 		});
 		test('should pass cwd sequence to the capability if it\'s initialized', async () => {
 			const mock = shellIntegrationAddon.getCommandDetectionMock(xterm);
-			mock.expects('setCwd').once().withExactArgs('/foo');
+			mock.expects('setCwd').once().withExactArgs('/foo', false);
 			await writeP(xterm, '\x1b]633;P;Cwd=/foo\x07');
 			mock.verify();
 		});

--- a/src/vs/workbench/contrib/terminal/test/browser/xterm/shellIntegrationAddon.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/xterm/shellIntegrationAddon.test.ts
@@ -51,10 +51,11 @@ suite('ShellIntegrationAddon', () => {
 			strictEqual(capabilities.has(TerminalCapability.CwdDetection), true);
 		});
 
-		test('should pass cwd sequence to the capability', async () => {
+		test('should pass cwd sequence to the capability as trusted when nonce matches', async () => {
 			const mock = shellIntegrationAddon.getCwdDectionMock();
-			mock.expects('updateCwd').once().withExactArgs('/foo', false);
-			await writeP(xterm, '\x1b]633;P;Cwd=/foo\x07');
+			// The addon is constructed with nonce '' so a trailing ';' produces args[1]==='' which matches
+			mock.expects('updateCwd').once().withExactArgs('/foo', true);
+			await writeP(xterm, '\x1b]633;P;Cwd=/foo;\x07');
 			mock.verify();
 		});
 

--- a/src/vs/workbench/contrib/testing/browser/testResultsView/testResultsOutput.ts
+++ b/src/vs/workbench/contrib/testing/browser/testResultsView/testResultsOutput.ts
@@ -451,6 +451,7 @@ export class TerminalMessagePeek extends Disposable implements IPeekOutputRender
 		const cwd = this.terminalCwd;
 		capabilities.add(TerminalCapability.CwdDetection, {
 			type: TerminalCapability.CwdDetection,
+			isTrusted: true,
 			get cwds() { return [cwd.value]; },
 			onDidChangeCwd: cwd.onDidChange,
 			getCwd: () => cwd.value,


### PR DESCRIPTION
Fixes a spoofing issue where any terminal output could inject CWD changes by emitting OSC escape sequences. The OSC 633 `Property;Cwd` handler did not validate a nonce, unlike the other VS Code shell integration commands (CommandLine, EnvJson, EnvSingle*).

## Changes

- **OSC 633 `Property;Cwd`**: now parses `args[1]` as a nonce and only marks the CWD update trusted when it matches `this._nonce` (matching the pattern used by CommandLine/Env* handlers).
- **OSC 7 (`_doHandleSetCwd`)**, **OSC 9;9 (`_doHandleSetWindowsFriendlyCwd`)**, **OSC 1337 (`_doHandleITermSequence`)**: these protocols have no nonce in their wire format, so all CWD updates from them are now marked untrusted.
- Plumbs `isTrusted` through `_updateCwd` → `ICwdDetectionCapability.updateCwd` and `ICommandDetectionCapability.setCwd`, exposing the flag on both capabilities so downstream features (link resolution, workspace-folder derivation, etc.) can consume it later.

## Impact

This addresses the baseline finder report. Per the assessment, workspace trust is unaffected (it is independent of terminal CWD tracking) — the actual impact is limited to **spoofing via relative-link redirection**, rated Low. The full fix (gating link resolution on `isTrusted`) is intentionally out of scope here: it would risk breaking intended functionality on shells that don't yet emit the nonce, and the trust signal is now available for an incremental follow-up.

## Tests

- Updated `shellIntegrationAddon.test.ts` to assert the new `isTrusted=false` argument for all four protocol handlers, plus a new case for an invalid nonce on Property;Cwd.
- Added `readonly isTrusted` to the `MockCwdDetectionCapability` in `terminalEvents.test.ts`.
- `./scripts/test.sh --grep "ShellIntegrationAddon|cwd|Cwd"` passes locally.