### PR TITLE
Extend suffix-anchored terminal links to capture embedded spaces

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkParsing.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkParsing.ts
@@ -211,6 +211,20 @@ function parseIntOptional(value: string | undefined): number | undefined {
 // character, otherwise it will stop at a space character.
 const linkWithSuffixPathCharacters = /(?<path>(?:file:\/\/\/)?[^\s\|<>\[\({][^\s\|<>]*)$/;
 
+/**
+ * Characters that always terminate a leftward extension of a suffix-anchored path. These are
+ * shell/quotation/grouping delimiters that would never be part of a valid file path. The path
+ * extension also stops at non-breaking space (U+00A0) since that is used by some prompts as a
+ * separator.
+ */
+const linkPathExtensionStopChars = '<>|\'"`(){}[]';
+
+/**
+ * The Windows drive prefix used to determine if an extended path looks like an absolute Windows
+ * path (e.g. `C:\` or `c:/`).
+ */
+const winDrivePrefixRe = /^[a-zA-Z]:[\\/]/;
+
 export function detectLinks(line: string, os: OperatingSystem) {
 	// 1: Detect all links on line via suffixes first
 	const results = detectLinksViaSuffix(line);
@@ -261,11 +275,67 @@ function binaryInsert(list: IParsedLink[], newItem: IParsedLink, low: number, hi
 	}
 }
 
+/**
+ * Attempts to extend a suffix-anchored path leftward through whitespace to capture paths that
+ * contain embedded spaces (eg. `/Users/me/My Project/file.ts:10`). The narrow `linkWithSuffixPathCharacters`
+ * regex above stops at any whitespace, so without this step a path with spaces is truncated to its
+ * final whitespace-free segment.
+ *
+ * To keep false positives in check, the extended candidate is only emitted when:
+ *   1. The extension stops at `minStart`, the start of the line, or at a hard delimiter
+ *      ([[linkPathExtensionStopChars]]).
+ *   2. The resulting candidate starts with an unambiguous absolute / home-relative path marker
+ *      (eg. `/`, `~/`, `~\`, a Windows drive letter or `file:///`). This avoids consuming
+ *      surrounding sentence words for relative paths where there is no signal that the leading
+ *      tokens are part of the path.
+ *
+ * Validation against the file system happens later in the link detector, so an incorrect
+ * extension simply fails to resolve rather than producing a broken link.
+ *
+ * @param line The full line being parsed.
+ * @param currentStart The start index in `line` of the narrowly-matched path.
+ * @param beforeSuffix `line.substring(0, suffix.suffix.index)`, ie. the portion of the line that
+ * precedes the current suffix. Substrings taken from this are used to test path-marker prefixes.
+ * @param minStart The minimum allowed start index in `line`. Set this to the end of the previous
+ * suffix to prevent an extension from spanning across a sibling link's region.
+ * @returns The start index in `line` of the extended path, or `undefined` if no qualifying
+ * extension exists.
+ */
+function tryExtendPathLeft(line: string, currentStart: number, beforeSuffix: string, minStart: number): number | undefined {
+	if (currentStart <= minStart) {
+		return undefined;
+	}
+	let extendedStart = currentStart;
+	let i = currentStart;
+	while (i > minStart) {
+		const prevChar = line[i - 1];
+		if (linkPathExtensionStopChars.indexOf(prevChar) !== -1) {
+			break;
+		}
+		i--;
+		// Only consider candidates whose leading character has changed (ie. we walked past a space)
+		// and which start at a recognizable absolute path marker. Walking through filename
+		// characters between spaces is fine, we just don't anchor on them.
+		const candidate = beforeSuffix.substring(i);
+		if (
+			candidate.startsWith('/') ||
+			candidate.startsWith('~/') ||
+			candidate.startsWith('~\\') ||
+			candidate.startsWith('file:///') ||
+			winDrivePrefixRe.test(candidate)
+		) {
+			extendedStart = i;
+		}
+	}
+	return extendedStart === currentStart ? undefined : extendedStart;
+}
+
 function detectLinksViaSuffix(line: string): IParsedLink[] {
 	const results: IParsedLink[] = [];
 
 	// 1: Detect link suffixes on the line
 	const suffixes = detectLinkSuffixes(line);
+	let previousSuffixEnd = 0;
 	for (const suffix of suffixes) {
 		const beforeSuffix = line.substring(0, suffix.suffix.index);
 		const possiblePathMatch = beforeSuffix.match(linkWithSuffixPathCharacters);
@@ -331,7 +401,28 @@ function detectLinksViaSuffix(line: string): IParsedLink[] {
 					});
 				}
 			}
+
+			// If the path could plausibly start earlier in the line through embedded spaces
+			// (eg. `/Users/me/My Project/file.ts:10`), emit an additional candidate covering
+			// that extended range. The standard narrow candidate is kept so that whichever
+			// path resolves on disk first wins during link validation. Only attempted when
+			// there's no prefix (quotes/etc anchor the start unambiguously). See #212334.
+			if (!prefix) {
+				const pathStartInLine = linkStartIndex;
+				const extendedStart = tryExtendPathLeft(line, pathStartInLine, beforeSuffix, previousSuffixEnd);
+				if (extendedStart !== undefined && extendedStart < pathStartInLine) {
+					results.push({
+						path: {
+							index: extendedStart,
+							text: beforeSuffix.substring(extendedStart)
+						},
+						prefix: undefined,
+						suffix
+					});
+				}
+			}
 		}
+		previousSuffixEnd = suffix.suffix.index + suffix.suffix.text.length;
 	}
 
 	return results;

--- a/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkParsing.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkParsing.test.ts
@@ -759,5 +759,92 @@ suite('TerminalLinkParsing', () => {
 				[] as IParsedLink[]
 			);
 		});
