### PR TITLE
sessions: add max-width to session title in titlebar

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsTitleBarWidget.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsTitleBarWidget.css
@@ -92,6 +92,7 @@
 .command-center .agent-sessions-titlebar-container .agent-sessions-titlebar-label {
 	flex: 0 999 auto;
 	min-width: 0;
+	max-width: 400px;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;


### PR DESCRIPTION
## Summary

Adds a `max-width: 400px` constraint to the session title label (`.agent-sessions-titlebar-label`) in the sessions window titlebar.

## Problem

Long session titles (e.g. from GitHub issue titles) could grow unbounded in the titlebar, pushing other elements (repo name, branch, diff stats, right-side actions) out of view.

## Fix

Added `max-width: 400px` to the title label element. The existing `overflow: hidden` and `text-overflow: ellipsis` properties already handle truncation — they just needed a width constraint to take effect when there is available space.