### PR TITLE
Dispose ConversationFeature in sanity test teardown

### DIFF
--- a/extensions/copilot/src/extension/test/vscode-node/sanity.sanity-test.ts
+++ b/extensions/copilot/src/extension/test/vscode-node/sanity.sanity-test.ts
@@ -89,7 +89,7 @@ suite('Copilot Chat Sanity Test', function () {
 				const conversation = conversationStore.getConversation(result2.metadata.responseId);
 				assert.ok(conversation, 'Expected conversation to be available');
 			} finally {
-				conversationFeature.activated = false;
+				conversationFeature.dispose();
 			}
 		});
 	});
@@ -132,7 +132,7 @@ suite('Copilot Chat Sanity Test', function () {
 				const conversation = conversationStore.getConversation(result2.metadata.responseId);
 				assert.ok(conversation, 'Expected conversation to be available');
 			} finally {
-				conversationFeature.activated = false;
+				conversationFeature.dispose();
 			}
 		});
 	});
@@ -153,7 +153,7 @@ suite('Copilot Chat Sanity Test', function () {
 				await interactiveSession.getResult();
 				assert.ok(progressReport.currentProgress);
 			} finally {
-				conversationFeature.activated = false;
+				conversationFeature.dispose();
 			}
 		});
 	});
@@ -216,7 +216,7 @@ suite('Copilot Chat Sanity Test', function () {
 				const text = await textPromise;
 				assert.ok(text.length > 0);
 			} finally {
-				conversationFeature.activated = false;
+				conversationFeature.dispose();
 				r.dispose();
 			}
 		});


### PR DESCRIPTION
Replace `conversationFeature.activated = false;` with `conversationFeature.dispose();` in each per-test `finally` block of the Copilot Chat Sanity Test suite.

The previous teardown only flipped the `activated` setter, which clears `_activatedDisposables` (commands, terminal quick-fix providers, participant registrations, etc.) but leaves `_disposables` intact. `_disposables` holds the two `onDidAuthenticationChange` listeners that each test instance subscribes to. Across retries those listeners accumulate on the shared `IAuthenticationService`, and on an auth-token oscillation they can re-trigger registration of the global `copilot-chat.fixWithCopilot` terminal quick-fix provider, surfacing as a flaky "already registered" failure.

`dispose()` is a strict superset of `activated = false` — it clears both stores. Each `ConversationFeature` instance's disposables are per-listener / per-registration (verified against `IAuthenticationService.onDidAuthenticationChange` and `vscode.window.registerTerminalQuickFixProvider`), so disposing the test-owned instance does not affect the contribution-registered `ConversationFeature` from the extension activation path.

No test reuses `conversationFeature` after its `finally` block.