### PR TITLE
Workspace picker: structured tab descriptors, mark Remote experimental

### DIFF
--- a/src/vs/platform/actionWidget/browser/tabbedActionListWidget.ts
+++ b/src/vs/platform/actionWidget/browser/tabbedActionListWidget.ts
@@ -9,6 +9,7 @@ import { Radio } from '../../../base/browser/ui/radio/radio.js';
 import { KeyCode } from '../../../base/common/keyCodes.js';
 import { Emitter } from '../../../base/common/event.js';
 import { Disposable, DisposableStore, MutableDisposable, toDisposable } from '../../../base/common/lifecycle.js';
+import { ThemeIcon } from '../../../base/common/themables.js';
 import { IContextViewService } from '../../contextview/browser/contextView.js';
 import { IInstantiationService } from '../../instantiation/common/instantiation.js';
 import { ActionList, IActionListDelegate, IActionListItem, IActionListOptions } from './actionList.js';
@@ -25,6 +26,23 @@ export interface ITabbedActionListBuildResult<T> {
 }
 
 /**
+ * Describes one tab in a {@link TabbedActionListWidget}. The {@link id}
+ * is the stable identity used everywhere the widget reasons about a
+ * tab (initial selection, change events, `createActionList` callback);
+ * {@link label}, {@link tooltip}, and {@link icon} are presentation only.
+ */
+export interface ITabDescriptor {
+	/** Stable identifier used for tab identity and selection callbacks. */
+	readonly id: string;
+	/** Visible label. Defaults to {@link id}. Localize at the call site. */
+	readonly label?: string;
+	/** Hover tooltip. Defaults to {@link label} ?? {@link id}. */
+	readonly tooltip?: string;
+	/** Optional leading icon rendered before the label. */
+	readonly icon?: ThemeIcon;
+}
+
+/**
  * Options for {@link TabbedActionListWidget.show}. The widget renders a
  * tab bar above an `ActionList` inside a single popup. Consumers describe
  * how to compute items for each tab; the widget handles tab switching and
@@ -35,9 +53,9 @@ export interface ITabbedActionListShowOptions<T> {
 	readonly user: string;
 	/** Element the popup is anchored to. */
 	readonly anchor: HTMLElement;
-	/** Tab labels rendered in order. Localize at the call site. */
-	readonly tabs: readonly string[];
-	/** Initially active tab. Must be present in {@link tabs}. */
+	/** Tabs rendered in order. */
+	readonly tabs: readonly ITabDescriptor[];
+	/** Initially active tab id. Must match an entry in {@link tabs}. */
 	readonly initialTab: string;
 	/** Computes the list items and per-tab options shown when the given tab is active. */
 	createActionList(activeTab: string): ITabbedActionListBuildResult<T>;
@@ -118,7 +136,11 @@ export class TabbedActionListWidget extends Disposable {
 					tabBar.classList.add(options.tabBarClassName);
 				}
 				const radio = renderDisposables.add(new Radio({
-					items: options.tabs.map(t => ({ text: t, tooltip: t, isActive: t === activeTab })),
+					items: options.tabs.map(tab => {
+						const label = tab.label ?? tab.id;
+						const text = tab.icon ? `$(${tab.icon.id}) ${label}` : label;
+						return { text, tooltip: tab.tooltip ?? label, isActive: tab.id === activeTab };
+					}),
 				}));
 				tabBar.appendChild(radio.domNode);
 
@@ -134,7 +156,7 @@ export class TabbedActionListWidget extends Disposable {
 				renderDisposables.add(radio.onDidSelect(index => {
 					const next = options.tabs[index];
 					if (next) {
-						activateTab(next);
+						activateTab(next.id);
 					}
 				}));
 
@@ -193,7 +215,7 @@ export class TabbedActionListWidget extends Disposable {
 					if (onEditable && !onTabBar) {
 						return;
 					}
-					const currentIndex = options.tabs.indexOf(activeTab);
+					const currentIndex = options.tabs.findIndex(t => t.id === activeTab);
 					if (currentIndex < 0) {
 						return;
 					}
@@ -201,7 +223,7 @@ export class TabbedActionListWidget extends Disposable {
 					const nextIndex = (currentIndex + delta + options.tabs.length) % options.tabs.length;
 					e.preventDefault();
 					e.stopPropagation();
-					activateTab(options.tabs[nextIndex]);
+					activateTab(options.tabs[nextIndex].id);
 				}));
 
 				// Dismiss when focus leaves the popup. Suppressed during a

