### PR TITLE
sessions: retry restore when provider session list changes

### DIFF
--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -725,6 +725,11 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 				};
 
 				disposables.add(this.sessionsProvidersService.onDidChangeProviders(() => tryRestore()));
+				// Also retry when a provider's session list changes. Providers
+				// like the agent host load their session cache asynchronously
+				// (after authentication settles), so the target session may
+				// appear without `onDidChangeProviders` ever firing again.
+				disposables.add(this.onDidChangeSessions(() => tryRestore()));
 
 				// Call immediately in case the session became available between the
 				// initial getSession check above and the listener registration here.

--- a/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
@@ -249,5 +249,57 @@ suite('SessionsManagementService', () => {
 		// The active session should remain unchanged
 		assert.strictEqual(service.activeSession.get()?.sessionId, 'original');
 	});
+
+	test('restoreLastActiveSession waits for session to appear via onDidChangeSessions', async () => {
+		const targetSession = stubSession({ sessionId: 'target', providerId: 'test' });
+		const onDidChangeSessions = disposables.add(new Emitter<ISessionChangeEvent>());
+
+		let sessions: ISession[] = [];
+		const provider = new class extends TestSessionsProvider {
+			override readonly onDidChangeSessions = onDidChangeSessions.event;
+			constructor() { super(targetSession); }
+			override getSessions(): ISession[] { return sessions; }
+		};
+
+		const instantiationService = disposables.add(new TestInstantiationService());
+		const chatWidgetService = new TestChatWidgetService();
+		const agentSessionsService = new TestAgentSessionsService();
+
+		// Seed storage so the management service treats `targetSession` as the
+		// last active session and tries to restore it on startup.
+		const storage = disposables.add(new InMemoryStorageService());
+		storage.store(
+			'agentSessions.activeSessionStates',
+			JSON.stringify([{ sessionResource: targetSession.resource.toString(), isActive: true }]),
+			1 /* StorageScope.WORKSPACE */,
+			1 /* StorageTarget.MACHINE */,
+		);
+
+		instantiationService.stub(IStorageService, storage);
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(IContextKeyService, disposables.add(new MockContextKeyService()));
+		instantiationService.stub(ISessionsProvidersService, new TestSessionsProvidersService([provider]));
+		instantiationService.stub(IUriIdentityService, { extUri: extUriBiasedIgnorePathCase });
+		instantiationService.stub(IChatWidgetService, chatWidgetService);
+		instantiationService.stub(IAgentSessionsService, agentSessionsService);
+		instantiationService.stub(IProgressService, new TestProgressService());
+
+		const service = disposables.add(instantiationService.createInstance(SessionsManagementService));
+
+		// At this point the provider does not yet know about the session
+		// (mimicking an agent host provider whose cache has not loaded yet).
+		const restorePromise = service.restoreLastActiveSession();
+		await Promise.resolve();
+		assert.deepStrictEqual(chatWidgetService.opened.map(uri => uri.toString()), []);
+
+		// Now the provider learns about the session and fires its change event.
+		// `onDidChangeProviders` does NOT fire here — only the per-provider
+		// session change event — so the fix must subscribe to it as well.
+		sessions = [targetSession];
+		onDidChangeSessions.fire({ added: [targetSession], removed: [], changed: [] });
+
+		await restorePromise;
+		assert.deepStrictEqual(chatWidgetService.opened.map(uri => uri.toString()), [targetSession.resource.toString()]);
+	});
 });
 


### PR DESCRIPTION
sessions: retry restore when provider session list changes

Fixes a hang where reloading a window with an agent host session active leaves the
Agents view stuck in a loading state.

- restoreLastActiveSession only re-ran its tryRestore loop on
  sessionsProvidersService.onDidChangeProviders. Providers (notably the local agent
  host) are registered once at startup and then populate their session cache
  asynchronously after authenticationPending settles, firing onDidChangeSessions but
  not onDidChangeProviders. The restore promise therefore never resolved.
- Also subscribe to this.onDidChangeSessions so the retry fires when a provider's
  session list changes after registration.
- Adds a regression test that pre-seeds the active-session state, starts restore with
  an empty provider cache, then fires onDidChangeSessions and asserts the session opens.

(Commit message generated by Copilot)