### PR TITLE
Re-show walkthrough when GitHub auth expires while web tab is open

### DIFF
--- a/extensions/github-authentication/src/extension.ts
+++ b/extensions/github-authentication/src/extension.ts
@@ -65,7 +65,8 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(uriHandler);
 	context.subscriptions.push(vscode.window.registerUriHandler(uriHandler));
 
-	context.subscriptions.push(new GitHubAuthenticationProvider(context, uriHandler));
+	const githubProvider = new GitHubAuthenticationProvider(context, uriHandler);
+	context.subscriptions.push(githubProvider);
 
 	let before = vscode.workspace.getConfiguration().get<string>('github-enterprise.uri');
 	let githubEnterpriseAuthProvider = initGHES(context, uriHandler);
@@ -79,6 +80,23 @@ export function activate(context: vscode.ExtensionContext) {
 			}
 		}
 	}));
+
+	// Allow other workbench code (e.g. the agent host tunnel layer, which
+	// can detect a 401 on a long-lived WebSocket but cannot cleanly observe
+	// expiry without a probe) to ask us to re-validate every stored session
+	// on demand. Returning a promise lets callers await and then re-check
+	// `getSessions` instead of polling.
+	context.subscriptions.push(vscode.commands.registerCommand(
+		'_github.authentication.validateSessions',
+		async () => {
+			await Promise.all([
+				githubProvider.validateSessions(),
+				githubEnterpriseAuthProvider instanceof GitHubAuthenticationProvider
+					? githubEnterpriseAuthProvider.validateSessions()
+					: Promise.resolve(),
+			]);
+		}
+	));
 
 	// Listener to prompt for reload when the fetch implementation setting changes
 	const beforeFetchSetting = vscode.workspace.getConfiguration().get<boolean>('github-authentication.useElectronFetch', true);

--- a/extensions/github-authentication/src/github.ts
+++ b/extensions/github-authentication/src/github.ts
@@ -128,12 +128,30 @@ export class UriEventHandler extends vscode.EventEmitter<vscode.Uri> implements 
 }
 
 export class GitHubAuthenticationProvider implements vscode.AuthenticationProvider, vscode.Disposable {
+	/** How long to trust a successful `/user` probe before re-checking. */
+	private static readonly _VALIDATION_THROTTLE_MS = 5 * 60 * 1000;
+	/** How often {@link validateSessions} runs in the background. */
+	private static readonly _PERIODIC_VALIDATION_INTERVAL_MS = 10 * 60 * 1000;
+
 	private readonly _sessionChangeEmitter = new vscode.EventEmitter<vscode.AuthenticationProviderAuthenticationSessionsChangeEvent>();
 	private readonly _logger: Log;
 	private readonly _githubServer: IGitHubServer;
 	private readonly _telemetryReporter: ExperimentationTelemetry;
 	private readonly _keychain: Keychain;
 	private readonly _accountsSeen = new Set<string>();
+	/**
+	 * Per-session timestamp of the last successful token validation. Used to
+	 * throttle live `/user` probes during {@link readSessions} so we don't
+	 * hammer GitHub on every keychain mutation.
+	 */
+	private readonly _lastValidatedAt = new Map<string /* session.id */, number>();
+	/**
+	 * Single in-flight promise for {@link validateSessions} so that concurrent
+	 * triggers (10-min timer, tunnel auth probe, listTunnels error handler,
+	 * sibling-window keychain change) coalesce into one full re-probe pass
+	 * rather than racing on `_sessionsPromise`.
+	 */
+	private _validateSessionsInFlight: Promise<void> | undefined;
 	private readonly _disposable: vscode.Disposable | undefined;
 
 	private _sessionsPromise: Promise<vscode.AuthenticationSession[]>;
@@ -174,6 +192,15 @@ export class GitHubAuthenticationProvider implements vscode.AuthenticationProvid
 		const supportedAuthorizationServers = ghesUri
 			? [vscode.Uri.joinPath(ghesUri, '/login/oauth')]
 			: [vscode.Uri.parse('https://github.com/login/oauth')];
+
+		// Periodically re-validate stored sessions so server-side revocations
+		// (token revoked from github.com, organisation removed the user, etc.)
+		// surface even when nothing else writes to the keychain. Without this,
+		// long-lived web tabs can keep retrying with a dead token forever.
+		const periodicTimer = setInterval(() => {
+			this.validateSessions().catch(err => this._logger.error(`Periodic session validation failed: ${err}`));
+		}, GitHubAuthenticationProvider._PERIODIC_VALIDATION_INTERVAL_MS);
+
 		this._disposable = vscode.Disposable.from(
 			this._telemetryReporter,
 			vscode.authentication.registerAuthenticationProvider(
@@ -185,7 +212,8 @@ export class GitHubAuthenticationProvider implements vscode.AuthenticationProvid
 					supportedAuthorizationServers
 				}
 			),
-			this.context.secrets.onDidChange(() => this.checkForUpdates())
+			this.context.secrets.onDidChange(() => this.checkForUpdates()),
+			new vscode.Disposable(() => clearInterval(periodicTimer))
 		);
 	}
 
