### PR TITLE
Chronicle: Add cost-tips command

### DIFF
--- a/extensions/copilot/assets/prompts/chronicle-cost-tips.prompt.md
+++ b/extensions/copilot/assets/prompts/chronicle-cost-tips.prompt.md
@@ -1,0 +1,5 @@
+---
+name: chronicle:cost-tips
+description: Get personalized tips to reduce token usage and Copilot cost
+---
+Analyze my recent chat session history and give me personalized, data-grounded tips to reduce token usage and Copilot cost. Use the **chronicle** skill — it documents the `copilot_sessionStoreSql` tool, the session-store schema, and the Cost Tips workflow for finding expensive sessions, token-heavy patterns, and concrete habit changes.

--- a/extensions/copilot/assets/prompts/skills/chronicle/SKILL.md
+++ b/extensions/copilot/assets/prompts/skills/chronicle/SKILL.md
@@ -96,6 +96,81 @@ Analysis dimensions to explore:
 
 If the session store has little data, acknowledge that and suggest features to try based on what configuration you found in the workspace.
 
+### Cost Tips
+
+When the user asks for cost tips, ways to reduce token usage, or how to lower Copilot spend (e.g. `/chronicle:cost-tips`):
+
+The goal is **personalized, data-grounded recommendations** for reducing token usage — not a generic checklist. Every tip must point to a specific pattern you observed in their data.
+
+**Cost-relevant schema (in addition to the Database Schema section below)**
+
+- **Cloud DuckDB only** — the local SQLite store does **not** record per-event token usage, has no `events` table, and has no attachments table. If the active backend is local, gate all token queries and tell the user that real token-level analysis requires enabling cloud sync (`chat.sessionSync.enabled`).
+- **events** (cloud): per-event billing — `usage_input_tokens`, `usage_output_tokens`, `usage_model`, plus `agent_name`/`agent_description`. Filter `usage_input_tokens IS NOT NULL` to isolate billable events.
+- **attachments** (cloud): file attachments from user messages — `session_id`, `display_name`, `path`, `type`. Join to sessions/turns to find sessions that pulled in large or frequent attachments.
+- **sessions.agent_name** / **agent_description** (both backends): values like `Copilot CLI`, `Copilot Coding Agent`, `Copilot Code Review`, or custom agents/subagents. Use to break spend down by agent type.
+- Use `LENGTH(user_message)` on `turns` (or `LENGTH(user_content)` on `events` where `type = 'user.message'`) to find oversized pastes.
+
+**Step 1: Investigate cost and token patterns**
+
+Use `copilot_sessionStoreSql` with `action: "query"`. What to investigate depends on the active backend.
+
+*Cloud (DuckDB) — start with agent-type awareness:*
+
+The session store mixes session types via `sessions.agent_name` (and `events.agent_name` for per-event scope). Your advice is only useful if you know which agents the user actually runs, so this is the **first** thing to learn.
+
+- **Enumerate every agent in use.** Run e.g. `SELECT agent_name, agent_description, COUNT(*) AS n FROM sessions WHERE created_at > now() - INTERVAL '30 days' GROUP BY 1, 2 ORDER BY n DESC` so you see the full inventory — official agents and any custom agents/subagents in `agent_description`. Do not assume.
+- **Decide which to advise on.** Include any agent type the user can make cheaper: `Copilot CLI` (interactive), `Copilot Coding Agent` (autonomous cloud tasks), custom agents and subagents. **Always exclude** `agent_name = 'Copilot Code Review'` and any other agent the user does not drive interactively.
+- **Tailor advice per agent.** CLI tips (compaction, model switching, subagent delegation) look different from Coding Agent tips (prompt scoping, smaller task framing) and custom-agent tips (slimming tool lists, narrowing prompts).
+
+Then drill into cost patterns:
+
+- **Token-heavy sessions and turns** — sum `usage_input_tokens` and `usage_output_tokens` per session and per model from `events`. Which sessions burned the most tokens? Which models?
+- **Input-to-output ratios** — when input tokens dwarf output tokens, the user is paying to re-send a bloated context every turn. Strongest signal that compaction, smaller working sets, or fresh sessions would help.
+- **Model mix** — break down spend by `usage_model`. Are premium models being used for routine work (renames, simple edits, status checks) that a cheaper model could handle?
+- **Per-turn growth** — within long sessions, does `usage_input_tokens` keep climbing turn-over-turn? Strong signal that compaction wasn't used.
+- **Large attachments or pastes** — query `attachments` for sessions that pulled in many or large files (group by `session_id`, count, look at `type`). Also use `LENGTH(user_content)` on `events` where `type = 'user.message'` for oversized pastes that should have been file references.
+- **Group cost breakdowns by `agent_name`** (and `agent_description` where useful) in at least one query so the user sees where their spend actually goes — and so you spot if a single custom agent dominates.
+
+*Local (SQLite) — no token data; use proxies:*
+
+- **Long sessions without compaction** — sessions with many turns and no rows in `checkpoints` (each `checkpoints` row is a successful compaction). `LEFT JOIN checkpoints c ON c.session_id = s.id WHERE c.session_id IS NULL` + a turn-count threshold gives prime candidates.
+- **Late compaction** — for sessions that *do* have checkpoints, compare `checkpoints.checkpoint_number` and `created_at` against the session's turn count. A first compaction at turn 60 of an 80-turn session is far less helpful than one at turn 25.
+- **Repeated large file reads** — in `session_files`, look for the same file read many times within one session, or across sessions.
+- **Tool-call thrash** — sessions with many turns and repeated tool calls often indicate the agent rediscovered the same context multiple times.
+- **Oversized pastes** — use `LENGTH(user_message)` on `turns` to find very long user messages that should have been file references.
+
+*Both backends:*
+
+- **Long-running sessions** — sessions with many turns or that span many hours drag a growing context window across every turn.
+- **Repeated work** — the same file/topic showing up in many sessions, or the same agent stumbling block recurring (suggesting a custom skill, agent, or `copilot-instructions.md` entry would let the model do the work in one shot).
+- **Subagent usage** — are heavyweight investigations being run in the main session (paying for their tokens to live in main context) when they could be delegated to a subagent that returns only a summary?
+
+Drill into a few of the most expensive sessions and read the actual conversation turns to understand *why* they were expensive. Don't just report aggregates — explain the cause.
+
+**Step 2: Map findings to features and habits**
+
+If the current workspace has a `.github/` folder, check `.github/copilot-instructions.md`, `.github/skills/`, and `.github/agents/` to see what custom configuration already exists. Do NOT look outside the workspace. Cost-relevant capabilities to keep in mind:
+
+- Mid-session compaction (e.g. `/compact`) to shrink the context window; for users who never compact, this is often the single biggest win.
+- Model picker — switch to a cheaper model for routine work; check whether premium models are being used for simple tasks.
+- Starting a fresh chat instead of continuing a bloated session.
+- Subagents/delegation for offloading heavy research into a sub-context whose tokens don't accrete into the main session.
+- Custom skills (`.github/skills/`) and custom agents (`.github/agents/`) so repeated workflows don't re-derive context each time.
+- `.github/copilot-instructions.md` to encode project conventions the model otherwise has to be told every session.
+- For cloud-enabled users, the Copilot usage view to inspect current premium-request spend.
+
+**Step 3: Provide tips**
+
+Give the user 3-5 specific, actionable tips. Each tip should:
+
+- **Be grounded in their data** — reference a specific session, file, model, or pattern you observed (with rough numbers when you have them: turn counts, token totals, file-read counts, etc.).
+- **Be non-obvious** — skip basics any returning user already knows. Assume they know compaction and fresh chats exist; help them notice they're not *using* them where it would matter.
+- **Quantify the win when possible** — "compacting around turn 30 of that 80-turn session would have shaved ~X input tokens off every subsequent turn" is far better than "consider compacting".
+- **Be concrete** — name the workflow change, command, or config file edit. If the suggestion is a custom skill or agent, sketch what it would cover.
+- **Match the agent type** — if a finding is specific to one `agent_name`, say so. Don't propose CLI-only fixes for findings from Coding Agent sessions, and vice versa.
+
+If the session store has little data (e.g., cloud store is empty, or only a handful of local sessions), say so plainly and offer 2-3 non-obvious cost-saving habits anchored in available features rather than fabricating findings. If the user is on local-only storage, end by noting that enabling `chat.sessionSync.enabled` unlocks per-event token analysis for sharper future tips.
+
 ### Search
 
 When the user asks to search, find, or look up past sessions by keyword (e.g. `/chronicle:search <query>`):

