### PR TITLE
Scope tool search to request tools and tighten deferred tool handling

### DIFF
--- a/extensions/copilot/src/extension/intents/node/agentIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/agentIntent.ts
@@ -159,6 +159,7 @@ export const getAgentTools = async (accessor: ServicesAccessor, request: vscode.
 	allowTools[ToolName.GetScmChanges] = getSCMChangesEnabled;
 
 	allowTools[ToolName.SessionStoreSql] = true;
+	allowTools[ToolName.CoreAskQuestions] = true;
 
 	allowTools[CUSTOM_TOOL_SEARCH_NAME] = !!model.supportsToolSearch;
 

--- a/extensions/copilot/src/extension/intents/node/test/backgroundTodoEnablement.spec.ts
+++ b/extensions/copilot/src/extension/intents/node/test/backgroundTodoEnablement.spec.ts
@@ -19,6 +19,8 @@ import { IInstantiationService } from '../../../../util/vs/platform/instantiatio
 import { createExtensionUnitTestingServices } from '../../../test/node/services';
 import { TestChatRequest } from '../../../test/node/testHelpers';
 import { ToolName } from '../../../tools/common/toolNames';
+import { IToolsService } from '../../../tools/common/toolsService';
+import { TestToolsService } from '../../../tools/node/test/testToolsService';
 import { AgentIntentInvocation, getAgentTools, isBackgroundTodoAgentEnabled, isTodoToolExplicitlyEnabled } from '../agentIntent';
 
 // ─── isTodoToolExplicitlyEnabled unit tests ──────────────────────
@@ -86,6 +88,13 @@ describe('getAgentTools background todo enablement', () => {
 		instantiationService = accessor.get(IInstantiationService);
 		configService = accessor.get(IConfigurationService);
 		experimentationService = accessor.get(IExperimentationService);
+		(accessor.get(IToolsService) as TestToolsService).addTestToolOverride({
+			name: ToolName.CoreAskQuestions,
+			description: 'ask questions',
+			inputSchema: { type: 'object', properties: {} },
+			tags: [],
+			source: undefined,
+		}, {} as any);
 		mockEndpoint = instantiationService.createInstance(MockEndpoint, undefined);
 	});
 
@@ -146,6 +155,13 @@ describe('getAgentTools background todo enablement', () => {
 		const request = new TestChatRequest('fix the bug');
 		const tools = await instantiationService.invokeFunction(getAgentTools, request, mockEndpoint);
 		expect(hasTool(tools, ToolName.CoreAskQuestions)).toBe(true);
+	});
+
+	test('does not publish vscode_askQuestions when the tool picker explicitly disables it', async () => {
+		const request = new TestChatRequest('fix the bug');
+		request.tools = new Map([[{ name: ToolName.CoreAskQuestions } as any, false]]);
+		const tools = await instantiationService.invokeFunction(getAgentTools, request, mockEndpoint);
+		expect(hasTool(tools, ToolName.CoreAskQuestions)).toBe(false);
 	});
 });
 

