### PR TITLE
Render chat attachments as request tiles

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/attachments/chatAttachmentWidgets.ts
+++ b/src/vs/workbench/contrib/chat/browser/attachments/chatAttachmentWidgets.ts
@@ -8,6 +8,7 @@ import { $ } from '../../../../../base/browser/dom.js';
 import { StandardKeyboardEvent } from '../../../../../base/browser/keyboardEvent.js';
 import { StandardMouseEvent } from '../../../../../base/browser/mouseEvent.js';
 import { Button } from '../../../../../base/browser/ui/button/button.js';
+import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { HoverStyle, IDelayedHoverOptions, type IHoverLifecycleOptions, type IHoverOptions } from '../../../../../base/browser/ui/hover/hover.js';
 import { createInstantHoverDelegate } from '../../../../../base/browser/ui/hover/hoverDelegateFactory.js';
 import { HoverPosition } from '../../../../../base/browser/ui/hover/hoverWidget.js';
@@ -19,7 +20,8 @@ import { Iterable } from '../../../../../base/common/iterator.js';
 import { KeyCode } from '../../../../../base/common/keyCodes.js';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable } from '../../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../../base/common/network.js';
-import { basename, dirname, extname } from '../../../../../base/common/path.js';
+import { basename, dirname } from '../../../../../base/common/path.js';
+import { joinPath } from '../../../../../base/common/resources.js';
 import { ScrollbarVisibility } from '../../../../../base/common/scrollable.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { URI } from '../../../../../base/common/uri.js';
