### PR TITLE
Fix language model picker visibility

### DIFF
--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsActions.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsActions.ts
@@ -469,7 +469,7 @@ export function getAvailableModels(
 	// models (those without a targetChatSessionType) since no extension
 	// registers models specifically targeting the 'local' session type.
 	if (session.sessionType === SessionType.Local) {
-		return allModels.filter(m => !m.metadata.targetChatSessionType && m.metadata.isUserSelectable);
+		return allModels.filter(m => !m.metadata.targetChatSessionType && m.metadata.isUserSelectable !== false);
 	}
 
 	return allModels.filter(m => m.metadata.targetChatSessionType === session.sessionType);

--- a/src/vs/workbench/contrib/chat/browser/chatManagement/chatModelsWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatManagement/chatModelsWidget.ts
@@ -804,6 +804,7 @@ class ActionsColumnRenderer extends ModelsTableColumnRenderer<IActionsColumnTemp
 		// Auto model cannot be pinned
 		if (entry.model.metadata.id !== 'auto') {
 			primaryActions.push(this.createPinAction(entry.model.identifier));
+			primaryActions.push(this.createVisibilityAction(entry.model.identifier, entry.model.metadata.isUserSelectable !== false));
 		}
 
 		const configActions = this.languageModelsService.getModelConfigurationActions(entry.model.identifier);
@@ -834,6 +835,20 @@ class ActionsColumnRenderer extends ModelsTableColumnRenderer<IActionsColumnTemp
 				} else {
 					this.languageModelsService.pinModel(modelIdentifier);
 				}
+				this.viewModel.refresh();
+			}
+		});
+	}
+
+	private createVisibilityAction(modelIdentifier: string, isVisible: boolean): IAction {
+		return toAction({
+			id: isVisible ? `hide.${modelIdentifier}` : `show.${modelIdentifier}`,
+			label: isVisible
+				? localize('models.hideModel', "Hide from Model Picker")
+				: localize('models.showModel', "Show in Model Picker"),
+			class: ThemeIcon.asClassName(isVisible ? Codicon.eye : Codicon.eyeClosed),
+			run: async () => {
+				await this.languageModelsService.setModelPickerVisibility(modelIdentifier, !isVisible);
 				this.viewModel.refresh();
 			}
 		});

--- a/src/vs/workbench/contrib/chat/browser/languageModelsConfigurationService.ts
+++ b/src/vs/workbench/contrib/chat/browser/languageModelsConfigurationService.ts
@@ -335,7 +335,16 @@ export class ChatLanguageModelsDataContribution extends Disposable implements IW
 							settings: {
 								type: 'object',
 								properties: {
-									[metadata.id]: metadata.configurationSchema
+									[metadata.id]: {
+										...metadata.configurationSchema,
+										properties: {
+											...metadata.configurationSchema.properties,
+											isUserSelectable: {
+												type: 'boolean',
+												description: localize('settings.modelPickerVisibility', "Whether the model is shown in the model picker.")
+											}
+										}
+									}
 								}
 							}
 						}

