### PR TITLE
Replace @debounce with disposable RunOnceScheduler in TerminalResizeDebouncer

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalResizeDebouncer.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalResizeDebouncer.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { getWindow, runWhenWindowIdle } from '../../../../base/browser/dom.js';
-import { debounce } from '../../../../base/common/decorators.js';
+import { RunOnceScheduler } from '../../../../base/common/async.js';
 import { Disposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import type { XtermTerminal } from './xterm/xtermTerminal.js';
 
@@ -13,6 +13,7 @@ const enum Constants {
 	 * The _normal_ buffer length threshold at which point resizing starts being debounced.
 	 */
 	StartDebouncingThreshold = 200,
+	DebounceResizeXDelay = 100,
 }
 
 export class TerminalResizeDebouncer extends Disposable {
@@ -21,6 +22,13 @@ export class TerminalResizeDebouncer extends Disposable {
 
 	private readonly _resizeXJob = this._register(new MutableDisposable());
 	private readonly _resizeYJob = this._register(new MutableDisposable());
+
+	// Owned by the disposable store so the pending timer is cancelled on dispose,
+	// avoiding callbacks that fire against a torn-down xterm renderer.
+	private readonly _debounceResizeXScheduler = this._register(new RunOnceScheduler(
+		() => this._resizeXCallback(this._latestX),
+		Constants.DebounceResizeXDelay,
+	));
 
 	constructor(
 		private readonly _isVisible: () => boolean,
@@ -43,6 +51,7 @@ export class TerminalResizeDebouncer extends Disposable {
 		if (immediate || this._getXterm()!.raw.buffer.normal.length < Constants.StartDebouncingThreshold) {
 			this._resizeXJob.clear();
 			this._resizeYJob.clear();
+			this._debounceResizeXScheduler.cancel();
 			this._resizeBothCallback(cols, rows);
 			return;
 		}
@@ -75,28 +84,18 @@ export class TerminalResizeDebouncer extends Disposable {
 		// expensive due to reflow.
 		this._resizeYCallback(rows);
 		this._latestX = cols;
-		this._debounceResizeX(cols);
+		this._debounceResizeXScheduler.schedule();
 	}
 
 	flush(): void {
 		if (this._store.isDisposed) {
 			return;
 		}
-		if (this._resizeXJob.value || this._resizeYJob.value) {
+		if (this._resizeXJob.value || this._resizeYJob.value || this._debounceResizeXScheduler.isScheduled()) {
 			this._resizeXJob.clear();
 			this._resizeYJob.clear();
+			this._debounceResizeXScheduler.cancel();
 			this._resizeBothCallback(this._latestX, this._latestY);
 		}
-	}
-
-	@debounce(100)
-	private _debounceResizeX(cols: number) {
-		// The @debounce decorator schedules a setTimeout that is not tied to the
-		// disposable store, so this can fire after the terminal/xterm renderer is
-		// disposed. Bail out to avoid throwing from xterm.js dimension getters.
-		if (this._store.isDisposed) {
-			return;
-		}
-		this._resizeXCallback(cols);
 	}
 }


### PR DESCRIPTION
## What

Replace the `@debounce(100)` decorator on `_debounceResizeX` with a `RunOnceScheduler` owned by the disposable store.

## Why

The `@debounce` decorator schedules a bare `setTimeout` and stashes the handle as an instance field (`$debounce$_debounceResizeX`). The timer is not registered with any `DisposableStore`, so `super.dispose()` does not cancel it. The callback can fire after the terminal/xterm has been torn down and crash inside xterm.js' `RenderService.get dimensions()` — telemetry buckets `aaa283a2`, `4826565b`, `1e83a096`.

PR #314795 worked around this with an `if (this._store.isDisposed) return;` guard inside `_debounceResizeX`. That closes the buckets but:

- Every new debounced callsite on this class needs the same guard — forget it once and a new bucket appears (commit d1a4f1b9 added a similar guard to `_resize` three weeks later for the same class of race).
- The stray timer still fires; we just early-return.
- It's inconsistent with the rest of the codebase, where timers live in a `DisposableStore` (`RunOnceScheduler`, `ThrottledDelayer`, `disposableTimeout`, …) and are cancelled deterministically at dispose.

As Daniel noted on #314795:
> moving off `@debounce` is the better option, this is a hack that doesn't truly fix the lifecycle.

## Changes

`terminalResizeDebouncer.ts`:

- Replace `@debounce(100) _debounceResizeX(cols)` with a `RunOnceScheduler` registered via `this._register(...)`. The scheduler reads `this._latestX` lazily (already updated before each schedule).
- Replace `this._debounceResizeX(cols)` with `this._debounceResizeXScheduler.schedule()`.
- Cancel the scheduler in the immediate-resize branch and in `flush()` so a queued X-debounce cannot fire after a fresh full resize.
- Drop the `import { debounce }` and the per-callsite `isDisposed` guard inside the debounced method.

After this change, disposing the `TerminalResizeDebouncer` cancels the pending timer through the normal disposable chain — no post-dispose callback can run, so no guard is needed.

## How to test

1. Open a terminal, type or generate >200 lines of output (debounce threshold).
2. Trigger dispose-during-resize:
   - Close (`Ctrl+Shift+W`) a terminal while resizing the window.
   - Toggle `terminal.integrated.fontFamily` immediately after killing a terminal.
   - Run `exit` in a long-running shell while the panel is mid-resize.
3. Verify no `Cannot read properties of undefined (reading 'dimensions')` in DevTools console.
4. Telemetry: bucket `4826565b` (the `_debounceResizeX` path) should stop firing.

## Risk

- Behavior in the live (non-disposed) path is identical: `RunOnceScheduler.schedule()` cancels and re-schedules a 100ms timer just like the decorator did, and reads the latest `cols` from `_latestX` which the caller updates before calling.
- The scheduler is cancelled in `flush()` and on immediate resize, so we cannot land a stale X-resize after a full resize — this was implicit before because `clearTimeout` did the same on the decorator's stored handle.

Refs #314795, #303546.
