### PR TITLE
Fix duplicate terminal tool render from pastTenseMessage in agent host sessions

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
@@ -406,7 +406,7 @@ function getToolErrorString(tc: ToolCallState): string | undefined {
  */
 export function completedToolCallToSerialized(tc: ICompletedToolCall, subAgentInvocationId: string | undefined, sessionResource: URI, connectionAuthority: string | undefined): IChatToolInvocationSerialized {
 	const terminalContentUri = tc.status === ToolCallStatus.Completed ? getTerminalContentUri(tc.content) : undefined;
-	const isTerminal = !!terminalContentUri;
+	const isTerminal = !!terminalContentUri || getToolKind(tc) === 'terminal';
 	const isSuccess = tc.status === ToolCallStatus.Completed && tc.success;
 	const invocationMsg = stringOrMarkdownToString(tc.invocationMessage, connectionAuthority) ?? localize('ahp.running', "Running {0}...", tc.displayName);
 
@@ -442,7 +442,7 @@ export function completedToolCallToSerialized(tc: ICompletedToolCall, subAgentIn
 	}
 
 	let toolSpecificData: IChatTerminalToolInvocationData | IChatSearchToolInvocationData | undefined;
-	if (isTerminal || getToolKind(tc) === 'terminal') {
+	if (isTerminal) {
 		toolSpecificData = {
 			kind: 'terminal',
 			commandLine: { original: getTerminalInput(tc) ?? '' },

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
@@ -322,6 +322,55 @@ suite('stateToProgressAdapter', () => {
 			assert.strictEqual(termData.terminalCommandState.exitCode, 0);
 		});
 
+		test('terminal tool call in history does not set pastTenseMessage (avoids duplicate render)', () => {
+			const turn = createTurn({
+				responseParts: [{
+					kind: ResponsePartKind.ToolCall, toolCall: createCompletedToolCall({
+						_meta: { toolKind: 'terminal' },
+						toolInput: 'echo hi',
+						pastTenseMessage: 'Ran echo hi',
+						content: [
+							{ type: ToolResultContentType.Terminal, resource: 'agenthost-terminal:///past', title: 'Terminal' },
+							{ type: ToolResultContentType.Text, text: 'hi' },
+						],
+						success: true,
+					})
+				} as ToolCallResponsePart],
+			});
+
+			const history = turnsToHistory(URI.file('/'), [turn], 'p');
+			const response = history[1];
+			assert.strictEqual(response.type, 'response');
+			if (response.type !== 'response') { return; }
+			const serialized = response.parts[0] as IChatToolInvocationSerialized;
+			assert.strictEqual(serialized.toolSpecificData?.kind, 'terminal');
+			assert.strictEqual(serialized.pastTenseMessage, undefined);
+		});
+
+		test('terminal tool call (by toolKind only) in history does not set pastTenseMessage', () => {
+			const turn = createTurn({
+				responseParts: [{
+					kind: ResponsePartKind.ToolCall, toolCall: createCompletedToolCall({
+						_meta: { toolKind: 'terminal' },
+						toolInput: 'echo hi',
+						pastTenseMessage: 'Ran echo hi',
+						content: [
+							{ type: ToolResultContentType.Text, text: 'hi' },
+						],
+						success: true,
+					})
+				} as ToolCallResponsePart],
+			});
+
+			const history = turnsToHistory(URI.file('/'), [turn], 'p');
+			const response = history[1];
+			assert.strictEqual(response.type, 'response');
+			if (response.type !== 'response') { return; }
+			const serialized = response.parts[0] as IChatToolInvocationSerialized;
+			assert.strictEqual(serialized.toolSpecificData?.kind, 'terminal');
+			assert.strictEqual(serialized.pastTenseMessage, undefined);
+		});
+
 		test('subagent tool call in history has correct subagent data', () => {
 			const turn = createTurn({
 				responseParts: [{


### PR DESCRIPTION
For agent host sessions, terminal tool calls were having `pastTenseMessage` set on the serialized history invocation, which the renderer then displays alongside the terminal command — causing the past-tense message to appear to duplicate the main message.

The live finalize path (`finalizeToolInvocation`) already suppressed `pastTenseMessage` for terminal tools using a broader check (terminal content URI OR tool kind === 'terminal'). The history replay path (`completedToolCallToSerialized`) was only checking the terminal content URI, so for terminal tools detected only via tool kind we'd set `toolSpecificData.kind === 'terminal'` AND `pastTenseMessage` — producing the duplicated render.

Aligned the two paths by expanding `isTerminal` in `completedToolCallToSerialized` to include the tool-kind check, and cleaned up the now-redundant `getToolKind(tc) === 'terminal'` check on the `toolSpecificData` assignment.

Added two tests covering both terminal detection paths.
