### PR TITLE
worktrees: add command-center switcher and per-worktree state management

### DIFF
--- a/build/lib/i18n.resources.json
+++ b/build/lib/i18n.resources.json
@@ -283,6 +283,10 @@
 			"project": "vscode-workbench"
 		},
 		{
+			"name": "vs/workbench/contrib/worktrees",
+			"project": "vscode-workbench"
+		},
+		{
 			"name": "vs/workbench/contrib/customEditor",
 			"project": "vscode-workbench"
 		},

--- a/src/vs/workbench/browser/parts/titlebar/commandCenterControl.ts
+++ b/src/vs/workbench/browser/parts/titlebar/commandCenterControl.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { isActiveDocument, reset } from '../../../../base/browser/dom.js';
+import { getWindow, isActiveDocument, reset } from '../../../../base/browser/dom.js';
 import { BaseActionViewItem, IBaseActionViewItemOptions } from '../../../../base/browser/ui/actionbar/actionViewItems.js';
 import { getDefaultHoverDelegate } from '../../../../base/browser/ui/hover/hoverDelegateFactory.js';
 import { IHoverDelegate } from '../../../../base/browser/ui/hover/hoverDelegate.js';
@@ -14,6 +14,7 @@ import { Emitter, Event } from '../../../../base/common/event.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { autorun } from '../../../../base/common/observable.js';
 import { localize } from '../../../../nls.js';
+import { IActionViewItemService } from '../../../../platform/actions/browser/actionViewItemService.js';
 import { createActionViewItem } from '../../../../platform/actions/browser/menuEntryActionViewItem.js';
 import { HiddenItemStrategy, MenuWorkbenchToolBar, WorkbenchToolBar } from '../../../../platform/actions/browser/toolbar.js';
 import { MenuId, MenuRegistry, SubmenuItemAction } from '../../../../platform/actions/common/actions.js';
@@ -105,6 +106,7 @@ class CommandCenterCenterViewItem extends BaseActionViewItem {
 		@IInstantiationService private _instaService: IInstantiationService,
 		@IEditorGroupsService private _editorGroupService: IEditorGroupsService,
 		@IConfigurationService private _configurationService: IConfigurationService,
+		@IActionViewItemService private readonly _actionViewItemService: IActionViewItemService,
 	) {
 		super(undefined, _submenu.actions.find(action => action.id === 'workbench.action.quickOpenWithModes') ?? _submenu.actions[0], options);
 		this._hoverDelegate = options.hoverDelegate ?? getDefaultHoverDelegate('mouse');
@@ -146,6 +148,16 @@ class CommandCenterCenterViewItem extends BaseActionViewItem {
 					};
 
 					if (action.id !== CommandCenterCenterViewItem._quickOpenCommandId) {
+						// Let other contributions supply a custom view item for any
+						// action rendered inside this pill (matches what
+						// MenuWorkbenchToolBar does at the outer level).
+						const factory = this._actionViewItemService.lookUp(MenuId.CommandCenterCenter, action instanceof SubmenuItemAction ? action.item.submenu.id : action.id);
+						if (factory) {
+							const custom = factory(action, options, this._instaService, getWindow(container).vscodeWindowId);
+							if (custom) {
+								return custom;
+							}
+						}
 						return createActionViewItem(this._instaService, action, options);
 					}
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/experiments/agentTitleBarStatusWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/experiments/agentTitleBarStatusWidget.ts
@@ -167,6 +167,7 @@ export class AgentTitleBarStatusWidget extends BaseActionViewItem {
 		@IChatEntitlementService private readonly chatEntitlementService: IChatEntitlementService,
 		@IChatWidgetService private readonly chatWidgetService: IChatWidgetService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
+		@IActionViewItemService private readonly actionViewItemService: IActionViewItemService,
 	) {
 		super(undefined, action, options);
 
@@ -752,7 +753,18 @@ export class AgentTitleBarStatusWidget extends BaseActionViewItem {
 			hiddenItemStrategy: HiddenItemStrategy.NoHide,
 			telemetrySource: 'agentStatusCommandCenter',
 			actionViewItemProvider: (action, options) => {
-				return createActionViewItem(this.instantiationService, action, { ...options, hoverDelegate });
+				const mergedOptions = { ...options, hoverDelegate };
+				// Allow other contributions to supply a custom view item for any
+				// action rendered inside the agent pill — same mechanism the
+				// outer command-center toolbar uses via MenuWorkbenchToolBar.
+				const factory = this.actionViewItemService.lookUp(MenuId.CommandCenterCenter, action instanceof SubmenuItemAction ? action.item.submenu.id : action.id);
+				if (factory) {
+					const custom = factory(action, mergedOptions, this.instantiationService, getWindow(toolbarContainer).vscodeWindowId);
+					if (custom) {
+						return custom;
+					}
+				}
+				return createActionViewItem(this.instantiationService, action, mergedOptions);
 			}
 		});
 		disposables.add(toolbar);

--- a/src/vs/workbench/contrib/worktrees/browser/media/worktreeSwitcher.css
+++ b/src/vs/workbench/contrib/worktrees/browser/media/worktreeSwitcher.css
@@ -1,0 +1,92 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* Hide the real flex separator so it doesn't take 1px of horizontal space; we
+ * draw an overlay separator on our switcher's right edge via `::after` below.
+ * Matches the chat toggle's `::before` pattern in agenttitlebarstatuswidget.css. */
+.agent-status-command-center-toolbar:has(.worktree-switcher-host) + .agent-status-line-separator {
+	display: none;
+}
+
+/* The action-item wrapper handed to us by the toolbar. No chrome of its own. */
+.worktree-switcher-host {
+	display: flex;
+	align-items: center;
+	height: 100%;
+}
+
+.worktree-switcher {
+	position: relative;
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	height: 100%;
+	padding: 0 8px;
+	cursor: pointer;
+	user-select: none;
+	color: var(--vscode-titleBar-activeForeground);
+	-webkit-app-region: no-drag;
+	max-width: 260px;
+	min-width: 0;
+	border-radius: 5px 0 0 5px;
+}
+
+/* Overlay 1px divider on our right edge — mirrors the chat toggle's
+ * badge-section divider in dimensions and color. Does not take flex space. */
+.worktree-switcher::after {
+	content: '';
+	position: absolute;
+	right: 0;
+	top: 4px;
+	bottom: 4px;
+	width: 1px;
+	background-color: var(--vscode-commandCenter-border, rgba(128, 128, 128, 0.35));
+	pointer-events: none;
+}
+
+.worktree-switcher:hover {
+	background-color: var(--vscode-toolbar-hoverBackground);
+}
+
+.worktree-switcher:focus,
+.worktree-switcher:focus-visible {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: -1px;
+}
+
+.worktree-switcher > .icon {
+	flex-shrink: 0;
+	font-size: 14px;
+	opacity: 0.85;
+}
+
+.worktree-switcher > .worktree-name,
+.worktree-switcher > .branch-name {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	min-width: 0;
+	font-size: 12px;
+}
+
+.worktree-switcher > .worktree-name {
+	max-width: 120px;
+}
+
+.worktree-switcher > .branch-name {
+	max-width: 120px;
+	opacity: 0.85;
+}
+
+.worktree-switcher > .separator {
+	flex-shrink: 0;
+	opacity: 0.5;
+	margin: 0 2px;
+}
+
+.worktree-switcher.empty > .worktree-name {
+	max-width: none;
+	opacity: 0.8;
+}

--- a/src/vs/workbench/contrib/worktrees/browser/worktreeLayoutController.ts
+++ b/src/vs/workbench/contrib/worktrees/browser/worktreeLayoutController.ts
@@ -50,6 +50,7 @@ interface IWorktreeLayoutEntry {
 	readonly worktreeResource: string;
 	readonly viewState?: IWorktreeViewState;
 	readonly editorWorkingSet?: IEditorWorkingSet;
+	readonly panelVisible?: boolean;
 }
 
 const WORKTREE_LAYOUT_STATE_KEY = 'worktrees.layoutState';
@@ -313,6 +314,9 @@ export class WorktreeLayoutController extends Disposable {
 				if (entry.viewState) {
 					this._viewStateByWorktree.set(uri, entry.viewState);
 				}
+				if (typeof entry.panelVisible === 'boolean') {
+					this._panelVisibilityByWorktree.set(uri, entry.panelVisible);
+				}
 			}
 		} catch {
 			this._storageService.remove(WORKTREE_LAYOUT_STATE_KEY, StorageScope.WORKSPACE);
@@ -329,6 +333,7 @@ export class WorktreeLayoutController extends Disposable {
 		const allResources = new ResourceMap<true>();
 		this._workingSets.forEach((_, r) => allResources.set(r, true));
 		this._viewStateByWorktree.forEach((_, r) => allResources.set(r, true));
+		this._panelVisibilityByWorktree.forEach((_, r) => allResources.set(r, true));
 
 		if (allResources.size === 0) {
 			this._storageService.remove(WORKTREE_LAYOUT_STATE_KEY, StorageScope.WORKSPACE);
@@ -341,6 +346,7 @@ export class WorktreeLayoutController extends Disposable {
 				worktreeResource: resource.toString(),
 				editorWorkingSet: this._workingSets.get(resource),
 				viewState: this._viewStateByWorktree.get(resource),
+				panelVisible: this._panelVisibilityByWorktree.get(resource),
 			});
 		});
 		this._storageService.store(WORKTREE_LAYOUT_STATE_KEY, JSON.stringify(entries), StorageScope.WORKSPACE, StorageTarget.MACHINE);