--- a/src/vs/workbench/contrib/chat/common/languageModels.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModels.ts
@@ -411,6 +411,11 @@ export interface ILanguageModelsService {
 	setModelConfiguration(modelId: string, values: IStringDictionary<unknown>): Promise<void>;
 
 	/**
+	 * Updates whether the given model is shown in model pickers.
+	 */
+	setModelPickerVisibility(modelId: string, visible: boolean): Promise<void>;
+
+	/**
 	 * Returns actions for configuring the given model based on its configuration schema.
 	 * For enum properties, returns submenu actions with checkable values.
 	 * Returns an empty array if the model has no configuration schema.
@@ -597,6 +602,7 @@ const CHAT_MODEL_PINNED_STORAGE_KEY = 'chatModelPinned';
 const AUTO_MODEL_IDENTIFIER = 'copilot/auto';
 const CHAT_PARTICIPANT_NAME_REGISTRY_STORAGE_KEY = 'chat.participantNameRegistry';
 const CHAT_MODELS_CONTROL_STORAGE_KEY = 'chat.modelsControl';
+const MODEL_PICKER_VISIBILITY_SETTING = 'isUserSelectable';
 
 interface IChatControlResponse {
 	readonly version: number;
@@ -875,11 +881,16 @@ export class LanguageModelsService implements ILanguageModelsService {
 				// Instead, apply the per-model config to the already-resolved models.
 				if (!vendor.configuration && allModels.length > 0) {
 					if (group.settings) {
-						for (const model of allModels) {
+						for (let i = 0; i < allModels.length; i++) {
+							const model = allModels[i];
 							const modelConfig = group.settings[model.metadata.id];
 							if (modelConfig) {
+								allModels[i] = this._applyModelSettings(model, modelConfig);
 								// Store raw config (without resolving secrets) to avoid leaking secrets on persist
-								perModelConfigurations.set(model.identifier, { ...modelConfig });
+								const providerConfig = this._getProviderModelConfiguration(modelConfig);
+								if (Object.keys(providerConfig).length > 0) {
+									perModelConfigurations.set(model.identifier, providerConfig);
+								}
 							}
 						}
 					}
@@ -902,6 +913,10 @@ export class LanguageModelsService implements ILanguageModelsService {
 							if (!models[i].metadata.detail) {
 								models[i] = { ...models[i], metadata: { ...models[i].metadata, detail: group.name } };
 							}
+							const modelConfig = group.settings?.[models[i].metadata.id];
+							if (modelConfig) {
+								models[i] = this._applyModelSettings(models[i], modelConfig);
+							}
 						}
 						allModels.push(...models);
 						languageModelsGroups.push({ group, modelIdentifiers: models.map(m => m.identifier) });
@@ -913,7 +928,10 @@ export class LanguageModelsService implements ILanguageModelsService {
 							const modelConfig = group.settings[model.metadata.id];
 							if (modelConfig) {
 								// Store raw config (without resolving secrets) to avoid leaking secrets on persist
-								perModelConfigurations.set(model.identifier, { ...modelConfig });
+								const providerConfig = this._getProviderModelConfiguration(modelConfig);
+								if (Object.keys(providerConfig).length > 0) {
+									perModelConfigurations.set(model.identifier, providerConfig);
+								}
 							}
 						}
 					}
@@ -983,6 +1001,20 @@ export class LanguageModelsService implements ILanguageModelsService {
 			}
 		}
 		return false;
+	}
+
+	private _applyModelSettings<T extends ILanguageModelChatMetadataAndIdentifier>(model: T, settings: IStringDictionary<unknown>): T {
+		const isUserSelectable = settings[MODEL_PICKER_VISIBILITY_SETTING];
+		if (typeof isUserSelectable === 'boolean') {
+			return { ...model, metadata: { ...model.metadata, isUserSelectable } };
+		}
+		return model;
+	}
+
+	private _getProviderModelConfiguration(settings: IStringDictionary<unknown>): IStringDictionary<unknown> {
+		const providerConfiguration = { ...settings };
+		delete providerConfiguration[MODEL_PICKER_VISIBILITY_SETTING];
+		return providerConfiguration;
 	}
 
 	getLanguageModelGroups(vendor: string): ILanguageModelsGroup[] {
@@ -1115,8 +1147,12 @@ export class LanguageModelsService implements ILanguageModelsService {
 			group = allGroups.find(g => g.vendor === metadata.vendor);
 		}
 
-		// Merge new values into existing config, removing properties set to their schema default
-		const existingConfig = this._modelConfigurations.get(modelId) ?? {};
+		// Merge new values into existing config, preserving model picker visibility
+		// overrides that share the same persisted settings object.
+		const existingConfig = {
+			...(group?.settings?.[metadata.id] ?? {}),
+			...(this._modelConfigurations.get(modelId) ?? {})
+		};
 		const updatedConfig = { ...existingConfig, ...values };
 		const schema = metadata.configurationSchema;
 		if (schema?.properties) {
@@ -1163,14 +1199,55 @@ export class LanguageModelsService implements ILanguageModelsService {
 			await this._languageModelsConfigurationService.addLanguageModelsProviderGroup(newGroup);
 		}
 
-		// Update the in-memory cache
-		if (Object.keys(updatedConfig).length > 0) {
-			this._modelConfigurations.set(modelId, updatedConfig);
+		// Update the in-memory provider configuration cache.
+		const providerConfig = this._getProviderModelConfiguration(updatedConfig);
+		if (Object.keys(providerConfig).length > 0) {
+			this._modelConfigurations.set(modelId, providerConfig);
 		} else {
 			this._modelConfigurations.delete(modelId);
 		}
 
 		// Notify listeners so UI (e.g., model picker label) updates
+		this._onLanguageModelChange.fire(metadata.vendor);
+	}
+
+	async setModelPickerVisibility(modelId: string, visible: boolean): Promise<void> {
+		const metadata = this._modelCache.get(modelId);
+		if (!metadata) {
+			return;
+		}
+
+		const allGroups = this._languageModelsConfigurationService.getLanguageModelsProviderGroups();
+		let group = allGroups.find(g => g.vendor === metadata.vendor && g.settings?.[metadata.id] !== undefined);
+		if (!group) {
+			group = allGroups.find(g => g.vendor === metadata.vendor);
+		}
+
+		const existingSettings = (group?.settings as IStringDictionary<IStringDictionary<unknown>> | undefined) ?? {};
+		const updatedModelSettings = {
+			...(existingSettings[metadata.id] ?? {}),
+			[MODEL_PICKER_VISIBILITY_SETTING]: visible
+		};
+		const updatedSettings = { ...existingSettings, [metadata.id]: updatedModelSettings };
+
+		if (group) {
+			await this._languageModelsConfigurationService.updateLanguageModelsProviderGroup(group, {
+				...group,
+				settings: updatedSettings
+			});
+		} else {
+			const vendor = this._vendors.get(metadata.vendor);
+			if (!vendor) {
+				return;
+			}
+			await this._languageModelsConfigurationService.addLanguageModelsProviderGroup({
+				name: vendor.displayName,
+				vendor: metadata.vendor,
+				settings: updatedSettings
+			});
+		}
+
+		this._modelCache.set(modelId, { ...metadata, isUserSelectable: visible });
 		this._onLanguageModelChange.fire(metadata.vendor);
 	}
 

--- a/src/vs/workbench/contrib/chat/common/languageModels.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModels.ts
@@ -1017,6 +1017,18 @@ export class LanguageModelsService implements ILanguageModelsService {
 		return providerConfiguration;
 	}
 
+	private _getModelProviderGroup(modelId: string, metadata: ILanguageModelChatMetadata): ILanguageModelsProviderGroup | undefined {
+		const vendorGroups = this._modelsGroups.get(metadata.vendor);
+		if (vendorGroups) {
+			for (const vendorGroup of vendorGroups) {
+				if (vendorGroup.modelIdentifiers.includes(modelId) && vendorGroup.group) {
+					return vendorGroup.group;
+				}
+			}
+		}
+		return undefined;
+	}
+
 	getLanguageModelGroups(vendor: string): ILanguageModelsGroup[] {
 		return this._modelsGroups.get(vendor) ?? [];
 	}
@@ -1218,7 +1230,13 @@ export class LanguageModelsService implements ILanguageModelsService {
 		}
 
 		const allGroups = this._languageModelsConfigurationService.getLanguageModelsProviderGroups();
-		let group = allGroups.find(g => g.vendor === metadata.vendor && g.settings?.[metadata.id] !== undefined);
+		const modelGroup = this._getModelProviderGroup(modelId, metadata);
+		let group = modelGroup
+			? allGroups.find(g => g.vendor === modelGroup.vendor && g.name === modelGroup.name) ?? modelGroup
+			: undefined;
+		if (!group) {
+			group = allGroups.find(g => g.vendor === metadata.vendor && g.settings?.[metadata.id] !== undefined);
+		}
 		if (!group) {
 			group = allGroups.find(g => g.vendor === metadata.vendor);
 		}

--- a/src/vs/workbench/contrib/chat/test/browser/chatManagement/chatModelsViewModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatManagement/chatModelsViewModel.test.ts
@@ -124,6 +124,14 @@ class MockLanguageModelsService implements ILanguageModelsService {
 	async setModelConfiguration(_modelId: string, _values: IStringDictionary<unknown>): Promise<void> {
 	}
 
+	async setModelPickerVisibility(modelId: string, visible: boolean): Promise<void> {
+		const metadata = this.models.get(modelId);
+		if (metadata) {
+			this.models.set(modelId, { ...metadata, isUserSelectable: visible });
+			this._onDidChangeLanguageModels.fire(metadata.vendor);
+		}
+	}
+
 	getModelConfigurationActions(_modelId: string): IAction[] {
 		return [];
 	}

--- a/src/vs/workbench/contrib/chat/test/common/languageModels.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/languageModels.test.ts
@@ -771,7 +771,7 @@ suite('LanguageModels - Per-Model Configuration', function () {
 						vendor: 'config-vendor',
 						name: 'default',
 						settings: {
-							'model-a': { temperature: 0.7, reasoningEffort: 'high' },
+							'model-a': { temperature: 0.7, reasoningEffort: 'high', isUserSelectable: false },
 							'model-b': { temperature: 0.2 }
 						}
 					}];
@@ -858,6 +858,11 @@ suite('LanguageModels - Per-Model Configuration', function () {
 		assert.deepStrictEqual(configB, { temperature: 0.2 });
 	});
 
+	test('model picker visibility setting updates metadata but is not provider configuration', function () {
+		assert.strictEqual(languageModelsService.lookupLanguageModel('config-vendor/default/model-a')?.isUserSelectable, false);
+		assert.deepStrictEqual(languageModelsService.getModelConfiguration('config-vendor/default/model-a'), { temperature: 0.7, reasoningEffort: 'high', maxTokens: 4096 });
+	});
+
 	test('getModelConfiguration returns undefined for unknown model', function () {
 		const config = languageModelsService.getModelConfiguration('config-vendor/default/model-c');
 		assert.strictEqual(config, undefined);
@@ -891,6 +896,91 @@ suite('LanguageModels - Per-Model Configuration', function () {
 		await request.result;
 
 		assert.deepStrictEqual(receivedOptions, { configuration: { temperature: 0.2 } });
+	});
+});
+
+suite('LanguageModels - Model Picker Visibility', function () {
+
+	const disposables = new DisposableStore();
+
+	teardown(function () {
+		disposables.clear();
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('setModelPickerVisibility persists and applies model visibility overrides', async function () {
+		const groups: ILanguageModelsProviderGroup[] = [];
+		const languageModelsService = disposables.add(new LanguageModelsService(
+			new class extends mock<IExtensionService>() {
+				override activateByEvent() {
+					return Promise.resolve();
+				}
+			},
+			new NullLogService(),
+			disposables.add(new TestStorageService()),
+			new MockContextKeyService(),
+			new class extends mock<ILanguageModelsConfigurationService>() {
+				override onDidChangeLanguageModelGroups = Event.None;
+				override getLanguageModelsProviderGroups() {
+					return groups;
+				}
+				override async addLanguageModelsProviderGroup(group: ILanguageModelsProviderGroup) {
+					groups.push(group);
+					return group;
+				}
+				override async updateLanguageModelsProviderGroup(from: ILanguageModelsProviderGroup, to: ILanguageModelsProviderGroup) {
+					const index = groups.indexOf(from);
+					if (index >= 0) {
+						groups[index] = to;
+					}
+					return to;
+				}
+			},
+			new class extends mock<IQuickInputService>() { },
+			new TestSecretStorageService(),
+			new class extends mock<IProductService>() { override readonly version = '1.100.0'; },
+			new class extends mock<IRequestService>() { },
+		));
+
+		languageModelsService.deltaLanguageModelChatProviderDescriptors([
+			{ vendor: 'visible-vendor', displayName: 'Visible Vendor', configuration: undefined, managementCommand: undefined, when: undefined }
+		], []);
+
+		disposables.add(languageModelsService.registerLanguageModelProvider('visible-vendor', {
+			onDidChange: Event.None,
+			provideLanguageModelChatInfo: async () => [{
+				metadata: {
+					extension: nullExtensionDescription.identifier,
+					name: 'Model',
+					vendor: 'visible-vendor',
+					family: 'family',
+					version: '1.0',
+					id: 'model',
+					maxInputTokens: 100,
+					maxOutputTokens: 100,
+					isDefaultForLocation: {}
+				} satisfies ILanguageModelChatMetadata,
+				identifier: 'visible-vendor/model'
+			}],
+			sendChatRequest: async () => { throw new Error(); },
+			provideTokenCount: async () => { throw new Error(); }
+		}));
+
+		await languageModelsService.selectLanguageModels({});
+		assert.notStrictEqual(languageModelsService.lookupLanguageModel('visible-vendor/model')?.isUserSelectable, false);
+
+		await languageModelsService.setModelPickerVisibility('visible-vendor/model', false);
+		assert.strictEqual(groups[0].settings?.['model']?.isUserSelectable, false);
+		assert.strictEqual(languageModelsService.lookupLanguageModel('visible-vendor/model')?.isUserSelectable, false);
+		assert.strictEqual(languageModelsService.getModelConfiguration('visible-vendor/model'), undefined);
+
+		await languageModelsService.selectLanguageModels({});
+		assert.strictEqual(languageModelsService.lookupLanguageModel('visible-vendor/model')?.isUserSelectable, false);
+
+		await languageModelsService.setModelPickerVisibility('visible-vendor/model', true);
+		assert.strictEqual(groups[0].settings?.['model']?.isUserSelectable, true);
+		assert.strictEqual(languageModelsService.lookupLanguageModel('visible-vendor/model')?.isUserSelectable, true);
 	});
 });
 

--- a/src/vs/workbench/contrib/chat/test/common/languageModels.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/languageModels.test.ts
@@ -982,6 +982,77 @@ suite('LanguageModels - Model Picker Visibility', function () {
 		assert.strictEqual(groups[0].settings?.['model']?.isUserSelectable, true);
 		assert.strictEqual(languageModelsService.lookupLanguageModel('visible-vendor/model')?.isUserSelectable, true);
 	});
+
+	test('setModelPickerVisibility persists to the resolved provider group', async function () {
+		const groups: ILanguageModelsProviderGroup[] = [
+			{ vendor: 'multi-vendor', name: 'Local' },
+			{ vendor: 'multi-vendor', name: 'Remote' }
+		];
+		const languageModelsService = disposables.add(new LanguageModelsService(
+			new class extends mock<IExtensionService>() {
+				override activateByEvent() {
+					return Promise.resolve();
+				}
+			},
+			new NullLogService(),
+			disposables.add(new TestStorageService()),
+			new MockContextKeyService(),
+			new class extends mock<ILanguageModelsConfigurationService>() {
+				override onDidChangeLanguageModelGroups = Event.None;
+				override getLanguageModelsProviderGroups() {
+					return groups;
+				}
+				override async updateLanguageModelsProviderGroup(from: ILanguageModelsProviderGroup, to: ILanguageModelsProviderGroup) {
+					const index = groups.indexOf(from);
+					if (index >= 0) {
+						groups[index] = to;
+					}
+					return to;
+				}
+			},
+			new class extends mock<IQuickInputService>() { },
+			new TestSecretStorageService(),
+			new class extends mock<IProductService>() { override readonly version = '1.100.0'; },
+			new class extends mock<IRequestService>() { },
+		));
+
+		languageModelsService.deltaLanguageModelChatProviderDescriptors([
+			{ vendor: 'multi-vendor', displayName: 'Multi Vendor', configuration: {} as unknown as undefined, managementCommand: undefined, when: undefined }
+		], []);
+
+		disposables.add(languageModelsService.registerLanguageModelProvider('multi-vendor', {
+			onDidChange: Event.None,
+			provideLanguageModelChatInfo: async (options) => {
+				if (!options.group) {
+					return [];
+				}
+				return [{
+					metadata: {
+						extension: nullExtensionDescription.identifier,
+						name: 'Shared Model',
+						vendor: 'multi-vendor',
+						family: 'shared',
+						version: '1.0',
+						id: 'shared-model',
+						maxInputTokens: 100,
+						maxOutputTokens: 100,
+						isDefaultForLocation: {}
+					} satisfies ILanguageModelChatMetadata,
+					identifier: `multi-vendor/${options.group}/shared-model`
+				}];
+			},
+			sendChatRequest: async () => { throw new Error(); },
+			provideTokenCount: async () => { throw new Error(); }
+		}));
+
+		await languageModelsService.selectLanguageModels({});
+		await languageModelsService.setModelPickerVisibility('multi-vendor/Remote/shared-model', false);
+
+		assert.strictEqual(groups[0].settings?.['shared-model']?.isUserSelectable, undefined);
+		assert.strictEqual(groups[1].settings?.['shared-model']?.isUserSelectable, false);
+		assert.notStrictEqual(languageModelsService.lookupLanguageModel('multi-vendor/Local/shared-model')?.isUserSelectable, false);
+		assert.strictEqual(languageModelsService.lookupLanguageModel('multi-vendor/Remote/shared-model')?.isUserSelectable, false);
+	});
 });
 
 suite('LanguageModels - Provider Group Detail Fallback', function () {

--- a/src/vs/workbench/contrib/chat/test/common/languageModels.ts
+++ b/src/vs/workbench/contrib/chat/test/common/languageModels.ts
@@ -83,6 +83,9 @@ export class NullLanguageModelsService implements ILanguageModelsService {
 	async setModelConfiguration(_modelId: string, _values: IStringDictionary<unknown>): Promise<void> {
 	}
 
+	async setModelPickerVisibility(_modelId: string, _visible: boolean): Promise<void> {
+	}
+
 	getModelConfigurationActions(_modelId: string): IAction[] {
 		return [];
 	}

--- a/src/vs/workbench/contrib/mcp/browser/mcpCommands.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpCommands.ts
@@ -1095,7 +1095,7 @@ export class McpConfigureSamplingModels extends Action2 {
 		const existingIds = new Set(mcpSampling.getConfig(server).allowedModels);
 		const allItems: IQuickPickItem[] = lmService.getLanguageModelIds().map(id => {
 			const model = lmService.lookupLanguageModel(id)!;
-			if (!model.isUserSelectable) {
+			if (model.isUserSelectable === false) {
 				return undefined;
 			}
 			return {


### PR DESCRIPTION
## Summary
- add a persisted model picker visibility toggle in the Manage Models panel
- apply `isUserSelectable` overrides from `chatLanguageModels.json` while keeping provider model configuration separate
- treat only explicit `isUserSelectable: false` as hidden so third-party models that omit the flag still appear in model pickers

## Tests
- `git diff --check`
- `npm run compile-check-ts-native` *(blocked: this workspace has an incomplete `node_modules` tree and `tsgo` is missing; `npm ci` and targeted package install did not restore executable packages)*
- pre-commit hook was bypassed for the same incomplete dependency tree (`event-stream` missing from `node_modules`)

Fixes #316481