### PR TITLE
Allow clipboard events to fall through to system clipboard for OSC52 support in `code serve-web`

### DIFF
--- a/src/vs/platform/clipboard/browser/clipboardService.ts
+++ b/src/vs/platform/clipboard/browser/clipboardService.ts
@@ -124,7 +124,7 @@ export class BrowserClipboardService extends Disposable implements IClipboardSer
 		// Clear resources given we are writing text
 		this.clearResourcesState();
 
-		// With type: only in-memory is supported
+		// With type (except 'clipboard'): only in-memory is supported
 		if (type && type !== 'clipboard') {
 			this.mapTextToType.set(type, text);
 			this.logService.trace('BrowserClipboardService#writeText');

--- a/src/vs/platform/clipboard/browser/clipboardService.ts
+++ b/src/vs/platform/clipboard/browser/clipboardService.ts
@@ -125,7 +125,7 @@ export class BrowserClipboardService extends Disposable implements IClipboardSer
 		this.clearResourcesState();
 
 		// With type: only in-memory is supported
-		if (type) {
+		if (type && type !== 'clipboard') {
 			this.mapTextToType.set(type, text);
 			this.logService.trace('BrowserClipboardService#writeText');
 			return;
@@ -178,7 +178,7 @@ export class BrowserClipboardService extends Disposable implements IClipboardSer
 	async readText(type?: string): Promise<string> {
 		this.logService.trace('BrowserClipboardService#readText called with type:', type);
 		// With type: only in-memory is supported
-		if (type) {
+		if (type && type !== 'clipboard') {
 			const readText = this.mapTextToType.get(type) || '';
 			this.logService.trace('BrowserClipboardService#readText text.length:', readText.length);
 			return readText;

--- a/src/vs/workbench/services/clipboard/browser/clipboardService.ts
+++ b/src/vs/workbench/services/clipboard/browser/clipboardService.ts
@@ -43,7 +43,7 @@ export class BrowserClipboardService extends BaseBrowserClipboardService {
 			type = 'vscode-tests'; // force in-memory clipboard for tests to avoid permission issues
 		}
 
-		if (type) {
+		if (type && type !== 'clipboard') {
 			this.logService.trace('BrowserClipboardService#super.readText');
 			return super.readText(type);
 		}


### PR DESCRIPTION
Closes #318254 by allowing clipboard events of type `clipboard` to access the code path for the system clipboard.

There is [a comment](https://github.com/microsoft/vscode/blob/main/src/vs/platform/clipboard/browser/clipboardService.ts#L127) that claims that only in-memory storage is supported with `type`, but I'm not sure why that would apply to `type: clipboard` targeting the system clipboard.

Tested by running `./scripts/code-server.sh` and sending a OSC52 snippet in the terminal:
<img width="910" height="145" alt="image" src="https://github.com/user-attachments/assets/32a7bc77-3247-456f-8680-e84080d2ec71" />


<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
