### PR TITLE
Allow optionally specifying shellType in linux terminal profiles, and autodetect flatpak-spawn and host-spawn

### DIFF
--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -732,6 +732,7 @@ export interface IShellLaunchConfigDto {
 	tabActions?: ITerminalTabAction[];
 	shellIntegrationEnvironmentReporting?: boolean;
 	titleTemplate?: string;
+	shellType?: string;
 }
 
 /**

--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -493,6 +493,7 @@ export interface IHeartbeatService {
 
 
 export interface IShellLaunchConfig {
+	shellType?: string;
 	/**
 	 * The name of the terminal, if this is not set the name of the process will be used.
 	 */
@@ -938,6 +939,7 @@ export interface ITerminalProfile {
 	overrideName?: boolean;
 	color?: string;
 	icon?: ThemeIcon | URI | { light: URI; dark: URI };
+	shellType?: string;
 }
 
 export interface ITerminalDimensionsOverride extends Readonly<ITerminalDimensions> {
@@ -960,6 +962,7 @@ export interface IBaseUnresolvedTerminalProfile {
 	color?: string;
 	env?: ITerminalEnvironment;
 	requiresPath?: string | ITerminalUnsafePath;
+	shellType?: string;
 }
 
 export interface ITerminalUnsafePath {

--- a/src/vs/platform/terminal/common/terminalPlatformConfiguration.ts
+++ b/src/vs/platform/terminal/common/terminalPlatformConfiguration.ts
@@ -56,6 +56,11 @@ export const terminalProfileBaseProperties: IJSONSchemaMap = {
 			type: ['string', 'null']
 		},
 		default: {}
+	},
+	shellType: {
+		description: localize('terminalProfile.shellType', 'Override the automatically detected shell type. Useful when using wrappers like host-spawn or flatpak-spawn.'),
+		type: 'string',
+		enum: ['bash', 'sh', 'zsh', 'pwsh', 'powershell', 'cmd', 'fish']
 	}
 };
 

--- a/src/vs/platform/terminal/common/terminalPlatformConfiguration.ts
+++ b/src/vs/platform/terminal/common/terminalPlatformConfiguration.ts
@@ -58,9 +58,9 @@ export const terminalProfileBaseProperties: IJSONSchemaMap = {
 		default: {}
 	},
 	shellType: {
-		description: localize('terminalProfile.shellType', 'Override the automatically detected shell executable basename for supported shells. Both variants with and without the \'.exe\' extension are supported (e.g., \'bash\' and \'bash.exe\') for cross-platform profile sharing. Useful when using wrappers like host-spawn or flatpak-spawn.'),
+		description: localize('terminalProfile.shellType', 'Override the automatically detected shell executable basename for supported shells. Supports both variants with and without the \'.exe\' extension (e.g., \'bash\' and \'bash.exe\') for cross-platform profile sharing. Useful when using wrappers like host-spawn or flatpak-spawn. Set to \'none\' to explicitly disable shell integration for this profile.'),
 		type: 'string',
-		enum: ['bash', 'bash.exe', 'zsh', 'zsh.exe', 'pwsh', 'pwsh.exe', 'powershell', 'powershell.exe', 'fish', 'fish.exe']
+		enum: ['none', 'bash', 'bash.exe', 'zsh', 'zsh.exe', 'pwsh', 'pwsh.exe', 'powershell', 'powershell.exe', 'fish', 'fish.exe']
 	}
 };
 

--- a/src/vs/platform/terminal/common/terminalPlatformConfiguration.ts
+++ b/src/vs/platform/terminal/common/terminalPlatformConfiguration.ts
@@ -58,9 +58,9 @@ export const terminalProfileBaseProperties: IJSONSchemaMap = {
 		default: {}
 	},
 	shellType: {
-		description: localize('terminalProfile.shellType', 'Override the automatically detected shell type. Useful when using wrappers like host-spawn or flatpak-spawn.'),
+		description: localize('terminalProfile.shellType', 'Override the automatically detected shell executable basename. Both variants with and without the \'.exe\' extension are supported (e.g., \'bash\' and \'bash.exe\') for cross-platform profile sharing. Useful when using wrappers like host-spawn or flatpak-spawn.'),
 		type: 'string',
-		enum: ['bash', 'zsh', 'pwsh', 'powershell', 'fish']
+		enum: ['bash', 'bash.exe', 'zsh', 'zsh.exe', 'pwsh', 'pwsh.exe', 'powershell', 'powershell.exe', 'cmd', 'cmd.exe', 'fish', 'fish.exe']
 	}
 };
 

--- a/src/vs/platform/terminal/common/terminalPlatformConfiguration.ts
+++ b/src/vs/platform/terminal/common/terminalPlatformConfiguration.ts
@@ -58,9 +58,9 @@ export const terminalProfileBaseProperties: IJSONSchemaMap = {
 		default: {}
 	},
 	shellType: {
-		description: localize('terminalProfile.shellType', 'Override the automatically detected shell executable basename. Both variants with and without the \'.exe\' extension are supported (e.g., \'bash\' and \'bash.exe\') for cross-platform profile sharing. Useful when using wrappers like host-spawn or flatpak-spawn.'),
+		description: localize('terminalProfile.shellType', 'Override the automatically detected shell executable basename for supported shells. Both variants with and without the \'.exe\' extension are supported (e.g., \'bash\' and \'bash.exe\') for cross-platform profile sharing. Useful when using wrappers like host-spawn or flatpak-spawn.'),
 		type: 'string',
-		enum: ['bash', 'bash.exe', 'zsh', 'zsh.exe', 'pwsh', 'pwsh.exe', 'powershell', 'powershell.exe', 'cmd', 'cmd.exe', 'fish', 'fish.exe']
+		enum: ['bash', 'bash.exe', 'zsh', 'zsh.exe', 'pwsh', 'pwsh.exe', 'powershell', 'powershell.exe', 'fish', 'fish.exe']
 	}
 };
 

--- a/src/vs/platform/terminal/common/terminalPlatformConfiguration.ts
+++ b/src/vs/platform/terminal/common/terminalPlatformConfiguration.ts
@@ -60,7 +60,7 @@ export const terminalProfileBaseProperties: IJSONSchemaMap = {
 	shellType: {
 		description: localize('terminalProfile.shellType', 'Override the automatically detected shell type. Useful when using wrappers like host-spawn or flatpak-spawn.'),
 		type: 'string',
-		enum: ['bash', 'sh', 'zsh', 'pwsh', 'powershell', 'cmd', 'fish']
+		enum: ['bash', 'zsh', 'pwsh', 'powershell', 'fish']
 	}
 };
 

--- a/src/vs/platform/terminal/node/terminalEnvironment.ts
+++ b/src/vs/platform/terminal/node/terminalEnvironment.ts
@@ -111,6 +111,8 @@ export async function getShellIntegrationInjection(
 		'VSCODE_INJECTION': '1'
 	};
 
+	let injectionResult: IShellIntegrationConfigInjection | undefined;
+
 	if (options.shellIntegration.nonce) {
 		envMixin['VSCODE_NONCE'] = options.shellIntegration.nonce;
 	}
