### PR TITLE
sessions: remove session deduplication

### DIFF
--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -121,7 +121,6 @@ export class AgentHostSessionAdapter implements ISession {
 	readonly mainChat: IChat;
 	readonly chats: IObservable<readonly IChat[]>;
 	readonly capabilities = { supportsMultipleChats: false };
-	readonly deduplicationKey: string;
 
 	readonly agentProvider: string;
 
@@ -152,7 +151,6 @@ export class AgentHostSessionAdapter implements ISession {
 			throw new Error(`Agent session URI has no provider scheme: ${metadata.session.toString()}`);
 		}
 		this.agentProvider = agentProvider;
-		this.deduplicationKey = metadata.session.toString();
 		this.resource = URI.from({ scheme: resourceScheme, path: `/${rawId}` });
 		this.sessionId = toSessionId(providerId, this.resource);
 		this.providerId = providerId;

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -22,7 +22,6 @@ import { ISessionsProvidersChangeEvent, ISessionsProvidersService } from './sess
 import { ISendRequestOptions, ISessionChangeEvent, ISessionsProvider } from '../common/sessionsProvider.js';
 import { IChat, ISession, SessionStatus, ISessionType } from '../common/session.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
-import { LOCAL_AGENT_HOST_PROVIDER_ID } from '../../../common/agentHostSessionsProvider.js';
 import { SessionsNavigation } from './sessionNavigation.js';
 
 const ACTIVE_SESSION_STATES_KEY = 'agentSessions.activeSessionStates';
@@ -194,7 +193,7 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 		for (const provider of this.sessionsProvidersService.getProviders()) {
 			sessions.push(...provider.getSessions());
 		}
-		return deduplicateSessions(sessions);
+		return sessions;
 	}
 
 	getSession(resource: URI): ISession | undefined {
@@ -793,36 +792,6 @@ class ActiveSession implements IActiveSession {
 	get chats() { return this._session.chats; }
 	get mainChat() { return this._session.mainChat; }
 	get capabilities() { return this._session.capabilities; }
-	get deduplicationKey() { return this._session.deduplicationKey; }
 }
 
 registerSingleton(ISessionsManagementService, SessionsManagementService, InstantiationType.Delayed);
-
-/**
- * Removes duplicate sessions across providers. When multiple sessions share
- * the same {@link ISession.deduplicationKey}, the session from the local
- * agent host provider is preferred; otherwise the first occurrence wins.
- */
-export function deduplicateSessions(sessions: ISession[]): ISession[] {
-	const seen = new Map<string, ISession>();
-	for (const session of sessions) {
-		const key = session.deduplicationKey;
-		if (!key) {
-			continue;
-		}
-		const existing = seen.get(key);
-		if (!existing) {
-			seen.set(key, session);
-		} else if (existing.providerId !== LOCAL_AGENT_HOST_PROVIDER_ID && session.providerId === LOCAL_AGENT_HOST_PROVIDER_ID) {
-			seen.set(key, session);
-		}
-	}
-
-	return sessions.filter(s => {
-		const key = s.deduplicationKey;
-		if (!key) {
-			return true;
-		}
-		return seen.get(key) === s;
-	});
-}

--- a/src/vs/sessions/services/sessions/common/session.ts
+++ b/src/vs/sessions/services/sessions/common/session.ts
@@ -261,13 +261,6 @@ export interface ISession {
 	readonly mainChat: IChat;
 	/** Capabilities of this session. */
 	readonly capabilities: ISessionCapabilities;
-	/**
-	 * Optional key used to deduplicate sessions across providers. When
-	 * multiple sessions share the same key, only one is kept by
-	 * {@link ISessionsManagementService.getSessions}. Local providers are
-	 * preferred over remote ones.
-	 */
-	readonly deduplicationKey?: string;
 }
 
 /**

--- a/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
@@ -11,7 +11,6 @@ import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { mock } from '../../../../../base/test/common/mock.js';
-import { LOCAL_AGENT_HOST_PROVIDER_ID } from '../../../../common/agentHostSessionsProvider.js';
 import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { MockContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
@@ -26,7 +25,7 @@ import { IChatEditorOptions } from '../../../../../workbench/contrib/chat/browse
 import { PreferredGroup } from '../../../../../workbench/services/editor/common/editorService.js';
 import { IChat, ISession, ISessionType, ISessionWorkspace } from '../../common/session.js';
 import { ISessionChangeEvent, ISendRequestOptions, ISessionsProvider } from '../../common/sessionsProvider.js';
-import { deduplicateSessions, SessionsManagementService } from '../../browser/sessionsManagementService.js';
+import { SessionsManagementService } from '../../browser/sessionsManagementService.js';
 import { ISessionsManagementService } from '../../common/sessionsManagement.js';
 import { ISessionsProvidersService } from '../../browser/sessionsProvidersService.js';
 
@@ -194,57 +193,6 @@ function createSessionsManagementService(session: ISession, disposables: ReturnT
 	return { service, chatWidgetService, agentSessionsService };
 }
 
-suite('deduplicateSessions', () => {
-
-	ensureNoDisposablesAreLeakedInTestSuite();
-
-	test('returns all sessions when no deduplication keys are set', () => {
-		const s1 = stubSession({ sessionId: 'a', providerId: 'p1' });
-		const s2 = stubSession({ sessionId: 'b', providerId: 'p2' });
-		const result = deduplicateSessions([s1, s2]);
-		assert.deepStrictEqual(result, [s1, s2]);
-	});
-
-	test('removes duplicate when same deduplicationKey appears across providers', () => {
-		const local = stubSession({ sessionId: 'local-1', providerId: LOCAL_AGENT_HOST_PROVIDER_ID, deduplicationKey: 'copilot:///abc123' });
-		const remote = stubSession({ sessionId: 'remote-1', providerId: 'agenthost-tunnel', deduplicationKey: 'copilot:///abc123' });
-		const result = deduplicateSessions([remote, local]);
-		assert.deepStrictEqual(result, [local]);
-	});
-
-	test('prefers local provider over remote regardless of order', () => {
-		const local = stubSession({ sessionId: 'local-1', providerId: LOCAL_AGENT_HOST_PROVIDER_ID, deduplicationKey: 'copilot:///abc123' });
-		const remote = stubSession({ sessionId: 'remote-1', providerId: 'agenthost-tunnel', deduplicationKey: 'copilot:///abc123' });
-
-		// local first
-		assert.deepStrictEqual(deduplicateSessions([local, remote]), [local]);
-		// remote first
-		assert.deepStrictEqual(deduplicateSessions([remote, local]), [local]);
-	});
-
-	test('keeps first occurrence when no local provider exists among duplicates', () => {
-		const r1 = stubSession({ sessionId: 'r1', providerId: 'agenthost-a', deduplicationKey: 'copilot:///abc123' });
-		const r2 = stubSession({ sessionId: 'r2', providerId: 'agenthost-b', deduplicationKey: 'copilot:///abc123' });
-		const result = deduplicateSessions([r1, r2]);
-		assert.deepStrictEqual(result, [r1]);
-	});
-
-	test('does not deduplicate sessions with different keys', () => {
-		const s1 = stubSession({ sessionId: 's1', providerId: LOCAL_AGENT_HOST_PROVIDER_ID, deduplicationKey: 'copilot:///aaa' });
-		const s2 = stubSession({ sessionId: 's2', providerId: 'agenthost-tunnel', deduplicationKey: 'copilot:///bbb' });
-		const result = deduplicateSessions([s1, s2]);
-		assert.deepStrictEqual(result, [s1, s2]);
-	});
-
-	test('mixes sessions with and without deduplication keys', () => {
-		const keyed1 = stubSession({ sessionId: 'k1', providerId: LOCAL_AGENT_HOST_PROVIDER_ID, deduplicationKey: 'copilot:///abc123' });
-		const keyed2 = stubSession({ sessionId: 'k2', providerId: 'agenthost-tunnel', deduplicationKey: 'copilot:///abc123' });
-		const noKey = stubSession({ sessionId: 'nk', providerId: 'copilot-chat' });
-		const result = deduplicateSessions([keyed2, noKey, keyed1]);
-		assert.deepStrictEqual(result, [noKey, keyed1]);
-	});
-});
-
 suite('SessionsManagementService', () => {
 
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
@@ -339,3 +287,4 @@ suite('SessionsManagementService', () => {
 		assert.strictEqual(service.activeSession.get()?.sessionId, 'original');
 	});
 });
+


### PR DESCRIPTION
## Summary

Removes the `deduplicationKey` concept from the sessions layer.

## Background

Previously, both the local (`local-agent-host`) and remote/tunnel (`agenthost-tunnel`) providers could expose the same underlying agent session simultaneously. Because `resource.scheme` is used for content provider routing, each provider assigns a different `resource` URI (e.g. `agent-host-copilot:///abc123` vs `remote-myhost-copilot:///abc123`) to the same session. Without deduplication, this caused the same session to appear twice in the sidebar.

The `deduplicationKey` (set to `metadata.session.toString()`, e.g. `copilot:///abc123`) was used in `getSessions()` to filter these duplicates out before returning sessions to consumers.

## Change

The deduplication is removed entirely. Duplicate sessions from different providers will appear as separate entries in the sidebar in the rare local+remote overlap scenario — this is considered acceptable.

### Files changed

- **`session.ts`** — Removed `deduplicationKey?: string` from `ISession` interface
- **`baseAgentHostSessionsProvider.ts`** — Removed `deduplicationKey` field and its assignment in `AgentHostSessionAdapter`
- **`sessionsManagementService.ts`** — Removed `deduplicateSessions()` function and its call in `getSessions()`, removed `deduplicationKey` proxy getter from `ActiveSession`, removed now-unused `LOCAL_AGENT_HOST_PROVIDER_ID` import
- **`sessionsManagementService.test.ts`** — Removed the `deduplicateSessions` test suite and related imports