### PR TITLE
build/darwin: skip @microsoft/mxc-sdk bin/ in Mach-O arch check

### DIFF
--- a/build/darwin/verify-macho.ts
+++ b/build/darwin/verify-macho.ts
@@ -40,6 +40,10 @@ const FILES_TO_SKIP = [
 	// ripgrep-universal: single-arch binaries in per-platform directories
 	'**/node_modules/@vscode/ripgrep-universal/bin/darwin-*/**',
 	'**/node_modules.asar.unpacked/@vscode/ripgrep-universal/bin/darwin-*/**',
+	// MXC SDK ships per-arch native binaries under bin/<arch>; the package
+	// includes both arm64 and x64 trees regardless of host arch.
+	'**/node_modules/@microsoft/mxc-sdk/bin/**',
+	'**/node_modules.asar.unpacked/@microsoft/mxc-sdk/bin/**',
 ];
 
 function isFileSkipped(file: string): boolean {


### PR DESCRIPTION
Fixes failing macOS x64 build introduced by #317669.

The `@microsoft/mxc-sdk` npm package ships per-arch native binaries under `bin/arm64` and `bin/x64` regardless of host arch. The macOS x64 build failed `Verify arch of Mach-O objects` on:

```
node_modules/@microsoft/mxc-sdk/bin/arm64/mxc-exec-mac
```

This blocked the unsigned x64 artifact, which then caused the universal stage to time out waiting for it (seen in insider build 441345).

Skip the whole `bin/` tree in `build/darwin/verify-macho.ts`, matching existing patterns for other multi-arch vendor payloads (`@github/copilot-darwin-*`, `@vscode/ripgrep-universal`).

Verified by:
- Listing tarball contents of `@microsoft/mxc-sdk@0.2.0` (both `bin/arm64` and `bin/x64`).
- Matching log output from insider build 441345 attempt 1.