@@ -143,8 +145,7 @@ export async function getShellIntegrationInjection(
 			newArgs = [...newArgs];
 			newArgs[newArgs.length - 1] = format(newArgs[newArgs.length - 1], appRoot, '');
 			envMixin['VSCODE_STABLE'] = productService.quality === 'stable' ? '1' : '0';
-			if (wrapperArgs) { newArgs = [...wrapperArgs, ...newArgs]; }
-			return { type, newArgs, envMixin };
+			injectionResult = { type, newArgs, envMixin };
 		} else if (shell === 'bash.exe') {
 			if (!originalArgs || originalArgs.length === 0) {
 				newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.Bash);
@@ -159,153 +160,163 @@ export async function getShellIntegrationInjection(
 			newArgs = [...newArgs]; // Shallow clone the array to avoid setting the default array
 			newArgs[newArgs.length - 1] = format(newArgs[newArgs.length - 1], appRoot);
 			envMixin['VSCODE_STABLE'] = productService.quality === 'stable' ? '1' : '0';
-			if (wrapperArgs) { newArgs = [...wrapperArgs, ...newArgs]; }
-			return { type, newArgs, envMixin };
+			injectionResult = { type, newArgs, envMixin };
+		} else {
+			logService.warn(`Shell integration cannot be enabled for executable "${shellLaunchConfig.executable}" and args`, shellLaunchConfig.args);
+			return { type: 'failure', reason: ShellIntegrationInjectionFailureReason.UnsupportedShell };
 		}
-		logService.warn(`Shell integration cannot be enabled for executable "${shellLaunchConfig.executable}" and args`, shellLaunchConfig.args);
-		return { type: 'failure', reason: ShellIntegrationInjectionFailureReason.UnsupportedShell };
-	}
-
-	// Linux & macOS
-	switch (shell) {
-		case 'bash': {
-			if (!originalArgs || originalArgs.length === 0) {
-				newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.Bash);
-			} else if (areZshBashFishLoginArgs(originalArgs)) {
-				envMixin['VSCODE_SHELL_LOGIN'] = '1';
-				addEnvMixinPathPrefix(options, envMixin, shell);
-				newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.Bash);
-			}
-			if (!newArgs) {
-				return { type: 'failure', reason: ShellIntegrationInjectionFailureReason.UnsupportedArgs };
-			}
-			newArgs = [...newArgs]; // Shallow clone the array to avoid setting the default array
-			newArgs[newArgs.length - 1] = format(newArgs[newArgs.length - 1], appRoot);
-			envMixin['VSCODE_STABLE'] = productService.quality === 'stable' ? '1' : '0';
-			if (wrapperArgs) { newArgs = [...wrapperArgs, ...newArgs]; }
-			return { type, newArgs, envMixin };
-		}
-		case 'fish': {
-			if (!originalArgs || originalArgs.length === 0) {
-				newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.Fish);
-			} else if (areZshBashFishLoginArgs(originalArgs)) {
-				newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.FishLogin);
-			} else if (originalArgs === shellIntegrationArgs.get(ShellIntegrationExecutable.Fish) || originalArgs === shellIntegrationArgs.get(ShellIntegrationExecutable.FishLogin)) {
-				newArgs = originalArgs;
-			}
-			if (!newArgs) {
-				return { type: 'failure', reason: ShellIntegrationInjectionFailureReason.UnsupportedArgs };
-			}
-
-			// On fish, '$fish_user_paths' is always prepended to the PATH, for both login and non-login shells, so we need
-			// to apply the path prefix fix always, not only for login shells (see #232291)
-			addEnvMixinPathPrefix(options, envMixin, shell);
-
-			newArgs = [...newArgs]; // Shallow clone the array to avoid setting the default array
-			newArgs[newArgs.length - 1] = format(newArgs[newArgs.length - 1], appRoot);
-			if (wrapperArgs) { newArgs = [...wrapperArgs, ...newArgs]; }
-			return { type, newArgs, envMixin };
-		}
-		case 'pwsh':
-		case 'powershell': {
-			if (!originalArgs || arePwshImpliedArgs(originalArgs)) {
-				newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.Pwsh);
-			} else if (arePwshLoginArgs(originalArgs)) {
-				newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.PwshLogin);
-			}
-			if (!newArgs) {
-				return { type: 'failure', reason: ShellIntegrationInjectionFailureReason.UnsupportedArgs };
-			}
-			newArgs = [...newArgs]; // Shallow clone the array to avoid setting the default array
-			newArgs[newArgs.length - 1] = format(newArgs[newArgs.length - 1], appRoot, '');
-			envMixin['VSCODE_STABLE'] = productService.quality === 'stable' ? '1' : '0';
-			if (wrapperArgs) { newArgs = [...wrapperArgs, ...newArgs]; }
-			return { type, newArgs, envMixin };
-		}
-		case 'zsh': {
-			if (!originalArgs || originalArgs.length === 0) {
-				newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.Zsh);
-			} else if (areZshBashFishLoginArgs(originalArgs)) {
-				newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.ZshLogin);
-				addEnvMixinPathPrefix(options, envMixin, shell);
-			} else if (originalArgs === shellIntegrationArgs.get(ShellIntegrationExecutable.Zsh) || originalArgs === shellIntegrationArgs.get(ShellIntegrationExecutable.ZshLogin)) {
-				newArgs = originalArgs;
-			}
-			if (!newArgs) {
-				return { type: 'failure', reason: ShellIntegrationInjectionFailureReason.UnsupportedArgs };
-			}
-			newArgs = [...newArgs]; // Shallow clone the array to avoid setting the default array
-			newArgs[newArgs.length - 1] = format(newArgs[newArgs.length - 1], appRoot);
-
-			// Move .zshrc into $ZDOTDIR as the way to activate the script
-			let username: string;
-			try {
-				username = os.userInfo().username;
-			} catch {
-				username = 'unknown';
-			}
-
-			// Resolve the actual tmp directory so we can set the sticky bit
-			const realTmpDir = realpathSync(os.tmpdir());
-			const zdotdir = path.join(realTmpDir, `${username}-${productService.applicationName}-zsh`);
-
-			// Set directory permissions using octal notation:
-			// - 0o1700:
-			// - Sticky bit is set, preventing non-owners from deleting or renaming files within this directory (1)
-			// - Owner has full read (4), write (2), execute (1) permissions
-			// - Group has no permissions (0)
-			// - Others have no permissions (0)
-			if (!skipStickyBit) {
-				// skip for tests
-				try {
-					const chmodAsync = promisify(chmod);
-					await chmodAsync(zdotdir, 0o1700);
-				} catch (err) {
-					if (err.message.includes('ENOENT')) {
-						try {
-							mkdirSync(zdotdir);
-						} catch (err) {
-							logService.error(`Failed to create zdotdir at ${zdotdir}: ${err}`);
-							return { type: 'failure', reason: ShellIntegrationInjectionFailureReason.FailedToCreateTmpDir };
-						}
-						try {
-							const chmodAsync = promisify(chmod);
-							await chmodAsync(zdotdir, 0o1700);
-						} catch {
-							logService.error(`Failed to set sticky bit on ${zdotdir}: ${err}`);
-							return { type: 'failure', reason: ShellIntegrationInjectionFailureReason.FailedToSetStickyBit };
-						}
-					}
-					logService.error(`Failed to set sticky bit on ${zdotdir}: ${err}`);
-					return { type: 'failure', reason: ShellIntegrationInjectionFailureReason.FailedToSetStickyBit };
+	} else {
+		// Linux & macOS
+		switch (shell) {
+			case 'bash': {
+				if (!originalArgs || originalArgs.length === 0) {
+					newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.Bash);
+				} else if (areZshBashFishLoginArgs(originalArgs)) {
+					envMixin['VSCODE_SHELL_LOGIN'] = '1';
+					addEnvMixinPathPrefix(options, envMixin, shell);
+					newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.Bash);
 				}
+				if (!newArgs) {
+					return { type: 'failure', reason: ShellIntegrationInjectionFailureReason.UnsupportedArgs };
+				}
+				newArgs = [...newArgs]; // Shallow clone the array to avoid setting the default array
+				newArgs[newArgs.length - 1] = format(newArgs[newArgs.length - 1], appRoot);
+				envMixin['VSCODE_STABLE'] = productService.quality === 'stable' ? '1' : '0';
+				injectionResult = { type, newArgs, envMixin };
+				break;
 			}
-			envMixin['ZDOTDIR'] = zdotdir;
-			const userZdotdir = env?.ZDOTDIR ?? os.homedir() ?? `~`;
-			envMixin['USER_ZDOTDIR'] = userZdotdir;
-			const filesToCopy: IShellIntegrationConfigInjection['filesToCopy'] = [];
-			filesToCopy.push({
-				source: path.join(appRoot, 'out/vs/workbench/contrib/terminal/common/scripts/shellIntegration-rc.zsh'),
-				dest: path.join(zdotdir, '.zshrc')
-			});
-			filesToCopy.push({
-				source: path.join(appRoot, 'out/vs/workbench/contrib/terminal/common/scripts/shellIntegration-profile.zsh'),
-				dest: path.join(zdotdir, '.zprofile')
-			});
-			filesToCopy.push({
-				source: path.join(appRoot, 'out/vs/workbench/contrib/terminal/common/scripts/shellIntegration-env.zsh'),
-				dest: path.join(zdotdir, '.zshenv')
-			});
-			filesToCopy.push({
-				source: path.join(appRoot, 'out/vs/workbench/contrib/terminal/common/scripts/shellIntegration-login.zsh'),
-				dest: path.join(zdotdir, '.zlogin')
-			});
-			if (wrapperArgs) { newArgs = [...wrapperArgs, ...newArgs]; }
-			return { type, newArgs, envMixin, filesToCopy };
+			case 'fish': {
+				if (!originalArgs || originalArgs.length === 0) {
+					newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.Fish);
+				} else if (areZshBashFishLoginArgs(originalArgs)) {
+					newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.FishLogin);
+				} else if (originalArgs === shellIntegrationArgs.get(ShellIntegrationExecutable.Fish) || originalArgs === shellIntegrationArgs.get(ShellIntegrationExecutable.FishLogin)) {
+					newArgs = originalArgs;
+				}
+				if (!newArgs) {
+					return { type: 'failure', reason: ShellIntegrationInjectionFailureReason.UnsupportedArgs };
+				}
+
+				// On fish, '$fish_user_paths' is always prepended to the PATH, for both login and non-login shells, so we need
+				// to apply the path prefix fix always, not only for login shells (see #232291)
+				addEnvMixinPathPrefix(options, envMixin, shell);
+
+				newArgs = [...newArgs]; // Shallow clone the array to avoid setting the default array
+				newArgs[newArgs.length - 1] = format(newArgs[newArgs.length - 1], appRoot);
+				injectionResult = { type, newArgs, envMixin };
+				break;
+			}
+			case 'pwsh':
+			case 'powershell': {
+				if (!originalArgs || arePwshImpliedArgs(originalArgs)) {
+					newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.Pwsh);
+				} else if (arePwshLoginArgs(originalArgs)) {
+					newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.PwshLogin);
+				}
+				if (!newArgs) {
+					return { type: 'failure', reason: ShellIntegrationInjectionFailureReason.UnsupportedArgs };
+				}
+				newArgs = [...newArgs]; // Shallow clone the array to avoid setting the default array
+				newArgs[newArgs.length - 1] = format(newArgs[newArgs.length - 1], appRoot, '');
+				envMixin['VSCODE_STABLE'] = productService.quality === 'stable' ? '1' : '0';
+				injectionResult = { type, newArgs, envMixin };
+				break;
+			}
+			case 'zsh': {
+				if (!originalArgs || originalArgs.length === 0) {
+					newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.Zsh);
+				} else if (areZshBashFishLoginArgs(originalArgs)) {
+					newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.ZshLogin);
+					addEnvMixinPathPrefix(options, envMixin, shell);
+				} else if (originalArgs === shellIntegrationArgs.get(ShellIntegrationExecutable.Zsh) || originalArgs === shellIntegrationArgs.get(ShellIntegrationExecutable.ZshLogin)) {
+					newArgs = originalArgs;
+				}
+				if (!newArgs) {
+					return { type: 'failure', reason: ShellIntegrationInjectionFailureReason.UnsupportedArgs };
+				}
+				newArgs = [...newArgs]; // Shallow clone the array to avoid setting the default array
+				newArgs[newArgs.length - 1] = format(newArgs[newArgs.length - 1], appRoot);
+
+				// Move .zshrc into $ZDOTDIR as the way to activate the script
+				let username: string;
+				try {
+					username = os.userInfo().username;
+				} catch {
+					username = 'unknown';
+				}
+
+				// Resolve the actual tmp directory so we can set the sticky bit
+				const realTmpDir = realpathSync(os.tmpdir());
+				const zdotdir = path.join(realTmpDir, `${username}-${productService.applicationName}-zsh`);
+
+				// Set directory permissions using octal notation:
+				// - 0o1700:
+				// - Sticky bit is set, preventing non-owners from deleting or renaming files within this directory (1)
+				// - Owner has full read (4), write (2), execute (1) permissions
+				// - Group has no permissions (0)
+				// - Others have no permissions (0)
+				if (!skipStickyBit) {
+					// skip for tests
+					try {
+						const chmodAsync = promisify(chmod);
+						await chmodAsync(zdotdir, 0o1700);
+					} catch (err) {
+						if (err.message.includes('ENOENT')) {
+							try {
+								mkdirSync(zdotdir);
+							} catch (err) {
+								logService.error(`Failed to create zdotdir at ${zdotdir}: ${err}`);
+								return { type: 'failure', reason: ShellIntegrationInjectionFailureReason.FailedToCreateTmpDir };
+							}
+							try {
+								const chmodAsync = promisify(chmod);
+								await chmodAsync(zdotdir, 0o1700);
+							} catch {
+								logService.error(`Failed to set sticky bit on ${zdotdir}: ${err}`);
+								return { type: 'failure', reason: ShellIntegrationInjectionFailureReason.FailedToSetStickyBit };
+							}
+						}
+						logService.error(`Failed to set sticky bit on ${zdotdir}: ${err}`);
+						return { type: 'failure', reason: ShellIntegrationInjectionFailureReason.FailedToSetStickyBit };
+					}
+				}
+				envMixin['ZDOTDIR'] = zdotdir;
+				const userZdotdir = env?.ZDOTDIR ?? os.homedir() ?? `~`;
+				envMixin['USER_ZDOTDIR'] = userZdotdir;
+				const filesToCopy: IShellIntegrationConfigInjection['filesToCopy'] = [];
+				filesToCopy.push({
+					source: path.join(appRoot, 'out/vs/workbench/contrib/terminal/common/scripts/shellIntegration-rc.zsh'),
+					dest: path.join(zdotdir, '.zshrc')
+				});
+				filesToCopy.push({
+					source: path.join(appRoot, 'out/vs/workbench/contrib/terminal/common/scripts/shellIntegration-profile.zsh'),
+					dest: path.join(zdotdir, '.zprofile')
+				});
+				filesToCopy.push({
+					source: path.join(appRoot, 'out/vs/workbench/contrib/terminal/common/scripts/shellIntegration-env.zsh'),
+					dest: path.join(zdotdir, '.zshenv')
+				});
+				filesToCopy.push({
+					source: path.join(appRoot, 'out/vs/workbench/contrib/terminal/common/scripts/shellIntegration-login.zsh'),
+					dest: path.join(zdotdir, '.zlogin')
+				});
+				injectionResult = { type, newArgs, envMixin, filesToCopy };
+				break;
+			}
+			default:
+				logService.warn(`Shell integration cannot be enabled for executable "${shellLaunchConfig.executable}" and args`, shellLaunchConfig.args);
+				return { type: 'failure', reason: ShellIntegrationInjectionFailureReason.UnsupportedShell };
 		}
 	}
