### PR TITLE
Clean up a bit more of chat output webview rendering

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatOutputItemRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatOutputItemRenderer.ts
@@ -14,14 +14,15 @@ import { Disposable, DisposableStore, IDisposable } from '../../../../base/commo
 import { autorun } from '../../../../base/common/observable.js';
 import { equalsIgnoreCase } from '../../../../base/common/strings.js';
 import { URI } from '../../../../base/common/uri.js';
-import { generateUuid } from '../../../../base/common/uuid.js';
 import * as nls from '../../../../nls.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { ExtensionIdentifier } from '../../../../platform/extensions/common/extensions.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
-import { IWebview, IWebviewService, WebviewContentPurpose } from '../../../contrib/webview/browser/webview.js';
+import { IStorageService } from '../../../../platform/storage/common/storage.js';
+import { ExtensionKeyedWebviewOriginStore, IWebview, IWebviewService, WebviewContentPurpose } from '../../../contrib/webview/browser/webview.js';
 import { IExtensionService, isProposedApiEnabled } from '../../../services/extensions/common/extensions.js';
 import { ExtensionsRegistry, IExtensionPointUser } from '../../../services/extensions/common/extensionsRegistry.js';
+import { IChatWidgetService } from './chat.js';
 
 export interface IChatOutputItemRenderer {
 	renderOutputPart(mime: string, data: Uint8Array, webview: IWebview, context: IChatOutputRenderContext, token: CancellationToken): Promise<void>;
@@ -51,7 +52,7 @@ export interface IChatOutputRendererService {
 
 	renderOutputPart(mime: string, data: Uint8Array, parent: HTMLElement, webviewOptions: RenderOutputPartWebviewOptions, token: CancellationToken): Promise<RenderedOutputPart>;
 
-	renderCodeBlock(languageIdentifier: string, data: Uint8Array, parent: HTMLElement, webviewOptions: RenderOutputPartWebviewOptions, token: CancellationToken): Promise<RenderedOutputPart>;
+	renderCodeBlock(languageIdentifier: string, data: Uint8Array, parent: HTMLElement, webviewOptions: RenderCodeBlockWebviewOptions, token: CancellationToken): Promise<RenderedOutputPart>;
 }
 
 export interface RenderedOutputPart extends IDisposable {
@@ -63,8 +64,12 @@ export interface RenderedOutputPart extends IDisposable {
 
 interface RenderOutputPartWebviewOptions {
 	readonly title?: string;
-	readonly origin?: string;
 	readonly webviewState?: string;
+	readonly chatSessionResource?: URI;
+}
+
+interface RenderCodeBlockWebviewOptions extends RenderOutputPartWebviewOptions {
+	readonly chatSessionResource: URI;
 }
 
 interface ContributionEntry {
@@ -81,6 +86,8 @@ interface RendererEntry {
 export class ChatOutputRendererService extends Disposable implements IChatOutputRendererService {
 	_serviceBrand: undefined;
 
+	private readonly _originStore: ExtensionKeyedWebviewOriginStore;
+
 	private readonly _contributions = new Map</*viewType*/ string, ContributionEntry>();
 
 	private readonly _renderers = new Map</*viewType*/ string, RendererEntry>();
@@ -89,8 +96,11 @@ export class ChatOutputRendererService extends Disposable implements IChatOutput
 		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
 		@IExtensionService private readonly _extensionService: IExtensionService,
 		@IWebviewService private readonly _webviewService: IWebviewService,
+		@IChatWidgetService private readonly _chatWidgetService: IChatWidgetService,
+		@IStorageService storageService: IStorageService,
 	) {
 		super();
+		this._originStore = new ExtensionKeyedWebviewOriginStore('chatOutputRenderer.origins', storageService);
 
 		this._register(chatOutputRenderContributionPoint.setHandler(extensions => {
 			this.updateContributions(extensions);
@@ -123,7 +133,7 @@ export class ChatOutputRendererService extends Disposable implements IChatOutput
 		return this.doRenderOutputPart(rendererData, mime, data, {}, parent, webviewOptions, token);
 	}
 
-	async renderCodeBlock(languageIdentifier: string, data: Uint8Array, parent: HTMLElement, webviewOptions: RenderOutputPartWebviewOptions, token: CancellationToken): Promise<RenderedOutputPart> {
+	async renderCodeBlock(languageIdentifier: string, data: Uint8Array, parent: HTMLElement, webviewOptions: RenderCodeBlockWebviewOptions, token: CancellationToken): Promise<RenderedOutputPart> {
 		const rendererData = await this.getRendererForCodeBlock(languageIdentifier, token);
 		if (token.isCancellationRequested) {
 			throw new CancellationError();
@@ -142,7 +152,7 @@ export class ChatOutputRendererService extends Disposable implements IChatOutput
 
 		const webview = store.add(this._webviewService.createWebviewElement({
 			title: webviewOptions.title ?? '',
-			origin: webviewOptions.origin ?? generateUuid(),
+			origin: this.getOrigin(rendererData),
 			providedViewType: rendererData.viewType,
 			options: {
 				enableFindWidget: false,
@@ -153,6 +163,9 @@ export class ChatOutputRendererService extends Disposable implements IChatOutput
 			extension: rendererData.options.extension ? rendererData.options.extension : undefined,
 		}));
 		webview.setContextKeyService(store.add(this._contextKeyService.createScoped(parent)));
+		if (webviewOptions.chatSessionResource) {
+			store.add(this.delegateScrollToChatWidget(webview, webviewOptions.chatSessionResource));
+		}
 
 		const onDidChangeHeight = store.add(new Emitter<number>());
 		store.add(autorun(reader => {
@@ -180,6 +193,20 @@ export class ChatOutputRendererService extends Disposable implements IChatOutput
 				webview.reinitializeAfterDismount();
 			},
 		};
+	}
+
+	private delegateScrollToChatWidget(webview: IWebview, chatSessionResource: URI): IDisposable {
+		return webview.onDidWheel(e => {
+			this._chatWidgetService.getWidgetBySessionResource(chatSessionResource)?.delegateScrollFromMouseWheelEvent({
+				...e,
+				preventDefault: () => { },
+				stopPropagation: () => { }
+			});
+		});
+	}
+
+	private getOrigin(rendererData: RendererEntry): string | undefined {
+		return rendererData.options.extension ? this._originStore.getOrigin(rendererData.viewType, rendererData.options.extension.id) : undefined;
 	}
 
 	private async getRendererForMime(mime: string, token: CancellationToken): Promise<RendererEntry | undefined> {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMarkdownContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMarkdownContentPart.ts
@@ -25,7 +25,6 @@ import { ScrollbarVisibility } from '../../../../../../base/common/scrollable.js
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { isEqual } from '../../../../../../base/common/resources.js';
 import { URI } from '../../../../../../base/common/uri.js';
-import { generateUuid } from '../../../../../../base/common/uuid.js';
 import { Range } from '../../../../../../editor/common/core/range.js';
 import { isLocation, type SymbolTag } from '../../../../../../editor/common/languages.js';
 import { ILanguageService } from '../../../../../../editor/common/languages/language.js';
@@ -54,7 +53,7 @@ import { IChatProgressRenderableResponseContent } from '../../../common/model/ch
 import { IChatContentInlineReference, IChatMarkdownContent, IChatService, IChatUndoStop } from '../../../common/chatService/chatService.js';
 import { isRequestVM, isResponseVM } from '../../../common/model/chatViewModel.js';
 import { ChatConfiguration } from '../../../common/constants.js';
-import { IChatCodeBlockInfo, IChatWidgetService } from '../../chat.js';
+import { IChatCodeBlockInfo } from '../../chat.js';
 import { IChatOutputRendererService, type RenderedOutputPart } from '../../chatOutputItemRenderer.js';
 import { allowedChatMarkdownHtmlTags } from '../chatContentMarkdownRenderer.js';
 import { IMarkdownDiffBlockData, MarkdownDiffBlockPart, parseUnifiedDiff } from './chatDiffBlockPart.js';
@@ -709,7 +708,6 @@ class ChatOutputCodeBlockPart extends Disposable {
 		private readonly onDidChangeHeight: () => void,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IChatOutputRendererService private readonly chatOutputRendererService: IChatOutputRendererService,
-		@IChatWidgetService private readonly chatWidgetService: IChatWidgetService,
 		@IChatOutputPartStateCache private readonly stateCache: IChatOutputPartStateCache,
 	) {
 		super();
@@ -726,7 +724,7 @@ class ChatOutputCodeBlockPart extends Disposable {
 		this.element.appendChild(parent);
 
 		const stateCacheKey = `codeBlock/${context.element.sessionResource.toString()}/${context.element.id}/${codeBlockIndex}/${identifier.toLowerCase()}`;
-		const partState: IOutputPartState = this.stateCache.get(stateCacheKey) ?? { height: 0, webviewOrigin: generateUuid() };
+		const partState: IOutputPartState = this.stateCache.get(stateCacheKey) ?? { height: 0 };
 		this.stateCache.set(stateCacheKey, partState);
 		if (partState.height) {
 			parent.style.height = `${partState.height}px`;
@@ -741,7 +739,11 @@ class ChatOutputCodeBlockPart extends Disposable {
 			return;
 		}
 
-		this.chatOutputRendererService.renderCodeBlock(identifier, new TextEncoder().encode(text), parent, { origin: partState.webviewOrigin, webviewState: partState.webviewState, title }, this._disposeCts.token).then(renderedItem => {
+		this.chatOutputRendererService.renderCodeBlock(identifier, new TextEncoder().encode(text), parent, {
+			webviewState: partState.webviewState,
+			title,
+			chatSessionResource: this.context.element.sessionResource,
+		}, this._disposeCts.token).then(renderedItem => {
 			if (this._disposeCts.token.isCancellationRequested) {
 				renderedItem.dispose();
 				return;
@@ -760,14 +762,6 @@ class ChatOutputCodeBlockPart extends Disposable {
 				partState.height = newHeight;
 				this.onDidChangeHeight();
 			}));
-			this._register(renderedItem.webview.onDidWheel(e => {
-				this.chatWidgetService.getWidgetBySessionResource(this.context.element.sessionResource)?.delegateScrollFromMouseWheelEvent({
-					...e,
-					preventDefault: () => { },
-					stopPropagation: () => { }
-				});
-			}));
-
 			this._register(this.context.onDidChangeVisibility(visible => {
 				if (visible) {
 					renderedItem.reinitialize();

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatOutputPartStateCache.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatOutputPartStateCache.ts
@@ -10,7 +10,6 @@ import { IStorageService, StorageScope, StorageTarget, WillSaveStateReason } fro
 import { InstantiationType, registerSingleton } from '../../../../../../platform/instantiation/common/extensions.js';
 
 export interface IOutputPartState {
-	webviewOrigin: string;
 	height: number;
 	webviewState?: string;
 }
@@ -62,11 +61,11 @@ export class ChatOutputPartStateCache implements IChatOutputPartStateCache {
 
 	private _deserialize(raw: string): void {
 		try {
-			const data: Record<string, IOutputPartState> = JSON.parse(raw);
+			const data: Record<string, Partial<IOutputPartState>> = JSON.parse(raw);
 			for (const key in data) {
 				const state = data[key];
-				if (typeof state.webviewOrigin === 'string' && typeof state.height === 'number') {
-					this._cache.set(key, state);
+				if (typeof state.height === 'number') {
+					this._cache.set(key, { height: state.height, webviewState: typeof state.webviewState === 'string' ? state.webviewState : undefined });
 				}
 			}
 		} catch {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolOutputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolOutputPart.ts
@@ -11,12 +11,11 @@ import { Codicon } from '../../../../../../../base/common/codicons.js';
 import { isCancellationError } from '../../../../../../../base/common/errors.js';
 import { Event } from '../../../../../../../base/common/event.js';
 import { ThemeIcon } from '../../../../../../../base/common/themables.js';
-import { generateUuid } from '../../../../../../../base/common/uuid.js';
 import { localize } from '../../../../../../../nls.js';
 import { IInstantiationService } from '../../../../../../../platform/instantiation/common/instantiation.js';
 import { IChatToolInvocation, IChatToolInvocationSerialized, IToolResultOutputDetailsSerialized } from '../../../../common/chatService/chatService.js';
 import { IToolResultOutputDetails } from '../../../../common/tools/languageModelToolsService.js';
-import { IChatCodeBlockInfo, IChatWidgetService } from '../../../chat.js';
+import { IChatCodeBlockInfo } from '../../../chat.js';
 import { IChatOutputRendererService } from '../../../chatOutputItemRenderer.js';
 import { IChatContentPartRenderContext } from '../chatContentParts.js';
 import { ChatProgressSubPart } from '../chatProgressContentPart.js';
@@ -37,7 +36,6 @@ export class ChatToolOutputSubPart extends BaseChatToolInvocationSubPart {
 		private readonly context: IChatContentPartRenderContext,
 		private readonly onDidRemount: Event<void>,
 		@IChatOutputRendererService private readonly chatOutputItemRendererService: IChatOutputRendererService,
-		@IChatWidgetService private readonly chatWidgetService: IChatWidgetService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IChatOutputPartStateCache private readonly stateCache: IChatOutputPartStateCache,
 	) {
@@ -79,16 +77,13 @@ export class ChatToolOutputSubPart extends BaseChatToolInvocationSubPart {
 		parent.style.maxHeight = '80vh';
 
 		// Try to restore cached state, or create new state
-		const partState: IOutputPartState = this.stateCache.get(toolInvocation.toolCallId) ?? { height: 0, webviewOrigin: generateUuid() };
+		const partState: IOutputPartState = this.stateCache.get(toolInvocation.toolCallId) ?? { height: 0 };
 
 		// Always update the cache with the current state reference
 		this.stateCache.set(toolInvocation.toolCallId, partState);
 
 		if (partState.height) {
 			parent.style.height = `${partState.height}px`;
-		}
-		if (partState.webviewOrigin) {
-			partState.webviewOrigin = partState.webviewOrigin;
 		}
 
 		const progressMessage = dom.$('span');
@@ -97,7 +92,10 @@ export class ChatToolOutputSubPart extends BaseChatToolInvocationSubPart {
 		parent.appendChild(progressPart.domNode);
 
 		// TODO: we also need to show the tool output in the UI
-		this.chatOutputItemRendererService.renderOutputPart(details.output.mimeType, details.output.value.buffer, parent, { origin: partState.webviewOrigin, webviewState: partState.webviewState }, this._disposeCts.token).then((renderedItem) => {
+		this.chatOutputItemRendererService.renderOutputPart(details.output.mimeType, details.output.value.buffer, parent, {
+			webviewState: partState.webviewState,
+			chatSessionResource: this.context.element.sessionResource,
+		}, this._disposeCts.token).then((renderedItem) => {
 			if (this._disposeCts.token.isCancellationRequested) {
 				return;
 			}
@@ -112,14 +110,6 @@ export class ChatToolOutputSubPart extends BaseChatToolInvocationSubPart {
 
 			this._register(renderedItem.onDidChangeHeight(newHeight => {
 				partState.height = newHeight;
-			}));
-
-			this._register(renderedItem.webview.onDidWheel(e => {
-				this.chatWidgetService.getWidgetBySessionResource(this.context.element.sessionResource)?.delegateScrollFromMouseWheelEvent({
-					...e,
-					preventDefault: () => { },
-					stopPropagation: () => { }
-				});
 			}));
 
 			// When the webview is disconnected from the DOM due to being hidden, we need to reload it when it is shown again.

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatMarkdownContentPart.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatMarkdownContentPart.test.ts
@@ -42,7 +42,6 @@ suite('ChatMarkdownContentPart', () => {
 	/** Data captured from each CodeBlockPart.render() call */
 	const renderedCodeBlocks: ICodeBlockData[] = [];
 	const renderedCodeBlockOutputs: { identifier: string; text: string }[] = [];
-	const renderedCodeBlockOutputOrigins: string[] = [];
 	let outputStateCache: Map<string, IOutputPartState>;
 
 	function createMockEditorPool(): EditorPool {
@@ -138,7 +137,6 @@ suite('ChatMarkdownContentPart', () => {
 		instantiationService = workbenchInstantiationService(undefined, disposables);
 		renderedCodeBlocks.length = 0;
 		renderedCodeBlockOutputs.length = 0;
-		renderedCodeBlockOutputOrigins.length = 0;
 		outputStateCache = new Map<string, IOutputPartState>();
 
 		// Seed configuration values needed by ChatEditorOptions
@@ -184,9 +182,8 @@ suite('ChatMarkdownContentPart', () => {
 			registerRenderer: () => ({ dispose: () => { } }),
 			hasCodeBlockRenderer: identifier => identifier.toLowerCase() === 'mermaid',
 			renderOutputPart: async () => { throw new Error('Unexpected output render'); },
-			renderCodeBlock: async (identifier, data, _parent, webviewOptions) => {
+			renderCodeBlock: async (identifier, data) => {
 				renderedCodeBlockOutputs.push({ identifier, text: new TextDecoder().decode(data) });
-				renderedCodeBlockOutputOrigins.push(webviewOptions.origin ?? '');
 				return {
 					webview: {
 						focus: () => { },
@@ -262,22 +259,6 @@ suite('ChatMarkdownContentPart', () => {
 		assert.strictEqual(renderedCodeBlocks.length, 0);
 		assert.deepStrictEqual(renderedCodeBlockOutputs, [{ identifier: 'Mermaid', text: 'graph TD' }]);
 		assert.ok(part.domNode.querySelector('.chat-output-code-block'));
-	});
-
-	test('reuses rendered code block origin across renders', () => {
-		const ctx = createRenderContext();
-		createMarkdownPart('```mermaid\ngraph TD\n```', ctx);
-		createMarkdownPart('```mermaid\ngraph TD\n```', ctx);
-
-		assert.deepStrictEqual({
-			renderCount: renderedCodeBlockOutputOrigins.length,
-			hasOrigin: renderedCodeBlockOutputOrigins[0].length > 0,
-			reusedOrigin: renderedCodeBlockOutputOrigins[0] === renderedCodeBlockOutputOrigins[1],
-		}, {
-			renderCount: 2,
-			hasOrigin: true,
-			reusedOrigin: true,
-		});
 	});
 
 	test('reuses rendered code block webview across incremental rerenders when content is unchanged', async () => {


### PR DESCRIPTION
- Use single origin per renderer+extension to further speed up loading (like we already do for webviews)

- Share single `delegateScrollToChatWidget` implementation instead of duplicating it

