### PR TITLE
Hide anonymous access setting from settings ui

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -1641,6 +1641,7 @@ configurationRegistry.registerConfiguration({
 			type: 'boolean',
 			description: nls.localize('chat.allowAnonymousAccess', "Controls whether anonymous access is allowed in chat."),
 			default: false,
+			included: false,
 			tags: ['experimental'],
 			experiment: {
 				mode: 'auto'


### PR DESCRIPTION
- Configuration update:
  * The `allowAnonymousAccess` setting in `chat.shared.contribution.ts` now has `included: false`, hiding it from default configuration listings.