### PR TITLE
aux window - anchor context menus to the originating window

### DIFF
--- a/src/vs/base/browser/contextmenu.ts
+++ b/src/vs/base/browser/contextmenu.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { isHTMLElement } from './dom.js';
 import { StandardMouseEvent } from './mouseEvent.js';
 import { IActionViewItemOptions } from './ui/actionbar/actionViewItems.js';
 import { IActionViewItem } from './ui/actionbar/actionbar.js';
@@ -47,6 +48,13 @@ export interface IContextMenuDelegate {
 	anchorAxisAlignment?: AnchorAxisAlignment;
 	domForShadowRoot?: HTMLElement;
 	/**
+	 * The container the context menu should render into. When unset, the
+	 * menu is rendered into the currently focused window's container, which
+	 * is wrong when the trigger originated from a non-focused window (e.g.
+	 * a right-click on a webview in a background auxiliary window).
+	 */
+	container?: HTMLElement;
+	/**
 	 * custom context menus with higher layers are rendered higher in z-index order
 	 */
 	layer?: number;
@@ -54,4 +62,23 @@ export interface IContextMenuDelegate {
 
 export interface IContextMenuProvider {
 	showContextMenu(delegate: IContextMenuDelegate): void;
+}
+
+/**
+ * The DOM element that triggered the context menu (the `container` if set,
+ * otherwise derived from the anchor). Used to anchor the menu to the
+ * originating window for auxiliary window support.
+ */
+export function getContextMenuTriggerElement(delegate: IContextMenuDelegate): HTMLElement | undefined {
+	if (isHTMLElement(delegate.container)) {
+		return delegate.container;
+	}
+	const anchor = delegate.getAnchor();
+	if (isHTMLElement(anchor)) {
+		return anchor;
+	}
+	if (anchor instanceof StandardMouseEvent) {
+		return anchor.target;
+	}
+	return undefined;
 }

--- a/src/vs/base/parts/contextmenu/common/contextmenu.ts
+++ b/src/vs/base/parts/contextmenu/common/contextmenu.ts
@@ -36,6 +36,12 @@ export interface IPopupOptions {
 	x?: number;
 	y?: number;
 	positioningItem?: number;
+	/**
+	 * `vscodeWindowId` of the window the menu should anchor to. When unset,
+	 * Electron defaults to the currently focused window, which is wrong when
+	 * the trigger came from a non-focused auxiliary window.
+	 */
+	targetWindowId?: number;
 }
 
 export const CONTEXT_MENU_CHANNEL = 'vscode:contextmenu';

--- a/src/vs/base/parts/contextmenu/electron-main/contextmenu.ts
+++ b/src/vs/base/parts/contextmenu/electron-main/contextmenu.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IpcMainEvent, Menu, MenuItem } from 'electron';
+import { BrowserWindow, IpcMainEvent, Menu, MenuItem } from 'electron';
 import { validatedIpcMain } from '../../ipc/electron-main/ipcMain.js';
 import { CONTEXT_MENU_CHANNEL, CONTEXT_MENU_CLOSE_CHANNEL, IPopupOptions, ISerializableContextMenuItem } from '../common/contextmenu.js';
 
@@ -11,7 +11,16 @@ export function registerContextMenuListener(): void {
 	validatedIpcMain.on(CONTEXT_MENU_CHANNEL, (event: IpcMainEvent, contextMenuId: number, items: ISerializableContextMenuItem[], onClickChannel: string, options?: IPopupOptions) => {
 		const menu = createMenu(event, onClickChannel, items);
 
+		// Anchor the popup to the originating window so it opens over the right
+		// window when the trigger came from a non-focused auxiliary window.
+		// `vscodeWindowId` matches BrowserWindow.id for main windows and
+		// WebContents.id for auxiliary windows.
+		const targetWindow = options?.targetWindowId !== undefined
+			? BrowserWindow.getAllWindows().find(w => w.id === options.targetWindowId || w.webContents.id === options.targetWindowId)
+			: undefined;
+
 		menu.popup({
+			window: targetWindow,
 			x: options ? options.x : undefined,
 			y: options ? options.y : undefined,
 			positioningItem: options ? options.positioningItem : undefined,

--- a/src/vs/editor/standalone/browser/standaloneServices.ts
+++ b/src/vs/editor/standalone/browser/standaloneServices.ts
@@ -1078,8 +1078,9 @@ class StandaloneContextMenuService extends ContextMenuService {
 		@IKeybindingService keybindingService: IKeybindingService,
 		@IMenuService menuService: IMenuService,
 		@IContextKeyService contextKeyService: IContextKeyService,
+		@ILayoutService layoutService: ILayoutService,
 	) {
-		super(telemetryService, notificationService, contextViewService, keybindingService, menuService, contextKeyService);
+		super(telemetryService, notificationService, contextViewService, keybindingService, menuService, contextKeyService, layoutService);
 		this.configure({ blockMouse: false }); // we do not want that in the standalone editor
 	}
 }

--- a/src/vs/platform/contextview/browser/contextMenuHandler.ts
+++ b/src/vs/platform/contextview/browser/contextMenuHandler.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IContextMenuDelegate } from '../../../base/browser/contextmenu.js';
+import { getContextMenuTriggerElement, IContextMenuDelegate } from '../../../base/browser/contextmenu.js';
 import { $, addDisposableListener, EventType, getActiveElement, getWindow, isAncestor, isHTMLElement } from '../../../base/browser/dom.js';
 import { StandardMouseEvent } from '../../../base/browser/mouseEvent.js';
 import { Menu } from '../../../base/browser/ui/menu/menu.js';
@@ -12,6 +12,7 @@ import { isCancellationError } from '../../../base/common/errors.js';
 import { combinedDisposable, DisposableStore, IDisposable } from '../../../base/common/lifecycle.js';
 import { IContextViewService } from './contextView.js';
 import { IKeybindingService } from '../../keybinding/common/keybinding.js';
+import { ILayoutService } from '../../layout/browser/layoutService.js';
 import { INotificationService } from '../../notification/common/notification.js';
 import { ITelemetryService } from '../../telemetry/common/telemetry.js';
 import { defaultMenuStyles } from '../../theme/browser/defaultStyles.js';
@@ -33,6 +34,7 @@ export class ContextMenuHandler {
 		private telemetryService: ITelemetryService,
 		private notificationService: INotificationService,
 		private keybindingService: IKeybindingService,
+		private layoutService: ILayoutService,
 	) { }
 
 	configure(options: IContextMenuHandlerOptions): void {
@@ -50,6 +52,13 @@ export class ContextMenuHandler {
 		let menu: Menu | undefined;
 
 		const shadowRootElement = isHTMLElement(delegate.domForShadowRoot) ? delegate.domForShadowRoot : undefined;
+		// Resolve the menu container to the workbench root of the trigger's
+		// window so the menu renders in the right window (e.g. auxiliary
+		// windows). Falls back to shadow root or activeContainer.
+		const triggerElement = getContextMenuTriggerElement(delegate);
+		const container = triggerElement
+			? this.layoutService.getContainer(getWindow(triggerElement))
+			: shadowRootElement;
 		this.contextViewService.showContextView({
 			getAnchor: () => delegate.getAnchor(),
 			canRelayout: false,
@@ -145,7 +154,7 @@ export class ContextMenuHandler {
 
 				this.lastContainer = null;
 			}
-		}, shadowRootElement, !!shadowRootElement);
+		}, container, !!shadowRootElement);
 	}
 
 	private onActionRun(e: IRunEvent, logTelemetry: boolean): void {

--- a/src/vs/platform/contextview/browser/contextMenuService.ts
+++ b/src/vs/platform/contextview/browser/contextMenuService.ts
@@ -12,6 +12,7 @@ import { getFlatContextMenuActions } from '../../actions/browser/menuEntryAction
 import { IMenuService, MenuId } from '../../actions/common/actions.js';
 import { IContextKeyService } from '../../contextkey/common/contextkey.js';
 import { IKeybindingService } from '../../keybinding/common/keybinding.js';
+import { ILayoutService } from '../../layout/browser/layoutService.js';
 import { INotificationService } from '../../notification/common/notification.js';
 import { ITelemetryService } from '../../telemetry/common/telemetry.js';
 import { ContextMenuHandler, IContextMenuHandlerOptions } from './contextMenuHandler.js';
@@ -24,7 +25,7 @@ export class ContextMenuService extends Disposable implements IContextMenuServic
 	private _contextMenuHandler: ContextMenuHandler | undefined = undefined;
 	private get contextMenuHandler(): ContextMenuHandler {
 		if (!this._contextMenuHandler) {
-			this._contextMenuHandler = new ContextMenuHandler(this.contextViewService, this.telemetryService, this.notificationService, this.keybindingService);
+			this._contextMenuHandler = new ContextMenuHandler(this.contextViewService, this.telemetryService, this.notificationService, this.keybindingService, this.layoutService);
 		}
 
 		return this._contextMenuHandler;
@@ -43,6 +44,7 @@ export class ContextMenuService extends Disposable implements IContextMenuServic
 		@IKeybindingService private readonly keybindingService: IKeybindingService,
 		@IMenuService private readonly menuService: IMenuService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
+		@ILayoutService private readonly layoutService: ILayoutService,
 	) {
 		super();
 	}

--- a/src/vs/workbench/browser/parts/compositeBarActions.ts
+++ b/src/vs/workbench/browser/parts/compositeBarActions.ts
@@ -680,7 +680,10 @@ export class CompositeActionViewItem extends CompositeBarActionViewItem {
 		this.contextMenuService.showContextMenu({
 			getAnchor: () => anchor,
 			getActions: () => actions,
-			getActionsContext: () => this.compositeBarActionItem.id
+			getActionsContext: () => this.compositeBarActionItem.id,
+			// Anchor is a bare IAnchor; pass container so the platform can
+			// route the menu to the right window (e.g. auxiliary windows).
+			container,
 		});
 	}
 

--- a/src/vs/workbench/contrib/webview/browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewElement.ts
@@ -32,6 +32,7 @@ import { IRemoteAuthorityResolverService } from '../../../../platform/remote/com
 import { ITunnelService } from '../../../../platform/tunnel/common/tunnel.js';
 import { WebviewPortMappingManager } from '../../../../platform/webview/common/webviewPortMapping.js';
 import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
+import { IWorkbenchLayoutService } from '../../../services/layout/browser/layoutService.js';
 import { decodeAuthority, webviewGenericCspSource, webviewRootResourceAuthority } from '../common/webview.js';
 import { loadLocalResource, WebviewResourceResponse } from './resourceLoading.js';
 import { WebviewThemeDataProvider } from './themeing.js';
@@ -176,6 +177,7 @@ export class WebviewElement extends Disposable implements IWebviewElement, Webvi
 		@ITunnelService private readonly _tunnelService: ITunnelService,
 		@IAccessibilityService private readonly _accessibilityService: IAccessibilityService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
+		@IWorkbenchLayoutService private readonly _layoutService: IWorkbenchLayoutService,
 	) {
 		super();
 
@@ -277,7 +279,10 @@ export class WebviewElement extends Disposable implements IWebviewElement, Webvi
 				getAnchor: () => ({
 					x: elementBox.x + data.clientX,
 					y: elementBox.y + data.clientY
-				})
+				}),
+				// Anchor is a bare IAnchor; pass container so the platform can
+				// route the menu to this webview's window (e.g. auxiliary windows).
+				container: this.window ? this._layoutService.getContainer(this.window) : undefined,
 			});
 			this._send('set-context-menu-visible', { visible: true });
 		}));

