### PR TITLE
Disable walkthrough if ai features disabled on startup

### DIFF
--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -2961,11 +2961,12 @@ class LayoutStateModel extends Disposable {
 				return true;
 			}
 
-			// New users: Show auxiliary bar even in empty workspaces
-			// but not if the user explicitly hides it
+			// New users: Show auxiliary bar even in empty workspaces,
+			// but not if the user explicitly hides it or AI features are disabled.
 			if (
 				this.isNew[StorageScope.APPLICATION] &&
-				configuration.value !== 'hidden'
+				configuration.value !== 'hidden' &&
+				!this.configurationService.getValue<boolean>('chat.disableAIFeatures')
 			) {
 				return false;
 			}

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/startupPage.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/startupPage.ts
@@ -34,6 +34,7 @@ import { getActiveElement } from '../../../../base/browser/dom.js';
 import { isWeb } from '../../../../base/common/platform.js';
 import { IOnboardingService } from '../../welcomeOnboarding/common/onboardingService.js';
 import { ONBOARDING_STORAGE_KEY } from '../../welcomeOnboarding/common/onboardingTypes.js';
+import { IChatEntitlementService } from '../../../services/chat/common/chatEntitlementService.js';
 
 export const restoreWalkthroughsConfigurationKey = 'workbench.welcomePage.restorableWalkthroughs';
 export type RestoreWalkthroughsConfigurationValue = { folder: string; category?: string; step?: string };
@@ -95,6 +96,7 @@ export class StartupPageRunnerContribution extends Disposable implements IWorkbe
 		@INotificationService private readonly notificationService: INotificationService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@IOnboardingService private readonly onboardingService: IOnboardingService,
+		@IChatEntitlementService private readonly chatEntitlementService: IChatEntitlementService,
 	) {
 		super();
 
@@ -244,8 +246,8 @@ export class StartupPageRunnerContribution extends Disposable implements IWorkbe
 			return; // experimental onboarding is disabled
 		}
 
-		if (this.configurationService.getValue<boolean>('chat.disableAIFeatures')) {
-			return; // AI features are disabled, do not show AI-focused onboarding
+		if (this.chatEntitlementService.sentiment.hidden) {
+			return; // AI features are hidden, do not show AI-focused onboarding
 		}
 
 		if (!this.storageService.isNew(StorageScope.APPLICATION)) {

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/startupPage.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/startupPage.ts
@@ -244,6 +244,10 @@ export class StartupPageRunnerContribution extends Disposable implements IWorkbe
 			return; // experimental onboarding is disabled
 		}
 
+		if (this.configurationService.getValue<boolean>('chat.disableAIFeatures')) {
+			return; // AI features are disabled, do not show AI-focused onboarding
+		}
+
 		if (!this.storageService.isNew(StorageScope.APPLICATION)) {
 			return; // only show onboarding for new users who have never used the product before
 		}


### PR DESCRIPTION
This pull request introduces logic to ensure that AI-focused onboarding and UI elements are only shown to users when AI features are enabled and visible. The changes primarily impact the onboarding experience for new users and the display of the auxiliary bar in empty workspaces.

Key changes:

**Onboarding and Welcome Experience:**

* The onboarding flow now checks if AI features are hidden (using `chatEntitlementService.sentiment.hidden`) and skips AI-focused onboarding for users where AI features are not available or visible.
* The `StartupPageRunnerContribution` class now injects the `IChatEntitlementService` dependency to access AI feature visibility.
* The `IChatEntitlementService` import was added to support the above logic.

**Auxiliary Bar Visibility:**

* The logic for showing the auxiliary bar to new users in empty workspaces now also checks if AI features are disabled via the `chat.disableAIFeatures` configuration, and hides the bar if so.

[LayoutStateModel.load()](vscode-file://vscode-app/c:/Users/cowebster/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/183159e2b3/resources/app/out/vs/code/electron-browser/workbench/workbench.html) runs during early layout initialization — before any [WorkbenchPhase](vscode-file://vscode-app/c:/Users/cowebster/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/183159e2b3/resources/app/out/vs/code/electron-browser/workbench/workbench.html). The [ChatEntitlementContext](vscode-file://vscode-app/c:/Users/cowebster/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/183159e2b3/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (which sets the chatSetupHidden context key from [chat.disableAIFeatures](vscode-file://vscode-app/c:/Users/cowebster/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/183159e2b3/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) is lazily created inside [ChatEntitlementService](vscode-file://vscode-app/c:/Users/cowebster/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/183159e2b3/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and won't be resolved yet. So [sentiment.hidden](vscode-file://vscode-app/c:/Users/cowebster/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/183159e2b3/resources/app/out/vs/code/electron-browser/workbench/workbench.html) would always return false at that point, defeating the guard.