### PR TITLE
agent-host: stop redundant customization sync events

### DIFF
--- a/src/vs/platform/agentHost/common/agentPluginManager.ts
+++ b/src/vs/platform/agentHost/common/agentPluginManager.ts
@@ -41,9 +41,9 @@ export interface IAgentPluginManager {
 	 * Syncs a set of client-provided customization refs to local storage.
 	 *
 	 * Each ref is copied to a local directory, respecting nonce-based
-	 * caching. The optional {@link progress} callback fires as individual
-	 * customizations complete or fail, allowing callers to publish
-	 * incremental status updates.
+	 * caching. The optional {@link progress} callback fires with the single
+	 * customization that completed or failed, allowing callers to publish
+	 * targeted incremental status updates.
 	 *
 	 * Concurrent calls for the same plugin URI are serialized so that
 	 * overlapping syncs do not clobber each other.
@@ -51,5 +51,5 @@ export interface IAgentPluginManager {
 	 * @returns Final status for every customization, with `pluginDir`
 	 * defined when the sync was successful.
 	 */
-	syncCustomizations(clientId: string, customizations: CustomizationRef[], progress?: (status: SessionCustomization[]) => void): Promise<ISyncedCustomization[]>;
+	syncCustomizations(clientId: string, customizations: CustomizationRef[], progress?: (status: SessionCustomization) => void): Promise<ISyncedCustomization[]>;
 }

--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -644,13 +644,13 @@ export interface IAgent {
 	onArchivedChanged?(session: URI, isArchived: boolean): Promise<void>;
 
 	/**
-	 * Receives client-provided customization refs and syncs them (e.g. copies
-	 * plugin files to local storage). Returns per-customization status with
-	 * local plugin directories.
+	 * Receives client-provided customization refs for a session and syncs them
+	 * (e.g. copies plugin files to local storage). The agent publishes
+	 * customization state actions as the sync progresses.
 	 *
 	 * The agent MAY defer a client restart until all active sessions are idle.
 	 */
-	setClientCustomizations(clientId: string, customizations: CustomizationRef[], progress?: (results: ISyncedCustomization[]) => void): Promise<ISyncedCustomization[]>;
+	setClientCustomizations(session: URI, clientId: string, customizations: CustomizationRef[]): Promise<ISyncedCustomization[]>;
 
 	/**
 	 * Receives client-provided tool definitions to make available in a

--- a/src/vs/platform/agentHost/node/agentPluginManager.ts
+++ b/src/vs/platform/agentHost/node/agentPluginManager.ts
@@ -68,32 +68,24 @@ export class AgentPluginManager implements IAgentPluginManager {
 	async syncCustomizations(
 		clientId: string,
 		customizations: CustomizationRef[],
-		progress?: (status: SessionCustomization[]) => void,
+		progress?: (status: SessionCustomization) => void,
 	): Promise<ISyncedCustomization[]> {
 		await this._ensureCacheLoaded();
 
-		// Build initial loading status and fire it immediately via progress
-		const statuses: SessionCustomization[] = customizations.map(c => ({
-			customization: c,
-			enabled: true,
-			status: CustomizationStatus.Loading,
-		}));
-		progress?.([...statuses]);
-
 		// Sync each customization in parallel, serialized per URI
-		const results = await Promise.all(customizations.map((ref, i) =>
+		const results = await Promise.all(customizations.map(ref =>
 			this._sequencer.queue(ref.uri, async (): Promise<ISyncedCustomization> => {
 				try {
 					const pluginDir = await this._syncPlugin(clientId, ref);
-					statuses[i] = { customization: ref, enabled: true, status: CustomizationStatus.Loaded };
-					progress?.([...statuses]);
-					return { customization: statuses[i], pluginDir };
+					const customization = { customization: ref, enabled: true, status: CustomizationStatus.Loaded };
+					progress?.(customization);
+					return { customization, pluginDir };
 				} catch (err) {
 					const message = err instanceof Error ? err.message : String(err);
 					this._logService.error(`[AgentPluginManager] Failed to sync plugin ${ref.uri}: ${message}`);
-					statuses[i] = { customization: ref, enabled: true, status: CustomizationStatus.Error, statusMessage: message };
-					progress?.([...statuses]);
-					return { customization: statuses[i] };
+					const customization = { customization: ref, enabled: true, status: CustomizationStatus.Error, statusMessage: message };
+					progress?.(customization);
+					return { customization };
 				}
 			})
 		));

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -332,14 +332,16 @@ export class AgentSideEffects extends Disposable {
 			return;
 		}
 
-		// No active turn on the session. Most signals are silently dropped,
-		// but a `SessionTurnComplete` (idle) still needs to drive its
-		// post-turn side effects — flushing pending diff computation,
-		// recomputing diffs, and notifying the host. Tests routinely fire
-		// `idle` without first dispatching the matching `SessionTurnStarted`
-		// through the state manager.
-		if (signal.kind === 'action' && signal.action.type === ActionType.SessionTurnComplete) {
-			this._runTurnCompleteSideEffects(sessionKey, undefined);
+		// No active turn on the session. Non-action signals are silently
+		// dropped, but action signals can still target session-level state
+		// such as customizations, title, or configuration. A turnComplete
+		// action also drives post-turn side effects even when the matching
+		// turnStarted was not observed by this side-effects instance.
+		if (signal.kind === 'action') {
+			this._stateManager.dispatchServerAction(sessionKey, signal.action);
+			if (signal.action.type === ActionType.SessionTurnComplete) {
+				this._runTurnCompleteSideEffects(sessionKey, undefined);
+			}
 		}
 	}
 
@@ -798,15 +800,7 @@ export class AgentSideEffects extends Disposable {
 				agent.setClientTools(URI.parse(channel), clientId, action.activeClient?.tools ?? []);
 
 				const refs = action.activeClient?.customizations ?? [];
-				agent.setClientCustomizations(
-					clientId,
-					refs,
-					() => {
-						this._publishSessionCustomizationsSoon(agent, channel);
-					},
-				).then(() => {
-					this._publishSessionCustomizationsSoon(agent, channel);
-				}).catch(err => {
+				agent.setClientCustomizations(URI.parse(channel), clientId, refs).catch(err => {
 					this._logService.error('[AgentSideEffects] setClientCustomizations failed', err);
 				});
 				break;
@@ -971,4 +965,3 @@ export class AgentSideEffects extends Disposable {
 		super.dispose();
 	}
 }
-

--- a/src/vs/platform/agentHost/node/claude/claudeAgent.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgent.ts
@@ -1078,7 +1078,7 @@ export class ClaudeAgent extends Disposable implements IAgent {
 		// matching pending promise on the SDK session.
 	}
 
-	setClientCustomizations(_clientId: string, _customizations: CustomizationRef[], _progress?: (results: ISyncedCustomization[]) => void): Promise<ISyncedCustomization[]> {
+	setClientCustomizations(_session: URI, _clientId: string, _customizations: CustomizationRef[]): Promise<ISyncedCustomization[]> {
 		throw new Error('TODO: Phase 11');
 	}
 

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -1964,7 +1964,13 @@ class PluginController extends Disposable {
 				return;
 			}
 			published.set(customization.customization.uri, { ...customization });
-			publish?.({ type: ActionType.SessionCustomizationUpdated, ...customization });
+			publish?.({
+				type: ActionType.SessionCustomizationUpdated,
+				customization: customization.customization,
+				enabled: customization.enabled,
+				status: customization.status,
+				statusMessage: customization.statusMessage,
+			});
 		};
 
 		const prev = this._clientSync;

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -30,6 +30,7 @@ import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
 import { ISessionDataService, SESSION_DB_FILENAME } from '../../common/sessionDataService.js';
 import type { ResolveSessionConfigResult, SessionConfigCompletionsResult } from '../../common/state/protocol/commands.js';
 import { ProtectedResourceMetadata, type ConfigSchema, type ModelSelection, type SessionCustomization, type ToolDefinition } from '../../common/state/protocol/state.js';
+import { ActionType, type SessionAction } from '../../common/state/sessionActions.js';
 import { AHP_AUTH_REQUIRED, ProtocolError } from '../../common/state/sessionProtocol.js';
 import { CustomizationRef, CustomizationStatus, ResponsePartKind, SessionInputResponseKind, parseSubagentSessionUri, type MessageAttachment, type PendingMessage, type PolicyState, type ResponsePart, type SessionInputAnswer, type ToolCallResult, type Turn } from '../../common/state/sessionState.js';
 import { IAgentConfigurationService } from '../agentConfigurationService.js';
@@ -310,14 +311,18 @@ export class CopilotAgent extends Disposable implements IAgent {
 	}
 
 	async getSessionCustomizations(session: URI): Promise<readonly SessionCustomization[]> {
+		return this._plugins.getSessionCustomizations(await this._getSessionCustomizationDirectory(session));
+	}
+
+	private async _getSessionCustomizationDirectory(session: URI): Promise<URI | undefined> {
 		const sessionId = AgentSession.id(session);
 		const provisional = this._provisionalSessions.get(sessionId);
 		if (provisional) {
-			return this._plugins.getSessionCustomizations(provisional.workingDirectory);
+			return provisional.workingDirectory;
 		}
 		const entry = this._sessions.get(sessionId);
 		const metadata = entry ? undefined : await this._readSessionMetadata(session);
-		return this._plugins.getSessionCustomizations(entry?.customizationDirectory ?? metadata?.customizationDirectory ?? metadata?.workingDirectory);
+		return entry?.customizationDirectory ?? metadata?.customizationDirectory ?? metadata?.workingDirectory;
 	}
 
 	async authenticate(resource: string, token: string): Promise<boolean> {
@@ -760,7 +765,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 			const ac = this._getOrCreateActiveClient(sessionUri);
 			ac.updateTools(config.activeClient.clientId, config.activeClient.tools);
 			if (config.activeClient.customizations !== undefined) {
-				await this._plugins.sync(config.activeClient.clientId, config.activeClient.customizations);
+				await this._plugins.sync(config.activeClient.clientId, config.activeClient.customizations, config.workingDirectory);
 			}
 		}
 
@@ -940,8 +945,11 @@ export class CopilotAgent extends Disposable implements IAgent {
 		return { items: branches.map(branch => ({ value: branch, label: branch })) };
 	}
 
-	async setClientCustomizations(clientId: string, customizations: CustomizationRef[], progress?: (results: ISyncedCustomization[]) => void): Promise<ISyncedCustomization[]> {
-		return this._plugins.sync(clientId, customizations, progress);
+	async setClientCustomizations(session: URI, clientId: string, customizations: CustomizationRef[]): Promise<ISyncedCustomization[]> {
+		const directory = await this._getSessionCustomizationDirectory(session);
+		return this._plugins.sync(clientId, customizations, directory, action => {
+			this._onDidSessionProgress.fire({ kind: 'action', session, action });
+		});
 	}
 
 	setClientTools(session: URI, clientId: string, tools: ToolDefinition[]): void {
@@ -1931,7 +1939,7 @@ class PluginController extends Disposable {
 		});
 	}
 
-	public sync(clientId: string, customizations: CustomizationRef[], progress?: (results: ISyncedCustomization[]) => void) {
+	public sync(clientId: string, customizations: CustomizationRef[], directory: URI | undefined, publish?: (action: SessionAction) => void) {
 		const revision = ++this._clientRevision;
 		this._clientCustomizations = customizations.map(customization => ({
 			customization: {
@@ -1941,7 +1949,23 @@ class PluginController extends Disposable {
 				status: CustomizationStatus.Loading,
 			},
 		}));
-		progress?.(this._clientCustomizations.map(item => ({ customization: this._applyEnablement(item.customization) })));
+		publish?.({
+			type: ActionType.SessionCustomizationsChanged,
+			customizations: [...this.getSessionCustomizations(directory)],
+		});
+		const published = new Map<string, SessionCustomization>();
+		for (const customization of this._clientCustomizations) {
+			const enabled = this._applyEnablement(customization.customization);
+			published.set(enabled.customization.uri, this._applyEnablement(customization.customization));
+		}
+		const publishUpdate = (item: IResolvedCustomization) => {
+			const customization = this._applyEnablement(item.customization);
+			if (equals(published.get(customization.customization.uri), customization)) {
+				return;
+			}
+			published.set(customization.customization.uri, { ...customization });
+			publish?.({ type: ActionType.SessionCustomizationUpdated, ...customization });
+		};
 
 		const prev = this._clientSync;
 		const promise = this._clientSync = prev.catch(err => {
@@ -1952,18 +1976,15 @@ class PluginController extends Disposable {
 					return;
 				}
 
-				this._clientCustomizations = status.map(customization => ({
-					customization: {
-						...customization,
-						clientId,
-					},
-				}));
-				progress?.(this._clientCustomizations.map(item => ({ customization: this._applyEnablement(item.customization) })));
+				publishUpdate({ customization: { ...status, clientId } });
 			});
 
 			const resolved = await Promise.all(result.map(item => this._resolveSyncedCustomization(item, clientId)));
 			if (revision === this._clientRevision) {
 				this._clientCustomizations = resolved;
+				for (const item of resolved) {
+					publishUpdate(item);
+				}
 			}
 			return resolved;
 		});

--- a/src/vs/platform/agentHost/test/node/agentPluginManager.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentPluginManager.test.ts
@@ -88,18 +88,15 @@ suite('AgentPluginManager', () => {
 			assert.strictEqual(results[1].pluginDir, undefined);
 		});
 
-		test('fires progress callback with loading, then loaded', async () => {
+		test('fires progress callback with changed customization status', async () => {
 			await seedPluginDir('prog', { 'index.js': 'content' });
 
-			const progressCalls: SessionCustomization[][] = [];
-			await manager.syncCustomizations('test-client', [makeRef('prog', 'n1')], statuses => {
-				progressCalls.push(statuses);
+			const progressCalls: SessionCustomization[] = [];
+			await manager.syncCustomizations('test-client', [makeRef('prog', 'n1')], status => {
+				progressCalls.push(status);
 			});
 
-			// At least two calls: initial loading + final loaded
-			assert.ok(progressCalls.length >= 2, `expected at least 2 progress calls, got ${progressCalls.length}`);
-			assert.strictEqual(progressCalls[0][0].status, CustomizationStatus.Loading);
-			assert.strictEqual(progressCalls[progressCalls.length - 1][0].status, CustomizationStatus.Loaded);
+			assert.deepStrictEqual(progressCalls.map(call => call.status), [CustomizationStatus.Loaded]);
 		});
 
 		test('skips copy when nonce matches', async () => {

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -1012,7 +1012,11 @@ suite('AgentSideEffects', () => {
 			}]);
 			const customizationActions = envelopes
 				.filter(e => e.action.type === ActionType.SessionCustomizationsChanged);
-			assert.strictEqual(customizationActions.length, 0);
+			assert.strictEqual(customizationActions.length, 1);
+			assert.deepStrictEqual(customizationActions[0].action, {
+				type: ActionType.SessionCustomizationsChanged,
+				customizations: [],
+			});
 		});
 
 		test('clears client customizations when activeClient is null', () => {

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -23,7 +23,7 @@ import { ISessionDataService } from '../../common/sessionDataService.js';
 import type { RootConfigChangedAction } from '../../common/state/protocol/actions.js';
 import { CustomizationStatus } from '../../common/state/protocol/state.js';
 import { ActionType, ActionEnvelope, SessionAction } from '../../common/state/sessionActions.js';
-import { buildSubagentSessionUri, MessageAttachmentKind, PendingMessageKind, ResponsePartKind, SessionStatus, ToolCallConfirmationReason, ToolCallStatus, ToolResultContentType } from '../../common/state/sessionState.js';
+import { buildSubagentSessionUri, MessageAttachmentKind, PendingMessageKind, ResponsePartKind, SessionStatus, ToolCallConfirmationReason, ToolCallStatus, ToolResultContentType, type SessionCustomization } from '../../common/state/sessionState.js';
 import { IProductService } from '../../../product/common/productService.js';
 import { ITelemetryService, TelemetryLevel } from '../../../telemetry/common/telemetry.js';
 import { NullTelemetryService } from '../../../telemetry/common/telemetryUtils.js';
@@ -864,7 +864,11 @@ suite('AgentSideEffects', () => {
 
 	suite('handleAction — session/activeClientChanged', () => {
 
-		test('calls setClientCustomizations and dispatches customizationsChanged', async () => {
+		setup(() => {
+			disposables.add(sideEffects.registerProgressListener(agent));
+		});
+
+		test('calls setClientCustomizations and dispatches customizationsChanged once', async () => {
 			setupSession();
 			agent.getSessionCustomizations = async () => [
 				{
@@ -908,7 +912,83 @@ suite('AgentSideEffects', () => {
 
 			const customizationActions = envelopes
 				.filter(e => e.action.type === ActionType.SessionCustomizationsChanged);
-			assert.ok(customizationActions.length >= 1, 'should dispatch at least one customizationsChanged');
+			assert.strictEqual(customizationActions.length, 1, 'should dispatch one full customizationsChanged replacement');
+			assert.strictEqual(
+				envelopes.filter(e => e.action.type === ActionType.SessionCustomizationUpdated).length,
+				0,
+				'should not dispatch customizationUpdated when progress matches the final state',
+			);
+		});
+
+		test('dispatches customizationUpdated for sync progress after initial replacement', async () => {
+			setupSession();
+			const customization = { uri: 'file:///plugin-a', displayName: 'Plugin A' };
+			let currentCustomizations: readonly SessionCustomization[] = [];
+			agent.getSessionCustomizations = async () => currentCustomizations;
+			agent.setClientCustomizations = async (session, clientId, customizations) => {
+				agent.setClientCustomizationsCalls.push({ clientId, customizations });
+				currentCustomizations = [{
+					customization,
+					enabled: true,
+					status: CustomizationStatus.Loading,
+				}];
+				agent.fireProgress({
+					kind: 'action',
+					session,
+					action: {
+						type: ActionType.SessionCustomizationsChanged,
+						customizations: [...currentCustomizations],
+					},
+				});
+				await new Promise(resolve => setTimeout(resolve, 0));
+				currentCustomizations = [{
+					customization,
+					enabled: true,
+					status: CustomizationStatus.Loaded,
+				}];
+				agent.fireProgress({
+					kind: 'action',
+					session,
+					action: {
+						type: ActionType.SessionCustomizationUpdated,
+						customization,
+						enabled: true,
+						status: CustomizationStatus.Loaded,
+					},
+				});
+				return currentCustomizations.map(customization => ({ customization }));
+			};
+
+			const envelopes: ActionEnvelope[] = [];
+			disposables.add(stateManager.onDidEmitEnvelope(e => envelopes.push(e)));
+
+			sideEffects.handleAction(sessionUri.toString(), {
+				type: ActionType.SessionActiveClientChanged,
+				activeClient: {
+					clientId: 'test-client',
+					tools: [],
+					customizations: [customization],
+				},
+			});
+			await new Promise(resolve => setTimeout(resolve, 50));
+
+			const customizationsChanged = envelopes.filter(e => e.action.type === ActionType.SessionCustomizationsChanged);
+			assert.strictEqual(customizationsChanged.length, 1);
+			const firstCustomizationsChanged = customizationsChanged[0].action;
+			assert.strictEqual(firstCustomizationsChanged.type, ActionType.SessionCustomizationsChanged);
+			assert.deepStrictEqual(firstCustomizationsChanged.customizations, [{
+				customization,
+				enabled: true,
+				status: CustomizationStatus.Loading,
+			}]);
+
+			const customizationUpdated = envelopes.filter(e => e.action.type === ActionType.SessionCustomizationUpdated);
+			assert.deepStrictEqual(customizationUpdated.map(e => e.action), [{
+				type: ActionType.SessionCustomizationUpdated,
+				customization,
+				enabled: true,
+				status: CustomizationStatus.Loaded,
+			}]);
 		});
 
 		test('clears client customizations when activeClient has no customizations', () => {

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -48,7 +48,7 @@ class TestAgentPluginManager implements IAgentPluginManager {
 
 	readonly basePath = URI.from({ scheme: 'inmemory', path: '/agentPlugins' });
 
-	async syncCustomizations(_clientId: string, _customizations: CustomizationRef[], _progress?: (status: SessionCustomization[]) => void): Promise<ISyncedCustomization[]> {
+	async syncCustomizations(_clientId: string, _customizations: CustomizationRef[], _progress?: (status: SessionCustomization) => void): Promise<ISyncedCustomization[]> {
 		return [];
 	}
 }
@@ -607,7 +607,7 @@ suite('CopilotAgent', () => {
 		class SpyingPluginManager extends TestAgentPluginManager {
 			public readonly calls: { clientId: string; customizations: CustomizationRef[] }[] = [];
 
-			override async syncCustomizations(clientId: string, customizations: CustomizationRef[], _progress?: (status: SessionCustomization[]) => void): Promise<ISyncedCustomization[]> {
+			override async syncCustomizations(clientId: string, customizations: CustomizationRef[], _progress?: (status: SessionCustomization) => void): Promise<ISyncedCustomization[]> {
 				this.calls.push({ clientId, customizations: [...customizations] });
 				return [];
 			}

--- a/src/vs/platform/agentHost/test/node/mockAgent.ts
+++ b/src/vs/platform/agentHost/test/node/mockAgent.ts
@@ -178,16 +178,14 @@ export class MockAgent implements IAgent {
 				status: CustomizationStatus.Loaded,
 			},
 		}));
-		if (results.length > 0) {
-			this._onDidSessionProgress.fire({
-				kind: 'action',
-				session,
-				action: {
-					type: ActionType.SessionCustomizationsChanged,
-					customizations: results.map(result => result.customization),
-				},
-			});
-		}
+		this._onDidSessionProgress.fire({
+			kind: 'action',
+			session,
+			action: {
+				type: ActionType.SessionCustomizationsChanged,
+				customizations: results.map(result => result.customization),
+			},
+		});
 		return results;
 	}
 

--- a/src/vs/platform/agentHost/test/node/mockAgent.ts
+++ b/src/vs/platform/agentHost/test/node/mockAgent.ts
@@ -169,7 +169,7 @@ export class MockAgent implements IAgent {
 		return this.customizations;
 	}
 
-	async setClientCustomizations(clientId: string, customizations: CustomizationRef[], progress?: (results: ISyncedCustomization[]) => void): Promise<ISyncedCustomization[]> {
+	async setClientCustomizations(session: URI, clientId: string, customizations: CustomizationRef[]): Promise<ISyncedCustomization[]> {
 		this.setClientCustomizationsCalls.push({ clientId, customizations });
 		const results: ISyncedCustomization[] = customizations.map(c => ({
 			customization: {
@@ -178,7 +178,16 @@ export class MockAgent implements IAgent {
 				status: CustomizationStatus.Loaded,
 			},
 		}));
-		progress?.(results);
+		if (results.length > 0) {
+			this._onDidSessionProgress.fire({
+				kind: 'action',
+				session,
+				action: {
+					type: ActionType.SessionCustomizationsChanged,
+					customizations: results.map(result => result.customization),
+				},
+			});
+		}
 		return results;
 	}
 

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/remoteAgentHostCustomizationHarness.test.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/remoteAgentHostCustomizationHarness.test.ts
@@ -9,9 +9,10 @@ import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { mock } from '../../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { type IAgentConnection } from '../../../../../../platform/agentHost/common/agentService.js';
-import { ActionType, type ActionEnvelope, type INotification, type StateAction } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
+import { ActionType, isSessionAction, type ActionEnvelope, type INotification, type StateAction } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
 import { CustomizationStatus, type AgentInfo, type CustomizationRef, type RootState, type SessionCustomization, type SessionState } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
-import { StateComponents } from '../../../../../../platform/agentHost/common/state/sessionState.js';
+import { StateComponents, type ComponentToState } from '../../../../../../platform/agentHost/common/state/sessionState.js';
+import { sessionReducer } from '../../../../../../platform/agentHost/common/state/sessionReducers.js';
 import { type IAgentSubscription } from '../../../../../../platform/agentHost/common/state/agentSubscription.js';
 import { IFileDialogService } from '../../../../../../platform/dialogs/common/dialogs.js';
 import { VSBuffer } from '../../../../../../base/common/buffer.js';
@@ -40,7 +41,7 @@ class MockAgentConnection extends mock<IAgentConnection>() {
 	private _rootStateValue: RootState = { agents: [] };
 	override readonly rootState;
 
-	private readonly _sessionStates = new Map<string, Partial<SessionState>>();
+	private readonly _sessionStates = new Map<string, SessionState>();
 
 	readonly dispatchedActions: { channel: string; action: StateAction }[] = [];
 
@@ -64,55 +65,31 @@ class MockAgentConnection extends mock<IAgentConnection>() {
 		this.dispatchedActions.push({ channel, action });
 	}
 
-	override getSubscriptionUnmanaged<T extends StateComponents>(kind: T, resource: URI): IAgentSubscription<unknown> | undefined {
+	override getSubscriptionUnmanaged<T extends StateComponents>(kind: T, resource: URI): IAgentSubscription<ComponentToState[T]> | undefined {
 		if (kind !== StateComponents.Session) {
 			return undefined;
 		}
-		const state = this._sessionStates.get(resource.toString());
-		if (!state) {
+		const self = this;
+		const channel = resource.toString();
+		if (!self._sessionStates.has(channel)) {
 			return undefined;
 		}
-		return {
-			get value() { return state as SessionState; },
-			get verifiedValue() { return state as SessionState; },
+		const subscription: IAgentSubscription<SessionState> = {
+			get value() { return self._sessionStates.get(channel); },
+			get verifiedValue() { return self._sessionStates.get(channel); },
 			onDidChange: Event.None,
 			onWillApplyAction: Event.None,
 			onDidApplyAction: Event.None,
 		};
+		return subscription as IAgentSubscription<ComponentToState[T]>;
 	}
 
 	fireAction(envelope: ActionEnvelope): void {
-		this._applyToSessionState(envelope);
+		if (isSessionAction(envelope.action)) {
+			const current = this._sessionStates.get(envelope.channel) ?? {} as SessionState;
+			this._sessionStates.set(envelope.channel, sessionReducer(current, envelope.action));
+		}
 		this._onDidAction.fire(envelope);
-	}
-
-	private _applyToSessionState(envelope: ActionEnvelope): void {
-		const action = envelope.action;
-		if (action.type !== ActionType.SessionCustomizationsChanged && action.type !== ActionType.SessionCustomizationUpdated) {
-			return;
-		}
-		const state = this._sessionStates.get(envelope.channel) ?? {};
-		if (action.type === ActionType.SessionCustomizationsChanged) {
-			state.customizations = [...action.customizations];
-		} else {
-			const current = [...(state.customizations ?? [])];
-			const { customization, enabled, status, statusMessage } = action;
-			const index = current.findIndex(c => c.customization.uri === customization.uri);
-			if (index === -1) {
-				current.push({ customization, enabled: enabled ?? false, status, statusMessage });
-			} else {
-				const existing = current[index];
-				current[index] = {
-					...existing,
-					customization,
-					enabled: enabled ?? existing.enabled,
-					status: status ?? existing.status,
-					statusMessage: statusMessage ?? existing.statusMessage,
-				};
-			}
-			state.customizations = current;
-		}
-		this._sessionStates.set(envelope.channel, state);
 	}
 
 	dispose(): void {

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/remoteAgentHostCustomizationHarness.test.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/remoteAgentHostCustomizationHarness.test.ts
@@ -10,7 +10,9 @@ import { mock } from '../../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { type IAgentConnection } from '../../../../../../platform/agentHost/common/agentService.js';
 import { ActionType, type ActionEnvelope, type INotification, type StateAction } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
-import { CustomizationStatus, type AgentInfo, type CustomizationRef, type RootState, type SessionCustomization } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
+import { CustomizationStatus, type AgentInfo, type CustomizationRef, type RootState, type SessionCustomization, type SessionState } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
+import { StateComponents } from '../../../../../../platform/agentHost/common/state/sessionState.js';
+import { type IAgentSubscription } from '../../../../../../platform/agentHost/common/state/agentSubscription.js';
 import { IFileDialogService } from '../../../../../../platform/dialogs/common/dialogs.js';
 import { VSBuffer } from '../../../../../../base/common/buffer.js';
 import { IFileService, type IFileContent, type IFileStat, type IFileStatResult } from '../../../../../../platform/files/common/files.js';
@@ -38,6 +40,8 @@ class MockAgentConnection extends mock<IAgentConnection>() {
 	private _rootStateValue: RootState = { agents: [] };
 	override readonly rootState;
 
+	private readonly _sessionStates = new Map<string, Partial<SessionState>>();
+
 	readonly dispatchedActions: { channel: string; action: StateAction }[] = [];
 
 	constructor() {
@@ -60,8 +64,55 @@ class MockAgentConnection extends mock<IAgentConnection>() {
 		this.dispatchedActions.push({ channel, action });
 	}
 
+	override getSubscriptionUnmanaged<T extends StateComponents>(kind: T, resource: URI): IAgentSubscription<unknown> | undefined {
+		if (kind !== StateComponents.Session) {
+			return undefined;
+		}
+		const state = this._sessionStates.get(resource.toString());
+		if (!state) {
+			return undefined;
+		}
+		return {
+			get value() { return state as SessionState; },
+			get verifiedValue() { return state as SessionState; },
+			onDidChange: Event.None,
+			onWillApplyAction: Event.None,
+			onDidApplyAction: Event.None,
+		};
+	}
+
 	fireAction(envelope: ActionEnvelope): void {
+		this._applyToSessionState(envelope);
 		this._onDidAction.fire(envelope);
+	}
+
+	private _applyToSessionState(envelope: ActionEnvelope): void {
+		const action = envelope.action;
+		if (action.type !== ActionType.SessionCustomizationsChanged && action.type !== ActionType.SessionCustomizationUpdated) {
+			return;
+		}
+		const state = this._sessionStates.get(envelope.channel) ?? {};
+		if (action.type === ActionType.SessionCustomizationsChanged) {
+			state.customizations = [...action.customizations];
+		} else {
+			const current = [...(state.customizations ?? [])];
+			const { customization, enabled, status, statusMessage } = action;
+			const index = current.findIndex(c => c.customization.uri === customization.uri);
+			if (index === -1) {
+				current.push({ customization, enabled: enabled ?? false, status, statusMessage });
+			} else {
+				const existing = current[index];
+				current[index] = {
+					...existing,
+					customization,
+					enabled: enabled ?? existing.enabled,
+					status: status ?? existing.status,
+					statusMessage: statusMessage ?? existing.statusMessage,
+				};
+			}
+			state.customizations = current;
+		}
+		this._sessionStates.set(envelope.channel, state);
 	}
 
 	dispose(): void {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentCustomizationItemProvider.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentCustomizationItemProvider.ts
@@ -10,7 +10,7 @@ import { ResourceMap } from '../../../../../../base/common/map.js';
 import { extname } from '../../../../../../base/common/path.js';
 import { joinPath } from '../../../../../../base/common/resources.js';
 import { URI } from '../../../../../../base/common/uri.js';
-import { CustomizationStatus, StateComponents, type SessionCustomization, type AgentInfo, type CustomizationRef, type RootState } from '../../../../../../platform/agentHost/common/state/sessionState.js';
+import { CustomizationStatus, type SessionCustomization, type AgentInfo, type CustomizationRef, type RootState } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { ILogService } from '../../../../../../platform/log/common/log.js';
 import { ICustomizationItem, ICustomizationItemAction, ICustomizationItemProvider } from '../../../common/customizationHarnessService.js';
 import { PromptsStorage } from '../../../common/promptSyntax/service/promptsService.js';
@@ -38,6 +38,8 @@ export class AgentCustomizationItemProvider extends Disposable implements ICusto
 	/** Cache: pluginUri → last expansion (keyed by nonce so we re-fetch on content change). */
 	private readonly _expansionCache = new ResourceMap<{ nonce: string | undefined; children: readonly ICustomizationItem[] }>();
 
+	private readonly _sessionCustomizationsCache = new Map<string, SessionCustomization[]>();
+
 	constructor(
 		private readonly _agentInfo: AgentInfo,
 		private readonly _connection: IAgentConnection,
@@ -59,7 +61,26 @@ export class AgentCustomizationItemProvider extends Disposable implements ICusto
 		}));
 
 		this._register(this._connection.onDidAction(envelope => {
-			if (envelope.action.type === ActionType.SessionCustomizationsChanged || envelope.action.type === ActionType.SessionCustomizationUpdated) {
+			if (envelope.action.type === ActionType.SessionCustomizationsChanged) {
+				this._sessionCustomizationsCache.set(envelope.channel, [...envelope.action.customizations]);
+				this._onDidChange.fire();
+			} else if (envelope.action.type === ActionType.SessionCustomizationUpdated) {
+				const current = this._sessionCustomizationsCache.get(envelope.channel) ?? [];
+				const { customization, enabled, status, statusMessage } = envelope.action;
+				const index = current.findIndex(c => c.customization.uri === customization.uri);
+				if (index === -1) {
+					current.push({ customization, enabled: enabled ?? false, status, statusMessage });
+				} else {
+					const existing = current[index];
+					current[index] = {
+						...existing,
+						customization,
+						enabled: enabled ?? existing.enabled,
+						status: status ?? existing.status,
+						statusMessage: statusMessage ?? existing.statusMessage,
+					};
+				}
+				this._sessionCustomizationsCache.set(envelope.channel, current);
 				this._onDidChange.fire();
 			}
 		}));
@@ -147,8 +168,7 @@ export class AgentCustomizationItemProvider extends Disposable implements ICusto
 			plugins.push({ item, nonce: customization.nonce, status: undefined, statusMessage: undefined, enabled: undefined, childGroupKey: REMOTE_HOST_GROUP, isBundleItem: false });
 		}
 		const sessionUri = this._resolveSessionUri(sessionResource);
