### PR TITLE
feat: render cloudflare .dev.vars files as dotenv files

### DIFF
--- a/extensions/dotenv/package.json
+++ b/extensions/dotenv/package.json
@@ -21,11 +21,13 @@
         ],
         "filenames": [
           ".env",
+          ".dev.vars",
           ".flaskenv",
           "user-dirs.dirs"
         ],
         "filenamePatterns": [
-          ".env.*"
+          ".env.*",
+          ".dev.vars.*"
         ],
         "aliases": [
           "Dotenv"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Edits dotenv extension configuration so Cloudflare's [`.dev.vars` files](https://developers.cloudflare.com/workers/configuration/environment-variables/#compare-secrets-and-environment-variables) render as dotenv files.

**Before / After**

<img height="90" alt="Screenshot 2026-05-16 at 8 47 08 AM" src="https://github.com/user-attachments/assets/5c01d09a-9b8c-4e8c-bdd5-d355594c4934" />
<img height="90" alt="Screenshot 2026-05-16 at 8 46 33 AM" src="https://github.com/user-attachments/assets/c5cf81c5-065b-4b6a-96e1-b3e6aa4abfc2" />