### PR TITLE
Honor /compact summary when auto-summarization is disabled

### DIFF
--- a/extensions/copilot/src/extension/prompts/node/agent/agentConversationHistory.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/agentConversationHistory.tsx
@@ -50,33 +50,69 @@ export class AgentConversationHistory extends PromptElement<AgentConversationHis
 	override async render(state: void, sizing: PromptSizing) {
 		const history: PromptElement[] = [];
 		const contextHistory = this.props.promptContext.history;
-		for (const [i, turn] of contextHistory.entries()) {
-			const metadata = turn.responseChatResult?.metadata as IResultMetadata | undefined;
 
-			if (metadata?.renderedUserMessage) {
+		// A summary (e.g. from a manual `/compact`) supersedes every message up to
+		// and including the round it is attached to. Find the most recent summarized
+		// round so the history it covers is dropped instead of replayed verbatim.
+		// Without this, a manual `/compact` has no effect when automatic
+		// summarization is disabled and the context window immediately refills on the
+		// next turn. `round.summary` is populated for historical rounds by
+		// `normalizeSummariesOnRounds`. This only applies an existing summary; it
+		// never triggers new summarization (which stays gated behind the setting).
+		let summaryTurnIndex = -1;
+		let summaryRoundIndex = -1;
+		findSummary: for (let t = contextHistory.length - 1; t >= 0; t--) {
+			const rounds = contextHistory[t].rounds;
+			for (let r = rounds.length - 1; r >= 0; r--) {
+				if (rounds[r].summary) {
+					summaryTurnIndex = t;
+					summaryRoundIndex = r;
+					break findSummary;
+				}
+			}
+		}
+
+		for (const [i, turn] of contextHistory.entries()) {
+			// Turns fully covered by a later summary are dropped.
+			if (i < summaryTurnIndex) {
+				continue;
+			}
+
+			const metadata = turn.responseChatResult?.metadata as IResultMetadata | undefined;
+			const isSummaryTurn = i === summaryTurnIndex;
+
+			if (isSummaryTurn) {
+				// The summary stands in for this turn's user message and the rounds up
+				// to and including the summarized one.
+				history.push(<UserMessage><Tag name='conversation-summary'>{contextHistory[i].rounds[summaryRoundIndex].summary}</Tag></UserMessage>);
+			} else if (metadata?.renderedUserMessage) {
 				history.push(<UserMessage><Chunk>{renderedMessageToTsxChildren(metadata.renderedUserMessage, false)}</Chunk></UserMessage>);
 			} else {
 				history.push(<AgentUserMessageInHistory turn={turn} userQueryTagName={this.props.userQueryTagName} />);
 			}
 
 			if (Array.isArray(metadata?.toolCallRounds) && metadata.toolCallRounds?.length > 0) {
-				// If a tool call limit is exceeded, the tool call from this turn will
-				// have been aborted and any result should be found in the next turn.
-				const toolCallResultInNextTurn = metadata.maxToolCallsExceeded;
-				let toolCallResults = metadata.toolCallResults;
-				if (toolCallResultInNextTurn) {
-					const nextMetadata = contextHistory.at(i + 1)?.responseChatResult?.metadata as IResultMetadata | undefined;
-					const mergeFrom = i === contextHistory.length - 1 ? this.props.promptContext.toolCallResults : nextMetadata?.toolCallResults;
-					toolCallResults = { ...toolCallResults, ...mergeFrom };
-				}
+				// On the summarized turn, only the rounds after the summary remain.
+				const toolCallRounds = isSummaryTurn ? metadata.toolCallRounds.slice(summaryRoundIndex + 1) : metadata.toolCallRounds;
+				if (toolCallRounds.length > 0) {
+					// If a tool call limit is exceeded, the tool call from this turn will
+					// have been aborted and any result should be found in the next turn.
+					const toolCallResultInNextTurn = metadata.maxToolCallsExceeded;
+					let toolCallResults = metadata.toolCallResults;
+					if (toolCallResultInNextTurn) {
+						const nextMetadata = contextHistory.at(i + 1)?.responseChatResult?.metadata as IResultMetadata | undefined;
+						const mergeFrom = i === contextHistory.length - 1 ? this.props.promptContext.toolCallResults : nextMetadata?.toolCallResults;
+						toolCallResults = { ...toolCallResults, ...mergeFrom };
+					}
 
-				history.push(<ChatToolCalls
-					promptContext={this.props.promptContext}
-					toolCallRounds={metadata.toolCallRounds}
-					toolCallResults={toolCallResults}
-					isHistorical={!(toolCallResultInNextTurn && i === contextHistory.length - 1)}
-				/>);
-			} else if (turn.responseMessage) {
+					history.push(<ChatToolCalls
+						promptContext={this.props.promptContext}
+						toolCallRounds={toolCallRounds}
+						toolCallResults={toolCallResults}
+						isHistorical={!(toolCallResultInNextTurn && i === contextHistory.length - 1)}
+					/>);
+				}
+			} else if (!isSummaryTurn && turn.responseMessage) {
 				history.push(<AssistantMessage>{turn.responseMessage?.message}</AssistantMessage>);
 			}
 		}

--- a/extensions/copilot/src/extension/prompts/node/agent/agentConversationHistory.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/agentConversationHistory.tsx
@@ -80,11 +80,16 @@ export class AgentConversationHistory extends PromptElement<AgentConversationHis
 
 			const metadata = turn.responseChatResult?.metadata as IResultMetadata | undefined;
 			const isSummaryTurn = i === summaryTurnIndex;
+			// Read both the summary text and the rounds we keep from one source so the
+			// summary index stays valid for the slice below. `turn.rounds` is the same
+			// reference as `metadata.toolCallRounds` whenever the latter is non-empty,
+			// which is always the case on a summary turn (the summary lives on a real round).
+			const rounds = turn.rounds;
 
 			if (isSummaryTurn) {
 				// The summary stands in for this turn's user message and the rounds up
 				// to and including the summarized one.
-				history.push(<UserMessage><Tag name='conversation-summary'>{contextHistory[i].rounds[summaryRoundIndex].summary}</Tag></UserMessage>);
+				history.push(<UserMessage><Tag name='conversation-summary'>{rounds[summaryRoundIndex].summary}</Tag></UserMessage>);
 			} else if (metadata?.renderedUserMessage) {
 				history.push(<UserMessage><Chunk>{renderedMessageToTsxChildren(metadata.renderedUserMessage, false)}</Chunk></UserMessage>);
 			} else {
@@ -93,7 +98,7 @@ export class AgentConversationHistory extends PromptElement<AgentConversationHis
 
 			if (Array.isArray(metadata?.toolCallRounds) && metadata.toolCallRounds?.length > 0) {
 				// On the summarized turn, only the rounds after the summary remain.
-				const toolCallRounds = isSummaryTurn ? metadata.toolCallRounds.slice(summaryRoundIndex + 1) : metadata.toolCallRounds;
+				const toolCallRounds = isSummaryTurn ? rounds.slice(summaryRoundIndex + 1) : metadata.toolCallRounds;
 				if (toolCallRounds.length > 0) {
 					// If a tool call limit is exceeded, the tool call from this turn will
 					// have been aborted and any result should be found in the next turn.

--- a/extensions/copilot/src/extension/prompts/node/agent/test/summarization.spec.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/summarization.spec.tsx
@@ -338,6 +338,55 @@ suite('Agent Summarization', () => {
 	test('FullSummarization - render summary in previous turn (with multiple)', () => testSummaryPrevTurnMultiple(TestPromptType.FullSummarization));
 	test('SimpleSummarization - render summary in previous turn (with multiple)', () => testSummaryPrevTurnMultiple(TestPromptType.SimpleSummarization));
 
+	test('manual /compact summary is honored when summarization is disabled (#311503)', async () => {
+		// Repro for #311503: with chat.summarizeAgentConversationHistory.enabled = false
+		// the agent renders the non-summarizing history path. A summary stored by a
+		// manual `/compact` must still cause the superseded history to be dropped
+		// instead of replayed verbatim, otherwise the context window immediately
+		// refills on the next turn.
+		const previousTurn = new Turn('id', { type: 'user', message: 'first user message EXCLUDED' });
+		previousTurn.setResponse(TurnStatus.Success, { type: 'user', message: 'response' }, 'responseId', {
+			metadata: {
+				toolCallRounds: [
+					new ToolCallRound('first response EXCLUDED', [createEditFileToolCall(1)], undefined, 'roundId1'),
+				],
+				toolCallResults: createEditFileToolResult(1),
+			}
+		});
+
+		const compactedTurn = new Turn('id', { type: 'user', message: 'second user message EXCLUDED' });
+		compactedTurn.setResponse(TurnStatus.Success, { type: 'user', message: 'response' }, 'responseId', {
+			metadata: {
+				summary: {
+					text: 'COMPACTED SUMMARY',
+					toolCallRoundId: 'roundId2'
+				},
+				toolCallRounds: [
+					new ToolCallRound('summarized round EXCLUDED', [createEditFileToolCall(2)], undefined, 'roundId2'),
+					new ToolCallRound('round after summary KEPT', [createEditFileToolCall(3)], undefined, 'roundId3'),
+				],
+				toolCallResults: createEditFileToolResult(2, 3),
+			}
+		});
+
+		const rendered = await agentPromptToString(
+			accessor,
+			{
+				chatVariables: new ChatVariablesCollection([{ id: 'vscode.file', name: 'file', value: fileTsUri }]),
+				history: [previousTurn, compactedTurn],
+				query: 'next prompt',
+				toolCallRounds: [],
+				tools,
+			},
+			{ enableSummarization: false },
+			TestPromptType.Agent
+		);
+
+		expect(rendered).toContain('COMPACTED SUMMARY');
+		expect(rendered).toContain('round after summary KEPT');
+		expect(rendered).not.toContain('EXCLUDED');
+	});
+
 	async function testSummarizeWithNoRoundsInCurrentTurn(promptType: TestPromptType) {
 		const previousTurn1 = new Turn('id', { type: 'user', message: 'previous turn 1' });
 		previousTurn1.setResponse(TurnStatus.Success, { type: 'user', message: 'response' }, 'responseId', {});


### PR DESCRIPTION
Fixes #311503.

### Problem
With `github.copilot.chat.summarizeAgentConversationHistory.enabled: false`, the agent renders conversation history via `AgentConversationHistory`, which replayed **every** turn's full tool-call history and never looked at `round.summary`. So after a manual `/compact` stored a summary, the next turn rebuilt the entire pre-compaction context and the context window meter immediately went red again.

**Repro:** disable the setting → fill the context → `/compact` (meter empties) → send another prompt → meter full again.

### Fix
The summary data is already available: `normalizeSummariesOnRounds()` runs on **every** request (in `chatParticipantRequestHandler.ts`) and populates `round.summary` on historical rounds. Only the summarized renderer honored it.

`AgentConversationHistory` now:
1. Finds the most recent summarized round across history.
2. Drops the turns/rounds it supersedes.
3. Emits the `<conversation-summary>` tag in place of that turn's user message.
4. Replays only the rounds that follow the summary.

This **applies** an existing summary but never **triggers** new summarization — automatic summarization stays gated behind the setting.

### Scope / risk
- Single production file changed (`agentConversationHistory.tsx`); no new props, imports, or exports.
- The common no-summary path is byte-for-byte unchanged (`summaryTurnIndex === -1` short-circuits every new branch).
- Distinct from #317163, whose logic lives entirely behind `summarizationEnabled === true` and was therefore inert in this disabled-setting scenario.

### Validation
- Typecheck clean (only pre-existing unrelated `chatSessions/` errors).
- `summarization.spec.tsx`: 35/35 pass, including a new regression test for #311503.
- `agentPrompt.spec.tsx`: 165/165 pass.