-		const sessionState = this._connection.getSubscriptionUnmanaged(StateComponents.Session, sessionUri)?.value;
-		const sessionCustomizations = sessionState && !(sessionState instanceof Error) ? sessionState.customizations ?? [] : [];
+		const sessionCustomizations = this._sessionCustomizationsCache.get(sessionUri.toString()) ?? [];
 		for (const sessionCustomization of sessionCustomizations) {
 			const isBundleItem = isSyntheticBundle(sessionCustomization.customization);
 			const isClientSynced = sessionCustomization.clientId !== undefined;

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentCustomizationItemProvider.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentCustomizationItemProvider.ts
@@ -10,7 +10,7 @@ import { ResourceMap } from '../../../../../../base/common/map.js';
 import { extname } from '../../../../../../base/common/path.js';
 import { joinPath } from '../../../../../../base/common/resources.js';
 import { URI } from '../../../../../../base/common/uri.js';
-import { CustomizationStatus, type SessionCustomization, type AgentInfo, type CustomizationRef, type RootState } from '../../../../../../platform/agentHost/common/state/sessionState.js';
+import { CustomizationStatus, StateComponents, type SessionCustomization, type AgentInfo, type CustomizationRef, type RootState } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { ILogService } from '../../../../../../platform/log/common/log.js';
 import { ICustomizationItem, ICustomizationItemAction, ICustomizationItemProvider } from '../../../common/customizationHarnessService.js';
 import { PromptsStorage } from '../../../common/promptSyntax/service/promptsService.js';
@@ -34,7 +34,6 @@ export class AgentCustomizationItemProvider extends Disposable implements ICusto
 	readonly onDidChange: Event<void> = this._onDidChange.event;
 
 	private _agentCustomizations: readonly CustomizationRef[];
-	private readonly _sessionCustomizationsCache = new Map<string, readonly SessionCustomization[]>();
 
 	/** Cache: pluginUri → last expansion (keyed by nonce so we re-fetch on content change). */
 	private readonly _expansionCache = new ResourceMap<{ nonce: string | undefined; children: readonly ICustomizationItem[] }>();
@@ -60,8 +59,7 @@ export class AgentCustomizationItemProvider extends Disposable implements ICusto
 		}));
 
 		this._register(this._connection.onDidAction(envelope => {
-			if (envelope.action.type === ActionType.SessionCustomizationsChanged) {
-				this._sessionCustomizationsCache.set(envelope.channel, envelope.action.customizations);
+			if (envelope.action.type === ActionType.SessionCustomizationsChanged || envelope.action.type === ActionType.SessionCustomizationUpdated) {
 				this._onDidChange.fire();
 			}
 		}));
@@ -149,7 +147,8 @@ export class AgentCustomizationItemProvider extends Disposable implements ICusto
 			plugins.push({ item, nonce: customization.nonce, status: undefined, statusMessage: undefined, enabled: undefined, childGroupKey: REMOTE_HOST_GROUP, isBundleItem: false });
 		}
 		const sessionUri = this._resolveSessionUri(sessionResource);
