### PR TITLE
Fix sudo -S sensitive input detection

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -596,7 +596,7 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 	}
 
 	private _isSensitivePrompt(prompt: string): boolean {
-		if (isNonInteractiveSudoSensitivePrompt(this._command, prompt)) {
+		if (isCanonicalSudoSPrompt(this._command, prompt)) {
 			return false;
 		}
 
@@ -604,7 +604,7 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 	}
 }
 
-function isNonInteractiveSudoSensitivePrompt(command: string, prompt: string): boolean {
+function isCanonicalSudoSPrompt(command: string, prompt: string): boolean {
 	return /(?:^|\s)sudo\s+-S(?:\s|$)/.test(command) && /^\[sudo\]\s+password for .+:\s*$/i.test(prompt);
 }
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -415,7 +415,7 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 		// In async mode, signal the agent so it can drive send_to_terminal.
 		if (this._asyncMode) {
 			if (shouldFireInputNeeded) {
-				if (detectsSensitiveInputPrompt(outputLastLine)) {
+				if (this._isSensitivePrompt(outputLastLine)) {
 					this._logService.trace('OutputMonitor: Async mode - sensitive input prompt detected, signaling sensitive UI');
 					this._onDidDetectSensitiveInputNeeded.fire();
 				} else {
@@ -433,7 +433,7 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 		// event so the tool can show a confirmation dialog that focuses the terminal —
 		// the secret must never be routed through the model.
 		if (shouldFireInputNeeded) {
-			if (detectsSensitiveInputPrompt(outputLastLine)) {
+			if (this._isSensitivePrompt(outputLastLine)) {
 				this._logService.trace('OutputMonitor: Sensitive input prompt detected, signaling sensitive UI');
 				this._onDidDetectSensitiveInputNeeded.fire();
 			} else {
@@ -596,8 +596,16 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 	}
 
 	private _isSensitivePrompt(prompt: string): boolean {
+		if (isNonInteractiveSudoSensitivePrompt(this._command, prompt)) {
+			return false;
+		}
+
 		return detectsSensitiveInputPrompt(prompt);
 	}
+}
+
+function isNonInteractiveSudoSensitivePrompt(command: string, prompt: string): boolean {
+	return /(?:^|\s)sudo\s+-S(?:\s|$)/.test(command) && /^\[sudo\]\s+password for .+:\s*$/i.test(prompt);
 }
 
 /**

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/outputMonitor.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/outputMonitor.test.ts
@@ -400,6 +400,40 @@ suite('OutputMonitor', () => {
 		});
 	});
 
+	test('sudo -S password prompt fires onDidDetectInputNeeded and not onDidDetectSensitiveInputNeeded', async () => {
+		return runWithFakedTimers({}, async () => {
+			execution.getOutput = () => '[sudo] password for jdoe: ';
+			monitor = store.add(instantiationService.createInstance(OutputMonitor, execution, undefined, createTestContext('1'), cts.token, 'ssh host && echo hunter2 | sudo -S systemctl restart myservice'));
+
+			let inputNeededFired = false;
+			let sensitiveFired = false;
+			store.add(monitor.onDidDetectInputNeeded(() => { inputNeededFired = true; }));
+			store.add(monitor.onDidDetectSensitiveInputNeeded(() => { sensitiveFired = true; }));
+
+			await Event.toPromise(monitor.onDidFinishCommand);
+
+			assert.strictEqual(inputNeededFired, true, 'sudo -S prompts should be treated as normal input-needed so the non-interactive flow can continue');
+			assert.strictEqual(sensitiveFired, false, 'sudo -S prompts should not be treated as sensitive interactive prompts');
+		});
+	});
+
+	test('plain sudo password prompt still fires onDidDetectSensitiveInputNeeded', async () => {
+		return runWithFakedTimers({}, async () => {
+			execution.getOutput = () => '[sudo] password for jdoe: ';
+			monitor = store.add(instantiationService.createInstance(OutputMonitor, execution, undefined, createTestContext('1'), cts.token, 'sudo systemctl restart myservice'));
+
+			let inputNeededFired = false;
+			let sensitiveFired = false;
+			store.add(monitor.onDidDetectInputNeeded(() => { inputNeededFired = true; }));
+			store.add(monitor.onDidDetectSensitiveInputNeeded(() => { sensitiveFired = true; }));
+
+			await Event.toPromise(monitor.onDidFinishCommand);
+
+			assert.strictEqual(sensitiveFired, true, 'interactive sudo prompts should still be treated as sensitive');
+			assert.strictEqual(inputNeededFired, false, 'interactive sudo prompts must not be routed to the agent');
+		});
+	});
+
 	test('detectsSensitiveInputPrompt matches common secret prompts', () => {
 		assert.strictEqual(detectsSensitiveInputPrompt('Password: '), true);
 		assert.strictEqual(detectsSensitiveInputPrompt('[sudo] password for jdoe: '), true);


### PR DESCRIPTION
Fixes #317490

## Summary

When `run_in_terminal` sees a sudo password prompt, it currently always classifies it as sensitive interactive input and triggers the sensitive-input flow. That is correct for plain `sudo`, but it is wrong for `sudo -S`, where the password is expected on `stdin` and the `[sudo] password for ...:` line is just status output.

This change keeps the existing sensitive-input behavior for interactive prompts, but treats the canonical sudo prompt as non-sensitive when the command includes `sudo -S`, so the terminal stays on the normal input-needed path instead of being auto-cancelled in auto-approve mode.

## Changes

- route sensitive prompt checks through `OutputMonitor._isSensitivePrompt(...)`
- add a narrow exception for `sudo -S` with the canonical `[sudo] password for ...:` prompt
- add focused tests covering both `sudo -S` and plain `sudo`

