### PR TITLE
Enhance comment selection and copying in agent feedback widget

### DIFF
--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorWidgetContribution.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorWidgetContribution.ts
@@ -85,6 +85,10 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 		// Create DOM structure
 		this._domNode = $('div.agent-feedback-widget');
 		this._domNode.classList.add('collapsed');
+		// Make focusable so that mousedown in selectable regions can pull focus
+		// away from the editor's textarea, allowing native Ctrl/Cmd+C to copy
+		// the DOM selection of the comment content.
+		this._domNode.tabIndex = -1;
 
 		// Header
 		this._headerNode = $('div.agent-feedback-widget-header');
@@ -257,13 +261,32 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 			}));
 
 			this._eventStore.add(addDisposableListener(item, 'click', e => {
-				if ((e.target as HTMLElement | null)?.closest('.action-bar')) {
+				const target = e.target as HTMLElement | null;
+				if (target?.closest('.action-bar')) {
 					return;
+				}
+				// Don't navigate if the user just selected text inside the comment.
+				if (target?.closest('.agent-feedback-widget-text, .agent-feedback-widget-suggestion-text')) {
+					const selection = this._domNode.ownerDocument.defaultView?.getSelection();
+					if (selection && !selection.isCollapsed && this._domNode.contains(selection.anchorNode)) {
+						return;
+					}
 				}
 				this.focusFeedback(comment.id);
 				this._agentFeedbackService.setNavigationAnchor(this._sessionResource, comment.id);
 				this._revealComment(comment);
 			}));
+
+			// Pull focus to the widget when starting a selection in selectable
+			// regions so that Ctrl/Cmd+C copies the DOM selection instead of
+			// triggering the editor's copy action.
+			const onSelectableMousedown = (e: MouseEvent) => {
+				const target = e.target as HTMLElement | null;
+				if (target?.closest('.agent-feedback-widget-text, .agent-feedback-widget-suggestion-text')) {
+					this._domNode.focus({ preventScroll: true });
+				}
+			};
+			this._eventStore.add(addDisposableListener(item, 'mousedown', onSelectableMousedown));
 
 			this._bodyNode.appendChild(item);
 		}

--- a/src/vs/sessions/contrib/agentFeedback/browser/media/agentFeedbackEditorWidget.css
+++ b/src/vs/sessions/contrib/agentFeedback/browser/media/agentFeedbackEditorWidget.css
@@ -23,6 +23,10 @@
 	opacity: 1;
 }
 
+.agent-feedback-widget:focus {
+	outline: none;
+}
+
 .agent-feedback-widget.fadeOut {
 	animation: agentFeedbackFadeOut 150ms ease-out forwards;
 }
@@ -220,6 +224,9 @@
 .agent-feedback-widget-text {
 	color: var(--vscode-foreground);
 	word-wrap: break-word;
+	user-select: text;
+	-webkit-user-select: text;
+	cursor: text;
 }
 
 .agent-feedback-widget-text .rendered-markdown p {
@@ -274,6 +281,9 @@
 	font-size: 11px;
 	line-height: 1.45;
 	background: var(--vscode-editorWidget-background);
+	user-select: text;
+	-webkit-user-select: text;
+	cursor: text;
 }
 
 /* Gutter decoration for range indicator on hover */


### PR DESCRIPTION
```Copilot Generated Description:``` Implement functionality to allow text selection and copying within the agent feedback widget. Adjustments include making the widget focusable and modifying event handling to prevent navigation when text is selected. Update CSS to support text selection styling.

fixes https://github.com/microsoft/vscode/issues/309597