### PR TITLE
Register Agent Host debug log export action only in workbench

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatDeveloperActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatDeveloperActions.ts
@@ -20,7 +20,6 @@ import { IChatWidgetService } from '../chat.js';
 import { IStorageService, StorageScope } from '../../../../../platform/storage/common/storage.js';
 import { AUTOPILOT_DONT_SHOW_AGAIN_KEY, AUTO_APPROVE_DONT_SHOW_AGAIN_KEY } from '../../common/chatPermissionStorageKeys.js';
 import { resetShownWarnings } from '../../common/chatPermissionWarnings.js';
-import { ExportAgentHostDebugLogsAction } from './exportAgentHostDebugLogsAction.js';
 import { OpenCopilotCliStateFileAction } from './openCopilotCliStateFileAction.js';
 
 function uriReplacer(_key: string, value: unknown): unknown {
@@ -44,7 +43,6 @@ export function registerChatDeveloperActions() {
 	registerAction2(ClearRecentlyUsedLanguageModelsAction);
 	registerAction2(ResetChatPermissionWarningDialogsAction);
 	registerAction2(OpenCopilotCliStateFileAction);
-	registerAction2(ExportAgentHostDebugLogsAction);
 }
 
 function formatChatModelReferenceInspection(accessor: ServicesAccessor): string {

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -4,6 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { ExportAgentHostDebugLogsAction } from './actions/exportAgentHostDebugLogsAction.js';
 import { ForkConversationAction } from './actions/chatForkActions.js';
 
 registerAction2(ForkConversationAction);
+registerAction2(ExportAgentHostDebugLogsAction);


### PR DESCRIPTION
The shared chat contribution is loaded by both the normal workbench and the Agents window. Registering the workbench-side `ExportAgentHostDebugLogsAction` from that shared developer-actions path made it appear in the Agents window alongside the Agents-window-specific action.

## Fix

Move the workbench action registration to `src/vs/workbench/contrib/chat/browser/chat.contribution.ts`, which is imported by the normal workbench but not by the Agents window.

This keeps `workbench.action.chat.exportAgentHostDebugLogs` available in VS Code while avoiding loading/registering that workbench command contribution in the Agents window. The Agents window continues to use its own `agentHost.exportDebugLogs` action.