### PR TITLE
Update codicon font sizes to use compact variable

### DIFF
--- a/src/vs/base/browser/ui/dropdown/dropdown.css
+++ b/src/vs/base/browser/ui/dropdown/dropdown.css
@@ -36,7 +36,7 @@
 }
 
 .monaco-dropdown-with-primary > .dropdown-action-container > .monaco-dropdown > .dropdown-label .codicon[class*='codicon-'] {
-	font-size: 12px;
+	font-size: var(--vscode-codiconFontSize-compact);
 	padding-left: 0px;
 	padding-right: 0px;
 	line-height: 16px;

--- a/src/vs/editor/browser/widget/diffEditor/components/accessibleDiffViewer.css
+++ b/src/vs/editor/browser/widget/diffEditor/components/accessibleDiffViewer.css
@@ -50,7 +50,7 @@
 	}
 
 	.diff-review-spacer > .codicon {
-		font-size: 9px !important;
+		font-size: var(--vscode-codiconFontSize-compact) !important;
 	}
 
 	.diff-review-actions {

--- a/src/vs/editor/contrib/colorPicker/browser/colorPicker.css
+++ b/src/vs/editor/contrib/colorPicker/browser/colorPicker.css
@@ -60,7 +60,6 @@
 
 .colorpicker-header .picked-color .codicon {
 	color: inherit;
-	font-size: 14px;
 }
 
 .colorpicker-header .picked-color.light {

--- a/src/vs/editor/contrib/hover/browser/hover.css
+++ b/src/vs/editor/contrib/hover/browser/hover.css
@@ -69,7 +69,7 @@
 
 .monaco-editor .monaco-hover .hover-row .verbosity-actions-inner .codicon {
 	cursor: pointer;
-	font-size: 11px;
+	font-size: var(--vscode-codiconFontSize-compact);
 }
 
 .monaco-editor .monaco-hover .hover-row .verbosity-actions-inner .codicon.enabled {

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/view.css
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/view.css
@@ -252,7 +252,7 @@
 }
 
 .inline-edit-alternative-action-label .codicon {
-	font-size: 12px !important;
+	font-size: var(--vscode-codiconFontSize-compact) !important;
 	padding-right: 4px;
 }
 

--- a/src/vs/platform/actionWidget/browser/actionWidget.css
+++ b/src/vs/platform/actionWidget/browser/actionWidget.css
@@ -132,7 +132,7 @@
 }
 
 .action-widget .monaco-list-row.action .codicon {
-	font-size: 12px;
+	font-size: var(--vscode-codiconFontSize-compact);
 }
 
 .action-widget .monaco-list-row.action .action-list-item-toolbar .codicon {

--- a/src/vs/platform/actions/browser/menuEntryActionViewItem.css
+++ b/src/vs/platform/actions/browser/menuEntryActionViewItem.css
@@ -57,7 +57,7 @@
 }
 
 .monaco-dropdown-with-default > .dropdown-action-container > .monaco-dropdown > .dropdown-label .codicon[class*='codicon-'] {
-	font-size: 12px;
+	font-size: var(--vscode-codiconFontSize-compact);
 	padding-left: 0px;
 	padding-right: 0px;
 	line-height: 16px;

--- a/src/vs/sessions/browser/parts/mobile/mobileChatShell.css
+++ b/src/vs/sessions/browser/parts/mobile/mobileChatShell.css
@@ -615,7 +615,7 @@
  * read at a comfortable size for touch but stay tight to the label,
  * matching the iOS reference proportions. */
 .agent-sessions-workbench.phone-layout .new-chat-widget-container .new-chat-bottom-container .action-label > .codicon {
-	font-size: 13px;
+	font-size: var(--vscode-codiconFontSize-compact);
 }
 
 .agent-sessions-workbench.phone-layout .new-chat-widget-container .new-chat-bottom-container .action-label > .codicon-chevron-down {

--- a/src/vs/sessions/browser/parts/mobile/mobileChatShell.css
+++ b/src/vs/sessions/browser/parts/mobile/mobileChatShell.css
@@ -619,7 +619,7 @@
 }
 
 .agent-sessions-workbench.phone-layout .new-chat-widget-container .new-chat-bottom-container .action-label > .codicon-chevron-down {
-	font-size: 10px;
+	font-size: var(--vscode-codiconFontSize-compact);
 	margin-left: 4px;
 	opacity: 0.7;
 }

--- a/src/vs/sessions/contrib/aquarium/browser/media/aquarium.css
+++ b/src/vs/sessions/contrib/aquarium/browser/media/aquarium.css
@@ -225,16 +225,13 @@
 	opacity: 1;
 	color: var(--vscode-icon-foreground, var(--vscode-foreground, #cccccc));
 }
-.agents-aquarium-toggle .codicon {
-	font-size: 14px;
-}
 
 /* Off-state icon: the agents window logo (same asset as the mobile chat
  * shell's workspace picker). Theme-swapped under `.vs` / `.hc-light`. */
 .agents-aquarium-toggle-logo {
 	display: inline-block;
-	width: 14px;
-	height: 14px;
+	width: 16px;
+	height: 16px;
 	background: url('../../../../browser/media/sessions-logo-light.svg') center / contain no-repeat;
 	transform-origin: 50% 50%;
 	/* Brief attention-grabbing wiggle every 12s. Keyframes hold the rest

--- a/src/vs/sessions/contrib/changes/browser/media/changesView.css
+++ b/src/vs/sessions/contrib/changes/browser/media/changesView.css
@@ -343,7 +343,7 @@
 }
 
 .changes-file-list .changes-review-comments-badge .codicon {
-	font-size: 12px;
+	font-size: var(--vscode-codiconFontSize-compact);
 }
 
 .changes-file-list .changes-agent-feedback-badge {
@@ -356,7 +356,7 @@
 }
 
 .changes-file-list .changes-agent-feedback-badge .codicon {
-	font-size: 12px;
+	font-size: var(--vscode-codiconFontSize-compact);
 }
 
 .changes-file-list .working-set-lines-added {

--- a/src/vs/sessions/contrib/changes/browser/media/changesView.css
+++ b/src/vs/sessions/contrib/changes/browser/media/changesView.css
@@ -80,7 +80,7 @@
 	}
 
 	> .codicon {
-		font-size: 10px !important;
+		font-size: var(--vscode-codiconFontSize-compact) !important;
 		padding-left: 4px;
 		width: 10px;
 		height: 10px;

--- a/src/vs/sessions/contrib/changes/browser/media/checksWidget.css
+++ b/src/vs/sessions/contrib/changes/browser/media/checksWidget.css
@@ -101,10 +101,6 @@
 	line-height: 1;
 }
 
-.ci-status-widget-count-badge .codicon {
-	font-size: 14px;
-}
-
 .ci-status-widget-count-badge.ci-status-success .codicon {
 	color: var(--vscode-testing-iconPassed, #73c991);
 }

--- a/src/vs/sessions/contrib/chat/browser/media/chatInput.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatInput.css
@@ -161,7 +161,7 @@
 }
 
 .sessions-chat-config-toolbar .monaco-action-bar .action-item .action-label > .codicon {
-	font-size: 12px;
+	font-size: var(--vscode-codiconFontSize-compact);
 	flex-shrink: 0;
 	/* Override the base .monaco-action-bar .action-item .codicon { width:16px; height:16px }
 	 * so the leading icon sizes naturally to its font-size, matching the bottom-row pickers. */
@@ -402,7 +402,7 @@
 }
 
 .sessions-chat-attachment-remove .codicon {
-	font-size: 12px;
+	font-size: var(--vscode-codiconFontSize-compact);
 	padding: 0;
 }
 
@@ -442,7 +442,7 @@
 
 .sessions-chat-dnd-overlay .attach-context-overlay-text .codicon {
 	height: 12px;
-	font-size: 12px;
+	font-size: var(--vscode-codiconFontSize-compact);
 	margin-right: 3px;
 }
 

--- a/src/vs/sessions/contrib/chat/browser/media/chatInput.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatInput.css
@@ -279,10 +279,6 @@
 	display: flex;
 }
 
-.sessions-chat-loading-spinner .codicon {
-	font-size: 14px;
-}
-
 /* Attach row (pills only, above editor, inside input area) */
 .sessions-chat-attach-row {
 	display: flex;
@@ -322,7 +318,7 @@
 }
 
 .monaco-workbench .sessions-chat-attach-button .codicon[class*='codicon-'] {
-	font-size: 14px;
+	font-size: var(--vscode-codiconFontSize-compact);
 }
 
 /* Attached context container */
@@ -359,7 +355,7 @@
 }
 
 .sessions-chat-attachment-pill .codicon {
-	font-size: 14px;
+	font-size: var(--vscode-codiconFontSize-compact) !important;
 	flex-shrink: 0;
 	padding: 0 3px;
 }

--- a/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
@@ -187,7 +187,7 @@
 }
 
 .new-chat-widget-container .new-chat-bottom-container .action-label > .codicon {
-	font-size: 12px;
+	font-size: var(--vscode-codiconFontSize-compact);
 }
 
 .new-chat-widget-container .new-chat-bottom-container .action-label > .codicon-chevron-down,
