### PR TITLE
fix(environment): add setter for editSessionId

### DIFF
--- a/src/vs/platform/environment/common/environmentService.ts
+++ b/src/vs/platform/environment/common/environmentService.ts
@@ -282,6 +282,7 @@ export abstract class AbstractNativeEnvironmentService implements INativeEnviron
 	}
 
 	get editSessionId(): string | undefined { return this.args['editSessionId']; }
+	set editSessionId(value: string | undefined) { this.args['editSessionId'] = value; }
 
 	get exportPolicyData(): string | undefined {
 		return this.args['export-policy-data'];

--- a/src/vs/workbench/services/environment/browser/environmentService.ts
+++ b/src/vs/workbench/services/environment/browser/environmentService.ts
@@ -266,8 +266,10 @@ export class BrowserWorkbenchEnvironmentService implements IBrowserWorkbenchEnvi
 	@memoize
 	get profile(): string | undefined { return this.payload?.get('profile'); }
 
+	private _editSessionId: string | undefined;
 	@memoize
-	get editSessionId(): string | undefined { return this.options.editSessionId; }
+	get editSessionId(): string | undefined { return this._editSessionId ?? this.options.editSessionId; }
+	set editSessionId(value: string | undefined) { this._editSessionId = value; }
 
 	private payload: Map<string, string> | undefined;
 


### PR DESCRIPTION
## Related Issue
Closes #316633

## Summary
The `editSessionId` property was defined as a getter only in both native and browser environment services. Code in `editSessions.contribution.ts` was assigning to it (to clear the ID after resume), causing "Cannot set property editSessionId which has only a getter" errors.

## Changes
- Add setter to `AbstractNativeEnvironmentService` (native)
- Add setter to `BrowserEnvironmentService` with private backing field (web)

## Verification Evidence
- `npm run compile-check-ts-native`: PASSED (no TypeScript errors)

## Checklist
- [x] Base branch is main
- [x] No unauthorized version bump
- [x] All feasible verification checks attempted
- [x] No unintended schema or lockfile changes
