### PR TITLE
Drop stale wheel events after focus return

### DIFF
--- a/src/vs/base/browser/mouseEvent.ts
+++ b/src/vs/base/browser/mouseEvent.ts
@@ -119,6 +119,35 @@ interface IGeckoMouseWheelEvent {
 	detail: number;
 }
 
+const STALE_MOUSE_WHEEL_EVENT_THRESHOLD = 1000;
+
+export function isStaleMouseWheelEvent(e: IMouseWheelEvent, now: number = Date.now()): boolean {
+	const timestamp = e.timeStamp;
+	if (!Number.isFinite(timestamp) || timestamp <= 0) {
+		return false;
+	}
+
+	const eventEpoch = timestamp > 1_000_000_000_000
+		? timestamp
+		: getMouseWheelEventTimeOrigin(e) + timestamp;
+
+	return eventEpoch < now - STALE_MOUSE_WHEEL_EVENT_THRESHOLD;
+}
+
+function getMouseWheelEventTimeOrigin(e: IMouseWheelEvent): number {
+	const eventPerformance = e.view?.performance ?? globalThis.performance;
+
+	if (typeof eventPerformance?.timeOrigin === 'number') {
+		return eventPerformance.timeOrigin;
+	}
+
+	if (typeof eventPerformance?.now === 'function') {
+		return Date.now() - eventPerformance.now();
+	}
+
+	return Date.now();
+}
+
 export class StandardWheelEvent {
 
 	public readonly browserEvent: IMouseWheelEvent | null;

--- a/src/vs/base/browser/ui/scrollbar/scrollableElement.ts
+++ b/src/vs/base/browser/ui/scrollbar/scrollableElement.ts
@@ -6,7 +6,7 @@
 import { getZoomFactor, isChrome } from '../../browser.js';
 import * as dom from '../../dom.js';
 import { FastDomNode, createFastDomNode } from '../../fastDomNode.js';
-import { IMouseEvent, IMouseWheelEvent, StandardWheelEvent } from '../../mouseEvent.js';
+import { IMouseEvent, IMouseWheelEvent, isStaleMouseWheelEvent, StandardWheelEvent } from '../../mouseEvent.js';
 import { ScrollbarHost } from './abstractScrollbar.js';
 import { HorizontalScrollbar } from './horizontalScrollbar.js';
 import { ScrollableElementChangeOptions, ScrollableElementCreationOptions, ScrollableElementResolvedOptions } from './scrollableElementOptions.js';
@@ -427,6 +427,12 @@ export abstract class AbstractScrollableElement extends Widget {
 
 	private _onMouseWheel(e: StandardWheelEvent): void {
 		if (e.browserEvent?.defaultPrevented) {
+			return;
+		}
+
+		if (e.browserEvent && isStaleMouseWheelEvent(e.browserEvent)) {
+			e.preventDefault();
+			e.stopPropagation();
 			return;
 		}
 

--- a/src/vs/base/test/browser/mouseEvent.test.ts
+++ b/src/vs/base/test/browser/mouseEvent.test.ts
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { IMouseWheelEvent, isStaleMouseWheelEvent } from '../../browser/mouseEvent.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../common/utils.js';
+
+suite('mouseEvent', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('detects stale mouse wheel events', () => {
+		const now = Date.now();
+		const performanceNow = performance.now();
+
+		const recentRelativeEvent = { timeStamp: performanceNow } as IMouseWheelEvent;
+		const staleRelativeEvent = { timeStamp: performanceNow - 2000 } as IMouseWheelEvent;
+		const recentEpochEvent = { timeStamp: now } as IMouseWheelEvent;
+		const staleEpochEvent = { timeStamp: now - 2000 } as IMouseWheelEvent;
+		const unknownTimestampEvent = { timeStamp: 0 } as IMouseWheelEvent;
+
+		assert.deepStrictEqual([
+			isStaleMouseWheelEvent(recentRelativeEvent, now),
+			isStaleMouseWheelEvent(staleRelativeEvent, now),
+			isStaleMouseWheelEvent(recentEpochEvent, now),
+			isStaleMouseWheelEvent(staleEpochEvent, now),
+			isStaleMouseWheelEvent(unknownTimestampEvent, now),
+		], [false, true, false, true, false]);
+	});
+});

--- a/src/vs/editor/browser/controller/mouseHandler.ts
+++ b/src/vs/editor/browser/controller/mouseHandler.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as dom from '../../../base/browser/dom.js';
-import { StandardWheelEvent, IMouseWheelEvent } from '../../../base/browser/mouseEvent.js';
+import { StandardWheelEvent, IMouseWheelEvent, isStaleMouseWheelEvent } from '../../../base/browser/mouseEvent.js';
 import { Disposable, IDisposable } from '../../../base/common/lifecycle.js';
 import * as platform from '../../../base/common/platform.js';
 import { HitTestContext, MouseTarget, MouseTargetFactory, PointerHandlerLastRenderData } from './mouseTarget.js';
@@ -147,6 +147,12 @@ export class MouseHandler extends ViewEventHandler {
 		let gestureAccumulatedDelta = 0;
 
 		const onMouseWheel = (browserEvent: IMouseWheelEvent) => {
+			if (isStaleMouseWheelEvent(browserEvent)) {
+				browserEvent.preventDefault();
+				browserEvent.stopPropagation();
+				return;
+			}
+
 			this.viewController.emitMouseWheel(browserEvent);
 
 			if (!this._context.configuration.options.get(EditorOption.mouseWheelZoom)) {


### PR DESCRIPTION
Fixes #28795

This drops stale wheel events before they reach editor wheel handling or shared scrollable elements. The guard uses the event timestamp and consumes events that are older than the current event loop by more than one second, which prevents queued wheel input from being replayed after VS Code regains focus while preserving current wheel input.

Verification:
- `npm run compile-check-ts-native`
- `NODE_OPTIONS=--max-old-space-size=8192 npx gulp compile-client` with Node 22.22.3
- `./scripts/test.sh --grep mouseEvent` with Node 22.22.3
- `npm run -s precommit` with Node 22.22.3
- `git diff --check`