@@ -39,6 +41,7 @@ import { ICommandService } from '../../../../../platform/commands/common/command
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IContextKey, IContextKeyService, IScopedContextKeyService, RawContextKey } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IContextMenuService } from '../../../../../platform/contextview/browser/contextView.js';
+import { IFileDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
 import { fillInSymbolsDragData } from '../../../../../platform/dnd/browser/dnd.js';
 import { IOpenEditorOptions, registerOpenEditorListeners } from '../../../../../platform/editor/browser/editor.js';
 import { ITextEditorOptions } from '../../../../../platform/editor/common/editor.js';
@@ -47,6 +50,7 @@ import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
 import { ILabelService } from '../../../../../platform/label/common/label.js';
 import { IMarkdownRendererService } from '../../../../../platform/markdown/browser/markdownRenderer.js';
+import { INotificationService } from '../../../../../platform/notification/common/notification.js';
 import { IOpenerService, OpenInternalOptions } from '../../../../../platform/opener/common/opener.js';
 import { FolderThemeIcon, IThemeService } from '../../../../../platform/theme/common/themeService.js';
 import { fillEditorsDragData } from '../../../../browser/dnd.js';
@@ -247,13 +251,13 @@ export class FileAttachmentWidget extends AbstractChatAttachmentWidget {
 		@IHoverService private readonly hoverService: IHoverService,
 		@ILanguageModelsService private readonly languageModelsService: ILanguageModelsService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
+		@IFileDialogService private readonly fileDialogService: IFileDialogService,
+		@IFileService private readonly fileService: IFileService,
+		@INotificationService private readonly notificationService: INotificationService,
 	) {
 		super(attachment, options, container, contextResourceLabels, currentLanguageModel, commandService, openerService, configurationService);
 
 		const fileBasename = basename(resource.path);
-		const attachmentType = attachment.kind === 'directory' ? localize('chat.directoryAttachmentType', "Folder") : extname(fileBasename).slice(1).toUpperCase() || localize('chat.fileAttachmentType', "File");
-		this.element.classList.add(attachment.kind === 'directory' ? 'directory-attachment' : 'file-attachment');
-		this.element.dataset.attachmentType = attachmentType;
 		const fileDirname = dirname(resource.path);
 		const friendlyName = `${fileBasename} ${fileDirname}`;
 		let ariaLabel = range ? localize('chat.fileAttachmentWithRange', "Attached file, {0}, line {1} to line {2}", friendlyName, range.startLineNumber, range.endLineNumber) : localize('chat.fileAttachment', "Attached file, {0}", friendlyName);
@@ -283,11 +287,46 @@ export class FileAttachmentWidget extends AbstractChatAttachmentWidget {
 		}
 
 		this.element.ariaLabel = this.appendDeletionHint(ariaLabel);
+		if (attachment.kind === 'file') {
+			this.attachSaveButton(resource, fileBasename, options.supportsDeletion);
+		}
 
 		this.instantiationService.invokeFunction(accessor => {
 			this._register(hookUpResourceAttachmentDragAndContextMenu(accessor, this.element, resource));
 		});
 		this.addResourceOpenHandlers(resource, range);
+	}
+
+	private attachSaveButton(resource: URI, name: string, supportsDeletion: boolean): void {
+		if (supportsDeletion) {
+			return;
+		}
+
+		const saveButton = new Button(this.element, {
+			supportIcons: true,
+			hoverDelegate: createInstantHoverDelegate(),
+			title: localize('chat.attachment.saveFileButton', "Save As...")
+		});
+		saveButton.element.classList.add('chat-attached-context-download-button');
+		saveButton.element.tabIndex = -1;
+		saveButton.icon = Codicon.cloudDownload;
+		this.element.insertBefore(saveButton.element, this.label.element);
+		this._register(saveButton);
+		this._register(saveButton.onDidClick(async e => {
+			e.preventDefault();
+			e.stopPropagation();
+			const defaultUri = joinPath(await this.fileDialogService.defaultFilePath(), name);
+			const target = await this.fileDialogService.showSaveDialog({ defaultUri });
+			if (!target) {
+				return;
+			}
+
+			try {
+				await this.fileService.copy(resource, target, true);
+			} catch (error) {
+				this.notificationService.error(localize('chat.attachment.saveFileError', "Failed to save file: {0}", error));
+			}
+		}));
 	}
 
 	private renderOmittedWarning(friendlyName: string, ariaLabel: string) {
@@ -453,6 +492,9 @@ export class ImageAttachmentWidget extends AbstractChatAttachmentWidget {
 		@ILabelService private readonly labelService: ILabelService,
 		@IChatEntitlementService private readonly chatEntitlementService: IChatEntitlementService,
 		@IChatImageCarouselService private readonly chatImageCarouselService: IChatImageCarouselService,
+		@IFileDialogService private readonly fileDialogService: IFileDialogService,
+		@IFileService private readonly fileService: IFileService,
+		@INotificationService private readonly notificationService: INotificationService,
 	) {
 		super(attachment, options, container, contextResourceLabels, currentLanguageModel, commandService, openerService, configurationService);
 		this.element.classList.add('image-attachment');
@@ -483,6 +525,7 @@ export class ImageAttachmentWidget extends AbstractChatAttachmentWidget {
 
 		const fullName = resource ? this.labelService.getUriLabel(resource) : (attachment.fullName || attachment.name);
 		this._register(createImageElements(resource, attachment.name, fullName, this.element, imageData ?? (attachment.value as Uint8Array), this.hoverService, ariaLabel, currentLanguageModelName, clickHandler, this.currentLanguageModel, attachment.omittedState, this.chatEntitlementService.previewFeaturesDisabled));
+		this.attachSaveButton(resource, imageData, attachment.name, options.supportsDeletion);
 		this.element.ariaLabel = this.appendDeletionHint(ariaLabel);
 
 		// Wire up click + keyboard (Enter/Space) open handlers
@@ -504,6 +547,41 @@ export class ImageAttachmentWidget extends AbstractChatAttachmentWidget {
 	private async openInCarousel(id: string, name: string, data: Uint8Array | undefined, referenceUri: URI | undefined): Promise<void> {
 		const resource = referenceUri ?? URI.from({ scheme: 'data', path: `${id}/${encodeURIComponent(name)}` });
 		await this.chatImageCarouselService.openCarouselAtResource(resource, data);
+	}
+
+	private attachSaveButton(resource: URI | undefined, imageData: Uint8Array | undefined, name: string, supportsDeletion: boolean): void {
+		if (supportsDeletion || (!resource && !imageData)) {
+			return;
+		}
+
+		const saveButton = new Button(this.element, {
+			supportIcons: true,
+			hoverDelegate: createInstantHoverDelegate(),
+			title: localize('chat.attachment.saveImageButton', "Save Image As...")
+		});
+		saveButton.element.classList.add('chat-attached-context-download-button');
+		saveButton.element.tabIndex = -1;
+		saveButton.icon = Codicon.cloudDownload;
+		this._register(saveButton);
+		this._register(saveButton.onDidClick(async e => {
+			e.preventDefault();
+			e.stopPropagation();
+			const defaultUri = joinPath(await this.fileDialogService.defaultFilePath(), name);
+			const target = await this.fileDialogService.showSaveDialog({ defaultUri });
+			if (!target) {
+				return;
+			}
+
+			try {
+				if (resource) {
+					await this.fileService.copy(resource, target, true);
+				} else if (imageData) {
+					await this.fileService.writeFile(target, VSBuffer.wrap(imageData));
+				}
+			} catch (error) {
+				this.notificationService.error(localize('chat.attachment.saveImageError', "Failed to save image: {0}", error));
+			}
+		}));
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/attachments/chatAttachmentWidgets.ts
+++ b/src/vs/workbench/contrib/chat/browser/attachments/chatAttachmentWidgets.ts
@@ -19,7 +19,7 @@ import { Iterable } from '../../../../../base/common/iterator.js';
 import { KeyCode } from '../../../../../base/common/keyCodes.js';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable } from '../../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../../base/common/network.js';
-import { basename, dirname } from '../../../../../base/common/path.js';
+import { basename, dirname, extname } from '../../../../../base/common/path.js';
 import { ScrollbarVisibility } from '../../../../../base/common/scrollable.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { URI } from '../../../../../base/common/uri.js';
@@ -251,6 +251,9 @@ export class FileAttachmentWidget extends AbstractChatAttachmentWidget {
 		super(attachment, options, container, contextResourceLabels, currentLanguageModel, commandService, openerService, configurationService);
 
 		const fileBasename = basename(resource.path);
+		const attachmentType = attachment.kind === 'directory' ? localize('chat.directoryAttachmentType', "Folder") : extname(fileBasename).slice(1).toUpperCase() || localize('chat.fileAttachmentType', "File");
+		this.element.classList.add(attachment.kind === 'directory' ? 'directory-attachment' : 'file-attachment');
+		this.element.dataset.attachmentType = attachmentType;
 		const fileDirname = dirname(resource.path);
 		const friendlyName = `${fileBasename} ${fileDirname}`;
 		let ariaLabel = range ? localize('chat.fileAttachmentWithRange', "Attached file, {0}, line {1} to line {2}", friendlyName, range.startLineNumber, range.endLineNumber) : localize('chat.fileAttachment', "Attached file, {0}", friendlyName);
@@ -452,6 +455,7 @@ export class ImageAttachmentWidget extends AbstractChatAttachmentWidget {
 		@IChatImageCarouselService private readonly chatImageCarouselService: IChatImageCarouselService,
 	) {
 		super(attachment, options, container, contextResourceLabels, currentLanguageModel, commandService, openerService, configurationService);
+		this.element.classList.add('image-attachment');
 
 		let ariaLabel: string;
 		if (attachment.omittedState === OmittedState.Full) {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatResourceGroupWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatResourceGroupWidget.ts
@@ -9,7 +9,7 @@ import { decodeBase64 } from '../../../../../../base/common/buffer.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { Emitter } from '../../../../../../base/common/event.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
-import { basename, joinPath } from '../../../../../../base/common/resources.js';
+import { basename, extname, joinPath } from '../../../../../../base/common/resources.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { generateUuid } from '../../../../../../base/common/uuid.js';
 import { localize, localize2 } from '../../../../../../nls.js';
@@ -25,7 +25,7 @@ import { INotificationService } from '../../../../../../platform/notification/co
 import { IProgressService, ProgressLocation } from '../../../../../../platform/progress/common/progress.js';
 import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
 import { REVEAL_IN_EXPLORER_COMMAND_ID } from '../../../../files/browser/fileConstants.js';
-import { getAttachableImageExtension } from '../../../common/model/chatModel.js';
+import { CHAT_ATTACHABLE_IMAGE_MIME_TYPES, getAttachableImageExtension } from '../../../common/model/chatModel.js';
 import { IChatRequestVariableEntry } from '../../../common/attachments/chatVariableEntries.js';
 import { ChatAttachmentsContentPart } from './chatAttachmentsContentPart.js';
 import { IChatCollapsibleIODataPart } from './chatToolInputOutputContentPart.js';
@@ -71,23 +71,24 @@ export class ChatResourceGroupWidget extends Disposable {
 	private async _fillInResourceGroup(parts: IChatCollapsibleIODataPart[], itemsContainer: HTMLElement, actionsContainer: HTMLElement) {
 		// First pass: create entries immediately, using file placeholders for base64 images
 		const entries: IChatRequestVariableEntry[] = [];
-		const deferredImageParts: { index: number; part: IChatCollapsibleIODataPart }[] = [];
+		const deferredImageParts: { index: number; part: IChatCollapsibleIODataPart; mimeType: string }[] = [];
 
 		for (let i = 0; i < parts.length; i++) {
 			const part = parts[i];
-			if (part.mimeType && getAttachableImageExtension(part.mimeType)) {
+			const imageMimeType = getResourceImageMimeType(part);
+			if (imageMimeType) {
 				if (part.base64Value) {
 					// Defer base64 decode - use file placeholder for now
 					entries.push({ kind: 'file', id: generateUuid(), name: basename(part.uri), fullName: part.uri.path, value: part.uri });
-					deferredImageParts.push({ index: i, part });
+					deferredImageParts.push({ index: i, part, mimeType: imageMimeType });
 				} else if (part.value) {
-					entries.push({ kind: 'image', id: generateUuid(), name: basename(part.uri), value: part.value, mimeType: part.mimeType, isURL: false, references: [{ kind: 'reference', reference: part.uri }] });
+					entries.push({ kind: 'image', id: generateUuid(), name: basename(part.uri), value: part.value, mimeType: imageMimeType, isURL: false, references: [{ kind: 'reference', reference: part.uri }] });
 				} else {
 					const value = await this._fileService.readFile(part.uri).then(f => f.value.buffer, () => undefined);
 					if (!value) {
 						entries.push({ kind: 'file', id: generateUuid(), name: basename(part.uri), fullName: part.uri.path, value: part.uri });
 					} else {
-						entries.push({ kind: 'image', id: generateUuid(), name: basename(part.uri), value, mimeType: part.mimeType, isURL: false, references: [{ kind: 'reference', reference: part.uri }] });
+						entries.push({ kind: 'image', id: generateUuid(), name: basename(part.uri), value, mimeType: imageMimeType, isURL: false, references: [{ kind: 'reference', reference: part.uri }] });
 					}
 				}
 			} else {
@@ -139,10 +140,10 @@ export class ChatResourceGroupWidget extends Disposable {
 		// Second pass: decode base64 images asynchronously and update in place
 		if (deferredImageParts.length > 0) {
 			this._register(disposableTimeout(() => {
-				for (const { index, part } of deferredImageParts) {
+				for (const { index, part, mimeType } of deferredImageParts) {
 					try {
 						const value = decodeBase64(part.base64Value!).buffer;
-						entries[index] = { kind: 'image', id: generateUuid(), name: basename(part.uri), value, mimeType: part.mimeType!, isURL: false, references: [{ kind: 'reference', reference: part.uri }] };
+						entries[index] = { kind: 'image', id: generateUuid(), name: basename(part.uri), value, mimeType, isURL: false, references: [{ kind: 'reference', reference: part.uri }] };
 					} catch {
 						// Keep the file placeholder on decode failure
 					}
@@ -154,6 +155,15 @@ export class ChatResourceGroupWidget extends Disposable {
 			}, IMAGE_DECODE_DELAY_MS));
 		}
 	}
+}
+
+function getResourceImageMimeType(part: IChatCollapsibleIODataPart): string | undefined {
+	if (part.mimeType && getAttachableImageExtension(part.mimeType)) {
+		return part.mimeType;
+	}
+
+	const extension = extname(part.uri).slice(1).toLowerCase();
+	return CHAT_ATTACHABLE_IMAGE_MIME_TYPES[extension];
 }
 
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -56,7 +56,7 @@ import { ChatPlanReviewData } from '../../common/model/chatProgressTypes/chatPla
 import { ChatQuestionCarouselData } from '../../common/model/chatProgressTypes/chatQuestionCarouselData.js';
 import { localChatSessionType } from '../../common/chatSessionsService.js';
 import { getChatSessionType } from '../../common/model/chatUri.js';
-import { getExplicitFileOrImageAttachmentSummary, IChatRequestVariableEntry } from '../../common/attachments/chatVariableEntries.js';
+import { getExplicitFileOrImageAttachmentSummary, IChatRequestVariableEntry, isExplicitFileOrImageVariableEntry } from '../../common/attachments/chatVariableEntries.js';
 import { IChatChangesSummaryPart, IChatCodeCitations, IChatErrorDetailsPart, IChatReferences, IChatRendererContent, IChatRequestViewModel, IChatResponseViewModel, IChatViewModel, IChatWorkingProgress, isRequestVM, isResponseVM, IChatPendingDividerViewModel, isPendingDividerVM } from '../../common/model/chatViewModel.js';
 import { getNWords } from '../../common/model/chatWordCounter.js';
 import { ChatAgentLocation, ChatConfiguration, ChatModeKind, CollapsedToolsDisplayMode, ThinkingDisplayMode } from '../../common/constants.js';
@@ -1416,12 +1416,16 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		}
 
 		let content: IChatRendererContent[] = [];
+		const explicitFileOrImageVariables = element.variables.filter(isExplicitFileOrImageVariableEntry);
+		const otherVariables = element.variables.filter(variable => !isExplicitFileOrImageVariableEntry(variable));
+		const explicitAttachmentSummary = getExplicitFileOrImageAttachmentSummary(explicitFileOrImageVariables);
+		const shouldHideAttachmentSummary = explicitAttachmentSummary !== undefined && element.messageText.trim() === explicitAttachmentSummary;
 		if (!element.confirmation) {
 			const markdown = isChatFollowup(element.message) ?
 				element.message.message :
 				this.markdownDecorationsRenderer.convertParsedRequestToMarkdown(element.sessionResource, element.message);
-			const attachmentSummary = !element.messageText.trim() ? getExplicitFileOrImageAttachmentSummary(element.variables) : undefined;
-			const requestMarkdown = markdown.trim() ? markdown : attachmentSummary;
+			const attachmentSummary = !element.messageText.trim() && !explicitFileOrImageVariables.length ? getExplicitFileOrImageAttachmentSummary(element.variables) : undefined;
+			const requestMarkdown = shouldHideAttachmentSummary ? undefined : markdown.trim() ? markdown : attachmentSummary;
 			if (requestMarkdown) {
 				content = [{ content: new MarkdownString(requestMarkdown), kind: 'markdownContent' }];
 			}
@@ -1437,6 +1441,13 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 
 		dom.clearNode(templateData.value);
 		const parts: IChatContentPart[] = [];
+		const explicitAttachmentsPart = explicitFileOrImageVariables.length ? this.renderAttachments(explicitFileOrImageVariables, element.contentReferences, element.modelId, templateData) : undefined;
+		if (explicitAttachmentsPart?.domNode) {
+			explicitAttachmentsPart.domNode.classList.add('chat-request-attachment-cards');
+			templateData.value.appendChild(explicitAttachmentsPart.domNode);
+			templateData.elementDisposables.add(explicitAttachmentsPart);
+		}
+		const contentContainer = templateData.value;
 
 		let inlineSlashCommandRendered = false;
 		let codeBlockStartIndex = 0;
@@ -1467,13 +1478,13 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 						newPart.domNode.style.display = 'inline-flex';
 					}
 					const cmdPart = this.instantiationService.createInstance(ChatAgentCommandContentPart, element.slashCommand, () => this._onDidClickRerunWithAgentOrCommandDetection.fire({ sessionResource: element.sessionResource, requestId: element.id }));
-					templateData.value.appendChild(cmdPart.domNode);
+					contentContainer.appendChild(cmdPart.domNode);
 					parts.push(cmdPart);
 					inlineSlashCommandRendered = true;
 				}
 
 				if (newPart.domNode && !newPart.domNode.parentElement) {
-					templateData.value.appendChild(newPart.domNode);
+					contentContainer.appendChild(newPart.domNode);
 				}
 				parts.push(newPart);
 				codeBlockStartIndex += newPart.codeblocks?.length ?? 0;
@@ -1485,8 +1496,8 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		}
 		templateData.renderedParts = parts;
 
-		if (element.variables.length) {
-			const newPart = this.renderAttachments(element.variables, element.contentReferences, element.modelId, templateData);
+		if (otherVariables.length) {
+			const newPart = this.renderAttachments(otherVariables, element.contentReferences, element.modelId, templateData);
 			if (newPart.domNode) {
 				// p has a :last-child rule for margin
 				templateData.value.appendChild(newPart.domNode);

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -1417,15 +1417,15 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 
 		let content: IChatRendererContent[] = [];
 		const explicitFileOrImageVariables = element.variables.filter(isExplicitFileOrImageVariableEntry);
+		const explicitImageVariables = explicitFileOrImageVariables.filter(variable => variable.kind === 'image');
+		const explicitFileOrDirectoryVariables = explicitFileOrImageVariables.filter(variable => variable.kind === 'file' || variable.kind === 'directory');
 		const otherVariables = element.variables.filter(variable => !isExplicitFileOrImageVariableEntry(variable));
-		const explicitAttachmentSummary = getExplicitFileOrImageAttachmentSummary(explicitFileOrImageVariables);
-		const shouldHideAttachmentSummary = explicitAttachmentSummary !== undefined && element.messageText.trim() === explicitAttachmentSummary;
 		if (!element.confirmation) {
 			const markdown = isChatFollowup(element.message) ?
 				element.message.message :
 				this.markdownDecorationsRenderer.convertParsedRequestToMarkdown(element.sessionResource, element.message);
 			const attachmentSummary = !element.messageText.trim() && !explicitFileOrImageVariables.length ? getExplicitFileOrImageAttachmentSummary(element.variables) : undefined;
-			const requestMarkdown = shouldHideAttachmentSummary ? undefined : markdown.trim() ? markdown : attachmentSummary;
+			const requestMarkdown = markdown.trim() ? markdown : attachmentSummary;
 			if (requestMarkdown) {
 				content = [{ content: new MarkdownString(requestMarkdown), kind: 'markdownContent' }];
 			}
@@ -1441,11 +1441,21 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 
 		dom.clearNode(templateData.value);
 		const parts: IChatContentPart[] = [];
-		const explicitAttachmentsPart = explicitFileOrImageVariables.length ? this.renderAttachments(explicitFileOrImageVariables, element.contentReferences, element.modelId, templateData) : undefined;
-		if (explicitAttachmentsPart?.domNode) {
-			explicitAttachmentsPart.domNode.classList.add('chat-request-attachment-cards');
-			templateData.value.appendChild(explicitAttachmentsPart.domNode);
-			templateData.elementDisposables.add(explicitAttachmentsPart);
+		const explicitImageAttachmentsPart = explicitImageVariables.length ? this.renderAttachments(explicitImageVariables, element.contentReferences, element.modelId, templateData) : undefined;
+		if (explicitImageAttachmentsPart?.domNode) {
+			explicitImageAttachmentsPart.domNode.classList.add('chat-request-attachment-cards', 'chat-request-image-attachments');
+			templateData.value.appendChild(explicitImageAttachmentsPart.domNode);
+			templateData.elementDisposables.add(explicitImageAttachmentsPart);
+		}
+		const explicitFileAttachmentsPart = explicitFileOrDirectoryVariables.length ? this.renderAttachments(explicitFileOrDirectoryVariables, element.contentReferences, element.modelId, templateData) : undefined;
+		if (explicitFileAttachmentsPart?.domNode) {
+			explicitFileAttachmentsPart.domNode.classList.add('chat-request-attachment-cards', 'chat-request-file-attachments');
+			explicitFileAttachmentsPart.domNode.style.display = 'flex';
+			explicitFileAttachmentsPart.domNode.style.flexDirection = 'column';
+			explicitFileAttachmentsPart.domNode.style.alignItems = 'flex-end';
+			explicitFileAttachmentsPart.domNode.style.flexWrap = 'nowrap';
+			templateData.value.appendChild(explicitFileAttachmentsPart.domNode);
+			templateData.elementDisposables.add(explicitFileAttachmentsPart);
 		}
 		const contentContainer = templateData.value;
 

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -842,19 +842,17 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 .chat-dnd-overlay .attach-context-overlay-text {
-	padding: 0.6em;
-	margin: 0.2em;
-	line-height: 12px;
-	height: 12px;
-	display: flex;
+	padding: 6px 8px;
+	border-radius: 6px;
+	display: inline-flex;
 	align-items: center;
+	gap: 6px;
+	line-height: normal;
 	text-align: center;
 }
 
 .chat-dnd-overlay .attach-context-overlay-text .codicon {
-	height: 12px;
-	font-size: 12px;
-	margin-right: 3px;
+	font-size: inherit;
 }
 
 .monaco-workbench .interactive-session .chat-input-container {

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -842,17 +842,19 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 .chat-dnd-overlay .attach-context-overlay-text {
-	padding: 6px 8px;
-	border-radius: 6px;
-	display: inline-flex;
+	padding: 0.6em;
+	margin: 0.2em;
+	line-height: 12px;
+	height: 12px;
+	display: flex;
 	align-items: center;
-	gap: 6px;
-	line-height: normal;
 	text-align: center;
 }
 
 .chat-dnd-overlay .attach-context-overlay-text .codicon {
-	font-size: inherit;
+	height: 12px;
+	font-size: 12px;
+	margin-right: 3px;
 }
 
 .monaco-workbench .interactive-session .chat-input-container {
@@ -2342,6 +2344,10 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	cursor: pointer;
 }
 
+.interactive-session .chat-attached-context .chat-attached-context-attachment .chat-attached-context-download-button {
+	display: none;
+}
+
 .interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-icon-label .codicon {
 	font-size: 14px;
 }
@@ -3429,6 +3435,12 @@ have to be updated for changes to the rules above, or to support more deeply nes
 		}
 	}
 
+	.interactive-item-container.interactive-request .value {
+		display: flex !important;
+		flex-direction: column !important;
+		align-items: flex-end !important;
+	}
+
 	.interactive-item-container.interactive-request .value .rendered-markdown {
 		background-color: var(--vscode-chat-requestBubbleBackground);
 		border-radius: var(--vscode-cornerRadius-xLarge);
@@ -3476,6 +3488,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 	.interactive-item-container.interactive-request .value > .chat-request-attachment-cards {
 		width: fit-content;
+		flex: 0 0 auto;
 		max-width: 90%;
 		margin-left: auto;
 		margin-bottom: 6px;
@@ -3486,43 +3499,74 @@ have to be updated for changes to the rules above, or to support more deeply nes
 		gap: 8px;
 	}
 
-	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment {
-		box-sizing: border-box;
-		width: 88px;
-		height: 88px;
-		padding: 8px;
-		border-radius: 8px;
-		background-color: var(--vscode-input-background);
-		border-color: var(--vscode-chat-requestBorder, var(--vscode-input-border, transparent));
-		align-items: flex-start;
-		justify-content: space-between;
+	.interactive-item-container.interactive-request .value > .chat-request-image-attachments,
+	.interactive-item-container.interactive-request .value > .chat-request-file-attachments,
+	.interactive-item-container.interactive-request .value > .rendered-markdown {
+		flex: 0 0 auto;
 	}
 
-	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.file-attachment,
-	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.directory-attachment {
-		color: var(--vscode-foreground);
-		flex-direction: column;
+	.interactive-item-container.interactive-request .value > .chat-request-file-attachments {
+		flex-direction: column !important;
+		align-items: flex-end !important;
+		flex-wrap: nowrap !important;
+		gap: 6px;
 	}
 
-	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.file-attachment::after,
-	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.directory-attachment::after {
-		content: attr(data-attachment-type);
-		max-width: 100%;
-		box-sizing: border-box;
-		padding: 1px 6px;
-		border: 1px solid var(--vscode-input-border, transparent);
-		border-radius: 4px;
+	.interactive-item-container.interactive-request .value .chat-request-file-attachments .chat-attached-context-attachment {
+		position: relative;
+		margin-left: 24px;
+		overflow: visible;
+	}
+
+	.interactive-item-container.interactive-request .value .chat-request-file-attachments .chat-attached-context-attachment::before {
+		content: '';
+		position: absolute;
+		left: -24px;
+		top: 0;
+		bottom: 0;
+		width: 24px;
+	}
+
+	.interactive-item-container.interactive-request .value .chat-request-file-attachments .chat-attached-context-attachment .chat-attached-context-download-button {
+		display: flex;
+		visibility: hidden;
+		opacity: 0;
+		position: absolute;
+		left: -22px;
+		top: 50%;
+		transform: translateY(-50%);
+		width: 18px;
+		height: 18px;
+		min-width: 18px;
+		margin: 0;
+		padding: 0;
+		align-items: center;
+		justify-content: center;
+		background: transparent;
 		color: var(--vscode-descriptionForeground);
-		font-size: 11px;
-		line-height: 16px;
-		text-transform: uppercase;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
+		border-radius: 4px;
+		z-index: 1;
+		transition: opacity 80ms ease-out;
+	}
+
+	.interactive-item-container.interactive-request .value .chat-request-file-attachments .chat-attached-context-attachment:hover .chat-attached-context-download-button,
+	.interactive-item-container.interactive-request .value .chat-request-file-attachments .chat-attached-context-attachment:focus-within .chat-attached-context-download-button {
+		visibility: visible;
+		opacity: 1;
+	}
+
+	.interactive-item-container.interactive-request .value .chat-request-file-attachments .chat-attached-context-attachment .chat-attached-context-download-button:hover {
+		background-color: var(--vscode-toolbar-hoverBackground);
 	}
 
 	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.image-attachment {
+		box-sizing: border-box;
+		width: 88px;
+		height: 88px;
+		border-radius: 8px;
 		padding: 0;
+		background-color: var(--vscode-input-background);
+		border-color: var(--vscode-chat-requestBorder, var(--vscode-input-border, transparent));
 		overflow: hidden;
 		justify-content: center;
 	}
@@ -3546,40 +3590,38 @@ have to be updated for changes to the rules above, or to support more deeply nes
 		display: none;
 	}
 
-	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.file-attachment .monaco-icon-label,
-	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.directory-attachment .monaco-icon-label {
-		width: 100%;
-		min-height: 0;
-		align-items: flex-start;
+	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.image-attachment .chat-attached-context-download-button {
+		display: flex !important;
+		visibility: hidden;
+		opacity: 0;
+		position: absolute;
+		right: 6px;
+		top: 6px;
+		width: 28px !important;
+		height: 28px !important;
+		min-width: 28px !important;
+		margin: 0 !important;
+		padding: 0 !important;
+		border-radius: 50%;
+		background-color: var(--vscode-input-background);
+		color: var(--vscode-foreground);
+		border: 1px solid var(--vscode-input-border, var(--vscode-contrastBorder, transparent));
+		box-shadow: 0 1px 4px rgb(0 0 0 / 45%);
+		align-items: center;
+		justify-content: center;
+		transition: opacity 80ms ease-out;
 	}
 
-	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.file-attachment .monaco-icon-label::before,
-	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.directory-attachment .monaco-icon-label::before {
-		display: none;
+	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.image-attachment .chat-attached-context-download-button .codicon {
+		color: var(--vscode-foreground) !important;
+		font-size: 16px;
+		margin: 0 !important;
 	}
 
-	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.file-attachment .monaco-icon-label-container,
-	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.directory-attachment .monaco-icon-label-container {
-		min-width: 0;
-		width: 100%;
-	}
-
-	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.file-attachment .monaco-icon-label,
-	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.file-attachment .monaco-icon-label-container,
-	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.file-attachment .monaco-highlighted-label,
-	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.directory-attachment .monaco-icon-label,
-	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.directory-attachment .monaco-icon-label-container,
-	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.directory-attachment .monaco-highlighted-label {
-		max-width: 100%;
-	}
-
-	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.file-attachment .monaco-highlighted-label,
-	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.directory-attachment .monaco-highlighted-label {
-		white-space: normal;
-		display: -webkit-box;
-		-webkit-line-clamp: 2;
-		line-clamp: 2;
-		-webkit-box-orient: vertical;
+	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.image-attachment:hover .chat-attached-context-download-button,
+	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.image-attachment:focus-within .chat-attached-context-download-button {
+		visibility: visible;
+		opacity: 1;
 	}
 
 	.interactive-request .header.header-disabled,

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -3351,6 +3351,56 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	color: var(--vscode-notificationsWarningIcon-foreground);
 }
 
+.chat-collapsible-io-resource-group {
+	display: flex;
+	align-items: flex-start;
+	gap: 8px;
+}
+
+.chat-collapsible-io-resource-items .chat-attached-context {
+	gap: 8px;
+	padding-bottom: 0;
+}
+
+.chat-collapsible-io-resource-items .chat-attached-context-attachment.image-attachment {
+	box-sizing: border-box;
+	width: 88px;
+	height: 88px;
+	border-radius: 8px;
+	padding: 0;
+	background-color: var(--vscode-input-background);
+	border-color: var(--vscode-chat-requestBorder, var(--vscode-input-border, transparent));
+	overflow: hidden;
+	justify-content: center;
+}
+
+.chat-collapsible-io-resource-items .chat-attached-context-attachment.image-attachment .chat-attached-context-pill {
+	width: 100%;
+	height: 100%;
+	padding: 0;
+	margin: 0;
+}
+
+.chat-collapsible-io-resource-items .chat-attached-context-attachment.image-attachment .chat-attached-context-pill-image {
+	width: 100%;
+	height: 100%;
+	border-radius: 7px;
+	margin: 0;
+	object-fit: cover;
+}
+
+.chat-collapsible-io-resource-items .chat-attached-context-attachment.image-attachment .chat-attached-context-custom-text {
+	display: none;
+}
+
+.chat-collapsible-io-resource-items .chat-attached-context-attachment.image-attachment .chat-attached-context-download-button {
+	display: none !important;
+}
+
+.chat-collapsible-io-resource-actions {
+	align-self: center;
+}
+
 .interactive-session .chat-scroll-down {
 	display: none;
 	position: absolute;

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -3476,6 +3476,114 @@ have to be updated for changes to the rules above, or to support more deeply nes
 		padding-bottom: 5px;
 	}
 
+	.interactive-item-container.interactive-request .value > .chat-request-attachment-cards {
+		width: fit-content;
+		max-width: 90%;
+		margin-left: auto;
+		margin-bottom: 6px;
+		padding-bottom: 0;
+		background: transparent;
+		border: 0;
+		justify-content: flex-end;
+		gap: 8px;
+	}
+
+	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment {
+		box-sizing: border-box;
+		width: 88px;
+		height: 88px;
+		padding: 8px;
+		border-radius: 8px;
+		background-color: var(--vscode-input-background);
+		border-color: var(--vscode-chat-requestBorder, var(--vscode-input-border, transparent));
+		align-items: flex-start;
+		justify-content: space-between;
+	}
+
+	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.file-attachment,
+	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.directory-attachment {
+		color: var(--vscode-foreground);
+		flex-direction: column;
+	}
+
+	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.file-attachment::after,
+	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.directory-attachment::after {
+		content: attr(data-attachment-type);
+		max-width: 100%;
+		box-sizing: border-box;
+		padding: 1px 6px;
+		border: 1px solid var(--vscode-input-border, transparent);
+		border-radius: 4px;
+		color: var(--vscode-descriptionForeground);
+		font-size: 11px;
+		line-height: 16px;
+		text-transform: uppercase;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.image-attachment {
+		padding: 0;
+		overflow: hidden;
+		justify-content: center;
+	}
+
+	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.image-attachment .chat-attached-context-pill {
+		width: 100%;
+		height: 100%;
+		padding: 0;
+		margin: 0;
+	}
+
+	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.image-attachment .chat-attached-context-pill-image {
+		width: 100%;
+		height: 100%;
+		border-radius: 7px;
+		margin: 0;
+		object-fit: cover;
+	}
+
+	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.image-attachment .chat-attached-context-custom-text {
+		display: none;
+	}
+
+	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.file-attachment .monaco-icon-label,
+	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.directory-attachment .monaco-icon-label {
+		width: 100%;
+		min-height: 0;
+		align-items: flex-start;
+	}
+
+	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.file-attachment .monaco-icon-label::before,
+	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.directory-attachment .monaco-icon-label::before {
+		display: none;
+	}
+
+	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.file-attachment .monaco-icon-label-container,
+	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.directory-attachment .monaco-icon-label-container {
+		min-width: 0;
+		width: 100%;
+	}
+
+	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.file-attachment .monaco-icon-label,
+	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.file-attachment .monaco-icon-label-container,
+	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.file-attachment .monaco-highlighted-label,
+	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.directory-attachment .monaco-icon-label,
+	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.directory-attachment .monaco-icon-label-container,
+	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.directory-attachment .monaco-highlighted-label {
+		max-width: 100%;
+	}
+
+	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.file-attachment .monaco-highlighted-label,
+	.interactive-item-container.interactive-request .value .chat-request-attachment-cards .chat-attached-context-attachment.directory-attachment .monaco-highlighted-label {
+		white-space: normal;
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		line-clamp: 2;
+		-webkit-box-orient: vertical;
+	}
+
 	.interactive-request .header.header-disabled,
 	.request-hover.has-no-actions,
 	.request-hover.hidden,

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatAttachmentsContentPart.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatAttachmentsContentPart.test.ts
@@ -204,8 +204,6 @@ suite('ChatAttachmentsContentPart', () => {
 
 			const attachments = part.domNode!.querySelectorAll('.chat-attached-context-attachment');
 			assert.strictEqual(attachments.length, 2, 'Should render 2 file attachments');
-			assert.ok(attachments[0].classList.contains('file-attachment'), 'File attachment should have styling class');
-			assert.strictEqual((attachments[0] as HTMLElement).dataset.attachmentType, 'TS');
 		});
 
 		test('should have chat-attached-context class on domNode', () => {

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatAttachmentsContentPart.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatAttachmentsContentPart.test.ts
@@ -110,6 +110,7 @@ suite('ChatAttachmentsContentPart', () => {
 			// Should still have 1 attachment (now as image)
 			const updatedAttachments = part.domNode!.querySelectorAll('.chat-attached-context-attachment');
 			assert.strictEqual(updatedAttachments.length, 1, 'Should have 1 attachment after update');
+			assert.ok(updatedAttachments[0].classList.contains('image-attachment'), 'Image attachment should have styling class');
 		});
 
 		test('should preserve contextMenuHandler after update', () => {
@@ -203,6 +204,8 @@ suite('ChatAttachmentsContentPart', () => {
 
 			const attachments = part.domNode!.querySelectorAll('.chat-attached-context-attachment');
 			assert.strictEqual(attachments.length, 2, 'Should render 2 file attachments');
+			assert.ok(attachments[0].classList.contains('file-attachment'), 'File attachment should have styling class');
+			assert.strictEqual((attachments[0] as HTMLElement).dataset.attachmentType, 'TS');
 		});
 
 		test('should have chat-attached-context class on domNode', () => {


### PR DESCRIPTION
This updates chat request rendering so explicit file and image attachments are shown as standalone request tiles above the user message instead of inline attachment pills or generated summary text.

Images render as square thumbnails, while files render as square tiles with the file name and type badge (we can change the latter with another design).

The underlying request text remains empty for attachment-only sends; the tiles provide the visible transcript representation.

Demo: 

https://github.com/user-attachments/assets/dc928a59-26fd-4a19-8100-f9476fd01563



