### PR TITLE
fix(breadcrumbs): show info when no symbols to copy

### DIFF
--- a/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
@@ -24,6 +24,7 @@ import { Categories } from '../../../../platform/action/common/actionCommonCateg
 import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
+import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { ContextKeyExpr, IContextKey, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { IContextViewService } from '../../../../platform/contextview/browser/contextView.js';
 import { fillInSymbolsDragData, LocalSelectionTransfer } from '../../../../platform/dnd/browser/dnd.js';
@@ -976,6 +977,7 @@ registerAction2(class CopyBreadcrumbPath extends Action2 {
 		const clipboardService = accessor.get(IClipboardService);
 		const configurationService = accessor.get(IConfigurationService);
 		const outlineService = accessor.get(IOutlineService);
+		const notificationService = accessor.get(INotificationService);
 
 		if (!groups.activeGroup.activeEditorPane) {
 			return;
@@ -992,6 +994,7 @@ registerAction2(class CopyBreadcrumbPath extends Action2 {
 		outline.dispose();
 
 		if (labels.length === 0) {
+			notificationService.info(localize('cmd.copyPath.noSymbols', "No breadcrumb symbols to copy."));
 			return;
 		}
 


### PR DESCRIPTION
## Related Issue
Closes #286240

## Summary
The 'Copy Breadcrumbs Path' command silently did nothing when there were no breadcrumb symbols to copy (e.g. when not focused on a symbol or in files without symbol support). This was confusing because users couldn't tell if the command worked or not.

## Changes
- Show an info notification when there are no breadcrumb symbols to copy

## Verification Evidence
- `npm run compile-check-ts-native`: PASSED (no TypeScript errors)

## Checklist
- [x] Base branch is main
- [x] No unauthorized version bump
- [x] All feasible verification checks attempted
- [x] No unintended schema or lockfile changes
