### PR TITLE
Default reasoning effort to first advertised level for unspecified families

### DIFF
--- a/extensions/copilot/src/extension/byok/vscode-node/byokModelInfo.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/byokModelInfo.ts
@@ -2,8 +2,9 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { l10n, type LanguageModelChatInformation, type LanguageModelConfigurationSchema } from 'vscode';
+import { type LanguageModelChatInformation, type LanguageModelConfigurationSchema } from 'vscode';
 import { BYOKKnownModels, BYOKModelCapabilities, byokKnownModelToAPIInfo } from '../common/byokProvider';
+import { buildReasoningEffortSchemaProperty } from '../../conversation/common/languageModelAccess';
 
 /**
  * Wraps {@link byokKnownModelToAPIInfo} and enriches the model entry with
@@ -33,32 +34,10 @@ export function byokKnownModelsToAPIInfoWithEffort(providerName: string, knownMo
 }
 
 function buildEffortConfigurationSchema(effortLevels: readonly string[], family: string): { configurationSchema?: LanguageModelConfigurationSchema } {
-	const lowerFamily = family.toLowerCase();
-	const preferred = lowerFamily.startsWith('claude') ? 'high' : 'medium';
-	const defaultEffort = effortLevels.includes(preferred) ? preferred : undefined;
-
 	return {
 		configurationSchema: {
 			properties: {
-				reasoningEffort: {
-					type: 'string',
-					title: l10n.t('Thinking Effort'),
-					enum: effortLevels,
-					enumItemLabels: effortLevels.map(level => level.charAt(0).toUpperCase() + level.slice(1)),
-					enumDescriptions: effortLevels.map(level => {
-						switch (level) {
-							case 'none': return l10n.t('No reasoning applied');
-							case 'minimal': return l10n.t('Minimal reasoning for fastest responses');
-							case 'low': return l10n.t('Faster responses with less reasoning');
-							case 'medium': return l10n.t('Balanced reasoning and speed');
-							case 'high': return l10n.t('Maximum reasoning depth');
-							case 'max': return l10n.t('Absolute maximum capability with no constraints');
-							default: return level;
-						}
-					}),
-					default: defaultEffort,
-					group: 'navigation',
-				}
+				reasoningEffort: buildReasoningEffortSchemaProperty(effortLevels, family),
 			}
 		}
 	};

--- a/extensions/copilot/src/extension/byok/vscode-node/byokModelInfo.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/byokModelInfo.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { type LanguageModelChatInformation, type LanguageModelConfigurationSchema } from 'vscode';
+import { type LanguageModelChatInformation } from 'vscode';
 import { BYOKKnownModels, BYOKModelCapabilities, byokKnownModelToAPIInfo } from '../common/byokProvider';
 import { buildReasoningEffortSchemaProperty } from '../../conversation/common/languageModelAccess';
 
@@ -19,7 +19,11 @@ export function byokKnownModelToAPIInfoWithEffort(providerName: string, id: stri
 	}
 	return {
 		...model,
-		...buildEffortConfigurationSchema(effortLevels, model.family),
+		configurationSchema: {
+			properties: {
+				reasoningEffort: buildReasoningEffortSchemaProperty(effortLevels, model.family),
+			},
+		},
 	};
 }
 
@@ -33,12 +37,3 @@ export function byokKnownModelsToAPIInfoWithEffort(providerName: string, knownMo
 	return Object.entries(knownModels).map(([id, capabilities]) => byokKnownModelToAPIInfoWithEffort(providerName, id, capabilities));
 }
 
-function buildEffortConfigurationSchema(effortLevels: readonly string[], family: string): { configurationSchema?: LanguageModelConfigurationSchema } {
-	return {
-		configurationSchema: {
-			properties: {
-				reasoningEffort: buildReasoningEffortSchemaProperty(effortLevels, family),
-			}
-		}
-	};
-}

--- a/extensions/copilot/src/extension/byok/vscode-node/test/byokModelInfo.spec.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/test/byokModelInfo.spec.ts
@@ -52,12 +52,12 @@ describe('byokKnownModelToAPIInfoWithEffort', () => {
 		expect((info as { configurationSchema?: { properties: { reasoningEffort: { default?: string } } } }).configurationSchema?.properties.reasoningEffort.default).toBe('high');
 	});
 
-	it('falls back to no default when the preferred level is not in the supported list', () => {
+	it('falls back to the first advertised level when the family has no explicit default', () => {
 		const info = byokKnownModelToAPIInfoWithEffort('TestProvider', 'grok-4', {
 			...baseCapabilities,
 			supportsReasoningEffort: ['low', 'high'],
 		});
 
-		expect((info as { configurationSchema?: { properties: { reasoningEffort: { default?: string } } } }).configurationSchema?.properties.reasoningEffort.default).toBeUndefined();
+		expect((info as { configurationSchema?: { properties: { reasoningEffort: { default?: string } } } }).configurationSchema?.properties.reasoningEffort.default).toBe('low');
 	});
 });

--- a/extensions/copilot/src/extension/conversation/common/languageModelAccess.ts
+++ b/extensions/copilot/src/extension/conversation/common/languageModelAccess.ts
@@ -6,7 +6,58 @@
 
 import { IChatEndpoint, IChatEndpointTokenPricing } from '../../../platform/networking/common/networking';
 import * as l10n from '@vscode/l10n';
-import type { LanguageModelChatInformation } from 'vscode';
+import type { LanguageModelChatInformation, LanguageModelConfigurationSchema } from 'vscode';
+
+/**
+ * Picks a sensible default reasoning-effort level given the levels advertised
+ * by an endpoint and the model `family`. The picker must never receive
+ * `undefined`, otherwise the UI shows an "undefined" state.
+ *
+ * Selection order:
+ *  - claude families  → 'high' if available
+ *  - other families   → 'medium' if available
+ *  - fallback         → the first advertised level
+ */
+export function pickDefaultReasoningEffort(effortLevels: readonly string[], family: string): string | undefined {
+	if (effortLevels.length === 0) {
+		return undefined;
+	}
+	const lowerFamily = family.toLowerCase();
+	const preferred = lowerFamily.startsWith('claude') ? 'high' : 'medium';
+	if (effortLevels.includes(preferred)) {
+		return preferred;
+	}
+	return effortLevels[0];
+}
+
+/**
+ * Builds the `reasoningEffort` property descriptor for a model's
+ * {@link LanguageModelConfigurationSchema}. Centralises the default-selection
+ * and localized descriptions so the picker stays consistent across the
+ * Copilot and BYOK code paths.
+ */
+export function buildReasoningEffortSchemaProperty(effortLevels: readonly string[], family: string): NonNullable<LanguageModelConfigurationSchema['properties']>[string] {
+	return {
+		type: 'string',
+		title: l10n.t('Thinking Effort'),
+		enum: effortLevels,
+		enumItemLabels: effortLevels.map(level => level.charAt(0).toUpperCase() + level.slice(1)),
+		enumDescriptions: effortLevels.map(level => {
+			switch (level) {
+				case 'none': return l10n.t('No reasoning applied');
+				case 'minimal': return l10n.t('Minimal reasoning for fastest responses');
+				case 'low': return l10n.t('Faster responses with less reasoning');
+				case 'medium': return l10n.t('Balanced reasoning and speed');
+				case 'high': return l10n.t('Greater reasoning depth but slower');
+				case 'xhigh': return l10n.t('Highest reasoning depth but slowest');
+				case 'max': return l10n.t('Absolute maximum capability with no constraints');
+				default: return level;
+			}
+		}),
+		default: pickDefaultReasoningEffort(effortLevels, family),
+		group: 'navigation',
+	};
+}
 
 /**
  * Returns a description of the model's capabilities and intended use cases.

--- a/extensions/copilot/src/extension/conversation/vscode-node/languageModelAccess.ts
+++ b/extensions/copilot/src/extension/conversation/vscode-node/languageModelAccess.ts
@@ -43,7 +43,7 @@ import { IExtensionContribution } from '../../common/contributions';
 import { PromptRenderer } from '../../prompts/node/base/promptRenderer';
 import { isImageDataPart } from '../common/languageModelChatMessageHelpers';
 import { LanguageModelAccessPrompt } from './languageModelAccessPrompt';
-import { formatPricingLabel, getModelCapabilitiesDescription } from '../common/languageModelAccess';
+import { formatPricingLabel, getModelCapabilitiesDescription, buildReasoningEffortSchemaProperty } from '../common/languageModelAccess';
 
 /**
  * Markers in the autoModelHint experiment variable that indicate the auto model
@@ -97,47 +97,12 @@ function buildConfigurationSchema(endpoint: IChatEndpoint): { configurationSchem
 		return {};
 	}
 
-	const properties: Record<string, {
-		type: string;
-		title: string;
-		enum: readonly (string | number)[];
-		enumItemLabels: string[];
-		enumDescriptions: string[];
-		default?: string | number;
-		group: string;
-	}> = {};
+	const properties: Record<string, NonNullable<vscode.LanguageModelConfigurationSchema['properties']>[string]> = {};
 
 	// Reasoning effort config
 	const effortLevels = endpoint.supportsReasoningEffort;
 	if (effortLevels && effortLevels.length > 1) {
-		let defaultEffort: string | undefined;
-		if (family.startsWith('claude')) {
-			defaultEffort = effortLevels.includes('high') ? 'high' : undefined;
-		} else if (family.startsWith('gpt-')) {
-			defaultEffort = effortLevels.includes('medium') ? 'medium' : undefined;
-		}
-		if (!defaultEffort) {
-			defaultEffort = effortLevels[0];
-		}
-
-		properties.reasoningEffort = {
-			type: 'string',
-			title: vscode.l10n.t('Thinking Effort'),
-			enum: effortLevels,
-			enumItemLabels: effortLevels.map(level => level.charAt(0).toUpperCase() + level.slice(1)),
-			enumDescriptions: effortLevels.map(level => {
-				switch (level) {
-					case 'none': return vscode.l10n.t('No reasoning applied');
-					case 'low': return vscode.l10n.t('Faster responses with less reasoning');
-					case 'medium': return vscode.l10n.t('Balanced reasoning and speed');
-					case 'high': return vscode.l10n.t('Greater reasoning depth but slower');
-					case 'xhigh': return vscode.l10n.t('Highest reasoning depth but slowest');
-					default: return level;
-				}
-			}),
-			default: defaultEffort,
-			group: 'navigation',
-		};
+		properties.reasoningEffort = buildReasoningEffortSchemaProperty(effortLevels, family);
 	}
 
 	// Context size config

--- a/extensions/copilot/src/extension/conversation/vscode-node/languageModelAccess.ts
+++ b/extensions/copilot/src/extension/conversation/vscode-node/languageModelAccess.ts
@@ -116,6 +116,9 @@ function buildConfigurationSchema(endpoint: IChatEndpoint): { configurationSchem
 		} else if (family.startsWith('gpt-')) {
 			defaultEffort = effortLevels.includes('medium') ? 'medium' : undefined;
 		}
+		if (!defaultEffort) {
+			defaultEffort = effortLevels[0];
+		}
 
 		properties.reasoningEffort = {
 			type: 'string',

--- a/extensions/copilot/src/extension/conversation/vscode-node/test/languageModelAccess.test.ts
+++ b/extensions/copilot/src/extension/conversation/vscode-node/test/languageModelAccess.test.ts
@@ -25,6 +25,7 @@ import { Event } from '../../../../util/vs/base/common/event';
 import { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
 import { createExtensionTestingServices } from '../../../test/vscode-node/services';
 import { buildUtilityAliasModelInfo, CopilotLanguageModelWrapper, LanguageModelAccess } from '../languageModelAccess';
+import { buildReasoningEffortSchemaProperty, pickDefaultReasoningEffort } from '../../common/languageModelAccess';
 
 
 suite('CopilotLanguageModelWrapper', () => {
@@ -354,5 +355,34 @@ suite('buildUtilityAliasModelInfo', () => {
 		// upper bound to assert the subtraction happened without re-importing
 		// the constant in the test.
 		assert.ok(result.info.maxInputTokens! < 32_000 - 100, `expected maxInputTokens to subtract baseCount and completion reserve, got ${result.info.maxInputTokens}`);
+	});
+});
+
+suite('reasoning effort schema', () => {
+	test('claude family prefers high when available', () => {
+		assert.strictEqual(pickDefaultReasoningEffort(['low', 'medium', 'high'], 'claude-sonnet-4'), 'high');
+	});
+
+	test('non-claude family prefers medium when available', () => {
+		assert.strictEqual(pickDefaultReasoningEffort(['low', 'medium', 'high'], 'gpt-5'), 'medium');
+		assert.strictEqual(pickDefaultReasoningEffort(['low', 'medium', 'high'], 'some-other-family'), 'medium');
+	});
+
+	test('falls back to first advertised level when preferred is missing', () => {
+		// Claude without 'high' → first
+		assert.strictEqual(pickDefaultReasoningEffort(['low', 'medium'], 'claude-haiku'), 'low');
+		// Other family without 'medium' → first
+		assert.strictEqual(pickDefaultReasoningEffort(['low', 'high'], 'unknown-family'), 'low');
+	});
+
+	test('returns undefined for empty levels', () => {
+		assert.strictEqual(pickDefaultReasoningEffort([], 'gpt-5'), undefined);
+	});
+
+	test('buildReasoningEffortSchemaProperty always sets a concrete default for non-empty levels', () => {
+		const prop = buildReasoningEffortSchemaProperty(['low', 'high'], 'unknown-family');
+		assert.strictEqual(prop.default, 'low', 'expected first advertised level, never undefined');
+		assert.deepStrictEqual(prop.enum, ['low', 'high']);
+		assert.strictEqual(prop.group, 'navigation');
 	});
 });


### PR DESCRIPTION
Falls back to the first advertised effort level when the model family doesn't have an explicit default, so the picker shows a real level instead of 'undefined'.