### PR TITLE
Fix : fix markdown fenced code block link detection

### DIFF
--- a/src/vs/editor/common/languages/linkComputer.ts
+++ b/src/vs/editor/common/languages/linkComputer.ts
@@ -10,6 +10,7 @@ import { ILink } from '../languages.js';
 export interface ILinkComputerTarget {
 	getLineCount(): number;
 	getLineContent(lineNumber: number): string;
+	getLanguageId?(): string;
 }
 
 export const enum State {
@@ -213,10 +214,51 @@ export class LinkComputer {
 	public static computeLinks(model: ILinkComputerTarget, stateMachine: StateMachine = getStateMachine()): ILink[] {
 		const classifier = getClassifier();
 
+		// Check if this is a markdown file to enable code block detection
+		const languageId = model.getLanguageId?.();
+		const isMarkdown = languageId === 'markdown';
+
+		// State for tracking markdown fenced code blocks (single-pass)
+		let inFencedCodeBlock = false;
+		let fencedCodeBlockFenceChar: string | undefined;
+		let fencedCodeBlockFenceLength = 0;
+
 		const result: ILink[] = [];
 		for (let i = 1, lineCount = model.getLineCount(); i <= lineCount; i++) {
 			const line = model.getLineContent(i);
 			const len = line.length;
+
+			// For markdown files, detect and track fenced code blocks
+			if (isMarkdown) {
+				const trimmedLine = line.trimStart();
+				// Detect fenced code block lines (``` or ~~~, 3 or more chars)
+				const fenceMatch = /^(`{3,}|~{3,})/u.exec(trimmedLine);
+				if (fenceMatch) {
+					const fence = fenceMatch[0];
+					const fenceChar = fence[0];
+					const fenceLength = fence.length;
+					const restOfLine = trimmedLine.slice(fence.length);
+
+					if (!inFencedCodeBlock) {
+						// Opening fence: record fence char/length and enter fenced code block
+						inFencedCodeBlock = true;
+						fencedCodeBlockFenceChar = fenceChar;
+						fencedCodeBlockFenceLength = fenceLength;
+						continue; // Skip link detection on fence line
+					} else if (fencedCodeBlockFenceChar === fenceChar && fenceLength >= fencedCodeBlockFenceLength && /^\s*$/.test(restOfLine)) {
+						// Closing fence: must match fence char and have at least the same length
+						inFencedCodeBlock = false;
+						fencedCodeBlockFenceChar = undefined;
+						fencedCodeBlockFenceLength = 0;
+						continue; // Skip link detection on fence line
+					}
+				}
+
+				// Skip link detection for lines inside code blocks
+				if (inFencedCodeBlock) {
+					continue;
+				}
+			}
 
 			let j = 0;
 			let linkBeginIndex = 0;

--- a/src/vs/editor/test/common/modes/linkComputer.test.ts
+++ b/src/vs/editor/test/common/modes/linkComputer.test.ts
@@ -9,7 +9,7 @@ import { ILinkComputerTarget, computeLinks } from '../../../common/languages/lin
 
 class SimpleLinkComputerTarget implements ILinkComputerTarget {
 
-	constructor(private _lines: string[]) {
+	constructor(private _lines: string[], private _languageId?: string) {
 		// Intentional Empty
 	}
 
@@ -20,10 +20,14 @@ class SimpleLinkComputerTarget implements ILinkComputerTarget {
 	public getLineContent(lineNumber: number): string {
 		return this._lines[lineNumber - 1];
 	}
+
+	public getLanguageId(): string | undefined {
+		return this._languageId;
+	}
 }
 
-function myComputeLinks(lines: string[]): ILink[] {
-	const target = new SimpleLinkComputerTarget(lines);
+function myComputeLinks(lines: string[], languageId?: string): ILink[] {
+	const target = new SimpleLinkComputerTarget(lines, languageId);
 	return computeLinks(target);
 }
 
@@ -282,5 +286,92 @@ suite('Editor Modes - Link Computer', () => {
 			` * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers|Promise.withResolvers}`,
 			`          https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers                       `,
 		);
+	});
+
+	test('issue #318083: Markdown wrong parsing for link in codeblock', () => {
+		// URLs inside markdown fenced code blocks should not be linkified
+		const lines = [
+			'Some text before',
+			'```',
+			'https://www.abc.com/',
+			'```',
+			'Some text after with https://www.example.com/'
+		];
+		const links = myComputeLinks(lines, 'markdown');
+
+		// Should only find the link outside the code block (line 5)
+		assert.strictEqual(links.length, 1);
+		assert.strictEqual(links[0].range.startLineNumber, 5);
+		assert.strictEqual(links[0].url, 'https://www.example.com/');
+	});
+
+	test('issue #318083: Markdown code block with language specifier', () => {
+		const lines = [
+			'Example:',
+			'```bash',
+			'curl https://api.example.com/data',
+			'```',
+			'See https://docs.example.com/ for more info'
+		];
+		const links = myComputeLinks(lines, 'markdown');
+
+		// Should only find the link outside the code block (line 5)
+		assert.strictEqual(links.length, 1);
+		assert.strictEqual(links[0].range.startLineNumber, 5);
+		assert.strictEqual(links[0].url, 'https://docs.example.com/');
+	});
+
+	test('issue #318083: Markdown tilde fenced code block', () => {
+		const lines = [
+			'Example:',
+			'~~~',
+			'https://www.test.com/',
+			'~~~',
+			'Link: https://www.real.com/'
+		];
+		const links = myComputeLinks(lines, 'markdown');
+
+		// Should only find the link outside the code block (line 5)
+		assert.strictEqual(links.length, 1);
+		assert.strictEqual(links[0].range.startLineNumber, 5);
+		assert.strictEqual(links[0].url, 'https://www.real.com/');
+	});
+
+	test('issue #318083: Markdown multiple code blocks', () => {
+		const lines = [
+			'First: https://first.com/',
+			'```',
+			'https://inside1.com/',
+			'```',
+			'Middle: https://middle.com/',
+			'```',
+			'https://inside2.com/',
+			'```',
+			'Last: https://last.com/'
+		];
+		const links = myComputeLinks(lines, 'markdown');
+
+		// Should find links on lines 1, 5, and 9 (outside code blocks)
+		assert.strictEqual(links.length, 3);
+		assert.strictEqual(links[0].range.startLineNumber, 1);
+		assert.strictEqual(links[0].url, 'https://first.com/');
+		assert.strictEqual(links[1].range.startLineNumber, 5);
+		assert.strictEqual(links[1].url, 'https://middle.com/');
+		assert.strictEqual(links[2].range.startLineNumber, 9);
+		assert.strictEqual(links[2].url, 'https://last.com/');
+	});
+
+	test('issue #318083: Non-markdown files should still linkify everything', () => {
+		const lines = [
+			'```',
+			'https://www.abc.com/',
+			'```'
+		];
+		const links = myComputeLinks(lines, 'javascript');
+
+		// Should find the link even though it looks like a code block
+		// because this is not a markdown file
+		assert.strictEqual(links.length, 1);
+		assert.strictEqual(links[0].url, 'https://www.abc.com/');
 	});
 });


### PR DESCRIPTION
## Description

Fixes incorrect link detection/rendering inside markdown fenced code blocks in diff/source control view.

Previously, URLs inside fenced markdown code blocks were still processed by the link detector, which could result in incorrect diff rendering such as injected span markup inside code block content.

### Changes

* Added markdown fenced code block detection in `LinkComputer`
* Skipped link computation for lines inside fenced code blocks
* Used a single-pass approach to avoid unnecessary range scans
* Added tests covering fenced code block behavior and normal markdown links outside code blocks

### Reproduction

````md
```text
https://www.abc.com/
````

```

Opening the markdown file in Source Control diff view could incorrectly render/linkify the URL inside the code block.

### Result
Links inside fenced markdown code blocks are no longer detected or decorated, while normal links outside code blocks continue to work correctly.
```

Fix #318083 