### PR TITLE
Relax event flush cadence and filter delta events for session sync

### DIFF
--- a/extensions/copilot/src/extension/chronicle/common/eventTranslator.ts
+++ b/extensions/copilot/src/extension/chronicle/common/eventTranslator.ts
@@ -9,12 +9,6 @@ import type { ICompletedSpanData } from '../../../platform/otel/common/otelServi
 import type { IDebugLogEntry } from '../../../platform/chat/common/chatDebugFileLoggerService';
 import type { SessionEvent, WorkingDirectoryContext } from './cloudSessionTypes';
 
-// ── Event classification (flush cadence) ────────────────────────────────────────
-// Mirrors the CLI's `STREAMING_EVENT_TYPES` / `TERMINAL_FLUSH_EVENT_TYPES` sets
-// in copilot-agent-runtime so VS Code's session-sync exporter applies the same
-// non-steerable flush cadence (terminal-event-driven with a 60s safety net) and
-// the same delta filtering.
-
 /**
  * Per-token streaming events that must never be forwarded to the cloud. The
  * current `translateSpan` does not emit any of these (assistant text is read

--- a/extensions/copilot/src/extension/chronicle/common/eventTranslator.ts
+++ b/extensions/copilot/src/extension/chronicle/common/eventTranslator.ts
@@ -9,6 +9,43 @@ import type { ICompletedSpanData } from '../../../platform/otel/common/otelServi
 import type { IDebugLogEntry } from '../../../platform/chat/common/chatDebugFileLoggerService';
 import type { SessionEvent, WorkingDirectoryContext } from './cloudSessionTypes';
 
+// ── Event classification (flush cadence) ────────────────────────────────────────
+// Mirrors the CLI's `STREAMING_EVENT_TYPES` / `TERMINAL_FLUSH_EVENT_TYPES` sets
+// in copilot-agent-runtime so VS Code's session-sync exporter applies the same
+// non-steerable flush cadence (terminal-event-driven with a 60s safety net) and
+// the same delta filtering.
+
+/**
+ * Per-token streaming events that must never be forwarded to the cloud. The
+ * current `translateSpan` does not emit any of these (assistant text is read
+ * from finalized `gen_ai.output.messages`), but the filter is kept defensively
+ * for parity with the CLI and for future translator changes.
+ */
+export const STREAMING_EVENT_TYPES: ReadonlySet<string> = new Set([
+	'assistant.streaming_delta',
+	'assistant.reasoning_delta',
+	'assistant.message_delta',
+	'tool.execution_partial_result',
+]);
+
+/**
+ * Events that mark a natural "end of something" and should trigger a prompt
+ * flush. Other events are buffered until the 60s safety timer fires or the
+ * batch hits `MAX_EVENTS_PER_FLUSH`.
+ */
+export const TERMINAL_FLUSH_EVENT_TYPES: ReadonlySet<string> = new Set([
+	'assistant.message',
+	'tool.execution_complete',
+	'session.idle',
+	'session.shutdown',
+	'session.error',
+]);
+
+/** Returns true if the event marks a flush boundary for non-steerable sessions. */
+export function isTerminalFlushEvent(event: SessionEvent): boolean {
+	return TERMINAL_FLUSH_EVENT_TYPES.has(event.type);
+}
+
 // ── Event size limit (bytes) ────────────────────────────────────────────────────
 // Whole events exceeding this size are dropped before buffering.
 

--- a/extensions/copilot/src/extension/chronicle/common/test/eventTranslator.spec.ts
+++ b/extensions/copilot/src/extension/chronicle/common/test/eventTranslator.spec.ts
@@ -6,7 +6,8 @@
 import { describe, expect, it } from 'vitest';
 import type { ICompletedSpanData } from '../../../../platform/otel/common/otelService';
 import type { IDebugLogEntry } from '../../../../platform/chat/common/chatDebugFileLoggerService';
