### PR TITLE
Show Model Manager in Agents Window

### DIFF
--- a/src/vs/platform/storage/test/electron-main/storageMainService.test.ts
+++ b/src/vs/platform/storage/test/electron-main/storageMainService.test.ts
@@ -44,6 +44,7 @@ suite('StorageMainService', function () {
 		keybindingsResource: joinPath(inMemoryProfileRoot, 'keybindingsResource'),
 		tasksResource: joinPath(inMemoryProfileRoot, 'tasksResource'),
 		mcpResource: joinPath(inMemoryProfileRoot, 'mcp.json'),
+		languageModelsResource: joinPath(inMemoryProfileRoot, 'chatLanguageModels.json'),
 		snippetsHome: joinPath(inMemoryProfileRoot, 'snippetsHome'),
 		promptsHome: joinPath(inMemoryProfileRoot, 'promptsHome'),
 		extensionsResource: joinPath(inMemoryProfileRoot, 'extensionsResource'),

--- a/src/vs/platform/userDataProfile/common/userDataProfile.ts
+++ b/src/vs/platform/userDataProfile/common/userDataProfile.ts
@@ -28,6 +28,7 @@ const AGENTS_WINDOW_PROFILE_FLAGS: UseDefaultProfileFlags = {
 	keybindings: true,
 	prompts: true,
 	mcp: true,
+	languageModels: true,
 	snippets: true,
 	tasks: true,
 	extensions: true,
@@ -42,6 +43,7 @@ export const enum ProfileResourceType {
 	Extensions = 'extensions',
 	GlobalState = 'globalState',
 	Mcp = 'mcp',
+	LanguageModels = 'languageModels',
 }
 
 /**
@@ -66,6 +68,7 @@ export interface IUserDataProfile {
 	readonly promptsHome: URI;
 	readonly extensionsResource: URI;
 	readonly mcpResource: URI;
+	readonly languageModelsResource: URI;
 	readonly agentPluginsHome: URI;
 	readonly cacheHome: URI;
 	readonly useDefaultFlags?: UseDefaultProfileFlags;
@@ -91,6 +94,7 @@ export function isUserDataProfile(thing: unknown): thing is IUserDataProfile {
 		&& URI.isUri(candidate.promptsHome)
 		&& URI.isUri(candidate.extensionsResource)
 		&& URI.isUri(candidate.mcpResource)
+		&& URI.isUri(candidate.languageModelsResource)
 		&& URI.isUri(candidate.agentPluginsHome)
 	);
 }
@@ -170,6 +174,7 @@ export function reviveProfile(profile: UriDto<IUserDataProfile>, scheme: string)
 		promptsHome: URI.revive(profile.promptsHome).with({ scheme }),
 		extensionsResource: URI.revive(profile.extensionsResource).with({ scheme }),
 		mcpResource: URI.revive(profile.mcpResource).with({ scheme }),
+		languageModelsResource: URI.revive(profile.languageModelsResource).with({ scheme }),
 		agentPluginsHome: URI.revive(profile.agentPluginsHome),
 		cacheHome: URI.revive(profile.cacheHome).with({ scheme }),
 		useDefaultFlags: profile.useDefaultFlags,
@@ -196,6 +201,7 @@ export function toUserDataProfile(id: string, name: string, location: URI, profi
 		promptsHome: defaultProfile && options?.useDefaultFlags?.prompts ? defaultProfile.promptsHome : joinPath(location, 'prompts'),
 		extensionsResource: defaultProfile && options?.useDefaultFlags?.extensions ? defaultProfile.extensionsResource : joinPath(location, 'extensions.json'),
 		mcpResource: defaultProfile && options?.useDefaultFlags?.mcp ? defaultProfile.mcpResource : joinPath(location, 'mcp.json'),
+		languageModelsResource: defaultProfile && options?.useDefaultFlags?.languageModels ? defaultProfile.languageModelsResource : joinPath(location, 'chatLanguageModels.json'),
 		agentPluginsHome: defaultProfile ? defaultProfile.agentPluginsHome : joinPath(location, 'agent-plugins'),
 		cacheHome: joinPath(profilesCacheHome, id),
 		useDefaultFlags: options?.useDefaultFlags,

--- a/src/vs/platform/userDataProfile/test/common/userDataProfileService.test.ts
+++ b/src/vs/platform/userDataProfile/test/common/userDataProfileService.test.ts
@@ -219,6 +219,14 @@ suite('UserDataProfileService (Common)', () => {
 		assert.strictEqual(profile.extensionsResource.toString(), testObject.defaultProfile.extensionsResource.toString());
 	});
 
+	test('profile using default profile for language models', async () => {
+		const profile = await testObject.createNamedProfile('name', { useDefaultFlags: { languageModels: true } });
+
+		assert.strictEqual(profile.isDefault, false);
+		assert.deepStrictEqual(profile.useDefaultFlags, { languageModels: true });
+		assert.strictEqual(profile.languageModelsResource.toString(), testObject.defaultProfile.languageModelsResource.toString());
+	});
+
 	test('update profile using default profile for keybindings', async () => {
 		let profile = await testObject.createNamedProfile('name');
 		profile = await testObject.updateProfile(profile, { useDefaultFlags: { keybindings: true } });

--- a/src/vs/platform/userDataProfile/test/electron-main/userDataProfileMainService.test.ts
+++ b/src/vs/platform/userDataProfile/test/electron-main/userDataProfileMainService.test.ts
@@ -125,6 +125,7 @@ suite('UserDataProfileMainService', () => {
 			keybindings: true,
 			prompts: true,
 			mcp: true,
+			languageModels: true,
 			snippets: true,
 			tasks: true,
 			extensions: true,
@@ -136,6 +137,7 @@ suite('UserDataProfileMainService', () => {
 		assert.strictEqual(profile.extensionsResource.toString(), testObject.defaultProfile.extensionsResource.toString());
 		assert.strictEqual(profile.promptsHome.toString(), testObject.defaultProfile.promptsHome.toString());
 		assert.strictEqual(profile.mcpResource.toString(), testObject.defaultProfile.mcpResource.toString());
+		assert.strictEqual(profile.languageModelsResource.toString(), testObject.defaultProfile.languageModelsResource.toString());
 	});
 
 });

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/COPILOT_CHAT_SESSIONS_PROVIDER.md
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/COPILOT_CHAT_SESSIONS_PROVIDER.md
@@ -1,15 +1,15 @@
 # CopilotChatSessionsProvider — Default Copilot Provider
 
-**File:** `src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts`
+**File:** `src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts`
 
-The default sessions provider, registered with ID `'default-copilot'`. Wraps the existing agent session infrastructure into the extensible provider model. Supports three session types: **Copilot CLI** (local), **Copilot Cloud** (remote), and **Claude** (local, gated by `sessions.chat.claudeAgent.enabled`).
+The default sessions provider, registered with ID `'default-copilot'`. Wraps the existing agent session infrastructure into the extensible provider model. Supports **Copilot CLI** (local), **Copilot Cloud** (remote), **Claude** (local, gated by `sessions.chat.claudeAgent.enabled`), and **Local** in-process chat sessions (gated by `sessions.chat.localAgent.enabled`).
 
 ## Registration
 
 Registered via `DefaultSessionsProviderContribution` workbench contribution at `WorkbenchPhase.AfterRestored`:
 
-```
-src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessions.contribution.ts
+```text
+src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessions.contribution.ts
 ```
 
 ```typescript
@@ -24,11 +24,11 @@ class DefaultSessionsProviderContribution extends Disposable {
 ## Identity
 
 | Property | Value |
-|----------|-------|
+| --- | --- |
 | `id` | `'default-copilot'` |
 | `label` | `'Copilot Chat'` |
 | `icon` | `Codicon.copilot` |
-| `sessionTypes` | `[CopilotCLISessionType, CopilotCloudSessionType]` (+ `ClaudeCodeSessionType` when enabled) |
+| `sessionTypes` | `[CopilotCLISessionType, CopilotCloudSessionType]` (+ `ClaudeCodeSessionType` and `LocalSessionType` when enabled) |
 
 ## Browse Actions
 
@@ -37,9 +37,10 @@ class DefaultSessionsProviderContribution extends Disposable {
 
 ## New Session Classes
 
-When `createNewSession(workspace)` is called, the provider creates one of two concrete `ISession` implementations based on the workspace URI scheme:
+When `createNewSession(workspace)` is called, the provider creates the concrete `ISession` implementation that matches the selected session type and workspace URI scheme:
 
 **`CopilotCLISession`** — For local `file://` workspaces:
+
 - Implements `ISession` plus provider-specific observable fields (`permissionLevel`, `branchObservable`, `isolationModeObservable`)
 - Performs async git repository resolution during construction (sets `loading` to true until resolved)
 - Configuration methods: `setIsolationMode()`, `setBranch()`, `setModelId()`, `setMode()`, `setPermissionLevel()`, `setModeById()`
@@ -47,6 +48,7 @@ When `createNewSession(workspace)` is called, the provider creates one of two co
 - Uses `IGitService` to open the repository and resolve branch information
 
 **`RemoteNewSession`** — For cloud `github-remote-file://` workspaces:
+
 - Implements `ISession`
 - Manages dynamic option groups from `IChatSessionsService.getOptionGroupsForSessionType()` with `when` clause visibility
 - No-ops for isolation/branch/client mode (cloud-managed)
@@ -54,14 +56,22 @@ When `createNewSession(workspace)` is called, the provider creates one of two co
 - Watches context key changes to dynamically show/hide option groups
 
 **`ClaudeCodeNewSession`** — For Claude agent sessions (local `file://` workspaces):
+
 - Implements `ISession` with simplified configuration (Claude manages its own worktrees and branches)
 - No-ops for `setIsolationMode()` and `setBranch()`
 - `setOption()` writes to `selectedOptions` map; options are propagated to `IChatSessionsService` during `_sendFirstChat()` via `updateSessionOptions()`
 - Gated by the `sessions.chat.claudeAgent.enabled` setting (default: `true`)
 
+**`LocalNewSession`** — For in-process VS Code chat sessions (local `file://` workspaces):
+
+- Implements `ISession` backed by a local chat model created through the chat service
+- Tracks the selected general-purpose language model for the pending session
+- Gated by the `sessions.chat.localAgent.enabled` setting
+
 ## `AgentSessionAdapter` — Wrapping Existing Sessions
 
 Adapts an existing `IAgentSession` from the chat layer into the `ISession` facade:
+
 - Constructs with initial values from the agent session's metadata and timing
 - `update(session)` performs a batched observable transaction to update all reactive properties
 - Extracts workspace info, changes, description, and GitHub info from session metadata
@@ -71,6 +81,7 @@ Adapts an existing `IAgentSession` from the chat layer into the `ISession` facad
 ## Session Cache & Change Events
 
 The provider maintains a `Map<string, AgentSessionAdapter>` cache keyed by resource URI:
+
 - `_ensureSessionCache()` performs lazy initialization
 - `_refreshSessionCache()` diffs current `IAgentSession` list against the cache, producing `added`, `removed`, and `changed` arrays
 - Changed adapters are updated in-place via `adapter.update(session)`
@@ -78,7 +89,7 @@ The provider maintains a `Map<string, AgentSessionAdapter>` cache keyed by resou
 
 ## Send Flow
 
-1. Validate the session is a current new session (`CopilotCLISession`, `RemoteNewSession`, or `ClaudeCodeNewSession`)
+1. Validate the session is a current new session (`CopilotCLISession`, `RemoteNewSession`, `ClaudeCodeNewSession`, or `LocalNewSession`)
 2. For the first chat, call `_sendFirstChat()`:
    a. Resolve mode, permission level, and send options from session configuration
    b. Open the chat widget via `IChatWidgetService.openSession()`
@@ -93,7 +104,7 @@ The provider maintains a `Map<string, AgentSessionAdapter>` cache keyed by resou
 
 ## New-Session Picker Contribution Model
 
-**File:** `src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsActions.ts`
+**File:** `src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsActions.ts`
 
 The welcome/new-session view (`NewChatInputWidget`) renders three toolbar menus for configuration pickers. Each picker requires a three-part registration:
 
@@ -101,13 +112,13 @@ The welcome/new-session view (`NewChatInputWidget`) renders three toolbar menus 
 2. **Action view item** — `actionViewItemService.register()` to provide a custom widget instead of a button
 3. **Picker widget** — A `Disposable` class with a `render(container)` method, wrapped in `PickerActionViewItem`
 
-Model picker widgets that back the new-chat `/models` slash command also inject `INewChatModelPickerService` and register their opener with it. `NewChatInputWidget` scopes that service per input, so action view item factories must instantiate those model picker widgets from the factory's `instantiationService` argument rather than a contribution-level service.
+Model picker widgets that back the new-chat `/models` slash command also inject `INewChatModelPickerService` and register their opener with it. `NewChatInputWidget` scopes that service per input, so action view item factories must instantiate those model picker widgets from the factory's `instantiationService` argument rather than a contribution-level service. The unified picker also opts **Local** sessions into the shared `Manage Models...` action, which opens the existing language-model management editor.
 
 ### Toolbar Menus
 
 | Menu | Purpose | Examples |
-|------|---------|----------|
-| `Menus.NewSessionConfig` | Session configuration (mode, model) | `ModePicker`, `CloudModelPicker`, unified model picker (CLI + Claude) |
+| --- | --- | --- |
+| `Menus.NewSessionConfig` | Session configuration (mode, model) | `ModePicker`, `CloudModelPicker`, unified model picker (CLI + Claude + Local) |
 | `Menus.NewSessionControl` | Session controls (permissions) | `PermissionPicker`, `ClaudePermissionModePicker` |
 | `Menus.NewSessionRepositoryConfig` | Repository configuration | `IsolationPicker`, `BranchPicker` |
 
@@ -116,10 +127,11 @@ Model picker widgets that back the new-chat `/models` slash command also inject 
 Each picker action uses a `when` clause to show only for the correct session type:
 
 | Expression | Matches |
-|------------|---------|
+| --- | --- |
 | `IsActiveSessionCopilotChatCLI` | Copilot CLI sessions |
 | `IsActiveSessionCopilotChatCloud` | Copilot Cloud sessions |
 | `IsActiveSessionCopilotChatClaudeCode` | Claude sessions |
+| `IsActiveSessionCopilotChatLocal` | Local in-process chat sessions |
 
 These are composed from `ActiveSessionTypeContext` (the session type ID) and `ActiveSessionProviderIdContext` (the provider ID).
 

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/COPILOT_CHAT_SESSIONS_PROVIDER.md
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/COPILOT_CHAT_SESSIONS_PROVIDER.md
@@ -1,15 +1,15 @@
 # CopilotChatSessionsProvider — Default Copilot Provider
 
-**File:** `src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts`
+**File:** `src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts`
 
-The default sessions provider, registered with ID `'default-copilot'`. Wraps the existing agent session infrastructure into the extensible provider model. Supports **Copilot CLI** (local), **Copilot Cloud** (remote), **Claude** (local, gated by `sessions.chat.claudeAgent.enabled`), and **Local** in-process chat sessions (gated by `sessions.chat.localAgent.enabled`).
+The default sessions provider, registered with ID `'default-copilot'`. Wraps the existing agent session infrastructure into the extensible provider model. Supports three session types: **Copilot CLI** (local), **Copilot Cloud** (remote), and **Claude** (local, gated by `sessions.chat.claudeAgent.enabled`).
 
 ## Registration
 
 Registered via `DefaultSessionsProviderContribution` workbench contribution at `WorkbenchPhase.AfterRestored`:
 
-```text
-src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessions.contribution.ts
+```
+src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessions.contribution.ts
 ```
 
 ```typescript
@@ -24,11 +24,11 @@ class DefaultSessionsProviderContribution extends Disposable {
 ## Identity
 
 | Property | Value |
-| --- | --- |
+|----------|-------|
 | `id` | `'default-copilot'` |
 | `label` | `'Copilot Chat'` |
 | `icon` | `Codicon.copilot` |
-| `sessionTypes` | `[CopilotCLISessionType, CopilotCloudSessionType]` (+ `ClaudeCodeSessionType` and `LocalSessionType` when enabled) |
+| `sessionTypes` | `[CopilotCLISessionType, CopilotCloudSessionType]` (+ `ClaudeCodeSessionType` when enabled) |
 
 ## Browse Actions
 
@@ -37,10 +37,9 @@ class DefaultSessionsProviderContribution extends Disposable {
 
 ## New Session Classes
 
-When `createNewSession(workspace)` is called, the provider creates the concrete `ISession` implementation that matches the selected session type and workspace URI scheme:
+When `createNewSession(workspace)` is called, the provider creates one of two concrete `ISession` implementations based on the workspace URI scheme:
 
 **`CopilotCLISession`** — For local `file://` workspaces:
-
 - Implements `ISession` plus provider-specific observable fields (`permissionLevel`, `branchObservable`, `isolationModeObservable`)
 - Performs async git repository resolution during construction (sets `loading` to true until resolved)
 - Configuration methods: `setIsolationMode()`, `setBranch()`, `setModelId()`, `setMode()`, `setPermissionLevel()`, `setModeById()`
@@ -48,7 +47,6 @@ When `createNewSession(workspace)` is called, the provider creates the concrete 
 - Uses `IGitService` to open the repository and resolve branch information
 
 **`RemoteNewSession`** — For cloud `github-remote-file://` workspaces:
-
 - Implements `ISession`
 - Manages dynamic option groups from `IChatSessionsService.getOptionGroupsForSessionType()` with `when` clause visibility
 - No-ops for isolation/branch/client mode (cloud-managed)
@@ -56,22 +54,14 @@ When `createNewSession(workspace)` is called, the provider creates the concrete 
 - Watches context key changes to dynamically show/hide option groups
 
 **`ClaudeCodeNewSession`** — For Claude agent sessions (local `file://` workspaces):
-
 - Implements `ISession` with simplified configuration (Claude manages its own worktrees and branches)
 - No-ops for `setIsolationMode()` and `setBranch()`
 - `setOption()` writes to `selectedOptions` map; options are propagated to `IChatSessionsService` during `_sendFirstChat()` via `updateSessionOptions()`
 - Gated by the `sessions.chat.claudeAgent.enabled` setting (default: `true`)
 
-**`LocalNewSession`** — For in-process VS Code chat sessions (local `file://` workspaces):
-
-- Implements `ISession` backed by a local chat model created through the chat service
-- Tracks the selected general-purpose language model for the pending session
-- Gated by the `sessions.chat.localAgent.enabled` setting
-
 ## `AgentSessionAdapter` — Wrapping Existing Sessions
 
 Adapts an existing `IAgentSession` from the chat layer into the `ISession` facade:
-
 - Constructs with initial values from the agent session's metadata and timing
 - `update(session)` performs a batched observable transaction to update all reactive properties
 - Extracts workspace info, changes, description, and GitHub info from session metadata
@@ -81,7 +71,6 @@ Adapts an existing `IAgentSession` from the chat layer into the `ISession` facad
 ## Session Cache & Change Events
 
 The provider maintains a `Map<string, AgentSessionAdapter>` cache keyed by resource URI:
-
 - `_ensureSessionCache()` performs lazy initialization
 - `_refreshSessionCache()` diffs current `IAgentSession` list against the cache, producing `added`, `removed`, and `changed` arrays
 - Changed adapters are updated in-place via `adapter.update(session)`
@@ -89,7 +78,7 @@ The provider maintains a `Map<string, AgentSessionAdapter>` cache keyed by resou
 
 ## Send Flow
 
-1. Validate the session is a current new session (`CopilotCLISession`, `RemoteNewSession`, `ClaudeCodeNewSession`, or `LocalNewSession`)
+1. Validate the session is a current new session (`CopilotCLISession`, `RemoteNewSession`, or `ClaudeCodeNewSession`)
 2. For the first chat, call `_sendFirstChat()`:
    a. Resolve mode, permission level, and send options from session configuration
    b. Open the chat widget via `IChatWidgetService.openSession()`
@@ -104,7 +93,7 @@ The provider maintains a `Map<string, AgentSessionAdapter>` cache keyed by resou
 
 ## New-Session Picker Contribution Model
 
-**File:** `src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsActions.ts`
+**File:** `src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsActions.ts`
 
 The welcome/new-session view (`NewChatInputWidget`) renders three toolbar menus for configuration pickers. Each picker requires a three-part registration:
 
@@ -112,13 +101,13 @@ The welcome/new-session view (`NewChatInputWidget`) renders three toolbar menus 
 2. **Action view item** — `actionViewItemService.register()` to provide a custom widget instead of a button
 3. **Picker widget** — A `Disposable` class with a `render(container)` method, wrapped in `PickerActionViewItem`
 
-Model picker widgets that back the new-chat `/models` slash command also inject `INewChatModelPickerService` and register their opener with it. `NewChatInputWidget` scopes that service per input, so action view item factories must instantiate those model picker widgets from the factory's `instantiationService` argument rather than a contribution-level service. The unified picker also opts **Local** sessions into the shared `Manage Models...` action, which opens the existing language-model management editor.
+Model picker widgets that back the new-chat `/models` slash command also inject `INewChatModelPickerService` and register their opener with it. `NewChatInputWidget` scopes that service per input, so action view item factories must instantiate those model picker widgets from the factory's `instantiationService` argument rather than a contribution-level service.
 
 ### Toolbar Menus
 
 | Menu | Purpose | Examples |
-| --- | --- | --- |
-| `Menus.NewSessionConfig` | Session configuration (mode, model) | `ModePicker`, `CloudModelPicker`, unified model picker (CLI + Claude + Local) |
+|------|---------|----------|
+| `Menus.NewSessionConfig` | Session configuration (mode, model) | `ModePicker`, `CloudModelPicker`, unified model picker (CLI + Claude) |
 | `Menus.NewSessionControl` | Session controls (permissions) | `PermissionPicker`, `ClaudePermissionModePicker` |
 | `Menus.NewSessionRepositoryConfig` | Repository configuration | `IsolationPicker`, `BranchPicker` |
 
@@ -127,11 +116,10 @@ Model picker widgets that back the new-chat `/models` slash command also inject 
 Each picker action uses a `when` clause to show only for the correct session type:
 
 | Expression | Matches |
-| --- | --- |
+|------------|---------|
 | `IsActiveSessionCopilotChatCLI` | Copilot CLI sessions |
 | `IsActiveSessionCopilotChatCloud` | Copilot Cloud sessions |
 | `IsActiveSessionCopilotChatClaudeCode` | Claude sessions |
-| `IsActiveSessionCopilotChatLocal` | Local in-process chat sessions |
 
 These are composed from `ActiveSessionTypeContext` (the session type ID) and `ActiveSessionProviderIdContext` (the provider ID).
 

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsActions.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsActions.ts
@@ -288,6 +288,11 @@ export function modelPickerStorageKey(sessionType: string): string {
 	return `sessions.modelPicker.${sessionType}.selectedModelId`;
 }
 
+export function shouldShowSessionManageModelsAction(sessionsManagementService: ISessionsManagementService): boolean {
+	const session = sessionsManagementService.activeSession.get();
+	return session?.providerId === COPILOT_PROVIDER_ID && session.sessionType === SessionType.Local;
+}
+
 function getVendorFromModelIdentifier(modelIdentifier: string): string | undefined {
 	const firstSlash = modelIdentifier.indexOf('/');
 	return firstSlash === -1 ? undefined : modelIdentifier.substring(0, firstSlash);
@@ -342,7 +347,7 @@ export class SessionModelPicker extends Disposable {
 			},
 			getModels: () => getAvailableModels(this._languageModelsService, this._sessionsManagementService),
 			useGroupedModelPicker: () => true,
-			showManageModelsAction: () => false,
+			showManageModelsAction: () => shouldShowSessionManageModelsAction(this._sessionsManagementService),
 			showUnavailableFeatured: () => false,
 			showFeatured: () => true,
 		};

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/modelPickerDelegate.test.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/modelPickerDelegate.test.ts
@@ -19,10 +19,11 @@ import { ISessionsProvidersService } from '../../../../../services/sessions/brow
 import { SessionStatus } from '../../../../../services/sessions/common/session.js';
 import { IActiveSession, ISessionsManagementService } from '../../../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsProvider } from '../../../../../services/sessions/common/sessionsProvider.js';
-import { getAvailableModels, modelPickerStorageKey, SessionModelPicker } from '../../browser/copilotChatSessionsActions.js';
+import { getAvailableModels, modelPickerStorageKey, SessionModelPicker, shouldShowSessionManageModelsAction } from '../../browser/copilotChatSessionsActions.js';
 import { CopilotCLISessionType } from '../../../agentHost/browser/baseAgentHostSessionsProvider.js';
-import { ClaudeCodeSessionType } from '../../browser/copilotChatSessionsProvider.js';
+import { ClaudeCodeSessionType, COPILOT_PROVIDER_ID } from '../../browser/copilotChatSessionsProvider.js';
 import { INewChatModelPickerService, NewChatModelPickerService } from '../../../../chat/browser/newChatModelPicker.js';
+import { SessionType } from '../../../../../../workbench/contrib/chat/common/chatSessionsService.js';
 
 function makeModel(id: string, sessionType: string): ILanguageModelChatMetadataAndIdentifier {
 	return {
@@ -145,6 +146,31 @@ suite('getAvailableModels', () => {
 		const sessionsManagementService = instantiationService.get(ISessionsManagementService);
 		const result = getAvailableModels(languageModelsService, sessionsManagementService);
 		assert.deepStrictEqual(result, [models[2]]);
+	});
+});
+
+suite('shouldShowSessionManageModelsAction', () => {
+	const disposables = new DisposableStore();
+
+	teardown(() => disposables.clear());
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('shows only for Copilot Local sessions', () => {
+		const localServices = stubServices(disposables, {
+			activeSession: { providerId: COPILOT_PROVIDER_ID, sessionId: 'local', sessionType: SessionType.Local },
+		}).instantiationService;
+		const cliServices = stubServices(disposables, {
+			activeSession: { providerId: COPILOT_PROVIDER_ID, sessionId: 'cli', sessionType: CopilotCLISessionType.id },
+		}).instantiationService;
+		const otherProviderServices = stubServices(disposables, {
+			activeSession: { providerId: 'other-provider', sessionId: 'other-local', sessionType: SessionType.Local },
+		}).instantiationService;
+
+		assert.deepStrictEqual([
+			shouldShowSessionManageModelsAction(localServices.get(ISessionsManagementService)),
+			shouldShowSessionManageModelsAction(cliServices.get(ISessionsManagementService)),
+			shouldShowSessionManageModelsAction(otherProviderServices.get(ISessionsManagementService)),
+		], [true, false, false]);
 	});
 });
 

--- a/src/vs/workbench/contrib/chat/browser/languageModelsConfigurationService.ts
+++ b/src/vs/workbench/contrib/chat/browser/languageModelsConfigurationService.ts
@@ -53,7 +53,7 @@ export class LanguageModelsConfigurationService extends Disposable implements IL
 		@IUriIdentityService uriIdentityService: IUriIdentityService,
 	) {
 		super();
-		this.modelsConfigurationFile = uriIdentityService.extUri.joinPath(userDataProfileService.currentProfile.location, 'chatLanguageModels.json');
+		this.modelsConfigurationFile = userDataProfileService.currentProfile.languageModelsResource;
 		this.updateLanguageModelsConfiguration();
 		// Watch the parent folder for reliable change detection across platforms (especially Windows
 		// where `fs.watch` on individual files can miss in-place writes).

--- a/src/vs/workbench/contrib/editSessions/test/browser/editSessions.test.ts
+++ b/src/vs/workbench/contrib/editSessions/test/browser/editSessions.test.ts
@@ -162,6 +162,7 @@ suite('Edit session sync', () => {
 				keybindingsResource: URI.file('keybindingsResource'),
 				tasksResource: URI.file('tasksResource'),
 				mcpResource: URI.file('mcp.json'),
+				languageModelsResource: URI.file('chatLanguageModels.json'),
 				snippetsHome: URI.file('snippetsHome'),
 				promptsHome: URI.file('promptsHome'),
 				extensionsResource: URI.file('extensionsResource'),

--- a/src/vs/workbench/services/storage/test/browser/storageService.test.ts
+++ b/src/vs/workbench/services/storage/test/browser/storageService.test.ts
@@ -43,6 +43,7 @@ async function createStorageService(): Promise<[DisposableStore, BrowserStorageS
 		keybindingsResource: joinPath(inMemoryExtraProfileRoot, 'keybindingsResource'),
 		tasksResource: joinPath(inMemoryExtraProfileRoot, 'tasksResource'),
 		mcpResource: joinPath(inMemoryExtraProfileRoot, 'mcp.json'),
+		languageModelsResource: joinPath(inMemoryExtraProfileRoot, 'chatLanguageModels.json'),
 		snippetsHome: joinPath(inMemoryExtraProfileRoot, 'snippetsHome'),
 		promptsHome: joinPath(inMemoryExtraProfileRoot, 'promptsHome'),
 		extensionsResource: joinPath(inMemoryExtraProfileRoot, 'extensionsResource'),

--- a/src/vs/workbench/services/userDataProfile/browser/userDataProfileImportExportService.ts
+++ b/src/vs/workbench/services/userDataProfile/browser/userDataProfileImportExportService.ts
@@ -751,6 +751,7 @@ class UserDataProfileExportState extends UserDataProfileImportExportState {
 			keybindingsResource: profile.keybindingsResource.with({ scheme: USER_DATA_PROFILE_EXPORT_SCHEME }),
 			tasksResource: profile.tasksResource.with({ scheme: USER_DATA_PROFILE_EXPORT_SCHEME }),
 			mcpResource: profile.mcpResource.with({ scheme: USER_DATA_PROFILE_EXPORT_SCHEME }),
+			languageModelsResource: profile.languageModelsResource.with({ scheme: USER_DATA_PROFILE_EXPORT_SCHEME }),
 			snippetsHome: profile.snippetsHome.with({ scheme: USER_DATA_PROFILE_EXPORT_SCHEME }),
 			promptsHome: profile.promptsHome.with({ scheme: USER_DATA_PROFILE_EXPORT_SCHEME }),
 			extensionsResource: profile.extensionsResource,

--- a/src/vs/workbench/services/workingCopy/test/electron-browser/workingCopyBackupService.test.ts
+++ b/src/vs/workbench/services/workingCopy/test/electron-browser/workingCopyBackupService.test.ts
@@ -48,6 +48,7 @@ const NULL_PROFILE = {
 	keybindingsResource: joinPath(homeDir, 'keybindings.json'),
 	tasksResource: joinPath(homeDir, 'tasks.json'),
 	mcpResource: joinPath(homeDir, 'mcp.json'),
+	languageModelsResource: joinPath(homeDir, 'chatLanguageModels.json'),
 	snippetsHome: joinPath(homeDir, 'snippets'),
 	promptsHome: joinPath(homeDir, 'prompts'),
 	extensionsResource: joinPath(homeDir, 'extensions.json'),


### PR DESCRIPTION
- Add profile-backed storage for language model configuration so Agents window profiles can share or isolate chatLanguageModels.json
- Route language model configuration reads through the new profile resource and cover profile creation/export/test fixtures
- Show `Manage Models...` in the local-session model picker, with focused test coverage for session gating