### PR TITLE
sessions: fix worktree-created task dispatch

### DIFF
--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -101,6 +101,8 @@ Each session operates on an **`ISessionWorkspace`** containing one or more **`IS
 
 Workspaces carry a `group` label (e.g., `"Local"`, `"Remote"`) used by the workspace picker to organize entries into tabs via the `SESSION_WORKSPACE_GROUP_LOCAL` / `SESSION_WORKSPACE_GROUP_REMOTE` constants.
 
+Tasks with `runOptions.runOn === "worktreeCreated"` are dispatched client-side only for newly created sessions, after the session reports a concrete `gitRepository.workTreeUri`. Restored sessions, untitled placeholders, and runtimes that declare `capabilities.runsWorktreeCreatedTasks` are skipped so setup tasks are not re-run on window open or double-run with server-side provisioning.
+
 ### Session Types
 
 An **`ISessionType`** identifies an agent backend (e.g., `'copilot-cli'`, `'copilot-cloud'`). Each provider declares which session types it supports and can dynamically update the list via `onDidChangeSessionTypes`. The management service exposes `getAllSessionTypes()` for UI pickers.
@@ -168,4 +170,3 @@ Providers may fire `onDidReplaceSession` when a temporary (untitled) session is 
 5. Use `toSessionId(providerId, resource)` for session IDs
 6. Fire `onDidChangeSessions` on every session change and `onDidReplaceSession` on untitled→committed transitions
 7. Set `supportsLocalWorkspaces: true` if the provider can resolve local file-system workspaces
-

--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -101,7 +101,7 @@ Each session operates on an **`ISessionWorkspace`** containing one or more **`IS
 
 Workspaces carry a `group` label (e.g., `"Local"`, `"Remote"`) used by the workspace picker to organize entries into tabs via the `SESSION_WORKSPACE_GROUP_LOCAL` / `SESSION_WORKSPACE_GROUP_REMOTE` constants.
 
-Tasks with `runOptions.runOn === "worktreeCreated"` are dispatched client-side only for newly created sessions, after the session reports a concrete `gitRepository.workTreeUri`. Restored sessions, untitled placeholders, and runtimes that declare `capabilities.runsWorktreeCreatedTasks` are skipped so setup tasks are not re-run on window open or double-run with server-side provisioning.
+Tasks with `runOptions.runOn === "worktreeCreated"` are dispatched client-side only for newly created sessions, after the session reports a concrete `gitRepository.workTreeUri`. Restored sessions and runtimes that declare `capabilities.runsWorktreeCreatedTasks` are skipped so setup tasks are not re-run on window open or double-run with server-side provisioning; untitled placeholders are deferred until they become committed worktree sessions.
 
 ### Session Types
 

--- a/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
@@ -40,6 +40,7 @@ import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextke
 import { AccessibleViewRegistry } from '../../../../platform/accessibility/browser/accessibleViewRegistry.js';
 import { SessionsChatAccessibilityHelp } from './sessionsChatAccessibilityHelp.js';
 import { SessionsOpenerParticipantContribution } from './sessionsOpenerParticipant.js';
+import { WorktreeCreatedTaskDispatcher } from './worktreeCreatedTaskDispatcher.js';
 import '../../sessions/browser/mobile/mobileOverlayContribution.js';
 
 
