### PR TITLE
agent-host: filter session list by workspace folders

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListController.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListController.ts
@@ -6,6 +6,7 @@
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { Emitter } from '../../../../../../base/common/event.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
+import { extUriBiasedIgnorePathCase } from '../../../../../../base/common/resources.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { generateUuid } from '../../../../../../base/common/uuid.js';
 import { AgentSession, type IAgentConnection } from '../../../../../../platform/agentHost/common/agentService.js';
@@ -107,6 +108,10 @@ export class AgentHostSessionListController extends Disposable implements IChatS
 			if (n.type === 'root/sessionAdded' && n.summary.provider === this._provider) {
 				const rawId = AgentSession.id(n.summary.resource);
 				this._pendingNewSessions.delete(rawId);
+				const workingDir = typeof n.summary.workingDirectory === 'string' ? URI.parse(n.summary.workingDirectory) : n.summary.workingDirectory;
+				if (!this._isWorkingDirectoryInWorkspace(workingDir)) {
+					return;
+				}
 				this._cachedSummaries.set(rawId, n.summary);
 				const item = this._makeItemFromSummary(rawId, n.summary);
 				const existingIndex = this._items.findIndex(item => item.resource.path === `/${rawId}`);
@@ -143,6 +148,15 @@ export class AgentHostSessionListController extends Disposable implements IChatS
 				}
 				this._onDidChangeChatSessionItems.fire({ addedOrUpdated: [item] });
 			}
+		}));
+
+		// Re-fetch the session list whenever the set of VS Code workspace
+		// folders changes, since filtering depends on it. The agent host
+		// itself doesn't know which workspace this VS Code window has open,
+		// so we have to drive the refresh from this side.
+		this._register(this._workspaceContextService.onDidChangeWorkspaceFolders(() => {
+			this._cacheValid = false;
+			void this.refresh(CancellationToken.None);
 		}));
 	}
 
@@ -197,9 +211,13 @@ export class AgentHostSessionListController extends Disposable implements IChatS
 			this._onDidChangeChatSessionItems.fire({ addedOrUpdated: this._items });
 			return;
 		}
