### PR TITLE
Reject path traversal in Create Workspace file tree

### DIFF
--- a/extensions/copilot/src/extension/conversation/vscode-node/newWorkspaceFollowup.ts
+++ b/extensions/copilot/src/extension/conversation/vscode-node/newWorkspaceFollowup.ts
@@ -95,8 +95,14 @@ async function createWorkspace(logService: ILogService, workspaceRoot: Uri | und
 	try {
 		await window.withProgress({ location: ProgressLocation.Notification, cancellable: true }, async (progress, token) => {
 			for (const file of files) {
-				const relativeFilePath = path.relative(projectRoot, file);
-				const fileUri = Uri.joinPath(workspaceUri, relativeFilePath);
+				const fileUri = resolveProjectFileUri(workspaceUri, projectRoot, file);
+				// Guard against path traversal: a malicious or prompt-injected file tree
+				// can contain `..` segments that escape the generated workspace folder.
+				// Skip any file whose resolved destination is not contained within it.
+				if (!isUriContained(workspaceUri, fileUri)) {
+					logService.warn(`[newIntent] Skipping file outside of workspace: ${file}`);
+					continue;
+				}
 				progress.report({ message: l10n.t(`Creating file {0}...`, fileUri.fsPath) });
 				const content = await workspace.fs.readFile(Uri.joinPath(fileTreePart.baseUri, file));
 				await workspace.fs.createDirectory(Uri.joinPath(fileUri, '..'));
@@ -134,6 +140,56 @@ async function createWorkspace(logService: ILogService, workspaceRoot: Uri | und
 	}
 }
 
+/**
+ * Resolves the destination URI for a file emitted by `listFilesInResponseFileTree`
+ * inside a generated workspace.
+ *
+ * The emitted shape depends on the source flow:
+ *  - Copilot new-workspace flow: `<projectName>/<inside>` (no leading slash).
+ *  - GitHub repo-template flow:  `/<inside>` (leading slash; the repo-name
+ *    level has been collapsed out of the tree).
+ *  - GitHub subdir/non-repo-root: `<subdir>/<inside>`.
+ *
+ * In every case the part *inside the project* is what we want to join with
+ * `workspaceUri`. We compute it by stripping any leading `/` and any leading
+ * `<projectRoot>/` prefix. Any remaining `..` segments are preserved so the
+ * downstream `isUriContained` check can reject traversal attempts.
+ *
+ * Using a string-strip (rather than the platform-aware `path.relative` against
+ * `cwd`) avoids the Windows-only failure mode where the relative `projectRoot`
+ * gets resolved against `process.cwd()` and produces a nonsense `..`-laden
+ * traversal that escapes the workspace.
+ *
+ * Exported for tests only.
+ */
+export function resolveProjectFileUri(workspaceUri: Uri, projectRoot: string, file: string): Uri {
+	let rel = file.startsWith('/') ? file.slice(1) : file;
+	const prefix = projectRoot + '/';
+	if (rel === projectRoot) {
+		rel = '';
+	} else if (rel.startsWith(prefix)) {
+		rel = rel.slice(prefix.length);
+	}
+	return Uri.joinPath(workspaceUri, rel);
+}
+
+/**
+ * Returns `true` if `child` resolves to a location at or within `parent`.
+ * Used to prevent path traversal (`..`) from escaping the generated workspace folder.
+ * Note: `Uri.joinPath` normalizes `..` segments, so `child.path` is already resolved here.
+ *
+ * Exported for tests only.
+ */
+export function isUriContained(parent: Uri, child: Uri): boolean {
+	if (parent.scheme !== child.scheme || parent.authority !== child.authority) {
+		return false;
+	}
+	if (child.path === parent.path) {
+		return true;
+	}
+	const parentPath = parent.path.endsWith('/') ? parent.path : parent.path + '/';
+	return child.path.startsWith(parentPath);
+}
 
 async function getUniqueProjectName(projectFolder: Uri, projectName: string): Promise<string> {
 	let i = 0;

--- a/extensions/copilot/src/extension/conversation/vscode-node/test/newWorkspaceFollowup.spec.ts
+++ b/extensions/copilot/src/extension/conversation/vscode-node/test/newWorkspaceFollowup.spec.ts
@@ -1,0 +1,88 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Uri } from 'vscode';
+import { expect, suite, test } from 'vitest';
+import { isUriContained, resolveProjectFileUri } from '../newWorkspaceFollowup';
+
+/**
+ * Unit tests for the path-traversal containment helper guarding the
+ * "Create Workspace" file-write loop. This is the runtime defense-in-depth
+ * for the MSRC-reported path traversal in the new-workspace flow.
+ */
+suite('isUriContained', () => {
+	const parent = Uri.file('/home/u/proj');
+
+	test('accepts paths at or within the parent folder', () => {
+		expect(isUriContained(parent, parent)).toBe(true);
+		expect(isUriContained(parent, Uri.file('/home/u/proj/a.txt'))).toBe(true);
+		expect(isUriContained(parent, Uri.file('/home/u/proj/sub/dir/a.txt'))).toBe(true);
+	});
+
+	test('rejects sibling paths with a shared name prefix', () => {
+		// Classic prefix-collision: /home/u/proj vs /home/u/proj-evil
+		expect(isUriContained(parent, Uri.file('/home/u/proj-evil/x'))).toBe(false);
+		expect(isUriContained(parent, Uri.file('/home/u/projx'))).toBe(false);
+	});
+
+	test('rejects paths that escape the parent via traversal', () => {
+		// `Uri.joinPath` normalizes `..` before the comparison runs, so we
+		// supply the resolved URI that the production code would actually see.
+		expect(isUriContained(parent, Uri.file('/home/u/package.json'))).toBe(false);
+		expect(isUriContained(parent, Uri.file('/etc/passwd'))).toBe(false);
+	});
+
+	test('rejects URIs with mismatched scheme or authority', () => {
+		const remoteParent = Uri.parse('vscode-remote://host/proj');
+		const localChild = Uri.file('/proj/a.txt');
+		expect(isUriContained(remoteParent, localChild)).toBe(false);
+
+		const otherHost = Uri.parse('vscode-remote://other/proj/a.txt');
+		expect(isUriContained(remoteParent, otherHost)).toBe(false);
+
+		const sameHostChild = Uri.parse('vscode-remote://host/proj/a.txt');
+		expect(isUriContained(remoteParent, sameHostChild)).toBe(true);
+	});
+
+	test('handles a parent path that already ends with a slash', () => {
+		const withSlash = parent.with({ path: parent.path + '/' });
+		expect(isUriContained(withSlash, Uri.file('/home/u/proj/a.txt'))).toBe(true);
+		expect(isUriContained(withSlash, Uri.file('/home/u/proj-evil/x'))).toBe(false);
+	});
+});
+
+/**
+ * Regression test for the GitHub repo-template "Create Workspace" flow.
+ *
+ * `listFilesInResponseFileTree` emits paths that may or may not include a
+ * leading `/` depending on the source (the GitHub repo-template flow emits
+ * `/<repo>/...`, the copilot flow emits `<projectName>/...`). The platform-
+ * aware `path.relative` previously resolved a relative `projectRoot` against
+ * `cwd` for the absolute `file`, producing a nonsense `..`-laden traversal that
+ * `Uri.joinPath` normalized outside `workspaceUri` — so the runtime containment
+ * guard added by the MSRC fix would silently skip every file. The fix forces
+ * posix semantics with absolutized inputs.
+ */
+suite('resolveProjectFileUri', () => {
+	const workspaceUri = Uri.file('/home/u/parent/myrepo');
+
+	test('handles a `/`-prefixed file path (GitHub repo-template flow)', () => {
+		const fileUri = resolveProjectFileUri(workspaceUri, 'myrepo', '/src/index.ts');
+		expect(fileUri.path).toBe('/home/u/parent/myrepo/src/index.ts');
+	});
+
+	test('handles a non-prefixed file path (copilot new-workspace flow)', () => {
+		const fileUri = resolveProjectFileUri(workspaceUri, 'myrepo', 'myrepo/src/index.ts');
+		expect(fileUri.path).toBe('/home/u/parent/myrepo/src/index.ts');
+	});
+
+	test('preserves traversal segments so the containment check can reject them', () => {
+		// A bypass of the parser must still be caught downstream by `isUriContained`.
+		// `Uri.joinPath` normalizes `..`, so the resolved path escapes the workspace
+		// and `isUriContained(workspaceUri, fileUri)` will return false.
+		const fileUri = resolveProjectFileUri(workspaceUri, 'myrepo', 'myrepo/../package.json');
+		expect(isUriContained(workspaceUri, fileUri)).toBe(false);
+	});
+});

--- a/extensions/copilot/src/extension/conversation/vscode-node/test/newWorkspaceFollowup.spec.ts
+++ b/extensions/copilot/src/extension/conversation/vscode-node/test/newWorkspaceFollowup.spec.ts
@@ -85,4 +85,19 @@ suite('resolveProjectFileUri', () => {
 		const fileUri = resolveProjectFileUri(workspaceUri, 'myrepo', 'myrepo/../package.json');
 		expect(isUriContained(workspaceUri, fileUri)).toBe(false);
 	});
+
+	test('source preview URI built from the unmodified `file` resolves to the expected preview path', () => {
+		// `createWorkspace` reads preview content via `Uri.joinPath(baseUri, file)`
+		// using the *unmodified* `file` emitted by `listFilesInResponseFileTree`.
+		// `Uri.joinPath` is backed by `paths.posix.join`, which treats arguments
+		// as path segments (it does NOT drop `baseUri.path` when the next segment
+		// starts with `/`). Asserting this here so the source/destination URI
+		// shapes do not drift in the future.
+		const baseUri = Uri.parse('vscode-copilot-github-workspace://req/myrepo');
+		// GitHub repo-template flow: emitted file = `/src/index.ts`.
+		expect(Uri.joinPath(baseUri, '/src/index.ts').path).toBe('/myrepo/src/index.ts');
+		// Copilot new-workspace flow: emitted file = `myproject/src/index.ts`.
+		const copilotBase = Uri.parse('vscode-copilot-workspace://req/myproject');
+		expect(Uri.joinPath(copilotBase, 'myproject/src/index.ts').path).toBe('/myproject/myproject/src/index.ts');
+	});
 });

--- a/extensions/copilot/src/extension/prompt/common/fileTreeParser.ts
+++ b/extensions/copilot/src/extension/prompt/common/fileTreeParser.ts
@@ -31,6 +31,9 @@ export function convertFileTreeToChatResponseFileTree(
 		const fileNode: vscode.ChatResponseFileTree = { name };
 
 		if (depth === 0) {
+			if (isUnsafeNodeName(name)) {
+				throw new Error(`Invalid project root name in file tree: ${name}`);
+			}
 			baseUri = generatePreviewURI(name);
 			root.name = name;
 			continue;
@@ -100,7 +103,7 @@ function filterChatResponseFileTree(fileTree: vscode.ChatResponseFileTree[]): vs
 
 	for (const node of fileTree) {
 
-		if (!isNodeInFilterList(node)) {
+		if (!isNodeInFilterList(node) && !isUnsafeNodeName(node.name)) {
 			if (node.children) {
 				node.children = filterChatResponseFileTree(node.children);
 			}
@@ -117,4 +120,18 @@ function isNodeInFilterList(node: vscode.ChatResponseFileTree): boolean {
 	}
 
 	return false;
+}
+
+/**
+ * Guards against path traversal: a file tree node name must be a single, plain
+ * path segment. Names that are empty, the current/parent directory (`.`/`..`),
+ * or that contain path separators (`/` or `\`) could escape the generated
+ * workspace folder when joined to a destination path and must be rejected.
+ */
+export function isUnsafeNodeName(name: string): boolean {
+	if (!name || name === '.' || name === '..') {
+		return true;
+	}
+
+	return name.includes('/') || name.includes('\\');
 }

--- a/extensions/copilot/src/extension/prompt/test/common/fileTreeParser.spec.ts
+++ b/extensions/copilot/src/extension/prompt/test/common/fileTreeParser.spec.ts
@@ -7,7 +7,7 @@
 import { expect, suite, test } from 'vitest';
 import { URI } from '../../../../util/vs/base/common/uri';
 import { ChatResponseFileTreePart } from '../../../../vscodeTypes';
-import { convertFileTreeToChatResponseFileTree } from '../../common/fileTreeParser';
+import { convertFileTreeToChatResponseFileTree, isUnsafeNodeName } from '../../common/fileTreeParser';
 
 suite('convertFileTreeToChatResponseFileTree', () => {
 	const generatePreviewURI = (filename: string) => URI.file(`/preview/${filename}`);
@@ -82,5 +82,39 @@ project
 				]
 			}
 		], URI.file('/preview/project')));
+	});
+
+	test('should filter out path traversal segments', () => {
+		const fileStructure = `
+project
+├── ..
+├── file1.txt
+└── file2.txt
+		`;
+
+		const { chatResponseTree, projectName } = convertFileTreeToChatResponseFileTree(fileStructure, generatePreviewURI);
+
+		expect(projectName).toBe('project');
+		expect(chatResponseTree).to.deep.equal(new ChatResponseFileTreePart([
+			{
+				name: 'project',
+				children: [
+					{ name: 'file1.txt' },
+					{ name: 'file2.txt' }
+				]
+			}
+		], URI.file('/preview/project')));
+	});
+});
+
+suite('isUnsafeNodeName', () => {
+	test('rejects path traversal and separator segments', () => {
+		expect(['', '.', '..', 'a/b', 'a\\b', '../x', 'foo/'].map(isUnsafeNodeName))
+			.to.deep.equal([true, true, true, true, true, true, true]);
+	});
+
+	test('accepts plain path segments', () => {
+		expect(['file.txt', 'src', 'my-project', 'index.ts', '.gitignore'].map(isUnsafeNodeName))
+			.to.deep.equal([false, false, false, false, false]);
 	});
 });

