### PR TITLE
Restore agents-specific copilot approval picker, add Claude picker similarly

### DIFF
--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostClaudePermissionModePicker.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostClaudePermissionModePicker.ts
@@ -1,0 +1,96 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { localize } from '../../../../../nls.js';
+import { ActionListItemKind, IActionListItem } from '../../../../../platform/actionWidget/browser/actionList.js';
+import { IActionWidgetService } from '../../../../../platform/actionWidget/browser/actionWidget.js';
+import { ClaudeSessionConfigKey } from '../../../../../platform/agentHost/common/claudeSessionConfigKeys.js';
+import { SessionConfigPropertySchema } from '../../../../../platform/agentHost/common/state/protocol/commands.js';
+import { IOpenerService } from '../../../../../platform/opener/common/opener.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
+import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
+import { AgentHostSessionEnumPicker, IAgentHostSessionEnumPickerItem } from './agentHostModePicker.js';
+import { isWellKnownClaudePermissionModeSchema } from './agentHostPermissionPickerDelegate.js';
+
+const CLAUDE_PERMISSION_MODE_LEARN_MORE_URL = 'https://code.claude.com/docs/en/permission-modes#available-modes';
+const LEARN_MORE_VALUE = '__agentHostClaudePermissionModePicker.learnMore__';
+
+function getPermissionModeIcon(value: string | undefined): ThemeIcon | undefined {
+	switch (value) {
+		case 'default': return Codicon.shield;
+		case 'acceptEdits': return Codicon.edit;
+		case 'bypassPermissions': return Codicon.warning;
+		case 'plan': return Codicon.lightbulb;
+		default: return undefined;
+	}
+}
+
+export class AgentHostClaudePermissionModePicker extends AgentHostSessionEnumPicker {
+
+	protected readonly _property = ClaudeSessionConfigKey.PermissionMode;
+	protected readonly _pickerId = 'agentHostClaudePermissionModePicker';
+	protected readonly _telemetryId = 'NewChatAgentHostClaudePermissionModePicker';
+
+	constructor(
+		@IActionWidgetService actionWidgetService: IActionWidgetService,
+		@ISessionsManagementService sessionsManagementService: ISessionsManagementService,
+		@ISessionsProvidersService sessionsProvidersService: ISessionsProvidersService,
+		@ITelemetryService telemetryService: ITelemetryService,
+		@IOpenerService private readonly _openerService: IOpenerService,
+	) {
+		super(actionWidgetService, sessionsManagementService, sessionsProvidersService, telemetryService);
+	}
+
+	protected _isWellKnownSchema(schema: SessionConfigPropertySchema): boolean {
+		return isWellKnownClaudePermissionModeSchema(schema);
+	}
+
+	protected _getTriggerIcon(value: string | undefined): ThemeIcon | undefined {
+		return getPermissionModeIcon(value);
+	}
+
+	protected _getActionItemIcon(item: IAgentHostSessionEnumPickerItem): ThemeIcon | undefined {
+		return getPermissionModeIcon(item.value);
+	}
+
+	protected _getTriggerAriaLabel(label: string): string {
+		return localize('agentHostClaudePermissionModePicker.triggerAriaLabel', "Pick Approvals, {0}", label);
+	}
+
+	protected _getWidgetAriaLabel(): string {
+		return localize('agentHostClaudePermissionModePicker.ariaLabel', "Approvals Picker");
+	}
+
+	protected override _getFooterActionItems(): readonly IActionListItem<IAgentHostSessionEnumPickerItem>[] {
+		const learnMoreLabel = localize('permissions.learnMore', "Learn more about permissions");
+		return [
+			{
+				kind: ActionListItemKind.Separator,
+				label: '',
+			},
+			{
+				kind: ActionListItemKind.Action,
+				label: learnMoreLabel,
+				group: { title: '', icon: Codicon.blank },
+				item: {
+					value: LEARN_MORE_VALUE,
+					label: learnMoreLabel,
+				},
+			},
+		];
+	}
+
+	protected override _handleFooterActionItem(item: IAgentHostSessionEnumPickerItem): boolean {
+		if (item.value !== LEARN_MORE_VALUE) {
+			return false;
+		}
+		void this._openerService.open(URI.parse(CLAUDE_PERMISSION_MODE_LEARN_MORE_URL));
+		return true;
+	}
+}

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostModePicker.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostModePicker.ts
@@ -14,6 +14,7 @@ import { localize } from '../../../../../nls.js';
 import { ActionListItemKind, IActionListDelegate, IActionListItem } from '../../../../../platform/actionWidget/browser/actionList.js';
 import { IActionWidgetService } from '../../../../../platform/actionWidget/browser/actionWidget.js';
 import { SessionConfigKey } from '../../../../../platform/agentHost/common/sessionConfigKeys.js';
