### PR TITLE
Bump vendored dompurify from 3.2.7 to 3.4.5

### DIFF
--- a/ThirdPartyNotices.txt
+++ b/ThirdPartyNotices.txt
@@ -734,7 +734,7 @@ Title to copyright in this work will at all times remain with copyright holders.
 
 ---------------------------------------------------------
 
-dompurify 3.2.7 - Apache 2.0
+dompurify 3.4.5 - Apache 2.0
 https://github.com/cure53/DOMPurify
 
 Apache License

--- a/src/vs/base/browser/dompurify/cgmanifest.json
+++ b/src/vs/base/browser/dompurify/cgmanifest.json
@@ -6,12 +6,12 @@
 				"git": {
 					"name": "dompurify",
 					"repositoryUrl": "https://github.com/cure53/DOMPurify",
-					"commitHash": "eaa0bdb26a1d0164af587d9059b98269008faece",
-					"tag": "3.2.7"
+					"commitHash": "011b0c78f2a0f57ee54f5fcccb697a46ca6e63ea",
+					"tag": "3.4.5"
 				}
 			},
 			"license": "Apache 2.0",
-			"version": "3.2.7"
+			"version": "3.4.5"
 		}
 	],
 	"version": 1

--- a/src/vs/base/browser/dompurify/dompurify.d.ts
+++ b/src/vs/base/browser/dompurify/dompurify.d.ts
@@ -1,410 +1,418 @@
-/*! @license DOMPurify 3.2.7 | (c) Cure53 and other contributors | Released under the Apache license 2.0 and Mozilla Public License 2.0 | github.com/cure53/DOMPurify/blob/3.2.7/LICENSE */
+/*! @license DOMPurify 3.4.5 | (c) Cure53 and other contributors | Released under the Apache license 2.0 and Mozilla Public License 2.0 | github.com/cure53/DOMPurify/blob/3.4.5/LICENSE */
 