@@ -195,6 +223,39 @@ export class GitHubAuthenticationProvider implements vscode.AuthenticationProvid
 
 	get onDidChangeSessions() {
 		return this._sessionChangeEmitter.event;
+	}
+
+	/**
+	 * Force-revalidate every stored session against `/user` and fire
+	 * `removed` events for any sessions the server no longer accepts.
+	 *
+	 * Invoked from the background timer (every ten minutes) and on demand
+	 * via the `_github.authentication.validateSessions` command, which
+	 * other workbench code calls when it suspects the token has expired
+	 * (e.g. a tunnel WebSocket upgrade fails) so the walkthrough can
+	 * re-show without waiting for the next periodic tick.
+	 */
+	public async validateSessions(): Promise<void> {
+		// Coalesce overlapping calls: the periodic timer, the tunnel auth
+		// probe, and the listTunnels error path can all fire concurrently.
+		// Without this, each entry point would clear the throttle map and
+		// kick off its own readSessions(), racing on `_sessionsPromise` and
+		// producing duplicate `removed` events.
+		if (this._validateSessionsInFlight) {
+			return this._validateSessionsInFlight;
+		}
+		const run = (async () => {
+			this._lastValidatedAt.clear();
+			await this.checkForUpdates();
+		})();
+		this._validateSessionsInFlight = run;
+		try {
+			await run;
+		} finally {
+			if (this._validateSessionsInFlight === run) {
+				this._validateSessionsInFlight = undefined;
+			}
+		}
 	}
 
 	async getSessions(scopes: string[] | undefined, options?: vscode.AuthenticationProviderSessionOptions): Promise<vscode.AuthenticationSession[]> {
@@ -280,18 +341,43 @@ export class GitHubAuthenticationProvider implements vscode.AuthenticationProvid
 		let seenNumberAccountId: boolean = false;
 		// TODO: eventually remove this Set because we should only have one session per set of scopes.
 		const scopesSeen = new Set<string>();
+		const now = Date.now();
 		const sessionPromises = sessionData.map(async (session: SessionData): Promise<vscode.AuthenticationSession | undefined> => {
 			// For GitHub scope list, order doesn't matter so we immediately sort the scopes
 			const scopesStr = [...session.scopes].sort().join(' ');
 			let userInfo: { id: string; accountName: string } | undefined;
 			if (!session.account) {
+				// Legacy session without account info — we have to fetch it
+				// anyway to populate the modern shape, so use the result to
+				// drop the session if the token is no longer accepted.
 				try {
 					userInfo = await this._githubServer.getUserInfo(session.accessToken);
+					this._lastValidatedAt.set(session.id, now);
 					this._logger.info(`Verified session with the following scopes: ${scopesStr}`);
 				} catch (e) {
 					// Remove sessions that return unauthorized response
 					if (e.message === 'Unauthorized') {
 						return undefined;
+					}
+				}
+			} else {
+				// Modern session with account info — proactively validate the
+				// token against `/user`, but only when the cached probe is
+				// stale, so we don't spam GitHub on every keychain change.
+				// On `invalid` we drop the session (the keychain will be
+				// rewritten below, which fires `removed` to listeners). On
+				// `unknown` (network error / unexpected status) we keep the
+				// session so a transient outage doesn't sign the user out.
+				const lastValidated = this._lastValidatedAt.get(session.id) ?? 0;
+				if (now - lastValidated >= GitHubAuthenticationProvider._VALIDATION_THROTTLE_MS) {
+					const status = await this._githubServer.validateToken(session.accessToken);
+					if (status === 'invalid') {
+						this._logger.info(`Dropping session ${session.id}: server rejected token.`);
+						this._lastValidatedAt.delete(session.id);
+						return undefined;
+					}
+					if (status === 'valid') {
+						this._lastValidatedAt.set(session.id, now);
 					}
 				}
 			}
@@ -327,6 +413,15 @@ export class GitHubAuthenticationProvider implements vscode.AuthenticationProvid
 			.filter(p => p.status === 'fulfilled')
 			.map(p => (p as PromiseFulfilledResult<vscode.AuthenticationSession | undefined>).value)
 			.filter(<T>(p?: T): p is T => Boolean(p));
+
+		// Drop validation timestamps for sessions that no longer exist so the
+		// throttle map doesn't grow unbounded as users sign in and out.
+		const verifiedIds = new Set(verifiedSessions.map(s => s.id));
+		for (const id of [...this._lastValidatedAt.keys()]) {
+			if (!verifiedIds.has(id)) {
+				this._lastValidatedAt.delete(id);
+			}
+		}
 
 		this._logger.info(`Got ${verifiedSessions.length} verified sessions.`);
 		if (seenNumberAccountId || verifiedSessions.length !== sessionData.length) {
@@ -370,6 +465,10 @@ export class GitHubAuthenticationProvider implements vscode.AuthenticationProvid
 			const scopeString = sortedScopes.join(' ');
 			const token = await this._githubServer.login(scopeString, signInProvider, options?.extraAuthorizeParameters, loginWith);
 			const session = await this.tokenToSession(token, scopes);
+			// `tokenToSession` just called `/user` to fetch the account info,
+			// so the token is known good — record the timestamp to keep the
+			// next periodic re-validation throttled.
+			this._lastValidatedAt.set(session.id, Date.now());
 			this.afterSessionLoad(session);
 
 			const sessionIndex = sessions.findIndex(s => s.account.id === session.account.id && arrayEquals([...s.scopes].sort(), sortedScopes));

--- a/extensions/github-authentication/src/githubServer.ts
+++ b/extensions/github-authentication/src/githubServer.ts
@@ -18,10 +18,26 @@ import { base64Encode } from './node/buffer';
 const REDIRECT_URL_STABLE = 'https://vscode.dev/redirect';
 const REDIRECT_URL_INSIDERS = 'https://insiders.vscode.dev/redirect';
 
+/**
+ * Result of a token validity probe.
+ * - `valid`: the server returned a 2xx response.
+ * - `invalid`: the server returned 401 or 403 — the token has been revoked or expired.
+ * - `unknown`: the probe failed for a reason unrelated to credentials (network
+ *   error, server outage, unexpected status). Callers should NOT drop the
+ *   session in this case — the next probe may succeed.
+ */
+export type TokenValidationResult = 'valid' | 'invalid' | 'unknown';
+
 export interface IGitHubServer {
 	login(scopes: string, signInProvider?: GitHubSocialSignInProvider, extraAuthorizeParameters?: Record<string, string>, existingLogin?: string): Promise<string>;
 	logout(session: vscode.AuthenticationSession): Promise<void>;
 	getUserInfo(token: string): Promise<{ id: string; accountName: string }>;
+	/**
+	 * Lightweight probe that asks GitHub whether {@link token} is still
+	 * accepted. Used to proactively detect server-side revocations so callers
+	 * can drop dead sessions instead of leaving them in storage indefinitely.
+	 */
+	validateToken(token: string): Promise<TokenValidationResult>;
 	sendAdditionalTelemetryInfo(session: vscode.AuthenticationSession): Promise<void>;
 	friendlyName: string;
 }
@@ -258,6 +274,41 @@ export class GitHubServer implements IGitHubServer {
 			this._logger.error(`Getting account info failed: ${errorMessage}`);
 			throw new Error(errorMessage);
 		}
+	}
+
+	public async validateToken(token: string): Promise<TokenValidationResult> {
+		let result;
+		try {
+			this._logger.info('Validating token...');
+			result = await fetching(this.getServerUri('/user').toString(), {
+				logger: this._logger,
+				retryFallbacks: true,
+				expectJSON: true,
+				headers: {
+					Authorization: `token ${token}`,
+					'User-Agent': `${vscode.env.appName} (${vscode.env.appHost})`
+				}
+			});
+		} catch (ex) {
+			this._logger.error(`Token validation network error: ${ex.message ?? ex}`);
+			return 'unknown';
+		}
+		if (result.ok) {
+			return 'valid';
+		}
+		// Only an explicit 401 means the credential itself was rejected. 403 is
+		// returned for non-credential reasons too: primary/secondary/abuse rate
+		// limits, organisation SAML SSO enforcement, IP allowlist denials and
+		// scope-policy tightening. Treating those as `invalid` would silently
+		// sign the user out — exactly the regression this validation path is
+		// meant to prevent — so map them to `unknown` and let the caller keep
+		// the session.
+		if (result.status === 401) {
+			this._logger.info('Token validation: server rejected token (401).');
+			return 'invalid';
+		}
+		this._logger.warn(`Token validation: non-OK status ${result.status}; treating as unknown.`);
+		return 'unknown';
 	}
 
 	public async sendAdditionalTelemetryInfo(session: vscode.AuthenticationSession): Promise<void> {

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/tunnelAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/tunnelAgentHost.contribution.ts
@@ -9,6 +9,7 @@ import { mainWindow } from '../../../../base/browser/window.js';
 import * as nls from '../../../../nls.js';
 import { IRemoteAgentHostService, RemoteAgentHostAutoConnectSettingId, RemoteAgentHostConnectionStatus, RemoteAgentHostsEnabledSettingId } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { ITunnelAgentHostService, TUNNEL_ADDRESS_PREFIX, type ITunnelInfo } from '../../../../platform/agentHost/common/tunnelAgentHost.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
@@ -63,8 +64,22 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 	private readonly _reconnectPaused = new Set<string>();
 	/** Addresses paused specifically because the remote host is offline. */
 	private readonly _hostOfflinePaused = new Set<string>();
+	/**
+	 * Addresses paused because the upstream rejected our credentials. We
+	 * track these separately so wake/visibility events do NOT auto-resume
+	 * them — only an authentication-session change (a fresh token, or an
+	 * explicit "removed" event firing from a session validation) should
+	 * lift the pause. Without this, any tab focus would burn through the
+	 * retry budget against a token that the server has already rejected.
+	 */
+	private readonly _reconnectPausedForAuth = new Set<string>();
 	/** Timestamp of the last wake-triggered resume, to rate-limit rapid tab toggles. */
 	private _lastResumeAt = 0;
+	/**
+	 * In-flight session-validation promise, to coalesce concurrent failures
+	 * across multiple addresses into a single command invocation.
+	 */
+	private _pendingValidation: Promise<void> | undefined;
 
 	/**
 	 * Per-address connect sessions for telemetry. A session starts at the
@@ -83,6 +98,7 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 		@ILogService private readonly _logService: ILogService,
 		@IAuthenticationService private readonly _authenticationService: IAuthenticationService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
+		@ICommandService private readonly _commandService: ICommandService,
 		@IAgentHostFilterService agentHostFilterService: IAgentHostFilterService,
 	) {
 		super();
@@ -295,13 +311,30 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 				this._finishConnectAttempt(address, { success: true, attemptNumber, attemptStart, session, isReconnect });
 			} catch (err) {
 				this._logService.warn(`[TunnelAgentHost] Connect to ${cached.name} failed:`, err);
-				const errorCategory = this._categorizeError(err);
+				let errorCategory = this._categorizeError(err);
 				this._finishConnectAttempt(address, { success: false, attemptNumber, attemptStart, session, isReconnect, error: err });
 				// Clear the pending-connect entry BEFORE deciding what to do
 				// next; otherwise `_scheduleReconnect`'s in-flight guard
 				// (`_pendingConnects.has(address)`) would silently bail and
 				// we'd never re-arm the timer, leaving the tunnel stuck.
 				this._pendingConnects.delete(address);
+
+				// The web embedder masks the upstream HTTP status — a 401 on
+				// the WebSocket upgrade arrives as the generic string
+				// `"WebSocket relay connection failed"`. Probe the auth
+				// provider before scheduling another retry, so we can
+				// upgrade a `relayConnectionFailed` to `authExpired` when
+				// the underlying cause was actually a revoked token.
+				if (errorCategory === 'relayConnectionFailed' && cached.authProvider) {
+					const authStillValid = await this._probeAuthValid(cached.authProvider);
+					if (authStillValid === false) {
+						this._logService.info(
+							`[TunnelAgentHost] Upgrading ${address} failure to authExpired ` +
+							`after auth-provider probe found no valid session.`
+						);
+						errorCategory = 'authExpired';
+					}
+				}
 
 				// Auth failures are not worth retrying — a fresh token must
 				// be acquired by the user or by a session-change event. Pause
@@ -497,6 +530,82 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 		}
 	}
 
+	/**
+	 * Ask the matching authentication provider to re-validate its stored
+	 * sessions, then check whether the user is still authenticated for that
+	 * provider. Returns:
+	 * - `true`: at least one session is still present, AND no session was
+	 *   removed during revalidation (i.e. the failure we're investigating
+	 *   was probably not auth).
+	 * - `false`: revalidation either removed all sessions, or removed at
+	 *   least one session — caller should treat this failure as auth-expired.
+	 * - `undefined`: we couldn't determine (provider doesn't support
+	 *   server-side revalidation, command not registered, etc.) — caller
+	 *   should not draw conclusions and should fall back to retry.
+	 *
+	 * Concurrent invocations share a single in-flight validation so a burst
+	 * of failed reconnect attempts triggers exactly one `/user` round-trip.
+	 *
+	 * Comparing the session-id set before vs. after revalidation (rather
+	 * than only checking whether *any* sessions remain afterwards) covers
+	 * the partial-revocation case: a user with multiple github sessions
+	 * (e.g. tunnel scope + Copilot scope) where only one was revoked still
+	 * has `getSessions(...).length > 0`, but their tunnel session is the
+	 * one that's gone.
+	 */
+	private async _probeAuthValid(providerId: 'github' | 'microsoft'): Promise<boolean | undefined> {
+		// Server-side revalidation is github-specific: only the
+		// github-authentication extension currently exposes the
+		// `_github.authentication.validateSessions` command. For other
+		// providers we have no way to force the keychain to re-probe,
+		// so we don't draw any conclusion.
+		if (providerId !== 'github') {
+			return undefined;
+		}
+
+		try {
+			const sessionsBefore = await this._authenticationService.getSessions(providerId);
+			const idsBefore = new Set(sessionsBefore.map(s => s.id));
+
+			if (!this._pendingValidation) {
+				this._pendingValidation = (async () => {
+					try {
+						// Fire-and-await: the github-authentication extension
+						// registers this command; on the desktop the auth
+						// provider may handle expiry differently and not
+						// register it — we tolerate that with a try/catch.
+						await this._commandService.executeCommand('_github.authentication.validateSessions');
+					} catch (err) {
+						this._logService.debug(`[TunnelAgentHost] Auth validation command failed: ${err}`);
+					}
+				})();
+				this._pendingValidation.finally(() => {
+					this._pendingValidation = undefined;
+				});
+			}
+			await this._pendingValidation;
+
+			const sessionsAfter = await this._authenticationService.getSessions(providerId);
+			if (sessionsAfter.length === 0) {
+				return false;
+			}
+			// If revalidation dropped any previously-known session id, treat
+			// the failure as auth-expired even though other sessions remain
+			// (partial revocation: a different scope set may still be valid
+			// but the tunnel-scoped one is gone).
+			const idsAfter = new Set(sessionsAfter.map(s => s.id));
+			for (const id of idsBefore) {
+				if (!idsAfter.has(id)) {
+					return false;
+				}
+			}
+			return true;
+		} catch (err) {
+			this._logService.debug(`[TunnelAgentHost] Auth probe failed: ${err}`);
+			return undefined;
+		}
+	}
+
 	private _cancelReconnect(address: string): void {
 		const timer = this._reconnectTimeouts.get(address);
 		if (timer !== undefined) {
@@ -510,6 +619,7 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 		this._reconnectAttempts.delete(address);
 		this._reconnectPaused.delete(address);
 		this._hostOfflinePaused.delete(address);
+		this._reconnectPausedForAuth.delete(address);
 	}
 
 	/** Drop all reconnect + telemetry state for an address (e.g. on removal). */
@@ -564,6 +674,14 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 			this._hostOfflinePaused.add(address);
 		} else {
 			this._hostOfflinePaused.delete(address);
+		}
+		// Auth-class failures must not be resumed by visibility/online events
+		// alone — only a session change ("removed" or "added") should clear
+		// them, otherwise we'd retry against the same rejected token forever.
+		if (reason === 'authExpired' || reason === 'auth') {
+			this._reconnectPausedForAuth.add(address);
+		} else {
+			this._reconnectPausedForAuth.delete(address);
 		}
 		this._logService.info(
 			`[TunnelAgentHost] Pausing auto-reconnect for ${address} (${reason}); ` +
@@ -663,11 +781,19 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 		// flaky Wi-Fi toggling online/offline) so we don't hammer the relay
 		// with immediate retries. This is an event-smoothing gate, not an
 		// error-backoff — that's handled by `_scheduleReconnect`.
-		const now = Date.now();
-		if (now - this._lastResumeAt < RESUME_RATE_LIMIT_MS) {
-			return;
+		//
+		// `sessionAdded` is NOT rate-limited: a session change is rare,
+		// authoritative, and is the only signal that releases an
+		// auth-paused tunnel (see `_reconnectPausedForAuth`). Dropping it
+		// because a wake event happened to fire ten seconds earlier would
+		// strand the auth pause until the user manually reconnects.
+		if (trigger !== 'sessionAdded') {
+			const now = Date.now();
+			if (now - this._lastResumeAt < RESUME_RATE_LIMIT_MS) {
+				return;
+			}
+			this._lastResumeAt = now;
 		}
-		this._lastResumeAt = now;
 
 		const cached = this._tunnelService.getCachedTunnels();
 		for (const tunnel of cached) {
@@ -677,6 +803,17 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 			}
 			const live = this._remoteAgentHostService.connections.find(c => c.address === address);
 			if (live && live.status === RemoteAgentHostConnectionStatus.Connected) {
+				continue;
+			}
+
+			// Don't resume an auth-paused tunnel from a wake/visibility/online
+			// event — the only valid resume signal is a session change. The
+			// background validation timer in github-authentication will clear
+			// (or re-issue) the session and trigger us via _handleSessionsChange.
+			if (this._reconnectPausedForAuth.has(address) && trigger !== 'sessionAdded') {
+				this._logService.info(
+					`[TunnelAgentHost] Skipping resume for ${address} (trigger: ${trigger}); auth-paused, awaiting session change.`
+				);
 				continue;
 			}
 
@@ -701,6 +838,7 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 			...this._reconnectTimeouts.keys(),
 			...this._reconnectAttempts.keys(),
 			...this._reconnectPaused,
+			...this._reconnectPausedForAuth,
 			...this._connectSessions.keys(),
 		]);
 		for (const address of tracked) {

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/webTunnelAgentHostService.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/webTunnelAgentHostService.ts
@@ -18,6 +18,7 @@ import {
 	type ICachedTunnel,
 	type ITunnelInfo,
 } from '../../../../platform/agentHost/common/tunnelAgentHost.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
@@ -59,6 +60,7 @@ export class WebTunnelAgentHostService extends Disposable implements ITunnelAgen
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IAuthenticationService private readonly _authenticationService: IAuthenticationService,
 		@IStorageService private readonly _storageService: IStorageService,
+		@ICommandService private readonly _commandService: ICommandService,
 	) {
 		super();
 		this._discoveryProvider = environmentService.options?.tunnelDiscoveryProvider;
@@ -94,6 +96,16 @@ export class WebTunnelAgentHostService extends Disposable implements ITunnelAgen
 			return results;
 		} catch (err) {
 			this._logService.error(`${LOG_PREFIX} Failed to list tunnels`, err);
+			// The embedder swallows the upstream HTTP status, so we cannot
+			// tell whether this was a 401 or a transient network failure.
+			// Nudge the GitHub auth provider to re-validate stored sessions —
+			// if the underlying cause was a revoked token, that will drop the
+			// session, fire `removed`, and let the walkthrough re-show via
+			// the welcome contribution. The provider coalesces concurrent
+			// invocations, so back-to-back calls from different code paths
+			// share a single `/user` round-trip per session.
+			this._commandService.executeCommand('_github.authentication.validateSessions')
+				.then(undefined, e => this._logService.debug(`${LOG_PREFIX} Auth revalidation failed`, e));
 			return [];
 		}
 	}


### PR DESCRIPTION
## Scenario

User opens vscode.dev/agents with a chat running → walks away → laptop sleeps → GitHub OAuth token expires or is revoked overnight → user returns.

**Before this PR:** the tunnel layer silently retries the WebSocket relay forever. No walkthrough, no error, no signal — just a dead connection masquerading as a network blip.

**After this PR:** within ≤10 min (or on the next reconnect attempt, whichever is first) the dead session is dropped, `removed` fires on `IAuthenticationService`, and the existing welcome contribution re-shows the GitHub walkthrough — identical to a fresh page load.

## Root cause

The web embedder strips the upstream HTTP status from WebSocket upgrade failures. A 401 from the relay arrives at the workbench as the generic string `"WebSocket relay connection failed"`. The reconnect categoriser had no way to tell auth expiry apart from a transient network outage, so it kept retrying against a dead token forever.

## Approach

Three independent triggers nudge the auth provider to revalidate against `/user`, because no single trigger is reliable on its own:

1. **10-min periodic timer** inside `GitHubAuthenticationProvider`. Safety net for the case where nothing else fails.
2. **Relay-failure probe** in `tunnelAgentHost.contribution.ts`. When a connect fails as `relayConnectionFailed`, snapshot the session ids, force a revalidation via an internal command, and if any pre-existing session disappeared, upgrade the failure to `authExpired`.
3. **`listTunnels` failure trigger** in `webTunnelAgentHostService.ts`. Discovery failures swallow the HTTP status; we fire the same revalidation command (fire-and-forget) so revoked tokens surface even when the only symptom is `listTunnels` returning `[]`.

Once the provider finds a 401 on `/user`, it drops the session from the keychain and fires `removed`. The existing welcome contribution already listens for that event — no new UX.

A new `_reconnectPausedForAuth` set keeps the tunnel paused across wake/visibility/online events so wake bursts don't fight the auth pause; only a `sessionAdded` event releases it (and `sessionAdded` is exempt from the 10-second resume rate-limit so a wake event can't strand the pause).

## Files

| File | Change |
|---|---|
| `extensions/github-authentication/src/githubServer.ts` | New `validateToken(token)` method on `IGitHubServer`. Returns `'valid' \| 'invalid' \| 'unknown'`. Only HTTP **401** maps to `'invalid'`. 403 maps to `'unknown'` so SAML SSO, IP allowlist, rate-limit and scope-policy denials don't sign users out. |
| `extensions/github-authentication/src/github.ts` | `readSessions` validates modern sessions with a 5-min per-session throttle. New `validateSessions()` public method with single-flight coalescing. 10-min `setInterval` calls it. `createSession` records the validation timestamp so fresh logins don't trigger an immediate probe. |
| `extensions/github-authentication/src/extension.ts` | Registers internal command `_github.authentication.validateSessions` that fans out to both the github and GHES providers. |
| `src/vs/sessions/contrib/remoteAgentHost/browser/tunnelAgentHost.contribution.ts` | `_probeAuthValid` helper: github-only, snapshot before/after session id comparison, in-flight coalescing. `_reconnectPausedForAuth` set with sticky behavior across wake/visibility events. `_resumeReconnects` rate-limit gate now skipped for `sessionAdded` triggers. |
| `src/vs/sessions/contrib/remoteAgentHost/browser/webTunnelAgentHostService.ts` | `listTunnels` catch fires the validation command. |

## End-to-end behavior

| Scenario | Before | After |
|---|---|---|
| Token revoked while tab open | Silent retry forever; walkthrough never reappears | Within ≤10 min (or first failed reconnect / failed `listTunnels`, whichever is first), validation drops the dead session, `removed` fires, walkthrough re-shows, tunnel state torn down |
| Sleep / wake with valid token | Worked | Still works (auth-pause set is empty, normal resume) |
| Auth-paused tunnel + tab focus | Resume cleared the pause → retry storm | Pause persists; only `sessionAdded` lifts it |
| WS-upgrade 401 | Misclassified as `relayConnectionFailed`, infinite retry | Probe escalates to `authExpired`; existing pause-then-walkthrough path runs |
| 403 from `/user` (rate-limit, SAML SSO, IP allowlist) | n/a (modern sessions weren't probed) | Treated as `'unknown'`; session kept |

## Validation

- ✅ `npm run compile-check-ts-native`
- ✅ `npm run valid-layers-check`
- ✅ `npx tsc -p extensions/github-authentication/tsconfig.json --noEmit`
- ✅ `npx tsc -p extensions/github-authentication/tsconfig.browser.json --noEmit`
- ✅ `npx eslint` on all five modified files

## Council review

This PR was developed and hardened via a multi-model council review pass. The reviewers caught four substantive issues, all fixed before submission:

| Finding | Reviewers | Fix |
|---|---|---|
| `validateToken` originally classified 403 as `'invalid'` → would sign users out on rate-limit / SAML SSO | 3/3 | Only 401 → `'invalid'`. 403 → `'unknown'`. |
| `_probeAuthValid` was provider-blind: failed for Microsoft tunnels and for partial GitHub revocation (multiple sessions, only one revoked) | 3/3 | Non-github providers return `undefined`. For github, compare session-id set before vs after — any removed id ⇒ auth-expired. |
| `validateSessions()` had no coalescing: concurrent triggers raced on `_sessionsPromise` and produced double `removed` events | 3/3 | Added `_validateSessionsInFlight` single-flight inside `validateSessions()`. |
| `_resumeReconnects` 10-s rate-limit gate could swallow the only `sessionAdded` signal that releases an auth pause | 1/3 (high-evidence) | `sessionAdded` bypasses the rate-limit gate. |

## Not addressed (deferred)

- **No unit tests** for `validateToken` classification or `_probeAuthValid` state machine. These classes had no prior test coverage; adding tests is a separate workstream. Happy to add at least a `validateToken` classification test if reviewers want it before merging.
- **GHES provider reference drift**: the `_github.authentication.validateSessions` command handler captures `githubEnterpriseAuthProvider` by reference at activation; if the user changes the GHES URI mid-session and the provider is recreated, the captured reference is stale. Pre-existing pattern issue, unrelated to this scenario.
- **Cookie-expiry destroying localStorage** (G5 in original analysis) and **in-flight chat replay** (G7) — both require vscode-dev changes or large architectural work. Tracked separately.

## How to manually test

This is hard to repro without revoking a token; the practical path is:
1. Open vscode.dev/agents, sign in, start a chat.
2. From github.com → Settings → Applications, revoke the relevant OAuth app authorization.
3. Wait ≤10 min, or close the laptop lid for 1-2 min and reopen.
4. Expected: walkthrough re-appears asking for sign-in, no infinite retry, no console spam.

Alternatively, set a breakpoint in `_probeAuthValid` and force a `relayConnectionFailed` via the network panel.
