### PR TITLE
Reset Copilot utility model cache and force one retry when CAPI omits chat fallback

### DIFF
--- a/extensions/copilot/src/platform/endpoint/node/modelMetadataFetcher.ts
+++ b/extensions/copilot/src/platform/endpoint/node/modelMetadataFetcher.ts
@@ -82,6 +82,7 @@ export class ModelMetadataFetcher extends Disposable implements IModelMetadataFe
 	private _completionsFamilyMap: Map<string, IModelAPIResponse[]> = new Map();
 	private _copilotUtilityModel: IModelAPIResponse | undefined;
 	private _lastFetchTime: number = 0;
+	private _hasForcedUtilityModelRetry: boolean = false;
 	private readonly _taskSingler = new TaskSingler<IModelAPIResponse | undefined | void>();
 	private _lastFetchError: any;
 
@@ -106,10 +107,12 @@ export class ModelMetadataFetcher extends Disposable implements IModelMetadataFe
 			// Only clear the family map if the copilot token is undefined, as this means the user has logged out and we should clear the models, otherwise we want to keep the old models around until we get a new list
 			if (this._authService.copilotToken === undefined) {
 				this._familyMap.clear();
+				this._copilotUtilityModel = undefined;
 			}
 
 			this._completionsFamilyMap.clear();
 			this._lastFetchTime = 0;
+			this._hasForcedUtilityModelRetry = false;
 		}));
 	}
 
@@ -172,9 +175,13 @@ export class ModelMetadataFetcher extends Disposable implements IModelMetadataFe
 
 	public async getCopilotUtilityModel(): Promise<IChatModelInformation> {
 		await this._taskSingler.getOrCreate(ModelMetadataFetcher.ALL_MODEL_KEY, this._fetchModels.bind(this));
-		if (!this._copilotUtilityModel && this._familyMap.size > 0) {
-			// Server returned models but did not flag a chat fallback; force one refresh
-			// before throwing so we are not stuck on a stale 10-minute cache window.
+		if (!this._copilotUtilityModel && this._familyMap.size > 0 && !this._hasForcedUtilityModelRetry) {
+			// Server returned models but did not flag a chat fallback. Force one refresh
+			// before throwing; gated so a persistent server misconfiguration cannot storm CAPI.
+			// The flag is cleared on auth change and on fetch failure so a recovered server
+			// can be retried later.
+			this._hasForcedUtilityModelRetry = true;
+			this._logService.warn('Utility model unset after initial fetch; forcing one refresh');
 			await this._taskSingler.getOrCreate(ModelMetadataFetcher.ALL_MODEL_KEY, () => this._fetchModels(true));
 		}
 		const resolvedModel = this._copilotUtilityModel;
@@ -301,6 +308,7 @@ export class ModelMetadataFetcher extends Disposable implements IModelMetadataFe
 			this._logService.error(e, `Failed to fetch models (${requestId})`);
 			this._lastFetchError = e;
 			this._lastFetchTime = 0;
+			this._hasForcedUtilityModelRetry = false;
 		}
 	}
 

--- a/extensions/copilot/src/platform/endpoint/node/modelMetadataFetcher.ts
+++ b/extensions/copilot/src/platform/endpoint/node/modelMetadataFetcher.ts
@@ -172,6 +172,11 @@ export class ModelMetadataFetcher extends Disposable implements IModelMetadataFe
 
 	public async getCopilotUtilityModel(): Promise<IChatModelInformation> {
 		await this._taskSingler.getOrCreate(ModelMetadataFetcher.ALL_MODEL_KEY, this._fetchModels.bind(this));
+		if (!this._copilotUtilityModel && this._familyMap.size > 0) {
+			// Server returned models but did not flag a chat fallback; force one refresh
+			// before throwing so we are not stuck on a stale 10-minute cache window.
+			await this._taskSingler.getOrCreate(ModelMetadataFetcher.ALL_MODEL_KEY, () => this._fetchModels(true));
+		}
 		const resolvedModel = this._copilotUtilityModel;
 		if (!resolvedModel || !isChatModelInformation(resolvedModel)) {
 			throw new Error(await this._getErrorMessage('Unable to resolve Copilot utility chat model (server did not mark a chat fallback model)'));
@@ -272,6 +277,7 @@ export class ModelMetadataFetcher extends Disposable implements IModelMetadataFe
 			}
 
 			this._familyMap.clear();
+			this._copilotUtilityModel = undefined;
 
 			const data: IModelAPIResponse[] = (await response.json()).data;
 			this._requestLogger.logModelListCall(requestId, requestMetadata, data);

--- a/extensions/copilot/src/platform/endpoint/node/modelMetadataFetcher.ts
+++ b/extensions/copilot/src/platform/endpoint/node/modelMetadataFetcher.ts
@@ -108,11 +108,11 @@ export class ModelMetadataFetcher extends Disposable implements IModelMetadataFe
 			if (this._authService.copilotToken === undefined) {
 				this._familyMap.clear();
 				this._copilotUtilityModel = undefined;
+				this._hasForcedUtilityModelRetry = false;
 			}
 
 			this._completionsFamilyMap.clear();
 			this._lastFetchTime = 0;
-			this._hasForcedUtilityModelRetry = false;
 		}));
 	}
 
