### PR TITLE
Fix `runTests` tool failing to find test files on remote environments

### DIFF
--- a/src/vs/workbench/contrib/testing/common/testService.ts
+++ b/src/vs/workbench/contrib/testing/common/testService.ts
@@ -174,6 +174,12 @@ export const waitForTestToBeIdle = (testService: ITestService, test: Incremental
  * in strictly descending order.
  */
 export const testsInFile = async function* (testService: ITestService, ident: IUriIdentityService, uri: URI, waitForIdle = true, descendInFile = true): AsyncIterable<readonly IncrementalTestCollectionItem[]> {
+	// Canonicalize the URI so that comparisons against test item URIs (which are
+	// stored in their canonical form via asCanonicalUri() during deserialization)
+	// work correctly in remote environments such as WSL, SSH, and dev containers
+	// where URI.file(path) may produce a non-canonical form. Fixes #275268.
+	uri = ident.asCanonicalUri(uri);
+
 	// In this function we go to a bit of effort to avoid awaiting unnecessarily
 	// and bulking the test collections we do collect for consumers. This fixes
 	// a performance issue (#235819) where a large number of tests in a file

--- a/src/vs/workbench/contrib/testing/common/testService.ts
+++ b/src/vs/workbench/contrib/testing/common/testService.ts
@@ -178,7 +178,7 @@ export const testsInFile = async function* (testService: ITestService, ident: IU
 	// stored in their canonical form via asCanonicalUri() during deserialization)
 	// work correctly in remote environments such as WSL, SSH, and dev containers
 	// where URI.file(path) may produce a non-canonical form. Fixes #275268.
-	uri = ident.asCanonicalUri(uri);
+	const canonicalUri = ident.asCanonicalUri(uri);
 
 	// In this function we go to a bit of effort to avoid awaiting unnecessarily
 	// and bulking the test collections we do collect for consumers. This fixes
@@ -186,7 +186,7 @@ export const testsInFile = async function* (testService: ITestService, ident: IU
 	// would cause a long delay switching editors.
 	const queue = new LinkedList<Iterable<string> | DeferredPromise<Iterable<string>>>();
 
-	const existing = [...testService.collection.getNodeByUrl(uri)].sort((a, b) => a.item.extId.length - b.item.extId.length);
+	const existing = [...testService.collection.getNodeByUrl(canonicalUri)].sort((a, b) => a.item.extId.length - b.item.extId.length);
 
 	// getNodeByUrl will return all known tests in the URI, but this can include
 	// children of tests even when `descendInFile` is false. Remove those cases.
@@ -230,7 +230,7 @@ export const testsInFile = async function* (testService: ITestService, ident: IU
 				continue;
 			}
 
-			if (ident.extUri.isEqual(uri, test.item.uri)) {
+			if (ident.extUri.isEqual(canonicalUri, test.item.uri)) {
 				gather.push(test);
 
 				if (!descendInFile) {
@@ -238,7 +238,7 @@ export const testsInFile = async function* (testService: ITestService, ident: IU
 				}
 			}
 
-			if (ident.extUri.isEqualOrParent(uri, test.item.uri)) {
+			if (ident.extUri.isEqualOrParent(canonicalUri, test.item.uri)) {
 				let prom: Promise<void> | undefined;
 				if (test.expand === TestItemExpandState.Expandable) {
 					prom = testService.collection.expand(test.item.extId, 1);

--- a/src/vs/workbench/contrib/testing/test/common/testService.test.ts
+++ b/src/vs/workbench/contrib/testing/test/common/testService.test.ts
@@ -4,10 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
+import { IExtUri } from '../../../../../base/common/resources.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { upcastPartial } from '../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IUriIdentityService } from '../../../../../platform/uriIdentity/common/uriIdentity.js';
 import { TestId } from '../../common/testId.js';
-import { simplifyTestsToExecute } from '../../common/testService.js';
-import { getInitializedMainTestCollection, makeSimpleStubTree } from './testStubs.js';
+import { ITestService, simplifyTestsToExecute, testsInFile } from '../../common/testService.js';
+import { TestTestCollection, TestTestItem, getInitializedMainTestCollection, makeSimpleStubTree } from './testStubs.js';
 
 suite('Workbench - Test Service', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
@@ -103,6 +107,45 @@ suite('Workbench - Test Service', () => {
 				new TestId(['ctrlId', 'a', 'b1', 'c2']).toString(),
 				new TestId(['ctrlId', 'a', 'b2']).toString(),
 			]);
+		});
+	});
+
+	suite('testsInFile', () => {
+		test('canonicalizes URI before comparing with stored test URIs (#275268)', async () => {
+			const canonicalUri = URI.from({ scheme: 'vscode-remote', authority: 'wsl+Ubuntu', path: '/home/user/test.py' });
+			const rawUri = URI.file('/home/user/test.py');
+
+			// Build a collection where test items are stored with the canonical URI.
+			const collection = new TestTestCollection();
+			collection.resolveHandler = item => {
+				if (item === undefined) {
+					collection.root.children.add(new TestTestItem(new TestId(['ctrlId', 'test1']), 'test1', canonicalUri));
+				}
+			};
+			const mainCollection = await getInitializedMainTestCollection(collection);
+
+			// Mock IUriIdentityService: asCanonicalUri maps rawUri to canonicalUri,
+			// simulating a remote environment where URI.file() produces a non-canonical form.
+			const ident = upcastPartial<IUriIdentityService>({
+				asCanonicalUri: (u: URI) => u.toString() === rawUri.toString() ? canonicalUri : u,
+				extUri: upcastPartial<IExtUri>({
+					isEqual: (a: URI, b: URI) => a.toString() === b.toString(),
+					isEqualOrParent: (a: URI, b: URI) => a.toString() === b.toString(),
+				}),
+			});
+
+			const testService = upcastPartial<ITestService>({
+				collection: mainCollection,
+			});
+
+			const found: string[] = [];
+			for await (const batch of testsInFile(testService, ident, rawUri, false)) {
+				for (const item of batch) {
+					found.push(item.item.extId);
+				}
+			}
+
+			assert.deepStrictEqual(found, [new TestId(['ctrlId', 'test1']).toString()]);
 		});
 	});
 });

--- a/src/vs/workbench/contrib/testing/test/common/testService.test.ts
+++ b/src/vs/workbench/contrib/testing/test/common/testService.test.ts
@@ -10,7 +10,9 @@ import { upcastPartial } from '../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { IUriIdentityService } from '../../../../../platform/uriIdentity/common/uriIdentity.js';
 import { TestId } from '../../common/testId.js';
+import { MainThreadTestCollection } from '../../common/mainThreadTestCollection.js';
 import { ITestService, simplifyTestsToExecute, testsInFile } from '../../common/testService.js';
+import { TestDiffOpType, TestItemExpandState } from '../../common/testTypes.js';
 import { TestTestCollection, TestTestItem, getInitializedMainTestCollection, makeSimpleStubTree } from './testStubs.js';
 
 suite('Workbench - Test Service', () => {
@@ -144,6 +146,72 @@ suite('Workbench - Test Service', () => {
 			}
 
 			assert.deepStrictEqual(found, [new TestId(['ctrlId', 'test1']).toString()]);
+		});
+
+		test('finds live diff-added tests after collection-side canonicalization', async () => {
+			const canonicalUri = URI.from({ scheme: 'vscode-remote', authority: 'wsl+Ubuntu', path: '/home/user/test.py' });
+			const rawUri = URI.file('/home/user/test.py');
+			const extUri = new ExtUri(() => false);
+
+			const collection = new MainThreadTestCollection({
+				asCanonicalUri: (u: URI) => u.toString() === rawUri.toString() ? canonicalUri : u,
+			}, async () => { });
+
+			const testId = new TestId(['ctrlId', 'test1']).toString();
+			collection.apply([
+				{
+					op: TestDiffOpType.Add,
+					item: {
+						expand: TestItemExpandState.NotExpandable,
+						item: {
+							extId: new TestId(['ctrlId']).toString(),
+							label: 'root',
+							tags: [],
+							busy: false,
+							uri: undefined,
+							range: null,
+							description: null,
+							error: null,
+							sortText: null,
+						},
+					}
+				},
+				{
+					op: TestDiffOpType.Add,
+					item: {
+						expand: TestItemExpandState.NotExpandable,
+						item: {
+							extId: testId,
+							label: 'test1',
+							tags: [],
+							busy: false,
+							uri: rawUri,
+							range: null,
+							description: null,
+							error: null,
+							sortText: null,
+						},
+					}
+				}
+			]);
+
+			const ident = upcastPartial<IUriIdentityService>({
+				asCanonicalUri: (u: URI) => u.toString() === rawUri.toString() ? canonicalUri : u,
+				extUri,
+			});
+
+			const testService = upcastPartial<ITestService>({
+				collection,
+			});
+
+			const found: string[] = [];
+			for await (const batch of testsInFile(testService, ident, rawUri, false)) {
+				for (const item of batch) {
+					found.push(item.item.extId);
+				}
+			}
+
+			assert.deepStrictEqual(found, [testId]);
 		});
 	});
 });

