### PR TITLE
sessions: extract local chat sessions into standalone provider

### DIFF
--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -57,6 +57,7 @@ Each provider lives in its own subfolder and implements `ISessionsProvider`:
 src/vs/sessions/contrib/providers/
 ├── agentHost/            # Local agent host provider
 ├── copilotChatSessions/  # Copilot chat sessions provider (wraps ChatSessionsService)
+├── localChatSessions/    # Local in-process VS Code chat sessions provider
 └── remoteAgentHost/      # Remote agent host provider (one instance per connection)
 ```
 
@@ -65,6 +66,7 @@ Providers can import from all layers below them (core, services, non-provider co
 ### Provider-Specific Documentation
 
 - [Copilot Chat Sessions Provider](contrib/providers/copilotChatSessions/COPILOT_CHAT_SESSIONS_PROVIDER.md) — wraps `ChatSessionsService`, metadata contract, workspace derivation
+- [Local Chat Sessions Provider](contrib/providers/localChatSessions/LOCAL_CHAT_SESSIONS_PROVIDER.md) — local in-process VS Code chat, self-managed session list via storage
 - [Remote Agent Host Provider](contrib/providers/remoteAgentHost/REMOTE_AGENT_HOST_SESSIONS_PROVIDER.md) — remote connections, per-host provider instances
 
 ### Related Specifications

--- a/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
@@ -186,6 +186,15 @@ export class SessionTypePicker extends Disposable {
 			return;
 		}
 
+		// Determine whether any session type label is duplicated across
+		// providers. When all labels are unique the provider header is
+		// redundant — skip it for a cleaner dropdown.
+		const labelCounts = new Map<string, number>();
+		for (const { sessionType } of folderTypes) {
+			labelCounts.set(sessionType.label, (labelCounts.get(sessionType.label) ?? 0) + 1);
+		}
+		const hasDuplicateLabels = Array.from(labelCounts.values()).some(c => c > 1);
+
 		// Group items by provider so the dropdown shows a provider header
 		// followed by that provider's types. Insert a separator between
 		// adjacent providers' types so the grouping is visually clear.
@@ -196,7 +205,7 @@ export class SessionTypePicker extends Disposable {
 			const provider = providersService.getProvider(providerId);
 			const groupTitle = provider?.label ?? providerId;
 			const isFirstInGroup = providerId !== lastProviderId;
-			if (isFirstInGroup && lastProviderId !== undefined) {
+			if (hasDuplicateLabels && isFirstInGroup && lastProviderId !== undefined) {
 				groupedItems.push({ kind: ActionListItemKind.Separator, label: '' });
 			}
 			lastProviderId = providerId;
@@ -207,8 +216,11 @@ export class SessionTypePicker extends Disposable {
 			groupedItems.push({
 				kind: ActionListItemKind.Action,
 				label: sessionType.label,
-				group: {
+				group: hasDuplicateLabels ? {
 					title: isFirstInGroup ? groupTitle : '',
+					icon: sessionType.icon,
+				} : {
+					title: '',
 					icon: sessionType.icon,
 				},
 				item,
@@ -236,7 +248,7 @@ export class SessionTypePicker extends Disposable {
 				getAriaLabel: (item) => item.label ?? '',
 				getWidgetAriaLabel: () => localize('sessionTypePicker.ariaLabel', "Session Type"),
 			},
-			{ showGroupTitleOnFirstItem: true },
+			{ showGroupTitleOnFirstItem: hasDuplicateLabels },
 		);
 	}
 

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessions.contribution.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessions.contribution.ts
@@ -5,19 +5,13 @@
 
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../../workbench/common/contributions.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
-import { Disposable, IDisposable } from '../../../../../base/common/lifecycle.js';
-import { CopilotChatSessionsProvider, COPILOT_MULTI_CHAT_SETTING, CLAUDE_CODE_ENABLED_SETTING, LOCAL_SESSION_ENABLED_SETTING, LocalSessionType } from '../../copilotChatSessions/browser/copilotChatSessionsProvider.js';
+import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { CopilotChatSessionsProvider, COPILOT_MULTI_CHAT_SETTING, CLAUDE_CODE_ENABLED_SETTING } from '../../copilotChatSessions/browser/copilotChatSessionsProvider.js';
 import '../../copilotChatSessions/browser/copilotChatSessionsActions.js';
 import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
 import { Registry } from '../../../../../platform/registry/common/platform.js';
 import { IConfigurationRegistry, Extensions as ConfigurationExtensions } from '../../../../../platform/configuration/common/configurationRegistry.js';
 import { localize } from '../../../../../nls.js';
-import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
-import { ForkConversationAction } from '../../../../../workbench/contrib/chat/browser/actions/chatForkActions.js';
-import { registerAction2 } from '../../../../../platform/actions/common/actions.js';
-import { URI } from '../../../../../base/common/uri.js';
-import { ILogService } from '../../../../../platform/log/common/log.js';
-import { raceTimeout } from '../../../../../base/common/async.js';
 
 Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
 	id: 'sessions',
@@ -33,13 +27,6 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			default: true,
 			experiment: { mode: 'startup' },
 			description: localize('sessions.chat.claudeAgent.enabled', "Enable Claude Agent sessions in the Agents window. Start and resume agentic coding sessions powered by Anthropic's Claude Agent SDK directly. Uses your existing Copilot subscription."),
-		},
-		[LOCAL_SESSION_ENABLED_SETTING]: {
-			type: 'boolean',
-			default: true,
-			tags: ['experimental'],
-			experiment: { mode: 'startup' },
-			description: localize('sessions.chat.localAgent.enabled', "Enable Local VS Code chat sessions in the Agents Window."),
 		},
 	},
 });
@@ -69,43 +56,3 @@ class DefaultSessionsProviderContribution extends Disposable implements IWorkben
 }
 
 registerWorkbenchContribution2(DefaultSessionsProviderContribution.ID, DefaultSessionsProviderContribution, WorkbenchPhase.AfterRestored);
-
-registerAction2(class extends ForkConversationAction {
-	protected override _openForkedSession(instantiationService: IInstantiationService, parentSessionResource: URI, forkedSessionResource: URI): Promise<void> {
-		return instantiationService.invokeFunction(async accessor => {
-			const sessionsManagementService = accessor.get(ISessionsManagementService);
-			const logService = accessor.get(ILogService);
-
-			const parentSession = sessionsManagementService.getSession(parentSessionResource);
-			if (!parentSession) {
-				logService.error(`Parent session ${parentSessionResource.toString()} not found when forking conversation`);
-				return super._openForkedSession(instantiationService, parentSessionResource, forkedSessionResource);
-			}
-
-			if (parentSession.sessionType !== LocalSessionType.id) {
-				return super._openForkedSession(instantiationService, parentSessionResource, forkedSessionResource);
-			}
-
-			// Local sessions — wait for the forked session to appear, but
-			// bound the wait so a missing session does not hang forever.
-			if (!sessionsManagementService.getSession(forkedSessionResource)) {
-				let listener: IDisposable | undefined;
-				const appeared = await raceTimeout(new Promise<boolean>(resolve => {
-					listener = sessionsManagementService.onDidChangeSessions(() => {
-						if (sessionsManagementService.getSession(forkedSessionResource)) {
-							resolve(true);
-						}
-					});
-				}), 30_000);
-				listener?.dispose();
-
-				if (!appeared) {
-					logService.error(`Forked session ${forkedSessionResource.toString()} did not appear within timeout`);
-					return;
-				}
-			}
-			await sessionsManagementService.openSession(forkedSessionResource);
-
-		});
-	}
-});

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsActions.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsActions.ts
@@ -30,7 +30,8 @@ import { ISessionsManagementService } from '../../../../services/sessions/common
 import { SessionItemContextMenuId } from '../../../sessions/browser/views/sessionsList.js';
 import { BranchPicker } from './branchPicker.js';
 import { ClaudePermissionModePicker } from './claudePermissionModePicker.js';
-import { ClaudeCodeSessionType, COPILOT_PROVIDER_ID, CopilotChatSessionsProvider, CopilotCloudSessionType, LocalSessionType } from './copilotChatSessionsProvider.js';
+import { ClaudeCodeSessionType, COPILOT_PROVIDER_ID, CopilotChatSessionsProvider, CopilotCloudSessionType } from './copilotChatSessionsProvider.js';
+import { LocalSessionType } from '../../localChatSessions/browser/localChatSessionsProvider.js';
 import { IsolationPicker } from './isolationPicker.js';
 import { ModePicker } from './modePicker.js';
 import { CloudModelPicker } from './modelPicker.js';
@@ -101,7 +102,7 @@ registerAction2(class extends Action2 {
 				id: Menus.NewSessionConfig,
 				group: 'navigation',
 				order: 0,
-				when: ContextKeyExpr.or(IsActiveSessionCopilotChatCLI, IsActiveSessionCopilotChatLocal),
+				when: ContextKeyExpr.or(IsActiveSessionCopilotChatCLI, IsActiveSessionCopilotChatLocal, IsActiveSessionLocal),
 			}],
 		});
 	}
@@ -118,7 +119,7 @@ registerAction2(class extends Action2 {
 				id: Menus.NewSessionConfig,
 				group: 'navigation',
 				order: 1,
-				when: ContextKeyExpr.or(IsActiveSessionCopilotChatCLI, IsActiveSessionCopilotChatClaudeCode, IsActiveSessionCopilotChatLocal),
+				when: ContextKeyExpr.or(IsActiveSessionCopilotChatCLI, IsActiveSessionCopilotChatClaudeCode, IsActiveSessionCopilotChatLocal, IsActiveSessionLocal),
 			}],
 		});
 	}
@@ -152,7 +153,7 @@ registerAction2(class extends Action2 {
 				id: Menus.NewSessionControl,
 				group: 'navigation',
 				order: 1,
-				when: ContextKeyExpr.or(IsActiveSessionCopilotChatCLI, IsActiveSessionCopilotChatLocal),
+				when: ContextKeyExpr.or(IsActiveSessionCopilotChatCLI, IsActiveSessionCopilotChatLocal, IsActiveSessionLocal),
 			}],
 		});
 	}

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -22,7 +22,7 @@ import { IAgentSessionsService } from '../../../../../workbench/contrib/chat/bro
 import { AgentSessionProviders, AgentSessionTarget } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentSessions.js';
 import { IChatService, IChatSendRequestOptions } from '../../../../../workbench/contrib/chat/common/chatService/chatService.js';
 import { IChatResponseModel } from '../../../../../workbench/contrib/chat/common/model/chatModel.js';
-import { ChatSessionStatus, IChatSessionsService, IChatSessionProviderOptionGroup, IChatSessionProviderOptionItem, SessionType, IChatSessionFileChange2 } from '../../../../../workbench/contrib/chat/common/chatSessionsService.js';
+import { ChatSessionStatus, IChatSessionsService, IChatSessionProviderOptionGroup, IChatSessionProviderOptionItem, SessionType } from '../../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { ISession, IChat, ISessionGitRepository, ISessionFolder, ISessionWorkspace, SessionStatus, GITHUB_REMOTE_FILE_SCHEME, IGitHubInfo, ISessionType, ISessionWorkspaceBrowseAction, ISessionFileChange, sessionFileChangesEqual, toSessionId, SESSION_WORKSPACE_GROUP_LOCAL, ISessionChangeset, IChatCheckpoints } from '../../../../services/sessions/common/session.js';
 import { ChatAgentLocation, ChatConfiguration, ChatModeKind, ChatPermissionLevel, isChatPermissionLevel } from '../../../../../workbench/contrib/chat/common/constants.js';
 import { basename, dirname, isEqual } from '../../../../../base/common/resources.js';
@@ -42,7 +42,6 @@ import { IConfigurationService } from '../../../../../platform/configuration/com
 import { ILabelService } from '../../../../../platform/label/common/label.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
 import { SessionConfigKey } from '../../../../../platform/agentHost/common/sessionConfigKeys.js';
-import { IFileService } from '../../../../../platform/files/common/files.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
 import { IGitHubService } from '../../../github/browser/githubService.js';
 import { computePullRequestIcon, GitHubPullRequestState } from '../../../github/common/types.js';
@@ -50,13 +49,6 @@ import { structuralEquals } from '../../../../../base/common/equals.js';
 import { CopilotCLISessionType } from '../../agentHost/browser/baseAgentHostSessionsProvider.js';
 import { createChangesets } from './copilotChatSessionsChangesets.js';
 import { IUriIdentityService } from '../../../../../platform/uriIdentity/common/uriIdentity.js';
-
-/** Local session type — in-process VS Code chat, no background agent or worktree. */
-export const LocalSessionType: ISessionType = {
-	id: 'local',
-	label: localize('localSession', "Local"),
-	icon: Codicon.vm,
-};
 
 /** Claude Code session type — local agent powered by Claude. */
 export const ClaudeCodeSessionType: ISessionType = {
@@ -156,19 +148,16 @@ export const COPILOT_MULTI_CHAT_SETTING = 'sessions.github.copilot.multiChatSess
 /** Setting key controlling whether Claude agent sessions are available. */
 export const CLAUDE_CODE_ENABLED_SETTING = 'sessions.chat.claudeAgent.enabled';
 
-/** Setting key controlling whether Local VS Code chat sessions are available in the Agents app. */
-export const LOCAL_SESSION_ENABLED_SETTING = 'sessions.chat.localAgent.enabled';
-
 const REPOSITORY_OPTION_ID = 'repository';
 const PARENT_SESSION_OPTION_ID = 'parentSessionId';
 const BRANCH_OPTION_ID = 'branch';
 const ISOLATION_OPTION_ID = 'isolation';
 const AGENT_OPTION_ID = 'agent';
 
-type NewSession = CopilotCLISession | RemoteNewSession | ClaudeCodeNewSession | LocalNewSession;
+type NewSession = CopilotCLISession | RemoteNewSession | ClaudeCodeNewSession;
 
 function isNewSession(session: ICopilotChatSession): session is NewSession {
-	return session instanceof CopilotCLISession || session instanceof RemoteNewSession || session instanceof ClaudeCodeNewSession || session instanceof LocalNewSession;
+	return session instanceof CopilotCLISession || session instanceof RemoteNewSession || session instanceof ClaudeCodeNewSession;
 }
 
 /**
@@ -769,287 +758,6 @@ export class RemoteNewSession extends Disposable implements ICopilotChatSession 
 	}
 
 	update(_session: IAgentSession): void { }
-}
-
-/**
- * New session for local (in-process VS Code chat) sessions.
- * Implements {@link ICopilotChatSession} (session facade) for local sessions
- * that run in-process without worktrees or remote agents.
- * Keeps the underlying chat model alive by retaining the
- * {@link IChatModelReference} returned from `startNewLocalSession` for the
- * lifetime of this object.
- */
-class LocalNewSession extends Disposable implements ICopilotChatSession {
-
-	// -- ISessionData fields --
-
-	readonly resource: URI;
-	readonly sessionId: string;
-	readonly providerId: string;
-	readonly sessionType: typeof SessionType.Local;
-	readonly icon: ThemeIcon;
-	readonly createdAt: Date;
-
-	private readonly _title = observableValue(this, '');
-	readonly title: IObservable<string> = this._title;
-
-	private readonly _updatedAt = observableValue(this, new Date());
-	readonly updatedAt: IObservable<Date> = this._updatedAt;
-
-	private readonly _status = observableValue(this, SessionStatus.Untitled);
-	readonly status: IObservable<SessionStatus> = this._status;
-
-	private readonly _permissionLevel = observableValue(this, ChatPermissionLevel.Default);
-	readonly permissionLevel: IObservable<ChatPermissionLevel> = this._permissionLevel;
-
-	private readonly _workspaceData = observableValue<ISessionWorkspace | undefined>(this, undefined);
-	readonly workspace: IObservable<ISessionWorkspace | undefined> = this._workspaceData;
-
-	readonly checkpoints: IObservable<IChatCheckpoints | undefined> = constObservable(undefined);
-
-	private readonly _changes = observableValue<readonly ISessionFileChange[]>(this, []);
-	readonly changes: IObservable<readonly ISessionFileChange[]> = this._changes;
-
-	private readonly _modelIdObservable = observableValue<string | undefined>(this, undefined);
-	readonly modelId: IObservable<string | undefined> = this._modelIdObservable;
-
-	private readonly _modeObservable = observableValue<{ readonly id: string; readonly kind: string } | undefined>(this, undefined);
-	readonly mode: IObservable<{ readonly id: string; readonly kind: string } | undefined> = this._modeObservable;
-
-	readonly loading: IObservable<boolean> = observableValue(this, false);
-
-	private readonly _isArchived = observableValue(this, false);
-	readonly isArchived: IObservable<boolean> = this._isArchived;
-	readonly isRead: IObservable<boolean> = observableValue(this, true);
-	readonly description: IObservable<IMarkdownString | undefined> = constObservable(undefined);
-	readonly lastTurnEnd: IObservable<Date | undefined> = constObservable(undefined);
-	readonly gitHubInfo: IObservable<IGitHubInfo | undefined> = constObservable(undefined);
-	readonly branch: IObservable<string | undefined> = constObservable(undefined);
-	readonly isolationMode: IObservable<IsolationMode | undefined> = constObservable(undefined);
-	readonly branches: IObservable<readonly string[]> = constObservable([]);
-	readonly gitRepository?: IGitRepository | undefined;
-
-	readonly mainChat: ISettableObservable<IChat>;
-
-	// -- New session configuration fields --
-
-	private _modelId: string | undefined;
-	private _mode: IChatMode | undefined;
-
-	readonly target = AgentSessionProviders.Local;
-	readonly selectedOptions = new Map<string, IChatSessionProviderOptionItem>();
-
-	get selectedModelId(): string | undefined { return this._modelId; }
-	get chatMode(): IChatMode | undefined { return this._mode; }
-	get query(): string | undefined { return undefined; }
-	get attachedContext(): IChatRequestVariableEntry[] | undefined { return undefined; }
-	get disabled(): boolean { return false; }
-
-	constructor(
-		// readonly resource: URI,
-		readonly sessionWorkspace: ISessionWorkspace,
-		providerId: string,
-		@IGitService private readonly gitService: IGitService,
-		@IChatService private readonly chatService: IChatService,
-		@IFileService private readonly fileService: IFileService,
-	) {
-		super();
-
-		// Create a real local chat model upfront so the chat service has
-		// a model registered for our resource. This avoids the
-		// contributed-session path (which would require a content
-		// provider for the 'local' chat session type).
-		const modelRef = this._register(this.chatService.startNewLocalSession(
-			ChatAgentLocation.Chat,
-			{ debugOwner: 'CopilotChatSessionsProvider#createNewSession.local' },
-		));
-		if (sessionWorkspace.folders.length > 0) {
-			modelRef.object.setWorkingDirectory(sessionWorkspace.folders[0]?.root);
-		}
-		this.resource = modelRef.object.sessionResource;
-
-		this.sessionId = toSessionId(providerId, this.resource);
-		this.providerId = providerId;
-		this.sessionType = AgentSessionProviders.Local;
-		this.icon = LocalSessionType.icon;
-		this.createdAt = new Date();
-
-		this._workspaceData.set(sessionWorkspace, undefined);
-
-		this.mainChat = observableValue<IChat>(this, buildChatFromSession(this));
-
-		// Resolve git state asynchronously so the Changes view has
-		// branch names, uncommitted counts, etc. without needing
-		// an agent session in agentSessionsService.
-		this._resolveGitState();
-	}
-
-	private async _resolveGitState(): Promise<void> {
-		const repoUri = this.sessionWorkspace.folders[0]?.root;
-		if (!repoUri) {
-			return;
-		}
-
-		try {
-			const repo = await this.gitService.openRepository(repoUri);
-			if (!repo) {
-				return;
-			}
-
-			const folder = this.sessionWorkspace.folders[0];
-			const baseGitRepo: ISessionGitRepository = folder.gitRepository ?? {
-				uri: folder.root,
-				workTreeUri: undefined,
-				baseBranchName: undefined,
-				gitHubInfo: constObservable(undefined),
-			};
-
-			this._register(autorun((reader) => {
-				const state = repo.state.read(reader);
-				const head = state.HEAD;
-				const branchName = head?.commit ? head.name : undefined;
-				const upstreamBranchName = head?.upstream
-					? `${head.upstream.remote}/${head.upstream.name}`
-					: undefined;
-				const uncommittedChanges = state.workingTreeChanges.length + state.untrackedChanges.length + state.indexChanges.length;
-
-				this._workspaceData.set({
-					...this.sessionWorkspace,
-					folders: [{
-						...folder,
-						gitRepository: {
-							...baseGitRepo,
-							branchName,
-							upstreamBranchName,
-							uncommittedChanges,
-						},
-					}],
-				}, undefined);
-
-				// Capture all known changed files from the current state snapshot
-				// so we can fill in any that diffBetweenWithStats2 misses
-				// (e.g. untracked files regardless of the git.untrackedChanges setting)
-				const allStateChanges = [...state.workingTreeChanges, ...state.untrackedChanges, ...state.indexChanges];
-
-				// Fetch real line-level diff stats asynchronously
-				repo.diffBetweenWithStats2('HEAD').then(async diffChanges => {
-					if (this._store.isDisposed) {
-						return;
-					}
-					// diffBetweenWithStats2 only covers tracked changes against HEAD;
-					// append any files from the git state that it missed
-					// (e.g. untracked/new files not yet staged) with real line counts
-					const trackedUris = new Set(diffChanges.map(el => el.uri.toString()));
-					const changes: IChatSessionFileChange2[] = diffChanges.map(el => ({
-						uri: el.uri,
-						originalUri: el.originalUri,
-						modifiedUri: el.modifiedUri ?? el.uri,
-						insertions: el.insertions,
-						deletions: el.deletions,
-					}));
-					const untrackedFiles = allStateChanges.filter(el => !trackedUris.has(el.uri.toString()));
-					const lineCountPromises = untrackedFiles.map(async el => {
-						let insertions = 0;
-						try {
-							const stat = await this.fileService.stat(el.uri);
-							if (!stat.isDirectory) {
-								const content = await this.fileService.readFile(el.uri);
-								// Count newlines; add 1 for the last line if file is non-empty
-								const text = content.value.toString();
-								insertions = text.length > 0 ? text.split('\n').length : 0;
-							}
-						} catch {
-							// File may have been deleted between state snapshot and read
-						}
-						return {
-							uri: el.uri,
-							originalUri: undefined,
-							modifiedUri: el.modifiedUri ?? el.uri,
-							insertions,
-							deletions: 0,
-						} satisfies IChatSessionFileChange2;
-					});
-					const untrackedChanges = await Promise.all(lineCountPromises);
-					if (this._store.isDisposed) {
-						return;
-					}
-					changes.push(...untrackedChanges);
-					this._changes.set(changes, undefined);
-				}, () => {
-					// Diff computation failed — fall back to zero stats
-					if (this._store.isDisposed) {
-						return;
-					}
-					this._changes.set(allStateChanges.map<IChatSessionFileChange2>(el => ({
-						uri: el.uri,
-						originalUri: el.originalUri,
-						modifiedUri: el.modifiedUri ?? el.uri,
-						insertions: 0,
-						deletions: 0,
-					})), undefined);
-				});
-			}));
-
-		} catch {
-			// No git repository available — workspace stays as-is
-		}
-	}
-
-	setOption(optionId: string, value: IChatSessionProviderOptionItem | string): void {
-		if (typeof value === 'string') {
-			this.selectedOptions.set(optionId, { id: value, name: value });
-		} else {
-			this.selectedOptions.set(optionId, value);
-		}
-	}
-
-	setPermissionLevel(level: ChatPermissionLevel): void {
-		this._permissionLevel.set(level, undefined);
-	}
-
-	setIsolationMode(_mode: IsolationMode): void {
-		// No-op — local sessions do not use isolation
-	}
-
-	setBranch(_branch: string | undefined): void {
-		// No-op — local sessions do not manage branches
-	}
-
-	setModelId(modelId: string | undefined): void {
-		this._modelId = modelId;
-		this._modelIdObservable.set(modelId, undefined);
-	}
-
-	setTitle(title: string): void {
-		this._title.set(title, undefined);
-	}
-
-	setStatus(status: SessionStatus): void {
-		this._status.set(status, undefined);
-	}
-
-	setArchived(archived: boolean): void {
-		this._isArchived.set(archived, undefined);
-	}
-
-	setMode(mode: IChatMode | undefined): void {
-		this._mode = mode;
-		if (mode) {
-			this._modeObservable.set({ id: mode.id, kind: mode.kind }, undefined);
-		} else {
-			this._modeObservable.set(undefined, undefined);
-		}
-	}
-
-	update(session: IAgentSession): void {
-		transaction(tx => {
-			this._title.set(session.label, tx);
-			const updatedTime = session.timing.lastRequestEnded ?? session.timing.lastRequestStarted ?? session.timing.created;
-			this._updatedAt.set(new Date(updatedTime), tx);
-			this._status.set(toSessionStatus(session.status), tx);
-			this._isArchived.set(session.isArchived(), tx);
-		});
-	}
 }
 
 /**
@@ -1656,9 +1364,6 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 
 	get sessionTypes(): readonly ISessionType[] {
 		const types: ISessionType[] = [CopilotCLISessionType, CopilotCloudSessionType];
-		if (this._localSessionEnabled) {
-			types.push(LocalSessionType);
-		}
 		if (this._claudeEnabled) {
 			types.push(ClaudeCodeSessionType);
 		}
@@ -1675,7 +1380,7 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 	readonly onDidReplaceSession: Event<{ readonly from: ISession; readonly to: ISession }> = this._onDidReplaceSession.event;
 
 	/** Cache of adapted sessions, keyed by resource URI string. */
-	private readonly _sessionCache = new Map<string, AgentSessionAdapter | CopilotCLISession | RemoteNewSession | ClaudeCodeNewSession | LocalNewSession>();
+	private readonly _sessionCache = new Map<string, AgentSessionAdapter | CopilotCLISession | RemoteNewSession | ClaudeCodeNewSession>();
 
 	/** Cache of ISession wrappers, keyed by session group ID. */
 	private readonly _sessionGroupCache = new Map<string, ISession>();
@@ -1697,7 +1402,6 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 
 	private readonly _multiChatEnabled: boolean;
 	private _claudeEnabled: boolean;
-	private _localSessionEnabled: boolean;
 
 	readonly browseActions: readonly ISessionWorkspaceBrowseAction[];
 	readonly supportsLocalWorkspaces = true;
@@ -1721,21 +1425,12 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 
 		this._multiChatEnabled = this.configurationService.getValue<boolean>(COPILOT_MULTI_CHAT_SETTING) ?? true;
 		this._claudeEnabled = this.configurationService.getValue<boolean>(CLAUDE_CODE_ENABLED_SETTING);
-		this._localSessionEnabled = this.configurationService.getValue<boolean>(LOCAL_SESSION_ENABLED_SETTING);
 
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration(CLAUDE_CODE_ENABLED_SETTING)) {
 				const claudeEnabled = this.configurationService.getValue<boolean>(CLAUDE_CODE_ENABLED_SETTING);
 				if (this._claudeEnabled !== claudeEnabled) {
 					this._claudeEnabled = claudeEnabled;
-					this._onDidChangeSessionTypes.fire();
-					this._refreshSessionCache();
-				}
-			}
-			if (e.affectsConfiguration(LOCAL_SESSION_ENABLED_SETTING)) {
-				const localSessionEnabled = this.configurationService.getValue<boolean>(LOCAL_SESSION_ENABLED_SETTING);
-				if (this._localSessionEnabled !== localSessionEnabled) {
-					this._localSessionEnabled = localSessionEnabled;
 					this._onDidChangeSessionTypes.fire();
 					this._refreshSessionCache();
 				}
@@ -1765,9 +1460,6 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 			return [CopilotCloudSessionType];
 		}
 		const types: ISessionType[] = [CopilotCLISessionType];
-		if (this._localSessionEnabled) {
-			types.push(LocalSessionType);
-		}
 		if (this._claudeEnabled) {
 			types.push(ClaudeCodeSessionType);
 		}
@@ -1848,13 +1540,6 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 		if (sessionTypeId === ClaudeCodeSessionType.id) {
 			const resource = URI.from({ scheme: AgentSessionProviders.Claude, path: `/untitled-${generateUuid()}` });
 			const session = this.instantiationService.createInstance(ClaudeCodeNewSession, resource, workspace, this.id);
-			this._currentNewSession.value = session;
-			return this._chatToSession(session);
-		}
-
-		if (sessionTypeId === LocalSessionType.id) {
-			const session = this.instantiationService.createInstance(LocalNewSession, workspace, this.id);
-			session.setPermissionLevel(this._defaultPermissionLevel());
 			this._currentNewSession.value = session;
 			return this._chatToSession(session);
 		}
@@ -2072,8 +1757,6 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 				}
 				(await this._createChatSession(newItem.resource, session)).dispose();
 				newChat = this._toChat(session, newItem.resource);
-			} else if (session instanceof LocalNewSession) {
-				newChat = this._toChat(session);
 			} else {
 				(await this._createChatSession(session.resource, session)).dispose();
 				newChat = this._toChat(session);
@@ -2169,7 +1852,7 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 		return this._sendExistingChat(sessionId, chatSession, options);
 	}
 
-	private async _sendFirstChat(session: CopilotCLISession | RemoteNewSession | ClaudeCodeNewSession | LocalNewSession, chatResource: URI, options: ISendRequestOptions): Promise<ISession> {
+	private async _sendFirstChat(session: CopilotCLISession | RemoteNewSession | ClaudeCodeNewSession, chatResource: URI, options: ISendRequestOptions): Promise<ISession> {
 
 		const { query, attachedContext } = options;
 
@@ -2734,8 +2417,7 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 		for (const session of this.agentSessionsService.model.sessions) {
 			if (session.providerType !== AgentSessionProviders.Background
 				&& session.providerType !== AgentSessionProviders.Cloud
-				&& session.providerType !== AgentSessionProviders.Claude
-				&& session.providerType !== AgentSessionProviders.Local) {
+				&& session.providerType !== AgentSessionProviders.Claude) {
 				continue;
 			}
 

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/copilotChatSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/copilotChatSessionsProvider.test.ts
@@ -384,7 +384,7 @@ suite('CopilotChatSessionsProvider', () => {
 		assert.strictEqual(sessions.length, 2);
 	});
 
-	test('getSessions includes Background and Local sessions', () => {
+	test('getSessions excludes Local sessions (now owned by LocalChatSessionsProvider)', () => {
 		const bgResource = URI.from({ scheme: AgentSessionProviders.Background, path: '/bg-session' });
 		const localResource = URI.from({ scheme: AgentSessionProviders.Local, path: '/local-session' });
 		model.addSession(createMockAgentSession(bgResource));
@@ -393,7 +393,7 @@ suite('CopilotChatSessionsProvider', () => {
 		const provider = createProvider(disposables, model);
 		const sessions = provider.getSessions();
 
-		assert.strictEqual(sessions.length, 2);
+		assert.strictEqual(sessions.length, 1);
 	});
 
 	test('getSessions includes Claude agent sessions when enabled', () => {

--- a/src/vs/sessions/contrib/providers/localChatSessions/LOCAL_CHAT_SESSIONS_PROVIDER.md
+++ b/src/vs/sessions/contrib/providers/localChatSessions/LOCAL_CHAT_SESSIONS_PROVIDER.md
@@ -1,0 +1,134 @@
+# LocalChatSessionsProvider — Local In-Process Chat Sessions
+
+**File:** `src/vs/sessions/contrib/providers/localChatSessions/browser/localChatSessionsProvider.ts`
+
+The local sessions provider, registered with ID `'local-chat'`. Wraps local in-process VS Code chat sessions (created via `IChatService.startNewLocalSession()`) into the extensible sessions provider model. Owns its own session list — does not rely on the chat history APIs at runtime.
+
+## Identity
+
+| Property | Value |
+|----------|-------|
+| `id` | `'local-chat'` |
+| `label` | `'Local Chat'` |
+| `icon` | `Codicon.vm` |
+| `sessionTypes` | `[LocalSessionType]` (static — provider is only registered when `sessions.chat.localAgent.enabled` is true at startup) |
+| `supportsLocalWorkspaces` | `true` |
+| `browseActions` | `[]` (uses the workspace picker's built-in folder browser) |
+
+`LocalSessionType` is defined as:
+
+```typescript
+{ id: 'local', label: 'Local', icon: Codicon.vm }
+```
+
+## Registration
+
+Registration is gated by the `sessions.chat.localAgent.enabled` setting, read once at workbench startup in `localChatSessions.contribution.ts`. If the setting is `false`, the provider is not created or registered at all. **Toggling the setting requires a window reload to take effect** — the provider does not listen for runtime configuration changes.
+
+## Architecture
+
+### Single `LocalSession` class
+
+Local sessions are represented by a single `LocalSession` class with two construction paths controlled by a `detail: IChatDetail | undefined` constructor parameter:
+
+- **`detail === undefined`** → new session: creates a fresh chat model via `IChatService.startNewLocalSession(ChatAgentLocation.Chat)`, resolves git state for the workspace via `IGitService`, and retains the model reference for the session's lifetime.
+- **`detail !== undefined`** → restored session: built from a persisted `IChatDetail` snapshot. Does not own a chat model reference; the model is loaded on demand via `IChatService.acquireOrLoadSession` when the user opens the session.
+
+The class exposes the standard `ISession` observable surface plus pre-send configuration (`setModelId`, `setMode`, `setPermissionLevel`, `setTitle`, `setStatus`, `setArchived`) and `trackModel(model, onChange)` for reactive status binding.
+
+### Provider state
+
+- **`_currentNewSession: MutableDisposable<LocalSession>`** — holds the session being composed before its first `sendRequest`.
+- **`_sessionCache: Map<string, LocalSession>`** — keyed by resource URI string. Populated when a session is sent for the first time or when persisted sessions are loaded on startup.
+
+A `LocalSession` moves from `_currentNewSession` → `_sessionCache` when `sendRequest` succeeds. The resource never changes — the same `LocalSession` instance is kept.
+
+### Persistence
+
+Local sessions are persisted in `IStorageService` profile-scoped, machine-target storage under the key `sessions.localChat.sessions`. Each entry is an `IStoredLocalSession`:
+
+```typescript
+interface IStoredLocalSession {
+	readonly uri: UriComponents;
+	readonly title: string;
+	readonly createdAt: number;
+	readonly lastMessageDate: number;
+	readonly workingDirectory: UriComponents; // mandatory
+	readonly archived?: boolean;
+}
+```
+
+- **Add** (`_addStoredSession`) — called after the first `sendRequest`. Refuses to persist if no working directory is available.
+- **Update** (`_updateStoredSession`) — called on rename, archive, response-completion, or `onDidSubmitRequest`-driven sync.
+- **Remove** (`_removeStoredSession`) — called from `deleteSession`.
+- **Load** (`_loadPersistedSessions`) — on provider construction; reads stored entries and creates `LocalSession` instances from them.
+
+Storage is self-contained: no `IChatService` calls are needed to list sessions, since title and timing are stored inline.
+
+### One-time migration
+
+On first run, `_migrateFromHistory()` reads `IChatService.getLocalSessionHistory()` once, imports each session with a working directory into our storage (skipping anything already stored), and sets the `sessions.localChat.migrated` flag. This brings forward existing local chat history when users upgrade.
+
+### Live model tracking
+
+When `onDidSubmitRequest` fires for a session in `_sessionCache`, `_syncSessionFromModel` calls `LocalSession.trackModel(model, onChange)`:
+
+- Subscribes to `model.requestInProgress` via `autorun`
+- Maps `true` → `SessionStatus.InProgress`, `false` → `SessionStatus.Completed`
+- Calls `onChange()` so the provider updates title, timing, persisted storage, and fires `onDidChangeSessions`
+
+A `MutableDisposable` on `LocalSession` ensures repeated `trackModel` calls don't accumulate listeners.
+
+## Lifecycle Flow
+
+### Creating a new session
+
+```
+1. User selects a folder in the workspace picker → createNewSession(folderUri, 'local')
+   → resolveWorkspace produces ISessionWorkspace
+   → LocalSession constructed with detail=undefined
+   → startNewLocalSession() creates chat model, resource is captured
+   → git state resolution scheduled
+   → _currentNewSession.value = session
+   → returns ISession
+
+2. User types a message → sendRequest(sessionId, chatResource, options)
+   → Sets title from first line of query, status InProgress
+   → Builds IChatSendRequestOptions (mode, model, permissions, attachedContext)
+   → _updateChatSessionState applies model/mode/permission to chat model
+   → chatService.sendRequest(chatResource, query, options)
+   → On success: session moves to _sessionCache, _currentNewSession cleared,
+     _addStoredSession persists the URI + metadata
+   → responseCompletePromise updates status to Completed and syncs from model
+```
+
+### Restoring sessions on startup
+
+```
+1. Provider constructor runs
+2. _migrateFromHistory (idempotent) imports any pre-existing local chat history
+3. _loadPersistedSessions reads IStoredLocalSession[] and creates LocalSession
+   instances directly from stored metadata — no chat models loaded yet
+4. Sessions appear in getSessions(); chat model is loaded lazily by the
+   chat view pane when the user clicks a session
+```
+
+### Actions
+
+- **`archiveSession` / `unarchiveSession`** — toggles `isArchived` on the cached session and persists.
+- **`deleteSession`** — calls `chatService.removeHistoryEntry()`, removes from cache, removes from storage.
+- **`renameChat`** — calls `chatService.setSessionTitle()`, updates session title, persists.
+- **`setModel`** — only meaningful for the current new session before send; updates pre-send model id.
+- **`createNewChat`** — for the current new session, returns the already-prepared `IChat` and updates `mainChat`.
+
+## Picker Contributions
+
+Local sessions reuse the Copilot provider's pickers (`ModePicker`, `SessionModelPicker`, `PermissionPicker`) via `when` clauses that match `ActiveSessionTypeContext === 'local'`. The picker actions in `copilotChatSessionsActions.ts` include `IsActiveSessionLocal` in their `when` expressions so the same widgets surface for both the copilot CLI provider and this local provider.
+
+## Differences from `CopilotChatSessionsProvider`
+
+- **No `IAgentSessionsService` dependency.** Uses `IChatService` directly.
+- **No untitled→committed URI swap.** Local session resources never change.
+- **No multi-chat support.** Each local session has exactly one chat.
+- **Self-managed session list.** Storage owns the source of truth, not the chat history.
+- **No worktree / branch / isolation.** Local sessions run in-process against the workspace folder as-is.

--- a/src/vs/sessions/contrib/providers/localChatSessions/browser/localChatSessions.contribution.ts
+++ b/src/vs/sessions/contrib/providers/localChatSessions/browser/localChatSessions.contribution.ts
@@ -1,0 +1,97 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../../workbench/common/contributions.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { Disposable, IDisposable } from '../../../../../base/common/lifecycle.js';
+import { LocalChatSessionsProvider, LOCAL_SESSION_ENABLED_SETTING, LocalSessionType } from './localChatSessionsProvider.js';
+import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
+import { Registry } from '../../../../../platform/registry/common/platform.js';
+import { IConfigurationRegistry, Extensions as ConfigurationExtensions } from '../../../../../platform/configuration/common/configurationRegistry.js';
+import { localize } from '../../../../../nls.js';
+import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
+import { ForkConversationAction } from '../../../../../workbench/contrib/chat/browser/actions/chatForkActions.js';
+import { registerAction2 } from '../../../../../platform/actions/common/actions.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
+import { raceTimeout } from '../../../../../base/common/async.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+
+Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
+	id: 'sessions',
+	properties: {
+		[LOCAL_SESSION_ENABLED_SETTING]: {
+			type: 'boolean',
+			default: true,
+			tags: ['experimental'],
+			experiment: { mode: 'startup' },
+			description: localize('sessions.chat.localAgent.enabled', "Enable Local VS Code chat sessions in the Agents Window. Reload the window for changes to take effect."),
+		},
+	},
+});
+
+class LocalSessionsProviderContribution extends Disposable implements IWorkbenchContribution {
+	static readonly ID = 'sessions.localSessionsProvider';
+
+	constructor(
+		@IInstantiationService instantiationService: IInstantiationService,
+		@ISessionsProvidersService sessionsProvidersService: ISessionsProvidersService,
+		@IConfigurationService configurationService: IConfigurationService,
+	) {
+		super();
+
+		// Only register the provider when enabled. The setting is read once
+		// at startup; toggling it requires a window reload.
+		if (!configurationService.getValue<boolean>(LOCAL_SESSION_ENABLED_SETTING)) {
+			return;
+		}
+
+		const provider = this._register(instantiationService.createInstance(LocalChatSessionsProvider));
+		this._register(sessionsProvidersService.registerProvider(provider));
+	}
+}
+
+registerWorkbenchContribution2(LocalSessionsProviderContribution.ID, LocalSessionsProviderContribution, WorkbenchPhase.AfterRestored);
+
+registerAction2(class extends ForkConversationAction {
+	protected override _openForkedSession(instantiationService: IInstantiationService, parentSessionResource: URI, forkedSessionResource: URI): Promise<void> {
+		return instantiationService.invokeFunction(async accessor => {
+			const sessionsManagementService = accessor.get(ISessionsManagementService);
+			const logService = accessor.get(ILogService);
+
+			const parentSession = sessionsManagementService.getSession(parentSessionResource);
+			if (!parentSession) {
+				logService.error(`Parent session ${parentSessionResource.toString()} not found when forking conversation`);
+				return super._openForkedSession(instantiationService, parentSessionResource, forkedSessionResource);
+			}
+
+			if (parentSession.sessionType !== LocalSessionType.id) {
+				return super._openForkedSession(instantiationService, parentSessionResource, forkedSessionResource);
+			}
+
+			// Local sessions — wait for the forked session to appear, but
+			// bound the wait so a missing session does not hang forever.
+			if (!sessionsManagementService.getSession(forkedSessionResource)) {
+				let listener: IDisposable | undefined;
+				const appeared = await raceTimeout(new Promise<boolean>(resolve => {
+					listener = sessionsManagementService.onDidChangeSessions(() => {
+						if (sessionsManagementService.getSession(forkedSessionResource)) {
+							resolve(true);
+						}
+					});
+				}), 30_000);
+				listener?.dispose();
+
+				if (!appeared) {
+					logService.error(`Forked session ${forkedSessionResource.toString()} did not appear within timeout`);
+					return;
+				}
+			}
+			await sessionsManagementService.openSession(forkedSessionResource);
+
+		});
+	}
+});
+

--- a/src/vs/sessions/contrib/providers/localChatSessions/browser/localChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/localChatSessions/browser/localChatSessionsProvider.ts
@@ -1,0 +1,925 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Emitter, Event } from '../../../../../base/common/event.js';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { Disposable, MutableDisposable } from '../../../../../base/common/lifecycle.js';
+import { Schemas } from '../../../../../base/common/network.js';
+import { autorun, constObservable, IObservable, ISettableObservable, observableValue, transaction } from '../../../../../base/common/observable.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
+import { URI, UriComponents } from '../../../../../base/common/uri.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { IChatService, IChatSendRequestOptions, IChatDetail, convertLegacyChatSessionTiming } from '../../../../../workbench/contrib/chat/common/chatService/chatService.js';
+import { IChatSessionFileChange2, IChatSessionProviderOptionItem, SessionType } from '../../../../../workbench/contrib/chat/common/chatSessionsService.js';
+import { ISession, IChat, ISessionGitRepository, ISessionFolder, ISessionWorkspace, SessionStatus, ISessionType, ISessionFileChange, toSessionId, SESSION_WORKSPACE_GROUP_LOCAL, IChatCheckpoints } from '../../../../services/sessions/common/session.js';
+import { ChatAgentLocation, ChatConfiguration, ChatModeKind, ChatPermissionLevel, isChatPermissionLevel } from '../../../../../workbench/contrib/chat/common/constants.js';
+import { basename, dirname } from '../../../../../base/common/resources.js';
+import { ISendRequestOptions, ISessionChangeEvent, ISessionsProvider } from '../../../../services/sessions/common/sessionsProvider.js';
+import { isBuiltinChatMode, IChatMode } from '../../../../../workbench/contrib/chat/common/chatModes.js';
+import { IChatModel } from '../../../../../workbench/contrib/chat/common/model/chatModel.js';
+import { IGitService } from '../../../../../workbench/contrib/git/common/gitService.js';
+import { localize } from '../../../../../nls.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { ILabelService } from '../../../../../platform/label/common/label.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
+import { IFileService } from '../../../../../platform/files/common/files.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
+import { ILanguageModelsService } from '../../../../../workbench/contrib/chat/common/languageModels.js';
+import { ILanguageModelToolsService } from '../../../../../workbench/contrib/chat/common/tools/languageModelToolsService.js';
+import { createChangesets } from '../../copilotChatSessions/browser/copilotChatSessionsChangesets.js';
+import { IMarkdownString } from '../../../../../base/common/htmlContent.js';
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+
+/** Local session type — in-process VS Code chat, no background agent or worktree. */
+export const LocalSessionType: ISessionType = {
+	id: 'local',
+	label: localize('localSession', "Local"),
+	icon: Codicon.vm,
+};
+
+/** Setting key controlling whether Local VS Code chat sessions are available in the Agents app. */
+export const LOCAL_SESSION_ENABLED_SETTING = 'sessions.chat.localAgent.enabled';
+
+const LOCAL_PROVIDER_ID = 'local-chat';
+const STORAGE_KEY_SESSIONS = 'sessions.localChat.sessions';
+const STORAGE_KEY_MIGRATED = 'sessions.localChat.migrated';
+
+interface IStoredLocalSession {
+	readonly uri: UriComponents;
+	readonly title: string;
+	readonly createdAt: number;
+	readonly lastMessageDate: number;
+	readonly workingDirectory: UriComponents;
+	readonly archived?: boolean;
+}
+
+/**
+ * Builds an {@link IChat} snapshot from a {@link LocalSession}.
+ */
+function buildChat(session: LocalSession): IChat {
+	return {
+		resource: session.resource,
+		createdAt: session.createdAt,
+		title: session.title,
+		updatedAt: session.updatedAt,
+		status: session.status,
+		changes: session.changes,
+		checkpoints: session.checkpoints,
+		modelId: session.modelId,
+		mode: session.mode,
+		isArchived: session.isArchived,
+		isRead: session.isRead,
+		description: session.description,
+		lastTurnEnd: session.lastTurnEnd,
+	};
+}
+
+/**
+ * A local chat session. Manages observable state and provides mutation
+ * methods used by the provider.
+ *
+ * Constructed in two ways:
+ * - **New session** (`detail` is `undefined`): creates a fresh chat model
+ *   through {@link IChatService.startNewLocalSession} and resolves git state.
+ * - **History session** (`detail` is provided): restores from a persisted
+ *   {@link IChatDetail} without owning a chat model reference.
+ */
+class LocalSession extends Disposable {
+
+	readonly resource: URI;
+	readonly sessionId: string;
+	readonly providerId: string;
+	readonly sessionType = SessionType.Local;
+	readonly icon: ThemeIcon;
+	readonly createdAt: Date;
+
+	private readonly _title = observableValue(this, '');
+	readonly title: IObservable<string> = this._title;
+
+	private readonly _updatedAt = observableValue(this, new Date());
+	readonly updatedAt: IObservable<Date> = this._updatedAt;
+
+	private readonly _status = observableValue(this, SessionStatus.Untitled);
+	readonly status: IObservable<SessionStatus> = this._status;
+
+	private readonly _permissionLevel = observableValue(this, ChatPermissionLevel.Default);
+	readonly permissionLevel: IObservable<ChatPermissionLevel> = this._permissionLevel;
+
+	private readonly _workspaceData = observableValue<ISessionWorkspace | undefined>(this, undefined);
+	readonly workspace: IObservable<ISessionWorkspace | undefined> = this._workspaceData;
+
+	readonly checkpoints: IObservable<IChatCheckpoints | undefined> = constObservable(undefined);
+
+	private readonly _changes = observableValue<readonly ISessionFileChange[]>(this, []);
+	readonly changes: IObservable<readonly ISessionFileChange[]> = this._changes;
+
+	private readonly _modelIdObservable = observableValue<string | undefined>(this, undefined);
+	readonly modelId: IObservable<string | undefined> = this._modelIdObservable;
+
+	private readonly _modeObservable = observableValue<{ readonly id: string; readonly kind: string } | undefined>(this, undefined);
+	readonly mode: IObservable<{ readonly id: string; readonly kind: string } | undefined> = this._modeObservable;
+
+	readonly loading: IObservable<boolean> = constObservable(false);
+
+	private readonly _isArchived = observableValue(this, false);
+	readonly isArchived: IObservable<boolean> = this._isArchived;
+	readonly isRead: IObservable<boolean> = constObservable(true);
+	readonly description: IObservable<IMarkdownString | undefined> = constObservable(undefined);
+
+	private readonly _lastTurnEnd = observableValue<Date | undefined>(this, undefined);
+	readonly lastTurnEnd: IObservable<Date | undefined> = this._lastTurnEnd;
+
+	readonly mainChat: ISettableObservable<IChat>;
+
+	// -- Pre-send configuration --
+
+	private _modelId: string | undefined;
+	private _mode: IChatMode | undefined;
+
+	readonly selectedOptions = new Map<string, IChatSessionProviderOptionItem>();
+
+	get selectedModelId(): string | undefined { return this._modelId; }
+	get chatMode(): IChatMode | undefined { return this._mode; }
+
+	/**
+	 * Creates a session from persisted chat history.
+	 */
+	static fromHistory(
+		detail: IChatDetail,
+		providerId: string,
+		workspace: ISessionWorkspace | undefined,
+		instantiationService: IInstantiationService,
+	): LocalSession {
+		return instantiationService.createInstance(LocalSession, detail, workspace, providerId);
+	}
+
+	constructor(
+		detail: IChatDetail | undefined,
+		workspace: ISessionWorkspace | undefined,
+		providerId: string,
+		@IGitService private readonly gitService: IGitService,
+		@IChatService private readonly chatService: IChatService,
+		@IFileService private readonly fileService: IFileService,
+	) {
+		super();
+
+		this.providerId = providerId;
+		this.icon = LocalSessionType.icon;
+
+		if (detail) {
+			// History session — restore from persisted data
+			const timing = convertLegacyChatSessionTiming(detail.timing);
+			this.resource = detail.sessionResource;
+			this.createdAt = new Date(timing.created);
+
+			const lastUpdate = detail.lastMessageDate || timing.lastRequestEnded || timing.lastRequestStarted || timing.created;
+			this._title.set(detail.title, undefined);
+			this._updatedAt.set(new Date(lastUpdate), undefined);
+			this._status.set(detail.isActive ? SessionStatus.InProgress : SessionStatus.Completed, undefined);
+			this._lastTurnEnd.set(timing.lastRequestEnded ? new Date(timing.lastRequestEnded) : undefined, undefined);
+
+			if (workspace) {
+				this._workspaceData.set(workspace, undefined);
+			}
+		} else {
+			// New session — create a fresh chat model
+			const modelRef = this._register(this.chatService.startNewLocalSession(
+				ChatAgentLocation.Chat,
+				{ debugOwner: 'LocalChatSessionsProvider#createNewSession' },
+			));
+			if (workspace && workspace.folders.length > 0) {
+				modelRef.object.setWorkingDirectory(workspace.folders[0]?.root);
+			}
+			this.resource = modelRef.object.sessionResource;
+			this.createdAt = new Date();
+
+			if (workspace) {
+				this._workspaceData.set(workspace, undefined);
+				this._resolveGitState(workspace);
+			}
+		}
+
+		this.sessionId = toSessionId(providerId, this.resource);
+		this.mainChat = observableValue<IChat>(this, buildChat(this));
+	}
+
+	private async _resolveGitState(workspace: ISessionWorkspace): Promise<void> {
+		const repoUri = workspace.folders[0]?.root;
+		if (!repoUri) {
+			return;
+		}
+
+		try {
+			const repo = await this.gitService.openRepository(repoUri);
+			if (!repo) {
+				return;
+			}
+
+			const folder = workspace.folders[0];
+			const baseGitRepo: ISessionGitRepository = folder.gitRepository ?? {
+				uri: folder.root,
+				workTreeUri: undefined,
+				baseBranchName: undefined,
+				gitHubInfo: constObservable(undefined),
+			};
+
+			// Monotonically increasing version used to discard stale diff results.
+			let diffVersion = 0;
+
+			this._register(autorun((reader) => {
+				const state = repo.state.read(reader);
+				const head = state.HEAD;
+				const branchName = head?.commit ? head.name : undefined;
+				const upstreamBranchName = head?.upstream
+					? `${head.upstream.remote}/${head.upstream.name}`
+					: undefined;
+				const uncommittedChanges = state.workingTreeChanges.length + state.untrackedChanges.length + state.indexChanges.length;
+
+				this._workspaceData.set({
+					...workspace,
+					folders: [{
+						...folder,
+						gitRepository: {
+							...baseGitRepo,
+							branchName,
+							upstreamBranchName,
+							uncommittedChanges,
+						},
+					}],
+				}, undefined);
+
+				const allStateChanges = [...state.workingTreeChanges, ...state.untrackedChanges, ...state.indexChanges];
+
+				const version = ++diffVersion;
+				repo.diffBetweenWithStats2('HEAD').then(async diffChanges => {
+					if (this._store.isDisposed || version !== diffVersion) {
+						return;
+					}
+					const trackedUris = new Set(diffChanges.map(el => el.uri.toString()));
+					const changes: IChatSessionFileChange2[] = diffChanges.map(el => ({
+						uri: el.uri,
+						originalUri: el.originalUri,
+						modifiedUri: el.modifiedUri ?? el.uri,
+						insertions: el.insertions,
+						deletions: el.deletions,
+					}));
+					const untrackedFiles = allStateChanges.filter(el => !trackedUris.has(el.uri.toString()));
+					const lineCountPromises = untrackedFiles.map(async el => {
+						let insertions = 0;
+						try {
+							const stat = await this.fileService.stat(el.uri);
+							if (!stat.isDirectory) {
+								const content = await this.fileService.readFile(el.uri);
+								const text = content.value.toString();
+								insertions = text.length > 0 ? text.split('\n').length : 0;
+							}
+						} catch {
+							// File may have been deleted between state snapshot and read
+						}
+						return {
+							uri: el.uri,
+							originalUri: undefined,
+							modifiedUri: el.modifiedUri ?? el.uri,
+							insertions,
+							deletions: 0,
+						} satisfies IChatSessionFileChange2;
+					});
+					const untrackedChanges = await Promise.all(lineCountPromises);
+					if (this._store.isDisposed || version !== diffVersion) {
+						return;
+					}
+					changes.push(...untrackedChanges);
+					this._changes.set(changes, undefined);
+				}, () => {
+					if (this._store.isDisposed || version !== diffVersion) {
+						return;
+					}
+					this._changes.set(allStateChanges.map<IChatSessionFileChange2>(el => ({
+						uri: el.uri,
+						originalUri: el.originalUri,
+						modifiedUri: el.modifiedUri ?? el.uri,
+						insertions: 0,
+						deletions: 0,
+					})), undefined);
+				});
+			}));
+		} catch {
+			// No git repository available — workspace stays as-is
+		}
+	}
+
+	setPermissionLevel(level: ChatPermissionLevel): void {
+		this._permissionLevel.set(level, undefined);
+	}
+
+	setModelId(modelId: string | undefined): void {
+		this._modelId = modelId;
+		this._modelIdObservable.set(modelId, undefined);
+	}
+
+	setTitle(title: string): void {
+		this._title.set(title, undefined);
+	}
+
+	setUpdatedAt(date: Date): void {
+		this._updatedAt.set(date, undefined);
+	}
+
+	setStatus(status: SessionStatus): void {
+		this._status.set(status, undefined);
+	}
+
+	setArchived(archived: boolean): void {
+		this._isArchived.set(archived, undefined);
+	}
+
+	private readonly _modelTracker = this._register(new MutableDisposable());
+
+	/**
+	 * Subscribe to live updates from the given chat model. Subsequent calls
+	 * replace any prior subscription. Disposed automatically with the session.
+	 */
+	trackModel(model: IChatModel, onChange: () => void): void {
+		this._modelTracker.value = autorun(reader => {
+			const inProgress = model.requestInProgress.read(reader);
+			this._status.set(inProgress ? SessionStatus.InProgress : SessionStatus.Completed, undefined);
+			onChange();
+		});
+	}
+
+	setMode(mode: IChatMode | undefined): void {
+		this._mode = mode;
+		if (mode) {
+			this._modeObservable.set({ id: mode.id, kind: mode.kind }, undefined);
+		} else {
+			this._modeObservable.set(undefined, undefined);
+		}
+	}
+
+	/**
+	 * Update this session from a persisted history detail.
+	 */
+	updateFromHistory(detail: IChatDetail): void {
+		const timing = convertLegacyChatSessionTiming(detail.timing);
+		const lastUpdate = detail.lastMessageDate || timing.lastRequestEnded || timing.lastRequestStarted || timing.created;
+		transaction(tx => {
+			this._title.set(detail.title, tx);
+			this._updatedAt.set(new Date(lastUpdate), tx);
+			this._status.set(detail.isActive ? SessionStatus.InProgress : SessionStatus.Completed, tx);
+			this._lastTurnEnd.set(timing.lastRequestEnded ? new Date(timing.lastRequestEnded) : undefined, tx);
+		});
+	}
+}
+
+/**
+ * Sessions provider that wraps local in-process chat sessions
+ * (using {@link IChatService} directly) into the {@link ISessionsProvider} interface.
+ */
+export class LocalChatSessionsProvider extends Disposable implements ISessionsProvider {
+
+	readonly id = LOCAL_PROVIDER_ID;
+	readonly label = localize('localChatSessionsProvider', "Local Chat");
+	readonly icon = Codicon.vm;
+	readonly browseActions: readonly [] = [];
+	readonly supportsLocalWorkspaces = true;
+
+	readonly sessionTypes: readonly ISessionType[] = [LocalSessionType];
+	readonly onDidChangeSessionTypes: Event<void> = Event.None;
+
+	private readonly _onDidChangeSessions = this._register(new Emitter<ISessionChangeEvent>());
+	readonly onDidChangeSessions: Event<ISessionChangeEvent> = this._onDidChangeSessions.event;
+
+	/** Cache of sessions, keyed by resource URI string. */
+	private readonly _sessionCache = new Map<string, LocalSession>();
+
+	private readonly _currentNewSession = this._register(new MutableDisposable<LocalSession>());
+
+	constructor(
+		@IChatService private readonly chatService: IChatService,
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
+		@ILanguageModelsService private readonly languageModelsService: ILanguageModelsService,
+		@ILanguageModelToolsService private readonly toolsService: ILanguageModelToolsService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@ILabelService private readonly labelService: ILabelService,
+		@ILogService private readonly logService: ILogService,
+		@IStorageService private readonly storageService: IStorageService,
+	) {
+		super();
+
+		// Track requests on our sessions to update last message date,
+		// title, and persisted metadata when the chat widget sends
+		// subsequent messages directly (not via our sendRequest).
+		this._register(this.chatService.onDidSubmitRequest(e => {
+			const session = this._sessionCache.get(e.chatSessionResource.toString());
+			if (session) {
+				this._syncSessionFromModel(session);
+			}
+		}));
+
+		// One-time migration: import existing local chat history into our storage
+		this._migrateFromHistory().finally(() => {
+			// Load persisted local sessions on initialization
+			this._loadPersistedSessions();
+		});
+	}
+
+	/**
+	 * One-time migration that imports existing local chat sessions from
+	 * {@link IChatService.getLocalSessionHistory} into our own persisted
+	 * storage. Only sessions with a working directory are migrated, since
+	 * a working directory is mandatory for {@link LocalSession}. Sessions
+	 * that are already in our storage are skipped.
+	 */
+	private async _migrateFromHistory(): Promise<void> {
+		if (this.storageService.getBoolean(STORAGE_KEY_MIGRATED, StorageScope.PROFILE, false)) {
+			return;
+		}
+
+		try {
+			const history = await this.chatService.getLocalSessionHistory();
+			const sessions = this._readStoredSessions();
+			const existingKeys = new Set(sessions.map(s => URI.revive(s.uri).toString()));
+			let changed = false;
+
+			for (const detail of history) {
+				if (!detail.workingDirectory) {
+					continue;
+				}
+				const key = detail.sessionResource.toString();
+				if (existingKeys.has(key)) {
+					continue;
+				}
+				const timing = convertLegacyChatSessionTiming(detail.timing);
+				const lastUpdate = detail.lastMessageDate || timing.lastRequestEnded || timing.lastRequestStarted || timing.created;
+				sessions.push({
+					uri: detail.sessionResource.toJSON(),
+					title: detail.title,
+					createdAt: timing.created,
+					lastMessageDate: lastUpdate,
+					workingDirectory: detail.workingDirectory.toJSON(),
+				});
+				changed = true;
+			}
+
+			if (changed) {
+				this._writeStoredSessions(sessions);
+			}
+			this.storageService.store(STORAGE_KEY_MIGRATED, true, StorageScope.PROFILE, StorageTarget.MACHINE);
+		} catch (e) {
+			this.logService.error('[LocalChatSessionsProvider] Failed to migrate local chat history', e);
+			// Do not mark migration complete on failure so it can be retried next time.
+		}
+	}
+
+	/**
+	 * Reads current title/timing from the live chat model, updates the
+	 * cached session, persists changes, and sets up reactive tracking
+	 * so subsequent status changes propagate automatically.
+	 */
+	private _syncSessionFromModel(session: LocalSession): void {
+		const model = this.chatService.getSession(session.resource);
+		if (!model) {
+			return;
+		}
+		session.trackModel(model, () => {
+			const timing = model.timing;
+			const lastUpdate = timing.lastRequestEnded ?? timing.lastRequestStarted ?? timing.created;
+			session.setTitle(model.title);
+			session.setUpdatedAt(new Date(lastUpdate));
+			this._updateStoredSession(session);
+			this._onDidChangeSessions.fire({ added: [], removed: [], changed: [this._toISession(session)] });
+		});
+	}
+
+	// -- Session types --
+
+	getSessionTypes(_workspaceUri: URI): ISessionType[] {
+		return [LocalSessionType];
+	}
+
+	// -- Sessions --
+
+	getSessions(): ISession[] {
+		return Array.from(this._sessionCache.values()).map(session => this._toISession(session));
+	}
+
+	/**
+	 * Loads sessions from our own persisted storage. No calls to
+	 * {@link IChatService} are needed — all metadata is stored inline.
+	 */
+	private _loadPersistedSessions(): void {
+		const storedSessions = this._readStoredSessions();
+		if (storedSessions.length === 0) {
+			return;
+		}
+
+		const added: ISession[] = [];
+
+		for (const stored of storedSessions) {
+			const uri = URI.revive(stored.uri);
+			const key = uri.toString();
+			if (this._sessionCache.has(key)) {
+				continue;
+			}
+
+			const workingDirectory = URI.revive(stored.workingDirectory);
+			const detail: IChatDetail = {
+				sessionResource: uri,
+				title: stored.title,
+				lastMessageDate: stored.lastMessageDate,
+				timing: { created: stored.createdAt, lastRequestStarted: undefined, lastRequestEnded: stored.lastMessageDate },
+				isActive: false,
+				lastResponseState: 0 /* ResponseModelState.Complete */,
+				workingDirectory,
+			};
+
+			const workspace = this.resolveWorkspace(workingDirectory);
+			const session = LocalSession.fromHistory(detail, this.id, workspace, this.instantiationService);
+			if (stored.archived) {
+				session.setArchived(true);
+			}
+			this._sessionCache.set(key, session);
+			added.push(this._toISession(session));
+		}
+
+		if (added.length > 0) {
+			this._onDidChangeSessions.fire({ added, removed: [], changed: [] });
+		}
+	}
+
+	// -- Storage helpers --
+
+	private _readStoredSessions(): IStoredLocalSession[] {
+		const raw = this.storageService.get(STORAGE_KEY_SESSIONS, StorageScope.PROFILE);
+		if (!raw) {
+			return [];
+		}
+		try {
+			const parsed = JSON.parse(raw);
+			return Array.isArray(parsed) ? parsed : [];
+		} catch {
+			return [];
+		}
+	}
+
+	private _addStoredSession(session: LocalSession): void {
+		const sessions = this._readStoredSessions();
+		const key = session.resource.toString();
+		if (sessions.some(s => URI.revive(s.uri).toString() === key)) {
+			return;
+		}
+		const workingDirectory = session.workspace.get()?.folders[0]?.root;
+		if (!workingDirectory) {
+			this.logService.warn(`[LocalChatSessionsProvider] Cannot persist session ${key} — no working directory`);
+			return;
+		}
+		sessions.push({
+			uri: session.resource.toJSON(),
+			title: session.title.get(),
+			createdAt: session.createdAt.getTime(),
+			lastMessageDate: session.updatedAt.get().getTime(),
+			workingDirectory: workingDirectory.toJSON(),
+		});
+		this._writeStoredSessions(sessions);
+	}
+
+	private _updateStoredSession(session: LocalSession): void {
+		const sessions = this._readStoredSessions();
+		const key = session.resource.toString();
+		const idx = sessions.findIndex(s => URI.revive(s.uri).toString() === key);
+		if (idx >= 0) {
+			sessions[idx] = {
+				...sessions[idx],
+				title: session.title.get(),
+				lastMessageDate: session.updatedAt.get().getTime(),
+				archived: session.isArchived.get(),
+			};
+			this._writeStoredSessions(sessions);
+		}
+	}
+
+	private _removeStoredSession(resource: URI): void {
+		const sessions = this._readStoredSessions();
+		const key = resource.toString();
+		const filtered = sessions.filter(s => URI.revive(s.uri).toString() !== key);
+		if (filtered.length !== sessions.length) {
+			this._writeStoredSessions(filtered);
+		}
+	}
+
+	private _writeStoredSessions(sessions: IStoredLocalSession[]): void {
+		this.storageService.store(
+			STORAGE_KEY_SESSIONS,
+			JSON.stringify(sessions),
+			StorageScope.PROFILE,
+			StorageTarget.MACHINE,
+		);
+	}
+
+	// -- Workspace --
+
+	resolveWorkspace(uri: URI): ISessionWorkspace | undefined {
+		if (uri.scheme !== Schemas.file) {
+			return undefined;
+		}
+		const folder: ISessionFolder = {
+			root: uri,
+			workingDirectory: uri,
+			name: basename(uri),
+			description: undefined,
+			gitRepository: undefined,
+		};
+		return {
+			uri,
+			label: basename(uri),
+			description: this.labelService.getUriLabel(dirname(uri), { relative: false }),
+			group: SESSION_WORKSPACE_GROUP_LOCAL,
+			icon: Codicon.folder,
+			folders: [folder],
+			requiresWorkspaceTrust: true,
+			isVirtualWorkspace: false,
+		};
+	}
+
+	// -- Session Lifecycle --
+
+	createNewSession(workspaceUri: URI, sessionTypeId: string): ISession {
+		if (sessionTypeId !== LocalSessionType.id) {
+			throw new Error(`Unsupported session type '${sessionTypeId}' for local provider`);
+		}
+
+		const workspace = this.resolveWorkspace(workspaceUri);
+		if (!workspace) {
+			throw new Error(`Cannot resolve workspace for URI: ${workspaceUri.toString()}`);
+		}
+
+		const session = this.instantiationService.createInstance(LocalSession, undefined, workspace, this.id);
+		session.setPermissionLevel(this._defaultPermissionLevel());
+		this._currentNewSession.value = session;
+		return this._toISession(session);
+	}
+
+	setModel(sessionId: string, modelId: string): void {
+		if (this._currentNewSession.value?.sessionId === sessionId) {
+			this._currentNewSession.value.setModelId(modelId);
+		}
+	}
+
+	// -- Session Actions --
+
+	async archiveSession(sessionId: string): Promise<void> {
+		const session = this._findSession(sessionId);
+		if (session) {
+			session.setArchived(true);
+			this._updateStoredSession(session);
+			this._onDidChangeSessions.fire({ added: [], removed: [], changed: [this._toISession(session)] });
+		}
+	}
+
+	async unarchiveSession(sessionId: string): Promise<void> {
+		const session = this._findSession(sessionId);
+		if (session) {
+			session.setArchived(false);
+			this._updateStoredSession(session);
+			this._onDidChangeSessions.fire({ added: [], removed: [], changed: [this._toISession(session)] });
+		}
+	}
+
+	async deleteSession(sessionId: string): Promise<void> {
+		const session = this._findSession(sessionId);
+		if (!session) {
+			return;
+		}
+
+		await this.chatService.removeHistoryEntry(session.resource);
+		this._sessionCache.delete(session.resource.toString());
+		this._removeStoredSession(session.resource);
+		if (this._currentNewSession.value?.sessionId === sessionId) {
+			this._currentNewSession.clear();
+		}
+		this._onDidChangeSessions.fire({ added: [], removed: [this._toISession(session)], changed: [] });
+		session.dispose();
+	}
+
+	async deleteChat(sessionId: string, _chatUri: URI): Promise<void> {
+		// Local sessions have a single chat — deleting the chat deletes the session
+		return this.deleteSession(sessionId);
+	}
+
+	async renameChat(_sessionId: string, chatUri: URI, title: string): Promise<void> {
+		this.chatService.setSessionTitle(chatUri, title);
+		const session = this._findSessionByResource(chatUri);
+		if (session) {
+			session.setTitle(title);
+			this._updateStoredSession(session);
+			this._onDidChangeSessions.fire({ added: [], removed: [], changed: [this._toISession(session)] });
+		}
+	}
+
+	async createNewChat(sessionId: string, _prompt?: string): Promise<IChat> {
+		if (this._currentNewSession.value?.sessionId === sessionId) {
+			const session = this._currentNewSession.value;
+			const chat = buildChat(session);
+			session.mainChat.set(chat, undefined);
+			return chat;
+		}
+		throw new Error(`Session '${sessionId}' not found or is not the current new session`);
+	}
+
+	// -- Send Request --
+
+	async sendRequest(sessionId: string, chatResource: URI, options: ISendRequestOptions): Promise<ISession> {
+		const newSession = this._currentNewSession.value;
+		if (!newSession || newSession.sessionId !== sessionId) {
+			throw new Error(`Session '${sessionId}' not found`);
+		}
+		if (chatResource.toString() !== newSession.resource.toString()) {
+			throw new Error(`Chat resource ${chatResource.toString()} does not match session resource ${newSession.resource.toString()}`);
+		}
+
+		const { query, attachedContext } = options;
+
+		newSession.setTitle(query.split('\n')[0].substring(0, 100) || localize('newSession', "New Session"));
+		newSession.setStatus(SessionStatus.InProgress);
+
+		const newISession = this._toISession(newSession);
+		this._onDidChangeSessions.fire({ added: [newISession], removed: [], changed: [] });
+
+		// Resolve mode
+		const modeKind = newSession.chatMode?.kind ?? ChatModeKind.Agent;
+		const modeIsBuiltin = newSession.chatMode ? isBuiltinChatMode(newSession.chatMode) : true;
+		const modeId: 'ask' | 'agent' | 'edit' | 'custom' | undefined = modeIsBuiltin ? modeKind : 'custom';
+
+		const rawModeInstructions = newSession.chatMode?.modeInstructions?.get();
+		const modeInstructions = rawModeInstructions ? {
+			name: newSession.chatMode!.name.get(),
+			content: rawModeInstructions.content,
+			toolReferences: this.toolsService.toToolReferences(rawModeInstructions.toolReferences),
+			metadata: rawModeInstructions.metadata,
+		} : undefined;
+
+		const permissionLevel = newSession.permissionLevel.get();
+
+		const sendOptions: IChatSendRequestOptions = {
+			location: ChatAgentLocation.Chat,
+			userSelectedModelId: newSession.selectedModelId,
+			modeInfo: {
+				kind: modeKind,
+				isBuiltin: modeIsBuiltin,
+				modeInstructions,
+				modeId,
+				applyCodeBlockSuggestionId: undefined,
+				permissionLevel,
+			},
+			attachedContext,
+		};
+
+		// Set model/mode/permission state on the chat model before sending
+		const modelRef = await this._updateChatSessionState(chatResource, newSession);
+		this.logService.debug(`[LocalChatSessionsProvider] Sending request for session ${newSession.sessionId}`);
+
+		try {
+			const result = await this.chatService.sendRequest(chatResource, query, sendOptions);
+			if (result.kind === 'rejected') {
+				this._currentNewSession.clearAndLeak();
+				this._onDidChangeSessions.fire({ added: [], removed: [newISession], changed: [] });
+				newSession.dispose();
+				throw new Error(`[LocalChatSessionsProvider] sendRequest rejected: ${result.reason}`);
+			}
+
+			// Put the new session into the cache and persist its URI.
+			this._sessionCache.set(newSession.resource.toString(), newSession);
+			this._addStoredSession(newSession);
+			this._currentNewSession.clearAndLeak();
+
+			// Track response completion to update session status and persist title
+			if (result.kind === 'sent') {
+				result.data.responseCompletePromise.then(() => {
+					newSession.setStatus(SessionStatus.Completed);
+					this._syncSessionFromModel(newSession);
+				}, error => {
+					// Response failed — still mark session completed so it doesn't appear stuck.
+					this.logService.error(`[LocalChatSessionsProvider] Response failed for session ${newSession.sessionId}:`, error);
+					newSession.setStatus(SessionStatus.Completed);
+					this._updateStoredSession(newSession);
+					this._onDidChangeSessions.fire({ added: [], removed: [], changed: [newISession] });
+				});
+			}
+
+			this._onDidChangeSessions.fire({ added: [], removed: [], changed: [newISession] });
+			return newISession;
+		} catch (error) {
+			this.logService.error(`[LocalChatSessionsProvider] Failed to send request for session ${newSession.sessionId}:`, error);
+			throw error;
+		} finally {
+			modelRef?.dispose();
+		}
+	}
+
+	// -- Private helpers --
+
+	override dispose(): void {
+		for (const session of this._sessionCache.values()) {
+			session.dispose();
+		}
+		this._sessionCache.clear();
+		super.dispose();
+	}
+
+	/**
+	 * Resolves the initial permission level for a brand-new session from
+	 * `chat.permissions.default`, clamped to `Default` when enterprise policy
+	 * disables global auto-approval.
+	 */
+	private _defaultPermissionLevel(): ChatPermissionLevel {
+		const policyRestricted = this.configurationService.inspect<boolean>(ChatConfiguration.GlobalAutoApprove).policyValue === false;
+		if (policyRestricted) {
+			return ChatPermissionLevel.Default;
+		}
+		const level = this.configurationService.getValue<string>(ChatConfiguration.DefaultPermissionLevel);
+		return isChatPermissionLevel(level) ? level : ChatPermissionLevel.Default;
+	}
+
+	/**
+	 * Updates the chat model state (model, mode, permission level) before sending.
+	 */
+	private async _updateChatSessionState(resource: URI, session: LocalSession): Promise<{ dispose(): void } | undefined> {
+		const modelRef = await this.chatService.acquireOrLoadSession(resource, ChatAgentLocation.Chat, CancellationToken.None);
+		if (!modelRef) {
+			return undefined;
+		}
+		const model = modelRef.object;
+		if (session.selectedModelId) {
+			const languageModel = this.languageModelsService.lookupLanguageModel(session.selectedModelId);
+			if (languageModel) {
+				model.inputModel.setState({ selectedModel: { identifier: session.selectedModelId, metadata: languageModel } });
+			}
+		}
+		if (session.chatMode) {
+			model.inputModel.setState({ mode: { id: session.chatMode.id, kind: session.chatMode.kind } });
+		}
+		const permissionLevel = session.permissionLevel.get();
+		if (permissionLevel) {
+			model.inputModel.setState({ permissionLevel });
+		}
+		return modelRef;
+	}
+
+	private _findSession(sessionId: string): LocalSession | undefined {
+		if (this._currentNewSession.value?.sessionId === sessionId) {
+			return this._currentNewSession.value;
+		}
+		for (const session of this._sessionCache.values()) {
+			if (session.sessionId === sessionId) {
+				return session;
+			}
+		}
+		return undefined;
+	}
+
+	private _findSessionByResource(resource: URI): LocalSession | undefined {
+		const cached = this._sessionCache.get(resource.toString());
+		if (cached) {
+			return cached;
+		}
+		if (this._currentNewSession.value?.resource.toString() === resource.toString()) {
+			return this._currentNewSession.value;
+		}
+		return undefined;
+	}
+
+	private _toISession(session: LocalSession): ISession {
+		const mainChat = session.mainChat;
+		const chatsObs = mainChat.map(c => [c] as readonly IChat[]);
+		const changesets = createChangesets(session.sessionType, session.workspace, chatsObs, this.instantiationService);
+
+		return {
+			sessionId: session.sessionId,
+			resource: session.resource,
+			providerId: session.providerId,
+			sessionType: session.sessionType,
+			icon: session.icon,
+			createdAt: session.createdAt,
+			workspace: session.workspace,
+			title: session.title,
+			updatedAt: session.updatedAt,
+			status: session.status,
+			changesets,
+			changes: session.changes,
+			modelId: session.modelId,
+			mode: session.mode,
+			loading: session.loading,
+			isArchived: session.isArchived,
+			isRead: session.isRead,
+			description: session.description,
+			lastTurnEnd: session.lastTurnEnd,
+			chats: chatsObs,
+			mainChat,
+			capabilities: {
+				supportsMultipleChats: false,
+			},
+		};
+	}
+}

--- a/src/vs/sessions/contrib/providers/localChatSessions/test/browser/localChatSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/localChatSessions/test/browser/localChatSessionsProvider.test.ts
@@ -1,0 +1,272 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Emitter, Event } from '../../../../../../base/common/event.js';
+import { Disposable, DisposableStore } from '../../../../../../base/common/lifecycle.js';
+import { IObservable, observableValue } from '../../../../../../base/common/observable.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { mock } from '../../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
+import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ILabelService } from '../../../../../../platform/label/common/label.js';
+import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
+import { IStorageService } from '../../../../../../platform/storage/common/storage.js';
+import { TestStorageService } from '../../../../../../workbench/test/common/workbenchTestServices.js';
+import { ChatAgentLocation } from '../../../../../../workbench/contrib/chat/common/constants.js';
+import { IChatModel } from '../../../../../../workbench/contrib/chat/common/model/chatModel.js';
+import { IChatModelReference, IChatService, IChatSessionStartOptions, IChatSessionTiming } from '../../../../../../workbench/contrib/chat/common/chatService/chatService.js';
+import { ILanguageModelsService } from '../../../../../../workbench/contrib/chat/common/languageModels.js';
+import { ILanguageModelToolsService } from '../../../../../../workbench/contrib/chat/common/tools/languageModelToolsService.js';
+import { IGitService } from '../../../../../../workbench/contrib/git/common/gitService.js';
+import { IFileService } from '../../../../../../platform/files/common/files.js';
+import { ISession, SessionStatus } from '../../../../../services/sessions/common/session.js';
+import { LocalChatSessionsProvider, LocalSessionType, LOCAL_SESSION_ENABLED_SETTING } from '../../browser/localChatSessionsProvider.js';
+
+// ---- Mock chat service ----------------------------------------------------
+
+function createMockModel(sessionResource: URI, opts?: { title?: string; requestInProgress?: IObservable<boolean>; timing?: IChatSessionTiming }): IChatModel {
+	let workingDirectory: URI | undefined;
+	const requestInProgress = opts?.requestInProgress ?? observableValue<boolean>('requestInProgress', false);
+	const timing: IChatSessionTiming = opts?.timing ?? { created: 1_000, lastRequestStarted: undefined, lastRequestEnded: undefined };
+	return new class extends mock<IChatModel>() {
+		override readonly sessionResource = sessionResource;
+		override readonly title = opts?.title ?? 'Test Session';
+		override readonly timing = timing;
+		override readonly requestInProgress = requestInProgress;
+		override get workingDirectory() { return workingDirectory; }
+		override setWorkingDirectory(uri: URI | undefined): void { workingDirectory = uri; }
+	}();
+}
+
+class MockChatService extends Disposable {
+	private readonly _models = new Map<string, IChatModel>();
+	private _counter = 0;
+
+	readonly sendRequestCalls: { resource: URI; query: string }[] = [];
+
+	private readonly _onDidDisposeSession = this._register(new Emitter<{ readonly sessionResources: readonly URI[]; readonly reason: 'cleared' }>());
+	readonly onDidDisposeSession = this._onDidDisposeSession.event;
+
+	private readonly _onDidSubmitRequest = this._register(new Emitter<{ readonly chatSessionResource: URI }>());
+	readonly onDidSubmitRequest = this._onDidSubmitRequest.event;
+
+	startNewLocalSession(_location: ChatAgentLocation, _options?: IChatSessionStartOptions): IChatModelReference {
+		const resource = URI.parse(`vscode-local-chat://chat/${++this._counter}`);
+		const model = createMockModel(resource);
+		this._models.set(resource.toString(), model);
+		return { object: model, dispose: () => { } };
+	}
+
+	getSession(resource: URI): IChatModel | undefined {
+		return this._models.get(resource.toString());
+	}
+
+	registerModel(model: IChatModel): void {
+		this._models.set(model.sessionResource.toString(), model);
+	}
+
+	async acquireOrLoadSession(): Promise<IChatModelReference | undefined> {
+		return undefined;
+	}
+
+	async sendRequest(resource: URI, query: string) {
+		this.sendRequestCalls.push({ resource, query });
+		return { kind: 'sent', data: { responseCompletePromise: Promise.resolve(), responseCreatedPromise: Promise.resolve({}) } };
+	}
+
+	async getLocalSessionHistory() { return []; }
+	async removeHistoryEntry(_resource: URI): Promise<void> { }
+	setSessionTitle(_resource: URI, _title: string): void { }
+
+	fireSubmitRequest(resource: URI): void {
+		this._onDidSubmitRequest.fire({ chatSessionResource: resource });
+	}
+}
+
+// ---- Test fixture ----------------------------------------------------------
+
+interface ITestFixture {
+	instantiationService: TestInstantiationService;
+	chatService: MockChatService;
+	storage: TestStorageService;
+	config: TestConfigurationService;
+}
+
+function createFixture(store: DisposableStore): ITestFixture {
+	const instantiationService = store.add(new TestInstantiationService());
+	const chatService = store.add(new MockChatService());
+	const storage = store.add(new TestStorageService());
+	const config = new TestConfigurationService();
+	config.setUserConfiguration(LOCAL_SESSION_ENABLED_SETTING, true);
+
+	instantiationService.stub(IChatService, chatService as unknown as IChatService);
+	instantiationService.stub(IStorageService, storage);
+	instantiationService.stub(IConfigurationService, config);
+	instantiationService.stub(ILogService, new NullLogService());
+	instantiationService.stub(ILabelService, new class extends mock<ILabelService>() {
+		override getUriLabel(uri: URI): string { return uri.fsPath; }
+	}());
+	instantiationService.stub(ILanguageModelsService, new class extends mock<ILanguageModelsService>() { }());
+	instantiationService.stub(ILanguageModelToolsService, new class extends mock<ILanguageModelToolsService>() { }());
+	instantiationService.stub(IGitService, new class extends mock<IGitService>() {
+		override async openRepository() { return undefined; }
+	}());
+	instantiationService.stub(IFileService, new class extends mock<IFileService>() { }());
+	instantiationService.stub(IInstantiationService, instantiationService);
+	return { instantiationService, chatService, storage, config };
+}
+
+const TEST_FOLDER = URI.file('/test/folder');
+
+async function commitNewSession(provider: LocalChatSessionsProvider): Promise<ISession> {
+	const newSession = provider.createNewSession(TEST_FOLDER, LocalSessionType.id);
+	const chat = await provider.createNewChat(newSession.sessionId);
+	await provider.sendRequest(newSession.sessionId, chat.resource, { query: 'hello' });
+	return newSession;
+}
+
+// ---- Suite ----------------------------------------------------------------
+
+suite('LocalChatSessionsProvider', () => {
+	const leaks = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('declares Local session type', () => {
+		const store = leaks.add(new DisposableStore());
+		const { instantiationService } = createFixture(store);
+
+		const provider = store.add(instantiationService.createInstance(LocalChatSessionsProvider));
+		assert.deepStrictEqual(provider.sessionTypes.map(t => t.id), [LocalSessionType.id]);
+	});
+
+	test('resolveWorkspace handles only file uris', () => {
+		const store = leaks.add(new DisposableStore());
+		const { instantiationService } = createFixture(store);
+		const provider = store.add(instantiationService.createInstance(LocalChatSessionsProvider));
+
+		assert.strictEqual(provider.resolveWorkspace(URI.parse('http://example.com')), undefined);
+
+		const ws = provider.resolveWorkspace(TEST_FOLDER);
+		assert.ok(ws);
+		assert.strictEqual(ws!.folders[0].root.toString(), TEST_FOLDER.toString());
+	});
+
+	test('createNewSession returns a session but does not show in getSessions until first send', async () => {
+		const store = leaks.add(new DisposableStore());
+		const { instantiationService } = createFixture(store);
+		const provider = store.add(instantiationService.createInstance(LocalChatSessionsProvider));
+
+		const newSession = provider.createNewSession(TEST_FOLDER, LocalSessionType.id);
+		assert.strictEqual(newSession.providerId, provider.id);
+		assert.strictEqual(provider.getSessions().length, 0);
+
+		const chat = await provider.createNewChat(newSession.sessionId);
+		await provider.sendRequest(newSession.sessionId, chat.resource, { query: 'hi' });
+		assert.strictEqual(provider.getSessions().length, 1);
+	});
+
+	test('createNewSession rejects unknown session types', () => {
+		const store = leaks.add(new DisposableStore());
+		const { instantiationService } = createFixture(store);
+		const provider = store.add(instantiationService.createInstance(LocalChatSessionsProvider));
+
+		assert.throws(() => provider.createNewSession(TEST_FOLDER, 'bogus'));
+	});
+
+	test('persists committed sessions and restores them on next provider instance', async () => {
+		const store = leaks.add(new DisposableStore());
+		const { instantiationService } = createFixture(store);
+
+		const provider = store.add(instantiationService.createInstance(LocalChatSessionsProvider));
+		const session = await commitNewSession(provider);
+
+		const provider2 = store.add(instantiationService.createInstance(LocalChatSessionsProvider));
+		await Event.toPromise(provider2.onDidChangeSessions);
+		const restored = provider2.getSessions();
+		assert.strictEqual(restored.length, 1);
+		assert.strictEqual(restored[0].resource.toString(), session.resource.toString());
+	});
+
+	test('deleteSession removes session from cache and storage', async () => {
+		const store = leaks.add(new DisposableStore());
+		const { instantiationService } = createFixture(store);
+
+		const provider = store.add(instantiationService.createInstance(LocalChatSessionsProvider));
+		const session = await commitNewSession(provider);
+
+		await provider.deleteSession(session.sessionId);
+		assert.strictEqual(provider.getSessions().length, 0);
+
+		const provider2 = store.add(instantiationService.createInstance(LocalChatSessionsProvider));
+		// Wait one microtask tick for the async migration/load to complete (no event fires when empty)
+		await Promise.resolve();
+		await Promise.resolve();
+		assert.strictEqual(provider2.getSessions().length, 0);
+	});
+
+	test('archiveSession and unarchiveSession toggle isArchived and persist', async () => {
+		const store = leaks.add(new DisposableStore());
+		const { instantiationService } = createFixture(store);
+
+		const provider = store.add(instantiationService.createInstance(LocalChatSessionsProvider));
+		const session = await commitNewSession(provider);
+
+		await provider.archiveSession(session.sessionId);
+		assert.strictEqual(provider.getSessions()[0].isArchived.get(), true);
+
+		await provider.unarchiveSession(session.sessionId);
+		assert.strictEqual(provider.getSessions()[0].isArchived.get(), false);
+
+		await provider.archiveSession(session.sessionId);
+		const provider2 = store.add(instantiationService.createInstance(LocalChatSessionsProvider));
+		await Event.toPromise(provider2.onDidChangeSessions);
+		assert.strictEqual(provider2.getSessions()[0].isArchived.get(), true);
+	});
+
+	test('renameChat updates session title and persists it', async () => {
+		const store = leaks.add(new DisposableStore());
+		const { instantiationService } = createFixture(store);
+
+		const provider = store.add(instantiationService.createInstance(LocalChatSessionsProvider));
+		const session = await commitNewSession(provider);
+
+		await provider.renameChat(session.sessionId, session.resource, 'Custom Title');
+		assert.strictEqual(provider.getSessions()[0].title.get(), 'Custom Title');
+
+		const provider2 = store.add(instantiationService.createInstance(LocalChatSessionsProvider));
+		await Event.toPromise(provider2.onDidChangeSessions);
+		assert.strictEqual(provider2.getSessions()[0].title.get(), 'Custom Title');
+	});
+
+	test('status follows model.requestInProgress after a submit event', async () => {
+		const store = leaks.add(new DisposableStore());
+		const { instantiationService, chatService } = createFixture(store);
+
+		const provider = store.add(instantiationService.createInstance(LocalChatSessionsProvider));
+		const session = await commitNewSession(provider);
+
+		// Replace the registered model with a controllable one for tracking
+		const inProgress = observableValue<boolean>('inProgress', false);
+		chatService.registerModel(createMockModel(session.resource, { requestInProgress: inProgress }));
+
+		chatService.fireSubmitRequest(session.resource);
+		assert.strictEqual(provider.getSessions()[0].status.get(), SessionStatus.Completed);
+
+		inProgress.set(true, undefined);
+		assert.strictEqual(provider.getSessions()[0].status.get(), SessionStatus.InProgress);
+
+		inProgress.set(false, undefined);
+		assert.strictEqual(provider.getSessions()[0].status.get(), SessionStatus.Completed);
+	});
+
+	test('Event.None and exports remain stable', () => {
+		assert.strictEqual(LocalSessionType.id, 'local');
+		assert.strictEqual(LOCAL_SESSION_ENABLED_SETTING, 'sessions.chat.localAgent.enabled');
+		assert.ok(Event.None);
+	});
+});

