### PR TITLE
Fix BYOK regression for non-OAuth Copilot token pathways (eval proxy)

### DIFF
--- a/extensions/copilot/src/extension/authentication/vscode-node/authentication.contribution.ts
+++ b/extensions/copilot/src/extension/authentication/vscode-node/authentication.contribution.ts
@@ -50,7 +50,7 @@ class AuthUpgradeAsk extends Disposable {
 	}
 
 	private async waitForChatEnabled() {
-		if (!this._authenticationService.anyGitHubSession) {
+		if (!this._authenticationService.hasCopilotTokenSource) {
 			// BYOK / air-gapped: do not wait for a Copilot token that may never arrive.
 			return;
 		}

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotCli.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotCli.ts
@@ -96,8 +96,8 @@ export class CopilotCLIModels extends Disposable implements ICopilotCLIModels {
 	}
 
 	private _fetchAndCacheModels(): void {
-		if (!this._authenticationService.anyGitHubSession) {
-			this.logService.info('[CopilotCLIModels] Skipping model fetch since there is no GitHub session');
+		if (!this._authenticationService.hasCopilotTokenSource) {
+			this.logService.info('[CopilotCLIModels] Skipping model fetch since there is no Copilot token source');
 			return;
 		}
 		const availableModels = this._availableModels = this._getAvailableModels();
@@ -137,7 +137,7 @@ export class CopilotCLIModels extends Disposable implements ICopilotCLIModels {
 	}
 
 	public async getModels(): Promise<CopilotCLIModelInfo[]> {
-		if (!this._authenticationService.anyGitHubSession) {
+		if (!this._authenticationService.hasCopilotTokenSource) {
 			return [];
 		}
 
@@ -178,7 +178,7 @@ export class CopilotCLIModels extends Disposable implements ICopilotCLIModels {
 			onDidChangeLanguageModelChatInformation: this._onDidChange.event,
 			provideLanguageModelChatInformation: async (_options, _token) => {
 				const autoModelEnabled = this.configurationService.getConfig(ConfigKey.Advanced.CLIAutoModelEnabled);
-				if (!this._authenticationService.anyGitHubSession || !this._resolvedModelInfos) {
+				if (!this._authenticationService.hasCopilotTokenSource || !this._resolvedModelInfos) {
 					return autoModelEnabled ? [buildAutoModel()] : [];
 				}
 				return this._resolvedModelInfos;

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotCliModels.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotCliModels.spec.ts
@@ -79,6 +79,10 @@ class MockAuthenticationService {
 		return this._anyGitHubSession;
 	}
 
+	get hasCopilotTokenSource(): boolean {
+		return !!this._anyGitHubSession;
+	}
+
 	setSession(session: AuthenticationSession | undefined): void {
 		this._anyGitHubSession = session;
 	}

--- a/extensions/copilot/src/extension/conversation/vscode-node/languageModelAccess.ts
+++ b/extensions/copilot/src/extension/conversation/vscode-node/languageModelAccess.ts
@@ -558,7 +558,7 @@ export class LanguageModelAccess extends Disposable implements IExtensionContrib
 	}
 
 	private async _getToken(): Promise<CopilotToken | undefined> {
-		if (!this._authenticationService.anyGitHubSession) {
+		if (!this._authenticationService.hasCopilotTokenSource) {
 			this._logService.warn('[LanguageModelAccess] LanguageModel/Embeddings are not available without auth session');
 			return undefined;
 		}

--- a/extensions/copilot/src/extension/conversation/vscode-node/languageModelAccess.ts
+++ b/extensions/copilot/src/extension/conversation/vscode-node/languageModelAccess.ts
@@ -559,7 +559,7 @@ export class LanguageModelAccess extends Disposable implements IExtensionContrib
 
 	private async _getToken(): Promise<CopilotToken | undefined> {
 		if (!this._authenticationService.hasCopilotTokenSource) {
-			this._logService.warn('[LanguageModelAccess] LanguageModel/Embeddings are not available without auth session');
+			this._logService.warn('[LanguageModelAccess] LanguageModel/Embeddings are not available without a Copilot token source');
 			return undefined;
 		}
 

--- a/extensions/copilot/src/lib/vscode-node/test/getInlineCompletions.spec.ts
+++ b/extensions/copilot/src/lib/vscode-node/test/getInlineCompletions.spec.ts
@@ -112,6 +112,7 @@ class TestAuthService extends Disposable implements IAuthenticationService {
 	readonly isMinimalMode = true;
 	readonly anyGitHubSession = undefined;
 	readonly permissiveGitHubSession = undefined;
+	readonly hasCopilotTokenSource = true;
 	readonly copilotToken = createTestCopilotToken();
 	speculativeDecodingEndpointToken: string | undefined;
 

--- a/extensions/copilot/src/platform/authentication/common/authentication.ts
+++ b/extensions/copilot/src/platform/authentication/common/authentication.ts
@@ -73,6 +73,17 @@ export interface IAuthenticationService {
 	readonly anyGitHubSession: AuthenticationSession | undefined;
 
 	/**
+	 * Whether the authentication service has a source from which a Copilot token can potentially be obtained
+	 * (e.g. a cached GitHub session, a static token provider, or a proxy/HMAC pathway). This is used as a fast,
+	 * synchronous gate before calling {@link getCopilotToken} in air-gapped/BYOK scenarios.
+	 *
+	 * Unlike {@link anyGitHubSession}, this does not assume GitHub OAuth is the only token pathway, so it stays
+	 * truthy for proxy/HMAC and test-harness implementations where {@link getCopilotToken} succeeds without a
+	 * cached GitHub session.
+	 */
+	readonly hasCopilotTokenSource: boolean;
+
+	/**
 	 * Checks if there is currently a permissive session available in the cache. Does not make any network requests and does not
 	 * call out to the underlying authentication provider.
 	 *
@@ -207,6 +218,14 @@ export abstract class BaseAuthenticationService extends Disposable implements IA
 	protected _anyGitHubSession: AuthenticationSession | undefined;
 	get anyGitHubSession(): AuthenticationSession | undefined {
 		return this._anyGitHubSession;
+	}
+
+	//#endregion
+
+	//#region Copilot Token Source
+
+	get hasCopilotTokenSource(): boolean {
+		return !!this._anyGitHubSession;
 	}
 
 	//#endregion

--- a/extensions/copilot/src/platform/authentication/common/staticGitHubAuthenticationService.ts
+++ b/extensions/copilot/src/platform/authentication/common/staticGitHubAuthenticationService.ts
@@ -43,6 +43,12 @@ export class StaticGitHubAuthenticationService extends BaseAuthenticationService
 		} : undefined;
 	}
 
+	override get hasCopilotTokenSource(): boolean {
+		// Static auth always represents a non-OAuth token pathway (proxy/HMAC, eval harness, ...),
+		// so a Copilot token is obtainable even when no GitHub session is cached.
+		return true;
+	}
+
 	override async getGitHubSession(kind: 'permissive' | 'any', options: AuthenticationGetSessionOptions & { createIfNone: StrictAuthenticationPresentationOptions }): Promise<AuthenticationSession>;
 	override async getGitHubSession(kind: 'permissive' | 'any', options: AuthenticationGetSessionOptions & { forceNewSession: StrictAuthenticationPresentationOptions }): Promise<AuthenticationSession>;
 	override async getGitHubSession(kind: 'permissive' | 'any', options: AuthenticationGetSessionOptions): Promise<AuthenticationSession | undefined>;

--- a/extensions/copilot/src/platform/authentication/test/node/authentication.spec.ts
+++ b/extensions/copilot/src/platform/authentication/test/node/authentication.spec.ts
@@ -72,6 +72,21 @@ suite('AuthenticationService', function () {
 		expect(authenticationService.copilotToken?.token).toBe(testToken);
 	});
 
+	test('hasCopilotTokenSource is true for static auth even without a GitHub session', () => {
+		// Static auth represents non-OAuth Copilot token pathways (proxy/HMAC, eval harness, ...),
+		// so it must report a token source regardless of whether anyGitHubSession is populated.
+		const accessor = disposables.add(createPlatformServices().createTestingAccessor());
+		const staticWithoutSession = disposables.add(new StaticGitHubAuthenticationService(
+			undefined,
+			accessor.get(ILogService),
+			accessor.get(ICopilotTokenStore),
+			copilotTokenManager,
+			accessor.get(IConfigurationService),
+		));
+		expect(staticWithoutSession.anyGitHubSession).toBeUndefined();
+		expect(staticWithoutSession.hasCopilotTokenSource).toBe(true);
+	});
+
 	test('Emits onDidAuthenticationChange when a Copilot Token change is notified', async () => {
 		const promise = Event.toPromise(authenticationService.onDidAuthenticationChange);
 		const newToken = 'tid=new';

--- a/extensions/copilot/src/platform/embeddings/common/remoteEmbeddingsComputer.ts
+++ b/extensions/copilot/src/platform/embeddings/common/remoteEmbeddingsComputer.ts
@@ -64,8 +64,8 @@ export class RemoteEmbeddingsComputer implements IEmbeddingsComputer {
 		});
 		try {
 			return await logExecTime(this._logService, 'RemoteEmbeddingsComputer::computeEmbeddings', async () => {
-				// The remote embeddings endpoint requires GitHub authentication.
-				if (!this._authService.anyGitHubSession) {
+				// The remote embeddings endpoint requires a Copilot token.
+				if (!this._authService.hasCopilotTokenSource) {
 					return { type: embeddingType, values: [] };
 				}
 

--- a/extensions/copilot/src/platform/embeddings/common/remoteEmbeddingsComputer.ts
+++ b/extensions/copilot/src/platform/embeddings/common/remoteEmbeddingsComputer.ts
@@ -76,9 +76,12 @@ export class RemoteEmbeddingsComputer implements IEmbeddingsComputer {
 					return embeddings ?? { type: embeddingType, values: [] };
 				}
 
+				// The Dotcom embeddings path requires a GitHub access token. Token pathways that mint a
+				// Copilot token without a cached GitHub session (proxy/HMAC, eval harness) cannot reach this
+				// endpoint, so fall back to returning empty embeddings instead of throwing.
 				const token = (await this._authService.getGitHubSession('any', { silent: true }))?.accessToken;
 				if (!token) {
-					throw new Error('No authentication token available');
+					return { type: embeddingType, values: [] };
 				}
 
 				const embeddingsOut: Embedding[] = [];

--- a/extensions/copilot/src/platform/ignore/node/test/mockAuthenticationService.ts
+++ b/extensions/copilot/src/platform/ignore/node/test/mockAuthenticationService.ts
@@ -21,6 +21,7 @@ export class MockAuthenticationService implements IAuthenticationService {
 	readonly onDidAdoAuthenticationChange: Event<void> = Event.None;
 	readonly anyGitHubSession: AuthenticationSession | undefined = undefined;
 	readonly permissiveGitHubSession: AuthenticationSession | undefined = undefined;
+	readonly hasCopilotTokenSource: boolean = false;
 
 	copilotToken: Omit<CopilotToken, 'token'> | undefined = undefined;
 	speculativeDecodingEndpointToken: string | undefined = undefined;


### PR DESCRIPTION
Fixes microsoft/vscode-copilot-evaluation#3977

## Problem

PR #317428 added `anyGitHubSession` guards in front of several Copilot token pathways to handle the air-gapped/BYOK case. That works for end-user OAuth scenarios, but it conflates *"has a cached GitHub OAuth session"* with *"can obtain a Copilot token"*. In eval-harness/proxy/HMAC scenarios these are uncorrelated: `getCopilotToken()` resolves successfully via the alternate auth path, but `anyGitHubSession` is `undefined`, so the new guard short-circuits before the real auth pathway runs and the `copilot/*` LM provider publishes zero models.

## Fix

Add a `hasCopilotTokenSource: boolean` predicate to `IAuthenticationService`. It is defaulted on `BaseAuthenticationService` to `!!this._anyGitHubSession` (so the real `AuthenticationService` keeps existing behavior) and overridden to `true` on `StaticGitHubAuthenticationService`, which exists precisely to represent non-OAuth Copilot token pathways (proxy/HMAC, eval harness). Group-A call sites that gate on *"can we mint a Copilot token?"* are switched to `hasCopilotTokenSource`:

- `languageModelAccess._getToken` (the original eval regression site)
- `authentication.contribution.waitForChatEnabled`
- `copilotCli` (`_fetchAndCacheModels`, `getModels`, `provideLanguageModelChatInformation`)
- `remoteEmbeddingsComputer`

Group-B sites that intentionally gate on a real signed-in GitHub user keep using `anyGitHubSession` (they pair with `copilotToken?.isNoAuthUser` and are explicitly about Copilot-as-signed-in-user):

- `conversationFeature` AI search / settings-search / participant-detection provider registration
- `byokUtilityModel.contribution` (the whole notification is about being signed out)

## Tests

Added a test in `authentication.spec.ts` verifying `StaticGitHubAuthenticationService.hasCopilotTokenSource === true` even when `anyGitHubSession` is undefined. Updated test doubles (`mockAuthenticationService`, `getInlineCompletions.spec`, `copilotCliModels.spec`) to expose the new property.

All impacted vitest specs pass; 0 TypeScript errors.