### PR TITLE
Soft reconnect for remote agent host protocol client

### DIFF
--- a/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
@@ -10,7 +10,7 @@
 import { DeferredPromise, IntervalTimer } from '../../../base/common/async.js';
 import { CancellationError } from '../../../base/common/errors.js';
 import { Emitter } from '../../../base/common/event.js';
-import { Disposable, IReference } from '../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, MutableDisposable, IReference } from '../../../base/common/lifecycle.js';
 import { Schemas } from '../../../base/common/network.js';
 import { hasKey } from '../../../base/common/types.js';
 import { URI } from '../../../base/common/uri.js';
@@ -25,13 +25,19 @@ import type { ClientNotificationMap, CommandMap, JsonRpcErrorResponse, JsonRpcRe
 import { ActionType, type ActionEnvelope, type INotification, type IRootConfigChangedAction, type SessionAction, type TerminalAction } from '../common/state/sessionActions.js';
 import { SessionSummary, SessionStatus, ROOT_STATE_URI, StateComponents, type CustomizationRef, type RootState } from '../common/state/sessionState.js';
 import { PROTOCOL_VERSION } from '../common/state/protocol/version/registry.js';
-import { isJsonRpcNotification, isJsonRpcRequest, isJsonRpcResponse, ProtocolError, type ProtocolMessage, type IStateSnapshot } from '../common/state/sessionProtocol.js';
+import { isJsonRpcNotification, isJsonRpcRequest, isJsonRpcResponse, ProtocolError, ReconnectResultType, type ProtocolMessage, type IStateSnapshot } from '../common/state/sessionProtocol.js';
 import { isClientTransport, type IProtocolTransport } from '../common/state/sessionTransport.js';
 import { AhpErrorCodes } from '../common/state/protocol/errors.js';
 import { ContentEncoding, ResourceRequestParams, type CompletionsParams, type CompletionsResult, type CreateTerminalParams, type ResolveSessionConfigResult, type SessionConfigCompletionsResult } from '../common/state/protocol/commands.js';
 import { decodeBase64, encodeBase64, VSBuffer } from '../../../base/common/buffer.js';
 
 const AHP_CLIENT_CONNECTION_CLOSED = -32000;
+
+/** Initial delay before the first transport-level reconnect attempt. */
+const RECONNECT_INITIAL_DELAY_MS = 1_000;
+
+/** Upper bound on the exponential backoff between reconnect attempts. */
+const RECONNECT_MAX_DELAY_MS = 30_000;
 
 /**
  * How often the connection liveness watchdog runs.
@@ -71,9 +77,65 @@ function connectionDisposedError(address: string): ProtocolError {
 	return new ProtocolError(AHP_CLIENT_CONNECTION_CLOSED, `Connection disposed: ${address}`);
 }
 
+function transportLostError(address: string): ProtocolError {
+	return new ProtocolError(AHP_CLIENT_CONNECTION_CLOSED, `Transport lost (reconnecting): ${address}`);
+}
+
 interface IRemoteAgentHostExtensionCommandMap {
 	'shutdown': { params: undefined; result: void };
 }
+
+/**
+ * High-level connection state of a {@link RemoteAgentHostProtocolClient}.
+ * Exposed via {@link RemoteAgentHostProtocolClient.onDidChangeConnectionState}
+ * so consumers can surface transient reconnect activity in the UI.
+ */
+export const enum AgentHostClientState {
+	/** Initial handshake in progress. */
+	Connecting = 'connecting',
+	/** Transport is open and handshake/reconnect has completed. */
+	Connected = 'connected',
+	/** Transport closed unexpectedly; an automatic reconnect is in flight or scheduled. */
+	Reconnecting = 'reconnecting',
+	/** Client has been disposed or has given up reconnecting. Terminal state. */
+	Closed = 'closed',
+}
+
+/**
+ * Reconnect-only bookkeeping. Lives exclusively inside the `Reconnecting`
+ * variant of {@link ClientState} so the fields can't be read or mutated when
+ * they're not meaningful.
+ */
+interface IReconnectState {
+	/**
+	 * Resolves when the current attempt's handshake succeeds; rejected and
+	 * replaced (via {@link _newReconnectGate}) on a failed attempt so awaiting
+	 * callers see the failure while new callers gate on the next attempt.
+	 */
+	gate: DeferredPromise<void>;
+	/**
+	 * Wire messages buffered while the gate is engaged. Drained onto the new
+	 * transport by {@link _drainAfterReconnect} once the handshake completes;
+	 * survives across failed attempts so messages ride through retry cycles.
+	 */
+	readonly outbox: ProtocolMessage[];
+	/** Number of reconnect attempts performed in this reconnect cycle. */
+	attempt: number;
+	/** Timer for the next scheduled attempt, if any. */
+	timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+}
+
+/**
+ * Internal connection state, discriminated by {@link AgentHostClientState}.
+ * Mutually-exclusive fields (close error, reconnect bookkeeping) live inside
+ * the variant where they're meaningful so callers can't accidentally read or
+ * write them in the wrong state.
+ */
+type ClientState =
+	| { readonly kind: AgentHostClientState.Connecting }
+	| { readonly kind: AgentHostClientState.Connected }
+	| { readonly kind: AgentHostClientState.Reconnecting; readonly reconnect: IReconnectState }
+	| { readonly kind: AgentHostClientState.Closed; readonly error: ProtocolError };
 
 /**
  * A protocol-level client for a single remote agent host connection.
@@ -89,7 +151,10 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 
 	private readonly _clientId = generateUuid();
 	private readonly _address: string;
-	private readonly _transport: IProtocolTransport;
+	private readonly _transportFactory: (() => IProtocolTransport) | undefined;
+	private _transport!: IProtocolTransport;
+	/** Disposable holding the listeners attached to the current transport. */
+	private readonly _transportListeners = this._register(new MutableDisposable<DisposableStore>());
 	private readonly _connectionAuthority: string;
 	private _serverSeq = 0;
 	private _nextClientSeq = 1;
@@ -106,11 +171,20 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 	private readonly _onDidClose = this._register(new Emitter<void>());
 	readonly onDidClose = this._onDidClose.event;
 
+	private readonly _onDidChangeConnectionState = this._register(new Emitter<AgentHostClientState>());
+	readonly onDidChangeConnectionState = this._onDidChangeConnectionState.event;
+
+	/**
+	 * Discriminated state union. Read via narrowing (`_state.kind === ...`);
+	 * reconnect-only fields like the gate/outbox/attempt counter are only
+	 * accessible while {@link _state.kind} is {@link AgentHostClientState.Reconnecting},
+	 * and the close error is only accessible while it's {@link AgentHostClientState.Closed}.
+	 */
+	private _state: ClientState = { kind: AgentHostClientState.Connecting };
+
 	/** Pending JSON-RPC requests keyed by request id. */
 	private readonly _pendingRequests = new Map<number, { deferred: DeferredPromise<unknown>; sentAt: number }>();
 	private _nextRequestId = 1;
-	private _isClosed = false;
-	private _closeError: ProtocolError | undefined;
 
 	/**
 	 * Timestamp of the most recent message of any kind received from the
@@ -147,9 +221,13 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 		return this._defaultDirectory;
 	}
 
+	get connectionState(): AgentHostClientState {
+		return this._state.kind;
+	}
+
 	constructor(
 		address: string,
-		transport: IProtocolTransport,
+		transportOrFactory: IProtocolTransport | (() => IProtocolTransport),
 		@ILogService private readonly _logService: ILogService,
 		@IFileService private readonly _fileService: IFileService,
 		@IAgentHostPermissionService private readonly _permissionService: IAgentHostPermissionService,
@@ -157,10 +235,14 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 		super();
 		this._address = address;
 		this._connectionAuthority = agentHostAuthority(address);
-		this._transport = transport;
-		this._register(this._transport);
-		this._register(this._transport.onMessage(msg => this._handleMessage(msg)));
-		this._register(this._transport.onClose(() => this._handleClose(connectionClosedError(this._address))));
+
+		if (typeof transportOrFactory === 'function') {
+			this._transportFactory = transportOrFactory;
+			this._installTransport(transportOrFactory());
+		} else {
+			this._transportFactory = undefined;
+			this._installTransport(transportOrFactory);
+		}
 
 		this._subscriptionManager = this._register(new AgentSubscriptionManager(
 			this._clientId,
@@ -177,6 +259,47 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 
 		// Detect silently-dead transports — see {@link _watchdogTick}.
 		this._watchdog.cancelAndSet(() => this._watchdogTick(), WATCHDOG_CHECK_INTERVAL_MS);
+	}
+
+	/**
+	 * Install a transport and wire listeners. Used both for the initial
+	 * transport and for replacements created by the factory during a
+	 * transport-level reconnect.
+	 */
+	private _installTransport(transport: IProtocolTransport): void {
+		const listeners = new DisposableStore();
+		listeners.add(transport);
+		listeners.add(transport.onMessage(msg => this._handleMessage(msg)));
+		listeners.add(transport.onClose(() => this._handleTransportClose()));
+		this._transport = transport;
+		this._transportListeners.value = listeners;
+	}
+
+	/**
+	 * Transition to a new {@link ClientState}. Fires {@link onDidChangeConnectionState}
+	 * only when the variant kind actually changes; in-place mutation of
+	 * reconnect-state fields (e.g. swapping the gate on a failed retry) does
+	 * NOT count as a transition and produces no event.
+	 */
+	private _transitionTo(next: ClientState): void {
+		if (this._state.kind === next.kind) {
+			return;
+		}
+		this._state = next;
+		this._onDidChangeConnectionState.fire(next.kind);
+	}
+
+	private _newReconnectGate(): DeferredPromise<void> {
+		const deferred = new DeferredPromise<void>();
+		// Always-attached handler so a rejection without an awaiter (e.g. a
+		// retry-fail during the reconnect RPC bypass window) doesn't get
+		// flagged as unhandled. Actual consumers attach their own `.then`/`await`.
+		deferred.p.then(undefined, () => { /* swallow — each real consumer handles its own await */ });
+		return deferred;
+	}
+
+	private _newReconnectState(): IReconnectState {
+		return { gate: this._newReconnectGate(), outbox: [], attempt: 0, timeoutHandle: undefined };
 	}
 
 	override dispose(): void {
@@ -216,6 +339,235 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 		}
 
 		this._completionTriggerCharacters = result.completionTriggerCharacters ?? [];
+		this._transitionTo({ kind: AgentHostClientState.Connected });
+	}
+
+	/**
+	 * Called from the transport's `onClose` event. When a {@link _transportFactory}
+	 * is configured we attempt to soft-reconnect rather than fire `onDidClose` —
+	 * the protocol-level `reconnect` request lets the server replay missed
+	 * actions and preserves the `clientId` so pending tool calls etc. are not
+	 * cancelled by the host-side disconnect timeout. Without a factory
+	 * (passive-transport SSH/relay path) we fall back to "close means closed"
+	 * and let the service decide whether to spin up a fresh client.
+	 */
+	private _handleTransportClose(): void {
+		switch (this._state.kind) {
+			case AgentHostClientState.Closed:
+				return;
+			case AgentHostClientState.Connecting:
+				// No handshake yet; we can't resume so always treat as fatal
+				// regardless of whether a factory is configured.
+				this._handleClose(connectionClosedError(this._address));
+				return;
+			case AgentHostClientState.Connected: {
+				if (!this._transportFactory) {
+					// Passive-transport path (SSH/tunnel): the transport
+					// can't be reconstructed from here, so we surface the
+					// close and let the service decide whether to spin up
+					// a fresh client.
+					this._handleClose(connectionClosedError(this._address));
+					return;
+				}
+				this._logService.info(`[RemoteAgentHostProtocol] Transport lost for ${this._address}; scheduling reconnect.`);
+				this._transitionTo({ kind: AgentHostClientState.Reconnecting, reconnect: this._newReconnectState() });
+				this._watchdog.cancel();
+				// In-flight requests can't be answered — the new transport has a
+				// separate request-id space. Reject them so callers can retry.
+				this._rejectPendingRequests(transportLostError(this._address));
+				this._scheduleReconnect();
+				return;
+			}
+			case AgentHostClientState.Reconnecting:
+				// A second transport drop while a reconnect was already in flight.
+				// Reject the in-flight `reconnect` RPC so `_attemptReconnect`'s
+				// catch path runs and schedules the next attempt — returning early
+				// would leave the await pending forever (#agent-host-deadlock).
+				// Scheduling lives in the catch so we don't end up with two
+				// concurrent setTimeouts racing to install new transports.
+				this._logService.info(`[RemoteAgentHostProtocol] Transport lost for ${this._address} mid-reconnect; aborting the current attempt.`);
+				this._watchdog.cancel();
+				this._rejectPendingRequests(transportLostError(this._address));
+				return;
+		}
+	}
+
+	private _scheduleReconnect(): void {
+		if (this._state.kind !== AgentHostClientState.Reconnecting || !this._transportFactory) {
+			return;
+		}
+		const reconnect = this._state.reconnect;
+		if (reconnect.timeoutHandle !== undefined) {
+			return;
+		}
+		const attempt = reconnect.attempt + 1;
+		const delay = Math.min(RECONNECT_INITIAL_DELAY_MS * Math.pow(2, attempt - 1), RECONNECT_MAX_DELAY_MS);
+		this._logService.info(`[RemoteAgentHostProtocol] Reconnecting to ${this._address} in ${delay}ms (attempt ${attempt}).`);
+		reconnect.timeoutHandle = setTimeout(() => {
+			if (this._state.kind === AgentHostClientState.Reconnecting) {
+				this._state.reconnect.timeoutHandle = undefined;
+			}
+			void this._attemptReconnect();
+		}, delay);
+	}
+
+	private async _attemptReconnect(): Promise<void> {
+		if (this._state.kind !== AgentHostClientState.Reconnecting || !this._transportFactory) {
+			return;
+		}
+		const reconnect = this._state.reconnect;
+		reconnect.attempt++;
+		let transport: IProtocolTransport | undefined;
+		try {
+			transport = this._transportFactory();
+			this._installTransport(transport);
+			if (isClientTransport(transport)) {
+				await transport.connect();
+			}
+			if (this._state.kind !== AgentHostClientState.Reconnecting) {
+				return;
+			}
+
+			const subscriptions = this._subscriptionManager.currentSubscriptionUris().map(u => u.toString());
+			// Always include the always-live root state alongside getSubscription-managed entries.
+			if (!subscriptions.includes(ROOT_STATE_URI)) {
+				subscriptions.unshift(ROOT_STATE_URI);
+			}
+			const lastSeenServerSeq = this._serverSeq;
+			const result = await this._dispatchRequest<CommandMap['reconnect']['result']>('reconnect', {
+				clientId: this._clientId,
+				lastSeenServerSeq,
+				subscriptions,
+			}, { bypassReconnectGate: true });
+
+			if (this._state.kind !== AgentHostClientState.Reconnecting) {
+				return;
+			}
+
+			this._applyReconnectResult(result);
+
+			// Drain the outbox BEFORE the transition so listeners reacting to
+			// {@link onDidChangeConnectionState} that synchronously dispatch see
+			// state=Connected and go direct, landing after the drained outbox
+			// in wire order.
+			const { gate } = reconnect;
+			this._drainAfterReconnect(reconnect.outbox);
+
+			this._lastReadTime = Date.now();
+			this._watchdog.cancelAndSet(() => this._watchdogTick(), WATCHDOG_CHECK_INTERVAL_MS);
+			this._transitionTo({ kind: AgentHostClientState.Connected });
+			gate.complete();
+			this._logService.info(`[RemoteAgentHostProtocol] Reconnected to ${this._address}.`);
+		} catch (err) {
+			this._logService.warn(`[RemoteAgentHostProtocol] Reconnect attempt failed for ${this._address}: ${err instanceof Error ? err.message : String(err)}`);
+			transport?.dispose();
+			if (this._state.kind !== AgentHostClientState.Reconnecting) {
+				return;
+			}
+			// Replace the gate so awaiting callers see the failure but new
+			// callers gate on the next attempt instead of slipping through onto
+			// the dead transport. Outbox carries forward to the next attempt.
+			const oldGate = this._state.reconnect.gate;
+			this._state.reconnect.gate = this._newReconnectGate();
+			oldGate.error(err);
+			this._scheduleReconnect();
+		}
+	}
+
+	/**
+	 * Apply a `reconnect` RPC result to the subscription manager. On `replay`
+	 * we feed each missed envelope through the normal action path; on
+	 * `snapshot` we reseat each named subscription with the fresh state and
+	 * advance the server seq cursor accordingly.
+	 */
+	private _applyReconnectResult(result: CommandMap['reconnect']['result']): void {
+		if (result.type === ReconnectResultType.Replay) {
+			let maxSeq = this._serverSeq;
+			for (const envelope of result.actions) {
+				// For own non-rejected actions, drop the matching pending entry up
+				// front so we don't resend it via {@link _replayPendingActions}.
+				// For rejected actions we MUST leave the entry in place so the
+				// subscription's reconcile path sees `idx !== -1` and discards
+				// the action instead of applying it to confirmed state.
+				if (envelope.origin?.clientId === this._clientId
+					&& envelope.origin.clientSeq !== undefined
+					&& !envelope.rejectionReason
+					&& hasKey(envelope.action, { session: true })) {
+					this._subscriptionManager.dropPendingSessionAction(envelope.action.session, envelope.origin.clientSeq);
+				}
+				if (envelope.serverSeq > maxSeq) {
+					maxSeq = envelope.serverSeq;
+				}
+				this._onDidAction.fire(envelope);
+			}
+			this._serverSeq = maxSeq;
+			if (result.missing.length > 0) {
+				this._logService.info(`[RemoteAgentHostProtocol] Server cannot resume ${result.missing.length} subscription(s) after reconnect.`);
+				this._subscriptionManager.markSubscriptionsMissing(result.missing.map(u => URI.parse(u)));
+			}
+		} else {
+			let maxSeq = this._serverSeq;
+			for (const snapshot of result.snapshots) {
+				this._subscriptionManager.applyReconnectSnapshot(URI.parse(snapshot.resource), snapshot.state, snapshot.fromSeq);
+				if (snapshot.fromSeq > maxSeq) {
+					maxSeq = snapshot.fromSeq;
+				}
+			}
+			this._serverSeq = maxSeq;
+		}
+	}
+
+	/**
+	 * Drain queued outgoing wire traffic after a successful soft reconnect:
+	 *
+	 * 1. Resend pending optimistic session actions that the server did NOT
+	 *    echo back in the replay buffer (i.e. anything still on
+	 *    {@link AgentSubscriptionManager.getPendingSessionActions}).
+	 * 2. Flush every message that {@link _sendNotification} queued onto the
+	 *    outbox while the gate was engaged.
+	 *
+	 * Replays are deduped against the outbox by `clientSeq` so a session
+	 * action that was both optimistic-tracked AND queued during the
+	 * reconnect window only goes out once.
+	 */
+	private _drainAfterReconnect(outbox: readonly ProtocolMessage[]): void {
+		// Build the set of clientSeqs already represented in the outbox so we
+		// don't replay a duplicate. Only `dispatchAction` notifications carry
+		// a clientSeq; nothing else is independently re-emitted by the replay
+		// path, so other queued message kinds need no dedup.
+		const queuedSeqs = new Set<number>();
+		for (const msg of outbox) {
+			if (hasKey(msg, { method: true }) && msg.method === 'dispatchAction') {
+				queuedSeqs.add(msg.params.clientSeq);
+			}
+		}
+
+		const replays: ProtocolMessage[] = [];
+		for (const entry of this._subscriptionManager.getPendingSessionActions()) {
+			if (queuedSeqs.has(entry.clientSeq)) {
+				continue;
+			}
+			this._grantImplicitReadsForOutgoingAction(entry.action);
+			replays.push({
+				jsonrpc: '2.0',
+				method: 'dispatchAction',
+				params: { clientSeq: entry.clientSeq, action: entry.action },
+			});
+		}
+
+		if (replays.length > 0) {
+			this._logService.info(`[RemoteAgentHostProtocol] Replaying ${replays.length} pending action(s) after reconnect to ${this._address}.`);
+		}
+
+		// Replays first (dispatched before the reconnect window), then the
+		// outbox (dispatched during it) so wire order roughly tracks
+		// dispatch order.
+		for (const msg of replays) {
+			this._transport.send(msg);
+		}
+		for (const msg of outbox) {
+			this._transport.send(msg);
+		}
 	}
 
 	// ---- IAgentConnection subscription API ----------------------------------
