### PR TITLE
sessions: add rich hover for titlebar and session list items

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsTitleBarWidget.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsTitleBarWidget.css
@@ -52,7 +52,7 @@
 	padding: 0 4px;
 	border-radius: 4px;
 	min-width: 0;
-	max-width: 600px;
+	max-width: 100%;
 	cursor: pointer;
 	touch-action: manipulation;
 }
@@ -88,9 +88,9 @@
 	color: var(--vscode-icon-foreground);
 }
 
-/* Label (title) */
+/* Label (title) — shrinks first so folder/branch/diff stats stay visible. */
 .command-center .agent-sessions-titlebar-container .agent-sessions-titlebar-label {
-	flex: 0 1 auto;
+	flex: 0 999 auto;
 	min-width: 0;
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -98,11 +98,11 @@
 	font-weight: 500;
 }
 
-/* Repository/worktree metadata shrinks before the primary title. */
+/* Repository/worktree metadata shrinks after the primary title. */
 .command-center .agent-sessions-titlebar-container .agent-sessions-titlebar-details {
 	display: flex;
 	align-items: center;
-	flex: 0 999 auto;
+	flex: 0 1 auto;
 	gap: 6px;
 	min-width: 0;
 	overflow: hidden;
@@ -127,6 +127,8 @@
 	display: flex;
 	align-items: center;
 	gap: 2px;
+	flex-shrink: 0;
+	white-space: nowrap;
 
 	.codicon {
 		font-size: 13px;
@@ -135,12 +137,22 @@
 	}
 }
 
