### PR TITLE
chat: persist installed plugin identity

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentPluginRepositoryService.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentPluginRepositoryService.ts
@@ -109,8 +109,16 @@ export class AgentPluginRepositoryService implements IAgentPluginRepositoryServi
 	}
 
 	getPluginInstallUri(plugin: IMarketplacePlugin): URI {
+		if (plugin.sourceDescriptor.kind !== PluginSourceKind.RelativePath) {
+			return this.getPluginSourceInstallUri(plugin.sourceDescriptor);
+		}
 		const repoDir = this.getRepositoryUri(plugin.marketplaceReference, plugin.marketplaceType);
-		return this._getPluginDir(repoDir, plugin.source);
+		const normalizedSource = plugin.source.trim().replace(/^\.?\/+|\/+$/g, '');
+		const pluginDir = normalizedSource ? joinPath(repoDir, normalizedSource) : repoDir;
+		if (!isEqualOrParent(pluginDir, repoDir)) {
+			throw new Error(`Invalid plugin source path '${plugin.source}'`);
+		}
+		return pluginDir;
 	}
 
 	async ensureRepository(marketplace: IMarketplaceReference, options?: IEnsureRepositoryOptions): Promise<URI> {
@@ -268,15 +276,6 @@ export class AgentPluginRepositoryService implements IAgentPluginRepositoryServi
 		} finally {
 			cts.dispose();
 		}
