### PR TITLE
feat: Implement changeset state caching and management in AgentHost

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostChangesetCoordinator.ts
+++ b/src/vs/platform/agentHost/node/agentHostChangesetCoordinator.ts
@@ -228,6 +228,32 @@ export class ChangesetSessionCoordinator extends Disposable {
 	}
 
 	/**
+	 * Restores the parent session when `resource` is a changeset URI and the
+	 * parent session is not already live. Returns `true` for known changeset
+	 * resources and `false` for non-changeset URIs.
+	 *
+	 * This is intentionally narrower than {@link tryHandleSubscribe}: it does
+	 * not compute per-turn / compare changesets and does not register static
+	 * changesets. It exists for the AgentService subscribe path where
+	 * `addSubscriber` may have already created a placeholder changeset snapshot
+	 * before the parent session restore had a chance to apply persisted diffs.
+	 */
+	async restoreSessionIfChangesetSubscription(resource: URI, restoreSession: (session: URI) => Promise<void>): Promise<boolean> {
+		const resourceStr = resource.toString();
+		const parsed = parseChangesetUri(resourceStr);
+		if (!parsed) {
+			return false;
+		}
+		if (parsed.kind === ChangesetKind.Unknown) {
+			throw new Error(`Cannot subscribe to unknown changeset resource: ${resourceStr}`);
+		}
+		if (!this._stateManager.getSessionState(parsed.sessionUri)) {
+			await restoreSession(URI.parse(parsed.sessionUri));
+		}
+		return true;
+	}
+
+	/**
 	 * If `resource` is a known changeset URI (uncommitted / session /
 	 * turn), seeds its state on the state manager and returns `true`.
 	 * Returns `false` for non-changeset URIs so callers fall through to
@@ -251,9 +277,7 @@ export class ChangesetSessionCoordinator extends Disposable {
 		if (parsed.kind === ChangesetKind.Unknown) {
 			throw new Error(`Cannot subscribe to unknown changeset resource: ${resourceStr}`);
 		}
-		if (!this._stateManager.getSessionState(parsed.sessionUri)) {
-			await restoreSession(URI.parse(parsed.sessionUri));
-		}
+		await this.restoreSessionIfChangesetSubscription(resource, restoreSession);
 		if (parsed.kind === ChangesetKind.Turn && parsed.turnId) {
 			await this._changesets.computeTurnChangeset(parsed.sessionUri, parsed.turnId);
 		} else if (parsed.kind === ChangesetKind.Compare && parsed.originalTurnId && parsed.modifiedTurnId) {

--- a/src/vs/platform/agentHost/node/agentHostChangesetCoordinator.ts
+++ b/src/vs/platform/agentHost/node/agentHostChangesetCoordinator.ts
@@ -333,15 +333,15 @@ export class ChangesetSessionCoordinator extends Disposable {
 		if (uncommittedRaw === undefined && sessionRaw === undefined && legacyRaw === undefined) {
 			return entry;
 		}
-		const restored = this._changesets.restorePersistedStaticChangesets(sessionStr, {
+		const restored = this._changesets.parsePersistedStaticChangesets(sessionStr, {
 			uncommittedRaw,
 			sessionRaw,
 			legacyRaw,
 		});
-		// `restorePersistedStaticChangesets` seeds the state manager; the
-		// catalogue itself is built here for unopened sessions only. Once
-		// the session is opened via `restoreSession`, the live overlay in
-		// `AgentService.listSessions` replaces this.
+		// `listSessions` must not seed full changeset state for every row;
+		// it only parses persisted blobs enough to render catalogue counts.
+		// Once the session is opened via `restoreSession`, the live overlay in
+		// `AgentService.listSessions` replaces this parse-only catalogue.
 		if (!liveSessionState) {
 			const catalogue = buildCatalogueFromPersistedDiffs(sessionStr, restored.uncommitted, restored.session);
 			if (catalogue) {

--- a/src/vs/platform/agentHost/node/agentHostChangesetCoordinator.ts
+++ b/src/vs/platform/agentHost/node/agentHostChangesetCoordinator.ts
@@ -229,8 +229,7 @@ export class ChangesetSessionCoordinator extends Disposable {
 
 	/**
 	 * Restores the parent session when `resource` is a changeset URI and the
-	 * parent session is not already live. Returns `true` for known changeset
-	 * resources and `false` for non-changeset URIs.
+	 * parent session is not already live. Non-changeset URIs are ignored.
 	 *
 	 * This is intentionally narrower than {@link tryHandleSubscribe}: it does
 	 * not compute per-turn / compare changesets and does not register static
@@ -238,11 +237,11 @@ export class ChangesetSessionCoordinator extends Disposable {
 	 * `addSubscriber` may have already created a placeholder changeset snapshot
 	 * before the parent session restore had a chance to apply persisted diffs.
 	 */
