### PR TITLE
FIx: show error message when running npm install without open workspace

### DIFF
--- a/.vscode/extensions/vscode-extras/src/npmUpToDateFeature.ts
+++ b/.vscode/extensions/vscode-extras/src/npmUpToDateFeature.ts
@@ -93,7 +93,7 @@ export class NpmUpToDateFeature extends vscode.Disposable {
 		}
 		const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri;
 		if (!workspaceRoot) {
-			vscode.window.showErrorMessage('npm install requires an open workspace folder');
+			void vscode.window.showErrorMessage('npm install requires an open workspace folder');
 			return;
 		}
 		this._terminal = vscode.window.createTerminal({ name: 'npm install', cwd: workspaceRoot });

--- a/.vscode/extensions/vscode-extras/src/npmUpToDateFeature.ts
+++ b/.vscode/extensions/vscode-extras/src/npmUpToDateFeature.ts
@@ -93,6 +93,7 @@ export class NpmUpToDateFeature extends vscode.Disposable {
 		}
 		const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri;
 		if (!workspaceRoot) {
+			vscode.window.showErrorMessage('npm install requires an open workspace folder');
 			return;
 		}
 		this._terminal = vscode.window.createTerminal({ name: 'npm install', cwd: workspaceRoot });


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Description
Fixes a silent failure where running `_runNpmInstall()` did nothing if a user did not have a folder open in the workspace. Added a clear error message utilizing `vscode.window.showErrorMessage` to provide immediate feedback to the user.

 How to Test
1. Close all open folders/workspaces in VS Code.
2. Trigger the `vscode-extras.runNpmInstall` command (via the status bar or command palette).
3. Verify that a native VS Code error notification appears stating: *"npm install requires an open workspace folder"*.
4. Open a workspace folder, run the command again, and verify that the terminal spawns and runs the install script normally.