--- a/src/vs/workbench/contrib/webview/electron-browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/electron-browser/webviewElement.ts
@@ -18,6 +18,7 @@ import { IRemoteAuthorityResolverService } from '../../../../platform/remote/com
 import { ITunnelService } from '../../../../platform/tunnel/common/tunnel.js';
 import { FindInFrameOptions, IWebviewManagerService } from '../../../../platform/webview/common/webviewManagerService.js';
 import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
+import { IWorkbenchLayoutService } from '../../../services/layout/browser/layoutService.js';
 import { WebviewThemeDataProvider } from '../browser/themeing.js';
 import { WebviewInitInfo } from '../browser/webview.js';
 import { WebviewElement } from '../browser/webviewElement.js';
@@ -52,10 +53,11 @@ export class ElectronWebviewElement extends WebviewElement {
 		@INativeHostService private readonly _nativeHostService: INativeHostService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IAccessibilityService accessibilityService: IAccessibilityService,
+		@IWorkbenchLayoutService layoutService: IWorkbenchLayoutService,
 	) {
 		super(initInfo, webviewThemeDataProvider,
 			configurationService, contextMenuService, notificationService, environmentService,
-			logService, remoteAuthorityResolverService, tunnelService, accessibilityService, instantiationService);
+			logService, remoteAuthorityResolverService, tunnelService, accessibilityService, instantiationService, layoutService);
 
 		this._webviewKeyboardHandler = new WindowIgnoreMenuShortcutsManager(configurationService, mainProcessService, _nativeHostService);
 