-import { createSessionTranslationState, deriveTitleFromUserMessage, makeIdleEvent, makeShutdownEvent, translateDebugLogEntry, translateSpan } from '../eventTranslator';
+import { createSessionTranslationState, deriveTitleFromUserMessage, isTerminalFlushEvent, makeIdleEvent, makeShutdownEvent, STREAMING_EVENT_TYPES, TERMINAL_FLUSH_EVENT_TYPES, translateDebugLogEntry, translateSpan } from '../eventTranslator';
+import type { SessionEvent } from '../cloudSessionTypes';
 
 function makeSpan(overrides: Partial<ICompletedSpanData> = {}): ICompletedSpanData {
 	return {
@@ -642,5 +643,49 @@ describe('deriveTitleFromUserMessage', () => {
 
 	it('returns undefined for empty content', () => {
 		expect(deriveTitleFromUserMessage('')).toBeUndefined();
+	});
+});
+describe('terminal / streaming event classification', () => {
+	function makeEvent(type: string): SessionEvent {
+		return { id: 'e', timestamp: '2024-01-01T00:00:00.000Z', parentId: null, type, data: {} };
+	}
+
+	it('marks the documented terminal flush event types', () => {
+		expect(TERMINAL_FLUSH_EVENT_TYPES).toEqual(new Set([
+			'assistant.message',
+			'tool.execution_complete',
+			'session.idle',
+			'session.shutdown',
+			'session.error',
+		]));
+	});
+
+	it('marks the documented streaming delta event types', () => {
+		expect(STREAMING_EVENT_TYPES).toEqual(new Set([
+			'assistant.streaming_delta',
+			'assistant.reasoning_delta',
+			'assistant.message_delta',
+			'tool.execution_partial_result',
+		]));
+	});
+
+	it('terminal and streaming sets are disjoint', () => {
+		for (const t of TERMINAL_FLUSH_EVENT_TYPES) {
+			expect(STREAMING_EVENT_TYPES.has(t)).toBe(false);
+		}
+	});
+
+	it('isTerminalFlushEvent recognizes terminal events', () => {
+		expect(isTerminalFlushEvent(makeEvent('assistant.message'))).toBe(true);
+		expect(isTerminalFlushEvent(makeEvent('tool.execution_complete'))).toBe(true);
+		expect(isTerminalFlushEvent(makeEvent('session.shutdown'))).toBe(true);
+	});
+
+	it('isTerminalFlushEvent returns false for non-terminal events', () => {
+		expect(isTerminalFlushEvent(makeEvent('session.start'))).toBe(false);
+		expect(isTerminalFlushEvent(makeEvent('user.message'))).toBe(false);
+		expect(isTerminalFlushEvent(makeEvent('assistant.usage'))).toBe(false);
+		expect(isTerminalFlushEvent(makeEvent('tool.execution_start'))).toBe(false);
+		expect(isTerminalFlushEvent(makeEvent('assistant.streaming_delta'))).toBe(false);
 	});
 });

--- a/extensions/copilot/src/extension/chronicle/vscode-node/remoteSessionExporter.ts
+++ b/extensions/copilot/src/extension/chronicle/vscode-node/remoteSessionExporter.ts
@@ -23,6 +23,8 @@ import { CircuitBreaker } from '../common/circuitBreaker';
 import {
 	createSessionTranslationState,
 	deriveTitleFromUserMessage,
+	isTerminalFlushEvent,
+	STREAMING_EVENT_TYPES,
 	translateSpan,
 	type SessionTranslationState,
 } from '../common/eventTranslator';
@@ -39,20 +41,24 @@ import { reindexSessions, reindexCloudSessions, type CloudReindexResult } from '
 
 // ── Configuration ───────────────────────────────────────────────────────────────
 
-/** How often to flush buffered events to the cloud (ms). */
+/**
+ * Delay between a terminal event arriving and the resulting flush. Small enough
+ * to feel realtime, large enough to coalesce events from the same turn into one
+ * request.
+ */
 const BATCH_INTERVAL_MS = 500;
 
-/** Faster drain interval when buffer is above soft cap. */
-const FAST_BATCH_INTERVAL_MS = 200;
+/**
+ * Safety-net interval for buffered events that did not trigger a terminal
+ * flush. Mirrors the CLI's `NON_STEERABLE_SAFETY_INTERVAL_MS`.
+ */
+const SAFETY_INTERVAL_MS = 60_000;
 
-/** Max events per flush request. */
+/** Max events per flush request — also acts as a buffer-size flush trigger. */
 const MAX_EVENTS_PER_FLUSH = 500;
 
 /** Hard cap on buffered events (drop oldest beyond this). */
 const MAX_BUFFER_SIZE = 1_000;
-
-/** Soft cap — switch to faster drain. */
-const SOFT_BUFFER_CAP = 500;
 
 /** Max CHAT spans buffered per session while awaiting INVOKE_AGENT. */
 const MAX_PENDING_CHAT_SPANS_PER_SESSION = 32;
@@ -64,7 +70,11 @@ const POLICY_BLOCKED_TTL_MS = 60 * 60 * 1000;
  * Exports VS Code chat session events to the cloud in real-time.
  *
  * - Listens to OTel spans, translates to cloud SessionEvent format
- * - Buffers events and flushes in batches every 500ms
+ * - Buffers events; flushes within ~500ms when a terminal event arrives
+ *   (assistant.message, tool.execution_complete) or when the buffer reaches
+ *   {@link MAX_EVENTS_PER_FLUSH}, otherwise waits up to
+ *   {@link SAFETY_INTERVAL_MS} as a safety net
+ * - Streaming delta events are dropped before buffering
  * - Circuit breaker prevents cascading failures when the cloud is unavailable
  * - Lazy initialization: no work until the first real chat interaction
  *
@@ -113,7 +123,8 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 	private readonly _cloudClient: CloudSessionApiClient;
 	private readonly _circuitBreaker: CircuitBreaker;
 
-	private _flushTimer: ReturnType<typeof setInterval> | undefined;
+	private _flushTimer: ReturnType<typeof setTimeout> | undefined;
+	private _flushTimerKind: 'fast' | 'safety' | undefined;
 	private _isFlushing = false;
 	private _firstCloudWriteLogged = false;
 
@@ -321,10 +332,7 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 	}
 
 	override dispose(): void {
-		if (this._flushTimer !== undefined) {
-			clearInterval(this._flushTimer);
-			this._flushTimer = undefined;
-		}
+		this._stopFlushTimer();
 
 		// Best-effort final flush with timeout
 		const pending = this._eventBuffer.length;
@@ -781,7 +789,6 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 
 			if (events.length > 0) {
 				this._bufferEvents(sessionId, events);
-				this._ensureFlushTimer();
 			}
 
 			// Replay any CHAT spans that arrived before session initialization
@@ -796,6 +803,11 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 						}
 					}
 				}
