### PR TITLE
Fix workbench hover not scrolling when content overflows

### DIFF
--- a/src/vs/platform/hover/browser/hoverWidget.ts
+++ b/src/vs/platform/hover/browser/hoverWidget.ts
@@ -615,6 +615,11 @@ export class HoverWidget extends Widget implements IHoverWidget {
 		}
 
 		this._hover.containerDomNode.style.maxHeight = `${maxHeight}px`;
+		// Scroll is owned by the DomScrollableElement around contentsDomNode; bounding only the
+		// outer container clips with no scrollbar. Mirror the editor ContentHoverWidget and also
+		// bound the scrollable root + contents node so scanDomNode() can show the scrollbar.
+		this._hover.scrollbar.getDomNode().style.maxHeight = `${maxHeight}px`;
+		this._hover.contentsDomNode.style.maxHeight = `${maxHeight}px`;
 		if (this._hover.contentsDomNode.clientHeight < this._hover.contentsDomNode.scrollHeight) {
 			// Add padding for a vertical scrollbar
 			const extraRightPadding = `${this._hover.scrollbar.options.verticalScrollbarSize}px`;

--- a/src/vs/platform/hover/test/browser/hoverWidget.test.ts
+++ b/src/vs/platform/hover/test/browser/hoverWidget.test.ts
@@ -1,0 +1,132 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { Event } from '../../../../base/common/event.js';
+import { toDisposable } from '../../../../base/common/lifecycle.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { TestInstantiationService } from '../../../instantiation/test/common/instantiationServiceMock.js';
+import { IConfigurationService } from '../../../configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../configuration/test/common/testConfigurationService.js';
+import { HoverService } from '../../browser/hoverService.js';
+import { IHoverService } from '../../browser/hover.js';
+import { HoverWidget } from '../../browser/hoverWidget.js';
+import { IContextMenuService } from '../../../contextview/browser/contextView.js';
+import { IKeybindingService } from '../../../keybinding/common/keybinding.js';
+import { ILayoutService } from '../../../layout/browser/layoutService.js';
+import { IAccessibilityService } from '../../../accessibility/common/accessibility.js';
+import { TestAccessibilityService } from '../../../accessibility/test/common/testAccessibilityService.js';
+import { mainWindow } from '../../../../base/browser/window.js';
+import { NoMatchingKb } from '../../../keybinding/common/keybindingResolver.js';
+import { IMarkdownRendererService } from '../../../markdown/browser/markdownRenderer.js';
+import type { IHoverWidget } from '../../../../base/browser/ui/hover/hover.js';
+
+suite('HoverWidget', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+	let hoverService: HoverService;
+	let fixture: HTMLElement;
+	let instantiationService: TestInstantiationService;
+
+	setup(() => {
+		fixture = document.createElement('div');
+		mainWindow.document.body.appendChild(fixture);
+		store.add(toDisposable(() => fixture.remove()));
+
+		instantiationService = store.add(new TestInstantiationService());
+
+		const configurationService = new TestConfigurationService();
+		configurationService.setUserConfiguration('workbench.hover.delay', 0);
+		instantiationService.stub(IConfigurationService, configurationService);
+
+		instantiationService.stub(IContextMenuService, { onDidShowContextMenu: Event.None });
+
+		instantiationService.stub(IKeybindingService, {
+			mightProducePrintableCharacter() { return false; },
+			softDispatch() { return NoMatchingKb; },
+			resolveKeyboardEvent() {
+				return {
+					getLabel() { return ''; },
+					getAriaLabel() { return ''; },
+					getElectronAccelerator() { return null; },
+					getUserSettingsLabel() { return null; },
+					isWYSIWYG() { return false; },
+					hasMultipleChords() { return false; },
+					getDispatchChords() { return [null]; },
+					getSingleModifierDispatchChords() { return []; },
+					getChords() { return []; }
+				};
+			}
+		});
+
+		instantiationService.stub(ILayoutService, {
+			activeContainer: fixture,
+			mainContainer: fixture,
+			getContainer() { return fixture; },
+			onDidLayoutContainer: Event.None
+		});
+
+		instantiationService.stub(IAccessibilityService, new TestAccessibilityService());
+
+		instantiationService.stub(IMarkdownRendererService, {
+			render() { return { element: document.createElement('div'), dispose() { } }; },
+			setDefaultCodeBlockRenderer() { }
+		});
+
+		hoverService = store.add(instantiationService.createInstance(HoverService));
+		instantiationService.stub(IHoverService, hoverService);
+	});
+
+	function createTarget(): HTMLElement {
+		const target = document.createElement('div');
+		target.style.width = '100px';
+		target.style.height = '100px';
+		fixture.appendChild(target);
+		return target;
+	}
+
+	// A history-item hover (SCM Commit Graph) passes an HTMLElement whose content
+	// (long commit message + many co-authors) can far exceed the viewport.
+	function createTallContent(): HTMLElement {
+		const el = document.createElement('div');
+		el.style.width = '300px';
+		el.style.height = '4000px';
+		el.textContent = 'Tall hover content';
+		return el;
+	}
+
+	test('overflowing HTMLElement content is bounded so the scrollbar can show (microsoft/vscode#scm-graph-hover-scroll)', () => {
+		const hover = hoverService.showInstantHover({
+			content: createTallContent(),
+			target: createTarget()
+		}) as IHoverWidget;
+		assert.ok(hover, 'Hover should be created');
+		store.add(toDisposable(() => (hover as HoverWidget).dispose()));
+
+		const containerDomNode = (hover as HoverWidget).domNode;
+		const scrollableElement = containerDomNode.querySelector<HTMLElement>('.monaco-scrollable-element');
+		const contentsDomNode = containerDomNode.querySelector<HTMLElement>('.monaco-hover-content');
+
+		assert.ok(scrollableElement, 'Scrollable element should exist');
+		assert.ok(contentsDomNode, 'Contents node should exist');
+
+		const containerMaxHeight = containerDomNode.style.maxHeight;
+		assert.notStrictEqual(containerMaxHeight, '', 'Outer container should be height-capped');
+
+		// Regression: the scroll viewport is the DomScrollableElement around
+		// contentsDomNode. If only the outer container is capped it just clips
+		// (overflow: hidden) and no scrollbar appears. The scrollable root and
+		// the contents node must be capped too (parity with editor ContentHoverWidget).
+		assert.strictEqual(
+			scrollableElement!.style.maxHeight,
+			containerMaxHeight,
+			'Scrollable element must share the container max-height so the scrollbar can render'
+		);
+		assert.strictEqual(
+			contentsDomNode!.style.maxHeight,
+			containerMaxHeight,
+			'Contents node must share the container max-height so the scrollbar can render'
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Workbench element hovers clip overflowing content with **no scrollbar**. Most visible on the Source Control **Commit Graph** history-item hover: a long commit message plus several co-authors is cut off with no way to scroll to the rest.

## Root cause

`HoverWidget.adjustHoverMaxHeight()` in `src/vs/platform/hover/browser/hoverWidget.ts` caps `max-height` **only** on the outer `containerDomNode` (`.monaco-hover`, which is `overflow: hidden`). But the scroll viewport is the `DomScrollableElement` that wraps `contentsDomNode`. Its root (`scrollbar.getDomNode()`) and `contentsDomNode` receive no height constraint, so `scrollbar.scanDomNode()` (run via `onContentsChanged()` at the end of `layout()`) measures `clientHeight === scrollHeight` and never renders the vertical scrollbar — the outer container just clips.

The editor `ContentHoverWidget._setHoverWidgetMaxDimensions()` already bounds all three nodes (`contentsDomNode`, `scrollbar.getDomNode()`, `containerDomNode`); the workbench hover bounded only one.

## Fix

Mirror the editor hover: also cap `max-height` on the scrollable root and `contentsDomNode`. As a side benefit the pre-existing "add right padding for the scrollbar" branch (previously dead because `clientHeight === scrollHeight`) now works as intended. Short content is unchanged (cap never hit → no scrollbar).

## Test

Adds `src/vs/platform/hover/test/browser/hoverWidget.test.ts`: shows a hover with tall HTMLElement content and asserts the scrollable root and contents node share the container `max-height`. Fails before the fix, passes after.

## Verification

Built VS Code and ran the Electron unit runner locally:

- `./scripts/test.sh --grep 'bounded so the scrollbar can show'` → **green** with the fix (`1 passing`).
- Same test with the two new lines removed → **red** (`AssertionError: '' !== '284px'`).

Verified against the `1.119.0` tag; `hoverWidget.ts` there is byte-identical to current `main`, so the result holds for this PR.

## Test plan

- [ ] Open a repo in the Source Control view, enable the Commit Graph (GRAPH section).
- [ ] Hover a commit whose message is long / has multiple co-authors.
- [ ] Before: content clipped, no scrollbar. After: vertical scrollbar, full content reachable.
- [ ] Short hovers unchanged (no scrollbar, same size).

🤖 Generated with [Claude Code](https://claude.com/claude-code)