### PR TITLE
fix(breadcrumbs): handle missing tree element in outline picker

### DIFF
--- a/src/vs/workbench/browser/parts/editor/breadcrumbsPicker.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbsPicker.ts
@@ -493,8 +493,12 @@ export class BreadcrumbsOutlinePicker extends BreadcrumbsPicker<IOutline<unknown
 
 		tree.setInput(input.outline);
 		if (input.element !== input.outline) {
-			tree.reveal(input.element, 0.5);
-			tree.setFocus([input.element], this._fakeEvent);
+			try {
+				tree.reveal(input.element, 0.5);
+				tree.setFocus([input.element], this._fakeEvent);
+			} catch {
+				// element may not be in tree yet
+			}
 		}
 		tree.domFocus();
 


### PR DESCRIPTION
## Related Issue
Closes #316635

## Summary
BreadcrumbsOutlinePicker._setInput could throw TreeError "Tree element not found" when calling tree.reveal/tree.setFocus on an element that was not yet present in the tree.

## Changes
- Wrap tree.reveal and tree.setFocus calls in try-catch to gracefully handle missing elements

## Verification Evidence
- `npm run compile-check-ts-native`: PASSED (no TypeScript errors)

## Checklist
- [x] Base branch is main
- [x] No unauthorized version bump
- [x] All feasible verification checks attempted
- [x] No unintended schema or lockfile changes
