### PR TITLE
fix(chat): add JSON schema type and validation for chatLanguageModels configuration

### DIFF
--- a/extensions/configuration-editing/package.json
+++ b/extensions/configuration-editing/package.json
@@ -133,6 +133,14 @@
         "url": "vscode://schemas/tasks"
       },
       {
+        "fileMatch": "%APP_SETTINGS_HOME%/chatLanguageModels.json",
+        "url": "vscode://schemas/language-models"
+      },
+      {
+        "fileMatch": "%APP_SETTINGS_HOME%/profiles/*/chatLanguageModels.json",
+        "url": "vscode://schemas/language-models"
+      },
+      {
         "fileMatch": "%APP_SETTINGS_HOME%/snippets/*.json",
         "url": "vscode://schemas/snippets"
       },

--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -1737,6 +1737,7 @@
         "vendor": "anthropic",
         "displayName": "Anthropic",
         "configuration": {
+          "type": "object",
           "properties": {
             "apiKey": {
               "type": "string",
@@ -1754,6 +1755,7 @@
         "vendor": "xai",
         "displayName": "xAI",
         "configuration": {
+          "type": "object",
           "properties": {
             "apiKey": {
               "type": "string",
@@ -1771,6 +1773,7 @@
         "vendor": "gemini",
         "displayName": "Google",
         "configuration": {
+          "type": "object",
           "properties": {
             "apiKey": {
               "type": "string",
@@ -1788,6 +1791,7 @@
         "vendor": "openrouter",
         "displayName": "OpenRouter",
         "configuration": {
+          "type": "object",
           "properties": {
             "apiKey": {
               "type": "string",
@@ -1805,6 +1809,7 @@
         "vendor": "openai",
         "displayName": "OpenAI",
         "configuration": {
+          "type": "object",
           "properties": {
             "apiKey": {
               "type": "string",


### PR DESCRIPTION
Adds JSON schema associations for chatLanguageModels.json profile files so the language models configuration file receives schema-backed IntelliSense, validation, and completions when opened directly.

Also normalizes native BYOK provider configuration schemas in the Copilot extension by declaring their API-key configuration blocks as explicit objects.