--- a/extensions/copilot/src/extension/intents/node/test/backgroundTodoEnablement.spec.ts
+++ b/extensions/copilot/src/extension/intents/node/test/backgroundTodoEnablement.spec.ts
@@ -102,6 +102,10 @@ describe('getAgentTools background todo enablement', () => {
 		return tools.some(t => t.name === ToolName.CoreManageTodoList);
 	}
 
+	function hasTool(tools: readonly { name: string }[], name: string): boolean {
+		return tools.some(tool => tool.name === name);
+	}
+
 	test('background todo agent is enabled only when experiment is on and todo is not explicit', () => {
 		const request = new TestChatRequest('fix the bug');
 		configService.setConfig(ConfigKey.Advanced.BackgroundTodoAgentEnabled, false);
@@ -136,6 +140,12 @@ describe('getAgentTools background todo enablement', () => {
 		(request as any).toolReferences = [{ name: 'read_file' }];
 		const tools = await instantiationService.invokeFunction(getAgentTools, request, mockEndpoint);
 		expect(hasTodoTool(tools)).toBe(false);
+	});
+
+	test('publishes vscode_askQuestions on the initial agent request without explicit tool picker opt-in', async () => {
+		const request = new TestChatRequest('fix the bug');
+		const tools = await instantiationService.invokeFunction(getAgentTools, request, mockEndpoint);
+		expect(hasTool(tools, ToolName.CoreAskQuestions)).toBe(true);
 	});
 });
 

--- a/extensions/copilot/src/extension/prompt/node/defaultIntentRequestHandler.ts
+++ b/extensions/copilot/src/extension/prompt/node/defaultIntentRequestHandler.ts
@@ -14,7 +14,6 @@ import { IConversationOptions } from '../../../platform/chat/common/conversation
 import { ISessionTranscriptService } from '../../../platform/chat/common/sessionTranscriptService';
 import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
 import { IEditSurvivalTrackerService, IEditSurvivalTrackingSession, NullEditSurvivalTrackingSession } from '../../../platform/editSurvivalTracking/common/editSurvivalTrackerService';
-import { isAnthropicFamily } from '../../../platform/endpoint/common/chatModelCapabilities';
 import { IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
 import { IFileSystemService } from '../../../platform/filesystem/common/fileSystemService';
 import { IGitService } from '../../../platform/git/common/gitService';
@@ -771,11 +770,6 @@ class DefaultToolCallingLoop extends ToolCallingLoop<IDefaultToolLoopOptions> {
 
 	protected override async getAvailableTools(outputStream: ChatResponseStream | undefined, token: CancellationToken): Promise<LanguageModelToolInformation[]> {
 		const tools = await this.options.invocation.getAvailableTools?.() ?? [];
-
-		// Skip tool grouping when Anthropic tool search is enabled
-		if (isAnthropicFamily(this.options.invocation.endpoint) && this.options.invocation.endpoint.supportsToolSearch) {
-			return tools;
-		}
 
 		if (this.toolGrouping) {
 			this.toolGrouping.tools = tools;

--- a/extensions/copilot/src/extension/prompt/node/test/defaultIntentRequestHandler.spec.ts
+++ b/extensions/copilot/src/extension/prompt/node/test/defaultIntentRequestHandler.spec.ts
@@ -6,7 +6,7 @@
 
 import { Raw, RenderPromptResult } from '@vscode/prompt-tsx';
 import { afterEach, beforeEach, expect, suite, test, vi } from 'vitest';
-import type { ChatLanguageModelToolReference, ChatPromptReference, ChatRequest, ExtendedChatResponsePart, LanguageModelChat } from 'vscode';
+import type { ChatLanguageModelToolReference, ChatPromptReference, ChatRequest, ExtendedChatResponsePart, LanguageModelChat, LanguageModelToolInformation } from 'vscode';
 import { IChatMLFetcher } from '../../../../platform/chat/common/chatMLFetcher';
 import { toTextPart } from '../../../../platform/chat/common/globalStringUtils';
 import { StaticChatMLFetcher } from '../../../../platform/chat/test/common/staticChatMLFetcher';
@@ -20,6 +20,7 @@ import { NullWorkspaceFileIndex } from '../../../../platform/workspaceChunkSearc
 import { IWorkspaceFileIndex } from '../../../../platform/workspaceChunkSearch/node/workspaceFileIndex';
 import { ChatResponseStreamImpl } from '../../../../util/common/chatResponseStreamImpl';
 import { CancellationToken } from '../../../../util/vs/base/common/cancellation';
+import { constObservable } from '../../../../util/vs/base/common/observableInternal';
 import { isObject, isUndefinedOrNull } from '../../../../util/vs/base/common/types';
 import { generateUuid } from '../../../../util/vs/base/common/uuid';
 import { SyncDescriptor } from '../../../../util/vs/platform/instantiation/common/descriptors';
@@ -28,6 +29,7 @@ import { ChatLocation, ChatResponseConfirmationPart, ChatResponseMarkdownPart, L
 import { ToolCallingLoop } from '../../../intents/node/toolCallingLoop';
 import { ToolResultMetadata } from '../../../prompts/node/panel/toolCalling';
 import { createExtensionUnitTestingServices } from '../../../test/node/services';
+import { IToolGrouping, IToolGroupingService } from '../../../tools/common/virtualTools/virtualToolTypes';
 import { Conversation, Turn } from '../../common/conversation';
 import { IBuildPromptContext } from '../../common/intents';
 import { ToolCallRound } from '../../common/toolCallRound';
@@ -42,9 +44,12 @@ suite('defaultIntentRequestHandler', () => {
 	let promptResult: RenderPromptResult | RenderPromptResult[];
 	let telemetry: SpyingTelemetryService;
 	let fetcher: StaticChatMLFetcher;
-	let endpoint: IChatEndpoint;
+	let endpoint: MockEndpoint;
 	let turnIdCounter = 0;
 	let builtPrompts: IBuildPromptContext[] = [];
+	let availableTools: LanguageModelToolInformation[] = [];
+	let groupedTools: LanguageModelToolInformation[] | undefined;
+	let toolGroupingComputeCount = 0;
 	const sessionId = 'some-session-id';
 
 	const getTurnId = () => `turn-id-${turnIdCounter}`;
@@ -57,12 +62,22 @@ suite('defaultIntentRequestHandler', () => {
 		services.define(ITelemetryService, telemetry);
 		services.define(IChatMLFetcher, fetcher);
 		services.define(IWorkspaceFileIndex, new SyncDescriptor(NullWorkspaceFileIndex));
+		services.define(IToolGroupingService, {
+			_serviceBrand: undefined,
+			threshold: constObservable(0),
+			create: (_sessionId, tools) => new TestToolGrouping(tools, () => groupedTools ?? tools, () => {
+				toolGroupingComputeCount++;
+			}),
+		});
 
 		accessor = services.createTestingAccessor();
 		endpoint = accessor.get(IInstantiationService).createInstance(MockEndpoint, undefined);
 		builtPrompts = [];
 		response = [];
 		promptResult = nullRenderPromptResult();
+		availableTools = [];
+		groupedTools = undefined;
+		toolGroupingComputeCount = 0;
 		turnIdCounter = 0;
 		(ToolCallingLoop as any).NextToolCallId = 0;
 		(ToolCallRound as any).generateID = () => 'static-id';
@@ -87,12 +102,65 @@ suite('defaultIntentRequestHandler', () => {
 		});
 	}
 
+	class TestToolGrouping implements IToolGrouping {
+		public tools: readonly LanguageModelToolInformation[];
+
+		constructor(
+			tools: readonly LanguageModelToolInformation[],
+			private readonly getComputedTools: () => readonly LanguageModelToolInformation[],
+			private readonly onCompute: () => void,
+		) {
+			this.tools = tools;
+		}
+
+		didCall(): LanguageModelToolResult | undefined {
+			return undefined;
+		}
+
+		didTakeTurn(): void {
+		}
+
+		didInvalidateCache(): void {
+		}
+
+		getContainerFor() {
+			return undefined;
+		}
+
+		ensureExpanded(): void {
+		}
+
+		async compute(): Promise<LanguageModelToolInformation[]> {
+			this.onCompute();
+			return [...this.getComputedTools()];
+		}
+
+		async computeAll(): Promise<LanguageModelToolInformation[]> {
+			this.onCompute();
+			return [...this.getComputedTools()];
+		}
+	}
+
+	function makeToolInfo(name: string): LanguageModelToolInformation {
+		return {
+			name,
+			description: `Tool for ${name}`,
+			inputSchema: { type: 'object', properties: {} },
+			source: undefined,
+			tags: [],
+		};
+	}
+
 	class TestIntent implements IIntent {
 		id = 'test';
 		description = 'test intent';
 		locations = [ChatLocation.Panel];
+
+		constructor(private readonly tools: readonly LanguageModelToolInformation[] = []) {
+		}
+
 		invoke(): Promise<IIntentInvocation> {
-			return Promise.resolve(new TestIntentInvocation(this, this.locations[0], endpoint));
+			return Promise.resolve(new TestIntentInvocation(this, this.locations[0], endpoint, this.tools));
 		}
 	}
 
@@ -103,7 +171,12 @@ suite('defaultIntentRequestHandler', () => {
 			readonly intent: IIntent,
 			readonly location: ChatLocation,
 			readonly endpoint: IChatEndpoint,
+			private readonly tools: readonly LanguageModelToolInformation[],
 		) { }
+
+		getAvailableTools(): LanguageModelToolInformation[] {
+			return [...this.tools];
+		}
 
 		async buildPrompt(context: IBuildPromptContext): Promise<RenderPromptResult> {
 			builtPrompts.push(context);
@@ -145,8 +218,9 @@ suite('defaultIntentRequestHandler', () => {
 
 	const makeHandler = ({
 		request = new TestChatRequest(),
-		turns = []
-	}: { request?: ChatRequest; turns?: Turn[] } = {}) => {
+		turns = [],
+		tools = availableTools,
+	}: { request?: ChatRequest; turns?: Turn[]; tools?: readonly LanguageModelToolInformation[] } = {}) => {
 		turns.push(new Turn(
 			getTurnId(),
 			{ type: 'user', message: request.prompt },
@@ -156,7 +230,7 @@ suite('defaultIntentRequestHandler', () => {
 		const instaService = accessor.get(IInstantiationService);
 		return instaService.createInstance(
 			DefaultIntentRequestHandler,
-			new TestIntent(),
+			new TestIntent(tools),
 			new Conversation(sessionId, turns),
 			request,
 			responseStream,
@@ -189,6 +263,34 @@ suite('defaultIntentRequestHandler', () => {
 		// Wait for event loop to finish as we often fire off telemetry without properly awaiting it as it doesn't matter when it is sent
 		await new Promise(setImmediate);
 		expect(getDerandomizedTelemetry()).toMatchSnapshot();
+	});
+
+	test('keeps activate_vs_code_interaction in request-scoped tools for anthropic tool search requests', async () => {
+		endpoint.family = 'claude-sonnet-4';
+		endpoint.model = 'claude-sonnet-4';
+		endpoint.supportsToolSearch = true;
+
+		availableTools = [
+			makeToolInfo('read_file'),
+			makeToolInfo('get_errors'),
+			makeToolInfo('create_new_workspace'),
+		];
+		groupedTools = [
+			makeToolInfo('read_file'),
+			makeToolInfo('activate_vs_code_interaction'),
+		];
+
+		const handler = makeHandler({ tools: availableTools });
+		chatResponse[0] = 'some response here :)';
+		promptResult = {
+			...nullRenderPromptResult(),
+			messages: [{ role: Raw.ChatRole.User, content: [toTextPart('hello world!')] }],
+		};
+
+		await handler.getResult();
+
+		expect(toolGroupingComputeCount).toBeGreaterThan(0);
+		expect(builtPrompts[0].tools?.availableTools.map(tool => tool.name)).toContain('activate_vs_code_interaction');
 	});
 
 	test('propagates resolvedModel into result metadata from a successful response', async () => {

--- a/extensions/copilot/src/extension/prompts/node/agent/agentPrompt.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/agentPrompt.tsx
@@ -500,6 +500,7 @@ export class AgentUserMessage extends PromptElement<AgentUserMessageProps> {
 		const ReminderInstructionsClass = this.props.ReminderInstructionsClass ?? DefaultReminderInstructions;
 		const reminderProps: ReminderInstructionsProps = {
 			endpoint: this.props.endpoint,
+			availableTools: this.props.availableTools,
 			hasTodoTool,
 			hasEditFileTool,
 			hasReplaceStringTool,

--- a/extensions/copilot/src/extension/prompts/node/agent/defaultAgentInstructions.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/defaultAgentInstructions.tsx
@@ -68,6 +68,7 @@ export class DefaultToolReferencesHint extends PromptElement<ToolReferencesHintP
 
 export interface ReminderInstructionsProps extends BasePromptElementProps {
 	readonly endpoint: IChatEndpoint;
+	readonly availableTools: readonly LanguageModelToolInformation[] | undefined;
 	readonly hasTodoTool: boolean;
 	readonly hasEditFileTool: boolean;
 	readonly hasReplaceStringTool: boolean;

--- a/extensions/copilot/src/extension/prompts/node/agent/openai/gpt54Prompt.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/openai/gpt54Prompt.tsx
@@ -3,9 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { PromptElement, PromptSizing } from '@vscode/prompt-tsx';
+import { PromptElement, PromptElementProps, PromptSizing } from '@vscode/prompt-tsx';
 import { isGpt54 } from '../../../../../platform/endpoint/common/chatModelCapabilities';
 import { IChatEndpoint } from '../../../../../platform/networking/common/networking';
+import { IToolDeferralService } from '../../../../../platform/networking/common/toolDeferralService';
 import { ToolName } from '../../../../tools/common/toolNames';
 import { GPT5CopilotIdentityRule } from '../../base/copilotIdentity';
 import { InstructionMessage } from '../../base/instructionMessage';
@@ -16,7 +17,7 @@ import { ResponseRenderingRules } from '../../panel/editorIntegrationRules';
 import { ApplyPatchInstructions, DefaultAgentPromptProps, detectToolCapabilities, getEditingReminder, McpToolInstructions, ReminderInstructionsProps } from '../defaultAgentInstructions';
 import { FileLinkificationInstructions } from '../fileLinkificationInstructions';
 import { CopilotIdentityRulesConstructor, IAgentPrompt, PromptRegistry, ReminderInstructionsConstructor, SafetyRulesConstructor, SystemPrompt } from '../promptRegistry';
-import { CUSTOM_TOOL_SEARCH_NAME, ToolSearchToolPromptOptimized } from '../toolSearchInstructions';
+import { CUSTOM_TOOL_SEARCH_NAME, shouldShowToolSearchPrompt, ToolSearchToolPromptOptimized } from '../toolSearchInstructions';
 
 export class Gpt54Prompt extends PromptElement<DefaultAgentPromptProps> {
 	async render(state: void, sizing: PromptSizing) {
@@ -241,8 +242,15 @@ class Gpt54PromptResolver implements IAgentPrompt {
 }
 
 export class Gpt54ReminderInstructions extends PromptElement<ReminderInstructionsProps> {
+	constructor(
+		props: PromptElementProps<ReminderInstructionsProps>,
+		@IToolDeferralService private readonly toolDeferralService: IToolDeferralService,
+	) {
+		super(props);
+	}
+
 	async render(state: void, sizing: PromptSizing) {
-		const toolSearchEnabled = !!this.props.endpoint.supportsToolSearch;
+		const toolSearchEnabled = shouldShowToolSearchPrompt(this.props.availableTools, this.props.endpoint.supportsToolSearch, this.toolDeferralService);
 		return <>
 			You are an agent—keep going until the user's query is completely resolved before ending your turn. ONLY stop if solved or genuinely blocked.<br />
 			Take action when possible; the user expects you to do useful work without unnecessary questions.<br />

--- a/extensions/copilot/src/extension/prompts/node/agent/openai/gpt55BasePrompt.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/openai/gpt55BasePrompt.tsx
@@ -3,7 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { PromptElement, PromptSizing } from '@vscode/prompt-tsx';
+import { PromptElement, PromptElementProps, PromptSizing } from '@vscode/prompt-tsx';
+import { IToolDeferralService } from '../../../../../platform/networking/common/toolDeferralService';
 import { ToolName } from '../../../../tools/common/toolNames';
 import { InstructionMessage } from '../../base/instructionMessage';
 import { ResponseTranslationRules } from '../../base/responseTranslationRules';
@@ -11,7 +12,7 @@ import { Tag } from '../../base/tag';
 import { ResponseRenderingRules } from '../../panel/editorIntegrationRules';
 import { ApplyPatchInstructions, DefaultAgentPromptProps, detectToolCapabilities, getEditingReminder, McpToolInstructions, ReminderInstructionsProps } from '../defaultAgentInstructions';
 import { FileLinkificationInstructionsOptimized } from '../fileLinkificationInstructions';
-import { CUSTOM_TOOL_SEARCH_NAME, ToolSearchToolPromptOptimized } from '../toolSearchInstructions';
+import { CUSTOM_TOOL_SEARCH_NAME, shouldShowToolSearchPrompt, ToolSearchToolPromptOptimized } from '../toolSearchInstructions';
 
 export abstract class Gpt55PromptBase extends PromptElement<DefaultAgentPromptProps> {
 	protected get includeLargePromptSections(): boolean {
@@ -266,8 +267,15 @@ export abstract class Gpt55PromptBase extends PromptElement<DefaultAgentPromptPr
 }
 
 export class Gpt55ReminderInstructions extends PromptElement<ReminderInstructionsProps> {
+	constructor(
+		props: PromptElementProps<ReminderInstructionsProps>,
+		@IToolDeferralService private readonly toolDeferralService: IToolDeferralService,
+	) {
+		super(props);
+	}
+
 	async render(state: void, sizing: PromptSizing) {
-		const toolSearchEnabled = !!this.props.endpoint.supportsToolSearch;
+		const toolSearchEnabled = shouldShowToolSearchPrompt(this.props.availableTools, this.props.endpoint.supportsToolSearch, this.toolDeferralService);
 		return <>
 			You are an agent—keep going until the user's query is completely resolved before ending your turn. ONLY stop if solved or genuinely blocked.<br />
 			Take action when possible; the user expects you to do useful work without unnecessary questions.<br />

--- a/extensions/copilot/src/extension/prompts/node/agent/openai/hiddenModelMPrompt.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/openai/hiddenModelMPrompt.tsx
@@ -3,9 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { PromptElement, PromptSizing } from '@vscode/prompt-tsx';
+import { PromptElement, PromptElementProps, PromptSizing } from '@vscode/prompt-tsx';
 import { isHiddenModelM } from '../../../../../platform/endpoint/common/chatModelCapabilities';
 import { IChatEndpoint } from '../../../../../platform/networking/common/networking';
+import { IToolDeferralService } from '../../../../../platform/networking/common/toolDeferralService';
 import { ToolName } from '../../../../tools/common/toolNames';
 import { Gpt55CopilotIdentityRule as HiddenModelMCopilotIdentityRule } from '../../base/copilotIdentity';
 import { InstructionMessage } from '../../base/instructionMessage';
@@ -15,7 +16,7 @@ import { Tag } from '../../base/tag';
 import { DefaultAgentPromptProps, detectToolCapabilities, getEditingReminder, ReminderInstructionsProps } from '../defaultAgentInstructions';
 import { FileLinkificationInstructionsOptimized } from '../fileLinkificationInstructions';
 import { CopilotIdentityRulesConstructor, IAgentPrompt, PromptRegistry, ReminderInstructionsConstructor, SafetyRulesConstructor, SystemPrompt } from '../promptRegistry';
-import { CUSTOM_TOOL_SEARCH_NAME, ToolSearchToolPromptOptimized } from '../toolSearchInstructions';
+import { CUSTOM_TOOL_SEARCH_NAME, shouldShowToolSearchPrompt, ToolSearchToolPromptOptimized } from '../toolSearchInstructions';
 
 class HiddenModelMPrompt extends PromptElement<DefaultAgentPromptProps> {
 	async render(state: void, sizing: PromptSizing) {
@@ -216,8 +217,15 @@ class HiddenModelMPromptResolver implements IAgentPrompt {
 }
 
 export class HiddenModelMReminderInstructions extends PromptElement<ReminderInstructionsProps> {
+	constructor(
+		props: PromptElementProps<ReminderInstructionsProps>,
+		@IToolDeferralService private readonly toolDeferralService: IToolDeferralService,
+	) {
+		super(props);
+	}
+
 	async render(state: void, sizing: PromptSizing) {
-		const toolSearchEnabled = !!this.props.endpoint.supportsToolSearch;
+		const toolSearchEnabled = shouldShowToolSearchPrompt(this.props.availableTools, this.props.endpoint.supportsToolSearch, this.toolDeferralService);
 		return <>
 			You are an agent—keep going until the user's query is completely resolved before ending your turn. ONLY stop if solved or genuinely blocked.<br />
 			Take action when possible; the user expects you to do useful work without unnecessary questions.<br />

--- a/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-opus-4.5/all_non_edit_tools.spec.snap
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-opus-4.5/all_non_edit_tools.spec.snap
@@ -36,7 +36,7 @@ If semantic_search returns the full contents of the text files in the workspace,
 You can use the grep_search to get an overview of a file by searching for a string within that one file, instead of using read_file many times.
 If you don't know exactly the string or filename pattern you're looking for, use semantic_search to do a semantic search across the workspace.
 Don't call execution_subagent multiple times in parallel. Instead, invoke one subagent and wait for its response before running the next command.
-When creating files, be intentional and avoid calling the create_file tool unnecessarily. Only create files that are essential to completing the user's request. 
+When creating files, be intentional and avoid calling the create_file tool unnecessarily. Only create files that are essential to completing the user's request.
 When invoking a tool that takes a file path, always use the absolute file path. If the file has a scheme like untitled: or vscode-userdata:, then use a URI with the scheme.
 You don't currently have any tools available for editing files. If the user asks you to edit a file, you can ask the user to enable editing tools or print a codeblock with the suggested changes.
 You don't currently have any tools available for running terminal commands. If the user asks you to run a terminal command, you can ask the user to enable terminal tools or print a codeblock with the suggested command.
@@ -196,7 +196,7 @@ The user's current OS is: Linux
 </environment_info>
 <workspace_info>
 I am working in a workspace with the following folders:
-- /workspace 
+- /workspace
 I am working in a workspace that has the following structure:
 ```
 
@@ -212,25 +212,6 @@ Session memory (/memories/session/) is empty. No session notes have been created
 <repoMemory>
 Repository memory (/memories/repo/) is empty. No workspace-scoped notes have been created yet.
 </repoMemory>
-<availableDeferredTools>
-Available deferred tools (must be loaded with tool_search before use):
-copilot_getNotebookSummary
-create_directory
-create_new_jupyter_notebook
-create_new_workspace
-edit_notebook_file
-get_vscode_api
-github_repo
-github_text_search
-install_extension
-read_notebook_cell_output
-read_project_structure
-resolve_memory_file_uri
-run_notebook_cell
-run_vscode_command
-search_workspace_symbols
-test_search
-</availableDeferredTools>
 
 ~~~
 

--- a/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-opus-4.5/all_tools.spec.snap
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-opus-4.5/all_tools.spec.snap
@@ -36,7 +36,7 @@ If semantic_search returns the full contents of the text files in the workspace,
 You can use the grep_search to get an overview of a file by searching for a string within that one file, instead of using read_file many times.
 If you don't know exactly the string or filename pattern you're looking for, use semantic_search to do a semantic search across the workspace.
 Don't call execution_subagent multiple times in parallel. Instead, invoke one subagent and wait for its response before running the next command.
-When creating files, be intentional and avoid calling the create_file tool unnecessarily. Only create files that are essential to completing the user's request. 
+When creating files, be intentional and avoid calling the create_file tool unnecessarily. Only create files that are essential to completing the user's request.
 When invoking a tool that takes a file path, always use the absolute file path. If the file has a scheme like untitled: or vscode-userdata:, then use a URI with the scheme.
 You don't currently have any tools available for running terminal commands. If the user asks you to run a terminal command, you can ask the user to enable terminal tools or print a codeblock with the suggested command.
 Tools can be disabled by the user. You may see tools used previously in the conversation that are not currently available. Be careful to only use the tools that are currently available to you.
@@ -197,7 +197,7 @@ The user's current OS is: Linux
 </environment_info>
 <workspace_info>
 I am working in a workspace with the following folders:
-- /workspace 
+- /workspace
 I am working in a workspace that has the following structure:
 ```
 
@@ -213,25 +213,6 @@ Session memory (/memories/session/) is empty. No session notes have been created
 <repoMemory>
 Repository memory (/memories/repo/) is empty. No workspace-scoped notes have been created yet.
 </repoMemory>
-<availableDeferredTools>
-Available deferred tools (must be loaded with tool_search before use):
-copilot_getNotebookSummary
-create_directory
-create_new_jupyter_notebook
-create_new_workspace
-edit_notebook_file
-get_vscode_api
-github_repo
-github_text_search
-install_extension
-read_notebook_cell_output
-read_project_structure
-resolve_memory_file_uri
-run_notebook_cell
-run_vscode_command
-search_workspace_symbols
-test_search
-</availableDeferredTools>
 
 ~~~
 

--- a/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-opus-4.6/all_non_edit_tools.spec.snap
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-opus-4.6/all_non_edit_tools.spec.snap
@@ -56,14 +56,6 @@ For semantic search across the workspace, use semantic_search. For exact text ma
 Don't call execution_subagent multiple times in parallel. Instead, invoke one subagent and wait for its response before running the next command.
 When invoking a tool that takes a file path, always use the absolute file path. If the file has a scheme like untitled: or vscode-userdata:, use a URI with the scheme.
 Tools can be disabled by the user. Only use tools that are currently available.
-<toolSearchInstructions>
-You MUST use tool_search to load deferred tools BEFORE calling them. Calling a deferred tool without loading it first will fail.
-
-Describe what capability you need in natural language. The search uses semantic similarity to find the most relevant tools.
-
-Do NOT call tool_search again for a tool already returned by a previous search. If a search returns no matching tools, the tool is not available. Do not retry with different patterns.
-
-</toolSearchInstructions>
 
 </toolUseInstructions>
 <communicationStyle>
@@ -149,7 +141,7 @@ The user's current OS is: Linux
 </environment_info>
 <workspace_info>
 I am working in a workspace with the following folders:
-- /workspace 
+- /workspace
 I am working in a workspace that has the following structure:
 ```
 
@@ -165,25 +157,6 @@ Session memory (/memories/session/) is empty. No session notes have been created
 <repoMemory>
 Repository memory (/memories/repo/) is empty. No workspace-scoped notes have been created yet.
 </repoMemory>
-<availableDeferredTools>
-Available deferred tools (must be loaded with tool_search before use):
-copilot_getNotebookSummary
-create_directory
-create_new_jupyter_notebook
-create_new_workspace
-edit_notebook_file
-get_vscode_api
-github_repo
-github_text_search
-install_extension
-read_notebook_cell_output
-read_project_structure
-resolve_memory_file_uri
-run_notebook_cell
-run_vscode_command
-search_workspace_symbols
-test_search
-</availableDeferredTools>
 
 ~~~
 

--- a/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-opus-4.6/all_tools.spec.snap
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-opus-4.6/all_tools.spec.snap
@@ -56,14 +56,6 @@ For semantic search across the workspace, use semantic_search. For exact text ma
 Don't call execution_subagent multiple times in parallel. Instead, invoke one subagent and wait for its response before running the next command.
 When invoking a tool that takes a file path, always use the absolute file path. If the file has a scheme like untitled: or vscode-userdata:, use a URI with the scheme.
 Tools can be disabled by the user. Only use tools that are currently available.
-<toolSearchInstructions>
-You MUST use tool_search to load deferred tools BEFORE calling them. Calling a deferred tool without loading it first will fail.
-
-Describe what capability you need in natural language. The search uses semantic similarity to find the most relevant tools.
-
-Do NOT call tool_search again for a tool already returned by a previous search. If a search returns no matching tools, the tool is not available. Do not retry with different patterns.
-
-</toolSearchInstructions>
 
 </toolUseInstructions>
 <communicationStyle>
@@ -151,7 +143,7 @@ The user's current OS is: Linux
 </environment_info>
 <workspace_info>
 I am working in a workspace with the following folders:
-- /workspace 
+- /workspace
 I am working in a workspace that has the following structure:
 ```
 
@@ -167,25 +159,6 @@ Session memory (/memories/session/) is empty. No session notes have been created
 <repoMemory>
 Repository memory (/memories/repo/) is empty. No workspace-scoped notes have been created yet.
 </repoMemory>
-<availableDeferredTools>
-Available deferred tools (must be loaded with tool_search before use):
-copilot_getNotebookSummary
-create_directory
-create_new_jupyter_notebook
-create_new_workspace
-edit_notebook_file
-get_vscode_api
-github_repo
-github_text_search
-install_extension
-read_notebook_cell_output
-read_project_structure
-resolve_memory_file_uri
-run_notebook_cell
-run_vscode_command
-search_workspace_symbols
-test_search
-</availableDeferredTools>
 
 ~~~
 

--- a/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-sonnet-4.5/all_non_edit_tools.spec.snap
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-sonnet-4.5/all_non_edit_tools.spec.snap
@@ -36,7 +36,7 @@ If semantic_search returns the full contents of the text files in the workspace,
 You can use the grep_search to get an overview of a file by searching for a string within that one file, instead of using read_file many times.
 If you don't know exactly the string or filename pattern you're looking for, use semantic_search to do a semantic search across the workspace.
 Don't call execution_subagent multiple times in parallel. Instead, invoke one subagent and wait for its response before running the next command.
-When creating files, be intentional and avoid calling the create_file tool unnecessarily. Only create files that are essential to completing the user's request. 
+When creating files, be intentional and avoid calling the create_file tool unnecessarily. Only create files that are essential to completing the user's request.
 When invoking a tool that takes a file path, always use the absolute file path. If the file has a scheme like untitled: or vscode-userdata:, then use a URI with the scheme.
 You don't currently have any tools available for editing files. If the user asks you to edit a file, you can ask the user to enable editing tools or print a codeblock with the suggested changes.
 You don't currently have any tools available for running terminal commands. If the user asks you to run a terminal command, you can ask the user to enable terminal tools or print a codeblock with the suggested command.
@@ -196,7 +196,7 @@ The user's current OS is: Linux
 </environment_info>
 <workspace_info>
 I am working in a workspace with the following folders:
-- /workspace 
+- /workspace
 I am working in a workspace that has the following structure:
 ```
 
@@ -212,25 +212,6 @@ Session memory (/memories/session/) is empty. No session notes have been created
 <repoMemory>
 Repository memory (/memories/repo/) is empty. No workspace-scoped notes have been created yet.
 </repoMemory>
-<availableDeferredTools>
-Available deferred tools (must be loaded with tool_search before use):
-copilot_getNotebookSummary
-create_directory
-create_new_jupyter_notebook
-create_new_workspace
-edit_notebook_file
-get_vscode_api
-github_repo
-github_text_search
-install_extension
-read_notebook_cell_output
-read_project_structure
-resolve_memory_file_uri
-run_notebook_cell
-run_vscode_command
-search_workspace_symbols
-test_search
-</availableDeferredTools>
 
 ~~~
 

--- a/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-sonnet-4.5/all_tools.spec.snap
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-sonnet-4.5/all_tools.spec.snap
@@ -36,7 +36,7 @@ If semantic_search returns the full contents of the text files in the workspace,
 You can use the grep_search to get an overview of a file by searching for a string within that one file, instead of using read_file many times.
 If you don't know exactly the string or filename pattern you're looking for, use semantic_search to do a semantic search across the workspace.
 Don't call execution_subagent multiple times in parallel. Instead, invoke one subagent and wait for its response before running the next command.
-When creating files, be intentional and avoid calling the create_file tool unnecessarily. Only create files that are essential to completing the user's request. 
+When creating files, be intentional and avoid calling the create_file tool unnecessarily. Only create files that are essential to completing the user's request.
 When invoking a tool that takes a file path, always use the absolute file path. If the file has a scheme like untitled: or vscode-userdata:, then use a URI with the scheme.
 You don't currently have any tools available for running terminal commands. If the user asks you to run a terminal command, you can ask the user to enable terminal tools or print a codeblock with the suggested command.
 Tools can be disabled by the user. You may see tools used previously in the conversation that are not currently available. Be careful to only use the tools that are currently available to you.
@@ -197,7 +197,7 @@ The user's current OS is: Linux
 </environment_info>
 <workspace_info>
 I am working in a workspace with the following folders:
-- /workspace 
+- /workspace
 I am working in a workspace that has the following structure:
 ```
 
@@ -213,25 +213,6 @@ Session memory (/memories/session/) is empty. No session notes have been created
 <repoMemory>
 Repository memory (/memories/repo/) is empty. No workspace-scoped notes have been created yet.
 </repoMemory>
-<availableDeferredTools>
-Available deferred tools (must be loaded with tool_search before use):
-copilot_getNotebookSummary
-create_directory
-create_new_jupyter_notebook
-create_new_workspace
-edit_notebook_file
-get_vscode_api
-github_repo
-github_text_search
-install_extension
-read_notebook_cell_output
-read_project_structure
-resolve_memory_file_uri
-run_notebook_cell
-run_vscode_command
-search_workspace_symbols
-test_search
-</availableDeferredTools>
 
 ~~~
 

--- a/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-sonnet-4.6/all_non_edit_tools.spec.snap
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-sonnet-4.6/all_non_edit_tools.spec.snap
@@ -56,14 +56,6 @@ For semantic search across the workspace, use semantic_search. For exact text ma
 Don't call execution_subagent multiple times in parallel. Instead, invoke one subagent and wait for its response before running the next command.
 When invoking a tool that takes a file path, always use the absolute file path. If the file has a scheme like untitled: or vscode-userdata:, use a URI with the scheme.
 Tools can be disabled by the user. Only use tools that are currently available.
-<toolSearchInstructions>
-You MUST use tool_search to load deferred tools BEFORE calling them. Calling a deferred tool without loading it first will fail.
-
-Describe what capability you need in natural language. The search uses semantic similarity to find the most relevant tools.
-
-Do NOT call tool_search again for a tool already returned by a previous search. If a search returns no matching tools, the tool is not available. Do not retry with different patterns.
-
-</toolSearchInstructions>
 
 </toolUseInstructions>
 <communicationStyle>
@@ -149,7 +141,7 @@ The user's current OS is: Linux
 </environment_info>
 <workspace_info>
 I am working in a workspace with the following folders:
-- /workspace 
+- /workspace
 I am working in a workspace that has the following structure:
 ```
 
@@ -165,25 +157,6 @@ Session memory (/memories/session/) is empty. No session notes have been created
 <repoMemory>
 Repository memory (/memories/repo/) is empty. No workspace-scoped notes have been created yet.
 </repoMemory>
-<availableDeferredTools>
-Available deferred tools (must be loaded with tool_search before use):
-copilot_getNotebookSummary
-create_directory
-create_new_jupyter_notebook
-create_new_workspace
-edit_notebook_file
-get_vscode_api
-github_repo
-github_text_search
-install_extension
-read_notebook_cell_output
-read_project_structure
-resolve_memory_file_uri
-run_notebook_cell
-run_vscode_command
-search_workspace_symbols
-test_search
-</availableDeferredTools>
 
 ~~~
 

--- a/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-sonnet-4.6/all_tools.spec.snap
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/__snapshots__/agentPrompts-claude-sonnet-4.6/all_tools.spec.snap
@@ -56,14 +56,6 @@ For semantic search across the workspace, use semantic_search. For exact text ma
 Don't call execution_subagent multiple times in parallel. Instead, invoke one subagent and wait for its response before running the next command.
 When invoking a tool that takes a file path, always use the absolute file path. If the file has a scheme like untitled: or vscode-userdata:, use a URI with the scheme.
 Tools can be disabled by the user. Only use tools that are currently available.
-<toolSearchInstructions>
-You MUST use tool_search to load deferred tools BEFORE calling them. Calling a deferred tool without loading it first will fail.
-
-Describe what capability you need in natural language. The search uses semantic similarity to find the most relevant tools.
-
-Do NOT call tool_search again for a tool already returned by a previous search. If a search returns no matching tools, the tool is not available. Do not retry with different patterns.
-
-</toolSearchInstructions>
 
 </toolUseInstructions>
 <communicationStyle>
@@ -151,7 +143,7 @@ The user's current OS is: Linux
 </environment_info>
 <workspace_info>
 I am working in a workspace with the following folders:
-- /workspace 
+- /workspace
 I am working in a workspace that has the following structure:
 ```
 
@@ -167,25 +159,6 @@ Session memory (/memories/session/) is empty. No session notes have been created
 <repoMemory>
 Repository memory (/memories/repo/) is empty. No workspace-scoped notes have been created yet.
 </repoMemory>
-<availableDeferredTools>
-Available deferred tools (must be loaded with tool_search before use):
-copilot_getNotebookSummary
-create_directory
-create_new_jupyter_notebook
-create_new_workspace
-edit_notebook_file
-get_vscode_api
-github_repo
-github_text_search
-install_extension
-read_notebook_cell_output
-read_project_structure
-resolve_memory_file_uri
-run_notebook_cell
-run_vscode_command
-search_workspace_symbols
-test_search
-</availableDeferredTools>
 
 ~~~
 

--- a/extensions/copilot/src/extension/prompts/node/agent/test/agentPrompt.spec.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/agentPrompt.spec.tsx
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { PromptElement } from '@vscode/prompt-tsx';
 import { afterAll, beforeAll, beforeEach, expect, suite, test } from 'vitest';
 import { IChatMLFetcher } from '../../../../../platform/chat/common/chatMLFetcher';
 import { ChatLocation } from '../../../../../platform/chat/common/commonTypes';
@@ -11,6 +12,7 @@ import { CodeGenerationTextInstruction, ConfigKey, IConfigurationService } from 
 import { MockEndpoint } from '../../../../../platform/endpoint/test/node/mockEndpoint';
 import { messageToMarkdown } from '../../../../../platform/log/common/messageStringify';
 import { IResponseDelta } from '../../../../../platform/networking/common/fetch';
+import { CUSTOM_TOOL_SEARCH_NAME } from '../../../../../platform/networking/common/anthropic';
 import { ITestingServicesAccessor } from '../../../../../platform/test/node/services';
 import { TestWorkspaceService } from '../../../../../platform/test/node/testWorkspaceService';
 import { IWorkspaceService } from '../../../../../platform/workspace/common/workspaceService';
@@ -28,7 +30,10 @@ import { createExtensionUnitTestingServices } from '../../../../test/node/servic
 import { ToolName } from '../../../../tools/common/toolNames';
 import { IToolsService } from '../../../../tools/common/toolsService';
 import { PromptRenderer } from '../../base/promptRenderer';
+import { InstructionMessage } from '../../base/instructionMessage';
 import { AgentPrompt, AgentPromptProps } from '../agentPrompt';
+import { ReminderInstructionsProps } from '../defaultAgentInstructions';
+import { HiddenModelMReminderInstructions } from '../openai/hiddenModelMPrompt';
 import { PromptRegistry } from '../promptRegistry';
 
 const testFamilies = [
@@ -48,6 +53,14 @@ const testFamilies = [
 	'gemini-2.0-flash',
 	'grok-code-fast-1'
 ];
+
+class HiddenModelMReminderMessage extends PromptElement<ReminderInstructionsProps> {
+	override render() {
+		return <InstructionMessage>
+			<HiddenModelMReminderInstructions {...this.props} />
+		</InstructionMessage>;
+	}
+}
 
 testFamilies.forEach(family => {
 	suite(`AgentPrompt - ${family}`, () => {
@@ -318,5 +331,163 @@ testFamilies.forEach(family => {
 				],
 			}, undefined))).toMatchFileSnapshot(getSnapshotFile('edited_file_events_grouped_by_kind'));
 		});
+	});
+});
+
+suite('OpenAI reminder instructions', () => {
+	let accessor: ITestingServicesAccessor;
+	const fileTsUri = URI.file('/workspace/file.ts');
+	let conversation: Conversation;
+
+	beforeAll(() => {
+		const testDoc = createTextDocumentData(fileTsUri, 'line 1\nline 2\n\nline 4\nline 5', 'ts').document;
+
+		const services = createExtensionUnitTestingServices();
+		services.define(IWorkspaceService, new SyncDescriptor(
+			TestWorkspaceService,
+			[
+				[URI.file('/workspace')],
+				[testDoc]
+			]
+		));
+		accessor = services.createTestingAccessor();
+	});
+
+	beforeEach(() => {
+		const turn = new Turn('turnId', { type: 'user', message: 'hello' });
+		conversation = new Conversation('sessionId', [turn]);
+	});
+
+	afterAll(() => {
+		accessor.dispose();
+	});
+
+	function createAvailableTool(name: string) {
+		return {
+			name,
+			description: `${name} tool`,
+			source: undefined,
+			inputSchema: { type: 'object', properties: {} },
+			tags: [],
+		};
+	}
+
+	async function renderAgentPromptForTools(family: string, availableTools: ReturnType<typeof createAvailableTool>[]): Promise<string> {
+		const instantiationService = accessor.get(IInstantiationService);
+		const endpoint = instantiationService.createInstance(MockEndpoint, family);
+		const customizations = await PromptRegistry.resolveAllCustomizations(instantiationService, endpoint);
+		const renderer = PromptRenderer.create(instantiationService, endpoint, AgentPrompt, {
+			priority: 1,
+			endpoint,
+			location: ChatLocation.Panel,
+			promptContext: {
+				chatVariables: new ChatVariablesCollection(),
+				history: [],
+				query: 'hello',
+				conversation,
+				tools: {
+					availableTools,
+					toolInvocationToken: null as never,
+					toolReferences: [],
+				}
+			},
+			customizations,
+		});
+
+		const result = await renderer.render();
+		return result.messages
+			.map(message => messageToMarkdown(message))
+			.join('\n\n')
+			.replace(/\\+/g, '/');
+	}
+
+	async function renderHiddenModelMReminderForTools(availableTools: ReturnType<typeof createAvailableTool>[], supportsToolSearch = true): Promise<string> {
+		const instantiationService = accessor.get(IInstantiationService);
+		const endpoint = instantiationService.createInstance(MockEndpoint, 'gpt-5.5');
+		endpoint.supportsToolSearch = supportsToolSearch;
+		const renderer = PromptRenderer.create(instantiationService, endpoint, HiddenModelMReminderMessage, {
+			priority: 1,
+			endpoint,
+			availableTools,
+			hasTodoTool: false,
+			hasEditFileTool: false,
+			hasReplaceStringTool: false,
+			hasMultiReplaceStringTool: false,
+		});
+
+		const result = await renderer.render();
+		return result.messages
+			.map(message => messageToMarkdown(message))
+			.join('\n\n')
+			.replace(/\\+/g, '/');
+	}
+
+	test.each([
+		'gpt-5.4',
+		'gpt-5.5',
+	])('omits tool_search reminder when %s has zero deferred tools', async family => {
+		const text = await renderAgentPromptForTools(family, [
+			createAvailableTool(ToolName.ReadFile),
+			createAvailableTool(ToolName.FindTextInFiles),
+			createAvailableTool(CUSTOM_TOOL_SEARCH_NAME),
+		]);
+
+		expect(text).not.toContain('IMPORTANT: Before calling any deferred tool that was not previously returned by tool_search');
+	});
+
+	test.each([
+		'gpt-5.4',
+		'gpt-5.5',
+	])('keeps tool_search reminder when %s still has deferred tools', async family => {
+		const text = await renderAgentPromptForTools(family, [
+			createAvailableTool(ToolName.ReadFile),
+			createAvailableTool(CUSTOM_TOOL_SEARCH_NAME),
+			createAvailableTool('create_directory'),
+		]);
+
+		expect(text).toContain('IMPORTANT: Before calling any deferred tool that was not previously returned by tool_search');
+	});
+
+	test.each([
+		'gpt-5.4',
+		'gpt-5.5',
+	])('omits tool_search prompt guidance when %s has deferred tools but tool_search is unavailable', async family => {
+		const text = await renderAgentPromptForTools(family, [
+			createAvailableTool(ToolName.ReadFile),
+			createAvailableTool('create_directory'),
+		]);
+
+		expect(text).not.toContain('IMPORTANT: Before calling any deferred tool that was not previously returned by tool_search');
+		expect(text).not.toContain('You MUST use tool_search to load deferred tools BEFORE calling them.');
+		expect(text).not.toContain('Available deferred tools (must be loaded with tool_search before use):');
+	});
+
+	test('hidden-model-m reminder omits tool_search reminder when zero deferred tools', async () => {
+		const text = await renderHiddenModelMReminderForTools([
+			createAvailableTool(ToolName.ReadFile),
+			createAvailableTool(ToolName.FindTextInFiles),
+			createAvailableTool(CUSTOM_TOOL_SEARCH_NAME),
+		]);
+
+		expect(text).not.toContain('IMPORTANT: Before calling any deferred tool that was not previously returned by tool_search');
+	});
+
+	test('hidden-model-m reminder keeps tool_search reminder when deferred tools remain', async () => {
+		const text = await renderHiddenModelMReminderForTools([
+			createAvailableTool(ToolName.ReadFile),
+			createAvailableTool(CUSTOM_TOOL_SEARCH_NAME),
+			createAvailableTool('create_directory'),
+		]);
+
+		expect(text).toContain('IMPORTANT: Before calling any deferred tool that was not previously returned by tool_search');
+	});
+
+	test('hidden-model-m reminder omits tool_search reminder when tool_search is unavailable', async () => {
+		const text = await renderHiddenModelMReminderForTools([
+			createAvailableTool(ToolName.ReadFile),
+			createAvailableTool('create_directory'),
+		], false);
+
+		expect(text).not.toContain('IMPORTANT: Before calling any deferred tool that was not previously returned by tool_search');
 	});
 });

--- a/extensions/copilot/src/extension/prompts/node/agent/toolSearchInstructions.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/toolSearchInstructions.tsx
@@ -18,6 +18,13 @@ export interface DeferredToolListReminderProps extends BasePromptElementProps {
 	readonly availableTools: readonly LanguageModelToolInformation[] | undefined;
 }
 
+export function hasAvailableTool(
+	availableTools: readonly LanguageModelToolInformation[] | undefined,
+	toolName: string,
+): boolean {
+	return !!availableTools?.some(tool => tool.name === toolName);
+}
+
 /**
  * True when `availableTools` contains at least one tool that the deferral
  * service treats as deferred. Shared between the system-prompt guidance and
@@ -28,6 +35,16 @@ export function hasDeferredTool(
 	toolDeferralService: IToolDeferralService,
 ): boolean {
 	return !!availableTools?.some(tool => !toolDeferralService.isNonDeferredTool(tool.name));
+}
+
+export function shouldShowToolSearchPrompt(
+	availableTools: readonly LanguageModelToolInformation[] | undefined,
+	endpointSupportsToolSearch: boolean | undefined,
+	toolDeferralService: IToolDeferralService,
+): boolean {
+	return !!endpointSupportsToolSearch
+		&& hasAvailableTool(availableTools, CUSTOM_TOOL_SEARCH_NAME)
+		&& hasDeferredTool(availableTools, toolDeferralService);
 }
 
 /**
@@ -46,7 +63,7 @@ export class ToolSearchToolPromptOptimized extends PromptElement<ToolSearchToolP
 
 	async render(state: void, sizing: PromptSizing) {
 		const endpoint = sizing.endpoint as IChatEndpoint | undefined;
-		if (!endpoint?.supportsToolSearch || !hasDeferredTool(this.props.availableTools, this.toolDeferralService)) {
+		if (!shouldShowToolSearchPrompt(this.props.availableTools, endpoint?.supportsToolSearch, this.toolDeferralService)) {
 			return;
 		}
 
@@ -83,7 +100,7 @@ export class DeferredToolListReminder extends PromptElement<DeferredToolListRemi
 
 	async render(state: void, sizing: PromptSizing) {
 		const endpoint = sizing.endpoint as IChatEndpoint | undefined;
-		if (!endpoint?.supportsToolSearch || !this.props.availableTools) {
+		if (!shouldShowToolSearchPrompt(this.props.availableTools, endpoint?.supportsToolSearch, this.toolDeferralService)) {
 			return;
 		}
 

--- a/extensions/copilot/src/extension/prompts/node/agent/toolSearchInstructions.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/toolSearchInstructions.tsx
@@ -100,11 +100,12 @@ export class DeferredToolListReminder extends PromptElement<DeferredToolListRemi
 
 	async render(state: void, sizing: PromptSizing) {
 		const endpoint = sizing.endpoint as IChatEndpoint | undefined;
-		if (!shouldShowToolSearchPrompt(this.props.availableTools, endpoint?.supportsToolSearch, this.toolDeferralService)) {
+		const availableTools = this.props.availableTools ?? [];
+		if (!shouldShowToolSearchPrompt(availableTools, endpoint?.supportsToolSearch, this.toolDeferralService)) {
 			return;
 		}
 
-		const deferredTools = this.props.availableTools
+		const deferredTools = availableTools
 			.filter(tool => !this.toolDeferralService.isNonDeferredTool(tool.name))
 			.map(tool => tool.name)
 			.sort();

--- a/extensions/copilot/src/extension/tools/common/requestToolManifest.ts
+++ b/extensions/copilot/src/extension/tools/common/requestToolManifest.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IToolDeferralService } from '../../../platform/networking/common/toolDeferralService';
+
+export interface IRequestToolManifest<TTool extends { name: string }> {
+	readonly activeTools: readonly TTool[];
+	readonly activeToolNames: readonly string[];
+	readonly nonDeferredTools: readonly TTool[];
+	readonly nonDeferredToolNames: readonly string[];
+	readonly deferredTools: readonly TTool[];
+	readonly deferredToolNames: readonly string[];
+	readonly hasDeferredTools: boolean;
+}
+
+export function createRequestToolManifest<TTool extends { name: string }>(activeTools: readonly TTool[], toolDeferralService: IToolDeferralService): IRequestToolManifest<TTool> {
+	const activeToolNames: string[] = [];
+	const nonDeferredTools: TTool[] = [];
+	const nonDeferredToolNames: string[] = [];
+	const deferredTools: TTool[] = [];
+	const deferredToolNames: string[] = [];
+
+	for (const tool of activeTools) {
+		activeToolNames.push(tool.name);
+		if (toolDeferralService.isNonDeferredTool(tool.name)) {
+			nonDeferredTools.push(tool);
+			nonDeferredToolNames.push(tool.name);
+		} else {
+			deferredTools.push(tool);
+			deferredToolNames.push(tool.name);
+		}
+	}
+
+	return {
+		activeTools,
+		activeToolNames,
+		nonDeferredTools,
+		nonDeferredToolNames,
+		deferredTools,
+		deferredToolNames,
+		hasDeferredTools: deferredTools.length > 0,
+	};
+}

--- a/extensions/copilot/src/extension/tools/common/requestToolManifest.ts
+++ b/extensions/copilot/src/extension/tools/common/requestToolManifest.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { CUSTOM_TOOL_SEARCH_NAME } from '../../../platform/networking/common/anthropic';
 import { IToolDeferralService } from '../../../platform/networking/common/toolDeferralService';
 
 export interface IRequestToolManifest<TTool extends { name: string }> {
@@ -15,6 +16,10 @@ export interface IRequestToolManifest<TTool extends { name: string }> {
 	readonly hasDeferredTools: boolean;
 }
 
+function isDeferredRequestTool(toolName: string, toolDeferralService: IToolDeferralService): boolean {
+	return toolName !== CUSTOM_TOOL_SEARCH_NAME && !toolDeferralService.isNonDeferredTool(toolName);
+}
+
 export function createRequestToolManifest<TTool extends { name: string }>(activeTools: readonly TTool[], toolDeferralService: IToolDeferralService): IRequestToolManifest<TTool> {
 	const activeToolNames: string[] = [];
 	const nonDeferredTools: TTool[] = [];
@@ -24,12 +29,12 @@ export function createRequestToolManifest<TTool extends { name: string }>(active
 
 	for (const tool of activeTools) {
 		activeToolNames.push(tool.name);
-		if (toolDeferralService.isNonDeferredTool(tool.name)) {
-			nonDeferredTools.push(tool);
-			nonDeferredToolNames.push(tool.name);
-		} else {
+		if (isDeferredRequestTool(tool.name, toolDeferralService)) {
 			deferredTools.push(tool);
 			deferredToolNames.push(tool.name);
+		} else {
+			nonDeferredTools.push(tool);
+			nonDeferredToolNames.push(tool.name);
 		}
 	}
 
@@ -42,4 +47,13 @@ export function createRequestToolManifest<TTool extends { name: string }>(active
 		deferredToolNames,
 		hasDeferredTools: deferredTools.length > 0,
 	};
+}
+
+export function pruneToolSearchWhenNoDeferredTools<TTool extends { name: string }>(activeTools: readonly TTool[], toolDeferralService: IToolDeferralService): TTool[] {
+	const requestToolManifest = createRequestToolManifest(activeTools, toolDeferralService);
+	if (requestToolManifest.hasDeferredTools) {
+		return [...activeTools];
+	}
+
+	return activeTools.filter(tool => tool.name !== CUSTOM_TOOL_SEARCH_NAME);
 }

--- a/extensions/copilot/src/extension/tools/common/virtualTools/builtInToolGroupHandler.ts
+++ b/extensions/copilot/src/extension/tools/common/virtualTools/builtInToolGroupHandler.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { LanguageModelToolInformation } from 'vscode';
+import { IToolDeferralService } from '../../../../platform/networking/common/toolDeferralService';
 import { assertNever } from '../../../../util/vs/base/common/assert';
 import { groupBy } from '../../../../util/vs/base/common/collections';
 import { getToolsForCategory, toolCategories, ToolCategory, ToolName } from '../toolNames';
@@ -40,7 +41,9 @@ function getCategorySummary(category: ToolCategory): string {
 }
 
 export class BuiltInToolGroupHandler {
-	constructor() { }
+	constructor(
+		@IToolDeferralService private readonly _toolDeferralService: IToolDeferralService,
+	) { }
 
 	/** Creates groups for built-in tools based on the type-safe categorization system */
 	createBuiltInToolGroups(tools: LanguageModelToolInformation[]): (VirtualTool | LanguageModelToolInformation)[] {
@@ -52,9 +55,15 @@ export class BuiltInToolGroupHandler {
 		const contributedTools = tools.filter(t => !toolCategories.hasOwnProperty(t.name));
 		const builtInTools = tools.filter(t => toolCategories.hasOwnProperty(t.name));
 
-		// Filter out Core tools from grouping (they should remain individual)
-		const toolsToGroup = builtInTools.filter(t => toolCategories[t.name as ToolName] !== ToolCategory.Core);
-		const coreTools = builtInTools.filter(t => toolCategories[t.name as ToolName] === ToolCategory.Core);
+		// Filter out Core tools and non-deferred tools from grouping (they should remain individual)
+		const toolsToGroup = builtInTools.filter(t => {
+			const category = toolCategories[t.name as ToolName];
+			return category !== ToolCategory.Core && !this._toolDeferralService.isNonDeferredTool(t.name);
+		});
+		const directBuiltInTools = builtInTools.filter(t => {
+			const category = toolCategories[t.name as ToolName];
+			return category === ToolCategory.Core || this._toolDeferralService.isNonDeferredTool(t.name);
+		});
 
 		const categories = groupBy(toolsToGroup, t => toolCategories[t.name as ToolName]);
 		const virtualTools = Object.entries(categories).flatMap<VirtualTool | LanguageModelToolInformation>(([category, tools]) => {
@@ -75,8 +84,8 @@ export class BuiltInToolGroupHandler {
 			);
 		});
 
-		// Return: virtual tool groups + individual core tools + contributed tools
-		return [...virtualTools, ...coreTools, ...contributedTools];
+		// Return: virtual tool groups + direct built-in tools + contributed tools
+		return [...virtualTools, ...directBuiltInTools, ...contributedTools];
 	}
 
 	static get BUILT_IN_GROUP_KEY(): string {

--- a/extensions/copilot/src/extension/tools/common/virtualTools/virtualToolGrouper.ts
+++ b/extensions/copilot/src/extension/tools/common/virtualTools/virtualToolGrouper.ts
@@ -43,7 +43,7 @@ export class VirtualToolGrouper implements IToolCategorization {
 		@IToolEmbeddingsComputer private readonly _toolEmbeddingsComputer: IToolEmbeddingsComputer,
 		@IInstantiationService _instantiationService: IInstantiationService,
 	) {
-		this.builtInToolGroupHandler = new BuiltInToolGroupHandler();
+		this.builtInToolGroupHandler = _instantiationService.createInstance(BuiltInToolGroupHandler);
 	}
 
 	/**

--- a/extensions/copilot/src/extension/tools/node/test/testToolsService.ts
+++ b/extensions/copilot/src/extension/tools/node/test/testToolsService.ts
@@ -17,7 +17,7 @@ import { isDisposable } from '../../../../util/vs/base/common/lifecycle';
 import { autorunIterableDelta } from '../../../../util/vs/base/common/observable';
 import { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
 import { LanguageModelToolInformation, LanguageModelToolResult2 } from '../../../../vscodeTypes';
-import { createRequestToolManifest } from '../../common/requestToolManifest';
+import { pruneToolSearchWhenNoDeferredTools } from '../../common/requestToolManifest';
 import { getContributedToolName, getToolName, mapContributedToolNamesInSchema, mapContributedToolNamesInString, ToolName } from '../../common/toolNames';
 import { ICopilotTool, ICopilotToolCtor, ToolRegistry } from '../../common/toolsRegistry';
 import { BaseToolsService, IToolsService } from '../../common/toolsService';
@@ -220,12 +220,7 @@ export class TestToolsService extends BaseToolsService implements IToolsService 
 				return packageJsonTools.has(tool.name);
 			});
 
-		const requestToolManifest = createRequestToolManifest(enabledTools, this._toolDeferralService);
-		if (requestToolManifest.hasDeferredTools) {
-			return enabledTools;
-		}
-
-		return enabledTools.filter(tool => tool.name !== ToolName.ToolSearch);
+		return pruneToolSearchWhenNoDeferredTools(enabledTools, this._toolDeferralService);
 
 	}
 

--- a/extensions/copilot/src/extension/tools/node/test/testToolsService.ts
+++ b/extensions/copilot/src/extension/tools/node/test/testToolsService.ts
@@ -8,6 +8,7 @@ import { packageJson } from '../../../../platform/env/common/packagejson';
 import { ILanguageDiagnosticsService } from '../../../../platform/languages/common/languageDiagnosticsService';
 import { ILogService } from '../../../../platform/log/common/logService';
 import { IChatEndpoint } from '../../../../platform/networking/common/networking';
+import { IToolDeferralService } from '../../../../platform/networking/common/toolDeferralService';
 import { CancellationToken } from '../../../../util/vs/base/common/cancellation';
 import { CancellationError } from '../../../../util/vs/base/common/errors';
 import { Iterable } from '../../../../util/vs/base/common/iterator';
@@ -16,6 +17,7 @@ import { isDisposable } from '../../../../util/vs/base/common/lifecycle';
 import { autorunIterableDelta } from '../../../../util/vs/base/common/observable';
 import { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
 import { LanguageModelToolInformation, LanguageModelToolResult2 } from '../../../../vscodeTypes';
+import { createRequestToolManifest } from '../../common/requestToolManifest';
 import { getContributedToolName, getToolName, mapContributedToolNamesInSchema, mapContributedToolNamesInString, ToolName } from '../../common/toolNames';
 import { ICopilotTool, ICopilotToolCtor, ToolRegistry } from '../../common/toolsRegistry';
 import { BaseToolsService, IToolsService } from '../../common/toolsService';
@@ -50,6 +52,7 @@ export class TestToolsService extends BaseToolsService implements IToolsService 
 		disabledTools: Set<string>,
 		@IInstantiationService protected readonly instantiationService: IInstantiationService,
 		@ILogService logService: ILogService,
+		@IToolDeferralService private readonly _toolDeferralService: IToolDeferralService,
 	) {
 		super(logService);
 
@@ -181,7 +184,7 @@ export class TestToolsService extends BaseToolsService implements IToolsService 
 		const requestToolsByName = new Map(Iterable.map(request.tools, ([t, enabled]) => [t.name, enabled]));
 
 		const packageJsonTools = getPackagejsonToolsForTest();
-		return this.tools
+		const enabledTools = this.tools
 			.map(tool => {
 				// Apply model-specific alternative if available via alternativeDefinition
 				const owned = this._copilotTools.get(getToolName(tool.name) as ToolName);
@@ -217,6 +220,13 @@ export class TestToolsService extends BaseToolsService implements IToolsService 
 				return packageJsonTools.has(tool.name);
 			});
 
+		const requestToolManifest = createRequestToolManifest(enabledTools, this._toolDeferralService);
+		if (requestToolManifest.hasDeferredTools) {
+			return enabledTools;
+		}
+
+		return enabledTools.filter(tool => tool.name !== ToolName.ToolSearch);
+
 	}
 
 	addTestToolOverride(info: LanguageModelToolInformation, tool: vscode.LanguageModelTool<unknown>): void {
@@ -229,8 +239,9 @@ export class NoopTestToolsService extends TestToolsService {
 	constructor(
 		@IInstantiationService instantiationService: IInstantiationService,
 		@ILogService logService: ILogService,
+		@IToolDeferralService toolDeferralService: IToolDeferralService,
 	) {
-		super(new Set(), instantiationService, logService);
+		super(new Set(), instantiationService, logService, toolDeferralService);
 	}
 
 	override invokeTool(name: string, options: vscode.LanguageModelToolInvocationOptions<unknown>, token: CancellationToken): Promise<LanguageModelToolResult2> {

--- a/extensions/copilot/src/extension/tools/node/test/toolSearchTool.spec.ts
+++ b/extensions/copilot/src/extension/tools/node/test/toolSearchTool.spec.ts
@@ -1,0 +1,139 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type * as vscode from 'vscode';
+import { expect, suite, test } from 'vitest';
+import { MockEndpoint } from '../../../../platform/endpoint/test/node/mockEndpoint';
+import { IToolDeferralService } from '../../../../platform/networking/common/toolDeferralService';
+import { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
+import { createExtensionUnitTestingServices } from '../../../test/node/services';
+import { TestChatRequest } from '../../../test/node/testHelpers';
+import { IToolsService } from '../../common/toolsService';
+import { ToolSearchTool } from '../toolSearchTool';
+import { TestToolsService } from './testToolsService';
+
+function makeToolInfo(name: string): vscode.LanguageModelToolInformation {
+	return {
+		name,
+		description: `${name} description`,
+		inputSchema: { type: 'object', properties: {} },
+		tags: [],
+		source: undefined,
+	} as vscode.LanguageModelToolInformation;
+}
+
+suite('ToolSearchTool', () => {
+	test('searches only deferred tools enabled for the active request', async () => {
+		const searchedToolNames: string[][] = [];
+		const tool = new ToolSearchTool(
+			{
+				searchToolsByQuery: async (_query: string, tools: readonly vscode.LanguageModelToolInformation[]) => {
+					searchedToolNames.push(tools.map(candidate => candidate.name));
+					return tools.map(candidate => candidate.name);
+				},
+			} as any,
+			{
+				tools: [
+					makeToolInfo('read_file'),
+					makeToolInfo('enabled_deferred_tool'),
+					makeToolInfo('disabled_deferred_tool'),
+				],
+			} as any,
+			{ trace() { } } as any,
+		);
+
+		await (tool as any).resolveInput?.(
+			{ query: 'deferred tool' },
+			{
+				tools: {
+					toolReferences: [],
+					toolInvocationToken: undefined as never,
+					availableTools: [
+						makeToolInfo('read_file'),
+						makeToolInfo('enabled_deferred_tool'),
+					],
+				},
+			},
+			0,
+		);
+
+		await tool.invoke(
+			{ input: { query: 'deferred tool' } } as vscode.LanguageModelToolInvocationOptions<{ query: string }>,
+			{ isCancellationRequested: false } as vscode.CancellationToken,
+		);
+
+		expect(searchedToolNames).toEqual([['enabled_deferred_tool']]);
+	});
+});
+
+suite('TestToolsService getEnabledTools', () => {
+	test('prunes tool_search when the request has zero deferred tools without removing unrelated tools', () => {
+		const services = createExtensionUnitTestingServices();
+		const nonDeferred = new Set(['tool_search', 'read_file']);
+		services.define(IToolDeferralService, {
+			_serviceBrand: undefined,
+			isNonDeferredTool: (name: string) => nonDeferred.has(name),
+		});
+		const accessor = services.createTestingAccessor();
+		try {
+			const instantiationService = accessor.get(IInstantiationService);
+			const endpoint = instantiationService.createInstance(MockEndpoint, undefined);
+			const toolsService = accessor.get(IToolsService) as TestToolsService;
+
+			toolsService.addTestToolOverride(makeToolInfo('tool_search'), {} as vscode.LanguageModelTool<unknown>);
+			toolsService.addTestToolOverride(makeToolInfo('read_file'), {} as vscode.LanguageModelTool<unknown>);
+
+			const request = new TestChatRequest('find tools');
+			request.tools = new Map([
+				[{ name: 'tool_search' } as vscode.LanguageModelToolInformation, true],
+				[{ name: 'read_file' } as vscode.LanguageModelToolInformation, true],
+			]);
+
+			const relevantNames = toolsService.getEnabledTools(request, endpoint)
+				.map(tool => tool.name)
+				.filter(name => name === 'tool_search' || name === 'read_file')
+				.sort();
+
+			expect(relevantNames).toEqual(['read_file']);
+		} finally {
+			accessor.dispose();
+		}
+	});
+
+	test('retains tool_search when the request includes deferred tools', () => {
+		const services = createExtensionUnitTestingServices();
+		const nonDeferred = new Set(['tool_search', 'read_file']);
+		services.define(IToolDeferralService, {
+			_serviceBrand: undefined,
+			isNonDeferredTool: (name: string) => nonDeferred.has(name),
+		});
+		const accessor = services.createTestingAccessor();
+		try {
+			const instantiationService = accessor.get(IInstantiationService);
+			const endpoint = instantiationService.createInstance(MockEndpoint, undefined);
+			const toolsService = accessor.get(IToolsService) as TestToolsService;
+
+			toolsService.addTestToolOverride(makeToolInfo('tool_search'), {} as vscode.LanguageModelTool<unknown>);
+			toolsService.addTestToolOverride(makeToolInfo('read_file'), {} as vscode.LanguageModelTool<unknown>);
+			toolsService.addTestToolOverride(makeToolInfo('enabled_deferred_tool'), {} as vscode.LanguageModelTool<unknown>);
+
+			const request = new TestChatRequest('find tools');
+			request.tools = new Map([
+				[{ name: 'tool_search' } as vscode.LanguageModelToolInformation, true],
+				[{ name: 'read_file' } as vscode.LanguageModelToolInformation, true],
+				[{ name: 'enabled_deferred_tool' } as vscode.LanguageModelToolInformation, true],
+			]);
+
+			const relevantNames = toolsService.getEnabledTools(request, endpoint)
+				.map(tool => tool.name)
+				.filter(name => name === 'tool_search' || name === 'read_file' || name === 'enabled_deferred_tool')
+				.sort();
+
+			expect(relevantNames).toEqual(['enabled_deferred_tool', 'read_file', 'tool_search']);
+		} finally {
+			accessor.dispose();
+		}
+	});
+});

--- a/extensions/copilot/src/extension/tools/node/test/toolSearchTool.spec.ts
+++ b/extensions/copilot/src/extension/tools/node/test/toolSearchTool.spec.ts
@@ -36,13 +36,6 @@ suite('ToolSearchTool', () => {
 				},
 			} as any,
 			{
-				tools: [
-					makeToolInfo('read_file'),
-					makeToolInfo('enabled_deferred_tool'),
-					makeToolInfo('disabled_deferred_tool'),
-				],
-			} as any,
-			{
 				isNonDeferredTool: (name: string) => nonDeferred.has(name),
 			} as any,
 			{ trace() { } } as any,
@@ -80,13 +73,6 @@ suite('ToolSearchTool', () => {
 					searchedToolNames.push(tools.map(candidate => candidate.name));
 					return tools.map(candidate => candidate.name);
 				},
-			} as any,
-			{
-				tools: [
-					makeToolInfo('read_file'),
-					makeToolInfo('request_a_tool'),
-					makeToolInfo('request_b_tool'),
-				],
 			} as any,
 			{
 				isNonDeferredTool: (name: string) => nonDeferred.has(name),
@@ -132,6 +118,45 @@ suite('ToolSearchTool', () => {
 		expect(searchedToolNames).toEqual([['request_a_tool']]);
 	});
 
+	test('retains request-scoped virtual activate groups during tool search candidate selection', async () => {
+		const searchedToolNames: string[][] = [];
+		const nonDeferred = new Set(['read_file']);
+		const tool = new ToolSearchTool(
+			{
+				searchToolsByQuery: async (_query: string, tools: readonly vscode.LanguageModelToolInformation[]) => {
+					searchedToolNames.push(tools.map(candidate => candidate.name));
+					return tools.map(candidate => candidate.name);
+				},
+			} as any,
+			{
+				isNonDeferredTool: (name: string) => nonDeferred.has(name),
+			} as any,
+			{ trace() { } } as any,
+		);
+
+		const resolvedInput = await (tool as any).resolveInput?.(
+			{ query: 'vscode interaction tools' },
+			{
+				tools: {
+					toolReferences: [],
+					toolInvocationToken: undefined as never,
+					availableTools: [
+						makeToolInfo('read_file'),
+						makeToolInfo('activate_vs_code_interaction'),
+					],
+				},
+			},
+			0,
+		);
+
+		await tool.invoke(
+			{ input: resolvedInput } as vscode.LanguageModelToolInvocationOptions<{ query: string }>,
+			{ isCancellationRequested: false } as vscode.CancellationToken,
+		);
+
+		expect(searchedToolNames).toEqual([['activate_vs_code_interaction']]);
+	});
+
 	test('fails explicitly when invoke runs without request-scoped resolveInput context', async () => {
 		const nonDeferred = new Set(['read_file']);
 		const tool = new ToolSearchTool(
@@ -139,11 +164,6 @@ suite('ToolSearchTool', () => {
 				searchToolsByQuery: async () => {
 					throw new Error('search should not run without resolveInput context');
 				},
-			} as any,
-			{
-				tools: [
-					makeToolInfo('enabled_deferred_tool'),
-				],
 			} as any,
 			{
 				isNonDeferredTool: (name: string) => nonDeferred.has(name),
@@ -155,6 +175,36 @@ suite('ToolSearchTool', () => {
 			{ input: { query: 'deferred tool' } } as vscode.LanguageModelToolInvocationOptions<{ query: string }>,
 			{ isCancellationRequested: false } as vscode.CancellationToken,
 		)).rejects.toThrow('ToolSearchTool: request-scoped deferred tools are unavailable. Ensure resolveInput is called before invoke.');
+	});
+
+	test('uses an empty deferred tool snapshot when promptContext.tools is missing', async () => {
+		const searchedToolNames: string[][] = [];
+		const tool = new ToolSearchTool(
+			{
+				searchToolsByQuery: async (_query: string, tools: readonly vscode.LanguageModelToolInformation[]) => {
+					searchedToolNames.push(tools.map(candidate => candidate.name));
+					return tools.map(candidate => candidate.name);
+				},
+			} as any,
+			{
+				isNonDeferredTool: () => false,
+			} as any,
+			{ trace() { } } as any,
+		);
+
+		const resolvedInput = await tool.resolveInput(
+			{ query: 'anything' },
+			{} as any,
+			0,
+		);
+
+		const result = await tool.invoke(
+			{ input: resolvedInput } as vscode.LanguageModelToolInvocationOptions<{ query: string }>,
+			{ isCancellationRequested: false } as vscode.CancellationToken,
+		);
+
+		expect(searchedToolNames).toEqual([[]]);
+		expect(result.content).toEqual([expect.objectContaining({ value: '[]' })]);
 	});
 });
 

--- a/extensions/copilot/src/extension/tools/node/test/toolSearchTool.spec.ts
+++ b/extensions/copilot/src/extension/tools/node/test/toolSearchTool.spec.ts
@@ -27,6 +27,7 @@ function makeToolInfo(name: string): vscode.LanguageModelToolInformation {
 suite('ToolSearchTool', () => {
 	test('searches only deferred tools enabled for the active request', async () => {
 		const searchedToolNames: string[][] = [];
+		const nonDeferred = new Set(['read_file']);
 		const tool = new ToolSearchTool(
 			{
 				searchToolsByQuery: async (_query: string, tools: readonly vscode.LanguageModelToolInformation[]) => {
@@ -41,10 +42,13 @@ suite('ToolSearchTool', () => {
 					makeToolInfo('disabled_deferred_tool'),
 				],
 			} as any,
+			{
+				isNonDeferredTool: (name: string) => nonDeferred.has(name),
+			} as any,
 			{ trace() { } } as any,
 		);
 
-		await (tool as any).resolveInput?.(
+		const resolvedInput = await (tool as any).resolveInput?.(
 			{ query: 'deferred tool' },
 			{
 				tools: {
@@ -60,11 +64,97 @@ suite('ToolSearchTool', () => {
 		);
 
 		await tool.invoke(
-			{ input: { query: 'deferred tool' } } as vscode.LanguageModelToolInvocationOptions<{ query: string }>,
+				{ input: resolvedInput } as vscode.LanguageModelToolInvocationOptions<{ query: string }>,
 			{ isCancellationRequested: false } as vscode.CancellationToken,
 		);
 
 		expect(searchedToolNames).toEqual([['enabled_deferred_tool']]);
+	});
+
+	test('keeps deferred tool snapshots isolated per resolved request input', async () => {
+		const searchedToolNames: string[][] = [];
+		const nonDeferred = new Set(['read_file']);
+		const tool = new ToolSearchTool(
+			{
+				searchToolsByQuery: async (_query: string, tools: readonly vscode.LanguageModelToolInformation[]) => {
+					searchedToolNames.push(tools.map(candidate => candidate.name));
+					return tools.map(candidate => candidate.name);
+				},
+			} as any,
+			{
+				tools: [
+					makeToolInfo('read_file'),
+					makeToolInfo('request_a_tool'),
+					makeToolInfo('request_b_tool'),
+				],
+			} as any,
+			{
+				isNonDeferredTool: (name: string) => nonDeferred.has(name),
+			} as any,
+			{ trace() { } } as any,
+		);
+
+		const requestAInput = await (tool as any).resolveInput?.(
+			{ query: 'request a' },
+			{
+				tools: {
+					toolReferences: [],
+					toolInvocationToken: undefined as never,
+					availableTools: [
+						makeToolInfo('read_file'),
+						makeToolInfo('request_a_tool'),
+					],
+				},
+			},
+			0,
+		);
+
+		await (tool as any).resolveInput?.(
+			{ query: 'request b' },
+			{
+				tools: {
+					toolReferences: [],
+					toolInvocationToken: undefined as never,
+					availableTools: [
+						makeToolInfo('read_file'),
+						makeToolInfo('request_b_tool'),
+					],
+				},
+			},
+			0,
+		);
+
+		await tool.invoke(
+			{ input: requestAInput } as vscode.LanguageModelToolInvocationOptions<{ query: string }>,
+			{ isCancellationRequested: false } as vscode.CancellationToken,
+		);
+
+		expect(searchedToolNames).toEqual([['request_a_tool']]);
+	});
+
+	test('fails explicitly when invoke runs without request-scoped resolveInput context', async () => {
+		const nonDeferred = new Set(['read_file']);
+		const tool = new ToolSearchTool(
+			{
+				searchToolsByQuery: async () => {
+					throw new Error('search should not run without resolveInput context');
+				},
+			} as any,
+			{
+				tools: [
+					makeToolInfo('enabled_deferred_tool'),
+				],
+			} as any,
+			{
+				isNonDeferredTool: (name: string) => nonDeferred.has(name),
+			} as any,
+			{ trace() { } } as any,
+		);
+
+		await expect(tool.invoke(
+			{ input: { query: 'deferred tool' } } as vscode.LanguageModelToolInvocationOptions<{ query: string }>,
+			{ isCancellationRequested: false } as vscode.CancellationToken,
+		)).rejects.toThrow('ToolSearchTool: request-scoped deferred tools are unavailable. Ensure resolveInput is called before invoke.');
 	});
 });
 

--- a/extensions/copilot/src/extension/tools/node/test/toolSearchTool.spec.ts
+++ b/extensions/copilot/src/extension/tools/node/test/toolSearchTool.spec.ts
@@ -208,6 +208,35 @@ suite('ToolSearchTool', () => {
 		expect((tool as any)._requestScopedDeferredToolsContexts.size).toBe(0);
 	});
 
+	test('evicts stale request-scoped deferred tool contexts opportunistically', async () => {
+		const nonDeferred = new Set(['read_file']);
+		const tool = new ToolSearchTool(
+			{
+				searchToolsByQuery: async (_query: string, tools: readonly vscode.LanguageModelToolInformation[]) => tools.map(candidate => candidate.name),
+			} as any,
+			{
+				isNonDeferredTool: (name: string) => nonDeferred.has(name),
+			} as any,
+			{ trace() { } } as any,
+		);
+
+		(tool as any)._requestScopedDeferredToolsContexts.set('stale-context', {
+			createdAt: Date.now() - (6 * 60 * 1000),
+			tools: Object.freeze([makeToolInfo('stale_tool')]),
+		});
+
+		await tool.resolveInput(
+			{ query: 'fresh tools' },
+			makePromptContext([
+				makeToolInfo('read_file'),
+				makeToolInfo('fresh_tool'),
+			]),
+			0,
+		);
+
+		expect((tool as any)._requestScopedDeferredToolsContexts.has('stale-context')).toBe(false);
+	});
+
 	test('preserves request-scoped deferred tools after resolved input is JSON-round-tripped', async () => {
 		const searchedToolNames: string[][] = [];
 		const nonDeferred = new Set(['read_file']);
@@ -292,12 +321,44 @@ suite('ToolSearchTool', () => {
 		expect(searchedToolNames).toEqual([[]]);
 		expect(result.content).toEqual([expect.objectContaining({ value: '[]' })]);
 	});
+
+	test('does not treat tool_search itself as a deferred candidate when building the request snapshot', async () => {
+		const searchedToolNames: string[][] = [];
+		const tool = new ToolSearchTool(
+			{
+				searchToolsByQuery: async (_query: string, tools: readonly vscode.LanguageModelToolInformation[]) => {
+					searchedToolNames.push(tools.map(candidate => candidate.name));
+					return tools.map(candidate => candidate.name);
+				},
+			} as any,
+			{
+				isNonDeferredTool: () => false,
+			} as any,
+			{ trace() { } } as any,
+		);
+
+		const resolvedInput = await tool.resolveInput(
+			{ query: 'real deferred tools' },
+			makePromptContext([
+				makeToolInfo('tool_search'),
+				makeToolInfo('create_directory'),
+			]),
+			0,
+		);
+
+		await tool.invoke(
+			{ input: resolvedInput } as vscode.LanguageModelToolInvocationOptions<{ query: string }>,
+			{ isCancellationRequested: false } as vscode.CancellationToken,
+		);
+
+		expect(searchedToolNames).toEqual([['create_directory']]);
+	});
 });
 
 suite('TestToolsService getEnabledTools', () => {
 	test('prunes tool_search when the request has zero deferred tools without removing unrelated tools', () => {
 		const services = createExtensionUnitTestingServices();
-		const nonDeferred = new Set(['tool_search', 'read_file']);
+		const nonDeferred = new Set(['read_file']);
 		services.define(IToolDeferralService, {
 			_serviceBrand: undefined,
 			isNonDeferredTool: (name: string) => nonDeferred.has(name),
@@ -317,7 +378,11 @@ suite('TestToolsService getEnabledTools', () => {
 				[{ name: 'read_file' } as vscode.LanguageModelToolInformation, true],
 			]);
 
-			const relevantNames = toolsService.getEnabledTools(request, endpoint)
+			const relevantNames = toolsService.getEnabledTools(
+				request,
+				endpoint,
+				tool => tool.name === 'tool_search' || tool.name === 'read_file',
+			)
 				.map(tool => tool.name)
 				.filter(name => name === 'tool_search' || name === 'read_file')
 				.sort();
@@ -352,7 +417,11 @@ suite('TestToolsService getEnabledTools', () => {
 				[{ name: 'enabled_deferred_tool' } as vscode.LanguageModelToolInformation, true],
 			]);
 
-			const relevantNames = toolsService.getEnabledTools(request, endpoint)
+			const relevantNames = toolsService.getEnabledTools(
+				request,
+				endpoint,
+				tool => tool.name === 'tool_search' || tool.name === 'read_file' || tool.name === 'enabled_deferred_tool',
+			)
 				.map(tool => tool.name)
 				.filter(name => name === 'tool_search' || name === 'read_file' || name === 'enabled_deferred_tool')
 				.sort();

--- a/extensions/copilot/src/extension/tools/node/test/toolSearchTool.spec.ts
+++ b/extensions/copilot/src/extension/tools/node/test/toolSearchTool.spec.ts
@@ -10,6 +10,8 @@ import { IToolDeferralService } from '../../../../platform/networking/common/too
 import { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
 import { createExtensionUnitTestingServices } from '../../../test/node/services';
 import { TestChatRequest } from '../../../test/node/testHelpers';
+import { ChatVariablesCollection } from '../../../prompt/common/chatVariablesCollection';
+import { IBuildPromptContext } from '../../../prompt/common/intents';
 import { IToolsService } from '../../common/toolsService';
 import { ToolSearchTool } from '../toolSearchTool';
 import { TestToolsService } from './testToolsService';
@@ -22,6 +24,19 @@ function makeToolInfo(name: string): vscode.LanguageModelToolInformation {
 		tags: [],
 		source: undefined,
 	} as vscode.LanguageModelToolInformation;
+}
+
+function makePromptContext(availableTools?: readonly vscode.LanguageModelToolInformation[]): IBuildPromptContext {
+	return {
+		query: 'test query',
+		history: [],
+		chatVariables: new ChatVariablesCollection([]),
+		tools: availableTools ? {
+			toolReferences: [],
+			toolInvocationToken: undefined as never,
+			availableTools,
+		} : undefined,
+	};
 }
 
 suite('ToolSearchTool', () => {
@@ -151,6 +166,77 @@ suite('ToolSearchTool', () => {
 
 		await tool.invoke(
 			{ input: resolvedInput } as vscode.LanguageModelToolInvocationOptions<{ query: string }>,
+			{ isCancellationRequested: false } as vscode.CancellationToken,
+		);
+
+		expect(searchedToolNames).toEqual([['activate_vs_code_interaction']]);
+	});
+
+	test('preserves request-scoped deferred tools after resolved input is shallow-cloned', async () => {
+		const searchedToolNames: string[][] = [];
+		const nonDeferred = new Set(['read_file']);
+		const tool = new ToolSearchTool(
+			{
+				searchToolsByQuery: async (_query: string, tools: readonly vscode.LanguageModelToolInformation[]) => {
+					searchedToolNames.push(tools.map(candidate => candidate.name));
+					return tools.map(candidate => candidate.name);
+				},
+			} as any,
+			{
+				isNonDeferredTool: (name: string) => nonDeferred.has(name),
+			} as any,
+			{ trace() { } } as any,
+		);
+
+		const resolvedInput = await tool.resolveInput(
+			{ query: 'vscode interaction tools' },
+			makePromptContext([
+				makeToolInfo('read_file'),
+				makeToolInfo('activate_vs_code_interaction'),
+			]),
+			0,
+		);
+
+		const clonedResolvedInput = { ...resolvedInput };
+
+		await tool.invoke(
+			{ input: clonedResolvedInput } as vscode.LanguageModelToolInvocationOptions<{ query: string }>,
+			{ isCancellationRequested: false } as vscode.CancellationToken,
+		);
+
+		expect(searchedToolNames).toEqual([['activate_vs_code_interaction']]);
+		expect((tool as any)._requestScopedDeferredToolsContexts.size).toBe(0);
+	});
+
+	test('preserves request-scoped deferred tools after resolved input is JSON-round-tripped', async () => {
+		const searchedToolNames: string[][] = [];
+		const nonDeferred = new Set(['read_file']);
+		const tool = new ToolSearchTool(
+			{
+				searchToolsByQuery: async (_query: string, tools: readonly vscode.LanguageModelToolInformation[]) => {
+					searchedToolNames.push(tools.map(candidate => candidate.name));
+					return tools.map(candidate => candidate.name);
+				},
+			} as any,
+			{
+				isNonDeferredTool: (name: string) => nonDeferred.has(name),
+			} as any,
+			{ trace() { } } as any,
+		);
+
+		const resolvedInput = await tool.resolveInput(
+			{ query: 'vscode interaction tools' },
+			makePromptContext([
+				makeToolInfo('read_file'),
+				makeToolInfo('activate_vs_code_interaction'),
+			]),
+			0,
+		);
+
+		const jsonRoundTrippedInput = JSON.parse(JSON.stringify(resolvedInput));
+
+		await tool.invoke(
+			{ input: jsonRoundTrippedInput } as vscode.LanguageModelToolInvocationOptions<{ query: string }>,
 			{ isCancellationRequested: false } as vscode.CancellationToken,
 		);
 

--- a/extensions/copilot/src/extension/tools/node/toolSearchTool.ts
+++ b/extensions/copilot/src/extension/tools/node/toolSearchTool.ts
@@ -20,13 +20,17 @@ export interface IToolSearchParams {
 }
 
 const DEFAULT_SEARCH_LIMIT = 5;
-const requestScopedDeferredToolsKey = Symbol('requestScopedDeferredTools');
+const requestScopedDeferredToolsContextIdKey = '__toolSearchRequestContextId';
+
+let nextRequestScopedDeferredToolsContextId = 0;
 
 type ResolvedToolSearchParams = IToolSearchParams & {
-	[requestScopedDeferredToolsKey]?: readonly vscode.LanguageModelToolInformation[];
+	[requestScopedDeferredToolsContextIdKey]?: string;
 };
 
 export class ToolSearchTool implements ICopilotModelSpecificTool<IToolSearchParams> {
+	private readonly _requestScopedDeferredToolsContexts = new Map<string, readonly vscode.LanguageModelToolInformation[]>();
+
 	constructor(
 		@IToolEmbeddingsComputer private readonly _toolEmbeddingsComputer: IToolEmbeddingsComputer,
 		@IToolDeferralService private readonly _toolDeferralService: IToolDeferralService,
@@ -42,7 +46,13 @@ export class ToolSearchTool implements ICopilotModelSpecificTool<IToolSearchPara
 			]);
 		}
 
-		const requestScopedDeferredTools = (options.input as ResolvedToolSearchParams)[requestScopedDeferredToolsKey];
+		const requestScopedDeferredToolsContextId = (options.input as ResolvedToolSearchParams)[requestScopedDeferredToolsContextIdKey];
+		const requestScopedDeferredTools = requestScopedDeferredToolsContextId
+			? this._requestScopedDeferredToolsContexts.get(requestScopedDeferredToolsContextId)
+			: undefined;
+		if (requestScopedDeferredToolsContextId && requestScopedDeferredTools) {
+			this._requestScopedDeferredToolsContexts.delete(requestScopedDeferredToolsContextId);
+		}
 
 		if (!requestScopedDeferredTools) {
 			throw new Error('ToolSearchTool: request-scoped deferred tools are unavailable. Ensure resolveInput is called before invoke.');
@@ -67,11 +77,12 @@ export class ToolSearchTool implements ICopilotModelSpecificTool<IToolSearchPara
 
 	async resolveInput(input: IToolSearchParams, promptContext: IBuildPromptContext, _mode: CopilotToolMode): Promise<IToolSearchParams> {
 		const manifest = createRequestToolManifest(promptContext.tools?.availableTools ?? [], this._toolDeferralService);
-		const resolvedInput: ResolvedToolSearchParams = { ...input };
-		Object.defineProperty(resolvedInput, requestScopedDeferredToolsKey, {
-			value: Object.freeze([...manifest.deferredTools]),
-			enumerable: false,
-		});
+		const requestScopedDeferredToolsContextId = `tool-search-${nextRequestScopedDeferredToolsContextId++}`;
+		this._requestScopedDeferredToolsContexts.set(requestScopedDeferredToolsContextId, Object.freeze([...manifest.deferredTools]));
+		const resolvedInput: ResolvedToolSearchParams = {
+			...input,
+			[requestScopedDeferredToolsContextIdKey]: requestScopedDeferredToolsContextId,
+		};
 		return resolvedInput;
 	}
 }

--- a/extensions/copilot/src/extension/tools/node/toolSearchTool.ts
+++ b/extensions/copilot/src/extension/tools/node/toolSearchTool.ts
@@ -12,7 +12,6 @@ import { LanguageModelTextPart, LanguageModelToolResult } from '../../../vscodeT
 import { IBuildPromptContext } from '../../prompt/common/intents';
 import { createRequestToolManifest } from '../common/requestToolManifest';
 import { CopilotToolMode, ICopilotModelSpecificTool, ToolRegistry } from '../common/toolsRegistry';
-import { IToolsService } from '../common/toolsService';
 import { IToolEmbeddingsComputer } from '../common/virtualTools/toolEmbeddingsComputer';
 
 export interface IToolSearchParams {
@@ -21,16 +20,15 @@ export interface IToolSearchParams {
 }
 
 const DEFAULT_SEARCH_LIMIT = 5;
-const requestScopedDeferredToolNamesKey = Symbol('requestScopedDeferredToolNames');
+const requestScopedDeferredToolsKey = Symbol('requestScopedDeferredTools');
 
 type ResolvedToolSearchParams = IToolSearchParams & {
-	[requestScopedDeferredToolNamesKey]?: readonly string[];
+	[requestScopedDeferredToolsKey]?: readonly vscode.LanguageModelToolInformation[];
 };
 
 export class ToolSearchTool implements ICopilotModelSpecificTool<IToolSearchParams> {
 	constructor(
 		@IToolEmbeddingsComputer private readonly _toolEmbeddingsComputer: IToolEmbeddingsComputer,
-		@IToolsService private readonly _toolsService: IToolsService,
 		@IToolDeferralService private readonly _toolDeferralService: IToolDeferralService,
 		@ILogService private readonly _logService: ILogService,
 	) { }
@@ -44,19 +42,15 @@ export class ToolSearchTool implements ICopilotModelSpecificTool<IToolSearchPara
 			]);
 		}
 
-		const requestScopedDeferredToolNames = (options.input as ResolvedToolSearchParams)[requestScopedDeferredToolNamesKey];
+		const requestScopedDeferredTools = (options.input as ResolvedToolSearchParams)[requestScopedDeferredToolsKey];
 
-		if (!requestScopedDeferredToolNames) {
+		if (!requestScopedDeferredTools) {
 			throw new Error('ToolSearchTool: request-scoped deferred tools are unavailable. Ensure resolveInput is called before invoke.');
 		}
 
-		const allowedToolNames = new Set(requestScopedDeferredToolNames);
-		const availableTools = createRequestToolManifest(this._toolsService.tools, this._toolDeferralService)
-			.deferredTools
-			.filter(tool => allowedToolNames.has(tool.name));
 		const matchedToolNames = await this._toolEmbeddingsComputer.searchToolsByQuery(
 			query,
-			availableTools,
+			requestScopedDeferredTools,
 			limit ?? DEFAULT_SEARCH_LIMIT,
 			token,
 		);
@@ -74,8 +68,8 @@ export class ToolSearchTool implements ICopilotModelSpecificTool<IToolSearchPara
 	async resolveInput(input: IToolSearchParams, promptContext: IBuildPromptContext, _mode: CopilotToolMode): Promise<IToolSearchParams> {
 		const manifest = createRequestToolManifest(promptContext.tools?.availableTools ?? [], this._toolDeferralService);
 		const resolvedInput: ResolvedToolSearchParams = { ...input };
-		Object.defineProperty(resolvedInput, requestScopedDeferredToolNamesKey, {
-			value: Object.freeze([...manifest.deferredToolNames]),
+		Object.defineProperty(resolvedInput, requestScopedDeferredToolsKey, {
+			value: Object.freeze([...manifest.deferredTools]),
 			enumerable: false,
 		});
 		return resolvedInput;

--- a/extensions/copilot/src/extension/tools/node/toolSearchTool.ts
+++ b/extensions/copilot/src/extension/tools/node/toolSearchTool.ts
@@ -7,8 +7,11 @@ import type * as vscode from 'vscode';
 import * as l10n from '@vscode/l10n';
 import { ILogService } from '../../../platform/log/common/logService';
 import { CUSTOM_TOOL_SEARCH_NAME } from '../../../platform/networking/common/anthropic';
+import { IToolDeferralService } from '../../../platform/networking/common/toolDeferralService';
 import { LanguageModelTextPart, LanguageModelToolResult } from '../../../vscodeTypes';
-import { ICopilotModelSpecificTool, ToolRegistry } from '../common/toolsRegistry';
+import { IBuildPromptContext } from '../../prompt/common/intents';
+import { createRequestToolManifest } from '../common/requestToolManifest';
+import { CopilotToolMode, ICopilotModelSpecificTool, ToolRegistry } from '../common/toolsRegistry';
 import { IToolsService } from '../common/toolsService';
 import { IToolEmbeddingsComputer } from '../common/virtualTools/toolEmbeddingsComputer';
 
@@ -18,11 +21,17 @@ export interface IToolSearchParams {
 }
 
 const DEFAULT_SEARCH_LIMIT = 5;
+const requestScopedDeferredToolNamesKey = Symbol('requestScopedDeferredToolNames');
+
+type ResolvedToolSearchParams = IToolSearchParams & {
+	[requestScopedDeferredToolNamesKey]?: readonly string[];
+};
 
 export class ToolSearchTool implements ICopilotModelSpecificTool<IToolSearchParams> {
 	constructor(
 		@IToolEmbeddingsComputer private readonly _toolEmbeddingsComputer: IToolEmbeddingsComputer,
 		@IToolsService private readonly _toolsService: IToolsService,
+		@IToolDeferralService private readonly _toolDeferralService: IToolDeferralService,
 		@ILogService private readonly _logService: ILogService,
 	) { }
 
@@ -35,7 +44,16 @@ export class ToolSearchTool implements ICopilotModelSpecificTool<IToolSearchPara
 			]);
 		}
 
-		const availableTools = this._toolsService.tools;
+		const requestScopedDeferredToolNames = (options.input as ResolvedToolSearchParams)[requestScopedDeferredToolNamesKey];
+
+		if (!requestScopedDeferredToolNames) {
+			throw new Error('ToolSearchTool: request-scoped deferred tools are unavailable. Ensure resolveInput is called before invoke.');
+		}
+
+		const allowedToolNames = new Set(requestScopedDeferredToolNames);
+		const availableTools = createRequestToolManifest(this._toolsService.tools, this._toolDeferralService)
+			.deferredTools
+			.filter(tool => allowedToolNames.has(tool.name));
 		const matchedToolNames = await this._toolEmbeddingsComputer.searchToolsByQuery(
 			query,
 			availableTools,
@@ -51,6 +69,16 @@ export class ToolSearchTool implements ICopilotModelSpecificTool<IToolSearchPara
 		return new LanguageModelToolResult([
 			new LanguageModelTextPart(JSON.stringify(matchedToolNames)),
 		]);
+	}
+
+	async resolveInput(input: IToolSearchParams, promptContext: IBuildPromptContext, _mode: CopilotToolMode): Promise<IToolSearchParams> {
+		const manifest = createRequestToolManifest(promptContext.tools?.availableTools ?? [], this._toolDeferralService);
+		const resolvedInput: ResolvedToolSearchParams = { ...input };
+		Object.defineProperty(resolvedInput, requestScopedDeferredToolNamesKey, {
+			value: Object.freeze([...manifest.deferredToolNames]),
+			enumerable: false,
+		});
+		return resolvedInput;
 	}
 }
 

--- a/extensions/copilot/src/extension/tools/node/toolSearchTool.ts
+++ b/extensions/copilot/src/extension/tools/node/toolSearchTool.ts
@@ -21,6 +21,8 @@ export interface IToolSearchParams {
 
 const DEFAULT_SEARCH_LIMIT = 5;
 const requestScopedDeferredToolsContextIdKey = '__toolSearchRequestContextId';
+const REQUEST_SCOPED_DEFERRED_TOOLS_CONTEXT_TTL_MS = 5 * 60 * 1000;
+const MAX_REQUEST_SCOPED_DEFERRED_TOOLS_CONTEXTS = 128;
 
 let nextRequestScopedDeferredToolsContextId = 0;
 
@@ -28,8 +30,13 @@ type ResolvedToolSearchParams = IToolSearchParams & {
 	[requestScopedDeferredToolsContextIdKey]?: string;
 };
 
+interface IRequestScopedDeferredToolsContextEntry {
+	readonly createdAt: number;
+	readonly tools: readonly vscode.LanguageModelToolInformation[];
+}
+
 export class ToolSearchTool implements ICopilotModelSpecificTool<IToolSearchParams> {
-	private readonly _requestScopedDeferredToolsContexts = new Map<string, readonly vscode.LanguageModelToolInformation[]>();
+	private readonly _requestScopedDeferredToolsContexts = new Map<string, IRequestScopedDeferredToolsContextEntry>();
 
 	constructor(
 		@IToolEmbeddingsComputer private readonly _toolEmbeddingsComputer: IToolEmbeddingsComputer,
@@ -46,13 +53,16 @@ export class ToolSearchTool implements ICopilotModelSpecificTool<IToolSearchPara
 			]);
 		}
 
+		this.cleanupRequestScopedDeferredToolsContexts();
+
 		const requestScopedDeferredToolsContextId = (options.input as ResolvedToolSearchParams)[requestScopedDeferredToolsContextIdKey];
-		const requestScopedDeferredTools = requestScopedDeferredToolsContextId
+		const requestScopedDeferredToolsContext = requestScopedDeferredToolsContextId
 			? this._requestScopedDeferredToolsContexts.get(requestScopedDeferredToolsContextId)
 			: undefined;
-		if (requestScopedDeferredToolsContextId && requestScopedDeferredTools) {
+		if (requestScopedDeferredToolsContextId && requestScopedDeferredToolsContext) {
 			this._requestScopedDeferredToolsContexts.delete(requestScopedDeferredToolsContextId);
 		}
+		const requestScopedDeferredTools = requestScopedDeferredToolsContext?.tools;
 
 		if (!requestScopedDeferredTools) {
 			throw new Error('ToolSearchTool: request-scoped deferred tools are unavailable. Ensure resolveInput is called before invoke.');
@@ -77,13 +87,36 @@ export class ToolSearchTool implements ICopilotModelSpecificTool<IToolSearchPara
 
 	async resolveInput(input: IToolSearchParams, promptContext: IBuildPromptContext, _mode: CopilotToolMode): Promise<IToolSearchParams> {
 		const manifest = createRequestToolManifest(promptContext.tools?.availableTools ?? [], this._toolDeferralService);
+		this.cleanupRequestScopedDeferredToolsContexts();
 		const requestScopedDeferredToolsContextId = `tool-search-${nextRequestScopedDeferredToolsContextId++}`;
-		this._requestScopedDeferredToolsContexts.set(requestScopedDeferredToolsContextId, Object.freeze([...manifest.deferredTools]));
+		this._requestScopedDeferredToolsContexts.set(requestScopedDeferredToolsContextId, {
+			createdAt: Date.now(),
+			tools: Object.freeze([...manifest.deferredTools]),
+		});
+		this.trimRequestScopedDeferredToolsContexts();
 		const resolvedInput: ResolvedToolSearchParams = {
 			...input,
 			[requestScopedDeferredToolsContextIdKey]: requestScopedDeferredToolsContextId,
 		};
 		return resolvedInput;
+	}
+
+	private cleanupRequestScopedDeferredToolsContexts(now = Date.now()): void {
+		for (const [contextId, context] of this._requestScopedDeferredToolsContexts) {
+			if (now - context.createdAt > REQUEST_SCOPED_DEFERRED_TOOLS_CONTEXT_TTL_MS) {
+				this._requestScopedDeferredToolsContexts.delete(contextId);
+			}
+		}
+	}
+
+	private trimRequestScopedDeferredToolsContexts(): void {
+		while (this._requestScopedDeferredToolsContexts.size > MAX_REQUEST_SCOPED_DEFERRED_TOOLS_CONTEXTS) {
+			const oldestContextId = this._requestScopedDeferredToolsContexts.keys().next().value;
+			if (!oldestContextId) {
+				return;
+			}
+			this._requestScopedDeferredToolsContexts.delete(oldestContextId);
+		}
 	}
 }
 

--- a/extensions/copilot/src/extension/tools/test/node/virtualTools/builtInToolGroupHandler.spec.ts
+++ b/extensions/copilot/src/extension/tools/test/node/virtualTools/builtInToolGroupHandler.spec.ts
@@ -1,0 +1,94 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it } from 'vitest';
+import type { LanguageModelToolInformation } from 'vscode';
+import { IToolDeferralService } from '../../../../../platform/networking/common/toolDeferralService';
+import { IInstantiationService } from '../../../../../util/vs/platform/instantiation/common/instantiation';
+import { createExtensionUnitTestingServices } from '../../../../test/node/services';
+import { ToolName } from '../../../common/toolNames';
+import { BuiltInToolGroupHandler } from '../../../common/virtualTools/builtInToolGroupHandler';
+import { VirtualTool } from '../../../common/virtualTools/virtualTool';
+
+function makeTool(name: string): LanguageModelToolInformation {
+	return {
+		name,
+		description: `Tool for ${name}`,
+		inputSchema: { type: 'object', properties: {} },
+		tags: [],
+		source: undefined,
+	};
+}
+
+describe('BuiltInToolGroupHandler', () => {
+	it('keeps non-deferred built-in tools direct when grouping deferred built-ins', () => {
+		const services = createExtensionUnitTestingServices();
+		services.define(IToolDeferralService, {
+			_serviceBrand: undefined,
+			isNonDeferredTool: (name: string) => name === ToolName.CoreAskQuestions || name === ToolName.CoreRunTest,
+		});
+		const accessor = services.createTestingAccessor();
+
+		try {
+			const handler = accessor.get(IInstantiationService).createInstance(BuiltInToolGroupHandler);
+			const results = handler.createBuiltInToolGroups([
+				makeTool(ToolName.CoreAskQuestions),
+				makeTool(ToolName.CoreRunTest),
+				makeTool(ToolName.CreateNewWorkspace),
+				makeTool(ToolName.InstallExtension),
+				makeTool(ToolName.FetchWebPage),
+				makeTool(ToolName.GithubTextSearch),
+			]);
+
+			const directToolNames = results
+				.filter((tool): tool is LanguageModelToolInformation => !(tool instanceof VirtualTool))
+				.map(tool => tool.name)
+				.sort();
+			const virtualTools = results.filter((tool): tool is VirtualTool => tool instanceof VirtualTool);
+
+			expect(directToolNames).toEqual([
+				ToolName.CoreAskQuestions,
+				ToolName.CoreRunTest,
+			].sort());
+			expect(virtualTools.map(tool => tool.name).sort()).toEqual([
+				'activate_vs_code_interaction',
+				'activate_web_interaction',
+			]);
+			expect(virtualTools.find(tool => tool.name === 'activate_vs_code_interaction')?.contents.map(tool => tool.name)).toEqual([
+				ToolName.CreateNewWorkspace,
+				ToolName.InstallExtension,
+			]);
+		} finally {
+			accessor.dispose();
+		}
+	});
+
+	it('does not create a virtual group when only one deferred tool remains after excluding non-deferred built-ins', () => {
+		const services = createExtensionUnitTestingServices();
+		services.define(IToolDeferralService, {
+			_serviceBrand: undefined,
+			isNonDeferredTool: (name: string) => name === ToolName.CoreAskQuestions,
+		});
+		const accessor = services.createTestingAccessor();
+
+		try {
+			const handler = accessor.get(IInstantiationService).createInstance(BuiltInToolGroupHandler);
+			const results = handler.createBuiltInToolGroups([
+				makeTool(ToolName.CoreAskQuestions),
+				makeTool(ToolName.CreateNewWorkspace),
+				makeTool(ToolName.ToolSearch),
+			]);
+
+			expect(results.every(tool => !(tool instanceof VirtualTool))).toBe(true);
+			expect(results.map(tool => tool.name).sort()).toEqual([
+				ToolName.CoreAskQuestions,
+				ToolName.CreateNewWorkspace,
+				ToolName.ToolSearch,
+			].sort());
+		} finally {
+			accessor.dispose();
+		}
+	});
+});

--- a/extensions/copilot/src/extension/tools/vscode-node/toolsService.ts
+++ b/extensions/copilot/src/extension/tools/vscode-node/toolsService.ts
@@ -8,6 +8,7 @@ import { ConfigKey, IConfigurationService } from '../../../platform/configuratio
 import { isGpt55 } from '../../../platform/endpoint/common/chatModelCapabilities';
 import { ILogService } from '../../../platform/log/common/logService';
 import { IChatEndpoint } from '../../../platform/networking/common/networking';
+import { IToolDeferralService } from '../../../platform/networking/common/toolDeferralService';
 import { CopilotChatAttr, emitToolCallEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, GenAiToolType, StdAttr, truncateForOTel } from '../../../platform/otel/common/index';
 import { IOTelService, SpanKind, SpanStatusCode } from '../../../platform/otel/common/otelService';
 import { getCurrentCapturingToken } from '../../../platform/requestLogger/node/requestLogger';
@@ -18,6 +19,7 @@ import { Lazy } from '../../../util/vs/base/common/lazy';
 import { isDisposable } from '../../../util/vs/base/common/lifecycle';
 import { autorunIterableDelta } from '../../../util/vs/base/common/observableInternal';
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
+import { createRequestToolManifest } from '../common/requestToolManifest';
 import { getContributedToolName, getToolName, mapContributedToolNamesInSchema, mapContributedToolNamesInString, ToolName } from '../common/toolNames';
 import { ICopilotTool, ICopilotToolExtension, modelSpecificToolApplies, ToolRegistry } from '../common/toolsRegistry';
 import { BaseToolsService } from '../common/toolsService';
@@ -91,6 +93,7 @@ export class ToolsService extends BaseToolsService {
 		@IOTelService private readonly _otelService: IOTelService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IExperimentationService private readonly _experimentationService: IExperimentationService,
+		@IToolDeferralService private readonly _toolDeferralService: IToolDeferralService,
 	) {
 		super(logService);
 		this._copilotTools = new Lazy(() => new Map(ToolRegistry.getTools().map(t => [t.toolName, _instantiationService.createInstance(t)] as const)));
@@ -275,7 +278,7 @@ export class ToolsService extends BaseToolsService {
 		const modelSpecificOverrides = new Map(this.getToolOverridesForEndpoint(endpoint, tools));
 		const modelSpecificTools = this.getModelSpecificTools();
 
-		return tools
+		const enabledTools = tools
 			.filter(tool => {
 				// 0. If the tool was a model specific tool with an override, it'll be mixed in in the 'map' later.
 				if (modelSpecificTools.get(tool.name)?.tool.overridesTool) {
@@ -354,6 +357,13 @@ export class ToolsService extends BaseToolsService {
 
 				return resultTool;
 			});
+
+		const requestToolManifest = createRequestToolManifest(enabledTools, this._toolDeferralService);
+		if (requestToolManifest.hasDeferredTools) {
+			return enabledTools;
+		}
+
+		return enabledTools.filter(tool => tool.name !== ToolName.ToolSearch);
 	}
 
 	private *getToolOverridesForEndpoint(endpoint: IChatEndpoint, tools = this.tools) {

--- a/extensions/copilot/src/extension/tools/vscode-node/toolsService.ts
+++ b/extensions/copilot/src/extension/tools/vscode-node/toolsService.ts
@@ -19,7 +19,7 @@ import { Lazy } from '../../../util/vs/base/common/lazy';
 import { isDisposable } from '../../../util/vs/base/common/lifecycle';
 import { autorunIterableDelta } from '../../../util/vs/base/common/observableInternal';
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
-import { createRequestToolManifest } from '../common/requestToolManifest';
+import { pruneToolSearchWhenNoDeferredTools } from '../common/requestToolManifest';
 import { getContributedToolName, getToolName, mapContributedToolNamesInSchema, mapContributedToolNamesInString, ToolName } from '../common/toolNames';
 import { ICopilotTool, ICopilotToolExtension, modelSpecificToolApplies, ToolRegistry } from '../common/toolsRegistry';
 import { BaseToolsService } from '../common/toolsService';
@@ -358,12 +358,7 @@ export class ToolsService extends BaseToolsService {
 				return resultTool;
 			});
 
-		const requestToolManifest = createRequestToolManifest(enabledTools, this._toolDeferralService);
-		if (requestToolManifest.hasDeferredTools) {
-			return enabledTools;
-		}
-
-		return enabledTools.filter(tool => tool.name !== ToolName.ToolSearch);
+		return pruneToolSearchWhenNoDeferredTools(enabledTools, this._toolDeferralService);
 	}
 
 	private *getToolOverridesForEndpoint(endpoint: IChatEndpoint, tools = this.tools) {

--- a/extensions/copilot/src/platform/endpoint/node/messagesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/messagesApi.ts
@@ -5,6 +5,7 @@
 
 import { ContentBlockParam, DocumentBlockParam, ImageBlockParam, MessageParam, RedactedThinkingBlockParam, TextBlockParam, ThinkingBlockParam, ToolReferenceBlockParam, ToolResultBlockParam } from '@anthropic-ai/sdk/resources';
 import { Raw } from '@vscode/prompt-tsx';
+import { createRequestToolManifest } from '../../../extension/tools/common/requestToolManifest';
 import { Response } from '../../../platform/networking/common/fetcherService';
 import { AsyncIterableObject } from '../../../util/vs/base/common/async';
 import { SSEParser } from '../../../util/vs/base/common/sseParser';
@@ -103,9 +104,17 @@ export function createMessagesRequestBody(accessor: ServicesAccessor, options: I
 	const configurationService = accessor.get(IConfigurationService);
 	const experimentationService = accessor.get(IExperimentationService);
 	const toolDeferralService = accessor.get(IToolDeferralService);
+	const requestToolManifest = createRequestToolManifest(
+		(options.requestOptions?.tools ?? [])
+			.filter(tool => !!tool.function.name)
+			.map(tool => ({ name: tool.function.name })),
+		toolDeferralService,
+	);
 
 	const toolSearchEnabled = !!endpoint.supportsToolSearch
-		&& !!options.requestOptions?.tools?.some(t => t.function.name === CUSTOM_TOOL_SEARCH_NAME);
+		&& !!options.modelCapabilities?.enableToolSearch
+		&& requestToolManifest.hasDeferredTools
+		&& requestToolManifest.activeToolNames.includes(CUSTOM_TOOL_SEARCH_NAME);
 
 	// Split tools into non-deferred and deferred up front so we can build finalTools
 	// with non-deferred first. This ensures the cache_control breakpoint on the last
@@ -115,6 +124,9 @@ export function createMessagesRequestBody(accessor: ServicesAccessor, options: I
 	if (options.requestOptions?.tools) {
 		for (const tool of options.requestOptions.tools) {
 			if (!tool.function.name || tool.function.name.length === 0) {
+				continue;
+			}
+			if (tool.function.name === CUSTOM_TOOL_SEARCH_NAME && !toolSearchEnabled) {
 				continue;
 			}
 			const isDeferred = options.modelCapabilities?.enableToolSearch && toolSearchEnabled && !toolDeferralService.isNonDeferredTool(tool.function.name);

--- a/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
@@ -14,6 +14,7 @@ import { SSEParser } from '../../../util/vs/base/common/sseParser';
 import { isDefined } from '../../../util/vs/base/common/types';
 import { generateUuid } from '../../../util/vs/base/common/uuid';
 import { IInstantiationService, ServicesAccessor } from '../../../util/vs/platform/instantiation/common/instantiation';
+import { createRequestToolManifest } from '../../../extension/tools/common/requestToolManifest';
 import { ChatLocation } from '../../chat/common/commonTypes';
 import { ConfigKey, IConfigurationService } from '../../configuration/common/configurationService';
 import { ILogService } from '../../log/common/logService';
@@ -48,6 +49,7 @@ export function getResponsesApiCompactionThreshold(configService: IConfiguration
 export function createResponsesRequestBody(accessor: ServicesAccessor, options: ICreateEndpointBodyOptions, model: string, endpoint: IChatEndpoint): IEndpointBody {
 	const configService = accessor.get(IConfigurationService);
 	const expService = accessor.get(IExperimentationService);
+	const toolDeferralService = accessor.get(IToolDeferralService);
 	const verbosity = getVerbosityForModelSync(endpoint);
 	const compactThreshold = getResponsesApiCompactionThreshold(configService, expService, endpoint);
 	// compaction supported for all the models but works well for codex models and any future models after 5.3
@@ -63,12 +65,18 @@ export function createResponsesRequestBody(accessor: ServicesAccessor, options: 
 	// (excluded from the request entirely). Uses OpenAI's client-executed tool search protocol: we add
 	// { type: 'tool_search', execution: 'client' }. The model emits tool_search_call, which we handle via
 	// our ToolSearchTool embeddings search, then round-trip as tool_search_output in the next request.
+	const requestToolManifest = createRequestToolManifest(
+		(options.requestOptions?.tools ?? [])
+			.filter(tool => !!tool.function.name)
+			.map(tool => ({ name: tool.function.name })),
+		toolDeferralService,
+	);
 	const toolSearchEnabled = !!endpoint.supportsToolSearch
-		&& !!options.requestOptions?.tools?.some(t => t.function.name === CUSTOM_TOOL_SEARCH_NAME);
+		&& requestToolManifest.hasDeferredTools
+		&& requestToolManifest.activeToolNames.includes(CUSTOM_TOOL_SEARCH_NAME);
 	const isAllowedConversationAgent = options.location === ChatLocation.Agent || options.location === ChatLocation.MessagesProxy;
 	const isSubagent = options.telemetryProperties?.subType?.startsWith('subagent') ?? false;
 	const shouldDeferTools = toolSearchEnabled && isAllowedConversationAgent && !isSubagent;
-	const toolDeferralService = shouldDeferTools ? accessor.get(IToolDeferralService) : undefined;
 
 	type ResponsesFunctionTool = OpenAI.Responses.FunctionTool & OpenAiResponsesFunctionTool;
 	const functionTools: ResponsesFunctionTool[] = [];
@@ -82,7 +90,7 @@ export function createResponsesRequestBody(accessor: ServicesAccessor, options: 
 			if (tool.function.name === CUSTOM_TOOL_SEARCH_NAME) {
 				continue;
 			}
-			const isDeferred = shouldDeferTools && !toolDeferralService!.isNonDeferredTool(tool.function.name);
+			const isDeferred = shouldDeferTools && !toolDeferralService.isNonDeferredTool(tool.function.name);
 			// Client-executed tool search: deferred tools are NOT sent in the request.
 			// They are returned via tool_search_output when the model searches for them.
 			if (isDeferred) {
@@ -122,7 +130,7 @@ export function createResponsesRequestBody(accessor: ServicesAccessor, options: 
 	const toolsMap = options.requestOptions?.tools
 		? new Map(options.requestOptions.tools.map(t => [t.function.name, t]))
 		: undefined;
-	const shouldLoadToolFromToolSearch = shouldDeferTools ? (name: string) => !toolDeferralService!.isNonDeferredTool(name) : undefined;
+	const shouldLoadToolFromToolSearch = shouldDeferTools ? (name: string) => !toolDeferralService.isNonDeferredTool(name) : undefined;
 
 	const body: IEndpointBody = {
 		model,

--- a/extensions/copilot/src/platform/endpoint/node/test/responsesApiToolSearch.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/responsesApiToolSearch.spec.ts
@@ -147,6 +147,29 @@ describe('createResponsesRequestBody tools', () => {
 		expect(tools.find(t => t.name === 'another_deferred_tool')).toBeUndefined();
 	});
 
+	it('omits client tool_search when the request has zero deferred tools', () => {
+		const endpoint = createMockEndpoint('gpt-5.4');
+
+		const options = createMockOptions({
+			requestOptions: {
+				tools: [
+					createFunctionTool('read_file', 'Read a file', { path: { type: 'string' } }, ['path']),
+					createFunctionTool('grep_search', 'Search for text', { query: { type: 'string' } }, ['query']),
+					createFunctionTool('tool_search', 'Search tools', { query: { type: 'string' } }, ['query']),
+				]
+			}
+		});
+
+		const body = accessor.get(IInstantiationService).invokeFunction(
+			createResponsesRequestBody, options, endpoint.model, endpoint
+		);
+
+		const tools = body.tools as any[];
+		expect(tools.find(t => t.type === 'tool_search')).toBeUndefined();
+		expect(tools.every(t => !t.defer_loading)).toBe(true);
+		expect(tools.map(t => t.name)).toEqual(['read_file', 'grep_search']);
+	});
+
 	it('does not defer tools for unsupported models', () => {
 		const endpoint = createMockEndpoint('gpt-4o');
 

--- a/extensions/copilot/src/platform/endpoint/test/node/messagesApi.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/test/node/messagesApi.spec.ts
@@ -1239,8 +1239,8 @@ describe('createMessagesRequestBody tool search deferral', () => {
 		const body = instantiationService.invokeFunction(createMessagesRequestBody, options, endpoint.model, endpoint);
 
 		const tools = body.tools as AnthropicMessagesTool[];
-		// RED contract for later phases: when no request tool is deferred, the
-		// request should omit the client-side tool_search scaffold entirely.
+		// Behavioral contract: when no request tool is deferred, the request
+		// should omit the client-side tool_search scaffold entirely.
 		expect(tools.map(tool => ({ name: tool.name, defer_loading: tool.defer_loading }))).toEqual([
 			{ name: 'read_file', defer_loading: undefined },
 			{ name: 'grep_search', defer_loading: undefined },

--- a/extensions/copilot/src/platform/endpoint/test/node/messagesApi.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/test/node/messagesApi.spec.ts
@@ -1228,6 +1228,26 @@ describe('createMessagesRequestBody tool search deferral', () => {
 		expect(tools.find(t => t.name === 'some_mcp_tool')?.defer_loading).toBe(true);
 	});
 
+	test('omits tool_search machinery when tool_search is present but every request tool is non-deferred', () => {
+		const endpoint = createMockEndpoint(true);
+		const options = createOptions([
+			makeTool('read_file'),
+			makeTool('grep_search'),
+			makeTool(CUSTOM_TOOL_SEARCH_NAME),
+		]);
+
+		const body = instantiationService.invokeFunction(createMessagesRequestBody, options, endpoint.model, endpoint);
+
+		const tools = body.tools as AnthropicMessagesTool[];
+		// RED contract for later phases: when no request tool is deferred, the
+		// request should omit the client-side tool_search scaffold entirely.
+		expect(tools.map(tool => ({ name: tool.name, defer_loading: tool.defer_loading }))).toEqual([
+			{ name: 'read_file', defer_loading: undefined },
+			{ name: 'grep_search', defer_loading: undefined },
+		]);
+		expect(tools.find(tool => tool.name === CUSTOM_TOOL_SEARCH_NAME)).toBeUndefined();
+	});
+
 	test('does not defer when endpoint does not support tool search', () => {
 		const endpoint = createMockEndpoint(false);
 		const options = createOptions([makeTool('read_file'), makeTool('some_mcp_tool'), makeTool(CUSTOM_TOOL_SEARCH_NAME)]);


### PR DESCRIPTION
## Summary
- centralize request-scoped tool classification with a shared request tool manifest
- scope tool search results to deferred tools available for the active request
- harden responses/messages serialization and prompt guidance for zero-deferred requests
- restore Anthropic request-scoped tool grouping, including virtual activate_* groups
- align ToolSearchTool with the request-scoped deferred snapshot, including virtual groups
- preserve tool_search request context across real invocation, shallow-clone, and plain-object/JSON round-trip boundaries with regression tests
- harden deferred tool handling by excluding tool_search from deferred manifests, sharing zero-deferred pruning, and opportunistically evicting stale request-scoped tool-search snapshots
- keep non-deferred built-in tools direct when default built-in grouping is enabled, so tools like vscode_askQuestions remain directly callable
- add regression coverage for request-scoped tool selection, endpoint behavior, prompt reminders, defaultIntentRequestHandler Anthropic grouping, clone-safe ToolSearchTool behavior, and built-in grouping behavior

## Testing
- npm run gulp compile-extensions
- npm --prefix extensions/copilot run test:unit -- src/extension/intents/node/test/backgroundTodoEnablement.spec.ts src/extension/tools/node/test/testToolsService.ts
- .\\node_modules\\.bin\\vitest.cmd run src/extension/prompt/node/test/defaultIntentRequestHandler.spec.ts --testNamePattern "keeps activate_vs_code_interaction in request-scoped tools for anthropic tool search requests"
- .\\node_modules\\.bin\\vitest.cmd run src/extension/tools/node/test/toolSearchTool.spec.ts --testNamePattern "searches only deferred tools enabled for the active request"
- .\\node_modules\\.bin\\vitest.cmd run src/extension/tools/node/test/toolSearchTool.spec.ts --testNamePattern "fails explicitly when invoke runs without request-scoped resolveInput context"
- .\\node_modules\\.bin\\vitest.cmd run src/extension/tools/node/test/toolSearchTool.spec.ts --testNamePattern "retains request-scoped virtual activate groups during tool search candidate selection|preserves request-scoped deferred tools after resolved input is shallow-cloned|preserves request-scoped deferred tools after resolved input is JSON-round-tripped"
- .\\node_modules\\.bin\\vitest.cmd run src/extension/tools/test/node/virtualTools/builtInToolGroupHandler.spec.ts --reporter=basic
- npx vitest run src/platform/endpoint/node/test/responsesApiToolSearch.spec.ts
- npx vitest run src/platform/endpoint/test/node/messagesApi.spec.ts
- npx vitest run src/extension/prompts/node/agent/test/agentPrompt.spec.tsx --testNamePattern "OpenAI reminder instructions"
- npm run test:unit -- src/extension/prompts/node/agent/test/agentPrompt.spec.tsx -t "tool_search reminder|hidden-model-m reminder"

## Review follow-up
- Built-in grouping follow-up (`fix(tool-grouping): keep non-deferred built-ins direct`) was reviewed by Code-Review-subagent and approved.
- No blocking correctness issues were found in the `BuiltInToolGroupHandler` / `VirtualToolGrouper` changes.
- Only non-blocking notes remained: a possible clarifying comment around the effectively unreachable `ToolCategory.Core` summary branch, and a note that `ToolSearch` stays direct in the new test because it is categorized as `Core`.

Fixes #316779
