### PR TITLE
Join Lines: exclude trailing line when selection ends at column 1

### DIFF
--- a/src/vs/editor/contrib/linesOperations/browser/linesOperations.ts
+++ b/src/vs/editor/contrib/linesOperations/browser/linesOperations.ts
@@ -921,6 +921,30 @@ export class JoinLinesAction extends EditorAction {
 			return;
 		}
 
+		const model = editor.getModel();
+		if (model === null) {
+			return;
+		}
+
+		// If a selection ends at column 1 of a line, exclude that line from the
+		// operation. This matches the convention used by other line-based actions
+		// (e.g. Delete Line, Move Line, line comment) so that selecting N full
+		// lines via Shift+Down (which leaves the cursor at column 1 of line N+1)
+		// joins only the N selected lines, not N+1.
+		const trimTrailingLine = (s: Selection): Selection => {
+			if (s.startLineNumber < s.endLineNumber && s.endColumn === 1) {
+				return s.setEndPosition(s.endLineNumber - 1, model.getLineMaxColumn(s.endLineNumber - 1));
+			}
+			return s;
+		};
+		for (let i = 0; i < selections.length; i++) {
+			const trimmed = trimTrailingLine(selections[i]);
+			if (trimmed !== selections[i] && primaryCursor.equalsSelection(selections[i])) {
+				primaryCursor = trimmed;
+			}
+			selections[i] = trimmed;
+		}
+
 		selections.sort(Range.compareRangesUsingStarts);
 		const reducedSelections: Selection[] = [];
 
@@ -950,11 +974,6 @@ export class JoinLinesAction extends EditorAction {
 		});
 
 		reducedSelections.push(lastSelection);
-
-		const model = editor.getModel();
-		if (model === null) {
-			return;
-		}
 
 		const edits: ISingleEditOperation[] = [];
 		const endCursorState: Selection[] = [];

--- a/src/vs/editor/contrib/linesOperations/test/browser/linesOperations.test.ts
+++ b/src/vs/editor/contrib/linesOperations/test/browser/linesOperations.test.ts
@@ -572,6 +572,26 @@ suite('Editor Contrib - Line Operations', () => {
 				});
 		});
 
+		test('#201093 selection ending at column 1 of next line should not include that line', function () {
+			withTestCodeEditor(
+				[
+					'one',
+					'two',
+					'three',
+					'four'
+				], {}, (editor) => {
+					const model = editor.getModel()!;
+					const joinLinesAction = new JoinLinesAction();
+
+					// Simulates Shift+Down x3 from the start of line 1: the cursor lands at
+					// column 1 of line 4, but only lines 1-3 are visually "fully" selected.
+					editor.setSelection(new Selection(1, 1, 4, 1));
+					executeAction(joinLinesAction, editor);
+					assert.strictEqual(model.getLineContent(1), 'one two three');
+					assert.strictEqual(model.getLineContent(2), 'four');
+				});
+		});
+
 		test('should push undo stop', function () {
 			withTestCodeEditor(
 				[


### PR DESCRIPTION
Fixes #201093

### Problem

Selecting N full lines via Shift+Down leaves the cursor at column 1 of line N+1. The user's intent is "join these N lines", but `editor.action.joinLines` currently treats the selection as covering N+1 lines and pulls in the line after the last fully-selected one.

Example with `editor.setSelection(new Selection(1, 1, 4, 1))` on:
```
one
two
three
four
```
Before: `'one two three four'` (line 4 is incorrectly joined)
After:  `'one two three'` + `'four'` (only the 3 selected lines are joined)

This matches the behavior of IntelliJ IDEA and Notepad++.

### Fix

Every other line-based action in the editor already excludes the trailing line when a selection ends at column 1:

- `DeleteLinesAction._getLinesToRemove` (linesOperations.ts:570)
- `MoveLinesCommand` (moveLinesCommand.ts:80)
- `CopyLinesCommand` (copyLinesCommand.ts:37)
- `LineCommentCommand` (lineCommentCommand.ts:347)
- `SortLinesAction` (linesOperations.ts:404)
- `ReindentSelectedLinesAction` (indentation.ts:298)
- `FindController` (findController.ts:289), `FindWidget` (findWidget.ts:865 / 1117), `FindDecorations` (findDecorations.ts:144)

`JoinLinesAction` was the only line-based action missing this normalization. The fix applies the same `setEndPosition(endLineNumber - 1, lineMaxColumn(...))` pattern up front, so the rest of the logic — including the multi-cursor `reduce` and the cursor-restoration math via `selectionEndPositionOffset` — sees a consistent end position.

### Tests

Added `linesOperations.test.ts` case `#201093 selection ending at column 1 of next line should not include that line` covering the exact Shift+Down x3 scenario from the issue. All existing JoinLines tests still pass (none of them use a multi-line selection ending at column 1).