### PR TITLE
Fix 'undefined' reasoning effort default for non-claude/gpt models

### DIFF
--- a/extensions/copilot/src/extension/conversation/vscode-node/languageModelAccess.ts
+++ b/extensions/copilot/src/extension/conversation/vscode-node/languageModelAccess.ts
@@ -116,6 +116,9 @@ function buildConfigurationSchema(endpoint: IChatEndpoint): { configurationSchem
 		} else if (family.startsWith('gpt-')) {
 			defaultEffort = effortLevels.includes('medium') ? 'medium' : undefined;
 		}
+		if (!defaultEffort) {
+			defaultEffort = effortLevels[0];
+		}
 
 		properties.reasoningEffort = {
 			type: 'string',


### PR DESCRIPTION
Falls back to the first advertised effort level when the model family isn't claude/gpt, so models default to a real level instead of 'undefined' in the picker.

Fixes microsoft/vscode-internalbacklog#7762