### PR TITLE
Fix phantom cursor from deeply nested snippet merges (#279349)

### DIFF
--- a/src/vs/editor/contrib/snippet/browser/snippetSession.ts
+++ b/src/vs/editor/contrib/snippet/browser/snippetSession.ts
@@ -353,9 +353,36 @@ export class OneSnippet {
 				}
 			}
 
+			// Renormalize fractional placeholder indicies back to small integers.
+			// Without this, deeply nested merges (~16+ levels) lose floating-point
+			// precision so distinct placeholders collapse onto the same index and
+			// produce phantom cursors. #279349
+			this._renormalizePlaceholderIndices();
+
 			// Last, re-create the placeholder groups by sorting placeholders by their index.
 			this._placeholderGroups = groupBy(this._snippet.placeholders, Placeholder.compareByIndex);
 		});
+	}
+
+	private _renormalizePlaceholderIndices(): void {
+		const placeholders = this._snippet.placeholders;
+		const uniqueIndices = new Set<number>();
+		for (const placeholder of placeholders) {
+			if (!placeholder.isFinalTabstop) {
+				uniqueIndices.add(placeholder.index);
+			}
+		}
+		const sorted = [...uniqueIndices].sort((a, b) => a - b);
+		const remap = new Map<number, number>();
+		for (let i = 0; i < sorted.length; i++) {
+			remap.set(sorted[i], i + 1);
+		}
+		for (const placeholder of placeholders) {
+			if (!placeholder.isFinalTabstop) {
+				placeholder.index = remap.get(placeholder.index)!;
+			}
+		}
+		this._nestingLevel = 1;
 	}
 
 	getEnclosingRange(): Range | undefined {

--- a/src/vs/editor/contrib/snippet/test/browser/snippetSession.test.ts
+++ b/src/vs/editor/contrib/snippet/test/browser/snippetSession.test.ts
@@ -487,6 +487,34 @@ suite('SnippetSession', function () {
 		assert.doesNotThrow(() => session.next());
 	});
 
+	test('snippets, deep merge does not produce phantom cursors (#279349)', function () {
+		// Recursively expanding a snippet (e.g. \sin\left(${1:x}\right)) used to assign
+		// fractional placeholder indicies. After ~16 nestings, double-precision rounding
+		// collapsed distinct placeholders onto the same index, producing a phantom cursor.
+		editor.getModel().setValue('');
+		editor.setSelection(new Selection(1, 1, 1, 1));
+		const session = new SnippetSession(editor, '\\sin\\left(${1:x}\\right) ', undefined, languageConfigurationService);
+		session.insert();
+		for (let i = 0; i < 25; i++) {
+			session.merge('\\sin\\left(${1:x}\\right) ');
+			assert.strictEqual(editor.getSelections()!.length, 1, `selection count after ${i + 1} merges`);
+		}
+	});
+
+	test('snippets, merge preserves mirrors in nested snippet', function () {
+		// Nested snippets that themselves contain mirrors ($1...$1) must still
+		// produce multi-cursor selections after renormalization of placeholder
+		// indicies, since the renormalize step maps each unique old index to a
+		// single new index.
+		editor.getModel().setValue('');
+		editor.setSelection(new Selection(1, 1, 1, 1));
+		const session = new SnippetSession(editor, '(${1:x})', undefined, languageConfigurationService);
+		session.insert();
+		session.merge('${1:y}-${1}');
+		assert.strictEqual(editor.getModel().getValue(), '(y-y)');
+		assert.strictEqual(editor.getSelections()!.length, 2);
+	});
+
 	test('snippets, merge does not throw when placeholder occurrences collapse to same position', function () {
 		// $1$1 places two zero-width occurrences of the same placeholder at the same position;
 		// the editor's cursor normalization collapses these into one selection. Previously this


### PR DESCRIPTION
Fixes #279349

## Problem
`OneSnippet.merge` encodes nested placeholder indices as fractions over an exponentially growing `_nestingLevel` (multiplied by 10 on each merge):

```ts
this._nestingLevel *= 10;
// ...
placeholder.index = placeholder.index + (nested.index / this._nestingLevel);
```

After ~16 nested merges `_nestingLevel` reaches `10^16`, which exceeds the precision of IEEE 754 doubles (`Number.EPSILON ≈ 2.22e-16`). Distinct fractional contributions collapse onto the same numeric value, so unrelated placeholders end up sharing an `index` and get grouped as mirrors by `groupBy(..., Placeholder.compareByIndex)`. The mirror grouping produces an extra (phantom) cursor at every snippet tab.

The user-visible repro is the LaTeX `\sin\left(${1:x}\right)` snippet expanded ~15–18 times in a row: after enough nestings, tabbing through placeholders produces an additional cursor parked on a previous tabstop.

## Fix
After each merge, renormalize placeholder indices back to small sequential integers (`1, 2, 3, …`) while:
- preserving mirror grouping (placeholders that previously shared an `index` still share the new one);
- preserving the final tabstop (`index === 0`);
- resetting `_nestingLevel` to `1`.

This keeps the fractional-index scheme local to a single merge, so precision is never exhausted regardless of nesting depth.

## Tests
- `snippets, deep merge does not produce phantom cursors (#279349)` — 25 nested `\sin\left(${1:x}\right)` merges, asserts the selection count stays `1`. Without the fix this fails at the 16th merge with `actual=2, expected=1`.
- `snippets, merge preserves mirrors in nested snippet` — guardrail that renormalization keeps mirror placeholders grouped (`${1:y}-${1}` merged into `(${1:x})` still yields `(y-y)` with 2 selections).

All 47 tests in `snippetSession.test.ts` pass.