### PR TITLE
agent-host: stringify URIs in AHP JSONL logs

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostClientResourceChannel.ts
+++ b/src/vs/platform/agentHost/common/agentHostClientResourceChannel.ts
@@ -8,7 +8,7 @@ import { Event } from '../../../base/common/event.js';
 import { URI } from '../../../base/common/uri.js';
 import { IChannel, IServerChannel } from '../../../base/parts/ipc/common/ipc.js';
 import { IFileService } from '../../files/common/files.js';
-import { AhpJsonlLogger, getAhpLogByteLength } from './ahpJsonlLogger.js';
+import { AhpJsonlLogger, getAhpLogEntryByteLength } from './ahpJsonlLogger.js';
 import { IRemoteFilesystemConnection } from './agentHostFileSystemProvider.js';
 import {
 	ContentEncoding, type DirectoryEntry, type ResourceDeleteParams, type ResourceDeleteResult,
@@ -65,7 +65,7 @@ export class AgentHostClientResourceChannel implements IServerChannel {
 	}
 
 	private _logReverseFrame(frame: object, dir: 'c2s' | 's2c'): void {
-		this._ahpLogger?.log(frame, dir, getAhpLogByteLength(safeStringify(frame)));
+		this._ahpLogger?.log(frame, dir, getAhpLogEntryByteLength(frame));
 	}
 
 	private async _call<T>(_ctx: unknown, command: string, arg?: unknown): Promise<T> {
@@ -136,12 +136,4 @@ export function createAgentHostClientResourceConnection(channel: IChannel): IRem
 		resourceDelete: (params) => channel.call('resourceDelete', { ...params, uri: params.uri.toString() }) as Promise<ResourceDeleteResult>,
 		resourceMove: (params) => channel.call('resourceMove', { ...params, source: params.source.toString(), destination: params.destination.toString() }) as Promise<ResourceMoveResult>,
 	};
-}
-
-function safeStringify(value: unknown): string {
-	try {
-		return JSON.stringify(value);
-	} catch {
-		return '';
-	}
 }

--- a/src/vs/platform/agentHost/common/agentHostClientResourceChannel.ts
+++ b/src/vs/platform/agentHost/common/agentHostClientResourceChannel.ts
@@ -8,7 +8,7 @@ import { Event } from '../../../base/common/event.js';
 import { URI } from '../../../base/common/uri.js';
 import { IChannel, IServerChannel } from '../../../base/parts/ipc/common/ipc.js';
 import { IFileService } from '../../files/common/files.js';
