### PR TITLE
build: increase mac signature verification timeout

### DIFF
--- a/build/azure-pipelines/darwin/product-build-darwin-universal.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin-universal.yml
@@ -201,7 +201,7 @@ jobs:
           fi
           echo "Startup timers:"
           cat "$TIMERS_FILE"
-        timeoutInMinutes: 2
+        timeoutInMinutes: 5
         displayName: Verify signature
 
       - script: |

--- a/build/azure-pipelines/darwin/steps/product-build-darwin-compile.yml
+++ b/build/azure-pipelines/darwin/steps/product-build-darwin-compile.yml
@@ -369,7 +369,7 @@ steps:
         fi
         echo "Startup timers:"
         cat "$TIMERS_FILE"
-      timeoutInMinutes: 3
+      timeoutInMinutes: 5
       displayName: Verify signature
 
     - script: |


### PR DESCRIPTION
## Summary
- increase macOS signature verification timeout from 3 minutes to 5 minutes for arch builds
- increase the universal macOS signature verification timeout from 2 minutes to 5 minutes

## Details
Build 440250 failed in the macOS (X64) Verify signature step because the signed app startup smoke check completed just as the Azure Pipelines task hit its timeout. The codesign output showed a valid Developer ID signature and a stapled notarization ticket, and the app eventually wrote startup timers, so this gives the smoke check more room without changing the verification behavior.

## Validation
- npm run precommit