### PR TITLE
Fix: cross-file inline edit list never disposed (handleListEndOfLifetime not fired)

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
@@ -1203,7 +1203,8 @@ export class InlineCompletionsModel extends Disposable {
 	 * Used for cross-file inline edits.
 	 */
 	public transplantCompletion(item: InlineSuggestionItem): void {
-		item.addRef();
+		// No explicit addRef needed: `seedWithCompletion` creates a new `InlineCompletionsState`
+		// which calls `addRef` on every item it holds and pairs it with `removeRef` in dispose.
 		transaction(tx => {
 			this._source.seedWithCompletion(item, tx);
 			this._isActive.set(true, tx);

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/provideInlineCompletions.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/provideInlineCompletions.ts
@@ -5,32 +5,32 @@
 
 import { assertNever } from '../../../../../base/common/assert.js';
 import { AsyncIterableProducer } from '../../../../../base/common/async.js';
+import { CachedFunction } from '../../../../../base/common/cache.js';
 import { CancellationToken, CancellationTokenSource } from '../../../../../base/common/cancellation.js';
-import { BugIndicatingError, onUnexpectedExternalError } from '../../../../../base/common/errors.js';
+import { groupByMap } from '../../../../../base/common/collections.js';
+import { BugIndicatingError, onUnexpectedError, onUnexpectedExternalError } from '../../../../../base/common/errors.js';
 import { Disposable, IDisposable } from '../../../../../base/common/lifecycle.js';
+import { isDefined } from '../../../../../base/common/types.js';
+import { URI } from '../../../../../base/common/uri.js';
 import { prefixedUuid } from '../../../../../base/common/uuid.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { ISingleEditOperation } from '../../../../common/core/editOperation.js';
 import { StringReplacement } from '../../../../common/core/edits/stringEdit.js';
-import { OffsetRange } from '../../../../common/core/ranges/offsetRange.js';
+import { TextReplacement } from '../../../../common/core/edits/textEdit.js';
 import { Position } from '../../../../common/core/position.js';
 import { Range } from '../../../../common/core/range.js';
-import { TextReplacement } from '../../../../common/core/edits/textEdit.js';
-import { InlineCompletionEndOfLifeReason, InlineCompletionEndOfLifeReasonKind, InlineCompletion, InlineCompletionContext, InlineCompletions, InlineCompletionsProvider, PartialAcceptInfo, InlineCompletionsDisposeReason, LifetimeSummary, ProviderId, IInlineCompletionHint, InlineCompletionTriggerKind } from '../../../../common/languages.js';
+import { OffsetRange } from '../../../../common/core/ranges/offsetRange.js';
+import { IInlineCompletionHint, InlineCompletion, InlineCompletionContext, InlineCompletionEndOfLifeReason, InlineCompletionEndOfLifeReasonKind, InlineCompletions, InlineCompletionsDisposeReason, InlineCompletionsProvider, InlineCompletionTriggerKind, LifetimeSummary, PartialAcceptInfo, ProviderId } from '../../../../common/languages.js';
 import { ILanguageConfigurationService } from '../../../../common/languages/languageConfigurationRegistry.js';
 import { ITextModel } from '../../../../common/model.js';
 import { fixBracketsInLine } from '../../../../common/model/bracketPairsTextModelPart/fixBrackets.js';
+import { EditDeltaInfo } from '../../../../common/textModelEditSource.js';
 import { SnippetParser, Text } from '../../../snippet/browser/snippetParser.js';
 import { ErrorResult, getReadonlyEmptyArray } from '../utils.js';
-import { groupByMap } from '../../../../../base/common/collections.js';
-import { DirectedGraph } from './graph.js';
-import { CachedFunction } from '../../../../../base/common/cache.js';
 import { InlineCompletionViewData, InlineCompletionViewKind } from '../view/inlineEdits/inlineEditsViewInterface.js';
-import { isDefined } from '../../../../../base/common/types.js';
-import { inlineCompletionIsVisible } from './inlineCompletionIsVisible.js';
-import { EditDeltaInfo } from '../../../../common/textModelEditSource.js';
-import { URI } from '../../../../../base/common/uri.js';
 import { InlineSuggestionEditKind } from './editKind.js';
+import { DirectedGraph } from './graph.js';
+import { inlineCompletionIsVisible } from './inlineCompletionIsVisible.js';
 import { InlineSuggestAlternativeAction } from './InlineSuggestAlternativeAction.js';
 
 export type InlineCompletionContextWithoutUuid = Omit<InlineCompletionContext, 'requestUuid'>;
@@ -659,6 +659,12 @@ export class InlineSuggestionList {
 				item.reportEndOfLife();
 			}
 			this.provider.disposeInlineCompletions(this.inlineSuggestions, reason);
+		} else if (this.refCount < 0) {
+			// Invariant: every addRef must be paired with exactly one removeRef.
+			// Going negative means a removeRef without a matching addRef somewhere.
+			onUnexpectedError(new BugIndicatingError(
+				`InlineSuggestionList (provider=${this.provider.providerId?.toString()}) refCount went negative (${this.refCount}) — more removeRef than addRef calls.`
+			));
 		}
 	}
 }


### PR DESCRIPTION
Fixes #318341

## Summary

`InlineSuggestionList` for a cross-file inline edit was never disposed after the user accepted it, because `InlineCompletionsModel.transplantCompletion` held one extra ref it never released. As a side effect, the extension-host `handleListEndOfLifetime` callback never fired on the producing provider, and any end-of-life telemetry the extension sends from that callback was silently dropped for every cross-file inline edit.

This PR removes the unpaired `addRef` and adds a cheap always-on invariant so a refcount that goes negative is surfaced via `onUnexpectedError`.

## The bug

Cross-file accept flow:

1. User accepts an inline edit whose `uri` points to a different document.
2. `InlineCompletionsModel.accept` opens the target editor via `ICodeEditorService.openCodeEditor`.
3. It calls the target model's `transplantCompletion(item)` to seed the item there.

`transplantCompletion` was:

```ts
public transplantCompletion(item: InlineSuggestionItem): void {
    item.addRef();                                  // ← unpaired
    transaction(tx => {
        this._source.seedWithCompletion(item, tx);  // already takes its own ref
        this._isActive.set(true, tx);
        this._inAcceptFlow.set(true, tx);
        this.dontRefetchSignal.trigger(tx);
    });
}
```

But `seedWithCompletion` already takes the necessary ref — it constructs a new `InlineCompletionsState([item], …)` whose ctor calls `inlineCompletion.addRef()` and pairs it with `removeRef()` in its dispose. The explicit `item.addRef()` had no matching `removeRef()` anywhere, leaking one ref on every cross-file accept.

`InlineSuggestionList.removeRef` only calls `provider.disposeInlineCompletions` when refCount reaches 0, so for cross-file edits it never did. On the extension-host side, `MainThreadLanguageFeatures.disposeInlineCompletions` is the trigger for `extHostLanguageFeatures.disposeCompletions`, which in turn calls `provider.handleListEndOfLifetime` — so all of that never ran for cross-file edits.

This was caught while investigating missing `provideInlineEdit` telemetry for cross-file NES in `extensions/copilot`, which depends on `handleListEndOfLifetime` to flush its per-suggestion builder.

## Investigation summary

This was caught by adding temporary instrumentation to `InlineSuggestionList`:
- per-instance id + alive-list registry
- captured `new Error().stack` on every `addRef`
- a `globalThis.__inlineCompletionListDump()` hook returning per-list `{ id, provider, requestUuid, refCount, ageMs, addRefStacks }`
- a `setTimeout` watchdog firing `onUnexpectedError` if a list remained alive past a threshold

Repro: edit `math.ts` to add an exported symbol used by `example.ts`, accept the resulting NES jump from `math.ts` to `example.ts`, then call `__inlineCompletionListDump()` from DevTools. Result: one leaked list per cross-file accept with `refCount=1` indefinitely; the dump showed an unpaired `addRef` stack pointing at `InlineCompletionsModel.transplantCompletion`.

After the fix, the same repro shows `__inlineCompletionListDump()` returning `[]` after the accept, and the extension's end-of-life telemetry fires as expected.

The instrumentation itself is not in this PR — only the cheap negative-refCount invariant is kept for ongoing safety.

## Changes

- `inlineCompletionsModel.ts`: remove the unpaired `item.addRef()` in `transplantCompletion`. Add a short comment explaining who already owns the ref (`seedWithCompletion` → `new InlineCompletionsState` ctor).
- `provideInlineCompletions.ts`: in `InlineSuggestionList.removeRef`, fire `onUnexpectedError(new BugIndicatingError(...))` if the count goes negative. This catches the inverse class of mistake — a `removeRef` without a matching `addRef` — at the same cost as the existing `=== 0` check.

## Risk

Very low. The removed line was redundant: tested manually against the original repro, and the new negative-refCount assertion did not fire during normal use (same-document and cross-file).

## Manual test

- Open a file `example.ts` importing a non-existent symbol from `./math`.
- In `math.ts`, add the missing export so NES suggests a cross-file edit.
- Accept the NES.
- Trigger any additional inline edits to give the model a chance to dispose stale state.
- Confirm extension's `handleListEndOfLifetime` fires (e.g. by logging in the extension or watching its telemetry).

## Notes for reviewers

- `transplantCompletion` was introduced in #290036 by @hediet (commit `37ac613`). The `item.addRef()` predates this fix and has been the source of the leak since that commit.
- I considered making `InlineCompletionsState` not take the ref so `transplantCompletion`'s explicit `addRef` would become correct, but `InlineCompletionsState` is used from many call sites and its current semantics — "the state owns refs on the items it holds" — is the cleaner invariant. The fix keeps that and drops the redundant ref in the one caller that double-counted.
- An end-to-end unit test that exercises `transplantCompletion` would be useful but requires additional test plumbing (second model + mocked `ICodeEditorService.openCodeEditor`); leaving that as a follow-up.