### PR TITLE
Add 'developer-tools' icon and update codicons version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@microsoft/mxc-sdk": "0.2.0",
         "@parcel/watcher": "^2.5.6",
         "@types/semver": "^7.5.8",
-        "@vscode/codicons": "^0.0.46-12",
+        "@vscode/codicons": "^0.0.46-13",
         "@vscode/copilot-api": "^0.4.0",
         "@vscode/deviceid": "^0.1.1",
         "@vscode/diff": "^0.0.2-0",
@@ -3615,9 +3615,9 @@
       }
     },
     "node_modules/@vscode/codicons": {
-      "version": "0.0.46-12",
-      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-12.tgz",
-      "integrity": "sha512-Nl8QKQiBTYmkjdVrHUYrvW7LIYz0otMCGSbgyMYj4G8o+Kq+IvMh+pTR+SnymXGs4GA3AzFWI0+K2mGZVyJMhg==",
+      "version": "0.0.46-13",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-13.tgz",
+      "integrity": "sha512-2nlRwaYDGiP19+GRPuoOx6DMDLBc35BsiLjCxKZPTNtHnS6rNpdm/Apa4HGt5+mFPB43nfxL2rcbAczso9KxQQ==",
       "license": "CC-BY-4.0"
     },
     "node_modules/@vscode/component-explorer": {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@microsoft/mxc-sdk": "0.2.0",
     "@parcel/watcher": "^2.5.6",
     "@types/semver": "^7.5.8",
-    "@vscode/codicons": "^0.0.46-12",
+    "@vscode/codicons": "^0.0.46-13",
     "@vscode/copilot-api": "^0.4.0",
     "@vscode/deviceid": "^0.1.1",
     "@vscode/diff": "^0.0.2-0",

--- a/remote/web/package-lock.json
+++ b/remote/web/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
-        "@vscode/codicons": "^0.0.46-12",
+        "@vscode/codicons": "^0.0.46-13",
         "@vscode/iconv-lite-umd": "0.7.1",
         "@vscode/tree-sitter-wasm": "^0.3.1",
         "@vscode/vscode-languagedetection": "1.0.23",
@@ -73,9 +73,9 @@
       "integrity": "sha512-n1VPsljTSkthsAFYdiWfC+DKzK2WwcRp83Y1YAqdX552BstvsDjft9YXppjUzp11BPsapDoO1LDgrDB0XVsfNQ=="
     },
     "node_modules/@vscode/codicons": {
-      "version": "0.0.46-12",
-      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-12.tgz",
-      "integrity": "sha512-Nl8QKQiBTYmkjdVrHUYrvW7LIYz0otMCGSbgyMYj4G8o+Kq+IvMh+pTR+SnymXGs4GA3AzFWI0+K2mGZVyJMhg==",
+      "version": "0.0.46-13",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-13.tgz",
+      "integrity": "sha512-2nlRwaYDGiP19+GRPuoOx6DMDLBc35BsiLjCxKZPTNtHnS6rNpdm/Apa4HGt5+mFPB43nfxL2rcbAczso9KxQQ==",
       "license": "CC-BY-4.0"
     },
     "node_modules/@vscode/iconv-lite-umd": {

--- a/remote/web/package.json
+++ b/remote/web/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",
-    "@vscode/codicons": "^0.0.46-12",
+    "@vscode/codicons": "^0.0.46-13",
     "@vscode/iconv-lite-umd": "0.7.1",
     "@vscode/tree-sitter-wasm": "^0.3.1",
     "@vscode/vscode-languagedetection": "1.0.23",

--- a/src/vs/base/common/codiconsLibrary.ts
+++ b/src/vs/base/common/codiconsLibrary.ts
@@ -713,4 +713,5 @@ export const codiconsLibrary = {
 	terminalCompact: register('terminal-compact', 0xecbb),
 	vmPending: register('vm-pending', 0xecbc),
 	worktreeCompact: register('worktree-compact', 0xecbd),
+	developerTools: register('developer-tools', 0xecbe),
 } as const;


### PR DESCRIPTION
Introduce a new 'developer-tools' icon to the codicons library and update the codicons package to version 0.0.46-13 across relevant files. This enhances the icon set available for developers.