--- a/src/vs/workbench/contrib/worktrees/browser/worktreeLayoutController.ts
+++ b/src/vs/workbench/contrib/worktrees/browser/worktreeLayoutController.ts
@@ -10,6 +10,7 @@ import { ResourceMap } from '../../../../base/common/map.js';
 import { autorun, derivedObservableWithCache, derivedOpts, observableFromEvent, runOnChange } from '../../../../base/common/observable.js';
 import { isEqual } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
 import { IEditorIdentifier } from '../../../common/editor.js';
@@ -78,6 +79,7 @@ export class WorktreeLayoutController extends Disposable {
 		@IEditorService private readonly _editorService: IEditorService,
 		@IEditorGroupsService private readonly _editorGroupsService: IEditorGroupsService,
 		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
+		@ILogService private readonly _logService: ILogService,
 	) {
 		super();
 
@@ -144,15 +146,19 @@ export class WorktreeLayoutController extends Disposable {
 
 		this._register(runOnChange(activeWorktreeForWorkingSet, (worktree, previous) => {
 			void this._workingSetSequencer.queue(async () => {
-				if (previous) {
-					await this._closeUnrestorableEditors();
-					this._saveWorkingSet(previous.uri);
-				}
-				// On initial load (no previous), only apply if we have a saved
-				// working set — skip applying 'empty' to avoid closing editors
-				// being restored.
-				if (previous || (worktree && this._workingSets.has(worktree.uri))) {
-					await this._applyWorkingSetInner(worktree?.uri);
+				try {
+					if (previous) {
+						await this._closeUnrestorableEditors();
+						this._saveWorkingSet(previous.uri);
+					}
+					// On initial load (no previous), only apply if we have a saved
+					// working set — skip applying 'empty' to avoid closing editors
+					// being restored.
+					if (previous || (worktree && this._workingSets.has(worktree.uri))) {
+						await this._applyWorkingSetInner(worktree?.uri);
+					}
+				} catch (err) {
+					this._logService.warn('[Worktrees] layout transition failed', err);
 				}
 			});
 		}));
@@ -318,7 +324,8 @@ export class WorktreeLayoutController extends Disposable {
 					this._panelVisibilityByWorktree.set(uri, entry.panelVisible);
 				}
 			}
-		} catch {
+		} catch (err) {
+			this._logService.warn('[Worktrees] failed to parse layout state, discarding', err);
 			this._storageService.remove(WORKTREE_LAYOUT_STATE_KEY, StorageScope.WORKSPACE);
 		}
 	}

