### PR TITLE
sharedProcess: preserve agents window workspace storage

### DIFF
--- a/src/vs/code/electron-utility/sharedProcess/contrib/storageDataCleaner.ts
+++ b/src/vs/code/electron-utility/sharedProcess/contrib/storageDataCleaner.ts
@@ -12,6 +12,7 @@ import { INativeEnvironmentService } from '../../../../platform/environment/comm
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { StorageClient } from '../../../../platform/storage/common/storageIpc.js';
 import { EXTENSION_DEVELOPMENT_EMPTY_WINDOW_WORKSPACE } from '../../../../platform/workspace/common/workspace.js';
+import { getWorkspaceIdentifier } from '../../../../platform/workspaces/common/workspaceIdentifier.js';
 import { NON_EMPTY_WORKSPACE_ID_LENGTH } from '../../../../platform/workspaces/node/workspaces.js';
 import { INativeHostService } from '../../../../platform/native/common/native.js';
 import { IMainProcessService } from '../../../../platform/ipc/common/mainProcessService.js';
@@ -33,7 +34,10 @@ export class UnusedWorkspaceStorageDataCleaner extends Disposable {
 		scheduler.schedule();
 	}
 
-	private async cleanUpStorage(): Promise<void> {
+	/**
+	 * Public for testing.
+	 */
+	async cleanUpStorage(): Promise<void> {
 		this.logService.trace('[storage cleanup]: Starting to clean up workspace storage folders for unused empty workspaces.');
 
 		try {
@@ -50,6 +54,10 @@ export class UnusedWorkspaceStorageDataCleaner extends Disposable {
 
 				if (workspaceStorageFolder === EXTENSION_DEVELOPMENT_EMPTY_WINDOW_WORKSPACE.id) {
 					return; // keep workspace storage for empty extension development workspaces
+				}
+
+				if (workspaceStorageFolder === getWorkspaceIdentifier(this.environmentService.agentSessionsWorkspace).id) {
+					return; // keep workspace storage for the agents window (permanent built-in surface)
 				}
 
 				const windows = await this.nativeHostService.getWindows({ includeAuxiliaryWindows: false });

--- a/src/vs/code/test/electron-utility/sharedProcess/contrib/storageDataCleaner.test.ts
+++ b/src/vs/code/test/electron-utility/sharedProcess/contrib/storageDataCleaner.test.ts
@@ -1,0 +1,76 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import * as fs from 'fs';
+import { tmpdir } from 'os';
+import { Event } from '../../../../../base/common/event.js';
+import { Schemas } from '../../../../../base/common/network.js';
+import { join } from '../../../../../base/common/path.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { Promises } from '../../../../../base/node/pfs.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { getRandomTestPath } from '../../../../../base/test/node/testUtils.js';
+import { IChannel } from '../../../../../base/parts/ipc/common/ipc.js';
+import { INativeEnvironmentService } from '../../../../../platform/environment/common/environment.js';
+import { IMainProcessService } from '../../../../../platform/ipc/common/mainProcessService.js';
+import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { INativeHostService } from '../../../../../platform/native/common/native.js';
+import { getWorkspaceIdentifier } from '../../../../../platform/workspaces/common/workspaceIdentifier.js';
+import { UnusedWorkspaceStorageDataCleaner } from '../../../../electron-utility/sharedProcess/contrib/storageDataCleaner.js';
+
+suite('UnusedWorkspaceStorageDataCleaner', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	let testDir: string;
+
+	setup(async () => {
+		testDir = getRandomTestPath(tmpdir(), 'vsctests', 'storageDataCleaner');
+		await fs.promises.mkdir(testDir, { recursive: true });
+	});
+
+	teardown(async () => {
+		await Promises.rm(testDir);
+	});
+
+	test('preserves agents window workspace storage', async () => {
+		const agentSessionsWorkspace = URI.file(join(testDir, 'agent-sessions.code-workspace'));
+		const agentsWindowFolder = getWorkspaceIdentifier(agentSessionsWorkspace).id;
+		const md5LikeFolder = '0'.repeat(32); // simulates a real (non-empty) workspace
+		const otherEmptyFolder = 'random-empty-id';
+
+		const workspaceStorageHome = join(testDir, 'workspaceStorage');
+		await fs.promises.mkdir(workspaceStorageHome);
+		for (const folder of [agentsWindowFolder, md5LikeFolder, 'ext-dev', otherEmptyFolder]) {
+			await fs.promises.mkdir(join(workspaceStorageHome, folder));
+		}
+
+		const environmentService = {
+			workspaceStorageHome: URI.file(workspaceStorageHome).with({ scheme: Schemas.file }),
+			agentSessionsWorkspace
+		} as INativeEnvironmentService;
+
+		const nativeHostService = {
+			getWindows: async () => []
+		} as Partial<INativeHostService> as INativeHostService;
+
+		const stubChannel: IChannel = {
+			call: async <T>(): Promise<T> => false as unknown as T,
+			listen: () => Event.None
+		};
+		const mainProcessService: IMainProcessService = {
+			_serviceBrand: undefined,
+			getChannel: () => stubChannel,
+			registerChannel: () => { }
+		};
+
+		const cleaner = disposables.add(new UnusedWorkspaceStorageDataCleaner(environmentService, new NullLogService(), nativeHostService, mainProcessService));
+		await cleaner.cleanUpStorage();
+
+		const remaining = (await Promises.readdir(workspaceStorageHome)).sort();
+		assert.deepStrictEqual(remaining, [agentsWindowFolder, md5LikeFolder, 'ext-dev'].sort());
+	});
+});

--- a/src/vs/editor/standalone/browser/standaloneServices.ts
+++ b/src/vs/editor/standalone/browser/standaloneServices.ts
@@ -245,6 +245,7 @@ class StandaloneEnvironmentService implements IEnvironmentService {
 	readonly isBuilt: boolean = false;
 	readonly disableTelemetry: boolean = false;
 	readonly serviceMachineIdResource: URI = URI.from({ scheme: 'monaco', authority: 'serviceMachineIdResource' });
+	readonly agentSessionsWorkspace: URI = URI.from({ scheme: 'monaco', authority: 'agentSessionsWorkspace' });
 	readonly policyFile?: URI | undefined = undefined;
 }
 

--- a/src/vs/platform/environment/common/environment.ts
+++ b/src/vs/platform/environment/common/environment.ts
@@ -91,7 +91,7 @@ export interface IEnvironmentService {
 	serviceMachineIdResource: URI;
 
 	// --- agent sessions workspace
-	agentSessionsWorkspace?: URI;
+	agentSessionsWorkspace: URI;
 	// --- Policy
 	policyFile?: URI;
 

--- a/src/vs/platform/workspaces/common/workspaceIdentifier.ts
+++ b/src/vs/platform/workspaces/common/workspaceIdentifier.ts
@@ -3,9 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ISingleFolderWorkspaceIdentifier, IWorkspaceIdentifier } from '../../../../platform/workspace/common/workspace.js';
-import { URI } from '../../../../base/common/uri.js';
-import { hash } from '../../../../base/common/hash.js';
+import { hash } from '../../../base/common/hash.js';
+import { URI } from '../../../base/common/uri.js';
+import { ISingleFolderWorkspaceIdentifier, IWorkspaceIdentifier } from '../../workspace/common/workspace.js';
 
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 // NOTE: DO NOT CHANGE. IDENTIFIERS HAVE TO REMAIN STABLE

--- a/src/vs/platform/workspaces/test/common/workspaceIdentifier.test.ts
+++ b/src/vs/platform/workspaces/test/common/workspaceIdentifier.test.ts
@@ -4,9 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { URI } from '../../../../../base/common/uri.js';
-import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { getWorkspaceIdentifier, getSingleFolderWorkspaceIdentifier } from '../../browser/workspaces.js';
+import { URI } from '../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { getWorkspaceIdentifier, getSingleFolderWorkspaceIdentifier } from '../../common/workspaceIdentifier.js';
 
 suite('Workspaces', () => {
 	test('workspace identifiers are stable', function () {

--- a/src/vs/sessions/browser/web.main.ts
+++ b/src/vs/sessions/browser/web.main.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { joinPath } from '../../base/common/resources.js';
 import { onUnexpectedError } from '../../base/common/errors.js';
 import { ServiceCollection } from '../../platform/instantiation/common/serviceCollection.js';
 import { ILogService } from '../../platform/log/common/log.js';
@@ -22,7 +21,7 @@ import { IRemoteAgentService } from '../../workbench/services/remote/common/remo
 import { IWorkspaceEditingService } from '../../workbench/services/workspaces/common/workspaceEditing.js';
 import { WorkspaceTrustEnablementService, WorkspaceTrustManagementService } from '../../workbench/services/workspaces/common/workspaceTrust.js';
 import { BrowserMain, IBrowserMainWorkbench } from '../../workbench/browser/web.main.js';
-import { getWorkspaceIdentifier } from '../../workbench/services/workspaces/browser/workspaces.js';
+import { getWorkspaceIdentifier } from '../../platform/workspaces/common/workspaceIdentifier.js';
 import { SessionsWorkspaceContextService } from '../services/workspace/browser/workspaceContextService.js';
 import { ConfigurationService } from '../services/configuration/browser/configurationService.js';
 import { Workbench as SessionsWorkbench } from './workbench.js';
@@ -52,8 +51,7 @@ export class SessionsBrowserMain extends BrowserMain {
 		// workspace file watchers or other resources.
 
 		// Workspace — use a stable synthetic workspace identifier for agents
-		const sessionsWorkspaceUri = joinPath(environmentService.userRoamingDataHome, 'agent-sessions.code-workspace');
-		const workspaceIdentifier = getWorkspaceIdentifier(sessionsWorkspaceUri);
+		const workspaceIdentifier = getWorkspaceIdentifier(environmentService.agentSessionsWorkspace);
 		const workspaceContextService = new SessionsWorkspaceContextService(workspaceIdentifier, uriIdentityService);
 
 		serviceCollection.set(IWorkspaceContextService, workspaceContextService);

--- a/src/vs/sessions/electron-browser/sessions.main.ts
+++ b/src/vs/sessions/electron-browser/sessions.main.ts
@@ -67,7 +67,7 @@ import { NativeMenubarControl } from '../../workbench/electron-browser/parts/tit
 import { IWorkspaceEditingService } from '../../workbench/services/workspaces/common/workspaceEditing.js';
 import { ConfigurationService } from '../services/configuration/browser/configurationService.js';
 import { SessionsWorkspaceContextService } from '../services/workspace/browser/workspaceContextService.js';
-import { getWorkspaceIdentifier } from '../../workbench/services/workspaces/browser/workspaces.js';
+import { getWorkspaceIdentifier } from '../../platform/workspaces/common/workspaceIdentifier.js';
 
 export class SessionsMain extends Disposable {
 

--- a/src/vs/sessions/services/configuration/test/browser/configurationService.test.ts
+++ b/src/vs/sessions/services/configuration/test/browser/configurationService.test.ts
@@ -24,7 +24,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/tes
 import { runWithFakedTimers } from '../../../../../base/test/common/timeTravelScheduler.js';
 import { ConfigurationService } from '../../browser/configurationService.js';
 import { SessionsWorkspaceContextService } from '../../../workspace/browser/workspaceContextService.js';
-import { getWorkspaceIdentifier } from '../../../../../workbench/services/workspaces/browser/workspaces.js';
+import { getWorkspaceIdentifier } from '../../../../../platform/workspaces/common/workspaceIdentifier.js';
 import { Event } from '../../../../../base/common/event.js';
 import { IUserDataProfileService } from '../../../../../workbench/services/userDataProfile/common/userDataProfile.js';
 

--- a/src/vs/sessions/services/workspace/browser/workspaceContextService.ts
+++ b/src/vs/sessions/services/workspace/browser/workspaceContextService.ts
@@ -10,7 +10,7 @@ import { URI } from '../../../../base/common/uri.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
 import { Workspace, WorkspaceFolder, IWorkspace, IWorkspaceContextService, IWorkspaceFoldersChangeEvent, IWorkspaceFoldersWillChangeEvent, IWorkspaceIdentifier, ISingleFolderWorkspaceIdentifier, IWorkspaceFolder, WorkbenchState } from '../../../../platform/workspace/common/workspace.js';
 import { IWorkspaceFolderCreationData } from '../../../../platform/workspaces/common/workspaces.js';
-import { getWorkspaceIdentifier } from '../../../../workbench/services/workspaces/browser/workspaces.js';
+import { getWorkspaceIdentifier } from '../../../../platform/workspaces/common/workspaceIdentifier.js';
 import { IWorkspaceEditingService } from '../../../../workbench/services/workspaces/common/workspaceEditing.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 

--- a/src/vs/workbench/browser/web.main.ts
+++ b/src/vs/workbench/browser/web.main.ts
@@ -37,7 +37,7 @@ import { BrowserStorageService } from '../services/storage/browser/storageServic
 import { IStorageService } from '../../platform/storage/common/storage.js';
 import { toLocalISOString } from '../../base/common/date.js';
 import { isWorkspaceToOpen, isFolderToOpen } from '../../platform/window/common/window.js';
-import { getSingleFolderWorkspaceIdentifier, getWorkspaceIdentifier } from '../services/workspaces/browser/workspaces.js';
+import { getSingleFolderWorkspaceIdentifier, getWorkspaceIdentifier } from '../../platform/workspaces/common/workspaceIdentifier.js';
 import { InMemoryFileSystemProvider } from '../../platform/files/common/inMemoryFilesystemProvider.js';
 import { ICommandService } from '../../platform/commands/common/commands.js';
 import { IndexedDBFileSystemProvider } from '../../platform/files/browser/indexedDBFileSystemProvider.js';

--- a/src/vs/workbench/services/configuration/test/browser/configurationEditing.test.ts
+++ b/src/vs/workbench/services/configuration/test/browser/configurationEditing.test.ts
@@ -38,7 +38,7 @@ import { InMemoryFileSystemProvider } from '../../../../../platform/files/common
 import { joinPath } from '../../../../../base/common/resources.js';
 import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { RemoteAgentService } from '../../../remote/browser/remoteAgentService.js';
-import { getSingleFolderWorkspaceIdentifier } from '../../../workspaces/browser/workspaces.js';
+import { getSingleFolderWorkspaceIdentifier } from '../../../../../platform/workspaces/common/workspaceIdentifier.js';
 import { IUserDataProfilesService, UserDataProfilesService } from '../../../../../platform/userDataProfile/common/userDataProfile.js';
 import { hash } from '../../../../../base/common/hash.js';
 import { FilePolicyService } from '../../../../../platform/policy/common/filePolicyService.js';

--- a/src/vs/workbench/services/environment/browser/environmentService.ts
+++ b/src/vs/workbench/services/environment/browser/environmentService.ts
@@ -142,6 +142,9 @@ export class BrowserWorkbenchEnvironmentService implements IBrowserWorkbenchEnvi
 	get untitledWorkspacesHome(): URI { return joinPath(this.userRoamingDataHome, 'Workspaces'); }
 
 	@memoize
+	get agentSessionsWorkspace(): URI { return joinPath(this.userRoamingDataHome, 'agent-sessions.code-workspace'); }
+
+	@memoize
 	get serviceMachineIdResource(): URI { return joinPath(this.userRoamingDataHome, 'machineid'); }
 
 	@memoize

--- a/src/vs/workbench/services/host/browser/browserHostService.ts
+++ b/src/vs/workbench/services/host/browser/browserHostService.ts
@@ -26,7 +26,7 @@ import { IInstantiationService } from '../../../../platform/instantiation/common
 import { ILifecycleService, BeforeShutdownEvent, ShutdownReason } from '../../lifecycle/common/lifecycle.js';
 import { BrowserLifecycleService } from '../../lifecycle/browser/lifecycleService.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
-import { getWorkspaceIdentifier } from '../../workspaces/browser/workspaces.js';
+import { getWorkspaceIdentifier } from '../../../../platform/workspaces/common/workspaceIdentifier.js';
 import { localize } from '../../../../nls.js';
 import Severity from '../../../../base/common/severity.js';
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';

--- a/src/vs/workbench/services/workspaces/browser/workspacesService.ts
+++ b/src/vs/workbench/services/workspaces/browser/workspacesService.ts
@@ -11,7 +11,7 @@ import { IStorageService, StorageScope, StorageTarget } from '../../../../platfo
 import { isTemporaryWorkspace, IWorkspaceContextService, IWorkspaceFoldersChangeEvent, IWorkspaceIdentifier, WorkbenchState, WORKSPACE_EXTENSION } from '../../../../platform/workspace/common/workspace.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
-import { getWorkspaceIdentifier } from './workspaces.js';
+import { getWorkspaceIdentifier } from '../../../../platform/workspaces/common/workspaceIdentifier.js';
 import { IFileService, FileOperationError, FileOperationResult } from '../../../../platform/files/common/files.js';
 import { IWorkbenchEnvironmentService } from '../../environment/common/environmentService.js';
 import { joinPath } from '../../../../base/common/resources.js';


### PR DESCRIPTION
Fix #317643

The shared-process `UnusedWorkspaceStorageDataCleaner` was deleting the agents window's workspace storage folder (chat sessions, edits, images, test results, etc.) when the agents window wasn't open within ~30s of Code launching.

### Why

The agents window uses a synthetic workspace identifier computed in the renderer via the browser-side `getWorkspaceIdentifier` (a short hex hash of the workspace URI). The on-disk storage folder under `workspaceStorage/` is named with this short id, but none of the cleaner's preservation checks matched:

- length check expects 32-char MD5 ids
- `ext-dev` id check doesn't match
- main-side `window.workspace.id` is the 32-char MD5 produced by `platform/workspaces/node/workspaces.ts` — never matches the short id
- `isUsed` is only true while the agents window is actually open

So if Code launches without the agents window opening within 30s, the folder is `rm -rf`'d, taking everything under it with it.

### What

- Move `getWorkspaceIdentifier` / `getSingleFolderWorkspaceIdentifier` from `workbench/services/workspaces/browser/workspaces.ts` → `platform/workspaces/common/workspaceIdentifier.ts` so the shared-process cleaner can import them without layer violations. Implementation unchanged — same stable hash.
- Promote `IEnvironmentService.agentSessionsWorkspace` to required and add a browser implementation in `BrowserWorkbenchEnvironmentService` (stub in `StandaloneEnvironmentService`). Previously `AbstractNativeEnvironmentService` was the only provider.
- In the cleaner, preserve the folder matching `getWorkspaceIdentifier(env.agentSessionsWorkspace).id`.
- Add a unit test asserting the agents window folder survives cleanup while other empty-workspace folders are removed.

### Notes for reviewers

- The renderer-side workspace identifier is intentionally kept unchanged (same short hash) so existing user storage continues to be addressed at the same on-disk path — no migration needed.
- The cleaner now correctly distinguishes the permanent agents window storage from genuinely unused empty-workspace storage regardless of whether the window happens to be open at cleanup time.