### PR TITLE
Messages API: skip historical thinking blocks to avoid 400s

### DIFF
--- a/extensions/copilot/src/extension/prompts/node/panel/toolCalling.tsx
+++ b/extensions/copilot/src/extension/prompts/node/panel/toolCalling.tsx
@@ -125,7 +125,7 @@ export class ChatToolCalls extends PromptElement<ChatToolCallsProps, void> {
 		// Backward compat: older persisted rounds use `phaseModelId` instead of `modelId`. Read both.
 		const roundModelId = round.modelId ?? (round as IToolCallRound & { phaseModelId?: string }).phaseModelId;
 		const sameModelAsEndpoint = roundModelId === this.promptEndpoint.model;
-		const apiSupportsHistoricalThinking = this.promptEndpoint.apiType === 'responses' || this.promptEndpoint.apiType === 'messages';
+		const apiSupportsHistoricalThinking = this.promptEndpoint.apiType === 'responses';
 		const includeThinking = sameModelAsEndpoint && (!this.props.isHistorical || apiSupportsHistoricalThinking);
 		const thinking = includeThinking && round.thinking && <ThinkingDataContainer thinking={round.thinking} />;
 		const phase = (round.phase && roundModelId === this.promptEndpoint.model) ? <PhaseDataContainer phase={round.phase} /> : undefined;

--- a/extensions/copilot/src/extension/tools/node/test/toolCalling.spec.tsx
+++ b/extensions/copilot/src/extension/tools/node/test/toolCalling.spec.tsx
@@ -201,24 +201,26 @@ suite('ChatToolCalls thinking handling', () => {
 		expect(hasThinkingPart(result)).toBe(true);
 	});
 
-	test('historical: includes thinking on messages API when modelId matches', async () => {
-		// Anthropic Messages API hashes thinking content as part of the prefix
-		// bytes; dropping it on subsequent turns invalidates every cache prefix
-		// from that assistant message forward.
-		const endpoint = makeEndpoint('claude-3.7-sonnet', 'messages');
-		const result = await render(endpoint, [makeThinkingRound('claude-3.7-sonnet')], true);
-		expect(hasThinkingPart(result)).toBe(true);
+	test('historical: drops thinking on messages API even when modelId matches', async () => {
+		// Anthropic Messages API frequently returns `messages.N.content.M: 'thinking' or
+		// 'redacted_thinking' blocks in the latest assistant message cannot be modified` 400s
+		// when round-tripping historical thinking with corrupted / rotated signatures, so we
+		// intentionally omit historical thinking on Messages API. Anthropic explicitly allows
+		// omitting thinking blocks from prior assistant turns.
+		const endpoint = makeEndpoint('claude-haiku-4-5', 'messages');
+		const result = await render(endpoint, [makeThinkingRound('claude-haiku-4-5')], true);
+		expect(hasThinkingPart(result)).toBe(false);
 	});
 
 	test('historical: drops thinking on messages API when modelId mismatches', async () => {
-		const endpoint = makeEndpoint('claude-3.7-sonnet', 'messages');
+		const endpoint = makeEndpoint('claude-haiku-4-5', 'messages');
 		const result = await render(endpoint, [makeThinkingRound('gpt-5')], true);
 		expect(hasThinkingPart(result)).toBe(false);
 	});
 
 	test('historical: drops thinking on responses API when modelId mismatches', async () => {
 		const endpoint = makeEndpoint('gpt-5', 'responses');
-		const result = await render(endpoint, [makeThinkingRound('claude-3.7-sonnet')], true);
+		const result = await render(endpoint, [makeThinkingRound('claude-haiku-4-5')], true);
 		expect(hasThinkingPart(result)).toBe(false);
 	});
 


### PR DESCRIPTION
Anthropic's Extended Thinking docs explicitly allow omitting thinking blocks from prior assistant turns. This drops `'messages'` from `apiSupportsHistoricalThinking` so historical thinking is no longer emitted on the Messages API. The Responses API (OpenAI) still needs to round-trip encrypted reasoning and is unchanged.

Test updated to assert the new behavior on the Messages API.