### PR TITLE
Git - fall back when `--show-superproject-working-tree` fails

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -560,13 +560,17 @@ export class Git {
 	async getRepositoryDotGit(repositoryPath: string): Promise<IDotGit> {
 		let dotGitPath: string | undefined, commonDotGitPath: string | undefined, superProjectPath: string | undefined;
 
-		const args = ['rev-parse', '--git-dir', '--git-common-dir'];
-		if (this.compareGitVersionTo('2.13.0') >= 0) {
-			args.push('--show-superproject-working-tree');
-		}
+		const baseArgs = ['rev-parse', '--git-dir', '--git-common-dir'];
+		const includeSuperproject = this.compareGitVersionTo('2.13.0') >= 0;
 
-		const result = await this.exec(repositoryPath, args);
-		[dotGitPath, commonDotGitPath, superProjectPath] = result.stdout.split('\n').map(r => r.trim());
+		// Some git builds (e.g. MSYS2 git on Windows) spawn an `ls-tree` helper
+		// when resolving `--show-superproject-working-tree`, which can fail inside
+		// the VS Code subprocess environment even when there is no superproject.
+		// In that case, retry without the flag so that repositories still open;
+		// they just won't be recognized as submodules. See issue #260851.
+		const stdout = await this.runRevParseDotGit(repositoryPath, baseArgs, includeSuperproject);
+
+		[dotGitPath, commonDotGitPath, superProjectPath] = stdout.split('\n').map(r => r.trim());
 
 		if (!path.isAbsolute(dotGitPath)) {
 			dotGitPath = path.join(repositoryPath, dotGitPath);
@@ -590,6 +594,25 @@ export class Git {
 			commonPath: commonDotGitPath !== dotGitPath ? commonDotGitPath : undefined,
 			superProjectPath: superProjectPath ? path.normalize(superProjectPath) : undefined
 		};
+	}
+
+	private async runRevParseDotGit(repositoryPath: string, baseArgs: string[], includeSuperproject: boolean): Promise<string> {
+		try {
+			const args = includeSuperproject ? [...baseArgs, '--show-superproject-working-tree'] : baseArgs;
+			const result = await this.exec(repositoryPath, args);
+			return result.stdout;
+		} catch (err) {
+			// Fall back without `--show-superproject-working-tree` when its child
+			// process (e.g. `ls-tree`) fails. Without this fallback, the repository
+			// fails to open even though `--git-dir` and `--git-common-dir` would
+			// have succeeded on their own.
+			if (includeSuperproject && err instanceof GitError) {
+				const result = await this.exec(repositoryPath, baseArgs);
+				return result.stdout;
+			}
+
+			throw err;
+		}
 	}
 
 	async exec(cwd: string, args: string[], options: SpawnOptions = {}): Promise<IExecutionResult<string>> {


### PR DESCRIPTION
## Summary

Fixes #260851. When the user configures `git.path` to point at MSYS2 git on Windows, opening a folder that contains a valid `.git` directory fails with *The folder currently open doesn't have a git repository* starting in 1.103. The repo was working in 1.102.3.

## Details

@lszomoru bisected this to 6c8a25ae47508ad3152de7e6269b64f993e53859, which appended `--show-superproject-working-tree` to the existing `git rev-parse --git-dir --git-common-dir` invocation in `getRepositoryDotGit`.

The user's trace log shows that when VS Code spawns MSYS2 git with the new flag, git writes `.git\n.git\n` to stdout for the first two flags, but then exits with code 128 and `fatal: ls-tree returned unexpected return code 127` on stderr:

```
> git rev-parse --git-dir --git-common-dir --show-superproject-working-tree [65ms]
fatal: ls-tree returned unexpected return code 127
Error:Failed to execute git {
  "exitCode": 128,
  "gitCommand": "rev-parse",
  "stdout": ".git\n.git\n",
  "stderr": "fatal: ls-tree returned unexpected return code 127\n"
}
```

Internally, `--show-superproject-working-tree` runs an `ls-tree` helper as a child process. When MSYS2 git is spawned by VS Code (versus run from the terminal), the subprocess environment cannot locate that helper and it fails — even though the repository has no superproject. The same command works correctly when the user runs it in the terminal.

Because the non-zero exit code makes `_exec` throw a `GitError`, `getRepositoryDotGit` never returns and the repository fails to open even though `--git-dir` and `--git-common-dir` resolved correctly.

This change catches the `GitError` from the combined invocation and retries with just the two original flags. The superproject detection (used to classify a repo as `submodule` in `Repository.kind`) is best-effort; falling back to the pre-regression behavior is strictly better than failing to open the repository at all.

## Test plan

- [x] On a non-affected platform, repository opens unchanged (the combined `rev-parse` call succeeds on the first try, no retry).
- [x] When the combined call throws, the fallback retry executes and uses the resulting stdout.
- [x] Errors from the fallback `rev-parse` itself still propagate.
- [ ] User with MSYS2 git on Windows confirms that opening a repository now succeeds (cannot reproduce locally without MSYS2 git on Windows).