### PR TITLE
Agents web: surface offline tunnels in host picker + add discovery telemetry

### DIFF
--- a/src/vs/sessions/common/sessionsTelemetry.ts
+++ b/src/vs/sessions/common/sessionsTelemetry.ts
@@ -112,6 +112,58 @@ export function logChangesViewReviewCommentAdded(telemetryService: ITelemetrySer
 	telemetryService.publicLog2<ChangesViewReviewCommentAddedEvent, ChangesViewReviewCommentAddedClassification>('vscodeAgents.changesView/reviewCommentAdded', data);
 }
 
+// --- Tunnel agent host discovery ---
+
+export type TunnelDiscoveryTrigger =
+	| 'startup'
+	| 'rediscover'
+	| 'sessionChange';
+
+type TunnelDiscoveryResultEvent = {
+	trigger: string;
+	totalFound: number;
+	withActiveHost: number;
+	cachedBefore: number;
+	autoConnectEnabled: boolean;
+	hostsEnabled: boolean;
+	success: boolean;
+};
+
+type TunnelDiscoveryResultClassification = {
+	owner: 'osortega';
+	comment: 'Tracks the outcome of agent-host tunnel discovery so we can diagnose stuck-after-discovery scenarios where tunnels are found but no providers ever appear.';
+	trigger: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'What initiated the discovery (startup, rediscover, sessionChange).' };
+	totalFound: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of tunnels returned by the embedder after the protocol-version filter.' };
+	withActiveHost: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of discovered tunnels that have a host process currently connected (hostConnectionCount > 0).' };
+	cachedBefore: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of tunnels in the local recent-tunnels cache before this discovery run.' };
+	autoConnectEnabled: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether chat.remoteAgentHostsAutoConnect is enabled.' };
+	hostsEnabled: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether chat.remoteAgentHostsEnabled is enabled.' };
+	success: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Whether the discovery call itself completed (false when listTunnels threw).' };
+};
+
+export function logTunnelDiscoveryResult(
+	telemetryService: ITelemetryService,
+	data: {
+		trigger: TunnelDiscoveryTrigger;
+		totalFound: number;
+		withActiveHost: number;
+		cachedBefore: number;
+		autoConnectEnabled: boolean;
+		hostsEnabled: boolean;
+		success: boolean;
+	},
+): void {
+	telemetryService.publicLog2<TunnelDiscoveryResultEvent, TunnelDiscoveryResultClassification>('vscodeAgents.tunnelDiscovery/result', {
+		trigger: data.trigger,
+		totalFound: data.totalFound,
+		withActiveHost: data.withActiveHost,
+		cachedBefore: data.cachedBefore,
+		autoConnectEnabled: data.autoConnectEnabled,
+		hostsEnabled: data.hostsEnabled,
+		success: data.success,
+	});
+}
+
 // --- Tunnel agent host connect ---
 
 export type TunnelConnectErrorCategory =

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/tunnelAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/tunnelAgentHost.contribution.ts
@@ -17,7 +17,7 @@ import { INotificationService, Severity } from '../../../../../platform/notifica
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../../workbench/common/contributions.js';
 import { AuthenticationSessionsChangeEvent, IAuthenticationService } from '../../../../../workbench/services/authentication/common/authentication.js';
-import { logTunnelConnectAttempt, logTunnelConnectResolved, TunnelConnectErrorCategory, TunnelConnectFailureReason } from '../../../../common/sessionsTelemetry.js';
+import { logTunnelConnectAttempt, logTunnelConnectResolved, logTunnelDiscoveryResult, TunnelConnectErrorCategory, TunnelConnectFailureReason, TunnelDiscoveryTrigger } from '../../../../common/sessionsTelemetry.js';
 import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
 import { IAgentHostFilterService } from '../../../../services/agentHostFilter/common/agentHostFilter.js';
 import { RemoteAgentHostSessionsProvider } from './remoteAgentHostSessionsProvider.js';
@@ -604,7 +604,7 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 		if (added) {
 			this._logService.info(`[TunnelAgentHost] ${e.providerId} session added; resuming reconnects and rediscovering.`);
 			this._resumeReconnects('sessionAdded');
-			this._silentStatusCheck();
+			this._silentStatusCheck('sessionChange');
 		}
 	}
 
@@ -766,15 +766,27 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 
 	// -- Silent status check --
 
