### PR TITLE
Fix SSH remote agent host passphrase auth

### DIFF
--- a/src/vs/platform/agentHost/common/sshConfigParsing.ts
+++ b/src/vs/platform/agentHost/common/sshConfigParsing.ts
@@ -59,6 +59,7 @@ export function parseSSHGOutput(stdout: string): ISSHResolvedConfig {
 		user: map.get('user') || undefined,
 		port: parseInt(map.get('port') ?? '22', 10),
 		identityFile: identityFiles,
+		identityAgent: map.get('identityagent') || undefined,
 		forwardAgent: map.get('forwardagent') === 'yes',
 	};
 }

--- a/src/vs/platform/agentHost/common/sshRemoteAgentHost.ts
+++ b/src/vs/platform/agentHost/common/sshRemoteAgentHost.ts
@@ -35,6 +35,8 @@ export interface ISSHAgentHostConfig {
 	readonly authMethod: SSHAuthMethod;
 	/** Path to the private key file (when {@link authMethod} is KeyFile). */
 	readonly privateKeyPath?: string;
+	/** SSH agent endpoint resolved from IdentityAgent, or undefined to use the default agent. */
+	readonly identityAgent?: string;
 	/** Password string (when {@link authMethod} is Password). */
 	readonly password?: string;
 	/** Display name for this connection. */
@@ -155,6 +157,7 @@ export interface ISSHResolvedConfig {
 	readonly user: string | undefined;
 	readonly port: number;
 	readonly identityFile: string[];
+	readonly identityAgent: string | undefined;
 	readonly forwardAgent: boolean;
 }
 

--- a/src/vs/platform/agentHost/common/sshRemoteAgentHost.ts
+++ b/src/vs/platform/agentHost/common/sshRemoteAgentHost.ts
@@ -35,7 +35,7 @@ export interface ISSHAgentHostConfig {
 	readonly authMethod: SSHAuthMethod;
 	/** Path to the private key file (when {@link authMethod} is KeyFile). */
 	readonly privateKeyPath?: string;
-	/** SSH agent endpoint resolved from IdentityAgent, or undefined to use the default agent. */
+	/** Raw IdentityAgent value from resolved SSH config; may be a socket path, `none`, `SSH_AUTH_SOCK`, or an environment reference. */
 	readonly identityAgent?: string;
 	/** Password string (when {@link authMethod} is Password). */
 	readonly password?: string;

--- a/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
+++ b/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
@@ -1136,11 +1136,12 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 
 	/**
 	 * Build the ordered list of authentication attempts to feed to ssh2's
-	 * `authHandler`. Mirrors OpenSSH's behavior: try the explicitly configured
-	 * key first (if any), then the SSH agent (if `SSH_AUTH_SOCK` is set), then
-	 * each readable default identity file in turn. This means a host that
-	 * accepts `~/.ssh/id_rsa` still works even if the agent doesn't have it
-	 * loaded — without needing an explicit `IdentityFile` entry in `~/.ssh/config`.
+	 * `authHandler`. In `Agent` mode we try the configured agent first (so a
+	 * loaded identity short-circuits before we ever touch an encrypted key
+	 * file), then any non-default explicit `IdentityFile`, then each readable
+	 * default identity in turn. A host that accepts `~/.ssh/id_rsa` still
+	 * works even if the agent doesn't have it loaded — without needing an
+	 * explicit `IdentityFile` entry in `~/.ssh/config`.
 	 */
 	protected async _buildAuthAttempts(config: ISSHAgentHostConfig): Promise<SSHAuthAttempt[]> {
 		const attempts: SSHAuthAttempt[] = [];
@@ -1148,20 +1149,24 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 
 		switch (config.authMethod) {
 			case SSHAuthMethod.Agent: {
-				if (config.privateKeyPath) {
-					const explicit = await this._readKeyFileIfExists(config.privateKeyPath);
-					if (explicit) {
-						attempts.push({ type: 'publickey', username, key: explicit, keyPath: config.privateKeyPath, ...(isEncryptedPrivateKey(explicit) ? { encrypted: true } : undefined) });
-					}
-				}
+				// Try the agent first: if it has any of the configured identities
+				// loaded, auth succeeds without ever touching on-disk keys. This
+				// matches OpenSSH's IdentityAgent semantics and avoids an
+				// unnecessary passphrase prompt when an encrypted key file is
+				// configured but the agent already holds its unlocked copy.
 				const agentSock = this._getAgentSocket(config);
 				if (agentSock) {
 					attempts.push({ type: 'agent', username, agent: agentSock });
 				}
-				for (const keyPath of SSHRemoteAgentHostMainService._defaultKeyPaths) {
-					if (config.privateKeyPath === keyPath) {
-						continue; // Already added as the explicit attempt above
+				const explicitKeyPath = config.privateKeyPath;
+				const explicitIsDefault = explicitKeyPath !== undefined && SSHRemoteAgentHostMainService._isDefaultKeyPath(explicitKeyPath);
+				if (explicitKeyPath && !explicitIsDefault) {
+					const explicit = await this._readKeyFileIfExists(explicitKeyPath);
+					if (explicit) {
+						attempts.push({ type: 'publickey', username, key: explicit, keyPath: explicitKeyPath, ...(isEncryptedPrivateKey(explicit) ? { encrypted: true } : undefined) });
 					}
+				}
+				for (const keyPath of SSHRemoteAgentHostMainService._defaultKeyPaths) {
 					const contents = await this._readKeyFileIfExists(keyPath);
 					if (contents) {
 						attempts.push({ type: 'publickey', username, key: contents, keyPath, ...(isEncryptedPrivateKey(contents) ? { encrypted: true } : undefined) });
@@ -1207,8 +1212,18 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 		'~/.ssh/id_xmss',
 	];
 
+	/**
+	 * Expand a leading `~` to the current user's home directory so that paths
+	 * coming back from `ssh -G` (always absolute) compare equal to our
+	 * `~`-prefixed defaults.
+	 */
+	private static _normalizeKeyPath(keyPath: string): string {
+		return keyPath.replace(/^~/, os.homedir());
+	}
+
 	private static _isDefaultKeyPath(keyPath: string): boolean {
-		return SSHRemoteAgentHostMainService._defaultKeyPaths.includes(keyPath);
+		const normalized = SSHRemoteAgentHostMainService._normalizeKeyPath(keyPath);
+		return SSHRemoteAgentHostMainService._defaultKeyPaths.some(p => SSHRemoteAgentHostMainService._normalizeKeyPath(p) === normalized);
 	}
 
 	/** Test seam: returns the SSH agent socket path, or undefined when no agent is available. */

--- a/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
+++ b/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
@@ -93,7 +93,7 @@ const RECONNECT_RELAY_TIMEOUT_MS = 60_000;
  * attempt is returned to ssh2.
  */
 export type SSHAuthAttempt =
-	| { readonly type: 'publickey'; readonly username: string; readonly key: Buffer; readonly keyPath: string }
+	| { readonly type: 'publickey'; readonly username: string; readonly key: Buffer; readonly keyPath: string; readonly encrypted?: boolean }
 	| { readonly type: 'agent'; readonly username: string; readonly agent: string }
 	| { readonly type: 'password'; readonly username: string; readonly password: string }
 	| { readonly type: 'keyboard-interactive'; readonly username: string };
@@ -119,6 +119,11 @@ export type SSHKeyboardInteractivePromptHandler = (
 	finish: (responses: readonly string[]) => void,
 ) => void;
 
+export type SSHKeyPassphrasePromptHandler = (
+	keyPath: string,
+	finish: (passphrase: string | undefined) => void,
+) => void;
+
 /**
  * Translate a {@link SSHAuthAttempt} into the payload shape ssh2 expects in
  * its `authHandler` callback. Returns `undefined` when the attempt cannot be
@@ -131,11 +136,26 @@ export type SSHKeyboardInteractivePromptHandler = (
 function toAuthMethod(
 	attempt: SSHAuthAttempt,
 	kbiHandler: SSHKeyboardInteractivePromptHandler | undefined,
+	keyPassphraseHandler: SSHKeyPassphrasePromptHandler | undefined,
+	callback: (next: AnyAuthMethod | false) => void,
 ): AnyAuthMethod | undefined {
 	switch (attempt.type) {
 		case 'publickey': {
 			// Strip our internal `keyPath` metadata before handing to ssh2.
-			const { keyPath: _kp, ...payload } = attempt;
+			const { keyPath: _kp, encrypted: _encrypted, ...payload } = attempt;
+			if (attempt.encrypted) {
+				if (!keyPassphraseHandler) {
+					return undefined;
+				}
+				keyPassphraseHandler(attempt.keyPath, passphrase => {
+					if (passphrase === undefined) {
+						callback(false);
+						return;
+					}
+					callback({ ...payload, passphrase });
+				});
+				return undefined;
+			}
 			return payload;
 		}
 		case 'agent':
@@ -184,6 +204,7 @@ export function makeAuthHandler(
 	attempts: readonly SSHAuthAttempt[],
 	logService: ILogService,
 	kbiHandler?: SSHKeyboardInteractivePromptHandler,
+	keyPassphraseHandler?: SSHKeyPassphrasePromptHandler,
 ): (methodsLeft: AuthenticationType[] | null, partialSuccess: boolean, callback: (next: AnyAuthMethod | false) => void) => void {
 	let index = 0;
 	return (methodsLeft, _partialSuccess, callback) => {
@@ -193,8 +214,12 @@ export function makeAuthHandler(
 				logService.info(`${LOG_PREFIX} Skipping ${describeAuthAttempt(attempt)} — server only allows ${methodsLeft!.join(', ')}`);
 				continue;
 			}
-			const method = toAuthMethod(attempt, kbiHandler);
+			const method = toAuthMethod(attempt, kbiHandler, keyPassphraseHandler, callback);
 			if (!method) {
+				if (attempt.type === 'publickey' && attempt.encrypted && keyPassphraseHandler) {
+					logService.info(`${LOG_PREFIX} Trying auth: ${describeAuthAttempt(attempt)}`);
+					return;
+				}
 				logService.warn(`${LOG_PREFIX} ${describeAuthAttempt(attempt)} skipped: no prompt handler available`);
 				continue;
 			}
@@ -205,6 +230,37 @@ export function makeAuthHandler(
 		logService.info(`${LOG_PREFIX} No more auth methods to try; giving up`);
 		callback(false);
 	};
+}
+
+function readSSHString(buffer: Buffer, offset: number): { value: string; offset: number } | undefined {
+	if (offset + 4 > buffer.length) {
+		return undefined;
+	}
+	const length = buffer.readUInt32BE(offset);
+	const valueOffset = offset + 4;
+	const nextOffset = valueOffset + length;
+	if (nextOffset > buffer.length) {
+		return undefined;
+	}
+	return { value: buffer.toString('utf8', valueOffset, nextOffset), offset: nextOffset };
+}
+
+function isEncryptedPrivateKey(key: Buffer): boolean {
+	const text = key.toString('utf8');
+	if (/-----BEGIN ENCRYPTED PRIVATE KEY-----/.test(text) || /Proc-Type:\s*4,ENCRYPTED/i.test(text)) {
+		return true;
+	}
+	const openSSHKey = /-----BEGIN OPENSSH PRIVATE KEY-----([\s\S]+?)-----END OPENSSH PRIVATE KEY-----/.exec(text);
+	if (!openSSHKey) {
+		return false;
+	}
+	const data = Buffer.from(openSSHKey[1].replace(/\s+/g, ''), 'base64');
+	const magic = Buffer.from('openssh-key-v1\0', 'utf8');
+	if (data.length < magic.length || !data.subarray(0, magic.length).equals(magic)) {
+		return false;
+	}
+	const cipher = readSSHString(data, magic.length);
+	return !!cipher && cipher.value !== 'none';
 }
 
 function sshExec(client: SSHClient, command: string, opts?: { ignoreExitCode?: boolean }): Promise<{ stdout: string; stderr: string; code: number }> {
@@ -809,6 +865,7 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 			username: resolved.user ?? sshConfigHost,
 			authMethod: SSHAuthMethod.Agent,
 			privateKeyPath,
+			identityAgent: resolved.identityAgent,
 			name,
 			sshConfigHost,
 			remoteAgentHostCommand,
@@ -978,10 +1035,25 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 				liveKbiRequests.add(requestId);
 			}
 			: undefined;
+		const keyPassphraseHandler: SSHKeyPassphrasePromptHandler | undefined = attempts.some(a => a.type === 'publickey' && a.encrypted)
+			? (keyPath, finish) => {
+				const requestId = this._handleKeyboardInteractive(
+					connectionKey ?? displayHost,
+					displayHost,
+					config.username,
+					localize('sshKeyPassphraseName', "SSH Key Passphrase"),
+					'',
+					[{ prompt: localize('sshKeyPassphrasePrompt', "Enter passphrase for SSH key {0}.", keyPath), echo: false }],
+					responses => finish(responses[0]),
+					() => cancelConnectFromKbi?.(),
+				);
+				liveKbiRequests.add(requestId);
+			}
+			: undefined;
 		// Cast: the ssh2 @types don't model `false` (give-up) for the
 		// callback nor `null` for the first invocation's `methodsLeft`,
 		// even though the runtime supports both per the ssh2 docs.
-		connectConfig.authHandler = makeAuthHandler(attempts, this._logService, kbiHandler) as unknown as ConnectConfig['authHandler'];
+		connectConfig.authHandler = makeAuthHandler(attempts, this._logService, kbiHandler, keyPassphraseHandler) as unknown as ConnectConfig['authHandler'];
 
 		const cancelLiveKbiRequests = () => {
 			for (const requestId of liveKbiRequests) {
@@ -999,7 +1071,7 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 		};
 
 		if (config.agentForward) {
-			const agentSock = this._isAgentAvailable();
+			const agentSock = this._getAgentSocket(config);
 			if (agentSock) {
 				// ssh2 needs `connectConfig.agent` set so it knows which local
 				// agent socket to forward to. Without it, agent forwarding is a
@@ -1008,7 +1080,7 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 				connectConfig.agentForward = true;
 				this._logService.info(`${LOG_PREFIX} SSH agent forwarding enabled`);
 			} else {
-				this._logService.warn(`${LOG_PREFIX} SSH agent forwarding requested, but SSH_AUTH_SOCK is not set; agent forwarding disabled`);
+				this._logService.warn(`${LOG_PREFIX} SSH agent forwarding requested, but no SSH agent endpoint is available; agent forwarding disabled`);
 			}
 		}
 
@@ -1079,10 +1151,10 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 				if (config.privateKeyPath) {
 					const explicit = await this._readKeyFileIfExists(config.privateKeyPath);
 					if (explicit) {
-						attempts.push({ type: 'publickey', username, key: explicit, keyPath: config.privateKeyPath });
+						attempts.push({ type: 'publickey', username, key: explicit, keyPath: config.privateKeyPath, ...(isEncryptedPrivateKey(explicit) ? { encrypted: true } : undefined) });
 					}
 				}
-				const agentSock = this._isAgentAvailable();
+				const agentSock = this._getAgentSocket(config);
 				if (agentSock) {
 					attempts.push({ type: 'agent', username, agent: agentSock });
 				}
@@ -1092,7 +1164,7 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 					}
 					const contents = await this._readKeyFileIfExists(keyPath);
 					if (contents) {
-						attempts.push({ type: 'publickey', username, key: contents, keyPath });
+						attempts.push({ type: 'publickey', username, key: contents, keyPath, ...(isEncryptedPrivateKey(contents) ? { encrypted: true } : undefined) });
 					}
 				}
 				// Final fallback: keyboard-interactive (typically a password prompt).
@@ -1113,7 +1185,7 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 				if (!explicit) {
 					throw new Error(localize('ssh.failedToReadPrivateKey', "Failed to read private key file: {0}", config.privateKeyPath));
 				}
-				attempts.push({ type: 'publickey', username, key: explicit, keyPath: config.privateKeyPath });
+				attempts.push({ type: 'publickey', username, key: explicit, keyPath: config.privateKeyPath, ...(isEncryptedPrivateKey(explicit) ? { encrypted: true } : undefined) });
 				break;
 			}
 			case SSHAuthMethod.Password: {
@@ -1142,6 +1214,28 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 	/** Test seam: returns the SSH agent socket path, or undefined when no agent is available. */
 	protected _isAgentAvailable(): string | undefined {
 		return process.env['SSH_AUTH_SOCK'];
+	}
+
+	protected _getAgentSocket(config: ISSHAgentHostConfig): string | undefined {
+		if (config.identityAgent !== undefined) {
+			return this._resolveIdentityAgent(config.identityAgent);
+		}
+		return this._isAgentAvailable();
+	}
+
+	private _resolveIdentityAgent(identityAgent: string): string | undefined {
+		const trimmed = identityAgent.trim();
+		if (!trimmed || trimmed.toLowerCase() === 'none') {
+			return undefined;
+		}
+		if (trimmed === 'SSH_AUTH_SOCK') {
+			return this._isAgentAvailable();
+		}
+		if (trimmed.startsWith('$')) {
+			const envMatch = /^\$\{(?<braced>[A-Za-z_][A-Za-z0-9_]*)\}$|^\$(?<plain>[A-Za-z_][A-Za-z0-9_]*)$/.exec(trimmed);
+			return envMatch?.groups ? process.env[envMatch.groups.braced ?? envMatch.groups.plain] || undefined : undefined;
+		}
+		return trimmed.replace(/^~/, os.homedir());
 	}
 
 	/**

--- a/src/vs/platform/agentHost/test/common/sshConfigParsing.test.ts
+++ b/src/vs/platform/agentHost/test/common/sshConfigParsing.test.ts
@@ -137,6 +137,7 @@ suite('SSH Config Parsing', () => {
 				user: 'admin',
 				port: 22,
 				identityFile: ['~/.ssh/id_rsa', '~/.ssh/id_ed25519'],
+				identityAgent: undefined,
 				forwardAgent: false,
 			});
 		});
@@ -151,6 +152,16 @@ suite('SSH Config Parsing', () => {
 
 			const result = parseSSHGOutput(output);
 			assert.strictEqual(result.forwardAgent, true);
+		});
+
+		test('parses identityagent', () => {
+			const output = [
+				'hostname example.com',
+				'user admin',
+				'identityagent //./pipe/pageant.user.1234',
+			].join('\n');
+
+			assert.strictEqual(parseSSHGOutput(output).identityAgent, '//./pipe/pageant.user.1234');
 		});
 
 		test('parses non-standard port', () => {
@@ -213,6 +224,7 @@ suite('SSH Config Parsing', () => {
 				user: undefined,
 				port: 22,
 				identityFile: [],
+				identityAgent: undefined,
 				forwardAgent: false,
 			});
 		});

--- a/src/vs/platform/agentHost/test/electron-browser/sshRemoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/sshRemoteAgentHostService.test.ts
@@ -104,7 +104,7 @@ class MockSSHMainService {
 	async ensureUserSSHConfig(): Promise<URI> { return URI.file('/tmp/ssh-config'); }
 	async listSSHConfigFiles(): Promise<URI[]> { return [URI.file('/tmp/ssh-config')]; }
 	async resolveSSHConfig(_host: string): Promise<ISSHResolvedConfig> {
-		return { hostname: '', user: undefined, port: 22, identityFile: [], forwardAgent: false };
+		return { hostname: '', user: undefined, port: 22, identityFile: [], identityAgent: undefined, forwardAgent: false };
 	}
 
 	dispose(): void {

--- a/src/vs/platform/agentHost/test/node/sshRemoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/node/sshRemoteAgentHostService.test.ts
@@ -294,6 +294,7 @@ class TestableSSHRemoteAgentHostMainService extends SSHRemoteAgentHostMainServic
 			port: 22,
 			user: 'testuser',
 			identityFile: [],
+			identityAgent: undefined,
 			forwardAgent: false,
 		};
 	}
@@ -1266,6 +1267,25 @@ suite('SSHRemoteAgentHostMainService - _buildAuthAttempts', () => {
 	const ED = Buffer.from('ed25519-key-bytes');
 	const EXPLICIT = Buffer.from('explicit-key-bytes');
 
+	function sshString(value: string): Buffer {
+		const valueBuffer = Buffer.from(value, 'utf8');
+		const lengthBuffer = Buffer.alloc(4);
+		lengthBuffer.writeUInt32BE(valueBuffer.length, 0);
+		return Buffer.concat([lengthBuffer, valueBuffer]);
+	}
+
+	function openSSHPrivateKeyWithCipher(cipher: string): Buffer {
+		const data = Buffer.concat([
+			Buffer.from('openssh-key-v1\0', 'utf8'),
+			sshString(cipher),
+		]);
+		return Buffer.from([
+			'-----BEGIN OPENSSH PRIVATE KEY-----',
+			data.toString('base64'),
+			'-----END OPENSSH PRIVATE KEY-----',
+		].join('\n'));
+	}
+
 	test('Agent + no SSH_AUTH_SOCK + only id_rsa exists → publickey id_rsa, then keyboard-interactive', async () => {
 		service.agentSock = undefined;
 		service.keyFiles.set('~/.ssh/id_rsa', RSA);
@@ -1319,6 +1339,49 @@ suite('SSHRemoteAgentHostMainService - _buildAuthAttempts', () => {
 		]);
 	});
 
+	test('Agent + IdentityAgent uses configured agent endpoint before default keys', async () => {
+		service.agentSock = '/tmp/ssh-agent.sock';
+		service.keyFiles.set('~/.ssh/id_rsa', RSA);
+
+		const attempts = await service.testBuildAuthAttempts(makeConfig({
+			authMethod: SSHAuthMethod.Agent,
+			identityAgent: '//./pipe/pageant.user.1234',
+		}));
+
+		assert.deepStrictEqual(attempts, [
+			{ type: 'agent', username: 'testuser', agent: '//./pipe/pageant.user.1234' },
+			{ type: 'publickey', username: 'testuser', key: RSA, keyPath: '~/.ssh/id_rsa' },
+			{ type: 'keyboard-interactive', username: 'testuser' },
+		]);
+	});
+
+	test('Agent + IdentityAgent SSH_AUTH_SOCK uses the default agent endpoint', async () => {
+		service.agentSock = '/tmp/ssh-agent.sock';
+
+		const attempts = await service.testBuildAuthAttempts(makeConfig({
+			authMethod: SSHAuthMethod.Agent,
+			identityAgent: 'SSH_AUTH_SOCK',
+		}));
+
+		assert.deepStrictEqual(attempts, [
+			{ type: 'agent', username: 'testuser', agent: '/tmp/ssh-agent.sock' },
+			{ type: 'keyboard-interactive', username: 'testuser' },
+		]);
+	});
+
+	test('Agent + IdentityAgent none disables the default SSH_AUTH_SOCK fallback', async () => {
+		service.agentSock = '/tmp/ssh-agent.sock';
+
+		const attempts = await service.testBuildAuthAttempts(makeConfig({
+			authMethod: SSHAuthMethod.Agent,
+			identityAgent: 'none',
+		}));
+
+		assert.deepStrictEqual(attempts, [
+			{ type: 'keyboard-interactive', username: 'testuser' },
+		]);
+	});
+
 	test('Agent + explicit privateKeyPath + SSH_AUTH_SOCK + id_rsa → explicit, agent, id_rsa, keyboard-interactive', async () => {
 		service.agentSock = '/tmp/ssh-agent.sock';
 		service.keyFiles.set('/some/explicit/key', EXPLICIT);
@@ -1366,6 +1429,20 @@ suite('SSHRemoteAgentHostMainService - _buildAuthAttempts', () => {
 
 		assert.deepStrictEqual(attempts, [
 			{ type: 'publickey', username: 'testuser', key: EXPLICIT, keyPath: '/some/explicit/key' },
+		]);
+	});
+
+	test('KeyFile + encrypted OpenSSH key marks attempt as encrypted', async () => {
+		const encryptedKey = openSSHPrivateKeyWithCipher('aes256-ctr');
+		service.keyFiles.set('/some/encrypted/key', encryptedKey);
+
+		const attempts = await service.testBuildAuthAttempts(makeConfig({
+			authMethod: SSHAuthMethod.KeyFile,
+			privateKeyPath: '/some/encrypted/key',
+		}));
+
+		assert.deepStrictEqual(attempts, [
+			{ type: 'publickey', username: 'testuser', key: encryptedKey, keyPath: '/some/encrypted/key', encrypted: true },
 		]);
 	});
 
@@ -1475,5 +1552,23 @@ suite('SSHRemoteAgentHostMainService - makeAuthHandler', () => {
 		(callsWithKbi[0] as { prompt: Function }).prompt('n', 'i', 'lang', [{ prompt: 'Password:', echo: false }], (responses: ReadonlyArray<string>) => finishCalls.push(responses));
 		assert.deepStrictEqual(promptArgs, { name: 'n', instructions: 'i', prompts: [{ prompt: 'Password:', echo: false }] });
 		assert.deepStrictEqual(finishCalls, [['secret']]);
+	});
+
+	test('encrypted publickey requests passphrase and passes it to ssh2', () => {
+		const encryptedAttempts: SSHAuthAttempt[] = [
+			{ type: 'publickey', username: 'u', key: KEY, keyPath: '~/.ssh/id_rsa', encrypted: true },
+		];
+
+		const calls: Array<object | false> = [];
+		const handler = makeAuthHandler(encryptedAttempts, new NullLogService(), undefined, (keyPath, finish) => {
+			assert.strictEqual(keyPath, '~/.ssh/id_rsa');
+			finish('passphrase');
+		});
+
+		handler(null, false, next => calls.push(next));
+
+		assert.deepStrictEqual(calls, [
+			{ type: 'publickey', username: 'u', key: KEY, passphrase: 'passphrase' },
+		]);
 	});
 });

--- a/src/vs/platform/agentHost/test/node/sshRemoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/node/sshRemoteAgentHostService.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import * as os from 'os';
 import { DeferredPromise } from '../../../../base/common/async.js';
 import { isCancellationError } from '../../../../base/common/errors.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
@@ -1382,7 +1383,7 @@ suite('SSHRemoteAgentHostMainService - _buildAuthAttempts', () => {
 		]);
 	});
 
-	test('Agent + explicit privateKeyPath + SSH_AUTH_SOCK + id_rsa → explicit, agent, id_rsa, keyboard-interactive', async () => {
+	test('Agent + explicit privateKeyPath + SSH_AUTH_SOCK + id_rsa → agent first, then explicit, id_rsa, keyboard-interactive', async () => {
 		service.agentSock = '/tmp/ssh-agent.sock';
 		service.keyFiles.set('/some/explicit/key', EXPLICIT);
 		service.keyFiles.set('~/.ssh/id_rsa', RSA);
@@ -1393,8 +1394,8 @@ suite('SSHRemoteAgentHostMainService - _buildAuthAttempts', () => {
 		}));
 
 		assert.deepStrictEqual(attempts, [
-			{ type: 'publickey', username: 'testuser', key: EXPLICIT, keyPath: '/some/explicit/key' },
 			{ type: 'agent', username: 'testuser', agent: '/tmp/ssh-agent.sock' },
+			{ type: 'publickey', username: 'testuser', key: EXPLICIT, keyPath: '/some/explicit/key' },
 			{ type: 'publickey', username: 'testuser', key: RSA, keyPath: '~/.ssh/id_rsa' },
 			{ type: 'keyboard-interactive', username: 'testuser' },
 		]);
@@ -1413,6 +1414,27 @@ suite('SSHRemoteAgentHostMainService - _buildAuthAttempts', () => {
 
 		assert.deepStrictEqual(attempts, [
 			{ type: 'publickey', username: 'testuser', key: RSA, keyPath: '~/.ssh/id_rsa' },
+			{ type: 'keyboard-interactive', username: 'testuser' },
+		]);
+	});
+
+	test('Agent + explicit privateKeyPath as absolute default path → agent first, key added once', async () => {
+		// Regression: `ssh -G` always returns absolute identity-file paths, so
+		// /Users/<me>/.ssh/id_ed25519 must be recognized as a default and not
+		// promoted to an explicit (encrypted) attempt that would fire a
+		// passphrase prompt before the agent ever gets a chance.
+		service.agentSock = '/tmp/ssh-agent.sock';
+		service.keyFiles.set('~/.ssh/id_ed25519', ED);
+		const absoluteDefault = `${os.homedir()}/.ssh/id_ed25519`;
+
+		const attempts = await service.testBuildAuthAttempts(makeConfig({
+			authMethod: SSHAuthMethod.Agent,
+			privateKeyPath: absoluteDefault,
+		}));
+
+		assert.deepStrictEqual(attempts, [
+			{ type: 'agent', username: 'testuser', agent: '/tmp/ssh-agent.sock' },
+			{ type: 'publickey', username: 'testuser', key: ED, keyPath: '~/.ssh/id_ed25519' },
 			{ type: 'keyboard-interactive', username: 'testuser' },
 		]);
 	});

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/REMOTE_AGENT_HOST_SESSIONS_PROVIDER.md
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/REMOTE_AGENT_HOST_SESSIONS_PROVIDER.md
@@ -76,6 +76,7 @@ Decoupling these allows copilot sessions from different providers (local CLI, re
 - Handles session notifications (`notify/sessionAdded`, `notify/sessionRemoved`) and state changes
 - Fires `onDidChangeSessionTypes` when the host's agent list changes
 - SSH connection progress notifications are closed when the connect promise settles; keyboard-interactive prompt cancellation rejects the connect promise as cancellation and does not show an error notification.
+- SSH config host connections use resolved `IdentityFile` and `IdentityAgent` values from `ssh -G`; encrypted private keys are prompted for a passphrase through the same quick-input bridge as keyboard-interactive auth.
 - Startup SSH auto-reconnect treats keyboard-interactive cancellation as an intentional pause and does not schedule another reconnect attempt.
 - A manual SSH reconnect from the host picker bypasses that paused auto-reconnect state and starts a fresh reconnect attempt for stored SSH hosts; host-picker disconnect/cancel for SSH uses the SSH service instead of removing the stored host.
 

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostActions.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostActions.ts
@@ -373,14 +373,10 @@ async function connectToConfiguredSSHHost(
 	const port = resolvedConfig.port !== 22 ? resolvedConfig.port : undefined;
 	const suggestedName = hostAlias;
 
-	let defaultKeyPath: string | undefined;
-	if (resolvedConfig.identityFile.length > 0) {
-		const firstKey = resolvedConfig.identityFile[0];
-		const defaultKeys = ['~/.ssh/id_rsa', '~/.ssh/id_ecdsa', '~/.ssh/id_ed25519', '~/.ssh/id_dsa', '~/.ssh/id_xmss'];
-		if (!defaultKeys.includes(firstKey)) {
-			defaultKeyPath = firstKey;
-		}
-	}
+	// Pass through the first resolved IdentityFile (if any) as the explicit
+	// key. The main process is responsible for de-duplicating against its
+	// default-key scan, so we don't need to filter here.
+	const defaultKeyPath = resolvedConfig.identityFile[0];
 
 	if (username) {
 		const config: ISSHAgentHostConfig = {

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostActions.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostActions.ts
@@ -389,6 +389,7 @@ async function connectToConfiguredSSHHost(
 			username,
 			authMethod: SSHAuthMethod.Agent,
 			privateKeyPath: defaultKeyPath,
+			identityAgent: resolvedConfig.identityAgent,
 			agentForward: resolvedConfig.forwardAgent || undefined,
 			name: suggestedName,
 			sshConfigHost: hostAlias,
@@ -404,7 +405,7 @@ async function connectToConfiguredSSHHost(
 
 	// Fallback: alias resolved without a user — fall through to manual flow
 	await instantiationService.invokeFunction(accessor =>
-		promptForCredentialsAndConnect(accessor, host, undefined, port, suggestedName, defaultKeyPath)
+		promptForCredentialsAndConnect(accessor, host, undefined, port, suggestedName, defaultKeyPath, resolvedConfig.identityAgent)
 	);
 }
 
@@ -415,6 +416,7 @@ async function promptForCredentialsAndConnect(
 	port: number | undefined,
 	suggestedName?: string,
 	defaultKeyPath?: string,
+	identityAgent?: string,
 ): Promise<void> {
 	const quickInputService = accessor.get(IQuickInputService);
 	const instantiationService = accessor.get(IInstantiationService);
@@ -510,6 +512,7 @@ async function promptForCredentialsAndConnect(
 		username,
 		authMethod,
 		privateKeyPath,
+		identityAgent,
 		password,
 		name: name.trim(),
 	};


### PR DESCRIPTION
Fixes #317549

This updates the Agents window SSH remote agent host auth path to honor resolved SSH config agent settings and encrypted private keys.

- Preserve `IdentityAgent` from `ssh -G` and pass it into ssh2 agent auth, including `IdentityAgent none` and `IdentityAgent SSH_AUTH_SOCK`.
- Detect encrypted private keys and prompt for their passphrase via the existing quick-input keyboard-interactive bridge before handing the key to ssh2.
- Pass resolved identity agent info through configured-host connect and reconnect paths.
- Add focused SSH config parsing and auth handler coverage.

Validation:
- `npm run compile-check-ts-native`
- `npm run valid-layers-check`
- `./scripts/test.sh --run src/vs/platform/agentHost/test/common/sshConfigParsing.test.ts --run src/vs/platform/agentHost/test/node/sshRemoteAgentHostService.test.ts --timeout 10000`
- `npm run precommit`