-	logService.warn(`Shell integration cannot be enabled for executable "${shellLaunchConfig.executable}" and args`, shellLaunchConfig.args);
-	return { type: 'failure', reason: ShellIntegrationInjectionFailureReason.UnsupportedShell };
+
+	if (injectionResult && wrapperArgs && injectionResult.type === 'injection') {
+		injectionResult = {
+			...injectionResult,
+			newArgs: [...wrapperArgs, ...(injectionResult.newArgs || [])]
+		};
+	}
+
+	return injectionResult || { type: 'failure', reason: ShellIntegrationInjectionFailureReason.UnsupportedShell };
 }
 
 /**

--- a/src/vs/platform/terminal/node/terminalEnvironment.ts
+++ b/src/vs/platform/terminal/node/terminalEnvironment.ts
@@ -82,8 +82,8 @@ export async function getShellIntegrationInjection(
 
 	let originalArgs = shellLaunchConfig.args;
 	let wrapperArgs: string[] | undefined;
-	const executableBasename = path.basename(shellLaunchConfig.executable).toLowerCase();
-	let shell = process.platform === 'win32' ? executableBasename : executableBasename;
+	const executableBasename = path.basename(shellLaunchConfig.executable);
+	let shell = process.platform === 'win32' ? executableBasename.toLowerCase() : executableBasename;
 
 	if (Array.isArray(originalArgs) && originalArgs.length > 0) {
 		if (executableBasename === 'host-spawn') {
@@ -104,6 +104,9 @@ export async function getShellIntegrationInjection(
 		shell = shellLaunchConfig.shellType.toLowerCase();
 	}
 
+	// Normalize .exe to make matching cross-platform and settings-sync friendly
+	shell = shell.replace(/\.exe$/, '');
+
 	const appRoot = path.dirname(FileAccess.asFileUri('').fsPath);
 	const type = 'injection';
 	let newArgs: string[] | undefined;
@@ -120,7 +123,7 @@ export async function getShellIntegrationInjection(
 	const scopedDownShellEnvs = ['PATH', 'VIRTUAL_ENV', 'HOME', 'SHELL', 'PWD'];
 	if (shellLaunchConfig.shellIntegrationEnvironmentReporting) {
 		if (isWindows) {
-			const enableWindowsEnvReporting = options.windowsUseConptyDll || windowsBuildNumber >= 22631 && shell !== 'bash.exe';
+			const enableWindowsEnvReporting = options.windowsUseConptyDll || windowsBuildNumber >= 22631 && shell !== 'bash';
 			if (enableWindowsEnvReporting) {
 				envMixin['VSCODE_SHELL_ENV_REPORTING'] = scopedDownShellEnvs.join(',');
 			}
@@ -131,7 +134,7 @@ export async function getShellIntegrationInjection(
 
 	// Windows
 	if (isWindows) {
-		if (shell === 'pwsh.exe' || shell === 'powershell.exe') {
+		if (shell === 'pwsh' || shell === 'powershell') {
 			envMixin['VSCODE_A11Y_MODE'] = options.isScreenReaderOptimized ? '1' : '0';
 
 			if (!originalArgs || arePwshImpliedArgs(originalArgs)) {
@@ -146,7 +149,7 @@ export async function getShellIntegrationInjection(
 			newArgs[newArgs.length - 1] = format(newArgs[newArgs.length - 1], appRoot, '');
 			envMixin['VSCODE_STABLE'] = productService.quality === 'stable' ? '1' : '0';
 			injectionResult = { type, newArgs, envMixin };
-		} else if (shell === 'bash.exe') {
+		} else if (shell === 'bash') {
 			if (!originalArgs || originalArgs.length === 0) {
 				newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.Bash);
 			} else if (areZshBashFishLoginArgs(originalArgs)) {

--- a/src/vs/platform/terminal/node/terminalEnvironment.ts
+++ b/src/vs/platform/terminal/node/terminalEnvironment.ts
@@ -80,14 +80,28 @@ export async function getShellIntegrationInjection(
 		return { type: 'failure', reason: ShellIntegrationInjectionFailureReason.UnsupportedWindowsBuild };
 	}
 
-		const originalArgs = shellLaunchConfig.args;
-	let shell = process.platform === 'win32' ? path.basename(shellLaunchConfig.executable).toLowerCase() : path.basename(shellLaunchConfig.executable);
+	let originalArgs = shellLaunchConfig.args;
+	let wrapperArgs: string[] | undefined;
+	const executableBasename = path.basename(shellLaunchConfig.executable).toLowerCase();
+	let shell = process.platform === 'win32' ? executableBasename : executableBasename;
+
+	if (Array.isArray(originalArgs) && originalArgs.length > 0) {
+		if (executableBasename === 'host-spawn') {
+			wrapperArgs = [originalArgs[0]];
+			originalArgs = originalArgs.slice(1);
+			shell = path.basename(wrapperArgs[0]).toLowerCase();
+		} else if (executableBasename === 'flatpak-spawn') {
+			const wrappedShellIndex = originalArgs.findIndex(arg => !arg.startsWith('-'));
+			if (wrappedShellIndex >= 0) {
+				wrapperArgs = originalArgs.slice(0, wrappedShellIndex + 1);
+				originalArgs = originalArgs.slice(wrappedShellIndex + 1);
+				shell = path.basename(wrapperArgs[wrappedShellIndex]).toLowerCase();
+			}
+		}
+	}
+
 	if (shellLaunchConfig.shellType) {
 		shell = shellLaunchConfig.shellType.toLowerCase();
-	} else if (shell === "host-spawn" || shell === "flatpak-spawn") {
-		if (Array.isArray(originalArgs) && originalArgs.length > 0) {
-			shell = path.basename(originalArgs[0]).toLowerCase();
-		}
 	}
 
 	const appRoot = path.dirname(FileAccess.asFileUri('').fsPath);
@@ -120,7 +134,7 @@ export async function getShellIntegrationInjection(
 
 			if (!originalArgs || arePwshImpliedArgs(originalArgs)) {
 				newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.WindowsPwsh);
-    } else if (arePwshLoginArgs(originalArgs)) {
+			} else if (arePwshLoginArgs(originalArgs)) {
 				newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.WindowsPwshLogin);
 			}
 			if (!newArgs) {
@@ -129,11 +143,12 @@ export async function getShellIntegrationInjection(
 			newArgs = [...newArgs];
 			newArgs[newArgs.length - 1] = format(newArgs[newArgs.length - 1], appRoot, '');
 			envMixin['VSCODE_STABLE'] = productService.quality === 'stable' ? '1' : '0';
+			if (wrapperArgs) { newArgs = [...wrapperArgs, ...newArgs]; }
 			return { type, newArgs, envMixin };
-    } else if (shell === 'bash.exe') {
+		} else if (shell === 'bash.exe') {
 			if (!originalArgs || originalArgs.length === 0) {
 				newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.Bash);
-    } else if (areZshBashFishLoginArgs(originalArgs)) {
+			} else if (areZshBashFishLoginArgs(originalArgs)) {
 				envMixin['VSCODE_SHELL_LOGIN'] = '1';
 				addEnvMixinPathPrefix(options, envMixin, shell);
 				newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.Bash);
@@ -144,6 +159,7 @@ export async function getShellIntegrationInjection(
 			newArgs = [...newArgs]; // Shallow clone the array to avoid setting the default array
 			newArgs[newArgs.length - 1] = format(newArgs[newArgs.length - 1], appRoot);
 			envMixin['VSCODE_STABLE'] = productService.quality === 'stable' ? '1' : '0';
+			if (wrapperArgs) { newArgs = [...wrapperArgs, ...newArgs]; }
 			return { type, newArgs, envMixin };
 		}
 		logService.warn(`Shell integration cannot be enabled for executable "${shellLaunchConfig.executable}" and args`, shellLaunchConfig.args);
@@ -155,7 +171,7 @@ export async function getShellIntegrationInjection(
 		case 'bash': {
 			if (!originalArgs || originalArgs.length === 0) {
 				newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.Bash);
-    } else if (areZshBashFishLoginArgs(originalArgs)) {
+			} else if (areZshBashFishLoginArgs(originalArgs)) {
 				envMixin['VSCODE_SHELL_LOGIN'] = '1';
 				addEnvMixinPathPrefix(options, envMixin, shell);
 				newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.Bash);
@@ -166,14 +182,15 @@ export async function getShellIntegrationInjection(
 			newArgs = [...newArgs]; // Shallow clone the array to avoid setting the default array
 			newArgs[newArgs.length - 1] = format(newArgs[newArgs.length - 1], appRoot);
 			envMixin['VSCODE_STABLE'] = productService.quality === 'stable' ? '1' : '0';
+			if (wrapperArgs) { newArgs = [...wrapperArgs, ...newArgs]; }
 			return { type, newArgs, envMixin };
 		}
 		case 'fish': {
 			if (!originalArgs || originalArgs.length === 0) {
 				newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.Fish);
-    } else if (areZshBashFishLoginArgs(originalArgs)) {
+			} else if (areZshBashFishLoginArgs(originalArgs)) {
 				newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.FishLogin);
-    } else if (originalArgs === shellIntegrationArgs.get(ShellIntegrationExecutable.Fish) || originalArgs === shellIntegrationArgs.get(ShellIntegrationExecutable.FishLogin)) {
+			} else if (originalArgs === shellIntegrationArgs.get(ShellIntegrationExecutable.Fish) || originalArgs === shellIntegrationArgs.get(ShellIntegrationExecutable.FishLogin)) {
 				newArgs = originalArgs;
 			}
 			if (!newArgs) {
@@ -186,12 +203,14 @@ export async function getShellIntegrationInjection(
 
 			newArgs = [...newArgs]; // Shallow clone the array to avoid setting the default array
 			newArgs[newArgs.length - 1] = format(newArgs[newArgs.length - 1], appRoot);
+			if (wrapperArgs) { newArgs = [...wrapperArgs, ...newArgs]; }
 			return { type, newArgs, envMixin };
 		}
-		case 'pwsh': {
+		case 'pwsh':
+		case 'powershell': {
 			if (!originalArgs || arePwshImpliedArgs(originalArgs)) {
 				newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.Pwsh);
-    } else if (arePwshLoginArgs(originalArgs)) {
+			} else if (arePwshLoginArgs(originalArgs)) {
 				newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.PwshLogin);
 			}
 			if (!newArgs) {
@@ -200,15 +219,16 @@ export async function getShellIntegrationInjection(
 			newArgs = [...newArgs]; // Shallow clone the array to avoid setting the default array
 			newArgs[newArgs.length - 1] = format(newArgs[newArgs.length - 1], appRoot, '');
 			envMixin['VSCODE_STABLE'] = productService.quality === 'stable' ? '1' : '0';
+			if (wrapperArgs) { newArgs = [...wrapperArgs, ...newArgs]; }
 			return { type, newArgs, envMixin };
 		}
 		case 'zsh': {
 			if (!originalArgs || originalArgs.length === 0) {
 				newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.Zsh);
-    } else if (areZshBashFishLoginArgs(originalArgs)) {
+			} else if (areZshBashFishLoginArgs(originalArgs)) {
 				newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.ZshLogin);
 				addEnvMixinPathPrefix(options, envMixin, shell);
-    } else if (originalArgs === shellIntegrationArgs.get(ShellIntegrationExecutable.Zsh) || originalArgs === shellIntegrationArgs.get(ShellIntegrationExecutable.ZshLogin)) {
+			} else if (originalArgs === shellIntegrationArgs.get(ShellIntegrationExecutable.Zsh) || originalArgs === shellIntegrationArgs.get(ShellIntegrationExecutable.ZshLogin)) {
 				newArgs = originalArgs;
 			}
 			if (!newArgs) {
@@ -280,6 +300,7 @@ export async function getShellIntegrationInjection(
 				source: path.join(appRoot, 'out/vs/workbench/contrib/terminal/common/scripts/shellIntegration-login.zsh'),
 				dest: path.join(zdotdir, '.zlogin')
 			});
+			if (wrapperArgs) { newArgs = [...wrapperArgs, ...newArgs]; }
 			return { type, newArgs, envMixin, filesToCopy };
 		}
 	}

--- a/src/vs/platform/terminal/node/terminalEnvironment.ts
+++ b/src/vs/platform/terminal/node/terminalEnvironment.ts
@@ -80,8 +80,16 @@ export async function getShellIntegrationInjection(
 		return { type: 'failure', reason: ShellIntegrationInjectionFailureReason.UnsupportedWindowsBuild };
 	}
 
-	const originalArgs = shellLaunchConfig.args;
-	const shell = process.platform === 'win32' ? path.basename(shellLaunchConfig.executable).toLowerCase() : path.basename(shellLaunchConfig.executable);
+		const originalArgs = shellLaunchConfig.args;
+	let shell = process.platform === 'win32' ? path.basename(shellLaunchConfig.executable).toLowerCase() : path.basename(shellLaunchConfig.executable);
+	if (shellLaunchConfig.shellType) {
+		shell = shellLaunchConfig.shellType.toLowerCase();
+	} else if (shell === "host-spawn" || shell === "flatpak-spawn") {
+		if (Array.isArray(originalArgs) && originalArgs.length > 0) {
+			shell = path.basename(originalArgs[0]).toLowerCase();
+		}
+	}
+
 	const appRoot = path.dirname(FileAccess.asFileUri('').fsPath);
 	const type = 'injection';
 	let newArgs: string[] | undefined;
@@ -112,7 +120,7 @@ export async function getShellIntegrationInjection(
 
 			if (!originalArgs || arePwshImpliedArgs(originalArgs)) {
 				newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.WindowsPwsh);
-			} else if (arePwshLoginArgs(originalArgs)) {
+    } else if (arePwshLoginArgs(originalArgs)) {
 				newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.WindowsPwshLogin);
 			}
 			if (!newArgs) {
@@ -122,10 +130,10 @@ export async function getShellIntegrationInjection(
 			newArgs[newArgs.length - 1] = format(newArgs[newArgs.length - 1], appRoot, '');
 			envMixin['VSCODE_STABLE'] = productService.quality === 'stable' ? '1' : '0';
 			return { type, newArgs, envMixin };
-		} else if (shell === 'bash.exe') {
+    } else if (shell === 'bash.exe') {
 			if (!originalArgs || originalArgs.length === 0) {
 				newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.Bash);
-			} else if (areZshBashFishLoginArgs(originalArgs)) {
+    } else if (areZshBashFishLoginArgs(originalArgs)) {
 				envMixin['VSCODE_SHELL_LOGIN'] = '1';
 				addEnvMixinPathPrefix(options, envMixin, shell);
 				newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.Bash);
@@ -147,7 +155,7 @@ export async function getShellIntegrationInjection(
 		case 'bash': {
 			if (!originalArgs || originalArgs.length === 0) {
 				newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.Bash);
-			} else if (areZshBashFishLoginArgs(originalArgs)) {
+    } else if (areZshBashFishLoginArgs(originalArgs)) {
 				envMixin['VSCODE_SHELL_LOGIN'] = '1';
 				addEnvMixinPathPrefix(options, envMixin, shell);
 				newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.Bash);
@@ -163,9 +171,9 @@ export async function getShellIntegrationInjection(
 		case 'fish': {
 			if (!originalArgs || originalArgs.length === 0) {
 				newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.Fish);
-			} else if (areZshBashFishLoginArgs(originalArgs)) {
+    } else if (areZshBashFishLoginArgs(originalArgs)) {
 				newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.FishLogin);
-			} else if (originalArgs === shellIntegrationArgs.get(ShellIntegrationExecutable.Fish) || originalArgs === shellIntegrationArgs.get(ShellIntegrationExecutable.FishLogin)) {
+    } else if (originalArgs === shellIntegrationArgs.get(ShellIntegrationExecutable.Fish) || originalArgs === shellIntegrationArgs.get(ShellIntegrationExecutable.FishLogin)) {
 				newArgs = originalArgs;
 			}
 			if (!newArgs) {
@@ -183,7 +191,7 @@ export async function getShellIntegrationInjection(
 		case 'pwsh': {
 			if (!originalArgs || arePwshImpliedArgs(originalArgs)) {
 				newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.Pwsh);
-			} else if (arePwshLoginArgs(originalArgs)) {
+    } else if (arePwshLoginArgs(originalArgs)) {
 				newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.PwshLogin);
 			}
 			if (!newArgs) {
@@ -197,10 +205,10 @@ export async function getShellIntegrationInjection(
 		case 'zsh': {
 			if (!originalArgs || originalArgs.length === 0) {
 				newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.Zsh);
-			} else if (areZshBashFishLoginArgs(originalArgs)) {
+    } else if (areZshBashFishLoginArgs(originalArgs)) {
 				newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.ZshLogin);
 				addEnvMixinPathPrefix(options, envMixin, shell);
-			} else if (originalArgs === shellIntegrationArgs.get(ShellIntegrationExecutable.Zsh) || originalArgs === shellIntegrationArgs.get(ShellIntegrationExecutable.ZshLogin)) {
+    } else if (originalArgs === shellIntegrationArgs.get(ShellIntegrationExecutable.Zsh) || originalArgs === shellIntegrationArgs.get(ShellIntegrationExecutable.ZshLogin)) {
 				newArgs = originalArgs;
 			}
 			if (!newArgs) {

--- a/src/vs/platform/terminal/node/terminalEnvironment.ts
+++ b/src/vs/platform/terminal/node/terminalEnvironment.ts
@@ -104,6 +104,11 @@ export async function getShellIntegrationInjection(
 		shell = shellLaunchConfig.shellType.toLowerCase();
 	}
 
+	// When shellType is 'none', disable shell integration without logging a warning for unsupported shells.
+	if (shell === 'none') {
+		return { type: 'failure', reason: ShellIntegrationInjectionFailureReason.IgnoreShellIntegrationFlag };
+	}
+
 	// Normalize .exe to make matching cross-platform and settings-sync friendly
 	shell = shell.replace(/\.exe$/, '');
 

--- a/src/vs/platform/terminal/node/terminalEnvironment.ts
+++ b/src/vs/platform/terminal/node/terminalEnvironment.ts
@@ -283,9 +283,10 @@ export async function getShellIntegrationInjection(
 								logService.error(`Failed to set sticky bit on ${zdotdir}: ${err}`);
 								return { type: 'failure', reason: ShellIntegrationInjectionFailureReason.FailedToSetStickyBit };
 							}
+						} else {
+							logService.error(`Failed to set sticky bit on ${zdotdir}: ${err}`);
+							return { type: 'failure', reason: ShellIntegrationInjectionFailureReason.FailedToSetStickyBit };
 						}
-						logService.error(`Failed to set sticky bit on ${zdotdir}: ${err}`);
-						return { type: 'failure', reason: ShellIntegrationInjectionFailureReason.FailedToSetStickyBit };
 					}
 				}
 				envMixin['ZDOTDIR'] = zdotdir;

--- a/src/vs/platform/terminal/node/terminalProfiles.ts
+++ b/src/vs/platform/terminal/node/terminalProfiles.ts
@@ -265,6 +265,7 @@ async function getValidatedProfile(
 	validatedProfile.isAutoDetected = profile.isAutoDetected;
 	validatedProfile.icon = icon;
 	validatedProfile.color = profile.color;
+	validatedProfile.shellType = profile.shellType;
 	return validatedProfile;
 }
 

--- a/src/vs/platform/terminal/test/node/terminalEnvironment.test.ts
+++ b/src/vs/platform/terminal/test/node/terminalEnvironment.test.ts
@@ -42,7 +42,7 @@ suite('platform - terminalEnvironment', async () => {
 
                         test('when executable or shellType is "none"', async () => {
                                 strictEqual((await getShellIntegrationInjection({ executable: 'none', args: [] }, enabledProcessOptions, defaultEnvironment, logService, productService, true)).type, 'failure');
-                                strictEqual((await getShellIntegrationInjection({ executable: pwshExe, shellType: 'none', args: [] } as any, enabledProcessOptions, defaultEnvironment, logService, productService, true)).type, 'failure');
+                                strictEqual((await getShellIntegrationInjection({ executable: pwshExe, shellType: 'none', args: [] } as unknown as IShellLaunchConfig, enabledProcessOptions, defaultEnvironment, logService, productService, true)).type, 'failure');
                         });
 		// These tests are only expected to work on Windows 10 build 18309 and above
 		(getWindowsBuildNumberSync() < 18309 ? suite.skip : suite)('pwsh', async () => {

--- a/src/vs/platform/terminal/test/node/terminalEnvironment.test.ts
+++ b/src/vs/platform/terminal/test/node/terminalEnvironment.test.ts
@@ -291,7 +291,7 @@ suite('platform - terminalEnvironment', async () => {
 				strictEqual(injection.envMixin?.['VSCODE_SHELL_LOGIN'], '1');
 			});
 			(isWindows ? test.skip : test)('should respect a shellType=powershell override when executable=unknown-shell', async () => {
-				const result = await getShellIntegrationInjection({ executable: 'unknown-shell', shellType: 'powershell', args: ['-Command', 'echo'] }, enabledProcessOptions, defaultEnvironment, logService, productService, false);
+				const result = await getShellIntegrationInjection({ executable: 'unknown-shell', shellType: 'powershell', args: [] }, enabledProcessOptions, defaultEnvironment, logService, productService, false);
 				strictEqual(result.type, 'injection');
 				const injection = result as IShellIntegrationConfigInjection;
 				strictEqual(injection.newArgs?.some(arg => arg.includes('shellIntegration')), true);

--- a/src/vs/platform/terminal/test/node/terminalEnvironment.test.ts
+++ b/src/vs/platform/terminal/test/node/terminalEnvironment.test.ts
@@ -40,6 +40,10 @@ suite('platform - terminalEnvironment', async () => {
 			});
 		});
 
+                        test('when executable or shellType is "none"', async () => {
+                                strictEqual((await getShellIntegrationInjection({ executable: 'none', args: [] }, enabledProcessOptions, defaultEnvironment, logService, productService, true)).type, 'failure');
+                                strictEqual((await getShellIntegrationInjection({ executable: pwshExe, shellType: 'none', args: [] } as any, enabledProcessOptions, defaultEnvironment, logService, productService, true)).type, 'failure');
+                        });
 		// These tests are only expected to work on Windows 10 build 18309 and above
 		(getWindowsBuildNumberSync() < 18309 ? suite.skip : suite)('pwsh', async () => {
 			const expectedPs1 = process.platform === 'win32'
@@ -62,6 +66,9 @@ suite('platform - terminalEnvironment', async () => {
 					deepStrictEqualIgnoreStableVar(await getShellIntegrationInjection({ executable: pwshExe, args: [] }, enabledProcessOptions, defaultEnvironment, logService, productService, true), enabledExpectedResult);
 					deepStrictEqualIgnoreStableVar(await getShellIntegrationInjection({ executable: pwshExe, args: undefined }, enabledProcessOptions, defaultEnvironment, logService, productService, true), enabledExpectedResult);
 				});
+                                test('executable should be normalized to remove .exe', async () => {
+                                        deepStrictEqualIgnoreStableVar(await getShellIntegrationInjection({ executable: 'pwsh.exe', args: [] }, enabledProcessOptions, defaultEnvironment, logService, productService, true), enabledExpectedResult);
+                                });
 				suite('when no logo', async () => {
 					test('array - case insensitive', async () => {
 						deepStrictEqualIgnoreStableVar(await getShellIntegrationInjection({ executable: pwshExe, args: ['-NoLogo'] }, enabledProcessOptions, defaultEnvironment, logService, productService, true), enabledExpectedResult);

--- a/src/vs/platform/terminal/test/node/terminalEnvironment.test.ts
+++ b/src/vs/platform/terminal/test/node/terminalEnvironment.test.ts
@@ -268,6 +268,28 @@ suite('platform - terminalEnvironment', async () => {
 				strictEqual(customProcessOptions.shellIntegration.nonce, 'custom-nonce-12345');
 			});
 		});
+
+		suite('shellType auto-detection and overrides', async () => {
+			test('should auto-detect host-spawn wrapper', async () => {
+				const result = await getShellIntegrationInjection({ executable: '/app/bin/host-spawn', args: ['bash'] }, enabledProcessOptions, defaultEnvironment, logService, productService, false);
+				strictEqual(result.type, 'injection');
+				const injection = result as IShellIntegrationConfigInjection;
+				strictEqual(injection.newArgs?.[0], 'bash'); // The wrapperArg
+			});
+			test('should auto-detect flatpak-spawn wrapper', async () => {
+				const result = await getShellIntegrationInjection({ executable: 'flatpak-spawn', args: ['--host', 'bash'] }, enabledProcessOptions, defaultEnvironment, logService, productService, false);
+				strictEqual(result.type, 'injection');
+				const injection = result as IShellIntegrationConfigInjection;
+				strictEqual(injection.newArgs?.[0], '--host'); // The wrapperArg
+				strictEqual(injection.newArgs?.[1], 'bash'); // The wrapperArg
+			});
+			test('should respect a shellType=bash override when executable=unknown-shell', async () => {
+				const result = await getShellIntegrationInjection({ executable: 'unknown-shell', shellType: 'bash', args: ['-l'] }, enabledProcessOptions, defaultEnvironment, logService, productService, false);
+				strictEqual(result.type, 'injection');
+				const injection = result as IShellIntegrationConfigInjection;
+				strictEqual(injection.envMixin?.['VSCODE_SHELL_LOGIN'], '1');
+			});
+		});
 	});
 
 	suite('sanitizeEnvForLogging', () => {

--- a/src/vs/platform/terminal/test/node/terminalEnvironment.test.ts
+++ b/src/vs/platform/terminal/test/node/terminalEnvironment.test.ts
@@ -5,6 +5,7 @@
 
 /* eslint-disable local/code-no-test-async-suite */
 import { deepStrictEqual, ok, strictEqual } from 'assert';
