### PR TITLE
Use AsyncIterableProducer for document diff changes

### DIFF
--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -5,7 +5,7 @@
 
 import type * as vscode from 'vscode';
 import { CancellationTokenSource } from '../../../base/common/cancellation.js';
-import { AsyncIterableObject, raceCancellationError } from '../../../base/common/async.js';
+import { AsyncIterableProducer, raceCancellationError } from '../../../base/common/async.js';
 import * as errors from '../../../base/common/errors.js';
 import { Emitter, Event } from '../../../base/common/event.js';
 import { combinedDisposable } from '../../../base/common/lifecycle.js';
@@ -1171,7 +1171,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 				if (token?.isCancellationRequested) {
 					const error = new errors.CancellationError();
 					return {
-						changes: AsyncIterableObject.EMPTY,
+						changes: AsyncIterableProducer.EMPTY,
 						complete: Promise.reject(error),
 					};
 				}
@@ -1203,7 +1203,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 				// In the future, we may want to stream changes incrementally as they are computed
 				// (e.g. by having the worker yield partial results).
 				return {
-					changes: new AsyncIterableObject<vscode.TextDiffChange>(async emitter => {
+					changes: new AsyncIterableProducer<vscode.TextDiffChange>(async emitter => {
 						const result = await mappedPromise;
 						emitter.emitMany(result.changes.map(mapChange));
 					}),


### PR DESCRIPTION
Part of #256854

This migrates the `getTextDiff` changes iterable from `AsyncIterableObject` to `AsyncIterableProducer`.

The document diff API currently computes all changes once and emits them once, so the iterable does not need to retain emitted values for later re-iteration. Using `AsyncIterableProducer` avoids keeping those emitted values in the async iterable implementation.

Validation:
- `nvm use && npm run compile-check-ts-native`

Notes:
- Dependency installation requires Node 22. After switching to Node 22.22.1, the main TypeScript compile check completed successfully.
- Full `npm install` stopped while installing `remote/node_modules` because the local machine ran out of disk space (`ENOSPC`), but this change only touches `src/` and the targeted compile check passed.