--- a/src/vs/workbench/contrib/worktrees/browser/worktreeLayoutController.ts
+++ b/src/vs/workbench/contrib/worktrees/browser/worktreeLayoutController.ts
@@ -1,0 +1,348 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { mainWindow } from '../../../../base/browser/window.js';
+import { Sequencer } from '../../../../base/common/async.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { ResourceMap } from '../../../../base/common/map.js';
+import { autorun, derivedObservableWithCache, derivedOpts, observableFromEvent, runOnChange } from '../../../../base/common/observable.js';
+import { isEqual } from '../../../../base/common/resources.js';
+import { URI } from '../../../../base/common/uri.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
+import { IEditorIdentifier } from '../../../common/editor.js';
+import { ViewContainerLocation } from '../../../common/views.js';
+import { IEditorGroupsService, IEditorWorkingSet } from '../../../services/editor/common/editorGroupsService.js';
+import { IEditorService } from '../../../services/editor/common/editorService.js';
+import { IWorkbenchLayoutService, Parts } from '../../../services/layout/browser/layoutService.js';
+import { IPaneCompositePartService } from '../../../services/panecomposite/browser/panecomposite.js';
+import { IViewsService } from '../../../services/views/common/viewsService.js';
+import { IWorktree, IWorktreeGroupService } from '../../../services/worktrees/common/worktrees.js';
+
+/**
+ * Editor input typeIds that don't survive `editorGroupsService.applyWorkingSet`
+ * because their backing model lives in a separate manager which disposes the
+ * model when the editor closes. On restore, the saved input's `resolve()`
+ * asserts that the model still exists and throws. We pre-close these on
+ * switch so the working set only contains restore-safe inputs.
+ *
+ * - `workbench.editors.webviewEditor`: CustomEditorInput (e.g. Markdown
+ *   preview, image previewer, any contributed custom editor).
+ * - `workbench.editors.webviewInput`: WebviewInput (extension webview panels
+ *   surfaced as editors).
+ */
+const UNRESTORABLE_EDITOR_TYPE_IDS: ReadonlySet<string> = new Set([
+	'workbench.editors.webviewEditor',
+	'workbench.editors.webviewInput',
+]);
+
+/**
+ * Per-worktree view state captured when switching away.
+ */
+interface IWorktreeViewState {
+	readonly auxiliaryBarVisible: boolean;
+	readonly auxiliaryBarActiveViewContainerId: string | undefined;
+}
+
+interface IWorktreeLayoutEntry {
+	readonly worktreeResource: string;
+	readonly viewState?: IWorktreeViewState;
+	readonly editorWorkingSet?: IEditorWorkingSet;
+}
+
+const WORKTREE_LAYOUT_STATE_KEY = 'worktrees.layoutState';
+
+/**
+ * Saves and restores per-worktree layout state: editor working set, auxiliary
+ * bar visibility, and panel visibility. Mirrors the Sessions layout controller
+ * but keyed by worktree URI instead of session resource.
+ */
+export class WorktreeLayoutController extends Disposable {
+
+	static readonly ID = 'workbench.contrib.worktrees.layoutController';
+
+	private readonly _panelVisibilityByWorktree = new ResourceMap<boolean>();
+	private readonly _viewStateByWorktree = new ResourceMap<IWorktreeViewState>();
+	private readonly _workingSets = new ResourceMap<IEditorWorkingSet>();
+	private readonly _workingSetSequencer = new Sequencer();
+
+	constructor(
+		@IWorkbenchLayoutService private readonly _layoutService: IWorkbenchLayoutService,
+		@IWorktreeGroupService private readonly _worktreeGroupService: IWorktreeGroupService,
+		@IViewsService private readonly _viewsService: IViewsService,
+		@IPaneCompositePartService private readonly _paneCompositePartService: IPaneCompositePartService,
+		@IStorageService private readonly _storageService: IStorageService,
+		@IEditorService private readonly _editorService: IEditorService,
+		@IEditorGroupsService private readonly _editorGroupsService: IEditorGroupsService,
+		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
+	) {
+		super();
+
+		this._loadState();
+		this._register(this._storageService.onWillSaveState(() => this._saveState()));
+
+		const activeWorktreeUriObs = derivedOpts<URI | undefined>({
+			equalsFn: isEqual,
+		}, reader => this._worktreeGroupService.activeWorktree.read(reader)?.uri);
+
+		// Auxiliary bar: capture outgoing state immediately so we snapshot the
+		// user's current aux bar before the workspace folder swap fires any
+		// resets. Restore happens later, on `activeWorktreeForWorkingSet`,
+		// after the workspace has caught up — otherwise the workbench's own
+		// per-workspace layout restoration overwrites ours.
+		let previousWorktreeUri: URI | undefined;
+		this._register(autorun(reader => {
+			const activeUri = activeWorktreeUriObs.read(reader);
+
+			const isWorktreeSwitch = previousWorktreeUri !== undefined
+				&& !isEqual(previousWorktreeUri, activeUri);
+			if (isWorktreeSwitch) {
+				this._captureViewState(previousWorktreeUri!);
+			}
+			previousWorktreeUri = activeUri;
+		}));
+
+		// Panel visibility tracking — record user toggles.
+		this._register(this._layoutService.onDidChangePartVisibility(e => {
+			if (e.partId !== Parts.PANEL_PART) {
+				return;
+			}
+			const active = this._worktreeGroupService.activeWorktree.get();
+			if (active) {
+				this._panelVisibilityByWorktree.set(active.uri, e.visible);
+			}
+		}));
+
+		// Panel visibility: restore on switch.
+		this._register(autorun(reader => {
+			const activeUri = activeWorktreeUriObs.read(reader);
+			this._syncPanelVisibility(activeUri);
+		}));
+
+		// Editor working sets — only apply after workspace folders match the
+		// active worktree, otherwise we'd close editors mid-swap.
+		const workspaceFoldersObs = observableFromEvent(
+			this._workspaceContextService.onDidChangeWorkspaceFolders,
+			() => this._workspaceContextService.getWorkspace().folders,
+		);
+
+		const activeWorktreeForWorkingSet = derivedObservableWithCache<IWorktree | undefined>(this, (reader, lastValue) => {
+			const folders = workspaceFoldersObs.read(reader);
+			const active = this._worktreeGroupService.activeWorktree.read(reader);
+			if (active && !folders.some(f => isEqual(f.uri, active.uri))) {
+				// Workspace hasn't caught up to the new worktree yet — keep last value.
+				return lastValue;
+			}
+			if (isEqual(active?.uri, lastValue?.uri)) {
+				return lastValue;
+			}
+			return active;
+		});
+
+		this._register(runOnChange(activeWorktreeForWorkingSet, (worktree, previous) => {
+			void this._workingSetSequencer.queue(async () => {
+				if (previous) {
+					await this._closeUnrestorableEditors();
+					this._saveWorkingSet(previous.uri);
+				}
+				// On initial load (no previous), only apply if we have a saved
+				// working set — skip applying 'empty' to avoid closing editors
+				// being restored.
+				if (previous || (worktree && this._workingSets.has(worktree.uri))) {
+					await this._applyWorkingSetInner(worktree?.uri);
+				}
+			});
+		}));
+
+		// Aux bar restore: runs once the workspace folders have caught up to
+		// the active worktree, so the workbench's own per-workspace layout
+		// restoration can't overwrite us. Falls back to the previous worktree's
+		// state on a first visit so visibility "carries over" naturally rather
+		// than collapsing to the new workspace's default.
+		this._register(runOnChange(activeWorktreeForWorkingSet, (worktree, previous) => {
+			if (!worktree) {
+				return;
+			}
+			this._syncAuxiliaryBarVisibility(worktree.uri, previous?.uri);
+		}));
+
+		// Drop state for worktrees that disappeared from the filesystem.
+		this._register(this._worktreeGroupService.onDidChangeWorktrees(e => {
+			for (const removed of e.removed) {
+				this._deleteWorkingSet(removed.uri);
+			}
+		}));
+	}
+
+	// --- Auxiliary bar ---
+
+	private _captureViewState(worktreeUri: URI): void {
+		const auxiliaryBarVisible = this._layoutService.isVisible(Parts.AUXILIARYBAR_PART);
+		const activeViewContainerId = this._paneCompositePartService.getActivePaneComposite(ViewContainerLocation.AuxiliaryBar)?.getId();
+		this._viewStateByWorktree.set(worktreeUri, {
+			auxiliaryBarVisible,
+			auxiliaryBarActiveViewContainerId: activeViewContainerId,
+		});
+	}
+
+	private _syncAuxiliaryBarVisibility(worktreeUri: URI, fallbackUri: URI | undefined): void {
+		// Prefer the worktree's own saved state. On a first visit there's no
+		// saved state, so carry over from the worktree we just switched away
+		// from — this keeps aux bar visibility stable across switches instead
+		// of collapsing to the new workspace's default (which is what the
+		// workbench's per-workspace restoration produces).
+		const state = this._viewStateByWorktree.get(worktreeUri)
+			?? (fallbackUri ? this._viewStateByWorktree.get(fallbackUri) : undefined);
+		if (!state) {
+			return;
+		}
+		if (!state.auxiliaryBarVisible) {
+			this._layoutService.setPartHidden(true, Parts.AUXILIARYBAR_PART);
+			return;
+		}
+		// Explicit show — `openViewContainer` alone doesn't unhide the part,
+		// so without this we'd silently no-op when the workbench has just
+		// hidden the aux bar as part of its workspace-folder restoration.
+		this._layoutService.setPartHidden(false, Parts.AUXILIARYBAR_PART);
+		if (state.auxiliaryBarActiveViewContainerId) {
+			this._viewsService.openViewContainer(state.auxiliaryBarActiveViewContainerId, false);
+		}
+	}
+
+	// --- Panel ---
+
+	private _syncPanelVisibility(worktreeUri: URI | undefined): void {
+		if (!worktreeUri) {
+			return;
+		}
+		const saved = this._panelVisibilityByWorktree.get(worktreeUri);
+		if (saved === undefined) {
+			// No record — leave panel as the user last set it.
+			return;
+		}
+		this._layoutService.setPartHidden(!saved, Parts.PANEL_PART);
+	}
+
+	// --- Editor working sets ---
+
+	private async _applyWorkingSetInner(worktreeUri: URI | undefined): Promise<void> {
+		const preserveFocus = this._layoutService.hasFocus(Parts.PANEL_PART);
+		const workingSet: IEditorWorkingSet | 'empty' = worktreeUri
+			? (this._workingSets.get(worktreeUri) ?? 'empty')
+			: 'empty';
+
+		if (workingSet === 'empty') {
+			await this._editorGroupsService.applyWorkingSet(workingSet, { preserveFocus });
+			return;
+		}
+
+		if (!this._layoutService.isVisible(Parts.EDITOR_PART, mainWindow)) {
+			this._layoutService.setPartHidden(false, Parts.EDITOR_PART);
+		}
+
+		const result = await this._editorGroupsService.applyWorkingSet(workingSet, { preserveFocus });
+		if (result && !this._layoutService.isVisible(Parts.EDITOR_PART, mainWindow)) {
+			this._layoutService.setPartHidden(false, Parts.EDITOR_PART);
+		}
+	}
+
+	/**
+	 * Closes editors whose typeIds are listed in `UNRESTORABLE_EDITOR_TYPE_IDS`,
+	 * so the subsequent `saveWorkingSet` snapshot contains only inputs that can
+	 * be restored cleanly later. Best-effort: failures are non-fatal.
+	 */
+	private async _closeUnrestorableEditors(): Promise<void> {
+		const toClose: IEditorIdentifier[] = [];
+		for (const group of this._editorGroupsService.groups) {
+			for (const editor of group.editors) {
+				if (UNRESTORABLE_EDITOR_TYPE_IDS.has(editor.typeId)) {
+					toClose.push({ editor, groupId: group.id });
+				}
+			}
+		}
+		if (toClose.length === 0) {
+			return;
+		}
+		await this._editorService.closeEditors(toClose, { preserveFocus: true });
+	}
+
+	private _saveWorkingSet(worktreeUri: URI): void {
+		this._deleteWorkingSet(worktreeUri);
+		if (this._editorService.visibleEditors.length === 0) {
+			return;
+		}
+		// Defensive: never persist a working set that contains an editor whose
+		// restore would throw. The runtime switch path already pre-closes these
+		// via `_closeUnrestorableEditors`, but the sync shutdown path
+		// (onWillSaveState) can't await, so the guard keeps the saved state
+		// safe to apply later.
+		if (this._editorService.visibleEditors.some(e => UNRESTORABLE_EDITOR_TYPE_IDS.has(e.typeId))) {
+			return;
+		}
+		const workingSetName = `worktree-working-set:${worktreeUri.toString()}`;
+		const workingSet = this._editorGroupsService.saveWorkingSet(workingSetName);
+		this._workingSets.set(worktreeUri, workingSet);
+	}
+
+	private _deleteWorkingSet(worktreeUri: URI): void {
+		const existing = this._workingSets.get(worktreeUri);
+		if (!existing) {
+			return;
+		}
+		this._editorGroupsService.deleteWorkingSet(existing);
+		this._workingSets.delete(worktreeUri);
+		this._viewStateByWorktree.delete(worktreeUri);
+		this._panelVisibilityByWorktree.delete(worktreeUri);
+	}
+
+	// --- Persistence ---
+
+	private _loadState(): void {
+		const raw = this._storageService.get(WORKTREE_LAYOUT_STATE_KEY, StorageScope.WORKSPACE);
+		if (!raw) {
+			return;
+		}
+		try {
+			for (const entry of JSON.parse(raw) as IWorktreeLayoutEntry[]) {
+				const uri = URI.parse(entry.worktreeResource);
+				if (entry.editorWorkingSet) {
+					this._workingSets.set(uri, entry.editorWorkingSet);
+				}
+				if (entry.viewState) {
+					this._viewStateByWorktree.set(uri, entry.viewState);
+				}
+			}
+		} catch {
+			this._storageService.remove(WORKTREE_LAYOUT_STATE_KEY, StorageScope.WORKSPACE);
+		}
+	}
+
+	private _saveState(): void {
+		const active = this._worktreeGroupService.activeWorktree.get();
+		if (active) {
+			this._captureViewState(active.uri);
+			this._saveWorkingSet(active.uri);
+		}
+
+		const allResources = new ResourceMap<true>();
+		this._workingSets.forEach((_, r) => allResources.set(r, true));
+		this._viewStateByWorktree.forEach((_, r) => allResources.set(r, true));
+
+		if (allResources.size === 0) {
+			this._storageService.remove(WORKTREE_LAYOUT_STATE_KEY, StorageScope.WORKSPACE);
+			return;
+		}
+
+		const entries: IWorktreeLayoutEntry[] = [];
+		allResources.forEach((_, resource) => {
+			entries.push({
+				worktreeResource: resource.toString(),
+				editorWorkingSet: this._workingSets.get(resource),
+				viewState: this._viewStateByWorktree.get(resource),
+			});
+		});
+		this._storageService.store(WORKTREE_LAYOUT_STATE_KEY, JSON.stringify(entries), StorageScope.WORKSPACE, StorageTarget.MACHINE);
+	}
+}

