### PR TITLE
build: retry TSA upload task

### DIFF
--- a/build/azure-pipelines/win32/sdl-scan-win32.yml
+++ b/build/azure-pipelines/win32/sdl-scan-win32.yml
@@ -164,6 +164,7 @@ steps:
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
     displayName: TSA Upload
     continueOnError: true
+    retryCountOnTaskFailure: 3
     inputs:
       GdnPublishTsaOnboard: true
       GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)/build/azure-pipelines/config/tsaoptions.json'


### PR DESCRIPTION
This adds `retryCountOnTaskFailure: 3` to the existing `TSAUpload@2` task in the Windows SDL scan pipeline.

The TSA upload step already exists and is marked `continueOnError: true`; this change gives transient TSA upload failures a few automatic retries before continuing, without adding a new task block or changing the broader 1ES SDL configuration.