### PR TITLE
Chronicle: fold sub-agent sessions into parent timeline and address session overwrite issue

### DIFF
--- a/extensions/copilot/src/extension/chronicle/common/cloudSessionTypes.ts
+++ b/extensions/copilot/src/extension/chronicle/common/cloudSessionTypes.ts
@@ -67,6 +67,13 @@ export interface SessionEvent {
 	parentId: string | null;
 	/** When true, the event is transient and not persisted. */
 	ephemeral?: boolean;
+	/**
+	 * Sub-agent instance identifier. Absent for events from the root/main agent
+	 * and for session-level events. Used by the cloud renderer to scope events
+	 * (assistant.message, tool.execution_*) under a sub-agent envelope so they
+	 * are not displayed as standalone sessions.
+	 */
+	agentId?: string;
 	/** Event type discriminator. */
 	type: string;
 	/** Event-specific payload. */

--- a/extensions/copilot/src/extension/chronicle/common/eventTranslator.ts
+++ b/extensions/copilot/src/extension/chronicle/common/eventTranslator.ts
@@ -98,6 +98,7 @@ export function translateSpan(
 	span: ICompletedSpanData,
 	state: SessionTranslationState,
 	context?: WorkingDirectoryContext,
+	subagentId?: string,
 ): SessionEvent[] {
 	const operationName = span.attributes[GenAiAttr.OPERATION_NAME] as string | undefined;
 	const events: SessionEvent[] = [];
@@ -106,8 +107,10 @@ export function translateSpan(
 		// Extract user message first — needed for session.start summary
 		const userRequest = span.attributes[CopilotChatAttr.USER_REQUEST] as string | undefined;
 
-		// First invoke_agent span → session.start
-		if (!state.started) {
+		// First invoke_agent span → session.start.
+		// Skip when this span is from a sub-agent: the parent session owns
+		// session.start, and sub-agent events fold into the parent's timeline.
+		if (!state.started && !subagentId) {
 			state.started = true;
 			pushEvent(events, state, 'session.start', {
 				sessionId: getSessionId(span) ?? generateUuid(),
@@ -126,11 +129,19 @@ export function translateSpan(
 			});
 		}
 
-		// Emit user.message (matches CLI format)
-		if (userRequest) {
+		// Emit user.message (matches CLI canonical format).
+		// NOTE: do NOT set `source` — the cloud timeline filter treats any
+		// `source` other than "user" (per UserMessageSource enum) as a
+		// skill/system-injected message and hides it from the timeline.
+		// Omitting `source` is normalized to `"user"` on the cloud side.
+		//
+		// Skip user.message for sub-agent spans — the "user request" of a
+		// sub-agent is the synthetic prompt produced by the parent's tool
+		// invocation, not a real user turn. The CLI explicitly does NOT bridge
+		// user.message events from sub-agents to the parent session.
+		if (userRequest && !subagentId) {
 			pushEvent(events, state, 'user.message', {
 				content: userRequest,
-				source: 'chat',
 				agentMode: 'interactive',
 			});
 		}
@@ -143,7 +154,7 @@ export function translateSpan(
 				messageId: generateUuid(),
 				content: assistantText ?? '',
 				toolRequests: toolRequests.length > 0 ? toolRequests : undefined,
-			});
+			}, /*ephemeral*/ false, subagentId);
 
 			// Emit tool.execution_start for each tool request (matches CLI pattern)
 			for (const req of toolRequests) {
@@ -151,7 +162,7 @@ export function translateSpan(
 					toolCallId: req.toolCallId,
 					toolName: req.name,
 					arguments: req.arguments,
-				});
+				}, /*ephemeral*/ false, subagentId);
 			}
 		}
 	}
@@ -176,7 +187,7 @@ export function translateSpan(
 					message: resultContent || 'Tool execution failed',
 					code: 'failure',
 				} : undefined,
-			});
+			}, /*ephemeral*/ false, subagentId);
 		}
 	}
 
