### PR TITLE
refactor(otel): share BYOK OTel capture, harden chatMLFetcher system collection

### DIFF
--- a/extensions/copilot/src/extension/byok/vscode-node/anthropicProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/anthropicProvider.ts
@@ -20,6 +20,7 @@ import { CopilotChatAttr, emitInferenceDetailsEvent, GenAiAttr, GenAiMetrics, Ge
 import { IOTelService, SpanKind, SpanStatusCode } from '../../../platform/otel/common/otelService';
 import { IRequestLogger } from '../../../platform/requestLogger/common/requestLogger';
 import { retrieveCapturingTokenByCorrelation, runWithCapturingToken } from '../../../platform/requestLogger/node/requestLogger';
+import { buildOTelInputFromChatMessages } from './byokOTelHelpers';
 import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
 import { ITelemetryService } from '../../../platform/telemetry/common/telemetry';
 import { toErrorMessage } from '../../../util/common/errorMessage';
@@ -505,43 +506,7 @@ export class AnthropicLMProvider extends AbstractLanguageModelChatProvider {
 					otelSpan.setAttribute(GenAiAttr.TOOL_DEFINITIONS, truncateForOTel(JSON.stringify(toolDefs), this._otelService.config.maxAttributeSizeChars));
 				}
 				try {
-					const roleNames: Record<number, string> = { 1: 'user', 2: 'assistant', 3: 'system' };
-					const systemTexts: string[] = [];
-					const inputMsgs: Array<{ role: string; parts: Array<{ type: string; content?: string | unknown; id?: string; name?: string; arguments?: unknown; response?: unknown }> }> = [];
-					for (const m of messages) {
-						const msg = m as LanguageModelChatMessage;
-						const role = roleNames[msg.role] ?? String(msg.role);
-						// System messages are emitted via gen_ai.system_instructions only — keeping them
-						// in gen_ai.input.messages causes trace viewers to render the system prompt twice
-						// (issue #299932). Collect their text into the dedicated attribute and skip the entry.
-						if (role === 'system') {
-							if (Array.isArray(msg.content)) {
-								for (const p of msg.content) {
-									if (p instanceof LanguageModelTextPart) {
-										systemTexts.push(p.value);
-									}
-								}
-							}
-							continue;
-						}
-						const parts: Array<{ type: string; content?: string | unknown; id?: string; name?: string; arguments?: unknown; response?: unknown }> = [];
-						if (Array.isArray(msg.content)) {
-							for (const p of msg.content) {
-								if (p instanceof LanguageModelTextPart) {
-									parts.push({ type: 'text', content: p.value });
-								} else if (p instanceof LanguageModelToolCallPart) {
-									parts.push({ type: 'tool_call', id: p.callId, name: p.name, arguments: p.input });
-								} else if (p instanceof LanguageModelToolResultPart) {
-									const resultText = p.content.map((c: unknown) => c instanceof LanguageModelTextPart ? c.value : '').join('');
-									parts.push({ type: 'tool_call_response', id: p.callId, response: resultText });
-								}
-							}
-						}
-						if (parts.length === 0) {
-							parts.push({ type: 'text', content: '[non-text content]' });
-						}
-						inputMsgs.push({ role, parts });
-					}
+					const { systemTexts, inputMsgs } = buildOTelInputFromChatMessages(messages);
 					const systemInstructions = toSystemInstructions(systemTexts);
 					if (systemInstructions) {
 						otelSpan.setAttribute(GenAiAttr.SYSTEM_INSTRUCTIONS, truncateForOTel(JSON.stringify(systemInstructions), this._otelService.config.maxAttributeSizeChars));

--- a/extensions/copilot/src/extension/byok/vscode-node/byokOTelHelpers.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/byokOTelHelpers.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { LanguageModelChatMessage, LanguageModelChatMessage2, LanguageModelTextPart, LanguageModelToolCallPart, LanguageModelToolResultPart } from 'vscode';
+import { LanguageModelChatMessage, LanguageModelChatMessage2, LanguageModelChatMessageRole, LanguageModelTextPart, LanguageModelToolCallPart, LanguageModelToolResultPart } from 'vscode';
 
 /** A single content part inside an OTel `gen_ai.input.messages` entry. */
 export interface OTelInputMessagePart {
@@ -21,7 +21,14 @@ export interface OTelInputMessage {
 	parts: OTelInputMessagePart[];
 }
 
-const ROLE_NAMES: Record<number, string> = { 1: 'user', 2: 'assistant', 3: 'system' };
+function roleName(role: LanguageModelChatMessageRole | number): string {
+	switch (role) {
+		case LanguageModelChatMessageRole.User: return 'user';
+		case LanguageModelChatMessageRole.Assistant: return 'assistant';
+		case LanguageModelChatMessageRole.System: return 'system';
+		default: return String(role);
+	}
+}
 
 /**
  * Convert provider chat messages into OTel `gen_ai.system_instructions` text
@@ -35,7 +42,7 @@ export function buildOTelInputFromChatMessages(
 	const systemTexts: string[] = [];
 	const inputMsgs: OTelInputMessage[] = [];
 	for (const msg of messages) {
-		if (msg.role === 3 /* LanguageModelChatMessageRole.System */) {
+		if (msg.role === LanguageModelChatMessageRole.System) {
 			if (Array.isArray(msg.content)) {
 				for (const p of msg.content) {
 					if (p instanceof LanguageModelTextPart) {
@@ -45,7 +52,7 @@ export function buildOTelInputFromChatMessages(
 			}
 			continue;
 		}
-		const role = ROLE_NAMES[msg.role] ?? String(msg.role);
+		const role = roleName(msg.role);
 		const parts: OTelInputMessagePart[] = [];
 		if (Array.isArray(msg.content)) {
 			for (const p of msg.content) {
@@ -55,7 +62,7 @@ export function buildOTelInputFromChatMessages(
 					parts.push({ type: 'tool_call', id: p.callId, name: p.name, arguments: p.input });
 				} else if (p instanceof LanguageModelToolResultPart) {
 					const resultText = p.content.map((c: unknown) => c instanceof LanguageModelTextPart ? c.value : '').join('');
-					parts.push({ type: 'tool_call_response', id: p.callId, response: resultText });
+					parts.push({ type: 'tool_call_response', id: p.callId, response: resultText || '[non-text content]' });
 				}
 			}
 		}

--- a/extensions/copilot/src/extension/byok/vscode-node/byokOTelHelpers.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/byokOTelHelpers.ts
@@ -1,0 +1,68 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { LanguageModelChatMessage, LanguageModelChatMessage2, LanguageModelTextPart, LanguageModelToolCallPart, LanguageModelToolResultPart } from 'vscode';
+
+/** A single content part inside an OTel `gen_ai.input.messages` entry. */
+export interface OTelInputMessagePart {
+	type: string;
+	content?: string;
+	id?: string;
+	name?: string;
+	arguments?: unknown;
+	response?: string;
+}
+
+/** A single OTel `gen_ai.input.messages` entry. */
+export interface OTelInputMessage {
+	role: string;
+	parts: OTelInputMessagePart[];
+}
+
+const ROLE_NAMES: Record<number, string> = { 1: 'user', 2: 'assistant', 3: 'system' };
+
+/**
+ * Convert provider chat messages into OTel `gen_ai.system_instructions` text
+ * and `gen_ai.input.messages` entries. System-role messages are surfaced via
+ * `systemTexts` and excluded from `inputMsgs` to avoid double-rendering in
+ * trace viewers. Non-text parts inside system messages are dropped.
+ */
+export function buildOTelInputFromChatMessages(
+	messages: ReadonlyArray<LanguageModelChatMessage | LanguageModelChatMessage2>
+): { systemTexts: string[]; inputMsgs: OTelInputMessage[] } {
+	const systemTexts: string[] = [];
+	const inputMsgs: OTelInputMessage[] = [];
+	for (const msg of messages) {
+		if (msg.role === 3 /* LanguageModelChatMessageRole.System */) {
+			if (Array.isArray(msg.content)) {
+				for (const p of msg.content) {
+					if (p instanceof LanguageModelTextPart) {
+						systemTexts.push(p.value);
+					}
+				}
+			}
+			continue;
+		}
+		const role = ROLE_NAMES[msg.role] ?? String(msg.role);
+		const parts: OTelInputMessagePart[] = [];
+		if (Array.isArray(msg.content)) {
+			for (const p of msg.content) {
+				if (p instanceof LanguageModelTextPart) {
+					parts.push({ type: 'text', content: p.value });
+				} else if (p instanceof LanguageModelToolCallPart) {
+					parts.push({ type: 'tool_call', id: p.callId, name: p.name, arguments: p.input });
+				} else if (p instanceof LanguageModelToolResultPart) {
+					const resultText = p.content.map((c: unknown) => c instanceof LanguageModelTextPart ? c.value : '').join('');
+					parts.push({ type: 'tool_call_response', id: p.callId, response: resultText });
+				}
+			}
+		}
+		if (parts.length === 0) {
+			parts.push({ type: 'text', content: '[non-text content]' });
+		}
+		inputMsgs.push({ role, parts });
+	}
+	return { systemTexts, inputMsgs };
+}

--- a/extensions/copilot/src/extension/byok/vscode-node/geminiNativeProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/geminiNativeProvider.ts
@@ -16,6 +16,7 @@ import { IRequestLogger } from '../../../platform/requestLogger/common/requestLo
 import { retrieveCapturingTokenByCorrelation, runWithCapturingToken } from '../../../platform/requestLogger/node/requestLogger';
 import { ITelemetryService } from '../../../platform/telemetry/common/telemetry';
 import { toErrorMessage } from '../../../util/common/errorMessage';
+import { buildOTelInputFromChatMessages } from './byokOTelHelpers';
 import { RecordedProgress } from '../../../util/common/progressRecorder';
 import { generateUuid } from '../../../util/vs/base/common/uuid';
 import { BYOKKnownModels, byokKnownModelsToAPIInfo, BYOKModelCapabilities, LMResponsePart } from '../common/byokProvider';
@@ -366,40 +367,7 @@ export class GeminiNativeBYOKLMProvider extends AbstractLanguageModelChatProvide
 					otelSpan.setAttribute(GenAiAttr.TOOL_DEFINITIONS, truncateForOTel(JSON.stringify(toolDefs), this._otelService.config.maxAttributeSizeChars));
 				}
 				try {
-					const roleNames: Record<number, string> = { 1: 'user', 2: 'assistant', 3: 'system' };
-					const systemTexts: string[] = [];
-					const inputMsgs: Array<{ role: string; parts: Array<{ type: string; content?: string; id?: string; name?: string; arguments?: unknown }> }> = [];
-					for (const m of messages) {
-						const msg = m as LanguageModelChatMessage;
-						const role = roleNames[msg.role] ?? String(msg.role);
-						// System messages are emitted via gen_ai.system_instructions only — keeping them
-						// in gen_ai.input.messages causes trace viewers to render the system prompt twice
-						// (issue #299932). Collect their text into the dedicated attribute and skip the entry.
-						if (role === 'system') {
-							if (Array.isArray(msg.content)) {
-								for (const p of msg.content) {
-									if (p instanceof LanguageModelTextPart) {
-										systemTexts.push(p.value);
-									}
-								}
-							}
-							continue;
-						}
-						const parts: Array<{ type: string; content?: string; id?: string; name?: string; arguments?: unknown }> = [];
-						if (Array.isArray(msg.content)) {
-							for (const p of msg.content) {
-								if (p instanceof LanguageModelTextPart) {
-									parts.push({ type: 'text', content: p.value });
-								} else if (p instanceof LanguageModelToolCallPart) {
-									parts.push({ type: 'tool_call', id: p.callId, name: p.name, arguments: p.input });
-								}
-							}
-						}
-						if (parts.length === 0) {
-							parts.push({ type: 'text', content: '[non-text content]' });
-						}
-						inputMsgs.push({ role, parts });
-					}
+					const { systemTexts, inputMsgs } = buildOTelInputFromChatMessages(messages);
 					const systemInstructions = toSystemInstructions(systemTexts);
 					if (systemInstructions) {
 						otelSpan.setAttribute(GenAiAttr.SYSTEM_INSTRUCTIONS, truncateForOTel(JSON.stringify(systemInstructions), this._otelService.config.maxAttributeSizeChars));

--- a/extensions/copilot/src/extension/byok/vscode-node/test/byokOTelHelpers.spec.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/test/byokOTelHelpers.spec.ts
@@ -87,6 +87,22 @@ describe('buildOTelInputFromChatMessages', () => {
 		]);
 	});
 
+	it('falls back to a placeholder when tool_result has no text content', () => {
+		const messages: LanguageModelChatMessage[] = [
+			{
+				role: LanguageModelChatMessageRole.User,
+				content: [new LanguageModelToolResultPart('call_1', [])],
+				name: undefined,
+			},
+		];
+
+		const { inputMsgs } = buildOTelInputFromChatMessages(messages);
+
+		expect(inputMsgs).toEqual([
+			{ role: 'user', parts: [{ type: 'tool_call_response', id: 'call_1', response: '[non-text content]' }] },
+		]);
+	});
+
 	it('returns empty results for an empty messages array', () => {
 		expect(buildOTelInputFromChatMessages([])).toEqual({ systemTexts: [], inputMsgs: [] });
 	});

--- a/extensions/copilot/src/extension/byok/vscode-node/test/byokOTelHelpers.spec.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/test/byokOTelHelpers.spec.ts
@@ -1,0 +1,93 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it } from 'vitest';
+import type { LanguageModelChatMessage } from 'vscode';
+import { LanguageModelChatMessageRole, LanguageModelTextPart, LanguageModelToolCallPart, LanguageModelToolResultPart } from '../../../../vscodeTypes';
+import { buildOTelInputFromChatMessages } from '../byokOTelHelpers';
+
+describe('buildOTelInputFromChatMessages', () => {
+	it('extracts a single system message and removes it from input messages', () => {
+		const messages: LanguageModelChatMessage[] = [
+			{ role: LanguageModelChatMessageRole.System, content: [new LanguageModelTextPart('You are helpful')], name: undefined },
+			{ role: LanguageModelChatMessageRole.User, content: [new LanguageModelTextPart('hi')], name: undefined },
+		];
+
+		const { systemTexts, inputMsgs } = buildOTelInputFromChatMessages(messages);
+
+		expect(systemTexts).toEqual(['You are helpful']);
+		expect(inputMsgs).toEqual([
+			{ role: 'user', parts: [{ type: 'text', content: 'hi' }] },
+		]);
+	});
+
+	it('preserves order of multiple system messages', () => {
+		const messages: LanguageModelChatMessage[] = [
+			{ role: LanguageModelChatMessageRole.System, content: [new LanguageModelTextPart('personality')], name: undefined },
+			{ role: LanguageModelChatMessageRole.System, content: [new LanguageModelTextPart('instructions')], name: undefined },
+			{ role: LanguageModelChatMessageRole.User, content: [new LanguageModelTextPart('hi')], name: undefined },
+		];
+
+		const { systemTexts, inputMsgs } = buildOTelInputFromChatMessages(messages);
+
+		expect(systemTexts).toEqual(['personality', 'instructions']);
+		expect(inputMsgs).toHaveLength(1);
+	});
+
+	it('drops non-text parts inside a system message', () => {
+		const messages: LanguageModelChatMessage[] = [
+			{
+				role: LanguageModelChatMessageRole.System,
+				content: [
+					new LanguageModelTextPart('keep me'),
+					new LanguageModelToolCallPart('id1', 'tool', { a: 1 }),
+				],
+				name: undefined,
+			},
+		];
+
+		const { systemTexts } = buildOTelInputFromChatMessages(messages);
+
+		expect(systemTexts).toEqual(['keep me']);
+	});
+
+	it('maps tool_call and tool_call_response parts', () => {
+		const messages: LanguageModelChatMessage[] = [
+			{
+				role: LanguageModelChatMessageRole.Assistant,
+				content: [new LanguageModelToolCallPart('call_1', 'search', { q: 'vscode' })],
+				name: undefined,
+			},
+			{
+				role: LanguageModelChatMessageRole.User,
+				content: [new LanguageModelToolResultPart('call_1', [new LanguageModelTextPart('result')])],
+				name: undefined,
+			},
+		];
+
+		const { inputMsgs } = buildOTelInputFromChatMessages(messages);
+
+		expect(inputMsgs).toEqual([
+			{ role: 'assistant', parts: [{ type: 'tool_call', id: 'call_1', name: 'search', arguments: { q: 'vscode' } }] },
+			{ role: 'user', parts: [{ type: 'tool_call_response', id: 'call_1', response: 'result' }] },
+		]);
+	});
+
+	it('falls back to a placeholder when no parts are recognized', () => {
+		const messages: LanguageModelChatMessage[] = [
+			{ role: LanguageModelChatMessageRole.User, content: [], name: undefined },
+		];
+
+		const { inputMsgs } = buildOTelInputFromChatMessages(messages);
+
+		expect(inputMsgs).toEqual([
+			{ role: 'user', parts: [{ type: 'text', content: '[non-text content]' }] },
+		]);
+	});
+
+	it('returns empty results for an empty messages array', () => {
+		expect(buildOTelInputFromChatMessages([])).toEqual({ systemTexts: [], inputMsgs: [] });
+	});
+});

--- a/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
+++ b/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
@@ -27,7 +27,7 @@ import { sendEngineMessagesTelemetry } from '../../../platform/networking/node/c
 import { CAPIWebSocketErrorEvent, IChatWebSocketManager, isCAPIWebSocketError } from '../../../platform/networking/node/chatWebSocketManager';
 import { sendCommunicationErrorTelemetry } from '../../../platform/networking/node/stream';
 import { ChatFailKind, ChatRequestCanceled, ChatRequestFailed, ChatResults, FetchResponseKind } from '../../../platform/openai/node/fetch';
-import { CopilotChatAttr, emitInferenceDetailsEvent, extractTextFromContent, GenAiAttr, GenAiMetrics, GenAiOperationName, GenAiProviderName, normalizeProviderMessages, StdAttr, toSystemInstructions, toToolDefinitions, truncateForOTel } from '../../../platform/otel/common/index';
+import { collectSystemTextsFromRequestBody, CopilotChatAttr, emitInferenceDetailsEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, GenAiProviderName, normalizeProviderMessages, StdAttr, toSystemInstructions, toToolDefinitions, truncateForOTel } from '../../../platform/otel/common/index';
 import { IOTelService, ISpanHandle, SpanKind, SpanStatusCode } from '../../../platform/otel/common/otelService';
 import { IRequestLogger } from '../../../platform/requestLogger/common/requestLogger';
 import { getCurrentCapturingToken } from '../../../platform/requestLogger/node/requestLogger';
@@ -273,26 +273,9 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 							: JSON.stringify(lastUserMsg.content);
 						otelInferenceSpan.setAttribute(CopilotChatAttr.USER_REQUEST, truncateForOTel(userContent, this._otelService.config.maxAttributeSizeChars));
 					}
-					// System instructions — collect every system-role entry from the messages array
-					// (OpenAI Chat Completions can carry multiple, e.g. personality + instructions),
-					// plus top-level `system` (Anthropic Messages API) or `instructions`
-					// (OpenAI Responses API). Emitted via `gen_ai.system_instructions` only and
-					// stripped from `gen_ai.input.messages` below to avoid the double-render
-					// described in issue #299932.
-					const systemTexts: string[] = [];
-					if (capiMessages) {
-						for (const m of capiMessages) {
-							if (m.role === 'system') {
-								const t = extractTextFromContent(m.content);
-								if (t) { systemTexts.push(t); }
-							}
-						}
-					}
-					const topLevelSystem = extractTextFromContent(
-						(requestBody as Record<string, unknown>).system
-						?? (requestBody as Record<string, unknown>).instructions
-					);
-					if (topLevelSystem) { systemTexts.push(topLevelSystem); }
+					// System instructions go on a dedicated attribute; stripped from
+					// input messages below to avoid rendering the prompt twice.
+					const systemTexts = collectSystemTextsFromRequestBody(requestBody);
 					const systemInstructions = toSystemInstructions(systemTexts);
 					if (systemInstructions) {
 						otelInferenceSpan.setAttribute(GenAiAttr.SYSTEM_INSTRUCTIONS, truncateForOTel(JSON.stringify(systemInstructions), this._otelService.config.maxAttributeSizeChars));
@@ -303,10 +286,8 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 				if (otelInferenceSpan) {
 					const capiMessages = (requestBody.messages ?? requestBody.input) as ReadonlyArray<Record<string, unknown>> | undefined;
 					if (capiMessages) {
-						// Normalize provider-specific content (Anthropic tool_use/tool_result, OpenAI tool messages) to OTel schema.
-						// System-role entries are excluded — they are emitted via `gen_ai.system_instructions`
-						// above. Keeping them in both attributes causes trace viewers (e.g. Aspire) to render
-						// the system prompt twice — see issue #299932.
+						// Normalize provider-specific content to OTel schema; exclude
+						// system entries since they are emitted via `system_instructions`.
 						const nonSystemMessages = capiMessages.filter(m => (m as { role?: unknown }).role !== 'system');
 						otelInferenceSpan.setAttribute(GenAiAttr.INPUT_MESSAGES, truncateForOTel(JSON.stringify(normalizeProviderMessages(nonSystemMessages)), this._otelService.config.maxAttributeSizeChars));
 					}

--- a/extensions/copilot/src/platform/otel/common/index.ts
+++ b/extensions/copilot/src/platform/otel/common/index.ts
@@ -6,7 +6,7 @@
 export { CopilotChatAttr, CopilotCliSdkAttr, GenAiAttr, GenAiOperationName, GenAiProviderName, GenAiTokenType, GenAiToolType, StdAttr } from './genAiAttributes';
 export { emitAgentTurnEvent, emitCloudSessionInvokeEvent, emitEditFeedbackEvent, emitEditHunkActionEvent, emitEditSurvivalEvent, emitInferenceDetailsEvent, emitInlineDoneEvent, emitSessionStartEvent, emitToolCallEvent, emitUserFeedbackEvent } from './genAiEvents';
 export { GenAiMetrics } from './genAiMetrics';
-export { extractTextFromContent, normalizeProviderMessages, toInputMessages, toOutputMessages, toSystemInstructions, toToolDefinitions, truncateForOTel } from './messageFormatters';
+export { collectSystemTextsFromRequestBody, extractTextFromContent, normalizeProviderMessages, toInputMessages, toOutputMessages, toSystemInstructions, toToolDefinitions, truncateForOTel } from './messageFormatters';
 export { NoopOTelService } from './noopOtelService';
 export { resolveOTelConfig, DEFAULT_OTLP_ENDPOINT, type OTelConfig, type OTelConfigInput } from './otelConfig';
 export { IOTelService, SpanKind, SpanStatusCode, type ICompletedSpanData, type ISpanEventData, type ISpanEventRecord, type ISpanHandle, type OTelModelOptions, type SpanOptions, type TraceContext } from './otelService';

--- a/extensions/copilot/src/platform/otel/common/messageFormatters.ts
+++ b/extensions/copilot/src/platform/otel/common/messageFormatters.ts
@@ -131,13 +131,9 @@ export function toOutputMessages(choices: ReadonlyArray<{
 }
 
 /**
- * Convert one or more system messages to OTel system instruction format.
- *
- * Accepts either a single string or an array of strings (so callers that
- * collect multiple system-role entries from the provider request — e.g. the
- * OpenAI Chat Completions personality + instructions split — can preserve
- * them as distinct content blocks). Returns `undefined` when no non-empty
- * text is available so the caller can skip setting the attribute.
+ * Convert system message text to OTel system instruction format.
+ * Accepts a single string or an array (one block per entry). Returns
+ * `undefined` when no non-empty text is available.
  */
 export function toSystemInstructions(systemMessage: string | ReadonlyArray<string> | undefined): OTelSystemInstruction | undefined {
 	if (systemMessage === undefined) {
@@ -151,11 +147,8 @@ export function toSystemInstructions(systemMessage: string | ReadonlyArray<strin
 }
 
 /**
- * Extract plain text from a message-content value, which may be a string,
- * an array of content blocks (Anthropic `system`, Responses API `instructions`,
- * Chat Completions multimodal parts), or some other shape. Returns an empty
- * string when no text can be extracted. Used to feed `toSystemInstructions`
- * from provider-specific request bodies.
+ * Extract plain text from a message-content value (string or array of
+ * content blocks). Returns an empty string when no text can be extracted.
  */
 export function extractTextFromContent(content: unknown): string {
 	if (typeof content === 'string') {
@@ -176,6 +169,34 @@ export function extractTextFromContent(content: unknown): string {
 			.join('\n');
 	}
 	return '';
+}
+
+/**
+ * Collect system-instruction text from a provider request body. Uses
+ * messages-level `system` entries when present, otherwise falls back to
+ * top-level `system` or `instructions`.
+ */
+export function collectSystemTextsFromRequestBody(requestBody: {
+	readonly messages?: ReadonlyArray<{ role?: unknown; content?: unknown }>;
+	readonly input?: ReadonlyArray<{ role?: unknown; content?: unknown }>;
+	readonly system?: unknown;
+	readonly instructions?: unknown;
+}): string[] {
+	const systemTexts: string[] = [];
+	const capiMessages = requestBody.messages ?? requestBody.input;
+	if (capiMessages) {
+		for (const m of capiMessages) {
+			if (m.role === 'system') {
+				const t = extractTextFromContent(m.content);
+				if (t) { systemTexts.push(t); }
+			}
+		}
+	}
+	if (systemTexts.length === 0) {
+		const topLevelSystem = extractTextFromContent(requestBody.system ?? requestBody.instructions);
+		if (topLevelSystem) { systemTexts.push(topLevelSystem); }
+	}
+	return systemTexts;
 }
 
 /**

--- a/extensions/copilot/src/platform/otel/common/test/messageFormatters.spec.ts
+++ b/extensions/copilot/src/platform/otel/common/test/messageFormatters.spec.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { describe, expect, it } from 'vitest';
-import { extractTextFromContent, normalizeProviderMessages, toInputMessages, toOutputMessages, toSystemInstructions, toToolDefinitions, truncateForOTel } from '../messageFormatters';
+import { collectSystemTextsFromRequestBody, extractTextFromContent, normalizeProviderMessages, toInputMessages, toOutputMessages, toSystemInstructions, toToolDefinitions, truncateForOTel } from '../messageFormatters';
 
 describe('toInputMessages', () => {
 	it('converts a simple text message', () => {
@@ -346,6 +346,75 @@ describe('extractTextFromContent', () => {
 	it('returns empty string for unknown shapes', () => {
 		expect(extractTextFromContent(42)).toBe('');
 		expect(extractTextFromContent({ foo: 'bar' })).toBe('');
+	});
+});
+
+describe('collectSystemTextsFromRequestBody', () => {
+	it('collects a single system message from OpenAI Chat Completions `messages`', () => {
+		expect(collectSystemTextsFromRequestBody({
+			messages: [
+				{ role: 'system', content: 'You are helpful' },
+				{ role: 'user', content: 'hi' },
+			],
+		})).toEqual(['You are helpful']);
+	});
+
+	it('collects multiple system messages in order (e.g. personality + instructions)', () => {
+		expect(collectSystemTextsFromRequestBody({
+			messages: [
+				{ role: 'system', content: 'You are helpful' },
+				{ role: 'system', content: 'Always be concise' },
+				{ role: 'user', content: 'hi' },
+			],
+		})).toEqual(['You are helpful', 'Always be concise']);
+	});
+
+	it('falls back to top-level `system` (Anthropic) when no messages-level system exists', () => {
+		expect(collectSystemTextsFromRequestBody({
+			messages: [{ role: 'user', content: 'hi' }],
+			system: 'Anthropic system prompt',
+		})).toEqual(['Anthropic system prompt']);
+	});
+
+	it('falls back to top-level `instructions` (Responses API) when no messages-level system exists', () => {
+		expect(collectSystemTextsFromRequestBody({
+			input: [{ role: 'user', content: 'hi' }],
+			instructions: 'Responses API instructions',
+		})).toEqual(['Responses API instructions']);
+	});
+
+	it('extracts text from Anthropic-style content-block arrays in top-level system', () => {
+		expect(collectSystemTextsFromRequestBody({
+			messages: [],
+			system: [
+				{ type: 'text', text: 'block one', cache_control: { type: 'ephemeral' } },
+				{ type: 'text', text: 'block two' },
+			],
+		})).toEqual(['block one\nblock two']);
+	});
+
+	it('prefers messages-level system over top-level fields to avoid duplication', () => {
+		expect(collectSystemTextsFromRequestBody({
+			messages: [{ role: 'system', content: 'from messages' }],
+			system: 'from top-level',
+			instructions: 'from instructions',
+		})).toEqual(['from messages']);
+	});
+
+	it('returns empty array when no system content exists anywhere', () => {
+		expect(collectSystemTextsFromRequestBody({
+			messages: [{ role: 'user', content: 'hi' }],
+		})).toEqual([]);
+		expect(collectSystemTextsFromRequestBody({})).toEqual([]);
+	});
+
+	it('skips system entries whose content extracts to empty text', () => {
+		expect(collectSystemTextsFromRequestBody({
+			messages: [
+				{ role: 'system', content: '' },
+				{ role: 'system', content: 'real' },
+			],
+		})).toEqual(['real']);
 	});
 });
 


### PR DESCRIPTION
Follow-up to #317663 (system-prompt dedup). Addresses the duplication noted by the PR reviewer and adds a defensive guard around the chatMLFetcher source merge.

### Changes

- **`byokOTelHelpers.ts`** (new): `buildOTelInputFromChatMessages` owns role mapping, system extraction, and part conversion (text / tool_call / tool_call_response). Used by both `anthropicProvider` and `geminiNativeProvider`, replacing ~25 lines of duplicated code per provider.
- **`messageFormatters.ts`**: new `collectSystemTextsFromRequestBody` used by `chatMLFetcher`. Messages-level system entries take precedence; top-level `system`/`instructions` is only a fallback so a request carrying both shapes can't re-introduce the double-render.
- JSDoc trimmed across the helpers.
- Unit tests added for the new helpers (covering single/multiple system, non-text drop, tool_call mapping, precedence guard).

### Side effect

Gemini's OTel capture now also surfaces `tool_call_response` parts (previously fell through to the `[non-text content]` placeholder). Improvement, not a regression.

### Verification

`npx vitest run src/platform/otel src/extension/byok/vscode-node/test` — 227 passing.