--- a/src/vs/platform/actionWidget/test/browser/tabbedActionListWidget.test.ts
+++ b/src/vs/platform/actionWidget/test/browser/tabbedActionListWidget.test.ts
@@ -109,7 +109,7 @@ suite('TabbedActionListWidget', () => {
 		widget.show<ITestItem>({
 			user: 'test',
 			anchor,
-			tabs: ['Local', 'Remote'],
+			tabs: [{ id: 'Local' }, { id: 'Remote' }],
 			initialTab: 'Local',
 			createActionList: () => ({ items: [action('a')] }),
 			delegate: { onSelect: () => { }, onHide: () => { } },
@@ -130,7 +130,7 @@ suite('TabbedActionListWidget', () => {
 		widget.show<ITestItem>({
 			user: 'test',
 			anchor,
-			tabs: ['Local', 'Remote'],
+			tabs: [{ id: 'Local' }, { id: 'Remote' }],
 			initialTab: 'Remote',
 			createActionList: (tab) => {
 				calls.push(tab);
@@ -151,7 +151,7 @@ suite('TabbedActionListWidget', () => {
 		const showOnce = () => widget.show<ITestItem>({
 			user: 'test',
 			anchor,
-			tabs: ['Local'],
+			tabs: [{ id: 'Local' }],
 			initialTab: 'Local',
 			createActionList: () => ({ items: [action('a')] }),
 			delegate: { onSelect: () => { }, onHide: () => { } },
@@ -176,7 +176,7 @@ suite('TabbedActionListWidget', () => {
 		widget.show<ITestItem>({
 			user: 'test',
 			anchor,
-			tabs: ['Local'],
+			tabs: [{ id: 'Local' }],
 			initialTab: 'Local',
 			createActionList: () => ({ items: [action('a')] }),
 			delegate: { onSelect: () => { }, onHide: () => { } },

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -16,7 +16,7 @@ import { autorun } from '../../../../base/common/observable.js';
 import { localize } from '../../../../nls.js';
 import { IActionWidgetService } from '../../../../platform/actionWidget/browser/actionWidget.js';
 import { ActionListItemKind, IActionListDelegate, IActionListItem, IActionListOptions } from '../../../../platform/actionWidget/browser/actionList.js';
-import { TabbedActionListWidget } from '../../../../platform/actionWidget/browser/tabbedActionListWidget.js';
+import { ITabDescriptor, TabbedActionListWidget } from '../../../../platform/actionWidget/browser/tabbedActionListWidget.js';
 import { IMenuService, MenuItemAction } from '../../../../platform/actions/common/actions.js';
 import { IRemoteAgentHostService, RemoteAgentHostConnectionStatus } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { TUNNEL_ADDRESS_PREFIX } from '../../../../platform/agentHost/common/tunnelAgentHost.js';
@@ -284,7 +284,7 @@ export class WorkspacePicker extends Disposable {
 			return;
 		}
 
-		const tabs = this._showTabs() ? this._getAvailableGroups() : [];
+		const tabs = this._showTabs() ? this._getAvailableTabs() : [];
 
 		// Default the active tab to the group of the currently selected
 		// workspace. The user-pick latch is reset on every selection change,
@@ -292,11 +292,11 @@ export class WorkspacePicker extends Disposable {
 		// override auto-tab.
 		if (tabs.length > 0) {
 			const selectedGroup = this._selectedWorkspace?.workspace.group;
-			if (!this._userPickedTab && selectedGroup && tabs.includes(selectedGroup)) {
+			if (!this._userPickedTab && selectedGroup && tabs.some(t => t.id === selectedGroup)) {
 				this._activeTab = selectedGroup;
 			}
-			if (!this._activeTab || !tabs.includes(this._activeTab)) {
-				this._activeTab = tabs[0];
+			if (!this._activeTab || !tabs.some(t => t.id === this._activeTab)) {
+				this._activeTab = tabs[0].id;
 			}
 		}
 
@@ -317,23 +317,27 @@ export class WorkspacePicker extends Disposable {
 		return true;
 	}
 
-	protected _getAvailableGroups(): string[] {
-		const groups = new Set<string>();
-		groups.add(SESSION_WORKSPACE_GROUP_REMOTE);
+	protected _getAvailableTabs(): ITabDescriptor[] {
+		const byLabel = new Map<string, ITabDescriptor>();
+		byLabel.set(SESSION_WORKSPACE_GROUP_REMOTE, {
+			id: SESSION_WORKSPACE_GROUP_REMOTE,
+			icon: Codicon.beaker,
+			tooltip: `${SESSION_WORKSPACE_GROUP_REMOTE} (${localize('workspacePicker.experimental', "Experimental")})`,
+		});
 		for (const provider of this.sessionsProvidersService.getProviders()) {
-			if (provider.supportsLocalWorkspaces) {
-				groups.add(SESSION_WORKSPACE_GROUP_LOCAL);
+			if (provider.supportsLocalWorkspaces && !byLabel.has(SESSION_WORKSPACE_GROUP_LOCAL)) {
+				byLabel.set(SESSION_WORKSPACE_GROUP_LOCAL, { id: SESSION_WORKSPACE_GROUP_LOCAL });
 			}
 			for (const action of provider.browseActions) {
-				if (action.group) {
-					groups.add(action.group);
+				if (action.group && !byLabel.has(action.group)) {
+					byLabel.set(action.group, { id: action.group });
 				}
 			}
 		}
-		return Array.from(groups).sort((a, b) =>
-			a === SESSION_WORKSPACE_GROUP_LOCAL ? -1
-				: b === SESSION_WORKSPACE_GROUP_LOCAL ? 1
-					: a.localeCompare(b));
+		return Array.from(byLabel.values()).sort((a, b) =>
+			a.id === SESSION_WORKSPACE_GROUP_LOCAL ? -1
+				: b.id === SESSION_WORKSPACE_GROUP_LOCAL ? 1
+					: a.id.localeCompare(b.id));
 	}
 
 	/**
@@ -395,7 +399,7 @@ export class WorkspacePicker extends Disposable {
 	 * platform `TabbedActionListWidget`; this picker only owns the data
 	 * and selection logic.
 	 */
-	private _showTabbedPicker(tabs: readonly string[]): void {
+	private _showTabbedPicker(tabs: readonly ITabDescriptor[]): void {
 		const triggerElement = this._triggerElement!;
 		// Hide the flat picker if it's visible — the two presentations
 		// don't co-exist.
@@ -410,12 +414,12 @@ export class WorkspacePicker extends Disposable {
 		};
 
 		triggerElement.setAttribute('aria-expanded', 'true');
-		this._pickerGroupContext.set(this._activeTab ?? tabs[0]);
+		this._pickerGroupContext.set(this._activeTab ?? tabs[0].id);
 		this._tabbedWidget.show<IWorkspacePickerItem>({
 			user: 'workspacePicker',
 			anchor: triggerElement,
 			tabs,
-			initialTab: this._activeTab ?? tabs[0],
+			initialTab: this._activeTab ?? tabs[0].id,
 			createActionList: (tab) => {
 				this._activeTab = tab;
 				const items = this._buildItems();
@@ -619,7 +623,7 @@ export class WorkspacePicker extends Disposable {
 
 	/** True when the picker is currently scoped to a single tab. */
 	protected _isTabFiltered(): boolean {
-		return this._showTabs() && !!this._activeTab && this._getAvailableGroups().length > 1;
+		return this._showTabs() && !!this._activeTab && this._getAvailableTabs().length > 1;
 	}
 
 	/**

--- a/src/vs/sessions/contrib/chat/test/browser/sessionWorkspacePicker.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionWorkspacePicker.test.ts
@@ -530,7 +530,7 @@ suite('WorkspacePicker - Connection Status', () => {
 /** Minimal subclass that exposes the protected `_getAvailableTabs` for testing. */
 class TestablePicker extends WorkspacePicker {
 	getAvailableTabs(): string[] {
-		return this._getAvailableGroups();
+		return this._getAvailableTabs().map(t => t.id);
 	}
 }
 


### PR DESCRIPTION
Refactor `TabbedActionListWidget` to take an `ITabDescriptor[]` (id + optional label/tooltip + optional `ThemeIcon`) instead of parallel string arrays. The session workspace picker builds these descriptors at the source of truth in `_getAvailableTabs`, attaching a beaker codicon and an "Experimental" tooltip to the Remote tab.

Note: the icon is a placeholder — final icon TBD.

(Written by Copilot)