### PR TITLE
test(mcp): silence sinon FakeTimers native-timer warning in sampling log tests

### DIFF
--- a/src/vs/workbench/contrib/mcp/test/common/mcpSamplingLog.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpSamplingLog.test.ts
@@ -30,7 +30,11 @@ suite('MCP - Sampling Log', () => {
 	setup(() => {
 		storage = ds.add(new TestStorageService());
 		log = ds.add(new McpSamplingLog(storage));
-		clock = sinon.useFakeTimers();
+		// `shouldClearNativeTimers` silently absorbs `clearTimeout` calls for
+		// native timer IDs scheduled outside the fake clock (e.g. by cross-test
+		// background schedulers) instead of emitting a `console.warn` that would
+		// fail the renderer's no-console-output assertion.
+		clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
 		clock.setSystemTime(new Date('2023-10-01T00:00:00Z').getTime());
 	});
 

--- a/src/vs/workbench/contrib/mcp/test/common/mcpSamplingLog.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpSamplingLog.test.ts
@@ -33,8 +33,11 @@ suite('MCP - Sampling Log', () => {
 		// `shouldClearNativeTimers` silently absorbs `clearTimeout` calls for
 		// native timer IDs scheduled outside the fake clock (e.g. by cross-test
 		// background schedulers) instead of emitting a `console.warn` that would
-		// fail the renderer's no-console-output assertion.
-		clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
+		// fail the renderer's no-console-output assertion. The option exists in
+		// @sinonjs/fake-timers but is missing from the @types/sinon typings, so
+		// we widen the config type locally.
+		const fakeTimerOpts: Partial<sinon.SinonFakeTimersConfig> & { shouldClearNativeTimers: boolean } = { shouldClearNativeTimers: true };
+		clock = sinon.useFakeTimers(fakeTimerOpts);
 		clock.setSystemTime(new Date('2023-10-01T00:00:00Z').getTime());
 	});
 


### PR DESCRIPTION
Fixes the flaky failure seen in [Insider build 440965](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=440965&view=logs&j=e352877c-ff47-5dec-32e2-b206099d9704&t=65ec82f4-0572-5637-164d-da46c15920ac) (macOS → Electron Tests):

```
1) "after each" hook for "handles different content types":
   AssertionError [ERR_ASSERTION]: Error: Unexpected console output in test run.
   Please ensure no console.[log|error|info|warn] usage in tests or runtime errors.
       at Context.<anonymous> (renderer.js:298:11)
```

The actual `MCP - Sampling Log > handles different content types` test passed (✔). The `afterEach` hook in `test/unit/electron/renderer.js` failed because Sinon's FakeTimers library wrote to the console during the run:

```
FakeTimers: clearTimeout was invoked to clear a native timer instead of one
created by this library.
To automatically clean-up native timers, use `shouldClearNativeTimers`.
```

This happens when `clearTimeout` is called with a native timer ID while the fake clock is installed — typically a cross-test interaction where a timer scheduled outside this suite is cleaned up while sinon's fake `clearTimeout` is active.

This PR passes `{ shouldClearNativeTimers: true }` to `sinon.useFakeTimers()` in the suite, which tells the library to silently delegate such calls to the real `clearTimeout` instead of emitting `console.warn`. It eliminates the spurious failure without changing any test behavior.

Verified locally: `scripts/test.bat --run src/vs/workbench/contrib/mcp/test/common/mcpSamplingLog.test.ts` → 7 passing.