+				// Parent INVOKE_AGENT completion marks a turn boundary. Force a fast
+				// flush even when the turn produced no terminal event (e.g. cancelled
+				// before any tokens streamed) so buffered user.message/session.start
+				// don't sit until the 60s safety timer.
+				this._scheduleFlush(BATCH_INTERVAL_MS);
 			}
 		} catch {
 			// Non-fatal — individual span processing failure
@@ -1124,9 +1136,28 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 
 	// ── Buffering ────────────────────────────────────────────────────────────────
 
+	/**
+	 * Buffer events, drop streaming deltas, and schedule a flush.
+	 *
+	 * Scheduling matches the CLI's non-steerable cadence:
+	 * - terminal event present in the batch → fast flush ({@link BATCH_INTERVAL_MS})
+	 * - buffer at/over {@link MAX_EVENTS_PER_FLUSH} → fast flush
+	 * - otherwise → safety flush ({@link SAFETY_INTERVAL_MS})
+	 */
 	private _bufferEvents(chatSessionId: string, events: SessionEvent[]): void {
+		let hasTerminal = false;
 		for (const event of events) {
+			if (STREAMING_EVENT_TYPES.has(event.type)) {
+				continue;
+			}
 			this._eventBuffer.push({ chatSessionId, event });
+			if (!hasTerminal && isTerminalFlushEvent(event)) {
+				hasTerminal = true;
+			}
+		}
+
+		if (this._eventBuffer.length === 0) {
+			return;
 		}
 
 		// Hard cap — drop oldest events
@@ -1140,20 +1171,34 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 				bufferSize: MAX_BUFFER_SIZE,
 			});
 		}
