### PR TITLE
Add chat markdown plain text fast path

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentMarkdownRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentMarkdownRenderer.ts
@@ -19,7 +19,7 @@ import { AGENT_HOST_SCHEME } from '../../../../../platform/agentHost/common/agen
 
 const _remoteImageDisallowed = () => false;
 
-const nonPlainTextMarkdownSyntax = /[\\`*[\]<>|&$~]/;
+const nonPlainTextMarkdownSyntax = /[\\`*_[\]<>|&$~]/;
 const gfmAutolink = /\b(?:https?:\/\/|www\.)/i;
 const blockMarkdownSyntax = /(^|\n)\s{0,3}(?:#{1,6}\s|>\s?|[-+]\s|\d+[.)]\s|---+\s*$)/;
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentMarkdownRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentMarkdownRenderer.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { $ } from '../../../../../base/browser/dom.js';
+import { $, reset } from '../../../../../base/browser/dom.js';
 import { IRenderedMarkdown, MarkdownRenderOptions } from '../../../../../base/browser/markdownRenderer.js';
 import { getDefaultHoverDelegate } from '../../../../../base/browser/ui/hover/hoverDelegateFactory.js';
 import { IMarkdownString } from '../../../../../base/common/htmlContent.js';
@@ -18,6 +18,25 @@ import { Schemas } from '../../../../../base/common/network.js';
 import { AGENT_HOST_SCHEME } from '../../../../../platform/agentHost/common/agentHostUri.js';
 
 const _remoteImageDisallowed = () => false;
+
+const nonPlainTextMarkdownSyntax = /[\\`*[\]<>|&$~]/;
+const gfmAutolink = /\b(?:https?:\/\/|www\.)/i;
+const blockMarkdownSyntax = /(^|\n)\s{0,3}(?:#{1,6}\s|>\s?|[-+]\s|\d+[.)]\s|---+\s*$)/;
+
+function renderPlainTextMarkdown(markdown: IMarkdownString, outElement?: HTMLElement): IRenderedMarkdown | undefined {
+	const value = markdown.value;
+	if (!value || nonPlainTextMarkdownSyntax.test(value) || gfmAutolink.test(value) || blockMarkdownSyntax.test(value)) {
+		return undefined;
+	}
+
+	const element = outElement ?? $('div');
+	element.classList.add('rendered-markdown');
+	reset(element, $('p', undefined, value.length > 100_000 ? `${value.substr(0, 100_000)}…` : value));
+	return {
+		element,
+		dispose: () => { }
+	};
+}
 
 export const allowedChatMarkdownHtmlTags = Object.freeze([
 	'b',
@@ -74,6 +93,11 @@ export class ChatContentMarkdownRenderer implements IMarkdownRenderer {
 	) { }
 
 	render(markdown: IMarkdownString, options?: MarkdownRenderOptions, outElement?: HTMLElement): IRenderedMarkdown {
+		const plainTextResult = renderPlainTextMarkdown(markdown, outElement);
+		if (plainTextResult) {
+			return plainTextResult;
+		}
+
 		options = {
 			...options,
 			sanitizerConfig: {

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatMarkdownRenderer.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatMarkdownRenderer.test.ts
@@ -25,6 +25,34 @@ suite('ChatMarkdownRenderer', () => {
 		await assertSnapshot(result.element.textContent);
 	});
 
+	test('plain text fast path preserves rendered markdown shape', () => {
+		const md = new MarkdownString('Hello, world. This_is_plain.', { isTrusted: true, supportHtml: true, supportThemeIcons: true });
+		const result = store.add(testRenderer.render(md));
+
+		assert.deepStrictEqual({
+			outerHTML: result.element.outerHTML,
+			textContent: result.element.textContent,
+		}, {
+			outerHTML: '<div class="rendered-markdown"><p>Hello, world. This_is_plain.</p></div>',
+			textContent: 'Hello, world. This_is_plain.',
+		});
+	});
+
+	test('plain text fast path reuses target element', () => {
+		const md = new MarkdownString('Hello, world.');
+		const target = document.createElement('div');
+		target.appendChild(document.createElement('span'));
+		const result = store.add(testRenderer.render(md, undefined, target));
+
+		assert.deepStrictEqual({
+			sameElement: result.element === target,
+			outerHTML: target.outerHTML,
+		}, {
+			sameElement: true,
+			outerHTML: '<div class="rendered-markdown"><p>Hello, world.</p></div>',
+		});
+	});
+
 	test('supportHtml with one-line markdown', async () => {
 		const md = new MarkdownString('**hello**');
 		md.supportHtml = true;

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatMarkdownRenderer.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatMarkdownRenderer.test.ts
@@ -26,15 +26,15 @@ suite('ChatMarkdownRenderer', () => {
 	});
 
 	test('plain text fast path preserves rendered markdown shape', () => {
-		const md = new MarkdownString('Hello, world. This_is_plain.', { isTrusted: true, supportHtml: true, supportThemeIcons: true });
+		const md = new MarkdownString('Hello, world. This is plain.', { isTrusted: true, supportHtml: true, supportThemeIcons: true });
 		const result = store.add(testRenderer.render(md));
 
 		assert.deepStrictEqual({
 			outerHTML: result.element.outerHTML,
 			textContent: result.element.textContent,
 		}, {
-			outerHTML: '<div class="rendered-markdown"><p>Hello, world. This_is_plain.</p></div>',
-			textContent: 'Hello, world. This_is_plain.',
+			outerHTML: '<div class="rendered-markdown"><p>Hello, world. This is plain.</p></div>',
+			textContent: 'Hello, world. This is plain.',
 		});
 	});
 


### PR DESCRIPTION
Summary:
- Add a chat markdown renderer fast path for plain text content with no markdown-significant syntax
- Preserve the expected rendered-markdown/p DOM shape while avoiding marked and sanitizer work
- Add focused tests for fast-path shape and target reuse

Validation:
- npm run compile-check-ts-native -- --pretty false
- ./scripts/test.sh --run src/vs/workbench/contrib/chat/test/browser/widget/chatMarkdownRenderer.test.ts
- node --experimental-strip-types build/hygiene.ts src/vs/workbench/contrib/chat/browser/widget/chatContentMarkdownRenderer.ts src/vs/workbench/contrib/chat/test/browser/widget/chatMarkdownRenderer.test.ts