### PR TITLE
feat: expose focused tree view state to extension host

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadTreeViews.ts
+++ b/src/vs/workbench/api/browser/mainThreadTreeViews.ts
@@ -31,6 +31,8 @@ export class MainThreadTreeViews extends Disposable implements MainThreadTreeVie
 	private readonly _dataProviders: DisposableMap<string, { dataProvider: TreeViewDataProvider; dispose: () => void }> = this._register(new DisposableMap<string, { dataProvider: TreeViewDataProvider; dispose: () => void }>());
 	private readonly _dndControllers = new Map<string, TreeViewDragAndDropController>();
 
+	private _lastFocusedTreeView: string | undefined;
+
 	constructor(
 		extHostContext: IExtHostContext,
 		@IViewsService private readonly viewsService: IViewsService,
@@ -41,6 +43,8 @@ export class MainThreadTreeViews extends Disposable implements MainThreadTreeVie
 	) {
 		super();
 		this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostTreeViews);
+
+		this._register(this.viewsService.onDidChangeFocusedView(() => this.updateFocusedTreeView()));
 	}
 
 	async $registerTreeViewDataProvider(treeViewId: string, options: { showCollapseAll: boolean; canSelectMany: boolean; dropMimeTypes: string[]; dragMimeTypes: string[]; hasHandleDrag: boolean; hasHandleDrop: boolean; manuallyManageCheckboxes: boolean }): Promise<void> {
@@ -154,6 +158,24 @@ export class MainThreadTreeViews extends Disposable implements MainThreadTreeVie
 		this.telemetryService.publicLog2<TreeViewResolveFailureEvent, TreeViewResolveFailureClassification>('treeView.resolveFailure', {
 			extensionId
 		});
+	}
+
+	private updateFocusedTreeView() {
+		let next: string | undefined;
+
+		const focusedView = this.viewsService.getFocusedView();
+
+		if (focusedView) {
+			const viewId = focusedView.id;
+			if (this._dataProviders.has(viewId)) {
+				next = viewId;
+			}
+		}
+
+		if (next !== this._lastFocusedTreeView) {
+			this._lastFocusedTreeView = next;
+			this._proxy.$setFocusedTreeView(next);
+		}
 	}
 
 	private async reveal(treeView: ITreeView, dataProvider: TreeViewDataProvider, itemIn: ITreeItem, parentChain: ITreeItem[], options: IRevealOptions): Promise<void> {

--- a/src/vs/workbench/api/browser/mainThreadTreeViews.ts
+++ b/src/vs/workbench/api/browser/mainThreadTreeViews.ts
@@ -69,6 +69,7 @@ export class MainThreadTreeViews extends Disposable implements MainThreadTreeVie
 				}
 				viewer.dataProvider = dataProvider;
 				this.registerListeners(treeViewId, viewer, disposables);
+				this.updateFocusedTreeView();
 				this._proxy.$setVisible(treeViewId, viewer.visible);
 			} else {
 				this.notificationService.error('No view is registered with id: ' + treeViewId);
@@ -144,6 +145,7 @@ export class MainThreadTreeViews extends Disposable implements MainThreadTreeVie
 		}
 
 		this._dataProviders.deleteAndDispose(treeViewId);
+		this.updateFocusedTreeView();
 	}
 
 	$logResolveTreeNodeFailure(extensionId: string): void {
@@ -160,7 +162,7 @@ export class MainThreadTreeViews extends Disposable implements MainThreadTreeVie
 		});
 	}
 
