### PR TITLE
Support agent feedback attachments in Agent Host

### DIFF
--- a/src/vs/platform/agentHost/common/agentFeedbackAttachments.ts
+++ b/src/vs/platform/agentHost/common/agentFeedbackAttachments.ts
@@ -19,9 +19,6 @@ export interface IAgentFeedbackAttachmentItemMetadata {
 	readonly text: string;
 	readonly resourceUri: string;
 	readonly range: TextRange;
-	readonly codeSelection?: string;
-	readonly diffHunks?: string;
-	readonly sourcePRReviewCommentId?: string;
 }
 
 export function isAgentFeedbackAttachment(attachment: MessageAttachment): attachment is SimpleMessageAttachment {
@@ -64,9 +61,6 @@ function parseAgentFeedbackAttachmentItem(item: unknown): IAgentFeedbackAttachme
 		text: item.text,
 		resourceUri: item.resourceUri,
 		range,
-		codeSelection: isString(item.codeSelection) ? item.codeSelection : undefined,
-		diffHunks: isString(item.diffHunks) ? item.diffHunks : undefined,
-		sourcePRReviewCommentId: isString(item.sourcePRReviewCommentId) ? item.sourcePRReviewCommentId : undefined,
 	};
 }
 

--- a/src/vs/platform/agentHost/common/agentFeedbackAttachments.ts
+++ b/src/vs/platform/agentHost/common/agentFeedbackAttachments.ts
@@ -1,0 +1,94 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { isString } from '../../../base/common/types.js';
+import { MessageAttachmentKind, type MessageAttachment, type SimpleMessageAttachment, type TextRange } from './state/protocol/state.js';
+
+export const AgentFeedbackAttachmentDisplayKind = 'agentFeedback';
+export const AgentFeedbackAttachmentMetadataKey = 'agentFeedback';
+
+export interface IAgentFeedbackAttachmentMetadata {
+	readonly sessionResource: string;
+	readonly feedbackItems: readonly IAgentFeedbackAttachmentItemMetadata[];
+}
+
+export interface IAgentFeedbackAttachmentItemMetadata {
+	readonly id: string;
+	readonly text: string;
+	readonly resourceUri: string;
+	readonly range: TextRange;
+	readonly codeSelection?: string;
+	readonly diffHunks?: string;
+	readonly sourcePRReviewCommentId?: string;
+}
+
+export function isAgentFeedbackAttachment(attachment: MessageAttachment): attachment is SimpleMessageAttachment {
+	return attachment.type === MessageAttachmentKind.Simple && attachment.displayKind === AgentFeedbackAttachmentDisplayKind;
+}
+
+export function getAgentFeedbackAttachmentMetadata(attachment: MessageAttachment): IAgentFeedbackAttachmentMetadata | undefined {
+	if (!isAgentFeedbackAttachment(attachment)) {
+		return undefined;
+	}
+	const metadata = attachment._meta?.[AgentFeedbackAttachmentMetadataKey];
+	if (!isRecord(metadata) || !isString(metadata.sessionResource) || !Array.isArray(metadata.feedbackItems)) {
+		return undefined;
+	}
+
+	const feedbackItems: IAgentFeedbackAttachmentItemMetadata[] = [];
+	for (const item of metadata.feedbackItems) {
+		const parsedItem = parseAgentFeedbackAttachmentItem(item);
+		if (parsedItem) {
+			feedbackItems.push(parsedItem);
+		}
+	}
+
+	return {
+		sessionResource: metadata.sessionResource,
+		feedbackItems,
+	};
+}
+
+function parseAgentFeedbackAttachmentItem(item: unknown): IAgentFeedbackAttachmentItemMetadata | undefined {
+	if (!isRecord(item) || !isString(item.id) || !isString(item.text) || !isString(item.resourceUri)) {
+		return undefined;
+	}
+	const range = parseTextRange(item.range);
+	if (!range) {
+		return undefined;
+	}
+	return {
+		id: item.id,
+		text: item.text,
+		resourceUri: item.resourceUri,
+		range,
+		codeSelection: isString(item.codeSelection) ? item.codeSelection : undefined,
+		diffHunks: isString(item.diffHunks) ? item.diffHunks : undefined,
+		sourcePRReviewCommentId: isString(item.sourcePRReviewCommentId) ? item.sourcePRReviewCommentId : undefined,
+	};
+}
+
+function parseTextRange(range: unknown): TextRange | undefined {
+	if (!isRecord(range) || !isRecord(range.start) || !isRecord(range.end)) {
+		return undefined;
+	}
+	const start = parseTextPosition(range.start);
+	const end = parseTextPosition(range.end);
+	if (!start || !end) {
+		return undefined;
+	}
+	return { start, end };
+}
+
+function parseTextPosition(position: Record<string, unknown>): TextRange['start'] | undefined {
+	if (typeof position.line !== 'number' || typeof position.character !== 'number') {
+		return undefined;
+	}
+	return { line: position.line, character: position.character };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null;
+}

--- a/src/vs/platform/agentHost/node/claude/claudePromptResolver.ts
+++ b/src/vs/platform/agentHost/node/claude/claudePromptResolver.ts
@@ -5,7 +5,6 @@
 
 import type Anthropic from '@anthropic-ai/sdk';
 import { URI } from '../../../../base/common/uri.js';
