### PR TITLE
Hide default text icons in suggest widget for chat completions

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/newChatInput.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInput.ts
@@ -191,6 +191,9 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 		// Overflow widget DOM node at the top level so the suggest widget
 		// is not clipped by any overflow:hidden ancestor.
 		const editorOverflowWidgetsDomNode = dom.append(root, dom.$('.sessions-chat-editor-overflow.monaco-editor'));
+		// Suppress the default `Text` kind icon in the suggest widget; chat slash/skill
+		// completions use that kind and rely on the chat module's CSS rule scoped to this class.
+		editorOverflowWidgetsDomNode.classList.add('hideSuggestTextIcons');
 		this._register({ dispose: () => editorOverflowWidgetsDomNode.remove() });
 
 		// Notification widget above the input area


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

**Before** 
<img width="562" height="187" alt="image" src="https://github.com/user-attachments/assets/ee14337e-51b6-41b0-9176-68c4f4f58e48" />

**After**
<img width="583" height="312" alt="image" src="https://github.com/user-attachments/assets/d0ea8502-84a7-410a-9194-bacd1a90cc15" />

**Aligns with what we have today in regular chat**
<img width="1136" height="854" alt="image" src="https://github.com/user-attachments/assets/36b961f0-5f41-47c4-9a79-198cd4fa0f36" />