@@ -363,7 +363,7 @@
 }
 
 .sessions-chat-picker-slot .action-label .codicon {
-	font-size: 12px;
+	font-size: var(--vscode-codiconFontSize-compact);
 	flex-shrink: 0;
 	/* Override the base .monaco-action-bar .action-item .codicon { width:16px; height:16px }
 	 * so codicons here size naturally to their font-size, matching pickers (like Copilot CLI)

--- a/src/vs/sessions/contrib/chat/browser/media/newChatInSession.css
+++ b/src/vs/sessions/contrib/chat/browser/media/newChatInSession.css
@@ -87,7 +87,7 @@
 
 .new-chat-in-session .new-chat-bottom-container .action-label .codicon,
 .new-chat-in-session .sessions-chat-toolbar .action-label .codicon {
-	font-size: 12px;
+	font-size: var(--vscode-codiconFontSize-compact);
 }
 
 .new-chat-in-session .sessions-chat-dropdown-label {

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/media/hostFilter.css
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/media/hostFilter.css
@@ -110,7 +110,7 @@
 }
 
 .agent-host-filter-combo .agent-host-filter-icon .codicon {
-	font-size: 14px;
+	font-size: var(--vscode-codiconFontSize-compact);
 }
 
 .agent-host-filter-combo .agent-host-filter-chevron .codicon {
@@ -162,7 +162,7 @@
 }
 
 .agent-host-filter-combo .agent-host-filter-connect .codicon {
-	font-size: 14px;
+	font-size: var(--vscode-codiconFontSize-compact);
 }
 
 .agent-host-filter-combo .agent-host-filter-connect.connected .codicon {

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/media/hostFilter.css
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/media/hostFilter.css
@@ -114,7 +114,7 @@
 }
 
 .agent-host-filter-combo .agent-host-filter-chevron .codicon {
-	font-size: 12px;
+	font-size: var(--vscode-codiconFontSize-compact);
 	opacity: 0.8;
 }
 

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -106,7 +106,7 @@
 
 		> .codicon {
 			flex-shrink: 0;
-			font-size: 12px;
+			font-size: var(--vscode-codiconFontSize-compact);
 			height: 16px;
 			display: flex;
 			align-items: center;
@@ -152,7 +152,7 @@
 			align-items: center;
 
 			> .codicon {
-				font-size: 12px;
+				font-size: var(--vscode-codiconFontSize-compact);
 			}
 		}
 

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -106,7 +106,6 @@
 
 		> .codicon {
 			flex-shrink: 0;
-			font-size: var(--vscode-codiconFontSize-compact);
 			height: 16px;
 			display: flex;
 			align-items: center;
@@ -481,7 +480,6 @@
 		line-height: 20px;
 
 		> .codicon {
-			font-size: 14px;
 			height: 20px;
 		}
 	}

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsTitleBarWidget.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsTitleBarWidget.css
@@ -129,9 +129,9 @@
 	gap: 2px;
 
 	.codicon {
-		font-size: 13px;
-		width: 13px;
-		height: 13px;
+		font-size: var(--vscode-codiconFontSize-compact);
+		width: var(--vscode-codiconFontSize-compact);
+		height: var(--vscode-codiconFontSize-compact);
 	}
 }
 

--- a/src/vs/workbench/browser/parts/activitybar/media/activityaction.css
+++ b/src/vs/workbench/browser/parts/activitybar/media/activityaction.css
@@ -210,7 +210,7 @@
 }
 
 .monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .badge .codicon.badge-content {
-	font-size: 13px;
+	font-size: var(--vscode-codiconFontSize-compact);
 	font-weight: unset;
 	padding: 0;
 	justify-content: center;

--- a/src/vs/workbench/browser/parts/views/media/paneviewlet.css
+++ b/src/vs/workbench/browser/parts/views/media/paneviewlet.css
@@ -62,7 +62,7 @@
 }
 
 .monaco-pane-view .pane > .pane-header .description .codicon {
-	font-size: 9px;
+	font-size: var(--vscode-codiconFontSize-compact);
 	margin-left: 2px;
 }
 

--- a/src/vs/workbench/browser/parts/views/media/views.css
+++ b/src/vs/workbench/browser/parts/views/media/views.css
@@ -133,7 +133,7 @@
 }
 
 .monaco-workbench .pane > .pane-body .welcome-view-content > p .codicon[class*='codicon-'] {
-	font-size: 13px;
+	font-size: var(--vscode-codiconFontSize-compact);
 	line-height: 1.4em;
 	vertical-align: bottom;
 }
@@ -177,7 +177,7 @@
 }
 
 .customview-tree .monaco-list .monaco-list-row .custom-view-tree-node-item .custom-view-tree-node-item-checkbox.codicon {
-	font-size: 13px;
+	font-size: var(--vscode-codiconFontSize-compact);
 	line-height: 15px;
 }
 

--- a/src/vs/workbench/contrib/browserView/electron-browser/media/browser.css
+++ b/src/vs/workbench/contrib/browserView/electron-browser/media/browser.css
@@ -111,7 +111,7 @@
 		}
 
 		.codicon {
-			font-size: 14px;
+			font-size: var(--vscode-codiconFontSize-compact);
 		}
 	}
 
@@ -171,7 +171,7 @@
 
 		.codicon {
 			color: inherit;
-			font-size: 14px;
+			font-size: var(--vscode-codiconFontSize-compact);
 			flex-shrink: 0;
 			opacity: 1;
 		}

--- a/src/vs/workbench/contrib/browserView/electron-browser/media/browser.css
+++ b/src/vs/workbench/contrib/browserView/electron-browser/media/browser.css
@@ -557,7 +557,7 @@
 		}
 
 		.codicon {
-			font-size: 15px;
+			font-size: 16px;
 			margin: 0;
 			color: var(--vscode-statusBarItem-errorForeground);
 		}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/media/agentHostChatInputPicker.css
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/media/agentHostChatInputPicker.css
@@ -43,7 +43,7 @@
 }
 
 .agent-host-chat-input-picker-slot .action-label .codicon-chevron-down {
-	font-size: 10px;
+	font-size: var(--vscode-codiconFontSize-compact);
 	margin-left: 4px;
 	opacity: 0.75;
 }

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/media/agentHostChatInputPicker.css
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/media/agentHostChatInputPicker.css
@@ -85,7 +85,7 @@
 		}
 
 		.codicon {
-			font-size: 12px;
+			font-size: var(--vscode-codiconFontSize-compact);
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/experiments/media/unifiedQuickAccess.css
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/experiments/media/unifiedQuickAccess.css
@@ -79,7 +79,7 @@
 }
 
 .unified-send-button .codicon {
-	font-size: 14px !important;
+	font-size: var(--vscode-codiconFontSize-compact) !important;
 	color: var(--vscode-button-foreground) !important;
 }
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/experiments/media/unifiedQuickAccess.css
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/experiments/media/unifiedQuickAccess.css
@@ -149,7 +149,7 @@
 }
 
 .unified-quick-access-pr-badge .codicon {
-	font-size: 12px;
+	font-size: var(--vscode-codiconFontSize-compact);
 }
 
 /* Action text styling (e.g., "Run 'zsh' command?") */

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -847,7 +847,7 @@
 }
 
 .ai-customization-management-editor .ai-customization-embedded-detail .embedded-detail-scope .codicon {
-	font-size: 12px;
+	font-size: var(--vscode-codiconFontSize-compact);
 }
 
 .ai-customization-management-editor .ai-customization-embedded-detail .embedded-detail-description {

--- a/src/vs/workbench/contrib/chat/browser/chatManagement/media/chatModelsWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/chatManagement/media/chatModelsWidget.css
@@ -183,7 +183,7 @@
 }
 
 .models-widget .models-table-container .monaco-table-td .model-token-limits .codicon {
-	font-size: 12px;
+	font-size: var(--vscode-codiconFontSize-compact);
 }
 
 /** Capabilities column styling **/

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/media/chatSessionPickerActionItem.css
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/media/chatSessionPickerActionItem.css
@@ -29,12 +29,12 @@
 	}
 
 	span.codicon {
-		font-size: 12px;
+		font-size: var(--vscode-codiconFontSize-compact);
 		margin-left: 2px;
 	}
 
 	span.codicon.codicon-chevron-down {
-		font-size: 12px;
+		font-size: var(--vscode-codiconFontSize-compact);
 		margin-left: 2px;
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatConfirmationWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatConfirmationWidget.css
@@ -449,7 +449,7 @@
 	}
 
 	.monaco-button-dropdown > .monaco-button.monaco-dropdown-button.codicon[class*='codicon-'] {
-		font-size: 12px;
+		font-size: var(--vscode-codiconFontSize-compact);
 	}
 }
 
