### PR TITLE
agentHost: support running tasks in remote workspaces

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
@@ -21,6 +21,9 @@ import './nullChatTipService.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { ISessionsTasksService, SessionsTasksService } from './sessionsTasksService.js';
+import { ISessionTaskRunnerRegistry, SessionTaskRunnerRegistry } from './sessionTaskRunner.js';
+import { RegisterDefaultSessionTaskRunnersContribution } from './registerDefaultSessionTaskRunners.js';
+import { WorktreeCreatedTaskDispatcher } from './worktreeCreatedTaskDispatcher.js';
 import { AgenticPromptsService } from './promptsService.js';
 import { IPromptsService } from '../../../../workbench/contrib/chat/common/promptSyntax/service/promptsService.js';
 import { IAICustomizationWorkspaceService } from '../../../../workbench/contrib/chat/common/aiCustomizationWorkspaceService.js';
@@ -146,9 +149,12 @@ registerAction2(BranchChatSessionAction);
 registerWorkbenchContribution2(RegisterChatViewContainerContribution.ID, RegisterChatViewContainerContribution, WorkbenchPhase.BlockStartup);
 registerWorkbenchContribution2(RunScriptContribution.ID, RunScriptContribution, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(SessionsOpenerParticipantContribution.ID, SessionsOpenerParticipantContribution, WorkbenchPhase.BlockStartup);
+registerWorkbenchContribution2(RegisterDefaultSessionTaskRunnersContribution.ID, RegisterDefaultSessionTaskRunnersContribution, WorkbenchPhase.BlockStartup);
+registerWorkbenchContribution2(WorktreeCreatedTaskDispatcher.ID, WorktreeCreatedTaskDispatcher, WorkbenchPhase.AfterRestored);
 
 // register services
 registerSingleton(IPromptsService, AgenticPromptsService, InstantiationType.Delayed);
+registerSingleton(ISessionTaskRunnerRegistry, SessionTaskRunnerRegistry, InstantiationType.Delayed);
 registerSingleton(ISessionsTasksService, SessionsTasksService, InstantiationType.Delayed);
 registerSingleton(IAICustomizationWorkspaceService, SessionsAICustomizationWorkspaceService, InstantiationType.Delayed);
 registerSingleton(ICustomizationHarnessService, SessionsCustomizationHarnessService, InstantiationType.Delayed);

--- a/src/vs/sessions/contrib/chat/browser/registerDefaultSessionTaskRunners.ts
+++ b/src/vs/sessions/contrib/chat/browser/registerDefaultSessionTaskRunners.ts
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { IWorkbenchContribution } from '../../../../workbench/common/contributions.js';
+import { ISessionTaskRunnerRegistry } from './sessionTaskRunner.js';
+import { WorkbenchSessionTaskRunner } from './workbenchSessionTaskRunner.js';
+
+/**
+ * Registers the default {@link WorkbenchSessionTaskRunner} with the
+ * {@link ISessionTaskRunnerRegistry}. The workbench runner is the lowest
+ * priority fallback; specialized runners (e.g. for agent hosts) register
+ * themselves separately from their own contributions.
+ */
+export class RegisterDefaultSessionTaskRunnersContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'workbench.contrib.sessions.registerDefaultTaskRunners';
+
+	constructor(
+		@IInstantiationService instantiationService: IInstantiationService,
+		@ISessionTaskRunnerRegistry registry: ISessionTaskRunnerRegistry,
+	) {
+		super();
+		const runner = instantiationService.createInstance(WorkbenchSessionTaskRunner);
+		this._register(registry.register(runner));
+	}
+}

--- a/src/vs/sessions/contrib/chat/browser/sessionTaskRunner.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionTaskRunner.ts
@@ -1,0 +1,91 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+import { ISession } from '../../../services/sessions/common/session.js';
+import { ITaskEntry } from './sessionsTasksService.js';
+
+/**
+ * Pluggable runner that knows how to execute a session task in the runtime
+ * associated with a given session.
+ *
+ * Implementations are registered via {@link ISessionTaskRunnerRegistry.register}
+ * and consulted by {@link ISessionsTasksService.runTask}, which dispatches to
+ * the highest-priority runner whose {@link canRun} returns `true`.
+ */
+export interface ISessionTaskRunner {
+	/** Stable identifier for the runner (used for logging and diagnostics). */
+	readonly id: string;
+	/**
+	 * Priority; higher values are preferred when multiple runners claim a
+	 * session. The built-in workbench runner uses priority `0`; agent-host
+	 * runners typically use a higher value (e.g. `100`).
+	 */
+	readonly priority: number;
+	/** Returns `true` if this runner can execute tasks for the given session. */
+	canRun(session: ISession): boolean;
+	/**
+	 * Executes the given task in the session's runtime. The returned promise
+	 * resolves once the task has been launched (not when it has finished).
+	 */
+	runTask(task: ITaskEntry, session: ISession): Promise<void>;
+}
+
+/**
+ * Registry of {@link ISessionTaskRunner} implementations. Consumed by
+ * {@link ISessionsTasksService.runTask} to dispatch task execution to the
+ * runtime that owns a session.
+ */
+export interface ISessionTaskRunnerRegistry {
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * Registers a runner with the registry. The returned disposable removes
+	 * the runner. If multiple runners claim the same session, the one with
+	 * the higher {@link ISessionTaskRunner.priority} wins; ties are broken
+	 * in registration order (later registrations win).
+	 */
+	register(runner: ISessionTaskRunner): IDisposable;
+
+	/**
+	 * Returns the highest-priority runner that claims the given session, or
+	 * `undefined` if no registered runner can run tasks for it.
+	 */
+	getRunner(session: ISession): ISessionTaskRunner | undefined;
+}
+
+export const ISessionTaskRunnerRegistry = createDecorator<ISessionTaskRunnerRegistry>('sessionTaskRunnerRegistry');
+
+export class SessionTaskRunnerRegistry implements ISessionTaskRunnerRegistry {
+
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _runners: ISessionTaskRunner[] = [];
+
+	register(runner: ISessionTaskRunner): IDisposable {
+		this._runners.push(runner);
+		return toDisposable(() => {
+			const idx = this._runners.indexOf(runner);
+			if (idx >= 0) {
+				this._runners.splice(idx, 1);
+			}
+		});
+	}
+
+	getRunner(session: ISession): ISessionTaskRunner | undefined {
+		let best: ISessionTaskRunner | undefined;
+		// Iterate forward so later registrations beat earlier ones at equal priority.
+		for (const runner of this._runners) {
+			if (!runner.canRun(session)) {
+				continue;
+			}
+			if (!best || runner.priority >= best.priority) {
+				best = runner;
+			}
+		}
+		return best;
+	}
+}

--- a/src/vs/sessions/contrib/chat/browser/sessionsTasksService.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionsTasksService.ts
@@ -10,14 +10,12 @@ import { parse } from '../../../../base/common/jsonc.js';
 import { URI } from '../../../../base/common/uri.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
-import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
 import { ISession } from '../../../services/sessions/common/session.js';
 import { IJSONEditingService } from '../../../../workbench/services/configuration/common/jsonEditing.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { IPreferencesService } from '../../../../workbench/services/preferences/common/preferences.js';
 import { CommandString } from '../../../../workbench/contrib/tasks/common/taskConfiguration.js';
-import { TaskRunSource } from '../../../../workbench/contrib/tasks/common/tasks.js';
-import { ITaskService } from '../../../../workbench/contrib/tasks/common/taskService.js';
+import { ISessionTaskRunnerRegistry } from './sessionTaskRunner.js';
 
 export type TaskStorageTarget = 'user' | 'workspace';
 type TaskRunOnOption = 'default' | 'folderOpen' | 'worktreeCreated';
@@ -41,6 +39,8 @@ export interface ITaskEntry {
 	readonly windows?: { command?: string; args?: CommandString[] };
 	readonly osx?: { command?: string; args?: CommandString[] };
 	readonly linux?: { command?: string; args?: CommandString[] };
+	readonly dependsOn?: string | readonly string[];
+	readonly dependsOrder?: 'sequence' | 'parallel';
 	readonly [key: string]: unknown;
 }
 