+import { SessionConfigPropertySchema } from '../../../../../platform/agentHost/common/state/protocol/commands.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { type IAgentHostSessionsProvider, isAgentHostProvider } from '../../../../common/agentHostSessionsProvider.js';
 import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
@@ -22,7 +23,7 @@ import { type ISessionsProvider } from '../../../../services/sessions/common/ses
 import { reportNewChatPickerClosed } from '../../../chat/browser/newChatPickerTelemetry.js';
 import { isWellKnownModeSchema } from './agentHostPermissionPickerDelegate.js';
 
-interface IModePickerItem {
+export interface IAgentHostSessionEnumPickerItem {
 	readonly value: string;
 	readonly label: string;
 	readonly description?: string;
@@ -38,23 +39,20 @@ function getModeIcon(value: string | undefined): ThemeIcon | undefined {
 }
 
 /**
- * Self-contained picker widget for the agent-host `mode` session-config
- * property (`interactive` / `plan` / `autopilot`).
- *
- * Mirrors the existing default-Copilot mode picker UX but is backed by the
- * active agent-host session's resolved config via
- * {@link IAgentHostSessionsProvider}. Renders nothing when the active
- * session does not advertise a {@link isWellKnownModeSchema well-known}
- * mode schema, so the generic per-property
- * {@link AgentHostSessionConfigPicker} can take over for non-conforming
- * agents.
+ * Shared active-session picker for well-known string-enum session config.
+ * Concrete subclasses provide the property key, schema guard, icon policy,
+ * and labels while this class owns the provider subscription and picker UI.
  */
-export class AgentHostModePicker extends Disposable {
+export abstract class AgentHostSessionEnumPicker extends Disposable {
 
 	private readonly _renderDisposables = this._register(new DisposableStore());
 	private readonly _providerListeners = this._register(new DisposableMap<string>());
 	private _slotElement: HTMLElement | undefined;
 	protected _triggerElement: HTMLElement | undefined;
+
+	protected abstract readonly _property: string;
+	protected abstract readonly _pickerId: string;
+	protected abstract readonly _telemetryId: string;
 
 	constructor(
 		@IActionWidgetService private readonly _actionWidgetService: IActionWidgetService,
@@ -118,7 +116,15 @@ export class AgentHostModePicker extends Disposable {
 		}
 	}
 
-	private _getActiveContext(): { provider: IAgentHostSessionsProvider; sessionId: string; currentValue: string; items: readonly IModePickerItem[] } | undefined {
+	protected abstract _isWellKnownSchema(schema: SessionConfigPropertySchema): boolean;
+	protected abstract _getTriggerIcon(value: string | undefined): ThemeIcon | undefined;
+	protected abstract _getActionItemIcon(item: IAgentHostSessionEnumPickerItem, currentValue: string): ThemeIcon | undefined;
+	protected abstract _getTriggerAriaLabel(label: string): string;
+	protected abstract _getWidgetAriaLabel(): string;
+	protected _getFooterActionItems(): readonly IActionListItem<IAgentHostSessionEnumPickerItem>[] { return []; }
+	protected _handleFooterActionItem(_item: IAgentHostSessionEnumPickerItem): boolean { return false; }
+
+	private _getActiveContext(): { provider: IAgentHostSessionsProvider; sessionId: string; currentValue: string; items: readonly IAgentHostSessionEnumPickerItem[] } | undefined {
 		const session = this._sessionsManagementService.activeSession.get();
 		if (!session) {
 			return undefined;
@@ -128,19 +134,19 @@ export class AgentHostModePicker extends Disposable {
 			return undefined;
 		}
 		const config = rawProvider.getSessionConfig(session.sessionId);
-		const schema = config?.schema.properties[SessionConfigKey.Mode];
-		if (!schema || !isWellKnownModeSchema(schema)) {
+		const schema = config?.schema.properties[this._property];
+		if (!schema || !this._isWellKnownSchema(schema)) {
 			return undefined;
 		}
 		const enumValues = schema.enum ?? [];
 		const enumLabels = schema.enumLabels ?? [];
 		const enumDescriptions = schema.enumDescriptions ?? [];
-		const items: IModePickerItem[] = enumValues.map((value, index) => ({
+		const items: IAgentHostSessionEnumPickerItem[] = enumValues.map((value, index) => ({
 			value,
 			label: enumLabels[index] ?? value,
 			description: enumDescriptions[index],
 		}));
-		const rawCurrent = config?.values[SessionConfigKey.Mode] ?? schema.default;
+		const rawCurrent = config?.values[this._property] ?? schema.default;
 		const currentValue = typeof rawCurrent === 'string' && enumValues.includes(rawCurrent) ? rawCurrent : enumValues[0] ?? '';
 		return { provider: rawProvider, sessionId: session.sessionId, currentValue, items };
 	}
@@ -162,7 +168,7 @@ export class AgentHostModePicker extends Disposable {
 		const item = ctx.items.find(i => i.value === ctx.currentValue);
 		const label = item?.label ?? ctx.currentValue;
 
-		const icon = getModeIcon(ctx.currentValue);
+		const icon = this._getTriggerIcon(ctx.currentValue);
 		if (icon) {
 			dom.append(this._triggerElement, renderIcon(icon));
 		}
@@ -171,7 +177,7 @@ export class AgentHostModePicker extends Disposable {
 		labelSpan.textContent = label;
 		dom.append(this._triggerElement, renderIcon(Codicon.chevronDown));
 
-		this._triggerElement.ariaLabel = localize('agentHostModePicker.triggerAriaLabel', "Pick Agent Mode, {0}", label);
+		this._triggerElement.ariaLabel = this._getTriggerAriaLabel(label);
 	}
 
 	protected _showPicker(): void {
@@ -184,34 +190,41 @@ export class AgentHostModePicker extends Disposable {
 		}
 
 		const triggerElement = this._triggerElement;
-		const actionItems: IActionListItem<IModePickerItem>[] = ctx.items.map(item => ({
+		const actionItems: IActionListItem<IAgentHostSessionEnumPickerItem>[] = ctx.items.map(item => ({
 			kind: ActionListItemKind.Action,
 			label: item.label,
 			description: item.description,
-			group: { title: '', icon: item.value === ctx.currentValue ? Codicon.check : Codicon.blank },
+			group: { title: '', icon: this._getActionItemIcon(item, ctx.currentValue) },
 			item,
 		}));
+		actionItems.push(...this._getFooterActionItems());
 
-		const delegate: IActionListDelegate<IModePickerItem> = {
+		const delegate: IActionListDelegate<IAgentHostSessionEnumPickerItem> = {
 			onSelect: item => {
 				this._actionWidgetService.hide();
+				if (this._handleFooterActionItem(item)) {
+					return;
+				}
+				if (!ctx.items.some(candidate => candidate.value === item.value)) {
+					return;
+				}
 				const previousItem = ctx.items.find(i => i.value === ctx.currentValue);
 				reportNewChatPickerClosed(this._telemetryService, {
-					id: 'NewChatAgentHostModePicker',
+					id: this._telemetryId,
 					optionIdBefore: ctx.currentValue,
 					optionIdAfter: item.value,
 					optionLabelBefore: previousItem?.label ?? ctx.currentValue,
 					optionLabelAfter: item.label,
 					isPII: false,
 				});
-				ctx.provider.setSessionConfigValue(ctx.sessionId, SessionConfigKey.Mode, item.value)
+				ctx.provider.setSessionConfigValue(ctx.sessionId, this._property, item.value)
 					.catch(() => { /* best-effort */ });
 			},
 			onHide: () => triggerElement.focus(),
 		};
 
-		this._actionWidgetService.show<IModePickerItem>(
-			'agentHostModePicker',
+		this._actionWidgetService.show<IAgentHostSessionEnumPickerItem>(
+			this._pickerId,
 			false,
 			actionItems,
 			delegate,
@@ -220,8 +233,39 @@ export class AgentHostModePicker extends Disposable {
 			[],
 			{
 				getAriaLabel: i => i.label ?? '',
-				getWidgetAriaLabel: () => localize('agentHostModePicker.ariaLabel', "Agent Mode Picker"),
+				getWidgetAriaLabel: () => this._getWidgetAriaLabel(),
 			},
 		);
+	}
+}
+
+/**
+ * Picker widget for the agent-host `mode` session-config property
+ * (`interactive` / `plan` / `autopilot`).
+ */
+export class AgentHostModePicker extends AgentHostSessionEnumPicker {
+
+	protected readonly _property = SessionConfigKey.Mode;
+	protected readonly _pickerId = 'agentHostModePicker';
+	protected readonly _telemetryId = 'NewChatAgentHostModePicker';
+
+	protected _isWellKnownSchema(schema: SessionConfigPropertySchema): boolean {
+		return isWellKnownModeSchema(schema);
+	}
+
+	protected _getTriggerIcon(value: string | undefined): ThemeIcon | undefined {
+		return getModeIcon(value);
+	}
+
+	protected _getActionItemIcon(item: IAgentHostSessionEnumPickerItem, currentValue: string): ThemeIcon {
+		return item.value === currentValue ? Codicon.check : Codicon.blank;
+	}
+
+	protected _getTriggerAriaLabel(label: string): string {
+		return localize('agentHostModePicker.triggerAriaLabel', "Pick Agent Mode, {0}", label);
+	}
+
+	protected _getWidgetAriaLabel(): string {
+		return localize('agentHostModePicker.ariaLabel', "Agent Mode Picker");
 	}
 }

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostPermissionPickerActionItem.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostPermissionPickerActionItem.ts
@@ -1,0 +1,80 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { autorun } from '../../../../../base/common/observable.js';
+import { MenuItemAction } from '../../../../../platform/actions/common/actions.js';
+import { IActionWidgetService } from '../../../../../platform/actionWidget/browser/actionWidget.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { IDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { IKeybindingService } from '../../../../../platform/keybinding/common/keybinding.js';
+import { IOpenerService } from '../../../../../platform/opener/common/opener.js';
+import { IStorageService } from '../../../../../platform/storage/common/storage.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { IChatInputPickerOptions } from '../../../../../workbench/contrib/chat/browser/widget/input/chatInputPickerActionItem.js';
+import { PermissionPickerActionItem } from '../../../../../workbench/contrib/chat/browser/widget/input/permissionPickerActionItem.js';
+import { AgentHostPermissionPickerDelegate } from './agentHostPermissionPickerDelegate.js';
+
+/**
+ * Agent host wrapper around the workbench {@link PermissionPickerActionItem}
+ * for use in the running chat widget's secondary toolbar
+ * (`MenuId.ChatInputSecondary`). Owns its
+ * {@link AgentHostPermissionPickerDelegate} and reactively hides itself when
+ * the active session's `autoApprove` schema doesn't match the well-known
+ * shape.
+ */
+export class AgentHostPermissionPickerActionItem extends PermissionPickerActionItem {
+
+	private readonly _delegate: AgentHostPermissionPickerDelegate;
+
+	constructor(
+		action: MenuItemAction,
+		pickerOptions: IChatInputPickerOptions,
+		@IInstantiationService instantiationService: IInstantiationService,
+		@IActionWidgetService actionWidgetService: IActionWidgetService,
+		@IKeybindingService keybindingService: IKeybindingService,
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@ITelemetryService telemetryService: ITelemetryService,
+		@IConfigurationService configurationService: IConfigurationService,
+		@IDialogService dialogService: IDialogService,
+		@IOpenerService openerService: IOpenerService,
+		@IStorageService storageService: IStorageService,
+	) {
+		const delegate = instantiationService.createInstance(AgentHostPermissionPickerDelegate);
+		super(
+			action,
+			delegate,
+			pickerOptions,
+			actionWidgetService,
+			keybindingService,
+			contextKeyService,
+			telemetryService,
+			configurationService,
+			dialogService,
+			openerService,
+			storageService,
+		);
+		this._delegate = this._register(delegate);
+
+		// The base widget's label is rendered on demand via `refresh()`. Keep it
+		// in sync with the delegate's level observable.
+		this._register(autorun(reader => {
+			delegate.currentPermissionLevel.read(reader);
+			this.refresh();
+		}));
+	}
+
+	override render(container: HTMLElement): void {
+		super.render(container);
+		// The active session can change while this view item is alive (the
+		// `IActionViewItemService` factory only runs once per render), so gate
+		// visibility reactively rather than at construction time.
+		this._register(autorun(reader => {
+			const visible = this._delegate.isApplicable.read(reader);
+			container.style.display = visible ? '' : 'none';
+		}));
+	}
+}

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostPermissionPickerDelegate.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostPermissionPickerDelegate.ts
@@ -6,6 +6,7 @@
 import { Disposable, DisposableMap } from '../../../../../base/common/lifecycle.js';
 import { derived, IObservable, IReader, observableSignal } from '../../../../../base/common/observable.js';
 import { KNOWN_AUTO_APPROVE_VALUES, SessionConfigKey } from '../../../../../platform/agentHost/common/sessionConfigKeys.js';
+import { narrowClaudePermissionMode } from '../../../../../platform/agentHost/common/claudeSessionConfigKeys.js';
 import { SessionConfigPropertySchema } from '../../../../../platform/agentHost/common/state/protocol/commands.js';
 import { ChatPermissionLevel, isChatPermissionLevel } from '../../../../../workbench/contrib/chat/common/constants.js';
 import { IPermissionPickerDelegate } from '../../copilotChatSessions/browser/permissionPicker.js';
@@ -16,6 +17,7 @@ import { ISessionsManagementService } from '../../../../services/sessions/common
 
 const REQUIRED_AUTO_APPROVE_VALUE = 'default';
 const REQUIRED_MODE_VALUE = 'interactive';
+const REQUIRED_PERMISSION_MODE_VALUE = 'default';
 
 /**
  * Returns `true` when an `autoApprove` session-config property uses the
@@ -156,4 +158,18 @@ export function isWellKnownModeSchema(schema: SessionConfigPropertySchema): bool
 		return false;
 	}
 	return true;
+}
+
+/**
+ * Returns `true` when a `permissionMode` session-config property uses the
+ * Claude SDK's well-known permission-mode value set and includes `default`.
+ */
+export function isWellKnownClaudePermissionModeSchema(schema: SessionConfigPropertySchema): boolean {
+	if (schema.type !== 'string' || !Array.isArray(schema.enum) || schema.enum.length === 0) {
+		return false;
+	}
+	if (!schema.enum.includes(REQUIRED_PERMISSION_MODE_VALUE)) {
+		return false;
+	}
+	return schema.enum.every(value => narrowClaudePermissionMode(value) !== undefined);
 }

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionConfigPicker.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionConfigPicker.ts
@@ -14,12 +14,12 @@ import { Delayer } from '../../../../../base/common/async.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { MarkdownString } from '../../../../../base/common/htmlContent.js';
 import { Disposable, DisposableMap, DisposableStore, IDisposable } from '../../../../../base/common/lifecycle.js';
-import { autorun } from '../../../../../base/common/observable.js';
+import { autorun, observableValue } from '../../../../../base/common/observable.js';
 import Severity from '../../../../../base/common/severity.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { localize, localize2 } from '../../../../../nls.js';
-import { IActionViewItemService } from '../../../../../platform/actions/browser/actionViewItemService.js';
-import { Action2, MenuId, registerAction2 } from '../../../../../platform/actions/common/actions.js';
+import { IActionViewItemService, type IActionViewItemFactory } from '../../../../../platform/actions/browser/actionViewItemService.js';
+import { Action2, MenuId, MenuItemAction, registerAction2 } from '../../../../../platform/actions/common/actions.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { ContextKeyExpr, IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
@@ -29,6 +29,7 @@ import type { SessionConfigPropertySchema, SessionConfigValueItem } from '../../
 import { ChatConfiguration } from '../../../../../workbench/contrib/chat/common/constants.js';
 import { ChatContextKeyExprs } from '../../../../../workbench/contrib/chat/common/actions/chatContextKeys.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../../workbench/common/contributions.js';
+import { type IChatInputPickerOptions } from '../../../../../workbench/contrib/chat/browser/widget/input/chatInputPickerActionItem.js';
 import { Menus } from '../../../../browser/menus.js';
 import { ActiveSessionProviderIdContext, IsPhoneLayoutContext } from '../../../../common/contextkeys.js';
 import { IWorkbenchLayoutService } from '../../../../../workbench/services/layout/browser/layoutService.js';
@@ -43,8 +44,10 @@ import { isPhoneLayout } from '../../../../browser/parts/mobile/mobileLayout.js'
 import { showMobilePickerSheet, IMobilePickerSheetItem, IMobilePickerSheetSearchSource } from '../../../../browser/parts/mobile/mobilePickerSheet.js';
 import { AgentHostModePicker } from './agentHostModePicker.js';
 import { MobileAgentHostModePicker } from './mobile/mobileAgentHostModePicker.js';
+import { AgentHostPermissionPickerActionItem } from './agentHostPermissionPickerActionItem.js';
 import { AgentHostPermissionPickerDelegate, isWellKnownAutoApproveSchema, isWellKnownModeSchema } from './agentHostPermissionPickerDelegate.js';
 import { SessionConfigKey } from '../../../../../platform/agentHost/common/sessionConfigKeys.js';
+import { AgentHostClaudePermissionModePicker } from './agentHostClaudePermissionModePicker.js';
 
 const IsActiveSessionRemoteAgentHost = ContextKeyExpr.regex(ActiveSessionProviderIdContext.key, REMOTE_AGENT_HOST_PROVIDER_RE);
 const IsActiveSessionLocalAgentHost = ContextKeyExpr.equals(ActiveSessionProviderIdContext.key, LOCAL_AGENT_HOST_PROVIDER_ID);
@@ -768,6 +771,16 @@ class AgentHostSessionConfigPickerContribution extends Disposable implements IWo
 			NEW_SESSION_APPROVE_PICKER_ID,
 			() => this._createNewSessionPermissionPicker(),
 		));
+		this._register(actionViewItemService.register(
+			MenuId.ChatInputSecondary,
+			RUNNING_SESSION_CONFIG_PICKER_ID,
+			this._createRunningSessionPermissionPickerFactory(),
+		));
+		this._register(actionViewItemService.register(
+			MenuId.ChatInputSecondary,
+			RUNNING_SESSION_PERMISSION_MODE_PICKER_ID,
+			() => new PickerActionViewItem(this._instantiationService.createInstance(AgentHostClaudePermissionModePicker)),
+		));
 	}
 
 	/**
@@ -779,6 +792,28 @@ class AgentHostSessionConfigPickerContribution extends Disposable implements IWo
 		const delegate = this._instantiationService.createInstance(AgentHostPermissionPickerDelegate);
 		const picker = this._instantiationService.createInstance(MobilePermissionPicker, delegate);
 		return new PickerActionViewItem(picker, delegate);
+	}
+
+	/**
+	 * Inside a running chat widget (`ChatInputSecondary`), use the workbench
+	 * {@link PermissionPickerActionItem} so it matches the rest of the
+	 * chat-input secondary toolbar (which is what the extension-host CLI
+	 * already uses).
+	 */
+	private _createRunningSessionPermissionPickerFactory(): IActionViewItemFactory {
+		return (action, _options, instantiationService) => {
+			if (!(action instanceof MenuItemAction)) {
+				return undefined;
+			}
+			const pickerOptions: IChatInputPickerOptions = {
+				hideChevrons: observableValue('hideChevrons', false),
+			};
+			return instantiationService.createInstance(
+				AgentHostPermissionPickerActionItem,
+				action,
+				pickerOptions,
+			);
+		};
 	}
 }
 
@@ -804,7 +839,6 @@ registerAction2(class extends Action2 {
 	override async run(): Promise<void> { }
 });
 
-
 // ---- New session mode picker (NewSessionConfig) ----
 
 const NEW_SESSION_MODE_PICKER_ID = 'sessions.agentHost.newSessionModePicker';
@@ -826,6 +860,49 @@ registerAction2(class extends Action2 {
 					ContextKeyExpr.or(IsActiveSessionLocalAgentHost, IsActiveSessionRemoteAgentHost),
 					IsPhoneLayoutContext.negate(),
 				),
+			}],
+		});
+	}
+
+	override async run(): Promise<void> { }
+});
+
+
+// ---- Running session config picker (ChatInputSecondary) ----
+
+const RUNNING_SESSION_CONFIG_PICKER_ID = 'sessions.agentHost.runningSessionConfigPicker';
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: RUNNING_SESSION_CONFIG_PICKER_ID,
+			title: localize2('agentHostRunningSessionConfigPicker', "Session Approvals"),
+			f1: false,
+			menu: [{
+				id: MenuId.ChatInputSecondary,
+				group: 'navigation',
+				order: 10,
+				when: ChatContextKeyExprs.isAgentHostSession,
+			}],
+		});
+	}
+
+	override async run(): Promise<void> { }
+});
+
+const RUNNING_SESSION_PERMISSION_MODE_PICKER_ID = 'sessions.agentHost.runningSessionPermissionModePicker';
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: RUNNING_SESSION_PERMISSION_MODE_PICKER_ID,
+			title: localize2('agentHostRunningSessionPermissionModePicker', "Approvals"),
+			f1: false,
+			menu: [{
+				id: MenuId.ChatInputSecondary,
+				group: 'navigation',
+				order: 11,
+				when: ChatContextKeyExprs.isAgentHostSession,
 			}],
 		});
 	}

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/agentHost/agentHostPermissionPickerDelegate.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/agentHost/agentHostPermissionPickerDelegate.test.ts
@@ -12,7 +12,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../ba
 import { TestInstantiationService } from '../../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { ResolveSessionConfigResult, SessionConfigPropertySchema } from '../../../../../../../platform/agentHost/common/state/protocol/commands.js';
 import { ChatPermissionLevel } from '../../../../../../../workbench/contrib/chat/common/constants.js';
