### PR TITLE
Recover from stale reconnection token after server replacement

### DIFF
--- a/src/vs/base/parts/ipc/common/ipc.net.ts
+++ b/src/vs/base/parts/ipc/common/ipc.net.ts
@@ -857,6 +857,10 @@ export class PersistentProtocol implements IMessagePassingProtocol {
 	private readonly _onSocketTimeout = new BufferedEmitter<SocketTimeoutEvent>();
 	readonly onSocketTimeout: Event<SocketTimeoutEvent> = this._onSocketTimeout.event;
 
+	private readonly _onDidResetSession = new Emitter<void>();
+	/** Fires after {@link resetSessionStateForFreshHandshake} has cleared session state. Listeners can synchronously queue messages (e.g. an IPC init context) while `_isReconnecting` is still true so they replay ahead of any concurrent sends. */
+	readonly onDidResetSession: Event<void> = this._onDidResetSession.event;
+
 	public get unacknowledgedCount(): number {
 		return this._outgoingMsgId - this._outgoingAckId;
 	}
@@ -969,6 +973,30 @@ export class PersistentProtocol implements IMessagePassingProtocol {
 		this._socketDisposables.add(this._socket.onClose(e => this._onSocketClose.fire(e)));
 
 		this._socketReader.acceptChunk(initialDataChunk);
+	}
+
+	/** Reset state to talk to a fresh server. Call between begin/endAcceptReconnection. Fires {@link onDidResetSession} synchronously after the reset. */
+	public resetSessionStateForFreshHandshake(): void {
+		if (!this._isReconnecting) {
+			throw new Error('resetSessionStateForFreshHandshake must be called between beginAcceptReconnection and endAcceptReconnection');
+		}
+		if (this._outgoingAckTimeout) {
+			clearTimeout(this._outgoingAckTimeout);
+			this._outgoingAckTimeout = null;
+		}
+		if (this._incomingAckTimeout) {
+			clearTimeout(this._incomingAckTimeout);
+			this._incomingAckTimeout = null;
+		}
+		this._outgoingUnackMsg = new Queue<ProtocolMessage>();
+		this._outgoingMsgId = 0;
+		this._outgoingAckId = 0;
+		this._incomingMsgId = 0;
+		this._incomingAckId = 0;
+		// Baseline to now so ack scheduling uses a sensible window until the first message arrives.
+		this._incomingMsgLastTime = Date.now();
+		this._didSendDisconnect = false;
+		this._onDidResetSession.fire();
 	}
 
 	public endAcceptReconnection(): void {

--- a/src/vs/base/parts/ipc/common/ipc.ts
+++ b/src/vs/base/parts/ipc/common/ipc.ts
@@ -543,7 +543,10 @@ export class ChannelClient implements IChannelClient, IDisposable {
 
 	private isDisposed = false;
 	private state: State = State.Uninitialized;
-	private activeRequests = new Set<IDisposable>();
+	/** Pending promise-style requests. Disposing an entry rejects the promise. */
+	private activePromiseRequests = new Set<IDisposable>();
+	/** Live event subscriptions. Indexed by request id so they can be re-sent on transport replacement. */
+	private activeEventSubscriptions = new Map<number, { emitter: Emitter<any>; request: IRawRequest }>();
 	private handlers = new Map<number, IHandler>();
 	private lastRequestId = 0;
 	private protocolListener: IDisposable | null;
@@ -662,12 +665,12 @@ export class ChannelClient implements IChannelClient, IDisposable {
 				})
 			};
 
-			this.activeRequests.add(disposableWithRequestCancel);
+			this.activePromiseRequests.add(disposableWithRequestCancel);
 		});
 
 		return result.finally(() => {
 			disposable?.dispose(); // Seen as undefined in tests.
-			this.activeRequests.delete(disposableWithRequestCancel);
+			this.activePromiseRequests.delete(disposableWithRequestCancel);
 		});
 	}
 
@@ -683,7 +686,7 @@ export class ChannelClient implements IChannelClient, IDisposable {
 				const handler: IHandler = (res: IRawResponse) => emitter.fire((res as IRawEventFireResponse).data);
 				this.handlers.set(id, handler);
 				const doRequest = () => {
-					this.activeRequests.add(emitter);
+					this.activeEventSubscriptions.set(id, { emitter, request });
 					this.sendRequest(request);
 				};
 				if (this.state === State.Idle) {
@@ -701,7 +704,7 @@ export class ChannelClient implements IChannelClient, IDisposable {
 					uninitializedPromise.cancel();
 					uninitializedPromise = null;
 				} else {
-					this.activeRequests.delete(emitter);
+					this.activeEventSubscriptions.delete(id);
 					this.sendRequest({ id, type: RequestType.EventDispose });
 				}
 				this.handlers.delete(id);
@@ -795,14 +798,37 @@ export class ChannelClient implements IChannelClient, IDisposable {
 		}
 	}
 
+	/** Reject pending promise-style requests and drop their handlers. Event subscriptions are left alive. */
+	public cancelPendingPromiseRequests(): void {
+		dispose(this.activePromiseRequests.values());
+		this.activePromiseRequests.clear();
+		// Promise handlers self-remove on response; sweep the ones whose responses will never arrive.
+		for (const id of [...this.handlers.keys()]) {
+			if (!this.activeEventSubscriptions.has(id)) {
+				this.handlers.delete(id);
+			}
+		}
+	}
+
+	/** Re-send EventListen for every live subscription so a replaced server can register them. Ids are preserved so existing client-side handlers continue to route correctly. */
+	public replayEventSubscriptions(): void {
+		for (const { request } of this.activeEventSubscriptions.values()) {
+			this.sendRequest(request);
+		}
+	}
+
 	dispose(): void {
 		this.isDisposed = true;
 		if (this.protocolListener) {
 			this.protocolListener.dispose();
 			this.protocolListener = null;
 		}
-		dispose(this.activeRequests.values());
-		this.activeRequests.clear();
+		this.cancelPendingPromiseRequests();
+		for (const { emitter } of this.activeEventSubscriptions.values()) {
+			emitter.dispose();
+		}
+		this.activeEventSubscriptions.clear();
+		this.handlers.clear();
 		this._onDidInitialize.dispose();
 	}
 }
