### PR TITLE
Fix git extension not working when repo root is "/" (chroot)

### DIFF
--- a/extensions/git/src/test/git.test.ts
+++ b/extensions/git/src/test/git.test.ts
@@ -6,7 +6,7 @@
 import 'mocha';
 import { GitStatusParser, parseGitCommits, parseGitmodules, parseLsTree, parseLsFiles, parseGitRemotes, parseCoAuthors } from '../git';
 import * as assert from 'assert';
-import { splitInChunks } from '../util';
+import { splitInChunks, isDescendant, pathEquals, relativePath } from '../util';
 
 suite('git', () => {
 	suite('GitStatusParser', () => {
@@ -641,6 +641,51 @@ suite('git', () => {
 				parseCoAuthors('Fix bug\n\nSigned-off-by: Admin <admin@corp.com>\nCo-authored-by: Jane Doe <jane@example.com>'),
 				[{ name: 'Jane Doe', email: 'jane@example.com' }]
 			);
+		});
+	});
+
+	suite('isDescendant', () => {
+		test('regular paths', function () {
+			if (process.platform !== 'win32') {
+				assert.strictEqual(isDescendant('/foo', '/foo/bar'), true);
+				assert.strictEqual(isDescendant('/foo/', '/foo/bar'), true);
+				assert.strictEqual(isDescendant('/foo', '/bar/baz'), false);
+				assert.strictEqual(isDescendant('/foo', '/foo'), true);
+			}
+		});
+
+		test('root path "/" (chroot environments)', function () {
+			if (process.platform !== 'win32') {
+				assert.strictEqual(isDescendant('/', '/foo'), true);
+				assert.strictEqual(isDescendant('/', '/foo/bar'), true);
+				assert.strictEqual(isDescendant('/', '/'), true);
+			}
+		});
+	});
+
+	suite('pathEquals', () => {
+		test('regular paths', function () {
+			if (process.platform !== 'win32') {
+				assert.strictEqual(pathEquals('/foo', '/foo'), true);
+				assert.strictEqual(pathEquals('/foo/', '/foo'), true);
+				assert.strictEqual(pathEquals('/foo', '/bar'), false);
+			}
+		});
+
+		test('root path "/"', function () {
+			if (process.platform !== 'win32') {
+				assert.strictEqual(pathEquals('/', '/'), true);
+				assert.strictEqual(pathEquals('/', '/foo'), false);
+			}
+		});
+	});
+
+	suite('relativePath', () => {
+		test('root path "/" as base (chroot environments)', function () {
+			if (process.platform !== 'win32') {
+				assert.strictEqual(relativePath('/', '/foo'), 'foo');
+				assert.strictEqual(relativePath('/', '/foo/bar'), 'foo/bar');
+			}
 		});
 	});
 

--- a/extensions/git/src/util.ts
+++ b/extensions/git/src/util.ts
@@ -313,8 +313,9 @@ function normalizePath(path: string): string {
 	}
 
 	// Trailing separator
-	if (/[/\\]$/.test(path)) {
-		// Remove trailing separator
+	if (path.length > 1 && /[/\\]$/.test(path)) {
+		// Remove trailing separator, but preserve root paths
+		// (e.g., "/" on Linux/macOS or "C:\" on Windows)
 		path = path.substring(0, path.length - 1);
 	}
 

--- a/extensions/git/src/util.ts
+++ b/extensions/git/src/util.ts
@@ -313,9 +313,9 @@ function normalizePath(path: string): string {
 	}
 
 	// Trailing separator
-	if (path.length > 1 && /[/\\]$/.test(path)) {
-		// Remove trailing separator, but preserve root paths
-		// (e.g., "/" on Linux/macOS or "C:\" on Windows)
+	if (path !== dirname(path) && /[/\\]$/.test(path)) {
+		// Remove trailing separators from non-root paths, while preserving
+		// filesystem roots such as "/" on Linux/macOS and "C:\" or UNC roots on Windows.
 		path = path.substring(0, path.length - 1);
 	}
 


### PR DESCRIPTION
## Problem

When working in a chroot environment where the project/repository root is `/`, the git extension fails silently — discard changes, diffs, and staging all break.

**Root cause:** The `normalizePath()` function in `extensions/git/src/util.ts` unconditionally strips trailing path separators. When the path is `/` (root), stripping the trailing `/` produces an empty string `""`, which `path.normalize("")` converts to `"."`. This breaks both `isDescendant()` and `pathEquals()`:

```javascript
// Before fix:
normalizePath("/")  → "."     // WRONG — should be "/"
isDescendant("/", "/foo")  → false  // WRONG — should be true
```

As a result, the git extension cannot match files to their repository when the repository root is `/`.

## Fix

Add a `path.length > 1` guard before stripping the trailing separator, preserving root paths (`/` on Linux/macOS):

```javascript
// After fix:
normalizePath("/")  → "/"     // Correct
isDescendant("/", "/foo")  → true  // Correct
```

This is consistent with how the core VS Code `removeTrailingPathSeparator()` in `src/vs/base/common/extpath.ts` already handles this case.

## Testing

- Added unit tests for `isDescendant`, `pathEquals`, and `relativePath` covering the root path `/` scenario.
- Verified compilation passes with 0 errors.
- Verified old behavior was broken and new behavior is correct.


