### PR TITLE
Defer Copilot Steering Consumption Signals

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -348,6 +348,8 @@ export class CopilotAgentSession extends Disposable {
 	private _wrapper!: CopilotSessionWrapper;
 	/** Last agent mode pushed to the SDK via {@link applyMode}, to elide redundant `rpc.mode.set` calls. */
 	private _lastAppliedMode: CopilotSdkMode | undefined;
+	private readonly _steeringMessagesInFlight = new Set<string>();
+	private readonly _consumedSteeringMessages = new Set<string>();
 
 	/** Snapshot captured at session creation for refresh detection. */
 	private readonly _appliedSnapshot: IActiveClientSnapshot;
@@ -449,6 +451,26 @@ export class CopilotAgentSession extends Disposable {
 			action,
 			parentToolCallId,
 		});
+		if (action.type === ActionType.SessionToolCallStart && !parentToolCallId) {
+			this._flushConsumedSteeringMessages();
+		} else if (action.type === ActionType.SessionTurnComplete) {
+			this._flushConsumedSteeringMessages();
+		}
+	}
+
+	private _flushConsumedSteeringMessages(): void {
+		if (this._consumedSteeringMessages.size === 0) {
+			return;
+		}
+		const ids = [...this._consumedSteeringMessages];
+		this._consumedSteeringMessages.clear();
+		for (const id of ids) {
+			this._onDidSessionProgress.fire({
+				kind: 'steering_consumed',
+				session: this.sessionUri,
+				id,
+			});
+		}
 	}
 
 	private _parentToolCallIdForSubagentEvent(e: { readonly agentId?: string }): string | undefined {
@@ -799,19 +821,21 @@ export class CopilotAgentSession extends Disposable {
 	}
 
 	async sendSteering(steeringMessage: PendingMessage): Promise<void> {
+		if (this._steeringMessagesInFlight.has(steeringMessage.id) || this._consumedSteeringMessages.has(steeringMessage.id)) {
+			return;
+		}
+		this._steeringMessagesInFlight.add(steeringMessage.id);
 		this._logService.info(`[Copilot:${this.sessionId}] Sending steering message: "${steeringMessage.userMessage.text.substring(0, 100)}"`);
 		try {
 			await this._wrapper.session.send({
 				prompt: steeringMessage.userMessage.text,
 				mode: 'immediate',
 			});
-			this._onDidSessionProgress.fire({
-				kind: 'steering_consumed',
-				session: this.sessionUri,
-				id: steeringMessage.id,
-			});
+			this._consumedSteeringMessages.add(steeringMessage.id);
 		} catch (err) {
 			this._logService.error(`[Copilot:${this.sessionId}] Steering message failed`, err);
+		} finally {
+			this._steeringMessagesInFlight.delete(steeringMessage.id);
 		}
 	}
 
@@ -842,6 +866,7 @@ export class CopilotAgentSession extends Disposable {
 	async abort(): Promise<void> {
 		this._logService.info(`[Copilot:${this.sessionId}] Aborting session...`);
 		this._denyPendingPermissions();
+		this._flushConsumedSteeringMessages();
 		await this._wrapper.session.abort();
 	}
 

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -887,13 +887,57 @@ suite('CopilotAgentSession', () => {
 
 	suite('sendSteering', () => {
 
-		test('fires steering_consumed after send resolves', async () => {
-			const { session, signals } = await createAgentSession(disposables);
+		test('fires steering_consumed after send resolves and the next tool starts', async () => {
+			const { session, mockSession, signals } = await createAgentSession(disposables);
 
 			await session.sendSteering({ id: 'steer-1', userMessage: { text: 'focus on tests' } });
 
+			let consumed = signals.find(s => s.kind === 'steering_consumed');
+			assert.strictEqual(consumed, undefined, 'should keep steering visible after the SDK send resolves');
+
+			mockSession.fire('tool.execution_start', {
+				toolCallId: 'tc-steer',
+				toolName: 'bash',
+				arguments: { command: 'echo hi' },
+			} as SessionEventPayload<'tool.execution_start'>['data']);
+
+			consumed = signals.find(s => s.kind === 'steering_consumed');
+			assert.ok(consumed, 'should fire steering_consumed signal after the next tool starts');
+			assert.strictEqual((consumed as { id: string }).id, 'steer-1');
+		});
+
+		test('fires steering_consumed after send resolves and the turn ends without a tool', async () => {
+			const { session, mockSession, signals } = await createAgentSession(disposables);
+
+			await session.sendSteering({ id: 'steer-1', userMessage: { text: 'focus on tests' } });
+
+			let consumed = signals.find(s => s.kind === 'steering_consumed');
+			assert.strictEqual(consumed, undefined, 'should keep steering visible after the SDK send resolves');
+
+			mockSession.fire('session.idle', {} as SessionEventPayload<'session.idle'>['data']);
+
+			consumed = signals.find(s => s.kind === 'steering_consumed');
+			assert.ok(consumed, 'should fire steering_consumed signal after the turn ends');
+			assert.strictEqual((consumed as { id: string }).id, 'steer-1');
+		});
+
+		test('does not send the same steering message again before it is flushed', async () => {
+			const { session, mockSession } = await createAgentSession(disposables);
+
+			await session.sendSteering({ id: 'steer-1', userMessage: { text: 'focus on tests' } });
+			await session.sendSteering({ id: 'steer-1', userMessage: { text: 'focus on tests' } });
+
+			assert.strictEqual(mockSession.sendRequests.length, 1);
+		});
+
+		test('fires steering_consumed on abort after send resolves', async () => {
+			const { session, signals } = await createAgentSession(disposables);
+
+			await session.sendSteering({ id: 'steer-1', userMessage: { text: 'focus on tests' } });
+			await session.abort();
+
 			const consumed = signals.find(s => s.kind === 'steering_consumed');
-			assert.ok(consumed, 'should fire steering_consumed signal');
+			assert.ok(consumed, 'should fire steering_consumed signal when the turn is aborted');
 			assert.strictEqual((consumed as { id: string }).id, 'steer-1');
 		});
 


### PR DESCRIPTION
This moves Copilot steering consumption signaling into `CopilotAgentSession` so steering messages stay visible until the Copilot SDK response resumes with a top-level tool call or the turn completes.

Summary:
- Deduplicate in-flight and already-consumed steering messages before sending to the SDK.
- Flush deferred `steering_consumed` signals on the next top-level tool start, turn completion, or abort.
- Add focused tests for deferred flushing, duplicate sends, and abort behavior.

Fixes #317877