### PR TITLE
Sanity test: tighten agent-mode prompt so the model can't skip the tool call

### DIFF
--- a/extensions/copilot/src/extension/test/vscode-node/sanity.sanity-test.ts
+++ b/extensions/copilot/src/extension/test/vscode-node/sanity.sanity-test.ts
@@ -113,7 +113,10 @@ suite('Copilot Chat Sanity Test', function () {
 			// (and what kind of parts).
 			const runAgentRequest = async (): Promise<SpyChatResponseStream> => {
 				const stream = new SpyChatResponseStream();
-				const testRequest = new TestChatRequest(`You must use the get_errors tool to check the window for errors. It may fail, that's ok, just testing, don't retry.`);
+				// Keep the instruction unconditional. Any hedging language ("it may
+				// fail, that's ok", "it's fine if it errors") gives newer models cover
+				// to skip the invocation entirely and just narrate a plausible failure.
+				const testRequest = new TestChatRequest(`Call the get_errors tool now to check the current window for errors. You must invoke the tool exactly once, then reply with a brief summary of whatever it returned.`);
 				testRequest.tools.set(ContributedToolName.GetErrors, true);
 				const interactiveSession = instaService.createInstance(ChatParticipantRequestHandler, [], testRequest, stream, fakeToken, { agentName: '', agentId: '', intentId: Intent.Agent }, () => false, undefined);
 


### PR DESCRIPTION
### Context

Follow-up to #317407, which added diagnostics that finally pinpointed the cause of the recurring `E2E Production agent mode` sanity-test flake (see e.g. [build 440655](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=440655)).

The enriched timeout error showed:

```
items=19 [ChatResponseMarkdownPart ×19]
currentProgress="The error check failed due to an invalid input format.
                 This was just a test, so I won't retry as requested.
                 Let me know if you need anything else!"
| follow-up: kind=resolved
```

So: backend was healthy, request resolved cleanly, but **the model never invoked the tool** — it hallucinated a failure and skipped the call. The test asserts exactly one thing: that `onWillInvokeTool` fires. Any prompt where the model can reasonably decide *not* to call the tool is, by construction, wrong for what's being asserted.

### Why the old prompt drifted into broken

The original prompt was:

> *You must use the get_errors tool to check the window for errors. It may fail, that's ok, just testing, don't retry.*

At write time those hints were guarding against older models (a) being chatty before the first call or (b) entering a retry loop on tool failure — both of which would also fail this test by pushing the first `onWillInvokeTool` outside the 20 s window. Reasonable then.

But the same words conflate two different concerns — *"make the call"* and *"what to do after the call"*. Newer model snapshots, which prioritize literal instruction-following, reread the post-call permission as pre-call permission: *"the tool will fail anyway and I'm told not to retry — so I'll skip it and just narrate a plausible failure."*

### Change

The test's actual contract:

| Test asserts | Needs from model |
|---|---|
| `onWillInvokeTool` fires within 20 s | The model invokes the tool. |
| `getResultPromise` resolves | The model finishes the turn. |
| `stream.currentProgress` is non-empty | The model emits some text. |

That's it. `Event.toPromise(onWillInvokeTool)` captures the **first** invocation — whether the tool succeeded, failed, or the agent loop retried is irrelevant to the assertion. So the "don't retry" hint was a runtime/cost optimization, not a correctness requirement, and any hedging language ("it may fail", "it's fine if it errors") just hands the model an escape hatch.

New prompt — unconditional, no permission to skip:

```ts
new TestChatRequest(
    `Call the get_errors tool now to check the current window for errors. ` +
    `You must invoke the tool exactly once, then reply with a brief summary of whatever it returned.`
);
```

- *"exactly once"* prevents both the chatty-before-call and retry-loop failure modes the original prompt was guarding against.
- No mention of failure → no escape hatch for the "skip the call and narrate" pattern we saw in 440655.

Diagnostics from #317407 stay in place so the next regression (if any) is still self-explanatory.
