### PR TITLE
Preserve keybinding default metadata when key is not set

### DIFF
--- a/src/vs/platform/keybinding/common/keybindingsRegistry.ts
+++ b/src/vs/platform/keybinding/common/keybindingsRegistry.ts
@@ -152,18 +152,16 @@ class KeybindingsRegistryImpl implements IKeybindingsRegistry {
 		const result: IKeybindingItem[] = [];
 		let keybindingsLen = 0;
 		for (const rule of rules) {
-			if (rule.keybinding) {
-				result[keybindingsLen++] = {
-					keybinding: rule.keybinding,
-					command: rule.id,
-					commandArgs: rule.args,
-					when: rule.when,
-					weight1: rule.weight,
-					weight2: 0,
-					extensionId: rule.extensionId || null,
-					isBuiltinExtension: rule.isBuiltinExtension || false
-				};
-			}
+			result[keybindingsLen++] = {
+				keybinding: rule.keybinding,
+				command: rule.id,
+				commandArgs: rule.args,
+				when: rule.when,
+				weight1: rule.weight,
+				weight2: 0,
+				extensionId: rule.extensionId || null,
+				isBuiltinExtension: rule.isBuiltinExtension || false
+			};
 		}
 
 		this._extensionKeybindings = result;

--- a/src/vs/platform/keybinding/test/common/keybindingResolver.test.ts
+++ b/src/vs/platform/keybinding/test/common/keybindingResolver.test.ts
@@ -194,6 +194,20 @@ suite('KeybindingResolver', () => {
 			]);
 		});
 
