### PR TITLE
agent host: clear sticky incompatible status after upgrade reconnect

### DIFF
--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution.ts
@@ -290,16 +290,18 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 		// Update connection status on all providers (including those
 		// that are reconnecting and don't have an active connection).
 		for (const [address, provider] of this._providerInstances) {
-			// Preserve incompatible state — set by the SSH catch and the
-			// generic WebSocket connect failure path. Otherwise this loop
-			// would overwrite it back to `disconnected` on the next event.
-			if (RemoteAgentHostConnectionStatus.isIncompatible(provider.connectionStatus.get())) {
-				continue;
-			}
 			const connectionInfo = this._remoteAgentHostService.connections.find(c => c.address === address);
 			if (connectionInfo) {
+				// Service has an entry for this address — its status is
+				// authoritative (including the `incompatible` set by the
+				// WebSocket connect failure path, and the `connecting`
+				// status of a fresh reconnect attempt after an upgrade).
 				provider.setConnectionStatus(connectionInfo.status);
-			} else {
+			} else if (!RemoteAgentHostConnectionStatus.isIncompatible(provider.connectionStatus.get())) {
+				// No service entry. Preserve incompatible state set by
+				// the SSH reconnect catch (where the failure happens
+				// before the service ever sees an entry); otherwise fall
+				// back to disconnected.
 				provider.setConnectionStatus(RemoteAgentHostConnectionStatus.disconnected);
 			}
 		}

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/tunnelAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/tunnelAgentHost.contribution.ts
@@ -230,16 +230,23 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 
 	private _updateConnectionStatuses(): void {
 		for (const [address, provider] of this._providerInstances) {
-			// Preserve incompatible state until the user retries — otherwise
-			// the catch in `_connectTunnel` would set it and the `finally`
-			// block immediately overwrite it back to `disconnected`.
+			const connectionInfo = this._remoteAgentHostService.connections.find(c => c.address === address);
+			if (connectionInfo) {
+				// Service has an entry — its status is authoritative
+				// (including incompatible from the WebSocket connect
+				// failure path, and connecting/connected from a fresh
+				// reconnect after an upgrade).
+				provider.setConnectionStatus(connectionInfo.status);
+				continue;
+			}
+			// Preserve incompatible state set by `_connectTunnel`'s catch
+			// (where the failure happens before the service ever has an
+			// entry) until the user retries — otherwise the `finally`
+			// block would immediately overwrite it back to `disconnected`.
 			if (RemoteAgentHostConnectionStatus.isIncompatible(provider.connectionStatus.get())) {
 				continue;
 			}
-			const connectionInfo = this._remoteAgentHostService.connections.find(c => c.address === address);
-			if (connectionInfo) {
-				provider.setConnectionStatus(connectionInfo.status);
-			} else if (this._pendingConnects.has(address)) {
+			if (this._pendingConnects.has(address)) {
 				provider.setConnectionStatus(RemoteAgentHostConnectionStatus.connecting);
 			} else if (!this._initialStatusChecked) {
 				// Keep the initial "Connecting" state so the picker doesn't


### PR DESCRIPTION
The provider's status was preserved as `incompatible` in the reconcile loops to prevent it from being clobbered by a subsequent `disconnected` update. But the early-return also blocked legitimate `connecting`/`connected` transitions from a post-upgrade reconnect, leaving the server marked incompatible until the window reloaded.

Only preserve the sticky incompatible state when the service has no entry for the address (the SSH/tunnel catch path, where the failure happens before the service ever sees an entry). When the service does have an entry, its status is authoritative.

Fixes https://github.com/microsoft/vscode/issues/316554