### PR TITLE
Drop wheel events queued before window focus

### DIFF
--- a/src/vs/base/browser/mouseEvent.ts
+++ b/src/vs/base/browser/mouseEvent.ts
@@ -141,7 +141,7 @@ function getLastWindowFocusTime(e: IMouseWheelEvent): number {
 	let lastFocusTime = lastWindowFocusTime.get(targetWindow);
 
 	if (typeof lastFocusTime === 'undefined') {
-		lastFocusTime = 0;
+		lastFocusTime = targetWindow.document.hasFocus() ? Date.now() : 0;
 		lastWindowFocusTime.set(targetWindow, lastFocusTime);
 		targetWindow.addEventListener('focus', () => lastWindowFocusTime.set(targetWindow, Date.now()), true);
 	}

--- a/src/vs/base/browser/mouseEvent.ts
+++ b/src/vs/base/browser/mouseEvent.ts
@@ -5,6 +5,7 @@
 
 import * as browser from './browser.js';
 import { IframeUtils } from './iframe.js';
+import { mainWindow } from './window.js';
 import * as platform from '../common/platform.js';
 
 export interface IMouseEvent {
@@ -117,6 +118,60 @@ interface IGeckoMouseWheelEvent {
 	VERTICAL_AXIS: number;
 	axis: number;
 	detail: number;
+}
+
+const PRE_FOCUS_MOUSE_WHEEL_EVENT_GRACE = 50;
+const lastWindowFocusTime = new WeakMap<Window, number>();
+
+export function isMouseWheelEventFromBeforeWindowFocus(e: IMouseWheelEvent, lastFocusTime = getLastWindowFocusTime(e)): boolean {
+	if (lastFocusTime <= 0) {
+		return false;
+	}
+
+	const eventTime = getMouseWheelEventEpochTime(e);
+	if (eventTime === null) {
+		return false;
+	}
+
+	return eventTime < lastFocusTime - PRE_FOCUS_MOUSE_WHEEL_EVENT_GRACE;
+}
+
+function getLastWindowFocusTime(e: IMouseWheelEvent): number {
+	const targetWindow = e.view ?? mainWindow;
+	let lastFocusTime = lastWindowFocusTime.get(targetWindow);
+
+	if (typeof lastFocusTime === 'undefined') {
+		lastFocusTime = 0;
+		lastWindowFocusTime.set(targetWindow, lastFocusTime);
+		targetWindow.addEventListener('focus', () => lastWindowFocusTime.set(targetWindow, Date.now()), true);
+	}
+
+	return lastFocusTime;
+}
+
+function getMouseWheelEventEpochTime(e: IMouseWheelEvent): number | null {
+	const timestamp = e.timeStamp;
+	if (!Number.isFinite(timestamp) || timestamp <= 0) {
+		return null;
+	}
+
+	return timestamp > 1_000_000_000_000
+		? timestamp
+		: getMouseWheelEventTimeOrigin(e) + timestamp;
+}
+
+function getMouseWheelEventTimeOrigin(e: IMouseWheelEvent): number {
+	const eventPerformance = e.view?.performance ?? mainWindow.performance;
+
+	if (typeof eventPerformance?.timeOrigin === 'number') {
+		return eventPerformance.timeOrigin;
+	}
+
+	if (typeof eventPerformance?.now === 'function') {
+		return Date.now() - eventPerformance.now();
+	}
+
+	return Date.now();
 }
 
 export class StandardWheelEvent {

--- a/src/vs/base/browser/ui/scrollbar/scrollableElement.ts
+++ b/src/vs/base/browser/ui/scrollbar/scrollableElement.ts
@@ -6,7 +6,7 @@
 import { getZoomFactor, isChrome } from '../../browser.js';
 import * as dom from '../../dom.js';
 import { FastDomNode, createFastDomNode } from '../../fastDomNode.js';
-import { IMouseEvent, IMouseWheelEvent, StandardWheelEvent } from '../../mouseEvent.js';
+import { IMouseEvent, IMouseWheelEvent, isMouseWheelEventFromBeforeWindowFocus, StandardWheelEvent } from '../../mouseEvent.js';
 import { ScrollbarHost } from './abstractScrollbar.js';
 import { HorizontalScrollbar } from './horizontalScrollbar.js';
 import { ScrollableElementChangeOptions, ScrollableElementCreationOptions, ScrollableElementResolvedOptions } from './scrollableElementOptions.js';
@@ -418,6 +418,12 @@ export abstract class AbstractScrollableElement extends Widget {
 		// Start listening (if necessary)
 		if (shouldListen) {
 			const onMouseWheel = (browserEvent: IMouseWheelEvent) => {
+				if (isMouseWheelEventFromBeforeWindowFocus(browserEvent)) {
+					browserEvent.preventDefault();
+					browserEvent.stopPropagation();
+					return;
+				}
+
 				this._onMouseWheel(new StandardWheelEvent(browserEvent));
 			};
 

--- a/src/vs/base/test/browser/mouseEvent.test.ts
+++ b/src/vs/base/test/browser/mouseEvent.test.ts
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { IMouseWheelEvent, isMouseWheelEventFromBeforeWindowFocus } from '../../browser/mouseEvent.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../common/utils.js';
+
+suite('mouseEvent', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('detects wheel events that predate the latest window focus', () => {
+		const targetWindow = { performance: { timeOrigin: 1_000 } } as unknown as Window;
+
+		const staleRelativeEvent = { timeStamp: 1_000, view: targetWindow } as IMouseWheelEvent;
+		const recentRelativeEvent = { timeStamp: 1_300, view: targetWindow } as IMouseWheelEvent;
+		const nearFocusRelativeEvent = { timeStamp: 1_260, view: targetWindow } as IMouseWheelEvent;
+		const staleEpochEvent = { timeStamp: 2_000_000_000_000, view: targetWindow } as IMouseWheelEvent;
+		const unknownTimestampEvent = { timeStamp: 0, view: targetWindow } as IMouseWheelEvent;
+
+		assert.strictEqual(isMouseWheelEventFromBeforeWindowFocus(staleRelativeEvent, 2_200), true);
+		assert.strictEqual(isMouseWheelEventFromBeforeWindowFocus(recentRelativeEvent, 2_200), false);
+		assert.strictEqual(isMouseWheelEventFromBeforeWindowFocus(nearFocusRelativeEvent, 2_300), false);
+		assert.strictEqual(isMouseWheelEventFromBeforeWindowFocus(staleEpochEvent, 2_000_000_000_200), true);
+		assert.strictEqual(isMouseWheelEventFromBeforeWindowFocus(unknownTimestampEvent, 2_200), false);
+		assert.strictEqual(isMouseWheelEventFromBeforeWindowFocus(staleRelativeEvent, 0), false);
+	});
+});

--- a/src/vs/base/test/browser/mouseEvent.test.ts
+++ b/src/vs/base/test/browser/mouseEvent.test.ts
@@ -26,4 +26,41 @@ suite('mouseEvent', () => {
 		assert.strictEqual(isMouseWheelEventFromBeforeWindowFocus(unknownTimestampEvent, 2_200), false);
 		assert.strictEqual(isMouseWheelEventFromBeforeWindowFocus(staleRelativeEvent, 0), false);
 	});
+
+	test('tracks the latest window focus time for wheel event filtering', () => {
+		const originalDateNow = Date.now;
+		const now = 2_200;
+
+		try {
+			Date.now = () => now;
+
+			const focusedWindow = {
+				document: { hasFocus: () => true },
+				performance: { timeOrigin: 1_000 },
+				addEventListener: () => { },
+			} as unknown as Window;
+
+			const staleAfterAlreadyFocusedEvent = { timeStamp: 1_000, view: focusedWindow } as IMouseWheelEvent;
+			assert.strictEqual(isMouseWheelEventFromBeforeWindowFocus(staleAfterAlreadyFocusedEvent), true);
+
+			let focusListener: ((event: Event) => void) | undefined;
+			const initiallyUnfocusedWindow = {
+				document: { hasFocus: () => false },
+				performance: { timeOrigin: 1_000 },
+				addEventListener: (type: string, listener: EventListenerOrEventListenerObject) => {
+					if (type === 'focus' && typeof listener === 'function') {
+						focusListener = listener;
+					}
+				},
+			} as unknown as Window;
+
+			const staleBeforeFocusEvent = { timeStamp: 1_000, view: initiallyUnfocusedWindow } as IMouseWheelEvent;
+			assert.strictEqual(isMouseWheelEventFromBeforeWindowFocus(staleBeforeFocusEvent), false);
+
+			focusListener?.(new Event('focus'));
+			assert.strictEqual(isMouseWheelEventFromBeforeWindowFocus(staleBeforeFocusEvent), true);
+		} finally {
+			Date.now = originalDateNow;
+		}
+	});
 });

--- a/src/vs/editor/browser/controller/mouseHandler.ts
+++ b/src/vs/editor/browser/controller/mouseHandler.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as dom from '../../../base/browser/dom.js';
-import { StandardWheelEvent, IMouseWheelEvent } from '../../../base/browser/mouseEvent.js';
+import { StandardWheelEvent, IMouseWheelEvent, isMouseWheelEventFromBeforeWindowFocus } from '../../../base/browser/mouseEvent.js';
 import { Disposable, IDisposable } from '../../../base/common/lifecycle.js';
 import * as platform from '../../../base/common/platform.js';
 import { HitTestContext, MouseTarget, MouseTargetFactory, PointerHandlerLastRenderData } from './mouseTarget.js';
@@ -147,6 +147,12 @@ export class MouseHandler extends ViewEventHandler {
 		let gestureAccumulatedDelta = 0;
 
 		const onMouseWheel = (browserEvent: IMouseWheelEvent) => {
+			if (isMouseWheelEventFromBeforeWindowFocus(browserEvent)) {
+				browserEvent.preventDefault();
+				browserEvent.stopPropagation();
+				return;
+			}
+
 			this.viewController.emitMouseWheel(browserEvent);
 
 			if (!this._context.configuration.options.get(EditorOption.mouseWheelZoom)) {


### PR DESCRIPTION
Fixes #28795

This filters wheel events whose timestamp predates the latest window focus before they reach the editor mouse wheel handler or the shared scrollable element handler. Those events can be queued while the window is unfocused and then replayed after focus returns, causing an unexpected editor scroll jump.

The filter keeps a small grace window around the focus timestamp so normal wheel input immediately after refocus is not discarded. It also handles both epoch-style and relative DOM event timestamps.

Verification:
- npm run -s compile-check-ts-native
- npm run -s eslint -- src/vs/base/browser/mouseEvent.ts src/vs/base/browser/ui/scrollbar/scrollableElement.ts src/vs/editor/browser/controller/mouseHandler.ts src/vs/base/test/browser/mouseEvent.test.ts
- npm run test-browser-no-install -- --run src/vs/base/test/browser/mouseEvent.test.ts --browser chromium
- npm run gulp -- compile-client
- npm run -s precommit