### PR TITLE
Fix double "Enter" in feedback widget hover tip

### DIFF
--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorInputContribution.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorInputContribution.ts
@@ -73,7 +73,7 @@ class AgentFeedbackInputWidget extends Disposable implements IOverlayWidget {
 
 		this._addAction = this._register(new Action(
 			'agentFeedback.add',
-			localize('agentFeedback.add', "Add Feedback (Enter)"),
+			localize('agentFeedback.add', "Add Feedback"),
 			ThemeIcon.asClassName(Codicon.plus),
 			false,
 			() => { this._onDidTriggerAdd.fire(); return Promise.resolve(); }
@@ -81,7 +81,7 @@ class AgentFeedbackInputWidget extends Disposable implements IOverlayWidget {
 
 		this._addAndSubmitAction = this._register(new Action(
 			'agentFeedback.addAndSubmit',
-			localize('agentFeedback.addAndSubmit', "Add Feedback and Submit (Alt+Enter)"),
+			localize('agentFeedback.addAndSubmit', "Add Feedback and Submit"),
 			ThemeIcon.asClassName(Codicon.send),
 			false,
 			() => { this._onDidTriggerAddAndSubmit.fire(); return Promise.resolve(); }


### PR DESCRIPTION
```Copilot Generated Description:``` Remove the redundant "Enter" from the hover tips for the Add Feedback and Add Feedback and Submit actions in the feedback widget.

Fixes microsoft/vscode#309601