@@ -1036,6 +1062,16 @@ export class IPCClient<TContext = string> implements IChannelClient, IChannelSer
 
 	registerChannel(channelName: string, channel: IServerChannel<TContext>): void {
 		this.channelServer.registerChannel(channelName, channel);
+	}
+
+	/** Reject pending channel calls so they don't hang after a transport-level recovery. Event subscriptions are left intact. */
+	public cancelPendingCalls(): void {
+		this.channelClient.cancelPendingPromiseRequests();
+	}
+
+	/** Re-send EventListen for each live subscription so the replaced server can register them again. */
+	public replayEventSubscriptions(): void {
+		this.channelClient.replayEventSubscriptions();
 	}
 
 	dispose(): void {

--- a/src/vs/base/parts/ipc/common/ipc.ts
+++ b/src/vs/base/parts/ipc/common/ipc.ts
@@ -1043,17 +1043,21 @@ export class IPCClient<TContext = string> implements IChannelClient, IChannelSer
 	private channelClient: ChannelClient;
 	private channelServer: ChannelServer<TContext>;
 
-	constructor(protocol: IMessagePassingProtocol, ctx: TContext, ipcLogger: IIPCLogger | null = null) {
+	constructor(private readonly _protocol: IMessagePassingProtocol, private readonly _ctx: TContext, ipcLogger: IIPCLogger | null = null) {
+		this.sendInitialContext();
+		this.channelClient = new ChannelClient(_protocol, ipcLogger);
+		this.channelServer = new ChannelServer(_protocol, _ctx, ipcLogger);
+	}
+
+	/** Send the connection context as the first protocol message; the server reads it to identify this client. */
+	private sendInitialContext(): void {
 		const writer = new BufferWriter();
 		try {
-			serialize(writer, ctx);
-			protocol.send(writer.buffer);
+			serialize(writer, this._ctx);
+			this._protocol.send(writer.buffer);
 		} finally {
 			writer.dispose();
 		}
-
-		this.channelClient = new ChannelClient(protocol, ipcLogger);
-		this.channelServer = new ChannelServer(protocol, ctx, ipcLogger);
 	}
 
 	getChannel<T extends IChannel>(channelName: string): T {
@@ -1069,8 +1073,9 @@ export class IPCClient<TContext = string> implements IChannelClient, IChannelSer
 		this.channelClient.cancelPendingPromiseRequests();
 	}
 
-	/** Re-send EventListen for each live subscription so the replaced server can register them again. */
-	public replayEventSubscriptions(): void {
+	/** After a session reset for a replaced server, re-send the connection context (message #1) and replay live event subscriptions (ids preserved so existing handlers keep routing). */
+	public resendInitialContextAndReplay(): void {
+		this.sendInitialContext();
 		this.channelClient.replayEventSubscriptions();
 	}
 

--- a/src/vs/base/parts/ipc/common/ipc.ts
+++ b/src/vs/base/parts/ipc/common/ipc.ts
@@ -341,7 +341,7 @@ export class ChannelServer<TContext = string> implements IChannelServer<TContext
 
 	constructor(private protocol: IMessagePassingProtocol, private ctx: TContext, private logger: IIPCLogger | null = null, private timeoutDelay = 1000) {
 		this.protocolListener = this.protocol.onMessage(msg => this.onRawMessage(msg));
-		this.sendResponse({ type: ResponseType.Initialize });
+		this.reinitialize();
 	}
 
 	registerChannel(channelName: string, channel: IServerChannel<TContext>): void {
@@ -349,6 +349,11 @@ export class ChannelServer<TContext = string> implements IChannelServer<TContext
 
 		// https://github.com/microsoft/vscode/issues/72531
 		setTimeout(() => this.flushPendingRequests(channelName), 0);
+	}
+
+	/** Establish (or re-establish) this server's session: send Initialize so the peer's ChannelClient leaves the Uninitialized state. Run at construction and again after a transport replacement. */
+	public reinitialize(): void {
+		this.sendResponse({ type: ResponseType.Initialize });
 	}
 
 	private sendResponse(response: IRawResponse): void {
@@ -653,7 +658,8 @@ export class ChannelClient implements IChannelClient, IDisposable {
 				} else {
 					this.sendRequest({ id, type: RequestType.PromiseCancel });
 				}
-
+				// Drop our handler; the promise is settled below and no response will arrive.
+				this.handlers.delete(id);
 				e(new CancellationError());
 			};
 
@@ -798,20 +804,14 @@ export class ChannelClient implements IChannelClient, IDisposable {
 		}
 	}
 
-	/** Reject pending promise-style requests and drop their handlers. Event subscriptions are left alive. */
+	/** Reject pending promise-style requests (each clears its own handler). Event subscriptions stay alive. */
 	public cancelPendingPromiseRequests(): void {
 		dispose(this.activePromiseRequests.values());
 		this.activePromiseRequests.clear();
-		// Promise handlers self-remove on response; sweep the ones whose responses will never arrive.
-		for (const id of [...this.handlers.keys()]) {
-			if (!this.activeEventSubscriptions.has(id)) {
-				this.handlers.delete(id);
-			}
-		}
 	}
 
-	/** Re-send EventListen for every live subscription so a replaced server can register them. Ids are preserved so existing client-side handlers continue to route correctly. */
-	public replayEventSubscriptions(): void {
+	/** Re-establish this client's session: re-send EventListen for every live subscription so a replaced server can register them. Ids are preserved so existing client-side handlers continue to route correctly. */
+	public reinitialize(): void {
 		for (const { request } of this.activeEventSubscriptions.values()) {
 			this.sendRequest(request);
 		}
@@ -1044,6 +1044,8 @@ export class IPCClient<TContext = string> implements IChannelClient, IChannelSer
 	private channelServer: ChannelServer<TContext>;
 
 	constructor(private readonly _protocol: IMessagePassingProtocol, private readonly _ctx: TContext, ipcLogger: IIPCLogger | null = null) {
+		// Context first (message #1), then each child establishes itself in its constructor. Whatever is sent
+		// here to set up the session must also be re-sent by reinitialize(); keep the two in sync.
 		this.sendInitialContext();
 		this.channelClient = new ChannelClient(_protocol, ipcLogger);
 		this.channelServer = new ChannelServer(_protocol, _ctx, ipcLogger);
@@ -1073,10 +1075,15 @@ export class IPCClient<TContext = string> implements IChannelClient, IChannelSer
 		this.channelClient.cancelPendingPromiseRequests();
 	}
 
-	/** After a session reset for a replaced server, re-send the connection context (message #1) and replay live event subscriptions (ids preserved so existing handlers keep routing). */
-	public resendInitialContextAndReplay(): void {
+	/**
+	 * Re-establish the whole session against a replaced server, mirroring the constructor's setup in order:
+	 * context (message #1), then each child's reinitialize(). Add any new session-establishing component's
+	 * reinitialize() here so recovery stays complete.
+	 */
+	public reinitialize(): void {
 		this.sendInitialContext();
-		this.channelClient.replayEventSubscriptions();
+		this.channelServer.reinitialize();
+		this.channelClient.reinitialize();
 	}
 
 	dispose(): void {

--- a/src/vs/base/parts/ipc/test/common/ipc.test.ts
+++ b/src/vs/base/parts/ipc/test/common/ipc.test.ts
@@ -450,7 +450,7 @@ suite('Base IPC', function () {
 			assert.deepStrictEqual(messages, ['hello']);
 		});
 
-		test('replayEventSubscriptions re-issues EventListen for live subscriptions against a replaced server', async function () {
+		test('ChannelClient reinitialize re-issues EventListen for live subscriptions against a replaced server', async function () {
 			// Model a replaced remote: the ChannelClient keeps its protocol, but the ChannelServer on
 			// the other end is swapped for a fresh one (as after stale-token recovery). Replayed
 			// EventListen must register on the new server, for live subscriptions only.
@@ -481,10 +481,37 @@ suite('Base IPC', function () {
 			const secondServer = store.add(new ChannelServer(serverProtocol, 'ctx'));
 			secondServer.registerChannel(TestChannelId, secondChannel);
 
-			channelClient.replayEventSubscriptions();
+			channelClient.reinitialize();
 			await timeout(0);
 			// The two live subscriptions are re-issued on the fresh server; the disposed one is skipped.
 			assert.strictEqual(secondChannel.listenCount, 2);
+		});
+
+		test('reinitialize lets a replaced server-side ChannelClient issue server->client calls', async function () {
+			// After stale-token recovery the client keeps its ChannelServer but the server stands up a fresh
+			// ChannelClient. Initialize is sent only in the ChannelServer constructor, so without re-sending it
+			// the fresh client blocks in whenInitialized().
+			const toClient = store.add(new Emitter<VSBuffer>());
+			const toServer = store.add(new Emitter<VSBuffer>());
+			const clientProtocol: IMessagePassingProtocol = { onMessage: toClient.event, send: buffer => toServer.fire(buffer) };
+			const serverProtocol: IMessagePassingProtocol = { onMessage: toServer.event, send: buffer => toClient.fire(buffer) };
+
+			// Create the server-side ChannelClient first so it receives the constructor Initialize.
+			const firstServerClient = store.add(new ChannelClient(serverProtocol));
+			const clientChannelServer = store.add(new ChannelServer(clientProtocol, 'ctx'));
+			clientChannelServer.registerChannel(TestChannelId, new TestChannel(service));
+			assert.strictEqual(await firstServerClient.getChannel<IChannel>(TestChannelId).call('marco'), 'polo');
+
+			// Replace the server side: a fresh ChannelClient that never saw an Initialize.
+			firstServerClient.dispose();
+			const secondServerClient = store.add(new ChannelClient(serverProtocol));
+			let resolved = false;
+			const callPromise = secondServerClient.getChannel<IChannel>(TestChannelId).call('marco').then(r => { resolved = true; return r; });
+			await timeout(0);
+			assert.strictEqual(resolved, false); // blocked while the fresh client is Uninitialized
+
+			clientChannelServer.reinitialize();
+			assert.strictEqual(await callPromise, 'polo');
 		});
 	});
 

--- a/src/vs/base/parts/ipc/test/common/ipc.test.ts
+++ b/src/vs/base/parts/ipc/test/common/ipc.test.ts
@@ -161,6 +161,8 @@ class TestService implements ITestService {
 
 class TestChannel implements IServerChannel {
 
+	public listenCount = 0;
+
 	constructor(private service: ITestService) { }
 
 	call(_: unknown, command: string, arg: any, cancellationToken: CancellationToken): Promise<any> {
@@ -176,7 +178,9 @@ class TestChannel implements IServerChannel {
 
 	listen(_: unknown, event: string, arg?: any): Event<any> {
 		switch (event) {
-			case 'onPong': return this.service.onPong;
+			case 'onPong':
+				this.listenCount++;
+				return this.service.onPong;
 			default: throw new Error('not implemented');
 		}
 	}
@@ -243,6 +247,7 @@ suite('Base IPC', function () {
 		let server: IPCServer;
 		let client: IPCClient;
 		let service: TestService;
+		let serverChannel: TestChannel;
 		let ipcService: ITestService;
 
 		setup(function () {
@@ -250,7 +255,8 @@ suite('Base IPC', function () {
 			const testServer = store.add(new TestIPCServer());
 			server = testServer;
 
-			server.registerChannel(TestChannelId, new TestChannel(service));
+			serverChannel = new TestChannel(service);
+			server.registerChannel(TestChannelId, serverChannel);
 
 			client = store.add(testServer.createConnection('client1'));
 			ipcService = new TestChannelClient(client.getChannel(TestChannelId));
@@ -407,6 +413,59 @@ suite('Base IPC', function () {
 			clientIncoming.fire(serverOutbox[0]);
 
 			await assert.rejects(resultPromise);
+		});
+
+		test('cancelPendingCalls rejects in-flight calls and leaves event subscriptions alive', async function () {
+			const pending1 = ipcService.neverComplete();
+			const pending2 = ipcService.neverComplete();
+			const messages: string[] = [];
+			store.add(ipcService.onPong(msg => messages.push(msg)));
+			await timeout(0);
+
+			service.ping('before');
+			await timeout(0);
+			assert.deepStrictEqual(messages, ['before']);
+
+			client.cancelPendingCalls();
+
+			await assert.rejects(pending1, /Canceled/);
+			await assert.rejects(pending2, /Canceled/);
+
+			// event subscription should still fire
+			service.ping('after');
+			await timeout(0);
+			assert.deepStrictEqual(messages, ['before', 'after']);
+		});
+
+		test('client is still usable after cancelPendingCalls', async function () {
+			const pending = ipcService.neverComplete();
+			client.cancelPendingCalls();
+			await assert.rejects(pending, /Canceled/);
+
+			assert.strictEqual(await ipcService.marco(), 'polo');
+
+			const messages: string[] = [];
+			store.add(ipcService.onPong(msg => messages.push(msg)));
+			await timeout(0);
+			service.ping('hello');
+			await timeout(0);
+			assert.deepStrictEqual(messages, ['hello']);
+		});
+
+		test('replayEventSubscriptions re-issues EventListen for live subscriptions and skips disposed ones', async function () {
+			store.add(ipcService.onPong(() => { }));
+			store.add(ipcService.onPong(() => { }));
+			const sub3 = ipcService.onPong(() => { });
+			await timeout(0);
+			assert.strictEqual(serverChannel.listenCount, 3);
+
+			sub3.dispose();
+			await timeout(0);
+
+			client.replayEventSubscriptions();
+			await timeout(0);
+			// sub1 and sub2 are re-issued; sub3 was disposed and is skipped
+			assert.strictEqual(serverChannel.listenCount, 5);
 		});
 	});
 

--- a/src/vs/base/parts/ipc/test/common/ipc.test.ts
+++ b/src/vs/base/parts/ipc/test/common/ipc.test.ts
@@ -247,7 +247,6 @@ suite('Base IPC', function () {
 		let server: IPCServer;
 		let client: IPCClient;
 		let service: TestService;
-		let serverChannel: TestChannel;
 		let ipcService: ITestService;
 
 		setup(function () {
@@ -255,8 +254,7 @@ suite('Base IPC', function () {
 			const testServer = store.add(new TestIPCServer());
 			server = testServer;
 
-			serverChannel = new TestChannel(service);
-			server.registerChannel(TestChannelId, serverChannel);
+			server.registerChannel(TestChannelId, new TestChannel(service));
 
 			client = store.add(testServer.createConnection('client1'));
 			ipcService = new TestChannelClient(client.getChannel(TestChannelId));
@@ -452,20 +450,41 @@ suite('Base IPC', function () {
 			assert.deepStrictEqual(messages, ['hello']);
 		});
 
-		test('replayEventSubscriptions re-issues EventListen for live subscriptions and skips disposed ones', async function () {
-			store.add(ipcService.onPong(() => { }));
-			store.add(ipcService.onPong(() => { }));
-			const sub3 = ipcService.onPong(() => { });
+		test('replayEventSubscriptions re-issues EventListen for live subscriptions against a replaced server', async function () {
+			// Model a replaced remote: the ChannelClient keeps its protocol, but the ChannelServer on
+			// the other end is swapped for a fresh one (as after stale-token recovery). Replayed
+			// EventListen must register on the new server, for live subscriptions only.
+			const toClient = store.add(new Emitter<VSBuffer>());
+			const toServer = store.add(new Emitter<VSBuffer>());
+			const clientProtocol: IMessagePassingProtocol = { onMessage: toClient.event, send: buffer => toServer.fire(buffer) };
+			const serverProtocol: IMessagePassingProtocol = { onMessage: toServer.event, send: buffer => toClient.fire(buffer) };
+
+			const channelClient = store.add(new ChannelClient(clientProtocol));
+			const channel = channelClient.getChannel<IChannel>(TestChannelId);
+
+			const firstChannel = new TestChannel(service);
+			const firstServer = store.add(new ChannelServer(serverProtocol, 'ctx'));
+			firstServer.registerChannel(TestChannelId, firstChannel);
+
+			store.add(channel.listen('onPong')(() => { }));
+			store.add(channel.listen('onPong')(() => { }));
+			const sub3 = channel.listen('onPong')(() => { });
 			await timeout(0);
-			assert.strictEqual(serverChannel.listenCount, 3);
+			assert.strictEqual(firstChannel.listenCount, 3);
 
 			sub3.dispose();
 			await timeout(0);
 
-			client.replayEventSubscriptions();
+			// Replace the server: tear down the old one, stand up a fresh ChannelServer on the same protocol.
+			firstServer.dispose();
+			const secondChannel = new TestChannel(service);
+			const secondServer = store.add(new ChannelServer(serverProtocol, 'ctx'));
+			secondServer.registerChannel(TestChannelId, secondChannel);
+
+			channelClient.replayEventSubscriptions();
 			await timeout(0);
-			// sub1 and sub2 are re-issued; sub3 was disposed and is skipped
-			assert.strictEqual(serverChannel.listenCount, 5);
+			// The two live subscriptions are re-issued on the fresh server; the disposed one is skipped.
+			assert.strictEqual(secondChannel.listenCount, 2);
 		});
 	});
 

--- a/src/vs/base/parts/ipc/test/node/ipc.net.test.ts
+++ b/src/vs/base/parts/ipc/test/node/ipc.net.test.ts
@@ -579,6 +579,61 @@ suite('PersistentProtocol reconnection', () => {
 		);
 	});
 
+	test('resetSessionStateForFreshHandshake clears state and preserves replay order against a fresh partner', async () => {
+		await runWithFakedTimers(
+			{
+				useFakeTimers: true,
+				useSetImmediate: true,
+				maxTaskCount: 1000
+			},
+			async () => {
+
+				const loadEstimator: ILoadEstimator = {
+					hasHighLoad: () => false
+				};
+				const ether = new Ether();
+				const aSocket = new NodeSocket(ether.a);
+				const a = new PersistentProtocol({ socket: aSocket, loadEstimator });
+				const bSocket = new NodeSocket(ether.b);
+				const b = new PersistentProtocol({ socket: bSocket, loadEstimator });
+				const bMessages = new MessageStream(b);
+
+				// give A some outgoing state with the original partner
+				a.send(VSBuffer.fromString('m1'));
+				await bMessages.waitForOne();
+				assert.ok(a.unacknowledgedCount > 0);
+
+				// simulate the server being replaced: attach A to a new socket,
+				// reset session state, then queue two messages before endAcceptReconnection
+				b.dispose();
+				bMessages.dispose();
+				const ether2 = new Ether();
+				const aSocket2 = new NodeSocket(ether2.a);
+				a.beginAcceptReconnection(aSocket2, null);
+				a.resetSessionStateForFreshHandshake();
+				assert.strictEqual(a.unacknowledgedCount, 0);
+
+				a.send(VSBuffer.fromString('context'));
+				a.send(VSBuffer.fromString('after-context'));
+
+				const bSocket2 = new NodeSocket(ether2.b);
+				const freshB = new PersistentProtocol({ socket: bSocket2, loadEstimator });
+				const freshBMessages = new MessageStream(freshB);
+				a.endAcceptReconnection();
+
+				// the fresh partner sees both queued messages in the order they were sent
+				const first = await freshBMessages.waitForOne();
+				const second = await freshBMessages.waitForOne();
+				assert.strictEqual(first.toString(), 'context');
+				assert.strictEqual(second.toString(), 'after-context');
+
+				freshBMessages.dispose();
+				a.dispose();
+				freshB.dispose();
+			}
+		);
+	});
+
 	test('writing can be paused', async () => {
 		await runWithFakedTimers({ useFakeTimers: true, maxTaskCount: 100 }, async () => {
 			const loadEstimator: ILoadEstimator = {

--- a/src/vs/base/parts/ipc/test/node/ipc.net.test.ts
+++ b/src/vs/base/parts/ipc/test/node/ipc.net.test.ts
@@ -12,6 +12,7 @@ import { Barrier, timeout } from '../../../../common/async.js';
 import { VSBuffer } from '../../../../common/buffer.js';
 import { Emitter, Event } from '../../../../common/event.js';
 import { Disposable, DisposableStore, toDisposable } from '../../../../common/lifecycle.js';
+import { ChannelClient, ChannelServer, IChannel, IServerChannel } from '../../common/ipc.js';
 import { ILoadEstimator, PersistentProtocol, Protocol, ProtocolConstants, SocketCloseEvent, SocketDiagnosticsEventType, SocketTimeoutReason } from '../../common/ipc.net.js';
 import { createRandomIPCHandle, createStaticIPCHandle, NodeSocket, WebSocketNodeSocket } from '../../node/ipc.net.js';
 import { flakySuite } from '../../../../test/common/testUtils.js';
@@ -628,6 +629,66 @@ suite('PersistentProtocol reconnection', () => {
 				assert.strictEqual(second.toString(), 'after-context');
 
 				freshBMessages.dispose();
+				a.dispose();
+				freshB.dispose();
+			}
+		);
+	});
+
+	test('calls made while a fresh handshake is in flight are rejected at session reset instead of hanging', async () => {
+		await runWithFakedTimers(
+			{
+				useFakeTimers: true,
+				useSetImmediate: true,
+				maxTaskCount: 1000
+			},
+			async () => {
+
+				const loadEstimator: ILoadEstimator = {
+					hasHighLoad: () => false
+				};
+				const ether = new Ether();
+				const a = new PersistentProtocol({ socket: new NodeSocket(ether.a), loadEstimator });
+				const b = new PersistentProtocol({ socket: new NodeSocket(ether.b), loadEstimator });
+
+				// channel layer on top of the protocol, wired like ManagementPersistentConnection
+				const channelClient = new ChannelClient(a);
+				const resetListener = a.onDidResetSession(() => {
+					channelClient.reinitialize();
+					channelClient.cancelPendingPromiseRequests();
+				});
+				const serverChannel: IServerChannel = {
+					call: (_, command): Promise<any> => command === 'marco' ? Promise.resolve('polo') : new Promise(() => { }),
+					listen: (): Event<any> => { throw new Error('not implemented'); }
+				};
+				const firstServer = new ChannelServer(b, 'ctx');
+				firstServer.registerChannel('test', serverChannel);
+				const channel = channelClient.getChannel<IChannel>('test');
+				assert.strictEqual(await channel.call('marco'), 'polo');
+
+				// the server goes away and a reconnect attempt leaves the protocol reconnecting
+				firstServer.dispose();
+				b.dispose();
+				const ether2 = new Ether();
+				a.beginAcceptReconnection(new NodeSocket(ether2.a), null);
+
+				// a call made in this window is only queued (never written); the reset used to
+				// silently discard it with the queue, leaving the promise hanging forever
+				const inFlight = channel.call('never');
+				a.resetSessionStateForFreshHandshake();
+				await assert.rejects(inFlight, /Canceled/);
+
+				// and the client stays usable against the fresh server
+				const freshB = new PersistentProtocol({ socket: new NodeSocket(ether2.b), loadEstimator });
+				const freshServer = new ChannelServer(freshB, 'ctx');
+				freshServer.registerChannel('test', serverChannel);
+				a.endAcceptReconnection();
+				assert.strictEqual(await channel.call('marco'), 'polo');
+
+				resetListener.dispose();
+				channelClient.dispose();
+				firstServer.dispose();
+				freshServer.dispose();
 				a.dispose();
 				freshB.dispose();
 			}

--- a/src/vs/platform/remote/common/remoteAgentConnection.ts
+++ b/src/vs/platform/remote/common/remoteAgentConnection.ts
@@ -13,7 +13,7 @@ import { RemoteAuthorities } from '../../../base/common/network.js';
 import * as performance from '../../../base/common/performance.js';
 import { StopWatch } from '../../../base/common/stopwatch.js';
 import { generateUuid } from '../../../base/common/uuid.js';
-import { IIPCLogger } from '../../../base/parts/ipc/common/ipc.js';
+import { BufferWriter, IIPCLogger, serialize } from '../../../base/parts/ipc/common/ipc.js';
 import { Client, ISocket, PersistentProtocol, ProtocolConstants, SocketCloseEventType } from '../../../base/parts/ipc/common/ipc.net.js';
 import { ILogService } from '../../log/common/log.js';
 import { RemoteAgentConnectionContext } from './remoteAgentEnvironment.js';
@@ -22,6 +22,7 @@ import { IRemoteSocketFactoryService } from './remoteSocketFactoryService.js';
 import { ISignService } from '../../sign/common/sign.js';
 
 const RECONNECT_TIMEOUT = 30 * 1000 /* 30s */;
+const MAX_FRESH_HANDSHAKE_ATTEMPTS = 3;
 
 export const enum ConnectionType {
 	Management = 1,
@@ -62,7 +63,39 @@ export interface ConnectionTypeRequest {
 
 export interface ErrorMessage {
 	type: 'error';
+	/** Human-readable diagnostic. Always populated for backward compatibility with older/forked clients. */
 	reason: string;
+	/** Stable machine-readable code. Newer servers always populate this; control flow (e.g. recovery decisions) matches on it. */
+	reasonCode?: ConnectionRejectionReason;
+	/** Optional runtime context appended to the code's default description. */
+	detail?: string;
+}
+
+/** Stable machine-readable rejection codes. Values must remain unchanged. */
+export const enum ConnectionRejectionReason {
+	UnknownReconnectionTokenNeverSeen = 'unknown-reconnection-token-never-seen',
+	UnknownReconnectionTokenSeenBefore = 'unknown-reconnection-token-seen-before',
+	DuplicateReconnectionToken = 'duplicate-reconnection-token',
+	HandshakeMalformed = 'handshake-malformed',
+	HandshakeInvalid = 'handshake-invalid',
+	AuthRefused = 'auth-refused',
+	VersionMismatch = 'version-mismatch',
+	UnknownInitialData = 'unknown-initial-data',
+}
+
+/** Default human-readable description for a rejection code. */
+export function describeConnectionRejection(code: ConnectionRejectionReason): string {
+	switch (code) {
+		case ConnectionRejectionReason.UnknownReconnectionTokenNeverSeen: return 'Unknown reconnection token (never seen)';
+		case ConnectionRejectionReason.UnknownReconnectionTokenSeenBefore: return 'Unknown reconnection token (seen before)';
+		case ConnectionRejectionReason.DuplicateReconnectionToken: return 'Duplicate reconnection token';
+		case ConnectionRejectionReason.HandshakeMalformed: return 'Malformed handshake message';
+		case ConnectionRejectionReason.HandshakeInvalid: return 'Invalid handshake message';
+		case ConnectionRejectionReason.AuthRefused: return 'Unauthorized client refused';
+		case ConnectionRejectionReason.VersionMismatch: return 'Client refused: version mismatch';
+		case ConnectionRejectionReason.UnknownInitialData: return 'Unknown initial data received';
+		default: return `Unknown connection rejection: ${code}`;
+	}
 }
 
 export interface OKMessage {
@@ -79,6 +112,8 @@ interface ISimpleConnectionOptions<T extends RemoteConnection = RemoteConnection
 	connectionToken: string | undefined;
 	reconnectionToken: string;
 	reconnectionProtocol: PersistentProtocol | null;
+	/** Reuse the existing protocol but tell the server `reconnection=false` (stale-token recovery). The protocol's owner reacts via {@link PersistentProtocol.onDidResetSession} to queue any post-reset init messages. */
+	isFreshHandshakeOnExistingProtocol: boolean;
 	remoteSocketFactoryService: IRemoteSocketFactoryService;
 	signService: ISignService;
 	logService: ILogService;
@@ -232,7 +267,7 @@ async function connectToRemoteExtensionHostAgent<T extends RemoteConnection>(opt
 
 	let socket: ISocket;
 	try {
-		socket = await createSocket(options.logService, options.remoteSocketFactoryService, options.connectTo, RemoteAuthorities.getServerRootPath(), `reconnectionToken=${options.reconnectionToken}&reconnection=${options.reconnectionProtocol ? 'true' : 'false'}`, connectionTypeToString(connectionType), `renderer-${connectionTypeToString(connectionType)}-${options.reconnectionToken}`, timeoutCancellationToken);
+		socket = await createSocket(options.logService, options.remoteSocketFactoryService, options.connectTo, RemoteAuthorities.getServerRootPath(), `reconnectionToken=${options.reconnectionToken}&reconnection=${options.reconnectionProtocol && !options.isFreshHandshakeOnExistingProtocol ? 'true' : 'false'}`, connectionTypeToString(connectionType), `renderer-${connectionTypeToString(connectionType)}-${options.reconnectionToken}`, timeoutCancellationToken);
 	} catch (error) {
 		options.logService.error(`${logPrefix} socketFactory.connect() failed or timed out. Error:`);
 		options.logService.error(error);
@@ -245,6 +280,11 @@ async function connectToRemoteExtensionHostAgent<T extends RemoteConnection>(opt
 	let ownsProtocol: boolean;
 	if (options.reconnectionProtocol) {
 		options.reconnectionProtocol.beginAcceptReconnection(socket, null);
+		if (options.isFreshHandshakeOnExistingProtocol) {
+			// Fires onDidResetSession synchronously; listeners (e.g. ManagementPersistentConnection) queue
+			// any post-reset init messages while _isReconnecting is still true so they replay in order.
+			options.reconnectionProtocol.resetSessionStateForFreshHandshake();
+		}
 		protocol = options.reconnectionProtocol;
 		ownsProtocol = false;
 	} else {
@@ -387,7 +427,7 @@ export interface IConnectionOptions<T extends RemoteConnection = RemoteConnectio
 	ipcLogger: IIPCLogger | null;
 }
 
-async function resolveConnectionOptions<T extends RemoteConnection>(options: IConnectionOptions<T>, reconnectionToken: string, reconnectionProtocol: PersistentProtocol | null): Promise<ISimpleConnectionOptions<T>> {
+async function resolveConnectionOptions<T extends RemoteConnection>(options: IConnectionOptions<T>, reconnectionToken: string, reconnectionProtocol: PersistentProtocol | null, isFreshHandshakeOnExistingProtocol: boolean): Promise<ISimpleConnectionOptions<T>> {
 	const { connectTo, connectionToken } = await options.addressProvider.getAddress();
 	return {
 		commit: options.commit,
@@ -396,6 +436,7 @@ async function resolveConnectionOptions<T extends RemoteConnection>(options: ICo
 		connectionToken: connectionToken,
 		reconnectionToken: reconnectionToken,
 		reconnectionProtocol: reconnectionProtocol,
+		isFreshHandshakeOnExistingProtocol,
 		remoteSocketFactoryService: options.remoteSocketFactoryService,
 		signService: options.signService,
 		logService: options.logService
@@ -440,7 +481,7 @@ async function createInitialConnection<T extends PersistentConnection, O extends
 	for (let attempt = 1; ; attempt++) {
 		try {
 			const reconnectionToken = generateUuid();
-			const simpleOptions = await resolveConnectionOptions(options, reconnectionToken, null);
+			const simpleOptions = await resolveConnectionOptions(options, reconnectionToken, null, false);
 			const result = await connectionFactory(simpleOptions);
 			return result;
 		} catch (err) {
@@ -458,7 +499,7 @@ async function createInitialConnection<T extends PersistentConnection, O extends
 }
 
 export async function connectRemoteAgentTunnel(options: IConnectionOptions, tunnelRemoteHost: string, tunnelRemotePort: number): Promise<PersistentProtocol> {
-	const simpleOptions = await resolveConnectionOptions(options, generateUuid(), null);
+	const simpleOptions = await resolveConnectionOptions(options, generateUuid(), null, false);
 	const protocol = await doConnectRemoteAgentTunnel(simpleOptions, { host: tunnelRemoteHost, port: tunnelRemotePort }, CancellationToken.None);
 	return protocol;
 }
@@ -564,16 +605,19 @@ export abstract class PersistentConnection extends Disposable {
 	private _isReconnecting: boolean = false;
 	private _isDisposed: boolean = false;
 	private _reconnectionGraceTime: number = ProtocolConstants.ReconnectionGraceTime;
+	private _reconnectionToken: string;
+	/** Updated when we re-handshake against a replaced server with a fresh token. */
+	public get reconnectionToken(): string { return this._reconnectionToken; }
 
 	constructor(
 		private readonly _connectionType: ConnectionType,
 		protected readonly _options: IConnectionOptions,
-		public readonly reconnectionToken: string,
+		reconnectionToken: string,
 		public readonly protocol: PersistentProtocol,
 		private readonly _reconnectionFailureIsFatal: boolean
 	) {
 		super();
-
+		this._reconnectionToken = reconnectionToken;
 
 		this._onDidStateChange.fire(new ConnectionGainEvent(this.reconnectionToken, 0, 0));
 
@@ -643,7 +687,7 @@ export abstract class PersistentConnection extends Disposable {
 			// no more attempts!
 			return;
 		}
-		const logPrefix = commonLogPrefix(this._connectionType, this.reconnectionToken, true);
+		let logPrefix = commonLogPrefix(this._connectionType, this.reconnectionToken, true);
 		this._options.logService.info(`${logPrefix} starting reconnecting loop. You can get more information with the trace log level.`);
 		this._onDidStateChange.fire(new ConnectionLostEvent(this.reconnectionToken, this.protocol.getMillisSinceLastIncomingData()));
 		const TIMES = [0, 5, 5, 10, 10, 10, 10, 10, 30];
@@ -656,9 +700,15 @@ export abstract class PersistentConnection extends Disposable {
 		}
 		const loopStartTime = Date.now();
 		let attempt = -1;
+		// Bounded retry for stale-token recovery if the server gets replaced
+		// repeatedly within one loop (e.g. flapping).
+		let freshHandshakeAttempts = 0;
+		let nextAttemptIsFreshHandshake = false;
 		do {
 			attempt++;
 			const waitTime = (attempt < TIMES.length ? TIMES[attempt] : TIMES[TIMES.length - 1]);
+			const isFreshHandshakeThisAttempt = nextAttemptIsFreshHandshake;
+			nextAttemptIsFreshHandshake = false;
 			try {
 				if (waitTime > 0) {
 					const sleepPromise = sleep(waitTime);
@@ -678,7 +728,7 @@ export abstract class PersistentConnection extends Disposable {
 				// connection was lost, let's try to re-establish it
 				this._onDidStateChange.fire(new ReconnectionRunningEvent(this.reconnectionToken, this.protocol.getMillisSinceLastIncomingData(), attempt + 1));
 				this._options.logService.info(`${logPrefix} resolving connection...`);
-				const simpleOptions = await resolveConnectionOptions(this._options, this.reconnectionToken, this.protocol);
+				const simpleOptions = await resolveConnectionOptions(this._options, this.reconnectionToken, this.protocol, isFreshHandshakeThisAttempt);
 				this._options.logService.info(`${logPrefix} connecting to ${simpleOptions.connectTo}...`);
 				await this._reconnect(simpleOptions, createTimeoutCancellation(RECONNECT_TIMEOUT));
 				this._options.logService.info(`${logPrefix} reconnected!`);
@@ -687,6 +737,21 @@ export abstract class PersistentConnection extends Disposable {
 				break;
 			} catch (err) {
 				if (err.code === 'VSCODE_CONNECTION_ERROR') {
+					// Only Management recovers transparently. ExtHost takes the existing
+					// permanent-failure path which the workbench handles by restarting the host.
+					const isStaleToken = err.reasonCode === ConnectionRejectionReason.UnknownReconnectionTokenNeverSeen
+						|| err.reasonCode === ConnectionRejectionReason.UnknownReconnectionTokenSeenBefore;
+					if (this._connectionType === ConnectionType.Management && isStaleToken && freshHandshakeAttempts < MAX_FRESH_HANDSHAKE_ATTEMPTS && Date.now() - loopStartTime < graceTime) {
+						// Server has no record of our token, so it was replaced
+						// (typical after a long client sleep). Re-handshake fresh
+						// rather than failing the user to Reload Window.
+						freshHandshakeAttempts++;
+						this._options.logService.info(`${logPrefix} server reported stale reconnection token (attempt ${freshHandshakeAttempts}/${MAX_FRESH_HANDSHAKE_ATTEMPTS}); re-handshaking with a fresh token.`);
+						this._reconnectionToken = generateUuid();
+						logPrefix = commonLogPrefix(this._connectionType, this.reconnectionToken, true);
+						nextAttemptIsFreshHandshake = true;
+						continue;
+					}
 					this._options.logService.error(`${logPrefix} A permanent error occurred in the reconnecting loop! Will give up now! Error:`);
 					this._options.logService.error(err);
 					this._onReconnectionPermanentFailure(this.protocol.getMillisSinceLastIncomingData(), attempt + 1, false);
@@ -757,13 +822,26 @@ export class ManagementPersistentConnection extends PersistentConnection {
 
 	constructor(options: IConnectionOptions, remoteAuthority: string, clientId: string, reconnectionToken: string, protocol: PersistentProtocol) {
 		super(ConnectionType.Management, options, reconnectionToken, protocol, /*reconnectionFailureIsFatal*/true);
-		this.client = this._register(new Client<RemoteAgentConnectionContext>(protocol, {
-			remoteAuthority: remoteAuthority,
-			clientId: clientId
-		}, options.ipcLogger));
+		const context: RemoteAgentConnectionContext = { remoteAuthority, clientId };
+		const writer = new BufferWriter();
+		serialize(writer, context);
+		const serializedContext = writer.buffer;
+		this.client = this._register(new Client<RemoteAgentConnectionContext>(protocol, context, options.ipcLogger));
+
+		// On a stale-token recovery, the protocol's session state is wiped and the new server expects the IPC
+		// init context as msg #1. Re-queue it (and replay live event subscriptions) synchronously here while
+		// _isReconnecting is still true so they ride out with the next endAcceptReconnection replay.
+		this._register(protocol.onDidResetSession(() => {
+			protocol.send(serializedContext);
+			this.client.replayEventSubscriptions();
+		}));
 	}
 
 	protected async _reconnect(options: ISimpleConnectionOptions, timeoutCancellationToken: CancellationToken): Promise<void> {
+		if (options.isFreshHandshakeOnExistingProtocol) {
+			// Reject in-flight calls up front; the replaced server can't answer them.
+			this.client.cancelPendingCalls();
+		}
 		await doConnectRemoteAgentManagement(options, timeoutCancellationToken);
 	}
 }
@@ -797,12 +875,40 @@ function safeDisposeProtocolAndSocket(protocol: PersistentProtocol): void {
 
 function getErrorFromMessage(msg: any): Error | null {
 	if (msg && msg.type === 'error') {
-		const error = new Error(`Connection error: ${msg.reason}`);
+		const rawReason: string | undefined = msg.reason;
+		const reasonCode: ConnectionRejectionReason | undefined = msg.reasonCode ?? inferReasonCodeFromLegacyReason(rawReason);
+		const detail: string | undefined = msg.detail;
+		const baseReason = rawReason ?? (reasonCode ? describeConnectionRejection(reasonCode) : 'unknown');
+		const reason = detail ? `${baseReason}: ${detail}` : baseReason;
+		const error = new Error(`Connection error: ${reason}`);
 		// eslint-disable-next-line local/code-no-any-casts
 		(<any>error).code = 'VSCODE_CONNECTION_ERROR';
+		// eslint-disable-next-line local/code-no-any-casts
+		(<any>error).reasonCode = reasonCode;
 		return error;
 	}
 	return null;
+}
+
+/**
+ * Best-effort map from a legacy `reason: string` to a {@link ConnectionRejectionReason}
+ * when talking to an older/forked server that doesn't populate {@link ErrorMessage.reasonCode}.
+ * Only covers the codes that recovery logic acts on; everything else stays undefined.
+ */
+function inferReasonCodeFromLegacyReason(reason: string | undefined): ConnectionRejectionReason | undefined {
+	if (!reason) {
+		return undefined;
+	}
+	if (reason.indexOf('Unknown reconnection token (never seen)') !== -1) {
+		return ConnectionRejectionReason.UnknownReconnectionTokenNeverSeen;
+	}
+	if (reason.indexOf('Unknown reconnection token (seen before)') !== -1) {
+		return ConnectionRejectionReason.UnknownReconnectionTokenSeenBefore;
+	}
+	if (reason.indexOf('Duplicate reconnection token') !== -1) {
+		return ConnectionRejectionReason.DuplicateReconnectionToken;
+	}
+	return undefined;
 }
 
 function sanitizeGraceTime(candidate: number, fallback: number): number {

--- a/src/vs/platform/remote/common/remoteAgentConnection.ts
+++ b/src/vs/platform/remote/common/remoteAgentConnection.ts
@@ -13,7 +13,7 @@ import { RemoteAuthorities } from '../../../base/common/network.js';
 import * as performance from '../../../base/common/performance.js';
 import { StopWatch } from '../../../base/common/stopwatch.js';
 import { generateUuid } from '../../../base/common/uuid.js';
-import { BufferWriter, IIPCLogger, serialize } from '../../../base/parts/ipc/common/ipc.js';
+import { IIPCLogger } from '../../../base/parts/ipc/common/ipc.js';
 import { Client, ISocket, PersistentProtocol, ProtocolConstants, SocketCloseEventType } from '../../../base/parts/ipc/common/ipc.net.js';
 import { ILogService } from '../../log/common/log.js';
 import { RemoteAgentConnectionContext } from './remoteAgentEnvironment.js';
@@ -703,12 +703,12 @@ export abstract class PersistentConnection extends Disposable {
 		// Bounded retry for stale-token recovery if the server gets replaced
 		// repeatedly within one loop (e.g. flapping).
 		let freshHandshakeAttempts = 0;
-		let nextAttemptIsFreshHandshake = false;
+		// Sticky once the server is detected as replaced: keep re-handshaking with reconnection=false.
+		// Reverting to reconnection=true would just be rejected again and could replay a half-reset session.
+		let useFreshHandshake = false;
 		do {
 			attempt++;
 			const waitTime = (attempt < TIMES.length ? TIMES[attempt] : TIMES[TIMES.length - 1]);
-			const isFreshHandshakeThisAttempt = nextAttemptIsFreshHandshake;
-			nextAttemptIsFreshHandshake = false;
 			try {
 				if (waitTime > 0) {
 					const sleepPromise = sleep(waitTime);
@@ -728,7 +728,7 @@ export abstract class PersistentConnection extends Disposable {
 				// connection was lost, let's try to re-establish it
 				this._onDidStateChange.fire(new ReconnectionRunningEvent(this.reconnectionToken, this.protocol.getMillisSinceLastIncomingData(), attempt + 1));
 				this._options.logService.info(`${logPrefix} resolving connection...`);
-				const simpleOptions = await resolveConnectionOptions(this._options, this.reconnectionToken, this.protocol, isFreshHandshakeThisAttempt);
+				const simpleOptions = await resolveConnectionOptions(this._options, this.reconnectionToken, this.protocol, useFreshHandshake);
 				this._options.logService.info(`${logPrefix} connecting to ${simpleOptions.connectTo}...`);
 				await this._reconnect(simpleOptions, createTimeoutCancellation(RECONNECT_TIMEOUT));
 				this._options.logService.info(`${logPrefix} reconnected!`);
@@ -749,7 +749,7 @@ export abstract class PersistentConnection extends Disposable {
 						this._options.logService.info(`${logPrefix} server reported stale reconnection token (attempt ${freshHandshakeAttempts}/${MAX_FRESH_HANDSHAKE_ATTEMPTS}); re-handshaking with a fresh token.`);
 						this._reconnectionToken = generateUuid();
 						logPrefix = commonLogPrefix(this._connectionType, this.reconnectionToken, true);
-						nextAttemptIsFreshHandshake = true;
+						useFreshHandshake = true;
 						continue;
 					}
 					this._options.logService.error(`${logPrefix} A permanent error occurred in the reconnecting loop! Will give up now! Error:`);
@@ -822,19 +822,12 @@ export class ManagementPersistentConnection extends PersistentConnection {
 
 	constructor(options: IConnectionOptions, remoteAuthority: string, clientId: string, reconnectionToken: string, protocol: PersistentProtocol) {
 		super(ConnectionType.Management, options, reconnectionToken, protocol, /*reconnectionFailureIsFatal*/true);
-		const context: RemoteAgentConnectionContext = { remoteAuthority, clientId };
-		const writer = new BufferWriter();
-		serialize(writer, context);
-		const serializedContext = writer.buffer;
-		this.client = this._register(new Client<RemoteAgentConnectionContext>(protocol, context, options.ipcLogger));
+		this.client = this._register(new Client<RemoteAgentConnectionContext>(protocol, { remoteAuthority, clientId }, options.ipcLogger));
 
-		// On a stale-token recovery, the protocol's session state is wiped and the new server expects the IPC
-		// init context as msg #1. Re-queue it (and replay live event subscriptions) synchronously here while
-		// _isReconnecting is still true so they ride out with the next endAcceptReconnection replay.
-		this._register(protocol.onDidResetSession(() => {
-			protocol.send(serializedContext);
-			this.client.replayEventSubscriptions();
-		}));
+		// On a stale-token recovery the protocol session is wiped and the new server expects the init
+		// context as msg #1; do it (and replay subscriptions) synchronously while _isReconnecting so they
+		// replay in order on the next endAcceptReconnection.
+		this._register(protocol.onDidResetSession(() => this.client.resendInitialContextAndReplay()));
 	}
 
 	protected async _reconnect(options: ISimpleConnectionOptions, timeoutCancellationToken: CancellationToken): Promise<void> {

--- a/src/vs/platform/remote/common/remoteAgentConnection.ts
+++ b/src/vs/platform/remote/common/remoteAgentConnection.ts
@@ -63,12 +63,10 @@ export interface ConnectionTypeRequest {
 
 export interface ErrorMessage {
 	type: 'error';
-	/** Human-readable diagnostic. Always populated for backward compatibility with older/forked clients. */
+	/** Human-readable diagnostic (description plus any detail). Always populated for older/forked clients. */
 	reason: string;
 	/** Stable machine-readable code. Newer servers always populate this; control flow (e.g. recovery decisions) matches on it. */
 	reasonCode?: ConnectionRejectionReason;
-	/** Optional runtime context appended to the code's default description. */
-	detail?: string;
 }
 
 /** Stable machine-readable rejection codes. Values must remain unchanged. */
@@ -827,7 +825,7 @@ export class ManagementPersistentConnection extends PersistentConnection {
 		// On a stale-token recovery the protocol session is wiped and the new server expects the init
 		// context as msg #1; do it (and replay subscriptions) synchronously while _isReconnecting so they
 		// replay in order on the next endAcceptReconnection.
-		this._register(protocol.onDidResetSession(() => this.client.resendInitialContextAndReplay()));
+		this._register(protocol.onDidResetSession(() => this.client.reinitialize()));
 	}
 
 	protected async _reconnect(options: ISimpleConnectionOptions, timeoutCancellationToken: CancellationToken): Promise<void> {
@@ -868,11 +866,8 @@ function safeDisposeProtocolAndSocket(protocol: PersistentProtocol): void {
 
 function getErrorFromMessage(msg: any): Error | null {
 	if (msg && msg.type === 'error') {
-		const rawReason: string | undefined = msg.reason;
-		const reasonCode: ConnectionRejectionReason | undefined = msg.reasonCode ?? inferReasonCodeFromLegacyReason(rawReason);
-		const detail: string | undefined = msg.detail;
-		const baseReason = rawReason ?? (reasonCode ? describeConnectionRejection(reasonCode) : 'unknown');
-		const reason = detail ? `${baseReason}: ${detail}` : baseReason;
+		const reasonCode: ConnectionRejectionReason | undefined = msg.reasonCode ?? inferReasonCodeFromLegacyReason(msg.reason);
+		const reason: string = msg.reason ?? (reasonCode ? describeConnectionRejection(reasonCode) : 'unknown');
 		const error = new Error(`Connection error: ${reason}`);
 		// eslint-disable-next-line local/code-no-any-casts
 		(<any>error).code = 'VSCODE_CONNECTION_ERROR';
@@ -887,6 +882,9 @@ function getErrorFromMessage(msg: any): Error | null {
  * Best-effort map from a legacy `reason: string` to a {@link ConnectionRejectionReason}
  * when talking to an older/forked server that doesn't populate {@link ErrorMessage.reasonCode}.
  * Only covers the codes that recovery logic acts on; everything else stays undefined.
+ *
+ * The literals below are the fixed strings older servers send; do not replace them with
+ * describeConnectionRejection, whose wording can change.
  */
 function inferReasonCodeFromLegacyReason(reason: string | undefined): ConnectionRejectionReason | undefined {
 	if (!reason) {

--- a/src/vs/platform/remote/common/remoteAgentConnection.ts
+++ b/src/vs/platform/remote/common/remoteAgentConnection.ts
@@ -65,7 +65,7 @@ export interface ErrorMessage {
 	type: 'error';
 	/** Human-readable diagnostic (description plus any detail). Always populated for older/forked clients. */
 	reason: string;
-	/** Stable machine-readable code. Newer servers always populate this; control flow (e.g. recovery decisions) matches on it. */
+	/** Stable machine-readable code. Newer servers populate this on connection rejections and recovery control flow matches on it; other error paths (e.g. tunnel connect failures) carry only `reason`. */
 	reasonCode?: ConnectionRejectionReason;
 }
 
@@ -823,16 +823,19 @@ export class ManagementPersistentConnection extends PersistentConnection {
 		this.client = this._register(new Client<RemoteAgentConnectionContext>(protocol, { remoteAuthority, clientId }, options.ipcLogger));
 
 		// On a stale-token recovery the protocol session is wiped and the new server expects the init
-		// context as msg #1; do it (and replay subscriptions) synchronously while _isReconnecting so they
-		// replay in order on the next endAcceptReconnection.
-		this._register(protocol.onDidResetSession(() => this.client.reinitialize()));
+		// context as msg #1; replay it (and the event subscriptions) synchronously while _isReconnecting so
+		// they ride the next endAcceptReconnection ahead of any concurrent sends. Pending calls are rejected
+		// here, at reset time, rather than earlier in the reconnect loop: that also covers calls made while
+		// the fresh socket was being established, which the reset would otherwise silently discard, leaving
+		// their promises hanging forever. Rejecting after reinitialize() keeps the init context as msg #1;
+		// the rejections' PromiseCancel messages queue behind it and the new server ignores their unknown ids.
+		this._register(protocol.onDidResetSession(() => {
+			this.client.reinitialize();
+			this.client.cancelPendingCalls();
+		}));
 	}
 
 	protected async _reconnect(options: ISimpleConnectionOptions, timeoutCancellationToken: CancellationToken): Promise<void> {
-		if (options.isFreshHandshakeOnExistingProtocol) {
-			// Reject in-flight calls up front; the replaced server can't answer them.
-			this.client.cancelPendingCalls();
-		}
 		await doConnectRemoteAgentManagement(options, timeoutCancellationToken);
 	}
 }
@@ -867,7 +870,7 @@ function safeDisposeProtocolAndSocket(protocol: PersistentProtocol): void {
 function getErrorFromMessage(msg: any): Error | null {
 	if (msg && msg.type === 'error') {
 		const reasonCode: ConnectionRejectionReason | undefined = msg.reasonCode ?? inferReasonCodeFromLegacyReason(msg.reason);
-		const reason: string = msg.reason ?? (reasonCode ? describeConnectionRejection(reasonCode) : 'unknown');
+		const reason: string = msg.reason ?? 'unknown';
 		const error = new Error(`Connection error: ${reason}`);
 		// eslint-disable-next-line local/code-no-any-casts
 		(<any>error).code = 'VSCODE_CONNECTION_ERROR';

--- a/src/vs/server/node/remoteExtensionHostAgentServer.ts
+++ b/src/vs/server/node/remoteExtensionHostAgentServer.ts
@@ -30,7 +30,7 @@ import { IConfigurationService } from '../../platform/configuration/common/confi
 import { IInstantiationService } from '../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../platform/log/common/log.js';
 import { IProductService } from '../../platform/product/common/productService.js';
-import { ConnectionType, ConnectionTypeRequest, ErrorMessage, HandshakeMessage, IRemoteExtensionHostStartParams, ITunnelConnectionStartParams, OKMessage, SignRequest } from '../../platform/remote/common/remoteAgentConnection.js';
+import { ConnectionRejectionReason, ConnectionType, ConnectionTypeRequest, describeConnectionRejection, ErrorMessage, HandshakeMessage, IRemoteExtensionHostStartParams, ITunnelConnectionStartParams, OKMessage, SignRequest } from '../../platform/remote/common/remoteAgentConnection.js';
 import { RemoteAgentConnectionContext } from '../../platform/remote/common/remoteAgentEnvironment.js';
 import { ITelemetryService } from '../../platform/telemetry/common/telemetry.js';
 import { ExtensionHostConnection } from './extensionHostConnection.js';
@@ -237,12 +237,15 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 		return _socket.remoteAddress || `<unknown>`;
 	}
 
-	private async _rejectWebSocketConnection(logPrefix: string, protocol: PersistentProtocol, reason: string): Promise<void> {
+	private async _rejectWebSocketConnection(logPrefix: string, protocol: PersistentProtocol, reasonCode: ConnectionRejectionReason, detail?: string): Promise<void> {
 		const socket = protocol.getSocket();
-		this._logService.error(`${logPrefix} ${reason}.`);
+		const reason = describeConnectionRejection(reasonCode);
+		this._logService.error(`${logPrefix} ${detail ? `${reason}: ${detail}` : reason}.`);
 		const errMessage: ErrorMessage = {
 			type: 'error',
-			reason: reason
+			reason: reason,
+			reasonCode: reasonCode,
+			detail: detail
 		};
 		protocol.sendControl(VSBuffer.fromString(JSON.stringify(errMessage)));
 		protocol.dispose();
@@ -271,10 +274,10 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 		}
 		let state = State.WaitingForAuth;
 
-		const rejectWebSocketConnection = (msg: string) => {
+		const rejectWebSocketConnection = (code: ConnectionRejectionReason, detail?: string) => {
 			state = State.Error;
 			listener.dispose();
-			this._rejectWebSocketConnection(logPrefix, protocol, msg);
+			this._rejectWebSocketConnection(logPrefix, protocol, code, detail);
 		};
 
 		const listener = protocol.onControlMessage((raw) => {
@@ -283,14 +286,14 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 				try {
 					msg1 = <HandshakeMessage>JSON.parse(raw.toString());
 				} catch (err) {
-					return rejectWebSocketConnection(`Malformed first message`);
+					return rejectWebSocketConnection(ConnectionRejectionReason.HandshakeMalformed, 'auth');
 				}
 				if (msg1.type !== 'auth') {
-					return rejectWebSocketConnection(`Invalid first message`);
+					return rejectWebSocketConnection(ConnectionRejectionReason.HandshakeInvalid, 'auth');
 				}
 
 				if (this._connectionToken.type === ServerConnectionTokenType.Mandatory && !this._connectionToken.validate(msg1.auth)) {
-					return rejectWebSocketConnection(`Unauthorized client refused: auth mismatch`);
+					return rejectWebSocketConnection(ConnectionRejectionReason.AuthRefused, 'auth mismatch');
 				}
 
 				// Send `sign` request
@@ -323,13 +326,13 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 				try {
 					msg2 = <HandshakeMessage>JSON.parse(raw.toString());
 				} catch (err) {
-					return rejectWebSocketConnection(`Malformed second message`);
+					return rejectWebSocketConnection(ConnectionRejectionReason.HandshakeMalformed, 'connectionType');
 				}
 				if (msg2.type !== 'connectionType') {
-					return rejectWebSocketConnection(`Invalid second message`);
+					return rejectWebSocketConnection(ConnectionRejectionReason.HandshakeInvalid, 'connectionType');
 				}
 				if (typeof msg2.signedData !== 'string') {
-					return rejectWebSocketConnection(`Invalid second message field type`);
+					return rejectWebSocketConnection(ConnectionRejectionReason.HandshakeInvalid, 'connectionType field type');
 				}
 
 				const rendererCommit = msg2.commit;
@@ -337,7 +340,7 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 				if (rendererCommit && myCommit) {
 					// Running in the built version where commits are defined
 					if (rendererCommit !== myCommit) {
-						return rejectWebSocketConnection(`Client refused: version mismatch`);
+						return rejectWebSocketConnection(ConnectionRejectionReason.VersionMismatch);
 					}
 				}
 
@@ -356,7 +359,7 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 
 				if (!valid) {
 					if (this._environmentService.isBuilt) {
-						return rejectWebSocketConnection(`Unauthorized client refused`);
+						return rejectWebSocketConnection(ConnectionRejectionReason.AuthRefused);
 					} else {
 						this._logService.error(`${logPrefix} Unauthorized client handshake failed but we proceed because of dev mode.`);
 					}
@@ -401,10 +404,10 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 				if (!this._managementConnections[reconnectionToken]) {
 					if (!this._allReconnectionTokens.has(reconnectionToken)) {
 						// This is an unknown reconnection token
-						return this._rejectWebSocketConnection(logPrefix, protocol, `Unknown reconnection token (never seen)`);
+						return this._rejectWebSocketConnection(logPrefix, protocol, ConnectionRejectionReason.UnknownReconnectionTokenNeverSeen);
 					} else {
 						// This is a connection that was seen in the past, but is no longer valid
-						return this._rejectWebSocketConnection(logPrefix, protocol, `Unknown reconnection token (seen before)`);
+						return this._rejectWebSocketConnection(logPrefix, protocol, ConnectionRejectionReason.UnknownReconnectionTokenSeenBefore);
 					}
 				}
 
@@ -417,7 +420,7 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 				// This is a fresh connection
 				if (this._managementConnections[reconnectionToken]) {
 					// Cannot have two concurrent connections using the same reconnection token
-					return this._rejectWebSocketConnection(logPrefix, protocol, `Duplicate reconnection token`);
+					return this._rejectWebSocketConnection(logPrefix, protocol, ConnectionRejectionReason.DuplicateReconnectionToken);
 				}
 
 				protocol.sendControl(VSBuffer.fromString(JSON.stringify({ type: 'ok' })));
@@ -448,10 +451,10 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 				if (!this._extHostConnections[reconnectionToken]) {
 					if (!this._allReconnectionTokens.has(reconnectionToken)) {
 						// This is an unknown reconnection token
-						return this._rejectWebSocketConnection(logPrefix, protocol, `Unknown reconnection token (never seen)`);
+						return this._rejectWebSocketConnection(logPrefix, protocol, ConnectionRejectionReason.UnknownReconnectionTokenNeverSeen);
 					} else {
 						// This is a connection that was seen in the past, but is no longer valid
-						return this._rejectWebSocketConnection(logPrefix, protocol, `Unknown reconnection token (seen before)`);
+						return this._rejectWebSocketConnection(logPrefix, protocol, ConnectionRejectionReason.UnknownReconnectionTokenSeenBefore);
 					}
 				}
 
@@ -465,7 +468,7 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 				// This is a fresh connection
 				if (this._extHostConnections[reconnectionToken]) {
 					// Cannot have two concurrent connections using the same reconnection token
-					return this._rejectWebSocketConnection(logPrefix, protocol, `Duplicate reconnection token`);
+					return this._rejectWebSocketConnection(logPrefix, protocol, ConnectionRejectionReason.DuplicateReconnectionToken);
 				}
 
 				protocol.sendPause();
@@ -496,7 +499,7 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 
 		} else {
 
-			return this._rejectWebSocketConnection(logPrefix, protocol, `Unknown initial data received`);
+			return this._rejectWebSocketConnection(logPrefix, protocol, ConnectionRejectionReason.UnknownInitialData);
 
 		}
 	}

--- a/src/vs/server/node/remoteExtensionHostAgentServer.ts
+++ b/src/vs/server/node/remoteExtensionHostAgentServer.ts
@@ -239,13 +239,13 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 
 	private async _rejectWebSocketConnection(logPrefix: string, protocol: PersistentProtocol, reasonCode: ConnectionRejectionReason, detail?: string): Promise<void> {
 		const socket = protocol.getSocket();
-		const reason = describeConnectionRejection(reasonCode);
-		this._logService.error(`${logPrefix} ${detail ? `${reason}: ${detail}` : reason}.`);
+		const description = describeConnectionRejection(reasonCode);
+		const reason = detail ? `${description}: ${detail}` : description;
+		this._logService.error(`${logPrefix} ${reason}.`);
 		const errMessage: ErrorMessage = {
 			type: 'error',
 			reason: reason,
-			reasonCode: reasonCode,
-			detail: detail
+			reasonCode: reasonCode
 		};
 		protocol.sendControl(VSBuffer.fromString(JSON.stringify(errMessage)));
 		protocol.dispose();

--- a/src/vs/workbench/contrib/remote/browser/remote.ts
+++ b/src/vs/workbench/contrib/remote/browser/remote.ts
@@ -845,6 +845,8 @@ export class RemoteAgentConnectionStatusListener extends Disposable implements I
 			let reconnectionToken: string = '';
 			let lastIncomingDataTime: number = 0;
 			let reconnectionAttempts: number = 0;
+			// Stable across reconnect-loop token rotations; a change at the next ConnectionGain means stale-token recovery.
+			let reconnectionTokenAtLoss: string = '';
 
 			const reconnectButton = {
 				label: nls.localize('reconnectNow', "Reconnect Now"),
@@ -895,6 +897,7 @@ export class RemoteAgentConnectionStatusListener extends Disposable implements I
 				switch (e.type) {
 					case PersistentConnectionEventType.ConnectionLost:
 						reconnectionToken = e.reconnectionToken;
+						reconnectionTokenAtLoss = e.reconnectionToken;
 						lastIncomingDataTime = Date.now() - e.millisSinceLastIncomingData;
 						reconnectionAttempts = 0;
 
@@ -1017,10 +1020,15 @@ export class RemoteAgentConnectionStatusListener extends Disposable implements I
 						}
 						break;
 
-					case PersistentConnectionEventType.ConnectionGain:
+					case PersistentConnectionEventType.ConnectionGain: {
+						const wasReplaced = !!reconnectionTokenAtLoss && reconnectionTokenAtLoss !== e.reconnectionToken;
+						reconnectionTokenAtLoss = '';
 						reconnectionToken = e.reconnectionToken;
 						lastIncomingDataTime = Date.now() - e.millisSinceLastIncomingData;
 						reconnectionAttempts = e.attempt;
+						if (wasReplaced) {
+							logService.warn(`Reconnected to a replaced remote server; previous server-side session state is gone.`);
+						}
 
 						type RemoteConnectionGainClassification = {
 							owner: 'alexdima';
@@ -1029,22 +1037,26 @@ export class RemoteAgentConnectionStatusListener extends Disposable implements I
 							reconnectionToken: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The identifier of the connection.' };
 							millisSinceLastIncomingData: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Elapsed time (in ms) since data was last received.' };
 							attempt: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The reconnection attempt counter.' };
+							wasReplaced: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Whether the remote server was replaced (stale-token recovery).' };
 						};
 						type RemoteConnectionGainEvent = {
 							remoteName: string | undefined;
 							reconnectionToken: string;
 							millisSinceLastIncomingData: number;
 							attempt: number;
+							wasReplaced: boolean;
 						};
 						telemetryService.publicLog2<RemoteConnectionGainEvent, RemoteConnectionGainClassification>('remoteConnectionGain', {
 							remoteName: getRemoteName(environmentService.remoteAuthority),
 							reconnectionToken: e.reconnectionToken,
 							millisSinceLastIncomingData: e.millisSinceLastIncomingData,
-							attempt: e.attempt
+							attempt: e.attempt,
+							wasReplaced
 						});
 
 						hideProgress();
 						break;
+					}
 				}
 			}));
 		}

--- a/src/vs/workbench/contrib/remote/browser/remote.ts
+++ b/src/vs/workbench/contrib/remote/browser/remote.ts
@@ -1027,7 +1027,7 @@ export class RemoteAgentConnectionStatusListener extends Disposable implements I
 						lastIncomingDataTime = Date.now() - e.millisSinceLastIncomingData;
 						reconnectionAttempts = e.attempt;
 						if (wasReplaced) {
-							logService.warn(`Reconnected to a replaced remote server; previous server-side session state is gone.`);
+							logService.warn('Reconnected to a replaced remote server; previous server-side session state is gone.');
 						}
 
 						type RemoteConnectionGainClassification = {


### PR DESCRIPTION
Follow-up to #310131 ([evidence & rationale](https://github.com/microsoft/vscode/pull/310131#issuecomment-4508229968)).

After a long client sleep with `--enable-remote-auto-shutdown`, the remote server is replaced and the management reconnect is rejected with `Unknown reconnection token (never seen)`, falling through to a Reload Window prompt. This recovers it transparently.

### What changes

- **Reject shape (additive).** `ErrorMessage` keeps `reason: string` and adds optional `reasonCode: ConnectionRejectionReason`. Control flow matches on `reasonCode`, falling back to parsing the legacy `reason` for older servers; `detail` is folded into `reason`.
- **Fresh handshake.** On an unknown-token rejection, `ManagementPersistentConnection` rotates its token, resets the `PersistentProtocol` session (clears ack timeouts, zeroes message counters, rebaselines the incoming-data time), and re-handshakes against the new server. Bounded by 3 attempts and the existing grace time.
- **Session replay.** `PersistentProtocol.onDidResetSession` fires from the reset; the client re-establishes its session in order via `reinitialize()`: IPC context (`msg #1`), `ChannelServer` Initialize (so the new server can call back), then `EventListen` for each live subscription with preserved ids. These ride the next `endAcceptReconnection` replay, ahead of any concurrent call.
- **In-flight calls.** `cancelPendingCalls` rejects pending promises (each clears its own handler); event subscriptions survive locally and are re-registered by the replay.
- **Detection.** A token snapshot on `ConnectionLost` compared on `ConnectionGain` surfaces a `wasReplaced` telemetry field and a warning log.

### Scope

Management only. Extension Host keeps the existing permanent-failure path; the workbench restarts the host on `onDidDispose` (a brief "extensions reloading" blip). Transparent ExtHost recovery is tracked in #317980.

### Known trade-offs

- Not instant: the first fresh handshake rides the normal backoff (~5s) to avoid hammering a server that may still be coming up.
- Older/forked server recovery relies on exact `reason` matching in `inferReasonCodeFromLegacyReason` (newer servers always send `reasonCode`).
- Stale server→client subscriptions from the old server aren't torn down, so they fire into ignored responses until disposed; server→client calls themselves work via the re-sent Initialize.
