### PR TITLE
Fix terminal title overflow in panel toolbar

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/terminal.css
+++ b/src/vs/workbench/contrib/terminal/browser/media/terminal.css
@@ -477,6 +477,20 @@
 .monaco-action-bar .action-item .single-terminal-tab {
 	display: flex !important;
 	align-items: center;
+	min-width: 0;
+	max-width: 100%;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.monaco-action-bar .action-item.single-terminal-tab-container {
+	min-width: 0;
+	flex-shrink: 1;
+}
+
+.monaco-action-bar .action-item .single-terminal-tab .codicon {
+	flex-shrink: 0;
 }
 
 .monaco-action-bar .action-item .single-terminal-tab .codicon:first-child {

--- a/src/vs/workbench/contrib/terminal/browser/terminalView.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalView.ts
@@ -503,6 +503,7 @@ class SingleTerminalTabActionViewItem extends MenuEntryActionViewItem {
 				dom.reset(label, '');
 				return;
 			}
+			this.element?.classList.add('single-terminal-tab-container');
 			label.classList.add('single-terminal-tab');
 			let colorStyle = '';
 			const primaryStatus = instance.statusList.primary;


### PR DESCRIPTION
Fixes #312970

This updates the single-terminal tab action item used in the terminal panel toolbar so long terminal title/status content can shrink within the action bar instead of overflowing into neighboring toolbar actions.

### Changes
- add a dedicated class to the single terminal tab action item container
- allow the item and label to shrink, clip overflow, and keep codicons from collapsing

### Verification
- `git diff --check`

I was not able to run the full VS Code build/test suite in this sparse checkout.