### PR TITLE
Store SSH remote agent hosts in storage

### DIFF
--- a/src/vs/platform/agentHost/browser/remoteAgentHostServiceImpl.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostServiceImpl.ts
@@ -133,6 +133,10 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 				this._reconcileConnections();
 			}
 		}));
+		this._register(this._storageService.onDidChangeValue(StorageScope.APPLICATION, SSH_REMOTE_AGENT_HOSTS_STORAGE_KEY, this._store)(() => {
+			this._reconcileConnections();
+			this._onDidChangeConnections.fire();
+		}));
 
 		this._migrateSSHEntriesFromSetting();
 

--- a/src/vs/platform/agentHost/browser/remoteAgentHostServiceImpl.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostServiceImpl.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 // Service implementation that manages WebSocket connections to remote agent
-// host processes. Reads addresses from the `chat.remoteAgentHosts` setting
-// and maintains connections, reconnecting as the setting changes.
+// host processes. Reads WebSocket addresses from the `chat.remoteAgentHosts`
+// setting and SSH connection details from storage, then maintains connections.
 
 import { Emitter } from '../../../base/common/event.js';
 import { Disposable, DisposableStore, IDisposable } from '../../../base/common/lifecycle.js';
@@ -15,6 +15,7 @@ import { IEnvironmentService } from '../../environment/common/environment.js';
 import { IInstantiationService } from '../../instantiation/common/instantiation.js';
 import { ILabelService } from '../../label/common/label.js';
 import { ILogService } from '../../log/common/log.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../storage/common/storage.js';
 
 import { AgentHostAhpJsonlLoggingSettingId, type IAgentConnection } from '../common/agentService.js';
 import {
@@ -37,6 +38,8 @@ import { isDefined } from '../../../base/common/types.js';
 import { PROTOCOL_VERSION } from '../common/state/protocol/version/registry.js';
 import { type IVscodeUpgradeResult } from '../common/state/protocolUpgrade.js';
 
+const SSH_REMOTE_AGENT_HOSTS_STORAGE_KEY = 'remoteAgentHost.sshConnections';
+
 /** Tracks a single remote connection through its lifecycle. */
 interface IConnectionEntry {
 	readonly store: DisposableStore;
@@ -57,6 +60,20 @@ interface IConnectionEntry {
 function disposeEntry(entry: IConnectionEntry): void {
 	entry.store.dispose();
 	entry.transportDisposable?.dispose();
+}
+
+function isRawRemoteAgentHostEntry(value: unknown): value is IRawRemoteAgentHostEntry {
+	if (typeof value !== 'object' || value === null) {
+		return false;
+	}
+	const candidate = value as Partial<Record<keyof IRawRemoteAgentHostEntry, unknown>>;
+	return typeof candidate.address === 'string'
+		&& typeof candidate.name === 'string'
+		&& (candidate.connectionToken === undefined || typeof candidate.connectionToken === 'string')
+		&& (candidate.sshConfigHost === undefined || typeof candidate.sshConfigHost === 'string')
+		&& (candidate.sshHostName === undefined || typeof candidate.sshHostName === 'string')
+		&& (candidate.sshUser === undefined || typeof candidate.sshUser === 'string')
+		&& (candidate.sshPort === undefined || typeof candidate.sshPort === 'number');
 }
 
 export class RemoteAgentHostService extends Disposable implements IRemoteAgentHostService {
@@ -106,6 +123,7 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 		@ILogService private readonly _logService: ILogService,
 		@ILabelService private readonly _labelService: ILabelService,
 		@IEnvironmentService private readonly _environmentService: IEnvironmentService,
+		@IStorageService private readonly _storageService: IStorageService,
 	) {
 		super();
 
@@ -115,6 +133,8 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 				this._reconcileConnections();
 			}
 		}));
+
+		this._migrateSSHEntriesFromSetting();
 
 		// Initial connection
 		this._reconcileConnections();
@@ -372,8 +392,8 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 			return;
 		}
 
