### PR TITLE
Enable sandboxing only for default approvals permissions.

### DIFF
--- a/src/vs/platform/sandbox/common/terminalSandboxEngine.ts
+++ b/src/vs/platform/sandbox/common/terminalSandboxEngine.ts
@@ -20,7 +20,7 @@ import { AgentSandboxEnabledValue, AgentSandboxSettingId } from './settings.js';
 import { IWindowsMxcTerminalSandboxRuntime } from './terminalSandboxMxcRuntime.js';
 import { getTerminalSandboxReadAllowListForCommands } from './terminalSandboxReadAllowList.js';
 import { getTerminalSandboxRuntimeConfigurationForCommands } from './terminalSandboxRuntimeConfigurationPerOperation.js';
-import { ITerminalSandboxCommand, ITerminalSandboxPrerequisiteCheckResult, ITerminalSandboxResolvedNetworkDomains, ITerminalSandboxWrapResult, TerminalSandboxPrerequisiteCheck } from './terminalSandboxService.js';
+import { ITerminalSandboxCommand, ITerminalSandboxPrecheckInputs, ITerminalSandboxPrerequisiteCheckResult, ITerminalSandboxResolvedNetworkDomains, ITerminalSandboxWrapResult, TerminalSandboxPrerequisiteCheck } from './terminalSandboxService.js';
 
 interface ITerminalSandboxFileSystemSetting {
 	denyRead?: string[];
@@ -144,12 +144,12 @@ export class TerminalSandboxEngine extends Disposable {
 		this._register(this._host.onDidChangeRoots(() => this.setNeedsForceUpdateConfigFile()));
 	}
 
-	async isEnabled(): Promise<boolean> {
-		return this._isSandboxConfiguredEnabled();
+	async isEnabled(precheckInputs?: ITerminalSandboxPrecheckInputs): Promise<boolean> {
+		return this._isSandboxConfiguredEnabled(precheckInputs);
 	}
 
-	async isSandboxAllowNetworkEnabled(): Promise<boolean> {
-		if (!(await this._isSandboxConfiguredEnabled())) {
+	async isSandboxAllowNetworkEnabled(precheckInputs?: ITerminalSandboxPrecheckInputs): Promise<boolean> {
+		if (!(await this._isSandboxConfiguredEnabled(precheckInputs))) {
 			return false;
 		}
 		return this._isSandboxAllowNetworkConfigured();
@@ -274,8 +274,8 @@ export class TerminalSandboxEngine extends Disposable {
 		};
 	}
 
-	async checkForSandboxingPrereqs(forceRefresh: boolean = false): Promise<ITerminalSandboxPrerequisiteCheckResult> {
-		if (!(await this._isSandboxConfiguredEnabled())) {
+	async checkForSandboxingPrereqs(forceRefresh: boolean = false, precheckInputs?: ITerminalSandboxPrecheckInputs): Promise<ITerminalSandboxPrerequisiteCheckResult> {
+		if (!(await this._isSandboxConfiguredEnabled(precheckInputs))) {
 			return {
 				enabled: false,
 				sandboxConfigPath: undefined,
@@ -283,7 +283,7 @@ export class TerminalSandboxEngine extends Disposable {
 			};
 		}
 
-		const sandboxConfigPath = await this.getSandboxConfigPath(forceRefresh);
+		const sandboxConfigPath = await this.getSandboxConfigPath(forceRefresh, precheckInputs);
 		if (!sandboxConfigPath) {
 			return {
 				enabled: true,
@@ -308,8 +308,8 @@ export class TerminalSandboxEngine extends Disposable {
 		};
 	}
 
-	async getSandboxConfigPath(forceRefresh: boolean = false): Promise<string | undefined> {
-		if (!(await this._isSandboxConfiguredEnabled())) {
+	async getSandboxConfigPath(forceRefresh: boolean = false, precheckInputs?: ITerminalSandboxPrecheckInputs): Promise<string | undefined> {
+		if (!(await this._isSandboxConfiguredEnabled(precheckInputs))) {
 			return undefined;
 		}
 		await this._resolveRuntimeInfo();
@@ -501,7 +501,14 @@ export class TerminalSandboxEngine extends Disposable {
 		return JSON.stringify(a) === JSON.stringify(b);
 	}
 
-	private async _isSandboxConfiguredEnabled(): Promise<boolean> {
+	private _isSandboxAllowedByPrecheckInputs(precheckInputs: ITerminalSandboxPrecheckInputs | undefined): boolean {
+		return precheckInputs?.isDefaultApprovalPermissionEnabled !== false;
+	}
+
+	private async _isSandboxConfiguredEnabled(precheckInputs?: ITerminalSandboxPrecheckInputs): Promise<boolean> {
+		if (!this._isSandboxAllowedByPrecheckInputs(precheckInputs)) {
+			return false;
+		}
 		await this.getOS();
 		if (this._os === OperatingSystem.Windows) {
 			return this._getSandboxConfiguredWindowsEnabledValue() === AgentSandboxEnabledValue.AllowNetwork;

--- a/src/vs/platform/sandbox/common/terminalSandboxService.ts
+++ b/src/vs/platform/sandbox/common/terminalSandboxService.ts
@@ -37,6 +37,13 @@ export interface ITerminalSandboxWrapResult {
 	requiresUnsandboxConfirmation?: boolean;
 }
 
+export interface ITerminalSandboxPrecheckInputs {
+	/**
+	 * Whether the current caller is using the default approval permission flow.
+	 */
+	readonly isDefaultApprovalPermissionEnabled?: boolean;
+}
+
 export interface ITerminalSandboxCommand {
 	/**
 	 * Normalized command name without path or executable suffix.
@@ -84,17 +91,17 @@ export interface ISandboxDependencyInstallResult {
 
 export interface ITerminalSandboxService {
 	readonly _serviceBrand: undefined;
-	isEnabled(): Promise<boolean>;
-	isSandboxAllowNetworkEnabled(): Promise<boolean>;
+	isEnabled(precheckInputs?: ITerminalSandboxPrecheckInputs): Promise<boolean>;
+	isSandboxAllowNetworkEnabled(precheckInputs?: ITerminalSandboxPrecheckInputs): Promise<boolean>;
 	getOS(): Promise<OperatingSystem>;
-	checkForSandboxingPrereqs(forceRefresh?: boolean): Promise<ITerminalSandboxPrerequisiteCheckResult>;
+	checkForSandboxingPrereqs(forceRefresh?: boolean, precheckInputs?: ITerminalSandboxPrecheckInputs): Promise<ITerminalSandboxPrerequisiteCheckResult>;
 	/**
 	 * Wraps a command line for sandbox execution. Command details are optional,
 	 * but when provided they are used to derive command-specific read/write
 	 * allow-list entries.
 	 */
 	wrapCommand(command: string, requestUnsandboxedExecution?: boolean, shell?: string, cwd?: URI, commandDetails?: readonly ITerminalSandboxCommand[]): Promise<ITerminalSandboxWrapResult>;
-	getSandboxConfigPath(forceRefresh?: boolean): Promise<string | undefined>;
+	getSandboxConfigPath(forceRefresh?: boolean, precheckInputs?: ITerminalSandboxPrecheckInputs): Promise<string | undefined>;
 	getTempDir(): URI | undefined;
 	setNeedsForceUpdateConfigFile(): void;
 	getResolvedNetworkDomains(): ITerminalSandboxResolvedNetworkDomains;

--- a/src/vs/platform/sandbox/test/common/terminalSandboxEngine.test.ts
+++ b/src/vs/platform/sandbox/test/common/terminalSandboxEngine.test.ts
@@ -249,6 +249,24 @@ suite('TerminalSandboxEngine', () => {
 		await engine.cleanupTempDir(); // must not throw
 	});
 
+	test('precheck inputs can disable sandboxing when default approval permission is disabled', async () => {
+		const host = createHost();
+		const engine = store.add(instantiationService.createInstance(TerminalSandboxEngine, host));
+
+		strictEqual(await engine.isEnabled({ isDefaultApprovalPermissionEnabled: true }), true);
+		strictEqual(await engine.isEnabled({ isDefaultApprovalPermissionEnabled: false }), false);
+		strictEqual(await engine.isSandboxAllowNetworkEnabled({ isDefaultApprovalPermissionEnabled: false }), false);
+		strictEqual(await engine.getSandboxConfigPath(false, { isDefaultApprovalPermissionEnabled: false }), undefined);
+
+		deepStrictEqual(await engine.checkForSandboxingPrereqs(false, { isDefaultApprovalPermissionEnabled: false }), {
+			enabled: false,
+			sandboxConfigPath: undefined,
+			failedCheck: undefined,
+		});
+
+		strictEqual(createFileCount, 0, 'Disabled sandbox precheck should not create sandbox config files');
+	});
+
 	test('isEnabled returns false on Windows when Windows sandbox setting is disabled by default', async () => {
 		const host = createWindowsHost();
 		const engine = store.add(instantiationService.createInstance(TerminalSandboxEngine, host));

--- a/src/vs/workbench/contrib/chat/browser/tools/toolHelpers.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/toolHelpers.ts
@@ -7,7 +7,11 @@ import { MarkdownString } from '../../../../../base/common/htmlContent.js';
 import { escapeRegExpCharacters } from '../../../../../base/common/strings.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ITextModel } from '../../../../../editor/common/model.js';
+import type { ITerminalSandboxPrecheckInputs } from '../../../../../platform/sandbox/common/terminalSandboxService.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
+import type { IChatWidgetService } from '../chat.js';
+import type { IChatService } from '../../common/chatService/chatService.js';
+import { ChatPermissionLevel, isAutoApproveLevel } from '../../common/constants.js';
 import { IToolResult } from '../../common/tools/languageModelToolsService.js';
 import { createToolSimpleTextResult } from '../../common/tools/builtinTools/toolHelpers.js';
 import { WorkingDirectory } from '../../common/workingDirectory.js';
@@ -33,6 +37,54 @@ export function resolveToolUri(input: ISymbolToolInput, workspaceContextService:
 		return workingDir.resolveRelativePath(input.filePath);
 	}
 	return undefined;
+}
+
+/**
+ * Gets the chat permission level that should apply to a tool invocation.
+ *
+ * When a request id is available, the request-stamped permission level is the
+ * source of truth for that invocation. If the request cannot be resolved (for
+ * example during early streaming), fall back to the live session widget and then
+ * the latest request in the chat model.
+ */
+export function getChatPermissionLevelForToolInvocation(
+	chatSessionResource: URI | undefined,
+	chatRequestId: string | undefined,
+	chatWidgetService: IChatWidgetService,
+	chatService: IChatService,
+): ChatPermissionLevel | undefined {
+	if (!chatSessionResource) {
+		return undefined;
+	}
+
+	const model = chatService.getSession(chatSessionResource);
+	const request = chatRequestId
+		? model?.getRequests().find(request => request.id === chatRequestId)
+		: undefined;
+	if (request) {
+		return request.modeInfo?.permissionLevel ?? ChatPermissionLevel.Default;
+	}
+
+	const widget = chatWidgetService.getWidgetBySessionResource(chatSessionResource);
+	if (widget) {
+		return widget.input.currentModeInfo.permissionLevel ?? ChatPermissionLevel.Default;
+	}
+
+	return model?.getRequests().at(-1)?.modeInfo?.permissionLevel ?? ChatPermissionLevel.Default;
+}
+
+/**
+ * Translates the chat permission level for a tool invocation into the
+ * platform-neutral sandbox precheck inputs.
+ */
+export function getSandboxPrecheckInputsForToolInvocation(
+	chatSessionResource: URI | undefined,
+	chatRequestId: string | undefined,
+	chatWidgetService: IChatWidgetService,
+	chatService: IChatService,
+): ITerminalSandboxPrecheckInputs | undefined {
+	const chatPermissionLevel = getChatPermissionLevelForToolInvocation(chatSessionResource, chatRequestId, chatWidgetService, chatService);
+	return chatPermissionLevel === undefined ? undefined : { isDefaultApprovalPermissionEnabled: !isAutoApproveLevel(chatPermissionLevel) };
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/test/browser/tools/toolHelpers.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/tools/toolHelpers.test.ts
@@ -9,7 +9,10 @@ import { IWorkspaceContextService, IWorkspaceFolder } from '../../../../../../pl
 import { createTextModel } from '../../../../../../editor/test/common/testTextModel.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
-import { resolveToolUri, findLineNumber, findSymbolColumn, errorResult } from '../../../browser/tools/toolHelpers.js';
+import { resolveToolUri, findLineNumber, findSymbolColumn, errorResult, getChatPermissionLevelForToolInvocation, getSandboxPrecheckInputsForToolInvocation } from '../../../browser/tools/toolHelpers.js';
+import type { IChatService } from '../../../common/chatService/chatService.js';
+import { ChatPermissionLevel } from '../../../common/constants.js';
+import type { IChatWidgetService } from '../../../browser/chat.js';
 
 suite('Tool Helpers', () => {
 
@@ -37,6 +40,20 @@ suite('Tool Helpers', () => {
 				return null;
 			},
 		} as unknown as IWorkspaceContextService;
+	}
+
+	function createMockChatService(requests: readonly { id: string; modeInfo?: { permissionLevel?: ChatPermissionLevel } }[] | undefined): IChatService {
+		return {
+			_serviceBrand: undefined,
+			getSession: () => requests ? { getRequests: () => requests } : undefined,
+		} as unknown as IChatService;
+	}
+
+	function createMockChatWidgetService(permissionLevel: ChatPermissionLevel | undefined): IChatWidgetService {
+		return {
+			_serviceBrand: undefined,
+			getWidgetBySessionResource: () => permissionLevel === undefined ? undefined : { input: { currentModeInfo: { permissionLevel } } },
+		} as unknown as IChatWidgetService;
 	}
 
 	suite('resolveToolUri', () => {
@@ -84,6 +101,83 @@ suite('Tool Helpers', () => {
 			const workingDirectory = URI.parse('file:///session-dir');
 			const result = resolveToolUri({ symbol: 'x', lineContent: 'x', uri: 'file:///absolute/path.ts' }, ws, workingDirectory);
 			assert.strictEqual(result?.toString(), 'file:///absolute/path.ts');
+		});
+	});
+
+	suite('getChatPermissionLevelForToolInvocation', () => {
+
+		test('returns undefined when there is no chat session resource', () => {
+			const result = getChatPermissionLevelForToolInvocation(undefined, undefined, createMockChatWidgetService(ChatPermissionLevel.Default), createMockChatService([]));
+			assert.strictEqual(result, undefined);
+		});
+
+		test('prefers the request permission level for the provided request id', () => {
+			const sessionResource = URI.parse('vscode-chat://session/test');
+			const result = getChatPermissionLevelForToolInvocation(
+				sessionResource,
+				'request-2',
+				createMockChatWidgetService(ChatPermissionLevel.Default),
+				createMockChatService([
+					{ id: 'request-1', modeInfo: { permissionLevel: ChatPermissionLevel.Default } },
+					{ id: 'request-2', modeInfo: { permissionLevel: ChatPermissionLevel.AutoApprove } },
+				]),
+			);
+
+			assert.strictEqual(result, ChatPermissionLevel.AutoApprove);
+		});
+
+		test('falls back to the live widget permission level when the request is not found', () => {
+			const sessionResource = URI.parse('vscode-chat://session/test');
+			const result = getChatPermissionLevelForToolInvocation(
+				sessionResource,
+				'missing-request',
+				createMockChatWidgetService(ChatPermissionLevel.Autopilot),
+				createMockChatService([{ id: 'request-1', modeInfo: { permissionLevel: ChatPermissionLevel.Default } }]),
+			);
+
+			assert.strictEqual(result, ChatPermissionLevel.Autopilot);
+		});
+
+		test('falls back to the latest request permission level when there is no widget', () => {
+			const sessionResource = URI.parse('vscode-chat://session/test');
+			const result = getChatPermissionLevelForToolInvocation(
+				sessionResource,
+				undefined,
+				createMockChatWidgetService(undefined),
+				createMockChatService([
+					{ id: 'request-1', modeInfo: { permissionLevel: ChatPermissionLevel.Default } },
+					{ id: 'request-2', modeInfo: { permissionLevel: ChatPermissionLevel.AutoApprove } },
+				]),
+			);
+
+			assert.strictEqual(result, ChatPermissionLevel.AutoApprove);
+		});
+	});
+
+	suite('getSandboxPrecheckInputsForToolInvocation', () => {
+
+		test('returns undefined when there is no chat permission level', () => {
+			const result = getSandboxPrecheckInputsForToolInvocation(undefined, undefined, createMockChatWidgetService(ChatPermissionLevel.AutoApprove), createMockChatService([]));
+			assert.strictEqual(result, undefined);
+		});
+
+		test('returns undefined for the default chat permission level', () => {
+			const sessionResource = URI.parse('vscode-chat://session/test');
+			const result = getSandboxPrecheckInputsForToolInvocation(sessionResource, undefined, createMockChatWidgetService(ChatPermissionLevel.Default), createMockChatService([]));
+			assert.deepStrictEqual(result, { isDefaultApprovalPermissionEnabled: true });
+		});
+
+		test('disables default approval permission for auto-approve chat permission levels', () => {
+			const sessionResource = URI.parse('vscode-chat://session/test');
+
+			assert.deepStrictEqual(
+				getSandboxPrecheckInputsForToolInvocation(sessionResource, undefined, createMockChatWidgetService(ChatPermissionLevel.AutoApprove), createMockChatService([])),
+				{ isDefaultApprovalPermissionEnabled: false }
+			);
+			assert.deepStrictEqual(
+				getSandboxPrecheckInputsForToolInvocation(sessionResource, undefined, createMockChatWidgetService(ChatPermissionLevel.Autopilot), createMockChatService([])),
+				{ isDefaultApprovalPermissionEnabled: false }
+			);
 		});
 	});
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineRewriter/commandLineRewriter.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineRewriter/commandLineRewriter.ts
@@ -7,6 +7,7 @@ import type { MaybePromise } from '../../../../../../../base/common/async.js';
 import type { IDisposable } from '../../../../../../../base/common/lifecycle.js';
 import type { OperatingSystem } from '../../../../../../../base/common/platform.js';
 import type { URI } from '../../../../../../../base/common/uri.js';
+import type { ITerminalSandboxPrecheckInputs } from '../../../common/terminalSandboxService.js';
 
 export interface ICommandLineRewriter extends IDisposable {
 	rewrite(options: ICommandLineRewriterOptions): MaybePromise<ICommandLineRewriterResult | undefined>;
@@ -19,6 +20,7 @@ export interface ICommandLineRewriterOptions {
 	os: OperatingSystem;
 	isBackground?: boolean;
 	requestUnsandboxedExecution?: boolean;
+	sandboxPrecheckInputs?: ITerminalSandboxPrecheckInputs;
 }
 
 export interface ICommandLineRewriterResult {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineRewriter/commandLineSandboxRewriter.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineRewriter/commandLineSandboxRewriter.ts
@@ -18,7 +18,7 @@ export class CommandLineSandboxRewriter extends Disposable implements ICommandLi
 	}
 
 	async rewrite(options: ICommandLineRewriterOptions): Promise<ICommandLineRewriterResult | undefined> {
-		const sandboxPrereqs = await this._sandboxService.checkForSandboxingPrereqs();
+		const sandboxPrereqs = await this._sandboxService.checkForSandboxingPrereqs(false, options.sandboxPrecheckInputs);
 		if (!sandboxPrereqs.enabled || sandboxPrereqs.failedCheck === TerminalSandboxPrerequisiteCheck.Config) {
 			return undefined;
 		}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -79,11 +79,12 @@ import { clamp } from '../../../../../../base/common/numbers.js';
 import { IOutputAnalyzer } from './outputAnalyzer.js';
 import { SandboxOutputAnalyzer, outputLooksSandboxBlocked } from './sandboxOutputAnalyzer.js';
 import { IAgentSessionsService } from '../../../../chat/browser/agentSessions/agentSessionsService.js';
-import { ITerminalSandboxService, TerminalSandboxPrerequisiteCheck, type ITerminalSandboxResolvedNetworkDomains } from '../../common/terminalSandboxService.js';
+import { ITerminalSandboxService, TerminalSandboxPrerequisiteCheck, type ITerminalSandboxPrecheckInputs, type ITerminalSandboxResolvedNetworkDomains } from '../../common/terminalSandboxService.js';
 import { LanguageModelPartAudience } from '../../../../chat/common/languageModels.js';
 import { isSessionAutoApproveLevel, isTerminalAutoApproveAllowed, isToolEligibleForTerminalAutoApproval } from './terminalToolAutoApprove.js';
 import type { IJSONSchemaMap } from '../../../../../../base/common/jsonSchema.js';
 import { ChatElicitationRequestPart } from '../../../../chat/common/model/chatProgressTypes/chatElicitationRequestPart.js';
+import { getSandboxPrecheckInputsForToolInvocation } from '../../../../chat/browser/tools/toolHelpers.js';
 
 // #region Tool data
 
@@ -714,6 +715,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		const executionOptions = this._resolveExecutionOptions(args);
 
 		const chatSessionResource = context.chatSessionResource;
+		const sandboxPrecheckInputs = this._getSandboxPrecheckInputs(chatSessionResource, context.chatRequestId);
 		let instance: ITerminalInstance | undefined;
 		if (chatSessionResource) {
 			const toolTerminal = this._sessionTerminalAssociations.get(chatSessionResource);
@@ -740,7 +742,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 				}
 				return cwd;
 			})(),
-			this._terminalSandboxService.checkForSandboxingPrereqs()
+			this._terminalSandboxService.checkForSandboxingPrereqs(false, sandboxPrecheckInputs)
 		]);
 		const language = os === OperatingSystem.Windows ? 'pwsh' : 'sh';
 		const isSandboxEnabled = sandboxPrereqs.enabled;
@@ -787,6 +789,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			isBackground: executionOptions.persistentSession,
 			requestUnsandboxedExecution: allowUnsandboxedCommands ? requiresUnsandboxConfirmation : false,
 			requestUnsandboxedExecutionReason,
+			sandboxPrecheckInputs,
 		});
 		const rewrittenCommand: string | undefined = rewriteResult.rewrittenCommand;
 		const forDisplayCommand: string | undefined = rewriteResult.forDisplayCommand;
@@ -1057,6 +1060,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		isBackground: boolean;
 		requestUnsandboxedExecution: boolean;
 		requestUnsandboxedExecutionReason?: string;
+		sandboxPrecheckInputs?: ITerminalSandboxPrecheckInputs;
 	}): Promise<{
 		rewrittenCommand: string;
 		forDisplayCommand: string | undefined;
@@ -1080,6 +1084,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 				os: options.os,
 				isBackground: options.isBackground,
 				requestUnsandboxedExecution: requiresUnsandboxConfirmation,
+				sandboxPrecheckInputs: options.sandboxPrecheckInputs,
 			});
 			if (rewriteResult) {
 				rewrittenCommand = rewriteResult.rewritten;
@@ -1108,6 +1113,10 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			requestUnsandboxedExecutionReason,
 			blockedDomains,
 		};
+	}
+
+	private _getSandboxPrecheckInputs(chatSessionResource: URI | undefined, chatRequestId: string | undefined): ITerminalSandboxPrecheckInputs | undefined {
+		return getSandboxPrecheckInputsForToolInvocation(chatSessionResource, chatRequestId, this._chatWidgetService, this._chatService);
 	}
 
 	private async _confirmAutomaticUnsandboxRetry(sessionResource: URI | undefined, command: string, shell: string, blockedDomains: string[] | undefined, riskAssessment: { toolId: string; parameters: unknown } | undefined, token: CancellationToken): Promise<boolean> {
@@ -1342,7 +1351,8 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 
 		const args = invocation.parameters as IRunInTerminalInputParams;
 		const allowUnsandboxedCommands = this._getAllowToRunUnsandboxedCommands(args);
-		const isSandboxEnabled = await this._terminalSandboxService.isEnabled();
+		const sandboxPrecheckInputs = this._getSandboxPrecheckInputs(invocation.context.sessionResource, invocation.chatRequestId);
+		const isSandboxEnabled = await this._terminalSandboxService.isEnabled(sandboxPrecheckInputs);
 		if (this._shouldRejectUnsandboxedExecutionRequest(isSandboxEnabled, allowUnsandboxedCommands, args)) {
 			const message = this._getUnsandboxedExecutionDisabledMessage();
 			return {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalSandboxService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalSandboxService.ts
@@ -25,7 +25,7 @@ import { SANDBOX_HELPER_CHANNEL_NAME, SandboxHelperChannelClient } from '../../.
 import { ISandboxDependencyStatus, ISandboxHelperService, IWindowsMxcFilesystemPolicy } from '../../../../../platform/sandbox/common/sandboxHelperService.js';
 import { ITerminalSandboxEngineHost, ITerminalSandboxRuntimeInfo, TerminalSandboxEngine } from '../../../../../platform/sandbox/common/terminalSandboxEngine.js';
 import { readSandboxSetting, SANDBOX_SETTING_KEYS } from './sandboxSettingsReader.js';
-import { ITerminalSandboxService, type ISandboxDependencyInstallOptions, type ISandboxDependencyInstallResult, type ITerminalSandboxCommand, type ITerminalSandboxPrerequisiteCheckResult, type ITerminalSandboxResolvedNetworkDomains, type ITerminalSandboxWrapResult } from '../../../../../platform/sandbox/common/terminalSandboxService.js';
+import { ITerminalSandboxService, type ISandboxDependencyInstallOptions, type ISandboxDependencyInstallResult, type ITerminalSandboxCommand, type ITerminalSandboxPrecheckInputs, type ITerminalSandboxPrerequisiteCheckResult, type ITerminalSandboxResolvedNetworkDomains, type ITerminalSandboxWrapResult } from '../../../../../platform/sandbox/common/terminalSandboxService.js';
 import { TerminalCapability } from '../../../../../platform/terminal/common/capabilities/capabilities.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { ChatModel } from '../../../chat/common/model/chatModel.js';
@@ -35,7 +35,7 @@ import { IRemoteAgentService } from '../../../../services/remote/common/remoteAg
 import { ILifecycleService, WillShutdownJoinerOrder } from '../../../../services/lifecycle/common/lifecycle.js';
 
 export { ITerminalSandboxService, TerminalSandboxPrerequisiteCheck } from '../../../../../platform/sandbox/common/terminalSandboxService.js';
-export type { ISandboxDependencyInstallOptions, ISandboxDependencyInstallResult, ISandboxDependencyInstallTerminal, ITerminalSandboxCommand, ITerminalSandboxPrerequisiteCheckResult, ITerminalSandboxResolvedNetworkDomains, ITerminalSandboxWrapResult } from '../../../../../platform/sandbox/common/terminalSandboxService.js';
+export type { ISandboxDependencyInstallOptions, ISandboxDependencyInstallResult, ISandboxDependencyInstallTerminal, ITerminalSandboxCommand, ITerminalSandboxPrecheckInputs, ITerminalSandboxPrerequisiteCheckResult, ITerminalSandboxResolvedNetworkDomains, ITerminalSandboxWrapResult } from '../../../../../platform/sandbox/common/terminalSandboxService.js';
 
 /**
  * Context passed to the password prompt during dependency installation.
@@ -112,12 +112,12 @@ export class TerminalSandboxService extends Disposable implements ITerminalSandb
 
 	// ---- ITerminalSandboxService forwarders ---------------------------------
 
-	isEnabled(): Promise<boolean> {
-		return this._engine.isEnabled();
+	isEnabled(precheckInputs?: ITerminalSandboxPrecheckInputs): Promise<boolean> {
+		return this._engine.isEnabled(precheckInputs);
 	}
 
-	isSandboxAllowNetworkEnabled(): Promise<boolean> {
-		return this._engine.isSandboxAllowNetworkEnabled();
+	isSandboxAllowNetworkEnabled(precheckInputs?: ITerminalSandboxPrecheckInputs): Promise<boolean> {
+		return this._engine.isSandboxAllowNetworkEnabled(precheckInputs);
 	}
 
 	getOS(): Promise<OperatingSystem> {
@@ -128,12 +128,12 @@ export class TerminalSandboxService extends Disposable implements ITerminalSandb
 		return this._engine.wrapCommand(command, requestUnsandboxedExecution, shell, cwd, commandDetails);
 	}
 
-	checkForSandboxingPrereqs(forceRefresh: boolean = false): Promise<ITerminalSandboxPrerequisiteCheckResult> {
-		return this._engine.checkForSandboxingPrereqs(forceRefresh);
+	checkForSandboxingPrereqs(forceRefresh: boolean = false, precheckInputs?: ITerminalSandboxPrecheckInputs): Promise<ITerminalSandboxPrerequisiteCheckResult> {
+		return this._engine.checkForSandboxingPrereqs(forceRefresh, precheckInputs);
 	}
 
-	getSandboxConfigPath(forceRefresh: boolean = false): Promise<string | undefined> {
-		return this._engine.getSandboxConfigPath(forceRefresh);
+	getSandboxConfigPath(forceRefresh: boolean = false, precheckInputs?: ITerminalSandboxPrecheckInputs): Promise<string | undefined> {
+		return this._engine.getSandboxConfigPath(forceRefresh, precheckInputs);
 	}
 
 	getTempDir(): URI | undefined {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -37,10 +37,10 @@ import { TerminalToolConfirmationStorageKeys } from '../../../../chat/browser/wi
 import { IChatService, type IChatTerminalToolInvocationData } from '../../../../chat/common/chatService/chatService.js';
 import { IChatWidgetService } from '../../../../chat/browser/chat.js';
 import { ChatAgentLocation, ChatPermissionLevel } from '../../../../chat/common/constants.js';
-import { ChatModel } from '../../../../chat/common/model/chatModel.js';
+import { ChatModel, type IChatRequestModeInfo } from '../../../../chat/common/model/chatModel.js';
 import { LocalChatSessionUri } from '../../../../chat/common/model/chatUri.js';
 import { ChatRequestTextPart } from '../../../../chat/common/requestParser/chatParserTypes.js';
-import { ITerminalSandboxService, TerminalSandboxPrerequisiteCheck, type ITerminalSandboxPrerequisiteCheckResult } from '../../common/terminalSandboxService.js';
+import { ITerminalSandboxService, TerminalSandboxPrerequisiteCheck, type ITerminalSandboxPrecheckInputs, type ITerminalSandboxPrerequisiteCheckResult } from '../../common/terminalSandboxService.js';
 import { ILanguageModelToolsService, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolInvocationPreparationContext, IToolResult, ToolDataSource, ToolProgress, ToolSet, type ToolConfirmationAction } from '../../../../chat/common/tools/languageModelToolsService.js';
 import { IToolResultCompressor } from '../../../../chat/common/tools/toolResultCompressor.js';
 import { ITerminalChatService, ITerminalService, type ITerminalInstance } from '../../../../terminal/browser/terminal.js';
@@ -94,6 +94,10 @@ suite('RunInTerminalTool', () => {
 	let chatSessions: Map<string, ChatModel>;
 
 	let runInTerminalTool: TestRunInTerminalTool;
+
+	function isDefaultChatPermissionSandboxPrecheckInputs(precheckInputs: ITerminalSandboxPrecheckInputs | undefined): boolean {
+		return precheckInputs?.isDefaultApprovalPermissionEnabled !== false;
+	}
 
 	setup(() => {
 		configurationService = new TestConfigurationService();
@@ -194,14 +198,16 @@ suite('RunInTerminalTool', () => {
 		});
 		terminalSandboxService = {
 			_serviceBrand: undefined,
-			isEnabled: async () => sandboxEnabled,
+			isEnabled: async (precheckInputs) => sandboxEnabled && isDefaultChatPermissionSandboxPrecheckInputs(precheckInputs),
 			isSandboxAllowNetworkEnabled: async () => false,
 			wrapCommand: async (command: string, requestUnsandboxedExecution?: boolean) => ({
 				command: requestUnsandboxedExecution ? `unsandboxed:${command}` : `sandbox:${command}`,
 				isSandboxWrapped: !requestUnsandboxedExecution,
 			}),
 			getSandboxConfigPath: async () => sandboxEnabled ? '/tmp/sandbox.json' : undefined,
-			checkForSandboxingPrereqs: async () => sandboxPrereqResult,
+			checkForSandboxingPrereqs: async (_forceRefresh?: boolean, precheckInputs?: ITerminalSandboxPrecheckInputs) => isDefaultChatPermissionSandboxPrecheckInputs(precheckInputs)
+				? sandboxPrereqResult
+				: { enabled: false, sandboxConfigPath: undefined, failedCheck: undefined },
 			getTempDir: () => undefined,
 			setNeedsForceUpdateConfigFile: () => { },
 			getOS: async () => OperatingSystem.Linux,
@@ -318,10 +324,21 @@ suite('RunInTerminalTool', () => {
 		}
 	}
 
-	function createChatModelWithRequest(sessionResource: URI): ChatModel {
+	function createChatModeInfo(permissionLevel: ChatPermissionLevel): IChatRequestModeInfo {
+		return {
+			kind: undefined,
+			isBuiltin: true,
+			modeInstructions: undefined,
+			modeId: 'agent',
+			applyCodeBlockSuggestionId: undefined,
+			permissionLevel,
+		};
+	}
+
+	function createChatModelWithRequest(sessionResource: URI, modeInfo?: IChatRequestModeInfo, requestId?: string): ChatModel {
 		const model = store.add(instantiationService.createInstance(ChatModel, undefined, { initialLocation: ChatAgentLocation.Chat, canUseTools: true }));
 		const text = 'retry';
-		model.addRequest({ text, parts: [new ChatRequestTextPart(new OffsetRange(0, text.length), new Range(1, text.length, 1, text.length), text)] }, { variables: [] }, 0);
+		model.addRequest({ text, parts: [new ChatRequestTextPart(new OffsetRange(0, text.length), new Range(1, text.length, 1, text.length), text)] }, { variables: [] }, 0, modeInfo, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, requestId);
 		chatSessions.set(sessionResource.toString(), model);
 		return model;
 	}
@@ -498,6 +515,110 @@ suite('RunInTerminalTool', () => {
 
 			const terminalData = preparedInvocation.toolSpecificData as IChatTerminalToolInvocationData;
 			strictEqual(terminalData.commandLine.isSandboxWrapped, true);
+		});
+
+		test('should enable sandboxing when chat permission level is default', async () => {
+			sandboxEnabled = true;
+			sandboxPrereqResult = {
+				enabled: true,
+				sandboxConfigPath: '/tmp/vscode-sandbox-settings.json',
+				failedCheck: undefined,
+			};
+			const sessionResource = LocalChatSessionUri.forSession('sandbox-default-permission-session');
+			instantiationService.stub(IChatWidgetService, {
+				getWidgetBySessionResource: (() => ({ input: { currentModeInfo: { permissionLevel: ChatPermissionLevel.Default } } })) as unknown as IChatWidgetService['getWidgetBySessionResource'],
+				lastFocusedWidget: undefined,
+			});
+			const defaultPermissionTool = store.add(instantiationService.createInstance(TestRunInTerminalTool));
+
+			const preparedInvocation = await defaultPermissionTool.prepareToolInvocation({
+				parameters: {
+					command: 'echo hello',
+					explanation: 'Print hello',
+					goal: 'Print hello',
+					mode: 'sync',
+				} as IRunInTerminalInputParams,
+				chatSessionResource: sessionResource,
+			} as IToolInvocationPreparationContext, CancellationToken.None);
+
+			const terminalData = preparedInvocation!.toolSpecificData as IChatTerminalToolInvocationData;
+			strictEqual(terminalData.commandLine.isSandboxWrapped, true);
+			strictEqual((preparedInvocation!.invocationMessage as IMarkdownString).value, 'Running `echo hello` in sandbox');
+		});
+
+		test('should disable sandboxing when chat permission level is elevated', async () => {
+			sandboxEnabled = true;
+			sandboxPrereqResult = {
+				enabled: true,
+				sandboxConfigPath: '/tmp/vscode-sandbox-settings.json',
+				failedCheck: undefined,
+			};
+
+			const originalWrapCommand = terminalSandboxService.wrapCommand.bind(terminalSandboxService);
+			for (const permissionLevel of [ChatPermissionLevel.AutoApprove, ChatPermissionLevel.Autopilot]) {
+				let wrapCalls = 0;
+				terminalSandboxService.wrapCommand = async (...args) => {
+					wrapCalls++;
+					return originalWrapCommand(...args);
+				};
+
+				const sessionResource = LocalChatSessionUri.forSession(`sandbox-${permissionLevel}-permission-session`);
+				instantiationService.stub(IChatWidgetService, {
+					getWidgetBySessionResource: (() => ({ input: { currentModeInfo: { permissionLevel } } })) as unknown as IChatWidgetService['getWidgetBySessionResource'],
+					lastFocusedWidget: undefined,
+				});
+				const elevatedPermissionTool = store.add(instantiationService.createInstance(TestRunInTerminalTool));
+
+				const preparedInvocation = await elevatedPermissionTool.prepareToolInvocation({
+					parameters: {
+						command: 'echo hello',
+						explanation: 'Print hello',
+						goal: 'Print hello',
+						mode: 'sync',
+					} as IRunInTerminalInputParams,
+					chatSessionResource: sessionResource,
+				} as IToolInvocationPreparationContext, CancellationToken.None);
+
+				const terminalData = preparedInvocation!.toolSpecificData as IChatTerminalToolInvocationData;
+				strictEqual(terminalData.commandLine.isSandboxWrapped, false, `Expected no sandbox wrapping for ${permissionLevel}`);
+				strictEqual(terminalData.requestUnsandboxedExecution, false, `Expected no unsandbox confirmation for ${permissionLevel}`);
+				strictEqual((preparedInvocation!.invocationMessage as IMarkdownString).value, 'Running `echo hello`');
+				strictEqual(wrapCalls, 0, `Expected sandbox wrapping to be skipped for ${permissionLevel}`);
+				terminalSandboxService.wrapCommand = originalWrapCommand;
+			}
+		});
+
+		test('should use request permission level before current widget permission level', async () => {
+			sandboxEnabled = true;
+			sandboxPrereqResult = {
+				enabled: true,
+				sandboxConfigPath: '/tmp/vscode-sandbox-settings.json',
+				failedCheck: undefined,
+			};
+
+			const sessionResource = LocalChatSessionUri.forSession('sandbox-request-permission-session');
+			const requestId = 'sandbox-request-permission-request';
+			createChatModelWithRequest(sessionResource, createChatModeInfo(ChatPermissionLevel.AutoApprove), requestId);
+			instantiationService.stub(IChatWidgetService, {
+				getWidgetBySessionResource: (() => ({ input: { currentModeInfo: { permissionLevel: ChatPermissionLevel.Default } } })) as unknown as IChatWidgetService['getWidgetBySessionResource'],
+				lastFocusedWidget: undefined,
+			});
+			const requestPermissionTool = store.add(instantiationService.createInstance(TestRunInTerminalTool));
+
+			const preparedInvocation = await requestPermissionTool.prepareToolInvocation({
+				parameters: {
+					command: 'echo hello',
+					explanation: 'Print hello',
+					goal: 'Print hello',
+					mode: 'sync',
+				} as IRunInTerminalInputParams,
+				chatSessionResource: sessionResource,
+				chatRequestId: requestId,
+			} as IToolInvocationPreparationContext, CancellationToken.None);
+
+			const terminalData = preparedInvocation!.toolSpecificData as IChatTerminalToolInvocationData;
+			strictEqual(terminalData.commandLine.isSandboxWrapped, false);
+			strictEqual((preparedInvocation!.invocationMessage as IMarkdownString).value, 'Running `echo hello`');
 		});
 
 		test('should not show sandbox wrapper in chat when sandboxed async command is detached', async () => {


### PR DESCRIPTION
fixes #318080
## Summary
- derive sandbox precheck inputs from the chat permission level helper
- skip terminal sandboxing when the invocation is not using the default approval permission flow
- keep wrapCommand focused on wrapping after callers have checked sandbox prerequisites
- update sandbox and terminal tool tests for the new precheck behavior

## Validation
- get_errors reported no diagnostics for touched files
- git diff --check
- precommit hook ran during commit