### PR TITLE
Add .agents workspace and personal path support for prompts, instructions, hooks, and agents

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -65,7 +65,7 @@ import { ChatToolRiskAssessmentService, IChatToolRiskAssessmentService } from '.
 import { agentPluginDiscoveryRegistry, IAgentPluginService } from '../common/plugins/agentPluginService.js';
 import { ChatPromptFilesExtensionPointHandler } from '../common/promptSyntax/chatPromptFilesContribution.js';
 import { isTildePath, PromptsConfig } from '../common/promptSyntax/config/config.js';
-import { INSTRUCTIONS_DEFAULT_SOURCE_FOLDER, INSTRUCTION_FILE_EXTENSION, LEGACY_MODE_DEFAULT_SOURCE_FOLDER, LEGACY_MODE_FILE_EXTENSION, PROMPT_DEFAULT_SOURCE_FOLDER, PROMPT_FILE_EXTENSION, DEFAULT_SKILL_SOURCE_FOLDERS, AGENTS_SOURCE_FOLDER, AGENT_FILE_EXTENSION, SKILL_FILENAME, CLAUDE_AGENTS_SOURCE_FOLDER, DEFAULT_HOOK_FILE_PATHS, DEFAULT_INSTRUCTIONS_SOURCE_FOLDERS, COPILOT_USER_AGENTS_SOURCE_FOLDER } from '../common/promptSyntax/config/promptFileLocations.js';
+import { INSTRUCTIONS_DEFAULT_SOURCE_FOLDER, INSTRUCTION_FILE_EXTENSION, LEGACY_MODE_DEFAULT_SOURCE_FOLDER, LEGACY_MODE_FILE_EXTENSION, PROMPT_DEFAULT_SOURCE_FOLDER, PROMPT_FILE_EXTENSION, DEFAULT_SKILL_SOURCE_FOLDERS, AGENTS_SOURCE_FOLDER, AGENT_FILE_EXTENSION, SKILL_FILENAME, DEFAULT_HOOK_FILE_PATHS, DEFAULT_INSTRUCTIONS_SOURCE_FOLDERS, DEFAULT_PROMPT_SOURCE_FOLDERS, DEFAULT_AGENT_SOURCE_FOLDERS } from '../common/promptSyntax/config/promptFileLocations.js';
 import { PromptLanguageFeaturesProvider } from './promptSyntax/promptFileContributions.js';
 import { AGENT_DOCUMENTATION_URL, INSTRUCTIONS_DOCUMENTATION_URL, PROMPT_DOCUMENTATION_URL, SKILL_DOCUMENTATION_URL, HOOK_DOCUMENTATION_URL, PromptsType, PromptFileSource } from '../common/promptSyntax/promptTypes.js';
 import { hookFileSchema, HOOK_SCHEMA_URI } from '../common/promptSyntax/hookSchema.js';