+
+		suite('paths with embedded spaces (#212334)', () => {
+			test('absolute posix path with a single embedded space and a row suffix', () => {
+				const links = detectLinks('/Users/me/My Project/file.ts:10', OperatingSystem.Linux);
+				// The narrow match (path after the space) is always emitted first, the extended
+				// match that includes the embedded space is appended for validation to choose.
+				ok(
+					links.some(l => l.path.text === '/Users/me/My Project/file.ts' && l.path.index === 0),
+					`expected an extended candidate covering the full path with spaces, got ${JSON.stringify(links)}`
+				);
+				ok(
+					links.some(l => l.path.text === 'Project/file.ts'),
+					`expected the original narrow candidate to still be present, got ${JSON.stringify(links)}`
+				);
+			});
+
+			test('absolute posix path with multiple embedded spaces and a row/col suffix', () => {
+				const links = detectLinks('/foo bar baz.ts:10:5', OperatingSystem.Linux);
+				ok(
+					links.some(l => l.path.text === '/foo bar baz.ts' && l.path.index === 0),
+					`expected an extended candidate covering the full path, got ${JSON.stringify(links)}`
+				);
+			});
+
+			test('Windows drive-letter path with embedded spaces and a row suffix', () => {
+				const links = detectLinks('C:\\Users\\Test User\\file.ts:10', OperatingSystem.Windows);
+				ok(
+					links.some(l => l.path.text === 'C:\\Users\\Test User\\file.ts' && l.path.index === 0),
+					`expected an extended candidate covering the full Windows path with spaces, got ${JSON.stringify(links)}`
+				);
+			});
+
+			test('tilde-relative path with embedded spaces and a row suffix', () => {
+				const links = detectLinks('~/My Folder/file.ts:10', OperatingSystem.Linux);
+				ok(
+					links.some(l => l.path.text === '~/My Folder/file.ts' && l.path.index === 0),
+					`expected an extended candidate for tilde paths, got ${JSON.stringify(links)}`
+				);
+			});
+
+			test('does not extend when the leading tokens are not a path marker', () => {
+				// `cat` is not a path-absolute marker so the extension must not consume it.
+				const links = detectLinks('cat foo.ts:10', OperatingSystem.Linux);
+				strictEqual(
+					links.some(l => l.path.text.startsWith('cat')),
+					false,
+					`expected no candidate to include the non-path leading word "cat", got ${JSON.stringify(links)}`
+				);
+			});
+
+			test('extension stops at a hard delimiter (single quote)', () => {
+				// The single quote on the left bounds the extension - leading shell text must
+				// not be consumed.
+				const links = detectLinks("echo '/foo bar.ts:10", OperatingSystem.Linux);
+				strictEqual(
+					links.some(l => l.path.text.includes('echo')),
+					false,
+					`extension must not span past a single quote, got ${JSON.stringify(links)}`
+				);
+				ok(
+					links.some(l => l.path.text === '/foo bar.ts'),
+					`expected the extended path bounded by the quote, got ${JSON.stringify(links)}`
+				);
+			});
+
+			test('extension does not span past a previous suffix on the same line', () => {
+				// Two distinct links on one line. The second one's extension would otherwise walk
+				// across the first one's range and produce a candidate spanning both.
+				const links = detectLinks('/a:1 /b/c d.ts:2', OperatingSystem.Linux);
+				strictEqual(
+					links.some(l => l.path.text.startsWith('/a:')),
+					false,
+					`extension must stop at the previous suffix boundary, got ${JSON.stringify(links)}`
+				);
+				ok(
+					links.some(l => l.path.text === '/b/c d.ts'),
+					`expected the extended candidate for the second path, got ${JSON.stringify(links)}`
+				);
+			});
+
+			test('path already starting at index 0 is not duplicated', () => {
+				// No leading whitespace to consume - we must not emit a redundant identical candidate.
+				const links = detectLinks('/foo.ts:10', OperatingSystem.Linux);
+				const fooMatches = links.filter(l => l.path.text === '/foo.ts');
+				strictEqual(fooMatches.length, 1, `expected exactly one parsed link, got ${JSON.stringify(links)}`);
+			});
+		});
 	});
 });

