### PR TITLE
fix(otel): deduplicate system prompt between gen_ai.system_instructions and gen_ai.input.messages

### DIFF
--- a/extensions/copilot/src/extension/byok/vscode-node/anthropicProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/anthropicProvider.ts
@@ -16,7 +16,7 @@ import { ContextManagementResponse, CUSTOM_TOOL_SEARCH_NAME, getContextManagemen
 import { IToolDeferralService } from '../../../platform/networking/common/toolDeferralService';
 import { IResponseDelta, OpenAiFunctionTool } from '../../../platform/networking/common/fetch';
 import { APIUsage } from '../../../platform/networking/common/openai';
-import { CopilotChatAttr, emitInferenceDetailsEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, GenAiProviderName, type OTelModelOptions, StdAttr, toToolDefinitions, truncateForOTel } from '../../../platform/otel/common/index';
+import { CopilotChatAttr, emitInferenceDetailsEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, GenAiProviderName, type OTelModelOptions, StdAttr, toSystemInstructions, toToolDefinitions, truncateForOTel } from '../../../platform/otel/common/index';
 import { IOTelService, SpanKind, SpanStatusCode } from '../../../platform/otel/common/otelService';
 import { IRequestLogger } from '../../../platform/requestLogger/common/requestLogger';
 import { retrieveCapturingTokenByCorrelation, runWithCapturingToken } from '../../../platform/requestLogger/node/requestLogger';
@@ -506,9 +506,24 @@ export class AnthropicLMProvider extends AbstractLanguageModelChatProvider {
 				}
 				try {
 					const roleNames: Record<number, string> = { 1: 'user', 2: 'assistant', 3: 'system' };
-					const inputMsgs = messages.map(m => {
+					const systemTexts: string[] = [];
+					const inputMsgs: Array<{ role: string; parts: Array<{ type: string; content?: string | unknown; id?: string; name?: string; arguments?: unknown; response?: unknown }> }> = [];
+					for (const m of messages) {
 						const msg = m as LanguageModelChatMessage;
 						const role = roleNames[msg.role] ?? String(msg.role);
+						// System messages are emitted via gen_ai.system_instructions only — keeping them
+						// in gen_ai.input.messages causes trace viewers to render the system prompt twice
+						// (issue #299932). Collect their text into the dedicated attribute and skip the entry.
+						if (role === 'system') {
+							if (Array.isArray(msg.content)) {
+								for (const p of msg.content) {
+									if (p instanceof LanguageModelTextPart) {
+										systemTexts.push(p.value);
+									}
+								}
+							}
+							continue;
+						}
 						const parts: Array<{ type: string; content?: string | unknown; id?: string; name?: string; arguments?: unknown; response?: unknown }> = [];
 						if (Array.isArray(msg.content)) {
 							for (const p of msg.content) {
@@ -525,8 +540,12 @@ export class AnthropicLMProvider extends AbstractLanguageModelChatProvider {
 						if (parts.length === 0) {
 							parts.push({ type: 'text', content: '[non-text content]' });
 						}
-						return { role, parts };
-					});
+						inputMsgs.push({ role, parts });
+					}
+					const systemInstructions = toSystemInstructions(systemTexts);
+					if (systemInstructions) {
+						otelSpan.setAttribute(GenAiAttr.SYSTEM_INSTRUCTIONS, truncateForOTel(JSON.stringify(systemInstructions), this._otelService.config.maxAttributeSizeChars));
+					}
 					otelSpan.setAttribute(GenAiAttr.INPUT_MESSAGES, truncateForOTel(JSON.stringify(inputMsgs), this._otelService.config.maxAttributeSizeChars));
 				} catch { /* swallow */ }
 			}

--- a/extensions/copilot/src/extension/byok/vscode-node/geminiNativeProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/geminiNativeProvider.ts
@@ -10,7 +10,7 @@ import { ILogService } from '../../../platform/log/common/logService';
 import { IResponseDelta, OpenAiFunctionTool } from '../../../platform/networking/common/fetch';
 import { APIUsage } from '../../../platform/networking/common/openai';
 import { CustomDataPartMimeTypes } from '../../../platform/endpoint/common/endpointTypes';
-import { CopilotChatAttr, emitInferenceDetailsEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, GenAiProviderName, type OTelModelOptions, StdAttr, toToolDefinitions, truncateForOTel } from '../../../platform/otel/common/index';
+import { CopilotChatAttr, emitInferenceDetailsEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, GenAiProviderName, type OTelModelOptions, StdAttr, toSystemInstructions, toToolDefinitions, truncateForOTel } from '../../../platform/otel/common/index';
 import { IOTelService, SpanKind, SpanStatusCode } from '../../../platform/otel/common/otelService';
 import { IRequestLogger } from '../../../platform/requestLogger/common/requestLogger';
 import { retrieveCapturingTokenByCorrelation, runWithCapturingToken } from '../../../platform/requestLogger/node/requestLogger';
@@ -367,9 +367,24 @@ export class GeminiNativeBYOKLMProvider extends AbstractLanguageModelChatProvide
 				}
 				try {
 					const roleNames: Record<number, string> = { 1: 'user', 2: 'assistant', 3: 'system' };
-					const inputMsgs = messages.map(m => {
+					const systemTexts: string[] = [];
+					const inputMsgs: Array<{ role: string; parts: Array<{ type: string; content?: string; id?: string; name?: string; arguments?: unknown }> }> = [];
+					for (const m of messages) {
 						const msg = m as LanguageModelChatMessage;
 						const role = roleNames[msg.role] ?? String(msg.role);
+						// System messages are emitted via gen_ai.system_instructions only — keeping them
+						// in gen_ai.input.messages causes trace viewers to render the system prompt twice
+						// (issue #299932). Collect their text into the dedicated attribute and skip the entry.
+						if (role === 'system') {
+							if (Array.isArray(msg.content)) {
+								for (const p of msg.content) {
+									if (p instanceof LanguageModelTextPart) {
+										systemTexts.push(p.value);
+									}
+								}
+							}
+							continue;
+						}
 						const parts: Array<{ type: string; content?: string; id?: string; name?: string; arguments?: unknown }> = [];
 						if (Array.isArray(msg.content)) {
 							for (const p of msg.content) {
@@ -383,8 +398,12 @@ export class GeminiNativeBYOKLMProvider extends AbstractLanguageModelChatProvide
 						if (parts.length === 0) {
 							parts.push({ type: 'text', content: '[non-text content]' });
 						}
-						return { role, parts };
-					});
+						inputMsgs.push({ role, parts });
+					}
+					const systemInstructions = toSystemInstructions(systemTexts);
+					if (systemInstructions) {
+						otelSpan.setAttribute(GenAiAttr.SYSTEM_INSTRUCTIONS, truncateForOTel(JSON.stringify(systemInstructions), this._otelService.config.maxAttributeSizeChars));
+					}
 					otelSpan.setAttribute(GenAiAttr.INPUT_MESSAGES, truncateForOTel(JSON.stringify(inputMsgs), this._otelService.config.maxAttributeSizeChars));
 				} catch { /* swallow */ }
 			}

--- a/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
+++ b/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
@@ -27,7 +27,7 @@ import { sendEngineMessagesTelemetry } from '../../../platform/networking/node/c
 import { CAPIWebSocketErrorEvent, IChatWebSocketManager, isCAPIWebSocketError } from '../../../platform/networking/node/chatWebSocketManager';
 import { sendCommunicationErrorTelemetry } from '../../../platform/networking/node/stream';
 import { ChatFailKind, ChatRequestCanceled, ChatRequestFailed, ChatResults, FetchResponseKind } from '../../../platform/openai/node/fetch';
-import { CopilotChatAttr, emitInferenceDetailsEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, GenAiProviderName, normalizeProviderMessages, StdAttr, toSystemInstructions, toToolDefinitions, truncateForOTel } from '../../../platform/otel/common/index';
+import { CopilotChatAttr, emitInferenceDetailsEvent, extractTextFromContent, GenAiAttr, GenAiMetrics, GenAiOperationName, GenAiProviderName, normalizeProviderMessages, StdAttr, toSystemInstructions, toToolDefinitions, truncateForOTel } from '../../../platform/otel/common/index';
 import { IOTelService, ISpanHandle, SpanKind, SpanStatusCode } from '../../../platform/otel/common/otelService';
 import { IRequestLogger } from '../../../platform/requestLogger/common/requestLogger';
 import { getCurrentCapturingToken } from '../../../platform/requestLogger/node/requestLogger';
@@ -268,29 +268,29 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 							: JSON.stringify(lastUserMsg.content);
 						otelInferenceSpan.setAttribute(CopilotChatAttr.USER_REQUEST, truncateForOTel(userContent, this._otelService.config.maxAttributeSizeChars));
 					}
-					// System instructions — check messages array, top-level system (Anthropic), or instructions (Responses API)
-					const systemMsg = capiMessages?.find(m => m.role === 'system');
-					const systemContent = systemMsg?.content
-						?? (requestBody as Record<string, unknown>).system
-						?? (requestBody as Record<string, unknown>).instructions;
-					if (systemContent) {
-						let systemText: string;
-						if (typeof systemContent === 'string') {
-							systemText = systemContent;
-						} else if (Array.isArray(systemContent)) {
-							// Anthropic format: array of content blocks — extract text only,
-							// dropping metadata like cache_control so the value is stable across turns.
-							systemText = (systemContent as Array<{ text?: string }>)
-								.map(b => b.text ?? '')
-								.join('\n');
-						} else {
-							systemText = JSON.stringify(systemContent);
+					// System instructions — collect every system-role entry from the messages array
+					// (OpenAI Chat Completions can carry multiple, e.g. personality + instructions),
+					// plus top-level `system` (Anthropic Messages API) or `instructions`
+					// (OpenAI Responses API). Emitted via `gen_ai.system_instructions` only and
+					// stripped from `gen_ai.input.messages` below to avoid the double-render
+					// described in issue #299932.
+					const systemTexts: string[] = [];
+					if (capiMessages) {
+						for (const m of capiMessages) {
+							if (m.role === 'system') {
+								const t = extractTextFromContent(m.content);
+								if (t) { systemTexts.push(t); }
+							}
 						}
-						// Format as OTel GenAI system instruction JSON schema
-						const systemInstructions = toSystemInstructions(systemText);
-						if (systemInstructions) {
-							otelInferenceSpan.setAttribute(GenAiAttr.SYSTEM_INSTRUCTIONS, JSON.stringify(systemInstructions));
-						}
+					}
+					const topLevelSystem = extractTextFromContent(
+						(requestBody as Record<string, unknown>).system
+						?? (requestBody as Record<string, unknown>).instructions
+					);
+					if (topLevelSystem) { systemTexts.push(topLevelSystem); }
+					const systemInstructions = toSystemInstructions(systemTexts);
+					if (systemInstructions) {
+						otelInferenceSpan.setAttribute(GenAiAttr.SYSTEM_INSTRUCTIONS, truncateForOTel(JSON.stringify(systemInstructions), this._otelService.config.maxAttributeSizeChars));
 					}
 				}
 
@@ -298,8 +298,12 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 				if (otelInferenceSpan) {
 					const capiMessages = (requestBody.messages ?? requestBody.input) as ReadonlyArray<Record<string, unknown>> | undefined;
 					if (capiMessages) {
-						// Normalize provider-specific content (Anthropic tool_use/tool_result, OpenAI tool messages) to OTel schema
-						otelInferenceSpan.setAttribute(GenAiAttr.INPUT_MESSAGES, truncateForOTel(JSON.stringify(normalizeProviderMessages(capiMessages)), this._otelService.config.maxAttributeSizeChars));
+						// Normalize provider-specific content (Anthropic tool_use/tool_result, OpenAI tool messages) to OTel schema.
+						// System-role entries are excluded — they are emitted via `gen_ai.system_instructions`
+						// above. Keeping them in both attributes causes trace viewers (e.g. Aspire) to render
+						// the system prompt twice — see issue #299932.
+						const nonSystemMessages = capiMessages.filter(m => (m as { role?: unknown }).role !== 'system');
+						otelInferenceSpan.setAttribute(GenAiAttr.INPUT_MESSAGES, truncateForOTel(JSON.stringify(normalizeProviderMessages(nonSystemMessages)), this._otelService.config.maxAttributeSizeChars));
 					}
 					// Tool definitions: emit on every chat span so trace viewers can render the
 					// tool catalog per LLM call (issue #299934). Includes `parameters` per

--- a/extensions/copilot/src/platform/otel/common/index.ts
+++ b/extensions/copilot/src/platform/otel/common/index.ts
@@ -6,7 +6,7 @@
 export { CopilotChatAttr, CopilotCliSdkAttr, GenAiAttr, GenAiOperationName, GenAiProviderName, GenAiTokenType, GenAiToolType, StdAttr } from './genAiAttributes';
 export { emitAgentTurnEvent, emitCloudSessionInvokeEvent, emitEditFeedbackEvent, emitEditHunkActionEvent, emitEditSurvivalEvent, emitInferenceDetailsEvent, emitInlineDoneEvent, emitSessionStartEvent, emitToolCallEvent, emitUserFeedbackEvent } from './genAiEvents';
 export { GenAiMetrics } from './genAiMetrics';
-export { normalizeProviderMessages, toInputMessages, toOutputMessages, toSystemInstructions, toToolDefinitions, truncateForOTel } from './messageFormatters';
+export { extractTextFromContent, normalizeProviderMessages, toInputMessages, toOutputMessages, toSystemInstructions, toToolDefinitions, truncateForOTel } from './messageFormatters';
 export { NoopOTelService } from './noopOtelService';
 export { resolveOTelConfig, DEFAULT_OTLP_ENDPOINT, type OTelConfig, type OTelConfigInput } from './otelConfig';
 export { IOTelService, SpanKind, SpanStatusCode, type ICompletedSpanData, type ISpanEventData, type ISpanEventRecord, type ISpanHandle, type OTelModelOptions, type SpanOptions, type TraceContext } from './otelService';

--- a/extensions/copilot/src/platform/otel/common/messageFormatters.ts
+++ b/extensions/copilot/src/platform/otel/common/messageFormatters.ts
@@ -131,13 +131,51 @@ export function toOutputMessages(choices: ReadonlyArray<{
 }
 
 /**
- * Convert system message to OTel system instruction format.
+ * Convert one or more system messages to OTel system instruction format.
+ *
+ * Accepts either a single string or an array of strings (so callers that
+ * collect multiple system-role entries from the provider request — e.g. the
+ * OpenAI Chat Completions personality + instructions split — can preserve
+ * them as distinct content blocks). Returns `undefined` when no non-empty
+ * text is available so the caller can skip setting the attribute.
  */
-export function toSystemInstructions(systemMessage: string | undefined): OTelSystemInstruction | undefined {
-	if (!systemMessage) {
+export function toSystemInstructions(systemMessage: string | ReadonlyArray<string> | undefined): OTelSystemInstruction | undefined {
+	if (systemMessage === undefined) {
 		return undefined;
 	}
-	return [{ type: 'text', content: systemMessage }];
+	const inputs = Array.isArray(systemMessage) ? systemMessage : [systemMessage as string];
+	const blocks = inputs
+		.filter(s => typeof s === 'string' && s.length > 0)
+		.map(content => ({ type: 'text' as const, content }));
+	return blocks.length > 0 ? blocks : undefined;
+}
+
+/**
+ * Extract plain text from a message-content value, which may be a string,
+ * an array of content blocks (Anthropic `system`, Responses API `instructions`,
+ * Chat Completions multimodal parts), or some other shape. Returns an empty
+ * string when no text can be extracted. Used to feed `toSystemInstructions`
+ * from provider-specific request bodies.
+ */
+export function extractTextFromContent(content: unknown): string {
+	if (typeof content === 'string') {
+		return content;
+	}
+	if (Array.isArray(content)) {
+		return content
+			.map(block => {
+				if (typeof block === 'string') { return block; }
+				if (block && typeof block === 'object') {
+					const b = block as { text?: unknown; content?: unknown };
+					if (typeof b.text === 'string') { return b.text; }
+					if (typeof b.content === 'string') { return b.content; }
+				}
+				return '';
+			})
+			.filter(s => s.length > 0)
+			.join('\n');
+	}
+	return '';
 }
 
 /**

--- a/extensions/copilot/src/platform/otel/common/test/messageFormatters.spec.ts
+++ b/extensions/copilot/src/platform/otel/common/test/messageFormatters.spec.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { describe, expect, it } from 'vitest';
-import { normalizeProviderMessages, toInputMessages, toOutputMessages, toSystemInstructions, toToolDefinitions, truncateForOTel } from '../messageFormatters';
+import { extractTextFromContent, normalizeProviderMessages, toInputMessages, toOutputMessages, toSystemInstructions, toToolDefinitions, truncateForOTel } from '../messageFormatters';
 
 describe('toInputMessages', () => {
 	it('converts a simple text message', () => {
@@ -292,6 +292,60 @@ describe('toSystemInstructions', () => {
 
 	it('returns undefined for undefined input', () => {
 		expect(toSystemInstructions(undefined)).toBeUndefined();
+	});
+
+	it('returns multiple blocks for multiple system messages', () => {
+		expect(toSystemInstructions(['You are helpful', 'Always be concise'])).toEqual([
+			{ type: 'text', content: 'You are helpful' },
+			{ type: 'text', content: 'Always be concise' },
+		]);
+	});
+
+	it('filters empty strings from array input', () => {
+		expect(toSystemInstructions(['', 'real', ''])).toEqual([
+			{ type: 'text', content: 'real' },
+		]);
+	});
+
+	it('returns undefined for array containing only empty strings', () => {
+		expect(toSystemInstructions(['', ''])).toBeUndefined();
+	});
+
+	it('returns undefined for empty array', () => {
+		expect(toSystemInstructions([])).toBeUndefined();
+	});
+});
+
+describe('extractTextFromContent', () => {
+	it('returns string content as-is', () => {
+		expect(extractTextFromContent('hello world')).toBe('hello world');
+	});
+
+	it('returns empty string for undefined/null', () => {
+		expect(extractTextFromContent(undefined)).toBe('');
+		expect(extractTextFromContent(null)).toBe('');
+	});
+
+	it('joins text blocks from Anthropic-style content array', () => {
+		expect(extractTextFromContent([
+			{ type: 'text', text: 'first' },
+			{ type: 'text', text: 'second' },
+		])).toBe('first\nsecond');
+	});
+
+	it('handles cache_control and other metadata gracefully', () => {
+		expect(extractTextFromContent([
+			{ type: 'text', text: 'system prompt', cache_control: { type: 'ephemeral' } },
+		])).toBe('system prompt');
+	});
+
+	it('treats plain strings inside arrays as text', () => {
+		expect(extractTextFromContent(['a', 'b'])).toBe('a\nb');
+	});
+
+	it('returns empty string for unknown shapes', () => {
+		expect(extractTextFromContent(42)).toBe('');
+		expect(extractTextFromContent({ foo: 'bar' })).toBe('');
 	});
 });
 


### PR DESCRIPTION
Fixes #299932

## Problem

Trace viewers (Aspire Dashboard, etc.) render `gen_ai.system_instructions` and each entry in `gen_ai.input.messages` as separate nodes. The Copilot Chat OTel emission path placed the system prompt in **both** attributes, so the system prompt appeared twice in the trace tree.

This was confirmed reproducible on the OpenAI Chat Completions path (GPT models) via raw OTel attribute inspection — `gen_ai.system_instructions` and `gen_ai.input.messages[0]` carried identical system text. The Anthropic top-level-\`system\` path was accidentally OK; the BYOK Anthropic and Gemini providers were also vulnerable.

## Fix (producer-side, OTel-only)

- **`chatMLFetcher.ts`** — collects every `role: 'system'` entry from `requestBody.messages` / `input` (OpenAI Chat Completions can carry multiple — personality + instructions), plus top-level `system` (Anthropic Messages API) and `instructions` (OpenAI Responses API). Emits them via \`gen_ai.system_instructions\` and filters system out of \`gen_ai.input.messages\`.
- **BYOK \`anthropicProvider.ts\` / \`geminiNativeProvider.ts\`** — splits \`LanguageModelChatMessage\` \`role === 3\` (system) into the dedicated attribute; never emits it on \`gen_ai.input.messages\`.
- **\`messageFormatters.ts\`** — \`toSystemInstructions\` now accepts \`string | string[]\` so multiple system texts surface as distinct content blocks; added \`extractTextFromContent\` helper that handles strings and Anthropic-style content-block arrays.

## What does NOT change

The actual request payload sent to every model is unchanged. \`requestBody.messages\`, \`opts.messages\`, and the BYOK \`messages\` list are never mutated — only local filtered copies are passed to \`setAttribute\`. Agent normal flow is unaffected.

## Tests

- 9 new test cases in [messageFormatters.spec.ts](extensions/copilot/src/platform/otel/common/test/messageFormatters.spec.ts) cover array form of \`toSystemInstructions\` and \`extractTextFromContent\`.
- All 68 OTel tests pass; 23 chatMLFetcher tests pass; \`tsgo --noEmit\` on the copilot extension is clean.

## Verification

After the fix, Aspire renders a single \`System Message\` block under \`gen_ai.system_instructions\`, and \`gen_ai.input.messages\` contains only user / assistant / tool turns.