-		const sessionCustomizations = this._sessionCustomizationsCache.get(sessionUri.toString()) ?? [];
+		const sessionState = this._connection.getSubscriptionUnmanaged(StateComponents.Session, sessionUri)?.value;
+		const sessionCustomizations = sessionState && !(sessionState instanceof Error) ? sessionState.customizations ?? [] : [];
 		for (const sessionCustomization of sessionCustomizations) {
 			const isBundleItem = isSyntheticBundle(sessionCustomization.customization);
 			const isClientSynced = sessionCustomization.clientId !== undefined;

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentCustomizationItemProvider.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentCustomizationItemProvider.ts
@@ -10,7 +10,7 @@ import { ResourceMap } from '../../../../../../base/common/map.js';
 import { extname } from '../../../../../../base/common/path.js';
 import { joinPath } from '../../../../../../base/common/resources.js';
 import { URI } from '../../../../../../base/common/uri.js';
-import { CustomizationStatus, type SessionCustomization, type AgentInfo, type CustomizationRef, type RootState } from '../../../../../../platform/agentHost/common/state/sessionState.js';
+import { CustomizationStatus, StateComponents, type SessionCustomization, type AgentInfo, type CustomizationRef, type RootState } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { ILogService } from '../../../../../../platform/log/common/log.js';
 import { ICustomizationItem, ICustomizationItemAction, ICustomizationItemProvider } from '../../../common/customizationHarnessService.js';
 import { PromptsStorage } from '../../../common/promptSyntax/service/promptsService.js';
@@ -38,8 +38,6 @@ export class AgentCustomizationItemProvider extends Disposable implements ICusto
 	/** Cache: pluginUri → last expansion (keyed by nonce so we re-fetch on content change). */
 	private readonly _expansionCache = new ResourceMap<{ nonce: string | undefined; children: readonly ICustomizationItem[] }>();
 
-	private readonly _sessionCustomizationsCache = new Map<string, SessionCustomization[]>();
-
 	constructor(
 		private readonly _agentInfo: AgentInfo,
 		private readonly _connection: IAgentConnection,
@@ -61,26 +59,7 @@ export class AgentCustomizationItemProvider extends Disposable implements ICusto
 		}));
 
 		this._register(this._connection.onDidAction(envelope => {
-			if (envelope.action.type === ActionType.SessionCustomizationsChanged) {
-				this._sessionCustomizationsCache.set(envelope.channel, [...envelope.action.customizations]);
-				this._onDidChange.fire();
-			} else if (envelope.action.type === ActionType.SessionCustomizationUpdated) {
-				const current = this._sessionCustomizationsCache.get(envelope.channel) ?? [];
-				const { customization, enabled, status, statusMessage } = envelope.action;
-				const index = current.findIndex(c => c.customization.uri === customization.uri);
-				if (index === -1) {
-					current.push({ customization, enabled: enabled ?? false, status, statusMessage });
-				} else {
-					const existing = current[index];
-					current[index] = {
-						...existing,
-						customization,
-						enabled: enabled ?? existing.enabled,
-						status: status ?? existing.status,
-						statusMessage: statusMessage ?? existing.statusMessage,
-					};
-				}
-				this._sessionCustomizationsCache.set(envelope.channel, current);
+			if (envelope.action.type === ActionType.SessionCustomizationsChanged || envelope.action.type === ActionType.SessionCustomizationUpdated) {
 				this._onDidChange.fire();
 			}
 		}));
@@ -168,7 +147,8 @@ export class AgentCustomizationItemProvider extends Disposable implements ICusto
 			plugins.push({ item, nonce: customization.nonce, status: undefined, statusMessage: undefined, enabled: undefined, childGroupKey: REMOTE_HOST_GROUP, isBundleItem: false });
 		}
 		const sessionUri = this._resolveSessionUri(sessionResource);
