### PR TITLE
Chronicle: handle policy-blocked and rate-limited responses gracefully

### DIFF
--- a/extensions/copilot/src/extension/chronicle/common/cloudSessionTypes.ts
+++ b/extensions/copilot/src/extension/chronicle/common/cloudSessionTypes.ts
@@ -91,9 +91,14 @@ export interface WorkingDirectoryContext {
 }
 
 /** Reason why session creation failed. */
-export type CreateSessionFailureReason = 'policy_blocked' | 'error';
+export type CreateSessionFailureReason = 'policy_blocked' | 'rate_limited' | 'error';
 
 /** Result of attempting to create a cloud session. */
 export type CreateSessionResult =
 	| { ok: true; response: CreateSessionResponse }
 	| { ok: false; reason: CreateSessionFailureReason };
+
+/** Result of attempting to submit a batch of session events. */
+export type SubmitSessionEventsResult =
+	| { ok: true }
+	| { ok: false; reason: 'policy_blocked' | 'rate_limited' | 'error' };

--- a/extensions/copilot/src/extension/chronicle/node/cloudSessionApiClient.ts
+++ b/extensions/copilot/src/extension/chronicle/node/cloudSessionApiClient.ts
@@ -7,7 +7,7 @@ import { IAuthenticationService } from '../../../platform/authentication/common/
 import { ICopilotTokenManager } from '../../../platform/authentication/common/copilotTokenManager';
 import { INTEGRATION_ID } from '../../../platform/endpoint/common/licenseAgreement';
 import { IFetcherService } from '../../../platform/networking/common/fetcherService';
-import type { CreateSessionFailureReason, CreateSessionResult, CloudSession, SessionEvent } from '../common/cloudSessionTypes';
+import type { CreateSessionFailureReason, CreateSessionResult, CloudSession, SessionEvent, SubmitSessionEventsResult } from '../common/cloudSessionTypes';
 
 /** Timeout for individual cloud API requests (ms). */
 const REQUEST_TIMEOUT_MS = 10_000;
