### PR TITLE
feat: add commit and sync skill buttons to Changes View for agent-hos…

### DIFF
--- a/src/vs/sessions/contrib/changes/browser/changesView.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesView.ts
@@ -69,7 +69,7 @@ import { EditorResourceAccessor, SideBySideEditor } from '../../../../workbench/
 import { logChangesViewFileSelect, logChangesViewVersionModeChange, logChangesViewViewModeChange } from '../../../common/sessionsTelemetry.js';
 import { ChecksViewModel } from './checksViewModel.js';
 // eslint-disable-next-line local/code-import-patterns -- TODO: move skill button constants out of providers
-import { AGENT_HOST_SKILL_BUTTON_UPDATE_PR_ID, isAgentHostSkillButtonId } from '../../providers/agentHost/browser/agentHostSkillButtons.js';
+import { AGENT_HOST_SKILL_BUTTON_COMMIT_ID, AGENT_HOST_SKILL_BUTTON_SYNC_ID, AGENT_HOST_SKILL_BUTTON_UPDATE_PR_ID, isAgentHostSkillButtonId } from '../../providers/agentHost/browser/agentHostSkillButtons.js';
 import { ActiveSessionContextKeys, CHANGES_VIEW_CONTAINER_ID, CHANGES_VIEW_ID, ChangesContextKeys, ChangesViewMode, IsolationMode } from '../common/changes.js';
 import { buildTreeChildren, ChangesTreeElement, ChangesTreeRenderer, IChangesFileItem, IChangesTreeRootInfo, isChangesFileItem, toIChangesFileItem } from './changesViewRenderer.js';
 import { ChangesViewModel } from './changesViewModel.js';
