### PR TITLE
Allow sending chat requests with attachments only

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/newChatInput.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInput.ts
@@ -48,7 +48,7 @@ import { SlashCommandHandler } from './slashCommands.js';
 import { VariableCompletionHandler } from './variableCompletions.js';
 import { AgentHostInputCompletionHandler } from './agentHostInputCompletions.js';
 import { IChatModelInputState } from '../../../../workbench/contrib/chat/common/model/chatModel.js';
-import { IChatRequestVariableEntry, isExplicitFileOrImageVariableEntry } from '../../../../workbench/contrib/chat/common/attachments/chatVariableEntries.js';
+import { getExplicitFileOrImageAttachmentSummary, IChatRequestVariableEntry, isExplicitFileOrImageVariableEntry } from '../../../../workbench/contrib/chat/common/attachments/chatVariableEntries.js';
 import { ChatAgentLocation, ChatModeKind } from '../../../../workbench/contrib/chat/common/constants.js';
 import { ChatHistoryNavigator } from '../../../../workbench/contrib/chat/common/widget/chatWidgetHistoryService.js';
 import { IHistoryNavigationWidget } from '../../../../base/browser/history.js';
@@ -544,6 +544,7 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 		const attachedContext = this._contextAttachments.attachments.length > 0
 			? [...this._contextAttachments.attachments]
 			: undefined;
