### PR TITLE
Constrain GHE input width and wrap helper text

### DIFF
--- a/src/vs/workbench/contrib/welcomeOnboarding/browser/media/variationA.css
+++ b/src/vs/workbench/contrib/welcomeOnboarding/browser/media/variationA.css
@@ -310,6 +310,7 @@
 	flex-direction: column;
 	justify-content: center;
 	gap: 10px;
+	min-width: 0;
 }
 
 .onboarding-a-signin-title {
@@ -334,6 +335,7 @@
 	gap: 8px;
 	margin-top: 4px;
 	flex-wrap: nowrap;
+	min-width: 0;
 }
 
 .onboarding-a-signin-footer {
@@ -443,6 +445,7 @@
 	margin-top: 4px;
 	min-width: 0;
 	width: 100%;
+	max-width: 320px;
 }
 
 .onboarding-a-signin-ghe-input .monaco-inputbox {
@@ -500,6 +503,12 @@
 	font-size: 12px;
 	line-height: 1.4;
 	color: var(--vscode-descriptionForeground);
+	width: 100%;
+	max-width: 100%;
+	box-sizing: border-box;
+	white-space: normal;
+	overflow-wrap: anywhere;
+	word-break: break-word;
 	min-height: 16px;
 }
 


### PR DESCRIPTION
Tweaks to the GHE.com onboarding instance input so the input stays at a comfortable width and the validation/helper text wraps to additional lines instead of stretching the input.

Changes in `src/vs/workbench/contrib/welcomeOnboarding/browser/media/variationA.css`:

- Cap `.onboarding-a-signin-ghe-input` at `max-width: 320px` so the input no longer stretches with its parent's content column.
- Allow `.onboarding-a-signin-ghe-message` to wrap to multiple lines via `white-space: normal`, `overflow-wrap: anywhere`, `word-break: break-word`.
- Add `min-width: 0` to `.onboarding-a-signin-content-main` and `.onboarding-a-signin-actions` so flex children can shrink (allows wrapping instead of expanding to max-content).

Suggested follow-up to #317205.