### PR TITLE
sessions: fix isolation picker and loading spinner regressions from Sessions Grid refactor

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/newChatInput.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInput.ts
@@ -454,6 +454,7 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 		const loadingIcon = dom.append(this._loadingSpinner, renderIcon(ThemeIcon.modify(Codicon.loading, 'spin')));
 		loadingIcon.setAttribute('aria-hidden', 'true');
 		this._register(this.hoverService.setupManagedHover(getDefaultHoverDelegate('mouse'), this._loadingSpinner, localize('loading', "Loading...")));
+		this._loadingSpinner.classList.toggle('visible', this.options.loading.get());
 
 		const sendButtonContainer = dom.append(toolbar, dom.$('.sessions-chat-send-button'));
 		const sendButton = this._sendButton = this._register(new Button(sendButtonContainer, {

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -135,7 +135,11 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 
 	private _handleActiveSessionContextKeys(session: IActiveSession | undefined): void {
 		// Update context keys from session data
-		this._isNewChatSessionContext.set(session === undefined || this._pendingNewSession !== undefined);
+		// IsNewChatSessionContext is true when no active session exists, OR when the
+		// active session is still pending (created but not yet sent for the first time).
+		// Scoping to the active session avoids flipping into "new chat" mode while
+		// viewing a different established session.
+		this._isNewChatSessionContext.set(session === undefined || session.sessionId === this._pendingNewSession?.sessionId);
 		this._activeSessionProviderId.set(session?.providerId ?? '');
 		this._activeSessionType.set(session?.sessionType ?? '');
 		this._activeSessionWorkspaceIsVirtual.set(session?.workspace.get()?.isVirtualWorkspace ?? true);

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -135,7 +135,7 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 
 	private _handleActiveSessionContextKeys(session: IActiveSession | undefined): void {
 		// Update context keys from session data
-		this._isNewChatSessionContext.set(session === undefined);
+		this._isNewChatSessionContext.set(session === undefined || this._pendingNewSession !== undefined);
 		this._activeSessionProviderId.set(session?.providerId ?? '');
 		this._activeSessionType.set(session?.sessionType ?? '');
 		this._activeSessionWorkspaceIsVirtual.set(session?.workspace.get()?.isVirtualWorkspace ?? true);
@@ -455,6 +455,7 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 
 	async sendNewChatRequest(session: ISession, options: ISendRequestOptions): Promise<void> {
 		this._pendingNewSession = undefined;
+		this._isNewChatSessionContext.set(false);
 
 		const setActiveChatToLast = () => {
 			const activeSession = this._visibility.activeSession.get();


### PR DESCRIPTION
## Summary

Fixes two regressions introduced by the Sessions Grid refactor (#317309).

### 1. Isolation / branch pickers not shown on new-session page

**Root cause:** `_handleActiveSessionContextKeys` now sets `IsNewChatSessionContext = session === undefined`. For a pending new session (created but not yet sent), `session` is defined, so the context key was `false` — hiding the isolation/branch pickers whose `when` clauses require `IsNewChatSessionContext`.

**Fix:** Set `IsNewChatSessionContext = true` when `_pendingNewSession !== undefined`, and explicitly clear it to `false` in `sendNewChatRequest` when the first message is sent.

### 2. Loading spinner not shown while session resolves git repo

**Root cause:** The autorun that toggles the spinner fires in `NewChatInputWidget`'s constructor, before `render()` creates the `_loadingSpinner` DOM element. When the active session is already in a loading state at construction time (e.g. on window reload), the autorun fires with `_loadingSpinner === undefined` and is a no-op. The spinner is created shortly after in `render()`, but since `loading` hasn't changed, the autorun doesn't re-fire.

**Fix:** Sync the spinner's initial visibility immediately after creating the DOM element in `render()` using `this.options.loading.get()`.

## Files changed

- `src/vs/sessions/services/sessions/browser/sessionsManagementService.ts` — isolation picker context key fix
- `src/vs/sessions/contrib/chat/browser/newChatInput.ts` — loading spinner initial state fix