### PR TITLE
fix(diffEditor): guard against null model in diffEditorHelper

### DIFF
--- a/src/vs/workbench/contrib/codeEditor/browser/diffEditorHelper.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/diffEditorHelper.ts
@@ -45,9 +45,12 @@ class DiffEditorHelperContribution extends Disposable implements IDiffEditorCont
 						localize('hintWhitespace', "Show Whitespace Differences"),
 						null
 					));
-					store.add(helperWidget.onClick(() => {
-						this._textResourceConfigurationService.updateValue(this._diffEditor.getModel()!.modified.uri, 'diffEditor.ignoreTrimWhitespace', false);
-					}));
+				store.add(helperWidget.onClick(() => {
+					const model = this._diffEditor.getModel();
+					if (model) {
+						this._textResourceConfigurationService.updateValue(model.modified.uri, 'diffEditor.ignoreTrimWhitespace', false);
+					}
+				}));
 					helperWidget.render();
 				}
 			}));
@@ -62,7 +65,10 @@ class DiffEditorHelperContribution extends Disposable implements IDiffEditorCont
 						[{
 							label: localize('removeTimeout', "Remove Limit"),
 							run: () => {
-								this._textResourceConfigurationService.updateValue(this._diffEditor.getModel()!.modified.uri, 'diffEditor.maxComputationTime', 0);
+								const model = this._diffEditor.getModel();
+								if (model) {
+									this._textResourceConfigurationService.updateValue(model.modified.uri, 'diffEditor.maxComputationTime', 0);
+								}
 							}
 						}],
 						{}


### PR DESCRIPTION
## Related Issue
Closes #318310

## Summary
The diffEditorHelper's click handlers for "Remove Limit" and "Show Whitespace Differences" accessed `getModel()` with a non-null assertion (`!`), but the model can be null if the diff editor model is disposed or not yet set. This caused `Cannot read properties of null (reading 'modified')` errors when users clicked these buttons.

## Changes
- Added null checks before accessing `model.modified.uri` in both click handlers
- The configuration update is skipped if no model is available

## Verification Evidence
- `npm run compile-check-ts-native`: PASSED (no TypeScript errors)
- No additional tests needed (defensive null guard)

## Community Rules Review
- CONTRIBUTING.md reviewed; it points code contributors to the VS Code wiki.
- Base branch: main

## Checklist
- [x] Base branch is main
- [x] No unauthorized version bump
- [x] All feasible verification checks attempted
- [x] No unintended schema or lockfile changes
