### PR TITLE
Keep last used permission mode when starting new Claude chats

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/vscode-node/claudeChatSessionContentProvider.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/claudeChatSessionContentProvider.ts
@@ -100,6 +100,7 @@ export class ClaudeChatSessionContentProvider extends Disposable implements vsco
 		for (const update of updates) {
 			const value = update.value;
 			if (update.optionId === PERMISSION_MODE_OPTION_ID && value && isPermissionMode(value)) {
+				this._controller.rememberPermissionMode(value);
 				this.sessionStateService.setPermissionModeForSession(sessionId, value);
 			}
 		}
@@ -137,6 +138,7 @@ export class ClaudeChatSessionContentProvider extends Disposable implements vsco
 				throw new Error(`Permission mode not set for session ${effectiveSessionId}`);
 			}
 			const permissionMode = selectedPermissionId;
+			this._controller.rememberPermissionMode(permissionMode);
 			const selectedFolderUri = getSelectedFolderUri(chatSessionContext.inputState);
 			const folderInfo = await this._controller.getFolderInfoForSession(effectiveSessionId, selectedFolderUri);
 
@@ -428,6 +430,10 @@ export class ClaudeChatSessionItemController extends Disposable {
 		}));
 
 		this._setupInputState();
+	}
+
+	rememberPermissionMode(permissionMode: PermissionMode): void {
+		this._optionBuilder.rememberPermissionMode(permissionMode);
 	}
 
 	// #region Input State

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/claudeSessionOptionBuilder.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/claudeSessionOptionBuilder.ts
@@ -37,6 +37,10 @@ export class ClaudeSessionOptionBuilder {
 		return this._lastUsedPermissionMode;
 	}
 
+	rememberPermissionMode(permissionMode: PermissionMode): void {
+		this._lastUsedPermissionMode = permissionMode;
+	}
+
 	constructor(
 		private readonly _configurationService: IConfigurationService,
 		private readonly _folderMruService: IChatFolderMruService,
@@ -150,7 +154,7 @@ export class ClaudeSessionOptionBuilder {
 		const selectedPermission = getSelectedOption(groups, PERMISSION_MODE_OPTION_ID);
 		let permissionMode: PermissionMode | undefined;
 		if (selectedPermission && isPermissionMode(selectedPermission.id)) {
-			this._lastUsedPermissionMode = selectedPermission.id;
+			this.rememberPermissionMode(selectedPermission.id);
 			permissionMode = selectedPermission.id;
 		}
 

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/test/claudeChatSessionContentProvider.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/test/claudeChatSessionContentProvider.spec.ts
@@ -406,6 +406,34 @@ describe('ChatSessionContentProvider', () => {
 			expect(restoredGroup!.selected?.id).toBe('plan');
 		});
 
+		it('uses the last live permission option change for new sessions', async () => {
+			provider.provideHandleOptionsChange(createClaudeSessionUri('changed-session'), [
+				{ optionId: 'permissionMode', value: 'default' }
+			], CancellationToken.None);
+
+			const state = await getInputState();
+
+			expect(getGroup(state, 'permissionMode')!.selected?.id).toBe('default');
+		});
+
+		it('uses the last sent permission mode for new sessions', async () => {
+			await runHandlerAndCapture(provider, accessor, 'sent-default-session', mockSessionService, { permissionMode: 'default' });
+
+			const state = await getInputState();
+
+			expect(getGroup(state, 'permissionMode')!.selected?.id).toBe('default');
+		});
+
+		it('ignores invalid live permission option changes for new sessions', async () => {
+			provider.provideHandleOptionsChange(createClaudeSessionUri('invalid-session'), [
+				{ optionId: 'permissionMode', value: 'garbage' }
+			], CancellationToken.None);
+
+			const state = await getInputState();
+
+			expect(getGroup(state, 'permissionMode')!.selected?.id).toBe('acceptEdits');
+		});
+
 		it('does not include folder group for single-root workspace', async () => {
 			const state = await getInputState();
 			const folderGroup = getGroup(state, 'folder');

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/test/claudeSessionOptionBuilder.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/test/claudeSessionOptionBuilder.spec.ts
@@ -133,6 +133,17 @@ describe('ClaudeSessionOptionBuilder', () => {
 			expect(permGroup!.selected?.id).toBe('acceptEdits');
 		});
 
+		it('uses remembered permission mode as default selection', async () => {
+			builder = createBuilder([URI.file('/project')]);
+			builder.rememberPermissionMode('default');
+
+			const groups = await builder.buildNewSessionGroups();
+
+			const permGroup = groups.find(g => g.id === 'permissionMode');
+			expect(permGroup).toBeDefined();
+			expect(permGroup!.selected?.id).toBe('default');
+		});
+
 		it('excludes folder group for single-root workspace', async () => {
 			builder = createBuilder([URI.file('/project')]);
 


### PR DESCRIPTION
Fixes #312774

## Summary
- New Claude chats now keep the user's last selected permission mode instead of resetting to default "Edit automatically".
- This preserves safer choices like "Ask before edits" across the new-chat flow.
- Permission mode updates from both the picker and the first-send path are remembered for the next Claude chat.

## Validation
Figure 1: Start a Claude chat with the “Ask before edits” permission mode selected instead of the default “Edit automatically”
<img width="962" height="714" alt="image" src="https://github.com/user-attachments/assets/b4b05a8f-e1b3-4bf1-9f58-5e769d522e72" />

<br>
Figure 2: Start a new Claude chat, and the previously selected “Ask before edits” permission mode is preserved
<img width="957" height="714" alt="image" src="https://github.com/user-attachments/assets/1dd579e4-117f-4b82-ba26-3bf8e473f622" />