--- a/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLocalLinkDetector.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLocalLinkDetector.test.ts
@@ -344,6 +344,18 @@ suite('Workbench - TerminalLocalLinkDetector', () => {
 				await assertLinks(TerminalBuiltinLinkType.LocalFile, baseLink, [{ uri: resource, range: [[1, 1], [baseLink.length, 1]] }]);
 			});
 		}
+
+		// Suffix-anchored paths with embedded spaces only resolve when the file system says the
+		// extended path exists. See #212334.
+		test('should detect absolute path with embedded space when followed by a row suffix (#212334)', async () => {
+			const resource = URI.file('/Users/me/My Project/file.ts');
+			validResources = [resource];
+			fileService.setFiles(validResources);
+			const line = '/Users/me/My Project/file.ts:10';
+			await assertLinks(TerminalBuiltinLinkType.LocalFile, line, [
+				{ uri: resource, range: [[1, 1], [line.length, 1]] }
+			]);
+		});
 	});
 
 	// Only test these when on Windows because there is special behavior around replacing separators
@@ -428,6 +440,17 @@ suite('Workbench - TerminalLocalLinkDetector', () => {
 					await assertLinks(TerminalBuiltinLinkType.LocalFile, baseLink, [{ uri: resource, range: [[1, 1], [baseLink.length, 1]] }]);
 				});
 			}