+
+		if (hasTerminal || this._eventBuffer.length >= MAX_EVENTS_PER_FLUSH) {
+			this._scheduleFlush(BATCH_INTERVAL_MS);
+		} else {
+			this._scheduleFlush(SAFETY_INTERVAL_MS);
+		}
 	}
 
-	// ── Flush timer ──────────────────────────────────────────────────────────────
+	// ── Flush scheduling ─────────────────────────────────────────────────────────
 
-	private _ensureFlushTimer(): void {
+	/**
+	 * Schedule a one-shot flush. Upgrade-only: a pending fast flush is never
+	 * downgraded by a later safety request.
+	 */
+	private _scheduleFlush(intervalMs: number): void {
+		const kind: 'fast' | 'safety' = intervalMs === SAFETY_INTERVAL_MS ? 'safety' : 'fast';
+
 		if (this._flushTimer !== undefined) {
-			return;
+			if (kind === 'safety' || this._flushTimerKind === 'fast') {
+				return;
+			}
+			clearTimeout(this._flushTimer);
 		}
 
-		const interval = this._eventBuffer.length > SOFT_BUFFER_CAP
-			? FAST_BATCH_INTERVAL_MS
-			: BATCH_INTERVAL_MS;
-
-		this._flushTimer = setInterval(() => {
+		this._flushTimerKind = kind;
+		this._flushTimer = setTimeout(() => {
+			this._flushTimer = undefined;
+			this._flushTimerKind = undefined;
 			this._flushBatch().catch(err => {
 
 				this._telemetryService.sendMSFTTelemetryErrorEvent('chronicle.cloudSync', {
@@ -1162,13 +1207,14 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 					error: err instanceof Error ? err.message.substring(0, 100) : 'unknown',
 				}, {});
 			});
-		}, interval);
+		}, intervalMs);
 	}
 
 	private _stopFlushTimer(): void {
 		if (this._flushTimer !== undefined) {
-			clearInterval(this._flushTimer);
+			clearTimeout(this._flushTimer);
 			this._flushTimer = undefined;
+			this._flushTimerKind = undefined;
 		}
 	}
 
@@ -1180,9 +1226,6 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 		}
 
 		if (this._eventBuffer.length === 0) {
-			if (this._cloudSessions.size === 0) {
-				this._stopFlushTimer();
-			}
 			return;
 		}
 
@@ -1377,9 +1420,14 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 			this._isFlushing = false;
 		}
 
-		if (this._eventBuffer.length > SOFT_BUFFER_CAP && this._flushTimer !== undefined) {
-			this._stopFlushTimer();
-			this._ensureFlushTimer();
+		// Re-arm after a flush:
+		//  - buffer still has work (re-queued orphans / rate-limited entries) → fast flush
+		//  - otherwise, keep a safety timer running while any cloud session is active
+		//    so late spans are caught even without a terminal event
+		if (this._eventBuffer.length > 0) {
+			this._scheduleFlush(BATCH_INTERVAL_MS);
+		} else if (this._cloudSessions.size > 0) {
+			this._scheduleFlush(SAFETY_INTERVAL_MS);
 		}
 	}
 

