### PR TITLE
agent-host: Pause SSH reconnect after auth cancellation

### DIFF
--- a/src/vs/sessions/contrib/providers/remoteAgentHost/REMOTE_AGENT_HOST_SESSIONS_PROVIDER.md
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/REMOTE_AGENT_HOST_SESSIONS_PROVIDER.md
@@ -77,6 +77,7 @@ Decoupling these allows copilot sessions from different providers (local CLI, re
 - Fires `onDidChangeSessionTypes` when the host's agent list changes
 - SSH connection progress notifications are closed when the connect promise settles; keyboard-interactive prompt cancellation rejects the connect promise as cancellation and does not show an error notification.
 - Startup SSH auto-reconnect treats keyboard-interactive cancellation as an intentional pause and does not schedule another reconnect attempt.
+- A manual SSH reconnect from the host picker bypasses that paused auto-reconnect state and starts a fresh reconnect attempt; host-picker disconnect/cancel for SSH uses the SSH service instead of removing the stored host.
 
 ## Stubbed Operations
 

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/REMOTE_AGENT_HOST_SESSIONS_PROVIDER.md
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/REMOTE_AGENT_HOST_SESSIONS_PROVIDER.md
@@ -77,7 +77,7 @@ Decoupling these allows copilot sessions from different providers (local CLI, re
 - Fires `onDidChangeSessionTypes` when the host's agent list changes
 - SSH connection progress notifications are closed when the connect promise settles; keyboard-interactive prompt cancellation rejects the connect promise as cancellation and does not show an error notification.
 - Startup SSH auto-reconnect treats keyboard-interactive cancellation as an intentional pause and does not schedule another reconnect attempt.
-- A manual SSH reconnect from the host picker bypasses that paused auto-reconnect state and starts a fresh reconnect attempt; host-picker disconnect/cancel for SSH uses the SSH service instead of removing the stored host.
+- A manual SSH reconnect from the host picker bypasses that paused auto-reconnect state and starts a fresh reconnect attempt for stored SSH hosts; host-picker disconnect/cancel for SSH uses the SSH service instead of removing the stored host.
 
 ## Stubbed Operations
 

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/REMOTE_AGENT_HOST_SESSIONS_PROVIDER.md
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/REMOTE_AGENT_HOST_SESSIONS_PROVIDER.md
@@ -76,6 +76,7 @@ Decoupling these allows copilot sessions from different providers (local CLI, re
 - Handles session notifications (`notify/sessionAdded`, `notify/sessionRemoved`) and state changes
 - Fires `onDidChangeSessionTypes` when the host's agent list changes
 - SSH connection progress notifications are closed when the connect promise settles; keyboard-interactive prompt cancellation rejects the connect promise as cancellation and does not show an error notification.
+- Startup SSH auto-reconnect treats keyboard-interactive cancellation as an intentional pause and does not schedule another reconnect attempt.
 
 ## Stubbed Operations
 

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution.ts
@@ -5,6 +5,7 @@
 
 import { Disposable, DisposableMap, DisposableStore, MutableDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { disposableTimeout } from '../../../../../base/common/async.js';
+import { isCancellationError } from '../../../../../base/common/errors.js';
 import { Event } from '../../../../../base/common/event.js';
 import { observableValue } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
@@ -105,6 +106,10 @@ export class SSHReconnectState extends Disposable {
 		this.paused = false;
 		this._timer.clear();
 	}
+}
+
+export function shouldPauseSSHReconnectAfterFailure(err: unknown): boolean {
+	return isCancellationError(err);
 }
 
 /** Per-connection state bundle, disposed when a connection is removed. */
@@ -351,8 +356,15 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 				this._sshReconnectStates.deleteAndDispose(sshConfigHost);
 				return;
 			}
-			this._logService.error(`[RemoteAgentHost] SSH reconnect failed for ${sshConfigHost}`, err);
 			const provider = this._providerInstances.get(address);
+			if (shouldPauseSSHReconnectAfterFailure(err)) {
+				this._logService.info(`[RemoteAgentHost] Pausing SSH auto-reconnect for ${sshConfigHost} after user cancellation`);
+				provider?.unpublishCachedSessions();
+				const liveState = this._getOrCreateSSHReconnectState(sshConfigHost);
+				liveState.paused = true;
+				return;
+			}
+			this._logService.error(`[RemoteAgentHost] SSH reconnect failed for ${sshConfigHost}`, err);
 			// Surface protocol-version mismatches on the provider so the
 			// workspace picker can show the host's message and the user
 			// can read it. Other errors stay as the existing disconnected

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution.ts
@@ -12,7 +12,7 @@ import { URI } from '../../../../../base/common/uri.js';
 import * as nls from '../../../../../nls.js';
 import { agentHostAuthority } from '../../../../../platform/agentHost/common/agentHostUri.js';
 import { type AgentProvider, type IAgentConnection } from '../../../../../platform/agentHost/common/agentService.js';
-import { IRemoteAgentHostConnectionInfo, IRemoteAgentHostEntry, IRemoteAgentHostService, RemoteAgentHostAutoConnectSettingId, RemoteAgentHostConnectionStatus, RemoteAgentHostEntryType, RemoteAgentHostsEnabledSettingId, RemoteAgentHostsSettingId, getEntryAddress } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { IRemoteAgentHostConnectionInfo, IRemoteAgentHostEntry, IRemoteAgentHostService, type IRemoteAgentHostSSHConnection, RemoteAgentHostAutoConnectSettingId, RemoteAgentHostConnectionStatus, RemoteAgentHostEntryType, RemoteAgentHostsEnabledSettingId, RemoteAgentHostsSettingId, getEntryAddress } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { TunnelAgentHostsSettingId } from '../../../../../platform/agentHost/common/tunnelAgentHost.js';
 import { PROTOCOL_VERSION } from '../../../../../platform/agentHost/common/state/protocol/version/registry.js';
 import { AgentHostLocalFilePermissionsSettingId } from '../../../../../platform/agentHost/common/agentHostPermissionService.js';
@@ -52,7 +52,7 @@ import { createRemoteAgentCustomizationItemProvider, createRemoteAgentHarnessDes
 import { RemoteAgentHostSessionsProvider } from './remoteAgentHostSessionsProvider.js';
 import { watchForIncompatibleNotifications } from './remoteHostOptions.js';
 import { SyncedCustomizationBundler } from './syncedCustomizationBundler.js';
-import { ISSHRemoteAgentHostService } from '../../../../../platform/agentHost/common/sshRemoteAgentHost.js';
+import { ISSHRemoteAgentHostService, SSHAuthMethod } from '../../../../../platform/agentHost/common/sshRemoteAgentHost.js';
 import { IAgentHostTerminalService } from '../../../../../workbench/contrib/terminal/browser/agentHostTerminalService.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { logTerminalRecovery } from '../../../../common/sessionsTelemetry.js';
@@ -275,12 +275,12 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 
 	private _createProvider(entry: IRemoteAgentHostEntry): void {
 		const address = getEntryAddress(entry);
-		const sshConfigHost = entry.connection.type === RemoteAgentHostEntryType.SSH ? entry.connection.sshConfigHost : undefined;
-		const connectOnDemand = sshConfigHost
-			? () => this._connectSSHOnDemand(sshConfigHost, entry.name, address)
+		const sshConnection = entry.connection.type === RemoteAgentHostEntryType.SSH ? entry.connection : undefined;
+		const connectOnDemand = sshConnection
+			? () => this._connectSSHOnDemand(sshConnection, entry.name, address)
 			: undefined;
-		const disconnectOnDemand = sshConfigHost
-			? () => this._disconnectSSHOnDemand(sshConfigHost)
+		const disconnectOnDemand = sshConnection
+			? () => this._disconnectSSHOnDemand(sshConnection)
 			: undefined;
 		const store = new DisposableStore();
 		const provider = this._instantiationService.createInstance(
@@ -348,7 +348,18 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 		}
 	}
 
-	private async _connectSSHOnDemand(sshConfigHost: string, name: string, address: string): Promise<void> {
+	private async _connectSSHOnDemand(connection: IRemoteAgentHostSSHConnection, name: string, address: string): Promise<void> {
+		const sshConfigHost = connection.sshConfigHost;
+		if (!sshConfigHost) {
+			await this._sshService.connect({
+				host: connection.hostName,
+				port: connection.port,
+				username: connection.user ?? connection.hostName,
+				authMethod: SSHAuthMethod.Agent,
+				name,
+			});
+			return;
+		}
 		if (this._pendingSSHReconnects.has(sshConfigHost)) {
 			return;
 		}
@@ -356,9 +367,14 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 		await this._attemptSSHReconnect(sshConfigHost, name, address, { userInitiated: true });
 	}
 
-	private async _disconnectSSHOnDemand(sshConfigHost: string): Promise<void> {
-		this._sshReconnectStates.deleteAndDispose(sshConfigHost);
-		await this._sshService.disconnect(sshConfigHost);
+	private async _disconnectSSHOnDemand(connection: IRemoteAgentHostSSHConnection): Promise<void> {
+		const connectionKey = connection.sshConfigHost
+			? `ssh:${connection.sshConfigHost}`
+			: `${connection.user ?? connection.hostName}@${connection.hostName}:${connection.port ?? 22}`;
+		if (connection.sshConfigHost) {
+			this._sshReconnectStates.deleteAndDispose(connection.sshConfigHost);
+		}
+		await this._sshService.disconnect(connectionKey);
 	}
 
 	private async _attemptSSHReconnect(sshConfigHost: string, name: string, address: string, options: { userInitiated?: boolean } = {}): Promise<void> {

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution.ts
@@ -275,9 +275,16 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 
 	private _createProvider(entry: IRemoteAgentHostEntry): void {
 		const address = getEntryAddress(entry);
+		const sshConfigHost = entry.connection.type === RemoteAgentHostEntryType.SSH ? entry.connection.sshConfigHost : undefined;
+		const connectOnDemand = sshConfigHost
+			? () => this._connectSSHOnDemand(sshConfigHost, entry.name, address)
+			: undefined;
+		const disconnectOnDemand = sshConfigHost
+			? () => this._disconnectSSHOnDemand(sshConfigHost)
+			: undefined;
 		const store = new DisposableStore();
 		const provider = this._instantiationService.createInstance(
-			RemoteAgentHostSessionsProvider, { address, name: entry.name });
+			RemoteAgentHostSessionsProvider, { address, name: entry.name, connectOnDemand, disconnectOnDemand });
 		store.add(provider);
 		store.add(this._sessionsProvidersService.registerProvider(provider));
 		store.add(watchForIncompatibleNotifications(provider, this._instantiationService, this._notificationService));
@@ -330,7 +337,7 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 			if (!autoConnect) {
 				continue;
 			}
-			this._attemptSSHReconnect(sshConfigHost, entry.name, address);
+			void this._attemptSSHReconnect(sshConfigHost, entry.name, address);
 		}
 
 		// Drop retry state for hosts that are no longer configured.
@@ -341,22 +348,42 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 		}
 	}
 
-	private _attemptSSHReconnect(sshConfigHost: string, name: string, address: string): void {
+	private async _connectSSHOnDemand(sshConfigHost: string, name: string, address: string): Promise<void> {
+		if (this._pendingSSHReconnects.has(sshConfigHost)) {
+			return;
+		}
+		this._sshReconnectStates.get(sshConfigHost)?.resetForResume();
+		await this._attemptSSHReconnect(sshConfigHost, name, address, { userInitiated: true });
+	}
+
+	private async _disconnectSSHOnDemand(sshConfigHost: string): Promise<void> {
+		this._sshReconnectStates.deleteAndDispose(sshConfigHost);
+		await this._sshService.disconnect(sshConfigHost);
+	}
+
+	private async _attemptSSHReconnect(sshConfigHost: string, name: string, address: string, options: { userInitiated?: boolean } = {}): Promise<void> {
 		this._pendingSSHReconnects.add(sshConfigHost);
 		const state = this._getOrCreateSSHReconnectState(sshConfigHost);
 		const attempt = state.attempts;
+		const provider = this._providerInstances.get(address);
+		if (options.userInitiated) {
+			provider?.setConnectionStatus(RemoteAgentHostConnectionStatus.connecting);
+		}
 		this._logService.info(`[RemoteAgentHost] Re-establishing SSH tunnel for ${sshConfigHost} (attempt ${attempt + 1})`);
-		this._sshService.reconnect(sshConfigHost, name).then(() => {
+		try {
+			await this._sshService.reconnect(sshConfigHost, name);
 			this._pendingSSHReconnects.delete(sshConfigHost);
 			this._sshReconnectStates.deleteAndDispose(sshConfigHost);
 			this._logService.info(`[RemoteAgentHost] SSH tunnel re-established for ${sshConfigHost}`);
-		}).catch(err => {
+		} catch (err) {
 			this._pendingSSHReconnects.delete(sshConfigHost);
 			if (!this._configurationService.getValue<boolean>(RemoteAgentHostsEnabledSettingId)) {
 				this._sshReconnectStates.deleteAndDispose(sshConfigHost);
 				return;
 			}
-			const provider = this._providerInstances.get(address);
+			if (options.userInitiated) {
+				provider?.setConnectionStatus(RemoteAgentHostConnectionStatus.disconnected);
+			}
 			if (shouldPauseSSHReconnectAfterFailure(err)) {
 				this._logService.info(`[RemoteAgentHost] Pausing SSH auto-reconnect for ${sshConfigHost} after user cancellation`);
 				provider?.unpublishCachedSessions();
@@ -391,8 +418,11 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 				liveState.paused = true;
 				return;
 			}
+			if (options.userInitiated) {
+				return;
+			}
 			this._scheduleSSHReconnect(sshConfigHost, name, address, liveState);
-		});
+		}
 	}
 
 	private _scheduleSSHReconnect(sshConfigHost: string, name: string, address: string, state: SSHReconnectState): void {
@@ -417,7 +447,7 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 			if (this._pendingSSHReconnects.has(sshConfigHost)) {
 				return;
 			}
-			this._attemptSSHReconnect(sshConfigHost, name, address);
+			void this._attemptSSHReconnect(sshConfigHost, name, address);
 		});
 	}
 

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/remoteAgentHost.contribution.test.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/remoteAgentHost.contribution.test.ts
@@ -5,9 +5,10 @@
 
 import assert from 'assert';
 import { timeout } from '../../../../../../base/common/async.js';
+import { CancellationError } from '../../../../../../base/common/errors.js';
 import { runWithFakedTimers } from '../../../../../../base/test/common/timeTravelScheduler.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
-import { SSHReconnectState } from '../../browser/remoteAgentHost.contribution.js';
+import { shouldPauseSSHReconnectAfterFailure, SSHReconnectState } from '../../browser/remoteAgentHost.contribution.js';
 
 suite('SSHReconnectState', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
@@ -96,6 +97,20 @@ suite('SSHReconnectState', () => {
 
 			await timeout(2000);
 			assert.strictEqual(fired, 0, 'pending retry must be cancelled by resetForResume');
+		});
+	});
+});
+
+suite('shouldPauseSSHReconnectAfterFailure', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('pauses reconnect after cancellation but not after regular failures', () => {
+		assert.deepStrictEqual({
+			cancellation: shouldPauseSSHReconnectAfterFailure(new CancellationError()),
+			regularError: shouldPauseSSHReconnectAfterFailure(new Error('boom')),
+		}, {
+			cancellation: true,
+			regularError: false,
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- pause startup SSH auto-reconnect when keyboard-interactive auth is canceled
- keep cached sessions unpublished after cancellation instead of scheduling another retry
- document the reconnect cancellation behavior and cover the classifier with a browser unit test

## Validation
- npm run compile-check-ts-native
- npm run valid-layers-check
- node --experimental-strip-types build/hygiene.ts src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution.ts src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/remoteAgentHost.contribution.test.ts src/vs/sessions/contrib/providers/remoteAgentHost/REMOTE_AGENT_HOST_SESSIONS_PROVIDER.md
- npm run transpile-client
- ./scripts/test.sh --run src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/remoteAgentHost.contribution.test.ts

(Written by Copilot)