-import type { TrustedTypePolicy, TrustedHTML, TrustedTypesWindow } from 'trusted-types/lib/index.d.ts';
+import { TrustedTypePolicy, TrustedTypesWindow, TrustedHTML } from 'trusted-types/lib/index.js';
 
 /**
  * Configuration to control DOMPurify behavior.
  */
 interface Config {
-	/**
-	 * Extend the existing array of allowed attributes.
-	 */
-	ADD_ATTR?: string[] | undefined;
-	/**
-	 * Extend the existing array of elements that can use Data URIs.
-	 */
-	ADD_DATA_URI_TAGS?: string[] | undefined;
-	/**
-	 * Extend the existing array of allowed tags.
-	 */
-	ADD_TAGS?: string[] | undefined;
-	/**
-	 * Extend the existing array of elements that are safe for URI-like values (be careful, XSS risk).
-	 */
-	ADD_URI_SAFE_ATTR?: string[] | undefined;
-	/**
-	 * Allow ARIA attributes, leave other safe HTML as is (default is true).
-	 */
-	ALLOW_ARIA_ATTR?: boolean | undefined;
-	/**
-	 * Allow HTML5 data attributes, leave other safe HTML as is (default is true).
-	 */
-	ALLOW_DATA_ATTR?: boolean | undefined;
-	/**
-	 * Allow external protocol handlers in URL attributes (default is false, be careful, XSS risk).
-	 * By default only `http`, `https`, `ftp`, `ftps`, `tel`, `mailto`, `callto`, `sms`, `cid` and `xmpp` are allowed.
-	 */
-	ALLOW_UNKNOWN_PROTOCOLS?: boolean | undefined;
-	/**
-	 * Decide if self-closing tags in attributes are allowed.
-	 * Usually removed due to a mXSS issue in jQuery 3.0.
-	 */
-	ALLOW_SELF_CLOSE_IN_ATTR?: boolean | undefined;
-	/**
-	 * Allow only specific attributes.
-	 */
-	ALLOWED_ATTR?: string[] | undefined;
-	/**
-	 * Allow only specific elements.
-	 */
-	ALLOWED_TAGS?: string[] | undefined;
-	/**
-	 * Allow only specific namespaces. Defaults to:
-	 *  - `http://www.w3.org/1999/xhtml`
-	 *  - `http://www.w3.org/2000/svg`
-	 *  - `http://www.w3.org/1998/Math/MathML`
-	 */
-	ALLOWED_NAMESPACES?: string[] | undefined;
-	/**
-	 * Allow specific protocols handlers in URL attributes via regex (be careful, XSS risk).
-	 * Default RegExp:
-	 * ```
-	 * /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|sms|cid|xmpp):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i;
-	 * ```
-	 */
-	ALLOWED_URI_REGEXP?: RegExp | undefined;
-	/**
-	 * Define how custom elements are handled.
-	 */
-	CUSTOM_ELEMENT_HANDLING?: {
-		/**
-		 * Regular expression or function to match to allowed elements.
-		 * Default is null (disallow any custom elements).
-		 */
-		tagNameCheck?: RegExp | ((tagName: string) => boolean) | null | undefined;
-		/**
-		 * Regular expression or function to match to allowed attributes.
-		 * Default is null (disallow any attributes not on the allow list).
-		 */
-		attributeNameCheck?: RegExp | ((attributeName: string, tagName?: string) => boolean) | null | undefined;
-		/**
-		 * Allow custom elements derived from built-ins if they pass `tagNameCheck`. Default is false.
-		 */
-		allowCustomizedBuiltInElements?: boolean | undefined;
-	};
-	/**
-	 * Add attributes to block-list.
-	 */
-	FORBID_ATTR?: string[] | undefined;
-	/**
-	 * Add child elements to be removed when their parent is removed.
-	 */
-	FORBID_CONTENTS?: string[] | undefined;
-	/**
-	 * Add elements to block-list.
-	 */
-	FORBID_TAGS?: string[] | undefined;
-	/**
-	 * Glue elements like style, script or others to `document.body` and prevent unintuitive browser behavior in several edge-cases (default is false).
-	 */
-	FORCE_BODY?: boolean | undefined;
-	/**
-	 * Map of non-standard HTML element names to support. Map to true to enable support. For example:
-	 *
-	 * ```
-	 * HTML_INTEGRATION_POINTS: { foreignobject: true }
-	 * ```
-	 */
-	HTML_INTEGRATION_POINTS?: Record<string, boolean> | undefined;
-	/**
-	 * Sanitize a node "in place", which is much faster depending on how you use DOMPurify.
-	 */
-	IN_PLACE?: boolean | undefined;
-	/**
-	 * Keep an element's content when the element is removed (default is true).
-	 */
-	KEEP_CONTENT?: boolean | undefined;
-	/**
-	 * Map of MathML element names to support. Map to true to enable support. For example:
-	 *
-	 * ```
-	 * MATHML_TEXT_INTEGRATION_POINTS: { mtext: true }
-	 * ```
-	 */
-	MATHML_TEXT_INTEGRATION_POINTS?: Record<string, boolean> | undefined;
-	/**
-	 * Change the default namespace from HTML to something different.
-	 */
-	NAMESPACE?: string | undefined;
-	/**
-	 * Change the parser type so sanitized data is treated as XML and not as HTML, which is the default.
-	 */
-	PARSER_MEDIA_TYPE?: DOMParserSupportedType | undefined;
-	/**
-	 * Return a DOM `DocumentFragment` instead of an HTML string (default is false).
-	 */
-	RETURN_DOM_FRAGMENT?: boolean | undefined;
-	/**
-	 * Return a DOM `HTMLBodyElement` instead of an HTML string (default is false).
-	 */
-	RETURN_DOM?: boolean | undefined;
-	/**
-	 * Return a TrustedHTML object instead of a string if possible.
-	 */
-	RETURN_TRUSTED_TYPE?: boolean | undefined;
-	/**
-	 * Strip `{{ ... }}`, `${ ... }` and `<% ... %>` to make output safe for template systems.
-	 * Be careful please, this mode is not recommended for production usage.
-	 * Allowing template parsing in user-controlled HTML is not advised at all.
-	 * Only use this mode if there is really no alternative.
-	 */
-	SAFE_FOR_TEMPLATES?: boolean | undefined;
-	/**
-	 * Change how e.g. comments containing risky HTML characters are treated.
-	 * Be very careful, this setting should only be set to `false` if you really only handle
-	 * HTML and nothing else, no SVG, MathML or the like.
-	 * Otherwise, changing from `true` to `false` will lead to XSS in this or some other way.
-	 */
-	SAFE_FOR_XML?: boolean | undefined;
-	/**
-	 * Use DOM Clobbering protection on output (default is true, handle with care, minor XSS risks here).
-	 */
-	SANITIZE_DOM?: boolean | undefined;
-	/**
-	 * Enforce strict DOM Clobbering protection via namespace isolation (default is false).
-	 * When enabled, isolates the namespace of named properties (i.e., `id` and `name` attributes)
-	 * from JS variables by prefixing them with the string `user-content-`
-	 */
-	SANITIZE_NAMED_PROPS?: boolean | undefined;
-	/**
-	 * Supplied policy must define `createHTML` and `createScriptURL`.
-	 */
-	TRUSTED_TYPES_POLICY?: TrustedTypePolicy | undefined;
-	/**
-	 * Controls categories of allowed elements.
-	 *
-	 * Note that the `USE_PROFILES` setting will override the `ALLOWED_TAGS` setting
-	 * so don't use them together.
-	 */
-	USE_PROFILES?: false | UseProfilesConfig | undefined;
-	/**
-	 * Return entire document including <html> tags (default is false).
-	 */
-	WHOLE_DOCUMENT?: boolean | undefined;
+    /**
+     * Extend the existing array of allowed attributes.
+     * Can be an array of attribute names, or a function that receives
+     * the attribute name and tag name to determine if the attribute is allowed.
+     */
+    ADD_ATTR?: string[] | ((attributeName: string, tagName: string) => boolean) | undefined;
+    /**
+     * Extend the existing array of elements that can use Data URIs.
+     */
+    ADD_DATA_URI_TAGS?: string[] | undefined;
+    /**
+     * Extend the existing array of allowed tags.
+     * Can be an array of tag names, or a function that receives
+     * the tag name to determine if the tag is allowed.
+     */
+    ADD_TAGS?: string[] | ((tagName: string) => boolean) | undefined;
+    /**
+     * Extend the existing array of elements that are safe for URI-like values (be careful, XSS risk).
+     */
+    ADD_URI_SAFE_ATTR?: string[] | undefined;
+    /**
+     * Allow ARIA attributes, leave other safe HTML as is (default is true).
+     */
+    ALLOW_ARIA_ATTR?: boolean | undefined;
+    /**
+     * Allow HTML5 data attributes, leave other safe HTML as is (default is true).
+     */
+    ALLOW_DATA_ATTR?: boolean | undefined;
+    /**
+     * Allow external protocol handlers in URL attributes (default is false, be careful, XSS risk).
+     * By default only `http`, `https`, `ftp`, `ftps`, `tel`, `mailto`, `callto`, `sms`, `cid` and `xmpp` are allowed.
+     */
+    ALLOW_UNKNOWN_PROTOCOLS?: boolean | undefined;
+    /**
+     * Decide if self-closing tags in attributes are allowed.
+     * Usually removed due to a mXSS issue in jQuery 3.0.
+     */
+    ALLOW_SELF_CLOSE_IN_ATTR?: boolean | undefined;
+    /**
+     * Allow only specific attributes.
+     */
+    ALLOWED_ATTR?: string[] | undefined;
+    /**
+     * Allow only specific elements.
+     */
+    ALLOWED_TAGS?: string[] | undefined;
+    /**
+     * Allow only specific namespaces. Defaults to:
+     *  - `http://www.w3.org/1999/xhtml`
+     *  - `http://www.w3.org/2000/svg`
+     *  - `http://www.w3.org/1998/Math/MathML`
+     */
+    ALLOWED_NAMESPACES?: string[] | undefined;
+    /**
+     * Allow specific protocols handlers in URL attributes via regex (be careful, XSS risk).
+     * Default RegExp:
+     * ```
+     * /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|sms|cid|xmpp):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i;
+     * ```
+     */
+    ALLOWED_URI_REGEXP?: RegExp | undefined;
+    /**
+     * Define how custom elements are handled.
+     */
+    CUSTOM_ELEMENT_HANDLING?: {
+        /**
+         * Regular expression or function to match to allowed elements.
+         * Default is null (disallow any custom elements).
+         */
+        tagNameCheck?: RegExp | ((tagName: string) => boolean) | null | undefined;
+        /**
+         * Regular expression or function to match to allowed attributes.
+         * Default is null (disallow any attributes not on the allow list).
+         */
+        attributeNameCheck?: RegExp | ((attributeName: string, tagName?: string) => boolean) | null | undefined;
+        /**
+         * Allow custom elements derived from built-ins if they pass `tagNameCheck`. Default is false.
+         */
+        allowCustomizedBuiltInElements?: boolean | undefined;
+    };
+    /**
+     * Add attributes to block-list.
+     */
+    FORBID_ATTR?: string[] | undefined;
+    /**
+     * Add child elements to be removed when their parent is removed.
+     */
+    FORBID_CONTENTS?: string[] | undefined;
+    /**
+     * Extend the existing or default array of forbidden content elements.
+     */
+    ADD_FORBID_CONTENTS?: string[] | undefined;
+    /**
+     * Add elements to block-list.
+     */
+    FORBID_TAGS?: string[] | undefined;
+    /**
+     * Glue elements like style, script or others to `document.body` and prevent unintuitive browser behavior in several edge-cases (default is false).
+     */
+    FORCE_BODY?: boolean | undefined;
+    /**
+     * Map of non-standard HTML element names to support. Map to true to enable support. For example:
+     *
+     * ```
+     * HTML_INTEGRATION_POINTS: { foreignobject: true }
+     * ```
+     */
+    HTML_INTEGRATION_POINTS?: Record<string, boolean> | undefined;
+    /**
+     * Sanitize a node "in place", which is much faster depending on how you use DOMPurify.
+     */
+    IN_PLACE?: boolean | undefined;
+    /**
+     * Keep an element's content when the element is removed (default is true).
+     */
+    KEEP_CONTENT?: boolean | undefined;
+    /**
+     * Map of MathML element names to support. Map to true to enable support. For example:
+     *
+     * ```
+     * MATHML_TEXT_INTEGRATION_POINTS: { mtext: true }
+     * ```
+     */
+    MATHML_TEXT_INTEGRATION_POINTS?: Record<string, boolean> | undefined;
+    /**
+     * Change the default namespace from HTML to something different.
+     */
+    NAMESPACE?: string | undefined;
+    /**
+     * Change the parser type so sanitized data is treated as XML and not as HTML, which is the default.
+     */
+    PARSER_MEDIA_TYPE?: DOMParserSupportedType | undefined;
+    /**
+     * Return a DOM `DocumentFragment` instead of an HTML string (default is false).
+     */
+    RETURN_DOM_FRAGMENT?: boolean | undefined;
+    /**
+     * Return a DOM `HTMLBodyElement` instead of an HTML string (default is false).
+     */
+    RETURN_DOM?: boolean | undefined;
+    /**
+     * Return a TrustedHTML object instead of a string if possible.
+     */
+    RETURN_TRUSTED_TYPE?: boolean | undefined;
+    /**
+     * Strip `{{ ... }}`, `${ ... }` and `<% ... %>` to make output safe for template systems.
+     * Be careful please, this mode is not recommended for production usage.
+     * Allowing template parsing in user-controlled HTML is not advised at all.
+     * Only use this mode if there is really no alternative.
+     */
+    SAFE_FOR_TEMPLATES?: boolean | undefined;
+    /**
+     * Change how e.g. comments containing risky HTML characters are treated.
+     * Be very careful, this setting should only be set to `false` if you really only handle
+     * HTML and nothing else, no SVG, MathML or the like.
+     * Otherwise, changing from `true` to `false` will lead to XSS in this or some other way.
+     */
+    SAFE_FOR_XML?: boolean | undefined;
+    /**
+     * Use DOM Clobbering protection on output (default is true, handle with care, minor XSS risks here).
+     */
+    SANITIZE_DOM?: boolean | undefined;
+    /**
+     * Enforce strict DOM Clobbering protection via namespace isolation (default is false).
+     * When enabled, isolates the namespace of named properties (i.e., `id` and `name` attributes)
+     * from JS variables by prefixing them with the string `user-content-`
+     */
+    SANITIZE_NAMED_PROPS?: boolean | undefined;
+    /**
+     * Supplied policy must define `createHTML` and `createScriptURL`.
+     */
+    TRUSTED_TYPES_POLICY?: TrustedTypePolicy | undefined;
+    /**
+     * Controls categories of allowed elements.
+     *
+     * Note that the `USE_PROFILES` setting will override the `ALLOWED_TAGS` setting
+     * so don't use them together.
+     */
+    USE_PROFILES?: false | UseProfilesConfig | undefined;
+    /**
+     * Return entire document including <html> tags (default is false).
+     */
+    WHOLE_DOCUMENT?: boolean | undefined;
 }
 /**
  * Defines categories of allowed elements.
  */
 interface UseProfilesConfig {
-	/**
-	 * Allow all safe MathML elements.
-	 */
-	mathMl?: boolean | undefined;
-	/**
-	 * Allow all safe SVG elements.
-	 */
-	svg?: boolean | undefined;
-	/**
-	 * Allow all save SVG Filters.
-	 */
-	svgFilters?: boolean | undefined;
-	/**
-	 * Allow all safe HTML elements.
-	 */
-	html?: boolean | undefined;
+    /**
+     * Allow all safe MathML elements.
+     */
+    mathMl?: boolean | undefined;
+    /**
+     * Allow all safe SVG elements.
+     */
+    svg?: boolean | undefined;
+    /**
+     * Allow all safe SVG Filters.
+     */
+    svgFilters?: boolean | undefined;
+    /**
+     * Allow all safe HTML elements.
+     */
+    html?: boolean | undefined;
 }
 
 declare const _default: DOMPurify;
 
 interface DOMPurify {
-	/**
-	 * Creates a DOMPurify instance using the given window-like object. Defaults to `window`.
-	 */
-	(root?: WindowLike): DOMPurify;
-	/**
-	 * Version label, exposed for easier checks
-	 * if DOMPurify is up to date or not
-	 */
-	version: string;
-	/**
-	 * Array of elements that DOMPurify removed during sanitation.
-	 * Empty if nothing was removed.
-	 */
-	removed: Array<RemovedElement | RemovedAttribute>;
-	/**
-	 * Expose whether this browser supports running the full DOMPurify.
-	 */
-	isSupported: boolean;
-	/**
-	 * Set the configuration once.
-	 *
-	 * @param cfg configuration object
-	 */
-	setConfig(cfg?: Config): void;
-	/**
-	 * Removes the configuration.
-	 */
-	clearConfig(): void;
-	/**
-	 * Provides core sanitation functionality.
-	 *
-	 * @param dirty string or DOM node
-	 * @param cfg object
-	 * @returns Sanitized TrustedHTML.
-	 */
-	sanitize(dirty: string | Node, cfg: Config & {
-		RETURN_TRUSTED_TYPE: true;
-	}): TrustedHTML;
-	/**
-	 * Provides core sanitation functionality.
-	 *
-	 * @param dirty DOM node
-	 * @param cfg object
-	 * @returns Sanitized DOM node.
-	 */
-	sanitize(dirty: Node, cfg: Config & {
-		IN_PLACE: true;
-	}): Node;
-	/**
-	 * Provides core sanitation functionality.
-	 *
-	 * @param dirty string or DOM node
-	 * @param cfg object
-	 * @returns Sanitized DOM node.
-	 */
-	sanitize(dirty: string | Node, cfg: Config & {
-		RETURN_DOM: true;
-	}): Node;
-	/**
-	 * Provides core sanitation functionality.
-	 *
-	 * @param dirty string or DOM node
-	 * @param cfg object
-	 * @returns Sanitized document fragment.
-	 */
-	sanitize(dirty: string | Node, cfg: Config & {
-		RETURN_DOM_FRAGMENT: true;
-	}): DocumentFragment;
-	/**
-	 * Provides core sanitation functionality.
-	 *
-	 * @param dirty string or DOM node
-	 * @param cfg object
-	 * @returns Sanitized string.
-	 */
-	sanitize(dirty: string | Node, cfg?: Config): string;
-	/**
-	 * Checks if an attribute value is valid.
-	 * Uses last set config, if any. Otherwise, uses config defaults.
-	 *
-	 * @param tag Tag name of containing element.
-	 * @param attr Attribute name.
-	 * @param value Attribute value.
-	 * @returns Returns true if `value` is valid. Otherwise, returns false.
-	 */
-	isValidAttribute(tag: string, attr: string, value: string): boolean;
-	/**
-	 * Adds a DOMPurify hook.
-	 *
-	 * @param entryPoint entry point for the hook to add
-	 * @param hookFunction function to execute
-	 */
-	addHook(entryPoint: BasicHookName, hookFunction: NodeHook): void;
-	/**
-	 * Adds a DOMPurify hook.
-	 *
-	 * @param entryPoint entry point for the hook to add
-	 * @param hookFunction function to execute
-	 */
-	addHook(entryPoint: ElementHookName, hookFunction: ElementHook): void;
-	/**
-	 * Adds a DOMPurify hook.
-	 *
-	 * @param entryPoint entry point for the hook to add
-	 * @param hookFunction function to execute
-	 */
-	addHook(entryPoint: DocumentFragmentHookName, hookFunction: DocumentFragmentHook): void;
-	/**
-	 * Adds a DOMPurify hook.
-	 *
-	 * @param entryPoint entry point for the hook to add
-	 * @param hookFunction function to execute
-	 */
-	addHook(entryPoint: 'uponSanitizeElement', hookFunction: UponSanitizeElementHook): void;
-	/**
-	 * Adds a DOMPurify hook.
-	 *
-	 * @param entryPoint entry point for the hook to add
-	 * @param hookFunction function to execute
-	 */
-	addHook(entryPoint: 'uponSanitizeAttribute', hookFunction: UponSanitizeAttributeHook): void;
-	/**
-	 * Remove a DOMPurify hook at a given entryPoint
-	 * (pops it from the stack of hooks if hook not specified)
-	 *
-	 * @param entryPoint entry point for the hook to remove
-	 * @param hookFunction optional specific hook to remove
-	 * @returns removed hook
-	 */
-	removeHook(entryPoint: BasicHookName, hookFunction?: NodeHook): NodeHook | undefined;
-	/**
-	 * Remove a DOMPurify hook at a given entryPoint
-	 * (pops it from the stack of hooks if hook not specified)
-	 *
-	 * @param entryPoint entry point for the hook to remove
-	 * @param hookFunction optional specific hook to remove
-	 * @returns removed hook
-	 */
-	removeHook(entryPoint: ElementHookName, hookFunction?: ElementHook): ElementHook | undefined;
-	/**
-	 * Remove a DOMPurify hook at a given entryPoint
-	 * (pops it from the stack of hooks if hook not specified)
-	 *
-	 * @param entryPoint entry point for the hook to remove
-	 * @param hookFunction optional specific hook to remove
-	 * @returns removed hook
-	 */
-	removeHook(entryPoint: DocumentFragmentHookName, hookFunction?: DocumentFragmentHook): DocumentFragmentHook | undefined;
-	/**
-	 * Remove a DOMPurify hook at a given entryPoint
-	 * (pops it from the stack of hooks if hook not specified)
-	 *
-	 * @param entryPoint entry point for the hook to remove
-	 * @param hookFunction optional specific hook to remove
-	 * @returns removed hook
-	 */
-	removeHook(entryPoint: 'uponSanitizeElement', hookFunction?: UponSanitizeElementHook): UponSanitizeElementHook | undefined;
-	/**
-	 * Remove a DOMPurify hook at a given entryPoint
-	 * (pops it from the stack of hooks if hook not specified)
-	 *
-	 * @param entryPoint entry point for the hook to remove
-	 * @param hookFunction optional specific hook to remove
-	 * @returns removed hook
-	 */
-	removeHook(entryPoint: 'uponSanitizeAttribute', hookFunction?: UponSanitizeAttributeHook): UponSanitizeAttributeHook | undefined;
-	/**
-	 * Removes all DOMPurify hooks at a given entryPoint
-	 *
-	 * @param entryPoint entry point for the hooks to remove
-	 */
-	removeHooks(entryPoint: HookName): void;
-	/**
-	 * Removes all DOMPurify hooks.
-	 */
-	removeAllHooks(): void;
+    /**
+     * Creates a DOMPurify instance using the given window-like object. Defaults to `window`.
+     */
+    (root?: WindowLike): DOMPurify;
+    /**
+     * Version label, exposed for easier checks
+     * if DOMPurify is up to date or not
+     */
+    version: string;
+    /**
+     * Array of elements that DOMPurify removed during sanitation.
+     * Empty if nothing was removed.
+     */
+    removed: Array<RemovedElement | RemovedAttribute>;
+    /**
+     * Expose whether this browser supports running the full DOMPurify.
+     */
+    isSupported: boolean;
+    /**
+     * Set the configuration once.
+     *
+     * @param cfg configuration object
+     */
+    setConfig(cfg?: Config): void;
+    /**
+     * Removes the configuration.
+     */
+    clearConfig(): void;
+    /**
+     * Provides core sanitation functionality.
+     *
+     * @param dirty string or DOM node
+     * @param cfg object
+     * @returns Sanitized TrustedHTML.
+     */
+    sanitize(dirty: string | Node, cfg: Config & {
+        RETURN_TRUSTED_TYPE: true;
+    }): TrustedHTML;
+    /**
+     * Provides core sanitation functionality.
+     *
+     * @param dirty DOM node
+     * @param cfg object
+     * @returns Sanitized DOM node.
+     */
+    sanitize(dirty: Node, cfg: Config & {
+        IN_PLACE: true;
+    }): Node;
+    /**
+     * Provides core sanitation functionality.
+     *
+     * @param dirty string or DOM node
+     * @param cfg object
+     * @returns Sanitized DOM node.
+     */
+    sanitize(dirty: string | Node, cfg: Config & {
+        RETURN_DOM: true;
+    }): Node;
+    /**
+     * Provides core sanitation functionality.
+     *
+     * @param dirty string or DOM node
+     * @param cfg object
+     * @returns Sanitized document fragment.
+     */
+    sanitize(dirty: string | Node, cfg: Config & {
+        RETURN_DOM_FRAGMENT: true;
+    }): DocumentFragment;
+    /**
+     * Provides core sanitation functionality.
+     *
+     * @param dirty string or DOM node
+     * @param cfg object
+     * @returns Sanitized string.
+     */
+    sanitize(dirty: string | Node, cfg?: Config): string;
+    /**
+     * Checks if an attribute value is valid.
+     * Uses last set config, if any. Otherwise, uses config defaults.
+     *
+     * @param tag Tag name of containing element.
+     * @param attr Attribute name.
+     * @param value Attribute value.
+     * @returns Returns true if `value` is valid. Otherwise, returns false.
+     */
+    isValidAttribute(tag: string, attr: string, value: string): boolean;
+    /**
+     * Adds a DOMPurify hook.
+     *
+     * @param entryPoint entry point for the hook to add
+     * @param hookFunction function to execute
+     */
+    addHook(entryPoint: BasicHookName, hookFunction: NodeHook): void;
+    /**
+     * Adds a DOMPurify hook.
+     *
+     * @param entryPoint entry point for the hook to add
+     * @param hookFunction function to execute
+     */
+    addHook(entryPoint: ElementHookName, hookFunction: ElementHook): void;
+    /**
+     * Adds a DOMPurify hook.
+     *
+     * @param entryPoint entry point for the hook to add
+     * @param hookFunction function to execute
+     */
+    addHook(entryPoint: DocumentFragmentHookName, hookFunction: DocumentFragmentHook): void;
+    /**
+     * Adds a DOMPurify hook.
+     *
+     * @param entryPoint entry point for the hook to add
+     * @param hookFunction function to execute
+     */
+    addHook(entryPoint: 'uponSanitizeElement', hookFunction: UponSanitizeElementHook): void;
+    /**
+     * Adds a DOMPurify hook.
+     *
+     * @param entryPoint entry point for the hook to add
+     * @param hookFunction function to execute
+     */
+    addHook(entryPoint: 'uponSanitizeAttribute', hookFunction: UponSanitizeAttributeHook): void;
+    /**
+     * Remove a DOMPurify hook at a given entryPoint
+     * (pops it from the stack of hooks if hook not specified)
+     *
+     * @param entryPoint entry point for the hook to remove
+     * @param hookFunction optional specific hook to remove
+     * @returns removed hook
+     */
+    removeHook(entryPoint: BasicHookName, hookFunction?: NodeHook): NodeHook | undefined;
+    /**
+     * Remove a DOMPurify hook at a given entryPoint
+     * (pops it from the stack of hooks if hook not specified)
+     *
+     * @param entryPoint entry point for the hook to remove
+     * @param hookFunction optional specific hook to remove
+     * @returns removed hook
+     */
+    removeHook(entryPoint: ElementHookName, hookFunction?: ElementHook): ElementHook | undefined;
+    /**
+     * Remove a DOMPurify hook at a given entryPoint
+     * (pops it from the stack of hooks if hook not specified)
+     *
+     * @param entryPoint entry point for the hook to remove
+     * @param hookFunction optional specific hook to remove
+     * @returns removed hook
+     */
+    removeHook(entryPoint: DocumentFragmentHookName, hookFunction?: DocumentFragmentHook): DocumentFragmentHook | undefined;
+    /**
+     * Remove a DOMPurify hook at a given entryPoint
+     * (pops it from the stack of hooks if hook not specified)
+     *
+     * @param entryPoint entry point for the hook to remove
+     * @param hookFunction optional specific hook to remove
+     * @returns removed hook
+     */
+    removeHook(entryPoint: 'uponSanitizeElement', hookFunction?: UponSanitizeElementHook): UponSanitizeElementHook | undefined;
+    /**
+     * Remove a DOMPurify hook at a given entryPoint
+     * (pops it from the stack of hooks if hook not specified)
+     *
+     * @param entryPoint entry point for the hook to remove
+     * @param hookFunction optional specific hook to remove
+     * @returns removed hook
+     */
+    removeHook(entryPoint: 'uponSanitizeAttribute', hookFunction?: UponSanitizeAttributeHook): UponSanitizeAttributeHook | undefined;
+    /**
+     * Removes all DOMPurify hooks at a given entryPoint
+     *
+     * @param entryPoint entry point for the hooks to remove
+     */
+    removeHooks(entryPoint: HookName): void;
+    /**
+     * Removes all DOMPurify hooks.
+     */
+    removeAllHooks(): void;
 }
 /**
  * An element removed by DOMPurify.
  */
 interface RemovedElement {
-	/**
-	 * The element that was removed.
-	 */
-	element: Node;
+    /**
+     * The element that was removed.
+     */
+    element: Node;
 }
 /**
  * An element removed by DOMPurify.
  */
 interface RemovedAttribute {
-	/**
-	 * The attribute that was removed.
-	 */
-	attribute: Attr | null;
-	/**
-	 * The element that the attribute was removed.
-	 */
-	from: Node;
+    /**
+     * The attribute that was removed.
+     */
+    attribute: Attr | null;
+    /**
+     * The element that the attribute was removed.
+     */
+    from: Node;
 }
 type BasicHookName = 'beforeSanitizeElements' | 'afterSanitizeElements' | 'uponSanitizeShadowNode';
 type ElementHookName = 'beforeSanitizeAttributes' | 'afterSanitizeAttributes';
