### PR TITLE
Integrating MXC for windows sandboxing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@microsoft/dev-tunnels-management": "^1.3.41",
         "@microsoft/dev-tunnels-ssh": "^3.12.22",
         "@microsoft/dev-tunnels-ssh-tcp": "^3.12.22",
-        "@microsoft/mxc-sdk": "^0.2.0",
+        "@microsoft/mxc-sdk": "0.2.0",
         "@parcel/watcher": "^2.5.6",
         "@types/semver": "^7.5.8",
         "@vscode/codicons": "^0.0.46-11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@microsoft/dev-tunnels-management": "^1.3.41",
         "@microsoft/dev-tunnels-ssh": "^3.12.22",
         "@microsoft/dev-tunnels-ssh-tcp": "^3.12.22",
+        "@microsoft/mxc-sdk": "^0.2.0",
         "@parcel/watcher": "^2.5.6",
         "@types/semver": "^7.5.8",
         "@vscode/codicons": "^0.0.46-11",
@@ -1937,6 +1938,19 @@
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-1.1.9.tgz",
       "integrity": "sha512-n1VPsljTSkthsAFYdiWfC+DKzK2WwcRp83Y1YAqdX552BstvsDjft9YXppjUzp11BPsapDoO1LDgrDB0XVsfNQ=="
+    },
+    "node_modules/@microsoft/mxc-sdk": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/mxc-sdk/-/mxc-sdk-0.2.0.tgz",
+      "integrity": "sha512-xgWTV0nvIzl+IjlIhLGw++/A1eeZYORDoMLGLlDpSE8tMPWLbQIF627Xsb0pkb04MB9vtZl9P+RRNB7fwS3PXA==",
+      "license": "MIT",
+      "dependencies": {
+        "node-pty": "^1.2.0-beta.12",
+        "semver": "^7.7.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "@microsoft/dev-tunnels-management": "^1.3.41",
     "@microsoft/dev-tunnels-ssh": "^3.12.22",
     "@microsoft/dev-tunnels-ssh-tcp": "^3.12.22",
+    "@microsoft/mxc-sdk": "^0.2.0",
     "@parcel/watcher": "^2.5.6",
     "@types/semver": "^7.5.8",
     "@vscode/codicons": "^0.0.46-11",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@microsoft/dev-tunnels-management": "^1.3.41",
     "@microsoft/dev-tunnels-ssh": "^3.12.22",
     "@microsoft/dev-tunnels-ssh-tcp": "^3.12.22",
-    "@microsoft/mxc-sdk": "^0.2.0",
+    "@microsoft/mxc-sdk": "0.2.0",
     "@parcel/watcher": "^2.5.6",
     "@types/semver": "^7.5.8",
     "@vscode/codicons": "^0.0.46-11",

--- a/remote/package-lock.json
+++ b/remote/package-lock.json
@@ -12,7 +12,7 @@
         "@github/copilot-sdk": "^0.3.0",
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
-        "@microsoft/mxc-sdk": "^0.2.0",
+        "@microsoft/mxc-sdk": "0.2.0",
         "@parcel/watcher": "^2.5.6",
         "@vscode/copilot-api": "^0.3.0",
         "@vscode/deviceid": "^0.1.1",

--- a/remote/package-lock.json
+++ b/remote/package-lock.json
@@ -12,6 +12,7 @@
         "@github/copilot-sdk": "^0.3.0",
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
+        "@microsoft/mxc-sdk": "^0.2.0",
         "@parcel/watcher": "^2.5.6",
         "@vscode/copilot-api": "^0.3.0",
         "@vscode/deviceid": "^0.1.1",
@@ -243,6 +244,19 @@
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-1.1.9.tgz",
       "integrity": "sha512-n1VPsljTSkthsAFYdiWfC+DKzK2WwcRp83Y1YAqdX552BstvsDjft9YXppjUzp11BPsapDoO1LDgrDB0XVsfNQ=="
+    },
+    "node_modules/@microsoft/mxc-sdk": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/mxc-sdk/-/mxc-sdk-0.2.0.tgz",
+      "integrity": "sha512-xgWTV0nvIzl+IjlIhLGw++/A1eeZYORDoMLGLlDpSE8tMPWLbQIF627Xsb0pkb04MB9vtZl9P+RRNB7fwS3PXA==",
+      "license": "MIT",
+      "dependencies": {
+        "node-pty": "^1.2.0-beta.12",
+        "semver": "^7.7.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@parcel/watcher": {
       "version": "2.5.6",
@@ -1417,12 +1431,10 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },

--- a/remote/package.json
+++ b/remote/package.json
@@ -7,6 +7,7 @@
     "@github/copilot-sdk": "^0.3.0",
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",
+    "@microsoft/mxc-sdk": "^0.2.0",
     "@parcel/watcher": "^2.5.6",
     "@vscode/copilot-api": "^0.3.0",
     "@vscode/deviceid": "^0.1.1",

--- a/remote/package.json
+++ b/remote/package.json
@@ -7,7 +7,7 @@
     "@github/copilot-sdk": "^0.3.0",
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",
-    "@microsoft/mxc-sdk": "^0.2.0",
+    "@microsoft/mxc-sdk": "0.2.0",
     "@parcel/watcher": "^2.5.6",
     "@vscode/copilot-api": "^0.3.0",
     "@vscode/deviceid": "^0.1.1",

--- a/src/vs/platform/sandbox/browser/sandboxHelperService.ts
+++ b/src/vs/platform/sandbox/browser/sandboxHelperService.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { InstantiationType, registerSingleton } from '../../instantiation/common/extensions.js';
-import { ISandboxDependencyStatus, ISandboxHelperService } from '../common/sandboxHelperService.js';
+import { ISandboxDependencyStatus, ISandboxHelperService, IWindowsMxcFilesystemPolicy } from '../common/sandboxHelperService.js';
 
 class NullSandboxHelperService implements ISandboxHelperService {
 	declare readonly _serviceBrand: undefined;
@@ -17,6 +17,14 @@ class NullSandboxHelperService implements ISandboxHelperService {
 			bubblewrapInstalled: true,
 			socatInstalled: true,
 		};
+	}
+
+	async getWindowsMxcFilesystemPolicy(): Promise<IWindowsMxcFilesystemPolicy | undefined> {
+		return undefined;
+	}
+
+	async getWindowsMxcEnvironment(): Promise<string[] | undefined> {
+		return undefined;
 	}
 }
 

--- a/src/vs/platform/sandbox/common/sandboxHelperIpc.ts
+++ b/src/vs/platform/sandbox/common/sandboxHelperIpc.ts
@@ -6,7 +6,7 @@
 import { Event } from '../../../base/common/event.js';
 import { CancellationToken } from '../../../base/common/cancellation.js';
 import { IChannel, IServerChannel } from '../../../base/parts/ipc/common/ipc.js';
-import { ISandboxDependencyStatus, ISandboxHelperService } from './sandboxHelperService.js';
+import { ISandboxDependencyStatus, ISandboxHelperService, IWindowsMxcFilesystemPolicy } from './sandboxHelperService.js';
 
 export const SANDBOX_HELPER_CHANNEL_NAME = 'sandboxHelper';
 
