### PR TITLE
Gate replayed thinking blocks on same-model match for all rounds

### DIFF
--- a/extensions/copilot/src/extension/prompts/node/panel/toolCalling.tsx
+++ b/extensions/copilot/src/extension/prompts/node/panel/toolCalling.tsx
@@ -126,8 +126,7 @@ export class ChatToolCalls extends PromptElement<ChatToolCallsProps, void> {
 		const roundModelId = round.modelId ?? (round as IToolCallRound & { phaseModelId?: string }).phaseModelId;
 		const sameModelAsEndpoint = roundModelId === this.promptEndpoint.model;
 		const apiSupportsHistoricalThinking = this.promptEndpoint.apiType === 'responses' || this.promptEndpoint.apiType === 'messages';
-		const includeThinking = !this.props.isHistorical
-			|| (apiSupportsHistoricalThinking && sameModelAsEndpoint);
+		const includeThinking = sameModelAsEndpoint && (!this.props.isHistorical || apiSupportsHistoricalThinking);
 		const thinking = includeThinking && round.thinking && <ThinkingDataContainer thinking={round.thinking} />;
 		const phase = (round.phase && roundModelId === this.promptEndpoint.model) ? <PhaseDataContainer phase={round.phase} /> : undefined;
 		const compaction = round.compaction && <CompactionDataContainer compaction={round.compaction} />;

--- a/extensions/copilot/src/extension/tools/node/test/toolCalling.spec.tsx
+++ b/extensions/copilot/src/extension/tools/node/test/toolCalling.spec.tsx
@@ -235,10 +235,16 @@ suite('ChatToolCalls thinking handling', () => {
 		expect(hasThinkingPart(result)).toBe(false);
 	});
 
-	test('non-historical: includes thinking regardless of apiType/modelId', async () => {
+	test('non-historical: includes thinking when modelId matches (regardless of apiType)', async () => {
 		const endpoint = makeEndpoint('gpt-5', 'chatCompletions');
-		const result = await render(endpoint, [makeThinkingRound('claude-3.7-sonnet')], false);
+		const result = await render(endpoint, [makeThinkingRound('gpt-5')], false);
 		expect(hasThinkingPart(result)).toBe(true);
+	});
+
+	test('non-historical: drops thinking when modelId mismatches', async () => {
+		const endpoint = makeEndpoint('gpt-5', 'responses');
+		const result = await render(endpoint, [makeThinkingRound('claude-4.6-sonnet')], false);
+		expect(hasThinkingPart(result)).toBe(false);
 	});
 
 	test('historical: backward-compat reads phaseModelId when modelId is missing', async () => {


### PR DESCRIPTION
Fix: make \`sameModelAsEndpoint\` a hard precondition. Historical rounds additionally require the endpoint's API to support replaying historical thinking (Messages or Responses).

Fixes: #316536