### PR TITLE
fix: defer ChatInputPart carousel max-height update to next animation frame (#316509)

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -2776,8 +2776,18 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 		this.renderAttachedContext();
 
+		// Defer only the carousel max-height update to the next animation
+		// frame. That write changes a descendant whose height flexes back
+		// up into `this.container` (the observed element), which is what
+		// trips the browser's "ResizeObserver loop completed with
+		// undelivered notifications" warning under bursty input (see
+		// #316509). Publishing `this.height` stays synchronous because its
+		// autorun consumers re-layout siblings/ancestors of the input
+		// container, not the container itself, so they do not feed back
+		// into the same observation phase.
+		const updateCarouselMaxHeightScheduler = this._register(new dom.AnimationFrameScheduler(this.container, () => this.updateToolConfirmationCarouselMaxHeight()));
 		const inputResizeObserver = this._register(new dom.DisposableResizeObserver('ChatInputPart.containerHeight', () => {
-			this.updateToolConfirmationCarouselMaxHeight();
+			updateCarouselMaxHeightScheduler.schedule();
 			const newHeight = this.container.offsetHeight;
 			this.height.set(newHeight, undefined);
 		}));


### PR DESCRIPTION
## Summary

Fixes the `ResizeObserver loop completed with undelivered notifications` warning attributed to `[DisposableResizeObserver(ChatInputPart.containerHeight)]` in error telemetry.

The `ChatInputPart.containerHeight` resize observer's callback called `updateToolConfirmationCarouselMaxHeight()` synchronously. That writes `style.maxHeight` on the tool-confirmation carousel — a descendant of the observed `this.container`. Under flexbox, the descendant's height change flexes back up into the observed container, causing the browser to re-queue a notification for the same observer. When external mutations (rapid type+Enter) keep arriving during the next observation phases, Chromium's loop algorithm exhausts its depth budget and emits the synthetic warning.

This change defers only the carousel max-height write to the next animation frame via `AnimationFrameScheduler`. Publishing `this.height` via the observable stays synchronous because its autorun consumers re-layout siblings/ancestors of the input container (the message list, welcome container, view pane), not the container itself, so they do not feed back into the same observation phase.

Fixes #316509

## Trigger scenarios

- A chat session with one or more pending tool confirmations queued in the carousel such that the carousel's natural height exceeds its budget (`maxHeight - otherInputHeight`).
- A burst of input events that resize the chat input container (rapid typing, Enter to queue more steering items, attachment changes, toolbar reflows) arriving across consecutive resize-observation phases.
- The combination causes `setMaxHeight` inside the RO callback to materially shrink the carousel, which propagates back up to `this.container`, which the browser flags as an undelivered notification.

## Code flow diagram

```mermaid
sequenceDiagram
    participant User
    participant Browser
    participant Observer
    participant InputPart
    participant Carousel
    participant Flex

    User->>Browser: rapid type plus Enter
    Browser->>Browser: container resizes
    Browser->>Observer: deliver notification at depth D
    Observer->>InputPart: updateToolConfirmationCarouselMaxHeight
    InputPart->>Carousel: setMaxHeight budget minus otherInputHeight
    Carousel->>Flex: write style maxHeight and carousel shrinks
    Flex->>Browser: container offsetHeight changed at depth D
    Browser->>Browser: active observation pending at depth not greater than D
    Note over Browser: another external resize arrives before phase drains
    Browser->>User: dispatches ResizeObserver loop completed with undelivered notifications
```

## How the fix works

- `src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts`
  - Wrap `updateToolConfirmationCarouselMaxHeight()` in an `AnimationFrameScheduler` so the descendant write that flexes back up into the observed container happens **outside** the resize-observation phase.
  - Keep `this.height.set(newHeight, undefined)` synchronous so parent layout (message list, welcome container) tracks the input height with no perceptible 1-frame lag.
  - Bursts of resize events coalesce into a single rAF run via the scheduler's pending-runner guard, which also reduces layout thrash in the bug's repro path.

## Manual validation steps

1. Build VS Code (`Run Dev` task).
2. Open Chat in agent mode and start a session that will queue several tool confirmations (e.g., a prompt that triggers multiple successive tool calls so the carousel fills with pending items).
3. Open DevTools console.
4. With pending confirmations visible, rapidly type into the chat input and press Enter several times in quick succession to queue more steering items.
5. **Before the fix**: the console intermittently logs `ResizeObserver loop completed with undelivered notifications`, surfaced as an error-telemetry event with attribution `[DisposableResizeObserver(ChatInputPart.containerHeight)]`.
6. **After the fix**: the warning no longer appears under the same interaction, and there is no perceptible visual lag in the input or the message list above it.