@@ -418,22 +426,23 @@ type DocumentFragmentHook = (this: DOMPurify, currentNode: DocumentFragment, hoo
 type UponSanitizeElementHook = (this: DOMPurify, currentNode: Node, hookEvent: UponSanitizeElementHookEvent, config: Config) => void;
 type UponSanitizeAttributeHook = (this: DOMPurify, currentNode: Element, hookEvent: UponSanitizeAttributeHookEvent, config: Config) => void;
 interface UponSanitizeElementHookEvent {
-	tagName: string;
-	allowedTags: Record<string, boolean>;
+    tagName: string;
+    allowedTags: Record<string, boolean>;
 }
 interface UponSanitizeAttributeHookEvent {
-	attrName: string;
-	attrValue: string;
-	keepAttr: boolean;
-	allowedAttributes: Record<string, boolean>;
-	forceKeepAttr: boolean | undefined;
+    attrName: string;
+    attrValue: string;
+    keepAttr: boolean;
+    allowedAttributes: Record<string, boolean>;
+    forceKeepAttr: boolean | undefined;
 }
 /**
  * A `Window`-like object containing the properties and types that DOMPurify requires.
  */
 type WindowLike = Pick<typeof globalThis, 'DocumentFragment' | 'HTMLTemplateElement' | 'Node' | 'Element' | 'NodeFilter' | 'NamedNodeMap' | 'HTMLFormElement' | 'DOMParser'> & {
-	document?: Document;
-	MozNamedAttrMap?: typeof window.NamedNodeMap;
+    document?: Document;
+    MozNamedAttrMap?: typeof window.NamedNodeMap;
 } & Pick<TrustedTypesWindow, 'trustedTypes'>;
 
-export { type Config, type DOMPurify, type DocumentFragmentHook, type ElementHook, type HookName, type NodeHook, type RemovedAttribute, type RemovedElement, type UponSanitizeAttributeHook, type UponSanitizeAttributeHookEvent, type UponSanitizeElementHook, type UponSanitizeElementHookEvent, type WindowLike, _default as default };
+export { _default as default };
+export type { Config, DOMPurify, DocumentFragmentHook, ElementHook, HookName, NodeHook, RemovedAttribute, RemovedElement, UponSanitizeAttributeHook, UponSanitizeAttributeHookEvent, UponSanitizeElementHook, UponSanitizeElementHookEvent, WindowLike };

--- a/src/vs/base/browser/dompurify/dompurify.js
+++ b/src/vs/base/browser/dompurify/dompurify.js
@@ -1,21 +1,62 @@
-/*! @license DOMPurify 3.2.7 | (c) Cure53 and other contributors | Released under the Apache license 2.0 and Mozilla Public License 2.0 | github.com/cure53/DOMPurify/blob/3.2.7/LICENSE */
+/*! @license DOMPurify 3.4.5 | (c) Cure53 and other contributors | Released under the Apache license 2.0 and Mozilla Public License 2.0 | github.com/cure53/DOMPurify/blob/3.4.5/LICENSE */
 
-const {
-  entries,
-  setPrototypeOf,
-  isFrozen,
-  getPrototypeOf,
-  getOwnPropertyDescriptor
-} = Object;
-let {
-  freeze,
-  seal,
-  create
-} = Object; // eslint-disable-line import/no-mutable-exports
-let {
-  apply,
-  construct
-} = typeof Reflect !== 'undefined' && Reflect;
+function _arrayLikeToArray(r, a) {
+  (null == a || a > r.length) && (a = r.length);
+  for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e];
+  return n;
+}
+function _arrayWithHoles(r) {
+  if (Array.isArray(r)) return r;
+}
+function _iterableToArrayLimit(r, l) {
+  var t = null == r ? null : "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"];
+  if (null != t) {
+    var e,
+      n,
+      i,
+      u,
+      a = [],
+      f = true,
+      o = false;
+    try {
+      if (i = (t = t.call(r)).next, 0 === l) ; else for (; !(f = (e = i.call(t)).done) && (a.push(e.value), a.length !== l); f = !0);
+    } catch (r) {
+      o = true, n = r;
+    } finally {
+      try {
+        if (!f && null != t.return && (u = t.return(), Object(u) !== u)) return;
+      } finally {
+        if (o) throw n;
+      }
+    }
+    return a;
+  }
+}
+function _nonIterableRest() {
+  throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
+}
+function _slicedToArray(r, e) {
+  return _arrayWithHoles(r) || _iterableToArrayLimit(r, e) || _unsupportedIterableToArray(r, e) || _nonIterableRest();
+}
+function _unsupportedIterableToArray(r, a) {
+  if (r) {
+    if ("string" == typeof r) return _arrayLikeToArray(r, a);
+    var t = {}.toString.call(r).slice(8, -1);
+    return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0;
+  }
+}
+
+const entries = Object.entries,
+  setPrototypeOf = Object.setPrototypeOf,
+  isFrozen = Object.isFrozen,
+  getPrototypeOf = Object.getPrototypeOf,
+  getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+let freeze = Object.freeze,
+  seal = Object.seal,
+  create = Object.create; // eslint-disable-line import/no-mutable-exports
+let _ref = typeof Reflect !== 'undefined' && Reflect,
+  apply = _ref.apply,
+  construct = _ref.construct;
 if (!freeze) {
   freeze = function freeze(x) {
     return x;
@@ -47,13 +88,19 @@ const arrayLastIndexOf = unapply(Array.prototype.lastIndexOf);
 const arrayPop = unapply(Array.prototype.pop);
 const arrayPush = unapply(Array.prototype.push);
 const arraySplice = unapply(Array.prototype.splice);
+const arrayIsArray = Array.isArray;
 const stringToLowerCase = unapply(String.prototype.toLowerCase);
 const stringToString = unapply(String.prototype.toString);
 const stringMatch = unapply(String.prototype.match);
 const stringReplace = unapply(String.prototype.replace);
 const stringIndexOf = unapply(String.prototype.indexOf);
 const stringTrim = unapply(String.prototype.trim);
+const numberToString = unapply(Number.prototype.toString);
+const booleanToString = unapply(Boolean.prototype.toString);
+const bigintToString = typeof BigInt === 'undefined' ? null : unapply(BigInt.prototype.toString);
+const symbolToString = typeof Symbol === 'undefined' ? null : unapply(Symbol.prototype.toString);
 const objectHasOwnProperty = unapply(Object.prototype.hasOwnProperty);
+const objectToString = unapply(Object.prototype.toString);
 const regExpTest = unapply(RegExp.prototype.test);
 const typeErrorCreate = unconstruct(TypeError);
 /**
@@ -103,6 +150,9 @@ function addToSet(set, array) {
     // Prevent prototype setters from intercepting set as a this value.
     setPrototypeOf(set, null);
   }
+  if (!arrayIsArray(array)) {
+    return set;
+  }
   let l = array.length;
   while (l--) {
     let element = array[l];
@@ -143,10 +193,13 @@ function cleanArray(array) {
  */
 function clone(object) {
   const newObject = create(null);
-  for (const [property, value] of entries(object)) {
+  for (const _ref2 of entries(object)) {
+    var _ref3 = _slicedToArray(_ref2, 2);
+    const property = _ref3[0];
+    const value = _ref3[1];
     const isPropertyExist = objectHasOwnProperty(object, property);
     if (isPropertyExist) {
-      if (Array.isArray(value)) {
+      if (arrayIsArray(value)) {
         newObject[property] = cleanArray(value);
       } else if (value && typeof value === 'object' && value.constructor === Object) {
         newObject[property] = clone(value);
@@ -156,6 +209,58 @@ function clone(object) {
     }
   }
   return newObject;
+}
+/**
+ * Convert non-node values into strings without depending on direct property access.
+ *
+ * @param value - The value to stringify.
+ * @returns A string representation of the provided value.
+ */
+function stringifyValue(value) {
+  switch (typeof value) {
+    case 'string':
+      {
+        return value;
+      }
+    case 'number':
+      {
+        return numberToString(value);
+      }
+    case 'boolean':
+      {
+        return booleanToString(value);
+      }
+    case 'bigint':
+      {
+        return bigintToString ? bigintToString(value) : '0';
+      }
+    case 'symbol':
+      {
+        return symbolToString ? symbolToString(value) : 'Symbol()';
+      }
+    case 'undefined':
+      {
+        return objectToString(value);
+      }
+    case 'function':
+    case 'object':
+      {
+        if (value === null) {
+          return objectToString(value);
+        }
+        const valueAsRecord = value;
+        const valueToString = lookupGetter(valueAsRecord, 'toString');
+        if (typeof valueToString === 'function') {
+          const stringified = valueToString(valueAsRecord);
+          return typeof stringified === 'string' ? stringified : objectToString(stringified);
+        }
+        return objectToString(value);
+      }
+    default:
+      {
+        return objectToString(value);
+      }
+  }
 }
 /**
  * This method automatically checks if the prop is function or getter and behaves accordingly.
@@ -182,9 +287,17 @@ function lookupGetter(object, prop) {
   }
   return fallbackValue;
 }
+function isRegex(value) {
+  try {
+    regExpTest(value, '');
+    return true;
+  } catch (_unused) {
+    return false;
+  }
+}
 
 const html$1 = freeze(['a', 'abbr', 'acronym', 'address', 'area', 'article', 'aside', 'audio', 'b', 'bdi', 'bdo', 'big', 'blink', 'blockquote', 'body', 'br', 'button', 'canvas', 'caption', 'center', 'cite', 'code', 'col', 'colgroup', 'content', 'data', 'datalist', 'dd', 'decorator', 'del', 'details', 'dfn', 'dialog', 'dir', 'div', 'dl', 'dt', 'element', 'em', 'fieldset', 'figcaption', 'figure', 'font', 'footer', 'form', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'head', 'header', 'hgroup', 'hr', 'html', 'i', 'img', 'input', 'ins', 'kbd', 'label', 'legend', 'li', 'main', 'map', 'mark', 'marquee', 'menu', 'menuitem', 'meter', 'nav', 'nobr', 'ol', 'optgroup', 'option', 'output', 'p', 'picture', 'pre', 'progress', 'q', 'rp', 'rt', 'ruby', 's', 'samp', 'search', 'section', 'select', 'shadow', 'slot', 'small', 'source', 'spacer', 'span', 'strike', 'strong', 'style', 'sub', 'summary', 'sup', 'table', 'tbody', 'td', 'template', 'textarea', 'tfoot', 'th', 'thead', 'time', 'tr', 'track', 'tt', 'u', 'ul', 'var', 'video', 'wbr']);
-const svg$1 = freeze(['svg', 'a', 'altglyph', 'altglyphdef', 'altglyphitem', 'animatecolor', 'animatemotion', 'animatetransform', 'circle', 'clippath', 'defs', 'desc', 'ellipse', 'enterkeyhint', 'exportparts', 'filter', 'font', 'g', 'glyph', 'glyphref', 'hkern', 'image', 'inputmode', 'line', 'lineargradient', 'marker', 'mask', 'metadata', 'mpath', 'part', 'path', 'pattern', 'polygon', 'polyline', 'radialgradient', 'rect', 'slot', 'stop', 'style', 'switch', 'symbol', 'text', 'textpath', 'title', 'tref', 'tspan', 'view', 'vkern']);
+const svg$1 = freeze(['svg', 'a', 'altglyph', 'altglyphdef', 'altglyphitem', 'animatecolor', 'animatemotion', 'animatetransform', 'circle', 'clippath', 'defs', 'desc', 'ellipse', 'enterkeyhint', 'exportparts', 'filter', 'font', 'g', 'glyph', 'glyphref', 'hkern', 'image', 'inputmode', 'line', 'lineargradient', 'marker', 'mask', 'metadata', 'mpath', 'part', 'path', 'pattern', 'polygon', 'polyline', 'radialgradient', 'rect', 'stop', 'style', 'switch', 'symbol', 'text', 'textpath', 'title', 'tref', 'tspan', 'view', 'vkern']);
 const svgFilters = freeze(['feBlend', 'feColorMatrix', 'feComponentTransfer', 'feComposite', 'feConvolveMatrix', 'feDiffuseLighting', 'feDisplacementMap', 'feDistantLight', 'feDropShadow', 'feFlood', 'feFuncA', 'feFuncB', 'feFuncG', 'feFuncR', 'feGaussianBlur', 'feImage', 'feMerge', 'feMergeNode', 'feMorphology', 'feOffset', 'fePointLight', 'feSpecularLighting', 'feSpotLight', 'feTile', 'feTurbulence']);
 // List of SVG elements that are disallowed by default.
 // We still need to know them so that we can do namespace
@@ -197,15 +310,14 @@ const mathMl$1 = freeze(['math', 'menclose', 'merror', 'mfenced', 'mfrac', 'mgly
 const mathMlDisallowed = freeze(['maction', 'maligngroup', 'malignmark', 'mlongdiv', 'mscarries', 'mscarry', 'msgroup', 'mstack', 'msline', 'msrow', 'semantics', 'annotation', 'annotation-xml', 'mprescripts', 'none']);
 const text = freeze(['#text']);
 
-const html = freeze(['accept', 'action', 'align', 'alt', 'autocapitalize', 'autocomplete', 'autopictureinpicture', 'autoplay', 'background', 'bgcolor', 'border', 'capture', 'cellpadding', 'cellspacing', 'checked', 'cite', 'class', 'clear', 'color', 'cols', 'colspan', 'controls', 'controlslist', 'coords', 'crossorigin', 'datetime', 'decoding', 'default', 'dir', 'disabled', 'disablepictureinpicture', 'disableremoteplayback', 'download', 'draggable', 'enctype', 'enterkeyhint', 'exportparts', 'face', 'for', 'headers', 'height', 'hidden', 'high', 'href', 'hreflang', 'id', 'inert', 'inputmode', 'integrity', 'ismap', 'kind', 'label', 'lang', 'list', 'loading', 'loop', 'low', 'max', 'maxlength', 'media', 'method', 'min', 'minlength', 'multiple', 'muted', 'name', 'nonce', 'noshade', 'novalidate', 'nowrap', 'open', 'optimum', 'part', 'pattern', 'placeholder', 'playsinline', 'popover', 'popovertarget', 'popovertargetaction', 'poster', 'preload', 'pubdate', 'radiogroup', 'readonly', 'rel', 'required', 'rev', 'reversed', 'role', 'rows', 'rowspan', 'spellcheck', 'scope', 'selected', 'shape', 'size', 'sizes', 'slot', 'span', 'srclang', 'start', 'src', 'srcset', 'step', 'style', 'summary', 'tabindex', 'title', 'translate', 'type', 'usemap', 'valign', 'value', 'width', 'wrap', 'xmlns', 'slot']);
-const svg = freeze(['accent-height', 'accumulate', 'additive', 'alignment-baseline', 'amplitude', 'ascent', 'attributename', 'attributetype', 'azimuth', 'basefrequency', 'baseline-shift', 'begin', 'bias', 'by', 'class', 'clip', 'clippathunits', 'clip-path', 'clip-rule', 'color', 'color-interpolation', 'color-interpolation-filters', 'color-profile', 'color-rendering', 'cx', 'cy', 'd', 'dx', 'dy', 'diffuseconstant', 'direction', 'display', 'divisor', 'dur', 'edgemode', 'elevation', 'end', 'exponent', 'fill', 'fill-opacity', 'fill-rule', 'filter', 'filterunits', 'flood-color', 'flood-opacity', 'font-family', 'font-size', 'font-size-adjust', 'font-stretch', 'font-style', 'font-variant', 'font-weight', 'fx', 'fy', 'g1', 'g2', 'glyph-name', 'glyphref', 'gradientunits', 'gradienttransform', 'height', 'href', 'id', 'image-rendering', 'in', 'in2', 'intercept', 'k', 'k1', 'k2', 'k3', 'k4', 'kerning', 'keypoints', 'keysplines', 'keytimes', 'lang', 'lengthadjust', 'letter-spacing', 'kernelmatrix', 'kernelunitlength', 'lighting-color', 'local', 'marker-end', 'marker-mid', 'marker-start', 'markerheight', 'markerunits', 'markerwidth', 'maskcontentunits', 'maskunits', 'max', 'mask', 'media', 'method', 'mode', 'min', 'name', 'numoctaves', 'offset', 'operator', 'opacity', 'order', 'orient', 'orientation', 'origin', 'overflow', 'paint-order', 'path', 'pathlength', 'patterncontentunits', 'patterntransform', 'patternunits', 'points', 'preservealpha', 'preserveaspectratio', 'primitiveunits', 'r', 'rx', 'ry', 'radius', 'refx', 'refy', 'repeatcount', 'repeatdur', 'restart', 'result', 'rotate', 'scale', 'seed', 'shape-rendering', 'slope', 'specularconstant', 'specularexponent', 'spreadmethod', 'startoffset', 'stddeviation', 'stitchtiles', 'stop-color', 'stop-opacity', 'stroke-dasharray', 'stroke-dashoffset', 'stroke-linecap', 'stroke-linejoin', 'stroke-miterlimit', 'stroke-opacity', 'stroke', 'stroke-width', 'style', 'surfacescale', 'systemlanguage', 'tabindex', 'tablevalues', 'targetx', 'targety', 'transform', 'transform-origin', 'text-anchor', 'text-decoration', 'text-rendering', 'textlength', 'type', 'u1', 'u2', 'unicode', 'values', 'viewbox', 'visibility', 'version', 'vert-adv-y', 'vert-origin-x', 'vert-origin-y', 'width', 'word-spacing', 'wrap', 'writing-mode', 'xchannelselector', 'ychannelselector', 'x', 'x1', 'x2', 'xmlns', 'y', 'y1', 'y2', 'z', 'zoomandpan']);
-const mathMl = freeze(['accent', 'accentunder', 'align', 'bevelled', 'close', 'columnsalign', 'columnlines', 'columnspan', 'denomalign', 'depth', 'dir', 'display', 'displaystyle', 'encoding', 'fence', 'frame', 'height', 'href', 'id', 'largeop', 'length', 'linethickness', 'lspace', 'lquote', 'mathbackground', 'mathcolor', 'mathsize', 'mathvariant', 'maxsize', 'minsize', 'movablelimits', 'notation', 'numalign', 'open', 'rowalign', 'rowlines', 'rowspacing', 'rowspan', 'rspace', 'rquote', 'scriptlevel', 'scriptminsize', 'scriptsizemultiplier', 'selection', 'separator', 'separators', 'stretchy', 'subscriptshift', 'supscriptshift', 'symmetric', 'voffset', 'width', 'xmlns']);
+const html = freeze(['accept', 'action', 'align', 'alt', 'autocapitalize', 'autocomplete', 'autopictureinpicture', 'autoplay', 'background', 'bgcolor', 'border', 'capture', 'cellpadding', 'cellspacing', 'checked', 'cite', 'class', 'clear', 'color', 'cols', 'colspan', 'command', 'commandfor', 'controls', 'controlslist', 'coords', 'crossorigin', 'datetime', 'decoding', 'default', 'dir', 'disabled', 'disablepictureinpicture', 'disableremoteplayback', 'download', 'draggable', 'enctype', 'enterkeyhint', 'exportparts', 'face', 'for', 'headers', 'height', 'hidden', 'high', 'href', 'hreflang', 'id', 'inert', 'inputmode', 'integrity', 'ismap', 'kind', 'label', 'lang', 'list', 'loading', 'loop', 'low', 'max', 'maxlength', 'media', 'method', 'min', 'minlength', 'multiple', 'muted', 'name', 'nonce', 'noshade', 'novalidate', 'nowrap', 'open', 'optimum', 'part', 'pattern', 'placeholder', 'playsinline', 'popover', 'popovertarget', 'popovertargetaction', 'poster', 'preload', 'pubdate', 'radiogroup', 'readonly', 'rel', 'required', 'rev', 'reversed', 'role', 'rows', 'rowspan', 'spellcheck', 'scope', 'selected', 'shape', 'size', 'sizes', 'slot', 'span', 'srclang', 'start', 'src', 'srcset', 'step', 'style', 'summary', 'tabindex', 'title', 'translate', 'type', 'usemap', 'valign', 'value', 'width', 'wrap', 'xmlns']);
+const svg = freeze(['accent-height', 'accumulate', 'additive', 'alignment-baseline', 'amplitude', 'ascent', 'attributename', 'attributetype', 'azimuth', 'basefrequency', 'baseline-shift', 'begin', 'bias', 'by', 'class', 'clip', 'clippathunits', 'clip-path', 'clip-rule', 'color', 'color-interpolation', 'color-interpolation-filters', 'color-profile', 'color-rendering', 'cx', 'cy', 'd', 'dx', 'dy', 'diffuseconstant', 'direction', 'display', 'divisor', 'dur', 'edgemode', 'elevation', 'end', 'exponent', 'fill', 'fill-opacity', 'fill-rule', 'filter', 'filterunits', 'flood-color', 'flood-opacity', 'font-family', 'font-size', 'font-size-adjust', 'font-stretch', 'font-style', 'font-variant', 'font-weight', 'fx', 'fy', 'g1', 'g2', 'glyph-name', 'glyphref', 'gradientunits', 'gradienttransform', 'height', 'href', 'id', 'image-rendering', 'in', 'in2', 'intercept', 'k', 'k1', 'k2', 'k3', 'k4', 'kerning', 'keypoints', 'keysplines', 'keytimes', 'lang', 'lengthadjust', 'letter-spacing', 'kernelmatrix', 'kernelunitlength', 'lighting-color', 'local', 'marker-end', 'marker-mid', 'marker-start', 'markerheight', 'markerunits', 'markerwidth', 'maskcontentunits', 'maskunits', 'max', 'mask', 'mask-type', 'media', 'method', 'mode', 'min', 'name', 'numoctaves', 'offset', 'operator', 'opacity', 'order', 'orient', 'orientation', 'origin', 'overflow', 'paint-order', 'path', 'pathlength', 'patterncontentunits', 'patterntransform', 'patternunits', 'points', 'preservealpha', 'preserveaspectratio', 'primitiveunits', 'r', 'rx', 'ry', 'radius', 'refx', 'refy', 'repeatcount', 'repeatdur', 'restart', 'result', 'rotate', 'scale', 'seed', 'shape-rendering', 'slope', 'specularconstant', 'specularexponent', 'spreadmethod', 'startoffset', 'stddeviation', 'stitchtiles', 'stop-color', 'stop-opacity', 'stroke-dasharray', 'stroke-dashoffset', 'stroke-linecap', 'stroke-linejoin', 'stroke-miterlimit', 'stroke-opacity', 'stroke', 'stroke-width', 'style', 'surfacescale', 'systemlanguage', 'tabindex', 'tablevalues', 'targetx', 'targety', 'transform', 'transform-origin', 'text-anchor', 'text-decoration', 'text-rendering', 'textlength', 'type', 'u1', 'u2', 'unicode', 'values', 'viewbox', 'visibility', 'version', 'vert-adv-y', 'vert-origin-x', 'vert-origin-y', 'width', 'word-spacing', 'wrap', 'writing-mode', 'xchannelselector', 'ychannelselector', 'x', 'x1', 'x2', 'xmlns', 'y', 'y1', 'y2', 'z', 'zoomandpan']);
+const mathMl = freeze(['accent', 'accentunder', 'align', 'bevelled', 'close', 'columnalign', 'columnlines', 'columnspacing', 'columnspan', 'denomalign', 'depth', 'dir', 'display', 'displaystyle', 'encoding', 'fence', 'frame', 'height', 'href', 'id', 'largeop', 'length', 'linethickness', 'lquote', 'lspace', 'mathbackground', 'mathcolor', 'mathsize', 'mathvariant', 'maxsize', 'minsize', 'movablelimits', 'notation', 'numalign', 'open', 'rowalign', 'rowlines', 'rowspacing', 'rowspan', 'rspace', 'rquote', 'scriptlevel', 'scriptminsize', 'scriptsizemultiplier', 'selection', 'separator', 'separators', 'stretchy', 'subscriptshift', 'supscriptshift', 'symmetric', 'voffset', 'width', 'xmlns']);
 const xml = freeze(['xlink:href', 'xml:id', 'xlink:title', 'xml:space', 'xmlns:xlink']);
 
-// eslint-disable-next-line unicorn/better-regex
-const MUSTACHE_EXPR = seal(/\{\{[\w\W]*|[\w\W]*\}\}/gm); // Specify template detection regex for SAFE_FOR_TEMPLATES mode
-const ERB_EXPR = seal(/<%[\w\W]*|[\w\W]*%>/gm);
-const TMPLIT_EXPR = seal(/\$\{[\w\W]*/gm); // eslint-disable-line unicorn/better-regex
+const MUSTACHE_EXPR = seal(/{{[\w\W]*|^[\w\W]*}}/g);
+const ERB_EXPR = seal(/<%[\w\W]*|^[\w\W]*%>/g);
+const TMPLIT_EXPR = seal(/\${[\w\W]*/g);
 const DATA_ATTR = seal(/^data-[\-\w.\u00B7-\uFFFF]+$/); // eslint-disable-line no-useless-escape
 const ARIA_ATTR = seal(/^aria-[\-\w]+$/); // eslint-disable-line no-useless-escape
 const IS_ALLOWED_URI = seal(/^(?:(?:(?:f|ht)tps?|mailto|tel|callto|sms|cid|xmpp|matrix):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i // eslint-disable-line no-useless-escape
@@ -216,38 +328,15 @@ const ATTR_WHITESPACE = seal(/[\u0000-\u0020\u00A0\u1680\u180E\u2000-\u2029\u205
 const DOCTYPE_NAME = seal(/^html$/i);
 const CUSTOM_ELEMENT = seal(/^[a-z][.\w]*(-[.\w]+)+$/i);
 
-var EXPRESSIONS = /*#__PURE__*/Object.freeze({
-  __proto__: null,
-  ARIA_ATTR: ARIA_ATTR,
-  ATTR_WHITESPACE: ATTR_WHITESPACE,
-  CUSTOM_ELEMENT: CUSTOM_ELEMENT,
-  DATA_ATTR: DATA_ATTR,
-  DOCTYPE_NAME: DOCTYPE_NAME,
-  ERB_EXPR: ERB_EXPR,
-  IS_ALLOWED_URI: IS_ALLOWED_URI,
-  IS_SCRIPT_OR_DATA: IS_SCRIPT_OR_DATA,
-  MUSTACHE_EXPR: MUSTACHE_EXPR,
-  TMPLIT_EXPR: TMPLIT_EXPR
-});
-
 /* eslint-disable @typescript-eslint/indent */
 // https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType
 const NODE_TYPE = {
   element: 1,
-  attribute: 2,
   text: 3,
-  cdataSection: 4,
-  entityReference: 5,
-  // Deprecated
-  entityNode: 6,
   // Deprecated
   progressingInstruction: 7,
   comment: 8,
-  document: 9,
-  documentType: 10,
-  documentFragment: 11,
-  notation: 12 // Deprecated
-};
+  document: 9};
 const getGlobal = function getGlobal() {
   return typeof window === 'undefined' ? null : window;
 };
@@ -305,7 +394,7 @@ const _createHooksMap = function _createHooksMap() {
 function createDOMPurify() {
   let window = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : getGlobal();
   const DOMPurify = root => createDOMPurify(root);
-  DOMPurify.version = '3.2.7';
+  DOMPurify.version = '3.4.5';
   DOMPurify.removed = [];
   if (!window || !window.document || window.document.nodeType !== NODE_TYPE.document || !window.Element) {
     // Not running in a browser, provide a factory function
@@ -313,28 +402,26 @@ function createDOMPurify() {
     DOMPurify.isSupported = false;
     return DOMPurify;
   }
-  let {
-    document
-  } = window;
+  let document = window.document;
   const originalDocument = document;
   const currentScript = originalDocument.currentScript;
-  const {
-    DocumentFragment,
-    HTMLTemplateElement,
-    Node,
-    Element,
-    NodeFilter,
-    NamedNodeMap = window.NamedNodeMap || window.MozNamedAttrMap,
-    HTMLFormElement,
-    DOMParser,
-    trustedTypes
-  } = window;
+  const DocumentFragment = window.DocumentFragment,
+    HTMLTemplateElement = window.HTMLTemplateElement,
+    Node = window.Node,
+    Element = window.Element,
+    NodeFilter = window.NodeFilter,
+    _window$NamedNodeMap = window.NamedNodeMap,
+    NamedNodeMap = _window$NamedNodeMap === void 0 ? window.NamedNodeMap || window.MozNamedAttrMap : _window$NamedNodeMap,
+    HTMLFormElement = window.HTMLFormElement,
+    DOMParser = window.DOMParser,
+    trustedTypes = window.trustedTypes;
   const ElementPrototype = Element.prototype;
   const cloneNode = lookupGetter(ElementPrototype, 'cloneNode');
   const remove = lookupGetter(ElementPrototype, 'remove');
   const getNextSibling = lookupGetter(ElementPrototype, 'nextSibling');
   const getChildNodes = lookupGetter(ElementPrototype, 'childNodes');
   const getParentNode = lookupGetter(ElementPrototype, 'parentNode');
+  const getNodeType = Node && Node.prototype ? lookupGetter(Node.prototype, 'nodeType') : null;
   // As per issue #47, the web-components registry is inherited by a
   // new document created via createHTMLDocument. As per the spec
   // (http://w3c.github.io/webcomponents/spec/custom/#creating-and-passing-registries)
@@ -349,33 +436,26 @@ function createDOMPurify() {
   }
   let trustedTypesPolicy;
   let emptyHTML = '';
-  const {
-    implementation,
-    createNodeIterator,
-    createDocumentFragment,
-    getElementsByTagName
-  } = document;
-  const {
-    importNode
-  } = originalDocument;
+  const _document = document,
+    implementation = _document.implementation,
+    createNodeIterator = _document.createNodeIterator,
+    createDocumentFragment = _document.createDocumentFragment,
+    getElementsByTagName = _document.getElementsByTagName;
+  const importNode = originalDocument.importNode;
   let hooks = _createHooksMap();
   /**
    * Expose whether this browser supports running the full DOMPurify.
    */
   DOMPurify.isSupported = typeof entries === 'function' && typeof getParentNode === 'function' && implementation && implementation.createHTMLDocument !== undefined;
-  const {
-    MUSTACHE_EXPR,
-    ERB_EXPR,
-    TMPLIT_EXPR,
-    DATA_ATTR,
-    ARIA_ATTR,
-    IS_SCRIPT_OR_DATA,
-    ATTR_WHITESPACE,
-    CUSTOM_ELEMENT
-  } = EXPRESSIONS;
-  let {
-    IS_ALLOWED_URI: IS_ALLOWED_URI$1
-  } = EXPRESSIONS;
+  const MUSTACHE_EXPR$1 = MUSTACHE_EXPR,
+    ERB_EXPR$1 = ERB_EXPR,
+    TMPLIT_EXPR$1 = TMPLIT_EXPR,
+    DATA_ATTR$1 = DATA_ATTR,
+    ARIA_ATTR$1 = ARIA_ATTR,
+    IS_SCRIPT_OR_DATA$1 = IS_SCRIPT_OR_DATA,
+    ATTR_WHITESPACE$1 = ATTR_WHITESPACE,
+    CUSTOM_ELEMENT$1 = CUSTOM_ELEMENT;
+  let IS_ALLOWED_URI$1 = IS_ALLOWED_URI;
   /**
    * We consider the elements and attributes below to be safe. Ideally
    * don't add any new ones but feel free to remove unwanted ones.
@@ -416,6 +496,21 @@ function createDOMPurify() {
   let FORBID_TAGS = null;
   /* Explicitly forbidden attributes (overrides ALLOWED_ATTR/ADD_ATTR) */
   let FORBID_ATTR = null;
+  /* Config object to store ADD_TAGS/ADD_ATTR functions (when used as functions) */
+  const EXTRA_ELEMENT_HANDLING = Object.seal(create(null, {
+    tagCheck: {
+      writable: true,
+      configurable: false,
+      enumerable: true,
+      value: null
+    },
+    attributeCheck: {
+      writable: true,
+      configurable: false,
+      enumerable: true,
+      value: null
+    }
+  }));
   /* Decide if ARIA attributes are okay */
   let ALLOW_ARIA_ATTR = true;
   /* Decide if custom data attributes are okay */
@@ -538,15 +633,15 @@ function createDOMPurify() {
     // HTML tags and attributes are not case-sensitive, converting to lowercase. Keeping XHTML as is.
     transformCaseFunc = PARSER_MEDIA_TYPE === 'application/xhtml+xml' ? stringToString : stringToLowerCase;
     /* Set configuration parameters */
-    ALLOWED_TAGS = objectHasOwnProperty(cfg, 'ALLOWED_TAGS') ? addToSet({}, cfg.ALLOWED_TAGS, transformCaseFunc) : DEFAULT_ALLOWED_TAGS;
-    ALLOWED_ATTR = objectHasOwnProperty(cfg, 'ALLOWED_ATTR') ? addToSet({}, cfg.ALLOWED_ATTR, transformCaseFunc) : DEFAULT_ALLOWED_ATTR;
-    ALLOWED_NAMESPACES = objectHasOwnProperty(cfg, 'ALLOWED_NAMESPACES') ? addToSet({}, cfg.ALLOWED_NAMESPACES, stringToString) : DEFAULT_ALLOWED_NAMESPACES;
-    URI_SAFE_ATTRIBUTES = objectHasOwnProperty(cfg, 'ADD_URI_SAFE_ATTR') ? addToSet(clone(DEFAULT_URI_SAFE_ATTRIBUTES), cfg.ADD_URI_SAFE_ATTR, transformCaseFunc) : DEFAULT_URI_SAFE_ATTRIBUTES;
-    DATA_URI_TAGS = objectHasOwnProperty(cfg, 'ADD_DATA_URI_TAGS') ? addToSet(clone(DEFAULT_DATA_URI_TAGS), cfg.ADD_DATA_URI_TAGS, transformCaseFunc) : DEFAULT_DATA_URI_TAGS;
-    FORBID_CONTENTS = objectHasOwnProperty(cfg, 'FORBID_CONTENTS') ? addToSet({}, cfg.FORBID_CONTENTS, transformCaseFunc) : DEFAULT_FORBID_CONTENTS;
-    FORBID_TAGS = objectHasOwnProperty(cfg, 'FORBID_TAGS') ? addToSet({}, cfg.FORBID_TAGS, transformCaseFunc) : clone({});
-    FORBID_ATTR = objectHasOwnProperty(cfg, 'FORBID_ATTR') ? addToSet({}, cfg.FORBID_ATTR, transformCaseFunc) : clone({});
-    USE_PROFILES = objectHasOwnProperty(cfg, 'USE_PROFILES') ? cfg.USE_PROFILES : false;
+    ALLOWED_TAGS = objectHasOwnProperty(cfg, 'ALLOWED_TAGS') && arrayIsArray(cfg.ALLOWED_TAGS) ? addToSet({}, cfg.ALLOWED_TAGS, transformCaseFunc) : DEFAULT_ALLOWED_TAGS;
+    ALLOWED_ATTR = objectHasOwnProperty(cfg, 'ALLOWED_ATTR') && arrayIsArray(cfg.ALLOWED_ATTR) ? addToSet({}, cfg.ALLOWED_ATTR, transformCaseFunc) : DEFAULT_ALLOWED_ATTR;
+    ALLOWED_NAMESPACES = objectHasOwnProperty(cfg, 'ALLOWED_NAMESPACES') && arrayIsArray(cfg.ALLOWED_NAMESPACES) ? addToSet({}, cfg.ALLOWED_NAMESPACES, stringToString) : DEFAULT_ALLOWED_NAMESPACES;
+    URI_SAFE_ATTRIBUTES = objectHasOwnProperty(cfg, 'ADD_URI_SAFE_ATTR') && arrayIsArray(cfg.ADD_URI_SAFE_ATTR) ? addToSet(clone(DEFAULT_URI_SAFE_ATTRIBUTES), cfg.ADD_URI_SAFE_ATTR, transformCaseFunc) : DEFAULT_URI_SAFE_ATTRIBUTES;
+    DATA_URI_TAGS = objectHasOwnProperty(cfg, 'ADD_DATA_URI_TAGS') && arrayIsArray(cfg.ADD_DATA_URI_TAGS) ? addToSet(clone(DEFAULT_DATA_URI_TAGS), cfg.ADD_DATA_URI_TAGS, transformCaseFunc) : DEFAULT_DATA_URI_TAGS;
+    FORBID_CONTENTS = objectHasOwnProperty(cfg, 'FORBID_CONTENTS') && arrayIsArray(cfg.FORBID_CONTENTS) ? addToSet({}, cfg.FORBID_CONTENTS, transformCaseFunc) : DEFAULT_FORBID_CONTENTS;
+    FORBID_TAGS = objectHasOwnProperty(cfg, 'FORBID_TAGS') && arrayIsArray(cfg.FORBID_TAGS) ? addToSet({}, cfg.FORBID_TAGS, transformCaseFunc) : clone({});
+    FORBID_ATTR = objectHasOwnProperty(cfg, 'FORBID_ATTR') && arrayIsArray(cfg.FORBID_ATTR) ? addToSet({}, cfg.FORBID_ATTR, transformCaseFunc) : clone({});
+    USE_PROFILES = objectHasOwnProperty(cfg, 'USE_PROFILES') ? cfg.USE_PROFILES && typeof cfg.USE_PROFILES === 'object' ? clone(cfg.USE_PROFILES) : cfg.USE_PROFILES : false;
     ALLOW_ARIA_ATTR = cfg.ALLOW_ARIA_ATTR !== false; // Default true
     ALLOW_DATA_ATTR = cfg.ALLOW_DATA_ATTR !== false; // Default true
     ALLOW_UNKNOWN_PROTOCOLS = cfg.ALLOW_UNKNOWN_PROTOCOLS || false; // Default false
@@ -562,19 +657,20 @@ function createDOMPurify() {
     SANITIZE_NAMED_PROPS = cfg.SANITIZE_NAMED_PROPS || false; // Default false
     KEEP_CONTENT = cfg.KEEP_CONTENT !== false; // Default true
     IN_PLACE = cfg.IN_PLACE || false; // Default false
-    IS_ALLOWED_URI$1 = cfg.ALLOWED_URI_REGEXP || IS_ALLOWED_URI;
-    NAMESPACE = cfg.NAMESPACE || HTML_NAMESPACE;
-    MATHML_TEXT_INTEGRATION_POINTS = cfg.MATHML_TEXT_INTEGRATION_POINTS || MATHML_TEXT_INTEGRATION_POINTS;
-    HTML_INTEGRATION_POINTS = cfg.HTML_INTEGRATION_POINTS || HTML_INTEGRATION_POINTS;
-    CUSTOM_ELEMENT_HANDLING = cfg.CUSTOM_ELEMENT_HANDLING || {};
-    if (cfg.CUSTOM_ELEMENT_HANDLING && isRegexOrFunction(cfg.CUSTOM_ELEMENT_HANDLING.tagNameCheck)) {
-      CUSTOM_ELEMENT_HANDLING.tagNameCheck = cfg.CUSTOM_ELEMENT_HANDLING.tagNameCheck;
+    IS_ALLOWED_URI$1 = isRegex(cfg.ALLOWED_URI_REGEXP) ? cfg.ALLOWED_URI_REGEXP : IS_ALLOWED_URI; // Default regexp
+    NAMESPACE = typeof cfg.NAMESPACE === 'string' ? cfg.NAMESPACE : HTML_NAMESPACE; // Default HTML namespace
+    MATHML_TEXT_INTEGRATION_POINTS = objectHasOwnProperty(cfg, 'MATHML_TEXT_INTEGRATION_POINTS') && cfg.MATHML_TEXT_INTEGRATION_POINTS && typeof cfg.MATHML_TEXT_INTEGRATION_POINTS === 'object' ? clone(cfg.MATHML_TEXT_INTEGRATION_POINTS) : addToSet({}, ['mi', 'mo', 'mn', 'ms', 'mtext']); // Default built-in map
+    HTML_INTEGRATION_POINTS = objectHasOwnProperty(cfg, 'HTML_INTEGRATION_POINTS') && cfg.HTML_INTEGRATION_POINTS && typeof cfg.HTML_INTEGRATION_POINTS === 'object' ? clone(cfg.HTML_INTEGRATION_POINTS) : addToSet({}, ['annotation-xml']); // Default built-in map
+    const customElementHandling = objectHasOwnProperty(cfg, 'CUSTOM_ELEMENT_HANDLING') && cfg.CUSTOM_ELEMENT_HANDLING && typeof cfg.CUSTOM_ELEMENT_HANDLING === 'object' ? clone(cfg.CUSTOM_ELEMENT_HANDLING) : create(null);
+    CUSTOM_ELEMENT_HANDLING = create(null);
+    if (objectHasOwnProperty(customElementHandling, 'tagNameCheck') && isRegexOrFunction(customElementHandling.tagNameCheck)) {
+      CUSTOM_ELEMENT_HANDLING.tagNameCheck = customElementHandling.tagNameCheck; // Default undefined
     }
-    if (cfg.CUSTOM_ELEMENT_HANDLING && isRegexOrFunction(cfg.CUSTOM_ELEMENT_HANDLING.attributeNameCheck)) {
-      CUSTOM_ELEMENT_HANDLING.attributeNameCheck = cfg.CUSTOM_ELEMENT_HANDLING.attributeNameCheck;
+    if (objectHasOwnProperty(customElementHandling, 'attributeNameCheck') && isRegexOrFunction(customElementHandling.attributeNameCheck)) {
+      CUSTOM_ELEMENT_HANDLING.attributeNameCheck = customElementHandling.attributeNameCheck; // Default undefined
     }
-    if (cfg.CUSTOM_ELEMENT_HANDLING && typeof cfg.CUSTOM_ELEMENT_HANDLING.allowCustomizedBuiltInElements === 'boolean') {
-      CUSTOM_ELEMENT_HANDLING.allowCustomizedBuiltInElements = cfg.CUSTOM_ELEMENT_HANDLING.allowCustomizedBuiltInElements;
+    if (objectHasOwnProperty(customElementHandling, 'allowCustomizedBuiltInElements') && typeof customElementHandling.allowCustomizedBuiltInElements === 'boolean') {
+      CUSTOM_ELEMENT_HANDLING.allowCustomizedBuiltInElements = customElementHandling.allowCustomizedBuiltInElements; // Default undefined
     }
     if (SAFE_FOR_TEMPLATES) {
       ALLOW_DATA_ATTR = false;
@@ -585,7 +681,7 @@ function createDOMPurify() {
     /* Parse profile info */
     if (USE_PROFILES) {
       ALLOWED_TAGS = addToSet({}, text);
-      ALLOWED_ATTR = [];
+      ALLOWED_ATTR = create(null);
       if (USE_PROFILES.html === true) {
         addToSet(ALLOWED_TAGS, html$1);
         addToSet(ALLOWED_ATTR, html);
@@ -606,27 +702,45 @@ function createDOMPurify() {
         addToSet(ALLOWED_ATTR, xml);
       }
     }
+    /* Always reset function-based ADD_TAGS / ADD_ATTR checks to prevent
+     * leaking across calls when switching from function to array config */
+    EXTRA_ELEMENT_HANDLING.tagCheck = null;
+    EXTRA_ELEMENT_HANDLING.attributeCheck = null;
     /* Merge configuration parameters */
-    if (cfg.ADD_TAGS) {
-      if (ALLOWED_TAGS === DEFAULT_ALLOWED_TAGS) {
-        ALLOWED_TAGS = clone(ALLOWED_TAGS);
+    if (objectHasOwnProperty(cfg, 'ADD_TAGS')) {
+      if (typeof cfg.ADD_TAGS === 'function') {
+        EXTRA_ELEMENT_HANDLING.tagCheck = cfg.ADD_TAGS;
+      } else if (arrayIsArray(cfg.ADD_TAGS)) {
+        if (ALLOWED_TAGS === DEFAULT_ALLOWED_TAGS) {
+          ALLOWED_TAGS = clone(ALLOWED_TAGS);
+        }
+        addToSet(ALLOWED_TAGS, cfg.ADD_TAGS, transformCaseFunc);
       }
-      addToSet(ALLOWED_TAGS, cfg.ADD_TAGS, transformCaseFunc);
     }
-    if (cfg.ADD_ATTR) {
-      if (ALLOWED_ATTR === DEFAULT_ALLOWED_ATTR) {
-        ALLOWED_ATTR = clone(ALLOWED_ATTR);
+    if (objectHasOwnProperty(cfg, 'ADD_ATTR')) {
+      if (typeof cfg.ADD_ATTR === 'function') {
+        EXTRA_ELEMENT_HANDLING.attributeCheck = cfg.ADD_ATTR;
+      } else if (arrayIsArray(cfg.ADD_ATTR)) {
+        if (ALLOWED_ATTR === DEFAULT_ALLOWED_ATTR) {
+          ALLOWED_ATTR = clone(ALLOWED_ATTR);
+        }
+        addToSet(ALLOWED_ATTR, cfg.ADD_ATTR, transformCaseFunc);
       }
-      addToSet(ALLOWED_ATTR, cfg.ADD_ATTR, transformCaseFunc);
     }
-    if (cfg.ADD_URI_SAFE_ATTR) {
+    if (objectHasOwnProperty(cfg, 'ADD_URI_SAFE_ATTR') && arrayIsArray(cfg.ADD_URI_SAFE_ATTR)) {
       addToSet(URI_SAFE_ATTRIBUTES, cfg.ADD_URI_SAFE_ATTR, transformCaseFunc);
     }
-    if (cfg.FORBID_CONTENTS) {
+    if (objectHasOwnProperty(cfg, 'FORBID_CONTENTS') && arrayIsArray(cfg.FORBID_CONTENTS)) {
       if (FORBID_CONTENTS === DEFAULT_FORBID_CONTENTS) {
         FORBID_CONTENTS = clone(FORBID_CONTENTS);
       }
       addToSet(FORBID_CONTENTS, cfg.FORBID_CONTENTS, transformCaseFunc);
+    }
+    if (objectHasOwnProperty(cfg, 'ADD_FORBID_CONTENTS') && arrayIsArray(cfg.ADD_FORBID_CONTENTS)) {
+      if (FORBID_CONTENTS === DEFAULT_FORBID_CONTENTS) {
+        FORBID_CONTENTS = clone(FORBID_CONTENTS);
+      }
+      addToSet(FORBID_CONTENTS, cfg.ADD_FORBID_CONTENTS, transformCaseFunc);
     }
     /* Add #text in case KEEP_CONTENT is set to true */
     if (KEEP_CONTENT) {
@@ -862,6 +976,40 @@ function createDOMPurify() {
     NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_COMMENT | NodeFilter.SHOW_TEXT | NodeFilter.SHOW_PROCESSING_INSTRUCTION | NodeFilter.SHOW_CDATA_SECTION, null);
   };
   /**
+   * Strip template-engine expressions ({{...}}, ${...}, <%...%>) from the
+   * character data of an element subtree. Used as the final safety net for
+   * SAFE_FOR_TEMPLATES on every DOM-returning code path so that expressions
+   * which only form after text-node normalization (e.g. fragments split across
+   * stripped elements) cannot survive into a template-evaluating framework.
+   *
+   * Walks text/comment/CDATA/processing-instruction nodes and mutates `.data`
+   * in place rather than round-tripping through innerHTML. This preserves
+   * descendant node references (important for IN_PLACE callers), avoids a
+   * serialize/reparse cycle, and reads literal character data — which means
+   * `<%...%>` in text content matches the ERB regex against its real bytes
+   * instead of the HTML-entity-escaped form innerHTML would produce.
+   *
+   * Attribute values are not visited here; SAFE_FOR_TEMPLATES handling for
+   * attributes is performed during the per-node `_sanitizeAttributes` pass.
+   *
+   * @param node The root element whose character data should be scrubbed.
+   */
+  const _scrubTemplateExpressions = function _scrubTemplateExpressions(node) {
+    node.normalize();
+    const walker = createNodeIterator.call(node.ownerDocument || node, node,
+    // eslint-disable-next-line no-bitwise
+    NodeFilter.SHOW_TEXT | NodeFilter.SHOW_COMMENT | NodeFilter.SHOW_CDATA_SECTION | NodeFilter.SHOW_PROCESSING_INSTRUCTION, null);
+    let currentNode = walker.nextNode();
+    while (currentNode) {
+      let data = currentNode.data;
+      arrayForEach([MUSTACHE_EXPR$1, ERB_EXPR$1, TMPLIT_EXPR$1], expr => {
+        data = stringReplace(data, expr, ' ');
+      });
+      currentNode.data = data;
+      currentNode = walker.nextNode();
+    }
+  };
+  /**
    * _isClobbered
    *
    * @param element element to check for clobbering attacks
@@ -871,13 +1019,31 @@ function createDOMPurify() {
     return element instanceof HTMLFormElement && (typeof element.nodeName !== 'string' || typeof element.textContent !== 'string' || typeof element.removeChild !== 'function' || !(element.attributes instanceof NamedNodeMap) || typeof element.removeAttribute !== 'function' || typeof element.setAttribute !== 'function' || typeof element.namespaceURI !== 'string' || typeof element.insertBefore !== 'function' || typeof element.hasChildNodes !== 'function');
   };
   /**
-   * Checks whether the given object is a DOM node.
+   * Checks whether the given object is a DOM node, including nodes that
+   * originate from a different window/realm (e.g. an iframe's
+   * contentDocument). The previous `value instanceof Node` check was
+   * realm-bound: nodes from a different window failed it, causing
+   * sanitize() to silently stringify them and reset IN_PLACE to false,
+   * returning the original node unsanitized. See GHSA-4w3q-35jp-p934.
+   *
+   * Implementation: call the cached `nodeType` getter from Node.prototype
+   * directly on the value. This bypasses any clobbered instance property
+   * (e.g. a child element named "nodeType") and works across realms
+   * because the WebIDL `nodeType` getter reads an internal slot that
+   * every real Node has, regardless of which window minted it.
    *
    * @param value object to check whether it's a DOM node
-   * @return true is object is a DOM node
+   * @return true if value is a DOM node from any realm
    */
   const _isNode = function _isNode(value) {
-    return typeof Node === 'function' && value instanceof Node;
+    if (!getNodeType || typeof value !== 'object' || value === null) {
+      return false;
+    }
+    try {
+      return typeof getNodeType(value) === 'number';
+    } catch (_) {
+      return false;
+    }
   };
   function _executeHooks(hooks, currentNode, data) {
     arrayForEach(hooks, hook => {
@@ -914,6 +1080,11 @@ function createDOMPurify() {
       _forceRemove(currentNode);
       return true;
     }
+    /* Remove risky CSS construction leading to mXSS */
+    if (SAFE_FOR_XML && currentNode.namespaceURI === HTML_NAMESPACE && tagName === 'style' && _isNode(currentNode.firstElementChild)) {
+      _forceRemove(currentNode);
+      return true;
+    }
     /* Remove any occurrence of processing instructions */
     if (currentNode.nodeType === NODE_TYPE.progressingInstruction) {
       _forceRemove(currentNode);
@@ -925,7 +1096,7 @@ function createDOMPurify() {
       return true;
     }
     /* Remove element if anything forbids its presence */
-    if (!ALLOWED_TAGS[tagName] || FORBID_TAGS[tagName]) {
+    if (FORBID_TAGS[tagName] || !(EXTRA_ELEMENT_HANDLING.tagCheck instanceof Function && EXTRA_ELEMENT_HANDLING.tagCheck(tagName)) && !ALLOWED_TAGS[tagName]) {
       /* Check if we have a custom element to handle */
       if (!FORBID_TAGS[tagName] && _isBasicCustomElement(tagName)) {
         if (CUSTOM_ELEMENT_HANDLING.tagNameCheck instanceof RegExp && regExpTest(CUSTOM_ELEMENT_HANDLING.tagNameCheck, tagName)) {
@@ -943,7 +1114,6 @@ function createDOMPurify() {
           const childCount = childNodes.length;
           for (let i = childCount - 1; i >= 0; --i) {
             const childClone = cloneNode(childNodes[i], true);
-            childClone.__removalCount = (currentNode.__removalCount || 0) + 1;
             parentNode.insertBefore(childClone, getNextSibling(currentNode));
           }
         }
@@ -965,7 +1135,7 @@ function createDOMPurify() {
     if (SAFE_FOR_TEMPLATES && currentNode.nodeType === NODE_TYPE.text) {
       /* Get the element's text content */
       content = currentNode.textContent;
-      arrayForEach([MUSTACHE_EXPR, ERB_EXPR, TMPLIT_EXPR], expr => {
+      arrayForEach([MUSTACHE_EXPR$1, ERB_EXPR$1, TMPLIT_EXPR$1], expr => {
         content = stringReplace(content, expr, ' ');
       });
       if (currentNode.textContent !== content) {
@@ -989,15 +1159,20 @@ function createDOMPurify() {
    */
   // eslint-disable-next-line complexity
   const _isValidAttribute = function _isValidAttribute(lcTag, lcName, value) {
+    /* FORBID_ATTR must always win, even if ADD_ATTR predicate would allow it */
+    if (FORBID_ATTR[lcName]) {
+      return false;
+    }
     /* Make sure attribute cannot clobber */
     if (SANITIZE_DOM && (lcName === 'id' || lcName === 'name') && (value in document || value in formElement)) {
       return false;
     }
+    const nameIsPermitted = ALLOWED_ATTR[lcName] || EXTRA_ELEMENT_HANDLING.attributeCheck instanceof Function && EXTRA_ELEMENT_HANDLING.attributeCheck(lcName, lcTag);
     /* Allow valid data-* attributes: At least one character after "-"
         (https://html.spec.whatwg.org/multipage/dom.html#embedding-custom-non-visible-data-with-the-data-*-attributes)
         XML-compatible (https://html.spec.whatwg.org/multipage/infrastructure.html#xml-compatible and http://www.w3.org/TR/xml/#d0e804)
         We don't need to check the value; it's always URI safe. */
-    if (ALLOW_DATA_ATTR && !FORBID_ATTR[lcName] && regExpTest(DATA_ATTR, lcName)) ; else if (ALLOW_ARIA_ATTR && regExpTest(ARIA_ATTR, lcName)) ; else if (!ALLOWED_ATTR[lcName] || FORBID_ATTR[lcName]) {
+    if (ALLOW_DATA_ATTR && !FORBID_ATTR[lcName] && regExpTest(DATA_ATTR$1, lcName)) ; else if (ALLOW_ARIA_ATTR && regExpTest(ARIA_ATTR$1, lcName)) ; else if (!nameIsPermitted || FORBID_ATTR[lcName]) {
       if (
       // First condition does a very basic check if a) it's basically a valid custom element tagname AND
       // b) if the tagName passes whatever the user has configured for CUSTOM_ELEMENT_HANDLING.tagNameCheck
@@ -1009,11 +1184,15 @@ function createDOMPurify() {
         return false;
       }
       /* Check value is safe. First, is attr inert? If so, is safe */
-    } else if (URI_SAFE_ATTRIBUTES[lcName]) ; else if (regExpTest(IS_ALLOWED_URI$1, stringReplace(value, ATTR_WHITESPACE, ''))) ; else if ((lcName === 'src' || lcName === 'xlink:href' || lcName === 'href') && lcTag !== 'script' && stringIndexOf(value, 'data:') === 0 && DATA_URI_TAGS[lcTag]) ; else if (ALLOW_UNKNOWN_PROTOCOLS && !regExpTest(IS_SCRIPT_OR_DATA, stringReplace(value, ATTR_WHITESPACE, ''))) ; else if (value) {
+    } else if (URI_SAFE_ATTRIBUTES[lcName]) ; else if (regExpTest(IS_ALLOWED_URI$1, stringReplace(value, ATTR_WHITESPACE$1, ''))) ; else if ((lcName === 'src' || lcName === 'xlink:href' || lcName === 'href') && lcTag !== 'script' && stringIndexOf(value, 'data:') === 0 && DATA_URI_TAGS[lcTag]) ; else if (ALLOW_UNKNOWN_PROTOCOLS && !regExpTest(IS_SCRIPT_OR_DATA$1, stringReplace(value, ATTR_WHITESPACE$1, ''))) ; else if (value) {
       return false;
     } else ;
     return true;
   };
+  /* Names the HTML spec reserves from valid-custom-element-name; these must
+   * never be treated as basic custom elements even when a permissive
+   * CUSTOM_ELEMENT_HANDLING.tagNameCheck is configured. */
+  const RESERVED_CUSTOM_ELEMENT_NAMES = addToSet({}, ['annotation-xml', 'color-profile', 'font-face', 'font-face-format', 'font-face-name', 'font-face-src', 'font-face-uri', 'missing-glyph']);
   /**
    * _isBasicCustomElement
    * checks if at least one dash is included in tagName, and it's not the first char
@@ -1023,7 +1202,7 @@ function createDOMPurify() {
    * @returns Returns true if the tag name meets the basic criteria for a custom element, otherwise false.
    */
   const _isBasicCustomElement = function _isBasicCustomElement(tagName) {
-    return tagName !== 'annotation-xml' && stringMatch(tagName, CUSTOM_ELEMENT);
+    return !RESERVED_CUSTOM_ELEMENT_NAMES[stringToLowerCase(tagName)] && regExpTest(CUSTOM_ELEMENT$1, tagName);
   };
   /**
    * _sanitizeAttributes
@@ -1038,9 +1217,7 @@ function createDOMPurify() {
   const _sanitizeAttributes = function _sanitizeAttributes(currentNode) {
     /* Execute a hook if present */
     _executeHooks(hooks.beforeSanitizeAttributes, currentNode, null);
-    const {
-      attributes
-    } = currentNode;
+    const attributes = currentNode.attributes;
     /* Check if we have attributes; if not we might have a text node */
     if (!attributes || _isClobbered(currentNode)) {
       return;
@@ -1056,11 +1233,9 @@ function createDOMPurify() {
     /* Go backwards over all attributes; safely remove bad ones */
     while (l--) {
       const attr = attributes[l];
-      const {
-        name,
-        namespaceURI,
-        value: attrValue
-      } = attr;
+      const name = attr.name,
+        namespaceURI = attr.namespaceURI,
+        attrValue = attr.value;
       const lcName = transformCaseFunc(name);
       const initValue = attrValue;
       let value = name === 'value' ? initValue : stringTrim(initValue);
@@ -1074,14 +1249,16 @@ function createDOMPurify() {
       /* Full DOM Clobbering protection via namespace isolation,
        * Prefix id and name attributes with `user-content-`
        */
-      if (SANITIZE_NAMED_PROPS && (lcName === 'id' || lcName === 'name')) {
+      if (SANITIZE_NAMED_PROPS && (lcName === 'id' || lcName === 'name') && stringIndexOf(value, SANITIZE_NAMED_PROPS_PREFIX) !== 0) {
         // Remove the attribute with this value
         _removeAttribute(name, currentNode);
         // Prefix the value and later re-create the attribute with the sanitized value
         value = SANITIZE_NAMED_PROPS_PREFIX + value;
       }
+      // Else: already prefixed, leave the attribute alone — the prefix is
+      // itself the clobbering protection, and re-applying it is incorrect.
       /* Work around a security issue with comments inside attributes */
-      if (SAFE_FOR_XML && regExpTest(/((--!?|])>)|<\/(style|title|textarea)/i, value)) {
+      if (SAFE_FOR_XML && regExpTest(/((--!?|])>)|<\/(style|script|title|xmp|textarea|noscript|iframe|noembed|noframes)/i, value)) {
         _removeAttribute(name, currentNode);
         continue;
       }
@@ -1106,7 +1283,7 @@ function createDOMPurify() {
       }
       /* Sanitize attribute content to be template-safe */
       if (SAFE_FOR_TEMPLATES) {
-        arrayForEach([MUSTACHE_EXPR, ERB_EXPR, TMPLIT_EXPR], expr => {
+        arrayForEach([MUSTACHE_EXPR$1, ERB_EXPR$1, TMPLIT_EXPR$1], expr => {
           value = stringReplace(value, expr, ' ');
         });
       }
@@ -1160,7 +1337,7 @@ function createDOMPurify() {
    *
    * @param fragment to iterate over recursively
    */
-  const _sanitizeShadowDOM = function _sanitizeShadowDOM(fragment) {
+  const _sanitizeShadowDOM2 = function _sanitizeShadowDOM(fragment) {
     let shadowNode = null;
     const shadowIterator = _createNodeIterator(fragment);
     /* Execute a hook if present */
@@ -1174,11 +1351,54 @@ function createDOMPurify() {
       _sanitizeAttributes(shadowNode);
       /* Deep shadow DOM detected */
       if (shadowNode.content instanceof DocumentFragment) {
-        _sanitizeShadowDOM(shadowNode.content);
+        _sanitizeShadowDOM2(shadowNode.content);
       }
     }
     /* Execute a hook if present */
     _executeHooks(hooks.afterSanitizeShadowDOM, fragment, null);
+  };
+  /**
+   * _sanitizeAttachedShadowRoots
+   *
+   * Walks `root` and feeds every attached shadow root we encounter into
+   * the existing _sanitizeShadowDOM pipeline. The default node iterator
+   * does not descend into shadow trees, so nodes inside an attached
+   * shadow root would otherwise be skipped entirely.
+   *
+   * Two real input paths put attached shadow roots in front of us:
+   *   1. IN_PLACE on a DOM node that already has shadow roots attached.
+   *   2. DOM-node input where importNode(dirty, true) deep-clones the
+   *      shadow root because it was created with `clonable: true`.
+   *
+   * This pass runs once, up front, so the main iteration loop (and the
+   * existing _sanitizeShadowDOM template-content recursion) stay
+   * untouched — string-input paths are not affected.
+   *
+   * @param root the subtree root to walk for attached shadow roots
+   */
+  const _sanitizeAttachedShadowRoots2 = function _sanitizeAttachedShadowRoots(root) {
+    if (root.nodeType === NODE_TYPE.element && root.shadowRoot instanceof DocumentFragment) {
+      const sr = root.shadowRoot;
+      // Recurse first so that nested shadow roots are reached even if
+      // _sanitizeShadowDOM removes hosts at this level.
+      _sanitizeAttachedShadowRoots2(sr);
+      _sanitizeShadowDOM2(sr);
+    }
+    // Snapshot children before recursing. Sanitization of one subtree
+    // (e.g. via an uponSanitizeShadowNode hook) may detach siblings,
+    // and naive nextSibling traversal would silently skip the rest of
+    // the list once a node is detached.
+    const childNodes = root.childNodes;
+    if (!childNodes) {
+      return;
+    }
+    const snapshot = [];
+    arrayForEach(childNodes, child => {
+      arrayPush(snapshot, child);
+    });
+    for (const child of snapshot) {
+      _sanitizeAttachedShadowRoots2(child);
+    }
   };
   // eslint-disable-next-line complexity
   DOMPurify.sanitize = function (dirty) {
@@ -1196,13 +1416,9 @@ function createDOMPurify() {
     }
     /* Stringify, in case dirty is an object */
     if (typeof dirty !== 'string' && !_isNode(dirty)) {
-      if (typeof dirty.toString === 'function') {
-        dirty = dirty.toString();
-        if (typeof dirty !== 'string') {
-          throw typeErrorCreate('dirty is not a string, aborting');
-        }
-      } else {
-        throw typeErrorCreate('toString is not a function');
+      dirty = stringifyValue(dirty);
+      if (typeof dirty !== 'string') {
+        throw typeErrorCreate('dirty is not a string, aborting');
       }
     }
     /* Return dirty HTML if DOMPurify cannot run */
@@ -1221,13 +1437,17 @@ function createDOMPurify() {
     }
     if (IN_PLACE) {
       /* Do some early pre-sanitization to avoid unsafe root nodes */
-      if (dirty.nodeName) {
-        const tagName = transformCaseFunc(dirty.nodeName);
+      const nn = dirty.nodeName;
+      if (typeof nn === 'string') {
+        const tagName = transformCaseFunc(nn);
         if (!ALLOWED_TAGS[tagName] || FORBID_TAGS[tagName]) {
           throw typeErrorCreate('root node is forbidden and cannot be sanitized in-place');
         }
       }
-    } else if (dirty instanceof Node) {
+      /* Sanitize attached shadow roots before the main iterator runs.
+         The iterator does not descend into shadow trees. */
+      _sanitizeAttachedShadowRoots2(dirty);
+    } else if (_isNode(dirty)) {
       /* If dirty is a DOM element, append to an empty document to avoid
          elements being stripped by the parser */
       body = _initDocument('<!---->');
@@ -1241,6 +1461,10 @@ function createDOMPurify() {
         // eslint-disable-next-line unicorn/prefer-dom-node-append
         body.appendChild(importedNode);
       }
+      /* Clonable shadow roots are deep-cloned by importNode(); sanitize
+         them before the main iterator runs, since the iterator does not
+         descend into shadow trees. */
+      _sanitizeAttachedShadowRoots2(importedNode);
     } else {
       /* Exit directly if we have nothing to do */
       if (!RETURN_DOM && !SAFE_FOR_TEMPLATES && !WHOLE_DOCUMENT &&
@@ -1269,15 +1493,21 @@ function createDOMPurify() {
       _sanitizeAttributes(currentNode);
       /* Shadow DOM detected, sanitize it */
       if (currentNode.content instanceof DocumentFragment) {
-        _sanitizeShadowDOM(currentNode.content);
+        _sanitizeShadowDOM2(currentNode.content);
       }
     }
     /* If we sanitized `dirty` in-place, return it. */
     if (IN_PLACE) {
+      if (SAFE_FOR_TEMPLATES) {
+        _scrubTemplateExpressions(dirty);
+      }
       return dirty;
     }
     /* Return sanitized string or DOM */
     if (RETURN_DOM) {
+      if (SAFE_FOR_TEMPLATES) {
+        _scrubTemplateExpressions(body);
+      }
       if (RETURN_DOM_FRAGMENT) {
         returnNode = createDocumentFragment.call(body.ownerDocument);
         while (body.firstChild) {
@@ -1306,7 +1536,7 @@ function createDOMPurify() {
     }
     /* Sanitize final string template-safe */
     if (SAFE_FOR_TEMPLATES) {
-      arrayForEach([MUSTACHE_EXPR, ERB_EXPR, TMPLIT_EXPR], expr => {
+      arrayForEach([MUSTACHE_EXPR$1, ERB_EXPR$1, TMPLIT_EXPR$1], expr => {
         serializedHTML = stringReplace(serializedHTML, expr, ' ');
       });
     }

--- a/src/vs/base/browser/dompurify/dompurify.license.txt
+++ b/src/vs/base/browser/dompurify/dompurify.license.txt
@@ -1,5 +1,5 @@
 DOMPurify
-Copyright 2015 Mario Heiderich
+Copyright 2025 Dr.-Ing. Mario Heiderich, Cure53
 
 DOMPurify is free software; you can redistribute it and/or modify it under the
 terms of either:


### PR DESCRIPTION
Updates the vendored DOMPurify copy at `src/vs/base/browser/dompurify/` from 3.2.7 to 3.4.5, addressing the following CVEs:

| CVE | Severity | Fixed in |
|-----|----------|----------|
| CVE-2026-0540 | Medium (6.1) | 3.3.2 |
| CVE-2026-41238 | Medium (6.9) | 3.4.0 |
| CVE-2026-41239 | Medium (6.8) | 3.4.0 |
| CVE-2026-41240 | Medium (6.0) | 3.4.0 |

VS Code's usage (via `domSanitize.ts`) does not exercise the affected code paths for most of these CVEs, as it never uses `SAFE_FOR_TEMPLATES`, `CUSTOM_ELEMENT_HANDLING`, function-form `ADD_TAGS`/`ADD_ATTR`, or `FORBID_TAGS`.

Fixes #313084