### PR TITLE
Sanity test: enrich agent-mode timeout error with stream diagnostics

### DIFF
--- a/extensions/copilot/src/extension/test/vscode-node/sanity.sanity-test.ts
+++ b/extensions/copilot/src/extension/test/vscode-node/sanity.sanity-test.ts
@@ -138,7 +138,13 @@ suite('Copilot Chat Sanity Test', function () {
 						getResultPromise.then(r => ({ kind: 'resolved' as const, value: r }), e => ({ kind: 'rejected' as const, error: e })),
 						timeout(5_000).then(() => ({ kind: 'still-pending' as const }))
 					]);
-					throw new Error(`${err instanceof Error ? err.message : String(err)} | follow-up: kind=${settled.kind}${'error' in settled ? ` error=${settled.error}` : ''} ${dumpStream()}`);
+					const cause = err instanceof Error ? err : new Error(String(err));
+					const followUpError = 'error' in settled
+						? settled.error instanceof Error
+							? ` error=${settled.error.stack ?? settled.error.message}`
+							: ` error=${String(settled.error)}`
+						: '';
+					throw new Error(`${cause.message} | follow-up: kind=${settled.kind}${followUpError} ${dumpStream()}`, { cause });
 				}
 			};
 

--- a/extensions/copilot/src/extension/test/vscode-node/sanity.sanity-test.ts
+++ b/extensions/copilot/src/extension/test/vscode-node/sanity.sanity-test.ts
@@ -106,25 +106,53 @@ suite('Copilot Chat Sanity Test', function () {
 			const conversationStore = accessor.get(IConversationStore);
 			const instaService = accessor.get(IInstantiationService);
 			const toolsService = accessor.get(IToolsService);
-			let stream = new SpyChatResponseStream();
-			const testRequest = new TestChatRequest(`You must use the get_errors tool to check the window for errors. It may fail, that's ok, just testing, don't retry.`);
-			testRequest.tools.set(ContributedToolName.GetErrors, true);
-			let interactiveSession = instaService.createInstance(ChatParticipantRequestHandler, [], testRequest, stream, fakeToken, { agentName: '', agentId: '', intentId: Intent.Agent }, () => false, undefined);
 
-			const onWillInvokeTool = Event.toPromise(toolsService.onWillInvokeTool);
-			const getResultPromise = interactiveSession.getResult();
-			await Promise.race([onWillInvokeTool, timeout(20_000).then(() => Promise.reject(new Error('timed out waiting for tool call. ' + (stream.currentProgress ? ('Got progress: ' + stream.currentProgress) : ''))))]);
-			await getResultPromise;
+			// The model may occasionally take more than 20 s to emit its first
+			// tool-call delta on the production backend. Enrich the timeout error
+			// so we can tell from CI logs whether the stream produced anything
+			// (and what kind of parts).
+			const runAgentRequest = async (): Promise<SpyChatResponseStream> => {
+				const stream = new SpyChatResponseStream();
+				const testRequest = new TestChatRequest(`You must use the get_errors tool to check the window for errors. It may fail, that's ok, just testing, don't retry.`);
+				testRequest.tools.set(ContributedToolName.GetErrors, true);
+				const interactiveSession = instaService.createInstance(ChatParticipantRequestHandler, [], testRequest, stream, fakeToken, { agentName: '', agentId: '', intentId: Intent.Agent }, () => false, undefined);
+
+				const onWillInvokeTool = Event.toPromise(toolsService.onWillInvokeTool);
+				const getResultPromise = interactiveSession.getResult();
+				const dumpStream = () => {
+					const parts = stream.items.map(p => p.constructor.name);
+					return `items=${stream.items.length} [${parts.join(', ')}] currentProgress=${JSON.stringify(stream.currentProgress)}`;
+				};
+				try {
+					await Promise.race([
+						onWillInvokeTool,
+						timeout(20_000).then(() => Promise.reject(new Error('timed out waiting for tool call. ' + dumpStream())))
+					]);
+					await getResultPromise;
+					return stream;
+				} catch (err) {
+					// Give the in-flight request a short grace period so we can
+					// classify the failure mode in the error message instead of
+					// reporting a bare timeout.
+					const settled = await Promise.race([
+						getResultPromise.then(r => ({ kind: 'resolved' as const, value: r }), e => ({ kind: 'rejected' as const, error: e })),
+						timeout(5_000).then(() => ({ kind: 'still-pending' as const }))
+					]);
+					throw new Error(`${err instanceof Error ? err.message : String(err)} | follow-up: kind=${settled.kind}${'error' in settled ? ` error=${settled.error}` : ''} ${dumpStream()}`);
+				}
+			};
+
+			const stream = await runAgentRequest();
 
 			assert.ok(stream.currentProgress, 'Expected output');
 			const oldText = stream.currentProgress;
 
-			stream = new SpyChatResponseStream();
-			interactiveSession = instaService.createInstance(ChatParticipantRequestHandler, [], new TestChatRequest('And what is 1+1'), stream, fakeToken, { agentName: '', agentId: '', intentId: Intent.Agent }, () => false, undefined);
+			const stream2 = new SpyChatResponseStream();
+			const interactiveSession = instaService.createInstance(ChatParticipantRequestHandler, [], new TestChatRequest('And what is 1+1'), stream2, fakeToken, { agentName: '', agentId: '', intentId: Intent.Agent }, () => false, undefined);
 			const result2 = await interactiveSession.getResult();
 
-			assert.ok(stream.currentProgress, 'Expected progress after second request');
-			assert.notStrictEqual(stream.currentProgress, oldText, 'Expected different progress text after second request');
+			assert.ok(stream2.currentProgress, 'Expected progress after second request');
+			assert.notStrictEqual(stream2.currentProgress, oldText, 'Expected different progress text after second request');
 
 			const conversation = conversationStore.getConversation(result2.metadata.responseId);
 			assert.ok(conversation, 'Expected conversation to be available');


### PR DESCRIPTION
### Context

The Copilot sanity test `E2E Production agent mode` (in [`sanity.sanity-test.ts`](https://github.com/microsoft/vscode/blob/main/extensions/copilot/src/extension/test/vscode-node/sanity.sanity-test.ts)) has been intermittently failing release / pre-release builds, e.g. [build 440598](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=440598&view=logs&j=15ec5277-fdc6-550c-b203-acb65f44f31c&t=120c9214-43d4-5761-6dc9-d5e173c65e37), with the unhelpful error:

```
Error: timed out waiting for tool call.
```

The test waits up to 20 s for the production backend to emit a tool-call delta on the SSE stream. When it times out, the existing message only appends `stream.currentProgress`, which only captures `ChatResponseMarkdownPart` / `ChatResponseAnchorPart`. Any other streamed parts (progress, confirmations, tool calls, etc.) are invisible, so we can't tell whether:

- the stream produced nothing (backend stall), or
- the model answered in plain text / non-markdown parts (model-decision flake), or
- the request eventually errored after the timeout window.

### Change

Enrich the timeout error to dump:

1. `stream.items.length` and the constructor name of each part.
2. The markdown/anchor `currentProgress` (preserved from before).
3. After the timeout fires, give the in-flight request a 5 s grace period and report whether it ended up `resolved` / `rejected` / `still-pending` — including the underlying error if rejected.

The runtime path for the happy case is unchanged. No retries are added; this PR is purely diagnostic.

Worst-case duration on failure goes from 20 s → 25 s (still well under the suite's 60 s timeout).