@@ -69,8 +69,33 @@ export interface ISessionsTasksService {
 	 * Observable list of tasks with `inAgents: true`, automatically
 	 * updated when the tasks.json file changes. Each entry includes the
 	 * storage target the task was loaded from.
+	 *
+	 * **Note:** This observable is shared across all sessions — repeated
+	 * calls with different sessions overwrite it with the most recently
+	 * requested session's tasks. It is intended for a single follower
+	 * (e.g. the toolbar tracking the active session). Consumers that need
+	 * a one-time snapshot for a specific session should use
+	 * {@link getSessionTasksOnce} instead.
 	 */
 	getSessionTasks(session: ISession): IObservable<readonly ISessionTaskWithTarget[]>;
+
+	/**
+	 * Returns a one-shot snapshot of the session tasks (with `inAgents: true`)
+	 * for the given session, reading from both workspace and user `tasks.json`.
+	 *
+	 * Unlike {@link getSessionTasks}, this method does NOT touch the shared
+	 * `_sessionTasks` observable, so it is safe to call concurrently for
+	 * multiple sessions.
+	 */
+	getSessionTasksOnce(session: ISession): Promise<readonly ISessionTaskWithTarget[]>;
+
+	/**
+	 * Returns a one-shot snapshot of **all** tasks (with or without
+	 * `inAgents`) declared for the given session, reading from both workspace
+	 * and user `tasks.json`. Used by the agent-host runner to look up
+	 * dependency tasks referenced via `dependsOn`.
+	 */
+	getAllTasks(session: ISession): Promise<readonly ISessionTaskWithTarget[]>;
 
 	/**
 	 * Returns tasks that do NOT have `inAgents: true` — used as
@@ -164,8 +189,7 @@ export class SessionsTasksService extends Disposable implements ISessionsTasksSe
 		@IFileService private readonly _fileService: IFileService,
 		@IJSONEditingService private readonly _jsonEditingService: IJSONEditingService,
 		@IPreferencesService private readonly _preferencesService: IPreferencesService,
-		@ITaskService private readonly _taskService: ITaskService,
-		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
+		@ISessionTaskRunnerRegistry private readonly _taskRunnerRegistry: ISessionTaskRunnerRegistry,
 		@IStorageService private readonly _storageService: IStorageService,
 	) {
 		super();
@@ -185,29 +209,38 @@ export class SessionsTasksService extends Disposable implements ISessionsTasksSe
 		return this._sessionTasks;
 	}
 
+	async getSessionTasksOnce(session: ISession): Promise<readonly ISessionTaskWithTarget[]> {
+		return this._readTasksFromBothTargets(session, t => !!t.inAgents);
+	}
+
+	async getAllTasks(session: ISession): Promise<readonly ISessionTaskWithTarget[]> {
+		return this._readTasksFromBothTargets(session, () => true);
+	}
+
 	async getNonSessionTasks(session: ISession): Promise<readonly INonSessionTaskEntry[]> {
-		const result: INonSessionTaskEntry[] = [];
+		return this._readTasksFromBothTargets(session, t => !t.inAgents);
+	}
 
-		const workspaceUri = this._getTasksJsonUri(session, 'workspace');
-		if (workspaceUri) {
-			const workspaceJson = await this._readTasksJson(workspaceUri);
-			for (const task of workspaceJson.tasks ?? []) {
-				if (!task.inAgents && this._isSupportedTask(task)) {
-					result.push({ task, target: 'workspace' });
+	/**
+	 * Reads tasks from both workspace and user `tasks.json` for a session,
+	 * filtering each entry through `predicate` (in addition to the supported-type
+	 * check) and tagging it with its storage target.
+	 */
+	private async _readTasksFromBothTargets(session: ISession, predicate: (task: ITaskEntry) => boolean): Promise<ISessionTaskWithTarget[]> {
+		const result: ISessionTaskWithTarget[] = [];
+		const targets: TaskStorageTarget[] = ['workspace', 'user'];
+		for (const target of targets) {
+			const uri = this._getTasksJsonUri(session, target);
+			if (!uri) {
+				continue;
+			}
+			const json = await this._readTasksJson(uri);
+			for (const task of json.tasks ?? []) {
+				if (predicate(task) && this._isSupportedTask(task)) {
+					result.push({ task, target });
 				}
 			}
 		}
-
-		const userUri = this._getTasksJsonUri(session, 'user');
-		if (userUri) {
-			const userJson = await this._readTasksJson(userUri);
-			for (const task of userJson.tasks ?? []) {
-				if (!task.inAgents && this._isSupportedTask(task)) {
-					result.push({ task, target: 'user' });
-				}
-			}
-		}
-
 		return result;
 	}
 
@@ -332,23 +365,11 @@ export class SessionsTasksService extends Disposable implements ISessionsTasksSe
 	}
 
 	async runTask(task: ITaskEntry, session: ISession): Promise<void> {
-		const repo = this._getSessionRepo(session);
-		const cwd = repo?.workingDirectory ?? repo?.root;
-		if (!cwd) {
+		const runner = this._taskRunnerRegistry.getRunner(session);
+		if (!runner) {
 			return;
 		}
-
-		const workspaceFolder = this._workspaceContextService.getWorkspaceFolder(cwd);
-		if (!workspaceFolder) {
-			return;
-		}
-
-		const resolvedTask = await this._taskService.getTask(workspaceFolder, task.label);
-		if (!resolvedTask) {
-			return;
-		}
-
-		await this._taskService.run(resolvedTask, undefined, TaskRunSource.User);
+		await runner.runTask(task, session);
 	}
 
 	getPinnedTaskLabel(repository: URI | undefined): IObservable<string | undefined> {

--- a/src/vs/sessions/contrib/chat/browser/taskCommand.ts
+++ b/src/vs/sessions/contrib/chat/browser/taskCommand.ts
@@ -1,0 +1,175 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CommandString } from '../../../../workbench/contrib/tasks/common/taskConfiguration.js';
+import { ITaskEntry } from './sessionsTasksService.js';
+
+/**
+ * Operating system identifier used to pick the right OS-specific overrides on
+ * an `ITaskEntry`. Mirrors the keys used in `tasks.json` (`windows`, `osx`,
+ * `linux`).
+ */
+export type TaskTargetOS = 'windows' | 'osx' | 'linux';
+
+/**
+ * Context passed to {@link resolveTaskCommand}.
+ */
+export interface ITaskResolutionContext {
+	/**
+	 * Target OS for picking OS-specific `command`/`args` overrides.
+	 */
+	readonly targetOS?: TaskTargetOS;
+	/**
+	 * Lookup used to resolve `dependsOn` references. Should return the
+	 * referenced `ITaskEntry` by `label`, or `undefined` if the task is not
+	 * declared in any reachable `tasks.json`.
+	 */
+	readonly lookup?: (label: string) => ITaskEntry | undefined;
+}
+
+/**
+ * Characters that require POSIX-shell quoting when present in a plain string
+ * argument. Conservative — wraps anything that could cause re-tokenization or
+ * variable / glob / metachar interpretation.
+ */
+const POSIX_NEEDS_QUOTING = /[^A-Za-z0-9_\-.,:/=@%+]/;
+
+function posixStrong(value: string): string {
+	return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function posixWeak(value: string): string {
+	return `"${value.replace(/(["\\$`])/g, '\\$1')}"`;
+}
+
+function posixEscape(value: string): string {
+	return value.replace(/([\\\s"'`$&|;<>(){}[\]*?#~!])/g, '\\$1');
+}
+
+function renderArg(arg: CommandString): string {
+	if (typeof arg === 'string') {
+		return POSIX_NEEDS_QUOTING.test(arg) ? posixStrong(arg) : arg;
+	}
+	if (Array.isArray(arg)) {
+		return arg.map(renderArg).join(' ');
+	}
+	const value = CommandString.value(arg);
+	switch (arg.quoting) {
+		case 'strong': return posixStrong(value);
+		case 'weak': return posixWeak(value);
+		case 'escape': return posixEscape(value);
+		default: return POSIX_NEEDS_QUOTING.test(value) ? posixStrong(value) : value;
+	}
+}
+
+/**
+ * Resolves a task entry's own `command`/`script` (ignoring `dependsOn`).
+ */
+function resolveOwnCommand(task: ITaskEntry, targetOS?: TaskTargetOS): string | undefined {
+	const override = targetOS ? task[targetOS] as { command?: string; args?: CommandString[] } | undefined : undefined;
+	const command = override?.command ?? task.command;
+	const args = override?.args ?? task.args;
+
+	if (command) {
+		const parts: string[] = [command];
+		if (args) {
+			for (const arg of args) {
+				parts.push(renderArg(arg));
+			}
+		}
+		return parts.join(' ');
+	}
+
+	if (task.script && (!task.type || task.type === 'npm')) {
+		return `npm run ${task.script}`;
+	}
+
+	return undefined;
+}
+
+/**
+ * Resolves a task's `dependsOn` chain into a single shell snippet, recursing
+ * through each dependency.
+ *
+ * Returns `undefined` if no dependency could be resolved. Self-referencing or
+ * cyclic chains are broken by tracking the active resolution stack — the
+ * cycling task contributes `undefined` and the rest of the chain proceeds.
+ */
+function resolveDependencies(task: ITaskEntry, ctx: ITaskResolutionContext, stack: Set<string>): string | undefined {
+	if (!task.dependsOn || !ctx.lookup) {
+		return undefined;
+	}
+	const depLabels = typeof task.dependsOn === 'string' ? [task.dependsOn] : task.dependsOn;
+	const resolved: string[] = [];
+	for (const label of depLabels) {
+		const dep = ctx.lookup(label);
+		if (!dep) {
+			continue;
+		}
+		const cmd = resolveInternal(dep, ctx, stack);
+		if (cmd) {
+			resolved.push(cmd);
+		}
+	}
+	if (resolved.length === 0) {
+		return undefined;
+	}
+	if (resolved.length === 1) {
+		return resolved[0];
+	}
+	// `parallel` is rendered as backgrounded subshells joined by `&`, with a
+	// trailing `wait` so the overall command only completes when every
+	// dependency does. Output interleaving is unavoidable but matches the
+	// semantics of the Tasks extension. `sequence` (and the unspecified
+	// default) chain with `&&` so a failing dependency short-circuits.
+	return task.dependsOrder === 'parallel'
+		? `${resolved.map(c => `( ${c} )`).join(' & ')} & wait`
+		: resolved.join(' && ');
+}
+
+function resolveInternal(task: ITaskEntry, ctx: ITaskResolutionContext, stack: Set<string>): string | undefined {
+	if (stack.has(task.label)) {
+		// Cycle — break here. Other branches of the chain still resolve.
+		return undefined;
+	}
+	stack.add(task.label);
+	try {
+		const own = resolveOwnCommand(task, ctx.targetOS);
+		const deps = resolveDependencies(task, ctx, stack);
+		if (own && deps) {
+			return `${deps} && ${own}`;
+		}
+		return own ?? deps;
+	} finally {
+		stack.delete(task.label);
+	}
+}
+
+/**
+ * Resolves an `ITaskEntry` into a single shell command line that can be sent
+ * to a terminal verbatim.
+ *
+ * This is intentionally a much smaller surface than the full Tasks extension
+ * task resolution: it handles
+ * - explicit `command` + `args` (including OS-specific `windows`/`osx`/`linux` overrides),
+ * - `type: 'npm'` + `script` → `npm run <script>`,
+ * - `dependsOn` chains (resolved recursively via `ctx.lookup`); `dependsOrder`
+ *   of `sequence` (default) joins dependencies with `&&`, `parallel` joins
+ *   them as backgrounded subshells with a trailing `wait`,
+ *
+ * and applies POSIX-shell quoting to `args` based on each arg's explicit
+ * `CommandString` `quoting` metadata. Plain string args that contain shell
+ * metacharacters are also strong-quoted so they are not re-tokenized by the
+ * shell.
+ *
+ * It does NOT expand variables (e.g. `${workspaceFolder}`), apply problem
+ * matchers, or honour `presentation` options.
+ *
+ * @returns the resolved command line, or `undefined` if neither the task nor
+ *          any of its dependencies contain enough information to produce one.
+ */
+export function resolveTaskCommand(task: ITaskEntry, ctx?: ITaskResolutionContext): string | undefined {
+	return resolveInternal(task, ctx ?? {}, new Set<string>());
+}

--- a/src/vs/sessions/contrib/chat/browser/workbenchSessionTaskRunner.ts
+++ b/src/vs/sessions/contrib/chat/browser/workbenchSessionTaskRunner.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Schemas } from '../../../../base/common/network.js';
+import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
+import { TaskRunSource } from '../../../../workbench/contrib/tasks/common/tasks.js';
+import { ITaskService } from '../../../../workbench/contrib/tasks/common/taskService.js';
+import { ISession } from '../../../services/sessions/common/session.js';
+import { ISessionTaskRunner } from './sessionTaskRunner.js';
+import { ITaskEntry } from './sessionsTasksService.js';
+
+/**
+ * Default task runner that delegates to the workbench `ITaskService`. Used
+ * for sessions whose workspace is a real local folder loaded into the
+ * workbench (so the Tasks extension can run them). Acts as the lowest-priority
+ * fallback when no specialized runner (e.g. for an agent host) claims the
+ * session.
+ */
+export class WorkbenchSessionTaskRunner implements ISessionTaskRunner {
+
+	readonly id = 'workbench';
+	readonly priority = 0;
+
+	constructor(
+		@ITaskService private readonly _taskService: ITaskService,
+		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
+	) { }
+
+	canRun(session: ISession): boolean {
+		const cwd = this._getCwd(session);
+		// The workbench task service only works against folders loaded into
+		// the workbench workspace. Restrict to file-scheme URIs that resolve
+		// to a known workspace folder so we don't no-op against virtual /
+		// agent-host workspaces.
+		if (!cwd || cwd.scheme !== Schemas.file) {
+			return false;
+		}
+		return !!this._workspaceContextService.getWorkspaceFolder(cwd);
+	}
+
+	async runTask(task: ITaskEntry, session: ISession): Promise<void> {
+		const cwd = this._getCwd(session);
+		if (!cwd) {
+			return;
+		}
+		const workspaceFolder = this._workspaceContextService.getWorkspaceFolder(cwd);
+		if (!workspaceFolder) {
+			return;
+		}
+		const resolved = await this._taskService.getTask(workspaceFolder, task.label);
+		if (!resolved) {
+			return;
+		}
+		await this._taskService.run(resolved, undefined, TaskRunSource.User);
+	}
+
+	private _getCwd(session: ISession) {
+		const repo = session.workspace.get()?.folders[0];
+		return repo?.workingDirectory ?? repo?.root;
+	}
+}

--- a/src/vs/sessions/contrib/chat/browser/worktreeCreatedTaskDispatcher.ts
+++ b/src/vs/sessions/contrib/chat/browser/worktreeCreatedTaskDispatcher.ts
@@ -1,0 +1,110 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable, DisposableMap, DisposableStore } from '../../../../base/common/lifecycle.js';
+import { autorun } from '../../../../base/common/observable.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { IWorkbenchContribution } from '../../../../workbench/common/contributions.js';
+import { ISession } from '../../../services/sessions/common/session.js';
+import { ISessionsChangeEvent, ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
+import { ISessionsTasksService } from './sessionsTasksService.js';
+
+const LOG_PREFIX = '[WorktreeCreatedTaskDispatcher]';
+
+/**
+ * Workbench contribution that runs all tasks tagged with
+ * `runOptions.runOn === 'worktreeCreated'` once per session, when the session
+ * first appears and finishes loading.
+ *
+ * Sessions whose runtime already runs these tasks server-side (signalled via
+ * {@link ISessionCapabilities.runsWorktreeCreatedTasks}) are skipped to avoid
+ * double-execution.
+ *
+ * We deliberately don't persist any "already ran" marker across reloads:
+ * worktree creation itself is a one-shot event, setup tasks are conventionally
+ * idempotent (`npm install`, `pip install -r ...`), and the cost of running
+ * them again on the rare case where the agents window reloads while the same
+ * session is still attached is much smaller than the leak / state-management
+ * cost of tracking them indefinitely.
+ */
+export class WorktreeCreatedTaskDispatcher extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'workbench.contrib.sessions.worktreeCreatedTaskDispatcher';
+
+	// Track per-session disposables (one per in-flight session subscription) so
+	// we tear them down when the session is removed.
+	private readonly _sessionDisposables = this._register(new DisposableMap<string>());
+
+	constructor(
+		@ISessionsManagementService private readonly _sessionsManagementService: ISessionsManagementService,
+		@ISessionsTasksService private readonly _sessionsTasksService: ISessionsTasksService,
+		@ILogService private readonly _logService: ILogService,
+	) {
+		super();
+
+		// Bootstrap: handle sessions that are already known when we start up.
+		for (const session of this._sessionsManagementService.getSessions()) {
+			this._trackSession(session);
+		}
+
+		this._register(this._sessionsManagementService.onDidChangeSessions(e => this._onDidChangeSessions(e)));
+	}
+
+	private _onDidChangeSessions(e: ISessionsChangeEvent): void {
+		for (const session of e.added) {
+			this._trackSession(session);
+		}
+		for (const session of e.removed) {
+			this._sessionDisposables.deleteAndDispose(session.sessionId);
+		}
+	}
+
+	private _trackSession(session: ISession): void {
+		if (session.capabilities.runsWorktreeCreatedTasks) {
+			// The session's runtime already runs these tasks itself.
+			return;
+		}
+		if (this._sessionDisposables.get(session.sessionId)) {
+			return;
+		}
+
+		const store = new DisposableStore();
+		this._sessionDisposables.set(session.sessionId, store);
+
+		// Wait for the session to finish loading, then dispatch any pending
+		// worktreeCreated tasks once. Set `dispatched` synchronously before
+		// the await so any re-firing of the autorun observes it and bails.
+		let dispatched = false;
+		store.add(autorun(reader => {
+			if (session.loading.read(reader) || dispatched) {
+				return;
+			}
+			dispatched = true;
+			void this._dispatchWorktreeCreatedTasks(session);
+		}));
+	}
+
+	private async _dispatchWorktreeCreatedTasks(session: ISession): Promise<void> {
+		let tasks;
+		try {
+			tasks = await this._sessionsTasksService.getSessionTasksOnce(session);
+		} catch (err) {
+			this._logService.warn(`${LOG_PREFIX} Failed to read tasks for session '${session.sessionId}': ${err}`);
+			return;
+		}
+
+		for (const { task } of tasks) {
+			if (task.runOptions?.runOn !== 'worktreeCreated') {
+				continue;
+			}
+			this._logService.trace(`${LOG_PREFIX} Running worktreeCreated task '${task.label}' for session '${session.sessionId}'`);
+			try {
+				await this._sessionsTasksService.runTask(task, session);
+			} catch (err) {
+				this._logService.warn(`${LOG_PREFIX} Failed to run task '${task.label}' for session '${session.sessionId}': ${err}`);
+			}
+		}
+	}
+}

--- a/src/vs/sessions/contrib/chat/test/browser/sessionTaskRunner.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionTaskRunner.test.ts
@@ -1,0 +1,91 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { ISession } from '../../../../services/sessions/common/session.js';
+import { ISessionTaskRunner, SessionTaskRunnerRegistry } from '../../browser/sessionTaskRunner.js';
+
+function makeRunner(id: string, priority: number, canRun: (session: ISession) => boolean = () => true): ISessionTaskRunner {
+	return {
+		id,
+		priority,
+		canRun,
+		runTask: async () => { /* no-op */ },
+	};
+}
+
+suite('SessionTaskRunnerRegistry', () => {
+
+	const store = new DisposableStore();
+
+	teardown(() => store.clear());
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const fakeSession = {} as ISession;
+
+	test('returns undefined when no runners are registered', () => {
+		const registry = new SessionTaskRunnerRegistry();
+		assert.strictEqual(registry.getRunner(fakeSession), undefined);
+	});
+
+	test('returns the single registered runner', () => {
+		const registry = new SessionTaskRunnerRegistry();
+		const runner = makeRunner('a', 0);
+		store.add(registry.register(runner));
+		assert.strictEqual(registry.getRunner(fakeSession), runner);
+	});
+
+	test('higher priority wins', () => {
+		const registry = new SessionTaskRunnerRegistry();
+		store.add(registry.register(makeRunner('low', 0)));
+		const high = makeRunner('high', 100);
+		store.add(registry.register(high));
+		assert.strictEqual(registry.getRunner(fakeSession), high);
+	});
+
+	test('priority order is independent of registration order', () => {
+		const registry = new SessionTaskRunnerRegistry();
+		const high = makeRunner('high', 100);
+		// Register high first.
+		store.add(registry.register(high));
+		store.add(registry.register(makeRunner('low', 0)));
+		assert.strictEqual(registry.getRunner(fakeSession), high);
+	});
+
+	test('later registration wins at equal priority', () => {
+		const registry = new SessionTaskRunnerRegistry();
+		store.add(registry.register(makeRunner('first', 50)));
+		const second = makeRunner('second', 50);
+		store.add(registry.register(second));
+		assert.strictEqual(registry.getRunner(fakeSession), second);
+	});
+
+	test('runners that decline are skipped', () => {
+		const registry = new SessionTaskRunnerRegistry();
+		store.add(registry.register(makeRunner('declining', 100, () => false)));
+		const accepting = makeRunner('accepting', 0, () => true);
+		store.add(registry.register(accepting));
+		assert.strictEqual(registry.getRunner(fakeSession), accepting);
+	});
+
+	test('returns undefined when all registered runners decline', () => {
+		const registry = new SessionTaskRunnerRegistry();
+		store.add(registry.register(makeRunner('a', 0, () => false)));
+		store.add(registry.register(makeRunner('b', 100, () => false)));
+		assert.strictEqual(registry.getRunner(fakeSession), undefined);
+	});
+
+	test('disposing a registration removes the runner', () => {
+		const registry = new SessionTaskRunnerRegistry();
+		const runner = makeRunner('a', 0);
+		const disposable = registry.register(runner);
+		assert.strictEqual(registry.getRunner(fakeSession), runner);
+		disposable.dispose();
+		assert.strictEqual(registry.getRunner(fakeSession), undefined);
+	});
+});

--- a/src/vs/sessions/contrib/chat/test/browser/sessionsTaskService.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionsTaskService.test.ts
@@ -13,15 +13,13 @@ import { IFileContent, IFileService } from '../../../../../platform/files/common
 import { InMemoryStorageService, IStorageService } from '../../../../../platform/storage/common/storage.js';
 import { IJSONEditingService, IJSONValue } from '../../../../../workbench/services/configuration/common/jsonEditing.js';
 import { IPreferencesService } from '../../../../../workbench/services/preferences/common/preferences.js';
-import { IWorkspaceContextService, IWorkspaceFolder } from '../../../../../platform/workspace/common/workspace.js';
 import { INonSessionTaskEntry, ISessionsTasksService, SessionsTasksService, ITaskEntry } from '../../browser/sessionsTasksService.js';
 import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { constObservable, observableValue } from '../../../../../base/common/observable.js';
-import { Task } from '../../../../../workbench/contrib/tasks/common/tasks.js';
-import { ITaskService } from '../../../../../workbench/contrib/tasks/common/taskService.js';
 import { IChat, ISession, ISessionFolder, ISessionWorkspace, SessionStatus } from '../../../../services/sessions/common/session.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { IActiveSession, ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
+import { ISessionTaskRunner, ISessionTaskRunnerRegistry, SessionTaskRunnerRegistry } from '../../browser/sessionTaskRunner.js';
 
 function makeSession(opts: { repository?: URI; worktree?: URI } = {}): ISession {
 	const workspace = opts.repository ? {
@@ -101,12 +99,11 @@ suite('SessionsTasksService', () => {
 	let service: ISessionsTasksService;
 	let fileContents: Map<string, string>;
 	let jsonEdits: { uri: URI; values: IJSONValue[] }[];
-	let ranTasks: { label: string }[];
+	let ranTasks: { label: string; session: ISession }[];
 	let storageService: InMemoryStorageService;
 	let readFileCalls: URI[];
 	let activeSessionObs: ReturnType<typeof observableValue<IActiveSession | undefined>>;
-	let tasksByLabel: Map<string, Task>;
-	let workspaceFoldersByUri: Map<string, IWorkspaceFolder>;
+	let runnerCanRun: (session: ISession) => boolean;
 	let preferencesService: IPreferencesService & { userSettingsResource: URI };
 
 	const userSettingsUri = URI.parse('file:///user/settings.json');
@@ -118,8 +115,7 @@ suite('SessionsTasksService', () => {
 		jsonEdits = [];
 		ranTasks = [];
 		readFileCalls = [];
-		tasksByLabel = new Map();
-		workspaceFoldersByUri = new Map();
+		runnerCanRun = () => true;
 
 		const instantiationService = store.add(new TestInstantiationService());
 		activeSessionObs = observableValue('activeSession', undefined);
@@ -148,24 +144,18 @@ suite('SessionsTasksService', () => {
 		};
 		instantiationService.stub(IPreferencesService, preferencesService);
 
-		instantiationService.stub(ITaskService, new class extends mock<ITaskService>() {
-			override async getTask(_workspaceFolder: any, alias: string | any) {
-				const label = typeof alias === 'string' ? alias : '';
-				return tasksByLabel.get(label);
-			}
-			override async run(task: Task | undefined) {
-				if (task) {
-					ranTasks.push({ label: task._label });
-				}
-				return undefined;
-			}
-		});
-
-		instantiationService.stub(IWorkspaceContextService, new class extends mock<IWorkspaceContextService>() {
-			override getWorkspaceFolder(resource: URI): IWorkspaceFolder | null {
-				return workspaceFoldersByUri.get(resource.toString()) ?? null;
-			}
-		});
+		// Real registry with a recording fake runner so we exercise the
+		// dispatch path in SessionsTasksService.runTask without pulling in the
+		// workbench runner's dependencies.
+		const registry = new SessionTaskRunnerRegistry();
+		const fakeRunner: ISessionTaskRunner = {
+			id: 'fake',
+			priority: 0,
+			canRun: session => runnerCanRun(session),
+			runTask: async (task, session) => { ranTasks.push({ label: task.label, session }); },
+		};
+		store.add(registry.register(fakeRunner));
+		instantiationService.stub(ISessionTaskRunnerRegistry, registry);
 
 		instantiationService.stub(ISessionsManagementService, new class extends mock<ISessionsManagementService>() {
 			override activeSession = activeSessionObs;
@@ -642,52 +632,22 @@ suite('SessionsTasksService', () => {
 
 	// --- runTask ---
 
-	function registerMockTask(label: string, folder: URI): void {
-		tasksByLabel.set(label, { _label: label } as unknown as Task);
-		workspaceFoldersByUri.set(folder.toString(), { uri: folder, name: 'folder', index: 0, toResource: () => folder } as IWorkspaceFolder);
-	}
-
-	test('runTask looks up task by label and runs it via the task service', async () => {
-		registerMockTask('build', worktreeUri);
+	test('runTask delegates to the registry runner', async () => {
 		const session = makeSession({ worktree: worktreeUri, repository: repoUri });
 
 		await service.runTask(makeTask('build', 'npm run build'), session);
 
 		assert.strictEqual(ranTasks.length, 1);
 		assert.strictEqual(ranTasks[0].label, 'build');
+		assert.strictEqual(ranTasks[0].session, session);
 	});
 
-	test('runTask does nothing when no cwd available', async () => {
-		const session = makeSession({ repository: undefined, worktree: undefined });
-		await service.runTask(makeTask('build', 'npm run build'), session);
-
-		assert.strictEqual(ranTasks.length, 0);
-	});
-
-	test('runTask does nothing when workspace folder not found', async () => {
-		// No workspace folder registered for worktreeUri
+	test('runTask is a no-op when no runner claims the session', async () => {
+		runnerCanRun = () => false;
 		const session = makeSession({ worktree: worktreeUri, repository: repoUri });
-		await service.runTask(makeTask('build', 'npm run build'), session);
-
-		assert.strictEqual(ranTasks.length, 0);
-	});
-
-	test('runTask does nothing when task not found by label', async () => {
-		workspaceFoldersByUri.set(worktreeUri.toString(), { uri: worktreeUri, name: 'folder', index: 0, toResource: () => worktreeUri } as IWorkspaceFolder);
-		// No task registered for 'nonexistent'
-		const session = makeSession({ worktree: worktreeUri, repository: repoUri });
-		await service.runTask(makeTask('nonexistent', 'echo hi'), session);
-
-		assert.strictEqual(ranTasks.length, 0);
-	});
-
-	test('runTask uses repository as cwd when worktree is not available', async () => {
-		registerMockTask('build', repoUri);
-		const session = makeSession({ repository: repoUri });
 
 		await service.runTask(makeTask('build', 'npm run build'), session);
 
-		assert.strictEqual(ranTasks.length, 1);
-		assert.strictEqual(ranTasks[0].label, 'build');
+		assert.strictEqual(ranTasks.length, 0);
 	});
 });

--- a/src/vs/sessions/contrib/chat/test/browser/taskCommand.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/taskCommand.test.ts
@@ -1,0 +1,196 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { ITaskEntry } from '../../browser/sessionsTasksService.js';
+import { resolveTaskCommand } from '../../browser/taskCommand.js';
+
+suite('resolveTaskCommand', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('shell command with args', () => {
+		const task: ITaskEntry = { label: 'echo', type: 'shell', command: 'echo', args: ['hello', 'world'] };
+		assert.strictEqual(resolveTaskCommand(task), 'echo hello world');
+	});
+
+	test('plain string args containing spaces are POSIX strong-quoted', () => {
+		const task: ITaskEntry = { label: 'echo', type: 'shell', command: 'echo', args: ['hello world', 'plain'] };
+		assert.strictEqual(resolveTaskCommand(task), `echo 'hello world' plain`);
+	});
+
+	test('shell command without args', () => {
+		const task: ITaskEntry = { label: 'pwd', type: 'shell', command: 'pwd' };
+		assert.strictEqual(resolveTaskCommand(task), 'pwd');
+	});
+
+	test('npm script', () => {
+		const task: ITaskEntry = { label: 'build', type: 'npm', script: 'build' };
+		assert.strictEqual(resolveTaskCommand(task), 'npm run build');
+	});
+
+	test('npm script with no type defaults to npm', () => {
+		const task: ITaskEntry = { label: 'build', script: 'build' };
+		assert.strictEqual(resolveTaskCommand(task), 'npm run build');
+	});
+
+	test('command takes precedence over script', () => {
+		const task: ITaskEntry = { label: 'run', type: 'shell', command: 'make', script: 'ignored' };
+		assert.strictEqual(resolveTaskCommand(task), 'make');
+	});
+
+	test('os override replaces command and args', () => {
+		const task: ITaskEntry = {
+			label: 'list',
+			type: 'shell',
+			command: 'ls',
+			args: ['-la'],
+			windows: { command: 'dir', args: ['/B'] },
+		};
+		assert.strictEqual(resolveTaskCommand(task, { targetOS: 'windows' }), 'dir /B');
+		assert.strictEqual(resolveTaskCommand(task, { targetOS: 'linux' }), 'ls -la');
+		assert.strictEqual(resolveTaskCommand(task), 'ls -la');
+	});
+
+	test('CommandString arg with quoting=strong is single-quoted', () => {
+		const task: ITaskEntry = {
+			label: 'echo',
+			type: 'shell',
+			command: 'echo',
+			args: [{ value: 'hello world', quoting: 'strong' }],
+		};
+		assert.strictEqual(resolveTaskCommand(task), `echo 'hello world'`);
+	});
+
+	test('CommandString arg with quoting=strong escapes embedded single quotes', () => {
+		const task: ITaskEntry = {
+			label: 'echo',
+			type: 'shell',
+			command: 'echo',
+			args: [{ value: `it's fine`, quoting: 'strong' }],
+		};
+		assert.strictEqual(resolveTaskCommand(task), `echo 'it'\\''s fine'`);
+	});
+
+	test('CommandString arg with quoting=weak escapes shell metacharacters in double quotes', () => {
+		const task: ITaskEntry = {
+			label: 'echo',
+			type: 'shell',
+			command: 'echo',
+			args: [{ value: `$HOME "x"`, quoting: 'weak' }],
+		};
+		assert.strictEqual(resolveTaskCommand(task), `echo "\\$HOME \\"x\\""`);
+	});
+
+	test('CommandString arg with quoting=escape backslash-escapes shell-special characters', () => {
+		const task: ITaskEntry = {
+			label: 'echo',
+			type: 'shell',
+			command: 'echo',
+			args: [{ value: 'a b;c', quoting: 'escape' }],
+		};
+		assert.strictEqual(resolveTaskCommand(task), 'echo a\\ b\\;c');
+	});
+
+	test('returns undefined when no command or script is set', () => {
+		const task: ITaskEntry = { label: 'empty' };
+		assert.strictEqual(resolveTaskCommand(task), undefined);
+	});
+
+	// --- dependsOn ---
+
+	function lookupFrom(...tasks: ITaskEntry[]): (label: string) => ITaskEntry | undefined {
+		const map = new Map(tasks.map(t => [t.label, t]));
+		return label => map.get(label);
+	}
+
+	test('dependsOn with a single string label chains the dependency before the own command', () => {
+		const dep: ITaskEntry = { label: 'prep', type: 'shell', command: 'npm', args: ['install'] };
+		const task: ITaskEntry = { label: 'build', type: 'shell', command: 'make', dependsOn: 'prep' };
+		assert.strictEqual(
+			resolveTaskCommand(task, { lookup: lookupFrom(dep) }),
+			'npm install && make'
+		);
+	});
+
+	test('dependsOn array with default sequence order joins with &&', () => {
+		const a: ITaskEntry = { label: 'a', type: 'shell', command: 'echo', args: ['a'] };
+		const b: ITaskEntry = { label: 'b', type: 'shell', command: 'echo', args: ['b'] };
+		const task: ITaskEntry = { label: 'top', dependsOn: ['a', 'b'] };
+		assert.strictEqual(
+			resolveTaskCommand(task, { lookup: lookupFrom(a, b) }),
+			'echo a && echo b'
+		);
+	});
+
+	test('dependsOrder=sequence is explicit and equivalent to default', () => {
+		const a: ITaskEntry = { label: 'a', type: 'shell', command: 'echo', args: ['a'] };
+		const b: ITaskEntry = { label: 'b', type: 'shell', command: 'echo', args: ['b'] };
+		const task: ITaskEntry = { label: 'top', dependsOn: ['a', 'b'], dependsOrder: 'sequence' };
+		assert.strictEqual(
+			resolveTaskCommand(task, { lookup: lookupFrom(a, b) }),
+			'echo a && echo b'
+		);
+	});
+
+	test('dependsOrder=parallel renders as backgrounded subshells with trailing wait', () => {
+		const a: ITaskEntry = { label: 'a', type: 'shell', command: 'echo', args: ['a'] };
+		const b: ITaskEntry = { label: 'b', type: 'shell', command: 'echo', args: ['b'] };
+		const task: ITaskEntry = { label: 'top', dependsOn: ['a', 'b'], dependsOrder: 'parallel' };
+		assert.strictEqual(
+			resolveTaskCommand(task, { lookup: lookupFrom(a, b) }),
+			'( echo a ) & ( echo b ) & wait'
+		);
+	});
+
+	test('dependsOn-only task (no own command) resolves to the dependency chain', () => {
+		const a: ITaskEntry = { label: 'a', type: 'shell', command: 'echo', args: ['a'] };
+		const b: ITaskEntry = { label: 'b', type: 'shell', command: 'echo', args: ['b'] };
+		const task: ITaskEntry = { label: 'group', dependsOn: ['a', 'b'], dependsOrder: 'sequence' };
+		assert.strictEqual(
+			resolveTaskCommand(task, { lookup: lookupFrom(a, b) }),
+			'echo a && echo b'
+		);
+	});
+
+	test('dependsOn missing in lookup is skipped, others still resolve', () => {
+		const a: ITaskEntry = { label: 'a', type: 'shell', command: 'echo', args: ['a'] };
+		const task: ITaskEntry = { label: 'top', dependsOn: ['a', 'does-not-exist'] };
+		assert.strictEqual(
+			resolveTaskCommand(task, { lookup: lookupFrom(a) }),
+			'echo a'
+		);
+	});
+
+	test('dependsOn cycles are broken by cycle-tracking', () => {
+		const a: ITaskEntry = { label: 'a', type: 'shell', command: 'echo', args: ['a'], dependsOn: 'b' };
+		const b: ITaskEntry = { label: 'b', type: 'shell', command: 'echo', args: ['b'], dependsOn: 'a' };
+		// Starting from `a`: a depends on b; b depends on a; a is already on the
+		// stack so the inner reference contributes nothing — b resolves to its
+		// own command, which then runs before a's own command.
+		assert.strictEqual(
+			resolveTaskCommand(a, { lookup: lookupFrom(a, b) }),
+			'echo b && echo a'
+		);
+	});
+
+	test('nested dependencies resolve recursively', () => {
+		const leaf: ITaskEntry = { label: 'leaf', type: 'shell', command: 'echo', args: ['leaf'] };
+		const mid: ITaskEntry = { label: 'mid', type: 'shell', command: 'echo', args: ['mid'], dependsOn: 'leaf' };
+		const top: ITaskEntry = { label: 'top', type: 'shell', command: 'echo', args: ['top'], dependsOn: 'mid' };
+		assert.strictEqual(
+			resolveTaskCommand(top, { lookup: lookupFrom(leaf, mid) }),
+			'echo leaf && echo mid && echo top'
+		);
+	});
+
+	test('dependsOn without lookup falls back to own command (or undefined)', () => {
+		const task: ITaskEntry = { label: 'top', type: 'shell', command: 'make', dependsOn: 'prep' };
+		assert.strictEqual(resolveTaskCommand(task), 'make');
+		const taskNoOwn: ITaskEntry = { label: 'group', dependsOn: 'prep' };
+		assert.strictEqual(resolveTaskCommand(taskNoOwn), undefined);
+	});
+});

--- a/src/vs/sessions/contrib/chat/test/browser/workbenchSessionTaskRunner.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/workbenchSessionTaskRunner.test.ts
@@ -1,0 +1,168 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { Schemas } from '../../../../../base/common/network.js';
+import { constObservable, observableValue } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { mock } from '../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { IWorkspaceContextService, IWorkspaceFolder } from '../../../../../platform/workspace/common/workspace.js';
+import { Task } from '../../../../../workbench/contrib/tasks/common/tasks.js';
+import { ITaskService } from '../../../../../workbench/contrib/tasks/common/taskService.js';
+import { IChat, ISession, ISessionFolder, ISessionWorkspace, SessionStatus } from '../../../../services/sessions/common/session.js';
+import { ITaskEntry } from '../../browser/sessionsTasksService.js';
+import { WorkbenchSessionTaskRunner } from '../../browser/workbenchSessionTaskRunner.js';
+
+function makeSession(opts: { repository?: URI; worktree?: URI } = {}): ISession {
+	const workspace = opts.repository ? {
+		uri: opts.repository,
+		label: 'test',
+		icon: Codicon.folder,
+		folders: [{
+			root: opts.repository,
+			workingDirectory: opts.worktree ?? opts.repository,
+			name: 'test',
+			description: undefined,
+			gitRepository: { uri: opts.repository, workTreeUri: opts.worktree, baseBranchName: undefined, gitHubInfo: constObservable(undefined) },
+		} satisfies ISessionFolder],
+		requiresWorkspaceTrust: false,
+	} : undefined;
+	const chat = { resource: URI.parse('file:///session') } as IChat;
+	return {
+		sessionId: 'test:session',
+		resource: chat.resource,
+		providerId: 'test',
+		sessionType: 'background',
+		icon: Codicon.copilot,
+		createdAt: new Date(),
+		workspace: observableValue('workspace', workspace as ISessionWorkspace | undefined),
+		title: observableValue('title', 'session'),
+		updatedAt: observableValue('updatedAt', new Date()),
+		status: observableValue('status', SessionStatus.Untitled),
+		changesets: constObservable([]),
+		changes: constObservable([]),
+		modelId: observableValue('modelId', undefined),
+		mode: observableValue('mode', undefined),
+		loading: observableValue('loading', false),
+		isArchived: observableValue('isArchived', false),
+		isRead: observableValue('isRead', true),
+		lastTurnEnd: observableValue('lastTurnEnd', undefined),
+		description: observableValue('description', undefined),
+		chats: observableValue('chats', [chat]),
+		mainChat: chat,
+		capabilities: { supportsMultipleChats: false },
+	};
+}
+
+function makeTask(label: string, command?: string): ITaskEntry {
+	return { label, type: 'shell', command: command ?? label };
+}
+
+suite('WorkbenchSessionTaskRunner', () => {
+
+	const store = new DisposableStore();
+	let runner: WorkbenchSessionTaskRunner;
+	let ranTasks: { label: string }[];
+	let tasksByLabel: Map<string, Task>;
+	let workspaceFoldersByUri: Map<string, IWorkspaceFolder>;
+
+	const repoUri = URI.parse('file:///repo');
+	const worktreeUri = URI.parse('file:///worktree');
+
+	setup(() => {
+		ranTasks = [];
+		tasksByLabel = new Map();
+		workspaceFoldersByUri = new Map();
+
+		const instantiationService = store.add(new TestInstantiationService());
+
+		instantiationService.stub(ITaskService, new class extends mock<ITaskService>() {
+			override async getTask(_workspaceFolder: any, alias: string | any) {
+				const label = typeof alias === 'string' ? alias : '';
+				return tasksByLabel.get(label);
+			}
+			override async run(task: Task | undefined) {
+				if (task) {
+					ranTasks.push({ label: task._label });
+				}
+				return undefined;
+			}
+		});
+
+		instantiationService.stub(IWorkspaceContextService, new class extends mock<IWorkspaceContextService>() {
+			override getWorkspaceFolder(resource: URI): IWorkspaceFolder | null {
+				return workspaceFoldersByUri.get(resource.toString()) ?? null;
+			}
+		});
+
+		runner = instantiationService.createInstance(WorkbenchSessionTaskRunner);
+	});
+
+	teardown(() => store.clear());
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function registerMockTask(label: string, folder: URI): void {
+		tasksByLabel.set(label, { _label: label } as unknown as Task);
+		workspaceFoldersByUri.set(folder.toString(), { uri: folder, name: 'folder', index: 0, toResource: () => folder } as IWorkspaceFolder);
+	}
+
+	test('canRun: false for sessions without a workspace', () => {
+		assert.strictEqual(runner.canRun(makeSession()), false);
+	});
+
+	test('canRun: false for non-file schemes', () => {
+		const session = makeSession({ repository: URI.parse('vscode-vfs://github/owner/repo') });
+		assert.strictEqual(runner.canRun(session), false);
+	});
+
+	test('canRun: false when no workspace folder is loaded for the path', () => {
+		const session = makeSession({ worktree: worktreeUri, repository: repoUri });
+		assert.strictEqual(runner.canRun(session), false);
+	});
+
+	test('canRun: true for local file sessions with a loaded workspace folder', () => {
+		workspaceFoldersByUri.set(worktreeUri.toString(), { uri: worktreeUri, name: 'folder', index: 0, toResource: () => worktreeUri } as IWorkspaceFolder);
+		const session = makeSession({ worktree: worktreeUri, repository: repoUri });
+		assert.strictEqual(runner.canRun(session), true);
+	});
+
+	test('runTask looks up by label and runs via ITaskService', async () => {
+		registerMockTask('build', worktreeUri);
+		const session = makeSession({ worktree: worktreeUri, repository: repoUri });
+
+		await runner.runTask(makeTask('build'), session);
+
+		assert.deepStrictEqual(ranTasks, [{ label: 'build' }]);
+	});
+
+	test('runTask is a no-op when task is not registered', async () => {
+		workspaceFoldersByUri.set(worktreeUri.toString(), { uri: worktreeUri, name: 'folder', index: 0, toResource: () => worktreeUri } as IWorkspaceFolder);
+		const session = makeSession({ worktree: worktreeUri, repository: repoUri });
+
+		await runner.runTask(makeTask('nope'), session);
+
+		assert.strictEqual(ranTasks.length, 0);
+	});
+
+	test('runTask uses repository as cwd when worktree is not available', async () => {
+		registerMockTask('build', repoUri);
+		const session = makeSession({ repository: repoUri });
+
+		await runner.runTask(makeTask('build'), session);
+
+		assert.deepStrictEqual(ranTasks, [{ label: 'build' }]);
+	});
+
+	test('priority is 0 (lowest fallback)', () => {
+		assert.strictEqual(runner.priority, 0);
+		// Sanity check on Schemas import usage so unused-import doesn't bite.
+		assert.strictEqual(Schemas.file, 'file');
+	});
+});

--- a/src/vs/sessions/contrib/chat/test/browser/worktreeCreatedTaskDispatcher.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/worktreeCreatedTaskDispatcher.test.ts
@@ -1,0 +1,255 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Emitter } from '../../../../../base/common/event.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { constObservable, observableValue } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
+import { IChat, ISession, ISessionWorkspace, SessionStatus } from '../../../../services/sessions/common/session.js';
+import { ISessionsChangeEvent, ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
+import { ISessionsTasksService, ISessionTaskWithTarget, ITaskEntry } from '../../browser/sessionsTasksService.js';
+import { WorktreeCreatedTaskDispatcher } from '../../browser/worktreeCreatedTaskDispatcher.js';
+
+interface ITestSession {
+	readonly session: ISession;
+	readonly loading: ReturnType<typeof observableValue<boolean>>;
+}
+
+function makeSession(opts: { id?: string; runsWorktreeCreatedTasks?: boolean; loading?: boolean } = {}): ITestSession {
+	const loading = observableValue('loading', opts.loading ?? false);
+	const chat = { resource: URI.parse('file:///session') } as IChat;
+	const session: ISession = {
+		sessionId: opts.id ?? 'test:session',
+		resource: chat.resource,
+		providerId: 'test',
+		sessionType: 'background',
+		icon: Codicon.copilot,
+		createdAt: new Date(),
+		workspace: constObservable(undefined as ISessionWorkspace | undefined),
+		title: observableValue('title', 'session'),
+		updatedAt: observableValue('updatedAt', new Date()),
+		status: observableValue('status', SessionStatus.Untitled),
+		changesets: constObservable([]),
+		changes: constObservable([]),
+		modelId: observableValue('modelId', undefined),
+		mode: observableValue('mode', undefined),
+		loading,
+		isArchived: observableValue('isArchived', false),
+		isRead: observableValue('isRead', true),
+		lastTurnEnd: observableValue('lastTurnEnd', undefined),
+		description: observableValue('description', undefined),
+		chats: observableValue('chats', [chat]),
+		mainChat: chat,
+		capabilities: { supportsMultipleChats: false, runsWorktreeCreatedTasks: opts.runsWorktreeCreatedTasks },
+	};
+	return { session, loading };
+}
+
+function entry(label: string, runOn?: 'worktreeCreated' | 'folderOpen' | 'default'): ISessionTaskWithTarget {
+	const task: ITaskEntry = {
+		label,
+		type: 'shell',
+		command: label,
+		runOptions: runOn ? { runOn } : undefined,
+	};
+	return { task, target: 'workspace' };
+}
+
+class FakeSessionsTasksService implements Partial<ISessionsTasksService> {
+	declare readonly _serviceBrand: undefined;
+	readonly ranTasks: { label: string; sessionId: string }[] = [];
+	private readonly _tasks = new Map<string, readonly ISessionTaskWithTarget[]>();
+	runTaskFails = false;
+
+	setTasks(sessionId: string, tasks: readonly ISessionTaskWithTarget[]): void {
+		this._tasks.set(sessionId, tasks);
+	}
+
+	async getSessionTasksOnce(session: ISession): Promise<readonly ISessionTaskWithTarget[]> {
+		return this._tasks.get(session.sessionId) ?? [];
+	}
+
+	async runTask(task: ITaskEntry, session: ISession): Promise<void> {
+		this.ranTasks.push({ label: task.label, sessionId: session.sessionId });
+		if (this.runTaskFails) {
+			throw new Error('simulated launch failure');
+		}
+	}
+}
+
+class FakeSessionsManagementService implements Partial<ISessionsManagementService> {
+	declare readonly _serviceBrand: undefined;
+	readonly emitter = new Emitter<ISessionsChangeEvent>();
+	readonly onDidChangeSessions = this.emitter.event;
+	sessions: ISession[] = [];
+	getSessions(): ISession[] { return this.sessions; }
+}
+
+suite('WorktreeCreatedTaskDispatcher', () => {
+
+	const store = new DisposableStore();
+	let tasks: FakeSessionsTasksService;
+	let mgmt: FakeSessionsManagementService;
+
+	function createDispatcher(): WorktreeCreatedTaskDispatcher {
+		const instantiationService = store.add(new TestInstantiationService());
+		instantiationService.stub(ISessionsTasksService, tasks as unknown as ISessionsTasksService);
+		instantiationService.stub(ISessionsManagementService, mgmt as unknown as ISessionsManagementService);
+		instantiationService.stub(ILogService, new NullLogService());
+		return store.add(instantiationService.createInstance(WorktreeCreatedTaskDispatcher));
+	}
+
+	setup(() => {
+		tasks = new FakeSessionsTasksService();
+		mgmt = new FakeSessionsManagementService();
+	});
+
+	teardown(() => {
+		mgmt.emitter.dispose();
+		store.clear();
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	async function settle(): Promise<void> {
+		await new Promise(r => setTimeout(r, 0));
+	}
+
+	test('runs worktreeCreated tasks once for a newly added session', async () => {
+		createDispatcher();
+		const { session } = makeSession({ id: 'a' });
+		tasks.setTasks(session.sessionId, [
+			entry('setup', 'worktreeCreated'),
+			entry('lint'),
+		]);
+		mgmt.emitter.fire({ added: [session], removed: [], changed: [] });
+		await settle();
+
+		assert.deepStrictEqual(tasks.ranTasks, [{ label: 'setup', sessionId: 'a' }]);
+	});
+
+	test('runTask failures are logged but do not abort the loop', async () => {
+		createDispatcher();
+		tasks.runTaskFails = true;
+		const { session } = makeSession({ id: 'a' });
+		tasks.setTasks(session.sessionId, [
+			entry('setup-a', 'worktreeCreated'),
+			entry('setup-b', 'worktreeCreated'),
+		]);
+		mgmt.emitter.fire({ added: [session], removed: [], changed: [] });
+		await settle();
+
+		// Both tasks are attempted even though each throws.
+		assert.deepStrictEqual(tasks.ranTasks, [
+			{ label: 'setup-a', sessionId: 'a' },
+			{ label: 'setup-b', sessionId: 'a' },
+		]);
+	});
+
+	test('does not re-dispatch when loading flickers', async () => {
+		createDispatcher();
+		const { session, loading } = makeSession({ id: 'a', loading: true });
+		tasks.setTasks(session.sessionId, [entry('setup', 'worktreeCreated')]);
+		mgmt.emitter.fire({ added: [session], removed: [], changed: [] });
+		await settle();
+
+		loading.set(false, undefined);
+		await settle();
+		// Flip loading back to true and false again — dispatch must not retrigger.
+		loading.set(true, undefined);
+		await settle();
+		loading.set(false, undefined);
+		await settle();
+
+		assert.deepStrictEqual(tasks.ranTasks, [{ label: 'setup', sessionId: 'a' }]);
+	});
+
+	test('per-session task lists do not cross-contaminate', async () => {
+		createDispatcher();
+		const { session: sessionA } = makeSession({ id: 'a' });
+		const { session: sessionB } = makeSession({ id: 'b' });
+		tasks.setTasks(sessionA.sessionId, [entry('setup-a', 'worktreeCreated')]);
+		tasks.setTasks(sessionB.sessionId, [entry('setup-b', 'worktreeCreated')]);
+		mgmt.emitter.fire({ added: [sessionA, sessionB], removed: [], changed: [] });
+		await settle();
+
+		// Each task fires against its own session.
+		assert.deepStrictEqual(
+			[...tasks.ranTasks].sort((x, y) => x.label.localeCompare(y.label)),
+			[
+				{ label: 'setup-a', sessionId: 'a' },
+				{ label: 'setup-b', sessionId: 'b' },
+			]
+		);
+	});
+
+	test('skips sessions whose runtime already runs worktreeCreated tasks', async () => {
+		createDispatcher();
+		const { session } = makeSession({ id: 'a', runsWorktreeCreatedTasks: true });
+		tasks.setTasks(session.sessionId, [entry('setup', 'worktreeCreated')]);
+		mgmt.emitter.fire({ added: [session], removed: [], changed: [] });
+		await settle();
+
+		assert.deepStrictEqual(tasks.ranTasks, []);
+	});
+
+	test('waits for loading to flip to false before running', async () => {
+		createDispatcher();
+		const { session, loading } = makeSession({ id: 'a', loading: true });
+		tasks.setTasks(session.sessionId, [entry('setup', 'worktreeCreated')]);
+		mgmt.emitter.fire({ added: [session], removed: [], changed: [] });
+		await settle();
+		assert.deepStrictEqual(tasks.ranTasks, []);
+
+		loading.set(false, undefined);
+		await settle();
+		assert.deepStrictEqual(tasks.ranTasks, [{ label: 'setup', sessionId: 'a' }]);
+	});
+
+	test('ignores tasks without runOn worktreeCreated', async () => {
+		createDispatcher();
+		const { session } = makeSession({ id: 'a' });
+		tasks.setTasks(session.sessionId, [
+			entry('default'),
+			entry('on-open', 'folderOpen'),
+			entry('explicit-default', 'default'),
+		]);
+		mgmt.emitter.fire({ added: [session], removed: [], changed: [] });
+		await settle();
+
+		assert.deepStrictEqual(tasks.ranTasks, []);
+	});
+
+	test('handles sessions present at startup', async () => {
+		const { session } = makeSession({ id: 'a' });
+		tasks.setTasks(session.sessionId, [entry('setup', 'worktreeCreated')]);
+		mgmt.sessions = [session];
+
+		createDispatcher();
+		await settle();
+
+		assert.deepStrictEqual(tasks.ranTasks, [{ label: 'setup', sessionId: 'a' }]);
+	});
+
+	test('tears down subscription when a session is removed', async () => {
+		createDispatcher();
+		const { session } = makeSession({ id: 'a' });
+		// No tasks yet — autorun should be subscribed but inert.
+		mgmt.emitter.fire({ added: [session], removed: [], changed: [] });
+		await settle();
+
+		mgmt.emitter.fire({ added: [], removed: [session], changed: [] });
+		// Now publish tasks; if the subscription still exists, it would run.
+		tasks.setTasks(session.sessionId, [entry('setup', 'worktreeCreated')]);
+		await settle();
+
+		assert.deepStrictEqual(tasks.ranTasks, []);
+	});
+});

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -3122,6 +3122,10 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 			mainChat,
 			capabilities: {
 				supportsMultipleChats: primaryChat.sessionType === CopilotCLISessionType.id && this._isMultiChatEnabled(),
+				// Cloud-agent sessions run worktreeCreated tasks server-side during
+				// environment provisioning, so the agents-window dispatcher must
+				// not re-run them. CLI / local sessions don't.
+				runsWorktreeCreatedTasks: primaryChat.sessionType === CopilotCloudSessionType.id,
 			},
 		};
 		this._sessionGroupCache.set(sessionId, session);
@@ -3155,7 +3159,10 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 			lastTurnEnd: chat.lastTurnEnd,
 			chats: chatsObs,
 			mainChat,
-			capabilities: { supportsMultipleChats: false },
+			capabilities: {
+				supportsMultipleChats: false,
+				runsWorktreeCreatedTasks: chat.sessionType === CopilotCloudSessionType.id,
+			},
 		};
 	}
 

--- a/src/vs/sessions/contrib/terminal/browser/agentHostSessionTaskRunner.ts
+++ b/src/vs/sessions/contrib/terminal/browser/agentHostSessionTaskRunner.ts
@@ -1,0 +1,107 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize } from '../../../../nls.js';
+import { Schemas } from '../../../../base/common/network.js';
+import { URI } from '../../../../base/common/uri.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { AGENT_HOST_SCHEME, fromAgentHostUri } from '../../../../platform/agentHost/common/agentHostUri.js';
+import { IAgentHostTerminalService } from '../../../../workbench/contrib/terminal/browser/agentHostTerminalService.js';
+import { ITerminalGroupService, ITerminalService } from '../../../../workbench/contrib/terminal/browser/terminal.js';
+import { isAgentHostProvider } from '../../../common/agentHostSessionsProvider.js';
+import { ISessionTaskRunner } from '../../chat/browser/sessionTaskRunner.js';
+import { resolveTaskCommand } from '../../chat/browser/taskCommand.js';
+import { ITaskEntry, ISessionsTasksService } from '../../chat/browser/sessionsTasksService.js';
+import { ISession } from '../../../services/sessions/common/session.js';
+import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
+
+const LOG_PREFIX = '[AgentHostSessionTaskRunner]';
+
+/**
+ * Task runner for sessions backed by an agent host (local or remote). Resolves
+ * the task into a shell command via {@link resolveTaskCommand} and dispatches
+ * it through an agent-host terminal created by
+ * {@link IAgentHostTerminalService.createTerminalForEntry}.
+ */
+export class AgentHostSessionTaskRunner implements ISessionTaskRunner {
+
+	readonly id = 'agentHost';
+	readonly priority = 100;
+
+	constructor(
+		@IAgentHostTerminalService private readonly _agentHostTerminalService: IAgentHostTerminalService,
+		@ISessionsProvidersService private readonly _sessionsProvidersService: ISessionsProvidersService,
+		@ISessionsTasksService private readonly _sessionsTasksService: ISessionsTasksService,
+		@ITerminalService private readonly _terminalService: ITerminalService,
+		@ITerminalGroupService private readonly _terminalGroupService: ITerminalGroupService,
+		@ILogService private readonly _logService: ILogService,
+	) { }
+
+	canRun(session: ISession): boolean {
+		return this._getAddress(session) !== undefined;
+	}
+
+	async runTask(task: ITaskEntry, session: ISession): Promise<void> {
+		const address = this._getAddress(session);
+		if (!address) {
+			return;
+		}
+
+		const allTasks = await this._sessionsTasksService.getAllTasks(session);
+		const byLabel = new Map<string, ITaskEntry>();
+		for (const entry of allTasks) {
+			byLabel.set(entry.task.label, entry.task);
+		}
+
+		const command = resolveTaskCommand(task, { lookup: label => byLabel.get(label) });
+		if (!command) {
+			this._logService.trace(`${LOG_PREFIX} Skipping task '${task.label}' — no command could be resolved.`);
+			return;
+		}
+
+		const cwd = this._getCwd(session);
+		const instance = await this._agentHostTerminalService.createTerminalForEntry(address, {
+			cwd,
+			name: localize('agentHostSessionTaskTerminalName', "Task: {0}", task.label),
+		});
+		if (!instance) {
+			this._logService.warn(`${LOG_PREFIX} Failed to create terminal for task '${task.label}' on '${address}'.`);
+			return;
+		}
+
+		this._terminalService.setActiveInstance(instance);
+		await this._terminalGroupService.showPanel(true);
+		await instance.sendText(command, /*shouldExecute*/ true);
+	}
+
+	private _getAddress(session: ISession): string | undefined {
+		const provider = this._sessionsProvidersService.getProvider(session.providerId);
+		if (!provider || !isAgentHostProvider(provider)) {
+			return undefined;
+		}
+		return provider.remoteAddress ?? '__local__';
+	}
+
+	private _getCwd(session: ISession): URI | undefined {
+		const folder = session.workspace.get()?.folders[0];
+		const cwd = folder?.workingDirectory ?? folder?.root;
+		if (!cwd) {
+			return undefined;
+		}
+		// Agent-host workspaces use the `agent-host:` scheme; unwrap to the
+		// underlying file path so the host can chdir into it directly. Local
+		// agent-host sessions use file URIs as-is (the host shares the local
+		// filesystem). For any other scheme (e.g. `vscode-vfs://`) we don't
+		// know how to translate the path on the remote, so omit cwd and let
+		// the host fall back to its default working directory.
+		if (cwd.scheme === AGENT_HOST_SCHEME) {
+			return fromAgentHostUri(cwd);
+		}
+		if (cwd.scheme === Schemas.file) {
+			return cwd;
+		}
+		return undefined;
+	}
+}

--- a/src/vs/sessions/contrib/terminal/browser/sessionsTerminalContribution.ts
+++ b/src/vs/sessions/contrib/terminal/browser/sessionsTerminalContribution.ts
@@ -11,6 +11,7 @@ import { ServicesAccessor } from '../../../../editor/browser/editorExtensions.js
 import { localize, localize2 } from '../../../../nls.js';
 import { Action2, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { AGENT_HOST_SCHEME, fromAgentHostUri } from '../../../../platform/agentHost/common/agentHostUri.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IWorkbenchContribution, getWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
 import { IAgentHostTerminalService } from '../../../../workbench/contrib/terminal/browser/agentHostTerminalService.js';
@@ -30,6 +31,8 @@ import { logSessionsInteraction } from '../../../common/sessionsTelemetry.js';
 import { IViewsService } from '../../../../workbench/services/views/common/viewsService.js';
 import { ITerminalProfileService, TERMINAL_VIEW_ID } from '../../../../workbench/contrib/terminal/common/terminal.js';
 import { IWorkbenchLayoutService, Parts } from '../../../../workbench/services/layout/browser/layoutService.js';
+import { ISessionTaskRunnerRegistry } from '../../chat/browser/sessionTaskRunner.js';
+import { AgentHostSessionTaskRunner } from './agentHostSessionTaskRunner.js';
 
 const SessionsTerminalViewVisibleContext = new RawContextKey<boolean>('sessionsTerminalViewVisible', false);
 
@@ -433,6 +436,28 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 }
 
 registerWorkbenchContribution2(SessionsTerminalContribution.ID, SessionsTerminalContribution, WorkbenchPhase.AfterRestored);
+
+/**
+ * Registers an {@link AgentHostSessionTaskRunner} with the
+ * {@link ISessionTaskRunnerRegistry}. Lives next to the other agent-host
+ * terminal wiring so that the runner is removed together with the rest of
+ * the sessions terminal contribution if the agents app shuts down.
+ */
+class RegisterAgentHostSessionTaskRunnerContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'workbench.contrib.sessions.registerAgentHostTaskRunner';
+
+	constructor(
+		@IInstantiationService instantiationService: IInstantiationService,
+		@ISessionTaskRunnerRegistry registry: ISessionTaskRunnerRegistry,
+	) {
+		super();
+		const runner = instantiationService.createInstance(AgentHostSessionTaskRunner);
+		this._register(registry.register(runner));
+	}
+}
+
+registerWorkbenchContribution2(RegisterAgentHostSessionTaskRunnerContribution.ID, RegisterAgentHostSessionTaskRunnerContribution, WorkbenchPhase.BlockStartup);
 
 class OpenSessionInTerminalAction extends Action2 {
 

--- a/src/vs/sessions/contrib/terminal/test/browser/agentHostSessionTaskRunner.test.ts
+++ b/src/vs/sessions/contrib/terminal/test/browser/agentHostSessionTaskRunner.test.ts
@@ -1,0 +1,204 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { Event } from '../../../../../base/common/event.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { constObservable, observableValue } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { mock } from '../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { NullLogService, ILogService } from '../../../../../platform/log/common/log.js';
+import { AGENT_HOST_SCHEME, toAgentHostUri } from '../../../../../platform/agentHost/common/agentHostUri.js';
+import { IAgentHostTerminalCreateOptions, IAgentHostTerminalService } from '../../../../../workbench/contrib/terminal/browser/agentHostTerminalService.js';
+import { ITerminalGroupService, ITerminalInstance, ITerminalService } from '../../../../../workbench/contrib/terminal/browser/terminal.js';
+import { ISessionsProvider } from '../../../../services/sessions/common/sessionsProvider.js';
+import { IAgentHostSessionsProvider, LOCAL_AGENT_HOST_PROVIDER_ID, REMOTE_AGENT_HOST_PROVIDER_PREFIX } from '../../../../common/agentHostSessionsProvider.js';
+import { IChat, ISession, ISessionFolder, ISessionWorkspace, SessionStatus } from '../../../../services/sessions/common/session.js';
+import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
+import { ITaskEntry, ISessionsTasksService, ISessionTaskWithTarget } from '../../../chat/browser/sessionsTasksService.js';
+import { AgentHostSessionTaskRunner } from '../../browser/agentHostSessionTaskRunner.js';
+
+function makeSession(opts: { providerId: string; cwd?: URI }): ISession {
+	const folder: ISessionFolder | undefined = opts.cwd ? {
+		root: opts.cwd,
+		workingDirectory: opts.cwd,
+		name: 'test',
+		description: undefined,
+		gitRepository: { uri: opts.cwd, workTreeUri: undefined, baseBranchName: undefined, gitHubInfo: constObservable(undefined) },
+	} : undefined;
+	const workspace: ISessionWorkspace | undefined = folder ? {
+		uri: opts.cwd!,
+		label: 'test',
+		icon: Codicon.folder,
+		folders: [folder],
+		requiresWorkspaceTrust: false,
+		isVirtualWorkspace: false,
+	} : undefined;
+	const chat = { resource: URI.parse('file:///session') } as IChat;
+	return {
+		sessionId: `${opts.providerId}:session`,
+		resource: chat.resource,
+		providerId: opts.providerId,
+		sessionType: 'background',
+		icon: Codicon.copilot,
+		createdAt: new Date(),
+		workspace: observableValue('workspace', workspace),
+		title: observableValue('title', 'session'),
+		updatedAt: observableValue('updatedAt', new Date()),
+		status: observableValue('status', SessionStatus.Untitled),
+		changesets: constObservable([]),
+		changes: constObservable([]),
+		modelId: observableValue('modelId', undefined),
+		mode: observableValue('mode', undefined),
+		loading: observableValue('loading', false),
+		isArchived: observableValue('isArchived', false),
+		isRead: observableValue('isRead', true),
+		lastTurnEnd: observableValue('lastTurnEnd', undefined),
+		description: observableValue('description', undefined),
+		chats: observableValue('chats', [chat]),
+		mainChat: chat,
+		capabilities: { supportsMultipleChats: false },
+	};
+}
+
+suite('AgentHostSessionTaskRunner', () => {
+
+	const store = new DisposableStore();
+	let runner: AgentHostSessionTaskRunner;
+	let createdTerminals: { address: string; options?: IAgentHostTerminalCreateOptions }[];
+	let sentText: { text: string; shouldExecute: boolean }[];
+	let allTasks: ISessionTaskWithTarget[];
+	const fakeInstance = { sendText: async (text: string, shouldExecute: boolean) => { sentText.push({ text, shouldExecute }); } } as ITerminalInstance;
+
+	setup(() => {
+		createdTerminals = [];
+		sentText = [];
+		allTasks = [];
+
+		const instantiationService = store.add(new TestInstantiationService());
+
+		instantiationService.stub(IAgentHostTerminalService, new class extends mock<IAgentHostTerminalService>() {
+			override async createTerminalForEntry(address: string, options?: IAgentHostTerminalCreateOptions) {
+				createdTerminals.push({ address, options });
+				return fakeInstance;
+			}
+		});
+
+		instantiationService.stub(ISessionsTasksService, new class extends mock<ISessionsTasksService>() {
+			override async getAllTasks() {
+				return allTasks;
+			}
+		});
+
+		instantiationService.stub(ISessionsProvidersService, new class extends mock<ISessionsProvidersService>() {
+			override getProvider<T extends ISessionsProvider>(id: string): T | undefined {
+				if (id === LOCAL_AGENT_HOST_PROVIDER_ID || id.startsWith(REMOTE_AGENT_HOST_PROVIDER_PREFIX)) {
+					return new class extends mock<IAgentHostSessionsProvider>() {
+						override id = id;
+						override remoteAddress = id === LOCAL_AGENT_HOST_PROVIDER_ID ? undefined : `remote-${id}`;
+					} as unknown as T;
+				}
+				return undefined;
+			}
+		});
+
+		instantiationService.stub(ITerminalService, new class extends mock<ITerminalService>() {
+			override setActiveInstance() { /* no-op */ }
+		});
+
+		instantiationService.stub(ITerminalGroupService, new class extends mock<ITerminalGroupService>() {
+			override async showPanel() { /* no-op */ }
+		});
+
+		instantiationService.stub(ILogService, new NullLogService());
+
+		runner = instantiationService.createInstance(AgentHostSessionTaskRunner);
+		// Reference unused imports to keep them in the bundle and silence linters.
+		void Event;
+	});
+
+	teardown(() => store.clear());
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function shellTask(): ITaskEntry {
+		return { label: 'build', type: 'shell', command: 'echo', args: ['hi'] };
+	}
+
+	test('canRun: false for non-agent-host providers', () => {
+		assert.strictEqual(runner.canRun(makeSession({ providerId: 'copilot-chat-sessions' })), false);
+	});
+
+	test('canRun: true for local agent host', () => {
+		assert.strictEqual(runner.canRun(makeSession({ providerId: LOCAL_AGENT_HOST_PROVIDER_ID })), true);
+	});
+
+	test('canRun: true for remote agent host', () => {
+		assert.strictEqual(runner.canRun(makeSession({ providerId: 'agenthost-myhost' })), true);
+	});
+
+	test('local agent-host sessions pass through file: cwd', async () => {
+		const cwd = URI.parse('file:///path/to/worktree');
+		const session = makeSession({ providerId: LOCAL_AGENT_HOST_PROVIDER_ID, cwd });
+
+		await runner.runTask(shellTask(), session);
+
+		assert.strictEqual(createdTerminals.length, 1);
+		assert.strictEqual(createdTerminals[0].address, '__local__');
+		assert.deepStrictEqual(createdTerminals[0].options?.cwd?.toString(), cwd.toString());
+		assert.deepStrictEqual(sentText, [{ text: 'echo hi', shouldExecute: true }]);
+	});
+
+	test('agent-host scheme cwds are unwrapped to their original URI', async () => {
+		const innerCwd = URI.parse('file:///remote/path');
+		const wrapped = toAgentHostUri(innerCwd, 'remote');
+		assert.strictEqual(wrapped.scheme, AGENT_HOST_SCHEME, 'precondition: wrapped uri');
+		const session = makeSession({ providerId: 'agenthost-myhost', cwd: wrapped });
+
+		await runner.runTask(shellTask(), session);
+
+		assert.strictEqual(createdTerminals.length, 1);
+		assert.strictEqual(createdTerminals[0].options?.cwd?.toString(), innerCwd.toString());
+	});
+
+	test('unknown scheme cwds are omitted (host uses default)', async () => {
+		const session = makeSession({ providerId: 'agenthost-myhost', cwd: URI.parse('vscode-vfs://github/owner/repo') });
+
+		await runner.runTask(shellTask(), session);
+
+		assert.strictEqual(createdTerminals.length, 1);
+		assert.strictEqual(createdTerminals[0].options?.cwd, undefined);
+	});
+
+	test('skips when no command can be resolved from the task', async () => {
+		const session = makeSession({ providerId: LOCAL_AGENT_HOST_PROVIDER_ID, cwd: URI.parse('file:///x') });
+		await runner.runTask({ label: 'empty' }, session);
+		assert.deepStrictEqual(createdTerminals, []);
+	});
+
+	test('resolves dependsOn chains against the full tasks.json', async () => {
+		const session = makeSession({ providerId: LOCAL_AGENT_HOST_PROVIDER_ID, cwd: URI.parse('file:///x') });
+		const transpile: ITaskEntry = { label: 'Transpile Client', type: 'shell', command: 'npm', args: ['run', 'transpile'] };
+		const runDev: ITaskEntry = { label: 'Run Dev', type: 'shell', command: 'npm', args: ['run', 'dev'] };
+		const top: ITaskEntry = {
+			label: 'Run and Compile Code - OSS',
+			dependsOn: ['Transpile Client', 'Run Dev'],
+			dependsOrder: 'sequence',
+			inAgents: true,
+		};
+		allTasks = [
+			{ task: transpile, target: 'workspace' },
+			{ task: runDev, target: 'workspace' },
+			{ task: top, target: 'workspace' },
+		];
+
+		await runner.runTask(top, session);
+
+		assert.deepStrictEqual(sentText, [{ text: 'npm run transpile && npm run dev', shouldExecute: true }]);
+	});
+});

--- a/src/vs/sessions/services/sessions/common/session.ts
+++ b/src/vs/sessions/services/sessions/common/session.ts
@@ -292,6 +292,16 @@ export function toSessionId(providerId: string, resource: URI): string {
 export interface ISessionCapabilities {
 	/** Whether this session supports multiple chats. */
 	readonly supportsMultipleChats: boolean;
+	/**
+	 * Whether the session's underlying runtime (e.g. a cloud agent host)
+	 * already runs `runOptions.runOn === 'worktreeCreated'` tasks during
+	 * environment provisioning. When `true`, the agents-window
+	 * client-side dispatcher must NOT run those tasks itself to avoid
+	 * double-execution. Defaults to `false` for sessions backed by local
+	 * or remote agent hosts, where the client is the only thing that
+	 * could trigger them.
+	 */
+	readonly runsWorktreeCreatedTasks?: boolean;
 }
 
 /**


### PR DESCRIPTION
# agentHost: support running tasks in remote workspaces

Fixes #312052

## What this does

The "Run Task" toolbar in the agents window let you tag tasks with `inAgents: true` and pick them from a dropdown, but actually running them was a no-op for any session whose workspace wasn't a real local folder loaded into the workbench — i.e., everything backed by an agent host. `runOptions.runOn === 'worktreeCreated'` was also purely visual: nothing on the client side ever auto-ran those tasks.

This adds a small extensibility point so different runtimes can run tasks, plus a contribution that handles auto-run on session creation.

## Design

**`ISessionTaskRunnerRegistry`** (`src/vs/sessions/contrib/chat/browser/sessionTaskRunner.ts`) — priority-based registry of runners. `SessionsTasksService.runTask` is now a thin dispatcher that asks the registry for the highest-priority runner whose `canRun(session)` returns true.

Two runners ship out of the box:

- **`WorkbenchSessionTaskRunner`** (priority 0) wraps the existing `ITaskService` path. `canRun` = `cwd.scheme === 'file'` *and* a workspace folder is loaded for it. Identical behavior to today for local sessions.
- **`AgentHostSessionTaskRunner`** (priority 100) claims agent-host sessions (local + remote). It resolves the task to a shell command, opens a terminal via `IAgentHostTerminalService.createTerminalForEntry`, and `sendText`s the command. The runner uses the existing `IAgentHostTerminalService` wiring that other agent-host features rely on, so it works in any session backed by an agent host — including over WebSocket/SSH/tunnel transports.

**`resolveTaskCommand`** (`taskCommand.ts`) converts an `ITaskEntry` into a shell command line. Handles:

- `command` + `args` with OS-specific `windows`/`osx`/`linux` overrides.
- `type: 'npm'` + `script` → `npm run <script>`.
- POSIX shell quoting that honours explicit `CommandString` `quoting` metadata (`strong`/`weak`/`escape`); plain strings containing shell metacharacters are auto-strong-quoted.
- `dependsOn` chains (recursive), with `dependsOrder: 'sequence'` (default) joined by `&&` and `dependsOrder: 'parallel'` rendered as backgrounded subshells with a trailing `wait`. Cycles are broken by stack-tracking.

This is deliberately a small subset of what the Tasks extension does — no problem matchers, no `${...}` variable expansion, no presentation options. The goal is "good enough to run normal setup/build/dev commands on the agent host", not feature parity.

**`WorktreeCreatedTaskDispatcher`** — new workbench contribution. When a session is added and finishes loading, it reads the session's tasks via the new `getSessionTasksOnce(session)` (a per-session one-shot read; the existing `getSessionTasks` returns a *shared* observable that would cross-contaminate parallel dispatchers) and dispatches each `worktreeCreated` task once. Sessions opt out of client-side dispatch via the new `ISessionCapabilities.runsWorktreeCreatedTasks` flag — set to `true` on cloud-agent sessions because the cloud host already runs those tasks during environment provisioning.

No persistent storage is used to track "already ran" — worktree creation is one-shot in the session's lifetime and setup tasks are conventionally idempotent (`npm install` etc.), so an extra run on rare window-reload-with-attached-session is preferable to indefinite key growth in app storage.

## Concrete example

The original motivation was a workspace task like:
```jsonc
{
  "label": "Run and Compile Code - OSS",
  "dependsOn": ["Transpile Client", "Run Dev"],
  "dependsOrder": "sequence",
  "inAgents": true
}
```
This task has no `command`/`script` of its own, so previously `resolveTaskCommand` returned `undefined` and the agent-host runner skipped it. Now `getAllTasks` provides the dependency lookup and the runner sends `npm run transpile && npm run dev` to the agent-host terminal.

## Validation

- TypeScript: `npm run compile-check-ts-native` clean.
- ESLint: clean on all touched files.
- Layering: `npm run valid-layers-check` clean.
- Tests: 710 sessions tests pass, including 21 `resolveTaskCommand` cases (quoting, OS overrides, dependsOn chains, cycles, parallel), 8 `AgentHostSessionTaskRunner` cases (cwd scheme handling, dependsOn against tasks.json), 9 `WorktreeCreatedTaskDispatcher` cases (cross-session non-contamination, loading flicker, capability opt-out, failure-doesn't-abort-loop), 8 `WorkbenchSessionTaskRunner` cases, 8 `SessionTaskRunnerRegistry` cases.
- All findings from a three-model council review (Opus, GPT-5.5, GPT-5.3-Codex) were addressed: cross-session task contamination via the shared observable, marker-before-launch, dropped quoting, dropped cwd on local agent-host sessions.
