### PR TITLE
sessions: scope navigation keybindings to non-editor focus

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
@@ -14,6 +14,7 @@ import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextke
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { IQuickInputService, IQuickPickItem, IQuickPickSeparator } from '../../../../platform/quickinput/common/quickInput.js';
+import { EditorContextKeys } from '../../../../editor/common/editorContextKeys.js';
 import { IsAuxiliaryWindowContext, IsSessionsWindowContext } from '../../../../workbench/common/contextkeys.js';
 import { Menus } from '../../../browser/menus.js';
 import { SessionsCategories } from '../../../common/categories.js';
@@ -129,7 +130,7 @@ registerAction2(class GoBackAction extends Action2 {
 				win: { primary: KeyMod.Alt | KeyCode.LeftArrow },
 				mac: { primary: KeyMod.WinCtrl | KeyCode.Minus },
 				linux: { primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.Minus },
-				when: IsSessionsWindowContext,
+				when: ContextKeyExpr.and(IsSessionsWindowContext, EditorContextKeys.editorTextFocus.toNegated()),
 			},
 			menu: [{
 				id: Menus.TitleBarLeftLayout,
@@ -169,7 +170,7 @@ registerAction2(class GoForwardAction extends Action2 {
 				win: { primary: KeyMod.Alt | KeyCode.RightArrow },
 				mac: { primary: KeyMod.WinCtrl | KeyMod.Shift | KeyCode.Minus },
 				linux: { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Minus },
-				when: IsSessionsWindowContext,
+				when: ContextKeyExpr.and(IsSessionsWindowContext, EditorContextKeys.editorTextFocus.toNegated()),
 			},
 			menu: [{
 				id: Menus.TitleBarLeftLayout,


### PR DESCRIPTION
## Summary

Adds `EditorContextKeys.editorTextFocus.toNegated()` to the `when` clause of the **Go Back** and **Go Forward** session navigation keybindings.

## Problem

The session navigation keybindings (e.g., Alt+Left/Right on Windows) conflict with editor text navigation shortcuts when a text editor has focus in the Agents window.

## Solution

The keybindings now require that the editor text is **not** focused, so they work everywhere in the Agents window (sidebar, chat area, etc.) but don't interfere with editor shortcuts like word navigation.