### PR TITLE
Mark Publish Node Modules outputs as production

### DIFF
--- a/build/azure-pipelines/darwin/product-build-darwin-ci.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin-ci.yml
@@ -25,7 +25,7 @@ jobs:
           artifactName: node-modules-macos-$(VSCODE_ARCH)-${{ lower(parameters.VSCODE_TEST_SUITE) }}-$(System.JobAttempt)
           displayName: Publish Node Modules
           sbomEnabled: false
-          isProduction: false
+          isProduction: true
           condition: failed()
         - output: pipelineArtifact
           targetPath: $(Build.SourcesDirectory)/.build/logs

--- a/build/azure-pipelines/darwin/product-build-darwin.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin.yml
@@ -36,7 +36,7 @@ jobs:
             artifactName: node-modules-macos-$(VSCODE_ARCH)-$(System.JobAttempt)
             displayName: "Publish Node Modules"
             sbomEnabled: false
-            isProduction: false
+            isProduction: true
             condition: failed()
           - output: pipelineArtifact
             targetPath: $(Build.SourcesDirectory)/.build/logs

--- a/build/azure-pipelines/linux/product-build-linux-ci.yml
+++ b/build/azure-pipelines/linux/product-build-linux-ci.yml
@@ -32,7 +32,7 @@ jobs:
           artifactName: node-modules-linux-$(VSCODE_ARCH)-${{ lower(parameters.VSCODE_TEST_SUITE) }}-$(System.JobAttempt)
           displayName: Publish Node Modules
           sbomEnabled: false
-          isProduction: false
+          isProduction: true
           condition: failed()
         - output: pipelineArtifact
           targetPath: $(Build.SourcesDirectory)/.build/logs

--- a/build/azure-pipelines/linux/product-build-linux.yml
+++ b/build/azure-pipelines/linux/product-build-linux.yml
@@ -52,7 +52,7 @@ jobs:
             artifactName: node-modules-linux-$(VSCODE_ARCH)-$(System.JobAttempt)
             displayName: Publish Node Modules
             sbomEnabled: false
-            isProduction: false
+            isProduction: true
             condition: failed()
           - output: pipelineArtifact
             targetPath: $(Build.SourcesDirectory)/.build/logs

--- a/build/azure-pipelines/win32/product-build-win32-ci.yml
+++ b/build/azure-pipelines/win32/product-build-win32-ci.yml
@@ -27,7 +27,7 @@ jobs:
           artifactName: node-modules-windows-$(VSCODE_ARCH)-${{ lower(parameters.VSCODE_TEST_SUITE) }}-$(System.JobAttempt)
           displayName: Publish Node Modules
           sbomEnabled: false
-          isProduction: false
+          isProduction: true
           condition: failed()
         - output: pipelineArtifact
           targetPath: $(Build.SourcesDirectory)/.build/logs

--- a/build/azure-pipelines/win32/product-build-win32.yml
+++ b/build/azure-pipelines/win32/product-build-win32.yml
@@ -38,7 +38,7 @@ jobs:
             artifactName: node-modules-windows-$(VSCODE_ARCH)-$(System.JobAttempt)
             displayName: Publish Node Modules
             sbomEnabled: false
-            isProduction: false
+            isProduction: true
             condition: failed()
           - output: pipelineArtifact
             targetPath: $(Build.SourcesDirectory)/.build/logs


### PR DESCRIPTION
Mark node_module pipeline artifact as prod to prevent things such as: https://dev.azure.com/monacotools/Monaco/_build/results?buildId=441573&view=logs&j=7c206f6d-993c-583c-875a-239a70ef97fe&t=f282ecbe-c8de-5fd7-4489-ae109dd68c5c 