### PR TITLE
Add `.wixproj` to xml language extension list

### DIFF
--- a/extensions/xml/package.json
+++ b/extensions/xml/package.json
@@ -64,6 +64,7 @@
           ".vbproj.user",
           ".vcxproj",
           ".vcxproj.filters",
+          ".wixproj",
           ".wsdl",
           ".wxi",
           ".wxl",


### PR DESCRIPTION
WiX MSBuild project files (`.wixproj`) are XML, like the other MSBuild project file extensions already in the list (`.csproj`, `.vbproj`, `.fsproj`, `.vcxproj`, `.shproj`).

The associated WiX source files (`.wxs`, `.wxi`, `.wxl`) are already recognized as XML, so it's a natural addition to also recognize the project file that references them.

Without this, `.wixproj` files open as plain text by default and users have to add a `files.associations` entry per workspace.