### PR TITLE
agentHost: surface steering messages as their own user turn

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -351,7 +351,20 @@ export class CopilotAgentSession extends Disposable {
 	/** Last agent mode pushed to the SDK via {@link applyMode}, to elide redundant `rpc.mode.set` calls. */
 	private _lastAppliedMode: CopilotSdkMode | undefined;
 	private readonly _steeringMessagesInFlight = new Set<string>();
-	private readonly _consumedSteeringMessages = new Set<string>();
+	/**
+	 * Steering messages that have been accepted by the SDK but not yet
+	 * surfaced to the chat UI as a separate user message. The next SDK
+	 * `assistant.turn_start` we observe is treated as the new turn for the
+	 * head entry: we finalize the current turn and dispatch a new
+	 * {@link ActionType.SessionTurnStarted} whose `userMessage` is the
+	 * steering content. The reducer also removes the pending steering via
+	 * the action's `queuedMessageId`.
+	 *
+	 * Entries left here at abort/dispose time are flushed as
+	 * `steering_consumed` signals so the chat UI's pending state still
+	 * clears in cleanup paths where we never observe a fresh turn_start.
+	 */
+	private readonly _pendingSteeringFlips = new Map<string, PendingMessage>();
 
 	/** Snapshot captured at session creation for refresh detection. */
 	private readonly _appliedSnapshot: IActiveClientSnapshot;
@@ -415,6 +428,7 @@ export class CopilotAgentSession extends Disposable {
 		this._register(toDisposable(() => this._cancelPendingUserInputs()));
 		this._register(toDisposable(() => this._cancelPendingElicitations()));
 		this._register(toDisposable(() => this._cancelPendingPlanReviews()));
+		this._register(toDisposable(() => this._drainPendingSteeringFlips()));
 
 		// When a shell tool associates a terminal with a tool call, fire a
 		// tool_content_changed event so the UI can connect to the terminal
@@ -453,19 +467,52 @@ export class CopilotAgentSession extends Disposable {
 			action,
 			parentToolCallId,
 		});
-		if (action.type === ActionType.SessionToolCallStart && !parentToolCallId) {
-			this._flushConsumedSteeringMessages();
-		} else if (action.type === ActionType.SessionTurnComplete) {
-			this._flushConsumedSteeringMessages();
-		}
 	}
 
