### PR TITLE
Only generate copilot ThirdPartyNotices when publishing or releasing

### DIFF
--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -223,6 +223,8 @@ extends:
           os: linux
         jobs:
           - template: build/azure-pipelines/product-copilot.yml@self
+            parameters:
+              VSCODE_RELEASE: ${{ parameters.VSCODE_RELEASE }}
 
       - ${{ if eq(variables['VSCODE_BUILD_STAGE_WINDOWS'], true) }}:
         - stage: Windows

--- a/build/azure-pipelines/product-copilot.yml
+++ b/build/azure-pipelines/product-copilot.yml
@@ -35,6 +35,7 @@ jobs:
           outputformat: text
         continueOnError: true
         retryCountOnTaskFailure: 5
+        condition: and(succeeded(), or(eq(lower(variables['VSCODE_PUBLISH']), 'true'), eq(lower(variables['VSCODE_RELEASE']), 'true')))
         displayName: Generate NOTICE file
 
       - script: |

--- a/build/azure-pipelines/product-copilot.yml
+++ b/build/azure-pipelines/product-copilot.yml
@@ -34,14 +34,14 @@ jobs:
       - template: copilot/build-steps.yml
       - template: copilot/l10n-steps.yml
 
-      - task: notice@0
-        inputs:
-          outputfile: $(Build.SourcesDirectory)/extensions/copilot/ThirdPartyNotices.txt
-          outputformat: text
-        continueOnError: true
-        retryCountOnTaskFailure: 5
-        condition: and(succeeded(), or(eq(lower(variables['VSCODE_PUBLISH']), 'true'), ${{ eq(parameters.VSCODE_RELEASE, true) }}))
-        displayName: Generate NOTICE file
+      - ${{ if or(eq(variables['VSCODE_PUBLISH'], true), eq(parameters.VSCODE_RELEASE, true)) }}:
+        - task: notice@0
+          inputs:
+            outputfile: $(Build.SourcesDirectory)/extensions/copilot/ThirdPartyNotices.txt
+            outputformat: text
+          continueOnError: true
+          retryCountOnTaskFailure: 5
+          displayName: Generate NOTICE file
 
       - script: |
           set -e

--- a/build/azure-pipelines/product-copilot.yml
+++ b/build/azure-pipelines/product-copilot.yml
@@ -1,3 +1,8 @@
+parameters:
+  - name: VSCODE_RELEASE
+    type: boolean
+    default: false
+
 jobs:
   - job: Copilot
     displayName: Copilot
@@ -35,7 +40,7 @@ jobs:
           outputformat: text
         continueOnError: true
         retryCountOnTaskFailure: 5
-        condition: and(succeeded(), or(eq(lower(variables['VSCODE_PUBLISH']), 'true'), eq(lower(variables['VSCODE_RELEASE']), 'true')))
+        condition: and(succeeded(), or(eq(lower(variables['VSCODE_PUBLISH']), 'true'), ${{ eq(parameters.VSCODE_RELEASE, true) }}))
         displayName: Generate NOTICE file
 
       - script: |


### PR DESCRIPTION
Quick win for https://vscodeteam.slack.com/archives/C1Y427SES/p1778478238390869

Gates the `Generate NOTICE file` step in `build/azure-pipelines/product-copilot.yml` so it only runs when `VSCODE_PUBLISH` or `VSCODE_RELEASE` is `true`, matching the conditional pattern used in `product-quality-checks.yml`.

No downstream step requires `ThirdPartyNotices.txt`:
- `vsce package` uses `!ThirdPartyNotices.txt` in `.vscodeignore`, which only un-ignores the file if present (no failure if absent).
- No other step in the pipeline reads it.

Side effect: copilot VSIXs produced by non-publishing CI runs will not contain `ThirdPartyNotices.txt`. Publishing/release builds are unchanged.