@@ -485,7 +485,7 @@
 		}
 
 		.codicon {
-			font-size: 12px;
+			font-size: var(--vscode-codiconFontSize-compact);
 		}
 
 		&:hover  {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatThinkingContent.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatThinkingContent.css
@@ -35,7 +35,7 @@
 		}
 
 		.codicon {
-			font-size: 12px;
+			font-size: var(--vscode-codiconFontSize-compact);
 		}
 
 		.rendered-markdown.collapsible-title-content {

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -1449,7 +1449,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 .interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-clear-button-container .monaco-button .codicon {
-	font-size: 10px;
+	font-size: var(--vscode-codiconFontSize-compact);
 	color: var(--vscode-foreground);
 }
 
@@ -1732,7 +1732,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 .monaco-workbench .interactive-session .chat-secondary-toolbar .chat-input-picker-item .action-label .codicon-chevron-down {
-	font-size: 10px;
+	font-size: var(--vscode-codiconFontSize-compact);
 	margin-left: 4px;
 	opacity: 0.75;
 }
@@ -1978,7 +1978,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 .monaco-workbench .interactive-session .chat-input-toolbar .chat-input-picker-item .action-label .codicon-chevron-down,
 .monaco-workbench .interactive-session .chat-input-toolbar .chat-sessionPicker-item .action-label .codicon-chevron-down,
 .monaco-workbench .interactive-session .chat-secondary-input-toolbar .chat-sessionPicker-item .action-label .codicon-chevron-down {
-	font-size: 10px;
+	font-size: var(--vscode-codiconFontSize-compact);
 	margin-left: 4px;
 	opacity: 0.75;
 }
@@ -2304,7 +2304,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 .interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-button.codicon.codicon-plus {
 	padding-left: 4px;
-	font-size: 11px;
+	font-size: var(--vscode-codiconFontSize-compact);
 }
 
 .action-item.chat-attached-context-attachment.chat-add-files:hover,

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -760,7 +760,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 .interactive-item-container.interactive-item-compact .header .codicon-avatar .codicon {
-	font-size: 12px;
+	font-size: var(--vscode-codiconFontSize-compact);
 }
 
 .interactive-item-container.interactive-item-compact .header .avatar + .avatar {
@@ -1696,7 +1696,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 			}
 
 			.codicon {
-				font-size: 12px;
+				font-size: var(--vscode-codiconFontSize-compact);
 			}
 		}
 
