### PR TITLE
Fix bracket snippet deleting following char (#235515)

### DIFF
--- a/src/vs/workbench/contrib/snippets/browser/snippetCompletionProvider.ts
+++ b/src/vs/workbench/contrib/snippets/browser/snippetCompletionProvider.ts
@@ -141,8 +141,9 @@ export class SnippetCompletionProvider implements CompletionItemProvider {
 
 			let endColumn = endsWithPrefixRest === 0 ? position.column + prefixRestLen : position.column;
 
-			// First check if there is anything to the right of the cursor
-			if (columnOffset < lineContentLow.length) {
+			// First check if there is anything to the right of the cursor and that the replace range
+			// hasn't already absorbed the closing character via prefix matching (#235515)
+			if (columnOffset < lineContentLow.length && endColumn === position.column) {
 				const autoClosingPairs = languageConfig.getAutoClosingPairs();
 				const standardAutoClosingPairConditionals = autoClosingPairs.autoClosingPairsCloseSingleChar.get(lineContentLow[columnOffset]);
 				// If the character to the right of the cursor is a closing character of an autoclosing pair

--- a/src/vs/workbench/contrib/snippets/test/browser/snippetsService.test.ts
+++ b/src/vs/workbench/contrib/snippets/test/browser/snippetsService.test.ts
@@ -803,6 +803,43 @@ suite('SnippetsService', function () {
 		model.dispose();
 	});
 
+	test('Brackets Snippet deleting chars #235515', async function () {
+		const languageConfigurationService = disposables.add(new TestLanguageConfigurationService());
+		disposables.add(languageConfigurationService.register('fooLang', {
+			brackets: [
+				['{', '}'],
+				['[', ']'],
+				['(', ')'],
+			]
+		}));
+
+		snippetService = new SimpleSnippetService([new Snippet(
+			false,
+			['fooLang'],
+			'Brackets',
+			'()',
+			'',
+			'()',
+			'',
+			SnippetSource.User,
+			generateUuid()
+		)]);
+
+		const provider = new SnippetCompletionProvider(languageService, snippetService, languageConfigurationService);
+
+		// Cursor is between `(` and `)` with extra char after closing bracket.
+		// The replace range must cover `()` only — not also eat the `!`.
+		const model = instantiateTextModel(instantiationService, '()!!', 'fooLang');
+		const result = await provider.provideCompletionItems(model, new Position(1, 2), defaultCompletionContext)!;
+
+		assert.strictEqual(result.suggestions.length, 1);
+		const [first] = result.suggestions;
+		assert.strictEqual((first.range as CompletionItemRanges).insert.endColumn, 2);
+		assert.strictEqual((first.range as CompletionItemRanges).replace.endColumn, 3);
+
+		model.dispose();
+	});
+
 	test('Leading whitespace in snippet prefix #123860', async function () {
 
 		snippetService = new SimpleSnippetService([new Snippet(


### PR DESCRIPTION
Fixes #235515

## Problem

When inserting a snippet whose `prefix` exactly matches an auto-closing pair (e.g. `()`, `[]`) and the document already contains that pair followed by another character, accepting the snippet deleted the next character.

Repro from the issue:
1. Set `editor.suggest.insertMode` to `replace`
2. Add a global snippet:
   ```json
   {
     "Brackets": {
       "scope": "plaintext",
       "prefix": "()",
       "body": "()"
     }
   }
   ```
3. In a `plaintext` file with `()!!`, place the cursor between `(` and `)` and invoke the `Brackets` snippet — the `!` after `)` is consumed.

## Cause

In `SnippetCompletionProvider.provideCompletionItems`, the "eat the auto-closed character" branch unconditionally did `endColumn++`. But when the snippet prefix already matches the text past the cursor (`endsWithPrefixRest === 0`), `endColumn` has already been extended to cover the closing bracket. Incrementing again over-eats one character outside the closing bracket.

## Fix

Only increment `endColumn` when the replace range hasn't already absorbed the closing character (`endColumn === position.column`). This preserves the original intent (eating the auto-closed `)` after typing `(`) while not over-eating when the closing bracket is already part of the matched prefix.

## Tests

- Added `Brackets Snippet deleting chars #235515` regression test.
- Existing `Snippet will replace auto-closing pair if specified in prefix` test still passes (covers the intended `endColumn++` path).