### PR TITLE
fix: disable breadcrumb path copy without symbols

### DIFF
--- a/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
@@ -237,10 +237,12 @@ export class BreadcrumbsControl {
 	static readonly CK_BreadcrumbsPossible = new RawContextKey('breadcrumbsPossible', false, localize('breadcrumbsPossible', "Whether the editor can show breadcrumbs"));
 	static readonly CK_BreadcrumbsVisible = new RawContextKey('breadcrumbsVisible', false, localize('breadcrumbsVisible', "Whether breadcrumbs are currently visible"));
 	static readonly CK_BreadcrumbsActive = new RawContextKey('breadcrumbsActive', false, localize('breadcrumbsActive', "Whether breadcrumbs have focus"));
+	static readonly CK_BreadcrumbsSymbolPath = new RawContextKey('breadcrumbsSymbolPath', false, localize('breadcrumbsSymbolPath', "Whether breadcrumbs contain a symbol path"));
 
 	private readonly _ckBreadcrumbsPossible: IContextKey<boolean>;
 	private readonly _ckBreadcrumbsVisible: IContextKey<boolean>;
 	private readonly _ckBreadcrumbsActive: IContextKey<boolean>;
+	private readonly _ckBreadcrumbsSymbolPath: IContextKey<boolean>;
 
 	private readonly _cfUseQuickPick: BreadcrumbsConfig<boolean>;
 	private readonly _cfShowIcons: BreadcrumbsConfig<boolean>;
@@ -305,6 +307,7 @@ export class BreadcrumbsControl {
 		this._ckBreadcrumbsPossible = BreadcrumbsControl.CK_BreadcrumbsPossible.bindTo(this._contextKeyService);
 		this._ckBreadcrumbsVisible = BreadcrumbsControl.CK_BreadcrumbsVisible.bindTo(this._contextKeyService);
 		this._ckBreadcrumbsActive = BreadcrumbsControl.CK_BreadcrumbsActive.bindTo(this._contextKeyService);
+		this._ckBreadcrumbsSymbolPath = BreadcrumbsControl.CK_BreadcrumbsSymbolPath.bindTo(this._contextKeyService);
 
 		this._hoverDelegate = getDefaultHoverDelegate('mouse');
 
@@ -319,6 +322,7 @@ export class BreadcrumbsControl {
 		this._ckBreadcrumbsPossible.reset();
 		this._ckBreadcrumbsVisible.reset();
 		this._ckBreadcrumbsActive.reset();
+		this._ckBreadcrumbsSymbolPath.reset();
 		this._cfUseQuickPick.dispose();
 		this._cfShowIcons.dispose();
 		this._cfTitleScrollbarSizing.dispose();
@@ -345,6 +349,7 @@ export class BreadcrumbsControl {
 
 		this._breadcrumbsDisposables.clear();
 		this._ckBreadcrumbsVisible.set(false);
+		this._ckBreadcrumbsSymbolPath.set(false);
 		this.domNode.classList.toggle('hidden', true);
 
 		if (!wasHidden) {
@@ -378,6 +383,7 @@ export class BreadcrumbsControl {
 			// cleanup and return when there is no input or when
 			// we cannot handle this input
 			this._ckBreadcrumbsPossible.set(false);
+			this._ckBreadcrumbsSymbolPath.set(false);
 			if (!wasHidden) {
 				this.hide();
 				return true;
@@ -408,7 +414,10 @@ export class BreadcrumbsControl {
 				showFileIcons: this._options.showFileIcons && showIcons,
 				showSymbolIcons: this._options.showSymbolIcons && showIcons
 			};
-			const items = model.getElements().map(element => element instanceof FileElement
+			const elements = model.getElements();
+			this._ckBreadcrumbsSymbolPath.set(elements.some(element => element instanceof OutlineElement2 && element.element !== element.outline));
+
+			const items = elements.map(element => element instanceof FileElement
 				? this._instantiationService.createInstance(FileItem, model, element, options, this._labels, this._hoverDelegate)
 				: this._instantiationService.createInstance(OutlineItem, model, element, options));
 			if (items.length === 0) {
@@ -961,13 +970,13 @@ registerAction2(class CopyBreadcrumbPath extends Action2 {
 			id: 'breadcrumbs.copyPath',
 			title: localize2('cmd.copyPath', "Copy Breadcrumbs Path"),
 			category: Categories.View,
-			precondition: BreadcrumbsControl.CK_BreadcrumbsVisible,
+			precondition: ContextKeyExpr.and(BreadcrumbsControl.CK_BreadcrumbsVisible, BreadcrumbsControl.CK_BreadcrumbsSymbolPath),
 			f1: true,
 			menu: [{
 				id: MenuId.EditorTitleContext,
 				group: '1_cutcopypaste',
 				order: 100,
-				when: BreadcrumbsControl.CK_BreadcrumbsPossible
+				when: ContextKeyExpr.and(BreadcrumbsControl.CK_BreadcrumbsPossible, BreadcrumbsControl.CK_BreadcrumbsSymbolPath)
 			}]
 		});
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

## Related Issue

Closes #286240

## Summary

Disable the `Copy Breadcrumbs Path` command unless the active breadcrumbs contain an actual symbol path.

The command previously stayed enabled for file-only breadcrumbs or placeholder symbol breadcrumbs and then silently returned without copying anything. This adds a breadcrumbs context key that is true only when at least one real outline breadcrumb is present, so the command/menu item is unavailable when it would be a no-op.

## How to Test

1. Open a file that has no symbol breadcrumb selection.
2. Right-click the editor tab.
3. Verify `Copy Breadcrumbs Path` is disabled/hidden while `Copy Path` and `Copy Relative Path` remain available.
4. Open a file with symbol breadcrumbs and place the cursor inside a symbol.
5. Verify `Copy Breadcrumbs Path` is available and still copies the symbol breadcrumb path.

## Community Rules Review

- `CONTRIBUTING.md` reviewed; it points code contributors to the VS Code wiki.
- `.github/pull_request_template.md` reviewed and included above.
- VS Code wiki reviewed: CLA required, one PR per issue, linked issue, small changes, coding guidelines, and tests whenever possible.
- CI reviewed: `.github/workflows/pr.yml` targets `main` and runs Compile & Hygiene plus Linux/macOS/Windows test workflows.
- Base branch: `main`, confirmed via `gh repo view microsoft/vscode --json defaultBranchRef`.

## Verification Evidence

### Dependency Setup

- `bun install`: attempted; failed building `@vscode/sqlite3` because local Windows environment lacks Visual Studio C++ Build Tools.
- Fallback: `npm install --ignore-scripts` succeeded for static tooling; generated `package-lock.json` diff was restored before code changes.
- Environment note: repository `.nvmrc` expects Node `22.22.1`; local Node is `24.14.0`.

### Tests

- `node test/unit/browser/index.js --grep "Breadcrumb"`: runner completed with exit code 0 after installing Playwright browsers, but reported `0 passing`, so no matching automated test executed.
- `bun test --bail`: unavailable for this repo setup; Bun starts `test/monaco/monaco.test.ts` and fails resolving `chai` before reaching this change.

### Type Check

- `npm run compile-check-ts-native`: passed.
- LSP diagnostics for `src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts`: no diagnostics.
- `bun run typecheck`: unavailable because VS Code root `package.json` has no `typecheck` script.

### Build

- `bun run build`: unavailable because VS Code root `package.json` has no `build` script.
- Official VS Code build/CI equivalent is Compile & Hygiene in `.github/workflows/pr.yml`; local full build was not run because native dependency installation failed without Visual Studio C++ Build Tools.

### Diff Summary

```text
src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts | 15 ++++++++++++---
1 file changed, 12 insertions(+), 3 deletions(-)
```

## Checklist

- [x] Base branch is `main`
- [x] Associated issue is linked
- [x] No unauthorized version bump
- [x] All feasible verification checks attempted; unavailable checks documented with reason
- [x] Commits split if >=3 files changed (single-file change)
- [x] No unintended schema or lockfile regeneration