@@ -1803,7 +1803,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 			}
 
 			.codicon {
-				font-size: 12px;
+				font-size: var(--vscode-codiconFontSize-compact);
 			}
 		}
 
@@ -1910,7 +1910,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 .chat-input-picker-item .action-label.model-picker-split .model-picker-section .codicon {
-	font-size: 12px;
+	font-size: var(--vscode-codiconFontSize-compact);
 }
 
 .chat-input-picker-item .action-label.model-picker-split .model-picker-section span + .chat-input-picker-label {
@@ -2962,7 +2962,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 .interactive-session .chat-file-changes-label .monaco-button .codicon,
 .interactive-session .chat-used-context-label .monaco-button .codicon {
-	font-size: 12px;
+	font-size: var(--vscode-codiconFontSize-compact);
 	color: var(--vscode-icon-foreground) !important;
 }
 
@@ -3003,10 +3003,10 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	padding-top: 2px;
 
 	> .codicon[class*='codicon-'] {
-		font-size: 12px;
+		font-size: var(--vscode-codiconFontSize-compact);
 
 		&::before {
-			font-size: 12px;
+			font-size: var(--vscode-codiconFontSize-compact);
 		}
 	}
 
@@ -3307,7 +3307,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 	.codicon.codicon-file-media,
 	.codicon.codicon-warning {
-		font-size: 12px;
+		font-size: var(--vscode-codiconFontSize-compact);
 		margin-right: 2px;
 	}
 }