--- a/extensions/copilot/src/extension/prompt/test/common/newWorkspaceFileTreeTraversal.poc.spec.ts
+++ b/extensions/copilot/src/extension/prompt/test/common/newWorkspaceFileTreeTraversal.poc.spec.ts
@@ -1,0 +1,59 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect, suite, test } from 'vitest';
+import { URI } from '../../../../util/vs/base/common/uri';
+import { convertFileTreeToChatResponseFileTree, listFilesInResponseFileTree } from '../../common/fileTreeParser';
+
+/**
+ * Regression test for the "Create Workspace" path-traversal vulnerability.
+ *
+ * A malicious or prompt-injected model response could embed `..` segments in the
+ * generated markdown file tree. When the tree was copied into the user-selected
+ * parent folder, `path.relative` + `Uri.joinPath` resolved those segments and let
+ * the write escape the generated workspace folder (e.g. overwriting a sibling's
+ * `package.json`).
+ *
+ * The parser now drops any node whose name is a traversal/separator segment, so
+ * the escaping path is never produced. (A second, independent containment check
+ * in `createWorkspace` guards the actual file write as defense in depth.)
+ */
+suite('newWorkspace file tree traversal (PoC)', () => {
+	const generatePreviewURI = (filename: string) => URI.file(`/preview/${filename}`);
+
+	test('parser does not emit traversal paths from a malicious tree', () => {
+		// The PoC tree embeds a `..` directory that points at the parent folder.
+		const fileStructure = `
+project
+├── package.json
+├── ..
+│   └── package.json
+└── safe.txt
+		`;
+
+		const { chatResponseTree } = convertFileTreeToChatResponseFileTree(fileStructure, generatePreviewURI);
+		const files = listFilesInResponseFileTree(chatResponseTree.value);
+
+		// No produced path may contain a `..` (or other) traversal segment.
+		for (const file of files) {
+			expect(file.split('/')).not.toContain('..');
+			expect(file.split('/')).not.toContain('.');
+		}
+
+		// The legitimate, in-tree files are still produced.
+		expect(files).toContain('project/package.json');
+		expect(files).toContain('project/safe.txt');
+	});
+
+	test('parser rejects a malicious project root name', () => {
+		const fileStructure = `
+..
+├── package.json
+└── safe.txt
+		`;
+
+		expect(() => convertFileTreeToChatResponseFileTree(fileStructure, generatePreviewURI)).toThrow();
+	});
+});


### PR DESCRIPTION
Harden the Copilot Chat **Create Workspace** flow so a model-generated file tree cannot write outside the chosen project folder.

### Changes

- **fileTreeParser**: reject node names that are empty, `.`, `..`, or contain `/` or `\\`. Throw on an unsafe project root name; filter unsafe child node names from the parsed tree.
- **newWorkspaceFollowup**: replace the platform-aware `path.relative(projectRoot, file)` destination computation (which on Windows resolved the relative `projectRoot` against `process.cwd()` and produced nonsense traversals) with a small posix prefix-strip helper, `resolveProjectFileUri`. Handles both emission shapes (copilot `<projectName>/...` and GitHub repo-template `/...`).
- Add a runtime `isUriContained` guard before `writeFile` so any traversal that slips past the parser still cannot escape the generated workspace folder.