+		const previousResources = this._items.map(item => item.resource);
 		try {
 			const sessions = await this._connection.listSessions();
-			const filtered = sessions.filter(s => AgentSession.provider(s.session) === this._provider);
+			const filtered = sessions.filter(s =>
+				AgentSession.provider(s.session) === this._provider
+				&& this._isWorkingDirectoryInWorkspace(s.workingDirectory)
+			);
 			this._cachedSummaries.clear();
 			this._items = filtered.map(s => {
 				const rawId = AgentSession.id(s.session);
@@ -237,7 +255,32 @@ export class AgentHostSessionListController extends Disposable implements IChatS
 			this._cachedSummaries.clear();
 			this._items = [];
 		}
-		this._onDidChangeChatSessionItems.fire({ addedOrUpdated: this._items });
+		const currentResources = new Set(this._items.map(item => item.resource.toString()));
+		const removed = previousResources.filter(r => !currentResources.has(r.toString()));
+		this._onDidChangeChatSessionItems.fire({
+			...(this._items.length > 0 ? { addedOrUpdated: this._items } : undefined),
+			...(removed.length > 0 ? { removed } : undefined),
+		});
+	}
+
+	/**
+	 * Returns `true` if a session with the given working directory belongs
+	 * to the current VS Code workspace. When the window has no workspace
+	 * folders open (e.g. the Agents window, or an empty VS Code window),
+	 * filtering is disabled and every session is considered in-scope.
+	 *
+	 * Sessions without a working directory are excluded when a workspace
+	 * is open since they cannot be attributed to any folder.
+	 */
+	private _isWorkingDirectoryInWorkspace(workingDirectory: URI | undefined): boolean {
+		const folders = this._workspaceContextService.getWorkspace().folders;
+		if (folders.length === 0) {
+			return true;
+		}
+		if (!workingDirectory) {
+			return false;
+		}
+		return folders.some(folder => extUriBiasedIgnorePathCase.isEqualOrParent(workingDirectory, folder.uri));
 	}
 
 	private _makeItemFromSummary(rawId: string, summary: SessionSummary): IChatSessionItem {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListController.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListController.ts
@@ -89,6 +89,15 @@ export class AgentHostSessionListController extends Disposable implements IChatS
 	 * replacement), so this flag naturally resets on reconnect.
 	 */
 	private _cacheValid = false;
+	/**
+	 * Incremented whenever the in-memory list is mutated outside of
+	 * {@link refresh}. Used to detect races where a `root/sessionAdded`,
+	 * `root/sessionRemoved`, or `root/sessionSummaryChanged` notification
+	 * arrives while a `listSessions()` round-trip is in flight — in that
+	 * case our snapshot is stale and we must discard it and re-fetch
+	 * instead of overwriting the just-updated `_items`/`_cachedSummaries`.
+	 */
+	private _mutationGeneration = 0;
 
 	constructor(
 		private readonly _sessionType: string,
@@ -112,6 +121,7 @@ export class AgentHostSessionListController extends Disposable implements IChatS
 				if (!this._isWorkingDirectoryInWorkspace(workingDir)) {
 					return;
 				}
+				this._mutationGeneration++;
 				this._cachedSummaries.set(rawId, n.summary);
 				const item = this._makeItemFromSummary(rawId, n.summary);
 				const existingIndex = this._items.findIndex(item => item.resource.path === `/${rawId}`);
@@ -126,6 +136,7 @@ export class AgentHostSessionListController extends Disposable implements IChatS
 				this._pendingNewSessions.delete(removedId);
 				const idx = this._items.findIndex(item => item.resource.path === `/${removedId}`);
 				if (idx >= 0) {
+					this._mutationGeneration++;
 					const [removed] = this._items.splice(idx, 1);
 					this._cachedSummaries.delete(removedId);
 					this._onDidChangeChatSessionItems.fire({ removed: [removed.resource] });
@@ -136,6 +147,7 @@ export class AgentHostSessionListController extends Disposable implements IChatS
 				if (!cached) {
 					return;
 				}
+				this._mutationGeneration++;
 				const updated = { ...cached, ...n.changes };
 				this._cachedSummaries.set(rawId, updated);
 
@@ -203,60 +215,86 @@ export class AgentHostSessionListController extends Disposable implements IChatS
 		return item;
 	}
 
-	async refresh(_token: CancellationToken): Promise<void> {
+	async refresh(token: CancellationToken): Promise<void> {
 		if (this._cacheValid) {
 			// Cache is kept in sync by notify/sessionAdded,
 			// notify/sessionRemoved, and notify/sessionSummaryChanged. No
 			// need to round-trip through the agent host on every refresh.
-			this._onDidChangeChatSessionItems.fire({ addedOrUpdated: this._items });
+			if (this._items.length > 0) {
+				this._onDidChangeChatSessionItems.fire({ addedOrUpdated: this._items });
+			}
 			return;
 		}
 		const previousResources = this._items.map(item => item.resource);
+		const startGeneration = this._mutationGeneration;
+		let sessions;
 		try {
-			const sessions = await this._connection.listSessions();
-			const filtered = sessions.filter(s =>
-				AgentSession.provider(s.session) === this._provider
-				&& this._isWorkingDirectoryInWorkspace(s.workingDirectory)
-			);
-			this._cachedSummaries.clear();
-			this._items = filtered.map(s => {
-				const rawId = AgentSession.id(s.session);
-				this._pendingNewSessions.delete(rawId);
-				let status = s.status ?? SessionStatus.Idle;
-				if (s.isRead) {
-					status |= SessionStatus.IsRead;
-				}
-				if (s.isArchived) {
-					status |= SessionStatus.IsArchived;
-				}
-				this._cachedSummaries.set(rawId, {
-					resource: s.session.toString(),
-					provider: this._provider,
-					title: s.summary ?? `Session ${rawId.substring(0, 8)}`,
-					status,
-					activity: s.activity,
-					createdAt: s.startTime,
-					modifiedAt: s.modifiedTime,
-					workingDirectory: s.workingDirectory?.toString(),
-					changesets: s.changesets ? [...s.changesets] : undefined,
-				});
-				return this._makeItem(rawId, {
-					title: s.summary,
-					status,
-					activity: s.activity,
-					workingDirectory: s.workingDirectory,
-					createdAt: s.startTime,
-					modifiedAt: s.modifiedTime,
-					changesets: s.changesets,
-				});
-			});
-			this._cacheValid = true;
+			sessions = await this._connection.listSessions();
 		} catch {
+			// If notifications mutated the list while we were fetching,
+			// the in-memory state is more up-to-date than our (now failed)
+			// fetch. Bail out without clobbering it.
+			if (startGeneration !== this._mutationGeneration) {
+				return;
+			}
+			if (this._items.length === 0) {
+				return;
+			}
+			const removed = previousResources;
 			this._cachedSummaries.clear();
 			this._items = [];
+			this._onDidChangeChatSessionItems.fire({ removed });
+			return;
 		}
+		// If notifications mutated the list between the request and the
+		// response, our snapshot is stale — discard it and re-fetch
+		// instead of overwriting the just-updated `_items` /
+		// `_cachedSummaries`.
+		if (startGeneration !== this._mutationGeneration) {
+			return this.refresh(token);
+		}
+		const filtered = sessions.filter(s =>
+			AgentSession.provider(s.session) === this._provider
+			&& this._isWorkingDirectoryInWorkspace(s.workingDirectory)
+		);
+		this._cachedSummaries.clear();
+		this._items = filtered.map(s => {
+			const rawId = AgentSession.id(s.session);
+			this._pendingNewSessions.delete(rawId);
+			let status = s.status ?? SessionStatus.Idle;
+			if (s.isRead) {
+				status |= SessionStatus.IsRead;
+			}
+			if (s.isArchived) {
+				status |= SessionStatus.IsArchived;
+			}
+			this._cachedSummaries.set(rawId, {
+				resource: s.session.toString(),
+				provider: this._provider,
+				title: s.summary ?? `Session ${rawId.substring(0, 8)}`,
+				status,
+				activity: s.activity,
+				createdAt: s.startTime,
+				modifiedAt: s.modifiedTime,
+				workingDirectory: s.workingDirectory?.toString(),
+				changesets: s.changesets ? [...s.changesets] : undefined,
+			});
+			return this._makeItem(rawId, {
+				title: s.summary,
+				status,
+				activity: s.activity,
+				workingDirectory: s.workingDirectory,
+				createdAt: s.startTime,
+				modifiedAt: s.modifiedTime,
+				changesets: s.changesets,
+			});
+		});
+		this._cacheValid = true;
 		const currentResources = new Set(this._items.map(item => item.resource.toString()));
 		const removed = previousResources.filter(r => !currentResources.has(r.toString()));
+		if (this._items.length === 0 && removed.length === 0) {
+			return;
+		}
 		this._onDidChangeChatSessionItems.fire({
 			...(this._items.length > 0 ? { addedOrUpdated: this._items } : undefined),
 			...(removed.length > 0 ? { removed } : undefined),

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -331,6 +331,10 @@ class MockAgentHostService extends mock<IAgentHostService>() {
 		this._sessions.set(AgentSession.id(meta.session), meta);
 	}
 
+	fireNotification(notification: INotification): void {
+		this._onDidNotification.fire(notification);
+	}
+
 	dispose(): void {
 		this._onDidAction.dispose();
 		this._onDidNotification.dispose();
@@ -426,7 +430,7 @@ function createTestServices(disposables: DisposableStore, workingDirectoryResolv
 		_serviceBrand: undefined,
 	});
 	instantiationService.stub(IOutputService, { getChannel: () => undefined });
-	instantiationService.stub(IWorkspaceContextService, { getWorkspace: () => ({ id: '', folders: [] }), getWorkspaceFolder: () => null });
+	instantiationService.stub(IWorkspaceContextService, { getWorkspace: () => ({ id: '', folders: [] }), getWorkspaceFolder: () => null, onDidChangeWorkspaceFolders: Event.None });
 	instantiationService.stub(IChatEditingService, {
 		registerEditingSessionProvider: () => toDisposable(() => { }),
 	});
@@ -844,6 +848,115 @@ suite('AgentHostChatContribution', () => {
 			assert.strictEqual(listCalls, 2);
 		});
 
+		test('refresh filters out sessions whose workingDirectory is not in any workspace folder', async () => {
+			const { instantiationService, agentHostService } = createTestServices(disposables);
+
+			const workspaceFolder = URI.file('/workspace/root');
+			instantiationService.stub(IWorkspaceContextService, {
+				getWorkspace: () => ({ id: '', folders: [{ uri: workspaceFolder, name: 'root', index: 0, toResource: () => workspaceFolder }] }),
+				getWorkspaceFolder: () => null,
+				onDidChangeWorkspaceFolders: Event.None,
+			});
+
+			agentHostService.addSession({ session: AgentSession.uri('copilot', 'in-ws'), startTime: 1000, modifiedTime: 2000, summary: 'In workspace', workingDirectory: URI.file('/workspace/root/sub') });
+			agentHostService.addSession({ session: AgentSession.uri('copilot', 'out-ws'), startTime: 1000, modifiedTime: 2000, summary: 'Outside workspace', workingDirectory: URI.file('/other/place') });
+			agentHostService.addSession({ session: AgentSession.uri('copilot', 'no-wd'), startTime: 1000, modifiedTime: 2000, summary: 'No working directory' });
+
+			const listController = disposables.add(instantiationService.createInstance(AgentHostSessionListController, 'agent-host-copilot', 'copilot', agentHostService, undefined, 'local'));
+
+			await listController.refresh(CancellationToken.None);
+
+			assert.deepStrictEqual(listController.items.map(item => item.label), ['In workspace']);
+		});
+
+		test('refresh does not filter when no workspace folders are open', async () => {
+			const { listController, agentHostService } = createContribution(disposables);
+
+			agentHostService.addSession({ session: AgentSession.uri('copilot', 'a'), startTime: 1000, modifiedTime: 2000, summary: 'A', workingDirectory: URI.file('/any/path') });
+			agentHostService.addSession({ session: AgentSession.uri('copilot', 'b'), startTime: 1000, modifiedTime: 2000, summary: 'B' });
+
+			await listController.refresh(CancellationToken.None);
+
+			assert.strictEqual(listController.items.length, 2);
+		});
+
+		test('workspace folder change re-fetches and updates the filtered session list', async () => {
+			const { instantiationService, agentHostService } = createTestServices(disposables);
+
+			const workspaceFolder = URI.file('/workspace/root');
+			let folders: { uri: URI; name: string; index: number; toResource: () => URI }[] = [];
+			const onDidChangeWorkspaceFolders = disposables.add(new Emitter<{ readonly added: never[]; readonly removed: never[]; readonly changed: never[] }>());
+			instantiationService.stub(IWorkspaceContextService, {
+				getWorkspace: () => ({ id: '', folders: [...folders] }),
+				getWorkspaceFolder: () => null,
+				onDidChangeWorkspaceFolders: onDidChangeWorkspaceFolders.event,
+			});
+
+			agentHostService.addSession({ session: AgentSession.uri('copilot', 'in-ws'), startTime: 1000, modifiedTime: 2000, summary: 'In workspace', workingDirectory: URI.file('/workspace/root/sub') });
+			agentHostService.addSession({ session: AgentSession.uri('copilot', 'out-ws'), startTime: 1000, modifiedTime: 2000, summary: 'Outside workspace', workingDirectory: URI.file('/other/place') });
+
+			const listController = disposables.add(instantiationService.createInstance(AgentHostSessionListController, 'agent-host-copilot', 'copilot', agentHostService, undefined, 'local'));
+
+			// Initially: no folders → no filter → both sessions visible.
+			await listController.refresh(CancellationToken.None);
+			assert.strictEqual(listController.items.length, 2);
+
+			// Open a workspace folder → only the in-workspace session should remain.
+			folders = [{ uri: workspaceFolder, name: 'root', index: 0, toResource: () => workspaceFolder }];
+			onDidChangeWorkspaceFolders.fire({ added: [], removed: [], changed: [] });
+			await timeout(0);
+
+			assert.deepStrictEqual(listController.items.map(item => item.label), ['In workspace']);
+		});
+
+		test('sessionAdded notification filters out sessions outside the workspace', async () => {
+			const { instantiationService, agentHostService } = createTestServices(disposables);
+
+			const workspaceFolder = URI.file('/workspace/root');
+			instantiationService.stub(IWorkspaceContextService, {
+				getWorkspace: () => ({ id: '', folders: [{ uri: workspaceFolder, name: 'root', index: 0, toResource: () => workspaceFolder }] }),
+				getWorkspaceFolder: () => null,
+				onDidChangeWorkspaceFolders: Event.None,
+			});
+
+			const listController = disposables.add(instantiationService.createInstance(AgentHostSessionListController, 'agent-host-copilot', 'copilot', agentHostService, undefined, 'local'));
+
+			await listController.refresh(CancellationToken.None);
+			assert.strictEqual(listController.items.length, 0);
+
+			// Simulate a remote session being added in another workspace.
+			agentHostService.fireNotification({
+				type: 'root/sessionAdded',
+				summary: {
+					resource: AgentSession.uri('copilot', 'foreign').toString(),
+					provider: 'copilot',
+					title: 'Foreign workspace session',
+					status: SessionStatus.Idle,
+					createdAt: 1000,
+					modifiedAt: 2000,
+					workingDirectory: URI.file('/other/workspace').toString(),
+				},
+			} as INotification);
+
+			assert.strictEqual(listController.items.length, 0);
+
+			// And one in our workspace should be included.
+			agentHostService.fireNotification({
+				type: 'root/sessionAdded',
+				summary: {
+					resource: AgentSession.uri('copilot', 'local').toString(),
+					provider: 'copilot',
+					title: 'Local session',
+					status: SessionStatus.Idle,
+					createdAt: 1000,
+					modifiedAt: 2000,
+					workingDirectory: URI.file('/workspace/root/sub').toString(),
+				},
+			} as INotification);
+
+			assert.deepStrictEqual(listController.items.map(item => item.label), ['Local session']);
+		});
+
 		test('newChatSessionItem creates final-looking resource used for requested backend session', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { listController, sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
@@ -876,6 +989,7 @@ suite('AgentHostChatContribution', () => {
 			instantiationService.stub(IWorkspaceContextService, {
 				getWorkspace: () => ({ id: '', folders: [{ uri: workspaceFolder, name: 'root', index: 0, toResource: () => workspaceFolder }] }),
 				getWorkspaceFolder: () => null,
+				onDidChangeWorkspaceFolders: Event.None,
 			});
 
 			const rebindCalls: { oldResource: URI; newResource: URI; provider: string; workingDirectory: URI | undefined }[] = [];


### PR DESCRIPTION
When connected to the local agent host, the chat sessions sidebar was listing every running session regardless of where they were started. This change filters those sessions to only include ones whose `workingDirectory` is inside one of the current VS Code workspace folders.

### Changes

- `AgentHostSessionListController` now filters sessions by workspace folder in:
  - `refresh()` — when initially listing sessions from `IAgentConnection.listSessions()`
  - The `root/sessionAdded` notification handler — for live updates
- Subscribes to `IWorkspaceContextService.onDidChangeWorkspaceFolders` and re-fetches when folders are added/removed.
- `refresh()` now also emits `removed` items (diffed against previous resources) so the UI clears sessions that drop out of scope.

### Behavior when no workspace folders are open

Filtering is disabled when no workspace folders are open. This preserves the existing behavior of the Agents window (which has an empty workspace) and empty windows.

### Tests

Added 4 unit tests covering:
- Filtering on `refresh()`
- No filter when no workspace folders are open
- Workspace folder change triggers re-fetch and updates the list
- `sessionAdded` notifications are also filtered

All 138 tests in the affected file pass.

(Written by Copilot)