### PR TITLE
Add aggregate image metadata to Copilot telemetry

### DIFF
--- a/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
+++ b/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
@@ -18,6 +18,7 @@ import { ConfigKey, HARD_TOOL_LIMIT, IConfigurationService } from '../../../plat
 import { ICAPIClientService } from '../../../platform/endpoint/common/capiClient';
 import { isAutoModel } from '../../../platform/endpoint/node/autoChatEndpoint';
 import { getResponsesApiCompactionThresholdFromBody, OpenAIResponsesProcessor, responseApiInputToRawMessagesForLogging, sendCompletionOutputTelemetry } from '../../../platform/endpoint/node/responsesApi';
+import { getImageTelemetryMeasurementsFromMessages, type ImageTelemetryMeasurements } from '../../../platform/image/common/imageTelemetry';
 import { collectSingleLineErrorMessage, ILogService } from '../../../platform/log/common/logService';
 import { FinishedCallback, getRequestId, IResponseDelta, OptionalChatRequestParams, RequestId } from '../../../platform/networking/common/fetch';
 import { FetcherId, IFetcherService, Response } from '../../../platform/networking/common/fetcherService';
@@ -173,7 +174,7 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 			requestId: ourRequestId,
 			postOptions
 		});
-
+		const imageTelemetryMeasurements = getImageTelemetryMeasurementsFromMessages(messages);
 
 		const baseTelemetry = TelemetryData.createAndMarkAsIssued({
 			...telemetryProperties,
@@ -325,7 +326,7 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 			pendingLoggedChatRequest?.markTimeToFirstToken(timeToFirstToken);
 			switch (response.type) {
 				case FetchResponseKind.Success: {
-					const result = await this.processSuccessfulResponse(response, messages, requestBody, ourRequestId, maxResponseTokens, tokenCount, timeToFirstToken, streamRecorder, baseTelemetry, chatEndpoint, userInitiatedRequest, interactionType, transport, actualFetcher, actualBytesReceived, suspendEventSeen, resumeEventSeen, actualModelCallId);
+					const result = await this.processSuccessfulResponse(response, messages, imageTelemetryMeasurements, requestBody, ourRequestId, maxResponseTokens, tokenCount, timeToFirstToken, streamRecorder, baseTelemetry, chatEndpoint, userInitiatedRequest, interactionType, transport, actualFetcher, actualBytesReceived, suspendEventSeen, resumeEventSeen, actualModelCallId);
 
 					// Handle FilteredRetry case with augmented messages
 					if (result.type === ChatFetchResponseType.FilteredRetry) {
@@ -522,6 +523,7 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 							isAuto: isAutoModel(chatEndpoint),
 							bytesReceived: actualBytesReceived,
 							issuedTime: baseTelemetry.issuedTime,
+							imageTelemetryMeasurements,
 						});
 					pendingLoggedChatRequest?.resolveWithCancelation();
 					// Set canceled status on OTel span
@@ -555,6 +557,7 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 							bytesReceived: actualBytesReceived,
 							baseTelemetry,
 							streamRecorder,
+							imageTelemetryMeasurements,
 							retryReason: 'server_error',
 							debugNamePrefix: 'retry-server-error-',
 							pendingLoggedChatRequest,
@@ -577,6 +580,7 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 						maxResponseTokens,
 						timeToFirstToken,
 						isVisionRequest: this.filterImageMessages(messages),
+						imageTelemetryMeasurements,
 						transport,
 						interactionType,
 						fetcher: actualFetcher,
@@ -626,6 +630,7 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 					bytesReceived: err.bytesReceived,
 					baseTelemetry,
 					streamRecorder,
+					imageTelemetryMeasurements,
 					retryReason: 'network_error',
 					debugNamePrefix: 'retry-error-',
 					pendingLoggedChatRequest,
@@ -673,6 +678,7 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 						isAuto: isAutoModel(chatEndpoint),
 						bytesReceived: err.bytesReceived,
 						issuedTime: baseTelemetry.issuedTime,
+						imageTelemetryMeasurements,
 					}
 				);
 			} else {
@@ -685,6 +691,7 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 					maxResponseTokens,
 					timeToFirstToken: timeToError,
 					isVisionRequest: this.filterImageMessages(messages),
+					imageTelemetryMeasurements,
 					transport,
 					interactionType,
 					fetcher: actualFetcher,
@@ -766,6 +773,7 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 		bytesReceived: number | undefined;
 		baseTelemetry: TelemetryData;
 		streamRecorder: FetchStreamRecorder;
+		imageTelemetryMeasurements: ImageTelemetryMeasurements;
 		retryReason: 'network_error' | 'server_error';
 		debugNamePrefix: string;
 		pendingLoggedChatRequest: ReturnType<IRequestLogger['logChatRequest']>;
@@ -788,6 +796,7 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 			bytesReceived,
 			baseTelemetry,
 			streamRecorder,
+			imageTelemetryMeasurements,
 			retryReason,
 			debugNamePrefix,
 			pendingLoggedChatRequest,
@@ -828,6 +837,7 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 				maxResponseTokens,
 				timeToFirstToken: timeToError,
 				isVisionRequest: this.filterImageMessages(opts.messages),
+				imageTelemetryMeasurements,
 				transport,
 				interactionType,
 				fetcher: actualFetcher,
@@ -1772,6 +1782,7 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 	private async processSuccessfulResponse(
 		response: ChatResults,
 		messages: Raw.ChatMessage[],
+		imageTelemetryMeasurements: ImageTelemetryMeasurements,
 		requestBody: IEndpointBody,
 		requestId: string,
 		maxResponseTokens: number,
@@ -1807,6 +1818,7 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 					timeToFirstToken,
 					timeToFirstTokenEmitted: (baseTelemetry && streamRecorder.firstTokenEmittedTime) ? streamRecorder.firstTokenEmittedTime - baseTelemetry.issuedTime : -1,
 					hasImageMessages: this.filterImageMessages(messages),
+					imageTelemetryMeasurements,
 					transport,
 					fetcher,
 					bytesReceived,

--- a/extensions/copilot/src/extension/prompt/node/chatMLFetcherTelemetry.ts
+++ b/extensions/copilot/src/extension/prompt/node/chatMLFetcherTelemetry.ts
@@ -5,6 +5,7 @@
 
 import { ChatFetchError } from '../../../platform/chat/common/commonTypes';
 import { isAutoModel } from '../../../platform/endpoint/node/autoChatEndpoint';
+import { getImageTelemetryEventMeasurements, type ImageTelemetryMeasurements } from '../../../platform/image/common/imageTelemetry';
 import { FetcherId } from '../../../platform/networking/common/fetcherService';
 import { IChatEndpoint, IChatRequestTelemetryProperties, IEndpointBody } from '../../../platform/networking/common/networking';
 import { ChatCompletion } from '../../../platform/networking/common/openai';
@@ -24,6 +25,7 @@ export interface IChatMLFetcherSuccessfulData {
 	timeToFirstToken: number;
 	timeToFirstTokenEmitted: number;
 	hasImageMessages: boolean;
+	imageTelemetryMeasurements: ImageTelemetryMeasurements;
 	transport: string;
 	fetcher: FetcherId | undefined;
 	bytesReceived: number | undefined;
@@ -64,6 +66,7 @@ export interface IChatMLFetcherCancellationMeasures {
 	isAuto: number;
 	bytesReceived: number | undefined;
 	issuedTime: number;
+	imageTelemetryMeasurements: ImageTelemetryMeasurements;
 }
 
 export interface IChatMLFetcherErrorData {
@@ -75,6 +78,7 @@ export interface IChatMLFetcherErrorData {
 	maxResponseTokens: number;
 	timeToFirstToken: number;
 	isVisionRequest: boolean;
+	imageTelemetryMeasurements: ImageTelemetryMeasurements;
 	transport: string;
 	interactionType: string;
 	fetcher: FetcherId | undefined;
@@ -101,6 +105,7 @@ export class ChatMLFetcherTelemetrySender {
 			timeToFirstToken,
 			timeToFirstTokenEmitted,
 			hasImageMessages,
+			imageTelemetryMeasurements,
 			transport,
 			fetcher,
 			bytesReceived,
@@ -144,6 +149,19 @@ export class ChatMLFetcherTelemetrySender {
 				"timeToComplete": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Time to complete the request", "isMeasurement": true },
 				"issuedTime": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Timestamp when the request was issued", "isMeasurement": true },
 				"isVisionRequest": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Whether the request was for a vision model", "isMeasurement": true },
+				"imageCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Number of input images attached to the request", "isMeasurement": true },
+				"totalImageBytes": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Sum of byte sizes for attached input images when known", "isMeasurement": true },
+				"maxImageBytes": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Largest known input image byte size in the request", "isMeasurement": true },
+				"imagePngCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of PNG input images", "isMeasurement": true },
+				"imageJpegCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of JPEG input images", "isMeasurement": true },
+				"imageGifCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of GIF input images", "isMeasurement": true },
+				"imageWebpCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of WebP input images", "isMeasurement": true },
+				"imageUnknownMimeCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of input images whose MIME type is unknown or unsupported", "isMeasurement": true },
+				"imageClipboardCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of input images sourced from clipboard or paste", "isMeasurement": true },
+				"imageScreenshotCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of input images sourced from screenshot capture", "isMeasurement": true },
+				"imageFileCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of input images sourced from local file attachment", "isMeasurement": true },
+				"imageUrlCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of input images sourced from URL", "isMeasurement": true },
+				"imageUnknownSourceCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of input images whose source could not be determined", "isMeasurement": true },
 				"isBYOK": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether the request was for a BYOK model", "isMeasurement": true },
 				"isAuto": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether the request was for an Auto model", "isMeasurement": true },
 				"bytesReceived": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Number of bytes received in the response", "isMeasurement": true },