--- a/extensions/copilot/assets/prompts/skills/chronicle/SKILL.md
+++ b/extensions/copilot/assets/prompts/skills/chronicle/SKILL.md
@@ -104,10 +104,9 @@ The goal is **personalized, data-grounded recommendations** for reducing token u
 
 **Cost-relevant schema (in addition to the Database Schema section below)**
 
-- **Cloud DuckDB only** — the local SQLite store does **not** record per-event token usage, has no `events` table, and has no attachments table. If the active backend is local, gate all token queries and tell the user that real token-level analysis requires enabling cloud sync (`chat.sessionSync.enabled`).
-- **events** (cloud): per-event billing — `usage_input_tokens`, `usage_output_tokens`, `usage_model`, plus `agent_name`/`agent_description`. Filter `usage_input_tokens IS NOT NULL` to isolate billable events.
-- **attachments** (cloud): file attachments from user messages — `session_id`, `display_name`, `path`, `type`. Join to sessions/turns to find sessions that pulled in large or frequent attachments.
-- **sessions.agent_name** / **agent_description** (both backends): values like `Copilot CLI`, `Copilot Coding Agent`, `Copilot Code Review`, or custom agents/subagents. Use to break spend down by agent type.
+- **Cloud DuckDB only** — the local SQLite store does **not** record per-event token usage and has no `events` table. If the active backend is local, gate all token queries and tell the user that real token-level analysis requires enabling cloud sync (`chat.sessionSync.enabled`).
+- **events** (cloud): per-event billing — rows where `type = 'assistant.usage'` carry `usage_input_tokens`, `usage_output_tokens`, `usage_model`. To break spend down by agent type, JOIN `events e` to `sessions s ON s.id = e.session_id` and group by `s.agent_name`.
+- **sessions.agent_name** / **agent_description** (both backends): values like `VS Code agent` (VS Code chat), `Copilot CLI`, `Copilot Coding Agent`, `Copilot Code Review`, or custom agents/subagents. Use to break spend down by agent type.
 - Use `LENGTH(user_message)` on `turns` (or `LENGTH(user_content)` on `events` where `type = 'user.message'`) to find oversized pastes.
 
 **Step 1: Investigate cost and token patterns**
