### PR TITLE
cli: do not block control server startup on agent host supervisor

### DIFF
--- a/cli/src/commands/tunnels.rs
+++ b/cli/src/commands/tunnels.rs
@@ -4,12 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 use base64::{engine::general_purpose as b64, Engine as _};
-use futures::{stream::FuturesUnordered, StreamExt};
+use futures::{stream::FuturesUnordered, FutureExt, StreamExt};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 use std::{
 	net::{IpAddr, Ipv4Addr, SocketAddr},
 	str::FromStr,
+	sync::Arc,
 	time::Duration,
 };
 use sysinfo::Pid;
@@ -49,6 +50,7 @@ use crate::{
 			make_singleton_server, start_singleton_server, BroadcastLogSink, SingletonServerArgs,
 		},
 		AuthRequired, Next, ServeStreamParams, ServiceContainer, ServiceManager,
+		SharedActiveAgentHost,
 	},
 	util::{
 		app_lock::AppMutex,
@@ -148,24 +150,27 @@ pub async fn command_shell(ctx: CommandContext, args: CommandShellArgs) -> Resul
 		shutdown_reqs.push(ShutdownRequest::ParentProcessKilled(p));
 	}
 
-	// Ensure a per-machine agent host supervisor is running on the remote
-	// (the SSH/`command-shell` entry point) so the renderer that connects
-	// to the spawned VS Code server can reach the agent host via the
-	// `agentHostProxy` IPC channel. Best-effort: if the supervisor can't
-	// be started we still serve the stream so editing / extension host
-	// keep working — the renderer will just see "Unknown channel:
-	// agentHostProxy".
-	let agent_host_bridge = match ensure_supervisor_running(&ctx.paths, &ctx.log).await {
-		Ok(a) => Some(a),
-		Err(e) => {
-			warning!(
-				ctx.log,
-				"Could not start agent host supervisor; the renderer will not be able to reach it: {}",
-				e
-			);
-			None
+	// Kick off the agent host supervisor in the background. The supervisor
+	// is what lets the renderer reach the agent host via the
+	// `agentHostProxy` IPC channel on the spawned VS Code server. We do
+	// NOT await it here — `command-shell` needs to start listening
+	// immediately. `handle_serve` awaits the shared future on demand and
+	// mixes the bridge endpoint into the per-request `code_server_args`.
+	// On failure the renderer just won't see `agentHostProxy`; editing
+	// and the extension host still work.
+	let active_agent_host: SharedActiveAgentHost = {
+		let paths = ctx.paths.clone();
+		let log = ctx.log.clone();
+		async move {
+			ensure_supervisor_running(&paths, &log)
+				.await
+				.map(Arc::new)
+				.map_err(Arc::new)
 		}
+		.boxed()
+		.shared()
 	};
+	tokio::spawn(active_agent_host.clone());
 
 	let mut params = ServeStreamParams {
 		log: ctx.log,
@@ -177,13 +182,10 @@ pub async fn command_shell(ctx: CommandContext, args: CommandShellArgs) -> Resul
 			.unwrap_or(AuthRequired::VSDA),
 		exit_barrier: ShutdownRequest::create_rx(shutdown_reqs),
 		code_server_args: (&ctx.args).into(),
+		active_agent_host: Some(active_agent_host),
 	};
 
 	args.server_args.apply_to(&mut params.code_server_args);
-
-	if let Some(a) = &agent_host_bridge {
-		a.apply_to_bridge(&mut params.code_server_args);
-	}
 
 	let mut listener: Box<dyn AsyncRWAccepter> =
 		match (args.on_port.first(), &args.on_host, args.on_socket) {

--- a/cli/src/tunnels.rs
+++ b/cli/src/tunnels.rs
@@ -37,7 +37,9 @@ mod service_windows;
 mod socket_signal;
 mod wsl_detect;
 
-pub use control_server::{serve, serve_stream, AuthRequired, Next, ServeStreamParams};
+pub use control_server::{
+	serve, serve_stream, AuthRequired, Next, ServeStreamParams, SharedActiveAgentHost,
+};
 pub use nosleep::SleepInhibitor;
 pub use service::{
 	create_service_manager, ServiceContainer, ServiceManager, SERVICE_LOG_FILE_NAME,

--- a/cli/src/tunnels/control_server.rs
+++ b/cli/src/tunnels/control_server.rs
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 use crate::async_pipe::get_socket_rw_stream;
-use crate::commands::agent_host::ensure_supervisor_running;
+use crate::commands::agent_host::{ensure_supervisor_running, ActiveAgentHost};
 use crate::constants::{AGENT_HOST_PORT, CONTROL_PORT, PRODUCT_NAME_LONG};
 use crate::log;
 use crate::msgpack_rpc::{new_msgpack_rpc, start_msgpack_rpc, MsgPackCodec, MsgPackSerializer};
@@ -27,6 +27,7 @@ use crate::util::machine::kill_pid;
 use crate::util::os::os_release;
 use crate::util::sync::{new_barrier, Barrier, BarrierOpener};
 
+use futures::future::{BoxFuture, Shared};
 use futures::stream::FuturesUnordered;
 use futures::FutureExt;
 use std::collections::HashMap;
@@ -70,6 +71,14 @@ use super::socket_signal::{
 type HttpRequestsMap = Arc<std::sync::Mutex<HashMap<u32, DelegatedHttpRequest>>>;
 type CodeServerCell = Arc<Mutex<Option<SocketCodeServer>>>;
 
+/// Shared, cloneable future that resolves once the agent host supervisor
+/// is up. We kick it off from `serve()` so the tunnel can start accepting
+/// connections immediately and only block on the supervisor in places
+/// that actually need it (currently `handle_serve` and the agent-host
+/// port forwarder).
+pub type SharedActiveAgentHost =
+	Shared<BoxFuture<'static, Result<Arc<ActiveAgentHost>, Arc<AnyError>>>>;
+
 struct HandlerContext {
 	/// Log handle for the server
 	log: log::Logger,
@@ -95,6 +104,11 @@ struct HandlerContext {
 	http: Arc<FallbackSimpleHttp>,
 	/// requests being served by the client
 	http_requests: HttpRequestsMap,
+	/// Shared handle to the background `ensure_supervisor_running` task,
+	/// awaited in `handle_serve` to mix the bridge info into the spawned
+	/// server's args. `None` for callers (e.g. `command-shell`) that
+	/// already applied the bridge eagerly.
+	active_agent_host: Option<SharedActiveAgentHost>,
 }
 
 /// Handler auth state.
@@ -186,27 +200,31 @@ pub async fn serve(
 	let (tx, mut rx) = mpsc::channel::<ServerSignal>(4);
 	let (exit_barrier, signal_exit) = new_barrier();
 
-	// Make sure an agent host supervisor is running on this machine before
-	// we start advertising the `agent-host` port over the tunnel. The
-	// supervisor is the only process that binds the user-facing TCP
-	// listener and owns the canonical lockfile; we never spawn an
-	// in-process sidecar here. If one is already live we reuse it; if
-	// not, we daemonize a fresh supervisor and consume the resulting
-	// lockfile.
-	let active_agent_host = ensure_supervisor_running(launcher_paths, log).await?;
-
-	// Thread the active agent-host endpoint into the args used when spawning
-	// VS Code servers for renderer clients. The server uses these to register
-	// its `agentHostProxy` IPC channel so the renderer can reach the agent
-	// host over the existing renderer↔server connection. Note: this does NOT
-	// ask the spawned server to start its own agent host (that path uses
-	// `--agent-host-port` / `--agent-host-path` instead), it only points the
-	// bridge at the active agent host.
-	let code_server_args = {
-		let mut csa = code_server_args.clone();
-		active_agent_host.apply_to_bridge(&mut csa);
-		csa
+	// Kick off the agent host supervisor in the background. The supervisor
+	// is the only process that binds the user-facing TCP listener and owns
+	// the canonical lockfile; we never spawn an in-process sidecar here.
+	// We deliberately do NOT await this here — the tunnel needs to start
+	// accepting connections immediately. Consumers that need the
+	// supervisor's endpoint (currently `handle_serve` for the
+	// `agentHostProxy` bridge, and the `agent-host` port forwarder below)
+	// await this shared future when they actually need it. Driving a
+	// clone with `tokio::spawn` ensures the work makes progress even if no
+	// one is currently awaiting it.
+	let active_agent_host: SharedActiveAgentHost = {
+		let launcher_paths = launcher_paths.clone();
+		let log = log.clone();
+		async move {
+			ensure_supervisor_running(&launcher_paths, &log)
+				.await
+				.map(Arc::new)
+				.map_err(Arc::new)
+		}
+		.boxed()
+		.shared()
 	};
+	tokio::spawn(active_agent_host.clone());
+
+	let code_server_args = code_server_args.clone();
 
 	if !code_server_args.install_extensions.is_empty() {
 		info!(
@@ -254,17 +272,26 @@ pub async fn serve(
 				forwarding.process(w, &mut tunnel).await;
 			},
 			Some(socket) = agent_host_port.recv() => {
-				let host = active_agent_host.dial_host().to_string();
-				let port = active_agent_host.port;
-				let token = active_agent_host.token.clone();
 				let log = log.clone();
+				let active_agent_host = active_agent_host.clone();
 				tokio::spawn(async move {
+					let active = match active_agent_host.await {
+						Ok(a) => a,
+						Err(e) => {
+							warning!(
+								log,
+								"Cannot forward agent-host tunnel connection; supervisor unavailable: {}",
+								e
+							);
+							return;
+						}
+					};
 					forward_tunnel_connection_to_existing_ah(
 						log,
 						socket.into_rw(),
-						host,
-						port,
-						token,
+						active.dial_host().to_string(),
+						active.port,
+						active.token.clone(),
 					)
 					.await;
 				});
@@ -287,6 +314,7 @@ pub async fn serve(
 				let own_exit = exit_barrier.clone();
 				let own_code_server_args = code_server_args.clone();
 				let own_forwarding = forwarding.handle();
+				let own_active_agent_host = active_agent_host.clone();
 
 				tokio::spawn(async move {
 					debug!(own_log, "Serving new connection");
@@ -299,6 +327,7 @@ pub async fn serve(
 						platform,
 						exit_barrier: own_exit,
 						requires_auth: AuthRequired::None,
+						active_agent_host: Some(own_active_agent_host),
 					}).await;
 				});
 			}
@@ -321,6 +350,7 @@ pub struct ServeStreamParams {
 	pub platform: Platform,
 	pub requires_auth: AuthRequired,
 	pub exit_barrier: Barrier<ShutdownSignal>,
+	pub active_agent_host: Option<SharedActiveAgentHost>,
 }
 
 pub async fn serve_stream(
@@ -352,6 +382,7 @@ fn make_socket_rpc(
 	requires_auth: AuthRequired,
 	platform: Platform,
 	http_requests: HttpRequestsMap,
+	active_agent_host: Option<SharedActiveAgentHost>,
 ) -> RpcDispatcher<MsgPackSerializer, HandlerContext> {
 	let server_bridges = ServerMultiplexer::new();
 	let mut rpc = RpcBuilder::new(MsgPackSerializer {}).methods(HandlerContext {
@@ -374,6 +405,7 @@ fn make_socket_rpc(
 			http_delegated,
 		)),
 		http_requests,
+		active_agent_host,
 	});
 
 	rpc.register_sync("ping", |_: EmptyObject, _| Ok(EmptyObject {}));
@@ -553,6 +585,7 @@ async fn process_socket(
 		code_server_args,
 		platform,
 		requires_auth,
+		active_agent_host,
 	} = params;
 
 	let (http_delegated, mut http_rx) = DelegatedSimpleHttp::new(log.clone());
@@ -571,6 +604,7 @@ async fn process_socket(
 		requires_auth,
 		platform,
 		http_requests.clone(),
+		active_agent_host,
 	);
 
 	{
@@ -754,6 +788,21 @@ async fn handle_serve(
 	let mut csa = c.code_server_args.clone();
 	csa.connection_token = params.connection_token.or(csa.connection_token);
 	csa.install_extensions.extend(params.extensions);
+
+	// Mix in the agent-host bridge info now that we actually need to spawn
+	// the VS Code server. The supervisor was started in the background by
+	// `serve()`, so this only blocks if it hasn't finished yet. If it
+	// failed we still serve — the renderer just won't see `agentHostProxy`.
+	if let Some(ah_fut) = c.active_agent_host.clone() {
+		match ah_fut.await {
+			Ok(a) => a.apply_to_bridge(&mut csa),
+			Err(e) => warning!(
+				c.log,
+				"Agent host supervisor unavailable; renderer will not see agentHostProxy: {}",
+				e
+			),
+		}
+	}
 
 	let params_raw = ServerParamsRaw {
 		commit_id: params.commit_id,


### PR DESCRIPTION
- ensure_supervisor_running now runs as a background task driven by
  tokio::spawn, so the tunnel control server and command-shell can
  start accepting connections immediately instead of waiting for the
  supervisor to come up.
- handle_serve (and the agent-host port forwarder) await the shared
  future on demand and mix the bridge endpoint into the per-request
  code_server_args. Supervisor failure is logged as a warning so editing
  and the extension host keep working; the renderer just misses
  agentHostProxy.
- This eliminates the startup stall that was sporadically tripping
  remote SSH's 450ms command-shell ready timeout.

Fixes #317714

(Commit message generated by Copilot)