### PR TITLE
Speed up `npm run eslint`

### DIFF
--- a/.eslint-ignore
+++ b/.eslint-ignore
@@ -1,4 +1,3 @@
-**/build/*/**/*.js
 **/dist/**/*
 **/extensions/**/*.d.ts
 **/extensions/**/build/**

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ vscode.db
 product.overrides.json
 *.snap.actual
 *.tsbuildinfo
+.eslintcache
 .vscode-test
 .chat-simulation-data
 vscode-telemetry-docs/

--- a/.vscode/extensions/vscode-extras/src/npmUpToDateFeature.ts
+++ b/.vscode/extensions/vscode-extras/src/npmUpToDateFeature.ts
@@ -121,7 +121,7 @@ export class NpmUpToDateFeature extends vscode.Disposable {
 			this._output.trace('raw output:', output.trim());
 			return parsed;
 		} catch (e) {
-			this._output.error('_queryState error:', e as any);
+			this._output.error('_queryState error:', e);
 			return undefined;
 		}
 	}

--- a/build/azure-pipelines/common/installPlaywright.js
+++ b/build/azure-pipelines/common/installPlaywright.js
@@ -1,12 +1,12 @@
-"use strict";
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+"use strict";
 process.env.DEBUG = 'pw:install'; // enable logging for this (https://github.com/microsoft/playwright/issues/17394)
 const { installDefaultBrowsersForNpmInstall } = require('playwright-core/lib/server');
 async function install() {
-    await installDefaultBrowsersForNpmInstall();
+	await installDefaultBrowsersForNpmInstall();
 }
 install();
 //# sourceMappingURL=installPlaywright.js.map

--- a/build/eslint.ts
+++ b/build/eslint.ts
@@ -3,25 +3,38 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import eventStream from 'event-stream';
-import vfs from 'vinyl-fs';
+import { ESLint } from 'eslint';
 import { eslintFilter } from './filters.ts';
-import gulpEslint from './gulp-eslint.ts';
 
-function eslint(): NodeJS.ReadWriteStream {
-	return vfs
-		.src(Array.from(eslintFilter), { base: '.', follow: true, allowEmpty: true })
-		.pipe(
-			gulpEslint((results) => {
-				if (results.warningCount > 0 || results.errorCount > 0) {
-					throw new Error(`eslint failed with ${results.warningCount + results.errorCount} warnings and/or errors`);
-				}
-			})
-		).pipe(eventStream.through(function () { /* noop, important for the stream to end */ }));
+async function eslint(): Promise<void> {
+	const linter = new ESLint({
+		cache: true,
+		cacheLocation: '.eslintcache',
+		cacheStrategy: 'content',
+		concurrency: 'auto',
+		errorOnUnmatchedPattern: false,
+	});
+	const formatter = await linter.loadFormatter('compact');
+
+	const results = await linter.lintFiles(Array.from(eslintFilter));
+	const message = await formatter.format(results);
+	if (message) {
+		console.log(message);
+	}
+
+	let warningCount = 0;
+	let errorCount = 0;
+	for (const r of results) {
+		warningCount += r.warningCount;
+		errorCount += r.errorCount;
+	}
+	if (warningCount > 0 || errorCount > 0) {
+		throw new Error(`eslint failed with ${warningCount + errorCount} warnings and/or errors`);
+	}
 }
 
 if (import.meta.main) {
-	eslint().on('error', (err) => {
+	eslint().catch((err) => {
 		console.error();
 		console.error(err);
 		process.exit(1);


### PR DESCRIPTION
6x speed up for `npm run eslint` after the first run (and slight speed up for first run too). Mostly due to caching with some from concurrency too
