### PR TITLE
BYOK custom endpoint:  Respect user-supplied api-key / Authorization header

### DIFF
--- a/extensions/copilot/src/extension/byok/node/openAIEndpoint.ts
+++ b/extensions/copilot/src/extension/byok/node/openAIEndpoint.ts
@@ -138,6 +138,10 @@ export class OpenAIEndpoint extends ChatEndpoint {
 		this._customHeaders = this._sanitizeCustomHeaders(_modelMetadata.requestHeaders);
 	}
 
+	protected _isReservedHeader(lowerKey: string): boolean {
+		return OpenAIEndpoint._reservedHeaders.has(lowerKey);
+	}
+
 	private _sanitizeCustomHeaders(headers: Readonly<Record<string, string>> | undefined): Record<string, string> {
 		if (!headers) {
 			return {};
@@ -174,7 +178,7 @@ export class OpenAIEndpoint extends ChatEndpoint {
 			}
 
 			const lowerKey = key.toLowerCase();
-			if (OpenAIEndpoint._reservedHeaders.has(lowerKey)) {
+			if (this._isReservedHeader(lowerKey)) {
 				this.logService.warn(`[OpenAIEndpoint] Model '${this.modelMetadata.id}' attempted to override reserved header '${key}', skipping.`);
 				continue;
 			}

--- a/extensions/copilot/src/extension/byok/node/openAIEndpoint.ts
+++ b/extensions/copilot/src/extension/byok/node/openAIEndpoint.ts
@@ -138,6 +138,13 @@ export class OpenAIEndpoint extends ChatEndpoint {
 		this._customHeaders = this._sanitizeCustomHeaders(_modelMetadata.requestHeaders);
 	}
 
+	/**
+	 * BYOK endpoints supply their own credential (`api-key` / `Authorization`)
+	 * via {@link getExtraHeaders}, so the chat fetcher must not fall back to the
+	 * CAPI Copilot bearer token nor raise a missing-key error for these requests.
+	 */
+	public readonly ownsAuthorization = true;
+
 	protected _isReservedHeader(lowerKey: string): boolean {
 		return OpenAIEndpoint._reservedHeaders.has(lowerKey);
 	}

--- a/extensions/copilot/src/extension/byok/node/test/openAIEndpoint.spec.ts
+++ b/extensions/copilot/src/extension/byok/node/test/openAIEndpoint.spec.ts
@@ -85,6 +85,20 @@ describe('OpenAIEndpoint - Reasoning Properties', () => {
 		disposables.clear();
 	});
 
+	describe('ownsAuthorization', () => {
+		it('declares ownsAuthorization=true so the chat fetcher does not attach the CAPI Copilot token or raise a missing-key error for BYOK endpoints', () => {
+			const endpoint = instaService.createInstance(OpenAIEndpoint,
+				{
+					...modelMetadata,
+					supported_endpoints: [ModelSupportedEndpoint.ChatCompletions]
+				},
+				'test-api-key',
+				'https://api.openai.com/v1/chat/completions');
+
+			expect(endpoint.ownsAuthorization).toBe(true);
+		});
+	});
+
 	describe('CAPI mode (useResponsesApi = false)', () => {
 		it('should set cot_id and cot_summary properties when processing thinking content', () => {
 			const endpoint = instaService.createInstance(OpenAIEndpoint,

--- a/extensions/copilot/src/extension/byok/vscode-node/customEndpointProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/customEndpointProvider.ts
@@ -182,9 +182,45 @@ export class CustomEndpointBYOKModelProvider extends AbstractOpenAICompatibleLMP
  *    selected the Messages API for their endpoint, so we honor that unconditionally.
  * 2. Sends Anthropic-style auth (`x-api-key`) and `anthropic-version` plus beta
  *    headers when the Messages API is in use, instead of `Authorization: Bearer`.
- *    Users can still override any header via the model's `requestHeaders` setting.
+ * 3. Lets users override the auth header via `requestHeaders` for endpoints
+ *    behind APIM, gateways, vanity domains, etc. where the URL-based heuristic
+ *    cannot infer the correct header. The reserved auth headers `api-key` and
+ *    `authorization` are permitted through the sanitizer (only for this
+ *    subclass), and the literal token `${apiKey}` in a header value is
+ *    replaced with the configured API key so the secret stays in
+ *    `${input:...}` secret storage. When the user supplies any well-known auth
+ *    header, the default inferred auth header is suppressed to avoid sending
+ *    conflicting credentials.
  */
 export class CustomEndpointOAIEndpoint extends OpenAIEndpoint {
+	/**
+	 * Reserved auth headers that we permit users to override via `requestHeaders`
+	 * for this subclass only. Other well-known auth headers like `x-api-key`,
+	 * `x-goog-api-key`, `apikey`, `ocp-apim-subscription-key`, and
+	 * `x-functions-key` are not on the base reserved list, so they already pass
+	 * through without needing to be listed here.
+	 */
+	private static readonly _overridableReservedAuthHeaders: ReadonlySet<string> = new Set([
+		'api-key',
+		'authorization',
+	]);
+
+	/**
+	 * Well-known auth header names whose presence in `requestHeaders` signals
+	 * that the user is supplying their own credentials, so the default URL-
+	 * inferred auth header should not also be sent (otherwise the endpoint
+	 * receives two conflicting credentials). Headers that are typically
+	 * complementary to a backend auth header (e.g. APIM subscription keys,
+	 * Azure Functions keys) are intentionally excluded.
+	 */
+	private static readonly _userAuthHeaderSuppressionSet: ReadonlySet<string> = new Set([
+		'api-key',
+		'authorization',
+		'x-api-key',
+		'x-goog-api-key',
+		'apikey',
+	]);
+
 	constructor(
 		modelMetadata: IChatModelInformation,
 		apiKey: string,
@@ -205,22 +241,60 @@ export class CustomEndpointOAIEndpoint extends OpenAIEndpoint {
 		return !!this.modelMetadata.supported_endpoints?.includes(ModelSupportedEndpoint.Messages);
 	}
 
+	/**
+	 * Custom endpoints always carry their own auth (api-key / x-api-key / Authorization)
+	 * via {@link getExtraHeaders}, so the chat fetcher must not fall back to the CAPI
+	 * Copilot bearer token for `Authorization`.
+	 */
+	public readonly ownsAuthorization = true;
+
+	protected override _isReservedHeader(lowerKey: string): boolean {
+		if (CustomEndpointOAIEndpoint._overridableReservedAuthHeaders.has(lowerKey)) {
+			return false;
+		}
+		return super._isReservedHeader(lowerKey);
+	}
+
 	public override getExtraHeaders(): Record<string, string> {
 		const headers: Record<string, string> = {
 			'Content-Type': 'application/json'
 		};
+		const userSuppliedAuth = this._hasUserAuthHeader();
 		if (this.useMessagesApi) {
-			headers['x-api-key'] = this._apiKey;
+			if (!userSuppliedAuth) {
+				headers['x-api-key'] = this._apiKey;
+			}
 			headers['anthropic-version'] = '2023-06-01';
 			Object.assign(headers, this.getAnthropicBetaHeader());
-		} else if (this._modelUrl.includes('openai.azure')) {
-			headers['api-key'] = this._apiKey;
-		} else {
-			headers['Authorization'] = `Bearer ${this._apiKey}`;
+		} else if (!userSuppliedAuth) {
+			if (this._modelUrl.includes('openai.azure')) {
+				headers['api-key'] = this._apiKey;
+			} else {
+				headers['Authorization'] = `Bearer ${this._apiKey}`;
+			}
 		}
 		for (const [key, value] of Object.entries(this._customHeaders)) {
-			headers[key] = value;
+			headers[key] = this._interpolateApiKey(value);
 		}
 		return headers;
+	}
+
+	private _hasUserAuthHeader(): boolean {
+		for (const key of Object.keys(this._customHeaders)) {
+			if (CustomEndpointOAIEndpoint._userAuthHeaderSuppressionSet.has(key.toLowerCase())) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private _interpolateApiKey(value: string): string {
+		// Replace the literal token `${apiKey}` with the configured API key so
+		// users can keep the secret in VS Code's secret storage via
+		// `"apiKey": "${input:...}"` while still wiring it into a custom header.
+		if (!value.includes('${apiKey}')) {
+			return value;
+		}
+		return value.split('${apiKey}').join(this._apiKey);
 	}
 }

--- a/extensions/copilot/src/extension/byok/vscode-node/customEndpointProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/customEndpointProvider.ts
@@ -241,13 +241,6 @@ export class CustomEndpointOAIEndpoint extends OpenAIEndpoint {
 		return !!this.modelMetadata.supported_endpoints?.includes(ModelSupportedEndpoint.Messages);
 	}
 
-	/**
-	 * Custom endpoints always carry their own auth (api-key / x-api-key / Authorization)
-	 * via {@link getExtraHeaders}, so the chat fetcher must not fall back to the CAPI
-	 * Copilot bearer token for `Authorization`.
-	 */
-	public readonly ownsAuthorization = true;
-
 	protected override _isReservedHeader(lowerKey: string): boolean {
 		if (CustomEndpointOAIEndpoint._overridableReservedAuthHeaders.has(lowerKey)) {
 			return false;

--- a/extensions/copilot/src/extension/byok/vscode-node/test/customEndpointProvider.spec.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/test/customEndpointProvider.spec.ts
@@ -176,5 +176,184 @@ describe('CustomEndpointBYOKModelProvider', () => {
 				authorization: undefined,
 			});
 		});
+
+		it('uses user-supplied api-key header instead of default Bearer for Chat Completions endpoints behind APIM', () => {
+			const metadata = makeMetadata(undefined);
+			metadata.requestHeaders = { 'api-key': 'apim-secret' };
+			const endpoint = instaService.createInstance(CustomEndpointOAIEndpoint,
+				metadata,
+				'test-api-key',
+				'https://my-apim.azure-api.net/openai/v1/chat/completions');
+			const headers = endpoint.getExtraHeaders();
+
+			expect({
+				authApiKey: headers['api-key'],
+				authorization: headers['Authorization'],
+			}).toEqual({
+				authApiKey: 'apim-secret',
+				authorization: undefined,
+			});
+		});
+
+		it('uses user-supplied api-key header for bare base URLs without an explicit API path', () => {
+			// URL contains neither /messages, /responses, nor /chat/completions, and is not an
+			// openai.azure host — exercises the path where neither the api-type inference nor the
+			// azure heuristic apply, and verifies the user-supplied auth header still wins.
+			const metadata = makeMetadata(undefined);
+			metadata.requestHeaders = { 'api-key': 'apim-secret' };
+			const endpoint = instaService.createInstance(CustomEndpointOAIEndpoint,
+				metadata,
+				'test-api-key',
+				'https://my-apim.azure-api.net/openai/v1');
+			const headers = endpoint.getExtraHeaders();
+
+			expect({
+				authApiKey: headers['api-key'],
+				authorization: headers['Authorization'],
+			}).toEqual({
+				authApiKey: 'apim-secret',
+				authorization: undefined,
+			});
+		});
+
+		it('suppresses default x-api-key on Messages API when user supplies Authorization header', () => {
+			const metadata = makeMetadata([ModelSupportedEndpoint.Messages]);
+			metadata.requestHeaders = { 'Authorization': 'Bearer override' };
+			const endpoint = instaService.createInstance(CustomEndpointOAIEndpoint,
+				metadata,
+				'test-api-key',
+				'https://anthropic.example.com/v1/messages');
+			const headers = endpoint.getExtraHeaders();
+
+			expect({
+				xApiKey: headers['x-api-key'],
+				authorization: headers['Authorization'],
+				anthropicVersion: headers['anthropic-version'],
+			}).toEqual({
+				xApiKey: undefined,
+				authorization: 'Bearer override',
+				anthropicVersion: '2023-06-01',
+			});
+		});
+
+		it('interpolates ${apiKey} token in user-supplied header values', () => {
+			const metadata = makeMetadata(undefined);
+			metadata.requestHeaders = { 'X-Custom-Auth': 'ApiKey ${apiKey}' };
+			const endpoint = instaService.createInstance(CustomEndpointOAIEndpoint,
+				metadata,
+				'secret-123',
+				'https://api.example.com/v1/chat/completions');
+			const headers = endpoint.getExtraHeaders();
+
+			expect(headers['X-Custom-Auth']).toBe('ApiKey secret-123');
+		});
+
+		it('suppresses default Bearer when user supplies a well-known non-reserved auth header (x-goog-api-key)', () => {
+			const metadata = makeMetadata(undefined);
+			metadata.requestHeaders = { 'x-goog-api-key': '${apiKey}' };
+			const endpoint = instaService.createInstance(CustomEndpointOAIEndpoint,
+				metadata,
+				'gemini-secret',
+				'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions');
+			const headers = endpoint.getExtraHeaders();
+
+			expect({
+				googKey: headers['x-goog-api-key'],
+				authorization: headers['Authorization'],
+				apiKey: headers['api-key'],
+			}).toEqual({
+				googKey: 'gemini-secret',
+				authorization: undefined,
+				apiKey: undefined,
+			});
+		});
+
+		it('declares ownsAuthorization=true so the chat fetcher will not fall back to the CAPI Copilot token', () => {
+			const endpoint = instaService.createInstance(CustomEndpointOAIEndpoint,
+				makeMetadata(undefined),
+				'test-api-key',
+				'https://api.example.com/v1/chat/completions');
+
+			expect(endpoint.ownsAuthorization).toBe(true);
+		});
+
+		it('replaces default Bearer with user-supplied Authorization header on Chat Completions endpoints', () => {
+			const metadata = makeMetadata(undefined);
+			metadata.requestHeaders = { 'Authorization': 'Bearer user-token' };
+			const endpoint = instaService.createInstance(CustomEndpointOAIEndpoint,
+				metadata,
+				'test-api-key',
+				'https://api.example.com/v1/chat/completions');
+			const headers = endpoint.getExtraHeaders();
+
+			expect({
+				authorization: headers['Authorization'],
+				apiKey: headers['api-key'],
+			}).toEqual({
+				authorization: 'Bearer user-token',
+				apiKey: undefined,
+			});
+		});
+
+		it('detects user-supplied auth headers case-insensitively', () => {
+			const metadata = makeMetadata(undefined);
+			metadata.requestHeaders = { 'API-KEY': 'apim-secret' };
+			const endpoint = instaService.createInstance(CustomEndpointOAIEndpoint,
+				metadata,
+				'test-api-key',
+				'https://api.example.com/v1/chat/completions');
+			const headers = endpoint.getExtraHeaders();
+
+			expect({
+				authApiKey: headers['API-KEY'],
+				lowercaseApiKey: headers['api-key'],
+				authorization: headers['Authorization'],
+			}).toEqual({
+				authApiKey: 'apim-secret',
+				lowercaseApiKey: undefined,
+				authorization: undefined,
+			});
+		});
+
+		it('still sends default Bearer alongside complementary headers (e.g. Ocp-Apim-Subscription-Key)', () => {
+			// Complementary credentials such as APIM subscription keys or Azure Functions keys
+			// are intentionally excluded from the suppression set — they sit in front of the
+			// backend auth header, not in place of it.
+			const metadata = makeMetadata(undefined);
+			metadata.requestHeaders = { 'Ocp-Apim-Subscription-Key': 'apim-sub-key' };
+			const endpoint = instaService.createInstance(CustomEndpointOAIEndpoint,
+				metadata,
+				'test-api-key',
+				'https://api.example.com/v1/chat/completions');
+			const headers = endpoint.getExtraHeaders();
+
+			expect({
+				subKey: headers['Ocp-Apim-Subscription-Key'],
+				authorization: headers['Authorization'],
+			}).toEqual({
+				subKey: 'apim-sub-key',
+				authorization: 'Bearer test-api-key',
+			});
+		});
+
+		it('suppresses default Bearer when user supplies an `apikey` (no dash) header', () => {
+			const metadata = makeMetadata(undefined);
+			metadata.requestHeaders = { 'apikey': 'supabase-style-key' };
+			const endpoint = instaService.createInstance(CustomEndpointOAIEndpoint,
+				metadata,
+				'test-api-key',
+				'https://api.example.com/v1/chat/completions');
+			const headers = endpoint.getExtraHeaders();
+
+			expect({
+				apikey: headers['apikey'],
+				authorization: headers['Authorization'],
+				dashedApiKey: headers['api-key'],
+			}).toEqual({
+				apikey: 'supabase-style-key',
+				authorization: undefined,
+				dashedApiKey: undefined,
+			});
+		});
 	});
 });

--- a/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
+++ b/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
@@ -1020,9 +1020,14 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 			this._logService.debug(`modelMaxResponseTokens ${request.max_tokens ?? 2048}`);
 			this._logService.debug(`chat model ${chatEndpointInfo.model}`);
 
-			secretKey ??= copilotToken?.token;
-			// BYOK endpoints may not need a secret key (e.g., Ollama local), they use getExtraHeaders instead.
-			if (!secretKey && !chatEndpointInfo.getExtraHeaders) {
+			// BYOK endpoints that own their `Authorization` (see IChatEndpoint.ownsAuthorization)
+			// opt out of the CAPI Copilot-token fallback to avoid leaking the user's bearer to a
+			// third-party URL and to keep the wire request from carrying an unintended
+			// `Authorization: Bearer …` alongside their own auth header.
+			if (!chatEndpointInfo.ownsAuthorization) {
+				secretKey ??= copilotToken?.token;
+			}
+			if (!secretKey && !chatEndpointInfo.ownsAuthorization) {
 				const urlOrRequestMetadata = stringifyUrlOrRequestMetadata(chatEndpointInfo.urlOrRequestMetadata);
 				this._logService.error(`Failed to send request to ${urlOrRequestMetadata} due to missing key`);
 				sendCommunicationErrorTelemetry(this._telemetryService, `Failed to send request to ${urlOrRequestMetadata} due to missing key`);

--- a/extensions/copilot/src/platform/networking/common/networking.ts
+++ b/extensions/copilot/src/platform/networking/common/networking.ts
@@ -306,6 +306,15 @@ export interface IChatEndpoint extends IEndpoint {
 	readonly isExtensionContributed?: boolean;
 	readonly maxPromptImages?: number;
 	/**
+	 * When true, this endpoint owns its own credentials via {@link IEndpoint.getExtraHeaders}
+	 * (e.g. a BYOK target with a user-supplied `api-key`, `x-api-key`, or `Authorization`) and
+	 * the chat fetcher must not fall back to the CAPI Copilot token for the `Authorization`
+	 * header. Prevents leaking the user's CAPI bearer token to third-party endpoints, and
+	 * avoids over-sending an unintended `Authorization: Bearer …` to gateways (strict
+	 * APIM policies, etc.) that validate the header.
+	 */
+	readonly ownsAuthorization?: boolean;
+	/**
 	 * Handles processing of responses from a chat endpoint. Each endpoint can have different response formats.
 	 * @param telemetryService The telemetry service
 	 * @param logService The log service


### PR DESCRIPTION
Fixes #317810

The customendpoint BYOK provider had two related issues when talking to OpenAI-compatible endpoints behind APIM, Azure gateways, or vanity domains:


- **User-supplied auth headers ignored or duplicated**. Users couldn't override the framework's URL-inferred auth header (Authorization / api-key) via requestHeaders, and well-known auth headers like x-api-key were sent alongside the default, producing two conflicting credentials on the wire.
- **Authorization fallback was too broad**. chatMLFetcher always populated a missing secretKey from the first-party Copilot token, which meant BYOK custom-endpoint requests could pick up a first-party Authorization header in addition to the credentials the endpoint actually requires.

**Changes**

- _User configured auth wins over system defaults:_ api-key and Authorization are now allowed through requestHeaders for custom endpoints; when the user supplies a well-known auth header (api-key, Authorization, x-api-key, x-goog-api-key, apikey, case-insensitive), the default URL-inferred auth header is suppressed so exactly one credential goes on the wire.
- _Complimentary headers stay:_ APIM subscription keys, Azure Functions keys, etc. are not treated as auth replacements and continue to be sent alongside the default credential.


Example setting:
```

[
  {
    "name": "Foundry",
    "vendor": "customendpoint",
    "apiKey": "${input:chat.lm.secret.example}",
    "apiType": "responses",
    "models": [
      {
        "id": "gpt-5.3-codex",
        "name": "gpt-5.3-codex-apim",
        "url": "https://example.azure-api.net/openai/v1",
        "toolCalling": true,
        "vision": true,
        "maxInputTokens": 200000,
        "maxOutputTokens": 64000,
        "requestHeaders": {
                "api-key": "${apiKey}"
              }
      }
    ]
  }
]
```