### PR TITLE
debug: adopt action widget dropdown for launch configurations

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugActionViewItems.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugActionViewItems.ts
@@ -8,7 +8,7 @@ import { IAction } from '../../../../base/common/actions.js';
 import { KeyCode } from '../../../../base/common/keyCodes.js';
 import * as dom from '../../../../base/browser/dom.js';
 import { StandardKeyboardEvent } from '../../../../base/browser/keyboardEvent.js';
-import { SelectBox, ISelectOptionItem, SeparatorSelectOption } from '../../../../base/browser/ui/selectBox/selectBox.js';
+import { ISelectOptionItem } from '../../../../base/browser/ui/selectBox/selectBox.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IDebugService, IDebugSession, IDebugConfiguration, IConfig, ILaunch, State } from '../common/debug.js';
@@ -29,14 +29,18 @@ import { AccessibilityCommandId } from '../../accessibility/common/accessibility
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { hasNativeContextMenu } from '../../../../platform/window/common/window.js';
 import { Gesture, EventType as TouchEventType } from '../../../../base/browser/touch.js';
-
-const $ = dom.$;
+import { ActionWidgetDropdown, IActionWidgetDropdownAction } from '../../../../platform/actionWidget/browser/actionWidgetDropdown.js';
+import { IActionWidgetService } from '../../../../platform/actionWidget/browser/actionWidget.js';
+import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
+import { renderLabelWithIcons } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
 
 export class StartDebugActionViewItem extends BaseActionViewItem {
 
 	private container!: HTMLElement;
 	private start!: HTMLElement;
-	private selectBox: SelectBox;
+	private configurationContainer!: HTMLElement;
+	private dropdownLabel: HTMLElement | undefined;
+	private dropdown!: ActionWidgetDropdown;
 	private debugOptions: { label: string; handler: (() => Promise<boolean>) }[] = [];
 	private toDispose: IDisposable[];
 	private selected = 0;
@@ -50,16 +54,15 @@ export class StartDebugActionViewItem extends BaseActionViewItem {
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@ICommandService private readonly commandService: ICommandService,
 		@IWorkspaceContextService private readonly contextService: IWorkspaceContextService,
-		@IContextViewService contextViewService: IContextViewService,
+		@IContextViewService _contextViewService: IContextViewService,
 		@IKeybindingService private readonly keybindingService: IKeybindingService,
 		@IHoverService private readonly hoverService: IHoverService,
-		@IContextKeyService private readonly contextKeyService: IContextKeyService
+		@IContextKeyService private readonly contextKeyService: IContextKeyService,
+		@IActionWidgetService private readonly actionWidgetService: IActionWidgetService,
+		@ITelemetryService private readonly telemetryService: ITelemetryService
 	) {
 		super(context, action, options);
 		this.toDispose = [];
-		this.selectBox = new SelectBox([], -1, contextViewService, defaultSelectBoxStyles, { ariaLabel: nls.localize('debugLaunchConfigurations', 'Debug Launch Configurations'), useCustomDrawn: !hasNativeContextMenu(this.configurationService) });
-		this.selectBox.setFocusable(false);
-		this.toDispose.push(this.selectBox);
 
 		this.registerListeners();
 	}
@@ -78,7 +81,7 @@ export class StartDebugActionViewItem extends BaseActionViewItem {
 	override render(container: HTMLElement): void {
 		this.container = container;
 		container.classList.add('start-debug-action-item');
-		this.start = dom.append(container, $(ThemeIcon.asCSSSelector(debugStart)));
+		this.start = dom.append(container, dom.$(ThemeIcon.asCSSSelector(debugStart)));
 		const title = this.keybindingService.appendKeybinding(this.action.label, this.action.id);
 		this.toDispose.push(this.hoverService.setupManagedHover(getDefaultHoverDelegate('mouse'), this.start, title));
 		this.start.setAttribute('role', 'button');
@@ -110,35 +113,52 @@ export class StartDebugActionViewItem extends BaseActionViewItem {
 			const event = new StandardKeyboardEvent(e);
 			if (event.equals(KeyCode.RightArrow)) {
 				this.start.tabIndex = -1;
-				this.selectBox.focus();
+				this.dropdownLabel?.focus();
 				event.stopPropagation();
 			}
 		}));
-		this.toDispose.push(this.selectBox.onDidSelect(async e => {
-			const target = this.debugOptions[e.index];
-			const shouldBeSelected = target.handler ? await target.handler() : false;
-			if (shouldBeSelected) {
-				this.selected = e.index;
-			} else {
-				// Some select options should not remain selected https://github.com/microsoft/vscode/issues/31526
-				this.selectBox.select(this.selected);
-			}
+
+		this.configurationContainer = dom.append(container, dom.$('.configuration'));
+
+		this.dropdown = new ActionWidgetDropdown(this.configurationContainer, {
+			label: nls.localize('debugLaunchConfigurations', 'Debug Launch Configurations'),
+			labelRenderer: (el: HTMLElement) => {
+				this.dropdownLabel = el;
+				el.classList.add('start-debug-action-item-dropdown-label');
+				el.tabIndex = -1;
+				el.setAttribute('role', 'button');
+				el.setAttribute('aria-haspopup', 'true');
+				el.setAttribute('aria-expanded', 'false');
+				this.renderDropdownLabel();
+				return null;
+			},
+			actionProvider: { getActions: () => this.getDropdownActions() },
+			listOptions: {
+				showFilter: true,
+				filterPlaceholder: nls.localize('debugLaunchConfigurations.search', "Search configurations"),
+				focusFilterOnOpen: true,
+			},
+		}, this.actionWidgetService, this.keybindingService, this.telemetryService);
+		this.toDispose.push(this.dropdown);
+		this.toDispose.push(this.dropdown.onDidChangeVisibility(visible => {
+			this.dropdownLabel?.setAttribute('aria-expanded', String(visible));
 		}));
 
-		const selectBoxContainer = $('.configuration');
-		this.selectBox.render(dom.append(container, selectBoxContainer));
-		this.toDispose.push(dom.addDisposableListener(selectBoxContainer, dom.EventType.KEY_DOWN, (e: KeyboardEvent) => {
+		this.toDispose.push(dom.addDisposableListener(this.configurationContainer, dom.EventType.KEY_DOWN, (e: KeyboardEvent) => {
 			const event = new StandardKeyboardEvent(e);
 			if (event.equals(KeyCode.LeftArrow)) {
-				this.selectBox.setFocusable(false);
+				if (this.dropdownLabel) {
+					this.dropdownLabel.tabIndex = -1;
+				}
 				this.start.tabIndex = 0;
 				this.start.focus();
 				event.stopPropagation();
 				event.preventDefault();
 			}
 		}));
+
 		this.container.style.border = `1px solid ${asCssVariable(selectBorder)}`;
-		selectBoxContainer.style.borderLeft = `1px solid ${asCssVariable(selectBorder)}`;
+		this.configurationContainer.style.borderLeft = `1px solid ${asCssVariable(selectBorder)}`;
 		this.container.style.backgroundColor = asCssVariable(selectBackground);
 
 		const configManager = this.debugService.getConfigurationManager();
@@ -164,7 +184,10 @@ export class StartDebugActionViewItem extends BaseActionViewItem {
 
 	override focus(fromRight?: boolean): void {
 		if (fromRight) {
-			this.selectBox.focus();
+			if (this.dropdownLabel) {
+				this.dropdownLabel.tabIndex = 0;
+				this.dropdownLabel.focus();
+			}
 		} else {
 			this.start.tabIndex = 0;
 			this.start.focus();
@@ -173,7 +196,10 @@ export class StartDebugActionViewItem extends BaseActionViewItem {
 
 	override blur(): void {
 		this.start.tabIndex = -1;
-		this.selectBox.blur();
+		if (this.dropdownLabel) {
+			this.dropdownLabel.tabIndex = -1;
+			this.dropdownLabel.blur();
+		}
 		this.container.blur();
 	}
 
@@ -182,7 +208,9 @@ export class StartDebugActionViewItem extends BaseActionViewItem {
 			this.start.tabIndex = 0;
 		} else {
 			this.start.tabIndex = -1;
-			this.selectBox.setFocusable(false);
+			if (this.dropdownLabel) {
+				this.dropdownLabel.tabIndex = -1;
+			}
 		}
 	}
 
@@ -191,21 +219,63 @@ export class StartDebugActionViewItem extends BaseActionViewItem {
 		super.dispose();
 	}
 
+	private renderDropdownLabel(): void {
+		if (!this.dropdownLabel) {
+			return;
+		}
+		const currentLabel = this.debugOptions[this.selected]?.label
+			?? nls.localize('noConfigurations', "No Configurations");
+		const labelSpan = dom.$('span.start-debug-action-item-label', undefined, currentLabel);
+		const chevron = renderLabelWithIcons('$(chevron-down)');
+		dom.reset(this.dropdownLabel, labelSpan, ...chevron);
+		this.dropdownLabel.title = currentLabel;
+		this.dropdownLabel.setAttribute('aria-label', nls.localize('debugLaunchConfigurationsAriaLabel', "Debug Launch Configurations: {0}", currentLabel));
+	}
+
+	private getDropdownActions(): IActionWidgetDropdownAction[] {
+		const actions: IActionWidgetDropdownAction[] = [];
+		for (let i = 0; i < this.debugOptions.length; i++) {
+			const option = this.debugOptions[i];
+			const category = this.optionCategories[i];
+			actions.push({
+				id: `debug.config.${i}`,
+				label: option.label,
+				tooltip: option.label,
+				class: undefined,
+				enabled: true,
+				checked: i === this.selected,
+				category,
+				run: async () => {
+					// Selection state and label are reconciled by updateOptions(),
+					// triggered by manager.onDidSelectConfiguration.
+					await option.handler();
+				}
+			});
+		}
+		return actions;
+	}
+
+	private optionCategories: ({ label: string; order: number } | undefined)[] = [];
+
 	private updateOptions(): void {
 		this.selected = 0;
 		this.debugOptions = [];
+		this.optionCategories = [];
 		const manager = this.debugService.getConfigurationManager();
 		const inWorkspace = this.contextService.getWorkbenchState() === WorkbenchState.WORKSPACE;
 		let lastGroup: string | undefined;
-		const disabledIdxs: number[] = [];
-		const separatorIdxs: number[] = [];
+		let groupOrder = 0;
+
+		const pushOption = (option: { label: string; handler: (() => Promise<boolean>) }, category: { label: string; order: number } | undefined) => {
+			this.debugOptions.push(option);
+			this.optionCategories.push(category);
+		};
+
 		manager.getAllConfigurations().forEach(({ launch, name, presentation }) => {
 			if (lastGroup !== presentation?.group) {
 				lastGroup = presentation?.group;
 				if (this.debugOptions.length) {
-					this.debugOptions.push({ label: SeparatorSelectOption.text, handler: () => Promise.resolve(false) });
-					disabledIdxs.push(this.debugOptions.length - 1);
-					separatorIdxs.push(this.debugOptions.length - 1);
+					groupOrder++;
 				}
 			}
 			if (name === manager.selectedConfiguration.name && launch === manager.selectedConfiguration.launch) {
@@ -213,12 +283,12 @@ export class StartDebugActionViewItem extends BaseActionViewItem {
 			}
 
 			const label = inWorkspace ? `${name} (${launch.name})` : name;
-			this.debugOptions.push({
+			pushOption({
 				label, handler: async () => {
 					await manager.selectConfiguration(launch, name);
 					return true;
 				}
-			});
+			}, { label: `configurations-${groupOrder}`, order: groupOrder });
 		});
 
 		// Only take 3 elements from the recent dynamic configurations to not clutter the dropdown
@@ -226,26 +296,21 @@ export class StartDebugActionViewItem extends BaseActionViewItem {
 			if (type === manager.selectedConfiguration.type && manager.selectedConfiguration.name === name) {
 				this.selected = this.debugOptions.length;
 			}
-			this.debugOptions.push({
+			pushOption({
 				label: name,
 				handler: async () => {
 					await manager.selectConfiguration(undefined, name, undefined, { type });
 					return true;
 				}
-			});
+			}, { label: 'recent-dynamic', order: 100 });
 		});
 
 		if (this.debugOptions.length === 0) {
-			this.debugOptions.push({ label: nls.localize('noConfigurations', "No Configurations"), handler: async () => false });
+			pushOption({ label: nls.localize('noConfigurations', "No Configurations"), handler: async () => false }, undefined);
 		}
 
-		this.debugOptions.push({ label: SeparatorSelectOption.text, handler: () => Promise.resolve(false) });
-		disabledIdxs.push(this.debugOptions.length - 1);
-		separatorIdxs.push(this.debugOptions.length - 1);
-
 		this.providers.forEach(p => {
-
-			this.debugOptions.push({
+			pushOption({
 				label: `${p.label}...`,
 				handler: async () => {
 					const picked = await p.pick();
@@ -255,24 +320,20 @@ export class StartDebugActionViewItem extends BaseActionViewItem {
 					}
 					return false;
 				}
-			});
+			}, { label: 'actions', order: 200 });
 		});
 
 		manager.getLaunches().filter(l => !l.hidden).forEach(l => {
 			const label = inWorkspace ? nls.localize("addConfigTo", "Add Config ({0})...", l.name) : nls.localize('addConfiguration', "Add Configuration...");
-			this.debugOptions.push({
+			pushOption({
 				label, handler: async () => {
 					await this.commandService.executeCommand(ADD_CONFIGURATION_ID, l.uri.toString());
 					return false;
 				}
-			});
+			}, { label: 'actions', order: 200 });
 		});
 
-		this.selectBox.setOptions(this.debugOptions.map((data, index): ISelectOptionItem => ({
-			text: data.label,
-			isDisabled: disabledIdxs.indexOf(index) !== -1,
-			isSeparator: separatorIdxs.indexOf(index) !== -1,
-		})), this.selected);
+		this.renderDropdownLabel();
 	}
 
 	private _setAriaLabel(title: string): void {

--- a/src/vs/workbench/contrib/debug/browser/media/debugViewlet.css
+++ b/src/vs/workbench/contrib/debug/browser/media/debugViewlet.css
@@ -73,7 +73,7 @@
 	min-width: 0;
 	flex: 1;
 	border-radius: 0 var(--vscode-cornerRadius-small) var(--vscode-cornerRadius-small) 0;
-	color: var(--vscode-foreground);
+	color: var(--vscode-dropdown-foreground);
 	outline-offset: -1px;
 }
 

--- a/src/vs/workbench/contrib/debug/browser/media/debugViewlet.css
+++ b/src/vs/workbench/contrib/debug/browser/media/debugViewlet.css
@@ -50,28 +50,52 @@
 	border-radius: var(--vscode-cornerRadius-small) 0 0 var(--vscode-cornerRadius-small);
 }
 
-.monaco-workbench .monaco-action-bar .start-debug-action-item .configuration .monaco-select-box {
-	border: none;
-	margin-top: 0px;
-	cursor: pointer;
-	line-height: inherit;
-	padding-top: 0;
-	padding-bottom: 0;
-	border-radius: 0 var(--vscode-cornerRadius-small) var(--vscode-cornerRadius-small) 0;
-
-	/* The debug view title is crowded, let this one get narrower than others */
+.monaco-workbench .monaco-action-bar .start-debug-action-item .configuration {
+	display: flex;
+	align-items: stretch;
 	min-width: 90px;
+	overflow: hidden;
+}
 
+.monaco-workbench .monaco-action-bar .start-debug-action-item .configuration .monaco-dropdown {
+	display: flex;
+	align-items: stretch;
+	flex: 1;
+	min-width: 0;
+}
+
+.monaco-workbench .monaco-action-bar .start-debug-action-item .configuration .monaco-dropdown > .dropdown-label {
+	display: flex;
+	align-items: center;
+	cursor: pointer;
+	padding: 0 4px 0 6px;
+	gap: 4px;
+	min-width: 0;
+	flex: 1;
+	border-radius: 0 var(--vscode-cornerRadius-small) var(--vscode-cornerRadius-small) 0;
+	color: var(--vscode-foreground);
+	outline-offset: -1px;
+}
+
+.monaco-workbench .monaco-action-bar .start-debug-action-item .configuration .monaco-dropdown > .dropdown-label:focus {
+	outline: 1px solid var(--vscode-focusBorder);
+}
+
+.monaco-workbench .monaco-action-bar .start-debug-action-item .configuration .monaco-dropdown > .dropdown-label .start-debug-action-item-label {
+	overflow: hidden;
 	white-space: nowrap;
 	text-overflow: ellipsis;
+	flex: 1;
+	min-width: 0;
 }
 
-
-.monaco-workbench.safari .monaco-action-bar .start-debug-action-item .configuration .monaco-select-box {
-	margin-bottom: 0px;
+.monaco-workbench .monaco-action-bar .start-debug-action-item .configuration .monaco-dropdown > .dropdown-label .codicon-chevron-down {
+	font-size: 10px;
+	opacity: 0.75;
+	flex-shrink: 0;
 }
 
-.monaco-workbench .monaco-action-bar .start-debug-action-item .configuration.disabled .monaco-select-box {
+.monaco-workbench .monaco-action-bar .start-debug-action-item .configuration.disabled .monaco-dropdown > .dropdown-label {
 	opacity: 0.7;
 	font-style: italic;
 	cursor: initial;


### PR DESCRIPTION
Replace the native `SelectBox`-based launch configuration picker in the Run and Debug view title with the same `ActionWidgetDropdown` that powers the chat **Pick Model** picker.

### Changes
- `StartDebugActionViewItem` now renders an `ActionWidgetDropdown` instead of a `SelectBox`. Configurations are surfaced as `IActionWidgetDropdownAction`s, grouped by presentation group with auto-inserted separators, followed by recent dynamic configs and dynamic providers / add-configuration actions.
- The trigger keeps the combo-button look glued to the **Start Debugging** play icon: same border, same `selectBackground`, just a new chevron-down indicator.
- The dropdown opens with a focused **Search configurations** filter input (`focusFilterOnOpen: true`), matching the model picker's UX.
- Keyboard navigation between the start button and the dropdown trigger is preserved (Left/Right arrows).
- Accessibility: the trigger has a stable `aria-label` of `"Debug Launch Configurations: <current>"` so screen readers announce both the control's purpose and current selection.
- CSS in `debugViewlet.css` is updated to style the new `.monaco-dropdown` trigger inside `.configuration` (label, chevron, focus outline, disabled state).

### Out of scope
- The session focus dropdown (`FocusSessionActionViewItem`) still uses `SelectActionViewItem` — separate widget, not part of this change.

### Review
Reviewed by Opus, Sonnet, and GPT-5.4 via an internal code-review pass; the only consensus issue (missing `aria-label` on the trigger) was fixed before commit, along with a small stale-index cleanup in the action `run` callback that `updateOptions()` already handles.