+		test('empty keybinding override is preserved', () => {
+			const defaults = [
+				kbItem(KeyCode.KeyA, 'command1', null, undefined, true)
+			];
+			const overrides = [
+				kbItem(0, 'command1', null, undefined, false)
+			];
+			const actual = KeybindingResolver.handleRemovals([...defaults, ...overrides]);
+			assert.deepStrictEqual(actual, [
+				kbItem(KeyCode.KeyA, 'command1', null, undefined, true),
+				kbItem(0, 'command1', null, undefined, false)
+			]);
+		});
+
 		test('issue #138997 - removal in default list', () => {
 			const defaults = [
 				kbItem(KeyCode.KeyA, 'yes1', null, undefined, true),

--- a/src/vs/platform/keybinding/test/common/keybindingResolver.test.ts
+++ b/src/vs/platform/keybinding/test/common/keybindingResolver.test.ts
@@ -13,6 +13,7 @@ import { KeybindingResolver, ResultKind } from '../../common/keybindingResolver.
 import { ResolvedKeybindingItem } from '../../common/resolvedKeybindingItem.js';
 import { USLayoutResolvedKeybinding } from '../../common/usLayoutResolvedKeybinding.js';
 import { createUSLayoutResolvedKeybinding } from './keybindingsTestUtils.js';
+import { KeybindingsRegistry } from '../../common/keybindingsRegistry.js';
 
 function createContext(ctx: any) {
 	return {
@@ -194,7 +195,7 @@ suite('KeybindingResolver', () => {
 			]);
 		});
 
-		test('empty keybinding override is preserved', () => {
+		test('unbound override keybindings are preserved during removal handling', () => {
 			const defaults = [
 				kbItem(KeyCode.KeyA, 'command1', null, undefined, true)
 			];
@@ -206,6 +207,29 @@ suite('KeybindingResolver', () => {
 				kbItem(KeyCode.KeyA, 'command1', null, undefined, true),
 				kbItem(0, 'command1', null, undefined, false)
 			]);
+		});
+
+		test('registry preserves metadata-only extension keybinding rules', () => {
+			const commandId = 'test.metadataOnlyCommand';
+
+			KeybindingsRegistry.setExtensionKeybindings([
+				{
+					id: commandId,
+					keybinding: null,
+					when: ContextKeyExpr.deserialize('editorTextFocus'),
+					weight: 100,
+					extensionId: 'test.extension',
+					isBuiltinExtension: false
+				}
+			]);
+
+			const actual = KeybindingsRegistry
+				.getDefaultKeybindings()
+				.find(item => item.command === commandId);
+
+			assert.ok(actual);
+			assert.strictEqual(actual.keybinding, null);
+			assert.strictEqual(actual.when?.serialize(), 'editorTextFocus');
 		});
 
 		test('issue #138997 - removal in default list', () => {

--- a/src/vs/workbench/services/keybinding/browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/browser/keybindingService.ts
@@ -624,7 +624,7 @@ export class WorkbenchKeybindingService extends AbstractKeybindingService {
 
 		const { command, args, when, key, mac, linux, win } = binding;
 		const keybinding = WorkbenchKeybindingService.bindToCurrentPlatform(key, mac, linux, win);
-		if (!keybinding) {
+		if (keybinding === undefined) {
 			return undefined;
 		}
 

--- a/src/vs/workbench/services/keybinding/common/keybindingIO.ts
+++ b/src/vs/workbench/services/keybinding/common/keybindingIO.ts
@@ -19,14 +19,19 @@ export interface IUserKeybindingItem {
 export class KeybindingIO {
 
 	public static writeKeybindingItem(out: OutputBuilder, item: ResolvedKeybindingItem): void {
-		if (!item.resolvedKeybinding) {
-			return;
-		}
-		const quotedSerializedKeybinding = JSON.stringify(item.resolvedKeybinding.getUserSettingsLabel());
+		const keyLabel = item.resolvedKeybinding
+			? item.resolvedKeybinding.getUserSettingsLabel()
+			: null;
+
+		// null means metadata-only default keybinding
+		const quotedSerializedKeybinding = keyLabel
+			? JSON.stringify(keyLabel)
+			: 'null';
+
 		out.write(`{ "key": ${rightPaddedString(quotedSerializedKeybinding + ',', 25)} "command": `);
 
 		const quotedSerializedWhen = item.when ? JSON.stringify(item.when.serialize()) : '';
-		const quotedSerializeCommand = JSON.stringify(item.command);
+		const quotedSerializeCommand = JSON.stringify(item.command ?? null);
 		if (quotedSerializedWhen.length > 0) {
 			out.write(`${quotedSerializeCommand},`);
 			out.writeLine();

--- a/src/vs/workbench/services/keybinding/test/browser/keybindingIO.test.ts
+++ b/src/vs/workbench/services/keybinding/test/browser/keybindingIO.test.ts
@@ -10,6 +10,8 @@ import { OperatingSystem } from '../../../../../base/common/platform.js';
 import { KeybindingIO } from '../../common/keybindingIO.js';
 import { createUSLayoutResolvedKeybinding } from '../../../../../platform/keybinding/test/common/keybindingsTestUtils.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { WorkbenchKeybindingService } from '../../browser/keybindingService.js';
+import { ExtensionIdentifier } from '../../../../../platform/extensions/common/extensions.js';
 
 suite('keybindingIO', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
@@ -124,6 +126,31 @@ suite('keybindingIO', () => {
 		);
 	});
 
+	test('empty contributed keybinding creates metadata-only rule', () => {
+		const commandId = 'test.emptyKeybindingCommand';
+
+		const rule = WorkbenchKeybindingService.prototype['_asCommandRule'].call(
+			{},
+			new ExtensionIdentifier('test.extension'),
+			false,
+			0,
+			{
+				command: commandId,
+				args: undefined,
+				key: '',
+				mac: undefined,
+				linux: undefined,
+				win: undefined,
+				when: 'editorTextFocus'
+			}
+		);
+
+		assert.ok(rule);
+
+		assert.strictEqual(rule.keybinding, null);
+		assert.strictEqual(rule.id, commandId);
+	});
+
 	test('issue #10452 - invalid command', () => {
 		const strJSON = `[{ "key": "ctrl+k ctrl+f", "command": ["firstcommand", "seccondcommand"] }]`;
 		const userKeybinding = <Object>JSON.parse(strJSON)[0];
@@ -158,4 +185,5 @@ suite('keybindingIO', () => {
 		const keybindingItem = KeybindingIO.readUserKeybindingItem(userKeybinding);
 		assert.strictEqual((keybindingItem.commandArgs as unknown as { text: string }).text, 'theText');
 	});
+
 });


### PR DESCRIPTION
This PR enables (or fixes) the ability for extensions to define default keybinding metadata without setting an explicit key.

Currently, the metadata (most importantly the `when` property) is lost when defining a keybinding like this, even though the schema itself is valid (command2):

```json
{
    "key": "shift+g",
    "command": "extension.command1",
    "when": "extensionContext1"
},
{
    "key": "",
    "command": "extension.command2",
    "when": "extensionContext2"
}
```
**Result:**

<img width="598" height="201" alt="nopreserve" src="https://github.com/user-attachments/assets/57feeb53-075b-4453-8616-ec9d3ee166b9" />

As a result, extensions cannot provide optional bindable commands without instructing extension users about the correct `when` values, which can be complex, may evolve across extension versions and generally should not be a concern for extension users when possible.

This change preserves default values, so extension users only need to set the keybinding:

<img width="598" height="201" alt="preserve" src="https://github.com/user-attachments/assets/c9b6140a-e352-4280-b831-d52e0539caac" />

#### Changes

What initially looked like it would require a special case turned out, after investigation, to be a straightforward fix:

https://github.com/microsoft/vscode/blob/aa21abcbab6b9a929f7aad632d8377b6fa16bbcd/src/vs/workbench/services/keybinding/browser/keybindingService.ts#L626-L629

This truthiness check was filtering out empty `key` cases. It can safely be replaced with a check for `undefined` only, since after that [KeybindingParser.parseKeybinding(keybinding)](https://github.com/microsoft/vscode/blob/aa21abcbab6b9a929f7aad632d8377b6fa16bbcd/src/vs/workbench/services/keybinding/browser/keybindingService.ts#L654) resolves empty strings to `null`, which is a valid value for `IExtensionKeybindingRule`.

Later, another filter:

https://github.com/microsoft/vscode/blob/aa21abcbab6b9a929f7aad632d8377b6fa16bbcd/src/vs/platform/keybinding/common/keybindingsRegistry.ts#L154-L156

This appears to be another historical truthiness shortcut rather than an intentional semantic filter, since:
* Renderer paths already handle `null` values correctly
* Resolver paths already handle `null` values correctly
* Types already allow `null`

In this context, `null` should not mean “discard rule”, but rather “keep rule, but with no keybinding”.

Adjusting the first guard and removing the second filter prevents keybindings from being discarded, which in turn preserves the keybinding metadata.