### PR TITLE
agent-host: Cancel SSH connect when auth prompt is dismissed

### DIFF
--- a/src/vs/platform/agentHost/common/sshRemoteAgentHost.ts
+++ b/src/vs/platform/agentHost/common/sshRemoteAgentHost.ts
@@ -244,8 +244,8 @@ export interface ISSHRemoteAgentHostMainService {
 
 	/**
 	 * Provide responses for a previously fired keyboard-interactive request.
-	 * Pass `undefined` (e.g. when the user cancels the prompt) to submit empty
-	 * responses, which causes the server to fail this auth attempt.
+	 * Pass `undefined` when the user cancels the prompt; this aborts the
+	 * owning SSH connection attempt.
 	 */
 	respondKeyboardInteractive(requestId: string, responses: readonly string[] | undefined): Promise<void>;
 

--- a/src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts
+++ b/src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts
@@ -321,7 +321,7 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 					return;
 				}
 				if (value === undefined) {
-					// User cancelled — submit empty responses to fail this attempt.
+					// User cancelled — abort the owning connection attempt.
 					await this._mainService.respondKeyboardInteractive(request.requestId, undefined);
 					return;
 				}

--- a/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
+++ b/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
@@ -956,10 +956,6 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 		config: ISSHAgentHostConfig,
 		connectionKey?: string,
 	): Promise<SSHClient> {
-		const nativeRequire = await this._getNativeRequire();
-		const ssh2Module = nativeRequire('ssh2') as { Client: new () => unknown };
-		const SSHClientCtor = ssh2Module.Client;
-
 		const connectConfig: ConnectConfig = {
 			host: config.host,
 			port: config.port ?? 22,
@@ -1016,8 +1012,8 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 			}
 		}
 
+		const client = await this._createSSHClient();
 		return new Promise<SSHClient>((resolve, reject) => {
-			const client = new SSHClientCtor() as SSHClient;
 			let settled = false;
 
 			const resolveConnect = () => {
@@ -1058,6 +1054,12 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 
 			client.connect(connectConfig);
 		});
+	}
+
+	protected async _createSSHClient(): Promise<SSHClient> {
+		const nativeRequire = await this._getNativeRequire();
+		const ssh2Module = nativeRequire('ssh2') as { Client: new () => unknown };
+		return new ssh2Module.Client() as SSHClient;
 	}
 
 	/**
@@ -1191,8 +1193,8 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 			return;
 		}
 		if (responses === undefined) {
-			pending.finish([]);
 			pending.cancelConnect();
+			pending.finish([]);
 			return;
 		}
 		pending.finish(responses);

--- a/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
+++ b/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
@@ -12,6 +12,7 @@ import { dirname, join, isAbsolute, basename } from '../../../base/common/path.j
 import { Emitter, Event } from '../../../base/common/event.js';
 import { Disposable, DisposableMap, toDisposable } from '../../../base/common/lifecycle.js';
 import { raceTimeout } from '../../../base/common/async.js';
+import { CancellationError } from '../../../base/common/errors.js';
 import { URI } from '../../../base/common/uri.js';
 import { localize } from '../../../nls.js';
 import { ILogService } from '../../log/common/log.js';
@@ -505,10 +506,10 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 
 	/**
 	 * Pending keyboard-interactive prompts awaiting a response from the renderer.
-	 * Keyed by `requestId`. Each entry is the ssh2 `finish` callback to invoke
-	 * with the user's responses (or empty array on cancel).
+	 * Keyed by `requestId`. Each entry can either finish the ssh2 prompt with
+	 * responses or cancel the owning connect attempt when the user dismisses it.
 	 */
-	private readonly _pendingKbiRequests = new Map<string, (responses: readonly string[]) => void>();
+	private readonly _pendingKbiRequests = new Map<string, { finish: (responses: readonly string[]) => void; cancelConnect: () => void }>();
 	private _kbiRequestCounter = 0;
 
 	private readonly _connections = this._register(new DisposableMap<string, SSHConnection>());
@@ -974,9 +975,10 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 		// onDidCancelKeyboardInteractive for any still-pending prompts when
 		// the connect attempt fails or completes.
 		const liveKbiRequests = new Set<string>();
