### PR TITLE
Remove old setting to toggle the mermaid markdown tool

### DIFF
--- a/extensions/mermaid-markdown-features/package.json
+++ b/extensions/mermaid-markdown-features/package.json
@@ -78,12 +78,6 @@
     "configuration": {
       "title": "%config.title%",
       "properties": {
-        "mermaid-markdown.enabled": {
-          "type": "boolean",
-          "default": true,
-          "description": "%config.enabled.description%",
-          "scope": "application"
-        },
         "markdown-mermaid.lightModeTheme": {
           "order": 0,
           "type": "string",
@@ -205,7 +199,7 @@
         "canBeReferencedInPrompt": true,
         "modelDescription": "Renders a Mermaid diagram from Mermaid.js markup.",
         "userDescription": "Render a Mermaid.js diagram from markup.",
-        "when": "config.mermaid-markdown.enabled",
+        "when": "chatSessionType == local",
         "inputSchema": {
           "type": "object",
           "properties": {

--- a/extensions/mermaid-markdown-features/package.nls.json
+++ b/extensions/mermaid-markdown-features/package.nls.json
@@ -5,7 +5,6 @@
 	"command.openInEditor.title": "Open Diagram in Editor",
 	"command.copySource.title": "Copy Diagram Source",
 	"config.title": "Mermaid",
-	"config.enabled.description": "Enable a tool for Mermaid diagram rendering in chat responses.",
 	"config.markdown-mermaid.lightModeTheme.description": "Default Mermaid theme for light mode.",
 	"config.markdown-mermaid.darkModeTheme.description": "Default Mermaid theme for dark mode.",
 	"config.markdown-mermaid.languages.description": "Default languages in Markdown.",


### PR DESCRIPTION
Instead you can now disable the tool itself, which is more consistent with the rest of our UX

Non-local session can use mermaid fenced code blocks