-	private async _silentStatusCheck(): Promise<void> {
-		const enabled = this._configurationService.getValue<boolean>(RemoteAgentHostsEnabledSettingId);
-		if (!enabled) {
+	private async _silentStatusCheck(trigger?: TunnelDiscoveryTrigger): Promise<void> {
+		const resolvedTrigger: TunnelDiscoveryTrigger = trigger ?? (this._initialStatusChecked ? 'rediscover' : 'startup');
+		const hostsEnabled = this._configurationService.getValue<boolean>(RemoteAgentHostsEnabledSettingId);
+		const autoConnectEnabled = this._configurationService.getValue<boolean>(RemoteAgentHostAutoConnectSettingId);
+		if (!hostsEnabled) {
 			this._initialStatusChecked = true;
 			this._updateConnectionStatuses();
+			logTunnelDiscoveryResult(this._telemetryService, {
+				trigger: resolvedTrigger,
+				totalFound: 0,
+				withActiveHost: 0,
+				cachedBefore: this._tunnelService.getCachedTunnels().length,
+				autoConnectEnabled,
+				hostsEnabled,
+				success: true,
+			});
 			return;
 		}
 
 		this._lastStatusCheck = Date.now();
+		const cachedBefore = this._tunnelService.getCachedTunnels().length;
 
 		// Fetch tunnel list silently to check online status
 		let onlineTunnels: ITunnelInfo[] | undefined;
@@ -784,6 +796,15 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 			// No cached token or network error — leave statuses as-is
 			this._initialStatusChecked = true;
 			this._updateConnectionStatuses();
+			logTunnelDiscoveryResult(this._telemetryService, {
+				trigger: resolvedTrigger,
+				totalFound: 0,
+				withActiveHost: 0,
+				cachedBefore,
+				autoConnectEnabled,
+				hostsEnabled,
+				success: false,
+			});
 			return;
 		}
 
@@ -797,13 +818,15 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 				}
 			}
 
-			// Auto-cache online tunnels that aren't cached yet so they
-			// appear in the UI on first discovery (e.g. fresh web session).
-			// Pass 'github' as authProvider so _handleSessionsChange can
-			// match these tunnels for teardown on session removal.
+			// Auto-cache every discovered tunnel that isn't cached yet so
+			// it appears in the picker on first discovery (e.g. fresh web
+			// session), including tunnels whose host process is currently
+			// offline — those render grayed-out via the status-update loop
+			// below. Pass 'github' as authProvider so _handleSessionsChange
+			// can match these tunnels for teardown on session removal.
 			const cachedIds = new Set(cached.map(t => t.tunnelId));
 			for (const tunnel of onlineTunnels) {
-				if (!cachedIds.has(tunnel.tunnelId) && tunnel.hostConnectionCount > 0) {
+				if (!cachedIds.has(tunnel.tunnelId)) {
 					this._tunnelService.cacheTunnel(tunnel, 'github');
 				}
 			}
@@ -873,6 +896,21 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 
 		this._initialStatusChecked = true;
 		this._updateConnectionStatuses();
+
+		const totalFound = onlineTunnels?.length ?? 0;
+		const withActiveHost = onlineTunnels?.filter(t => t.hostConnectionCount > 0).length ?? 0;
+		this._logService.info(
+			`[TunnelAgentHost] Silent status check (${resolvedTrigger}): totalFound=${totalFound}, withActiveHost=${withActiveHost}, cachedBefore=${cachedBefore}, autoConnect=${autoConnectEnabled}`
+		);
+		logTunnelDiscoveryResult(this._telemetryService, {
+			trigger: resolvedTrigger,
+			totalFound,
+			withActiveHost,
+			cachedBefore,
+			autoConnectEnabled,
+			hostsEnabled,
+			success: true,
+		});
 	}
 }
 

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/webTunnelAgentHostService.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/webTunnelAgentHostService.ts
@@ -225,7 +225,7 @@ export class WebTunnelAgentHostService extends Disposable implements ITunnelAgen
 			authProvider,
 		});
 		this.clearAutoConnectSuppression(tunnel.tunnelId);
-		this._storeCachedTunnels(filtered.slice(0, 20));
+		this._storeCachedTunnels(filtered);
 		this._onDidChangeTunnels.fire();
 	}
 

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/webTunnelAgentHostService.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/webTunnelAgentHostService.ts
@@ -84,15 +84,29 @@ export class WebTunnelAgentHostService extends Disposable implements ITunnelAgen
 			// The embedder acquires tokens internally via its own auth flow
 			const discovered = await this._discoveryProvider.listTunnels();
 			const results: ITunnelInfo[] = [];
