### PR TITLE
Fix Windows agent sandbox setting ID

### DIFF
--- a/src/vs/platform/sandbox/common/settings.ts
+++ b/src/vs/platform/sandbox/common/settings.ts
@@ -8,7 +8,7 @@
  */
 export const enum AgentSandboxSettingId {
 	AgentSandboxEnabled = 'chat.agent.sandbox.enabled',
-	AgentSandboxWindowsEnabled = 'chat.agent.sandbox.enabled.windows',
+	AgentSandboxWindowsEnabled = 'chat.agent.sandbox.enabledWindows',
 	AgentSandboxAllowUnsandboxedCommands = 'chat.agent.sandbox.allowUnsandboxedCommands',
 	AgentSandboxAutoApproveUnsandboxedCommands = 'chat.agent.sandbox.autoApproveUnsandboxedCommands',
 	AgentSandboxAllowAutoApprove = 'chat.agent.sandbox.allowAutoApprove',


### PR DESCRIPTION
Fixes #318038

This updates AgentSandboxWindowsEnabled to use chat.agent.sandbox.enabledWindows instead of chat.agent.sandbox.enabled.windows.

Validation:
- Precommit hygiene hook passed during commit