@@ -22,6 +22,10 @@ export class SandboxHelperChannel implements IServerChannel {
 		switch (command) {
 			case 'checkSandboxDependencies':
 				return this.service.checkSandboxDependencies() as Promise<T>;
+			case 'getWindowsMxcFilesystemPolicy':
+				return this.service.getWindowsMxcFilesystemPolicy() as Promise<T>;
+			case 'getWindowsMxcEnvironment':
+				return this.service.getWindowsMxcEnvironment() as Promise<T>;
 		}
 
 		throw new Error('Invalid call');
@@ -35,5 +39,13 @@ export class SandboxHelperChannelClient implements ISandboxHelperService {
 
 	checkSandboxDependencies(): Promise<ISandboxDependencyStatus | undefined> {
 		return this.channel.call<ISandboxDependencyStatus | undefined>('checkSandboxDependencies');
+	}
+
+	getWindowsMxcFilesystemPolicy(): Promise<IWindowsMxcFilesystemPolicy | undefined> {
+		return this.channel.call<IWindowsMxcFilesystemPolicy | undefined>('getWindowsMxcFilesystemPolicy');
+	}
+
+	getWindowsMxcEnvironment(): Promise<string[] | undefined> {
+		return this.channel.call<string[] | undefined>('getWindowsMxcEnvironment');
 	}
 }

--- a/src/vs/platform/sandbox/common/sandboxHelperService.ts
+++ b/src/vs/platform/sandbox/common/sandboxHelperService.ts
@@ -12,7 +12,14 @@ export interface ISandboxDependencyStatus {
 	readonly socatInstalled: boolean;
 }
 
+export interface IWindowsMxcFilesystemPolicy {
+	readonly readonlyPaths: string[];
+	readonly readwritePaths: string[];
+}
+
 export interface ISandboxHelperService {
 	readonly _serviceBrand: undefined;
 	checkSandboxDependencies(): Promise<ISandboxDependencyStatus | undefined>;
+	getWindowsMxcFilesystemPolicy(): Promise<IWindowsMxcFilesystemPolicy | undefined>;
+	getWindowsMxcEnvironment(): Promise<string[] | undefined>;
 }

--- a/src/vs/platform/sandbox/common/settings.ts
+++ b/src/vs/platform/sandbox/common/settings.ts
@@ -13,6 +13,7 @@ export const enum AgentSandboxSettingId {
 	AgentSandboxAllowAutoApprove = 'chat.agent.sandbox.allowAutoApprove',
 	AgentSandboxLinuxFileSystem = 'chat.agent.sandbox.fileSystem.linux',
 	AgentSandboxMacFileSystem = 'chat.agent.sandbox.fileSystem.mac',
+	AgentSandboxWindowsFileSystem = 'chat.agent.sandbox.fileSystem.windows',
 	AgentSandboxAdvancedRuntime = 'chat.agent.sandbox.advanced.runtime',
 	DeprecatedAgentSandboxEnabled = 'chat.agent.sandbox',
 	DeprecatedAgentSandboxLinuxFileSystem = 'chat.agent.sandboxFileSystem.linux',

--- a/src/vs/platform/sandbox/common/settings.ts
+++ b/src/vs/platform/sandbox/common/settings.ts
@@ -8,6 +8,7 @@
  */
 export const enum AgentSandboxSettingId {
 	AgentSandboxEnabled = 'chat.agent.sandbox.enabled',
+	AgentSandboxWindowsEnabled = 'chat.agent.sandbox.enabled.windows',
 	AgentSandboxAllowUnsandboxedCommands = 'chat.agent.sandbox.allowUnsandboxedCommands',
 	AgentSandboxAutoApproveUnsandboxedCommands = 'chat.agent.sandbox.autoApproveUnsandboxedCommands',
 	AgentSandboxAllowAutoApprove = 'chat.agent.sandbox.allowAutoApprove',

--- a/src/vs/platform/sandbox/common/terminalSandboxEngine.ts
+++ b/src/vs/platform/sandbox/common/terminalSandboxEngine.ts
@@ -6,7 +6,7 @@
 import { VSBuffer } from '../../../base/common/buffer.js';
 import { Event } from '../../../base/common/event.js';
 import { Disposable } from '../../../base/common/lifecycle.js';
-import { dirname, posix, win32 } from '../../../base/common/path.js';
+import { posix, win32 } from '../../../base/common/path.js';
 import { OperatingSystem, OS } from '../../../base/common/platform.js';
 import { URI } from '../../../base/common/uri.js';
 import { generateUuid } from '../../../base/common/uuid.js';
@@ -15,8 +15,9 @@ import { IFileService } from '../../files/common/files.js';
 import { ILogService } from '../../log/common/log.js';
 import { matchesDomainPattern, normalizeDomain } from '../../networkFilter/common/domainMatcher.js';
 import { AgentNetworkDomainSettingId } from '../../networkFilter/common/settings.js';
-import { ISandboxDependencyStatus } from './sandboxHelperService.js';
+import { ISandboxDependencyStatus, IWindowsMxcFilesystemPolicy } from './sandboxHelperService.js';
 import { AgentSandboxEnabledValue, AgentSandboxSettingId } from './settings.js';
+import { WindowsMxcTerminalSandboxRuntime } from './terminalSandboxMxcRuntime.js';
 import { getTerminalSandboxReadAllowListForCommands } from './terminalSandboxReadAllowList.js';
 import { getTerminalSandboxRuntimeConfigurationForCommands } from './terminalSandboxRuntimeConfigurationPerOperation.js';
 import { ITerminalSandboxCommand, ITerminalSandboxPrerequisiteCheckResult, ITerminalSandboxResolvedNetworkDomains, ITerminalSandboxWrapResult, TerminalSandboxPrerequisiteCheck } from './terminalSandboxService.js';
@@ -41,6 +42,8 @@ export interface ITerminalSandboxRuntimeInfo {
 	 * `execPath` already points at a real `node` binary (remote, agent host).
 	 */
 	runAsNode?: boolean;
+	/** CPU architecture of the environment that runs the sandbox runtime. */
+	arch?: string;
 }
 
 /**
@@ -71,6 +74,10 @@ export interface ITerminalSandboxEngineHost {
 	readonly onDidChangeRoots: Event<void>;
 	/** Resolves the installed sandbox-dependency status (bubblewrap, socat). */
 	checkSandboxDependencies(): Promise<ISandboxDependencyStatus | undefined>;
+	/** Resolves host filesystem policy fragments needed by the Windows MXC process container. */
+	getWindowsMxcFilesystemPolicy(): Promise<IWindowsMxcFilesystemPolicy | undefined>;
+	/** Resolves host environment variables needed by the Windows MXC process container. */
+	getWindowsMxcEnvironment(): Promise<string[] | undefined>;
 }
 
 /**
@@ -96,6 +103,9 @@ export class TerminalSandboxEngine extends Disposable {
 	private _userHome: URI | undefined;
 	private _srtPath: string | undefined;
 	private _rgPath: string | undefined;
+	private _mxcPath: string | undefined;
+	private _windowsMxcFilesystemPolicy: IWindowsMxcFilesystemPolicy | undefined;
+	private _windowsMxcEnvironment: string[] | undefined;
 	private _sandboxConfigPath: string | undefined;
 	private _sandboxDependencyStatus: ISandboxDependencyStatus | undefined;
 	private _needsForceUpdateConfigFile = true;
@@ -103,8 +113,11 @@ export class TerminalSandboxEngine extends Disposable {
 	private _commandAllowListKeywords: readonly string[] = [];
 	private _commandAllowListCommandDetails: readonly ITerminalSandboxCommand[] = [];
 	private _commandCwd: URI | undefined;
+	private _commandLine: string | undefined;
+	private _commandShell: string | undefined;
 	private _os: OperatingSystem = OS;
 	private readonly _defaultWritePaths: string[] = [];
+	private readonly _windowsMxcRuntime = new WindowsMxcTerminalSandboxRuntime();
 
 	constructor(
 		private readonly _host: ITerminalSandboxEngineHost,
@@ -163,11 +176,14 @@ export class TerminalSandboxEngine extends Disposable {
 			|| !this._areStringArraysEqual(this._commandAllowListKeywords, normalizedCommandKeywords)
 			|| !this._areStringArraysEqual(currentReadAllowListPaths, nextReadAllowListPaths)
 			|| !this._areObjectsEqual(currentRuntimeConfiguration, nextRuntimeConfiguration)
-			|| this._commandCwd?.toString() !== cwd?.toString();
+			|| this._commandCwd?.toString() !== cwd?.toString()
+			|| (this._os === OperatingSystem.Windows && (this._commandLine !== command || this._commandShell !== shell));
 		if (shouldRefreshConfig) {
 			this._commandAllowListKeywords = normalizedCommandKeywords;
 			this._commandAllowListCommandDetails = normalizedCommandDetails;
 			this._commandCwd = cwd;
+			this._commandLine = command;
+			this._commandShell = shell;
 			await this.getSandboxConfigPath(true);
 		}
 
@@ -197,6 +213,16 @@ export class TerminalSandboxEngine extends Disposable {
 			};
 		}
 
+		if (this._os === OperatingSystem.Windows) {
+			if (!this._mxcPath) {
+				throw new Error('MXC executable path not resolved');
+			}
+			return {
+				command: this._windowsMxcRuntime.wrapCommand(this._mxcPath, this._sandboxConfigPath, shell),
+				isSandboxWrapped: true,
+			};
+		}
+
 		if (!this._execPath) {
 			throw new Error('Executable path not set to run sandbox commands');
 		}
@@ -210,7 +236,7 @@ export class TerminalSandboxEngine extends Disposable {
 		// TMPDIR must be set as environment variable before the command
 		// Quote shell arguments so the wrapped command cannot break out of the outer shell.
 		const commandToRunInSandbox = this._getSandboxCommandWithPreservedCwd(command, cwd);
-		const sandboxRuntimeCommand = `PATH="$PATH:${dirname(this._rgPath)}" TMPDIR="${this._tempDir.path}" CLAUDE_TMPDIR="${this._tempDir.path}" "${this._execPath}" "${this._srtPath}" --settings "${this._sandboxConfigPath}" -c ${this._quoteShellArgument(commandToRunInSandbox)}`;
+		const sandboxRuntimeCommand = `PATH="$PATH:${this._pathDirname(this._rgPath)}" TMPDIR="${this._tempDir.path}" CLAUDE_TMPDIR="${this._tempDir.path}" "${this._execPath}" "${this._srtPath}" --settings "${this._sandboxConfigPath}" -c ${this._quoteShellArgument(commandToRunInSandbox)}`;
 		const wrappedCommand = this._os === OperatingSystem.Linux && cwd?.path && cwd.path !== this._tempDir.path
 			? `cd ${this._quoteShellArgument(this._tempDir.path)}; ${sandboxRuntimeCommand}`
 			: sandboxRuntimeCommand;
@@ -336,7 +362,7 @@ export class TerminalSandboxEngine extends Disposable {
 	private async _checkSandboxDependencies(forceRefresh = false): Promise<boolean> {
 		const os = await this.getOS();
 		if (os === OperatingSystem.Windows) {
-			return false;
+			return true;
 		}
 
 		if (!forceRefresh && this._sandboxDependencyStatus) {
@@ -368,6 +394,9 @@ export class TerminalSandboxEngine extends Disposable {
 	}
 
 	private _wrapUnsandboxedCommand(command: string, shell?: string): string {
+		if (this._os === OperatingSystem.Windows) {
+			return this._windowsMxcRuntime.wrapUnsandboxedCommand(command, this._tempDir, shell);
+		}
 		if (!this._tempDir?.path) {
 			return command;
 		}
@@ -473,10 +502,7 @@ export class TerminalSandboxEngine extends Disposable {
 	}
 
 	private async _isSandboxConfiguredEnabled(): Promise<boolean> {
-		const os = await this.getOS();
-		if (os === OperatingSystem.Windows) {
-			return false;
-		}
+		await this.getOS();
 		const value = this._getSandboxConfiguredEnabledValue();
 		return value === true || value === AgentSandboxEnabledValue.On || value === AgentSandboxEnabledValue.AllowNetwork;
 	}
@@ -493,6 +519,7 @@ export class TerminalSandboxEngine extends Disposable {
 		this._userHome = await this._host.getUserHome();
 		this._srtPath = this._pathJoin(this._appRoot, 'node_modules', '@vscode', 'sandbox-runtime', 'dist', 'cli.js');
 		this._rgPath = this._pathJoin(this._appRoot, 'node_modules', '@vscode', 'ripgrep', 'bin', 'rg');
+		this._mxcPath = this._windowsMxcRuntime.getExecutablePath(this._appRoot, runtimeInfo.arch);
 	}
 
 	private async _createSandboxConfig(): Promise<string | undefined> {
@@ -519,7 +546,14 @@ export class TerminalSandboxEngine extends Disposable {
 		let allowReadPaths: string[] = [];
 		let denyReadPaths: string[] = [];
 		let denyWritePaths: string[] | undefined;
-		if (this._os === OperatingSystem.Macintosh) {
+		if (this._os === OperatingSystem.Windows) {
+			const filesystemPolicy = await this._getWindowsMxcFilesystemPolicy();
+			const env = await this._getWindowsMxcEnvironment();
+			allowWritePaths = await this._resolveFileSystemPaths(this._updateAllowWritePathsWithWorkspaceFolders(undefined, commandRuntimeAllowWritePaths));
+			allowReadPaths = await this._resolveFileSystemPaths([...(await this._updateAllowReadPathsWithAllowWrite(undefined, allowWritePaths, commandRuntimeAllowReadPaths)), ...filesystemPolicy.readonlyPaths]);
+			denyReadPaths = await this._resolveFileSystemPaths(this._updateDenyReadPathsWithHome(undefined));
+			this._windowsMxcEnvironment = env;
+		} else if (this._os === OperatingSystem.Macintosh) {
 			allowWritePaths = await this._resolveFileSystemPaths(this._updateAllowWritePathsWithWorkspaceFolders(macFileSystemSetting.allowWrite, commandRuntimeAllowWritePaths));
 			allowReadPaths = await this._resolveFileSystemPaths(await this._updateAllowReadPathsWithAllowWrite(macFileSystemSetting.allowRead, allowWritePaths, commandRuntimeAllowReadPaths));
 			denyReadPaths = await this._resolveFileSystemPaths(this._updateDenyReadPathsWithHome(macFileSystemSetting.denyRead));
@@ -530,7 +564,18 @@ export class TerminalSandboxEngine extends Disposable {
 			denyReadPaths = await this._resolveFileSystemPaths(this._updateDenyReadPathsWithHome(linuxFileSystemSetting.denyRead));
 			denyWritePaths = await this._resolveFileSystemPaths(linuxFileSystemSetting.denyWrite);
 		}
-		const sandboxSettings = {
+		const sandboxSettings = this._os === OperatingSystem.Windows ? this._windowsMxcRuntime.createConfig({
+			command: this._commandLine ?? '',
+			shell: this._commandShell,
+			cwd: this._commandCwd,
+			tempDir: this._tempDir,
+			allowNetwork,
+			networkDomains: this.getResolvedNetworkDomains(),
+			allowReadPaths,
+			allowWritePaths,
+			denyReadPaths,
+			env: this._windowsMxcEnvironment ?? [],
+		}) : {
 			network: allowNetwork ? { allowedDomains: [], deniedDomains: [], enabled: false } : this.getResolvedNetworkDomains(),
 			filesystem: {
 				denyRead: denyReadPaths,
@@ -539,9 +584,11 @@ export class TerminalSandboxEngine extends Disposable {
 				denyWrite: denyWritePaths,
 			},
 		};
-		this._mergeAdditionalSandboxConfigProperties(sandboxSettings as Record<string, unknown>, allowNetwork ? this._withoutNetworkRuntimeSetting(runtimeSetting) : runtimeSetting);
-		this._mergeAdditionalSandboxConfigProperties(sandboxSettings as Record<string, unknown>, commandRuntimeSetting);
-		this._sandboxConfigPath = configFileUri.path;
+		if (this._os !== OperatingSystem.Windows) {
+			this._mergeAdditionalSandboxConfigProperties(sandboxSettings as Record<string, unknown>, allowNetwork ? this._withoutNetworkRuntimeSetting(runtimeSetting) : runtimeSetting);
+			this._mergeAdditionalSandboxConfigProperties(sandboxSettings as Record<string, unknown>, commandRuntimeSetting);
+		}
+		this._sandboxConfigPath = this._getUriPath(configFileUri);
 		await this._fileService.createFile(configFileUri, VSBuffer.fromString(JSON.stringify(sandboxSettings, null, '\t')), { overwrite: true });
 		return this._sandboxConfigPath;
 	}
@@ -584,10 +631,32 @@ export class TerminalSandboxEngine extends Disposable {
 		return typeof value === 'object' && value !== null && !Array.isArray(value);
 	}
 
+	private async _getWindowsMxcFilesystemPolicy(): Promise<IWindowsMxcFilesystemPolicy> {
+		if (!this._windowsMxcFilesystemPolicy) {
+			this._windowsMxcFilesystemPolicy = await this._host.getWindowsMxcFilesystemPolicy() ?? { readonlyPaths: [], readwritePaths: [] };
+		}
+		return this._windowsMxcFilesystemPolicy;
+	}
+
+	private async _getWindowsMxcEnvironment(): Promise<string[]> {
+		if (!this._windowsMxcEnvironment) {
+			this._windowsMxcEnvironment = await this._host.getWindowsMxcEnvironment() ?? [];
+		}
+		return this._windowsMxcEnvironment;
+	}
+
 	private _pathJoin = (...segments: string[]) => {
 		const path = this._os === OperatingSystem.Windows ? win32 : posix;
 		return path.join(...segments);
 	};
+
+	private _pathDirname(path: string): string {
+		return (this._os === OperatingSystem.Windows ? win32 : posix).dirname(path);
+	}
+
+	private _getUriPath(uri: URI): string {
+		return this._os === OperatingSystem.Windows ? this._windowsMxcRuntime.toWindowsPath(uri) : uri.path;
+	}
 
 	private async _initTempDir(): Promise<void> {
 		if (!(await this.isEnabled())) {
@@ -597,19 +666,19 @@ export class TerminalSandboxEngine extends Disposable {
 		this._tempDir = await this._host.getSandboxTempDir();
 		if (this._tempDir) {
 			await this._fileService.createFolder(this._tempDir);
-			this._defaultWritePaths.push(this._tempDir.path);
+			this._defaultWritePaths.push(this._getUriPath(this._tempDir));
 		} else {
 			this._logService.warn('TerminalSandboxEngine: Cannot create sandbox settings file because no tmpDir is available in this environment');
 		}
 	}
 
 	private _updateAllowWritePathsWithWorkspaceFolders(configuredAllowWrite: string[] | undefined, commandRuntimeAllowWrite: string[] = []): string[] {
-		const writeRootPaths = this._host.getWriteRoots().map(folder => folder.path);
+		const writeRootPaths = this._host.getWriteRoots().map(folder => this._getUriPath(folder));
 		return [...new Set([...writeRootPaths, ...this._defaultWritePaths, ...(configuredAllowWrite ?? []), ...commandRuntimeAllowWrite])];
 	}
 
 	private _updateDenyReadPathsWithHome(configuredDenyRead: string[] | undefined): string[] {
-		const userHome = this._userHome?.path;
+		const userHome = this._userHome ? this._getUriPath(this._userHome) : undefined;
 		return [...new Set([...(configuredDenyRead ?? []), ...(userHome ? [userHome] : [])])];
 	}
 
@@ -624,6 +693,9 @@ export class TerminalSandboxEngine extends Disposable {
 
 	private async _resolveFileSystemPath(path: string): Promise<string> {
 		const expandedPath = this._os === OperatingSystem.Linux ? this._expandHomePath(path) : path;
+		if (this._os === OperatingSystem.Windows) {
+			return expandedPath;
+		}
 		if (!this._isAbsoluteFileSystemPath(expandedPath)) {
 			return expandedPath;
 		}
@@ -662,9 +734,12 @@ export class TerminalSandboxEngine extends Disposable {
 		if (!this._appRoot) {
 			return [];
 		}
+		if (this._os === OperatingSystem.Windows) {
+			return this._windowsMxcRuntime.getRuntimeReadPaths(this._appRoot, this._mxcPath);
+		}
 		const paths: string[] = [this._appRoot];
 		if (this._execPath) {
-			for (const path of [this._execPath, dirname(this._execPath)]) {
+			for (const path of [this._execPath, this._pathDirname(this._execPath)]) {
 				if (!this._isPathUnderAppRoot(path)) {
 					paths.push(path);
 				}
@@ -682,7 +757,7 @@ export class TerminalSandboxEngine extends Disposable {
 
 	private async _getWorkspaceStorageReadPaths(): Promise<string[]> {
 		const root = await this._host.getWorkspaceStorageReadRoot();
-		return root ? [root.path] : [];
+		return root ? [this._getUriPath(root)] : [];
 	}
 
 	private _getSandboxConfiguredEnabledValue(): AgentSandboxEnabledValue | boolean {

--- a/src/vs/platform/sandbox/common/terminalSandboxEngine.ts
+++ b/src/vs/platform/sandbox/common/terminalSandboxEngine.ts
@@ -345,6 +345,7 @@ export class TerminalSandboxEngine extends Disposable {
 			return true; // initial run-and-subscribe
 		}
 		return e.affectsConfiguration(AgentSandboxSettingId.AgentSandboxEnabled)
+			|| e.affectsConfiguration(AgentSandboxSettingId.AgentSandboxWindowsEnabled)
 			|| e.affectsConfiguration(AgentSandboxSettingId.DeprecatedAgentSandboxEnabled)
 			|| e.affectsConfiguration(AgentNetworkDomainSettingId.AllowedNetworkDomains)
 			|| e.affectsConfiguration(AgentNetworkDomainSettingId.DeprecatedSandboxAllowedNetworkDomains)
@@ -505,7 +506,14 @@ export class TerminalSandboxEngine extends Disposable {
 	private async _isSandboxConfiguredEnabled(): Promise<boolean> {
 		await this.getOS();
 		const value = this._getSandboxConfiguredEnabledValue();
-		return value === true || value === AgentSandboxEnabledValue.On || value === AgentSandboxEnabledValue.AllowNetwork;
+		const enabled = value === true || value === AgentSandboxEnabledValue.On || value === AgentSandboxEnabledValue.AllowNetwork;
+		if (!enabled) {
+			return false;
+		}
+		if (this._os === OperatingSystem.Windows) {
+			return this._getSandboxConfiguredWindowsEnabledValue() === AgentSandboxEnabledValue.AllowNetwork;
+		}
+		return true;
 	}
 
 	private async _resolveRuntimeInfo(): Promise<void> {
@@ -774,7 +782,14 @@ export class TerminalSandboxEngine extends Disposable {
 		return this._getSettingValue<AgentSandboxEnabledValue | boolean>(AgentSandboxSettingId.AgentSandboxEnabled, AgentSandboxSettingId.DeprecatedAgentSandboxEnabled) ?? AgentSandboxEnabledValue.Off;
 	}
 
+	private _getSandboxConfiguredWindowsEnabledValue(): AgentSandboxEnabledValue {
+		return this._getSettingValue<AgentSandboxEnabledValue>(AgentSandboxSettingId.AgentSandboxWindowsEnabled) ?? AgentSandboxEnabledValue.Off;
+	}
+
 	private _isSandboxAllowNetworkConfigured(): boolean {
+		if (this._os === OperatingSystem.Windows) {
+			return this._getSandboxConfiguredWindowsEnabledValue() === AgentSandboxEnabledValue.AllowNetwork;
+		}
 		return this._getSandboxConfiguredEnabledValue() === AgentSandboxEnabledValue.AllowNetwork;
 	}
 

--- a/src/vs/platform/sandbox/common/terminalSandboxEngine.ts
+++ b/src/vs/platform/sandbox/common/terminalSandboxEngine.ts
@@ -505,15 +505,11 @@ export class TerminalSandboxEngine extends Disposable {
 
 	private async _isSandboxConfiguredEnabled(): Promise<boolean> {
 		await this.getOS();
-		const value = this._getSandboxConfiguredEnabledValue();
-		const enabled = value === true || value === AgentSandboxEnabledValue.On || value === AgentSandboxEnabledValue.AllowNetwork;
-		if (!enabled) {
-			return false;
-		}
 		if (this._os === OperatingSystem.Windows) {
 			return this._getSandboxConfiguredWindowsEnabledValue() === AgentSandboxEnabledValue.AllowNetwork;
 		}
-		return true;
+		const value = this._getSandboxConfiguredEnabledValue();
+		return value === true || value === AgentSandboxEnabledValue.On || value === AgentSandboxEnabledValue.AllowNetwork;
 	}
 
 	private async _resolveRuntimeInfo(): Promise<void> {

--- a/src/vs/platform/sandbox/common/terminalSandboxEngine.ts
+++ b/src/vs/platform/sandbox/common/terminalSandboxEngine.ts
@@ -573,7 +573,6 @@ export class TerminalSandboxEngine extends Disposable {
 		}
 		const sandboxSettings = this._os === OperatingSystem.Windows ? this._windowsMxcRuntime.createConfig({
 			command: this._commandLine ?? '',
-			powerShellPath: this._commandShell,
 			cwd: this._commandCwd,
 			tempDir: this._tempDir,
 			allowNetwork,

--- a/src/vs/platform/sandbox/common/terminalSandboxEngine.ts
+++ b/src/vs/platform/sandbox/common/terminalSandboxEngine.ts
@@ -396,7 +396,7 @@ export class TerminalSandboxEngine extends Disposable {
 
 	private _wrapUnsandboxedCommand(command: string, shell?: string): string {
 		if (this._os === OperatingSystem.Windows) {
-			return this._windowsMxcRuntime.wrapUnsandboxedCommand(command, this._tempDir);
+			return this._windowsMxcRuntime.wrapUnsandboxedCommand(command);
 		}
 		if (!this._tempDir?.path) {
 			return command;

--- a/src/vs/platform/sandbox/common/terminalSandboxEngine.ts
+++ b/src/vs/platform/sandbox/common/terminalSandboxEngine.ts
@@ -553,7 +553,10 @@ export class TerminalSandboxEngine extends Disposable {
 		if (this._os === OperatingSystem.Windows) {
 			const filesystemPolicy = await this._getWindowsMxcFilesystemPolicy();
 			const env = await this._getWindowsMxcEnvironment();
-			allowWritePaths = await this._resolveFileSystemPaths(this._updateAllowWritePathsWithWorkspaceFolders(windowsFileSystemSetting.allowWrite, commandRuntimeAllowWritePaths));
+			allowWritePaths = await this._resolveFileSystemPaths([
+				...this._updateAllowWritePathsWithWorkspaceFolders(windowsFileSystemSetting.allowWrite, commandRuntimeAllowWritePaths),
+				...filesystemPolicy.readwritePaths
+			]);
 			allowReadPaths = await this._resolveFileSystemPaths([...(await this._updateAllowReadPathsWithAllowWrite(windowsFileSystemSetting.allowRead, allowWritePaths, commandRuntimeAllowReadPaths)), ...filesystemPolicy.readonlyPaths]);
 			denyReadPaths = await this._resolveFileSystemPaths(this._updateDenyReadPathsWithHome(windowsFileSystemSetting.denyRead));
 			this._windowsMxcEnvironment = env;

--- a/src/vs/platform/sandbox/common/terminalSandboxEngine.ts
+++ b/src/vs/platform/sandbox/common/terminalSandboxEngine.ts
@@ -17,7 +17,7 @@ import { matchesDomainPattern, normalizeDomain } from '../../networkFilter/commo
 import { AgentNetworkDomainSettingId } from '../../networkFilter/common/settings.js';
 import { ISandboxDependencyStatus, IWindowsMxcFilesystemPolicy } from './sandboxHelperService.js';
 import { AgentSandboxEnabledValue, AgentSandboxSettingId } from './settings.js';
-import { WindowsMxcTerminalSandboxRuntime } from './terminalSandboxMxcRuntime.js';
+import { IWindowsMxcTerminalSandboxRuntime } from './terminalSandboxMxcRuntime.js';
 import { getTerminalSandboxReadAllowListForCommands } from './terminalSandboxReadAllowList.js';
 import { getTerminalSandboxRuntimeConfigurationForCommands } from './terminalSandboxRuntimeConfigurationPerOperation.js';
 import { ITerminalSandboxCommand, ITerminalSandboxPrerequisiteCheckResult, ITerminalSandboxResolvedNetworkDomains, ITerminalSandboxWrapResult, TerminalSandboxPrerequisiteCheck } from './terminalSandboxService.js';
@@ -117,13 +117,13 @@ export class TerminalSandboxEngine extends Disposable {
 	private _commandShell: string | undefined;
 	private _os: OperatingSystem = OS;
 	private readonly _defaultWritePaths: string[] = [];
-	private readonly _windowsMxcRuntime = new WindowsMxcTerminalSandboxRuntime();
 
 	constructor(
 		private readonly _host: ITerminalSandboxEngineHost,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IFileService private readonly _fileService: IFileService,
 		@ILogService private readonly _logService: ILogService,
+		@IWindowsMxcTerminalSandboxRuntime private readonly _windowsMxcRuntime: IWindowsMxcTerminalSandboxRuntime,
 	) {
 		super();
 		this._register(Event.runAndSubscribe(this._configurationService.onDidChangeConfiguration, (e: IConfigurationChangeEvent | undefined) => {
@@ -218,7 +218,7 @@ export class TerminalSandboxEngine extends Disposable {
 				throw new Error('MXC executable path not resolved');
 			}
 			return {
-				command: this._windowsMxcRuntime.wrapCommand(this._mxcPath, this._sandboxConfigPath, shell),
+				command: this._windowsMxcRuntime.wrapCommand(this._mxcPath, this._sandboxConfigPath),
 				isSandboxWrapped: true,
 			};
 		}
@@ -356,6 +356,7 @@ export class TerminalSandboxEngine extends Disposable {
 			|| e.affectsConfiguration(AgentSandboxSettingId.DeprecatedAgentSandboxLinuxFileSystem)
 			|| e.affectsConfiguration(AgentSandboxSettingId.AgentSandboxMacFileSystem)
 			|| e.affectsConfiguration(AgentSandboxSettingId.DeprecatedAgentSandboxMacFileSystem)
+			|| e.affectsConfiguration(AgentSandboxSettingId.AgentSandboxWindowsFileSystem)
 			|| e.affectsConfiguration(AgentSandboxSettingId.AgentSandboxAdvancedRuntime);
 	}
 
@@ -395,7 +396,7 @@ export class TerminalSandboxEngine extends Disposable {
 
 	private _wrapUnsandboxedCommand(command: string, shell?: string): string {
 		if (this._os === OperatingSystem.Windows) {
-			return this._windowsMxcRuntime.wrapUnsandboxedCommand(command, this._tempDir, shell);
+			return this._windowsMxcRuntime.wrapUnsandboxedCommand(command, this._tempDir);
 		}
 		if (!this._tempDir?.path) {
 			return command;
@@ -537,6 +538,9 @@ export class TerminalSandboxEngine extends Disposable {
 		const macFileSystemSetting = this._os === OperatingSystem.Macintosh
 			? this._getSettingValue<ITerminalSandboxFileSystemSetting>(AgentSandboxSettingId.AgentSandboxMacFileSystem, AgentSandboxSettingId.DeprecatedAgentSandboxMacFileSystem) ?? {}
 			: {};
+		const windowsFileSystemSetting = this._os === OperatingSystem.Windows
+			? this._getSettingValue<ITerminalSandboxFileSystemSetting>(AgentSandboxSettingId.AgentSandboxWindowsFileSystem) ?? {}
+			: {};
 		const runtimeSetting = this._getSettingValue<Record<string, unknown>>(AgentSandboxSettingId.AgentSandboxAdvancedRuntime) ?? {};
 		const commandRuntimeSetting = getTerminalSandboxRuntimeConfigurationForCommands(this._os, this._commandAllowListCommandDetails);
 		const commandRuntimeAllowReadPaths = this._getCommandRuntimeFileSystemPaths(commandRuntimeSetting, 'allowRead');
@@ -549,9 +553,9 @@ export class TerminalSandboxEngine extends Disposable {
 		if (this._os === OperatingSystem.Windows) {
 			const filesystemPolicy = await this._getWindowsMxcFilesystemPolicy();
 			const env = await this._getWindowsMxcEnvironment();
-			allowWritePaths = await this._resolveFileSystemPaths(this._updateAllowWritePathsWithWorkspaceFolders(undefined, commandRuntimeAllowWritePaths));
-			allowReadPaths = await this._resolveFileSystemPaths([...(await this._updateAllowReadPathsWithAllowWrite(undefined, allowWritePaths, commandRuntimeAllowReadPaths)), ...filesystemPolicy.readonlyPaths]);
-			denyReadPaths = await this._resolveFileSystemPaths(this._updateDenyReadPathsWithHome(undefined));
+			allowWritePaths = await this._resolveFileSystemPaths(this._updateAllowWritePathsWithWorkspaceFolders(windowsFileSystemSetting.allowWrite, commandRuntimeAllowWritePaths));
+			allowReadPaths = await this._resolveFileSystemPaths([...(await this._updateAllowReadPathsWithAllowWrite(windowsFileSystemSetting.allowRead, allowWritePaths, commandRuntimeAllowReadPaths)), ...filesystemPolicy.readonlyPaths]);
+			denyReadPaths = await this._resolveFileSystemPaths(this._updateDenyReadPathsWithHome(windowsFileSystemSetting.denyRead));
 			this._windowsMxcEnvironment = env;
 		} else if (this._os === OperatingSystem.Macintosh) {
 			allowWritePaths = await this._resolveFileSystemPaths(this._updateAllowWritePathsWithWorkspaceFolders(macFileSystemSetting.allowWrite, commandRuntimeAllowWritePaths));
@@ -566,7 +570,7 @@ export class TerminalSandboxEngine extends Disposable {
 		}
 		const sandboxSettings = this._os === OperatingSystem.Windows ? this._windowsMxcRuntime.createConfig({
 			command: this._commandLine ?? '',
-			shell: this._commandShell,
+			powerShellPath: this._commandShell,
 			cwd: this._commandCwd,
 			tempDir: this._tempDir,
 			allowNetwork,
@@ -678,6 +682,10 @@ export class TerminalSandboxEngine extends Disposable {
 	}
 
 	private _updateDenyReadPathsWithHome(configuredDenyRead: string[] | undefined): string[] {
+		// TODO: On Windows, deny read on home directory.
+		if (this._os === OperatingSystem.Windows) {
+			return [...new Set(configuredDenyRead ?? [])];
+		}
 		const userHome = this._userHome ? this._getUriPath(this._userHome) : undefined;
 		return [...new Set([...(configuredDenyRead ?? []), ...(userHome ? [userHome] : [])])];
 	}

--- a/src/vs/platform/sandbox/common/terminalSandboxMxcRuntime.ts
+++ b/src/vs/platform/sandbox/common/terminalSandboxMxcRuntime.ts
@@ -47,7 +47,6 @@ export interface IWindowsMxcConfig {
 
 export interface IWindowsMxcConfigOptions {
 	command: string;
-	powerShellPath: string | undefined;
 	cwd: URI | undefined;
 	tempDir: URI;
 	allowNetwork: boolean;
@@ -81,7 +80,6 @@ export class WindowsMxcTerminalSandboxRuntime implements IWindowsMxcTerminalSand
 	declare readonly _serviceBrand: undefined;
 
 	private readonly _configVersion = '0.4.0-alpha';
-	private readonly _fallbackPowerShellPath = 'powershell.exe';
 
 	getExecutablePath(appRoot: string, arch: string | undefined): string {
 		const binArch = arch === 'arm64' ? 'arm64' : 'x64';
@@ -110,7 +108,7 @@ export class WindowsMxcTerminalSandboxRuntime implements IWindowsMxcTerminalSand
 				preservePolicy: false,
 			},
 			process: {
-				commandLine: this._createPowerShellCommandLine(options.command, options.powerShellPath),
+				commandLine: options.command,
 				cwd: options.cwd ? this.toWindowsPath(options.cwd) : tempDirPath,
 				env: [
 					...options.env
@@ -157,27 +155,14 @@ export class WindowsMxcTerminalSandboxRuntime implements IWindowsMxcTerminalSand
 	}
 
 	private _createNetworkConfig(allowNetwork: boolean, networkDomains: ITerminalSandboxResolvedNetworkDomains): IWindowsMxcNetworkConfig {
-		// if (allowNetwork) {
-		// 	return { defaultPolicy: 'allow' };
-		// }
-		return { defaultPolicy: 'allow' };
-		// TODO: No Proxy support in MXC yet, so we can't reliably allowlist domains. For now, we just block all network access when network is disallowed, and will add allowlist support later when Proxy is supported.
-		// return {
-		// 	defaultPolicy: 'block',
-		// 	allowedHosts: networkDomains.allowedDomains,
-		// 	blockedHosts: networkDomains.deniedDomains
-		// };
-	}
-
-	private _createPowerShellCommandLine(command: string, powerShellPath: string | undefined): string {
-		return `${this._quoteWindowsProcessArgument(powerShellPath ?? this._fallbackPowerShellPath)} -NonInteractive -Command ${this._quoteWindowsProcessArgument(command)}`;
-	}
-
-	private _quoteWindowsProcessArgument(value: string): string {
-		if (value.length > 0 && !/[\s"]/.test(value)) {
-			return value;
+		if (allowNetwork) {
+			return { defaultPolicy: 'allow' };
 		}
-		return `"${value.replace(/(\\*)"/g, `$1$1\\"`).replace(/\\+$/g, `$&$&`)}"`;
+		return {
+			defaultPolicy: 'block',
+			allowedHosts: networkDomains.allowedDomains,
+			blockedHosts: networkDomains.deniedDomains
+		};
 	}
 
 	private _quotePowerShellArgument(value: string): string {

--- a/src/vs/platform/sandbox/common/terminalSandboxMxcRuntime.ts
+++ b/src/vs/platform/sandbox/common/terminalSandboxMxcRuntime.ts
@@ -1,0 +1,194 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { win32 } from '../../../base/common/path.js';
+import { URI } from '../../../base/common/uri.js';
+import type { ITerminalSandboxResolvedNetworkDomains } from './terminalSandboxService.js';
+
+interface IWindowsMxcProcessConfig {
+	commandLine: string;
+	cwd?: string;
+	env: string[];
+	timeout: number;
+}
+
+interface IWindowsMxcFilesystemConfig {
+	readwritePaths: string[];
+	readonlyPaths: string[];
+	deniedPaths: string[];
+}
+
+interface IWindowsMxcNetworkConfig {
+	defaultPolicy: 'allow' | 'block';
+	allowedHosts?: string[];
+	blockedHosts?: string[];
+}
+
+interface IWindowsMxcConfig {
+	version: string;
+	containment: 'process';
+	lifecycle: {
+		destroyOnExit: boolean;
+		preservePolicy: boolean;
+	};
+	process: IWindowsMxcProcessConfig;
+	filesystem: IWindowsMxcFilesystemConfig;
+	network: IWindowsMxcNetworkConfig;
+	ui: {
+		disable: boolean;
+		clipboard: 'none';
+		injection: boolean;
+	};
+}
+
+export interface IWindowsMxcConfigOptions {
+	command: string;
+	shell: string | undefined;
+	cwd: URI | undefined;
+	tempDir: URI;
+	allowNetwork: boolean;
+	networkDomains: ITerminalSandboxResolvedNetworkDomains;
+	allowReadPaths: string[];
+	allowWritePaths: string[];
+	denyReadPaths: string[];
+	env: string[];
+}
+
+/**
+ * Windows-only MXC integration for terminal sandboxing.
+ *
+ * This class is intentionally isolated from the SRT-backed runtime so it can be
+ * removed once SRT supports Windows sandboxing.
+ */
+export class WindowsMxcTerminalSandboxRuntime {
+	private static readonly _configVersion = '0.4.0-alpha';
+
+	getExecutablePath(appRoot: string, arch: string | undefined): string {
+		const binArch = arch === 'arm64' ? 'arm64' : 'x64';
+		return win32.join(appRoot, 'node_modules', '@microsoft', 'mxc-sdk', 'bin', binArch, 'wxc-exec.exe');
+	}
+
+	getRuntimeReadPaths(appRoot: string | undefined, executablePath: string | undefined): string[] {
+		const paths: string[] = [];
+		if (appRoot) {
+			paths.push(appRoot);
+		}
+		if (executablePath) {
+			paths.push(executablePath, win32.dirname(executablePath));
+		}
+		return [...new Set(paths)];
+	}
+
+	createConfig(options: IWindowsMxcConfigOptions): IWindowsMxcConfig {
+		const tempDirPath = this.toWindowsPath(options.tempDir);
+		return {
+			version: WindowsMxcTerminalSandboxRuntime._configVersion,
+			containment: 'process',
+			lifecycle: {
+				destroyOnExit: true,
+				preservePolicy: false,
+			},
+			process: {
+				commandLine: this._createProcessCommandLine(options.command, options.shell),
+				cwd: options.cwd ? this.toWindowsPath(options.cwd) : tempDirPath,
+				env: [
+					`TEMP=${tempDirPath}`,
+					`TMP=${tempDirPath}`,
+					...options.env
+				],
+				timeout: 0,
+			},
+			filesystem: {
+				readwritePaths: options.allowWritePaths,
+				readonlyPaths: options.allowReadPaths,
+				deniedPaths: []
+				// deniedPaths: options.denyReadPaths,
+			},
+			network: this._createNetworkConfig(options.allowNetwork, options.networkDomains),
+			ui: {
+				disable: false,
+				clipboard: 'none',
+				injection: false,
+			},
+		};
+	}
+
+	wrapCommand(executablePath: string, configPath: string, shell: string | undefined): string {
+		if (this._isCmd(shell)) {
+			return `${this._quoteCmdArgument(executablePath)} --debug --log-file debug.json ${this._quoteCmdArgument(configPath)}`;
+		}
+		return `& ${this._quotePowerShellArgument(executablePath)} --debug --log-file debug.json ${this._quotePowerShellArgument(configPath)}`;
+	}
+
+	wrapUnsandboxedCommand(command: string, tempDir: URI | undefined, shell: string | undefined): string {
+		if (!tempDir) {
+			return command;
+		}
+
+		const tempDirPath = this.toWindowsPath(tempDir);
+		if (this._isCmd(shell)) {
+			return `set ${this._quoteCmdArgument(`TEMP=${tempDirPath}`)} && set ${this._quoteCmdArgument(`TMP=${tempDirPath}`)} && ${command}`;
+		}
+		return `$env:TEMP=${this._quotePowerShellArgument(tempDirPath)}; $env:TMP=${this._quotePowerShellArgument(tempDirPath)}; ${command}`;
+	}
+
+	toWindowsPath(uri: URI): string {
+		let value: string;
+		if (uri.authority && uri.path.length > 1 && uri.scheme === 'file') {
+			value = `\\\\${uri.authority}${uri.path}`;
+		} else if (/^\/[a-zA-Z]:/.test(uri.path)) {
+			value = uri.path.slice(1);
+		} else {
+			value = uri.fsPath;
+		}
+		return value.replace(/\//g, '\\');
+	}
+
+	private _createNetworkConfig(allowNetwork: boolean, networkDomains: ITerminalSandboxResolvedNetworkDomains): IWindowsMxcNetworkConfig {
+		if (allowNetwork) {
+			return { defaultPolicy: 'allow' };
+		}
+
+		return {
+			defaultPolicy: 'block',
+			allowedHosts: networkDomains.allowedDomains,
+			blockedHosts: networkDomains.deniedDomains,
+		};
+	}
+
+	private _isCmd(shell: string | undefined): boolean {
+		const shellName = shell ? win32.basename(shell).toLowerCase() : '';
+		return shellName === 'cmd' || shellName === 'cmd.exe';
+	}
+
+	private _isPowerShell(shell: string | undefined): boolean {
+		const shellName = shell ? win32.basename(shell).toLowerCase().replace(/\.exe$/, '') : '';
+		return shellName === 'powershell' || shellName === 'pwsh' || shellName === 'powershell-preview' || shellName === 'pwsh-preview';
+	}
+
+	private _createProcessCommandLine(command: string, shell: string | undefined): string {
+		if (this._isPowerShell(shell)) {
+			return `${this._quoteWindowsProcessArgument(shell!)} -Command ${this._quoteWindowsProcessArgument(command)}`;
+		}
+
+		const cmdShell = shell && this._isCmd(shell) ? shell : 'cmd.exe';
+		return `${this._quoteWindowsProcessArgument(cmdShell)} /d /s /c ${this._quoteCmdArgument(command)}`;
+	}
+
+	private _quoteWindowsProcessArgument(value: string): string {
+		if (value.length > 0 && !/[\s"]/.test(value)) {
+			return value;
+		}
+		return `"${value.replace(/(\\*)"/g, `$1$1\\"`).replace(/\\+$/g, `$&$&`)}"`;
+	}
+
+	private _quotePowerShellArgument(value: string): string {
+		return `'${value.replace(/'/g, `''`)}'`;
+	}
+
+	private _quoteCmdArgument(value: string): string {
+		return `"${value.replace(/"/g, `""`)}"`;
+	}
+}

--- a/src/vs/platform/sandbox/common/terminalSandboxMxcRuntime.ts
+++ b/src/vs/platform/sandbox/common/terminalSandboxMxcRuntime.ts
@@ -157,15 +157,16 @@ export class WindowsMxcTerminalSandboxRuntime implements IWindowsMxcTerminalSand
 	}
 
 	private _createNetworkConfig(allowNetwork: boolean, networkDomains: ITerminalSandboxResolvedNetworkDomains): IWindowsMxcNetworkConfig {
-		if (allowNetwork) {
-			return { defaultPolicy: 'allow' };
-		}
-
-		return {
-			defaultPolicy: 'block',
-			allowedHosts: networkDomains.allowedDomains,
-			blockedHosts: networkDomains.deniedDomains
-		};
+		// if (allowNetwork) {
+		// 	return { defaultPolicy: 'allow' };
+		// }
+		return { defaultPolicy: 'allow' };
+		// TODO: No Proxy support in MXC yet, so we can't reliably allowlist domains. For now, we just block all network access when network is disallowed, and will add allowlist support later when Proxy is supported.
+		// return {
+		// 	defaultPolicy: 'block',
+		// 	allowedHosts: networkDomains.allowedDomains,
+		// 	blockedHosts: networkDomains.deniedDomains
+		// };
 	}
 
 	private _createPowerShellCommandLine(command: string, powerShellPath: string | undefined): string {

--- a/src/vs/platform/sandbox/common/terminalSandboxMxcRuntime.ts
+++ b/src/vs/platform/sandbox/common/terminalSandboxMxcRuntime.ts
@@ -66,7 +66,7 @@ export interface IWindowsMxcTerminalSandboxRuntime {
 	getRuntimeReadPaths(appRoot: string | undefined, executablePath: string | undefined): string[];
 	createConfig(options: IWindowsMxcConfigOptions): IWindowsMxcConfig;
 	wrapCommand(executablePath: string, configPath: string): string;
-	wrapUnsandboxedCommand(command: string, tempDir: URI | undefined): string;
+	wrapUnsandboxedCommand(command: string): string;
 	toWindowsPath(uri: URI): string;
 }
 
@@ -133,13 +133,8 @@ export class WindowsMxcTerminalSandboxRuntime implements IWindowsMxcTerminalSand
 		return `& ${this._quotePowerShellArgument(executablePath)} ${this._quotePowerShellArgument(configPath)}`;
 	}
 
-	wrapUnsandboxedCommand(command: string, tempDir: URI | undefined): string {
-		if (!tempDir) {
-			return command;
-		}
-
-		const tempDirPath = this.toWindowsPath(tempDir);
-		return `$env:TEMP=${this._quotePowerShellArgument(tempDirPath)}; $env:TMP=${this._quotePowerShellArgument(tempDirPath)}; ${command}`;
+	wrapUnsandboxedCommand(command: string): string {
+		return command;
 	}
 
 	toWindowsPath(uri: URI): string {

--- a/src/vs/platform/sandbox/common/terminalSandboxMxcRuntime.ts
+++ b/src/vs/platform/sandbox/common/terminalSandboxMxcRuntime.ts
@@ -122,8 +122,7 @@ export class WindowsMxcTerminalSandboxRuntime implements IWindowsMxcTerminalSand
 				readonlyPaths: [...new Set([tempDirPath, ...options.allowReadPaths])],
 				deniedPaths: options.denyReadPaths,
 			},
-			//TODO: currently no proxy. By default we allow all network access.
-			network: this._createNetworkConfig(true, options.networkDomains),
+			network: this._createNetworkConfig(options.allowNetwork, options.networkDomains),
 			ui: {
 				disable: false,
 				clipboard: 'none',
@@ -133,7 +132,7 @@ export class WindowsMxcTerminalSandboxRuntime implements IWindowsMxcTerminalSand
 	}
 
 	wrapCommand(executablePath: string, configPath: string): string {
-		return `& ${this._quotePowerShellArgument(executablePath)}  ${this._quotePowerShellArgument(configPath)}`;
+		return `& ${this._quotePowerShellArgument(executablePath)} ${this._quotePowerShellArgument(configPath)}`;
 	}
 
 	wrapUnsandboxedCommand(command: string, tempDir: URI | undefined): string {

--- a/src/vs/platform/sandbox/common/terminalSandboxMxcRuntime.ts
+++ b/src/vs/platform/sandbox/common/terminalSandboxMxcRuntime.ts
@@ -5,29 +5,31 @@
 
 import { win32 } from '../../../base/common/path.js';
 import { URI } from '../../../base/common/uri.js';
+import { createDecorator } from '../../instantiation/common/instantiation.js';
 import type { ITerminalSandboxResolvedNetworkDomains } from './terminalSandboxService.js';
 
-interface IWindowsMxcProcessConfig {
+export interface IWindowsMxcProcessConfig {
 	commandLine: string;
 	cwd?: string;
 	env: string[];
 	timeout: number;
 }
 
-interface IWindowsMxcFilesystemConfig {
+export interface IWindowsMxcFilesystemConfig {
 	readwritePaths: string[];
 	readonlyPaths: string[];
 	deniedPaths: string[];
 }
 
-interface IWindowsMxcNetworkConfig {
+export interface IWindowsMxcNetworkConfig {
 	defaultPolicy: 'allow' | 'block';
 	allowedHosts?: string[];
 	blockedHosts?: string[];
 }
 
-interface IWindowsMxcConfig {
+export interface IWindowsMxcConfig {
 	version: string;
+	containerId: string;
 	containment: 'process';
 	lifecycle: {
 		destroyOnExit: boolean;
@@ -45,7 +47,7 @@ interface IWindowsMxcConfig {
 
 export interface IWindowsMxcConfigOptions {
 	command: string;
-	shell: string | undefined;
+	powerShellPath: string | undefined;
 	cwd: URI | undefined;
 	tempDir: URI;
 	allowNetwork: boolean;
@@ -56,14 +58,30 @@ export interface IWindowsMxcConfigOptions {
 	env: string[];
 }
 
+export const IWindowsMxcTerminalSandboxRuntime = createDecorator<IWindowsMxcTerminalSandboxRuntime>('windowsMxcTerminalSandboxRuntime');
+
+export interface IWindowsMxcTerminalSandboxRuntime {
+	readonly _serviceBrand: undefined;
+
+	getExecutablePath(appRoot: string, arch: string | undefined): string;
+	getRuntimeReadPaths(appRoot: string | undefined, executablePath: string | undefined): string[];
+	createConfig(options: IWindowsMxcConfigOptions): IWindowsMxcConfig;
+	wrapCommand(executablePath: string, configPath: string): string;
+	wrapUnsandboxedCommand(command: string, tempDir: URI | undefined): string;
+	toWindowsPath(uri: URI): string;
+}
+
 /**
  * Windows-only MXC integration for terminal sandboxing.
  *
  * This class is intentionally isolated from the SRT-backed runtime so it can be
  * removed once SRT supports Windows sandboxing.
  */
-export class WindowsMxcTerminalSandboxRuntime {
-	private static readonly _configVersion = '0.4.0-alpha';
+export class WindowsMxcTerminalSandboxRuntime implements IWindowsMxcTerminalSandboxRuntime {
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _configVersion = '0.4.0-alpha';
+	private readonly _fallbackPowerShellPath = 'powershell.exe';
 
 	getExecutablePath(appRoot: string, arch: string | undefined): string {
 		const binArch = arch === 'arm64' ? 'arm64' : 'x64';
@@ -84,29 +102,28 @@ export class WindowsMxcTerminalSandboxRuntime {
 	createConfig(options: IWindowsMxcConfigOptions): IWindowsMxcConfig {
 		const tempDirPath = this.toWindowsPath(options.tempDir);
 		return {
-			version: WindowsMxcTerminalSandboxRuntime._configVersion,
+			version: this._configVersion,
+			containerId: 'vscode-terminal-sandbox',
 			containment: 'process',
 			lifecycle: {
 				destroyOnExit: true,
 				preservePolicy: false,
 			},
 			process: {
-				commandLine: this._createProcessCommandLine(options.command, options.shell),
+				commandLine: this._createPowerShellCommandLine(options.command, options.powerShellPath),
 				cwd: options.cwd ? this.toWindowsPath(options.cwd) : tempDirPath,
 				env: [
-					`TEMP=${tempDirPath}`,
-					`TMP=${tempDirPath}`,
 					...options.env
 				],
 				timeout: 0,
 			},
 			filesystem: {
-				readwritePaths: options.allowWritePaths,
-				readonlyPaths: options.allowReadPaths,
-				deniedPaths: []
-				// deniedPaths: options.denyReadPaths,
+				readwritePaths: [...new Set([...options.allowWritePaths])],
+				readonlyPaths: [...new Set([tempDirPath, ...options.allowReadPaths])],
+				deniedPaths: options.denyReadPaths,
 			},
-			network: this._createNetworkConfig(options.allowNetwork, options.networkDomains),
+			//TODO: currently no proxy. By default we allow all network access.
+			network: this._createNetworkConfig(true, options.networkDomains),
 			ui: {
 				disable: false,
 				clipboard: 'none',
@@ -115,22 +132,16 @@ export class WindowsMxcTerminalSandboxRuntime {
 		};
 	}
 
-	wrapCommand(executablePath: string, configPath: string, shell: string | undefined): string {
-		if (this._isCmd(shell)) {
-			return `${this._quoteCmdArgument(executablePath)} --debug --log-file debug.json ${this._quoteCmdArgument(configPath)}`;
-		}
-		return `& ${this._quotePowerShellArgument(executablePath)} --debug --log-file debug.json ${this._quotePowerShellArgument(configPath)}`;
+	wrapCommand(executablePath: string, configPath: string): string {
+		return `& ${this._quotePowerShellArgument(executablePath)}  ${this._quotePowerShellArgument(configPath)}`;
 	}
 
-	wrapUnsandboxedCommand(command: string, tempDir: URI | undefined, shell: string | undefined): string {
+	wrapUnsandboxedCommand(command: string, tempDir: URI | undefined): string {
 		if (!tempDir) {
 			return command;
 		}
 
 		const tempDirPath = this.toWindowsPath(tempDir);
-		if (this._isCmd(shell)) {
-			return `set ${this._quoteCmdArgument(`TEMP=${tempDirPath}`)} && set ${this._quoteCmdArgument(`TMP=${tempDirPath}`)} && ${command}`;
-		}
 		return `$env:TEMP=${this._quotePowerShellArgument(tempDirPath)}; $env:TMP=${this._quotePowerShellArgument(tempDirPath)}; ${command}`;
 	}
 
@@ -154,27 +165,12 @@ export class WindowsMxcTerminalSandboxRuntime {
 		return {
 			defaultPolicy: 'block',
 			allowedHosts: networkDomains.allowedDomains,
-			blockedHosts: networkDomains.deniedDomains,
+			blockedHosts: networkDomains.deniedDomains
 		};
 	}
 
-	private _isCmd(shell: string | undefined): boolean {
-		const shellName = shell ? win32.basename(shell).toLowerCase() : '';
-		return shellName === 'cmd' || shellName === 'cmd.exe';
-	}
-
-	private _isPowerShell(shell: string | undefined): boolean {
-		const shellName = shell ? win32.basename(shell).toLowerCase().replace(/\.exe$/, '') : '';
-		return shellName === 'powershell' || shellName === 'pwsh' || shellName === 'powershell-preview' || shellName === 'pwsh-preview';
-	}
-
-	private _createProcessCommandLine(command: string, shell: string | undefined): string {
-		if (this._isPowerShell(shell)) {
-			return `${this._quoteWindowsProcessArgument(shell!)} -Command ${this._quoteWindowsProcessArgument(command)}`;
-		}
-
-		const cmdShell = shell && this._isCmd(shell) ? shell : 'cmd.exe';
-		return `${this._quoteWindowsProcessArgument(cmdShell)} /d /s /c ${this._quoteCmdArgument(command)}`;
+	private _createPowerShellCommandLine(command: string, powerShellPath: string | undefined): string {
+		return `${this._quoteWindowsProcessArgument(powerShellPath ?? this._fallbackPowerShellPath)} -NonInteractive -Command ${this._quoteWindowsProcessArgument(command)}`;
 	}
 
 	private _quoteWindowsProcessArgument(value: string): string {
@@ -186,9 +182,5 @@ export class WindowsMxcTerminalSandboxRuntime {
 
 	private _quotePowerShellArgument(value: string): string {
 		return `'${value.replace(/'/g, `''`)}'`;
-	}
-
-	private _quoteCmdArgument(value: string): string {
-		return `"${value.replace(/"/g, `""`)}"`;
 	}
 }

--- a/src/vs/platform/sandbox/common/terminalSandboxReadAllowList.ts
+++ b/src/vs/platform/sandbox/common/terminalSandboxReadAllowList.ts
@@ -86,6 +86,10 @@ const terminalSandboxReadAllowListKeywordMap: ReadonlyMap<string, TerminalSandbo
  */
 
 function getTerminalSandboxReadAllowListForOperation(operation: TerminalSandboxReadAllowListOperation, os: OperatingSystem): readonly string[] {
+	if (os === OperatingSystem.Windows) {
+		return [];
+	}
+
 	switch (operation) {
 		case TerminalSandboxReadAllowListOperation.Git:
 			switch (os) {

--- a/src/vs/platform/sandbox/common/terminalSandboxRuntimeConfigurationPerOperation.ts
+++ b/src/vs/platform/sandbox/common/terminalSandboxRuntimeConfigurationPerOperation.ts
@@ -53,6 +53,8 @@ function getTerminalSandboxRuntimeConfigurationForOperation(operation: TerminalS
 
 		case TerminalSandboxRuntimeConfigurationOperation.Node:
 			switch (os) {
+				case OperatingSystem.Windows:
+					return {};
 				case OperatingSystem.Macintosh:
 				case OperatingSystem.Linux:
 				default:

--- a/src/vs/platform/sandbox/node/sandboxHelper.ts
+++ b/src/vs/platform/sandbox/node/sandboxHelper.ts
@@ -3,9 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { isLinux } from '../../../base/common/platform.js';
+import { getCaseInsensitive } from '../../../base/common/objects.js';
+import { isLinux, isWindows } from '../../../base/common/platform.js';
 import { findExecutable } from '../../../base/node/processes.js';
-import { ISandboxDependencyStatus, ISandboxHelperService } from '../common/sandboxHelperService.js';
+import { ISandboxDependencyStatus, ISandboxHelperService, IWindowsMxcFilesystemPolicy } from '../common/sandboxHelperService.js';
 
 type FindCommand = (command: string) => Promise<string | undefined>;
 
@@ -30,5 +31,35 @@ export class SandboxHelperService implements ISandboxHelperService {
 
 	checkSandboxDependencies(): Promise<ISandboxDependencyStatus | undefined> {
 		return SandboxHelperService.checkSandboxDependenciesWith(findExecutable);
+	}
+
+	async getWindowsMxcFilesystemPolicy(): Promise<IWindowsMxcFilesystemPolicy | undefined> {
+		if (!isWindows) {
+			return undefined;
+		}
+
+		const { getAvailableToolsPolicy, getUserProfilePolicy } = await import('@microsoft/mxc-sdk');
+		const availableToolsPolicy = getAvailableToolsPolicy(process.env, { containerType: 'processcontainer' });
+		const userProfilePolicy = getUserProfilePolicy();
+		return {
+			readonlyPaths: [...new Set([...availableToolsPolicy.readonlyPaths, ...userProfilePolicy.readonlyPaths])],
+			readwritePaths: [...new Set([...availableToolsPolicy.readwritePaths, ...userProfilePolicy.readwritePaths])],
+		};
+	}
+
+	async getWindowsMxcEnvironment(): Promise<string[] | undefined> {
+		if (!isWindows) {
+			return undefined;
+		}
+
+		const env: string[] = [];
+		const path = getCaseInsensitive(process.env, 'PATH');
+		if (typeof path === 'string' && path) {
+			env.push(`PATH=${path}`);
+		}
+
+		const pathExt = getCaseInsensitive(process.env, 'PATHEXT');
+		env.push(`PATHEXT=${typeof pathExt === 'string' && pathExt ? pathExt : '.COM;.EXE;.BAT;.CMD'}`);
+		return env;
 	}
 }

--- a/src/vs/platform/sandbox/node/sandboxHelper.ts
+++ b/src/vs/platform/sandbox/node/sandboxHelper.ts
@@ -42,7 +42,7 @@ export class SandboxHelperService implements ISandboxHelperService {
 		const availableToolsPolicy = getAvailableToolsPolicy(process.env, { containerType: 'processcontainer' });
 		const userProfilePolicy = getUserProfilePolicy();
 		return {
-			readonlyPaths: [...new Set([...availableToolsPolicy.readonlyPaths, ...userProfilePolicy.readonlyPaths])],
+			readonlyPaths: [...new Set([...availableToolsPolicy.readonlyPaths, ...userProfilePolicy.readonlyPaths, ...this._getPSModuleReadPaths(), ...this._getTempReadPaths()])],
 			readwritePaths: [...new Set([...availableToolsPolicy.readwritePaths, ...userProfilePolicy.readwritePaths])],
 		};
 	}
@@ -60,6 +60,31 @@ export class SandboxHelperService implements ISandboxHelperService {
 
 		const pathExt = getCaseInsensitive(process.env, 'PATHEXT');
 		env.push(`PATHEXT=${typeof pathExt === 'string' && pathExt ? pathExt : '.COM;.EXE;.BAT;.CMD'}`);
+
+		const psModulePath = this._getPSModuleReadPaths();
+		if (psModulePath.length) {
+			env.push(`PSModulePath=${psModulePath.join(';')}`);
+		}
 		return env;
+	}
+
+	private _getPSModuleReadPaths(): string[] {
+		const paths: string[] = [];
+		const psModulePath = getCaseInsensitive(process.env, 'PSModulePath');
+		if (typeof psModulePath === 'string' && psModulePath) {
+			paths.push(...psModulePath.split(';'));
+		}
+		return paths;
+	}
+
+	private _getTempReadPaths(): string[] {
+		const paths: string[] = [];
+		for (const variable of ['TMP', 'TEMP']) {
+			const path = getCaseInsensitive(process.env, variable);
+			if (typeof path === 'string' && path) {
+				paths.push(path);
+			}
+		}
+		return paths;
 	}
 }

--- a/src/vs/platform/sandbox/node/sandboxHelper.ts
+++ b/src/vs/platform/sandbox/node/sandboxHelper.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { getCaseInsensitive } from '../../../base/common/objects.js';
+import { win32 } from '../../../base/common/path.js';
 import { isLinux, isWindows } from '../../../base/common/platform.js';
 import { findExecutable } from '../../../base/node/processes.js';
 import { ISandboxDependencyStatus, ISandboxHelperService, IWindowsMxcFilesystemPolicy } from '../common/sandboxHelperService.js';
@@ -41,8 +42,9 @@ export class SandboxHelperService implements ISandboxHelperService {
 		const { getAvailableToolsPolicy, getUserProfilePolicy } = await import('@microsoft/mxc-sdk');
 		const availableToolsPolicy = getAvailableToolsPolicy(process.env, { containerType: 'processcontainer' });
 		const userProfilePolicy = getUserProfilePolicy();
+		const psHome = await this._getPSHome();
 		return {
-			readonlyPaths: [...new Set([...availableToolsPolicy.readonlyPaths, ...userProfilePolicy.readonlyPaths, ...this._getPSModuleReadPaths(), ...this._getTempReadPaths()])],
+			readonlyPaths: [...new Set([...availableToolsPolicy.readonlyPaths, ...userProfilePolicy.readonlyPaths, ...this._getTempReadPaths(), ...(psHome ? [psHome] : [])])],
 			readwritePaths: [...new Set([...availableToolsPolicy.readwritePaths, ...userProfilePolicy.readwritePaths])],
 		};
 	}
@@ -58,23 +60,21 @@ export class SandboxHelperService implements ISandboxHelperService {
 			env.push(`PATH=${path}`);
 		}
 
-		const pathExt = getCaseInsensitive(process.env, 'PATHEXT');
-		env.push(`PATHEXT=${typeof pathExt === 'string' && pathExt ? pathExt : '.COM;.EXE;.BAT;.CMD'}`);
-
-		const psModulePath = this._getPSModuleReadPaths();
-		if (psModulePath.length) {
-			env.push(`PSModulePath=${psModulePath.join(';')}`);
+		const psHome = await this._getPSHome();
+		if (psHome) {
+			env.push(`PSHOME=${psHome}`);
 		}
 		return env;
 	}
 
-	private _getPSModuleReadPaths(): string[] {
-		const paths: string[] = [];
-		const psModulePath = getCaseInsensitive(process.env, 'PSModulePath');
-		if (typeof psModulePath === 'string' && psModulePath) {
-			paths.push(...psModulePath.split(';'));
+	private async _getPSHome(): Promise<string | undefined> {
+		const psHome = getCaseInsensitive(process.env, 'PSHOME');
+		if (typeof psHome === 'string' && psHome) {
+			return psHome;
 		}
-		return paths;
+
+		const powerShellPath = await findExecutable('pwsh') ?? await findExecutable('powershell');
+		return powerShellPath ? win32.dirname(powerShellPath) : undefined;
 	}
 
 	private _getTempReadPaths(): string[] {

--- a/src/vs/platform/sandbox/test/common/terminalSandboxEngine.test.ts
+++ b/src/vs/platform/sandbox/test/common/terminalSandboxEngine.test.ts
@@ -99,6 +99,10 @@ suite('TerminalSandboxEngine', () => {
 		return path.replace(/\\/g, '/').toLowerCase();
 	}
 
+	function enableWindowsSandbox(): void {
+		configurationService.setUserConfiguration(AgentSandboxSettingId.AgentSandboxWindowsEnabled, AgentSandboxEnabledValue.AllowNetwork);
+	}
+
 	setup(() => {
 		createdFiles = new Map();
 		createFileCount = 0;
@@ -228,15 +232,26 @@ suite('TerminalSandboxEngine', () => {
 		await engine.cleanupTempDir(); // must not throw
 	});
 
-	test('isEnabled returns true on Windows when configured', async () => {
+	test('isEnabled returns false on Windows when Windows sandbox setting is disabled by default', async () => {
+		const host = createWindowsHost();
+		const engine = store.add(instantiationService.createInstance(TerminalSandboxEngine, host));
+
+		strictEqual(await engine.isEnabled(), false);
+		strictEqual(await engine.isSandboxAllowNetworkEnabled(), false);
+		strictEqual(await engine.getSandboxConfigPath(), undefined);
+	});
+
+	test('isEnabled returns true on Windows when globally enabled and Windows sandbox setting allows network', async () => {
+		enableWindowsSandbox();
 		const host = createWindowsHost();
 		const engine = store.add(instantiationService.createInstance(TerminalSandboxEngine, host));
 
 		strictEqual(await engine.isEnabled(), true);
-		strictEqual(await engine.isSandboxAllowNetworkEnabled(), false);
+		strictEqual(await engine.isSandboxAllowNetworkEnabled(), true);
 	});
 
 	test('wrapCommand uses MXC executable and writes MXC config on Windows', async () => {
+		enableWindowsSandbox();
 		const host = createWindowsHost();
 		const engine = store.add(instantiationService.createInstance(TerminalSandboxEngine, host));
 
@@ -255,7 +270,7 @@ suite('TerminalSandboxEngine', () => {
 		strictEqual(config.ui.disable, false);
 		ok(config.process.env.includes('PATH=C:\\tools\\node;C:\\Windows\\System32'), 'PATH should be injected into the MXC process env');
 		ok(config.process.env.includes('PSHOME=C:\\Program Files\\PowerShell\\7'), 'PSHOME should be injected into the MXC process env');
-		deepStrictEqual(config.network, { defaultPolicy: 'block', allowedHosts: [], blockedHosts: [] });
+		deepStrictEqual(config.network, { defaultPolicy: 'allow' });
 		ok(config.filesystem.readwritePaths.some((path: string) => normalizeWindowsPathForAssert(path) === 'c:/workspace'), 'Workspace should be writable');
 		ok(config.filesystem.readwritePaths.some((path: string) => normalizeWindowsPathForAssert(path).endsWith('/.test-data/tmp')), 'Sandbox temp dir should be writable');
 		ok(config.filesystem.readonlyPaths.some((path: string) => normalizeWindowsPathForAssert(path).endsWith('/.test-data/tmp')), 'Sandbox temp dir should be readable through readonly paths');
@@ -267,6 +282,7 @@ suite('TerminalSandboxEngine', () => {
 	});
 
 	test('wrapCommand applies Windows filesystem setting to MXC config', async () => {
+		enableWindowsSandbox();
 		configurationService.setUserConfiguration(AgentSandboxSettingId.AgentSandboxWindowsFileSystem, {
 			allowWrite: ['C:\\configured\\write'],
 			allowRead: ['C:\\configured\\read'],
@@ -288,6 +304,7 @@ suite('TerminalSandboxEngine', () => {
 	});
 
 	test('wrapCommand uses arm64 MXC executable on Windows arm64', async () => {
+		enableWindowsSandbox();
 		const host = createWindowsHost({
 			getRuntimeInfo: () => Promise.resolve({ appRoot: 'C:\\app', arch: 'arm64' }),
 		});
@@ -303,6 +320,7 @@ suite('TerminalSandboxEngine', () => {
 	});
 
 	test('wrapCommand rewrites MXC config when Windows command changes', async () => {
+		enableWindowsSandbox();
 		const host = createWindowsHost();
 		const engine = store.add(instantiationService.createInstance(TerminalSandboxEngine, host));
 
@@ -320,6 +338,7 @@ suite('TerminalSandboxEngine', () => {
 	});
 
 	test('allowNetwork maps to MXC allow network config on Windows', async () => {
+		enableWindowsSandbox();
 		configurationService.setUserConfiguration(AgentSandboxSettingId.AgentSandboxEnabled, AgentSandboxEnabledValue.AllowNetwork);
 		const host = createWindowsHost();
 		const engine = store.add(instantiationService.createInstance(TerminalSandboxEngine, host));

--- a/src/vs/platform/sandbox/test/common/terminalSandboxEngine.test.ts
+++ b/src/vs/platform/sandbox/test/common/terminalSandboxEngine.test.ts
@@ -90,7 +90,7 @@ suite('TerminalSandboxEngine', () => {
 			getWorkspaceStorageReadRoot: () => Promise.resolve(URI.from({ scheme: 'file', path: '/c:/Users/user/workspaceStorage/workspace-id' })),
 			getWriteRoots: () => [URI.from({ scheme: 'file', path: '/c:/workspace' })],
 			getWindowsMxcFilesystemPolicy: () => Promise.resolve({ readonlyPaths: ['C:\\tools\\node', 'C:\\tools\\python', 'C:\\Users\\user\\AppData\\Local\\Programs\\Git', 'C:\\Users\\user\\AppData\\Local\\Temp'], readwritePaths: [] }),
-			getWindowsMxcEnvironment: () => Promise.resolve(['PATH=C:\\tools\\node;C:\\Windows\\System32', 'PATHEXT=.COM;.EXE;.BAT;.CMD']),
+			getWindowsMxcEnvironment: () => Promise.resolve(['PATH=C:\\tools\\node;C:\\Windows\\System32', 'PSHOME=C:\\Program Files\\PowerShell\\7']),
 			...overrides,
 		});
 	}
@@ -254,7 +254,7 @@ suite('TerminalSandboxEngine', () => {
 		strictEqual(normalizeWindowsPathForAssert(config.process.cwd), 'c:/workspace');
 		strictEqual(config.ui.disable, false);
 		ok(config.process.env.includes('PATH=C:\\tools\\node;C:\\Windows\\System32'), 'PATH should be injected into the MXC process env');
-		ok(config.process.env.includes('PATHEXT=.COM;.EXE;.BAT;.CMD'), 'PATHEXT should be injected into the MXC process env');
+		ok(config.process.env.includes('PSHOME=C:\\Program Files\\PowerShell\\7'), 'PSHOME should be injected into the MXC process env');
 		deepStrictEqual(config.network, { defaultPolicy: 'block', allowedHosts: [], blockedHosts: [] });
 		ok(config.filesystem.readwritePaths.some((path: string) => normalizeWindowsPathForAssert(path) === 'c:/workspace'), 'Workspace should be writable');
 		ok(config.filesystem.readwritePaths.some((path: string) => normalizeWindowsPathForAssert(path).endsWith('/.test-data/tmp')), 'Sandbox temp dir should be writable');

--- a/src/vs/platform/sandbox/test/common/terminalSandboxEngine.test.ts
+++ b/src/vs/platform/sandbox/test/common/terminalSandboxEngine.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ok, strictEqual } from 'assert';
+import { deepStrictEqual, ok, strictEqual } from 'assert';
 import { VSBuffer } from '../../../../base/common/buffer.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { OperatingSystem } from '../../../../base/common/platform.js';
@@ -14,7 +14,7 @@ import { TestConfigurationService } from '../../../configuration/test/common/tes
 import { IFileService } from '../../../files/common/files.js';
 import { TestInstantiationService } from '../../../instantiation/test/common/instantiationServiceMock.js';
 import { ILogService, NullLogService } from '../../../log/common/log.js';
-import type { ISandboxDependencyStatus } from '../../common/sandboxHelperService.js';
+import type { ISandboxDependencyStatus, IWindowsMxcFilesystemPolicy } from '../../common/sandboxHelperService.js';
 import { AgentSandboxEnabledValue, AgentSandboxSettingId } from '../../common/settings.js';
 import { ITerminalSandboxEngineHost, ITerminalSandboxRuntimeInfo, TerminalSandboxEngine } from '../../common/terminalSandboxEngine.js';
 
@@ -42,7 +42,12 @@ suite('TerminalSandboxEngine', () => {
 
 		async createFile(uri: URI, content: VSBuffer): Promise<any> {
 			createFileCount++;
-			createdFiles.set(uri.path, content.toString());
+			const contentString = content.toString();
+			createdFiles.set(uri.path, contentString);
+			createdFiles.set(uri.fsPath, contentString);
+			if (/^\/[a-zA-Z]:/.test(uri.path)) {
+				createdFiles.set(uri.path.slice(1).replace(/\//g, '\\'), contentString);
+			}
 			return {};
 		}
 		async createFolder(uri: URI): Promise<any> {
@@ -68,9 +73,29 @@ suite('TerminalSandboxEngine', () => {
 			getWriteRoots: () => [URI.file('/workspace')],
 			onDidChangeRoots: rootsEmitter.event,
 			checkSandboxDependencies: (): Promise<ISandboxDependencyStatus | undefined> => Promise.resolve({ bubblewrapInstalled: true, socatInstalled: true }),
+			getWindowsMxcFilesystemPolicy: (): Promise<IWindowsMxcFilesystemPolicy | undefined> => Promise.resolve(undefined),
+			getWindowsMxcEnvironment: (): Promise<string[] | undefined> => Promise.resolve(undefined),
 			...overrides,
 		};
 		return Object.assign(host, { rootsEmitter });
+	}
+
+	function createWindowsHost(overrides: Partial<ITerminalSandboxEngineHost> = {}): ITerminalSandboxEngineHost & { rootsEmitter: Emitter<void> } {
+		return createHost({
+			getOS: () => Promise.resolve(OperatingSystem.Windows),
+			getRuntimeInfo: () => Promise.resolve({ appRoot: 'C:\\app', arch: 'x64' }),
+			getUserHome: () => Promise.resolve(URI.from({ scheme: 'file', path: '/c:/Users/user' })),
+			getSandboxTempDir: () => Promise.resolve(URI.from({ scheme: 'file', path: '/c:/Users/user/.test-data/tmp' })),
+			getWorkspaceStorageReadRoot: () => Promise.resolve(URI.from({ scheme: 'file', path: '/c:/Users/user/workspaceStorage/workspace-id' })),
+			getWriteRoots: () => [URI.from({ scheme: 'file', path: '/c:/workspace' })],
+			getWindowsMxcFilesystemPolicy: () => Promise.resolve({ readonlyPaths: ['C:\\tools\\node', 'C:\\tools\\python', 'C:\\Users\\user\\AppData\\Local\\Programs\\Git'], readwritePaths: [] }),
+			getWindowsMxcEnvironment: () => Promise.resolve(['PATH=C:\\tools\\node;C:\\Windows\\System32', 'PATHEXT=.COM;.EXE;.BAT;.CMD']),
+			...overrides,
+		});
+	}
+
+	function normalizeWindowsPathForAssert(path: string): string {
+		return path.replace(/\\/g, '/').toLowerCase();
 	}
 
 	setup(() => {
@@ -201,12 +226,86 @@ suite('TerminalSandboxEngine', () => {
 		await engine.cleanupTempDir(); // must not throw
 	});
 
-	test('isEnabled returns false on Windows regardless of configuration', async () => {
-		const host = createHost({ getOS: () => Promise.resolve(OperatingSystem.Windows) });
+	test('isEnabled returns true on Windows when configured', async () => {
+		const host = createWindowsHost();
 		const engine = store.add(instantiationService.createInstance(TerminalSandboxEngine, host));
 
-		strictEqual(await engine.isEnabled(), false);
+		strictEqual(await engine.isEnabled(), true);
 		strictEqual(await engine.isSandboxAllowNetworkEnabled(), false);
+	});
+
+	test('wrapCommand uses MXC executable and writes MXC config on Windows', async () => {
+		const host = createWindowsHost();
+		const engine = store.add(instantiationService.createInstance(TerminalSandboxEngine, host));
+
+		const wrapped = await engine.wrapCommand('echo hello', false, 'pwsh', URI.from({ scheme: 'file', path: '/c:/workspace' }));
+		const configPath = await engine.getSandboxConfigPath();
+		ok(configPath, 'Config path should be defined');
+		const config = JSON.parse(createdFiles.get(configPath)!);
+
+		strictEqual(wrapped.isSandboxWrapped, true);
+		ok(wrapped.command.startsWith(`& 'C:\\app\\node_modules\\@microsoft\\mxc-sdk\\bin\\x64\\wxc-exec.exe'`), `Expected MXC executable. Actual: ${wrapped.command}`);
+		ok(wrapped.command.includes(` --debug --log-file debug.json '${configPath}'`), `Expected wrapped command to pass --debug, --log-file, and the MXC config path. Actual: ${wrapped.command}`);
+		strictEqual(config.version, '0.4.0-alpha');
+		strictEqual(config.containment, 'process');
+		ok(config.process.commandLine.startsWith('pwsh -NonInteractive -Command '), `Expected MXC process to launch through PowerShell. Actual: ${config.process.commandLine}`);
+		strictEqual(normalizeWindowsPathForAssert(config.process.cwd), 'c:/workspace');
+		strictEqual(config.ui.disable, false, 'PowerShell requires windowing APIs to start under MXC');
+		ok(config.process.env.includes('PATH=C:\\tools\\node;C:\\Windows\\System32'), 'PATH should be injected into the MXC process env');
+		ok(config.process.env.includes('PATHEXT=.COM;.EXE;.BAT;.CMD'), 'PATHEXT should be injected into the MXC process env');
+		deepStrictEqual(config.network, { defaultPolicy: 'block', allowedHosts: [], blockedHosts: [] });
+		ok(config.filesystem.readwritePaths.some((path: string) => normalizeWindowsPathForAssert(path) === 'c:/workspace'), 'Workspace should be writable');
+		ok(config.filesystem.readwritePaths.some((path: string) => normalizeWindowsPathForAssert(path).endsWith('/.test-data/tmp')), 'Sandbox temp dir should be writable');
+		ok(config.filesystem.readonlyPaths.some((path: string) => normalizeWindowsPathForAssert(path) === 'c:/app'), 'App root should be readable for MXC');
+		ok(config.filesystem.readonlyPaths.some((path: string) => normalizeWindowsPathForAssert(path) === 'c:/tools/node'), 'MXC available tools policy should add tool paths to readonly paths');
+		ok(config.filesystem.readonlyPaths.some((path: string) => normalizeWindowsPathForAssert(path) === 'c:/users/user/appdata/local/programs/git'), 'MXC user profile policy should add user profile paths to readonly paths');
+		ok(config.filesystem.deniedPaths.some((path: string) => normalizeWindowsPathForAssert(path) === 'c:/users/user'), 'User home should be denied by default');
+	});
+
+	test('wrapCommand uses arm64 MXC executable on Windows arm64', async () => {
+		const host = createWindowsHost({
+			getRuntimeInfo: () => Promise.resolve({ appRoot: 'C:\\app', arch: 'arm64' }),
+		});
+		const engine = store.add(instantiationService.createInstance(TerminalSandboxEngine, host));
+
+		const wrapped = await engine.wrapCommand('echo hello', false, 'pwsh');
+		const configPath = await engine.getSandboxConfigPath();
+		ok(configPath, 'Config path should be defined');
+		const config = JSON.parse(createdFiles.get(configPath)!);
+
+		ok(wrapped.command.startsWith(`& 'C:\\app\\node_modules\\@microsoft\\mxc-sdk\\bin\\arm64\\wxc-exec.exe' --debug --log-file debug.json `), `Expected arm64 MXC executable with --debug and --log-file. Actual: ${wrapped.command}`);
+		strictEqual(normalizeWindowsPathForAssert(config.process.cwd), 'c:/users/user/.test-data/tmp');
+	});
+
+	test('wrapCommand rewrites MXC config when Windows command changes', async () => {
+		const host = createWindowsHost();
+		const engine = store.add(instantiationService.createInstance(TerminalSandboxEngine, host));
+
+		await engine.wrapCommand('echo first', false, 'pwsh');
+		let configPath = await engine.getSandboxConfigPath();
+		ok(configPath, 'Config path should be defined');
+		const firstCommandLine = JSON.parse(createdFiles.get(configPath)!).process.commandLine;
+		ok(firstCommandLine.startsWith('pwsh -NonInteractive -Command '), `Expected first command to launch through PowerShell. Actual: ${firstCommandLine}`);
+
+		await engine.wrapCommand('echo second', false, 'pwsh');
+		configPath = await engine.getSandboxConfigPath();
+		ok(configPath, 'Config path should be defined');
+		const secondCommandLine = JSON.parse(createdFiles.get(configPath)!).process.commandLine;
+		ok(secondCommandLine.startsWith('pwsh -NonInteractive -Command '), `Expected second command to launch through PowerShell. Actual: ${secondCommandLine}`);
+		ok(secondCommandLine !== firstCommandLine, 'Changing the Windows command should rewrite the MXC process command line');
+	});
+
+	test('allowNetwork maps to MXC allow network config on Windows', async () => {
+		configurationService.setUserConfiguration(AgentSandboxSettingId.AgentSandboxEnabled, AgentSandboxEnabledValue.AllowNetwork);
+		const host = createWindowsHost();
+		const engine = store.add(instantiationService.createInstance(TerminalSandboxEngine, host));
+
+		await engine.wrapCommand('curl https://example.com', false, 'pwsh');
+		const configPath = await engine.getSandboxConfigPath();
+		ok(configPath, 'Config path should be defined');
+		const config = JSON.parse(createdFiles.get(configPath)!);
+
+		deepStrictEqual(config.network, { defaultPolicy: 'allow' });
 	});
 
 	test('uses OS-specific filesystem absolute path detection', async () => {

--- a/src/vs/platform/sandbox/test/common/terminalSandboxEngine.test.ts
+++ b/src/vs/platform/sandbox/test/common/terminalSandboxEngine.test.ts
@@ -241,7 +241,8 @@ suite('TerminalSandboxEngine', () => {
 		strictEqual(await engine.getSandboxConfigPath(), undefined);
 	});
 
-	test('isEnabled returns true on Windows when globally enabled and Windows sandbox setting allows network', async () => {
+	test('isEnabled returns true on Windows when Windows sandbox setting allows network even if global sandboxing is off', async () => {
+		configurationService.setUserConfiguration(AgentSandboxSettingId.AgentSandboxEnabled, AgentSandboxEnabledValue.Off);
 		enableWindowsSandbox();
 		const host = createWindowsHost();
 		const engine = store.add(instantiationService.createInstance(TerminalSandboxEngine, host));

--- a/src/vs/platform/sandbox/test/common/terminalSandboxEngine.test.ts
+++ b/src/vs/platform/sandbox/test/common/terminalSandboxEngine.test.ts
@@ -17,6 +17,7 @@ import { ILogService, NullLogService } from '../../../log/common/log.js';
 import type { ISandboxDependencyStatus, IWindowsMxcFilesystemPolicy } from '../../common/sandboxHelperService.js';
 import { AgentSandboxEnabledValue, AgentSandboxSettingId } from '../../common/settings.js';
 import { ITerminalSandboxEngineHost, ITerminalSandboxRuntimeInfo, TerminalSandboxEngine } from '../../common/terminalSandboxEngine.js';
+import { IWindowsMxcTerminalSandboxRuntime, WindowsMxcTerminalSandboxRuntime } from '../../common/terminalSandboxMxcRuntime.js';
 
 suite('TerminalSandboxEngine', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
@@ -88,7 +89,7 @@ suite('TerminalSandboxEngine', () => {
 			getSandboxTempDir: () => Promise.resolve(URI.from({ scheme: 'file', path: '/c:/Users/user/.test-data/tmp' })),
 			getWorkspaceStorageReadRoot: () => Promise.resolve(URI.from({ scheme: 'file', path: '/c:/Users/user/workspaceStorage/workspace-id' })),
 			getWriteRoots: () => [URI.from({ scheme: 'file', path: '/c:/workspace' })],
-			getWindowsMxcFilesystemPolicy: () => Promise.resolve({ readonlyPaths: ['C:\\tools\\node', 'C:\\tools\\python', 'C:\\Users\\user\\AppData\\Local\\Programs\\Git'], readwritePaths: [] }),
+			getWindowsMxcFilesystemPolicy: () => Promise.resolve({ readonlyPaths: ['C:\\tools\\node', 'C:\\tools\\python', 'C:\\Users\\user\\AppData\\Local\\Programs\\Git', 'C:\\Users\\user\\AppData\\Local\\Temp'], readwritePaths: [] }),
 			getWindowsMxcEnvironment: () => Promise.resolve(['PATH=C:\\tools\\node;C:\\Windows\\System32', 'PATHEXT=.COM;.EXE;.BAT;.CMD']),
 			...overrides,
 		});
@@ -111,6 +112,7 @@ suite('TerminalSandboxEngine', () => {
 		instantiationService.stub(IConfigurationService, configurationService);
 		instantiationService.stub(IFileService, fileService);
 		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(IWindowsMxcTerminalSandboxRuntime, instantiationService.createInstance(WindowsMxcTerminalSandboxRuntime));
 	});
 
 	test('runAsNode=true prefixes the wrapped command with ELECTRON_RUN_AS_NODE=1', async () => {
@@ -256,10 +258,33 @@ suite('TerminalSandboxEngine', () => {
 		deepStrictEqual(config.network, { defaultPolicy: 'block', allowedHosts: [], blockedHosts: [] });
 		ok(config.filesystem.readwritePaths.some((path: string) => normalizeWindowsPathForAssert(path) === 'c:/workspace'), 'Workspace should be writable');
 		ok(config.filesystem.readwritePaths.some((path: string) => normalizeWindowsPathForAssert(path).endsWith('/.test-data/tmp')), 'Sandbox temp dir should be writable');
+		ok(config.filesystem.readonlyPaths.some((path: string) => normalizeWindowsPathForAssert(path).endsWith('/.test-data/tmp')), 'Sandbox temp dir should be readable through readonly paths');
 		ok(config.filesystem.readonlyPaths.some((path: string) => normalizeWindowsPathForAssert(path) === 'c:/app'), 'App root should be readable for MXC');
 		ok(config.filesystem.readonlyPaths.some((path: string) => normalizeWindowsPathForAssert(path) === 'c:/tools/node'), 'MXC available tools policy should add tool paths to readonly paths');
 		ok(config.filesystem.readonlyPaths.some((path: string) => normalizeWindowsPathForAssert(path) === 'c:/users/user/appdata/local/programs/git'), 'MXC user profile policy should add user profile paths to readonly paths');
-		ok(config.filesystem.deniedPaths.some((path: string) => normalizeWindowsPathForAssert(path) === 'c:/users/user'), 'User home should be denied by default');
+		ok(config.filesystem.readonlyPaths.some((path: string) => normalizeWindowsPathForAssert(path) === 'c:/users/user/appdata/local/temp'), 'MXC actual temp policy should add host temp path to readonly paths');
+		ok(!config.filesystem.deniedPaths.some((path: string) => normalizeWindowsPathForAssert(path) === 'c:/users/user'), 'User home should not be denied by default on Windows');
+	});
+
+	test('wrapCommand applies Windows filesystem setting to MXC config', async () => {
+		configurationService.setUserConfiguration(AgentSandboxSettingId.AgentSandboxWindowsFileSystem, {
+			allowWrite: ['C:\\configured\\write'],
+			allowRead: ['C:\\configured\\read'],
+			denyRead: ['C:\\configured\\secret'],
+		});
+		const host = createWindowsHost();
+		const engine = store.add(instantiationService.createInstance(TerminalSandboxEngine, host));
+
+		await engine.wrapCommand('echo hello', false, 'pwsh');
+		const configPath = await engine.getSandboxConfigPath();
+		ok(configPath, 'Config path should be defined');
+		const config = JSON.parse(createdFiles.get(configPath)!);
+
+		ok(config.filesystem.readwritePaths.some((path: string) => normalizeWindowsPathForAssert(path) === 'c:/configured/write'), 'Configured Windows allowWrite path should be writable');
+		ok(config.filesystem.readonlyPaths.some((path: string) => normalizeWindowsPathForAssert(path) === 'c:/configured/read'), 'Configured Windows allowRead path should be readonly');
+		ok(config.filesystem.readonlyPaths.some((path: string) => normalizeWindowsPathForAssert(path) === 'c:/users/user/appdata/local/temp'), 'Host temp path from Windows policy should be readonly');
+		ok(config.filesystem.deniedPaths.some((path: string) => normalizeWindowsPathForAssert(path) === 'c:/configured/secret'), 'Configured Windows denyRead path should be denied');
+		ok(!config.filesystem.deniedPaths.some((path: string) => normalizeWindowsPathForAssert(path) === 'c:/users/user'), 'User home should not be denied by default on Windows');
 	});
 
 	test('wrapCommand uses arm64 MXC executable on Windows arm64', async () => {

--- a/src/vs/platform/sandbox/test/common/terminalSandboxEngine.test.ts
+++ b/src/vs/platform/sandbox/test/common/terminalSandboxEngine.test.ts
@@ -247,12 +247,12 @@ suite('TerminalSandboxEngine', () => {
 
 		strictEqual(wrapped.isSandboxWrapped, true);
 		ok(wrapped.command.startsWith(`& 'C:\\app\\node_modules\\@microsoft\\mxc-sdk\\bin\\x64\\wxc-exec.exe'`), `Expected MXC executable. Actual: ${wrapped.command}`);
-		ok(wrapped.command.includes(` --debug --log-file debug.json '${configPath}'`), `Expected wrapped command to pass --debug, --log-file, and the MXC config path. Actual: ${wrapped.command}`);
+		ok(wrapped.command.includes(` '${configPath}'`), `Expected wrapped command to pass the MXC config path. Actual: ${wrapped.command}`);
 		strictEqual(config.version, '0.4.0-alpha');
 		strictEqual(config.containment, 'process');
-		ok(config.process.commandLine.startsWith('pwsh -NonInteractive -Command '), `Expected MXC process to launch through PowerShell. Actual: ${config.process.commandLine}`);
+		strictEqual(config.process.commandLine, 'echo hello');
 		strictEqual(normalizeWindowsPathForAssert(config.process.cwd), 'c:/workspace');
-		strictEqual(config.ui.disable, false, 'PowerShell requires windowing APIs to start under MXC');
+		strictEqual(config.ui.disable, false);
 		ok(config.process.env.includes('PATH=C:\\tools\\node;C:\\Windows\\System32'), 'PATH should be injected into the MXC process env');
 		ok(config.process.env.includes('PATHEXT=.COM;.EXE;.BAT;.CMD'), 'PATHEXT should be injected into the MXC process env');
 		deepStrictEqual(config.network, { defaultPolicy: 'block', allowedHosts: [], blockedHosts: [] });
@@ -298,7 +298,7 @@ suite('TerminalSandboxEngine', () => {
 		ok(configPath, 'Config path should be defined');
 		const config = JSON.parse(createdFiles.get(configPath)!);
 
-		ok(wrapped.command.startsWith(`& 'C:\\app\\node_modules\\@microsoft\\mxc-sdk\\bin\\arm64\\wxc-exec.exe' --debug --log-file debug.json `), `Expected arm64 MXC executable with --debug and --log-file. Actual: ${wrapped.command}`);
+		strictEqual(wrapped.command, `& 'C:\\app\\node_modules\\@microsoft\\mxc-sdk\\bin\\arm64\\wxc-exec.exe' '${configPath}'`);
 		strictEqual(normalizeWindowsPathForAssert(config.process.cwd), 'c:/users/user/.test-data/tmp');
 	});
 
@@ -310,14 +310,13 @@ suite('TerminalSandboxEngine', () => {
 		let configPath = await engine.getSandboxConfigPath();
 		ok(configPath, 'Config path should be defined');
 		const firstCommandLine = JSON.parse(createdFiles.get(configPath)!).process.commandLine;
-		ok(firstCommandLine.startsWith('pwsh -NonInteractive -Command '), `Expected first command to launch through PowerShell. Actual: ${firstCommandLine}`);
+		strictEqual(firstCommandLine, 'echo first');
 
 		await engine.wrapCommand('echo second', false, 'pwsh');
 		configPath = await engine.getSandboxConfigPath();
 		ok(configPath, 'Config path should be defined');
 		const secondCommandLine = JSON.parse(createdFiles.get(configPath)!).process.commandLine;
-		ok(secondCommandLine.startsWith('pwsh -NonInteractive -Command '), `Expected second command to launch through PowerShell. Actual: ${secondCommandLine}`);
-		ok(secondCommandLine !== firstCommandLine, 'Changing the Windows command should rewrite the MXC process command line');
+		strictEqual(secondCommandLine, 'echo second');
 	});
 
 	test('allowNetwork maps to MXC allow network config on Windows', async () => {

--- a/src/vs/workbench/contrib/terminal/terminalContribExports.ts
+++ b/src/vs/workbench/contrib/terminal/terminalContribExports.ts
@@ -56,6 +56,7 @@ export const enum TerminalContribSettingId {
 	DeprecatedAgentSandboxMacFileSystem = TerminalChatAgentToolsSettingId.DeprecatedAgentSandboxMacFileSystem,
 	AgentSandboxLinuxFileSystem = TerminalChatAgentToolsSettingId.AgentSandboxLinuxFileSystem,
 	AgentSandboxMacFileSystem = TerminalChatAgentToolsSettingId.AgentSandboxMacFileSystem,
+	AgentSandboxWindowsFileSystem = TerminalChatAgentToolsSettingId.AgentSandboxWindowsFileSystem,
 }
 
 // HACK: Export some context key strings from `terminalContrib/` that are depended upon elsewhere.

--- a/src/vs/workbench/contrib/terminal/terminalContribExports.ts
+++ b/src/vs/workbench/contrib/terminal/terminalContribExports.ts
@@ -48,6 +48,7 @@ export const enum TerminalContribSettingId {
 	ShellIntegrationTimeout = TerminalChatAgentToolsSettingId.ShellIntegrationTimeout,
 	OutputLocation = TerminalChatAgentToolsSettingId.OutputLocation,
 	AgentSandboxEnabled = AgentSandboxSettingId.AgentSandboxEnabled,
+	AgentSandboxWindowsEnabled = AgentSandboxSettingId.AgentSandboxWindowsEnabled,
 	AgentSandboxAllowUnsandboxedCommands = AgentSandboxSettingId.AgentSandboxAllowUnsandboxedCommands,
 	AgentSandboxAutoApproveUnsandboxedCommands = AgentSandboxSettingId.AgentSandboxAutoApproveUnsandboxedCommands,
 	AgentSandboxAllowAutoApprove = AgentSandboxSettingId.AgentSandboxAllowAutoApprove,

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/terminal.chatAgentTools.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/terminal.chatAgentTools.contribution.ts
@@ -35,11 +35,13 @@ import { GetTaskOutputTool, GetTaskOutputToolData } from './tools/task/getTaskOu
 import { RunTaskTool, RunTaskToolData } from './tools/task/runTaskTool.js';
 import { registerTerminalCompressors } from './tools/terminalOutputCompressor.js';
 import { InstantiationType, registerSingleton } from '../../../../../platform/instantiation/common/extensions.js';
+import { IWindowsMxcTerminalSandboxRuntime, WindowsMxcTerminalSandboxRuntime } from '../../../../../platform/sandbox/common/terminalSandboxMxcRuntime.js';
 import { ITerminalSandboxService, TerminalSandboxService } from '../common/terminalSandboxService.js';
 import { isNumber } from '../../../../../base/common/types.js';
 
 // #region Services
 
+registerSingleton(IWindowsMxcTerminalSandboxRuntime, WindowsMxcTerminalSandboxRuntime, InstantiationType.Delayed);
 registerSingleton(ITerminalSandboxService, TerminalSandboxService, InstantiationType.Delayed);
 
 // #endregion Services
@@ -158,7 +160,8 @@ export class ChatAgentToolsContribution extends Disposable implements IWorkbench
 				e.affectsConfiguration(TerminalChatAgentToolsSettingId.AgentSandboxLinuxFileSystem) ||
 				e.affectsConfiguration(TerminalChatAgentToolsSettingId.DeprecatedAgentSandboxLinuxFileSystem) ||
 				e.affectsConfiguration(TerminalChatAgentToolsSettingId.AgentSandboxMacFileSystem) ||
-				e.affectsConfiguration(TerminalChatAgentToolsSettingId.DeprecatedAgentSandboxMacFileSystem)
+				e.affectsConfiguration(TerminalChatAgentToolsSettingId.DeprecatedAgentSandboxMacFileSystem) ||
+				e.affectsConfiguration(TerminalChatAgentToolsSettingId.AgentSandboxWindowsFileSystem)
 			) {
 				this._registerRunInTerminalTool();
 			}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/terminal.chatAgentTools.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/terminal.chatAgentTools.contribution.ts
@@ -149,6 +149,7 @@ export class ChatAgentToolsContribution extends Disposable implements IWorkbench
 		this._register(this._configurationService.onDidChangeConfiguration(e => {
 			if (
 				e.affectsConfiguration(AgentSandboxSettingId.AgentSandboxEnabled) ||
+				e.affectsConfiguration(AgentSandboxSettingId.AgentSandboxWindowsEnabled) ||
 				e.affectsConfiguration(AgentSandboxSettingId.DeprecatedAgentSandboxEnabled) ||
 				e.affectsConfiguration(AgentSandboxSettingId.AgentSandboxAllowUnsandboxedCommands) ||
 				e.affectsConfiguration(AgentNetworkDomainSettingId.AllowedNetworkDomains) ||

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/sandboxOutputAnalyzer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/sandboxOutputAnalyzer.ts
@@ -30,9 +30,18 @@ export class SandboxOutputAnalyzer extends Disposable implements IOutputAnalyzer
 		}
 
 		const os = await this._sandboxService.getOS();
-		const fileSystemSetting = os === OperatingSystem.Linux
-			? TerminalChatAgentToolsSettingId.AgentSandboxLinuxFileSystem
-			: TerminalChatAgentToolsSettingId.AgentSandboxMacFileSystem;
+		let fileSystemSetting: TerminalChatAgentToolsSettingId;
+		switch (os) {
+			case OperatingSystem.Linux:
+				fileSystemSetting = TerminalChatAgentToolsSettingId.AgentSandboxLinuxFileSystem;
+				break;
+			case OperatingSystem.Windows:
+				fileSystemSetting = TerminalChatAgentToolsSettingId.AgentSandboxWindowsFileSystem;
+				break;
+			default:
+				fileSystemSetting = TerminalChatAgentToolsSettingId.AgentSandboxMacFileSystem;
+				break;
+		}
 
 		const prefix = knownFailure
 			? 'Command failed while running in sandboxed mode. If the command failed due to sandboxing:'

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
@@ -22,6 +22,7 @@ export const enum TerminalChatAgentToolsSettingId {
 	OutputLocation = 'chat.tools.terminal.outputLocation',
 	AgentSandboxLinuxFileSystem = 'chat.agent.sandbox.fileSystem.linux',
 	AgentSandboxMacFileSystem = 'chat.agent.sandbox.fileSystem.mac',
+	AgentSandboxWindowsFileSystem = 'chat.agent.sandbox.fileSystem.windows',
 	AgentSandboxAdvancedRuntime = 'chat.agent.sandbox.advanced.runtime',
 	PreventShellHistory = 'chat.tools.terminal.preventShellHistory',
 	EnforceTimeoutFromModel = 'chat.tools.terminal.enforceTimeoutFromModel',
@@ -688,6 +689,37 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 			allowRead: [],
 			allowWrite: [],
 			denyWrite: []
+		},
+		tags: ['preview'],
+		restricted: true,
+	},
+	[TerminalChatAgentToolsSettingId.AgentSandboxWindowsFileSystem]: {
+		markdownDescription: localize('agentSandbox.windowsFileSystemSetting', "Note: this setting is applicable only when {0} is enabled. Controls file system access in sandbox on Windows. Paths do not support glob patterns, only literal paths (ex: C:\\src, C:\\Users\\me\\.ssh, .env).", `\`#${AgentSandboxSettingId.AgentSandboxEnabled}#\``),
+		type: 'object',
+		properties: {
+			denyRead: {
+				type: 'array',
+				description: localize('agentSandbox.windowsFileSystemSetting.denyRead', "Array of paths to deny access. Leave empty to allow reading all paths."),
+				items: { type: 'string' },
+				default: []
+			},
+			allowRead: {
+				type: 'array',
+				description: localize('agentSandbox.windowsFileSystemSetting.allowRead', "Array of additional paths to allow read-only access. Takes precedence over denyRead."),
+				items: { type: 'string' },
+				default: []
+			},
+			allowWrite: {
+				type: 'array',
+				description: localize('agentSandbox.windowsFileSystemSetting.allowWrite', "Array of additional paths to allow read/write access. Leave empty to disallow writes outside the workspace folders and sandbox temp directory."),
+				items: { type: 'string' },
+				default: []
+			}
+		},
+		default: {
+			denyRead: [],
+			allowRead: [],
+			allowWrite: []
 		},
 		tags: ['preview'],
 		restricted: true,

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
@@ -563,6 +563,21 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 			}
 		}
 	},
+	[AgentSandboxSettingId.AgentSandboxWindowsEnabled]: {
+		markdownDescription: localize('agentSandbox.windowsEnabledSetting', "Controls whether agent mode sandboxing can be enabled on Windows. This applies only when {0} is enabled.", `\`#${AgentSandboxSettingId.AgentSandboxEnabled}#\``),
+		type: 'string',
+		enum: [AgentSandboxEnabledValue.Off, AgentSandboxEnabledValue.AllowNetwork],
+		enumDescriptions: [
+			localize('agentSandbox.windowsEnabledSetting.offDescription', 'Disable sandboxing for agent mode tools on Windows.'),
+			localize('agentSandbox.windowsEnabledSetting.allowNetworkDescription', 'Enable sandboxing for agent mode tools on Windows and allow all network domains.'),
+		],
+		default: AgentSandboxEnabledValue.Off,
+		tags: ['experimental'],
+		restricted: true,
+		experiment: {
+			mode: 'auto'
+		}
+	},
 	[AgentSandboxSettingId.AgentSandboxAllowUnsandboxedCommands]: {
 		markdownDescription: localize('agentSandbox.allowUnsandboxedCommands', "Controls whether agent mode terminal commands can run outside the sandbox after user confirmation when a sandboxed command fails or when sandbox restrictions would block the command. This applies only when {0} is enabled.", `\`#${AgentSandboxSettingId.AgentSandboxEnabled}#\``),
 		type: 'boolean',

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
@@ -564,7 +564,7 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 		}
 	},
 	[AgentSandboxSettingId.AgentSandboxWindowsEnabled]: {
-		markdownDescription: localize('agentSandbox.windowsEnabledSetting', "Controls whether agent mode sandboxing can be enabled on Windows.", `\`#${AgentSandboxSettingId.AgentSandboxEnabled}#\``),
+		markdownDescription: localize('agentSandbox.windowsEnabledSetting', "Controls whether agent mode uses sandboxing on Windows."),
 		type: 'string',
 		enum: [AgentSandboxEnabledValue.Off, AgentSandboxEnabledValue.AllowNetwork],
 		enumDescriptions: [

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
@@ -564,7 +564,7 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 		}
 	},
 	[AgentSandboxSettingId.AgentSandboxWindowsEnabled]: {
-		markdownDescription: localize('agentSandbox.windowsEnabledSetting', "Controls whether agent mode sandboxing can be enabled on Windows. This applies only when {0} is enabled.", `\`#${AgentSandboxSettingId.AgentSandboxEnabled}#\``),
+		markdownDescription: localize('agentSandbox.windowsEnabledSetting', "Controls whether agent mode sandboxing can be enabled on Windows.", `\`#${AgentSandboxSettingId.AgentSandboxEnabled}#\``),
 		type: 'string',
 		enum: [AgentSandboxEnabledValue.Off, AgentSandboxEnabledValue.AllowNetwork],
 		enumDescriptions: [

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalSandboxService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalSandboxService.ts
@@ -11,6 +11,7 @@ import { Disposable, DisposableStore } from '../../../../../base/common/lifecycl
 import { FileAccess } from '../../../../../base/common/network.js';
 import { dirname } from '../../../../../base/common/path.js';
 import { OperatingSystem, OS } from '../../../../../base/common/platform.js';
+import { arch } from '../../../../../base/common/process.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { localize } from '../../../../../nls.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
@@ -21,7 +22,7 @@ import { ILogService } from '../../../../../platform/log/common/log.js';
 import { IProductService } from '../../../../../platform/product/common/productService.js';
 import { IRemoteAgentEnvironment } from '../../../../../platform/remote/common/remoteAgentEnvironment.js';
 import { SANDBOX_HELPER_CHANNEL_NAME, SandboxHelperChannelClient } from '../../../../../platform/sandbox/common/sandboxHelperIpc.js';
-import { ISandboxDependencyStatus, ISandboxHelperService } from '../../../../../platform/sandbox/common/sandboxHelperService.js';
+import { ISandboxDependencyStatus, ISandboxHelperService, IWindowsMxcFilesystemPolicy } from '../../../../../platform/sandbox/common/sandboxHelperService.js';
 import { ITerminalSandboxEngineHost, ITerminalSandboxRuntimeInfo, TerminalSandboxEngine } from '../../../../../platform/sandbox/common/terminalSandboxEngine.js';
 import { ITerminalSandboxService, type ISandboxDependencyInstallOptions, type ISandboxDependencyInstallResult, type ITerminalSandboxCommand, type ITerminalSandboxPrerequisiteCheckResult, type ITerminalSandboxResolvedNetworkDomains, type ITerminalSandboxWrapResult } from '../../../../../platform/sandbox/common/terminalSandboxService.js';
 import { TerminalCapability } from '../../../../../platform/terminal/common/capabilities/capabilities.js';
@@ -81,6 +82,8 @@ export class TerminalSandboxService extends Disposable implements ITerminalSandb
 			getWriteRoots: () => this._workspaceContextService.getWorkspace().folders.map(folder => folder.uri),
 			onDidChangeRoots: this._onDidChangeRoots.event,
 			checkSandboxDependencies: () => this._resolveSandboxDependencyStatus(),
+			getWindowsMxcFilesystemPolicy: () => this._resolveWindowsMxcFilesystemPolicy(),
+			getWindowsMxcEnvironment: () => this._resolveWindowsMxcEnvironment(),
 		};
 		this._engine = this._register(instantiationService.createInstance(TerminalSandboxEngine, host));
 
@@ -158,13 +161,26 @@ export class TerminalSandboxService extends Disposable implements ITerminalSandb
 		const remoteEnv = await this._resolveRemoteEnv();
 		if (remoteEnv) {
 			// Remote workbench: server resolves a real `node` binary, no env prefix needed.
-			return { appRoot: remoteEnv.appRoot.path, execPath: remoteEnv.execPath, runAsNode: false };
+			return { appRoot: remoteEnv.os === OperatingSystem.Windows ? this._toWindowsPath(remoteEnv.appRoot) : remoteEnv.appRoot.path, execPath: remoteEnv.execPath, runAsNode: false, arch: remoteEnv.arch };
 		}
 		// Local workbench: app root is local and exec path points at the Electron binary,
 		// so the engine must prefix `ELECTRON_RUN_AS_NODE=1` when invoking it.
-		const localAppRoot = dirname(FileAccess.asFileUri('').path);
+		const localAppRootUri = FileAccess.asFileUri('');
+		const localAppRoot = OS === OperatingSystem.Windows ? dirname(localAppRootUri.fsPath) : dirname(localAppRootUri.path);
 		const nativeEnv = this._environmentService as IEnvironmentService & { execPath?: string };
-		return { appRoot: localAppRoot, execPath: nativeEnv.execPath, runAsNode: true };
+		return { appRoot: localAppRoot, execPath: nativeEnv.execPath, runAsNode: true, arch };
+	}
+
+	private _toWindowsPath(uri: URI): string {
+		let value: string;
+		if (uri.authority && uri.path.length > 1 && uri.scheme === 'file') {
+			value = `\\\\${uri.authority}${uri.path}`;
+		} else if (/^\/[a-zA-Z]:/.test(uri.path)) {
+			value = uri.path.slice(1);
+		} else {
+			value = uri.fsPath;
+		}
+		return value.replace(/\//g, '\\');
 	}
 
 	private async _resolveUserHome(): Promise<URI | undefined> {
@@ -214,6 +230,28 @@ export class TerminalSandboxService extends Disposable implements ITerminalSandb
 			});
 		}
 		return this._sandboxHelperService.checkSandboxDependencies();
+	}
+
+	private async _resolveWindowsMxcFilesystemPolicy(): Promise<IWindowsMxcFilesystemPolicy | undefined> {
+		const connection = this._remoteAgentService.getConnection();
+		if (connection) {
+			return connection.withChannel(SANDBOX_HELPER_CHANNEL_NAME, channel => {
+				const sandboxHelper = new SandboxHelperChannelClient(channel);
+				return sandboxHelper.getWindowsMxcFilesystemPolicy();
+			});
+		}
+		return this._sandboxHelperService.getWindowsMxcFilesystemPolicy();
+	}
+
+	private async _resolveWindowsMxcEnvironment(): Promise<string[] | undefined> {
+		const connection = this._remoteAgentService.getConnection();
+		if (connection) {
+			return connection.withChannel(SANDBOX_HELPER_CHANNEL_NAME, channel => {
+				const sandboxHelper = new SandboxHelperChannelClient(channel);
+				return sandboxHelper.getWindowsMxcEnvironment();
+			});
+		}
+		return this._sandboxHelperService.getWindowsMxcEnvironment();
 	}
 
 	// ---- workbench-only flows -----------------------------------------------

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts
@@ -27,7 +27,7 @@ import { IRemoteAgentEnvironment } from '../../../../../../platform/remote/commo
 import { IWorkspace, IWorkspaceContextService, IWorkspaceFolder, IWorkspaceFoldersChangeEvent, IWorkspaceIdentifier, ISingleFolderWorkspaceIdentifier, WorkbenchState } from '../../../../../../platform/workspace/common/workspace.js';
 import { testWorkspace } from '../../../../../../platform/workspace/test/common/testWorkspace.js';
 import { ILifecycleService } from '../../../../../services/lifecycle/common/lifecycle.js';
-import { ISandboxDependencyStatus, ISandboxHelperService } from '../../../../../../platform/sandbox/common/sandboxHelperService.js';
+import { ISandboxDependencyStatus, ISandboxHelperService, IWindowsMxcFilesystemPolicy } from '../../../../../../platform/sandbox/common/sandboxHelperService.js';
 import { getTerminalSandboxRuntimeConfigurationForCommands } from '../../../../../../platform/sandbox/common/terminalSandboxRuntimeConfigurationPerOperation.js';
 
 suite('TerminalSandboxService - network domains', () => {
@@ -52,6 +52,10 @@ suite('TerminalSandboxService - network domains', () => {
 			createFileCount++;
 			const contentString = content.toString();
 			createdFiles.set(uri.path, contentString);
+			createdFiles.set(uri.fsPath, contentString);
+			if (/^\/[a-zA-Z]:/.test(uri.path)) {
+				createdFiles.set(uri.path.slice(1).replace(/\//g, '\\'), contentString);
+			}
 			return {};
 		}
 
@@ -96,8 +100,8 @@ suite('TerminalSandboxService - network domains', () => {
 		}
 
 		async getEnvironment(): Promise<IRemoteAgentEnvironment | null> {
-			// Return a Linux environment to ensure tests pass on Windows
-			// (sandbox is not supported on Windows)
+			// Return a Linux environment so the default test expectations are
+			// independent of the local OS.
 			return this.remoteEnvironment;
 		}
 	}
@@ -157,10 +161,23 @@ suite('TerminalSandboxService - network domains', () => {
 			bubblewrapInstalled: true,
 			socatInstalled: true,
 		};
+		filesystemPolicy: IWindowsMxcFilesystemPolicy = {
+			readonlyPaths: ['c:\\tools\\node'],
+			readwritePaths: [],
+		};
+		environment = ['PATH=c:\\tools\\node;c:\\windows\\system32', 'PATHEXT=.COM;.EXE;.BAT;.CMD'];
 
 		checkSandboxDependencies(): Promise<ISandboxDependencyStatus> {
 			this.callCount++;
 			return Promise.resolve(this.status);
+		}
+
+		getWindowsMxcFilesystemPolicy(): Promise<IWindowsMxcFilesystemPolicy> {
+			return Promise.resolve(this.filesystemPolicy);
+		}
+
+		getWindowsMxcEnvironment(): Promise<string[]> {
+			return Promise.resolve(this.environment);
 		}
 	}
 
@@ -1164,7 +1181,7 @@ suite('TerminalSandboxService - network domains', () => {
 
 	test('should prefix wrapped command with ELECTRON_RUN_AS_NODE=1 when no remote env is available', async function () {
 		if (isWindows) {
-			// Sandbox is disabled on Windows when no remote env is available.
+			// Local Windows uses MXC, which launches wxc-exec.exe directly instead of SRT through Electron-as-Node.
 			this.skip();
 		}
 		remoteAgentService.remoteEnvironment = null;
@@ -1185,9 +1202,49 @@ suite('TerminalSandboxService - network domains', () => {
 		ok(!wrapped.command.startsWith('ELECTRON_RUN_AS_NODE='), `Remote workbench should not add the env prefix. Actual: ${wrapped.command}`);
 	});
 
+	test('should route remote Windows sandbox commands through MXC', async () => {
+		remoteAgentService.remoteEnvironment = {
+			...remoteAgentService.remoteEnvironment!,
+			os: OperatingSystem.Windows,
+			appRoot: URI.file('/c:/app'),
+			execPath: 'c:\\app\\Code.exe',
+			tmpDir: URI.file('/c:/tmp'),
+			userHome: URI.file('/c:/Users/test'),
+			workspaceStorageHome: URI.file('/c:/Users/test/AppData/Roaming/Code/User/workspaceStorage'),
+			arch: 'arm64'
+		};
+		workspaceContextService.setWorkspaceFolders([URI.file('/c:/workspace-one')]);
+		const sandboxService = store.add(instantiationService.createInstance(TerminalSandboxService));
+
+		const configPath = await sandboxService.getSandboxConfigPath();
+		const wrapped = await sandboxService.wrapCommand('echo test', false, 'pwsh.exe', URI.file('/c:/workspace-one'));
+
+		ok(configPath, 'Config path should be defined for remote Windows');
+		const configContent = createdFiles.get(configPath);
+		ok(configContent, 'Config file should be created for remote Windows');
+		const config = JSON.parse(configContent);
+
+		strictEqual(wrapped.isSandboxWrapped, true);
+		ok(wrapped.command.includes('node_modules\\@microsoft\\mxc-sdk\\bin\\arm64\\wxc-exec.exe'), `Wrapped command should use the MXC Windows executable. Actual: ${wrapped.command}`);
+		ok(wrapped.command.includes(' --debug '), `Wrapped command should pass --debug to MXC. Actual: ${wrapped.command}`);
+		ok(wrapped.command.includes(' --log-file debug.json '), `Wrapped command should pass --log-file debug.json to MXC. Actual: ${wrapped.command}`);
+		ok(wrapped.command.includes(configPath), `Wrapped command should pass the MXC config path. Actual: ${wrapped.command}`);
+		strictEqual(config.version, '0.4.0-alpha');
+		strictEqual(config.containment, 'process');
+		ok(config.process.commandLine.startsWith('pwsh.exe -NonInteractive -Command '), `Expected MXC process to launch through PowerShell. Actual: ${config.process.commandLine}`);
+		strictEqual(config.process.cwd, 'c:\\workspace-one');
+		ok(config.process.env.includes('PATH=c:\\tools\\node;c:\\windows\\system32'), 'PATH should be injected into the MXC process env');
+		ok(config.process.env.includes('PATHEXT=.COM;.EXE;.BAT;.CMD'), 'PATHEXT should be injected into the MXC process env');
+		ok(config.filesystem.readwritePaths.includes('c:\\workspace-one'), 'Workspace folder should be writable in the MXC config');
+		ok(config.filesystem.readwritePaths.some((path: string) => path.includes('tmp_vscode_7')), 'Sandbox temp dir should be writable in the MXC config');
+		ok(config.filesystem.readonlyPaths.includes('c:\\app'), 'VS Code app root should be readable in the MXC config');
+		ok(config.filesystem.readonlyPaths.includes('c:\\tools\\node'), 'MXC available tools policy should add tool paths to readonly paths');
+		ok(config.filesystem.deniedPaths.includes('c:\\Users\\test'), 'User home should be denied by default in the MXC config');
+	});
+
 	test('should place sandbox temp dir under the local data folder when no remote env is available', async function () {
 		if (isWindows) {
-			// Sandbox is disabled on Windows when no remote env is available.
+			// Local Windows uses MXC, which does not use the POSIX local temp-dir path shape asserted below.
 			this.skip();
 		}
 		remoteAgentService.remoteEnvironment = null;

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts
@@ -28,6 +28,7 @@ import { IWorkspace, IWorkspaceContextService, IWorkspaceFolder, IWorkspaceFolde
 import { testWorkspace } from '../../../../../../platform/workspace/test/common/testWorkspace.js';
 import { ILifecycleService } from '../../../../../services/lifecycle/common/lifecycle.js';
 import { ISandboxDependencyStatus, ISandboxHelperService, IWindowsMxcFilesystemPolicy } from '../../../../../../platform/sandbox/common/sandboxHelperService.js';
+import { IWindowsMxcTerminalSandboxRuntime, WindowsMxcTerminalSandboxRuntime } from '../../../../../../platform/sandbox/common/terminalSandboxMxcRuntime.js';
 import { getTerminalSandboxRuntimeConfigurationForCommands } from '../../../../../../platform/sandbox/common/terminalSandboxRuntimeConfigurationPerOperation.js';
 
 suite('TerminalSandboxService - network domains', () => {
@@ -223,6 +224,7 @@ suite('TerminalSandboxService - network domains', () => {
 		instantiationService.stub(IWorkspaceContextService, workspaceContextService);
 		instantiationService.stub(ILifecycleService, lifecycleService);
 		instantiationService.stub(ISandboxHelperService, sandboxHelperService);
+		instantiationService.stub(IWindowsMxcTerminalSandboxRuntime, instantiationService.createInstance(WindowsMxcTerminalSandboxRuntime));
 	});
 
 	test('dependency checks should not be called for isEnabled', async () => {
@@ -1239,7 +1241,7 @@ suite('TerminalSandboxService - network domains', () => {
 		ok(config.filesystem.readwritePaths.some((path: string) => path.includes('tmp_vscode_7')), 'Sandbox temp dir should be writable in the MXC config');
 		ok(config.filesystem.readonlyPaths.includes('c:\\app'), 'VS Code app root should be readable in the MXC config');
 		ok(config.filesystem.readonlyPaths.includes('c:\\tools\\node'), 'MXC available tools policy should add tool paths to readonly paths');
-		ok(config.filesystem.deniedPaths.includes('c:\\Users\\test'), 'User home should be denied by default in the MXC config');
+		ok(!config.filesystem.deniedPaths.includes('c:\\Users\\test'), 'User home should not be denied by default in the MXC config on Windows');
 	});
 
 	test('should place sandbox temp dir under the local data folder when no remote env is available', async function () {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts
@@ -1205,6 +1205,7 @@ suite('TerminalSandboxService - network domains', () => {
 	});
 
 	test('should route remote Windows sandbox commands through MXC', async () => {
+		configurationService.setUserConfiguration(AgentSandboxSettingId.AgentSandboxEnabled, AgentSandboxEnabledValue.Off);
 		configurationService.setUserConfiguration(AgentSandboxSettingId.AgentSandboxWindowsEnabled, AgentSandboxEnabledValue.AllowNetwork);
 		remoteAgentService.remoteEnvironment = {
 			...remoteAgentService.remoteEnvironment!,
@@ -1257,7 +1258,7 @@ suite('TerminalSandboxService - network domains', () => {
 		workspaceContextService.setWorkspaceFolders([URI.file('/c:/workspace-one')]);
 		const sandboxService = store.add(instantiationService.createInstance(TerminalSandboxService));
 
-		strictEqual(await sandboxService.isEnabled(), false, 'Windows sandbox should be disabled by default even when the global sandbox setting is enabled');
+		strictEqual(await sandboxService.isEnabled(), false, 'Windows sandbox should be disabled when the Windows sandbox setting is off');
 		strictEqual(await sandboxService.getSandboxConfigPath(), undefined, 'Windows sandbox config should not be created unless the Windows setting is enabled');
 		const prereqs = await sandboxService.checkForSandboxingPrereqs();
 		strictEqual(prereqs.enabled, false, 'Prereq checks should report Windows sandbox disabled when the Windows setting is disabled');

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts
@@ -1228,12 +1228,10 @@ suite('TerminalSandboxService - network domains', () => {
 
 		strictEqual(wrapped.isSandboxWrapped, true);
 		ok(wrapped.command.includes('node_modules\\@microsoft\\mxc-sdk\\bin\\arm64\\wxc-exec.exe'), `Wrapped command should use the MXC Windows executable. Actual: ${wrapped.command}`);
-		ok(wrapped.command.includes(' --debug '), `Wrapped command should pass --debug to MXC. Actual: ${wrapped.command}`);
-		ok(wrapped.command.includes(' --log-file debug.json '), `Wrapped command should pass --log-file debug.json to MXC. Actual: ${wrapped.command}`);
 		ok(wrapped.command.includes(configPath), `Wrapped command should pass the MXC config path. Actual: ${wrapped.command}`);
 		strictEqual(config.version, '0.4.0-alpha');
 		strictEqual(config.containment, 'process');
-		ok(config.process.commandLine.startsWith('pwsh.exe -NonInteractive -Command '), `Expected MXC process to launch through PowerShell. Actual: ${config.process.commandLine}`);
+		strictEqual(config.process.commandLine, 'echo test');
 		strictEqual(config.process.cwd, 'c:\\workspace-one');
 		ok(config.process.env.includes('PATH=c:\\tools\\node;c:\\windows\\system32'), 'PATH should be injected into the MXC process env');
 		ok(config.process.env.includes('PATHEXT=.COM;.EXE;.BAT;.CMD'), 'PATHEXT should be injected into the MXC process env');

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts
@@ -1205,6 +1205,7 @@ suite('TerminalSandboxService - network domains', () => {
 	});
 
 	test('should route remote Windows sandbox commands through MXC', async () => {
+		configurationService.setUserConfiguration(AgentSandboxSettingId.AgentSandboxWindowsEnabled, AgentSandboxEnabledValue.AllowNetwork);
 		remoteAgentService.remoteEnvironment = {
 			...remoteAgentService.remoteEnvironment!,
 			os: OperatingSystem.Windows,
@@ -1240,6 +1241,27 @@ suite('TerminalSandboxService - network domains', () => {
 		ok(config.filesystem.readonlyPaths.includes('c:\\app'), 'VS Code app root should be readable in the MXC config');
 		ok(config.filesystem.readonlyPaths.includes('c:\\tools\\node'), 'MXC available tools policy should add tool paths to readonly paths');
 		ok(!config.filesystem.deniedPaths.includes('c:\\Users\\test'), 'User home should not be denied by default in the MXC config on Windows');
+	});
+
+	test('should keep remote Windows sandbox disabled unless Windows sandbox setting allows network', async () => {
+		remoteAgentService.remoteEnvironment = {
+			...remoteAgentService.remoteEnvironment!,
+			os: OperatingSystem.Windows,
+			appRoot: URI.file('/c:/app'),
+			execPath: 'c:\\app\\Code.exe',
+			tmpDir: URI.file('/c:/tmp'),
+			userHome: URI.file('/c:/Users/test'),
+			workspaceStorageHome: URI.file('/c:/Users/test/AppData/Roaming/Code/User/workspaceStorage'),
+			arch: 'x64'
+		};
+		workspaceContextService.setWorkspaceFolders([URI.file('/c:/workspace-one')]);
+		const sandboxService = store.add(instantiationService.createInstance(TerminalSandboxService));
+
+		strictEqual(await sandboxService.isEnabled(), false, 'Windows sandbox should be disabled by default even when the global sandbox setting is enabled');
+		strictEqual(await sandboxService.getSandboxConfigPath(), undefined, 'Windows sandbox config should not be created unless the Windows setting is enabled');
+		const prereqs = await sandboxService.checkForSandboxingPrereqs();
+		strictEqual(prereqs.enabled, false, 'Prereq checks should report Windows sandbox disabled when the Windows setting is disabled');
+		strictEqual(prereqs.failedCheck, undefined, 'No prereq check should fail when Windows sandboxing is disabled');
 	});
 
 	test('should place sandbox temp dir under the local data folder when no remote env is available', async function () {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts
@@ -166,7 +166,7 @@ suite('TerminalSandboxService - network domains', () => {
 			readonlyPaths: ['c:\\tools\\node'],
 			readwritePaths: [],
 		};
-		environment = ['PATH=c:\\tools\\node;c:\\windows\\system32', 'PATHEXT=.COM;.EXE;.BAT;.CMD'];
+		environment = ['PATH=c:\\tools\\node;c:\\windows\\system32', 'PSHOME=c:\\program files\\powershell\\7'];
 
 		checkSandboxDependencies(): Promise<ISandboxDependencyStatus> {
 			this.callCount++;
@@ -1234,7 +1234,7 @@ suite('TerminalSandboxService - network domains', () => {
 		strictEqual(config.process.commandLine, 'echo test');
 		strictEqual(config.process.cwd, 'c:\\workspace-one');
 		ok(config.process.env.includes('PATH=c:\\tools\\node;c:\\windows\\system32'), 'PATH should be injected into the MXC process env');
-		ok(config.process.env.includes('PATHEXT=.COM;.EXE;.BAT;.CMD'), 'PATHEXT should be injected into the MXC process env');
+		ok(config.process.env.includes('PSHOME=c:\\program files\\powershell\\7'), 'PSHOME should be injected into the MXC process env');
 		ok(config.filesystem.readwritePaths.includes('c:\\workspace-one'), 'Workspace folder should be writable in the MXC config');
 		ok(config.filesystem.readwritePaths.some((path: string) => path.includes('tmp_vscode_7')), 'Sandbox temp dir should be writable in the MXC config');
 		ok(config.filesystem.readonlyPaths.includes('c:\\app'), 'VS Code app root should be readable in the MXC config');


### PR DESCRIPTION
fixes #317711
## Summary
- Integrated `@microsoft/mxc-sdk` for windows sandboxing.
- Wires Windows-specific sandbox filesystem policy/configuration, including read/write/read-deny handling and host temp directory access.
- Runs Windows MXC process containers with the provided command line directly and keeps the wrapper focused on invoking `wxc-exec` with the generated config.

Pending from integration:
No network isolation yet for windows sandboxing as proxy support is not provided yet.
Env variables are not being injected correctly into the sandbox and awaiting on fix by mxc package owners.
