### PR TITLE
Add retries to git checkout pipeline steps

### DIFF
--- a/build/azure-pipelines/common/checkout.yml
+++ b/build/azure-pipelines/common/checkout.yml
@@ -2,4 +2,5 @@ steps:
   - checkout: self
     fetchDepth: 1
     fetchTags: false
+    retryCountOnTaskFailure: 3
     displayName: Checkout microsoft/vscode

--- a/build/azure-pipelines/common/sanity-tests.yml
+++ b/build/azure-pipelines/common/sanity-tests.yml
@@ -44,6 +44,7 @@ jobs:
         fetchDepth: 1
         fetchTags: false
         sparseCheckoutDirectories: build/azure-pipelines/config test/sanity .nvmrc
+        retryCountOnTaskFailure: 3
         displayName: Checkout test/sanity
 
       - ${{ if eq(parameters.os, 'windows') }}:

--- a/build/azure-pipelines/product-copilot-recovery.yml
+++ b/build/azure-pipelines/product-copilot-recovery.yml
@@ -55,6 +55,7 @@ extends:
     testSteps:
       - checkout: self
         lfs: true
+        retryCountOnTaskFailure: 3
       - template: copilot/setup-steps.yml
       - template: copilot/test-steps.yml
 

--- a/build/azure-pipelines/product-copilot.yml
+++ b/build/azure-pipelines/product-copilot.yml
@@ -20,6 +20,7 @@ jobs:
         lfs: true
         fetchDepth: 1
         fetchTags: false
+        retryCountOnTaskFailure: 3
         displayName: Checkout microsoft/vscode
 
       - template: copilot/setup-steps.yml


### PR DESCRIPTION
Adds `retryCountOnTaskFailure: 3` to all `- checkout: self` steps in the build pipeline.

## Changes
- `common/checkout.yml` — shared template used by ~19 build jobs (Linux/Alpine/Darwin/Win32/Web CLI + node-modules + compile + quality-checks + publish + release + sdl-scan).
- `common/sanity-tests.yml` — sparse checkout for sanity test jobs (4 platforms).
- `product-copilot.yml` — Copilot product build checkout.
- `product-copilot-recovery.yml` — Copilot recovery pipeline checkout.

## Why
7-day pipeline analysis (May 6–13, 2026): `Checkout microsoft/vscode` accounted for **13 of 22** failures (~59%) in the Infra/Transient bucket. These are transient git fetch / network issues that typically resolve on retry — no real fix exists short of waiting out a TCP reset or a DNS hiccup.

## Risks
- Low. `retryCountOnTaskFailure` only fires on a failed task, so green builds are unaffected.
- Worst case: ~3x checkout time on a persistently-broken connection (rare; usually network is back within seconds).

## Related
- vscode-engineering#2777 (build reliability tracking)
- Companion to #316508 (sanity test retries)

Also kicked off https://dev.azure.com/monacotools/Monaco/_build/results?buildId=439482&view=results to ensure the build actually runs