-	async restoreSessionIfChangesetSubscription(resource: URI, restoreSession: (session: URI) => Promise<void>): Promise<boolean> {
+	async restoreSessionIfChangesetSubscription(resource: URI, restoreSession: (session: URI) => Promise<void>): Promise<void> {
 		const resourceStr = resource.toString();
 		const parsed = parseChangesetUri(resourceStr);
 		if (!parsed) {
-			return false;
+			return;
 		}
 		if (parsed.kind === ChangesetKind.Unknown) {
 			throw new Error(`Cannot subscribe to unknown changeset resource: ${resourceStr}`);
@@ -250,7 +249,6 @@ export class ChangesetSessionCoordinator extends Disposable {
 		if (!this._stateManager.getSessionState(parsed.sessionUri)) {
 			await restoreSession(URI.parse(parsed.sessionUri));
 		}
-		return true;
 	}
 
 	/**

--- a/src/vs/platform/agentHost/node/agentHostChangesetService.ts
+++ b/src/vs/platform/agentHost/node/agentHostChangesetService.ts
@@ -234,22 +234,44 @@ export interface IAgentHostChangesetService {
 
 	/**
 	 * Parses the persisted changeset metadata blobs (`uncommitted`,
-	 * `session`, and the legacy `diffs` fallback for `session`), applies
-	 * each parsed file list via {@link restoreStaticChangeset}, and returns
-	 * the parsed diffs so the caller can pass them into
-	 * {@link buildCatalogueFromPersistedDiffs} for the session-list overlay.
+	 * `session`, and the legacy `diffs` fallback for `session`) without
+	 * mutating live state. Intended for list overlays that only need
+	 * aggregate catalogue counts and should not pin full changeset state in
+	 * memory.
+	 */
+	parsePersistedStaticChangesets(sessionUri: ProtocolURI, metadata: IPersistedChangesetMetadata): IRestoredChangesetDiffs;
+
+	/**
+	 * Applies parsed persisted changeset diffs to live state via
+	 * {@link restoreStaticChangeset}. This is the side-effectful half of
+	 * persisted restore and should only be used on real restore/subscribe
+	 * paths that need a subscribable changeset snapshot.
+	 *
+	 * Honours `seedIfEmpty`: when a live changeset state already has files
+	 * for the same kind, persisted diffs are NOT applied (they would
+	 * otherwise overwrite the live state).
+	 */
+	applyPersistedStaticChangesets(sessionUri: ProtocolURI, diffs: IRestoredChangesetDiffs): void;
+
+	/**
+	 * Compatibility wrapper that parses persisted changeset metadata and then
+	 * applies it to live state. New list-overlay callers should prefer
+	 * {@link parsePersistedStaticChangesets}; restore/subscribe callers can
+	 * use this method when they intentionally want both parse and seed.
 	 *
 	 * The `AgentService` orchestration boundary batches the metadata read
 	 * (custom title + read / archive flags + config values + these three
 	 * blobs) in a single database round-trip, then hands the raw values
 	 * here; the service does not open the database itself for this method.
-	 *
-	 * Honours `seedIfEmpty`: when a live changeset state already has files
-	 * for the same kind, persisted diffs are NOT applied (they would
-	 * otherwise overwrite the live state). Malformed JSON is logged and
-	 * the corresponding slot is left `undefined`.
 	 */
 	restorePersistedStaticChangesets(sessionUri: ProtocolURI, metadata: IPersistedChangesetMetadata): IRestoredChangesetDiffs;
+
+	/**
+	 * Returns true when the static changeset identified by `changesetUri` is
+	 * currently being recomputed. Used by cache eviction to avoid dropping a
+	 * slot while its producer is mid-flight.
+	 */
+	isStaticChangesetComputeActive(changesetUri: ProtocolURI): boolean;
 
 	/**
 	 * Lazy refresh of the uncommitted changeset, kicked off when a client
@@ -330,6 +352,7 @@ export class AgentHostChangesetService extends Disposable implements IAgentHostC
 	private readonly _debouncedDiffTimers = this._register(new DisposableMap<string>());
 	/** Per-`(session, turnId)` debounce timers for mid-turn per-turn changeset recomputation. */
 	private readonly _perTurnDebouncedDiffTimers = this._register(new DisposableMap<string>());
+	private readonly _activeStaticComputes = new Set<ProtocolURI>();
 	private static readonly _DIFF_DEBOUNCE_MS = 5000;
 
 	/**
@@ -371,22 +394,34 @@ export class AgentHostChangesetService extends Disposable implements IAgentHostC
 		this._publishChangesetDiffs(session, changesetUri, diffs);
 	}
 
-	restorePersistedStaticChangesets(sessionUri: ProtocolURI, metadata: IPersistedChangesetMetadata): IRestoredChangesetDiffs {
+	parsePersistedStaticChangesets(sessionUri: ProtocolURI, metadata: IPersistedChangesetMetadata): IRestoredChangesetDiffs {
 		const persistedUncommitted = tryParsePersistedDiffs(metadata.uncommittedRaw, sessionUri, 'uncommitted', this._logService);
 		// Legacy `diffs` is the migration fallback for the session-wide
 		// changeset only — it never carried uncommitted state.
 		const persistedSession = tryParsePersistedDiffs(metadata.sessionRaw, sessionUri, 'session', this._logService)
 			?? tryParsePersistedDiffs(metadata.legacyRaw, sessionUri, 'session (legacy)', this._logService);
 
+		return { uncommitted: persistedUncommitted, session: persistedSession };
+	}
+
+	applyPersistedStaticChangesets(sessionUri: ProtocolURI, diffs: IRestoredChangesetDiffs): void {
 		// `seedIfEmpty`: only reseed persisted diffs when the matching live
 		// changeset state is absent or empty. Live state (e.g. from a prior
 		// refresh in this lifetime) is always more authoritative than a
 		// potentially-stale persisted blob; without this guard a fresh
 		// `restorePersistedStaticChangesets` call would clobber it.
-		this._seedIfEmpty(sessionUri, 'uncommitted', persistedUncommitted);
-		this._seedIfEmpty(sessionUri, 'session', persistedSession);
+		this._seedIfEmpty(sessionUri, 'uncommitted', diffs.uncommitted);
+		this._seedIfEmpty(sessionUri, 'session', diffs.session);
+	}
 
-		return { uncommitted: persistedUncommitted, session: persistedSession };
+	restorePersistedStaticChangesets(sessionUri: ProtocolURI, metadata: IPersistedChangesetMetadata): IRestoredChangesetDiffs {
+		const parsed = this.parsePersistedStaticChangesets(sessionUri, metadata);
+		this.applyPersistedStaticChangesets(sessionUri, parsed);
+		return parsed;
+	}
+
+	isStaticChangesetComputeActive(changesetUri: ProtocolURI): boolean {
+		return this._activeStaticComputes.has(changesetUri);
 	}
 
 	private _seedIfEmpty(session: ProtocolURI, kind: StaticChangesetKind, diffs: readonly ISessionFileDiff[] | undefined): void {
@@ -662,14 +697,18 @@ export class AgentHostChangesetService extends Disposable implements IAgentHostC
 	}
 
 	private async _doComputeStaticChangeset(session: ProtocolURI, kind: StaticChangesetKind, changedTurnId?: string): Promise<void> {
+		const changesetUri = staticChangesetUri(session, kind);
+		this._activeStaticComputes.add(changesetUri);
 		let ref: ReturnType<ISessionDataService['openDatabase']>;
 		try {
 			ref = this._sessionDataService.openDatabase(URI.parse(session));
 		} catch (err) {
 			this._logService.warn(`[AgentHostChangesetService] Failed to open session database for ${kind} diff computation: ${session}`, err);
+			this._activeStaticComputes.delete(changesetUri);
+			this._stateManager.onChangesetLivenessChanged();
 			return;
 		}
-		const changesetUri = this._stateManager.registerChangeset(staticChangesetUri(session, kind));
+		this._stateManager.registerChangeset(changesetUri);
 		try {
 			let diffs = await this._tryComputeGitDiffs(session, ref.object, kind);
 			if (!diffs) {
@@ -717,6 +756,8 @@ export class AgentHostChangesetService extends Disposable implements IAgentHostC
 				error: { errorType: 'computeFailed', message: err instanceof Error ? err.message : String(err) },
 			});
 		} finally {
+			this._activeStaticComputes.delete(changesetUri);
+			this._stateManager.onChangesetLivenessChanged();
 			ref.dispose();
 		}
 	}

--- a/src/vs/platform/agentHost/node/agentHostChangesetStateCache.ts
+++ b/src/vs/platform/agentHost/node/agentHostChangesetStateCache.ts
@@ -1,0 +1,126 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { LinkedMap, Touch } from '../../../base/common/map.js';
+import { ChangesetStatus, type ChangesetState, type URI } from '../common/state/sessionState.js';
+
+/**
+ * Default number of expanded changeset states kept hot in memory.
+ *
+ * This cache only stores the subscribable `ChangesetState` payloads. The
+ * lightweight catalogue on `SessionSummary.changesets` remains on the session
+ * summary, and static changesets can be rehydrated from persisted metadata or
+ * recomputed on demand. The limit is intentionally a soft cap: subscribed or
+ * actively-computing changesets may pin the cache above this value until they
+ * become evictable.
+ */
+const DEFAULT_CHANGESET_STATE_SOFT_LIMIT = 500;
+
+export interface IAgentHostChangesetStateRetentionOptions {
+	/**
+	 * Number of expanded changeset states kept hot in memory. The limit is soft:
+	 * entries for which {@link canEvict} returns false may temporarily keep the
+	 * cache above this value.
+	 */
+	readonly softLimit?: number;
+
+	/**
+	 * Returns whether a changeset state can be silently evicted from the cache.
+	 * Production callers should provide this from `AgentService`, which owns
+	 * protocol subscription refcounts and can ask the changeset service about
+	 * active producers. Return false for changesets that are subscribed or have
+	 * an active producer that may still publish into the changeset URI.
+	 */
+	readonly canEvict?: (changeset: URI) => boolean;
+}
+
+/**
+ * Owns the memory policy for expanded changeset states.
+ *
+ * The state manager owns protocol sequencing and reducer application; this
+ * helper owns the cache mechanics needed to keep dormant changesets bounded.
+ * Eviction here is deliberately silent: protocol-visible teardown still goes
+ * through `AgentHostStateManager.disposeChangeset`, which emits
+ * `ChangesetCleared` before removing state.
+ */
+export class AgentHostChangesetStateCache {
+
+	private readonly _states = new Map<string, ChangesetState>();
+	private readonly _lru = new LinkedMap<string, true>();
+	private readonly _softLimit: number;
+	private readonly _canEvict: (changeset: URI) => boolean;
+
+	constructor(options: IAgentHostChangesetStateRetentionOptions = {}) {
+		this._softLimit = Math.max(0, options.softLimit ?? DEFAULT_CHANGESET_STATE_SOFT_LIMIT);
+		this._canEvict = options.canEvict ?? (() => true);
+	}
+
+	keys(): IterableIterator<string> {
+		return this._states.keys();
+	}
+
+	has(changeset: URI): boolean {
+		return this._states.has(changeset);
+	}
+
+	get(changeset: URI): ChangesetState | undefined {
+		this._touch(changeset);
+		return this._states.get(changeset);
+	}
+
+	set(changeset: URI, state: ChangesetState): void {
+		this._states.set(changeset, state);
+		this._touch(changeset);
+		this._evictIfOverLimit();
+	}
+
+	delete(changeset: URI): void {
+		this._states.delete(changeset);
+		this._lru.delete(changeset);
+	}
+
+	register(changeset: URI, initialStatus: ChangesetStatus = ChangesetStatus.Computing): void {
+		if (this._states.has(changeset)) {
+			this._touch(changeset);
+			return;
+		}
+		this.set(changeset, { status: initialStatus, files: [] });
+	}
+
+	/** Re-runs eviction after external liveness changes, such as unsubscribe or compute completion. */
+	trimEvictableEntries(): void {
+		this._evictIfOverLimit();
+	}
+
+	private _touch(changeset: URI): void {
+		if (this._states.has(changeset)) {
+			this._lru.set(changeset, true, Touch.AsNew);
+		}
+	}
+
+	private _evictIfOverLimit(): void {
+		if (this._softLimit === 0) {
+			for (const changeset of [...this._lru.keys()]) {
+				if (this._canEvict(changeset)) {
+					this.delete(changeset);
+				}
+			}
+			return;
+		}
+
+		for (const changeset of [...this._lru.keys()]) {
+			if (this._states.size <= this._softLimit) {
+				return;
+			}
+			if (!this._states.has(changeset)) {
+				this._lru.delete(changeset);
+				continue;
+			}
+			if (this._canEvict(changeset)) {
+				this.delete(changeset);
+			}
+		}
+	}
+}

--- a/src/vs/platform/agentHost/node/agentHostStateManager.ts
+++ b/src/vs/platform/agentHost/node/agentHostStateManager.ts
@@ -16,6 +16,11 @@ import { createRootState, createSessionState, isAhpRootChannel, SessionLifecycle
 import { AgentHostTelemetryLevelConfigKey, IPermissionsValue, platformRootSchema, telemetryLevelToAgentHostConfigValue } from '../common/agentHostSchema.js';
 import { SessionConfigKey } from '../common/sessionConfigKeys.js';
 import { parseChangesetUri } from '../common/changesetUri.js';
+import { AgentHostChangesetStateCache, type IAgentHostChangesetStateRetentionOptions } from './agentHostChangesetStateCache.js';
+
+export interface IAgentHostStateManagerOptions {
+	readonly changesetStateRetention?: IAgentHostChangesetStateRetentionOptions;
+}
 
 /**
  * Field-level equality for two changeset catalogue arrays. Used by
@@ -55,12 +60,8 @@ export class AgentHostStateManager extends Disposable {
 	private _rootState: RootState;
 	private readonly _sessionStates = new Map<string, SessionState>();
 
-	/**
-	 * Per-changeset state, keyed by the **expanded** changeset URI (the
-	 * value the client will pass to `subscribe` after expanding the
-	 * `uriTemplate` from the catalogue).
-	 */
-	private readonly _changesetStates = new Map<string, ChangesetState>();
+	/** Expanded changeset states, separated from protocol sequencing so cache policy stays local. */
+	private readonly _changesets: AgentHostChangesetStateCache;
 
 	/**
 	 * Sessions whose authoritative state has an active turn. Derived from
@@ -87,8 +88,10 @@ export class AgentHostStateManager extends Disposable {
 
 	constructor(
 		@ILogService private readonly _logService: ILogService,
+		options: IAgentHostStateManagerOptions = {},
 	) {
 		super();
+		this._changesets = new AgentHostChangesetStateCache(options.changesetStateRetention);
 		this._rootState = createRootState();
 		// Seed the host-level configuration schema + default values so that
 		// RootConfigChanged actions can merge into it, and clients see the
@@ -162,7 +165,7 @@ export class AgentHostStateManager extends Disposable {
 		// Changeset URIs are nested under their session URI; check them
 		// before falling back to the session map so a session whose URI
 		// happens to share a prefix with a changeset never collides.
-		const changesetState = this._changesetStates.get(resource);
+		const changesetState = this._changesets.get(resource);
 		if (changesetState) {
 			return {
 				resource,
@@ -185,7 +188,12 @@ export class AgentHostStateManager extends Disposable {
 
 	/** Read-only accessor for callers that only need to inspect a changeset (not subscribe). */
 	getChangesetState(changeset: URI): ChangesetState | undefined {
-		return this._changesetStates.get(changeset);
+		return this._changesets.get(changeset);
+	}
+
+	/** Reconsiders changeset state retention after subscribers or computes release their pins. */
+	onChangesetLivenessChanged(): void {
+		this._changesets.trimEvictableEntries();
 	}
 
 	// ---- Session lifecycle --------------------------------------------------
@@ -415,10 +423,7 @@ export class AgentHostStateManager extends Disposable {
 	 * Returns the supplied changeset URI for caller convenience.
 	 */
 	registerChangeset(changesetUri: URI, initialStatus: ChangesetStatus = ChangesetStatus.Computing): URI {
-		if (this._changesetStates.has(changesetUri)) {
-			return changesetUri;
-		}
-		this._changesetStates.set(changesetUri, { status: initialStatus, files: [] });
+		this._changesets.register(changesetUri, initialStatus);
 		return changesetUri;
 	}
 
@@ -473,13 +478,13 @@ export class AgentHostStateManager extends Disposable {
 	 * actions defensively.
 	 */
 	disposeChangeset(changeset: URI): void {
-		if (!this._changesetStates.has(changeset)) {
+		if (!this._changesets.has(changeset)) {
 			return;
 		}
 		this.dispatchServerAction(changeset, {
 			type: ActionType.ChangesetCleared,
 		});
-		this._changesetStates.delete(changeset);
+		this._changesets.delete(changeset);
 	}
 
 	/**
@@ -491,7 +496,7 @@ export class AgentHostStateManager extends Disposable {
 		// Collect first because `disposeChangeset` mutates the underlying
 		// map via its envelope handler.
 		const toDispose: URI[] = [];
-		for (const uri of this._changesetStates.keys()) {
+		for (const uri of this._changesets.keys()) {
 			const parsed = parseChangesetUri(uri);
 			if (parsed && parsed.sessionUri === session) {
 				toDispose.push(uri);
@@ -604,7 +609,7 @@ export class AgentHostStateManager extends Disposable {
 		if (isChangesetAction(action)) {
 			const changesetAction = action as ChangesetAction;
 			const key = channel;
-			const state = this._changesetStates.get(key);
+			const state = this._changesets.get(key);
 			if (!state) {
 				// Unknown changeset: log and bail before envelope creation.
 				// Routing the action to subscribers (Issue 1) makes
@@ -615,7 +620,7 @@ export class AgentHostStateManager extends Disposable {
 			}
 			const newState = changesetReducer(state, changesetAction, this._log);
 			if (newState !== state) {
-				this._changesetStates.set(key, newState);
+				this._changesets.set(key, newState);
 			}
 			resultingState = newState;
 		}

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -21,7 +21,7 @@ import { ServiceCollection } from '../../instantiation/common/serviceCollection.
 import { ILogService } from '../../log/common/log.js';
 import { AgentProvider, AgentSession, IAgent, IAgentCreateSessionConfig, IAgentMaterializeSessionEvent, IAgentResolveSessionConfigParams, IAgentService, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, AuthenticateParams, AuthenticateResult } from '../common/agentService.js';
 import { ISessionDataService, SESSION_ATTACHMENTS_DIRNAME } from '../common/sessionDataService.js';
-import { buildDefaultChangesetCatalogue, buildSessionChangesetUri, buildUncommittedChangesetUri, formatSessionChangesetDescription } from '../common/changesetUri.js';
+import { buildDefaultChangesetCatalogue, buildSessionChangesetUri, buildUncommittedChangesetUri, formatSessionChangesetDescription, parseChangesetUri } from '../common/changesetUri.js';
 import { ActionType, ActionEnvelope, INotification, type IRootConfigChangedAction, type SessionAction, type TerminalAction } from '../common/state/sessionActions.js';
 import type { CompletionsParams, CompletionsResult, CreateTerminalParams, ResolveSessionConfigResult, SessionConfigCompletionsResult } from '../common/state/protocol/commands.js';
 import { AhpErrorCodes, AHP_SESSION_NOT_FOUND, ContentEncoding, JSON_RPC_INTERNAL_ERROR, ProtocolError, type DirectoryEntry, type ResourceCopyParams, type ResourceCopyResult, type ResourceDeleteParams, type ResourceDeleteResult, type ResourceListResult, type ResourceMoveParams, type ResourceMoveResult, type ResourceReadResult, type ResourceWriteParams, type ResourceWriteResult, type IStateSnapshot } from '../common/state/sessionProtocol.js';
@@ -147,7 +147,14 @@ export class AgentService extends Disposable implements IAgentService {
 	) {
 		super();
 		this._logService.info('AgentService initialized');
-		this._stateManager = this._register(new AgentHostStateManager(_logService));
+		this._stateManager = this._register(new AgentHostStateManager(_logService, {
+			changesetStateRetention: {
+				// The cache calls this lazily after construction. If a future state-manager
+				// initialization path registers changesets before `_changesets` is assigned,
+				// keep the entry pinned rather than evicting with incomplete liveness data.
+				canEvict: changeset => this._changesets ? this._isChangesetEvictable(changeset) : false,
+			},
+		}));
 		this._register(this._stateManager.onDidEmitEnvelope(e => this._onDidAction.fire(e)));
 		this._register(this._stateManager.onDidEmitNotification(e => this._onDidNotification.fire(e)));
 
@@ -855,6 +862,7 @@ export class AgentService extends Disposable implements IAgentService {
 		}
 		this._resourceSubscribers.delete(resource);
 		this._changesetCoordinator.onLastSubscriber(resource);
+		this._stateManager.onChangesetLivenessChanged();
 		// An empty session whose last subscriber dropped is a candidate for
 		// full GC (provider session, worktree, on-disk state). Sessions with
 		// at least one turn fall through to {@link _maybeEvictIdleSession},
@@ -977,6 +985,47 @@ export class AgentService extends Disposable implements IAgentService {
 			this._stateManager.removeSession(cachedKey);
 		}
 		this._stateManager.removeSession(evictionTargetKey);
+	}
+
+	/**
+	 * Subscriber-aware guard for {@link AgentHostStateManager}'s changeset retention.
+	 * The state manager owns the changeset state cache, but it deliberately
+	 * does not know about protocol subscribers or changeset compute lifetimes.
+	 * Keep that cross-component knowledge here, next to `_resourceSubscribers`:
+	 *
+	 * - A direct changeset subscriber means a client is rendering the expanded
+	 *   changeset URI, so evicting would make the next envelope target a missing
+	 *   state object.
+	 * - A parent session subscriber means the session catalogue can still be
+	 *   updated from the static changeset counts, so keep the backing state live
+	 *   while the session itself is observed.
+	 * - A subscribed subagent descendant pins the parent session tree; treat it
+	 *   like a parent-session subscriber for eviction purposes.
+	 * - An active static recompute owns the slot until it publishes or fails.
+	 *
+	 * Eviction that passes this predicate is silent and lossy only as a cache
+	 * operation: persisted diffs can rehydrate the changeset on the next restore
+	 * / subscribe path, and no client is currently observing the entry.
+	 */
+	private _isChangesetEvictable(changeset: string): boolean {
+		const changesetUri = URI.parse(changeset);
+		if (this._resourceSubscribers.has(changesetUri)) {
+			return false;
+		}
+		const parsed = parseChangesetUri(changeset);
+		if (!parsed) {
+			return false;
+		}
+		const sessionUri = URI.parse(parsed.sessionUri);
+		if (this._resourceSubscribers.has(sessionUri)) {
+			return false;
+		}
+		for (const subscribedUri of this._resourceSubscribers.keys()) {
+			if (this._isSubagentDescendantOf(subscribedUri, sessionUri)) {
+				return false;
+			}
+		}
+		return !this._changesets.isStaticChangesetComputeActive(changeset);
 	}
 
 	private _isSubagentDescendantOf(resource: URI, parent: URI): boolean {

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -789,6 +789,11 @@ export class AgentService extends Disposable implements IAgentService {
 			}
 
 			let snapshot = this._stateManager.getSnapshot(resourceStr);
+			const parsedChangeset = parseChangesetUri(resourceStr);
+			if (snapshot && parsedChangeset && !this._stateManager.getSessionState(parsedChangeset.sessionUri)) {
+				await this._changesetCoordinator.restoreSessionIfChangesetSubscription(resource, s => this.restoreSession(s));
+				snapshot = this._stateManager.getSnapshot(resourceStr);
+			}
 			if (!snapshot) {
 				// Changeset URIs are routed through the coordinator (which
 				// owns its URI shape, the unknown-id early throw, and turn

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -992,44 +992,35 @@ export class AgentService extends Disposable implements IAgentService {
 		this._stateManager.removeSession(evictionTargetKey);
 	}
 
-	/**
-	 * Subscriber-aware guard for {@link AgentHostStateManager}'s changeset retention.
-	 * The state manager owns the changeset state cache, but it deliberately
-	 * does not know about protocol subscribers or changeset compute lifetimes.
-	 * Keep that cross-component knowledge here, next to `_resourceSubscribers`:
-	 *
-	 * - A direct changeset subscriber means a client is rendering the expanded
-	 *   changeset URI, so evicting would make the next envelope target a missing
-	 *   state object.
-	 * - A parent session subscriber means the session catalogue can still be
-	 *   updated from the static changeset counts, so keep the backing state live
-	 *   while the session itself is observed.
-	 * - A subscribed subagent descendant pins the parent session tree; treat it
-	 *   like a parent-session subscriber for eviction purposes.
-	 * - An active static recompute owns the slot until it publishes or fails.
-	 *
-	 * Eviction that passes this predicate is silent and lossy only as a cache
-	 * operation: persisted diffs can rehydrate the changeset on the next restore
-	 * / subscribe path, and no client is currently observing the entry.
-	 */
+	// Returns true when a changeset is safe to drop from the in-memory cache.
 	private _isChangesetEvictable(changeset: string): boolean {
 		const changesetUri = URI.parse(changeset);
+		// A direct changeset subscriber is rendering this expanded URI. Keep
+		// the state alive so future envelopes still target an existing object.
 		if (this._resourceSubscribers.has(changesetUri)) {
 			return false;
 		}
 		const parsed = parseChangesetUri(changeset);
+		// This guard only handles recognized changeset URIs; leave anything else alone.
 		if (!parsed) {
 			return false;
 		}
 		const sessionUri = URI.parse(parsed.sessionUri);
+		// A parent-session subscriber can still receive catalogue count updates
+		// from this changeset, so keep the backing state while the session is observed.
 		if (this._resourceSubscribers.has(sessionUri)) {
 			return false;
 		}
+		// Subagent views are backed by the parent session tree; treat any
+		// subscribed descendant as a parent-session pin for cache eviction.
 		for (const subscribedUri of this._resourceSubscribers.keys()) {
 			if (this._isSubagentDescendantOf(subscribedUri, sessionUri)) {
 				return false;
 			}
 		}
+		// If a git/session/uncommitted changeset recompute is currently running for this changeset URI,
+		// do not evict its cached state yet. Once the compute is done,
+		// it is safe to evict because the state is just a cache and can be recreated later.
 		return !this._changesets.isStaticChangesetComputeActive(changeset);
 	}
 

--- a/src/vs/platform/agentHost/test/node/agentHostChangesetService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostChangesetService.test.ts
@@ -11,7 +11,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/c
 import { runWithFakedTimers } from '../../../../base/test/common/timeTravelScheduler.js';
 import { NullLogService } from '../../../log/common/log.js';
 import { AgentSession } from '../../common/agentService.js';
-import { buildDefaultChangesetCatalogue } from '../../common/changesetUri.js';
+import { buildDefaultChangesetCatalogue, buildSessionChangesetUri, buildUncommittedChangesetUri } from '../../common/changesetUri.js';
 import { ActionEnvelope, ActionType } from '../../common/state/sessionActions.js';
 import { SessionStatus } from '../../common/state/sessionState.js';
 import { AgentHostChangesetService } from '../../node/agentHostChangesetService.js';
@@ -440,6 +440,49 @@ suite('AgentHostChangesetService', () => {
 		const bDiff = { after: { uri: 'file:///wd/b.ts', content: { uri: 'file:///wd/b.ts' } }, diff: { added: 2, removed: 0 } };
 		const sessionStr = sessionUri.toString();
 
+		test('parsePersistedStaticChangesets parses without mutating state', () => {
+			setupSession();
+			changesetService.registerStaticChangesets(sessionStr);
+
+			const result = changesetService.parsePersistedStaticChangesets(sessionStr, {
+				uncommittedRaw: JSON.stringify([aDiff]),
+				sessionRaw: JSON.stringify([bDiff]),
+			});
+
+			assert.deepStrictEqual({
+				uncommitted: result.uncommitted?.map(d => d.after?.uri),
+				session: result.session?.map(d => d.after?.uri),
+				uncommittedState: stateManager.getChangesetState(buildUncommittedChangesetUri(sessionStr)),
+				sessionState: stateManager.getChangesetState(buildSessionChangesetUri(sessionStr)),
+			}, {
+				uncommitted: ['file:///wd/a.ts'],
+				session: ['file:///wd/b.ts'],
+				uncommittedState: { status: 'computing', files: [] },
+				sessionState: { status: 'computing', files: [] },
+			});
+		});
+
+		test('applyPersistedStaticChangesets seeds parsed diffs', () => {
+			setupSession();
+			changesetService.registerStaticChangesets(sessionStr);
+			const parsed = changesetService.parsePersistedStaticChangesets(sessionStr, {
+				uncommittedRaw: JSON.stringify([aDiff]),
+				sessionRaw: JSON.stringify([bDiff]),
+			});
+
+			changesetService.applyPersistedStaticChangesets(sessionStr, parsed);
+
+			const uncommitted = stateManager.getChangesetState(buildUncommittedChangesetUri(sessionStr));
+			const session = stateManager.getChangesetState(buildSessionChangesetUri(sessionStr));
+			assert.deepStrictEqual({
+				uncommitted: uncommitted && { status: uncommitted.status, files: uncommitted.files.map(f => f.id) },
+				session: session && { status: session.status, files: session.files.map(f => f.id) },
+			}, {
+				uncommitted: { status: 'ready', files: ['file:///wd/a.ts'] },
+				session: { status: 'ready', files: ['file:///wd/b.ts'] },
+			});
+		});
+
 		test('new uncommitted key restores only uncommitted state', () => {
 			setupSession();
 			changesetService.registerStaticChangesets(sessionStr);
@@ -537,6 +580,85 @@ suite('AgentHostChangesetService', () => {
 				deletions: 0,
 				files: 2,
 			}, 'catalogue counts must reflect restored files');
+		});
+	});
+
+	suite('idle changeset LRU eviction', () => {
+
+		const sessionStr = sessionUri.toString();
+
+		test('idle changeset states are evicted over the soft limit', () => {
+			const localStateManager = disposables.add(new AgentHostStateManager(new NullLogService(), { changesetStateRetention: { softLimit: 2 } }));
+			const first = `${sessionStr}/changeset/session`;
+			const second = `${sessionStr}/changeset/uncommitted`;
+			const third = `${sessionStr}/changeset/turn/turn-1`;
+
+			localStateManager.registerChangeset(first);
+			localStateManager.registerChangeset(second);
+			localStateManager.registerChangeset(third);
+
+			assert.deepStrictEqual({
+				first: localStateManager.getChangesetState(first),
+				second: localStateManager.getChangesetState(second)?.status,
+				third: localStateManager.getChangesetState(third)?.status,
+			}, {
+				first: undefined,
+				second: 'computing',
+				third: 'computing',
+			});
+		});
+
+		test('evictability probe protects subscribed changesets', () => {
+			const first = `${sessionStr}/changeset/session`;
+			const second = `${sessionStr}/changeset/uncommitted`;
+			const third = `${sessionStr}/changeset/turn/turn-1`;
+			const localStateManager = disposables.add(new AgentHostStateManager(new NullLogService(), { changesetStateRetention: { softLimit: 2, canEvict: changeset => changeset !== first } }));
+
+			localStateManager.registerChangeset(first);
+			localStateManager.registerChangeset(second);
+			localStateManager.registerChangeset(third);
+
+			assert.deepStrictEqual({
+				first: localStateManager.getChangesetState(first)?.status,
+				second: localStateManager.getChangesetState(second),
+				third: localStateManager.getChangesetState(third)?.status,
+			}, {
+				first: 'computing',
+				second: undefined,
+				third: 'computing',
+			});
+		});
+
+		test('LRU eviction is silent and does not dispatch ChangesetCleared', () => {
+			const localStateManager = disposables.add(new AgentHostStateManager(new NullLogService(), { changesetStateRetention: { softLimit: 1 } }));
+			const envelopes: ActionEnvelope[] = [];
+			const listener = disposables.add(localStateManager.onDidEmitEnvelope(e => envelopes.push(e)));
+
+			localStateManager.registerChangeset(`${sessionStr}/changeset/session`);
+			localStateManager.registerChangeset(`${sessionStr}/changeset/uncommitted`);
+
+			assert.deepStrictEqual(envelopes.map(e => e.action.type), []);
+			listener.dispose();
+		});
+
+		test('trimming reconsiders entries after they become evictable', () => {
+			let canEvict = false;
+			const localStateManager = disposables.add(new AgentHostStateManager(new NullLogService(), { changesetStateRetention: { softLimit: 1, canEvict: () => canEvict } }));
+			const first = `${sessionStr}/changeset/session`;
+			const second = `${sessionStr}/changeset/uncommitted`;
+
+			localStateManager.registerChangeset(first);
+			localStateManager.registerChangeset(second);
+			canEvict = true;
+			localStateManager.onChangesetLivenessChanged();
+
+			assert.deepStrictEqual({
+				first: localStateManager.getChangesetState(first),
+				second: localStateManager.getChangesetState(second)?.status,
+			}, {
+				first: undefined,
+				second: 'computing',
+			});
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -606,7 +606,7 @@ suite('AgentService (node dispatcher)', () => {
 			assert.strictEqual(sessions[0].changesets, undefined);
 		});
 
-		test('listSessions seeds the server-side changeset state from persisted diffs (so chip subscriptions resolve for unopened sessions)', async () => {
+		test('listSessions advertises persisted changeset counts without seeding state; changeset subscribe restores lazily', async () => {
 			const db = disposables.add(await SessionDatabase.open(':memory:'));
 			const persistedDiffs = [
 				{
@@ -637,13 +637,24 @@ suite('AgentService (node dispatcher)', () => {
 			const svc = disposables.add(new AgentService(new NullLogService(), fileService, sessionDataService, { _serviceBrand: undefined } as IProductService, createNoopGitService()));
 			svc.registerProvider(agent);
 
-			await svc.listSessions();
+			const sessions = await svc.listSessions();
+			const changesetUri = buildSessionChangesetUri(sessionUri.toString());
 
-			// Even without any explicit `restoreSession` call, the
-			// changeset URI should be subscribable on the server side
-			// with the persisted files.
-			const snapshot = svc.stateManager.getSnapshot(`${sessionUri.toString()}/changeset/session`);
-			assert.ok(snapshot, 'expected listSessions to seed the changeset state');
+			assert.deepStrictEqual({
+				listCatalogueEntry: sessions[0].changesets?.find(c => c.uriTemplate === changesetUri),
+				listSeededSnapshot: svc.stateManager.getSnapshot(changesetUri),
+			}, {
+				listCatalogueEntry: {
+					label: 'Branch Changes',
+					uriTemplate: changesetUri,
+					additions: 5,
+					deletions: 2,
+					files: 1,
+				},
+				listSeededSnapshot: undefined,
+			});
+
+			const snapshot = await svc.subscribe(URI.parse(changesetUri), 'client-changeset');
 			const state = snapshot.state as { status: string; files: Array<{ id: string }> };
 			assert.strictEqual(state.status, 'ready');
 			assert.deepStrictEqual(state.files.map(f => f.id), ['file:///wd/a.ts']);

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -52,7 +52,10 @@ class FakeChangesetService implements IAgentHostChangesetService {
 
 	registerStaticChangesets(): void { /* no-op for routing tests */ }
 	restoreStaticChangeset(_session: string, _kind: StaticChangesetKind, _diffs: readonly unknown[]): void { /* no-op */ }
+	parsePersistedStaticChangesets(): { uncommitted?: undefined; session?: undefined } { return {}; }
+	applyPersistedStaticChangesets(): void { /* no-op */ }
 	restorePersistedStaticChangesets(): { uncommitted?: undefined; session?: undefined } { return {}; }
+	isStaticChangesetComputeActive(): boolean { return false; }
 	refreshUncommittedChangeset(): void { /* no-op */ }
 	refreshSessionChangeset(): void { /* no-op */ }
 	setTurnSubscriberProbe(): void { /* no-op */ }

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -9,7 +9,7 @@ import { Codicon } from '../../../../../base/common/codicons.js';
 import { structuralEquals } from '../../../../../base/common/equals.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { IMarkdownString, MarkdownString } from '../../../../../base/common/htmlContent.js';
-import { Disposable, DisposableMap, DisposableStore, IDisposable, IReference, MutableDisposable } from '../../../../../base/common/lifecycle.js';
+import { Disposable, DisposableMap, DisposableStore, IDisposable, IReference, MutableDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { equals } from '../../../../../base/common/objects.js';
 import { autorun, constObservable, derived, derivedOpts, IObservable, ISettableObservable, observableFromPromise, observableValue, observableValueOpts, transaction } from '../../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
@@ -432,6 +432,10 @@ export class AgentHostSessionAdapter implements ISession {
 		if (!sessionFileChangesEqual(this.changes.get(), mapped)) {
 			this.changes.set(mapped, undefined);
 		}
+	}
+
+	releaseBranchChanges(): void {
+		this._branchChangesPopulated = false;
 	}
 }
 
@@ -1080,6 +1084,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 				return;
 			}
 			const ref = reader.store.add(this.connection.getSubscription(StateComponents.Changeset, target.uri));
+			reader.store.add(toDisposable(() => target.adapter.releaseBranchChanges()));
 			const apply = (state: ChangesetState | Error | undefined) => {
 				if (!state || state instanceof Error) {
 					return;

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
@@ -15,7 +15,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/
 import { AgentSession, IAgentHostService, type IAgentCreateSessionConfig, type IAgentSessionMetadata } from '../../../../../../platform/agentHost/common/agentService.js';
 import type { IAgentSubscription } from '../../../../../../platform/agentHost/common/state/agentSubscription.js';
 import type { ResolveSessionConfigResult } from '../../../../../../platform/agentHost/common/state/protocol/commands.js';
-import { CustomizationStatus, SessionLifecycle, type AgentInfo, type ModelSelection, type RootState, type SessionConfigState, type SessionState } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
+import { CustomizationStatus, SessionLifecycle, type AgentInfo, type ChangesetSummary, type ModelSelection, type RootState, type SessionConfigState, type SessionState, type SessionSummary } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
 import { ChangesetStatus, SessionStatus as ProtocolSessionStatus, StateComponents, type ChangesetState } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { ActionType, NotificationType, type ActionEnvelope, type IRootConfigChangedAction, type SessionAction, type TerminalAction, type INotification } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
@@ -309,6 +309,16 @@ function fireSessionRemoved(agentHost: MockAgentHostService, rawId: string, prov
 		channel: 'ahp-root://',
 		type: NotificationType.SessionRemoved,
 		session: sessionUri.toString(),
+	});
+}
+
+function fireSessionSummaryChanged(agentHost: MockAgentHostService, rawId: string, changes: Partial<SessionSummary>, provider = 'copilotcli'): void {
+	const sessionUri = AgentSession.uri(provider, rawId);
+	agentHost.fireNotification({
+		channel: 'ahp-root://',
+		type: NotificationType.SessionSummaryChanged,
+		session: sessionUri.toString(),
+		changes,
 	});
 }
 
@@ -1759,6 +1769,10 @@ suite('LocalAgentHostSessionsProvider - active-session uncommitted refresh rotat
 		return `${AgentSession.uri(sessionType, rawId).toString()}/changeset/session`;
 	}
 
+	function catalogueFor(rawId: string, additions: number, deletions: number, sessionType: string = 'copilotcli'): ChangesetSummary[] {
+		return [{ label: 'Branch Changes', uriTemplate: branchChangesKeyFor(rawId, sessionType), additions, deletions, files: 1 }];
+	}
+
 	test('subscribes to <activeSession>/changeset/uncommitted when an AHP session becomes active', () => {
 		const provider = createProvider(disposables, agentHost, undefined, { activeSession });
 
@@ -1854,5 +1868,32 @@ suite('LocalAgentHostSessionsProvider - active-session uncommitted refresh rotat
 			insertions: 2,
 			deletions: 1,
 		}]);
+	});
+
+	test('catalogue count updates resume after active branch changeset subscription is released', () => {
+		const provider = createProvider(disposables, agentHost, undefined, { activeSession });
+		fireSessionAdded(agentHost, 'sess-A', { title: 'Session A' });
+		const session = provider.getSessions().find(session => session.title.get() === 'Session A');
+		assert.ok(session);
+
+		activeSession.set(makeActive('sess-A', provider.id), undefined);
+		agentHost.setChangesetState(branchChangesKeyFor('sess-A'), {
+			status: ChangesetStatus.Ready,
+			files: [{
+				id: 'file:///repo/file.ts',
+				edit: {
+					before: { uri: 'file:///repo/file.ts', content: { uri: 'session-db:///before/file.ts' } },
+					after: { uri: 'file:///repo/file.ts', content: { uri: 'file:///repo/file.ts' } },
+					diff: { added: 2, removed: 1 },
+				},
+			}],
+		});
+
+		activeSession.set(makeActive('sess-B', provider.id), undefined);
+		fireSessionSummaryChanged(agentHost, 'sess-A', { changesets: catalogueFor('sess-A', 5, 3) });
+
+		assert.deepStrictEqual(session.changes.get().map(change => ({ insertions: change.insertions, deletions: change.deletions })), [
+			{ insertions: 5, deletions: 3 },
+		]);
 	});
 });


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

**Problem today**
* we have 1000 sessions
* `listSessions` will build the state for the session
* We load the changeset, but only count number of changes `+added -deleted`
* However we also load and store the state of changesets for each session in memory
* However since none of the sessions have been opened (not subscribed), this changeset information for all 1000 sessions is a waste of resources, ideally we should load this into state as and when required (when a session is opened)

**Fix**
* we have 1000 sessions
* `listSessions` will build the state for the session
* We load the changeset, but only count number of changes `+added -deleted`
* No more loading changesets into memory unless its requested