+		let cancelConnectFromKbi: (() => void) | undefined;
 		const kbiHandler: SSHKeyboardInteractivePromptHandler | undefined = attempts.some(a => a.type === 'keyboard-interactive')
 			? (name, instructions, prompts, finish) => {
-				const requestId = this._handleKeyboardInteractive(connectionKey ?? displayHost, displayHost, config.username, name, instructions, prompts, finish);
+				const requestId = this._handleKeyboardInteractive(connectionKey ?? displayHost, displayHost, config.username, name, instructions, prompts, finish, () => cancelConnectFromKbi?.());
 				liveKbiRequests.add(requestId);
 			}
 			: undefined;
@@ -992,10 +994,10 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 				// this, ssh2 hangs until `readyTimeout` elapses when a connect
 				// attempt is aborted mid-prompt. The renderer also gets notified
 				// so it can dismiss any open quick-input UI.
-				const finish = this._pendingKbiRequests.get(requestId);
+				const pending = this._pendingKbiRequests.get(requestId);
 				this._pendingKbiRequests.delete(requestId);
 				this._onDidCancelKeyboardInteractive.fire(requestId);
-				finish?.([]);
+				pending?.finish([]);
 			}
 			liveKbiRequests.clear();
 		};
@@ -1016,17 +1018,42 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 
 		return new Promise<SSHClient>((resolve, reject) => {
 			const client = new SSHClientCtor() as SSHClient;
+			let settled = false;
 
-			client.on('ready', () => {
+			const resolveConnect = () => {
+				if (settled) {
+					return;
+				}
+				settled = true;
 				this._logService.info(`${LOG_PREFIX} SSH connection established to ${config.host}`);
 				cancelLiveKbiRequests();
 				resolve(client);
+			};
+
+			const rejectConnect = (err: Error, endClient: boolean) => {
+				if (settled) {
+					return;
+				}
+				settled = true;
+				cancelLiveKbiRequests();
+				if (endClient) {
+					client.end();
+				}
+				reject(err);
+			};
+
+			cancelConnectFromKbi = () => {
+				this._logService.info(`${LOG_PREFIX} SSH keyboard-interactive prompt cancelled by user for ${displayHost}`);
+				rejectConnect(new CancellationError(), true);
+			};
+
+			client.on('ready', () => {
+				resolveConnect();
 			});
 
 			client.on('error', (err: Error) => {
 				this._logService.error(`${LOG_PREFIX} SSH connection error: ${err.message}`);
-				cancelLiveKbiRequests();
-				reject(err);
+				rejectConnect(err, false);
 			});
 
 			client.connect(connectConfig);
@@ -1121,7 +1148,7 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 	 * supply the user's responses when they arrive. Returns the generated
 	 * `requestId` so the caller can track in-flight prompts.
 	 */
-	private _handleKeyboardInteractive(
+	protected _handleKeyboardInteractive(
 		connectionKey: string,
 		displayHost: string,
 		username: string,
@@ -1129,6 +1156,7 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 		instructions: string,
 		prompts: readonly ISSHKeyboardInteractivePrompt[],
 		finish: (responses: readonly string[]) => void,
+		cancelConnect: () => void,
 	): string {
 		const requestId = `kbi-${++this._kbiRequestCounter}`;
 		// Wrap finish so it can only fire once — ssh2 ignores duplicate calls,
@@ -1142,7 +1170,7 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 			this._pendingKbiRequests.delete(requestId);
 			finish(responses);
 		};
-		this._pendingKbiRequests.set(requestId, finishOnce);
+		this._pendingKbiRequests.set(requestId, { finish: finishOnce, cancelConnect });
 		this._logService.info(`${LOG_PREFIX} keyboard-interactive challenge from ${displayHost}: ${prompts.length} prompt(s)`);
 		this._onDidRequestKeyboardInteractive.fire({
 			requestId,
@@ -1157,15 +1185,17 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 	}
 
 	async respondKeyboardInteractive(requestId: string, responses: readonly string[] | undefined): Promise<void> {
-		const finish = this._pendingKbiRequests.get(requestId);
-		if (!finish) {
+		const pending = this._pendingKbiRequests.get(requestId);
+		if (!pending) {
 			this._logService.warn(`${LOG_PREFIX} respondKeyboardInteractive: no pending request for ${requestId}`);
 			return;
 		}
-		// Cancel and "no responses" are both surfaced as an empty answer array,
-		// which causes ssh2 to fail this auth attempt and move on (or surface
-		// the auth failure if no further attempts remain).
-		finish(responses ?? []);
+		if (responses === undefined) {
+			pending.finish([]);
+			pending.cancelConnect();
+			return;
+		}
+		pending.finish(responses);
 	}
 
 	/**

--- a/src/vs/platform/agentHost/test/node/sshRemoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/node/sshRemoteAgentHostService.test.ts
@@ -9,7 +9,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/c
 import { NullLogService } from '../../../log/common/log.js';
 import { IProductService } from '../../../product/common/productService.js';
 import { createRemoteAgentHostState } from '../../common/remoteAgentHostMetadata.js';
-import { SSHAuthMethod, type ISSHAgentHostConfig, type ISSHConnectProgress } from '../../common/sshRemoteAgentHost.js';
+import { SSHAuthMethod, type ISSHAgentHostConfig, type ISSHConnectProgress, type ISSHKeyboardInteractivePrompt, type ISSHKeyboardInteractiveRequest } from '../../common/sshRemoteAgentHost.js';
 import { SSHRemoteAgentHostMainService, makeAuthHandler, type SSHAuthAttempt } from '../../node/sshRemoteAgentHostService.js';
 
 const dataFolderName = '.vscode-insiders';
@@ -296,6 +296,14 @@ class TestableSSHRemoteAgentHostMainService extends SSHRemoteAgentHostMainServic
 	/** Sets the relay creation timeout; exposed for tests only. */
 	setRelayCreationTimeoutForTest(ms: number): void {
 		this.relayCreationTimeoutMs = ms;
+	}
+
+	startKeyboardInteractiveForTest(
+		prompts: readonly ISSHKeyboardInteractivePrompt[],
+		finish: (responses: readonly string[]) => void,
+		cancelConnect: () => void,
+	): string {
+		return this._handleKeyboardInteractive('ssh:test-host', 'test-host', 'testuser', '', '', prompts, finish, cancelConnect);
 	}
 }
 
@@ -859,6 +867,57 @@ suite('SSHRemoteAgentHostMainService - connect flow', () => {
 		assert.ok(progress.length >= 3, `expected at least 3 progress events, got ${progress.length}`);
 		assert.ok(progress.every(p => p.connectionKey === 'ssh:myhost'));
 		assert.ok(progress.every(p => p.message.length > 0), 'all progress messages should be non-empty');
+	});
+
+	test('cancelling keyboard-interactive prompt cancels connection attempt', async () => {
+		const requests: ISSHKeyboardInteractiveRequest[] = [];
+		disposables.add(service.onDidRequestKeyboardInteractive(request => requests.push(request)));
+		let finished: readonly string[] | undefined;
+		let cancelled = false;
+
+		const requestId = service.startKeyboardInteractiveForTest([
+			{ prompt: 'Password: ', echo: false },
+		], responses => { finished = responses; }, () => { cancelled = true; });
+
+		await service.respondKeyboardInteractive(requestId, undefined);
+
+		assert.deepStrictEqual({
+			finished,
+			cancelled,
+			requests: requests.map(request => ({
+				requestId: request.requestId,
+				connectionKey: request.connectionKey,
+				displayHost: request.displayHost,
+				username: request.username,
+				prompts: request.prompts,
+			})),
+		}, {
+			finished: [],
+			cancelled: true,
+			requests: [{
+				requestId,
+				connectionKey: 'ssh:test-host',
+				displayHost: 'test-host',
+				username: 'testuser',
+				prompts: [{ prompt: 'Password: ', echo: false }],
+			}],
+		});
+	});
+
+	test('responding to keyboard-interactive prompt does not cancel connection attempt', async () => {
+		let finished: readonly string[] | undefined;
+		let cancelled = false;
+
+		const requestId = service.startKeyboardInteractiveForTest([
+			{ prompt: 'Password: ', echo: false },
+		], responses => { finished = responses; }, () => { cancelled = true; });
+
+		await service.respondKeyboardInteractive(requestId, ['secret']);
+
+		assert.deepStrictEqual({ finished, cancelled }, {
+			finished: ['secret'],
+			cancelled: false,
+		});
 	});
 
 	// --- SSH client close triggers connection disposal ---

--- a/src/vs/platform/agentHost/test/node/sshRemoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/node/sshRemoteAgentHostService.test.ts
@@ -4,6 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { DeferredPromise } from '../../../../base/common/async.js';
+import { isCancellationError } from '../../../../base/common/errors.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { NullLogService } from '../../../log/common/log.js';
@@ -11,6 +13,7 @@ import { IProductService } from '../../../product/common/productService.js';
 import { createRemoteAgentHostState } from '../../common/remoteAgentHostMetadata.js';
 import { SSHAuthMethod, type ISSHAgentHostConfig, type ISSHConnectProgress, type ISSHKeyboardInteractivePrompt, type ISSHKeyboardInteractiveRequest } from '../../common/sshRemoteAgentHost.js';
 import { SSHRemoteAgentHostMainService, makeAuthHandler, type SSHAuthAttempt } from '../../node/sshRemoteAgentHostService.js';
+import type { AnyAuthMethod, AuthenticationType, ConnectConfig } from 'ssh2';
 
 const dataFolderName = '.vscode-insiders';
 const quality = 'insider';
@@ -138,6 +141,49 @@ class MockSSHClient {
 
 	end(): void {
 		this.ended = true;
+	}
+}
+
+class KeyboardInteractiveMockSSHClient {
+	ended = false;
+	finishResponses: readonly string[] | undefined;
+
+	private readonly _errorListeners: Array<(err: Error) => void> = [];
+
+	on(event: 'ready', listener: () => void): this;
+	on(event: 'error', listener: (err: Error) => void): this;
+	on(event: 'close', listener: () => void): this;
+	on(event: string, listener: ((err: Error) => void) | (() => void)): this {
+		if (event === 'error') {
+			this._errorListeners.push(listener as (err: Error) => void);
+		}
+		return this;
+	}
+
+	removeListener(_event: string, _listener: (...args: never[]) => void): this {
+		return this;
+	}
+
+	connect(config: ConnectConfig): void {
+		const authHandler = config.authHandler as ((methodsLeft: AuthenticationType[] | null, partialSuccess: boolean, callback: (next: AnyAuthMethod | false) => void) => void) | undefined;
+		authHandler?.(null, false, method => {
+			if (method && method.type === 'keyboard-interactive') {
+				method.prompt('Keyboard', '', 'en-US', [{ prompt: 'Password: ', echo: false }], responses => {
+					this.finishResponses = responses;
+					this.fireError(new Error('All configured authentication methods failed'));
+				});
+			}
+		});
+	}
+
+	end(): void {
+		this.ended = true;
+	}
+
+	private fireError(err: Error): void {
+		for (const listener of this._errorListeners) {
+			listener(err);
+		}
 	}
 }
 
@@ -304,6 +350,22 @@ class TestableSSHRemoteAgentHostMainService extends SSHRemoteAgentHostMainServic
 		cancelConnect: () => void,
 	): string {
 		return this._handleKeyboardInteractive('ssh:test-host', 'test-host', 'testuser', '', '', prompts, finish, cancelConnect);
+	}
+}
+
+class KeyboardInteractiveConnectTestService extends SSHRemoteAgentHostMainService {
+	readonly client = new KeyboardInteractiveMockSSHClient();
+
+	protected override async _createSSHClient() {
+		return this.client as never;
+	}
+
+	protected override async _buildAuthAttempts(config: ISSHAgentHostConfig): Promise<SSHAuthAttempt[]> {
+		return [{ type: 'keyboard-interactive', username: config.username }];
+	}
+
+	connectSSHForTest(config: ISSHAgentHostConfig) {
+		return this._connectSSH(config, 'ssh:test-host');
 	}
 }
 
@@ -869,38 +931,29 @@ suite('SSHRemoteAgentHostMainService - connect flow', () => {
 		assert.ok(progress.every(p => p.message.length > 0), 'all progress messages should be non-empty');
 	});
 
-	test('cancelling keyboard-interactive prompt cancels connection attempt', async () => {
-		const requests: ISSHKeyboardInteractiveRequest[] = [];
-		disposables.add(service.onDidRequestKeyboardInteractive(request => requests.push(request)));
-		let finished: readonly string[] | undefined;
-		let cancelled = false;
+	test('cancelling keyboard-interactive prompt rejects connect with cancellation', async () => {
+		const kbiService = disposables.add(new KeyboardInteractiveConnectTestService(
+			new NullLogService(),
+			{
+				_serviceBrand: undefined,
+				quality,
+				dataFolderName,
+			} as IProductService,
+		));
+		const request = new DeferredPromise<ISSHKeyboardInteractiveRequest>();
+		disposables.add(kbiService.onDidRequestKeyboardInteractive(kbiRequest => request.complete(kbiRequest)));
 
-		const requestId = service.startKeyboardInteractiveForTest([
-			{ prompt: 'Password: ', echo: false },
-		], responses => { finished = responses; }, () => { cancelled = true; });
+		const connectPromise = kbiService.connectSSHForTest(makeConfig({ sshConfigHost: 'test-host' }));
+		const kbiRequest = await request.p;
+		await kbiService.respondKeyboardInteractive(kbiRequest.requestId, undefined);
 
-		await service.respondKeyboardInteractive(requestId, undefined);
-
+		await assert.rejects(connectPromise, error => isCancellationError(error));
 		assert.deepStrictEqual({
-			finished,
-			cancelled,
-			requests: requests.map(request => ({
-				requestId: request.requestId,
-				connectionKey: request.connectionKey,
-				displayHost: request.displayHost,
-				username: request.username,
-				prompts: request.prompts,
-			})),
+			ended: kbiService.client.ended,
+			finishResponses: kbiService.client.finishResponses,
 		}, {
-			finished: [],
-			cancelled: true,
-			requests: [{
-				requestId,
-				connectionKey: 'ssh:test-host',
-				displayHost: 'test-host',
-				username: 'testuser',
-				prompts: [{ prompt: 'Password: ', echo: false }],
-			}],
+			ended: true,
+			finishResponses: [],
 		});
 	});
 

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/REMOTE_AGENT_HOST_SESSIONS_PROVIDER.md
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/REMOTE_AGENT_HOST_SESSIONS_PROVIDER.md
@@ -75,6 +75,7 @@ Decoupling these allows copilot sessions from different providers (local CLI, re
 - `clearConnection()` — Clears the connection when the host disconnects
 - Handles session notifications (`notify/sessionAdded`, `notify/sessionRemoved`) and state changes
 - Fires `onDidChangeSessionTypes` when the host's agent list changes
+- SSH connection progress notifications are closed when the connect promise settles; keyboard-interactive prompt cancellation rejects the connect promise as cancellation and does not show an error notification.
 
 ## Stubbed Operations
 

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostActions.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostActions.ts
@@ -6,6 +6,7 @@
 import { localize, localize2 } from '../../../../../nls.js';
 import { Action2, registerAction2 } from '../../../../../platform/actions/common/actions.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
+import { isCancellationError } from '../../../../../base/common/errors.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
@@ -553,6 +554,9 @@ async function connectWithProgress(
 		return connection;
 	} catch (err) {
 		handle.close();
+		if (isCancellationError(err)) {
+			return undefined;
+		}
 		notificationService.error(localize('sshConnectFailed', "Failed to connect via SSH to {0}: {1}", displayHost, String(err)));
 		return undefined;
 	} finally {


### PR DESCRIPTION
## Summary
- abort the SSH connect attempt when a keyboard-interactive prompt is dismissed
- close the sessions connection progress notification without showing an error for intentional cancellation
- add unit coverage for cancelled and completed keyboard-interactive responses

## Validation
- npm run compile-check-ts-native
- npm run valid-layers-check
- node --experimental-strip-types build/hygiene.ts src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts src/vs/platform/agentHost/common/sshRemoteAgentHost.ts src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts src/vs/platform/agentHost/test/node/sshRemoteAgentHostService.test.ts src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostActions.ts src/vs/sessions/contrib/providers/remoteAgentHost/REMOTE_AGENT_HOST_SESSIONS_PROVIDER.md
- ./scripts/test.sh --run src/vs/platform/agentHost/test/node/sshRemoteAgentHostService.test.ts

(Written by Copilot)