@@ -3843,7 +3843,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 /* Chevron icon in dropdown container */
 .chat-welcome-view-suggested-prompt .codicon-chevron-down.dropdown-chevron {
-	font-size: 12px;
+	font-size: var(--vscode-codiconFontSize-compact);
 	opacity: 0.7;
 	flex-shrink: 0;
 }
@@ -3986,7 +3986,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 .monaco-workbench .chat-model-hover-description .codicon[class*='codicon-'] {
 	vertical-align: middle;
-	font-size: 12px;
+	font-size: var(--vscode-codiconFontSize-compact);
 }
 
 .chat-model-hover-description > div p {

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -1972,7 +1972,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 .interactive-session .chat-input-toolbar .action-item:has(.codicon-add) .codicon-add {
-	font-size: 14px;
+	font-size: var(--vscode-codiconFontSize-compact);
 }
 
 .monaco-workbench .interactive-session .chat-input-toolbar .chat-input-picker-item .action-label .codicon-chevron-down,
@@ -2345,7 +2345,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 .interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-icon-label .codicon {
-	font-size: 14px;
+	font-size: var(--vscode-codiconFontSize-compact);
 }
 
 .interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-icon-label .monaco-icon-label-iconpath.codicon {

--- a/src/vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsTree.css
+++ b/src/vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsTree.css
@@ -39,7 +39,7 @@
 
 .monaco-list .outline-element .outline-element-decoration.bubble {
 	font-family: codicon;
-	font-size: 14px;
+	font-size: var(--vscode-codiconFontSize-compact);
 	opacity: 0.4;
 	padding-right: 8px;
 }

--- a/src/vs/workbench/contrib/comments/browser/media/review.css
+++ b/src/vs/workbench/contrib/comments/browser/media/review.css
@@ -595,7 +595,7 @@ div.preview.inline .monaco-editor .comment-range-glyph {
 .monaco-editor .comment-range-glyph.comment-thread-unresolved:before,
 .monaco-editor .comment-range-glyph.comment-thread-draft:before {
 	font-family: "codicon";
-	font-size: 13px;
+	font-size: var(--vscode-codiconFontSize-compact);
 	width: 18px !important;
 	line-height: 100%;
 	border-radius: 3px;

--- a/src/vs/workbench/contrib/debug/browser/media/debugViewlet.css
+++ b/src/vs/workbench/contrib/debug/browser/media/debugViewlet.css
@@ -90,7 +90,7 @@
 }
 
 .monaco-workbench .monaco-action-bar .start-debug-action-item .configuration .monaco-dropdown > .dropdown-label .codicon-chevron-down {
-	font-size: 10px;
+	font-size: var(--vscode-codiconFontSize-compact);
 	opacity: 0.75;
 	flex-shrink: 0;
 }

--- a/src/vs/workbench/contrib/extensions/browser/media/extension.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/extension.css
@@ -157,7 +157,7 @@
 }
 
 .extension-list-item > .details > .header-container > .header .extension-icon-badge > .codicon {
-	font-size: 12px;
+	font-size: var(--vscode-codiconFontSize-compact);
 	color: currentColor;
 }
 

--- a/src/vs/workbench/contrib/extensions/browser/media/extensionEditor.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/extensionEditor.css
@@ -106,7 +106,7 @@
 
 .extension-editor > .header > .details > .title > .pre-release > .codicon.codicon-extensions-pre-release {
 	color: #ffffff;
-	font-size: 14px;
+	font-size: var(--vscode-codiconFontSize-compact);
 }
 
 .extension-editor > .header > .details > .title > .pre-release > .pre-release-text {

--- a/src/vs/workbench/contrib/inlineChat/browser/media/inlineChat.css
+++ b/src/vs/workbench/contrib/inlineChat/browser/media/inlineChat.css
@@ -245,7 +245,7 @@
 
 .monaco-workbench .inline-chat .status .label > .codicon {
 	padding: 0 3px;
-	font-size: 12px;
+	font-size: var(--vscode-codiconFontSize-compact);
 	line-height: 18px;
 }
 

--- a/src/vs/workbench/contrib/mergeEditor/browser/view/media/mergeEditor.css
+++ b/src/vs/workbench/contrib/mergeEditor/browser/view/media/mergeEditor.css
@@ -43,7 +43,7 @@
 }
 
 .monaco-workbench .merge-editor .code-view > .header > span.description .codicon {
-	font-size: 14px;
+	font-size: var(--vscode-codiconFontSize-compact);
 	color: var(--vscode-descriptionForeground);
 }
 
@@ -54,7 +54,7 @@
 }
 
 .monaco-workbench .merge-editor .code-view > .header > span.detail .codicon {
-	font-size: 13px;
+	font-size: var(--vscode-codiconFontSize-compact);
 }
 
 /* for input1|2 -> align details to the left  */

--- a/src/vs/workbench/contrib/notebook/browser/media/notebook.css
+++ b/src/vs/workbench/contrib/notebook/browser/media/notebook.css
@@ -270,7 +270,7 @@
 }
 
 .monaco-workbench .notebookOverlay > .cell-list-container > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row .execution-count-label .codicon {
-	font-size: 14px;
+	font-size: var(--vscode-codiconFontSize-compact);
 }
 
 .monaco-workbench .notebookOverlay .cell .cell-editor-part {

--- a/src/vs/workbench/contrib/notebook/browser/media/notebookCellChat.css
+++ b/src/vs/workbench/contrib/notebook/browser/media/notebookCellChat.css
@@ -135,7 +135,7 @@
 
 .monaco-workbench .notebookOverlay .cell-chat-part .inline-chat .status .label.info > .codicon {
 	padding: 0 5px;
-	font-size: 12px;
+	font-size: var(--vscode-codiconFontSize-compact);
 	line-height: 18px;
 }
 

--- a/src/vs/workbench/contrib/notebook/browser/media/notebookCellInsertToolbar.css
+++ b/src/vs/workbench/contrib/notebook/browser/media/notebookCellInsertToolbar.css
@@ -88,5 +88,5 @@
 .monaco-workbench .notebookOverlay .cell-list-top-cell-toolbar-container span.codicon,
 .monaco-workbench .notebookOverlay > .cell-list-container > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row .cell-bottom-toolbar-container span.codicon {
 	text-align: center;
-	font-size: 14px;
+	font-size: 16px;
 }

--- a/src/vs/workbench/contrib/notebook/browser/media/notebookCellStatusBar.css
+++ b/src/vs/workbench/contrib/notebook/browser/media/notebookCellStatusBar.css
@@ -58,7 +58,7 @@
 }
 
 .monaco-workbench .notebookOverlay .cell-statusbar-container .codicon {
-	font-size: 14px;
+	font-size: var(--vscode-codiconFontSize-compact);
 	color: unset; /* Inherit from parent cell-status-item */
 }
 

