### PR TITLE
Default Export Agent Host Debug Logs save dialog to home dir

### DIFF
--- a/src/vs/workbench/contrib/chat/electron-browser/actions/exportAgentHostDebugLogsService.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/actions/exportAgentHostDebugLogsService.ts
@@ -20,7 +20,7 @@ class NativeAgentHostDebugLogsExportService implements IAgentHostDebugLogsExport
 	) { }
 
 	async save(exportName: string, files: readonly { path: string; contents: string }[]): Promise<void> {
-		const defaultUri = joinPath(await this.fileDialogService.defaultFilePath(Schemas.file), `${exportName}.zip`);
+		const defaultUri = joinPath(await this.fileDialogService.preferredHome(Schemas.file), `${exportName}.zip`);
 		const saveUri = await this.fileDialogService.showSaveDialog({
 			title: localize('exportDebugLogs.saveDialogTitle', "Export Agent Host Debug Logs"),
 			defaultUri,


### PR DESCRIPTION
The save dialog for the Export Agent Host Debug Logs action was defaulting to the current workspace (via `defaultFilePath`), which prefers the last active file or workspace root. Use `preferredHome` instead so the dialog opens in the user's home directory.

(Written by Copilot)