### PR TITLE
Fix paths when printing type errors in gulp editor-distro

### DIFF
--- a/build/lib/treeshaking.ts
+++ b/build/lib/treeshaking.ts
@@ -63,11 +63,11 @@ export interface ITreeShakingResult {
 	[file: string]: string;
 }
 
-function printDiagnostics(options: ITreeShakingOptions, diagnostics: ReadonlyArray<ts.Diagnostic>): void {
+function printDiagnostics(diagnostics: ReadonlyArray<ts.Diagnostic>): void {
 	for (const diag of diagnostics) {
 		let result = '';
 		if (diag.file) {
-			result += `${path.join(options.sourcesRoot, diag.file.fileName)}`;
+			result += diag.file.fileName;
 		}
 		if (diag.file && diag.start) {
 			const location = diag.file.getLineAndCharacterOfPosition(diag.start);
@@ -84,19 +84,19 @@ export function shake(options: ITreeShakingOptions): ITreeShakingResult {
 
 	const globalDiagnostics = program.getGlobalDiagnostics();
 	if (globalDiagnostics.length > 0) {
-		printDiagnostics(options, globalDiagnostics);
+		printDiagnostics(globalDiagnostics);
 		throw new Error(`Compilation Errors encountered.`);
 	}
 
 	const syntacticDiagnostics = program.getSyntacticDiagnostics();
 	if (syntacticDiagnostics.length > 0) {
-		printDiagnostics(options, syntacticDiagnostics);
+		printDiagnostics(syntacticDiagnostics);
 		throw new Error(`Compilation Errors encountered.`);
 	}
 
 	const semanticDiagnostics = program.getSemanticDiagnostics();
 	if (semanticDiagnostics.length > 0) {
-		printDiagnostics(options, semanticDiagnostics);
+		printDiagnostics(semanticDiagnostics);
 		throw new Error(`Compilation Errors encountered.`);
 	}
 


### PR DESCRIPTION
The `gulp editor-distro` command performs type checking. When type errors occur, the script prepends the cwd to the file paths. However, TypeScript already returns absolute file paths. As a result, the script would log something like `/path/to/vscode/path/to/vscode/file.ts`, instead of `/path/to/vscode/file.ts`.

This change fixes it by removing the extra cwd prefix.