### PR TITLE
Chat sessions: add legacyResource for one-way URI state migration

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadChatSessions.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatSessions.ts
@@ -605,6 +605,7 @@ class MainThreadChatSessionItem implements IChatSessionItem {
 	readonly changes?: IChatSessionItem['changes'];
 	readonly archived?: boolean;
 	readonly metadata?: { readonly [key: string]: unknown };
+	readonly legacyResource?: URI;
 
 	constructor(dto: Dto<IChatSessionItem>, model: IChatModel | undefined, detailOverrides: IChatDetail | undefined) {
 		this.resource = URI.revive(dto.resource);
@@ -615,6 +616,7 @@ class MainThreadChatSessionItem implements IChatSessionItem {
 		this.tooltip = reviveMarkdownString(dto.tooltip);
 		this.archived = dto.archived;
 		this.metadata = dto.metadata;
+		this.legacyResource = dto.legacyResource ? URI.revive(dto.legacyResource) : undefined;
 
 		this.description = (model && getInProgressSessionDescription(model)) ?? reviveMarkdownString(dto.description);
 		this.status = (model && getSessionStatusForModel(model)) ?? dto.status;
@@ -647,7 +649,8 @@ class MainThreadChatSessionItem implements IChatSessionItem {
 			&& stringOrMarkdownEqual(this.badge, other.badge)
 			&& stringOrMarkdownEqual(this.tooltip, other.tooltip)
 			&& this.archived === other.archived
-			&& equals(this.metadata, other.metadata);
+			&& equals(this.metadata, other.metadata)
+			&& isEqual(this.legacyResource, other.legacyResource);
 	}
 }
 

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -4241,6 +4241,7 @@ export namespace ChatSessionItem {
 			},
 			changes: sessionContent.changes instanceof Array ? sessionContent.changes : undefined,
 			metadata: sessionContent.metadata,
+			legacyResource: sessionContent.legacyResource,
 		};
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsModel.ts
@@ -672,6 +672,7 @@ export class AgentSessionsModel extends Disposable implements IAgentSessionsMode
 					timing: session.timing,
 					changes: normalizedChanges,
 					metadata: session.metadata,
+					legacyResource: session.legacyResource,
 				}));
 			}
 		}
@@ -716,8 +717,37 @@ export class AgentSessionsModel extends Disposable implements IAgentSessionsMode
 
 	private readonly sessionStates: ResourceMap<IAgentSessionState>;
 
+	/**
+	 * Resolve the state entry for a session, honoring a one-way migration from
+	 * {@link IAgentSessionData.legacyResource} when no entry yet exists for the
+	 * session's current resource. Adopts the legacy entry forward (copies it onto
+	 * the current resource key and removes the legacy entry). Returns undefined if
+	 * neither a current nor a legacy entry exists.
+	 */
+	private resolveStateEntry(session: IInternalAgentSessionData): IAgentSessionState | undefined {
+		const own = this.sessionStates.get(session.resource);
+		if (own !== undefined) {
+			return own;
+		}
+		const legacy = session.legacyResource;
+		if (!legacy) {
+			return undefined;
+		}
+		// Cross-scheme and self-referential mappings are rejected defensively.
+		if (legacy.scheme !== session.resource.scheme || legacy.toString() === session.resource.toString()) {
+			return undefined;
+		}
+		const prev = this.sessionStates.get(legacy);
+		if (prev === undefined) {
+			return undefined;
+		}
+		this.sessionStates.set(session.resource, { ...prev });
+		this.sessionStates.delete(legacy);
+		return this.sessionStates.get(session.resource);
+	}
+
 	private isArchived(session: IInternalAgentSessionData): boolean {
-		return this.sessionStates.get(session.resource)?.archived ?? Boolean(session.archived);
+		return this.resolveStateEntry(session)?.archived ?? Boolean(session.archived);
 	}
 
 	private setArchived(session: IInternalAgentSessionData, archived: boolean): void {
@@ -741,7 +771,7 @@ export class AgentSessionsModel extends Disposable implements IAgentSessionsMode
 	}
 
 	private isPinned(session: IInternalAgentSessionData): boolean {
-		return this.sessionStates.get(session.resource)?.pinned ?? false;
+		return this.resolveStateEntry(session)?.pinned ?? false;
 	}
 
 	private setPinned(session: IInternalAgentSessionData, pinned: boolean): void {
@@ -857,6 +887,8 @@ interface ISerializedAgentSession {
 
 	readonly metadata: { [key: string]: unknown } | undefined;
 
+	readonly legacyResource?: string;
+
 	readonly timing: {
 		readonly created: number;
 		readonly lastRequestStarted?: number;
@@ -904,7 +936,8 @@ class AgentSessionsCache {
 			timing: session.timing,
 
 			changes: session.changes,
-			metadata: session.metadata
+			metadata: session.metadata,
+			legacyResource: session.legacyResource?.toString()
 		} satisfies ISerializedAgentSession));
 
 		this.storageService.store(AgentSessionsCache.SESSIONS_STORAGE_KEY, safeStringify(serialized), StorageScope.WORKSPACE, StorageTarget.MACHINE);
@@ -946,6 +979,7 @@ class AgentSessionsCache {
 					deletions: change.deletions,
 				})) : session.changes,
 				metadata: session.metadata,
