### PR TITLE
Fix stale background compaction across model switches and /compact

### DIFF
--- a/extensions/copilot/src/extension/intents/node/agentIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/agentIntent.ts
@@ -49,7 +49,7 @@ import { IDefaultIntentRequestHandlerOptions } from '../../prompt/node/defaultIn
 import { IDocumentContext } from '../../prompt/node/documentContext';
 import { IBuildPromptResult, IIntent, IIntentInvocation } from '../../prompt/node/intents';
 import { AgentPrompt, AgentPromptProps } from '../../prompts/node/agent/agentPrompt';
-import { BackgroundSummarizationState, BackgroundSummarizer, IBackgroundSummarizationResult, shouldKickOffBackgroundSummarization } from '../../prompts/node/agent/backgroundSummarizer';
+import { BackgroundSummarizationState, BackgroundSummarizationThresholds, BackgroundSummarizer, IBackgroundSummarizationResult, shouldKickOffBackgroundSummarization } from '../../prompts/node/agent/backgroundSummarizer';
 import { BackgroundTodoDecision, BackgroundTodoProcessor, IBackgroundTodoExecutionContext } from '../../prompts/node/agent/backgroundTodoProcessor';
 import { AgentPromptCustomizations, PromptRegistry } from '../../prompts/node/agent/promptRegistry';
 import { extractSummary, SummarizationUserMessage, SummarizedConversationHistory, SummarizedConversationHistoryMetadata, SummarizedConversationHistoryPropsBuilder, appendTranscriptHintToSummary, computeSummarizationRoundCounts } from '../../prompts/node/agent/summarizedConversationHistory';
@@ -253,13 +253,35 @@ export class AgentIntent extends EditCodeIntent {
 		});
 	}
 
