### PR TITLE
Use numeric comparator when re-indexing resolved extensions across pages

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsViews.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsViews.ts
@@ -1680,7 +1680,7 @@ export class PreferredExtensionsPagedModel implements IPagedModel<IExtension> {
 		// Skip first page as the preferred extensions are always in the first page
 		if (pageIndex !== 0 && adjustIndexOfNextPagesBy) {
 			const nextPageStartIndex = (pageIndex + 1) * this.pager.pageSize;
-			const indices = [...this.resolved.keys()].sort();
+			const indices = [...this.resolved.keys()].sort((a, b) => a - b);
 			for (const index of indices) {
 				if (index >= nextPageStartIndex) {
 					const e = this.resolved.get(index);


### PR DESCRIPTION
## Problem
`PreferredExtensionsPagedModel.populateResolvedExtensions` re-keys entries in `this.resolved` (a `Map<number, IExtension>`) when a later page contains preferred gallery extensions that shifted earlier indices:

```ts
const indices = [...this.resolved.keys()].sort();   // <-- string sort
for (const index of indices) {
    if (index >= nextPageStartIndex) {
        const e = this.resolved.get(index);
        if (e) {
            this.resolved.delete(index);
            this.resolved.set(index - adjustIndexOfNextPagesBy, e);
        }
    }
}
```

`Array.prototype.sort()` without a comparator compares elements as strings. When the resolved map spans both 2-digit and 3+ digit indices (e.g. `20, 100`), the lex order is `["100", "20"]`. The loop then processes `100` first — `set(100 - adjust, e)` — before processing `20`. If `100 - adjust ≤ 20` (typical for larger `adjustIndexOfNextPagesBy`), the `set` lands on a slot still occupied by another extension and silently overwrites it. Net effect: an extension disappears from the paged model.

The condition requires enough preferred gallery hits across pages plus a wide enough resolved-index range (≥100 entries with default page sizes), so it shows up at scale rather than in the common case.

## Fix
Pass an ascending numeric comparator: `.sort((a, b) => a - b)`.

## Tests
There's no existing unit-test scaffolding for `PreferredExtensionsPagedModel` and the bug requires a multi-page `IPager` mock with ≥100 entries plus preferred-gallery hits in non-first pages. Skipping a dedicated regression test for that — the change is a single-character comparator addition and the failure mode (overwrite during reverse re-keying) is the same defensive pattern already documented in [the sibling fix to `MimeTypeDisplayOrder.prioritize`](https://github.com/microsoft/vscode/pull/316826).