### PR TITLE
Fix copilot NOTICE file generation when publishing

### DIFF
--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -224,6 +224,7 @@ extends:
         jobs:
           - template: build/azure-pipelines/product-copilot.yml@self
             parameters:
+              VSCODE_PUBLISH: ${{ variables.VSCODE_PUBLISH }}
               VSCODE_RELEASE: ${{ parameters.VSCODE_RELEASE }}
 
       - ${{ if eq(variables['VSCODE_BUILD_STAGE_WINDOWS'], true) }}:

--- a/build/azure-pipelines/product-copilot.yml
+++ b/build/azure-pipelines/product-copilot.yml
@@ -1,4 +1,7 @@
 parameters:
+  - name: VSCODE_PUBLISH
+    type: boolean
+    default: false
   - name: VSCODE_RELEASE
     type: boolean
     default: false
@@ -35,7 +38,7 @@ jobs:
       - template: copilot/build-steps.yml
       - template: copilot/l10n-steps.yml
 
-      - ${{ if or(eq(variables['VSCODE_PUBLISH'], true), eq(parameters.VSCODE_RELEASE, true)) }}:
+      - ${{ if or(eq(parameters.VSCODE_PUBLISH, true), eq(parameters.VSCODE_RELEASE, true)) }}:
         - task: notice@0
           inputs:
             outputfile: $(Build.SourcesDirectory)/extensions/copilot/ThirdPartyNotices.txt


### PR DESCRIPTION
:robot: AI-assisted PR

## What happened

In #316650 the NOTICE-generation step in `product-copilot.yml` was gated on:

```yaml
${{ if or(eq(variables['VSCODE_PUBLISH'], true), eq(parameters.VSCODE_RELEASE, true)) }}:
```

`VSCODE_RELEASE` is correctly threaded in as a template parameter, but `VSCODE_PUBLISH` is referenced as `variables['VSCODE_PUBLISH']`. That variable is defined in the parent `product-build.yml`, not in the included `product-copilot.yml` template.

Template `${{ }}` expressions in an included template are evaluated at template-expansion time and can only see:
- The template's own `parameters`
- Variables defined within that same template file
- System / predefined variables

User-defined variables from the parent pipeline are **not** in scope. So `eq(variables['VSCODE_PUBLISH'], true)` was always false, and on a regular publish build (e.g. [build 439795](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=439795&view=results)) the entire `notice@0` step was pruned from the generated YAML.

## Fix

Plumb `VSCODE_PUBLISH` through as a template parameter, mirroring how `VSCODE_RELEASE` is already wired up.

```yaml
# product-build.yml
- template: build/azure-pipelines/product-copilot.yml@self
  parameters:
    VSCODE_PUBLISH: ${{ variables.VSCODE_PUBLISH }}
    VSCODE_RELEASE: ${{ parameters.VSCODE_RELEASE }}
```

```yaml
# product-copilot.yml
- ${{ if or(eq(parameters.VSCODE_PUBLISH, true), eq(parameters.VSCODE_RELEASE, true)) }}:
  - task: notice@0
    ...
```

Workflow where the step exists on publish: https://dev.azure.com/monacotools/Monaco/_build/results?buildId=440647&view=results

Workflow where the step does not exist (no publish or release): https://dev.azure.com/monacotools/Monaco/_build/results?buildId=440648&view=logs&s=0237fa6e-9275-5b98-04d5-29ae92fc4838

Release + publish sample (step is there): https://dev.azure.com/monacotools/Monaco/_build/results?buildId=440656&view=results
Release no publish sample (step is there): https://dev.azure.com/monacotools/Monaco/_build/results?buildId=440657&view=results