### PR TITLE
 Switch from Copilot Proxy to CAPI

### DIFF
--- a/extensions/copilot/src/extension/intents/node/agentIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/agentIntent.ts
@@ -15,6 +15,7 @@ import { ConfigKey, IConfigurationService } from '../../../platform/configuratio
 import { isAnthropicFamily, isGptFamily, modelCanUseApplyPatchExclusively, modelCanUseReplaceStringExclusively, modelSupportsApplyPatch, modelSupportsMultiReplaceString, modelSupportsReplaceString, modelSupportsSimplifiedApplyPatchInstructions } from '../../../platform/endpoint/common/chatModelCapabilities';
 import { IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
 import { IAutomodeService } from '../../../platform/endpoint/node/automodeService';
+import { SEARCH_AGENT_FAMILY } from '../../../platform/endpoint/node/searchAgentChatEndpoint';
 import { IEnvService } from '../../../platform/env/common/envService';
 import { ILogService } from '../../../platform/log/common/logService';
 import { IEditLogService } from '../../../platform/multiFileEdit/common/editLogService';
@@ -191,20 +192,16 @@ export const getAgentTools = async (accessor: ServicesAccessor, request: vscode.
 		const searchSubagentEnabled = configurationService.getExperimentBasedConfig(ConfigKey.Advanced.SearchSubagentToolEnabled, experimentationService);
 		const exploreAgentEnabled = configurationService.getExperimentBasedConfig(ConfigKey.ExploreAgentEnabled, experimentationService);
 		const isGptOrAnthropic = isGptFamily(model) || isAnthropicFamily(model);
-		allowTools[ToolName.SearchSubagent] = isGptOrAnthropic && searchSubagentEnabled && exploreAgentEnabled;
-		allowTools[ToolName.ExploreSubagent] = isGptOrAnthropic && searchSubagentEnabled && !exploreAgentEnabled;
+		const allEndpoints = await endpointProvider.getAllChatEndpoints().catch(() => [] as IChatEndpoint[]);
+		const searchAgentAvailable = allEndpoints.some(e => e.family === SEARCH_AGENT_FAMILY);
+		allowTools[ToolName.SearchSubagent] = isGptOrAnthropic && searchSubagentEnabled && exploreAgentEnabled && searchAgentAvailable;
+		allowTools[ToolName.ExploreSubagent] = isGptOrAnthropic && searchSubagentEnabled && !exploreAgentEnabled && searchAgentAvailable;
 
 		const executionSubagentEnabled = configurationService.getExperimentBasedConfig(ConfigKey.Advanced.ExecutionSubagentToolEnabled, experimentationService);
 		// The execution subagent is powered by gemini-3-flash, so it can only be
 		// offered when that model is actually available to the user. If it isn't
 		// in the user's endpoints, keep the tool disabled regardless of the setting.
-		// Skip the (potentially expensive) endpoint lookup when the tool would be
-		// disabled anyway based on model family or the experiment setting.
-		let hasGemini3Flash = false;
-		if (isGptOrAnthropic && executionSubagentEnabled) {
-			const allEndpoints = await endpointProvider.getAllChatEndpoints();
-			hasGemini3Flash = allEndpoints.some(ep => ep.family.toLowerCase().includes('gemini-3-flash'));
-		}
+		const hasGemini3Flash = allEndpoints.some(ep => ep.family.toLowerCase().includes('gemini-3-flash'));
 		allowTools[ToolName.ExecutionSubagent] = isGptOrAnthropic && executionSubagentEnabled && hasGemini3Flash;
 	}
 

--- a/extensions/copilot/src/extension/intents/node/agentIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/agentIntent.ts
@@ -191,13 +191,19 @@ export const getAgentTools = async (accessor: ServicesAccessor, request: vscode.
 	} else {
 		const searchSubagentEnabled = configurationService.getExperimentBasedConfig(ConfigKey.Advanced.SearchSubagentToolEnabled, experimentationService);
 		const exploreAgentEnabled = configurationService.getExperimentBasedConfig(ConfigKey.ExploreAgentEnabled, experimentationService);
+		const executionSubagentEnabled = configurationService.getExperimentBasedConfig(ConfigKey.Advanced.ExecutionSubagentToolEnabled, experimentationService);
 		const isGptOrAnthropic = isGptFamily(model) || isAnthropicFamily(model);
-		const allEndpoints = await endpointProvider.getAllChatEndpoints().catch(() => [] as IChatEndpoint[]);
+
+		// Only look up endpoints when a subagent that depends on model availability
+		// could actually be enabled, since the lookup is otherwise unnecessary.
+		const allEndpoints = isGptOrAnthropic && (searchSubagentEnabled || executionSubagentEnabled)
+			? await endpointProvider.getAllChatEndpoints().catch(() => [] as IChatEndpoint[])
+			: [];
+
 		const searchAgentAvailable = allEndpoints.some(e => e.family === SEARCH_AGENT_FAMILY);
 		allowTools[ToolName.SearchSubagent] = isGptOrAnthropic && searchSubagentEnabled && exploreAgentEnabled && searchAgentAvailable;
 		allowTools[ToolName.ExploreSubagent] = isGptOrAnthropic && searchSubagentEnabled && !exploreAgentEnabled && searchAgentAvailable;
 
-		const executionSubagentEnabled = configurationService.getExperimentBasedConfig(ConfigKey.Advanced.ExecutionSubagentToolEnabled, experimentationService);
 		// The execution subagent is powered by gemini-3-flash, so it can only be
 		// offered when that model is actually available to the user. If it isn't
 		// in the user's endpoints, keep the tool disabled regardless of the setting.

--- a/extensions/copilot/src/extension/intents/node/test/searchSubagentGating.spec.ts
+++ b/extensions/copilot/src/extension/intents/node/test/searchSubagentGating.spec.ts
@@ -1,0 +1,110 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest';
+import { ConfigKey, IConfigurationService } from '../../../../platform/configuration/common/configurationService';
+import { IEndpointProvider } from '../../../../platform/endpoint/common/endpointProvider';
+import { MockEndpoint } from '../../../../platform/endpoint/test/node/mockEndpoint';
+import { SEARCH_AGENT_FAMILY } from '../../../../platform/endpoint/node/searchAgentChatEndpoint';
+import { IChatEndpoint } from '../../../../platform/networking/common/networking';
+import { ITestingServicesAccessor } from '../../../../platform/test/node/services';
+import { TestWorkspaceService } from '../../../../platform/test/node/testWorkspaceService';
+import { IWorkspaceService } from '../../../../platform/workspace/common/workspaceService';
+import { NullWorkspaceFileIndex } from '../../../../platform/workspaceChunkSearch/node/nullWorkspaceFileIndex';
+import { IWorkspaceFileIndex } from '../../../../platform/workspaceChunkSearch/node/workspaceFileIndex';
+import { Event } from '../../../../util/vs/base/common/event';
+import { URI } from '../../../../util/vs/base/common/uri';
+import { SyncDescriptor } from '../../../../util/vs/platform/instantiation/common/descriptors';
+import { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
+import { createExtensionUnitTestingServices } from '../../../test/node/services';
+import { TestChatRequest } from '../../../test/node/testHelpers';
+import { ToolName } from '../../../tools/common/toolNames';
+import { getAgentTools } from '../agentIntent';
+
+class StubEndpointProvider implements IEndpointProvider {
+	declare readonly _serviceBrand: undefined;
+	endpoints: IChatEndpoint[] = [];
+	readonly onDidModelsRefresh = Event.None;
+	async getChatEndpoint(): Promise<IChatEndpoint> { return this.endpoints[0]; }
+	async getEmbeddingsEndpoint(): Promise<never> { throw new Error('not implemented'); }
+	async getAllChatEndpoints(): Promise<IChatEndpoint[]> { return this.endpoints; }
+	async getAllCompletionModels(): Promise<never[]> { return []; }
+}
+
+describe('getAgentTools search subagent gating', () => {
+	let accessor: ITestingServicesAccessor;
+	let instantiationService: IInstantiationService;
+	let configService: IConfigurationService;
+	let endpointProvider: StubEndpointProvider;
+	let userEndpoint: IChatEndpoint;
+	let searchAgentEndpoint: IChatEndpoint;
+
+	beforeAll(() => {
+		const services = createExtensionUnitTestingServices();
+		services.define(IWorkspaceFileIndex, new SyncDescriptor(NullWorkspaceFileIndex));
+		services.define(IWorkspaceService, new SyncDescriptor(
+			TestWorkspaceService,
+			[
+				[URI.file('/workspace')],
+				[]
+			]
+		));
+		endpointProvider = new StubEndpointProvider();
+		services.define(IEndpointProvider, endpointProvider);
+		accessor = services.createTestingAccessor();
+		instantiationService = accessor.get(IInstantiationService);
+		configService = accessor.get(IConfigurationService);
+
+		// User-selected model: must be gpt/anthropic family for the subagent gates to even consider enabling.
+		userEndpoint = instantiationService.createInstance(MockEndpoint, 'gpt-5');
+		searchAgentEndpoint = instantiationService.createInstance(MockEndpoint, SEARCH_AGENT_FAMILY);
+	});
+
+	afterAll(() => {
+		accessor.dispose();
+	});
+
+	beforeEach(() => {
+		endpointProvider.endpoints = [userEndpoint];
+		configService.setConfig(ConfigKey.Advanced.SearchSubagentToolEnabled, true);
+		configService.setConfig(ConfigKey.ExploreAgentEnabled, true);
+	});
+
+	function hasTool(tools: readonly { name: string }[], name: ToolName): boolean {
+		return tools.some(t => t.name === name);
+	}
+
+	test('hides both subagents when search-agent family is not in CAPI', async () => {
+		const request = new TestChatRequest('find usages of foo');
+		const tools = await instantiationService.invokeFunction(getAgentTools, request, userEndpoint);
+		expect(hasTool(tools, ToolName.SearchSubagent)).toBe(false);
+		expect(hasTool(tools, ToolName.ExploreSubagent)).toBe(false);
+	});
+
+	test('exposes SearchSubagent when family is in CAPI and explore-agent experiment is on', async () => {
+		endpointProvider.endpoints = [userEndpoint, searchAgentEndpoint];
+		const request = new TestChatRequest('find usages of foo');
+		const tools = await instantiationService.invokeFunction(getAgentTools, request, userEndpoint);
+		expect(hasTool(tools, ToolName.SearchSubagent)).toBe(true);
+		expect(hasTool(tools, ToolName.ExploreSubagent)).toBe(false);
+	});
+
+	test('exposes ExploreSubagent (legacy path) when family is in CAPI and explore-agent experiment is off', async () => {
+		endpointProvider.endpoints = [userEndpoint, searchAgentEndpoint];
+		configService.setConfig(ConfigKey.ExploreAgentEnabled, false);
+		const request = new TestChatRequest('find usages of foo');
+		const tools = await instantiationService.invokeFunction(getAgentTools, request, userEndpoint);
+		expect(hasTool(tools, ToolName.ExploreSubagent)).toBe(true);
+		expect(hasTool(tools, ToolName.SearchSubagent)).toBe(false);
+	});
+
+	test('hides both subagents when CAPI fetch fails', async () => {
+		endpointProvider.getAllChatEndpoints = async () => { throw new Error('CAPI unreachable'); };
+		const request = new TestChatRequest('find usages of foo');
+		const tools = await instantiationService.invokeFunction(getAgentTools, request, userEndpoint);
+		expect(hasTool(tools, ToolName.SearchSubagent)).toBe(false);
+		expect(hasTool(tools, ToolName.ExploreSubagent)).toBe(false);
+	});
+});

--- a/extensions/copilot/src/extension/prompt/node/searchSubagentToolCallingLoop.ts
+++ b/extensions/copilot/src/extension/prompt/node/searchSubagentToolCallingLoop.ts
@@ -101,8 +101,10 @@ export class SearchSubagentToolCallingLoop extends ToolCallingLoop<ISearchSubage
 		const useAgenticProxy = this._configurationService.getExperimentBasedConfig(ConfigKey.Advanced.SearchSubagentUseAgenticProxy, this._experimentationService);
 
 		if (useAgenticProxy) {
-			// Use the CAPI search-agent model. Fall back to the main agent endpoint if the model
-			// is not available for this user
+			// Primary gating lives in getAgentTools, which is hidden
+			// when CAPI doesn't advertise the search-agent family. This fallback handles
+			// the secondary cases: races between gating and execution, transient CAPI
+			// errors, and any future caller that invokes the loop without the agent gate
 			try {
 				const allEndpoints = await this.endpointProvider.getAllChatEndpoints();
 				const searchAgentEndpoint = allEndpoints.find(e => e.family === SEARCH_AGENT_FAMILY);

--- a/extensions/copilot/src/extension/prompt/node/searchSubagentToolCallingLoop.ts
+++ b/extensions/copilot/src/extension/prompt/node/searchSubagentToolCallingLoop.ts
@@ -10,7 +10,8 @@ import { IChatHookService } from '../../../platform/chat/common/chatHookService'
 import { ChatFetchResponseType, ChatLocation, ChatResponse } from '../../../platform/chat/common/commonTypes';import { ISessionTranscriptService } from '../../../platform/chat/common/sessionTranscriptService';
 import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
 import { ChatEndpointFamily, IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
-import { ProxyAgenticEndpoint } from '../../../platform/endpoint/node/proxyAgenticEndpoint';
+import { ChatEndpoint } from '../../../platform/endpoint/node/chatEndpoint';
+import { SEARCH_AGENT_FAMILY, SearchAgentChatEndpoint } from '../../../platform/endpoint/node/searchAgentChatEndpoint';
 import { IFileSystemService } from '../../../platform/filesystem/common/fileSystemService';
 import { IGitService } from '../../../platform/git/common/gitService';
 import { ILogService } from '../../../platform/log/common/logService';
@@ -92,8 +93,6 @@ export class SearchSubagentToolCallingLoop extends ToolCallingLoop<ISearchSubage
 		return context;
 	}
 
-	private static readonly DEFAULT_AGENTIC_PROXY_MODEL = 'vscode-agentic-search-router-a';
-
 	/**
 	 * Get the endpoint to use for the search subagent
 	 */
@@ -102,9 +101,19 @@ export class SearchSubagentToolCallingLoop extends ToolCallingLoop<ISearchSubage
 		const useAgenticProxy = this._configurationService.getExperimentBasedConfig(ConfigKey.Advanced.SearchSubagentUseAgenticProxy, this._experimentationService);
 
 		if (useAgenticProxy) {
-			// Use agentic proxy with SearchSubagentModel or default to 'agentic-search-v3'
-			const agenticProxyModel = modelName || SearchSubagentToolCallingLoop.DEFAULT_AGENTIC_PROXY_MODEL;
-			return this.instantiationService.createInstance(ProxyAgenticEndpoint, agenticProxyModel);
+			// Use the CAPI search-agent model. Fall back to the main agent endpoint if the model
+			// is not available for this user
+			try {
+				const allEndpoints = await this.endpointProvider.getAllChatEndpoints();
+				const searchAgentEndpoint = allEndpoints.find(e => e.family === SEARCH_AGENT_FAMILY);
+				if (searchAgentEndpoint instanceof ChatEndpoint) {
+					return this.instantiationService.createInstance(SearchAgentChatEndpoint, searchAgentEndpoint.modelMetadata);
+				}
+				this._logService.warn(`Search-agent model not available in CAPI, falling back to main agent endpoint`);
+			} catch (error) {
+				this._logService.warn(`Failed to get search-agent endpoint from CAPI, falling back to main agent: ${error}`);
+			}
+			return await this.endpointProvider.getChatEndpoint(this.options.request);
 		}
 
 		if (modelName) {

--- a/extensions/copilot/src/extension/tools/vscode-node/toolsService.ts
+++ b/extensions/copilot/src/extension/tools/vscode-node/toolsService.ts
@@ -6,6 +6,8 @@
 import * as vscode from 'vscode';
 import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
 import { isGpt55 } from '../../../platform/endpoint/common/chatModelCapabilities';
+import { IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
+import { SEARCH_AGENT_FAMILY } from '../../../platform/endpoint/node/searchAgentChatEndpoint';
 import { ILogService } from '../../../platform/log/common/logService';
 import { IChatEndpoint } from '../../../platform/networking/common/networking';
 import { CopilotChatAttr, emitToolCallEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, GenAiToolType, StdAttr, truncateForOTel } from '../../../platform/otel/common/index';
@@ -92,10 +94,30 @@ export class ToolsService extends BaseToolsService {
 		@IOTelService private readonly _otelService: IOTelService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IExperimentationService private readonly _experimentationService: IExperimentationService,
+		@IEndpointProvider private readonly _endpointProvider: IEndpointProvider,
 	) {
 		super(logService);
 		this._copilotTools = new Lazy(() => new Map(ToolRegistry.getTools().map(t => [t.toolName, _instantiationService.createInstance(t)] as const)));
 		this._toolExtensions = new Lazy(() => new Map(ToolRegistry.getToolExtensions().map(t => [t.toolName, _instantiationService.createInstance(t)] as const)));
+		this._register(this._endpointProvider.onDidModelsRefresh(() => this._refreshAvailableChatModelFamilies()));
+		void this._refreshAvailableChatModelFamilies();
+	}
+
+	/**
+	 * Cached set of model families available from CAPI for the current user.
+	 * `undefined` means we have not yet received a model list — in that case
+	 * dynamic family-based tool filters should not hide tools (default to
+	 * enabled until proven unavailable)
+	 */
+	private _availableChatModelFamilies: ReadonlySet<string> | undefined;
+
+	private async _refreshAvailableChatModelFamilies(): Promise<void> {
+		try {
+			const endpoints = await this._endpointProvider.getAllChatEndpoints();
+			this._availableChatModelFamilies = new Set(endpoints.map(e => e.family));
+		} catch {
+			// If the fetch fails (e.g. user not authenticated), leave the cache untouched
+		}
 	}
 
 	private getModelSpecificTools() {
@@ -320,6 +342,16 @@ export class ToolsService extends BaseToolsService {
 					tool.name === ToolName.ReadFile
 					&& isGpt55(endpoint)
 					&& !this._configurationService.getExperimentBasedConfig(ConfigKey.EnableGpt55ReadFileTool, this._experimentationService)
+				) {
+					return false;
+				}
+
+				// Disable search_subagent / explore_subagent when the
+				// CAPI search-agent model is not available to the current user
+				if (
+					(tool.name === ToolName.SearchSubagent || tool.name === ToolName.ExploreSubagent)
+					&& this._availableChatModelFamilies !== undefined
+					&& !this._availableChatModelFamilies.has(SEARCH_AGENT_FAMILY)
 				) {
 					return false;
 				}

--- a/extensions/copilot/src/extension/tools/vscode-node/toolsService.ts
+++ b/extensions/copilot/src/extension/tools/vscode-node/toolsService.ts
@@ -6,8 +6,6 @@
 import * as vscode from 'vscode';
 import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
 import { isGpt55 } from '../../../platform/endpoint/common/chatModelCapabilities';
-import { IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
-import { SEARCH_AGENT_FAMILY } from '../../../platform/endpoint/node/searchAgentChatEndpoint';
 import { ILogService } from '../../../platform/log/common/logService';
 import { IChatEndpoint } from '../../../platform/networking/common/networking';
 import { CopilotChatAttr, emitToolCallEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, GenAiToolType, StdAttr, truncateForOTel } from '../../../platform/otel/common/index';
@@ -94,30 +92,10 @@ export class ToolsService extends BaseToolsService {
 		@IOTelService private readonly _otelService: IOTelService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IExperimentationService private readonly _experimentationService: IExperimentationService,
-		@IEndpointProvider private readonly _endpointProvider: IEndpointProvider,
 	) {
 		super(logService);
 		this._copilotTools = new Lazy(() => new Map(ToolRegistry.getTools().map(t => [t.toolName, _instantiationService.createInstance(t)] as const)));
 		this._toolExtensions = new Lazy(() => new Map(ToolRegistry.getToolExtensions().map(t => [t.toolName, _instantiationService.createInstance(t)] as const)));
-		this._register(this._endpointProvider.onDidModelsRefresh(() => this._refreshAvailableChatModelFamilies()));
-		void this._refreshAvailableChatModelFamilies();
-	}
-
-	/**
-	 * Cached set of model families available from CAPI for the current user.
-	 * `undefined` means we have not yet received a model list — in that case
-	 * dynamic family-based tool filters should not hide tools (default to
-	 * enabled until proven unavailable)
-	 */
-	private _availableChatModelFamilies: ReadonlySet<string> | undefined;
-
-	private async _refreshAvailableChatModelFamilies(): Promise<void> {
-		try {
-			const endpoints = await this._endpointProvider.getAllChatEndpoints();
-			this._availableChatModelFamilies = new Set(endpoints.map(e => e.family));
-		} catch {
-			// If the fetch fails (e.g. user not authenticated), leave the cache untouched
-		}
 	}
 
 	private getModelSpecificTools() {
@@ -342,16 +320,6 @@ export class ToolsService extends BaseToolsService {
 					tool.name === ToolName.ReadFile
 					&& isGpt55(endpoint)
 					&& !this._configurationService.getExperimentBasedConfig(ConfigKey.EnableGpt55ReadFileTool, this._experimentationService)
-				) {
-					return false;
-				}
-
-				// Disable search_subagent / explore_subagent when the
-				// CAPI search-agent model is not available to the current user
-				if (
-					(tool.name === ToolName.SearchSubagent || tool.name === ToolName.ExploreSubagent)
-					&& this._availableChatModelFamilies !== undefined
-					&& !this._availableChatModelFamilies.has(SEARCH_AGENT_FAMILY)
 				) {
 					return false;
 				}

--- a/extensions/copilot/src/platform/endpoint/node/searchAgentChatEndpoint.ts
+++ b/extensions/copilot/src/platform/endpoint/node/searchAgentChatEndpoint.ts
@@ -1,0 +1,70 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
+import { IAuthenticationService } from '../../authentication/common/authentication';
+import { IChatMLFetcher } from '../../chat/common/chatMLFetcher';
+import { IConfigurationService } from '../../configuration/common/configurationService';
+import { IEnvService } from '../../env/common/envService';
+import { ILogService } from '../../log/common/logService';
+import { IFetcherService } from '../../networking/common/fetcherService';
+import { IChatWebSocketManager } from '../../networking/node/chatWebSocketManager';
+import { IExperimentationService } from '../../telemetry/common/nullExperimentationService';
+import { ITelemetryService } from '../../telemetry/common/telemetry';
+import { ITokenizerProvider } from '../../tokenizer/node/tokenizer';
+import { ICAPIClientService } from '../common/capiClient';
+import { IDomainService } from '../common/domainService';
+import { IChatModelInformation } from '../common/endpointProvider';
+import { CopilotChatEndpoint } from './copilotChatEndpoint';
+
+export const SEARCH_AGENT_FAMILY = 'search-agent';
+
+export class SearchAgentChatEndpoint extends CopilotChatEndpoint {
+
+	constructor(
+		modelMetadata: IChatModelInformation,
+		@IDomainService domainService: IDomainService,
+		@ICAPIClientService capiClientService: ICAPIClientService,
+		@IFetcherService fetcherService: IFetcherService,
+		@IEnvService envService: IEnvService,
+		@ITelemetryService telemetryService: ITelemetryService,
+		@IAuthenticationService authService: IAuthenticationService,
+		@IChatMLFetcher chatMLFetcher: IChatMLFetcher,
+		@ITokenizerProvider tokenizerProvider: ITokenizerProvider,
+		@IInstantiationService instantiationService: IInstantiationService,
+		@IConfigurationService configurationService: IConfigurationService,
+		@IExperimentationService experimentationService: IExperimentationService,
+		@IChatWebSocketManager chatWebSocketService: IChatWebSocketManager,
+		@ILogService logService: ILogService,
+	) {
+		const modelInfo: IChatModelInformation = {
+			...modelMetadata,
+			capabilities: {
+				...modelMetadata.capabilities,
+				limits: {
+					...modelMetadata.capabilities.limits,
+					max_prompt_tokens: 260000, // preserved from proxyAgenticEndpoint
+					max_output_tokens: 16000,
+				},
+			},
+		};
+		super(
+			modelInfo,
+			domainService,
+			capiClientService,
+			fetcherService,
+			envService,
+			telemetryService,
+			authService,
+			chatMLFetcher,
+			tokenizerProvider,
+			instantiationService,
+			configurationService,
+			experimentationService,
+			chatWebSocketService,
+			logService,
+		);
+	}
+}


### PR DESCRIPTION
Currently, we use copilot-proxy as a go-between to get access from VS Code to models hosted in Fireworks. This PR covers changes needed to switch to CAPI: 

- CAPI returns a list of models available based on a user's SKU, FSI status, etc. We disabled the search subagent tool (for explore as well) if the search subagent models are not in the list of models returned by CAPI. So, if a user is blocked from using Qwen models, they're blocked from using our subagent tool.
- Updated the search subagent tool to use a CAPI endpoint, instead of proxyAgenticEndpoint
