### PR TITLE
Remove compression banners to prevent model refetch - rm grep/tree/find filters for now

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/tools/toolResultCompressorService.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/toolResultCompressorService.ts
@@ -177,13 +177,19 @@ export class ToolResultCompressorService extends Disposable implements IToolResu
 
 			totalAfter += current.length;
 			if (current !== original) {
-				anyCompressed = true;
 				// Prepend a banner so the model knows the output was filtered, by
 				// which filters, and how to disable compression. We only annotate
 				// the parts we actually changed — non-compressed parts pass through
 				// untouched.
 				const banner = formatCompressionBanner(partFilterIds, original.length, current.length);
 				const annotated = `${banner}\n${current}`;
+				// Only apply compression if the savings exceed the banner overhead.
+				// Otherwise the "compressed" result is actually larger.
+				if (annotated.length >= original.length) {
+					totalAfter = totalAfter - current.length + original.length;
+					return part;
+				}
+				anyCompressed = true;
 				const rewritten: IToolResultTextPart = {
 					kind: 'text',
 					value: annotated,
@@ -200,7 +206,16 @@ export class ToolResultCompressorService extends Disposable implements IToolResu
 			return undefined;
 		}
 
-		this._sendTelemetry(toolId, [...usedFilterIds], totalBefore, totalAfter, false);
+		// Guard: don't return a "compressed" result if banner overhead makes it
+		// larger than the original. This is the primary cause of increased token
+		// usage — short savings get wiped out by per-part banners.
+		const actualAfter = newContent.reduce((acc, p) => acc + (p.kind === 'text' ? p.value.length : 0), 0);
+		if (actualAfter >= totalBefore) {
+			this._recordInCaches(toolId, input, result, caches);
+			return undefined;
+		}
+
+		this._sendTelemetry(toolId, [...usedFilterIds], totalBefore, actualAfter, false);
 
 		const finalResult: IToolResult = {
 			...result,

--- a/src/vs/workbench/contrib/chat/browser/tools/toolResultCompressorService.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/toolResultCompressorService.ts
@@ -10,7 +10,7 @@ import { ILogService } from '../../../../../platform/log/common/log.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { ChatConfiguration } from '../../common/constants.js';
 import { IToolResult, IToolResultTextPart } from '../../common/tools/languageModelToolsService.js';
-import { formatCompressionBanner, IToolResultCache, IToolResultCompressor, IToolResultFilter, isProtectedFromCompression, MIN_COMPRESSIBLE_LENGTH } from '../../common/tools/toolResultCompressor.js';
+import { IToolResultCache, IToolResultCompressor, IToolResultFilter, isProtectedFromCompression, MIN_COMPRESSIBLE_LENGTH } from '../../common/tools/toolResultCompressor.js';
 
 type ToolResultCompressedClassification = {
 	owner: 'meganrogge';
@@ -177,22 +177,10 @@ export class ToolResultCompressorService extends Disposable implements IToolResu
 
 			totalAfter += current.length;
 			if (current !== original) {
-				// Prepend a banner so the model knows the output was filtered, by
-				// which filters, and how to disable compression. We only annotate
-				// the parts we actually changed — non-compressed parts pass through
-				// untouched.
-				const banner = formatCompressionBanner(partFilterIds, original.length, current.length);
-				const annotated = `${banner}\n${current}`;
-				// Only apply compression if the savings exceed the banner overhead.
-				// Otherwise the "compressed" result is actually larger.
-				if (annotated.length >= original.length) {
-					totalAfter = totalAfter - current.length + original.length;
-					return part;
-				}
 				anyCompressed = true;
 				const rewritten: IToolResultTextPart = {
 					kind: 'text',
-					value: annotated,
+					value: current,
 					audience: part.audience,
 					title: part.title,
 				};
@@ -206,16 +194,7 @@ export class ToolResultCompressorService extends Disposable implements IToolResu
 			return undefined;
 		}
 
-		// Guard: don't return a "compressed" result if banner overhead makes it
-		// larger than the original. This is the primary cause of increased token
-		// usage — short savings get wiped out by per-part banners.
-		const actualAfter = newContent.reduce((acc, p) => acc + (p.kind === 'text' ? p.value.length : 0), 0);
-		if (actualAfter >= totalBefore) {
-			this._recordInCaches(toolId, input, result, caches);
-			return undefined;
-		}
-
-		this._sendTelemetry(toolId, [...usedFilterIds], totalBefore, actualAfter, false);
+		this._sendTelemetry(toolId, [...usedFilterIds], totalBefore, totalAfter, false);
 
 		const finalResult: IToolResult = {
 			...result,
@@ -227,7 +206,7 @@ export class ToolResultCompressorService extends Disposable implements IToolResu
 
 	private _buildCacheHitResult(original: IToolResult, hit: { text: string; timestamp: number }): IToolResult {
 		const iso = new Date(hit.timestamp).toISOString();
-		const text = `Same output as last run (${iso}). To disable, set ${ChatConfiguration.CompressOutputEnabled} to false.`;
+		const text = `Same output as last run (${iso}).`;
 		// Preserve the first text part's audience metadata so downstream
 		// model-routing logic still behaves the same way.
 		const firstText = original.content.find((p): p is IToolResultTextPart => p.kind === 'text');

--- a/src/vs/workbench/contrib/chat/browser/tools/toolResultCompressorService.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/toolResultCompressorService.ts
@@ -205,8 +205,12 @@ export class ToolResultCompressorService extends Disposable implements IToolResu
 	}
 
 	private _buildCacheHitResult(original: IToolResult, hit: { text: string; timestamp: number }): IToolResult {
-		const iso = new Date(hit.timestamp).toISOString();
-		const text = `Same output as last run (${iso}).`;
+		// Show a preview of the cached output so the model has context, plus
+		// "(unchanged)" — mirrors ztk's dedup approach. Avoids timestamps or
+		// settings references that waste tokens.
+		const MAX_PREVIEW = 200;
+		const preview = hit.text.length <= MAX_PREVIEW ? hit.text : hit.text.slice(0, MAX_PREVIEW);
+		const text = `${preview} (unchanged)`;
 		// Preserve the first text part's audience metadata so downstream
 		// model-routing logic still behaves the same way.
 		const firstText = original.content.find((p): p is IToolResultTextPart => p.kind === 'text');

--- a/src/vs/workbench/contrib/chat/browser/tools/toolResultCompressorService.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/toolResultCompressorService.ts
@@ -209,7 +209,7 @@ export class ToolResultCompressorService extends Disposable implements IToolResu
 		// "(unchanged)" — mirrors ztk's dedup approach. Avoids timestamps or
 		// settings references that waste tokens.
 		const MAX_PREVIEW = 200;
-		const preview = hit.text.length <= MAX_PREVIEW ? hit.text : hit.text.slice(0, MAX_PREVIEW);
+		const preview = hit.text.length <= MAX_PREVIEW ? hit.text : hit.text.slice(0, MAX_PREVIEW) + '…';
 		const text = `${preview} (unchanged)`;
 		// Preserve the first text part's audience metadata so downstream
 		// model-routing logic still behaves the same way.

--- a/src/vs/workbench/contrib/chat/common/tools/toolResultCompressor.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/toolResultCompressor.ts
@@ -125,17 +125,8 @@ export function isProtectedFromCompression(text: string): boolean {
 /**
  * Outputs below this many characters (UTF-16 code units, i.e.
  * `string.length`) are not worth compressing: filter savings on short
- * outputs rarely outweigh the banner overhead, and skipping them avoids
+ * outputs rarely outweigh the overhead, and skipping them avoids
  * the agent issuing redundant `read_file` / `get_terminal_output` calls
  * to recover content that would have fit uncompressed.
  */
 export const MIN_COMPRESSIBLE_LENGTH = 1024;
-
-/**
- * Format the banner that gets prepended to compressed text parts so the
- * model knows compression happened, which filters fired, and how to opt out.
- */
-export function formatCompressionBanner(filterIds: readonly string[], beforeChars: number, afterChars: number): string {
-	const ids = filterIds.length > 0 ? filterIds.join(', ') : 'unknown';
-	return `[Output compressed by ${ids} (${beforeChars} → ${afterChars} chars). To disable, set chat.tools.compressOutput.enabled to false.]`;
-}

--- a/src/vs/workbench/contrib/chat/test/browser/tools/toolResultCompressorService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/tools/toolResultCompressorService.test.ts
@@ -89,13 +89,11 @@ suite('ToolResultCompressorService', () => {
 		strictEqual(calls, 1);
 		strictEqual(log.warnings.length, 1);
 		ok(log.warnings[0].includes('thrower'));
-		// The other filter still rewrites every text part. Each emitted part starts
-		// with the compression banner and ends with the filter's replacement text.
+		// The other filter still rewrites every text part.
 		for (const part of out!.content) {
 			strictEqual(part.kind, 'text');
 			const value = (part as { value: string }).value;
-			ok(/^\[Output compressed by test\.replaceWithFoo /.test(value));
-			ok(value.endsWith('\nfoo'));
+			strictEqual(value, 'foo');
 		}
 	});
 
@@ -109,8 +107,7 @@ suite('ToolResultCompressorService', () => {
 		strictEqual(out!.content[0], dataPart);
 		strictEqual(out!.content[1].kind, 'text');
 		const value = (out!.content[1] as IToolResultTextPart).value;
-		ok(/^\[Output compressed by test\.replaceWithFoo /.test(value));
-		ok(value.endsWith('\nfoo'));
+		strictEqual(value, 'foo');
 	});
 
 	test('preserves text part audience metadata when rewriting', () => {
@@ -122,8 +119,7 @@ suite('ToolResultCompressorService', () => {
 		ok(out);
 		strictEqual(out!.content[0].kind, 'text');
 		const part = out!.content[0] as IToolResultTextPart;
-		ok(/^\[Output compressed by test\.replaceWithFoo /.test(part.value));
-		ok(part.value.endsWith('\nfoo'));
+		strictEqual(part.value, 'foo');
 		strictEqual(part.audience, audience);
 	});
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/terminalOutputCompressor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/terminalOutputCompressor.ts
@@ -655,9 +655,6 @@ export function registerTerminalCompressors(compressor: IToolResultCompressor): 
 	compressor.registerFilter(gitStatusFilter);
 	// File ops
 	compressor.registerFilter(lsFilter);
-	compressor.registerFilter(findFilter);
-	compressor.registerFilter(grepFilter);
-	compressor.registerFilter(treeFilter);
 	// Test / build / lint
 	compressor.registerFilter(testRunnerFilter);
 	compressor.registerFilter(buildToolFilter);


### PR DESCRIPTION
## Summary

Code hygiene and correctness improvements to terminal output compression. Eval results show no measurable impact on token cost (Δ = −5.1%, 95% CI [−45%, +35%], not significant at n=10 seeds).

### Changes

1. **Remove compression banners** — the banner text (`[Output compressed by ... To disable, set ...]`) is noise in tool output that the model does not need. Compressed output is now returned silently, matching [ztk](https://github.com/codejunkie99/ztk)'s approach.

2. **Remove find/grep/tree filters** — these filters naively cap output at 200 lines, silently dropping results past that limit. With silent compression, the model has no way to know results were lost, which is a **correctness problem** — the agent could miss matches or files it needs. Tracked in #316502 to reintroduce with smart summarization (grouping by directory/file like ztk, instead of line capping).

3. **Simplify cache dedup message** — show a preview of the cached output (up to 200 chars) + `(unchanged)` instead of a timestamp and settings reference, modeled after ztk's `computeDelta` approach. Gives the model context without wasting tokens on metadata.

### Files

- `toolResultCompressorService.ts`: Remove banner prepending, update `_buildCacheHitResult` to preview + `(unchanged)`
- `toolResultCompressor.ts`: Remove `formatCompressionBanner` function
- `terminalOutputCompressor.ts`: Unregister `findFilter`, `grepFilter`, `treeFilter`
- `toolResultCompressorService.test.ts`: Update tests to match bannerless output