--- a/src/vs/workbench/contrib/notebook/browser/media/notebookOutline.css
+++ b/src/vs/workbench/contrib/notebook/browser/media/notebookOutline.css
@@ -34,7 +34,7 @@
 
 .monaco-list .notebook-outline-element > .element-decoration.bubble {
 	font-family: codicon;
-	font-size: 14px;
+	font-size: var(--vscode-codiconFontSize-compact);
 	opacity: 0.4;
 	padding-right: 8px;
 }

--- a/src/vs/workbench/contrib/scm/browser/media/scm.css
+++ b/src/vs/workbench/contrib/scm/browser/media/scm.css
@@ -657,12 +657,12 @@
 
 .monaco-hover.history-item-hover .history-item-hover-container p > span > span.codicon.codicon-tag,
 .monaco-hover.history-item-hover .history-item-hover-container p > span > span.codicon.codicon-target {
-	font-size: 14px;
+	font-size: var(--vscode-codiconFontSize-compact);
 	margin-bottom: 2px !important;
 }
 
 .monaco-hover.history-item-hover .history-item-hover-container p > span > span.codicon.codicon-cloud {
-	font-size: 14px;
+	font-size: var(--vscode-codiconFontSize-compact);
 	margin-bottom: 1px !important;
 }
 

--- a/src/vs/workbench/contrib/scm/browser/media/scm.css
+++ b/src/vs/workbench/contrib/scm/browser/media/scm.css
@@ -235,7 +235,7 @@
 }
 
 .scm-view .monaco-list-row .history-item > .label-container > .label > .codicon.codicon-git-branch {
-	font-size: 12px;
+	font-size: var(--vscode-codiconFontSize-compact);
 	padding: 3px;
 }
 
