### PR TITLE
turn off harness & mcp provided slash commands for agent host backed agents

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/editor/chatInputCompletions.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/editor/chatInputCompletions.ts
@@ -229,6 +229,10 @@ class SlashCommandCompletions extends Disposable {
 					return null;
 				}
 
+				if (isAgentHostBackedWidget(widget)) {
+					return;
+				}
+
 				const range = computeCompletionRanges(model, position, SlashCommandWord);
 				if (!range) {
 					return null;
@@ -287,6 +291,10 @@ class SlashCommandCompletions extends Disposable {
 				const widget = this.chatWidgetService.getWidgetByInputUri(model.uri);
 				if (!widget || !widget.viewModel) {
 					return null;
+				}
+
+				if (isAgentHostBackedWidget(widget)) {
+					return;
 				}
 
 				// regex is the opposite of `mcpPromptReplaceSpecialChars` found in `mcpTypes.ts`


### PR DESCRIPTION
For https://github.com/microsoft/vscode/issues/305327

FYI @connor4312 MCP commands will have to come from the agent host as well. My understanding is that the agent host will maintain the MCP server connections, is that correct?