### PR TITLE
plugins: support git-subdir marketplace source kind

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/pluginSources.ts
+++ b/src/vs/workbench/contrib/chat/browser/pluginSources.ts
@@ -299,14 +299,32 @@ export class GitHubPluginSource extends AbstractGitPluginSource {
 export class GitUrlPluginSource extends AbstractGitPluginSource {
 	readonly kind = PluginSourceKind.GitUrl;
 
+	/** Returns the URI where the plugin content lives (repo root + optional sub-path). */
 	getInstallUri(cacheRoot: URI, descriptor: IPluginSourceDescriptor): URI {
+		const repoDir = this._getRepoDir(cacheRoot, descriptor);
+		const git = descriptor as IGitUrlPluginSource;
+		if (git.path) {
+			const normalizedPath = git.path.trim().replace(/^\.?\/+|\/+$/g, '');
+			if (normalizedPath) {
+				const target = joinPath(repoDir, normalizedPath);
+				if (isEqualOrParent(target, repoDir)) {
+					return target;
+				}
+			}
+		}
+		return repoDir;
+	}
+
+	/** Returns the cloned repository root (without sub-path). */
+	protected override _getRepoDir(cacheRoot: URI, descriptor: IPluginSourceDescriptor): URI {
 		const git = descriptor as IGitUrlPluginSource;
 		const segments = this._gitUrlCacheSegments(git.url, git.ref, git.sha);
 		return joinPath(cacheRoot, ...segments);
 	}
 
 	getLabel(descriptor: IPluginSourceDescriptor): string {
-		return (descriptor as IGitUrlPluginSource).url;
+		const git = descriptor as IGitUrlPluginSource;
+		return git.path ? `${git.url}/${git.path}` : git.url;
 	}
 
 	protected _cloneUrl(descriptor: IPluginSourceDescriptor): string {

--- a/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
@@ -68,6 +68,8 @@ export interface IGitUrlPluginSource {
 	readonly url: string;
 	readonly ref?: string;
 	readonly sha?: string;
+	/** Subdirectory within the repository where the plugin lives (for `git-subdir` sources). */
+	readonly path?: string;
 }
 
 export interface INpmPluginSource {
@@ -978,21 +980,31 @@ export function parsePluginSource(
 				path: rawSource.path,
 			};
 		}
-		case 'url': {
+		case 'url':
+		case 'git-subdir': {
 			if (typeof rawSource.url !== 'string' || !rawSource.url) {
-				logContext.logService.warn(`${logContext.logPrefix} Skipping plugin '${logContext.pluginName}': url source is missing required 'url' field`);
+				logContext.logService.warn(`${logContext.logPrefix} Skipping plugin '${logContext.pluginName}': ${rawSource.source} source is missing required 'url' field`);
 				return undefined;
 			}
-			if (!rawSource.url.toLowerCase().endsWith('.git')) {
+			if (rawSource.source === 'url' && !rawSource.url.toLowerCase().endsWith('.git')) {
 				logContext.logService.warn(`${logContext.logPrefix} Skipping plugin '${logContext.pluginName}': url source must end with '.git'`);
 				return undefined;
 			}
 			if (!isOptionalString(rawSource.ref)) {
-				logContext.logService.warn(`${logContext.logPrefix} Skipping plugin '${logContext.pluginName}': url source 'ref' must be a string when provided`);
+				logContext.logService.warn(`${logContext.logPrefix} Skipping plugin '${logContext.pluginName}': ${rawSource.source} source 'ref' must be a string when provided`);
 				return undefined;
 			}
 			if (!isOptionalGitSha(rawSource.sha)) {
-				logContext.logService.warn(`${logContext.logPrefix} Skipping plugin '${logContext.pluginName}': url source 'sha' must be a full 40-character commit hash when provided`);
+				logContext.logService.warn(`${logContext.logPrefix} Skipping plugin '${logContext.pluginName}': ${rawSource.source} source 'sha' must be a full 40-character commit hash when provided`);
+				return undefined;
+			}
+			if (rawSource.source === 'git-subdir') {
+				if (typeof rawSource.path !== 'string' || !rawSource.path) {
+					logContext.logService.warn(`${logContext.logPrefix} Skipping plugin '${logContext.pluginName}': git-subdir source is missing required 'path' field`);
+					return undefined;
+				}
+			} else if (!isOptionalString(rawSource.path)) {
+				logContext.logService.warn(`${logContext.logPrefix} Skipping plugin '${logContext.pluginName}': url source 'path' must be a string when provided`);
 				return undefined;
 			}
 			return {
@@ -1000,6 +1012,7 @@ export function parsePluginSource(
 				url: rawSource.url,
 				ref: rawSource.ref,
 				sha: rawSource.sha,
+				path: rawSource.path,
 			};
 		}
 		case 'npm': {
@@ -1063,7 +1076,7 @@ export function getPluginSourceLabel(descriptor: IPluginSourceDescriptor): strin
 		case PluginSourceKind.GitHub:
 			return descriptor.path ? `${descriptor.repo}/${descriptor.path}` : descriptor.repo;
 		case PluginSourceKind.GitUrl:
-			return descriptor.url;
+			return descriptor.path ? `${descriptor.url}/${descriptor.path}` : descriptor.url;
 		case PluginSourceKind.Npm:
 			return descriptor.version ? `${descriptor.package}@${descriptor.version}` : descriptor.package;
 		case PluginSourceKind.Pip:
@@ -1087,7 +1100,8 @@ export function hasSourceChanged(installed: IPluginSourceDescriptor, marketplace
 				|| installed.path !== (marketplace as typeof installed).path;
 		case PluginSourceKind.GitUrl:
 			return installed.ref !== (marketplace as typeof installed).ref
-				|| installed.sha !== (marketplace as typeof installed).sha;
+				|| installed.sha !== (marketplace as typeof installed).sha
+				|| installed.path !== (marketplace as typeof installed).path;
 		case PluginSourceKind.Npm:
 			return installed.version !== (marketplace as typeof installed).version;
 		case PluginSourceKind.Pip:

--- a/src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts
@@ -427,7 +427,7 @@ suite('parsePluginSource', () => {
 
 	test('parses url object source', () => {
 		const result = parsePluginSource({ source: 'url', url: 'https://gitlab.com/team/plugin.git' }, undefined, logContext);
-		assert.deepStrictEqual(result, { kind: PluginSourceKind.GitUrl, url: 'https://gitlab.com/team/plugin.git', ref: undefined, sha: undefined });
+		assert.deepStrictEqual(result, { kind: PluginSourceKind.GitUrl, url: 'https://gitlab.com/team/plugin.git', ref: undefined, sha: undefined, path: undefined });
 	});
 
 	test('returns undefined for url source missing url field', () => {
@@ -436,6 +436,30 @@ suite('parsePluginSource', () => {
 
 	test('returns undefined for url source not ending in .git', () => {
 		assert.strictEqual(parsePluginSource({ source: 'url', url: 'https://gitlab.com/team/plugin' }, undefined, logContext), undefined);
+	});
+
+	test('parses git-subdir object source', () => {
+		const result = parsePluginSource({ source: 'git-subdir', url: 'https://github.com/acme/monorepo.git', path: 'tools/claude-plugin' }, undefined, logContext);
+		assert.deepStrictEqual(result, { kind: PluginSourceKind.GitUrl, url: 'https://github.com/acme/monorepo.git', ref: undefined, sha: undefined, path: 'tools/claude-plugin' });
+	});
+
+	test('parses git-subdir object source with ref and sha', () => {
+		const result = parsePluginSource({ source: 'git-subdir', url: 'https://example.com/repo.git', path: 'plugins/foo', ref: 'v2.0.0', sha: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0' }, undefined, logContext);
+		assert.deepStrictEqual(result, { kind: PluginSourceKind.GitUrl, url: 'https://example.com/repo.git', ref: 'v2.0.0', sha: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0', path: 'plugins/foo' });
+	});
+
+	test('parses git-subdir source without .git suffix', () => {
+		// git-subdir does not require .git suffix (Azure DevOps / AWS CodeCommit compatibility)
+		const result = parsePluginSource({ source: 'git-subdir', url: 'https://dev.azure.com/org/project/_git/repo', path: 'plugins/foo' }, undefined, logContext);
+		assert.deepStrictEqual(result, { kind: PluginSourceKind.GitUrl, url: 'https://dev.azure.com/org/project/_git/repo', ref: undefined, sha: undefined, path: 'plugins/foo' });
+	});
+
+	test('returns undefined for git-subdir source missing url field', () => {
+		assert.strictEqual(parsePluginSource({ source: 'git-subdir', path: 'plugins/foo' }, undefined, logContext), undefined);
+	});
+
+	test('returns undefined for git-subdir source missing path field', () => {
+		assert.strictEqual(parsePluginSource({ source: 'git-subdir', url: 'https://example.com/repo.git' }, undefined, logContext), undefined);
 	});
 
 	test('parses npm object source', () => {
@@ -504,6 +528,10 @@ suite('getPluginSourceLabel', () => {
 
 	test('formats url source', () => {
 		assert.strictEqual(getPluginSourceLabel({ kind: PluginSourceKind.GitUrl, url: 'https://example.com/repo.git' }), 'https://example.com/repo.git');
+	});
+
+	test('formats url source with path', () => {
+		assert.strictEqual(getPluginSourceLabel({ kind: PluginSourceKind.GitUrl, url: 'https://example.com/repo.git', path: 'plugins/foo' }), 'https://example.com/repo.git/plugins/foo');
 	});
 
 	test('formats npm source without version', () => {


### PR DESCRIPTION
plugins: support git-subdir marketplace source kind

Adds support for the `git-subdir` plugin source kind in marketplace.json files,
matching the Claude Code marketplace schema. The `git-subdir` source clones an
arbitrary git URL and installs a plugin from a subdirectory of that repository,
useful for monorepos that publish many plugins from a single repo.

- Extends `IGitUrlPluginSource` with an optional `path` field.
- Accepts both `"source": "url"` and `"source": "git-subdir"` discriminants
  when parsing marketplace.json. `git-subdir` requires both `url` and
  `path`; the .git suffix is not required (Azure DevOps / AWS CodeCommit).
- Updates `GitUrlPluginSource` to resolve the install URI as repo-root + path
  (mirroring the existing GitHub sub-path handling), while the clone target
  remains the repository root.
- Includes `path` in update detection (`hasSourceChanged`) and the
  human-readable label (`getPluginSourceLabel`).

Fixes https://github.com/microsoft/vscode/issues/310850

(Commit message generated by Copilot)

