### PR TITLE
Highlight symbol body when revealing from notebook outline

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/outline/notebookOutline.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/outline/notebookOutline.ts
@@ -18,7 +18,7 @@ import { URI } from '../../../../../../base/common/uri.js';
 import { getIconClassesForLanguageId } from '../../../../../../editor/common/services/getIconClasses.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../../../../../platform/configuration/common/configurationRegistry.js';
-import { IEditorOptions } from '../../../../../../platform/editor/common/editor.js';
+import { IEditorOptions, ITextEditorSelection } from '../../../../../../platform/editor/common/editor.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { IWorkbenchDataTreeOptions } from '../../../../../../platform/list/browser/listService.js';
 import { MarkerSeverity } from '../../../../../../platform/markers/common/markers.js';
@@ -736,12 +736,21 @@ export class NotebookCellOutline implements IOutline<OutlineEntry> {
 		this.delayerRecomputeActive.trigger(() => { this.recomputeActive(); });
 	}
 
-	async reveal(entry: OutlineEntry, options: IEditorOptions, sideBySide: boolean): Promise<void> {
+	async reveal(entry: OutlineEntry, options: IEditorOptions, sideBySide: boolean, select: boolean): Promise<void> {
+		// Match the document symbols outline behavior:
+		// - On select (double-click), highlight the full symbol body using `range`.
+		// - Otherwise (single-click), collapse the cursor to the start of the symbol name (`selectionRange`).
+		let selection: ITextEditorSelection | undefined = entry.position;
+		if (entry.range) {
+			selection = select
+				? entry.range
+				: Range.collapseToStart(entry.selectionRange ?? entry.range);
+		}
 		const notebookEditorOptions: INotebookEditorOptions = {
 			...options,
 			override: this._editor.input?.editorId,
 			cellRevealType: CellRevealType.Top,
-			selection: entry.position,
+			selection,
 			viewState: undefined,
 		};
 		await this._editorService.openEditor({

--- a/src/vs/workbench/contrib/notebook/browser/viewModel/OutlineEntry.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/OutlineEntry.ts
@@ -39,6 +39,7 @@ export class OutlineEntry {
 		readonly isPaused: boolean,
 		readonly range?: IRange,
 		readonly symbolKind?: SymbolKind,
+		readonly selectionRange?: IRange,
 	) { }
 
 	addChild(entry: OutlineEntry) {

--- a/src/vs/workbench/contrib/notebook/browser/viewModel/notebookOutlineEntryFactory.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/notebookOutlineEntryFactory.ts
@@ -24,6 +24,7 @@ export const enum NotebookOutlineConstants {
 type entryDesc = {
 	name: string;
 	range: IRange;
+	selectionRange: IRange;
 	level: number;
 	kind: SymbolKind;
 };
@@ -104,7 +105,7 @@ export class NotebookOutlineEntryFactory implements INotebookOutlineEntryFactory
 					// push code cell entry that is a parent of cached symbols, always necessary. filtering for quickpick done in that provider.
 					entries.push(new OutlineEntry(index++, NotebookOutlineConstants.NonHeaderOutlineLevel, cell, preview, !!exeState, exeState ? exeState.isPaused : false));
 					cached.forEach((entry) => {
-						entries.push(new OutlineEntry(index++, entry.level, cell, entry.name, false, false, entry.range, entry.kind));
+						entries.push(new OutlineEntry(index++, entry.level, cell, entry.name, false, false, entry.range, entry.kind, entry.selectionRange));
 					});
 				}
 			}
@@ -144,7 +145,7 @@ type documentSymbol = ReturnType<outlineModel['getTopLevelSymbols']>[number];
 function createOutlineEntries(symbols: documentSymbol[], level: number): entryDesc[] {
 	const entries: entryDesc[] = [];
 	symbols.forEach(symbol => {
-		entries.push({ name: symbol.name, range: symbol.range, level, kind: symbol.kind });
+		entries.push({ name: symbol.name, range: symbol.range, selectionRange: symbol.selectionRange, level, kind: symbol.kind });
 		if (symbol.children) {
 			entries.push(...createOutlineEntries(symbol.children, level + 1));
 		}


### PR DESCRIPTION
Fixes #209161

## Problem

Clicking a symbol entry in the notebook outline (Outline view, breadcrumbs, etc.) opens the cell and places the cursor at the start of the symbol, but does not highlight or select the symbol like the regular document symbols outline does in normal editors.

## Root cause

`NotebookCellOutline.reveal()` ignored the `select` parameter from the `IOutline.reveal()` interface and always passed `entry.position` (the start of `entry.range`, without an end position) as the selection. The canonical implementation in `documentSymbolsOutline.ts` switches on `select`:

```ts
selection: select ? entry.symbol.range : Range.collapseToStart(entry.symbol.selectionRange),
```

The notebook outline also wasn't storing `symbol.selectionRange` from the document symbols, so it had no way to follow the same pattern.

## Fix

- Capture `symbol.selectionRange` in `createOutlineEntries` and thread it through `OutlineEntry` as an optional `selectionRange` field next to `range`.
- In `NotebookCellOutline.reveal()`, honor the `select` parameter:
  - `select === true` (double-click) → use `entry.range` so the full symbol body is highlighted.
  - `select === false` (single-click) → use `Range.collapseToStart(entry.selectionRange ?? entry.range)` so the cursor lands at the symbol name without selecting it.

Entries without a `range` (e.g. the parent code-cell entries and markdown header entries that have no language-symbol range) fall back to the previous behavior via `entry.position`.

## Notes

This supersedes the stale draft #251149 and addresses the review feedback there: ranges *are* stored correctly (they come from the same `symbol.range` the editor outline uses), and the missing piece was honoring `select` and storing `selectionRange` so single-click vs double-click match the regular outline.