### PR TITLE
fix: don't rebuild tab model on EDITORS_SELECTION event

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadEditorTabs.ts
+++ b/src/vs/workbench/api/browser/mainThreadEditorTabs.ts
@@ -604,6 +604,11 @@ export class MainThreadEditorTabs implements MainThreadEditorTabsShape {
 			case GroupModelChangeKind.EDITOR_TRANSIENT:
 				// Currently not exposed in the API
 				break;
+			case GroupModelChangeKind.EDITORS_SELECTION:
+				// Multi-select state of editors is workbench-internal and not exposed in the tabs API.
+				// Treat as no-op so we do not rebuild the entire model (which would invalidate
+				// any `vscode.Tab` references the extension is currently holding).
+				break;
 			case GroupModelChangeKind.EDITOR_MOVE:
 				if (isGroupEditorMoveEvent(event) && event.editor && event.editorIndex !== undefined && event.oldEditorIndex !== undefined) {
 					this._onDidTabMove(groupId, event.editorIndex, event.oldEditorIndex, event.editor);


### PR DESCRIPTION
## Summary

Fixes #228270 — `vscode.window.tabGroups.close(tab)` throws `Tab close: Invalid tab not found!` after an extension opens a webview in the same view column as the stored tab.

## Root cause

bpasero's bisect on the issue points at 88bc75f68c (Tabs Multi Select, #211712), which introduced a new `GroupModelChangeKind.EDITORS_SELECTION` event that the editor group model fires whenever the selected editors change (e.g. as a side effect of `setSelection` on `EDITOR_OPEN` and `EDITOR_ACTIVE`).

The switch in `MainThreadEditorTabs._updateTabsModel` doesn't have a case for `EDITORS_SELECTION`, so it falls through to `default`, which calls `_createTabsModel()` and sends a full `$acceptEditorTabModel` to the extension host. `ExtHostEditorTabs.$acceptEditorTabModel` rebuilds every `ExtHostEditorTabGroup` / `ExtHostEditorTab` from scratch, so any `vscode.Tab` API object an extension is still holding becomes a stale reference.

`_findExtHostTabFromApi` then can't match the extension's tab via `tab.apiObject === apiTab` and `_closeTabs` throws `Tab close: Invalid tab not found!`.

The issue's repro is:

1. Extension stores `tabGroups.activeTabGroup.activeTab`.
2. Extension calls `createWebviewPanel(..., tab.group.viewColumn)` → `EDITOR_OPEN` (handled) followed by `EDITORS_SELECTION` (falls into `default` → full rebuild → tab reference invalidated).
3. Extension awaits any async hop (e.g. `webview.postMessage`), then calls `tabGroups.close(tab)` → throws.

## Fix

Handle `EDITORS_SELECTION` as a no-op in the switch. Multi-select is a workbench-internal concept and isn't exposed via the tabs API — the same treatment we already give `EDITOR_TRANSIENT`. The handled events (`EDITOR_OPEN`, `EDITOR_CLOSE`, `EDITOR_ACTIVE`, etc.) already deliver the surface that's actually exposed through `vscode.window.tabGroups`, so suppressing the rebuild has no observable effect on the API other than preserving reference identity.

## Test plan

- [x] Build with the change against `main`.
- [x] Manual repro from the issue:
  - Install a dev extension whose command runs:
    ```ts
    const tab = vscode.window.tabGroups.activeTabGroup.activeTab;
    const panel = vscode.window.createWebviewPanel('TestPanel', 'Test', tab.group.viewColumn);
    panel.webview.html = '<body>Hello</body>';
    await panel.webview.postMessage('hello');
    vscode.window.tabGroups.close(tab);
    ```
  - Before fix: throws `Tab close: Invalid tab not found!` in the debug console.
  - After fix: original tab closes cleanly, no `onDidChangeTabs` event lost.
- [x] Existing `ExtHostEditorTabs` suite still passes (no changes to extHost side, model rebuild path is unchanged for events that should rebuild).

Regression introduced by 88bc75f68ce7940321c07d20f539cae61e7204af.