### PR TITLE
Rework custom editor diff/merge contribution points

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorConfiguration.ts
+++ b/src/vs/workbench/browser/parts/editor/editorConfiguration.ts
@@ -9,7 +9,7 @@ import { IWorkbenchContribution } from '../../../common/contributions.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { IConfigurationRegistry, Extensions as ConfigurationExtensions, IConfigurationNode, ConfigurationScope } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { workbenchConfigurationNodeBase } from '../../../common/configuration.js';
-import { diffEditorsAssociationsSettingId, editorsAssociationsAgentsWindowDefault, editorsAssociationsSettingId, IEditorResolverService, RegisteredEditorInfo, RegisteredEditorPriority } from '../../../services/editor/common/editorResolverService.js';
+import { diffEditorsAssociationsSettingId, editorsAssociationsAgentsWindowDefault, editorsAssociationsSettingId, IEditorResolverService, RegisteredEditorInfo, RegisteredEditorPriority, toRegisteredEditorPriorityInfo } from '../../../services/editor/common/editorResolverService.js';
 import { IJSONSchemaMap } from '../../../../base/common/jsonSchema.js';
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
 import { coalesce } from '../../../../base/common/arrays.js';
@@ -36,22 +36,22 @@ export class DynamicEditorConfigurations extends Disposable implements IWorkbenc
 		{
 			id: 'workbench.input.interactive',
 			label: localize('interactiveWindow', 'Interactive Window'),
-			priority: RegisteredEditorPriority.builtin
+			priority: toRegisteredEditorPriorityInfo(RegisteredEditorPriority.builtin)
 		},
 		{
 			id: 'mainThreadWebview-markdown.preview',
 			label: localize('markdownPreview', "Markdown Preview"),
-			priority: RegisteredEditorPriority.builtin
+			priority: toRegisteredEditorPriorityInfo(RegisteredEditorPriority.builtin)
 		},
 		{
 			id: 'mainThreadWebview-simpleBrowser.view',
 			label: localize('simpleBrowser', "Simple Browser"),
-			priority: RegisteredEditorPriority.builtin
+			priority: toRegisteredEditorPriorityInfo(RegisteredEditorPriority.builtin)
 		},
 		{
 			id: 'mainThreadWebview-browserPreview',
 			label: localize('livePreview', "Live Preview"),
-			priority: RegisteredEditorPriority.builtin
+			priority: toRegisteredEditorPriorityInfo(RegisteredEditorPriority.builtin)
 		}
 	];
 
