### PR TITLE
sessions: clean up ISessionsProvider chat API

### DIFF
--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -81,14 +81,14 @@ A **session** groups one or more **chats** (conversations) that share the same w
 
 ```
 ISession
-├── mainChat: IChat              ← primary (first) chat
-├── chats: IObservable<IChat[]>  ← all chats in creation order
+├── mainChat: IObservable<IChat>   ← primary (first) chat (settable by provider when committing a new session)
+├── chats: IObservable<IChat[]>    ← all chats in creation order
 ├── capabilities.supportsMultipleChats
-└── session-level observables    ← derived from chats
+└── session-level observables      ← derived from chats
 ```
 
 Session-level properties are derived from chats:
-- Most properties (`title`, `changes`, `changesets`, `modelId`, etc.) come from `mainChat`
+- Most properties (`title`, `changes`, `changesets`, `modelId`, etc.) come from the main chat
 - `updatedAt` and `lastTurnEnd` are the latest across all chats
 - `status` is aggregated (`NeedsInput` > `InProgress` > other)
 - `isRead` is `true` only when all chats are read
@@ -135,8 +135,11 @@ Sessions produce file changes organized into **`ISessionChangeset`** groups — 
      is also offered by another provider
 
 3. User types a message and sends
-   → SessionsManagementService.sendAndCreateChat(session, {query, attachedContext})
-   → Delegates to provider.sendAndCreateChat(sessionId, options)
+   → SessionsManagementService.sendNewChatRequest(session, {query, attachedContext})
+   → Calls provider.createNewChat(sessionId)
+   → Provider creates the backend chat model and returns an IChat
+   → Management service opens the chat widget with that chat's resource
+   → Delegates to provider.sendRequest(sessionId, chatResource, options)
    → Provider sends request, returns committed session
    → isNewChatSession context → false
 ```
@@ -180,3 +183,22 @@ Providers may fire `onDidReplaceSession` when a temporary (untitled) session is 
 5. Use `toSessionId(providerId, resource)` for session IDs
 6. Fire `onDidChangeSessions` on every session change and `onDidReplaceSession` on untitled→committed transitions
 7. Set `supportsLocalWorkspaces: true` if the provider can resolve local file-system workspaces
+
+---
+
+## Interface Design Guidelines
+
+### `ISessionsProvider` must have no optional methods
+
+Every method on `ISessionsProvider` is part of the mandatory contract. Do **not** declare any method as optional (i.e., using `?`). Every provider must implement the full interface. If a method is not meaningful for a particular provider, implement it as a no-op or return a safe default.
+
+**Rationale:** Optional methods weaken the contract and force call sites to add guard code (`if (provider.method)`). Mandatory methods keep the management service clean and ensure the interface documents the complete capability set of every provider.
+
+### Any addition to `ISession` or `ISessionsProvider` must be consumed in the agents window core workbench
+
+The **agents window core workbench** is defined as all sessions code *outside* `src/vs/sessions/contrib/providers/` — that is, code in `src/vs/sessions/services/`, `src/vs/sessions/browser/`, `src/vs/sessions/common/`, and non-provider `src/vs/sessions/contrib/*` folders (views, UI contributions, toolbars, etc.).
+
+When you add a property or method to `ISession` or `ISessionsProvider`, it **must** be referenced by at least one file in the core workbench, not only within provider implementations.
+
+**Rationale:** If an interface member is only used inside providers, it belongs on the provider's concrete class, not on the shared interface. Interfaces should capture what the orchestration layer (management service, UI) needs from providers — not internal implementation details that leak outward.
+

--- a/src/vs/sessions/browser/parts/chatCompositeBar.ts
+++ b/src/vs/sessions/browser/parts/chatCompositeBar.ts
@@ -75,7 +75,7 @@ export class ChatCompositeBar extends Disposable {
 
 			const chats = activeSession.chats.read(reader);
 			const activeChatUri = activeSession.activeChat.read(reader)?.resource.toString() ?? '';
-			const mainChatUri = activeSession.mainChat.resource.toString();
+			const mainChatUri = activeSession.mainChat.read(reader).resource.toString();
 			this._rebuildTabs(chats, activeChatUri, mainChatUri);
 		}));
 

--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -345,7 +345,7 @@ class NewChatWidget extends Disposable {
 			return;
 		}
 		try {
-			await this.sessionsManagementService.sendAndCreateChat(session, { query, attachedContext });
+			await this.sessionsManagementService.sendNewChatRequest(session, { query, attachedContext });
 		} catch (e) {
 			this.logService.error('Failed to send request:', e);
 		}

--- a/src/vs/sessions/contrib/chat/browser/runScriptAction.ts
+++ b/src/vs/sessions/contrib/chat/browser/runScriptAction.ts
@@ -302,12 +302,12 @@ export class RunScriptContribution extends Disposable implements IWorkbenchContr
 	private async _generateNewTask(session: ISession): Promise<void> {
 		const query = '/generate-run-commands';
 		// Prefer sending to the already-open chat widget for the session;
-		// fall back to sendAndCreateChat for untitled sessions or when no widget is loaded.
-		const widget = this._chatWidgetService.getWidgetBySessionResource(session.mainChat.resource);
+		// fall back to sendRequest for untitled sessions or when no widget is loaded.
+		const widget = this._chatWidgetService.getWidgetBySessionResource(session.mainChat.get().resource);
 		if (widget) {
 			await widget.acceptInput(query);
 		} else {
-			await this._sessionManagementService.sendAndCreateChat(session, { query });
+			await this._sessionManagementService.sendNewChatRequest(session, { query });
 		}
 	}
 

--- a/src/vs/sessions/contrib/chat/test/browser/sessionWorkspacePicker.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionWorkspacePicker.test.ts
@@ -26,7 +26,7 @@ import { IOutputService } from '../../../../../workbench/services/output/common/
 import { IUriIdentityService } from '../../../../../platform/uriIdentity/common/uriIdentity.js';
 import { extUri } from '../../../../../base/common/resources.js';
 import { ISessionsProvidersChangeEvent, ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
-import { ISessionsProvider } from '../../../../services/sessions/common/sessionsProvider.js';
+import { ISendRequestOptions, ISessionsProvider } from '../../../../services/sessions/common/sessionsProvider.js';
 import { IAgentHostSessionsProvider } from '../../../../common/agentHostSessionsProvider.js';
 import { ISessionWorkspace, ISessionWorkspaceBrowseAction, SESSION_WORKSPACE_GROUP_LOCAL, SESSION_WORKSPACE_GROUP_REMOTE } from '../../../../services/sessions/common/session.js';
 import { WorkspacePicker } from '../../browser/sessionWorkspacePicker.js';
@@ -98,9 +98,8 @@ function createMockProvider(id: string, opts?: {
 		unarchiveSession: async () => { },
 		deleteSession: async () => { },
 		deleteChat: async () => { },
-		sendAndCreateChat: async () => { throw new Error('Not implemented'); },
-		addChat: () => { throw new Error('Not implemented'); },
-		sendRequest: async () => { throw new Error('Not implemented'); },
+		createNewChat: async () => { throw new Error('Not implemented'); },
+		sendRequest: async (_sessionId: string, _chatResource: URI, _options: ISendRequestOptions) => { throw new Error('Not implemented'); },
 	};
 	if (opts?.connectionStatus) {
 		return {

--- a/src/vs/sessions/contrib/chat/test/browser/sessionsTaskService.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionsTaskService.test.ts
@@ -71,7 +71,7 @@ function makeSession(opts: { repository?: URI; worktree?: URI } = {}): ISession 
 		lastTurnEnd: chat.lastTurnEnd,
 		description: chat.description,
 		chats: observableValue('chats', [chat]),
-		mainChat: chat,
+		mainChat: constObservable(chat),
 		capabilities: { supportsMultipleChats: false },
 	} satisfies ISession;
 	return session;

--- a/src/vs/sessions/contrib/chat/test/browser/workbenchSessionTaskRunner.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/workbenchSessionTaskRunner.test.ts
@@ -55,7 +55,7 @@ function makeSession(opts: { repository?: URI; worktree?: URI } = {}): ISession 
 		lastTurnEnd: observableValue('lastTurnEnd', undefined),
 		description: observableValue('description', undefined),
 		chats: observableValue('chats', [chat]),
-		mainChat: chat,
+		mainChat: constObservable(chat),
 		capabilities: { supportsMultipleChats: false },
 	};
 }

--- a/src/vs/sessions/contrib/chat/test/browser/worktreeCreatedTaskDispatcher.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/worktreeCreatedTaskDispatcher.test.ts
@@ -69,7 +69,7 @@ function makeSession(opts: { id?: string; runsWorktreeCreatedTasks?: boolean; lo
 		lastTurnEnd: observableValue('lastTurnEnd', undefined),
 		description: observableValue('description', undefined),
 		chats: observableValue('chats', [chat]),
-		mainChat: chat,
+		mainChat: constObservable(chat),
 		capabilities: { supportsMultipleChats: false, runsWorktreeCreatedTasks: opts.runsWorktreeCreatedTasks },
 	};
 	return { session, loading, status, workspace };

--- a/src/vs/sessions/contrib/github/test/browser/githubContribution.test.ts
+++ b/src/vs/sessions/contrib/github/test/browser/githubContribution.test.ts
@@ -8,7 +8,7 @@ import { Codicon } from '../../../../../base/common/codicons.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { IMarkdownString } from '../../../../../base/common/htmlContent.js';
 import { DisposableStore, IDisposable, ImmortalReference, IReference, toDisposable } from '../../../../../base/common/lifecycle.js';
-import { IObservable, observableValue } from '../../../../../base/common/observable.js';
+import { constObservable, IObservable, observableValue } from '../../../../../base/common/observable.js';
 import { GitHubPullRequestModel } from '../../browser/models/githubPullRequestModel.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
@@ -167,7 +167,7 @@ class TestSession implements ISession {
 	readonly description: ReturnType<typeof observableValue<IMarkdownString | undefined>>;
 	readonly lastTurnEnd: ReturnType<typeof observableValue<Date | undefined>>;
 	readonly chats: ReturnType<typeof observableValue<readonly IChat[]>>;
-	readonly mainChat: IChat;
+	readonly mainChat: IObservable<IChat>;
 	readonly capabilities: ISessionCapabilities = { supportsMultipleChats: false };
 
 	constructor(id: string, gitHubInfo: IGitHubInfo | undefined, archived: boolean) {
@@ -204,7 +204,7 @@ class TestSession implements ISession {
 
 		const checkpoints = observableValue<IChatCheckpoints | undefined>(`test.checkpoints.${id}`, undefined);
 
-		this.mainChat = {
+		const mainChat: IChat = {
 			resource: this.resource,
 			createdAt: this.createdAt,
 			title: this.title,
@@ -219,7 +219,8 @@ class TestSession implements ISession {
 			description: this.description,
 			lastTurnEnd: this.lastTurnEnd,
 		};
-		this.chats = observableValue<readonly IChat[]>(`test.chats.${id}`, [this.mainChat]);
+		this.mainChat = constObservable(mainChat);
+		this.chats = observableValue<readonly IChat[]>(`test.chats.${id}`, [mainChat]);
 	}
 }
 

--- a/src/vs/sessions/contrib/layout/test/browser/sessionLayoutController.test.ts
+++ b/src/vs/sessions/contrib/layout/test/browser/sessionLayoutController.test.ts
@@ -91,7 +91,7 @@ function makeSession(resource: URI, opts?: {
 		description: chat.description,
 		chats: observableValue('chats', [chat]),
 		activeChat: observableValue('activeChat', chat),
-		mainChat: chat,
+		mainChat: constObservable(chat),
 		capabilities: { supportsMultipleChats: false },
 	};
 }

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -27,7 +27,7 @@ import type { IAgentSubscription } from '../../../../../platform/agentHost/commo
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
-import { ChatViewPaneTarget, IChatWidgetService } from '../../../../../workbench/contrib/chat/browser/chat.js';
+import { IChatWidgetService } from '../../../../../workbench/contrib/chat/browser/chat.js';
 import { IChatSendRequestOptions, IChatService } from '../../../../../workbench/contrib/chat/common/chatService/chatService.js';
 import { IChatSessionFileChange, IChatSessionFileChange2, IChatSessionsService } from '../../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { ChatAgentLocation, ChatConfiguration, ChatModeKind } from '../../../../../workbench/contrib/chat/common/constants.js';
@@ -119,7 +119,7 @@ export class AgentHostSessionAdapter implements ISession {
 	readonly lastTurnEnd: ISettableObservable<Date | undefined>;
 	readonly gitHubInfo: IObservable<IGitHubInfo | undefined>;
 
-	readonly mainChat: IChat;
+	readonly mainChat: IObservable<IChat>;
 	readonly chats: IObservable<readonly IChat[]>;
 	readonly capabilities = { supportsMultipleChats: false };
 
@@ -252,7 +252,7 @@ export class AgentHostSessionAdapter implements ISession {
 
 		const checkpoints = observableValue(this, undefined);
 
-		this.mainChat = {
+		const mainChat: IChat = {
 			resource: this.resource,
 			createdAt: this.createdAt,
 			title: this.title,
@@ -267,7 +267,8 @@ export class AgentHostSessionAdapter implements ISession {
 			description: this.description,
 			lastTurnEnd: this.lastTurnEnd,
 		};
-		this.chats = constObservable([this.mainChat]);
+		this.mainChat = observableValue<IChat>(this, mainChat);
+		this.chats = this.mainChat.map(c => [c]);
 		this.changesets = createChangesets(this.sessionType, this.workspace, this.chats, _options.instantiationService);
 	}
 
@@ -493,7 +494,7 @@ interface INewSessionConstructionContext {
  *
  * Encapsulates:
  *  - the `ISession` skeleton + its observables (status, modelId, loading)
- *  - the user's selected model (read by `sendAndCreateChat`)
+ *  - the user's selected model (read by `sendRequest`)
  *  - the resolved session config + a stale-request guard
  *  - the eagerly created backend session (URI + subscription) that lets the
  *    chat handler skip its legacy `createSession`-on-first-message round-trip
@@ -503,7 +504,7 @@ interface INewSessionConstructionContext {
  *    subscription. Wire ordering matters — see the comment in the body.
  *  - {@link graduate} releases the subscription without firing
  *    `disposeSession`; called when the session successfully transitions into
- *    a real running session via `sendAndCreateChat`.
+ *    a real running session via `sendRequest`.
  *  - {@link Disposable.dispose}/`dispose` releases the subscription **and**
  *    fires `connection.disposeSession`; called when the user abandons the
  *    new session (workspace switch, send failure, etc.).
@@ -519,6 +520,7 @@ class NewSession extends Disposable {
 	private readonly _modelId: ISettableObservable<string | undefined>;
 	private readonly _mode: ISettableObservable<{ readonly id: string; readonly kind: string } | undefined>;
 	private readonly _loading: ISettableObservable<boolean>;
+	private readonly _mainChat: ISettableObservable<IChat>;
 	private _selectedModelId: string | undefined;
 	private _selectedAgent: ISessionAgentRef | undefined;
 
@@ -593,9 +595,10 @@ class NewSession extends Disposable {
 			modelId: this._modelId,
 			mode, isArchived, isRead, description, lastTurnEnd,
 		};
+		this._mainChat = observableValue<IChat>(this, mainChat);
 		const authPending = ctx.authenticationPending;
 		const loading = this._loading;
-		const chats = constObservable<readonly IChat[]>([mainChat]);
+		const chats = this._mainChat.map(c => [c]);
 		const changesets = createChangesets(ctx.sessionType.id, workspaceObs, chats, ctx.instantiationService);
 		this.session = {
 			sessionId: `${ctx.providerId}:${resource.toString()}`,
@@ -617,7 +620,7 @@ class NewSession extends Disposable {
 			isRead,
 			description,
 			lastTurnEnd,
-			mainChat,
+			mainChat: this._mainChat,
 			chats,
 			capabilities: { supportsMultipleChats: false },
 		};
@@ -790,7 +793,7 @@ class NewSession extends Disposable {
 
 	/**
 	 * Release the backend subscription without firing `disposeSession`.
-	 * Used on the success path in `sendAndCreateChat` when the session has
+	 * Used on the success path in `sendRequest` when the session has
 	 * graduated into a real running session.
 	 */
 	graduate(): void {
@@ -850,7 +853,7 @@ class NewSession extends Disposable {
  * the session cache, the new-session/running-session config picker state,
  * the lazy session-state subscriptions, the AHP notification/action
  * handlers, and every connection-routed method (set/get/archive/delete/
- * rename/setModel/sendAndCreateChat).
+ * rename/setModel/sendRequest).
  *
  * Subclasses supply the genuine variation points: the connection
  * accessor, the authentication-pending observable, an adapter factory,
@@ -1465,7 +1468,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 		if (this._newSession?.sessionId === sessionId) {
 			this._newSession.setSelectedAgent(agent);
 			// The selection is forwarded to the host at first-message time
-			// via `sendOptions.agentHostSessionAgent` (see `sendAndCreateChat`),
+			// via `sendOptions.agentHostSessionAgent` (see `sendRequest`),
 			// mirroring how `userSelectedModelId` flows.
 			return;
 		}
@@ -1548,15 +1551,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 		// Agent host sessions don't support deleting individual chats
 	}
 