@@ -149,8 +150,7 @@ registerWorkbenchContribution2(RegisterChatViewContainerContribution.ID, Registe
 registerWorkbenchContribution2(RunScriptContribution.ID, RunScriptContribution, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(SessionsOpenerParticipantContribution.ID, SessionsOpenerParticipantContribution, WorkbenchPhase.BlockStartup);
 registerWorkbenchContribution2(RegisterDefaultSessionTaskRunnersContribution.ID, RegisterDefaultSessionTaskRunnersContribution, WorkbenchPhase.BlockStartup);
-// todo@connor4312: temp until bugfix:
-// registerWorkbenchContribution2(WorktreeCreatedTaskDispatcher.ID, WorktreeCreatedTaskDispatcher, WorkbenchPhase.AfterRestored);
+registerWorkbenchContribution2(WorktreeCreatedTaskDispatcher.ID, WorktreeCreatedTaskDispatcher, WorkbenchPhase.AfterRestored);
 
 // register services
 registerSingleton(IPromptsService, AgenticPromptsService, InstantiationType.Delayed);

--- a/src/vs/sessions/contrib/chat/browser/worktreeCreatedTaskDispatcher.ts
+++ b/src/vs/sessions/contrib/chat/browser/worktreeCreatedTaskDispatcher.ts
@@ -7,7 +7,7 @@ import { Disposable, DisposableMap, DisposableStore } from '../../../../base/com
 import { autorun } from '../../../../base/common/observable.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IWorkbenchContribution } from '../../../../workbench/common/contributions.js';
-import { ISession } from '../../../services/sessions/common/session.js';
+import { ISession, SessionStatus } from '../../../services/sessions/common/session.js';
 import { ISessionsChangeEvent, ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsTasksService } from './sessionsTasksService.js';
 
@@ -15,19 +15,15 @@ const LOG_PREFIX = '[WorktreeCreatedTaskDispatcher]';
 
 /**
  * Workbench contribution that runs all tasks tagged with
- * `runOptions.runOn === 'worktreeCreated'` once per session, when the session
- * first appears and finishes loading.
+ * `runOptions.runOn === 'worktreeCreated'` once per newly-created session,
+ * when the session first reports an actual git worktree.
  *
  * Sessions whose runtime already runs these tasks server-side (signalled via
  * {@link ISessionCapabilities.runsWorktreeCreatedTasks}) are skipped to avoid
  * double-execution.
  *
- * We deliberately don't persist any "already ran" marker across reloads:
- * worktree creation itself is a one-shot event, setup tasks are conventionally
- * idempotent (`npm install`, `pip install -r ...`), and the cost of running
- * them again on the rare case where the agents window reloads while the same
- * session is still attached is much smaller than the leak / state-management
- * cost of tracking them indefinitely.
+ * We deliberately ignore sessions that predate this contribution so restored
+ * sessions don't re-run setup tasks when the agents window opens.
  */
 export class WorktreeCreatedTaskDispatcher extends Disposable implements IWorkbenchContribution {
 
@@ -36,6 +32,7 @@ export class WorktreeCreatedTaskDispatcher extends Disposable implements IWorkbe
 	// Track per-session disposables (one per in-flight session subscription) so
 	// we tear them down when the session is removed.
 	private readonly _sessionDisposables = this._register(new DisposableMap<string>());
+	private readonly _startedAt = Date.now();
 
 	constructor(
 		@ISessionsManagementService private readonly _sessionsManagementService: ISessionsManagementService,
@@ -44,26 +41,36 @@ export class WorktreeCreatedTaskDispatcher extends Disposable implements IWorkbe
 	) {
 		super();
 
-		// Bootstrap: handle sessions that are already known when we start up.
 		for (const session of this._sessionsManagementService.getSessions()) {
-			this._trackSession(session);
+			if (session.status.get() === SessionStatus.Untitled) {
+				this._trackSession(session, true);
+			}
 		}
 
 		this._register(this._sessionsManagementService.onDidChangeSessions(e => this._onDidChangeSessions(e)));
 	}
 
 	private _onDidChangeSessions(e: ISessionsChangeEvent): void {
-		for (const session of e.added) {
-			this._trackSession(session);
-		}
 		for (const session of e.removed) {
 			this._sessionDisposables.deleteAndDispose(session.sessionId);
 		}
+		for (const session of e.added) {
+			this._trackSession(session);
+		}
+		for (const session of e.changed) {
+			this._trackSession(session);
+		}
 	}
 
-	private _trackSession(session: ISession): void {
+	private _trackSession(session: ISession, allowPredatedSession = false): void {
 		if (session.capabilities.runsWorktreeCreatedTasks) {
 			// The session's runtime already runs these tasks itself.
+			return;
+		}
+		if (!allowPredatedSession && session.createdAt.getTime() < this._startedAt) {
+			// Restored sessions can be reported as "added" while providers
+			// hydrate on window open. Only sessions created after this dispatcher
+			// starts are eligible for the one-shot worktree-created hook.
 			return;
 		}
 		if (this._sessionDisposables.get(session.sessionId)) {
@@ -73,12 +80,19 @@ export class WorktreeCreatedTaskDispatcher extends Disposable implements IWorkbe
 		const store = new DisposableStore();
 		this._sessionDisposables.set(session.sessionId, store);
 
-		// Wait for the session to finish loading, then dispatch any pending
-		// worktreeCreated tasks once. Set `dispatched` synchronously before
-		// the await so any re-firing of the autorun observes it and bails.
+		// Wait for the session to finish loading and report an actual worktree,
+		// then dispatch any pending worktreeCreated tasks once. Set
+		// `dispatched` synchronously before the await so any re-firing of the
+		// autorun observes it and bails.
 		let dispatched = false;
 		store.add(autorun(reader => {
 			if (session.loading.read(reader) || dispatched) {
+				return;
+			}
+			if (session.status.read(reader) === SessionStatus.Untitled) {
+				return;
+			}
+			if (!session.workspace.read(reader)?.folders.some(folder => !!folder.gitRepository?.workTreeUri)) {
 				return;
 			}
 			dispatched = true;

--- a/src/vs/sessions/contrib/chat/browser/worktreeCreatedTaskDispatcher.ts
+++ b/src/vs/sessions/contrib/chat/browser/worktreeCreatedTaskDispatcher.ts
@@ -32,7 +32,7 @@ export class WorktreeCreatedTaskDispatcher extends Disposable implements IWorkbe
 	// Track per-session disposables (one per in-flight session subscription) so
 	// we tear them down when the session is removed.
 	private readonly _sessionDisposables = this._register(new DisposableMap<string>());
-	private readonly _startedAt = Date.now();
+	private readonly _dispatchedSessions = new Set<string>();
 
 	constructor(
 		@ISessionsManagementService private readonly _sessionsManagementService: ISessionsManagementService,
@@ -42,38 +42,41 @@ export class WorktreeCreatedTaskDispatcher extends Disposable implements IWorkbe
 		super();
 
 		for (const session of this._sessionsManagementService.getSessions()) {
-			if (session.status.get() === SessionStatus.Untitled) {
-				this._trackSession(session, true);
-			}
+			this._trackSession(session);
 		}
 
 		this._register(this._sessionsManagementService.onDidChangeSessions(e => this._onDidChangeSessions(e)));
 	}
 
 	private _onDidChangeSessions(e: ISessionsChangeEvent): void {
+		const removedTrackedSessions: ISession[] = [];
 		for (const session of e.removed) {
+			if (this._sessionDisposables.get(session.sessionId) && !this._dispatchedSessions.has(session.sessionId)) {
+				removedTrackedSessions.push(session);
+			}
 			this._sessionDisposables.deleteAndDispose(session.sessionId);
+			this._dispatchedSessions.delete(session.sessionId);
 		}
 		for (const session of e.added) {
 			this._trackSession(session);
 		}
+		const replacement = e.added.length === 0 && e.changed.length === 1 && removedTrackedSessions.length === 1
+			? removedTrackedSessions[0]
+			: undefined;
 		for (const session of e.changed) {
-			this._trackSession(session);
+			this._trackSession(session, replacement?.providerId === session.providerId && replacement.sessionType === session.sessionType);
 		}
 	}
 
-	private _trackSession(session: ISession, allowPredatedSession = false): void {
+	private _trackSession(session: ISession, allowReadySession = false): void {
 		if (session.capabilities.runsWorktreeCreatedTasks) {
 			// The session's runtime already runs these tasks itself.
 			return;
 		}
-		if (!allowPredatedSession && session.createdAt.getTime() < this._startedAt) {
-			// Restored sessions can be reported as "added" while providers
-			// hydrate on window open. Only sessions created after this dispatcher
-			// starts are eligible for the one-shot worktree-created hook.
+		if (this._sessionDisposables.get(session.sessionId)) {
 			return;
 		}
-		if (this._sessionDisposables.get(session.sessionId)) {
+		if (!allowReadySession && !this._isPendingWorktreeSession(session)) {
 			return;
 		}
 
@@ -96,8 +99,17 @@ export class WorktreeCreatedTaskDispatcher extends Disposable implements IWorkbe
 				return;
 			}
 			dispatched = true;
+			this._dispatchedSessions.add(session.sessionId);
 			void this._dispatchWorktreeCreatedTasks(session);
 		}));
+	}
+
+	private _isPendingWorktreeSession(session: ISession): boolean {
+		return session.status.get() === SessionStatus.Untitled || session.loading.get() || !this._hasWorktree(session);
+	}
+
+	private _hasWorktree(session: ISession): boolean {
+		return session.workspace.get()?.folders.some(folder => !!folder.gitRepository?.workTreeUri) ?? false;
 	}
 
 	private async _dispatchWorktreeCreatedTasks(session: ISession): Promise<void> {

--- a/src/vs/sessions/contrib/chat/test/browser/worktreeCreatedTaskDispatcher.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/worktreeCreatedTaskDispatcher.test.ts
@@ -43,7 +43,7 @@ function makeWorkspace(hasWorktree: boolean): ISessionWorkspace {
 	};
 }
 
-function makeSession(opts: { id?: string; runsWorktreeCreatedTasks?: boolean; loading?: boolean; status?: SessionStatus; hasWorktree?: boolean; createdAt?: Date } = {}): ITestSession {
+function makeSession(opts: { id?: string; runsWorktreeCreatedTasks?: boolean; loading?: boolean; status?: SessionStatus; hasWorktree?: boolean } = {}): ITestSession {
 	const loading = observableValue('loading', opts.loading ?? false);
 	const status = observableValue('status', opts.status ?? SessionStatus.InProgress);
 	const workspace = observableValue<ISessionWorkspace | undefined>('workspace', makeWorkspace(opts.hasWorktree ?? true));
@@ -54,7 +54,7 @@ function makeSession(opts: { id?: string; runsWorktreeCreatedTasks?: boolean; lo
 		providerId: 'test',
 		sessionType: 'background',
 		icon: Codicon.copilot,
-		createdAt: opts.createdAt ?? new Date(),
+		createdAt: new Date(),
 		workspace,
 		title: observableValue('title', 'session'),
 		updatedAt: observableValue('updatedAt', new Date()),
@@ -147,12 +147,14 @@ suite('WorktreeCreatedTaskDispatcher', () => {
 
 	test('runs worktreeCreated tasks once for a newly added session', async () => {
 		createDispatcher();
-		const { session } = makeSession({ id: 'a' });
+		const { session, workspace } = makeSession({ id: 'a', hasWorktree: false });
 		tasks.setTasks(session.sessionId, [
 			entry('setup', 'worktreeCreated'),
 			entry('lint'),
 		]);
 		mgmt.emitter.fire({ added: [session], removed: [], changed: [] });
+		await settle();
+		workspace.set(makeWorkspace(true), undefined);
 		await settle();
 
 		assert.deepStrictEqual(tasks.ranTasks, [{ label: 'setup', sessionId: 'a' }]);
@@ -161,12 +163,13 @@ suite('WorktreeCreatedTaskDispatcher', () => {
 	test('runTask failures are logged but do not abort the loop', async () => {
 		createDispatcher();
 		tasks.runTaskFails = true;
-		const { session } = makeSession({ id: 'a' });
+		const { session, workspace } = makeSession({ id: 'a', hasWorktree: false });
 		tasks.setTasks(session.sessionId, [
 			entry('setup-a', 'worktreeCreated'),
 			entry('setup-b', 'worktreeCreated'),
 		]);
 		mgmt.emitter.fire({ added: [session], removed: [], changed: [] });
+		workspace.set(makeWorkspace(true), undefined);
 		await settle();
 
 		// Both tasks are attempted even though each throws.
@@ -196,11 +199,13 @@ suite('WorktreeCreatedTaskDispatcher', () => {
 
 	test('per-session task lists do not cross-contaminate', async () => {
 		createDispatcher();
-		const { session: sessionA } = makeSession({ id: 'a' });
-		const { session: sessionB } = makeSession({ id: 'b' });
+		const { session: sessionA, workspace: workspaceA } = makeSession({ id: 'a', hasWorktree: false });
+		const { session: sessionB, workspace: workspaceB } = makeSession({ id: 'b', hasWorktree: false });
 		tasks.setTasks(sessionA.sessionId, [entry('setup-a', 'worktreeCreated')]);
 		tasks.setTasks(sessionB.sessionId, [entry('setup-b', 'worktreeCreated')]);
 		mgmt.emitter.fire({ added: [sessionA, sessionB], removed: [], changed: [] });
+		workspaceA.set(makeWorkspace(true), undefined);
+		workspaceB.set(makeWorkspace(true), undefined);
 		await settle();
 
 		// Each task fires against its own session.
@@ -265,8 +270,7 @@ suite('WorktreeCreatedTaskDispatcher', () => {
 		const { session, status, workspace } = makeSession({
 			id: 'a',
 			status: SessionStatus.Untitled,
-			hasWorktree: false,
-			createdAt: new Date(Date.now() - 1_000)
+			hasWorktree: false
 		});
 		tasks.setTasks(session.sessionId, [entry('setup', 'worktreeCreated')]);
 		mgmt.sessions = [session];
@@ -283,12 +287,58 @@ suite('WorktreeCreatedTaskDispatcher', () => {
 
 	test('does not run for restored sessions reported as added after startup', async () => {
 		createDispatcher();
-		const { session } = makeSession({ id: 'a', createdAt: new Date(Date.now() - 1_000) });
+		const { session } = makeSession({ id: 'a' });
 		tasks.setTasks(session.sessionId, [entry('setup', 'worktreeCreated')]);
 		mgmt.emitter.fire({ added: [session], removed: [], changed: [] });
 		await settle();
 
 		assert.deepStrictEqual(tasks.ranTasks, []);
+	});
+
+	test('runs for committed replacement of tracked pending session', async () => {
+		createDispatcher();
+		const { session: pending } = makeSession({ id: 'pending', hasWorktree: false });
+		const { session: committed } = makeSession({ id: 'committed', hasWorktree: true });
+		tasks.setTasks(committed.sessionId, [entry('setup', 'worktreeCreated')]);
+
+		mgmt.emitter.fire({ added: [pending], removed: [], changed: [] });
+		await settle();
+		mgmt.emitter.fire({ added: [], removed: [pending], changed: [committed] });
+		await settle();
+
+		assert.deepStrictEqual(tasks.ranTasks, [{ label: 'setup', sessionId: 'committed' }]);
+	});
+
+	test('does not treat mixed changed sessions as pending replacements', async () => {
+		createDispatcher();
+		const { session: pending } = makeSession({ id: 'pending', hasWorktree: false });
+		const { session: committed } = makeSession({ id: 'committed', hasWorktree: true });
+		const { session: restored } = makeSession({ id: 'restored', hasWorktree: true });
+		tasks.setTasks(committed.sessionId, [entry('setup-committed', 'worktreeCreated')]);
+		tasks.setTasks(restored.sessionId, [entry('setup-restored', 'worktreeCreated')]);
+
+		mgmt.emitter.fire({ added: [pending], removed: [], changed: [] });
+		await settle();
+		mgmt.emitter.fire({ added: [], removed: [pending], changed: [committed, restored] });
+		await settle();
+
+		assert.deepStrictEqual(tasks.ranTasks, []);
+	});
+
+	test('does not treat dispatched sessions as pending replacements', async () => {
+		createDispatcher();
+		const { session: dispatched, workspace } = makeSession({ id: 'dispatched', hasWorktree: false });
+		const { session: changed } = makeSession({ id: 'changed', hasWorktree: true });
+		tasks.setTasks(dispatched.sessionId, [entry('setup-dispatched', 'worktreeCreated')]);
+		tasks.setTasks(changed.sessionId, [entry('setup-changed', 'worktreeCreated')]);
+
+		mgmt.emitter.fire({ added: [dispatched], removed: [], changed: [] });
+		workspace.set(makeWorkspace(true), undefined);
+		await settle();
+		mgmt.emitter.fire({ added: [], removed: [dispatched], changed: [changed] });
+		await settle();
+
+		assert.deepStrictEqual(tasks.ranTasks, [{ label: 'setup-dispatched', sessionId: 'dispatched' }]);
 	});
 
 	test('waits for a worktree before running', async () => {

--- a/src/vs/sessions/contrib/chat/test/browser/worktreeCreatedTaskDispatcher.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/worktreeCreatedTaskDispatcher.test.ts
@@ -20,10 +20,33 @@ import { WorktreeCreatedTaskDispatcher } from '../../browser/worktreeCreatedTask
 interface ITestSession {
 	readonly session: ISession;
 	readonly loading: ReturnType<typeof observableValue<boolean>>;
+	readonly status: ReturnType<typeof observableValue<SessionStatus>>;
+	readonly workspace: ReturnType<typeof observableValue<ISessionWorkspace | undefined>>;
 }
 
-function makeSession(opts: { id?: string; runsWorktreeCreatedTasks?: boolean; loading?: boolean } = {}): ITestSession {
+function makeWorkspace(hasWorktree: boolean): ISessionWorkspace {
+	const root = URI.parse('file:///repo');
+	const workTreeUri = hasWorktree ? URI.parse('file:///repo-worktree') : undefined;
+	return {
+		uri: root,
+		label: 'repo',
+		icon: Codicon.folder,
+		folders: [{
+			root,
+			workingDirectory: workTreeUri ?? root,
+			name: 'repo',
+			description: undefined,
+			gitRepository: { uri: root, workTreeUri, baseBranchName: undefined, gitHubInfo: constObservable(undefined) },
+		}],
+		requiresWorkspaceTrust: true,
+		isVirtualWorkspace: false,
+	};
+}
+
+function makeSession(opts: { id?: string; runsWorktreeCreatedTasks?: boolean; loading?: boolean; status?: SessionStatus; hasWorktree?: boolean; createdAt?: Date } = {}): ITestSession {
 	const loading = observableValue('loading', opts.loading ?? false);
+	const status = observableValue('status', opts.status ?? SessionStatus.InProgress);
+	const workspace = observableValue<ISessionWorkspace | undefined>('workspace', makeWorkspace(opts.hasWorktree ?? true));
 	const chat = { resource: URI.parse('file:///session') } as IChat;
 	const session: ISession = {
 		sessionId: opts.id ?? 'test:session',
@@ -31,11 +54,11 @@ function makeSession(opts: { id?: string; runsWorktreeCreatedTasks?: boolean; lo
 		providerId: 'test',
 		sessionType: 'background',
 		icon: Codicon.copilot,
-		createdAt: new Date(),
-		workspace: constObservable(undefined as ISessionWorkspace | undefined),
+		createdAt: opts.createdAt ?? new Date(),
+		workspace,
 		title: observableValue('title', 'session'),
 		updatedAt: observableValue('updatedAt', new Date()),
-		status: observableValue('status', SessionStatus.Untitled),
+		status,
 		changesets: constObservable([]),
 		changes: constObservable([]),
 		modelId: observableValue('modelId', undefined),
@@ -49,7 +72,7 @@ function makeSession(opts: { id?: string; runsWorktreeCreatedTasks?: boolean; lo
 		mainChat: chat,
 		capabilities: { supportsMultipleChats: false, runsWorktreeCreatedTasks: opts.runsWorktreeCreatedTasks },
 	};
-	return { session, loading };
+	return { session, loading, status, workspace };
 }
 
 function entry(label: string, runOn?: 'worktreeCreated' | 'folderOpen' | 'default'): ISessionTaskWithTarget {
@@ -227,7 +250,7 @@ suite('WorktreeCreatedTaskDispatcher', () => {
 		assert.deepStrictEqual(tasks.ranTasks, []);
 	});
 
-	test('handles sessions present at startup', async () => {
+	test('does not run for sessions present at startup', async () => {
 		const { session } = makeSession({ id: 'a' });
 		tasks.setTasks(session.sessionId, [entry('setup', 'worktreeCreated')]);
 		mgmt.sessions = [session];
@@ -235,6 +258,62 @@ suite('WorktreeCreatedTaskDispatcher', () => {
 		createDispatcher();
 		await settle();
 
+		assert.deepStrictEqual(tasks.ranTasks, []);
+	});
+
+	test('tracks pending untitled sessions present at startup', async () => {
+		const { session, status, workspace } = makeSession({
+			id: 'a',
+			status: SessionStatus.Untitled,
+			hasWorktree: false,
+			createdAt: new Date(Date.now() - 1_000)
+		});
+		tasks.setTasks(session.sessionId, [entry('setup', 'worktreeCreated')]);
+		mgmt.sessions = [session];
+
+		createDispatcher();
+		await settle();
+		assert.deepStrictEqual(tasks.ranTasks, []);
+
+		status.set(SessionStatus.InProgress, undefined);
+		workspace.set(makeWorkspace(true), undefined);
+		await settle();
+		assert.deepStrictEqual(tasks.ranTasks, [{ label: 'setup', sessionId: 'a' }]);
+	});
+
+	test('does not run for restored sessions reported as added after startup', async () => {
+		createDispatcher();
+		const { session } = makeSession({ id: 'a', createdAt: new Date(Date.now() - 1_000) });
+		tasks.setTasks(session.sessionId, [entry('setup', 'worktreeCreated')]);
+		mgmt.emitter.fire({ added: [session], removed: [], changed: [] });
+		await settle();
+
+		assert.deepStrictEqual(tasks.ranTasks, []);
+	});
+
+	test('waits for a worktree before running', async () => {
+		createDispatcher();
+		const { session, workspace } = makeSession({ id: 'a', hasWorktree: false });
+		tasks.setTasks(session.sessionId, [entry('setup', 'worktreeCreated')]);
+		mgmt.emitter.fire({ added: [session], removed: [], changed: [] });
+		await settle();
+		assert.deepStrictEqual(tasks.ranTasks, []);
+
+		workspace.set(makeWorkspace(true), undefined);
+		await settle();
+		assert.deepStrictEqual(tasks.ranTasks, [{ label: 'setup', sessionId: 'a' }]);
+	});
+
+	test('waits for untitled sessions to start before running', async () => {
+		createDispatcher();
+		const { session, status } = makeSession({ id: 'a', status: SessionStatus.Untitled });
+		tasks.setTasks(session.sessionId, [entry('setup', 'worktreeCreated')]);
+		mgmt.emitter.fire({ added: [session], removed: [], changed: [] });
+		await settle();
+		assert.deepStrictEqual(tasks.ranTasks, []);
+
+		status.set(SessionStatus.InProgress, undefined);
+		await settle();
 		assert.deepStrictEqual(tasks.ranTasks, [{ label: 'setup', sessionId: 'a' }]);
 	});
 


### PR DESCRIPTION
## What changed
- Re-enable `WorktreeCreatedTaskDispatcher`.
- Dispatch `runOn: "worktreeCreated"` tasks only for newly-created sessions after a concrete worktree URI is reported.
- Skip restored sessions and runtimes that already run these tasks server-side, while still tracking pending untitled sessions created before the dispatcher starts.

## Validation
- `npm run compile-check-ts-native`
- `npm run valid-layers-check`
- `scripts\test.bat --run src\vs\sessions\contrib\chat\test\browser\worktreeCreatedTaskDispatcher.test.ts`
- `node --experimental-strip-types build\hygiene.ts src\vs\sessions\contrib\chat\browser\worktreeCreatedTaskDispatcher.ts src\vs\sessions\contrib\chat\browser\chat.contribution.ts src\vs\sessions\contrib\chat\test\browser\worktreeCreatedTaskDispatcher.test.ts src\vs\sessions\SESSIONS.md`