### PR TITLE
Add marketplace ref support for plugin marketplaces

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentPluginRepositoryService.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentPluginRepositoryService.ts
@@ -137,7 +137,7 @@ export class AgentPluginRepositoryService implements IAgentPluginRepositoryServi
 
 			const progressTitle = options?.progressTitle ?? localize('preparingMarketplace', "Preparing plugin marketplace '{0}'...", marketplace.displayLabel);
 			const failureLabel = options?.failureLabel ?? marketplace.displayLabel;
-			await this._cloneRepository(repoDir, marketplace.cloneUrl, progressTitle, failureLabel);
+			await this._cloneRepository(repoDir, marketplace.cloneUrl, progressTitle, failureLabel, marketplace.ref);
 			this._updateMarketplaceIndex(marketplace, repoDir, options?.marketplaceType);
 			return repoDir;
 		});

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -878,8 +878,8 @@ configurationRegistry.registerConfiguration({
 			items: {
 				type: 'string',
 			},
-			markdownDescription: nls.localize('chat.plugins.marketplaces', "Plugin marketplaces to query. Entries may be GitHub shorthand (`owner/repo`), direct Git repository URIs (`https://...git`, `ssh://...git`, or `git@host:path.git`), or local repository URIs (`file:///...`). Equivalent GitHub shorthand and URI entries are deduplicated."),
-			default: ['github/copilot-plugins', 'github/awesome-copilot'],
+			markdownDescription: nls.localize('chat.plugins.marketplaces', "Plugin marketplaces to query. Entries may be GitHub shorthand (`owner/repo` or `owner/repo#ref`), direct Git repository URIs (`https://...git`, `ssh://...git`, or `git@host:path.git`, each optionally suffixed with `#ref`), or local repository URIs (`file:///...`). Equivalent GitHub shorthand and URI entries are deduplicated."),
+			default: ['github/copilot-plugins', 'github/awesome-copilot#marketplace'],
 			scope: ConfigurationScope.APPLICATION,
 			tags: ['experimental'],
 		},

--- a/src/vs/workbench/contrib/chat/common/plugins/marketplaceReference.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/marketplaceReference.ts
@@ -18,6 +18,7 @@ export interface IMarketplaceReference {
 	readonly canonicalId: string;
 	readonly cacheSegments: readonly string[];
 	readonly kind: MarketplaceReferenceKind;
+	readonly ref?: string;
 	readonly githubRepo?: string;
 	readonly localRepositoryUri?: URI;
 }
@@ -76,17 +77,19 @@ export function parseMarketplaceReference(value: string): IMarketplaceReference 
 		return scpReference;
 	}
 
