### PR TITLE
Add js/ts.projectConfig.additionalFilePatterns setting

### DIFF
--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -2845,6 +2845,7 @@
             "items": {
               "type": "string"
             },
+            "uniqueItems": true,
             "default": [],
             "markdownDescription": "%js/ts.projectConfig.additionalFilePatterns%",
             "scope": "window",

--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -2839,6 +2839,19 @@
             "description": "%typescript.tsserver.pluginPaths%",
             "markdownDeprecationMessage": "%typescript.tsserver.pluginPaths.unifiedDeprecationMessage%",
             "scope": "machine"
+          },
+          "js/ts.projectConfig.additionalFilePatterns": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [],
+            "markdownDescription": "%js/ts.projectConfig.additionalFilePatterns%",
+            "scope": "window",
+            "keywords": [
+              "TypeScript",
+              "JavaScript"
+            ]
           }
         }
       }

--- a/extensions/typescript-language-features/package.nls.json
+++ b/extensions/typescript-language-features/package.nls.json
@@ -35,7 +35,7 @@
 	"typescript.tsserver.pluginPaths": "Additional paths to discover TypeScript Language Service plugins.",
 	"typescript.tsserver.pluginPaths.item": "Either an absolute or relative path. Relative path will be resolved against workspace folder(s).",
 	"typescript.tsserver.pluginPaths.unifiedDeprecationMessage": "This setting is deprecated. Use `#js/ts.tsserver.pluginPaths#` instead.",
-	"js/ts.projectConfig.additionalFilePatterns": "Additional glob patterns for files to treat as TypeScript or JavaScript project configuration files. Useful for monorepos that name configs without `tsconfig`/`jsconfig` in the filename (for example `base.json`, `build.json`). The standard `tsconfig.json`/`jsconfig.json` patterns are always included; entries here are added to them. Matching files get document links for `extends`, `references`, and `files`.",
+	"js/ts.projectConfig.additionalFilePatterns": "Additional glob patterns identifying files that should receive `tsconfig.json`/`jsconfig.json`-style document links (for `extends`, `references`, and `files`). Useful for monorepos that name configs without `tsconfig`/`jsconfig` in the filename (for example `base.json`, `build.json`). The standard `tsconfig.json`/`jsconfig.json` patterns are always included; entries here are added to them. Does not affect TypeScript/JavaScript project loading.",
 	"typescript.tsserver.trace": "Enables tracing of messages sent to the TS server. This trace can be used to diagnose TS Server issues. The trace may contain file paths, source code, and other potentially sensitive information from your project.",
 	"typescript.validate.enable": "Enable/disable TypeScript validation.",
 	"javascript.validate.enable": "Enable/disable JavaScript validation.",

--- a/extensions/typescript-language-features/package.nls.json
+++ b/extensions/typescript-language-features/package.nls.json
@@ -35,6 +35,7 @@
 	"typescript.tsserver.pluginPaths": "Additional paths to discover TypeScript Language Service plugins.",
 	"typescript.tsserver.pluginPaths.item": "Either an absolute or relative path. Relative path will be resolved against workspace folder(s).",
 	"typescript.tsserver.pluginPaths.unifiedDeprecationMessage": "This setting is deprecated. Use `#js/ts.tsserver.pluginPaths#` instead.",
+	"js/ts.projectConfig.additionalFilePatterns": "Additional glob patterns for files to treat as TypeScript or JavaScript project configuration files. Useful for monorepos that name configs without `tsconfig`/`jsconfig` in the filename (for example `base.json`, `build.json`). The standard `tsconfig.json`/`jsconfig.json` patterns are always included; entries here are added to them. Matching files get document links for `extends`, `references`, and `files`.",
 	"typescript.tsserver.trace": "Enables tracing of messages sent to the TS server. This trace can be used to diagnose TS Server issues. The trace may contain file paths, source code, and other potentially sensitive information from your project.",
 	"typescript.validate.enable": "Enable/disable TypeScript validation.",
 	"javascript.validate.enable": "Enable/disable JavaScript validation.",

