### PR TITLE
agentHost: enable subagent integration test for Claude real SDK

### DIFF
--- a/src/vs/platform/agentHost/test/node/protocol/claudeRealSdk.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/claudeRealSdk.integrationTest.ts
@@ -59,14 +59,14 @@ const CLAUDE_CONFIG: IRealSdkProviderConfig = {
 	provider: 'claude',
 	scheme: 'claude',
 	shellToolName: 'Bash',
-	subagentToolName: 'Task',
+	subagentToolNames: ['Task', 'Agent'],
 	exitPlanModeToolName: 'ExitPlanMode',
 	enabled: REAL_SDK_ENABLED && !!CLAUDE_SDK_PATH,
 	claudeSdkPath: CLAUDE_SDK_PATH,
-	// Claude has not landed worktree isolation or subagents yet (deferred to
-	// Phase 12). The shared suite skips those tests when the flags are false.
+	// Claude has not landed worktree isolation yet (deferred to Phase 12).
+	// The shared suite skips that test when the flag is false.
 	supportsWorktreeIsolation: false,
-	supportsSubagents: false,
+	supportsSubagents: true,
 	// Plan mode is wired (`ExitPlanMode` interactive tool exists) but the
 	// shared test's Copilot-flavoured prompt doesn't reliably drive Claude
 	// to invoke it. TODO: rework the prompt for Claude conventions.

--- a/src/vs/platform/agentHost/test/node/protocol/copilotRealSdk.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/copilotRealSdk.integrationTest.ts
@@ -42,7 +42,7 @@ const COPILOT_CONFIG: IRealSdkProviderConfig = {
 	provider: 'copilotcli',
 	scheme: 'copilotcli',
 	shellToolName: 'bash',
-	subagentToolName: 'task',
+	subagentToolNames: ['task'],
 	exitPlanModeToolName: 'exit_plan_mode',
 	enabled: REAL_SDK_ENABLED,
 	supportsWorktreeIsolation: true,

--- a/src/vs/platform/agentHost/test/node/protocol/realSdkTestHelpers.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/realSdkTestHelpers.ts
@@ -79,10 +79,13 @@ export interface IRealSdkProviderConfig {
 	 */
 	readonly shellToolName: string;
 	/**
-	 * Tool name used by the provider for spawning a subagent. Used in the
-	 * subagent-routing prompt. (`task` for Copilot, `Task` for Claude.)
+	 * Tool names the provider uses to dispatch a subagent. The first entry
+	 * is used in the subagent-routing prompt; all entries are exempted from
+	 * the "parent must not contain inner tool calls" assertion. (`['task']`
+	 * for Copilot; Claude exposes both `Task` and `Agent` as subagent-kind
+	 * tools and the model may pick either.)
 	 */
-	readonly subagentToolName: string;
+	readonly subagentToolNames: readonly string[];
 	/**
 	 * Tool name used by the provider to confirm the user is ready to leave
 	 * plan mode. (`exit_plan_mode` for Copilot, `ExitPlanMode` for Claude.)
@@ -866,7 +869,7 @@ export function defineSharedRealSdkTests(config: IRealSdkProviderConfig): void {
 			})();
 
 			dispatchTurn(client, sessionUri, 'turn-sa',
-				`Use the \`${config.subagentToolName}\` tool to spawn a subagent to list the files in the current working directory. ` +
+				`Use the \`${config.subagentToolNames[0]}\` tool to spawn a subagent to list the files in the current working directory. ` +
 				'The subagent should call a single read-only tool (e.g. `view` or shell with `ls`) to enumerate the directory. ' +
 				'Do not enumerate the directory yourself — delegate to the subagent.',
 				1);
@@ -904,7 +907,8 @@ export function defineSharedRealSdkTests(config: IRealSdkProviderConfig): void {
 			const parentStarts = toolStarts.filter(t => t.channel === sessionUri).map(t => t.action);
 			const subagentStarts = toolStarts.filter(t => t.channel === subagentSessionUri).map(t => t.action);
 
-			const parentNonTaskStarts = parentStarts.filter(a => a.toolName !== config.subagentToolName);
+			const subagentToolNames = new Set<string>(config.subagentToolNames);
+			const parentNonTaskStarts = parentStarts.filter(a => !subagentToolNames.has(a.toolName));
 			assert.deepStrictEqual(parentNonTaskStarts.map(a => a.toolName), [],
 				`parent session should not contain inner tool calls; found: ${JSON.stringify(parentNonTaskStarts.map(a => a.toolName))}`);
 


### PR DESCRIPTION
Now that subagent routing is wired up for Claude, enable the shared subagent integration test for the Claude real-SDK suite.

### Changes

- Refactor `IRealSdkProviderConfig.subagentToolName` (string) to `subagentToolNames` (`readonly string[]`) so providers that expose multiple subagent-kind tools can list them all. The first entry is used in the test prompt; all entries are exempted from the *parent must not contain inner tool calls* assertion.
- Claude registers both `Task` and `Agent` as subagent-kind tools (see [`claudeToolDisplay.ts`](src/vs/platform/agentHost/node/claude/claudeToolDisplay.ts)) and the model may pick either when asked to spawn a subagent. List both.
- Flip `supportsSubagents: true` for the Claude config.
- Copilot config updated to use the new array shape (`['task']`).

### Verification

Both real-SDK suites pass end-to-end with `AGENT_HOST_REAL_SDK=1`:

```
Protocol WebSocket — Real Claude SDK
  ✔ subagent tool calls are routed to the subagent session, not flat in the parent (18s)
  ... 7 passing, 2 pending (worktree + plan mode still unsupported)

Protocol WebSocket — Real Copilot SDK
  ... 10 passing (no regression)
```