### PR TITLE
Stop injecting root install dir into PATH on Windows

### DIFF
--- a/build/win32/code.iss
+++ b/build/win32/code.iss
@@ -1303,7 +1303,8 @@ Root: {#EnvironmentRootKey}; Subkey: "{#EnvironmentKey}"; ValueType: expandsz; V
 
 ; App Paths - allows running code from Explorer address bar
 Root: {#EnvironmentRootKey}; Subkey: "Software\Microsoft\Windows\CurrentVersion\App Paths\{#ApplicationName}.exe"; ValueType: string; ValueName: ""; ValueData: "{app}\{#ExeBasename}.exe"; Flags: uninsdeletekey
-Root: {#EnvironmentRootKey}; Subkey: "Software\Microsoft\Windows\CurrentVersion\App Paths\{#ApplicationName}.exe"; ValueType: string; ValueName: "Path"; ValueData: "{app}"; Flags: uninsdeletekey
+; Remove the "Path" value previously written here; ShellExecute appends it to the launched process PATH, polluting the env. Default value above is enough to resolve `code` from Explorer/Run.
+Root: {#EnvironmentRootKey}; Subkey: "Software\Microsoft\Windows\CurrentVersion\App Paths\{#ApplicationName}.exe"; ValueType: none; ValueName: "Path"; Flags: deletevalue
 
 [Code]
 function IsBackgroundUpdate(): Boolean;


### PR DESCRIPTION
Fixes #300231
Fixes #299416
Fixes #299523
Fixes #299598
Fixes #299703
Fixes #302026
Fixes #303020
Fixes #303021
Fixes #304350
Fixes #304797
Fixes #308193
Fixes #309315
Fixes #309316
Fixes #311267
Fixes #300307
Fixes #311187
Fixes #301050
Fixes #312434
Fixes #299962