### PR TITLE
extensions: disable Disable Globally when extension is workspace-enabled only

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -1780,7 +1780,7 @@ export class DisableGloballyAction extends ExtensionAction {
 				return;
 			}
 			this.enabled = this.extension.state === ExtensionState.Installed
-				&& (this.extension.enablementState === EnablementState.EnabledGlobally || this.extension.enablementState === EnablementState.EnabledWorkspace)
+				&& this.extension.enablementState === EnablementState.EnabledGlobally
 				&& this.extensionEnablementService.canChangeEnablement(this.extension.local);
 		}
 	}

--- a/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsActions.test.ts
+++ b/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsActions.test.ts
@@ -908,6 +908,28 @@ suite('ExtensionsActions', () => {
 			});
 	});
 
+	test('Test DisableGloballyAction when the extension is only enabled for workspace', () => {
+		const local = aLocalExtension('a');
+		instantiationService.stub(IExtensionService, {
+			extensions: [toExtensionDescription(local)],
+			onDidChangeExtensions: Event.None,
+			whenInstalledExtensionsRegistered: () => Promise.resolve(true)
+		});
+
+		return instantiationService.get(IWorkbenchExtensionEnablementService).setEnablement([local], EnablementState.DisabledGlobally)
+			.then(() => instantiationService.get(IWorkbenchExtensionEnablementService).setEnablement([local], EnablementState.EnabledWorkspace))
+			.then(() => {
+				instantiationService.stubPromise(IExtensionManagementService, 'getInstalled', [local]);
+
+				return instantiationService.get(IExtensionsWorkbenchService).queryLocal()
+					.then(extensions => {
+						const testObject: ExtensionsActions.DisableGloballyAction = disposables.add(instantiationService.createInstance(ExtensionsActions.DisableGloballyAction));
+						testObject.extension = extensions[0];
+						assert.ok(!testObject.enabled);
+					});
+			});
+	});
+
 	test('Test DisableGloballyAction when extension is uninstalled', () => {
 		const gallery = aGalleryExtension('a');
 		instantiationService.stubPromise(IExtensionGalleryService, 'query', aPage(gallery));


### PR DESCRIPTION
Fixes #244138 

## Summary
`DisableGloballyAction` was enabled when an extension was `EnabledWorkspace`.
In that state, the extension is only enabled for the current workspace and is not globally enabled, so "Disable (Globally)" should not be available.

## Changes
- Updated `DisableGloballyAction.update()` to enable only when:
  - extension is installed
  - enablement state is `EnablementState.EnabledGlobally`
  - global enablement can be changed
- Added regression test:
  - `Test DisableGloballyAction when the extension is only enabled for workspace`

## Files
- src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
- src/vs/workbench/contrib/extensions/test/electron-browser/extensionsActions.test.ts

## Before / After
- Before: "Disable (Globally)" could be enabled for `EnabledWorkspace`.
- After: "Disable (Globally)" is enabled only for `EnabledGlobally`.

## Validation
- Targeted `DisableGloballyAction` tests pass, including the new regression case.