--- a/src/vs/workbench/contrib/testing/test/common/testService.test.ts
+++ b/src/vs/workbench/contrib/testing/test/common/testService.test.ts
@@ -148,7 +148,7 @@ suite('Workbench - Test Service', () => {
 			assert.deepStrictEqual(found, [new TestId(['ctrlId', 'test1']).toString()]);
 		});
 
-		test('finds live diff-added tests after collection-side canonicalization', async () => {
+		test('indexes live diff-added tests by canonical URI and still finds them from raw URI input', async () => {
 			const canonicalUri = URI.from({ scheme: 'vscode-remote', authority: 'wsl+Ubuntu', path: '/home/user/test.py' });
 			const rawUri = URI.file('/home/user/test.py');
 			const extUri = new ExtUri(() => false);
@@ -162,6 +162,7 @@ suite('Workbench - Test Service', () => {
 				{
 					op: TestDiffOpType.Add,
 					item: {
+						controllerId: 'ctrlId',
 						expand: TestItemExpandState.NotExpandable,
 						item: {
 							extId: new TestId(['ctrlId']).toString(),
@@ -179,6 +180,7 @@ suite('Workbench - Test Service', () => {
 				{
 					op: TestDiffOpType.Add,
 					item: {
+						controllerId: 'ctrlId',
 						expand: TestItemExpandState.NotExpandable,
 						item: {
 							extId: testId,
@@ -194,6 +196,11 @@ suite('Workbench - Test Service', () => {
 					}
 				}
 			]);
+
+			const added = collection.getNodeById(testId)!;
+			assert.ok(extUri.isEqual(added.item.uri, canonicalUri), 'added test URI should be canonicalized on apply');
+			assert.deepStrictEqual([...collection.getNodeByUrl(canonicalUri)].map(t => t.item.extId), [testId]);
+			assert.deepStrictEqual([...collection.getNodeByUrl(rawUri)].map(t => t.item.extId), []);
 
 			const ident = upcastPartial<IUriIdentityService>({
 				asCanonicalUri: (u: URI) => u.toString() === rawUri.toString() ? canonicalUri : u,

--- a/src/vs/workbench/contrib/testing/test/common/testService.test.ts
+++ b/src/vs/workbench/contrib/testing/test/common/testService.test.ts
@@ -130,7 +130,7 @@ suite('Workbench - Test Service', () => {
 			// Mock IUriIdentityService: asCanonicalUri maps rawUri to canonicalUri,
 			// simulating a remote environment where URI.file() produces a non-canonical form.
 			const ident = upcastPartial<IUriIdentityService>({
-				asCanonicalUri: (u: URI) => u.toString() === rawUri.toString() ? canonicalUri : u,
+				asCanonicalUri: (u: URI) => extUri.isEqual(u, rawUri) ? canonicalUri : u,
 				extUri,
 			});
 
@@ -203,7 +203,7 @@ suite('Workbench - Test Service', () => {
 			assert.deepStrictEqual([...collection.getNodeByUrl(rawUri)].map(t => t.item.extId), []);
 
 			const ident = upcastPartial<IUriIdentityService>({
-				asCanonicalUri: (u: URI) => u.toString() === rawUri.toString() ? canonicalUri : u,
+				asCanonicalUri: (u: URI) => extUri.isEqual(u, rawUri) ? canonicalUri : u,
 				extUri,
 			});
 

--- a/src/vs/workbench/contrib/testing/test/common/testService.test.ts
+++ b/src/vs/workbench/contrib/testing/test/common/testService.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { IExtUri } from '../../../../../base/common/resources.js';
+import { ExtUri } from '../../../../../base/common/resources.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { upcastPartial } from '../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
@@ -114,6 +114,7 @@ suite('Workbench - Test Service', () => {
 		test('canonicalizes URI before comparing with stored test URIs (#275268)', async () => {
 			const canonicalUri = URI.from({ scheme: 'vscode-remote', authority: 'wsl+Ubuntu', path: '/home/user/test.py' });
 			const rawUri = URI.file('/home/user/test.py');
+			const extUri = new ExtUri(() => false);
 
 			// Build a collection where test items are stored with the canonical URI.
 			const collection = new TestTestCollection();
@@ -128,10 +129,7 @@ suite('Workbench - Test Service', () => {
 			// simulating a remote environment where URI.file() produces a non-canonical form.
 			const ident = upcastPartial<IUriIdentityService>({
 				asCanonicalUri: (u: URI) => u.toString() === rawUri.toString() ? canonicalUri : u,
-				extUri: upcastPartial<IExtUri>({
-					isEqual: (a: URI, b: URI) => a.toString() === b.toString(),
-					isEqualOrParent: (a: URI, b: URI) => a.toString() === b.toString(),
-				}),
+				extUri,
 			});
 
 			const testService = upcastPartial<ITestService>({


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes `runTests` file lookups in remote environments by canonicalizing the URI passed to `testsInFile()` before comparing it with stored test item URIs.

Test item URIs are already canonicalized during deserialization. In remote environments such as WSL, SSH, and dev containers, `URI.file(path)` can produce a non-canonical URI, which causes `getNodeByUrl()` and later URI comparisons to miss tests in the requested file. This change normalizes the incoming URI with `IUriIdentityService.asCanonicalUri()` and adds a unit test that covers the raw-vs-canonical mismatch.

Fixes #275268.

Credits to @grimlor for the [analysis](https://github.com/microsoft/vscode/issues/275268#issuecomment-4291392195).

_Disclaimer: this PR has been written with assistance of Claude Sonnet 4.6._