### PR TITLE
sessions: restore X-button removal of SSH remote agent host entries

### DIFF
--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution.ts
@@ -416,6 +416,23 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 		if (connection.sshConfigHost) {
 			this._sshReconnectStates.deleteAndDispose(connection.sshConfigHost);
 		}
+		// Remove the entry from configured storage BEFORE tearing down the
+		// SSH tunnel. Two reasons:
+		//   1) `_sshService.disconnect` fires `onDidCloseConnection` →
+		//      `notifyConnectionClosed` → `onDidChangeConnections` → our
+		//      `_reconcile` → `_reconnectSSHEntries`, all synchronously
+		//      during the `await` below. If the entry is still in storage at
+		//      that point, the auto-reconnect path immediately reconnects
+		//      the host we just told it to disconnect.
+		//   2) Without removing the entry, it stays in storage and is
+		//      auto-reconnected on the next window reload.
+		// `removeRemoteAgentHost` also runs the entry's transportDisposable
+		// (which itself calls `_mainService.disconnect(connectionId)`), so it
+		// already tears down the underlying SSH tunnel — the explicit
+		// `_sshService.disconnect(connectionKey)` below is belt-and-suspenders
+		// to keep the prior behavior of clearing the connection by its
+		// connection key as well.
+		await this._remoteAgentHostService.removeRemoteAgentHost(connection.address);
 		await this._sshService.disconnect(connectionKey);
 	}
 

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution.ts
@@ -130,6 +130,44 @@ export function shouldPauseSSHReconnectAfterFailure(err: unknown): boolean {
 	return isCancellationError(err);
 }
 
