### PR TITLE
fix: support array form of tsconfig "extends" in document links

### DIFF
--- a/extensions/typescript-language-features/src/languageFeatures/tsconfig.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/tsconfig.ts
@@ -42,15 +42,24 @@ class TsconfigLinkProvider implements vscode.DocumentLinkProvider {
 		}
 
 		return coalesce([
-			this.getExtendsLink(document, root),
+			...this.getExtendsLinks(document, root),
 			...this.getFilesLinks(document, root),
 			...this.getReferencesLinks(document, root)
 		]);
 	}
 
-	private getExtendsLink(document: vscode.TextDocument, root: jsonc.Node): vscode.DocumentLink | undefined {
+	private getExtendsLinks(document: vscode.TextDocument, root: jsonc.Node) {
 		const node = jsonc.findNodeAtLocation(root, ['extends']);
-		return node && this.tryCreateTsConfigLink(document, node, TsConfigLinkType.Extends);
+
+		if (!node) {
+			return [];
+		}
+
+		if (node.type === 'array') {
+			return mapChildren(node, child => this.tryCreateTsConfigLink(document, child, TsConfigLinkType.Extends));
+		}
+
+		return [this.tryCreateTsConfigLink(document, node, TsConfigLinkType.Extends)];
 	}
 
 	private getReferencesLinks(document: vscode.TextDocument, root: jsonc.Node) {

--- a/extensions/typescript-language-features/src/languageFeatures/tsconfig.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/tsconfig.ts
@@ -48,7 +48,7 @@ class TsconfigLinkProvider implements vscode.DocumentLinkProvider {
 		]);
 	}
 
-	private getExtendsLinks(document: vscode.TextDocument, root: jsonc.Node) {
+	private getExtendsLinks(document: vscode.TextDocument, root: jsonc.Node): (vscode.DocumentLink | undefined)[] {
 		const node = jsonc.findNodeAtLocation(root, ['extends']);
 
 		if (!node) {
@@ -62,7 +62,7 @@ class TsconfigLinkProvider implements vscode.DocumentLinkProvider {
 		return [this.tryCreateTsConfigLink(document, node, TsConfigLinkType.Extends)];
 	}
 
-	private getReferencesLinks(document: vscode.TextDocument, root: jsonc.Node) {
+	private getReferencesLinks(document: vscode.TextDocument, root: jsonc.Node): (vscode.DocumentLink | undefined)[] {
 		return mapChildren(
 			jsonc.findNodeAtLocation(root, ['references']),
 			child => {
@@ -89,7 +89,7 @@ class TsconfigLinkProvider implements vscode.DocumentLinkProvider {
 		return link;
 	}
 
-	private getFilesLinks(document: vscode.TextDocument, root: jsonc.Node) {
+	private getFilesLinks(document: vscode.TextDocument, root: jsonc.Node): (vscode.DocumentLink | undefined)[] {
 		return mapChildren(
 			jsonc.findNodeAtLocation(root, ['files']),
 			child => this.pathNodeToLink(document, child));


### PR DESCRIPTION
<!-- Associated issue: none filed; happy to open one if preferred. -->

### Description

`TsconfigLinkProvider` (in `extensions/typescript-language-features/src/languageFeatures/tsconfig.ts`) only created a document link when the `extends` field was a string. TypeScript 5.0 added support for an array of base configs:

```jsonc
{
  "extends": ["./tsconfig.base.json", "@tsconfig/strictest/tsconfig.json"]
}
```

<img width="543" height="208" alt="image" src="https://github.com/user-attachments/assets/eebcb2a6-24ec-460e-abf0-61fade43ada3" />

In that case, the existing code asked `jsonc.findNodeAtLocation(root, ['extends'])` and handed the resulting node straight to `tryCreateTsConfigLink`. `isPathValue` requires `node.type === 'string'`, so the array case was silently dropped — Cmd+Click did nothing on any of the entries.

This change renames `getExtendsLink` to `getExtendsLinks` and:

- returns `[]` when no `extends` is present
- iterates array children via the existing `mapChildren` helper when `extends` is an array
- falls through to the original single-string behavior otherwise

Each element is resolved through the unchanged `tryCreateTsConfigLink` → `openExtendsLinkCommandId` → `getTsconfigPath` pipeline, so relative paths, absolute paths, and `node_modules` package resolution continue to work per element.

For consistency, all three sibling getters (`getExtendsLinks`, `getFilesLinks`, `getReferencesLinks`) now carry an explicit `(vscode.DocumentLink | undefined)[]` return type. The outer `coalesce` in `provideDocumentLinks` is unchanged and still filters the `undefined` entries.

Reference: [TypeScript 5.0 release notes – Supporting Multiple Configuration Files in `extends`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-0.html#supporting-multiple-configuration-files-in-extends).

### How to test

1. Open a workspace containing a `tsconfig.json` such as:
   ```jsonc
   {
     "extends": ["./tsconfig.base.json", "./tsconfig.strict.json"]
   }
   ```
   with both referenced files present next to it.
2. Hover each string inside the `extends` array — a "Follow link" tooltip should appear.
3. Cmd+Click (Ctrl+Click on Windows/Linux) each entry and confirm the correct file opens.
4. Confirm the existing single-string form still works:
   ```jsonc
   { "extends": "./tsconfig.base.json" }
   ```
5. Confirm `files` and `references` links are unaffected.