### PR TITLE
Fix snippet choice trapping Shift+Tab navigation

### DIFF
--- a/src/vs/editor/contrib/snippet/browser/snippetController2.ts
+++ b/src/vs/editor/contrib/snippet/browser/snippetController2.ts
@@ -21,7 +21,7 @@ import { showSimpleSuggestions } from '../../suggest/browser/suggest.js';
 import { OvertypingCapturer } from '../../suggest/browser/suggestOvertypingCapturer.js';
 import { localize } from '../../../../nls.js';
 import { ContextKeyExpr, IContextKey, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
-import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
+import { KeybindingsRegistry, KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { ISnippetEdit, SnippetSession } from './snippetSession.js';
 import { TextModelEditSource } from '../../../common/textModelEditSource.js';
@@ -59,11 +59,13 @@ export class SnippetController2 implements IEditorContribution {
 	static readonly InSnippetMode = new RawContextKey('inSnippetMode', false, localize('inSnippetMode', "Whether the editor in current in snippet mode"));
 	static readonly HasNextTabstop = new RawContextKey('hasNextTabstop', false, localize('hasNextTabstop', "Whether there is a next tab stop when in snippet mode"));
 	static readonly HasPrevTabstop = new RawContextKey('hasPrevTabstop', false, localize('hasPrevTabstop', "Whether there is a previous tab stop when in snippet mode"));
+	static readonly InSnippetChoice = new RawContextKey('inSnippetChoice', false, localize('inSnippetChoice', "Whether the current snippet tab stop is a choice"));
 
 	private readonly _inSnippet: IContextKey<boolean>;
 	private readonly _inSnippetObservable = observableValue(this, false);
 	private readonly _hasNextTabstop: IContextKey<boolean>;
 	private readonly _hasPrevTabstop: IContextKey<boolean>;
+	private readonly _inSnippetChoice: IContextKey<boolean>;
 
 	private _session?: SnippetSession;
 	private readonly _snippetListener = new DisposableStore();
@@ -82,6 +84,7 @@ export class SnippetController2 implements IEditorContribution {
 		this._inSnippet = SnippetController2.InSnippetMode.bindTo(contextKeyService);
 		this._hasNextTabstop = SnippetController2.HasNextTabstop.bindTo(contextKeyService);
 		this._hasPrevTabstop = SnippetController2.HasPrevTabstop.bindTo(contextKeyService);
+		this._inSnippetChoice = SnippetController2.InSnippetChoice.bindTo(contextKeyService);
 	}
 
 	dispose(): void {
@@ -89,6 +92,7 @@ export class SnippetController2 implements IEditorContribution {
 		this._inSnippetObservable.set(false, undefined);
 		this._hasPrevTabstop.reset();
 		this._hasNextTabstop.reset();
+		this._inSnippetChoice.reset();
 		this._session?.dispose();
 		this._snippetListener.dispose();
 	}
@@ -257,6 +261,7 @@ export class SnippetController2 implements IEditorContribution {
 	private _handleChoice(): void {
 		if (!this._session || !this._editor.hasModel()) {
 			this._currentChoice = undefined;
+			this._inSnippetChoice.reset();
 			return;
 		}
 
@@ -264,8 +269,11 @@ export class SnippetController2 implements IEditorContribution {
 		if (!activeChoice || !this._choiceCompletions) {
 			this._choiceCompletions?.disable();
 			this._currentChoice = undefined;
+			this._inSnippetChoice.reset();
 			return;
 		}
+
+		this._inSnippetChoice.set(true);
 
 		if (this._currentChoice !== activeChoice.choice) {
 			this._currentChoice = activeChoice.choice;
@@ -290,6 +298,7 @@ export class SnippetController2 implements IEditorContribution {
 		this._inSnippetObservable.set(false, undefined);
 		this._hasPrevTabstop.reset();
 		this._hasNextTabstop.reset();
+		this._inSnippetChoice.reset();
 		this._snippetListener.clear();
 
 		this._currentChoice = undefined;
@@ -346,6 +355,7 @@ registerEditorCommand(new CommandCtor({
 		primary: KeyCode.Tab
 	}
 }));
+
 registerEditorCommand(new CommandCtor({
 	id: 'jumpToPrevSnippetPlaceholder',
 	precondition: ContextKeyExpr.and(SnippetController2.InSnippetMode, SnippetController2.HasPrevTabstop),
@@ -356,6 +366,17 @@ registerEditorCommand(new CommandCtor({
 		primary: KeyMod.Shift | KeyCode.Tab
 	}
 }));
+
+// When a snippet choice is active, the suggest widget is shown and would normally
+// claim Shift+Tab for `acceptAlternativeSelectedSuggestion`. Register a higher-weight
+// rule so Shift+Tab navigates to the previous snippet placeholder instead. See #236489.
+KeybindingsRegistry.registerKeybindingRule({
+	id: 'jumpToPrevSnippetPlaceholder',
+	weight: KeybindingWeight.EditorContrib + 91,
+	when: ContextKeyExpr.and(SnippetController2.InSnippetMode, SnippetController2.HasPrevTabstop, SnippetController2.InSnippetChoice, EditorContextKeys.textInputFocus),
+	primary: KeyMod.Shift | KeyCode.Tab
+});
+
 registerEditorCommand(new CommandCtor({
 	id: 'leaveSnippet',
 	precondition: SnippetController2.InSnippetMode,


### PR DESCRIPTION
Fixes #236489

When a snippet choice tab stop is active (e.g. `${3|I,O,IO|}`), the suggest widget shows the choice options. The suggest widget registers `Shift+Tab` as a secondary binding for `acceptAlternativeSelectedSuggestion` at `KeybindingWeight.EditorContrib + 90`, which outranked the snippet's `jumpToPrevSnippetPlaceholder` at `KeybindingWeight.EditorContrib + 30`. As a result, `Shift+Tab` could not navigate back to the previous tab stop while sitting on a choice.

### Fix

- Add a new `inSnippetChoice` context key on `SnippetController2`, set in `_handleChoice` whenever an `activeChoice` is present and reset on cancel / dispose / non-choice tab stops.
- Register an additional `Shift+Tab` keybinding rule for the existing `jumpToPrevSnippetPlaceholder` command with weight `EditorContrib + 91`, gated on `InSnippetMode && HasPrevTabstop && InSnippetChoice && textInputFocus`. This narrowly targets the choice scenario without affecting normal suggest behaviour outside snippet choices.

All 41 existing snippet controller tests still pass.