### PR TITLE
agent-host: stop config pickers flashing during resolveSessionConfig

### DIFF
--- a/src/vs/sessions/common/agentHostSessionsProvider.ts
+++ b/src/vs/sessions/common/agentHostSessionsProvider.ts
@@ -45,6 +45,12 @@ export interface IAgentHostSessionsProvider extends ISessionsProvider {
 	readonly onDidChangeSessionConfig: Event<string>;
 	/** Returns the last resolved dynamic configuration for a session. */
 	getSessionConfig(sessionId: string): ResolveSessionConfigResult | undefined;
+	/**
+	 * Observable: `true` while a `resolveSessionConfig` round-trip is in
+	 * flight. Pickers gate on this rather than `session.loading` so they
+	 * stay interactive in the required-values-missing state.
+	 */
+	isSessionConfigResolving(sessionId: string): IObservable<boolean>;
 	/** Sets one dynamic configuration property and re-resolves the schema. */
 	setSessionConfigValue(sessionId: string, property: string, value: unknown): Promise<void>;
 	/**

--- a/src/vs/sessions/contrib/chat/browser/media/chatInput.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatInput.css
@@ -54,7 +54,8 @@
 	color: var(--vscode-agentsChatInput-placeholderForeground);
 }
 
-.chat-input-picker-item .action-label.disabled {
+.chat-input-picker-item .action-label.disabled,
+.chat-input-picker-item.disabled .action-label {
 	opacity: 0.5;
 	cursor: default;
 	pointer-events: none;

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostModePicker.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostModePicker.ts
@@ -124,6 +124,23 @@ export abstract class AgentHostSessionEnumPicker extends Disposable {
 	protected _getFooterActionItems(): readonly IActionListItem<IAgentHostSessionEnumPickerItem>[] { return []; }
 	protected _handleFooterActionItem(_item: IAgentHostSessionEnumPickerItem): boolean { return false; }
 
+	/**
+	 * `true` while the active session's provider is resolving its config.
+	 * Subclasses gate picker-open paths on this; the desktop chip is
+	 * rendered visually disabled in {@link _updateTrigger}.
+	 */
+	protected _isCurrentlyResolvingConfig(): boolean {
+		const session = this._sessionsManagementService.activeSession.get();
+		if (!session) {
+			return false;
+		}
+		const provider = this._sessionsProvidersService.getProvider(session.providerId);
+		if (!provider || !isAgentHostProvider(provider)) {
+			return false;
+		}
+		return provider.isSessionConfigResolving(session.sessionId).get();
+	}
+
 	private _getActiveContext(): { provider: IAgentHostSessionsProvider; sessionId: string; currentValue: string; items: readonly IAgentHostSessionEnumPickerItem[] } | undefined {
 		const session = this._sessionsManagementService.activeSession.get();
 		if (!session) {
@@ -177,6 +194,13 @@ export abstract class AgentHostSessionEnumPicker extends Disposable {
 		labelSpan.textContent = label;
 
 		this._triggerElement.ariaLabel = this._getTriggerAriaLabel(label);
+
+		// Reflect the resolving state. Schema is preserved across the
+		// round-trip so the chip keeps its label; toggling `.disabled`
+		// on the slot blocks pointer events (see chatWidget.css).
+		const isResolving = ctx.provider.isSessionConfigResolving(ctx.sessionId).get();
+		this._slotElement.classList.toggle('disabled', isResolving);
+		this._triggerElement.setAttribute('aria-disabled', isResolving ? 'true' : 'false');
 	}
 
 	protected _showPicker(): void {
@@ -185,6 +209,10 @@ export abstract class AgentHostSessionEnumPicker extends Disposable {
 		}
 		const ctx = this._getActiveContext();
 		if (!ctx) {
+			return;
+		}
+		// Defensive against stale keyboard activation on a disabled chip.
+		if (this._isCurrentlyResolvingConfig()) {
 			return;
 		}
 

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostPermissionPickerActionItem.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostPermissionPickerActionItem.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { autorun, derived } from '../../../../../base/common/observable.js';
+import { autorun, derived, IObservable } from '../../../../../base/common/observable.js';
 import { MenuItemAction } from '../../../../../platform/actions/common/actions.js';
 import { IActionWidgetService } from '../../../../../platform/actionWidget/browser/actionWidget.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
@@ -32,6 +32,8 @@ import { AgentHostPermissionPickerDelegate } from './agentHostPermissionPickerDe
 export class AgentHostPermissionPickerActionItem extends PermissionPickerActionItem {
 
 	private readonly _delegate: AgentHostPermissionPickerDelegate;
+	/** Active session's `isSessionConfigResolving`. */
+	private readonly _isResolvingActiveSessionConfig: IObservable<boolean>;
 
 	constructor(
 		action: MenuItemAction,
@@ -63,6 +65,19 @@ export class AgentHostPermissionPickerActionItem extends PermissionPickerActionI
 			storageService,
 		);
 		this._delegate = this._register(delegate);
+		// Initialized here (not as a class field) so the `derived` body can
+		// safely close over the parameter-property service references.
+		this._isResolvingActiveSessionConfig = derived(this, reader => {
+			const session = this._sessionsManagementService.activeSession.read(reader);
+			if (!session) {
+				return false;
+			}
+			const provider = this._sessionsProvidersService.getProvider(session.providerId);
+			if (!provider || !isAgentHostProvider(provider)) {
+				return false;
+			}
+			return provider.isSessionConfigResolving(session.sessionId).read(reader);
+		});
 
 		// The base widget's label is rendered on demand via `refresh()`. Keep it
 		// in sync with the delegate's level observable.
@@ -71,19 +86,6 @@ export class AgentHostPermissionPickerActionItem extends PermissionPickerActionI
 			this.refresh();
 		}));
 	}
-
-	/** Active session's `isSessionConfigResolving`. */
-	private readonly _isResolvingActiveSessionConfig = derived(this, reader => {
-		const session = this._sessionsManagementService.activeSession.read(reader);
-		if (!session) {
-			return false;
-		}
-		const provider = this._sessionsProvidersService.getProvider(session.providerId);
-		if (!provider || !isAgentHostProvider(provider)) {
-			return false;
-		}
-		return provider.isSessionConfigResolving(session.sessionId).read(reader);
-	});
 
 	override render(container: HTMLElement): void {
 		super.render(container);

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostPermissionPickerActionItem.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostPermissionPickerActionItem.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { autorun } from '../../../../../base/common/observable.js';
+import { autorun, derived } from '../../../../../base/common/observable.js';
 import { MenuItemAction } from '../../../../../platform/actions/common/actions.js';
 import { IActionWidgetService } from '../../../../../platform/actionWidget/browser/actionWidget.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
@@ -16,6 +16,9 @@ import { IStorageService } from '../../../../../platform/storage/common/storage.
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { IChatInputPickerOptions } from '../../../../../workbench/contrib/chat/browser/widget/input/chatInputPickerActionItem.js';
 import { PermissionPickerActionItem } from '../../../../../workbench/contrib/chat/browser/widget/input/permissionPickerActionItem.js';
+import { isAgentHostProvider } from '../../../../common/agentHostSessionsProvider.js';
+import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
+import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
 import { AgentHostPermissionPickerDelegate } from './agentHostPermissionPickerDelegate.js';
 
 /**
@@ -42,6 +45,8 @@ export class AgentHostPermissionPickerActionItem extends PermissionPickerActionI
 		@IDialogService dialogService: IDialogService,
 		@IOpenerService openerService: IOpenerService,
 		@IStorageService storageService: IStorageService,
+		@ISessionsManagementService private readonly _sessionsManagementService: ISessionsManagementService,
+		@ISessionsProvidersService private readonly _sessionsProvidersService: ISessionsProvidersService,
 	) {
 		const delegate = instantiationService.createInstance(AgentHostPermissionPickerDelegate);
 		super(
@@ -67,6 +72,19 @@ export class AgentHostPermissionPickerActionItem extends PermissionPickerActionI
 		}));
 	}
 
+	/** Active session's `isSessionConfigResolving`. */
+	private readonly _isResolvingActiveSessionConfig = derived(this, reader => {
+		const session = this._sessionsManagementService.activeSession.read(reader);
+		if (!session) {
+			return false;
+		}
+		const provider = this._sessionsProvidersService.getProvider(session.providerId);
+		if (!provider || !isAgentHostProvider(provider)) {
+			return false;
+		}
+		return provider.isSessionConfigResolving(session.sessionId).read(reader);
+	});
+
 	override render(container: HTMLElement): void {
 		super.render(container);
 		// The active session can change while this view item is alive (the
@@ -75,6 +93,24 @@ export class AgentHostPermissionPickerActionItem extends PermissionPickerActionI
 		this._register(autorun(reader => {
 			const visible = this._delegate.isApplicable.read(reader);
 			container.style.display = visible ? '' : 'none';
+		}));
+
+		// Reflect the resolving state. The underlying ActionWidgetDropdown
+		// still handles Enter/Space on its label and pointer-events: none
+		// doesn't block keyboard, so the delegate also bails at the
+		// provider boundary.
+		this._register(autorun(reader => {
+			const isResolving = this._isResolvingActiveSessionConfig.read(reader);
+			const element = this.element;
+			if (!element) {
+				return;
+			}
+			element.classList.toggle('disabled', isResolving);
+			if (isResolving) {
+				element.setAttribute('aria-disabled', 'true');
+			} else {
+				element.removeAttribute('aria-disabled');
+			}
 		}));
 	}
 }

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostPermissionPickerDelegate.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostPermissionPickerDelegate.ts
@@ -92,6 +92,11 @@ export class AgentHostPermissionPickerDelegate extends Disposable implements IPe
 		if (!provider) {
 			return;
 		}
+		// Defensive: ActionWidgetDropdown picks up Enter/Space on its
+		// label even when `pointer-events: none` is set on the chip.
+		if (provider.isSessionConfigResolving(session.sessionId).get()) {
+			return;
+		}
 		provider.setSessionConfigValue(session.sessionId, SessionConfigKey.AutoApprove, level)
 			.catch(() => { /* best-effort */ });
 	}

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionConfigPicker.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionConfigPicker.ts
@@ -252,10 +252,7 @@ export class AgentHostSessionConfigPicker extends Disposable {
 		super();
 
 		this._register(autorun(reader => {
-			const session = this._sessionsManagementService.activeSession.read(reader);
-			if (session) {
-				session.loading.read(reader);
-			}
+			this._sessionsManagementService.activeSession.read(reader);
 			this._renderConfigPickers();
 		}));
 
@@ -305,6 +302,11 @@ export class AgentHostSessionConfigPicker extends Disposable {
 		// non-mutable properties like `isolation` must remain visible and
 		// interactive there.
 		const isNewSession = provider.getCreateSessionConfig(session.sessionId) !== undefined;
+		// Disable interactions while a resolve is in flight. Schema is
+		// preserved so chips stay visible. Not `session.loading` —
+		// that also covers the required-values-missing state where
+		// chips must remain interactive.
+		const isLoading = provider.isSessionConfigResolving(session.sessionId).get();
 
 		const properties = this._orderProperties(Object.entries(resolvedConfig.schema.properties));
 
@@ -340,8 +342,9 @@ export class AgentHostSessionConfigPicker extends Disposable {
 			}
 			const value = resolvedConfig.values[property] ?? schema.default;
 			const isReadOnly = this._isReadOnlyChip(property, schema, isNewSession);
+			const isDisabled = isReadOnly || isLoading;
 			const slot = dom.append(this._container, dom.$('.sessions-chat-picker-slot'));
-			const trigger = renderPickerTrigger(slot, isReadOnly, this._renderDisposables, () => this._showPicker(provider, session.sessionId, property, schema, trigger));
+			const trigger = renderPickerTrigger(slot, isDisabled, this._renderDisposables, () => this._showPicker(provider, session.sessionId, property, schema, trigger));
 			this._renderTrigger(trigger, property, schema, value, isReadOnly);
 		}
 	}
