### PR TITLE
Add branch changeset description formatting and update session management

### DIFF
--- a/src/vs/platform/agentHost/common/changesetUri.ts
+++ b/src/vs/platform/agentHost/common/changesetUri.ts
@@ -62,17 +62,19 @@ export const thisTurnChangesetLabel = (): string => localize('thisTurnChangeset.
 
 /**
  * Returns the description shown next to the `Branch Changes` catalogue
- * entry — formatted as `${branchName} → ${baseBranchName}`. Returns
- * `undefined` when the branch info is incomplete or the current branch
- * equals the base (e.g. working directly on `main`), so callers can omit
- * the description entirely in those cases. This is intentionally
- * worktree-flavoured: `baseBranchName` is only populated by the git
- * probe when `refs/remotes/origin/HEAD` resolves, which is the typical
- * worktree-isolation scenario.
+ * entry. When both `branchName` and `baseBranchName` are known
+ * (typical worktree-isolation case), formats as `${branchName} → ${baseBranchName}`.
+ * Falls back to `branchName` alone when the base branch is unknown
+ * (non-worktree session, or a session whose working copy has no
+ * `refs/remotes/origin/HEAD`). Returns `undefined` only when no branch
+ * name is known at all, so callers can omit the description entirely.
  */
 export function formatSessionChangesetDescription(branchName: string | undefined, baseBranchName: string | undefined): string | undefined {
-	if (!branchName || !baseBranchName || branchName === baseBranchName) {
-		return undefined;
+	if (!branchName || !baseBranchName) {
+		return branchName;
+	}
+	if (branchName === baseBranchName) {
+		return branchName;
 	}
 	return `${branchName} → ${baseBranchName}`;
 }

--- a/src/vs/platform/agentHost/common/changesetUri.ts
+++ b/src/vs/platform/agentHost/common/changesetUri.ts
@@ -60,6 +60,23 @@ export const uncommittedChangesetDescription = (): string => localize('uncommitt
 /** Localized human-readable label for the per-turn changeset template entry. */
 export const thisTurnChangesetLabel = (): string => localize('thisTurnChangeset.label', "This Turn");
 
+/**
+ * Returns the description shown next to the `Branch Changes` catalogue
+ * entry — formatted as `${branchName} → ${baseBranchName}`. Returns
+ * `undefined` when the branch info is incomplete or the current branch
+ * equals the base (e.g. working directly on `main`), so callers can omit
+ * the description entirely in those cases. This is intentionally
+ * worktree-flavoured: `baseBranchName` is only populated by the git
+ * probe when `refs/remotes/origin/HEAD` resolves, which is the typical
+ * worktree-isolation scenario.
+ */
+export function formatSessionChangesetDescription(branchName: string | undefined, baseBranchName: string | undefined): string | undefined {
+	if (!branchName || !baseBranchName || branchName === baseBranchName) {
+		return undefined;
+	}
+	return `${branchName} → ${baseBranchName}`;
+}
+
 /** Marker injected into a changeset URI's path. */
 const CHANGESET_PATH_SEGMENT = '/changeset/';
 

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -21,7 +21,7 @@ import { ServiceCollection } from '../../instantiation/common/serviceCollection.
 import { ILogService } from '../../log/common/log.js';
 import { AgentProvider, AgentSession, IAgent, IAgentCreateSessionConfig, IAgentMaterializeSessionEvent, IAgentResolveSessionConfigParams, IAgentService, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, AuthenticateParams, AuthenticateResult } from '../common/agentService.js';
 import { ISessionDataService, SESSION_ATTACHMENTS_DIRNAME } from '../common/sessionDataService.js';
-import { buildDefaultChangesetCatalogue, buildSessionChangesetUri, buildUncommittedChangesetUri } from '../common/changesetUri.js';
+import { buildDefaultChangesetCatalogue, buildSessionChangesetUri, buildUncommittedChangesetUri, formatSessionChangesetDescription } from '../common/changesetUri.js';
 import { ActionType, ActionEnvelope, INotification, type IRootConfigChangedAction, type SessionAction, type TerminalAction } from '../common/state/sessionActions.js';
 import type { CompletionsParams, CompletionsResult, CreateTerminalParams, ResolveSessionConfigResult, SessionConfigCompletionsResult } from '../common/state/protocol/commands.js';
 import { AhpErrorCodes, AHP_SESSION_NOT_FOUND, ContentEncoding, JSON_RPC_INTERNAL_ERROR, ProtocolError, type DirectoryEntry, type ResourceCopyParams, type ResourceCopyResult, type ResourceDeleteParams, type ResourceDeleteResult, type ResourceListResult, type ResourceMoveParams, type ResourceMoveResult, type ResourceReadResult, type ResourceWriteParams, type ResourceWriteResult, type IStateSnapshot } from '../common/state/sessionProtocol.js';
@@ -585,6 +585,7 @@ export class AgentService extends Disposable implements IAgentService {
 				}
 				const next = withSessionGitState(current, gitState);
 				this._stateManager.setSessionMeta(sessionKey, next);
+				this._updateBranchChangesetDescription(sessionKey, gitState);
 			},
 			e => {
 				this._logService.warn(`[AgentService] Failed to compute git state for ${session}`, e);
@@ -614,6 +615,45 @@ export class AgentService extends Disposable implements IAgentService {
 			return;
 		}
 		this._stateManager.setSessionChangesets(sessionKey, filtered);
+	}
+
+	/**
+	 * Patches the `Branch Changes` catalogue entry's `description` to
+	 * `${branchName} → ${baseBranchName}` once the git probe resolves
+	 * both names (typical worktree-isolation case). No-ops when the
+	 * entry has already been stripped (non-git working dir), when the
+	 * branch info is incomplete, or when the description is unchanged.
+	 * The count-refresh path in `AgentHostChangesetService` preserves
+	 * extra fields via spread, so the description survives subsequent
+	 * compute passes without further plumbing.
+	 */
+	private _updateBranchChangesetDescription(sessionKey: string, gitState: { branchName?: string; baseBranchName?: string }): void {
+		const description = formatSessionChangesetDescription(gitState.branchName, gitState.baseBranchName);
+		const state = this._stateManager.getSessionState(sessionKey);
+		const current = state?.summary.changesets;
+		if (!current || current.length === 0) {
+			return;
+		}
+		const branchUri = buildSessionChangesetUri(sessionKey);
+		let changed = false;
+		const next = current.map(c => {
+			if (c.uriTemplate !== branchUri) {
+				return c;
+			}
+			if (c.description === description) {
+				return c;
+			}
+			changed = true;
+			if (description === undefined) {
+				const { description: _omit, ...rest } = c;
+				return rest;
+			}
+			return { ...c, description };
+		});
+		if (!changed) {
+			return;
+		}
+		this._stateManager.setSessionChangesets(sessionKey, next);
 	}
 
 	private _persistConfigValues(session: URI, values: Record<string, unknown>): void {

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -991,7 +991,7 @@ suite('AgentService (node dispatcher)', () => {
 			const state = localService.stateManager.getSessionState(session.toString());
 			assert.ok(state);
 			assert.deepStrictEqual(state!.summary.changesets, [
-				{ label: 'Branch Changes', uriTemplate: `${session.toString()}/changeset/session` },
+				{ label: 'Branch Changes', uriTemplate: `${session.toString()}/changeset/session`, description: 'main' },
 				{ label: 'Uncommitted Changes', uriTemplate: `${session.toString()}/changeset/uncommitted`, description: 'Show uncommitted changes in this session' },
 				{ label: 'This Turn', uriTemplate: `${session.toString()}/changeset/turn/{turnId}` },
 			]);

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -997,6 +997,41 @@ suite('AgentService (node dispatcher)', () => {
 			]);
 		});
 
+		test('createSession sets Branch Changes description from worktree branch info', async () => {
+			const workingDirectory = URI.file('/workspace/repo');
+			const gitState = {
+				hasGitHubRemote: false,
+				branchName: 'feature/x',
+				baseBranchName: 'main',
+				upstreamBranchName: undefined,
+				incomingChanges: 0,
+				outgoingChanges: 0,
+				uncommittedChanges: 0,
+			};
+			const gitService = createNoopGitService();
+			gitService.getSessionGitState = async () => gitState;
+
+			const localService = disposables.add(new AgentService(new NullLogService(), fileService, nullSessionDataService, { _serviceBrand: undefined } as IProductService, gitService));
+			const agent = new MockAgent('copilot');
+			disposables.add(toDisposable(() => agent.dispose()));
+			agent.resolvedWorkingDirectory = workingDirectory;
+			agent.sessionMetadataOverrides = { workingDirectory };
+			localService.registerProvider(agent);
+
+			const session = await localService.createSession({ provider: 'copilot' });
+			for (let i = 0; i < 5; i++) {
+				await Promise.resolve();
+			}
+
+			const state = localService.stateManager.getSessionState(session.toString());
+			assert.ok(state);
+			assert.deepStrictEqual(state!.summary.changesets, [
+				{ label: 'Branch Changes', uriTemplate: `${session.toString()}/changeset/session`, description: 'feature/x → main' },
+				{ label: 'Uncommitted Changes', uriTemplate: `${session.toString()}/changeset/uncommitted`, description: 'Show uncommitted changes in this session' },
+				{ label: 'This Turn', uriTemplate: `${session.toString()}/changeset/turn/{turnId}` },
+			]);
+		});
+
 		test('subscribe lazily attaches git state when an existing session has no _meta.git', async () => {
 			// Regression test: previously AgentService was constructed without
 			// a git service, so _attachGitState always bailed and `_meta.git`


### PR DESCRIPTION
Introduce a function to format the branch changeset description and update the session management to utilize this new formatting. This change enhances the clarity of branch information in the session state. A test verifies that the description is correctly set based on the current branch and base branch names.

Fixes https://github.com/microsoft/vscode/issues/317038