### PR TITLE
Improving external ingest states messaging

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -5176,7 +5176,7 @@
 					},
 					"github.copilot.chat.workspace.codeSearchExternalIngest.enabled": {
 						"type": "boolean",
-						"default": false,
+						"default": true,
 						"markdownDescription": "%github.copilot.config.workspace.codeSearchExternalIngest.enabled%",
 						"tags": [
 							"advanced",

--- a/extensions/copilot/package.nls.json
+++ b/extensions/copilot/package.nls.json
@@ -175,7 +175,7 @@
 	"github.copilot.config.localIndex.enabled": "Enable local session tracking. When enabled, session data is tracked locally for /chronicle commands.",
 	"github.copilot.config.sessionSearch.cloudSync.enabled": "Enable cloud sync for session data. When enabled, session data is synced to your Copilot account for cross-device access.",
 	"github.copilot.config.sessionSearch.cloudSync.excludeRepositories": "Repository patterns to exclude from cloud sync. Use exact `owner/repo` names or glob patterns like `my-org/*`. Sessions from matching repos will only be stored locally.",
-	"github.copilot.config.workspace.codeSearchExternalIngest.enabled": "Enable external ingest for semantic codebase search in this workspace. External ingest availability is controlled by your Copilot policy.",
+	"github.copilot.config.workspace.codeSearchExternalIngest.enabled": "Enable external ingest for semantic codebase search in this workspace. This setting can be used to enable/disable external ingest, but your Copilot Enterprise or Copilot subscription policies ultimately control availability. [Learn more about external ingest policies](https://aka.ms/vscode-external-ingest-policy).",
 	"copilot.workspace.explain.description": "Explain how the code in your active editor works",
 	"copilot.workspace.edit.description": "Edit files in your workspace",
 	"copilot.workspace.review.description": "Review the selected code in your active editor",

--- a/extensions/copilot/src/extension/workspaceChunkSearch/vscode-node/workspaceIndexingStatus.ts
+++ b/extensions/copilot/src/extension/workspaceChunkSearch/vscode-node/workspaceIndexingStatus.ts
@@ -21,6 +21,17 @@ import { buildRemoteIndexCommandId, enableExternalIngestCommandId } from './comm
 const reauthenticateCommandId = '_copilot.workspaceIndex.signInAgain';
 
 const codebaseSemanticSearchDocsLink = 'https://aka.ms/vscode-copilot-workspace-remote-index';
+const externalIngestPolicyLink = 'https://aka.ms/vscode-external-ingest-policy';
+const enableExternalIngestCommandLink = `command:${enableExternalIngestCommandId}`;
+
+const enableExternalIngestCommandTitle = t('Enable External Ingest');
+const externalIngestPolicyDetail = t('External ingest is disabled by your organization\'s policy. [Learn more]({0})', externalIngestPolicyLink);
+const externalIngestPolicyNoReposDetail = t('External ingest is disabled by your organization\'s policy, and no external repositories were found. [Learn more]({0})', externalIngestPolicyLink);
+const externalIngestPolicyAvailableDetail = t('External ingest is disabled by your organization\'s policy. Results may be incomplete or out of date. [Learn more]({0})', externalIngestPolicyLink);
+const externalIngestDisabledInWorkspaceDetail = t`External ingest is disabled in this workspace.`;
+const externalIngestDisabledInWorkspaceNoReposDetail = t`External ingest is disabled in this workspace, and no external repositories were found.`;
+const enableExternalIngestDetail = t('External ingest is disabled in this workspace. [Enable external ingest?]({0} "{1}")', enableExternalIngestCommandLink, enableExternalIngestCommandTitle);
+const enableExternalIngestNoReposDetail = t('External ingest is disabled in this workspace, and no external repositories were found. [Enable external ingest?]({0} "{1}")', enableExternalIngestCommandLink, enableExternalIngestCommandTitle);
 
 interface WorkspaceIndexStateReporter {
 	readonly onDidChangeIndexState: Event<void>;
@@ -64,6 +75,9 @@ interface ChatStatusItemState {
 }
 
 const spinnerCodicon = '$(loading~spin)';
+const warningCodicon = '$(warning)';
+const errorCodicon = '$(error)';
+const checkCodicon = '$(check)';
 const statusTitle = t`Codebase Semantic Index`;
 
 export class ChatStatusWorkspaceIndexingStatus extends Disposable {
@@ -130,6 +144,7 @@ export class ChatStatusWorkspaceIndexingStatus extends Disposable {
 			case 'loaded': {
 				const externalIngestDisabledByPolicy = state.remoteIndexState.externalIngestEnablement === ExternalIngestEnablement.DisabledByPolicy;
 				const externalIngestDisabledInWorkspace = state.remoteIndexState.externalIngestEnablement === ExternalIngestEnablement.DisabledBySetting;
+				const noRepos = state.remoteIndexState.repos.length === 0;
 
 				// See if any repos are still being resolved
 				if (state.remoteIndexState.repos.some(repo => repo.status === CodeSearchRepoStatus.Resolving)) {
@@ -169,13 +184,14 @@ export class ChatStatusWorkspaceIndexingStatus extends Disposable {
 				if (externalIngestDisabledInWorkspace && !state.remoteIndexState.hasPromptedForExternalIngest) {
 					return this._writeStatusItem({
 						primary: {
-							message: t`External ingest off`,
+							message: t`Disabled`,
+							icon: noRepos ? errorCodicon : warningCodicon,
 						},
 						details: {
-							message: `[${t`Enable external ingest?`}](command:${enableExternalIngestCommandId} "${t('Enable External Ingest')}")`,
+							message: noRepos ? enableExternalIngestNoReposDetail : enableExternalIngestDetail,
 							busy: false,
 						},
-						tooltip: t`Enable external ingest to improve semantic search for files not covered by the codebase index. Availability is controlled by your Copilot policy.`,
+						tooltip: t`External ingest is disabled in this workspace.`,
 					});
 				}
 
@@ -220,10 +236,10 @@ export class ChatStatusWorkspaceIndexingStatus extends Disposable {
 					return this._writeStatusItem({
 						primary: {
 							message: t`Available`,
-							icon: '$(check)',
+							icon: warningCodicon,
 						},
 						details: {
-							message: t`May be incomplete or out of date`,
+							message: externalIngestPolicyAvailableDetail,
 							busy: false,
 						},
 						tooltip: t`Codebase semantic search is available from indexed repositories, but external ingest is disabled by your organization's policy. Results may be incomplete or out of date.`,
@@ -236,7 +252,7 @@ export class ChatStatusWorkspaceIndexingStatus extends Disposable {
 					return this._writeStatusItem({
 						primary: {
 							message: t`Not available`,
-							icon: '$(warning)',
+							icon: errorCodicon,
 						},
 						tooltip: t`This repository can't be indexed. It may be too large or not supported.`,
 					});
@@ -271,8 +287,12 @@ export class ChatStatusWorkspaceIndexingStatus extends Disposable {
 					return this._writeStatusItem({
 						primary: {
 							message: t`Ready`,
-							icon: '$(check)',
+							icon: externalIngestDisabledInWorkspace ? warningCodicon : checkCodicon,
 						},
+						details: externalIngestDisabledInWorkspace ? {
+							message: externalIngestDisabledInWorkspaceDetail,
+							busy: false,
+						} : undefined,
 						tooltip: t`Your index is up to date and being used to improve suggestions.`,
 					});
 				}
@@ -280,9 +300,14 @@ export class ChatStatusWorkspaceIndexingStatus extends Disposable {
 				if (externalIngestDisabledInWorkspace) {
 					return this._writeStatusItem({
 						primary: {
-							message: t`External ingest off`,
+							message: t`Disabled`,
+							icon: noRepos ? errorCodicon : warningCodicon,
 						},
-						tooltip: t`External ingest is disabled in this workspace. Availability is controlled by your Copilot policy.`,
+						details: {
+							message: noRepos ? externalIngestDisabledInWorkspaceNoReposDetail : externalIngestDisabledInWorkspaceDetail,
+							busy: false,
+						},
+						tooltip: t`External ingest is disabled in this workspace.`,
 					});
 				}
 
@@ -308,15 +333,26 @@ export class ChatStatusWorkspaceIndexingStatus extends Disposable {
 			}
 		}
 
+		const externalIngestDisabledByPolicy = state.remoteIndexState.externalIngestEnablement === ExternalIngestEnablement.DisabledByPolicy;
+		const externalIngestDisabledInWorkspace = state.remoteIndexState.externalIngestEnablement === ExternalIngestEnablement.DisabledBySetting;
+		const noRepos = state.remoteIndexState.repos.length === 0;
+
 		this._writeStatusItem({
 			primary: {
-				message: state.remoteIndexState.externalIngestEnablement === ExternalIngestEnablement.DisabledByPolicy ? t`Disabled by policy` : t`Not available`,
-				icon: '$(warning)',
+				message: externalIngestDisabledByPolicy || externalIngestDisabledInWorkspace ? t`Disabled` : t`Not available`,
+				icon: (externalIngestDisabledByPolicy || externalIngestDisabledInWorkspace) && !noRepos ? warningCodicon : errorCodicon,
 			},
-			details: undefined,
-			tooltip: state.remoteIndexState.externalIngestEnablement === ExternalIngestEnablement.DisabledByPolicy
+			details: externalIngestDisabledByPolicy || externalIngestDisabledInWorkspace ? {
+				message: externalIngestDisabledByPolicy
+					? noRepos ? externalIngestPolicyNoReposDetail : externalIngestPolicyDetail
+					: noRepos ? externalIngestDisabledInWorkspaceNoReposDetail : externalIngestDisabledInWorkspaceDetail,
+				busy: false,
+			} : undefined,
+			tooltip: externalIngestDisabledByPolicy
 				? t`External ingest is disabled by your organization's policy.`
-				: t`This repository can't be indexed. It may be too large or not supported.`,
+				: externalIngestDisabledInWorkspace
+					? t`External ingest is disabled in this workspace.`
+					: t`This repository can't be indexed. It may be too large or not supported.`,
 		});
 	}
 

--- a/extensions/copilot/src/platform/configuration/common/configurationService.ts
+++ b/extensions/copilot/src/platform/configuration/common/configurationService.ts
@@ -643,7 +643,7 @@ export namespace ConfigKey {
 		export const ProjectLabelsInline = defineAndMigrateExpSetting<boolean>('chat.advanced.projectLabels.inline', 'chat.projectLabels.inline', false);
 		export const WorkspaceMaxLocalIndexSize = defineAndMigrateExpSetting<number>('chat.advanced.workspace.maxLocalIndexSize', 'chat.workspace.maxLocalIndexSize', 100_000);
 		export const WorkspaceEnableCodeSearch = defineAndMigrateExpSetting<boolean>('chat.advanced.workspace.enableCodeSearch', 'chat.workspace.enableCodeSearch', true);
-		export const WorkspaceEnableCodeSearchExternalIngest = defineSetting<boolean>('chat.workspace.codeSearchExternalIngest.enabled', ConfigType.ExperimentBased, false, undefined, undefined, { experimentName: 'copilotchat.config.chat.advanced.workspace.codeSearchExternalIngest.enabled' });
+		export const WorkspaceEnableCodeSearchExternalIngest = defineSetting<boolean>('chat.workspace.codeSearchExternalIngest.enabled', ConfigType.ExperimentBased, true, undefined, undefined, { experimentName: 'copilotchat.config.chat.advanced.workspace.codeSearchExternalIngest.enabled' });
 		export const WorkspacePreferredEmbeddingsModel = defineAndMigrateExpSetting<string>('chat.advanced.workspace.preferredEmbeddingsModel', 'chat.workspace.preferredEmbeddingsModel', '');
 		export const NotebookAlternativeDocumentFormat = defineAndMigrateExpSetting<AlternativeNotebookFormat>('chat.advanced.notebook.alternativeFormat', 'chat.notebook.alternativeFormat', AlternativeNotebookFormat.xml);
 		export const UseAlternativeNESNotebookFormat = defineAndMigrateExpSetting<boolean>('chat.advanced.notebook.alternativeNESFormat.enabled', 'chat.notebook.alternativeNESFormat.enabled', false);

--- a/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.ts
@@ -422,9 +422,10 @@ export class ChatStatusDashboard extends DomWidget {
 			const headerLabel = typeof item.label === 'string' ? item.label : item.label.label;
 			let headerLink = typeof item.label === 'string' ? undefined : item.label.link;
 			let linkDescription = typeof item.label === 'string' ? undefined : item.label.helpText;
+			const section = this.element.appendChild($('div.contributed-section'));
 
 			// Single non-collapsible header row
-			const header = this.element.appendChild($('div.collapsible-header.non-collapsible'));
+			const header = section.appendChild($('div.collapsible-header.non-collapsible'));
 			header.appendChild($('span.collapsible-label', undefined, headerLabel));
 
 			// Info icon (replaces chevron) — shows helpText in a nested hover
@@ -466,7 +467,7 @@ export class ChatStatusDashboard extends DomWidget {
 
 			let detailEl: HTMLElement | undefined;
 			if (item.detail) {
-				detailEl = header.appendChild($('span.contributed-detail'));
+				detailEl = section.appendChild($('div.contributed-detail'));
 				this.renderTextPlus(detailEl, item.detail, sectionStore);
 			}
 
@@ -495,7 +496,7 @@ export class ChatStatusDashboard extends DomWidget {
 							detailEl = undefined;
 						}
 					} else if (e.entry.detail) {
-						detailEl = header.appendChild($('span.contributed-detail'));
+						detailEl = section.appendChild($('div.contributed-detail'));
 						this.renderTextPlus(detailEl, e.entry.detail, newStore);
 					}
 				}

--- a/src/vs/workbench/contrib/chat/browser/chatStatus/media/chatStatus.css
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus/media/chatStatus.css
@@ -43,6 +43,11 @@
 	cursor: default;
 }
 
+.chat-status-bar-entry-tooltip .contributed-section {
+	display: flex;
+	flex-direction: column;
+}
+
 .chat-status-bar-entry-tooltip .collapsible-header:focus {
 	outline: none;
 }
@@ -104,13 +109,12 @@
 
 .chat-status-bar-entry-tooltip .contributed-detail {
 	font-size: 12px;
+	line-height: 16px;
 	font-weight: 400;
 	color: var(--vscode-descriptionForeground);
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
 	min-width: 0;
-	flex-shrink: 1;
+	padding-bottom: 6px;
+	white-space: normal;
 }
 
 .chat-status-bar-entry-tooltip .collapsible-content {


### PR DESCRIPTION
Also turns the client side setting on by default. This setting is controlled by an experiment so it's already 100% enabled for individual users on recent VS Code version. For enterprise, the companies are controlling the rollout through a policy

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
