### PR TITLE
fix(terminal): guard against disposed link detector adapter

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkDetectorAdapter.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkDetectorAdapter.ts
@@ -103,6 +103,9 @@ export class TerminalLinkDetectorAdapter extends Disposable implements ILinkProv
 			l.text = l.text.slice(0, -1);
 			l.bufferRange.end.x--;
 		}
+		if (this._store.isDisposed) {
+			throw new Error('Terminal link detector adapter has been disposed');
+		}
 		return this._instantiationService.createInstance(TerminalLink,
 			this._detector.xterm,
 			l.bufferRange,


### PR DESCRIPTION
## Related Issue
Closes #316439

## Summary
TerminalLinkDetectorAdapter._createTerminalLink was calling createInstance on a disposed InstantiationService when the terminal had been closed while link detection was in progress, causing unhandled "InstantiationService has been disposed" errors.

## Changes
- Add disposed check (`this._store.isDisposed`) before the `createInstance` call in `_createTerminalLink`
- Throw a descriptive error instead of letting the unhandled InstantiationService error propagate

## Verification Evidence
- `npm run compile-check-ts-native`: PASSED (no TypeScript errors)

## Checklist
- [x] Base branch is main
- [x] No unauthorized version bump
- [x] All feasible verification checks attempted
- [x] No unintended schema or lockfile changes
