### PR TITLE
Only flush once on content or injected text

### DIFF
--- a/src/vs/editor/common/viewModel/viewModelImpl.ts
+++ b/src/vs/editor/common/viewModel/viewModelImpl.ts
@@ -350,6 +350,7 @@ export class ViewModel extends Disposable implements IViewModel {
 			// We defer this until after the loop because the coordinatesConverter
 			// relies on projections that may not yet reflect all changes in the batch.
 			const customLineHeightRangesToInsert: { fromLineNumber: number; toLineNumber: number }[] = [];
+			let shouldFlushViewLayout = false;
 
 			for (const change of changes) {
 				switch (change.changeType) {
@@ -357,7 +358,7 @@ export class ViewModel extends Disposable implements IViewModel {
 						this._lines.onModelFlushed();
 						eventsCollector.emitViewEvent(new viewEvents.ViewFlushedEvent());
 						this._decorations.reset();
-						this.viewLayout.onFlushed(this.getLineCount(), this._getCustomLineHeights());
+						shouldFlushViewLayout = false;
 						hadOtherModelChange = true;
 						break;
 					}
@@ -407,6 +408,10 @@ export class ViewModel extends Disposable implements IViewModel {
 						break;
 					}
 				}
+			}
+
+			if (shouldFlushViewLayout) {
+				this.viewLayout.onFlushed(this.getLineCount(), this._getCustomLineHeights());
 			}
 
 			if (versionId !== null) {

--- a/src/vs/editor/common/viewModel/viewModelImpl.ts
+++ b/src/vs/editor/common/viewModel/viewModelImpl.ts
@@ -358,7 +358,7 @@ export class ViewModel extends Disposable implements IViewModel {
 						this._lines.onModelFlushed();
 						eventsCollector.emitViewEvent(new viewEvents.ViewFlushedEvent());
 						this._decorations.reset();
-						shouldFlushViewLayout = false;
+						shouldFlushViewLayout = true;
 						hadOtherModelChange = true;
 						break;
 					}


### PR DESCRIPTION
In the `ViewModel#onDidChangeContentOrInjectedText` event handler, the view layout is flushed in a loop. This works, because these changes typically contain at most one flush event. Actually flushing multiple times, causes weird rendering issues.

This change is extracted from my fork with all sorts of font size and line wrapping fixes, where more event types need to cause a view layout flush. The goal of this change, is to align the two versions more, so I can hopefully get to a point where I can contribute more changes back to VSCode.

I also believe this better expresses intent.