### PR TITLE
feat(notifications): add smooth fade-out transition for notification toasts

### DIFF
--- a/src/vs/workbench/browser/parts/notifications/media/notificationsToasts.css
+++ b/src/vs/workbench/browser/parts/notifications/media/notificationsToasts.css
@@ -69,6 +69,15 @@
 	transition: none;
 }
 
+.monaco-workbench > .notifications-toasts .notification-toast-container > .notification-toast.notification-fade-out {
+	opacity: 0;
+	transition: opacity 200ms ease-in;
+}
+
+.monaco-workbench.monaco-reduce-motion > .notifications-toasts .notification-toast-container > .notification-toast.notification-fade-out {
+	transition: opacity 0ms ease-in;
+}
+
 /* Icons */
 
 .monaco-workbench > .notifications-toasts .codicon.codicon-error {

--- a/src/vs/workbench/browser/parts/notifications/notificationsToasts.ts
+++ b/src/vs/workbench/browser/parts/notifications/notificationsToasts.ts
@@ -71,7 +71,7 @@ export class NotificationsToasts extends Themable implements INotificationsToast
 	private isNotificationsCenterVisible: boolean | undefined;
 
 	private readonly mapNotificationToToast = new Map<INotificationViewItem, INotificationToast>();
-	private readonly mapNotificationToDisposable = new Map<INotificationViewItem, IDisposable>();
+	private readonly mapNotificationToDisposable = new Map<INotificationViewItem, DisposableStore>();
 
 	private readonly notificationsToastsVisibleContextKey: IContextKey<boolean>;
 
@@ -392,19 +392,76 @@ export class NotificationsToasts extends Themable implements INotificationsToast
 		disposables.add(toDisposable(() => clearTimeout(purgeTimeoutHandle)));
 	}
 
-	private removeToast(item: INotificationViewItem): void {
-		let focusEditor = false;
+	private readonly pendingRemoveToasts = new Set<INotificationViewItem>();
 
-		// UI
+	private removeToast(item: INotificationViewItem): void {
+		if (this.pendingRemoveToasts.has(item)) {
+			return;
+		}
+
 		const notificationToast = this.mapNotificationToToast.get(item);
-		if (notificationToast) {
-			const toastHasDOMFocus = isAncestorOfActiveElement(notificationToast.container);
-			if (toastHasDOMFocus) {
-				focusEditor = !(this.focusNext() || this.focusPrevious()); // focus next if any, otherwise focus editor
+		if (!notificationToast) {
+			this.doRemoveToast(item, false);
+			return;
+		}
+
+		const toastHasDOMFocus = isAncestorOfActiveElement(notificationToast.container);
+		let focusEditor = false;
+		if (toastHasDOMFocus) {
+			focusEditor = !(this.focusNext() || this.focusPrevious());
+		}
+
+		this.pendingRemoveToasts.add(item);
+
+		const toastElement = notificationToast.toast;
+		toastElement.classList.add('notification-fade-out');
+
+		const complete = () => {
+			if (!this.pendingRemoveToasts.has(item)) {
+				return;
+			}
+			this.pendingRemoveToasts.delete(item);
+
+			// Check if focus is still inside the toast container or has fallen back to the body.
+			// If the user has moved focus elsewhere (e.g. to a panel or sidebar), we should not steal it.
+			let finalFocusEditor = false;
+			if (focusEditor) {
+				const activeElement = getActiveElement();
+				const toastWindow = getWindow(toastElement);
+				if (isAncestorOfActiveElement(notificationToast.container) || activeElement === toastWindow.document.body) {
+					finalFocusEditor = true;
+				}
 			}
 
-			this.mapNotificationToToast.delete(item);
+			this.doRemoveToast(item, finalFocusEditor);
+		};
+
+		// Check if reduced motion is enabled
+		const reduceMotion = getWindow(toastElement).matchMedia('(prefers-reduced-motion: reduce)').matches;
+		if (reduceMotion) {
+			complete();
+			return;
 		}
+
+		const itemDisposables = this.mapNotificationToDisposable.get(item);
+		if (itemDisposables) {
+			const fallbackTimeout = setTimeout(complete, 300);
+			itemDisposables.add(toDisposable(() => clearTimeout(fallbackTimeout)));
+
+			const listener = addDisposableListener(toastElement, 'transitionend', () => {
+				listener.dispose();
+				complete();
+			});
+			itemDisposables.add(listener);
+		} else {
+			complete();
+		}
+	}
+
+	private doRemoveToast(item: INotificationViewItem, focusEditor: boolean): void {
+
+		// UI
+		this.mapNotificationToToast.delete(item);
 
 		// Disposables
 		const notificationDisposables = this.mapNotificationToDisposable.get(item);
@@ -431,6 +488,9 @@ export class NotificationsToasts extends Themable implements INotificationsToast
 	}
 
 	private removeToasts(): void {
+
+		// Cancel any pending fade-out animations
+		this.pendingRemoveToasts.clear();
 
 		// Toast
 		this.mapNotificationToToast.clear();


### PR DESCRIPTION


<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR addresses a minor but noticeable visual inconsistency in the Developer Experience. Notification toasts currently have a smooth slide+fade entry animation (`notification-fade-in`), but they vanish instantly without any transition when they are dismissed or time out.
This PR adds a smooth **200ms fade-out transition** (`opacity: 1 -> 0`) before the toast is removed from the DOM, creating a more cohesive and polished interaction. 
- Applies a `notification-fade-out` CSS class to the toast container before disposal.
- Waits for the `transitionend` event (with a 300ms safety fallback timeout) before running the existing disposal logic.
- Adds anti-reentry guards and race condition checks.
- Respects `prefers-reduced-motion` settings (0ms transition duration), matching the existing behavior for the entry animation.
- Bulk removals (e.g., when opening the Notification Center) skip the animation for better performance.
### How to test
1. Open the command palette and run `Developer: Show Notification`.
2. Notice the smooth fade-in animation.
3. Click the close (`X`) button on the toast, or wait for it to dismiss automatically.
4. Verify that the toast now smoothly fades out (opacity to 0) instead of disappearing instantly.
5. Enable "Reduce Motion" in your OS accessibility settings and verify that the toast is removed instantly without animation.