-import { AgentHostPermissionPickerDelegate, isWellKnownAutoApproveSchema, isWellKnownModeSchema } from '../../../browser/agentHostPermissionPickerDelegate.js';
+import { AgentHostPermissionPickerDelegate, isWellKnownAutoApproveSchema, isWellKnownClaudePermissionModeSchema, isWellKnownModeSchema } from '../../../browser/agentHostPermissionPickerDelegate.js';
 import { IAgentHostSessionsProvider } from '../../../../../../common/agentHostSessionsProvider.js';
 import { ISessionsProvidersChangeEvent, ISessionsProvidersService } from '../../../../../../services/sessions/browser/sessionsProvidersService.js';
 import { ISessionsProvider } from '../../../../../../services/sessions/common/sessionsProvider.js';
@@ -240,5 +240,37 @@ suite('isWellKnownModeSchema', () => {
 		assert.strictEqual(isWellKnownModeSchema(schema({ type: 'number' as 'string' })), false);
 		assert.strictEqual(isWellKnownModeSchema(schema({ enum: undefined })), false);
 		assert.strictEqual(isWellKnownModeSchema(schema({ enum: [] })), false);
+	});
+});
+
+suite('isWellKnownClaudePermissionModeSchema', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function schema(overrides: Partial<SessionConfigPropertySchema> = {}): SessionConfigPropertySchema {
+		return {
+			title: 'Approvals',
+			description: 'desc',
+			type: 'string',
+			enum: ['default', 'acceptEdits', 'bypassPermissions', 'plan', 'dontAsk', 'auto'],
+			...overrides,
+		} as SessionConfigPropertySchema;
+	}
+
+	test('matches the canonical permission-mode enum', () => {
+		assert.strictEqual(isWellKnownClaudePermissionModeSchema(schema()), true);
+	});
+
+	test('matches a subset that still contains "default"', () => {
+		assert.strictEqual(isWellKnownClaudePermissionModeSchema(schema({ enum: ['default', 'acceptEdits'] })), true);
+	});
+
+	test('rejects schemas missing "default" or containing custom values', () => {
+		assert.strictEqual(isWellKnownClaudePermissionModeSchema(schema({ enum: ['acceptEdits', 'plan'] })), false);
+		assert.strictEqual(isWellKnownClaudePermissionModeSchema(schema({ enum: ['default', 'custom'] })), false);
+	});
+
+	test('rejects non-string types and missing enums', () => {
+		assert.strictEqual(isWellKnownClaudePermissionModeSchema(schema({ type: 'number' as 'string' })), false);
+		assert.strictEqual(isWellKnownClaudePermissionModeSchema(schema({ enum: undefined })), false);
 	});
 });

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/agentHostClaudePermissionModePicker.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/agentHostClaudePermissionModePicker.test.ts
@@ -1,0 +1,117 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Event } from '../../../../../../base/common/event.js';
+import { observableValue } from '../../../../../../base/common/observable.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { mock } from '../../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { IActionListItem } from '../../../../../../platform/actionWidget/browser/actionList.js';
+import { IActionWidgetService } from '../../../../../../platform/actionWidget/browser/actionWidget.js';
+import { ResolveSessionConfigResult } from '../../../../../../platform/agentHost/common/state/protocol/commands.js';
+import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { IOpenerService } from '../../../../../../platform/opener/common/opener.js';
+import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
+import { NullTelemetryService } from '../../../../../../platform/telemetry/common/telemetryUtils.js';
+import { IAgentHostSessionsProvider } from '../../../../../common/agentHostSessionsProvider.js';
+import { ISessionsProvidersService } from '../../../../../services/sessions/browser/sessionsProvidersService.js';
+import { IActiveSession, ISessionsManagementService } from '../../../../../services/sessions/common/sessionsManagement.js';
+import { ISessionsProvider } from '../../../../../services/sessions/common/sessionsProvider.js';
+import { AgentHostClaudePermissionModePicker } from '../../browser/agentHostClaudePermissionModePicker.js';
+import { IAgentHostSessionEnumPickerItem } from '../../browser/agentHostModePicker.js';
+
+const PROVIDER_ID = 'local-agent-host';
+const SESSION_ID = 'local-agent-host:s1';
+const LEARN_MORE_URL = 'https://code.claude.com/docs/en/permission-modes#available-modes';
+
+function makeClaudePermissionModeConfig(): ResolveSessionConfigResult {
+	return {
+		schema: {
+			type: 'object',
+			properties: {
+				permissionMode: {
+					title: 'Approvals',
+					description: '',
+					type: 'string',
+					enum: ['default', 'acceptEdits'],
+				},
+			},
+		},
+		values: { permissionMode: 'default' },
+	} as ResolveSessionConfigResult;
+}
+
+class FakeProvider implements Pick<IAgentHostSessionsProvider, 'id' | 'onDidChangeSessionConfig' | 'getSessionConfig' | 'setSessionConfigValue'> {
+	readonly id = PROVIDER_ID;
+	readonly onDidChangeSessionConfig: Event<string> = Event.None;
+	readonly setCalls: Array<[string, string, unknown]> = [];
+
+	getSessionConfig(_sessionId: string): ResolveSessionConfigResult {
+		return makeClaudePermissionModeConfig();
+	}
+
+	async setSessionConfigValue(sessionId: string, property: string, value: unknown): Promise<void> {
+		this.setCalls.push([sessionId, property, value]);
+	}
+}
+
+suite('AgentHostClaudePermissionModePicker', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('Learn More footer opens docs without writing session config', () => {
+		const provider = new FakeProvider();
+		const openedResources: string[] = [];
+		const actionWidgetItems: IActionListItem<IAgentHostSessionEnumPickerItem>[] = [];
+		let onSelect: ((item: IAgentHostSessionEnumPickerItem) => void) | undefined;
+
+		const instantiationService = store.add(new TestInstantiationService());
+		instantiationService.stub(IActionWidgetService, {
+			isVisible: false,
+			hide: () => { },
+			show: <T>(_id: string, _supportsPreview: boolean, items: IActionListItem<T>[], delegate: { onSelect: (item: T) => void }) => {
+				actionWidgetItems.splice(0, actionWidgetItems.length, ...(items as IActionListItem<IAgentHostSessionEnumPickerItem>[]));
+				onSelect = delegate.onSelect as (item: IAgentHostSessionEnumPickerItem) => void;
+			},
+		});
+		instantiationService.set(ISessionsManagementService, new (class extends mock<ISessionsManagementService>() {
+			override readonly activeSession = observableValue<IActiveSession | undefined>('activeSession', { providerId: PROVIDER_ID, sessionId: SESSION_ID } as IActiveSession);
+		})());
+		instantiationService.set(ISessionsProvidersService, new (class extends mock<ISessionsProvidersService>() {
+			override readonly onDidChangeProviders = Event.None;
+			override getProviders(): ISessionsProvider[] { return [provider as unknown as ISessionsProvider]; }
+			override getProvider<T extends ISessionsProvider>(id: string): T | undefined {
+				return id === provider.id ? provider as unknown as T : undefined;
+			}
+		})());
+		instantiationService.set(IOpenerService, new (class extends mock<IOpenerService>() {
+			override async open(resource: URI | string): Promise<boolean> {
+				openedResources.push(resource.toString());
+				return true;
+			}
+		})());
+		instantiationService.stub(ITelemetryService, NullTelemetryService);
+
+		const picker = store.add(instantiationService.createInstance(AgentHostClaudePermissionModePicker));
+		const container = document.createElement('div');
+		picker.render(container);
+		container.querySelector<HTMLElement>('a.action-label')?.click();
+
+		const learnMoreItem = actionWidgetItems.at(-1)?.item;
+		assert.ok(onSelect);
+		assert.ok(learnMoreItem);
+		onSelect(learnMoreItem);
+
+		assert.deepStrictEqual({
+			footerLabels: actionWidgetItems.slice(-2).map(item => item.label),
+			openedResources,
+			setCalls: provider.setCalls,
+		}, {
+			footerLabels: ['', 'Learn more about permissions'],
+			openedResources: [LEARN_MORE_URL],
+			setCalls: [],
+		});
+	});
+});


### PR DESCRIPTION
Reverts part of https://github.com/microsoft/vscode/pull/316276 to restore the copilot approval picker, and uses the same strategy to add Claude's.

## Summary
- support well-known Claude Agent Host `permissionMode` config in running sessions
- share enum-picker plumbing while keeping Claude-specific footer behavior in the subclass
- add the Claude permissions Learn More action, hide inactive approval toolbar wrappers, and cover the footer path with focused tests

## Validation
- `npm run compile-check-ts-native`
- focused Agent Host picker tests
- `npm run valid-layers-check`
- focused hygiene check

(Written by Copilot)