### PR TITLE
Preserve selected Agent Host model for new Copilot CLI sessions in Agents window

### DIFF
--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostModelPicker.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostModelPicker.ts
@@ -89,10 +89,16 @@ export function resolveAgentHostModel(
 	models: readonly ILanguageModelChatMetadataAndIdentifier[],
 	sessionModelId: string | undefined,
 	storedModelId: string | undefined,
+	currentModelId?: string,
 ): ILanguageModelChatMetadataAndIdentifier | undefined {
 	const sessionModel = sessionModelId ? models.find(model => model.identifier === sessionModelId) : undefined;
 	if (sessionModel) {
 		return sessionModel;
+	}
+
+	const currentModel = currentModelId ? models.find(model => model.identifier === currentModelId) : undefined;
+	if (currentModel) {
+		return currentModel;
 	}
 
 	return storedModelId ? models.find(model => model.identifier === storedModelId) : undefined;
@@ -117,6 +123,8 @@ class AgentHostModelPickerContribution extends Disposable implements IWorkbenchC
 			Menus.NewSessionConfig, 'sessions.agentHost.modelPicker',
 			(_action, _options, scopedInstantiationService) => {
 				const currentModel = observableValue<ILanguageModelChatMetadataAndIdentifier | undefined>('currentModel', undefined);
+				let lastResourceScheme: string | undefined;
+				let lastPushedSessionId: string | undefined;
 				let settingModelInternally = false;
 				const delegate: IModelPickerDelegate = {
 					currentModel,
@@ -128,6 +136,7 @@ class AgentHostModelPickerContribution extends Disposable implements IWorkbenchC
 							storageService.store(agentHostModelPickerStorageKey(session.resource.scheme), model.identifier, StorageScope.PROFILE, StorageTarget.MACHINE);
 							const provider = sessionsProvidersService.getProviders().find(p => p.id === session.providerId);
 							provider?.setModel(session.sessionId, model.identifier);
+							lastPushedSessionId = session.sessionId;
 						}
 						if (!settingModelInternally) {
 							reportNewChatPickerClosed(telemetryService, {
@@ -153,6 +162,13 @@ class AgentHostModelPickerContribution extends Disposable implements IWorkbenchC
 				const modelPicker = scopedInstantiationService.createInstance(ModelPickerActionItem, action, delegate, pickerOptions);
 
 				const initModel = (session: ISession | undefined, sessionModelId: string | undefined, isUntitled: boolean) => {
+					const resourceScheme = session?.resource.scheme;
+					if (resourceScheme !== lastResourceScheme) {
+						currentModel.set(undefined, undefined);
+						lastResourceScheme = resourceScheme;
+						lastPushedSessionId = undefined;
+					}
+
 					const models = getAgentHostModels(languageModelsService, session);
 					modelPicker.setEnabled(models.length > 0);
 
@@ -164,12 +180,18 @@ class AgentHostModelPickerContribution extends Disposable implements IWorkbenchC
 					const storedModelId = isUntitled
 						? storageService.get(agentHostModelPickerStorageKey(session.resource.scheme), StorageScope.PROFILE)
 						: undefined;
-					const resolvedModel = resolveAgentHostModel(models, sessionModelId, storedModelId);
+					const resolvedModel = resolveAgentHostModel(models, sessionModelId, storedModelId, isUntitled ? currentModel.get()?.identifier : undefined);
 					currentModel.set(resolvedModel, undefined);
-					if (!sessionModelId && isUntitled && resolvedModel) {
+					if (!isUntitled || sessionModelId) {
+						lastPushedSessionId = session.sessionId;
+						return;
+					}
+
+					if (resolvedModel && session.sessionId !== lastPushedSessionId) {
 						settingModelInternally = true;
 						try {
 							delegate.setModel(resolvedModel);
+							lastPushedSessionId = session.sessionId;
 						} finally {
 							settingModelInternally = false;
 						}

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostModelPicker.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostModelPicker.ts
@@ -135,8 +135,10 @@ class AgentHostModelPickerContribution extends Disposable implements IWorkbenchC
 						if (session) {
 							storageService.store(agentHostModelPickerStorageKey(session.resource.scheme), model.identifier, StorageScope.PROFILE, StorageTarget.MACHINE);
 							const provider = sessionsProvidersService.getProviders().find(p => p.id === session.providerId);
-							provider?.setModel(session.sessionId, model.identifier);
-							lastPushedSessionId = session.sessionId;
+							if (provider) {
+								provider.setModel(session.sessionId, model.identifier);
+								lastPushedSessionId = session.sessionId;
+							}
 						}
 						if (!settingModelInternally) {
 							reportNewChatPickerClosed(telemetryService, {
@@ -180,7 +182,7 @@ class AgentHostModelPickerContribution extends Disposable implements IWorkbenchC
 					const storedModelId = isUntitled
 						? storageService.get(agentHostModelPickerStorageKey(session.resource.scheme), StorageScope.PROFILE)
 						: undefined;
-					const resolvedModel = resolveAgentHostModel(models, sessionModelId, storedModelId, isUntitled ? currentModel.get()?.identifier : undefined);
+					const resolvedModel = resolveAgentHostModel(models, sessionModelId, storedModelId, isUntitled && !sessionModelId ? currentModel.get()?.identifier : undefined);
 					currentModel.set(resolvedModel, undefined);
 					if (!isUntitled || sessionModelId) {
 						lastPushedSessionId = session.sessionId;

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -590,6 +590,12 @@ class NewSession extends Disposable {
 	 */
 	private readonly _stateListener = this._register(new MutableDisposable());
 	private readonly _onSessionState: ((sessionId: string, state: SessionState | undefined) => void) | undefined;
+	/**
+	 * Model selection pending dispatch to the eager backend session. Set when
+	 * {@link setSelectedModelId} is called before {@link eagerCreate} finishes,
+	 * or updated when called after. Cleared after the dispatch is sent.
+	 */
+	private _pendingModelSelection: ModelSelection | undefined;
 
 	private readonly _logService: ILogService;
 	private readonly _providerId: string;
@@ -670,9 +676,33 @@ class NewSession extends Disposable {
 
 	// -- Picker mutations ----------------------------------------------------
 
-	setSelectedModelId(modelId: string): void {
+	setSelectedModelId(modelId: string, modelSelection?: ModelSelection): void {
 		this._selectedModelId = modelId;
 		this._modelId.set(modelId, undefined);
+
+		// If the eager backend session has already been created, dispatch the
+		// model change immediately so the backend summary reflects the correct
+		// model before the first turn starts, preventing the transient flicker
+		// to the default model (Claude Sonnet 4.6 Medium).
+		if (modelSelection) {
+			this._pendingModelSelection = modelSelection;
+			// Only dispatch once createSession() has resolved (_subscription is
+			// the sentinel — it is set only after the wire round-trip completes).
+			if (this._subscription && this._connection && this._backendUri) {
+				this._flushModelToBackend(this._connection, this._backendUri);
+			}
+		}
+	}
+
+	/** Dispatch a `SessionModelChanged` action to the already-created eager backend session. */
+	private _flushModelToBackend(connection: IAgentConnection, backendUri: URI): void {
+		const modelSelection = this._pendingModelSelection;
+		if (!modelSelection) {
+			return;
+		}
+		this._pendingModelSelection = undefined;
+		const action = { type: ActionType.SessionModelChanged as const, model: modelSelection };
+		connection.dispatch(backendUri.toString(), action);
 	}
 
 	getSelectedModelId(): string | undefined { return this._selectedModelId; }
@@ -855,6 +885,12 @@ class NewSession extends Disposable {
 					onSessionState(this.sessionId, state);
 				});
 			}
+
+			// If the picker already selected a model before eager create
+			// finished, dispatch it now so the backend summary shows the
+			// correct model from the start, preventing the transient flicker
+			// to the default model.
+			this._flushModelToBackend(connection, backendUri);
 		})();
 	}
 
@@ -1581,7 +1617,13 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 
 	setModel(sessionId: string, modelId: string): void {
 		if (this._newSession?.sessionId === sessionId) {
-			this._newSession.setSelectedModelId(modelId);
+			// Build the ModelSelection so NewSession can dispatch it to the
+			// eager backend session immediately (prevents the transient flicker
+			// to the default model before the first turn starts).
+			const resourceScheme = this._newSession.session.resource.scheme;
+			const rawModelId = modelId.startsWith(`${resourceScheme}:`) ? modelId.substring(resourceScheme.length + 1) : modelId;
+			const modelSelection: ModelSelection = { id: rawModelId };
+			this._newSession.setSelectedModelId(modelId, modelSelection);
 			return;
 		}
 

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -2195,14 +2195,20 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 	private _handleModelChanged(session: string, model: ModelSelection): void {
 		const rawId = AgentSession.id(session);
 		const cached = this._sessionCache.get(rawId);
-		if (cached) {
-			cached.modelSelection = model;
-		}
-		const modelId = cached ? `${cached.resource.scheme}:${model.id}` : undefined;
-		if (cached && cached.modelId.get() !== modelId) {
-			cached.modelId.set(modelId, undefined);
+		if (cached && this._updateCachedModel(cached, model)) {
 			this._onDidChangeSessions.fire({ added: [], removed: [], changed: [cached] });
 		}
+	}
+
+	private _updateCachedModel(cached: AgentHostSessionAdapter, model: ModelSelection | undefined): boolean {
+		const didModelSelectionChange = cached.modelSelection?.id !== model?.id || !equals(cached.modelSelection?.config, model?.config);
+		cached.modelSelection = model;
+		const modelId = model ? `${cached.resource.scheme}:${model.id}` : undefined;
+		if (cached.modelId.get() !== modelId) {
+			cached.modelId.set(modelId, undefined);
+			return true;
+		}
+		return didModelSelectionChange;
 	}
 
 	private _handleAgentChanged(session: string, agent: AgentSelection | undefined): void {
@@ -2259,6 +2265,10 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 		// templates). The chip aggregate is recomputed from those counts
 		// here; per-file detail is not part of this notification path.
 		if (changes.changesets !== undefined && cached.applyCatalogueCounts(changes.changesets)) {
+			didChange = true;
+		}
+
+		if (Object.prototype.hasOwnProperty.call(changes, 'model') && this._updateCachedModel(cached, changes.model)) {
 			didChange = true;
 		}
 

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/agentHostModelPicker.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/agentHostModelPicker.test.ts
@@ -71,6 +71,18 @@ suite('AgentHostModelPicker', () => {
 		assert.strictEqual(resolveAgentHostModel(models, undefined, 'agent-host-copilotcli:stored'), models[1]);
 	});
 
+	test('uses the current picker model before the stored model for new untitled sessions', () => {
+		const models = [
+			makeModel('agent-host-copilotcli:current'),
+			makeModel('agent-host-copilotcli:stored'),
+		];
+
+		assert.strictEqual(
+			resolveAgentHostModel(models, undefined, 'agent-host-copilotcli:stored', 'agent-host-copilotcli:current'),
+			models[0],
+		);
+	});
+
 	test('does not fall back to the first model for new untitled sessions without stored state', () => {
 		const models = [
 			makeModel('agent-host-copilotcli:first'),

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
@@ -665,6 +665,54 @@ suite('LocalAgentHostSessionsProvider', () => {
 		});
 	});
 
+	test('setModel on new session before eager create completes queues model and dispatches after createSession resolves', async () => {
+		const provider = createProvider(disposables, agentHost);
+		const workspaceUri = URI.parse('file:///home/user/project');
+		const session = provider.createNewSession(workspaceUri, provider.sessionTypes[0].id);
+
+		// Set model before the eager createSession round-trip resolves
+		provider.setModel(session.sessionId, 'agent-host-copilotcli:gpt-5-5-xhigh');
+
+		// No dispatch yet — backend session hasn't been created
+		assert.strictEqual(agentHost.dispatchedActions.length, 0, 'no dispatch before eager create completes');
+
+		await timeout(0); // let eager createSession resolve
+
+		const rawId = session.resource.path.substring(1);
+		const expectedBackendUri = AgentSession.uri(provider.sessionTypes[0].id, rawId);
+
+		const lastDispatch = agentHost.dispatchedActions.at(-1);
+		assert.deepStrictEqual({ channel: lastDispatch?.channel, action: lastDispatch?.action }, {
+			channel: expectedBackendUri.toString(),
+			action: {
+				type: ActionType.SessionModelChanged,
+				model: { id: 'gpt-5-5-xhigh' },
+			},
+		}, 'queued model should be dispatched once eager create completes');
+	});
+
+	test('setModel on new session after eager create completes dispatches immediately', async () => {
+		const provider = createProvider(disposables, agentHost);
+		const workspaceUri = URI.parse('file:///home/user/project');
+		const session = provider.createNewSession(workspaceUri, provider.sessionTypes[0].id);
+
+		await timeout(0); // let eager createSession resolve first
+
+		const rawId = session.resource.path.substring(1);
+		const expectedBackendUri = AgentSession.uri(provider.sessionTypes[0].id, rawId);
+
+		provider.setModel(session.sessionId, 'agent-host-copilotcli:gpt-5-5-xhigh');
+
+		const lastDispatch = agentHost.dispatchedActions.at(-1);
+		assert.deepStrictEqual({ channel: lastDispatch?.channel, action: lastDispatch?.action }, {
+			channel: expectedBackendUri.toString(),
+			action: {
+				type: ActionType.SessionModelChanged,
+				model: { id: 'gpt-5-5-xhigh' },
+			},
+		}, 'model should be dispatched immediately when eager create has already completed');
+	});
+
 	test('setAgent updates existing session agent and dispatches SessionAgentChanged', () => {
 		const provider = createProvider(disposables, agentHost);
 		fireSessionAdded(agentHost, 'set-agent', { title: 'Set Agent Session' });

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
@@ -1306,6 +1306,39 @@ suite('LocalAgentHostSessionsProvider', () => {
 		assert.strictEqual(changes[0].changed.length, 1);
 	});
 
+	test('SessionSummaryChanged notification updates cached model', () => {
+		const provider = createProvider(disposables, agentHost);
+		fireSessionAdded(agentHost, 'summary-model-change', { title: 'Summary Model Change', model: 'old-model' });
+
+		const target = provider.getSessions().find(s => s.title.get() === 'Summary Model Change');
+		assert.ok(target);
+
+		const changes: ISessionChangeEvent[] = [];
+		disposables.add(provider.onDidChangeSessions(e => changes.push(e)));
+
+		const backendSession = AgentSession.uri('copilotcli', 'summary-model-change').toString();
+		agentHost.fireNotification({
+			channel: 'ahp-root://',
+			type: NotificationType.SessionSummaryChanged,
+			session: backendSession,
+			changes: { model: { id: 'new-model' } },
+		});
+		agentHost.fireNotification({
+			channel: 'ahp-root://',
+			type: NotificationType.SessionSummaryChanged,
+			session: backendSession,
+			changes: { model: undefined },
+		});
+
+		assert.deepStrictEqual({
+			modelId: target!.modelId.get(),
+			changedSessionIds: changes.flatMap(e => e.changed.map(s => s.sessionId)),
+		}, {
+			modelId: undefined,
+			changedSessionIds: [target!.sessionId, target!.sessionId],
+		});
+	});
+
 	// ---- Refresh on turnComplete -------
 
 	test('turnComplete action triggers session refresh', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {


### PR DESCRIPTION
Fixes #316044

## Summary

This fixes an Agent Host model-selection race where the model picker could show the intended model, such as GPT-5.5 XHigh or Claude Opus 4.7, while a new Copilot CLI session still briefly used or displayed the backend default model, **Claude Sonnet 4.6 Medium**.

The change ensures that new untitled Agent Host sessions receive the selected model before the first message is sent, and that eagerly-created backend sessions are updated with the selected model as soon as they are available. This keeps the picker, session cache, and backend session summary aligned during new session startup.

## Root cause

The first-send path only includes `userSelectedModelId` and the corresponding model configuration when the `NewSession` already has a selected model.

For new untitled Agent Host sessions, the picker could resolve and display a model from current picker state or stored profile state without pushing that model into the backing session before send. In that case, the first request was sent without `userSelectedModelId`, allowing the backend to fall back to its default model.

Cached session model state was also only updated from dedicated model-change actions. When a session summary update included `changes.model`, the cached `modelId` and `modelSelection` could remain stale.

There was one related startup flicker: `NewSession.eagerCreate()` creates the backend session before the selected model is propagated to it. The backend can initially summarize the session with its default model, Claude Sonnet 4.6 Medium, before the later first-turn `SessionModelChanged` action corrects it.

Figure 1.1: The session automatically switches to Claude Sonnet 4.6 Medium even though GPT-5.5 XHigh was initially selected
<img width="868" height="717" alt="image" src="https://github.com/user-attachments/assets/cfda459c-9bc3-4e02-abb3-e4d50c1fdd43" />


## Fix

- Applies the resolved picker model to new untitled Agent Host sessions before first send.
- Uses the current picker selection before falling back to the stored profile model for new untitled sessions.
- Avoids changing sessions that already have an explicit model.
- Keeps picker state scoped to the Agent Host resource scheme.
- Updates cached session model state when `SessionSummaryChanged` includes `changes.model`, including explicit model clearing.
- Queues the selected model while eager backend session creation is in flight.
- Dispatches `SessionModelChanged` once eager `createSession()` completes, or immediately if the eager backend session already exists, preventing the transient Claude Sonnet 4.6 Medium flicker.

## Validation
Figure 2.1: Start a new Copilot CLI session with GPT-5.5 XHigh selected in the model picker
<img width="989" height="737" alt="image" src="https://github.com/user-attachments/assets/1708a8e2-dd43-4534-a5f1-bb207a76018d" />
<br>
Figure 2.2: During processing, the UI continues to display the user-selected model instead of briefly falling back to Claude Sonnet 4.6 Medium
<img width="987" height="737" alt="image" src="https://github.com/user-attachments/assets/f047849a-1b11-4993-90bb-9f992fb6ea7d" />
<br>
Figure 2.3: After completion, the session still displays the user-selected model rather than Claude Sonnet 4.6 Medium
<img width="979" height="737" alt="image" src="https://github.com/user-attachments/assets/be725ba3-72da-4c48-ac91-948e9314973d" />

