### PR TITLE
Expose agent sandbox advanced runtime setting

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
@@ -740,10 +740,11 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 		restricted: true,
 	},
 	[TerminalChatAgentToolsSettingId.AgentSandboxAdvancedRuntime]: {
-		included: false,
 		markdownDescription: localize('agentSandbox.runtimeSetting', "Note: this setting is applicable only when {0} is enabled. Key/value pairs are passed through to the root of the sandbox runtime configuration.", `\`#${AgentSandboxSettingId.AgentSandboxEnabled}#\``),
 		type: 'object',
-		default: {},
+		default: {
+			enableWeakerNestedSandbox: false
+		},
 		additionalProperties: true,
 		tags: ['preview'],
 		restricted: true,


### PR DESCRIPTION
## Summary
- Expose `chat.agent.sandbox.advanced.runtime` in settings by allowing the configuration entry to be included.
- Add a discoverable default for `enableWeakerNestedSandbox` set to `false` so users can opt in through settings.
```

  "chat.agent.sandbox.advanced.runtime": {  
    "enableWeakerNestedSandbox": true,
  },
```

Fixes #316705