### PR TITLE
Ignore queued wheel events from before window focus

### DIFF
--- a/src/vs/base/browser/mouseEvent.ts
+++ b/src/vs/base/browser/mouseEvent.ts
@@ -119,6 +119,82 @@ interface IGeckoMouseWheelEvent {
 	detail: number;
 }
 
+const MOUSE_WHEEL_FOCUS_GRACE_TIME = 50;
+
+interface IWindowMouseWheelEventFilterState {
+	readonly targetWindow: Window;
+	readonly onFocus: (event: Event) => void;
+	references: number;
+	lastFocusTime: number;
+}
+
+const windowMouseWheelEventFilterStates = new WeakMap<Window, IWindowMouseWheelEventFilterState>();
+
+export class WindowMouseWheelEventFilter {
+
+	private readonly _state: IWindowMouseWheelEventFilterState;
+
+	constructor(private readonly _targetWindow: Window) {
+		this._state = getWindowMouseWheelEventFilterState(this._targetWindow);
+		this._state.references++;
+	}
+
+	public shouldIgnore(e: IMouseWheelEvent): boolean {
+		if (!this._state.lastFocusTime) {
+			return false;
+		}
+
+		const eventTime = getEventTime(e, e.view?.window ?? this._targetWindow);
+		return eventTime > 0 && eventTime < this._state.lastFocusTime - MOUSE_WHEEL_FOCUS_GRACE_TIME;
+	}
+
+	public dispose(): void {
+		this._state.references--;
+		if (this._state.references === 0) {
+			this._state.targetWindow.removeEventListener('focus', this._state.onFocus, true);
+			windowMouseWheelEventFilterStates.delete(this._state.targetWindow);
+		}
+	}
+}
+
+function getWindowMouseWheelEventFilterState(targetWindow: Window): IWindowMouseWheelEventFilterState {
+	let state = windowMouseWheelEventFilterStates.get(targetWindow);
+	if (!state) {
+		state = {
+			targetWindow,
+			references: 0,
+			lastFocusTime: targetWindow.document.hasFocus() ? getWindowTime(targetWindow) : 0,
+			onFocus: (event: Event) => {
+				state!.lastFocusTime = getEventTime(event, targetWindow);
+			}
+		};
+		targetWindow.addEventListener('focus', state.onFocus, true);
+		windowMouseWheelEventFilterStates.set(targetWindow, state);
+	}
+	return state;
+}
+
+function getWindowTime(targetWindow: Window): number {
+	return typeof targetWindow.performance?.now === 'function' ? targetWindow.performance.now() : Date.now();
+}
+
+function getEventTime(e: Event, targetWindow: Window): number {
+	const timeStamp = e.timeStamp;
+	if (!Number.isFinite(timeStamp) || timeStamp <= 0) {
+		return 0;
+	}
+
+	if (timeStamp > 1_000_000_000_000) {
+		const timeOrigin = typeof targetWindow.performance?.timeOrigin === 'number'
+			? targetWindow.performance.timeOrigin
+			: Date.now() - getWindowTime(targetWindow);
+
+		return timeStamp - timeOrigin;
+	}
+
+	return timeStamp;
+}
+
 export class StandardWheelEvent {
 
 	public readonly browserEvent: IMouseWheelEvent | null;

--- a/src/vs/base/browser/ui/scrollbar/scrollableElement.ts
+++ b/src/vs/base/browser/ui/scrollbar/scrollableElement.ts
@@ -6,7 +6,7 @@
 import { getZoomFactor, isChrome } from '../../browser.js';
 import * as dom from '../../dom.js';
 import { FastDomNode, createFastDomNode } from '../../fastDomNode.js';
-import { IMouseEvent, IMouseWheelEvent, StandardWheelEvent } from '../../mouseEvent.js';
+import { IMouseEvent, IMouseWheelEvent, StandardWheelEvent, WindowMouseWheelEventFilter } from '../../mouseEvent.js';
 import { ScrollbarHost } from './abstractScrollbar.js';
 import { HorizontalScrollbar } from './horizontalScrollbar.js';
 import { ScrollableElementChangeOptions, ScrollableElementCreationOptions, ScrollableElementResolvedOptions } from './scrollableElementOptions.js';
@@ -184,6 +184,7 @@ export abstract class AbstractScrollableElement extends Widget {
 	private readonly _topLeftShadowDomNode: FastDomNode<HTMLElement> | null;
 
 	private readonly _listenOnDomNode: HTMLElement;
+	private _mouseWheelEventFilter: WindowMouseWheelEventFilter | null = null;
 
 	private _mouseWheelToDispose: IDisposable[];
 
@@ -368,7 +369,25 @@ export abstract class AbstractScrollableElement extends Widget {
 	}
 
 	public delegateScrollFromMouseWheelEvent(browserEvent: IMouseWheelEvent) {
+		if (this._shouldIgnoreMouseWheelEvent(browserEvent)) {
+			return;
+		}
+
 		this._onMouseWheel(new StandardWheelEvent(browserEvent));
+	}
+
+	private _shouldIgnoreMouseWheelEvent(browserEvent: IMouseWheelEvent): boolean {
+		if (!this._mouseWheelEventFilter) {
+			this._mouseWheelEventFilter = this._register(new WindowMouseWheelEventFilter(dom.getWindow(this._listenOnDomNode)));
+		}
+
+		if (!this._mouseWheelEventFilter.shouldIgnore(browserEvent)) {
+			return false;
+		}
+
+		browserEvent.preventDefault();
+		browserEvent.stopPropagation();
+		return true;
 	}
 
 	private async _periodicSync(): Promise<void> {
@@ -418,7 +437,7 @@ export abstract class AbstractScrollableElement extends Widget {
 		// Start listening (if necessary)
 		if (shouldListen) {
 			const onMouseWheel = (browserEvent: IMouseWheelEvent) => {
-				this._onMouseWheel(new StandardWheelEvent(browserEvent));
+				this.delegateScrollFromMouseWheelEvent(browserEvent);
 			};
 
 			this._mouseWheelToDispose.push(dom.addDisposableListener(this._listenOnDomNode, dom.EventType.MOUSE_WHEEL, onMouseWheel, { passive: false }));

--- a/src/vs/base/test/browser/mouseEvent.test.ts
+++ b/src/vs/base/test/browser/mouseEvent.test.ts
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { IMouseWheelEvent, WindowMouseWheelEventFilter } from '../../browser/mouseEvent.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../common/utils.js';
+
+suite('mouseEvent', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('ignores wheel events queued before the window regained focus', () => {
+		const targetWindow = createTestWindow({ hasFocus: false, now: 100 });
+		const filter = store.add(new WindowMouseWheelEventFilter(targetWindow.window));
+
+		assert.strictEqual(filter.shouldIgnore(createWheelEvent(10, targetWindow.window)), false);
+
+		targetWindow.dispatchFocus(1000);
+
+		assert.strictEqual(filter.shouldIgnore(createWheelEvent(200, targetWindow.window)), true);
+		assert.strictEqual(filter.shouldIgnore(createWheelEvent(970, targetWindow.window)), false);
+		assert.strictEqual(filter.shouldIgnore(createWheelEvent(1000, targetWindow.window)), false);
+		assert.strictEqual(filter.shouldIgnore(createWheelEvent(1050, targetWindow.window)), false);
+	});
+
+	test('normalizes epoch-based wheel event timestamps', () => {
+		const targetWindow = createTestWindow({ hasFocus: false, now: 100, timeOrigin: 100000 });
+		const filter = store.add(new WindowMouseWheelEventFilter(targetWindow.window));
+
+		targetWindow.dispatchFocus(101000);
+
+		assert.strictEqual(filter.shouldIgnore(createWheelEvent(100200, targetWindow.window)), true);
+		assert.strictEqual(filter.shouldIgnore(createWheelEvent(100970, targetWindow.window)), false);
+		assert.strictEqual(filter.shouldIgnore(createWheelEvent(101000, targetWindow.window)), false);
+	});
+});
+
+function createTestWindow(options: { hasFocus: boolean; now: number; timeOrigin?: number }): { window: Window; dispatchFocus(timeStamp: number): void } {
+	let hasFocus = options.hasFocus;
+	let focusListener: ((event: Event) => void) | undefined;
+
+	const testWindow = {
+		document: {
+			hasFocus: () => hasFocus
+		},
+		performance: {
+			now: () => options.now,
+			timeOrigin: options.timeOrigin ?? 0
+		},
+		addEventListener: (type: string, listener: EventListenerOrEventListenerObject) => {
+			if (type === 'focus') {
+				focusListener = typeof listener === 'function' ? listener : (event: Event) => listener.handleEvent(event);
+			}
+		},
+		removeEventListener: (type: string) => {
+			if (type === 'focus') {
+				focusListener = undefined;
+			}
+		}
+	} as unknown as Window;
+
+	return {
+		window: testWindow,
+		dispatchFocus: (timeStamp: number) => {
+			hasFocus = true;
+			focusListener?.({ timeStamp } as Event);
+		}
+	};
+}
+
+function createWheelEvent(timeStamp: number, targetWindow: Window): IMouseWheelEvent {
+	return { timeStamp, view: targetWindow } as IMouseWheelEvent;
+}

--- a/src/vs/editor/browser/controller/mouseHandler.ts
+++ b/src/vs/editor/browser/controller/mouseHandler.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as dom from '../../../base/browser/dom.js';
-import { StandardWheelEvent, IMouseWheelEvent } from '../../../base/browser/mouseEvent.js';
+import { StandardWheelEvent, IMouseWheelEvent, WindowMouseWheelEventFilter } from '../../../base/browser/mouseEvent.js';
 import { Disposable, IDisposable } from '../../../base/common/lifecycle.js';
 import * as platform from '../../../base/common/platform.js';
 import { HitTestContext, MouseTarget, MouseTargetFactory, PointerHandlerLastRenderData } from './mouseTarget.js';
@@ -140,6 +140,7 @@ export class MouseHandler extends ViewEventHandler {
 	private _setupMouseWheelZoomListener(): void {
 
 		const classifier = MouseWheelClassifier.INSTANCE;
+		const mouseWheelEventFilter = this._register(new WindowMouseWheelEventFilter(dom.getWindow(this.viewHelper.viewDomNode)));
 
 		let prevMouseWheelTime = 0;
 		let gestureStartZoomLevel = EditorZoom.getZoomLevel();
@@ -147,6 +148,12 @@ export class MouseHandler extends ViewEventHandler {
 		let gestureAccumulatedDelta = 0;
 
 		const onMouseWheel = (browserEvent: IMouseWheelEvent) => {
+			if (mouseWheelEventFilter.shouldIgnore(browserEvent)) {
+				browserEvent.preventDefault();
+				browserEvent.stopPropagation();
+				return;
+			}
+
 			this.viewController.emitMouseWheel(browserEvent);
 
 			if (!this._context.configuration.options.get(EditorOption.mouseWheelZoom)) {


### PR DESCRIPTION
Fixes #28795

This filters wheel events that were generated before the VS Code window regained focus. The guard records the window focus timestamp and ignores later-delivered wheel events whose event timestamp predates that focus point, preventing queued scroll input from being replayed into the editor or shared scrollable elements after returning to VS Code.

This is intentionally tied to the window focus boundary instead of dropping every event older than a fixed age, so delayed wheel events while the window has continuously been focused are preserved.

Verification:
- `git diff --check`
- Transpile syntax check for `src/vs/base/browser/mouseEvent.ts`, `src/vs/base/browser/ui/scrollbar/scrollableElement.ts`, `src/vs/editor/browser/controller/mouseHandler.ts`, and `src/vs/base/test/browser/mouseEvent.test.ts` with TypeScript `6.0.0-dev.20260416`

I could not run the full VS Code browser test suite in this environment because this checkout does not have `node_modules` installed.