--- a/src/vs/workbench/contrib/worktrees/browser/worktreeSwitcherViewItem.ts
+++ b/src/vs/workbench/contrib/worktrees/browser/worktreeSwitcherViewItem.ts
@@ -1,0 +1,99 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import './media/worktreeSwitcher.css';
+import * as DOM from '../../../../base/browser/dom.js';
+import { BaseActionViewItem, IBaseActionViewItemOptions } from '../../../../base/browser/ui/actionbar/actionViewItems.js';
+import { getDefaultHoverDelegate } from '../../../../base/browser/ui/hover/hoverDelegateFactory.js';
+import { Codicon } from '../../../../base/common/codicons.js';
+import { autorun } from '../../../../base/common/observable.js';
+import { ThemeIcon } from '../../../../base/common/themables.js';
+import { IAction } from '../../../../base/common/actions.js';
+import { localize } from '../../../../nls.js';
+import { IHoverService } from '../../../../platform/hover/browser/hover.js';
+import { IWorktreeGroupService } from '../../../services/worktrees/common/worktrees.js';
+
+const $ = DOM.$;
+
+/**
+ * Renders the active worktree as a clickable pill in the titlebar:
+ * `[repo-icon] <worktree-name>  /  [git-branch] <branch-name>`. Click runs
+ * the wrapped action (typically `workbench.action.worktrees.switch`), which
+ * opens the worktree quick pick.
+ */
+export class WorktreeSwitcherViewItem extends BaseActionViewItem {
+
+	constructor(
+		action: IAction,
+		options: IBaseActionViewItemOptions,
+		@IWorktreeGroupService private readonly worktreeGroupService: IWorktreeGroupService,
+		@IHoverService private readonly hoverService: IHoverService,
+	) {
+		super(undefined, action, options);
+	}
+
+	override render(container: HTMLElement): void {
+		super.render(container);
+		container.classList.add('worktree-switcher-host');
+
+		const root = DOM.append(container, $('.worktree-switcher'));
+		root.role = 'button';
+		root.tabIndex = 0;
+
+		const worktreeIcon = DOM.append(root, $('span.icon'));
+		const worktreeLabel = DOM.append(root, $('span.worktree-name'));
+		const separator = DOM.append(root, $('span.separator'));
+		separator.textContent = '/';
+		const branchIcon = DOM.append(root, $('span.icon.branch'));
+		const branchLabel = DOM.append(root, $('span.branch-name'));
+
+		const hoverDelegate = this.options.hoverDelegate ?? getDefaultHoverDelegate('mouse');
+		const hover = this._register(this.hoverService.setupManagedHover(hoverDelegate, root, ''));
+
+		this._register(autorun(reader => {
+			const active = this.worktreeGroupService.activeWorktree.read(reader);
+			if (!active) {
+				root.classList.add('empty');
+				worktreeIcon.className = `icon ${ThemeIcon.asClassName(Codicon.listTree)}`;
+				worktreeLabel.textContent = localize('worktrees.switcher.none', "Worktrees");
+				separator.style.display = 'none';
+				branchIcon.style.display = 'none';
+				branchLabel.textContent = '';
+				hover.update(localize('worktrees.switcher.tooltip.none', "Switch Worktree..."));
+				return;
+			}
+
+			root.classList.remove('empty');
+			// Main worktree → repo icon; linked → list-tree (matches SCM's worktree picker).
+			worktreeIcon.className = `icon ${ThemeIcon.asClassName(active.isMain ? Codicon.repo : Codicon.listTree)}`;
+			worktreeLabel.textContent = active.label.read(reader);
+
+			const branch = active.branch.read(reader);
+			if (branch) {
+				separator.style.display = '';
+				branchIcon.style.display = '';
+				branchIcon.className = `icon branch ${ThemeIcon.asClassName(Codicon.gitBranch)}`;
+				branchLabel.textContent = branch;
+				hover.update(localize('worktrees.switcher.tooltip', "{0} ({1}) — Click to switch worktree", active.label.read(reader), branch));
+			} else {
+				separator.style.display = 'none';
+				branchIcon.style.display = 'none';
+				branchLabel.textContent = '';
+				hover.update(localize('worktrees.switcher.tooltip.nobranch', "{0} — Click to switch worktree", active.label.read(reader)));
+			}
+		}));
+
+		this._register(DOM.addDisposableListener(root, DOM.EventType.CLICK, e => {
+			DOM.EventHelper.stop(e, true);
+			this.actionRunner.run(this._action);
+		}));
+		this._register(DOM.addDisposableListener(root, DOM.EventType.KEY_DOWN, (e: KeyboardEvent) => {
+			if (e.key === 'Enter' || e.key === ' ') {
+				DOM.EventHelper.stop(e, true);
+				this.actionRunner.run(this._action);
+			}
+		}));
+	}
+}

--- a/src/vs/workbench/contrib/worktrees/browser/worktreeSwitcherViewItem.ts
+++ b/src/vs/workbench/contrib/worktrees/browser/worktreeSwitcherViewItem.ts
@@ -61,28 +61,34 @@ export class WorktreeSwitcherViewItem extends BaseActionViewItem {
 				separator.style.display = 'none';
 				branchIcon.style.display = 'none';
 				branchLabel.textContent = '';
-				hover.update(localize('worktrees.switcher.tooltip.none', "Switch Worktree..."));
+				const tooltip = localize('worktrees.switcher.tooltip.none', "Switch Worktree...");
+				hover.update(tooltip);
+				root.setAttribute('aria-label', tooltip);
 				return;
 			}
 
 			root.classList.remove('empty');
 			// Main worktree → repo icon; linked → list-tree (matches SCM's worktree picker).
 			worktreeIcon.className = `icon ${ThemeIcon.asClassName(active.isMain ? Codicon.repo : Codicon.listTree)}`;
-			worktreeLabel.textContent = active.label.read(reader);
+			const activeLabel = active.label.read(reader);
+			worktreeLabel.textContent = activeLabel;
 
 			const branch = active.branch.read(reader);
+			let tooltip: string;
 			if (branch) {
 				separator.style.display = '';
 				branchIcon.style.display = '';
 				branchIcon.className = `icon branch ${ThemeIcon.asClassName(Codicon.gitBranch)}`;
 				branchLabel.textContent = branch;
-				hover.update(localize('worktrees.switcher.tooltip', "{0} ({1}) — Click to switch worktree", active.label.read(reader), branch));
+				tooltip = localize('worktrees.switcher.tooltip', "{0} ({1}) — Click to switch worktree", activeLabel, branch);
 			} else {
 				separator.style.display = 'none';
 				branchIcon.style.display = 'none';
 				branchLabel.textContent = '';
-				hover.update(localize('worktrees.switcher.tooltip.nobranch', "{0} — Click to switch worktree", active.label.read(reader)));
+				tooltip = localize('worktrees.switcher.tooltip.nobranch', "{0} — Click to switch worktree", activeLabel);
 			}