--- a/extensions/copilot/src/extension/chronicle/vscode-node/remoteSessionExporter.ts
+++ b/extensions/copilot/src/extension/chronicle/vscode-node/remoteSessionExporter.ts
@@ -50,7 +50,7 @@ const BATCH_INTERVAL_MS = 500;
 
 /**
  * Safety-net interval for buffered events that did not trigger a terminal
- * flush. Mirrors the CLI's `NON_STEERABLE_SAFETY_INTERVAL_MS`.
+ * flush.
  */
 const SAFETY_INTERVAL_MS = 60_000;
 
@@ -1139,7 +1139,7 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 	/**
 	 * Buffer events, drop streaming deltas, and schedule a flush.
 	 *
-	 * Scheduling matches the CLI's non-steerable cadence:
+	 * Scheduling cadence:
 	 * - terminal event present in the batch → fast flush ({@link BATCH_INTERVAL_MS})
 	 * - buffer at/over {@link MAX_EVENTS_PER_FLUSH} → fast flush
 	 * - otherwise → safety flush ({@link SAFETY_INTERVAL_MS})

--- a/extensions/copilot/src/extension/chronicle/vscode-node/remoteSessionExporter.ts
+++ b/extensions/copilot/src/extension/chronicle/vscode-node/remoteSessionExporter.ts
@@ -1254,6 +1254,7 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 		const uniqueSessionsInBatch = new Set(batch.map(e => e.chatSessionId)).size;
 		this._setSyncState({ kind: 'syncing', sessionCount: uniqueSessionsInBatch });
 
+		let flushFailed = false;
 		try {
 			// Group events by chat session ID for correct cloud session routing
 			const eventsBySession = new Map<string, { events: SessionEvent[]; chatSessionIds: Set<string>; entries: typeof batch }>();
@@ -1367,6 +1368,7 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 			} else if (hadTransientError) {
 				this._circuitBreaker.recordFailure();
 				this._setSyncState({ kind: 'error' });
+				flushFailed = true;
 
 				this._telemetryService.sendMSFTTelemetryEvent('chronicle.cloudSync', {
 					operation: 'flushFailure',
@@ -1409,6 +1411,7 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 			// Re-queue on unexpected error
 			this._eventBuffer.unshift(...batch);
 			this._circuitBreaker.recordFailure();
+			flushFailed = true;
 
 			this._telemetryService.sendMSFTTelemetryErrorEvent('chronicle.cloudSync', {
 				operation: 'flushBatch',
@@ -1421,10 +1424,15 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 		}
 
 		// Re-arm after a flush:
+		//  - transient failure → back off at safety cadence (60s) so we don't
+		//    busy-loop against a failing endpoint; the circuit breaker still
+		//    short-circuits attempts during its own backoff window
 		//  - buffer still has work (re-queued orphans / rate-limited entries) → fast flush
 		//  - otherwise, keep a safety timer running while any cloud session is active
 		//    so late spans are caught even without a terminal event
-		if (this._eventBuffer.length > 0) {
+		if (flushFailed && this._eventBuffer.length > 0) {
+			this._scheduleFlush(SAFETY_INTERVAL_MS);
+		} else if (this._eventBuffer.length > 0) {
 			this._scheduleFlush(BATCH_INTERVAL_MS);
 		} else if (this._cloudSessions.size > 0) {
 			this._scheduleFlush(SAFETY_INTERVAL_MS);

--- a/extensions/copilot/src/extension/chronicle/vscode-node/remoteSessionExporter.ts
+++ b/extensions/copilot/src/extension/chronicle/vscode-node/remoteSessionExporter.ts
@@ -52,7 +52,7 @@ const BATCH_INTERVAL_MS = 500;
  * Safety-net interval for buffered events that did not trigger a terminal
  * flush.
  */
-const SAFETY_INTERVAL_MS = 60_000;
+export const SAFETY_INTERVAL_MS = 60_000;
 
 /** Max events per flush request — also acts as a buffer-size flush trigger. */
 const MAX_EVENTS_PER_FLUSH = 500;