+import { isWindows } from '../../../../base/common/platform.js';
 import { homedir, userInfo } from 'os';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { NullLogService } from '../../../log/common/log.js';
@@ -270,24 +271,30 @@ suite('platform - terminalEnvironment', async () => {
 		});
 
 		suite('shellType auto-detection and overrides', async () => {
-			test('should auto-detect host-spawn wrapper', async () => {
+			(isWindows ? test.skip : test)('should auto-detect host-spawn wrapper', async () => {
 				const result = await getShellIntegrationInjection({ executable: '/app/bin/host-spawn', args: ['bash'] }, enabledProcessOptions, defaultEnvironment, logService, productService, false);
 				strictEqual(result.type, 'injection');
 				const injection = result as IShellIntegrationConfigInjection;
 				strictEqual(injection.newArgs?.[0], 'bash'); // The wrapperArg
 			});
-			test('should auto-detect flatpak-spawn wrapper', async () => {
+			(isWindows ? test.skip : test)('should auto-detect flatpak-spawn wrapper', async () => {
 				const result = await getShellIntegrationInjection({ executable: 'flatpak-spawn', args: ['--host', 'bash'] }, enabledProcessOptions, defaultEnvironment, logService, productService, false);
 				strictEqual(result.type, 'injection');
 				const injection = result as IShellIntegrationConfigInjection;
 				strictEqual(injection.newArgs?.[0], '--host'); // The wrapperArg
 				strictEqual(injection.newArgs?.[1], 'bash'); // The wrapperArg
 			});
-			test('should respect a shellType=bash override when executable=unknown-shell', async () => {
+			(isWindows ? test.skip : test)('should respect a shellType=bash override when executable=unknown-shell', async () => {
 				const result = await getShellIntegrationInjection({ executable: 'unknown-shell', shellType: 'bash', args: ['-l'] }, enabledProcessOptions, defaultEnvironment, logService, productService, false);
 				strictEqual(result.type, 'injection');
 				const injection = result as IShellIntegrationConfigInjection;
 				strictEqual(injection.envMixin?.['VSCODE_SHELL_LOGIN'], '1');
+			});
+			(isWindows ? test.skip : test)('should respect a shellType=powershell override when executable=unknown-shell', async () => {
+				const result = await getShellIntegrationInjection({ executable: 'unknown-shell', shellType: 'powershell', args: ['-Command', 'echo'] }, enabledProcessOptions, defaultEnvironment, logService, productService, false);
+				strictEqual(result.type, 'injection');
+				const injection = result as IShellIntegrationConfigInjection;
+				strictEqual(injection.newArgs?.some(arg => arg.includes('shellIntegration')), true);
 			});
 		});
 	});

--- a/src/vs/server/node/remoteTerminalChannel.ts
+++ b/src/vs/server/node/remoteTerminalChannel.ts
@@ -207,6 +207,7 @@ export class RemoteTerminalChannel extends Disposable implements IServerChannel<
 			forceShellIntegration: args.shellLaunchConfig.forceShellIntegration,
 			tabActions: args.shellLaunchConfig.tabActions,
 			shellIntegrationEnvironmentReporting: args.shellLaunchConfig.shellIntegrationEnvironmentReporting,
+			shellType: args.shellLaunchConfig.shellType
 		};
 
 

--- a/src/vs/workbench/contrib/terminal/browser/remoteTerminalBackend.ts
+++ b/src/vs/workbench/contrib/terminal/browser/remoteTerminalBackend.ts
@@ -194,6 +194,7 @@ class RemoteTerminalBackend extends BaseTerminalBackend implements ITerminalBack
 			forceShellIntegration: shellLaunchConfig.forceShellIntegration,
 			tabActions: shellLaunchConfig.tabActions,
 			shellIntegrationEnvironmentReporting: shellLaunchConfig.shellIntegrationEnvironmentReporting,
+			shellType: shellLaunchConfig.shellType,
 		};
 		const activeWorkspaceRootUri = getWorkspaceForTerminal(shellLaunchConfig.cwd, this._workspaceContextService, this._historyService)?.uri;
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalProfileResolverService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProfileResolverService.ts
@@ -133,7 +133,6 @@ export abstract class BaseTerminalProfileResolverService extends Disposable impl
 			shellLaunchConfig.shellType = resolvedProfile.shellType;
 		}
 
-
 		// Verify the icon is valid, and fallback correctly to the generic terminal id if there is
 		// an issue
 		const resource = shellLaunchConfig === undefined || isString(shellLaunchConfig.cwd) ? undefined : shellLaunchConfig.cwd;

--- a/src/vs/workbench/contrib/terminal/browser/terminalProfileResolverService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProfileResolverService.ts
@@ -129,6 +129,10 @@ export abstract class BaseTerminalProfileResolverService extends Disposable impl
 				shellLaunchConfig.env = resolvedProfile.env;
 			}
 		}