--- a/extensions/typescript-language-features/src/languageFeatures/tsconfig.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/tsconfig.ts
@@ -118,6 +118,64 @@ class TsconfigLinkProvider implements vscode.DocumentLinkProvider {
 	}
 }
 
+class TsconfigLinkProviderRegistration implements vscode.Disposable {
+
+	private static readonly configSection = 'js/ts';
+	private static readonly configKey = 'projectConfig.additionalFilePatterns';
+	private static readonly languages: readonly string[] = ['json', 'jsonc'];
+	private static readonly defaultPatterns: readonly string[] = [
+		'**/[jt]sconfig.json',
+		'**/[jt]sconfig.*.json',
+	];
+
+	private readonly _configListener: vscode.Disposable;
+	private _providerRegistration: vscode.Disposable | undefined;
+
+	constructor(private readonly _provider: vscode.DocumentLinkProvider) {
+		this.update();
+		this._configListener = vscode.workspace.onDidChangeConfiguration(e => {
+			const fullKey = `${TsconfigLinkProviderRegistration.configSection}.${TsconfigLinkProviderRegistration.configKey}`;
+			if (e.affectsConfiguration(fullKey)) {
+				this.update();
+			}
+		});
+	}
+
+	dispose(): void {
+		this._configListener.dispose();
+		this._providerRegistration?.dispose();
+		this._providerRegistration = undefined;
+	}
+
+	private update(): void {
+		this._providerRegistration?.dispose();
+		this._providerRegistration = vscode.languages.registerDocumentLinkProvider(this.buildSelector(), this._provider);
+	}
+
+	private buildSelector(): vscode.DocumentSelector {
+		const patterns = this.readPatterns();
+		return TsconfigLinkProviderRegistration.languages.flatMap(
+			language => patterns.map((pattern): vscode.DocumentFilter => ({ language, pattern })));
+	}
+
+	private readPatterns(): string[] {
+		const patterns = new Set<string>(TsconfigLinkProviderRegistration.defaultPatterns);
+		const configured = vscode.workspace
+			.getConfiguration(TsconfigLinkProviderRegistration.configSection)
+			.get(TsconfigLinkProviderRegistration.configKey);
+
+		if (Array.isArray(configured)) {
+			for (const value of configured) {
+				if (typeof value === 'string' && value.length > 0) {
+					patterns.add(value);
+				}
+			}
+		}
+
+		return Array.from(patterns);
+	}
+}
+
 async function resolveNodeModulesPath(baseDirUri: vscode.Uri, pathCandidates: string[]): Promise<vscode.Uri | undefined> {
 	let currentUri = baseDirUri;
 	const baseCandidate = pathCandidates[0];
@@ -191,17 +249,6 @@ async function getTsconfigPath(baseDirUri: vscode.Uri, pathValue: string, linkTy
 }
 
 export function register() {
-	const patterns: vscode.GlobPattern[] = [
-		'**/[jt]sconfig.json',
-		'**/[jt]sconfig.*.json',
-	];
-
-	const languages = ['json', 'jsonc'];
-
-	const selector: vscode.DocumentSelector =
-		languages.map(language => patterns.map((pattern): vscode.DocumentFilter => ({ language, pattern })))
-			.flat();
-
 	return vscode.Disposable.from(
 		vscode.commands.registerCommand(openExtendsLinkCommandId, async ({ resourceUri, extendsValue, linkType }: OpenExtendsLinkCommandArgs) => {
 			const tsconfigPath = await getTsconfigPath(Utils.dirname(vscode.Uri.from(resourceUri)), extendsValue, linkType);
@@ -212,6 +259,7 @@ export function register() {
 			// Will suggest to create a .json variant if it doesn't exist yet (but only for relative paths)
 			await vscode.commands.executeCommand('vscode.open', tsconfigPath);
 		}),
-		vscode.languages.registerDocumentLinkProvider(selector, new TsconfigLinkProvider()),
+		new TsconfigLinkProviderRegistration(new TsconfigLinkProvider()),
 	);
 }
+

--- a/extensions/typescript-language-features/src/languageFeatures/tsconfig.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/tsconfig.ts
@@ -130,6 +130,7 @@ class TsconfigLinkProviderRegistration implements vscode.Disposable {
 
 	private readonly _configListener: vscode.Disposable;
 	private _providerRegistration: vscode.Disposable | undefined;
+	private _lastPatternsKey: string | undefined;
 
 	constructor(private readonly _provider: vscode.DocumentLinkProvider) {
 		this.update();
@@ -148,12 +149,20 @@ class TsconfigLinkProviderRegistration implements vscode.Disposable {
 	}
 
 	private update(): void {
+		const patterns = this.readPatterns();
+		const key = patterns.join('\n');
+
+		if (key === this._lastPatternsKey) {
+			return;
+		}
+
+		this._lastPatternsKey = key;
 		this._providerRegistration?.dispose();
-		this._providerRegistration = vscode.languages.registerDocumentLinkProvider(this.buildSelector(), this._provider);
+		this._providerRegistration = vscode.languages.registerDocumentLinkProvider(
+			this.buildSelector(patterns), this._provider);
 	}
 
-	private buildSelector(): vscode.DocumentSelector {
-		const patterns = this.readPatterns();
+	private buildSelector(patterns: readonly string[]): vscode.DocumentSelector {
 		return TsconfigLinkProviderRegistration.languages.flatMap(
 			language => patterns.map((pattern): vscode.DocumentFilter => ({ language, pattern })));
 	}
@@ -166,8 +175,14 @@ class TsconfigLinkProviderRegistration implements vscode.Disposable {
 
 		if (Array.isArray(configured)) {
 			for (const value of configured) {
-				if (typeof value === 'string' && value.length > 0) {
-					patterns.add(value);
+				if (typeof value !== 'string') {
+					continue;
+				}
+
+				const trimmed = value.trim();
+
+				if (trimmed.length > 0) {
+					patterns.add(trimmed);
 				}
 			}
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. -->

## Summary

- Adds the `js/ts.projectConfig.additionalFilePatterns` setting (array of glob patterns).
- `TsconfigLinkProvider` now also activates for files matching user-supplied globs, in addition to the existing `**/[jt]sconfig.json` and `**/[jt]sconfig.*.json` defaults.
- Introduces `TsconfigLinkProviderRegistration` to own the provider lifecycle: re-registers when the setting changes, disposes cleanly, defends against malformed config values.

This is useful for monorepos that name TSConfig/JSConfig files without `tsconfig`/`jsconfig` in the filename (for example `base.json`, `build.json`).

|||
|--------|--------|
| <img width="486" height="219" alt="image" src="https://github.com/user-attachments/assets/d144cae9-d373-4665-bc98-ebd2e3fa3e50" /> | <img width="456" height="230" alt="image" src="https://github.com/user-attachments/assets/0c5db356-de49-41e9-a933-b9c037e4c726" /> |
| <img width="450" height="216" alt="image" src="https://github.com/user-attachments/assets/e2663576-19b2-4b48-80c0-8d3675b3fade" /> | <img width="551" height="256" alt="image" src="https://github.com/user-attachments/assets/404e0060-22e7-45c1-be3e-97d3ec70cfc5" /> | 

## Test plan

- [x] Open a workspace with a standard `tsconfig.json` containing `extends` / `references` / `files` — verify document links still work.
- [x] Add `"js/ts.projectConfig.additionalFilePatterns": ["**/server.json"]` to user settings; open a matching `server.json` — verify links appear on its `extends`/`references`/`files` entries.
- [x] Edit the setting at runtime — links update without a window reload.
- [x] Set the value to an invalid type (e.g. a string instead of an array) — defaults still apply, no errors thrown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)