### PR TITLE
debug: prevent run and debug action item from overflowing

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/media/debugViewlet.css
+++ b/src/vs/workbench/contrib/debug/browser/media/debugViewlet.css
@@ -25,11 +25,27 @@
 	border: 1px solid white;
 }
 
+.monaco-workbench .part > .title > .title-actions:has(.start-debug-action-item) {
+	min-width: 0;
+	overflow: hidden;
+}
+
 .monaco-workbench .part > .title > .title-actions .start-debug-action-item {
 	display: flex;
 	align-items: center;
 	line-height: 20px;
 	flex-shrink: 1;
+	min-width: 0;
+}
+
+.monaco-workbench .monaco-action-bar .actions-container > .action-item.start-debug-action-item {
+	min-width: 0;
+	flex-shrink: 1;
+	overflow: hidden;
+}
+
+.monaco-workbench .monaco-action-bar .actions-container > .action-item.start-debug-action-item ~ .action-item {
+	flex-shrink: 0;
 }
 
 .monaco-workbench.mac .part > .title > .title-actions .start-debug-action-item {
@@ -53,7 +69,7 @@
 .monaco-workbench .monaco-action-bar .start-debug-action-item .configuration {
 	display: flex;
 	align-items: stretch;
-	min-width: 90px;
+	min-width: 0;
 	overflow: hidden;
 }
 
@@ -87,6 +103,7 @@
 	text-overflow: ellipsis;
 	flex: 1;
 	min-width: 0;
+	font-size: 12px;
 }
 
 .monaco-workbench .monaco-action-bar .start-debug-action-item .configuration .monaco-dropdown > .dropdown-label .codicon-chevron-down {


### PR DESCRIPTION
- The launch configuration name in the Run and Debug view title could grow wider than the title bar, pushing the dropdown past the sidebar edge instead of getting clipped or truncated.
- The flex chain inside `.title-actions` could not shrink because the block-level `.monaco-toolbar` / `.monaco-action-bar` wrappers propagated the action item's intrinsic min-content (a long launch configuration name) up to `.title-actions`, so its `min-width: auto` kept it at full content width.
- Constrain `.title-actions` with `min-width: 0` and `overflow: hidden` (scoped via `:has(.start-debug-action-item)`) so the inner flex layout has a finite width, and propagate `min-width: 0` down the chain so the label can ellipsize. Sibling action items keep their natural size via `flex-shrink: 0`.
- Drop the configuration's `min-width: 90px` so the dropdown contents are the first to shrink, and reduce the label to 12px to better match the surrounding title row.

Fixes no issue

(Commit message generated by Copilot)