### PR TITLE
sessions: only show provider name for duplicated session types in picker

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/mobile/mobileSessionTypePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/mobile/mobileSessionTypePicker.ts
@@ -64,18 +64,24 @@ export class MobileSessionTypePicker extends SessionTypePicker {
 		// Build sheet items — composite id is `providerId\u0000sessionTypeId`
 		// so we can map back to the right provider on selection. Use the
 		// provider's label as a section title on the first item of each
-		// group so the sheet visually separates providers.
+		// group so the sheet visually separates providers, but only when
+		// the session type label is duplicated across providers.
+		const labelCounts = new Map<string, number>();
+		for (const { sessionType } of this._folderSessionTypes) {
+			labelCounts.set(sessionType.label, (labelCounts.get(sessionType.label) ?? 0) + 1);
+		}
 		const sheetItems: IMobilePickerSheetItem[] = [];
 		let lastProviderId: string | undefined;
 		for (const { providerId, sessionType } of this._folderSessionTypes) {
 			const isFirstInGroup = providerId !== lastProviderId;
 			lastProviderId = providerId;
+			const isLabelDuplicated = (labelCounts.get(sessionType.label) ?? 0) > 1;
 			sheetItems.push({
 				id: `${providerId}\u0000${sessionType.id}`,
 				label: sessionType.label,
 				icon: sessionType.icon,
 				checked: providerId === this._picked?.providerId && sessionType.id === this._picked?.sessionTypeId,
-				sectionTitle: isFirstInGroup ? (this._sessionsProvidersService.getProvider(providerId)?.label ?? providerId) : undefined,
+				sectionTitle: isLabelDuplicated && isFirstInGroup ? (this._sessionsProvidersService.getProvider(providerId)?.label ?? providerId) : undefined,
 			});
 		}
 

--- a/src/vs/sessions/contrib/chat/browser/mobile/mobileSessionTypePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/mobile/mobileSessionTypePicker.ts
@@ -62,26 +62,30 @@ export class MobileSessionTypePicker extends SessionTypePicker {
 		}
 
 		// Build sheet items — composite id is `providerId\u0000sessionTypeId`
-		// so we can map back to the right provider on selection. Use the
-		// provider's label as a section title on the first item of each
-		// group so the sheet visually separates providers, but only when
-		// the session type label is duplicated across providers.
+		// so we can map back to the right provider on selection. Show the
+		// provider's label as a section title only for provider groups
+		// that contain at least one duplicated session type label.
 		const labelCounts = new Map<string, number>();
 		for (const { sessionType } of this._folderSessionTypes) {
 			labelCounts.set(sessionType.label, (labelCounts.get(sessionType.label) ?? 0) + 1);
+		}
+		const providersWithDuplicates = new Set<string>();
+		for (const { providerId, sessionType } of this._folderSessionTypes) {
+			if ((labelCounts.get(sessionType.label) ?? 0) > 1) {
+				providersWithDuplicates.add(providerId);
+			}
 		}
 		const sheetItems: IMobilePickerSheetItem[] = [];
 		let lastProviderId: string | undefined;
 		for (const { providerId, sessionType } of this._folderSessionTypes) {
 			const isFirstInGroup = providerId !== lastProviderId;
 			lastProviderId = providerId;
-			const isLabelDuplicated = (labelCounts.get(sessionType.label) ?? 0) > 1;
 			sheetItems.push({
 				id: `${providerId}\u0000${sessionType.id}`,
 				label: sessionType.label,
 				icon: sessionType.icon,
 				checked: providerId === this._picked?.providerId && sessionType.id === this._picked?.sessionTypeId,
-				sectionTitle: isLabelDuplicated && isFirstInGroup ? (this._sessionsProvidersService.getProvider(providerId)?.label ?? providerId) : undefined,
+				sectionTitle: providersWithDuplicates.has(providerId) && isFirstInGroup ? (this._sessionsProvidersService.getProvider(providerId)?.label ?? providerId) : undefined,
 			});
 		}
 

--- a/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
@@ -205,18 +205,17 @@ export class SessionTypePicker extends Disposable {
 			const provider = providersService.getProvider(providerId);
 			const groupTitle = provider?.label ?? providerId;
 			const isFirstInGroup = providerId !== lastProviderId;
-			if (hasDuplicateLabels && isFirstInGroup && lastProviderId !== undefined) {
-				groupedItems.push({ kind: ActionListItemKind.Separator, label: '' });
-			}
+
 			lastProviderId = providerId;
 			const isCurrent = this._picked?.providerId === providerId && this._picked?.sessionTypeId === sessionType.id;
 			const item: ISessionTypePickerItem = isCurrent
 				? { providerId, sessionTypeId: sessionType.id, label: sessionType.label, checked: true }
 				: { providerId, sessionTypeId: sessionType.id, label: sessionType.label };
+			const isLabelDuplicated = (labelCounts.get(sessionType.label) ?? 0) > 1;
 			groupedItems.push({
 				kind: ActionListItemKind.Action,
 				label: sessionType.label,
-				group: hasDuplicateLabels ? {
+				group: isLabelDuplicated ? {
 					title: isFirstInGroup ? groupTitle : '',
 					icon: sessionType.icon,
 				} : {

--- a/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
@@ -186,18 +186,20 @@ export class SessionTypePicker extends Disposable {
 			return;
 		}
 
-		// Determine whether any session type label is duplicated across
-		// providers. When all labels are unique the provider header is
-		// redundant — skip it for a cleaner dropdown.
+		// Determine which providers contain at least one duplicated label.
+		// Only those providers need a group title for disambiguation.
 		const labelCounts = new Map<string, number>();
 		for (const { sessionType } of folderTypes) {
 			labelCounts.set(sessionType.label, (labelCounts.get(sessionType.label) ?? 0) + 1);
 		}
-		const hasDuplicateLabels = Array.from(labelCounts.values()).some(c => c > 1);
+		const providersWithDuplicates = new Set<string>();
+		for (const { providerId, sessionType } of folderTypes) {
+			if ((labelCounts.get(sessionType.label) ?? 0) > 1) {
+				providersWithDuplicates.add(providerId);
+			}
+		}
+		const hasDuplicateLabels = providersWithDuplicates.size > 0;
 
-		// Group items by provider so the dropdown shows a provider header
-		// followed by that provider's types. Insert a separator between
-		// adjacent providers' types so the grouping is visually clear.
 		const providersService = this.sessionsProvidersService;
 		const groupedItems: IActionListItem<ISessionTypePickerItem>[] = [];
 		let lastProviderId: string | undefined;
@@ -205,17 +207,15 @@ export class SessionTypePicker extends Disposable {
 			const provider = providersService.getProvider(providerId);
 			const groupTitle = provider?.label ?? providerId;
 			const isFirstInGroup = providerId !== lastProviderId;
-
 			lastProviderId = providerId;
 			const isCurrent = this._picked?.providerId === providerId && this._picked?.sessionTypeId === sessionType.id;
 			const item: ISessionTypePickerItem = isCurrent
 				? { providerId, sessionTypeId: sessionType.id, label: sessionType.label, checked: true }
 				: { providerId, sessionTypeId: sessionType.id, label: sessionType.label };
-			const isLabelDuplicated = (labelCounts.get(sessionType.label) ?? 0) > 1;
 			groupedItems.push({
 				kind: ActionListItemKind.Action,
 				label: sessionType.label,
-				group: isLabelDuplicated ? {
+				group: providersWithDuplicates.has(providerId) ? {
 					title: isFirstInGroup ? groupTitle : '',
 					icon: sessionType.icon,
 				} : {


### PR DESCRIPTION
The session type picker was showing the provider name (description) for all session types whenever any label was duplicated across providers. For example, "Local" showed "Local Chat" even though "Local" is a unique name — only "Copilot CLI" is duplicated.

### Changes
- **Desktop picker** (`sessionTypePicker.ts`): Changed from a global `hasDuplicateLabels` flag to a per-item `isLabelDuplicated` check, so the provider name only appears next to items whose label actually occurs in multiple providers. Also removed separators between provider groups.
- **Mobile picker** (`mobileSessionTypePicker.ts`): Same per-item check — section titles only show for groups containing items with duplicated labels.