@@ -1234,6 +1234,9 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 				const dropped = this._eventBuffer.length - MAX_BUFFER_SIZE;
 				this._eventBuffer.splice(0, dropped);
 			}
+			// Re-arm at the safety cadence so buffered events are retried once the
+			// breaker transitions to HALF_OPEN, even if no new spans arrive.
+			this._scheduleFlush(SAFETY_INTERVAL_MS);
 			return;
 		}
 
@@ -1245,6 +1248,9 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 			// Release the probe slot consumed by canRequest() above so we don't
 			// burn it on a flush we never actually attempted.
 			this._circuitBreaker.cancelProbe();
+			// Re-arm at the safety cadence so buffered events are retried once the
+			// client's Retry-After window elapses, even if no new spans arrive.
+			this._scheduleFlush(SAFETY_INTERVAL_MS);
 			return;
 		}
 

--- a/extensions/copilot/src/extension/chronicle/vscode-node/remoteSessionExporter.ts
+++ b/extensions/copilot/src/extension/chronicle/vscode-node/remoteSessionExporter.ts
@@ -1333,9 +1333,12 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 					}
 				} else if (result.reason === 'rate_limited') {
 					// Client is already self-backing-off; don't trip the circuit breaker.
-					// Requeue the unsent events so they're retried after the backoff.
+					// Requeue the unsent events so they're retried after the backoff, and
+					// fall into the safety cadence (60s) so we don't busy-poll the
+					// isRateLimited() flag at the fast batch interval until it lifts.
 					rateLimitedSessions++;
 					requeueOnRateLimit.push(...slot.entries);
+					flushFailed = true;
 				} else {
 					hadTransientError = true;
 				}
@@ -1424,10 +1427,11 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 		}
 
 		// Re-arm after a flush:
-		//  - transient failure → back off at safety cadence (60s) so we don't
-		//    busy-loop against a failing endpoint; the circuit breaker still
-		//    short-circuits attempts during its own backoff window
-		//  - buffer still has work (re-queued orphans / rate-limited entries) → fast flush
+		//  - transient failure or rate limit → back off at safety cadence (60s)
+		//    so we don't busy-loop against a failing or throttled endpoint;
+		//    the circuit breaker (for failures) and the client's own backoff
+		//    (for rate limits) still gate the actual request independently
+		//  - buffer still has work (re-queued orphans) → fast flush
 		//  - otherwise, keep a safety timer running while any cloud session is active
 		//    so late spans are caught even without a terminal event
 		if (flushFailed && this._eventBuffer.length > 0) {

--- a/extensions/copilot/src/extension/chronicle/vscode-node/test/remoteSessionExporter.spec.ts
+++ b/extensions/copilot/src/extension/chronicle/vscode-node/test/remoteSessionExporter.spec.ts
@@ -1,0 +1,90 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it, vi } from 'vitest';
+import { RemoteSessionExporter, SAFETY_INTERVAL_MS } from '../remoteSessionExporter';
+
+/**
+ * Focused tests for the early-return safety re-arm in `_flushBatch`.
+ *
+ * The full RemoteSessionExporter has ~13 service dependencies, so these tests
+ * bypass the constructor with `Object.create` and only seed the private fields
+ * that the early-return paths touch. We assert that `_scheduleFlush` is invoked
+ * with `SAFETY_INTERVAL_MS` so buffered work is guaranteed to be retried once
+ * the breaker / rate-limit window elapses, even if no further spans arrive.
+ */
+
+interface ExporterStubs {
+	scheduleFlush: ReturnType<typeof vi.fn>;
+	cancelProbe: ReturnType<typeof vi.fn>;
+}
+
+function makeStubExporter(opts: {
+	breakerOpen?: boolean;
+	rateLimited?: boolean;
+	bufferLength?: number;
+}): { exporter: RemoteSessionExporter; stubs: ExporterStubs } {
+	const scheduleFlush = vi.fn();
+	const cancelProbe = vi.fn();
+
+	const exporter = Object.create(RemoteSessionExporter.prototype) as RemoteSessionExporter;
+	const fields = exporter as unknown as {
+		_isFlushing: boolean;
+		_eventBuffer: { chatSessionId: string; event: { type: string } }[];
+		_circuitBreaker: { canRequest: () => boolean; cancelProbe: () => void };
+		_cloudClient: { isRateLimited: () => boolean };
+		_scheduleFlush: (intervalMs: number) => void;
+	};
+
+	fields._isFlushing = false;
+	fields._eventBuffer = Array.from({ length: opts.bufferLength ?? 1 }, (_, i) => ({
+		chatSessionId: `s${i}`,
+		event: { type: 'assistant.message' },
+	}));
+	fields._circuitBreaker = {
+		canRequest: () => !opts.breakerOpen,
+		cancelProbe,
+	};
+	fields._cloudClient = {
+		isRateLimited: () => !!opts.rateLimited,
+	};
+	fields._scheduleFlush = scheduleFlush;
+
+	return { exporter, stubs: { scheduleFlush, cancelProbe } };
+}
+
+async function invokeFlushBatch(exporter: RemoteSessionExporter): Promise<void> {
+	await (exporter as unknown as { _flushBatch: () => Promise<void> })._flushBatch();
+}
+
+describe('RemoteSessionExporter._flushBatch early-return safety re-arm', () => {
+	it('arms a safety-cadence flush when the circuit breaker is open', async () => {
+		const { exporter, stubs } = makeStubExporter({ breakerOpen: true });
+
+		await invokeFlushBatch(exporter);
+
+		expect(stubs.scheduleFlush).toHaveBeenCalledTimes(1);
+		expect(stubs.scheduleFlush).toHaveBeenCalledWith(SAFETY_INTERVAL_MS);
+	});
+
+	it('arms a safety-cadence flush when the client is rate-limited', async () => {
+		const { exporter, stubs } = makeStubExporter({ rateLimited: true });
+
+		await invokeFlushBatch(exporter);
+
+		expect(stubs.scheduleFlush).toHaveBeenCalledTimes(1);
+		expect(stubs.scheduleFlush).toHaveBeenCalledWith(SAFETY_INTERVAL_MS);
+		// Probe slot consumed by canRequest() must be released.
+		expect(stubs.cancelProbe).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not arm a flush when the buffer is empty (benign no-op)', async () => {
+		const { exporter, stubs } = makeStubExporter({ bufferLength: 0 });
+
+		await invokeFlushBatch(exporter);
+
+		expect(stubs.scheduleFlush).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
Event flushes  are now driven by terminal events (turn end, tool complete, session idle/error/shutdown) instead of a fixed 500ms timer, with a 60s safety net while any session is active.

Adds streaming-delta filtering so per-token events never reach the cloud even if the translator starts emitting them in the future.

## Export cadence

Chronicle session-sync now uses an event-driven export cadence:

| Behavior | Before | After |
|----------|--------|-------|
| Flush trigger | Periodic timer | Event-driven (terminal events) |
| Flush interval | Every 500ms (always running) | 500ms after terminal event / on buffer cap |
| Safety-net interval | N/A | 60s while any cloud session is active |
| Streaming deltas | Buffered | Filtered out before buffering |
| Per-flush event cap | 500 | 500 (unchanged) |
| Buffer cap | 1000 | 1000 (unchanged) |
| Retry on failure | 500ms (gated by circuit breaker only) | 60s back-off after any failure |

### Terminal events that trigger a flush
- `assistant.message` — assistant turn finished
- `tool.execution_complete` — tool call finished
- `session.idle` — turn completed, waiting for user
- `session.shutdown` — session ending
- `session.error` — error occurred

### Additional fast-flush triggers
- `INVOKE_AGENT` span observed (closes the cancel-before-tokens-streamed gap)
- Buffer reaches the per-flush cap (500 events)