@@ -204,6 +222,7 @@ export class ChatMLFetcherTelemetrySender {
 			timeToComplete: Date.now() - baseTelemetry.issuedTime,
 			issuedTime: baseTelemetry.issuedTime,
 			isVisionRequest: hasImageMessages ? 1 : -1,
+			...getImageTelemetryEventMeasurements(imageTelemetryMeasurements),
 			isBYOK: isBYOKModel(chatEndpointInfo),
 			isAuto: isAutoModel(chatEndpointInfo),
 			bytesReceived,
@@ -245,6 +264,7 @@ export class ChatMLFetcherTelemetrySender {
 			isAuto,
 			bytesReceived,
 			issuedTime,
+			imageTelemetryMeasurements,
 		}: IChatMLFetcherCancellationMeasures
 	) {
 		/* __GDPR__
@@ -270,6 +290,19 @@ export class ChatMLFetcherTelemetrySender {
 				"timeToComplete": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Time to complete the request", "isMeasurement": true },
 				"issuedTime": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Timestamp when the request was issued", "isMeasurement": true },
 				"isVisionRequest": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Whether the request was for a vision model", "isMeasurement": true },
+				"imageCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Number of input images attached to the request", "isMeasurement": true },
+				"totalImageBytes": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Sum of byte sizes for attached input images when known", "isMeasurement": true },
+				"maxImageBytes": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Largest known input image byte size in the request", "isMeasurement": true },
+				"imagePngCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of PNG input images", "isMeasurement": true },
+				"imageJpegCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of JPEG input images", "isMeasurement": true },
+				"imageGifCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of GIF input images", "isMeasurement": true },
+				"imageWebpCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of WebP input images", "isMeasurement": true },
+				"imageUnknownMimeCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of input images whose MIME type is unknown or unsupported", "isMeasurement": true },
+				"imageClipboardCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of input images sourced from clipboard or paste", "isMeasurement": true },
+				"imageScreenshotCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of input images sourced from screenshot capture", "isMeasurement": true },
+				"imageFileCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of input images sourced from local file attachment", "isMeasurement": true },
+				"imageUrlCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of input images sourced from URL", "isMeasurement": true },
+				"imageUnknownSourceCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of input images whose source could not be determined", "isMeasurement": true },
 				"isBYOK": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether the request was for a BYOK model", "isMeasurement": true },
 				"isAuto": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether the request was for an Auto model", "isMeasurement": true },
 				"bytesReceived": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Number of bytes received before cancellation", "isMeasurement": true },
@@ -308,6 +341,7 @@ export class ChatMLFetcherTelemetrySender {
 			timeToComplete: timeToCancelled,
 			issuedTime,
 			isVisionRequest,
+			...getImageTelemetryEventMeasurements(imageTelemetryMeasurements),
 			isBYOK,
 			isAuto,
 			bytesReceived,
@@ -327,6 +361,7 @@ export class ChatMLFetcherTelemetrySender {
 			maxResponseTokens,
 			timeToFirstToken,
 			isVisionRequest,
+			imageTelemetryMeasurements,
 			transport,
 			interactionType,
 			fetcher,
@@ -364,6 +399,19 @@ export class ChatMLFetcherTelemetrySender {
 				"timeToComplete": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Time to complete the request", "isMeasurement": true },
 				"issuedTime": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Timestamp when the request was issued", "isMeasurement": true },
 				"isVisionRequest": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Whether the request was for a vision model", "isMeasurement": true },
+				"imageCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Number of input images attached to the request", "isMeasurement": true },
+				"totalImageBytes": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Sum of byte sizes for attached input images when known", "isMeasurement": true },
+				"maxImageBytes": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Largest known input image byte size in the request", "isMeasurement": true },
+				"imagePngCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of PNG input images", "isMeasurement": true },
+				"imageJpegCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of JPEG input images", "isMeasurement": true },
+				"imageGifCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of GIF input images", "isMeasurement": true },
+				"imageWebpCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of WebP input images", "isMeasurement": true },
+				"imageUnknownMimeCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of input images whose MIME type is unknown or unsupported", "isMeasurement": true },
+				"imageClipboardCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of input images sourced from clipboard or paste", "isMeasurement": true },
+				"imageScreenshotCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of input images sourced from screenshot capture", "isMeasurement": true },
+				"imageFileCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of input images sourced from local file attachment", "isMeasurement": true },
+				"imageUrlCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of input images sourced from URL", "isMeasurement": true },
+				"imageUnknownSourceCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of input images whose source could not be determined", "isMeasurement": true },
 				"isBYOK": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether the request was for a BYOK model", "isMeasurement": true },
 				"isAuto": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether the request was for an Auto model", "isMeasurement": true },
 				"wasRetried": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Whether the error will be retried", "isMeasurement": true },
@@ -406,6 +454,7 @@ export class ChatMLFetcherTelemetrySender {
 			timeToComplete: Date.now() - issuedTime,
 			issuedTime,
 			isVisionRequest: isVisionRequest ? 1 : -1,
+			...getImageTelemetryEventMeasurements(imageTelemetryMeasurements),
 			isBYOK: isBYOKModel(chatEndpointInfo),
 			isAuto: isAutoModel(chatEndpointInfo),
 			wasRetried: wasRetried ? 1 : 0,

--- a/extensions/copilot/src/platform/endpoint/node/automodeService.ts
+++ b/extensions/copilot/src/platform/endpoint/node/automodeService.ts
@@ -13,6 +13,7 @@ import { ChatLocation } from '../../../vscodeTypes';
 import { IAuthenticationService } from '../../authentication/common/authentication';
 import { ConfigKey, IConfigurationService } from '../../configuration/common/configurationService';
 import { IEnvService } from '../../env/common/envService';
+import { getImageTelemetryEventMeasurements, getImageTelemetryMeasurementsFromReferences } from '../../image/common/imageTelemetry';
 import { ILogService } from '../../log/common/logService';
 import { createCapiClientFetchedValue } from '../../networking/common/capiClientFetchedValue';
 import { isAbortError } from '../../networking/common/fetcherService';
@@ -194,6 +195,8 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 		const routerResult = skipRouter
 			? { lastRoutedPrompt: chatRequest?.prompt?.trim() ?? entry?.lastRoutedPrompt }
 			: await this._tryRouterSelection(chatRequest, conversationId, entry, token, knownEndpoints);
+		const imageTelemetryMeasurements = getImageTelemetryMeasurementsFromReferences(chatRequest?.references);
+		const imageTelemetryEventMeasurements = getImageTelemetryEventMeasurements(imageTelemetryMeasurements);
 		let selectedModel = routerResult.selectedModel;
 		const lastRoutedPrompt = routerResult.lastRoutedPrompt;
 		const routerFallbackReason = routerResult.fallbackReason;
@@ -206,13 +209,26 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 						"owner": "lramos15",
 						"comment": "Reports when the auto mode router is skipped or fails and falls back to default model selection",
 						"reason": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "The reason the router was skipped or failed, e.g. emptyPrompt, emptyCandidateList, noMatchingEndpoint, routerError, routerTimeout, or a server error code" },
-						"hasImage": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Whether the request contained an attached image" }
+						"hasImage": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Whether the request contained an attached image" },
+						"imageCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Number of input images attached to the request", "isMeasurement": true },
+						"totalImageBytes": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Sum of byte sizes for attached input images when known", "isMeasurement": true },
+						"maxImageBytes": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Largest known input image byte size in the request", "isMeasurement": true },
+						"imagePngCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of PNG input images", "isMeasurement": true },
+						"imageJpegCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of JPEG input images", "isMeasurement": true },
+						"imageGifCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of GIF input images", "isMeasurement": true },
+						"imageWebpCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of WebP input images", "isMeasurement": true },
+						"imageUnknownMimeCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of input images whose MIME type is unknown or unsupported", "isMeasurement": true },
+						"imageClipboardCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of input images sourced from clipboard or paste", "isMeasurement": true },
+						"imageScreenshotCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of input images sourced from screenshot capture", "isMeasurement": true },
+						"imageFileCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of input images sourced from local file attachment", "isMeasurement": true },
+						"imageUrlCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of input images sourced from URL", "isMeasurement": true },
+						"imageUnknownSourceCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of input images whose source could not be determined", "isMeasurement": true }
 					}
 				*/
 				this._telemetryService.sendMSFTTelemetryEvent('automode.routerFallback', {
 					reason: routerFallbackReason,
-					hasImage: String(hasImage(chatRequest)),
-				});
+					hasImage: String(imageTelemetryMeasurements.imageCount > 0),
+				}, imageTelemetryEventMeasurements);
 			}
 			selectedModel = this._selectDefaultModel(entry?.endpoint?.modelProvider, token.available_models, knownEndpoints);
 		}