-	addChat(_sessionId: string): IChat {
-		throw new Error('Multiple chats per session is not supported for agent host sessions');
-	}
-
-	async sendRequest(_sessionId: string, _chatResource: URI, _options: ISendRequestOptions): Promise<ISession> {
-		throw new Error('Multiple chats per session is not supported for agent host sessions');
-	}
-
-	async sendAndCreateChat(chatId: string, options: ISendRequestOptions): Promise<ISession> {
+	async createNewChat(chatId: string): Promise<IChat> {
 		const connection = this.connection;
 		if (!connection) {
 			throw new Error(this._notConnectedSendErrorMessage());
@@ -1566,13 +1561,29 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 		if (!newSession || newSession.sessionId !== chatId) {
 			throw new Error(`Session '${chatId}' not found or not a new session`);
 		}
-		const sessionResource = newSession.session.resource;
+
+		// Create the chat session model so the management service can open the widget
+		await this._chatSessionsService.getOrCreateChatSession(newSession.session.resource, CancellationToken.None);
+		return newSession.session.mainChat.get();
+	}
+
+	async sendRequest(chatId: string, chatResource: URI, options: ISendRequestOptions): Promise<ISession> {
+		const newSession = this._newSession;
+		if (!newSession || newSession.sessionId !== chatId) {
+			throw new Error(`Session '${chatId}' not found or not a new session`);
+		}
+
+		const connection = this.connection;
+		if (!connection) {
+			throw new Error(this._notConnectedSendErrorMessage());
+		}
+
 		const selectedModelId = newSession.getSelectedModelId();
 		const selectedAgent = newSession.getSelectedAgent();
 
 		const { query, attachedContext } = options;
 
-		const sessionType = sessionResource.scheme;
+		const sessionType = chatResource.scheme;
 		const contribution = this._chatSessionsService.getChatSessionContribution(sessionType);
 
 		const sendOptions: IChatSendRequestOptions = {
@@ -1603,16 +1614,10 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			agentHostSessionConfig: this.getCreateSessionConfig(chatId),
 		};
 
-		// Open chat widget — getOrCreateChatSession will wait for the session
-		// handler to become available via canResolveChatSession internally.
-		await this._chatSessionsService.getOrCreateChatSession(sessionResource, CancellationToken.None);
-		const chatWidget = await this._chatWidgetService.openSession(sessionResource, ChatViewPaneTarget);
-		if (!chatWidget) {
-			throw new Error(`[${this.id}] Failed to open chat widget`);
-		}
-
-		// Load session model and apply selected model
-		const modelRef = await this._chatService.acquireOrLoadSession(sessionResource, ChatAgentLocation.Chat, CancellationToken.None);
+		// Chat session model was already created by createNewChat and
+		// the widget was opened by the management service. Load session
+		// model and apply selected model.
+		const modelRef = await this._chatService.acquireOrLoadSession(chatResource, ChatAgentLocation.Chat, CancellationToken.None);
 		if (modelRef) {
 			if (selectedModelId) {
 				const languageModel = this._languageModelsService.lookupLanguageModel(selectedModelId);
@@ -1637,7 +1642,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 		this._ensureSessionCache();
 		const existingKeys = new Set(this._sessionCache.keys());
 
-		const result = await this._chatService.sendRequest(sessionResource, query, sendOptions);
+		const result = await this._chatService.sendRequest(chatResource, query, sendOptions);
 		if (result.kind === 'rejected') {
 			throw new Error(`[${this.id}] sendRequest rejected: ${result.reason}`);
 		}
@@ -1687,7 +1692,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 		return skeleton;
 	}
 
-	/** Localized error message when sendAndCreateChat is invoked without a connection. Subclasses can override. */
+	/** Localized error message when sendRequest is invoked without a connection. Subclasses can override. */
 	protected _notConnectedSendErrorMessage(): string {
 		return localize('notConnectedSend', "Cannot send request: not connected to agent host.");
 	}

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/agentHostSkillButtons.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/agentHostSkillButtons.test.ts
@@ -62,7 +62,7 @@ function makeActiveSession(providerId: string): IActiveSession {
 		description: chat.description,
 		chats: observableValue('chats', [chat]),
 		activeChat: observableValue('ac', chat),
-		mainChat: chat,
+		mainChat: constObservable(chat),
 		capabilities: { supportsMultipleChats: false },
 	} satisfies IActiveSession;
 }

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
@@ -1418,17 +1418,17 @@ suite('LocalAgentHostSessionsProvider', () => {
 		assert.strictEqual(session.loading.get(), false);
 	});
 
-	// ---- sendAndCreateChat -------
+	// ---- sendRequest -------
 
-	test('sendAndCreateChat throws for unknown session', async () => {
+	test('sendRequest throws for unknown session', async () => {
 		const provider = createProvider(disposables, agentHost);
 		await assert.rejects(
-			() => provider.sendAndCreateChat('nonexistent', { query: 'test' }),
+			() => provider.sendRequest('nonexistent', URI.parse('untitled:chat'), { query: 'test' }),
 			/not found or not a new session/,
 		);
 	});
 
-	test('sendAndCreateChat forwards resolved session config to chat service', async () => {
+	test('sendRequest forwards resolved session config to chat service', async () => {
 		const sendOptions: IChatSendRequestOptions[] = [];
 		const provider = createProvider(disposables, agentHost, undefined, {
 			openSession: true,
@@ -1443,7 +1443,8 @@ suite('LocalAgentHostSessionsProvider', () => {
 		const session = provider.createNewSession(URI.parse('file:///home/user/project'), provider.sessionTypes[0].id);
 		await waitForSessionConfig(provider, session.sessionId, config => config?.values.isolation === 'worktree');
 
-		await provider.sendAndCreateChat(session.sessionId, { query: 'hello' });
+		const chat = await provider.createNewChat(session.sessionId);
+		await provider.sendRequest(session.sessionId, chat.resource, { query: 'hello' });
 
 		assert.deepStrictEqual(sendOptions.map(options => options.agentHostSessionConfig), [{ isolation: 'worktree' }]);
 	});

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/COPILOT_CHAT_SESSIONS_PROVIDER.md
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/COPILOT_CHAT_SESSIONS_PROVIDER.md
@@ -78,18 +78,16 @@ The provider maintains a `Map<string, AgentSessionAdapter>` cache keyed by resou
 
 ## Send Flow
 
-1. Validate the session is a current new session (`CopilotCLISession`, `RemoteNewSession`, or `ClaudeCodeNewSession`)
-2. For the first chat, call `_sendFirstChat()`:
-   a. Resolve mode, permission level, and send options from session configuration
-   b. Open the chat widget via `IChatWidgetService.openSession()`
-   c. Load the session model and apply selected model, mode, and options
-   d. Send the request via `IChatService.sendRequest()`
-   e. Add temp session to cache and fire `onDidChangeSessions`
-   f. Wait for session commit (untitled → real URI)
-   g. Replace via `onDidReplaceSession` event with the committed session
-3. For subsequent chats (if `capabilities.supportsMultipleChats` enabled on the session), call `_sendSubsequentChat()`
-4. Wrap the new agent session as `AgentSessionAdapter` and return it
-5. Clear the current new session reference
+The provider exposes two entry points on `ISessionsProvider`:
+
+- **`createNewChat(sessionId, prompt?)`** — Creates the backend chat model and returns the resulting `IChat`. The management service uses the returned `chat.resource` to open the widget *before* sending. For new sessions the provider also swaps the session's `mainChat` observable with the committed chat so the cached `ISession` reflects the real backend resource.
+- **`sendRequest(sessionId, chatResource, options)`** — Sends a request for a chat that was already created via `createNewChat`. Internally it dispatches between:
+  - `_sendFirstChat()` when the session is the current new session — resolves mode/permission/send options, calls `IChatService.sendRequest`, adds the temp session to the cache, fires `onDidChangeSessions`, waits for commit (untitled → real URI for CLI sessions), and then fires `onDidReplaceSession` with the committed session.
+  - `_sendExistingChat()` when the session already has committed chats — sends to the existing chat resource.
+
+For multi-chat sessions (`capabilities.supportsMultipleChats === true`), `createNewChat()` on an existing session calls `_createNewSubsequentChat()`, which creates a fresh `CopilotCLISession` linked to the parent via the `parentSessionId` option, registers it in `_currentNewSession`, and returns its `IChat`. A subsequent `sendRequest(sessionId, chat.resource, options)` then routes through `_sendFirstChat`.
+
+The provider never opens the chat widget itself; widget opening is owned by the management service.
 
 ## New-Session Picker Contribution Model
 

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -2070,12 +2070,12 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 				if (!newItem) {
 					throw new Error('[CopilotChatSessionsProvider] Failed to create Claude session item');
 				}
-				await this._createChatSession(newItem.resource, session);
+				(await this._createChatSession(newItem.resource, session)).dispose();
 				newChat = this._toChat(session, newItem.resource);
 			} else if (session instanceof LocalNewSession) {
 				newChat = this._toChat(session);
 			} else {
-				await this._createChatSession(session.resource, session);
+				(await this._createChatSession(session.resource, session)).dispose();
 				newChat = this._toChat(session);
 			}
 			session.mainChat.set(newChat, undefined);
@@ -2126,7 +2126,7 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 		session.setTitle(localize('new chat', "New Chat"));
 		this._currentNewSession.value = session;
 
-		await this._createChatSession(session.resource, session);
+		(await this._createChatSession(session.resource, session)).dispose();
 
 		this._sessionCache.set(session.resource.toString(), session);
 		this._invalidateGroupingCaches();
@@ -2222,9 +2222,15 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 		try {
 			const result = await this.chatService.sendRequest(chatResource, query, sendOptions);
 			if (result.kind === 'rejected') {
+				// Clean up the temp session that was added to the cache and
+				// dispatched as `added` above, so the UI doesn't keep showing
+				// a stuck InProgress session that will never make progress.
 				this._sessionCache.delete(session.resource.toString());
 				this._invalidateGroupingCaches();
+				this._sessionGroupCache.delete(session.sessionId);
+				this._clearCurrentNewSessionIfMatch(session, /* leak */ true);
 				this._onDidChangeSessions.fire({ added: [], removed: [newSession], changed: [] });
+				session.dispose();
 				throw new Error(`[DefaultCopilotProvider] sendRequest rejected: ${result.reason}`);
 			}
 			// Extract promises to detect cancellation vs normal completion
@@ -2342,68 +2348,71 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 			agentHostSessionConfig: newChatSession.getAgentHostSessionConfig(),
 		};
 
-		await this._updateChatSessionState(newChatSession.resource, newChatSession);
-
-		// Send request
-		const result = await this.chatService.sendRequest(newChatSession.resource, query, sendOptions);
-		if (result.kind === 'rejected') {
-			this._sessionCache.delete(key);
-			this._invalidateGroupingCaches();
-			throw new Error(`[DefaultCopilotProvider] sendRequest rejected: ${result.reason}`);
-		}
-
-		// Extract promises to detect cancellation vs normal completion
-		const responseCompletePromise = result.kind === 'sent'
-			? result.data.responseCompletePromise
-			: undefined;
-		const responseCreatedPromise = result.kind === 'sent'
-			? result.data.responseCreatedPromise
-			: undefined;
-
+		const ref = await this._updateChatSessionState(newChatSession.resource, newChatSession);
 		try {
-			// Wait for the session to be committed
-			const committedResource = await this._waitForCommittedSession(newChatSession.resource, responseCompletePromise, responseCreatedPromise);
+			// Send request
+			const result = await this.chatService.sendRequest(newChatSession.resource, query, sendOptions);
+			if (result.kind === 'rejected') {
+				this._sessionCache.delete(key);
+				this._invalidateGroupingCaches();
+				throw new Error(`[DefaultCopilotProvider] sendRequest rejected: ${result.reason}`);
+			}
 
-			const committedChat = await this._waitForSessionInCache(committedResource);
+			// Extract promises to detect cancellation vs normal completion
+			const responseCompletePromise = result.kind === 'sent'
+				? result.data.responseCompletePromise
+				: undefined;
+			const responseCreatedPromise = result.kind === 'sent'
+				? result.data.responseCreatedPromise
+				: undefined;
 
-			// Clean up temp
-			this._sessionCache.delete(key);
-			this._invalidateGroupingCaches();
-			this._clearCurrentNewSessionIfMatch(newChatSession);
+			try {
+				// Wait for the session to be committed
+				const committedResource = await this._waitForCommittedSession(newChatSession.resource, responseCompletePromise, responseCreatedPromise);
 
-			// Invalidate the session group cache so it rebuilds with the committed chat
-			this._sessionGroupCache.delete(sessionId);
-			this._onDidGroupMembershipChange.fire({ sessionId });
-			const updatedSession = this._chatToSession(committedChat);
-			this._onDidChangeSessions.fire({ added: [], removed: [], changed: [updatedSession] });
+				const committedChat = await this._waitForSessionInCache(committedResource);
 
-			return updatedSession;
-		} catch (error) {
-			this._clearCurrentNewSessionIfMatch(newChatSession, /* leak */ true);
+				// Clean up temp
+				this._sessionCache.delete(key);
+				this._invalidateGroupingCaches();
+				this._clearCurrentNewSessionIfMatch(newChatSession);
 
-			if (error instanceof CancellationError) {
-				// Cancelled before commit — keep the chat in the group so the
-				// user can review the content the agent produced.
-				newChatSession.setStatus(SessionStatus.Completed);
+				// Invalidate the session group cache so it rebuilds with the committed chat
 				this._sessionGroupCache.delete(sessionId);
-				const updatedSession = this._chatToSession(newChatSession);
+				this._onDidGroupMembershipChange.fire({ sessionId });
+				const updatedSession = this._chatToSession(committedChat);
 				this._onDidChangeSessions.fire({ added: [], removed: [], changed: [updatedSession] });
-				return updatedSession;
-			}
 
-			// Unexpected error — clean up on error, fire changed on the parent session group
-			this._sessionCache.delete(key);
-			this._invalidateGroupingCaches();
-			this._sessionGroupCache.delete(sessionId);
-			newChatSession.dispose();
-			// Find the parent session's primary chat to fire a valid changed event
-			const parentChatIds = this._getChatIdsInGroup(sessionId);
-			const parentChatId = parentChatIds[0];
-			const parentChat = parentChatId ? this._sessionCache.get(this._localIdFromchatId(parentChatId)) : undefined;
-			if (parentChat) {
-				this._onDidChangeSessions.fire({ added: [], removed: [], changed: [this._chatToSession(parentChat)] });
+				return updatedSession;
+			} catch (error) {
+				this._clearCurrentNewSessionIfMatch(newChatSession, /* leak */ true);
+
+				if (error instanceof CancellationError) {
+					// Cancelled before commit — keep the chat in the group so the
+					// user can review the content the agent produced.
+					newChatSession.setStatus(SessionStatus.Completed);
+					this._sessionGroupCache.delete(sessionId);
+					const updatedSession = this._chatToSession(newChatSession);
+					this._onDidChangeSessions.fire({ added: [], removed: [], changed: [updatedSession] });
+					return updatedSession;
+				}
+
+				// Unexpected error — clean up on error, fire changed on the parent session group
+				this._sessionCache.delete(key);
+				this._invalidateGroupingCaches();
+				this._sessionGroupCache.delete(sessionId);
+				newChatSession.dispose();
+				// Find the parent session's primary chat to fire a valid changed event
+				const parentChatIds = this._getChatIdsInGroup(sessionId);
+				const parentChatId = parentChatIds[0];
+				const parentChat = parentChatId ? this._sessionCache.get(this._localIdFromchatId(parentChatId)) : undefined;
+				if (parentChat) {
+					this._onDidChangeSessions.fire({ added: [], removed: [], changed: [this._chatToSession(parentChat)] });
+				}
+				throw error;
 			}
-			throw error;
+		} finally {
+			ref.dispose();
 		}
 	}
 

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -2222,6 +2222,9 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 		try {
 			const result = await this.chatService.sendRequest(chatResource, query, sendOptions);
 			if (result.kind === 'rejected') {
+				this._sessionCache.delete(session.resource.toString());
+				this._invalidateGroupingCaches();
+				this._onDidChangeSessions.fire({ added: [], removed: [newSession], changed: [] });
 				throw new Error(`[DefaultCopilotProvider] sendRequest rejected: ${result.reason}`);
 			}
 			// Extract promises to detect cancellation vs normal completion

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -10,7 +10,7 @@ import { CancellationError } from '../../../../../base/common/errors.js';
 import { IMarkdownString, MarkdownString } from '../../../../../base/common/htmlContent.js';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable } from '../../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../../base/common/network.js';
-import { autorun, constObservable, derived, IObservable, IReader, observableFromEvent, observableValue, observableValueOpts, transaction } from '../../../../../base/common/observable.js';
+import { autorun, constObservable, derived, IObservable, IReader, ISettableObservable, observableFromEvent, observableValue, observableValueOpts, transaction } from '../../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
@@ -29,7 +29,6 @@ import { basename, dirname, isEqual } from '../../../../../base/common/resources
 import { ISendRequestOptions, ISessionChangeEvent, ISessionsProvider } from '../../../../services/sessions/common/sessionsProvider.js';
 import { ISessionOptionGroup } from '../../../chat/browser/newSession.js';
 import { IsolationMode } from './isolationPicker.js';
-import { ChatViewPaneTarget, IChatWidgetService } from '../../../../../workbench/contrib/chat/browser/chat.js';
 import { ILanguageModelToolsService } from '../../../../../workbench/contrib/chat/common/tools/languageModelToolsService.js';
 import { isBuiltinChatMode, IChatMode } from '../../../../../workbench/contrib/chat/common/chatModes.js';
 import { CancellationToken, CancellationTokenSource } from '../../../../../base/common/cancellation.js';
@@ -50,6 +49,7 @@ import { computePullRequestIcon, GitHubPullRequestState } from '../../../github/
 import { structuralEquals } from '../../../../../base/common/equals.js';
 import { CopilotCLISessionType } from '../../agentHost/browser/baseAgentHostSessionsProvider.js';
 import { createChangesets } from './copilotChatSessionsChangesets.js';
+import { IUriIdentityService } from '../../../../../platform/uriIdentity/common/uriIdentity.js';
 
 /** Local session type — in-process VS Code chat, no background agent or worktree. */
 export const LocalSessionType: ISessionType = {
@@ -77,7 +77,7 @@ const STORAGE_KEY_ISOLATION_MODE = 'sessions.isolationPicker.selectedMode';
 
 export interface ICopilotChatSession {
 	/** Globally unique session ID (`providerId:localId`). */
-	readonly id: string;
+	readonly sessionId: string;
 	/** Resource URI identifying this session. */
 	readonly resource: URI;
 	/** ID of the provider that owns this session. */
@@ -135,6 +135,14 @@ export interface ICopilotChatSession {
 
 	readonly gitRepository?: IGitRepository;
 	readonly branches: IObservable<readonly string[]>;
+
+	/**
+	 * Settable observable holding the {@link IChat} representation of this chat.
+	 * For committed chats, the value is stable. For new sessions, the provider
+	 * replaces the initial value via {@link createNewChat} once the real backend
+	 * resource is known (e.g., Claude assigns a new resource on commit).
+	 */
+	readonly mainChat: ISettableObservable<IChat>;
 }
 
 const OPEN_REPO_COMMAND = 'github.copilot.chat.cloudSessions.openRepository';
@@ -164,6 +172,30 @@ function isNewSession(session: ICopilotChatSession): session is NewSession {
 }
 
 /**
+ * Builds an {@link IChat} snapshot from an {@link ICopilotChatSession}. Used to
+ * seed the chat's own `mainChat` observable. An optional `resource` override is
+ * supported for cases where the chat resource differs from the session resource
+ * (e.g. Claude commits a new resource at send time).
+ */
+function buildChatFromSession(chat: Omit<ICopilotChatSession, 'mainChat'>, resource?: URI): IChat {
+	return {
+		resource: resource ?? chat.resource,
+		createdAt: chat.createdAt,
+		title: chat.title,
+		updatedAt: chat.updatedAt,
+		status: chat.status,
+		changes: chat.changes,
+		checkpoints: chat.checkpoints,
+		modelId: chat.modelId,
+		mode: chat.mode,
+		isArchived: chat.isArchived,
+		isRead: chat.isRead,
+		description: chat.description,
+		lastTurnEnd: chat.lastTurnEnd,
+	};
+}
+
+/**
  * Local new session for Background agent sessions.
  * Implements {@link ICopilotChatSession} (session facade) and provides
  * pre-send configuration methods for the new-session flow.
@@ -174,7 +206,7 @@ class CopilotCLISession extends Disposable implements ICopilotChatSession {
 
 	// -- ISessionData fields --
 
-	readonly id: string;
+	readonly sessionId: string;
 	readonly providerId: string;
 	readonly sessionType: typeof SessionType.CopilotCLI;
 	readonly icon: ThemeIcon;
@@ -233,6 +265,8 @@ class CopilotCLISession extends Disposable implements ICopilotChatSession {
 	private readonly _branches = observableValue<readonly string[]>(this, []);
 	readonly branches: IObservable<readonly string[]> = this._branches;
 
+	readonly mainChat: ISettableObservable<IChat>;
+
 	private _defaultBranch: string | undefined;
 
 	// -- New session configuration fields --
@@ -273,7 +307,7 @@ class CopilotCLISession extends Disposable implements ICopilotChatSession {
 		@IStorageService private readonly storageService: IStorageService,
 	) {
 		super();
-		this.id = toSessionId(providerId, resource);
+		this.sessionId = toSessionId(providerId, resource);
 		this.providerId = providerId;
 		this.sessionType = AgentSessionProviders.Background;
 		this.icon = CopilotCLISessionType.icon;
@@ -306,6 +340,8 @@ class CopilotCLISession extends Disposable implements ICopilotChatSession {
 
 		this._checkpoints = observableValueOpts<IChatCheckpoints | undefined>({ owner: this, equalsFn: structuralEquals }, undefined);
 		this.checkpoints = this._checkpoints;
+
+		this.mainChat = observableValue<IChat>(this, buildChatFromSession(this));
 	}
 
 	private async _resolveGitRepository(): Promise<void> {
@@ -499,7 +535,7 @@ export class RemoteNewSession extends Disposable implements ICopilotChatSession 
 
 	// -- ISessionData fields --
 
-	readonly id: string;
+	readonly sessionId: string;
 	readonly providerId: string;
 	readonly sessionType: string;
 	readonly icon: ThemeIcon;
@@ -542,6 +578,8 @@ export class RemoteNewSession extends Disposable implements ICopilotChatSession 
 	readonly branches: IObservable<readonly string[]> = constObservable([]);
 	readonly gitRepository?: IGitRepository | undefined;
 
+	readonly mainChat: ISettableObservable<IChat>;
+
 	readonly _hasGitRepo = observableValue(this, false);
 	readonly hasGitRepo: IObservable<boolean> = this._hasGitRepo;
 
@@ -578,7 +616,7 @@ export class RemoteNewSession extends Disposable implements ICopilotChatSession 
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 	) {
 		super();
-		this.id = toSessionId(providerId, resource);
+		this.sessionId = toSessionId(providerId, resource);
 		this.providerId = providerId;
 		this.sessionType = target;
 		this.icon = CopilotCloudSessionType.icon;
@@ -603,6 +641,7 @@ export class RemoteNewSession extends Disposable implements ICopilotChatSession 
 			this.setOption('repositories', { id, name: id });
 		}
 
+		this.mainChat = observableValue<IChat>(this, buildChatFromSession(this));
 	}
 	setPermissionLevel(level: ChatPermissionLevel): void {
 		throw new Error('Method not implemented.');
@@ -745,7 +784,7 @@ class LocalNewSession extends Disposable implements ICopilotChatSession {
 	// -- ISessionData fields --
 
 	readonly resource: URI;
-	readonly id: string;
+	readonly sessionId: string;
 	readonly providerId: string;
 	readonly sessionType: typeof SessionType.Local;
 	readonly icon: ThemeIcon;
@@ -790,6 +829,8 @@ class LocalNewSession extends Disposable implements ICopilotChatSession {
 	readonly branches: IObservable<readonly string[]> = constObservable([]);
 	readonly gitRepository?: IGitRepository | undefined;
 
+	readonly mainChat: ISettableObservable<IChat>;
+
 	// -- New session configuration fields --
 
 	private _modelId: string | undefined;
@@ -827,13 +868,15 @@ class LocalNewSession extends Disposable implements ICopilotChatSession {
 		}
 		this.resource = modelRef.object.sessionResource;
 
-		this.id = toSessionId(providerId, this.resource);
+		this.sessionId = toSessionId(providerId, this.resource);
 		this.providerId = providerId;
 		this.sessionType = AgentSessionProviders.Local;
 		this.icon = LocalSessionType.icon;
 		this.createdAt = new Date();
 
 		this._workspaceData.set(sessionWorkspace, undefined);
+
+		this.mainChat = observableValue<IChat>(this, buildChatFromSession(this));
 
 		// Resolve git state asynchronously so the Changes view has
 		// branch names, uncommitted counts, etc. without needing
@@ -1020,7 +1063,7 @@ class ClaudeCodeNewSession extends Disposable implements ICopilotChatSession {
 
 	// -- ISessionData fields --
 
-	readonly id: string;
+	readonly sessionId: string;
 	readonly providerId: string;
 	readonly sessionType: typeof SessionType.ClaudeCode;
 	readonly icon: ThemeIcon;
@@ -1063,6 +1106,8 @@ class ClaudeCodeNewSession extends Disposable implements ICopilotChatSession {
 	readonly branches: IObservable<readonly string[]> = constObservable([]);
 	readonly gitRepository?: IGitRepository | undefined;
 
+	readonly mainChat: ISettableObservable<IChat>;
+
 	// -- New session configuration fields --
 
 	private _modelId: string | undefined;
@@ -1083,13 +1128,15 @@ class ClaudeCodeNewSession extends Disposable implements ICopilotChatSession {
 		providerId: string,
 	) {
 		super();
-		this.id = toSessionId(providerId, resource);
+		this.sessionId = toSessionId(providerId, resource);
 		this.providerId = providerId;
 		this.sessionType = AgentSessionProviders.Claude;
 		this.icon = ClaudeCodeSessionType.icon;
 		this.createdAt = new Date();
 
 		this._workspaceData.set(sessionWorkspace, undefined);
+
+		this.mainChat = observableValue<IChat>(this, buildChatFromSession(this));
 	}
 
 	setOption(optionId: string, value: IChatSessionProviderOptionItem | string): void {
@@ -1162,7 +1209,7 @@ function toSessionStatus(status: ChatSessionStatus): SessionStatus {
  */
 class AgentSessionAdapter implements ICopilotChatSession {
 
-	readonly id: string;
+	readonly sessionId: string;
 	readonly resource: URI;
 	readonly providerId: string;
 	readonly sessionType: string;
@@ -1213,12 +1260,14 @@ class AgentSessionAdapter implements ICopilotChatSession {
 	readonly gitRepository?: IGitRepository | undefined;
 	readonly branches: IObservable<readonly string[]> = constObservable([]);
 
+	readonly mainChat: ISettableObservable<IChat>;
+
 	constructor(
 		session: IAgentSession,
 		providerId: string,
 		private readonly _gitHubService: IGitHubService,
 	) {
-		this.id = toSessionId(providerId, session.resource);
+		this.sessionId = toSessionId(providerId, session.resource);
 		this.resource = session.resource;
 		this.providerId = providerId;
 		this.sessionType = session.providerType;
@@ -1271,6 +1320,8 @@ class AgentSessionAdapter implements ICopilotChatSession {
 		this.description = this._description;
 		this._lastTurnEnd = observableValue(this, session.timing.lastRequestEnded ? new Date(session.timing.lastRequestEnded) : undefined);
 		this.lastTurnEnd = this._lastTurnEnd;
+
+		this.mainChat = observableValue<IChat>(this, buildChatFromSession(this));
 	}
 
 	setPermissionLevel(level: ChatPermissionLevel): void {
@@ -1602,6 +1653,7 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 	readonly id = COPILOT_PROVIDER_ID;
 	readonly label = localize('copilotChatSessionsProvider', "Copilot Chat");
 	readonly icon = Codicon.copilot;
+
 	get sessionTypes(): readonly ISessionType[] {
 		const types: ISessionType[] = [CopilotCLISessionType, CopilotCloudSessionType];
 		if (this._localSessionEnabled) {
@@ -1654,7 +1706,6 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 		@IAgentSessionsService private readonly agentSessionsService: IAgentSessionsService,
 		@IChatService private readonly chatService: IChatService,
 		@IChatSessionsService private readonly chatSessionsService: IChatSessionsService,
-		@IChatWidgetService private readonly chatWidgetService: IChatWidgetService,
 		@IDialogService private readonly dialogService: IDialogService,
 		@ICommandService private readonly commandService: ICommandService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
@@ -1664,6 +1715,7 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 		@ILogService private readonly logService: ILogService,
 		@IGitHubService private readonly gitHubService: IGitHubService,
 		@ILabelService private readonly labelService: ILabelService,
+		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
 	) {
 		super();
 
@@ -1771,7 +1823,7 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 	}
 
 	getSession(sessionId: string): ICopilotChatSession | undefined {
-		if (this._currentNewSession.value?.id === sessionId) {
+		if (this._currentNewSession.value?.sessionId === sessionId) {
 			return this._currentNewSession.value;
 		}
 		return this._findChatSession(sessionId);
@@ -1832,7 +1884,7 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 	}
 
 	setModel(sessionId: string, modelId: string): void {
-		if (this._currentNewSession.value?.id === sessionId) {
+		if (this._currentNewSession.value?.sessionId === sessionId) {
 			this._currentNewSession.value.setModelId(modelId);
 			return;
 		}
@@ -1975,7 +2027,7 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 				const key = chat.resource.toString();
 				this._sessionCache.delete(key);
 				this._invalidateGroupingCaches();
-				if (this._currentNewSession.value?.id === chatId) {
+				if (this._currentNewSession.value?.sessionId === chatId) {
 					this._currentNewSession.clear();
 				}
 			}
@@ -2004,51 +2056,110 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 		}
 	}
 
-	// -- Send --
-
-	async sendAndCreateChat(sessionId: string, options: ISendRequestOptions): Promise<ISession> {
-		// Determine if this is the first chat or a subsequent chat
-		const session = this._currentNewSession.value;
-		if (session && session.id === sessionId) {
-			// First chat — use the existing new-session flow
-			return this._sendFirstChat(session, options);
+	async createNewChat(sessionId: string, prompt?: string): Promise<IChat> {
+		if (this._currentNewSession.value?.sessionId === sessionId) {
+			const session = this._currentNewSession.value;
+			let newChat: IChat;
+			// new session
+			if (session instanceof ClaudeCodeNewSession) {
+				const newItem = await this.chatSessionsService.createNewChatSessionItem(
+					session.target,
+					{ prompt: prompt ?? '', initialSessionOptions: session.selectedOptions.size > 0 ? session.selectedOptions : undefined, untitledResource: session.resource },
+					CancellationToken.None,
+				);
+				if (!newItem) {
+					throw new Error('[CopilotChatSessionsProvider] Failed to create Claude session item');
+				}
+				await this._createChatSession(newItem.resource, session);
+				newChat = this._toChat(session, newItem.resource);
+			} else if (session instanceof LocalNewSession) {
+				newChat = this._toChat(session);
+			} else {
+				await this._createChatSession(session.resource, session);
+				newChat = this._toChat(session);
+			}
+			session.mainChat.set(newChat, undefined);
+			return newChat;
 		}
 
 		if (!this._isMultiChatEnabled()) {
-			throw new Error(`Session '${sessionId}' not found or not a new session`);
+			throw new Error(`[CopilotChatSessionsProvider] Session '${sessionId}' does not support multiple chats`);
 		}
 
-		// Subsequent chat — create a new chat within the existing session
-		return this._sendSubsequentChat(sessionId, options);
+		return this._createNewSubsequentChat(sessionId);
 	}
 
-	addChat(sessionId: string): IChat {
-		const session = this._findSession(sessionId);
-		if (!session?.capabilities.supportsMultipleChats) {
-			throw new Error('Multiple chats per session is not supported');
+	private async _createNewSubsequentChat(sessionId: string): Promise<IChat> {
+		// Find the primary chat for this session
+		const chatIds = this._getChatIdsInGroup(sessionId);
+		const firstChatId = chatIds[0] ?? sessionId;
+		const chat = this._sessionCache.get(this._localIdFromchatId(firstChatId));
+		if (!chat) {
+			throw new Error(`Session '${sessionId}' not found`);
 		}
 
-		const newChatSession = this._createNewSessionFrom(sessionId);
+		if (chat.sessionType !== CopilotCLISessionType.id) {
+			throw new Error('Multiple chats per session is only supported for Copilot CLI sessions');
+		}
 
-		newChatSession.setTitle(localize('new chat', "New Chat"));
-		const key = newChatSession.resource.toString();
-		this._sessionCache.set(key, newChatSession);
+		const workspace = chat.workspace.get();
+		if (!workspace) {
+			throw new Error('Chat session has no associated workspace');
+		}
+
+		const folder = workspace.folders[0];
+		if (!folder) {
+			throw new Error('Workspace has no folder');
+		}
+
+		const newWorkspace = this.resolveWorkspace(folder.workingDirectory);
+		if (!newWorkspace) {
+			throw new Error(`Cannot resolve workspace for working directory URI: ${folder.workingDirectory.toString()}`);
+		}
+
+		const resource = URI.from({ scheme: AgentSessionProviders.Background, path: `/untitled-${generateUuid()}` });
+		const session = this.instantiationService.createInstance(CopilotCLISession, resource, newWorkspace, this.id);
+		session.setModelId(chat.modelId.get());
+		session.setIsolationMode('workspace');
+		session.setOption(PARENT_SESSION_OPTION_ID, chat.resource.path.slice(1));
+		session.setPermissionLevel(this._defaultPermissionLevel());
+		session.setTitle(localize('new chat', "New Chat"));
+		this._currentNewSession.value = session;
+
+		await this._createChatSession(session.resource, session);
+
+		this._sessionCache.set(session.resource.toString(), session);
 		this._invalidateGroupingCaches();
-
-		// Invalidate the session group cache so it rebuilds with the new chat
 		this._sessionGroupCache.delete(sessionId);
-		this._onDidGroupMembershipChange.fire({ sessionId });
-		this._onDidChangeSessions.fire({ added: [], removed: [], changed: [this._chatToSession(newChatSession)] });
 
-		return this._toChat(newChatSession);
+		this._onDidGroupMembershipChange.fire({ sessionId });
+		this._onDidChangeSessions.fire({ added: [], removed: [], changed: [this._chatToSession(session)] });
+
+		return this._toChat(session);
 	}
 
 	async sendRequest(sessionId: string, chatResource: URI, options: ISendRequestOptions): Promise<ISession> {
-		if (!this._isMultiChatEnabled()) {
+		const newSession = this._currentNewSession.value;
+		if (newSession && newSession.sessionId === sessionId) {
+			if (!this.uriIdentityService.extUri.isEqual(newSession.mainChat.get().resource, chatResource)) {
+				throw new Error('Chat resource does not match the main chat of the current new session');
+			}
+			return this._sendFirstChat(newSession, chatResource, options);
+		}
+
+		const session = this._findSession(sessionId);
+		if (!session) {
+			throw new Error(`Session '${sessionId}' not found`);
+		}
+
+		if (!session.capabilities.supportsMultipleChats) {
 			throw new Error('Multiple chats per session is not supported');
 		}
 
-		// The chat must already exist (created via addChat)
+		if (!session.chats.get().some(chat => this.uriIdentityService.extUri.isEqual(chat.resource, chatResource))) {
+			throw new Error(`Chat '${chatResource.toString()}' does not belong to session '${sessionId}'`);
+		}
+
 		const key = chatResource.toString();
 		const chatSession = this._sessionCache.get(key);
 		if (!chatSession || !(chatSession instanceof CopilotCLISession)) {
@@ -2058,13 +2169,18 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 		return this._sendExistingChat(sessionId, chatSession, options);
 	}
 
-	/**
-	 * Sends the first chat for a newly created session.
-	 * Adds the temp session to the cache, waits for commit, then replaces it.
-	 */
-	private async _sendFirstChat(session: CopilotCLISession | RemoteNewSession | ClaudeCodeNewSession | LocalNewSession, options: ISendRequestOptions): Promise<ISession> {
+	private async _sendFirstChat(session: CopilotCLISession | RemoteNewSession | ClaudeCodeNewSession | LocalNewSession, chatResource: URI, options: ISendRequestOptions): Promise<ISession> {
 
 		const { query, attachedContext } = options;
+
+		session.setTitle(query.split('\n')[0].substring(0, 100) || localize('new session', "New Session"));
+		session.setStatus(SessionStatus.InProgress);
+		this._sessionCache.set(session.resource.toString(), session);
+		this._invalidateGroupingCaches();
+
+		// Add the new session to the sessions model immediately so it appears in the sessions list
+		const newSession = this._chatToSession(session);
+		this._onDidChangeSessions.fire({ added: [newSession], removed: [], changed: [] });
 
 		const contribution = this.chatSessionsService.getChatSessionContribution(session.target);
 
@@ -2099,272 +2215,74 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 			agentHostSessionConfig: session instanceof CopilotCLISession ? session.getAgentHostSessionConfig() : undefined,
 		};
 
-		// Claude sessions use the ChatSessionItemController API which creates
-		// real session URIs upfront, bypassing the untitled→commit→swap flow.
-		if (session instanceof ClaudeCodeNewSession) {
-			return this._sendFirstChatViaController(session, query, sendOptions);
-		}
-
-		// Local sessions run in-process and do not go through the
-		// untitled→commit→swap flow (chatServiceImpl explicitly skips
-		// commit for localChatSessionType). Send the request and keep
-		// the session on its original URI.
-		if (session instanceof LocalNewSession) {
-			return this._sendFirstChatLocal(session, query, sendOptions, permissionLevel);
-		}
-
-		await this.chatSessionsService.getOrCreateChatSession(session.resource, CancellationToken.None);
-		const disposable = await this._applySessionModelState(session.resource, session, permissionLevel);
-		const chatWidget = await this.chatWidgetService.openSession(session.resource, ChatViewPaneTarget);
-		disposable.dispose();
-		if (!chatWidget) {
-			throw new Error('[DefaultCopilotProvider] Failed to open chat widget');
-		}
-
-		// Send request
-		this.logService.debug(`[CopilotChatSessionsProvider] Sending first chat for session ${session.id} with options:`, {
+		const ref = await this._updateChatSessionState(chatResource, session, sendOptions.modeInfo?.permissionLevel);
+		this.logService.debug(`[CopilotChatSessionsProvider] Sending first chat for session ${session.sessionId} with options:`, {
 			userSelectedModelId: sendOptions.userSelectedModelId,
 		});
-		const result = await this.chatService.sendRequest(session.resource, query, sendOptions);
-		if (result.kind === 'rejected') {
-			throw new Error(`[DefaultCopilotProvider] sendRequest rejected: ${result.reason}`);
-		}
-
-		// Extract promises to detect cancellation vs normal completion
-		const responseCompletePromise = result.kind === 'sent'
-			? result.data.responseCompletePromise
-			: undefined;
-		const responseCreatedPromise = result.kind === 'sent'
-			? result.data.responseCreatedPromise
-			: undefined;
-
-		// Add the new session to the sessions model immediately so it appears in the sessions list
-		session.setTitle(localize('new session', "New Session"));
-		session.setStatus(SessionStatus.InProgress);
-		const key = session.resource.toString();
-		this._sessionCache.set(key, session);
-		this._invalidateGroupingCaches();
-		const newSession = this._chatToSession(session);
-		this._onDidChangeSessions.fire({ added: [newSession], removed: [], changed: [] });
-
 		try {
-
-			// Wait for the session to be committed (URI swapped from untitled to real)
-			const committedResource = await this._waitForCommittedSession(session.resource, responseCompletePromise, responseCreatedPromise);
-
-			// Wait for _refreshSessionCache to populate the committed adapter
-			const committedChat = await this._waitForSessionInCache(committedResource);
-
-			// Remove the temp from the cache (the adapter now owns the committed key)
-			this._sessionCache.delete(key);
-			// Guard: only clear if _currentNewSession still points at this
-			// session — a newer createNewSession may have replaced it while
-			// we were awaiting the commit.
-			this._clearCurrentNewSessionIfMatch(session);
-
-			const committedSession = this._chatToSession(committedChat);
-
-			// Notify listeners that the temp session was replaced by the committed one
-			this._sessionGroupCache.delete(session.id);
-			this._onDidReplaceSession.fire({ from: newSession, to: committedSession });
-
-			return committedSession;
-		} catch (error) {
-			this._clearCurrentNewSessionIfMatch(session, /* leak */ true);
-
-			if (error instanceof CancellationError) {
-				session.setStatus(SessionStatus.Completed);
-				this._onDidChangeSessions.fire({ added: [], removed: [], changed: [newSession] });
-				return newSession;
+			const result = await this.chatService.sendRequest(chatResource, query, sendOptions);
+			if (result.kind === 'rejected') {
+				throw new Error(`[DefaultCopilotProvider] sendRequest rejected: ${result.reason}`);
 			}
-
-			// Unexpected error — clean up the temp session entirely
-			this._sessionCache.delete(key);
-			this._invalidateGroupingCaches();
-			this._sessionGroupCache.delete(session.id);
-			this._onDidChangeSessions.fire({ added: [], removed: [this._chatToSession(session)], changed: [] });
-			session.dispose();
-			throw error;
-		}
-	}
-
-	/**
-	 * Sends the first chat for a local (in-process) session.
-	 *
-	 * Local sessions do not create worktrees and the chat service explicitly
-	 * skips the untitled→commit flow for {@link localChatSessionType}.
-	 * Instead of waiting for a commit event that will never arrive, this
-	 * method keeps the session on its original untitled URI.
-	 */
-	private async _sendFirstChatLocal(
-		session: LocalNewSession,
-		query: string,
-		sendOptions: IChatSendRequestOptions,
-		permissionLevel: ChatPermissionLevel,
-	): Promise<ISession> {
-		// The chat model was already created in createNewSession via
-		// startNewLocalSession, so we skip getOrCreateChatSession here
-		// (which would otherwise try to resolve a content provider).
-		const disposable = await this._applySessionModelState(session.resource, session, permissionLevel);
-		const chatWidget = await this.chatWidgetService.openSession(session.resource, ChatViewPaneTarget);
-		disposable.dispose();
-		if (!chatWidget) {
-			throw new Error('[CopilotChatSessionsProvider] Failed to open chat widget for local session');
-		}
-
-		// Obtain user-selected tools from the chat widget so the copilot
-		// extension sees the full tool set. Without this, the direct
-		// chatService.sendRequest bypasses chatWidget.acceptInput() which
-		// normally provides these.
-		const { userSelectedTools } = chatWidget.getModeRequestOptions();
-
-		this.logService.debug(`[CopilotChatSessionsProvider] Sending first chat for local session ${session.id}`);
-		const result = await this.chatService.sendRequest(session.resource, query, {
-			...sendOptions,
-			userSelectedTools,
-			instructionContext: {
-				modeKind: sendOptions.modeInfo?.kind ?? ChatModeKind.Agent,
-				enabledTools: userSelectedTools?.get(),
-			},
-		});
-		if (result.kind === 'rejected') {
-			throw new Error(`[CopilotChatSessionsProvider] Local sendRequest rejected: ${result.reason}`);
-		}
-
-		// Local sessions stay on their original URI — no commit swap needed.
-		session.setTitle(query.split('\n')[0].substring(0, 100) || localize('new session', "New Session"));
-		session.setStatus(SessionStatus.InProgress);
-		const key = session.resource.toString();
-		this._sessionCache.set(key, session);
-		this._invalidateGroupingCaches();
-		this._currentNewSession.clearAndLeak();
-		const newSession = this._chatToSession(session);
-		this._onDidChangeSessions.fire({ added: [newSession], removed: [], changed: [] });
-
-		// Listen for the response to complete so we can flip the status
-		// from InProgress → Completed and unblock the input box.
-		if (result.kind === 'sent') {
-			result.data.responseCompletePromise.then(() => {
-				session.setStatus(SessionStatus.Completed);
-				this._onDidChangeSessions.fire({ added: [], removed: [], changed: [newSession] });
+			// Extract promises to detect cancellation vs normal completion
+			const cts = new CancellationTokenSource();
+			const responseCompletePromise = result.kind === 'sent' ? result.data.responseCompletePromise : undefined;
+			const responseCreatedPromise = result.kind === 'sent' ? result.data.responseCreatedPromise : undefined;
+			responseCreatedPromise?.then(r => {
+				if (r?.isCanceled) {
+					cts.cancel();
+				}
 			});
-		}
 
-		return newSession;
-	}
+			try {
+				let committedResource = chatResource;
+				if (session instanceof CopilotCLISession) {
+					committedResource = await this._waitForCommittedSession(session.resource, responseCompletePromise, responseCreatedPromise);
+				}
 
-	/**
-	 * Sends the first chat for a Claude session using the controller API.
-	 *
-	 * Unlike the legacy untitled→commit→swap flow, this creates the real
-	 * session URI upfront via {@link IChatSessionsService.createNewChatSessionItem},
-	 * then sends the request directly to that URI. This avoids the commit
-	 * event race and ensures the session appears under the correct workspace
-	 * immediately.
-	 */
-	private async _sendFirstChatViaController(
-		session: ClaudeCodeNewSession,
-		query: string,
-		sendOptions: IChatSendRequestOptions,
-	): Promise<ISession> {
-		// Create the real session item via the controller's newChatSessionItemHandler.
-		// This returns a session with a real (non-untitled) URI.
-		const newItem = await this.chatSessionsService.createNewChatSessionItem(
-			session.target,
-			{ prompt: query, initialSessionOptions: session.selectedOptions.size > 0 ? session.selectedOptions : undefined },
-			CancellationToken.None,
-		);
-		if (!newItem) {
-			throw new Error('[CopilotChatSessionsProvider] Failed to create Claude session item');
-		}
+				// Wait for _refreshSessionCache to populate the committed adapter
+				const committedChat = await this._waitForSessionInCache(committedResource, cts.token);
+				this._sessionCache.delete(session.resource.toString());
+				this._clearCurrentNewSessionIfMatch(session);
 
-		const realResource = newItem.resource;
+				const committedSession = this._chatToSession(committedChat);
+				this._sessionGroupCache.delete(session.sessionId);
+				this._onDidReplaceSession.fire({ from: newSession, to: committedSession });
 
-		// Open chat session and widget with the real URI
-		await this.chatSessionsService.getOrCreateChatSession(realResource, CancellationToken.None);
-		const disposable = await this._applySessionModelState(realResource, session, sendOptions.modeInfo?.permissionLevel);
-		const chatWidget = await this.chatWidgetService.openSession(realResource, ChatViewPaneTarget);
-		disposable.dispose();
-		if (!chatWidget) {
-			throw new Error('[CopilotChatSessionsProvider] Failed to open chat widget');
-		}
+				return committedSession;
+			} catch (error) {
+				this._clearCurrentNewSessionIfMatch(session, /* leak */ true);
 
-		// Send request to the real URI — sendRequest skips the
-		// createNewChatSessionItem block since the URI is not untitled.
-		this.logService.debug(`[CopilotChatSessionsProvider] Sending first Claude chat to ${realResource.toString()} with options:`, {
-			userSelectedModelId: sendOptions.userSelectedModelId,
-		});
-		const result = await this.chatService.sendRequest(realResource, query, sendOptions);
-		if (result.kind === 'rejected') {
-			throw new Error(`[CopilotChatSessionsProvider] sendRequest rejected: ${result.reason}`);
-		}
+				if (error instanceof CancellationError) {
+					session.setStatus(SessionStatus.Completed);
+					this._onDidChangeSessions.fire({ added: [], removed: [], changed: [newSession] });
+					return newSession;
+				}
 
-		// Add the temp session to the cache immediately so it appears in the sessions list
-		session.setTitle(newItem.label);
-		session.setStatus(SessionStatus.InProgress);
-		const tempKey = session.resource.toString();
-		this._sessionCache.set(tempKey, session);
-		const tempSession = this._chatToSession(session);
-		this._onDidChangeSessions.fire({ added: [tempSession], removed: [], changed: [] });
-
-		// Extract response promises for cancellation detection
-		const responseCreatedPromise = result.kind === 'sent'
-			? result.data.responseCreatedPromise
-			: undefined;
-		const cts = new CancellationTokenSource();
-		// TODO: Understand why we are not awaiting this an only handling the cancellation
-		responseCreatedPromise?.then(r => {
-			if (r?.isCanceled) {
-				cts.cancel();
+				// Unexpected error — clean up the temp session entirely
+				this._sessionCache.delete(session.resource.toString());
+				this._invalidateGroupingCaches();
+				this._sessionGroupCache.delete(session.sessionId);
+				this._onDidChangeSessions.fire({ added: [], removed: [this._chatToSession(session)], changed: [] });
+				session.dispose();
+				throw error;
+			} finally {
+				cts.dispose();
 			}
-		});
-
-		try {
-			// Wait for the agent sessions model to pick up the real session,
-			// racing against cancellation so we don't timeout when the user
-			// stops the request before the agent creates a worktree.
-			const committedChat = await this._waitForSessionInCache(realResource, cts.token);
-
-			// Clean up temp session and replace with the real adapter
-			this._sessionCache.delete(tempKey);
-			this._clearCurrentNewSessionIfMatch(session);
-
-			const committedSession = this._chatToSession(committedChat);
-			this._sessionGroupCache.delete(session.id);
-			this._onDidReplaceSession.fire({ from: tempSession, to: committedSession });
-
-			return committedSession;
 		} catch (error) {
-			this._clearCurrentNewSessionIfMatch(session, /* leak */ true);
-
-			if (error instanceof CancellationError) {
-				// Keep the temp session visible so the user can review
-				// whatever content the agent produced before the cancellation.
-				session.setStatus(SessionStatus.Completed);
-				this._onDidChangeSessions.fire({ added: [], removed: [], changed: [tempSession] });
-				return tempSession;
-			}
-
-			// Unexpected error — clean up the temp session entirely
-			this._sessionCache.delete(tempKey);
-			this._sessionGroupCache.delete(session.id);
-			this._onDidChangeSessions.fire({ added: [], removed: [tempSession], changed: [] });
-			session.dispose();
+			this.logService.error(`[CopilotChatSessionsProvider] Failed to send first chat for session ${session.sessionId}:`, error);
 			throw error;
 		} finally {
-			cts.dispose();
+			ref?.dispose();
 		}
 	}
 
-	/**
-	 * Loads the session model for the given resource and applies the selected
-	 * language model, chat mode, and session options from the new session object.
-	 */
-	private async _applySessionModelState(
-		resource: URI,
-		session: { selectedModelId?: string; chatMode?: IChatMode; selectedOptions: Map<string, IChatSessionProviderOptionItem> },
-		permissionLevel?: ChatPermissionLevel,
-	): Promise<IDisposable> {
+	private async _createChatSession(resource: URI, session: NewSession, permissionLevel?: ChatPermissionLevel): Promise<IDisposable> {
+		await this.chatSessionsService.getOrCreateChatSession(resource, CancellationToken.None);
+		return this._updateChatSessionState(resource, session, permissionLevel);
+	}
+
+	private async _updateChatSessionState(resource: URI, session: NewSession, permissionLevel?: ChatPermissionLevel): Promise<IDisposable> {
 		const modelRef = await this.chatService.acquireOrLoadSession(resource, ChatAgentLocation.Chat, CancellationToken.None);
 		if (!modelRef) {
 			return Disposable.None;
@@ -2386,31 +2304,6 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 			model.inputModel.setState({ permissionLevel });
 		}
 		return modelRef;
-	}
-
-	/**
-	 * Sends a subsequent chat for an existing session that already has chats.
-	 * Creates a new {@link CopilotCLISession} from the existing workspace and
-	 * fires a `changed` event on the grouped session rather than an `added` event.
-	 */
-	private async _sendSubsequentChat(sessionId: string, options: ISendRequestOptions): Promise<ISession> {
-		// Reuse a chat that was pre-created by addChat(), otherwise create one
-		let newChatSession: CopilotCLISession;
-		const current = this._currentNewSession.value;
-		if (current && this._getGroupIdForChat(current) === sessionId) {
-			newChatSession = current as CopilotCLISession;
-		} else {
-			newChatSession = this._createNewSessionFrom(sessionId);
-			newChatSession.setTitle(localize('new chat', "New Chat"));
-			const key = newChatSession.resource.toString();
-			this._sessionCache.set(key, newChatSession);
-			this._invalidateGroupingCaches();
-			this._sessionGroupCache.delete(sessionId);
-			this._onDidGroupMembershipChange.fire({ sessionId });
-			this._onDidChangeSessions.fire({ added: [], removed: [], changed: [this._chatToSession(newChatSession)] });
-		}
-
-		return this._sendExistingChat(sessionId, newChatSession, options);
 	}
 
 	/**
@@ -2446,17 +2339,7 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 			agentHostSessionConfig: newChatSession.getAgentHostSessionConfig(),
 		};
 
-		// Open chat widget
-		await this.chatSessionsService.getOrCreateChatSession(newChatSession.resource, CancellationToken.None);
-		const chatWidget = await this.chatWidgetService.openSession(newChatSession.resource, ChatViewPaneTarget);
-		if (!chatWidget) {
-			this._sessionCache.delete(key);
-			this._invalidateGroupingCaches();
-			throw new Error('[DefaultCopilotProvider] Failed to open chat widget for subsequent chat');
-		}
-
-		// Load session model with selected options
-		(await this._applySessionModelState(newChatSession.resource, newChatSession)).dispose();
+		await this._updateChatSessionState(newChatSession.resource, newChatSession);
 
 		// Send request
 		const result = await this.chatService.sendRequest(newChatSession.resource, query, sendOptions);
@@ -2519,51 +2402,6 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 			}
 			throw error;
 		}
-	}
-
-	/**
-	 * Creates a new {@link CopilotCLISession} from an existing session's workspace.
-	 * Used for subsequent chats that share the same workspace but are independent conversations.
-	 */
-	private _createNewSessionFrom(sessionId: string): CopilotCLISession {
-		// Find the primary chat for this session
-		const chatIds = this._getChatIdsInGroup(sessionId);
-		const firstChatId = chatIds[0] ?? sessionId;
-		const chat = this._sessionCache.get(this._localIdFromchatId(firstChatId));
-		if (!chat) {
-			throw new Error(`Session '${sessionId}' not found`);
-		}
-
-		if (chat.sessionType === AgentSessionProviders.Cloud) {
-			throw new Error('Multiple chats per session is not supported for cloud sessions');
-		}
-
-		if (chat.sessionType === AgentSessionProviders.Claude) {
-			throw new Error('Multiple chats per session is not supported for Claude sessions');
-		}
-
-		const workspace = chat.workspace.get();
-		if (!workspace) {
-			throw new Error('Chat session has no associated workspace');
-		}
-
-		const folder = workspace.folders[0];
-		if (!folder) {
-			throw new Error('Workspace has no folder');
-		}
-
-		const newWorkspace = this.resolveWorkspace(folder.workingDirectory);
-		if (!newWorkspace) {
-			throw new Error(`Cannot resolve workspace for working directory URI: ${folder.workingDirectory.toString()}`);
-		}
-		const resource = URI.from({ scheme: AgentSessionProviders.Background, path: `/untitled-${generateUuid()}` });
-		const session = this.instantiationService.createInstance(CopilotCLISession, resource, newWorkspace, this.id);
-		session.setModelId(chat.modelId.get());
-		session.setIsolationMode('workspace');
-		session.setOption(PARENT_SESSION_OPTION_ID, chat.resource.path.slice(1));
-		session.setPermissionLevel(this._defaultPermissionLevel());
-		this._currentNewSession.value = session;
-		return session;
 	}
 
 	/**
@@ -2779,7 +2617,7 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 		const chatsByGroupId = new Map<string, ICopilotChatSession[]>();
 
 		const resolveGroupId = (chat: ICopilotChatSession): string => {
-			const cachedGroupId = groupIdByChatId.get(chat.id);
+			const cachedGroupId = groupIdByChatId.get(chat.sessionId);
 			if (cachedGroupId) {
 				return cachedGroupId;
 			}
@@ -2789,37 +2627,37 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 			let current: ICopilotChatSession = chat;
 
 			for (let depth = 0; depth < 100; depth++) {
-				const currentCachedGroupId = groupIdByChatId.get(current.id);
+				const currentCachedGroupId = groupIdByChatId.get(current.sessionId);
 				if (currentCachedGroupId) {
 					for (const trailChat of trail) {
-						groupIdByChatId.set(trailChat.id, currentCachedGroupId);
+						groupIdByChatId.set(trailChat.sessionId, currentCachedGroupId);
 					}
 					return currentCachedGroupId;
 				}
 
-				if (seen.has(current.id)) {
+				if (seen.has(current.sessionId)) {
 					for (const trailChat of trail) {
-						groupIdByChatId.set(trailChat.id, current.id);
+						groupIdByChatId.set(trailChat.sessionId, current.sessionId);
 					}
-					return current.id;
+					return current.sessionId;
 				}
 
 				trail.push(current);
-				seen.add(current.id);
+				seen.add(current.sessionId);
 
 				const parentRawSessionId = this._getDirectParentRawSessionId(current);
 				if (!parentRawSessionId) {
 					for (const trailChat of trail) {
-						groupIdByChatId.set(trailChat.id, current.id);
+						groupIdByChatId.set(trailChat.sessionId, current.sessionId);
 					}
-					return current.id;
+					return current.sessionId;
 				}
 
 				const parentChat = chatByRawSessionId.get(parentRawSessionId);
 				if (!parentChat) {
 					const syntheticGroupId = this._getSyntheticGroupId(parentRawSessionId);
 					for (const trailChat of trail) {
-						groupIdByChatId.set(trailChat.id, syntheticGroupId);
+						groupIdByChatId.set(trailChat.sessionId, syntheticGroupId);
 					}
 					return syntheticGroupId;
 				}
@@ -2827,8 +2665,8 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 				current = parentChat;
 			}
 
-			groupIdByChatId.set(chat.id, chat.id);
-			return chat.id;
+			groupIdByChatId.set(chat.sessionId, chat.sessionId);
+			return chat.sessionId;
 		};
 
 		for (const chat of chats) {
@@ -2841,7 +2679,7 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 		const chatIdsByGroupId = new Map<string, string[]>();
 		for (const [groupId, groupChats] of chatsByGroupId) {
 			groupChats.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
-			chatIdsByGroupId.set(groupId, groupChats.map(chat => chat.id));
+			chatIdsByGroupId.set(groupId, groupChats.map(chat => chat.sessionId));
 		}
 
 		this._chatByRawSessionIdCache = chatByRawSessionId;
@@ -2863,12 +2701,12 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 		const key = chatSession.resource.toString();
 		this._sessionCache.delete(key);
 		this._invalidateGroupingCaches();
-		this._sessionGroupCache.delete(chatSession.id);
-		if (this._currentNewSession.value?.id === chatSession.id) {
+		this._sessionGroupCache.delete(chatSession.sessionId);
+		if (this._currentNewSession.value?.sessionId === chatSession.sessionId) {
 			this._currentNewSession.clearAndLeak();
 		}
 		const removedSession = this._chatToSession(chatSession);
-		this._sessionGroupCache.delete(chatSession.id);
+		this._sessionGroupCache.delete(chatSession.sessionId);
 		this._onDidChangeSessions.fire({ added: [], removed: [removedSession], changed: [] });
 		if (isNewSession(chatSession)) {
 			chatSession.dispose();
@@ -3051,7 +2889,7 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 	 */
 	private _getGroupIdForChat(chat: ICopilotChatSession): string {
 		this._ensureGroupingCaches();
-		return this._groupIdByChatIdCache?.get(chat.id) ?? chat.id;
+		return this._groupIdByChatIdCache?.get(chat.sessionId) ?? chat.sessionId;
 	}
 
 	/**
@@ -3118,13 +2956,18 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 			? this._sessionCache.get(this._localIdFromchatId(firstChatId)) ?? chat
 			: chat;
 
-		const chatsObs = observableFromEvent<readonly IChat[]>(
+		// The primary chat owns the settable `mainChat` observable. When `createNewChat`
+		// commits a new session, it updates `primaryChat.mainChat` so the wrapping ISession
+		// reflects the real backend resource without rebuilding the cached wrapper.
+		const mainChat = primaryChat.mainChat;
+
+		const groupChatsObs = observableFromEvent<readonly IChat[] | undefined>(
 			this,
 			Event.filter(this._onDidGroupMembershipChange.event, e => e.sessionId === sessionId),
 			() => {
 				const chatIds = this._getChatIdsInGroup(sessionId);
 				if (chatIds.length === 0) {
-					return [this._toChat(chat)];
+					return undefined;
 				}
 				const resolved: ICopilotChatSession[] = [];
 				for (const id of chatIds) {
@@ -3134,13 +2977,19 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 					}
 				}
 				if (resolved.length === 0) {
-					return [this._toChat(chat)];
+					return undefined;
 				}
 				return resolved.map(c => this._toChat(c));
 			},
 		);
 
-		const mainChat = this._toChat(primaryChat);
+		// When the group has no resolved chats (typical for a new session before
+		// commit), fall back to the settable `mainChat` so it stays in sync after
+		// `createNewChat` swaps it.
+		const chatsObs: IObservable<readonly IChat[]> = derived(reader => {
+			const groupChats = groupChatsObs.read(reader);
+			return groupChats ?? [mainChat.read(reader)];
+		});
 		const session: ISession = {
 			sessionId,
 			resource: primaryChat.resource,
@@ -3176,12 +3025,12 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 	}
 
 	private _chatToSingleChatSession(chat: ICopilotChatSession): ISession {
-		const mainChat = this._toChat(chat);
-		const chatsObs = constObservable<readonly IChat[]>([mainChat]);
+		const mainChat = chat.mainChat;
+		const chatsObs = mainChat.map(c => [c] as readonly IChat[]);
 		const changesets = this._createChangesets(chat.sessionType, chat.workspace, chatsObs);
 
 		return {
-			sessionId: chat.id,
+			sessionId: chat.sessionId,
 			resource: chat.resource,
 			providerId: chat.providerId,
 			sessionType: chat.sessionType,
@@ -3209,9 +3058,9 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 		};
 	}
 
-	private _toChat(chat: ICopilotChatSession): IChat {
+	private _toChat(chat: ICopilotChatSession, resource?: URI): IChat {
 		return {
-			resource: chat.resource,
+			resource: resource ?? chat.resource,
 			createdAt: chat.createdAt,
 			title: chat.title,
 			updatedAt: chat.updatedAt,

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/copilotChatSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/copilotChatSessionsProvider.test.ts
@@ -35,6 +35,8 @@ import { ChatConfiguration, ChatPermissionLevel } from '../../../../../../workbe
 import { CLAUDE_CODE_ENABLED_SETTING, CopilotChatSessionsProvider, COPILOT_PROVIDER_ID, ClaudeCodeSessionType, ICopilotChatSession } from '../../browser/copilotChatSessionsProvider.js';
 import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
 import { ILabelService } from '../../../../../../platform/label/common/label.js';
+import { IUriIdentityService } from '../../../../../../platform/uriIdentity/common/uriIdentity.js';
+import { extUri } from '../../../../../../base/common/resources.js';
 import { CopilotCLISessionType } from '../../../agentHost/browser/baseAgentHostSessionsProvider.js';
 
 // ---- Helpers ----------------------------------------------------------------
@@ -185,6 +187,7 @@ function createProviderWithConfig(
 	instantiationService.stub(ILabelService, {
 		getUriLabel: (uri: URI) => uri.path,
 	});
+	instantiationService.stub(IUriIdentityService, { extUri });
 
 	const provider = disposables.add(instantiationService.createInstance(CopilotChatSessionsProvider));
 	return { provider, configService };
@@ -257,6 +260,7 @@ function createProviderForSendTests(
 	instantiationService.stub(ILabelService, {
 		getUriLabel: (uri: URI) => uri.path,
 	});
+	instantiationService.stub(IUriIdentityService, { extUri });
 
 	return disposables.add(instantiationService.createInstance(CopilotChatSessionsProvider));
 }
@@ -540,7 +544,7 @@ suite('CopilotChatSessionsProvider', () => {
 
 		assert.strictEqual(sessions.length, 1);
 		assert.strictEqual(sessions[0].chats.get().length, 1);
-		assert.strictEqual(sessions[0].mainChat.resource.toString(), resource.toString());
+		assert.strictEqual(sessions[0].mainChat.get().resource.toString(), resource.toString());
 	});
 
 	test('setModel applies to existing sessions and their new chats', async () => {
@@ -553,7 +557,7 @@ suite('CopilotChatSessionsProvider', () => {
 
 		assert.strictEqual(session.modelId.get(), 'copilot/gpt-4o');
 
-		const chat = provider.addChat(session.sessionId);
+		const chat = await provider.createNewChat(session.sessionId);
 		try {
 			assert.strictEqual(chat.modelId.get(), 'copilot/gpt-4o');
 		} finally {
@@ -561,10 +565,10 @@ suite('CopilotChatSessionsProvider', () => {
 		}
 	});
 
-	test('sendAndCreateChat throws for unknown session', async () => {
+	test('sendRequest throws for unknown session', async () => {
 		const provider = createProvider(disposables, model);
 		await assert.rejects(
-			() => provider.sendAndCreateChat('nonexistent', { query: 'test' }),
+			() => provider.sendRequest('nonexistent', URI.parse('untitled:chat'), { query: 'test' }),
 			/not found/,
 		);
 	});
@@ -604,7 +608,7 @@ suite('CopilotChatSessionsProvider', () => {
 
 		assert.strictEqual(sessions.length, 1);
 		assert.strictEqual(sessions[0].chats.get().length, 3);
-		assert.strictEqual(sessions[0].mainChat.resource.toString(), rootResource.toString());
+		assert.strictEqual(sessions[0].mainChat.get().resource.toString(), rootResource.toString());
 	});
 
 	test('orders chats within a grouped session by createdAt', () => {
@@ -712,7 +716,7 @@ suite('CopilotChatSessionsProvider', () => {
 		const sessions = provider.getSessions();
 
 		assert.ok(sessions[0].mainChat);
-		assert.strictEqual(sessions[0].mainChat.resource.toString(), resource.toString());
+		assert.strictEqual(sessions[0].mainChat.get().resource.toString(), resource.toString());
 	});
 
 	test('deleteSession removes session from model and list', async () => {
@@ -993,7 +997,8 @@ suite('CopilotChatSessionsProvider', () => {
 
 		// Send and commit so the session enters the cache and can be disposed
 		const added = waitForSessionAdded(provider);
-		const sendPromise = provider.sendAndCreateChat(session.sessionId, { query: 'test' });
+		const chat = await provider.createNewChat(session.sessionId);
+		const sendPromise = provider.sendRequest(session.sessionId, chat.resource, { query: 'test' });
 		await added;
 		commitSession();
 		await assert.doesNotReject(sendPromise);
@@ -1005,7 +1010,8 @@ suite('CopilotChatSessionsProvider', () => {
 		const session = provider.createNewSession(workspace, ClaudeCodeSessionType.id);
 
 		const added = waitForSessionAdded(provider);
-		const sendPromise = provider.sendAndCreateChat(session.sessionId, { query: 'test' });
+		const chat1 = await provider.createNewChat(session.sessionId);
+		const sendPromise = provider.sendRequest(session.sessionId, chat1.resource, { query: 'test' });
 		await added;
 
 		await provider.archiveSession(session.sessionId);
@@ -1024,7 +1030,8 @@ suite('CopilotChatSessionsProvider', () => {
 		const session = provider.createNewSession(workspace, ClaudeCodeSessionType.id);
 
 		const added = waitForSessionAdded(provider);
-		const sendPromise = provider.sendAndCreateChat(session.sessionId, { query: 'test' });
+		const chat2 = await provider.createNewChat(session.sessionId);
+		const sendPromise = provider.sendRequest(session.sessionId, chat2.resource, { query: 'test' });
 		await added;
 
 		await provider.archiveSession(session.sessionId);
@@ -1042,7 +1049,7 @@ suite('CopilotChatSessionsProvider', () => {
 
 	// ---- Claude controller-based send flow -------
 
-	test('sendAndCreateChat replaces temp session with committed session on success', async () => {
+	test('sendRequest replaces temp session with committed session on success', async () => {
 		const { provider, commitSession } = makeClaudeInFlightProvider();
 		const workspace = URI.file('/test/project');
 		const session = provider.createNewSession(workspace, ClaudeCodeSessionType.id);
@@ -1051,7 +1058,8 @@ suite('CopilotChatSessionsProvider', () => {
 		disposables.add(provider.onDidReplaceSession(e => replacements.push(e)));
 
 		const added = waitForSessionAdded(provider);
-		const sendPromise = provider.sendAndCreateChat(session.sessionId, { query: 'hello world' });
+		const chat3 = await provider.createNewChat(session.sessionId);
+		const sendPromise = provider.sendRequest(session.sessionId, chat3.resource, { query: 'hello world' });
 		await added;
 
 		assert.strictEqual(provider.getSessions().length, 1, 'temp session should appear while in-flight');
@@ -1064,13 +1072,14 @@ suite('CopilotChatSessionsProvider', () => {
 		assert.ok(replacements.length > 0, 'onDidReplaceSessions should have fired');
 	});
 
-	test('sendAndCreateChat uses the query as the temp session title', async () => {
+	test('sendRequest uses the query as the temp session title', async () => {
 		const { provider, cancelRequest } = makeClaudeInFlightProvider();
 		const workspace = URI.file('/test/project');
 		const session = provider.createNewSession(workspace, ClaudeCodeSessionType.id);
 
 		const added = waitForSessionAdded(provider);
-		const sendPromise = provider.sendAndCreateChat(session.sessionId, { query: 'fix the login bug' });
+		const chat4 = await provider.createNewChat(session.sessionId);
+		const sendPromise = provider.sendRequest(session.sessionId, chat4.resource, { query: 'fix the login bug' });
 		await added;
 
 		const sessions = provider.getSessions();
@@ -1081,13 +1090,14 @@ suite('CopilotChatSessionsProvider', () => {
 		await provider.deleteSession(session.sessionId);
 	});
 
-	test('sendAndCreateChat keeps temp session on cancellation', async () => {
+	test('sendRequest keeps temp session on cancellation', async () => {
 		const { provider, cancelRequest } = makeClaudeInFlightProvider();
 		const workspace = URI.file('/test/project');
 		const session = provider.createNewSession(workspace, ClaudeCodeSessionType.id);
 
 		const added = waitForSessionAdded(provider);
-		const sendPromise = provider.sendAndCreateChat(session.sessionId, { query: 'test' });
+		const chat5 = await provider.createNewChat(session.sessionId);
+		const sendPromise = provider.sendRequest(session.sessionId, chat5.resource, { query: 'test' });
 		await added;
 
 		// Cancel before the agent session appears
@@ -1183,7 +1193,8 @@ suite('CopilotChatSessionsProvider', () => {
 			const sessionId = newSession.sessionId;
 
 			const added = waitForSessionAdded(provider);
-			const sendPromise = provider.sendAndCreateChat(sessionId, { query: 'test' });
+			const chat = await provider.createNewChat(sessionId);
+			const sendPromise = provider.sendRequest(sessionId, chat.resource, { query: 'test' });
 			await added;
 
 			assert.strictEqual(provider.getSessions().length, 1, 'session should appear while in-flight');
@@ -1203,7 +1214,8 @@ suite('CopilotChatSessionsProvider', () => {
 			const sessionId = newSession.sessionId;
 
 			const added = waitForSessionAdded(provider);
-			const sendPromise = provider.sendAndCreateChat(sessionId, { query: 'test' });
+			const chat = await provider.createNewChat(sessionId);
+			const sendPromise = provider.sendRequest(sessionId, chat.resource, { query: 'test' });
 			await added;
 
 			assert.strictEqual(provider.getSessions().length, 1, 'session should appear while in-flight');
@@ -1227,7 +1239,8 @@ suite('CopilotChatSessionsProvider', () => {
 			const sessionId = newSession.sessionId;
 
 			const added = waitForSessionAdded(provider);
-			const sendPromise = provider.sendAndCreateChat(sessionId, { query: 'test' });
+			const chat = await provider.createNewChat(sessionId);
+			const sendPromise = provider.sendRequest(sessionId, chat.resource, { query: 'test' });
 			await added;
 
 			// Stop before commit arrives — session should stay as completed
@@ -1246,107 +1259,6 @@ suite('CopilotChatSessionsProvider', () => {
 			assert.strictEqual(provider.getSessions()[0].isArchived.get(), false, 'session should be unarchived');
 
 			// Clean up to avoid leaked disposable
-			await provider.deleteSession(sessionId);
-		});
-
-		/**
-		 * Returns a provider where the commit event is controllable. The
-		 * caller can fire the commit event at the right moment to simulate
-		 * the session being committed mid-request, then cancel the request
-		 * afterwards. The session should persist after cancellation.
-		 */
-		function makeCommittableProvider(): {
-			provider: CopilotChatSessionsProvider;
-			commitSession: (original: URI, committed: URI) => void;
-			cancelRequest: () => void;
-		} {
-			let resolveComplete!: () => void;
-			let resolveCreated!: (r: IChatResponseModel) => void;
-			const responseCompletePromise = new Promise<void>(r => { resolveComplete = r; });
-			const responseCreatedPromise = new Promise<IChatResponseModel>(r => { resolveCreated = r; });
-
-			const commitEmitter = disposables.add(new Emitter<{ original: URI; committed: URI }>());
-
-			const provider = createProviderForSendTests(disposables, model, async () => ({
-				kind: 'sent' as const,
-				data: {
-					responseCompletePromise,
-					responseCreatedPromise,
-					agent: new class extends mock<IChatAgentData>() { }(),
-				} as IChatSendRequestData,
-			}), { onDidCommitSession: commitEmitter.event });
-
-			return {
-				provider,
-				commitSession: (original, committed) => commitEmitter.fire({ original, committed }),
-				cancelRequest: () => {
-					resolveCreated({ isCanceled: true } as unknown as IChatResponseModel);
-					resolveComplete();
-				},
-			};
-		}
-
-		test('stopping a committed session keeps it in the list', async () => {
-			const { provider, commitSession, cancelRequest } = makeCommittableProvider();
-
-			const newSession = provider.createNewSession(workspace, CopilotCLISessionType.id);
-			const sessionId = newSession.sessionId;
-
-			const added = waitForSessionAdded(provider);
-			const sendPromise = provider.sendAndCreateChat(sessionId, { query: 'test' });
-			await added;
-
-			assert.strictEqual(provider.getSessions().length, 1, 'session should appear while in-flight');
-
-			// Get the temp session's resource so we can fire the commit event
-			const tempSession = provider.getSessions()[0];
-			const tempResource = tempSession.resource;
-
-			// Simulate commit: the agent created the worktree, so the URI
-			// swaps from untitled to a real committed resource.
-			const committedResource = URI.from({ scheme: AgentSessionProviders.Background, path: `/committed-${Date.now()}` });
-			const committedAgentSession = createMockAgentSession(committedResource);
-			model.addSession(committedAgentSession);
-			commitSession(tempResource, committedResource);
-
-			// _sendFirstChat should complete successfully now
-			await sendPromise;
-
-			assert.strictEqual(provider.getSessions().length, 1, 'committed session should remain in list');
-
-			// Now cancel the request — session must stay
-			cancelRequest();
-
-			assert.strictEqual(provider.getSessions().length, 1, 'committed session should persist after stopping');
-		});
-
-		test('cancelling the request before commit keeps the session with completed status', async () => {
-			const { provider, cancelRequest } = makeInFlightProvider();
-
-			const changes: ISessionChangeEvent[] = [];
-			disposables.add(provider.onDidChangeSessions(e => changes.push(e)));
-
-			const newSession = provider.createNewSession(workspace, CopilotCLISessionType.id);
-			const sessionId = newSession.sessionId;
-
-			const added = waitForSessionAdded(provider);
-			const sendPromise = provider.sendAndCreateChat(sessionId, { query: 'test' });
-			await added;
-
-			assert.strictEqual(provider.getSessions().length, 1, 'session should appear while in-flight');
-			assert.ok(changes.some(e => e.added.some(s => s.sessionId === sessionId)), 'added event should have fired');
-
-			// Simulate user stopping the request
-			cancelRequest();
-			await sendPromise;
-
-			assert.strictEqual(provider.getSessions().length, 1, 'session should stay in list after cancellation');
-			assert.ok(
-				changes.some(e => e.changed.some(s => s.sessionId === sessionId)),
-				'changed event should have fired',
-			);
-
-			// Clean up the kept session so it doesn't leak
 			await provider.deleteSession(sessionId);
 		});
 	});

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/remoteAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/remoteAgentHostSessionsProvider.test.ts
@@ -877,15 +877,15 @@ suite('RemoteAgentHostSessionsProvider', () => {
 		);
 	}));
 
-	test('sendAndCreateChat throws for unknown session', async () => {
+	test('sendRequest throws for unknown session', async () => {
 		const provider = createProvider(disposables, connection);
 		await assert.rejects(
-			() => provider.sendAndCreateChat('nonexistent', { query: 'test' }),
+			() => provider.sendRequest('nonexistent', URI.parse('untitled:chat'), { query: 'test' }),
 			/not found or not a new session/,
 		);
 	});
 
-	test('sendAndCreateChat forwards resolved session config to chat service', async () => {
+	test('sendRequest forwards resolved session config to chat service', async () => {
 		const sendOptions: IChatSendRequestOptions[] = [];
 		const provider = createProvider(disposables, connection, {
 			openSession: true,
@@ -900,7 +900,8 @@ suite('RemoteAgentHostSessionsProvider', () => {
 		const session = provider.createNewSession(URI.parse('vscode-agent-host://auth/home/user/project'), provider.sessionTypes[0].id);
 		await timeout(0);
 
-		await provider.sendAndCreateChat(session.sessionId, { query: 'hello' });
+		const chat = await provider.createNewChat(session.sessionId);
+		await provider.sendRequest(session.sessionId, chat.resource, { query: 'hello' });
 
 		assert.deepStrictEqual(sendOptions.map(options => options.agentHostSessionConfig), [{ isolation: 'worktree' }]);
 	});

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
@@ -672,7 +672,7 @@ registerAction2(class RenameSessionAction extends Action2 {
 		if (newTitle) {
 			const trimmedTitle = newTitle.trim();
 			if (trimmedTitle) {
-				await sessionsManagementService.renameChat(session, session.mainChat.resource, trimmedTitle);
+				await sessionsManagementService.renameChat(session, session.mainChat.get().resource, trimmedTitle);
 			}
 		}
 	}
@@ -896,6 +896,6 @@ registerAction2(class AddChatAction extends Action2 {
 			return;
 		}
 
-		sessionsManagementService.openNewChatInSession(activeSession);
+		await sessionsManagementService.openNewChatInSession(activeSession);
 	}
 });

--- a/src/vs/sessions/contrib/sessions/test/browser/sessionsList.test.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/sessionsList.test.ts
@@ -47,7 +47,7 @@ function createSession(id: string, opts: {
 		description: observableValue(`description-${id}`, undefined),
 		lastTurnEnd: observableValue(`lastTurnEnd-${id}`, undefined),
 		chats: observableValue<readonly IChat[]>(`chats-${id}`, []),
-		mainChat: undefined!,
+		mainChat: observableValue<IChat>(`mainChat-${id}`, undefined!),
 		capabilities: { supportsMultipleChats: false },
 	};
 }

--- a/src/vs/sessions/contrib/sessions/test/browser/sessionsListModelService.test.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/sessionsListModelService.test.ts
@@ -43,7 +43,7 @@ function createSession(id: string, status: SessionStatus = SessionStatus.Complet
 		description: observableValue(`description-${id}`, undefined),
 		lastTurnEnd: observableValue(`lastTurnEnd-${id}`, undefined),
 		chats: observableValue<readonly IChat[]>(`chats-${id}`, []),
-		mainChat: undefined!,
+		mainChat: constObservable<IChat>(undefined!),
 		capabilities: { supportsMultipleChats: false },
 	};
 }
@@ -361,7 +361,7 @@ suite('SessionsListModelService', () => {
 		service.markRead(session);
 
 		// Make session the active one
-		activeSession.set({ ...session, activeChat: constObservable(session.mainChat) }, undefined);
+		activeSession.set({ ...session, activeChat: constObservable(session.mainChat.get()) }, undefined);
 
 		// Seed the last-known status as InProgress
 		sessionsChangedEmitter.fire({ added: [], removed: [], changed: [session] });

--- a/src/vs/sessions/contrib/terminal/test/browser/agentHostSessionTaskRunner.test.ts
+++ b/src/vs/sessions/contrib/terminal/test/browser/agentHostSessionTaskRunner.test.ts
@@ -61,7 +61,7 @@ function makeSession(opts: { providerId: string; cwd?: URI }): ISession {
 		lastTurnEnd: observableValue('lastTurnEnd', undefined),
 		description: observableValue('description', undefined),
 		chats: observableValue('chats', [chat]),
-		mainChat: chat,
+		mainChat: constObservable(chat),
 		capabilities: { supportsMultipleChats: false },
 	};
 }

--- a/src/vs/sessions/contrib/terminal/test/browser/sessionsTerminalContribution.test.ts
+++ b/src/vs/sessions/contrib/terminal/test/browser/sessionsTerminalContribution.test.ts
@@ -110,7 +110,7 @@ function makeAgentSession(opts: {
 		description: chat.description,
 		chats: observableValue('test.chats', [chat]),
 		activeChat: observableValue('test.activeChat', chat),
-		mainChat: chat,
+		mainChat: constObservable(chat),
 		capabilities: { supportsMultipleChats: false },
 	} satisfies TestActiveSession;
 	return session;
@@ -167,7 +167,7 @@ function makeNonAgentSession(opts: { repository?: URI; worktree?: URI; providerT
 		lastTurnEnd: chat.lastTurnEnd,
 		description: chat.description,
 		chats: observableValue('test.chats', [chat]),
-		mainChat: chat,
+		mainChat: constObservable(chat),
 		capabilities: { supportsMultipleChats: false },
 	} satisfies ISession;
 	return session;

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -416,7 +416,7 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 
 			// Ask the provider to create the new chat; open its widget before sending
 			const chat = await provider.createNewChat(session.sessionId, options.query);
-			await this.chatWidgetService.openSession(chat.resource);
+			await this.chatWidgetService.openSession(chat.resource, ChatViewPaneTarget);
 
 			const updatedSession = await provider.sendRequest(session.sessionId, chat.resource, options);
 			if (updatedSession.sessionId !== session.sessionId && this._activeSession.get()?.sessionId === session.sessionId) {

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -386,7 +386,7 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 		return session;
 	}
 
-	async sendAndCreateChat(session: ISession, options: ISendRequestOptions): Promise<void> {
+	async sendNewChatRequest(session: ISession, options: ISendRequestOptions): Promise<void> {
 		this._pendingNewSession = undefined;
 		this.isNewChatSessionContext.set(false);
 		this._isNewChatInSessionContext.set(false);
@@ -413,9 +413,14 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 			if (!provider) {
 				throw new Error(`Sessions provider '${session.providerId}' not found`);
 			}
-			const updatedSession = await provider.sendAndCreateChat(session.sessionId, options);
+
+			// Ask the provider to create the new chat; open its widget before sending
+			const chat = await provider.createNewChat(session.sessionId, options.query);
+			await this.chatWidgetService.openSession(chat.resource);
+
+			const updatedSession = await provider.sendRequest(session.sessionId, chat.resource, options);
 			if (updatedSession.sessionId !== session.sessionId && this._activeSession.get()?.sessionId === session.sessionId) {
-				this.logService.info(`[SessionsManagement] sendAndCreateChat: active session replaced: ${session.sessionId} -> ${updatedSession.sessionId}`);
+				this.logService.info(`[SessionsManagement] sendRequest: active session replaced: ${session.sessionId} -> ${updatedSession.sessionId}`);
 				this.setActiveSession(updatedSession);
 				setActiveChatToLast();
 			}
@@ -466,7 +471,7 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 		}
 	}
 
-	openNewChatInSession(session: ISession): void {
+	async openNewChatInSession(session: ISession): Promise<void> {
 		this._startOpenSession();
 		const provider = this._getProvider(session);
 		if (!provider) {
@@ -476,7 +481,9 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 
 		// Reuse an existing untitled chat if one exists, otherwise create a new one
 		const existingUntitled = session.chats.get().find(c => c.status.get() === SessionStatus.Untitled);
-		const chat = existingUntitled ?? provider.addChat(session.sessionId);
+		const chat = existingUntitled ?? await provider.createNewChat(session.sessionId);
+
+		await this.chatWidgetService.openSession(chat.resource, ChatViewPaneTarget);
 
 		this.setActiveSession(session);
 
@@ -565,16 +572,18 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 			}));
 
 			// Track chat list changes — if the active chat is removed, fall back
-			this._activeSessionDisposables.add(autorun(reader => {
-				const chats = session.chats.read(reader);
-				const activeChat = activeChatObs.read(reader);
-				if (activeChat && !chats.some(c => this.uriIdentityService.extUri.isEqual(c.resource, activeChat.resource))) {
-					const fallback = chats[chats.length - 1] ?? session.mainChat;
-					if (fallback) {
-						this.openChat(session, fallback.resource);
+			if (session.status.get() !== SessionStatus.Untitled) {
+				this._activeSessionDisposables.add(autorun(reader => {
+					const chats = session.chats.read(reader);
+					const activeChat = activeChatObs.read(reader);
+					if (activeChat && !chats.some(c => this.uriIdentityService.extUri.isEqual(c.resource, activeChat.resource))) {
+						const fallback = chats[chats.length - 1] ?? session.mainChat.read(reader);
+						if (fallback) {
+							this.openChat(session, fallback.resource);
+						}
 					}
-				}
-			}));
+				}));
+			}
 
 			// Track active chat changes to persist per-session state
 			this._activeSessionDisposables.add(autorun(reader => {

--- a/src/vs/sessions/services/sessions/common/session.ts
+++ b/src/vs/sessions/services/sessions/common/session.ts
@@ -269,8 +269,8 @@ export interface ISession {
 	readonly lastTurnEnd: IObservable<Date | undefined>;
 	/** The chats belonging to this session group. */
 	readonly chats: IObservable<readonly IChat[]>;
-	/** The main (first) chat of this session. */
-	readonly mainChat: IChat;
+	/** The main (first) chat of this session. Providers may replace it for a new session via {@link ISessionsProvider.createNewChat}. */
+	readonly mainChat: IObservable<IChat>;
 	/** Capabilities of this session. */
 	readonly capabilities: ISessionCapabilities;
 }

--- a/src/vs/sessions/services/sessions/common/sessionsManagement.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsManagement.ts
@@ -162,7 +162,7 @@ export interface ISessionsManagementService {
 	/**
 	 * Send a request, creating a new chat in the session.
 	 */
-	sendAndCreateChat(session: ISession, options: ISendRequestOptions): Promise<void>;
+	sendNewChatRequest(session: ISession, options: ISendRequestOptions): Promise<void>;
 
 	/**
 	 * Send a request for an existing chat within a session.
@@ -174,7 +174,7 @@ export interface ISessionsManagementService {
 	 * Adds a new chat to the session via the provider, makes it the active chat,
 	 * and shows a rich input for composing a message.
 	 */
-	openNewChatInSession(session: ISession): void;
+	openNewChatInSession(session: ISession): Promise<void>;
 
 	/** Navigate to the previous session in the navigation history. */
 	openPreviousSession(): Promise<void>;

--- a/src/vs/sessions/services/sessions/common/sessionsProvider.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsProvider.ts
@@ -152,23 +152,16 @@ export interface ISessionsProvider {
 	deleteChat(sessionId: string, chatUri: URI): Promise<void>;
 
 	/**
-	 * Send a request to a session and create a new chat with the response.
-	 * @param sessionId The ID of the session to send the request to.
-	 * @param options Options for the request, including the query and any attached context entries.
+	 * Create a new chat in the given session and return it.
+	 *
+	 * @param sessionId The ID of the session to create the new chat in.
+	 * @param prompt Optional prompt to initialize the new chat with.
 	 */
-	sendAndCreateChat(sessionId: string, options: ISendRequestOptions): Promise<ISession>;
+	createNewChat(sessionId: string, prompt?: string): Promise<IChat>;
 
 	/**
-	 * Add a new empty chat to an existing session without sending a request.
-	 * The new chat is registered in the group model and can be used to compose
-	 * a message before sending.
-	 * @param sessionId The ID of the session to add a chat to.
-	 * @returns The newly created chat.
-	 */
-	addChat(sessionId: string): IChat;
-
-	/**
-	 * Send a request for an existing chat within a session.
+	 * Send a request for a chat within a session.
+	 *
 	 * @param sessionId The ID of the session containing the chat.
 	 * @param chatResource The resource URI of the chat to send the request for.
 	 * @param options Options for the request, including the query and any attached context entries.

--- a/src/vs/sessions/services/sessions/test/browser/sessionNavigation.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionNavigation.test.ts
@@ -74,7 +74,7 @@ function stubSession(id: string, status: SessionStatus = SessionStatus.Completed
 		description: constObservable(undefined),
 		lastTurnEnd: constObservable(undefined),
 		chats: constObservable(sessionChats),
-		mainChat: sessionChats[0],
+		mainChat: constObservable(sessionChats[0]),
 		capabilities: { supportsMultipleChats: chats !== undefined && chats.length > 1 },
 	};
 }
@@ -159,9 +159,9 @@ class MockSessionStore implements ISessionsManagementService {
 	restoreLastActiveSession(): Promise<void> { throw new Error('not implemented'); }
 	createNewSession(_folderUri: URI, _options?: ICreateNewSessionOptions): ISession { throw new Error('not implemented'); }
 	unsetNewSession(): void { throw new Error('not implemented'); }
-	sendAndCreateChat(_session: ISession, _options: ISendRequestOptions): Promise<void> { throw new Error('not implemented'); }
+	sendNewChatRequest(_session: ISession, _options: ISendRequestOptions): Promise<void> { throw new Error('not implemented'); }
 	sendRequest(_session: ISession, _chat: IChat, _options: ISendRequestOptions): Promise<void> { throw new Error('not implemented'); }
-	openNewChatInSession(_session: ISession): void { throw new Error('not implemented'); }
+	openNewChatInSession(_session: ISession): Promise<void> { throw new Error('not implemented'); }
 	openPreviousSession(): Promise<void> { throw new Error('not implemented'); }
 	openNextSession(): Promise<void> { throw new Error('not implemented'); }
 	archiveSession(_session: ISession): Promise<void> { throw new Error('not implemented'); }

--- a/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
@@ -65,7 +65,7 @@ function stubSession(overrides: Partial<ISession> & Pick<ISession, 'sessionId' |
 		description: constObservable(undefined),
 		lastTurnEnd: constObservable(undefined),
 		chats: constObservable([]),
-		mainChat: stubChat,
+		mainChat: constObservable(stubChat),
 		capabilities: { supportsMultipleChats: false },
 		...overrides,
 	};
@@ -170,9 +170,8 @@ class TestSessionsProvider extends mock<ISessionsProvider>() {
 	override async unarchiveSession(): Promise<void> { }
 	override async deleteSession(): Promise<void> { }
 	override async deleteChat(): Promise<void> { }
-	override async sendAndCreateChat(): Promise<ISession> { return this._session; }
-	override addChat(): IChat { return this._session.mainChat; }
 	override async sendRequest(_sessionId: string, _chatResource: URI, _options: ISendRequestOptions): Promise<ISession> { return this._session; }
+	override async createNewChat(): Promise<IChat> { return this._session.mainChat.get(); }
 }
 
 function createSessionsManagementService(session: ISession, disposables: ReturnType<typeof ensureNoDisposablesAreLeakedInTestSuite>): { service: ISessionsManagementService; chatWidgetService: TestChatWidgetService; agentSessionsService: TestAgentSessionsService } {


### PR DESCRIPTION
Cleans up `ISessionsProvider` and the management-service send flow so providers own only backend chat lifecycle, and the management service is the sole owner of widget opening.

## Provider API
- Remove `sendAndCreateChat` and `addChat` from `ISessionsProvider`.
- Add `createNewChat(sessionId)` that returns the committed `IChat`, so the management service can open the widget on the real backend resource *before* sending.
- `sendRequest(sessionId, chatResource, options)` now handles both first-send (new session) and subsequent-send paths; providers dispatch internally based on `_currentNewSession`.
- For multi-chat sessions, `createNewChat` on an existing session gates on `_isMultiChatEnabled()` and creates a fresh chat in the group.

## Session model
- `ISession.mainChat` changes from `IChat` to `IObservable<IChat>` so providers can swap the chat when an untitled new session commits to a real backend resource (e.g. Claude).
- `ICopilotChatSession` owns its own `ISettableObservable<IChat>` `mainChat` field; the provider no longer keeps a parallel `_mainChatBySessionId` map.

## Management service
- `sendNewChatRequest` (renamed from `sendAndCreateChat`) calls `createNewChat`, opens the widget on the returned `chat.resource`, then calls `sendRequest`.
- `openNewChatInSession` is now async and opens the widget after `createNewChat` returns.

## Copilot provider
- Drops the `IChatWidgetService` injection — the provider never opens widgets directly.
- Drops `userSelectedTools` from the local send path (no widget available there).

## Spec updates
- `SESSIONS.md`: documents two new interface-design rules:
  1. `ISessionsProvider` must have no optional methods.
  2. Every addition to `ISession` or `ISessionsProvider` must be consumed in the agents-window core workbench (anything outside `contrib/providers/`).
- `COPILOT_CHAT_SESSIONS_PROVIDER.md`: send-flow section rewritten to describe the new `createNewChat` + `sendRequest` two-step contract.

## Validation
- `npm run compile-check-ts-native` — clean (sessions code; only pre-existing unrelated `proxyResolver.ts` errors remain).
- `npm run valid-layers-check` — clean.
- `scripts/test.sh --glob "**/sessions/**/*.test.js"` — 753 passing.