### PR TITLE
Enable custom endpoint provider in package.json

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -1973,7 +1973,6 @@
       },
       {
         "vendor": "customendpoint",
-        "when": "productQualityType != 'stable'",
         "displayName": "Custom Endpoint",
         "configuration": {
           "type": "object",


### PR DESCRIPTION
Remove the condition that restricts the display of the custom endpoint in package.json, allowing it to be shown regardless of product quality type.