### PR TITLE
Send enhanced NES `provideInlineEdit` telemetry from chat-lib

### DIFF
--- a/extensions/copilot/src/extension/inlineEdits/node/nextEditProviderTelemetry.ts
+++ b/extensions/copilot/src/extension/inlineEdits/node/nextEditProviderTelemetry.ts
@@ -961,6 +961,15 @@ export class TelemetrySender implements IDisposable {
 				this._removeEntry(nextEditResult, data);
 			}
 		}
+		this.sendTelemetryForBuilderWithEnhanced(builder);
+	}
+
+	/**
+	 * Send both the non-enhanced and enhanced telemetry events for this builder immediately.
+	 * Use this when there is no {@link INextEditResult} lifecycle (e.g. a chat-lib host) and no
+	 * idle/jump scheduling is needed.
+	 */
+	public sendTelemetryForBuilderWithEnhanced(builder: NextEditProviderTelemetryBuilder): void {
 		const telemetry = builder.build(true);
 		if (!builder.isSent) {
 			this._doSendTelemetry(telemetry);

--- a/extensions/copilot/src/lib/node/chatLibMain.ts
+++ b/extensions/copilot/src/lib/node/chatLibMain.ts
@@ -281,7 +281,7 @@ class NESProvider extends Disposable implements INESProvider<NESResult> {
 
 	private handleEndOfLifetime(result: NESResult): void {
 		try {
-			this._telemetrySender.sendTelemetry(undefined, result.telemetryBuilder);
+			this._telemetrySender.sendTelemetryForBuilderWithEnhanced(result.telemetryBuilder);
 		} finally {
 			result.telemetryBuilder.dispose();
 		}
@@ -335,7 +335,7 @@ class NESProvider extends Disposable implements INESProvider<NESResult> {
 			return result;
 		} catch (e) {
 			try {
-				this._telemetrySender.sendTelemetry(undefined, telemetryBuilder);
+				this._telemetrySender.sendTelemetryForBuilderWithEnhanced(telemetryBuilder);
 			} finally {
 				telemetryBuilder.dispose();
 			}

--- a/extensions/copilot/src/lib/node/chatLibMain.ts
+++ b/extensions/copilot/src/lib/node/chatLibMain.ts
@@ -281,7 +281,7 @@ class NESProvider extends Disposable implements INESProvider<NESResult> {
 
 	private handleEndOfLifetime(result: NESResult): void {
 		try {
-			this._telemetrySender.sendTelemetryForBuilder(result.telemetryBuilder);
+			this._telemetrySender.sendTelemetry(undefined, result.telemetryBuilder);
 		} finally {
 			result.telemetryBuilder.dispose();
 		}
@@ -335,7 +335,7 @@ class NESProvider extends Disposable implements INESProvider<NESResult> {
 			return result;
 		} catch (e) {
 			try {
-				this._telemetrySender.sendTelemetryForBuilder(telemetryBuilder);
+				this._telemetrySender.sendTelemetry(undefined, telemetryBuilder);
 			} finally {
 				telemetryBuilder.dispose();
 			}


### PR DESCRIPTION
### Problem
When chat-lib hosts the NES (next edit suggestions) provider, the host's `ITelemetrySender.sendEnhancedTelemetryEvent` callback only ever received `engine.*` events (emitted directly from `chatStream.ts`). The enhanced `copilot-nes/provideInlineEdit` event was missing, even though the non-enhanced version of the same event was being delivered correctly.

### Root cause
`TelemetrySender` in `nextEditProviderTelemetry.ts` exposes two public methods for emitting telemetry at the end of a suggestion's lifetime:

| Method | non-enhanced (`_doSendTelemetry`) | enhanced (`_doSendEnhancedTelemetry`) |
|---|---|---|
| `sendTelemetryForBuilder(builder)` | ✅ | ❌ |
| `sendTelemetry(result, builder)` | ✅ | ✅ |

chat-lib's `NESProvider` was calling `sendTelemetryForBuilder` from `handleEndOfLifetime` (and from the `getNextEdit` catch block), so `_doSendEnhancedTelemetry` was never reached.

The main copilot extension reaches `_doSendEnhancedTelemetry` via `scheduleSendingEnhancedTelemetry`, which adds idle-detection / cursor-jump / hard-cap timers. chat-lib doesn't need that machinery — it just needs both events to fire immediately when the suggestion ends.

### Fix
Add a dedicated `sendTelemetryForBuilderWithEnhanced(builder)` method on `TelemetrySender` that emits both the non-enhanced and enhanced events for a builder, with no `INextEditResult` lifecycle and no idle/jump scheduling. chat-lib's two end-of-lifetime call sites now use it. `sendTelemetry(result, builder)` is refactored to delegate to the new helper after handling its result-cleanup branch, so the main extension's behavior is unchanged.

### Result
Hosts that implement `sendEnhancedTelemetryEvent` now receive `copilot-nes/provideInlineEdit` on the enhanced channel alongside the existing `engine.messages` / `engine.messages.length` events.