### PR TITLE
Fix Copilot CLI sessions hanging on patch apply after stream close

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
@@ -47,6 +47,7 @@ import { type McCommand, type McEvent, type McSessionCreateResult, MissionContro
 import { handleMcpPermission, handleReadPermission, handleShellPermission, handleWritePermission, type PermissionRequest, type PermissionRequestResult, showInteractivePermissionPrompt } from './permissionHelpers';
 import { TodoSqlQuery } from './todoSqlQuery';
 import { IQuestion, IQuestionAnswer, IUserQuestionHandler } from './userInputHelpers';
+import { createSingleCallFunction } from '../../../../util/vs/base/common/functional';
 
 /**
  * Known commands that can be sent to a CopilotCLI session instead of a free-form prompt.
@@ -109,7 +110,7 @@ class CopilotCLIResponseStreamRouter {
 		textEdit: (target: vscode.Uri, editsOrDone: vscode.TextEdit | vscode.TextEdit[] | true): void => { this._call('textEdit', [target, editsOrDone]); },
 		notebookEdit: (target: vscode.Uri, editsOrDone: vscode.NotebookEdit | vscode.NotebookEdit[] | true): void => { this._call('notebookEdit', [target, editsOrDone]); },
 		workspaceEdit: (edits: vscode.ChatWorkspaceFileEdit[]): void => { this._call('workspaceEdit', [edits]); },
-		externalEdit: (target: vscode.Uri | vscode.Uri[], callback: () => Thenable<unknown>): Thenable<string> => this._call('externalEdit', [target, callback]) as Thenable<string>,
+		externalEdit: (target: vscode.Uri | vscode.Uri[], callback: () => Thenable<unknown>): Thenable<string> => this._call('externalEdit', [target, createSingleCallFunction(callback)]) as Thenable<string>,
 		markdownWithVulnerabilities: (value: string | vscode.MarkdownString, vulnerabilities: vscode.ChatVulnerability[]): void => { this._call('markdownWithVulnerabilities', [value, vulnerabilities]); },
 		codeblockUri: (uri: vscode.Uri, isEdit?: boolean): void => { this._call('codeblockUri', [uri, isEdit]); },
 		confirmation: (title: string, message: string | vscode.MarkdownString, data: unknown, buttons?: string[]): void => { this._call('confirmation', [title, message, data, buttons]); },
@@ -123,7 +124,7 @@ class CopilotCLIResponseStreamRouter {
 		clearToPreviousToolInvocation: (reason: vscode.ChatResponseClearToPreviousToolInvocationReason): void => { this._call('clearToPreviousToolInvocation', [reason]); },
 		usage: (usage: vscode.ChatResultUsage): void => { this._call('usage', [usage]); },
 	};
-	private static readonly _closedStreamErrorMessage = 'Response stream has been closed';
+	private static readonly _closedStreamErrorFragment = 'Response stream has been closed'.toLowerCase();
 
 	constructor(
 		private readonly _logService: ILogService,
@@ -141,6 +142,14 @@ class CopilotCLIResponseStreamRouter {
 				this._stream = undefined;
 			}
 		});
+	}
+
+	private static _isClosedStreamError(error: unknown): boolean {
+		if (!error) {
+			return false;
+		}
+		const message = error instanceof Error ? error.message : String(error);
+		return message.toLowerCase().includes(CopilotCLIResponseStreamRouter._closedStreamErrorFragment);
 	}
 
 	private _call(method: string, args: unknown[]): unknown {
@@ -166,7 +175,7 @@ class CopilotCLIResponseStreamRouter {
 	}
 
 	private _handleCallError(error: unknown, method: string, args: unknown[], stream: vscode.ChatResponseStream): unknown {
-		if (error instanceof Error && error.message === CopilotCLIResponseStreamRouter._closedStreamErrorMessage) {
+		if (CopilotCLIResponseStreamRouter._isClosedStreamError(error)) {
 			if (this._stream === stream) {
 				this._stream = undefined;
 			}

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
@@ -94,6 +94,104 @@ interface McSharedState {
 }
 const mcStateBySessionId = new Map<string, McSharedState>();
 
+class CopilotCLIResponseStreamRouter {
+	private _stream: vscode.ChatResponseStream | undefined;
+	private readonly _routedStream: vscode.ChatResponseStream = {
+		markdown: (value: string | vscode.MarkdownString): void => { this._call('markdown', [value]); },
+		anchor: (value: vscode.Uri | vscode.Location, title?: string): void => { this._call('anchor', [value, title]); },
+		button: (command: vscode.Command): void => { this._call('button', [command]); },
+		filetree: (value: vscode.ChatResponseFileTree[], baseUri: vscode.Uri): void => { this._call('filetree', [value, baseUri]); },
+		progress: (value: string, task?: (progress: vscode.Progress<vscode.ChatResponseWarningPart | vscode.ChatResponseReferencePart>) => Thenable<string | void>): void => { this._call('progress', [value, task]); },
+		reference: (value: vscode.Uri | vscode.Location | { variableName: string; value?: vscode.Uri | vscode.Location }, iconPath?: vscode.Uri | vscode.ThemeIcon | { light: vscode.Uri; dark: vscode.Uri }): void => { this._call('reference', [value, iconPath]); },
+		push: (part: vscode.ExtendedChatResponsePart): void => { this._call('push', [part]); },
+		thinkingProgress: (thinkingDelta: vscode.ThinkingDelta): void => { this._call('thinkingProgress', [thinkingDelta]); },
+		hookProgress: (hookType: vscode.ChatHookType, stopReason?: string, systemMessage?: string): void => { this._call('hookProgress', [hookType, stopReason, systemMessage]); },
+		textEdit: (target: vscode.Uri, editsOrDone: vscode.TextEdit | vscode.TextEdit[] | true): void => { this._call('textEdit', [target, editsOrDone]); },
+		notebookEdit: (target: vscode.Uri, editsOrDone: vscode.NotebookEdit | vscode.NotebookEdit[] | true): void => { this._call('notebookEdit', [target, editsOrDone]); },
+		workspaceEdit: (edits: vscode.ChatWorkspaceFileEdit[]): void => { this._call('workspaceEdit', [edits]); },
+		externalEdit: (target: vscode.Uri | vscode.Uri[], callback: () => Thenable<unknown>): Thenable<string> => this._call('externalEdit', [target, callback]) as Thenable<string>,
+		markdownWithVulnerabilities: (value: string | vscode.MarkdownString, vulnerabilities: vscode.ChatVulnerability[]): void => { this._call('markdownWithVulnerabilities', [value, vulnerabilities]); },
+		codeblockUri: (uri: vscode.Uri, isEdit?: boolean): void => { this._call('codeblockUri', [uri, isEdit]); },
+		confirmation: (title: string, message: string | vscode.MarkdownString, data: unknown, buttons?: string[]): void => { this._call('confirmation', [title, message, data, buttons]); },
+		questionCarousel: (questions: vscode.ChatQuestion[], allowSkip?: boolean): Thenable<Record<string, unknown> | undefined> => this._call('questionCarousel', [questions, allowSkip]) as Thenable<Record<string, unknown> | undefined>,
+		warning: (message: string | vscode.MarkdownString): void => { this._call('warning', [message]); },
+		info: (message: string | vscode.MarkdownString): void => { this._call('info', [message]); },
+		reference2: (value: vscode.Uri | vscode.Location | string | { variableName: string; value?: vscode.Uri | vscode.Location }, iconPath?: vscode.Uri | vscode.ThemeIcon | { light: vscode.Uri; dark: vscode.Uri }, options?: { status?: { description: string; kind: vscode.ChatResponseReferencePartStatusKind } }): void => { this._call('reference2', [value, iconPath, options]); },
+		codeCitation: (value: vscode.Uri, license: string, snippet: string): void => { this._call('codeCitation', [value, license, snippet]); },
+		beginToolInvocation: (toolCallId: string, toolName: string, streamData?: vscode.ChatToolInvocationStreamData & { subagentInvocationId?: string }): void => { this._call('beginToolInvocation', [toolCallId, toolName, streamData]); },
+		updateToolInvocation: (toolCallId: string, streamData: vscode.ChatToolInvocationStreamData): void => { this._call('updateToolInvocation', [toolCallId, streamData]); },
+		clearToPreviousToolInvocation: (reason: vscode.ChatResponseClearToPreviousToolInvocationReason): void => { this._call('clearToPreviousToolInvocation', [reason]); },
+		usage: (usage: vscode.ChatResultUsage): void => { this._call('usage', [usage]); },
+	};
+	private static readonly _closedStreamErrorMessage = 'Response stream has been closed';
+
+	constructor(
+		private readonly _logService: ILogService,
+		private readonly _sessionId: string,
+	) { }
+
+	get stream(): vscode.ChatResponseStream {
+		return this._routedStream;
+	}
+
+	attach(stream: vscode.ChatResponseStream): IDisposable {
+		this._stream = stream;
+		return toDisposable(() => {
+			if (this._stream === stream) {
+				this._stream = undefined;
+			}
+		});
+	}
+
+	private _call(method: string, args: unknown[]): unknown {
+		const stream = this._stream;
+		if (!stream) {
+			return this._fallback(method, args);
+		}
+
+		const fn = (stream as unknown as Record<string, unknown>)[method];
+		if (typeof fn !== 'function') {
+			return this._fallback(method, args);
+		}
+
+		try {
+			const result = fn.apply(stream, args);
+			if (method === 'externalEdit' || method === 'questionCarousel') {
+				return Promise.resolve(result).catch(error => this._handleCallError(error, method, args, stream));
+			}
+			return result;
+		} catch (error) {
+			return this._handleCallError(error, method, args, stream);
+		}
+	}
+
+	private _handleCallError(error: unknown, method: string, args: unknown[], stream: vscode.ChatResponseStream): unknown {
+		if (error instanceof Error && error.message === CopilotCLIResponseStreamRouter._closedStreamErrorMessage) {
+			if (this._stream === stream) {
+				this._stream = undefined;
+			}
+			this._logService.trace(`[CopilotCLISession] Dropping ${method} for closed response stream in session ${this._sessionId}`);
+			return this._fallback(method, args);
+		}
+		throw error;
+	}
+
+	private _fallback(method: string, args: unknown[]): unknown {
+		if (method === 'externalEdit') {
+			const callback = args[1];
+			if (typeof callback === 'function') {
+				// The callback is the caller's proceed signal; dropping it would stall the tool when only the UI stream is gone.
+				return Promise.resolve().then(() => (callback as () => Thenable<unknown>)()).then(() => '');
+			}
+			return Promise.resolve('');
+		}
+		if (method === 'questionCarousel') {
+			return Promise.resolve(undefined);
+		}
+		return undefined;
+	}
+}
+
 const MISSION_CONTROL_KEEPALIVE_INTERVAL_MS = 10_000;
 
 type MissionControlMode = 'plan' | 'autopilot' | 'interactive';
@@ -760,7 +858,8 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 	}
 	private _onDidChangeTitle = this.add(new Emitter<string>());
 	public onDidChangeTitle = this._onDidChangeTitle.event;
-	private _stream?: vscode.ChatResponseStream;
+	private readonly _streamRouter: CopilotCLIResponseStreamRouter;
+	private readonly _stream: vscode.ChatResponseStream;
 	private _toolInvocationToken?: ChatParticipantToolToken;
 	public get sdkSession() {
 		return this._sdkSession;
@@ -820,17 +919,14 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 	) {
 		super();
 		this.sessionId = _sdkSession.sessionId;
+		this._streamRouter = new CopilotCLIResponseStreamRouter(this.logService, this.sessionId);
+		this._stream = this._streamRouter.stream;
 		this._missionControlApiClient = this.instantiationService.createInstance(MissionControlApiClient);
 		this.add(toDisposable(() => this._todoSqlQuery.dispose()));
 	}
 
 	attachStream(stream: vscode.ChatResponseStream): IDisposable {
-		this._stream = stream;
-		return toDisposable(() => {
-			if (this._stream === stream) {
-				this._stream = undefined;
-			}
-		});
+		return this._streamRouter.attach(stream);
 	}
 
 	public setPermissionLevel(level: string | undefined): void {

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotcliSession.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotcliSession.spec.ts
@@ -5,7 +5,7 @@
 
 import type { Session, SessionOptions } from '@github/copilot/sdk';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { ChatParticipantToolToken } from 'vscode';
+import type { ChatParticipantToolToken, ChatResponseStream } from 'vscode';
 import { ConfigKey, IConfigurationService } from '../../../../../platform/configuration/common/configurationService';
 import { ILogService } from '../../../../../platform/log/common/logService';
 import { NoopOTelService, resolveOTelConfig } from '../../../../../platform/otel/common/index';
@@ -286,6 +286,80 @@ describe('CopilotCLISession', () => {
 		expect(session.status).toBe(ChatSessionStatus.Completed);
 		expect(stream.output.join('\n')).toContain('Echo: Hello');
 		// Listeners are disposed after completion, so we only assert original streamed content.
+	});
+
+	it('routes in-flight output to the latest attached stream', async () => {
+		let continueSend!: () => void;
+		let markSendStarted!: () => void;
+		const sendStarted = new Promise<void>(resolve => { markSendStarted = resolve; });
+		sdkSession.send = async ({ prompt }) => {
+			sdkSession.emit('user.message', { content: prompt });
+			markSendStarted();
+			await new Promise<void>(resolve => { continueSend = resolve; });
+			sdkSession.emit('assistant.message', { messageId: 'after-reattach', content: 'After reattach' });
+		};
+
+		const session = await createSession();
+		const firstStream = new MockChatResponseStream();
+		const firstStreamAttachment = disposables.add(session.attachStream(firstStream));
+		const request = session.handleRequest({ id: '', toolInvocationToken: undefined as never }, { prompt: 'Hello' }, [], undefined, authInfo, CancellationToken.None);
+		await sendStarted;
+
+		const secondStream = new MockChatResponseStream();
+		disposables.add(session.attachStream(secondStream));
+		firstStreamAttachment.dispose();
+		continueSend();
+		await request;
+
+		expect(firstStream.output.join('\n')).not.toContain('After reattach');
+		expect(secondStream.output.join('\n')).toContain('After reattach');
+	});
+
+	it('routed response stream is not thenable', async () => {
+		const session = await createSession();
+		const routedStream = (session as unknown as { readonly _stream: unknown })._stream;
+
+		await expect(Promise.race([
+			Promise.resolve(routedStream).then(value => value === routedStream),
+			new Promise<boolean>(resolve => setTimeout(() => resolve(false), 10)),
+		])).resolves.toBe(true);
+	});
+
+	it('drops writes to a closed attached stream', async () => {
+		class ClosedChatResponseStream extends MockChatResponseStream {
+			override markdown(): void {
+				throw new Error('Response stream has been closed');
+			}
+		}
+
+		sdkSession.send = async () => {
+			sdkSession.emit('assistant.message', { messageId: 'closed-stream', content: 'Dropped' });
+		};
+
+		const session = await createSession();
+		disposables.add(session.attachStream(new ClosedChatResponseStream()));
+		await session.handleRequest({ id: '', toolInvocationToken: undefined as never }, { prompt: 'Hello' }, [], undefined, authInfo, CancellationToken.None);
+
+		expect(session.status).toBe(ChatSessionStatus.Completed);
+	});
+
+	it('falls back when async stream methods reject as closed', async () => {
+		class ClosedExternalEditStream extends MockChatResponseStream {
+			override externalEdit(): Promise<string> {
+				return Promise.reject(new Error('Response stream has been closed'));
+			}
+		}
+
+		const session = await createSession();
+		disposables.add(session.attachStream(new ClosedExternalEditStream()));
+		const routedStream = (session as unknown as { readonly _stream: ChatResponseStream })._stream;
+		let callbackRan = false;
+
+		await expect(routedStream.externalEdit(Uri.file('/workspace/file.ts'), async () => {
+			callbackRan = true;
+		})).resolves.toBe('');
+
+		expect(callbackRan).toBe(true);
 	});
 
 	it('switches model when different modelId provided', async () => {

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotcliSession.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotcliSession.spec.ts
@@ -362,6 +362,26 @@ describe('CopilotCLISession', () => {
 		expect(callbackRan).toBe(true);
 	});
 
+	it('does not re-invoke externalEdit callback when the underlying call already started it', async () => {
+		class MidFlightCloseStream extends MockChatResponseStream {
+			override async externalEdit(_target: Uri | Uri[], callback: () => Thenable<unknown>): Promise<string> {
+				await callback();
+				throw new Error('Response stream has been closed');
+			}
+		}
+
+		const session = await createSession();
+		disposables.add(session.attachStream(new MidFlightCloseStream()));
+		const routedStream = (session as unknown as { readonly _stream: ChatResponseStream })._stream;
+		let invocations = 0;
+
+		await expect(routedStream.externalEdit(Uri.file('/workspace/file.ts'), async () => {
+			invocations++;
+		})).resolves.toBe('');
+
+		expect(invocations).toBe(1);
+	});
+
 	it('switches model when different modelId provided', async () => {
 		const session = await createSession();
 		const stream = new MockChatResponseStream();

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotcliSession.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotcliSession.spec.ts
@@ -1827,9 +1827,9 @@ describe('CopilotCLISession', () => {
 			await Promise.all([firstRequest, remoteRequest]);
 
 			firstTokenSource.dispose(true);
-			expect(firstStream.output.join('')).toContain('Echo: First prompt');
+			expect(firstStream.output.join('')).toEqual('');
 			const output = remoteStream.output.join('');
-			expect(output).not.toContain('Echo: First prompt');
+			expect(output).toContain('Echo: First prompt');
 			expect(output).toContain('Remote control is disabled. Use /remote on to enable it.');
 		});
 

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/test/copilotCLIChatSessionParticipant.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/test/copilotCLIChatSessionParticipant.spec.ts
@@ -254,6 +254,7 @@ async function waitForScheduledUntitledSwap(): Promise<void> {
 
 class TestCopilotCLISession extends CopilotCLISession {
 	public requests: Array<{ input: CopilotCLISessionInput; attachments: Attachment[]; model: { model: string; reasoningEffort?: string } | undefined; authInfo: NonNullable<SessionOptions['authInfo']>; token: vscode.CancellationToken }> = [];
+	public readonly attachedStreams: vscode.ChatResponseStream[] = [];
 	public permissionLevel: string | undefined;
 	public static nextHandleRequestResult: Promise<void> | undefined;
 	public static handleRequestHook: ((request: { id: string; toolInvocationToken: vscode.ChatParticipantToolToken; sessionResource?: vscode.Uri }, input: CopilotCLISessionInput) => Promise<void>) | undefined;
@@ -268,6 +269,10 @@ class TestCopilotCLISession extends CopilotCLISession {
 			return TestCopilotCLISession.handleRequestHook(request, input);
 		}
 		return TestCopilotCLISession.nextHandleRequestResult ?? Promise.resolve();
+	}
+	override attachStream(stream: vscode.ChatResponseStream): ReturnType<CopilotCLISession['attachStream']> {
+		this.attachedStreams.push(stream);
+		return super.attachStream(stream);
 	}
 	override setPermissionLevel(level: string | undefined): void {
 		this.permissionLevel = level;
@@ -659,14 +664,29 @@ describe('CopilotCLIChatSessionParticipant.handleRequest', () => {
 		expect(itemProvider.swap).not.toHaveBeenCalled();
 	});
 
-	it.skip('returns early when yield is requested while the session is still running', async () => {
+	it('returns early when yield is requested and attaches steering stream while the session is still running', async () => {
 		const sessionId = 'existing-yield';
 		const sdkSession = new MockCliSdkSession(sessionId, new Date());
 		manager.sessions.set(sessionId, sdkSession);
-		let resolveHandleRequest!: () => void;
+		let resolveFirstRequest!: () => void;
+		let resolveSecondRequest!: () => void;
+		let resolveSecondRequestStarted!: () => void;
 		let yieldRequested = false;
-		TestCopilotCLISession.nextHandleRequestResult = new Promise<void>(resolve => {
-			resolveHandleRequest = resolve;
+		const firstRequestDeferred = new Promise<void>(resolve => {
+			resolveFirstRequest = resolve;
+		});
+		const secondRequestDeferred = new Promise<void>(resolve => {
+			resolveSecondRequest = resolve;
+		});
+		const secondRequestStarted = new Promise<void>(resolve => {
+			resolveSecondRequestStarted = resolve;
+		});
+		TestCopilotCLISession.handleRequestHook = vi.fn((_request, input) => {
+			if (input.prompt === 'Continue') {
+				return firstRequestDeferred;
+			}
+			resolveSecondRequestStarted();
+			return secondRequestDeferred;
 		});
 
 		const request = new TestChatRequest('Continue');
@@ -691,11 +711,24 @@ describe('CopilotCLIChatSessionParticipant.handleRequest', () => {
 		expect(resolved).toBe(false);
 
 		yieldRequested = true;
-		await new Promise(resolve => setTimeout(resolve, 600));
+		await new Promise(resolve => setTimeout(resolve, 150));
 		expect(resolved).toBe(true);
-
-		resolveHandleRequest();
 		await handlerPromise;
+
+		const steeringRequest = new TestChatRequest('Steer');
+		steeringRequest.sessionResource = request.sessionResource;
+		const steeringContext = createChatContext(sessionId, false, steeringRequest);
+		const steeringStream = new MockChatResponseStream();
+		const steeringToken = disposables.add(new CancellationTokenSource()).token;
+		const steeringPromise = participant.createHandler()(steeringRequest, steeringContext, steeringStream, steeringToken);
+		await secondRequestStarted;
+
+		expect(cliSessions[0].attachedStreams).toEqual([stream, steeringStream]);
+
+		resolveSecondRequest();
+		await steeringPromise;
+		resolveFirstRequest();
+		await new Promise(resolve => setTimeout(resolve, 0));
 	});
 
 	it('defers worktree handleRequestCompleted until all steering requests complete', async () => {


### PR DESCRIPTION
Fixes #316053

## Summary
Copilot CLI sessions could hang forever while applying patches whenever the chat stream closed mid-turn (most commonly after a steering yield, sometimes after a window reload). This wraps the session's response stream in a small router so an in-flight SDK turn survives its UI stream going away.


## Root Cause
When the participant yields for steering, VS Code closes the original
`ChatResponseStream` while the SDK turn keeps running in the background. The
next write throws `"Response stream has been closed"` from `throwIfDone`.

The fatal case is `ExternalEditTracker.trackEdit`, which only resolves once
`externalEdit`'s callback fires:

```ts
const onDidComplete = stream.externalEdit(uris, async () => {
		proceedWithEdit();   // never called if externalEdit throws synchronously
		await deferred.p;
});
```

A synchronous throw skips the callback, so proceedWithEdit never runs, the
patch-apply step awaits a promise nothing will resolve, and the session is
stuck until the window is reloaded.

Figure 1: Copilot CLI Patch Application Hang Forever After Mid-Turn Stream Closure
<img width="802" height="751" alt="image" src="https://github.com/user-attachments/assets/e6a00a3f-1873-48dc-96b4-917b4b7414b2" />


## Fix
Introduce `CopilotCLIResponseStreamRouter`, a stable facade that the session holds for its lifetime:
- attachStream swaps the target behind the router, so in-flight turns always reach the currently active stream (or are dropped when none is).
- Writes that throw "Response stream has been closed" clear the target and fall through to a no-op — correct when no UI is listening.
- externalEdit's fallback still invokes the callback, then resolves with an empty undoStopId. This is the single change that unblocks the SDK and fixes the hang.
- questionCarousel's fallback resolves to undefined, matching a dismissed prompt.


## Validation

Figure 2: Copilot CLI Patch Application No Longer Gets Stuck and Session Continues
<img width="930" height="711" alt="image" src="https://github.com/user-attachments/assets/f5bab3c7-8b95-496c-9a9f-041c13dee3fe" />