@@ -411,7 +414,11 @@ export class AgentHostSessionConfigPicker extends Disposable {
 		if (schema.readOnly || this._actionWidgetService.isVisible) {
 			return;
 		}
-
+		// Mobile bottom-sheet override dispatches through this entry
+		// point, so guard here for both invocation paths.
+		if (provider.isSessionConfigResolving(sessionId).get()) {
+			return;
+		}
 
 		const rawItems = await this._getItems(provider, sessionId, property, schema);
 		const { items, policyRestricted } = applyAutoApproveFiltering(rawItems, property, this._configurationService);

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionConfigPicker.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionConfigPicker.ts
@@ -342,9 +342,18 @@ export class AgentHostSessionConfigPicker extends Disposable {
 			}
 			const value = resolvedConfig.values[property] ?? schema.default;
 			const isReadOnly = this._isReadOnlyChip(property, schema, isNewSession);
-			const isDisabled = isReadOnly || isLoading;
 			const slot = dom.append(this._container, dom.$('.sessions-chat-picker-slot'));
-			const trigger = renderPickerTrigger(slot, isDisabled, this._renderDisposables, () => this._showPicker(provider, session.sessionId, property, schema, trigger));
+			// `renderPickerTrigger`'s `disabled` flag means "read-only"
+			// (renders a `<span>` with `aria-readonly`). The resolving
+			// state is transient and uses `.disabled` on the slot (see
+			// CSS in `chatWidget.css`) + `aria-disabled` on the trigger,
+			// keeping it focusable and using correct ARIA semantics. The
+			// click handler bails when resolving in `_showPicker`.
+			const trigger = renderPickerTrigger(slot, isReadOnly, this._renderDisposables, () => this._showPicker(provider, session.sessionId, property, schema, trigger));
+			if (!isReadOnly && isLoading) {
+				slot.classList.add('disabled');
+				trigger.setAttribute('aria-disabled', 'true');
+			}
 			this._renderTrigger(trigger, property, schema, value, isReadOnly);
 		}
 	}

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -537,6 +537,15 @@ class NewSession extends Disposable {
 	 */
 	private _configRequestSeq = 0;
 
+	/**
+	 * `true` while a `resolveConfig` round-trip is in flight. Distinct from
+	 * {@link ISession.loading} which also stays true when required config
+	 * values are missing — pickers gate on this so they stay interactive
+	 * in that state. Set sync in {@link beginResolveConfigSync} so the
+	 * optimistic `onDidChangeSessionConfig` pulse already exposes it.
+	 */
+	private readonly _isResolvingConfig: ISettableObservable<boolean>;
+
 	/** Backend session URI, set the moment {@link eagerCreate} starts. */
 	private _backendUri: URI | undefined;
 	/** Connection used to create the backend session, captured for `disposeSession` on tear-down. */
@@ -583,6 +592,7 @@ class NewSession extends Disposable {
 		const description = observableValue<IMarkdownString | undefined>(this, undefined);
 		const lastTurnEnd = observableValue<Date | undefined>(this, undefined);
 		this._loading = observableValue(this, true);
+		this._isResolvingConfig = observableValue(this, false);
 		const createdAt = new Date();
 
 		const mainChat: IChat = {
@@ -658,13 +668,37 @@ class NewSession extends Disposable {
 	getConfigValues(): Record<string, unknown> | undefined { return this._config?.values; }
 
 	/**
-	 * Optimistically merges a single property into the cached config. Used by
-	 * the picker to update local state before the next {@link resolveConfig}
-	 * round-trip completes.
+	 * Optimistically merges a single property into the cached config.
+	 * Preserves the existing schema so schema-driven pickers don't flash
+	 * during the async re-resolve. {@link resolveConfig} replaces both
+	 * schema and values when its response lands.
 	 */
 	setConfigValue(property: string, value: unknown): void {
-		const current = this._config?.values ?? {};
-		this._config = { schema: { type: 'object', properties: {} }, values: { ...current, [property]: value } };
+		const current = this._config;
+		this._config = {
+			schema: current?.schema ?? { type: 'object', properties: {} },
+			values: { ...(current?.values ?? {}), [property]: value },
+		};
+	}
+
+	/**
+	 * `true` while a {@link resolveConfig} round-trip is in flight. See
+	 * {@link _isResolvingConfig} for why this is distinct from {@link ISession.loading}.
+	 */
+	get isResolvingConfig(): IObservable<boolean> { return this._isResolvingConfig; }
+
+	/** Mark a resolve as starting before the optimistic event fires. */
+	beginResolveConfigSync(): void {
+		this._isResolvingConfig.set(true, undefined);
+	}
+
+	/**
+	 * Clear the in-flight flag for early-return paths that skip
+	 * {@link resolveConfig} (e.g. no connection), where the `finally`
+	 * cleanup never runs.
+	 */
+	endResolveConfigSync(): void {
+		this._isResolvingConfig.set(false, undefined);
 	}
 
 	/**
@@ -676,6 +710,7 @@ class NewSession extends Disposable {
 	 */
 	async resolveConfig(connection: IAgentConnection): Promise<boolean> {
 		const seq = ++this._configRequestSeq;
+		this._isResolvingConfig.set(true, undefined);
 		try {
 			const result = await connection.resolveSessionConfig({
 				provider: this.agentProvider,
@@ -693,6 +728,11 @@ class NewSession extends Disposable {
 			}
 			this._config = undefined;
 			return true;
+		} finally {
+			// Only the latest request owns the flag.
+			if (seq === this._configRequestSeq) {
+				this._isResolvingConfig.set(false, undefined);
+			}
 		}
 	}
 
@@ -1208,7 +1248,12 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 	private async _refreshNewSessionConfig(session: NewSession): Promise<void> {
 		const connection = this.connection;
 		if (!connection) {
+			// {@link resolveConfig} (the only other clear path) is skipped
+			// on this branch, so clear the flag here to avoid stalling
+			// the picker forever.
+			session.endResolveConfigSync();
 			session.setLoading(false);
+			this._onDidChangeSessionConfig.fire(session.sessionId);
 			return;
 		}
 		session.setLoading(true);
@@ -1269,10 +1314,33 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 		return this._runningSessionConfigs.get(sessionId);
 	}
 
+	/**
+	 * Observable: `true` while a `resolveSessionConfig` round-trip is in
+	 * flight. Distinct from `session.loading` (which also covers the
+	 * required-values-missing state) — pickers gate on this so they stay
+	 * interactive when the user has to fill in required values.
+	 */
+	isSessionConfigResolving(sessionId: string): IObservable<boolean> {
+		return this._newSession?.sessionId === sessionId
+			? this._newSession.isResolvingConfig
+			: constObservable(false);
+	}
+
 	async setSessionConfigValue(sessionId: string, property: string, value: unknown): Promise<void> {
-		// New session (pre-creation): re-resolve the full config schema
+		// New session: re-resolve the full config schema. Flip the
+		// resolving flag and `loading` *before* firing the change event
+		// so the first picker re-render already observes the in-flight
+		// state.
 		const newSession = this._newSession?.sessionId === sessionId ? this._newSession : undefined;
 		if (newSession) {
+			// Defense-in-depth: pickers render disabled during a resolve,
+			// but keyboard dropdown and mobile sheet paths bypass that.
+			// Drop the second pick so it can't race the schema replacement.
+			if (newSession.isResolvingConfig.get()) {
+				return;
+			}
+			newSession.beginResolveConfigSync();
+			newSession.setLoading(true);
 			newSession.setConfigValue(property, value);
 			this._onDidChangeSessionConfig.fire(sessionId);
 			await this._refreshNewSessionConfig(newSession);

--- a/src/vs/sessions/contrib/providers/agentHost/browser/mobile/mobileAgentHostModePicker.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/mobile/mobileAgentHostModePicker.ts
@@ -35,6 +35,11 @@ export class MobileAgentHostModePicker extends AgentHostModePicker {
 		if (!this._triggerElement) {
 			return;
 		}
+		// Guard applies to both the phone sheet and the desktop popover —
+		// either path can dispatch through `setSessionConfigValue`.
+		if (this._isCurrentlyResolvingConfig()) {
+			return;
+		}
 		if (this._phonePresenter.enabled.get()) {
 			// The presenter's agent-host branch reads mode + model
 			// directly from the active session's provider, so we don't

--- a/src/vs/sessions/contrib/providers/agentHost/browser/mobile/mobileChatInputConfigPicker.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/mobile/mobileChatInputConfigPicker.ts
@@ -278,6 +278,12 @@ class MobileChatInputConfigPicker extends Disposable {
 			"Pick Mode and Model, {0}",
 			ariaParts.join(', '),
 		);
+
+		// Sheet's mode row writes through `setSessionConfigValue`, so
+		// disable the chip while a resolve is in flight.
+		const isResolving = ctx.provider.isSessionConfigResolving(ctx.session.sessionId).get();
+		this._slotElement.classList.toggle('disabled', isResolving);
+		this._triggerElement.setAttribute('aria-disabled', isResolving ? 'true' : 'false');
 	}
 
 	/**
@@ -307,13 +313,20 @@ class MobileChatInputConfigPicker extends Disposable {
 		if (!this._triggerElement) {
 			return;
 		}
+		// Sheet's mode row writes through `setSessionConfigValue`; the
+		// chip retains its tap target while visually disabled, so
+		// guard explicitly.
+		const ctx = this._getContext();
+		if (ctx && ctx.provider.isSessionConfigResolving(ctx.session.sessionId).get()) {
+			return;
+		}
 		// Delegate sheet construction to the shared phone presenter so
 		// the new-session chip and the opened-chat chip render the exact
 		// same Mode + Model rows. The presenter's agent-host branch
 		// reads the active session's config + filtered models and
 		// handles the writes (provider mode/model + shared storage key).
 		const trigger = this._triggerElement;
-		const beforeCtx = this._getContext();
+		const beforeCtx = ctx;
 		const beforeMode = beforeCtx?.currentMode;
 		const beforeModeItem = beforeCtx?.modeItems.find(i => i.value === beforeMode);
 		const beforeModelId = beforeCtx?.currentModelId;

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/agentHost/agentHostPermissionPickerDelegate.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/agentHost/agentHostPermissionPickerDelegate.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import { Emitter, Event } from '../../../../../../../base/common/event.js';
 import { DisposableStore } from '../../../../../../../base/common/lifecycle.js';
-import { observableValue } from '../../../../../../../base/common/observable.js';
+import { constObservable, observableValue } from '../../../../../../../base/common/observable.js';
 import { mock } from '../../../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
 import { TestInstantiationService } from '../../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
@@ -39,7 +39,7 @@ function makeWellKnownConfig(value: string | undefined): ResolveSessionConfigRes
 	} as ResolveSessionConfigResult;
 }
 
-class FakeProvider implements Pick<IAgentHostSessionsProvider, 'id' | 'onDidChangeSessionConfig' | 'getSessionConfig' | 'setSessionConfigValue'> {
+class FakeProvider implements Pick<IAgentHostSessionsProvider, 'id' | 'onDidChangeSessionConfig' | 'getSessionConfig' | 'setSessionConfigValue' | 'isSessionConfigResolving'> {
 	readonly id: string = PROVIDER_ID;
 	private readonly _onDidChange = new Emitter<string>();
 	readonly onDidChangeSessionConfig: Event<string> = this._onDidChange.event;
@@ -49,6 +49,9 @@ class FakeProvider implements Pick<IAgentHostSessionsProvider, 'id' | 'onDidChan
 
 	getSessionConfig(_sessionId: string): ResolveSessionConfigResult | undefined {
 		return this.config;
+	}
+	isSessionConfigResolving(_sessionId: string) {
+		return constObservable(false);
 	}
 	async setSessionConfigValue(sessionId: string, property: string, value: string): Promise<void> {
 		this.setCalls.push([sessionId, property, value]);

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/agentHostClaudePermissionModePicker.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/agentHostClaudePermissionModePicker.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { Event } from '../../../../../../base/common/event.js';
-import { observableValue } from '../../../../../../base/common/observable.js';
+import { constObservable, observableValue } from '../../../../../../base/common/observable.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { mock } from '../../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
@@ -44,13 +44,17 @@ function makeClaudePermissionModeConfig(): ResolveSessionConfigResult {
 	} as ResolveSessionConfigResult;
 }
 
-class FakeProvider implements Pick<IAgentHostSessionsProvider, 'id' | 'onDidChangeSessionConfig' | 'getSessionConfig' | 'setSessionConfigValue'> {
+class FakeProvider implements Pick<IAgentHostSessionsProvider, 'id' | 'onDidChangeSessionConfig' | 'getSessionConfig' | 'setSessionConfigValue' | 'isSessionConfigResolving'> {
 	readonly id = PROVIDER_ID;
 	readonly onDidChangeSessionConfig: Event<string> = Event.None;
 	readonly setCalls: Array<[string, string, unknown]> = [];
 
 	getSessionConfig(_sessionId: string): ResolveSessionConfigResult {
 		return makeClaudePermissionModeConfig();
+	}
+
+	isSessionConfigResolving(_sessionId: string) {
+		return constObservable(false);
 	}
 
 	async setSessionConfigValue(sessionId: string, property: string, value: unknown): Promise<void> {


### PR DESCRIPTION
When a user changes a session-config picker (isolation, branch, autoApprove, mode, claude permission mode) on an agent-host new session, all schema-driven pickers visually disappear and reappear while the async `resolveSessionConfig` round-trip runs.

## Root cause

`NewSession.setConfigValue` wiped the cached schema to `{ properties: {} }` during the optimistic update, so every well-known mode / autoApprove guard returned `false` and hid its picker until the new schema arrived ~200–500 ms later.

## Fix

- Preserve the existing schema in \`NewSession.setConfigValue\`.
- Introduce an observable \`isResolvingConfig\` on \`NewSession\`, owned by \`resolveConfig\`'s \`finally\`, with \`begin\`/\`endResolveConfigSync\` helpers for the synchronous-set-before-event path and the no-connection early-return path.
- Expose \`IObservable<boolean> isSessionConfigResolving(sessionId)\` on \`IAgentHostSessionsProvider\`; \`constObservable(false)\` for any session that isn't the in-flight new session.
- Distinct from \`session.loading\`: the latter also stays \`true\` while config is complete-but-required-values-missing, where pickers must remain interactive.

Every picker that mutates session config now disables on this observable: generic per-property chips, mode / claude permission mode enum pickers, the autoApprove permission action item, the mobile bottom-sheet mode picker, and the mobile combined Mode + Model new-session chip.

The autoApprove permission picker also gates the delegate's \`setPermissionLevel\` on the same observable, because \`ActionWidgetDropdown\` opens via Enter/Space directly on its label and CSS \`pointer-events: none\` does not block keyboard activation.

A defense-in-depth bail in \`setSessionConfigValue\` drops second-arrival changes on a new session while a resolve is already in flight.

## Review

Reviewed by a multi-model council (Claude Opus 4.6, GPT-5.5, GPT-5.3-Codex). Three real issues surfaced by GPT-5.5 — keyboard activation bypass on the permission picker, mobile mode picker bypassing the new guard, and the resolving flag leaking on the no-connection path — were all addressed in this change set.

## Follow-up

Pure-dispatch new-session-only methods on \`IAgentHostSessionsProvider\` (\`getCreateSessionConfig\`, \`clearSessionConfig\`, \`getSessionConfigCompletions\`, \`isSessionConfigResolving\`) will be moved onto a new \`IAgentHostNewSession\` interface exposed as an observable handle in a follow-up PR.