@@ -245,9 +256,10 @@ export function translateDebugLogEntry(
 					? entry.attrs.userRequest
 					: undefined;
 			if (content) {
+				// See translateSpan: do not set `source`, or the cloud renderer
+				// will treat the message as synthetic and hide it.
 				pushEventAt(events, state, ts, 'user.message', {
 					content,
-					source: 'chat',
 					agentMode: 'interactive',
 				});
 			}
@@ -340,8 +352,9 @@ function pushEvent(
 	type: string,
 	data: Record<string, unknown>,
 	ephemeral?: boolean,
+	agentId?: string,
 ): void {
-	pushEventAt(events, state, new Date().toISOString(), type, data, ephemeral);
+	pushEventAt(events, state, new Date().toISOString(), type, data, ephemeral, agentId);
 }
 
 function pushEventAt(
@@ -351,6 +364,7 @@ function pushEventAt(
 	type: string,
 	data: Record<string, unknown>,
 	ephemeral?: boolean,
+	agentId?: string,
 ): void {
 	const event: SessionEvent = {
 		id: generateUuid(),
@@ -361,6 +375,9 @@ function pushEventAt(
 	};
 	if (ephemeral) {
 		event.ephemeral = true;
+	}
+	if (agentId) {
+		event.agentId = agentId;
 	}
 	if (estimateEventSize(event, MAX_EVENT_SIZE + 1) > MAX_EVENT_SIZE) {
 		state.droppedCount++;

--- a/extensions/copilot/src/extension/chronicle/common/test/eventTranslator.spec.ts
+++ b/extensions/copilot/src/extension/chronicle/common/test/eventTranslator.spec.ts
@@ -201,6 +201,99 @@ describe('translateSpan', () => {
 		// Critical: assistant.message must chain to session.start, not the dropped user.message.
 		expect(events[1].parentId).toBe(events[0].id);
 	});
+
+	it('folds sub-agent spans into parent: skips session.start + user.message and tags agentId', () => {
+		// Parent has already started (root invoke_agent emitted session.start + user.message).
+		const state = createSessionTranslationState();
+		state.started = true;
+		state.lastEventId = 'parent-last-event-id';
+
+		const outputMessages = JSON.stringify([
+			{ role: 'assistant', parts: [{ type: 'text', content: 'sub-agent reply' }] },
+		]);
+		const subagentSpan = makeSpan({
+			attributes: {
+				'gen_ai.operation.name': 'invoke_agent',
+				'copilot_chat.user_request': 'synthetic prompt to sub-agent',
+				'gen_ai.output.messages': outputMessages,
+			},
+		});
+
+		const events = translateSpan(subagentSpan, state, undefined, 'child-session-id');
+
+		// Only assistant.message should be emitted; session.start (parent owns it)
+		// and user.message (synthetic sub-agent prompt) must be suppressed.
+		expect(events.map(e => e.type)).toEqual(['assistant.message']);
+		expect(events[0].agentId).toBe('child-session-id');
+		expect(events[0].parentId).toBe('parent-last-event-id');
+	});
+
+	it('tags agentId on tool.execution_start events from sub-agent invoke_agent spans', () => {
+		const state = createSessionTranslationState();
+		state.started = true;
+		state.lastEventId = 'parent-last';
+
+		const outputMessages = JSON.stringify([
+			{
+				role: 'assistant',
+				parts: [
+					{ type: 'text', content: 'calling tool' },
+					{ type: 'tool-call', toolCallId: 'call-1', toolName: 'read_file', args: { path: 'a.ts' } },
+				],
+			},
+		]);
+		const span = makeSpan({
+			attributes: {
+				'gen_ai.operation.name': 'invoke_agent',
+				'gen_ai.output.messages': outputMessages,
+			},
+		});
+
+		const events = translateSpan(span, state, undefined, 'child-session-id');
+
+		expect(events.map(e => e.type)).toEqual(['assistant.message', 'tool.execution_start']);
+		expect(events.every(e => e.agentId === 'child-session-id')).toBe(true);
+	});
+
+	it('tags agentId on tool.execution_complete events from sub-agent execute_tool spans', () => {
+		const state = createSessionTranslationState();
+		state.started = true;
+		state.lastEventId = 'parent-last';
+
+		const span = makeSpan({
+			attributes: {
+				'gen_ai.operation.name': 'execute_tool',
+				'gen_ai.tool.name': 'read_file',
+				'gen_ai.tool.call.id': 'call-1',
+				'gen_ai.tool.result': 'file contents',
+			},
+		});
+
+		const events = translateSpan(span, state, undefined, 'child-session-id');
+
+		expect(events).toHaveLength(1);
+		expect(events[0].type).toBe('tool.execution_complete');
+		expect(events[0].agentId).toBe('child-session-id');
+	});
+
+	it('does not set agentId on events from non-sub-agent (root) spans', () => {
+		const state = createSessionTranslationState();
+		const outputMessages = JSON.stringify([
+			{ role: 'assistant', parts: [{ type: 'text', content: 'root reply' }] },
+		]);
+		const span = makeSpan({
+			attributes: {
+				'gen_ai.operation.name': 'invoke_agent',
+				'copilot_chat.user_request': 'hi',
+				'gen_ai.output.messages': outputMessages,
+			},
+		});
+
+		const events = translateSpan(span, state);
+
+		expect(events.map(e => e.type)).toEqual(['session.start', 'user.message', 'assistant.message']);
+		expect(events.every(e => e.agentId === undefined)).toBe(true);
+	});
 });
 
 describe('makeIdleEvent', () => {

--- a/extensions/copilot/src/extension/chronicle/vscode-node/remoteSessionExporter.ts
+++ b/extensions/copilot/src/extension/chronicle/vscode-node/remoteSessionExporter.ts
@@ -704,9 +704,13 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 				return;
 			}
 
-			// Only start tracking on invoke_agent (real user interaction)
+			// Only start tracking on invoke_agent (real user interaction).
+			// Sub-agent invoke_agent spans must never initialize the parent: child spans
+			// typically complete before their parent, and using a sub-agent span as the
+			// init trigger would seed sessionSource/firstCloudWriteSessionSource and
+			// telemetry from the sub-agent's AGENT_NAME instead of the parent's.
 			if (!this._cloudSessions.has(sessionId) && !this._initializingSessions.has(sessionId)) {
-				if (operationName !== GenAiOperationName.INVOKE_AGENT) {
+				if (operationName !== GenAiOperationName.INVOKE_AGENT || subagentId) {
 					return;
 				}
 				// Trigger lazy initialization — don't await, buffer events in the meantime

--- a/extensions/copilot/src/extension/chronicle/vscode-node/remoteSessionExporter.ts
+++ b/extensions/copilot/src/extension/chronicle/vscode-node/remoteSessionExporter.ts
@@ -690,7 +690,15 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 
 	private _handleSpan(span: ICompletedSpanData): void {
 		try {
-			const sessionId = this._getSessionId(span);
+			// For sub-agent spans, fold events into the parent session so they
+			// appear as one continuous timeline in the cloud rather than
+			// surfacing each sub-agent invocation as its own standalone session.
+			const parentChatSessionId = span.attributes[CopilotChatAttr.PARENT_CHAT_SESSION_ID] as string | undefined;
+			const ownChatSessionId = (span.attributes[CopilotChatAttr.CHAT_SESSION_ID] as string | undefined)
+				?? (span.attributes[GenAiAttr.CONVERSATION_ID] as string | undefined)
+				?? (span.attributes[CopilotChatAttr.SESSION_ID] as string | undefined);
+			const sessionId = parentChatSessionId ?? ownChatSessionId;
+			const subagentId = parentChatSessionId ? ownChatSessionId : undefined;
 			const operationName = span.attributes[GenAiAttr.OPERATION_NAME] as string | undefined;
 			if (!sessionId || this._disabledSessions.has(sessionId)) {
 				return;
@@ -708,7 +716,7 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 			// Translate span to cloud events
 			const state = this._getOrCreateTranslationState(sessionId);
 			const context = this._extractContext(span);
-			const events = translateSpan(span, state, context);
+			const events = translateSpan(span, state, context, subagentId);
 
 			if (events.length > 0) {
 				this._bufferEvents(sessionId, events);
@@ -717,12 +725,6 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 		} catch {
 			// Non-fatal — individual span processing failure
 		}
-	}
-
-	private _getSessionId(span: ICompletedSpanData): string | undefined {
-		return (span.attributes[CopilotChatAttr.CHAT_SESSION_ID] as string | undefined)
-			?? (span.attributes[GenAiAttr.CONVERSATION_ID] as string | undefined)
-			?? (span.attributes[CopilotChatAttr.SESSION_ID] as string | undefined);
 	}
 
 	private _getOrCreateTranslationState(sessionId: string): SessionTranslationState {

--- a/extensions/copilot/src/extension/chronicle/vscode-node/sessionStoreTracker.ts
+++ b/extensions/copilot/src/extension/chronicle/vscode-node/sessionStoreTracker.ts
@@ -158,8 +158,20 @@ export class SessionStoreTracker extends Disposable implements IExtensionContrib
 
 	private _handleSpan(span: ICompletedSpanData): void {
 		try {
-			const sessionId = this._getSessionId(span);
 			const operationName = span.attributes[GenAiAttr.OPERATION_NAME] as string | undefined;
+
+			// Sub-agent spans have no row of their own (schema has no sub-agent concept).
+			// Attribute their tool calls to the parent so we don't lose file/ref signal;
+			// drop their invoke_agent span — the parent's covers that turn.
+			const parentChatSessionId = span.attributes[CopilotChatAttr.PARENT_CHAT_SESSION_ID] as string | undefined;
+			if (parentChatSessionId) {
+				if (operationName === GenAiOperationName.EXECUTE_TOOL && this._initializedSessions.has(parentChatSessionId)) {
+					this._handleToolSpan(parentChatSessionId, span);
+				}
+				return;
+			}
+
+			const sessionId = this._getSessionId(span);
 			if (!sessionId) {
 				return;
 			}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/315808, https://github.com/microsoft/vscode/issues/316339

Bug fixes:
- sub-agent invocations were uploaded to the cloud as separate, standalone sessions, polluting the user's session list with many small one-shot entries that should have appeared inline in the parent's timeline.
- only latest message was stored due to incorrect tag