@@ -255,7 +607,7 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 	/**
 	 * Dispatch a client action to the server. Returns the clientSeq used.
 	 */
-	dispatchAction(action: SessionAction | TerminalAction | IRootConfigChangedAction, _clientId: string, clientSeq: number): void {
+	private dispatchAction(action: SessionAction | TerminalAction | IRootConfigChangedAction, _clientId: string, clientSeq: number): void {
 		this._grantImplicitReadsForOutgoingAction(action);
 		this._sendNotification('dispatchAction', { clientSeq, action });
 	}
@@ -446,7 +798,7 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 	}
 
 	private _handleMessage(msg: ProtocolMessage): void {
-		if (this._isClosed) {
+		if (this._state.kind === AgentHostClientState.Closed) {
 			// After close, the transport may still emit late messages (e.g.
 			// because the same shared event source is also feeding a newer
 			// transport for the same connectionId). Drop them so they can't
@@ -499,29 +851,38 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 	}
 
 	private _handleClose(error: ProtocolError): void {
-		if (this._isClosed) {
+		if (this._state.kind === AgentHostClientState.Closed) {
 			return;
 		}
-
-		this._isClosed = true;
-		this._closeError = error;
 		// Stop the watchdog so it doesn't keep ticking on a dead connection
 		// (the client may outlive the close, waiting to be replaced).
 		this._watchdog.cancel();
+		if (this._state.kind === AgentHostClientState.Reconnecting) {
+			const reconnect = this._state.reconnect;
+			if (reconnect.timeoutHandle !== undefined) {
+				clearTimeout(reconnect.timeoutHandle);
+			}
+			if (!reconnect.gate.isSettled) {
+				reconnect.gate.error(error);
+			}
+			// Outbox is dropped when the reconnect state is discarded by the
+			// transition below.
+		}
 		this._rejectPendingRequests(error);
 		this._permissionService.connectionClosed(this._address);
 		this._grantedCustomizationUris.clear();
+		this._transitionTo({ kind: AgentHostClientState.Closed, error });
 		this._onDidClose.fire();
 	}
 
 	private async _raceClose<T>(promise: Promise<T>): Promise<T> {
-		if (this._closeError) {
-			return Promise.reject(this._closeError);
+		if (this._state.kind === AgentHostClientState.Closed) {
+			return Promise.reject(this._state.error);
 		}
 
 		let closeListener = Disposable.None;
 		const closePromise = new Promise<never>((_resolve, reject) => {
-			closeListener = this.onDidClose(() => reject(this._closeError));
+			closeListener = this.onDidClose(() => reject(this._state.kind === AgentHostClientState.Closed ? this._state.error : connectionClosedError(this._address)));
 		});
 
 		try {
@@ -542,8 +903,14 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 	 * `resourceRequest` and retry.
 	 */
 	private _handleReverseRequest(id: number, method: string, params: unknown): void {
+		// Capture the transport at request-entry so async handlers (permission
+		// checks, file ops) reply on the same transport the request arrived on.
+		// Without this, a soft reconnect mid-handler would route the response
+		// onto a new transport with a stale id — stray response at best, id
+		// collision with a new server-issued reverse RPC at worst.
+		const transport = this._transport;
 		const sendResult = (result: unknown) => {
-			this._transport.send({ jsonrpc: '2.0', id, result });
+			transport.send({ jsonrpc: '2.0', id, result });
 		};
 		const sendError = (err: unknown) => {
 			const fsCode = toFileSystemProviderErrorCode(err instanceof Error ? err : undefined);
@@ -553,10 +920,10 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 				case FileSystemProviderErrorCode.NoPermissions: code = AhpErrorCodes.PermissionDenied; break;
 				case FileSystemProviderErrorCode.FileExists: code = AhpErrorCodes.AlreadyExists; break;
 			}
-			this._transport.send({ jsonrpc: '2.0', id, error: { code, message: err instanceof Error ? err.message : String(err) } });
+			transport.send({ jsonrpc: '2.0', id, error: { code, message: err instanceof Error ? err.message : String(err) } });
 		};
 		const sendPermissionDenied = (request: ResourceRequestParams | undefined) => {
-			this._transport.send({
+			transport.send({
 				jsonrpc: '2.0',
 				id,
 				error: {
@@ -677,30 +1044,70 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 
 	/** Send a typed JSON-RPC notification for a protocol-defined method. */
 	private _sendNotification<M extends keyof ClientNotificationMap>(method: M, params: ClientNotificationMap[M]['params']): void {
+		if (this._state.kind === AgentHostClientState.Closed) {
+			return;
+		}
 		// Generic M can't satisfy the distributive AhpNotification union directly
 		// eslint-disable-next-line local/code-no-dangerous-type-assertions
-		this._transport.send({ jsonrpc: '2.0' as const, method, params } as ProtocolMessage);
+		const message = { jsonrpc: '2.0' as const, method, params } as ProtocolMessage;
+		if (this._state.kind === AgentHostClientState.Reconnecting) {
+			// Queue for the new transport — drained by {@link _drainAfterReconnect}
+			// once the soft-reconnect handshake completes. The outbox persists
+			// across failed attempts so a message rides through retry cycles
+			// rather than being silently dropped.
+			this._state.reconnect.outbox.push(message);
+			return;
+		}
+		this._transport.send(message);
 	}
 
 	/** Send a typed JSON-RPC request for a protocol-defined method. */
 	private _sendRequest<M extends keyof CommandMap>(method: M, params: CommandMap[M]['params']): Promise<CommandMap[M]['result']> {
-		if (this._closeError) {
-			return Promise.reject(this._closeError);
-		}
-
-		const id = this._nextRequestId++;
-		const deferred = new DeferredPromise<unknown>();
-		this._pendingRequests.set(id, { deferred, sentAt: Date.now() });
-		// Generic M can't satisfy the distributive AhpRequest union directly
-		// eslint-disable-next-line local/code-no-dangerous-type-assertions
-		this._transport.send({ jsonrpc: '2.0' as const, id, method, params } as ProtocolMessage);
-		return deferred.p as Promise<CommandMap[M]['result']>;
+		return this._dispatchRequest<CommandMap[M]['result']>(method, params);
 	}
 
 	/** Send a JSON-RPC request for a VS Code extension method (not in the protocol spec). */
 	private _sendExtensionRequest<M extends keyof IRemoteAgentHostExtensionCommandMap>(method: M, params?: IRemoteAgentHostExtensionCommandMap[M]['params']): Promise<IRemoteAgentHostExtensionCommandMap[M]['result']> {
-		if (this._closeError) {
-			return Promise.reject(this._closeError);
+		return this._dispatchRequest<IRemoteAgentHostExtensionCommandMap[M]['result']>(method, params);
+	}
+
+	/**
+	 * Common path for outgoing JSON-RPC requests: gate on any in-flight
+	 * reconnect (unless explicitly bypassed for the `reconnect` RPC itself),
+	 * assign an id, register the pending deferred, and write to the wire.
+	 *
+	 * The bypass option is the single special case that exists: the
+	 * `reconnect` request is sent from inside `_attemptReconnect` while the
+	 * gate is engaged, so it can't wait on its own resolution.
+	 */
+	private async _dispatchRequest<TResult>(
+		method: string,
+		params: unknown,
+		options: { readonly bypassReconnectGate?: boolean } = {},
+	): Promise<TResult> {
+		if (this._state.kind === AgentHostClientState.Closed) {
+			throw this._state.error;
+		}
+
+		if (this._state.kind === AgentHostClientState.Reconnecting && !options.bypassReconnectGate) {
+			const gate = this._state.reconnect.gate;
+			try {
+				await gate.p;
+			} catch (err) {
+				// Reconnect failed; surface the same error to the caller so
+				// they don't hang on a request that can never complete on this
+				// attempt. The protocol client's own retry loop continues in
+				// the background.
+				const after = this._state as ClientState;
+				if (after.kind === AgentHostClientState.Closed) {
+					throw after.error;
+				}
+				throw err instanceof ProtocolError ? err : connectionClosedError(this._address);
+			}
+			const after = this._state as ClientState;
+			if (after.kind === AgentHostClientState.Closed) {
+				throw after.error;
+			}
 		}
 
 		const id = this._nextRequestId++;
@@ -708,7 +1115,7 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 		this._pendingRequests.set(id, { deferred, sentAt: Date.now() });
 		const request: JsonRpcRequest = { jsonrpc: '2.0', id, method, params };
 		this._transport.send(request);
-		return deferred.p as Promise<IRemoteAgentHostExtensionCommandMap[M]['result']>;
+		return deferred.p as Promise<TResult>;
 	}
 
 	private _toProtocolError(error: JsonRpcErrorResponse['error']): ProtocolError {
@@ -735,7 +1142,7 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 	 * counting ticks.
 	 */
 	private _watchdogTick(): void {
-		if (this._isClosed || this._pendingRequests.size === 0) {
+		if (this._state.kind === AgentHostClientState.Closed || this._pendingRequests.size === 0) {
 			return;
 		}
 		const now = Date.now();
@@ -762,6 +1169,17 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 			+ `${this._pendingRequests.size} request(s) outstanding, no message received for ${sinceLastRead}ms, `
 			+ `oldest request ${oldestAge}ms old. Forcing close to trigger reconnect.`,
 		);
+		if (this._transportFactory) {
+			// In factory mode, route directly through the soft-reconnect path.
+			// We can't rely on `_transport.dispose()` to fire the transport's
+			// `onClose` listener: WebSocketClientTransport.dispose() disposes
+			// its emitters synchronously before the native WebSocket close
+			// event arrives, so a watchdog-triggered dispose alone would never
+			// reach {@link _handleTransportClose} and the client would stall.
+			this._rejectPendingRequests(connectionTimeoutError(this._address, sinceLastRead, oldestAge));
+			this._handleTransportClose();
+			return;
+		}
 		this._handleClose(connectionTimeoutError(this._address, sinceLastRead, oldestAge));
 	}
 

--- a/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
@@ -1085,29 +1085,30 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 		params: unknown,
 		options: { readonly bypassReconnectGate?: boolean } = {},
 	): Promise<TResult> {
+		// Ride through any number of reconnect cycles until the client is
+		// either Connected (proceed) or Closed (throw). A transient failed
+		// attempt does NOT surface to the caller — the request stays gated
+		// until the connection eventually resumes, matching how the
+		// notification outbox rides across retries. A subsequent transport
+		// drop that bounces us back into Reconnecting after the gate already
+		// resolved is also handled here: the loop re-checks state on each
+		// iteration so we never send on a dead/reconnecting transport.
+		while (!options.bypassReconnectGate && this._state.kind === AgentHostClientState.Reconnecting) {
+			const current = this._state as ClientState;
+			if (current.kind !== AgentHostClientState.Reconnecting) {
+				break;
+			}
+			try {
+				await current.reconnect.gate.p;
+			} catch {
+				// Transient attempt failure — swallow and re-check state on the
+				// next loop iteration. If we transitioned to Closed the check
+				// after the loop surfaces the error; if we're still Reconnecting
+				// with a fresh gate we'll await that one.
+			}
+		}
 		if (this._state.kind === AgentHostClientState.Closed) {
 			throw this._state.error;
-		}
-
-		if (this._state.kind === AgentHostClientState.Reconnecting && !options.bypassReconnectGate) {
-			const gate = this._state.reconnect.gate;
-			try {
-				await gate.p;
-			} catch (err) {
-				// Reconnect failed; surface the same error to the caller so
-				// they don't hang on a request that can never complete on this
-				// attempt. The protocol client's own retry loop continues in
-				// the background.
-				const after = this._state as ClientState;
-				if (after.kind === AgentHostClientState.Closed) {
-					throw after.error;
-				}
-				throw err instanceof ProtocolError ? err : connectionClosedError(this._address);
-			}
-			const after = this._state as ClientState;
-			if (after.kind === AgentHostClientState.Closed) {
-				throw after.error;
-			}
 		}
 
 		const id = this._nextRequestId++;

--- a/src/vs/platform/agentHost/browser/remoteAgentHostServiceImpl.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostServiceImpl.ts
@@ -30,7 +30,7 @@ import {
 	type IRemoteAgentHostConnectionInfo,
 	type IRemoteAgentHostEntry,
 } from '../common/remoteAgentHostService.js';
-import { RemoteAgentHostProtocolClient } from './remoteAgentHostProtocolClient.js';
+import { RemoteAgentHostProtocolClient, AgentHostClientState } from './remoteAgentHostProtocolClient.js';
 import { WebSocketClientTransport } from './webSocketClientTransport.js';
 import { AGENT_HOST_LABEL_FORMATTER, AGENT_HOST_SCHEME, agentHostAuthority, normalizeRemoteAgentHostAddress } from '../common/agentHostUri.js';
 import { isDefined } from '../../../base/common/types.js';
@@ -402,15 +402,19 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 
 		const store = new DisposableStore();
 		const ahpLoggingEnabled = !!this._configurationService.getValue<boolean>(AgentHostAhpJsonlLoggingSettingId);
-		const transport = store.add(this._instantiationService.createInstance(
+		// Factory so the protocol client can replace the underlying transport
+		// across transient drops and use the `reconnect` RPC to resume — see
+		// {@link RemoteAgentHostProtocolClient}. The store owns only the client;
+		// individual transports are owned by the client itself.
+		const transportFactory = () => this._instantiationService.createInstance(
 			WebSocketClientTransport,
 			address,
 			connectionToken,
 			ahpLoggingEnabled
 				? { logsHome: this._environmentService.logsHome, connectionId: address, transport: 'websocket' }
 				: undefined,
-		));
-		const client = store.add(this._instantiationService.createInstance(RemoteAgentHostProtocolClient, address, transport));
+		);
+		const client = store.add(this._instantiationService.createInstance(RemoteAgentHostProtocolClient, address, transportFactory));
 		const entry: IConnectionEntry = { store, client, connected: false, status: RemoteAgentHostConnectionStatus.connecting };
 		this._entries.set(address, entry);
 
@@ -426,8 +430,34 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 			entry.connected = false;
 			entry.status = RemoteAgentHostConnectionStatus.disconnected;
 			this._onDidChangeConnections.fire();
-			// Schedule reconnect if the address is still configured
+			// Schedule reconnect if the address is still configured. This is
+			// the "fatal" path — the protocol client already gave up its own
+			// soft-reconnect attempts (or it was never enabled), so we rebuild
+			// from scratch.
 			this._scheduleReconnect(address, connectionToken);
+		}));
+
+		// Reflect transient transport drops as `connecting` status (rather
+		// than `disconnected`) so the UI doesn't flicker session lists into
+		// an empty state during a soft reconnect.
+		store.add(client.onDidChangeConnectionState(state => {
+			if (!isCurrentEntry()) {
+				return;
+			}
+			switch (state) {
+				case AgentHostClientState.Reconnecting:
+					entry.connected = false;
+					entry.status = RemoteAgentHostConnectionStatus.connecting;
+					this._onDidChangeConnections.fire();
+					break;
+				case AgentHostClientState.Connected:
+					entry.connected = true;
+					entry.status = RemoteAgentHostConnectionStatus.connected;
+					this._onDidChangeConnections.fire();
+					break;
+				default:
+					break;
+			}
 		}));
 
 		this._logService.info(`[RemoteAgentHost] Connecting to ${address}`);

--- a/src/vs/platform/agentHost/common/state/agentSubscription.ts
+++ b/src/vs/platform/agentHost/common/state/agentSubscription.ts
@@ -14,7 +14,7 @@ import { terminalReducer } from './protocol/reducers.js';
 import type { RootAction, SessionAction as IProtocolSessionAction, TerminalAction } from './protocol/action-origin.generated.js';
 import type { RootState, SessionState, TerminalState } from './protocol/state.js';
 import type { IStateSnapshot } from './sessionProtocol.js';
-import { StateComponents } from './sessionState.js';
+import { ROOT_STATE_URI, StateComponents } from './sessionState.js';
 
 // --- Public API --------------------------------------------------------------
 
@@ -201,6 +201,11 @@ interface IPendingAction {
 	readonly action: SessionAction;
 }
 
+export interface IPendingSessionAction extends IPendingAction {
+	/** URI of the session this action targets, as stored on the subscription. */
+	readonly sessionUri: string;
+}
+
 /**
  * Subscription to a session at `copilot:/<uuid>`.
  * Supports write-ahead reconciliation for client-dispatchable actions.
@@ -310,6 +315,31 @@ export class SessionStateSubscription extends BaseAgentSubscription<SessionState
 	clearPending(): void {
 		this._pendingActions.length = 0;
 		this._optimisticState = undefined;
+	}
+
+	/**
+	 * Snapshot of the currently-pending optimistic actions, with the session
+	 * URI included so callers can re-issue them across a reconnect. The
+	 * actions remain in the subscription so the optimistic state continues
+	 * to reflect them — the client must explicitly drop entries echoed back
+	 * by the server.
+	 */
+	getPendingActions(): IPendingSessionAction[] {
+		return this._pendingActions.map(p => ({ clientSeq: p.clientSeq, action: p.action, sessionUri: this._sessionUri }));
+	}
+
+	/**
+	 * Drop the pending entry whose `clientSeq` matches the supplied value.
+	 * Used during reconnect to evict actions the server already echoed back
+	 * in the replay buffer so they're not resent.
+	 */
+	dropPendingByClientSeq(clientSeq: number): boolean {
+		const idx = this._pendingActions.findIndex(p => p.clientSeq === clientSeq);
+		if (idx === -1) {
+			return false;
+		}
+		this._pendingActions.splice(idx, 1);
+		return true;
 	}
 }
 
@@ -462,6 +492,90 @@ export class AgentSubscriptionManager extends Disposable {
 			}
 		}
 		return this._seqAllocator();
+	}
+
+	/**
+	 * URIs currently subscribed to via {@link getSubscription}. Used to
+	 * build the `subscriptions` payload for a `reconnect` RPC so the
+	 * server can restore them in one round-trip.
+	 *
+	 * Does NOT include the always-live root state, which the protocol
+	 * client manages separately.
+	 */
+	currentSubscriptionUris(): URI[] {
+		return [...this._subscriptions.keys()];
+	}
+
+	/**
+	 * Snapshot of every pending optimistic action across all session
+	 * subscriptions. Callers use this to replay actions after a transport
+	 * reconnect; entries are kept on their subscriptions until they're
+	 * either echoed back by the server or explicitly dropped via
+	 * {@link dropPendingSessionAction}.
+	 */
+	getPendingSessionActions(): IPendingSessionAction[] {
+		const out: IPendingSessionAction[] = [];
+		for (const { sub } of this._subscriptions.values()) {
+			if (sub instanceof SessionStateSubscription) {
+				out.push(...sub.getPendingActions());
+			}
+		}
+		return out;
+	}
+
+	/**
+	 * Remove a single pending optimistic action for a session by its
+	 * `clientSeq`. Used during reconnect to evict actions the server
+	 * already processed (and replayed back to us) so they're not resent.
+	 */
+	dropPendingSessionAction(sessionUri: string, clientSeq: number): void {
+		const entry = this._subscriptions.get(URI.parse(sessionUri));
+		if (entry?.sub instanceof SessionStateSubscription) {
+			entry.sub.dropPendingByClientSeq(clientSeq);
+		}
+	}
+
+	/**
+	 * Apply a fresh snapshot to a subscribed resource — used when the server
+	 * responds to a `reconnect` request with `type: 'snapshot'` because the
+	 * replay buffer no longer covers the client's gap. Routes to the root
+	 * subscription when {@link ROOT_STATE_URI} matches, otherwise reseats the
+	 * matching entry in {@link _subscriptions}. Unknown resources are ignored.
+	 */
+	applyReconnectSnapshot(resource: URI, state: unknown, fromSeq: number): void {
+		if (resource.toString() === ROOT_STATE_URI) {
+			this._rootState.handleSnapshot(state as RootState, fromSeq);
+			return;
+		}
+		const entry = this._subscriptions.get(resource);
+		if (!entry) {
+			return;
+		}
+		// Clear any pending optimistic actions before reseating confirmed
+		// state \u2014 they were predicated on the pre-disconnect confirmed
+		// state and won't reconcile correctly against a fresh snapshot.
+		if (entry.sub instanceof SessionStateSubscription) {
+			entry.sub.clearPending();
+		}
+		entry.sub.handleSnapshot(state as never, fromSeq);
+	}
+
+	/**
+	 * Mark a set of subscriptions as no longer resumable on the server
+	 * (reported via `ReconnectReplayResult.missing`). The subscriptions
+	 * themselves stay alive so consumers continue to hold valid references,
+	 * but their value transitions to an `Error` until they're recreated.
+	 */
+	markSubscriptionsMissing(missing: readonly URI[]): void {
+		for (const resource of missing) {
+			const entry = this._subscriptions.get(resource);
+			if (entry) {
+				if (entry.sub instanceof SessionStateSubscription) {
+					entry.sub.clearPending();
+				}
+				entry.sub.setError(new Error(`Subscription no longer available after reconnect: ${resource.toString()}`));
+			}
+		}
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
@@ -1098,6 +1098,46 @@ suite('RemoteAgentHostProtocolClient', () => {
 			});
 		});
 
+		test('request issued during reconnect rides retries until success', async function () {
+			this.timeout(10_000);
+			return runWithFakedTimers({ useFakeTimers: true, maxTaskCount: 10_000 }, async () => {
+				const { client, transports } = createFactoryClient();
+				const connectPromise = client.connect();
+				await completeHandshake(transports[0], connectPromise);
+
+				transports[0].fireClose();
+				await waitForReconnecting(client);
+
+				// Issue a request while the gate is engaged. The first reconnect
+				// attempt will fail; the request must NOT surface the transient
+				// failure to its caller, it should stay gated until the next
+				// successful handshake.
+				const inFlight = client.resourceList(URI.file('/workspace')).catch(err => err);
+
+				const attempt1 = await waitForTransport(transports, 1);
+				attempt1.connectDeferred.error(new Error('connect failed'));
+
+				const attempt2 = await waitForTransport(transports, 2);
+				assert.strictEqual(findRequest(attempt2, 'resourceList'), undefined,
+					'request must not slip through to the new transport before its handshake completes');
+
+				attempt2.connectDeferred.complete();
+				const reconnect2 = await waitForRequest(attempt2, 'reconnect');
+				attempt2.fireMessage({
+					jsonrpc: '2.0', id: reconnect2.id,
+					result: { type: ReconnectResultType.Replay, actions: [], missing: [] },
+				});
+
+				const resourceList = await waitForRequest(attempt2, 'resourceList');
+				attempt2.fireMessage({ jsonrpc: '2.0', id: resourceList.id, result: { entries: [] } });
+
+				const value = await inFlight;
+				assert.deepStrictEqual(value, { entries: [] },
+					'request must resolve once a later reconnect attempt succeeds');
+				client.dispose();
+			});
+		});
+
 		test('_sendExtensionRequest waits for the reconnect gate', async function () {
 			this.timeout(10_000);
 			return runWithFakedTimers({ useFakeTimers: true, maxTaskCount: 10_000 }, async () => {

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
@@ -6,21 +6,22 @@
 import assert from 'assert';
 import { DeferredPromise, timeout } from '../../../../base/common/async.js';
 import { CancellationError } from '../../../../base/common/errors.js';
-import { Emitter } from '../../../../base/common/event.js';
+import { Emitter, Event } from '../../../../base/common/event.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { observableValue } from '../../../../base/common/observable.js';
 import { URI } from '../../../../base/common/uri.js';
-import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { runWithFakedTimers } from '../../../../base/test/common/timeTravelScheduler.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { FileService } from '../../../files/common/fileService.js';
 import { NullLogService } from '../../../log/common/log.js';
-import { RemoteAgentHostProtocolClient } from '../../browser/remoteAgentHostProtocolClient.js';
+import { AgentHostClientState, RemoteAgentHostProtocolClient } from '../../browser/remoteAgentHostProtocolClient.js';
 import { IAgentHostPermissionService } from '../../common/agentHostPermissionService.js';
+import { ContentEncoding, ReconnectResultType } from '../../common/state/protocol/commands.js';
 import { AhpErrorCodes } from '../../common/state/protocol/errors.js';
-import { ContentEncoding } from '../../common/state/protocol/commands.js';
 import { PROTOCOL_VERSION } from '../../common/state/protocol/version/registry.js';
-import { ActionType, type SessionActiveClientChangedAction } from '../../common/state/sessionActions.js';
+import { ActionType, type SessionActiveClientChangedAction, type SessionTitleChangedAction } from '../../common/state/sessionActions.js';
 import { ProtocolError, type AhpServerNotification, type JsonRpcNotification, type JsonRpcRequest, type JsonRpcResponse, type ProtocolMessage } from '../../common/state/sessionProtocol.js';
+import { ROOT_STATE_URI, StateComponents } from '../../common/state/sessionState.js';
 import type { IClientTransport, IProtocolTransport } from '../../common/state/sessionTransport.js';
 
 type ProtocolTransportMessage = ProtocolMessage | AhpServerNotification | JsonRpcNotification | JsonRpcResponse | JsonRpcRequest;
@@ -676,6 +677,479 @@ suite('RemoteAgentHostProtocolClient', () => {
 				calls.map(c => c.uri.toString()),
 				['file:///plugins/foo'],
 			);
+		});
+	});
+
+	suite('soft reconnect (transport factory)', () => {
+
+		function findRequest(transport: TestProtocolTransport, method: string): JsonRpcRequest | undefined {
+			return transport.sentMessages.find(
+				(m): m is JsonRpcRequest => 'method' in m && (m as JsonRpcRequest).method === method && 'id' in m,
+			);
+		}
+
+		function findNotification(transport: TestProtocolTransport, method: string): JsonRpcNotification | undefined {
+			return transport.sentMessages.find(
+				(m): m is JsonRpcNotification => 'method' in m && (m as JsonRpcNotification).method === method && !('id' in m),
+			);
+		}
+
+		async function flushMicrotasks(): Promise<void> {
+			// `await Promise.resolve()` only advances one microtask; loop a few times to
+			// drain chained .then handlers without resorting to fake timers.
+			for (let i = 0; i < 10; i++) {
+				await Promise.resolve();
+			}
+		}
+
+		/** Wait until the client transitions into the {@link AgentHostClientState.Reconnecting} state. */
+		async function waitForReconnecting(client: RemoteAgentHostProtocolClient): Promise<void> {
+			if (client.connectionState === AgentHostClientState.Reconnecting) {
+				return;
+			}
+			await Event.toPromise(Event.filter(client.onDidChangeConnectionState, s => s === AgentHostClientState.Reconnecting));
+		}
+
+		/** Wait for the next time a method-named request appears in the transport's outbox. */
+		async function waitForRequest(transport: TestProtocolTransport, method: string): Promise<JsonRpcRequest> {
+			while (true) {
+				const req = findRequest(transport, method);
+				if (req) {
+					return req;
+				}
+				await Promise.resolve();
+			}
+		}
+
+		/** Wait for the next time the new transport is created by the factory. */
+		async function waitForTransport(transports: TestClientProtocolTransport[], index: number): Promise<TestClientProtocolTransport> {
+			while (transports.length <= index) {
+				await new Promise<void>(r => setTimeout(r, 25));
+			}
+			return transports[index];
+		}
+
+		/**
+		 * Build a client wired to a transport factory that hands out fresh
+		 * `TestClientProtocolTransport`s on each invocation. Returns the
+		 * client plus a `transports` array recording each transport handed
+		 * out, so tests can drive handshake/reconnect interactions.
+		 */
+		function createFactoryClient(): { client: RemoteAgentHostProtocolClient; transports: TestClientProtocolTransport[] } {
+			const transports: TestClientProtocolTransport[] = [];
+			const factory = () => {
+				const t = disposables.add(new TestClientProtocolTransport());
+				transports.push(t);
+				return t;
+			};
+			const fileService = disposables.add(new FileService(new NullLogService()));
+			const client = disposables.add(new RemoteAgentHostProtocolClient(
+				'test.example:1234', factory, new NullLogService(), fileService, createPermissionService(),
+			));
+			return { client, transports };
+		}
+
+		async function completeHandshake(transport: TestClientProtocolTransport, connectPromise: Promise<void>): Promise<void> {
+			transport.connectDeferred.complete();
+			while (findRequest(transport, 'initialize') === undefined) {
+				await Promise.resolve();
+			}
+			const init = findRequest(transport, 'initialize')!;
+			transport.fireMessage({
+				jsonrpc: '2.0', id: init.id,
+				result: { protocolVersion: PROTOCOL_VERSION, serverSeq: 5, snapshots: [] },
+			});
+			await connectPromise;
+		}
+
+		test('reuses clientId across transport reconnects', async function () {
+			this.timeout(10_000);
+			return runWithFakedTimers({ useFakeTimers: true, maxTaskCount: 10_000 }, async () => {
+				const { client, transports } = createFactoryClient();
+				const connectPromise = client.connect();
+				await completeHandshake(transports[0], connectPromise);
+				const originalClientId = client.clientId;
+
+				// Drop the transport; the client should attach a fresh one and
+				// reconnect with the same clientId rather than restart from scratch.
+				transports[0].fireClose();
+				await waitForReconnecting(client);
+				const reconnectTransport = await waitForTransport(transports, 1);
+				reconnectTransport.connectDeferred.complete();
+				const reconnect = await waitForRequest(reconnectTransport, 'reconnect');
+
+				const params = reconnect.params as { clientId: string; lastSeenServerSeq: number; subscriptions: unknown[] };
+				assert.strictEqual(params.clientId, originalClientId);
+				assert.strictEqual(params.lastSeenServerSeq, 5);
+				assert.ok(Array.isArray(params.subscriptions));
+
+				reconnectTransport.fireMessage({
+					jsonrpc: '2.0', id: reconnect.id,
+					result: { type: ReconnectResultType.Replay, actions: [], missing: [] },
+				});
+				await flushMicrotasks();
+				client.dispose();
+			});
+		});
+
+		test('replays pending optimistic actions after reconnect', async function () {
+			this.timeout(10_000);
+			return runWithFakedTimers({ useFakeTimers: true, maxTaskCount: 10_000 }, async () => {
+				const { client, transports } = createFactoryClient();
+				const connectPromise = client.connect();
+				await completeHandshake(transports[0], connectPromise);
+
+				// Establish a session subscription so dispatch() can apply optimistically.
+				const sessionUri = URI.parse('copilot:/test-session');
+				const subRef = client.getSubscription(StateComponents.Session, sessionUri);
+				const subscribeReq = await waitForRequest(transports[0], 'subscribe');
+				transports[0].fireMessage({
+					jsonrpc: '2.0', id: subscribeReq.id,
+					result: { snapshot: { resource: sessionUri.toString(), state: { turns: [] }, fromSeq: 5 } },
+				});
+				await Promise.resolve();
+
+				// Dispatch an optimistic action right before the transport drops.
+				const action: SessionTitleChangedAction = {
+					type: ActionType.SessionTitleChanged,
+					session: sessionUri.toString(),
+					title: 'Renamed by user',
+				};
+				client.dispatch(action);
+				const initialDispatch = findNotification(transports[0], 'dispatchAction');
+				assert.ok(initialDispatch, 'optimistic dispatch should reach the original transport');
+				const initialSeq = (initialDispatch.params as { clientSeq: number }).clientSeq;
+
+				// Drop the transport mid-flight. The new transport receives a
+				// reconnect RPC plus a replay of the unconfirmed dispatch.
+				transports[0].fireClose();
+				await waitForReconnecting(client);
+				const reconnectTransport = await waitForTransport(transports, 1);
+				reconnectTransport.connectDeferred.complete();
+				const reconnect = await waitForRequest(reconnectTransport, 'reconnect');
+				reconnectTransport.fireMessage({
+					jsonrpc: '2.0', id: reconnect.id,
+					result: { type: ReconnectResultType.Replay, actions: [], missing: [] },
+				});
+				await flushMicrotasks();
+
+				const replayed = findNotification(reconnectTransport, 'dispatchAction');
+				assert.ok(replayed, 'pending optimistic action should be re-sent after reconnect');
+				assert.strictEqual((replayed.params as { clientSeq: number }).clientSeq, initialSeq, 'replayed dispatch must reuse the original clientSeq');
+
+				subRef.dispose();
+				client.dispose();
+			});
+		});
+
+		test('skips replay when server already echoed the action in the replay buffer', async function () {
+			this.timeout(10_000);
+			return runWithFakedTimers({ useFakeTimers: true, maxTaskCount: 10_000 }, async () => {
+				const { client, transports } = createFactoryClient();
+				const connectPromise = client.connect();
+				await completeHandshake(transports[0], connectPromise);
+
+				const sessionUri = URI.parse('copilot:/test-session');
+				const subRef = client.getSubscription(StateComponents.Session, sessionUri);
+				const subscribeReq = await waitForRequest(transports[0], 'subscribe');
+				transports[0].fireMessage({
+					jsonrpc: '2.0', id: subscribeReq.id,
+					result: { snapshot: { resource: sessionUri.toString(), state: { turns: [] }, fromSeq: 5 } },
+				});
+				await Promise.resolve();
+
+				const action: SessionTitleChangedAction = {
+					type: ActionType.SessionTitleChanged,
+					session: sessionUri.toString(),
+					title: 'Echoed back',
+				};
+				client.dispatch(action);
+				const initialDispatch = findNotification(transports[0], 'dispatchAction')!;
+				const initialSeq = (initialDispatch.params as { clientSeq: number }).clientSeq;
+
+				transports[0].fireClose();
+				await waitForReconnecting(client);
+				const reconnectTransport = await waitForTransport(transports, 1);
+				reconnectTransport.connectDeferred.complete();
+				const reconnect = await waitForRequest(reconnectTransport, 'reconnect');
+				// Reply with a replay buffer that already contains our action,
+				// echoed back with origin = { clientId, clientSeq }.
+				reconnectTransport.fireMessage({
+					jsonrpc: '2.0', id: reconnect.id,
+					result: {
+						type: ReconnectResultType.Replay,
+						actions: [{
+							action,
+							serverSeq: 6,
+							origin: { clientId: client.clientId, clientSeq: initialSeq },
+							rejectionReason: undefined,
+						}],
+						missing: [],
+					},
+				});
+				await flushMicrotasks();
+
+				assert.strictEqual(findNotification(reconnectTransport, 'dispatchAction'), undefined,
+					'action echoed back via replay buffer must not be re-sent');
+
+				subRef.dispose();
+				client.dispose();
+			});
+		});
+
+		test('outgoing requests wait for reconnect to complete', async function () {
+			this.timeout(10_000);
+			return runWithFakedTimers({ useFakeTimers: true, maxTaskCount: 10_000 }, async () => {
+				const { client, transports } = createFactoryClient();
+				const connectPromise = client.connect();
+				await completeHandshake(transports[0], connectPromise);
+
+				// Drop the transport, then issue a new request while the
+				// soft-reconnect is in flight. The request must land on the new
+				// transport rather than racing the dead one or being dropped.
+				transports[0].fireClose();
+				const inFlight = client.resourceList(URI.file('/workspace')).catch(err => err);
+
+				// Hold off the new transport's connect() so the request stays gated.
+				await waitForReconnecting(client);
+				const reconnectTransport = await waitForTransport(transports, 1);
+				assert.strictEqual(findRequest(reconnectTransport, 'resourceList'), undefined,
+					'request must NOT be sent before reconnect completes');
+
+				reconnectTransport.connectDeferred.complete();
+				const reconnect = await waitForRequest(reconnectTransport, 'reconnect');
+				reconnectTransport.fireMessage({
+					jsonrpc: '2.0', id: reconnect.id,
+					result: { type: ReconnectResultType.Replay, actions: [], missing: [] },
+				});
+
+				const resourceList = await waitForRequest(reconnectTransport, 'resourceList');
+				reconnectTransport.fireMessage({ jsonrpc: '2.0', id: resourceList.id, result: { entries: [] } });
+
+				const value = await inFlight;
+				assert.deepStrictEqual(value, { entries: [] });
+				client.dispose();
+			});
+		});
+
+		test('rejected action echoed in replay buffer is not applied to confirmed state', async function () {
+			this.timeout(10_000);
+			return runWithFakedTimers({ useFakeTimers: true, maxTaskCount: 10_000 }, async () => {
+				const { client, transports } = createFactoryClient();
+				const connectPromise = client.connect();
+				await completeHandshake(transports[0], connectPromise);
+
+				const sessionUri = URI.parse('copilot:/test-session');
+				const subRef = client.getSubscription<{ summary: { title: string } }>(StateComponents.Session, sessionUri);
+				const subscribeReq = await waitForRequest(transports[0], 'subscribe');
+				transports[0].fireMessage({
+					jsonrpc: '2.0', id: subscribeReq.id,
+					result: { snapshot: { resource: sessionUri.toString(), state: { summary: { title: 'Original' }, turns: [] }, fromSeq: 5 } },
+				});
+				await Promise.resolve();
+
+				const action: SessionTitleChangedAction = {
+					type: ActionType.SessionTitleChanged,
+					session: sessionUri.toString(),
+					title: 'Rejected change',
+				};
+				client.dispatch(action);
+				const initialDispatch = findNotification(transports[0], 'dispatchAction')!;
+				const initialSeq = (initialDispatch.params as { clientSeq: number }).clientSeq;
+
+				transports[0].fireClose();
+				await waitForReconnecting(client);
+				const reconnectTransport = await waitForTransport(transports, 1);
+				reconnectTransport.connectDeferred.complete();
+				const reconnect = await waitForRequest(reconnectTransport, 'reconnect');
+				// Server echoes back the action with a rejectionReason — the
+				// confirmed state must NOT advance to 'Rejected change'.
+				reconnectTransport.fireMessage({
+					jsonrpc: '2.0', id: reconnect.id,
+					result: {
+						type: ReconnectResultType.Replay,
+						actions: [{
+							action,
+							serverSeq: 6,
+							origin: { clientId: client.clientId, clientSeq: initialSeq },
+							rejectionReason: 'unauthorized',
+						}],
+						missing: [],
+					},
+				});
+				await flushMicrotasks();
+
+				const sessionState = subRef.object.verifiedValue;
+				assert.ok(sessionState, 'session state should be hydrated');
+				assert.strictEqual(sessionState.summary.title, 'Original',
+					'rejected action must not have been applied to confirmed state');
+				assert.strictEqual(findNotification(reconnectTransport, 'dispatchAction'), undefined,
+					'rejected action must not be re-dispatched');
+
+				subRef.dispose();
+				client.dispose();
+			});
+		});
+
+		test('snapshot reconnect result reseats the root state', async function () {
+			this.timeout(10_000);
+			return runWithFakedTimers({ useFakeTimers: true, maxTaskCount: 10_000 }, async () => {
+				const { client, transports } = createFactoryClient();
+				const connectPromise = client.connect();
+				await completeHandshake(transports[0], connectPromise);
+
+				transports[0].fireClose();
+				await waitForReconnecting(client);
+				const reconnectTransport = await waitForTransport(transports, 1);
+				reconnectTransport.connectDeferred.complete();
+				const reconnect = await waitForRequest(reconnectTransport, 'reconnect');
+				reconnectTransport.fireMessage({
+					jsonrpc: '2.0', id: reconnect.id,
+					result: {
+						type: ReconnectResultType.Snapshot,
+						snapshots: [{
+							resource: ROOT_STATE_URI,
+							state: { agents: [{ provider: 'copilot', displayName: 'Copilot', models: [], tools: [] }], activeSessions: 0, terminals: [] },
+							fromSeq: 42,
+						}],
+					},
+				});
+				await flushMicrotasks();
+
+				const root = client.rootState.value;
+				assert.ok(root && !(root instanceof Error), 'root state should be hydrated from snapshot');
+				assert.strictEqual(root.agents[0]?.provider, 'copilot');
+				client.dispose();
+			});
+		});
+
+		test('transport drop during reconnect RPC re-schedules instead of hanging', async function () {
+			this.timeout(10_000);
+			return runWithFakedTimers({ useFakeTimers: true, maxTaskCount: 10_000 }, async () => {
+				const { client, transports } = createFactoryClient();
+				const connectPromise = client.connect();
+				await completeHandshake(transports[0], connectPromise);
+
+				transports[0].fireClose();
+				await waitForReconnecting(client);
+				const attempt1 = await waitForTransport(transports, 1);
+				attempt1.connectDeferred.complete();
+				await waitForRequest(attempt1, 'reconnect');
+
+				// Second drop mid-handshake. The attempt's pending RPC must be rejected
+				// so the retry path fires; without that the await stays pending and
+				// every subsequent request deadlocks on the reconnect gate.
+				attempt1.fireClose();
+
+				const attempt2 = await waitForTransport(transports, 2);
+				attempt2.connectDeferred.complete();
+				const reconnect2 = await waitForRequest(attempt2, 'reconnect');
+				attempt2.fireMessage({
+					jsonrpc: '2.0', id: reconnect2.id,
+					result: { type: ReconnectResultType.Replay, actions: [], missing: [] },
+				});
+				await flushMicrotasks();
+
+				assert.strictEqual(client.connectionState, AgentHostClientState.Connected,
+					'client must recover to Connected after a mid-reconnect drop');
+				client.dispose();
+			});
+		});
+
+		test('non-session dispatch issued during reconnect rides retries until success', async function () {
+			this.timeout(10_000);
+			return runWithFakedTimers({ useFakeTimers: true, maxTaskCount: 10_000 }, async () => {
+				const { client, transports } = createFactoryClient();
+				const connectPromise = client.connect();
+				await completeHandshake(transports[0], connectPromise);
+
+				// Drop transport before any successful reconnect so the gate stays
+				// engaged across the failed attempt.
+				transports[0].fireClose();
+				await waitForReconnecting(client);
+
+				// A terminal action dispatched while reconnecting. There is no
+				// optimistic replay path for terminal/root actions; the only way
+				// these reach the server is via the notification gate.
+				const terminalUri = URI.parse('agenthost-terminal:/term-1');
+				client.dispatch({
+					type: ActionType.TerminalInput,
+					terminal: terminalUri.toString(),
+					data: 'echo hello\n',
+				});
+
+				// First attempt fails. The notification must NOT be dropped; the
+				// rejection handler should re-queue it onto the new gate.
+				const attempt1 = await waitForTransport(transports, 1);
+				attempt1.connectDeferred.error(new Error('connect failed'));
+
+				const attempt2 = await waitForTransport(transports, 2);
+				attempt2.connectDeferred.complete();
+				const reconnect2 = await waitForRequest(attempt2, 'reconnect');
+				attempt2.fireMessage({
+					jsonrpc: '2.0', id: reconnect2.id,
+					result: { type: ReconnectResultType.Replay, actions: [], missing: [] },
+				});
+				await flushMicrotasks();
+
+				const dispatched = findNotification(attempt2, 'dispatchAction');
+				assert.ok(dispatched, 'terminal dispatch must ride the failed attempt through to the next successful one');
+				client.dispose();
+			});
+		});
+
+		test('_sendExtensionRequest waits for the reconnect gate', async function () {
+			this.timeout(10_000);
+			return runWithFakedTimers({ useFakeTimers: true, maxTaskCount: 10_000 }, async () => {
+				const { client, transports } = createFactoryClient();
+				const connectPromise = client.connect();
+				await completeHandshake(transports[0], connectPromise);
+
+				transports[0].fireClose();
+				await waitForReconnecting(client);
+				const shutdown = client.shutdown().catch(err => err);
+
+				const reconnectTransport = await waitForTransport(transports, 1);
+				// Extension requests must not race the dead transport — nothing
+				// should be on the wire yet.
+				assert.strictEqual(findRequest(reconnectTransport, 'shutdown'), undefined,
+					'shutdown extension request must NOT be sent before reconnect completes');
+
+				reconnectTransport.connectDeferred.complete();
+				const reconnect = await waitForRequest(reconnectTransport, 'reconnect');
+				reconnectTransport.fireMessage({
+					jsonrpc: '2.0', id: reconnect.id,
+					result: { type: ReconnectResultType.Replay, actions: [], missing: [] },
+				});
+
+				const shutdownReq = await waitForRequest(reconnectTransport, 'shutdown');
+				reconnectTransport.fireMessage({ jsonrpc: '2.0', id: shutdownReq.id, result: null });
+				await shutdown;
+				client.dispose();
+			});
+		});
+
+		test('watchdog dead-transport detection triggers soft reconnect', async function () {
+			this.timeout(60_000);
+			return runWithFakedTimers({ useFakeTimers: true, maxTaskCount: 10_000 }, async () => {
+				const { client, transports } = createFactoryClient();
+				const connectPromise = client.connect();
+				await completeHandshake(transports[0], connectPromise);
+
+				// Issue a request the server never answers. After WATCHDOG_TIMEOUT_MS
+				// of silence the watchdog must route through the soft-reconnect
+				// path — *not* rely on the transport's onClose firing (it never
+				// will for a silent dead socket, see WebSocketClientTransport.dispose).
+				const pending = client.resourceList(URI.file('/workspace')).catch(err => err);
+				await timeout(30_000);
+
+				assert.strictEqual(client.connectionState, AgentHostClientState.Reconnecting,
+					'watchdog must drive the client into Reconnecting via soft reconnect rather than firing onDidClose');
+
+				const err = await pending;
+				assert.ok(err instanceof ProtocolError);
+				assert.match((err as ProtocolError).message, /Connection appears dead/);
+			});
 		});
 	});
 });

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostService.test.ts
@@ -40,6 +40,7 @@ class MockProtocolClient extends Disposable {
 	readonly onDidClose = this._onDidClose.event;
 	readonly onDidAction = Event.None;
 	readonly onDidNotification = Event.None;
+	readonly onDidChangeConnectionState = Event.None;
 
 	public connectDeferred = new DeferredPromise<void>();
 


### PR DESCRIPTION
Persist the protocol client across transport drops. On WebSocket close or watchdog timeout, install a fresh transport via an optional constructor-supplied factory and issue a `reconnect` RPC with the existing clientId, last-seen server seq, and active subscription URIs; server replies with a replay buffer or fresh snapshots. Outgoing requests and buffered notifications gate on a DeferredPromise until the handshake completes, then drain (with dedup of optimistic actions the server already echoed). State is modeled as a discriminated union so reconnect-only fields can't leak into other states. Service-layer surfaces Reconnecting as `connecting` so the UI doesn't flicker.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
