### PR TITLE
agent host: route Claude through CAPI's user-discovered Bearer auth

### DIFF
--- a/src/vs/platform/agentHost/node/shared/copilotApiService.ts
+++ b/src/vs/platform/agentHost/node/shared/copilotApiService.ts
@@ -30,26 +30,29 @@ export interface ICopilotApiServiceRequestOptions {
 }
 
 /**
- * Envelope returned by the GitHub `copilot_internal/v2/token` endpoint.
- * @see https://docs.github.com/en/rest/copilot
+ * Subset of the GitHub `copilot_internal/user` response we care about.
+ * The full payload carries entitlement info; we only need `endpoints` (for
+ * routing CAPI requests) and `access_type_sku` (which `CAPIClient.updateDomains`
+ * stamps onto requests).
  */
-interface ICopilotTokenEnvelope {
-	readonly token: string;
-	readonly expires_at: number;
-	readonly refresh_in: number;
-	readonly endpoints?: { readonly api?: string };
-	readonly sku?: string;
+interface ICopilotUserResponse {
+	readonly endpoints?: {
+		readonly api?: string;
+		readonly telemetry?: string;
+		readonly proxy?: string;
+		readonly 'origin-tracker'?: string;
+	};
+	readonly access_type_sku?: string;
 }
 
-interface ICachedToken {
+interface ICachedCapiContext {
 	readonly githubToken: string;
-	readonly copilotToken: string;
 	readonly expiresAt: number;
 }
 
 interface ICapiInit {
 	readonly capiClient: CAPIClient;
-	readonly tokenUrl: string;
+	readonly userUrl: string;
 }
 
 // #endregion
@@ -67,12 +70,16 @@ interface ICapiInit {
 export const COPILOT_API_ERROR_STATUS_STREAMING = 520;
 
 /**
- * Refresh the cached Copilot token this many seconds before its real expiry,
- * so an in-flight request never hits a token that expires mid-request.
+ * Re-resolve the CAPI endpoint discovery this many seconds before the cache
+ * entry's notional expiry. The `/copilot_internal/user` response itself
+ * carries no expiry, so we apply a fixed TTL and refresh ahead of it.
  */
-const TOKEN_REFRESH_BUFFER_SECONDS = 5 * 60;
+const CAPI_CONTEXT_REFRESH_BUFFER_SECONDS = 5 * 60;
 
-const TOKEN_API_VERSION = '2025-04-01';
+/** Conservative TTL for the `/copilot_internal/user` discovery result. */
+const CAPI_CONTEXT_TTL_SECONDS = 30 * 60;
+
+const USER_API_VERSION = '2025-04-01';
 
 // #endregion
 
@@ -173,38 +180,47 @@ export const ICopilotApiService = createDecorator<ICopilotApiService>('copilotAp
  * ## Goals
  *
  * 1. **Single source of truth for CAPI auth.** Callers pass a raw GitHub token
- *    and never deal with Copilot session token minting, expiry, refresh, or
- *    invalidation themselves.
+ *    and never deal with endpoint discovery or routing themselves.
  * 2. **Stable surface for chat agents.** A small, typed API that abstracts the
  *    underlying `CAPIClient`, SSE framing, and Anthropic event taxonomy so
  *    feature code can focus on prompting.
  * 3. **Resource-safe streaming.** Async-generator output that fully releases
  *    the underlying HTTP connection regardless of how the consumer terminates
  *    iteration (early `break`, thrown error, abort, or natural end-of-stream).
- * 4. **Skew- and revocation-tolerant token cache.** Tokens stay cached as long
- *    as they're usable, are re-minted when the server tells us they're stale
- *    (`refresh_in`), and are invalidated immediately on `401`/`403` so callers
- *    self-heal without restarting the host.
+ * 4. **Skew- and revocation-tolerant context cache.** Endpoint/sku discovery
+ *    stays cached as long as it's usable and is invalidated immediately on
+ *    `401`/`403` so callers self-heal without restarting the host.
+ *
+ * ## Auth strategy
+ *
+ * The GitHub user token IS the credential. There is no Copilot session-token
+ * mint; we send `Authorization: Bearer <github-token>` directly to CAPI's
+ * `/v1/messages` and `/models` endpoints. This mirrors what the
+ * `@github/copilot` CLI does (see `fetchCopilotUser` and
+ * `CopilotAnthropicClient.createWithOAuthToken` in `github/copilot-agent-runtime`).
+ *
+ * The `endpoints.api` URL CAPI requests are routed to is discovered per-token
+ * by calling `GET /copilot_internal/user` once and caching the result. This
+ * works for both consumer (`api.githubcopilot.com`) and Enterprise
+ * (`api.enterprise.githubcopilot.com`) accounts without configuration.
  *
  * ## Non-goals
  *
  * - Per-conversation history, retry/backoff, or rate-limit handling. Callers
  *   own request orchestration.
- * - GitHub Enterprise auth host derivation. The mint URL comes from
- *   `IProductService.defaultChatAgent.tokenEntitlementUrl`. See the TODO in
- *   `_buildCapiInit` for what GHE support would require.
  *
  * ## Concurrency model
  *
  * - Multiple in-flight requests for the same GitHub token share a single
- *   token mint via an in-flight de-dup map (no thundering herd on cold
- *   start).
- * - The token cache holds **one** entry. Callers that alternate between two
- *   GitHub tokens will pay a mint round-trip on every alternation; this is
- *   intentional — the agent host is single-tenant in practice.
+ *   endpoint-discovery call via an in-flight de-dup map (no thundering herd
+ *   on cold start).
+ * - The context cache holds **one** entry. Callers that alternate between two
+ *   GitHub tokens will pay a discovery round-trip on every alternation; this
+ *   is intentional — the agent host is single-tenant in practice.
  * - `AbortSignal` is forwarded to the outgoing API request (messages, models)
- *   but **not** to the shared token mint, so cancellation propagates to the
- *   caller's own request without affecting concurrent callers sharing the mint.
+ *   but **not** to the shared discovery call, so cancellation propagates to
+ *   the caller's own request without affecting concurrent callers sharing the
+ *   discovery.
  *
  * ## Error semantics
  *
@@ -219,9 +235,9 @@ export const ICopilotApiService = createDecorator<ICopilotApiService>('copilotAp
  *   `status` set to {@link COPILOT_API_ERROR_STATUS_STREAMING} (the upstream
  *   HTTP status was 200 and is no longer meaningful) and the server-supplied
  *   error envelope preserved verbatim.
- * - Failures of the internal Copilot token-mint endpoint throw plain
- *   `Error` (not `CopilotApiError`) with a `"Copilot token minting failed:
- *   ..."` prefix — token mint is an implementation detail of this service
+ * - Failures of the `/copilot_internal/user` discovery call throw plain
+ *   `Error` (not `CopilotApiError`) with a `"Copilot endpoint discovery
+ *   failed: ..."` prefix — it is an implementation detail of this service
  *   and is not part of the Anthropic-shaped CAPI surface.
  * - Malformed JSON in an SSE `data:` line is logged and skipped, not thrown.
  */
@@ -286,8 +302,8 @@ export class CopilotApiService implements ICopilotApiService {
 	declare readonly _serviceBrand: undefined;
 
 	private _capiInitPromise: Promise<ICapiInit> | null = null;
-	private _cachedToken: ICachedToken | null = null;
-	private readonly _pendingTokenMints = new Map<string, Promise<string>>();
+	private _cachedCapiContext: ICachedCapiContext | null = null;
+	private readonly _pendingDiscoveries = new Map<string, Promise<void>>();
 	private readonly _fetch: FetchFunction;
 
 	constructor(
@@ -330,8 +346,8 @@ export class CopilotApiService implements ICopilotApiService {
 	}
 
 	async models(githubToken: string, options?: ICopilotApiServiceRequestOptions): Promise<CCAModel[]> {
-		const { capiClient, tokenUrl } = await this._getCapiInit();
-		const copilotToken = await this._getCopilotToken(githubToken, capiClient, tokenUrl);
+		const { capiClient } = await this._getCapiInit();
+		await this._ensureCapiContext(githubToken, capiClient);
 
 		this._logService.debug('[CopilotApiService] GET models');
 
@@ -340,7 +356,7 @@ export class CopilotApiService implements ICopilotApiService {
 				method: 'GET',
 				headers: {
 					...options?.headers,
-					'Authorization': `Bearer ${copilotToken}`,
+					'Authorization': `Bearer ${githubToken}`,
 				},
 				signal: options?.signal,
 			},
@@ -349,7 +365,7 @@ export class CopilotApiService implements ICopilotApiService {
 
 		if (!response.ok) {
 			if (response.status === 401 || response.status === 403) {
-				this._invalidateCachedToken(githubToken);
+				this._invalidateCachedCapiContext(githubToken);
 			}
 			const text = await response.text().catch(() => '');
 			throw buildCopilotApiHttpError(response.status, response.statusText, text, 'CAPI models request failed');
@@ -367,7 +383,7 @@ export class CopilotApiService implements ICopilotApiService {
 		if (!this._capiInitPromise) {
 			this._capiInitPromise = this._buildCapiInit().catch(err => {
 				this._capiInitPromise = null;
-				this._cachedToken = null;
+				this._cachedCapiContext = null;
 				throw err;
 			});
 		}
@@ -400,15 +416,12 @@ export class CopilotApiService implements ICopilotApiService {
 			}),
 		});
 
-		// TODO(GHE): For GitHub Enterprise users the mint URL must point to
-		// `api.<enterprise-host>/copilot_internal/v2/token` instead. This
-		// requires threading the enterprise host URL through `ICopilotApiService`
-		// (e.g. as an extra parameter on `messages`/`models`, or as a separate
-		// `create(enterpriseHost?)` factory) and deriving the URL the same way
-		// `defaultAccount.ts` does for the main workbench auth path.
-		const tokenUrl = this._productService.defaultChatAgent.tokenEntitlementUrl;
+		// The user-info endpoint is hosted on api.github.com for consumer accounts.
+		// For GitHub Enterprise the host changes, but we don't currently support
+		// GHE in the agent host — see CopilotAgent for the same assumption.
+		const userUrl = 'https://api.github.com/copilot_internal/user';
 
-		return { capiClient, tokenUrl };
+		return { capiClient, userUrl };
 	}
 
 	// #endregion
@@ -452,8 +465,8 @@ export class CopilotApiService implements ICopilotApiService {
 		stream: boolean,
 		options?: ICopilotApiServiceRequestOptions,
 	): Promise<Response> {
-		const { capiClient, tokenUrl } = await this._getCapiInit();
-		const copilotToken = await this._getCopilotToken(githubToken, capiClient, tokenUrl);
+		const { capiClient } = await this._getCapiInit();
+		await this._ensureCapiContext(githubToken, capiClient);
 		const requestId = generateUuid();
 
 		this._logService.debug('[CopilotApiService] POST messages', `model=${request.model} stream=${stream} requestId=${requestId}`);
@@ -474,7 +487,7 @@ export class CopilotApiService implements ICopilotApiService {
 				headers: {
 					...options?.headers,
 					'Content-Type': 'application/json',
-					'Authorization': `Bearer ${copilotToken}`,
+					'Authorization': `Bearer ${githubToken}`,
 					'X-Request-Id': requestId,
 					'OpenAI-Intent': 'conversation',
 				},
@@ -485,7 +498,7 @@ export class CopilotApiService implements ICopilotApiService {
 		);
 		if (!response.ok) {
 			if (response.status === 401 || response.status === 403) {
-				this._invalidateCachedToken(githubToken);
+				this._invalidateCachedCapiContext(githubToken);
 			}
 			const text = await response.text().catch(() => '');
 			throw buildCopilotApiHttpError(response.status, response.statusText, text);
@@ -496,75 +509,79 @@ export class CopilotApiService implements ICopilotApiService {
 
 	// #endregion
 
-	// #region Token Minting
+	// #region Endpoint Discovery
 
-	private async _getCopilotToken(githubToken: string, capiClient: CAPIClient, tokenUrl: string): Promise<string> {
+	/**
+	 * Ensure the underlying {@link CAPIClient} has the correct `endpoints.api`
+	 * for the supplied user. Calls `/copilot_internal/user` once per token (with
+	 * a TTL) and feeds the response into `capiClient.updateDomains` so all
+	 * subsequent `RequestType.Models` / `RequestType.ChatMessages` calls route
+	 * to the right host (consumer or Enterprise).
+	 *
+	 * Concurrent callers for the same token share the discovery via
+	 * {@link _pendingDiscoveries} so we don't issue duplicate requests on cold
+	 * start.
+	 */
+	private async _ensureCapiContext(githubToken: string, capiClient: CAPIClient): Promise<void> {
 		const now = Date.now() / 1000;
 		if (
-			this._cachedToken &&
-			this._cachedToken.githubToken === githubToken &&
-			this._cachedToken.expiresAt - now > TOKEN_REFRESH_BUFFER_SECONDS
+			this._cachedCapiContext
+			&& this._cachedCapiContext.githubToken === githubToken
+			&& this._cachedCapiContext.expiresAt - now > CAPI_CONTEXT_REFRESH_BUFFER_SECONDS
 		) {
-			return this._cachedToken.copilotToken;
+			return;
 		}
 
-		if (!this._pendingTokenMints.has(githubToken)) {
-			// Omit the caller's signal here: a deduped mint is shared across
-			// concurrent callers, so aborting one must not cancel the mint for
-			// the others. Each caller still forwards its signal to the API call.
-			const mint = this._mintToken(githubToken, capiClient, tokenUrl)
-				.finally(() => { this._pendingTokenMints.delete(githubToken); });
-			this._pendingTokenMints.set(githubToken, mint);
+		let pending = this._pendingDiscoveries.get(githubToken);
+		if (!pending) {
+			// Omit the caller's signal here: a deduped discovery is shared across
+			// concurrent callers, so aborting one must not cancel it for the
+			// others. Each caller still forwards its signal to the API call.
+			pending = this._discoverCapiContext(githubToken, capiClient)
+				.finally(() => { this._pendingDiscoveries.delete(githubToken); });
+			this._pendingDiscoveries.set(githubToken, pending);
 		}
-		return this._pendingTokenMints.get(githubToken)!;
+		await pending;
 	}
 
-	private _invalidateCachedToken(githubToken: string): void {
-		if (this._cachedToken?.githubToken === githubToken) {
-			this._cachedToken = null;
+	private _invalidateCachedCapiContext(githubToken: string): void {
+		if (this._cachedCapiContext?.githubToken === githubToken) {
+			this._cachedCapiContext = null;
 		}
 	}
 
-	private async _mintToken(githubToken: string, capiClient: CAPIClient, tokenUrl: string): Promise<string> {
-		this._logService.debug('[CopilotApiService] Minting new Copilot token');
+	private async _discoverCapiContext(githubToken: string, capiClient: CAPIClient, userUrl?: string): Promise<void> {
+		const url = userUrl ?? (await this._getCapiInit()).userUrl;
+		this._logService.debug('[CopilotApiService] Discovering CAPI endpoints via /copilot_internal/user');
 
-		const response = await this._fetch(tokenUrl, {
+		const response = await this._fetch(url, {
 			method: 'GET',
 			headers: {
-				'Authorization': `token ${githubToken}`,
-				'X-GitHub-Api-Version': TOKEN_API_VERSION,
+				'Authorization': `Bearer ${githubToken}`,
+				'Accept': 'application/json',
+				'X-GitHub-Api-Version': USER_API_VERSION,
 			},
 		});
 
 		if (!response.ok) {
 			const text = await response.text().catch(() => '');
-			throw new Error(`Copilot token minting failed: ${response.status} ${response.statusText} — ${text}`);
+			throw new Error(`Copilot endpoint discovery failed: ${response.status} ${response.statusText} — ${text}`);
 		}
 
-		const envelope: ICopilotTokenEnvelope = await response.json();
+		const envelope: ICopilotUserResponse = await response.json();
 
 		capiClient.updateDomains(
-			{ endpoints: envelope.endpoints ?? {}, sku: envelope.sku ?? '' },
+			{ endpoints: envelope.endpoints ?? {}, sku: envelope.access_type_sku ?? '' },
 			undefined,
 		);
 
-		// Prefer `refresh_in` over `expires_at` so clients with skewed clocks
-		// don't end up re-minting on every request. Mirrors the behavior in
-		// extensions/copilot/.../copilotTokenManager.ts.
 		const nowSeconds = Date.now() / 1000;
-		const expiresAt = typeof envelope.refresh_in === 'number'
-			? nowSeconds + envelope.refresh_in + TOKEN_REFRESH_BUFFER_SECONDS
-			: envelope.expires_at;
-
-		this._cachedToken = {
+		this._cachedCapiContext = {
 			githubToken,
-			copilotToken: envelope.token,
-			expiresAt,
+			expiresAt: nowSeconds + CAPI_CONTEXT_TTL_SECONDS,
 		};
 
-		this._logService.debug('[CopilotApiService] Token minted, cacheValidUntil:', expiresAt, 'serverExpiresAt:', envelope.expires_at);
-
-		return envelope.token;
+		this._logService.debug('[CopilotApiService] CAPI endpoint discovered, api=', envelope.endpoints?.api);
 	}
 
 	// #endregion

--- a/src/vs/platform/agentHost/node/shared/copilotApiService.ts
+++ b/src/vs/platform/agentHost/node/shared/copilotApiService.ts
@@ -45,13 +45,17 @@ interface ICopilotUserResponse {
 	readonly access_type_sku?: string;
 }
 
-interface ICachedCapiContext {
-	readonly githubToken: string;
+interface ICachedClient {
+	readonly capiClient: CAPIClient;
 	readonly expiresAt: number;
 }
 
-interface ICapiInit {
-	readonly capiClient: CAPIClient;
+/**
+ * Memoized parts of `CAPIClient` construction that don't depend on the user
+ * token. Built once and reused by every per-token client.
+ */
+interface ICapiBase {
+	readonly extensionInfo: IExtensionInformation;
 	readonly userUrl: string;
 }
 
@@ -211,12 +215,13 @@ export const ICopilotApiService = createDecorator<ICopilotApiService>('copilotAp
  *
  * ## Concurrency model
  *
- * - Multiple in-flight requests for the same GitHub token share a single
- *   endpoint-discovery call via an in-flight de-dup map (no thundering herd
+ * - Each cached entry is a **distinct {@link CAPIClient} instance** with its
+ *   own discovered domain state. Concurrent in-flight requests for two
+ *   different GitHub tokens cannot trample each other's `endpoints.api` —
+ *   token A's request will always route through the client built for A.
+ * - Multiple in-flight requests for the **same** GitHub token share a single
+ *   endpoint-discovery call via the per-token cache map (no thundering herd
  *   on cold start).
- * - The context cache holds **one** entry. Callers that alternate between two
- *   GitHub tokens will pay a discovery round-trip on every alternation; this
- *   is intentional — the agent host is single-tenant in practice.
  * - `AbortSignal` is forwarded to the outgoing API request (messages, models)
  *   but **not** to the shared discovery call, so cancellation propagates to
  *   the caller's own request without affecting concurrent callers sharing the
@@ -301,9 +306,8 @@ export class CopilotApiService implements ICopilotApiService {
 
 	declare readonly _serviceBrand: undefined;
 
-	private _capiInitPromise: Promise<ICapiInit> | null = null;
-	private _cachedCapiContext: ICachedCapiContext | null = null;
-	private readonly _pendingDiscoveries = new Map<string, Promise<void>>();
+	private _capiBasePromise: Promise<ICapiBase> | null = null;
+	private readonly _clientsByToken = new Map<string, Promise<ICachedClient>>();
 	private readonly _fetch: FetchFunction;
 
 	constructor(
@@ -346,8 +350,7 @@ export class CopilotApiService implements ICopilotApiService {
 	}
 
 	async models(githubToken: string, options?: ICopilotApiServiceRequestOptions): Promise<CCAModel[]> {
-		const { capiClient } = await this._getCapiInit();
-		await this._ensureCapiContext(githubToken, capiClient);
+		const capiClient = await this._getClientForToken(githubToken);
 
 		this._logService.debug('[CopilotApiService] GET models');
 
@@ -365,7 +368,7 @@ export class CopilotApiService implements ICopilotApiService {
 
 		if (!response.ok) {
 			if (response.status === 401 || response.status === 403) {
-				this._invalidateCachedCapiContext(githubToken);
+				this._invalidateClientForToken(githubToken);
 			}
 			const text = await response.text().catch(() => '');
 			throw buildCopilotApiHttpError(response.status, response.statusText, text, 'CAPI models request failed');
@@ -379,18 +382,17 @@ export class CopilotApiService implements ICopilotApiService {
 
 	// #region Lazy Init
 
-	private _getCapiInit(): Promise<ICapiInit> {
-		if (!this._capiInitPromise) {
-			this._capiInitPromise = this._buildCapiInit().catch(err => {
-				this._capiInitPromise = null;
-				this._cachedCapiContext = null;
+	private _getCapiBase(): Promise<ICapiBase> {
+		if (!this._capiBasePromise) {
+			this._capiBasePromise = this._buildCapiBase().catch(err => {
+				this._capiBasePromise = null;
 				throw err;
 			});
 		}
-		return this._capiInitPromise;
+		return this._capiBasePromise;
 	}
 
-	private async _buildCapiInit(): Promise<ICapiInit> {
+	private async _buildCapiBase(): Promise<ICapiBase> {
 		const [machineId, deviceId] = await Promise.all([
 			getMachineId(err => this._logService.warn('[CopilotApiService] getMachineId failed', err)),
 			getDevDeviceId(err => this._logService.warn('[CopilotApiService] getDevDeviceId failed', err)),
@@ -406,22 +408,12 @@ export class CopilotApiService implements ICopilotApiService {
 			buildType: this._productService.quality === 'stable' ? 'prod' : 'dev',
 		};
 
-		const fetch = this._fetch;
-		const capiClient = new CAPIClient(extensionInfo, undefined, {
-			fetch: (url, options) => fetch(url, {
-				method: options.method ?? 'GET',
-				headers: options.headers,
-				body: options.body,
-				signal: options.signal as AbortSignal | undefined,
-			}),
-		});
-
 		// The user-info endpoint is hosted on api.github.com for consumer accounts.
 		// For GitHub Enterprise the host changes, but we don't currently support
 		// GHE in the agent host — see CopilotAgent for the same assumption.
 		const userUrl = 'https://api.github.com/copilot_internal/user';
 
-		return { capiClient, userUrl };
+		return { extensionInfo, userUrl };
 	}
 
 	// #endregion
@@ -465,8 +457,7 @@ export class CopilotApiService implements ICopilotApiService {
 		stream: boolean,
 		options?: ICopilotApiServiceRequestOptions,
 	): Promise<Response> {
-		const { capiClient } = await this._getCapiInit();
-		await this._ensureCapiContext(githubToken, capiClient);
+		const capiClient = await this._getClientForToken(githubToken);
 		const requestId = generateUuid();
 
 		this._logService.debug('[CopilotApiService] POST messages', `model=${request.model} stream=${stream} requestId=${requestId}`);
@@ -498,7 +489,7 @@ export class CopilotApiService implements ICopilotApiService {
 		);
 		if (!response.ok) {
 			if (response.status === 401 || response.status === 403) {
-				this._invalidateCachedCapiContext(githubToken);
+				this._invalidateClientForToken(githubToken);
 			}
 			const text = await response.text().catch(() => '');
 			throw buildCopilotApiHttpError(response.status, response.statusText, text);
@@ -509,52 +500,64 @@ export class CopilotApiService implements ICopilotApiService {
 
 	// #endregion
 
-	// #region Endpoint Discovery
+	// #region Per-Token Client
 
 	/**
-	 * Ensure the underlying {@link CAPIClient} has the correct `endpoints.api`
-	 * for the supplied user. Calls `/copilot_internal/user` once per token (with
-	 * a TTL) and feeds the response into `capiClient.updateDomains` so all
-	 * subsequent `RequestType.Models` / `RequestType.ChatMessages` calls route
-	 * to the right host (consumer or Enterprise).
-	 *
-	 * Concurrent callers for the same token share the discovery via
-	 * {@link _pendingDiscoveries} so we don't issue duplicate requests on cold
-	 * start.
+	 * Resolve a {@link CAPIClient} that has had its domains updated for the
+	 * supplied user. Concurrent callers for the same token share one
+	 * `/copilot_internal/user` discovery via the cache map; callers with
+	 * different tokens get their **own** `CAPIClient` instance, so the
+	 * `updateDomains` mutation for token A can never affect a request being
+	 * dispatched for token B.
 	 */
-	private async _ensureCapiContext(githubToken: string, capiClient: CAPIClient): Promise<void> {
-		const now = Date.now() / 1000;
-		if (
-			this._cachedCapiContext
-			&& this._cachedCapiContext.githubToken === githubToken
-			&& this._cachedCapiContext.expiresAt - now > CAPI_CONTEXT_REFRESH_BUFFER_SECONDS
-		) {
-			return;
+	private _getClientForToken(githubToken: string): Promise<CAPIClient> {
+		const nowSeconds = Date.now() / 1000;
+		const existing = this._clientsByToken.get(githubToken);
+		if (existing) {
+			return existing.then(entry => {
+				if (entry.expiresAt - nowSeconds > CAPI_CONTEXT_REFRESH_BUFFER_SECONDS) {
+					return entry.capiClient;
+				}
+				// Stale — evict and recurse to build a fresh entry.
+				this._clientsByToken.delete(githubToken);
+				return this._getClientForToken(githubToken);
+			}).catch(err => {
+				// A previous failed build leaked into the cache; evict and rebuild.
+				this._clientsByToken.delete(githubToken);
+				throw err;
+			});
 		}
 
-		let pending = this._pendingDiscoveries.get(githubToken);
-		if (!pending) {
-			// Omit the caller's signal here: a deduped discovery is shared across
-			// concurrent callers, so aborting one must not cancel it for the
-			// others. Each caller still forwards its signal to the API call.
-			pending = this._discoverCapiContext(githubToken, capiClient)
-				.finally(() => { this._pendingDiscoveries.delete(githubToken); });
-			this._pendingDiscoveries.set(githubToken, pending);
-		}
-		await pending;
+		// Omit the caller's signal here: a deduped build is shared across
+		// concurrent callers, so aborting one must not cancel it for the
+		// others. Each caller still forwards its signal to the API call.
+		const pending = this._buildClientForToken(githubToken).catch(err => {
+			this._clientsByToken.delete(githubToken);
+			throw err;
+		});
+		this._clientsByToken.set(githubToken, pending);
+		return pending.then(entry => entry.capiClient);
 	}
 
-	private _invalidateCachedCapiContext(githubToken: string): void {
-		if (this._cachedCapiContext?.githubToken === githubToken) {
-			this._cachedCapiContext = null;
-		}
+	private _invalidateClientForToken(githubToken: string): void {
+		this._clientsByToken.delete(githubToken);
 	}
 
-	private async _discoverCapiContext(githubToken: string, capiClient: CAPIClient, userUrl?: string): Promise<void> {
-		const url = userUrl ?? (await this._getCapiInit()).userUrl;
+	private async _buildClientForToken(githubToken: string): Promise<ICachedClient> {
+		const { extensionInfo, userUrl } = await this._getCapiBase();
+		const fetch = this._fetch;
+		const capiClient = new CAPIClient(extensionInfo, undefined, {
+			fetch: (url, options) => fetch(url, {
+				method: options.method ?? 'GET',
+				headers: options.headers,
+				body: options.body,
+				signal: options.signal as AbortSignal | undefined,
+			}),
+		});
+
 		this._logService.debug('[CopilotApiService] Discovering CAPI endpoints via /copilot_internal/user');
 
-		const response = await this._fetch(url, {
+		const response = await this._fetch(userUrl, {
 			method: 'GET',
 			headers: {
 				'Authorization': `Bearer ${githubToken}`,
@@ -575,13 +578,12 @@ export class CopilotApiService implements ICopilotApiService {
 			undefined,
 		);
 
-		const nowSeconds = Date.now() / 1000;
-		this._cachedCapiContext = {
-			githubToken,
-			expiresAt: nowSeconds + CAPI_CONTEXT_TTL_SECONDS,
-		};
-
 		this._logService.debug('[CopilotApiService] CAPI endpoint discovered, api=', envelope.endpoints?.api);
+
+		return {
+			capiClient,
+			expiresAt: Date.now() / 1000 + CAPI_CONTEXT_TTL_SECONDS,
+		};
 	}
 
 	// #endregion

--- a/src/vs/platform/agentHost/test/node/protocol/claudeRealSdk.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/claudeRealSdk.integrationTest.ts
@@ -9,23 +9,18 @@
  * The cross-provider portion lives in {@link defineSharedRealSdkTests}; this
  * file would layer on Claude-specific assertions as the provider grows.
  *
- * Disabled by default. To run, set BOTH `AGENT_HOST_REAL_SDK=1` and
- * `AGENT_HOST_REAL_SDK_CLAUDE=1`. The Claude SDK is resolved automatically
- * from the dev dependency in `node_modules/@anthropic-ai/claude-agent-sdk`.
+ * Disabled by default. To run, set `AGENT_HOST_REAL_SDK=1`. The Claude SDK
+ * is resolved automatically from the dev dependency in
+ * `node_modules/@anthropic-ai/claude-agent-sdk`.
  *
- *   AGENT_HOST_REAL_SDK=1 AGENT_HOST_REAL_SDK_CLAUDE=1 \
- *     ./scripts/test-integration.sh --run \
+ *   AGENT_HOST_REAL_SDK=1 ./scripts/test-integration.sh --run \
  *     src/vs/platform/agentHost/test/node/protocol/claudeRealSdk.integrationTest.ts
  *
  * **Authentication:** token from `GITHUB_TOKEN` (preferred) or `gh auth
- * token`. Claude mints a Copilot session token via
- * `/copilot_internal/v2/token`, which requires an OAuth token issued from a
- * Copilot-enabled app — the default `gh auth login` token does NOT work.
- * Capture a token from VS Code's GitHub auth provider (e.g. by reading the
- * relevant secret from your keychain) and set `GITHUB_TOKEN` to it before
- * running. The opt-in env var exists so the suite isn't accidentally enabled
- * with an `AGENT_HOST_REAL_SDK=1`-only invocation that would fail for
- * everyone using a vanilla `gh auth token`.
+ * token`. Either works — the agent host's `CopilotApiService` discovers the
+ * user's CAPI endpoint via `GET /copilot_internal/user` and uses the GitHub
+ * token directly as a Bearer credential, the same pattern as the
+ * `@github/copilot` CLI.
  */
 
 import { existsSync } from 'fs';
@@ -33,7 +28,6 @@ import { join } from '../../../../../base/common/path.js';
 import { defineSharedRealSdkTests, type IRealSdkProviderConfig } from './realSdkTestHelpers.js';
 
 const REAL_SDK_ENABLED = process.env['AGENT_HOST_REAL_SDK'] === '1';
-const CLAUDE_OPT_IN = process.env['AGENT_HOST_REAL_SDK_CLAUDE'] === '1';
 
 /**
  * Resolve the path of the locally installed `@anthropic-ai/claude-agent-sdk`
@@ -58,7 +52,7 @@ function resolveClaudeSdkPath(): string | undefined {
 
 // Resolve lazily: if the suite isn't opted in, skip the filesystem probe so a
 // missing SDK directory can't trip a disabled run.
-const CLAUDE_SDK_PATH = (REAL_SDK_ENABLED && CLAUDE_OPT_IN) ? resolveClaudeSdkPath() : undefined;
+const CLAUDE_SDK_PATH = REAL_SDK_ENABLED ? resolveClaudeSdkPath() : undefined;
 
 const CLAUDE_CONFIG: IRealSdkProviderConfig = {
 	suiteTitle: 'Protocol WebSocket — Real Claude SDK',
@@ -67,7 +61,7 @@ const CLAUDE_CONFIG: IRealSdkProviderConfig = {
 	shellToolName: 'Bash',
 	subagentToolName: 'Task',
 	exitPlanModeToolName: 'ExitPlanMode',
-	enabled: REAL_SDK_ENABLED && CLAUDE_OPT_IN && !!CLAUDE_SDK_PATH,
+	enabled: REAL_SDK_ENABLED && !!CLAUDE_SDK_PATH,
 	claudeSdkPath: CLAUDE_SDK_PATH,
 	// Claude has not landed worktree isolation or subagents yet (deferred to
 	// Phase 12). The shared suite skips those tests when the flags are false.

--- a/src/vs/platform/agentHost/test/node/shared/copilotApiService.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/copilotApiService.test.ts
@@ -125,11 +125,11 @@ suite('CopilotApiService', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	// #region Token Minting
+	// #region Endpoint Discovery
 
-	suite('Token Minting', () => {
+	suite('Endpoint Discovery', () => {
 
-		test('mints a token on first request', async () => {
+		test('runs endpoint discovery on first request', async () => {
 			let mintCount = 0;
 			const service = createService(async (input) => {
 				const url = getUrl(input);
@@ -144,7 +144,7 @@ suite('CopilotApiService', () => {
 			assert.strictEqual(mintCount, 1);
 		});
 
-		test('reuses cached token for consecutive calls with same github token', async () => {
+		test('reuses cached endpoint discovery for consecutive calls with same github token', async () => {
 			let mintCount = 0;
 			const service = createService(async (input) => {
 				const url = getUrl(input);
@@ -161,7 +161,7 @@ suite('CopilotApiService', () => {
 			assert.strictEqual(mintCount, 1);
 		});
 
-		test('re-mints when the github token changes', async () => {
+		test('re-discovers endpoints when the github token changes', async () => {
 			let mintCount = 0;
 			const service = createService(async (input) => {
 				const url = getUrl(input);
@@ -177,43 +177,7 @@ suite('CopilotApiService', () => {
 			assert.strictEqual(mintCount, 2);
 		});
 
-		test('re-mints when the copilot token is within 5 minutes of expiry', async () => {
-			let mintCount = 0;
-			const service = createService(async (input) => {
-				const url = getUrl(input);
-				if (url.includes('/copilot_internal')) {
-					mintCount++;
-					// Both expires_at AND refresh_in must point to a soon-expiring token,
-					// because cache validity prefers refresh_in over expires_at.
-					return tokenResponse({ expires_at: Date.now() / 1000 + 120, refresh_in: 0 });
-				}
-				return anthropicResponse([{ type: 'text', text: 'hi' }]);
-			});
-
-			await service.messages('gh-tok', baseRequest);
-			await service.messages('gh-tok', baseRequest);
-			assert.strictEqual(mintCount, 2);
-		});
-
-		test('uses refresh_in (not expires_at) for cache validity to tolerate clock skew', async () => {
-			// Server says expires_at is in the past (simulating client clock ahead of server),
-			// but refresh_in is comfortably long. Cache must still be valid.
-			let mintCount = 0;
-			const service = createService(async (input) => {
-				const url = getUrl(input);
-				if (url.includes('/copilot_internal')) {
-					mintCount++;
-					return tokenResponse({ expires_at: Date.now() / 1000 - 999, refresh_in: 1800 });
-				}
-				return anthropicResponse([{ type: 'text', text: 'hi' }]);
-			});
-
-			await service.messages('gh-tok', baseRequest);
-			await service.messages('gh-tok', baseRequest);
-			assert.strictEqual(mintCount, 1);
-		});
-
-		test('invalidates cached token on 401 from messages so the next call re-mints', async () => {
+		test('invalidates cached endpoint discovery on 401 from messages so the next call re-discovers', async () => {
 			let mintCount = 0;
 			let messageCallCount = 0;
 			const service = createService(async (input) => {
@@ -234,7 +198,7 @@ suite('CopilotApiService', () => {
 			assert.strictEqual(mintCount, 2);
 		});
 
-		test('invalidates cached token on 403 from models so the next call re-mints', async () => {
+		test('invalidates cached endpoint discovery on 403 from models so the next call re-discovers', async () => {
 			let mintCount = 0;
 			let modelsCallCount = 0;
 			const service = createService(async (input) => {
@@ -255,7 +219,7 @@ suite('CopilotApiService', () => {
 			assert.strictEqual(mintCount, 2);
 		});
 
-		test('does not re-mint when copilot token has plenty of time left', async () => {
+		test('does not re-discover when the cache is still warm for the same token', async () => {
 			let mintCount = 0;
 			const service = createService(async (input) => {
 				const url = getUrl(input);
@@ -271,7 +235,7 @@ suite('CopilotApiService', () => {
 			assert.strictEqual(mintCount, 1);
 		});
 
-		test('uses endpoints.api from the token envelope as the CAPI base', async () => {
+		test('uses endpoints.api from the /copilot_internal/user response as the CAPI base', async () => {
 			const { fetch: fetchFn, captured } = routingFetch(
 				() => anthropicResponse([{ type: 'text', text: 'ok' }]),
 				{ endpoints: { api: 'https://custom.copilot.example.com' } },
@@ -292,7 +256,7 @@ suite('CopilotApiService', () => {
 			assert.strictEqual(captured().url, 'https://api.githubcopilot.com/v1/messages');
 		});
 
-		test('sends the github token as Authorization header to the mint endpoint', async () => {
+		test('sends the github token as a Bearer Authorization header to the discovery endpoint', async () => {
 			let capturedAuthHeader: string | undefined;
 			const service = createService(async (input, init) => {
 				const url = getUrl(input);
@@ -305,26 +269,26 @@ suite('CopilotApiService', () => {
 			});
 
 			await service.messages('my-secret-gh-token', baseRequest);
-			assert.strictEqual(capturedAuthHeader, 'token my-secret-gh-token');
+			assert.strictEqual(capturedAuthHeader, 'Bearer my-secret-gh-token');
 		});
 
-		test('throws on 403 from token mint', async () => {
+		test('throws on 403 from endpoint discovery', async () => {
 			const service = createService(async () => new Response('{"message":"Not authorized"}', { status: 403, statusText: 'Forbidden' }));
 			await assert.rejects(
 				() => service.messages('bad-tok', baseRequest),
-				(err: Error) => err.message.includes('Copilot token minting failed: 403'),
+				(err: Error) => err.message.includes('Copilot endpoint discovery failed: 403'),
 			);
 		});
 
-		test('throws on 500 from token mint', async () => {
+		test('throws on 500 from endpoint discovery', async () => {
 			const service = createService(async () => new Response('internal error', { status: 500, statusText: 'Internal Server Error' }));
 			await assert.rejects(
 				() => service.messages('gh-tok', baseRequest),
-				(err: Error) => err.message.includes('Copilot token minting failed: 500'),
+				(err: Error) => err.message.includes('Copilot endpoint discovery failed: 500'),
 			);
 		});
 
-		test('does not double-mint when concurrent requests race on first call', async () => {
+		test('does not double-discover when concurrent requests race on first call', async () => {
 			let mintCount = 0;
 			const service = createService(async (input) => {
 				const url = getUrl(input);
@@ -343,7 +307,7 @@ suite('CopilotApiService', () => {
 			assert.strictEqual(mintCount, 1);
 		});
 
-		test('in-flight mint dedup spans concurrent messages + models calls', async () => {
+		test('in-flight discovery dedup spans concurrent messages + models calls', async () => {
 			let mintCount = 0;
 			const service = createService(async (input) => {
 				const url = getUrl(input);
@@ -365,7 +329,7 @@ suite('CopilotApiService', () => {
 			assert.strictEqual(mintCount, 1);
 		});
 
-		test('error from token mint does not include the github token', async () => {
+		test('error from endpoint discovery does not include the github token', async () => {
 			const service = createService(async () => new Response('forbidden', { status: 403, statusText: 'Forbidden' }));
 			await assert.rejects(
 				() => service.messages('super-secret-gh-token-xyz', baseRequest),
@@ -373,7 +337,7 @@ suite('CopilotApiService', () => {
 			);
 		});
 
-		test('error from CAPI does not include the copilot or github token', async () => {
+		test('error from CAPI does not include the github token', async () => {
 			const service = createService(async (input) => {
 				const url = getUrl(input);
 				if (url.includes('/copilot_internal')) {
@@ -387,7 +351,7 @@ suite('CopilotApiService', () => {
 			);
 		});
 
-		test('mints independently for concurrent requests with different github tokens', async () => {
+		test('discovers independently for concurrent requests with different github tokens', async () => {
 			const minted: string[] = [];
 			const service = createService(async (input, init) => {
 				const url = getUrl(input);
@@ -498,7 +462,7 @@ suite('CopilotApiService', () => {
 			const headers = captured().init?.headers as Record<string, string>;
 
 			assert.strictEqual(headers['Content-Type'], 'application/json');
-			assert.strictEqual(headers['Authorization'], 'Bearer copilot-tok-abc');
+			assert.strictEqual(headers['Authorization'], 'Bearer gh-tok');
 			assert.strictEqual(headers['OpenAI-Intent'], 'conversation');
 			assert.ok(headers['X-Request-Id'], 'should have a request id');
 			assert.ok(headers['X-GitHub-Api-Version'], 'CAPIClient should inject API version');
@@ -547,7 +511,7 @@ suite('CopilotApiService', () => {
 
 			assert.strictEqual(headers['X-Custom-Trace'], 'abc-123');
 			assert.strictEqual(headers['X-Session-Id'], 'sess-456');
-			assert.strictEqual(headers['Authorization'], 'Bearer copilot-tok-abc', 'standard headers should not be overridden');
+			assert.strictEqual(headers['Authorization'], 'Bearer gh-tok', 'standard headers should not be overridden');
 		});
 
 		test('caller-supplied headers cannot override security-sensitive standard headers', async () => {
@@ -568,7 +532,7 @@ suite('CopilotApiService', () => {
 			});
 			const headers = captured().init?.headers as Record<string, string>;
 
-			assert.strictEqual(headers['Authorization'], 'Bearer copilot-tok-abc');
+			assert.strictEqual(headers['Authorization'], 'Bearer gh-tok');
 			assert.strictEqual(headers['Content-Type'], 'application/json');
 			assert.notStrictEqual(headers['X-Request-Id'], 'attacker-id');
 			assert.strictEqual(headers['OpenAI-Intent'], 'conversation');
@@ -1494,7 +1458,7 @@ suite('CopilotApiService', () => {
 			});
 
 			await service.models('gh-tok');
-			assert.strictEqual(capturedAuthHeader, 'Bearer copilot-tok-abc');
+			assert.strictEqual(capturedAuthHeader, 'Bearer gh-tok');
 		});
 
 		test('throws on non-200 response', async () => {
@@ -1555,7 +1519,7 @@ suite('CopilotApiService', () => {
 			await service.models('gh-tok', {
 				headers: { 'Authorization': 'Bearer attacker-token' },
 			});
-			assert.strictEqual(capturedHeaders?.['Authorization'], 'Bearer copilot-tok-abc');
+			assert.strictEqual(capturedHeaders?.['Authorization'], 'Bearer gh-tok');
 		});
 	});
 

--- a/src/vs/platform/product/common/product.ts
+++ b/src/vs/platform/product/common/product.ts
@@ -84,9 +84,7 @@ else {
 						name: 'GitHub Enterprise',
 					}
 				},
-				providerScopes: [],
-				tokenEntitlementUrl: 'https://api.github.com/copilot_internal/v2/token',
-				mcpRegistryDataUrl: 'https://api.github.com/copilot/mcp_registry',
+				providerScopes: []
 			}
 		});
 	}


### PR DESCRIPTION
## What

Replace `CopilotApiService`'s `_mintToken` flow (which posts to `https://api.github.com/copilot_internal/v2/token` and returns 404 for everyone — vanilla `gh` tokens, Copilot Enterprise tokens, the CLI's own cached `gho_` tokens) with what the `@github/copilot` CLI actually does:

1. `GET https://api.github.com/copilot_internal/user` with `Authorization: Bearer <github-token>` to discover the user's CAPI endpoint (`endpoints.api`) and `access_type_sku`.
2. Hand both to `CAPIClient.updateDomains` so subsequent `RequestType.Models` / `RequestType.ChatMessages` route to the right host (consumer or Enterprise).
3. Send `Authorization: Bearer <github-token>` directly to `${endpoints.api}/models` and `${endpoints.api}/v1/messages`. **No session-token mint.** The user token IS the credential.

## Why

`/copilot_internal/v2/token` is dead — it 404s for every kind of GitHub user token I tested, including Enterprise tokens and the OAuth tokens the `@github/copilot` CLI itself caches. The CLI doesn't call it. The agent host's existing path was inventing an exchange step that no upstream supports, so Claude only worked when something else (likely a stale cached Copilot session token) happened to be lying around.

## Citations from `github/copilot-agent-runtime@8f7f8d3`

- `fetchCopilotUser` — entitlement endpoint: [src/core/github/gitHubApi.ts#L384-L401](https://github.com/github/copilot-agent-runtime/blob/8f7f8d3/src/core/github/gitHubApi.ts#L384-L401)
- `endpoints.api` field in the response: [src/core/github/gitHubApi.ts#L168-L176](https://github.com/github/copilot-agent-runtime/blob/8f7f8d3/src/core/github/gitHubApi.ts#L168-L176)
- Anthropic client built with `authToken: <user-token>` + `baseURL: capiUrl`: [src/model/capi/copilot-anthropic-client.ts#L155-L182](https://github.com/github/copilot-agent-runtime/blob/8f7f8d3/src/model/capi/copilot-anthropic-client.ts#L155-L182)
- `apiEndpoint: '/v1/messages'`: [src/model/capi/anthropic-messages-client.ts#L555](https://github.com/github/copilot-agent-runtime/blob/8f7f8d3/src/model/capi/anthropic-messages-client.ts#L555)

## Empirically verified

```sh
# Both work with vanilla `gh auth token`:
GET  https://api.github.com/copilot_internal/user                           -> 200
     (returns endpoints.api = https://api.enterprise.githubcopilot.com on this account)
GET  https://api.enterprise.githubcopilot.com/models                         -> 200 (36 models, 9 Anthropic)
POST https://api.enterprise.githubcopilot.com/v1/messages                    -> 200 (real Claude response)
```

## Net effects

- **Claude tests work with `gh auth token` for everyone.** Previously the `claudeRealSdk.integrationTest.ts` suite required a Copilot-OAuth token captured from VS Code's keychain and was gated behind a second env var.
- **Copilot Enterprise users work too** — endpoint discovery is dynamic, no config needed.
- One round-trip removed per cold start (no separate session-token mint).
- `IProductService.defaultChatAgent.tokenEntitlementUrl` is no longer read by this service. Left in `product.ts` because the workbench's `defaultAccount.ts` still uses it.

## Test changes

- `copilotApiService.test.ts`: rename "Token Minting" suite to "Endpoint Discovery"; rename `mintCount` semantics; drop two tests that asserted on server-supplied `refresh_in` / `expires_at` (the new fixed-TTL cache doesn't model them); update auth-header assertions to expect the user token verbatim.
- `claudeRealSdk.integrationTest.ts`: drop the `AGENT_HOST_REAL_SDK_CLAUDE` opt-in (no longer needed) and rewrite the auth section of the docstring.

## Verified locally

| Suite | Result |
|---|---|
| `copilotApiService.test.ts` (unit) | 82/82 pass |
| `copilotRealSdk.integrationTest.ts` | 12/12 pass |
| `claudeRealSdk.integrationTest.ts` (with vanilla `gh auth token`) | 6/6 active pass; 3 capability-flag-gated pending (worktree, subagents, plan-mode — unchanged from #316532) |

## Follow-up

The 3 pending Claude tests (worktree isolation, subagents, plan mode) remain blocked on Claude-side phase-12 work, not on auth. Tracking via the capability flags introduced in #316532.
