### PR TITLE
Add Cmd+Click navigation for tsconfig lib entries

### DIFF
--- a/extensions/typescript-language-features/src/extension.browser.ts
+++ b/extensions/typescript-language-features/src/extension.browser.ts
@@ -94,7 +94,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
 	// context.subscriptions.push(task.register(lazyClientHost.map(x => x.serviceClient)));
 
 	import('./languageFeatures/tsconfig').then(module => {
-		context.subscriptions.push(module.register());
+		context.subscriptions.push(module.register(versionProvider, context.workspaceState));
 	});
 
 	context.subscriptions.push(lazilyActivateClient(lazyClientHost, pluginManager, activeJsTsEditorTracker, async () => {

--- a/extensions/typescript-language-features/src/extension.ts
+++ b/extensions/typescript-language-features/src/extension.ts
@@ -55,7 +55,7 @@ export function activate(
 
 	// Register features that work in both TSGO and non-TSGO modes
 	import('./languageFeatures/tsconfig').then(module => {
-		context.subscriptions.push(module.register());
+		context.subscriptions.push(module.register(versionProvider, context.workspaceState));
 	});
 
 	// Conditionally register features based on whether TSGO is enabled

--- a/extensions/typescript-language-features/src/languageFeatures/tsconfig.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/tsconfig.ts
@@ -4,9 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as jsonc from 'jsonc-parser';
-import { isAbsolute, posix } from 'path';
+import { dirname, isAbsolute, join, posix } from 'path';
 import * as vscode from 'vscode';
 import { Utils } from 'vscode-uri';
+import { useWorkspaceTsdkStorageKey } from '../tsServer/versionManager';
+import { ITypeScriptVersionProvider, TypeScriptVersion } from '../tsServer/versionProvider';
 import { coalesce } from '../utils/arrays';
 import { exists, looksLikeAbsoluteWindowsPath } from '../utils/fs';
 
@@ -20,7 +22,8 @@ const openExtendsLinkCommandId = '_typescript.openExtendsLink';
 
 enum TsConfigLinkType {
 	Extends,
-	References
+	References,
+	Lib,
 }
 
 type OpenExtendsLinkCommandArgs = {
@@ -44,8 +47,15 @@ class TsconfigLinkProvider implements vscode.DocumentLinkProvider {
 		return coalesce([
 			this.getExtendsLink(document, root),
 			...this.getFilesLinks(document, root),
-			...this.getReferencesLinks(document, root)
+			...this.getReferencesLinks(document, root),
+			...this.getLibLinks(document, root)
 		]);
+	}
+
+	private getLibLinks(document: vscode.TextDocument, root: jsonc.Node) {
+		return mapChildren(
+			jsonc.findNodeAtLocation(root, ['compilerOptions', 'lib']),
+			child => this.tryCreateTsConfigLink(document, child, TsConfigLinkType.Lib));
 	}
 
 	private getExtendsLink(document: vscode.TextDocument, root: jsonc.Node): vscode.DocumentLink | undefined {
@@ -190,7 +200,74 @@ async function getTsconfigPath(baseDirUri: vscode.Uri, pathValue: string, linkTy
 	]);
 }
 
-export function register() {
+function libFileUri(versionPath: string, fileName: string): vscode.Uri {
+	if (versionPath.includes('://')) {
+		// Browser: bundled tsserver path is a URI string
+		return vscode.Uri.joinPath(vscode.Uri.parse(versionPath), '..', fileName);
+	}
+
+	// Electron: fs path to tsserver.js
+	return vscode.Uri.file(join(dirname(versionPath), fileName));
+}
+
+function getActiveVersion(versionProvider: ITypeScriptVersionProvider, workspaceState: vscode.Memento): TypeScriptVersion | undefined {
+	const useWorkspaceTsdk = workspaceState.get<boolean>(useWorkspaceTsdkStorageKey, false);
+
+	if (useWorkspaceTsdk && vscode.workspace.isTrusted) {
+		const local = versionProvider.localVersion;
+
+		if (local) {
+			return local;
+		}
+	}
+
+	try {
+		return versionProvider.defaultVersion;
+	} catch {
+		return undefined;
+	}
+}
+
+async function resolveLibPath(versionProvider: ITypeScriptVersionProvider, workspaceState: vscode.Memento, libValue: string): Promise<vscode.Uri | undefined> {
+	const fileName = `lib.${libValue.toLowerCase()}.d.ts`;
+
+	// Priority: the version the TS service is actively using, then any
+	// other locally available versions, then the bundled TS as a final fallback.
+	const versions: TypeScriptVersion[] = [];
+	const active = getActiveVersion(versionProvider, workspaceState);
+
+	if (active) {
+		versions.push(active);
+	}
+
+	versions.push(...versionProvider.localVersions);
+
+	try {
+		versions.push(versionProvider.bundledVersion);
+	} catch {
+		// bundled TS missing; nothing more we can try
+	}
+
+	const seen = new Set<string>();
+
+	for (const version of versions) {
+		if (seen.has(version.path)) {
+			continue;
+		}
+
+		seen.add(version.path);
+
+		const candidate = libFileUri(version.path, fileName);
+
+		if (await exists(candidate)) {
+			return candidate;
+		}
+	}
+
+	return undefined;
+}
+
+export function register(versionProvider: ITypeScriptVersionProvider, workspaceState: vscode.Memento) {
 	const patterns: vscode.GlobPattern[] = [
 		'**/[jt]sconfig.json',
 		'**/[jt]sconfig.*.json',
@@ -204,13 +281,18 @@ export function register() {
 
 	return vscode.Disposable.from(
 		vscode.commands.registerCommand(openExtendsLinkCommandId, async ({ resourceUri, extendsValue, linkType }: OpenExtendsLinkCommandArgs) => {
-			const tsconfigPath = await getTsconfigPath(Utils.dirname(vscode.Uri.from(resourceUri)), extendsValue, linkType);
-			if (tsconfigPath === undefined) {
+			const baseDirUri = Utils.dirname(vscode.Uri.from(resourceUri));
+			const target = linkType === TsConfigLinkType.Lib
+				? await resolveLibPath(versionProvider, workspaceState, extendsValue)
+				: await getTsconfigPath(baseDirUri, extendsValue, linkType);
+
+			if (target === undefined) {
 				vscode.window.showErrorMessage(vscode.l10n.t("Failed to resolve {0} as module", extendsValue));
 				return;
 			}
+
 			// Will suggest to create a .json variant if it doesn't exist yet (but only for relative paths)
-			await vscode.commands.executeCommand('vscode.open', tsconfigPath);
+			await vscode.commands.executeCommand('vscode.open', target);
 		}),
 		vscode.languages.registerDocumentLinkProvider(selector, new TsconfigLinkProvider()),
 	);

--- a/extensions/typescript-language-features/src/languageFeatures/tsconfig.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/tsconfig.ts
@@ -28,7 +28,7 @@ enum TsConfigLinkType {
 
 type OpenExtendsLinkCommandArgs = {
 	readonly resourceUri: vscode.Uri;
-	readonly extendsValue: string;
+	readonly pathValue: string;
 	readonly linkType: TsConfigLinkType;
 };
 
@@ -79,7 +79,7 @@ class TsconfigLinkProvider implements vscode.DocumentLinkProvider {
 
 		const args: OpenExtendsLinkCommandArgs = {
 			resourceUri: { ...document.uri.toJSON(), $mid: undefined },
-			extendsValue: node.value,
+			pathValue: node.value,
 			linkType
 		};
 
@@ -200,8 +200,14 @@ async function getTsconfigPath(baseDirUri: vscode.Uri, pathValue: string, linkTy
 	]);
 }
 
+// Matches the start of a URI scheme (e.g. `vscode-file:`, `https:`), used to
+// tell apart `vscode.Uri.toString()` results from filesystem paths. Excludes
+// Windows drive paths like `C:\…`, which also start with a letter + colon.
+const URI_SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
+const WINDOWS_DRIVE_RE = /^[a-zA-Z]:[\\/]/;
+
 function libFileUri(versionPath: string, fileName: string): vscode.Uri {
-	if (versionPath.includes('://')) {
+	if (URI_SCHEME_RE.test(versionPath) && !WINDOWS_DRIVE_RE.test(versionPath)) {
 		// Browser: bundled tsserver path is a URI string
 		return vscode.Uri.joinPath(vscode.Uri.parse(versionPath), '..', fileName);
 	}
@@ -280,14 +286,17 @@ export function register(versionProvider: ITypeScriptVersionProvider, workspaceS
 			.flat();
 
 	return vscode.Disposable.from(
-		vscode.commands.registerCommand(openExtendsLinkCommandId, async ({ resourceUri, extendsValue, linkType }: OpenExtendsLinkCommandArgs) => {
+		vscode.commands.registerCommand(openExtendsLinkCommandId, async ({ resourceUri, pathValue, linkType }: OpenExtendsLinkCommandArgs) => {
 			const baseDirUri = Utils.dirname(vscode.Uri.from(resourceUri));
 			const target = linkType === TsConfigLinkType.Lib
-				? await resolveLibPath(versionProvider, workspaceState, extendsValue)
-				: await getTsconfigPath(baseDirUri, extendsValue, linkType);
+				? await resolveLibPath(versionProvider, workspaceState, pathValue)
+				: await getTsconfigPath(baseDirUri, pathValue, linkType);
 
 			if (target === undefined) {
-				vscode.window.showErrorMessage(vscode.l10n.t("Failed to resolve {0} as module", extendsValue));
+				const message = linkType === TsConfigLinkType.Lib
+					? vscode.l10n.t("Failed to resolve TypeScript lib {0}", pathValue)
+					: vscode.l10n.t("Failed to resolve {0} as module", pathValue);
+				vscode.window.showErrorMessage(message);
 				return;
 			}
 

--- a/extensions/typescript-language-features/src/tsServer/versionManager.ts
+++ b/extensions/typescript-language-features/src/tsServer/versionManager.ts
@@ -12,7 +12,7 @@ import { Disposable } from '../utils/dispose';
 import { ITypeScriptVersionProvider, TypeScriptVersion } from './versionProvider';
 
 
-const useWorkspaceTsdkStorageKey = 'typescript.useWorkspaceTsdk';
+export const useWorkspaceTsdkStorageKey = 'typescript.useWorkspaceTsdk';
 const suppressPromptWorkspaceTsdkStorageKey = 'typescript.suppressPromptWorkspaceTsdk';
 
 interface QuickPickItem extends vscode.QuickPickItem {


### PR DESCRIPTION
## Description

Adds document links for entries in `compilerOptions.lib[]` inside `tsconfig.json` / `jsconfig.json`, so that Cmd+Click on a value like `"DOM"` or `"ES2020"` opens the corresponding `lib.<name>.d.ts` file. This mirrors the existing behavior for `extends`, `files`, and `references`.

The target lib file is resolved from the same TypeScript version the language service is currently using:

1. The active version (honors `typescript.tsdk` and the "Use Workspace Version" picker selection — reads the same `typescript.useWorkspaceTsdk` workspace state the version manager writes).
2. Any other locally available TypeScript install (workspace `node_modules/typescript`, configured tsdk).
3. The bundled TypeScript shipped with VS Code.

Implementation reuses the existing `_typescript.openExtendsLink` command and `TsConfigLinkType` enum (new `Lib` variant) rather than introducing a parallel command + args type.

## How to test

1. Open a `tsconfig.json` containing:
   ```json
   {
     "compilerOptions": {
       "lib": ["DOM", "DOM.Iterable", "ESNext"]
     }
   }
   ```
2. Cmd+Click (or Ctrl+Click on Linux/Windows) on any of the lib entries → the corresponding `lib.dom.d.ts`, `lib.dom.iterable.d.ts`, `lib.esnext.d.ts` opens.
3. Toggle "TypeScript: Select TypeScript Version…" between bundled and workspace versions → Cmd+Click target should follow the active selection.
4. In a workspace with no local TypeScript install, links should still resolve to the bundled VS Code TypeScript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)