@@ -229,7 +245,20 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 					"conversationId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The conversation ID" },
 					"candidateModel": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The router's top candidate model (candidate_models[0])" },
 					"actualModel": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The model actually selected after all client-side overrides" },
-					"overrideReason": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Why the actual model differs from the candidate: none or clientOverride" }
+					"overrideReason": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Why the actual model differs from the candidate: none or clientOverride" },
+					"imageCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Number of input images attached to the request", "isMeasurement": true },
+					"totalImageBytes": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Sum of byte sizes for attached input images when known", "isMeasurement": true },
+					"maxImageBytes": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Largest known input image byte size in the request", "isMeasurement": true },
+					"imagePngCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of PNG input images", "isMeasurement": true },
+					"imageJpegCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of JPEG input images", "isMeasurement": true },
+					"imageGifCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of GIF input images", "isMeasurement": true },
+					"imageWebpCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of WebP input images", "isMeasurement": true },
+					"imageUnknownMimeCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of input images whose MIME type is unknown or unsupported", "isMeasurement": true },
+					"imageClipboardCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of input images sourced from clipboard or paste", "isMeasurement": true },
+					"imageScreenshotCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of input images sourced from screenshot capture", "isMeasurement": true },
+					"imageFileCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of input images sourced from local file attachment", "isMeasurement": true },
+					"imageUrlCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of input images sourced from URL", "isMeasurement": true },
+					"imageUnknownSourceCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Count of input images whose source could not be determined", "isMeasurement": true }
 				}
 			*/
 			const candidateModel = routerResult.candidateModel;
