### PR TITLE
fix: support keyboard activation for agents profile icon

### DIFF
--- a/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
+++ b/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
@@ -19,7 +19,7 @@ import { appendUpdateMenuItems as registerUpdateMenuItems } from '../../../../wo
 import { Menus } from '../../../browser/menus.js';
 import { IActionViewItemService } from '../../../../platform/actions/browser/actionViewItemService.js';
 import { fillInActionBarActions } from '../../../../platform/actions/browser/menuEntryActionViewItem.js';
-import { $, append, disposableWindowInterval, getDomNodePagePosition } from '../../../../base/browser/dom.js';
+import { $, addDisposableListener, append, disposableWindowInterval, EventType, getDomNodePagePosition } from '../../../../base/browser/dom.js';
 import { mainWindow } from '../../../../base/browser/window.js';
 import { ActionBar, ActionsOrientation } from '../../../../base/browser/ui/actionbar/actionbar.js';
 import { BaseActionViewItem, IBaseActionViewItemOptions } from '../../../../base/browser/ui/actionbar/actionViewItems.js';
@@ -205,6 +205,13 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 		container.classList.add('sessions-account-titlebar-widget');
 		container.setAttribute('role', 'button');
 		container.tabIndex = 0;
+		this._register(addDisposableListener(container, EventType.KEY_DOWN, (event: KeyboardEvent) => {
+			if (event.key === 'Enter' || event.key === ' ') {
+				event.preventDefault();
+				event.stopPropagation();
+				this.showCombinedPanel();
+			}
+		}));
 
 		this.avatarElement = append(container, $('img.sessions-account-titlebar-widget-avatar', { alt: localize('accountAvatarAltFallback', "Account profile image"), draggable: 'false' })) as HTMLImageElement;
 		this.avatarElement.decoding = 'async';
@@ -267,6 +274,7 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 		this.container.classList.add(`kind-${state.kind}`);
 		this.container.classList.toggle('menu-visible', this.isMenuVisible);
 		this.container.setAttribute('aria-label', state.ariaLabel);
+		this.container.setAttribute('aria-expanded', String(this.isMenuVisible));
 
 		const badgeKey = getAccountTitleBarBadgeKey(state);
 		if (badgeKey !== this.lastBadgeKey) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

## Related Issue

Closes #317114

## Summary

Adds keyboard activation support to the Agents window title bar account/profile widget.

The widget was already focusable and exposed as a button, but pressing Enter or Space did not toggle the account/status panel. This wires those keys to the same panel toggle used by mouse activation and exposes `aria-expanded` so assistive technologies can track the expanded state.

## How to Test

1. Open the Agents window.
2. Tab to the account/profile icon in the title bar.
3. Press Enter or Space.
4. Verify the account/status panel opens.
5. Press Enter or Space again while focus is back on the account/profile icon.
6. Verify the panel closes without focus moving away from the icon.

## Community Rules Review

- `CONTRIBUTING.md` reviewed; it points code contributors to the VS Code wiki.
- `.github/pull_request_template.md` reviewed and included above.
- VS Code wiki reviewed: CLA required, one PR per issue, linked issue, small changes, coding guidelines, and tests whenever possible.
- CI reviewed: `.github/workflows/pr.yml` targets `main` and runs Compile & Hygiene plus Linux/macOS/Windows test workflows.
- Base branch: `main`, confirmed via `gh repo view microsoft/vscode --json defaultBranchRef`.

## Verification Evidence

### Dependency Setup

- `bun install`: attempted previously in this clean clone; failed building `@vscode/sqlite3` because local Windows environment lacks Visual Studio C++ Build Tools.
- Fallback: `npm install --ignore-scripts` succeeded for static tooling; generated `package-lock.json` diff was restored before code changes.
- Environment note: repository `.nvmrc` expects Node `22.22.1`; local Node is `24.14.0`.

### Tests

- Manual verification required in the Agents window UI for focus behavior.
- No dedicated automated test was found for `TitleBarAccountWidget` keyboard activation.
- `bun test --bail`: unavailable for this repo setup; Bun starts `test/monaco/monaco.test.ts` and fails resolving `chai` before reaching this change.

### Type Check / Lint

- `npm run compile-check-ts-native`: passed.
- `npm run eslint -- src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts`: passed (`ESLINT_EXIT=0`; warning only: `ESLintPoorConcurrencyWarning`).
- LSP diagnostics for `src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts`: no diagnostics.
- `bun run typecheck`: unavailable because VS Code root `package.json` has no `typecheck` script.

### Build

- `bun run build`: unavailable because VS Code root `package.json` has no `build` script.
- Official VS Code build/CI equivalent is Compile & Hygiene in `.github/workflows/pr.yml`; local full build was not run because native dependency installation failed without Visual Studio C++ Build Tools.

### Diff Summary

```text
src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts | 10 +++++++++-
1 file changed, 9 insertions(+), 1 deletion(-)
```

## Checklist

- [x] Base branch is `main`
- [x] Associated issue is linked
- [x] No unauthorized version bump
- [x] All feasible verification checks attempted; unavailable checks documented with reason
- [x] Commits split if >=3 files changed (single-file change)
- [x] No unintended schema or lockfile regeneration
