### PR TITLE
agent-host: fix image detection in browser screenshot tool

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -617,9 +617,7 @@ export class CopilotAgentSession extends Disposable {
 
 		const binaryResults = result.content
 			?.filter(c => c.type === ToolResultContentType.EmbeddedResource)
-			.map(c => {
-				return { data: c.data, mimeType: c.contentType, type: c.contentType };
-			});
+			.map(c => ({ data: c.data, mimeType: c.contentType, type: /^image(\/|$)/.test(c.contentType) ? 'image' : 'resource' }));
 
 		if (result.success) {
 			deferred.complete({


### PR DESCRIPTION
Fixes the type field for embedded resources in tool results so that images
are properly recognized by the SDK. The tool was returning images with a
content type in the 'type' field instead of the semantic 'image' marker.

This ensures that when the Integrated Browser screenshot tool returns
image content, the Agent Host correctly identifies and surfaces those images
in the chat UI.

Fixes https://github.com/microsoft/vscode/issues/315947

(Commit message generated by Copilot)