### PR TITLE
Agent host: clearer worktree git timeout errors and 60s budget

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostGitService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitService.ts
@@ -10,6 +10,7 @@ import { generateUuid } from '../../../base/common/uuid.js';
 import { INativeEnvironmentService } from '../../environment/common/environment.js';
 import { IFileService } from '../../files/common/files.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
+import { ILogService } from '../../log/common/log.js';
 import { FileEditKind, type ISessionFileDiff, type ISessionGitState } from '../common/state/sessionState.js';
 import { buildGitBlobUri } from './gitDiffContent.js';
 
@@ -179,6 +180,7 @@ export class AgentHostGitService implements IAgentHostGitService {
 	constructor(
 		@IFileService private readonly _fileService: IFileService,
 		@INativeEnvironmentService private readonly _environmentService: INativeEnvironmentService,
+		@ILogService private readonly _logService: ILogService,
 	) { }
 
 	async isInsideWorkTree(workingDirectory: URI): Promise<boolean> {
@@ -552,8 +554,13 @@ export class AgentHostGitService implements IAgentHostGitService {
 			// easy to exceed for diff output in large repos. Exceeding it
 			// causes execFile to error and we'd silently drop the diff.
 			const child = cp.execFile('git', [...args], { cwd: workingDirectory.fsPath, env, maxBuffer: options?.maxBuffer ?? 32 * 1024 * 1024 }, (error, stdout, stderr) => {
-				clearTimeout(timer);
 				if (error) {
+					// stderr is summarized in the thrown error message to keep
+					// it readable; log the full unmodified output here so the
+					// raw progress/diagnostic text is still available.
+					if (stderr) {
+						this._logService.warn(`[agentHostGitService] git ${args.join(' ')} failed; full stderr:\n${stderr}`);
+					}
 					if (options?.throwOnError) {
 						reject(new Error(formatGitError(args, timeoutMs, didTimeOut, error, stderr), { cause: error }));
 						return;
@@ -567,6 +574,7 @@ export class AgentHostGitService implements IAgentHostGitService {
 				didTimeOut = true;
 				child.kill();
 			}, timeoutMs);
+			child.on('exit', () => clearTimeout(timer));
 		});
 	}
 }
@@ -593,8 +601,29 @@ export function formatGitError(args: readonly string[], timeoutMs: number, didTi
 	} else {
 		reason = error.message;
 	}
-	const detail = stderr.trim();
+	const detail = summarizeStderrForError(stderr);
 	return detail ? `${reason}: ${detail}` : reason;
+}
+
+/**
+ * Squashes multi-line / carriage-return-heavy stderr (e.g. git progress
+ * meters that emit `Updating files:   0% (149/14834)\r...` repeatedly)
+ * into a single short line suitable for a one-liner error message.
+ * Keeps the most recent non-empty line and caps total length.
+ *
+ * Exported for tests.
+ */
+export function summarizeStderrForError(stderr: string): string {
+	if (!stderr) {
+		return '';
+	}
+	const lines = stderr.split(/[\r\n]+/g).map(line => line.trim()).filter(line => line.length > 0);
+	if (lines.length === 0) {
+		return '';
+	}
+	const last = lines[lines.length - 1];
+	const MAX = 200;
+	return last.length > MAX ? `${last.slice(0, MAX - 1)}…` : last;
 }
 
 /**

--- a/src/vs/platform/agentHost/node/agentHostGitService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitService.ts
@@ -250,15 +250,15 @@ export class AgentHostGitService implements IAgentHostGitService {
 		// tracking from the start point (e.g. when starting from
 		// 'origin/main', without --no-track git would set the new branch's
 		// upstream to origin/main, which would mis-attribute pushes/pulls).
-		await this._runGit(repositoryRoot, ['worktree', 'add', '--no-track', '-b', branchName, worktree.fsPath, resolvedStartPoint], { timeout: 30_000, throwOnError: true });
+		await this._runGit(repositoryRoot, ['worktree', 'add', '--no-track', '-b', branchName, worktree.fsPath, resolvedStartPoint], { timeout: 60_000, throwOnError: true });
 	}
 
 	async addExistingWorktree(repositoryRoot: URI, worktree: URI, branchName: string): Promise<void> {
-		await this._runGit(repositoryRoot, ['worktree', 'add', worktree.fsPath, branchName], { timeout: 30_000, throwOnError: true });
+		await this._runGit(repositoryRoot, ['worktree', 'add', worktree.fsPath, branchName], { timeout: 60_000, throwOnError: true });
 	}
 
 	async removeWorktree(repositoryRoot: URI, worktree: URI): Promise<void> {
-		await this._runGit(repositoryRoot, ['worktree', 'remove', '--force', worktree.fsPath], { timeout: 30_000, throwOnError: true });
+		await this._runGit(repositoryRoot, ['worktree', 'remove', '--force', worktree.fsPath], { timeout: 60_000, throwOnError: true });
 	}
 
 	async branchExists(repositoryRoot: URI, branchName: string): Promise<boolean> {
@@ -542,13 +542,20 @@ export class AgentHostGitService implements IAgentHostGitService {
 	private _runGit(workingDirectory: URI, args: readonly string[], options?: { readonly timeout?: number; readonly throwOnError?: boolean; readonly env?: Record<string, string>; readonly maxBuffer?: number }): Promise<string | undefined> {
 		return new Promise((resolve, reject) => {
 			const env = options?.env ? { ...process.env, ...options.env } : undefined;
+			const timeoutMs = options?.timeout ?? 5000;
+			// Use our own timer rather than execFile's `timeout` option so
+			// we can definitively flag the timeout case in the error
+			// message — execFile only surfaces signal/killed, which can
+			// also mean the process was killed for other reasons.
+			let didTimeOut = false;
 			// Default maxBuffer is 32MB — Node's default is ~1MB, which is
 			// easy to exceed for diff output in large repos. Exceeding it
 			// causes execFile to error and we'd silently drop the diff.
-			cp.execFile('git', [...args], { cwd: workingDirectory.fsPath, timeout: options?.timeout ?? 5000, env, maxBuffer: options?.maxBuffer ?? 32 * 1024 * 1024 }, (error, stdout, stderr) => {
+			const child = cp.execFile('git', [...args], { cwd: workingDirectory.fsPath, env, maxBuffer: options?.maxBuffer ?? 32 * 1024 * 1024 }, (error, stdout, stderr) => {
+				clearTimeout(timer);
 				if (error) {
 					if (options?.throwOnError) {
-						reject(new Error(stderr || error.message));
+						reject(new Error(formatGitError(args, timeoutMs, didTimeOut, error, stderr), { cause: error }));
 						return;
 					}
 					resolve(undefined);
@@ -556,8 +563,38 @@ export class AgentHostGitService implements IAgentHostGitService {
 				}
 				resolve(stdout);
 			});
+			const timer = setTimeout(() => {
+				didTimeOut = true;
+				child.kill();
+			}, timeoutMs);
 		});
 	}
+}
+
+/**
+ * Builds a diagnostic error message for a failed `git` invocation that
+ * preserves the reason (timeout / signal / exit code) instead of just
+ * surfacing whatever happened to be on stderr. When `git` is killed by
+ * the timeout, stderr often contains only progress output (e.g.
+ * `Updating files:   0% (149/14834)`), so without the timeout indicator
+ * the bubbled-up error is misleading.
+ *
+ * Exported for tests.
+ */
+export function formatGitError(args: readonly string[], timeoutMs: number, didTimeOut: boolean, error: cp.ExecFileException, stderr: string): string {
+	const subcommand = args[0] ?? '(unknown)';
+	let reason: string;
+	if (didTimeOut) {
+		reason = `git ${subcommand} timed out after ${timeoutMs}ms`;
+	} else if (error.killed && error.signal) {
+		reason = `git ${subcommand} killed by ${error.signal}`;
+	} else if (typeof error.code === 'number') {
+		reason = `git ${subcommand} exited with code ${error.code}`;
+	} else {
+		reason = error.message;
+	}
+	const detail = stderr.trim();
+	return detail ? `${reason}: ${detail}` : reason;
 }
 
 /**

--- a/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
@@ -33,7 +33,7 @@ function createGitService(disposables: Pick<DisposableStore, 'add'>): AgentHostG
 	const fileService = disposables.add(new FileService(logService));
 	disposables.add(fileService.registerProvider(Schemas.file, disposables.add(new DiskFileSystemProvider(logService))));
 	const env: Partial<INativeEnvironmentService> = { tmpDir: URI.file(tmpdir()) };
-	return new AgentHostGitService(fileService, env as INativeEnvironmentService);
+	return new AgentHostGitService(fileService, env as INativeEnvironmentService, logService);
 }
 
 suite('AgentHostGitService - getSessionGitState (real git)', () => {

--- a/src/vs/platform/agentHost/test/node/agentHostGitService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitService.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
-import { EMPTY_TREE_OBJECT, getBranchCompletions, parseDefaultBranchRef, parseGitDiffRawNumstat, parseGitHubRepoFromRemote, parseGitStatusV2, parseHasGitHubRemote, parseUntrackedPaths } from '../../node/agentHostGitService.js';
+import { EMPTY_TREE_OBJECT, formatGitError, getBranchCompletions, parseDefaultBranchRef, parseGitDiffRawNumstat, parseGitHubRepoFromRemote, parseGitStatusV2, parseHasGitHubRemote, parseUntrackedPaths } from '../../node/agentHostGitService.js';
 import { buildGitBlobUri } from '../../node/gitDiffContent.js';
 import { URI } from '../../../../base/common/uri.js';
 
@@ -268,6 +268,40 @@ suite('AgentHostGitService', () => {
 
 	test('exports the well-known empty-tree object SHA', () => {
 		assert.strictEqual(EMPTY_TREE_OBJECT, '4b825dc642cb6eb9a060e54bf8d69288fbee4904');
+	});
+
+	suite('formatGitError', () => {
+		test('reports timeout when our timer fired', () => {
+			const err = Object.assign(new Error('Command failed'), { killed: true, signal: 'SIGTERM' as const });
+			assert.strictEqual(
+				formatGitError(['worktree', 'add', '-b', 'x', '/tmp/y', 'origin/main'], 30_000, true, err, 'Updating files:   0% (149/14834)\r'),
+				'git worktree timed out after 30000ms: Updating files:   0% (149/14834)',
+			);
+		});
+
+		test('reports kill signal when killed but not by our timer', () => {
+			const err = Object.assign(new Error('Command failed'), { killed: true, signal: 'SIGTERM' as const });
+			assert.strictEqual(
+				formatGitError(['worktree', 'add'], 30_000, false, err, ''),
+				'git worktree killed by SIGTERM',
+			);
+		});
+
+		test('reports numeric exit code when git failed normally', () => {
+			const err = Object.assign(new Error('Command failed'), { code: 128 });
+			assert.strictEqual(
+				formatGitError(['worktree', 'add', '/tmp/y', 'missing-branch'], 30_000, false, err, 'fatal: invalid reference: missing-branch\n'),
+				'git worktree exited with code 128: fatal: invalid reference: missing-branch',
+			);
+		});
+
+		test('falls back to error message when there is no signal or exit code', () => {
+			const err = new Error('spawn git ENOENT');
+			assert.strictEqual(
+				formatGitError(['status'], 5_000, false, err, ''),
+				'spawn git ENOENT',
+			);
+		});
 	});
 });
 

--- a/src/vs/platform/agentHost/test/node/agentHostGitService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitService.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
-import { EMPTY_TREE_OBJECT, formatGitError, getBranchCompletions, parseDefaultBranchRef, parseGitDiffRawNumstat, parseGitHubRepoFromRemote, parseGitStatusV2, parseHasGitHubRemote, parseUntrackedPaths } from '../../node/agentHostGitService.js';
+import { EMPTY_TREE_OBJECT, formatGitError, getBranchCompletions, parseDefaultBranchRef, parseGitDiffRawNumstat, parseGitHubRepoFromRemote, parseGitStatusV2, parseHasGitHubRemote, parseUntrackedPaths, summarizeStderrForError } from '../../node/agentHostGitService.js';
 import { buildGitBlobUri } from '../../node/gitDiffContent.js';
 import { URI } from '../../../../base/common/uri.js';
 
@@ -271,10 +271,11 @@ suite('AgentHostGitService', () => {
 	});
 
 	suite('formatGitError', () => {
-		test('reports timeout when our timer fired', () => {
+		test('reports timeout when our timer fired and summarises progress-meter stderr', () => {
 			const err = Object.assign(new Error('Command failed'), { killed: true, signal: 'SIGTERM' as const });
+			const progress = 'Updating files:   0% (7/14834)\rUpdating files:   0% (149/14834)\r';
 			assert.strictEqual(
-				formatGitError(['worktree', 'add', '-b', 'x', '/tmp/y', 'origin/main'], 30_000, true, err, 'Updating files:   0% (149/14834)\r'),
+				formatGitError(['worktree', 'add', '-b', 'x', '/tmp/y', 'origin/main'], 30_000, true, err, progress),
 				'git worktree timed out after 30000ms: Updating files:   0% (149/14834)',
 			);
 		});
@@ -301,6 +302,32 @@ suite('AgentHostGitService', () => {
 				formatGitError(['status'], 5_000, false, err, ''),
 				'spawn git ENOENT',
 			);
+		});
+	});
+
+	suite('summarizeStderrForError', () => {
+		test('returns empty string for empty input', () => {
+			assert.strictEqual(summarizeStderrForError(''), '');
+		});
+
+		test('returns empty string for whitespace-only input', () => {
+			assert.strictEqual(summarizeStderrForError('  \r\n\r\n  '), '');
+		});
+
+		test('keeps the last non-empty line of a multi-line progress meter', () => {
+			const progress = 'Updating files:   0% (7/14834)\rUpdating files:   0% (149/14834)\r';
+			assert.strictEqual(summarizeStderrForError(progress), 'Updating files:   0% (149/14834)');
+		});
+
+		test('passes through a normal single-line message', () => {
+			assert.strictEqual(summarizeStderrForError('fatal: invalid reference: x\n'), 'fatal: invalid reference: x');
+		});
+
+		test('truncates very long lines with an ellipsis', () => {
+			const long = `fatal: ${'a'.repeat(500)}`;
+			const result = summarizeStderrForError(long);
+			assert.strictEqual(result.length, 200);
+			assert.ok(result.endsWith('…'), 'expected trailing ellipsis');
 		});
 	});
 });


### PR DESCRIPTION
## Problem

A user reported `createSession` failing on an SSH remote with this misleading error in the side-effects log:

```
[AgentSideEffects] sendMessage failed for session=copilotcli:/537534a9...:
code=undefined,
message=Preparing worktree (new branch 'agents/vsckb-implement-please-investigate-...')
Updating files:   0% (7/14834) ... Updating files:   1% (149/14834)
```

The remote (a Mac Air) happened to be under heavy disk-I/O contention from many concurrent `npm install` runs in other worktrees, so `git worktree add` only managed 149 of 14,834 files in 30s and got killed by the timeout in `AgentHostGitService.addWorktree`.

Two underlying bugs surfaced:

1. **Error reporting was misleading.** In `_runGit`, the timeout path did `reject(new Error(stderr || error.message))`. When git was killed before producing any diagnostic stderr, the surfaced error was just the progress meter, with `code=undefined` and no hint of what really happened.
2. **30s is tight for worktree ops on a large repo** when the remote is under load. Normally sub-second, but no headroom for transient I/O storms.

## Changes

- **All three worktree operations** (`addWorktree`, `addExistingWorktree`, `removeWorktree --force`) now use a **60s** timeout instead of 30s. All three can do real filesystem work proportional to the worktree's content, so they share the same  bumping consistently rather than leaving `removeWorktree` at 30s.rationale 
- **`_runGit`**: replaced `execFile`'s built-in `timeout` option with our own `setTimeout` that flips a `didTimeOut` flag before calling `child.kill()`. The flag lets us definitively distinguish a timeout from other kill paths (rather than "killed && signal, *likely* a timeout"). The timer is cleared via `child.on('exit')`.
- **New exported helper `formatGitError`**: classifies the failure (timeout / signal / exit code / other) and produces messages like:
  - `git worktree timed out after 60000ms: Updating files:   0% (149/14834)`
  - `git worktree exited with code 128: fatal: invalid reference: missing-branch`
  - `spawn git ENOENT`
  
  The underlying `ExecFileException` is preserved as `Error.cause` so downstream consumers can still inspect it.
- **`summarizeStderrForError` helper**: git progress output is full of `\r`-separated repaints (e.g. `Updating files:   0% (7/14834)\rUpdating files:   0% (149/14834)\r`). Stripping naively still left a noisy multi-line blob in the error. The helper now keeps only the last non-empty line and caps at 200 chars, so the error message is a clean one-liner.
- **Full stderr is still logged.** Since the thrown error message is summarized, `_runGit` now logs the complete unmodified stderr at `warn` level via `ILogService` on any git failure, so no diagnostic context is lost.
- **Unit tests** for `formatGitError` (four classification branches) and `summarizeStderrForError` (empty / whitespace / multi-line progress / normal one-liner / truncation).

After this change, the same failure would be surfaced as a one-liner that immediately says "timed out after  diagnosable from the side-effects log without log archaeology, with the full raw stderr available in the agent-host log if deeper inspection is needed.60000ms" 

(Written by Copilot)