-		const sessionCustomizations = this._sessionCustomizationsCache.get(sessionUri.toString()) ?? [];
+		const sessionState = this._connection.getSubscriptionUnmanaged(StateComponents.Session, sessionUri)?.value;
+		const sessionCustomizations = sessionState && !(sessionState instanceof Error) ? sessionState.customizations ?? [] : [];
 		for (const sessionCustomization of sessionCustomizations) {
 			const isBundleItem = isSyntheticBundle(sessionCustomization.customization);
 			const isClientSynced = sessionCustomization.clientId !== undefined;

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
@@ -6,6 +6,7 @@
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { Disposable, DisposableMap, DisposableStore, toDisposable } from '../../../../../../base/common/lifecycle.js';
 import { Event } from '../../../../../../base/common/event.js';
+import { equals } from '../../../../../../base/common/objects.js';
 import { observableValue } from '../../../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { localize } from '../../../../../../nls.js';
@@ -212,6 +213,9 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 		const customizations = observableValue<CustomizationRef[]>('agentCustomizations', []);
 		const updateCustomizations = async () => {
 			const refs = await resolveCustomizationRefs(this._promptsService, syncProvider, this._agentPluginService, bundler, sessionType);
+			if (equals(customizations.get(), refs)) {
+				return;
+			}
 			customizations.set(refs, undefined);
 		};
 		store.add(syncProvider.onDidChange(() => updateCustomizations()));

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -23,7 +23,7 @@ import { AgentFeedbackAttachmentDisplayKind, AgentFeedbackAttachmentMetadataKey 
 import { IAgentSubscription, observableFromSubscription } from '../../../../../../platform/agentHost/common/state/agentSubscription.js';
 import { SessionTruncatedAction } from '../../../../../../platform/agentHost/common/state/protocol/actions.js';
 import { CompletionItemKind as AhpCompletionItemKind, type CompletionItem as AhpCompletionItem } from '../../../../../../platform/agentHost/common/state/protocol/commands.js';
-import { ConfirmationOptionKind, CustomizationRef, TerminalClaimKind, ToolResultContentType, type ConfirmationOption, type ProtectedResourceMetadata, type ToolDefinition } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
+import { ConfirmationOptionKind, CustomizationRef, TerminalClaimKind, ToolResultContentType, type ConfirmationOption, type ProtectedResourceMetadata, type SessionActiveClient, type ToolDefinition } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
 import { ActionType, SessionTurnStartedAction, type ClientSessionAction, type SessionAction, type SessionInputCompletedAction } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
 import { AHP_AUTH_REQUIRED, ProtocolError } from '../../../../../../platform/agentHost/common/state/sessionProtocol.js';
 import { buildSubagentSessionUri, getToolFileEdits, getToolSubagentContent, MessageAttachmentKind, PendingMessageKind, ResponsePartKind, SessionInputAnswerState, SessionInputAnswerValueKind, SessionInputQuestionKind, SessionInputResponseKind, StateComponents, ToolCallCancellationReason, ToolCallConfirmationReason, ToolCallStatus, TurnState, type ICompletedToolCall, type MarkdownResponsePart, type MessageAttachment, type ModelSelection, type ReasoningResponsePart, type RootState, type SessionInputAnswer, type SessionInputRequest, type SessionState, type ToolCallResponsePart, type ToolCallState, type Turn, type UsageInfo } from '../../../../../../platform/agentHost/common/state/sessionState.js';
@@ -479,17 +479,15 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			},
 		));
 
