### PR TITLE
Add Claude Haiku 4.5 to extended cache TTL eligibility

### DIFF
--- a/extensions/copilot/src/platform/endpoint/test/node/messagesApi.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/test/node/messagesApi.spec.ts
@@ -528,7 +528,7 @@ suite('addToolsAndSystemCacheControl', function () {
 
 suite('modelSupportsExtendedCacheTtl', function () {
 
-	test('matches Opus 4.5/4.6/4.7 and Sonnet 4.5/4.6 variants and rejects everything else', function () {
+	test('matches Opus 4.5/4.6/4.7, Sonnet 4.5/4.6, and Haiku 4.5 variants and rejects everything else', function () {
 		expect({
 			'claude-opus-4.6-1m': modelSupportsExtendedCacheTtl('claude-opus-4.6-1m'),
 			'claude-opus-4-6-1m': modelSupportsExtendedCacheTtl('claude-opus-4-6-1m'),
@@ -557,7 +557,7 @@ suite('modelSupportsExtendedCacheTtl', function () {
 			'claude-sonnet-4.5': true,
 			'claude-opus-4-1': false,
 			'claude-sonnet-4': false,
-			'claude-haiku-4-5': false,
+			'claude-haiku-4-5': true,
 			'gpt-5': false,
 		});
 	});

--- a/extensions/copilot/src/platform/networking/common/anthropic.ts
+++ b/extensions/copilot/src/platform/networking/common/anthropic.ts
@@ -148,6 +148,7 @@ export function isAnthropicContextEditingEnabled(
  * - Claude Opus 4.5
  * - Claude Sonnet 4.6
  * - Claude Sonnet 4.5
+ * - Claude Haiku 4.5
  */
 export function modelSupportsExtendedCacheTtl(modelId: string): boolean {
 	const normalized = modelId.toLowerCase().replace(/\./g, '-');
@@ -155,7 +156,8 @@ export function modelSupportsExtendedCacheTtl(modelId: string): boolean {
 		normalized.startsWith('claude-opus-4-6') ||
 		normalized.startsWith('claude-opus-4-5') ||
 		normalized.startsWith('claude-sonnet-4-6') ||
-		normalized.startsWith('claude-sonnet-4-5');
+		normalized.startsWith('claude-sonnet-4-5') ||
+		normalized.startsWith('claude-haiku-4-5');
 }
 
 /**


### PR DESCRIPTION
Adds Claude Haiku 4.5 to `modelSupportsExtendedCacheTtl` so it can participate in the 1h prompt-cache TTL experiment alongside the other current Claude 4.x models.