+/**
+ * Connection key passed to {@link ISSHRemoteAgentHostService.disconnect} for
+ * an SSH-backed remote agent host entry. Mirrors the key the SSH service
+ * itself constructs when it stores the connection.
+ */
+export function sshConnectionKey(connection: IRemoteAgentHostSSHConnection): string {
+	return connection.sshConfigHost
+		? `ssh:${connection.sshConfigHost}`
+		: `${connection.user ?? connection.hostName}@${connection.hostName}:${connection.port ?? 22}`;
+}
+
+/**
+ * Sequence the steps to disconnect an SSH-backed remote agent host entry
+ * triggered by the user (e.g. clicking X in the workspace picker).
+ *
+ * Order matters: `removeRemoteAgentHost` MUST run before the SSH tunnel
+ * teardown. `sshService.disconnect()` fires `onDidCloseConnection`
+ * synchronously, which the renderer translates into `onDidChangeConnections`
+ * and the contribution's `_reconcile` → `_reconnectSSHEntries`. If the entry
+ * is still in configured storage at that point, the auto-reconnect path
+ * immediately reconnects the host we just told it to disconnect.
+ *
+ * `removeRemoteAgentHost` itself runs the entry's transport disposable
+ * (which calls `_mainService.disconnect(connectionId)`), so the underlying
+ * SSH tunnel is already closed when this returns. The explicit
+ * `sshService.disconnect(connectionKey)` is belt-and-suspenders to clear
+ * the connection by its connection key as well, matching the prior
+ * teardown behavior.
+ */
+export async function disconnectSSHEntry(
+	connection: IRemoteAgentHostSSHConnection,
+	remoteAgentHostService: Pick<IRemoteAgentHostService, 'removeRemoteAgentHost'>,
+	sshService: Pick<ISSHRemoteAgentHostService, 'disconnect'>,
+): Promise<void> {
+	await remoteAgentHostService.removeRemoteAgentHost(connection.address);
+	await sshService.disconnect(sshConnectionKey(connection));
+}
+
 /** Per-connection state bundle, disposed when a connection is removed. */
 class ConnectionState extends Disposable {
 	readonly store = this._register(new DisposableStore());
@@ -410,30 +448,10 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 	}
 
 	private async _disconnectSSHOnDemand(connection: IRemoteAgentHostSSHConnection): Promise<void> {
-		const connectionKey = connection.sshConfigHost
-			? `ssh:${connection.sshConfigHost}`
-			: `${connection.user ?? connection.hostName}@${connection.hostName}:${connection.port ?? 22}`;
 		if (connection.sshConfigHost) {
 			this._sshReconnectStates.deleteAndDispose(connection.sshConfigHost);
 		}
-		// Remove the entry from configured storage BEFORE tearing down the
-		// SSH tunnel. Two reasons:
-		//   1) `_sshService.disconnect` fires `onDidCloseConnection` →
-		//      `notifyConnectionClosed` → `onDidChangeConnections` → our
-		//      `_reconcile` → `_reconnectSSHEntries`, all synchronously
-		//      during the `await` below. If the entry is still in storage at
-		//      that point, the auto-reconnect path immediately reconnects
-		//      the host we just told it to disconnect.
-		//   2) Without removing the entry, it stays in storage and is
-		//      auto-reconnected on the next window reload.
-		// `removeRemoteAgentHost` also runs the entry's transportDisposable
-		// (which itself calls `_mainService.disconnect(connectionId)`), so it
-		// already tears down the underlying SSH tunnel — the explicit
-		// `_sshService.disconnect(connectionKey)` below is belt-and-suspenders
-		// to keep the prior behavior of clearing the connection by its
-		// connection key as well.
-		await this._remoteAgentHostService.removeRemoteAgentHost(connection.address);
-		await this._sshService.disconnect(connectionKey);
+		await disconnectSSHEntry(connection, this._remoteAgentHostService, this._sshService);
 	}
 
 	private async _attemptSSHReconnect(sshConfigHost: string, name: string, address: string, options: { userInitiated?: boolean } = {}): Promise<void> {

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/remoteAgentHost.contribution.test.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/remoteAgentHost.contribution.test.ts
@@ -4,11 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { timeout } from '../../../../../../base/common/async.js';
+import { DeferredPromise, timeout } from '../../../../../../base/common/async.js';
 import { CancellationError } from '../../../../../../base/common/errors.js';
 import { runWithFakedTimers } from '../../../../../../base/test/common/timeTravelScheduler.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
-import { shouldPauseSSHReconnectAfterFailure, SSHReconnectState } from '../../browser/remoteAgentHost.contribution.js';
+import { IRemoteAgentHostSSHConnection, RemoteAgentHostEntryType } from '../../../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { disconnectSSHEntry, shouldPauseSSHReconnectAfterFailure, sshConnectionKey, SSHReconnectState } from '../../browser/remoteAgentHost.contribution.js';
 
 suite('SSHReconnectState', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
@@ -111,6 +112,115 @@ suite('shouldPauseSSHReconnectAfterFailure', () => {
 		}, {
 			cancellation: true,
 			regularError: false,
+		});
+	});
+});
+
+suite('disconnectSSHEntry', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function makeSSHConfigConnection(overrides: Partial<IRemoteAgentHostSSHConnection> = {}): IRemoteAgentHostSSHConnection {
+		return {
+			type: RemoteAgentHostEntryType.SSH,
+			address: 'localhost:4321',
+			sshConfigHost: 'myserver',
+			hostName: 'myserver.example.com',
+			...overrides,
+		};
+	}
+
+	test('removes the entry from configured storage BEFORE tearing down the SSH tunnel', async () => {
+		// Regression guard for the X-button picker fix. `_sshService.disconnect`
+		// fires `onDidChangeConnections` synchronously, which the contribution
+		// translates into `_reconcile` → `_reconnectSSHEntries`. If the entry
+		// is still in configured storage at that point, the auto-reconnect
+		// path immediately reconnects the host we just told it to disconnect
+		// (and on the next window reload, the persisted entry reconnects too).
+		const calls: string[] = [];
+		const connection = makeSSHConfigConnection();
+
+		// Block removeRemoteAgentHost so we can prove disconnect waits for it.
+		const removed = new DeferredPromise<void>();
+
+		const remoteAgentHostService = {
+			removeRemoteAgentHost: async (address: string) => {
+				calls.push(`remove:${address}`);
+				await removed.p;
+			},
+		};
+		const sshService = {
+			disconnect: async (key: string) => {
+				calls.push(`ssh:${key}`);
+			},
+		};
+
+		const pending = disconnectSSHEntry(connection, remoteAgentHostService, sshService);
+
+		// Give microtasks a chance to drain. ssh disconnect must NOT have run yet
+		// because removeRemoteAgentHost is still pending.
+		await timeout(0);
+		assert.deepStrictEqual(calls, ['remove:localhost:4321']);
+
+		removed.complete();
+		await pending;
+
+		assert.deepStrictEqual(calls, ['remove:localhost:4321', 'ssh:ssh:myserver']);
+	});
+
+	test('uses sshConfigHost-based key when sshConfigHost is set', async () => {
+		const calls: string[] = [];
+		await disconnectSSHEntry(
+			makeSSHConfigConnection({ sshConfigHost: 'myserver' }),
+			{ removeRemoteAgentHost: async () => { /* noop */ } },
+			{ disconnect: async (key: string) => { calls.push(key); } },
+		);
+		assert.deepStrictEqual(calls, ['ssh:myserver']);
+	});
+
+	test('uses user@host:port key when sshConfigHost is not set', async () => {
+		const calls: string[] = [];
+		await disconnectSSHEntry(
+			{
+				type: RemoteAgentHostEntryType.SSH,
+				address: 'localhost:4321',
+				hostName: 'myserver.example.com',
+				user: 'me',
+				port: 2222,
+			},
+			{ removeRemoteAgentHost: async () => { /* noop */ } },
+			{ disconnect: async (key: string) => { calls.push(key); } },
+		);
+		assert.deepStrictEqual(calls, ['me@myserver.example.com:2222']);
+	});
+});
+
+suite('sshConnectionKey', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('matches the keys the SSH service stores connections under', () => {
+		assert.deepStrictEqual({
+			configHost: sshConnectionKey({
+				type: RemoteAgentHostEntryType.SSH,
+				address: 'localhost:4321',
+				sshConfigHost: 'myserver',
+				hostName: 'ignored',
+			}),
+			userHostPort: sshConnectionKey({
+				type: RemoteAgentHostEntryType.SSH,
+				address: 'localhost:4321',
+				hostName: 'myserver.example.com',
+				user: 'me',
+				port: 2222,
+			}),
+			hostOnly: sshConnectionKey({
+				type: RemoteAgentHostEntryType.SSH,
+				address: 'localhost:4321',
+				hostName: 'myserver.example.com',
+			}),
+		}, {
+			configHost: 'ssh:myserver',
+			userHostPort: 'me@myserver.example.com:2222',
+			hostOnly: 'myserver.example.com@myserver.example.com:22',
 		});
 	});
 });