-import { AhpJsonlLogger, getAhpLogEntryByteLength } from './ahpJsonlLogger.js';
+import { AhpJsonlLogger } from './ahpJsonlLogger.js';
 import { IRemoteFilesystemConnection } from './agentHostFileSystemProvider.js';
 import {
 	ContentEncoding, type DirectoryEntry, type ResourceDeleteParams, type ResourceDeleteResult,
@@ -65,7 +65,7 @@ export class AgentHostClientResourceChannel implements IServerChannel {
 	}
 
 	private _logReverseFrame(frame: object, dir: 'c2s' | 's2c'): void {
-		this._ahpLogger?.log(frame, dir, getAhpLogEntryByteLength(frame));
+		this._ahpLogger?.log(frame, dir);
 	}
 
 	private async _call<T>(_ctx: unknown, command: string, arg?: unknown): Promise<T> {

--- a/src/vs/platform/agentHost/common/ahpJsonlLogger.ts
+++ b/src/vs/platform/agentHost/common/ahpJsonlLogger.ts
@@ -66,7 +66,7 @@ export class AhpJsonlLogger extends Disposable {
 				...(typeof byteLength === 'number' ? { byteLength } : {}),
 			}
 		};
-		const line = `${JSON.stringify(entry)}\n`;
+		const line = `${stringifyAhpLogEntry(entry)}\n`;
 		const buffer = VSBuffer.fromString(line);
 		this._queue = this._queue.then(() => this._appendLine(buffer)).catch(error => {
 			this._logService.error('[AHPLog] Failed to write transport log', error);
@@ -124,6 +124,10 @@ export class AhpJsonlLogger extends Disposable {
 
 export function getAhpLogByteLength(text: string): number {
 	return VSBuffer.fromString(text).byteLength;
+}
+
+export function stringifyAhpLogEntry(value: unknown): string {
+	return JSON.stringify(value, (_key, nestedValue) => URI.isUri(nestedValue) ? nestedValue.toString() : nestedValue);
 }
 
 function toFileTimestamp(date: Date): string {

--- a/src/vs/platform/agentHost/common/ahpJsonlLogger.ts
+++ b/src/vs/platform/agentHost/common/ahpJsonlLogger.ts
@@ -127,7 +127,31 @@ export function getAhpLogByteLength(text: string): number {
 }
 
 export function stringifyAhpLogEntry(value: unknown): string {
-	return JSON.stringify(value, (_key, nestedValue) => URI.isUri(nestedValue) ? nestedValue.toString() : nestedValue);
+	return JSON.stringify(_replaceUris(value));
+}
+
+/**
+ * Recursively replaces {@link URI} instances with their string form before
+ * handing the value to JSON.stringify. A replacer function is NOT sufficient
+ * because JSON.stringify calls toJSON() on an object *before* invoking the
+ * replacer, so the replacer would receive a plain UriComponents object rather
+ * than the original URI instance, and URI.isUri() would return false for it.
+ */
+function _replaceUris(value: unknown): unknown {
+	if (URI.isUri(value)) {
+		return value.toString();
+	}
+	if (Array.isArray(value)) {
+		return value.map(_replaceUris);
+	}
+	if (value !== null && typeof value === 'object') {
+		const result: Record<string, unknown> = {};
+		for (const key of Object.keys(value)) {
+			result[key] = _replaceUris((value as Record<string, unknown>)[key]);
+		}
+		return result;
+	}
+	return value;
 }
 
 function toFileTimestamp(date: Date): string {

--- a/src/vs/platform/agentHost/common/ahpJsonlLogger.ts
+++ b/src/vs/platform/agentHost/common/ahpJsonlLogger.ts
@@ -126,6 +126,10 @@ export function getAhpLogByteLength(text: string): number {
 	return VSBuffer.fromString(text).byteLength;
 }
 
+export function getAhpLogEntryByteLength(value: unknown): number {
+	return getAhpLogByteLength(stringifyAhpLogEntry(value));
+}
+
 export function stringifyAhpLogEntry(value: unknown): string {
 	return JSON.stringify(value, (_key, nestedValue) => URI.isUri(nestedValue) ? nestedValue.toString() : nestedValue);
 }

--- a/src/vs/platform/agentHost/common/ahpJsonlLogger.ts
+++ b/src/vs/platform/agentHost/common/ahpJsonlLogger.ts
@@ -126,10 +126,6 @@ export function getAhpLogByteLength(text: string): number {
 	return VSBuffer.fromString(text).byteLength;
 }
 
-export function getAhpLogEntryByteLength(value: unknown): number {
-	return getAhpLogByteLength(stringifyAhpLogEntry(value));
-}
-
 export function stringifyAhpLogEntry(value: unknown): string {
 	return JSON.stringify(value, (_key, nestedValue) => URI.isUri(nestedValue) ? nestedValue.toString() : nestedValue);
 }

--- a/src/vs/platform/agentHost/electron-browser/localAgentHostService.ts
+++ b/src/vs/platform/agentHost/electron-browser/localAgentHostService.ts
@@ -16,7 +16,7 @@ import { IConfigurationService } from '../../configuration/common/configuration.
 import { IEnvironmentService } from '../../environment/common/environment.js';
 import { ILogService } from '../../log/common/log.js';
 import { AgentHostAhpJsonlLoggingSettingId, AgentHostEnabledSettingId, AgentHostIpcChannels, IAgentCreateSessionConfig, IAgentHostInspectInfo, IAgentHostService, IAgentResolveSessionConfigParams, IAgentService, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, AuthenticateParams, AuthenticateResult, IAgentHostSocketInfo, IConnectionTrackerService } from '../common/agentService.js';
-import { AhpJsonlLogger, getAhpLogByteLength } from '../common/ahpJsonlLogger.js';
+import { AhpJsonlLogger, getAhpLogEntryByteLength } from '../common/ahpJsonlLogger.js';
 import { wrapAgentServiceWithAhpLogging } from './localAhpJsonlLogging.js';
 import { AgentSubscriptionManager, type IAgentSubscription } from '../common/state/agentSubscription.js';
 import type { CompletionsParams, CompletionsResult, CreateTerminalParams, ResolveSessionConfigResult, SessionConfigCompletionsResult } from '../common/state/protocol/commands.js';
@@ -148,7 +148,7 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 			const revived = revive(e) as ActionEnvelope;
 			if (this._ahpLogger) {
 				const frame = { jsonrpc: '2.0' as const, method: 'action', params: e };
-				this._ahpLogger.log(frame, 's2c', getAhpLogByteLength(JSON.stringify(frame)));
+				this._ahpLogger.log(frame, 's2c', getAhpLogEntryByteLength(frame));
 			}
 			this._subscriptionManager.receiveEnvelope(revived);
 			this._onDidAction.fire(revived);
@@ -156,7 +156,7 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 		store.add(this._proxy.onDidNotification(e => {
 			if (this._ahpLogger) {
 				const frame = { jsonrpc: '2.0' as const, method: 'notification', params: { notification: e } };
-				this._ahpLogger.log(frame, 's2c', getAhpLogByteLength(JSON.stringify(frame)));
+				this._ahpLogger.log(frame, 's2c', getAhpLogEntryByteLength(frame));
 			}
 			this._onDidNotification.fire(revive(e));
 		}));

--- a/src/vs/platform/agentHost/electron-browser/localAgentHostService.ts
+++ b/src/vs/platform/agentHost/electron-browser/localAgentHostService.ts
@@ -16,7 +16,7 @@ import { IConfigurationService } from '../../configuration/common/configuration.
 import { IEnvironmentService } from '../../environment/common/environment.js';
 import { ILogService } from '../../log/common/log.js';
 import { AgentHostAhpJsonlLoggingSettingId, AgentHostEnabledSettingId, AgentHostIpcChannels, IAgentCreateSessionConfig, IAgentHostInspectInfo, IAgentHostService, IAgentResolveSessionConfigParams, IAgentService, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, AuthenticateParams, AuthenticateResult, IAgentHostSocketInfo, IConnectionTrackerService } from '../common/agentService.js';
-import { AhpJsonlLogger, getAhpLogEntryByteLength } from '../common/ahpJsonlLogger.js';
+import { AhpJsonlLogger } from '../common/ahpJsonlLogger.js';
 import { wrapAgentServiceWithAhpLogging } from './localAhpJsonlLogging.js';
 import { AgentSubscriptionManager, type IAgentSubscription } from '../common/state/agentSubscription.js';
 import type { CompletionsParams, CompletionsResult, CreateTerminalParams, ResolveSessionConfigResult, SessionConfigCompletionsResult } from '../common/state/protocol/commands.js';
@@ -148,7 +148,7 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 			const revived = revive(e) as ActionEnvelope;
 			if (this._ahpLogger) {
 				const frame = { jsonrpc: '2.0' as const, method: 'action', params: e };
-				this._ahpLogger.log(frame, 's2c', getAhpLogEntryByteLength(frame));
+				this._ahpLogger.log(frame, 's2c');
 			}
 			this._subscriptionManager.receiveEnvelope(revived);
 			this._onDidAction.fire(revived);
@@ -156,7 +156,7 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 		store.add(this._proxy.onDidNotification(e => {
 			if (this._ahpLogger) {
 				const frame = { jsonrpc: '2.0' as const, method: 'notification', params: { notification: e } };
-				this._ahpLogger.log(frame, 's2c', getAhpLogEntryByteLength(frame));
+				this._ahpLogger.log(frame, 's2c');
 			}
 			this._onDidNotification.fire(revive(e));
 		}));

--- a/src/vs/platform/agentHost/electron-browser/localAhpJsonlLogging.ts
+++ b/src/vs/platform/agentHost/electron-browser/localAhpJsonlLogging.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AhpJsonlLogger, getAhpLogByteLength } from '../common/ahpJsonlLogger.js';
+import { AhpJsonlLogger, getAhpLogByteLength, stringifyAhpLogEntry } from '../common/ahpJsonlLogger.js';
 import type { AuthenticateParams, IAgentService } from '../common/agentService.js';
 
 const REDACTED_VALUE = '<redacted>';
@@ -132,7 +132,7 @@ function isAuthenticateParams(value: unknown): value is AuthenticateParams {
 
 function safeStringify(value: unknown): string {
 	try {
-		return JSON.stringify(value);
+		return stringifyAhpLogEntry(value);
 	} catch {
 		return '';
 	}

--- a/src/vs/platform/agentHost/electron-browser/localAhpJsonlLogging.ts
+++ b/src/vs/platform/agentHost/electron-browser/localAhpJsonlLogging.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AhpJsonlLogger, getAhpLogEntryByteLength } from '../common/ahpJsonlLogger.js';
+import { AhpJsonlLogger } from '../common/ahpJsonlLogger.js';
 import type { AuthenticateParams, IAgentService } from '../common/agentService.js';
 
 const REDACTED_VALUE = '<redacted>';
@@ -76,18 +76,18 @@ export function wrapAgentServiceWithAhpLogging(target: IAgentService, logger: Ah
 				const logArgs = redactParams(method, args);
 				if (isNotification) {
 					const frame = { jsonrpc: '2.0' as const, method, params: logArgs };
-					logger.log(frame, 'c2s', getAhpLogEntryByteLength(frame));
+					logger.log(frame, 'c2s');
 					return value.apply(t, args);
 				}
 				const id = nextId++;
 				const requestFrame = { jsonrpc: '2.0' as const, id, method, params: logArgs };
-				logger.log(requestFrame, 'c2s', getAhpLogEntryByteLength(requestFrame));
+				logger.log(requestFrame, 'c2s');
 				const result = value.apply(t, args) as Promise<unknown> | unknown;
 				if (result && typeof (result as Promise<unknown>).then === 'function') {
 					return (result as Promise<unknown>).then(
 						res => {
 							const responseFrame = { jsonrpc: '2.0' as const, id, result: res ?? null };
-							logger.log(responseFrame, 's2c', getAhpLogEntryByteLength(responseFrame));
+							logger.log(responseFrame, 's2c');
 							return res;
 						},
 						err => {
@@ -99,7 +99,7 @@ export function wrapAgentServiceWithAhpLogging(target: IAgentService, logger: Ah
 									message: err instanceof Error ? err.message : String(err),
 								},
 							};
-							logger.log(errorFrame, 's2c', getAhpLogEntryByteLength(errorFrame));
+							logger.log(errorFrame, 's2c');
 							throw err;
 						},
 					);

--- a/src/vs/platform/agentHost/electron-browser/localAhpJsonlLogging.ts
+++ b/src/vs/platform/agentHost/electron-browser/localAhpJsonlLogging.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AhpJsonlLogger, getAhpLogByteLength, stringifyAhpLogEntry } from '../common/ahpJsonlLogger.js';
+import { AhpJsonlLogger, getAhpLogEntryByteLength } from '../common/ahpJsonlLogger.js';
 import type { AuthenticateParams, IAgentService } from '../common/agentService.js';
 
 const REDACTED_VALUE = '<redacted>';
@@ -76,18 +76,18 @@ export function wrapAgentServiceWithAhpLogging(target: IAgentService, logger: Ah
 				const logArgs = redactParams(method, args);
 				if (isNotification) {
 					const frame = { jsonrpc: '2.0' as const, method, params: logArgs };
-					logger.log(frame, 'c2s', getAhpLogByteLength(safeStringify(frame)));
+					logger.log(frame, 'c2s', getAhpLogEntryByteLength(frame));
 					return value.apply(t, args);
 				}
 				const id = nextId++;
 				const requestFrame = { jsonrpc: '2.0' as const, id, method, params: logArgs };
-				logger.log(requestFrame, 'c2s', getAhpLogByteLength(safeStringify(requestFrame)));
+				logger.log(requestFrame, 'c2s', getAhpLogEntryByteLength(requestFrame));
 				const result = value.apply(t, args) as Promise<unknown> | unknown;
 				if (result && typeof (result as Promise<unknown>).then === 'function') {
 					return (result as Promise<unknown>).then(
 						res => {
 							const responseFrame = { jsonrpc: '2.0' as const, id, result: res ?? null };
-							logger.log(responseFrame, 's2c', getAhpLogByteLength(safeStringify(responseFrame)));
+							logger.log(responseFrame, 's2c', getAhpLogEntryByteLength(responseFrame));
 							return res;
 						},
 						err => {
@@ -99,7 +99,7 @@ export function wrapAgentServiceWithAhpLogging(target: IAgentService, logger: Ah
 									message: err instanceof Error ? err.message : String(err),
 								},
 							};
-							logger.log(errorFrame, 's2c', getAhpLogByteLength(safeStringify(errorFrame)));
+							logger.log(errorFrame, 's2c', getAhpLogEntryByteLength(errorFrame));
 							throw err;
 						},
 					);
@@ -128,12 +128,4 @@ function isAuthenticateParams(value: unknown): value is AuthenticateParams {
 		&& 'token' in value
 		&& typeof value.resource === 'string'
 		&& typeof value.token === 'string';
-}
-
-function safeStringify(value: unknown): string {
-	try {
-		return stringifyAhpLogEntry(value);
-	} catch {
-		return '';
-	}
 }

--- a/src/vs/platform/agentHost/test/common/ahpJsonlLogger.test.ts
+++ b/src/vs/platform/agentHost/test/common/ahpJsonlLogger.test.ts
@@ -27,10 +27,11 @@ suite('AhpJsonlLogger', () => {
 		));
 
 		const requestText = '{"jsonrpc":"2.0","id":"request-1","method":"initialize","params":{"protocolVersion":1}}';
+		const uri = URI.parse('ahp-session:/session-1');
 		logger.log(JSON.parse(requestText), 'c2s', getAhpLogByteLength(requestText));
 		logger.log({ jsonrpc: '2.0', id: 2, result: { ok: true } }, 's2c');
 		logger.log({ jsonrpc: '2.0', id: null, error: { code: -32000, message: 'Nope' } }, 's2c');
-		logger.log({ jsonrpc: '2.0', method: 'notification', params: { value: true } }, 's2c');
+		logger.log({ jsonrpc: '2.0', method: 'notification', params: { uri } }, 's2c');
 		await logger.flush();
 
 		const content = (await fileService.readFile(logger.resource)).value.toString();
@@ -43,6 +44,7 @@ suite('AhpJsonlLogger', () => {
 			method: entry.method,
 			hasResult: Object.hasOwn(entry, 'result'),
 			hasError: Object.hasOwn(entry, 'error'),
+			params: entry.params,
 			log: entry._ahpLog,
 		})), [
 			{
@@ -51,6 +53,7 @@ suite('AhpJsonlLogger', () => {
 				method: 'initialize',
 				hasResult: false,
 				hasError: false,
+				params: { protocolVersion: 1 },
 				log: {
 					ts: parsed[0]._ahpLog.ts,
 					dir: 'c2s',
@@ -65,6 +68,7 @@ suite('AhpJsonlLogger', () => {
 				method: undefined,
 				hasResult: true,
 				hasError: false,
+				params: undefined,
 				log: {
 					ts: parsed[1]._ahpLog.ts,
 					dir: 's2c',
@@ -78,6 +82,7 @@ suite('AhpJsonlLogger', () => {
 				method: undefined,
 				hasResult: false,
 				hasError: true,
+				params: undefined,
 				log: {
 					ts: parsed[2]._ahpLog.ts,
 					dir: 's2c',
@@ -91,6 +96,7 @@ suite('AhpJsonlLogger', () => {
 				method: 'notification',
 				hasResult: false,
 				hasError: false,
+				params: { uri: uri.toString() },
 				log: {
 					ts: parsed[3]._ahpLog.ts,
 					dir: 's2c',

--- a/src/vs/platform/agentHost/test/electron-browser/localAhpJsonlLogging.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/localAhpJsonlLogging.test.ts
@@ -12,7 +12,7 @@ import { NullLogService } from '../../../log/common/log.js';
 import { AhpJsonlLogger } from '../../common/ahpJsonlLogger.js';
 import { AgentHostClientResourceChannel } from '../../common/agentHostClientResourceChannel.js';
 import { wrapAgentServiceWithAhpLogging } from '../../electron-browser/localAhpJsonlLogging.js';
-import type { IAgentService } from '../../common/agentService.js';
+import type { IAgentCreateSessionConfig, IAgentService } from '../../common/agentService.js';
 import { ContentEncoding } from '../../common/state/protocol/commands.js';
 
 suite('localAhpJsonlLogging', () => {
@@ -42,7 +42,7 @@ suite('localAhpJsonlLogging', () => {
 		const target = {
 			async authenticate(params: { resource: string; token: string }) { return { authenticated: params.token.length > 0 }; },
 			async listSessions() { return ['a', 'b']; },
-			async createSession(config: unknown) { return URI.parse(`agent-host://session/1?cfg=${JSON.stringify(config)}`); },
+			async createSession(_config: IAgentCreateSessionConfig) { return URI.parse('agent-host://session/1'); },
 			async disposeTerminal() { return undefined; },
 			async resourceRead(uri: URI) { throw new Error('boom: ' + uri.toString()); },
 			dispatchAction(channel: URI, action: unknown, clientId: string, clientSeq: number) { void channel; void action; void clientId; void clientSeq; },
@@ -53,7 +53,16 @@ suite('localAhpJsonlLogging', () => {
 
 		await wrapped.authenticate({ resource: 'https://example.com', token: 'secret' });
 		await wrapped.listSessions();
-		await wrapped.createSession({ kind: 'demo' } as never);
+		const session = URI.parse('agent-host://session/1');
+		const workingDirectory = URI.file('/workspace');
+		const forkSession = URI.parse('agent-host://session/source');
+		await wrapped.createSession({
+			provider: 'copilot',
+			session,
+			workingDirectory,
+			fork: { session: forkSession, turnIndex: 3, turnId: 'turn-1' },
+			config: { autoApprove: 'autoApprove' },
+		});
 		await wrapped.disposeTerminal(URI.parse('agent-host://terminal/1'));
 		await assert.rejects(() => wrapped.resourceRead(URI.parse('agent-host://x/y')));
 		wrapped.dispatchAction('agent-host://session/1', { type: 'noop' } as never, 'client-1', 7);
@@ -86,6 +95,14 @@ suite('localAhpJsonlLogging', () => {
 		]);
 
 		assert.deepStrictEqual(entries[0].params, [{ resource: 'https://example.com', token: '<redacted>' }]);
+		assert.deepStrictEqual(entries[4].params, [{
+			provider: 'copilot',
+			session: session.toString(),
+			workingDirectory: workingDirectory.toString(),
+			fork: { session: forkSession.toString(), turnIndex: 3, turnId: 'turn-1' },
+			config: { autoApprove: 'autoApprove' },
+		}]);
+		assert.strictEqual(entries[5].result, session.toString());
 		assert.strictEqual(entries[7].result, null);
 	});
 


### PR DESCRIPTION
## Summary
- Serialize `URI` instances as strings when writing AHP JSONL entries
- Reuse the same serialization for local synthetic AHP log byte-length calculation
- Add regression coverage for URI serialization in common and local AHP logging tests

## Notes
The local AHP JSONL logger wraps structured IPC calls, so without a custom serializer `URI.toJSON()` logs component objects instead of protocol URI strings. This keeps local logs aligned with the AHP wire format. (Written by Copilot)