--- a/src/vs/sessions/sessions.common.main.ts
+++ b/src/vs/sessions/sessions.common.main.ts
@@ -453,6 +453,7 @@ import './contrib/providers/agentHost/browser/exportDebugLogsAction.js';
 import './contrib/providers/agentHost/browser/agentHostSessionConfigPicker.js';
 import './contrib/chat/browser/customizationsDebugLog.contribution.js';
 import './contrib/providers/copilotChatSessions/browser/copilotChatSessions.contribution.js';
+import './contrib/providers/localChatSessions/browser/localChatSessions.contribution.js';
 import './contrib/sessions/browser/sessions.contribution.js';
 import './contrib/sessions/browser/views/sessionsListModelService.js';
 import './services/agentHostFilter/browser/agentHostFilterService.js';


### PR DESCRIPTION
Extract the local harness (in-process VS Code chat sessions) from `CopilotChatSessionsProvider` into a standalone `LocalChatSessionsProvider` under `src/vs/sessions/contrib/providers/localChatSessions/`.

## What changed

- **New `LocalChatSessionsProvider`** (`id: 'local-chat'`) that uses `IChatService` directly — no `IAgentSessionsService` dependency. Creates models via `startNewLocalSession()`, sends via `sendRequest()`, resolves git state via `IGitService`.
- **Single `LocalSession` class** with two construction paths controlled by a `detail: IChatDetail | undefined` parameter (new vs restored from history).
- **Self-managed session list** persisted to `IStorageService` (profile-scoped, machine target) under key `sessions.localChat.sessions`. Each entry stores `uri`, `title`, `createdAt`, `lastMessageDate`, `workingDirectory`, and optional `archived` flag — no runtime dependency on chat history APIs for listing.
- **One-time migration** from `getLocalSessionHistory()` brings forward existing local chat sessions on first run (guarded by `sessions.localChat.migrated` flag).
- **Live status tracking** via `LocalSession.trackModel(model, onChange)` — subscribes to `model.requestInProgress` to flip status between `InProgress` and `Completed`.
- **Session type picker** now hides the provider group label when no two providers offer session types with the same label, reducing visual noise.
- **Pickers** (mode, model, permission) extended via `when` clauses to match local sessions from the new provider, not just the copilot one.
- **Removed local session handling** from `CopilotChatSessionsProvider` (the `LocalNewSession` class, `LocalSessionType`, `LOCAL_SESSION_ENABLED_SETTING`, and associated branches in `createNewSession`, `createNewChat`, `_sendFirstChat`, `_refreshSessionCache`, etc).
- **Unit tests** — 10 tests covering session type declaration/hiding, workspace resolution, lifecycle, persistence, archive/unarchive, rename, deletion, status tracking from chat model.
- **Spec docs**: new `LOCAL_CHAT_SESSIONS_PROVIDER.md` and updated `SESSIONS.md` providers list.

## Notes for reviewers

- The new provider coexists with `CopilotChatSessionsProvider` and `AgentHost` providers.
- Archiving is purely a UI/metadata concept for local sessions — no underlying chat-service archive mechanism.
- The chat session URI is stable for a local session's entire lifetime, which lets us cache and persist by URI without any commit/swap dance.
- Known limitation: the chat content viewer doesn't always open immediately after reload — being investigated separately.