### PR TITLE
Update modal background opacity to 50% for improved visibility

### DIFF
--- a/src/vs/base/browser/ui/dialog/dialog.css
+++ b/src/vs/base/browser/ui/dialog/dialog.css
@@ -17,7 +17,7 @@
 }
 
 .monaco-dialog-modal-block.dimmed {
-	background: rgba(0, 0, 0, 0.3);
+	background: rgba(0, 0, 0, 0.5);
 }
 
 /** Dialog: Container */

--- a/src/vs/platform/windows/electron-main/windowImpl.ts
+++ b/src/vs/platform/windows/electron-main/windowImpl.ts
@@ -462,15 +462,15 @@ export abstract class BaseWindow extends Disposable implements IBaseWindow {
 
 	private dimColor(color: string): string {
 
-		// Blend a CSS color with black at 30% opacity to match the
-		// dimming overlay of `rgba(0, 0, 0, 0.3)` used by modals.
+		// Blend a CSS color with black at 50% opacity to match the
+		// dimming overlay of `rgba(0, 0, 0, 0.5)` used by modals.
 
 		const parsed = Color.Format.CSS.parse(color);
 		if (!parsed) {
 			return color;
 		}
 
-		const dimFactor = 0.7; // 1 - 0.3 opacity of black overlay
+		const dimFactor = 0.5; // 1 - 0.5 opacity of black overlay
 		const r = Math.round(parsed.rgba.r * dimFactor);
 		const g = Math.round(parsed.rgba.g * dimFactor);
 		const b = Math.round(parsed.rgba.b * dimFactor);

--- a/src/vs/sessions/contrib/chat/browser/media/runScriptAction.css
+++ b/src/vs/sessions/contrib/chat/browser/media/runScriptAction.css
@@ -181,6 +181,6 @@
 .run-script-action-modal-backdrop {
 	position: fixed;
 	inset: 0;
-	background: rgba(0, 0, 0, 0.3);
+	background: rgba(0, 0, 0, 0.5);
 	z-index: 2549;
 }

--- a/src/vs/workbench/browser/parts/editor/media/modalEditorPart.css
+++ b/src/vs/workbench/browser/parts/editor/media/modalEditorPart.css
@@ -14,7 +14,7 @@
 	z-index: 2540;
 	/* Never allow content to escape above the title bar */
 	overflow: hidden;
-	background: rgba(0, 0, 0, 0.3);
+	background: rgba(0, 0, 0, 0.5);
 
 	.modal-editor-resizable {
 		position: absolute;


### PR DESCRIPTION
Enhance the visibility of modal backgrounds by updating their opacity to 50%. This change applies to various modal components across the application, ensuring a consistent user experience. Test the modals to confirm the improved visibility.

Fixes: https://github.com/microsoft/vscode/issues/317691