+		const request = query || getExplicitFileOrImageAttachmentSummary(attachedContext ?? []) || '';
 
 		if (this._draftState) {
 			this._history.append(this._toHistoryEntry(this._draftState));
@@ -556,7 +557,7 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 		this._updateInputLoadingState();
 
 		try {
-			await this.options.sendRequest(query, attachedContext);
+			await this.options.sendRequest(request, attachedContext);
 			this._contextAttachments.clear();
 			this._editor.getModel()?.setValue('');
 		} catch (e) {

--- a/src/vs/sessions/contrib/chat/browser/newChatInput.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInput.ts
@@ -48,7 +48,7 @@ import { SlashCommandHandler } from './slashCommands.js';
 import { VariableCompletionHandler } from './variableCompletions.js';
 import { AgentHostInputCompletionHandler } from './agentHostInputCompletions.js';
 import { IChatModelInputState } from '../../../../workbench/contrib/chat/common/model/chatModel.js';
-import { IChatRequestVariableEntry } from '../../../../workbench/contrib/chat/common/attachments/chatVariableEntries.js';
+import { IChatRequestVariableEntry, isExplicitFileOrImageVariableEntry } from '../../../../workbench/contrib/chat/common/attachments/chatVariableEntries.js';
 import { ChatAgentLocation, ChatModeKind } from '../../../../workbench/contrib/chat/common/constants.js';
 import { ChatHistoryNavigator } from '../../../../workbench/contrib/chat/common/widget/chatWidgetHistoryService.js';
 import { IHistoryNavigationWidget } from '../../../../base/browser/history.js';
@@ -177,6 +177,7 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 		this.sessionTypePicker = this._register(this.instantiationService.createInstance(MobileSessionTypePicker));
 		this._register(this._contextAttachments.onDidChangeContext(() => {
 			this._updateDraftState();
+			this._updateSendButtonState();
 			this.focus();
 		}));
 		this._register(autorun(reader => {
@@ -528,13 +529,14 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 
 
 	private async _send(): Promise<void> {
-		const query = this._editor.getModel()?.getValue().trim();
-		if (!query || this._sending) {
+		const query = this._editor.getModel()?.getValue().trim() ?? '';
+		const hasSendableAttachment = this._contextAttachments.attachments.some(isExplicitFileOrImageVariableEntry);
+		if ((!query && !hasSendableAttachment) || this._sending) {
 			return;
 		}
 
 		// Check for slash commands first
-		if (this._slashCommandHandler?.tryExecuteSlashCommand(query)) {
+		if (query && this._slashCommandHandler?.tryExecuteSlashCommand(query)) {
 			this._editor.getModel()?.setValue('');
 			return;
 		}
@@ -572,7 +574,8 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 			return;
 		}
 		const hasText = !!this._editor?.getModel()?.getValue().trim();
-		this._sendButton.enabled = !this._sending && hasText && this.options.canSendRequest.get();
+		const hasSendableAttachment = this._contextAttachments.attachments.some(isExplicitFileOrImageVariableEntry);
+		this._sendButton.enabled = !this._sending && (hasText || hasSendableAttachment) && this.options.canSendRequest.get();
 	}
 
 	private _restoreState(): void {

--- a/src/vs/sessions/contrib/chat/browser/newChatInput.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInput.ts
@@ -48,7 +48,7 @@ import { SlashCommandHandler } from './slashCommands.js';
 import { VariableCompletionHandler } from './variableCompletions.js';
 import { AgentHostInputCompletionHandler } from './agentHostInputCompletions.js';
 import { IChatModelInputState } from '../../../../workbench/contrib/chat/common/model/chatModel.js';
-import { getExplicitFileOrImageAttachmentSummary, IChatRequestVariableEntry, isExplicitFileOrImageVariableEntry } from '../../../../workbench/contrib/chat/common/attachments/chatVariableEntries.js';
+import { IChatRequestVariableEntry, isExplicitFileOrImageVariableEntry } from '../../../../workbench/contrib/chat/common/attachments/chatVariableEntries.js';
 import { ChatAgentLocation, ChatModeKind } from '../../../../workbench/contrib/chat/common/constants.js';
 import { ChatHistoryNavigator } from '../../../../workbench/contrib/chat/common/widget/chatWidgetHistoryService.js';
 import { IHistoryNavigationWidget } from '../../../../base/browser/history.js';
@@ -544,7 +544,7 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 		const attachedContext = this._contextAttachments.attachments.length > 0
 			? [...this._contextAttachments.attachments]
 			: undefined;
-		const request = query || getExplicitFileOrImageAttachmentSummary(attachedContext ?? []) || '';
+		const request = query;
 
 		if (this._draftState) {
 			this._history.append(this._toHistoryEntry(this._draftState));

--- a/src/vs/workbench/contrib/chat/browser/accessibility/chatAccessibilityProvider.ts
+++ b/src/vs/workbench/contrib/chat/browser/accessibility/chatAccessibilityProvider.ts
@@ -14,6 +14,7 @@ import { IInstantiationService, ServicesAccessor } from '../../../../../platform
 import { IKeybindingService } from '../../../../../platform/keybinding/common/keybinding.js';
 import { AccessibilityVerbositySettingId } from '../../../accessibility/browser/accessibilityConfiguration.js';
 import { migrateLegacyTerminalToolSpecificData } from '../../common/chat.js';
+import { getExplicitFileOrImageAttachmentSummary } from '../../common/attachments/chatVariableEntries.js';
 import { IChatToolInvocation } from '../../common/chatService/chatService.js';
 import { IChatResponseViewModel, isRequestVM, isResponseVM } from '../../common/model/chatViewModel.js';
 import { isToolResultInputOutputDetails, isToolResultOutputDetails, toolContentToA11yString } from '../../common/tools/languageModelToolsService.js';
@@ -98,7 +99,7 @@ export class ChatAccessibilityProvider implements IListAccessibilityProvider<Cha
 
 	getAriaLabel(element: ChatTreeItem): string {
 		if (isRequestVM(element)) {
-			return element.messageText;
+			return element.messageText.trim() || getExplicitFileOrImageAttachmentSummary(element.variables) || '';
 		}
 
 		if (isResponseVM(element)) {

--- a/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
@@ -190,7 +190,7 @@ export class ChatSubmitAction extends SubmitAction {
 	constructor() {
 		const menuCondition = ChatContextKeys.chatModeKind.isEqualTo(ChatModeKind.Ask);
 		const precondition = ContextKeyExpr.and(
-			ChatContextKeys.inputHasText,
+			ChatContextKeys.inputHasSendableContent,
 			ContextKeyExpr.or(whenNotInProgress, ChatContextKeys.editingRequestType.isEqualTo(ChatContextKeys.EditingRequestType.Sent)),
 			ChatContextKeys.chatSessionOptionsValid,
 		);
@@ -762,7 +762,7 @@ export class ChatEditingSessionSubmitAction extends SubmitAction {
 
 		const menuCondition = ChatContextKeys.chatModeKind.notEqualsTo(ChatModeKind.Ask);
 		const precondition = ContextKeyExpr.and(
-			ChatContextKeys.inputHasText,
+			ChatContextKeys.inputHasSendableContent,
 			notInProgressOrEditing,
 			ChatContextKeys.chatSessionOptionsValid
 		);

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -56,7 +56,7 @@ import { ChatPlanReviewData } from '../../common/model/chatProgressTypes/chatPla
 import { ChatQuestionCarouselData } from '../../common/model/chatProgressTypes/chatQuestionCarouselData.js';
 import { localChatSessionType } from '../../common/chatSessionsService.js';
 import { getChatSessionType } from '../../common/model/chatUri.js';
-import { IChatRequestVariableEntry } from '../../common/attachments/chatVariableEntries.js';
+import { getExplicitFileOrImageAttachmentSummary, IChatRequestVariableEntry } from '../../common/attachments/chatVariableEntries.js';
 import { IChatChangesSummaryPart, IChatCodeCitations, IChatErrorDetailsPart, IChatReferences, IChatRendererContent, IChatRequestViewModel, IChatResponseViewModel, IChatViewModel, IChatWorkingProgress, isRequestVM, isResponseVM, IChatPendingDividerViewModel, isPendingDividerVM } from '../../common/model/chatViewModel.js';
 import { getNWords } from '../../common/model/chatWordCounter.js';
 import { ChatAgentLocation, ChatConfiguration, ChatModeKind, CollapsedToolsDisplayMode, ThinkingDisplayMode } from '../../common/constants.js';
@@ -1407,7 +1407,11 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			const markdown = isChatFollowup(element.message) ?
 				element.message.message :
 				this.markdownDecorationsRenderer.convertParsedRequestToMarkdown(element.sessionResource, element.message);
-			content = [{ content: new MarkdownString(markdown), kind: 'markdownContent' }];
+			const attachmentSummary = !element.messageText.trim() ? getExplicitFileOrImageAttachmentSummary(element.variables) : undefined;
+			const requestMarkdown = markdown.trim() ? markdown : attachmentSummary;
+			if (requestMarkdown) {
+				content = [{ content: new MarkdownString(requestMarkdown), kind: 'markdownContent' }];
+			}
 
 			if (this.rendererOptions.renderStyle === 'minimal' && !element.isComplete) {
 				templateData.value.classList.add('inline-progress');

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -80,7 +80,7 @@ import { AccessibilityCommandId } from '../../../../accessibility/common/accessi
 import { getSimpleCodeEditorWidgetOptions, getSimpleEditorOptions, setupSimpleEditorSelectionStyling } from '../../../../codeEditor/browser/simpleEditorOptions.js';
 import { IChatViewTitleActionContext } from '../../../common/actions/chatActions.js';
 import { ChatContextKeys } from '../../../common/actions/chatContextKeys.js';
-import { ChatRequestVariableSet, getImageAttachmentLimit, IChatRequestVariableEntry, isBrowserViewVariableEntry, isElementVariableEntry, isImageVariableEntry, isNotebookOutputVariableEntry, isPasteVariableEntry, isPromptFileVariableEntry, isPromptTextVariableEntry, isSCMHistoryItemChangeRangeVariableEntry, isSCMHistoryItemChangeVariableEntry, isSCMHistoryItemVariableEntry, isStringVariableEntry, OmittedState } from '../../../common/attachments/chatVariableEntries.js';
+import { ChatRequestVariableSet, getImageAttachmentLimit, IChatRequestVariableEntry, isBrowserViewVariableEntry, isElementVariableEntry, isExplicitFileOrImageVariableEntry, isImageVariableEntry, isNotebookOutputVariableEntry, isPasteVariableEntry, isPromptFileVariableEntry, isPromptTextVariableEntry, isSCMHistoryItemChangeRangeVariableEntry, isSCMHistoryItemChangeVariableEntry, isSCMHistoryItemVariableEntry, isStringVariableEntry, OmittedState } from '../../../common/attachments/chatVariableEntries.js';
 import { ChatMode, getModeNameForTelemetry, IChatMode, IChatModes, IChatModeService } from '../../../common/chatModes.js';
 import { IChatFollowup, IChatPlanReview, IChatQuestionCarousel, IChatToolInvocation } from '../../../common/chatService/chatService.js';
 import { IChatSessionProviderOptionGroup, IChatSessionProviderOptionItem, IChatSessionsService, isIChatSessionFileChange2, localChatSessionType, SessionType } from '../../../common/chatSessionsService.js';
@@ -381,6 +381,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	private historyNavigationForewardsEnablement!: IContextKey<boolean>;
 	private inputModel: ITextModel | undefined;
 	private inputEditorHasText: IContextKey<boolean>;
+	private inputEditorHasSendableContent: IContextKey<boolean>;
 	private chatCursorAtTop: IContextKey<boolean>;
 	private inputEditorHasFocus: IContextKey<boolean>;
 	private currentlyEditingInputKey!: IContextKey<boolean>;
@@ -630,6 +631,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		this.inputEditorMinHeight = this.options.inputEditorMinLines ? this.options.inputEditorMinLines * INPUT_EDITOR_LINE_HEIGHT + padding.top + padding.bottom : undefined;
 
 		this.inputEditorHasText = ChatContextKeys.inputHasText.bindTo(contextKeyService);
+		this.inputEditorHasSendableContent = ChatContextKeys.inputHasSendableContent.bindTo(contextKeyService);
 		this.chatCursorAtTop = ChatContextKeys.inputCursorAtTop.bindTo(contextKeyService);
 		this.inputEditorHasFocus = ChatContextKeys.inputHasFocus.bindTo(contextKeyService);
 		this._hasQuestionCarouselContextKey = ChatContextKeys.Editing.hasQuestionCarousel.bindTo(contextKeyService);
@@ -1791,7 +1793,14 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 	private _handleAttachedContextChange() {
 		this._hasFileAttachmentContextKey.set(Boolean(this._attachmentModel.attachments.find(a => a.kind === 'file')));
+		this._updateInputContentContextKeys();
 		this.renderAttachedContext();
+	}
+
+	private _updateInputContentContextKeys(): void {
+		const inputHasText = !!this._inputEditor?.getModel()?.getValue().trim();
+		this.inputEditorHasText.set(inputHasText);
+		this.inputEditorHasSendableContent.set(inputHasText || this._attachmentModel.attachments.some(isExplicitFileOrImageVariableEntry));
 	}
 
 	private getOrCreateOptionEmitter(optionGroupId: string): Emitter<IChatSessionProviderOptionItem> {
@@ -2441,9 +2450,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 				}
 			}
 
-			const model = this._inputEditor.getModel();
-			const inputHasText = !!model && model.getValue().trim().length > 0;
-			this.inputEditorHasText.set(inputHasText);
+			this._updateInputContentContextKeys();
 
 			// Debounced sync to model for text changes
 			this._syncTextDebounced.schedule();

--- a/src/vs/workbench/contrib/chat/common/actions/chatContextKeys.ts
+++ b/src/vs/workbench/contrib/chat/common/actions/chatContextKeys.ts
@@ -40,6 +40,7 @@ export namespace ChatContextKeys {
 	export const editApplied = new RawContextKey<boolean>('chatEditApplied', false, { type: 'boolean', description: localize('chatEditApplied', "True when the chat text edits have been applied.") });
 
 	export const inputHasText = new RawContextKey<boolean>('chatInputHasText', false, { type: 'boolean', description: localize('interactiveInputHasText', "True when the chat input has text.") });
+	export const inputHasSendableContent = new RawContextKey<boolean>('chatInputHasSendableContent', false, { type: 'boolean', description: localize('interactiveInputHasSendableContent', "True when the chat input has text or file attachments that can be sent.") });
 	export const inputHasFocus = new RawContextKey<boolean>('chatInputHasFocus', false, { type: 'boolean', description: localize('interactiveInputHasFocus', "True when the chat input has focus.") });
 	export const inChatInput = new RawContextKey<boolean>('inChatInput', false, { type: 'boolean', description: localize('inInteractiveInput', "True when focus is in the chat input, false otherwise.") });
 	export const inChatSession = new RawContextKey<boolean>('inChat', false, { type: 'boolean', description: localize('inChat', "True when focus is in the chat widget, false otherwise.") });

--- a/src/vs/workbench/contrib/chat/common/attachments/chatVariableEntries.ts
+++ b/src/vs/workbench/contrib/chat/common/attachments/chatVariableEntries.ts
@@ -466,6 +466,27 @@ export function isImageVariableEntry(obj: IChatRequestVariableEntry): obj is IIm
 	return obj.kind === 'image';
 }
 
+export function isExplicitFileOrImageVariableEntry(obj: IChatRequestVariableEntry): obj is IChatRequestFileEntry | IChatRequestDirectoryEntry | IImageVariableEntry {
+	return obj.kind === 'file' || obj.kind === 'directory' || obj.kind === 'image';
+}
+
+export function getExplicitFileOrImageAttachmentSummary(entries: readonly IChatRequestVariableEntry[]): string | undefined {
+	const fileOrImageEntries = entries.filter(isExplicitFileOrImageVariableEntry);
+	if (!fileOrImageEntries.length) {
+		return undefined;
+	}
+
+	if (fileOrImageEntries.every(isImageVariableEntry)) {
+		return fileOrImageEntries.length === 1
+			? localize('chat.attachmentSummary.image.one', "Attached 1 image")
+			: localize('chat.attachmentSummary.image.many', "Attached {0} images", fileOrImageEntries.length);
+	}
+
+	return fileOrImageEntries.length === 1
+		? localize('chat.attachmentSummary.file.one', "Attached 1 file")
+		: localize('chat.attachmentSummary.file.many', "Attached {0} files", fileOrImageEntries.length);
+}
+
 export function isNotebookOutputVariableEntry(obj: IChatRequestVariableEntry): obj is INotebookOutputVariableEntry {
 	return obj.kind === 'notebookOutput';
 }

--- a/src/vs/workbench/contrib/chat/common/chatImageExtraction.ts
+++ b/src/vs/workbench/contrib/chat/common/chatImageExtraction.ts
@@ -12,7 +12,7 @@ import { IChatResponseViewModel, IChatRequestViewModel, isRequestVM } from './mo
 import { ChatResponseResource } from './model/chatModel.js';
 import { IChatContentInlineReference, IChatToolInvocation, IChatToolInvocationSerialized, IToolResultOutputDetailsSerialized } from './chatService/chatService.js';
 import { isToolResultInputOutputDetails, isToolResultOutputDetails, IToolResultOutputDetails } from './tools/languageModelToolsService.js';
-import { isImageVariableEntry } from './attachments/chatVariableEntries.js';
+import { getExplicitFileOrImageAttachmentSummary, isImageVariableEntry } from './attachments/chatVariableEntries.js';
 
 export interface IChatExtractedImage {
 	readonly id: string;
@@ -57,7 +57,7 @@ export async function extractImagesFromChatResponse(
 
 	// Use the corresponding user request as the carousel title
 	const request = response.session.getItems().find((item): item is IChatRequestViewModel => isRequestVM(item) && item.id === response.requestId);
-	const title = request ? request.messageText : localize('chatImageExtraction.defaultTitle', "Images");
+	const title = request ? request.messageText.trim() || getExplicitFileOrImageAttachmentSummary(request.variables) || localize('chatImageExtraction.defaultTitle', "Images") : localize('chatImageExtraction.defaultTitle', "Images");
 
 	return {
 		id: response.sessionResource.toString() + '_' + response.id,

--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -46,7 +46,7 @@ import { ChatSessionStore, IChatSessionEntryMetadata } from '../model/chatSessio
 import { IChatSlashCommandService } from '../participants/chatSlashCommands.js';
 import { IChatTransferService } from '../model/chatTransferService.js';
 import { chatSessionResourceToId, getChatSessionType, isUntitledChatSession, LocalChatSessionUri } from '../model/chatUri.js';
-import { ChatRequestVariableSet, IChatRequestVariableEntry, isPromptTextVariableEntry } from '../attachments/chatVariableEntries.js';
+import { ChatRequestVariableSet, IChatRequestVariableEntry, isExplicitFileOrImageVariableEntry, isPromptTextVariableEntry } from '../attachments/chatVariableEntries.js';
 import { IDynamicVariable } from '../attachments/chatVariables.js';
 import { ChatAgentLocation, ChatModeKind } from '../constants.js';
 import { ChatMessageRole, IChatMessage, ILanguageModelsService } from '../languageModels.js';
@@ -909,7 +909,8 @@ export class ChatService extends Disposable implements IChatService {
 	async sendRequest(sessionResource: URI, request: string, options?: IChatSendRequestOptions): Promise<ChatSendResult> {
 		this.trace('sendRequest', `sessionResource: ${sessionResource.toString()}, message: ${request.substring(0, 20)}${request.length > 20 ? '[...]' : ''}}`);
 
-		if (!request.trim() && !options?.slashCommand && !options?.agentId && !options?.agentIdSilent) {
+		const hasSendableAttachment = options?.attachedContext?.some(isExplicitFileOrImageVariableEntry) || options?.resolvedVariables?.some(isExplicitFileOrImageVariableEntry);
+		if (!request.trim() && !hasSendableAttachment && !options?.slashCommand && !options?.agentId && !options?.agentIdSilent) {
 			this.trace('sendRequest', 'Rejected empty message');
 			return { kind: 'rejected', reason: 'Empty message' };
 		}

--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -46,7 +46,7 @@ import { ChatSessionStore, IChatSessionEntryMetadata } from '../model/chatSessio
 import { IChatSlashCommandService } from '../participants/chatSlashCommands.js';
 import { IChatTransferService } from '../model/chatTransferService.js';
 import { chatSessionResourceToId, getChatSessionType, isUntitledChatSession, LocalChatSessionUri } from '../model/chatUri.js';
-import { ChatRequestVariableSet, getExplicitFileOrImageAttachmentSummary, IChatRequestVariableEntry, isPromptTextVariableEntry } from '../attachments/chatVariableEntries.js';
+import { ChatRequestVariableSet, IChatRequestVariableEntry, isExplicitFileOrImageVariableEntry, isPromptTextVariableEntry } from '../attachments/chatVariableEntries.js';
 import { IDynamicVariable } from '../attachments/chatVariables.js';
 import { ChatAgentLocation, ChatModeKind } from '../constants.js';
 import { ChatMessageRole, IChatMessage, ILanguageModelsService } from '../languageModels.js';
@@ -909,12 +909,8 @@ export class ChatService extends Disposable implements IChatService {
 	async sendRequest(sessionResource: URI, request: string, options?: IChatSendRequestOptions): Promise<ChatSendResult> {
 		this.trace('sendRequest', `sessionResource: ${sessionResource.toString()}, message: ${request.substring(0, 20)}${request.length > 20 ? '[...]' : ''}}`);
 
-		const requestAttachmentSummary = getExplicitFileOrImageAttachmentSummary([...(options?.attachedContext ?? []), ...(options?.resolvedVariables ?? [])]);
-		if (!request.trim() && requestAttachmentSummary) {
-			request = requestAttachmentSummary;
-		}
-
-		if (!request.trim() && !options?.slashCommand && !options?.agentId && !options?.agentIdSilent) {
+		const hasExplicitFileOrImageAttachment = [...(options?.attachedContext ?? []), ...(options?.resolvedVariables ?? [])].some(isExplicitFileOrImageVariableEntry);
+		if (!request.trim() && !hasExplicitFileOrImageAttachment && !options?.slashCommand && !options?.agentId && !options?.agentIdSilent) {
 			this.trace('sendRequest', 'Rejected empty message');
 			return { kind: 'rejected', reason: 'Empty message' };
 		}

--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -46,7 +46,7 @@ import { ChatSessionStore, IChatSessionEntryMetadata } from '../model/chatSessio
 import { IChatSlashCommandService } from '../participants/chatSlashCommands.js';
 import { IChatTransferService } from '../model/chatTransferService.js';
 import { chatSessionResourceToId, getChatSessionType, isUntitledChatSession, LocalChatSessionUri } from '../model/chatUri.js';
-import { ChatRequestVariableSet, IChatRequestVariableEntry, isExplicitFileOrImageVariableEntry, isPromptTextVariableEntry } from '../attachments/chatVariableEntries.js';
+import { ChatRequestVariableSet, getExplicitFileOrImageAttachmentSummary, IChatRequestVariableEntry, isPromptTextVariableEntry } from '../attachments/chatVariableEntries.js';
 import { IDynamicVariable } from '../attachments/chatVariables.js';
 import { ChatAgentLocation, ChatModeKind } from '../constants.js';
 import { ChatMessageRole, IChatMessage, ILanguageModelsService } from '../languageModels.js';
@@ -909,8 +909,12 @@ export class ChatService extends Disposable implements IChatService {
 	async sendRequest(sessionResource: URI, request: string, options?: IChatSendRequestOptions): Promise<ChatSendResult> {
 		this.trace('sendRequest', `sessionResource: ${sessionResource.toString()}, message: ${request.substring(0, 20)}${request.length > 20 ? '[...]' : ''}}`);
 
-		const hasSendableAttachment = options?.attachedContext?.some(isExplicitFileOrImageVariableEntry) || options?.resolvedVariables?.some(isExplicitFileOrImageVariableEntry);
-		if (!request.trim() && !hasSendableAttachment && !options?.slashCommand && !options?.agentId && !options?.agentIdSilent) {
+		const requestAttachmentSummary = getExplicitFileOrImageAttachmentSummary([...(options?.attachedContext ?? []), ...(options?.resolvedVariables ?? [])]);
+		if (!request.trim() && requestAttachmentSummary) {
+			request = requestAttachmentSummary;
+		}
+
+		if (!request.trim() && !options?.slashCommand && !options?.agentId && !options?.agentIdSilent) {
 			this.trace('sendRequest', 'Rejected empty message');
 			return { kind: 'rejected', reason: 'Empty message' };
 		}

--- a/src/vs/workbench/contrib/chat/test/common/attachments/chatVariableEntries.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/attachments/chatVariableEntries.test.ts
@@ -1,0 +1,42 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { URI } from '../../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { getExplicitFileOrImageAttachmentSummary, IChatRequestVariableEntry, isExplicitFileOrImageVariableEntry } from '../../../common/attachments/chatVariableEntries.js';
+
+suite('Chat variable entries', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('identifies explicit file and image entries', () => {
+		const fileEntry: IChatRequestVariableEntry = { kind: 'file', id: 'file', name: 'README.md', value: URI.file('/test/README.md') };
+		const imageEntry: IChatRequestVariableEntry = { kind: 'image', id: 'image', name: 'screenshot.png', value: new Uint8Array(), mimeType: 'image/png' };
+		const workspaceEntry: IChatRequestVariableEntry = { kind: 'workspace', id: 'workspace', name: 'workspace', value: 'workspace' };
+
+		assert.strictEqual(isExplicitFileOrImageVariableEntry(fileEntry), true);
+		assert.strictEqual(isExplicitFileOrImageVariableEntry(imageEntry), true);
+		assert.strictEqual(isExplicitFileOrImageVariableEntry(workspaceEntry), false);
+	});
+
+	test('summarizes explicit file and image entries', () => {
+		const fileEntry: IChatRequestVariableEntry = { kind: 'file', id: 'file', name: 'README.md', value: URI.file('/test/README.md') };
+		const imageEntry1: IChatRequestVariableEntry = { kind: 'image', id: 'image-1', name: 'screenshot-1.png', value: new Uint8Array(), mimeType: 'image/png' };
+		const imageEntry2: IChatRequestVariableEntry = { kind: 'image', id: 'image-2', name: 'screenshot-2.png', value: new Uint8Array(), mimeType: 'image/png' };
+
+		assert.strictEqual(getExplicitFileOrImageAttachmentSummary([imageEntry1]), 'Attached 1 image');
+		assert.strictEqual(getExplicitFileOrImageAttachmentSummary([imageEntry1, imageEntry2]), 'Attached 2 images');
+		assert.strictEqual(getExplicitFileOrImageAttachmentSummary([fileEntry]), 'Attached 1 file');
+		assert.strictEqual(getExplicitFileOrImageAttachmentSummary([fileEntry, imageEntry1]), 'Attached 2 files');
+	});
+
+	test('does not summarize hidden or automatic context entries', () => {
+		const workspaceEntry: IChatRequestVariableEntry = { kind: 'workspace', id: 'workspace', name: 'workspace', value: 'workspace' };
+		const implicitEntry: IChatRequestVariableEntry = { kind: 'implicit', id: 'implicit', name: 'implicit', value: undefined, uri: undefined, isFile: true, isSelection: false, enabled: true };
+		const promptEntry: IChatRequestVariableEntry = { kind: 'promptText', id: 'prompt', name: 'prompt', value: 'instructions', modelDescription: 'instructions', automaticallyAdded: true };
+
+		assert.strictEqual(getExplicitFileOrImageAttachmentSummary([workspaceEntry, implicitEntry, promptEntry]), undefined);
+	});
+});

--- a/src/vs/workbench/contrib/chat/test/common/chatImageExtraction.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatImageExtraction.test.ts
@@ -7,7 +7,7 @@ import assert from 'assert';
 import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { IImageVariableEntry } from '../../common/attachments/chatVariableEntries.js';
+import { IChatRequestVariableEntry, IImageVariableEntry } from '../../common/attachments/chatVariableEntries.js';
 import { IChatProgressResponseContent } from '../../common/model/chatModel.js';
 import { IChatRequestViewModel, IChatResponseViewModel } from '../../common/model/chatViewModel.js';
 import { IChatContentInlineReference, IChatToolInvocationSerialized, IToolResultOutputDetailsSerialized } from '../../common/chatService/chatService.js';
@@ -44,6 +44,7 @@ function makeResponse(items: ReadonlyArray<IChatProgressResponseContent>, opts: 
 	requestId?: string;
 	id?: string;
 	requestMessageText?: string;
+	requestVariables?: readonly IChatRequestVariableEntry[];
 	noMatchingRequest?: boolean;
 } = {}): IChatResponseViewModel {
 	const sessionResource = opts.sessionResource ?? URI.parse('chat-session://test/session');
@@ -61,6 +62,7 @@ function makeResponse(items: ReadonlyArray<IChatProgressResponseContent>, opts: 
 				id: requestId,
 				messageText: requestMessageText,
 				message: { parts: [], text: requestMessageText },
+				variables: opts.requestVariables ?? [],
 			}],
 		},
 	} as unknown as IChatResponseViewModel;
@@ -118,6 +120,13 @@ suite('extractImagesFromChatResponse', () => {
 		const response = makeResponse([], { noMatchingRequest: true });
 		const result = await extractImagesFromChatResponse(response, fakeReadFile);
 		assert.strictEqual(result.title, 'Images');
+	});
+
+	test('uses attachment summary title when matching request has no message text', async () => {
+		const image = makeImageVariableEntry({ value: VSBuffer.fromString('image').buffer });
+		const response = makeResponse([], { requestMessageText: '', requestVariables: [image] });
+		const result = await extractImagesFromChatResponse(response, fakeReadFile);
+		assert.strictEqual(result.title, 'Attached 1 image');
 	});
 
 	test('extracts image from tool invocation with IToolResultOutputDetails', async () => {

--- a/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
@@ -40,6 +40,7 @@ import { IWorkspaceEditingService } from '../../../../../services/workspaces/com
 import { InMemoryTestFileService, mock, TestChatEntitlementService, TestContextService, TestExtensionService, TestStorageService } from '../../../../../test/common/workbenchTestServices.js';
 import { IMcpService } from '../../../../mcp/common/mcpTypes.js';
 import { TestMcpService } from '../../../../mcp/test/common/testMcpService.js';
+import { IChatRequestVariableEntry } from '../../../common/attachments/chatVariableEntries.js';
 import { IChatVariablesService } from '../../../common/attachments/chatVariables.js';
 import { IChatDebugService } from '../../../common/chatDebugService.js';
 import { ChatDebugServiceImpl } from '../../../common/chatDebugServiceImpl.js';
@@ -408,6 +409,33 @@ suite('ChatService', () => {
 		assert.strictEqual(model.getRequests().length, 1);
 		assert.ok(model.getRequests()[0].response);
 		assert.strictEqual(model.getRequests()[0].response?.response.toString(), 'test response');
+	});
+
+	test('sendRequest accepts empty message with explicit file attachment', async () => {
+		const testService = createChatService();
+
+		const modelRef = testDisposables.add(startSessionModel(testService));
+		const model = modelRef.object;
+		const fileEntry: IChatRequestVariableEntry = { kind: 'file', id: 'file', name: 'README.md', value: URI.file('/test/README.md') };
+		const response = await testService.sendRequest(model.sessionResource, '', { attachedContext: [fileEntry] });
+		ChatSendResult.assertSent(response);
+		await response.data.responseCompletePromise;
+
+		assert.strictEqual(model.getRequests().length, 1);
+		assert.strictEqual(model.getRequests()[0].message.text, '');
+		assert.deepStrictEqual(model.getRequests()[0].variableData.variables, [fileEntry]);
+	});
+
+	test('sendRequest rejects empty message without explicit file attachment', async () => {
+		const testService = createChatService();
+
+		const modelRef = testDisposables.add(startSessionModel(testService));
+		const model = modelRef.object;
+		const workspaceEntry: IChatRequestVariableEntry = { kind: 'workspace', id: 'workspace', name: 'workspace', value: 'workspace' };
+
+		assert.deepStrictEqual(await testService.sendRequest(model.sessionResource, ''), { kind: 'rejected', reason: 'Empty message' });
+		assert.deepStrictEqual(await testService.sendRequest(model.sessionResource, '', { attachedContext: [workspaceEntry] }), { kind: 'rejected', reason: 'Empty message' });
+		assert.strictEqual(model.getRequests().length, 0);
 	});
 
 	test('sendRequest fails', async () => {

--- a/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
@@ -411,7 +411,7 @@ suite('ChatService', () => {
 		assert.strictEqual(model.getRequests()[0].response?.response.toString(), 'test response');
 	});
 
-	test('sendRequest accepts empty message with explicit file attachment', async () => {
+	test('sendRequest uses attachment summary message with explicit file attachment', async () => {
 		const testService = createChatService();
 
 		const modelRef = testDisposables.add(startSessionModel(testService));
@@ -422,7 +422,7 @@ suite('ChatService', () => {
 		await response.data.responseCompletePromise;
 
 		assert.strictEqual(model.getRequests().length, 1);
-		assert.strictEqual(model.getRequests()[0].message.text, '');
+		assert.strictEqual(model.getRequests()[0].message.text, 'Attached 1 file');
 		assert.deepStrictEqual(model.getRequests()[0].variableData.variables, [fileEntry]);
 	});
 

--- a/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
@@ -411,7 +411,7 @@ suite('ChatService', () => {
 		assert.strictEqual(model.getRequests()[0].response?.response.toString(), 'test response');
 	});
 
-	test('sendRequest uses attachment summary message with explicit file attachment', async () => {
+	test('sendRequest allows empty message with explicit file attachment', async () => {
 		const testService = createChatService();
 
 		const modelRef = testDisposables.add(startSessionModel(testService));
@@ -422,7 +422,7 @@ suite('ChatService', () => {
 		await response.data.responseCompletePromise;
 
 		assert.strictEqual(model.getRequests().length, 1);
-		assert.strictEqual(model.getRequests()[0].message.text, 'Attached 1 file');
+		assert.strictEqual(model.getRequests()[0].message.text, '');
 		assert.deepStrictEqual(model.getRequests()[0].variableData.variables, [fileEntry]);
 	});
 


### PR DESCRIPTION
Fixes #317775

This change allows chat requests to be sent with explicit attachments even when the text input is empty.

The work is split into two commits:

1. `Allow sending chat requests with attachments only`

   Enables attachment-only sends for explicit file, directory, and image attachments.

   This updates the chat input send gating and service-side empty-message validation so attachment-only requests are accepted, while hidden or automatic context such as workspace/implicit context does not make an empty request sendable.

   It also adds localized fallback request summaries for the UI and accessibility paths, so attachment-only requests do not appear blank. Examples:
   - `Attached 1 image`
   - `Attached 2 images`
   - `Attached 1 file`
   - `Attached 2 files`

2. `Use attachment summary for empty chat request text` (I don't know if necessary)

   Uses the same attachment summary as the actual request text for attachment-only sends.

   This means the user sees `Attached 1 image` / `Attached N files`, and the model also receives that summary as the request message alongside the attached context.

Videos: attachment-only send works and displays the attachment summary (Both VSCode and Agents app)

https://github.com/user-attachments/assets/a1292265-65d6-4b77-bd1a-74c21c88cd82

https://github.com/user-attachments/assets/c06926e2-ed52-4eb8-8a6f-60d73fe60a2c