### PR TITLE
Guard against null result from caretPositionFromPoint in mouseTarget

### DIFF
--- a/src/vs/editor/browser/controller/mouseTarget.ts
+++ b/src/vs/editor/browser/controller/mouseTarget.ts
@@ -1041,8 +1041,15 @@ export class MouseTargetFactory {
 	 * Most probably Gecko
 	 */
 	private static _doHitTestWithCaretPositionFromPoint(ctx: HitTestContext, coords: ClientCoordinates): HitTestResult {
+		// `caretPositionFromPoint` returns `null` when the point lies outside the
+		// document (e.g. while drag-selecting and the cursor leaves the browser
+		// viewport). Mirror the symmetric guard in `_actualDoHitTestWithCaretRangeFromPoint`.
 		// eslint-disable-next-line local/code-no-any-casts, @typescript-eslint/no-explicit-any
-		const hitResult: { offsetNode: Node; offset: number } = (<any>ctx.viewDomNode.ownerDocument).caretPositionFromPoint(coords.clientX, coords.clientY);
+		const hitResult: { offsetNode: Node; offset: number } | null = (<any>ctx.viewDomNode.ownerDocument).caretPositionFromPoint(coords.clientX, coords.clientY);
+
+		if (!hitResult || !hitResult.offsetNode) {
+			return new UnknownHitTestResult();
+		}
 
 		if (hitResult.offsetNode.nodeType === hitResult.offsetNode.TEXT_NODE) {
 			// offsetNode is expected to be the token text


### PR DESCRIPTION
## Summary

Fixes #231280.

While drag-selecting text in a Firefox-based browser and moving the cursor out of the browser viewport (with the mouse button still pressed), the console fills with `TypeError: s is null` originating from `_doHitTest`. The error fires on every animation frame for the lifetime of the drag.

## Root cause

The auto-scroll loop in `dragScrolling.ts` keeps invoking `MouseTargetFactory.createMouseTarget(...)` with the last known page coordinates while a drag is in progress. When the cursor is outside the browser window, those coordinates can resolve to a point that lies outside the document.

In that state, the Gecko-specific path `_doHitTestWithCaretPositionFromPoint` (`src/vs/editor/browser/controller/mouseTarget.ts:1043-1082`) calls `document.caretPositionFromPoint(x, y)`. Per spec, that API returns `null` when no caret position can be determined for the given point, but the local type annotation declared the result as non-null and the code immediately dereferenced `hitResult.offsetNode`, throwing the observed `TypeError`.

The sibling Chrome path `_actualDoHitTestWithCaretRangeFromPoint` already handles the same null contract on `caretRangeFromPoint` and returns `UnknownHitTestResult` (`mouseTarget.ts:1005-1006`). The Gecko path was simply missing the symmetric guard.

## What changed

- `_doHitTestWithCaretPositionFromPoint`: widened the local result type to `{ offsetNode: Node; offset: number } | null` to reflect the real DOM API contract, and added an early `return new UnknownHitTestResult()` when the result (or its `offsetNode`) is `null`. This matches the existing handling in the Chrome path.

No other code changes; callers already cope with `UnknownHitTestResult` (it is the existing fallback returned several times further down in the same function).

## Test plan

- [x] Manual repro (issue steps): open an editor in a Firefox-based build, select text with the mouse held down, drag the cursor out of the browser window. Before the change: `TypeError: s is null` is logged repeatedly. After the change: no console error; the auto-scroll selection behaviour is unchanged.
- [x] Verified the non-null code path is unaffected: when `caretPositionFromPoint` returns a real `CaretPosition`, the function proceeds exactly as before.
- [x] No new test added: `mouseTarget.ts` does not currently have unit tests in `src/vs/editor/test/browser/controller/` and this fix is a one-line null check that mirrors an existing guard a few lines above.