### PR TITLE
Handle sandbox path resolution across platforms

### DIFF
--- a/src/vs/platform/sandbox/common/terminalSandboxEngine.ts
+++ b/src/vs/platform/sandbox/common/terminalSandboxEngine.ts
@@ -520,15 +520,15 @@ export class TerminalSandboxEngine extends Disposable {
 		let denyReadPaths: string[] = [];
 		let denyWritePaths: string[] | undefined;
 		if (this._os === OperatingSystem.Macintosh) {
-			allowWritePaths = this._updateAllowWritePathsWithWorkspaceFolders(macFileSystemSetting.allowWrite, commandRuntimeAllowWritePaths);
-			allowReadPaths = await this._updateAllowReadPathsWithAllowWrite(macFileSystemSetting.allowRead, allowWritePaths, commandRuntimeAllowReadPaths);
-			denyReadPaths = this._updateDenyReadPathsWithHome(macFileSystemSetting.denyRead);
-			denyWritePaths = macFileSystemSetting.denyWrite;
+			allowWritePaths = await this._resolveFileSystemPaths(this._updateAllowWritePathsWithWorkspaceFolders(macFileSystemSetting.allowWrite, commandRuntimeAllowWritePaths));
+			allowReadPaths = await this._resolveFileSystemPaths(await this._updateAllowReadPathsWithAllowWrite(macFileSystemSetting.allowRead, allowWritePaths, commandRuntimeAllowReadPaths));
+			denyReadPaths = await this._resolveFileSystemPaths(this._updateDenyReadPathsWithHome(macFileSystemSetting.denyRead));
+			denyWritePaths = macFileSystemSetting.denyWrite ? await this._resolveFileSystemPaths(macFileSystemSetting.denyWrite) : undefined;
 		} else if (this._os === OperatingSystem.Linux) {
-			allowWritePaths = this._resolveLinuxFileSystemPaths(this._updateAllowWritePathsWithWorkspaceFolders(linuxFileSystemSetting.allowWrite, commandRuntimeAllowWritePaths));
-			allowReadPaths = this._resolveLinuxFileSystemPaths(await this._updateAllowReadPathsWithAllowWrite(linuxFileSystemSetting.allowRead, allowWritePaths, commandRuntimeAllowReadPaths));
-			denyReadPaths = this._resolveLinuxFileSystemPaths(this._updateDenyReadPathsWithHome(linuxFileSystemSetting.denyRead));
-			denyWritePaths = this._resolveLinuxFileSystemPaths(linuxFileSystemSetting.denyWrite);
+			allowWritePaths = await this._resolveFileSystemPaths(this._updateAllowWritePathsWithWorkspaceFolders(linuxFileSystemSetting.allowWrite, commandRuntimeAllowWritePaths));
+			allowReadPaths = await this._resolveFileSystemPaths(await this._updateAllowReadPathsWithAllowWrite(linuxFileSystemSetting.allowRead, allowWritePaths, commandRuntimeAllowReadPaths));
+			denyReadPaths = await this._resolveFileSystemPaths(this._updateDenyReadPathsWithHome(linuxFileSystemSetting.denyRead));
+			denyWritePaths = await this._resolveFileSystemPaths(linuxFileSystemSetting.denyWrite);
 		}
 		const sandboxSettings = {
 			network: allowNetwork ? { allowedDomains: [], deniedDomains: [], enabled: false } : this.getResolvedNetworkDomains(),
@@ -617,8 +617,31 @@ export class TerminalSandboxEngine extends Disposable {
 		return [...new Set([...(configuredAllowRead ?? []), ...getTerminalSandboxReadAllowListForCommands(this._os, this._commandAllowListKeywords, this._commandAllowListCommandDetails), ...commandRuntimeAllowRead, ...this._getSandboxRuntimeReadPaths(), ...await this._getWorkspaceStorageReadPaths(), ...allowWrite])];
 	}
 
-	private _resolveLinuxFileSystemPaths(paths: string[] | undefined): string[] {
-		return (paths ?? []).map(path => this._expandHomePath(path));
+	private async _resolveFileSystemPaths(paths: string[] | undefined): Promise<string[]> {
+		const resolvedPaths = await Promise.all((paths ?? []).map(path => this._resolveFileSystemPath(path)));
+		return [...new Set(resolvedPaths)];
+	}
+
+	private async _resolveFileSystemPath(path: string): Promise<string> {
+		const expandedPath = this._os === OperatingSystem.Linux ? this._expandHomePath(path) : path;
+		if (!this._isAbsoluteFileSystemPath(expandedPath)) {
+			return expandedPath;
+		}
+
+		try {
+			const realpath = await this._fileService.realpath(this._toFileSystemResource(expandedPath));
+			return realpath?.path && realpath.path !== expandedPath ? realpath.path : expandedPath;
+		} catch {
+			return expandedPath;
+		}
+	}
+
+	private _isAbsoluteFileSystemPath(path: string): boolean {
+		return (this._os === OperatingSystem.Windows ? win32 : posix).isAbsolute(path);
+	}
+
+	private _toFileSystemResource(path: string): URI {
+		return this._userHome?.with({ path }) ?? this._tempDir?.with({ path }) ?? this._host.getWriteRoots()[0]?.with({ path }) ?? URI.file(path);
 	}
 
 	private _expandHomePath(path: string): string {

--- a/src/vs/platform/sandbox/test/common/terminalSandboxEngine.test.ts
+++ b/src/vs/platform/sandbox/test/common/terminalSandboxEngine.test.ts
@@ -29,6 +29,17 @@ suite('TerminalSandboxEngine', () => {
 	let createdFolders: string[];
 
 	class MockFileService {
+		private readonly _realpaths = new Map<string, string>();
+
+		setRealpath(path: string, realpath: string): void {
+			this._realpaths.set(path, realpath);
+		}
+
+		async realpath(uri: URI): Promise<URI | undefined> {
+			const realpath = this._realpaths.get(uri.path);
+			return realpath ? uri.with({ path: realpath }) : undefined;
+		}
+
 		async createFile(uri: URI, content: VSBuffer): Promise<any> {
 			createFileCount++;
 			createdFiles.set(uri.path, content.toString());
@@ -125,6 +136,60 @@ suite('TerminalSandboxEngine', () => {
 		ok(!config.filesystem.allowWrite.includes('/workspace-a'), 'Refreshed config should drop the old write root');
 	});
 
+	test('resolves filesystem paths and expands home on Linux when writing the config', async () => {
+		configurationService.setUserConfiguration(AgentSandboxSettingId.AgentSandboxLinuxFileSystem, {
+			allowRead: ['~/read-link'],
+			allowWrite: ['/write-link'],
+			denyRead: ['~/deny-read-link'],
+			denyWrite: ['/deny-write-link'],
+		});
+		fileService.setRealpath('/workspace-link', '/real/workspace');
+		fileService.setRealpath('/write-link', '/real/write');
+		fileService.setRealpath('/home/user/read-link', '/real/read');
+		fileService.setRealpath('/home/user/deny-read-link', '/real/deny-read');
+		fileService.setRealpath('/deny-write-link', '/real/deny-write');
+		fileService.setRealpath('/home/user/.gnupg', '/real/gnupg');
+		const host = createHost({
+			getWriteRoots: () => [URI.file('/workspace-link')],
+		});
+		const engine = store.add(instantiationService.createInstance(TerminalSandboxEngine, host));
+
+		await engine.wrapCommand('git commit -S', false, undefined, undefined, [{ keyword: 'git', args: ['commit', '-S'] }]);
+
+		const configPath = await engine.getSandboxConfigPath();
+		ok(configPath, 'Config path should be defined');
+		const config = JSON.parse(createdFiles.get(configPath)!);
+		ok(config.filesystem.allowWrite.includes('/real/workspace'), 'Workspace write root symlink should be resolved');
+		ok(config.filesystem.allowWrite.includes('/real/write'), 'Configured allowWrite symlink should be resolved');
+		ok(config.filesystem.allowRead.includes('/real/read'), 'Configured allowRead should expand ~ and resolve symlink');
+		ok(config.filesystem.allowRead.includes('/real/gnupg'), 'Command runtime allowRead should expand ~ and resolve symlink');
+		ok(config.filesystem.allowWrite.includes('/real/gnupg'), 'Command runtime allowWrite should expand ~ and resolve symlink');
+		ok(config.filesystem.denyRead.includes('/real/deny-read'), 'Configured denyRead should expand ~ and resolve symlink');
+		ok(config.filesystem.denyWrite.includes('/real/deny-write'), 'Configured denyWrite symlink should be resolved');
+	});
+
+	test('keeps filesystem paths without symlinks when writing the config', async () => {
+		configurationService.setUserConfiguration(AgentSandboxSettingId.AgentSandboxLinuxFileSystem, {
+			allowRead: ['~/read-plain'],
+			allowWrite: ['/write-plain'],
+			denyRead: ['~/deny-read-plain'],
+			denyWrite: ['/deny-write-plain'],
+		});
+		const host = createHost({
+			getWriteRoots: () => [URI.file('/workspace-plain')],
+		});
+		const engine = store.add(instantiationService.createInstance(TerminalSandboxEngine, host));
+
+		const configPath = await engine.getSandboxConfigPath();
+		ok(configPath, 'Config path should be defined');
+		const config = JSON.parse(createdFiles.get(configPath)!);
+		ok(config.filesystem.allowWrite.includes('/workspace-plain'), 'Workspace write root without symlink should be preserved');
+		ok(config.filesystem.allowWrite.includes('/write-plain'), 'Configured allowWrite without symlink should be preserved');
+		ok(config.filesystem.allowRead.includes('/home/user/read-plain'), 'Configured allowRead without symlink should expand ~ and be preserved');
+		ok(config.filesystem.denyRead.includes('/home/user/deny-read-plain'), 'Configured denyRead without symlink should expand ~ and be preserved');
+		ok(config.filesystem.denyWrite.includes('/deny-write-plain'), 'Configured denyWrite without symlink should be preserved');
+	});
+
 	test('cleanupTempDir is a no-op when no temp dir was ever created', async () => {
 		const host = createHost();
 		const engine = store.add(instantiationService.createInstance(TerminalSandboxEngine, host));
@@ -142,6 +207,26 @@ suite('TerminalSandboxEngine', () => {
 
 		strictEqual(await engine.isEnabled(), false);
 		strictEqual(await engine.isSandboxAllowNetworkEnabled(), false);
+	});
+
+	test('uses OS-specific filesystem absolute path detection', async () => {
+		const linuxEngine = store.add(instantiationService.createInstance(TerminalSandboxEngine, createHost()));
+		await linuxEngine.getOS();
+		const isLinuxAbsolutePath = (linuxEngine as unknown as { _isAbsoluteFileSystemPath(path: string): boolean })._isAbsoluteFileSystemPath.bind(linuxEngine);
+
+		strictEqual(isLinuxAbsolutePath('/home/user'), true);
+		strictEqual(isLinuxAbsolutePath('relative/path'), false);
+		strictEqual(isLinuxAbsolutePath('C:\\Users\\user'), false);
+
+		const windowsEngine = store.add(instantiationService.createInstance(TerminalSandboxEngine, createHost({ getOS: () => Promise.resolve(OperatingSystem.Windows) })));
+		await windowsEngine.getOS();
+		const isWindowsAbsolutePath = (windowsEngine as unknown as { _isAbsoluteFileSystemPath(path: string): boolean })._isAbsoluteFileSystemPath.bind(windowsEngine);
+
+		strictEqual(isWindowsAbsolutePath('/Users/user'), true);
+		strictEqual(isWindowsAbsolutePath('C:\\Users\\user'), true);
+		strictEqual(isWindowsAbsolutePath('C:/Users/user'), true);
+		strictEqual(isWindowsAbsolutePath('\\\\server\\share'), true);
+		strictEqual(isWindowsAbsolutePath('relative\\path'), false);
 	});
 
 	test('checkForSandboxingPrereqs reports missing dependencies', async () => {


### PR DESCRIPTION
fixes #313015
## Summary
- Resolve sandbox filesystem allow/deny paths through `realpath` before writing the config.
- Use OS-specific absolute path detection so Windows drive and UNC paths are handled correctly.
- Add focused `TerminalSandboxEngine` tests for symlink resolution and platform-specific absolute paths.

## Testing
- `./scripts/test.sh --run src/vs/platform/sandbox/test/common/terminalSandboxEngine.test.ts`