### PR TITLE
Move terminal telemetry into a terminalContrib

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminal.contribution.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.contribution.ts
@@ -45,7 +45,6 @@ import { TerminalMainContribution } from './terminalMainContribution.js';
 import { setupTerminalMenus } from './terminalMenus.js';
 import { TerminalProfileService } from './terminalProfileService.js';
 import { TerminalService } from './terminalService.js';
-import { TerminalTelemetryContribution } from './terminalTelemetry.js';
 import { TerminalViewPane } from './terminalView.js';
 import { AgentHostTerminalService, IAgentHostTerminalService } from './agentHostTerminalService.js';
 
@@ -64,7 +63,6 @@ registerSingleton(IAgentHostTerminalService, AgentHostTerminalService, Instantia
 // This contribution blocks startup as it's critical to enable the web embedder window.createTerminal API
 registerWorkbenchContribution2(TerminalMainContribution.ID, TerminalMainContribution, WorkbenchPhase.BlockStartup);
 registerWorkbenchContribution2(RemoteTerminalBackendContribution.ID, RemoteTerminalBackendContribution, WorkbenchPhase.AfterRestored);
-registerWorkbenchContribution2(TerminalTelemetryContribution.ID, TerminalTelemetryContribution, WorkbenchPhase.AfterRestored);
 
 // Register configurations
 registerTerminalPlatformConfiguration();

--- a/src/vs/workbench/contrib/terminal/terminal.all.ts
+++ b/src/vs/workbench/contrib/terminal/terminal.all.ts
@@ -34,5 +34,6 @@ import '../terminalContrib/resizeDimensionsOverlay/browser/terminal.resizeDimens
 import '../terminalContrib/sendSequence/browser/terminal.sendSequence.contribution.js';
 import '../terminalContrib/sendSignal/browser/terminal.sendSignal.contribution.js';
 import '../terminalContrib/suggest/browser/terminal.suggest.contribution.js';
+import '../terminalContrib/telemetry/browser/terminal.telemetry.contribution.js';
 import '../terminalContrib/wslRecommendation/browser/terminal.wslRecommendation.contribution.js';
 import '../terminalContrib/voice/browser/terminal.voice.contribution.js';

--- a/src/vs/workbench/contrib/terminalContrib/telemetry/browser/terminal.telemetry.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/telemetry/browser/terminal.telemetry.contribution.ts
@@ -1,0 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { registerWorkbenchContribution2, WorkbenchPhase } from '../../../../common/contributions.js';
+import { TerminalTelemetryContribution } from './terminalTelemetry.js';
+
+registerWorkbenchContribution2(TerminalTelemetryContribution.ID, TerminalTelemetryContribution, WorkbenchPhase.AfterRestored);

--- a/src/vs/workbench/contrib/terminalContrib/telemetry/browser/terminalTelemetry.ts
+++ b/src/vs/workbench/contrib/terminalContrib/telemetry/browser/terminalTelemetry.ts
@@ -3,20 +3,20 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { getWindowById } from '../../../../base/browser/dom.js';
-import { isAuxiliaryWindow } from '../../../../base/browser/window.js';
-import { timeout } from '../../../../base/common/async.js';
-import { Event } from '../../../../base/common/event.js';
-import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
-import { basename } from '../../../../base/common/path.js';
-import { isString } from '../../../../base/common/types.js';
-import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
-import { TelemetryTrustedValue } from '../../../../platform/telemetry/common/telemetryUtils.js';
-import { TerminalCapability } from '../../../../platform/terminal/common/capabilities/capabilities.js';
-import { TerminalLocation, type IShellLaunchConfig, type ShellIntegrationInjectionFailureReason } from '../../../../platform/terminal/common/terminal.js';
-import type { IWorkbenchContribution } from '../../../common/contributions.js';
-import { ILifecycleService } from '../../../services/lifecycle/common/lifecycle.js';
-import { ITerminalEditorService, ITerminalService, type ITerminalInstance } from './terminal.js';
+import { getWindowById } from '../../../../../base/browser/dom.js';
+import { isAuxiliaryWindow } from '../../../../../base/browser/window.js';
+import { timeout } from '../../../../../base/common/async.js';
+import { Event } from '../../../../../base/common/event.js';
+import { Disposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { basename } from '../../../../../base/common/path.js';
+import { isString } from '../../../../../base/common/types.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { TelemetryTrustedValue } from '../../../../../platform/telemetry/common/telemetryUtils.js';
+import { TerminalCapability } from '../../../../../platform/terminal/common/capabilities/capabilities.js';
+import { TerminalLocation, type IShellLaunchConfig, type ShellIntegrationInjectionFailureReason } from '../../../../../platform/terminal/common/terminal.js';
+import type { IWorkbenchContribution } from '../../../../common/contributions.js';
+import { ILifecycleService } from '../../../../services/lifecycle/common/lifecycle.js';
+import { ITerminalEditorService, ITerminalService, type ITerminalInstance } from '../../../terminal/browser/terminal.js';
 
 export class TerminalTelemetryContribution extends Disposable implements IWorkbenchContribution {
 	static ID = 'terminalTelemetry';


### PR DESCRIPTION
This is easily isolated in a contrib, simplifying the core terminal further

@meganrogge @anthonykim1 