### PR TITLE
feat(files-dialog): support ~ in defaultPath

### DIFF
--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -367,8 +367,8 @@ configurationRegistry.registerConfiguration({
 		},
 		'files.dialog.defaultPath': {
 			'type': 'string',
-			'pattern': '^((\\/|\\\\\\\\|[a-zA-Z]:\\\\).*)?$', // slash OR UNC-root OR drive-root OR undefined
-			'patternErrorMessage': nls.localize('defaultPathErrorMessage', "Default path for file dialogs must be an absolute path (e.g. C:\\\\myFolder or /myFolder)."),
+			'pattern': '^((\\/|~(\\/|\\\\|$)|\\\\\\\\|[a-zA-Z]:\\\\).*)?$', // slash OR tilde OR UNC-root OR drive-root OR undefined
+			'patternErrorMessage': nls.localize('defaultPathErrorMessage', "Default path for file dialogs must be an absolute path (e.g. C:\\\\myFolder, /myFolder, or ~/myFolder)."),
 			'description': nls.localize('fileDialogDefaultPath', "Default path for file dialogs, overriding user's home path. Only used in the absence of a context-specific path, such as most recently opened file or folder."),
 			'scope': ConfigurationScope.MACHINE
 		},

--- a/src/vs/workbench/services/dialogs/browser/abstractFileDialogService.ts
+++ b/src/vs/workbench/services/dialogs/browser/abstractFileDialogService.ts
@@ -131,17 +131,27 @@ export abstract class AbstractFileDialogService implements IFileDialogService {
 		this.logService.debug(`[FileDialogService] Preferred home: preferLocal=${preferLocal}, userLocalValue=${preferredHomeConfig.userLocalValue}, userRemoteValue=${preferredHomeConfig.userRemoteValue}`);
 
 		if (preferredHomeCandidate) {
-			const path = preferLocal ? undefined : await this.pathService.path;
-			const normalize = preferLocal ? localPathNormalize : path!.normalize;
-			const isAbsolute = preferLocal ? localPathIsAbsolute : path!.isAbsolute;
+			let _path: Promise<{ isAbsolute: (p: string) => boolean; normalize: (p: string) => string }> | undefined;
+			const getPath = async () => {
+				if (preferLocal) {
+					_path = Promise.resolve({
+						isAbsolute: localPathIsAbsolute,
+						normalize: localPathNormalize,
+					});
+				} else {
+					_path = this.pathService.path;
+				}
+
+				return _path!;
+			};
 
 			let preferredHomeUri: URI | undefined;
 
 			if (preferredHomeCandidate.startsWith('~')) {
 				// Handle tilde expansion
 				if (preferredHomeCandidate === '~' || preferredHomeCandidate.startsWith('~/') || preferredHomeCandidate.startsWith('~\\')) {
-					const relativePath = normalize(preferredHomeCandidate.slice(2));
-					if (!isAbsolute(relativePath)) {
+					const relativePath = (await getPath()).normalize(preferredHomeCandidate.slice(2));
+					if (!(await getPath()).isAbsolute(relativePath)) {
 						preferredHomeUri = resources.joinPath(await getUserHome(), relativePath);
 					} else {
 						this.logService.debug(`[FileDialogService] Preferred home path after ~ resolved to absolute: ${relativePath}`);
@@ -151,8 +161,8 @@ export abstract class AbstractFileDialogService implements IFileDialogService {
 				}
 			} else {
 				// Handle absolute paths
-				if (isAbsolute(preferredHomeCandidate)) {
-					const preferredHomeNormalized = normalize(preferredHomeCandidate);
+				if ((await getPath()).isAbsolute(preferredHomeCandidate)) {
+					const preferredHomeNormalized = (await getPath()).normalize(preferredHomeCandidate);
 					preferredHomeUri = resources.toLocalResource(await this.pathService.fileURI(preferredHomeNormalized), this.environmentService.remoteAuthority, this.pathService.defaultUriScheme);
 				} else {
 					this.logService.debug(`[FileDialogService] Preferred home files.dialog.defaultPath is not absolute: ${preferredHomeCandidate}`);

--- a/src/vs/workbench/services/dialogs/browser/abstractFileDialogService.ts
+++ b/src/vs/workbench/services/dialogs/browser/abstractFileDialogService.ts
@@ -123,7 +123,9 @@ export abstract class AbstractFileDialogService implements IFileDialogService {
 	async preferredHome(schemeFilter = this.getSchemeFilterForWindow()): Promise<URI> {
 		const preferLocal = schemeFilter === Schemas.file;
 
-		const userHome = await this.pathService.userHome({ preferLocal });
+		let _userHome: Promise<URI> | undefined;
+		const getUserHome = () => _userHome ??= this.pathService.userHome({ preferLocal });
+
 		const preferredHomeConfig = this.configurationService.inspect<string>('files.dialog.defaultPath');
 		const preferredHomeCandidate = preferLocal ? preferredHomeConfig.userLocalValue : preferredHomeConfig.userRemoteValue;
 		this.logService.debug(`[FileDialogService] Preferred home: preferLocal=${preferLocal}, userLocalValue=${preferredHomeConfig.userLocalValue}, userRemoteValue=${preferredHomeConfig.userRemoteValue}`);
@@ -140,7 +142,7 @@ export abstract class AbstractFileDialogService implements IFileDialogService {
 				if (preferredHomeCandidate === '~' || preferredHomeCandidate.startsWith('~/') || preferredHomeCandidate.startsWith('~\\')) {
 					const relativePath = normalize(preferredHomeCandidate.slice(2));
 					if (!isAbsolute(relativePath)) {
-						preferredHomeUri = resources.joinPath(userHome, relativePath);
+						preferredHomeUri = resources.joinPath(await getUserHome(), relativePath);
 					} else {
 						this.logService.debug(`[FileDialogService] Preferred home path after ~ resolved to absolute: ${relativePath}`);
 					}
@@ -166,6 +168,7 @@ export abstract class AbstractFileDialogService implements IFileDialogService {
 			}
 		}
 
+		const userHome = await getUserHome();
 		this.logService.debug(`[FileDialogService] Preferred home using user home: ${userHome}`);
 		return userHome;
 	}

--- a/src/vs/workbench/services/dialogs/browser/abstractFileDialogService.ts
+++ b/src/vs/workbench/services/dialogs/browser/abstractFileDialogService.ts
@@ -122,9 +122,6 @@ export abstract class AbstractFileDialogService implements IFileDialogService {
 
 	async preferredHome(schemeFilter = this.getSchemeFilterForWindow()): Promise<URI> {
 		const preferLocal = schemeFilter === Schemas.file;
-		const path = preferLocal ? undefined : await this.pathService.path;
-		const normalize = preferLocal ? localPathNormalize : path!.normalize;
-		const isAbsolute = preferLocal ? localPathIsAbsolute : path!.isAbsolute;
 
 		const userHome = await this.pathService.userHome({ preferLocal });
 		const preferredHomeConfig = this.configurationService.inspect<string>('files.dialog.defaultPath');
@@ -132,6 +129,10 @@ export abstract class AbstractFileDialogService implements IFileDialogService {
 		this.logService.debug(`[FileDialogService] Preferred home: preferLocal=${preferLocal}, userLocalValue=${preferredHomeConfig.userLocalValue}, userRemoteValue=${preferredHomeConfig.userRemoteValue}`);
 
 		if (preferredHomeCandidate) {
+			const path = preferLocal ? undefined : await this.pathService.path;
+			const normalize = preferLocal ? localPathNormalize : path!.normalize;
+			const isAbsolute = preferLocal ? localPathIsAbsolute : path!.isAbsolute;
+
 			let preferredHomeUri: URI | undefined;
 
 			if (preferredHomeCandidate.startsWith('~')) {

--- a/src/vs/workbench/services/dialogs/browser/abstractFileDialogService.ts
+++ b/src/vs/workbench/services/dialogs/browser/abstractFileDialogService.ts
@@ -122,6 +122,10 @@ export abstract class AbstractFileDialogService implements IFileDialogService {
 
 	async preferredHome(schemeFilter = this.getSchemeFilterForWindow()): Promise<URI> {
 		const preferLocal = schemeFilter === Schemas.file;
+		const path = preferLocal ? undefined : await this.pathService.path;
+		const normalize = preferLocal ? localPathNormalize : path!.normalize;
+		const isAbsolute = preferLocal ? localPathIsAbsolute : path!.isAbsolute;
+
 		const userHome = await this.pathService.userHome({ preferLocal });
 		const preferredHomeConfig = this.configurationService.inspect<string>('files.dialog.defaultPath');
 		const preferredHomeCandidate = preferLocal ? preferredHomeConfig.userLocalValue : preferredHomeConfig.userRemoteValue;
@@ -133,12 +137,8 @@ export abstract class AbstractFileDialogService implements IFileDialogService {
 			if (preferredHomeCandidate.startsWith('~')) {
 				// Handle tilde expansion
 				if (preferredHomeCandidate === '~' || preferredHomeCandidate.startsWith('~/') || preferredHomeCandidate.startsWith('~\\')) {
-					let relativePath = preferredHomeCandidate.slice(2);
-					relativePath = preferLocal
-						? localPathNormalize(relativePath)
-						: (await this.pathService.path).normalize(relativePath);
-					const isRelativePath = preferLocal ? !localPathIsAbsolute(relativePath) : !(await this.pathService.path).isAbsolute(relativePath);
-					if (isRelativePath) {
+					const relativePath = normalize(preferredHomeCandidate.slice(2));
+					if (!isAbsolute(relativePath)) {
 						preferredHomeUri = resources.joinPath(userHome, relativePath);
 					} else {
 						this.logService.debug(`[FileDialogService] Preferred home path after ~ resolved to absolute: ${relativePath}`);
@@ -148,9 +148,8 @@ export abstract class AbstractFileDialogService implements IFileDialogService {
 				}
 			} else {
 				// Handle absolute paths
-				const isPreferredHomeCandidateAbsolute = preferLocal ? localPathIsAbsolute(preferredHomeCandidate) : (await this.pathService.path).isAbsolute(preferredHomeCandidate);
-				if (isPreferredHomeCandidateAbsolute) {
-					const preferredHomeNormalized = preferLocal ? localPathNormalize(preferredHomeCandidate) : (await this.pathService.path).normalize(preferredHomeCandidate);
+				if (isAbsolute(preferredHomeCandidate)) {
+					const preferredHomeNormalized = normalize(preferredHomeCandidate);
 					preferredHomeUri = resources.toLocalResource(await this.pathService.fileURI(preferredHomeNormalized), this.environmentService.remoteAuthority, this.pathService.defaultUriScheme);
 				} else {
 					this.logService.debug(`[FileDialogService] Preferred home files.dialog.defaultPath is not absolute: ${preferredHomeCandidate}`);

--- a/src/vs/workbench/services/dialogs/browser/abstractFileDialogService.ts
+++ b/src/vs/workbench/services/dialogs/browser/abstractFileDialogService.ts
@@ -122,25 +122,50 @@ export abstract class AbstractFileDialogService implements IFileDialogService {
 
 	async preferredHome(schemeFilter = this.getSchemeFilterForWindow()): Promise<URI> {
 		const preferLocal = schemeFilter === Schemas.file;
+		const userHome = await this.pathService.userHome({ preferLocal });
 		const preferredHomeConfig = this.configurationService.inspect<string>('files.dialog.defaultPath');
 		const preferredHomeCandidate = preferLocal ? preferredHomeConfig.userLocalValue : preferredHomeConfig.userRemoteValue;
 		this.logService.debug(`[FileDialogService] Preferred home: preferLocal=${preferLocal}, userLocalValue=${preferredHomeConfig.userLocalValue}, userRemoteValue=${preferredHomeConfig.userRemoteValue}`);
+
 		if (preferredHomeCandidate) {
-			const isPreferredHomeCandidateAbsolute = preferLocal ? localPathIsAbsolute(preferredHomeCandidate) : (await this.pathService.path).isAbsolute(preferredHomeCandidate);
-			if (isPreferredHomeCandidateAbsolute) {
-				const preferredHomeNormalized = preferLocal ? localPathNormalize(preferredHomeCandidate) : (await this.pathService.path).normalize(preferredHomeCandidate);
-				const preferredHome = resources.toLocalResource(await this.pathService.fileURI(preferredHomeNormalized), this.environmentService.remoteAuthority, this.pathService.defaultUriScheme);
-				if (await this.fileService.exists(preferredHome)) {
-					this.logService.debug(`[FileDialogService] Preferred home using files.dialog.defaultPath setting: ${preferredHome}`);
-					return preferredHome;
+			let preferredHomeUri: URI | undefined;
+
+			if (preferredHomeCandidate.startsWith('~')) {
+				// Handle tilde expansion
+				if (preferredHomeCandidate === '~' || preferredHomeCandidate.startsWith('~/') || preferredHomeCandidate.startsWith('~\\')) {
+					let relativePath = preferredHomeCandidate.slice(2);
+					relativePath = preferLocal
+						? localPathNormalize(relativePath)
+						: (await this.pathService.path).normalize(relativePath);
+					const isRelativePath = preferLocal ? !localPathIsAbsolute(relativePath) : !(await this.pathService.path).isAbsolute(relativePath);
+					if (isRelativePath) {
+						preferredHomeUri = resources.joinPath(userHome, relativePath);
+					} else {
+						this.logService.debug(`[FileDialogService] Preferred home path after ~ resolved to absolute: ${relativePath}`);
+					}
+				} else {
+					this.logService.debug(`[FileDialogService] Preferred home files.dialog.defaultPath does not support tilde expansion: ${preferredHomeCandidate}`);
 				}
-				this.logService.debug(`[FileDialogService] Preferred home files.dialog.defaultPath path does not exist: ${preferredHome}`);
 			} else {
-				this.logService.debug(`[FileDialogService] Preferred home files.dialog.defaultPath is not absolute: ${preferredHomeCandidate}`);
+				// Handle absolute paths
+				const isPreferredHomeCandidateAbsolute = preferLocal ? localPathIsAbsolute(preferredHomeCandidate) : (await this.pathService.path).isAbsolute(preferredHomeCandidate);
+				if (isPreferredHomeCandidateAbsolute) {
+					const preferredHomeNormalized = preferLocal ? localPathNormalize(preferredHomeCandidate) : (await this.pathService.path).normalize(preferredHomeCandidate);
+					preferredHomeUri = resources.toLocalResource(await this.pathService.fileURI(preferredHomeNormalized), this.environmentService.remoteAuthority, this.pathService.defaultUriScheme);
+				} else {
+					this.logService.debug(`[FileDialogService] Preferred home files.dialog.defaultPath is not absolute: ${preferredHomeCandidate}`);
+				}
+			}
+
+			if (preferredHomeUri) {
+				if (await this.fileService.exists(preferredHomeUri)) {
+					this.logService.debug(`[FileDialogService] Preferred home using files.dialog.defaultPath setting: ${preferredHomeUri}`);
+					return preferredHomeUri;
+				}
+				this.logService.debug(`[FileDialogService] Preferred home files.dialog.defaultPath path does not exist: ${preferredHomeUri}`);
 			}
 		}
 
-		const userHome = this.pathService.userHome({ preferLocal });
 		this.logService.debug(`[FileDialogService] Preferred home using user home: ${userHome}`);
 		return userHome;
 	}

--- a/src/vs/workbench/services/dialogs/browser/abstractFileDialogService.ts
+++ b/src/vs/workbench/services/dialogs/browser/abstractFileDialogService.ts
@@ -145,7 +145,7 @@ export abstract class AbstractFileDialogService implements IFileDialogService {
 						this.logService.debug(`[FileDialogService] Preferred home path after ~ resolved to absolute: ${relativePath}`);
 					}
 				} else {
-					this.logService.debug(`[FileDialogService] Preferred home files.dialog.defaultPath does not support tilde expansion: ${preferredHomeCandidate}`);
+					this.logService.debug(`[FileDialogService] Preferred home files.dialog.defaultPath does not support tilde prefixes: ${preferredHomeCandidate}`);
 				}
 			} else {
 				// Handle absolute paths

--- a/src/vs/workbench/services/dialogs/browser/abstractFileDialogService.ts
+++ b/src/vs/workbench/services/dialogs/browser/abstractFileDialogService.ts
@@ -133,16 +133,18 @@ export abstract class AbstractFileDialogService implements IFileDialogService {
 		if (preferredHomeCandidate) {
 			let _path: Promise<{ isAbsolute: (p: string) => boolean; normalize: (p: string) => string }> | undefined;
 			const getPath = async () => {
+				if (_path) {
+					return _path;
+				}
+
 				if (preferLocal) {
-					_path = Promise.resolve({
+					return _path = Promise.resolve({
 						isAbsolute: localPathIsAbsolute,
 						normalize: localPathNormalize,
 					});
-				} else {
-					_path = this.pathService.path;
 				}
 
-				return _path!;
+				return _path = this.pathService.path;
 			};
 
 			let preferredHomeUri: URI | undefined;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
add support for `~`, `~/Projects`, `~\Projects`, etc.

reject `~user/Projects`, `~+/Projects`, `~//Projects`

fix #317729

## How to test

1. Set `files.dialog.defaultPath` to a value that starts with ~
2. Press <kbd>Ctrl</kbd>+<kbd>O</kbd> in an empty workspace
3. Notice that the path is interpreted correctly


