### PR TITLE
chat: fix duplicate command registration for agent-host-copilotcli

### DIFF
--- a/src/vs/workbench/contrib/chat/electron-browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/chat.contribution.ts
@@ -336,13 +336,6 @@ async function openNewAgentHostSession(accessor: ServicesAccessor, position: Cha
 	}));
 }
 
-// Register command for opening a new Agent Host session from the session type picker
-CommandsRegistry.registerCommand(
-	`workbench.action.chat.openNewChatSessionInPlace.${AgentSessionProviders.AgentHostCopilot}`,
-	(accessor, chatSessionPosition: string) =>
-		openNewAgentHostSession(accessor, chatSessionPosition === 'editor' ? ChatSessionPosition.Editor : ChatSessionPosition.Sidebar)
-);
-
 // Static sidebar/editor open commands for the Agent Host umbrella scheme.
 // The dynamic per-agent commands (e.g. `agent-host-copilot`) are only
 // registered after the agent host starts and surfaces an AgentInfo, which


### PR DESCRIPTION
Fixes an error thrown on startup:

```
Error: Cannot register two commands with the same id: workbench.action.chat.openNewChatSessionInPlace.agent-host-copilotcli
```

The command was being registered twice:

1. **Statically** in `src/vs/workbench/contrib/chat/electron-browser/chat.contribution.ts` (added in [#314187](https://github.com/microsoft/vscode/pull/314187)).
2. **Dynamically** in `src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts` via the autorun that registers an in-place `openNewChatSessionInPlace.<type>` action for every contributed session type. The agent host calls `registerChatSessionContribution` for `agent-host-copilotcli` at startup, which triggers that registration — that path was added in [#312628](https://github.com/microsoft/vscode/pull/312628) specifically to ensure types like `agent-host-copilotcli` get the in-place command.

`CommandsRegistry.registerCommand` asserts on duplicate ids, so the second registration threw.

## Fix

Remove the static duplicate from `electron-browser/chat.contribution.ts`. The dynamic registration already covers it, runs as soon as the agent host registers its contribution, and is the systematic mechanism for all session types.

The neighbouring `openNewSessionSidebar` / `openNewSessionEditor` static commands stay — they have distinct ids and serve their documented purpose of providing stable command ids for automation that may run before the agent host has registered.

(Written by Copilot)