@@ -651,7 +651,7 @@
 }
 
 .monaco-hover.history-item-hover .history-item-hover-container p > span > span.codicon.codicon-git-branch {
-	font-size: 12px;
+	font-size: var(--vscode-codiconFontSize-compact);
 	margin-bottom: 2px !important;
 }
 
@@ -784,7 +784,7 @@
 }
 
 .scm-history-view .history-item-load-more .history-item-placeholder .monaco-highlighted-label .codicon {
-	font-size: 12px;
+	font-size: var(--vscode-codiconFontSize-compact);
 	color: var(--vscode-textLink-foreground)
 }
 

--- a/src/vs/workbench/contrib/testing/browser/media/testing.css
+++ b/src/vs/workbench/contrib/testing/browser/media/testing.css
@@ -437,7 +437,7 @@
 
 	.codicon.codicon-testing-failed-icon {
 		color: currentColor !important;
-		font-size: 11px;
+		font-size: var(--vscode-codiconFontSize-compact);
 		margin: 1px 0 0 -4px;
 		z-index: 1;
 	}

--- a/src/vs/workbench/contrib/welcomeOnboarding/browser/media/variationA.css
+++ b/src/vs/workbench/contrib/welcomeOnboarding/browser/media/variationA.css
@@ -1020,7 +1020,7 @@
 
 /* Keymap pills with icons */
 .onboarding-a-keymap-pill .codicon {
-	font-size: 13px;
+	font-size: var(--vscode-codiconFontSize-compact);
 	opacity: 0.7;
 }
 


### PR DESCRIPTION
This pull request standardizes the font size of Codicon icons across the application by replacing hardcoded `font-size` values in various CSS files with the CSS variable `--vscode-codiconFontSize-compact`. This change improves maintainability and ensures consistent icon sizing throughout the UI. Additionally, a few redundant or conflicting font-size rules have been removed, and some icon container dimensions have been updated for consistency.

**Codicon font size standardization:**