+
+			// Suffix-anchored Windows path with embedded space. See #212334.
+			test('should detect drive-letter path with embedded space when followed by a row suffix (#212334)', async () => {
+				const resource = URI.file('C:\\Users\\Test User\\file.ts');
+				validResources = [resource];
+				fileService.setFiles(validResources);
+				const line = 'C:\\Users\\Test User\\file.ts:10';
+				await assertLinks(TerminalBuiltinLinkType.LocalFile, line, [
+					{ uri: resource, range: [[1, 1], [line.length, 1]] }
+				]);
+			});
 
 			suite('WSL', () => {
 				test('Unix -> Windows /mnt/ style links', async () => {


### PR DESCRIPTION
## Summary

The integrated terminal cannot detect file paths that contain spaces when they are followed by a `:row[:col]` suffix (`/Users/me/My Project/file.ts:10`, `C:\Users\Test User\file.ts:10`, etc.). The link detector ends up only highlighting the trailing whitespace-free segment (`Project/file.ts:10`), which never resolves on the file system.

Refs #212334.

## Details

`detectLinksViaSuffix` in `terminalLinkParsing.ts` finds suffixes first, then walks the line backwards to recover the path with the regex `linkWithSuffixPathCharacters` (`/(?<path>(?:file:\/\/\/)?[^\s\|<>\[\({][^\s\|<>]*)$/`). Both character classes in that regex exclude `\s`, so the match terminates at the first space scanning backwards. With validation already happening on the file system in `terminalLocalLinkDetector`, the truncated candidate never resolves and no link is created.

This change keeps the existing narrow candidate and additionally emits an extended candidate per suffix that walks leftward through whitespace until it either:

- Hits a hard shell/quotation delimiter (`< > | ' " \` ( ) { } [ ]`),
- Reaches the end of the previous suffix on the same line (so two adjacent links cannot merge), or
- Reaches the start of the line.

The extended candidate is only emitted when its first character is an unambiguous absolute path marker (`/`, `~/`, `~\`, `file:///`, or a Windows drive letter followed by `\` or `/`). This avoids consuming surrounding shell text for relative paths like `foo.ts:10` while still covering the well-known absolute-path-with-spaces case that motivates the issue. The file-system check in the detector decides which candidate wins, so an incorrect extension just falls through without producing a broken link.

Only `terminalLinkParsing.detectLinksViaSuffix` is changed; no behaviour for relative paths, quoted paths, bracketed paths, the no-suffix scan in `detectPathsNoSuffix`, or the existing `fallbackMatchers` in `terminalLocalLinkDetector` is altered. Existing tests (including the "should detect 3 suffix links on a single line" exhaustive matrix and the multi-quote / `notlink[foo:45]` cases) continue to pass.

This complements PR #254504 which addressed the narrower `PS ...>` PowerShell-prompt path case via the fallback matchers.

## Test plan

Unit tests added to `terminalLinkParsing.test.ts` under `paths with embedded spaces (#212334)`:

- [x] Absolute posix path with a single embedded space and a `:10` suffix is parsed at index 0
- [x] Absolute posix path with multiple embedded spaces and `:10:5` suffix is parsed at index 0
- [x] Windows drive-letter path with embedded spaces is parsed at index 0
- [x] Tilde-relative path (`~/My Folder/file.ts:10`) is parsed at index 0
- [x] Non-path leading tokens (`cat foo.ts:10`) are not consumed
- [x] Extension stops at a single quote (`echo '/foo bar.ts:10`)
- [x] Extension stops at a previous suffix on the same line (`/a:1 /b/c d.ts:2`)
- [x] No duplicate candidate is emitted when the path already starts at index 0

End-to-end tests added to `terminalLocalLinkDetector.test.ts`:

- [x] `/Users/me/My Project/file.ts:10` resolves and the buffer range spans the full path including the suffix
- [x] `C:\Users\Test User\file.ts:10` resolves on Windows

Manual repro of the original issue:

1. `mkdir "/tmp/My Project" && touch "/tmp/My Project/file.ts"`
2. In an integrated terminal: `echo "/tmp/My Project/file.ts:10"`
3. Ctrl/Cmd-hover the printed path. Before this change only `Project/file.ts:10` underlines and clicking does nothing. After this change the full `/tmp/My Project/file.ts:10` underlines and clicking jumps to line 10 of the file.