-		// When the customizations observable changes, re-dispatch
-		// activeClientChanged for sessions where this client is already
-		// the active client. This avoids overwriting another client's
-		// active status on sessions we're only observing.
+		// When this client's exposed customization list changes, update sessions
+		// where this client is already active without reclaiming observed sessions.
 		if (config.customizations) {
 			this._register(autorun(reader => {
 				const refs = config.customizations!.read(reader);
 				for (const [sessionResource] of this._activeSessions) {
 					const backendSession = this._resolveSessionUri(sessionResource);
 					const state = this._getSessionState(backendSession.toString());
-					if (state?.activeClient?.clientId === this._config.connection.clientId) {
+					if (state?.activeClient?.clientId === this._config.connection.clientId && !equals(state.activeClient.customizations ?? [], refs)) {
 						this._dispatchActiveClient(backendSession, refs);
 					}
 				}
@@ -655,10 +653,6 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			} catch (err) {
 				this._logService.warn(`[AgentHost] Failed to subscribe to existing session: ${resolvedSession.toString()}`, err);
 			}
-
-			// Claim the active client role with current customizations
-			const customizations = this._config.customizations?.get() ?? [];
-			this._dispatchActiveClient(resolvedSession, customizations);
 		}
 		const session = this._instantiationService.createInstance(
 			AgentHostChatSession,
@@ -813,12 +807,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 				});
 			}
 
-			// Claim the active-client role and publish current tools +
-			// customizations. The eager `connection.createSession` from the
-			// sessions provider couldn't include them because the handler
-			// owns them; this dispatch is the equivalent of the
-			// `activeClient` parameter on the legacy createSession call.
-			this._dispatchActiveClient(resolvedSession, this._config.customizations?.get() ?? []);
+			this._ensureActiveClientForMessage(resolvedSession);
 		}
 
 		const completedTurn = await this._handleTurn(resolvedSession, request, progress, cancellationToken);