@@ -176,10 +176,7 @@ export class ModelMetadataFetcher extends Disposable implements IModelMetadataFe
 	public async getCopilotUtilityModel(): Promise<IChatModelInformation> {
 		await this._taskSingler.getOrCreate(ModelMetadataFetcher.ALL_MODEL_KEY, this._fetchModels.bind(this));
 		if (!this._copilotUtilityModel && this._familyMap.size > 0 && !this._hasForcedUtilityModelRetry) {
-			// Server returned models but did not flag a chat fallback. Force one refresh
-			// before throwing; gated so a persistent server misconfiguration cannot storm CAPI.
-			// The flag is cleared on auth change and on fetch failure so a recovered server
-			// can be retried later.
+			// One-shot retry per auth epoch: avoids storming CAPI on persistent server misconfig.
 			this._hasForcedUtilityModelRetry = true;
 			this._logService.warn('Utility model unset after initial fetch; forcing one refresh');
 			await this._taskSingler.getOrCreate(ModelMetadataFetcher.ALL_MODEL_KEY, () => this._fetchModels(true));

--- a/extensions/copilot/src/platform/endpoint/node/modelMetadataFetcher.ts
+++ b/extensions/copilot/src/platform/endpoint/node/modelMetadataFetcher.ts
@@ -175,7 +175,7 @@ export class ModelMetadataFetcher extends Disposable implements IModelMetadataFe
 
 	public async getCopilotUtilityModel(): Promise<IChatModelInformation> {
 		await this._taskSingler.getOrCreate(ModelMetadataFetcher.ALL_MODEL_KEY, this._fetchModels.bind(this));
-		if (!this._copilotUtilityModel && this._familyMap.size > 0 && !this._hasForcedUtilityModelRetry) {
+		if (!this._copilotUtilityModel && this._familyMap.size > 0 && !this._hasForcedUtilityModelRetry && this._envService.isActive) {
 			// One-shot retry per auth epoch: avoids storming CAPI on persistent server misconfig.
 			this._hasForcedUtilityModelRetry = true;
 			this._logService.warn('Utility model unset after initial fetch; forcing one refresh');
@@ -281,6 +281,7 @@ export class ModelMetadataFetcher extends Disposable implements IModelMetadataFe
 			}
 
 			this._familyMap.clear();
+			this._completionsFamilyMap.clear();
 			this._copilotUtilityModel = undefined;
 
 			const data: IModelAPIResponse[] = (await response.json()).data;

--- a/extensions/copilot/src/platform/endpoint/node/modelMetadataFetcher.ts
+++ b/extensions/copilot/src/platform/endpoint/node/modelMetadataFetcher.ts
@@ -300,6 +300,9 @@ export class ModelMetadataFetcher extends Disposable implements IModelMetadataFe
 				familyMap.get(family)?.push(model);
 			}
 			this._lastFetchError = undefined;
+			if (this._copilotUtilityModel) {
+				this._hasForcedUtilityModelRetry = false;
+			}
 			this._onDidModelRefresh.fire();
 		} catch (e) {
 			this._logService.error(e, `Failed to fetch models (${requestId})`);

--- a/extensions/copilot/src/platform/endpoint/node/modelMetadataFetcher.ts
+++ b/extensions/copilot/src/platform/endpoint/node/modelMetadataFetcher.ts
@@ -175,11 +175,17 @@ export class ModelMetadataFetcher extends Disposable implements IModelMetadataFe
 
 	public async getCopilotUtilityModel(): Promise<IChatModelInformation> {
 		await this._taskSingler.getOrCreate(ModelMetadataFetcher.ALL_MODEL_KEY, this._fetchModels.bind(this));
-		if (!this._copilotUtilityModel && this._familyMap.size > 0 && !this._hasForcedUtilityModelRetry && this._envService.isActive) {
-			// One-shot retry per auth epoch: avoids storming CAPI on persistent server misconfig.
-			this._hasForcedUtilityModelRetry = true;
-			this._logService.warn('Utility model unset after initial fetch; forcing one refresh');
-			await this._taskSingler.getOrCreate(ModelMetadataFetcher.ALL_MODEL_KEY, () => this._fetchModels(true));
+		if (!this._copilotUtilityModel && this._familyMap.size > 0 && this._envService.isActive) {
+			// One-shot retry per auth epoch: gated inside the factory so concurrent callers
+			// coalesce on the same forced fetch via TaskSingler instead of falling through.
+			await this._taskSingler.getOrCreate(ModelMetadataFetcher.ALL_MODEL_KEY, async () => {
+				if (this._hasForcedUtilityModelRetry) {
+					return;
+				}
+				this._hasForcedUtilityModelRetry = true;
+				this._logService.warn('Utility model unset after initial fetch; forcing one refresh');
+				await this._fetchModels(true);
+			});
 		}
 		const resolvedModel = this._copilotUtilityModel;
 		if (!resolvedModel || !isChatModelInformation(resolvedModel)) {


### PR DESCRIPTION
Fix a caching bug in `ModelMetadataFetcher` that can lock the Copilot utility chat model into a permanently-unresolvable state for up to 10 minutes after a single CAPI `/models` response that doesn't flag any model with `is_chat_fallback: true`.

### Problem

`_copilotUtilityModel` is only ever assigned inside `_fetchModels` when a model has `is_chat_fallback === true`. It is never cleared. Combined with `_shouldRefreshModels()`, which short-circuits while `_familyMap.size > 0` and `_lastFetchTime` is within the 10-minute window, a single bad response (or a 429 short-circuit while the cache is fresh) leaves `getCopilotUtilityModel()` throwing `"Unable to resolve Copilot utility chat model (server did not mark a chat fallback model)"` until the cache expires.

This has been a contributing source of sanity-test flakes in CI.

### Fix

Two complementary changes:

**1. Reset `_copilotUtilityModel = undefined` adjacent to `_familyMap.clear()` in `_fetchModels`.**

This makes `_copilotUtilityModel` a derived value of the current response rather than a sticky field that accumulates across fetches. The pattern now matches what `_fetchModels` already does for `_familyMap` — clear, then repopulate from the current response.

Without the reset:
- If a previous fetch set `_copilotUtilityModel = ModelA` and the current response no longer flags any model as the fallback, we'd keep serving the stale `ModelA` for the utility endpoint indefinitely.
- The cache would lie about what the server actually said.

The reset on its own does not fix the original flake (a first-ever bad response still leaves `_copilotUtilityModel` undefined), but it is correctness hygiene that the retry below relies on.

**2. Force one refresh in `getCopilotUtilityModel()` when models are cached but the utility model is missing.**

```ts
if (!this._copilotUtilityModel && this._familyMap.size > 0) {
    await this._taskSingler.getOrCreate(ALL_MODEL_KEY, () => this._fetchModels(true));
}
```

The `true` argument is the `force` parameter on `_fetchModels`, which bypasses the `_shouldRefreshModels()` cache check. Without `force`, the retry would no-op immediately because the bad response just populated `_familyMap` and set `_lastFetchTime = Date.now()`. With `force`, we guarantee a fresh CAPI request, rebuild `_familyMap`, and (thanks to change #1) repopulate `_copilotUtilityModel` if the server flags one this time.

The forced refresh is bounded to one call per `getCopilotUtilityModel` invocation and still flows through `TaskSingler`, so coalescing semantics are preserved.