### PR DESCRIPTION
The X button on remote agent host SSH entries in the workspace picker disconnected the SSH tunnel but did not remove the entry from configured storage: on the next reconcile pass (or on reload) `_reconnectSSHEntries` found the entry still configured and immediately auto-reconnected it.

This regressed in [#316810](https://github.com/microsoft/vscode/pull/316810), which routed SSH disconnect through the provider's `_disconnectOnDemand` hook. The provider's `disconnect()` returns early when that hook is set, so it no longer called `removeRemoteAgentHost` for SSH entries (the pre-#316810 behavior). Combined with the synchronous reconcile that fires from `_sshService.disconnect`'s own close event, the entry was reconnected before the disconnect even returned.

### Fix

Call `removeRemoteAgentHost` from `_disconnectSSHOnDemand` before the `_sshService.disconnect` await so the entry is gone before the close-event chain triggers `_reconnectSSHEntries`. `removeRemoteAgentHost` also runs the SSH transport disposable, which itself tears down the main-process SSH tunnel; the explicit `_sshService.disconnect(connectionKey)` is kept as belt-and-suspenders.

### Behavior

|                              | Before #316810           | After #316810 (bug) | After this fix |
| ---------------------------- | ------------------------ | ------------------- | -------------- |
| Entry               |removed                    | from                         | storage   | 
| SSH tunnel torn down         | (              |broken                    | differently)     | 
| Stays               |disconnected                    | on                         | reload | 

(Written by Copilot)
