### PR TITLE
Don't propagate custom pty title/icon updates to the pty host

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -736,7 +736,7 @@ export class TerminalService extends Disposable implements ITerminalService {
 
 	@debounce(500)
 	private _updateTitle(instance: ITerminalInstance | undefined): void {
-		if (!this._terminalConfigurationService.config.enablePersistentSessions || !instance || !instance.persistentProcessId || !instance.title || instance.isDisposed) {
+		if (!this._terminalConfigurationService.config.enablePersistentSessions || !instance || instance.shellLaunchConfig.customPtyImplementation || !instance.persistentProcessId || !instance.title || instance.isDisposed) {
 			return;
 		}
 		if (instance.staticTitle) {
@@ -748,7 +748,7 @@ export class TerminalService extends Disposable implements ITerminalService {
 
 	@debounce(500)
 	private _updateIcon(instance: ITerminalInstance, userInitiated: boolean): void {
-		if (!this._terminalConfigurationService.config.enablePersistentSessions || !instance || !instance.persistentProcessId || !instance.icon || instance.isDisposed) {
+		if (!this._terminalConfigurationService.config.enablePersistentSessions || !instance || instance.shellLaunchConfig.customPtyImplementation || !instance.persistentProcessId || !instance.icon || instance.isDisposed) {
 			return;
 		}
 		this._primaryBackend?.updateIcon(instance.persistentProcessId, userInitiated, instance.icon, instance.color);

--- a/src/vs/workbench/contrib/terminal/test/browser/terminalService.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/terminalService.test.ts
@@ -3,13 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { fail } from 'assert';
+import { fail, strictEqual } from 'assert';
 import { Emitter } from '../../../../../base/common/event.js';
+import { runWithFakedTimers } from '../../../../../base/test/common/timeTravelScheduler.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { IDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
 import { TestDialogService } from '../../../../../platform/dialogs/test/common/testDialogService.js';
-import { TerminalLocation } from '../../../../../platform/terminal/common/terminal.js';
+import { TerminalLocation, TitleEventSource, type ITerminalBackend, type TerminalIcon } from '../../../../../platform/terminal/common/terminal.js';
 import { ITerminalInstance, ITerminalInstanceService, ITerminalService } from '../../browser/terminal.js';
 import { TerminalService } from '../../browser/terminalService.js';
 import { TERMINAL_CONFIG_SECTION } from '../../common/terminal.js';
@@ -30,7 +31,8 @@ suite('Workbench - TerminalService', () => {
 			files: {},
 			terminal: {
 				integrated: {
-					confirmOnKill: 'never'
+					confirmOnKill: 'never',
+					enablePersistentSessions: true
 				}
 			}
 		});
@@ -159,6 +161,41 @@ suite('Workbench - TerminalService', () => {
 			} satisfies Partial<ITerminalInstance> as unknown as ITerminalInstance);
 		});
 	});
+
+	suite('persistent title and icon updates', () => {
+		let backend: TestPersistentTerminalBackend;
+
+		setup(() => {
+			backend = new TestPersistentTerminalBackend();
+			(terminalService as unknown as { _primaryBackend: Partial<ITerminalBackend> })._primaryBackend = backend;
+		});
+
+		test('should not update pty host metadata for custom pty terminals', async () => {
+			const instance = createTerminalInstance({ customPtyImplementation: true });
+
+			await runWithFakedTimers({}, async () => {
+				updateTitle(terminalService, instance);
+				updateIcon(terminalService, instance, false);
+			});
+
+			strictEqual(backend.titleUpdateCount, 0);
+			strictEqual(backend.iconUpdateCount, 0);
+		});
+
+		test('should update pty host metadata for regular pty terminals', async () => {
+			const instance = createTerminalInstance();
+
+			await runWithFakedTimers({}, async () => {
+				updateTitle(terminalService, instance);
+				updateIcon(terminalService, instance, true);
+			});
+
+			strictEqual(backend.titleUpdateCount, 1);
+			strictEqual(backend.iconUpdateCount, 1);
+			strictEqual(backend.lastTitle, 'terminal title');
+			strictEqual(backend.lastIconUserInitiated, true);
+		});
+	});
 });
 
 async function setConfirmOnKill(configurationService: TestConfigurationService, value: 'never' | 'always' | 'panel' | 'editor') {
@@ -167,4 +204,46 @@ async function setConfirmOnKill(configurationService: TestConfigurationService, 
 		affectsConfiguration: () => true,
 		affectedKeys: ['terminal.integrated.confirmOnKill']
 	} as unknown as IConfigurationChangeEvent);
+}
+
+class TestPersistentTerminalBackend implements Partial<ITerminalBackend> {
+	titleUpdateCount = 0;
+	iconUpdateCount = 0;
+	lastTitle: string | undefined;
+	lastIconUserInitiated: boolean | undefined;
+
+	async updateTitle(_id: number, title: string, _titleSource: TitleEventSource): Promise<void> {
+		this.titleUpdateCount++;
+		this.lastTitle = title;
+	}
+
+	async updateIcon(_id: number, userInitiated: boolean, _icon: TerminalIcon, _color?: string): Promise<void> {
+		this.iconUpdateCount++;
+		this.lastIconUserInitiated = userInitiated;
+	}
+}
+
+function createTerminalInstance(options?: { customPtyImplementation?: boolean }): ITerminalInstance {
+	return {
+		persistentProcessId: 13,
+		title: 'terminal title',
+		titleSource: TitleEventSource.Process,
+		staticTitle: undefined,
+		icon: { id: 'remote' },
+		color: undefined,
+		isDisposed: false,
+		shellLaunchConfig: options?.customPtyImplementation
+			? { customPtyImplementation: () => { throw new Error('should not be called'); } }
+			: {},
+	} satisfies Partial<ITerminalInstance> as unknown as ITerminalInstance;
+}
+
+function updateTitle(terminalService: TerminalService, instance: ITerminalInstance): void {
+	const fn = Reflect.get(terminalService, '_updateTitle') as (instance: ITerminalInstance) => void;
+	fn.call(terminalService, instance);
+}
+
+function updateIcon(terminalService: TerminalService, instance: ITerminalInstance, userInitiated: boolean): void {
+	const fn = Reflect.get(terminalService, '_updateIcon') as (instance: ITerminalInstance, userInitiated: boolean) => void;
+	fn.call(terminalService, instance, userInitiated);
 }


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/314809 

For agent host ptys, they are not owned by traditional pty host + ptyservice, but rather agentHostTerminalManager.

-----------------------------------------
Inspirations from:

- Agent Host terminal ownership comes from [`AgentHostPty`](https://github.com/microsoft/vscode/blob/4f3eea00277fdacddf0dcca1cc51060b54103464/src/vs/workbench/contrib/terminal/browser/agentHostPty.ts#L82-L86), which documents that Agent Host custom PTYs bypass the pty host backend.

Follow-up: https://github.com/microsoft/vscode/issues/316486 


/cc @meganrogge 