+				legacyResource: session.legacyResource ? URI.parse(session.legacyResource) : undefined,
 			}));
 		} catch {
 			return []; // invalid data in storage, fallback to empty sessions list

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsModel.ts
@@ -759,7 +759,7 @@ export class AgentSessionsModel extends Disposable implements IAgentSessionsMode
 			return; // no change
 		}
 
-		const state = this.sessionStates.get(session.resource) ?? {};
+		const state = this.resolveStateEntry(session) ?? {};
 		this.sessionStates.set(session.resource, { ...state, archived });
 
 		const agentSession = this._sessions.get(session.resource);
@@ -779,14 +779,14 @@ export class AgentSessionsModel extends Disposable implements IAgentSessionsMode
 			return; // no change
 		}
 
-		const state = this.sessionStates.get(session.resource) ?? {};
+		const state = this.resolveStateEntry(session) ?? {};
 		this.sessionStates.set(session.resource, { ...state, pinned });
 
 		this._onDidChangeSessions.fire();
 	}
 
 	private isMarkedUnread(session: IInternalAgentSessionData): boolean {
-		return this.sessionStates.get(session.resource)?.read === AgentSessionsModel.UNREAD_MARKER;
+		return this.resolveStateEntry(session)?.read === AgentSessionsModel.UNREAD_MARKER;
 	}
 
 	private isRead(session: IInternalAgentSessionData): boolean {
@@ -794,7 +794,7 @@ export class AgentSessionsModel extends Disposable implements IAgentSessionsMode
 			return true; // archived sessions are always read
 		}
 
-		const storedReadDate = this.sessionStates.get(session.resource)?.read;
+		const storedReadDate = this.resolveStateEntry(session)?.read;
 		if (storedReadDate === AgentSessionsModel.UNREAD_MARKER) {
 			return false;
 		}
@@ -818,7 +818,9 @@ export class AgentSessionsModel extends Disposable implements IAgentSessionsMode
 	}
 
 	private setRead(session: IInternalAgentSessionData, read: boolean, skipEvent?: boolean): void {
-		const state = this.sessionStates.get(session.resource) ?? {};
+		// Adopt any legacy state forward first so we don't establish an own entry
+		// under the current resource and orphan the legacy one.
+		const state = this.resolveStateEntry(session) ?? {};
 
 		let newRead: number;
 		if (read) {

--- a/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
@@ -134,6 +134,13 @@ export interface IChatSessionItem {
 	} | readonly IChatSessionFileChange[] | readonly IChatSessionFileChange2[];
 	readonly archived?: boolean;
 	readonly metadata?: IChatSessionItemMetadata;
+	/**
+	 * Resource identifier the item was previously known by. When set, host-stored
+	 * per-resource state (archive, pin, read) recorded under that URI is adopted
+	 * forward onto {@link resource} on first state read, and the legacy entry is
+	 * removed. Scheme must match {@link resource}'s scheme; otherwise ignored.
+	 */
+	readonly legacyResource?: URI;
 }
 
 export interface IChatSessionItemMetadata {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionViewModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionViewModel.test.ts
@@ -1498,6 +1498,32 @@ suite('AgentSessions', () => {
 			});
 		});
 