* Replaced hardcoded `font-size` values for `.codicon` elements with `var(--vscode-codiconFontSize-compact)` in multiple components, including dropdowns, editors, action widgets, color pickers, chat widgets, and activity bar badges. [[1]](diffhunk://#diff-1737af24b45e28c919900bf8f1043712475ec3ea48b932e5f0cda2d7e853d557L39-R39) [[2]](diffhunk://#diff-610cbc570f86f6a319921333ae604aae1f066425b6e1dec3b77f3869a5df7daaL53-R53) [[3]](diffhunk://#diff-1592c4d1ed803e7ad695294f164514263db715f161e54ee643c95d67f58db00fL72-R72) [[4]](diffhunk://#diff-2f5da92213ad5dbafdb4212d2c3b4b11f428678f0a00cdbcba0ad0f8d52c1e20L255-R255) [[5]](diffhunk://#diff-ccde3eafe6f1bdf6802118d065818be5cada627f294ffad4af8696cb16015b90L135-R135) [[6]](diffhunk://#diff-bfc94b888624f78670388c3180ec201e5b9441de4a0aeb1148ae24b778a3bdc7L60-R60) [[7]](diffhunk://#diff-00da381c737dc232bf4f1c482530dc611f4976fa563e34be2b0cbcd4988601baL618-R622) [[8]](diffhunk://#diff-0810cce998f144341dbe42cd925b22833a88d562e8641e92cf1d5518535c2b04L83-R83) [[9]](diffhunk://#diff-0810cce998f144341dbe42cd925b22833a88d562e8641e92cf1d5518535c2b04L346-R346) [[10]](diffhunk://#diff-0810cce998f144341dbe42cd925b22833a88d562e8641e92cf1d5518535c2b04L359-R359) [[11]](diffhunk://#diff-c4e0b42ac094b12a8e55ac366e26fd40ba6bf584ad01e1ca6828bf1a87c4bf33L164-R164) [[12]](diffhunk://#diff-c4e0b42ac094b12a8e55ac366e26fd40ba6bf584ad01e1ca6828bf1a87c4bf33L325-R321) [[13]](diffhunk://#diff-c4e0b42ac094b12a8e55ac366e26fd40ba6bf584ad01e1ca6828bf1a87c4bf33L362-R358) [[14]](diffhunk://#diff-c4e0b42ac094b12a8e55ac366e26fd40ba6bf584ad01e1ca6828bf1a87c4bf33L405-R401) [[15]](diffhunk://#diff-c4e0b42ac094b12a8e55ac366e26fd40ba6bf584ad01e1ca6828bf1a87c4bf33L445-R441) [[16]](diffhunk://#diff-83275f73d2a4d754bb3de569831b872db071d6afd74929b978f7b8cbad8efa0eL190-R190) [[17]](diffhunk://#diff-83275f73d2a4d754bb3de569831b872db071d6afd74929b978f7b8cbad8efa0eL366-R366) [[18]](diffhunk://#diff-37362f8da1613c5403e627bad99373321a000255480edc86e001dc30ec0be160L90-R90) [[19]](diffhunk://#diff-92b483bb3c1d6f56433aea6096c1d69d0da12cb4b96baca54b660493da10eeebL113-R117) [[20]](diffhunk://#diff-92b483bb3c1d6f56433aea6096c1d69d0da12cb4b96baca54b660493da10eeebL165-R165) [[21]](diffhunk://#diff-fd9669576e99ab30bc76563f9128ed7eae19675968e6c1e7ba8f9119d4c858baL155-R154) [[22]](diffhunk://#diff-71a268bf982e66d5b080b833347c28765fceb85ce949f7dce4704f48dbae43d8L132-R134) [[23]](diffhunk://#diff-275c1692dbfc6d6c05796399d3d79303675d94b5320014191354929465fd711cL213-R213) [[24]](diffhunk://#diff-c251eca41eeaf1ba4b69774a5d369ee211271207be2d435e0de196008f4b69d7L65-R65) [[25]](diffhunk://#diff-e79ceb29c5f019a3f3ca49addf3963e9559da82456829d08b65c1fb3fe27f8a5L136-R136) [[26]](diffhunk://#diff-e79ceb29c5f019a3f3ca49addf3963e9559da82456829d08b65c1fb3fe27f8a5L180-R180)

**Icon size and dimension adjustments:**

* Updated width and height of certain icon containers (e.g., `.agents-aquarium-toggle-logo`, `.sessionsTitleBarWidget .codicon`) to align with the new standardized font size. [[1]](diffhunk://#diff-8e838ad1cb99ab9e0530bf8b7118aaa68c5f96ae19cc0bf25ca4931dca162ba8L228-R234) [[2]](diffhunk://#diff-71a268bf982e66d5b080b833347c28765fceb85ce949f7dce4704f48dbae43d8L132-R134)

**Removal of redundant or conflicting rules:**

* Removed unnecessary or conflicting hardcoded `font-size` rules for Codicon icons in several files, such as color picker, checks widget, chat input, and session list. [[1]](diffhunk://#diff-6a39e9df47e14d5f9bf3dfd8dfd520a549b054086046b9587a00c73dd1223b07L63) [[2]](diffhunk://#diff-2bdfd74f34143179b838f3705c9d77384c179037bd1f599c7abfbe6c6be4fdb1L104-L107) [[3]](diffhunk://#diff-c4e0b42ac094b12a8e55ac366e26fd40ba6bf584ad01e1ca6828bf1a87c4bf33L282-L285) [[4]](diffhunk://#diff-fd9669576e99ab30bc76563f9128ed7eae19675968e6c1e7ba8f9119d4c858baL109) [[5]](diffhunk://#diff-fd9669576e99ab30bc76563f9128ed7eae19675968e6c1e7ba8f9119d4c858baL484)

These changes collectively ensure that icon sizing is consistent and controlled via a single CSS variable, making future adjustments easier and improving UI consistency.