@@ -1238,7 +1238,7 @@ configurationRegistry.registerConfiguration({
 				PROMPT_DOCUMENTATION_URL,
 			),
 			default: {
-				[PROMPT_DEFAULT_SOURCE_FOLDER]: true,
+				...DEFAULT_PROMPT_SOURCE_FOLDERS.map((folder) => ({ [folder.path]: true })).reduce((acc, curr) => ({ ...acc, ...curr }), {}),
 			},
 			additionalProperties: { type: 'boolean' },
 			unevaluatedProperties: { type: 'boolean' },
@@ -1301,9 +1301,7 @@ configurationRegistry.registerConfiguration({
 				AGENT_DOCUMENTATION_URL,
 			),
 			default: {
-				[AGENTS_SOURCE_FOLDER]: true,
-				[CLAUDE_AGENTS_SOURCE_FOLDER]: true,
-				[COPILOT_USER_AGENTS_SOURCE_FOLDER]: true,
+				...DEFAULT_AGENT_SOURCE_FOLDERS.map((folder) => ({ [folder.path]: true })).reduce((acc, curr) => ({ ...acc, ...curr }), {}),
 			},
 			additionalProperties: { type: 'boolean' },
 			propertyNames: {

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/config/promptFileLocations.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/config/promptFileLocations.ts
@@ -112,6 +112,26 @@ export const CLAUDE_AGENTS_SOURCE_FOLDER = '.claude/agents';
 export const COPILOT_USER_AGENTS_SOURCE_FOLDER = '~/.copilot/agents';
 
 /**
+ * .agents workspace agents folder.
+ */
+export const AGENTS_WORKSPACE_AGENTS_FOLDER = '.agents/agents';
+
+/**
+ * .agents workspace prompts folder.
+ */
+export const AGENTS_WORKSPACE_PROMPTS_FOLDER = '.agents/prompts';
+
+/**
+ * .agents workspace instructions folder.
+ */
+export const AGENTS_WORKSPACE_INSTRUCTIONS_FOLDER = '.agents/instructions';
+
+/**
+ * .agents workspace hooks folder.
+ */
+export const AGENTS_WORKSPACE_HOOKS_FOLDER = '.agents/hooks';
+
+/**
  * Claude rules folder.
  */
 export const CLAUDE_RULES_SOURCE_FOLDER = '.claude/rules';
@@ -173,6 +193,7 @@ export const DEFAULT_SKILL_SOURCE_FOLDERS: readonly IPromptSourceFolder[] = [
  */
 export const DEFAULT_INSTRUCTIONS_SOURCE_FOLDERS: readonly IPromptSourceFolder[] = [
 	{ path: INSTRUCTIONS_DEFAULT_SOURCE_FOLDER, source: PromptFileSource.GitHubWorkspace, storage: PromptsStorage.local },
+	{ path: AGENTS_WORKSPACE_INSTRUCTIONS_FOLDER, source: PromptFileSource.AgentsWorkspace, storage: PromptsStorage.local },
 	{ path: CLAUDE_RULES_SOURCE_FOLDER, source: PromptFileSource.ClaudeWorkspace, storage: PromptsStorage.local },
 	{ path: '~/.copilot/instructions', source: PromptFileSource.CopilotPersonal, storage: PromptsStorage.user },
 	{ path: '~/' + CLAUDE_RULES_SOURCE_FOLDER, source: PromptFileSource.ClaudePersonal, storage: PromptsStorage.user },
@@ -183,6 +204,7 @@ export const DEFAULT_INSTRUCTIONS_SOURCE_FOLDERS: readonly IPromptSourceFolder[]
  */
 export const DEFAULT_PROMPT_SOURCE_FOLDERS: readonly IPromptSourceFolder[] = [
 	{ path: PROMPT_DEFAULT_SOURCE_FOLDER, source: PromptFileSource.GitHubWorkspace, storage: PromptsStorage.local },
+	{ path: AGENTS_WORKSPACE_PROMPTS_FOLDER, source: PromptFileSource.AgentsWorkspace, storage: PromptsStorage.local },
 ];
 
 /**
@@ -190,6 +212,7 @@ export const DEFAULT_PROMPT_SOURCE_FOLDERS: readonly IPromptSourceFolder[] = [
  */
 export const DEFAULT_AGENT_SOURCE_FOLDERS: readonly IPromptSourceFolder[] = [
 	{ path: AGENTS_SOURCE_FOLDER, source: PromptFileSource.GitHubWorkspace, storage: PromptsStorage.local },
+	{ path: AGENTS_WORKSPACE_AGENTS_FOLDER, source: PromptFileSource.AgentsWorkspace, storage: PromptsStorage.local },
 	{ path: CLAUDE_AGENTS_SOURCE_FOLDER, source: PromptFileSource.ClaudeWorkspace, storage: PromptsStorage.local },
 	{ path: COPILOT_USER_AGENTS_SOURCE_FOLDER, source: PromptFileSource.CopilotPersonal, storage: PromptsStorage.user },
 	{ path: '~/' + CLAUDE_AGENTS_SOURCE_FOLDER, source: PromptFileSource.ClaudePersonal, storage: PromptsStorage.user },
@@ -201,6 +224,7 @@ export const DEFAULT_AGENT_SOURCE_FOLDERS: readonly IPromptSourceFolder[] = [
  */
 export const DEFAULT_HOOK_FILE_PATHS: readonly IPromptSourceFolder[] = [
 	{ path: '.github/hooks', source: PromptFileSource.GitHubWorkspace, storage: PromptsStorage.local },
+	{ path: AGENTS_WORKSPACE_HOOKS_FOLDER, source: PromptFileSource.AgentsWorkspace, storage: PromptsStorage.local },
 	{ path: '.claude/settings.local.json', source: PromptFileSource.ClaudeWorkspaceLocal, storage: PromptsStorage.local },
 	{ path: '.claude/settings.json', source: PromptFileSource.ClaudeWorkspace, storage: PromptsStorage.local },
 	{ path: '~/.copilot/hooks', source: PromptFileSource.CopilotPersonal, storage: PromptsStorage.user },

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/config/promptFileLocations.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/config/promptFileLocations.ts
@@ -197,6 +197,7 @@ export const DEFAULT_INSTRUCTIONS_SOURCE_FOLDERS: readonly IPromptSourceFolder[]
 	{ path: CLAUDE_RULES_SOURCE_FOLDER, source: PromptFileSource.ClaudeWorkspace, storage: PromptsStorage.local },
 	{ path: '~/.copilot/instructions', source: PromptFileSource.CopilotPersonal, storage: PromptsStorage.user },
 	{ path: '~/' + CLAUDE_RULES_SOURCE_FOLDER, source: PromptFileSource.ClaudePersonal, storage: PromptsStorage.user },
+	{ path: '~/' + AGENTS_WORKSPACE_INSTRUCTIONS_FOLDER, source: PromptFileSource.AgentsPersonal, storage: PromptsStorage.user },
 ];
 
 /**
@@ -216,6 +217,7 @@ export const DEFAULT_AGENT_SOURCE_FOLDERS: readonly IPromptSourceFolder[] = [
 	{ path: CLAUDE_AGENTS_SOURCE_FOLDER, source: PromptFileSource.ClaudeWorkspace, storage: PromptsStorage.local },
 	{ path: COPILOT_USER_AGENTS_SOURCE_FOLDER, source: PromptFileSource.CopilotPersonal, storage: PromptsStorage.user },
 	{ path: '~/' + CLAUDE_AGENTS_SOURCE_FOLDER, source: PromptFileSource.ClaudePersonal, storage: PromptsStorage.user },
+	{ path: '~/' + AGENTS_WORKSPACE_AGENTS_FOLDER, source: PromptFileSource.AgentsPersonal, storage: PromptsStorage.user },
 ];
 
 /**
@@ -229,6 +231,7 @@ export const DEFAULT_HOOK_FILE_PATHS: readonly IPromptSourceFolder[] = [
 	{ path: '.claude/settings.json', source: PromptFileSource.ClaudeWorkspace, storage: PromptsStorage.local },
 	{ path: '~/.copilot/hooks', source: PromptFileSource.CopilotPersonal, storage: PromptsStorage.user },
 	{ path: '~/.claude/settings.json', source: PromptFileSource.ClaudePersonal, storage: PromptsStorage.user },
+	{ path: '~/' + AGENTS_WORKSPACE_HOOKS_FOLDER, source: PromptFileSource.AgentsPersonal, storage: PromptsStorage.user },
 ];
 
 /**


### PR DESCRIPTION
## Summary

Adds support for resolving `.agents` workspace folder paths for:

- agents
- prompts
- instructions
- hooks

Skills were already supported previously, so this change brings the remaining workspace resource types to feature parity.

## Changes

- Added `.agents` workspace path handling for agent resources
- Added support for prompt path resolution
- Added support for instruction path resolution
- Added support for hook path resolution
- Kept existing skills behavior unchanged

## Motivation

This improves consistency across workspace resource loading and enables all supported resource types to be discovered from the `.agents` workspace structure.