### PR TITLE
Always register built-in chat tools (drop when: gates)

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -994,7 +994,6 @@
 				"icon": "$(notebook-render-output)",
 				"modelDescription": "This tool will retrieve the output for a notebook cell from its most recent execution or restored from disk. The cell may have output even when it has not been run in the current kernel session. This tool has a higher token limit for output length than the runNotebookCell tool.",
 				"userDescription": "%copilot.tools.getNotebookCellOutput.description%",
-				"when": "userHasOpenedNotebook",
 				"tags": [],
 				"inputSchema": {
 					"type": "object",

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -1583,24 +1583,6 @@ configurationRegistry.registerConfiguration({
 				mode: 'auto'
 			}
 		},
-		'chat.tools.usagesTool.enabled': {
-			type: 'boolean',
-			default: true,
-			markdownDescription: nls.localize('chat.tools.usagesTool.enabled', "Controls whether the usages tool is available for finding references, definitions, and implementations of code symbols."),
-			tags: ['preview'],
-			experiment: {
-				mode: 'auto'
-			}
-		},
-		'chat.tools.renameTool.enabled': {
-			type: 'boolean',
-			default: true,
-			markdownDescription: nls.localize('chat.tools.renameTool.enabled', "Controls whether the rename tool is available for renaming code symbols across the workspace."),
-			tags: ['preview'],
-			experiment: {
-				mode: 'auto'
-			}
-		},
 		[ChatConfiguration.ThinkingPhrases]: {
 			type: 'object',
 			default: {

--- a/src/vs/workbench/contrib/chat/browser/tools/renameTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/renameTool.ts
@@ -16,7 +16,6 @@ import { ILanguageFeaturesService } from '../../../../../editor/common/services/
 import { ITextModelService } from '../../../../../editor/common/services/resolverService.js';
 import { rename } from '../../../../../editor/contrib/rename/browser/rename.js';
 import { localize } from '../../../../../nls.js';
-import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { IWorkbenchContribution } from '../../../../common/contributions.js';
@@ -83,7 +82,6 @@ export class RenameTool extends Disposable implements IToolImpl {
 			userDescription,
 			modelDescription,
 			source: ToolDataSource.Internal,
-			when: ContextKeyExpr.has('config.chat.tools.renameTool.enabled'),
 			inputSchema: {
 				type: 'object',
 				properties: {

--- a/src/vs/workbench/contrib/chat/browser/tools/usagesTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/usagesTool.ts
@@ -19,7 +19,6 @@ import { ILanguageFeaturesService } from '../../../../../editor/common/services/
 import { ITextModelService } from '../../../../../editor/common/services/resolverService.js';
 import { getDefinitionsAtPosition, getImplementationsAtPosition, getReferencesAtPosition } from '../../../../../editor/contrib/gotoSymbol/browser/goToSymbol.js';
 import { localize } from '../../../../../nls.js';
-import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { IWorkbenchContribution } from '../../../../common/contributions.js';
@@ -80,7 +79,6 @@ export class UsagesTool extends Disposable implements IToolImpl {
 			userDescription,
 			modelDescription,
 			source: ToolDataSource.Internal,
-			when: ContextKeyExpr.has('config.chat.tools.usagesTool.enabled'),
 			inputSchema: {
 				type: 'object',
 				properties: {

--- a/src/vs/workbench/contrib/chat/common/tools/builtinTools/resolveDebugEventDetailsTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/builtinTools/resolveDebugEventDetailsTool.ts
@@ -5,7 +5,6 @@
 
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { localize } from '../../../../../../nls.js';
-import { ChatContextKeys } from '../../actions/chatContextKeys.js';
 import { ChatDebugHookResult, IChatDebugEvent, IChatDebugResolvedEventContent, IChatDebugService } from '../../chatDebugService.js';
 import { CountTokensCallback, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolInvocationPreparationContext, IToolResult, ToolDataSource, ToolProgress } from '../languageModelToolsService.js';
 
@@ -15,7 +14,6 @@ export const ResolveDebugEventDetailsToolData: IToolData = {
 	id: ResolveDebugEventDetailsToolId,
 	toolReferenceName: 'resolveDebugEventDetails',
 	displayName: localize('resolveDebugEventDetails.displayName', "Resolve Debug Event Details"),
-	when: ChatContextKeys.chatSessionHasDebugTools,
 	canBeReferencedInPrompt: false,
 	modelDescription: 'Resolves the full details for a specific chat debug event by its event ID. Use this tool to get detailed information about a debug event such as tool call input/output, model turn details, user message sections, or file lists. The event ID can be found in the debug event log summary provided in the conversation context.',
 	source: ToolDataSource.Internal,

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/getTaskOutputTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/getTaskOutputTool.ts
@@ -12,7 +12,7 @@ import { IConfigurationService } from '../../../../../../../platform/configurati
 import { IInstantiationService } from '../../../../../../../platform/instantiation/common/instantiation.js';
 import { ITelemetryService } from '../../../../../../../platform/telemetry/common/telemetry.js';
 import { ToolDataSource, type CountTokensCallback, type IPreparedToolInvocation, type IToolData, type IToolImpl, type IToolInvocation, type IToolInvocationPreparationContext, type IToolResult, type ToolProgress } from '../../../../../chat/common/tools/languageModelToolsService.js';
-import { ITaskService, Task, TasksAvailableContext } from '../../../../../tasks/common/taskService.js';
+import { ITaskService, Task } from '../../../../../tasks/common/taskService.js';
 import { ITerminalService } from '../../../../../terminal/browser/terminal.js';
 import { collectTerminalResults, getTaskDefinition, getTaskForTool, resolveDependencyTasks, tasksMatch } from '../../taskHelpers.js';
 import { toolResultDetailsFromResponse, toolResultMessageFromResponse } from './taskHelpers.js';
@@ -26,7 +26,6 @@ export const GetTaskOutputToolData: IToolData = {
 	displayName: localize('getTaskOutputTool.displayName', 'Get Task Output'),
 	modelDescription: 'Get the output of a task',
 	source: ToolDataSource.Internal,
-	when: TasksAvailableContext,
 	inputSchema: {
 		type: 'object',
 		properties: {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/runTaskTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/runTaskTool.ts
@@ -8,7 +8,7 @@ import { CancellationToken } from '../../../../../../../base/common/cancellation
 import { localize } from '../../../../../../../nls.js';
 import { ITelemetryService } from '../../../../../../../platform/telemetry/common/telemetry.js';
 import { CountTokensCallback, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolInvocationPreparationContext, IToolResult, ToolDataSource, ToolProgress } from '../../../../../chat/common/tools/languageModelToolsService.js';
-import { ITaskService, ITaskSummary, Task, TasksAvailableContext } from '../../../../../tasks/common/taskService.js';
+import { ITaskService, ITaskSummary, Task } from '../../../../../tasks/common/taskService.js';
 import { TaskRunSource } from '../../../../../tasks/common/tasks.js';
 import { ITerminalInstance, ITerminalService } from '../../../../../terminal/browser/terminal.js';
 import { collectTerminalResults, getTaskDefinition, getTaskForTool, resolveDependencyTasks, tasksMatch } from '../../taskHelpers.js';
@@ -173,7 +173,6 @@ export const RunTaskToolData: IToolData = {
 	userDescription: localize('runInTerminalTool.userDescription', 'Run tasks in the workspace'),
 	icon: Codicon.tools,
 	source: ToolDataSource.Internal,
-	when: TasksAvailableContext,
 	inputSchema: {
 		'type': 'object',
 		'properties': {

--- a/src/vs/workbench/contrib/testing/common/testingChatAgentTool.ts
+++ b/src/vs/workbench/contrib/testing/common/testingChatAgentTool.ts
@@ -31,7 +31,6 @@ import {
 } from '../../chat/common/tools/languageModelToolsService.js';
 import { TestId } from './testId.js';
 import { FileCoverage, TestCoverage, getTotalCoveragePercent } from './testCoverage.js';
-import { TestingContextKeys } from './testingContextKeys.js';
 import { collectTestStateCounts, getTestProgressText } from './testingProgressMessages.js';
 import { isFailedState } from './testingStates.js';
 import { ITestResult, LiveTestResult } from './testResult.js';
@@ -75,7 +74,6 @@ export class RunTestTool implements IToolImpl {
 		id: this.ID,
 		toolReferenceName: 'runTests',
 		legacyToolReferenceFullNames: ['runTests'],
-		when: TestingContextKeys.hasRunnableTests,
 		displayName: 'Run tests',
 		modelDescription: 'Runs unit tests in files. Use this tool if the user asks to run tests or when you want to validate changes using unit tests, and prefer using this tool instead of the terminal tool. When possible, always try to provide `files` paths containing the relevant unit tests in order to avoid unnecessarily long test runs. This tool outputs detailed information about the results of the test run. Set mode="coverage" to also collect coverage and optionally provide coverageFiles for focused reporting.',
 		icon: Codicon.beaker,
@@ -331,7 +329,6 @@ export class TestFailureTool implements IToolImpl {
 		id: this.ID,
 		toolReferenceName: 'testFailure',
 		legacyToolReferenceFullNames: ['copilot_testFailure'],
-		when: TestingContextKeys.hasAnyResults,
 		displayName: localize('testFailureTool.displayName', 'Test failures'),
 		modelDescription: 'Includes test failure information in the prompt. Use this tool to get the details of test failures from the most recent test run. If there are no failures yet, suggest running tests first.',
 		icon: Codicon.beaker,


### PR DESCRIPTION
Built-in tools should always be registered so the tool list is stable per session. The `when:` clauses caused tools to register/unregister at runtime (e.g. on task discovery, test runs, notebook open, debug session start), which busts the system-prompt cache mid-conversation.

Refs #316187.

## Tools touched

| Tool | File | Removed gate |
|---|---|---|
| `get_task_output` | `terminalContrib/chatAgentTools/.../getTaskOutputTool.ts` | `TasksAvailableContext` |
| `run_task` | `terminalContrib/chatAgentTools/.../runTaskTool.ts` | `TasksAvailableContext` |
| `runTests` | `testing/common/testingChatAgentTool.ts` | `TestingContextKeys.hasRunnableTests` |
| `testFailure` | `testing/common/testingChatAgentTool.ts` | `TestingContextKeys.hasAnyResults` |
| `vscode_renameSymbol` | `chat/browser/tools/renameTool.ts` | `config.chat.tools.renameTool.enabled` |
| `vscode_listCodeUsages` | `chat/browser/tools/usagesTool.ts` | `config.chat.tools.usagesTool.enabled` |
| `vscode_resolveDebugEventDetails_internal` | `chat/common/tools/builtinTools/resolveDebugEventDetailsTool.ts` | `ChatContextKeys.chatSessionHasDebugTools` |
| `copilot_readNotebookCellOutput` | `extensions/copilot/package.json` | `userHasOpenedNotebook` |

Net: **+2 / -14** lines across 7 files (also drops now-unused imports).

## Not in this PR

Other `when:` clauses on `languageModelTools[]` in `extensions/copilot/package.json` were left alone because they are either:
- static config flags users don't toggle mid-session (so they don't actually bust cache), or
- A-or-B alternates where two tool variants gate on opposing flags (`search_subagent` vs `explore_subagent`, `getProjectSetupInfo` vs project-setup skill, `installExtension` vs install-extension skill, `githubRepo` vs GitHub MCP server), or
- platform / kill-switches (`!isWeb`, `!disableReplaceTool`).

Evals show a per instance cache hit rate improvments.