-	getOrCreateBackgroundSummarizer(sessionId: string, modelMaxPromptTokens: number): BackgroundSummarizer {
+	getOrCreateBackgroundSummarizer(sessionId: string, modelMaxPromptTokens: number, endpointId: string): BackgroundSummarizer {
 		let summarizer = this._backgroundSummarizers.get(sessionId);
+		if (summarizer && summarizer.endpointId !== endpointId) {
+			// Endpoint switched mid-session. A summary kicked off against the
+			// previous endpoint's prefix would be applied unconditionally on the
+			// next pre-render, producing a surprising "Compacted conversation"
+			// notice on the new endpoint — cancel and start fresh.
+			summarizer.cancel();
+			this._backgroundSummarizers.delete(sessionId);
+			summarizer = undefined;
+		}
 		if (!summarizer) {
-			summarizer = new BackgroundSummarizer(modelMaxPromptTokens);
+			summarizer = new BackgroundSummarizer(modelMaxPromptTokens, endpointId);
 			this._backgroundSummarizers.set(sessionId, summarizer);
 		}
 		return summarizer;
+	}
+
+	/**
+	 * Cancel and forget the background summarizer for this session. Used by
+	 * `/compact` so a pending background result doesn't immediately overwrite
+	 * the user's explicit foreground compaction on the next turn.
+	 */
+	cancelBackgroundSummarizer(sessionId: string): void {
+		const summarizer = this._backgroundSummarizers.get(sessionId);
+		if (summarizer) {
+			summarizer.cancel();
+			this._backgroundSummarizers.delete(sessionId);
+		}
 	}
 
 	getOrCreateBackgroundTodoProcessor(sessionId: string): BackgroundTodoProcessor {
@@ -346,6 +368,11 @@ export class AgentIntent extends EditCodeIntent {
 			stream.markdown(l10n.t('Compaction is already managed by context management for this session.'));
 			return {};
 		}
+
+		// Foreground compaction is now authoritative for this session. Cancel any
+		// pending background summarizer so its (potentially stale) result doesn't
+		// overwrite this `/compact` on the next render.
+		this.cancelBackgroundSummarizer(conversation.sessionId);
 
 		const availableTools = await this.instantiationService.invokeFunction(getAgentTools, request, endpoint);
 		const promptContext: IBuildPromptContext = {
@@ -593,20 +620,32 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 		// we don't immediately re-trigger background compaction in the post-render check.
 		let didSummarizeThisIteration = false;
 
-		// If a previous background pass completed, apply its summary now.
+		// If a previous background pass completed, apply its summary now — but
+		// only when the current context ratio still warrants it. After a model
+		// switch to a larger window (or an increased context-size override) the
+		// ratio can drop below `applyMinRatio`; applying a stale summary in that
+		// case surfaces a confusing "Compacted conversation" notice with
+		// plenty of headroom remaining.
 		if (summarizationEnabled && backgroundSummarizer?.state === BackgroundSummarizationState.Completed) {
-			const bgResult = backgroundSummarizer.consumeAndReset();
-			if (bgResult) {
-				this.logService.debug(`[ConversationHistorySummarizer] applying completed background summary (roundId=${bgResult.toolCallRoundId})`);
-				progress.report(new ChatResponseProgressPart2(l10n.t('Compacted conversation'), async () => l10n.t('Compacted conversation')));
-				this._applySummaryToRounds(bgResult, promptContext);
-				this._persistSummaryOnTurn(bgResult, promptContext, this._lastRenderTokenCount);
-				this._sendBackgroundCompactionTelemetry('preRender', 'applied', contextRatio, promptContext);
-				didSummarizeThisIteration = true;
+			if (contextRatio >= BackgroundSummarizationThresholds.applyMinRatio) {
+				const bgResult = backgroundSummarizer.consumeAndReset();
+				if (bgResult) {
+					this.logService.debug(`[ConversationHistorySummarizer] applying completed background summary (roundId=${bgResult.toolCallRoundId})`);
+					progress.report(new ChatResponseProgressPart2(l10n.t('Compacted conversation'), async () => l10n.t('Compacted conversation')));
+					this._applySummaryToRounds(bgResult, promptContext);
+					this._persistSummaryOnTurn(bgResult, promptContext, this._lastRenderTokenCount);
+					this._sendBackgroundCompactionTelemetry('preRender', 'applied', contextRatio, promptContext);
+					didSummarizeThisIteration = true;
+				} else {
+					this.logService.warn(`[ConversationHistorySummarizer] background compaction state was Completed but consumeAndReset returned no result`);
+					this._sendBackgroundCompactionTelemetry('preRender', 'noResult', contextRatio, promptContext);
+					this._recordBackgroundCompactionFailure(promptContext, 'preRender');
+				}
 			} else {
-				this.logService.warn(`[ConversationHistorySummarizer] background compaction state was Completed but consumeAndReset returned no result`);
-				this._sendBackgroundCompactionTelemetry('preRender', 'noResult', contextRatio, promptContext);
-				this._recordBackgroundCompactionFailure(promptContext, 'preRender');
+				// Drop the stale summary so a fresh kick-off can replace it later.
+				backgroundSummarizer.consumeAndReset();
+				this.logService.debug(`[ConversationHistorySummarizer] discarding completed background summary; contextRatio ${(contextRatio * 100).toFixed(0)}% below applyMinRatio ${(BackgroundSummarizationThresholds.applyMinRatio * 100).toFixed(0)}% (likely model switch or context-size override)`);
+				this._sendBackgroundCompactionTelemetry('preRender', 'discardedBelowApplyMinRatio', contextRatio, promptContext);
 			}
 		}
 
@@ -1111,7 +1150,12 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 		if (!sessionId || !(this.intent instanceof AgentIntent)) {
 			return undefined;
 		}
-		return this.intent.getOrCreateBackgroundSummarizer(sessionId, this.endpoint.modelMaxPromptTokens);
+		// Compose a stable endpoint identity. `model` alone is not unique across
+		// providers (the same model id can come from different providers / api
+		// types), so include those to avoid reusing a summary built against a
+		// different endpoint's prefix.
+		const endpointId = `${this.endpoint.modelProvider}:${this.endpoint.model}${this.endpoint.apiType ? `:${this.endpoint.apiType}` : ''}`;
+		return this.intent.getOrCreateBackgroundSummarizer(sessionId, this.endpoint.modelMaxPromptTokens, endpointId);
 	}
 
 	/**
@@ -1209,7 +1253,7 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 				"owner": "bhavyau",
 				"comment": "Tracks background compaction orchestration decisions and outcomes in the agent loop.",
 				"trigger": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The code path that triggered background compaction consumption." },
-				"outcome": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Outcome of the background compaction consumption. One of: 'applied' (result applied and re-render succeeded), 'appliedButReRenderFailed' (result applied but the subsequent re-render still exceeded budget and required a fallback), 'noResult' (no usable result was produced)." },
+				"outcome": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Outcome of the background compaction consumption. One of: 'applied' (result applied and re-render succeeded), 'appliedButReRenderFailed' (result applied but the subsequent re-render still exceeded budget and required a fallback), 'noResult' (no usable result was produced), 'discardedBelowApplyMinRatio' (a completed background result was thrown away because the current context ratio dropped below the apply threshold \u2014 typically after a model switch to a larger window)." },
 				"conversationId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Id for the current chat conversation." },
 				"chatRequestId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The chat request ID that this background compaction was consumed during." },
 				"model": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The model ID used." },

--- a/extensions/copilot/src/extension/intents/node/test/agentSummarizeCommand.spec.ts
+++ b/extensions/copilot/src/extension/intents/node/test/agentSummarizeCommand.spec.ts
@@ -66,8 +66,8 @@ describe('AgentIntent /summarize command', () => {
 		onCancellationRequested: Event.None,
 	};
 
-	async function runSummarize(conversation: Conversation) {
-		const intent = instantiationService.createInstance(AgentIntent);
+	async function runSummarize(conversation: Conversation, intent?: AgentIntent) {
+		intent ??= instantiationService.createInstance(AgentIntent);
 		const request = new TestChatRequest('');
 		request.command = 'compact';
 		const stream = new MockChatResponseStream();
@@ -94,7 +94,7 @@ describe('AgentIntent /summarize command', () => {
 			() => false
 		);
 
-		return { result, stream };
+		return { result, stream, intent };
 	}
 
 	function createEditFileToolCall(idx: number): IToolCall {
@@ -174,5 +174,48 @@ describe('AgentIntent /summarize command', () => {
 
 		// Should have output with "Nothing to compact" message
 		expect(stream.output.some(msg => msg.toLowerCase().includes('nothing to compact'))).toBe(true);
+	});
+
+	test('cancels any pending background summarizer for the session', async () => {
+		const intent = instantiationService.createInstance(AgentIntent);
+
+		// Prime a background summarizer for this session before /compact runs.
+		// Its identity is what we want to see disappear from the map afterward.
+		const before = intent.getOrCreateBackgroundSummarizer('sessionId', 100_000, 'test-model');
+
+		const conversation = createConversationWithHistory();
+		await runSummarize(conversation, intent);
+
+		// After /compact, a follow-up get must create a fresh instance — the
+		// pre-existing summarizer was cancelled and removed so its (potentially
+		// stale) result can't overwrite the user-initiated compaction on the
+		// next render.
+		const after = intent.getOrCreateBackgroundSummarizer('sessionId', 100_000, 'test-model');
+		expect(after).not.toBe(before);
+	});
+
+	test('endpoint switch on the same session cancels the previous summarizer', () => {
+		const intent = instantiationService.createInstance(AgentIntent);
+
+		const onModelA = intent.getOrCreateBackgroundSummarizer('sessionId', 100_000, 'model-a');
+			expect(onModelA.endpointId).toBe('model-a');
+		// Switching the endpoint identity must hand back a different instance
+		// (the previous one's pending/completed state is for the old prefix
+		// and would surprise the user on the new model).
+		const onModelB = intent.getOrCreateBackgroundSummarizer('sessionId', 200_000, 'model-b');
+		expect(onModelB).not.toBe(onModelA);
+			expect(onModelB.endpointId).toBe('model-b');
+		// Re-asking for model A must NOT return the old instance — it was
+		// dropped from the map when we switched away.
+		const onModelAAgain = intent.getOrCreateBackgroundSummarizer('sessionId', 100_000, 'model-a');
+		expect(onModelAAgain).not.toBe(onModelA);
+	});
+
+	test('same endpoint returns the same summarizer instance', () => {
+		const intent = instantiationService.createInstance(AgentIntent);
+
+		const first = intent.getOrCreateBackgroundSummarizer('sessionId', 100_000, 'model-a');
+		const second = intent.getOrCreateBackgroundSummarizer('sessionId', 100_000, 'model-a');
+		expect(second).toBe(first);
 	});
 });

--- a/extensions/copilot/src/extension/prompts/node/agent/backgroundSummarizer.ts
+++ b/extensions/copilot/src/extension/prompts/node/agent/backgroundSummarizer.ts
@@ -55,6 +55,15 @@ export const BackgroundSummarizationThresholds = {
 	 * without relying on foreground compaction.
 	 */
 	emergency: 0.90,
+	/**
+	 * Minimum context ratio for applying a previously-completed background
+	 * summary on the next render. Below this we discard the stale summary —
+	 * typically because the user switched to a model with a larger context
+	 * window (or increased the configured context size), and applying it would
+	 * surface a surprising "Compacted conversation" notice with plenty of
+	 * headroom remaining.
+	 */
+	applyMinRatio: 0.65,
 } as const;
 
 /**
@@ -104,13 +113,23 @@ export class BackgroundSummarizer {
 
 	readonly modelMaxPromptTokens: number;
 
+	/**
+	 * Identity of the endpoint this summarizer was created for (provider +
+	 * model + apiType, composed by the caller). Used by
+	 * {@link AgentIntent.getOrCreateBackgroundSummarizer} to detect a
+	 * mid-session endpoint switch — a summary computed against one endpoint's
+	 * prefix is cancelled rather than applied to a different endpoint.
+	 */
+	readonly endpointId: string | undefined;
+
 	get state(): BackgroundSummarizationState { return this._state; }
 	get error(): unknown { return this._error; }
 
 	get token() { return this._cts?.token; }
 
-	constructor(modelMaxPromptTokens: number) {
+	constructor(modelMaxPromptTokens: number, endpointId?: string) {
 		this.modelMaxPromptTokens = modelMaxPromptTokens;
+		this.endpointId = endpointId;
 	}
 
 	start(work: (token: CancellationToken) => Promise<IBackgroundSummarizationResult>, parentToken?: CancellationToken): void {


### PR DESCRIPTION
Fixes #316116.

`AgentIntent._backgroundSummarizers` is keyed only by `sessionId`, so a completed background summary kicked off against one model's prefix was applied unconditionally on the next render — even after the user switched models (typically to a bigger window) or ran `/compact`. Result: surprising "Compacted conversation" notice on a turn with plenty of headroom.

The floor logic from #315444 composes correctly across switches; the bug is in **state lifecycle**.

### Fix
1. `BackgroundSummarizer` now records the `endpointModel` it was built for.
2. `AgentIntent.getOrCreateBackgroundSummarizer` cancels & recreates the summarizer when the endpoint changes mid-session.
3. `handleSummarizeCommand` (`/compact`) cancels any pending background summarizer once foreground compaction starts.
4. Pre-render apply now gates on `contextRatio >= 0.65` as defense-in-depth (covers context-size overrides). Below threshold the stale result is consumed-and-discarded.