@@ -88,7 +88,7 @@ export class CloudSessionApiClient {
 		indexingLevel: 'user' | 'repo_and_user' = 'user',
 	): Promise<CreateSessionResult> {
 		if (this._isRateLimited()) {
-			return { ok: false, reason: 'error' };
+			return { ok: false, reason: 'rate_limited' };
 		}
 		try {
 			const { url, headers } = await this._buildRequest(SESSIONS_PATH);
@@ -113,7 +113,7 @@ export class CloudSessionApiClient {
 
 			if (res.status === 429) {
 				this._handleRateLimit(res, 'createSession');
-				return { ok: false, reason: 'error' };
+				return { ok: false, reason: 'rate_limited' };
 			}
 
 			if (!res.ok) {
@@ -130,19 +130,20 @@ export class CloudSessionApiClient {
 
 	/**
 	 * Submit a batch of events to a session.
-	 * @returns true if the submission succeeded.
+	 * @returns ok on success, or a failure reason distinguishing policy-blocked
+	 *          responses from generic/transient errors.
 	 */
 	async submitSessionEvents(
 		sessionId: string,
 		events: SessionEvent[],
-	): Promise<boolean> {
+	): Promise<SubmitSessionEventsResult> {
 		if (this._isRateLimited()) {
-			return false;
+			return { ok: false, reason: 'rate_limited' };
 		}
 		try {
 			const { url, headers } = await this._buildRequest(`${SESSIONS_PATH}/${sessionId}/events`);
 			if (!url) {
-				return false;
+				return { ok: false, reason: 'error' };
 			}
 
 			const res = await this._fetcherService.fetch(url, {
@@ -155,16 +156,17 @@ export class CloudSessionApiClient {
 
 			if (res.status === 429) {
 				this._handleRateLimit(res, 'submitEvents');
-				return false;
+				return { ok: false, reason: 'rate_limited' };
 			}
 
 			if (!res.ok) {
-				return false;
+				const reason: 'policy_blocked' | 'error' = res.status === 403 ? 'policy_blocked' : 'error';
+				return { ok: false, reason };
 			}
 
-			return true;
+			return { ok: true };
 		} catch (err) {
-			return false;
+			return { ok: false, reason: 'error' };
 		}
 	}
 

--- a/extensions/copilot/src/extension/chronicle/node/cloudSessionApiClient.ts
+++ b/extensions/copilot/src/extension/chronicle/node/cloudSessionApiClient.ts
@@ -53,7 +53,7 @@ export class CloudSessionApiClient {
 	) { }
 
 	/** Returns true if we're currently rate-limited and should skip requests. */
-	private _isRateLimited(): boolean {
+	isRateLimited(): boolean {
 		return Date.now() < this._rateLimitedUntil;
 	}
 
@@ -87,7 +87,7 @@ export class CloudSessionApiClient {
 		sessionId: string,
 		indexingLevel: 'user' | 'repo_and_user' = 'user',
 	): Promise<CreateSessionResult> {
-		if (this._isRateLimited()) {
+		if (this.isRateLimited()) {
 			return { ok: false, reason: 'rate_limited' };
 		}
 		try {
@@ -137,7 +137,7 @@ export class CloudSessionApiClient {
 		sessionId: string,
 		events: SessionEvent[],
 	): Promise<SubmitSessionEventsResult> {
-		if (this._isRateLimited()) {
+		if (this.isRateLimited()) {
 			return { ok: false, reason: 'rate_limited' };
 		}
 		try {
@@ -174,7 +174,7 @@ export class CloudSessionApiClient {
 	 * Get a session by ID (used for reattach verification).
 	 */
 	async getSession(sessionId: string): Promise<CloudSession | undefined> {
-		if (this._isRateLimited()) {
+		if (this.isRateLimited()) {
 			return undefined;
 		}
 		try {
@@ -211,7 +211,7 @@ export class CloudSessionApiClient {
 	 */
 	async listSessions(): Promise<Array<{ id: string; task_id?: string; agent_task_id?: string; agent_id?: number; state: string; created_at: string }>> {
 		const allSessions: Array<{ id: string; task_id?: string; agent_task_id?: string; agent_id?: number; state: string; created_at: string }> = [];
-		if (this._isRateLimited()) {
+		if (this.isRateLimited()) {
 			return allSessions;
 		}
 		const pageSize = 100;
@@ -272,7 +272,7 @@ export class CloudSessionApiClient {
 	 * treated as success), or 'error' on failure.
 	 */
 	async deleteSession(taskId: string): Promise<'deleted' | 'not_found' | 'error'> {
-		if (this._isRateLimited()) {
+		if (this.isRateLimited()) {
 			return 'error';
 		}
 		try {
@@ -311,7 +311,7 @@ export class CloudSessionApiClient {
 	 * Single API call that queues all eligible sessions for reindexing.
 	 */
 	async backfillAnalytics(indexingLevel: 'user' | 'repo_and_user'): Promise<{ ok: true; sessionsQueued: number } | { ok: false }> {
-		if (this._isRateLimited()) {
+		if (this.isRateLimited()) {
 			return { ok: false };
 		}
 		try {

--- a/extensions/copilot/src/extension/chronicle/node/sessionReindexer.ts
+++ b/extensions/copilot/src/extension/chronicle/node/sessionReindexer.ts
@@ -489,7 +489,7 @@ async function reindexOneCloudSession(
 		const chunk = batch.slice(i, i + MAX_EVENTS_PER_UPLOAD);
 		const filtered = chunk.map(e => filterSecretsFromObj(e));
 		const success = await cloudClient.submitSessionEvents(cloudSessionId, filtered);
-		if (success) {
+		if (success.ok) {
 			uploaded += chunk.length;
 		} else {
 			uploadFailed = true;

--- a/extensions/copilot/src/extension/chronicle/node/test/cloudSessionApiClient.spec.ts
+++ b/extensions/copilot/src/extension/chronicle/node/test/cloudSessionApiClient.spec.ts
@@ -1,0 +1,127 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it, vi } from 'vitest';
+import type { IAuthenticationService } from '../../../../platform/authentication/common/authentication';
+import type { ICopilotTokenManager } from '../../../../platform/authentication/common/copilotTokenManager';
+import type { IFetcherService } from '../../../../platform/networking/common/fetcherService';
+import { CloudSessionApiClient } from '../cloudSessionApiClient';
+
+function createMockServices() {
+	const tokenManager: ICopilotTokenManager = {
+		_serviceBrand: undefined as any,
+		getCopilotToken: vi.fn(async () => ({
+			token: 'test-token',
+			endpoints: { api: 'https://api.test.com' },
+		})),
+	} as any;
+
+	const authService: IAuthenticationService = {
+		_serviceBrand: undefined as any,
+		anyGitHubSession: { accessToken: 'gh-token' },
+	} as any;
+
+	const fetcherService: IFetcherService = {
+		_serviceBrand: undefined as any,
+		fetch: vi.fn(),
+	} as any;
+
+	return { tokenManager, authService, fetcherService };
+}
+
+function makeFetchResponse(status: number, body: unknown = {}): { ok: boolean; status: number; headers: { get: (n: string) => string | null }; json: () => Promise<unknown> } {
+	return {
+		ok: status >= 200 && status < 300,
+		status,
+		headers: { get: () => null },
+		json: async () => body,
+	};
+}
+
+describe('CloudSessionApiClient', () => {
+	describe('createSession', () => {
+		it('returns ok with response on success', async () => {
+			const { tokenManager, authService, fetcherService } = createMockServices();
+			(fetcherService.fetch as any).mockResolvedValue(makeFetchResponse(200, { id: 'sess-1', task_id: 'task-1' }));
+
+			const client = new CloudSessionApiClient(tokenManager, authService, fetcherService);
+			const result = await client.createSession(1, 2, 'local-1');
+
+			expect(result).toEqual({ ok: true, response: { id: 'sess-1', task_id: 'task-1' } });
+		});
+
+		it('maps HTTP 403 to policy_blocked', async () => {
+			const { tokenManager, authService, fetcherService } = createMockServices();
+			(fetcherService.fetch as any).mockResolvedValue(makeFetchResponse(403));
+
+			const client = new CloudSessionApiClient(tokenManager, authService, fetcherService);
+			const result = await client.createSession(1, 2, 'local-1');
+
+			expect(result).toEqual({ ok: false, reason: 'policy_blocked' });
+		});
+
+		it('maps other 4xx/5xx to error', async () => {
+			const { tokenManager, authService, fetcherService } = createMockServices();
+			(fetcherService.fetch as any).mockResolvedValue(makeFetchResponse(500));
+
+			const client = new CloudSessionApiClient(tokenManager, authService, fetcherService);
+			const result = await client.createSession(1, 2, 'local-1');
+
+			expect(result).toEqual({ ok: false, reason: 'error' });
+		});
+
+		it('maps HTTP 429 to rate_limited', async () => {
+			const { tokenManager, authService, fetcherService } = createMockServices();
+			(fetcherService.fetch as any).mockResolvedValue(makeFetchResponse(429));
+
+			const client = new CloudSessionApiClient(tokenManager, authService, fetcherService);
+			const result = await client.createSession(1, 2, 'local-1');
+
+			expect(result).toEqual({ ok: false, reason: 'rate_limited' });
+		});
+	});
+
+	describe('submitSessionEvents', () => {
+		it('returns ok on success', async () => {
+			const { tokenManager, authService, fetcherService } = createMockServices();
+			(fetcherService.fetch as any).mockResolvedValue(makeFetchResponse(200));
+
+			const client = new CloudSessionApiClient(tokenManager, authService, fetcherService);
+			const result = await client.submitSessionEvents('sess-1', []);
+
+			expect(result).toEqual({ ok: true });
+		});
+
+		it('maps HTTP 403 to policy_blocked', async () => {
+			const { tokenManager, authService, fetcherService } = createMockServices();
+			(fetcherService.fetch as any).mockResolvedValue(makeFetchResponse(403));
+
+			const client = new CloudSessionApiClient(tokenManager, authService, fetcherService);
+			const result = await client.submitSessionEvents('sess-1', []);
+
+			expect(result).toEqual({ ok: false, reason: 'policy_blocked' });
+		});
+
+		it('maps other 4xx/5xx to error', async () => {
+			const { tokenManager, authService, fetcherService } = createMockServices();
+			(fetcherService.fetch as any).mockResolvedValue(makeFetchResponse(500));
+
+			const client = new CloudSessionApiClient(tokenManager, authService, fetcherService);
+			const result = await client.submitSessionEvents('sess-1', []);
+
+			expect(result).toEqual({ ok: false, reason: 'error' });
+		});
+
+		it('maps HTTP 429 to rate_limited', async () => {
+			const { tokenManager, authService, fetcherService } = createMockServices();
+			(fetcherService.fetch as any).mockResolvedValue(makeFetchResponse(429));
+
+			const client = new CloudSessionApiClient(tokenManager, authService, fetcherService);
+			const result = await client.submitSessionEvents('sess-1', []);
+
+			expect(result).toEqual({ ok: false, reason: 'rate_limited' });
+		});
+	});
+});

--- a/extensions/copilot/src/extension/chronicle/node/test/sessionReindexer.spec.ts
+++ b/extensions/copilot/src/extension/chronicle/node/test/sessionReindexer.spec.ts
@@ -363,7 +363,7 @@ function createMockCloudClient(overrides: Partial<CloudSessionApiClient> = {}): 
 			ok: true,
 			response: { id: 'cloud-session-1', task_id: 'task-1' },
 		}),
-		submitSessionEvents: vi.fn().mockResolvedValue(true),
+		submitSessionEvents: vi.fn().mockResolvedValue({ ok: true }),
 		backfillAnalytics: vi.fn().mockResolvedValue({ ok: true, sessionsQueued: 5 }),
 		listSessions: vi.fn().mockResolvedValue([]),
 		getSession: vi.fn().mockResolvedValue(undefined),

--- a/extensions/copilot/src/extension/chronicle/vscode-node/remoteSessionExporter.ts
+++ b/extensions/copilot/src/extension/chronicle/vscode-node/remoteSessionExporter.ts
@@ -54,6 +54,9 @@ const MAX_BUFFER_SIZE = 1_000;
 /** Soft cap — switch to faster drain. */
 const SOFT_BUFFER_CAP = 500;
 
+/** Time to suppress further cloud session creates for an owner after a policy-blocked response. */
+const POLICY_BLOCKED_TTL_MS = 60 * 60 * 1000;
+
 /**
  * Exports VS Code chat session events to the cloud in real-time.
  *
@@ -87,6 +90,12 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 
 	/** Sessions currently initializing (prevent concurrent init). */
 	private readonly _initializingSessions = new Set<string>();
+
+	/** Per-owner expiry (epoch ms) suppressing further createCloudSession attempts after a policy_blocked response. */
+	private readonly _policyBlockedUntilByOwner = new Map<number, number>();
+
+	/** Whether the policy-blocked notification has been shown this window. */
+	private _policyNotificationShown = false;
 
 	// ── Shared state ─────────────────────────────────────────────────────────────
 
@@ -800,14 +809,15 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 						"error": { "classification": "CallstackOrException", "purpose": "PerformanceAndHealth", "comment": "Truncated error message if failed." },
 						"indexingLevel": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "The indexing level for the session." },
 						"droppedEvents": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "comment": "Number of events in a failed batch." },
-						"reason": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Reason session was disabled (no_consent, no_repo, init_error, create_error)." },
+						"reason": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Reason session was disabled (no_consent, no_repo, init_error, create_error, policy_blocked_cached)." },
 						"transition": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Circuit breaker state transition (open, closed)." },
 						"eventsCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Number of actually submitted events (sum of eventsBySession sizes)." },
 						"orphanedCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Number of orphaned events not submitted (re-queued or dropped)." },
 						"batchDurationMs": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "comment": "Time to submit batch in ms." },
 						"bufferSize": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "comment": "Buffer size at time of event." },
 						"failureCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "comment": "Consecutive failure count." },
-						"droppedCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "comment": "Events dropped due to buffer overflow." }
+						"droppedCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "comment": "Events dropped due to buffer overflow." },
+						"sessionCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "comment": "Number of cloud sessions affected by a policy-blocked or rate-limited response in a flush batch." }
 					}
 				*/
 				this._telemetryService.sendMSFTTelemetryEvent('chronicle.cloudSync', {
@@ -827,6 +837,15 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 					operation: 'sessionDisabled',
 					sessionSource,
 					reason: 'no_consent',
+				});
+				return;
+			}
+			if (this._isOwnerPolicyBlocked(repo.repoIds.ownerId)) {
+				this._disabledSessions.add(sessionId);
+				this._telemetryService.sendMSFTTelemetryEvent('chronicle.cloudSync', {
+					operation: 'sessionDisabled',
+					sessionSource,
+					reason: 'policy_blocked_cached',
 				});
 				return;
 			}
@@ -870,6 +889,10 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 
 		for (const sessionId of this._translationStates.keys()) {
 			if (!this._cloudSessions.has(sessionId) && !this._disabledSessions.has(sessionId)) {
+				if (this._isOwnerPolicyBlocked(repo.repoIds.ownerId)) {
+					this._disabledSessions.add(sessionId);
+					continue;
+				}
 				await this._createCloudSession(sessionId, repo, level);
 			}
 		}
@@ -894,7 +917,14 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 				success: 'false',
 				error: result.reason?.substring(0, 100) ?? 'unknown',
 			}, {});
-			this._disabledSessions.add(sessionId);
+			if (result.reason === 'policy_blocked') {
+				this._disabledSessions.add(sessionId);
+				this._markOwnerPolicyBlocked(repo.repoIds.ownerId);
+			} else if (result.reason !== 'rate_limited') {
+				// Rate limits are transient and self-recover via the client's backoff;
+				// leave the session uninitialized so a later flush can retry.
+				this._disabledSessions.add(sessionId);
+			}
 			return;
 		}
 
@@ -921,6 +951,35 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 			success: 'true',
 			indexingLevel,
 		});
+	}
+
+	/** Returns true if the owner is currently within the policy-blocked TTL window. */
+	private _isOwnerPolicyBlocked(ownerId: number): boolean {
+		const expiry = this._policyBlockedUntilByOwner.get(ownerId);
+		if (expiry === undefined) {
+			return false;
+		}
+		if (Date.now() >= expiry) {
+			this._policyBlockedUntilByOwner.delete(ownerId);
+			return false;
+		}
+		return true;
+	}
+
+	/** Record a policy-blocked response for an owner and show the user a one-time notification. */
+	private _markOwnerPolicyBlocked(ownerId: number): void {
+		this._policyBlockedUntilByOwner.set(ownerId, Date.now() + POLICY_BLOCKED_TTL_MS);
+		this._showPolicyBlockedNotification();
+	}
+
+	private _showPolicyBlockedNotification(): void {
+		if (this._policyNotificationShown) {
+			return;
+		}
+		this._policyNotificationShown = true;
+		void vscode.window.showInformationMessage(
+			vscode.l10n.t('Cloud sync for chat session insights is disabled for this workspace by your organization\'s policy.')
+		);
 	}
 
 	/**
@@ -1062,15 +1121,22 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 
 		try {
 			// Group events by chat session ID for correct cloud session routing
-			const eventsBySession = new Map<string, SessionEvent[]>();
+			const eventsBySession = new Map<string, { events: SessionEvent[]; chatSessionIds: Set<string> }>();
 			const orphanedEntries: typeof batch = [];
 
 			for (const entry of batch) {
 				const cloudIds = this._cloudSessions.get(entry.chatSessionId);
 				if (cloudIds) {
-					const arr = eventsBySession.get(cloudIds.cloudSessionId) ?? [];
-					arr.push(entry.event);
-					eventsBySession.set(cloudIds.cloudSessionId, arr);
+					const slot = eventsBySession.get(cloudIds.cloudSessionId);
+					if (slot) {
+						slot.events.push(entry.event);
+						slot.chatSessionIds.add(entry.chatSessionId);
+					} else {
+						eventsBySession.set(cloudIds.cloudSessionId, {
+							events: [entry.event],
+							chatSessionIds: new Set([entry.chatSessionId]),
+						});
+					}
 				} else {
 					orphanedEntries.push(entry);
 				}
@@ -1089,16 +1155,35 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 			}
 
 			// Submit each session's events to the correct cloud session
-			let allSuccess = true;
+			let hadTransientError = false;
+			let policyBlockedSessions = 0;
+			let rateLimitedSessions = 0;
 			let submittedCount = 0;
-			for (const [cloudSessionId, events] of eventsBySession) {
-				submittedCount += events.length;
-				const filteredEvents = events.map(e => filterSecretsFromObj(e));
-				const success = await this._cloudClient.submitSessionEvents(cloudSessionId, filteredEvents);
-				if (!success) {
-					allSuccess = false;
+			for (const [cloudSessionId, slot] of eventsBySession) {
+				submittedCount += slot.events.length;
+				const filteredEvents = slot.events.map(e => filterSecretsFromObj(e));
+				const result = await this._cloudClient.submitSessionEvents(cloudSessionId, filteredEvents);
+				if (result.ok) {
+					continue;
+				}
+				if (result.reason === 'policy_blocked') {
+					policyBlockedSessions++;
+					// Disable the affected chat session(s) so further events are dropped.
+					for (const chatSessionId of slot.chatSessionIds) {
+						this._disabledSessions.add(chatSessionId);
+					}
+					if (this._repository) {
+						this._markOwnerPolicyBlocked(this._repository.repoIds.ownerId);
+					}
+				} else if (result.reason === 'rate_limited') {
+					// Client is already self-backing-off; don't trip the circuit breaker.
+					rateLimitedSessions++;
+				} else {
+					hadTransientError = true;
 				}
 			}
+
+			const allSuccess = !hadTransientError && policyBlockedSessions === 0 && rateLimitedSessions === 0;
 
 			if (allSuccess && eventsBySession.size > 0) {
 				this._circuitBreaker.recordSuccess();
@@ -1120,7 +1205,7 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 						sessionSource: this._firstCloudWriteSessionSource ?? 'unknown',
 					}, {});
 				}
-			} else if (!allSuccess) {
+			} else if (hadTransientError) {
 				this._circuitBreaker.recordFailure();
 				this._setSyncState({ kind: 'error' });
 
@@ -1135,7 +1220,24 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 				});
 			}
 
-			if (allSuccess) {
+			if (policyBlockedSessions > 0) {
+				// Policy responses are expected — do not count as circuit breaker failures.
+				this._telemetryService.sendMSFTTelemetryEvent('chronicle.cloudSync', {
+					operation: 'policyBlocked',
+				}, {
+					sessionCount: policyBlockedSessions,
+				});
+			}
+
+			if (rateLimitedSessions > 0) {
+				this._telemetryService.sendMSFTTelemetryEvent('chronicle.cloudSync', {
+					operation: 'rateLimited',
+				}, {
+					sessionCount: rateLimitedSessions,
+				});
+			}
+
+			if (!hadTransientError) {
 				this._setSyncState({ kind: 'up-to-date', syncedCount: this._getLocalSyncedCount() });
 			}
 		} catch (err) {

--- a/extensions/copilot/src/extension/chronicle/vscode-node/remoteSessionExporter.ts
+++ b/extensions/copilot/src/extension/chronicle/vscode-node/remoteSessionExporter.ts
@@ -91,6 +91,9 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 	/** Sessions currently initializing (prevent concurrent init). */
 	private readonly _initializingSessions = new Set<string>();
 
+	/** Sessions whose cloud-session creation was rate-limited; awaiting retry on a later flush. */
+	private readonly _rateLimitedSessions = new Set<string>();
+
 	/** Per-owner expiry (epoch ms) suppressing further createCloudSession attempts after a policy_blocked response. */
 	private readonly _policyBlockedUntilByOwner = new Map<number, number>();
 
@@ -319,6 +322,7 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 		this._translationStates.clear();
 		this._disabledSessions.clear();
 		this._initializingSessions.clear();
+		this._rateLimitedSessions.clear();
 
 		super.dispose();
 	}
@@ -550,6 +554,7 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 					this._cloudSessions.delete(session.id);
 					this._translationStates.delete(session.id);
 					this._disabledSessions.delete(session.id);
+					this._rateLimitedSessions.delete(session.id);
 				}
 			},
 		);
@@ -623,6 +628,7 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 			this._cloudSessions.delete(sessionId);
 			this._translationStates.delete(sessionId);
 			this._disabledSessions.delete(sessionId);
+			this._rateLimitedSessions.delete(sessionId);
 		}
 		this._invalidateLocalSyncedCount();
 		this._setSyncState({ kind: 'up-to-date', syncedCount: this._getLocalSyncedCount() });
@@ -718,7 +724,9 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 			// typically complete before their parent, and using a sub-agent span as the
 			// init trigger would seed sessionSource/firstCloudWriteSessionSource and
 			// telemetry from the sub-agent's AGENT_NAME instead of the parent's.
-			if (!this._cloudSessions.has(sessionId) && !this._initializingSessions.has(sessionId)) {
+			if (!this._cloudSessions.has(sessionId)
+				&& !this._initializingSessions.has(sessionId)
+				&& !this._rateLimitedSessions.has(sessionId)) {
 				if (operationName !== GenAiOperationName.INVOKE_AGENT || subagentId) {
 					return;
 				}
@@ -912,18 +920,33 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 
 		if (!result.ok) {
 
-			this._telemetryService.sendMSFTTelemetryErrorEvent('chronicle.cloudSync', {
-				operation: 'createCloudSession',
-				success: 'false',
-				error: result.reason?.substring(0, 100) ?? 'unknown',
-			}, {});
 			if (result.reason === 'policy_blocked') {
+				this._telemetryService.sendMSFTTelemetryEvent('chronicle.cloudSync', {
+					operation: 'policyBlocked',
+				}, {
+					sessionCount: 1,
+				});
 				this._disabledSessions.add(sessionId);
+				this._rateLimitedSessions.delete(sessionId);
 				this._markOwnerPolicyBlocked(repo.repoIds.ownerId);
-			} else if (result.reason !== 'rate_limited') {
-				// Rate limits are transient and self-recover via the client's backoff;
-				// leave the session uninitialized so a later flush can retry.
+			} else if (result.reason === 'rate_limited') {
+				this._telemetryService.sendMSFTTelemetryEvent('chronicle.cloudSync', {
+					operation: 'rateLimited',
+				}, {
+					sessionCount: 1,
+				});
+				// Transient — the client is self-backing-off. Mark for retry so
+				// buffered events for this session are not dropped as orphans
+				// and a later flush will reattempt initialization.
+				this._rateLimitedSessions.add(sessionId);
+			} else {
+				this._telemetryService.sendMSFTTelemetryErrorEvent('chronicle.cloudSync', {
+					operation: 'createCloudSession',
+					success: 'false',
+					error: result.reason?.substring(0, 100) ?? 'unknown',
+				}, {});
 				this._disabledSessions.add(sessionId);
+				this._rateLimitedSessions.delete(sessionId);
 			}
 			return;
 		}
@@ -935,6 +958,7 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 				error: 'missing_task_id',
 			}, {});
 			this._disabledSessions.add(sessionId);
+			this._rateLimitedSessions.delete(sessionId);
 			return;
 		}
 
@@ -944,6 +968,7 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 		};
 
 		this._cloudSessions.set(sessionId, cloudIds);
+		this._rateLimitedSessions.delete(sessionId);
 		this._invalidateLocalSyncedCount();
 
 		this._telemetryService.sendMSFTTelemetryEvent('chronicle.cloudSync', {
@@ -1037,6 +1062,7 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 		this._translationStates.delete(sessionId);
 		this._disabledSessions.delete(sessionId);
 		this._initializingSessions.delete(sessionId);
+		this._rateLimitedSessions.delete(sessionId);
 		// Keep _cloudSessions entry — the cloud session ID mapping is needed
 		// for future delete operations (e.g. sidebar delete fires after dispose).
 	}
@@ -1113,6 +1139,14 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 			return;
 		}
 
+		// Skip the whole flush while the client is in rate-limit backoff. Calls
+		// would short-circuit anyway, but doing nothing here avoids the
+		// splice/unshift churn on each timer tick. _bufferEvents still enforces
+		// MAX_BUFFER_SIZE so memory stays bounded.
+		if (this._cloudClient.isRateLimited()) {
+			return;
+		}
+
 		this._isFlushing = true;
 		const batch = this._eventBuffer.splice(0, MAX_EVENTS_PER_FLUSH);
 		const batchStart = Date.now();
@@ -1121,7 +1155,7 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 
 		try {
 			// Group events by chat session ID for correct cloud session routing
-			const eventsBySession = new Map<string, { events: SessionEvent[]; chatSessionIds: Set<string> }>();
+			const eventsBySession = new Map<string, { events: SessionEvent[]; chatSessionIds: Set<string>; entries: typeof batch }>();
 			const orphanedEntries: typeof batch = [];
 
 			for (const entry of batch) {
@@ -1131,14 +1165,31 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 					if (slot) {
 						slot.events.push(entry.event);
 						slot.chatSessionIds.add(entry.chatSessionId);
+						slot.entries.push(entry);
 					} else {
 						eventsBySession.set(cloudIds.cloudSessionId, {
 							events: [entry.event],
 							chatSessionIds: new Set([entry.chatSessionId]),
+							entries: [entry],
 						});
 					}
 				} else {
 					orphanedEntries.push(entry);
+				}
+			}
+
+			// Retry cloud-session creation for any session previously marked
+			// rate-limited that now has buffered events. The client short-circuits
+			// while still in backoff, so this is cheap when the limit hasn't lifted.
+			if (this._rateLimitedSessions.size > 0 && this._repository) {
+				const repo = this._repository;
+				const level = this._indexingPreference.getStorageLevel(`${repo.owner}/${repo.repo}`);
+				const pending = new Set(orphanedEntries.map(e => e.chatSessionId));
+				const toRetry = [...this._rateLimitedSessions].filter(id =>
+					pending.has(id) && !this._initializingSessions.has(id)
+				);
+				for (const sessionId of toRetry) {
+					await this._createCloudSession(sessionId, repo, level);
 				}
 			}
 
@@ -1147,7 +1198,9 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 			if (orphanedEntries.length > 0) {
 				const requeue = orphanedEntries.filter(e =>
 					!this._disabledSessions.has(e.chatSessionId)
-					&& (this._initializingSessions.has(e.chatSessionId) || this._cloudSessions.has(e.chatSessionId))
+					&& (this._initializingSessions.has(e.chatSessionId)
+						|| this._cloudSessions.has(e.chatSessionId)
+						|| this._rateLimitedSessions.has(e.chatSessionId))
 				);
 				if (requeue.length > 0) {
 					this._eventBuffer.unshift(...requeue);
@@ -1159,6 +1212,7 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 			let policyBlockedSessions = 0;
 			let rateLimitedSessions = 0;
 			let submittedCount = 0;
+			const requeueOnRateLimit: typeof batch = [];
 			for (const [cloudSessionId, slot] of eventsBySession) {
 				submittedCount += slot.events.length;
 				const filteredEvents = slot.events.map(e => filterSecretsFromObj(e));
@@ -1177,10 +1231,16 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 					}
 				} else if (result.reason === 'rate_limited') {
 					// Client is already self-backing-off; don't trip the circuit breaker.
+					// Requeue the unsent events so they're retried after the backoff.
 					rateLimitedSessions++;
+					requeueOnRateLimit.push(...slot.entries);
 				} else {
 					hadTransientError = true;
 				}
+			}
+
+			if (requeueOnRateLimit.length > 0) {
+				this._eventBuffer.unshift(...requeueOnRateLimit);
 			}
 
 			const allSuccess = !hadTransientError && policyBlockedSessions === 0 && rateLimitedSessions === 0;


### PR DESCRIPTION
Fixes #317331

Chronicle's session sync treats every non-2xx from /agents/sessions as a transient error, so users whose org blocks chronicle by policy (HTTP 403) generate a continuous stream of failed-request telemetry and trip the circuit breaker on every chat session start. Rate-limit responses (429) get the same reaction even though the client already self-throttles.

#### Changes
- API client now returns a discriminated { ok: false; reason: 'policy_blocked' | 'rate_limited' | 'error' } for both createSession and submitSessionEvents (403 → policy_blocked, 429 → rate_limited).

- On policy_blocked, the owner ID is cached for 1 hour; subsequent session inits short-circuit with reason: 'policy_blocked_cached' and a one-time user notification is shown.

- policy_blocked and rate_limited no longer trip the circuit breaker; rate_limited from createSession leaves the session uninitialized so a later flush can retry.