@@ -239,7 +268,7 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 				candidateModel,
 				actualModel: selectedModel.model,
 				overrideReason,
-			});
+			}, imageTelemetryEventMeasurements);
 		}
 
 		// Reuse the cached endpoint if the session token and model haven't changed

--- a/extensions/copilot/src/platform/endpoint/node/test/automodeService.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/automodeService.spec.ts
@@ -929,7 +929,6 @@ describe('AutomodeService', () => {
 			const firstResult = await automodeService.resolveAutoModeEndpoint(chatRequest as ChatRequest, [gpt4oEndpoint, claudeEndpoint]);
 			expect(firstResult.model).toBe('gpt-4o');
 
-			// Without invalidation, changing prompt should still return cached model
 			const chatRequest2: Partial<ChatRequest> = {
 				location: ChatLocation.Panel,
 				prompt: 'second question',
@@ -938,10 +937,8 @@ describe('AutomodeService', () => {
 			const cachedResult = await automodeService.resolveAutoModeEndpoint(chatRequest2 as ChatRequest, [gpt4oEndpoint, claudeEndpoint]);
 			expect(cachedResult.model).toBe('gpt-4o');
 
-			// Invalidate the cache
 			automodeService.invalidateRouterCache({ sessionId: 'session-invalidate' } as ChatRequest);
 
-			// Now the router should re-run and pick claude
 			mockRouterResponse(
 				['gpt-4o', 'claude-sonnet'],
 				{ chosen_model: 'claude-sonnet', candidate_models: ['claude-sonnet'] }
@@ -1022,7 +1019,6 @@ describe('AutomodeService', () => {
 			};
 
 			const result = await automodeService.resolveAutoModeEndpoint(chatRequest as ChatRequest, [nonVisionEndpoint1, nonVisionEndpoint2]);
-			// No vision model available, should keep the first available model and warn
 			expect(result.model).toBe('gpt-4o-mini');
 			expect(mockLogService.warn).toHaveBeenCalledWith(
 				expect.stringContaining('no vision-capable model')
@@ -1093,7 +1089,6 @@ describe('AutomodeService', () => {
 			const gpt4oEndpoint = createEndpoint('gpt-4o', 'OpenAI', { supportsVision: true });
 			const claudeEndpoint = createEndpoint('claude-sonnet', 'Anthropic', { supportsVision: false });
 
-			// Router picks claude-sonnet (no vision), vision fallback should override to gpt-4o
 			mockRouterResponse(
 				['claude-sonnet', 'gpt-4o'],
 				{ chosen_model: 'claude-sonnet', candidate_models: ['claude-sonnet', 'gpt-4o'] }
@@ -1104,7 +1099,7 @@ describe('AutomodeService', () => {
 				location: ChatLocation.Panel,
 				prompt: 'describe this image',
 				sessionId: 'session-telemetry-vision',
-				references: [{ id: 'img', value: { mimeType: 'image/png', data: new Uint8Array() } }] as any
+				references: [{ id: 'img', value: { mimeType: 'image/png', data: new Uint8Array([1, 2, 3]), isPasted: true } }] as any
 			};
 
 			await automodeService.resolveAutoModeEndpoint(chatRequest as ChatRequest, [gpt4oEndpoint, claudeEndpoint]);
@@ -1116,6 +1111,13 @@ describe('AutomodeService', () => {
 				candidateModel: 'claude-sonnet',
 				actualModel: 'gpt-4o',
 				overrideReason: 'clientOverride',
+			});
+			expect(selectionEvent![2]).toMatchObject({
+				imageCount: 1,
+				totalImageBytes: 3,
+				maxImageBytes: 3,
+				imagePngCount: 1,
+				imageClipboardCount: 1,
 			});
 		});
 
@@ -1139,7 +1141,6 @@ describe('AutomodeService', () => {
 
 			const telemetryCalls = mockTelemetryService.sendMSFTTelemetryEvent.mock.calls;
 			const selectionEvent = telemetryCalls.find((call: unknown[]) => call[0] === 'automode.routerModelSelection');
-			// candidateModel is not set when router returns unknown model, so event should not emit
 			expect(selectionEvent).toBeUndefined();
 		});
 	});

--- a/extensions/copilot/src/platform/image/common/imageTelemetry.ts
+++ b/extensions/copilot/src/platform/image/common/imageTelemetry.ts
@@ -1,0 +1,239 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+type ImageTelemetrySource = 'clipboard' | 'screenshot' | 'file' | 'url' | 'unknown';
+
+export interface ImageTelemetryMeasurements {
+	imageCount: number;
+	totalImageBytes: number;
+	maxImageBytes: number;
+	imagePngCount: number;
+	imageJpegCount: number;
+	imageGifCount: number;
+	imageWebpCount: number;
+	imageUnknownMimeCount: number;
+	imageClipboardCount: number;
+	imageScreenshotCount: number;
+	imageFileCount: number;
+	imageUrlCount: number;
+	imageUnknownSourceCount: number;
+}
+
+interface ImageTelemetryInput {
+	mimeType?: string;
+	byteLength?: number;
+	source?: ImageTelemetrySource;
+}
+
+interface MessageWithContent {
+	content?: unknown;
+}
+
+interface ReferenceWithValue {
+	id?: unknown;
+	value?: unknown;
+}
+
+const screenshotVariableId = 'screenshot-focused-window';
+
+function createEmptyImageTelemetryMeasurements(): ImageTelemetryMeasurements {
+	return {
+		imageCount: 0,
+		totalImageBytes: 0,
+		maxImageBytes: 0,
+		imagePngCount: 0,
+		imageJpegCount: 0,
+		imageGifCount: 0,
+		imageWebpCount: 0,
+		imageUnknownMimeCount: 0,
+		imageClipboardCount: 0,
+		imageScreenshotCount: 0,
+		imageFileCount: 0,
+		imageUrlCount: 0,
+		imageUnknownSourceCount: 0,
+	};
+}
+
+export function getImageTelemetryEventMeasurements(measurements: ImageTelemetryMeasurements): Partial<ImageTelemetryMeasurements> {
+	return measurements.imageCount > 0 ? measurements : {};
+}
+
+export function getImageTelemetryMeasurementsFromMessages(messages: readonly MessageWithContent[] | undefined): ImageTelemetryMeasurements {
+	const measurements = createEmptyImageTelemetryMeasurements();
+
+	for (const message of messages ?? []) {
+		if (!Array.isArray(message.content)) {
+			continue;
+		}
+
+		for (const part of message.content) {
+			const imageUrl = getObjectProperty(part, 'imageUrl');
+			const url = getStringProperty(imageUrl, 'url');
+			if (!url) {
+				continue;
+			}
+
+			const input = getImageTelemetryInputFromUrl(url, getStringProperty(imageUrl, 'mediaType'));
+			if (input) {
+				addImageTelemetryInput(measurements, input);
+			}
+		}
+	}
+
+	return measurements;
+}
+
+export function getImageTelemetryMeasurementsFromReferences(references: readonly ReferenceWithValue[] | undefined): ImageTelemetryMeasurements {
+	const measurements = createEmptyImageTelemetryMeasurements();
+
+	for (const reference of references ?? []) {
+		const value = asRecord(reference.value);
+		if (!value) {
+			continue;
+		}
+
+		const mimeType = getStringProperty(value, 'mimeType');
+		if (!mimeType?.toLowerCase().startsWith('image/')) {
+			continue;
+		}
+
+		addImageTelemetryInput(measurements, {
+			mimeType,
+			byteLength: getByteLength(value.data) ?? getByteLength(value.value),
+			source: getImageSourceFromReference(reference, value),
+		});
+	}
+
+	return measurements;
+}
+
+function addImageTelemetryInput(measurements: ImageTelemetryMeasurements, input: ImageTelemetryInput): void {
+	measurements.imageCount++;
+
+	const byteLength = input.byteLength ?? 0;
+	measurements.totalImageBytes += byteLength;
+	measurements.maxImageBytes = Math.max(measurements.maxImageBytes, byteLength);
+
+	switch (normalizeMimeType(input.mimeType)) {
+		case 'png':
+			measurements.imagePngCount++;
+			break;
+		case 'jpeg':
+			measurements.imageJpegCount++;
+			break;
+		case 'gif':
+			measurements.imageGifCount++;
+			break;
+		case 'webp':
+			measurements.imageWebpCount++;
+			break;
+		default:
+			measurements.imageUnknownMimeCount++;
+	}
+
+	switch (input.source) {
+		case 'clipboard':
+			measurements.imageClipboardCount++;
+			break;
+		case 'screenshot':
+			measurements.imageScreenshotCount++;
+			break;
+		case 'file':
+			measurements.imageFileCount++;
+			break;
+		case 'url':
+			measurements.imageUrlCount++;
+			break;
+		default:
+			measurements.imageUnknownSourceCount++;
+	}
+}
+
+function getImageTelemetryInputFromUrl(url: string, mediaType: string | undefined): ImageTelemetryInput | undefined {
+	if (!url.startsWith('data:')) {
+		return url.startsWith('https://') ? { mimeType: mediaType, source: 'url' } : undefined;
+	}
+
+	const match = /^data:(image\/(?:jpeg|png|gif|webp));base64,(.+)$/.exec(url);
+	if (!match) {
+		return undefined;
+	}
+
+	return {
+		mimeType: mediaType ?? match[1],
+		byteLength: getBase64ByteLength(match[2]),
+		source: 'unknown',
+	};
+}
+
+function normalizeMimeType(mimeType: string | undefined): 'png' | 'jpeg' | 'gif' | 'webp' | 'unknown' {
+	const normalized = mimeType?.toLowerCase().split(';')[0].trim();
+	switch (normalized) {
+		case 'image/png':
+			return 'png';
+		case 'image/jpeg':
+		case 'image/jpg':
+			return 'jpeg';
+		case 'image/gif':
+			return 'gif';
+		case 'image/webp':
+			return 'webp';
+		default:
+			return 'unknown';
+	}
+}
+
+function getImageSourceFromReference(reference: ReferenceWithValue, value: Record<string, unknown>): ImageTelemetrySource {
+	if (value.isPasted === true) {
+		return 'clipboard';
+	}
+	if (value.isURL === true) {
+		return 'url';
+	}
+	if (reference.id === screenshotVariableId || value.id === screenshotVariableId) {
+		return 'screenshot';
+	}
+	if (value.isURL === false) {
+		return 'file';
+	}
+	return 'unknown';
+}
+
+function getBase64ByteLength(base64Data: string): number {
+	const trimmed = base64Data.trim();
+	let padding = 0;
+	if (trimmed.endsWith('==')) {
+		padding = 2;
+	} else if (trimmed.endsWith('=')) {
+		padding = 1;
+	}
+	return Math.max(0, Math.floor(trimmed.length * 3 / 4) - padding);
+}
+
+function getByteLength(value: unknown): number | undefined {
+	if (value instanceof ArrayBuffer) {
+		return value.byteLength;
+	}
+	if (ArrayBuffer.isView(value)) {
+		return value.byteLength;
+	}
+
+	const objectValue = asRecord(value);
+	const byteLength = objectValue?.byteLength;
+	return typeof byteLength === 'number' && Number.isFinite(byteLength) && byteLength >= 0 ? byteLength : undefined;
+}
+
+function getObjectProperty(value: unknown, property: string): Record<string, unknown> | undefined {
+	return asRecord(asRecord(value)?.[property]);
+}
+
+function getStringProperty(value: unknown, property: string): string | undefined {
+	const propertyValue = asRecord(value)?.[property];
+	return typeof propertyValue === 'string' ? propertyValue : undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+	return typeof value === 'object' && value !== null ? value as Record<string, unknown> : undefined;
+}

--- a/extensions/copilot/src/platform/image/common/test/imageTelemetry.spec.ts
+++ b/extensions/copilot/src/platform/image/common/test/imageTelemetry.spec.ts
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it } from 'vitest';
+import { getImageTelemetryEventMeasurements, getImageTelemetryMeasurementsFromMessages, getImageTelemetryMeasurementsFromReferences } from '../imageTelemetry';
+
+describe('imageTelemetry', () => {
+	it('collects MIME and byte counts from message data URLs', () => {
+		const measurements = getImageTelemetryMeasurementsFromMessages([
+			{
+				content: [
+					{ imageUrl: { url: 'data:image/png;base64,AQIDBA==' } },
+					{ imageUrl: { url: 'data:image/jpeg;base64,AQI=' } },
+				]
+			}
+		]);
+
+		expect(measurements).toMatchObject({
+			imageCount: 2,
+			totalImageBytes: 6,
+			maxImageBytes: 4,
+			imagePngCount: 1,
+			imageJpegCount: 1,
+			imageUnknownSourceCount: 2,
+		});
+	});
+
+	it('skips message image URLs that are not sent to the endpoint', () => {
+		const measurements = getImageTelemetryMeasurementsFromMessages([
+			{
+				content: [
+					{ imageUrl: { url: 'http://example.com/image.png', mediaType: 'image/png' } },
+					{ imageUrl: { url: 'data:image/svg+xml;base64,AQID' } },
+					{ imageUrl: { url: 'data:image/png,AQID' } },
+					{ imageUrl: { url: 'https://example.com/image.png', mediaType: 'image/png' } },
+				]
+			}
+		]);
+
+		expect(measurements).toMatchObject({
+			imageCount: 1,
+			imagePngCount: 1,
+			imageUrlCount: 1,
+		});
+	});
+
+	it('collects source and byte counts from image references', () => {
+		const measurements = getImageTelemetryMeasurementsFromReferences([
+			{ id: 'paste', value: { mimeType: 'image/png', data: new Uint8Array([1, 2]), isPasted: true } },
+			{ id: 'remote', value: { mimeType: 'image/webp', data: new Uint8Array([3]), isURL: true } },
+			{ id: 'local', value: { mimeType: 'image/gif', data: new Uint8Array([4, 5, 6]), isURL: false } },
+		]);
+
+		expect(measurements).toMatchObject({
+			imageCount: 3,
+			totalImageBytes: 6,
+			maxImageBytes: 3,
+			imagePngCount: 1,
+			imageGifCount: 1,
+			imageWebpCount: 1,
+			imageClipboardCount: 1,
+			imageFileCount: 1,
+			imageUrlCount: 1,
+		});
+	});
+
+	it('omits telemetry measures when no images are present', () => {
+		const measurements = getImageTelemetryMeasurementsFromMessages([{ content: [{ text: 'hello' }] }]);
+
+		expect(getImageTelemetryEventMeasurements(measurements)).toEqual({});
+	});
+});


### PR DESCRIPTION
This adds non-restricted aggregate image metadata to Copilot chat telemetry.

## Changes
- Add a shared image telemetry helper for safe aggregate measurements.
- Include image aggregate measurements on chat response telemetry:
  - `response.success`
  - `response.error`
  - `response.cancelled`
- Add image aggregate measurements to Copilot Auto model selection telemetry.

## Privacy
This does not send image content, base64 payloads, OCR/text extracted from images, file paths, URLs, image IDs, hashes, prompts, or model responses.

The telemetry is limited to aggregate counts/sizes/categories:
- image count
- total/max image bytes
- MIME-family counts
- source-category counts

Restricted/private telemetry, if needed later, should be added separately through the Hydro/CTS path.