+			hover.update(tooltip);
+			root.setAttribute('aria-label', tooltip);
 		}));
 
 		this._register(DOM.addDisposableListener(root, DOM.EventType.CLICK, e => {

--- a/src/vs/workbench/contrib/worktrees/browser/worktreeTerminalContribution.ts
+++ b/src/vs/workbench/contrib/worktrees/browser/worktreeTerminalContribution.ts
@@ -1,0 +1,155 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { autorun } from '../../../../base/common/observable.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { TerminalCapability } from '../../../../platform/terminal/common/capabilities/capabilities.js';
+import { IWorkbenchContribution } from '../../../common/contributions.js';
+import { ITerminalInstance, ITerminalService } from '../../terminal/browser/terminal.js';
+import { IWorktree, IWorktreeGroupService } from '../../../services/worktrees/common/worktrees.js';
+
+/**
+ * Filters terminal visibility by the active worktree's filesystem path.
+ *
+ * - Terminals whose initial cwd matches the active worktree are foreground.
+ * - Terminals whose initial cwd matches some other (known) worktree are
+ *   hidden into the background and shown again when the user switches back.
+ * - Terminals with cwds outside any known worktree are left alone — they
+ *   may belong to unrelated folders.
+ * - `hideFromUser` terminals are never touched (managed by their owners,
+ *   e.g. the chat tool lifecycle).
+ *
+ * Terminals are never killed on a worktree switch — only re-parented.
+ */
+export class WorktreeTerminalContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'workbench.contrib.worktrees.terminal';
+
+	private _activeKey: string | undefined;
+
+	constructor(
+		@IWorktreeGroupService private readonly _worktreeGroupService: IWorktreeGroupService,
+		@ITerminalService private readonly _terminalService: ITerminalService,
+		@ILogService private readonly _logService: ILogService,
+	) {
+		super();
+
+		this._register(autorun(reader => {
+			const active = this._worktreeGroupService.activeWorktree.read(reader);
+			const all = this._worktreeGroupService.worktrees.read(reader);
+			void this._onActiveWorktreeChanged(active, all);
+		}));
+
+		// Hide restored terminals that arrive asynchronously after a window
+		// reload and don't belong to the current worktree.
+		this._register(this._terminalService.onDidCreateInstance(instance => {
+			if (instance.shellLaunchConfig.hideFromUser) {
+				return;
+			}
+			if (instance.shellLaunchConfig.attachPersistentProcess && this._activeKey) {
+				instance.getInitialCwd().then(cwd => {
+					if (!cwd || this._activeKey === undefined) {
+						return;
+					}
+					if (cwd.toLowerCase() !== this._activeKey) {
+						const available = this._getAvailableTerminal(instance);
+						if (available) {
+							this._terminalService.moveToBackground(available);
+							this._logService.trace(`[WorktreeTerminal] Hid restored terminal ${available.instanceId} (cwd: ${cwd})`);
+						}
+					}
+				});
+			}
+		}));
+	}
+
+	private async _onActiveWorktreeChanged(active: IWorktree | undefined, all: readonly IWorktree[]): Promise<void> {
+		if (!active) {
+			this._activeKey = undefined;
+			return;
+		}
+
+		const targetKey = active.uri.fsPath.toLowerCase();
+		if (this._activeKey === targetKey) {
+			return;
+		}
+		this._activeKey = targetKey;
+
+		const knownKeys = new Set<string>();
+		for (const wt of all) {
+			knownKeys.add(wt.uri.fsPath.toLowerCase());
+		}
+
+		await this._updateTerminalVisibility(targetKey, knownKeys);
+	}
+
+	private async _updateTerminalVisibility(activeKey: string, knownKeys: ReadonlySet<string>): Promise<void> {
+		const toShow: ITerminalInstance[] = [];
+		const toHide: ITerminalInstance[] = [];
+
+		for (const instance of [...this._terminalService.instances]) {
+			if (instance.shellLaunchConfig.hideFromUser) {
+				continue;
+			}
+			let cwd: string;
+			try {
+				cwd = (await instance.getInitialCwd()).toLowerCase();
+			} catch {
+				continue;
+			}
+			const available = this._getAvailableTerminal(instance);
+			if (!available) {
+				continue;
+			}
+
+			const belongsToActive = cwd === activeKey;
+			const belongsToKnownWorktree = knownKeys.has(cwd);
+			const isForeground = this._terminalService.foregroundInstances.includes(available);
+
+			if (belongsToActive && !isForeground) {
+				toShow.push(available);
+			} else if (belongsToKnownWorktree && !belongsToActive && isForeground) {
+				toHide.push(available);
+			}
+		}
+
+		for (const instance of toShow) {
+			const available = this._getAvailableTerminal(instance);
+			if (available) {
+				await this._terminalService.showBackgroundTerminal(available, true);
+			}
+		}
+		for (const instance of toHide) {
+			const available = this._getAvailableTerminal(instance);
+			if (available) {
+				this._terminalService.moveToBackground(available);
+			}
+		}
+
+		// Promote the foreground terminal with the most recent activity as active.
+		let mostRecent: ITerminalInstance | undefined;
+		let mostRecentTimestamp = -1;
+		for (const instance of this._terminalService.foregroundInstances) {
+			const cmdDetection = instance.capabilities.get(TerminalCapability.CommandDetection);
+			const lastCmd = cmdDetection?.commands.at(-1);
+			if (lastCmd && lastCmd.timestamp > mostRecentTimestamp) {
+				mostRecentTimestamp = lastCmd.timestamp;
+				mostRecent = instance;
+			}
+		}
+		if (mostRecent) {
+			this._terminalService.setActiveInstance(mostRecent);
+		}
+	}
+
+	private _getAvailableTerminal(instance: ITerminalInstance): ITerminalInstance | undefined {
+		const current = this._terminalService.getInstanceFromId(instance.instanceId);
+		if (!current || current.isDisposed) {
+			return undefined;
+		}
+		return current;
+	}
+}

--- a/src/vs/workbench/contrib/worktrees/browser/worktreeTerminalContribution.ts
+++ b/src/vs/workbench/contrib/worktrees/browser/worktreeTerminalContribution.ts
@@ -49,20 +49,26 @@ export class WorktreeTerminalContribution extends Disposable implements IWorkben
 			if (instance.shellLaunchConfig.hideFromUser) {
 				return;
 			}
-			if (instance.shellLaunchConfig.attachPersistentProcess && this._activeKey) {
-				instance.getInitialCwd().then(cwd => {
-					if (!cwd || this._activeKey === undefined) {
-						return;
-					}
-					if (cwd.toLowerCase() !== this._activeKey) {
-						const available = this._getAvailableTerminal(instance);
-						if (available) {
-							this._terminalService.moveToBackground(available);
-							this._logService.trace(`[WorktreeTerminal] Hid restored terminal ${available.instanceId} (cwd: ${cwd})`);
-						}
-					}
-				});
+			if (!instance.shellLaunchConfig.attachPersistentProcess || !this._activeKey) {
+				return;
 			}
+			void (async () => {
+				let cwd: string;
+				try {
+					cwd = await instance.getInitialCwd();
+				} catch {
+					return; // terminal disposed mid-flight or cwd unresolvable
+				}
+				if (!cwd || this._activeKey === undefined || cwd.toLowerCase() === this._activeKey) {
+					return;
+				}
+				const available = this._getAvailableTerminal(instance);
+				if (!available) {
+					return;
+				}
+				this._terminalService.moveToBackground(available);
+				this._logService.trace(`[WorktreeTerminal] Hid restored terminal ${available.instanceId} (cwd: ${cwd})`);
+			})();
 		}));
 	}
 

