### PR TITLE
chat: Disable CLI state file action in Agents window

### DIFF
--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/openSessionEventsFile.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/openSessionEventsFile.test.ts
@@ -6,8 +6,14 @@
 import assert from 'assert';
 import { URI } from '../../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import type { ContextKeyValue, IContext } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { IRemoteAgentHostConnectionInfo, RemoteAgentHostConnectionStatus } from '../../../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { IsSessionsWindowContext } from '../../../../../../workbench/common/contextkeys.js';
+import { OpenCopilotCliStateFileAction } from '../../../../../../workbench/contrib/chat/browser/actions/openCopilotCliStateFileAction.js';
+import { ChatContextKeys } from '../../../../../../workbench/contrib/chat/common/actions/chatContextKeys.js';
 import { resolveEventsUri } from '../../../../../../workbench/contrib/chat/browser/copilotCliEventsUri.js';
+import { IsAgentHostSession } from '../../browser/agentHostSkillButtons.js';
+import { OpenSessionEventsFileAction } from '../../browser/openSessionEventsFileActions.js';
 
 suite('openSessionEventsFile resolveEventsUri', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
@@ -23,6 +29,41 @@ suite('openSessionEventsFile resolveEventsUri', () => {
 			status: RemoteAgentHostConnectionStatus.connected,
 		};
 	}
+
+	function context(values: Record<string, ContextKeyValue>): IContext {
+		return {
+			getValue: <T extends ContextKeyValue = ContextKeyValue>(key: string): T | undefined => values[key] as T | undefined,
+		};
+	}
+
+	test('workbench command is disabled in the Agents window', () => {
+		const workbenchPrecondition = new OpenCopilotCliStateFileAction().desc.precondition;
+		const sessionsPrecondition = new OpenSessionEventsFileAction().desc.precondition;
+
+		assert.deepStrictEqual({
+			workbenchVSCodeWindow: workbenchPrecondition?.evaluate(context({
+				[ChatContextKeys.enabled.key]: true,
+				[IsSessionsWindowContext.key]: false,
+			})),
+			workbenchAgentsWindow: workbenchPrecondition?.evaluate(context({
+				[ChatContextKeys.enabled.key]: true,
+				[IsSessionsWindowContext.key]: true,
+			})),
+			sessionsCopilotCliSession: sessionsPrecondition?.evaluate(context({
+				[ChatContextKeys.enabled.key]: true,
+				[IsAgentHostSession.key]: false,
+			})),
+			sessionsAgentHostSession: sessionsPrecondition?.evaluate(context({
+				[ChatContextKeys.enabled.key]: true,
+				[IsAgentHostSession.key]: true,
+			})),
+		}, {
+			workbenchVSCodeWindow: true,
+			workbenchAgentsWindow: false,
+			sessionsCopilotCliSession: false,
+			sessionsAgentHostSession: true,
+		});
+	});
 
 	test('local AH copilotcli session resolves to ~/.copilot/session-state/<id>/events.jsonl', () => {
 		const result = resolveEventsUri(URI.parse('agent-host-copilotcli:/abc'), userHome, () => undefined);

--- a/src/vs/workbench/contrib/chat/browser/actions/openCopilotCliStateFileAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/openCopilotCliStateFileAction.ts
@@ -9,8 +9,10 @@ import { Categories } from '../../../../../platform/action/common/actionCommonCa
 import { Action2 } from '../../../../../platform/actions/common/actions.js';
 import { agentHostAuthority } from '../../../../../platform/agentHost/common/agentHostUri.js';
 import { IRemoteAgentHostService } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
 import { INotificationService } from '../../../../../platform/notification/common/notification.js';
+import { IsSessionsWindowContext } from '../../../../common/contextkeys.js';
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
 import { IPathService } from '../../../../services/path/common/pathService.js';
 import { IChatWidgetService } from '../chat.js';
@@ -78,7 +80,10 @@ export class OpenCopilotCliStateFileAction extends Action2 {
 			title: localize2('openSessionEventsFile', "Open Copilot CLI State File"),
 			f1: true,
 			category: Categories.Developer,
-			precondition: ChatContextKeys.enabled,
+			precondition: ContextKeyExpr.and(
+				ChatContextKeys.enabled,
+				IsSessionsWindowContext.negate(),
+			),
 		});
 	}
 


### PR DESCRIPTION
## Summary
- Disable the VS Code workbench "Open Copilot CLI State File" command when running in the Agents window.
- Keep the Agents-window-specific command gated on agent-host sessions.
- Add regression coverage for the two command preconditions.

## Validation
- npm run compile-check-ts-native
- npm run valid-layers-check
- node --experimental-strip-types build/hygiene.ts src/vs/workbench/contrib/chat/browser/actions/openCopilotCliStateFileAction.ts src/vs/sessions/contrib/providers/agentHost/test/browser/openSessionEventsFile.test.ts
- node build/next/index.ts transpile && scripts/test.sh --grep "openSessionEventsFile"

(Written by Copilot)