-import { isAgentFeedbackAttachment } from '../../common/agentFeedbackAttachments.js';
 import { MessageAttachmentKind, type MessageAttachment } from '../../common/state/protocol/state.js';
 
 /**
@@ -14,19 +13,18 @@ import { MessageAttachmentKind, type MessageAttachment } from '../../common/stat
  * attachments accompanying the user message.
  *
  * Phase 6 keeps the resolver pure and minimal: a single `text` block
- * carrying the prompt, plus (when attachments are present) a second
- * `text` block wrapped in `<system-reminder>` tags listing the
- * referenced URIs. This mirrors the production extension's resolver
- * shape so a future phase that adds image rendering or inline range
- * substitution can extend without restructuring.
+ * carrying the prompt, plus additional text blocks for attachments. This
+ * mirrors the production extension's resolver shape so a future phase that
+ * adds image rendering or inline range substitution can extend without
+ * restructuring.
  *
  * Selections are rendered as URI references with an optional line
  * suffix. The protocol's {@link TextSelection} carries range metadata
  * only; the selected text is not included inline.
  *
- * Only resource attachments and agent-feedback simple attachments are
- * honoured today — other simple and embedded resources are dropped because
- * the current Claude path does not have a place to consume them.
+ * Resource attachments and simple attachments with model representations
+ * are honoured today. Embedded resources are dropped because the current
+ * Claude path does not have a place to consume them.
  */
 export function resolvePromptToContentBlocks(
 	prompt: string,
@@ -37,11 +35,11 @@ export function resolvePromptToContentBlocks(
 		return blocks;
 	}
 	const refLines: string[] = [];
-	const feedbackBlocks: string[] = [];
+	const simpleBlocks: string[] = [];
 	for (const att of attachments) {
-		if (isAgentFeedbackAttachment(att)) {
+		if (att.type === MessageAttachmentKind.Simple) {
 			if (att.modelRepresentation) {
-				feedbackBlocks.push(att.modelRepresentation);
+				simpleBlocks.push(att.modelRepresentation);
 			}
 			continue;
 		}
@@ -56,12 +54,10 @@ export function resolvePromptToContentBlocks(
 			refLines.push(`- ${uriToString(uri)}`);
 		}
 	}
-	if (feedbackBlocks.length > 0) {
+	if (simpleBlocks.length > 0) {
 		blocks.push({
 			type: 'text',
-			text: '<system-reminder>\nThe user provided the following line feedback on code changes:\n\n' +
-				feedbackBlocks.join('\n\n') +
-				'\n</system-reminder>',
+			text: simpleBlocks.join('\n\n'),
 		});
 	}
 	if (refLines.length === 0) {

--- a/src/vs/platform/agentHost/node/claude/claudePromptResolver.ts
+++ b/src/vs/platform/agentHost/node/claude/claudePromptResolver.ts
@@ -5,6 +5,7 @@
 
 import type Anthropic from '@anthropic-ai/sdk';
 import { URI } from '../../../../base/common/uri.js';
+import { isAgentFeedbackAttachment } from '../../common/agentFeedbackAttachments.js';
 import { MessageAttachmentKind, type MessageAttachment } from '../../common/state/protocol/state.js';
 
 /**
@@ -23,9 +24,9 @@ import { MessageAttachmentKind, type MessageAttachment } from '../../common/stat
  * suffix. The protocol's {@link TextSelection} carries range metadata
  * only; the selected text is not included inline.
  *
- * Only resource attachments are honoured today — simple and embedded
- * resources are dropped because the current Claude path does not have
- * a place to consume them.
+ * Only resource attachments and agent-feedback simple attachments are
+ * honoured today — other simple and embedded resources are dropped because
+ * the current Claude path does not have a place to consume them.
  */
 export function resolvePromptToContentBlocks(
 	prompt: string,
@@ -36,7 +37,14 @@ export function resolvePromptToContentBlocks(
 		return blocks;
 	}
 	const refLines: string[] = [];
+	const feedbackBlocks: string[] = [];
 	for (const att of attachments) {
+		if (isAgentFeedbackAttachment(att)) {
+			if (att.modelRepresentation) {
+				feedbackBlocks.push(att.modelRepresentation);
+			}
+			continue;
+		}
 		if (att.type !== MessageAttachmentKind.Resource) {
 			continue;
 		}
@@ -47,6 +55,14 @@ export function resolvePromptToContentBlocks(
 		} else {
 			refLines.push(`- ${uriToString(uri)}`);
 		}
+	}
+	if (feedbackBlocks.length > 0) {
+		blocks.push({
+			type: 'text',
+			text: '<system-reminder>\nThe user provided the following line feedback on code changes:\n\n' +
+				feedbackBlocks.join('\n\n') +
+				'\n</system-reminder>',
+		});
 	}
 	if (refLines.length === 0) {
 		return blocks;

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -12,7 +12,7 @@ import { Schemas } from '../../../../base/common/network.js';
 import { isAbsolute, join } from '../../../../base/common/path.js';
 import { extUriBiasedIgnorePathCase, normalizePath } from '../../../../base/common/resources.js';
 import { splitLinesIncludeSeparators } from '../../../../base/common/strings.js';
-import { hasKey, isObject, isString } from '../../../../base/common/types.js';
+import { hasKey, isDefined, isObject, isString } from '../../../../base/common/types.js';
 import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { localize } from '../../../../nls.js';
@@ -36,7 +36,7 @@ import { parseLeadingSlashCommand } from './copilotSlashCommandCompletionProvide
 import type { ShellManager } from './copilotShellTools.js';
 import { getEditFilePaths, getInvocationMessage, getPastTenseMessage, getPermissionDisplay, getShellLanguage, getSubagentMetadata, getToolDisplayName, getToolInputString, getToolKind, isEditTool, isHiddenTool, isShellTool, synthesizeSkillToolCall, tryStringify, type ITypedPermissionRequest } from './copilotToolDisplay.js';
 import { FileEditTracker } from '../shared/fileEditTracker.js';
-import { mapSessionEvents, originalUserMessageMetadataKey } from './mapSessionEvents.js';
+import { mapSessionEvents } from './mapSessionEvents.js';
 import { buildPendingEditContentUri } from './pendingEditContentStore.js';
 
 /**
@@ -658,7 +658,6 @@ export class CopilotAgentSession extends Disposable {
 	// ---- session operations -------------------------------------------------
 
 	async send(prompt: string, attachments?: readonly MessageAttachment[], turnId?: string, mode?: CopilotSdkMode): Promise<void> {
-		const originalUserMessage = attachments?.length ? { text: prompt, attachments: [...attachments] } : undefined;
 		if (turnId) {
 			this._turnId = turnId;
 			this._turnCopilotUsageTotalNanoAiu = 0;
@@ -680,18 +679,15 @@ export class CopilotAgentSession extends Disposable {
 			prompt = slashCommand.rest;
 		}
 
-		const sdkAttachments = attachments
-			? (await Promise.all(attachments.map(a => this._toSdkAttachments(a)))).flat()
+		const sdkAttachments = attachments?.length
+			? (await Promise.all(attachments.map(a => this._toSdkAttachment(a)))).filter(isDefined)
 			: undefined;
 		if (sdkAttachments?.length) {
 			this._logService.trace(`[Copilot:${this.sessionId}] Attachments: ${JSON.stringify(sdkAttachments.map(a => ({ type: a.type })))}`);
 		}
 
 		await this.applyMode(mode);
-		const messageId = await this._wrapper.session.send({ prompt, attachments: sdkAttachments });
-		if (messageId && originalUserMessage) {
-			await this._databaseRef.object.setMetadata(originalUserMessageMetadataKey(messageId), JSON.stringify(originalUserMessage));
-		}
+		await this._wrapper.session.send({ prompt, attachments: sdkAttachments?.length ? sdkAttachments : undefined });
 		this._logService.info(`[Copilot:${this.sessionId}] session.send() returned`);
 	}
 
@@ -710,23 +706,23 @@ export class CopilotAgentSession extends Disposable {
 	 * carries the range, not the inline text). On read failure the
 	 * selection downgrades to a plain file reference.
 	 */
-	private async _toSdkAttachments(attachment: MessageAttachment): Promise<CopilotSdkAttachment[]> {
+	private async _toSdkAttachment(attachment: MessageAttachment): Promise<CopilotSdkAttachment | undefined> {
 		if (attachment.type === MessageAttachmentKind.Simple) {
 			if (attachment.modelRepresentation) {
-				return [{
+				return {
 					type: 'blob' as const,
 					data: encodeBase64(VSBuffer.fromString(attachment.modelRepresentation)),
 					mimeType: 'text/plain',
 					displayName: attachment.label,
-				}];
+				};
 			}
-			return [];
+			return undefined;
 		}
 		if (attachment.type === MessageAttachmentKind.EmbeddedResource) {
-			return [{ type: 'blob' as const, data: attachment.data, mimeType: attachment.contentType, displayName: attachment.label }];
+			return { type: 'blob' as const, data: attachment.data, mimeType: attachment.contentType, displayName: attachment.label };
 		}
 		if (attachment.type !== MessageAttachmentKind.Resource) {
-			return [];
+			return undefined;
 		}
 		const uri = URI.parse(attachment.uri);
 		const path = uri.scheme === 'file' ? uri.fsPath : uri.toString();
@@ -734,17 +730,17 @@ export class CopilotAgentSession extends Disposable {
 		if (attachment.displayKind === 'selection' && attachment.selection) {
 			try {
 				const text = await this._readSelectedText(uri, attachment.selection.range);
-				return [{ type: 'selection' as const, filePath: path, displayName, text, selection: attachment.selection.range }];
+				return { type: 'selection' as const, filePath: path, displayName, text, selection: attachment.selection.range };
 			} catch (err) {
 				this._logService.warn(`[Copilot:${this.sessionId}] Failed to read selected text for ${uri.toString()}: ${err}`);
-				return [{ type: 'file' as const, path, displayName }];
+				return { type: 'file' as const, path, displayName };
 			}
 		}
 		if (attachment.displayKind === 'selection') {
-			return [{ type: 'file' as const, path, displayName }];
+			return { type: 'file' as const, path, displayName };
 		}
 		const type = attachment.displayKind === 'directory' ? 'directory' : 'file';
-		return [{ type, path, displayName }];
+		return { type, path, displayName };
 	}
 
 	private async _readSelectedText(uri: URI, range: { readonly start: { readonly line: number; readonly character: number }; readonly end: { readonly line: number; readonly character: number } }): Promise<string> {

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -10,7 +10,7 @@ import { Emitter } from '../../../../base/common/event.js';
 import { Disposable, IReference, toDisposable } from '../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { isAbsolute, join } from '../../../../base/common/path.js';
-import { basename, extUriBiasedIgnorePathCase, normalizePath } from '../../../../base/common/resources.js';
+import { extUriBiasedIgnorePathCase, normalizePath } from '../../../../base/common/resources.js';
 import { splitLinesIncludeSeparators } from '../../../../base/common/strings.js';
 import { hasKey, isObject, isString } from '../../../../base/common/types.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -23,7 +23,7 @@ import { IInstantiationService } from '../../../instantiation/common/instantiati
 import { ILogService } from '../../../log/common/log.js';
 import { platformSessionSchema } from '../../common/agentHostSchema.js';
 import { AgentSignal } from '../../common/agentService.js';
-import { getAgentFeedbackAttachmentMetadata, isAgentFeedbackAttachment } from '../../common/agentFeedbackAttachments.js';
+import { isAgentFeedbackAttachment } from '../../common/agentFeedbackAttachments.js';
 import { stripRedundantCdPrefix } from '../../common/commandLineHelpers.js';
 import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
 import { ISessionDatabase, ISessionDataService, SESSION_ATTACHMENTS_DIRNAME } from '../../common/sessionDataService.js';
@@ -706,9 +706,8 @@ export class CopilotAgentSession extends Disposable {
 	 * session database before dispatching the turn, so by the time we
 	 * see them here the bytes are local and the original URI is gone.
 	 * Simple attachments are usually dropped — the SDK has no equivalent
-	 * shape for arbitrary text attachments. Agent-feedback simple
-	 * attachments are also appended to the prompt and their file ranges are
-	 * best-effort forwarded as selection attachments.
+	 * shape for arbitrary text attachments. Agent-feedback simple attachments
+	 * are appended to the prompt instead.
 	 *
 	 * For selections we read the resource content from disk and slice it
 	 * by the carried range (the protocol's {@link TextSelection} only
@@ -717,7 +716,7 @@ export class CopilotAgentSession extends Disposable {
 	 */
 	private async _toSdkAttachments(attachment: MessageAttachment): Promise<CopilotSdkAttachment[]> {
 		if (isAgentFeedbackAttachment(attachment)) {
-			return this._agentFeedbackToSdkAttachments(attachment);
+			return [];
 		}
 		if (attachment.type === MessageAttachmentKind.EmbeddedResource) {
 			return [{ type: 'blob' as const, data: attachment.data, mimeType: attachment.contentType, displayName: attachment.label }];
@@ -753,31 +752,6 @@ export class CopilotAgentSession extends Disposable {
 			return prompt;
 		}
 		return `${prompt}\n\n<system-reminder>\nThe user provided the following line feedback on code changes:\n\n${feedbackText.join('\n\n')}\n</system-reminder>`;
-	}
-
-	private async _agentFeedbackToSdkAttachments(attachment: MessageAttachment): Promise<CopilotSdkAttachment[]> {
-		const metadata = getAgentFeedbackAttachmentMetadata(attachment);
-		if (!metadata?.feedbackItems.length) {
-			return [];
-		}
-		const attachments: CopilotSdkAttachment[] = [];
-		for (const item of metadata.feedbackItems) {
-			const uri = URI.parse(item.resourceUri);
-			const path = uri.scheme === Schemas.file ? uri.fsPath : uri.toString();
-			const displayName = basename(uri) || path;
-			if (item.codeSelection !== undefined) {
-				attachments.push({ type: 'selection' as const, filePath: path, displayName, text: item.codeSelection, selection: item.range });
-				continue;
-			}
-			try {
-				const text = await this._readSelectedText(uri, item.range);
-				attachments.push({ type: 'selection' as const, filePath: path, displayName, text, selection: item.range });
-			} catch (err) {
-				this._logService.warn(`[Copilot:${this.sessionId}] Failed to read feedback selection text for ${uri.toString()}: ${err}`);
-				attachments.push({ type: 'file' as const, path, displayName });
-			}
-		}
-		return attachments;
 	}
 
 	private async _readSelectedText(uri: URI, range: { readonly start: { readonly line: number; readonly character: number }; readonly end: { readonly line: number; readonly character: number } }): Promise<string> {

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -10,7 +10,7 @@ import { Emitter } from '../../../../base/common/event.js';
 import { Disposable, IReference, toDisposable } from '../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { isAbsolute, join } from '../../../../base/common/path.js';
-import { extUriBiasedIgnorePathCase, normalizePath } from '../../../../base/common/resources.js';
+import { basename, extUriBiasedIgnorePathCase, normalizePath } from '../../../../base/common/resources.js';
 import { splitLinesIncludeSeparators } from '../../../../base/common/strings.js';
 import { hasKey, isObject, isString } from '../../../../base/common/types.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -23,6 +23,7 @@ import { IInstantiationService } from '../../../instantiation/common/instantiati
 import { ILogService } from '../../../log/common/log.js';
 import { platformSessionSchema } from '../../common/agentHostSchema.js';
 import { AgentSignal } from '../../common/agentService.js';
+import { getAgentFeedbackAttachmentMetadata, isAgentFeedbackAttachment } from '../../common/agentFeedbackAttachments.js';
 import { stripRedundantCdPrefix } from '../../common/commandLineHelpers.js';
 import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
 import { ISessionDatabase, ISessionDataService, SESSION_ATTACHMENTS_DIRNAME } from '../../common/sessionDataService.js';
@@ -679,9 +680,10 @@ export class CopilotAgentSession extends Disposable {
 			prompt = slashCommand.rest;
 		}
 
+		prompt = this._appendAgentFeedbackToPrompt(prompt, attachments);
+
 		const sdkAttachments = attachments
-			? (await Promise.all(attachments.map(a => this._toSdkAttachment(a))))
-				.filter((a): a is NonNullable<typeof a> => a !== undefined)
+			? (await Promise.all(attachments.map(a => this._toSdkAttachments(a)))).flat()
 			: undefined;
 		if (sdkAttachments?.length) {
 			this._logService.trace(`[Copilot:${this.sessionId}] Attachments: ${JSON.stringify(sdkAttachments.map(a => ({ type: a.type })))}`);
@@ -703,20 +705,25 @@ export class CopilotAgentSession extends Disposable {
 	 * snapshots inline / client-resident attachment bytes into the
 	 * session database before dispatching the turn, so by the time we
 	 * see them here the bytes are local and the original URI is gone.
-	 * Simple attachments are dropped — the SDK has no equivalent shape
-	 * for them.
+	 * Simple attachments are usually dropped — the SDK has no equivalent
+	 * shape for arbitrary text attachments. Agent-feedback simple
+	 * attachments are also appended to the prompt and their file ranges are
+	 * best-effort forwarded as selection attachments.
 	 *
 	 * For selections we read the resource content from disk and slice it
 	 * by the carried range (the protocol's {@link TextSelection} only
 	 * carries the range, not the inline text). On read failure the
 	 * selection downgrades to a plain file reference.
 	 */
-	private async _toSdkAttachment(attachment: MessageAttachment): Promise<CopilotSdkAttachment | undefined> {
+	private async _toSdkAttachments(attachment: MessageAttachment): Promise<CopilotSdkAttachment[]> {
+		if (isAgentFeedbackAttachment(attachment)) {
+			return this._agentFeedbackToSdkAttachments(attachment);
+		}
 		if (attachment.type === MessageAttachmentKind.EmbeddedResource) {
-			return { type: 'blob' as const, data: attachment.data, mimeType: attachment.contentType, displayName: attachment.label };
+			return [{ type: 'blob' as const, data: attachment.data, mimeType: attachment.contentType, displayName: attachment.label }];
 		}
 		if (attachment.type !== MessageAttachmentKind.Resource) {
-			return undefined;
+			return [];
 		}
 		const uri = URI.parse(attachment.uri);
 		const path = uri.scheme === 'file' ? uri.fsPath : uri.toString();
@@ -724,17 +731,53 @@ export class CopilotAgentSession extends Disposable {
 		if (attachment.displayKind === 'selection' && attachment.selection) {
 			try {
 				const text = await this._readSelectedText(uri, attachment.selection.range);
-				return { type: 'selection' as const, filePath: path, displayName, text, selection: attachment.selection.range };
+				return [{ type: 'selection' as const, filePath: path, displayName, text, selection: attachment.selection.range }];
 			} catch (err) {
 				this._logService.warn(`[Copilot:${this.sessionId}] Failed to read selected text for ${uri.toString()}: ${err}`);
-				return { type: 'file' as const, path, displayName };
+				return [{ type: 'file' as const, path, displayName }];
 			}
 		}
 		if (attachment.displayKind === 'selection') {
-			return { type: 'file' as const, path, displayName };
+			return [{ type: 'file' as const, path, displayName }];
 		}
 		const type = attachment.displayKind === 'directory' ? 'directory' : 'file';
-		return { type, path, displayName };
+		return [{ type, path, displayName }];
+	}
+
+	private _appendAgentFeedbackToPrompt(prompt: string, attachments: readonly MessageAttachment[] | undefined): string {
+		const feedbackText = attachments
+			?.filter(isAgentFeedbackAttachment)
+			.map(attachment => attachment.modelRepresentation)
+			.filter((text): text is string => typeof text === 'string' && text.length > 0);
+		if (!feedbackText?.length) {
+			return prompt;
+		}
+		return `${prompt}\n\n<system-reminder>\nThe user provided the following line feedback on code changes:\n\n${feedbackText.join('\n\n')}\n</system-reminder>`;
+	}
+
+	private async _agentFeedbackToSdkAttachments(attachment: MessageAttachment): Promise<CopilotSdkAttachment[]> {
+		const metadata = getAgentFeedbackAttachmentMetadata(attachment);
+		if (!metadata?.feedbackItems.length) {
+			return [];
+		}
+		const attachments: CopilotSdkAttachment[] = [];
+		for (const item of metadata.feedbackItems) {
+			const uri = URI.parse(item.resourceUri);
+			const path = uri.scheme === Schemas.file ? uri.fsPath : uri.toString();
+			const displayName = basename(uri) || path;
+			if (item.codeSelection !== undefined) {
+				attachments.push({ type: 'selection' as const, filePath: path, displayName, text: item.codeSelection, selection: item.range });
+				continue;
+			}
+			try {
+				const text = await this._readSelectedText(uri, item.range);
+				attachments.push({ type: 'selection' as const, filePath: path, displayName, text, selection: item.range });
+			} catch (err) {
+				this._logService.warn(`[Copilot:${this.sessionId}] Failed to read feedback selection text for ${uri.toString()}: ${err}`);
+				attachments.push({ type: 'file' as const, path, displayName });
+			}
+		}
+		return attachments;
 	}
 
 	private async _readSelectedText(uri: URI, range: { readonly start: { readonly line: number; readonly character: number }; readonly end: { readonly line: number; readonly character: number } }): Promise<string> {

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -5,7 +5,7 @@
 
 import type { MessageOptions, PermissionRequestResult, SessionConfig, Tool, ToolResultObject } from '@github/copilot-sdk';
 import { DeferredPromise } from '../../../../base/common/async.js';
-import { VSBuffer } from '../../../../base/common/buffer.js';
+import { encodeBase64, VSBuffer } from '../../../../base/common/buffer.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { Disposable, IReference, toDisposable } from '../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../base/common/network.js';
@@ -23,7 +23,6 @@ import { IInstantiationService } from '../../../instantiation/common/instantiati
 import { ILogService } from '../../../log/common/log.js';
 import { platformSessionSchema } from '../../common/agentHostSchema.js';
 import { AgentSignal } from '../../common/agentService.js';
-import { isAgentFeedbackAttachment } from '../../common/agentFeedbackAttachments.js';
 import { stripRedundantCdPrefix } from '../../common/commandLineHelpers.js';
 import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
 import { ISessionDatabase, ISessionDataService, SESSION_ATTACHMENTS_DIRNAME } from '../../common/sessionDataService.js';
@@ -37,7 +36,7 @@ import { parseLeadingSlashCommand } from './copilotSlashCommandCompletionProvide
 import type { ShellManager } from './copilotShellTools.js';
 import { getEditFilePaths, getInvocationMessage, getPastTenseMessage, getPermissionDisplay, getShellLanguage, getSubagentMetadata, getToolDisplayName, getToolInputString, getToolKind, isEditTool, isHiddenTool, isShellTool, synthesizeSkillToolCall, tryStringify, type ITypedPermissionRequest } from './copilotToolDisplay.js';
 import { FileEditTracker } from '../shared/fileEditTracker.js';
-import { mapSessionEvents } from './mapSessionEvents.js';
+import { mapSessionEvents, originalUserMessageMetadataKey } from './mapSessionEvents.js';
 import { buildPendingEditContentUri } from './pendingEditContentStore.js';
 
 /**
@@ -659,6 +658,7 @@ export class CopilotAgentSession extends Disposable {
 	// ---- session operations -------------------------------------------------
 
 	async send(prompt: string, attachments?: readonly MessageAttachment[], turnId?: string, mode?: CopilotSdkMode): Promise<void> {
+		const originalUserMessage = attachments?.length ? { text: prompt, attachments: [...attachments] } : undefined;
 		if (turnId) {
 			this._turnId = turnId;
 			this._turnCopilotUsageTotalNanoAiu = 0;
@@ -680,8 +680,6 @@ export class CopilotAgentSession extends Disposable {
 			prompt = slashCommand.rest;
 		}
 
-		prompt = this._appendAgentFeedbackToPrompt(prompt, attachments);
-
 		const sdkAttachments = attachments
 			? (await Promise.all(attachments.map(a => this._toSdkAttachments(a)))).flat()
 			: undefined;
@@ -690,7 +688,10 @@ export class CopilotAgentSession extends Disposable {
 		}
 
 		await this.applyMode(mode);
-		await this._wrapper.session.send({ prompt, attachments: sdkAttachments });
+		const messageId = await this._wrapper.session.send({ prompt, attachments: sdkAttachments });
+		if (messageId && originalUserMessage) {
+			await this._databaseRef.object.setMetadata(originalUserMessageMetadataKey(messageId), JSON.stringify(originalUserMessage));
+		}
 		this._logService.info(`[Copilot:${this.sessionId}] session.send() returned`);
 	}
 
@@ -701,9 +702,8 @@ export class CopilotAgentSession extends Disposable {
 	 * {@link MessageAttachmentBase.displayKind} advisory hint controls
 	 * which one). Embedded resources (e.g. inline image bytes) map to the
 	 * SDK's `blob` variant.
-	 * Simple attachments are usually dropped — the SDK has no equivalent
-	 * shape for arbitrary text attachments. Agent-feedback simple attachments
-	 * are appended to the prompt instead.
+	 * Simple attachments with a model representation map to `text/plain`
+	 * blob attachments.
 	 *
 	 * For selections we read the resource content from disk and slice it
 	 * by the carried range (the protocol's {@link TextSelection} only
@@ -711,7 +711,15 @@ export class CopilotAgentSession extends Disposable {
 	 * selection downgrades to a plain file reference.
 	 */
 	private async _toSdkAttachments(attachment: MessageAttachment): Promise<CopilotSdkAttachment[]> {
-		if (isAgentFeedbackAttachment(attachment)) {
+		if (attachment.type === MessageAttachmentKind.Simple) {
+			if (attachment.modelRepresentation) {
+				return [{
+					type: 'blob' as const,
+					data: encodeBase64(VSBuffer.fromString(attachment.modelRepresentation)),
+					mimeType: 'text/plain',
+					displayName: attachment.label,
+				}];
+			}
 			return [];
 		}
 		if (attachment.type === MessageAttachmentKind.EmbeddedResource) {
@@ -737,17 +745,6 @@ export class CopilotAgentSession extends Disposable {
 		}
 		const type = attachment.displayKind === 'directory' ? 'directory' : 'file';
 		return [{ type, path, displayName }];
-	}
-
-	private _appendAgentFeedbackToPrompt(prompt: string, attachments: readonly MessageAttachment[] | undefined): string {
-		const feedbackText = attachments
-			?.filter(isAgentFeedbackAttachment)
-			.map(attachment => attachment.modelRepresentation)
-			.filter((text): text is string => typeof text === 'string' && text.length > 0);
-		if (!feedbackText?.length) {
-			return prompt;
-		}
-		return `${prompt}\n\n<system-reminder>\nThe user provided the following line feedback on code changes:\n\n${feedbackText.join('\n\n')}\n</system-reminder>`;
 	}
 
 	private async _readSelectedText(uri: URI, range: { readonly start: { readonly line: number; readonly character: number }; readonly end: { readonly line: number; readonly character: number } }): Promise<string> {

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -700,11 +700,7 @@ export class CopilotAgentSession extends Disposable {
 	 * SDK's reference-style `file`/`directory`/`selection` variants (the
 	 * {@link MessageAttachmentBase.displayKind} advisory hint controls
 	 * which one). Embedded resources (e.g. inline image bytes) map to the
-	 * SDK's `blob` variant. Resource attachments that point at a
-	 * `session-db:` URI are also forwarded as `blob` — the agent host
-	 * snapshots inline / client-resident attachment bytes into the
-	 * session database before dispatching the turn, so by the time we
-	 * see them here the bytes are local and the original URI is gone.
+	 * SDK's `blob` variant.
 	 * Simple attachments are usually dropped — the SDK has no equivalent
 	 * shape for arbitrary text attachments. Agent-feedback simple attachments
 	 * are appended to the prompt instead.

--- a/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
+++ b/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { MessageOptions } from '@github/copilot-sdk';
+import { decodeBase64 } from '../../../../base/common/buffer.js';
 import { basename } from '../../../../base/common/path.js';
 import { isString } from '../../../../base/common/types.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -15,6 +16,12 @@ import { ResponsePartKind, ToolCallConfirmationReason, ToolCallStatus, ToolResul
 import { getInvocationMessage, getPastTenseMessage, getShellLanguage, getSubagentMetadata, getToolDisplayName, getToolInputString, getToolKind, isEditTool, isHiddenTool, synthesizeSkillToolCall } from './copilotToolDisplay.js';
 import { buildSessionDbUri } from '../shared/fileEditTracker.js';
 import { getMediaMime } from '../../../../base/common/mime.js';
+
+const ORIGINAL_USER_MESSAGE_METADATA_KEY_PREFIX = 'copilot.originalUserMessage.';
+
+export function originalUserMessageMetadataKey(messageId: string): string {
+	return `${ORIGINAL_USER_MESSAGE_METADATA_KEY_PREFIX}${messageId}`;
+}
 
 function tryStringify(value: unknown): string | undefined {
 	try {
@@ -330,8 +337,9 @@ export async function mapSessionEvents(
 				}
 				const d = (e as ISessionEventMessage).data;
 				const messageId = d?.messageId ?? d?.interactionId ?? '';
-				const content = d?.content ?? '';
-				const attachments = sdkAttachmentsToProtocol(d?.attachments);
+				const originalUserMessage = await getOriginalUserMessage(db, messageId);
+				const content = originalUserMessage?.text ?? d?.content ?? '';
+				const attachments = originalUserMessage?.attachments ?? sdkAttachmentsToProtocol(d?.attachments);
 				if (d?.parentToolCallId) {
 					// User messages with a parent tool call route into the
 					// subagent's transcript. They never start a new parent
@@ -485,6 +493,31 @@ export async function mapSessionEvents(
 	}
 }
 
+async function getOriginalUserMessage(db: ISessionDatabase | undefined, messageId: string): Promise<UserMessage | undefined> {
+	if (!db || !messageId) {
+		return undefined;
+	}
+	const raw = await db.getMetadata(originalUserMessageMetadataKey(messageId));
+	if (!raw) {
+		return undefined;
+	}
+	try {
+		const parsed = JSON.parse(raw) as Partial<UserMessage>;
+		if (!isString(parsed.text)) {
+			return undefined;
+		}
+		if (parsed.attachments !== undefined && !Array.isArray(parsed.attachments)) {
+			return undefined;
+		}
+		return {
+			text: parsed.text,
+			attachments: parsed.attachments as MessageAttachment[] | undefined,
+		};
+	} catch {
+		return undefined;
+	}
+}
+
 /**
  * Translates the SDK's `UserMessageAttachment[]` payload back into the
  * agent-protocol {@link MessageAttachment} shape. Blob attachments are
@@ -541,6 +574,13 @@ function sdkAttachmentToProtocol(
 			};
 		}
 		case 'blob': {
+			if (attachment.mimeType.startsWith('text/plain')) {
+				return {
+					type: MessageAttachmentKind.Simple,
+					label: attachment.displayName ?? 'attachment',
+					modelRepresentation: decodeBase64(attachment.data).toString(),
+				};
+			}
 			const displayKind = attachment.mimeType.startsWith('image/') ? 'image' : undefined;
 			return {
 				type: MessageAttachmentKind.EmbeddedResource,

--- a/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
+++ b/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
@@ -17,12 +17,6 @@ import { getInvocationMessage, getPastTenseMessage, getShellLanguage, getSubagen
 import { buildSessionDbUri } from '../shared/fileEditTracker.js';
 import { getMediaMime } from '../../../../base/common/mime.js';
 
-const ORIGINAL_USER_MESSAGE_METADATA_KEY_PREFIX = 'copilot.originalUserMessage.';
-
-export function originalUserMessageMetadataKey(messageId: string): string {
-	return `${ORIGINAL_USER_MESSAGE_METADATA_KEY_PREFIX}${messageId}`;
-}
-
 function tryStringify(value: unknown): string | undefined {
 	try {
 		return JSON.stringify(value);
@@ -337,9 +331,8 @@ export async function mapSessionEvents(
 				}
 				const d = (e as ISessionEventMessage).data;
 				const messageId = d?.messageId ?? d?.interactionId ?? '';
-				const originalUserMessage = await getOriginalUserMessage(db, messageId);
-				const content = originalUserMessage?.text ?? d?.content ?? '';
-				const attachments = originalUserMessage?.attachments ?? sdkAttachmentsToProtocol(d?.attachments);
+				const content = d?.content ?? '';
+				const attachments = sdkAttachmentsToProtocol(d?.attachments);
 				if (d?.parentToolCallId) {
 					// User messages with a parent tool call route into the
 					// subagent's transcript. They never start a new parent
@@ -493,40 +486,16 @@ export async function mapSessionEvents(
 	}
 }
 
-async function getOriginalUserMessage(db: ISessionDatabase | undefined, messageId: string): Promise<UserMessage | undefined> {
-	if (!db || !messageId) {
-		return undefined;
-	}
-	const raw = await db.getMetadata(originalUserMessageMetadataKey(messageId));
-	if (!raw) {
-		return undefined;
-	}
-	try {
-		const parsed = JSON.parse(raw) as Partial<UserMessage>;
-		if (!isString(parsed.text)) {
-			return undefined;
-		}
-		if (parsed.attachments !== undefined && !Array.isArray(parsed.attachments)) {
-			return undefined;
-		}
-		return {
-			text: parsed.text,
-			attachments: parsed.attachments as MessageAttachment[] | undefined,
-		};
-	} catch {
-		return undefined;
-	}
-}
-
 /**
  * Translates the SDK's `UserMessageAttachment[]` payload back into the
- * agent-protocol {@link MessageAttachment} shape. Blob attachments are
- * surfaced as inline {@link MessageAttachmentKind.EmbeddedResource}
- * payloads; file/directory/selection variants reconstruct local
- * `Resource` attachments. We don't try to re-link these to the on-disk
- * snapshots produced by the agent host's attachment rewriter — the SDK
- * keeps a copy of the bytes / paths it actually saw on send, which is
- * the authoritative record for replay.
+ * agent-protocol {@link MessageAttachment} shape. Text blob attachments
+ * surface as {@link MessageAttachmentKind.Simple}; other blobs surface as
+ * inline {@link MessageAttachmentKind.EmbeddedResource} payloads.
+ * File/directory/selection variants reconstruct local `Resource`
+ * attachments. We don't try to re-link these to the on-disk snapshots
+ * produced by the agent host's attachment rewriter — the SDK keeps a
+ * copy of the bytes / paths it actually saw on send, which is the
+ * authoritative record for replay.
  */
 function sdkAttachmentsToProtocol(
 	attachments: readonly ISdkUserMessageAttachment[] | undefined,

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -2094,7 +2094,7 @@ suite('ClaudeAgent', () => {
 		assert.ok(!blocks[1].text.includes('```'));
 	});
 
-	test('agent feedback simple attachments become a system-reminder block', () => {
+	test('simple attachments use their model representation as context', () => {
 		const blocks = resolvePromptToContentBlocks('/act-on-feedback', [{
 			type: MessageAttachmentKind.Simple,
 			label: 'Feedback',
@@ -2106,7 +2106,7 @@ suite('ClaudeAgent', () => {
 			{ type: 'text', text: '/act-on-feedback' },
 			{
 				type: 'text',
-				text: '<system-reminder>\nThe user provided the following line feedback on code changes:\n\nFeedback text for the model\n</system-reminder>',
+				text: 'Feedback text for the model',
 			},
 		]);
 	});
@@ -4044,7 +4044,6 @@ suite('ClaudeAgent (Phase 13 — getSessionMessages)', () => {
 });
 
 // #endregion
-
 
 
 

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -35,6 +35,7 @@ import { ILogService, NullLogService } from '../../../log/common/log.js';
 import { IProductService } from '../../../product/common/productService.js';
 import { FileService } from '../../../files/common/fileService.js';
 import { IAgentMaterializeSessionEvent, AgentSession, AgentSignal, GITHUB_COPILOT_PROTECTED_RESOURCE } from '../../common/agentService.js';
+import { AgentFeedbackAttachmentDisplayKind } from '../../common/agentFeedbackAttachments.js';
 import { ActionType } from '../../common/state/sessionActions.js';
 import { MessageAttachmentKind, ResponsePartKind, SessionInputResponseKind, SessionStatus } from '../../common/state/sessionState.js';
 import { ISessionDataService } from '../../common/sessionDataService.js';
@@ -2093,6 +2094,23 @@ suite('ClaudeAgent', () => {
 		assert.ok(!blocks[1].text.includes('```'));
 	});
 
+	test('agent feedback simple attachments become a system-reminder block', () => {
+		const blocks = resolvePromptToContentBlocks('/act-on-feedback', [{
+			type: MessageAttachmentKind.Simple,
+			label: 'Feedback',
+			displayKind: AgentFeedbackAttachmentDisplayKind,
+			modelRepresentation: 'Feedback text for the model',
+		}]);
+
+		assert.deepStrictEqual(blocks, [
+			{ type: 'text', text: '/act-on-feedback' },
+			{
+				type: 'text',
+				text: '<system-reminder>\nThe user provided the following line feedback on code changes:\n\nFeedback text for the model\n</system-reminder>',
+			},
+		]);
+	});
+
 	test('shutdown resolves without throwing', async () => {
 		const { agent } = createTestContext(disposables);
 		await agent.shutdown();
@@ -4026,7 +4044,6 @@ suite('ClaudeAgent (Phase 13 — getSessionMessages)', () => {
 });
 
 // #endregion
-
 
 
 

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -18,7 +18,6 @@ import { InstantiationService } from '../../../instantiation/common/instantiatio
 import { ServiceCollection } from '../../../instantiation/common/serviceCollection.js';
 import { ILogService, NullLogService } from '../../../log/common/log.js';
 import { AgentSession, type AgentSignal, type IAgentActionSignal, type IAgentToolPendingConfirmationSignal } from '../../common/agentService.js';
-import { AgentFeedbackAttachmentDisplayKind, AgentFeedbackAttachmentMetadataKey } from '../../common/agentFeedbackAttachments.js';
 import { IDiffComputeService } from '../../common/diffComputeService.js';
 import { ISessionDataService } from '../../common/sessionDataService.js';
 import { ActionType, type SessionDeltaAction, type SessionErrorAction, type SessionInputRequestedAction, type SessionResponsePartAction, type SessionToolCallCompleteAction, type SessionToolCallReadyAction, type SessionToolCallStartAction } from '../../common/state/sessionActions.js';
@@ -311,50 +310,19 @@ suite('CopilotAgentSession', () => {
 		}]);
 	});
 
-	test('sends simple attachments as text blobs and restores original user message', async () => {
-		const fileUri = URI.file('/workspace/file.ts');
+	test('sends simple attachments as text blobs and restores them from SDK blobs', async () => {
 		const { session, mockSession } = await createAgentSession(disposables);
 
 		await session.send('/act-on-feedback', [{
 			type: MessageAttachmentKind.Simple,
 			label: 'Feedback',
-			displayKind: AgentFeedbackAttachmentDisplayKind,
 			modelRepresentation: 'Feedback text for the model',
-			_meta: {
-				[AgentFeedbackAttachmentMetadataKey]: {
-					sessionResource: AgentSession.uri('copilot', 'feedback').toString(),
-					feedbackItems: [{
-						id: 'feedback-1',
-						text: 'Please simplify this.',
-						resourceUri: fileUri.toString(),
-						range: {
-							start: { line: 1, character: 2 },
-							end: { line: 3, character: 4 },
-						},
-					}],
-				},
-			},
 		}]);
 
 		const expectedAttachment = {
 			type: MessageAttachmentKind.Simple,
 			label: 'Feedback',
-			displayKind: AgentFeedbackAttachmentDisplayKind,
 			modelRepresentation: 'Feedback text for the model',
-			_meta: {
-				[AgentFeedbackAttachmentMetadataKey]: {
-					sessionResource: AgentSession.uri('copilot', 'feedback').toString(),
-					feedbackItems: [{
-						id: 'feedback-1',
-						text: 'Please simplify this.',
-						resourceUri: fileUri.toString(),
-						range: {
-							start: { line: 1, character: 2 },
-							end: { line: 3, character: 4 },
-						},
-					}],
-				},
-			},
 		};
 		assert.deepStrictEqual(mockSession.sendRequests, [{
 			prompt: '/act-on-feedback',

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -6,7 +6,7 @@
 import type { CopilotSession, SessionEvent, SessionEventPayload, SessionEventType, Tool, ToolResultObject, TypedSessionEventHandler } from '@github/copilot-sdk';
 import assert from 'assert';
 import { DeferredPromise } from '../../../../base/common/async.js';
-import { VSBuffer } from '../../../../base/common/buffer.js';
+import { encodeBase64, VSBuffer } from '../../../../base/common/buffer.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { join, sep } from '../../../../base/common/path.js';
@@ -40,6 +40,7 @@ class MockCopilotSession {
 	readonly sessionId = 'test-session-1';
 	readonly sendRequests: unknown[] = [];
 	readonly modeSetCalls: Array<{ mode: 'interactive' | 'plan' | 'autopilot' }> = [];
+	messages: SessionEvent[] = [];
 
 	private readonly _handlers = new Map<string, Set<(event: SessionEvent) => void>>();
 	planReadResult: { exists: boolean; content: string | null; path: string | null } = { exists: false, content: null, path: null };
@@ -66,10 +67,13 @@ class MockCopilotSession {
 	}
 
 	// Stubs for methods the wrapper / session class calls
-	async send(request: unknown) { this.sendRequests.push(request); return ''; }
+	async send(request: unknown) {
+		this.sendRequests.push(request);
+		return `message-${this.sendRequests.length}`;
+	}
 	async abort() { }
 	async setModel() { }
-	async getMessages(): Promise<SessionEvent[]> { return []; }
+	async getMessages(): Promise<SessionEvent[]> { return this.messages; }
 	async destroy() { }
 
 	readonly rpc = {
@@ -307,7 +311,7 @@ suite('CopilotAgentSession', () => {
 		}]);
 	});
 
-	test('appends agent feedback to prompt without duplicating SDK attachments', async () => {
+	test('sends simple attachments as text blobs and restores original user message', async () => {
 		const fileUri = URI.file('/workspace/file.ts');
 		const { session, mockSession } = await createAgentSession(disposables);
 
@@ -332,9 +336,62 @@ suite('CopilotAgentSession', () => {
 			},
 		}]);
 
+		const expectedAttachment = {
+			type: MessageAttachmentKind.Simple,
+			label: 'Feedback',
+			displayKind: AgentFeedbackAttachmentDisplayKind,
+			modelRepresentation: 'Feedback text for the model',
+			_meta: {
+				[AgentFeedbackAttachmentMetadataKey]: {
+					sessionResource: AgentSession.uri('copilot', 'feedback').toString(),
+					feedbackItems: [{
+						id: 'feedback-1',
+						text: 'Please simplify this.',
+						resourceUri: fileUri.toString(),
+						range: {
+							start: { line: 1, character: 2 },
+							end: { line: 3, character: 4 },
+						},
+					}],
+				},
+			},
+		};
 		assert.deepStrictEqual(mockSession.sendRequests, [{
-			prompt: '/act-on-feedback\n\n<system-reminder>\nThe user provided the following line feedback on code changes:\n\nFeedback text for the model\n</system-reminder>',
-			attachments: [],
+			prompt: '/act-on-feedback',
+			attachments: [{
+				type: 'blob',
+				data: encodeBase64(VSBuffer.fromString('Feedback text for the model')),
+				mimeType: 'text/plain',
+				displayName: 'Feedback',
+			}],
+		}]);
+
+		mockSession.messages = [{
+			type: 'user.message',
+			id: 'event-1',
+			parentId: null,
+			timestamp: new Date().toISOString(),
+			data: {
+				interactionId: 'message-1',
+				content: '/act-on-feedback',
+				attachments: [{
+					type: 'blob',
+					data: encodeBase64(VSBuffer.fromString('Feedback text for the model')),
+					mimeType: 'text/plain',
+					displayName: 'Feedback',
+				}],
+			},
+		}];
+
+		assert.deepStrictEqual(await session.getMessages(), [{
+			id: 'message-1',
+			userMessage: {
+				text: '/act-on-feedback',
+				attachments: [expectedAttachment],
+			},
+			responseParts: [],
+			usage: undefined,
+			state: 'cancelled',
 		}]);
 	});
 

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -18,6 +18,7 @@ import { InstantiationService } from '../../../instantiation/common/instantiatio
 import { ServiceCollection } from '../../../instantiation/common/serviceCollection.js';
 import { ILogService, NullLogService } from '../../../log/common/log.js';
 import { AgentSession, type AgentSignal, type IAgentActionSignal, type IAgentToolPendingConfirmationSignal } from '../../common/agentService.js';
+import { AgentFeedbackAttachmentDisplayKind, AgentFeedbackAttachmentMetadataKey } from '../../common/agentFeedbackAttachments.js';
 import { IDiffComputeService } from '../../common/diffComputeService.js';
 import { ISessionDataService } from '../../common/sessionDataService.js';
 import { ActionType, type SessionDeltaAction, type SessionErrorAction, type SessionInputRequestedAction, type SessionResponsePartAction, type SessionToolCallCompleteAction, type SessionToolCallReadyAction, type SessionToolCallStartAction } from '../../common/state/sessionActions.js';
@@ -303,6 +304,47 @@ suite('CopilotAgentSession', () => {
 					},
 				},
 			],
+		}]);
+	});
+
+	test('appends agent feedback to prompt and forwards feedback ranges as selections', async () => {
+		const fileUri = URI.file('/workspace/file.ts');
+		const { session, mockSession } = await createAgentSession(disposables);
+
+		await session.send('/act-on-feedback', [{
+			type: MessageAttachmentKind.Simple,
+			label: 'Feedback',
+			displayKind: AgentFeedbackAttachmentDisplayKind,
+			modelRepresentation: 'Feedback text for the model',
+			_meta: {
+				[AgentFeedbackAttachmentMetadataKey]: {
+					sessionResource: AgentSession.uri('copilot', 'feedback').toString(),
+					feedbackItems: [{
+						id: 'feedback-1',
+						text: 'Please simplify this.',
+						resourceUri: fileUri.toString(),
+						range: {
+							start: { line: 1, character: 2 },
+							end: { line: 3, character: 4 },
+						},
+						codeSelection: 'const value = compute();',
+					}],
+				},
+			},
+		}]);
+
+		assert.deepStrictEqual(mockSession.sendRequests, [{
+			prompt: '/act-on-feedback\n\n<system-reminder>\nThe user provided the following line feedback on code changes:\n\nFeedback text for the model\n</system-reminder>',
+			attachments: [{
+				type: 'selection',
+				filePath: fileUri.fsPath,
+				displayName: 'file.ts',
+				text: 'const value = compute();',
+				selection: {
+					start: { line: 1, character: 2 },
+					end: { line: 3, character: 4 },
+				},
+			}],
 		}]);
 	});
 

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -307,7 +307,7 @@ suite('CopilotAgentSession', () => {
 		}]);
 	});
 
-	test('appends agent feedback to prompt and forwards feedback ranges as selections', async () => {
+	test('appends agent feedback to prompt without duplicating SDK attachments', async () => {
 		const fileUri = URI.file('/workspace/file.ts');
 		const { session, mockSession } = await createAgentSession(disposables);
 
@@ -327,7 +327,6 @@ suite('CopilotAgentSession', () => {
 							start: { line: 1, character: 2 },
 							end: { line: 3, character: 4 },
 						},
-						codeSelection: 'const value = compute();',
 					}],
 				},
 			},
@@ -335,16 +334,7 @@ suite('CopilotAgentSession', () => {
 
 		assert.deepStrictEqual(mockSession.sendRequests, [{
 			prompt: '/act-on-feedback\n\n<system-reminder>\nThe user provided the following line feedback on code changes:\n\nFeedback text for the model\n</system-reminder>',
-			attachments: [{
-				type: 'selection',
-				filePath: fileUri.fsPath,
-				displayName: 'file.ts',
-				text: 'const value = compute();',
-				selection: {
-					start: { line: 1, character: 2 },
-					end: { line: 3, character: 4 },
-				},
-			}],
+			attachments: [],
 		}]);
 	});
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -2830,7 +2830,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			v.name,
 			typeof v.value === 'string' ? v.value : undefined,
 			{
-				...v._meta,
+				...(v._meta ?? {}),
 				[AgentFeedbackAttachmentMetadataKey]: {
 					sessionResource: v.sessionResource.toString(),
 					feedbackItems,

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -19,6 +19,7 @@ import { isLocation, type Location } from '../../../../../../editor/common/langu
 import { IPosition } from '../../../../../../editor/common/core/position.js';
 import { localize } from '../../../../../../nls.js';
 import { AgentProvider, AgentSession, type IAgentConnection } from '../../../../../../platform/agentHost/common/agentService.js';
+import { AgentFeedbackAttachmentDisplayKind, AgentFeedbackAttachmentMetadataKey } from '../../../../../../platform/agentHost/common/agentFeedbackAttachments.js';
 import { IAgentSubscription, observableFromSubscription } from '../../../../../../platform/agentHost/common/state/agentSubscription.js';
 import { SessionTruncatedAction } from '../../../../../../platform/agentHost/common/state/protocol/actions.js';
 import { CompletionItemKind as AhpCompletionItemKind, type CompletionItem as AhpCompletionItem } from '../../../../../../platform/agentHost/common/state/protocol/commands.js';
@@ -39,7 +40,7 @@ import { ITerminalChatService } from '../../../../terminal/browser/terminal.js';
 import { IChatWidgetService } from '../../chat.js';
 import { ChatRequestQueueKind, ConfirmedReason, ElicitationState, IChatProgress, IChatQuestion, IChatQuestionAnswers, IChatService, IChatToolInvocation, ToolConfirmKind, type IChatMultiSelectAnswer, type IChatQuestionAnswerValue, type IChatSingleSelectAnswer, type IChatTerminalToolInvocationData } from '../../../common/chatService/chatService.js';
 import { IChatSession, IChatSessionContentProvider, IChatSessionHistoryItem, IChatSessionItem, IChatSessionRequestHistoryItem, type IChatInputCompletionItem, type IChatInputCompletionsParams, type IChatInputCompletionsResult } from '../../../common/chatSessionsService.js';
-import { isImageVariableEntry, type IChatRequestVariableEntry, type IImageVariableEntry } from '../../../common/attachments/chatVariableEntries.js';
+import { isAgentFeedbackVariableEntry, isImageVariableEntry, type IAgentFeedbackVariableEntry, type IChatRequestVariableEntry, type IImageVariableEntry } from '../../../common/attachments/chatVariableEntries.js';
 import { coerceImageBuffer } from '../../../common/chatImageExtraction.js';
 import { getChatSessionType } from '../../../common/model/chatUri.js';
 import { ChatAgentLocation, ChatConfiguration, ChatModeKind } from '../../../common/constants.js';
@@ -2747,6 +2748,9 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		if (isImageVariableEntry(v)) {
 			return this._toImageAttachment(v, sessionResource);
 		}
+		if (isAgentFeedbackVariableEntry(v)) {
+			return this._toAgentFeedbackAttachment(v, sessionResource);
+		}
 		// Pasted code, prompt text, and free-form string entries: surface their
 		// textual representation as an opaque attachment.
 		if (v.kind === 'paste') {
@@ -2815,8 +2819,35 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		return undefined;
 	}
 
-	private _toSimpleAttachment(label: string, modelRepresentation: string | undefined, _meta: Record<string, unknown> | undefined): MessageAttachment {
+	private _toAgentFeedbackAttachment(v: IAgentFeedbackVariableEntry, sessionResource: URI): MessageAttachment {
+		const feedbackItems = v.feedbackItems.map(item => ({
+			id: item.id,
+			text: item.text,
+			resourceUri: this._rebaseAttachmentUri(item.resourceUri, sessionResource).toString(),
+			range: this._toTextRange(item.range),
+			codeSelection: item.codeSelection,
+			diffHunks: item.diffHunks,
+			sourcePRReviewCommentId: item.sourcePRReviewCommentId,
+		}));
+		return this._toSimpleAttachment(
+			v.name,
+			typeof v.value === 'string' ? v.value : undefined,
+			{
+				...v._meta,
+				[AgentFeedbackAttachmentMetadataKey]: {
+					sessionResource: v.sessionResource.toString(),
+					feedbackItems,
+				},
+			},
+			AgentFeedbackAttachmentDisplayKind,
+		);
+	}
+
+	private _toSimpleAttachment(label: string, modelRepresentation: string | undefined, _meta: Record<string, unknown> | undefined, displayKind?: string): MessageAttachment {
 		const attachment: MessageAttachment = { type: MessageAttachmentKind.Simple, label, modelRepresentation };
+		if (displayKind) {
+			attachment.displayKind = displayKind;
+		}
 		if (_meta) {
 			attachment._meta = _meta;
 		}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -2823,11 +2823,8 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		const feedbackItems = v.feedbackItems.map(item => ({
 			id: item.id,
 			text: item.text,
-			resourceUri: this._rebaseAttachmentUri(item.resourceUri, sessionResource).toString(),
+			resourceUri: item.resourceUri.toString(),
 			range: this._toTextRange(item.range),
-			codeSelection: item.codeSelection,
-			diffHunks: item.diffHunks,
-			sourcePRReviewCommentId: item.sourcePRReviewCommentId,
 		}));
 		return this._toSimpleAttachment(
 			v.name,

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
@@ -11,6 +11,7 @@ import { generateUuid } from '../../../../../../base/common/uuid.js';
 import { ToolCallStatus, TurnState, ResponsePartKind, getToolFileEdits, getToolOutputText, getToolSubagentContent, type ActiveTurn, type ICompletedToolCall, type ToolCallState, type Turn, FileEditKind, ToolResultContentType, type ToolResultContent, type UsageInfo } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { getToolKind } from '../../../../../../platform/agentHost/common/state/sessionReducers.js';
 import { AGENT_HOST_SCHEME, toAgentHostUri } from '../../../../../../platform/agentHost/common/agentHostUri.js';
+import { getAgentFeedbackAttachmentMetadata, isAgentFeedbackAttachment } from '../../../../../../platform/agentHost/common/agentFeedbackAttachments.js';
 import { MessageAttachmentKind, type FileEdit, type MessageAttachment, type StringOrMarkdown, type TextRange, type UserMessage } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
 import { type IChatModifiedFilesConfirmationData, type IChatProgress, type IChatSearchToolInvocationData, type IChatTerminalToolInvocationData, type IChatToolInputInvocationData, type IChatToolInvocationSerialized, type IChatUsage, ToolConfirmKind } from '../../../common/chatService/chatService.js';
 import { type IChatSessionHistoryItem } from '../../../common/chatSessionsService.js';
@@ -216,6 +217,29 @@ export function messageAttachmentsToVariableData(attachments: readonly MessageAt
 }
 
 function messageAttachmentToVariableEntry(attachment: MessageAttachment, connectionAuthority: string): IChatRequestVariableEntry | undefined {
+	if (isAgentFeedbackAttachment(attachment)) {
+		const metadata = getAgentFeedbackAttachmentMetadata(attachment);
+		if (metadata) {
+			return {
+				kind: 'agentFeedback',
+				id: generateUuid(),
+				name: attachment.label,
+				value: attachment.modelRepresentation || attachment.label,
+				sessionResource: URI.parse(metadata.sessionResource),
+				feedbackItems: metadata.feedbackItems.map(item => ({
+					id: item.id,
+					text: item.text,
+					resourceUri: toAgentHostUri(URI.parse(item.resourceUri), connectionAuthority),
+					range: textRangeToIRange(item.range),
+					codeSelection: item.codeSelection,
+					diffHunks: item.diffHunks,
+					sourcePRReviewCommentId: item.sourcePRReviewCommentId,
+				})),
+				_meta: attachment._meta,
+			};
+		}
+	}
+
 	if (attachment.type === MessageAttachmentKind.Resource) {
 		const uri = toAgentHostUri(URI.parse(attachment.uri), connectionAuthority);
 		const name = attachment.label;

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
@@ -231,9 +231,6 @@ function messageAttachmentToVariableEntry(attachment: MessageAttachment, connect
 					text: item.text,
 					resourceUri: toAgentHostUri(URI.parse(item.resourceUri), connectionAuthority),
 					range: textRangeToIRange(item.range),
-					codeSelection: item.codeSelection,
-					diffHunks: item.diffHunks,
-					sourcePRReviewCommentId: item.sourcePRReviewCommentId,
 				})),
 				_meta: attachment._meta,
 			};

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -17,6 +17,7 @@ import { Range } from '../../../../../../editor/common/core/range.js';
 import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { IAgentCreateSessionConfig, IAgentHostService, IAgentSessionMetadata, AgentSession } from '../../../../../../platform/agentHost/common/agentService.js';
+import { AgentFeedbackAttachmentDisplayKind, AgentFeedbackAttachmentMetadataKey } from '../../../../../../platform/agentHost/common/agentFeedbackAttachments.js';
 import { ActionType, isSessionAction, type ActionEnvelope, type IRootConfigChangedAction, type SessionAction, type TerminalAction, type INotification, type IToolCallConfirmedAction, type ITurnStartedAction } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
 import type { IStateSnapshot } from '../../../../../../platform/agentHost/common/state/sessionProtocol.js';
 import type { CustomizationRef } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
@@ -2135,6 +2136,98 @@ suite('AgentHostChatContribution', () => {
 			}
 		});
 
+		test('restores agent feedback attachments into request history variable data', async () => {
+			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const sessionResource = URI.from({ scheme: 'agent-host-copilot', path: '/feedback-history' });
+			const feedbackFile = URI.file('/workspace/foo.ts');
+			const sessionUri = AgentSession.uri('copilot', 'feedback-history');
+			agentHostService.sessionStates.set(sessionUri.toString(), {
+				...createSessionState({ resource: sessionUri.toString(), provider: 'copilot', title: 'Test', status: SessionStatus.Idle, createdAt: Date.now(), modifiedAt: Date.now() }),
+				lifecycle: SessionLifecycle.Ready,
+				turns: [{
+					id: 'turn-1',
+					userMessage: {
+						text: '/act-on-feedback',
+						attachments: [{
+							type: MessageAttachmentKind.Simple,
+							label: 'Feedback',
+							displayKind: AgentFeedbackAttachmentDisplayKind,
+							modelRepresentation: 'Feedback text for the model',
+							_meta: {
+								[AgentFeedbackAttachmentMetadataKey]: {
+									sessionResource: sessionResource.toString(),
+									feedbackItems: [{
+										id: 'feedback-1',
+										text: 'Please simplify this.',
+										resourceUri: feedbackFile.toString(),
+										range: {
+											start: { line: 1, character: 2 },
+											end: { line: 3, character: 4 },
+										},
+										codeSelection: 'const value = compute();',
+									}],
+								},
+							},
+						}],
+					},
+					responseParts: [],
+					usage: undefined,
+					state: TurnState.Complete,
+				}],
+			} as SessionState);
+
+			const session = await sessionHandler.provideChatSessionContent(sessionResource, CancellationToken.None);
+			disposables.add(toDisposable(() => session.dispose()));
+
+			assert.strictEqual(session.history.length, 2);
+			const request = session.history[0];
+			assert.strictEqual(request.type, 'request');
+			if (request.type === 'request') {
+				assert.ok(request.variableData);
+				const variables = request.variableData.variables;
+				const feedbackVariable = variables[0];
+				assert.strictEqual(feedbackVariable.kind, 'agentFeedback');
+				assert.deepStrictEqual({
+					...feedbackVariable,
+					sessionResource: feedbackVariable.sessionResource.toString(),
+					feedbackItems: feedbackVariable.feedbackItems.map(item => ({
+						...item,
+						resourceUri: item.resourceUri.toString(),
+					})),
+				}, {
+					kind: 'agentFeedback',
+					id: feedbackVariable.id,
+					name: 'Feedback',
+					value: 'Feedback text for the model',
+					sessionResource: sessionResource.toString(),
+					feedbackItems: [{
+						id: 'feedback-1',
+						text: 'Please simplify this.',
+						resourceUri: feedbackFile.toString(),
+						range: { startLineNumber: 2, startColumn: 3, endLineNumber: 4, endColumn: 5 },
+						codeSelection: 'const value = compute();',
+						diffHunks: undefined,
+						sourcePRReviewCommentId: undefined,
+					}],
+					_meta: {
+						[AgentFeedbackAttachmentMetadataKey]: {
+							sessionResource: sessionResource.toString(),
+							feedbackItems: [{
+								id: 'feedback-1',
+								text: 'Please simplify this.',
+								resourceUri: feedbackFile.toString(),
+								range: {
+									start: { line: 1, character: 2 },
+									end: { line: 3, character: 4 },
+								},
+								codeSelection: 'const value = compute();',
+							}],
+						},
+					},
+				});
+			}
+		});
+
 		test('untitled sessions have empty history', async () => {
 			const { sessionHandler } = createContribution(disposables);
 
@@ -2668,6 +2761,66 @@ suite('AgentHostChatContribution', () => {
 			assert.deepStrictEqual(turnAction.userMessage.attachments, [
 				{ type: MessageAttachmentKind.Resource, uri: URI.file('/workspace/test.ts').toString(), label: 'test.ts', displayKind: 'document', _meta: { provider: 'fs', score: 0.42 } },
 			]);
+		}));
+
+		test('agent feedback variable becomes simple attachment with structured metadata', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
+			const sessionResource = URI.from({ scheme: 'agent-host-copilot', path: '/feedback-test' });
+
+			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables, {
+				message: '/act-on-feedback',
+				sessionResource,
+				variables: {
+					variables: [
+						upcastPartial({
+							kind: 'agentFeedback',
+							id: 'feedback-var',
+							name: 'Feedback',
+							value: 'Feedback text for the model',
+							sessionResource,
+							feedbackItems: [{
+								id: 'feedback-1',
+								text: 'Please simplify this.',
+								resourceUri: URI.file('/workspace/foo.ts'),
+								range: new Range(2, 3, 4, 5),
+								codeSelection: 'const value = compute();',
+								diffHunks: '@@ -1 +1 @@',
+								sourcePRReviewCommentId: 'thread-1',
+							}],
+							_meta: { source: 'test' },
+						}),
+					],
+				},
+			});
+			fire({ type: 'session/turnComplete', session, turnId } as SessionAction);
+			await turnPromise;
+
+			assert.strictEqual(agentHostService.turnActions.length, 1);
+			const turnAction = agentHostService.turnActions[0].action as ITurnStartedAction;
+			assert.deepStrictEqual(turnAction.userMessage.attachments, [{
+				type: MessageAttachmentKind.Simple,
+				label: 'Feedback',
+				modelRepresentation: 'Feedback text for the model',
+				displayKind: AgentFeedbackAttachmentDisplayKind,
+				_meta: {
+					source: 'test',
+					[AgentFeedbackAttachmentMetadataKey]: {
+						sessionResource: sessionResource.toString(),
+						feedbackItems: [{
+							id: 'feedback-1',
+							text: 'Please simplify this.',
+							resourceUri: URI.file('/workspace/foo.ts').toString(),
+							range: {
+								start: { line: 1, character: 2 },
+								end: { line: 3, character: 4 },
+							},
+							codeSelection: 'const value = compute();',
+							diffHunks: '@@ -1 +1 @@',
+							sourcePRReviewCommentId: 'thread-1',
+						}],
+					},
+				},
+			}]);
 		}));
 
 		test('directory variable with file:// URI becomes directory attachment', () => runWithFakedTimers({ useFakeTimers: true }, async () => {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -2164,7 +2164,6 @@ suite('AgentHostChatContribution', () => {
 											start: { line: 1, character: 2 },
 											end: { line: 3, character: 4 },
 										},
-										codeSelection: 'const value = compute();',
 									}],
 								},
 							},
@@ -2205,9 +2204,6 @@ suite('AgentHostChatContribution', () => {
 						text: 'Please simplify this.',
 						resourceUri: feedbackFile.toString(),
 						range: { startLineNumber: 2, startColumn: 3, endLineNumber: 4, endColumn: 5 },
-						codeSelection: 'const value = compute();',
-						diffHunks: undefined,
-						sourcePRReviewCommentId: undefined,
 					}],
 					_meta: {
 						[AgentFeedbackAttachmentMetadataKey]: {
@@ -2220,7 +2216,6 @@ suite('AgentHostChatContribution', () => {
 									start: { line: 1, character: 2 },
 									end: { line: 3, character: 4 },
 								},
-								codeSelection: 'const value = compute();',
 							}],
 						},
 					},
@@ -2814,9 +2809,6 @@ suite('AgentHostChatContribution', () => {
 								start: { line: 1, character: 2 },
 								end: { line: 3, character: 4 },
 							},
-							codeSelection: 'const value = compute();',
-							diffHunks: '@@ -1 +1 @@',
-							sourcePRReviewCommentId: 'thread-1',
 						}],
 					},
 				},
@@ -3030,6 +3022,7 @@ suite('AgentHostChatContribution', () => {
 			const requestedDir = URI.file('/source');
 			const resolvedDir = URI.file('/worktree');
 			const expectedSelectionUri = URI.file('/worktree/sub/foo.ts');
+			const feedbackUri = URI.file('/source/commented.ts');
 			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables, {
 				workingDirectoryResolver: { resolve: () => requestedDir },
 			});
@@ -3051,6 +3044,20 @@ suite('AgentHostChatContribution', () => {
 							enabled: true,
 							value: { uri: URI.file('/source/sub/foo.ts'), range: new Range(2, 3, 4, 5) },
 						}),
+						upcastPartial({
+							kind: 'agentFeedback',
+							id: 'v-feedback',
+							name: 'Feedback',
+							value: 'Feedback text for the model',
+							sessionResource: URI.from({ scheme: 'agent-host-copilot', path: '/new-turntest' }),
+							feedbackItems: [{
+								id: 'feedback-1',
+								text: 'Please simplify this.',
+								resourceUri: feedbackUri,
+								range: new Range(6, 1, 6, 8),
+								codeSelection: 'compute',
+							}],
+						}),
 					],
 				},
 			});
@@ -3071,6 +3078,26 @@ suite('AgentHostChatContribution', () => {
 						range: {
 							start: { line: 1, character: 2 },
 							end: { line: 3, character: 4 },
+						},
+					},
+				},
+				{
+					type: MessageAttachmentKind.Simple,
+					label: 'Feedback',
+					modelRepresentation: 'Feedback text for the model',
+					displayKind: AgentFeedbackAttachmentDisplayKind,
+					_meta: {
+						[AgentFeedbackAttachmentMetadataKey]: {
+							sessionResource: URI.from({ scheme: 'agent-host-copilot', path: '/new-turntest' }).toString(),
+							feedbackItems: [{
+								id: 'feedback-1',
+								text: 'Please simplify this.',
+								resourceUri: feedbackUri.toString(),
+								range: {
+									start: { line: 5, character: 0 },
+									end: { line: 5, character: 7 },
+								},
+							}],
 						},
 					},
 				},


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/315061

## Summary

- Represent Agents window line feedback as Agent Host simple message attachments using `displayKind: agentFeedback` and structured `_meta.agentFeedback` metadata.
- Pass feedback through Copilot provider prompts and metadata-backed SDK selection attachments.
- Restore feedback attachments in Agent Host chat history and add Claude prompt fallback rendering.

## Validation

- `npm run compile-check-ts-native`
- `npm run transpile-client`
- `./scripts/test.sh --run src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts`
- `./scripts/test.sh --run src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts`
- `./scripts/test.sh --run src/vs/platform/agentHost/test/node/claudeAgent.test.ts`
- `npm run valid-layers-check`
- `npm run hygiene`
- `npm run precommit`