--- a/src/vs/workbench/services/contextmenu/electron-browser/contextmenuService.ts
+++ b/src/vs/workbench/services/contextmenu/electron-browser/contextmenuService.ts
@@ -11,7 +11,7 @@ import { IKeybindingService } from '../../../../platform/keybinding/common/keybi
 import { getZoomFactor } from '../../../../base/browser/browser.js';
 import { unmnemonicLabel } from '../../../../base/common/labels.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
-import { IContextMenuDelegate, IContextMenuEvent } from '../../../../base/browser/contextmenu.js';
+import { getContextMenuTriggerElement, IContextMenuDelegate, IContextMenuEvent } from '../../../../base/browser/contextmenu.js';
 import { createSingleCallFunction } from '../../../../base/common/functional.js';
 import { IContextMenuItem } from '../../../../base/parts/contextmenu/common/contextmenu.js';
 import { popup } from '../../../../base/parts/contextmenu/electron-browser/contextmenu.js';
@@ -26,6 +26,7 @@ import { Event, Emitter } from '../../../../base/common/event.js';
 import { AnchorAlignment, AnchorAxisAlignment, isAnchor } from '../../../../base/browser/ui/contextview/contextview.js';
 import { IMenuService } from '../../../../platform/actions/common/actions.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { ILayoutService } from '../../../../platform/layout/browser/layoutService.js';
 import { Disposable, IDisposable } from '../../../../base/common/lifecycle.js';
 
 export class ContextMenuService implements IContextMenuService {
@@ -46,11 +47,12 @@ export class ContextMenuService implements IContextMenuService {
 		@IContextViewService contextViewService: IContextViewService,
 		@IMenuService menuService: IMenuService,
 		@IContextKeyService contextKeyService: IContextKeyService,
+		@ILayoutService layoutService: ILayoutService,
 	) {
 		function createContextMenuService(native: boolean) {
 			return native ?
 				new NativeContextMenuService(notificationService, telemetryService, keybindingService, menuService, contextKeyService)
-				: new HTMLContextMenuService(telemetryService, notificationService, contextViewService, keybindingService, menuService, contextKeyService);
+				: new HTMLContextMenuService(telemetryService, notificationService, contextViewService, keybindingService, menuService, contextKeyService, layoutService);
 		}
 
 		// set initial context menu service
@@ -205,7 +207,11 @@ class NativeContextMenuService extends Disposable implements IContextMenuService
 				y = Math.floor(y * zoom);
 			}
 
-			popup(menu, { x, y, positioningItem: delegate.autoSelectFirstItem ? 0 : undefined, }, () => onHide());
+			// Anchor the popup to the trigger's window so the menu opens over
+			// the originating window (e.g. a non-focused auxiliary window).
+			const targetWindowId = dom.getWindow(getContextMenuTriggerElement(delegate)).vscodeWindowId;
+
+			popup(menu, { x, y, positioningItem: delegate.autoSelectFirstItem ? 0 : undefined, targetWindowId }, () => onHide());
 
 			this._onDidShowContextMenu.fire();
 		}