-	private updateFocusedTreeView() {
+	private updateFocusedTreeView(): void {
 		let next: string | undefined;
 
 		const focusedView = this.viewsService.getFocusedView();

--- a/src/vs/workbench/api/browser/mainThreadTreeViews.ts
+++ b/src/vs/workbench/api/browser/mainThreadTreeViews.ts
@@ -5,7 +5,7 @@
 
 import { Disposable, DisposableMap, DisposableStore } from '../../../base/common/lifecycle.js';
 import { ExtHostContext, MainThreadTreeViewsShape, ExtHostTreeViewsShape, MainContext, CheckboxUpdate } from '../common/extHost.protocol.js';
-import { ITreeItem, ITreeView, IViewsRegistry, ITreeViewDescriptor, IRevealOptions, Extensions, ResolvableTreeItem, ITreeViewDragAndDropController, IViewBadge, NoTreeViewError, ITreeViewDataProvider } from '../../common/views.js';
+import { ITreeItem, ITreeView, IViewsRegistry, ITreeViewDescriptor, IRevealOptions, Extensions, ResolvableTreeItem, ITreeViewDragAndDropController, IViewBadge, NoTreeViewError, ITreeViewDataProvider, ICustomViewDescriptor } from '../../common/views.js';
 import { extHostNamedCustomer, IExtHostContext } from '../../services/extensions/common/extHostCustomers.js';
 import { distinct } from '../../../base/common/arrays.js';
 import { INotificationService } from '../../../platform/notification/common/notification.js';
@@ -167,11 +167,8 @@ export class MainThreadTreeViews extends Disposable implements MainThreadTreeVie
 
 		const focusedView = this.viewsService.getFocusedView();
 
-		if (focusedView) {
-			const viewId = focusedView.id;
-			if (this._dataProviders.has(viewId)) {
-				next = viewId;
-			}
+		if (focusedView && (focusedView as ICustomViewDescriptor).extensionId) {
+			next = focusedView.id;
 		}
 
 		if (next !== this._lastFocusedTreeView) {

--- a/src/vs/workbench/api/browser/mainThreadTreeViews.ts
+++ b/src/vs/workbench/api/browser/mainThreadTreeViews.ts
@@ -167,7 +167,7 @@ export class MainThreadTreeViews extends Disposable implements MainThreadTreeVie
 
 		const focusedView = this.viewsService.getFocusedView();
 
-		if (focusedView && (focusedView as ICustomViewDescriptor).extensionId) {
+		if (focusedView && (focusedView as ICustomViewDescriptor).treeView) {
 			next = focusedView.id;
 		}
 

--- a/src/vs/workbench/api/browser/mainThreadTreeViews.ts
+++ b/src/vs/workbench/api/browser/mainThreadTreeViews.ts
@@ -45,6 +45,8 @@ export class MainThreadTreeViews extends Disposable implements MainThreadTreeVie
 		this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostTreeViews);
 
 		this._register(this.viewsService.onDidChangeFocusedView(() => this.updateFocusedTreeView()));
+
+		this.updateFocusedTreeView();
 	}
 
 	async $registerTreeViewDataProvider(treeViewId: string, options: { showCollapseAll: boolean; canSelectMany: boolean; dropMimeTypes: string[]; dragMimeTypes: string[]; hasHandleDrag: boolean; hasHandleDrop: boolean; manuallyManageCheckboxes: boolean }): Promise<void> {

--- a/src/vs/workbench/api/browser/mainThreadTreeViews.ts
+++ b/src/vs/workbench/api/browser/mainThreadTreeViews.ts
@@ -169,8 +169,12 @@ export class MainThreadTreeViews extends Disposable implements MainThreadTreeVie
 
 		const focusedView = this.viewsService.getFocusedView();
 
-		if (focusedView && (focusedView as ICustomViewDescriptor).treeView) {
-			next = focusedView.id;
+		if (focusedView) {
+			const customView = focusedView as Partial<ICustomViewDescriptor>;
+
+			if (customView.treeView && customView.extensionId) {
+				next = focusedView.id;
+			}
 		}
 
 		if (next !== this._lastFocusedTreeView) {

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1091,6 +1091,12 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 				checkProposedApiEnabled(extension, 'browser');
 				return extHostBrowsers.openBrowserTab(url, options);
 			},
+			get focusedTreeView() {
+				return extHostTreeViews.focusedTreeView;
+			},
+			onDidChangeFocusedTreeView(listener, thisArg?, disposables?) {
+				return _asExtensionEvent(extHostTreeViews.onDidChangeFocusedTreeView)(listener, thisArg, disposables);
+			},
 		};
 
 		// namespace: workspace

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -2418,6 +2418,7 @@ export interface CheckboxUpdate {
 }
 
 export interface ExtHostTreeViewsShape {
+	$setFocusedTreeView(treeViewId: string | undefined): void;
 	/**
 	 * To reduce what is sent on the wire:
 	 * w

--- a/src/vs/workbench/api/common/extHostTreeViews.ts
+++ b/src/vs/workbench/api/common/extHostTreeViews.ts
@@ -54,6 +54,14 @@ export class ExtHostTreeViews extends Disposable implements ExtHostTreeViewsShap
 	private _treeViews: Map<string, ExtHostTreeView<any>> = new Map<string, ExtHostTreeView<any>>();
 	private _treeDragAndDropService: ITreeViewsDnDService<vscode.DataTransfer> = new TreeViewsDnDService<vscode.DataTransfer>();
 
+	private _focusedTreeView: string | undefined;
+	get focusedTreeView(): string | undefined {
+		return this._focusedTreeView;
+	}
+
+	private readonly _onDidChangeFocusedTreeView = new Emitter<string | undefined>();
+	readonly onDidChangeFocusedTreeView = this._onDidChangeFocusedTreeView.event;
+
 	constructor(
 		private _proxy: MainThreadTreeViewsShape,
 		private _commands: ExtHostCommands,
@@ -162,6 +170,16 @@ export class ExtHostTreeViews extends Disposable implements ExtHostTreeViewsShap
 		};
 		this._register(view);
 		return view as vscode.TreeView<T>;
+	}
+
+	$setFocusedTreeView(treeViewId: string | undefined): void {
+		if (this._focusedTreeView === treeViewId) {
+			return;
+		}
+
+		this._focusedTreeView = treeViewId;
+
+		this._onDidChangeFocusedTreeView.fire(treeViewId);
 	}
 
 	async $getChildren(treeViewId: string, treeItemHandles?: string[]): Promise<(readonly (number | ITreeItem)[])[] | undefined> {

--- a/src/vs/workbench/api/test/browser/extHostTreeViews.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostTreeViews.test.ts
@@ -722,6 +722,45 @@ suite('ExtHostTreeView', function () {
 			});
 	});
 
+	test('updates focusedTreeView', () => {
+		assert.strictEqual(testObject.focusedTreeView, undefined);
+		testObject.$setFocusedTreeView('testNodeTreeProvider');
+		assert.strictEqual(testObject.focusedTreeView, 'testNodeTreeProvider');
+		testObject.$setFocusedTreeView(undefined);
+		assert.strictEqual(testObject.focusedTreeView, undefined);
+	});
+
+	test('fires onDidChangeFocusedTreeView', () => {
+		const events: Array<string | undefined> = [];
+		store.add(testObject.onDidChangeFocusedTreeView(viewId => {
+			events.push(viewId);
+		}));
+		const toFire: (string | undefined)[] = [
+			'testNodeTreeProvider1',
+			'testNodeTreeProvider2',
+			undefined,
+			'testNodeTreeProvider3'
+		];
+		for (const tf of toFire) {
+			testObject.$setFocusedTreeView(tf);
+		}
+		assert.deepStrictEqual(events, toFire);
+	});
+
+	test('does not fire onDidChangeFocusedTreeView for same value', () => {
+		let callCount = 0;
+		store.add(testObject.onDidChangeFocusedTreeView(() => {
+			callCount++;
+		}));
+		testObject.$setFocusedTreeView('testNodeTreeProvider');
+		testObject.$setFocusedTreeView('testNodeTreeProvider');
+		testObject.$setFocusedTreeView(undefined);
+		testObject.$setFocusedTreeView(undefined);
+		testObject.$setFocusedTreeView('testNodeTreeProvider');
+		testObject.$setFocusedTreeView('testNodeTreeProvider');
+		assert.strictEqual(callCount, 3);
+	});
+
 	function loadCompleteTree(treeId: string, element?: string): Promise<null> {
 		return testObject.$getChildren(treeId, element ? [element] : undefined)
 			.then(elements => {

--- a/src/vs/workbench/api/test/browser/mainThreadTreeViews.test.ts
+++ b/src/vs/workbench/api/test/browser/mainThreadTreeViews.test.ts
@@ -16,7 +16,7 @@ import { NullTelemetryService } from '../../../../platform/telemetry/common/tele
 import { MainThreadTreeViews } from '../../browser/mainThreadTreeViews.js';
 import { DataTransferDTO, ExtHostTreeViewsShape } from '../../common/extHost.protocol.js';
 import { CustomTreeView } from '../../../browser/parts/views/treeView.js';
-import { Extensions, ITreeItem, ITreeView, ITreeViewDescriptor, IViewContainersRegistry, IViewDescriptorService, IViewsRegistry, TreeItemCollapsibleState, ViewContainer, ViewContainerLocation } from '../../../common/views.js';
+import { Extensions, ITreeItem, ITreeView, ITreeViewDescriptor, IViewContainersRegistry, IViewDescriptor, IViewDescriptorService, IViewsRegistry, TreeItemCollapsibleState, ViewContainer, ViewContainerLocation } from '../../../common/views.js';
 import { IExtHostContext } from '../../../services/extensions/common/extHostCustomers.js';
 import { ExtensionHostKind } from '../../../services/extensions/common/extensionHostKind.js';
 import { ViewDescriptorService } from '../../../services/views/browser/viewDescriptorService.js';
@@ -25,6 +25,7 @@ import { TestExtensionService } from '../../../test/common/workbenchTestServices
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Mimes } from '../../../../base/common/mime.js';
 import { URI } from '../../../../base/common/uri.js';
+import * as sinon from 'sinon';
 
 suite('MainThreadHostTreeView', function () {
 	const testTreeViewId = 'testTreeView';
@@ -36,6 +37,8 @@ suite('MainThreadHostTreeView', function () {
 	}
 
 	class MockExtHostTreeViewsShape extends mock<ExtHostTreeViewsShape>() {
+		override $setFocusedTreeView(treeViewId: string | undefined): void { }
+
 		override async $getChildren(treeViewId: string, treeItemHandle?: string[]): Promise<(number | ITreeItem)[][]> {
 			return [[0, <CustomTreeItem>{ handle: 'testItem1', collapsibleState: TreeItemCollapsibleState.Expanded, customProp: customValue }]];
 		}
@@ -51,6 +54,7 @@ suite('MainThreadHostTreeView', function () {
 	let mainThreadTreeViews: MainThreadTreeViews;
 	let extHostTreeViewsShape: MockExtHostTreeViewsShape;
 	let instantiationService: TestInstantiationService;
+	let viewsService: TestViewsService;
 
 	teardown(() => {
 		ViewsRegistry.deregisterViews(ViewsRegistry.getViews(container), container);
@@ -62,6 +66,7 @@ suite('MainThreadHostTreeView', function () {
 		instantiationService = workbenchInstantiationService(undefined, disposables);
 		const viewDescriptorService = disposables.add(instantiationService.createInstance(ViewDescriptorService));
 		instantiationService.stub(IViewDescriptorService, viewDescriptorService);
+		viewsService = new TestViewsService();
 		// eslint-disable-next-line local/code-no-any-casts
 		container = Registry.as<IViewContainersRegistry>(Extensions.ViewContainersRegistry).registerViewContainer({ id: 'testContainer', title: nls.localize2('test', 'test'), ctorDescriptor: new SyncDescriptor(<any>{}) }, ViewContainerLocation.Sidebar);
 		const viewDescriptor: ITreeViewDescriptor = {
@@ -85,7 +90,7 @@ suite('MainThreadHostTreeView', function () {
 					return extHostTreeViewsShape;
 				}
 				drain(): any { return null; }
-			}, new TestViewsService(), new TestNotificationService(), testExtensionService, new NullLogService(), NullTelemetryService));
+			}, viewsService, new TestNotificationService(), testExtensionService, new NullLogService(), NullTelemetryService));
 		mainThreadTreeViews.$registerTreeViewDataProvider(testTreeViewId, { showCollapseAll: false, canSelectMany: false, dropMimeTypes: [], dragMimeTypes: [], hasHandleDrag: false, hasHandleDrop: false, manuallyManageCheckboxes: false });
 		await testExtensionService.whenInstalledExtensionsRegistered();
 	});
@@ -183,5 +188,46 @@ suite('MainThreadHostTreeView', function () {
 		assert.strictEqual(uriListValue, URI.from({ scheme: 'file', authority: '', path: '/transformed/correct/path.txt', query: '', fragment: '' }).toString());
 	});
 
+	test('updates focused tree view', () => {
+		const proxy = sinon.spy(extHostTreeViewsShape, '$setFocusedTreeView');
+
+		viewsService.setFocusedView(<IViewDescriptor>{
+			id: testTreeViewId
+		});
+
+		assert.strictEqual(proxy.callCount, 1);
+		assert.strictEqual(proxy.firstCall.args[0], testTreeViewId);
+
+		viewsService.setFocusedView(null);
+
+		assert.strictEqual(proxy.callCount, 2);
+		assert.strictEqual(proxy.secondCall.args[0], undefined);
+	});
+
+	test('ignores non-extension focused views', () => {
+		const proxy = sinon.spy(extHostTreeViewsShape, '$setFocusedTreeView');
+
+		viewsService.setFocusedView(<IViewDescriptor>{
+			id: 'unknownView'
+		});
+
+		assert.strictEqual(proxy.callCount, 0);
+	});
+
+	test('does not emit duplicate focused tree view values', () => {
+		const proxy = sinon.spy(extHostTreeViewsShape, '$setFocusedTreeView');
+
+		const view1 = <IViewDescriptor>{
+			id: testTreeViewId
+		};
+
+		viewsService.setFocusedView(view1);
+		viewsService.setFocusedView(view1);
+		viewsService.setFocusedView(null);
+
+		assert.strictEqual(proxy.callCount, 2);
+		assert.strictEqual(proxy.firstCall.args[0], testTreeViewId);
+		assert.strictEqual(proxy.secondCall.args[0], undefined);
+	});
 
 });

--- a/src/vs/workbench/api/test/browser/mainThreadTreeViews.test.ts
+++ b/src/vs/workbench/api/test/browser/mainThreadTreeViews.test.ts
@@ -211,7 +211,11 @@ suite('MainThreadHostTreeView', function () {
 		const proxy = sinon.spy(extHostTreeViewsShape, '$setFocusedTreeView');
 
 		viewsService.setFocusedView(<IViewDescriptor>{
-			id: 'unknownView'
+			id: 'noTreeView'
+		});
+		viewsService.setFocusedView(<ITreeViewDescriptor>{
+			id: 'builtInTreeView',
+			treeView: (<ITreeViewDescriptor>ViewsRegistry.getView(testTreeViewId)).treeView
 		});
 
 		assert.strictEqual(proxy.callCount, 0);

--- a/src/vs/workbench/api/test/browser/mainThreadTreeViews.test.ts
+++ b/src/vs/workbench/api/test/browser/mainThreadTreeViews.test.ts
@@ -16,7 +16,7 @@ import { NullTelemetryService } from '../../../../platform/telemetry/common/tele
 import { MainThreadTreeViews } from '../../browser/mainThreadTreeViews.js';
 import { DataTransferDTO, ExtHostTreeViewsShape } from '../../common/extHost.protocol.js';
 import { CustomTreeView } from '../../../browser/parts/views/treeView.js';
-import { Extensions, ITreeItem, ITreeView, ITreeViewDescriptor, IViewContainersRegistry, IViewDescriptor, IViewDescriptorService, IViewsRegistry, TreeItemCollapsibleState, ViewContainer, ViewContainerLocation } from '../../../common/views.js';
+import { Extensions, ICustomViewDescriptor, ITreeItem, ITreeView, ITreeViewDescriptor, IViewContainersRegistry, IViewDescriptor, IViewDescriptorService, IViewsRegistry, TreeItemCollapsibleState, ViewContainer, ViewContainerLocation } from '../../../common/views.js';
 import { IExtHostContext } from '../../../services/extensions/common/extHostCustomers.js';
 import { ExtensionHostKind } from '../../../services/extensions/common/extensionHostKind.js';
 import { ViewDescriptorService } from '../../../services/views/browser/viewDescriptorService.js';
@@ -26,6 +26,7 @@ import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Mimes } from '../../../../base/common/mime.js';
 import { URI } from '../../../../base/common/uri.js';
 import * as sinon from 'sinon';
+import { ExtensionIdentifier } from '../../../../platform/extensions/common/extensions.js';
 
 suite('MainThreadHostTreeView', function () {
 	const testTreeViewId = 'testTreeView';
@@ -191,8 +192,9 @@ suite('MainThreadHostTreeView', function () {
 	test('updates focused tree view', () => {
 		const proxy = sinon.spy(extHostTreeViewsShape, '$setFocusedTreeView');
 
-		viewsService.setFocusedView(<IViewDescriptor>{
-			id: testTreeViewId
+		viewsService.setFocusedView(<ICustomViewDescriptor>{
+			id: testTreeViewId,
+			extensionId: new ExtensionIdentifier('test.extension')
 		});
 
 		assert.strictEqual(proxy.callCount, 1);
@@ -217,8 +219,9 @@ suite('MainThreadHostTreeView', function () {
 	test('does not emit duplicate focused tree view values', () => {
 		const proxy = sinon.spy(extHostTreeViewsShape, '$setFocusedTreeView');
 
-		const view1 = <IViewDescriptor>{
-			id: testTreeViewId
+		const view1 = <ICustomViewDescriptor>{
+			id: testTreeViewId,
+			extensionId: new ExtensionIdentifier('test.extension')
 		};
 
 		viewsService.setFocusedView(view1);

--- a/src/vs/workbench/api/test/browser/mainThreadTreeViews.test.ts
+++ b/src/vs/workbench/api/test/browser/mainThreadTreeViews.test.ts
@@ -194,7 +194,8 @@ suite('MainThreadHostTreeView', function () {
 
 		viewsService.setFocusedView(<ICustomViewDescriptor>{
 			id: testTreeViewId,
-			extensionId: new ExtensionIdentifier('test.extension')
+			extensionId: new ExtensionIdentifier('test.extension'),
+			treeView: (<ITreeViewDescriptor>ViewsRegistry.getView(testTreeViewId)).treeView
 		});
 
 		assert.strictEqual(proxy.callCount, 1);
@@ -221,7 +222,8 @@ suite('MainThreadHostTreeView', function () {
 
 		const view1 = <ICustomViewDescriptor>{
 			id: testTreeViewId,
-			extensionId: new ExtensionIdentifier('test.extension')
+			extensionId: new ExtensionIdentifier('test.extension'),
+			treeView: (<ITreeViewDescriptor>ViewsRegistry.getView(testTreeViewId)).treeView
 		};
 
 		viewsService.setFocusedView(view1);
@@ -231,6 +233,17 @@ suite('MainThreadHostTreeView', function () {
 		assert.strictEqual(proxy.callCount, 2);
 		assert.strictEqual(proxy.firstCall.args[0], testTreeViewId);
 		assert.strictEqual(proxy.secondCall.args[0], undefined);
+	});
+
+	test('ignores extension-contributed non-tree views', () => {
+		const proxy = sinon.spy(extHostTreeViewsShape, '$setFocusedTreeView');
+
+		viewsService.setFocusedView(<ICustomViewDescriptor>{
+			id: 'webview',
+			extensionId: new ExtensionIdentifier('test.extension')
+		});
+
+		assert.strictEqual(proxy.callCount, 0);
 	});
 
 });

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -837,7 +837,6 @@ export class TestPanelPart implements IPaneCompositePart {
 export class TestViewsService implements IViewsService {
 	declare readonly _serviceBrand: undefined;
 
-
 	onDidChangeViewContainerVisibility = new Emitter<{ id: string; visible: boolean; location: ViewContainerLocation }>().event;
 	isViewContainerVisible(id: string): boolean { return true; }
 	isViewContainerActive(id: string): boolean { return true; }
@@ -856,8 +855,14 @@ export class TestViewsService implements IViewsService {
 	closeView(id: string): void { }
 	getViewProgressIndicator(id: string) { return null!; }
 	getActiveViewPaneContainerWithId(id: string) { return null; }
+
+	private focusedView: IViewDescriptor | null = null;
 	getFocusedViewName(): string { return ''; }
-	getFocusedView(): IViewDescriptor | null { return null; }
+	getFocusedView(): IViewDescriptor | null { return this.focusedView; }
+	setFocusedView(view: IViewDescriptor | null): void {
+		this.focusedView = view;
+		this.onDidChangeFocusedViewEmitter.fire();
+	}
 }
 
 export class TestEditorGroupsService implements IEditorGroupsService {

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -11156,6 +11156,20 @@ declare module 'vscode' {
 		export const onDidChangeNotebookEditorVisibleRanges: Event<NotebookEditorVisibleRangesChangeEvent>;
 
 		/**
+		 * The id of the currently focused tree view or `undefined` if no tree view has focus.
+		 *
+		 * *Note* that only tree views contributed by extensions are included.
+		 */
+		export const focusedTreeView: string | undefined;
+
+		/**
+		 * An {@link Event} which fires when the {@link window.focusedTreeView focused tree view} has changed.
+		 *
+		 * *Note* that the event also fires when the focused tree view changes to `undefined`.
+		 */
+		export const onDidChangeFocusedTreeView: Event<string | undefined>;
+
+		/**
 		 * The currently opened terminals or an empty array.
 		 */
 		export const terminals: readonly Terminal[];


### PR DESCRIPTION
This PR exposes focused tree view state to the extension host.

Closes #315186

#### Adds
```ts
/**
 * The id of the currently focused tree view or `undefined` if no tree view has focus.
 *
 * Note that only tree views contributed by extensions are included.
 */
vscode.window.focusedTreeView: string | undefined

/**
 * An {@link Event} which fires when the
 * {@link window.focusedTreeView focused tree view} changes.
 *
 * Note that the event also fires when the focused tree view changes to `undefined`.
 */
vscode.window.onDidChangeFocusedTreeView: Event<string | undefined>
```

The API does not expose built-in view focus changes and provides only view ids, avoiding cross-extension `TreeView` object exposure.

This PR does not introduce new behavior. It exposes the existing `ViewsService.onDidChangeFocusedView` workbench focus state to the extension host with simple filtering. Since the underlying behavior is already long-lived and stable, there is limited proposal-specific behavior to validate. If this is still expected to go through the proposal process, it can be converted accordingly.

#### Naming

The initial direction was `activeTreeView` (@jrieken, https://github.com/microsoft/vscode/issues/315186#issuecomment-4420803503), but the implementation ultimately uses `focusedTreeView`.

This introduces a new terminology distinction inside `vscode.window`, which was preferable to avoid initially, but `focused` ended up being more accurate:

* When a tree view loses focus, `activeTreeView === undefined`. However, the tree view may still be visible and operational, updating internally without direct interaction. In that state, the view is still "active", just not focused.

* When the tree view title is clicked and the view collapses, the title retains focus while the view content becomes invisible. In that state, `activeTreeView === id`, even though the view itself is no longer meaningfully "active". This case was the main reason for switching to `focusedTreeView`.

Another naming consideration was whether to use an `Id` suffix (`focusedTreeViewId`).

Using the suffix would be more explicit from the API design side, since the value is actually a string id and not a `TreeView` object. However, exposing implementation-oriented suffixes in `vscode.window` APIs generally feels undesirable and inconsistent with existing naming.

One important consideration is future API space. If a `TreeView` object were ever exposed in the future, the natural `focusedTreeView` naming would already be occupied by the string-returning API introduced here. This PR intentionally avoids exposing `TreeView` objects across extensions, so the current `focusedTreeView: string | undefined` shape still felt like the better tradeoff, but this naming reservation issue is worth explicitly calling out.

#### Subtle test cases

There is limited surface area to test, but a few notable cases were verified:
* Tree views correctly lose focus when the VS Code window loses focus and regain it when the window becomes active again.
* Opening a tree view context menu temporarily removes focus from the tree view. When a context menu command executes, focus is restored before command execution, so commands receive the correct `focusedTreeView` value.
* Dismissing the context menu (for example with Escape) correctly restores focus back to the tree view.

#### Checklist
- [ ] Confirm naming: `focusedTreeView` vs `activeTreeView` vs `...TreeViewId`.
- [ ] Confirm that filtering only extension-contributed tree views is the correct behavior, or remove filtering to report any view focus including built-in views.
- [ ] Confirm that `TreeView` object isolation should remain enforced and that exposing only `string | undefined` is preferred over `TreeView | undefined`.
- [ ] Confirm separation by view type, or convert to a unified `focusedView` endpoints.
- [ ] No pending changes/questions.

#### treeViewActiveItem proposal

The end of #315186 mentions the missing API for retrieving the active (focused/highlighted) tree item.

After additional investigation, there already appears to be a `treeViewActiveItem` proposal, which seems to cover this scenario correctly. Is there anything currently blocking it from being finalized? Basic testing revealed no problems with it.

Releasing it together with, or after `focusedTreeView` would significantly improve keyboard-driven tree view interactions.