### PR TITLE
copilot: truncate long lines in read_file results

### DIFF
--- a/extensions/copilot/src/extension/tools/node/readFileTool.tsx
+++ b/extensions/copilot/src/extension/tools/node/readFileTool.tsx
@@ -74,6 +74,7 @@ export interface IReadFileParamsV2 {
 }
 
 const MAX_LINES_PER_READ = 2000;
+const MAX_LINE_LENGTH = 2000;
 
 export type ReadFileParams = IReadFileParamsV1 | IReadFileParamsV2;
 
@@ -425,7 +426,19 @@ class ReadFileResult extends PromptElement<ReadFileResultProps> {
 			this.props.startLine - 1, 0,
 			this.props.endLine - 1, Infinity,
 		);
-		let contents = documentSnapshot.getText(range);
+		const rawContents = documentSnapshot.getText(range);
+		let hadLongLines = false;
+		let contents = rawContents.split('\n').map(line => {
+			if (line.length > MAX_LINE_LENGTH) {
+				hadLongLines = true;
+				return line.slice(0, MAX_LINE_LENGTH) + ' [truncated]';
+			}
+			return line;
+		}).join('\n');
+
+		if (hadLongLines) {
+			contents += `\n[One or more long lines were truncated at ${MAX_LINE_LENGTH} characters]\n`;
+		}
 
 		if (this.props.truncated) {
 			contents += `\n[File content truncated at line ${this.props.endLine}. Use ${ToolName.ReadFile} with offset/limit parameters to view more.]\n`;

--- a/extensions/copilot/src/extension/tools/node/test/readFile.spec.tsx
+++ b/extensions/copilot/src/extension/tools/node/test/readFile.spec.tsx
@@ -38,13 +38,17 @@ suite('ReadFile', () => {
 		// Create a large document for testing truncation (3000 lines to exceed MAX_LINES_PER_READ)
 		const largeContent = Array.from({ length: 3000 }, (_, i) => `line ${i + 1}`).join('\n');
 		const largeDoc = createTextDocumentData(URI.file('/workspace/large.ts'), largeContent, 'ts').document;
+		// Create a document with long lines to test per-line truncation (each line is 2500 chars)
+		const longLine = 'x'.repeat(2500);
+		const longLinesContent = `normal line\n${longLine}\nanother normal line\n${longLine}`;
+		const longLinesDoc = createTextDocumentData(URI.file('/workspace/longlines.ts'), longLinesContent, 'ts').document;
 
 		const services = createExtensionUnitTestingServices();
 		services.define(IWorkspaceService, new SyncDescriptor(
 			TestWorkspaceService,
 			[
 				[URI.file('/workspace')],
-				[testDoc, emptyDoc, whitespaceDoc, singleLineDoc, largeDoc],
+				[testDoc, emptyDoc, whitespaceDoc, singleLineDoc, largeDoc, longLinesDoc],
 			]
 		));
 		accessor = services.createTestingAccessor();
@@ -183,6 +187,25 @@ suite('ReadFile', () => {
 			expect(resultString).toContain('line 2000');
 			expect(resultString).toContain('[File content truncated at line 2000. Use read_file with offset/limit parameters to view more.]');
 			expect(resultString).not.toContain('line 2001');
+		});
+
+		test('long lines are truncated and a notice is appended', async () => {
+			const toolsService = accessor.get(IToolsService);
+
+			const input: IReadFileParamsV2 = {
+				filePath: '/workspace/longlines.ts'
+			};
+			const result = await toolsService.invokeTool(ToolName.ReadFile, { input, toolInvocationToken: null as never }, CancellationToken.None);
+			const resultString = await toolResultToString(accessor, result);
+			expect(resultString).toContain('normal line');
+			expect(resultString).toContain('[truncated]');
+			expect(resultString).toContain('[One or more long lines were truncated at 2000 characters]');
+			// The truncated line should be at most 2000 chars + ' [truncated]' = ~2012 chars, not the full 2500
+			const lines = resultString.split('\n');
+			const longLines = lines.filter(l => l.includes('x'.repeat(100)));
+			for (const l of longLines) {
+				expect(l.length).toBeLessThan(2500);
+			}
 		});
 
 		test('read file with offset beyond file line count should throw error', async () => {


### PR DESCRIPTION
### What

When `read_file` is invoked on a file containing very long lines (e.g. a previous tool result that was spilled to disk, a minified bundle, or a huge JSON blob), the prompt-tsx renderer would prune the content out of the model's context to fit the token budget. The agent then saw an empty `read_file` result and retried — typically against the same file — adding a fresh copy of the (still huge) tool result into the session log on every retry. We've seen sessions balloon to **450 MB+** from this loop (146× repeated 1.7 MB blobs on one request).

### Fix

Truncate any line in the read_file output to 2000 characters at the source (a common approximate value among harness implementations; the same as Gemini CLI) appending ` [truncated]` to the line. If any line was truncated, append a trailing notice:

> `[One or more long lines were truncated at 2000 characters]`

so the model can distinguish "data was elided" from "the file is empty" and stop retrying.

### Notes

- Truncation happens in `ReadFileResult.render()`, before content reaches the `CodeBlock` element, so both the prompt-tsx render path and the persisted session-log path see the truncated text.
- Added a unit test (`long lines are truncated and a notice is appended`) and a corresponding fixture; full readFile spec passes (34/34).