### PR TITLE
Enable “Continue in Claude” for chat handoffs

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/claude/node/claudeCodeAgent.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/node/claudeCodeAgent.ts
@@ -25,6 +25,7 @@ import { getErrorDetailsFromChatFetchError } from '../../../../platform/chat/com
 import { IOctoKitService } from '../../../../platform/github/common/githubService';
 import { LanguageModelToolMCPSource } from '../../../../vscodeTypes';
 import { IClaudePluginService } from './claudeSkills';
+import { IChatDelegationSummaryService } from '../../copilotcli/common/delegationSummaryService';
 import { ExternalEditTracker } from '../../common/externalEditTracker';
 import { buildMcpServersFromRegistry } from '../common/claudeMcpServerRegistry';
 import { dispatchMessage, ClaudeProxyError, KnownClaudeError } from '../common/claudeMessageDispatch';
@@ -236,6 +237,7 @@ export class ClaudeCodeSession extends Disposable {
 		@IClaudeRuntimeDataService private readonly runtimeDataService: IClaudeRuntimeDataService,
 		@IMcpService private readonly mcpService: IMcpService,
 		@IClaudePluginService private readonly claudePluginService: IClaudePluginService,
+		@IChatDelegationSummaryService private readonly chatDelegationSummaryService: IChatDelegationSummaryService,
 		@IOTelService private readonly _otelService: IOTelService,
 		@IChatDebugFileLoggerService private readonly _debugFileLogger: IChatDebugFileLoggerService,
 	) {
@@ -582,7 +584,9 @@ export class ClaudeCodeSession extends Disposable {
 			this.langModelServer.incrementUserInitiatedMessageCount(request.modelId.toEndpointModelId());
 
 			// Resolve the prompt content blocks now that this request is being handled
-			const prompt = await resolvePromptToContentBlocks(request.request);
+			const prompt = await resolvePromptToContentBlocks(request.request, {
+				resolveReferenceText: uri => this.chatDelegationSummaryService.provideTextDocumentContent(uri)
+			});
 
 			// Create a capturing token for this request to group tool calls under the request
 			// we use the last text block in the prompt as the label for the token, since that is most representative of the user's intent

--- a/extensions/copilot/src/extension/chatSessions/claude/node/claudePromptResolver.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/node/claudePromptResolver.ts
@@ -16,6 +16,10 @@ function uriToString(uri: URI): string {
 	return uri.scheme === 'file' ? uri.fsPath : uri.toString();
 }
 
+export interface IResolvePromptToContentBlocksOptions {
+	readonly resolveReferenceText?: (uri: URI) => string | undefined;
+}
+
 /**
  * Converts a `vscode.ChatRequest` into an array of Anthropic content blocks.
  *
@@ -24,7 +28,7 @@ function uriToString(uri: URI): string {
  * - Binary image references become `image` content blocks.
  * - Slash-command prompts (starting with `/`) are passed through unmodified.
  */
-export async function resolvePromptToContentBlocks(request: vscode.ChatRequest): Promise<Anthropic.ContentBlockParam[]> {
+export async function resolvePromptToContentBlocks(request: vscode.ChatRequest, options?: IResolvePromptToContentBlocksOptions): Promise<Anthropic.ContentBlockParam[]> {
 	if (request.prompt.startsWith('/')) {
 		return [{ type: 'text', text: request.prompt }];
 	}
@@ -64,7 +68,7 @@ export async function resolvePromptToContentBlocks(request: vscode.ChatRequest):
 		}
 
 		const valueText = URI.isUri(refValue)
-			? uriToString(refValue)
+			? (options?.resolveReferenceText?.(refValue) ?? uriToString(refValue))
 			: isLocation(refValue)
 				? `${uriToString(refValue.uri)}:${refValue.range.start.line + 1}`
 				: undefined;

--- a/extensions/copilot/src/extension/chatSessions/claude/node/test/claudeCodeAgent.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/node/test/claudeCodeAgent.spec.ts
@@ -24,6 +24,7 @@ import { ClaudeLanguageModelServer } from '../claudeLanguageModelServer';
 import { parseClaudeModelId } from '../claudeModelId';
 import type { ParsedClaudeModelId } from '../../common/claudeModelId';
 import { IClaudeSessionStateService } from '../../common/claudeSessionStateService';
+import { IChatDelegationSummaryService } from '../../../copilotcli/common/delegationSummaryService';
 import { MockClaudeCodeSdkService } from './mockClaudeCodeSdkService';
 
 function createMockLangModelServer(): ClaudeLanguageModelServer {
@@ -35,6 +36,23 @@ function createMockLangModelServer(): ClaudeLanguageModelServer {
 
 function createMockChatRequest(prompt = ''): vscode.ChatRequest {
 	return { prompt, references: [], tools: new Map(), id: 'test-request-id', toolInvocationToken: {} } as unknown as vscode.ChatRequest;
+}
+
+function createMockChatDelegationSummaryService(): IChatDelegationSummaryService {
+	return {
+		_serviceBrand: undefined,
+		scheme: 'test-summary',
+		summarize: vi.fn().mockResolvedValue(undefined),
+		trackSummaryUsage: vi.fn().mockResolvedValue(undefined),
+		extractPrompt: vi.fn().mockReturnValue(undefined),
+		provideTextDocumentContent: vi.fn().mockReturnValue(undefined),
+	};
+}
+
+function createClaudeCodeAgentTestingServices(store: DisposableStore) {
+	const services = store.add(createExtensionUnitTestingServices());
+	services.define(IChatDelegationSummaryService, createMockChatDelegationSummaryService());
+	return services;
 }
 
 const TEST_MODEL_ID = parseClaudeModelId('claude-3-sonnet');
@@ -67,7 +85,7 @@ describe('ClaudeAgentManager', () => {
 	let sessionStateService: IClaudeSessionStateService;
 
 	beforeEach(() => {
-		const services = store.add(createExtensionUnitTestingServices());
+		const services = createClaudeCodeAgentTestingServices(store);
 		const accessor = services.createTestingAccessor();
 		instantiationService = accessor.get(IInstantiationService);
 
@@ -213,7 +231,7 @@ describe('ClaudeCodeSession', () => {
 	let sessionStateService: IClaudeSessionStateService;
 
 	beforeEach(() => {
-		const services = store.add(createExtensionUnitTestingServices());
+		const services = createClaudeCodeAgentTestingServices(store);
 		const accessor = services.createTestingAccessor();
 		instantiationService = accessor.get(IInstantiationService);
 		sessionStateService = accessor.get(IClaudeSessionStateService);
@@ -559,7 +577,7 @@ describe('ClaudeAgentManager - error handling', () => {
 	let instantiationService: IInstantiationService;
 
 	beforeEach(() => {
-		const services = store.add(createExtensionUnitTestingServices());
+		const services = createClaudeCodeAgentTestingServices(store);
 		const accessor = services.createTestingAccessor();
 		instantiationService = accessor.get(IInstantiationService);
 	});
@@ -589,7 +607,7 @@ describe('ClaudeCodeSession - yield flow', () => {
 	let mockService: MockClaudeCodeSdkService;
 
 	beforeEach(() => {
-		const services = store.add(createExtensionUnitTestingServices());
+		const services = createClaudeCodeAgentTestingServices(store);
 		const accessor = services.createTestingAccessor();
 		instantiationService = accessor.get(IInstantiationService);
 		sessionStateService = accessor.get(IClaudeSessionStateService);
@@ -667,7 +685,7 @@ describe('ClaudeCodeSession - settings change restart', () => {
 	let mockFs: MockFileSystemService;
 
 	beforeEach(() => {
-		const services = store.add(createExtensionUnitTestingServices());
+		const services = createClaudeCodeAgentTestingServices(store);
 		const accessor = services.createTestingAccessor();
 		instantiationService = accessor.get(IInstantiationService);
 		sessionStateService = accessor.get(IClaudeSessionStateService);
@@ -745,7 +763,7 @@ describe('ClaudeCodeSession - tools restart', () => {
 	let mockService: MockClaudeCodeSdkService;
 
 	beforeEach(() => {
-		const services = store.add(createExtensionUnitTestingServices());
+		const services = createClaudeCodeAgentTestingServices(store);
 		const accessor = services.createTestingAccessor();
 		instantiationService = accessor.get(IInstantiationService);
 		sessionStateService = accessor.get(IClaudeSessionStateService);
@@ -834,7 +852,7 @@ describe('ClaudeCodeSession - edge cases', () => {
 	let sessionStateService: IClaudeSessionStateService;
 
 	beforeEach(() => {
-		const services = store.add(createExtensionUnitTestingServices());
+		const services = createClaudeCodeAgentTestingServices(store);
 		const accessor = services.createTestingAccessor();
 		instantiationService = accessor.get(IInstantiationService);
 		sessionStateService = accessor.get(IClaudeSessionStateService);

--- a/extensions/copilot/src/extension/chatSessions/claude/node/test/claudeCodeAgentOTel.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/node/test/claudeCodeAgentOTel.spec.ts
@@ -22,6 +22,7 @@ import { IClaudeCodeSdkService } from '../claudeCodeSdkService';
 import { ClaudeLanguageModelServer } from '../claudeLanguageModelServer';
 import { parseClaudeModelId } from '../claudeModelId';
 import { IClaudeSessionStateService } from '../../common/claudeSessionStateService';
+import { IChatDelegationSummaryService } from '../../../copilotcli/common/delegationSummaryService';
 
 const TEST_MODEL_ID_STRING = 'claude-3-sonnet';
 const TEST_MODEL_ID = parseClaudeModelId(TEST_MODEL_ID_STRING);
@@ -85,6 +86,17 @@ function createOTelService() {
 	const spans: ICompletedSpanData[] = [];
 	otelService.onDidCompleteSpan(span => spans.push(span));
 	return { otelService, spans };
+}
+
+function createMockChatDelegationSummaryService(): IChatDelegationSummaryService {
+	return {
+		_serviceBrand: undefined,
+		scheme: 'test-summary',
+		summarize: vi.fn().mockResolvedValue(undefined),
+		trackSummaryUsage: vi.fn().mockResolvedValue(undefined),
+		extractPrompt: vi.fn().mockReturnValue(undefined),
+		provideTextDocumentContent: vi.fn().mockReturnValue(undefined),
+	};
 }
 
 /** Creates a typed assistant message with tool_use content blocks */
@@ -174,6 +186,7 @@ describe('Claude Session OTel Tool Spans', () => {
 		spans = localSpans;
 		services.define(IOTelService, otelService);
 		services.define(IClaudeCodeSdkService, sdkService);
+		services.define(IChatDelegationSummaryService, createMockChatDelegationSummaryService());
 		const accessor = services.createTestingAccessor();
 		const localInstantiationService = accessor.get(IInstantiationService);
 		const localSessionStateService = accessor.get(IClaudeSessionStateService);
@@ -217,6 +230,7 @@ describe('Claude Session OTel Tool Spans', () => {
 		spans = localSpans;
 		services.define(IOTelService, otelService);
 		services.define(IClaudeCodeSdkService, sdkService);
+		services.define(IChatDelegationSummaryService, createMockChatDelegationSummaryService());
 		const accessor = services.createTestingAccessor();
 		const localInstantiationService = accessor.get(IInstantiationService);
 		const localSessionStateService = accessor.get(IClaudeSessionStateService);
@@ -259,6 +273,7 @@ describe('Claude Session OTel Tool Spans', () => {
 		spans = localSpans;
 		services.define(IOTelService, otelService);
 		services.define(IClaudeCodeSdkService, sdkService);
+		services.define(IChatDelegationSummaryService, createMockChatDelegationSummaryService());
 		const accessor = services.createTestingAccessor();
 		const localInstantiationService = accessor.get(IInstantiationService);
 		const localSessionStateService = accessor.get(IClaudeSessionStateService);
@@ -295,6 +310,7 @@ describe('Claude Session OTel Tool Spans', () => {
 		spans = localSpans;
 		services.define(IOTelService, otelService);
 		services.define(IClaudeCodeSdkService, sdkService);
+		services.define(IChatDelegationSummaryService, createMockChatDelegationSummaryService());
 		const accessor = services.createTestingAccessor();
 		const localInstantiationService = accessor.get(IInstantiationService);
 		const localSessionStateService = accessor.get(IClaudeSessionStateService);
@@ -331,6 +347,7 @@ describe('Claude Session OTel Tool Spans', () => {
 		spans = localSpans;
 		services.define(IOTelService, otelService);
 		services.define(IClaudeCodeSdkService, sdkService);
+		services.define(IChatDelegationSummaryService, createMockChatDelegationSummaryService());
 		const accessor = services.createTestingAccessor();
 		const localInstantiationService = accessor.get(IInstantiationService);
 		const localSessionStateService = accessor.get(IClaudeSessionStateService);

--- a/extensions/copilot/src/extension/chatSessions/claude/node/test/resolvePromptToContentBlocks.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/node/test/resolvePromptToContentBlocks.spec.ts
@@ -128,6 +128,21 @@ describe('resolvePromptToContentBlocks', () => {
 		expect(textBlocks(blocks)[1].text).toContain(fileUri.fsPath);
 	});
 
+	it('resolves non-inline URI references with provided text', async () => {
+		const summaryUri = URI.parse('copilot-delegated-chat-summary:/summary?request-id');
+		const ref = makeRef(summaryUri);
+		const request = new TestChatRequest('Start implementation\nComplete the task as described in the summary', [ref]);
+
+		const blocks = await resolvePromptToContentBlocks(request, {
+			resolveReferenceText: uri => uri.toString() === summaryUri.toString() ? 'Delegated summary content' : undefined
+		});
+
+		expect(blocks).toHaveLength(2);
+		expect(textBlocks(blocks)[0].text).toBe('Start implementation\nComplete the task as described in the summary');
+		expect(textBlocks(blocks)[1].text).toContain('Delegated summary content');
+		expect(textBlocks(blocks)[1].text).not.toContain(summaryUri.toString());
+	});
+
 	it('includes multiple non-inline references in a single system-reminder block', async () => {
 		const uri1 = URI.file('/a.ts');
 		const uri2 = URI.file('/b.ts');

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/chatSessions.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/chatSessions.ts
@@ -146,6 +146,7 @@ export class ChatSessionsContrib extends Disposable implements IExtensionContrib
 				[IClaudePlanFileTracker, new SyncDescriptor(ClaudePlanFileTracker)],
 				[IClaudeSessionStateService, new SyncDescriptor(ClaudeSessionStateService)],
 				[IClaudeSlashCommandService, new SyncDescriptor(ClaudeSlashCommandService)],
+				[IChatDelegationSummaryService, delegationSummary],
 				[IChatSessionMetadataStore, sessionMetadata],
 				[IChatSessionWorktreeService, new SyncDescriptor(ChatSessionWorktreeService)],
 				[IChatSessionWorktreeCheckpointService, new SyncDescriptor(ChatSessionWorktreeCheckpointService)],

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/claudeChatSessionContentProvider.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/claudeChatSessionContentProvider.ts
@@ -111,7 +111,7 @@ export class ClaudeChatSessionContentProvider extends Disposable implements vsco
 	createHandler(): ChatExtendedRequestHandler {
 		return async (request: vscode.ChatRequest, context: vscode.ChatContext, stream: vscode.ChatResponseStream, token: vscode.CancellationToken): Promise<vscode.ChatResult | void> => {
 			const { chatSessionContext } = context;
-			if (!chatSessionContext || request.sessionResource.scheme !== ClaudeSessionUri.scheme) {
+			if (!chatSessionContext || chatSessionContext.chatSessionItem.resource.scheme !== ClaudeSessionUri.scheme) {
 				return this.handleDelegationFromAnotherChat(request, context, stream, token);
 			}
 

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/claudeChatSessionContentProvider.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/claudeChatSessionContentProvider.ts
@@ -27,12 +27,14 @@ import { ClaudeSessionUri } from '../claude/common/claudeSessionUri';
 import { ClaudeAgentManager } from '../claude/node/claudeCodeAgent';
 import { CLAUDE_REASONING_EFFORT_PROPERTY, IClaudeCodeModels, pickReasoningEffort } from '../claude/node/claudeCodeModels';
 import { IClaudeCodeSdkService } from '../claude/node/claudeCodeSdkService';
-import { parseClaudeModelId } from '../claude/node/claudeModelId';
+import { parseClaudeModelId, tryParseClaudeModelId } from '../claude/node/claudeModelId';
 import { IClaudeSessionStateService } from '../claude/common/claudeSessionStateService';
 import { IClaudeCodeSessionService } from '../claude/node/sessionParser/claudeCodeSessionService';
 import { formatModelDetails, formatModelDetailsWithMultiplier } from '../../../platform/chat/common/chatModelDetails';
 import { IClaudeCodeSessionInfo, IClaudeCodeSession, SYNTHETIC_MODEL_ID } from '../claude/node/sessionParser/claudeSessionSchema';
 import { IClaudeSlashCommandService } from '../claude/vscode-node/claudeSlashCommandService';
+import { IChatDelegationSummaryService } from '../copilotcli/common/delegationSummaryService';
+import { convertReferenceToVariable } from '../copilotcli/vscode-node/copilotCLIPromptReferences';
 import { IChatFolderMruService } from '../common/folderRepositoryManager';
 import { builtinSlashCommands } from '../common/builtinSlashCommands';
 import { IClaudeWorkspaceFolderService } from '../common/claudeWorkspaceFolderService';
@@ -88,6 +90,7 @@ export class ClaudeChatSessionContentProvider extends Disposable implements vsco
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IChatQuotaService private readonly _chatQuotaService: IChatQuotaService,
+		@IChatDelegationSummaryService private readonly _chatDelegationSummaryService: IChatDelegationSummaryService,
 	) {
 		super();
 		this._controller = this._register(instantiationService.createInstance(ClaudeChatSessionItemController));
@@ -108,12 +111,8 @@ export class ClaudeChatSessionContentProvider extends Disposable implements vsco
 	createHandler(): ChatExtendedRequestHandler {
 		return async (request: vscode.ChatRequest, context: vscode.ChatContext, stream: vscode.ChatResponseStream, token: vscode.CancellationToken): Promise<vscode.ChatResult | void> => {
 			const { chatSessionContext } = context;
-			if (!chatSessionContext) {
-				/* Via @claude */
-				// TODO: Think about how this should work
-				stream.markdown(vscode.l10n.t("Start a new Claude Agent session"));
-				stream.button({ command: `workbench.action.chat.openNewSessionEditor.${ClaudeSessionUri.scheme}`, title: vscode.l10n.t("Start Session") });
-				return {};
+			if (!chatSessionContext || request.sessionResource.scheme !== ClaudeSessionUri.scheme) {
+				return this.handleDelegationFromAnotherChat(request, context, stream, token);
 			}
 
 			// Try to handle as a slash command first
@@ -189,6 +188,69 @@ export class ClaudeChatSessionContentProvider extends Disposable implements vsco
 				...(result.errorDetails ? { errorDetails: result.errorDetails } : {}),
 			};
 		};
+	}
+
+	private async handleDelegationFromAnotherChat(request: vscode.ChatRequest, context: vscode.ChatContext, stream: vscode.ChatResponseStream, token: vscode.CancellationToken): Promise<vscode.ChatResult> {
+		let prompt = request.prompt;
+		let summary: string | undefined;
+		if (this.hasHistoryToSummarize(context.history)) {
+			stream.progress(vscode.l10n.t('Analyzing chat history'));
+			summary = await this._chatDelegationSummaryService.summarize(context, token);
+			if (summary) {
+				summary = `**Summary**\n${summary}`;
+			}
+		}
+
+		if (token.isCancellationRequested) {
+			return {};
+		}
+
+		const attachedContext = [];
+		if (summary) {
+			const summaryRef = await this._chatDelegationSummaryService.trackSummaryUsage(request.id, summary);
+			if (summaryRef) {
+				prompt = `${prompt}\n${vscode.l10n.t('Complete the task as described in the {0}', `[summary](${summaryRef.id})`)}`;
+				attachedContext.push(convertReferenceToVariable(summaryRef, []));
+			} else {
+				prompt = `${prompt}\n${summary}`;
+			}
+		}
+
+		const chatOptions: { prompt: string; attachedContext: typeof attachedContext; userSelectedModelId?: string } = {
+			prompt,
+			attachedContext,
+		};
+		const userSelectedModelId = this.getClaudeRequestModelIdentifier(request);
+		if (userSelectedModelId) {
+			chatOptions.userSelectedModelId = userSelectedModelId;
+		}
+
+		await vscode.commands.executeCommand(`workbench.action.chat.openNewSessionEditor.${ClaudeSessionUri.scheme}`, chatOptions);
+
+		stream.markdown(vscode.l10n.t('A Claude Agent session has begun working on your request. Follow its progress in the sessions list.'));
+		return {};
+	}
+
+	private getClaudeRequestModelIdentifier(request: vscode.ChatRequest): string | undefined {
+		const model = request.model;
+		if (!model) {
+			return undefined;
+		}
+		const isClaudeModel = Boolean(tryParseClaudeModelId(model.id)) || (model.vendor === 'copilot' && model.family?.toLowerCase().startsWith('claude'));
+		return isClaudeModel ? `${ClaudeSessionUri.scheme}/${model.id}` : undefined;
+	}
+
+	private hasHistoryToSummarize(history: readonly (vscode.ChatRequestTurn | vscode.ChatResponseTurn)[]): boolean {
+		if (!history || history.length === 0) {
+			return false;
+		}
+		const allResponsesEmpty = history.every(turn => {
+			if (turn instanceof vscode.ChatResponseTurn) {
+				return turn.response.length === 0;
+			}
+			return true;
+		});
+		return !allResponsesEmpty;
 	}
 
 	// #endregion

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/test/claudeChatSessionContentProvider.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/test/claudeChatSessionContentProvider.spec.ts
@@ -16,7 +16,7 @@ import { ITestingServicesAccessor } from '../../../../platform/test/node/service
 import { TestWorkspaceService } from '../../../../platform/test/node/testWorkspaceService';
 import { IWorkspaceService } from '../../../../platform/workspace/common/workspaceService';
 import { mock } from '../../../../util/common/test/simpleMock';
-import { CancellationToken } from '../../../../util/vs/base/common/cancellation';
+import { CancellationToken, CancellationTokenSource } from '../../../../util/vs/base/common/cancellation';
 import { Emitter, Event } from '../../../../util/vs/base/common/event';
 import { DisposableStore } from '../../../../util/vs/base/common/lifecycle';
 import { observableValue } from '../../../../util/vs/base/common/observableInternal/observables/observableValue';
@@ -34,6 +34,7 @@ import { IClaudeSessionStateService } from '../../claude/common/claudeSessionSta
 import { IClaudeCodeSessionService } from '../../claude/node/sessionParser/claudeCodeSessionService';
 import { IClaudeCodeSessionInfo } from '../../claude/node/sessionParser/claudeSessionSchema';
 import { IClaudeSlashCommandService } from '../../claude/vscode-node/claudeSlashCommandService';
+import { IChatDelegationSummaryService } from '../../copilotcli/common/delegationSummaryService';
 import { FolderRepositoryMRUEntry, IChatFolderMruService } from '../../common/folderRepositoryManager';
 import { IClaudeWorkspaceFolderService } from '../../common/claudeWorkspaceFolderService';
 import { builtinSlashCommands } from '../../common/builtinSlashCommands';
@@ -266,6 +267,14 @@ function createProviderWithServices(
 		_serviceBrand: undefined,
 		getWorkspaceChanges: vi.fn().mockResolvedValue([]),
 	});
+	serviceCollection.define(IChatDelegationSummaryService, {
+		_serviceBrand: undefined,
+		scheme: 'test-summary',
+		summarize: vi.fn().mockResolvedValue(undefined),
+		trackSummaryUsage: vi.fn().mockResolvedValue(undefined),
+		extractPrompt: vi.fn().mockReturnValue(undefined),
+		provideTextDocumentContent: vi.fn().mockReturnValue(undefined),
+	});
 
 	const accessor = serviceCollection.createTestingAccessor();
 	const instaService = accessor.get(IInstantiationService);
@@ -376,6 +385,130 @@ describe('ChatSessionContentProvider', () => {
 
 			expect(result.history).toEqual([]);
 			expect(mockSessionService.getSession).toHaveBeenCalledWith(sessionUri, CancellationToken.None);
+		});
+	});
+
+	describe('createHandler delegation', () => {
+		function createDelegationContext(options?: { readonly history?: readonly (vscode.ChatRequestTurn | vscode.ChatResponseTurn)[] }): vscode.ChatContext {
+			return {
+				history: options?.history ?? [],
+				yieldRequested: false,
+				chatSessionContext: {
+					isUntitled: false,
+					chatSessionItem: {
+						resource: URI.parse('local:/source-session') as any,
+						label: 'Local Session',
+					},
+					inputState: { groups: [], sessionResource: undefined, onDidChange: Event.None, onDidDispose: Event.None },
+				},
+			} as vscode.ChatContext;
+		}
+
+		it('opens a new Claude session when invoked from a non-Claude chat session', async () => {
+			const request = createTestRequest('Start implementation');
+			request.sessionResource = URI.parse('local:/source-session') as any;
+			const context = createDelegationContext();
+
+			const handler = provider.createHandler();
+			const stream = new MockChatResponseStream();
+
+			await handler(request, context, stream, CancellationToken.None);
+
+			expect(vscodeShim.commands.executeCommand).toHaveBeenCalledWith(
+				'workbench.action.chat.openNewSessionEditor.claude-code',
+				{ prompt: 'Start implementation', attachedContext: [], userSelectedModelId: 'claude-code/claude-3-5-sonnet-20241022' }
+			);
+		});
+
+		it('does not pass a source model hint when the delegated request model is not Claude', async () => {
+			const request = createTestRequest('Start implementation');
+			request.sessionResource = URI.parse('local:/source-session') as any;
+			(request as any).model = { id: 'gpt-5', name: 'GPT-5', family: 'gpt-5', vendor: 'copilot' };
+			const context = createDelegationContext();
+
+			const handler = provider.createHandler();
+			const stream = new MockChatResponseStream();
+
+			await handler(request, context, stream, CancellationToken.None);
+
+			expect(vscodeShim.commands.executeCommand).toHaveBeenCalledWith(
+				'workbench.action.chat.openNewSessionEditor.claude-code',
+				{ prompt: 'Start implementation', attachedContext: [] }
+			);
+		});
+
+		it('opens the new Claude session with a summary attachment instead of source references', async () => {
+			const summaryUri = URI.parse('copilot-delegated-chat-summary:/summary?request-id') as any;
+			const delegationSummaryService = accessor.get(IChatDelegationSummaryService);
+			vi.mocked(delegationSummaryService.summarize).mockResolvedValue('The previous chat produced a complete implementation plan for the task.');
+			vi.mocked(delegationSummaryService.trackSummaryUsage).mockResolvedValue({
+				id: summaryUri.toString(),
+				name: 'Delegation Summary',
+				modelDescription: 'Summary of previous chat history for delegated request',
+				value: summaryUri,
+			});
+			const responseTurn = Object.create(vscodeShim.ChatResponseTurn.prototype) as vscode.ChatResponseTurn;
+			(responseTurn as any).response = ['response'];
+			const reference = {
+				id: 'file-ref',
+				name: 'AGENTS.md',
+				value: URI.file('/workspace/AGENTS.md') as any,
+			} as vscode.ChatPromptReference;
+			const request = createTestRequest('Start implementation');
+			request.references = [reference];
+			request.sessionResource = URI.parse('local:/source-session') as any;
+
+			const handler = provider.createHandler();
+			const stream = new MockChatResponseStream();
+
+			await handler(request, createDelegationContext({ history: [responseTurn] }), stream, CancellationToken.None);
+
+			expect(vscodeShim.commands.executeCommand).toHaveBeenCalledWith(
+				'workbench.action.chat.openNewSessionEditor.claude-code',
+				{
+					prompt: `Start implementation\nComplete the task as described in the [summary](${summaryUri.toString()})`,
+					attachedContext: [expect.objectContaining({ id: summaryUri.toString(), name: 'Delegation Summary' })],
+					userSelectedModelId: 'claude-code/claude-3-5-sonnet-20241022',
+				}
+			);
+		});
+
+		it('does not forward non-summary request references to the new Claude session', async () => {
+			const reference = {
+				id: 'file-ref',
+				name: 'AGENTS.md',
+				value: URI.file('/workspace/AGENTS.md') as any,
+			} as vscode.ChatPromptReference;
+			const request = createTestRequest('Start implementation');
+			request.references = [reference];
+			request.sessionResource = URI.parse('local:/source-session') as any;
+			const context = createDelegationContext();
+
+			const handler = provider.createHandler();
+			const stream = new MockChatResponseStream();
+
+			await handler(request, context, stream, CancellationToken.None);
+
+			expect(vscodeShim.commands.executeCommand).toHaveBeenCalledWith(
+				'workbench.action.chat.openNewSessionEditor.claude-code',
+				{ prompt: 'Start implementation', attachedContext: [], userSelectedModelId: 'claude-code/claude-3-5-sonnet-20241022' }
+			);
+		});
+
+		it('does not open a new Claude session when delegation is cancelled', async () => {
+			const request = createTestRequest('Start implementation');
+			request.sessionResource = URI.parse('local:/source-session') as any;
+			const context = createDelegationContext();
+			const cts = new CancellationTokenSource();
+			cts.cancel();
+
+			const handler = provider.createHandler();
+			const stream = new MockChatResponseStream();
+
+			await handler(request, context, stream, cts.token);
+
+			expect(vscodeShim.commands.executeCommand).not.toHaveBeenCalled();
+			cts.dispose();
 		});
 	});
 

--- a/src/vs/workbench/contrib/chat/browser/actions/chatContinueInAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatContinueInAction.ts
@@ -219,6 +219,12 @@ export class ChatContinueInSessionActionItem extends ActionWidgetDropdownActionV
 					actions.push(this.toAction(AgentSessionProviders.Cloud, cloudContrib, instantiationService, location, hasGitRepo));
 				}
 
+				// Continue in Claude
+				const claudeContrib = contributions.find(contrib => contrib.type === AgentSessionProviders.Claude);
+				if (claudeContrib && claudeContrib.canDelegate) {
+					actions.push(this.toAction(AgentSessionProviders.Claude, claudeContrib, instantiationService, location));
+				}
+
 				// Offer actions to enter setup if we have no contributions
 				if (actions.length === 0) {
 					actions.push(this.toSetupAction(AgentSessionProviders.Background, instantiationService));

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessions.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessions.ts
@@ -128,8 +128,8 @@ export function getAgentCanContinueIn(provider: AgentSessionTarget): boolean {
 		case AgentSessionProviders.Local:
 		case AgentSessionProviders.Background:
 		case AgentSessionProviders.Cloud:
-			return true;
 		case AgentSessionProviders.Claude:
+			return true;
 		case AgentSessionProviders.Codex:
 		case AgentSessionProviders.Growth:
 		case AgentSessionProviders.AgentHostCopilot:

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
@@ -50,9 +50,10 @@ import { Target } from '../../common/promptSyntax/promptTypes.js';
 import { slashReg } from '../../common/requestParser/chatRequestParser.js';
 import { OffsetRange } from '../../../../../editor/common/core/ranges/offsetRange.js';
 import { ILanguageModelToolsService } from '../../common/tools/languageModelToolsService.js';
-import { IChatModel } from '../../common/model/chatModel.js';
+import { IChatModel, IChatModelInputState } from '../../common/model/chatModel.js';
 import { ICustomizationHarnessService } from '../../common/customizationHarnessService.js';
 import { generateUuid } from '../../../../../base/common/uuid.js';
+import { ILanguageModelsService } from '../../common/languageModels.js';
 
 const extensionPoint = ExtensionsRegistry.registerExtensionPoint<IChatSessionsExtensionPoint[]>({
 	extensionPoint: 'chatSessions',
@@ -597,7 +598,7 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 					});
 				}
 
-				async run(accessor: ServicesAccessor, chatOptions?: { prompt: string; attachedContext?: IChatRequestVariableEntry[] }): Promise<void> {
+				async run(accessor: ServicesAccessor, chatOptions?: NewChatSessionSendOptions): Promise<void> {
 					const { type, displayName } = contribution;
 					await openChatSession(accessor, { type, displayName, position: ChatSessionPosition.Editor }, chatOptions);
 				}
@@ -619,7 +620,7 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 					});
 				}
 
-				async run(accessor: ServicesAccessor, chatOptions?: { prompt: string; attachedContext?: IChatRequestVariableEntry[] }): Promise<void> {
+				async run(accessor: ServicesAccessor, chatOptions?: NewChatSessionSendOptions): Promise<void> {
 					const { type, displayName } = contribution;
 					await openChatSession(accessor, { type, displayName, position: ChatSessionPosition.Sidebar }, chatOptions);
 				}
@@ -1334,6 +1335,7 @@ type NewChatSessionSendOptions = {
 	readonly prompt: string;
 	readonly attachedContext?: IChatRequestVariableEntry[];
 	readonly initialSessionOptions?: ReadonlyChatSessionOptionsMap;
+	readonly userSelectedModelId?: string;
 };
 
 export type NewChatSessionOpenOptions = {
@@ -1347,6 +1349,7 @@ export async function openChatSession(accessor: ServicesAccessor, openOptions: N
 	const viewsService = accessor.get(IViewsService);
 	const chatService = accessor.get(IChatService);
 	const chatSessionService = accessor.get(IChatSessionsService);
+	const languageModelsService = accessor.get(ILanguageModelsService);
 	const logService = accessor.get(ILogService);
 	const editorGroupService = accessor.get(IEditorGroupsService);
 	const editorService = accessor.get(IEditorService);
@@ -1355,6 +1358,7 @@ export async function openChatSession(accessor: ServicesAccessor, openOptions: N
 
 	// Determine resource to open
 	const sessionResource = getResourceForNewChatSession(openOptions);
+	const initialModelInputState = await getModelInputStateForInitialModel(chatSendOptions?.userSelectedModelId, languageModelsService);
 
 	// Open chat session
 	try {
@@ -1364,7 +1368,10 @@ export async function openChatSession(accessor: ServicesAccessor, openOptions: N
 				if (openOptions.type === AgentSessionProviders.Local) {
 					await view.widget.clear();
 				} else {
-					await view.loadSession(sessionResource);
+					const model = await view.loadSession(sessionResource);
+					if (model && initialModelInputState) {
+						model.inputModel.setState(initialModelInputState);
+					}
 				}
 				view.focus();
 				break;
@@ -1373,6 +1380,7 @@ export async function openChatSession(accessor: ServicesAccessor, openOptions: N
 				const options: IChatEditorOptions = {
 					override: ChatEditorInput.EditorID,
 					pinned: true,
+					...(initialModelInputState ? { modelInputState: initialModelInputState } : {}),
 					title: {
 						fallback: localize('chatEditorContributionName', "{0}", openOptions.displayName),
 					}
@@ -1410,11 +1418,34 @@ export async function openChatSession(accessor: ServicesAccessor, openOptions: N
 			if (promptFile) {
 				attachedContext = [promptFile, ...(attachedContext ?? [])];
 			}
-			await chatService.sendRequest(sessionResource, chatSendOptions.prompt, { agentIdSilent: openOptions.type, attachedContext });
+			await chatService.sendRequest(sessionResource, chatSendOptions.prompt, { agentIdSilent: openOptions.type, attachedContext, userSelectedModelId: chatSendOptions.userSelectedModelId });
 		} catch (e) {
 			logService.error(`Failed to send initial request to '${openOptions.type}' chat session with contextOptions: ${JSON.stringify(chatSendOptions)}`, e);
 		}
 	}
+}
+
+async function getModelInputStateForInitialModel(userSelectedModelId: string | undefined, languageModelsService: ILanguageModelsService): Promise<Partial<IChatModelInputState> | undefined> {
+	if (!userSelectedModelId) {
+		return undefined;
+	}
+	let metadata = languageModelsService.lookupLanguageModel(userSelectedModelId);
+	if (!metadata) {
+		const vendor = getVendorFromModelIdentifier(userSelectedModelId);
+		if (vendor) {
+			await languageModelsService.selectLanguageModels({ vendor });
+			metadata = languageModelsService.lookupLanguageModel(userSelectedModelId);
+		}
+	}
+	if (!metadata) {
+		return undefined;
+	}
+	return { selectedModel: { identifier: userSelectedModelId, metadata } };
+}
+
+function getVendorFromModelIdentifier(modelIdentifier: string): string | undefined {
+	const firstSlash = modelIdentifier.indexOf('/');
+	return firstSlash === -1 ? undefined : modelIdentifier.substring(0, firstSlash);
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatSuggestNextWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatSuggestNextWidget.ts
@@ -17,7 +17,13 @@ import { ChatConfiguration } from '../../../common/constants.js';
 import { IChatMode } from '../../../common/chatModes.js';
 import { IChatSessionsService } from '../../../common/chatSessionsService.js';
 import { IHandOff } from '../../../common/promptSyntax/promptFileParser.js';
-import { getAgentCanContinueIn, getAgentSessionProvider, getAgentSessionProviderIcon, getAgentSessionProviderName } from '../../agentSessions/agentSessions.js';
+import { AgentSessionProviders, getAgentCanContinueIn, getAgentSessionProvider, getAgentSessionProviderIcon, getAgentSessionProviderName } from '../../agentSessions/agentSessions.js';
+
+const continueInProviderOrder = new Map<AgentSessionProviders, number>([
+	[AgentSessionProviders.Background, 0],
+	[AgentSessionProviders.Cloud, 1],
+	[AgentSessionProviders.Claude, 2],
+]);
 
 export interface INextPromptSelection {
 	readonly handoff: IHandOff;
@@ -153,6 +159,10 @@ export class ChatSuggestNextWidget extends Disposable {
 			}
 			const provider = getAgentSessionProvider(c.type);
 			return provider !== undefined && getAgentCanContinueIn(provider);
+		}).sort((a, b) => {
+			const providerA = getAgentSessionProvider(a.type)!;
+			const providerB = getAgentSessionProvider(b.type)!;
+			return (continueInProviderOrder.get(providerA) ?? Number.MAX_SAFE_INTEGER) - (continueInProviderOrder.get(providerB) ?? Number.MAX_SAFE_INTEGER);
 		});
 
 		if (showContinueOn && availableContributions.length > 0) {

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/editor/chatEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/editor/chatEditor.ts
@@ -41,7 +41,7 @@ export interface IChatEditorOptions extends IEditorOptions {
 	 * new sessions are not persisted but may go away with
 	 * https://github.com/microsoft/vscode/pull/278476 as input state is stored on the model.
 	 */
-	modelInputState?: IChatModelInputState;
+	modelInputState?: Partial<IChatModelInputState>;
 	target?: { data: IExportableChatData | ISerializableChatData };
 	title?: {
 		preferred?: string;
@@ -256,11 +256,11 @@ export class ChatEditor extends AbstractEditorWithViewState<IChatEditorViewState
 				this.hideLoadingInChatWidget();
 			}
 
+			this.updateModel(editorModel.model);
+
 			if (options?.modelInputState) {
 				editorModel.model.inputModel.setState(options.modelInputState);
 			}
-
-			this.updateModel(editorModel.model);
 
 			const viewState = this.loadEditorViewState(input, context);
 			if (viewState) {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionViewModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionViewModel.test.ts
@@ -2295,6 +2295,11 @@ suite('AgentSessions', () => {
 			assert.strictEqual(result, true);
 		});
 
+		test('should return true for Claude provider', () => {
+			const result = getAgentCanContinueIn(AgentSessionProviders.Claude);
+			assert.strictEqual(result, true);
+		});
+
 		test('should return false for Growth provider', () => {
 			const result = getAgentCanContinueIn(AgentSessionProviders.Growth);
 			assert.strictEqual(result, false);


### PR DESCRIPTION
Fixes #300531

This enables Claude Agent as a functional `Continue In` destination from chat and plan-mode handoffs.

## Summary

Users can now continue work in Claude Agent from the existing `Continue In` UI, including the plan-mode `Start Implementation` dropdown. The handoff opens a real Claude Agent session and starts it with the delegated task context.

The implementation follows the existing Copilot CLI handoff pattern: when Claude is invoked from a non-Claude session, the Claude provider treats the request as a delegation, creates a new target session, and starts that session with summarized context rather than trying to process the source chat resource directly.

## Details

- Adds Claude Agent to the existing Continue In allowlist and dropdown.
- Adds Claude Agent to the plan-mode Continue In target list after Copilot CLI and Cloud.
- Handles `@claude` requests from non-Claude sessions as delegated handoffs, matching the Copilot CLI pattern.
- Starts a new `claude-code` session with a concise delegated prompt and summary attachment.
- Resolves delegated summary attachments before sending model input so Claude receives the summary content directly.
- Preserves the selected Claude model for the delegated request when the source handoff is already using a Claude model.

## Validation

Figure 1: Claude Added to the Start Implementation Continue In Menu
<img width="1082" height="862" alt="image" src="https://github.com/user-attachments/assets/0f245051-8163-4599-b810-e5822f1ae0ee" />

<br>

Figure 2: Claude Handoff Starts a Delegated Agent Session From Plan Mode
<img width="1087" height="866" alt="image" src="https://github.com/user-attachments/assets/54d9ab27-b7d7-454d-9e1d-745267c8c14b" />

<br>

Figure 3: Delegated Claude Session Uses Summary Context and Preserves the Selected Model
<img width="1088" height="866" alt="image" src="https://github.com/user-attachments/assets/7e3efb65-a717-41b5-8b8d-7b439f179bf4" />
