### PR TITLE
fix: Chat session persistence across Copilot auth/profile transitions

### DIFF
--- a/src/vs/sessions/contrib/providers/localChatSessions/LOCAL_CHAT_SESSIONS_PROVIDER.md
+++ b/src/vs/sessions/contrib/providers/localChatSessions/LOCAL_CHAT_SESSIONS_PROVIDER.md
@@ -63,7 +63,7 @@ interface IStoredLocalSession {
 - **Remove** (`_removeStoredSession`) — called from `deleteSession`.
 - **Load** (`_loadPersistedSessions`) — on provider construction; reads stored entries and creates `LocalSession` instances from them.
 
-Storage is self-contained: no `IChatService` calls are needed to list sessions, since title and timing are stored inline.
+Storage is self-contained: no `IChatService` calls are needed to list sessions, since title and timing are stored inline. Metadata is stored in `StorageScope.APPLICATION` so it remains available across profile/auth transitions; older `StorageScope.PROFILE` entries are merged forward on load.
 
 ### One-time migration
 

--- a/src/vs/sessions/contrib/providers/localChatSessions/browser/localChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/localChatSessions/browser/localChatSessionsProvider.ts
@@ -45,6 +45,8 @@ export const LOCAL_SESSION_ENABLED_SETTING = 'sessions.chat.localAgent.enabled';
 const LOCAL_PROVIDER_ID = 'local-chat';
 const STORAGE_KEY_SESSIONS = 'sessions.localChat.sessions';
 const STORAGE_KEY_MIGRATED = 'sessions.localChat.migrated';
+const STORAGE_SCOPE = StorageScope.APPLICATION;
+const LEGACY_STORAGE_SCOPE = StorageScope.PROFILE;
 
 interface IStoredLocalSession {
 	readonly uri: UriComponents;
@@ -396,6 +398,8 @@ export class LocalChatSessionsProvider extends Disposable implements ISessionsPr
 
 	private readonly _currentNewSession = this._register(new MutableDisposable<LocalSession>());
 
+	private _legacyStorageMigrationAttempted = false;
+
 	constructor(
 		@IChatService private readonly chatService: IChatService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
@@ -433,7 +437,12 @@ export class LocalChatSessionsProvider extends Disposable implements ISessionsPr
 	 * that are already in our storage are skipped.
 	 */
 	private async _migrateFromHistory(): Promise<void> {
-		if (this.storageService.getBoolean(STORAGE_KEY_MIGRATED, StorageScope.PROFILE, false)) {
+		const legacyMigrated = this.storageService.getBoolean(STORAGE_KEY_MIGRATED, LEGACY_STORAGE_SCOPE, false);
+		if (this.storageService.getBoolean(STORAGE_KEY_MIGRATED, STORAGE_SCOPE, false) || legacyMigrated) {
+			this._migrateStoredSessionsFromLegacyScope();
+			if (legacyMigrated) {
+				this.storageService.store(STORAGE_KEY_MIGRATED, true, STORAGE_SCOPE, StorageTarget.MACHINE);
+			}
 			return;
 		}
 
@@ -466,7 +475,7 @@ export class LocalChatSessionsProvider extends Disposable implements ISessionsPr
 			if (changed) {
 				this._writeStoredSessions(sessions);
 			}
-			this.storageService.store(STORAGE_KEY_MIGRATED, true, StorageScope.PROFILE, StorageTarget.MACHINE);
+			this.storageService.store(STORAGE_KEY_MIGRATED, true, STORAGE_SCOPE, StorageTarget.MACHINE);
 		} catch (e) {
 			this.logService.error('[LocalChatSessionsProvider] Failed to migrate local chat history', e);
 			// Do not mark migration complete on failure so it can be retried next time.
@@ -552,7 +561,12 @@ export class LocalChatSessionsProvider extends Disposable implements ISessionsPr
 	// -- Storage helpers --
 
 	private _readStoredSessions(): IStoredLocalSession[] {
-		const raw = this.storageService.get(STORAGE_KEY_SESSIONS, StorageScope.PROFILE);
+		this._migrateStoredSessionsFromLegacyScope();
+		const raw = this.storageService.get(STORAGE_KEY_SESSIONS, STORAGE_SCOPE);
+		return this._parseStoredSessions(raw);
+	}
+
+	private _parseStoredSessions(raw: string | undefined): IStoredLocalSession[] {
 		if (!raw) {
 			return [];
 		}
@@ -613,9 +627,41 @@ export class LocalChatSessionsProvider extends Disposable implements ISessionsPr
 		this.storageService.store(
 			STORAGE_KEY_SESSIONS,
 			JSON.stringify(sessions),
-			StorageScope.PROFILE,
+			STORAGE_SCOPE,
 			StorageTarget.MACHINE,
 		);
+	}
+
+	private _migrateStoredSessionsFromLegacyScope(): void {
+		if (this._legacyStorageMigrationAttempted) {
+			return;
+		}
+		this._legacyStorageMigrationAttempted = true;
+
+		const legacyRaw = this.storageService.get(STORAGE_KEY_SESSIONS, LEGACY_STORAGE_SCOPE);
+		if (!legacyRaw) {
+			return;
+		}
+
+		const storedSessions = this._parseStoredSessions(this.storageService.get(STORAGE_KEY_SESSIONS, STORAGE_SCOPE));
+		const storedKeys = new Set(storedSessions.map(s => URI.revive(s.uri).toString()));
+		const legacySessions = this._parseStoredSessions(legacyRaw);
+		let changed = false;
+
+		for (const session of legacySessions) {
+			const key = URI.revive(session.uri).toString();
+			if (!storedKeys.has(key)) {
+				storedKeys.add(key);
+				storedSessions.push(session);
+				changed = true;
+			}
+		}
+
+		if (changed) {
+			this.storageService.store(STORAGE_KEY_SESSIONS, JSON.stringify(storedSessions), STORAGE_SCOPE, StorageTarget.MACHINE);
+		}
+
+		this.storageService.remove(STORAGE_KEY_SESSIONS, LEGACY_STORAGE_SCOPE);
 	}
 
 	// -- Workspace --

--- a/src/vs/sessions/contrib/providers/localChatSessions/test/browser/localChatSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/localChatSessions/test/browser/localChatSessionsProvider.test.ts
@@ -16,7 +16,7 @@ import { IInstantiationService } from '../../../../../../platform/instantiation/
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { ILabelService } from '../../../../../../platform/label/common/label.js';
 import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
-import { IStorageService } from '../../../../../../platform/storage/common/storage.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../../../platform/storage/common/storage.js';
 import { TestStorageService } from '../../../../../../workbench/test/common/workbenchTestServices.js';
 import { ChatAgentLocation } from '../../../../../../workbench/contrib/chat/common/constants.js';
 import { IChatModel } from '../../../../../../workbench/contrib/chat/common/model/chatModel.js';
@@ -190,6 +190,33 @@ suite('LocalChatSessionsProvider', () => {
 		const restored = provider2.getSessions();
 		assert.strictEqual(restored.length, 1);
 		assert.strictEqual(restored[0].resource.toString(), session.resource.toString());
+	});
+
+	test('migrates persisted sessions from profile storage to application storage', async () => {
+		const store = leaks.add(new DisposableStore());
+		const { instantiationService, storage } = createFixture(store);
+
+		const resource = URI.parse('vscode-local-chat://chat/legacy');
+		const legacySessions = [{
+			uri: resource.toJSON(),
+			title: 'Legacy Session',
+			createdAt: 1_000,
+			lastMessageDate: 2_000,
+			workingDirectory: TEST_FOLDER.toJSON(),
+		}];
+		storage.store('sessions.localChat.sessions', JSON.stringify(legacySessions), StorageScope.PROFILE, StorageTarget.MACHINE);
+		storage.store('sessions.localChat.migrated', true, StorageScope.PROFILE, StorageTarget.MACHINE);
+
+		const provider = store.add(instantiationService.createInstance(LocalChatSessionsProvider));
+		await Event.toPromise(provider.onDidChangeSessions);
+
+		const restored = provider.getSessions();
+		assert.strictEqual(restored.length, 1);
+		assert.strictEqual(restored[0].resource.toString(), resource.toString());
+		assert.strictEqual(restored[0].title.get(), 'Legacy Session');
+		assert.strictEqual(storage.get('sessions.localChat.sessions', StorageScope.APPLICATION), JSON.stringify(legacySessions));
+		assert.strictEqual(storage.get('sessions.localChat.sessions', StorageScope.PROFILE), undefined);
+		assert.strictEqual(storage.getBoolean('sessions.localChat.migrated', StorageScope.APPLICATION), true);
 	});
 
 	test('deleteSession removes session from cache and storage', async () => {

--- a/src/vs/workbench/contrib/chat/common/model/chatSessionStore.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatSessionStore.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Sequencer } from '../../../../../base/common/async.js';
+import { Limiter, Sequencer } from '../../../../../base/common/async.js';
 import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { toErrorMessage } from '../../../../../base/common/errorMessage.js';
 import { MarkdownString } from '../../../../../base/common/htmlContent.js';
@@ -34,6 +34,7 @@ import { ChatSessionOperationLog } from './chatSessionOperationLog.js';
 import { LocalChatSessionUri } from './chatUri.js';
 
 const maxPersistedSessions = 50;
+const maxParallelSessionIndexRebuilds = 10;
 
 const ChatIndexStorageKey = 'chat.ChatSessionStore.index';
 const ChatTransferIndexStorageKey = 'ChatSessionStore.transferIndex';
@@ -537,6 +538,7 @@ export class ChatSessionStore extends Disposable {
 	}
 
 	private indexCache: IChatSessionIndexData | undefined;
+	private indexRebuildAttempted = false;
 	private internalGetIndex(): IChatSessionIndexData {
 		if (this.indexCache) {
 			return this.indexCache;
@@ -581,8 +583,72 @@ export class ChatSessionStore extends Disposable {
 
 	async getIndex(): Promise<IChatSessionIndex> {
 		return this.storeQueue.queue(async () => {
+			await this.rebuildIndexFromSessionFilesIfNeeded();
 			return this.internalGetIndex().entries;
 		});
+	}
+
+	private async rebuildIndexFromSessionFilesIfNeeded(): Promise<void> {
+		if (this.indexRebuildAttempted) {
+			return;
+		}
+		this.indexRebuildAttempted = true;
+
+		const index = this.internalGetIndex();
+		if (Object.keys(index.entries).length > 0) {
+			return;
+		}
+
+		try {
+			const storageDirectory = await this.fileService.resolve(this.storageRoot);
+			if (!storageDirectory.children) {
+				return;
+			}
+
+			const sessionIds = new Set<string>();
+			for (const child of storageDirectory.children) {
+				if (child.isDirectory) {
+					continue;
+				}
+				if (child.name.endsWith('.jsonl')) {
+					sessionIds.add(child.name.slice(0, -'.jsonl'.length));
+				} else if (child.name.endsWith('.json')) {
+					sessionIds.add(child.name.slice(0, -'.json'.length));
+				}
+			}
+
+			if (sessionIds.size === 0) {
+				return;
+			}
+
+			const limiter = new Limiter<IChatSessionEntryMetadata | undefined>(maxParallelSessionIndexRebuilds);
+			const recoveredEntries = await Promise.all([...sessionIds].map(sessionId => limiter.queue(async () => {
+				try {
+					const storageLocation = this.getStorageLocation(sessionId);
+					const session = await this.readSessionFromLocation(storageLocation.flat, storageLocation.log, sessionId);
+					if (session) {
+						return await getSessionMetadata(session.value as ISerializableChatData);
+					}
+				} catch (e) {
+					this.reportError('rebuildIndexFromSessionFile', `Error rebuilding chat session index entry ${sessionId}`, e);
+				}
+				return undefined;
+			})));
+
+			for (const entry of recoveredEntries) {
+				if (entry) {
+					index.entries[entry.sessionId] = entry;
+				}
+			}
+
+			if (Object.keys(index.entries).length > 0) {
+				await this.flushIndex();
+			}
+		} catch (e) {
+			if (toFileOperationResult(e) !== FileOperationResult.FILE_NOT_FOUND) {
+				this.reportError('rebuildIndexFromSessionFiles', 'Error rebuilding chat session index from session files', e);
+			}
+		}
 	}
 
 	getMetadataForSessionSync(sessionResource: URI): IChatSessionEntryMetadata | undefined {

--- a/src/vs/workbench/contrib/chat/test/common/model/chatSessionStore.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/model/chatSessionStore.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { VSBuffer } from '../../../../../../base/common/buffer.js';
 import { Emitter } from '../../../../../../base/common/event.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../../base/common/uri.js';
@@ -145,6 +146,23 @@ suite('ChatSessionStore', () => {
 		const index = await store.getIndex();
 		assert.ok(index['session-1']);
 		assert.strictEqual(index['session-1'].sessionId, 'session-1');
+	});
+
+	test('getIndex rebuilds missing index from persisted session files', async () => {
+		const store = createChatSessionStore();
+		const model = testDisposables.add(createMockChatModel(LocalChatSessionUri.forSession('session-1'), { customTitle: 'Recovered Session' }));
+
+		await store.storeSessions([model]);
+		await instantiationService.get(IFileService).writeFile(URI.joinPath(store.getChatStorageFolder(), 'corrupt-session.json'), VSBuffer.fromString('{'));
+
+		instantiationService.stub(IStorageService, testDisposables.add(new TestStorageService()));
+		const recoveredStore = createChatSessionStore();
+
+		const index = await recoveredStore.getIndex();
+		assert.ok(index['session-1']);
+		assert.strictEqual(index['session-1'].sessionId, 'session-1');
+		assert.strictEqual(index['session-1'].title, 'Recovered Session');
+		assert.strictEqual(index['corrupt-session'], undefined);
 	});
 
 	test('storeSessions persists custom title', async () => {


### PR DESCRIPTION
Closes #318152

This makes local chat session metadata auth/profile independent and adds recovery for session files whose storage index is missing.
Changes:
- Store `LocalChatSessionsProvider` metadata in `StorageScope.APPLICATION` instead of `StorageScope.PROFILE`.
- Merge existing profile-scoped local chat session metadata into application storage for compatibility.
- Rebuild `ChatSessionStore` index entries from persisted `.json` / `.jsonl` session files when the index is empty.
- Add regression tests for profile-to-application metadata migration and missing-index recovery.
- Update local chat sessions provider docs.
This prevents chat history from disappearing when switching between GitHub-authenticated and BYOK/anonymous Copilot modes, and improves recovery when session files remain on disk but their index metadata is missing.