@@ -116,19 +115,19 @@ Use `copilot_sessionStoreSql` with `action: "query"`. What to investigate depend
 
 *Cloud (DuckDB) — start with agent-type awareness:*
 
-The session store mixes session types via `sessions.agent_name` (and `events.agent_name` for per-event scope). Your advice is only useful if you know which agents the user actually runs, so this is the **first** thing to learn.
+The session store mixes session types via `sessions.agent_name` (join events to sessions on `session_id` to get the agent for any per-event analysis). Your advice is only useful if you know which agents the user actually runs, so this is the **first** thing to learn.
 
-- **Enumerate every agent in use.** Run e.g. `SELECT agent_name, agent_description, COUNT(*) AS n FROM sessions WHERE created_at > now() - INTERVAL '30 days' GROUP BY 1, 2 ORDER BY n DESC` so you see the full inventory — official agents and any custom agents/subagents in `agent_description`. Do not assume.
-- **Decide which to advise on.** Include any agent type the user can make cheaper: `Copilot CLI` (interactive), `Copilot Coding Agent` (autonomous cloud tasks), custom agents and subagents. **Always exclude** `agent_name = 'Copilot Code Review'` and any other agent the user does not drive interactively.
-- **Tailor advice per agent.** CLI tips (compaction, model switching, subagent delegation) look different from Coding Agent tips (prompt scoping, smaller task framing) and custom-agent tips (slimming tool lists, narrowing prompts).
+- **Enumerate every agent in use.** Run e.g. `SELECT agent_name, agent_description, COUNT(*) AS n FROM sessions WHERE updated_at > now() - INTERVAL '30 days' GROUP BY 1, 2 ORDER BY n DESC` so you see the full inventory — official agents and any custom agents/subagents in `agent_description`. Do not assume.
+- **Decide which to advise on.** Include any agent type the user can make cheaper: `VS Code agent` (VS Code chat — usually the dominant agent), `Copilot CLI` (interactive terminal), `Copilot Coding Agent` (autonomous cloud tasks), custom agents and subagents. **Always exclude** `agent_name = 'Copilot Code Review'` and any other agent the user does not drive interactively.
+- **Tailor advice per agent.** VS Code agent tips (compaction, model picker, fresh chats, `.github/copilot-instructions.md`, custom skills/agents) look different from CLI tips (compaction, model switching, subagent delegation), Coding Agent tips (prompt scoping, smaller task framing), and custom-agent tips (slimming tool lists, narrowing prompts).
 
