### PR TITLE
Use numeric comparator when sorting mimetype indices in MimeTypeDisplayOrder.prioritize

### DIFF
--- a/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
@@ -739,7 +739,7 @@ export class MimeTypeDisplayOrder {
 		// them after it, retaining order.
 		const uniqueIndices = new Set(otherMimeTypes.map(m => this.findIndex(m, chosenIndex)));
 		uniqueIndices.delete(-1);
-		const otherIndices = Array.from(uniqueIndices).sort();
+		const otherIndices = Array.from(uniqueIndices).sort((a, b) => a - b);
 		this.order.splice(chosenIndex + 1, 0, ...otherIndices.map(i => this.order[i]));
 
 		for (let oi = otherIndices.length - 1; oi >= 0; oi--) {

--- a/src/vs/workbench/contrib/notebook/test/browser/notebookCommon.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/notebookCommon.test.ts
@@ -206,6 +206,24 @@ suite('NotebookCommon', () => {
 		disposables.dispose();
 	});
 
+	test('prioritizes mimetypes with 10+ entries (numeric index sort)', () => {
+		// Regression for the case where `Array.from(uniqueIndices).sort()` did a
+		// lexicographic sort on numeric indices, so `[2, 10]` became `[10, 2]`
+		// and the reverse-splice loop removed the wrong entries.
+		const mimes = Array.from({ length: 12 }, (_, i) => `type/${i}`);
+		const m = new MimeTypeDisplayOrder(mimes);
+		assert.deepStrictEqual(m.toArray(), mimes);
+
+		m.prioritize('type/11', ['type/2', 'type/10']);
+		assert.deepStrictEqual(m.toArray(), [
+			'type/0', 'type/1', 'type/3', 'type/4', 'type/5',
+			'type/6', 'type/7', 'type/8', 'type/9', 'type/11',
+			'type/2', 'type/10',
+		]);
+
+		disposables.dispose();
+	});
+
 	test('sortMimeTypes glob', function () {
 		assert.deepStrictEqual(
 			new MimeTypeDisplayOrder([


### PR DESCRIPTION
## Problem
`MimeTypeDisplayOrder.prioritize` collects the indices of "other" mimetypes into a `Set<number>`, sorts them, then splices them into the order array using a reverse-iteration loop:

```ts
const uniqueIndices = new Set(otherMimeTypes.map(m => this.findIndex(m, chosenIndex)));
uniqueIndices.delete(-1);
const otherIndices = Array.from(uniqueIndices).sort();   // <-- string sort
this.order.splice(chosenIndex + 1, 0, ...otherIndices.map(i => this.order[i]));
for (let oi = otherIndices.length - 1; oi >= 0; oi--) {
    this.order.splice(otherIndices[oi], 1);
}
```

`Array.prototype.sort()` without a comparator compares elements as strings, so once the display order grows to ~10+ mimetypes, indices like `[2, 10]` sort to `[10, 2]`. The reverse-iteration splice then removes rows in the wrong order — when it processes the (originally smaller) index second, every higher row has already shifted, so the wrong entry is removed. The resulting order can contain duplicates and miss the chosen mimetype entirely.

Example with 12 mimetypes (`type/0` … `type/11`), calling `prioritize('type/11', ['type/2', 'type/10'])`:

Before the fix → `['type/0', 'type/1', 'type/3', …, 'type/9', 'type/10', 'type/10', 'type/2']` (duplicated `type/10`, lost `type/11`)
After the fix → `['type/0', 'type/1', 'type/3', …, 'type/9', 'type/11', 'type/2', 'type/10']` (correct)

## Fix
Pass a numeric ascending comparator: `.sort((a, b) => a - b)`.

## Test
Adds `prioritizes mimetypes with 10+ entries (numeric index sort)` to `notebookCommon.test.ts` covering the 12-mimetype case above. Fails without the fix.