### PR TITLE
Fix remoteAgentHostsEnabled gate in agents window, enable by default

### DIFF
--- a/src/vs/platform/agentHost/browser/remoteAgentHostServiceImpl.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostServiceImpl.ts
@@ -232,6 +232,10 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 	}
 
 	async addManagedConnection(entry: IRemoteAgentHostEntry, connection: IAgentConnection, transportDisposable?: IDisposable): Promise<IRemoteAgentHostConnectionInfo> {
+		if (!this._configurationService.getValue<boolean>(RemoteAgentHostsEnabledSettingId)) {
+			throw new Error('Remote agent host connections are not enabled.');
+		}
+
 		const address = getEntryAddress(entry);
 
 		// Dispose any existing entry for this address to avoid leaking
@@ -392,6 +396,10 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 	}
 
 	private _connectTo(address: string, connectionToken?: string): void {
+		if (!this._configurationService.getValue<boolean>(RemoteAgentHostsEnabledSettingId)) {
+			return;
+		}
+
 		// Dispose any existing entry for this address before creating a new one
 		// to avoid leaking disposables on reconnect.
 		const existingEntry = this._entries.get(address);

--- a/src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts
+++ b/src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts
@@ -13,7 +13,7 @@ import { IConfigurationService } from '../../configuration/common/configuration.
 import { IEnvironmentService } from '../../environment/common/environment.js';
 import { ISharedProcessService } from '../../ipc/electron-browser/services.js';
 import { ProxyChannel } from '../../../base/parts/ipc/common/ipc.js';
-import { IRemoteAgentHostService, RemoteAgentHostEntryType } from '../common/remoteAgentHostService.js';
+import { IRemoteAgentHostService, RemoteAgentHostEntryType, RemoteAgentHostsEnabledSettingId } from '../common/remoteAgentHostService.js';
 import { createDecorator, IInstantiationService } from '../../instantiation/common/instantiation.js';
 import { IQuickInputService } from '../../quickinput/common/quickInput.js';
 import { AhpJsonlLogger } from '../common/ahpJsonlLogger.js';
@@ -118,6 +118,10 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 	}
 
 	async connect(config: ISSHAgentHostConfig): Promise<ISSHAgentHostConnection> {
+		if (!this._configurationService.getValue<boolean>(RemoteAgentHostsEnabledSettingId)) {
+			throw new Error('Remote agent host connections are not enabled.');
+		}
+
 		const augmentedConfig = this._augmentConfig(config);
 		this._logService.info(`[SSHRemoteAgentHost] Connecting to ${config.host}`);
 		const result = await this._mainService.connect(augmentedConfig);
@@ -146,6 +150,10 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 	}
 
 	async reconnect(sshConfigHost: string, name: string): Promise<ISSHAgentHostConnection> {
+		if (!this._configurationService.getValue<boolean>(RemoteAgentHostsEnabledSettingId)) {
+			throw new Error('Remote agent host connections are not enabled.');
+		}
+
 		const commandOverride = this._getRemoteAgentHostCommand();
 		const agentForward = this._isSSHAgentForwardingEnabled();
 		this._logService.info(`[SSHRemoteAgentHost] Reconnecting to ${sshConfigHost}`);

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostService.test.ts
@@ -508,6 +508,15 @@ suite('RemoteAgentHostService', () => {
 			assert.strictEqual(service.getConnection('ws://managed:1234'), undefined);
 		});
 
+		test('throws when disabled', async () => {
+			configService.setEnabled(false);
+
+			await assert.rejects(
+				() => addManaged('Managed', 'managed:1234'),
+				/not enabled/,
+			);
+		});
+
 		test('does NOT dispose previous transportDisposable when entry is replaced', async () => {
 			// When the entry is replaced (e.g. on reconnect to the same address),
 			// the new entry takes ownership of the same underlying connectionId.

--- a/src/vs/platform/agentHost/test/electron-browser/sshRemoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/sshRemoteAgentHostService.test.ts
@@ -16,7 +16,7 @@ import { IConfigurationService } from '../../../configuration/common/configurati
 
 import { ISharedProcessService } from '../../../ipc/electron-browser/services.js';
 import { IQuickInputService } from '../../../quickinput/common/quickInput.js';
-import { IRemoteAgentHostService } from '../../common/remoteAgentHostService.js';
+import { IRemoteAgentHostService, RemoteAgentHostsEnabledSettingId } from '../../common/remoteAgentHostService.js';
 import type { IAgentConnection } from '../../common/agentService.js';
 import type {
 	ISSHAgentHostConfig,
@@ -63,11 +63,14 @@ class MockSSHMainService {
 	}
 
 	readonly disconnectCalls: string[] = [];
+	readonly connectCalls: ISSHAgentHostConfig[] = [];
+	readonly reconnectCalls: Array<{ sshConfigHost: string; name: string }> = [];
 	private _nextConnectionId = 1;
 
 	connectResult: Partial<ISSHConnectResult> | undefined;
 
 	async connect(config: ISSHAgentHostConfig): Promise<ISSHConnectResult> {
+		this.connectCalls.push(config);
 		const connectionId = this.connectResult?.connectionId ?? `conn-${this._nextConnectionId++}`;
 		return {
 			connectionId,
@@ -80,6 +83,7 @@ class MockSSHMainService {
 	}
 
 	async reconnect(sshConfigHost: string, name: string): Promise<ISSHConnectResult> {
+		this.reconnectCalls.push({ sshConfigHost, name });
 		return {
 			connectionId: `conn-${this._nextConnectionId++}`,
 			address: `ssh:${sshConfigHost}`,
@@ -181,7 +185,9 @@ class MockProtocolClient extends Disposable {
 
 class TestConfigurationService {
 	readonly onDidChangeConfiguration = Event.None;
-	getValue(): unknown { return undefined; }
+	constructor(private _remoteAgentHostsEnabled = true) { }
+	getValue(key?: string): unknown { return key === RemoteAgentHostsEnabledSettingId ? this._remoteAgentHostsEnabled : undefined; }
+	setRemoteAgentHostsEnabled(enabled: boolean): void { this._remoteAgentHostsEnabled = enabled; }
 }
 
 suite('SSHRemoteAgentHostService (renderer)', () => {
@@ -189,6 +195,7 @@ suite('SSHRemoteAgentHostService (renderer)', () => {
 	const disposables = new DisposableStore();
 	let mainService: MockSSHMainService;
 	let remoteAgentHostService: MockRemoteAgentHostService;
+	let configurationService: TestConfigurationService;
 	let createdClients: MockProtocolClient[];
 	let waitForClient: (index: number) => Promise<MockProtocolClient>;
 	let service: SSHRemoteAgentHostService;
@@ -205,7 +212,8 @@ suite('SSHRemoteAgentHostService (renderer)', () => {
 
 		const instantiationService = disposables.add(new TestInstantiationService());
 		instantiationService.stub(ILogService, new NullLogService());
-		instantiationService.stub(IConfigurationService, new TestConfigurationService() as Partial<IConfigurationService>);
+		configurationService = new TestConfigurationService();
+		instantiationService.stub(IConfigurationService, configurationService as Partial<IConfigurationService>);
 		instantiationService.stub(IQuickInputService, {} as Partial<IQuickInputService>);
 		instantiationService.stub(ISharedProcessService, sharedProcessService as ISharedProcessService);
 		instantiationService.stub(IRemoteAgentHostService, remoteAgentHostService as Partial<IRemoteAgentHostService>);
@@ -259,6 +267,19 @@ suite('SSHRemoteAgentHostService (renderer)', () => {
 		assert.ok(remoteAgentHostService.added[0].transport, 'a transport disposable is passed so removal can tear down the SSH tunnel');
 		assert.strictEqual(service.connections.length, 1);
 		assert.strictEqual(handle.localAddress, 'ssh:remote.example');
+	});
+
+	test('disabled setting prevents SSH tunnel connects and reconnects', async () => {
+		configurationService.setRemoteAgentHostsEnabled(false);
+
+		await assert.rejects(() => service.connect(sampleConfig), /not enabled/);
+		await assert.rejects(() => service.reconnect('remote.example', 'My Remote'), /not enabled/);
+
+		assert.deepStrictEqual({ connectCalls: mainService.connectCalls, reconnectCalls: mainService.reconnectCalls, added: remoteAgentHostService.added }, {
+			connectCalls: [],
+			reconnectCalls: [],
+			added: [],
+		});
 	});
 
 	test('removing the entry tears down the SSH tunnel and the renderer-side handle', async () => {

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -18,7 +18,7 @@ import { IActionWidgetService } from '../../../../platform/actionWidget/browser/
 import { ActionListItemKind, IActionListDelegate, IActionListItem, IActionListOptions } from '../../../../platform/actionWidget/browser/actionList.js';
 import { ITabDescriptor, TabbedActionListWidget } from '../../../../platform/actionWidget/browser/tabbedActionListWidget.js';
 import { IMenuService, MenuItemAction } from '../../../../platform/actions/common/actions.js';
-import { IRemoteAgentHostService, RemoteAgentHostConnectionStatus } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { IRemoteAgentHostService, RemoteAgentHostConnectionStatus, RemoteAgentHostsEnabledSettingId } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { TUNNEL_ADDRESS_PREFIX } from '../../../../platform/agentHost/common/tunnelAgentHost.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
@@ -158,7 +158,7 @@ export class WorkspacePicker extends Disposable {
 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
 		@ISessionsProvidersService protected readonly sessionsProvidersService: ISessionsProvidersService,
 		@IRemoteAgentHostService private readonly remoteAgentHostService: IRemoteAgentHostService,
-		@IConfigurationService _configurationService: IConfigurationService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@ICommandService private readonly commandService: ICommandService,
 		@IWorkspacesService private readonly workspacesService: IWorkspacesService,
 		@IMenuService private readonly menuService: IMenuService,
@@ -319,16 +319,22 @@ export class WorkspacePicker extends Disposable {
 
 	protected _getAvailableTabs(): ITabDescriptor[] {
 		const byLabel = new Map<string, ITabDescriptor>();
-		byLabel.set(SESSION_WORKSPACE_GROUP_REMOTE, {
-			id: SESSION_WORKSPACE_GROUP_REMOTE,
-			icon: Codicon.beaker,
-			tooltip: `${SESSION_WORKSPACE_GROUP_REMOTE} (${localize('workspacePicker.experimental', "Experimental")})`,
-		});
+		const remoteAgentHostsEnabled = this.configurationService.getValue<boolean>(RemoteAgentHostsEnabledSettingId);
+		if (remoteAgentHostsEnabled) {
+			byLabel.set(SESSION_WORKSPACE_GROUP_REMOTE, {
+				id: SESSION_WORKSPACE_GROUP_REMOTE,
+				icon: Codicon.beaker,
+				tooltip: `${SESSION_WORKSPACE_GROUP_REMOTE} (${localize('workspacePicker.experimental', "Experimental")})`,
+			});
+		}
 		for (const provider of this.sessionsProvidersService.getProviders()) {
 			if (provider.supportsLocalWorkspaces && !byLabel.has(SESSION_WORKSPACE_GROUP_LOCAL)) {
 				byLabel.set(SESSION_WORKSPACE_GROUP_LOCAL, { id: SESSION_WORKSPACE_GROUP_LOCAL });
 			}
 			for (const action of provider.browseActions) {
+				if (action.group === SESSION_WORKSPACE_GROUP_REMOTE && !remoteAgentHostsEnabled) {
+					continue;
+				}
 				if (action.group && !byLabel.has(action.group)) {
 					byLabel.set(action.group, { id: action.group });
 				}

--- a/src/vs/sessions/contrib/chat/test/browser/sessionWorkspacePicker.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionWorkspacePicker.test.ts
@@ -13,7 +13,7 @@ import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { runWithFakedTimers } from '../../../../../base/test/common/timeTravelScheduler.js';
 import { IActionWidgetService } from '../../../../../platform/actionWidget/browser/actionWidget.js';
-import { RemoteAgentHostConnectionStatus, IRemoteAgentHostService } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { RemoteAgentHostConnectionStatus, IRemoteAgentHostService, RemoteAgentHostsEnabledSettingId } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { IClipboardService } from '../../../../../platform/clipboard/common/clipboardService.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { IQuickInputService } from '../../../../../platform/quickinput/common/quickInput.js';
@@ -32,6 +32,7 @@ import { ISessionWorkspace, ISessionWorkspaceBrowseAction, SESSION_WORKSPACE_GRO
 import { WorkspacePicker, IWorkspaceSelection } from '../../browser/sessionWorkspacePicker.js';
 import { IWorkspacesService } from '../../../../../platform/workspaces/common/workspaces.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { IContextViewService } from '../../../../../platform/contextview/browser/contextView.js';
 import { IFileDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
@@ -160,7 +161,7 @@ function createTestPicker(
 	instantiationService.stub(IClipboardService, {});
 	instantiationService.stub(IPreferencesService, {});
 	instantiationService.stub(IOutputService, {});
-	instantiationService.stub(IConfigurationService, { getValue: () => undefined });
+	instantiationService.stub(IConfigurationService, new TestConfigurationService({ [RemoteAgentHostsEnabledSettingId]: true }));
 	instantiationService.stub(ICommandService, { executeCommand: async () => { } });
 	instantiationService.stub(IFileDialogService, {});
 	instantiationService.stub(IContextKeyService, new MockContextKeyService());
@@ -544,7 +545,7 @@ function makeBrowseAction(providerId: string, group: string | undefined, label =
 	};
 }
 
-function createTestablePicker(disposables: DisposableStore, providersService: MockSessionsProvidersService): TestablePicker {
+function createTestablePicker(disposables: DisposableStore, providersService: MockSessionsProvidersService, remoteAgentHostsEnabled = true): TestablePicker {
 	const instantiationService = disposables.add(new TestInstantiationService());
 	instantiationService.stub(IActionWidgetService, { isVisible: false, hide: () => { }, show: () => { } });
 	instantiationService.stub(IContextViewService, { showContextView: () => ({ close: () => { } }), hideContextView: () => { }, layout: () => { } });
@@ -556,7 +557,7 @@ function createTestablePicker(disposables: DisposableStore, providersService: Mo
 	instantiationService.stub(IClipboardService, {});
 	instantiationService.stub(IPreferencesService, {});
 	instantiationService.stub(IOutputService, {});
-	instantiationService.stub(IConfigurationService, { getValue: () => undefined });
+	instantiationService.stub(IConfigurationService, new TestConfigurationService({ [RemoteAgentHostsEnabledSettingId]: remoteAgentHostsEnabled }));
 	instantiationService.stub(ICommandService, { executeCommand: async () => { } });
 	instantiationService.stub(IFileDialogService, {});
 	instantiationService.stub(IContextKeyService, new MockContextKeyService());
@@ -587,6 +588,14 @@ suite('WorkspacePicker - Tab discovery', () => {
 		providersService.setProviders([createMockProvider('p1')]);
 		const picker = createTestablePicker(disposables, providersService);
 		assert.deepStrictEqual(picker.getAvailableTabs(), [SESSION_WORKSPACE_GROUP_REMOTE]);
+	});
+
+	test('hides Remote group when remote agent hosts are disabled', () => {
+		providersService.setProviders([
+			createMockProvider('p1', { browseActions: [makeBrowseAction('p1', SESSION_WORKSPACE_GROUP_REMOTE)] }),
+		]);
+		const picker = createTestablePicker(disposables, providersService, false);
+		assert.deepStrictEqual(picker.getAvailableTabs(), []);
 	});
 
 	test('orders well-known groups Local first, then alphabetical', () => {
@@ -661,7 +670,7 @@ suite('WorkspacePicker - Tab discovery', () => {
 		instantiationService.stub(IClipboardService, {});
 		instantiationService.stub(IPreferencesService, {});
 		instantiationService.stub(IOutputService, {});
-		instantiationService.stub(IConfigurationService, { getValue: () => undefined });
+		instantiationService.stub(IConfigurationService, new TestConfigurationService({ [RemoteAgentHostsEnabledSettingId]: true }));
 		instantiationService.stub(ICommandService, { executeCommand: async () => { } });
 		instantiationService.stub(IFileDialogService, {});
 		instantiationService.stub(IContextKeyService, new MockContextKeyService());

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution.ts
@@ -25,7 +25,6 @@ import { IFileService } from '../../../../../platform/files/common/files.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
 import { INotificationService } from '../../../../../platform/notification/common/notification.js';
-import product from '../../../../../platform/product/common/product.js';
 import { Registry } from '../../../../../platform/registry/common/platform.js';
 import { IStorageService } from '../../../../../platform/storage/common/storage.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../../workbench/common/contributions.js';
@@ -291,6 +290,11 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 	 * called.
 	 */
 	private _reconnectSSHEntries(): void {
+		if (!this._configurationService.getValue<boolean>(RemoteAgentHostsEnabledSettingId)) {
+			this._sshReconnectStates.clearAndDisposeAll();
+			return;
+		}
+
 		const autoConnect = this._configurationService.getValue<boolean>(RemoteAgentHostAutoConnectSettingId);
 		const entries = this._remoteAgentHostService.configuredEntries;
 		const stillConfigured = new Set<string>();
@@ -341,6 +345,10 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 			this._logService.info(`[RemoteAgentHost] SSH tunnel re-established for ${sshConfigHost}`);
 		}).catch(err => {
 			this._pendingSSHReconnects.delete(sshConfigHost);
+			if (!this._configurationService.getValue<boolean>(RemoteAgentHostsEnabledSettingId)) {
+				this._sshReconnectStates.deleteAndDispose(sshConfigHost);
+				return;
+			}
 			this._logService.error(`[RemoteAgentHost] SSH reconnect failed for ${sshConfigHost}`, err);
 			const provider = this._providerInstances.get(address);
 			// Surface protocol-version mismatches on the provider so the
@@ -379,6 +387,10 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 		state.scheduleRetry(delay, () => {
 			// Re-check eligibility — config might have changed, or a manual
 			// connect might have succeeded while we were waiting.
+			if (!this._configurationService.getValue<boolean>(RemoteAgentHostsEnabledSettingId)) {
+				this._sshReconnectStates.deleteAndDispose(sshConfigHost);
+				return;
+			}
 			const autoConnect = this._configurationService.getValue<boolean>(RemoteAgentHostAutoConnectSettingId);
 			if (!autoConnect) {
 				return;
@@ -753,7 +765,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 		[RemoteAgentHostsEnabledSettingId]: {
 			type: 'boolean',
 			description: nls.localize('chat.remoteAgentHosts.enabled', "Enable connecting to remote agent hosts."),
-			default: product.quality !== 'stable',
+			default: true,
 			scope: ConfigurationScope.APPLICATION,
 			tags: ['experimental', 'advanced'],
 		},

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/tunnelAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/tunnelAgentHost.contribution.ts
@@ -110,6 +110,13 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 			this._pruneReconnectState();
 		}));
 
+		this._register(this._configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration(RemoteAgentHostsEnabledSettingId)) {
+				this._reconcileProviders();
+				this._pruneReconnectState();
+			}
+		}));
+
 		// Re-run discovery when a GitHub session becomes available,
 		// and tear down tunnel state bound to that provider if its session
 		// is removed.

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/webTunnelAgentHostService.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/webTunnelAgentHostService.ts
@@ -123,6 +123,9 @@ export class WebTunnelAgentHostService extends Disposable implements ITunnelAgen
 		if (!this._discoveryProvider) {
 			throw new Error('No tunnelDiscoveryProvider available');
 		}
+		if (!this._configurationService.getValue<boolean>(RemoteAgentHostsEnabledSettingId)) {
+			throw new Error('Remote agent host connections are not enabled.');
+		}
 
 		const { tunnelId, clusterId } = tunnel;
 		this._logService.info(`${LOG_PREFIX} Connecting to tunnel '${tunnel.name}' (${tunnelId})`);

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/electron-browser/tunnelAgentHostServiceImpl.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/electron-browser/tunnelAgentHostServiceImpl.ts
@@ -90,6 +90,10 @@ export class TunnelAgentHostService extends Disposable implements ITunnelAgentHo
 	}
 
 	async connect(tunnel: ITunnelInfo, authProvider?: 'github' | 'microsoft'): Promise<void> {
+		if (!this._configurationService.getValue<boolean>(RemoteAgentHostsEnabledSettingId)) {
+			throw new Error('Remote agent host connections are not enabled.');
+		}
+
 		const auth = authProvider
 			? await this._getTokenForProvider(authProvider, false)
 			: await this._getToken(false);

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/tunnelAgentHost.contribution.test.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/tunnelAgentHost.contribution.test.ts
@@ -21,7 +21,7 @@ import {
 	ITunnelAgentHostService,
 	TUNNEL_ADDRESS_PREFIX,
 } from '../../../../../../platform/agentHost/common/tunnelAgentHost.js';
-import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
+import { ConfigurationTarget, IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
@@ -149,7 +149,7 @@ suite('TunnelAgentHostContribution', () => {
 
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
 
-	test('newly-cached tunnel binds to subsequent live connection', () => {
+	test('newly-cached tunnel binds to subsequent live connection', async () => {
 		// Regression guard for the picker flow: `tunnelService.connect()` is
 		// contractually obligated to cache the tunnel BEFORE announcing the
 		// live connection via `addManagedConnection`. That ordering lets the
@@ -159,12 +159,13 @@ suite('TunnelAgentHostContribution', () => {
 		const tunnelService = store.add(new StubTunnelService());
 		const remoteService = store.add(new StubRemoteAgentHostService());
 		const providersService = store.add(new StubSessionsProvidersService());
+		const configurationService = new TestConfigurationService({ [RemoteAgentHostsEnabledSettingId]: true });
 
 		const instantiationService = store.add(new TestInstantiationService());
 		instantiationService.stub(ITunnelAgentHostService, tunnelService as unknown as ITunnelAgentHostService);
 		instantiationService.stub(IRemoteAgentHostService, remoteService as unknown as IRemoteAgentHostService);
 		instantiationService.stub(ISessionsProvidersService, providersService as unknown as ISessionsProvidersService);
-		instantiationService.stub(IConfigurationService, new TestConfigurationService({ [RemoteAgentHostsEnabledSettingId]: true }));
+		instantiationService.stub(IConfigurationService, configurationService);
 		instantiationService.stub(INotificationService, { notify: () => ({ close() { } }) } as unknown as INotificationService);
 		instantiationService.stub(ILogService, new NullLogService());
 		instantiationService.stub(IAuthenticationService, { onDidChangeSessions: Event.None } as unknown as IAuthenticationService);
@@ -192,5 +193,15 @@ suite('TunnelAgentHostContribution', () => {
 		}, fakeConnection);
 
 		assert.deepStrictEqual(provider!.setConnectionCalls.map(c => c.connection), [fakeConnection]);
+
+		await configurationService.setUserConfiguration(RemoteAgentHostsEnabledSettingId, false);
+		configurationService.onDidChangeConfigurationEmitter.fire({
+			affectsConfiguration: key => key === RemoteAgentHostsEnabledSettingId,
+			affectedKeys: new Set([RemoteAgentHostsEnabledSettingId]),
+			change: { keys: [RemoteAgentHostsEnabledSettingId], overrides: [] },
+			source: ConfigurationTarget.USER,
+		});
+
+		assert.deepStrictEqual(providersService.getProviders(), []);
 	});
 });


### PR DESCRIPTION
## Summary
- hide the Remote workspace picker tab while remote agent hosts are disabled
- block WebSocket, SSH, and tunnel remote-host connection paths behind the setting
- stop stale SSH reconnect/tunnel provider state across setting transitions
- default `chat.remoteAgentHostsEnabled` to `true`

## Validation
- Core Typecheck watch task: 0 errors
- focused unit tests: 53 passed
- `npm run valid-layers-check`
- targeted hygiene check / commit hook hygiene

(Written by Copilot)