### PR DESCRIPTION
Fixes #316665

Right-clicking inside an unfocused window opened the context menu over the focused window. This reproduced in both directions across main and auxiliary windows, and affected both the custom HTML and native context menu styles.

## Before / After

**Before**
(from #316671)

https://github.com/user-attachments/assets/6c0af7f8-d45c-44ce-8aad-938efc7d9468

**After:**

https://github.com/user-attachments/assets/fffb178c-2c2d-4855-bf27-492122eef588

## Changes

- Added `IContextMenuDelegate.container?: HTMLElement` for callers whose anchor is a bare `IAnchor` with no DOM element (webviews, activity bar items).
- Added `IPopupOptions.targetWindowId?: number` for the native menu IPC, mirroring the pattern from #204095 / `INativeHostOptions.targetWindowId`.
- New shared helper `getContextMenuTriggerElement()` in `base/browser/contextmenu.ts` resolves the trigger element from `delegate.container` or the anchor.
- `ContextMenuHandler` (HTML path) derives the menu container from the trigger's window via `ILayoutService.getContainer()`.
- `electron-main/contextmenu.ts` (native path) anchors `menu.popup({ window })` to the `BrowserWindow` matching the supplied `targetWindowId`.

## Test plan

Verified manually on macOS:

- Markdown preview in aux window, right-click while main is focused — menu opens in aux
- Same in reverse direction (aux focused, right-click element in main)
- Activity bar / bottom panel header items in unfocused window
- With `window.menuStyle: native` — native menus also anchor correctly, including when the trigger window is already focused
- Single-window scenarios continue to work unchanged