+		test('migrates unread marker forward (read state, not just archived/pinned)', async () => {
+			return runWithFakedTimers({}, async () => {
+				const { oldUri, newUri } = uris();
+				// Stage 1: mark the old URI explicitly as unread.
+				mockChatSessionsService.registerChatSessionItemController(
+					chatSessionTestType,
+					new StaticChatSessionItemController([makeItem(oldUri)]),
+				);
+				viewModel = disposables.add(instantiationService.createInstance(AgentSessionsModel));
+				await viewModel.resolve(undefined);
+				viewModel.sessions[0].setRead(false);
+				assert.strictEqual(viewModel.sessions[0].isMarkedUnread(), true, 'pre-condition: legacy URI marked unread');
+
+				// Stage 2: provider URI shape changes; expect the unread marker to migrate
+				// forward. This proves resolveStateEntry routing covers ALL per-resource
+				// state (archive, pin, read), not just archived/pinned.
+				mockChatSessionsService.registerChatSessionItemController(
+					chatSessionTestType,
+					new StaticChatSessionItemController([makeItem(newUri, { legacyResource: oldUri })]),
+				);
+				await viewModel.resolve(undefined);
+
+				assert.strictEqual(viewModel.sessions[0].isMarkedUnread(), true);
+			});
+		});
+
 		test('does nothing when no host state exists under legacyResource', async () => {
 			return runWithFakedTimers({}, async () => {
 				const { oldUri, newUri } = uris();

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionViewModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionViewModel.test.ts
@@ -1410,6 +1410,217 @@ suite('AgentSessions', () => {
 		});
 	});
 
+	suite('AgentSessionsViewModel - legacyResource migration', () => {
+		const disposables = new DisposableStore();
+		let mockChatSessionsService: MockChatSessionsService;
+		let instantiationService: TestInstantiationService;
+		let viewModel: AgentSessionsModel;
+
+		setup(() => {
+			mockChatSessionsService = new MockChatSessionsService();
+			instantiationService = disposables.add(workbenchInstantiationService(undefined, disposables));
+			instantiationService.stub(IChatSessionsService, mockChatSessionsService);
+			instantiationService.stub(ILifecycleService, disposables.add(new TestLifecycleService()));
+		});
+
+		teardown(() => {
+			disposables.clear();
+		});
+
+		ensureNoDisposablesAreLeakedInTestSuite();
+
+		function uris() {
+			return {
+				oldUri: URI.parse(`${chatSessionTestType}://legacy-1`),
+				newUri: URI.parse(`${chatSessionTestType}://current-1`),
+			};
+		}
+
+		function makeItem(resource: URI, overrides?: Partial<IChatSessionItem>): IChatSessionItem {
+			return {
+				resource,
+				label: `Session ${resource.path}`,
+				timing: makeNewSessionTiming(),
+				...overrides,
+			};
+		}
+
+		test('migrates archived state forward from legacyResource to current resource', async () => {
+			return runWithFakedTimers({}, async () => {
+				const { oldUri, newUri } = uris();
+				// 1. Provider initially emits item under the legacy URI; user archives it.
+				mockChatSessionsService.registerChatSessionItemController(
+					chatSessionTestType,
+					new StaticChatSessionItemController([makeItem(oldUri)]),
+				);
+				viewModel = disposables.add(instantiationService.createInstance(AgentSessionsModel));
+				await viewModel.resolve(undefined);
+				viewModel.sessions[0].setArchived(true);
+
+				// 2. Provider URI shape changes; new emission carries legacyResource pointing
+				//    at the old URI. Host should adopt the archived state forward.
+				mockChatSessionsService.registerChatSessionItemController(
+					chatSessionTestType,
+					new StaticChatSessionItemController([makeItem(newUri, { legacyResource: oldUri })]),
+				);
+				await viewModel.resolve(undefined);
+
+				const session = viewModel.sessions[0];
+				assert.deepStrictEqual(
+					{ resource: session.resource.toString(), archived: session.isArchived() },
+					{ resource: newUri.toString(), archived: true },
+				);
+			});
+		});
+
+		test('migrates pinned state forward (not just archived)', async () => {
+			return runWithFakedTimers({}, async () => {
+				const { oldUri, newUri } = uris();
+				mockChatSessionsService.registerChatSessionItemController(
+					chatSessionTestType,
+					new StaticChatSessionItemController([makeItem(oldUri)]),
+				);
+				viewModel = disposables.add(instantiationService.createInstance(AgentSessionsModel));
+				await viewModel.resolve(undefined);
+				viewModel.sessions[0].setPinned(true);
+
+				mockChatSessionsService.registerChatSessionItemController(
+					chatSessionTestType,
+					new StaticChatSessionItemController([makeItem(newUri, { legacyResource: oldUri })]),
+				);
+				await viewModel.resolve(undefined);
+
+				const session = viewModel.sessions[0];
+				assert.deepStrictEqual(
+					{ pinned: session.isPinned(), archived: session.isArchived() },
+					{ pinned: true, archived: false },
+				);
+			});
+		});
+
+		test('does nothing when no host state exists under legacyResource', async () => {
+			return runWithFakedTimers({}, async () => {
+				const { oldUri, newUri } = uris();
+				mockChatSessionsService.registerChatSessionItemController(
+					chatSessionTestType,
+					new StaticChatSessionItemController([makeItem(newUri, { legacyResource: oldUri, archived: true })]),
+				);
+				viewModel = disposables.add(instantiationService.createInstance(AgentSessionsModel));
+				await viewModel.resolve(undefined);
+
+				// Falls back to provider-supplied archived bit; no migration needed.
+				assert.strictEqual(viewModel.sessions[0].isArchived(), true);
+			});
+		});
+
+		test('own state wins when both legacy and current URI have host state', async () => {
+			return runWithFakedTimers({}, async () => {
+				const { oldUri, newUri } = uris();
+				// Stage 1: archive under old URI.
+				mockChatSessionsService.registerChatSessionItemController(
+					chatSessionTestType,
+					new StaticChatSessionItemController([makeItem(oldUri)]),
+				);
+				viewModel = disposables.add(instantiationService.createInstance(AgentSessionsModel));
+				await viewModel.resolve(undefined);
+				viewModel.sessions[0].setArchived(true);
+
+				// Stage 2: emit new URI (no legacyResource yet) and explicitly toggle archive
+				// so that host state is established under the new URI (setArchived no-ops on
+				// values matching the current effective state, so we toggle through true).
+				mockChatSessionsService.registerChatSessionItemController(
+					chatSessionTestType,
+					new StaticChatSessionItemController([makeItem(newUri)]),
+				);
+				await viewModel.resolve(undefined);
+				viewModel.sessions[0].setArchived(true);
+				viewModel.sessions[0].setArchived(false);
+
+				// Stage 3: re-emit with legacyResource pointing at the (still-archived) old URI.
+				// Own (new) entry must win.
+				mockChatSessionsService.registerChatSessionItemController(
+					chatSessionTestType,
+					new StaticChatSessionItemController([makeItem(newUri, { legacyResource: oldUri })]),
+				);
+				await viewModel.resolve(undefined);
+
+				assert.strictEqual(viewModel.sessions[0].isArchived(), false);
+			});
+		});
+
+		test('ignores legacyResource equal to the current resource', async () => {
+			return runWithFakedTimers({}, async () => {
+				const { newUri } = uris();
+				mockChatSessionsService.registerChatSessionItemController(
+					chatSessionTestType,
+					new StaticChatSessionItemController([makeItem(newUri, { legacyResource: newUri, archived: false })]),
+				);
+				viewModel = disposables.add(instantiationService.createInstance(AgentSessionsModel));
+				await viewModel.resolve(undefined);
+
+				// Sanity: no infinite loop, falls back to provider value.
+				assert.strictEqual(viewModel.sessions[0].isArchived(), false);
+			});
+		});
+
+		test('ignores legacyResource with a different scheme', async () => {
+			return runWithFakedTimers({}, async () => {
+				const { newUri } = uris();
+				// Pre-archive an item under a different scheme to seed host state there.
+				const otherScheme = URI.parse('other-scheme://legacy-1');
+				mockChatSessionsService.registerChatSessionItemController(
+					chatSessionTestType,
+					new StaticChatSessionItemController([makeItem(otherScheme)]),
+				);
+				viewModel = disposables.add(instantiationService.createInstance(AgentSessionsModel));
+				await viewModel.resolve(undefined);
+				viewModel.sessions[0].setArchived(true);
+
+				// New emission references the other-scheme legacy URI; migration must be refused.
+				mockChatSessionsService.registerChatSessionItemController(
+					chatSessionTestType,
+					new StaticChatSessionItemController([makeItem(newUri, { legacyResource: otherScheme })]),
+				);
+				await viewModel.resolve(undefined);
+
+				assert.strictEqual(viewModel.sessions[0].isArchived(), false);
+			});
+		});
+
+		test('post-migration setArchived writes under current resource and frees the legacy slot', async () => {
+			return runWithFakedTimers({}, async () => {
+				const { oldUri, newUri } = uris();
+				// Stage 1: archive under old URI.
+				mockChatSessionsService.registerChatSessionItemController(
+					chatSessionTestType,
+					new StaticChatSessionItemController([makeItem(oldUri)]),
+				);
+				viewModel = disposables.add(instantiationService.createInstance(AgentSessionsModel));
+				await viewModel.resolve(undefined);
+				viewModel.sessions[0].setArchived(true);
+
+				// Stage 2: migrate to new URI.
+				mockChatSessionsService.registerChatSessionItemController(
+					chatSessionTestType,
+					new StaticChatSessionItemController([makeItem(newUri, { legacyResource: oldUri })]),
+				);
+				await viewModel.resolve(undefined);
+				viewModel.sessions[0].setArchived(false);
+
+				// Stage 3: provider re-emits the old URI (e.g. backend rollback). Its host
+				// state should be empty — the legacy entry was consumed by the migration,
+				// and setArchived(false) wrote to the new URI, not the legacy one.
+				mockChatSessionsService.registerChatSessionItemController(
+					chatSessionTestType,
+					new StaticChatSessionItemController([makeItem(oldUri)]),
+				);
+				await viewModel.resolve(undefined);
+
+				assert.strictEqual(viewModel.sessions[0].isArchived(), false);
+			});
+		});
+	});
+
 	suite('AgentSessionsViewModel - Session Read State', () => {
 		const disposables = new DisposableStore();
 		let mockChatSessionsService: MockChatSessionsService;

--- a/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
@@ -337,6 +337,26 @@ declare module 'vscode' {
 		archived?: boolean;
 
 		/**
+		 * Resource identifier this item was previously known by. When set, host-stored
+		 * per-resource state (archive, pin, read) recorded under that URI is treated as
+		 * also applying to this item.
+		 *
+		 * On first access of state for {@link resource}, the host adopts the entry
+		 * stored under `legacyResource` forward — copying it onto {@link resource} and
+		 * removing the legacy entry. The migration is transparent: no events fire and
+		 * the effective user-visible state is unchanged.
+		 *
+		 * Intended for providers that need to change the URI shape they emit (e.g. during
+		 * a backend or schema migration) without requiring users to re-archive or re-pin
+		 * items.
+		 *
+		 * The legacy URI's scheme must match {@link resource}'s scheme; otherwise the
+		 * field is ignored. Multi-hop migrations are not supported — providers should
+		 * collapse intermediate hops on their side and emit the original URI.
+		 */
+		readonly legacyResource?: Uri;
+
+		/**
 		 * Timing information for the chat session
 		 */
 		timing?: {


### PR DESCRIPTION
## Why

Chat session providers store per-URI state in the host (archive, pin, read). If a provider changes the URI shape it emits — even for the same underlying entity — that state is silently lost: the new URI has no host entry, and the old URI's entry is orphaned.

The Cloud Agents provider is about to do exactly this (migrating from `/<prNumber>` to `/task/<taskId>` URIs). Without help from the host, users would see every previously archived session reappear at migration time.

## What

Adds a single optional declarative field — `legacyResource` — that lets a provider say "this item used to live at URI X; if you have per-URI state for X, treat it as also applying to me." On first state read for the new URI, the host copies the legacy entry forward and removes it. Migration is transparent: no events fire, the effective user-visible state is unchanged, the change is self-cleaning, and the field can be dropped from emissions once everyone is on the new URI shape.

Considered alternatives:
- A provider-side archive store mirrored via `onDidChangeChatSessionItemState` — captures only what users re-touch during the rollout window; pre-existing archives are invisible to extensions and can't be recovered.
- An imperative `vscode.chat.consolidateResourceState(old, new)` API — wider surface, requires the provider to know all migrations upfront, not idempotent.

The declarative-on-item shape is the smallest surface that gets the job done.

## Surface

```ts
// vscode.proposed.chatSessionsProvider.d.ts
export interface ChatSessionItem {
    // …existing fields…
    readonly legacyResource?: Uri;
}
```

Host semantics (single function in `AgentSessionsModel`):

```ts
private resolveStateEntry(session): IAgentSessionState | undefined {
    const own = this.sessionStates.get(session.resource);
    if (own !== undefined) { return own; }                       // own wins
    const legacy = session.legacyResource;
    if (!legacy
        || legacy.scheme !== session.resource.scheme            // cross-scheme rejected
        || legacy.toString() === session.resource.toString()) { // self-ref rejected
        return undefined;
    }
    const prev = this.sessionStates.get(legacy);
    if (prev === undefined) { return undefined; }
    this.sessionStates.set(session.resource, { ...prev });        // adopt forward
    this.sessionStates.delete(legacy);                            // self-clean
    return this.sessionStates.get(session.resource);
}
```

`isArchived` and `isPinned` both route through this helper. `setArchived` / `setPinned` continue to write to `session.resource` (the helper has already adopted any legacy entry forward by the time set runs).

## Files

- `src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts` — new field with docstring describing semantics, scheme restriction, and the no-multi-hop rule.
- `src/vs/workbench/contrib/chat/common/chatSessionsService.ts` — matching field on `IChatSessionItem`.
- `src/vs/workbench/api/common/extHostTypeConverters.ts` — propagate through `ChatSessionItem.from`.
- `src/vs/workbench/api/browser/mainThreadChatSessions.ts` — revive in `MainThreadChatSessionItem` constructor, include in `isEqual`.
- `src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsModel.ts` — `resolveStateEntry` helper, `isArchived` / `isPinned` use it, cache serialization carries `legacyResource` through restarts.
- `src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionViewModel.test.ts` — 7 focused tests.

## Tests

`AgentSessionsViewModel - legacyResource migration`:

- ✅ migrates archived state forward
- ✅ migrates pinned state forward (proves it's full-state, not just archived)
- ✅ no-op when no host state exists under legacyResource
- ✅ own state wins when both legacy and current have host state
- ✅ self-referential `legacyResource === resource` is a no-op
- ✅ cross-scheme `legacyResource` is rejected
- ✅ post-migration `setArchived` writes under current resource and leaves no ghost under the legacy one

`./scripts/test.sh --run …agentSessionViewModel.test.ts`: 89 passing locally.

## Non-goals (intentionally out of scope)

- No multi-hop migration. Providers can collapse hops on their side and emit the original URI.
- No two-way alias. The legacy URI is consumed on first read.
- No event when the migration happens. Effective state is unchanged.

## Versioning

This is an additive change to the proposed `chatSessionsProvider` API — backwards-compatible per `.github/instructions/api-version.instructions.md`, so no proposal version bump.

## Follow-up

This unblocks the Cloud Agents provider migration to `createChatSessionItemController` with the `/task/<taskId>` URI shape. Plan documented in `extensions/copilot/docs/cloud-sessions-controller-migration-plan.md` (not in this PR).
