### PR TITLE
Add new chat tip for opening the Agents window

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatTipCatalog.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatTipCatalog.ts
@@ -6,9 +6,10 @@
 import { MarkdownString } from '../../../../base/common/htmlContent.js';
 import { localize } from '../../../../nls.js';
 import { ContextKeyExpr, ContextKeyExpression } from '../../../../platform/contextkey/common/contextkey.js';
+import { IsWebContext } from '../../../../platform/contextkey/common/contextkeys.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
 import { MenuRegistry } from '../../../../platform/actions/common/actions.js';
-import { ChatConfiguration, ChatModeKind } from '../common/constants.js';
+import { ChatConfiguration, ChatModeKind, OPEN_AGENTS_WINDOW_COMMAND_ID, OPEN_AGENTS_WINDOW_PRECONDITION, OPEN_WORKSPACE_IN_AGENTS_WINDOW_COMMAND_ID } from '../common/constants.js';
 import { ChatContextKeys } from '../common/actions/chatContextKeys.js';
 import { IsSessionsWindowContext } from '../../../common/contextkeys.js';
 import { localChatSessionType } from '../common/chatSessionsService.js';
@@ -410,6 +411,24 @@ export const TIP_CATALOG: readonly ITipDefinition[] = [
 		},
 		when: ChatContextKeys.chatSessionType.isEqualTo(localChatSessionType),
 		excludeWhenToolsInvoked: ['listDebugEvents'],