+		if (resolvedProfile.shellType) {
+			shellLaunchConfig.shellType = resolvedProfile.shellType;
+		}
+
 
 		// Verify the icon is valid, and fallback correctly to the generic terminal id if there is
 		// an issue

--- a/src/vs/workbench/contrib/terminal/browser/terminalProfileService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProfileService.ts
@@ -307,6 +307,7 @@ function profilesEqual(one: ITerminalProfile, other: ITerminalProfile) {
 		one.isAutoDetected === other.isAutoDetected &&
 		one.isDefault === other.isDefault &&
 		one.overrideName === other.overrideName &&
+		one.shellType === other.shellType &&
 		one.path === other.path;
 }
 

--- a/src/vs/workbench/contrib/terminal/test/node/terminalProfiles.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/node/terminalProfiles.test.ts
@@ -5,7 +5,7 @@
 
 import { deepStrictEqual, fail, ok, strictEqual } from 'assert';
 import { isWindows } from '../../../../../base/common/platform.js';
-import { ITerminalProfile, ProfileSource } from '../../../../../platform/terminal/common/terminal.js';
+import { ITerminalProfile, ProfileSource, GeneralShellType, PosixShellType } from '../../../../../platform/terminal/common/terminal.js';
 import { ITerminalConfiguration, ITerminalProfiles } from '../../common/terminal.js';
 import { detectAvailableProfiles, IFsProvider } from '../../../../../platform/terminal/node/terminalProfiles.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