-		const rawEntries = (this._configurationService.getValue<IRawRemoteAgentHostEntry[]>(RemoteAgentHostsSettingId) ?? []).map(rawEntryToEntry).filter(isDefined);
-		const entriesWithAddress = rawEntries.map(e => ({ entry: e, address: normalizeRemoteAgentHostAddress(getEntryAddress(e)) }));
+		const configuredEntries = this._getConfiguredEntries();
+		const entriesWithAddress = configuredEntries.map(e => ({ entry: e, address: normalizeRemoteAgentHostAddress(getEntryAddress(e)) }));
 		const desired = new Set(entriesWithAddress.map(e => e.address));
 
 		this._logService.info(`[RemoteAgentHost] Reconciling: desired=[${[...desired].join(', ')}], current=[${[...this._entries.keys()].map(a => `${a}(${this._entries.get(a)!.connected ? 'connected' : 'pending'})`).join(', ')}]`);
@@ -593,29 +613,14 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 	}
 
 	private _getConfiguredEntries(): IRemoteAgentHostEntry[] {
-		return (this._configurationService.getValue<IRawRemoteAgentHostEntry[]>(RemoteAgentHostsSettingId) ?? []).map(rawEntryToEntry).filter(isDefined);
+		return this._mergeConfiguredEntries(this._getConfiguredSettingEntries(), this._getStoredSSHEntries());
 	}
 
 	private _upsertConfiguredEntry(entry: IRemoteAgentHostEntry): IRemoteAgentHostEntry[] {
 		// Read from the same scope we'll write to, so we don't accidentally
 		// merge entries from an overriding scope (e.g. workspace) into the
 		// user scope and then lose them on the next read.
-		const target = this._getConfigurationTarget();
-		const inspected = this._configurationService.inspect<IRawRemoteAgentHostEntry[]>(RemoteAgentHostsSettingId);
-		let configuredRaw: readonly IRawRemoteAgentHostEntry[];
-		switch (target) {
-			case ConfigurationTarget.USER_LOCAL:
-				configuredRaw = inspected.userLocalValue ?? [];
-				break;
-			case ConfigurationTarget.USER_REMOTE:
-				configuredRaw = inspected.userRemoteValue ?? [];
-				break;
-			default:
-				configuredRaw = inspected.userValue ?? [];
-				break;
-		}
-
-		const configuredEntries = configuredRaw.map(rawEntryToEntry).filter((e): e is IRemoteAgentHostEntry => e !== undefined);
+		const configuredEntries = this._mergeConfiguredEntries(this._getConfiguredSettingEntriesForTarget(), this._getStoredSSHEntries());
 		const normalizedAddress = normalizeRemoteAgentHostAddress(getEntryAddress(entry));
 		const existingIndex = configuredEntries.findIndex(e => normalizeRemoteAgentHostAddress(getEntryAddress(e)) === normalizedAddress);
 		if (existingIndex === -1) {
@@ -626,7 +631,7 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 	}
 
 	private _getConfigurationTarget(): ConfigurationTarget {
-		const inspected = this._configurationService.inspect<IRemoteAgentHostEntry[]>(RemoteAgentHostsSettingId);
+		const inspected = this._configurationService.inspect<IRawRemoteAgentHostEntry[]>(RemoteAgentHostsSettingId);
 		if (inspected.userLocalValue !== undefined) {
 			return ConfigurationTarget.USER_LOCAL;
 		}
@@ -640,8 +645,86 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 	}
 
 	private async _storeConfiguredEntries(entries: IRemoteAgentHostEntry[]): Promise<void> {
-		const raw = entries.map(entryToRawEntry).filter(isDefined);
+		this._storeStoredSSHEntries(entries.filter(entry => entry.connection.type === RemoteAgentHostEntryType.SSH));
+		const raw = entries.filter(entry => entry.connection.type !== RemoteAgentHostEntryType.SSH).map(entryToRawEntry).filter(isDefined);
 		await this._configurationService.updateValue(RemoteAgentHostsSettingId, raw, this._getConfigurationTarget());
+	}
+
+	private _getConfiguredSettingEntries(): IRemoteAgentHostEntry[] {
+		return (this._configurationService.getValue<IRawRemoteAgentHostEntry[]>(RemoteAgentHostsSettingId) ?? []).map(rawEntryToEntry).filter(isDefined);
+	}
+
+	private _getConfiguredSettingEntriesForTarget(): IRemoteAgentHostEntry[] {
+		return this._getConfiguredRawEntriesForTarget().map(rawEntryToEntry).filter(isDefined);
+	}
+
+	private _getConfiguredRawEntriesForTarget(): readonly IRawRemoteAgentHostEntry[] {
+		const target = this._getConfigurationTarget();
+		const inspected = this._configurationService.inspect<IRawRemoteAgentHostEntry[]>(RemoteAgentHostsSettingId);
+		switch (target) {
+			case ConfigurationTarget.USER_LOCAL:
+				return inspected.userLocalValue ?? [];
+			case ConfigurationTarget.USER_REMOTE:
+				return inspected.userRemoteValue ?? [];
+			default:
+				return inspected.userValue ?? [];
+		}
+	}
+
+	private _getStoredSSHEntries(): IRemoteAgentHostEntry[] {
+		const raw = this._storageService.get(SSH_REMOTE_AGENT_HOSTS_STORAGE_KEY, StorageScope.APPLICATION);
+		if (!raw) {
+			return [];
+		}
+		try {
+			const parsed: unknown = JSON.parse(raw);
+			if (!Array.isArray(parsed)) {
+				return [];
+			}
+			return parsed.map(item => isRawRemoteAgentHostEntry(item) ? rawEntryToEntry(item) : undefined)
+				.filter((entry): entry is IRemoteAgentHostEntry => entry?.connection.type === RemoteAgentHostEntryType.SSH);
+		} catch {
+			return [];
+		}
+	}
+
+	private _storeStoredSSHEntries(entries: IRemoteAgentHostEntry[]): void {
+		const raw = entries.filter(entry => entry.connection.type === RemoteAgentHostEntryType.SSH).map(entryToRawEntry).filter(isDefined);
+		if (raw.length === 0) {
+			this._storageService.remove(SSH_REMOTE_AGENT_HOSTS_STORAGE_KEY, StorageScope.APPLICATION);
+		} else {
+			this._storageService.store(SSH_REMOTE_AGENT_HOSTS_STORAGE_KEY, JSON.stringify(raw), StorageScope.APPLICATION, StorageTarget.USER);
+		}
+	}
+
+	private _migrateSSHEntriesFromSetting(): void {
+		const configuredEntries = this._getConfiguredSettingEntriesForTarget();
+		const sshEntries = configuredEntries.filter(entry => entry.connection.type === RemoteAgentHostEntryType.SSH);
+		if (sshEntries.length === 0) {
+			return;
+		}
+
+		const migratedEntries = this._mergeConfiguredEntries(this._getStoredSSHEntries(), sshEntries);
+		this._storeStoredSSHEntries(migratedEntries);
+		const nonSSHEntries = configuredEntries.filter(entry => entry.connection.type !== RemoteAgentHostEntryType.SSH);
+		const raw = nonSSHEntries.map(entryToRawEntry).filter(isDefined);
+		this._configurationService.updateValue(RemoteAgentHostsSettingId, raw, this._getConfigurationTarget()).catch(err => {
+			this._logService.error('[RemoteAgentHost] Failed to migrate SSH connection details from settings to storage', err);
+		});
+	}
+
+	private _mergeConfiguredEntries(base: IRemoteAgentHostEntry[], incoming: IRemoteAgentHostEntry[]): IRemoteAgentHostEntry[] {
+		let result = base;
+		for (const entry of incoming) {
+			const normalizedAddress = normalizeRemoteAgentHostAddress(getEntryAddress(entry));
+			const existingIndex = result.findIndex(e => normalizeRemoteAgentHostAddress(getEntryAddress(e)) === normalizedAddress);
+			if (existingIndex === -1) {
+				result = [...result, entry];
+			} else {
+				result = result.map((e, index) => index === existingIndex ? entry : e);
+			}
+		}
+		return result;
 	}
 
 	private _getOrCreateConnectionWait(address: string): DeferredPromise<IRemoteAgentHostConnectionInfo> {

--- a/src/vs/platform/agentHost/common/remoteAgentHostService.ts
+++ b/src/vs/platform/agentHost/common/remoteAgentHostService.ts
@@ -208,7 +208,7 @@ export interface IRemoteAgentHostService {
 	/** Currently connected remote addresses with metadata. */
 	readonly connections: readonly IRemoteAgentHostConnectionInfo[];
 
-	/** All configured remote agent host entries from settings, regardless of connection status. */
+	/** All configured remote agent host entries, regardless of connection status. */
 	readonly configuredEntries: readonly IRemoteAgentHostEntry[];
 
 	/**

--- a/src/vs/platform/agentHost/common/remoteAgentHostService.ts
+++ b/src/vs/platform/agentHost/common/remoteAgentHostService.ts
@@ -89,7 +89,7 @@ export namespace RemoteAgentHostConnectionStatus {
 	}
 }
 
-/** Configuration key for the list of remote agent host addresses. */
+/** Configuration key for the list of WebSocket remote agent host addresses. */
 export const RemoteAgentHostsSettingId = 'chat.remoteAgentHosts';
 
 /** Configuration key to enable remote agent host connections. */
@@ -159,7 +159,7 @@ export interface IRemoteAgentHostTunnelConnection {
 
 export type RemoteAgentHostConnection = IRemoteAgentHostWebSocketConnection | IRemoteAgentHostSSHConnection | IRemoteAgentHostTunnelConnection;
 
-/** An entry in the {@link RemoteAgentHostsSettingId} setting. */
+/** A configured remote agent host entry. WebSocket entries are persisted in {@link RemoteAgentHostsSettingId}; SSH entries are persisted in storage. */
 export interface IRemoteAgentHostEntry {
 	readonly name: string;
 	readonly connectionToken?: string;
@@ -379,7 +379,7 @@ function formatRemoteAgentHostAddress(url: URL, protocol: 'ws:' | 'wss:' | undef
 	return `${base}${path}${query}`;
 }
 
-/** Raw shape of entries persisted in the {@link RemoteAgentHostsSettingId} setting. */
+/** Raw shape of persisted remote agent host entries. */
 export interface IRawRemoteAgentHostEntry {
 	readonly address: string;
 	readonly name: string;

--- a/src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts
+++ b/src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts
@@ -93,7 +93,7 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 		this.onDidReportConnectProgress = this._mainService.onDidReportConnectProgress;
 
 		// When shared process fires onDidCloseConnection, clean up the renderer-side handle.
-		// Do NOT remove the configured entry — it stays in settings so startup reconnect
+		// Do NOT remove the configured entry — it stays persisted so startup reconnect
 		// can re-establish the SSH tunnel on next launch.
 		this._register(this._mainService.onDidCloseConnection(connectionId => {
 			const handle = this._connections.get(connectionId);

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostService.test.ts
@@ -81,7 +81,12 @@ class TestConfigurationService {
 	}
 
 	async updateValue(_key: string, value: unknown): Promise<void> {
-		this._entries = (value as IRawRemoteAgentHostEntry[] | undefined) ?? [];
+		const entries = (value as IRawRemoteAgentHostEntry[] | undefined) ?? [];
+		const changed = JSON.stringify(this._entries) !== JSON.stringify(entries);
+		this._entries = entries;
+		if (!changed) {
+			return;
+		}
 		this._onDidChangeConfiguration.fire({
 			affectsConfiguration: (key: string) => key === RemoteAgentHostsSettingId || key === RemoteAgentHostsEnabledSettingId,
 		});
@@ -93,6 +98,13 @@ class TestConfigurationService {
 
 	setEntries(entries: IRemoteAgentHostEntry[]): void {
 		this._entries = entries.map(entryToRawEntry).filter((e): e is IRawRemoteAgentHostEntry => e !== undefined);
+		this._onDidChangeConfiguration.fire({
+			affectsConfiguration: (key: string) => key === RemoteAgentHostsSettingId || key === RemoteAgentHostsEnabledSettingId,
+		});
+	}
+
+	setRawEntries(entries: IRawRemoteAgentHostEntry[]): void {
+		this._entries = entries;
 		this._onDidChangeConfiguration.fire({
 			affectsConfiguration: (key: string) => key === RemoteAgentHostsSettingId || key === RemoteAgentHostsEnabledSettingId,
 		});
@@ -116,6 +128,7 @@ suite('RemoteAgentHostService', () => {
 	let configService: TestConfigurationService;
 	let createdClients: MockProtocolClient[];
 	let registeredFormatters: ResourceLabelFormatter[];
+	let instantiationService: TestInstantiationService;
 	let service: RemoteAgentHostService;
 
 	setup(() => {
@@ -124,7 +137,7 @@ suite('RemoteAgentHostService', () => {
 
 		createdClients = [];
 
-		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService = disposables.add(new TestInstantiationService());
 		instantiationService.stub(ILogService, new NullLogService());
 		instantiationService.stub(IEnvironmentService, { logsHome: URI.file('/logs') } as Partial<IEnvironmentService>);
 		instantiationService.stub(IConfigurationService, configService as Partial<IConfigurationService>);
@@ -585,6 +598,85 @@ suite('RemoteAgentHostService', () => {
 						port: 2222,
 					},
 				}],
+			});
+		});
+
+		test('migrates legacy SSH connection details from settings to storage', async () => {
+			service.dispose();
+			configService.setRawEntries([{
+				address: 'ssh:legacy',
+				name: 'Legacy SSH Host',
+				connectionToken: 'ssh-token',
+				sshConfigHost: 'legacy',
+				sshHostName: 'legacy.example',
+				sshUser: 'me',
+				sshPort: 2222,
+			}]);
+
+			service = disposables.add(instantiationService.createInstance(RemoteAgentHostService));
+
+			assert.deepStrictEqual({
+				settings: configService.entries,
+				configured: service.configuredEntries,
+			}, {
+				settings: [],
+				configured: [{
+					name: 'Legacy SSH Host',
+					connectionToken: 'ssh-token',
+					connection: {
+						type: RemoteAgentHostEntryType.SSH,
+						address: 'ssh:legacy',
+						sshConfigHost: 'legacy',
+						hostName: 'legacy.example',
+						user: 'me',
+						port: 2222,
+					},
+				}],
+			});
+
+			service.dispose();
+			service = disposables.add(instantiationService.createInstance(RemoteAgentHostService));
+
+			assert.deepStrictEqual({
+				settings: configService.entries,
+				configured: service.configuredEntries,
+			}, {
+				settings: [],
+				configured: [{
+					name: 'Legacy SSH Host',
+					connectionToken: 'ssh-token',
+					connection: {
+						type: RemoteAgentHostEntryType.SSH,
+						address: 'ssh:legacy',
+						sshConfigHost: 'legacy',
+						hostName: 'legacy.example',
+						user: 'me',
+						port: 2222,
+					},
+				}],
+			});
+		});
+
+		test('fires change when removing a storage-only SSH entry', async () => {
+			service.dispose();
+			configService.setRawEntries([{
+				address: 'ssh:legacy',
+				name: 'Legacy SSH Host',
+				sshConfigHost: 'legacy',
+				sshHostName: 'legacy.example',
+			}]);
+			service = disposables.add(instantiationService.createInstance(RemoteAgentHostService));
+
+			const changed = Event.toPromise(service.onDidChangeConnections);
+			await service.removeRemoteAgentHost('ssh:legacy');
+			await changed;
+
+			assert.deepStrictEqual({
+				settings: configService.entries,
+				configured: service.configuredEntries,
+			}, {
+				settings: [],
+				configured: [],
 			});
 		});
 	});

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostService.test.ts
@@ -18,6 +18,7 @@ import { RemoteAgentHostService } from '../../browser/remoteAgentHostServiceImpl
 import { parseRemoteAgentHostInput, RemoteAgentHostConnectionStatus, RemoteAgentHostEntryType, RemoteAgentHostsEnabledSettingId, RemoteAgentHostsSettingId, entryToRawEntry, type IRawRemoteAgentHostEntry, type IRemoteAgentHostEntry } from '../../common/remoteAgentHostService.js';
 import { AGENT_HOST_SCHEME, agentHostAuthority } from '../../common/agentHostUri.js';
 import { DeferredPromise } from '../../../../base/common/async.js';
+import { InMemoryStorageService, IStorageService } from '../../../storage/common/storage.js';
 
 // ---- Mock transport ---------------------------------------------------------
 
@@ -127,6 +128,8 @@ suite('RemoteAgentHostService', () => {
 		instantiationService.stub(ILogService, new NullLogService());
 		instantiationService.stub(IEnvironmentService, { logsHome: URI.file('/logs') } as Partial<IEnvironmentService>);
 		instantiationService.stub(IConfigurationService, configService as Partial<IConfigurationService>);
+		const storageService = disposables.add(new InMemoryStorageService());
+		instantiationService.stub(IStorageService, storageService);
 		registeredFormatters = [];
 		instantiationService.stub(ILabelService, {
 			registerFormatter(formatter: ResourceLabelFormatter) {
@@ -545,6 +548,44 @@ suite('RemoteAgentHostService', () => {
 			service.dispose();
 
 			assert.strictEqual(t.disposed(), true, 'transport disposable runs when service is disposed');
+		});
+
+		test('stores SSH connection details outside the remote hosts setting', async () => {
+			const mockClient = disposables.add(new MockProtocolClient('ssh:remote.example'));
+			await service.addManagedConnection(
+				{
+					name: 'SSH Host',
+					connectionToken: 'ssh-token',
+					connection: {
+						type: RemoteAgentHostEntryType.SSH,
+						address: 'ssh:remote.example',
+						sshConfigHost: 'remote',
+						hostName: 'remote.example',
+						user: 'me',
+						port: 2222,
+					},
+				},
+				mockClient as unknown as Parameters<typeof service.addManagedConnection>[1],
+			);
+
+			assert.deepStrictEqual({
+				settings: configService.entries,
+				configured: service.configuredEntries,
+			}, {
+				settings: [],
+				configured: [{
+					name: 'SSH Host',
+					connectionToken: 'ssh-token',
+					connection: {
+						type: RemoteAgentHostEntryType.SSH,
+						address: 'ssh:remote.example',
+						sshConfigHost: 'remote',
+						hostName: 'remote.example',
+						user: 'me',
+						port: 2222,
+					},
+				}],
+			});
 		});
 	});
 

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution.ts
@@ -797,14 +797,13 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			items: {
 				type: 'object',
 				properties: {
-					address: { type: 'string', description: nls.localize('chat.remoteAgentHosts.address', "The address of the remote agent host (e.g. \"localhost:3000\").") },
+					address: { type: 'string', description: nls.localize('chat.remoteAgentHosts.address', "The WebSocket address of the remote agent host (e.g. \"localhost:3000\").") },
 					name: { type: 'string', description: nls.localize('chat.remoteAgentHosts.name', "A display name for this remote agent host.") },
 					connectionToken: { type: 'string', description: nls.localize('chat.remoteAgentHosts.connectionToken', "An optional connection token for authenticating with the remote agent host.") },
-					sshConfigHost: { type: 'string', description: nls.localize('chat.remoteAgentHosts.sshConfigHost', "SSH config host alias for automatic reconnection via SSH tunnel.") },
 				},
 				required: ['address', 'name'],
 			},
-			description: nls.localize('chat.remoteAgentHosts', "A list of remote agent host addresses to connect to (e.g. \"localhost:3000\")."),
+			description: nls.localize('chat.remoteAgentHosts', "A list of WebSocket remote agent host addresses to connect to (e.g. \"localhost:3000\"). SSH remote agent host details are managed by VS Code."),
 			default: [],
 			scope: ConfigurationScope.APPLICATION,
 			tags: ['experimental', 'advanced'],


### PR DESCRIPTION
## Summary
- move SSH remote agent host connection details out of the `chat.remoteAgentHosts` setting and into application storage
- migrate legacy SSH entries from the setting to storage on startup
- keep the visible `chat.remoteAgentHosts` setting scoped to WebSocket remotes
- add coverage that SSH managed connections persist outside the setting while remaining in configured entries

## Validation
- `npm run compile-check-ts-native`
- `npm run gulp compile`
- `./scripts/test.sh --run src/vs/platform/agentHost/test/electron-browser/remoteAgentHostService.test.ts`
- `npm run precommit`