### PR TITLE
Make session sync flush params exp controllable

### DIFF
--- a/extensions/copilot/src/extension/chronicle/vscode-node/remoteSessionExporter.ts
+++ b/extensions/copilot/src/extension/chronicle/vscode-node/remoteSessionExporter.ts
@@ -51,7 +51,7 @@ const BATCH_INTERVAL_MS = 500;
 /**
  * Default safety-net interval for buffered events that did not trigger a
  * terminal flush. The effective value is read from
- * {@link ConfigKey.SessionSyncSafetyIntervalMs} at runtime; this constant is
+ * {@link ConfigKey.TeamInternal.SessionSyncSafetyIntervalMs} at runtime; this constant is
  * only used as the fallback when no configuration service is available
  * (e.g. in tests that bypass the constructor).
  */
@@ -60,7 +60,7 @@ export const SAFETY_INTERVAL_MS = 60_000;
 /**
  * Default max events per flush request — also acts as a buffer-size flush
  * trigger. The effective value is read from
- * {@link ConfigKey.SessionSyncMaxEventsPerFlush} at runtime.
+ * {@link ConfigKey.TeamInternal.SessionSyncMaxEventsPerFlush} at runtime.
  */
 const MAX_EVENTS_PER_FLUSH = 500;
 
@@ -204,7 +204,7 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 	 * safety backoff into an immediate timer and busy-poll a failing endpoint.
 	 */
 	private _getSafetyIntervalMs(): number {
-		const configured = this._configService?.getExperimentBasedConfig(ConfigKey.SessionSyncSafetyIntervalMs, this._expService);
+		const configured = this._configService?.getExperimentBasedConfig(ConfigKey.TeamInternal.SessionSyncSafetyIntervalMs, this._expService);
 		return typeof configured === 'number' && Number.isFinite(configured) && configured > 0
 			? configured
 			: SAFETY_INTERVAL_MS;
@@ -218,7 +218,7 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 	 * re-arming fast flushes without uploading any events.
 	 */
 	private _getMaxEventsPerFlush(): number {
-		const configured = this._configService?.getExperimentBasedConfig(ConfigKey.SessionSyncMaxEventsPerFlush, this._expService);
+		const configured = this._configService?.getExperimentBasedConfig(ConfigKey.TeamInternal.SessionSyncMaxEventsPerFlush, this._expService);
 		return Number.isInteger(configured) && configured > 0
 			? configured
 			: MAX_EVENTS_PER_FLUSH;

--- a/extensions/copilot/src/extension/chronicle/vscode-node/remoteSessionExporter.ts
+++ b/extensions/copilot/src/extension/chronicle/vscode-node/remoteSessionExporter.ts
@@ -49,12 +49,19 @@ import { reindexSessions, reindexCloudSessions, type CloudReindexResult } from '
 const BATCH_INTERVAL_MS = 500;
 
 /**
- * Safety-net interval for buffered events that did not trigger a terminal
- * flush.
+ * Default safety-net interval for buffered events that did not trigger a
+ * terminal flush. The effective value is read from
+ * {@link ConfigKey.SessionSyncSafetyIntervalMs} at runtime; this constant is
+ * only used as the fallback when no configuration service is available
+ * (e.g. in tests that bypass the constructor).
  */
 export const SAFETY_INTERVAL_MS = 60_000;
 
-/** Max events per flush request — also acts as a buffer-size flush trigger. */
+/**
+ * Default max events per flush request — also acts as a buffer-size flush
+ * trigger. The effective value is read from
+ * {@link ConfigKey.SessionSyncMaxEventsPerFlush} at runtime.
+ */
 const MAX_EVENTS_PER_FLUSH = 500;
 
 /** Hard cap on buffered events (drop oldest beyond this). */
@@ -187,6 +194,26 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 	/** Invalidate the cached local synced count (call after cloud session set/delete). */
 	private _invalidateLocalSyncedCount(): void {
 		this._cachedLocalSyncedCount = undefined;
+	}
+
+	/**
+	 * Effective safety-net interval (ms), read from configuration. Falls back to
+	 * {@link SAFETY_INTERVAL_MS} when the configuration service is unavailable
+	 * (e.g. tests that bypass the constructor).
+	 */
+	private _getSafetyIntervalMs(): number {
+		return this._configService?.getExperimentBasedConfig(ConfigKey.SessionSyncSafetyIntervalMs, this._expService)
+			?? SAFETY_INTERVAL_MS;
+	}
+
+	/**
+	 * Effective max events per flush request, read from configuration. Falls back
+	 * to {@link MAX_EVENTS_PER_FLUSH} when the configuration service is
+	 * unavailable.
+	 */
+	private _getMaxEventsPerFlush(): number {
+		return this._configService?.getExperimentBasedConfig(ConfigKey.SessionSyncMaxEventsPerFlush, this._expService)
+			?? MAX_EVENTS_PER_FLUSH;
 	}
 
 	/**
@@ -1172,10 +1199,10 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 			});
 		}
 
-		if (hasTerminal || this._eventBuffer.length >= MAX_EVENTS_PER_FLUSH) {
+		if (hasTerminal || this._eventBuffer.length >= this._getMaxEventsPerFlush()) {
 			this._scheduleFlush(BATCH_INTERVAL_MS);
 		} else {
-			this._scheduleFlush(SAFETY_INTERVAL_MS);
+			this._scheduleFlush(this._getSafetyIntervalMs());
 		}
 	}
 
@@ -1186,7 +1213,7 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 	 * downgraded by a later safety request.
 	 */
 	private _scheduleFlush(intervalMs: number): void {
-		const kind: 'fast' | 'safety' = intervalMs === SAFETY_INTERVAL_MS ? 'safety' : 'fast';
+		const kind: 'fast' | 'safety' = intervalMs === this._getSafetyIntervalMs() ? 'safety' : 'fast';
 
 		if (this._flushTimer !== undefined) {
 			if (kind === 'safety' || this._flushTimerKind === 'fast') {
@@ -1236,7 +1263,7 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 			}
 			// Re-arm at the safety cadence so buffered events are retried once the
 			// breaker transitions to HALF_OPEN, even if no new spans arrive.
-			this._scheduleFlush(SAFETY_INTERVAL_MS);
+			this._scheduleFlush(this._getSafetyIntervalMs());
 			return;
 		}
 
@@ -1250,12 +1277,12 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 			this._circuitBreaker.cancelProbe();
 			// Re-arm at the safety cadence so buffered events are retried once the
 			// client's Retry-After window elapses, even if no new spans arrive.
-			this._scheduleFlush(SAFETY_INTERVAL_MS);
+			this._scheduleFlush(this._getSafetyIntervalMs());
 			return;
 		}
 
 		this._isFlushing = true;
-		const batch = this._eventBuffer.splice(0, MAX_EVENTS_PER_FLUSH);
+		const batch = this._eventBuffer.splice(0, this._getMaxEventsPerFlush());
 		const batchStart = Date.now();
 		const uniqueSessionsInBatch = new Set(batch.map(e => e.chatSessionId)).size;
 		this._setSyncState({ kind: 'syncing', sessionCount: uniqueSessionsInBatch });
@@ -1441,11 +1468,11 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 		//  - otherwise, keep a safety timer running while any cloud session is active
 		//    so late spans are caught even without a terminal event
 		if (flushFailed && this._eventBuffer.length > 0) {
-			this._scheduleFlush(SAFETY_INTERVAL_MS);
+			this._scheduleFlush(this._getSafetyIntervalMs());
 		} else if (this._eventBuffer.length > 0) {
 			this._scheduleFlush(BATCH_INTERVAL_MS);
 		} else if (this._cloudSessions.size > 0) {
-			this._scheduleFlush(SAFETY_INTERVAL_MS);
+			this._scheduleFlush(this._getSafetyIntervalMs());
 		}
 	}
 

--- a/extensions/copilot/src/extension/chronicle/vscode-node/remoteSessionExporter.ts
+++ b/extensions/copilot/src/extension/chronicle/vscode-node/remoteSessionExporter.ts
@@ -199,21 +199,29 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 	/**
 	 * Effective safety-net interval (ms), read from configuration. Falls back to
 	 * {@link SAFETY_INTERVAL_MS} when the configuration service is unavailable
-	 * (e.g. tests that bypass the constructor).
+	 * (e.g. tests that bypass the constructor) or when the configured value is
+	 * not a positive finite number — otherwise an invalid treatment could turn
+	 * safety backoff into an immediate timer and busy-poll a failing endpoint.
 	 */
 	private _getSafetyIntervalMs(): number {
-		return this._configService?.getExperimentBasedConfig(ConfigKey.SessionSyncSafetyIntervalMs, this._expService)
-			?? SAFETY_INTERVAL_MS;
+		const configured = this._configService?.getExperimentBasedConfig(ConfigKey.SessionSyncSafetyIntervalMs, this._expService);
+		return typeof configured === 'number' && Number.isFinite(configured) && configured > 0
+			? configured
+			: SAFETY_INTERVAL_MS;
 	}
 
 	/**
 	 * Effective max events per flush request, read from configuration. Falls back
 	 * to {@link MAX_EVENTS_PER_FLUSH} when the configuration service is
-	 * unavailable.
+	 * unavailable or when the configured value is not a positive integer —
+	 * otherwise an invalid treatment could splice an empty batch and busy-loop
+	 * re-arming fast flushes without uploading any events.
 	 */
 	private _getMaxEventsPerFlush(): number {
-		return this._configService?.getExperimentBasedConfig(ConfigKey.SessionSyncMaxEventsPerFlush, this._expService)
-			?? MAX_EVENTS_PER_FLUSH;
+		const configured = this._configService?.getExperimentBasedConfig(ConfigKey.SessionSyncMaxEventsPerFlush, this._expService);
+		return Number.isInteger(configured) && configured > 0
+			? configured
+			: MAX_EVENTS_PER_FLUSH;
 	}
 
 	/**
@@ -834,7 +842,7 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 				// flush even when the turn produced no terminal event (e.g. cancelled
 				// before any tokens streamed) so buffered user.message/session.start
 				// don't sit until the 60s safety timer.
-				this._scheduleFlush(BATCH_INTERVAL_MS);
+				this._scheduleFlush(BATCH_INTERVAL_MS, 'fast');
 			}
 		} catch {
 			// Non-fatal — individual span processing failure
@@ -1200,9 +1208,9 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 		}
 
 		if (hasTerminal || this._eventBuffer.length >= this._getMaxEventsPerFlush()) {
-			this._scheduleFlush(BATCH_INTERVAL_MS);
+			this._scheduleFlush(BATCH_INTERVAL_MS, 'fast');
 		} else {
-			this._scheduleFlush(this._getSafetyIntervalMs());
+			this._scheduleFlush(this._getSafetyIntervalMs(), 'safety');
 		}
 	}
 
@@ -1212,8 +1220,7 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 	 * Schedule a one-shot flush. Upgrade-only: a pending fast flush is never
 	 * downgraded by a later safety request.
 	 */
-	private _scheduleFlush(intervalMs: number): void {
-		const kind: 'fast' | 'safety' = intervalMs === this._getSafetyIntervalMs() ? 'safety' : 'fast';
+	private _scheduleFlush(intervalMs: number, kind: 'fast' | 'safety'): void {
 
 		if (this._flushTimer !== undefined) {
 			if (kind === 'safety' || this._flushTimerKind === 'fast') {
@@ -1263,7 +1270,7 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 			}
 			// Re-arm at the safety cadence so buffered events are retried once the
 			// breaker transitions to HALF_OPEN, even if no new spans arrive.
-			this._scheduleFlush(this._getSafetyIntervalMs());
+			this._scheduleFlush(this._getSafetyIntervalMs(), 'safety');
 			return;
 		}
 
@@ -1277,7 +1284,7 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 			this._circuitBreaker.cancelProbe();
 			// Re-arm at the safety cadence so buffered events are retried once the
 			// client's Retry-After window elapses, even if no new spans arrive.
-			this._scheduleFlush(this._getSafetyIntervalMs());
+			this._scheduleFlush(this._getSafetyIntervalMs(), 'safety');
 			return;
 		}
 
@@ -1468,11 +1475,11 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 		//  - otherwise, keep a safety timer running while any cloud session is active
 		//    so late spans are caught even without a terminal event
 		if (flushFailed && this._eventBuffer.length > 0) {
-			this._scheduleFlush(this._getSafetyIntervalMs());
+			this._scheduleFlush(this._getSafetyIntervalMs(), 'safety');
 		} else if (this._eventBuffer.length > 0) {
-			this._scheduleFlush(BATCH_INTERVAL_MS);
+			this._scheduleFlush(BATCH_INTERVAL_MS, 'fast');
 		} else if (this._cloudSessions.size > 0) {
-			this._scheduleFlush(this._getSafetyIntervalMs());
+			this._scheduleFlush(this._getSafetyIntervalMs(), 'safety');
 		}
 	}
 

--- a/extensions/copilot/src/extension/chronicle/vscode-node/test/remoteSessionExporter.spec.ts
+++ b/extensions/copilot/src/extension/chronicle/vscode-node/test/remoteSessionExporter.spec.ts
@@ -35,7 +35,7 @@ function makeStubExporter(opts: {
 		_eventBuffer: { chatSessionId: string; event: { type: string } }[];
 		_circuitBreaker: { canRequest: () => boolean; cancelProbe: () => void };
 		_cloudClient: { isRateLimited: () => boolean };
-		_scheduleFlush: (intervalMs: number) => void;
+		_scheduleFlush: (intervalMs: number, kind: 'fast' | 'safety') => void;
 	};
 
 	fields._isFlushing = false;
@@ -66,7 +66,7 @@ describe('RemoteSessionExporter._flushBatch early-return safety re-arm', () => {
 		await invokeFlushBatch(exporter);
 
 		expect(stubs.scheduleFlush).toHaveBeenCalledTimes(1);
-		expect(stubs.scheduleFlush).toHaveBeenCalledWith(SAFETY_INTERVAL_MS);
+		expect(stubs.scheduleFlush).toHaveBeenCalledWith(SAFETY_INTERVAL_MS, 'safety');
 	});
 
 	it('arms a safety-cadence flush when the client is rate-limited', async () => {
@@ -75,7 +75,7 @@ describe('RemoteSessionExporter._flushBatch early-return safety re-arm', () => {
 		await invokeFlushBatch(exporter);
 
 		expect(stubs.scheduleFlush).toHaveBeenCalledTimes(1);
-		expect(stubs.scheduleFlush).toHaveBeenCalledWith(SAFETY_INTERVAL_MS);
+		expect(stubs.scheduleFlush).toHaveBeenCalledWith(SAFETY_INTERVAL_MS, 'safety');
 		// Probe slot consumed by canRequest() must be released.
 		expect(stubs.cancelProbe).toHaveBeenCalledTimes(1);
 	});

--- a/extensions/copilot/src/platform/configuration/common/configurationService.ts
+++ b/extensions/copilot/src/platform/configuration/common/configurationService.ts
@@ -1066,6 +1066,12 @@ export namespace ConfigKey {
 
 	/** Enable local session search index — tracks sessions locally and enables chronicle commands.*/
 	export const LocalIndexEnabled = defineSetting<boolean>('chat.localIndex.enabled', ConfigType.ExperimentBased, false);
+
+	/** Max events per cloud session sync flush request — also acts as a buffer-size flush trigger. */
+	export const SessionSyncMaxEventsPerFlush = defineSetting<number>('chat.sessionSync.maxEventsPerFlush', ConfigType.ExperimentBased, 500);
+
+	/** Safety-net interval (ms) for buffered cloud session sync events that did not trigger a terminal flush. */
+	export const SessionSyncSafetyIntervalMs = defineSetting<number>('chat.sessionSync.safetyIntervalMs', ConfigType.ExperimentBased, 60_000);
 }
 
 export function getAllConfigKeys(): string[] {

--- a/extensions/copilot/src/platform/configuration/common/configurationService.ts
+++ b/extensions/copilot/src/platform/configuration/common/configurationService.ts
@@ -914,6 +914,12 @@ export namespace ConfigKey {
 		/** Enable WebSocket transport for Responses API requests. When enabled, uses a persistent WebSocket connection per conversation instead of individual HTTP requests. */
 		export const ResponsesApiWebSocketEnabled = defineTeamInternalSetting<boolean>('chat.advanced.responsesApi.webSocket.enabled', ConfigType.ExperimentBased, true);
 		export const DebugSimulateWebSocketResponse = defineTeamInternalSetting<string>('chat.advanced.debug.simulateWebSocketResponse', ConfigType.Simple, '');
+
+		/** Max events per cloud session sync flush request — also acts as a buffer-size flush trigger. */
+		export const SessionSyncMaxEventsPerFlush = defineTeamInternalSetting<number>('chat.advanced.sessionSync.maxEventsPerFlush', ConfigType.ExperimentBased, 500);
+
+		/** Safety-net interval (ms) for buffered cloud session sync events that did not trigger a terminal flush. */
+		export const SessionSyncSafetyIntervalMs = defineTeamInternalSetting<number>('chat.advanced.sessionSync.safetyIntervalMs', ConfigType.ExperimentBased, 60_000);
 	}
 
 	/**
@@ -1066,12 +1072,6 @@ export namespace ConfigKey {
 
 	/** Enable local session search index — tracks sessions locally and enables chronicle commands.*/
 	export const LocalIndexEnabled = defineSetting<boolean>('chat.localIndex.enabled', ConfigType.ExperimentBased, false);
-
-	/** Max events per cloud session sync flush request — also acts as a buffer-size flush trigger. */
-	export const SessionSyncMaxEventsPerFlush = defineSetting<number>('chat.sessionSync.maxEventsPerFlush', ConfigType.ExperimentBased, 500);
-
-	/** Safety-net interval (ms) for buffered cloud session sync events that did not trigger a terminal flush. */
-	export const SessionSyncSafetyIntervalMs = defineSetting<number>('chat.sessionSync.safetyIntervalMs', ConfigType.ExperimentBased, 60_000);
 }
 
 export function getAllConfigKeys(): string[] {


### PR DESCRIPTION
Make session sync flush params exp controllable. Allows us to optimize upload  latency and throughput without requiring code deployments.