@@ -148,6 +148,23 @@ suite('Workbench - TerminalProfiles', () => {
 					strictEqual(profiles[0].profileName, 'PowerShell');
 				});
 			});
+                        test('should preserve shellType from profile', async () => {
+                                const config = {
+                                        profiles: {
+                                                windows: {
+                                                        'PowerShell': { path: 'C:\\pwsh.exe', shellType: GeneralShellType.PowerShell }
+                                                },
+                                                linux: {},
+                                                osx: {}
+                                        },
+                                        useWslProfiles: false
+                                } as ITestTerminalConfig as ITerminalConfiguration;
+                                const fsProvider = createFsProvider(['C:\\pwsh.exe']);
+                                const configurationService = new TestConfigurationService({ terminal: { integrated: config } });
+                                const profiles = await detectAvailableProfiles(undefined, undefined, false, configurationService, process.env, fsProvider, undefined, undefined, undefined);
+                                const expected = [{ profileName: 'PowerShell', path: 'C:\\pwsh.exe', isDefault: true, shellType: GeneralShellType.PowerShell }];
+                                profilesEqual(profiles, expected);
+                        });
 		} else {
 			const absoluteConfig = ({
 				profiles: {
@@ -220,6 +237,28 @@ suite('Workbench - TerminalProfiles', () => {
 				];
 				profilesEqual(profiles, expected);
 			});
+
+                        test('should preserve shellType from profile', async () => {
+                                const config = {
+                                        profiles: {
+                                                windows: {},
+                                                linux: {
+                                                        'fakeshell1': { path: '/bin/fakeshell1', shellType: PosixShellType.Sh }
+                                                },
+                                                osx: {
+                                                        'fakeshell1': { path: '/bin/fakeshell1', shellType: PosixShellType.Sh }
+                                                }
+                                        },
+                                        useWslProfiles: false
+                                } as ITestTerminalConfig as ITerminalConfiguration;
+                                const fsProvider = createFsProvider(['/bin/fakeshell1']);
+                                const configurationService = new TestConfigurationService({ terminal: { integrated: config } });
+                                const profiles = await detectAvailableProfiles(undefined, undefined, false, configurationService, process.env, fsProvider, undefined, undefined, undefined);
+                                const expected: ITerminalProfile[] = [
+                                        { profileName: 'fakeshell1', path: '/bin/fakeshell1', isDefault: true, shellType: PosixShellType.Sh }
+                                ];
+                                profilesEqual(profiles, expected);
+                        });
 		}
 	});
 


### PR DESCRIPTION
This introduces a `shellType` config option and auto-detects `flatpak-spawn`/`host-spawn` in shell integration logic.

Fixes:
- microsoft/vscode#316713

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