-	}
-
-	private _getPluginDir(repoDir: URI, source: string): URI {
-		const normalizedSource = source.trim().replace(/^\.?\/+|\/+$/g, '');
-		const pluginDir = normalizedSource ? joinPath(repoDir, normalizedSource) : repoDir;
-		if (!isEqualOrParent(pluginDir, repoDir)) {
-			throw new Error(`Invalid plugin source path '${source}'`);
-		}
-		return pluginDir;
 	}
 
 	getPluginSourceInstallUri(sourceDescriptor: IPluginSourceDescriptor): URI {

--- a/src/vs/workbench/contrib/chat/browser/pluginInstallService.ts
+++ b/src/vs/workbench/contrib/chat/browser/pluginInstallService.ts
@@ -413,10 +413,7 @@ export class PluginInstallService implements IPluginInstallService {
 	}
 
 	getPluginInstallUri(plugin: IMarketplacePlugin): URI {
-		if (plugin.sourceDescriptor.kind === PluginSourceKind.RelativePath) {
-			return this._pluginRepositoryService.getPluginInstallUri(plugin);
-		}
-		return this._pluginRepositoryService.getPluginSourceInstallUri(plugin.sourceDescriptor);
+		return this._pluginRepositoryService.getPluginInstallUri(plugin);
 	}
 
 	// --- Trust gate -------------------------------------------------------------

--- a/src/vs/workbench/contrib/chat/common/plugins/fileBackedInstalledPluginsStore.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/fileBackedInstalledPluginsStore.ts
@@ -25,11 +25,14 @@ const LEGACY_MARKETPLACE_INDEX_STORAGE_KEY = 'chat.plugins.marketplaces.index.v1
 /**
  * Minimal entry stored in `installed.json`. URIs are serialised as strings
  * so that external tools can read and write the file without depending on
- * VS Code internal URI representations.
+ * VS Code internal URI representations. The optional `name` identifies the
+ * marketplace plugin and lets VS Code re-read the full descriptor from the
+ * marketplace when needed.
  */
 interface IInstalledJsonEntry {
 	readonly pluginUri: string;
 	readonly marketplace: string;
+	readonly name?: string;
 }
 
 /**
@@ -46,6 +49,7 @@ interface IInstalledJson {
 export interface IStoredInstalledPlugin {
 	readonly pluginUri: URI;
 	readonly marketplace: string;
+	readonly name?: string;
 }
 
 /**
@@ -54,9 +58,9 @@ export interface IStoredInstalledPlugin {
  * the installed-plugin manifest discoverable by external tools (CLIs,
  * other editors, etc.) without depending on VS Code internals.
  *
- * The on-disk format stores only the plugin URI (as a string) and the
- * marketplace identifier. Plugin metadata (name, description, etc.) is
- * read from the plugin manifest on disk by the discovery layer -
+ * The on-disk format stores only the plugin URI (as a string), marketplace
+ * identifier, and plugin name. Full plugin metadata (description, source
+ * descriptor, etc.) is read from marketplace data by the discovery layer -
  * keeping a single source of truth.
  *
  * On construction the store:
@@ -134,10 +138,14 @@ export class FileBackedInstalledPluginsStore extends Disposable {
 				return undefined;
 			}
 
-			// Each entry is { pluginUri: string, enabled: boolean }.
+			// Each entry is { pluginUri, marketplace, name? }.
 			return json.installed
 				.filter((entry): entry is IInstalledJsonEntry => typeof entry.pluginUri === 'string' && typeof entry.marketplace === 'string')
-				.map(entry => ({ pluginUri: URI.parse(entry.pluginUri), marketplace: entry.marketplace }));
+				.map(entry => ({
+					pluginUri: URI.parse(entry.pluginUri),
+					marketplace: entry.marketplace,
+					name: typeof entry.name === 'string' ? entry.name : undefined,
+				}));
 		} catch {
 			return undefined;
 		}
@@ -153,6 +161,7 @@ export class FileBackedInstalledPluginsStore extends Disposable {
 		const entries: IInstalledJsonEntry[] = this.get().map(e => ({
 			pluginUri: e.pluginUri.toString(),
 			marketplace: e.marketplace,
+			...(e.name ? { name: e.name } : {}),
 		}));
 
 		const data: IInstalledJson = {
@@ -230,12 +239,13 @@ export class FileBackedInstalledPluginsStore extends Disposable {
 				return;
 			}
 
-			const migrated: IStoredInstalledPlugin[] = (revive(parsed) as { pluginUri: UriComponents; plugin?: { marketplaceReference?: { rawValue?: string } } }[]).map(entry => {
+			const migrated: IStoredInstalledPlugin[] = (revive(parsed) as { pluginUri: UriComponents; plugin?: { name?: string; marketplaceReference?: { rawValue?: string } } }[]).map(entry => {
 				const uri = URI.revive(entry.pluginUri);
 				const rebased = this._rebasePluginUri(uri);
 				return {
 					pluginUri: rebased ?? uri,
 					marketplace: entry.plugin?.marketplaceReference?.rawValue ?? '',
+					name: entry.plugin?.name,
 				};
 			}).filter(e => !!e.marketplace);
 

--- a/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
@@ -381,8 +381,8 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 
 		// Hydrate plugin metadata for installed entries that are not yet in
 		// the in-memory cache (e.g. after restart when installed.json is read
-		// but the metadata map is empty). Walks up from each plugin URI to
-		// find the marketplace.json in the enclosing repository directory.
+		// but the metadata map is empty). Modern entries match by plugin name;
+		// older entries without names fall back to matching by install URI.
 		this._register(autorun(reader => {
 			const entries = this._installedPluginsStore.value.read(reader);
 			const unhydrated = entries.filter(e => !this._pluginMetadata.has(e.pluginUri.toString()));
@@ -581,13 +581,18 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 
 	addInstalledPlugin(pluginUri: URI, plugin: IMarketplacePlugin): void {
 		this._pluginMetadata.set(pluginUri.toString(), plugin);
+		const entry: IStoredInstalledPlugin = {
+			pluginUri,
+			marketplace: plugin.marketplaceReference.rawValue,
+			name: plugin.name,
+		};
 		const current = this._installedPluginsStore.get();
 		const existing = current.find(e => isEqual(e.pluginUri, pluginUri));
 		if (existing) {
 			// Still update to trigger watchers to re-check, something might have happened that we want to know about
-			this._installedPluginsStore.set(current.map(c => c === existing ? { pluginUri, marketplace: plugin.marketplaceReference.rawValue } : c), undefined);
+			this._installedPluginsStore.set(current.map(c => c === existing ? entry : c), undefined);
 		} else {
-			this._installedPluginsStore.set([...current, { pluginUri, marketplace: plugin.marketplaceReference.rawValue }], undefined);
+			this._installedPluginsStore.set([...current, entry], undefined);
 		}
 	}
 
@@ -604,10 +609,10 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 	// --- Plugin metadata hydration -----------------------------------------------
 
 	/**
-	 * For each plugin URI that has no cached metadata, walk up the directory
-	 * tree from the plugin towards the agent-plugins root looking for a
-	 * marketplace definition file. When found, read the marketplace plugins
-	 * and match by source path to populate {@link _pluginMetadata}.
+	 * Hydrates installed entries from marketplace metadata. Entries written
+	 * by current builds include the marketplace plugin name, which is enough
+	 * to re-read the full plugin descriptor from the marketplace source. Old
+	 * entries without a name fall back to matching by install URI.
 	 *
 	 * After hydration completes the installed-plugins store is "touched" so
 	 * that the derived {@link installedPlugins} observable re-evaluates with
@@ -629,23 +634,8 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 			}
 
 			try {
-				const repoDir = this._pluginRepositoryService.getRepositoryUri(reference);
-				let plugins = await this._readPluginsFromDirectory(repoDir, reference);
-				if (plugins.length === 0) {
-					// The entry may have come from a single-plugin repo
-					// installed via `installPluginFromSource` (no
-					// marketplace.json). Try the plugin manifest at the
-					// repo root — its synthesised install URI matches what
-					// `addInstalledPlugin` recorded.
-					const single = await this.readSinglePluginManifest(repoDir, reference);
-					if (single) {
-						plugins = [single];
-					}
-				}
-				const match = plugins.find(p => {
-					const installUri = this._pluginRepositoryService.getPluginInstallUri(p);
-					return isEqual(installUri, entry.pluginUri);
-				});
+				const plugins = await this._readPluginsForInstalledEntry(reference, CancellationToken.None);
+				const match = plugins.find(p => entry.name ? p.name === entry.name : isEqual(this._pluginRepositoryService.getPluginInstallUri(p), entry.pluginUri));
 				if (match) {
 					this._pluginMetadata.set(key, match);
 					hydrated++;
@@ -661,6 +651,25 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 			const current = this._installedPluginsStore.get();
 			this._installedPluginsStore.set([...current], undefined);
 		}
+	}
+
+	private async _readPluginsForInstalledEntry(reference: IMarketplaceReference, token: CancellationToken): Promise<IMarketplacePlugin[]> {
+		if (reference.kind === MarketplaceReferenceKind.GitHubShorthand && reference.githubRepo) {
+			return this._fetchFromGitHubRepo(reference, reference.githubRepo, token);
+		}
+
+		const repoDir = this._pluginRepositoryService.getRepositoryUri(reference);
+		let plugins = await this._readPluginsFromDirectory(repoDir, reference, token);
+		if (plugins.length === 0) {
+			// The entry may have come from a single-plugin repo installed
+			// via `installPluginFromSource` (no marketplace.json). Try the
+			// plugin manifest at the repo root.
+			const single = await this.readSinglePluginManifest(repoDir, reference);
+			if (single) {
+				plugins = [single];
+			}
+		}
+		return plugins;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/test/browser/plugins/pluginInstallService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/plugins/pluginInstallService.test.ts
@@ -239,6 +239,9 @@ suite('PluginInstallService', () => {
 
 		instantiationService.stub(IAgentPluginRepositoryService, {
 			getPluginInstallUri: (plugin: IMarketplacePlugin) => {
+				if (plugin.sourceDescriptor.kind !== PluginSourceKind.RelativePath) {
+					return state.pluginSourceInstallUris.get(plugin.sourceDescriptor.kind) ?? URI.file(`/cache/agentPlugins/${plugin.sourceDescriptor.kind}/default`);
+				}
 				return URI.joinPath(state.ensureRepositoryResult, plugin.source);
 			},
 			getRepositoryUri: () => state.ensureRepositoryResult,

--- a/src/vs/workbench/contrib/chat/test/common/plugins/fileBackedInstalledPluginsStore.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/plugins/fileBackedInstalledPluginsStore.test.ts
@@ -133,7 +133,8 @@ suite('FileBackedInstalledPluginsStore', () => {
 		assert.strictEqual(parsed.version, 1);
 		assert.strictEqual(parsed.installed.length, 1);
 		assert.ok(parsed.installed[0].pluginUri.includes('/home/user/.vscode/agent-plugins/github.com/microsoft/plugins/plugins/my-plugin'));
-		// plugin metadata is NOT stored in the file
+		assert.strictEqual(parsed.installed[0].name, 'my-plugin');
+		// Full plugin metadata is NOT stored in the file.
 		assert.strictEqual(parsed.installed[0].plugin, undefined);
 		assert.strictEqual(pluginsStore.get().length, 1);
 

--- a/src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts
@@ -4,22 +4,24 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { timeout } from '../../../../../../base/common/async.js';
+import { VSBuffer } from '../../../../../../base/common/buffer.js';
 import { Event } from '../../../../../../base/common/event.js';
 import { observableValue } from '../../../../../../base/common/observable.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
-import { IFileService } from '../../../../../../platform/files/common/files.js';
+import { IFileService, IFileSystemWatcher } from '../../../../../../platform/files/common/files.js';
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
 import { IRequestService } from '../../../../../../platform/request/common/request.js';
-import { IStorageService, InMemoryStorageService } from '../../../../../../platform/storage/common/storage.js';
+import { IStorageService, InMemoryStorageService, StorageScope, StorageTarget } from '../../../../../../platform/storage/common/storage.js';
 import { IWorkspaceTrustManagementService } from '../../../../../../platform/workspace/common/workspaceTrust.js';
 import { IEnvironmentService } from '../../../../../../platform/environment/common/environment.js';
 import { ChatConfiguration } from '../../../common/constants.js';
 import { IAgentPluginRepositoryService } from '../../../common/plugins/agentPluginRepositoryService.js';
-import { IMarketplacePlugin, MarketplaceReferenceKind, MarketplaceType, PluginMarketplaceService, PluginSourceKind, getPluginSourceLabel, parseMarketplaceReference, parseMarketplaceReferences, parsePluginSource } from '../../../common/plugins/pluginMarketplaceService.js';
+import { IMarketplacePlugin, IMarketplaceReference, IPluginSourceDescriptor, MarketplaceReferenceKind, MarketplaceType, PluginMarketplaceService, PluginSourceKind, getPluginSourceLabel, parseMarketplaceReference, parseMarketplaceReferences, parsePluginSource } from '../../../common/plugins/pluginMarketplaceService.js';
 import { IWorkspacePluginSettingsService } from '../../../common/plugins/workspacePluginSettingsService.js';
 
 suite('PluginMarketplaceService', () => {
@@ -354,6 +356,230 @@ suite('PluginMarketplaceService - installed plugins lifecycle', () => {
 		const remaining = service.installedPlugins.get();
 		assert.strictEqual(remaining.length, 1);
 		assert.strictEqual(remaining[0].plugin.name, 'plugin-b');
+	});
+});
+
+suite('PluginMarketplaceService - hydration after restart', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	const CACHE_ROOT = URI.file('/agent-plugins');
+
+	class TestFileService {
+		readonly files = new Map<string, string>();
+		readonly folders = new Set<string>();
+
+		async exists(resource: URI): Promise<boolean> {
+			const key = resource.toString();
+			return this.files.has(key) || this.folders.has(key);
+		}
+
+		async readFile(resource: URI): Promise<{ value: VSBuffer }> {
+			const key = resource.toString();
+			const value = this.files.get(key);
+			if (value === undefined) {
+				throw new Error(`Missing file: ${key}`);
+			}
+			return { value: VSBuffer.fromString(value) };
+		}
+
+		async writeFile(resource: URI, content: VSBuffer): Promise<unknown> {
+			this.files.set(resource.toString(), content.toString());
+			return {};
+		}
+
+		async createFolder(resource: URI): Promise<unknown> {
+			this.folders.add(resource.toString());
+			return {};
+		}
+
+		createWatcher(): IFileSystemWatcher {
+			return { onDidChange: Event.None, dispose: () => { } };
+		}
+
+		setFile(resource: URI, content: string): void {
+			this.files.set(resource.toString(), content);
+		}
+	}
+
+	function createPluginRepositoryStub(): IAgentPluginRepositoryService {
+		const getRepositoryUri = (marketplace: IMarketplaceReference) => URI.joinPath(CACHE_ROOT, ...marketplace.cacheSegments);
+		const getPluginSourceInstallUri = (descriptor: IPluginSourceDescriptor) => {
+			if (descriptor.kind === PluginSourceKind.GitHub) {
+				const [owner, repo] = descriptor.repo.split('/');
+				const base = URI.joinPath(CACHE_ROOT, 'github.com', owner, repo);
+				return descriptor.path ? URI.joinPath(base, descriptor.path) : base;
+			}
+			if (descriptor.kind === PluginSourceKind.RelativePath) {
+				// Tests using this stub only exercise non-relative descriptors via this entry point.
+				throw new Error('RelativePath should not reach getPluginSourceInstallUri in hydration tests');
+			}
+			throw new Error(`Unhandled source kind in test stub: ${descriptor.kind}`);
+		};
+		return {
+			agentPluginsHome: CACHE_ROOT,
+			getRepositoryUri,
+			getPluginInstallUri: (plugin: IMarketplacePlugin) => {
+				if (plugin.sourceDescriptor.kind !== PluginSourceKind.RelativePath) {
+					return getPluginSourceInstallUri(plugin.sourceDescriptor);
+				}
+				const repoDir = getRepositoryUri(plugin.marketplaceReference);
+				return plugin.source ? URI.joinPath(repoDir, plugin.source) : repoDir;
+			},
+			getPluginSourceInstallUri,
+		} as unknown as IAgentPluginRepositoryService;
+	}
+
+	function makeAzurePlugin(marketplaceReference: IMarketplaceReference): IMarketplacePlugin {
+		return {
+			name: 'azure',
+			description: 'Microsoft Azure MCP Server and skills',
+			version: '1.0.0',
+			source: '',
+			sourceDescriptor: { kind: PluginSourceKind.GitHub, repo: 'microsoft/azure-skills', path: '.github/plugins/azure-skills' },
+			marketplace: marketplaceReference.displayLabel,
+			marketplaceReference,
+			marketplaceType: MarketplaceType.Copilot,
+		};
+	}
+
+	function storeMarketplaceCache(storageService: InMemoryStorageService, marketplaceReference: IMarketplaceReference, plugin: IMarketplacePlugin): void {
+		storageService.store('chat.plugins.marketplaces.githubCache.v1', JSON.stringify({
+			[marketplaceReference.canonicalId]: {
+				plugins: [plugin],
+				expiresAt: Date.now() + 60_000,
+				referenceRawValue: marketplaceReference.rawValue,
+			},
+		}), StorageScope.APPLICATION, StorageTarget.MACHINE);
+	}
+
+	test('hydrates a github-sourced plugin from installed.json name and marketplace cache after restart', async () => {
+		// Simulates: user installs the "azure" plugin from the
+		// "github/awesome-copilot" marketplace (fetched via HTTP, never
+		// cloned). After restart, installed.json contains only the durable
+		// identity for that plugin; the full descriptor is recovered from
+		// marketplace data cached from the prior fetch.
+
+		const storageService = store.add(new InMemoryStorageService());
+		const fileService = new TestFileService();
+
+		const awesomeCopilot = parseMarketplaceReference('github/awesome-copilot')!;
+		const azurePlugin = makeAzurePlugin(awesomeCopilot);
+		storeMarketplaceCache(storageService, awesomeCopilot, azurePlugin);
+		const azurePluginUri = URI.joinPath(CACHE_ROOT, 'github.com', 'microsoft', 'azure-skills', '.github', 'plugins', 'azure-skills');
+
+		const installedJson = URI.joinPath(CACHE_ROOT, 'installed.json');
+		fileService.setFile(installedJson, JSON.stringify({
+			version: 1,
+			installed: [{
+				pluginUri: azurePluginUri.toString(),
+				marketplace: awesomeCopilot.rawValue,
+				name: 'azure',
+			}],
+		}));
+
+		const instantiationService = store.add(new TestInstantiationService());
+		instantiationService.stub(IConfigurationService, new TestConfigurationService({
+			[ChatConfiguration.PluginMarketplaces]: ['github/awesome-copilot'],
+			[ChatConfiguration.PluginsEnabled]: true,
+		}));
+		instantiationService.stub(IEnvironmentService, { cacheHome: URI.file('/cache') } as Partial<IEnvironmentService> as IEnvironmentService);
+		instantiationService.stub(IFileService, fileService as unknown as IFileService);
+		instantiationService.stub(IAgentPluginRepositoryService, createPluginRepositoryStub());
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(IRequestService, {} as unknown as IRequestService);
+		instantiationService.stub(IStorageService, storageService);
+		instantiationService.stub(IWorkspacePluginSettingsService, {
+			extraMarketplaces: observableValue('test.extraMarketplaces', []),
+			enabledPlugins: observableValue('test.enabledPlugins', new Map()),
+		} as Partial<IWorkspacePluginSettingsService> as IWorkspacePluginSettingsService);
+		instantiationService.stub(IWorkspaceTrustManagementService, {
+			isWorkspaceTrusted: () => true,
+			onDidChangeTrust: Event.None,
+		} as Partial<IWorkspaceTrustManagementService> as IWorkspaceTrustManagementService);
+
+		const service = store.add(instantiationService.createInstance(PluginMarketplaceService));
+
+		// FileBackedInstalledPluginsStore initialises asynchronously.
+		for (let i = 0; i < 50; i++) {
+			if (service.installedPlugins.get().length === 1) {
+				break;
+			}
+			await timeout(10);
+		}
+
+		const installed = service.installedPlugins.get();
+		assert.strictEqual(installed.length, 1, 'azure plugin should be hydrated from marketplace data');
+		assert.strictEqual(installed[0].plugin.name, 'azure');
+		assert.strictEqual(installed[0].plugin.sourceDescriptor.kind, PluginSourceKind.GitHub);
+		assert.strictEqual(installed[0].plugin.marketplaceReference.canonicalId, awesomeCopilot.canonicalId);
+	});
+
+	test('persists plugin name when a plugin is added so it survives a restart', async () => {
+		// First service writes installed.json, second service (sharing the
+		// same file system + storage) reads it back and must reconstruct
+		// the plugin from its stored name plus marketplace data.
+		const storageService = store.add(new InMemoryStorageService());
+		const fileService = new TestFileService();
+
+		const awesomeCopilot = parseMarketplaceReference('github/awesome-copilot')!;
+		const azurePluginUri = URI.joinPath(CACHE_ROOT, 'github.com', 'microsoft', 'azure-skills', '.github', 'plugins', 'azure-skills');
+		const azurePlugin = makeAzurePlugin(awesomeCopilot);
+		storeMarketplaceCache(storageService, awesomeCopilot, azurePlugin);
+
+		function makeService(): PluginMarketplaceService {
+			const instantiationService = store.add(new TestInstantiationService());
+			instantiationService.stub(IConfigurationService, new TestConfigurationService({
+				[ChatConfiguration.PluginMarketplaces]: ['github/awesome-copilot'],
+				[ChatConfiguration.PluginsEnabled]: true,
+			}));
+			instantiationService.stub(IEnvironmentService, { cacheHome: URI.file('/cache') } as Partial<IEnvironmentService> as IEnvironmentService);
+			instantiationService.stub(IFileService, fileService as unknown as IFileService);
+			instantiationService.stub(IAgentPluginRepositoryService, createPluginRepositoryStub());
+			instantiationService.stub(ILogService, new NullLogService());
+			instantiationService.stub(IRequestService, {} as unknown as IRequestService);
+			instantiationService.stub(IStorageService, storageService);
+			instantiationService.stub(IWorkspacePluginSettingsService, {
+				extraMarketplaces: observableValue('test.extraMarketplaces', []),
+				enabledPlugins: observableValue('test.enabledPlugins', new Map()),
+			} as Partial<IWorkspacePluginSettingsService> as IWorkspacePluginSettingsService);
+			instantiationService.stub(IWorkspaceTrustManagementService, {
+				isWorkspaceTrusted: () => true,
+				onDidChangeTrust: Event.None,
+			} as Partial<IWorkspaceTrustManagementService> as IWorkspaceTrustManagementService);
+			return store.add(instantiationService.createInstance(PluginMarketplaceService));
+		}
+
+		// First session: install the plugin.
+		const first = makeService();
+		// Wait for FileBackedInstalledPluginsStore to finish initialisation
+		// so that subsequent writes are flushed to the file service.
+		await timeout(20);
+		first.addInstalledPlugin(azurePluginUri, azurePlugin);
+		// Wait for the throttled write to land.
+		await timeout(200);
+
+		const installedJson = URI.joinPath(CACHE_ROOT, 'installed.json');
+		const persisted = JSON.parse(fileService.files.get(installedJson.toString())!);
+		assert.strictEqual(persisted.installed.length, 1);
+		assert.deepStrictEqual(persisted.installed[0], {
+			pluginUri: azurePluginUri.toString(),
+			marketplace: awesomeCopilot.rawValue,
+			name: 'azure',
+		});
+
+		// Second session: restart with shared storage + file system. The
+		// plugin must be reconstructed from installed.json + marketplace data.
+		const second = makeService();
+		for (let i = 0; i < 50; i++) {
+			if (second.installedPlugins.get().length === 1) {
+				break;
+			}
+			await timeout(10);
+		}
+		const installed = second.installedPlugins.get();
+		assert.strictEqual(installed.length, 1);
+		assert.strictEqual(installed[0].plugin.name, 'azure');
+		assert.strictEqual(installed[0].plugin.sourceDescriptor.kind, PluginSourceKind.GitHub);
 	});
 });
 


### PR DESCRIPTION
chat: persist installed plugin identity

Persists enough installed plugin identity for marketplace plugins to survive reloads while keeping installed.json easy for external tools to read.

- Stores plugin name alongside plugin URI and marketplace in installed.json, avoiding full source descriptor persistence.
- Hydrates installed plugin metadata by re-reading marketplace data and matching current entries by stored name.
- Falls back to install URI matching for older entries without names and keeps package/git install URI handling consistent.
- Adds focused coverage for GitHub-sourced marketplace plugins like azure from awesome-copilot.

(Commit message generated by Copilot)