@@ -100,7 +100,7 @@ export class DynamicEditorConfigurations extends Disposable implements IWorkbenc
 
 	private updateDynamicEditorConfigurations(): void {
 		const lockableEditors = [...this.editorResolverService.getEditors(), ...DynamicEditorConfigurations.AUTO_LOCK_EXTRA_EDITORS].filter(e => !DynamicEditorConfigurations.AUTO_LOCK_REMOVE_EDITORS.has(e.id));
-		const binaryEditorCandidates = this.editorResolverService.getEditors().filter(e => e.priority !== RegisteredEditorPriority.exclusive).map(e => e.id);
+		const binaryEditorCandidates = this.editorResolverService.getEditors().filter(e => e.priority.editor !== RegisteredEditorPriority.exclusive).map(e => e.id);
 
 		// Build config from registered editors
 		const autoLockGroupConfiguration: IJSONSchemaMap = Object.create(null);

--- a/src/vs/workbench/contrib/customEditor/browser/customEditors.ts
+++ b/src/vs/workbench/contrib/customEditor/browser/customEditors.ts
@@ -177,8 +177,6 @@ export class CustomEditorService extends Disposable implements ICustomEditorServ
 						label: contributedEditor.displayName,
 						detail: contributedEditor.providerDisplayName,
 						priority: contributedEditor.priority,
-						diffEditorPriority: contributedEditor.diffEditorPriority,
-						mergeEditorPriority: contributedEditor.mergeEditorPriority,
 					},
 					{
 						singlePerResource: () => !(this.getCustomEditorCapabilities(contributedEditor.id)?.supportsMultipleEditorsPerDocument ?? false)
@@ -408,7 +406,7 @@ export class CustomEditorService extends Disposable implements ICustomEditorServ
 		const possibleEditors = this.getAllCustomEditors(newResource);
 
 		// See if we have any non-optional custom editor for this resource
-		if (!possibleEditors.allEditors.some(editor => editor.priority !== RegisteredEditorPriority.option)) {
+		if (!possibleEditors.allEditors.some(editor => editor.priority.editor !== RegisteredEditorPriority.option)) {
 			return;
 		}
 

--- a/src/vs/workbench/contrib/customEditor/common/contributedCustomEditors.ts
+++ b/src/vs/workbench/contrib/customEditor/common/contributedCustomEditors.ts
@@ -10,13 +10,22 @@ import * as nls from '../../../../nls.js';
 import { IExtensionDescription } from '../../../../platform/extensions/common/extensions.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { Memento } from '../../../common/memento.js';
-import { CustomEditorPriority, CustomEditorDescriptor, CustomEditorInfo } from './customEditor.js';
+import { CustomEditorDescriptor, CustomEditorInfo, CustomEditorPriority, CustomEditorPriorityInfo } from './customEditor.js';
 import { customEditorsExtensionPoint, ICustomEditorsExtensionPoint } from './extensionPoint.js';
 import { RegisteredEditorPriority } from '../../../services/editor/common/editorResolverService.js';
 import { IExtensionPointUser } from '../../../services/extensions/common/extensionsRegistry.js';
 
+type StoredCustomEditorPriorityInfo = Omit<CustomEditorPriorityInfo, 'diff' | 'merge'> & {
+	readonly diff?: RegisteredEditorPriority;
+	readonly merge?: RegisteredEditorPriority;
+};
+
+type StoredCustomEditorDescriptor = Omit<CustomEditorDescriptor, 'priority'> & {
+	readonly priority: StoredCustomEditorPriorityInfo | RegisteredEditorPriority;
+};
+
 interface CustomEditorsMemento {
-	editors?: CustomEditorDescriptor[];
+	editors?: StoredCustomEditorDescriptor[];
 }
 
 export class ContributedCustomEditors extends Disposable {
@@ -34,7 +43,7 @@ export class ContributedCustomEditors extends Disposable {
 
 		const mementoObject = this._memento.getMemento(StorageScope.PROFILE, StorageTarget.MACHINE);
 		for (const info of mementoObject[ContributedCustomEditors.CUSTOM_EDITORS_ENTRY_ID] || []) {
-			this.add(new CustomEditorInfo(info));
+			this.add(new CustomEditorInfo(normalizeStoredCustomEditorDescriptor(info)));
 		}
 
 		this._register(customEditorsExtensionPoint.setHandler(extensions => {
@@ -51,14 +60,13 @@ export class ContributedCustomEditors extends Disposable {
 		for (const extension of extensions) {
 			const hasCustomEditorPriorityProposal = extension.description.enabledApiProposals?.includes('customEditorPriority') ?? false;
 			for (const webviewEditorContribution of extension.value) {
+				const priority = getPriorityFromContribution(webviewEditorContribution.priority, extension.description, hasCustomEditorPriorityProposal);
 				this.add(new CustomEditorInfo({
 					id: webviewEditorContribution.viewType,
 					displayName: webviewEditorContribution.displayName,
 					providerDisplayName: extension.description.isBuiltin ? nls.localize('builtinProviderDisplayName', "Built-in") : extension.description.displayName || extension.description.identifier.value,
 					selector: webviewEditorContribution.selector || [],
-					priority: getPriorityFromContribution(webviewEditorContribution, extension.description, 'priority') ?? RegisteredEditorPriority.default,
-					diffEditorPriority: hasCustomEditorPriorityProposal ? getPriorityFromContribution(webviewEditorContribution, extension.description, 'diffEditorPriority') : undefined,
-					mergeEditorPriority: hasCustomEditorPriorityProposal ? getPriorityFromContribution(webviewEditorContribution, extension.description, 'mergeEditorPriority') : undefined,
+					priority,
 				}));
 			}
 		}
@@ -92,12 +100,38 @@ export class ContributedCustomEditors extends Disposable {
 	}
 }
 
+function normalizeStoredCustomEditorDescriptor(descriptor: StoredCustomEditorDescriptor): CustomEditorDescriptor {
+	return {
+		id: descriptor.id,
+		displayName: descriptor.displayName,
+		providerDisplayName: descriptor.providerDisplayName,
+		selector: descriptor.selector,
+		priority: typeof descriptor.priority === 'string' ? {
+			editor: descriptor.priority,
+			diff: descriptor.priority,
+			merge: descriptor.priority,
+		} : {
+			editor: descriptor.priority.editor,
+			diff: descriptor.priority.diff ?? descriptor.priority.editor,
+			merge: descriptor.priority.merge ?? descriptor.priority.editor,
+		},
+	};
+}
+
 function getPriorityFromContribution(
-	contribution: ICustomEditorsExtensionPoint,
+	contribution: ICustomEditorsExtensionPoint['priority'],
 	extension: IExtensionDescription,
-	field: 'priority' | 'diffEditorPriority' | 'mergeEditorPriority',
-): RegisteredEditorPriority | undefined {
-	const value = contribution[field] as CustomEditorPriority | undefined;
+	includeDiffAndMergePriority: boolean,
+): CustomEditorDescriptor['priority'] {
+	const editorPriority = getSinglePriorityFromContribution(typeof contribution === 'string' ? contribution : contribution?.editor, extension) ?? RegisteredEditorPriority.default;
+	return {
+		editor: editorPriority,
+		diff: includeDiffAndMergePriority && typeof contribution !== 'string' ? getSinglePriorityFromContribution(contribution?.diff, extension) ?? editorPriority : editorPriority,
+		merge: includeDiffAndMergePriority && typeof contribution !== 'string' ? getSinglePriorityFromContribution(contribution?.merge, extension) ?? editorPriority : editorPriority,
+	};
+}
+
+function getSinglePriorityFromContribution(value: CustomEditorPriority | undefined, extension: IExtensionDescription): RegisteredEditorPriority | undefined {
 	switch (value) {
 		case CustomEditorPriority.default:
 			return RegisteredEditorPriority.default;

--- a/src/vs/workbench/contrib/customEditor/common/customEditor.ts
+++ b/src/vs/workbench/contrib/customEditor/common/customEditor.ts
@@ -12,7 +12,7 @@ import * as nls from '../../../../nls.js';
 import { RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { IRevertOptions, ISaveOptions } from '../../../common/editor.js';
-import { globMatchesResource, priorityToRank, RegisteredEditorPriority } from '../../../services/editor/common/editorResolverService.js';
+import { globMatchesResource, priorityToRank, RegisteredEditorPriority, RegisteredEditorPriorityInfo } from '../../../services/editor/common/editorResolverService.js';
 
 export const ICustomEditorService = createDecorator<ICustomEditorService>('customEditorService');
 
@@ -92,13 +92,13 @@ export interface CustomEditorSelector {
 	readonly filenamePattern?: string;
 }
 
+export type CustomEditorPriorityInfo = RegisteredEditorPriorityInfo;
+
 export interface CustomEditorDescriptor {
 	readonly id: string;
 	readonly displayName: string;
 	readonly providerDisplayName: string;
-	readonly priority: RegisteredEditorPriority;
-	readonly diffEditorPriority?: RegisteredEditorPriority;
-	readonly mergeEditorPriority?: RegisteredEditorPriority;
+	readonly priority: CustomEditorPriorityInfo;
 	readonly selector: readonly CustomEditorSelector[];
 }
 
@@ -107,9 +107,7 @@ export class CustomEditorInfo implements CustomEditorDescriptor {
 	public readonly id: string;
 	public readonly displayName: string;
 	public readonly providerDisplayName: string;
-	public readonly priority: RegisteredEditorPriority;
-	public readonly diffEditorPriority?: RegisteredEditorPriority;
-	public readonly mergeEditorPriority?: RegisteredEditorPriority;
+	public readonly priority: CustomEditorPriorityInfo;
 	public readonly selector: readonly CustomEditorSelector[];
 
 	constructor(descriptor: CustomEditorDescriptor) {
@@ -117,8 +115,6 @@ export class CustomEditorInfo implements CustomEditorDescriptor {
 		this.displayName = descriptor.displayName;
 		this.providerDisplayName = descriptor.providerDisplayName;
 		this.priority = descriptor.priority;
-		this.diffEditorPriority = descriptor.diffEditorPriority;
-		this.mergeEditorPriority = descriptor.mergeEditorPriority;
 		this.selector = descriptor.selector;
 	}
 
@@ -145,7 +141,7 @@ export class CustomEditorInfoCollection {
 	 */
 	public get defaultEditor(): CustomEditorInfo | undefined {
 		return this.allEditors.find(editor => {
-			switch (editor.priority) {
+			switch (editor.priority.editor) {
 				case RegisteredEditorPriority.default:
 				case RegisteredEditorPriority.builtin:
 					// A default editor must have higher priority than all other contributed editors.
@@ -166,12 +162,12 @@ export class CustomEditorInfoCollection {
 	 */
 	public get bestAvailableEditor(): CustomEditorInfo | undefined {
 		const editors = Array.from(this.allEditors).sort((a, b) => {
-			return priorityToRank(a.priority) - priorityToRank(b.priority);
+			return priorityToRank(a.priority.editor) - priorityToRank(b.priority.editor);
 		});
 		return editors[0];
 	}
 }
 
 function isLowerPriority(otherEditor: CustomEditorInfo, editor: CustomEditorInfo): unknown {
-	return priorityToRank(otherEditor.priority) < priorityToRank(editor.priority);
+	return priorityToRank(otherEditor.priority.editor) < priorityToRank(editor.priority.editor);
 }

--- a/src/vs/workbench/contrib/customEditor/common/extensionPoint.ts
+++ b/src/vs/workbench/contrib/customEditor/common/extensionPoint.ts
@@ -20,9 +20,25 @@ const Fields = Object.freeze({
 	displayName: 'displayName',
 	selector: 'selector',
 	priority: 'priority',
-	diffEditorPriority: 'diffEditorPriority',
-	mergeEditorPriority: 'mergeEditorPriority',
 });
+
+const PriorityFields = Object.freeze({
+	editor: 'editor',
+	diff: 'diff',
+	merge: 'merge',
+});
+
+const customEditorPrioritySchema = {
+	type: 'string',
+	enum: [
+		CustomEditorPriority.default,
+		CustomEditorPriority.option,
+	],
+	markdownEnumDescriptions: [
+		nls.localize('contributes.priority.default', 'The editor is automatically used when the user opens a resource, provided that no other default custom editors are registered for that resource.'),
+		nls.localize('contributes.priority.option', 'The editor is not automatically used when the user opens a resource, but a user can switch to the editor using the `Reopen With` command.'),
+	],
+} as const satisfies IJSONSchema;
 
 const customEditorsContributionSchema = {
 	type: 'object',
@@ -61,41 +77,30 @@ const customEditorsContributionSchema = {
 			}
 		},
 		[Fields.priority]: {
-			type: 'string',
-			markdownDescription: nls.localize('contributes.priority', 'Controls if the custom editor is enabled automatically when the user opens a file. This may be overridden by users using the `workbench.editorAssociations` setting.'),
-			enum: [
-				CustomEditorPriority.default,
-				CustomEditorPriority.option,
-			],
-			markdownEnumDescriptions: [
-				nls.localize('contributes.priority.default', 'The editor is automatically used when the user opens a resource, provided that no other default custom editors are registered for that resource.'),
-				nls.localize('contributes.priority.option', 'The editor is not automatically used when the user opens a resource, but a user can switch to the editor using the `Reopen With` command.'),
+			markdownDescription: nls.localize('contributes.priority', 'Controls if the custom editor is enabled automatically when the user opens a file, diff, or merge editor. This may be overridden by users using the `workbench.editorAssociations` or `workbench.diffEditorAssociations` setting.'),
+			anyOf: [
+				customEditorPrioritySchema,
+				{
+					type: 'object',
+					required: [PriorityFields.editor],
+					additionalProperties: false,
+					properties: {
+						[PriorityFields.editor]: {
+							...customEditorPrioritySchema,
+							markdownDescription: nls.localize('contributes.priority.editor', 'Controls if the custom editor is enabled automatically when the user opens a file.'),
+						},
+						[PriorityFields.diff]: {
+							...customEditorPrioritySchema,
+							markdownDescription: nls.localize('contributes.priority.diff', 'Controls if the custom editor is enabled automatically when the user opens a diff. When not specified, the value of `editor` is used.'),
+						},
+						[PriorityFields.merge]: {
+							...customEditorPrioritySchema,
+							markdownDescription: nls.localize('contributes.priority.merge', 'Controls if the custom editor is enabled automatically when the user opens a merge editor. When not specified, the value of `editor` is used.'),
+						},
+					}
+				}
 			],
 			default: CustomEditorPriority.default
-		},
-		[Fields.diffEditorPriority]: {
-			type: 'string',
-			markdownDescription: nls.localize('contributes.diffEditorPriority', 'Controls if the custom editor is enabled automatically when the user opens a diff. When not specified, the value of `priority` is used.'),
-			enum: [
-				CustomEditorPriority.default,
-				CustomEditorPriority.option,
-			],
-			markdownEnumDescriptions: [
-				nls.localize('contributes.diffEditorPriority.default', 'The editor is automatically used when the user opens a diff, provided that no other default custom editors are registered for that resource.'),
-				nls.localize('contributes.diffEditorPriority.option', 'The editor is not automatically used when the user opens a diff, but a user can switch to the editor using the `Reopen With` command.'),
-			],
-		},
-		[Fields.mergeEditorPriority]: {
-			type: 'string',
-			markdownDescription: nls.localize('contributes.mergeEditorPriority', 'Controls if the custom editor is enabled automatically when the user opens a merge editor. When not specified, the value of `priority` is used.'),
-			enum: [
-				CustomEditorPriority.default,
-				CustomEditorPriority.option,
-			],
-			markdownEnumDescriptions: [
-				nls.localize('contributes.mergeEditorPriority.default', 'The editor is automatically used when the user opens a merge editor, provided that no other default custom editors are registered for that resource.'),
-				nls.localize('contributes.mergeEditorPriority.option', 'The editor is not automatically used when the user opens a merge editor, but a user can switch to the editor using the `Reopen With` command.'),
-			],
 		}
 	}
 } as const satisfies IJSONSchema;
@@ -153,7 +158,7 @@ class CustomEditorsDataRenderer extends Disposable implements IExtensionFeatureT
 			.map(customEditor => {
 				return [
 					customEditor.viewType,
-					customEditor.priority ?? '',
+					renderPriority(customEditor.priority),
 					coalesce(customEditor.selector.map(x => x.filenamePattern)).join(', ')
 				];
 			});
@@ -166,6 +171,20 @@ class CustomEditorsDataRenderer extends Disposable implements IExtensionFeatureT
 			dispose: () => { }
 		};
 	}
+}
+
+function renderPriority(priority: ICustomEditorsExtensionPoint['priority'] | string | undefined): string {
+	if (!priority) {
+		return '';
+	}
+	if (typeof priority === 'string') {
+		return priority;
+	}
+	return coalesce([
+		priority.editor ? `editor: ${priority.editor}` : undefined,
+		priority.diff ? `diff: ${priority.diff}` : undefined,
+		priority.merge ? `merge: ${priority.merge}` : undefined,
+	]).join(', ');
 }
 
 Registry.as<IExtensionFeaturesRegistry>(Extensions.ExtensionFeaturesRegistry).registerExtensionFeature({

--- a/src/vs/workbench/contrib/notebook/browser/services/notebookServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/services/notebookServiceImpl.ts
@@ -34,7 +34,7 @@ import { INotebookEditorModelResolverService } from '../../common/notebookEditor
 import { NotebookOutputRendererInfo, NotebookStaticPreloadInfo } from '../../common/notebookOutputRenderer.js';
 import { NotebookEditorDescriptor, NotebookProviderInfo } from '../../common/notebookProvider.js';
 import { INotebookSerializer, INotebookService, SimpleNotebookProviderInfo } from '../../common/notebookService.js';
-import { DiffEditorInputFactoryFunction, EditorInputFactoryFunction, EditorInputFactoryObject, IEditorResolverService, IEditorType, RegisteredEditorInfo, RegisteredEditorPriority, UntitledEditorInputFactoryFunction, type MergeEditorInputFactoryFunction } from '../../../../services/editor/common/editorResolverService.js';
+import { DiffEditorInputFactoryFunction, EditorInputFactoryFunction, EditorInputFactoryObject, IEditorResolverService, IEditorType, RegisteredEditorPriority, RegisteredEditorRegistrationInfo, UntitledEditorInputFactoryFunction, type MergeEditorInputFactoryFunction } from '../../../../services/editor/common/editorResolverService.js';
 import { IExtensionService, isProposedApiEnabled } from '../../../../services/extensions/common/extensions.js';
 import { IExtensionPointUser } from '../../../../services/extensions/common/extensionsRegistry.js';
 import { InstallRecommendedExtensionAction } from '../../../extensions/browser/extensionsActions.js';
@@ -177,7 +177,7 @@ export class NotebookProviderInfoStore extends Disposable {
 
 		for (const selector of notebookProviderInfo.selectors) {
 			const globPattern = (selector as INotebookExclusiveDocumentFilter).include || selector as glob.IRelativePattern | string;
-			const notebookEditorInfo: RegisteredEditorInfo = {
+			const notebookEditorInfo: RegisteredEditorRegistrationInfo = {
 				id: notebookProviderInfo.id,
 				label: notebookProviderInfo.displayName,
 				detail: notebookProviderInfo.providerDisplayName,

--- a/src/vs/workbench/services/editor/browser/editorResolverService.ts
+++ b/src/vs/workbench/services/editor/browser/editorResolverService.ts
@@ -25,7 +25,7 @@ import { SideBySideEditorInput } from '../../../common/editor/sideBySideEditorIn
 import { IExtensionService } from '../../extensions/common/extensions.js';
 import { findGroup } from '../common/editorGroupFinder.js';
 import { IEditorGroup, IEditorGroupsService } from '../common/editorGroupsService.js';
-import { diffEditorsAssociationsSettingId, EditorAssociation, EditorAssociations, EditorInputFactoryObject, editorsAssociationsSettingId, globMatchesResource, IEditorResolverService, priorityToRank, RegisteredEditorInfo, RegisteredEditorOptions, RegisteredEditorPriority, ResolvedEditor, ResolvedStatus } from '../common/editorResolverService.js';
+import { diffEditorsAssociationsSettingId, EditorAssociation, EditorAssociations, EditorInputFactoryObject, editorsAssociationsSettingId, globMatchesResource, IEditorResolverService, priorityToRank, RegisteredEditorInfo, RegisteredEditorOptions, RegisteredEditorPriority, RegisteredEditorRegistrationInfo, ResolvedEditor, ResolvedStatus, toRegisteredEditorPriorityInfo } from '../common/editorResolverService.js';
 import { PreferredGroup } from '../common/editorService.js';
 
 interface RegisteredEditor {
@@ -36,6 +36,15 @@ interface RegisteredEditor {
 }
 
 type RegisteredEditors = Array<RegisteredEditor>;
+
+function normalizeRegisteredEditorInfo(editorInfo: RegisteredEditorRegistrationInfo): RegisteredEditorInfo {
+	return {
+		id: editorInfo.id,
+		label: editorInfo.label,
+		detail: editorInfo.detail,
+		priority: toRegisteredEditorPriorityInfo(editorInfo.priority),
+	};
+}
 
 const enum EditorAssociationType {
 	Editor,
@@ -235,27 +244,28 @@ export class EditorResolverService extends Disposable implements IEditorResolver
 
 	registerEditor(
 		globPattern: string | glob.IRelativePattern,
-		editorInfo: RegisteredEditorInfo,
+		editorInfo: RegisteredEditorRegistrationInfo,
 		options: RegisteredEditorOptions,
 		editorFactoryObject: EditorInputFactoryObject
 	): IDisposable {
+		const registeredEditorInfo = normalizeRegisteredEditorInfo(editorInfo);
 		let registeredEditor = this._editors.get(globPattern);
 		if (registeredEditor === undefined) {
 			registeredEditor = new Map<string, RegisteredEditors>();
 			this._editors.set(globPattern, registeredEditor);
 		}
 
-		let editorsWithId = registeredEditor.get(editorInfo.id);
+		let editorsWithId = registeredEditor.get(registeredEditorInfo.id);
 		if (editorsWithId === undefined) {
 			editorsWithId = [];
 		}
 		const remove = insert(editorsWithId, {
 			globPattern,
-			editorInfo,
+			editorInfo: registeredEditorInfo,
 			options,
 			editorFactoryObject
 		});
-		registeredEditor.set(editorInfo.id, editorsWithId);
+		registeredEditor.set(registeredEditorInfo.id, editorsWithId);
 		this._shouldReFlattenEditors = true;
 		this._onDidChangeEditorRegistrations.fire();
 		return toDisposable(() => {
@@ -414,7 +424,7 @@ export class EditorResolverService extends Disposable implements IEditorResolver
 				}
 
 				const foundInSettings = userSettings.find(setting => setting.viewType === editor.editorInfo.id);
-				if ((foundInSettings && editor.editorInfo.priority !== RegisteredEditorPriority.exclusive) || globMatchesResource(key, resource)) {
+				if ((foundInSettings && this.getEffectivePriority(editor.editorInfo, associationType) !== RegisteredEditorPriority.exclusive) || globMatchesResource(key, resource)) {
 					matchingEditors.push(editor);
 				}
 			}
@@ -437,7 +447,7 @@ export class EditorResolverService extends Disposable implements IEditorResolver
 		// By resource
 		if (URI.isUri(resource)) {
 			const editors = this.findMatchingEditors(resource);
-			if (editors.find(e => e.editorInfo.priority === RegisteredEditorPriority.exclusive)) {
+			if (editors.find(e => e.editorInfo.priority.editor === RegisteredEditorPriority.exclusive)) {
 				return [];
 			}
 			return editors.map(editor => editor.editorInfo);
@@ -517,11 +527,11 @@ export class EditorResolverService extends Disposable implements IEditorResolver
 	private getEffectivePriority(editorInfo: RegisteredEditorInfo, associationType: EditorAssociationType): RegisteredEditorPriority {
 		switch (associationType) {
 			case EditorAssociationType.DiffEditor:
-				return editorInfo.diffEditorPriority ?? editorInfo.priority;
+				return editorInfo.priority.diff;
 			case EditorAssociationType.MergeEditor:
-				return editorInfo.mergeEditorPriority ?? editorInfo.priority;
+				return editorInfo.priority.merge;
 			default:
-				return editorInfo.priority;
+				return editorInfo.priority.editor;
 		}
 	}
 
@@ -724,7 +734,7 @@ export class EditorResolverService extends Disposable implements IEditorResolver
 	private mapEditorsToQuickPickEntry(resource: URI, showDefaultPicker: boolean | undefined, associationType: EditorAssociationType) {
 		const currentEditor = this.editorGroupService.activeGroup.findEditors(resource).at(0);
 		// If untitled, we want all registered editors
-		let registeredEditors = resource.scheme === Schemas.untitled ? this._registeredEditors.filter(e => e.editorInfo.priority !== RegisteredEditorPriority.exclusive) : this.findMatchingEditors(resource, associationType);
+		let registeredEditors = resource.scheme === Schemas.untitled ? this._registeredEditors.filter(e => e.editorInfo.priority.editor !== RegisteredEditorPriority.exclusive) : this.findMatchingEditors(resource, associationType);
 		if (associationType === EditorAssociationType.DiffEditor) {
 			registeredEditors = registeredEditors.filter(editor => !!editor.editorFactoryObject.createDiffEditorInput);
 		}
@@ -738,7 +748,7 @@ export class EditorResolverService extends Disposable implements IEditorResolver
 			} else if (b.editorInfo.id === DEFAULT_EDITOR_ASSOCIATION.id) {
 				return 1;
 			} else {
-				return priorityToRank(b.editorInfo.priority) - priorityToRank(a.editorInfo.priority);
+				return priorityToRank(this.getEffectivePriority(b.editorInfo, associationType)) - priorityToRank(this.getEffectivePriority(a.editorInfo, associationType));
 			}
 		});
 		const quickPickEntries: Array<QuickPickItem> = [];
@@ -747,7 +757,7 @@ export class EditorResolverService extends Disposable implements IEditorResolver
 		const currentDefaultAndActiveLabel = localize('promptOpenWith.currentDefaultAndActive', "Active and Default");
 		// Default order = setting -> highest priority -> text
 		let defaultViewType = defaultSetting;
-		if (!defaultViewType && registeredEditors.length > 2 && registeredEditors[1]?.editorInfo.priority !== RegisteredEditorPriority.option) {
+		if (!defaultViewType && registeredEditors.length > 2 && this.getEffectivePriority(registeredEditors[1].editorInfo, associationType) !== RegisteredEditorPriority.option) {
 			defaultViewType = registeredEditors[1]?.editorInfo.id;
 		}
 		if (!defaultViewType) {
@@ -762,7 +772,7 @@ export class EditorResolverService extends Disposable implements IEditorResolver
 				id: editor.editorInfo.id,
 				label: editor.editorInfo.label,
 				description: isActive && isDefault ? currentDefaultAndActiveLabel : isActive ? currentlyActiveLabel : isDefault ? currentDefaultLabel : undefined,
-				detail: editor.editorInfo.detail ?? editor.editorInfo.priority,
+				detail: editor.editorInfo.detail ?? editor.editorInfo.priority.editor,
 			};
 			quickPickEntries.push(quickPickEntry);
 		});
@@ -882,7 +892,7 @@ export class EditorResolverService extends Disposable implements IEditorResolver
 
 		// Store just the relative pattern pieces without any path info
 		for (const [globPattern, contribPoint] of this._flattenedEditors) {
-			const nonOptional = !!contribPoint.find(c => c.editorInfo.priority !== RegisteredEditorPriority.option && c.editorInfo.id !== DEFAULT_EDITOR_ASSOCIATION.id);
+			const nonOptional = !!contribPoint.find(c => c.editorInfo.priority.editor !== RegisteredEditorPriority.option && c.editorInfo.id !== DEFAULT_EDITOR_ASSOCIATION.id);
 			// Don't keep a cache of the optional ones as those wouldn't be opened on start anyways
 			if (!nonOptional) {
 				continue;

--- a/src/vs/workbench/services/editor/common/editorResolverService.ts
+++ b/src/vs/workbench/services/editor/common/editorResolverService.ts
@@ -112,14 +112,33 @@ export type RegisteredEditorOptions = {
 	canSupportResource?: (resource: URI) => boolean;
 };
 
+export type RegisteredEditorPriorityInfo = {
+	readonly editor: RegisteredEditorPriority;
+	readonly diff: RegisteredEditorPriority;
+	readonly merge: RegisteredEditorPriority;
+};
+
 export type RegisteredEditorInfo = {
 	readonly id: string;
 	readonly label: string;
 	readonly detail?: string;
-	readonly priority: RegisteredEditorPriority;
-	readonly diffEditorPriority?: RegisteredEditorPriority;
-	readonly mergeEditorPriority?: RegisteredEditorPriority;
+	readonly priority: RegisteredEditorPriorityInfo;
 };
+
+export type RegisteredEditorRegistrationInfo = Omit<RegisteredEditorInfo, 'priority'> & {
+	readonly priority: RegisteredEditorPriority | RegisteredEditorPriorityInfo;
+};
+
+export function toRegisteredEditorPriorityInfo(priority: RegisteredEditorPriority | RegisteredEditorPriorityInfo): RegisteredEditorPriorityInfo {
+	if (typeof priority !== 'string') {
+		return priority;
+	}
+	return {
+		editor: priority,
+		diff: priority,
+		merge: priority,
+	};
+}
 
 type EditorInputFactoryResult = EditorInputWithOptions | Promise<EditorInputWithOptions>;
 
@@ -179,7 +198,7 @@ export interface IEditorResolverService {
 	 */
 	registerEditor(
 		globPattern: string | glob.IRelativePattern,
-		editorInfo: RegisteredEditorInfo,
+		editorInfo: RegisteredEditorRegistrationInfo,
 		options: RegisteredEditorOptions,
 		editorFactoryObject: EditorInputFactoryObject
 	): IDisposable;

--- a/src/vs/workbench/services/editor/test/browser/editorResolverService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorResolverService.test.ts
@@ -676,7 +676,7 @@ suite('EditorResolverService', () => {
 		customEditor.dispose();
 	});
 
-	test('Diff editor Resolve - diffEditorPriority overrides priority for diffs', async () => {
+	test('Diff editor Resolve - priority.diff overrides priority.editor for diffs', async () => {
 		const CUSTOM_EDITOR_INPUT_ID = 'testCustomEditorForDiffPriority';
 		const [part, service, accessor] = await createEditorResolverService();
 		const registeredEditor = service.registerEditor('*.test-diff-priority',
@@ -684,8 +684,11 @@ suite('EditorResolverService', () => {
 				id: 'TEST_EDITOR',
 				label: 'Test Editor Label',
 				detail: 'Test Editor Details',
-				priority: RegisteredEditorPriority.default,
-				diffEditorPriority: RegisteredEditorPriority.option,
+				priority: {
+					editor: RegisteredEditorPriority.default,
+					diff: RegisteredEditorPriority.option,
+					merge: RegisteredEditorPriority.default,
+				},
 			},
 			{},
 			{
@@ -702,7 +705,7 @@ suite('EditorResolverService', () => {
 			}
 		);
 
-		// Regular editor should use custom editor (priority: default)
+		// Regular editor should use custom editor (priority.editor: default)
 		const editorResolution = await service.resolveEditor({ resource: URI.file('my://resource.test-diff-priority') }, part.activeGroup);
 		assert.ok(editorResolution);
 		assert.notStrictEqual(typeof editorResolution, 'number');
@@ -713,23 +716,23 @@ suite('EditorResolverService', () => {
 			assert.fail('Expected editor to resolve successfully');
 		}
 
-		// Diff editor should NOT use custom editor (diffEditorPriority: option)
+		// Diff editor should NOT use custom editor (priority.diff: option)
 		const diffResolution = await service.resolveEditor({
 			original: { resource: URI.file('my://resource.test-diff-priority') },
 			modified: { resource: URI.file('my://resource.test-diff-priority') }
 		}, part.activeGroup);
 		assert.ok(diffResolution);
-		// With diffEditorPriority: option, the custom editor should not be selected as default
+		// With priority.diff: option, the custom editor should not be selected as default
 		if (diffResolution !== ResolvedStatus.ABORT && diffResolution !== ResolvedStatus.NONE) {
 			assert.notStrictEqual(diffResolution.editor.typeId, CUSTOM_EDITOR_INPUT_ID,
-				'Custom editor with diffEditorPriority:option should not be used for diffs');
+				'Custom editor with priority.diff:option should not be used for diffs');
 			diffResolution.editor.dispose();
 		}
 
 		registeredEditor.dispose();
 	});
 
-	test('Diff editor Resolve - diffEditorPriority defaults to priority when not set', async () => {
+	test('Diff editor Resolve - string priority expands to diff priority', async () => {
 		const CUSTOM_EDITOR_INPUT_ID = 'testCustomEditorNoDiffPriority';
 		const [part, service, accessor] = await createEditorResolverService();
 		const registeredEditor = service.registerEditor('*.test-no-diff-priority',
@@ -738,7 +741,6 @@ suite('EditorResolverService', () => {
 				label: 'Test Editor Label',
 				detail: 'Test Editor Details',
 				priority: RegisteredEditorPriority.default,
-				// diffEditorPriority not set - should fall back to priority
 			},
 			{},
 			{
@@ -755,7 +757,7 @@ suite('EditorResolverService', () => {
 			}
 		);
 
-		// Diff editor should use custom editor since diffEditorPriority falls back to priority: default
+		// Diff editor should use custom editor since string priority expands to priority.diff: default
 		const diffResolution = await service.resolveEditor({
 			original: { resource: URI.file('my://resource.test-no-diff-priority') },
 			modified: { resource: URI.file('my://resource.test-no-diff-priority') }


### PR DESCRIPTION
For #292379

Instead of new top level fields, let's make it so these are all defined on the priority field like so:

```
priority: {
    editor: "default",
    diff: "option",
    merge: "option"
}
```

This should be more extensible going forward and keeps all the priorities nicely grouped

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