-	const shorthandMatch = /^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/.exec(rawValue);
+	const shorthandMatch = /^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)(?:#(.+))?$/.exec(rawValue);
 	if (shorthandMatch) {
 		const owner = shorthandMatch[1];
 		const repo = shorthandMatch[2];
+		const ref = shorthandMatch[3];
 		return {
 			rawValue,
-			displayLabel: `${owner}/${repo}`,
+			displayLabel: rawValue,
 			cloneUrl: `https://github.com/${owner}/${repo}.git`,
-			canonicalId: getGitHubCanonicalId(owner, repo),
-			cacheSegments: ['github.com', owner, repo],
+			canonicalId: getGitHubCanonicalId(owner, repo, ref),
+			cacheSegments: ['github.com', owner, repo, ...getRefCacheSegments(ref)],
 			kind: MarketplaceReferenceKind.GitHubShorthand,
+			ref,
 			githubRepo: `${owner}/${repo}`,
 		};
 	}
@@ -104,6 +107,9 @@ function parseUriMarketplaceReference(rawValue: string): IMarketplaceReference |
 
 	const scheme = uri.scheme.toLowerCase();
 	if (scheme === 'file' && /^file:\/\//i.test(rawValue)) {
+		if (uri.fragment) {
+			return undefined;
+		}
 		const localRepositoryUri = URI.file(uri.fsPath);
 		return {
 			rawValue,
@@ -128,6 +134,8 @@ function parseUriMarketplaceReference(rawValue: string): IMarketplaceReference |
 	if (!normalizedPath) {
 		return undefined;
 	}
+	const ref = uri.fragment || undefined;
+	const cloneUri = uri.fragment ? uri.with({ fragment: null }) : uri;
 
 	const gitSuffix = '.git';
 	const sanitizedAuthority = sanitizePathSegment(uri.authority.toLowerCase());
@@ -143,16 +151,17 @@ function parseUriMarketplaceReference(rawValue: string): IMarketplaceReference |
 	return {
 		rawValue,
 		displayLabel: rawValue,
-		cloneUrl: rawValue,
-		canonicalId: `git:${uri.authority.toLowerCase()}/${canonicalPath}`,
-		cacheSegments: [sanitizedAuthority, ...pathSegments],
+		cloneUrl: cloneUri.toString(),
+		canonicalId: appendRefSuffix(`git:${uri.authority.toLowerCase()}/${canonicalPath}`, ref),
+		cacheSegments: [sanitizedAuthority, ...pathSegments, ...getRefCacheSegments(ref)],
 		kind: MarketplaceReferenceKind.GitUri,
+		ref,
 		githubRepo,
 	};
 }
 
 function parseScpMarketplaceReference(rawValue: string): IMarketplaceReference | undefined {
-	const match = /^([^@\s]+)@([^:\s]+):(.+\.git)$/i.exec(rawValue);
+	const match = /^([^@\s]+)@([^:\s]+):(.+?\.git)(?:#(.+))?$/i.exec(rawValue);
 	if (!match) {
 		return undefined;
 	}
@@ -160,6 +169,7 @@ function parseScpMarketplaceReference(rawValue: string): IMarketplaceReference |
 	const gitSuffix = '.git';
 	const authority = match[2];
 	const pathWithGit = match[3].replace(/^\/+/, '');
+	const ref = match[4];
 	if (!pathWithGit.toLowerCase().endsWith(gitSuffix)) {
 		return undefined;
 	}
@@ -171,10 +181,11 @@ function parseScpMarketplaceReference(rawValue: string): IMarketplaceReference |
 	return {
 		rawValue,
 		displayLabel: rawValue,
-		cloneUrl: rawValue,
-		canonicalId: `git:${authority.toLowerCase()}/${pathWithGit.toLowerCase()}`,
-		cacheSegments: [sanitizePathSegment(authority.toLowerCase()), ...pathSegments],
+		cloneUrl: `${match[1]}@${authority}:${pathWithGit}`,
+		canonicalId: appendRefSuffix(`git:${authority.toLowerCase()}/${pathWithGit.toLowerCase()}`, ref),
+		cacheSegments: [sanitizePathSegment(authority.toLowerCase()), ...pathSegments, ...getRefCacheSegments(ref)],
 		kind: MarketplaceReferenceKind.GitUri,
+		ref,
 		githubRepo,
 	};
 }
@@ -212,8 +223,16 @@ function extractGitHubRepo(authority: string, pathWithoutGit: string): string | 
 	return undefined;
 }
 
-function getGitHubCanonicalId(owner: string, repo: string): string {
-	return `github:${owner.toLowerCase()}/${repo.toLowerCase()}`;
+function getGitHubCanonicalId(owner: string, repo: string, ref?: string): string {
+	return appendRefSuffix(`github:${owner.toLowerCase()}/${repo.toLowerCase()}`, ref);
+}
+
+function appendRefSuffix(canonicalId: string, ref: string | undefined): string {
+	return ref ? `${canonicalId}#${encodeURIComponent(ref)}` : canonicalId;
+}
+
+function getRefCacheSegments(ref: string | undefined): string[] {
+	return ref ? [`ref_${encodeURIComponent(ref)}`] : [];
 }
 
 function sanitizePathSegment(value: string): string {

--- a/src/vs/workbench/contrib/chat/common/plugins/marketplaceReference.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/marketplaceReference.ts
@@ -135,7 +135,7 @@ function parseUriMarketplaceReference(rawValue: string): IMarketplaceReference |
 		return undefined;
 	}
 	const ref = uri.fragment || undefined;
-	const cloneUri = uri.fragment ? uri.with({ fragment: null }) : uri;
+	const cloneUri = uri.fragment ? uri.with({ fragment: '' }) : uri;
 
 	const gitSuffix = '.git';
 	const sanitizedAuthority = sanitizePathSegment(uri.authority.toLowerCase());

--- a/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
@@ -463,7 +463,8 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 			if (token.isCancellationRequested) {
 				return undefined;
 			}
-			const url = `https://raw.githubusercontent.com/${repo}/main/${defPath}`;
+			const ref = encodeGitHubPathSegment(reference.ref ?? 'main');
+			const url = `https://raw.githubusercontent.com/${repo}/${ref}/${defPath}`;
 			try {
 				const context = await this._requestService.request({ type: 'GET', url, callSite: 'pluginMarketplaceService.fetchPluginList' }, token);
 				const statusCode = context.res.statusCode;
@@ -903,6 +904,10 @@ function normalizeMarketplacePath(value: string): string {
 	let normalized = value.trim().replace(/\\/g, '/');
 	normalized = normalized.replace(/^\.?\/+/, '').replace(/\/+$/g, '');
 	return normalized;
+}
+
+function encodeGitHubPathSegment(value: string): string {
+	return value.split('/').map(encodeURIComponent).join('/');
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
@@ -463,7 +463,7 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 			if (token.isCancellationRequested) {
 				return undefined;
 			}
-			const ref = encodeGitHubPathSegment(reference.ref ?? 'main');
+			const ref = encodeURIComponent(reference.ref ?? 'main');
 			const url = `https://raw.githubusercontent.com/${repo}/${ref}/${defPath}`;
 			try {
 				const context = await this._requestService.request({ type: 'GET', url, callSite: 'pluginMarketplaceService.fetchPluginList' }, token);
@@ -907,7 +907,7 @@ function normalizeMarketplacePath(value: string): string {
 }
 
 function encodeGitHubPathSegment(value: string): string {
-	return value.split('/').map(encodeURIComponent).join('/');
+	return encodeURIComponent(value);
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
@@ -906,10 +906,6 @@ function normalizeMarketplacePath(value: string): string {
 	return normalized;
 }
 
-function encodeGitHubPathSegment(value: string): string {
-	return encodeURIComponent(value);
-}
-
 /**
  * Resolve plugin source from marketplace metadata.
  * - If pluginRoot exists, plugin source is resolved relative to it.

--- a/src/vs/workbench/contrib/chat/common/plugins/workspacePluginSettingsService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/workspacePluginSettingsService.ts
@@ -55,6 +55,7 @@ interface IMarketplaceSourceJson {
 	readonly source?: string;
 	readonly repo?: string;
 	readonly url?: string;
+	readonly ref?: string;
 	readonly path?: string;
 }
 
@@ -62,6 +63,7 @@ interface IExtraMarketplaceJson {
 	readonly source?: string | IMarketplaceSourceJson;
 	readonly repo?: string;
 	readonly url?: string;
+	readonly ref?: string;
 	readonly path?: string;
 }
 
@@ -79,27 +81,34 @@ function marketplaceEntryToReference(entry: IExtraMarketplaceJson): IMarketplace
 	let sourceType: string | undefined;
 	let repo: string | undefined;
 	let url: string | undefined;
+	let ref: string | undefined;
 
 	if (typeof entry.source === 'object' && entry.source !== null) {
 		const nested = entry.source;
 		sourceType = nested.source;
 		repo = nested.repo;
 		url = nested.url;
+		ref = nested.ref;
 	} else {
 		sourceType = entry.source as string | undefined;
 		repo = entry.repo;
 		url = entry.url;
+		ref = entry.ref;
 	}
 
 	if (sourceType === 'github' && typeof repo === 'string') {
-		return parseMarketplaceReference(repo);
+		return parseMarketplaceReference(appendMarketplaceRef(repo, ref));
 	}
 
 	if (sourceType === 'git' && typeof url === 'string') {
-		return parseMarketplaceReference(url);
+		return parseMarketplaceReference(appendMarketplaceRef(url, ref));
 	}
 
 	return undefined;
+}
+
+function appendMarketplaceRef(value: string, ref: string | undefined): string {
+	return ref ? `${value}#${ref}` : value;
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/common/plugins/workspacePluginSettingsService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/workspacePluginSettingsService.ts
@@ -108,7 +108,13 @@ function marketplaceEntryToReference(entry: IExtraMarketplaceJson): IMarketplace
 }
 
 function appendMarketplaceRef(value: string, ref: string | undefined): string {
-	return ref ? `${value}#${ref}` : value;
+	if (!ref) {
+		return value;
+	}
+
+	const fragmentIndex = value.indexOf('#');
+	const baseValue = fragmentIndex === -1 ? value : value.slice(0, fragmentIndex);
+	return `${baseValue}#${ref}`;
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/test/browser/plugins/agentPluginRepositoryService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/plugins/agentPluginRepositoryService.test.ts
@@ -98,6 +98,14 @@ suite('AgentPluginRepositoryService', () => {
 		assert.strictEqual(uri.path, '/cache/agentPlugins/github.com/microsoft/vscode');
 	});
 
+	test('uses ref-specific cache path for GitHub shorthand plugin references', () => {
+		const service = createService();
+		const plugin = createPlugin('microsoft/vscode#marketplace', 'plugins/myPlugin');
+		const uri = service.getRepositoryUri(plugin.marketplaceReference, plugin.marketplaceType);
+
+		assert.strictEqual(uri.path, '/cache/agentPlugins/github.com/microsoft/vscode/ref_marketplace');
+	});
+
 	test('uses marketplaces cache path for direct git URI plugin references', () => {
 		const service = createService();
 		const plugin = createPlugin('https://example.com/org/repo.git', 'plugins/myPlugin');
@@ -129,6 +137,35 @@ suite('AgentPluginRepositoryService', () => {
 
 		assert.strictEqual(checkedPath, '/cache/agentPlugins/github.com/microsoft/vscode');
 		assert.strictEqual(uri.path, '/cache/agentPlugins/github.com/microsoft/vscode');
+	});
+
+	test('passes marketplace refs through cloneRepository', async () => {
+		let clonedRef: string | undefined;
+		const instantiationService = store.add(new TestInstantiationService());
+		instantiationService.stub(ICommandService, { executeCommand: async () => undefined } as unknown as ICommandService);
+		instantiationService.stub(IEnvironmentService, { cacheHome: URI.file('/cache') } as unknown as IEnvironmentService);
+		instantiationService.stub(IUserDataProfileService, { currentProfile: { agentPluginsHome: URI.file('/cache/agentPlugins') } } as unknown as IUserDataProfileService);
+		instantiationService.stub(IFileService, {
+			exists: async () => false,
+			createFolder: async () => undefined,
+		} as unknown as IFileService);
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(INotificationService, { notify: () => undefined } as unknown as INotificationService);
+		instantiationService.stub(IPluginGitService, stubPluginGit({
+			cloneRepository: async (_cloneUrl, _targetDir, ref) => {
+				clonedRef = ref;
+			},
+		}));
+		instantiationService.stub(IProgressService, {
+			withProgress: async (_options: unknown, callback: (...args: unknown[]) => Promise<unknown>) => callback(),
+		} as unknown as IProgressService);
+		instantiationService.stub(IStorageService, store.add(new InMemoryStorageService()));
+
+		const service = instantiationService.createInstance(AgentPluginRepositoryService);
+		const plugin = createPlugin('microsoft/vscode#marketplace', 'plugins/myPlugin');
+		await service.ensureRepository(plugin.marketplaceReference, { marketplaceType: plugin.marketplaceType });
+
+		assert.strictEqual(clonedRef, 'marketplace');
 	});
 
 	test('concurrent ensureRepository calls for the same marketplace clone only once', async () => {

--- a/src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts
@@ -5,7 +5,8 @@
 
 import assert from 'assert';
 import { timeout } from '../../../../../../base/common/async.js';
-import { VSBuffer } from '../../../../../../base/common/buffer.js';
+import { bufferToStream, VSBuffer } from '../../../../../../base/common/buffer.js';
+import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { Event } from '../../../../../../base/common/event.js';
 import { observableValue } from '../../../../../../base/common/observable.js';
 import { URI } from '../../../../../../base/common/uri.js';
@@ -41,6 +42,21 @@ suite('PluginMarketplaceService', () => {
 		assert.strictEqual(parsed.githubRepo, 'microsoft/vscode');
 	});
 
+	test('parses GitHub shorthand marketplace with ref suffix', () => {
+		const parsed = parseMarketplaceReference('microsoft/vscode#marketplace');
+		assert.ok(parsed);
+		if (!parsed) {
+			return;
+		}
+		assert.strictEqual(parsed.kind, MarketplaceReferenceKind.GitHubShorthand);
+		assert.strictEqual(parsed.cloneUrl, 'https://github.com/microsoft/vscode.git');
+		assert.strictEqual(parsed.canonicalId, 'github:microsoft/vscode#marketplace');
+		assert.strictEqual(parsed.displayLabel, 'microsoft/vscode#marketplace');
+		assert.deepStrictEqual(parsed.cacheSegments, ['github.com', 'microsoft', 'vscode', 'ref_marketplace']);
+		assert.strictEqual(parsed.ref, 'marketplace');
+		assert.strictEqual(parsed.githubRepo, 'microsoft/vscode');
+	});
+
 	test('parses direct HTTPS and SSH marketplaces ending in .git', () => {
 		const https = parseMarketplaceReference('https://example.com/org/repo.git');
 		assert.ok(https);
@@ -71,6 +87,22 @@ suite('PluginMarketplaceService', () => {
 		assert.strictEqual(parsed.canonicalId, 'git:example.com/org/repo.git');
 		assert.deepStrictEqual(parsed.cacheSegments, ['example.com', 'org', 'repo']);
 		assert.strictEqual(parsed.githubRepo, undefined);
+	});
+
+	test('parses git URI marketplaces with ref suffix', () => {
+		const https = parseMarketplaceReference('https://example.com/org/repo.git#marketplace');
+		assert.ok(https);
+		assert.strictEqual(https?.cloneUrl, 'https://example.com/org/repo.git');
+		assert.strictEqual(https?.canonicalId, 'git:example.com/org/repo.git#marketplace');
+		assert.deepStrictEqual(https?.cacheSegments, ['example.com', 'org', 'repo', 'ref_marketplace']);
+		assert.strictEqual(https?.ref, 'marketplace');
+
+		const scp = parseMarketplaceReference('git@example.com:org/repo.git#marketplace');
+		assert.ok(scp);
+		assert.strictEqual(scp?.cloneUrl, 'git@example.com:org/repo.git');
+		assert.strictEqual(scp?.canonicalId, 'git:example.com/org/repo.git#marketplace');
+		assert.deepStrictEqual(scp?.cacheSegments, ['example.com', 'org', 'repo', 'ref_marketplace']);
+		assert.strictEqual(scp?.ref, 'marketplace');
 	});
 
 	test('populates githubRepo for GitHub HTTPS URLs', () => {
@@ -174,6 +206,64 @@ suite('PluginMarketplaceService', () => {
 		const parsed = parseMarketplaceReferences([null, 42, {}, 'microsoft/vscode']);
 		assert.strictEqual(parsed.length, 1);
 		assert.strictEqual(parsed[0].canonicalId, 'github:microsoft/vscode');
+	});
+
+	test('treats different marketplace refs as distinct references', () => {
+		const parsed = parseMarketplaceReferences([
+			'microsoft/vscode#main',
+			'microsoft/vscode#marketplace',
+			'https://github.com/microsoft/vscode.git#marketplace',
+		]);
+
+		assert.deepStrictEqual(parsed.map(r => r.canonicalId), [
+			'github:microsoft/vscode#main',
+			'github:microsoft/vscode#marketplace',
+			'git:github.com/microsoft/vscode.git#marketplace',
+		]);
+	});
+});
+
+suite('PluginMarketplaceService - GitHub marketplace refs', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('fetches GitHub marketplace definitions from the configured ref', async () => {
+		const requestUrls: string[] = [];
+		const instantiationService = store.add(new TestInstantiationService());
+		instantiationService.stub(IConfigurationService, new TestConfigurationService({
+			[ChatConfiguration.PluginMarketplaces]: ['microsoft/vscode#marketplace'],
+			[ChatConfiguration.PluginsEnabled]: true,
+		}));
+		instantiationService.stub(IEnvironmentService, { cacheHome: URI.file('/cache') } as Partial<IEnvironmentService> as IEnvironmentService);
+		instantiationService.stub(IFileService, {} as unknown as IFileService);
+		instantiationService.stub(IAgentPluginRepositoryService, {
+			agentPluginsHome: URI.file('/agent-plugins'),
+			ensureRepository: async () => {
+				throw new Error('should not clone for 5xx responses');
+			},
+		} as Partial<IAgentPluginRepositoryService> as IAgentPluginRepositoryService);
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(IRequestService, {
+			request: async (options: { url: string }) => {
+				requestUrls.push(options.url);
+				return { res: { headers: {}, statusCode: 500 }, stream: bufferToStream(VSBuffer.fromString('')) };
+			},
+		} as Partial<IRequestService> as IRequestService);
+		instantiationService.stub(IStorageService, store.add(new InMemoryStorageService()));
+		instantiationService.stub(IWorkspacePluginSettingsService, {
+			extraMarketplaces: observableValue('test.extraMarketplaces', []),
+			enabledPlugins: observableValue('test.enabledPlugins', new Map()),
+		} as Partial<IWorkspacePluginSettingsService> as IWorkspacePluginSettingsService);
+		instantiationService.stub(IWorkspaceTrustManagementService, {
+			isWorkspaceTrusted: () => true,
+			onDidChangeTrust: Event.None,
+		} as Partial<IWorkspaceTrustManagementService> as IWorkspaceTrustManagementService);
+
+		const service = store.add(instantiationService.createInstance(PluginMarketplaceService));
+		await service.fetchMarketplacePlugins(CancellationToken.None);
+
+		assert.ok(requestUrls.length > 0);
+		assert.ok(requestUrls.every(url => url.includes('/marketplace/')));
+		assert.ok(requestUrls.every(url => !url.includes('/main/')));
 	});
 });
 
@@ -454,7 +544,7 @@ suite('PluginMarketplaceService - hydration after restart', () => {
 
 	test('hydrates a github-sourced plugin from installed.json name and marketplace cache after restart', async () => {
 		// Simulates: user installs the "azure" plugin from the
-		// "github/awesome-copilot" marketplace (fetched via HTTP, never
+		// "github/awesome-copilot#marketplace" marketplace (fetched via HTTP, never
 		// cloned). After restart, installed.json contains only the durable
 		// identity for that plugin; the full descriptor is recovered from
 		// marketplace data cached from the prior fetch.
@@ -462,7 +552,7 @@ suite('PluginMarketplaceService - hydration after restart', () => {
 		const storageService = store.add(new InMemoryStorageService());
 		const fileService = new TestFileService();
 
-		const awesomeCopilot = parseMarketplaceReference('github/awesome-copilot')!;
+		const awesomeCopilot = parseMarketplaceReference('github/awesome-copilot#marketplace')!;
 		const azurePlugin = makeAzurePlugin(awesomeCopilot);
 		storeMarketplaceCache(storageService, awesomeCopilot, azurePlugin);
 		const azurePluginUri = URI.joinPath(CACHE_ROOT, 'github.com', 'microsoft', 'azure-skills', '.github', 'plugins', 'azure-skills');
@@ -479,7 +569,7 @@ suite('PluginMarketplaceService - hydration after restart', () => {
 
 		const instantiationService = store.add(new TestInstantiationService());
 		instantiationService.stub(IConfigurationService, new TestConfigurationService({
-			[ChatConfiguration.PluginMarketplaces]: ['github/awesome-copilot'],
+			[ChatConfiguration.PluginMarketplaces]: ['github/awesome-copilot#marketplace'],
 			[ChatConfiguration.PluginsEnabled]: true,
 		}));
 		instantiationService.stub(IEnvironmentService, { cacheHome: URI.file('/cache') } as Partial<IEnvironmentService> as IEnvironmentService);
@@ -521,7 +611,7 @@ suite('PluginMarketplaceService - hydration after restart', () => {
 		const storageService = store.add(new InMemoryStorageService());
 		const fileService = new TestFileService();
 
-		const awesomeCopilot = parseMarketplaceReference('github/awesome-copilot')!;
+		const awesomeCopilot = parseMarketplaceReference('github/awesome-copilot#marketplace')!;
 		const azurePluginUri = URI.joinPath(CACHE_ROOT, 'github.com', 'microsoft', 'azure-skills', '.github', 'plugins', 'azure-skills');
 		const azurePlugin = makeAzurePlugin(awesomeCopilot);
 		storeMarketplaceCache(storageService, awesomeCopilot, azurePlugin);
@@ -529,7 +619,7 @@ suite('PluginMarketplaceService - hydration after restart', () => {
 		function makeService(): PluginMarketplaceService {
 			const instantiationService = store.add(new TestInstantiationService());
 			instantiationService.stub(IConfigurationService, new TestConfigurationService({
-				[ChatConfiguration.PluginMarketplaces]: ['github/awesome-copilot'],
+				[ChatConfiguration.PluginMarketplaces]: ['github/awesome-copilot#marketplace'],
 				[ChatConfiguration.PluginsEnabled]: true,
 			}));
 			instantiationService.stub(IEnvironmentService, { cacheHome: URI.file('/cache') } as Partial<IEnvironmentService> as IEnvironmentService);

--- a/src/vs/workbench/contrib/chat/test/common/plugins/workspacePluginSettingsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/plugins/workspacePluginSettingsService.test.ts
@@ -147,6 +147,25 @@ suite('WorkspacePluginSettingsService', () => {
 		assert.strictEqual(marketplaces[0].reference.githubRepo, 'owner/repo');
 	}));
 
+	test('parses marketplace refs from extraKnownMarketplaces', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+		await writeClaudeSettings(JSON.stringify({
+			extraKnownMarketplaces: {
+				'my-marketplace': {
+					source: 'github',
+					repo: 'owner/repo',
+					ref: 'marketplace',
+				}
+			}
+		}));
+
+		const service = createService();
+		await waitForState(service.extraMarketplaces, v => v.length > 0);
+
+		const marketplaces = service.extraMarketplaces.get();
+		assert.strictEqual(marketplaces[0].reference.ref, 'marketplace');
+		assert.strictEqual(marketplaces[0].reference.canonicalId, 'github:owner/repo#marketplace');
+	}));
+
 	test('parses nested source object from extraKnownMarketplaces', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 		await writeClaudeSettings(JSON.stringify({
 			extraKnownMarketplaces: {


### PR DESCRIPTION
## Description

This updates plugin marketplace references to support explicit Git refs and switches the default github/awesome-copilot marketplace to github/awesome-copilot#marketplace.

It also wires the marketplace ref through the related code paths so that:
- marketplace references can include #ref
- GitHub marketplace fetches read definition files from the configured ref instead of always using main
- ref-specific marketplace caches and clone locations stay distinct
- workspace marketplace settings can carry a ref
- tests cover parsing, fetching, and repository handling for ref-aware marketplaces

## Related Issue

https://github.com/github/awesome-copilot/issues/1368

## Testing

Not run in this checkout. Local validation was blocked because 
ode_modules and compiled out artifacts are not present.