### PR TITLE
Skip unchanged mime database updates

### DIFF
--- a/resources/linux/debian/postinst.template
+++ b/resources/linux/debian/postinst.template
@@ -19,7 +19,7 @@ fi
 
 # Update mimetype database to pickup workspace mimetype
 if hash update-mime-database 2>/dev/null; then
-	update-mime-database /usr/share/mime
+	update-mime-database -n /usr/share/mime
 fi
 
 if [ "@@NAME@@" != "code-oss" ]; then

--- a/resources/linux/debian/postrm.template
+++ b/resources/linux/debian/postrm.template
@@ -12,7 +12,7 @@ fi
 
 # Update mimetype database for removed workspace mimetype
 if hash update-mime-database 2>/dev/null; then
-	update-mime-database /usr/share/mime
+	update-mime-database -n /usr/share/mime
 fi
 
 RET=true

--- a/resources/linux/rpm/code.spec.template
+++ b/resources/linux/rpm/code.spec.template
@@ -68,14 +68,14 @@ fi
 update-desktop-database &> /dev/null || :
 
 # Update mimetype database to pickup workspace mimetype
-update-mime-database %{_datadir}/mime &> /dev/null || :
+update-mime-database -n %{_datadir}/mime &> /dev/null || :
 
 %postun
 # Uninstall the desktop entry
 update-desktop-database &> /dev/null || :
 
 # Update mimetype database for removed workspace mimetype
-update-mime-database %{_datadir}/mime &> /dev/null || :
+update-mime-database -n %{_datadir}/mime &> /dev/null || :
 
 %files
 %defattr(-,root,root)


### PR DESCRIPTION
Fixes #163690

This updates the Linux package scripts to pass `-n` to `update-mime-database`.

The `-n` option skips rebuilding the MIME database when it is already up to date, which avoids unnecessary work during package install/update/removal. The Debian package scripts are updated for the reported issue, and the RPM script is updated for consistency.

Validation:
- `git diff --check`
- `bash -n resources/linux/debian/postinst.template`
- `bash -n resources/linux/debian/postrm.template`
- `nvm use && node --experimental-strip-types build/hygiene.ts resources/linux/debian/postinst.template resources/linux/debian/postrm.template resources/linux/rpm/code.spec.template`