### PR TITLE
Add TS server node path picker

### DIFF
--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -2860,6 +2860,11 @@
         "category": "TypeScript"
       },
       {
+        "command": "typescript.selectNodePath",
+        "title": "%typescript.selectNodePath.title%",
+        "category": "TypeScript"
+      },
+      {
         "command": "typescript.goToProjectConfig",
         "title": "%typescript.goToProjectConfig.title%",
         "category": "TypeScript"
@@ -2958,6 +2963,10 @@
         },
         {
           "command": "typescript.selectTypeScriptVersion",
+          "when": "typescript.isManagedFile"
+        },
+        {
+          "command": "typescript.selectNodePath",
           "when": "typescript.isManagedFile"
         },
         {

--- a/extensions/typescript-language-features/package.nls.json
+++ b/extensions/typescript-language-features/package.nls.json
@@ -98,6 +98,7 @@
 	"typescript.openTsServerLog.title": "Open TS Server log",
 	"typescript.restartTsServer": "Restart TS Server",
 	"typescript.selectTypeScriptVersion.title": "Select TypeScript Version...",
+	"typescript.selectNodePath.title": "Select TS Server Node Path...",
 	"typescript.reportStyleChecksAsWarnings": "Report style checks as warnings.",
 	"configuration.reportStyleChecksAsWarnings.unifiedDeprecationMessage": "This setting is deprecated. Use `#js/ts.reportStyleChecksAsWarnings#` instead.",
 	"typescript.npm": "Specifies the path to the npm executable used for [Automatic Type Acquisition](https://code.visualstudio.com/docs/nodejs/working-with-javascript#_typings-and-automatic-type-acquisition).",

--- a/extensions/typescript-language-features/src/commands/index.ts
+++ b/extensions/typescript-language-features/src/commands/index.ts
@@ -16,6 +16,7 @@ import { OpenJsDocLinkCommand } from './openJsDocLink';
 import { OpenTsServerLogCommand } from './openTsServerLog';
 import { ReloadJavaScriptProjectsCommand, ReloadTypeScriptProjectsCommand } from './reloadProject';
 import { RestartTsServerCommand } from './restartTsServer';
+import { SelectNodeVersionCommand } from './selectNodeVersion';
 import { SelectTypeScriptVersionCommand } from './selectTypeScriptVersion';
 import { TSServerRequestCommand } from './tsserverRequests';
 
@@ -28,6 +29,7 @@ export function registerBaseCommands(
 	commandManager.register(new ReloadTypeScriptProjectsCommand(lazyClientHost));
 	commandManager.register(new ReloadJavaScriptProjectsCommand(lazyClientHost));
 	commandManager.register(new SelectTypeScriptVersionCommand(lazyClientHost));
+	commandManager.register(new SelectNodeVersionCommand(lazyClientHost));
 	commandManager.register(new OpenTsServerLogCommand(lazyClientHost));
 	commandManager.register(new RestartTsServerCommand(lazyClientHost));
 	commandManager.register(new TypeScriptGoToProjectConfigCommand(activeJsTsEditorTracker, lazyClientHost));

--- a/extensions/typescript-language-features/src/commands/selectNodeVersion.ts
+++ b/extensions/typescript-language-features/src/commands/selectNodeVersion.ts
@@ -1,0 +1,21 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import TypeScriptServiceClientHost from '../typeScriptServiceClientHost';
+import { Lazy } from '../utils/lazy';
+import { Command } from './commandManager';
+
+export class SelectNodeVersionCommand implements Command {
+	public static readonly id = 'typescript.selectNodePath';
+	public readonly id = SelectNodeVersionCommand.id;
+
+	public constructor(
+		private readonly lazyClientHost: Lazy<TypeScriptServiceClientHost>
+	) { }
+
+	public execute() {
+		this.lazyClientHost.value.serviceClient.showNodeVersionPicker();
+	}
+}

--- a/extensions/typescript-language-features/src/tsServer/nodeManager.ts
+++ b/extensions/typescript-language-features/src/tsServer/nodeManager.ts
@@ -14,6 +14,10 @@ const lastKnownWorkspaceNodeStorageKey = 'typescript.lastKnownWorkspaceNode';
 type UseWorkspaceNodeState = undefined | boolean;
 type LastKnownWorkspaceNodeState = undefined | string;
 
+interface QuickPickItem extends vscode.QuickPickItem {
+	run(): Promise<void> | void;
+}
+
 export class NodeVersionManager extends Disposable {
 	private _currentVersion: string | undefined;
 
@@ -61,6 +65,23 @@ export class NodeVersionManager extends Disposable {
 
 	public get currentVersion(): string | undefined {
 		return this._currentVersion;
+	}
+
+	public async promptUserForVersion(): Promise<void> {
+		const workspaceVersion = this.configuration.localNodePath;
+		const items: QuickPickItem[] = [
+			this.getDefaultPickItem(workspaceVersion),
+		];
+
+		if (workspaceVersion) {
+			items.push(this.getWorkspacePickItem(workspaceVersion));
+		}
+
+		const selected = await vscode.window.showQuickPick<QuickPickItem>(items, {
+			placeHolder: vscode.l10n.t("Select the Node installation used to run TS Server"),
+		});
+
+		return selected?.run();
 	}
 
 	public async updateConfiguration(nextConfiguration: TypeScriptServiceConfiguration) {
@@ -117,6 +138,40 @@ export class NodeVersionManager extends Disposable {
 				break;
 		}
 		return version;
+	}
+
+	private getDefaultPickItem(workspaceVersion: string | null): QuickPickItem {
+		const defaultVersion = this.configuration.globalNodePath || undefined;
+		const label = this.configuration.globalNodePath
+			? vscode.l10n.t("Use User Setting Node")
+			: vscode.l10n.t("Use VS Code's Node");
+
+		return {
+			label: (this.currentVersion === defaultVersion ? '• ' : '') + label,
+			description: this.configuration.globalNodePath ? vscode.l10n.t("User Setting") : vscode.l10n.t("Bundled with VS Code"),
+			detail: this.configuration.globalNodePath ?? undefined,
+			run: async () => {
+				if (workspaceVersion) {
+					await this.setUseWorkspaceNodeState(false, workspaceVersion);
+				}
+				this.updateActiveVersion(defaultVersion);
+			},
+		};
+	}
+
+	private getWorkspacePickItem(workspaceVersion: string): QuickPickItem {
+		return {
+			label: (this.currentVersion === workspaceVersion ? '• ' : '') + vscode.l10n.t("Use Workspace Node"),
+			description: vscode.l10n.t("Workspace Setting"),
+			detail: workspaceVersion,
+			run: async () => {
+				const trusted = await vscode.workspace.requestWorkspaceTrust();
+				if (trusted) {
+					await this.setUseWorkspaceNodeState(true, workspaceVersion);
+					this.updateActiveVersion(workspaceVersion);
+				}
+			},
+		};
 	}
 
 	private async promptAndSetWorkspaceNode(): Promise<void> {

--- a/extensions/typescript-language-features/src/typescriptService.ts
+++ b/extensions/typescript-language-features/src/typescriptService.ts
@@ -174,6 +174,7 @@ export interface ITypeScriptServiceClient {
 	onReady(f: () => void): Promise<void>;
 
 	showVersionPicker(): void;
+	showNodeVersionPicker(): void;
 
 	readonly apiVersion: API;
 

--- a/extensions/typescript-language-features/src/typescriptServiceClient.ts
+++ b/extensions/typescript-language-features/src/typescriptServiceClient.ts
@@ -533,6 +533,10 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 		this._versionManager.promptUserForVersion();
 	}
 
+	public async showNodeVersionPicker(): Promise<void> {
+		this._nodeVersionManager.promptUserForVersion();
+	}
+
 	public async openTsServerLogFile(): Promise<boolean> {
 		if (this._configuration.tsServerLogLevel === TsServerLogLevel.Off) {
 			vscode.window.showErrorMessage<vscode.MessageItem>(


### PR DESCRIPTION
Fixes #247088

This adds a `TypeScript: Select TS Server Node Path...` command so users can change the Node installation used to run TS Server after dismissing the workspace Node prompt.

Changes:
- contribute and register `typescript.selectNodePath`
- add a Node picker to `NodeVersionManager` using the existing workspace trust and workspace-state decision flow
- restart TS Server through the existing `onDidPickNewVersion` path when the selected Node changes

Validation:
- `npm install`
- `npx tsc -p extensions/typescript-language-features/tsconfig.json --noEmit`
- `jq empty extensions/typescript-language-features/package.json extensions/typescript-language-features/package.nls.json`
- `npm run eslint`