@@ -941,6 +930,23 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		this._config.connection.dispatch(channel.toString(), action);
 	}
 
+	private _getCurrentActiveClient(customizations: CustomizationRef[] = this._config.customizations?.get() ?? []): SessionActiveClient {
+		return {
+			clientId: this._config.connection.clientId,
+			tools: this._clientToolsObs.get().map(toolDataToDefinition),
+			customizations,
+		};
+	}
+
+	private _ensureActiveClientForMessage(backendSession: URI): void {
+		const state = this._getSessionState(backendSession.toString());
+		const activeClient = this._getCurrentActiveClient();
+		if (equals(state?.activeClient, activeClient)) {
+			return;
+		}
+		this._dispatchActiveClient(backendSession, activeClient.customizations ?? []);
+	}
+
 	/**
 	 * Dispatches `session/activeClientChanged` to claim the active client
 	 * role for this session and publish the current customizations and
@@ -949,11 +955,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 	private _dispatchActiveClient(backendSession: URI, customizations: CustomizationRef[]): void {
 		this._dispatchAction(backendSession, {
 			type: ActionType.SessionActiveClientChanged,
-			activeClient: {
-				clientId: this._config.connection.clientId,
-				tools: this._clientToolsObs.get().map(toolDataToDefinition),
-				customizations,
-			},
+			activeClient: this._getCurrentActiveClient(customizations),
 		});
 	}
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -4425,6 +4425,132 @@ suite('AgentHostChatContribution', () => {
 			assert.strictEqual(ac.activeClient.customizations?.length, 1);
 			assert.strictEqual(ac.activeClient.customizations?.[0].uri, 'file:///plugin-b');
 		});
+
+		test('does not dispatch activeClientChanged when an existing session is restored', async () => {
+			const { instantiationService, agentHostService } = createTestServices(disposables);
+			const sessionResource = AgentSession.uri('copilot', 'existing-session');
+			const summary: SessionSummary = {
+				resource: sessionResource.toString(),
+				provider: 'copilot',
+				title: 'Test',
+				status: SessionStatus.Idle,
+				createdAt: Date.now(),
+				modifiedAt: Date.now(),
+			};
+			agentHostService.sessionStates.set(sessionResource.toString(), {
+				...createSessionState(summary),
+				lifecycle: SessionLifecycle.Ready,
+				activeClient: {
+					clientId: 'other-client',
+					tools: [],
+				},
+			});
+
+			const sessionHandler = disposables.add(instantiationService.createInstance(AgentHostSessionHandler, {
+				provider: 'copilot' as const,
+				agentId: 'agent-host-copilot',
+				sessionType: 'agent-host-copilot',
+				fullName: 'Agent Host - Copilot',
+				description: 'test',
+				connection: agentHostService,
+				connectionAuthority: 'local',
+			}));
+
+			const chatSession = await sessionHandler.provideChatSessionContent(sessionResource, CancellationToken.None);
+			disposables.add(toDisposable(() => chatSession.dispose()));
+
+			assert.strictEqual(
+				agentHostService.dispatchedActions.filter(d => d.action.type === 'session/activeClientChanged').length,
+				0,
+			);
+		});
+
+		test('dispatches activeClientChanged before sending a message when another client is active', async () => {
+			const { instantiationService, agentHostService, chatAgentService } = createTestServices(disposables);
+			const sessionResource = AgentSession.uri('copilot', 'existing-session');
+			const summary: SessionSummary = {
+				resource: sessionResource.toString(),
+				provider: 'copilot',
+				title: 'Test',
+				status: SessionStatus.Idle,
+				createdAt: Date.now(),
+				modifiedAt: Date.now(),
+			};
+			agentHostService.sessionStates.set(sessionResource.toString(), {
+				...createSessionState(summary),
+				lifecycle: SessionLifecycle.Ready,
+				activeClient: {
+					clientId: 'other-client',
+					tools: [],
+				},
+			});
+
+			const sessionHandler = disposables.add(instantiationService.createInstance(AgentHostSessionHandler, {
+				provider: 'copilot' as const,
+				agentId: 'agent-host-copilot',
+				sessionType: 'agent-host-copilot',
+				fullName: 'Agent Host - Copilot',
+				description: 'test',
+				connection: agentHostService,
+				connectionAuthority: 'local',
+			}));
+
+			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables, { sessionResource });
+			fire({ type: 'session/turnComplete', session, turnId } as SessionAction);
+			await turnPromise;
+
+			const activeClientActions = agentHostService.dispatchedActions.filter(d => d.action.type === 'session/activeClientChanged');
+			assert.strictEqual(activeClientActions.length, 1);
+			assert.strictEqual(activeClientActions[0].channel, sessionResource.toString());
+		});
+
+		test('dispatches activeClientChanged before sending a message when current client customizations are stale', async () => {
+			const { instantiationService, agentHostService, chatAgentService } = createTestServices(disposables);
+			const customizations = observableValue<CustomizationRef[]>('customizations', [
+				{ uri: 'file:///plugin-new', displayName: 'Plugin New' },
+			]);
+			const sessionResource = AgentSession.uri('copilot', 'existing-session');
+			const summary: SessionSummary = {
+				resource: sessionResource.toString(),
+				provider: 'copilot',
+				title: 'Test',
+				status: SessionStatus.Idle,
+				createdAt: Date.now(),
+				modifiedAt: Date.now(),
+			};
+			agentHostService.sessionStates.set(sessionResource.toString(), {
+				...createSessionState(summary),
+				lifecycle: SessionLifecycle.Ready,
+				activeClient: {
+					clientId: agentHostService.clientId,
+					tools: [],
+					customizations: [{ uri: 'file:///plugin-old', displayName: 'Plugin Old' }],
+				},
+			});
+
+			const sessionHandler = disposables.add(instantiationService.createInstance(AgentHostSessionHandler, {
+				provider: 'copilot' as const,
+				agentId: 'agent-host-copilot',
+				sessionType: 'agent-host-copilot',
+				fullName: 'Agent Host - Copilot',
+				description: 'test',
+				connection: agentHostService,
+				connectionAuthority: 'local',
+				customizations,
+			}));
+
+			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables, { sessionResource });
+			fire({ type: 'session/turnComplete', session, turnId } as SessionAction);
+			await turnPromise;
+
+			const activeClientActions = agentHostService.dispatchedActions.filter(d => d.action.type === 'session/activeClientChanged');
+			assert.strictEqual(activeClientActions.length, 1);
+			const activeClientAction = activeClientActions[0].action;
+			assert.strictEqual(activeClientAction.type, 'session/activeClientChanged');
+			assert.deepStrictEqual(activeClientAction.activeClient?.customizations, [
+				{ uri: 'file:///plugin-new', displayName: 'Plugin New' },
+			]);
+		});
 	});
 
 	// ---- Subagent grouping ----------------------------------------------


### PR DESCRIPTION
agent-host: stop redundant customization sync events

Refactors customization syncing to publish state changes as SessionActions
through the session state manager rather than via a per-call progress callback
that emitted full lists each tick. Also avoids redundant `activeClientChanged`
dispatches that were driving large loops of customization/file requests across
the connection.

- `setClientCustomizations` now takes the session URI and publishes
  `SessionCustomizationsChanged` once with the resolved list, followed by
  `SessionCustomizationUpdated` actions only when an individual customization's
  state actually changes.
- `agentSideEffects` no longer wires its own progress callback; it lets the
  agent publish actions and forwards action signals into the state manager even
  when no turn is active so session-level state (customizations, title, config)
  stays consistent.
- `agentHostSessionHandler` no longer claims the active-client role on session
  restore, and only re-dispatches `activeClientChanged` when the local view of
  `activeClient` actually differs from the session state. The pre-send hook
  ensures the active client is current before sending a message.
- `agentCustomizationItemProvider` reads session customizations from the
  shared session subscription instead of caching them locally and re-firing on
  every customization update.
- Adds tests covering the no-redundant-dispatch behavior and the new progress
  publishing flow.

Fixes https://github.com/microsoft/vscode/issues/316538

(Commit message generated by Copilot)

