### PR TITLE
fix(search): alternative Go to Symbol in Workspace shortcut on web

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchActionsSymbol.ts
+++ b/src/vs/workbench/contrib/search/browser/searchActionsSymbol.ts
@@ -8,7 +8,8 @@ import { ServicesAccessor } from '../../../../platform/instantiation/common/inst
 import * as Constants from '../common/constants.js';
 import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
-import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
+import { KeyChord, KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
+import { IsWebContext } from '../../../../platform/contextkey/common/contextkeys.js';
 import { IQuickInputService } from '../../../../platform/quickinput/common/quickInput.js';
 
 //#region Actions
@@ -27,10 +28,21 @@ registerAction2(class ShowAllSymbolsAction extends Action2 {
 				mnemonicTitle: nls.localize({ key: 'miGotoSymbolInWorkspace', comment: ['&& denotes a mnemonic'] }, "Go to Symbol in &&Workspace..."),
 			},
 			f1: true,
-			keybinding: {
-				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyMod.CtrlCmd | KeyCode.KeyT
-			},
+			// Browsers handle Ctrl/Cmd+T (new tab). Use an alternate default on web (e.g. Codespaces).
+			// Avoid Ctrl+K T: it is used by notebook output collapse/expand with overlapping context.
+			// https://github.com/microsoft/vscode/issues/232381
+			keybinding: [
+				{
+					weight: KeybindingWeight.WorkbenchContrib,
+					primary: KeyMod.CtrlCmd | KeyCode.KeyT,
+					when: IsWebContext.toNegated()
+				},
+				{
+					weight: KeybindingWeight.WorkbenchContrib,
+					primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.KeyG),
+					when: IsWebContext
+				}
+			],
 			menu: {
 				id: MenuId.MenubarGoMenu,
 				group: '3_global_nav',


### PR DESCRIPTION
Ctrl/Cmd+T opens a new browser tab; keep it for desktop only. On web (Codespaces, vscode.dev) bind Go to Symbol in Workspace to Ctrl+K G.

Fixes #232381.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
