### PR TITLE
SSH agent host: fix reconnect failure after sleep/network-change

### DIFF
--- a/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
@@ -377,6 +377,21 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 	}
 
 	/**
+	 * Externally signal that the transport has closed. Used by services
+	 * managing a passive transport (SSH / dev-tunnels) when they observe
+	 * a connection-loss IPC event independent of the transport's own
+	 * onClose — without this, a single dropped IPC delivery on the
+	 * transport's close channel leaves the client stranded in
+	 * `Connected` until its watchdog fires (which can take hours when
+	 * the renderer is backgrounded and `setTimeout` is throttled).
+	 *
+	 * Idempotent — no-op if already closed or mid-reconnect.
+	 */
+	notifyTransportClosed(): void {
+		this._handleTransportClose();
+	}
+
+	/**
 	 * Called from the transport's `onClose` event. When a {@link _transportFactory}
 	 * is configured we attempt to soft-reconnect rather than fire `onDidClose` —
 	 * the protocol-level `reconnect` request lets the server replay missed

--- a/src/vs/platform/agentHost/browser/remoteAgentHostServiceImpl.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostServiceImpl.ts
@@ -376,7 +376,13 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 
 	notifyConnectionClosed(address: string): void {
 		const normalized = normalizeRemoteAgentHostAddress(address);
-		this._entries.get(normalized)?.client.notifyTransportClosed();
+		const entry = this._entries.get(normalized);
+		if (entry) {
+			this._logService.info(`[RemoteAgentHost] notifyConnectionClosed: notifying protocol client for ${normalized}`);
+			entry.client.notifyTransportClosed();
+		} else {
+			this._logService.info(`[RemoteAgentHost] notifyConnectionClosed: no entry found for ${normalized} (already removed?)`);
+		}
 	}
 
 	private _reconcileConnections(): void {

--- a/src/vs/platform/agentHost/browser/remoteAgentHostServiceImpl.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostServiceImpl.ts
@@ -374,6 +374,11 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 		}
 	}
 
+	notifyConnectionClosed(address: string): void {
+		const normalized = normalizeRemoteAgentHostAddress(address);
+		this._entries.get(normalized)?.client.notifyTransportClosed();
+	}
+
 	private _reconcileConnections(): void {
 		if (!this._configurationService.getValue<boolean>(RemoteAgentHostsEnabledSettingId)) {
 			// Disconnect all when disabled

--- a/src/vs/platform/agentHost/common/remoteAgentHostService.ts
+++ b/src/vs/platform/agentHost/common/remoteAgentHostService.ts
@@ -256,6 +256,21 @@ export interface IRemoteAgentHostService {
 	addManagedConnection(entry: IRemoteAgentHostEntry, connection: IAgentConnection, transportDisposable?: IDisposable): Promise<IRemoteAgentHostConnectionInfo>;
 
 	/**
+	 * Force the protocol client at `address` (if any) to treat its
+	 * transport as closed. Used by services that learn about a
+	 * connection loss out-of-band — e.g. the SSH service receiving an
+	 * `onDidCloseConnection` IPC event from the shared process — to
+	 * make sure the renderer-side client doesn't sit in `Connected`
+	 * waiting on its watchdog. The watchdog is a `setTimeout` and
+	 * Chromium aggressively throttles those in backgrounded windows,
+	 * so we can't rely on it as the sole death-detection path.
+	 *
+	 * No-op if no active entry exists for the address, or if the
+	 * existing client has already transitioned out of `Connected`.
+	 */
+	notifyConnectionClosed(address: string): void;
+
+	/**
 	 * Look up the {@link IRemoteAgentHostEntry} for a given address.
 	 * Checks both configured entries from settings and dynamically
 	 * registered entries (e.g. tunnel connections).
@@ -299,6 +314,7 @@ export class NullRemoteAgentHostService implements IRemoteAgentHostService {
 	}
 	async removeRemoteAgentHost(_address: string): Promise<void> { }
 	reconnect(_address: string): void { }
+	notifyConnectionClosed(_address: string): void { }
 	async addManagedConnection(): Promise<IRemoteAgentHostConnectionInfo> {
 		throw new Error('Remote agent host connections are not supported in this environment.');
 	}

--- a/src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts
+++ b/src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts
@@ -104,19 +104,21 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 				handle.fireClose();
 				handle.dispose();
 				this._onDidChangeConnections.fire();
+
+				// Defense-in-depth: also signal the protocol client directly. The
+				// SSHRelayTransport normally observes `onDidRelayClose` (fired from
+				// the same shared-process code path as this event) and calls back
+				// into the client. If that IPC delivery is missed for any reason,
+				// the renderer-side client would stay in `Connected` until its
+				// liveness watchdog fires — which can take hours when the
+				// renderer is backgrounded and Chromium throttles `setTimeout`.
+				// Use the handle's address (e.g., "ssh:macbook-air") since
+				// RemoteAgentHostService keys its clients by address, not connectionId.
+				this._logService.info(`[SSHRemoteAgentHost] onDidCloseConnection: notifying protocol client for ${handle.localAddress}`);
+				this._remoteAgentHostService.notifyConnectionClosed(handle.localAddress);
 			} else {
 				this._logService.info(`[SSHRemoteAgentHost] onDidCloseConnection: no renderer-side handle for ${connectionId} (already cleaned up?)`);
 			}
-
-			// Defense-in-depth: also signal the protocol client directly. The
-			// SSHRelayTransport normally observes `onDidRelayClose` (fired from
-			// the same shared-process code path as this event) and calls back
-			// into the client. If that IPC delivery is missed for any reason,
-			// the renderer-side client would stay in `Connected` until its
-			// liveness watchdog fires — which can take hours when the
-			// renderer is backgrounded and Chromium throttles `setTimeout`.
-			this._logService.info(`[SSHRemoteAgentHost] onDidCloseConnection: notifying protocol client for ${connectionId}`);
-			this._remoteAgentHostService.notifyConnectionClosed(connectionId);
 		}));
 
 		// Bridge keyboard-interactive prompts from the shared process to the

--- a/src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts
+++ b/src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts
@@ -103,6 +103,15 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 				handle.dispose();
 				this._onDidChangeConnections.fire();
 			}
+
+			// Defense-in-depth: also signal the protocol client directly. The
+			// SSHRelayTransport normally observes `onDidRelayClose` (fired from
+			// the same shared-process code path as this event) and calls back
+			// into the client. If that IPC delivery is missed for any reason,
+			// the renderer-side client would stay in `Connected` until its
+			// liveness watchdog fires — which can take hours when the
+			// renderer is backgrounded and Chromium throttles `setTimeout`.
+			this._remoteAgentHostService.notifyConnectionClosed(connectionId);
 		}));
 
 		// Bridge keyboard-interactive prompts from the shared process to the

--- a/src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts
+++ b/src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts
@@ -96,12 +96,16 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 		// Do NOT remove the configured entry — it stays persisted so startup reconnect
 		// can re-establish the SSH tunnel on next launch.
 		this._register(this._mainService.onDidCloseConnection(connectionId => {
+			this._logService.info(`[SSHRemoteAgentHost] onDidCloseConnection: connectionId=${connectionId}`);
 			const handle = this._connections.get(connectionId);
 			if (handle) {
+				this._logService.info(`[SSHRemoteAgentHost] onDidCloseConnection: found handle for ${connectionId}, cleaning up`);
 				this._connections.delete(connectionId);
 				handle.fireClose();
 				handle.dispose();
 				this._onDidChangeConnections.fire();
+			} else {
+				this._logService.info(`[SSHRemoteAgentHost] onDidCloseConnection: no renderer-side handle for ${connectionId} (already cleaned up?)`);
 			}
 
 			// Defense-in-depth: also signal the protocol client directly. The
@@ -111,6 +115,7 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 			// the renderer-side client would stay in `Connected` until its
 			// liveness watchdog fires — which can take hours when the
 			// renderer is backgrounded and Chromium throttles `setTimeout`.
+			this._logService.info(`[SSHRemoteAgentHost] onDidCloseConnection: notifying protocol client for ${connectionId}`);
 			this._remoteAgentHostService.notifyConnectionClosed(connectionId);
 		}));
 

--- a/src/vs/platform/agentHost/test/electron-browser/sshRemoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/sshRemoteAgentHostService.test.ts
@@ -150,6 +150,10 @@ class MockRemoteAgentHostService extends Disposable {
 		return { address, name: entry.name, clientId: 'mock', defaultDirectory: undefined, status: 0 };
 	}
 
+	notifyConnectionClosed(_address: string): void {
+		// no-op in tests — the defense-in-depth notification is exercised separately
+	}
+
 	/** Simulate user clicking "Remove Remote": disposes the per-entry store, which runs the transport disposable. */
 	removeEntry(address: string): void {
 		const e = this._entries.get(address);

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable, DisposableMap, DisposableStore, MutableDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
-import { disposableTimeout } from '../../../../../base/common/async.js';
+import { disposableTimeout, IntervalTimer } from '../../../../../base/common/async.js';
 import { isCancellationError } from '../../../../../base/common/errors.js';
 import { Event } from '../../../../../base/common/event.js';
 import { observableValue } from '../../../../../base/common/observable.js';
@@ -69,6 +69,20 @@ const SSH_RECONNECT_MAX_DELAY = 30_000;
  * still being responsive to "the network just came back".
  */
 const SSH_RECONNECT_MAX_ATTEMPTS = 10;
+/**
+ * After this much wall-clock time, a paused auto-reconnect is automatically
+ * resumed by the periodic reconcile. Covers the case where reconnect attempts
+ * all failed quickly (e.g. network not ready right after sleep), exhausted the
+ * attempt budget, and no other trigger (config change, connection event) fired
+ * to give them a fresh chance.
+ */
+const SSH_RECONNECT_PAUSE_AUTO_RESUME_MS = 5 * 60 * 1000; // 5 minutes
+/**
+ * How often the periodic reconcile backstop runs. This fires {@link _reconcile}
+ * even when no event arrives, so a broken event chain doesn't leave SSH hosts
+ * disconnected indefinitely.
+ */
+const SSH_RECONNECT_PERIODIC_INTERVAL_MS = 60_000; // 1 minute
 
 /**
  * Per-host SSH auto-reconnect state. Owned by {@link RemoteAgentHostContribution._sshReconnectStates}
@@ -82,6 +96,8 @@ export class SSHReconnectState extends Disposable {
 	attempts = 0;
 	/** True after we've given up auto-reconnecting until something resumes us. */
 	paused = false;
+	/** Wall-clock timestamp when {@link paused} was last set to true. */
+	pausedAt = 0;
 
 	get hasPendingTimer(): boolean {
 		return !!this._timer.value;
@@ -208,6 +224,17 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 
 		// Initial setup for configured entries and connected remotes
 		this._reconcile();
+
+		// Periodic backstop: even if the event-driven chain breaks (e.g. IPC
+		// delivery fails after a sleep/wake cycle), this ensures we retry SSH
+		// reconnects and reconcile providers at most once per minute.
+		this._register(new IntervalTimer()).cancelAndSet(
+			() => {
+				this._logService.trace('[RemoteAgentHost] Periodic reconcile (backstop)');
+				this._reconcile();
+			},
+			SSH_RECONNECT_PERIODIC_INTERVAL_MS,
+		);
 	}
 
 	private _reconcile(): void {
@@ -328,13 +355,26 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 				continue;
 			}
 			if (this._pendingSSHReconnects.has(sshConfigHost)) {
+				this._logService.trace(`[RemoteAgentHost] SSH reconnect for ${sshConfigHost}: reconnect already in progress, skipping`);
 				continue;
 			}
 			const state = this._sshReconnectStates.get(sshConfigHost);
-			if (state && (state.hasPendingTimer || state.paused)) {
+			if (state?.hasPendingTimer) {
+				this._logService.trace(`[RemoteAgentHost] SSH reconnect for ${sshConfigHost}: retry timer already scheduled, skipping`);
 				continue;
 			}
+			if (state?.paused) {
+				const pausedMs = Date.now() - state.pausedAt;
+				if (pausedMs < SSH_RECONNECT_PAUSE_AUTO_RESUME_MS) {
+					this._logService.trace(`[RemoteAgentHost] SSH reconnect for ${sshConfigHost}: paused (${Math.round(pausedMs / 1000)}s ago), skipping`);
+					continue;
+				}
+				// Pause duration exceeded — give it another chance automatically.
+				this._logService.info(`[RemoteAgentHost] SSH reconnect for ${sshConfigHost}: auto-resuming after ${Math.round(pausedMs / 1000)}s pause`);
+				state.resetForResume();
+			}
 			if (!autoConnect) {
+				this._logService.trace(`[RemoteAgentHost] SSH reconnect for ${sshConfigHost}: auto-connect disabled, skipping`);
 				continue;
 			}
 			void this._attemptSSHReconnect(sshConfigHost, entry.name, address);
@@ -405,6 +445,7 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 				provider?.unpublishCachedSessions();
 				const liveState = this._getOrCreateSSHReconnectState(sshConfigHost);
 				liveState.paused = true;
+				liveState.pausedAt = Date.now();
 				return;
 			}
 			this._logService.error(`[RemoteAgentHost] SSH reconnect failed for ${sshConfigHost}`, err);
@@ -432,6 +473,7 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 			if (liveState.attempts >= SSH_RECONNECT_MAX_ATTEMPTS) {
 				this._logService.info(`[RemoteAgentHost] Pausing SSH auto-reconnect for ${sshConfigHost} after ${liveState.attempts} consecutive failures`);
 				liveState.paused = true;
+				liveState.pausedAt = Date.now();
 				return;
 			}
 			if (options.userInitiated) {


### PR DESCRIPTION
## Problem

After a MacBook sleep + network change, the SSH remote agent host (`ssh:macbook-air`) failed to auto-reconnect for hours until a window reload.

**Root cause** (from `sharedprocess.log`):
1. At 10:11:52 the SSH keepalive timed out and the connection was torn down.
2. Post-wake reconnect attempts all failed quickly (network not ready), rapidly exhausting `SSH_RECONNECT_MAX_ATTEMPTS=10` and setting `paused=true`.
3. Nothing triggered `_resumeSSHReconnects()` or a fresh `_reconcile()` for the next 3+ hours — no config change, no new connection, nothing — so the host sat disconnected until a window reload at 13:29:39.

## Fixes

### Commit 1: Close-propagation defense (`8f0463968fd`)

When the SSH shared-process service fires `onDidCloseConnection`, the renderer-side SSH service now also directly calls `notifyConnectionClosed(address)` on `IRemoteAgentHostService`, which in turn calls `notifyTransportClosed()` on the protocol client. This is defense-in-depth: the `SSHRelayTransport` normally observes `onDidRelayClose` (fired from the same code path) and propagates the close into the protocol client. If that IPC delivery is missed for any reason (e.g. renderer throttled across sleep/wake), this second path ensures the protocol client transitions out of `Connected` promptly rather than waiting for the liveness watchdog.

### Commit 2: Periodic backstop + paused-state auto-resume + diagnostics (`75a9c10a224`)

**Periodic 60s reconcile backstop** — `RemoteAgentHostContribution` now registers a 60-second `IntervalTimer` that calls `_reconcile()`. Even if the entire event-driven chain (IPC → `onDidChangeConnections` → `_reconcile`) breaks, SSH reconnect is retried within a minute.

**Paused-state 5-minute auto-resume** — `SSHReconnectState` now tracks `pausedAt: number`. In `_reconnectSSHEntries()`, if a host has been paused for more than 5 minutes (`SSH_RECONNECT_PAUSE_AUTO_RESUME_MS`), the pause is automatically cleared and a fresh reconnect attempt is made. This directly addresses the root cause: reconnects failing quickly after wake should not silence retries indefinitely.

**Diagnostic logging** — Added `info`-level logs at every step of the reconnect chain:
- `onDidCloseConnection` receipt and whether a renderer-side handle was found
- `notifyConnectionClosed` lookup result
- Each skip condition in `_reconnectSSHEntries` (pending, timer already scheduled, paused with elapsed time, auto-connect disabled)
- Paused→auto-resume transitions

This ensures future failures are diagnosable from `renderer.log` alone.

## Files changed

- `src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution.ts` — periodic backstop, paused auto-resume, diagnostic logging
- `src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts` — diagnostic logging in `onDidCloseConnection` handler
- `src/vs/platform/agentHost/browser/remoteAgentHostServiceImpl.ts` — diagnostic logging in `notifyConnectionClosed`
- `src/vs/platform/agentHost/common/remoteAgentHostService.ts` — `notifyConnectionClosed` interface method (from commit 1)
- `src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts` — `notifyTransportClosed` public method (from commit 1)

(Written by Copilot)