### PR TITLE
agentHost: show fetched URL for web_fetch

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
@@ -6,7 +6,7 @@
 import type { PermissionRequest } from '@github/copilot-sdk';
 import { hasKey } from '../../../../base/common/types.js';
 import { URI } from '../../../../base/common/uri.js';
-import { appendEscapedMarkdownInlineCode, escapeMarkdownLinkLabel } from '../../../../base/common/htmlContent.js';
+import { appendEscapedMarkdownInlineCode, escapeMarkdownLinkLabel, MarkdownString } from '../../../../base/common/htmlContent.js';
 import { hash } from '../../../../base/common/hash.js';
 import { localize } from '../../../../nls.js';
 import type { IAgentToolPendingConfirmationSignal } from '../../common/agentService.js';
@@ -185,6 +185,11 @@ interface ICopilotGlobToolArgs {
 interface ICopilotSqlToolArgs {
 	description?: string;
 	query?: string;
+}
+
+/** Parameters for the `web_fetch` tool. */
+interface ICopilotWebFetchToolArgs {
+	url: string;
 }
 
 /**
@@ -403,6 +408,10 @@ function formatPathAsMarkdownLink(path: string): string {
 	return `[${basename(uri)}](${uri})`;
 }
 
+function formatUrlAsMarkdownLink(url: string): string {
+	return new MarkdownString().appendLink(url, truncate(url, 80)).value;
+}
+
 /**
  * Wraps a localized message containing a markdown file link into a
  * `StringOrMarkdown` object so the renderer treats it as markdown.
@@ -562,6 +571,13 @@ export function getInvocationMessage(toolName: string, displayName: string, para
 			const args = parameters as ICopilotSqlToolArgs | undefined;
 			return args?.description || localize('toolInvoke.sql', "Executing SQL query");
 		}
+		case CopilotToolName.WebFetch: {
+			const args = parameters as ICopilotWebFetchToolArgs | undefined;
+			if (args?.url) {
+				return md(localize('toolInvoke.webFetch', "Fetching {0}", formatUrlAsMarkdownLink(args.url)));
+			}
+			return localize('toolInvoke.webFetchGeneric', "Fetching URL");
+		}
 		case CopilotToolName.ExitPlanMode:
 			return localize('toolInvoke.exitPlanMode', "Presenting plan");
 		default:
@@ -664,6 +680,13 @@ export function getPastTenseMessage(toolName: string, displayName: string, param
 		case CopilotToolName.Sql: {
 			const args = parameters as ICopilotSqlToolArgs | undefined;
 			return args?.description || localize('toolComplete.sql', "Executed SQL query");
+		}
+		case CopilotToolName.WebFetch: {
+			const args = parameters as ICopilotWebFetchToolArgs | undefined;
+			if (args?.url) {
+				return md(localize('toolComplete.webFetch', "Fetched {0}", formatUrlAsMarkdownLink(args.url)));
+			}
+			return localize('toolComplete.webFetchGeneric', "Fetched URL");
 		}
 		case CopilotToolName.ExitPlanMode:
 			return localize('toolComplete.exitPlanMode', "Exited plan mode");
@@ -785,6 +808,10 @@ export function getToolInputString(toolName: string, parameters: Record<string, 
 		case CopilotToolName.Rg: {
 			const args = parameters as ICopilotRgToolArgs | undefined;
 			return args?.pattern ?? rawArguments;
+		}
+		case CopilotToolName.WebFetch: {
+			const args = parameters as ICopilotWebFetchToolArgs | undefined;
+			return args?.url ?? rawArguments;
 		}
 		default:
 			// For other tools, show the formatted JSON arguments

--- a/src/vs/platform/agentHost/test/node/copilotToolDisplay.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotToolDisplay.test.ts
@@ -463,6 +463,40 @@ suite('rg / grep search tool display', () => {
 	});
 });
 
+suite('web_fetch tool display', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function text(msg: ReturnType<typeof getInvocationMessage> | ReturnType<typeof getPastTenseMessage>): string {
+		return typeof msg === 'string' ? msg : msg.markdown;
+	}
+
+	test('uses the fetched URL for invocation and completion messages', () => {
+		const parameters = { url: 'https://example.com/docs' };
+		assert.deepStrictEqual({
+			invocation: text(getInvocationMessage('web_fetch', 'Fetch Web Content', parameters)),
+			pastTense: text(getPastTenseMessage('web_fetch', 'Fetch Web Content', parameters, true)),
+			input: getToolInputString('web_fetch', parameters, undefined),
+		}, {
+			invocation: 'Fetching [https://example.com/docs](https://example.com/docs)',
+			pastTense: 'Fetched [https://example.com/docs](https://example.com/docs)',
+			input: 'https://example.com/docs',
+		});
+	});
+
+	test('falls back to generic URL wording when the URL is absent', () => {
+		assert.deepStrictEqual({
+			invocation: text(getInvocationMessage('web_fetch', 'Fetch Web Content', undefined)),
+			pastTense: text(getPastTenseMessage('web_fetch', 'Fetch Web Content', undefined, true)),
+			failure: text(getPastTenseMessage('web_fetch', 'Fetch Web Content', { url: 'https://example.com/docs' }, false)),
+		}, {
+			invocation: 'Fetching URL',
+			pastTense: 'Fetched URL',
+			failure: '"Fetch Web Content" failed',
+		});
+	});
+});
+
 suite('sql tool display', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();


### PR DESCRIPTION
## Summary\n- Render Copilot CLI `web_fetch` invocation and completion messages with the fetched URL\n- Keep a generic URL fallback when the tool arguments do not include a URL\n- Add focused unit coverage for the fetch display behavior\n\n## Validation\n- `npm run compile-check-ts-native`\n- `node --experimental-strip-types build/hygiene.ts src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts src/vs/platform/agentHost/test/node/copilotToolDisplay.test.ts`\n- `npm run test-node -- --run src/vs/platform/agentHost/test/node/copilotToolDisplay.test.ts`\n\n(Written by Copilot)