### PR TITLE
feat: XAA enterprise-managed MCP authentication (ID-JAG)

### DIFF
--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -39,6 +39,21 @@
     ],
     "policies": [
         {
+            "key": "mcp.enterpriseManagedAuth.idp",
+            "name": "McpEnterpriseManagedAuthIdp",
+            "category": "InteractiveSession",
+            "minimumVersion": "1.122",
+            "localization": {
+                "description": {
+                    "key": "mcp.enterpriseManagedAuth.idp.policy",
+                    "value": "The OAuth/OIDC IdP configuration used for enterprise-managed Model Context Protocol (MCP) server authentication. Delivered through enterprise policy (Windows Group Policy, macOS managed preferences, Linux `/etc/vscode/policy.json`)."
+                }
+            },
+            "type": "object",
+            "default": {},
+            "included": false
+        },
+        {
             "key": "chat.mcp.gallery.serviceUrl",
             "name": "McpGalleryServiceUrl",
             "category": "InteractiveSession",

--- a/src/vs/base/common/oauth.ts
+++ b/src/vs/base/common/oauth.ts
@@ -11,6 +11,93 @@ export const AUTH_SERVER_METADATA_DISCOVERY_PATH = `${WELL_KNOWN_ROUTE}/oauth-au
 export const OPENID_CONNECT_DISCOVERY_PATH = `${WELL_KNOWN_ROUTE}/openid-configuration`;
 export const AUTH_SCOPE_SEPARATOR = ' ';
 
+/**
+ * RFC 8693 grant type for OAuth token exchange.
+ */
+export const GRANT_TYPE_TOKEN_EXCHANGE = 'urn:ietf:params:oauth:grant-type:token-exchange';
+
+/**
+ * RFC 8693 token type for an OAuth 2.0 access token used as the `subject_token`
+ * during a token exchange.
+ */
+export const TOKEN_TYPE_ACCESS_TOKEN = 'urn:ietf:params:oauth:token-type:access_token';
+
+/**
+ * Token type for an OpenID Connect ID Token. Used as the `subject_token_type` in
+ * the IdP-side token exchange that mints an ID-JAG.
+ */
+export const TOKEN_TYPE_ID_TOKEN = 'urn:ietf:params:oauth:token-type:id_token';
+
+/**
+ * Token type for an Identity Assertion Authorization Grant (ID-JAG) used in
+ * Cross App Access (XAA) flows.
+ */
+export const TOKEN_TYPE_ID_JAG = 'urn:ietf:params:oauth:token-type:id-jag';
+
+/**
+ * RFC 7523 grant type used to exchange a JWT assertion (e.g. an ID-JAG) for an
+ * access token at the resource's authorization server.
+ */
+export const GRANT_TYPE_JWT_BEARER = 'urn:ietf:params:oauth:grant-type:jwt-bearer';
+
+/**
+ * Build the request body for the IdP-side token exchange that mints an ID-JAG
+ * for the requested audience. See draft-ietf-oauth-identity-assertion-authz-grant.
+ *
+ * @param clientId the requesting app's client_id at the IdP.
+ * @param clientSecret the requesting app's client_secret at the IdP, if applicable.
+ *   Omit (or pass `undefined`) for public clients (`token_endpoint_auth_method=none`).
+ * @param idToken the OpenID Connect `id_token` previously issued by the IdP to
+ *   the requesting app. Per the spec the subject token MUST be an ID Token
+ *   (not an access token).
+ * @param audience the *authorization server* URL of the resource (the issuer
+ *   that will redeem the ID-JAG). Required.
+ * @param resource the resource indicator (RFC 8707) — the URL of the actual
+ *   protected resource (e.g. the MCP server URL). Optional but typically required
+ *   in practice.
+ * @param scopes scopes the requesting app wants granted at the resource.
+ */
+export function buildIdJagExchangeBody(clientId: string, clientSecret: string | undefined, idToken: string, audience: string, resource: string | undefined, scopes: readonly string[]): URLSearchParams {
+	const body = new URLSearchParams();
+	body.append('client_id', clientId);
+	if (clientSecret) {
+		body.append('client_secret', clientSecret);
+	}
+	body.append('grant_type', GRANT_TYPE_TOKEN_EXCHANGE);
+	body.append('subject_token', idToken);
+	body.append('subject_token_type', TOKEN_TYPE_ID_TOKEN);
+	body.append('requested_token_type', TOKEN_TYPE_ID_JAG);
+	body.append('audience', audience);
+	if (resource) {
+		body.append('resource', resource);
+	}
+	if (scopes.length) {
+		body.append('scope', scopes.join(AUTH_SCOPE_SEPARATOR));
+	}
+	return body;
+}
+
+/**
+ * Build the request body sent to a resource server's authorization server to
+ * redeem an ID-JAG for a resource-scoped access token (RFC 7523 JWT-bearer grant).
+ */
+export function buildResourceRedemptionBody(clientId: string, clientSecret: string | undefined, idJag: string, resource: string | undefined, scopes: readonly string[]): URLSearchParams {
+	const body = new URLSearchParams();
+	body.append('client_id', clientId);
+	if (clientSecret) {
+		body.append('client_secret', clientSecret);
+	}
+	body.append('grant_type', GRANT_TYPE_JWT_BEARER);
+	body.append('assertion', idJag);
+	if (resource) {
+		body.append('resource', resource);
+	}
+	if (scopes.length) {
+		body.append('scope', scopes.join(AUTH_SCOPE_SEPARATOR));
+	}
+	return body;
+}
+
 //#region types
 
 /**

--- a/src/vs/base/test/common/oauth.test.ts
+++ b/src/vs/base/test/common/oauth.test.ts
@@ -6,6 +6,8 @@
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import {
+	buildIdJagExchangeBody,
+	buildResourceRedemptionBody,
 	getClaimsFromJWT,
 	getDefaultMetadataForUrl,
 	isAuthorizationAuthorizeResponse,
@@ -2252,6 +2254,62 @@ suite('OAuth', () => {
 			assert.strictEqual(result.discoveryUrl, 'https://auth.example.com/.well-known/oauth-authorization-server');
 			const headers = fetchStub.firstCall.args[1].headers;
 			assert.strictEqual(headers['Accept'], 'application/json');
+		});
+	});
+
+	suite('Cross App Access (ID-JAG) wire format', () => {
+		// Spec: draft-ietf-oauth-identity-assertion-authz-grant-03
+		test('buildIdJagExchangeBody emits the exact spec parameters', () => {
+			const body = buildIdJagExchangeBody(
+				'my_idp_client_id',
+				'secret_xyz',
+				'<id_token>',
+				'https://auth.resource.example.com',
+				'https://api.resource.example.com',
+				['todos.read', 'mcp.access'],
+			);
+
+			assert.strictEqual(body.get('client_id'), 'my_idp_client_id');
+			assert.strictEqual(body.get('client_secret'), 'secret_xyz');
+			assert.strictEqual(body.get('grant_type'), 'urn:ietf:params:oauth:grant-type:token-exchange');
+			assert.strictEqual(body.get('subject_token'), '<id_token>');
+			assert.strictEqual(body.get('subject_token_type'), 'urn:ietf:params:oauth:token-type:id_token');
+			assert.strictEqual(body.get('requested_token_type'), 'urn:ietf:params:oauth:token-type:id-jag');
+			assert.strictEqual(body.get('audience'), 'https://auth.resource.example.com');
+			assert.strictEqual(body.get('resource'), 'https://api.resource.example.com');
+			assert.strictEqual(body.get('scope'), 'todos.read mcp.access');
+		});
+
+		test('buildIdJagExchangeBody omits client_secret when not provided', () => {
+			const body = buildIdJagExchangeBody(
+				'public_client_id',
+				undefined,
+				'<id_token>',
+				'https://auth.resource.example.com',
+				undefined,
+				[],
+			);
+
+			assert.strictEqual(body.has('client_secret'), false);
+			assert.strictEqual(body.has('resource'), false);
+			assert.strictEqual(body.has('scope'), false);
+		});
+
+		test('buildResourceRedemptionBody emits an RFC 7523 JWT-bearer grant', () => {
+			const body = buildResourceRedemptionBody(
+				'my_idp_client_id-at-todo0',
+				'secret_xyz',
+				'<id_jag>',
+				'https://api.resource.example.com',
+				['todos.read', 'mcp.access'],
+			);
+
+			assert.strictEqual(body.get('client_id'), 'my_idp_client_id-at-todo0');
+			assert.strictEqual(body.get('client_secret'), 'secret_xyz');
+			assert.strictEqual(body.get('grant_type'), 'urn:ietf:params:oauth:grant-type:jwt-bearer');
+			assert.strictEqual(body.get('assertion'), '<id_jag>');
+			assert.strictEqual(body.get('resource'), 'https://api.resource.example.com');
+			assert.strictEqual(body.get('scope'), 'todos.read mcp.access');
 		});
 	});
 });

--- a/src/vs/platform/extensions/common/extensionsApiProposals.ts
+++ b/src/vs/platform/extensions/common/extensionsApiProposals.ts
@@ -37,6 +37,9 @@ const _allApiProposals = {
 	authSession: {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.authSession.d.ts',
 	},
+	authSessionAudience: {
+		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.authSessionAudience.d.ts',
+	},
 	authenticationChallenges: {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.authenticationChallenges.d.ts',
 	},

--- a/src/vs/workbench/api/browser/mainThreadAuthentication.ts
+++ b/src/vs/workbench/api/browser/mainThreadAuthentication.ts
@@ -24,11 +24,15 @@ import { ILogService } from '../../../platform/log/common/log.js';
 import { ExtensionHostKind } from '../../services/extensions/common/extensionHostKind.js';
 import { IURLService } from '../../../platform/url/common/url.js';
 import { DeferredPromise, raceTimeout } from '../../../base/common/async.js';
-import { IAuthorizationTokenResponse } from '../../../base/common/oauth.js';
+import { fetchAuthorizationServerMetadata, IAuthorizationTokenResponse } from '../../../base/common/oauth.js';
 import { IDynamicAuthenticationProviderStorageService } from '../../services/authentication/common/dynamicAuthenticationProviderStorage.js';
 import { IClipboardService } from '../../../platform/clipboard/common/clipboardService.js';
 import { IQuickInputService } from '../../../platform/quickinput/common/quickInput.js';
+import { ISecretStorageService } from '../../../platform/secrets/common/secrets.js';
+import { mcpOAuthClientSecretStorageKey } from '../../contrib/mcp/common/mcpTypes.js';
 import { IProductService } from '../../../platform/product/common/productService.js';
+import { IConfigurationService } from '../../../platform/configuration/common/configuration.js';
+import { IMcpEnterpriseManagedAuthIdpConfig, mcpEnterpriseManagedAuthIdpSection } from '../../contrib/mcp/common/mcpConfiguration.js';
 
 export interface AuthenticationInteractiveOptions {
 	detail?: string;
@@ -130,7 +134,9 @@ export class MainThreadAuthentication extends Disposable implements MainThreadAu
 		@IURLService private readonly urlService: IURLService,
 		@IDynamicAuthenticationProviderStorageService private readonly dynamicAuthProviderStorageService: IDynamicAuthenticationProviderStorageService,
 		@IClipboardService private readonly clipboardService: IClipboardService,
-		@IQuickInputService private readonly quickInputService: IQuickInputService
+		@IQuickInputService private readonly quickInputService: IQuickInputService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@ISecretStorageService private readonly secretStorageService: ISecretStorageService,
 	) {
 		super();
 		this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostAuthentication);
@@ -174,6 +180,37 @@ export class MainThreadAuthentication extends Disposable implements MainThreadAu
 					authorizationServer,
 					serverMetadata,
 					resource,
+					clientId,
+					clientSecret,
+					initialTokens
+				);
+			},
+			createXaa: async (issuer) => {
+				// XAA providers are keyed by issuer alone so they can be reused across many enterprise-managed servers.
+				const authProviderId = `xaa:${issuer.toString(true)}`;
+				const { metadata: serverMetadata } = await fetchAuthorizationServerMetadata(issuer.toString(true));
+
+				// Prefer the user-configured IdP client_id / client_secret over any cached registration.
+				// XAA requires a pre-provisioned (admin-approved) client_id at the IdP — there is no DCR
+				// fallback — so an explicit setting is the most reliable source. Typically delivered via
+				// enterprise policy; developers may hand-edit settings.json for local testing.
+				const configuredIdp = this.configurationService.getValue<IMcpEnterpriseManagedAuthIdpConfig | undefined>(mcpEnterpriseManagedAuthIdpSection) ?? {};
+				const configuredClientId = configuredIdp.clientId?.trim() || undefined;
+				const configuredClientSecret = configuredIdp.clientSecret?.trim() || undefined;
+				const cached = await this.dynamicAuthProviderStorageService.getClientRegistration(authProviderId);
+				const clientId = configuredClientId ?? cached?.clientId;
+				const clientSecret = configuredClientSecret ?? cached?.clientSecret;
+				let initialTokens: (IAuthorizationTokenResponse & { created_at: number })[] | undefined = undefined;
+				if (clientId) {
+					initialTokens = await this.dynamicAuthProviderStorageService.getSessionsForDynamicAuthProvider(authProviderId, clientId);
+				}
+				// Note: XAA does NOT use CIMD or DCR — the requesting app must be pre-registered with the
+				// IdP under an admin-approved cross-app-access trust relationship. The ext-host side
+				// (`$registerXaaAuthProvider`) prompts the user for client_id + client_secret when there
+				// is no cached registration and no configured value.
+				return await this._proxy.$registerXaaAuthProvider(
+					issuer,
+					serverMetadata,
 					clientId,
 					clientSecret,
 					initialTokens
@@ -655,5 +692,50 @@ export class MainThreadAuthentication extends Disposable implements MainThreadAu
 			clientId: clientId.trim(),
 			clientSecret: clientSecret?.trim() || undefined
 		};
+	}
+
+	async $promptForResourceClientSecret(resourceClientId: string, resource: string): Promise<string | undefined> {
+		// Surface to the user that whatever they enter (including blank == none) will be remembered
+		// in OS secret storage, scoped to the MCP server URL + the resource client_id. This means:
+		//   - the codelens above `oauth.clientId` in mcp.json will flip to "Replace Client Secret"
+		//   - subsequent runs read the secret directly from storage and never re-prompt.
+		//
+		// Return contract:
+		//   - `undefined` — user pressed Escape (cancelled). Caller should NOT cache; re-prompt allowed.
+		//   - `''` (empty string) — user pressed Enter with blank input ("no secret"). Caller SHOULD
+		//     cache this as an explicit answer (public client / token_endpoint_auth_method=none).
+		//   - `'value'` — user supplied a secret.
+		const value = await this.quickInputService.input({
+			title: nls.localize('xaaResourceSecretTitle', "Resource Client Secret Required"),
+			prompt: nls.localize(
+				'xaaResourceSecretPrompt',
+				"The resource at '{0}' uses a per-resource client identifier '{1}'. Enter the matching client secret (leave blank if none). The value is saved in OS secret storage; manage it later via the 'Set Client Secret' code lens in mcp.json.",
+				resource,
+				resourceClientId,
+			),
+			placeHolder: nls.localize('xaaResourceSecretPlaceholder', "Resource client secret"),
+			password: true,
+			ignoreFocusLost: true,
+		});
+		if (value === undefined) {
+			// User cancelled (Escape). Don't persist anything.
+			return undefined;
+		}
+		const trimmed = value.trim();
+		const key = mcpOAuthClientSecretStorageKey(resource, resourceClientId);
+		try {
+			if (trimmed.length === 0) {
+				// Blank-on-confirm means "no client secret" (e.g. token_endpoint_auth_method=none).
+				// Clear any stale value so subsequent prompts can still capture a fresh secret if needed.
+				await this.secretStorageService.delete(key);
+			} else {
+				await this.secretStorageService.set(key, trimmed);
+			}
+		} catch (err) {
+			this.logService.warn(`[XAA] Failed to persist resource client secret for ${resource} / ${resourceClientId}: ${(err as Error).message}`);
+		}
+		// Distinct from cancel: return '' (not undefined) for blank-on-confirm so callers can
+		// proceed without a client secret instead of treating it as a cancel.
+		return trimmed;
 	}
 }

--- a/src/vs/workbench/api/browser/mainThreadMcp.ts
+++ b/src/vs/workbench/api/browser/mainThreadMcp.ts
@@ -14,6 +14,7 @@ import { URI, UriComponents } from '../../../base/common/uri.js';
 import { generateUuid } from '../../../base/common/uuid.js';
 import * as nls from '../../../nls.js';
 import { ContextKeyExpr, IContextKeyService } from '../../../platform/contextkey/common/contextkey.js';
+import { IConfigurationService } from '../../../platform/configuration/common/configuration.js';
 import { IDialogService, IPromptButton } from '../../../platform/dialogs/common/dialogs.js';
 import { ExtensionIdentifier } from '../../../platform/extensions/common/extensions.js';
 import { LogLevel } from '../../../platform/log/common/log.js';
@@ -22,6 +23,7 @@ import { ISecretStorageService } from '../../../platform/secrets/common/secrets.
 import { IWorkbenchMcpGatewayService } from '../../contrib/mcp/common/mcpGatewayService.js';
 import { IMcpMessageTransport, IMcpRegistry } from '../../contrib/mcp/common/mcpRegistryTypes.js';
 import { extensionPrefixedIdentifier, McpCollectionDefinition, McpCollectionSortOrder, McpConnectionState, McpServerDefinition, McpServerLaunch, McpServerTransportType, McpServerTrust, mcpOAuthClientSecretStorageKey, UserInteractionRequiredError } from '../../contrib/mcp/common/mcpTypes.js';
+import { IMcpEnterpriseManagedAuthIdpConfig, mcpEnterpriseManagedAuthIdpSection } from '../../contrib/mcp/common/mcpConfiguration.js';
 import { MCP } from '../../contrib/mcp/common/modelContextProtocol.js';
 import { IAuthenticationMcpAccessService } from '../../services/authentication/browser/authenticationMcpAccessService.js';
 import { IAuthenticationMcpService } from '../../services/authentication/browser/authenticationMcpService.js';
@@ -62,6 +64,7 @@ export class MainThreadMcp extends Disposable implements MainThreadMcpShape {
 		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 		@IWorkbenchMcpGatewayService private readonly _mcpGatewayService: IWorkbenchMcpGatewayService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@ISecretStorageService private readonly _secretStorageService: ISecretStorageService,
 	) {
 		super();
@@ -237,6 +240,51 @@ export class MainThreadMcp extends Disposable implements MainThreadMcpShape {
 		const authorizationServer = URI.revive(authDetails.authorizationServer);
 		const resourceServer = authDetails.resourceMetadata?.resource ? URI.parse(authDetails.resourceMetadata.resource) : undefined;
 		const resolvedScopes = authDetails.scopes ?? authDetails.resourceMetadata?.scopes_supported ?? authDetails.authorizationServerMetadata.scopes_supported ?? [];
+
+		// Enterprise-managed servers route through an XAA / ID-JAG provider keyed by the user-configured
+		// SSO issuer instead of doing a per-server DCR against the resource's authorization server.
+		if (authDetails.enterpriseManaged) {
+			const resource = authDetails.resourceMetadata?.resource;
+			if (!resource) {
+				throw new Error(nls.localize('mcp.enterpriseManaged.missingResource', "The enterprise-managed MCP server '{0}' did not advertise a protected-resource metadata document with a 'resource' identifier.", server.label));
+			}
+			// Per ID-JAG (draft-ietf-oauth-identity-assertion-authz-grant), the token exchange
+			// `audience` is the *authorization server* of the resource — i.e. the issuer that will
+			// redeem the ID-JAG assertion. We pick the first server advertised by the resource's
+			// oauth-protected-resource metadata.
+			const resourceAuthServers = authDetails.resourceMetadata?.authorization_servers ?? [];
+			const audience = resourceAuthServers[0];
+			if (!audience) {
+				throw new Error(nls.localize('mcp.enterpriseManaged.missingAS', "The enterprise-managed MCP server '{0}' did not advertise an `authorization_servers` entry in its protected-resource metadata.", server.label));
+			}
+			// For XAA the scopes sent to the IdP token-exchange step are the *resource* scopes
+			// (e.g. "todos.read mcp.access"), NOT the IdP login scopes (openid/offline_access/…).
+			// `resolvedScopes` may have fallen through to `authorizationServerMetadata.scopes_supported`
+			// which is the IdP's metadata — wrong for this step. Use only the scopes derived from the
+			// WWW-Authenticate challenge or the resource's own metadata.
+			const xaaScopes = authDetails.scopes ?? authDetails.resourceMetadata?.scopes_supported ?? [];
+			const issuer = this._ensureXaaIssuer();
+			const xaaProviderId = await this._authenticationService.createOrGetXaaProvider(issuer);
+			if (!xaaProviderId) {
+				return undefined;
+			}
+			const resourceClientId = clientId ?? authDetails.clientId;
+			// Resolve the resource-AS client secret from secret storage, keyed by the resource indicator
+			// + the configured resource client_id. Set via the "Set Client Secret" code lens above
+			// `oauth.clientId` in mcp.json (the server URL equals the resource indicator per RFC 9470).
+			// Using `resource` (not the server launch URI) ensures the key matches what the prompt
+			// writes in $promptForResourceClientSecret, so prompted secrets survive window reload.
+			let resourceClientSecret: string | undefined;
+			if (resourceClientId) {
+				try {
+					resourceClientSecret = await this._secretStorageService.get(mcpOAuthClientSecretStorageKey(resource, resourceClientId));
+				} catch {
+					// Best-effort lookup; fall through.
+				}
+			}
+			return this._getSessionForProvider(id, server, xaaProviderId, xaaScopes, issuer, errorOnUserInteraction, resourceClientId, resource, audience, resourceClientSecret);
+		}
+
 		let providerId = await this._authenticationService.getOrActivateProviderIdForServer(authorizationServer, resourceServer);
 
 		const resolvedClientId = clientId ?? authDetails.clientId;
@@ -282,7 +330,25 @@ export class MainThreadMcp extends Disposable implements MainThreadMcpShape {
 			providerId = provider.id;
 		}
 
-		return this._getSessionForProvider(id, server, providerId, resolvedScopes, authorizationServer, errorOnUserInteraction, resolvedClientId, authDetails.resourceMetadata?.resource, clientSecret);
+		return this._getSessionForProvider(id, server, providerId, resolvedScopes, authorizationServer, errorOnUserInteraction, resolvedClientId, authDetails.resourceMetadata?.resource, /* audience */ undefined, clientSecret);
+	}
+
+	private _ensureXaaIssuer(): URI {
+		const config = this._configurationService.getValue<IMcpEnterpriseManagedAuthIdpConfig | undefined>(mcpEnterpriseManagedAuthIdpSection) ?? {};
+		const configuredIssuer = config.issuer?.trim();
+		if (!configuredIssuer) {
+			throw new Error(nls.localize('mcp.enterpriseManaged.issuerMissing', "Enterprise-managed MCP authentication requires `mcp.enterpriseManagedAuth.idp.issuer` to be configured. Set it via enterprise policy (Windows Group Policy / macOS managed preferences / Linux `/etc/vscode/policy.json`) or, for local testing, by hand-editing `settings.json`."));
+		}
+		let parsed: URI;
+		try {
+			parsed = URI.parse(configuredIssuer);
+		} catch {
+			throw new Error(nls.localize('mcp.enterpriseManaged.issuerInvalid', "Enterprise-managed MCP authentication requires `mcp.enterpriseManagedAuth.idp.issuer` to be a valid `https://` URL; got '{0}'.", configuredIssuer));
+		}
+		if (parsed.scheme !== 'https') {
+			throw new Error(nls.localize('mcp.enterpriseManaged.issuerNotHttps', "Enterprise-managed MCP authentication requires `mcp.enterpriseManagedAuth.idp.issuer` to use the `https` scheme; got '{0}'.", configuredIssuer));
+		}
+		return parsed;
 	}
 
 	private async _getSessionForProvider(
@@ -294,9 +360,10 @@ export class MainThreadMcp extends Disposable implements MainThreadMcpShape {
 		errorOnUserInteraction: boolean = false,
 		clientId?: string,
 		resource?: string,
+		audience?: string,
 		clientSecret?: string,
 	): Promise<string | undefined> {
-		const sessions = await this._authenticationService.getSessions(providerId, scopes, { authorizationServer, clientId, clientSecret, resource }, true);
+		const sessions = await this._authenticationService.getSessions(providerId, scopes, { authorizationServer, clientId, clientSecret, resource, audience }, true);
 		const accountNamePreference = this.authenticationMcpServersService.getAccountPreference(server.id, providerId);
 		let matchingAccountPreferenceSession: AuthenticationSession | undefined;
 		if (accountNamePreference) {
@@ -351,7 +418,8 @@ export class MainThreadMcp extends Disposable implements MainThreadMcpShape {
 						authorizationServer,
 						clientId,
 						clientSecret,
-						resource
+						resource,
+						audience
 					});
 			} while (
 				accountToCreate

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -213,6 +213,12 @@ export interface IRegisterDynamicAuthenticationProviderDetails extends IRegister
 	authorizationServer: UriComponents;
 }
 
+export interface IXaaProviderDiscovery {
+	issuer: UriComponents;
+	serverMetadata: IAuthorizationServerMetadata;
+	clientId?: string;
+}
+
 export interface MainThreadAuthenticationShape extends IDisposable {
 	$registerAuthenticationProvider(details: IRegisterAuthenticationProviderDetails): Promise<void>;
 	$unregisterAuthenticationProvider(id: string): Promise<void>;
@@ -225,6 +231,7 @@ export interface MainThreadAuthenticationShape extends IDisposable {
 	$showContinueNotification(message: string): Promise<boolean>;
 	$showDeviceCodeModal(userCode: string, verificationUri: string): Promise<boolean>;
 	$promptForClientRegistration(authorizationServerUrl: string): Promise<{ clientId: string; clientSecret?: string } | undefined>;
+	$promptForResourceClientSecret(resourceClientId: string, resource: string): Promise<string | undefined>;
 	$registerDynamicAuthenticationProvider(details: IRegisterDynamicAuthenticationProviderDetails): Promise<void>;
 	$setSessionsForDynamicAuthProvider(authProviderId: string, clientId: string, sessions: (IAuthorizationTokenResponse & { created_at: number })[]): Promise<void>;
 	$sendDidChangeDynamicProviderInfo({ providerId, clientId, authorizationServer, label, clientSecret }: { providerId: string; clientId?: string; authorizationServer?: UriComponents; label?: string; clientSecret?: string }): Promise<void>;
@@ -2486,6 +2493,7 @@ export interface ExtHostAuthenticationShape {
 	$onDidChangeAuthenticationSessions(id: string, label: string, extensionIdFilter?: string[]): Promise<void>;
 	$onDidUnregisterAuthenticationProvider(id: string): Promise<void>;
 	$registerDynamicAuthProvider(authorizationServer: UriComponents, serverMetadata: IAuthorizationServerMetadata, resource?: IAuthorizationProtectedResourceMetadata, clientId?: string, clientSecret?: string, initialTokens?: (IAuthorizationTokenResponse & { created_at: number })[]): Promise<string>;
+	$registerXaaAuthProvider(issuer: UriComponents, serverMetadata: IAuthorizationServerMetadata, clientId?: string, clientSecret?: string, initialTokens?: (IAuthorizationTokenResponse & { created_at: number })[]): Promise<string>;
 	$onDidChangeDynamicAuthProviderTokens(authProviderId: string, clientId: string, tokens?: (IAuthorizationTokenResponse & { created_at: number })[]): Promise<void>;
 }
 
@@ -3593,6 +3601,13 @@ export interface IMcpAuthenticationDetails {
 	resourceMetadata: IAuthorizationProtectedResourceMetadata | undefined;
 	scopes: string[] | undefined;
 	clientId?: string;
+	/**
+	 * When true, the MCP server has opted into enterprise-managed authentication
+	 * (OAuth Identity Assertion Authorization Grant). The main thread is expected
+	 * to route token acquisition through the XAA authentication provider for the
+	 * configured issuer rather than the per-resource dynamic auth provider.
+	 */
+	enterpriseManaged?: boolean;
 }
 
 export interface IMcpAuthenticationOptions {

--- a/src/vs/workbench/api/common/extHostAuthentication.ts
+++ b/src/vs/workbench/api/common/extHostAuthentication.ts
@@ -27,6 +27,7 @@ import { IExtHostProgress } from './extHostProgress.js';
 import { IProgressStep } from '../../../platform/progress/common/progress.js';
 import { CancellationError, isCancellationError } from '../../../base/common/errors.js';
 import { raceCancellationError, SequencerByKey } from '../../../base/common/async.js';
+import { XaaifyAuthProvider } from './extHostXaaAuthProvider.js';
 
 export interface IExtHostAuthentication extends ExtHostAuthentication { }
 export const IExtHostAuthentication = createDecorator<IExtHostAuthentication>('IExtHostAuthentication');
@@ -43,6 +44,7 @@ export class ExtHostAuthentication implements ExtHostAuthenticationShape {
 	declare _serviceBrand: undefined;
 
 	protected readonly _dynamicAuthProviderCtor = DynamicAuthProvider;
+	protected readonly _xaaAuthProviderCtor = XaaifyAuthProvider(DynamicAuthProvider);
 
 	private _proxy: MainThreadAuthenticationShape;
 	private _authenticationProviders: Map<string, ProviderWithMetadata> = new Map<string, ProviderWithMetadata>();
@@ -341,6 +343,75 @@ export class ExtHostAuthentication implements ExtHostAuthenticationShape {
 		return provider.id;
 	}
 
+	async $registerXaaAuthProvider(
+		issuerComponents: UriComponents,
+		serverMetadata: IAuthorizationServerMetadata,
+		clientId: string | undefined,
+		clientSecret: string | undefined,
+		initialTokens: IAuthorizationToken[] | undefined
+	): Promise<string> {
+		const issuer = URI.revive(issuerComponents);
+		// XAA does not use Dynamic Client Registration — the IdP must already trust the requesting
+		// app for the target audience(s). Always require an admin-provisioned client_id (and
+		// typically client_secret).
+		if (!clientId) {
+			this._logService.info(`Prompting user for client registration details for XAA issuer ${issuer.toString()}`);
+			const clientDetails = await this._proxy.$promptForClientRegistration(issuer.toString());
+			if (!clientDetails) {
+				throw new Error('User did not provide client details');
+			}
+			clientId = clientDetails.clientId;
+			clientSecret = clientDetails.clientSecret;
+		}
+		const provider = new this._xaaAuthProviderCtor(
+			this._extHostWindow,
+			this._extHostUrls,
+			this._initData,
+			this._extHostProgress,
+			this._extHostLoggerService,
+			this._proxy,
+			issuer,
+			serverMetadata,
+			/* resourceMetadata */ undefined,
+			clientId,
+			clientSecret,
+			this._onDidDynamicAuthProviderTokensChange,
+			initialTokens || []
+		);
+
+		await this._providerOperations.queue(provider.id, async () => {
+			this._authenticationProviders.set(
+				provider.id,
+				{
+					label: provider.label,
+					provider,
+					disposable: Disposable.from(
+						provider,
+						provider.onDidChangeSessions(e => this._proxy.$sendDidChangeSessions(provider.id, e)),
+						provider.onDidChangeClientId(() => this._proxy.$sendDidChangeDynamicProviderInfo({
+							providerId: provider.id,
+							clientId: provider.clientId,
+							clientSecret: provider.clientSecret
+						}))
+					),
+					options: { supportsMultipleAccounts: true }
+				}
+			);
+
+			await this._proxy.$registerDynamicAuthenticationProvider({
+				id: provider.id,
+				label: provider.label,
+				supportsMultipleAccounts: true,
+				authorizationServer: issuerComponents,
+				resourceServer: undefined,
+				clientId: provider.clientId,
+				clientSecret: provider.clientSecret
+			});
+		});
+
+		return provider.id;
+	}
+
 	async $onDidChangeDynamicAuthProviderTokens(authProviderId: string, clientId: string, tokens: IAuthorizationToken[]): Promise<void> {
 		this._onDidDynamicAuthProviderTokensChange.fire({ authProviderId, clientId, tokens });
 	}
@@ -362,7 +433,7 @@ class TaskSingler<T> {
 }
 
 export class DynamicAuthProvider implements vscode.AuthenticationProvider {
-	readonly id: string;
+	id: string;
 	readonly label: string;
 
 	private _onDidChangeSessions = new Emitter<vscode.AuthenticationProviderAuthenticationSessionsChangeEvent>();
@@ -808,14 +879,14 @@ export class DynamicAuthProvider implements vscode.AuthenticationProvider {
 	}
 }
 
-type IAuthorizationToken = IAuthorizationTokenResponse & {
+export type IAuthorizationToken = IAuthorizationTokenResponse & {
 	/**
 	 * The time when the token was created, in milliseconds since the epoch.
 	 */
 	created_at: number;
 };
 
-class TokenStore implements Disposable {
+export class TokenStore implements Disposable {
 	private readonly _tokensObservable: ISettableObservable<IAuthorizationToken[]>;
 	private readonly _sessionsObservable: IObservable<vscode.AuthenticationSession[]>;
 

--- a/src/vs/workbench/api/common/extHostMcp.ts
+++ b/src/vs/workbench/api/common/extHostMcp.ts
@@ -707,6 +707,7 @@ export class McpHTTPHandle extends Disposable {
 					resourceMetadata: this._authMetadata.resourceMetadata,
 					scopes: this._authMetadata.scopes,
 					clientId: this._launch.oauth?.clientId,
+					enterpriseManaged: this._launch.oauth?.enterpriseManaged,
 				};
 				const token = await this._proxy.$getTokenFromServerMetadata(
 					this._id,

--- a/src/vs/workbench/api/common/extHostXaaAuthProvider.ts
+++ b/src/vs/workbench/api/common/extHostXaaAuthProvider.ts
@@ -1,0 +1,393 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type * as vscode from 'vscode';
+import { stringHash } from '../../../base/common/hash.js';
+import { buildIdJagExchangeBody, buildResourceRedemptionBody, fetchAuthorizationServerMetadata, getClaimsFromJWT, IAuthorizationJWTClaims, IAuthorizationTokenResponse, isAuthorizationTokenResponse } from '../../../base/common/oauth.js';
+import { DynamicAuthProvider } from './extHostAuthentication.js';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Ctor<T> = new (...args: any[]) => T;
+
+/**
+ * Scopes used when bootstrapping the IdP session for an XAA flow.
+ *
+ * `openid` is required because the ID-JAG token exchange uses the IdP-issued
+ * `id_token` as `subject_token` (per draft-ietf-oauth-identity-assertion-authz-grant
+ * section 3.1, the subject token MUST be of type `urn:ietf:params:oauth:token-type:id_token`).
+ * `offline_access` is requested so we get a refresh token for the IdP session.
+ */
+export const IDP_SCOPES: readonly string[] = ['openid', 'offline_access'];
+
+interface IResourceCacheEntry {
+	readonly resource: string;
+	readonly scopes: readonly string[];
+	readonly token: IAuthorizationTokenResponse;
+	readonly created_at: number;
+}
+
+/** Cache key for resource-scoped tokens. Exported for testing. */
+export function cacheKey(resource: string, scopes: readonly string[]): string {
+	return resource + '|' + [...scopes].sort().join(' ');
+}
+
+/**
+ * Returns true if the cached token is past (or within 60s of) its expiry. Pure
+ * and exported for testing.
+ *
+ * Mints fresh ID-JAG assertions are usually short-lived (minutes). We treat tokens as expired
+ * 60s before their nominal expiry to avoid clock skew and in-flight redemptions racing past
+ * `exp`. Tokens without `expires_in` defined are treated as never-expiring (cached
+ * until the process exits); `expires_in: 0` is treated as immediately expired.
+ */
+export function isExpired(entry: { token: { expires_in?: number }; created_at: number }, now: number = Date.now()): boolean {
+	if (entry.token.expires_in === undefined) {
+		return false;
+	}
+	return now > entry.created_at + (entry.token.expires_in * 1000) - 60_000;
+}
+
+/**
+ * (Preview) Mixin that turns a {@link DynamicAuthProvider} subclass into a
+ * Cross App Access (XAA) / enterprise-managed authentication provider, per
+ * `draft-ietf-oauth-identity-assertion-authz-grant`.
+ *
+ * The IdP login leg is identical to the base class — Auth Code + PKCE against
+ * the org-configured issuer, using the pre-registered client credentials. On
+ * top of that:
+ *
+ *   1. `createSession` ensures an IdP session exists (delegated to the base
+ *      class with {@link IDP_SCOPES}).
+ *   2. It POSTs to the IdP token endpoint with `grant_type=token-exchange`,
+ *      `subject_token=<id_token>`, `subject_token_type=id_token`,
+ *      `requested_token_type=id-jag`, `audience=<resource AS>`,
+ *      `resource=<resource indicator>`, `scope=<requested scopes>` to mint an
+ *      ID-JAG.
+ *   3. It discovers the resource's authorization server metadata (the audience
+ *      URL) and POSTs the ID-JAG to its token endpoint with
+ *      `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer`,
+ *      `assertion=<id-jag>`, `resource=<resource indicator>`,
+ *      `scope=<requested scopes>` to obtain a resource-scoped access token.
+ *   4. The resource-scoped token is cached in-memory per `(resource, scopes)`
+ *      and returned as the session's access token.
+ *
+ * The resource indicator is read from `options.resource` (RFC 8707) and the
+ * resource's authorization server URL from `options.audience` on
+ * {@link vscode.AuthenticationProviderSessionOptions}.
+ */
+export function XaaifyAuthProvider<TBase extends Ctor<DynamicAuthProvider>>(Base: TBase): TBase {
+	return class XaaAuthenticationProvider extends Base {
+		private readonly _resourceTokens = new Map<string, IResourceCacheEntry>();
+		/**
+		 * Per-(resource, client_id) client secrets. Lazily populated via the main-thread
+		 * prompt. Keyed by both the resource indicator and the client_id because two
+		 * different resources may legitimately share a client_id but require different
+		 * secrets — keying by client_id alone could send the wrong secret to the wrong AS.
+		 */
+		private readonly _resourceClientSecrets = new Map<string, string>();
+
+		/** Compound key for {@link _resourceClientSecrets}, matching main-thread secret storage scoping. */
+		private _resourceClientSecretKey(resource: string, clientId: string): string {
+			return `${resource}|${clientId}`;
+		}
+
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		constructor(...args: any[]) {
+			super(...args);
+			// `authorizationServer` is exposed as a readonly field by the base class — use it
+			// directly instead of indexing into `args` so this can't silently break if the
+			// base constructor signature changes.
+			const issuer = this.authorizationServer;
+			this.id = `xaa:${issuer.toString(true)}`;
+			this._logger.trace(`[XAA] Provider constructed for issuer ${issuer.toString(true)}. authorization_endpoint=${this._serverMetadata.authorization_endpoint}, token_endpoint=${this._serverMetadata.token_endpoint}`);
+		}
+
+		override async getSessions(scopes: readonly string[] | undefined, options: vscode.AuthenticationProviderSessionOptions): Promise<vscode.AuthenticationSession[]> {
+			const resource = options.resource;
+			const audience = options.audience;
+			if (!resource || !scopes || !audience) {
+				return [];
+			}
+			// 1. Fast path: in-memory cache from a prior createSession/getSessions in this window.
+			const key = cacheKey(resource, scopes);
+			const entry = this._resourceTokens.get(key);
+			if (entry && !isExpired(entry)) {
+				return [toSession(entry.token, entry.scopes)];
+			}
+			if (entry) {
+				// Expired — drop and try to silently re-mint below.
+				this._resourceTokens.delete(key);
+			}
+
+			// 2. Silent re-mint: the base DynamicAuthProvider persists the IdP session in secret
+			//    storage, so on window reload we can pick it up and re-run legs 2-4 (ID-JAG exchange
+			//    + resource redemption) without any user interaction. Per the IAuthenticationProvider
+			//    contract, getSessions MUST NOT prompt — if anything is missing we just return [].
+			const idpSession = await this._tryGetSilentIdpSession();
+			if (!idpSession?.idToken) {
+				return [];
+			}
+			try {
+				const minted = await this._mintResourceToken(idpSession, [...scopes], audience, resource, options, /* silent */ true);
+				if (!minted) {
+					return [];
+				}
+				return [toSession(minted.token, minted.scopes)];
+			} catch (err) {
+				// Silent path: log and fall back to "no session" so the caller decides whether
+				// to escalate to createSession (which is allowed to interact).
+				this._logger.warn(`[XAA] Silent token mint failed for resource=${resource}; falling back to interactive. Error: ${(err as Error).message}`);
+				return [];
+			}
+		}
+
+		override async createSession(scopes: string[], options: vscode.AuthenticationProviderSessionOptions): Promise<vscode.AuthenticationSession> {
+			const audience = options.audience;
+			const resource = options.resource;
+			this._logger.trace(`[XAA] createSession scopes=[${scopes.join(' ')}] audience=${audience} resource=${resource}`);
+			if (!audience) {
+				throw new Error('Enterprise-managed authentication requires `options.audience` (the resource\'s authorization server URL) but none was provided.');
+			}
+			if (!resource) {
+				throw new Error('Enterprise-managed authentication requires `options.resource` (the resource indicator / MCP server URL) but none was provided.');
+			}
+
+			// Ensure IdP session via the base class (may interact). Don't pass the XAA options through —
+			// the IdP login leg is unrelated to the resource/audience, and the base provider would
+			// otherwise look for cached tokens scoped by a foreign audience.
+			const idpSession = await this._ensureIdpSession();
+			if (!idpSession.idToken) {
+				throw new Error('IdP session is missing an id_token; the issuer must support OpenID Connect and the `openid` scope.');
+			}
+
+			const minted = await this._mintResourceToken(idpSession, scopes, audience, resource, options, /* silent */ false);
+			if (!minted) {
+				// `silent=false` only returns undefined if the mint logic itself decided to bail.
+				// Today the only such path is missing resource client_secret, which prompts the user;
+				// if the prompt is dismissed we still try the redemption with `undefined` (valid for
+				// `token_endpoint_auth_method=none`). So in practice this branch is unreachable for
+				// silent=false — guard defensively anyway.
+				throw new Error('Failed to mint a resource access token for the enterprise-managed MCP server.');
+			}
+			return toSession(minted.token, minted.scopes);
+		}
+
+		/**
+		 * Mints a resource-scoped access token by running legs 2-4 of the XAA flow:
+		 *   2. Exchange IdP id_token → ID-JAG (RFC 8693 token exchange at issuer)
+		 *   3. Discover the resource AS token endpoint
+		 *   4. Redeem the ID-JAG at the resource AS for an access token (RFC 7523 jwt-bearer grant)
+		 *
+		 * When `silent` is true, this method MUST NOT prompt the user. If the resource AS uses a
+		 * distinct client_id (xaa.dev's "{client}-at-{resource}" pattern) and no client_secret can
+		 * be resolved without prompting, this returns `undefined`.
+		 *
+		 * Caches the resulting token in `_resourceTokens` so subsequent getSessions are O(1).
+		 */
+		private async _mintResourceToken(
+			idpSession: vscode.AuthenticationSession,
+			scopes: string[],
+			audience: string,
+			resource: string,
+			options: vscode.AuthenticationProviderSessionOptions,
+			silent: boolean,
+		): Promise<IResourceCacheEntry | undefined> {
+			// Leg 2: id_token → ID-JAG
+			const jag = await this._exchangeForIdJag(idpSession.idToken!, audience, resource, scopes);
+
+			// Leg 3: resource AS token endpoint
+			const resourceTokenEndpoint = await this._discoverResourceTokenEndpoint(audience);
+
+			// Leg 4 prep: resolve the resource client_id.
+			// Per draft-ietf-oauth-identity-assertion-authz-grant section 3.2, the ID-JAG carries a
+			// `client_id` claim identifying the requesting app to the resource AS. This is often
+			// distinct from the IdP `client_id` (xaa.dev for example uses a
+			// `{idp_client_id}-at-{resource}` form), so we extract it from the assertion rather than
+			// reusing `this._clientId`. Caller-supplied `options.clientId` (from the MCP server's
+			// `oauth.clientId` config) takes precedence over the JAG-extracted value.
+			let resourceClientId = this._clientId;
+			let resourceClientIdFromJag = false;
+			const configuredResourceClientId = typeof options.clientId === 'string' && options.clientId.length > 0 ? options.clientId : undefined;
+			if (configuredResourceClientId) {
+				resourceClientId = configuredResourceClientId;
+				resourceClientIdFromJag = resourceClientId !== this._clientId;
+			} else {
+				try {
+					const jagClaims = getClaimsFromJWT(jag);
+					if (typeof jagClaims.client_id === 'string' && jagClaims.client_id.length > 0) {
+						resourceClientId = jagClaims.client_id;
+						resourceClientIdFromJag = resourceClientId !== this._clientId;
+					}
+				} catch (err) {
+					this._logger.warn(`[XAA] Could not decode ID-JAG to read resource client_id; falling back to IdP client_id. Error: ${(err as Error).message}`);
+				}
+			}
+
+			// Leg 4 prep: resolve the resource client_secret.
+			// If the resource AS uses a distinct client_id, it will reject `this._clientSecret`
+			// (the IdP secret) with `invalid_client`. The caller may supply the resource secret
+			// directly via `options.clientSecret` (resolved in `mainThreadMcp` from URL-scoped
+			// secret storage via the "Set Client Secret" code lens above `oauth.clientId` in
+			// mcp.json); otherwise we fall back to a cached per-resource secret or prompt the
+			// user. We pass `undefined` if the user leaves the prompt blank — that's valid for
+			// clients registered with `token_endpoint_auth_method=none`.
+			let resourceClientSecret: string | undefined = this._clientSecret;
+			const configuredResourceClientSecret = typeof options.clientSecret === 'string' && options.clientSecret.length > 0 ? options.clientSecret : undefined;
+			const secretCacheKey = this._resourceClientSecretKey(resource, resourceClientId);
+			if (configuredResourceClientSecret) {
+				resourceClientSecret = configuredResourceClientSecret;
+				this._resourceClientSecrets.set(secretCacheKey, configuredResourceClientSecret);
+			} else if (resourceClientIdFromJag) {
+				if (this._resourceClientSecrets.has(secretCacheKey)) {
+					resourceClientSecret = this._resourceClientSecrets.get(secretCacheKey);
+				} else if (silent) {
+					// Silent path: the only way to obtain the resource client_secret here is to
+					// prompt the user — which we can't do. Bail; the caller will escalate to
+					// createSession (allowed to interact) if it needs the token.
+					this._logger.info(`[XAA] Silent mint requires resource client_secret for '${resourceClientId}' but none is cached or configured; deferring to interactive flow.`);
+					return undefined;
+				} else {
+					this._logger.info(`[XAA] Resource AS requires a distinct client_id '${resourceClientId}' — prompting for matching client_secret.`);
+					const promptedSecret = await this._proxy.$promptForResourceClientSecret(resourceClientId, resource);
+					if (promptedSecret === undefined) {
+						// User cancelled — don't cache, so re-prompt is possible on next call.
+						return undefined;
+					}
+					// Blank-on-confirm is a valid answer (public client / token_endpoint_auth_method=none).
+					// The main thread returns '' for that case, undefined for cancel.
+					this._resourceClientSecrets.set(secretCacheKey, promptedSecret);
+					resourceClientSecret = promptedSecret.length > 0 ? promptedSecret : undefined;
+				}
+			}
+
+			// Leg 4: redemption.
+			const resourceToken = await this._redeemAtResource(resourceTokenEndpoint, jag, resource, scopes, resourceClientId, resourceClientSecret);
+
+			const entry: IResourceCacheEntry = {
+				resource,
+				scopes,
+				token: resourceToken,
+				created_at: Date.now(),
+			};
+			this._resourceTokens.set(cacheKey(resource, scopes), entry);
+			return entry;
+		}
+
+		/**
+		 * Returns the IdP session if one is available without any user interaction, otherwise
+		 * `undefined`. Critically does NOT call `super.createSession`, so this is safe to use
+		 * from {@link getSessions}.
+		 */
+		private async _tryGetSilentIdpSession(): Promise<vscode.AuthenticationSession | undefined> {
+			const cleanOptions: vscode.AuthenticationProviderSessionOptions = {};
+			const existing = await super.getSessions(IDP_SCOPES as string[], cleanOptions);
+			return existing.length ? existing[0] : undefined;
+		}
+
+		private async _ensureIdpSession(): Promise<vscode.AuthenticationSession> {
+			this._logger.trace(`[XAA] _ensureIdpSession: scopes=[${IDP_SCOPES.join(' ')}] authorization_endpoint=${this._serverMetadata.authorization_endpoint}`);
+			const silent = await this._tryGetSilentIdpSession();
+			if (silent?.idToken) {
+				this._logger.trace(`[XAA] _ensureIdpSession: reusing existing IdP session`);
+				return silent;
+			}
+			this._logger.trace(`[XAA] _ensureIdpSession: creating new IdP session via super.createSession`);
+			return super.createSession([...IDP_SCOPES], {});
+		}
+
+		private async _exchangeForIdJag(idToken: string, audience: string, resource: string, scopes: string[]): Promise<string> {
+			const tokenEndpoint = this._serverMetadata.token_endpoint;
+			if (!tokenEndpoint) {
+				throw new Error('Issuer metadata is missing token_endpoint; cannot perform XAA token exchange.');
+			}
+			const body = buildIdJagExchangeBody(this._clientId, this._clientSecret, idToken, audience, resource, scopes);
+			this._logger.trace(`[XAA] POST ${tokenEndpoint} (ID-JAG exchange) audience=${audience} resource=${resource} scope=${scopes.join(' ')}`);
+			const response = await fetch(tokenEndpoint, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+					'Accept': 'application/json',
+				},
+				body: body.toString(),
+			});
+			if (!response.ok) {
+				throw new Error(`XAA token exchange (IdP) failed: ${response.status} ${await safeText(response)}`);
+			}
+			const data: unknown = await response.json();
+			const issued = (data && typeof data === 'object' && typeof (data as { access_token?: unknown }).access_token === 'string')
+				? (data as { access_token: string }).access_token
+				: undefined;
+			if (!issued) {
+				throw new Error(`XAA token exchange (IdP) returned no access_token. Response: ${JSON.stringify(data)}`);
+			}
+			return issued;
+		}
+
+		private async _discoverResourceTokenEndpoint(audience: string): Promise<string> {
+			const { metadata, errors } = await fetchAuthorizationServerMetadata(audience);
+			if (!metadata?.token_endpoint) {
+				throw new Error(`Failed to discover resource authorization server metadata for '${audience}': ${errors.map(e => e.message).join('; ') || 'no token_endpoint in metadata'}`);
+			}
+			return metadata.token_endpoint;
+		}
+
+		private async _redeemAtResource(tokenEndpoint: string, idJag: string, resource: string, scopes: string[], resourceClientId: string, resourceClientSecret: string | undefined): Promise<IAuthorizationTokenResponse> {
+			const body = buildResourceRedemptionBody(resourceClientId, resourceClientSecret, idJag, resource, scopes);
+			this._logger.trace(`[XAA] POST ${tokenEndpoint} (ID-JAG redemption) client_id=${resourceClientId} resource=${resource} scope=${scopes.join(' ')}`);
+			const response = await fetch(tokenEndpoint, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+					'Accept': 'application/json',
+				},
+				body: body.toString(),
+			});
+			if (!response.ok) {
+				throw new Error(`XAA token exchange (resource) failed: ${response.status} ${await safeText(response)}`);
+			}
+			const data = await response.json();
+			if (!isAuthorizationTokenResponse(data)) {
+				throw new Error(`XAA token exchange (resource) returned an invalid token response: ${JSON.stringify(data)}`);
+			}
+			return data;
+		}
+	};
+}
+
+function toSession(token: IAuthorizationTokenResponse, scopes: readonly string[]): vscode.AuthenticationSession {
+	let claims: IAuthorizationJWTClaims | undefined;
+	if (token.id_token) {
+		try {
+			claims = getClaimsFromJWT(token.id_token);
+		} catch {
+			// ignore
+		}
+	}
+	if (!claims) {
+		try {
+			claims = getClaimsFromJWT(token.access_token);
+		} catch {
+			// ignore
+		}
+	}
+	return {
+		id: stringHash(token.access_token, 0).toString(),
+		accessToken: token.access_token,
+		account: {
+			id: claims?.sub || 'unknown',
+			label: claims?.preferred_username || claims?.name || claims?.email || 'XAA',
+		},
+		scopes: [...scopes],
+		idToken: token.id_token,
+	};
+}
+
+async function safeText(response: Response): Promise<string> {
+	try {
+		return await response.text();
+	} catch {
+		return response.statusText;
+	}
+}

--- a/src/vs/workbench/api/node/extHostAuthentication.ts
+++ b/src/vs/workbench/api/node/extHostAuthentication.ts
@@ -7,6 +7,7 @@ import * as nls from '../../../nls.js';
 import type * as vscode from 'vscode';
 import { URL } from 'url';
 import { ExtHostAuthentication, DynamicAuthProvider, IExtHostAuthentication } from '../common/extHostAuthentication.js';
+import { XaaifyAuthProvider } from '../common/extHostXaaAuthProvider.js';
 import { IExtHostRpcService } from '../common/extHostRpcService.js';
 import { IExtHostInitDataService } from '../common/extHostInitDataService.js';
 import { IExtHostWindow } from '../common/extHostWindow.js';
@@ -321,6 +322,7 @@ export class NodeDynamicAuthProvider extends DynamicAuthProvider {
 export class NodeExtHostAuthentication extends ExtHostAuthentication implements IExtHostAuthentication {
 
 	protected override readonly _dynamicAuthProviderCtor = NodeDynamicAuthProvider;
+	protected override readonly _xaaAuthProviderCtor = XaaifyAuthProvider(NodeDynamicAuthProvider);
 
 	constructor(
 		extHostRpc: IExtHostRpcService,

--- a/src/vs/workbench/api/test/browser/extHostXaaAuthProvider.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostXaaAuthProvider.test.ts
@@ -1,0 +1,62 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import {
+	cacheKey,
+	IDP_SCOPES,
+	isExpired,
+} from '../../common/extHostXaaAuthProvider.js';
+
+suite('XaaAuthProvider helpers', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('cacheKey is scope-order-independent', () => {
+		assert.strictEqual(
+			cacheKey('https://r.example.com', ['b', 'a']),
+			cacheKey('https://r.example.com', ['a', 'b'])
+		);
+	});
+
+	test('cacheKey distinguishes different audiences', () => {
+		assert.notStrictEqual(
+			cacheKey('https://r1.example.com', ['s']),
+			cacheKey('https://r2.example.com', ['s'])
+		);
+	});
+
+	test('isExpired treats tokens without expires_in as never expiring', () => {
+		assert.strictEqual(
+			isExpired({ token: {}, created_at: 0 }, Number.MAX_SAFE_INTEGER),
+			false
+		);
+	});
+
+	test('isExpired flags tokens within 60s of expiry as expired', () => {
+		const created_at = 1_000_000;
+		const expires_in = 3600;
+		// 60s before nominal expiry → already expired due to safety margin
+		const justInsideMargin = created_at + (expires_in * 1000) - 30_000;
+		assert.strictEqual(isExpired({ token: { expires_in }, created_at }, justInsideMargin), true);
+		// well before expiry
+		const earlier = created_at + 1000;
+		assert.strictEqual(isExpired({ token: { expires_in }, created_at }, earlier), false);
+	});
+
+	test('isExpired treats expires_in: 0 as immediately expired', () => {
+		// Distinguish from `expires_in === undefined` (which means "never"); zero must mean
+		// "already expired" so a malformed/edge-case AS response can't be served from cache.
+		assert.strictEqual(
+			isExpired({ token: { expires_in: 0 }, created_at: 1_000_000 }, 1_000_000),
+			true
+		);
+	});
+
+	test('IDP_SCOPES requests an OpenID session with refresh', () => {
+		assert.deepStrictEqual([...IDP_SCOPES].sort(), ['offline_access', 'openid']);
+	});
+});

--- a/src/vs/workbench/api/test/browser/mainThreadAuthentication.integrationTest.ts
+++ b/src/vs/workbench/api/test/browser/mainThreadAuthentication.integrationTest.ts
@@ -121,6 +121,7 @@ suite('MainThreadAuthentication', () => {
 			$removeSession: () => Promise.resolve(),
 			$onDidChangeAuthenticationSessions: () => Promise.resolve(),
 			$registerDynamicAuthProvider: () => Promise.resolve('test'),
+			$registerXaaAuthProvider: () => Promise.resolve('test'),
 			$onDidChangeDynamicAuthProviderTokens: () => Promise.resolve(),
 			$getSessionsFromChallenges: () => Promise.resolve([]),
 			// eslint-disable-next-line local/code-no-any-casts

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -38,7 +38,7 @@ import { IEditorResolverService, RegisteredEditorPriority } from '../../../servi
 import { IPathService } from '../../../services/path/common/pathService.js';
 import { IViewsService } from '../../../services/views/common/viewsService.js';
 import { AddConfigurationType, AssistedTypes } from '../../mcp/browser/mcpCommandsAddConfiguration.js';
-import { allDiscoverySources, discoverySourceSettingsLabel, McpCollisionBehavior, mcpDiscoverySection, mcpServerCollisionBehaviorSection, mcpServerSamplingSection } from '../../mcp/common/mcpConfiguration.js';
+import { allDiscoverySources, discoverySourceSettingsLabel, McpCollisionBehavior, mcpDiscoverySection, mcpEnterpriseManagedAuthIdpSection, mcpServerCollisionBehaviorSection, mcpServerSamplingSection } from '../../mcp/common/mcpConfiguration.js';
 import { ChatAgentNameService, ChatAgentService, IChatAgentNameService, IChatAgentService } from '../common/participants/chatAgents.js';
 import { CodeMapperService, ICodeMapperService } from '../common/editing/chatCodeMapperService.js';
 import '../common/widget/chatColors.js';
@@ -782,6 +782,41 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.mcp.ui.enabled', "Controls whether MCP servers can provide custom UI for tool invocations."),
 			default: true,
 			tags: ['experimental'],
+		},
+		[mcpEnterpriseManagedAuthIdpSection]: {
+			type: 'object',
+			default: {},
+			scope: ConfigurationScope.APPLICATION,
+			tags: ['preview', 'experimental'],
+			additionalProperties: false,
+			included: false,
+			properties: {
+				issuer: {
+					type: 'string',
+					format: 'uri',
+					markdownDescription: nls.localize('mcp.enterpriseManagedAuth.idp.issuer', "The OAuth/OIDC issuer URL of the SSO authorization server. Must be an `https://` URL."),
+				},
+				clientId: {
+					type: 'string',
+					markdownDescription: nls.localize('mcp.enterpriseManagedAuth.idp.clientId', "The OAuth client ID registered with the SSO issuer for this device."),
+				},
+				clientSecret: {
+					type: 'string',
+					markdownDescription: nls.localize('mcp.enterpriseManagedAuth.idp.clientSecret', "The OAuth client secret paired with `clientId`. Intended for local development only."),
+				},
+			},
+			markdownDescription: nls.localize('mcp.enterpriseManagedAuth.idp', "(Preview) The OAuth/OIDC IdP configuration used for enterprise-managed Model Context Protocol (MCP) servers. Typically delivered via enterprise policy (Windows Group Policy / macOS managed preferences / Linux `/etc/vscode/policy.json`); developers may hand-edit `settings.json` for local testing. Properties: `issuer` (HTTPS URL), `clientId`, `clientSecret`."),
+			policy: {
+				name: 'McpEnterpriseManagedAuthIdp',
+				category: PolicyCategory.InteractiveSession,
+				minimumVersion: '1.122',
+				localization: {
+					description: {
+						key: 'mcp.enterpriseManagedAuth.idp.policy',
+						value: nls.localize('mcp.enterpriseManagedAuth.idp.policy', "The OAuth/OIDC IdP configuration used for enterprise-managed Model Context Protocol (MCP) server authentication. Delivered through enterprise policy (Windows Group Policy, macOS managed preferences, Linux `/etc/vscode/policy.json`)."),
+					}
+				}
+			},
 		},
 		[mcpServerCollisionBehaviorSection]: {
 			type: 'string',

--- a/src/vs/workbench/contrib/mcp/browser/mcpLanguageFeatures.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpLanguageFeatures.ts
@@ -190,6 +190,7 @@ export class McpLanguageFeatures extends Disposable implements IWorkbenchContrib
 			}
 
 			const name = node.children[0].value as string;
+
 			const server = mcpServers.find(s => s.definition.label === name);
 			if (!server) {
 				continue;

--- a/src/vs/workbench/contrib/mcp/common/mcpConfiguration.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpConfiguration.ts
@@ -55,6 +55,25 @@ export const mcpConfigurationSection = 'mcp';
 export const mcpDiscoverySection = 'chat.mcp.discovery.enabled';
 export const mcpServerSamplingSection = 'chat.mcp.serverSampling';
 export const mcpServerCollisionBehaviorSection = 'chat.mcp.collisionBehavior';
+/**
+ * Configuration key for the enterprise-managed MCP IdP bag. The setting is
+ * registered with `included: false` so it is hidden from the Settings UI and
+ * settings.json IntelliSense; it is intended to be delivered through enterprise
+ * policy (Windows Group Policy / macOS managed preferences / Linux
+ * `/etc/vscode/policy.json`), with hand-editing of `settings.json` as a
+ * developer escape hatch.
+ */
+export const mcpEnterpriseManagedAuthIdpSection = 'mcp.enterpriseManagedAuth.idp';
+
+/**
+ * Shape of the {@link mcpEnterpriseManagedAuthIdpSection} setting. All fields
+ * are optional so partial configurations (e.g. just the issuer) remain valid.
+ */
+export interface IMcpEnterpriseManagedAuthIdpConfig {
+	readonly issuer?: string;
+	readonly clientId?: string;
+	readonly clientSecret?: string;
+}
 
 export const enum McpCollisionBehavior {
 	Disable = 'disable',
@@ -280,7 +299,12 @@ export const mcpServerSchema: IJSONSchema = {
 									clientId: {
 										type: 'string',
 										minLength: 1,
-										markdownDescription: localize('app.mcp.json.oauth.clientId', "The OAuth client ID to use when authenticating with the server. To set the matching client secret securely, use the *Set Client Secret* code lens above this field — secrets are stored in the OS secret store, not in this file.")
+										markdownDescription: localize('app.mcp.json.oauth.clientId', "The OAuth client ID to use when authenticating with the server. When `enterpriseManaged` is `true`, this is the **resource** authorization server's client ID (the client trusted by the protected resource), not the IdP's. To set the matching client secret, use the *Set Client Secret* code lens above this field — secrets are stored in the OS secret store, not in this file.")
+									},
+									enterpriseManaged: {
+										type: 'boolean',
+										default: false,
+										markdownDescription: localize('app.mcp.json.oauth.enterpriseManaged', "(Preview) When set to `true`, this MCP server authenticates through the SSO issuer configured by `#mcp.enterpriseManagedAuth.idp#` using OAuth Identity Assertion Authorization Grant (ID-JAG). After a one-time sign-in, subsequent enterprise-managed servers connect silently. The IdP issuer and client credentials are read from the `#mcp.enterpriseManagedAuth.idp#` setting; the `clientId` on this server entry is passed to the resource authorization server.")
 									}
 								}
 							},

--- a/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
@@ -545,6 +545,13 @@ export interface McpServerTransportHTTPAuthentication {
 
 export interface McpServerTransportHTTPOAuth {
 	readonly clientId?: string;
+	/**
+	 * (Preview) When true, the MCP server uses enterprise-managed authentication via the configured
+	 * SSO issuer (see `mcp.enterpriseManagedAuth.idp`). Tokens are obtained through OAuth Identity
+	 * Assertion Authorization Grant (ID-JAG) so that, after a one-time sign-in, subsequent enterprise-managed
+	 * servers connect silently.
+	 */
+	readonly enterpriseManaged?: boolean;
 }
 
 /**

--- a/src/vs/workbench/services/authentication/browser/authenticationService.ts
+++ b/src/vs/workbench/services/authentication/browser/authenticationService.ts
@@ -381,6 +381,25 @@ export class AuthenticationService extends Disposable implements IAuthentication
 		return undefined;
 	}
 
+	async createOrGetXaaProvider(issuer: URI): Promise<string | undefined> {
+		const providerId = `xaa:${issuer.toString(true)}`;
+		if (this._authenticationProviders.has(providerId)) {
+			return providerId;
+		}
+		const delegate = this._delegates.find(d => !!d.createXaa);
+		if (!delegate) {
+			this._logService.error('No authentication provider host delegate supports XAA');
+			return undefined;
+		}
+		const created = await delegate.createXaa!(issuer);
+		if (this._authenticationProviders.has(created)) {
+			this._logService.debug(`Created XAA authentication provider: ${created}`);
+			return created;
+		}
+		this._logService.error(`Failed to create XAA authentication provider for issuer: ${issuer.toString(true)}`);
+		return undefined;
+	}
+
 	registerAuthenticationProviderHostDelegate(delegate: IAuthenticationProviderHostDelegate): IDisposable {
 		this._delegates.push(delegate);
 		this._delegates.sort((a, b) => b.priority - a.priority);

--- a/src/vs/workbench/services/authentication/common/authentication.ts
+++ b/src/vs/workbench/services/authentication/common/authentication.ts
@@ -59,6 +59,13 @@ export interface IAuthenticationCreateSessionOptions {
 	 */
 	resource?: string;
 	/**
+	 * The audience for the requested access token. Primarily used for OAuth Identity Assertion
+	 * Authorization Grant (ID-JAG, defined in `draft-ietf-oauth-identity-assertion-authz-grant` using RFC 8693 token-exchange semantics) flows where the audience identifies the authorization server of the resource that
+	 * will redeem the assertion (typically the resource's authorization server URL). Providers that do not understand audience-bound tokens should
+	 * ignore this option.
+	 */
+	audience?: string;
+	/**
 	 * Allows the authentication provider to take in additional parameters.
 	 * It is up to the provider to define what these parameters are and handle them.
 	 * This is useful for passing in additional information that is specific to the provider
@@ -127,6 +134,13 @@ export interface IAuthenticationGetSessionsOptions {
 	 */
 	resource?: string;
 	/**
+	 * The audience for the requested access token. Primarily used for OAuth Identity Assertion
+	 * Authorization Grant (ID-JAG, defined in `draft-ietf-oauth-identity-assertion-authz-grant` using RFC 8693 token-exchange semantics) flows where the audience identifies the authorization server of the resource that
+	 * will redeem the assertion (typically the resource's authorization server URL). Providers that do not understand audience-bound tokens should
+	 * ignore this option.
+	 */
+	audience?: string;
+	/**
 	 * Allows the authentication provider to take in additional parameters.
 	 * It is up to the provider to define what these parameters are and handle them.
 	 * This is useful for passing in additional information that is specific to the provider
@@ -153,6 +167,11 @@ export interface IAuthenticationProviderHostDelegate {
 	/** Priority for this delegate, delegates are tested in descending priority order */
 	readonly priority: number;
 	create(authorizationServer: URI, serverMetadata: IAuthorizationServerMetadata, resource: IAuthorizationProtectedResourceMetadata | undefined, clientId?: string, clientSecret?: string): Promise<string>;
+	/**
+	 * Creates an XAA (enterprise-managed, ID-JAG) authentication provider for the given SSO issuer.
+	 * The returned string is the provider id.
+	 */
+	createXaa?(issuer: URI): Promise<string>;
 }
 
 export const IAuthenticationService = createDecorator<IAuthenticationService>('IAuthenticationService');
@@ -282,6 +301,15 @@ export interface IAuthenticationService {
 	 * @param serverMetadata The metadata for the server that is being authenticated against
 	 */
 	createDynamicAuthenticationProvider(authorizationServer: URI, serverMetadata: IAuthorizationServerMetadata, resourceMetadata: IAuthorizationProtectedResourceMetadata | undefined, clientId?: string, clientSecret?: string): Promise<IAuthenticationProvider | undefined>;
+
+	/**
+	 * Gets or creates a built-in XAA (enterprise-managed, ID-JAG) authentication provider for the given
+	 * SSO issuer. Subsequent calls with the same issuer return the existing provider. The returned id
+	 * can be used with {@link getSessions}/{@link createSession} just like any other provider.
+	 *
+	 * @param issuer The OAuth/OIDC issuer URL (typically read from `mcp.enterpriseManagedAuth.idp`).
+	 */
+	createOrGetXaaProvider(issuer: URI): Promise<string | undefined>;
 }
 
 export function isAuthenticationSession(thing: unknown): thing is AuthenticationSession {
@@ -391,6 +419,13 @@ export interface IAuthenticationProviderSessionOptions {
 	 * (RFC 8707 resource indicator).
 	 */
 	resource?: string;
+	/**
+	 * The audience for the requested access token. Primarily used for OAuth Identity Assertion
+	 * Authorization Grant (ID-JAG, defined in `draft-ietf-oauth-identity-assertion-authz-grant` using RFC 8693 token-exchange semantics) flows where the audience identifies the authorization server of the resource that
+	 * will redeem the assertion (typically the resource's authorization server URL). Providers that do not understand audience-bound tokens should
+	 * ignore this option.
+	 */
+	audience?: string;
 	/**
 	 * Allows the authentication provider to take in additional parameters.
 	 * It is up to the provider to define what these parameters are and handle them.

--- a/src/vs/workbench/services/authentication/test/browser/authenticationQueryServiceMocks.ts
+++ b/src/vs/workbench/services/authentication/test/browser/authenticationQueryServiceMocks.ts
@@ -342,6 +342,7 @@ export class TestAuthenticationService extends BaseTestService implements IAuthe
 	unregisterAuthenticationProvider(): void { }
 	registerAuthenticationProviderHostDelegate(): IDisposable { return { dispose: () => { } }; }
 	createDynamicAuthenticationProvider(): Promise<any> { return Promise.resolve(undefined); }
+	createOrGetXaaProvider(): Promise<string | undefined> { return Promise.resolve(undefined); }
 	async requestNewSession(): Promise<AuthenticationSession> { return createSession(); }
 	async getSession(): Promise<AuthenticationSession | undefined> { return createSession(); }
 	getOrActivateProviderIdForServer(): Promise<string | undefined> { return Promise.resolve(undefined); }

--- a/src/vscode-dts/vscode.proposed.authSessionAudience.d.ts
+++ b/src/vscode-dts/vscode.proposed.authSessionAudience.d.ts
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'vscode' {
+
+	// https://github.com/microsoft/vscode/issues/316625
+
+	export interface AuthenticationProviderSessionOptions {
+		/**
+		 * (Preview) The audience for the requested access token. Primarily used for OAuth Identity
+		 * Assertion Authorization Grant (ID-JAG; draft-ietf-oauth-identity-assertion-authz-grant)
+		 * flows where the audience is the authorization server URL of the resource that will redeem
+		 * the assertion. Combine with {@link resource} which carries the resource indicator (RFC 8707).
+		 * Providers that do not understand audience-bound tokens should ignore this option.
+		 */
+		audience?: string;
+	}
+
+	export interface AuthenticationGetSessionOptions {
+		/**
+		 * (Preview) The audience for the requested access token. Primarily used for OAuth Identity
+		 * Assertion Authorization Grant (ID-JAG) flows where the audience is the authorization server
+		 * URL of the resource that will redeem the assertion. Combine with {@link resource} (RFC 8707).
+		 */
+		audience?: string;
+	}
+}


### PR DESCRIPTION
## Motivation

Enterprises that centralize SSO at a single IdP (e.g. Entra, Okta, Auth0) don't want every MCP server to drive its own Dynamic Client Registration against its own authorization server. Instead, they want:

1. The user authenticates **once** against the enterprise IdP.
2. VS Code exchanges that IdP identity for a resource-scoped assertion via **ID-JAG** ([draft-ietf-oauth-identity-assertion-authz-grant](https://www.ietf.org/archive/id/draft-ietf-oauth-identity-assertion-authz-grant-03.txt)).
3. The assertion is redeemed at the MCP server's authorization server for an access token.

This PR adds that "XAA" (cross-app authorization) flow for MCP servers that opt in via `enterpriseManaged: true` in their `mcp.json` `oauth` block.

## The 3-leg flow

```
┌──────────┐  1. Auth Code + PKCE  ┌─────────┐
│   User   │ ────────────────────▶ │   IdP   │
└──────────┘   id_token + refresh  └─────────┘
                          │
                          ▼
┌────────────┐  2. token-exchange   ┌─────────┐
│  VS Code   │ ───────────────────▶ │   IdP   │
│ XAA mixin  │   subject=id_token   │ token   │
└────────────┘   audience=<AS>      │endpoint │
                                    └─────────┘
                          │ id-jag assertion
                          ▼
┌────────────┐  3. jwt-bearer       ┌──────────────┐
│  VS Code   │ ───────────────────▶ │  Resource AS │
│ XAA mixin  │   assertion=<jag>    │ token endpt  │
└────────────┘                      └──────────────┘
                          │ resource access_token
                          ▼
                  ┌──────────────┐
                  │  MCP server  │
                  └──────────────┘
```

## What's added

### `mcp.enterpriseManagedAuth.idp` setting (policy-managed)

Tenants supply IdP coordinates through a single setting object:

```jsonc
{
  "mcp.enterpriseManagedAuth.idp": {
    "issuer": "https://idp.example.com",
    "clientId": "vscode-mcp",
    "clientSecret": "..."   // optional for public clients
  }
}
```

Registered with `included: false` (hidden from Settings UI and IntelliSense) and a `policy` block (`McpEnterpriseManagedAuthIdp`) so it's primarily delivered via Group Policy / managed prefs / `/etc/vscode/policy.json`, but can also be set by hand in `settings.json` for local dev. `APPLICATION` scope = never syncs.

### `enterpriseManaged: true` in `mcp.json`

```jsonc
{
  "servers": {
    "todo0-mcp": {
      "url": "https://mcp.example.com/mcp",
      "oauth": {
        "enterpriseManaged": true,
        "clientId": "resource-client-id-at-mcp"
      }
    }
  }
}
```

When this flag is present, `mainThreadMcp` routes through `createOrGetXaaProvider(issuer)` instead of the standard per-server DCR path.

### Proposed API: `authSessionAudience`

Adds `audience?: string` to `AuthenticationProviderSessionOptions` so the XAA provider can receive the resource AS URL through the standard session options shape.

### `XaaAuthProvider` (extends `DynamicAuthProvider`)

The provider is a mixin that wraps the existing `DynamicAuthProvider` (so it gets PKCE / token endpoint discovery / refresh / OS secret storage for free) and layers legs 2-4 on top:

- `_mintResourceToken(silent)` runs legs 2-4 (ID-JAG exchange + resource AS redemption).
- `getSessions` attempts a fully silent re-mint on cache miss: reads the persisted IdP session from base-class secret storage, runs legs 2-4 with `silent: true`. **Window reload no longer loses auth state.**
- `createSession` is the interactive path: runs leg 1 if needed, then legs 2-4 with prompts allowed.
- Per-resource access tokens are cached in-memory keyed by `(resource, scopes)`.

### Resource-AS client secret storage

The resource's authorization server (separate from the IdP) may issue its own per-resource client credentials. These are stored in OS secret storage using the same key as the existing "Set Client Secret" codelens from #317950 — keyed by `(resource indicator, resource client_id)`. First-run prompt persists to storage so subsequent reloads are silent.

## Council review

3-model council (`GPT-5.5`, `Claude Opus 4.6`, `GPT-5.3-Codex`) reviewed the change set; all blocking findings are fixed in this PR:

1. **Argument shift broke non-enterprise `clientSecret`** — adding `audience` to `_getSessionForProvider`'s signature shifted `clientSecret` into the `audience` slot at the existing non-enterprise call site. ✅ Fixed.
2. **Cancel cached as "no secret"** — cancelling the resource client-secret prompt was permanently suppressing re-prompts in the same window. ✅ Fixed — cancel now returns early without caching.
3. **Storage key mismatch between prompt-write and XAA-read** — prompt wrote with the protected-resource indicator; XAA read with `server.launch.uri.toString(true)`. ✅ Fixed — both now use the resource indicator.

## Testing

E2E verified locally end-to-end via Code OSS Dev against the [xaa.dev](https://xaa.dev) sample IdP / resource AS / MCP server trio:

1. Configure `mcp.enterpriseManagedAuth.idp` and an `enterpriseManaged: true` server.
2. Start the server → IdP browser flow → resource client-secret prompt → MCP server reaches **Running**.
3. **Reload window** → start the same server → **no prompts**, silent re-mint of resource token from persisted IdP session.
4. Cancel the resource-secret prompt → next attempt re-prompts (no longer permanently suppressed).
5. Non-enterprise OAuth MCP servers (the existing `client_secret` flow from #317950) still work — `clientSecret` is no longer dropped at the call site.

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
