### PR TITLE
Extension Bisect: keep eliminated extensions disabled

### DIFF
--- a/src/vs/workbench/services/extensionManagement/browser/extensionBisect.ts
+++ b/src/vs/workbench/services/extensionManagement/browser/extensionBisect.ts
@@ -82,9 +82,14 @@ class ExtensionBisectService implements IExtensionBisectService {
 		this._state = BisectState.fromJSON(raw);
 
 		if (this._state) {
-			const { mid, high } = this._state;
+			const { mid } = this._state;
 			for (let i = 0; i < this._state.extensions.length; i++) {
-				const isDisabled = i >= mid && i < high;
+				// Disable both the currently bisected upper half [mid, high) and any
+				// extensions previously eliminated from the search via a "still bad"
+				// answer [high, length). Keeping the latter disabled is what allows
+				// bisect to find additional problematic extensions across repeated
+				// runs when more than one extension is faulty (issue #237092).
+				const isDisabled = i >= mid;
 				this._disabled.set(this._state.extensions[i], isDisabled);
 			}
 			logService.warn('extension BISECT active', [...this._disabled]);
@@ -96,7 +101,7 @@ class ExtensionBisectService implements IExtensionBisectService {
 	}
 
 	get disabledCount() {
-		return this._state ? this._state.high - this._state.mid : -1;
+		return this._state ? this._state.extensions.length - this._state.mid : -1;
 	}
 
 	isDisabledByBisect(extension: IExtension): boolean {
@@ -307,7 +312,7 @@ registerAction2(class extends Action2 {
 				message: localize('done.msg', "Extension Bisect"),
 				primaryButton: localize({ key: 'report', comment: ['&& denotes a mnemonic'] }, "&&Report Issue & Continue"),
 				cancelButton: localize('continue', "Continue"),
-				detail: localize('done.detail', "Extension Bisect is done and has identified {0} as the extension causing the problem.", done.id),
+				detail: localize('done.detail', "Extension Bisect is done and has identified {0} as the extension causing the problem. If you still experience the problem after disabling {0}, run Extension Bisect again to identify any additional problematic extensions.", done.id),
 				checkbox: { label: localize('done.disbale', "Keep this extension disabled"), checked: true }
 			});
 			if (res.checkboxChecked) {

--- a/src/vs/workbench/services/extensionManagement/browser/extensionBisect.ts
+++ b/src/vs/workbench/services/extensionManagement/browser/extensionBisect.ts
@@ -64,7 +64,7 @@ class BisectState {
 	) { }
 }
 
-class ExtensionBisectService implements IExtensionBisectService {
+export class ExtensionBisectService implements IExtensionBisectService {
 
 	declare readonly _serviceBrand: undefined;
 

--- a/src/vs/workbench/services/extensionManagement/test/browser/extensionBisect.test.ts
+++ b/src/vs/workbench/services/extensionManagement/test/browser/extensionBisect.test.ts
@@ -1,0 +1,156 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { InMemoryStorageService, IStorageService } from '../../../../../platform/storage/common/storage.js';
+import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { IWorkbenchEnvironmentService } from '../../../environment/common/environmentService.js';
+import { ExtensionBisectService, IExtensionBisectService } from '../../browser/extensionBisect.js';
+import { ILocalExtension } from '../../../../../platform/extensionManagement/common/extensionManagement.js';
+import { IExtension } from '../../../../../platform/extensions/common/extensions.js';
+
+suite('ExtensionBisectService', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	let storageService: IStorageService;
+	const logService = new NullLogService();
+	const envService = {} as IWorkbenchEnvironmentService;
+
+	setup(() => {
+		storageService = disposables.add(new InMemoryStorageService());
+	});
+
+	function createService(): IExtensionBisectService {
+		// the bisect service rehydrates its in-memory state from storage in its
+		// constructor; a fresh instance is required after every state-changing
+		// call to mimic the window reload that happens between bisect steps.
+		return new ExtensionBisectService(logService, storageService, envService);
+	}
+
+	function makeExtension(id: string): ILocalExtension {
+		return {
+			identifier: { id },
+			manifest: { name: id, version: '0.0.1', publisher: 'test', activationEvents: [] }
+		} as unknown as ILocalExtension;
+	}
+
+	function disabledIds(service: IExtensionBisectService, extensions: ILocalExtension[]): string[] {
+		return extensions
+			.filter(e => service.isDisabledByBisect(e as unknown as IExtension))
+			.map(e => e.identifier.id);
+	}
+
+	test('inactive before start', () => {
+		const service = createService();
+		assert.strictEqual(service.isActive, false);
+		assert.strictEqual(service.disabledCount, -1);
+	});
+
+	test('start disables every extension and reports the full count', async () => {
+		const extensions = Array.from({ length: 12 }, (_, i) => makeExtension(`pub.ext-${i}`));
+		await createService().start(extensions);
+
+		const service = createService();
+		assert.strictEqual(service.isActive, true);
+		assert.strictEqual(service.disabledCount, extensions.length);
+		assert.deepStrictEqual(disabledIds(service, extensions), extensions.map(e => e.identifier.id));
+	});
+
+	test('first "I can\'t reproduce" disables the upper half', async () => {
+		const extensions = Array.from({ length: 12 }, (_, i) => makeExtension(`pub.ext-${i}`));
+		await createService().start(extensions);
+		await createService().next(/*seeingBad*/ false);
+
+		const service = createService();
+		assert.strictEqual(service.disabledCount, 6);
+		assert.deepStrictEqual(disabledIds(service, extensions), extensions.slice(6).map(e => e.identifier.id));
+	});
+
+	test('"still bad" keeps previously eliminated extensions disabled (issue #237092)', async () => {
+		// Start -> "can't reproduce" -> "still bad". The upper half disabled in
+		// step 1 must remain disabled in step 2, otherwise additional bad
+		// extensions hiding there will keep the bisect from converging.
+		const extensions = Array.from({ length: 12 }, (_, i) => makeExtension(`pub.ext-${i}`));
+		await createService().start(extensions);
+		await createService().next(false);
+		await createService().next(true);
+
+		const service = createService();
+		// [0, 3) enabled (active search), [3, 12) disabled (3 active + 9 skipped).
+		assert.strictEqual(service.disabledCount, 9);
+		assert.deepStrictEqual(disabledIds(service, extensions), extensions.slice(3).map(e => e.identifier.id));
+	});
+
+	test('"can\'t reproduce" after narrowing keeps known-good extensions enabled', async () => {
+		// Sequence: start -> not bad -> still bad -> not bad.
+		// After the third answer the search range is [3, 6); extensions in
+		// [0, 3) are known-good (enabled), [3, 4) is active-enabled, [4, 12)
+		// is disabled (active + skipped).
+		const extensions = Array.from({ length: 12 }, (_, i) => makeExtension(`pub.ext-${i}`));
+		await createService().start(extensions);
+		await createService().next(false);
+		await createService().next(true);
+		await createService().next(false);
+
+		const service = createService();
+		assert.strictEqual(service.disabledCount, 8);
+		assert.deepStrictEqual(disabledIds(service, extensions), extensions.slice(4).map(e => e.identifier.id));
+	});
+
+	test('disabledCount always matches the size of the disabled set', async () => {
+		const extensions = Array.from({ length: 12 }, (_, i) => makeExtension(`pub.ext-${i}`));
+		await createService().start(extensions);
+
+		const answers: boolean[] = [false, true, false, true];
+		for (let i = 0; i <= answers.length; i++) {
+			const service = createService();
+			assert.strictEqual(service.disabledCount, disabledIds(service, extensions).length, `step ${i}`);
+			if (i < answers.length) {
+				await service.next(answers[i]);
+			}
+		}
+	});
+
+	test('identifies the bad extension when narrowed to a single candidate', async () => {
+		// 4 extensions, the bad one is at index 0.
+		const extensions = Array.from({ length: 4 }, (_, i) => makeExtension(`pub.ext-${i}`));
+		await createService().start(extensions);
+		// All disabled: bug gone.
+		assert.strictEqual(await createService().next(false), undefined);
+		// [0,2) enabled, [2,4) disabled: bug reproduces (idx 0 enabled).
+		assert.strictEqual(await createService().next(true), undefined);
+		// [0,1) enabled, [1,4) disabled (active + skipped): bug reproduces.
+		assert.strictEqual(await createService().next(true), undefined);
+		// Final step: [0] disabled, [1,4) skipped/disabled — everything disabled.
+		// User answers "can't reproduce" and ext-0 is identified.
+		const result = await createService().next(false);
+		assert.deepStrictEqual(result, { id: 'pub.ext-0', bad: false });
+
+		// And state should be cleared.
+		assert.strictEqual(createService().isActive, false);
+	});
+
+	test('reports "no extension identified" when problem persists with all extensions disabled', async () => {
+		const extensions = Array.from({ length: 4 }, (_, i) => makeExtension(`pub.ext-${i}`));
+		await createService().start(extensions);
+		const result = await createService().next(/*seeingBad*/ true);
+		assert.deepStrictEqual(result, { bad: true, id: '' });
+	});
+
+	test('reset clears bisect state', async () => {
+		const extensions = Array.from({ length: 4 }, (_, i) => makeExtension(`pub.ext-${i}`));
+		await createService().start(extensions);
+		assert.strictEqual(createService().isActive, true);
+
+		await createService().reset();
+
+		const service = createService();
+		assert.strictEqual(service.isActive, false);
+		assert.strictEqual(service.disabledCount, -1);
+		assert.deepStrictEqual(disabledIds(service, extensions), []);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #237092 — Extension Bisect now keeps previously eliminated extensions disabled so that it can identify a problematic extension even when more than one extension is faulty.

**Before:** When bisect narrowed the search via a "still bad" answer, extensions outside the new search range were re-enabled. If any of those extensions were also bad, the user would keep answering "still bad" all the way to the end and bisect would conclude with the misleading "no extension has been identified" message.

**After:** Extensions in `[high, length)` — those eliminated by a "still bad" answer — stay disabled for the remainder of the bisect run. Extensions in `[0, low)` (eliminated by "I can't reproduce") were already verified safe collectively, so they remain enabled as before. Bisect now identifies one problematic extension per run; the user repeats bisect to find additional ones, as suggested in the issue's design section.

The "extension identified" confirmation also now mentions that the user may want to re-run bisect to find any additional problematic extensions.

### Algorithm change

The bisect state `(low, mid, high)` partitions extensions into four regions:

| Range            | Meaning                                              | Disabled (before)        | Disabled (after) |
|------------------|------------------------------------------------------|--------------------------|------------------|
| `[0, low)`       | Known-good (eliminated via "I can't reproduce")       | no                       | no               |
| `[low, mid)`     | Active search, currently enabled                      | no                       | no               |
| `[mid, high)`    | Active search, currently disabled                     | **yes**                  | **yes**          |
| `[high, length)` | "Skipped" (eliminated via "still bad" — bad status unknown) | no (re-enabled — bug) | **yes** (fix)    |

This simplifies to `isDisabled = i >= mid` and `disabledCount = extensions.length - mid`.

## Test plan

- [ ] Manual: start bisect with two known-bad extensions, confirm a bad one is identified and the prompt suggests re-running bisect.
- [ ] Manual: start bisect with one bad extension, confirm behavior is unchanged from the previous single-bad case.
- [ ] Manual: confirm the disabled-count notification reflects the total disabled (active + skipped), not just the active half.

---

Authored this with AI, hope that's okay :)