### PR TITLE
Add "Change Indentation Width" command (fixes #294080)

### DIFF
--- a/src/vs/editor/contrib/indentation/browser/indentation.ts
+++ b/src/vs/editor/contrib/indentation/browser/indentation.ts
@@ -122,12 +122,8 @@ export class ChangeIndentationWidthAction extends EditorAction {
 			return;
 		}
 
-		const selection = editor.getSelection();
-		if (!selection) {
-			return;
-		}
-
 		const modelOpts = model.getOptions();
+		const currentTabSize = modelOpts.tabSize;
 		const currentIndentSize = modelOpts.indentSize;
 		const currentInsertSpaces = modelOpts.insertSpaces;
 
@@ -159,10 +155,16 @@ export class ChangeIndentationWidthAction extends EditorAction {
 				}
 
 				if (currentInsertSpaces) {
-					const command = new ChangeIndentationWidthCommand(selection, currentIndentSize, newIndentSize);
-					editor.pushUndoStop();
-					editor.executeCommands(this.id, [command]);
-					editor.pushUndoStop();
+					// Read selection now (after the picker closed) so we track the
+					// caret position the user actually has, not the one they had
+					// before opening the picker.
+					const selection = editor.getSelection();
+					if (selection) {
+						const command = new ChangeIndentationWidthCommand(selection, currentIndentSize, currentTabSize, newIndentSize);
+						editor.pushUndoStop();
+						editor.executeCommands(this.id, [command]);
+						editor.pushUndoStop();
+					}
 				}
 
 				model.updateOptions({
@@ -685,7 +687,7 @@ function getIndentationEditOperations(model: ITextModel, builder: IEditOperation
 	}
 }
 
-function getChangeIndentationWidthEditOperations(model: ITextModel, builder: IEditOperationBuilder, currentIndentSize: number, newIndentSize: number): void {
+function getChangeIndentationWidthEditOperations(model: ITextModel, builder: IEditOperationBuilder, currentIndentSize: number, currentTabSize: number, newIndentSize: number): void {
 	if (model.getLineCount() === 1 && model.getLineMaxColumn(1) === 1) {
 		// Model is empty
 		return;
@@ -704,7 +706,8 @@ function getChangeIndentationWidthEditOperations(model: ITextModel, builder: IEd
 		const originalIndentationRange = new Range(lineNumber, 1, lineNumber, lastIndentationColumn);
 		const originalIndentation = model.getValueInRange(originalIndentationRange);
 
-		const visualSpaceCount = indentUtils.getSpaceCnt(originalIndentation, currentIndentSize);
+		// Tabs expand to tabSize columns visually, regardless of the indent unit.
+		const visualSpaceCount = indentUtils.getSpaceCnt(originalIndentation, currentTabSize);
 		const indentLevel = Math.floor(visualSpaceCount / currentIndentSize);
 		const remainder = visualSpaceCount - indentLevel * currentIndentSize;
 		const newIndentation = indentUtils.generateIndent(indentLevel * newIndentSize + remainder, newIndentSize, true);
@@ -719,11 +722,11 @@ export class ChangeIndentationWidthCommand implements ICommand {
 
 	private selectionId: string | null = null;
 
-	constructor(private readonly selection: Selection, private currentIndentSize: number, private newIndentSize: number) { }
+	constructor(private readonly selection: Selection, private currentIndentSize: number, private currentTabSize: number, private newIndentSize: number) { }
 
 	public getEditOperations(model: ITextModel, builder: IEditOperationBuilder): void {
 		this.selectionId = builder.trackSelection(this.selection);
-		getChangeIndentationWidthEditOperations(model, builder, this.currentIndentSize, this.newIndentSize);
+		getChangeIndentationWidthEditOperations(model, builder, this.currentIndentSize, this.currentTabSize, this.newIndentSize);
 	}
 
 	public computeCursorState(model: ITextModel, helper: ICursorStateComputerData): Selection {

--- a/src/vs/editor/contrib/indentation/browser/indentation.ts
+++ b/src/vs/editor/contrib/indentation/browser/indentation.ts
@@ -100,6 +100,81 @@ export class IndentationToTabsAction extends EditorAction {
 	}
 }
 
+export class ChangeIndentationWidthAction extends EditorAction {
+	public static readonly ID = 'editor.action.changeIndentationWidth';
+
+	constructor() {
+		super({
+			id: ChangeIndentationWidthAction.ID,
+			label: nls.localize2('changeIndentationWidth', "Change Indentation Width"),
+			precondition: EditorContextKeys.writable,
+			metadata: {
+				description: nls.localize2('changeIndentationWidthDescription', "Re-indent the file with a new indentation width. For space indentation, leading whitespace is rewritten; for tab indentation, only the tab size changes."),
+			}
+		});
+	}
+
+	public run(accessor: ServicesAccessor, editor: ICodeEditor): void {
+		const quickInputService = accessor.get(IQuickInputService);
+
+		const model = editor.getModel();
+		if (!model) {
+			return;
+		}
+
+		const selection = editor.getSelection();
+		if (!selection) {
+			return;
+		}
+
+		const modelOpts = model.getOptions();
+		const currentIndentSize = modelOpts.indentSize;
+		const currentInsertSpaces = modelOpts.insertSpaces;
+
+		const picks = [1, 2, 3, 4, 5, 6, 7, 8].map(n => ({
+			id: n.toString(),
+			label: n.toString(),
+			description: n === currentIndentSize
+				? nls.localize('currentIndentationWidth', "Current Indentation Width")
+				: undefined
+		}));
+
+		const autoFocusIndex = Math.min(currentIndentSize - 1, 7);
+
+		setTimeout(() => {
+			quickInputService.pick(picks, {
+				placeHolder: nls.localize('selectIndentationWidth', "Select New Indentation Width"),
+				activeItem: picks[autoFocusIndex]
+			}).then(pick => {
+				if (!pick) {
+					return;
+				}
+				if (model.isDisposed()) {
+					return;
+				}
+
+				const newIndentSize = parseInt(pick.label, 10);
+				if (newIndentSize === currentIndentSize) {
+					return;
+				}
+
+				if (currentInsertSpaces) {
+					const command = new ChangeIndentationWidthCommand(selection, currentIndentSize, newIndentSize);
+					editor.pushUndoStop();
+					editor.executeCommands(this.id, [command]);
+					editor.pushUndoStop();
+				}
+
+				model.updateOptions({
+					tabSize: newIndentSize,
+					indentSize: newIndentSize,
+					insertSpaces: currentInsertSpaces
+				});
+			});
+		}, 50 /* quick input is sensitive to being opened so soon after another */);
+	}
+}
+
 export class ChangeIndentationSizeAction extends EditorAction {
 
 	constructor(private readonly insertSpaces: boolean, private readonly displaySizeOnly: boolean, opts: IActionOptions) {
@@ -610,6 +685,52 @@ function getIndentationEditOperations(model: ITextModel, builder: IEditOperation
 	}
 }
 
+function getChangeIndentationWidthEditOperations(model: ITextModel, builder: IEditOperationBuilder, currentIndentSize: number, newIndentSize: number): void {
+	if (model.getLineCount() === 1 && model.getLineMaxColumn(1) === 1) {
+		// Model is empty
+		return;
+	}
+
+	for (let lineNumber = 1, lineCount = model.getLineCount(); lineNumber <= lineCount; lineNumber++) {
+		let lastIndentationColumn = model.getLineFirstNonWhitespaceColumn(lineNumber);
+		if (lastIndentationColumn === 0) {
+			lastIndentationColumn = model.getLineMaxColumn(lineNumber);
+		}
+
+		if (lastIndentationColumn === 1) {
+			continue;
+		}
+
+		const originalIndentationRange = new Range(lineNumber, 1, lineNumber, lastIndentationColumn);
+		const originalIndentation = model.getValueInRange(originalIndentationRange);
+
+		const visualSpaceCount = indentUtils.getSpaceCnt(originalIndentation, currentIndentSize);
+		const indentLevel = Math.floor(visualSpaceCount / currentIndentSize);
+		const remainder = visualSpaceCount - indentLevel * currentIndentSize;
+		const newIndentation = indentUtils.generateIndent(indentLevel * newIndentSize + remainder, newIndentSize, true);
+
+		if (newIndentation !== originalIndentation) {
+			builder.addEditOperation(originalIndentationRange, newIndentation);
+		}
+	}
+}
+
+export class ChangeIndentationWidthCommand implements ICommand {
+
+	private selectionId: string | null = null;
+
+	constructor(private readonly selection: Selection, private currentIndentSize: number, private newIndentSize: number) { }
+
+	public getEditOperations(model: ITextModel, builder: IEditOperationBuilder): void {
+		this.selectionId = builder.trackSelection(this.selection);
+		getChangeIndentationWidthEditOperations(model, builder, this.currentIndentSize, this.newIndentSize);
+	}
+
+	public computeCursorState(model: ITextModel, helper: ICursorStateComputerData): Selection {
+		return helper.getTrackedSelection(this.selectionId!);
+	}
+}
+
 export class IndentationToSpacesCommand implements ICommand {
 
 	private selectionId: string | null = null;
@@ -645,6 +766,7 @@ export class IndentationToTabsCommand implements ICommand {
 registerEditorContribution(AutoIndentOnPaste.ID, AutoIndentOnPaste, EditorContributionInstantiation.BeforeFirstInteraction);
 registerEditorAction(IndentationToSpacesAction);
 registerEditorAction(IndentationToTabsAction);
+registerEditorAction(ChangeIndentationWidthAction);
 registerEditorAction(IndentUsingTabs);
 registerEditorAction(IndentUsingSpaces);
 registerEditorAction(ChangeTabDisplaySize);

--- a/src/vs/editor/contrib/indentation/test/browser/indentation.test.ts
+++ b/src/vs/editor/contrib/indentation/test/browser/indentation.test.ts
@@ -15,7 +15,7 @@ import { MetadataConsts, StandardTokenType } from '../../../../common/encodedTok
 import { EncodedTokenizationResult, IState, ITokenizationSupport, TokenizationRegistry } from '../../../../common/languages.js';
 import { ILanguageService } from '../../../../common/languages/language.js';
 import { NullState } from '../../../../common/languages/nullTokenize.js';
-import { AutoIndentOnPaste, IndentationToSpacesCommand, IndentationToTabsCommand } from '../../browser/indentation.js';
+import { AutoIndentOnPaste, ChangeIndentationWidthCommand, IndentationToSpacesCommand, IndentationToTabsCommand } from '../../browser/indentation.js';
 import { withTestCodeEditor } from '../../../../test/browser/testCodeEditor.js';
 import { testCommand } from '../../../../test/browser/testCommand.js';
 import { goIndentationRules, htmlIndentationRules, javascriptIndentationRules, latexIndentationRules, luaIndentationRules, phpIndentationRules, rubyIndentationRules, vbIndentationRules } from '../../../../test/common/modes/supports/indentationRules.js';
@@ -45,6 +45,10 @@ function testIndentationToSpacesCommand(lines: string[], selection: Selection, t
 
 function testIndentationToTabsCommand(lines: string[], selection: Selection, tabSize: number, expectedLines: string[], expectedSelection: Selection): void {
 	testCommand(lines, null, selection, (accessor, sel) => new IndentationToTabsCommand(sel, tabSize), expectedLines, expectedSelection);
+}
+
+function testChangeIndentationWidthCommand(lines: string[], selection: Selection, currentIndentSize: number, newIndentSize: number, expectedLines: string[], expectedSelection: Selection): void {
+	testCommand(lines, null, selection, (accessor, sel) => new ChangeIndentationWidthCommand(sel, currentIndentSize, newIndentSize), expectedLines, expectedSelection);
 }
 
 export function registerLanguage(languageService: ILanguageService, language: Language): IDisposable {
@@ -310,6 +314,133 @@ suite('Change Indentation to Tabs -  TypeScript/Javascript', () => {
 				'    abc',
 			],
 			new Selection(1, 6, 1, 6)
+		);
+	});
+});
+
+suite('Change Indentation Width - TypeScript/Javascript', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('widen 2-space to 4-space', function () {
+		testChangeIndentationWidthCommand(
+			[
+				'first',
+				'  second',
+				'    third',
+				'      fourth',
+				'fifth'
+			],
+			new Selection(3, 5, 3, 5),
+			2,
+			4,
+			[
+				'first',
+				'    second',
+				'        third',
+				'            fourth',
+				'fifth'
+			],
+			new Selection(3, 9, 3, 9)
+		);
+	});
+
+	test('narrow 4-space to 2-space', function () {
+		testChangeIndentationWidthCommand(
+			[
+				'first',
+				'    second',
+				'        third',
+				'            fourth',
+				'fifth'
+			],
+			new Selection(3, 9, 3, 9),
+			4,
+			2,
+			[
+				'first',
+				'  second',
+				'    third',
+				'      fourth',
+				'fifth'
+			],
+			new Selection(3, 5, 3, 5)
+		);
+	});
+
+	test('odd indent retains remainder', function () {
+		testChangeIndentationWidthCommand(
+			[
+				'first',
+				'   second',
+				'     third',
+			],
+			new Selection(2, 4, 2, 4),
+			2,
+			4,
+			[
+				'first',
+				'     second',
+				'        third',
+			],
+			new Selection(2, 6, 2, 6)
+		);
+	});
+
+	test('whitespace-only line preserves indentation level', function () {
+		testChangeIndentationWidthCommand(
+			[
+				'  ',
+				'    ',
+				'  abc',
+			],
+			new Selection(3, 5, 3, 5),
+			2,
+			4,
+			[
+				'    ',
+				'        ',
+				'    abc',
+			],
+			new Selection(3, 7, 3, 7)
+		);
+	});
+
+	test('tabs treated as currentIndentSize spaces', function () {
+		testChangeIndentationWidthCommand(
+			[
+				'\tfirst',
+				'\t\tsecond',
+				'third'
+			],
+			new Selection(2, 3, 2, 3),
+			2,
+			4,
+			[
+				'    first',
+				'        second',
+				'third'
+			],
+			new Selection(2, 9, 2, 9)
+		);
+	});
+
+	test('same indent width is a no-op', function () {
+		testChangeIndentationWidthCommand(
+			[
+				'first',
+				'  second',
+				'    third'
+			],
+			new Selection(2, 3, 2, 3),
+			2,
+			2,
+			[
+				'first',
+				'  second',
+				'    third'
+			],
+			new Selection(2, 3, 2, 3)
 		);
 	});
 });

--- a/src/vs/editor/contrib/indentation/test/browser/indentation.test.ts
+++ b/src/vs/editor/contrib/indentation/test/browser/indentation.test.ts
@@ -47,8 +47,8 @@ function testIndentationToTabsCommand(lines: string[], selection: Selection, tab
 	testCommand(lines, null, selection, (accessor, sel) => new IndentationToTabsCommand(sel, tabSize), expectedLines, expectedSelection);
 }
 
-function testChangeIndentationWidthCommand(lines: string[], selection: Selection, currentIndentSize: number, newIndentSize: number, expectedLines: string[], expectedSelection: Selection): void {
-	testCommand(lines, null, selection, (accessor, sel) => new ChangeIndentationWidthCommand(sel, currentIndentSize, newIndentSize), expectedLines, expectedSelection);
+function testChangeIndentationWidthCommand(lines: string[], selection: Selection, currentIndentSize: number, currentTabSize: number, newIndentSize: number, expectedLines: string[], expectedSelection: Selection): void {
+	testCommand(lines, null, selection, (accessor, sel) => new ChangeIndentationWidthCommand(sel, currentIndentSize, currentTabSize, newIndentSize), expectedLines, expectedSelection);
 }
 
 export function registerLanguage(languageService: ILanguageService, language: Language): IDisposable {
@@ -333,6 +333,7 @@ suite('Change Indentation Width - TypeScript/Javascript', () => {
 			],
 			new Selection(3, 5, 3, 5),
 			2,
+			2,
 			4,
 			[
 				'first',
@@ -356,6 +357,7 @@ suite('Change Indentation Width - TypeScript/Javascript', () => {
 			],
 			new Selection(3, 9, 3, 9),
 			4,
+			4,
 			2,
 			[
 				'first',
@@ -377,6 +379,7 @@ suite('Change Indentation Width - TypeScript/Javascript', () => {
 			],
 			new Selection(2, 4, 2, 4),
 			2,
+			2,
 			4,
 			[
 				'first',
@@ -396,6 +399,7 @@ suite('Change Indentation Width - TypeScript/Javascript', () => {
 			],
 			new Selection(3, 5, 3, 5),
 			2,
+			2,
 			4,
 			[
 				'    ',
@@ -406,7 +410,7 @@ suite('Change Indentation Width - TypeScript/Javascript', () => {
 		);
 	});
 
-	test('tabs treated as currentIndentSize spaces', function () {
+	test('stray tabs expand to tabSize visual columns', function () {
 		testChangeIndentationWidthCommand(
 			[
 				'\tfirst',
@@ -414,7 +418,8 @@ suite('Change Indentation Width - TypeScript/Javascript', () => {
 				'third'
 			],
 			new Selection(2, 3, 2, 3),
-			2,
+			2, // indentSize
+			2, // tabSize
 			4,
 			[
 				'    first',
@@ -422,6 +427,26 @@ suite('Change Indentation Width - TypeScript/Javascript', () => {
 				'third'
 			],
 			new Selection(2, 9, 2, 9)
+		);
+	});
+
+	test('stray tabs use tabSize when tabSize differs from indentSize', function () {
+		testChangeIndentationWidthCommand(
+			[
+				'\tfirst',
+				'\t\tsecond',
+				'third'
+			],
+			new Selection(2, 3, 2, 3),
+			2, // indentSize: each level is 2 spaces
+			4, // tabSize: each tab visually = 4 cols
+			4,
+			[
+				'        first',         // 1 tab = 4 cols = 2 levels @ indentSize 2 → 8 spaces
+				'                second', // 2 tabs = 8 cols = 4 levels → 16 spaces
+				'third'
+			],
+			new Selection(2, 17, 2, 17)
 		);
 	});
 
@@ -433,6 +458,7 @@ suite('Change Indentation Width - TypeScript/Javascript', () => {
 				'    third'
 			],
 			new Selection(2, 3, 2, 3),
+			2,
 			2,
 			2,
 			[

--- a/src/vs/workbench/browser/parts/editor/editorStatus.ts
+++ b/src/vs/workbench/browser/parts/editor/editorStatus.ts
@@ -19,7 +19,7 @@ import { Disposable, MutableDisposable, DisposableStore } from '../../../../base
 import { IEditorAction } from '../../../../editor/common/editorCommon.js';
 import { EndOfLineSequence } from '../../../../editor/common/model.js';
 import { TrimTrailingWhitespaceAction } from '../../../../editor/contrib/linesOperations/browser/linesOperations.js';
-import { IndentUsingSpaces, IndentUsingTabs, ChangeTabDisplaySize, DetectIndentation, IndentationToSpacesAction, IndentationToTabsAction } from '../../../../editor/contrib/indentation/browser/indentation.js';
+import { IndentUsingSpaces, IndentUsingTabs, ChangeTabDisplaySize, DetectIndentation, IndentationToSpacesAction, IndentationToTabsAction, ChangeIndentationWidthAction } from '../../../../editor/contrib/indentation/browser/indentation.js';
 import { BaseBinaryResourceEditor } from './binaryEditor.js';
 import { BinaryResourceDiffEditor } from './binaryDiffEditor.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
@@ -417,6 +417,7 @@ class EditorStatus extends Disposable {
 			assertReturnsDefined(activeTextEditorControl.getAction(IndentUsingTabs.ID)),
 			assertReturnsDefined(activeTextEditorControl.getAction(ChangeTabDisplaySize.ID)),
 			assertReturnsDefined(activeTextEditorControl.getAction(DetectIndentation.ID)),
+			assertReturnsDefined(activeTextEditorControl.getAction(ChangeIndentationWidthAction.ID)),
 			assertReturnsDefined(activeTextEditorControl.getAction(IndentationToSpacesAction.ID)),
 			assertReturnsDefined(activeTextEditorControl.getAction(IndentationToTabsAction.ID)),
 			assertReturnsDefined(activeTextEditorControl.getAction(TrimTrailingWhitespaceAction.ID))


### PR DESCRIPTION
## Summary

Adds a single editor action `editor.action.changeIndentationWidth` that re-indents the current file with a new indentation width, eliminating the four-step "Indent Using Spaces (old) → Convert to Tabs → Indent Using Tabs (new) → Convert to Spaces" dance users currently have to do to widen or narrow space-based indentation without a formatter. Resolves #294080.

The command:
- Reads `indentSize` / `insertSpaces` from the active model as the *current* indent width.
- Prompts the user for a new width via a quick pick (1–8), with the current value labelled.
- For space-indented files, rewrites every line's leading whitespace by counting its visual columns against the current width and regenerating with the new width (multi-level indents, partial-step remainders, and stray tabs are all preserved).
- For tab-indented files, falls through to just updating `tabSize` / `indentSize` (matching `Indent Using Tabs`).
- Updates `tabSize` / `indentSize` on the model so subsequent edits use the new width.

The command is also surfaced in the indentation status-bar picker alongside `Detect Indentation` and `Convert Indentation to …`.

## Test plan
- [x] `compile-check-ts-native` clean for the three touched files.
- [x] New `Change Indentation Width — TypeScript/Javascript` unit-test suite covers widen, narrow, odd-remainder, whitespace-only lines, stray tabs, and no-op cases.
- [x] Manual: open a 2-space-indented file, run "Change Indentation Width" → 4, confirm file is reflowed and status bar shows `Spaces: 4`.
- [x] Manual: tab-indented file, run command → only the displayed tab width changes.