### PR TITLE
sessions: workspace picker emits folder URI, session type picker spans providers

### DIFF
--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -93,8 +93,6 @@ Session-level properties are derived from chats:
 - `status` is aggregated (`NeedsInput` > `InProgress` > other)
 - `isRead` is `true` only when all chats are read
 
-A chat may also be marked **read-only** via `IChat.isReadOnly`. Providers use this to surface conversations the user can only observe (e.g. a sub-agent run exposed as a separate chat). The Agents window honors this by hiding the chat input bar entirely while a read-only chat is the active chat.
-
 The active session (`IActiveSession`) extends `ISession` with an `activeChat` observable that tracks which chat the user is viewing.
 
 ### Workspaces and Folders

--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -93,6 +93,8 @@ Session-level properties are derived from chats:
 - `status` is aggregated (`NeedsInput` > `InProgress` > other)
 - `isRead` is `true` only when all chats are read
 
+A chat may also be marked **read-only** via `IChat.isReadOnly`. Providers use this to surface conversations the user can only observe (e.g. a sub-agent run exposed as a separate chat). The Agents window honors this by hiding the chat input bar entirely while a read-only chat is the active chat.
+
 The active session (`IActiveSession`) extends `ISession` with an `activeChat` observable that tracks which chat the user is viewing.
 
 ### Workspaces and Folders