+			let droppedByProtocolVersion = 0;
+			let withoutIds = 0;
 
 			for (const tunnel of discovered) {
 				const info = this._toTunnelInfo(tunnel);
-				if (info && info.protocolVersion >= TUNNEL_MIN_PROTOCOL_VERSION) {
-					results.push(info);
+				if (!info) {
+					withoutIds++;
+					continue;
 				}
+				if (info.protocolVersion < TUNNEL_MIN_PROTOCOL_VERSION) {
+					droppedByProtocolVersion++;
+					this._logService.debug(
+						`${LOG_PREFIX} Dropping tunnel ${info.tunnelId} (protocolVersion=${info.protocolVersion} < ${TUNNEL_MIN_PROTOCOL_VERSION})`
+					);
+					continue;
+				}
+				results.push(info);
 			}
 
-			this._logService.info(`${LOG_PREFIX} Found ${results.length} tunnel(s) with agent host support`);
+			const withActiveHost = results.filter(t => t.hostConnectionCount > 0).length;
+			this._logService.info(
+				`${LOG_PREFIX} Discovery complete: total=${discovered.length}, accepted=${results.length}, withActiveHost=${withActiveHost}, droppedByProtocolVersion=${droppedByProtocolVersion}, droppedMissingIds=${withoutIds}`
+			);
 			return results;
 		} catch (err) {
 			this._logService.error(`${LOG_PREFIX} Failed to list tunnels`, err);

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/electron-browser/tunnelAgentHostServiceImpl.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/electron-browser/tunnelAgentHostServiceImpl.ts
@@ -272,7 +272,7 @@ export class TunnelAgentHostService extends Disposable implements ITunnelAgentHo
 			authProvider,
 		});
 		this.clearAutoConnectSuppression(tunnel.tunnelId);
-		this._storeCachedTunnels(filtered.slice(0, 20));
+		this._storeCachedTunnels(filtered);
 		this._onDidChangeTunnels.fire();
 	}
 


### PR DESCRIPTION
## Why

On a fresh web session (vscode.dev/agents), tunnel discovery would log `Found N tunnel(s) with agent host support` and then nothing happened — the UI stayed on the "Connect a host to get started" empty state. This happened whenever the user had previously created tunnels (e.g. via `code-insiders tunnel`) but no host process was currently attached, since `_silentStatusCheck` auto-cached only tunnels with `hostConnectionCount > 0`.

The picker is already wired to render disconnected providers grayed out for tunnels that have been connected before from this browser profile. The asymmetry was only on *first* discovery: brand-new offline tunnels were silently dropped, returning users saw them grayed out.

## What

**Surface offline tunnels in the picker.** Removed the `hostConnectionCount > 0` gate on the auto-cache loop in `tunnelAgentHost.contribution.ts` so newly discovered offline tunnels become cached providers. The status-update loop right below already marks them as `disconnected` and calls `unpublishCachedSessions()`. The auto-connect loop further down still gates on `hostConnectionCount > 0`, so we do not dial offline tunnels — this is purely a UI surfacing change.

**Add discovery telemetry.** New `vscodeAgents.tunnelDiscovery/result` event in `sessionsTelemetry.ts` with `trigger` (`startup` / `rediscover` / `sessionChange`), `totalFound`, `withActiveHost`, `cachedBefore`, `autoConnectEnabled`, `hostsEnabled`, and `success`. Fired from all three exit paths of `_silentStatusCheck` so we can distinguish empty-discovery, all-offline-tunnels, embedder failures, and gated-off-by-settings in production. Trigger is inferred from `_initialStatusChecked` unless an explicit one is passed.

**Enrich the discovery log.** `[WebTunnelAgentHost]` summary now breaks out `total`, `accepted`, `withActiveHost`, `droppedByProtocolVersion`, and `droppedMissingIds`, with per-tunnel debug logs for protocol-version drops, so the previously stuck-screen scenarios are diagnosable from logs alone.

## Notes for reviewers

- The auto-cache gate has been in place since the feature shipped (`8bae860e068`). I'm treating its removal as an intentional UX fix rather than a regression revert.
- No cap on cache size. If a user has many historical tunnels they'll all show up in the picker grayed out. If that becomes noisy in practice the next iteration could LRU/cap or hide entries that stay offline across N consecutive discoveries.
- `compile-check-ts-native` passes locally.