+	},
+	{
+		id: 'tip.agentsWindow',
+		tier: ChatTipTier.Qol,
+		buildMessage() {
+			return new MarkdownString(
+				localize(
+					'tip.agentsWindow',
+					"Work across multiple projects at once in the [Agents window](command:{0} \"Open Agents Window\").",
+					OPEN_AGENTS_WINDOW_COMMAND_ID
+				)
+			);
+		},
+		when: ContextKeyExpr.and(IsWebContext.negate(), OPEN_AGENTS_WINDOW_PRECONDITION),
+		excludeWhenCommandsExecuted: [
+			OPEN_AGENTS_WINDOW_COMMAND_ID,
+			OPEN_WORKSPACE_IN_AGENTS_WINDOW_COMMAND_ID,
+		],
 	},
 	{
 		id: 'tip.copilotCli',

--- a/src/vs/workbench/contrib/chat/browser/chatTipCatalog.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatTipCatalog.ts
@@ -30,6 +30,13 @@ export const enum ChatTipTier {
 }
 
 /**
+ * Treatment names for tip messages overridable via the workbench assignment service.
+ */
+export const enum ChatTipExperiment {
+	OpenAgentsWindowTip = 'openagentswindowtip',
+}
+
+/**
  * Context provided to tip builders for dynamic message construction.
  */
 export interface ITipBuildContext {
@@ -37,6 +44,11 @@ export interface ITipBuildContext {
 	 * Keybinding service for looking up keyboard shortcuts.
 	 */
 	readonly keybindingService: IKeybindingService;
+	/**
+	 * Experimental tip message overrides keyed by treatment name (see {@link ChatTipExperiment}).
+	 * Builders should fall back to their default localized strings when a treatment is not set.
+	 */
+	readonly experimentalTipMessages: ReadonlyMap<string, string>;
 }
 
 /**
@@ -415,14 +427,17 @@ export const TIP_CATALOG: readonly ITipDefinition[] = [
 	{
 		id: 'tip.agentsWindow',
 		tier: ChatTipTier.Qol,
-		buildMessage() {
-			return new MarkdownString(
-				localize(
-					'tip.agentsWindow',
-					"Work across multiple projects at once in the [Agents window](command:{0} \"Open Agents Window\").",
-					OPEN_AGENTS_WINDOW_COMMAND_ID
-				)
+		buildMessage(ctx) {
+			const defaultMessage = localize(
+				'tip.agentsWindow',
+				"Work across multiple projects at once in the [Agents window](command:{0} \"Open Agents Window\").",
+				OPEN_AGENTS_WINDOW_COMMAND_ID
 			);
+			const experimentalTemplate = ctx.experimentalTipMessages.get(ChatTipExperiment.OpenAgentsWindowTip);
+			const message = experimentalTemplate
+				? experimentalTemplate.replace(/\{0\}/g, OPEN_AGENTS_WINDOW_COMMAND_ID)
+				: defaultMessage;
+			return new MarkdownString(message);
 		},
 		when: ContextKeyExpr.and(IsWebContext.negate(), OPEN_AGENTS_WINDOW_PRECONDITION),
 		excludeWhenCommandsExecuted: [

--- a/src/vs/workbench/contrib/chat/browser/chatTipService.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatTipService.ts
@@ -23,8 +23,9 @@ import { ITelemetryService } from '../../../../platform/telemetry/common/telemet
 import { ChatRequestAgentSubcommandPart, ChatRequestDynamicVariablePart, ChatRequestSlashCommandPart, IParsedChatRequest } from '../common/requestParser/chatParserTypes.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
 import { TipEligibilityTracker } from './chatTipEligibilityTracker.js';
-import { ChatTipTier, extractCommandIds, ITipBuildContext, ITipDefinition, TIP_CATALOG } from './chatTipCatalog.js';
+import { ChatTipExperiment, ChatTipTier, extractCommandIds, ITipBuildContext, ITipDefinition, TIP_CATALOG } from './chatTipCatalog.js';
 import { ChatTipStorageKeys, TipTrackingCommands } from './chatTipStorageKeys.js';
+import { IWorkbenchAssignmentService } from '../../../services/assignment/common/assignmentService.js';
 
 type ChatTipEvent = {
 	tipId: string;
@@ -200,6 +201,7 @@ export class ChatTipService extends Disposable implements IChatTipService {
 	private _thinkingPhrasesEverModified: boolean;
 	private _tipsHiddenForSession = false;
 	private readonly _tipCommandListener = this._register(new MutableDisposable());
+	private readonly _experimentalTipMessages = new Map<string, string>();
 
 	constructor(
 		@IProductService private readonly _productService: IProductService,
@@ -212,10 +214,13 @@ export class ChatTipService extends Disposable implements IChatTipService {
 		@ICommandService private readonly _commandService: ICommandService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 		@IKeybindingService private readonly _keybindingService: IKeybindingService,
+		@IWorkbenchAssignmentService private readonly _assignmentService: IWorkbenchAssignmentService,
 	) {
 		super();
 		this._tracker = this._register(instantiationService.createInstance(TipEligibilityTracker, TIP_CATALOG));
 		this._createSlashCommandsUsageTracker = this._register(new CreateSlashCommandsUsageTracker(this._chatService, this._storageService, () => this._contextKeyService));
+		this._fetchExperimentalTipMessages();
+		this._register(this._assignmentService.onDidRefetchAssignments(() => this._fetchExperimentalTipMessages()));
 		this._register(this._chatEntitlementService.onDidChangeQuotaExceeded(() => {
 			if (this._chatEntitlementService.quotas.chat?.percentRemaining === 0 && this._shownTip) {
 				this.hideTip();
@@ -819,9 +824,17 @@ export class ChatTipService extends Disposable implements IChatTipService {
 		return !!defaultChatAgent?.chatExtensionId;
 	}
 
+	private _fetchExperimentalTipMessages(): void {
+		this._assignmentService.getTreatment<string>(ChatTipExperiment.OpenAgentsWindowTip).then(value => {
+			if (typeof value === 'string' && value.length > 0) {
+				this._experimentalTipMessages.set(ChatTipExperiment.OpenAgentsWindowTip, value);
+			}
+		});
+	}
+
 	private _createTip(tipDef: ITipDefinition): IChatTip {
 		// Build the tip message with dynamic keybindings and command labels
-		const ctx: ITipBuildContext = { keybindingService: this._keybindingService };
+		const ctx: ITipBuildContext = { keybindingService: this._keybindingService, experimentalTipMessages: this._experimentalTipMessages };
 		const rawMessage = tipDef.buildMessage(ctx);
 
 		// Add "Tip:" prefix once here, avoiding duplication in individual tip definitions
@@ -852,7 +865,7 @@ export class ChatTipService extends Disposable implements IChatTipService {
 		this._tipCommandListener.clear();
 
 		// Build message to extract enabled commands dynamically
-		const ctx: ITipBuildContext = { keybindingService: this._keybindingService };
+		const ctx: ITipBuildContext = { keybindingService: this._keybindingService, experimentalTipMessages: this._experimentalTipMessages };
 		const rawMessage = tip.buildMessage(ctx);
 		const enabledCommands = extractCommandIds(rawMessage.value);
 

--- a/src/vs/workbench/contrib/chat/test/browser/chatTipService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatTipService.test.ts
@@ -17,6 +17,8 @@ import { MockContextKeyService } from '../../../../../platform/keybinding/test/c
 import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
 import { IProductService } from '../../../../../platform/product/common/productService.js';
 import { IStorageService, InMemoryStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
+import { IWorkbenchAssignmentService } from '../../../../services/assignment/common/assignmentService.js';
+import { NullWorkbenchAssignmentService } from '../../../../services/assignment/test/common/nullAssignmentService.js';
 import { ChatTipService, CREATE_AGENT_INSTRUCTIONS_TRACKING_COMMAND, CREATE_AGENT_TRACKING_COMMAND, CREATE_PROMPT_TRACKING_COMMAND, CREATE_SKILL_TRACKING_COMMAND, FORK_CONVERSATION_TRACKING_COMMAND, IChatTip, ITipDefinition, TipEligibilityTracker } from '../../browser/chatTipService.js';
 import { AgentInstructionFileType, IPromptPath, IPromptsService, IAgentInstructionFile, PromptsStorage } from '../../common/promptSyntax/service/promptsService.js';
 import { URI } from '../../../../../base/common/uri.js';
@@ -127,6 +129,7 @@ suite('ChatTipService', () => {
 		instantiationService.stub(IKeybindingService, {
 			lookupKeybinding: () => undefined,
 		} as Partial<IKeybindingService> as IKeybindingService);
+		instantiationService.stub(IWorkbenchAssignmentService, new NullWorkbenchAssignmentService());
 	});
 
 	test('returns a welcome tip', () => {
@@ -144,6 +147,7 @@ suite('ChatTipService', () => {
 				keybindingService: {
 					lookupKeybinding: () => undefined,
 				} as Partial<IKeybindingService> as IKeybindingService,
+				experimentalTipMessages: new Map(),
 			}).value;
 
 			const commandLinkRegex = /\[[^\]]+\]\((command:[^)]+)\)/g;


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce a new chat tip that provides information on how to open the Agents window, including context conditions for its visibility.

https://github.com/microsoft/vscode-internalbacklog/issues/7779