### PR TITLE
cli: skip bare top-level directory entries when extracting archives

### DIFF
--- a/cli/src/util/extract_safety.rs
+++ b/cli/src/util/extract_safety.rs
@@ -43,9 +43,17 @@ pub fn prepare_extraction_root(root: &Path) -> Result<PathBuf, WrappedError> {
 }
 
 /// Joins an archive entry's relative path under `root_canonical` after
-/// rejecting any entry that would land outside the root. Rejects absolute
-/// paths, drive prefixes, and `..` traversal that escapes the root.
+/// rejecting any entry that would land outside the root. Rejects empty
+/// entries, absolute paths, drive prefixes, and `..` traversal that escapes
+/// the root.
 pub fn safe_extract_join(root_canonical: &Path, entry: &Path) -> Result<PathBuf, WrappedError> {
+	if entry.as_os_str().is_empty() {
+		return Err(wrap(
+			"empty extraction entry",
+			"refusing to extract empty archive entry".to_string(),
+		));
+	}
+
 	for component in entry.components() {
 		if matches!(component, Component::Prefix(_) | Component::RootDir) {
 			return Err(wrap(
@@ -168,6 +176,12 @@ mod tests {
 		assert!(safe_extract_join(&root, Path::new("/etc/passwd")).is_err());
 		let ok = safe_extract_join(&root, Path::new("a/b/c")).unwrap();
 		assert_eq!(ok, root.join("a/b/c"));
+	}
+
+	#[test]
+	fn safe_extract_join_rejects_empty_relative() {
+		let root = fs::canonicalize(std::env::temp_dir()).unwrap();
+		assert!(safe_extract_join(&root, Path::new("")).is_err());
 	}
 
 	#[cfg(unix)]

--- a/cli/src/util/tar.rs
+++ b/cli/src/util/tar.rs
@@ -107,8 +107,10 @@ where
 			// Skip bare top-level directory entries (e.g. "vscode-server-linux-x64/")
 			// once their single segment has been stripped. They contribute no file
 			// to extract, and the directory will be created on demand for nested
-			// entries below.
-			if relative.as_os_str().is_empty() {
+			// entries below. Only directory entries are skipped; non-directory
+			// entries with an empty relative path fall through to
+			// `safe_extract_join`, which rejects them.
+			if relative.as_os_str().is_empty() && entry.header().entry_type().is_dir() {
 				return Ok(());
 			}
 

--- a/cli/src/util/tar.rs
+++ b/cli/src/util/tar.rs
@@ -104,6 +104,14 @@ where
 				entry_path.into_owned()
 			};
 
+			// Skip bare top-level directory entries (e.g. "vscode-server-linux-x64/")
+			// once their single segment has been stripped. They contribute no file
+			// to extract, and the directory will be created on demand for nested
+			// entries below.
+			if relative.as_os_str().is_empty() {
+				return Ok(());
+			}
+
 			let path = safe_extract_join(&canonical_root, &relative)?;
 
 			if let Some(p) = path.parent() {
@@ -132,4 +140,62 @@ pub fn has_gzip_header(path: &Path) -> std::io::Result<(File, bool)> {
 	file.rewind()?;
 
 	Ok((file, header[0] == 0x1f && header[1] == 0x8b))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::util::io::SilentCopyProgress;
+	use flate2::write::GzEncoder;
+	use flate2::Compression;
+	use tar::{Builder, Header};
+
+	fn write_dir_entry(builder: &mut Builder<GzEncoder<Vec<u8>>>, name: &str) {
+		let mut header = Header::new_gnu();
+		header.set_size(0);
+		header.set_entry_type(tar::EntryType::Directory);
+		header.set_mode(0o755);
+		header.set_cksum();
+		builder.append_data(&mut header, name, std::io::empty()).unwrap();
+	}
+
+	fn write_file_entry(builder: &mut Builder<GzEncoder<Vec<u8>>>, name: &str, contents: &[u8]) {
+		let mut header = Header::new_gnu();
+		header.set_size(contents.len() as u64);
+		header.set_entry_type(tar::EntryType::Regular);
+		header.set_mode(0o644);
+		header.set_cksum();
+		builder.append_data(&mut header, name, contents).unwrap();
+	}
+
+	/// Regression test for #317660: a tarball with a bare top-level directory
+	/// entry (e.g. `prefix/`) plus files underneath used to fail extraction
+	/// with "extraction path resolves outside root" because the bare entry
+	/// produced an empty relative path after segment-stripping, whose parent
+	/// walked above the extraction root.
+	#[test]
+	fn decompress_tarball_with_bare_top_level_dir_entry() {
+		let tmp = tempfile::tempdir().unwrap();
+		let tar_path = tmp.path().join("archive.tar.gz");
+
+		let buf: Vec<u8> = {
+			let encoder = GzEncoder::new(Vec::new(), Compression::default());
+			let mut builder = Builder::new(encoder);
+			write_dir_entry(&mut builder, "prefix/");
+			write_file_entry(&mut builder, "prefix/file.txt", b"hello");
+			write_file_entry(&mut builder, "prefix/sub/nested.txt", b"world");
+			builder.into_inner().unwrap().finish().unwrap()
+		};
+
+		fs::write(&tar_path, &buf).unwrap();
+
+		let out_dir = tmp.path().join("out");
+		fs::create_dir_all(&out_dir).unwrap();
+
+		let file = fs::File::open(&tar_path).unwrap();
+		decompress_tarball(file, &out_dir, SilentCopyProgress()).expect("extraction should succeed");
+
+		assert_eq!(fs::read(out_dir.join("file.txt")).unwrap(), b"hello");
+		assert_eq!(fs::read(out_dir.join("sub/nested.txt")).unwrap(), b"world");
+	}
 }

--- a/cli/src/util/zipper.rs
+++ b/cli/src/util/zipper.rs
@@ -70,6 +70,11 @@ where
 		let outpath: PathBuf = match file.enclosed_name() {
 			Some(path) => {
 				let relative: PathBuf = path.iter().skip(skip_segments_no).collect();
+				// Skip bare top-level directory entries that become empty once
+				// their single segment has been stripped.
+				if relative.as_os_str().is_empty() {
+					continue;
+				}
 				safe_extract_join(&canonical_root, &relative)?
 			}
 			None => continue,

--- a/cli/src/util/zipper.rs
+++ b/cli/src/util/zipper.rs
@@ -71,8 +71,12 @@ where
 			Some(path) => {
 				let relative: PathBuf = path.iter().skip(skip_segments_no).collect();
 				// Skip bare top-level directory entries that become empty once
-				// their single segment has been stripped.
-				if relative.as_os_str().is_empty() {
+				// their single segment has been stripped. Only directory entries
+				// are skipped; non-directory entries with an empty relative path
+				// fall through to `safe_extract_join`, which rejects them.
+				if relative.as_os_str().is_empty()
+					&& (file.is_dir() || file.name().ends_with('/'))
+				{
 					continue;
 				}
 				safe_extract_join(&canonical_root, &relative)?


### PR DESCRIPTION
Fixes #317660

After #317393, Remote-SSH server installs fail with `extraction path resolves outside root` on any host whose server tarball includes a bare top-level directory entry (e.g. `vscode-server-linux-x64/`) — the default layout `tar` produces.

When `skip_first` is true, that bare entry collapses to an empty relative path; `safe_extract_join(root, "")` returns the root itself, and `path.parent()` then walks above the extraction root, tripping the containment check.

### Fix

- `safe_extract_join` rejects empty entries at the API boundary (defense in depth).
- `decompress_tarball` / `unzip_file` skip entries whose relative path is empty after segment-stripping. The bare prefix directory contributes no file, and any nested entries create directories on demand.

### Tests

- Unit test for the new empty-entry rejection in `safe_extract_join`.
- Integration test in `tar.rs` that synthesizes a tarball with a bare `prefix/` entry plus nested files and asserts `decompress_tarball` succeeds and extracts the contents.