-/* Provider label (shown for untitled sessions) */
-.command-center .agent-sessions-titlebar-container .agent-sessions-titlebar-provider {
+/* Diff stats (+insertions -deletions) shown for sessions with pending changes. */
+.command-center .agent-sessions-titlebar-container .agent-sessions-titlebar-diff {
 	display: flex;
 	align-items: center;
+	gap: 2px;
 	flex-shrink: 0;
-	opacity: 0.7;
+	font-variant-numeric: tabular-nums;
+	white-space: nowrap;
+}
+
+.command-center .agent-sessions-titlebar-container .agent-sessions-titlebar-diff-added {
+	color: var(--vscode-chat-linesAddedForeground);
+}
+
+.command-center .agent-sessions-titlebar-container .agent-sessions-titlebar-diff-removed {
+	color: var(--vscode-chat-linesRemovedForeground);
 }
 
 /* Sidebar toggle unread badge */

--- a/src/vs/sessions/contrib/sessions/browser/sessionHoverContent.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionHoverContent.ts
@@ -12,6 +12,27 @@ import { ISessionsProvidersService } from '../../../services/sessions/browser/se
 import { ISession } from '../../../services/sessions/common/session.js';
 
 /**
+ * Aggregated insertions/deletions across all of a session's changes,
+ * or `undefined` when the session has no pending changes.
+ */
+export function getSessionDiffStats(session: ISession): { files: number; insertions: number; deletions: number } | undefined {
+	const changes = session.changes.get();
+	if (changes.length === 0) {
+		return undefined;
+	}
+	let insertions = 0;
+	let deletions = 0;
+	for (const change of changes) {
+		insertions += change.insertions;
+		deletions += change.deletions;
+	}
+	if (insertions === 0 && deletions === 0) {
+		return undefined;
+	}
+	return { files: changes.length, insertions, deletions };
+}
+
+/**
  * Build a compact, reusable hover markdown describing a session.
  *
  * Layout:
@@ -24,7 +45,11 @@ export function buildSessionHoverContent(
 	session: ISession,
 	sessionsProvidersService: ISessionsProvidersService,
 ): IMarkdownString {
-	const md = new MarkdownString('', { isTrusted: true, supportThemeIcons: true, supportHtml: true });
+	// Note: `isTrusted` is intentionally left undefined. The hover renders
+	// untrusted, workspace-derived values (folder paths, branch names, session
+	// titles), so it must not enable command-link execution. User-controlled
+	// text is always appended via `appendText` so markdown characters are escaped.
+	const md = new MarkdownString('', { supportThemeIcons: true, supportHtml: true });
 
 	// Line 1: session icon + bold title
 	const title = session.title.get() || localize('agentSessions.newSession', "New Session");
@@ -36,43 +61,41 @@ export function buildSessionHoverContent(
 	md.appendMarkdown(`**`);
 	md.appendText('\n');
 
-	// Line 2: folder path · branch
+	// Line 2: folder icon + folder path · git branch
 	const workspace = session.workspace.get();
 	const folder = workspace?.folders[0];
-	const detailParts: string[] = [];
+	const branch = folder?.gitRepository?.branchName?.trim();
+	let appendedDetails = false;
 
 	if (folder && workspace) {
 		const isWorkspaceSession = workspace.folders.length > 0 && workspace.folders[0]?.gitRepository?.workTreeUri === undefined;
 		const folderIcon = workspace.isVirtualWorkspace ? Codicon.cloud : isWorkspaceSession ? Codicon.folder : Codicon.worktree;
-		detailParts.push(`$(${folderIcon.id}) ${folder.root.fsPath}`);
+		md.appendMarkdown(`$(${folderIcon.id}) `);
+		md.appendText(folder.root.fsPath);
+		appendedDetails = true;
 	}
 
-	const branch = folder?.gitRepository?.branchName?.trim();
 	if (branch) {
-		detailParts.push(`$(git-branch) ${branch}`);
+		if (appendedDetails) {
+			md.appendMarkdown(' · ');
+		}
+		md.appendMarkdown('$(git-branch) ');
+		md.appendText(branch);
+		appendedDetails = true;
 	}
 
-	if (detailParts.length > 0) {
-		md.appendMarkdown(detailParts.join(' · '));
+	if (appendedDetails) {
 		md.appendText('\n');
 	}
 
 	// Line 3: file count · diff stats
-	const changes = session.changes.get();
-	if (changes.length > 0) {
-		let insertions = 0;
-		let deletions = 0;
-		for (const change of changes) {
-			insertions += change.insertions;
-			deletions += change.deletions;
-		}
-		if (insertions > 0 || deletions > 0) {
-			const fileText = changes.length === 1
-				? localize('agentSessions.fileChanged', "1 file changed")
-				: localize('agentSessions.filesChanged', "{0} files changed", changes.length);
-			md.appendMarkdown(`${fileText} · <span style="color:${asCssVariable(chatLinesAddedForeground)};">+${insertions}</span> <span style="color:${asCssVariable(chatLinesRemovedForeground)};">-${deletions}</span>`);
-			md.appendText('\n');
-		}
+	const diffStats = getSessionDiffStats(session);
+	if (diffStats) {
+		const fileText = diffStats.files === 1
+			? localize('agentSessions.fileChanged', "1 file changed")
+			: localize('agentSessions.filesChanged', "{0} files changed", diffStats.files);
+		md.appendMarkdown(`${fileText} · <span style="color:${asCssVariable(chatLinesAddedForeground)};">+${diffStats.insertions}</span> <span style="color:${asCssVariable(chatLinesRemovedForeground)};">-${diffStats.deletions}</span>`);
+		md.appendText('\n');
 	}
 
 	// Line 4: provider name

--- a/src/vs/sessions/contrib/sessions/browser/sessionHoverContent.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionHoverContent.ts
@@ -1,0 +1,85 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Codicon } from '../../../../base/common/codicons.js';
+import { IMarkdownString, MarkdownString } from '../../../../base/common/htmlContent.js';
+import { localize } from '../../../../nls.js';
+import { asCssVariable } from '../../../../platform/theme/common/colorUtils.js';
+import { chatLinesAddedForeground, chatLinesRemovedForeground } from '../../../../workbench/contrib/chat/common/widget/chatColors.js';
+import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
+import { ISession } from '../../../services/sessions/common/session.js';
+
+/**
+ * Build a compact, reusable hover markdown describing a session.
+ *
+ * Layout:
+ *   Line 1: **session icon + title**
+ *   Line 2: folder icon + folder path · git branch
+ *   Line 3: "N files changed" · colored diff stats
+ *   Line 4: provider label
+ */
+export function buildSessionHoverContent(
+	session: ISession,
+	sessionsProvidersService: ISessionsProvidersService,
+): IMarkdownString {
+	const md = new MarkdownString('', { isTrusted: true, supportThemeIcons: true, supportHtml: true });
+
+	// Line 1: session icon + bold title
+	const title = session.title.get() || localize('agentSessions.newSession', "New Session");
+	if (session.icon) {
+		md.appendMarkdown(`$(${session.icon.id}) `);
+	}
+	md.appendMarkdown(`**`);
+	md.appendText(title);
+	md.appendMarkdown(`**`);
+	md.appendText('\n');
+
+	// Line 2: folder path · branch
+	const workspace = session.workspace.get();
+	const folder = workspace?.folders[0];
+	const detailParts: string[] = [];
+
+	if (folder && workspace) {
+		const isWorkspaceSession = workspace.folders.length > 0 && workspace.folders[0]?.gitRepository?.workTreeUri === undefined;
+		const folderIcon = workspace.isVirtualWorkspace ? Codicon.cloud : isWorkspaceSession ? Codicon.folder : Codicon.worktree;
+		detailParts.push(`$(${folderIcon.id}) ${folder.root.fsPath}`);
+	}
+
+	const branch = folder?.gitRepository?.branchName?.trim();
+	if (branch) {
+		detailParts.push(`$(git-branch) ${branch}`);
+	}
+
+	if (detailParts.length > 0) {
+		md.appendMarkdown(detailParts.join(' · '));
+		md.appendText('\n');
+	}
+
+	// Line 3: file count · diff stats
+	const changes = session.changes.get();
+	if (changes.length > 0) {
+		let insertions = 0;
+		let deletions = 0;
+		for (const change of changes) {
+			insertions += change.insertions;
+			deletions += change.deletions;
+		}
+		if (insertions > 0 || deletions > 0) {
+			const fileText = changes.length === 1
+				? localize('agentSessions.fileChanged', "1 file changed")
+				: localize('agentSessions.filesChanged', "{0} files changed", changes.length);
+			md.appendMarkdown(`${fileText} · <span style="color:${asCssVariable(chatLinesAddedForeground)};">+${insertions}</span> <span style="color:${asCssVariable(chatLinesRemovedForeground)};">-${deletions}</span>`);
+			md.appendText('\n');
+		}
+	}
+
+	// Line 4: provider name
+	const provider = sessionsProvidersService.getProvider(session.providerId);
+	if (provider) {
+		md.appendText(provider.label);
+	}
+
+	return md;
+}

--- a/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
@@ -32,7 +32,7 @@ import { IsSessionArchivedContext, IsSessionPinnedContext, IsSessionReadContext,
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { renderLabelWithIcons } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
 import { IMarkdownString, MarkdownString } from '../../../../base/common/htmlContent.js';
-import { buildSessionHoverContent } from './sessionHoverContent.js';
+import { buildSessionHoverContent, getSessionDiffStats } from './sessionHoverContent.js';
 
 const titleBarContextKeys = new Set([IsNewChatSessionContext.key]);
 
@@ -328,23 +328,7 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 	 */
 	private _getDiffStats(): { insertions: number; deletions: number } | undefined {
 		const sessionData = this.sessionsManagementService.activeSession.get();
-		if (!sessionData) {
-			return undefined;
-		}
-		const changes = sessionData.changes.get();
-		if (changes.length === 0) {
-			return undefined;
-		}
-		let insertions = 0;
-		let deletions = 0;
-		for (const change of changes) {
-			insertions += change.insertions;
-			deletions += change.deletions;
-		}
-		if (insertions === 0 && deletions === 0) {
-			return undefined;
-		}
-		return { insertions, deletions };
+		return sessionData ? getSessionDiffStats(sessionData) : undefined;
 	}
 
 	private _showContextMenu(e: MouseEvent): void {

--- a/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
@@ -9,8 +9,9 @@ import { Separator } from '../../../../base/common/actions.js';
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { StandardMouseEvent } from '../../../../base/browser/mouseEvent.js';
 import { localize } from '../../../../nls.js';
+import { HoverStyle } from '../../../../base/browser/ui/hover/hover.js';
+import { HoverPosition } from '../../../../base/browser/ui/hover/hoverWidget.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
-import { getDefaultHoverDelegate } from '../../../../base/browser/ui/hover/hoverDelegateFactory.js';
 import { BaseActionViewItem, IBaseActionViewItemOptions } from '../../../../base/browser/ui/actionbar/actionViewItems.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IMenuService, MenuRegistry, SubmenuItemAction } from '../../../../platform/actions/common/actions.js';
@@ -30,6 +31,8 @@ import { SHOW_SESSIONS_PICKER_COMMAND_ID } from './sessionsActions.js';
 import { IsSessionArchivedContext, IsSessionPinnedContext, IsSessionReadContext, SessionItemContextMenuId, SessionItemHasBranchNameContext } from './views/sessionsList.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { renderLabelWithIcons } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
+import { IMarkdownString, MarkdownString } from '../../../../base/common/htmlContent.js';
+import { buildSessionHoverContent } from './sessionHoverContent.js';
 
 const titleBarContextKeys = new Set([IsNewChatSessionContext.key]);
 
@@ -79,6 +82,7 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 				sessionData.title.read(reader);
 				sessionData.status.read(reader);
 				sessionData.workspace.read(reader);
+				sessionData.changes.read(reader);
 			}
 			this._lastRenderState = undefined;
 			this._render();
@@ -150,9 +154,10 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 			const icon = this._getActiveSessionIcon();
 			const repoLabel = this._getRepositoryLabel();
 			const repoBranchLabel = this._getRepositoryBranchLabel();
+			const diffStats = this._getDiffStats();
 
 			// Build a render-state key from all displayed data
-			const renderState = `${icon?.id ?? ''}|${label}|${repoLabel ?? ''}|${repoBranchLabel ?? ''}`;
+			const renderState = `${icon?.id ?? ''}|${label}|${repoLabel ?? ''}|${repoBranchLabel ?? ''}|${diffStats ? `${diffStats.insertions}/${diffStats.deletions}` : ''}`;
 
 			// Skip re-render if state hasn't changed
 			if (this._lastRenderState === renderState) {
@@ -204,6 +209,20 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 					detailsEl.appendChild(branchEl);
 				}
 
+				if (diffStats) {
+					const separatorEl = $('div.agent-sessions-titlebar-separator');
+					detailsEl.appendChild(separatorEl);
+
+					const diffEl = $('div.agent-sessions-titlebar-diff');
+					const addedEl = $('span.agent-sessions-titlebar-diff-added');
+					addedEl.textContent = `+${diffStats.insertions}`;
+					diffEl.appendChild(addedEl);
+					const removedEl = $('span.agent-sessions-titlebar-diff-removed');
+					removedEl.textContent = `-${diffStats.deletions}`;
+					diffEl.appendChild(removedEl);
+					detailsEl.appendChild(diffEl);
+				}
+
 				centerGroup.appendChild(detailsEl);
 			}
 
@@ -227,13 +246,13 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 
 			this._container.appendChild(sessionPill);
 
-			// Hover
-			const hover = `${label}${repoLabel ? `, ${repoLabel}` : ''}${repoBranchLabel ? `, ${repoBranchLabel}` : ''}`;
-			this._dynamicDisposables.add(this.hoverService.setupManagedHover(
-				getDefaultHoverDelegate('mouse'),
-				sessionPill,
-				hover
-			));
+			// Beacon-style hover with session details, positioned below center
+			this._dynamicDisposables.add(this.hoverService.setupDelayedHover(sessionPill, () => ({
+				content: this._buildSessionHoverContent(),
+				style: HoverStyle.Pointer,
+				position: { hoverPosition: HoverPosition.BELOW },
+				persistence: { hideOnHover: false },
+			})));
 
 			// Keyboard handler
 			this._dynamicDisposables.add(addDisposableListener(this._container, EventType.KEY_DOWN, (e: KeyboardEvent) => {
@@ -271,6 +290,17 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 	}
 
 	/**
+	 * Build a compact hover markdown for the active session.
+	 */
+	private _buildSessionHoverContent(): IMarkdownString {
+		const sessionData = this.sessionsManagementService.activeSession.get();
+		if (!sessionData) {
+			return new MarkdownString('');
+		}
+		return buildSessionHoverContent(sessionData, this.sessionsProvidersService);
+	}
+
+	/**
 	 * Get the repository label for the active session.
 	 */
 	private _getRepositoryLabel(): string | undefined {
@@ -290,6 +320,31 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 	private _getRepositoryBranchLabel(): string | undefined {
 		const sessionData = this.sessionsManagementService.activeSession.get();
 		return sessionData?.workspace.get()?.folders[0]?.gitRepository?.branchName?.trim() || undefined;
+	}
+
+	/**
+	 * Get the aggregated insertions/deletions for the active session, or
+	 * undefined when there are no changes.
+	 */
+	private _getDiffStats(): { insertions: number; deletions: number } | undefined {
+		const sessionData = this.sessionsManagementService.activeSession.get();
+		if (!sessionData) {
+			return undefined;
+		}
+		const changes = sessionData.changes.get();
+		if (changes.length === 0) {
+			return undefined;
+		}
+		let insertions = 0;
+		let deletions = 0;
+		for (const change of changes) {
+			insertions += change.insertions;
+			deletions += change.deletions;
+		}
+		if (insertions === 0 && deletions === 0) {
+			return undefined;
+		}
+		return { insertions, deletions };
 	}
 
 	private _showContextMenu(e: MouseEvent): void {

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -47,6 +47,8 @@ import { IAgentSessionsService } from '../../../../../workbench/contrib/chat/bro
 import { IAccessibilityService } from '../../../../../platform/accessibility/common/accessibility.js';
 import { ISessionsListModelService } from './sessionsListModelService.js';
 import { IAgentHostFilterService } from '../../../../services/agentHostFilter/common/agentHostFilter.js';
+import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
+import { buildSessionHoverContent } from '../sessionHoverContent.js';
 
 const $ = DOM.$;
 
@@ -200,6 +202,7 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 		private readonly hoverService: IHoverService,
 		private readonly agentSessionsService: IAgentSessionsService,
 		private readonly accessibilityService: IAccessibilityService,
+		private readonly sessionsProvidersService: ISessionsProvidersService,
 	) {
 		this._motionReducedSignal = observableSignalFromEvent('reduceMotion', this.accessibilityService.onDidChangeReducedMotion);
 	}
@@ -257,6 +260,15 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 		// by the time the row renders. Only fires for sessions that become
 		// visible in the viewport (O(visible rows), not O(all sessions)).
 		this.agentSessionsService.model.observeSession(element.resource);
+
+		// Rich hover on the row showing folder, branch, diff stats and provider.
+		// Shown to the right of the row, similar to the extensions list.
+		template.elementDisposables.add(this.hoverService.setupDelayedHover(template.container, () => ({
+			content: buildSessionHoverContent(element, this.sessionsProvidersService),
+			appearance: { showPointer: true },
+			position: { hoverPosition: HoverPosition.RIGHT, forcePosition: true },
+			persistence: { hideOnHover: false },
+		}), { groupId: 'sessions-list' }));
 
 		// Toolbar context
 		template.titleToolbar.context = element;
@@ -826,6 +838,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 		const hoverService = instantiationService.invokeFunction(accessor => accessor.get(IHoverService));
 		const agentSessionsService = instantiationService.invokeFunction(accessor => accessor.get(IAgentSessionsService));
 		const accessibilityService = instantiationService.invokeFunction(accessor => accessor.get(IAccessibilityService));
+		const sessionsProvidersService = instantiationService.invokeFunction(accessor => accessor.get(ISessionsProvidersService));
 		const sessionRenderer = new SessionItemRenderer(
 			{ grouping: this.options.grouping, sorting: this.options.sorting, isPinned: s => this.isSessionPinned(s), isRead: s => this.isSessionRead(s) },
 			approvalModel,
@@ -835,6 +848,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 			hoverService,
 			agentSessionsService,
 			accessibilityService,
+			sessionsProvidersService,
 		);
 
 		const showMoreRenderer = new SessionShowMoreRenderer();


### PR DESCRIPTION
## Summary

Adds a rich hover tooltip for sessions in both the titlebar pill and session list items.

### Titlebar pill
- Inline diff stats (`+insertions -deletions`) shown directly in the pill
- Improved truncation: title shrinks first, keeping folder/branch/diff metadata visible
- Beacon-style hover (pointer below) with full session details

### Session list items
- Rich hover positioned to the right of the row (like Extensions list)
- Instant transition between items via shared `groupId`
- Hover triggers on the full row, not just the title

### Hover content (shared)
Both surfaces use a new `buildSessionHoverContent()` that returns a `MarkdownString`:
1. **Session icon + bold title**
2. Folder/worktree icon + full path · git branch
3. File count + colored diff stats
4. Provider name

### Files changed
- `sessionHoverContent.ts` — new reusable hover builder
- `sessionsTitleBarWidget.ts` — inline diff stats + beacon hover
- `sessionsTitleBarWidget.css` — pill truncation + diff stat colors
- `sessionsList.ts` — rich hover on session rows