### PR TITLE
Claude: resume cross-window sessions from disk on first send

### DIFF
--- a/src/vs/platform/agentHost/node/claude/claudeAgent.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgent.ts
@@ -578,13 +578,23 @@ export class ClaudeAgent extends Disposable implements IAgent {
 		const permissionMode = this._readSessionPermissionMode(sessionUri)
 			?? overlay.permissionMode
 			?? 'default';
+		// Resolve git project metadata from the resumed cwd, same as
+		// createSession's non-fork path. Best-effort: a failure (no
+		// repo, git CLI missing, etc.) downgrades to `undefined` rather
+		// than blocking the resume.
+		let project: IAgentSessionProjectInfo | undefined;
+		try {
+			project = await projectFromCopilotContext({ cwd: workingDirectory.fsPath }, this._gitService);
+		} catch (err) {
+			this._logService.warn(`[Claude:${sessionId}] project resolution failed during resume; continuing without project`, err);
+		}
 		const abortController = new AbortController();
 		const provisional: IClaudeMaterializeProvisional = {
 			sessionId,
 			sessionUri,
 			workingDirectory,
 			abortController,
-			project: undefined,
+			project,
 			model: overlay.model,
 		};
 
@@ -614,7 +624,7 @@ export class ClaudeAgent extends Disposable implements IAgent {
 		this._onDidMaterializeSession.fire({
 			session: sessionUri,
 			workingDirectory,
-			project: undefined,
+			project,
 		});
 
 		return session;

--- a/src/vs/platform/agentHost/node/claude/claudeAgent.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgent.ts
@@ -35,7 +35,7 @@ import { mapSessionMessagesToTurns } from './claudeReplayMapper.js';
 import { getSubagentTranscript } from './claudeSubagentResolver.js';
 import { ClaudeAgentSession } from './claudeAgentSession.js';
 import { handleCanUseTool } from './claudeCanUseTool.js';
-import { ClaudeMaterializer } from './claudeMaterializer.js';
+import { ClaudeMaterializer, type IClaudeMaterializeProvisional } from './claudeMaterializer.js';
 import { tryParseClaudeModelId } from './claudeModelId.js';
 import { resolvePromptToContentBlocks } from './claudePromptResolver.js';
 import { IClaudeProxyHandle, IClaudeProxyService } from './claudeProxyService.js';
@@ -544,6 +544,83 @@ export class ClaudeAgent extends Disposable implements IAgent {
 	}
 
 	/**
+	 * Bring up a session whose state exists only on disk — created in
+	 * another window, or before an agent-host restart. Mirror of
+	 * `CopilotAgent._resumeSession`. Reads `workingDirectory` from the
+	 * SDK's session record and `model` / `permissionMode` from the
+	 * metadata overlay, builds an {@link IClaudeMaterializeProvisional}
+	 * record on the fly, and routes through
+	 * {@link ClaudeMaterializer.materialize} with `startMode: 'resume'`
+	 * so the SDK reloads the existing transcript instead of minting a
+	 * fresh one.
+	 *
+	 * Caller must hold the session sequencer so two concurrent
+	 * `sendMessage` calls for a freshly-resumed session collapse into
+	 * one resume + two ordered sends.
+	 */
+	private async _resumeSession(sessionId: string, sessionUri: URI): Promise<ClaudeAgentSession> {
+		this._logService.info(`[Claude:${sessionId}] _resumeSession — no in-memory state, rebuilding from disk`);
+		const proxyHandle = this._ensureAuthenticated();
+		const sdkInfo = await this._sdkService.getSessionInfo(sessionId);
+		if (!sdkInfo) {
+			throw new Error(`Cannot resume unknown session: ${sessionId} (not present in SDK transcript store)`);
+		}
+		const workingDirectory = sdkInfo.cwd ? URI.file(sdkInfo.cwd) : undefined;
+		if (!workingDirectory) {
+			throw new Error(`Cannot resume session ${sessionId}: workingDirectory missing from SDK transcript`);
+		}
+		let overlay: IClaudeSessionOverlay = {};
+		try {
+			overlay = await this._metadataStore.read(sessionUri);
+		} catch (err) {
+			this._logService.warn(`[Claude:${sessionId}] overlay read failed during resume; continuing with defaults`, err);
+		}
+		const permissionMode = this._readSessionPermissionMode(sessionUri)
+			?? overlay.permissionMode
+			?? 'default';
+		const abortController = new AbortController();
+		const provisional: IClaudeMaterializeProvisional = {
+			sessionId,
+			sessionUri,
+			workingDirectory,
+			abortController,
+			project: undefined,
+			model: overlay.model,
+		};
+
+		const canUseTool: NonNullable<Options['canUseTool']> = (toolName, input, options) =>
+			handleCanUseTool(
+				{ getSession: id => this._sessions.get(id)?.session, configurationService: this._configurationService },
+				sessionId, toolName, input, options,
+			);
+
+		const session = await this._materializer.materialize(provisional, proxyHandle, permissionMode, canUseTool, 'resume');
+
+		const initialEffort = clampEffortForRuntime(resolveClaudeEffort(overlay.model));
+		session.seedBijectiveState({
+			model: overlay.model?.id,
+			effort: initialEffort,
+			permissionMode,
+		});
+		session.attachRematerializer(async (_reason) => {
+			const liveMode = this._readSessionPermissionMode(sessionUri) ?? permissionMode;
+			return this._materializer.materializeResume(provisional, proxyHandle, liveMode, canUseTool);
+		});
+
+		const entry = new ClaudeSessionEntry(session);
+		entry.addDisposable(session.onDidSessionProgress(signal => this._onDidSessionProgress.fire(signal)));
+		this._sessions.set(sessionId, entry);
+
+		this._onDidMaterializeSession.fire({
+			session: sessionUri,
+			workingDirectory,
+			project: undefined,
+		});
+
+		return session;
+	}
+
+	/**
 	 * Pull `permissionMode` out of the post-validation `IAgentCreateSessionConfig.config`
 	 * bag, narrowing the runtime `unknown` value to the SDK's six-value
 	 * `PermissionMode` union (sdk.d.ts:1560). Falls back to `'default'`
@@ -835,12 +912,19 @@ export class ClaudeAgent extends Disposable implements IAgent {
 		return this._sessionSequencer.queue(sessionId, async () => {
 			let session = this._sessions.get(sessionId)?.session;
 			if (!session) {
-				if (!this._provisionalSessions.has(sessionId)) {
-					throw new Error(`Cannot send to unknown session: ${sessionId}`);
+				if (this._provisionalSessions.has(sessionId)) {
+					// Materialize seeds permissionMode via Options.permissionMode,
+					// so no setPermissionMode call needed on this turn.
+					session = await this._materializeProvisional(sessionId);
+				} else {
+					// Session exists on disk (created in another window or
+					// before agent restart) but has no in-memory state in
+					// this agent instance. Reconstruct a provisional record
+					// from the SDK transcript + metadata overlay and bring
+					// it up under `Options.resume` so the SDK reloads the
+					// existing history rather than minting a fresh one.
+					session = await this._resumeSession(sessionId, sessionUri);
 				}
-				// Materialize seeds permissionMode via Options.permissionMode,
-				// so no setPermissionMode call needed on this turn.
-				session = await this._materializeProvisional(sessionId);
 			} else {
 				// Plan S3.6: forward live `permissionMode` to the bound
 				// `Query` immediately before yielding the next user message

--- a/src/vs/platform/agentHost/node/claude/claudeAgent.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgent.ts
@@ -941,7 +941,18 @@ export class ClaudeAgent extends Disposable implements IAgent {
 				// so a `SessionConfigChanged` action that arrived between
 				// turns wins. Awaited so the SDK has acknowledged the mode
 				// change before `session.send(...)` yields the next prompt.
-				await session.setPermissionMode(this._readSessionPermissionMode(sessionUri) ?? 'default');
+				//
+				// Only call when the config carries an actual value:
+				// `_readSessionPermissionMode` returns `undefined` when
+				// the session's schema hasn't been registered (e.g. a
+				// cross-window resume that bypassed AgentService's
+				// schema-registration path), and falling back to
+				// `'default'` here would silently overwrite the
+				// session's seeded bijective state with the wrong mode.
+				const liveMode = this._readSessionPermissionMode(sessionUri);
+				if (liveMode !== undefined) {
+					await session.setPermissionMode(liveMode);
+				}
 			}
 
 			const contentBlocks = resolvePromptToContentBlocks(prompt, attachments);

--- a/src/vs/platform/agentHost/node/claude/claudeMaterializer.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeMaterializer.ts
@@ -70,17 +70,19 @@ export class ClaudeMaterializer {
 		proxyHandle: IClaudeProxyHandle,
 		permissionMode: ClaudePermissionMode,
 		canUseTool: NonNullable<Options['canUseTool']>,
+		startMode: 'fresh' | 'resume' = 'fresh',
 	): Promise<ClaudeAgentSession> {
 		if (!provisional.workingDirectory) {
 			throw new Error(`Cannot materialize Claude session ${provisional.sessionId}: workingDirectory is required`);
 		}
 
-		const options = await this._buildOptions(provisional, proxyHandle, permissionMode, canUseTool, false);
+		const isResume = startMode === 'resume';
+		const options = await this._buildOptions(provisional, proxyHandle, permissionMode, canUseTool, isResume);
 
 		// Trace what the SDK gets so live debugging doesn't have to infer
 		// from the absence of a `fileEdit` block whether the edit-tracking
 		// plumbing was wired this session.
-		this._logService.info(`[Claude] session ${provisional.sessionId}: enableFileCheckpointing=${options.enableFileCheckpointing} startMode=fresh`);
+		this._logService.info(`[Claude] session ${provisional.sessionId}: enableFileCheckpointing=${options.enableFileCheckpointing} startMode=${startMode}`);
 
 		const warm = await this._sdkService.startup({ options });
 

--- a/src/vs/platform/agentHost/node/claude/phase8.5-plan.md
+++ b/src/vs/platform/agentHost/node/claude/phase8.5-plan.md
@@ -4,7 +4,7 @@
 > Last updated: 2026-05-15 after 3-model council (GPT-5.5, Claude Opus 4.6,
 > GPT-5.3-Codex). Pre-grilling draft.
 
-**Status:** implemented (E2E partially validated live; rest covered by unit tests)
+**Status:** ✅ **DONE** (merged to main; E2E verified live)
 
 ## Goal
 

--- a/src/vs/platform/agentHost/node/claude/roadmap.md
+++ b/src/vs/platform/agentHost/node/claude/roadmap.md
@@ -803,7 +803,7 @@ client-side accept of one and reject of the other behaves correctly.
 Exit criteria: file diffs render in the workbench; per-file accept/reject
 works.
 
-### Phase 8.5 — Rich tool-call rendering parity with Copilot
+### Phase 8.5 — Rich tool-call rendering parity with Copilot ✅ **DONE**
 
 Claude's tool-call cards today only carry the static display name from
 [`claudeToolDisplay.ts`](./claudeToolDisplay.ts) (`"Run shell command"`,

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -1859,6 +1859,93 @@ suite('ClaudeAgent', () => {
 		});
 	});
 
+	test('sendMessage on a disk-only session (created in another window) resumes from disk', async () => {
+		// Regression for: "Open a session that was not started in the
+		// active window, send it a message → Error: Cannot send to
+		// unknown session: <id>". Before the fix, sendMessage's else
+		// branch (no `_sessions` entry AND no `_provisionalSessions`
+		// entry) threw outright. After the fix it routes through
+		// `_resumeSession`, which mirrors CopilotAgent._resumeSession:
+		// read `cwd` from `sdkService.getSessionInfo`, model + permission
+		// mode from the metadata overlay, build an on-the-fly provisional
+		// record, and materialize with `startMode: 'resume'` so the SDK
+		// loads the existing transcript via `Options.resume` instead of
+		// minting a fresh sessionId via `Options.sessionId`.
+		const { agent, sdk } = createTestContext(disposables);
+		await agent.authenticate(GITHUB_COPILOT_PROTECTED_RESOURCE.resource, 'tok');
+
+		// Stage a session that exists on disk (in the SDK's transcript
+		// store) but was never createSession'd on this agent instance.
+		const sessionId = 'cross-window-session-id';
+		const sessionUri = AgentSession.uri('claude', sessionId);
+		sdk.sessionList = [{
+			sessionId,
+			summary: 'From another window',
+			lastModified: 5000,
+			createdAt: 4900,
+			cwd: URI.file('/work').fsPath,
+		}];
+		sdk.nextQueryMessages = [
+			makeSystemInitMessage(sessionId),
+			makeResultSuccess(sessionId),
+		];
+
+		const events: IAgentMaterializeSessionEvent[] = [];
+		disposables.add(agent.onDidMaterializeSession(e => events.push(e)));
+
+		await agent.sendMessage(sessionUri, 'hi', undefined, 'turn-1');
+
+		assert.deepStrictEqual({
+			startupCallCount: sdk.startupCallCount,
+			materializeEventCount: events.length,
+			eventSession: events[0]?.session.toString(),
+			eventCwd: events[0]?.workingDirectory?.fsPath,
+			startupOptionsCwd: sdk.capturedStartupOptions[0]?.cwd,
+			// In resume mode the SDK gets `Options.resume = <id>` and
+			// MUST NOT get `Options.sessionId`.
+			startupOptionsResume: sdk.capturedStartupOptions[0]?.resume,
+			startupOptionsSessionId: sdk.capturedStartupOptions[0]?.sessionId,
+			sessionInMap: agent.getSessionForTesting(sessionUri) !== undefined,
+		}, {
+			startupCallCount: 1,
+			materializeEventCount: 1,
+			eventSession: sessionUri.toString(),
+			eventCwd: URI.file('/work').fsPath,
+			startupOptionsCwd: URI.file('/work').fsPath,
+			startupOptionsResume: sessionId,
+			startupOptionsSessionId: undefined,
+			sessionInMap: true,
+		});
+	});
+
+	test('sendMessage on a disk-only session whose SDK record is missing throws "unknown session"', async () => {
+		// Defense-in-depth pair to the resume-from-disk test above. If
+		// the SDK has no record of the session id at all (e.g. the
+		// transcript file was deleted out from under us), `_resumeSession`
+		// must surface a clear error rather than silently fabricating a
+		// fresh session bound to the wrong cwd. Also pins: no SDK startup
+		// is performed in this failure path (no subprocess spawn for a
+		// session we can't actually resume).
+		const { agent, sdk } = createTestContext(disposables);
+		await agent.authenticate(GITHUB_COPILOT_PROTECTED_RESOURCE.resource, 'tok');
+
+		const sessionUri = AgentSession.uri('claude', 'ghost-session-id');
+		// sdk.sessionList stays empty — getSessionInfo resolves undefined.
+
+		const sendErr = await agent.sendMessage(sessionUri, 'hi', undefined, 'turn-1')
+			.then(() => undefined, err => err);
+
+		assert.deepStrictEqual({
+			startupCallCount: sdk.startupCallCount,
+			sendThrewUnknown: sendErr instanceof Error && /unknown session/i.test(sendErr.message),
+			sessionAbsent: agent.getSessionForTesting(sessionUri) === undefined,
+		}, {
+			startupCallCount: 0,
+			sendThrewUnknown: true,
+			sessionAbsent: true,
+		});
+	});
+
 	test('shutdown drains a mix of provisional and materialized sessions', async () => {
 		// Phase 6 §5.1 Test 13. The shutdown spec is two-phase:
 		//  1) Provisional sessions: abort each AbortController + clear

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -511,13 +511,17 @@ class CapturingLogService extends NullLogService {
 
 function createTestContext(
 	disposables: Pick<DisposableStore, 'add'>,
-	overrides?: { logService?: ILogService },
+	overrides?: { logService?: ILogService; database?: TestSessionDatabase },
 ): ITestContext {
 	const proxy = new FakeClaudeProxyService();
 	const api = new FakeCopilotApiService();
 	api.models = async () => [...ALL_MODELS];
 	const sdk = new FakeClaudeAgentSdkService();
-	const sessionData = new RecordingSessionDataService(createSessionDataService());
+	const sessionData = new RecordingSessionDataService(
+		overrides?.database
+			? createSessionDataService(overrides.database)
+			: createSessionDataService()
+	);
 	const logService = overrides?.logService ?? new NullLogService();
 	const stateManager = disposables.add(new AgentHostStateManager(logService));
 	const configService = disposables.add(new AgentConfigurationService(stateManager, logService));
@@ -1943,6 +1947,59 @@ suite('ClaudeAgent', () => {
 			startupCallCount: 0,
 			sendThrewUnknown: true,
 			sessionAbsent: true,
+		});
+	});
+
+	test('resumed session keeps overlay-derived permissionMode on turn 2 (no silent flip to default)', async () => {
+		// Regression for Copilot review feedback on the cross-window
+		// resume PR. Before the fix, the materialized-session branch in
+		// `sendMessage` unconditionally called
+		// `session.setPermissionMode(_readSessionPermissionMode(uri) ?? 'default')`
+		// on turn 2. For a cross-window-resumed session, AgentService
+		// never registered the per-session schema (that happens via
+		// `sessionAdded` for createSession-spawned sessions), so
+		// `_readSessionPermissionMode` returned `undefined`, the
+		// fallback `'default'` won, and a plan-mode session silently
+		// downgraded to default mode mid-conversation.
+		//
+		// The fix: only forward `setPermissionMode` when the live config
+		// actually carries a value, leaving the session's seeded
+		// bijective state (set via `seedBijectiveState` at resume time)
+		// authoritative otherwise.
+		//
+		// Setup: stage the per-session DB with `claude.permissionMode='plan'`,
+		// then run two turns. Turn 1 picks up the mode via
+		// `Options.permissionMode` at materialize. Turn 2 must NOT
+		// record an extra `setPermissionMode` call.
+		const sessionId = 'cross-window-mode-session';
+		const sessionUri = AgentSession.uri('claude', sessionId);
+
+		const db = new TestSessionDatabase();
+		await db.setMetadata('claude.permissionMode', 'plan');
+
+		const { agent, sdk } = createTestContext(disposables, { database: db });
+		await agent.authenticate(GITHUB_COPILOT_PROTECTED_RESOURCE.resource, 'tok');
+
+		sdk.sessionList = [{
+			sessionId,
+			summary: 'From another window (plan mode)',
+			lastModified: 5000,
+			createdAt: 4900,
+			cwd: URI.file('/work').fsPath,
+		}];
+		sdk.nextQueryMessages = [makeSystemInitMessage(sessionId), makeResultSuccess(sessionId)];
+		await agent.sendMessage(sessionUri, 'turn-1', undefined, 't1');
+
+		sdk.nextQueryMessages = [makeResultSuccess(sessionId)];
+		await agent.sendMessage(sessionUri, 'turn-2', undefined, 't2');
+
+		const fakeQuery = sdk.warmQueries.at(-1)?.produced;
+		assert.deepStrictEqual({
+			optionsPermissionMode: sdk.capturedStartupOptions[0]?.permissionMode,
+			recordedModes: fakeQuery?.recordedPermissionModes ?? [],
+		}, {
+			optionsPermissionMode: 'plan',
+			recordedModes: ['plan'],
 		});
 	});
 


### PR DESCRIPTION
Repro: open a Claude session in window A, then in window B (or after
an agent-host restart) send a message to that session.

Before: sendMessage hit the 'session not in _sessions and not
provisional' branch and threw 'Cannot send to unknown session: <id>',
because materialize was only ever reachable via the createSession
provisional path.

After: that branch routes through new _resumeSession(sessionId, uri),
which mirrors CopilotAgent._resumeSession — reads workingDirectory
from sdkService.getSessionInfo, model + permissionMode from the
metadata overlay, synthesises an IClaudeMaterializeProvisional, and
calls materializer.materialize(..., 'resume') so the SDK reloads the
existing transcript instead of minting a fresh sessionId.

ClaudeMaterializer.materialize gains an optional startMode parameter
('fresh' | 'resume', default 'fresh') that selects Options.sessionId
vs Options.resume in _buildOptions. The existing fresh-startup call
sites are unchanged.

Tests: existing 'disposing a provisional session never calls SDK
startup' assertion still passes — the new error wording 'Cannot
resume unknown session' still matches /unknown session/i, and
_resumeSession throws before startup when the fake SDK has no
session record.