-Then drill into cost patterns:
+Then drill into cost patterns (filter `events` rows by `type = 'assistant.usage'` for billable rows):
 
-- **Token-heavy sessions and turns** — sum `usage_input_tokens` and `usage_output_tokens` per session and per model from `events`. Which sessions burned the most tokens? Which models?
+- **Token-heavy sessions and turns** — sum `usage_input_tokens` and `usage_output_tokens` per session and per model from `events` where `type = 'assistant.usage'`. Which sessions burned the most tokens? Which models?
 - **Input-to-output ratios** — when input tokens dwarf output tokens, the user is paying to re-send a bloated context every turn. Strongest signal that compaction, smaller working sets, or fresh sessions would help.
 - **Model mix** — break down spend by `usage_model`. Are premium models being used for routine work (renames, simple edits, status checks) that a cheaper model could handle?
 - **Per-turn growth** — within long sessions, does `usage_input_tokens` keep climbing turn-over-turn? Strong signal that compaction wasn't used.
-- **Large attachments or pastes** — query `attachments` for sessions that pulled in many or large files (group by `session_id`, count, look at `type`). Also use `LENGTH(user_content)` on `events` where `type = 'user.message'` for oversized pastes that should have been file references.
+- **Oversized pastes** — `LENGTH(user_content)` on `events` where `type = 'user.message'` to find user messages that should have been file references (also visible in `session_files` as repeated reads of the same path within one session).
 - **Group cost breakdowns by `agent_name`** (and `agent_description` where useful) in at least one query so the user sees where their spend actually goes — and so you spot if a single custom agent dominates.
 
 *Local (SQLite) — no token data; use proxies:*

--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -6620,6 +6620,13 @@
         ]
       },
       {
+        "path": "./assets/prompts/chronicle-cost-tips.prompt.md",
+        "when": "github.copilot.sessionSearch.enabled",
+        "sessionTypes": [
+          "local"
+        ]
+      },
+      {
         "path": "./assets/prompts/chronicle-reindex.prompt.md",
         "when": "github.copilot.sessionSearch.enabled",
         "sessionTypes": [

--- a/extensions/copilot/src/extension/tools/node/test/sessionStoreSqlTool.spec.ts
+++ b/extensions/copilot/src/extension/tools/node/test/sessionStoreSqlTool.spec.ts
@@ -496,7 +496,8 @@ describe('SessionStoreSqlTool', () => {
 			const required = [
 				'### Cost Tips',
 				'usage_input_tokens', 'usage_output_tokens', 'usage_model',
-				'attachments', 'agent_name',
+				'agent_name',
+				'assistant.usage',
 				'local SQLite',
 				'chat.sessionSync.enabled',
 			];

--- a/extensions/copilot/src/extension/tools/node/test/sessionStoreSqlTool.spec.ts
+++ b/extensions/copilot/src/extension/tools/node/test/sessionStoreSqlTool.spec.ts
@@ -480,12 +480,27 @@ describe('SessionStoreSqlTool', () => {
 
 		it('chronicle slash prompts reference the chronicle skill', () => {
 			const promptDir = path.join(copilotRoot, 'assets', 'prompts');
-			const prompts = ['chronicle-tips.prompt.md', 'chronicle-standup.prompt.md', 'chronicle-search.prompt.md'];
+			const prompts = ['chronicle-tips.prompt.md', 'chronicle-cost-tips.prompt.md', 'chronicle-standup.prompt.md', 'chronicle-search.prompt.md'];
 			const missing = prompts.filter(name => {
 				const body = fs.readFileSync(path.join(promptDir, name), 'utf-8');
 				return !/\*\*chronicle\*\* skill/.test(body);
 			});
 			expect(missing).toEqual([]);
+		});
+
+		it('chronicle SKILL.md Cost Tips section carries required anchors', () => {
+			const skill = fs.readFileSync(
+				path.join(copilotRoot, 'assets', 'prompts', 'skills', 'chronicle', 'SKILL.md'),
+				'utf-8',
+			);
+			const required = [
+				'### Cost Tips',
+				'usage_input_tokens', 'usage_output_tokens', 'usage_model',
+				'attachments', 'agent_name',
+				'local SQLite',
+				'chat.sessionSync.enabled',
+			];
+			expect(required.filter(a => !skill.includes(a))).toEqual([]);
 		});
 	});
 });


### PR DESCRIPTION
Adds a new chroniclecommand that analyzes session history and recommends ways to reduce token usage and Copilot cost.