### PR TITLE
Show a warning when showing the rendered markdown diff

### DIFF
--- a/extensions/markdown-language-features/src/extension.shared.ts
+++ b/extensions/markdown-language-features/src/extension.shared.ts
@@ -39,7 +39,7 @@ export function activateShared(
 	const opener = new MdLinkOpener(client);
 
 	const contentProvider = new MdDocumentRenderer(engine, context, cspArbiter, contributions, logger);
-	const previewManager = new MarkdownPreviewManager(contentProvider, logger, contributions, opener);
+	const previewManager = new MarkdownPreviewManager(contentProvider, logger, contributions, opener, context.workspaceState);
 	context.subscriptions.push(previewManager);
 
 	context.subscriptions.push(registerMarkdownLanguageFeatures(client, commandManager, engine));

--- a/extensions/markdown-language-features/src/preview/documentRenderer.ts
+++ b/extensions/markdown-language-features/src/preview/documentRenderer.ts
@@ -27,7 +27,7 @@ const previewStrings = {
 
 	cspAlertMessageTitle: vscode.l10n.t("Potentially unsafe or insecure content has been disabled in the Markdown preview. Change the Markdown preview security setting to allow insecure content or enable scripts"),
 
-	cspAlertMessageLabel: vscode.l10n.t("Content Disabled Security Warning")
+	cspAlertMessageLabel: vscode.l10n.t("Content Disabled Security Warning"),
 };
 
 export interface MarkdownContentProviderOutput {
@@ -44,14 +44,14 @@ export interface ImageInfo {
 export class MdDocumentRenderer {
 
 	readonly #engine: MarkdownItEngine;
-	readonly #context: vscode.ExtensionContext;
+	readonly #context: Pick<vscode.ExtensionContext, 'extensionUri'>;
 	readonly #cspArbiter: ContentSecurityPolicyArbiter;
 	readonly #contributionProvider: MarkdownContributionProvider;
 	readonly #logger: ILogger;
 
 	constructor(
 		engine: MarkdownItEngine,
-		context: vscode.ExtensionContext,
+		context: Pick<vscode.ExtensionContext, 'extensionUri'>,
 		cspArbiter: ContentSecurityPolicyArbiter,
 		contributionProvider: MarkdownContributionProvider,
 		logger: ILogger
@@ -139,7 +139,7 @@ export class MdDocumentRenderer {
 	): Promise<MarkdownContentProviderOutput> {
 		const innerChanges = lineChanges?.innerChanges;
 
-		// If there are inner changes, inject empty marker spans into the source text
+		// If there are inner changes, inject invisible marker text into the source text
 		// before rendering. The webview uses the CSS Custom Highlight API to create
 		// highlights between each marker pair, which works across HTML tag boundaries.
 		const input: vscode.TextDocument | string = innerChanges?.length

--- a/extensions/markdown-language-features/src/preview/preview.ts
+++ b/extensions/markdown-language-features/src/preview/preview.ts
@@ -79,6 +79,7 @@ class MarkdownPreview extends Disposable implements WebviewResourceProvider {
 
 	readonly #resource: vscode.Uri;
 	readonly #webviewPanel: vscode.WebviewPanel;
+	readonly #isDiffView: boolean;
 
 	#line: number | undefined;
 	readonly #scrollToFragment: string | undefined;
@@ -126,7 +127,8 @@ class MarkdownPreview extends Disposable implements WebviewResourceProvider {
 		this.#webviewPanel = webview;
 		this.#resource = resource;
 
-		this.#scrollToFirstDiffChange = !startingScroll && !!delegate.getLineChanges;
+		this.#isDiffView = !!delegate.getLineChanges;
+		this.#scrollToFirstDiffChange = !startingScroll && this.#isDiffView;
 
 		switch (startingScroll?.type) {
 			case 'line':
@@ -221,6 +223,10 @@ class MarkdownPreview extends Disposable implements WebviewResourceProvider {
 
 	public get resource(): vscode.Uri {
 		return this.#resource;
+	}
+
+	public get isDiffView(): boolean {
+		return this.#isDiffView;
 	}
 
 	public get state() {
@@ -519,6 +525,7 @@ export interface IManagedMarkdownPreview {
 
 	readonly resource: vscode.Uri;
 	readonly resourceColumn: vscode.ViewColumn;
+	readonly isDiffView: boolean;
 
 	readonly onDispose: vscode.Event<void>;
 	readonly onDidChangeViewState: vscode.Event<vscode.WebviewPanelOnDidChangeViewStateEvent>;
@@ -665,6 +672,10 @@ export class StaticMarkdownPreview extends Disposable implements IManagedMarkdow
 
 	public get resourceColumn() {
 		return this.#webviewPanel.viewColumn || vscode.ViewColumn.One;
+	}
+
+	public get isDiffView(): boolean {
+		return this.#preview.isDiffView;
 	}
 }
 
@@ -822,6 +833,10 @@ export class DynamicMarkdownPreview extends Disposable implements IManagedMarkdo
 
 	public get resourceColumn() {
 		return this.#resourceColumn;
+	}
+
+	public get isDiffView(): boolean {
+		return this.#preview.isDiffView;
 	}
 
 	public reveal(viewColumn: vscode.ViewColumn) {

--- a/extensions/markdown-language-features/src/preview/previewManager.ts
+++ b/extensions/markdown-language-features/src/preview/previewManager.ts
@@ -14,6 +14,7 @@ import { MdDocumentRenderer } from './documentRenderer';
 import { MarkdownPreviewLineDiffProvider } from './lineDiff';
 import { DynamicMarkdownPreview, IManagedMarkdownPreview, StaticMarkdownPreview } from './preview';
 import { MarkdownPreviewConfigurationManager } from './previewConfig';
+import { RenderedDiffWarningManager } from './renderedDiffWarning';
 import { scrollEditorToLine, StartingScrollFragment, StartingScrollLine, StartingScrollLocation } from './scrolling';
 import { getVisibleLine, TopmostLineMonitor } from './topmostLineMonitor';
 import type { DiffScrollSyncData, MarkdownPreviewLineChanges } from '../../types/previewMessaging';
@@ -86,12 +87,14 @@ export class MarkdownPreviewManager extends Disposable implements vscode.Webview
 	readonly #logger: ILogger;
 	readonly #contributions: MarkdownContributionProvider;
 	readonly #opener: MdLinkOpener;
+	readonly #renderedDiffWarning: RenderedDiffWarningManager;
 
 	public constructor(
 		contentProvider: MdDocumentRenderer,
 		logger: ILogger,
 		contributions: MarkdownContributionProvider,
 		opener: MdLinkOpener,
+		workspaceState: vscode.Memento,
 	) {
 		super();
 
@@ -99,6 +102,7 @@ export class MarkdownPreviewManager extends Disposable implements vscode.Webview
 		this.#logger = logger;
 		this.#contributions = contributions;
 		this.#opener = opener;
+		this.#renderedDiffWarning = this._register(new RenderedDiffWarningManager(workspaceState));
 
 		this._register(vscode.window.registerWebviewPanelSerializer(DynamicMarkdownPreview.viewType, this));
 
@@ -310,7 +314,7 @@ export class MarkdownPreviewManager extends Disposable implements vscode.Webview
 			getDiffScrollSync
 		);
 		this.#registerStaticPreview(preview);
-		this.#activePreview = preview;
+		this.#setActivePreview(preview);
 		return preview;
 	}
 
@@ -343,7 +347,7 @@ export class MarkdownPreviewManager extends Disposable implements vscode.Webview
 			this.#contributions,
 			this.#opener);
 
-		this.#activePreview = preview;
+		this.#setActivePreview(preview);
 		return this.#registerDynamicPreview(preview);
 	}
 
@@ -386,14 +390,19 @@ export class MarkdownPreviewManager extends Disposable implements vscode.Webview
 
 	#trackActive(preview: IManagedMarkdownPreview): void {
 		preview.onDidChangeViewState(({ webviewPanel }) => {
-			this.#activePreview = webviewPanel.active ? preview : undefined;
+			this.#setActivePreview(webviewPanel.active ? preview : undefined);
 		});
 
 		preview.onDispose(() => {
 			if (this.#activePreview === preview) {
-				this.#activePreview = undefined;
+				this.#setActivePreview(undefined);
 			}
 		});
+	}
+
+	#setActivePreview(preview: IManagedMarkdownPreview | undefined): void {
+		this.#activePreview = preview;
+		this.#renderedDiffWarning.setActiveDiffPreview(!!preview?.isDiffView);
 	}
 
 }

--- a/extensions/markdown-language-features/src/preview/renderedDiffWarning.ts
+++ b/extensions/markdown-language-features/src/preview/renderedDiffWarning.ts
@@ -64,7 +64,7 @@ export class RenderedDiffWarningManager extends Disposable {
 		if (!this.#statusBarItem) {
 			this.#statusBarItem = vscode.window.createStatusBarItem('markdown.renderedDiffWarning', vscode.StatusBarAlignment.Right, 100);
 			this.#statusBarItem.name = vscode.l10n.t('Rendered Markdown Diff Warning');
-			this.#statusBarItem.text = '$(warning) ' + vscode.l10n.t('Rendered Diff');
+			this.#statusBarItem.text = vscode.l10n.t('{0} Rendered Diff', '$(warning)');
 			this.#statusBarItem.tooltip = vscode.l10n.t('Rendered Markdown diffs may hide important changes. Click for details.');
 			this.#statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground');
 			this.#statusBarItem.command = this.#showWarningCommandId;

--- a/extensions/markdown-language-features/src/preview/renderedDiffWarning.ts
+++ b/extensions/markdown-language-features/src/preview/renderedDiffWarning.ts
@@ -1,0 +1,91 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { Disposable } from '../util/dispose';
+
+const suppressedStorageKey = 'markdown.preview.renderedDiffWarning.suppressed';
+const notificationShownStorageKey = 'markdown.preview.renderedDiffWarning.notificationShown';
+
+export class RenderedDiffWarningManager extends Disposable {
+
+	readonly #workspaceState: vscode.Memento;
+
+	#statusBarItem: vscode.StatusBarItem | undefined;
+	#hasActiveDiffPreview = false;
+
+	readonly #showWarningCommandId = '_markdown.preview.showRenderedDiffWarning';
+
+	constructor(workspaceState: vscode.Memento) {
+		super();
+
+		this.#workspaceState = workspaceState;
+
+		this._register(vscode.commands.registerCommand(this.#showWarningCommandId, () => {
+			void this.#showWarningNotification();
+		}));
+	}
+
+	override dispose(): void {
+		this.#statusBarItem?.dispose();
+		this.#statusBarItem = undefined;
+		super.dispose();
+	}
+
+	/**
+	 * Set whether a diff preview is currently the active editor.
+	 *
+	 * Drives the visibility of the status bar warning and triggers the one-time
+	 * notification the first time the user focuses a diff preview.
+	 */
+	public setActiveDiffPreview(active: boolean): void {
+		if (this.#isSuppressed() || this.#hasActiveDiffPreview === active) {
+			return;
+		}
+
+		this.#hasActiveDiffPreview = active;
+		this.#updateStatusBar();
+
+		if (active && !this.#workspaceState.get<boolean>(notificationShownStorageKey, false)) {
+			void this.#workspaceState.update(notificationShownStorageKey, true);
+			void this.#showWarningNotification();
+		}
+	}
+
+	#updateStatusBar(): void {
+		if (this.#isSuppressed() || !this.#hasActiveDiffPreview) {
+			this.#statusBarItem?.dispose();
+			this.#statusBarItem = undefined;
+			return;
+		}
+
+		if (!this.#statusBarItem) {
+			this.#statusBarItem = vscode.window.createStatusBarItem('markdown.renderedDiffWarning', vscode.StatusBarAlignment.Right, 100);
+			this.#statusBarItem.name = vscode.l10n.t('Rendered Markdown Diff Warning');
+			this.#statusBarItem.text = '$(warning) ' + vscode.l10n.t('Rendered Diff');
+			this.#statusBarItem.tooltip = vscode.l10n.t('Rendered Markdown diffs may hide important changes. Click for details.');
+			this.#statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground');
+			this.#statusBarItem.command = this.#showWarningCommandId;
+		}
+		this.#statusBarItem.show();
+	}
+
+	async #showWarningNotification(): Promise<void> {
+		const dontShowAgain = vscode.l10n.t("Don't Show Again");
+		const selected = await vscode.window.showWarningMessage(
+			vscode.l10n.t('Rendered Markdown diffs may hide important changes such as formatting, whitespace, links, or HTML. Switch to the text diff if you need to review them.'),
+			dontShowAgain,
+		);
+		if (selected === dontShowAgain) {
+			await this.#workspaceState.update(suppressedStorageKey, true);
+			this.#hasActiveDiffPreview = false;
+			this.#updateStatusBar();
+		}
+	}
+
+	#isSuppressed(): boolean {
+		return this.#workspaceState.get<boolean>(suppressedStorageKey, false);
+	}
+}


### PR DESCRIPTION
Our current implementation has some bugs that can hide changes. However even after fixing these, I'm not 100% confident a unexpected change wont sneak through. Best to make users aware of this while also trying to prevent this