--- a/src/vs/workbench/contrib/worktrees/browser/worktrees.contribution.ts
+++ b/src/vs/workbench/contrib/worktrees/browser/worktrees.contribution.ts
@@ -1,0 +1,178 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Codicon } from '../../../../base/common/codicons.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { URI } from '../../../../base/common/uri.js';
+import { localize, localize2 } from '../../../../nls.js';
+import { IActionViewItemService } from '../../../../platform/actions/browser/actionViewItemService.js';
+import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+import { IQuickInputService, IQuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
+import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../common/contributions.js';
+import { IWorktreeGroupService } from '../../../services/worktrees/common/worktrees.js';
+import { WorktreeLayoutController } from './worktreeLayoutController.js';
+import { WorktreeSwitcherViewItem } from './worktreeSwitcherViewItem.js';
+import { WorktreeTerminalContribution } from './worktreeTerminalContribution.js';
+
+const WORKTREES_CATEGORY = localize2('worktrees.category', "Worktrees");
+
+// Register the layout and terminal contributions — both must be live after
+// the workbench has restored its initial editors so that working-set save/
+// restore doesn't race with restore.
+registerWorkbenchContribution2(WorktreeLayoutController.ID, WorktreeLayoutController, WorkbenchPhase.AfterRestored);
+registerWorkbenchContribution2(WorktreeTerminalContribution.ID, WorktreeTerminalContribution, WorkbenchPhase.AfterRestored);
+
+// --- Commands ---
+
+class SwitchWorktreeAction extends Action2 {
+	static readonly ID = 'workbench.action.worktrees.switch';
+
+	constructor() {
+		super({
+			id: SwitchWorktreeAction.ID,
+			title: localize2('worktrees.switch', "Switch Worktree..."),
+			category: WORKTREES_CATEGORY,
+			icon: Codicon.listTree,
+			f1: true,
+			menu: [{
+				// Renders inside the command center pill via the
+				// `_renderCommandCenterToolbar` path; our custom view item
+				// (registered below) provides the rich [icon] name / [branch]
+				// content. Order < 999 places us before the project name.
+				id: MenuId.CommandCenterCenter,
+				order: 100,
+			}],
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		const worktreeService = accessor.get(IWorktreeGroupService);
+		const quickInput = accessor.get(IQuickInputService);
+
+		const worktrees = worktreeService.worktrees.get();
+		if (worktrees.length === 0) {
+			return;
+		}
+
+		const active = worktreeService.activeWorktree.get();
+		const items: (IQuickPickItem & { uri: URI })[] = worktrees.map(w => ({
+			label: w.label.get(),
+			description: w.branch.get() ?? '',
+			detail: w.uri.fsPath,
+			uri: w.uri,
+			picked: active?.uri.toString() === w.uri.toString(),
+		}));
+
+		const picked = await quickInput.pick(items, {
+			placeHolder: localize('worktrees.switch.placeholder', "Select a worktree to open"),
+			matchOnDescription: true,
+			matchOnDetail: true,
+		});
+
+		if (picked) {
+			await worktreeService.openWorktree(picked.uri);
+		}
+	}
+}
+
+class RefreshWorktreesAction extends Action2 {
+	static readonly ID = 'workbench.action.worktrees.refresh';
+
+	constructor() {
+		super({
+			id: RefreshWorktreesAction.ID,
+			title: localize2('worktrees.refresh', "Refresh Worktrees"),
+			category: WORKTREES_CATEGORY,
+			f1: true,
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		const worktreeService = accessor.get(IWorktreeGroupService);
+		await worktreeService.refresh();
+	}
+}
+
+/**
+ * Delegates to SCM's worktree creation flow. The git extension resolves the
+ * active git repository, prompts for a base ref + branch, and runs
+ * `git worktree add` — we refresh afterwards so the new worktree appears
+ * immediately in our list.
+ */
+class CreateWorktreeAction extends Action2 {
+	static readonly ID = 'workbench.action.worktrees.create';
+
+	constructor() {
+		super({
+			id: CreateWorktreeAction.ID,
+			title: localize2('worktrees.create', "New Worktree..."),
+			category: WORKTREES_CATEGORY,
+			f1: true,
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		const commandService = accessor.get(ICommandService);
+		const worktreeService = accessor.get(IWorktreeGroupService);
+		await commandService.executeCommand('git.createWorktree');
+		await worktreeService.refresh();
+	}
+}
+
+/**
+ * Delegates to SCM's worktree delete flow. The git extension prompts the
+ * user to pick which worktree to remove from the repository and handles all
+ * of git's edge cases (force-delete, locked worktrees, in-use branches).
+ */
+class DeleteWorktreeAction extends Action2 {
+	static readonly ID = 'workbench.action.worktrees.delete';
+
+	constructor() {
+		super({
+			id: DeleteWorktreeAction.ID,
+			title: localize2('worktrees.delete', "Delete Worktree..."),
+			category: WORKTREES_CATEGORY,
+			f1: true,
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		const commandService = accessor.get(ICommandService);
+		const worktreeService = accessor.get(IWorktreeGroupService);
+		await commandService.executeCommand('git.deleteWorktree');
+		await worktreeService.refresh();
+	}
+}
+
+registerAction2(SwitchWorktreeAction);
+registerAction2(RefreshWorktreesAction);
+registerAction2(CreateWorktreeAction);
+registerAction2(DeleteWorktreeAction);
+
+/**
+ * Registers our custom view item for the worktree switcher inside the
+ * command center pill. The pill renderer consults IActionViewItemService when
+ * rendering items from MenuId.CommandCenterCenter, so this registration is
+ * how we replace the default icon-button rendering with the rich
+ * "[icon] worktree / [icon] branch" pill content.
+ */
+class WorktreeSwitcherRendering extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'workbench.contrib.worktrees.switcherRendering';
+
+	constructor(
+		@IActionViewItemService actionViewItemService: IActionViewItemService,
+		@IInstantiationService instantiationService: IInstantiationService,
+	) {
+		super();
+		this._register(actionViewItemService.register(MenuId.CommandCenterCenter, SwitchWorktreeAction.ID, (action, options) => {
+			return instantiationService.createInstance(WorktreeSwitcherViewItem, action, options);
+		}));
+	}
+}
+
+registerWorkbenchContribution2(WorktreeSwitcherRendering.ID, WorktreeSwitcherRendering, WorkbenchPhase.BlockRestore);

--- a/src/vs/workbench/services/worktrees/browser/worktreeGroupService.ts
+++ b/src/vs/workbench/services/worktrees/browser/worktreeGroupService.ts
@@ -1,0 +1,405 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Emitter, Event } from '../../../../base/common/event.js';
+import { Disposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { ResourceMap } from '../../../../base/common/map.js';
+import { Schemas } from '../../../../base/common/network.js';
+import { IObservable, ISettableObservable, derived, observableFromEvent, observableValue, transaction } from '../../../../base/common/observable.js';
+import { basename, dirname, isEqual, joinPath } from '../../../../base/common/resources.js';
+import { URI } from '../../../../base/common/uri.js';
+import { IFileService } from '../../../../platform/files/common/files.js';
+import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
+import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
+import { IWorkspaceEditingService } from '../../workspaces/common/workspaceEditing.js';
+import { IWorktree, IWorktreeGroupService, IWorktreesChangeEvent } from '../common/worktrees.js';
+
+interface IDiscoveredWorktree {
+	readonly uri: URI;
+	readonly commonDir: URI;
+	readonly label: string;
+	readonly branch: string | undefined;
+	readonly isMain: boolean;
+}
+
+class Worktree implements IWorktree {
+
+	private readonly _label: ISettableObservable<string>;
+	private readonly _branch: ISettableObservable<string | undefined>;
+
+	readonly label: IObservable<string>;
+	readonly branch: IObservable<string | undefined>;
+
+	constructor(
+		readonly uri: URI,
+		readonly commonDir: URI,
+		readonly isMain: boolean,
+		initialLabel: string,
+		initialBranch: string | undefined,
+	) {
+		this._label = observableValue<string>(this, initialLabel);
+		this._branch = observableValue<string | undefined>(this, initialBranch);
+		this.label = this._label;
+		this.branch = this._branch;
+	}
+
+	update(label: string, branch: string | undefined): void {
+		transaction(tx => {
+			this._label.set(label, tx);
+			this._branch.set(branch, tx);
+		});
+	}
+}
+
+/**
+ * Parses an on-disk `HEAD` file (`ref: refs/heads/<branch>` or a raw SHA)
+ * and returns the branch name when present, otherwise `undefined`.
+ */
+function parseHeadFile(content: string): string | undefined {
+	const trimmed = content.trim();
+	const match = /^ref:\s*refs\/heads\/(.+)$/.exec(trimmed);
+	return match ? match[1] : undefined;
+}
+
+async function tryReadFile(fileService: IFileService, uri: URI): Promise<string | undefined> {
+	try {
+		const content = await fileService.readFile(uri);
+		return content.value.toString();
+	} catch {
+		return undefined;
+	}
+}
+
+export class WorktreeGroupService extends Disposable implements IWorktreeGroupService {
+
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _onDidChangeWorktrees = this._register(new Emitter<IWorktreesChangeEvent>());
+	readonly onDidChangeWorktrees: Event<IWorktreesChangeEvent> = this._onDidChangeWorktrees.event;
+
+	private readonly _worktrees: ISettableObservable<readonly IWorktree[]>;
+	readonly worktrees: IObservable<readonly IWorktree[]>;
+
+	private readonly _pendingActiveWorktree: ISettableObservable<URI | undefined>;
+	readonly activeWorktree: IObservable<IWorktree | undefined>;
+
+	private readonly _byUri = new ResourceMap<Worktree>();
+	private readonly _watcher = this._register(new MutableDisposable());
+	private _refreshInFlight: Promise<void> | undefined;
+
+	constructor(
+		@IFileService private readonly fileService: IFileService,
+		@IWorkspaceContextService private readonly workspaceContextService: IWorkspaceContextService,
+		@IWorkspaceEditingService private readonly workspaceEditingService: IWorkspaceEditingService,
+		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
+		@ILogService private readonly logService: ILogService,
+	) {
+		super();
+
+		this._worktrees = observableValue<readonly IWorktree[]>(this, []);
+		this.worktrees = this._worktrees;
+
+		this._pendingActiveWorktree = observableValue<URI | undefined>(this, undefined);
+
+		// Active worktree: prefer an explicitly pending one (set during openWorktree)
+		// when it matches a known worktree; otherwise fall back to whichever known
+		// worktree matches the first workspace folder.
+		const workspaceFoldersObs = observableFromEvent(
+			this.workspaceContextService.onDidChangeWorkspaceFolders,
+			() => this.workspaceContextService.getWorkspace().folders,
+		);
+
+		this.activeWorktree = derived(reader => {
+			const worktrees = this._worktrees.read(reader);
+			const pending = this._pendingActiveWorktree.read(reader);
+			const folders = workspaceFoldersObs.read(reader);
+			const firstFolder = folders[0]?.uri;
+
+			if (pending) {
+				const match = worktrees.find(w => isEqual(w.uri, pending));
+				if (match) {
+					return match;
+				}
+			}
+
+			if (!firstFolder) {
+				return undefined;
+			}
+			return worktrees.find(w => isEqual(w.uri, firstFolder));
+		});
+
+		this._register(this.workspaceContextService.onDidChangeWorkspaceFolders(() => {
+			void this.refresh();
+		}));
+
+		void this.refresh();
+	}
+
+	getWorktree(uri: URI): IWorktree | undefined {
+		return this._byUri.get(uri);
+	}
+
+	async openWorktree(uri: URI): Promise<void> {
+		const worktree = this._byUri.get(uri);
+		if (!worktree) {
+			this.logService.warn(`[Worktrees] openWorktree called for unknown worktree: ${uri.toString()}`);
+			return;
+		}
+
+		// Re-verify existence at click time: the directory may have been
+		// removed externally since the last refresh.
+		const stat = await this._tryStat(worktree.uri);
+		if (!stat?.isDirectory) {
+			this.logService.warn(`[Worktrees] worktree no longer exists on disk, refreshing: ${worktree.uri.toString()}`);
+			await this.refresh();
+			return;
+		}
+
+		const workspace = this.workspaceContextService.getWorkspace();
+		const currentFirst = workspace.folders[0]?.uri;
+		if (currentFirst && this.uriIdentityService.extUri.isEqual(currentFirst, worktree.uri)) {
+			this._pendingActiveWorktree.set(undefined, undefined);
+			return;
+		}
+
+		// Set pending first so observers (layout, terminal) react to the worktree
+		// change before the workspace folders swap.
+		this._pendingActiveWorktree.set(worktree.uri, undefined);
+
+		const folderData = {
+			uri: worktree.uri,
+			name: worktree.label.get(),
+		};
+
+		if (!currentFirst) {
+			await this.workspaceEditingService.addFolders([folderData], true);
+		} else {
+			await this.workspaceEditingService.updateFolders(0, 1, [folderData], true);
+		}
+	}
+
+	async refresh(): Promise<void> {
+		if (this._refreshInFlight) {
+			return this._refreshInFlight;
+		}
+		this._refreshInFlight = this._doRefresh()
+			.catch(err => this.logService.error('[Worktrees] refresh failed', err))
+			.finally(() => { this._refreshInFlight = undefined; });
+		return this._refreshInFlight;
+	}
+
+	private async _doRefresh(): Promise<void> {
+		const workspace = this.workspaceContextService.getWorkspace();
+		const firstFolder = workspace.folders[0]?.uri;
+		if (!firstFolder || firstFolder.scheme !== Schemas.file) {
+			this._applyDiscovered([]);
+			this._updateWatcher(undefined);
+			return;
+		}
+
+		const commonDir = await this._resolveCommonGitDir(firstFolder);
+		if (!commonDir) {
+			this._applyDiscovered([]);
+			this._updateWatcher(undefined);
+			return;
+		}
+
+		const discovered = await this._discoverWorktrees(commonDir);
+		this._applyDiscovered(discovered);
+		this._updateWatcher(commonDir);
+	}
+
+	/**
+	 * Resolves the absolute path to the main repository's common `.git` directory
+	 * starting from any folder inside any worktree of that repository.
+	 */
+	private async _resolveCommonGitDir(folder: URI): Promise<URI | undefined> {
+		let current: URI = folder;
+		while (true) {
+			const dotGit = joinPath(current, '.git');
+			const stat = await this._tryStat(dotGit);
+
+			if (stat?.isDirectory) {
+				return dotGit;
+			}
+
+			if (stat?.isFile) {
+				// Linked worktree: `.git` is a file `gitdir: <path>`.
+				const content = await tryReadFile(this.fileService, dotGit);
+				const match = content && /^gitdir:\s*(.+)$/m.exec(content);
+				if (match) {
+					const gitDirPath = match[1].trim();
+					const gitDirUri = URI.file(gitDirPath);
+					const commonDirFile = joinPath(gitDirUri, 'commondir');
+					const commonDirContents = await tryReadFile(this.fileService, commonDirFile);
+					if (commonDirContents) {
+						const rel = commonDirContents.trim();
+						return rel.startsWith('/')
+							? URI.file(rel)
+							: joinPath(gitDirUri, rel);
+					}
+					// Fallback: `.git/worktrees/<name>` → up two levels is the common `.git`.
+					return dirname(dirname(gitDirUri));
+				}
+				return undefined;
+			}
+
+			const parent = dirname(current);
+			if (isEqual(parent, current)) {
+				return undefined;
+			}
+			current = parent;
+		}
+	}
+
+	/**
+	 * Lists all worktrees rooted at the given common `.git` directory: the main
+	 * worktree (the directory containing `.git`) plus every linked worktree
+	 * recorded under `.git/worktrees/<name>/`.
+	 */
+	private async _discoverWorktrees(commonDir: URI): Promise<IDiscoveredWorktree[]> {
+		const results: IDiscoveredWorktree[] = [];
+
+		const mainWorktreeRoot = dirname(commonDir);
+		const mainHead = await tryReadFile(this.fileService, joinPath(commonDir, 'HEAD'));
+		const mainBranch = mainHead ? parseHeadFile(mainHead) : undefined;
+		results.push({
+			uri: mainWorktreeRoot,
+			commonDir,
+			label: basename(mainWorktreeRoot) || mainWorktreeRoot.fsPath,
+			branch: mainBranch,
+			isMain: true,
+		});
+
+		const worktreesDir = joinPath(commonDir, 'worktrees');
+		try {
+			const entries = await this.fileService.resolve(worktreesDir);
+			if (entries.children) {
+				for (const child of entries.children) {
+					if (child.isDirectory) {
+						const wt = await this._readLinkedWorktree(child.resource, commonDir);
+						if (wt) {
+							results.push(wt);
+						}
+					}
+				}
+			}
+		} catch {
+			// no linked worktrees — that's fine
+		}
+
+		return results;
+	}
+
+	private async _readLinkedWorktree(entryDir: URI, commonDir: URI): Promise<IDiscoveredWorktree | undefined> {
+		const gitdirFile = joinPath(entryDir, 'gitdir');
+		const gitdirContents = await tryReadFile(this.fileService, gitdirFile);
+		if (!gitdirContents) {
+			return undefined;
+		}
+
+		// `gitdir` contents point at the linked worktree's `.git` file, e.g.
+		// `/abs/path/to/linked-tree/.git`. The worktree root is its parent dir.
+		const worktreeGitFile = URI.file(gitdirContents.trim());
+		const worktreeRoot = dirname(worktreeGitFile);
+
+		// Skip prunable worktrees: the `.git/worktrees/<name>/` entry outlives
+		// the worktree directory when the user removes it externally. `git
+		// worktree prune` would clean these up; we just hide them from the list.
+		const rootStat = await this._tryStat(worktreeRoot);
+		if (!rootStat?.isDirectory) {
+			return undefined;
+		}
+
+		const head = await tryReadFile(this.fileService, joinPath(entryDir, 'HEAD'));
+		const branch = head ? parseHeadFile(head) : undefined;
+
+		return {
+			uri: worktreeRoot,
+			commonDir,
+			label: basename(worktreeRoot) || worktreeRoot.fsPath,
+			branch,
+			isMain: false,
+		};
+	}
+
+	private async _tryStat(uri: URI) {
+		try {
+			return await this.fileService.stat(uri);
+		} catch {
+			return undefined;
+		}
+	}
+
+	private _applyDiscovered(discovered: readonly IDiscoveredWorktree[]): void {
+		const seen = new ResourceMap<true>();
+		const added: IWorktree[] = [];
+
+		for (const d of discovered) {
+			seen.set(d.uri, true);
+			const existing = this._byUri.get(d.uri);
+			if (existing) {
+				existing.update(d.label, d.branch);
+			} else {
+				const wt = new Worktree(d.uri, d.commonDir, d.isMain, d.label, d.branch);
+				this._byUri.set(d.uri, wt);
+				added.push(wt);
+			}
+		}
+
+		const removed: IWorktree[] = [];
+		for (const [uri, wt] of this._byUri) {
+			if (!seen.has(uri)) {
+				removed.push(wt);
+				this._byUri.delete(uri);
+			}
+		}
+
+		if (added.length === 0 && removed.length === 0) {
+			return;
+		}
+
+		const list: IWorktree[] = [];
+		for (const wt of this._byUri.values()) {
+			list.push(wt);
+		}
+		// Stable ordering: main first, then alphabetical by label.
+		list.sort((a, b) => {
+			if (a.isMain !== b.isMain) {
+				return a.isMain ? -1 : 1;
+			}
+			return a.label.get().localeCompare(b.label.get());
+		});
+
+		this._worktrees.set(list, undefined);
+		this._onDidChangeWorktrees.fire({ added, removed });
+	}
+
+	private _updateWatcher(commonDir: URI | undefined): void {
+		if (!commonDir) {
+			this._watcher.value = undefined;
+			return;
+		}
+		try {
+			const worktreesDir = joinPath(commonDir, 'worktrees');
+			const watcher = this.fileService.createWatcher(worktreesDir, { recursive: false, excludes: [] });
+			const sub = watcher.onDidChange(() => {
+				void this.refresh();
+			});
+			this._watcher.value = {
+				dispose: () => {
+					sub.dispose();
+					watcher.dispose();
+				}
+			};
+		} catch (err) {
+			this.logService.warn(`[Worktrees] failed to watch worktrees dir: ${err}`);
+		}
+	}
+}
+
+registerSingleton(IWorktreeGroupService, WorktreeGroupService, InstantiationType.Delayed);

--- a/src/vs/workbench/services/worktrees/browser/worktreeGroupService.ts
+++ b/src/vs/workbench/services/worktrees/browser/worktreeGroupService.ts
@@ -8,6 +8,7 @@ import { Disposable, MutableDisposable } from '../../../../base/common/lifecycle
 import { ResourceMap } from '../../../../base/common/map.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { IObservable, ISettableObservable, derived, observableFromEvent, observableValue, transaction } from '../../../../base/common/observable.js';
+import { isAbsolute } from '../../../../base/common/path.js';
 import { basename, dirname, isEqual, joinPath } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
@@ -87,7 +88,7 @@ export class WorktreeGroupService extends Disposable implements IWorktreeGroupSe
 	private readonly _pendingActiveWorktree: ISettableObservable<URI | undefined>;
 	readonly activeWorktree: IObservable<IWorktree | undefined>;
 
-	private readonly _byUri = new ResourceMap<Worktree>();
+	private readonly _byUri: ResourceMap<Worktree>;
 	private readonly _watcher = this._register(new MutableDisposable());
 	private _refreshInFlight: Promise<void> | undefined;
 
@@ -99,6 +100,11 @@ export class WorktreeGroupService extends Disposable implements IWorktreeGroupSe
 		@ILogService private readonly logService: ILogService,
 	) {
 		super();
+
+		// Use the extUri comparison key so case-insensitive filesystems
+		// (Windows, default APFS) and encoded URI variants resolve to the
+		// same worktree on lookup.
+		this._byUri = new ResourceMap<Worktree>(uri => this.uriIdentityService.extUri.getComparisonKey(uri));
 
 		this._worktrees = observableValue<readonly IWorktree[]>(this, []);
 		this.worktrees = this._worktrees;
@@ -228,17 +234,21 @@ export class WorktreeGroupService extends Disposable implements IWorktreeGroupSe
 			}
 
 			if (stat?.isFile) {
-				// Linked worktree: `.git` is a file `gitdir: <path>`.
+				// Linked worktree: `.git` is a file `gitdir: <path>`. `git
+				// worktree add` writes absolute paths, but be defensive:
+				// resolve relative values against the worktree root.
 				const content = await tryReadFile(this.fileService, dotGit);
 				const match = content && /^gitdir:\s*(.+)$/m.exec(content);
 				if (match) {
 					const gitDirPath = match[1].trim();
-					const gitDirUri = URI.file(gitDirPath);
+					const gitDirUri = isAbsolute(gitDirPath)
+						? URI.file(gitDirPath)
+						: joinPath(dirname(dotGit), gitDirPath);
 					const commonDirFile = joinPath(gitDirUri, 'commondir');
 					const commonDirContents = await tryReadFile(this.fileService, commonDirFile);
 					if (commonDirContents) {
 						const rel = commonDirContents.trim();
-						return rel.startsWith('/')
+						return isAbsolute(rel)
 							? URI.file(rel)
 							: joinPath(gitDirUri, rel);
 					}

--- a/src/vs/workbench/services/worktrees/browser/worktreeGroupService.ts
+++ b/src/vs/workbench/services/worktrees/browser/worktreeGroupService.ts
@@ -4,14 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Emitter, Event } from '../../../../base/common/event.js';
-import { Disposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { combinedDisposable, Disposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { ResourceMap } from '../../../../base/common/map.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { IObservable, ISettableObservable, derived, observableFromEvent, observableValue, transaction } from '../../../../base/common/observable.js';
 import { isAbsolute } from '../../../../base/common/path.js';
 import { basename, dirname, isEqual, joinPath } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
-import { IFileService } from '../../../../platform/files/common/files.js';
+import { IFileService, IFileStatWithPartialMetadata } from '../../../../platform/files/common/files.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
@@ -61,9 +61,7 @@ class Worktree implements IWorktree {
  * and returns the branch name when present, otherwise `undefined`.
  */
 function parseHeadFile(content: string): string | undefined {
-	const trimmed = content.trim();
-	const match = /^ref:\s*refs\/heads\/(.+)$/.exec(trimmed);
-	return match ? match[1] : undefined;
+	return /^ref:\s*refs\/heads\/(?<branch>.+)$/.exec(content.trim())?.groups?.branch;
 }
 
 async function tryReadFile(fileService: IFileService, uri: URI): Promise<string | undefined> {
@@ -238,9 +236,8 @@ export class WorktreeGroupService extends Disposable implements IWorktreeGroupSe
 				// worktree add` writes absolute paths, but be defensive:
 				// resolve relative values against the worktree root.
 				const content = await tryReadFile(this.fileService, dotGit);
-				const match = content && /^gitdir:\s*(.+)$/m.exec(content);
-				if (match) {
-					const gitDirPath = match[1].trim();
+				const gitDirPath = content && /^gitdir:\s*(?<path>.+)$/m.exec(content)?.groups?.path.trim();
+				if (gitDirPath) {
 					const gitDirUri = isAbsolute(gitDirPath)
 						? URI.file(gitDirPath)
 						: joinPath(dirname(dotGit), gitDirPath);
@@ -337,7 +334,7 @@ export class WorktreeGroupService extends Disposable implements IWorktreeGroupSe
 		};
 	}
 
-	private async _tryStat(uri: URI) {
+	private async _tryStat(uri: URI): Promise<IFileStatWithPartialMetadata | undefined> {
 		try {
 			return await this.fileService.stat(uri);
 		} catch {
@@ -373,12 +370,8 @@ export class WorktreeGroupService extends Disposable implements IWorktreeGroupSe
 			return;
 		}
 
-		const list: IWorktree[] = [];
-		for (const wt of this._byUri.values()) {
-			list.push(wt);
-		}
 		// Stable ordering: main first, then alphabetical by label.
-		list.sort((a, b) => {
+		const list = Array.from(this._byUri.values()).sort((a, b) => {
 			if (a.isMain !== b.isMain) {
 				return a.isMain ? -1 : 1;
 			}
@@ -397,15 +390,8 @@ export class WorktreeGroupService extends Disposable implements IWorktreeGroupSe
 		try {
 			const worktreesDir = joinPath(commonDir, 'worktrees');
 			const watcher = this.fileService.createWatcher(worktreesDir, { recursive: false, excludes: [] });
-			const sub = watcher.onDidChange(() => {
-				void this.refresh();
-			});
-			this._watcher.value = {
-				dispose: () => {
-					sub.dispose();
-					watcher.dispose();
-				}
-			};
+			const sub = watcher.onDidChange(() => this.refresh());
+			this._watcher.value = combinedDisposable(sub, watcher);
 		} catch (err) {
 			this.logService.warn(`[Worktrees] failed to watch worktrees dir: ${err}`);
 		}

--- a/src/vs/workbench/services/worktrees/common/worktrees.ts
+++ b/src/vs/workbench/services/worktrees/common/worktrees.ts
@@ -1,0 +1,70 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Event } from '../../../../base/common/event.js';
+import { IObservable } from '../../../../base/common/observable.js';
+import { URI } from '../../../../base/common/uri.js';
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+
+/**
+ * A single git worktree belonging to a repository. Each worktree has a
+ * unique filesystem path and is bound to a branch/ref.
+ */
+export interface IWorktree {
+	/** Filesystem URI of the worktree directory. */
+	readonly uri: URI;
+
+	/** URI of the main repository's `.git` directory (the common dir). */
+	readonly commonDir: URI;
+
+	/** Display name for the worktree (basename or "main" for the primary). */
+	readonly label: IObservable<string>;
+
+	/** Current branch name, or `undefined` if detached HEAD. */
+	readonly branch: IObservable<string | undefined>;
+
+	/** Whether this is the main (primary) worktree. */
+	readonly isMain: boolean;
+}
+
+/**
+ * Event payload describing changes to the known worktree list.
+ */
+export interface IWorktreesChangeEvent {
+	readonly added: readonly IWorktree[];
+	readonly removed: readonly IWorktree[];
+}
+
+export interface IWorktreeGroupService {
+	readonly _serviceBrand: undefined;
+
+	/** All worktrees discovered for the active repository. */
+	readonly worktrees: IObservable<readonly IWorktree[]>;
+
+	/**
+	 * The currently active worktree. This is the worktree whose path matches
+	 * the first workspace folder; `undefined` when the workspace is empty or
+	 * does not correspond to any known worktree.
+	 */
+	readonly activeWorktree: IObservable<IWorktree | undefined>;
+
+	/** Fires whenever the discovered worktree list changes. */
+	readonly onDidChangeWorktrees: Event<IWorktreesChangeEvent>;
+
+	/** Look up a worktree by its filesystem URI. */
+	getWorktree(uri: URI): IWorktree | undefined;
+
+	/**
+	 * Switch to the given worktree. Triggers a workspace folder swap so the
+	 * explorer, source control, and search rebase onto the worktree path.
+	 * Layout state and terminal visibility follow reactively.
+	 */
+	openWorktree(uri: URI): Promise<void>;
+
+	/** Re-scan `.git/worktrees/` and refresh the list. */
+	refresh(): Promise<void>;
+}
+
+export const IWorktreeGroupService = createDecorator<IWorktreeGroupService>('worktreeGroupService');

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -276,6 +276,10 @@ import './contrib/scm/browser/scm.contribution.js';
 import './contrib/scm/browser/quickDiff.contribution.js';
 import './contrib/scm/browser/scm.service.contribution.js';
 
+// Worktrees
+import './services/worktrees/browser/worktreeGroupService.js';
+import './contrib/worktrees/browser/worktrees.contribution.js';
+
 // Debug
 import './contrib/debug/browser/debug.contribution.js';
 import './contrib/debug/browser/debugEditorContribution.js';


### PR DESCRIPTION
## TL;DR

https://github.com/user-attachments/assets/f4e6be04-9940-4d24-9e6d-a0b8a1ae389b

## Summary

Brings the worktree-switching experience from the Agents app into the regular workbench, decoupled from the AI session lifecycle.

In the Agents app, each session starts a git worktree and clicking another session swaps the workbench onto that worktree without spawning a new window. This PR exposes the same mechanic directly: a worktree switcher in the command center that lists the current repository's worktrees and switches between them on click. No session required.

## Why?

- #315699
- #314677
- #311858

The placement inside the command center is open — there may be a better home for the switcher long-term. The point is that the regular workbench can benefit from the same experience the Agents app already has, and as a side effect **Chat sessions end up naturally scoped to the active worktree without any extra plumbing**.

This is a working proof of concept. Switching delegates to existing primitives — workspace folder swap for the explorer/SCM rebase, and the git extension's own commands for creating and deleting worktrees — so the surface area is small.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
