### PR TITLE
sessions: Distinguish local agent host sessions

### DIFF
--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -163,7 +163,7 @@ Providers may fire `onDidReplaceSession` when a temporary (untitled) session is 
 
 ## Adding a New Provider
 
-1. **Implement `ISessionsProvider`** with a unique `id`, `sessionTypes`, and `browseActions`
+1. **Implement `ISessionsProvider`** with a unique `id`, `sessionTypes`, and `browseActions`; set the optional provider `icon` only when provider-level UI needs to disambiguate that provider from otherwise similar session types
 2. **Create session data classes** implementing `ISession` with observable properties
 3. **Place code under `contrib/providers/<name>/`**
 4. **Register via a workbench contribution** at `WorkbenchPhase.AfterRestored`:
@@ -201,4 +201,3 @@ The **agents window core workbench** is defined as all sessions code *outside* `
 When you add a property or method to `ISession` or `ISessionsProvider`, it **must** be referenced by at least one file in the core workbench, not only within provider implementations.
 
 **Rationale:** If an interface member is only used inside providers, it belongs on the provider's concrete class, not on the shared interface. Interfaces should capture what the orchestration layer (management service, UI) needs from providers — not internal implementation details that leak outward.
-

--- a/src/vs/sessions/SESSIONS_LIST.md
+++ b/src/vs/sessions/SESSIONS_LIST.md
@@ -30,6 +30,7 @@ Each session row displays:
 - **Workspace badge** — folder/worktree/cloud icon + label (hidden when redundant with section header)
 - **Diff stats** — `+insertions −deletions` when the session has pending changes
 - **Status description or timestamp** — InProgress/NeedsInput/Error show a status message; otherwise a relative timestamp
+- **Provider icon** - optional icon after the timestamp/status for providers that need disambiguation
 - **Approval row** (optional) — pending agent approvals with an "Allow" button
 
 ### Grouping

--- a/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
@@ -145,6 +145,13 @@
 		display: none;
 	}
 
+	/* When the label collapses, also hide the provider icon so the
+	 * chip stays a single icon (the provider icon only makes sense next to the
+	 * agent name). */
+	.new-chat-widget-container .new-chat-bottom-container .sessions-chat-dropdown-provider-icon {
+		display: none;
+	}
+
 	.new-chat-widget-container .new-chat-bottom-container .sessions-chat-permission-picker .sessions-chat-dropdown-label {
 		display: revert;
 	}
@@ -266,7 +273,7 @@
 }
 
 .sessions-chat-picker-slot.sessions-chat-workspace-picker .action-label > .codicon:not(.sessions-chat-dropdown-chevron),
-.sessions-chat-picker-slot.sessions-chat-session-type-picker .action-label > .codicon:not(.codicon-chevron-down) {
+.sessions-chat-picker-slot.sessions-chat-session-type-picker .action-label > .codicon:not(.codicon-chevron-down):not(.sessions-chat-dropdown-provider-icon) {
 	font-size: 16px;
 	margin: 0;
 }
@@ -280,6 +287,18 @@
 	margin-left: 6px;
 	line-height: 1;
 	transform: translateY(1px);
+}
+
+.sessions-chat-picker-slot.sessions-chat-session-type-picker .action-label > .codicon.sessions-chat-dropdown-provider-icon {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	flex: 0 0 auto;
+	font-size: 13px;
+	line-height: 1;
+	margin-left: 4px;
+	margin-right: -2px;
+	opacity: 0.7;
 }
 
 .sessions-chat-dropdown-label {

--- a/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
@@ -321,19 +321,30 @@ export class SessionTypePicker extends Disposable {
 		}
 
 		this._triggerElement.classList.remove('hidden');
-		const currentType = this._folderSessionTypes.find(t =>
-			t.providerId === this._picked?.providerId && t.sessionType.id === this._picked?.sessionTypeId)?.sessionType
-			?? this._folderSessionTypes.find(t => t.sessionType.id === this._picked?.sessionTypeId)?.sessionType;
+		const currentEntry = this._folderSessionTypes.find(t =>
+			t.providerId === this._picked?.providerId && t.sessionType.id === this._picked?.sessionTypeId)
+			?? this._folderSessionTypes.find(t => t.sessionType.id === this._picked?.sessionTypeId);
+		const currentType = currentEntry?.sessionType;
 		const modeIcon = currentType?.icon ?? Codicon.terminal;
 		const modeLabel = currentType?.label ?? this._picked?.sessionTypeId ?? '';
+		const provider = currentEntry ? this.sessionsProvidersService.getProvider(currentEntry.providerId) : undefined;
+		const providerIcon = provider?.icon;
 
 		dom.append(this._triggerElement, renderIcon(modeIcon));
 		const labelSpan = dom.append(this._triggerElement, dom.$('span.sessions-chat-dropdown-label'));
 		labelSpan.textContent = modeLabel;
 
+		if (providerIcon) {
+			const providerIconEl = dom.append(this._triggerElement, renderIcon(providerIcon));
+			providerIconEl.classList.add('sessions-chat-dropdown-provider-icon');
+			providerIconEl.setAttribute('aria-hidden', 'true');
+		}
+
 		const chevron = dom.append(this._triggerElement, renderIcon(Codicon.chevronDown));
 		chevron.classList.add('sessions-chat-dropdown-chevron');
 
-		this._triggerElement.ariaLabel = localize('sessionTypePicker.triggerAriaLabel', "Pick Session Type, {0}", modeLabel);
+		this._triggerElement.ariaLabel = providerIcon && provider?.label
+			? localize('sessionTypePicker.triggerAriaLabelWithProvider', "Pick Session Type, {0}, {1}", modeLabel, provider.label)
+			: localize('sessionTypePicker.triggerAriaLabel', "Pick Session Type, {0}", modeLabel);
 	}
 }

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -931,11 +931,11 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 
 	abstract readonly id: string;
 	abstract readonly label: string;
-	abstract readonly icon: ThemeIcon;
 	abstract readonly browseActions: readonly ISessionWorkspaceBrowseAction[];
 
 	get sessionTypes(): readonly ISessionType[] { return this._sessionTypes; }
 	protected _sessionTypes: ISessionType[] = [];
+	protected abstract readonly sessionIconFallback: ThemeIcon;
 
 	protected readonly _onDidChangeSessionTypes = this._register(new Emitter<void>());
 	readonly onDidChangeSessionTypes: Event<void> = this._onDidChangeSessionTypes.event;
@@ -1128,7 +1128,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			throw new Error(`Agent session URI has no provider scheme: ${meta.session.toString()}`);
 		}
 		return new AgentHostSessionAdapter(meta, this.id, this.resourceSchemeForProvider(provider), provider, {
-			icon: this.iconForAgentProvider(provider) ?? this.icon,
+			icon: this.iconForAgentProvider(provider) ?? this.sessionIconFallback,
 			loading: this.authenticationPending,
 			mapDiffUri: this._diffUriMapper(),
 			gitHubService: this._gitHubService,
@@ -1162,7 +1162,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 		const next = rootState.agents.map((agent): ISessionType => ({
 			id: agent.provider,
 			label: this._formatSessionTypeLabel(agent.displayName?.trim() || agent.provider),
-			icon: this.iconForAgentProvider(agent.provider) ?? this.icon,
+			icon: this.iconForAgentProvider(agent.provider) ?? this.sessionIconFallback,
 		}));
 
 		const prev = this._sessionTypes;

--- a/src/vs/sessions/contrib/providers/agentHost/browser/localAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/localAgentHostSessionsProvider.ts
@@ -43,9 +43,10 @@ export class LocalAgentHostSessionsProvider extends BaseAgentHostSessionsProvide
 
 	readonly id = LOCAL_AGENT_HOST_PROVIDER_ID;
 	readonly label: string;
-	readonly icon: ThemeIcon = Codicon.vm;
+	readonly icon: ThemeIcon = Codicon.serverProcess;
 	readonly browseActions: readonly ISessionWorkspaceBrowseAction[];
 	readonly supportsLocalWorkspaces = true;
+	protected readonly sessionIconFallback: ThemeIcon = Codicon.vm;
 
 	private readonly _localLabel = localize('localAgentHostSessionTypeLocation', "Local");
 	private readonly _localDescription = new MarkdownString(this._localLabel);

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -1652,7 +1652,6 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 
 	readonly id = COPILOT_PROVIDER_ID;
 	readonly label = localize('copilotChatSessionsProvider', "Copilot Chat");
-	readonly icon = Codicon.copilot;
 
 	get sessionTypes(): readonly ISessionType[] {
 		const types: ISessionType[] = [CopilotCLISessionType, CopilotCloudSessionType];

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
@@ -132,9 +132,9 @@ export class RemoteAgentHostSessionsProvider extends BaseAgentHostSessionsProvid
 
 	readonly id: string;
 	readonly label: string;
-	readonly icon: ThemeIcon = Codicon.remote;
 	readonly remoteAddress: string;
 	readonly browseActions: readonly ISessionWorkspaceBrowseAction[];
+	protected readonly sessionIconFallback: ThemeIcon = Codicon.remote;
 
 	private _outputChannelId: string | undefined;
 	get outputChannelId(): string | undefined { return this._outputChannelId; }

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -162,6 +162,15 @@
 			}
 		}
 
+		.session-provider-icon {
+			display: flex;
+			align-items: center;
+
+			> .codicon {
+				font-size: 12px;
+			}
+		}
+
 		.session-diff {
 			font-variant-numeric: tabular-nums;
 			overflow: hidden;

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -47,6 +47,7 @@ import { IAgentSessionsService } from '../../../../../workbench/contrib/chat/bro
 import { IAccessibilityService } from '../../../../../platform/accessibility/common/accessibility.js';
 import { ISessionsListModelService } from './sessionsListModelService.js';
 import { IAgentHostFilterService } from '../../../../services/agentHostFilter/common/agentHostFilter.js';
+import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
 
 const $ = DOM.$;
 
@@ -200,6 +201,7 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 		private readonly hoverService: IHoverService,
 		private readonly agentSessionsService: IAgentSessionsService,
 		private readonly accessibilityService: IAccessibilityService,
+		private readonly sessionsProvidersService: ISessionsProvidersService,
 	) {
 		this._motionReducedSignal = observableSignalFromEvent('reduceMotion', this.accessibilityService.onDidChangeReducedMotion);
 	}
@@ -458,8 +460,24 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 					timeEl.textContent = formatTime();
 				}, 60_000);
 				timeDisposable.value = toDisposable(() => targetWindow.clearInterval(interval));
+				parts.push(timeEl);
 			} else {
 				timeDisposable.clear();
+			}
+
+			// Provider-defined icon for session type disambiguation.
+			const provider = this.sessionsProvidersService.getProvider(element.providerId);
+			const providerIcon = provider?.icon;
+			if (providerIcon) {
+				if (parts.length > 0) {
+					DOM.append(template.detailsRow, $('span.session-separator.has-separator'));
+				}
+				const providerIconEl = DOM.append(template.detailsRow, $('span.session-provider-icon'));
+				DOM.append(providerIconEl, $(`span${ThemeIcon.asCSSSelector(providerIcon)}`));
+				const tooltip = provider?.label ?? localize('sessionsList.providerIndicator', "Session type indicator");
+				template.elementDisposables.add(this.hoverService.setupDelayedHover(providerIconEl, {
+					content: tooltip,
+				}));
 			}
 		}));
 
@@ -826,6 +844,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 		const hoverService = instantiationService.invokeFunction(accessor => accessor.get(IHoverService));
 		const agentSessionsService = instantiationService.invokeFunction(accessor => accessor.get(IAgentSessionsService));
 		const accessibilityService = instantiationService.invokeFunction(accessor => accessor.get(IAccessibilityService));
+		const sessionsProvidersService = instantiationService.invokeFunction(accessor => accessor.get(ISessionsProvidersService));
 		const sessionRenderer = new SessionItemRenderer(
 			{ grouping: this.options.grouping, sorting: this.options.sorting, isPinned: s => this.isSessionPinned(s), isRead: s => this.isSessionRead(s) },
 			approvalModel,
@@ -835,6 +854,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 			hoverService,
 			agentSessionsService,
 			accessibilityService,
+			sessionsProvidersService,
 		);
 
 		const showMoreRenderer = new SessionShowMoreRenderer();

--- a/src/vs/sessions/services/sessions/common/sessionsProvider.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsProvider.ts
@@ -47,9 +47,9 @@ export interface ISessionsProvider {
 	readonly label: string;
 
 	/**
-	 * Icon for the provider, used in the UI.
+	 * Optional icon for the provider, used in the UI.
 	 */
-	readonly icon: ThemeIcon;
+	readonly icon?: ThemeIcon;
 
 	/**
 	 * Session types supported by this provider. The provider is expected to update this list and fire `onDidChangeSessionTypes`


### PR DESCRIPTION
Icon in list

<img width="333" height="319" alt="image" src="https://github.com/user-attachments/assets/ad7eb3da-ba9b-46dd-8219-bf61af6c30df" />


## Summary

Adds a provider-level icon marker for local agent host sessions so they can be distinguished from local extension-host CLI sessions in shared new-session/session-list UI.

## Details

- Makes `ISessionsProvider.icon` optional and uses it as a client-side provider marker.
- Sets the local agent host provider icon to `server-process`; remote agent host and Copilot Chat providers do not set a provider marker.
- Keeps agent/session-type fallback icons separate via `sessionIconFallback`, preserving existing `vm`/`remote` fallbacks for unknown agent providers.
- Shows the provider marker in the session type picker chip and session list detail row, with adjusted layout and accessibility labels.

## Validation

- `npm run compile-check-ts-native`
- `npm run valid-layers-check`
- `node --experimental-strip-types build/hygiene.ts ...`
- `scripts/test.sh --grep "LocalAgentHostSessionsProvider|Sessions - SessionsList Helpers"`

(Written by Copilot)
