### PR TITLE
build/darwin: skip @microsoft/mxc-sdk bin/ in universal merger

### DIFF
--- a/build/darwin/create-universal-app.ts
+++ b/build/darwin/create-universal-app.ts
@@ -92,6 +92,10 @@ async function main(buildDir?: string) {
 		'**/node_modules/@vscode/ripgrep-universal/bin/darwin-arm64/**',
 		'**/node_modules.asar.unpacked/@vscode/ripgrep-universal/bin/darwin-x64/**',
 		'**/node_modules.asar.unpacked/@vscode/ripgrep-universal/bin/darwin-arm64/**',
+		// @microsoft/mxc-sdk ships per-arch native binaries under bin/<arch>;
+		// the package includes both arm64 and x64 trees regardless of host arch.
+		'**/node_modules/@microsoft/mxc-sdk/bin/**',
+		'**/node_modules.asar.unpacked/@microsoft/mxc-sdk/bin/**',
 	];
 
 	await makeUniversalApp({
@@ -101,7 +105,7 @@ async function main(buildDir?: string) {
 		outAppPath,
 		force: true,
 		mergeASARs: true,
-		x64ArchFiles: '{*/kerberos.node,**/extensions/microsoft-authentication/dist/libmsalruntime.dylib,**/extensions/microsoft-authentication/dist/msal-node-runtime.node,**/node_modules/@github/copilot-darwin-*/copilot,**/node_modules/@github/copilot/prebuilds/darwin-*/*,**/node_modules.asar.unpacked/@github/copilot-darwin-*/copilot,**/node_modules.asar.unpacked/@github/copilot/prebuilds/darwin-*/*,**/extensions/copilot/node_modules/@github/copilot/sdk/prebuilds/darwin-*/*,**/extensions/copilot/node_modules/@github/copilot/sdk/ripgrep/bin/darwin-*/*,**/node_modules/@vscode/ripgrep-universal/bin/darwin-*/*,**/node_modules.asar.unpacked/@vscode/ripgrep-universal/bin/darwin-*/*}',
+		x64ArchFiles: '{*/kerberos.node,**/extensions/microsoft-authentication/dist/libmsalruntime.dylib,**/extensions/microsoft-authentication/dist/msal-node-runtime.node,**/node_modules/@github/copilot-darwin-*/copilot,**/node_modules/@github/copilot/prebuilds/darwin-*/*,**/node_modules.asar.unpacked/@github/copilot-darwin-*/copilot,**/node_modules.asar.unpacked/@github/copilot/prebuilds/darwin-*/*,**/extensions/copilot/node_modules/@github/copilot/sdk/prebuilds/darwin-*/*,**/extensions/copilot/node_modules/@github/copilot/sdk/ripgrep/bin/darwin-*/*,**/node_modules/@vscode/ripgrep-universal/bin/darwin-*/*,**/node_modules.asar.unpacked/@vscode/ripgrep-universal/bin/darwin-*/*,**/node_modules/@microsoft/mxc-sdk/bin/**,**/node_modules.asar.unpacked/@microsoft/mxc-sdk/bin/**}',
 		filesToSkipComparison: (file: string) => {
 			for (const expected of filesToSkip) {
 				if (minimatch(file, expected)) {


### PR DESCRIPTION
Follow-up to #317865.

Insider build [441436](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=441436&view=results) still failed in the `Create Universal App` step with:

```
Error: Detected file "Contents/Resources/app/node_modules/@microsoft/mxc-sdk/bin/arm64/mxc-exec-mac" that's the same in both x64 and arm64 builds and not covered by the x64ArchFiles rule
```

`vscode-universal-bundler` keeps its own allowlist (`x64ArchFiles` + `filesToSkipComparison`) in [build/darwin/create-universal-app.ts](https://github.com/microsoft/vscode/blob/main/build/darwin/create-universal-app.ts), separate from `verify-macho.ts`. `@microsoft/mxc-sdk` (added by #317669 for Windows sandboxing) ships `bin/arm64/mxc-exec-mac` unchanged in both per-arch builds, so it needs to be:

- Added to `x64ArchFiles` so the merger keeps a single copy.
- Added to the `filesToSkip` set so the identical-file comparison passes.

This mirrors the existing entries for `@github/copilot-darwin-*` and `@vscode/ripgrep-universal/bin/darwin-*`.