### PR TITLE
Change icon for Toggle Developer Tools action

### DIFF
--- a/src/vs/workbench/contrib/browserView/electron-browser/features/browserDevToolsFeature.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/features/browserDevToolsFeature.ts
@@ -52,7 +52,7 @@ class ToggleDevToolsAction extends Action2 {
 			id: ToggleDevToolsAction.ID,
 			title: localize2('browser.toggleDevToolsAction', 'Toggle Developer Tools'),
 			category: BrowserActionCategory,
-			icon: Codicon.terminal,
+			icon: Codicon.developerTools,
 			f1: true,
 			precondition: ContextKeyExpr.and(BROWSER_EDITOR_ACTIVE, CONTEXT_BROWSER_HAS_URL, CONTEXT_BROWSER_HAS_ERROR.negate()),
 			toggled: ContextKeyExpr.equals(CONTEXT_BROWSER_DEVTOOLS_OPEN.key, true),


### PR DESCRIPTION
* Fixes https://github.com/microsoft/vscode/issues/317156


Before:
<img width="261" height="183" alt="Screenshot 2026-05-26 at 1 35 35 PM" src="https://github.com/user-attachments/assets/485ad5db-6b8c-4634-8ba0-d8978fa178f6" />


After:
<img width="286" height="240" alt="image" src="https://github.com/user-attachments/assets/f9a1da6d-988a-479d-9876-913ef12bf050" />