-	private _flushConsumedSteeringMessages(): void {
-		if (this._consumedSteeringMessages.size === 0) {
+	/**
+	 * Promotes the head pending steering message into its own protocol
+	 * turn: closes the in-flight turn (so its responseParts settle into
+	 * history) and dispatches {@link ActionType.SessionTurnStarted} for a
+	 * fresh turn whose user message is the steering content. The action's
+	 * `queuedMessageId` atomically clears the corresponding pending
+	 * steering message from the session state.
+	 *
+	 * All subsequent SDK events (message deltas, tool calls, …) emitted by
+	 * the agent now reference the new `_turnId`, so the steering response
+	 * lands in the new turn rather than being folded into the original.
+	 */
+	private _beginSteeringTurn(steering: PendingMessage): void {
+		const previousTurnId = this._turnId;
+		if (previousTurnId) {
+			this._emitAction({
+				type: ActionType.SessionTurnComplete,
+				turnId: previousTurnId,
+			});
+		}
+		const newTurnId = generateUuid();
+		this._emitAction({
+			type: ActionType.SessionTurnStarted,
+			turnId: newTurnId,
+			userMessage: steering.userMessage,
+			queuedMessageId: steering.id,
+		});
+		this._turnId = newTurnId;
+		this._currentMarkdownPartIds.clear();
+		this._currentReasoningPartIds.clear();
+	}
+
+	/**
+	 * Drains any steering messages we acknowledged to the SDK but never
+	 * promoted to their own turn (e.g. on abort or session dispose). Fires
+	 * `steering_consumed` so the chat UI removes the lingering pending
+	 * steering bubble even when no fresh `user.message` arrives.
+	 */
+	private _drainPendingSteeringFlips(): void {
+		if (this._pendingSteeringFlips.size === 0) {
 			return;
 		}
-		const ids = [...this._consumedSteeringMessages];
-		this._consumedSteeringMessages.clear();
+		const ids = [...this._pendingSteeringFlips.keys()];
+		this._pendingSteeringFlips.clear();
 		for (const id of ids) {
 			this._onDidSessionProgress.fire({
 				kind: 'steering_consumed',
@@ -473,6 +520,28 @@ export class CopilotAgentSession extends Disposable {
 				id,
 			});
 		}
+	}
+
+	/**
+	 * Pops the buffered steering message whose text matches the SDK
+	 * `user.message` content we just observed. Matching by content (rather
+	 * than just popping FIFO) keeps us robust against the SDK reordering
+	 * or coalescing entries — concurrent steering messages with different
+	 * texts are still matched to the correct one. Falls back to the head
+	 * entry only when no content match exists (defensive: should not
+	 * happen in practice).
+	 */
+	private _takeMatchingPendingSteering(content: string): PendingMessage | undefined {
+		if (this._pendingSteeringFlips.size === 0) {
+			return undefined;
+		}
+		for (const [id, msg] of this._pendingSteeringFlips) {
+			if (msg.userMessage.text === content) {
+				this._pendingSteeringFlips.delete(id);
+				return msg;
+			}
+		}
+		return undefined;
 	}
 
 	private _parentToolCallIdForSubagentEvent(e: { readonly agentId?: string }): string | undefined {
@@ -824,7 +893,7 @@ export class CopilotAgentSession extends Disposable {
 	}
 
 	async sendSteering(steeringMessage: PendingMessage): Promise<void> {
-		if (this._steeringMessagesInFlight.has(steeringMessage.id) || this._consumedSteeringMessages.has(steeringMessage.id)) {
+		if (this._steeringMessagesInFlight.has(steeringMessage.id) || this._pendingSteeringFlips.has(steeringMessage.id)) {
 			return;
 		}
 		this._steeringMessagesInFlight.add(steeringMessage.id);
@@ -834,7 +903,7 @@ export class CopilotAgentSession extends Disposable {
 				prompt: steeringMessage.userMessage.text,
 				mode: 'immediate',
 			});
-			this._consumedSteeringMessages.add(steeringMessage.id);
+			this._pendingSteeringFlips.set(steeringMessage.id, steeringMessage);
 		} catch (err) {
 			this._logService.error(`[Copilot:${this.sessionId}] Steering message failed`, err);
 		} finally {
@@ -869,7 +938,7 @@ export class CopilotAgentSession extends Disposable {
 	async abort(): Promise<void> {
 		this._logService.info(`[Copilot:${this.sessionId}] Aborting session...`);
 		this._denyPendingPermissions();
-		this._flushConsumedSteeringMessages();
+		this._drainPendingSteeringFlips();
 		await this._wrapper.session.abort();
 	}
 
@@ -1506,6 +1575,14 @@ export class CopilotAgentSession extends Disposable {
 		this._register(wrapper.onUserMessage(e => {
 			if (this._turnId) {
 				this._databaseRef.object.setTurnEventId(this._turnId, e.id);
+			}
+			if (e.data.source && e.data.source.toLowerCase() !== 'user') {
+				// Synthetic injection (skill content, etc.) — never user-visible.
+				return;
+			}
+			const steering = this._takeMatchingPendingSteering(e.data.content);
+			if (steering) {
+				this._beginSteeringTurn(steering);
 			}
 		}));
 

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -353,16 +353,16 @@ export class CopilotAgentSession extends Disposable {
 	private readonly _steeringMessagesInFlight = new Set<string>();
 	/**
 	 * Steering messages that have been accepted by the SDK but not yet
-	 * surfaced to the chat UI as a separate user message. The next SDK
-	 * `assistant.turn_start` we observe is treated as the new turn for the
-	 * head entry: we finalize the current turn and dispatch a new
-	 * {@link ActionType.SessionTurnStarted} whose `userMessage` is the
-	 * steering content. The reducer also removes the pending steering via
-	 * the action's `queuedMessageId`.
+	 * surfaced to the chat UI as a separate user message. When the SDK
+	 * echoes a steering through a `user.message` event whose `content`
+	 * matches one of these entries, we finalize the in-flight turn and
+	 * dispatch a new {@link ActionType.SessionTurnStarted} whose
+	 * `userMessage` is the steering content. The reducer also removes
+	 * the pending steering via the action's `queuedMessageId`.
 	 *
 	 * Entries left here at abort/dispose time are flushed as
 	 * `steering_consumed` signals so the chat UI's pending state still
-	 * clears in cleanup paths where we never observe a fresh turn_start.
+	 * clears in cleanup paths where we never observe the echo.
 	 */
 	private readonly _pendingSteeringFlips = new Map<string, PendingMessage>();
 
@@ -470,18 +470,23 @@ export class CopilotAgentSession extends Disposable {
 	}
 
 	/**
-	 * Promotes the head pending steering message into its own protocol
-	 * turn: closes the in-flight turn (so its responseParts settle into
-	 * history) and dispatches {@link ActionType.SessionTurnStarted} for a
-	 * fresh turn whose user message is the steering content. The action's
+	 * Promotes a pending steering message into its own protocol turn:
+	 * closes the in-flight turn (so its responseParts settle into history)
+	 * and dispatches {@link ActionType.SessionTurnStarted} for a fresh
+	 * turn whose user message is the steering content. The action's
 	 * `queuedMessageId` atomically clears the corresponding pending
 	 * steering message from the session state.
 	 *
-	 * All subsequent SDK events (message deltas, tool calls, …) emitted by
-	 * the agent now reference the new `_turnId`, so the steering response
-	 * lands in the new turn rather than being folded into the original.
+	 * All subsequent SDK events (message deltas, tool calls, …) emitted
+	 * by the agent now reference the new `_turnId`, so the steering
+	 * response lands in the new turn rather than being folded into the
+	 * original.
+	 *
+	 * Returns the new turn id so callers (notably the `user.message`
+	 * handler) can associate the SDK event id with the steering turn for
+	 * history.truncate / sessions.fork mapping.
 	 */
-	private _beginSteeringTurn(steering: PendingMessage): void {
+	private _beginSteeringTurn(steering: PendingMessage): string {
 		const previousTurnId = this._turnId;
 		if (previousTurnId) {
 			this._emitAction({
@@ -496,9 +501,11 @@ export class CopilotAgentSession extends Disposable {
 			userMessage: steering.userMessage,
 			queuedMessageId: steering.id,
 		});
-		this._turnId = newTurnId;
-		this._currentMarkdownPartIds.clear();
-		this._currentReasoningPartIds.clear();
+		// Mirror `resetTurnState` so per-turn counters/mappings (usage
+		// total, streaming part ids, subagent agentId map) don't bleed
+		// from the preempted turn into the new steering turn.
+		this.resetTurnState(newTurnId);
+		return newTurnId;
 	}
 
 	/**
@@ -527,9 +534,9 @@ export class CopilotAgentSession extends Disposable {
 	 * `user.message` content we just observed. Matching by content (rather
 	 * than just popping FIFO) keeps us robust against the SDK reordering
 	 * or coalescing entries — concurrent steering messages with different
-	 * texts are still matched to the correct one. Falls back to the head
-	 * entry only when no content match exists (defensive: should not
-	 * happen in practice).
+	 * texts are still matched to the correct one. Returns `undefined` if
+	 * no buffered entry matches; the caller treats the `user.message` as
+	 * an ordinary echo and skips the turn flip.
 	 */
 	private _takeMatchingPendingSteering(content: string): PendingMessage | undefined {
 		if (this._pendingSteeringFlips.size === 0) {
@@ -1569,20 +1576,35 @@ export class CopilotAgentSession extends Disposable {
 		const wrapper = this._wrapper;
 		const sessionId = this.sessionId;
 
-		// Capture SDK event IDs for each user.message event so we can map
-		// protocol turn indices to the event IDs needed by the SDK's
-		// history.truncate and sessions.fork RPCs.
+		// Handle `user.message` events with three responsibilities:
+		//
+		// 1. Skip SDK-injected (`source !== 'user'`) messages outright —
+		//    they are skill content / harness injections that must not
+		//    surface to the user and must not be associated with a turn
+		//    boundary (the SDK's truncate/fork mapping keys off the
+		//    user-visible message's event id).
+		//
+		// 2. If the content matches a steering message we acknowledged
+		//    via {@link sendSteering}, promote it to its own protocol
+		//    turn (closing the in-flight turn) BEFORE step 3 so the
+		//    event id is recorded against the new steering turn rather
+		//    than the preempted one.
+		//
+		// 3. Record the SDK event id against the current turn so the
+		//    `history.truncate` / `sessions.fork` RPCs can target the
+		//    right boundary. The DB only sets `event_id` when it's NULL,
+		//    so doing this for synthetic injections would permanently
+		//    pin the wrong event to the turn.
 		this._register(wrapper.onUserMessage(e => {
-			if (this._turnId) {
-				this._databaseRef.object.setTurnEventId(this._turnId, e.id);
-			}
 			if (e.data.source && e.data.source.toLowerCase() !== 'user') {
-				// Synthetic injection (skill content, etc.) — never user-visible.
 				return;
 			}
 			const steering = this._takeMatchingPendingSteering(e.data.content);
 			if (steering) {
 				this._beginSteeringTurn(steering);
+			}
+			if (this._turnId) {
+				this._databaseRef.object.setTurnEventId(this._turnId, e.id);
 			}
 		}));
 

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -887,41 +887,92 @@ suite('CopilotAgentSession', () => {
 
 	suite('sendSteering', () => {
 
-		test('fires steering_consumed after send resolves and the next tool starts', async () => {
+		test('promotes steering to its own turn when the SDK echoes the user message', async () => {
 			const { session, mockSession, signals } = await createAgentSession(disposables);
+			session.resetTurnState('turn-original');
 
 			await session.sendSteering({ id: 'steer-1', userMessage: { text: 'focus on tests' } });
 
-			let consumed = signals.find(s => s.kind === 'steering_consumed');
-			assert.strictEqual(consumed, undefined, 'should keep steering visible after the SDK send resolves');
+			// Sending the steering must not flip turns until the SDK has
+			// echoed the user message back through the event stream.
+			assert.strictEqual(signals.find(s => s.kind === 'action' && (s as IAgentActionSignal).action.type === ActionType.SessionTurnStarted), undefined);
 
-			mockSession.fire('tool.execution_start', {
-				toolCallId: 'tc-steer',
-				toolName: 'bash',
-				arguments: { command: 'echo hi' },
-			} as SessionEventPayload<'tool.execution_start'>['data']);
+			mockSession.fire('user.message', {
+				content: 'focus on tests',
+				interactionId: 'interaction-steer',
+			} as SessionEventPayload<'user.message'>['data']);
 
-			consumed = signals.find(s => s.kind === 'steering_consumed');
-			assert.ok(consumed, 'should fire steering_consumed signal after the next tool starts');
-			assert.strictEqual((consumed as { id: string }).id, 'steer-1');
+			const actions = signals.filter(s => s.kind === 'action').map(s => (s as IAgentActionSignal).action);
+			const turnComplete = actions.find(a => a.type === ActionType.SessionTurnComplete);
+			const turnStarted = actions.find(a => a.type === ActionType.SessionTurnStarted);
+			assert.ok(turnComplete, 'should complete the in-flight turn before promoting steering');
+			assert.strictEqual(turnComplete.turnId, 'turn-original');
+			assert.ok(turnStarted, 'should start a new turn for the steering message');
+			assert.notStrictEqual(turnStarted.turnId, 'turn-original');
+			assert.deepStrictEqual(turnStarted.userMessage, { text: 'focus on tests' });
+			assert.strictEqual(turnStarted.queuedMessageId, 'steer-1');
 		});
 
-		test('fires steering_consumed after send resolves and the turn ends without a tool', async () => {
+		test('routes subsequent SDK events into the steering turn', async () => {
 			const { session, mockSession, signals } = await createAgentSession(disposables);
+			session.resetTurnState('turn-original');
+
+			await session.sendSteering({ id: 'steer-1', userMessage: { text: 'focus on tests' } });
+			mockSession.fire('user.message', {
+				content: 'focus on tests',
+				interactionId: 'interaction-steer',
+			} as SessionEventPayload<'user.message'>['data']);
+
+			const turnStarted = signals
+				.filter(s => s.kind === 'action')
+				.map(s => (s as IAgentActionSignal).action)
+				.find(a => a.type === ActionType.SessionTurnStarted)!;
+
+			mockSession.fire('assistant.message_delta', {
+				deltaContent: 'No problem',
+			} as SessionEventPayload<'assistant.message_delta'>['data']);
+
+			const responseParts = signals
+				.filter(s => s.kind === 'action')
+				.map(s => (s as IAgentActionSignal).action)
+				.filter(a => a.type === ActionType.SessionResponsePart);
+			assert.ok(responseParts.length > 0, 'expected delta to allocate a response part');
+			assert.strictEqual(responseParts[0].turnId, turnStarted.turnId, 'response part should land in the steering turn, not the original');
+		});
+
+		test('does not flip turns for SDK-injected user messages (non-user source)', async () => {
+			const { session, mockSession, signals } = await createAgentSession(disposables);
+			session.resetTurnState('turn-original');
 
 			await session.sendSteering({ id: 'steer-1', userMessage: { text: 'focus on tests' } });
 
-			let consumed = signals.find(s => s.kind === 'steering_consumed');
-			assert.strictEqual(consumed, undefined, 'should keep steering visible after the SDK send resolves');
+			// SDK injects an unrelated user.message (e.g. skill content)
+			// with the steering's exact text but a non-'user' source.
+			// Even if the text happened to match, the synthetic-source
+			// guard MUST skip the flip.
+			mockSession.fire('user.message', {
+				content: 'focus on tests',
+				source: 'skill-pdf',
+			} as SessionEventPayload<'user.message'>['data']);
 
-			mockSession.fire('session.idle', {} as SessionEventPayload<'session.idle'>['data']);
-
-			consumed = signals.find(s => s.kind === 'steering_consumed');
-			assert.ok(consumed, 'should fire steering_consumed signal after the turn ends');
-			assert.strictEqual((consumed as { id: string }).id, 'steer-1');
+			const turnStarted = signals.find(s => s.kind === 'action' && (s as IAgentActionSignal).action.type === ActionType.SessionTurnStarted);
+			assert.strictEqual(turnStarted, undefined, 'synthetic user messages should not promote steering to a turn');
 		});
 
-		test('does not send the same steering message again before it is flushed', async () => {
+		test('does not flip turns when the user.message content does not match', async () => {
+			const { session, mockSession, signals } = await createAgentSession(disposables);
+			session.resetTurnState('turn-original');
+
+			await session.sendSteering({ id: 'steer-1', userMessage: { text: 'focus on tests' } });
+			mockSession.fire('user.message', {
+				content: 'something completely different',
+			} as SessionEventPayload<'user.message'>['data']);
+
+			const turnStarted = signals.find(s => s.kind === 'action' && (s as IAgentActionSignal).action.type === ActionType.SessionTurnStarted);
+			assert.strictEqual(turnStarted, undefined, 'unrelated user messages should not consume the pending steering');
+		});
+
+		test('does not send the same steering message again before it is flipped', async () => {
 			const { session, mockSession } = await createAgentSession(disposables);
 
 			await session.sendSteering({ id: 'steer-1', userMessage: { text: 'focus on tests' } });
@@ -930,18 +981,18 @@ suite('CopilotAgentSession', () => {
 			assert.strictEqual(mockSession.sendRequests.length, 1);
 		});
 
-		test('fires steering_consumed on abort after send resolves', async () => {
+		test('fires steering_consumed on abort when the steering never reached its turn', async () => {
 			const { session, signals } = await createAgentSession(disposables);
 
 			await session.sendSteering({ id: 'steer-1', userMessage: { text: 'focus on tests' } });
 			await session.abort();
 
 			const consumed = signals.find(s => s.kind === 'steering_consumed');
-			assert.ok(consumed, 'should fire steering_consumed signal when the turn is aborted');
+			assert.ok(consumed, 'abort should clean up pending steering UI state');
 			assert.strictEqual((consumed as { id: string }).id, 'steer-1');
 		});
 
-		test('does not fire steering_consumed when send fails', async () => {
+		test('does not signal cleanup when send fails', async () => {
 			const { session, mockSession, signals } = await createAgentSession(disposables);
 
 			mockSession.send = async () => { throw new Error('send failed'); };
@@ -949,7 +1000,9 @@ suite('CopilotAgentSession', () => {
 			await session.sendSteering({ id: 'steer-fail', userMessage: { text: 'will fail' } });
 
 			const consumed = signals.find(s => s.kind === 'steering_consumed');
+			const turnStarted = signals.find(s => s.kind === 'action' && (s as IAgentActionSignal).action.type === ActionType.SessionTurnStarted);
 			assert.strictEqual(consumed, undefined, 'should not fire steering_consumed on failure');
+			assert.strictEqual(turnStarted, undefined, 'should not start a new turn on failure');
 		});
 	});
 


### PR DESCRIPTION
When a user sent a steering message mid-turn, the Copilot agent host folded the SDK's response into the in-flight turn instead of showing the steering as a separate user message in the chat UI. The pending steering bubble silently disappeared and the assistant's reply appeared as a continuation of the original turn.

Buffer accepted steering messages and, when the SDK echoes them back through a `user.message` event (matched by content, skipping synthetic `source != 'user'` injections), promote the steering to its own protocol turn: dispatch `SessionTurnComplete` for the in-flight turn, then `SessionTurnStarted` with the steering's userMessage and `queuedMessageId` so the reducer atomically clears the pending entry. `_turnId` is updated so subsequent SDK deltas land in the new turn. Cleanup paths (abort, dispose) drain any unflipped buffer entries via `steering_consumed` so the chat UI bubble still clears.

Fixes #318265

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
