### PR TITLE
sessions: use per-agent icon for agent host sessions

### DIFF
--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -898,7 +898,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			throw new Error(`Agent session URI has no provider scheme: ${meta.session.toString()}`);
 		}
 		return new AgentHostSessionAdapter(meta, this.id, this.resourceSchemeForProvider(provider), provider, {
-			icon: this.icon,
+			icon: this.iconForAgentProvider(provider) ?? this.icon,
 			loading: this.authenticationPending,
 			mapDiffUri: this._diffUriMapper(),
 			gitHubService: this._gitHubService,
@@ -1065,7 +1065,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			workspace,
 			sessionType,
 			providerId: this.id,
-			icon: this.icon,
+			icon: sessionType.icon,
 			resourceScheme: this.resourceSchemeForProvider(sessionType.id),
 			authenticationPending: this.authenticationPending,
 			logService: this._logService,

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
@@ -398,6 +398,27 @@ suite('LocalAgentHostSessionsProvider', () => {
 		);
 	});
 
+	test('session icons match the session type icon', () => {
+		agentHost.setAgents([
+			{ provider: 'copilotcli', displayName: 'Copilot', description: '', models: [] } as AgentInfo,
+			{ provider: 'claude-code', displayName: 'Claude', description: '', models: [] } as AgentInfo,
+			{ provider: 'unknown-agent', displayName: 'Unknown', description: '', models: [] } as AgentInfo,
+		]);
+		const provider = createProvider(disposables, agentHost);
+		fireSessionAdded(agentHost, 'cli-sess', { title: 'CLI', provider: 'copilotcli' });
+		fireSessionAdded(agentHost, 'claude-sess', { title: 'Claude', provider: 'claude-code' });
+		fireSessionAdded(agentHost, 'unknown-sess', { title: 'Unknown', provider: 'unknown-agent' });
+
+		assert.deepStrictEqual(
+			provider.getSessions().map(s => ({ sessionType: s.sessionType, icon: s.icon.id })).sort((a, b) => a.sessionType.localeCompare(b.sessionType)),
+			[
+				{ sessionType: 'claude-code', icon: 'claude' },
+				{ sessionType: 'copilotcli', icon: 'copilot' },
+				{ sessionType: 'unknown-agent', icon: 'vm' },
+			],
+		);
+	});
+
 	// ---- Workspace resolution -------
 
 	test('resolveWorkspace builds workspace from URI', () => {


### PR DESCRIPTION
Sessions surfaced by the agent host sessions provider were using the generic provider icon (`vm` for Local, `remote` for Remote) instead of the per-agent icon that the matching session type already uses (e.g. `copilot`, `claude`, `openai`).

This routes session-adapter creation and the in-flight new-session through the same `iconForAgentProvider` lookup that `_syncSessionTypesFromRootState` uses, so a session's icon always matches its session type.

### Changes
- `baseAgentHostSessionsProvider.ts`:
  - `createAdapter()` now passes `iconForAgentProvider(provider) ?? this.icon` to the adapter.
  - `createNewSession()` now forwards `sessionType.icon` to the in-flight `NewSession`.
- Added a test asserting per-session icons line up with their session type.