### PR TITLE
Fix agent host SDK terminal tool rendering; disable custom terminal tool by default

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
@@ -369,7 +369,14 @@ function getTerminalInput(tc: ToolCallState): string | undefined {
 }
 function getTerminalOutput(tc: ToolCallState) {
 	const text = tc.status === ToolCallStatus.Completed || tc.status === ToolCallStatus.Running ? tc.content?.find(c => c.type === 'text')?.text : undefined;
-	return text ? { text } : undefined;
+	if (!text) {
+		return undefined;
+	}
+	// The detached xterm used to render this output treats input as a raw TTY stream,
+	// so a lone `\n` only advances the row without resetting the column (producing a
+	// staircase). SDK terminal tools return plain text with `\n` line endings, so
+	// normalize to `\r\n` here. The replace is idempotent on already-CRLF input.
+	return { text: text.replace(/\r?\n/g, '\r\n') };
 }
 
 function getTerminalLanguage(tc: ToolCallState) {

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -1011,7 +1011,7 @@ configurationRegistry.registerConfiguration({
 		[AgentHostCustomTerminalToolEnabledSettingId]: {
 			type: 'boolean',
 			description: nls.localize('chat.agentHost.customTerminalTool.enabled', "When enabled, Copilot SDK sessions use the Agent Host terminal tool override instead of the SDK's default terminal behavior."),
-			default: true,
+			default: false,
 			tags: ['experimental', 'advanced'],
 		},
 		[AgentHostOTelEnabledSettingId]: {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -2440,7 +2440,7 @@ suite('AgentHostChatContribution', () => {
 				dataKind: 'terminal',
 				commandLine: 'echo hello',
 				language: 'shellscript',
-				outputText: 'hello\n',
+				outputText: 'hello\r\n',
 				exitCode: 0,
 			});
 		}));
@@ -2597,7 +2597,7 @@ suite('AgentHostChatContribution', () => {
 				// Terminal tool has output and exit code
 				assert.strictEqual(toolPart.toolSpecificData?.kind, 'terminal');
 				const termData = toolPart.toolSpecificData as IChatTerminalToolInvocationData;
-				assert.strictEqual(termData.terminalCommandOutput?.text, 'file1\nfile2');
+				assert.strictEqual(termData.terminalCommandOutput?.text, 'file1\r\nfile2');
 				assert.strictEqual(termData.terminalCommandState?.exitCode, 0);
 			}
 		});

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
@@ -729,6 +729,36 @@ suite('stateToProgressAdapter', () => {
 			assert.strictEqual(IChatToolInvocation.resultDetails(invocation), undefined);
 		});
 
+		test('normalizes LF line endings to CRLF in terminal output for xterm rendering', () => {
+			const tc = createToolCallState({
+				toolInput: 'grep -n foo',
+				status: ToolCallStatus.Running,
+				content: [
+					{ type: ToolResultContentType.Terminal, resource: 'agenthost-terminal:///t5', title: 'Terminal' },
+				],
+			});
+			const invocation = toolCallStateToInvocation(tc);
+
+			finalizeToolInvocation(invocation, {
+				status: ToolCallStatus.Completed,
+				toolCallId: 'tc-1',
+				toolName: 'test_tool',
+				displayName: 'Test Tool',
+				invocationMessage: 'Running test tool...',
+				toolInput: 'grep -n foo',
+				confirmed: ToolCallConfirmationReason.NotNeeded,
+				success: true,
+				pastTenseMessage: 'Ran grep -n foo',
+				content: [
+					{ type: ToolResultContentType.Terminal, resource: 'agenthost-terminal:///t5', title: 'Terminal' },
+					{ type: ToolResultContentType.Text, text: 'line1\nline2\r\nline3\n' },
+				],
+			});
+
+			const termData = invocation.toolSpecificData as { kind: 'terminal'; terminalCommandOutput: { text: string } };
+			assert.strictEqual(termData.terminalCommandOutput.text, 'line1\r\nline2\r\nline3\r\n');
+		});
+
 		test('finalizes generic tool with input/output details', () => {
 			const tc = createToolCallState({
 				status: ToolCallStatus.Running,


### PR DESCRIPTION
Two related changes for the agent host SDK terminal tool experience.

## 1. Normalize LF to CRLF in agent host terminal tool output

The detached xterm used to render terminal tool output (`DetachedTerminalSnapshotMirror.render()` in `chatTerminalCommandMirror.ts`) calls `terminal.xterm.write(text)`, which treats input as a raw TTY stream. A lone `\n` is just LF (cursor moves down, column unchanged), so subsequent lines start at whatever column the previous line ended  producing a staircase.on 

Example SDK output:

```
394:\tsshConfigHost: hostAlias,\n541:\tconst expectedKey = config.sshConfigHost\n542:\t\t? `ssh:${config.sshConfigHost}`\n
```

Rendered as:

```
394:                    sshConfigHost: hostAlias,
                                                 541:   const expectedKey = config.sshConfigHost
                                                                                                  542:            ? `ssh:${config.sshConfigHost}`
```

### Why the custom terminal tool didn't hit this

 xterm's serialize addon, which emits proper VT with `\r\n`. The agent host SDK path in `stateToProgressAdapter.getTerminalOutput()` just passed the SDK's plain text through unchanged.

### Fix

 `\r\n` in ` the adapter boundary where SDK content is shaped into `terminalCommandOutput`. This:getTerminalOutput()` 

- keeps the custom-tool path untouched (already VT-correct);
- is co-located with the other SDK conversions;
- is idempotent on already-CRLF input.

Added a regression test covering mixed `\n` / `\r\n` input and updated two existing assertions in `agentHostChatContribution.test.ts` that exercised the same path.

## 2. Disable agent host custom terminal tool by default

Changed the default of `chat.agentHost.customTerminalTool.enabled` from `true` to `false`, so Copilot SDK sessions use the SDK's default terminal behavior out of the box. Users who want the Agent Host terminal tool override can still opt in.

(Written by Copilot)