### PR TITLE
Enhance feedback widget behavior with auto-hide logic

### DIFF
--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorInputContribution.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorInputContribution.ts
@@ -205,6 +205,7 @@ export class AgentFeedbackEditorInputContribution extends Disposable implements 
 	private _mouseDown = false;
 	private _suppressSelectionChangeOnce = false;
 	private _sessionResource: URI | undefined;
+	private _pinnedSelection: Selection | undefined;
 	private readonly _widgetListeners = this._store.add(new DisposableStore());
 
 	constructor(
@@ -228,7 +229,7 @@ export class AgentFeedbackEditorInputContribution extends Disposable implements 
 				return;
 			}
 			this._mouseDown = true;
-			this._hide();
+			this._autoHide();
 		}));
 		this._store.add(this._editor.onMouseUp((e) => {
 			this._mouseDown = false;
@@ -249,7 +250,7 @@ export class AgentFeedbackEditorInputContribution extends Disposable implements 
 				if (this._isWidgetTarget(getWindow(this._editor.getDomNode()!).document.activeElement)) {
 					return;
 				}
-				this._hide();
+				this._autoHide();
 			}, 0);
 		}));
 		this._store.add(this._editor.onDidFocusEditorText(() => this._onSelectionChanged()));
@@ -285,21 +286,28 @@ export class AgentFeedbackEditorInputContribution extends Disposable implements 
 			return;
 		}
 
+		// If the widget is open and the user has typed text, freeze its state.
+		// Auto-hide and auto-reposition are suppressed; the user must explicitly
+		// close the widget via Esc.
+		if (this._visible && this._hasInputText()) {
+			return;
+		}
+
 		const selection = this._editor.getSelection();
 		if (!selection || (selection.isEmpty() && !this._getDiffHunkForSelection(selection))) {
-			this._hide();
+			this._autoHide();
 			return;
 		}
 
 		const model = this._editor.getModel();
 		if (!model) {
-			this._hide();
+			this._autoHide();
 			return;
 		}
 
 		const sessionResource = getSessionForResource(model.uri, this._chatEditingService, this._sessionsManagementService);
 		if (!sessionResource) {
-			this._hide();
+			this._autoHide();
 			return;
 		}
 
@@ -317,6 +325,7 @@ export class AgentFeedbackEditorInputContribution extends Disposable implements 
 
 		widget.clearInput();
 		widget.show();
+		this._pinnedSelection = this._editor.getSelection() ?? undefined;
 		this._updatePosition();
 	}
 
@@ -326,6 +335,7 @@ export class AgentFeedbackEditorInputContribution extends Disposable implements 
 		}
 
 		this._visible = false;
+		this._pinnedSelection = undefined;
 		this._widgetListeners.clear();
 
 		if (this._widget) {
@@ -333,6 +343,22 @@ export class AgentFeedbackEditorInputContribution extends Disposable implements 
 			this._widget.setPosition(null);
 			this._widget.clearInput();
 		}
+	}
+
+	private _hasInputText(): boolean {
+		return !!this._widget && this._widget.inputElement.value.trim().length > 0;
+	}
+
+	/**
+	 * Hide the widget unless the user has typed text. When text is present the
+	 * widget is preserved so the user does not lose their in-progress feedback;
+	 * they can close it explicitly via Esc.
+	 */
+	private _autoHide(): void {
+		if (this._hasInputText()) {
+			return;
+		}
+		this._hide();
 	}
 
 	private _registerWidgetListeners(widget: AgentFeedbackInputWidget): void {
@@ -447,7 +473,7 @@ export class AgentFeedbackEditorInputContribution extends Disposable implements 
 				if (this._editor.hasWidgetFocus()) {
 					return;
 				}
-				this._hide();
+				this._autoHide();
 			}, 0);
 		}));
 	}
@@ -474,7 +500,7 @@ export class AgentFeedbackEditorInputContribution extends Disposable implements 
 			return false;
 		}
 
-		const selection = this._editor.getSelection();
+		const selection = this._pinnedSelection ?? this._editor.getSelection();
 		const model = this._editor.getModel();
 		if (!selection || !model || !this._sessionResource) {
 			return false;
@@ -495,7 +521,7 @@ export class AgentFeedbackEditorInputContribution extends Disposable implements 
 			return;
 		}
 
-		const selection = this._editor.getSelection();
+		const selection = this._pinnedSelection ?? this._editor.getSelection();
 		const model = this._editor.getModel();
 		if (!selection || !model || !this._sessionResource) {
 			return;
@@ -556,9 +582,14 @@ export class AgentFeedbackEditorInputContribution extends Disposable implements 
 			return;
 		}
 
-		const selection = this._editor.getSelection();
+		// While the user has typed text, keep the widget anchored to the
+		// selection it was opened against so it doesn't follow new selections
+		// or hide when the user clicks elsewhere in the editor.
+		const selection = (this._hasInputText() && this._pinnedSelection)
+			? this._pinnedSelection
+			: this._editor.getSelection();
 		if (!selection) {
-			this._hide();
+			this._autoHide();
 			return;
 		}
 
@@ -571,7 +602,7 @@ export class AgentFeedbackEditorInputContribution extends Disposable implements 
 		if (selection.isEmpty()) {
 			const diffHunk = this._getDiffHunkForSelection(selection);
 			if (!diffHunk) {
-				this._hide();
+				this._autoHide();
 				return;
 			}
 


### PR DESCRIPTION
```Copilot Generated Description:``` Implement auto-hide logic for the feedback widget and preserve its state when text is present. The widget will remain visible if the user has typed feedback, requiring explicit closure via Esc.

closes https://github.com/microsoft/vscode/issues/314909