### PR TITLE
fix(notifications): show close button after progress notification completes

### DIFF
--- a/src/vs/workbench/browser/parts/notifications/notificationsViewer.ts
+++ b/src/vs/workbench/browser/parts/notifications/notificationsViewer.ts
@@ -412,6 +412,7 @@ export class NotificationTemplateRenderer extends Disposable {
 					break;
 				case NotificationViewItemContentChangeKind.PROGRESS:
 					this.renderProgress(notification);
+					this.setInput(notification);
 					break;
 				case NotificationViewItemContentChangeKind.MESSAGE:
 					this.renderMessage(notification, messageCustomHover);

--- a/src/vs/workbench/common/notifications.ts
+++ b/src/vs/workbench/common/notifications.ts
@@ -617,7 +617,7 @@ export class NotificationViewItem extends Disposable implements INotificationVie
 	}
 
 	get hasProgress(): boolean {
-		return !!this._progress;
+		return !!this._progress && !this._progress.state.done;
 	}
 
 	get progress(): INotificationViewItemProgress {


### PR DESCRIPTION
## Related Issue
Closes #314963

## Summary
After a progress notification completes (`progress.done()` is called), the notification's `hasProgress` getter still returned `true` because `_progress` was never nulled out. This caused three broken behaviors:

1. The close (×) button was hidden on the notification row
2. The "Clear All Notifications" button was disabled
3. The `notifications.clearAll` command silently skipped the notification

## Changes
- **notifications.ts**: Fixed `hasProgress` getter to check `!!this._progress && !this._progress.state.done` (matching the existing `sticky` getter logic)
- **notificationsViewer.ts**: Added `this.setInput(notification)` call on `PROGRESS` content change events so the toolbar actions (including close button visibility) are re-rendered when progress completes

## Verification Evidence
- `npm run compile-check-ts-native`: PASSED (no TypeScript errors)

## Checklist
- [x] Base branch is main
- [x] No unauthorized version bump
- [x] All feasible verification checks attempted
- [x] No unintended schema or lockfile changes