@@ -116,13 +118,23 @@ Sessions produce file changes organized into **`ISessionChangeset`** groups — 
 ### Creating a New Session
 
 ```
-1. User picks a workspace in the workspace picker
-   → SessionsManagementService.createNewSession(providerId, workspaceUri, sessionTypeId?)
-   → Looks up provider in SessionsProvidersService
-   → Calls provider.createNewSession(workspaceUri, sessionTypeId)
+1. User picks a folder in the workspace picker
+   → WorkspacePicker fires onDidSelectWorkspace(folderUri)
+   → SessionsManagementService.createNewSession(folderUri, options?)
+   → Iterates providers, picks the first one whose resolveWorkspace(folderUri)
+     succeeds (filtered by options.sessionTypeId when given)
+   → Calls provider.createNewSession(folderUri, sessionTypeId)
    → Returns ISession, set as activeSession
 
-2. User types a message and sends
+2. User picks a different session type for the same folder
+   → SessionTypePicker queries getSessionTypesForFolder(folderUri),
+     groups entries by provider, shows them in the dropdown
+   → On selection, fires onDidSelectSessionType({ providerId, sessionTypeId })
+   → SessionsManagementService.createNewSession(folderUri, { providerId, sessionTypeId })
+     routes through the picked provider — even when the same sessionType.id
+     is also offered by another provider
+
+3. User types a message and sends
    → SessionsManagementService.sendAndCreateChat(session, {query, attachedContext})
    → Delegates to provider.sendAndCreateChat(sessionId, options)
    → Provider sends request, returns committed session

--- a/src/vs/sessions/contrib/chat/browser/mobile/mobileSessionTypePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/mobile/mobileSessionTypePicker.ts
@@ -30,12 +30,12 @@ export class MobileSessionTypePicker extends SessionTypePicker {
 	constructor(
 		@IActionWidgetService actionWidgetService: IActionWidgetService,
 		@ISessionsManagementService sessionsManagementService: ISessionsManagementService,
-		@ISessionsProvidersService sessionsProvidersService: ISessionsProvidersService,
+		@ISessionsProvidersService private readonly _sessionsProvidersService: ISessionsProvidersService,
 		@IStorageService storageService: IStorageService,
 		@ITelemetryService telemetryService: ITelemetryService,
 		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
 	) {
-		super(actionWidgetService, sessionsManagementService, sessionsProvidersService, storageService, telemetryService);
+		super(actionWidgetService, sessionsManagementService, _sessionsProvidersService, storageService, telemetryService);
 	}
 
 	override render(container: HTMLElement, options?: { className?: string }): void {
@@ -57,18 +57,27 @@ export class MobileSessionTypePicker extends SessionTypePicker {
 			super._showPicker();
 			return;
 		}
-		if (this._allProviderSessionTypes.length <= 1) {
+		if (this._folderSessionTypes.length <= 1) {
 			return;
 		}
 
-		const supportedTypeIds = new Set(this._supportedSessionTypes.map(t => t.id));
-		const sheetItems: IMobilePickerSheetItem[] = this._allProviderSessionTypes.map(type => ({
-			id: type.id,
-			label: type.label,
-			icon: type.icon,
-			disabled: !supportedTypeIds.has(type.id),
-			checked: type.id === this._sessionType,
-		}));
+		// Build sheet items — composite id is `providerId\u0000sessionTypeId`
+		// so we can map back to the right provider on selection. Use the
+		// provider's label as a section title on the first item of each
+		// group so the sheet visually separates providers.
+		const sheetItems: IMobilePickerSheetItem[] = [];
+		let lastProviderId: string | undefined;
+		for (const { providerId, sessionType } of this._folderSessionTypes) {
+			const isFirstInGroup = providerId !== lastProviderId;
+			lastProviderId = providerId;
+			sheetItems.push({
+				id: `${providerId}\u0000${sessionType.id}`,
+				label: sessionType.label,
+				icon: sessionType.icon,
+				checked: providerId === this._picked?.providerId && sessionType.id === this._picked?.sessionTypeId,
+				sectionTitle: isFirstInGroup ? (this._sessionsProvidersService.getProvider(providerId)?.label ?? providerId) : undefined,
+			});
+		}
 
 		const trigger = this._triggerElement;
 		trigger.setAttribute('aria-expanded', 'true');
@@ -80,7 +89,10 @@ export class MobileSessionTypePicker extends SessionTypePicker {
 			trigger.setAttribute('aria-expanded', 'false');
 			trigger.focus();
 			if (id !== undefined) {
-				this._handleSelectedSessionType(id);
+				const [providerId, sessionTypeId] = id.split('\u0000');
+				if (providerId && sessionTypeId) {
+					this._handleSelectedSessionType({ providerId, sessionTypeId });
+				}
 			}
 		});
 	}

--- a/src/vs/sessions/contrib/chat/browser/mobile/mobileWorkspacePickerSheet.ts
+++ b/src/vs/sessions/contrib/chat/browser/mobile/mobileWorkspacePickerSheet.ts
@@ -85,7 +85,7 @@ export function buildMobileWorkspacePickerRows(
 		// scoped to a single host via the host picker, so the host
 		// indication is redundant — render every workspace as a folder
 		// to match the inline folder search results below.
-		const isWorkspaceRow = !!data?.selection;
+		const isWorkspaceRow = !!data?.folderUri;
 		const icon = isWorkspaceRow ? Codicon.folder : item.group?.icon;
 		rows.push({
 			sheetItem: {
@@ -220,7 +220,11 @@ export async function showMobileWorkspacePickerSheet(
 				const sheetItems: IMobilePickerSheetItem[] = [];
 				flattened.forEach((entry, idx) => {
 					const id = `${SEARCH_RESULT_ID_PREFIX}${idx}`;
-					folderRunById.set(id, () => dispatch({ selection: { providerId: entry.providerId, workspace: entry.workspace } }));
+					const folderUri = entry.workspace.folders[0]?.root;
+					if (!folderUri) {
+						return;
+					}
+					folderRunById.set(id, () => dispatch({ folderUri, providerId: entry.providerId }));
 					folderLabelById.set(id, entry.workspace.label);
 					sheetItems.push({
 						id,

--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -26,7 +26,7 @@ import { IWorkspaceTrustRequestService } from '../../../../platform/workspace/co
 import { IViewPaneOptions, ViewPane } from '../../../../workbench/browser/parts/views/viewPane.js';
 import { WorkspacePicker } from './sessionWorkspacePicker.js';
 import { WebWorkspacePicker } from './webWorkspacePicker.js';
-import { IPickedSessionType } from './sessionTypePicker.js';
+import { IPreferredSessionType } from './sessionTypePicker.js';
 import { NewChatInputWidget } from './newChatInput.js';
 import { NoAgentHostEmptyState } from './noAgentHostEmptyState.js';
 import { IChatRequestVariableEntry } from '../../../../workbench/contrib/chat/common/attachments/chatVariableEntries.js';
@@ -96,8 +96,10 @@ class NewChatWidget extends Disposable {
 				// fall back to the provider's natural default by passing
 				// only the folder URI.
 				const picked = this._newChatInput.sessionTypePicker.selectedPick;
-				const validForFolder = picked && this.sessionsManagementService.getSessionTypesForFolder(folderUri)
-					.some(t => t.providerId === picked.providerId && t.sessionType.id === picked.sessionTypeId);
+				const folderTypes = picked ? this.sessionsManagementService.getSessionTypes(folderUri) : undefined;
+				const validForFolder = picked && folderTypes!.some(t =>
+					(picked.providerId === undefined || t.providerId === picked.providerId)
+					&& t.sessionType.id === picked.sessionTypeId);
 				await this._onWorkspaceSelected(folderUri, validForFolder ? picked : undefined);
 			} else {
 				await this._onWorkspaceSelected(undefined, undefined);
@@ -164,20 +166,25 @@ class NewChatWidget extends Disposable {
 		const sessionWorkspace = activeSession.workspace.get();
 		const folderUri = sessionWorkspace?.folders[0]?.root;
 		if (folderUri) {
-			this._workspacePicker.setSelectedWorkspace(folderUri, /* fireEvent */ false);
+			this._workspacePicker.setSelectedWorkspace(folderUri, { fireEvent: false });
 		}
 
 		return true;
 	}
 
-	private _createNewSession(folderUri: URI, pick: IPickedSessionType | undefined): void {
+	private _createNewSession(folderUri: URI, pick: IPreferredSessionType | undefined): void {
 		// If the carried-over pick can no longer be served for this folder
 		// (the picker upgraded to a different provider after restore), drop
-		// it so the management service picks the natural default.
+		// it so the management service picks the natural default. When the
+		// pick has no providerId yet (legacy stored preference), we accept
+		// any provider that offers the same sessionTypeId.
 		let effectivePick = pick;
 		if (effectivePick) {
-			const available = this.sessionsManagementService.getSessionTypesForFolder(folderUri);
-			if (!available.some(t => t.providerId === effectivePick!.providerId && t.sessionType.id === effectivePick!.sessionTypeId)) {
+			const available = this.sessionsManagementService.getSessionTypes(folderUri);
+			const matches = available.some(t =>
+				(effectivePick!.providerId === undefined || t.providerId === effectivePick!.providerId)
+				&& t.sessionType.id === effectivePick!.sessionTypeId);
+			if (!matches) {
 				effectivePick = undefined;
 			}
 		}
@@ -188,12 +195,12 @@ class NewChatWidget extends Disposable {
 		// agent-host-specific UI (model picker etc.) until the user re-picks the workspace.
 		// If the connection fails, the picker fires onDidSelectWorkspace(undefined) which
 		// clears the pending wait via _onWorkspaceSelected.
-		const availableNow = this.sessionsManagementService.getSessionTypesForFolder(folderUri);
+		const availableNow = this.sessionsManagementService.getSessionTypes(folderUri);
 		if (availableNow.length === 0) {
 			const pendingStore = new DisposableStore();
 			this._pendingSessionTypeWait.value = pendingStore;
 			pendingStore.add(this.sessionsManagementService.onDidChangeSessionTypes(() => {
-				if (this.sessionsManagementService.getSessionTypesForFolder(folderUri).length > 0) {
+				if (this.sessionsManagementService.getSessionTypes(folderUri).length > 0) {
 					this._pendingSessionTypeWait.clear();
 					this._createNewSession(folderUri, pick);
 				}
@@ -379,7 +386,7 @@ class NewChatWidget extends Disposable {
 	 * Handles a workspace selection from the workspace picker.
 	 * Requests folder trust if needed and creates a new session.
 	 */
-	private async _onWorkspaceSelected(folderUri: URI | undefined, pick: IPickedSessionType | undefined): Promise<void> {
+	private async _onWorkspaceSelected(folderUri: URI | undefined, pick: IPreferredSessionType | undefined): Promise<void> {
 		// Cancel any in-flight wait for a previous selection.
 		this._pendingSessionTypeWait.clear();
 
@@ -388,7 +395,7 @@ class NewChatWidget extends Disposable {
 			return;
 		}
 
-		const resolved = this.sessionsManagementService.resolveWorkspaceForFolder(folderUri);
+		const resolved = this.sessionsManagementService.resolveWorkspace(folderUri);
 		if (resolved?.workspace.requiresWorkspaceTrust) {
 			if (!await this._requestFolderTrust(folderUri)) {
 				return;
@@ -410,8 +417,8 @@ class NewChatWidget extends Disposable {
 		this._newChatInput.sendQuery(text);
 	}
 
-	selectWorkspace(folderUri: URI): void {
-		this._workspacePicker.setSelectedWorkspace(folderUri);
+	selectWorkspace(folderUri: URI, providerId?: string): void {
+		this._workspacePicker.setSelectedWorkspace(folderUri, { providerId });
 	}
 }
 
@@ -469,8 +476,8 @@ export class NewChatViewPane extends ViewPane {
 		this._widget?.sendQuery(text);
 	}
 
-	selectWorkspace(folderUri: URI): void {
-		this._widget?.selectWorkspace(folderUri);
+	selectWorkspace(folderUri: URI, providerId?: string): void {
+		this._widget?.selectWorkspace(folderUri, providerId);
 	}
 
 	override setVisible(visible: boolean): void {

--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -96,7 +96,7 @@ class NewChatWidget extends Disposable {
 				// fall back to the provider's natural default by passing
 				// only the folder URI.
 				const picked = this._newChatInput.sessionTypePicker.selectedPick;
-				const folderTypes = picked ? this.sessionsManagementService.getSessionTypes(folderUri) : undefined;
+				const folderTypes = picked ? this.sessionsManagementService.getSessionTypesForFolder(folderUri) : undefined;
 				const validForFolder = picked && folderTypes!.some(t =>
 					(picked.providerId === undefined || t.providerId === picked.providerId)
 					&& t.sessionType.id === picked.sessionTypeId);
@@ -180,7 +180,7 @@ class NewChatWidget extends Disposable {
 		// any provider that offers the same sessionTypeId.
 		let effectivePick = pick;
 		if (effectivePick) {
-			const available = this.sessionsManagementService.getSessionTypes(folderUri);
+			const available = this.sessionsManagementService.getSessionTypesForFolder(folderUri);
 			const matches = available.some(t =>
 				(effectivePick!.providerId === undefined || t.providerId === effectivePick!.providerId)
 				&& t.sessionType.id === effectivePick!.sessionTypeId);
@@ -195,12 +195,12 @@ class NewChatWidget extends Disposable {
 		// agent-host-specific UI (model picker etc.) until the user re-picks the workspace.
 		// If the connection fails, the picker fires onDidSelectWorkspace(undefined) which
 		// clears the pending wait via _onWorkspaceSelected.
-		const availableNow = this.sessionsManagementService.getSessionTypes(folderUri);
+		const availableNow = this.sessionsManagementService.getSessionTypesForFolder(folderUri);
 		if (availableNow.length === 0) {
 			const pendingStore = new DisposableStore();
 			this._pendingSessionTypeWait.value = pendingStore;
 			pendingStore.add(this.sessionsManagementService.onDidChangeSessionTypes(() => {
-				if (this.sessionsManagementService.getSessionTypes(folderUri).length > 0) {
+				if (this.sessionsManagementService.getSessionTypesForFolder(folderUri).length > 0) {
 					this._pendingSessionTypeWait.clear();
 					this._createNewSession(folderUri, pick);
 				}

--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -20,13 +20,13 @@ import { IThemeService } from '../../../../platform/theme/common/themeService.js
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { localize } from '../../../../nls.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
-import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
 import { IAquariumService, IMountedToggleHandle } from '../../aquarium/browser/aquariumOverlay.js';
 import { IViewDescriptorService } from '../../../../workbench/common/views.js';
 import { IWorkspaceTrustRequestService } from '../../../../platform/workspace/common/workspaceTrust.js';
 import { IViewPaneOptions, ViewPane } from '../../../../workbench/browser/parts/views/viewPane.js';
-import { WorkspacePicker, IWorkspaceSelection } from './sessionWorkspacePicker.js';
+import { WorkspacePicker } from './sessionWorkspacePicker.js';
 import { WebWorkspacePicker } from './webWorkspacePicker.js';
+import { IPickedSessionType } from './sessionTypePicker.js';
 import { NewChatInputWidget } from './newChatInput.js';
 import { NoAgentHostEmptyState } from './noAgentHostEmptyState.js';
 import { IChatRequestVariableEntry } from '../../../../workbench/contrib/chat/common/attachments/chatVariableEntries.js';
@@ -55,7 +55,6 @@ class NewChatWidget extends Disposable {
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@ILogService private readonly logService: ILogService,
 		@ISessionsManagementService private readonly sessionsManagementService: ISessionsManagementService,
-		@ISessionsProvidersService private readonly sessionsProvidersService: ISessionsProvidersService,
 		@IWorkspaceTrustRequestService private readonly workspaceTrustRequestService: IWorkspaceTrustRequestService,
 		@IAquariumService private readonly aquariumService: IAquariumService,
 		@IAgentHostFilterService private readonly agentHostFilterService: IAgentHostFilterService,
@@ -90,19 +89,23 @@ class NewChatWidget extends Disposable {
 			renderSessionTypePickerInControls: false,
 		}));
 
-		this._register(this._workspacePicker.onDidSelectWorkspace(async workspace => {
-			if (workspace) {
-				const selectedSessionType = this._newChatInput.sessionTypePicker.selectedType;
-				const validSessionTypes = this.sessionsProvidersService.getProvider(workspace.providerId)?.getSessionTypes(workspace.workspace.folders[0].root);
-				const validSessionType = selectedSessionType ? validSessionTypes?.find(type => type.id === selectedSessionType) : validSessionTypes?.[0];
-				await this._onWorkspaceSelected(workspace, validSessionType?.id);
+		this._register(this._workspacePicker.onDidSelectWorkspace(async folderUri => {
+			if (folderUri) {
+				// Carry over the user's preferred session type if some
+				// provider can still serve it for this folder; otherwise
+				// fall back to the provider's natural default by passing
+				// only the folder URI.
+				const picked = this._newChatInput.sessionTypePicker.selectedPick;
+				const validForFolder = picked && this.sessionsManagementService.getSessionTypesForFolder(folderUri)
+					.some(t => t.providerId === picked.providerId && t.sessionType.id === picked.sessionTypeId);
+				await this._onWorkspaceSelected(folderUri, validForFolder ? picked : undefined);
 			} else {
 				await this._onWorkspaceSelected(undefined, undefined);
 			}
 			this._newChatInput.focus();
 		}));
-		this._register(this._newChatInput.sessionTypePicker.onDidSelectSessionType(async sessionType => {
-			await this._onWorkspaceSelected(this._workspacePicker.selectedProject, sessionType);
+		this._register(this._newChatInput.sessionTypePicker.onDidSelectSessionType(async pick => {
+			await this._onWorkspaceSelected(this._workspacePicker.selectedFolderUri, pick);
 			this._newChatInput.focus();
 		}));
 	}
@@ -134,9 +137,9 @@ class NewChatWidget extends Disposable {
 		// picker fires onDidSelectWorkspace and our listener handles it.
 		// Skip if an active session already exists (restored by openNewSessionView
 		// from a pending new session when navigating back from another session).
-		const restoredProject = this._workspacePicker.selectedProject;
-		if (!this._syncWorkspacePickerFromActiveSession() && restoredProject) {
-			this._createNewSession(restoredProject, this._newChatInput.sessionTypePicker.selectedType);
+		const restoredFolderUri = this._workspacePicker.selectedFolderUri;
+		if (!this._syncWorkspacePickerFromActiveSession() && restoredFolderUri) {
+			this._createNewSession(restoredFolderUri, this._newChatInput.sessionTypePicker.selectedPick);
 		}
 
 		chatWidgetContainer.classList.add('revealed');
@@ -159,26 +162,24 @@ class NewChatWidget extends Disposable {
 		}
 
 		const sessionWorkspace = activeSession.workspace.get();
-		if (sessionWorkspace) {
-			this._workspacePicker.setSelectedWorkspace(
-				{ providerId: activeSession.providerId, workspace: sessionWorkspace },
-				/* fireEvent */ false,
-			);
+		const folderUri = sessionWorkspace?.folders[0]?.root;
+		if (folderUri) {
+			this._workspacePicker.setSelectedWorkspace(folderUri, /* fireEvent */ false);
 		}
 
 		return true;
 	}
 
-	private _createNewSession(selection: IWorkspaceSelection, sessionTypeId: string | undefined): void {
-		const provider = this.sessionsProvidersService.getProviders().find(p => p.id === selection.providerId);
-		const repoUri = selection.workspace.folders[0].root;
-
-		// Drop the carried-over sessionTypeId if it doesn't apply to this provider —
-		// happens when the picker upgrades to a different provider after restore and
-		// the previous active session's type (e.g. EH CLI's "agents") doesn't exist
-		// on the new provider (e.g. agent host).
-		if (sessionTypeId && provider && !provider.getSessionTypes(repoUri).some(t => t.id === sessionTypeId)) {
-			sessionTypeId = undefined;
+	private _createNewSession(folderUri: URI, pick: IPickedSessionType | undefined): void {
+		// If the carried-over pick can no longer be served for this folder
+		// (the picker upgraded to a different provider after restore), drop
+		// it so the management service picks the natural default.
+		let effectivePick = pick;
+		if (effectivePick) {
+			const available = this.sessionsManagementService.getSessionTypesForFolder(folderUri);
+			if (!available.some(t => t.providerId === effectivePick!.providerId && t.sessionType.id === effectivePick!.sessionTypeId)) {
+				effectivePick = undefined;
+			}
 		}
 
 		// Session types may not be available yet (e.g., agent host still connecting).
@@ -187,22 +188,31 @@ class NewChatWidget extends Disposable {
 		// agent-host-specific UI (model picker etc.) until the user re-picks the workspace.
 		// If the connection fails, the picker fires onDidSelectWorkspace(undefined) which
 		// clears the pending wait via _onWorkspaceSelected.
-		if (provider && !sessionTypeId && provider.getSessionTypes(repoUri).length === 0 && provider.onDidChangeSessionTypes) {
+		const availableNow = this.sessionsManagementService.getSessionTypesForFolder(folderUri);
+		if (availableNow.length === 0) {
 			const pendingStore = new DisposableStore();
 			this._pendingSessionTypeWait.value = pendingStore;
-
-			pendingStore.add(provider.onDidChangeSessionTypes(() => {
-				if (provider.getSessionTypes(repoUri).length > 0) {
+			pendingStore.add(this.sessionsManagementService.onDidChangeSessionTypes(() => {
+				if (this.sessionsManagementService.getSessionTypesForFolder(folderUri).length > 0) {
 					this._pendingSessionTypeWait.clear();
-					this._createNewSession(selection, sessionTypeId);
+					this._createNewSession(folderUri, pick);
 				}
 			}));
-
 			return;
 		}
 
+		// Fall back to the provider associated with the recently-picked
+		// workspace (e.g. Local Agent Host) when the session type picker has
+		// no explicit pick yet. This preserves the user's historical provider
+		// association across iteration-order changes in the providers list.
+		const fallbackProviderId = this._workspacePicker.selectedResolved?.providerId;
+
 		try {
-			this.sessionsManagementService.createNewSession(selection.providerId, repoUri, sessionTypeId);
+			this.sessionsManagementService.createNewSession(folderUri, effectivePick
+				? { providerId: effectivePick.providerId, sessionTypeId: effectivePick.sessionTypeId }
+				: fallbackProviderId
+					? { providerId: fallbackProviderId }
+					: undefined);
 		} catch (e) {
 			this.logService.error('Failed to create new session:', e);
 		}
@@ -212,13 +222,13 @@ class NewChatWidget extends Disposable {
 	 * Returns the workspace URI for the context picker based on the current workspace selection.
 	 */
 	private _getContextFolderUri(): URI | undefined {
-		return this._workspacePicker.selectedProject?.workspace.folders[0]?.root;
+		return this._workspacePicker.selectedFolderUri;
 	}
 
 	private _renderWorkspacePicker(container: HTMLElement): IDisposable {
 		const pickersRow = dom.append(container, dom.$('.session-workspace-picker'));
 		const pickersLabel = dom.append(pickersRow, dom.$('.session-workspace-picker-label'));
-		pickersLabel.textContent = this._workspacePicker.selectedProject
+		pickersLabel.textContent = this._workspacePicker.selectedFolderUri
 			? localize('newSessionIn', "New session in")
 			: localize('newSessionChooseWorkspace', "Start by picking a");
 
@@ -227,8 +237,8 @@ class NewChatWidget extends Disposable {
 		withLabel.textContent = localize('newSessionWith', "with");
 		this._newChatInput.sessionTypePicker.render(pickersRow, { className: 'sessions-chat-session-type-picker' });
 		return this._workspacePicker.onDidSelectWorkspace(() => {
-			const workspace = this._workspacePicker.selectedProject;
-			pickersLabel.textContent = workspace
+			const folderUri = this._workspacePicker.selectedFolderUri;
+			pickersLabel.textContent = folderUri
 				? localize('newSessionIn', "New session in")
 				: localize('newSessionChooseWorkspace', "Start by picking a");
 		});
@@ -369,23 +379,23 @@ class NewChatWidget extends Disposable {
 	 * Handles a workspace selection from the workspace picker.
 	 * Requests folder trust if needed and creates a new session.
 	 */
-	private async _onWorkspaceSelected(selection: IWorkspaceSelection | undefined, sessionTypeId: string | undefined): Promise<void> {
+	private async _onWorkspaceSelected(folderUri: URI | undefined, pick: IPickedSessionType | undefined): Promise<void> {
 		// Cancel any in-flight wait for a previous selection.
 		this._pendingSessionTypeWait.clear();
 
-		if (!selection) {
+		if (!folderUri) {
 			this.sessionsManagementService.unsetNewSession();
 			return;
 		}
 
-		if (selection.workspace.requiresWorkspaceTrust) {
-			const workspaceUri = selection.workspace.folders[0]?.root;
-			if (workspaceUri && !await this._requestFolderTrust(workspaceUri)) {
+		const resolved = this.sessionsManagementService.resolveWorkspaceForFolder(folderUri);
+		if (resolved?.workspace.requiresWorkspaceTrust) {
+			if (!await this._requestFolderTrust(folderUri)) {
 				return;
 			}
 		}
 
-		this._createNewSession(selection, sessionTypeId);
+		this._createNewSession(folderUri, pick);
 	}
 
 	prefillInput(text: string): void {
@@ -400,8 +410,8 @@ class NewChatWidget extends Disposable {
 		this._newChatInput.sendQuery(text);
 	}
 
-	selectWorkspace(workspace: IWorkspaceSelection): void {
-		this._workspacePicker.setSelectedWorkspace(workspace);
+	selectWorkspace(folderUri: URI): void {
+		this._workspacePicker.setSelectedWorkspace(folderUri);
 	}
 }
 
@@ -459,8 +469,8 @@ export class NewChatViewPane extends ViewPane {
 		this._widget?.sendQuery(text);
 	}
 
-	selectWorkspace(workspace: IWorkspaceSelection): void {
-		this._widget?.selectWorkspace(workspace);
+	selectWorkspace(folderUri: URI): void {
+		this._widget?.selectWorkspace(folderUri);
 	}
 
 	override setVisible(visible: boolean): void {

--- a/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
@@ -11,7 +11,7 @@ import { renderIcon } from '../../../../base/browser/ui/iconLabel/iconLabels.js'
 import { localize } from '../../../../nls.js';
 import { IActionWidgetService } from '../../../../platform/actionWidget/browser/actionWidget.js';
 import { ActionListItemKind, IActionListDelegate, IActionListItem } from '../../../../platform/actionWidget/browser/actionList.js';
-import { IFolderSessionType, ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
+import { IProviderSessionType, ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
 import { autorun } from '../../../../base/common/observable.js';
 import { ISession } from '../../../services/sessions/common/session.js';
@@ -75,7 +75,7 @@ export class SessionTypePicker extends Disposable {
 	readonly onDidSelectSessionType = this._onDidSelectSessionType.event;
 
 	/** Session types the active session's folder can be served by, across all providers. */
-	protected _folderSessionTypes: IFolderSessionType[] = [];
+	protected _folderSessionTypes: IProviderSessionType[] = [];
 
 	private readonly _renderDisposables = this._register(new DisposableStore());
 	protected _triggerElement: HTMLElement | undefined;
@@ -95,7 +95,7 @@ export class SessionTypePicker extends Disposable {
 		const refresh = (session: ISession | undefined) => {
 			if (session) {
 				const folderUri = session.workspace.get()?.folders[0]?.root;
-				this._folderSessionTypes = folderUri ? this.sessionsManagementService.getSessionTypes(folderUri) : [];
+				this._folderSessionTypes = folderUri ? this.sessionsManagementService.getSessionTypesForFolder(folderUri) : [];
 				// The active session's actual type wins over any stored preference
 				// for trigger-label rendering.
 				this._picked = { providerId: session.providerId, sessionTypeId: session.sessionType };
@@ -178,7 +178,7 @@ export class SessionTypePicker extends Disposable {
 		// land before the user clicks.
 		const folderUri = session.workspace.get()?.folders[0]?.root;
 		const folderTypes = folderUri
-			? this.sessionsManagementService.getSessionTypes(folderUri)
+			? this.sessionsManagementService.getSessionTypesForFolder(folderUri)
 			: this._folderSessionTypes;
 		this._folderSessionTypes = folderTypes;
 

--- a/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
@@ -34,6 +34,17 @@ export interface IPickedSessionType {
 	readonly sessionTypeId: string;
 }
 
+/**
+ * A stored or in-memory preference. When the providerId is unknown (legacy
+ * storage that only persisted the session type id, or a pick made before
+ * any folder was known) the picker resolves a provider lazily once the
+ * active folder is established.
+ */
+export interface IPreferredSessionType {
+	readonly providerId?: string;
+	readonly sessionTypeId: string;
+}
+
 interface IStoredSessionTypePick {
 	readonly providerId?: string;
 	readonly sessionTypeId: string;
@@ -53,7 +64,13 @@ interface ISessionTypePickerItem {
 
 export class SessionTypePicker extends Disposable {
 
-	protected _picked: IPickedSessionType | undefined;
+	/**
+	 * The currently displayed pick. May be missing `providerId` when restored
+	 * from legacy storage that only persisted the session type id — it will
+	 * be resolved to a concrete provider lazily when consumers create a
+	 * session.
+	 */
+	protected _picked: IPreferredSessionType | undefined;
 	protected readonly _onDidSelectSessionType = this._register(new Emitter<IPickedSessionType | undefined>());
 	readonly onDidSelectSessionType = this._onDidSelectSessionType.event;
 
@@ -78,7 +95,7 @@ export class SessionTypePicker extends Disposable {
 		const refresh = (session: ISession | undefined) => {
 			if (session) {
 				const folderUri = session.workspace.get()?.folders[0]?.root;
-				this._folderSessionTypes = folderUri ? this.sessionsManagementService.getSessionTypesForFolder(folderUri) : [];
+				this._folderSessionTypes = folderUri ? this.sessionsManagementService.getSessionTypes(folderUri) : [];
 				// The active session's actual type wins over any stored preference
 				// for trigger-label rendering.
 				this._picked = { providerId: session.providerId, sessionTypeId: session.sessionType };
@@ -102,7 +119,7 @@ export class SessionTypePicker extends Disposable {
 		}));
 	}
 
-	get selectedPick(): IPickedSessionType | undefined {
+	get selectedPick(): IPreferredSessionType | undefined {
 		return this._picked;
 	}
 
@@ -161,7 +178,7 @@ export class SessionTypePicker extends Disposable {
 		// land before the user clicks.
 		const folderUri = session.workspace.get()?.folders[0]?.root;
 		const folderTypes = folderUri
-			? this.sessionsManagementService.getSessionTypesForFolder(folderUri)
+			? this.sessionsManagementService.getSessionTypes(folderUri)
 			: this._folderSessionTypes;
 		this._folderSessionTypes = folderTypes;
 
@@ -256,7 +273,7 @@ export class SessionTypePicker extends Disposable {
 		}
 	}
 
-	private _readStoredPick(): IPickedSessionType | undefined {
+	private _readStoredPick(): IPreferredSessionType | undefined {
 		const raw = this.storageService.get(STORAGE_KEY_LAST_SESSION_TYPE, StorageScope.PROFILE);
 		if (!raw) {
 			return undefined;
@@ -265,15 +282,17 @@ export class SessionTypePicker extends Disposable {
 		// shape where only the sessionTypeId string was stored.
 		try {
 			const parsed = JSON.parse(raw) as IStoredSessionTypePick;
-			if (parsed && typeof parsed.sessionTypeId === 'string' && typeof parsed.providerId === 'string') {
-				return { providerId: parsed.providerId, sessionTypeId: parsed.sessionTypeId };
+			if (parsed && typeof parsed.sessionTypeId === 'string') {
+				return typeof parsed.providerId === 'string'
+					? { providerId: parsed.providerId, sessionTypeId: parsed.sessionTypeId }
+					: { sessionTypeId: parsed.sessionTypeId };
 			}
 		} catch {
-			// fall through to legacy handling
+			// Not JSON — fall through to legacy raw-string handling.
 		}
-		// Legacy string id — no providerId yet. The picker will resolve the
-		// provider lazily based on the active folder.
-		return undefined;
+		// Legacy raw string was just the session type id. Resolution to a
+		// provider happens lazily once the active folder is known.
+		return { sessionTypeId: raw };
 	}
 
 	private _writeStoredPick(pick: IPickedSessionType): void {

--- a/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
@@ -11,10 +11,10 @@ import { renderIcon } from '../../../../base/browser/ui/iconLabel/iconLabels.js'
 import { localize } from '../../../../nls.js';
 import { IActionWidgetService } from '../../../../platform/actionWidget/browser/actionWidget.js';
 import { ActionListItemKind, IActionListDelegate, IActionListItem } from '../../../../platform/actionWidget/browser/actionList.js';
-import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
+import { IFolderSessionType, ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
 import { autorun } from '../../../../base/common/observable.js';
-import { ISession, ISessionType } from '../../../services/sessions/common/session.js';
+import { ISession } from '../../../services/sessions/common/session.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { isWeb } from '../../../../base/common/platform.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
@@ -23,14 +23,42 @@ import { reportNewChatPickerClosed } from './newChatPickerTelemetry.js';
 
 export const STORAGE_KEY_LAST_SESSION_TYPE = 'sessions.lastSelectedSessionType';
 
+/**
+ * A picked session type, paired with the provider that serves it. Two
+ * providers can advertise the same session type id (e.g. both expose
+ * 'copilot-cli'), so callers need both to route session creation to the
+ * right provider.
+ */
+export interface IPickedSessionType {
+	readonly providerId: string;
+	readonly sessionTypeId: string;
+}
+
+interface IStoredSessionTypePick {
+	readonly providerId?: string;
+	readonly sessionTypeId: string;
+}
+
+/**
+ * Row item rendered inside the session type picker — carries both the
+ * provider id and the session type so we can dispatch creation through
+ * the correct provider when the same type is offered by multiple providers.
+ */
+interface ISessionTypePickerItem {
+	readonly providerId: string;
+	readonly sessionTypeId: string;
+	readonly label: string;
+	readonly checked?: boolean;
+}
+
 export class SessionTypePicker extends Disposable {
 
-	protected _sessionType: string | undefined;
-	protected readonly _onDidSelectSessionType = this._register(new Emitter<string | undefined>());
+	protected _picked: IPickedSessionType | undefined;
+	protected readonly _onDidSelectSessionType = this._register(new Emitter<IPickedSessionType | undefined>());
 	readonly onDidSelectSessionType = this._onDidSelectSessionType.event;
 
-	protected _supportedSessionTypes: ISessionType[] = [];
-	protected _allProviderSessionTypes: ISessionType[] = [];
+	/** Session types the active session's folder can be served by, across all providers. */
+	protected _folderSessionTypes: IFolderSessionType[] = [];
 
 	private readonly _renderDisposables = this._register(new DisposableStore());
 	protected _triggerElement: HTMLElement | undefined;
@@ -45,25 +73,20 @@ export class SessionTypePicker extends Disposable {
 		super();
 
 		// Restore the previously selected session type from storage
-		this._sessionType = this.storageService.get(STORAGE_KEY_LAST_SESSION_TYPE, StorageScope.PROFILE);
+		this._picked = this._readStoredPick();
 
 		const refresh = (session: ISession | undefined) => {
 			if (session) {
-				const provider = this.sessionsProvidersService.getProvider(session.providerId);
-				this._supportedSessionTypes = provider?.getSessionTypes(session.resource) ?? [];
-				const providerTypes = provider ? [...provider.sessionTypes] : [];
-				const providerTypeIds = new Set(providerTypes.map(t => t.id));
-				this._allProviderSessionTypes = [
-					...providerTypes,
-					...this._supportedSessionTypes.filter(t => !providerTypeIds.has(t.id)),
-				];
-				this._sessionType = session.sessionType;
+				const folderUri = session.workspace.get()?.folders[0]?.root;
+				this._folderSessionTypes = folderUri ? this.sessionsManagementService.getSessionTypesForFolder(folderUri) : [];
+				// The active session's actual type wins over any stored preference
+				// for trigger-label rendering.
+				this._picked = { providerId: session.providerId, sessionTypeId: session.sessionType };
 			} else {
-				this._supportedSessionTypes = [];
-				this._allProviderSessionTypes = [];
-				// Preserve the stored session type when no active session exists,
+				this._folderSessionTypes = [];
+				// Preserve the stored pick when no active session exists,
 				// so it can be used as the default for the next new session.
-				this._sessionType = this.storageService.get(STORAGE_KEY_LAST_SESSION_TYPE, StorageScope.PROFILE);
+				this._picked = this._readStoredPick();
 			}
 			this._updateTriggerLabel();
 		};
@@ -79,8 +102,8 @@ export class SessionTypePicker extends Disposable {
 		}));
 	}
 
-	get selectedType(): string | undefined {
-		return this._sessionType;
+	get selectedPick(): IPickedSessionType | undefined {
+		return this._picked;
 	}
 
 	render(container: HTMLElement, options?: { className?: string }): void {
@@ -127,38 +150,67 @@ export class SessionTypePicker extends Disposable {
 			return;
 		}
 
-		if (this._allProviderSessionTypes.length <= 1) {
-			return;
-		}
-
 		const session = this.sessionsManagementService.activeSession.get();
 		if (!session) {
 			return;
 		}
 
-		const supportedTypeIds = new Set(this._supportedSessionTypes.map(t => t.id));
+		// Recompute types fresh at open time so a late-registering provider
+		// (e.g. Local Agent Host whose session types are populated only after
+		// agent discovery) shows up without waiting for the refresh event to
+		// land before the user clicks.
+		const folderUri = session.workspace.get()?.folders[0]?.root;
+		const folderTypes = folderUri
+			? this.sessionsManagementService.getSessionTypesForFolder(folderUri)
+			: this._folderSessionTypes;
+		this._folderSessionTypes = folderTypes;
 
-		const items: IActionListItem<ISessionType>[] = this._allProviderSessionTypes.map(type => ({
-			kind: ActionListItemKind.Action,
-			label: type.label,
-			group: { title: '', icon: type.icon },
-			disabled: !supportedTypeIds.has(type.id),
-			item: type.id === this._sessionType ? { ...type, checked: true } : type,
-		}));
+		if (folderTypes.length <= 1) {
+			return;
+		}
+
+		// Group items by provider so the dropdown shows a provider header
+		// followed by that provider's types. Insert a separator between
+		// adjacent providers' types so the grouping is visually clear.
+		const providersService = this.sessionsProvidersService;
+		const groupedItems: IActionListItem<ISessionTypePickerItem>[] = [];
+		let lastProviderId: string | undefined;
+		for (const { providerId, sessionType } of folderTypes) {
+			const provider = providersService.getProvider(providerId);
+			const groupTitle = provider?.label ?? providerId;
+			const isFirstInGroup = providerId !== lastProviderId;
+			if (isFirstInGroup && lastProviderId !== undefined) {
+				groupedItems.push({ kind: ActionListItemKind.Separator, label: '' });
+			}
+			lastProviderId = providerId;
+			const isCurrent = this._picked?.providerId === providerId && this._picked?.sessionTypeId === sessionType.id;
+			const item: ISessionTypePickerItem = isCurrent
+				? { providerId, sessionTypeId: sessionType.id, label: sessionType.label, checked: true }
+				: { providerId, sessionTypeId: sessionType.id, label: sessionType.label };
+			groupedItems.push({
+				kind: ActionListItemKind.Action,
+				label: sessionType.label,
+				group: {
+					title: isFirstInGroup ? groupTitle : '',
+					icon: sessionType.icon,
+				},
+				item,
+			});
+		}
 
 		const triggerElement = this._triggerElement;
-		const delegate: IActionListDelegate<ISessionType> = {
-			onSelect: (type) => {
+		const delegate: IActionListDelegate<ISessionTypePickerItem> = {
+			onSelect: (item) => {
 				this.actionWidgetService.hide();
-				this._handleSelectedSessionType(type.id);
+				this._handleSelectedSessionType(item);
 			},
 			onHide: () => { triggerElement.focus(); },
 		};
 
-		this.actionWidgetService.show<ISessionType>(
+		this.actionWidgetService.show<ISessionTypePickerItem>(
 			'sessionTypePicker',
 			false,
-			items,
+			groupedItems,
 			delegate,
 			this._triggerElement,
 			undefined,
@@ -167,6 +219,7 @@ export class SessionTypePicker extends Disposable {
 				getAriaLabel: (item) => item.label ?? '',
 				getWidgetAriaLabel: () => localize('sessionTypePicker.ariaLabel', "Session Type"),
 			},
+			{ showGroupTitleOnFirstItem: true },
 		);
 	}
 
@@ -174,31 +227,59 @@ export class SessionTypePicker extends Disposable {
 	 * Handles the user picking a session type. Emits `newChatPickerClosed`
 	 * telemetry (with the previously selected type read from storage, or
 	 * the in-memory field when nothing is stored), and — when the
-	 * selection actually changed — persists the new type and fires
+	 * selection actually changed — persists the new pick and fires
 	 * {@link onDidSelectSessionType}.
 	 *
 	 * Shared between desktop (action-widget popup) and mobile (bottom
 	 * sheet) presentations so both surfaces report identical telemetry.
 	 */
-	protected _handleSelectedSessionType(typeId: string): void {
-		const beforeId = this.storageService.get(STORAGE_KEY_LAST_SESSION_TYPE, StorageScope.PROFILE) ?? this._sessionType;
-		const beforeLabel = this._allProviderSessionTypes.find(t => t.id === beforeId)?.label;
-		const afterLabel = this._allProviderSessionTypes.find(t => t.id === typeId)?.label;
+	protected _handleSelectedSessionType(pick: IPickedSessionType): void {
+		const stored = this._readStoredPick();
+		const beforeId = stored?.sessionTypeId ?? this._picked?.sessionTypeId;
+		const beforeLabel = this._folderSessionTypes.find(t => t.sessionType.id === beforeId)?.sessionType.label;
+		const afterLabel = this._folderSessionTypes.find(t => t.providerId === pick.providerId && t.sessionType.id === pick.sessionTypeId)?.sessionType.label;
 
 		reportNewChatPickerClosed(this.telemetryService, {
 			id: 'NewChatSessionTypePicker',
 			name: 'NewChatSessionTypePicker',
 			optionIdBefore: beforeId,
-			optionIdAfter: typeId,
+			optionIdAfter: pick.sessionTypeId,
 			optionLabelBefore: beforeLabel,
 			optionLabelAfter: afterLabel,
 			isPII: false,
 		});
 
-		if (typeId !== this._sessionType) {
-			this.storageService.store(STORAGE_KEY_LAST_SESSION_TYPE, typeId, StorageScope.PROFILE, StorageTarget.MACHINE);
-			this._onDidSelectSessionType.fire(typeId);
+		const changed = pick.providerId !== this._picked?.providerId || pick.sessionTypeId !== this._picked?.sessionTypeId;
+		if (changed) {
+			this._writeStoredPick(pick);
+			this._onDidSelectSessionType.fire(pick);
 		}
+	}
+
+	private _readStoredPick(): IPickedSessionType | undefined {
+		const raw = this.storageService.get(STORAGE_KEY_LAST_SESSION_TYPE, StorageScope.PROFILE);
+		if (!raw) {
+			return undefined;
+		}
+		// Try parsing as the new JSON shape first; fall back to the legacy
+		// shape where only the sessionTypeId string was stored.
+		try {
+			const parsed = JSON.parse(raw) as IStoredSessionTypePick;
+			if (parsed && typeof parsed.sessionTypeId === 'string' && typeof parsed.providerId === 'string') {
+				return { providerId: parsed.providerId, sessionTypeId: parsed.sessionTypeId };
+			}
+		} catch {
+			// fall through to legacy handling
+		}
+		// Legacy string id — no providerId yet. The picker will resolve the
+		// provider lazily based on the active folder.
+		return undefined;
+	}
+
+	private _writeStoredPick(pick: IPickedSessionType): void {
+		this._picked = pick;
+		const stored: IStoredSessionTypePick = { providerId: pick.providerId, sessionTypeId: pick.sessionTypeId };
+		this.storageService.store(STORAGE_KEY_LAST_SESSION_TYPE, JSON.stringify(stored), StorageScope.PROFILE, StorageTarget.MACHINE);
 	}
 
 	private _updateTriggerLabel(): void {
@@ -214,20 +295,23 @@ export class SessionTypePicker extends Disposable {
 		// Note: the existing CSS rule on `.session-workspace-picker-with-label`
 		// uses `:has(+ .sessions-chat-session-type-picker .action-label.hidden)`
 		// to also hide the "with" connector when the trigger is hidden.
-		const hideForSingleHarness = isWeb && this._allProviderSessionTypes.length <= 1;
-		if (this._allProviderSessionTypes.length === 0 || hideForSingleHarness) {
+		const hideForSingleHarness = isWeb && this._folderSessionTypes.length <= 1;
+		if (this._folderSessionTypes.length === 0 || hideForSingleHarness) {
 			this._triggerElement.classList.add('hidden');
 			return;
 		}
 
 		this._triggerElement.classList.remove('hidden');
-		const currentType = this._allProviderSessionTypes.find(t => t.id === this._sessionType);
+		const currentType = this._folderSessionTypes.find(t =>
+			t.providerId === this._picked?.providerId && t.sessionType.id === this._picked?.sessionTypeId)?.sessionType
+			?? this._folderSessionTypes.find(t => t.sessionType.id === this._picked?.sessionTypeId)?.sessionType;
 		const modeIcon = currentType?.icon ?? Codicon.terminal;
-		const modeLabel = currentType?.label ?? this._sessionType ?? '';
+		const modeLabel = currentType?.label ?? this._picked?.sessionTypeId ?? '';
 
 		dom.append(this._triggerElement, renderIcon(modeIcon));
 		const labelSpan = dom.append(this._triggerElement, dom.$('span.sessions-chat-dropdown-label'));
 		labelSpan.textContent = modeLabel;
+
 		const chevron = dom.append(this._triggerElement, renderIcon(Codicon.chevronDown));
 		chevron.classList.add('sessions-chat-dropdown-chevron');
 

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -24,7 +24,6 @@ import { ICommandService } from '../../../../platform/commands/common/commands.j
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IContextKeyService, IContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { IFileDialogService } from '../../../../platform/dialogs/common/dialogs.js';
-import { IQuickInputService } from '../../../../platform/quickinput/common/quickInput.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
 import { renderIcon } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
@@ -61,9 +60,19 @@ const TABBED_PICKER_WIDTH = 360;
 const RESTORE_CONNECT_GRACE_MS = 5000;
 
 /**
- * A workspace selection from the picker, pairing the workspace with its owning provider.
+ * A workspace entry as resolved from a folder URI for rendering. The
+ * `providerId` is the provider that resolved the URI (first match in
+ * iteration order). For local URIs that any local provider can resolve,
+ * this is the first registered local provider; for remote URIs it is the
+ * remote provider for that authority.
+ *
+ * Selection now flows out of the picker as a plain folder URI — the
+ * provider is rediscovered at session-creation time by
+ * {@link ISessionsManagementService.createNewSession}. The `providerId`
+ * carried here is only used internally for rendering (connection state,
+ * grouping into tabs).
  */
-export interface IWorkspaceSelection {
+export interface IResolvedFolderWorkspace {
 	readonly providerId: string;
 	readonly workspace: ISessionWorkspace;
 }
@@ -71,10 +80,14 @@ export interface IWorkspaceSelection {
 /**
  * Stored recent workspace entry. The `checked` flag marks the currently
  * selected workspace so we only need a single storage key.
+ *
+ * `providerId` is retained for backwards compatibility with previously
+ * stored entries; new entries are written without it. When reading,
+ * entries are resolved by iterating registered providers.
  */
 interface IStoredRecentWorkspace {
 	readonly uri: UriComponents;
-	readonly providerId: string;
+	readonly providerId?: string;
 	readonly checked: boolean;
 }
 
@@ -82,7 +95,9 @@ interface IStoredRecentWorkspace {
  * Item type used in the action list.
  */
 export interface IWorkspacePickerItem {
-	readonly selection?: IWorkspaceSelection;
+	readonly folderUri?: URI;
+	/** The resolved workspace (used for unavailable-provider checks). */
+	readonly providerId?: string;
 	readonly browseActionIndex?: number;
 	readonly checked?: boolean;
 	/** Command to execute when this item is selected. */
@@ -101,12 +116,13 @@ type IWorkspacePickerAction = IAction & { icon?: ThemeIcon; hoverContent?: strin
  */
 export class WorkspacePicker extends Disposable {
 
-	protected readonly _onDidSelectWorkspace = this._register(new Emitter<IWorkspaceSelection | undefined>());
-	readonly onDidSelectWorkspace: Event<IWorkspaceSelection | undefined> = this._onDidSelectWorkspace.event;
+	protected readonly _onDidSelectWorkspace = this._register(new Emitter<URI | undefined>());
+	readonly onDidSelectWorkspace: Event<URI | undefined> = this._onDidSelectWorkspace.event;
 	protected readonly _onDidChangeSelection = this._register(new Emitter<void>());
 	readonly onDidChangeSelection: Event<void> = this._onDidChangeSelection.event;
 
-	private _selectedWorkspace: IWorkspaceSelection | undefined;
+	private _selectedFolderUri: URI | undefined;
+	private _selectedResolved: IResolvedFolderWorkspace | undefined;
 
 	/**
 	 * Set to `true` once the user has explicitly picked or cleared a workspace.
@@ -123,9 +139,6 @@ export class WorkspacePicker extends Disposable {
 	 * and we fall back.
 	 */
 	private readonly _connectionStatusWatch = this._register(new MutableDisposable());
-
-	/** Provider ID chosen during the last local folder browse. */
-	private _selectedLocalProviderId: string | undefined;
 
 	protected _triggerElement: HTMLElement | undefined;
 	private readonly _renderDisposables = this._register(new DisposableStore());
@@ -148,8 +161,19 @@ export class WorkspacePicker extends Disposable {
 	/** Cached VS Code recent folder URIs, resolved lazily. */
 	private _vsCodeRecentFolderUris: URI[] = [];
 
-	get selectedProject(): IWorkspaceSelection | undefined {
-		return this._selectedWorkspace;
+	get selectedFolderUri(): URI | undefined {
+		return this._selectedFolderUri;
+	}
+
+	/**
+	 * Returns the currently selected folder resolved to a workspace via the
+	 * first provider that can resolve it. Used internally for rendering
+	 * (label, icon, group). The provider association is not part of the
+	 * picker's public contract — callers should use {@link selectedFolderUri}
+	 * and let the management service rediscover the provider.
+	 */
+	get selectedResolved(): IResolvedFolderWorkspace | undefined {
+		return this._selectedResolved;
 	}
 
 	constructor(
@@ -165,7 +189,6 @@ export class WorkspacePicker extends Disposable {
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IFileDialogService private readonly fileDialogService: IFileDialogService,
-		@IQuickInputService private readonly quickInputService: IQuickInputService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
 	) {
 		super();
@@ -182,9 +205,10 @@ export class WorkspacePicker extends Disposable {
 		}));
 
 		// Restore selected workspace from storage
-		this._selectedWorkspace = this._restoreSelectedWorkspace();
-		if (this._selectedWorkspace) {
-			this._watchForConnectionFailure(this._selectedWorkspace);
+		const restored = this._restoreSelectedWorkspace();
+		this._applySelection(restored);
+		if (this._selectedResolved) {
+			this._watchForConnectionFailure(this._selectedResolved);
 		}
 
 		// React to provider registrations/removals: re-validate the current
@@ -192,24 +216,28 @@ export class WorkspacePicker extends Disposable {
 		// from storage so we upgrade from any fallback to the user's actual
 		// stored selection once its provider arrives.
 		this._register(this.sessionsProvidersService.onDidChangeProviders(() => {
-			if (this._selectedWorkspace) {
-				const providers = this.sessionsProvidersService.getProviders();
-				if (!providers.some(p => p.id === this._selectedWorkspace!.providerId)) {
-					this._selectedWorkspace = undefined;
+			if (this._selectedFolderUri) {
+				// Re-resolve in case the previous resolving provider was removed.
+				const reresolved = this._resolveFolder(this._selectedFolderUri);
+				if (!reresolved) {
+					this._selectedFolderUri = undefined;
+					this._selectedResolved = undefined;
 					this._connectionStatusWatch.clear();
 					this._updateTriggerLabel();
 					this._onDidChangeSelection.fire();
 					this._onDidSelectWorkspace.fire(undefined);
+				} else {
+					this._selectedResolved = reresolved;
 				}
 			}
 			if (!this._userHasPicked) {
-				const restored = this._restoreSelectedWorkspace();
-				if (restored && !this._isSelectedWorkspace(restored)) {
-					this._selectedWorkspace = restored;
+				const restoredNow = this._restoreSelectedWorkspace();
+				if (restoredNow && !this._isSelectedFolder(restoredNow.workspace.folders[0]?.root)) {
+					this._applySelection(restoredNow);
 					this._updateTriggerLabel();
 					this._onDidChangeSelection.fire();
-					this._onDidSelectWorkspace.fire(restored);
-					this._watchForConnectionFailure(restored);
+					this._onDidSelectWorkspace.fire(this._selectedFolderUri);
+					this._watchForConnectionFailure(restoredNow);
 				}
 			}
 		}));
@@ -291,7 +319,7 @@ export class WorkspacePicker extends Disposable {
 		// so picking a tab during one open of the picker doesn't permanently
 		// override auto-tab.
 		if (tabs.length > 0) {
-			const selectedGroup = this._selectedWorkspace?.workspace.group;
+			const selectedGroup = this._selectedResolved?.workspace.group;
 			if (!this._userPickedTab && selectedGroup && tabs.some(t => t.id === selectedGroup)) {
 				this._activeTab = selectedGroup;
 			}
@@ -450,14 +478,14 @@ export class WorkspacePicker extends Disposable {
 			item.run();
 		} else if (item.commandId) {
 			this.commandService.executeCommand(item.commandId);
-		} else if (item.selection && this._isProviderUnavailable(item.selection.providerId)) {
+		} else if (item.folderUri && item.providerId && this._isProviderUnavailable(item.providerId)) {
 			// Workspace belongs to an unavailable remote — ignore selection
 			return;
 		}
 		if (item.browseActionIndex !== undefined) {
 			this._executeBrowseAction(item.browseActionIndex);
-		} else if (item.selection) {
-			this._selectProject(item.selection);
+		} else if (item.folderUri) {
+			this._selectFolder(item.folderUri);
 		}
 	}
 
@@ -470,25 +498,26 @@ export class WorkspacePicker extends Disposable {
 	 */
 	private _reportPickerClosed(item: IWorkspacePickerItem): void {
 		const beforeFromStorage = this._restoreCheckedWorkspace();
-		const before = beforeFromStorage ?? this._selectedWorkspace;
-		const after = item.selection;
+		const before = beforeFromStorage ?? this._selectedResolved;
+		const afterUri = item.folderUri;
+		const afterResolved = afterUri ? this._resolveFolder(afterUri) : undefined;
 		reportNewChatPickerClosed(this.telemetryService, {
 			id: 'NewChatWorkspacePicker',
 			name: 'NewChatWorkspacePicker',
 			optionIdBefore: before?.workspace?.uri.toString(),
-			optionIdAfter: after?.workspace?.uri.toString(),
+			optionIdAfter: afterResolved?.workspace?.uri.toString(),
 			optionLabelBefore: before?.workspace?.label,
-			optionLabelAfter: after?.workspace?.label,
+			optionLabelAfter: afterResolved?.workspace?.label,
 			isPII: true,
 		});
 	}
 
 	/**
-	 * Programmatically set the selected project.
+	 * Programmatically set the selected workspace by folder URI.
 	 * @param fireEvent Whether to fire the onDidSelectWorkspace event. Defaults to true.
 	 */
-	setSelectedWorkspace(project: IWorkspaceSelection, fireEvent = true): void {
-		this._selectProject(project, fireEvent);
+	setSelectedWorkspace(folderUri: URI, fireEvent = true): void {
+		this._selectFolder(folderUri, fireEvent);
 	}
 
 	/**
@@ -510,7 +539,8 @@ export class WorkspacePicker extends Disposable {
 		this._hidePicker();
 		this._userHasPicked = true;
 		this._connectionStatusWatch.clear();
-		this._selectedWorkspace = undefined;
+		this._selectedFolderUri = undefined;
+		this._selectedResolved = undefined;
 		// Clear checked state from all recents
 		const recents = this._getStoredRecentWorkspaces();
 		const updated = recents.map(p => ({ ...p, checked: false }));
@@ -523,21 +553,60 @@ export class WorkspacePicker extends Disposable {
 	 * Clears the selection if it matches the given URI.
 	 */
 	removeFromRecents(uri: URI): void {
-		if (this._selectedWorkspace && this.uriIdentityService.extUri.isEqual(this._selectedWorkspace.workspace.folders[0]?.root, uri)) {
+		if (this._selectedFolderUri && this.uriIdentityService.extUri.isEqual(this._selectedFolderUri, uri)) {
 			this.clearSelection();
 		}
 	}
 
-	private _selectProject(selection: IWorkspaceSelection, fireEvent = true): void {
+	private _selectFolder(folderUri: URI, fireEvent = true): void {
 		this._userHasPicked = true;
 		this._connectionStatusWatch.clear();
-		this._selectedWorkspace = selection;
-		this._persistSelectedWorkspace(selection);
+		// Prefer the historical providerId stored in the recents for this URI,
+		// so re-picking a Local Agent Host folder restores the Local Agent
+		// Host association even when another provider also resolves the URI.
+		const storedProviderId = this._getStoredRecentWorkspaces()
+			.find(r => this.uriIdentityService.extUri.isEqual(URI.revive(r.uri), folderUri))
+			?.providerId;
+		const resolved = this._resolveFolder(folderUri, storedProviderId);
+		this._selectedFolderUri = folderUri;
+		this._selectedResolved = resolved;
+		this._persistSelectedFolder(folderUri, resolved?.providerId);
 		this._updateTriggerLabel();
 		this._onDidChangeSelection.fire();
 		if (fireEvent) {
-			this._onDidSelectWorkspace.fire(selection);
+			this._onDidSelectWorkspace.fire(folderUri);
 		}
+	}
+
+	/**
+	 * Apply a restored selection without firing events or persisting. Used
+	 * during construction and after provider list changes.
+	 */
+	private _applySelection(resolved: IResolvedFolderWorkspace | undefined): void {
+		this._selectedResolved = resolved;
+		this._selectedFolderUri = resolved?.workspace.folders[0]?.root;
+	}
+
+	/**
+	 * Iterate providers and return the first resolution of the folder URI.
+	 * When `preferredProviderId` is given, that provider is tried first so a
+	 * user's historical pick survives provider iteration order changes.
+	 */
+	private _resolveFolder(folderUri: URI, preferredProviderId?: string): IResolvedFolderWorkspace | undefined {
+		if (preferredProviderId) {
+			const preferred = this.sessionsProvidersService.getProvider(preferredProviderId);
+			const workspace = preferred?.resolveWorkspace(folderUri);
+			if (workspace) {
+				return { providerId: preferredProviderId, workspace };
+			}
+		}
+		for (const provider of this.sessionsProvidersService.getProviders()) {
+			const workspace = provider.resolveWorkspace(folderUri);
+			if (workspace) {
+				return { providerId: provider.id, workspace };
+			}
+		}
+		return undefined;
 	}
 
 	/**
@@ -553,14 +622,9 @@ export class WorkspacePicker extends Disposable {
 		try {
 			const workspace = await action.run();
 			if (workspace) {
-				let providerId = action.providerId;
-				if (!providerId) {
-					// Picker-owned local action — use the provider chosen during browse
-					providerId = this._selectedLocalProviderId ?? '';
-					this._selectedLocalProviderId = undefined;
-				}
-				if (providerId) {
-					this._selectProject({ providerId, workspace });
+				const folderUri = workspace.folders[0]?.root;
+				if (folderUri) {
+					this._selectFolder(folderUri);
 				}
 			}
 		} catch {
@@ -592,26 +656,14 @@ export class WorkspacePicker extends Disposable {
 	}
 
 	/**
-	 * Opens a folder picker dialog and resolves the selected folder through
-	 * a provider that supports local workspaces. When multiple providers
-	 * support local workspaces, shows a quick pick to choose the provider first.
+	 * Opens a folder picker dialog and returns the chosen URI. The folder's
+	 * provider is rediscovered later by the management service when the
+	 * session is created — no provider quick-pick is needed here.
 	 */
 	private async _browseForLocalFolder(): Promise<ISessionWorkspace | undefined> {
 		const localProviders = this.sessionsProvidersService.getProviders().filter(p => p.supportsLocalWorkspaces);
 		if (localProviders.length === 0) {
 			return undefined;
-		}
-
-		let provider = localProviders[0];
-		if (localProviders.length > 1) {
-			const picked = await this.quickInputService.pick(
-				localProviders.map(p => ({ label: p.label, provider: p })),
-				{ placeHolder: localize('pickLocalProvider', "Select a provider") },
-			);
-			if (!picked) {
-				return undefined;
-			}
-			provider = picked.provider;
 		}
 
 		const result = await this.fileDialogService.showOpenDialog({
@@ -623,8 +675,16 @@ export class WorkspacePicker extends Disposable {
 			return undefined;
 		}
 
-		this._selectedLocalProviderId = provider.id;
-		return provider.resolveWorkspace(result[0]);
+		// Resolve through any local provider so the returned ISessionWorkspace
+		// carries a label/icon for the browse-action handshake; the actual
+		// provider used to create the session is rediscovered at creation time.
+		for (const provider of localProviders) {
+			const workspace = provider.resolveWorkspace(result[0]);
+			if (workspace) {
+				return workspace;
+			}
+		}
+		return undefined;
 	}
 
 	/** True when the picker is currently scoped to a single tab. */
@@ -646,16 +706,16 @@ export class WorkspacePicker extends Disposable {
 		const allProviders = this.sessionsProvidersService.getProviders();
 		const providerIds = new Set(allProviders.map(p => p.id));
 		const tabFilter = this._isTabFiltered()
-			? (w: IWorkspaceSelection) => w.workspace.group === this._activeTab
+			? (w: IResolvedFolderWorkspace) => w.workspace.group === this._activeTab
 			: undefined;
 		const ownRecentWorkspaces = this._getRecentWorkspaces()
 			.filter(w => providerIds.has(w.providerId))
-			.filter(w => !tabFilter || tabFilter({ providerId: w.providerId, workspace: w.workspace }));
+			.filter(w => !tabFilter || tabFilter(w));
 
 		// Merge VS Code recent folders (resolved through providers, deduplicated)
 		const vsCodeRecents = this._getVSCodeRecentWorkspaces()
 			.filter(w => providerIds.has(w.providerId))
-			.filter(w => !tabFilter || tabFilter({ providerId: w.providerId, workspace: w.workspace }));
+			.filter(w => !tabFilter || tabFilter(w));
 		const ownRecentCount = ownRecentWorkspaces.length;
 		const recentWorkspaces = [...ownRecentWorkspaces, ...vsCodeRecents];
 
@@ -666,16 +726,19 @@ export class WorkspacePicker extends Disposable {
 			const provider = allProviders.find(p => p.id === providerId);
 			const connectionStatus = provider && isAgentHostProvider(provider) ? provider.connectionStatus?.get() : undefined;
 			const isDisconnected = RemoteAgentHostConnectionStatus.isDisconnected(connectionStatus) || RemoteAgentHostConnectionStatus.isIncompatible(connectionStatus);
-			const selection: IWorkspaceSelection = { providerId, workspace };
-			const selected = this._isSelectedWorkspace(selection);
+			const folderUri = workspace.folders[0]?.root;
+			if (!folderUri) {
+				continue;
+			}
+			const selected = this._isSelectedFolder(folderUri);
 			items.push({
 				kind: ActionListItemKind.Action,
 				label: workspace.label,
 				description: workspace.description,
 				group: { title: '', icon: workspace.icon },
 				disabled: isDisconnected,
-				item: { selection, checked: selected || undefined },
-				onRemove: isOwnRecent ? () => this._removeRecentWorkspace(selection) : () => this._removeVSCodeRecentWorkspace(selection),
+				item: { folderUri, providerId, checked: selected || undefined },
+				onRemove: isOwnRecent ? () => this._removeRecentWorkspace(folderUri) : () => this._removeVSCodeRecentWorkspace(folderUri),
 			});
 		}
 
@@ -784,7 +847,7 @@ export class WorkspacePicker extends Disposable {
 		}
 
 		dom.clearNode(this._triggerElement);
-		const workspace = this._selectedWorkspace?.workspace;
+		const workspace = this._selectedResolved?.workspace;
 		const label = workspace ? workspace.label : localize('pickWorkspace', "workspace");
 		const icon = workspace ? workspace.icon : Codicon.project;
 
@@ -795,8 +858,7 @@ export class WorkspacePicker extends Disposable {
 		dom.append(this._triggerElement, renderIcon(icon));
 		const labelSpan = dom.append(this._triggerElement, dom.$('span.sessions-chat-dropdown-label'));
 		labelSpan.textContent = label;
-		const chevron = dom.append(this._triggerElement, renderIcon(Codicon.chevronDown));
-		chevron.classList.add('sessions-chat-dropdown-chevron');
+		dom.append(this._triggerElement, renderIcon(Codicon.chevronDown)).classList.add('sessions-chat-dropdown-chevron');
 	}
 
 	/**
@@ -812,27 +874,18 @@ export class WorkspacePicker extends Disposable {
 		return !RemoteAgentHostConnectionStatus.isConnected(provider.connectionStatus.get());
 	}
 
-	protected _isSelectedWorkspace(selection: IWorkspaceSelection): boolean {
-		if (!this._selectedWorkspace) {
+	protected _isSelectedFolder(folderUri: URI | undefined): boolean {
+		if (!this._selectedFolderUri || !folderUri) {
 			return false;
 		}
-		if (this._selectedWorkspace.providerId !== selection.providerId) {
-			return false;
-		}
-		const selectedUri = this._selectedWorkspace.workspace.folders[0]?.root;
-		const candidateUri = selection.workspace.folders[0]?.root;
-		return this.uriIdentityService.extUri.isEqual(selectedUri, candidateUri);
+		return this.uriIdentityService.extUri.isEqual(this._selectedFolderUri, folderUri);
 	}
 
-	private _persistSelectedWorkspace(selection: IWorkspaceSelection): void {
-		const uri = selection.workspace.folders[0]?.root;
-		if (!uri) {
-			return;
-		}
-		this._addRecentWorkspace(selection.providerId, selection.workspace, true);
+	private _persistSelectedFolder(folderUri: URI, providerId: string | undefined): void {
+		this._addRecentFolder(folderUri, providerId, true);
 	}
 
-	private _restoreSelectedWorkspace(): IWorkspaceSelection | undefined {
+	private _restoreSelectedWorkspace(): IResolvedFolderWorkspace | undefined {
 		// Try the checked entry first
 		const checked = this._restoreCheckedWorkspace();
 		if (checked) {
@@ -844,22 +897,17 @@ export class WorkspacePicker extends Disposable {
 		// to be ready: we don't want to silently land on, e.g., a disconnected
 		// remote workspace that the user never picked.
 		try {
-			const providers = this.sessionsProvidersService.getProviders();
-			const providerIds = new Set(providers.map(p => p.id));
 			const storedRecents = this._getStoredRecentWorkspaces();
-
 			for (const stored of storedRecents) {
-				if (!providerIds.has(stored.providerId)) {
-					continue;
-				}
-				if (this._isProviderUnavailable(stored.providerId)) {
-					continue;
-				}
 				const uri = URI.revive(stored.uri);
-				const workspace = this.sessionsProvidersService.getProvider(stored.providerId)?.resolveWorkspace(uri);
-				if (workspace) {
-					return { providerId: stored.providerId, workspace };
+				const resolved = this._resolveFolder(uri, stored.providerId);
+				if (!resolved) {
+					continue;
 				}
+				if (this._isProviderUnavailable(resolved.providerId)) {
+					continue;
+				}
+				return resolved;
 			}
 			return undefined;
 		} catch {
@@ -868,26 +916,24 @@ export class WorkspacePicker extends Disposable {
 	}
 
 	/**
-	 * Restore only the checked (previously selected) workspace if its provider
-	 * is registered. The provider's connection status is intentionally NOT
-	 * checked — we honor the user's explicit pick even if the remote is still
-	 * connecting or currently disconnected. The trigger label reflects the
-	 * connection state separately (spinner / grayed).
+	 * Restore only the checked (previously selected) workspace if any
+	 * provider can resolve its URI. The provider's connection status is
+	 * intentionally NOT checked — we honor the user's explicit pick even
+	 * if the remote is still connecting or currently disconnected. The
+	 * trigger label reflects the connection state separately
+	 * (spinner / grayed).
 	 */
-	private _restoreCheckedWorkspace(): IWorkspaceSelection | undefined {
+	private _restoreCheckedWorkspace(): IResolvedFolderWorkspace | undefined {
 		try {
-			const providers = this.sessionsProvidersService.getProviders();
-			const providerIds = new Set(providers.map(p => p.id));
 			const storedRecents = this._getStoredRecentWorkspaces();
-
 			for (const stored of storedRecents) {
-				if (!stored.checked || !providerIds.has(stored.providerId)) {
+				if (!stored.checked) {
 					continue;
 				}
 				const uri = URI.revive(stored.uri);
-				const workspace = this.sessionsProvidersService.getProvider(stored.providerId)?.resolveWorkspace(uri);
-				if (workspace) {
-					return { providerId: stored.providerId, workspace };
+				const resolved = this._resolveFolder(uri, stored.providerId);
+				if (resolved) {
+					return resolved;
 				}
 			}
 			return undefined;
@@ -911,8 +957,8 @@ export class WorkspacePicker extends Disposable {
 	 *
 	 * Has no effect once the user makes an explicit pick (`_userHasPicked`).
 	 */
-	private _watchForConnectionFailure(selection: IWorkspaceSelection): void {
-		const provider = this.sessionsProvidersService.getProvider(selection.providerId);
+	private _watchForConnectionFailure(resolved: IResolvedFolderWorkspace): void {
+		const provider = this.sessionsProvidersService.getProvider(resolved.providerId);
 		if (!provider || !isAgentHostProvider(provider) || !provider.connectionStatus) {
 			return;
 		}
@@ -921,13 +967,19 @@ export class WorkspacePicker extends Disposable {
 			return;
 		}
 
+		const folderUri = resolved.workspace.folders[0]?.root;
+		if (!folderUri) {
+			return;
+		}
+
 		const store = new DisposableStore();
 		this._connectionStatusWatch.value = store;
 
 		const fallback = () => {
 			this._connectionStatusWatch.clear();
-			if (!this._userHasPicked && this._isSelectedWorkspace(selection)) {
-				this._selectedWorkspace = undefined;
+			if (!this._userHasPicked && this._isSelectedFolder(folderUri)) {
+				this._selectedFolderUri = undefined;
+				this._selectedResolved = undefined;
 				this._updateTriggerLabel();
 				this._onDidChangeSelection.fire();
 				this._onDidSelectWorkspace.fire(undefined);
@@ -957,15 +1009,11 @@ export class WorkspacePicker extends Disposable {
 
 	// -- Recent workspaces storage --
 
-	private _addRecentWorkspace(providerId: string, workspace: ISessionWorkspace, checked: boolean): void {
-		const uri = workspace.folders[0]?.root;
-		if (!uri) {
-			return;
-		}
+	private _addRecentFolder(folderUri: URI, providerId: string | undefined, checked: boolean): void {
 		const recents = this._getStoredRecentWorkspaces();
 		const filtered = recents.map(p => {
 			// Remove the entry being re-added (it will go to the front)
-			if (p.providerId === providerId && this.uriIdentityService.extUri.isEqual(URI.revive(p.uri), uri)) {
+			if (this.uriIdentityService.extUri.isEqual(URI.revive(p.uri), folderUri)) {
 				return undefined;
 			}
 			// Clear checked from all other entries when marking checked
@@ -975,55 +1023,45 @@ export class WorkspacePicker extends Disposable {
 			return p;
 		}).filter((p): p is IStoredRecentWorkspace => p !== undefined);
 
-		const entry: IStoredRecentWorkspace = { uri: uri.toJSON(), providerId, checked };
+		const entry: IStoredRecentWorkspace = { uri: folderUri.toJSON(), providerId, checked };
 		const updated = [entry, ...filtered].slice(0, MAX_RECENT_WORKSPACES);
 		this.storageService.store(STORAGE_KEY_RECENT_WORKSPACES, JSON.stringify(updated), StorageScope.PROFILE, StorageTarget.MACHINE);
 	}
 
-	protected _getRecentWorkspaces(): { providerId: string; workspace: ISessionWorkspace }[] {
+	protected _getRecentWorkspaces(): IResolvedFolderWorkspace[] {
 		return this._getStoredRecentWorkspaces()
 			.map(stored => {
 				const uri = URI.revive(stored.uri);
-				const workspace = this.sessionsProvidersService.getProvider(stored.providerId)?.resolveWorkspace(uri);
-				if (!workspace) {
-					return undefined;
-				}
-				return { providerId: stored.providerId, workspace };
+				return this._resolveFolder(uri, stored.providerId);
 			})
-			.filter((w): w is { providerId: string; workspace: ISessionWorkspace } => w !== undefined);
+			.filter((w): w is IResolvedFolderWorkspace => w !== undefined);
 	}
 
-	protected _removeRecentWorkspace(selection: IWorkspaceSelection): void {
-		const uri = selection.workspace.folders[0]?.root;
-		if (!uri) {
-			return;
-		}
+	protected _removeRecentWorkspace(folderUri: URI): void {
 		const recents = this._getStoredRecentWorkspaces();
 		const updated = recents.filter(p =>
-			!(p.providerId === selection.providerId && this.uriIdentityService.extUri.isEqual(URI.revive(p.uri), uri))
+			!this.uriIdentityService.extUri.isEqual(URI.revive(p.uri), folderUri)
 		);
 		this.storageService.store(STORAGE_KEY_RECENT_WORKSPACES, JSON.stringify(updated), StorageScope.PROFILE, StorageTarget.MACHINE);
 
 		// Clear current selection if it was the removed workspace
-		if (this._isSelectedWorkspace(selection)) {
+		if (this._isSelectedFolder(folderUri)) {
 			this._hidePicker();
-			this._selectedWorkspace = undefined;
+			this._selectedFolderUri = undefined;
+			this._selectedResolved = undefined;
 			this._updateTriggerLabel();
 			this._onDidSelectWorkspace.fire(undefined);
 		}
 	}
 
-	protected _removeVSCodeRecentWorkspace(selection: IWorkspaceSelection): void {
-		const uri = selection.workspace.folders[0]?.root;
-		if (!uri) {
-			return;
-		}
-		this.workspacesService.removeRecentlyOpened([uri]);
+	protected _removeVSCodeRecentWorkspace(folderUri: URI): void {
+		this.workspacesService.removeRecentlyOpened([folderUri]);
 
 		// Clear current selection if it was the removed workspace
-		if (this._isSelectedWorkspace(selection)) {
+		if (this._isSelectedFolder(folderUri)) {
 			this._hidePicker();
-			this._selectedWorkspace = undefined;
+			this._selectedFolderUri = undefined;
+			this._selectedResolved = undefined;
 			this._updateTriggerLabel();
 			this._onDidSelectWorkspace.fire(undefined);
 		}
@@ -1065,7 +1103,7 @@ export class WorkspacePicker extends Disposable {
 	 * providers, excluding any URIs already present in the sessions' own
 	 * recent workspace history.
 	 */
-	protected _getVSCodeRecentWorkspaces(): { providerId: string; workspace: ISessionWorkspace }[] {
+	protected _getVSCodeRecentWorkspaces(): IResolvedFolderWorkspace[] {
 		if (this._vsCodeRecentFolderUris.length === 0) {
 			return [];
 		}
@@ -1074,21 +1112,15 @@ export class WorkspacePicker extends Disposable {
 		const ownRecents = this._getStoredRecentWorkspaces();
 		const ownUris = new Set(ownRecents.map(r => URI.revive(r.uri).toString()));
 
-		const providers = this.sessionsProvidersService.getProviders();
-		const result: { providerId: string; workspace: ISessionWorkspace }[] = [];
+		const result: IResolvedFolderWorkspace[] = [];
 
 		for (const folderUri of this._vsCodeRecentFolderUris) {
 			if (ownUris.has(folderUri.toString())) {
 				continue;
 			}
-			for (const provider of providers) {
-				if (this._isProviderUnavailable(provider.id)) {
-					continue;
-				}
-				const workspace = provider.resolveWorkspace(folderUri);
-				if (workspace) {
-					result.push({ providerId: provider.id, workspace });
-				}
+			const resolved = this._resolveFolder(folderUri);
+			if (resolved && !this._isProviderUnavailable(resolved.providerId)) {
+				result.push(resolved);
 			}
 			if (result.length >= 10) {
 				break;

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -514,10 +514,16 @@ export class WorkspacePicker extends Disposable {
 
 	/**
 	 * Programmatically set the selected workspace by folder URI.
-	 * @param fireEvent Whether to fire the onDidSelectWorkspace event. Defaults to true.
+	 * @param folderUri The folder URI to select.
+	 * @param options.fireEvent Whether to fire the onDidSelectWorkspace event. Defaults to true.
+	 * @param options.providerId Optional providerId hint that wins over any historical
+	 *        recent entry's provider. Use when the caller knows which provider should
+	 *        own the resulting session (e.g. "New Session" invoked from a workspace
+	 *        section in the sessions list, where the existing sessions for the
+	 *        workspace were created by a specific provider).
 	 */
-	setSelectedWorkspace(folderUri: URI, fireEvent = true): void {
-		this._selectFolder(folderUri, fireEvent);
+	setSelectedWorkspace(folderUri: URI, options?: { fireEvent?: boolean; providerId?: string }): void {
+		this._selectFolder(folderUri, options?.fireEvent ?? true, options?.providerId);
 	}
 
 	/**
@@ -558,16 +564,17 @@ export class WorkspacePicker extends Disposable {
 		}
 	}
 
-	private _selectFolder(folderUri: URI, fireEvent = true): void {
+	private _selectFolder(folderUri: URI, fireEvent = true, providerIdHint?: string): void {
 		this._userHasPicked = true;
 		this._connectionStatusWatch.clear();
-		// Prefer the historical providerId stored in the recents for this URI,
-		// so re-picking a Local Agent Host folder restores the Local Agent
-		// Host association even when another provider also resolves the URI.
+		// Prefer the caller-supplied providerId hint, then the historical
+		// providerId stored in the recents for this URI, so re-picking a
+		// Local Agent Host folder restores the Local Agent Host association
+		// even when another provider also resolves the URI.
 		const storedProviderId = this._getStoredRecentWorkspaces()
 			.find(r => this.uriIdentityService.extUri.isEqual(URI.revive(r.uri), folderUri))
 			?.providerId;
-		const resolved = this._resolveFolder(folderUri, storedProviderId);
+		const resolved = this._resolveFolder(folderUri, providerIdHint ?? storedProviderId);
 		this._selectedFolderUri = folderUri;
 		this._selectedResolved = resolved;
 		this._persistSelectedFolder(folderUri, resolved?.providerId);

--- a/src/vs/sessions/contrib/chat/browser/webWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/webWorkspacePicker.ts
@@ -14,14 +14,13 @@ import { IConfigurationService } from '../../../../platform/configuration/common
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { IFileDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
-import { IQuickInputService } from '../../../../platform/quickinput/common/quickInput.js';
 import { IStorageService } from '../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
 import { IWorkbenchLayoutService } from '../../../../workbench/services/layout/browser/layoutService.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
 import { IAgentHostFilterService } from '../../../services/agentHostFilter/common/agentHostFilter.js';
-import { IWorkspacePickerItem, IWorkspaceSelection, WorkspacePicker } from './sessionWorkspacePicker.js';
+import { IWorkspacePickerItem, WorkspacePicker } from './sessionWorkspacePicker.js';
 import { showMobileWorkspacePickerSheet, shouldUseMobileWorkspacePickerSheet } from './mobile/mobileWorkspacePickerSheet.js';
 import { IWorkspacesService } from '../../../../platform/workspaces/common/workspaces.js';
 
@@ -58,7 +57,6 @@ export class WebWorkspacePicker extends WorkspacePicker {
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IFileDialogService fileDialogService: IFileDialogService,
-		@IQuickInputService quickInputService: IQuickInputService,
 		@ITelemetryService telemetryService: ITelemetryService,
 		@IAgentHostFilterService private readonly _agentHostFilterService: IAgentHostFilterService,
 		@IWorkbenchLayoutService private readonly _layoutService: IWorkbenchLayoutService,
@@ -76,7 +74,6 @@ export class WebWorkspacePicker extends WorkspacePicker {
 			contextKeyService,
 			instantiationService,
 			fileDialogService,
-			quickInputService,
 			telemetryService,
 		);
 
@@ -116,8 +113,8 @@ export class WebWorkspacePicker extends WorkspacePicker {
 
 	private _onScopedHostChanged(): void {
 		const scopedProviderId = this._agentHostFilterService.selectedProviderId;
-		const current = this.selectedProject;
-		if (current && scopedProviderId !== undefined && current.providerId === scopedProviderId) {
+		const currentResolved = this.selectedResolved;
+		if (currentResolved && scopedProviderId !== undefined && currentResolved.providerId === scopedProviderId) {
 			this._onDidChangeSelection.fire();
 			return;
 		}
@@ -126,8 +123,11 @@ export class WebWorkspacePicker extends WorkspacePicker {
 			? this._getRecentWorkspaces().find(w => w.providerId === scopedProviderId)
 			: undefined;
 		if (firstRecent) {
-			this.setSelectedWorkspace({ providerId: firstRecent.providerId, workspace: firstRecent.workspace });
-			return;
+			const folderUri = firstRecent.workspace.folders[0]?.root;
+			if (folderUri) {
+				this.setSelectedWorkspace(folderUri);
+				return;
+			}
 		}
 
 		this.clearSelection();
@@ -149,14 +149,18 @@ export class WebWorkspacePicker extends WorkspacePicker {
 		// 1. Recent workspaces for the scoped provider
 		const recents = this._getRecentWorkspaces().filter(w => w.providerId === scopedProviderId);
 		for (const { workspace, providerId } of recents) {
-			const selection: IWorkspaceSelection = { providerId, workspace };
+			const folderUri = workspace.folders[0]?.root;
+			if (!folderUri) {
+				continue;
+			}
+			const checked = this._isSelectedFolder(folderUri);
 			items.push({
 				kind: ActionListItemKind.Action,
 				label: workspace.label,
 				description: workspace.description,
 				group: { title: '', icon: workspace.icon },
-				item: { selection, checked: this._isSelectedWorkspace(selection) || undefined },
-				onRemove: () => this._removeRecentWorkspace(selection),
+				item: { folderUri, providerId, checked: checked || undefined },
+				onRemove: () => this._removeRecentWorkspace(folderUri),
 			});
 		}
 

--- a/src/vs/sessions/contrib/chat/electron-browser/chat.contribution.ts
+++ b/src/vs/sessions/contrib/chat/electron-browser/chat.contribution.ts
@@ -59,16 +59,14 @@ class SelectAgentsFolderContribution extends Disposable implements IWorkbenchCon
 	}
 
 	private tryResolveAndSelect(folderUri: URI): boolean {
-		for (const provider of this.sessionsProvidersService.getProviders()) {
-			const workspace = provider.resolveWorkspace(folderUri);
-			if (workspace) {
-				this.viewsService.openView<NewChatViewPane>(SessionsViewId).then(view => {
-					view?.selectWorkspace({ providerId: provider.id, workspace });
-				});
-				return true;
-			}
+		const resolved = this.sessionsManagementService.resolveWorkspaceForFolder(folderUri);
+		if (!resolved) {
+			return false;
 		}
-		return false;
+		this.viewsService.openView<NewChatViewPane>(SessionsViewId).then(view => {
+			view?.selectWorkspace(folderUri);
+		});
+		return true;
 	}
 }
 

--- a/src/vs/sessions/contrib/chat/electron-browser/chat.contribution.ts
+++ b/src/vs/sessions/contrib/chat/electron-browser/chat.contribution.ts
@@ -59,7 +59,7 @@ class SelectAgentsFolderContribution extends Disposable implements IWorkbenchCon
 	}
 
 	private tryResolveAndSelect(folderUri: URI): boolean {
-		const resolved = this.sessionsManagementService.resolveWorkspaceForFolder(folderUri);
+		const resolved = this.sessionsManagementService.resolveWorkspace(folderUri);
 		if (!resolved) {
 			return false;
 		}

--- a/src/vs/sessions/contrib/chat/test/browser/sessionWorkspacePicker.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionWorkspacePicker.test.ts
@@ -29,7 +29,7 @@ import { ISessionsProvidersChangeEvent, ISessionsProvidersService } from '../../
 import { ISessionsProvider } from '../../../../services/sessions/common/sessionsProvider.js';
 import { IAgentHostSessionsProvider } from '../../../../common/agentHostSessionsProvider.js';
 import { ISessionWorkspace, ISessionWorkspaceBrowseAction, SESSION_WORKSPACE_GROUP_LOCAL, SESSION_WORKSPACE_GROUP_REMOTE } from '../../../../services/sessions/common/session.js';
-import { WorkspacePicker, IWorkspaceSelection } from '../../browser/sessionWorkspacePicker.js';
+import { WorkspacePicker } from '../../browser/sessionWorkspacePicker.js';
 import { IWorkspacesService } from '../../../../../platform/workspaces/common/workspaces.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
@@ -45,10 +45,23 @@ const STORAGE_KEY_RECENT_WORKSPACES = 'sessions.recentlyPickedWorkspaces';
 
 // ---- Mock providers ---------------------------------------------------------
 
+// Maps mock provider id → URI path prefix it resolves. In production, the
+// URI's authority/scheme determines which provider can resolve it; the
+// tests use file URIs only, so we map provider ids to their conventional
+// path roots (e.g. /remote, /local, /copilot, /agent-host).
+const MOCK_PROVIDER_PATH_PREFIXES: Record<string, string> = {
+	'agenthost-remote-1': '/remote',
+	'local-1': '/local',
+	'default-copilot': '/copilot',
+	'local-agent-host': '/agent-host',
+};
+
 function createMockProvider(id: string, opts?: {
 	connectionStatus?: ISettableObservable<RemoteAgentHostConnectionStatus>;
 	browseActions?: readonly ISessionWorkspaceBrowseAction[];
 }): ISessionsProvider {
+	const pathPrefix = MOCK_PROVIDER_PATH_PREFIXES[id];
+	const canResolve = (uri: URI) => !pathPrefix || uri.path === pathPrefix || uri.path.startsWith(`${pathPrefix}/`);
 	const base = {
 		id,
 		label: `Provider ${id}`,
@@ -56,20 +69,25 @@ function createMockProvider(id: string, opts?: {
 		sessionTypes: [],
 		onDidChangeSessionTypes: Event.None,
 		browseActions: opts?.browseActions ?? [],
-		resolveWorkspace: (uri: URI): ISessionWorkspace => ({
-			uri,
-			label: uri.path.substring(1) || uri.path,
-			icon: Codicon.folder,
-			folders: [{
-				root: uri,
-				workingDirectory: uri,
-				name: uri.path.substring(1) || uri.path,
-				description: undefined,
-				gitRepository: { uri, workTreeUri: undefined, baseBranchName: undefined, gitHubInfo: constObservable(undefined) },
-			}],
-			requiresWorkspaceTrust: false,
-			isVirtualWorkspace: false,
-		}),
+		resolveWorkspace: (uri: URI): ISessionWorkspace | undefined => {
+			if (!canResolve(uri)) {
+				return undefined;
+			}
+			return {
+				uri,
+				label: uri.path.substring(1) || uri.path,
+				icon: Codicon.folder,
+				folders: [{
+					root: uri,
+					workingDirectory: uri,
+					name: uri.path.substring(1) || uri.path,
+					description: undefined,
+					gitRepository: { uri, workTreeUri: undefined, baseBranchName: undefined, gitHubInfo: constObservable(undefined) },
+				}],
+				requiresWorkspaceTrust: false,
+				isVirtualWorkspace: false,
+			};
+		},
 		onDidChangeSessions: Event.None,
 		getSessions: () => [],
 		createNewSession: () => { throw new Error('Not implemented'); },
@@ -178,7 +196,7 @@ function createTestPicker(
 // ---- Assertion helpers ------------------------------------------------------
 
 function assertSelectedProvider(picker: WorkspacePicker, expectedProviderId: string | undefined, message?: string): void {
-	assert.strictEqual(picker.selectedProject?.providerId, expectedProviderId, message);
+	assert.strictEqual(picker.selectedResolved?.providerId, expectedProviderId, message);
 }
 
 // ---- Tests ------------------------------------------------------------------
@@ -237,7 +255,7 @@ suite('WorkspacePicker - Connection Status', () => {
 
 		assertSelectedProvider(picker, 'agenthost-remote-1', 'Selection is restored synchronously');
 
-		const events: Array<IWorkspaceSelection | undefined> = [];
+		const events: Array<URI | undefined> = [];
 		disposables.add(picker.onDidSelectWorkspace(e => events.push(e)));
 
 		// Advance past the grace period.
@@ -287,11 +305,7 @@ suite('WorkspacePicker - Connection Status', () => {
 		const picker = createTestPicker(disposables, providersService, storage);
 
 		// User picks a local workspace while the remote is still trying to connect.
-		const localPick: IWorkspaceSelection = {
-			providerId: 'local-1',
-			workspace: localProvider.resolveWorkspace(URI.file('/local/picked'))!,
-		};
-		picker.setSelectedWorkspace(localPick, false);
+		picker.setSelectedWorkspace(URI.file('/local/picked'), false);
 
 		// Grace period elapses; remote still disconnected — must not affect user pick.
 		await timeout(10_000);
@@ -344,7 +358,7 @@ suite('WorkspacePicker - Connection Status', () => {
 
 		assertSelectedProvider(picker, 'agenthost-remote-1', 'Selection is restored while connecting');
 
-		const events: Array<IWorkspaceSelection | undefined> = [];
+		const events: Array<URI | undefined> = [];
 		disposables.add(picker.onDidSelectWorkspace(e => events.push(e)));
 
 		// SSH tunnel begins.
@@ -409,7 +423,7 @@ suite('WorkspacePicker - Connection Status', () => {
 		remoteStatus.set(RemoteAgentHostConnectionStatus.connected, undefined);
 		assertSelectedProvider(picker, 'agenthost-remote-1');
 		assert.strictEqual(
-			picker.selectedProject?.workspace.folders[0]?.root.path,
+			picker.selectedResolved?.workspace.folders[0]?.root.path,
 			'/remote/project',
 		);
 	});
@@ -431,19 +445,15 @@ suite('WorkspacePicker - Connection Status', () => {
 		// Select the local workspace
 		const resolvedWorkspace = localProvider.resolveWorkspace(URI.file('/local/project'));
 		assert.ok(resolvedWorkspace, 'resolveWorkspace should resolve file:// URIs');
-		const localWorkspace: IWorkspaceSelection = {
-			providerId: 'local-1',
-			workspace: resolvedWorkspace,
-		};
-		picker.setSelectedWorkspace(localWorkspace, false);
+		picker.setSelectedWorkspace(URI.file('/local/project'), false);
 
 		// Verify storage: only the local entry should be checked
 		const raw = storage.get(STORAGE_KEY_RECENT_WORKSPACES, StorageScope.PROFILE);
 		assert.ok(raw, 'Storage should have recent workspaces');
-		const stored = JSON.parse(raw!) as { providerId: string; checked: boolean }[];
+		const stored = JSON.parse(raw!) as { uri: { path: string }; checked: boolean }[];
 		const checkedEntries = stored.filter(e => e.checked);
 		assert.strictEqual(checkedEntries.length, 1, 'Only one entry should be checked');
-		assert.strictEqual(checkedEntries[0].providerId, 'local-1', 'The local entry should be checked');
+		assert.strictEqual(checkedEntries[0].uri.path, '/local/project', 'The local entry should be checked');
 	});
 
 	test('local provider is never treated as unavailable', () => {
@@ -511,11 +521,7 @@ suite('WorkspacePicker - Connection Status', () => {
 		assertSelectedProvider(picker, undefined, 'No fallback while checked entry pending');
 
 		// User explicitly picks a Copilot workspace.
-		const copilotPick: IWorkspaceSelection = {
-			providerId: 'default-copilot',
-			workspace: copilotProvider.resolveWorkspace(URI.file('/copilot/picked'))!,
-		};
-		picker.setSelectedWorkspace(copilotPick, false);
+		picker.setSelectedWorkspace(URI.file('/copilot/picked'), false);
 		assertSelectedProvider(picker, 'default-copilot', 'User pick is honored');
 
 		// Now the late provider for the (still-stored) checked entry arrives.

--- a/src/vs/sessions/contrib/chat/test/browser/sessionWorkspacePicker.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionWorkspacePicker.test.ts
@@ -305,7 +305,7 @@ suite('WorkspacePicker - Connection Status', () => {
 		const picker = createTestPicker(disposables, providersService, storage);
 
 		// User picks a local workspace while the remote is still trying to connect.
-		picker.setSelectedWorkspace(URI.file('/local/picked'), false);
+		picker.setSelectedWorkspace(URI.file('/local/picked'), { fireEvent: false });
 
 		// Grace period elapses; remote still disconnected — must not affect user pick.
 		await timeout(10_000);
@@ -445,7 +445,7 @@ suite('WorkspacePicker - Connection Status', () => {
 		// Select the local workspace
 		const resolvedWorkspace = localProvider.resolveWorkspace(URI.file('/local/project'));
 		assert.ok(resolvedWorkspace, 'resolveWorkspace should resolve file:// URIs');
-		picker.setSelectedWorkspace(URI.file('/local/project'), false);
+		picker.setSelectedWorkspace(URI.file('/local/project'), { fireEvent: false });
 
 		// Verify storage: only the local entry should be checked
 		const raw = storage.get(STORAGE_KEY_RECENT_WORKSPACES, StorageScope.PROFILE);
@@ -521,7 +521,7 @@ suite('WorkspacePicker - Connection Status', () => {
 		assertSelectedProvider(picker, undefined, 'No fallback while checked entry pending');
 
 		// User explicitly picks a Copilot workspace.
-		picker.setSelectedWorkspace(URI.file('/copilot/picked'), false);
+		picker.setSelectedWorkspace(URI.file('/copilot/picked'), { fireEvent: false });
 		assertSelectedProvider(picker, 'default-copilot', 'User pick is honored');
 
 		// Now the late provider for the (still-stored) checked entry arrives.

--- a/src/vs/sessions/contrib/providers/agentHost/browser/localAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/localAgentHostSessionsProvider.ts
@@ -123,7 +123,7 @@ export class LocalAgentHostSessionsProvider extends BaseAgentHostSessionsProvide
 				const uriForDescription = project?.uri ?? workingDirectory;
 				const description = uriForDescription ? this._labelService.getUriLabel(dirname(uriForDescription), { relative: false }) : undefined;
 				const branchProtectionPatterns = readBranchProtectionPatterns(this._configurationService, workingDirectory ?? project?.uri);
-				return LocalAgentHostSessionsProvider.buildWorkspace(project, workingDirectory, this._localLabel, gitHubInfo, gitState, description, branchProtectionPatterns);
+				return LocalAgentHostSessionsProvider.buildWorkspace(project, workingDirectory, gitHubInfo, gitState, description, branchProtectionPatterns);
 			},
 		};
 	}
@@ -143,8 +143,13 @@ export class LocalAgentHostSessionsProvider extends BaseAgentHostSessionsProvide
 
 	// -- Workspaces ----------------------------------------------------------
 
-	static buildWorkspace(project: IAgentSessionMetadata['project'], workingDirectory: URI | undefined, providerLabel: string, gitHubInfo: IObservable<IGitHubInfo | undefined>, gitState: ISessionGitState | undefined, description?: string, branchProtectionPatterns?: readonly string[]): ISessionWorkspace | undefined {
-		return buildAgentHostSessionWorkspace(project, workingDirectory, { providerLabel, fallbackIcon: Codicon.folder, requiresWorkspaceTrust: true, description, branchProtectionPatterns, group: SESSION_WORKSPACE_GROUP_LOCAL }, gitHubInfo, gitState);
+	static buildWorkspace(project: IAgentSessionMetadata['project'], workingDirectory: URI | undefined, gitHubInfo: IObservable<IGitHubInfo | undefined>, gitState: ISessionGitState | undefined, description?: string, branchProtectionPatterns?: readonly string[]): ISessionWorkspace | undefined {
+		// Intentionally pass `undefined` for `providerLabel` so the workspace
+		// label matches the one produced by `resolveWorkspace` (and by other
+		// providers serving the same folder). Sessions list grouping uses
+		// `workspace.label` as the group key — divergent labels would surface
+		// the same folder as multiple groups.
+		return buildAgentHostSessionWorkspace(project, workingDirectory, { providerLabel: undefined, fallbackIcon: Codicon.folder, requiresWorkspaceTrust: true, description, branchProtectionPatterns, group: SESSION_WORKSPACE_GROUP_LOCAL }, gitHubInfo, gitState);
 	}
 
 	resolveWorkspace(repositoryUri: URI): ISessionWorkspace | undefined {
@@ -154,7 +159,7 @@ export class LocalAgentHostSessionsProvider extends BaseAgentHostSessionsProvide
 		const folderName = basename(repositoryUri) || repositoryUri.path;
 		return {
 			uri: repositoryUri,
-			label: `${folderName} [${this._localLabel}]`,
+			label: folderName,
 			description: this._labelService.getUriLabel(dirname(repositoryUri), { relative: false }),
 			group: SESSION_WORKSPACE_GROUP_LOCAL,
 			icon: Codicon.folder,

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
@@ -400,13 +400,13 @@ suite('LocalAgentHostSessionsProvider', () => {
 
 	// ---- Workspace resolution -------
 
-	test('resolveWorkspace builds workspace from URI with [Local] tag', () => {
+	test('resolveWorkspace builds workspace from URI', () => {
 		const provider = createProvider(disposables, agentHost);
 		const uri = URI.parse('file:///home/user/project');
 		const ws = provider.resolveWorkspace(uri);
 
 		assert.ok(ws, 'resolveWorkspace should resolve file:// URIs');
-		assert.strictEqual(ws.label, 'project [Local]');
+		assert.strictEqual(ws.label, 'project');
 		assert.strictEqual(ws.folders.length, 1);
 		assert.strictEqual(ws.folders[0].root.toString(), uri.toString());
 		assert.strictEqual(ws.requiresWorkspaceTrust, true);
@@ -564,13 +564,13 @@ suite('LocalAgentHostSessionsProvider', () => {
 			repository: workspace?.folders[0]?.root.toString(),
 			workingDirectory: workspace?.folders[0]?.workingDirectory?.toString(),
 		}, {
-			label: 'vscode [Local]',
+			label: 'vscode',
 			repository: projectUri.toString(),
 			workingDirectory: workingDirectory.toString(),
 		});
 	}));
 
-	test('listed session with only workingDirectory (no project) shows folder name with [Local] tag', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
+	test('listed session with only workingDirectory (no project) shows folder name', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
 		const workingDirectory = URI.file('/home/user/standalone-folder');
 		agentHost.addSession(createSession('wd-only-1', {
 			summary: 'WD-only Session',
@@ -582,7 +582,7 @@ suite('LocalAgentHostSessionsProvider', () => {
 		await timeout(0);
 
 		const workspace = provider.getSessions()[0].workspace.get();
-		assert.strictEqual(workspace?.label, 'standalone-folder [Local]');
+		assert.strictEqual(workspace?.label, 'standalone-folder');
 	}));
 
 	test('uses model metadata as selected model for listed sessions', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
@@ -645,7 +645,7 @@ suite('LocalAgentHostSessionsProvider', () => {
 		assert.strictEqual(session.providerId, provider.id);
 		assert.strictEqual(session.status.get(), SessionStatus.Untitled);
 		assert.ok(session.workspace.get());
-		assert.strictEqual(session.workspace.get()?.label, 'my-project [Local]');
+		assert.strictEqual(session.workspace.get()?.label, 'my-project');
 		assert.strictEqual(session.sessionType, provider.sessionTypes[0].id);
 		assert.deepStrictEqual(provider.getSessionConfig(session.sessionId), { schema: { type: 'object', properties: {} }, values: {} });
 	});
@@ -728,7 +728,7 @@ suite('LocalAgentHostSessionsProvider', () => {
 		}, {
 			listedSessions: 0,
 			resolvedResource: session.resource.toString(),
-			resolvedWorkspaceLabel: 'my-project [Local]',
+			resolvedWorkspaceLabel: 'my-project',
 		});
 	});
 
@@ -1020,7 +1020,7 @@ suite('LocalAgentHostSessionsProvider', () => {
 
 		const workspace = wsSession!.workspace.get();
 		assert.ok(workspace);
-		assert.strictEqual(workspace!.label, 'myrepo [Local]');
+		assert.strictEqual(workspace!.label, 'myrepo');
 	}));
 
 	test('session adapter without working directory has no workspace', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostActions.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostActions.ts
@@ -593,10 +593,14 @@ async function promptForRemoteFolder(
 	if (!workspace) {
 		return;
 	}
+	const folderUri = workspace.folders[0]?.root;
+	if (!folderUri) {
+		return;
+	}
 
 	sessionsManagementService.openNewSessionView();
 	const view = await viewsService.openView<NewChatViewPane>(SessionsViewId, true);
-	view?.selectWorkspace({ providerId: provider.id, workspace });
+	view?.selectWorkspace(folderUri);
 }
 
 registerAction2(class extends Action2 {
@@ -939,10 +943,14 @@ async function promptForTunnelFolder(
 	if (!workspace) {
 		return;
 	}
+	const folderUri = workspace.folders[0]?.root;
+	if (!folderUri) {
+		return;
+	}
 
 	sessionsManagementService.openNewSessionView();
 	const view = await viewsService.openView<NewChatViewPane>(SessionsViewId, true);
-	view?.selectWorkspace({ providerId: provider.id, workspace });
+	view?.selectWorkspace(folderUri);
 }
 
 registerAction2(class extends Action2 {

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
@@ -353,10 +353,12 @@ registerAction2(class NewSessionForWorkspaceAction extends Action2 {
 		const commandService = accessor.get(ICommandService);
 		sessionsManagementService.openNewSessionView();
 		const view = await viewsService.openView<NewChatViewPane>(NewChatViewId, true);
-		const workspace = context.sessions[0].workspace.get();
+		const session = context.sessions[0];
+		const workspace = session.workspace.get();
 		const folderUri = workspace?.folders[0]?.root;
+		const providerId = session.providerId;
 		if (view && folderUri) {
-			view.selectWorkspace(folderUri);
+			view.selectWorkspace(folderUri, providerId);
 		}
 		// On mobile web, the sidebar drawer covers the viewport; close it so
 		// the new session view becomes visible after creation. Routes through

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
@@ -354,8 +354,9 @@ registerAction2(class NewSessionForWorkspaceAction extends Action2 {
 		sessionsManagementService.openNewSessionView();
 		const view = await viewsService.openView<NewChatViewPane>(NewChatViewId, true);
 		const workspace = context.sessions[0].workspace.get();
-		if (view && workspace) {
-			view.selectWorkspace({ providerId: context.sessions[0].providerId, workspace });
+		const folderUri = workspace?.folders[0]?.root;
+		if (view && folderUri) {
+			view.selectWorkspace(folderUri);
 		}
 		// On mobile web, the sidebar drawer covers the viewport; close it so
 		// the new session view becomes visible after creation. Routes through

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -17,7 +17,7 @@ import { IProgressService } from '../../../../platform/progress/common/progress.
 import { IAgentSessionsService } from '../../../../workbench/contrib/chat/browser/agentSessions/agentSessionsService.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
 import { ActiveSessionProviderIdContext, ActiveSessionTypeContext, IsActiveSessionArchivedContext, ActiveSessionWorkspaceIsVirtualContext, IsNewChatInSessionContext, IsNewChatSessionContext } from '../../../common/contextkeys.js';
-import { ActiveSessionSupportsMultiChatContext, IActiveSession, ICreateNewSessionOptions, IFolderSessionType, ISessionsChangeEvent, ISessionsManagementService } from '../common/sessionsManagement.js';
+import { ActiveSessionSupportsMultiChatContext, IActiveSession, ICreateNewSessionOptions, IProviderSessionType, ISessionsChangeEvent, ISessionsManagementService } from '../common/sessionsManagement.js';
 import { ISessionsProvidersChangeEvent, ISessionsProvidersService } from './sessionsProvidersService.js';
 import { ISendRequestOptions, ISessionChangeEvent, ISessionsProvider } from '../common/sessionsProvider.js';
 import { IChat, ISession, ISessionWorkspace, SessionStatus, ISessionType } from '../common/session.js';
@@ -194,8 +194,8 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 		return [...this._sessionTypes];
 	}
 
-	getSessionTypes(folderUri: URI): IFolderSessionType[] {
-		const result: IFolderSessionType[] = [];
+	getSessionTypesForFolder(folderUri: URI): IProviderSessionType[] {
+		const result: IProviderSessionType[] = [];
 		for (const provider of this.sessionsProvidersService.getProviders()) {
 			if (!provider.resolveWorkspace(folderUri)) {
 				continue;

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -194,7 +194,7 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 		return [...this._sessionTypes];
 	}
 
-	getSessionTypesForFolder(folderUri: URI): IFolderSessionType[] {
+	getSessionTypes(folderUri: URI): IFolderSessionType[] {
 		const result: IFolderSessionType[] = [];
 		for (const provider of this.sessionsProvidersService.getProviders()) {
 			if (!provider.resolveWorkspace(folderUri)) {
@@ -207,7 +207,7 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 		return result;
 	}
 
-	resolveWorkspaceForFolder(folderUri: URI): { providerId: string; workspace: ISessionWorkspace } | undefined {
+	resolveWorkspace(folderUri: URI): { providerId: string; workspace: ISessionWorkspace } | undefined {
 		for (const provider of this.sessionsProvidersService.getProviders()) {
 			const workspace = provider.resolveWorkspace(folderUri);
 			if (workspace) {

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -17,10 +17,10 @@ import { IProgressService } from '../../../../platform/progress/common/progress.
 import { IAgentSessionsService } from '../../../../workbench/contrib/chat/browser/agentSessions/agentSessionsService.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
 import { ActiveSessionProviderIdContext, ActiveSessionTypeContext, IsActiveSessionArchivedContext, ActiveSessionWorkspaceIsVirtualContext, IsNewChatInSessionContext, IsNewChatSessionContext } from '../../../common/contextkeys.js';
-import { ActiveSessionSupportsMultiChatContext, IActiveSession, ISessionsChangeEvent, ISessionsManagementService } from '../common/sessionsManagement.js';
+import { ActiveSessionSupportsMultiChatContext, IActiveSession, ICreateNewSessionOptions, IFolderSessionType, ISessionsChangeEvent, ISessionsManagementService } from '../common/sessionsManagement.js';
 import { ISessionsProvidersChangeEvent, ISessionsProvidersService } from './sessionsProvidersService.js';
 import { ISendRequestOptions, ISessionChangeEvent, ISessionsProvider } from '../common/sessionsProvider.js';
-import { IChat, ISession, SessionStatus, ISessionType } from '../common/session.js';
+import { IChat, ISession, ISessionWorkspace, SessionStatus, ISessionType } from '../common/session.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { SessionsNavigation } from './sessionNavigation.js';
 
@@ -194,6 +194,29 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 		return [...this._sessionTypes];
 	}
 
+	getSessionTypesForFolder(folderUri: URI): IFolderSessionType[] {
+		const result: IFolderSessionType[] = [];
+		for (const provider of this.sessionsProvidersService.getProviders()) {
+			if (!provider.resolveWorkspace(folderUri)) {
+				continue;
+			}
+			for (const sessionType of provider.getSessionTypes(folderUri)) {
+				result.push({ providerId: provider.id, sessionType });
+			}
+		}
+		return result;
+	}
+
+	resolveWorkspaceForFolder(folderUri: URI): { providerId: string; workspace: ISessionWorkspace } | undefined {
+		for (const provider of this.sessionsProvidersService.getProviders()) {
+			const workspace = provider.resolveWorkspace(folderUri);
+			if (workspace) {
+				return { providerId: provider.id, workspace };
+			}
+		}
+		return undefined;
+	}
+
 	private _collectSessionTypes(): ISessionType[] {
 		const types: ISessionType[] = [];
 		const seen = new Set<string>();
@@ -209,13 +232,14 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 	}
 
 	private _updateSessionTypes(): void {
-		const newTypes = this._collectSessionTypes();
-		const changed = this._sessionTypes.length !== newTypes.length
-			|| this._sessionTypes.some((t, i) => t.id !== newTypes[i].id || t.label !== newTypes[i].label);
-		if (changed) {
-			this._sessionTypes = newTypes;
-			this._onDidChangeSessionTypes.fire();
-		}
+		// Always fire — the deduplicated flat list (used by surfaces that
+		// only need a set of type ids) may be unchanged, but the per-folder
+		// result of {@link getSessionTypesForFolder} can change whenever any
+		// provider's types or the set of providers changes, because each
+		// entry is keyed by (providerId × sessionType) rather than by type
+		// id alone.
+		this._sessionTypes = this._collectSessionTypes();
+		this._onDidChangeSessionTypes.fire();
 	}
 
 	/**
@@ -312,24 +336,51 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 		this.setActiveSession(undefined);
 	}
 
-	createNewSession(providerId: string, repositoryUri: URI, sessionTypeId?: string): ISession {
+	createNewSession(folderUri: URI, options?: ICreateNewSessionOptions): ISession {
 		this._startOpenSession();
 		if (!this.isNewChatSessionContext.get()) {
 			this.isNewChatSessionContext.set(true);
 		}
 
-		const provider = this.sessionsProvidersService.getProviders().find(p => p.id === providerId);
-		if (!provider) {
-			throw new Error(`Sessions provider '${providerId}' not found`);
-		}
+		const providers = this.sessionsProvidersService.getProviders();
+		let provider: ISessionsProvider | undefined;
 
-		if (!sessionTypeId) {
-			sessionTypeId = provider.getSessionTypes(repositoryUri)[0]?.id;
-			if (!sessionTypeId) {
-				throw new Error(`No session types available for provider '${providerId}'`);
+		if (options?.providerId) {
+			provider = providers.find(p => p.id === options.providerId);
+			if (!provider) {
+				throw new Error(`Sessions provider '${options.providerId}' not found`);
+			}
+			if (!provider.resolveWorkspace(folderUri)) {
+				throw new Error(`Sessions provider '${options.providerId}' cannot resolve folder '${folderUri.toString()}'`);
+			}
+		} else {
+			// Iterate providers and pick the first one that can resolve the folder.
+			// When a specific session type was requested, also require the provider to
+			// advertise that type for the folder.
+			for (const candidate of providers) {
+				if (!candidate.resolveWorkspace(folderUri)) {
+					continue;
+				}
+				if (options?.sessionTypeId && !candidate.getSessionTypes(folderUri).some(t => t.id === options.sessionTypeId)) {
+					continue;
+				}
+				provider = candidate;
+				break;
+			}
+			if (!provider) {
+				throw new Error(`No sessions provider can resolve folder '${folderUri.toString()}'`);
 			}
 		}
-		const session = provider.createNewSession(repositoryUri, sessionTypeId);
+
+		let sessionTypeId = options?.sessionTypeId;
+		if (!sessionTypeId) {
+			sessionTypeId = provider.getSessionTypes(folderUri)[0]?.id;
+			if (!sessionTypeId) {
+				throw new Error(`No session types available for provider '${provider.id}'`);
+			}
+		}
+
+		const session = provider.createNewSession(folderUri, sessionTypeId);
 		this._pendingNewSession = session;
 		this.setActiveSession(session);
 		return session;

--- a/src/vs/sessions/services/sessions/common/sessionsManagement.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsManagement.ts
@@ -13,12 +13,12 @@ import { IChat, ISession, ISessionType, ISessionWorkspace } from './session.js';
 import { ISendRequestOptions } from './sessionsProvider.js';
 
 /**
- * A session type advertised by a specific provider for a given folder URI.
- * Returned by {@link ISessionsManagementService.getSessionTypesForFolder} so
- * the UI can group types by provider when more than one provider can serve
- * the same folder.
+ * A (provider, session-type) pair returned by
+ * {@link ISessionsManagementService.getSessionTypesForFolder} so the UI can
+ * group session types by provider when more than one provider can serve the
+ * same folder.
  */
-export interface IFolderSessionType {
+export interface IProviderSessionType {
 	readonly providerId: string;
 	readonly sessionType: ISessionType;
 }
@@ -91,7 +91,7 @@ export interface ISessionsManagementService {
 	 * so the UI can group types by provider when more than one provider can
 	 * serve the same workspace.
 	 */
-	getSessionTypes(workspaceUri: URI): IFolderSessionType[];
+	getSessionTypesForFolder(folderUri: URI): IProviderSessionType[];
 
 	/**
 	 * Resolve a workspace URI to a workspace using the first provider whose

--- a/src/vs/sessions/services/sessions/common/sessionsManagement.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsManagement.ts
@@ -9,8 +9,37 @@ import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
-import { IChat, ISession, ISessionType } from './session.js';
+import { IChat, ISession, ISessionType, ISessionWorkspace } from './session.js';
 import { ISendRequestOptions } from './sessionsProvider.js';
+
+/**
+ * A session type advertised by a specific provider for a given folder URI.
+ * Returned by {@link ISessionsManagementService.getSessionTypesForFolder} so
+ * the UI can group types by provider when more than one provider can serve
+ * the same folder.
+ */
+export interface IFolderSessionType {
+	readonly providerId: string;
+	readonly sessionType: ISessionType;
+}
+
+/**
+ * Options for {@link ISessionsManagementService.createNewSession}.
+ */
+export interface ICreateNewSessionOptions {
+	/**
+	 * Force creation through a specific provider. When omitted, the service
+	 * iterates registered providers and picks the first one whose
+	 * {@link ISessionsProvider.resolveWorkspace} succeeds for the folder URI
+	 * (and, when `sessionTypeId` is given, whose `getSessionTypes` includes it).
+	 */
+	readonly providerId?: string;
+	/**
+	 * The session type to use. When omitted, defaults to the first type the
+	 * chosen provider advertises for the folder URI.
+	 */
+	readonly sessionTypeId?: string;
+}
 
 export const ActiveSessionSupportsMultiChatContext = new RawContextKey<boolean>('activeSessionSupportsMultiChat', false, localize('activeSessionSupportsMultiChat', "Whether the active session supports multiple chats"));
 
@@ -57,6 +86,21 @@ export interface ISessionsManagementService {
 	getAllSessionTypes(): ISessionType[];
 
 	/**
+	 * Get all session types that can serve the given folder URI, across all
+	 * registered providers. Returns one entry per (provider × supported type),
+	 * so the UI can group types by provider when more than one provider can
+	 * serve the same folder.
+	 */
+	getSessionTypesForFolder(folderUri: URI): IFolderSessionType[];
+
+	/**
+	 * Resolve a folder URI to a workspace using the first provider whose
+	 * {@link ISessionsProvider.resolveWorkspace} succeeds. Returns `undefined`
+	 * when no registered provider can resolve the URI.
+	 */
+	resolveWorkspaceForFolder(folderUri: URI): { providerId: string; workspace: ISessionWorkspace } | undefined;
+
+	/**
 	 * Fires when available session types change (providers added/removed).
 	 */
 	readonly onDidChangeSessionTypes: Event<void>;
@@ -99,10 +143,16 @@ export interface ISessionsManagementService {
 	openNewSessionView(): void;
 
 	/**
-	 * Create a new session for the given workspace.
-	 * Delegates to the provider identified by providerId.
+	 * Create a new session for the given folder.
+	 *
+	 * When `options.providerId` is omitted, iterates registered providers and
+	 * picks the first one whose {@link ISessionsProvider.resolveWorkspace}
+	 * succeeds for `folderUri` (and, when `options.sessionTypeId` is given,
+	 * whose `getSessionTypes` includes it). When `options.sessionTypeId` is
+	 * omitted, defaults to the chosen provider's first advertised type for
+	 * the folder.
 	 */
-	createNewSession(providerId: string, workspaceUri: URI, sessionTypeId?: string): ISession;
+	createNewSession(folderUri: URI, options?: ICreateNewSessionOptions): ISession;
 
 	/**
 	 * Unset the new session

--- a/src/vs/sessions/services/sessions/common/sessionsManagement.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsManagement.ts
@@ -86,19 +86,19 @@ export interface ISessionsManagementService {
 	getAllSessionTypes(): ISessionType[];
 
 	/**
-	 * Get all session types that can serve the given folder URI, across all
+	 * Get all session types that can serve the given workspace URI, across all
 	 * registered providers. Returns one entry per (provider × supported type),
 	 * so the UI can group types by provider when more than one provider can
-	 * serve the same folder.
+	 * serve the same workspace.
 	 */
-	getSessionTypesForFolder(folderUri: URI): IFolderSessionType[];
+	getSessionTypes(workspaceUri: URI): IFolderSessionType[];
 
 	/**
-	 * Resolve a folder URI to a workspace using the first provider whose
+	 * Resolve a workspace URI to a workspace using the first provider whose
 	 * {@link ISessionsProvider.resolveWorkspace} succeeds. Returns `undefined`
 	 * when no registered provider can resolve the URI.
 	 */
-	resolveWorkspaceForFolder(folderUri: URI): { providerId: string; workspace: ISessionWorkspace } | undefined;
+	resolveWorkspace(workspaceUri: URI): { providerId: string; workspace: ISessionWorkspace } | undefined;
 
 	/**
 	 * Fires when available session types change (providers added/removed).
@@ -186,12 +186,16 @@ export interface ISessionsManagementService {
 
 	/** Archive a session. */
 	archiveSession(session: ISession): Promise<void>;
+
 	/** Unarchive a session. */
 	unarchiveSession(session: ISession): Promise<void>;
+
 	/** Delete a session. */
 	deleteSession(session: ISession): Promise<void>;
+
 	/** Delete a single chat from a session by its URI. */
 	deleteChat(session: ISession, chatUri: URI): Promise<void>;
+
 	/** Rename a chat within a session. */
 	renameChat(session: ISession, chatUri: URI, title: string): Promise<void>;
 }

--- a/src/vs/sessions/services/sessions/common/sessionsProvider.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsProvider.ts
@@ -93,23 +93,23 @@ export interface ISessionsProvider {
 	 * Resolve a workspace for the given repository URI.
 	 * Returns `undefined` when the provider cannot handle the given URI
 	 * (e.g. wrong scheme or authority).
-	 * @param repositoryUri The URI of the repository to resolve the workspace for.
+	 * @param workspaceUri The URI of the repository to resolve the workspace for.
 	 */
-	resolveWorkspace(repositoryUri: URI): ISessionWorkspace | undefined;
+	resolveWorkspace(workspaceUri: URI): ISessionWorkspace | undefined;
 
 	/**
-	 * Create a new session for the given repository URI.
+	 * Create a new session for the given workspace URI.
 	 * The provider should not add this session to its session list until the first request is sent.
-	 * @param repositoryUri The URI of the repository to create the session for.
+	 * @param workspaceUri The URI of the repository to create the session for.
 	 * @param sessionTypeId The ID of the session type to create.
 	 */
-	createNewSession(repositoryUri: URI, sessionTypeId: string): ISession;
+	createNewSession(workspaceUri: URI, sessionTypeId: string): ISession;
 
 	/**
-	 * Get the session types supported for a given repository URI.
-	 * @param repositoryUri The URI of the repository to get session types for.
+	 * Get the session types supported for a given workspace URI.
+	 * @param workspaceUri The URI of the workspace to get session types for.
 	 */
-	getSessionTypes(repositoryUri: URI): ISessionType[];
+	getSessionTypes(workspaceUri: URI): ISessionType[];
 
 	/**
 	 * Rename a chat within a session.

--- a/src/vs/sessions/services/sessions/test/browser/sessionNavigation.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionNavigation.test.ts
@@ -127,8 +127,8 @@ class MockSessionStore implements ISessionsManagementService {
 	}
 
 	getAllSessionTypes(): ISessionType[] { return []; }
-	getSessionTypesForFolder(_folderUri: URI): IFolderSessionType[] { return []; }
-	resolveWorkspaceForFolder(_folderUri: URI): { providerId: string; workspace: ISessionWorkspace } | undefined { return undefined; }
+	getSessionTypes(_folderUri: URI): IFolderSessionType[] { return []; }
+	resolveWorkspace(_folderUri: URI): { providerId: string; workspace: ISessionWorkspace } | undefined { return undefined; }
 
 	async openSession(sessionResource: URI): Promise<void> {
 		this._openedResource = sessionResource;

--- a/src/vs/sessions/services/sessions/test/browser/sessionNavigation.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionNavigation.test.ts
@@ -11,7 +11,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/tes
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { NullLogService } from '../../../../../platform/log/common/log.js';
 import { MockContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
-import { IActiveSession, ICreateNewSessionOptions, IFolderSessionType, ISessionsManagementService } from '../../common/sessionsManagement.js';
+import { IActiveSession, ICreateNewSessionOptions, IProviderSessionType, ISessionsManagementService } from '../../common/sessionsManagement.js';
 import { IChat, ISession, ISessionType, ISessionWorkspace, SessionStatus } from '../../common/session.js';
 import { SessionsNavigation } from '../../browser/sessionNavigation.js';
 import { Event } from '../../../../../base/common/event.js';
@@ -127,7 +127,7 @@ class MockSessionStore implements ISessionsManagementService {
 	}
 
 	getAllSessionTypes(): ISessionType[] { return []; }
-	getSessionTypes(_folderUri: URI): IFolderSessionType[] { return []; }
+	getSessionTypesForFolder(_folderUri: URI): IProviderSessionType[] { return []; }
 	resolveWorkspace(_folderUri: URI): { providerId: string; workspace: ISessionWorkspace } | undefined { return undefined; }
 
 	async openSession(sessionResource: URI): Promise<void> {

--- a/src/vs/sessions/services/sessions/test/browser/sessionNavigation.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionNavigation.test.ts
@@ -11,8 +11,8 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/tes
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { NullLogService } from '../../../../../platform/log/common/log.js';
 import { MockContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
-import { IActiveSession, ISessionsManagementService } from '../../common/sessionsManagement.js';
-import { IChat, ISession, ISessionType, SessionStatus } from '../../common/session.js';
+import { IActiveSession, ICreateNewSessionOptions, IFolderSessionType, ISessionsManagementService } from '../../common/sessionsManagement.js';
+import { IChat, ISession, ISessionType, ISessionWorkspace, SessionStatus } from '../../common/session.js';
 import { SessionsNavigation } from '../../browser/sessionNavigation.js';
 import { Event } from '../../../../../base/common/event.js';
 import { ISendRequestOptions } from '../../common/sessionsProvider.js';
@@ -127,6 +127,8 @@ class MockSessionStore implements ISessionsManagementService {
 	}
 
 	getAllSessionTypes(): ISessionType[] { return []; }
+	getSessionTypesForFolder(_folderUri: URI): IFolderSessionType[] { return []; }
+	resolveWorkspaceForFolder(_folderUri: URI): { providerId: string; workspace: ISessionWorkspace } | undefined { return undefined; }
 
 	async openSession(sessionResource: URI): Promise<void> {
 		this._openedResource = sessionResource;
@@ -155,7 +157,7 @@ class MockSessionStore implements ISessionsManagementService {
 		}
 	}
 	restoreLastActiveSession(): Promise<void> { throw new Error('not implemented'); }
-	createNewSession(_providerId: string, _workspaceUri: URI, _sessionTypeId?: string): ISession { throw new Error('not implemented'); }
+	createNewSession(_folderUri: URI, _options?: ICreateNewSessionOptions): ISession { throw new Error('not implemented'); }
 	unsetNewSession(): void { throw new Error('not implemented'); }
 	sendAndCreateChat(_session: ISession, _options: ISendRequestOptions): Promise<void> { throw new Error('not implemented'); }
 	sendRequest(_session: ISession, _chat: IChat, _options: ISendRequestOptions): Promise<void> { throw new Error('not implemented'); }


### PR DESCRIPTION
## What

Refactors the new-session workspace picker so it selects only a folder URI instead of a `(providerId, workspace)` pair. The session management service resolves the provider from the URI at session-creation time. The session type picker now queries the management service for all session types every registered provider can serve for the folder, grouped by provider with a separator between groups.

## Why

Previously, the workspace picker forced the user to pick a provider up front (via a `quickInputService.pick`) when more than one provider supported local folders. That coupling made the session type picker limited to one provider's types for the active session. With the new flow:

- The user picks just a folder.
- The session type picker shows every (provider × type) combination that can serve that folder.
- Picking a type creates the new session through the correct provider — even when the same `sessionType.id` (e.g. `copilot-cli`) is offered by multiple providers.

## Key changes

**`ISessionsManagementService`**
- `getSessionTypesForFolder(folderUri)` → `Array<{ providerId, sessionType }>`.
- `resolveWorkspaceForFolder(folderUri)` → first provider that resolves the URI.
- `createNewSession(folderUri, options?)` — iterates providers; picks the first matching one when no `providerId` is supplied.
- `_updateSessionTypes` now fires `onDidChangeSessionTypes` unconditionally so the per-folder list isn't stale when two providers contribute overlapping `sessionType.id`s.

**`WorkspacePicker`**
- Emits `URI | undefined`; `selectedFolderUri` / `setSelectedWorkspace(uri)`.
- Drops the up-front quick-pick for choosing between local providers.
- Recents storage keeps a backward-compat `providerId` hint; restoration prefers it so re-picking a Local Agent Host folder stays on Local Agent Host.

**`SessionTypePicker`**
- Reads `getSessionTypesForFolder`; groups items by provider with a separator and the provider label as a header.
- Emits `IPickedSessionType = { providerId, sessionTypeId }`.
- Recomputes types at open time as a safety net for late-registering providers.
- Mobile sheet variant mirrors the same shape via a composite id.

**`LocalAgentHostSessionsProvider`**
- Drops the `[Local]` suffix from workspace labels so its sessions for a folder share the same workspace group with other providers' sessions for that folder.

**`NewChatViewPane`**
- Rewired to the URI flow.
- Falls back to `workspacePicker.selectedResolved.providerId` when the session type picker has no explicit pick, preserving the user's historical provider association for recently-picked folders.

## Notes for reviewers

- The provider × type grouping in the session type picker uses provider label as the section header and inserts a `Separator` between groups.
- Recent workspace storage retains the legacy `providerId` field on read for forward compat; writes include it as a hint.
- Documentation in `SESSIONS.md` was updated to reflect the new data flow.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>