@@ -206,6 +206,25 @@ class ChangesButtonBarWidget extends Disposable {
 			const labelWithCount = outgoingChanges > 0
 				? `${action.label} ${outgoingChanges}↑`
 				: `${action.label}`;
+			if (!hasGitOperationInProgress) {
+				return { showIcon: true, showLabel: true, isSecondary: false, customLabel: labelWithCount };
+			}
+			return { showIcon: false, showLabel: true, isSecondary: false, customLabel: `$(loading) ${labelWithCount}` };
+		}
+		if (action.id === AGENT_HOST_SKILL_BUTTON_COMMIT_ID) {
+			if (!hasGitOperationInProgress) {
+				return { showIcon: true, showLabel: true, isSecondary: false };
+			}
+			const customLabelObs = derived(reader => {
+				const running = runningLabelObs.read(reader);
+				return `$(loading) ${running ?? action.label}`;
+			});
+			return { showIcon: false, showLabel: true, isSecondary: false, customLabelObs };
+		}
+		if (action.id === AGENT_HOST_SKILL_BUTTON_SYNC_ID) {
+			const labelWithCount = outgoingChanges > 0
+				? `${action.label} ${outgoingChanges}↑`
+				: action.label;
 			if (!hasGitOperationInProgress) {
 				return { showIcon: true, showLabel: true, isSecondary: false, customLabel: labelWithCount };
 			}

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSkillButtons.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSkillButtons.ts
@@ -79,11 +79,43 @@ interface IAgentHostSkillButtonSpec {
 	readonly group: string;
 	readonly order: number;
 	readonly extraWhen: ContextKeyExpression | undefined;
+	/** Menu to register the button on. Defaults to {@link MenuId.AgentsChangesPrimaryActionSubMenu}. */
+	readonly menuId?: MenuId;
 }
 
 const AGENT_HOST_SKILL_BUTTON_ID_PREFIX = 'workbench.action.agentSessions.runSkill.';
 
 const AGENT_HOST_SKILL_BUTTONS: readonly IAgentHostSkillButtonSpec[] = [
+	{
+		id: `${AGENT_HOST_SKILL_BUTTON_ID_PREFIX}commit`,
+		title: localize2('agentSessions.runSkill.commit', "Commit"),
+		skill: 'commit',
+		icon: Codicon.check,
+		group: 'navigation',
+		order: 0,
+		menuId: MenuId.AgentsChangesToolbar,
+		extraWhen: ContextKeyExpr.and(
+			ActiveSessionContextKeys.IsolationMode.isEqualTo(IsolationMode.Worktree),
+			ActiveSessionContextKeys.HasUncommittedChanges,
+		),
+	},
+	{
+		id: `${AGENT_HOST_SKILL_BUTTON_ID_PREFIX}sync`,
+		title: localize2('agentSessions.runSkill.sync', "Sync"),
+		skill: 'sync',
+		icon: Codicon.sync,
+		group: 'navigation',
+		order: 0,
+		menuId: MenuId.AgentsChangesToolbar,
+		extraWhen: ContextKeyExpr.and(
+			ActiveSessionContextKeys.IsolationMode.isEqualTo(IsolationMode.Worktree),
+			ActiveSessionContextKeys.HasUpstream,
+			ContextKeyExpr.or(
+				ActiveSessionContextKeys.HasIncomingChanges,
+				ActiveSessionContextKeys.HasOutgoingChanges,
+			),
+		),
+	},
 	{
 		id: `${AGENT_HOST_SKILL_BUTTON_ID_PREFIX}merge`,
 		title: localize2('agentSessions.runSkill.merge', "Merge Changes"),
@@ -152,6 +184,8 @@ const AGENT_HOST_SKILL_BUTTONS: readonly IAgentHostSkillButtonSpec[] = [
  * as the Copilot CLI extension's Sync PR button. Exported so the changes
  * view can pick it out of the toolbar without re-deriving the ID.
  */
+export const AGENT_HOST_SKILL_BUTTON_COMMIT_ID = `${AGENT_HOST_SKILL_BUTTON_ID_PREFIX}commit`;
+export const AGENT_HOST_SKILL_BUTTON_SYNC_ID = `${AGENT_HOST_SKILL_BUTTON_ID_PREFIX}sync`;
 export const AGENT_HOST_SKILL_BUTTON_UPDATE_PR_ID = `${AGENT_HOST_SKILL_BUTTON_ID_PREFIX}updatePR`;
 
 /**
@@ -171,7 +205,7 @@ function registerAgentHostSkillButton(spec: IAgentHostSkillButtonSpec): void {
 				icon: spec.icon,
 				f1: false,
 				menu: {
-					id: MenuId.AgentsChangesPrimaryActionSubMenu,
+					id: spec.menuId ?? MenuId.AgentsChangesPrimaryActionSubMenu,
 					group: spec.group,
 					order: spec.order,
 					when: ContextKeyExpr.and(

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/agentHostSkillButtons.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/agentHostSkillButtons.test.ts
@@ -18,7 +18,7 @@ import { IChat } from '../../../../../services/sessions/common/session.js';
 import { ISessionsProvidersService } from '../../../../../services/sessions/browser/sessionsProvidersService.js';
 import { ISessionsProvider } from '../../../../../services/sessions/common/sessionsProvider.js';
 import { IActiveSession, ISessionsManagementService } from '../../../../../services/sessions/common/sessionsManagement.js';
-import { AGENT_HOST_SKILL_BUTTON_UPDATE_PR_ID, IsAgentHostSession, IsAgentHostSessionContextContribution, isAgentHostSkillButtonId } from '../../browser/agentHostSkillButtons.js';
+import { AGENT_HOST_SKILL_BUTTON_COMMIT_ID, AGENT_HOST_SKILL_BUTTON_SYNC_ID, AGENT_HOST_SKILL_BUTTON_UPDATE_PR_ID, IsAgentHostSession, IsAgentHostSessionContextContribution, isAgentHostSkillButtonId } from '../../browser/agentHostSkillButtons.js';
 import { BaseAgentHostSessionsProvider } from '../../browser/baseAgentHostSessionsProvider.js';
 // Importing this contribution registers the apply submenu on the changes toolbar,
 // which is the slot that hosts our skill buttons as a dropdown.
@@ -163,8 +163,8 @@ suite('agentHostSkillButtons - menu registration', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	function skillButtonItems() {
-		const all = MenuRegistry.getMenuItems(MenuId.AgentsChangesPrimaryActionSubMenu);
+	function skillButtonItems(menuId: MenuId = MenuId.AgentsChangesPrimaryActionSubMenu) {
+		const all = MenuRegistry.getMenuItems(menuId);
 		const menuItems: { command: { id: string }; when?: ContextKeyExpression }[] = [];
 		for (const item of all) {
 			if (!isIMenuItem(item)) {
@@ -187,8 +187,16 @@ suite('agentHostSkillButtons - menu registration', () => {
 		]);
 	});
 
+	test('registers commit and sync skill buttons on the changes toolbar', () => {
+		const ids = skillButtonItems(MenuId.AgentsChangesToolbar).map(item => item.command.id).sort();
+		assert.deepStrictEqual(ids, [
+			'workbench.action.agentSessions.runSkill.commit',
+			'workbench.action.agentSessions.runSkill.sync',
+		]);
+	});
+
 	test('every skill button `when` clause includes sessions.isAgentHostSession and isSessionsWindow', () => {
-		for (const item of skillButtonItems()) {
+		for (const item of [...skillButtonItems(), ...skillButtonItems(MenuId.AgentsChangesToolbar)]) {
 			const whenStr = item.when?.serialize() ?? '';
 			assert.ok(
 				whenStr.includes(IsAgentHostSession.key),
@@ -205,6 +213,18 @@ suite('agentHostSkillButtons - menu registration', () => {
 		assert.ok(isAgentHostSkillButtonId(AGENT_HOST_SKILL_BUTTON_UPDATE_PR_ID));
 		assert.ok(CommandsRegistry.getCommand(AGENT_HOST_SKILL_BUTTON_UPDATE_PR_ID),
 			`expected command ${AGENT_HOST_SKILL_BUTTON_UPDATE_PR_ID} to be registered`);
+	});
+
+	test('exported commit id matches the registered command', () => {
+		assert.ok(isAgentHostSkillButtonId(AGENT_HOST_SKILL_BUTTON_COMMIT_ID));
+		assert.ok(CommandsRegistry.getCommand(AGENT_HOST_SKILL_BUTTON_COMMIT_ID),
+			`expected command ${AGENT_HOST_SKILL_BUTTON_COMMIT_ID} to be registered`);
+	});
+
+	test('exported sync id matches the registered command', () => {
+		assert.ok(isAgentHostSkillButtonId(AGENT_HOST_SKILL_BUTTON_SYNC_ID));
+		assert.ok(CommandsRegistry.getCommand(AGENT_HOST_SKILL_BUTTON_SYNC_ID),
+			`expected command ${AGENT_HOST_SKILL_BUTTON_SYNC_ID} to be registered`);
 	});
 
 	test('the apply submenu is contributed to the changes toolbar in the navigation group', () => {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #317937

## Description

Adds **Commit** and **Sync** skill buttons to the Changes View toolbar for agent-host sessions, complementing the existing Merge/Create PR/Update PR skill buttons in the dropdown submenu.

### Changes

**`agentHostSkillButtons.ts`**
- Added `commit` skill button registered on `AgentsChangesToolbar`:
  - Visible when worktree isolation mode with uncommitted changes
  - Sends `/commit` prompt to the agent
- Added `sync` skill button registered on `AgentsChangesToolbar`:
  - Visible when upstream exists with incoming/outgoing changes
  - Sends `/sync` prompt to the agent
- Added optional `menuId` field to `IAgentHostSkillButtonSpec` to support registering buttons on either the toolbar directly or the dropdown submenu
- Exported `AGENT_HOST_SKILL_BUTTON_COMMIT_ID` and `AGENT_HOST_SKILL_BUTTON_SYNC_ID` constants

**`changesView.ts`**
- Added button configuration for the commit button: shows loading spinner during git operations
- Added button configuration for the sync button: shows outgoing changes count badge (`↑`) and loading spinner

**`agentHostSkillButtons.test.ts`**
- Added test for commit/sync toolbar registration
- Updated `skillButtonItems()` helper to accept a menu ID parameter
- Updated context key validation to cover all skill buttons (toolbar + submenu)
- Added tests for exported commit and sync button IDs

### How to Test

1. Open a session in the Agent Window with an agent-host provider using worktree isolation
2. Make changes that result in uncommitted files → **Commit** button should appear on the Changes View toolbar
3. After committing, if there are outgoing changes → **Sync** button should appear with count badge (e.g., `Sync 2↑`)
4. During git operations, both buttons should show loading spinners
5. The existing Merge/PR dropdown should still work alongside the new toolbar buttons
6. Unit tests: `scripts/test.sh --grep "agentHostSkillButtons"` → 13 tests passing