### PR TITLE
Chat: OTel enrichment for Claude agent sessions

### DIFF
--- a/extensions/copilot/docs/monitoring/agent_monitoring.md
+++ b/extensions/copilot/docs/monitoring/agent_monitoring.md
@@ -645,6 +645,11 @@ copilot-chat invoke_agent claude               [~33s]
 | `gen_ai.usage.output_tokens` | `1100` |
 | `gen_ai.usage.cache_read.input_tokens` | `64062` |
 | `gen_ai.usage.cache_creation.input_tokens` | `39629` |
+| `github.copilot.agent.type` | `builtin` |
+| `github.copilot.git.repository` | `https://github.com/microsoft/vscode.git` |
+| `github.copilot.git.branch` | `main` |
+| `github.copilot.git.commit_sha` | `deadbeef...` |
+| `github.copilot.github.org` | `microsoft` |
 | `copilot_chat.turn_count` | `8` |
 | `copilot_chat.total_cost_usd` | `0.067` (session-wide, includes subagents) |
 | `copilot_chat.chat_session_id` | VS Code session ID |
@@ -652,6 +657,18 @@ copilot-chat invoke_agent claude               [~33s]
 **`chat`** — one span per LLM API call, created by `chatMLFetcher` via the Claude language model proxy server. Same attributes as foreground agent `chat` spans (token usage, TTFT, response model, cache breakdown).
 
 **`execute_tool`** — one span per tool invocation. When the tool is `Agent` (subagent), child `chat` and `execute_tool` spans are nested underneath, giving full subagent visibility.
+
+| Attribute | Requirement | Example |
+|---|---|---|
+| `gen_ai.operation.name` | Required | `execute_tool` |
+| `gen_ai.tool.name` | Required | `Edit` |
+| `github.copilot.tool.parameters.edit_type` | Edit tools (`Write`, `Edit`, `MultiEdit`, `NotebookEdit`) | `create` \| `str_replace` \| `update` |
+| `github.copilot.tool.parameters.mcp_server_name_hash` | MCP tools | SHA-256 hex of server name |
+| `github.copilot.tool.parameters.mcp_tool_name` | MCP tools | `search_issues` |
+| `github.copilot.tool.parameters.command` | Shell tools (`Bash`), opt-in (captureContent) | `npm test` (truncated to 256 chars) |
+| `github.copilot.tool.parameters.file_path` | File tools (`Read`, `Edit`, `MultiEdit`, `Write`, `NotebookEdit`), opt-in (captureContent) | `/src/app.ts` |
+| `github.copilot.tool.parameters.mcp_server_name` | MCP tools, opt-in (captureContent) | `github` |
+| `gen_ai.tool.call.arguments` | Opt-in (captureContent) | `{"file_path":"/src/app.ts",...}` |
 
 **`execute_hook`** — one span per Claude hook execution (e.g., `Stop` hooks).
 

--- a/extensions/copilot/docs/monitoring/agent_monitoring_arch.md
+++ b/extensions/copilot/docs/monitoring/agent_monitoring_arch.md
@@ -376,8 +376,8 @@ return this._otel.startActiveSpan('invoke_agent child', { parentTraceContext: pa
 | Namespace | Used By | Examples |
 |---|---|---|
 | `gen_ai.*` | All agents (standard) | `gen_ai.operation.name`, `gen_ai.usage.input_tokens` |
-| `copilot_chat.*` | Extension-specific | `copilot_chat.session_id`, `copilot_chat.chat_session_id` |
-| `github.copilot.*` | CLI SDK internal | `github.copilot.cost`, `github.copilot.aiu` |
+| `copilot_chat.*` | Extension-specific (legacy; several keys dual-emit alongside `github.copilot.*`) | `copilot_chat.session_id`, `copilot_chat.chat_session_id` |
+| `github.copilot.*` | Canonical Copilot namespace — extension-emitted enrichment (foreground agent, Claude agent, CLI bridge) + CLI SDK internal metrics | `github.copilot.agent.type`, `github.copilot.git.repository`, `github.copilot.tool.parameters.edit_type`, `github.copilot.hook.decision`, `github.copilot.cost`, `github.copilot.aiu` |
 | `claude_code.*` | Claude subprocess | `claude_code.token.usage`, `claude_code.cost.usage` |
 
 ---

--- a/extensions/copilot/src/extension/chatSessions/claude/common/claudeMessageDispatch.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/common/claudeMessageDispatch.ts
@@ -11,7 +11,8 @@ import type * as vscode from 'vscode';
 import type { ChatFetchError } from '../../../../platform/chat/common/commonTypes';
 import { vBoolean, vLiteral, vObj, vString, type ValidatorType } from '../../../../platform/configuration/common/validator';
 import { ILogService } from '../../../../platform/log/common/logService';
-import { CopilotChatAttr, GenAiAttr, GenAiOperationName, IOTelService, SpanKind, SpanStatusCode, truncateForOTel, type ISpanHandle, type TraceContext } from '../../../../platform/otel/common/index';
+import { CopilotChatAttr, GenAiAttr, GenAiOperationName, GitHubCopilotAttr, IOTelService, SpanKind, SpanStatusCode, truncateForOTel, type ISpanHandle, type TraceContext } from '../../../../platform/otel/common/index';
+import { extractToolParameters } from '../../../../platform/otel/node/extractToolParameters';
 import { CapturingToken } from '../../../../platform/requestLogger/common/capturingToken';
 import { IRequestLogger } from '../../../../platform/requestLogger/common/requestLogger';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry';
@@ -42,6 +43,7 @@ export interface MessageHandlerState {
 	readonly toolStartTimes: Map<string, number>;
 	readonly otelToolSpans: Map<string, ISpanHandle>;
 	readonly otelHookSpans: Map<string, ISpanHandle>;
+	readonly hookStartTimes: Map<string, number>;
 	readonly parentTraceContext?: TraceContext;
 	/** Trace contexts for subagent tool spans, keyed by tool_use_id. Used to parent
 	 *  child spans (chat, tool) from subagent messages under the Agent tool span. */
@@ -214,6 +216,20 @@ export function handleAssistantMessage(
 					logService.warn(`[ClaudeMessageDispatch] Failed to serialize tool arguments for ${item.name}: ${e}`);
 				}
 			}
+
+			// Structured `github.copilot.tool.parameters.*`. Hashes and edit_type emit
+			// unconditionally; raw paths, commands, and MCP names are gated.
+			try {
+				const { attrs: paramAttrs, gatedAttrs: gatedParamAttrs } = extractToolParameters(item.name, item.input);
+				for (const [k, v] of Object.entries(paramAttrs)) {
+					toolSpan.setAttribute(k, v);
+				}
+				if (otelService.config.captureContent) {
+					for (const [k, v] of Object.entries(gatedParamAttrs)) {
+						toolSpan.setAttribute(k, v);
+					}
+				}
+			} catch { /* swallow extraction errors */ }
 			otelToolSpans.set(item.id, toolSpan);
 
 			// For Agent/Task (subagent) tool calls, store the span's trace context so that
@@ -491,6 +507,7 @@ export function handleHookStarted(
 		parentTraceContext: state.parentTraceContext,
 	});
 	state.otelHookSpans.set(message.hook_id, span);
+	state.hookStartTimes.set(message.hook_id, Date.now());
 }
 
 // #region Hook JSON output validator
@@ -617,6 +634,17 @@ export function handleHookResponse(
 	// #region OTel span
 	const span = state.otelHookSpans.get(message.hook_id);
 	if (span) {
+		const startTime = state.hookStartTimes.get(message.hook_id);
+		if (startTime !== undefined) {
+			span.setAttribute(GitHubCopilotAttr.HOOK_DURATION_SECONDS, (Date.now() - startTime) / 1000);
+			state.hookStartTimes.delete(message.hook_id);
+		}
+		const hookDecision = message.outcome === 'success'
+			? 'pass'
+			: message.exit_code === 2
+				? 'block'
+				: 'non_blocking_error';
+		span.setAttribute(GitHubCopilotAttr.HOOK_DECISION, hookDecision);
 		if (message.outcome === 'error') {
 			span.setStatus(SpanStatusCode.ERROR, message.stderr || message.output);
 		} else if (message.outcome === 'cancelled') {

--- a/extensions/copilot/src/extension/chatSessions/claude/common/claudeMessageDispatch.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/common/claudeMessageDispatch.ts
@@ -12,7 +12,6 @@ import type { ChatFetchError } from '../../../../platform/chat/common/commonType
 import { vBoolean, vLiteral, vObj, vString, type ValidatorType } from '../../../../platform/configuration/common/validator';
 import { ILogService } from '../../../../platform/log/common/logService';
 import { CopilotChatAttr, GenAiAttr, GenAiOperationName, GitHubCopilotAttr, IOTelService, SpanKind, SpanStatusCode, truncateForOTel, type ISpanHandle, type TraceContext } from '../../../../platform/otel/common/index';
-import { extractToolParameters } from '../../../../platform/otel/node/extractToolParameters';
 import { CapturingToken } from '../../../../platform/requestLogger/common/capturingToken';
 import { IRequestLogger } from '../../../../platform/requestLogger/common/requestLogger';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry';
@@ -48,6 +47,11 @@ export interface MessageHandlerState {
 	/** Trace contexts for subagent tool spans, keyed by tool_use_id. Used to parent
 	 *  child spans (chat, tool) from subagent messages under the Agent tool span. */
 	readonly subagentTraceContexts: Map<string, TraceContext>;
+	/** Injected by the node-layer caller. Produces structured
+	 *  `github.copilot.tool.parameters.*` attributes (hashed/safe in `attrs`,
+	 *  content-sensitive in `gatedAttrs`). Common code cannot import from node
+	 *  directly, so the function is threaded through state. */
+	readonly extractToolParameters: (toolName: string, input: unknown) => { attrs: Record<string, string>; gatedAttrs: Record<string, string> };
 }
 
 export interface MessageHandlerResult {
@@ -210,7 +214,8 @@ export function handleAssistantMessage(
 			if (item.input !== undefined) {
 				try {
 					toolSpan.setAttribute(GenAiAttr.TOOL_CALL_ARGUMENTS, truncateForOTel(
-						typeof item.input === 'string' ? item.input : JSON.stringify(item.input)
+						typeof item.input === 'string' ? item.input : JSON.stringify(item.input),
+						otelService.config.maxAttributeSizeChars
 					));
 				} catch (e) {
 					logService.warn(`[ClaudeMessageDispatch] Failed to serialize tool arguments for ${item.name}: ${e}`);
@@ -220,7 +225,7 @@ export function handleAssistantMessage(
 			// Structured `github.copilot.tool.parameters.*`. Hashes and edit_type emit
 			// unconditionally; raw paths, commands, and MCP names are gated.
 			try {
-				const { attrs: paramAttrs, gatedAttrs: gatedParamAttrs } = extractToolParameters(item.name, item.input);
+				const { attrs: paramAttrs, gatedAttrs: gatedParamAttrs } = state.extractToolParameters(item.name, item.input);
 				for (const [k, v] of Object.entries(paramAttrs)) {
 					toolSpan.setAttribute(k, v);
 				}

--- a/extensions/copilot/src/extension/chatSessions/claude/common/test/claudeMessageDispatch.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/common/test/claudeMessageDispatch.spec.ts
@@ -113,7 +113,34 @@ function createState(): MessageHandlerState {
 		otelHookSpans: new Map(),
 		hookStartTimes: new Map(),
 		subagentTraceContexts: new Map(),
+		extractToolParameters: stubExtractToolParameters,
 	};
+}
+
+/**
+ * Test stub that mimics the real `extractToolParameters` for the small set of
+ * Claude tool inputs exercised in these tests. Keeps the test in the `common/`
+ * layer (the real implementation lives in `node/` and cannot be imported here).
+ */
+function stubExtractToolParameters(toolName: string, input: unknown): { attrs: Record<string, string>; gatedAttrs: Record<string, string> } {
+	const attrs: Record<string, string> = {};
+	const gatedAttrs: Record<string, string> = {};
+	if (typeof input !== 'object' || input === null) {
+		return { attrs, gatedAttrs };
+	}
+	const obj = input as Record<string, unknown>;
+	if (toolName === 'Edit' || toolName === 'MultiEdit') {
+		attrs['github.copilot.tool.parameters.edit_type'] = 'str_replace';
+	} else if (toolName === 'Write') {
+		attrs['github.copilot.tool.parameters.edit_type'] = 'create';
+	}
+	if (typeof obj.file_path === 'string') {
+		gatedAttrs['github.copilot.tool.parameters.file_path'] = obj.file_path;
+	}
+	if (typeof obj.command === 'string') {
+		gatedAttrs['github.copilot.tool.parameters.command'] = obj.command;
+	}
+	return { attrs, gatedAttrs };
 }
 
 function createMockSpan(): ISpanHandle {

--- a/extensions/copilot/src/extension/chatSessions/claude/common/test/claudeMessageDispatch.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/common/test/claudeMessageDispatch.spec.ts
@@ -111,6 +111,7 @@ function createState(): MessageHandlerState {
 		toolStartTimes: new Map(),
 		otelToolSpans: new Map(),
 		otelHookSpans: new Map(),
+		hookStartTimes: new Map(),
 		subagentTraceContexts: new Map(),
 	};
 }
@@ -435,6 +436,18 @@ describe('handleAssistantMessage', () => {
 			expect.objectContaining({ attributes: expect.any(Object) }),
 		);
 		expect(state.otelToolSpans.has('tool-456')).toBe(true);
+	});
+
+	it('emits github.copilot.tool.parameters.* via extractToolParameters', () => {
+		const mockSpan = createMockSpan();
+		vi.spyOn(services.otelService, 'startSpan').mockReturnValue(mockSpan);
+		handleAssistantMessage(
+			makeAssistantMessage([{
+				type: 'tool_use', id: 'tool-edit', name: 'Edit', input: { file_path: '/x.ts', old_string: 'a', new_string: 'b' },
+			}]),
+			accessor, TEST_SESSION_ID, request, state,
+		);
+		expect(mockSpan.setAttribute).toHaveBeenCalledWith('github.copilot.tool.parameters.edit_type', 'str_replace');
 	});
 
 	it('sets subAgentInvocationId when parent_tool_use_id is present', () => {
@@ -793,6 +806,33 @@ describe('handleHookResponse', () => {
 		expect(mockSpan.setStatus).toHaveBeenCalledWith(expect.anything()); // SpanStatusCode.OK
 		expect(mockSpan.end).toHaveBeenCalled();
 		expect(state.otelHookSpans.has('hook-1')).toBe(false);
+	});
+
+	it('sets github.copilot.hook.decision and hook.duration on hook completion', () => {
+		const mockSpan = createMockSpan();
+		state.otelHookSpans.set('hook-1', mockSpan);
+		state.hookStartTimes.set('hook-1', Date.now() - 100);
+
+		handleHookResponse(makeHookResponse('hook-1', 'success'), accessor, request, state);
+
+		expect(mockSpan.setAttribute).toHaveBeenCalledWith('github.copilot.hook.decision', 'pass');
+		expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+			'github.copilot.hook.duration',
+			expect.any(Number),
+		);
+		expect(state.hookStartTimes.has('hook-1')).toBe(false);
+	});
+
+	it('maps exit_code 2 to hook.decision=block', () => {
+		const mockSpan = createMockSpan();
+		state.otelHookSpans.set('hook-1', mockSpan);
+
+		handleHookResponse(
+			makeHookResponse('hook-1', 'error', { exit_code: 2, stderr: 'blocked', hook_event: 'PreToolUse' }),
+			accessor, request, state,
+		);
+
+		expect(mockSpan.setAttribute).toHaveBeenCalledWith('github.copilot.hook.decision', 'block');
 	});
 
 	it('ends the OTel span with ERROR on failure and surfaces error via hookProgress', () => {

--- a/extensions/copilot/src/extension/chatSessions/claude/node/claudeCodeAgent.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/node/claudeCodeAgent.ts
@@ -15,6 +15,7 @@ import { IAuthenticationService } from '../../../../platform/authentication/comm
 import { IMcpService } from '../../../../platform/mcp/common/mcpService';
 import { IOTelService, type ISpanHandle, SpanStatusCode, type TraceContext } from '../../../../platform/otel/common/index';
 import { deriveClaudeOTelEnv } from '../../../../platform/otel/common/agentOTelEnv';
+import { extractToolParameters } from '../../../../platform/otel/node/extractToolParameters';
 import { CapturingToken } from '../../../../platform/requestLogger/common/capturingToken';
 import { IWorkspaceService } from '../../../../platform/workspace/common/workspaceService';
 import { DeferredPromise } from '../../../../util/vs/base/common/async';
@@ -668,6 +669,7 @@ export class ClaudeCodeSession extends Disposable {
 						hookStartTimes,
 						parentTraceContext: this._otelTracker.traceContext,
 						subagentTraceContexts,
+						extractToolParameters,
 					});
 				} catch (dispatchError) {
 					if (dispatchError instanceof ClaudeProxyError || dispatchError instanceof KnownClaudeError) {

--- a/extensions/copilot/src/extension/chatSessions/claude/node/claudeCodeAgent.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/node/claudeCodeAgent.ts
@@ -9,6 +9,7 @@ import * as l10n from '@vscode/l10n';
 import type * as vscode from 'vscode';
 import { IChatDebugFileLoggerService } from '../../../../platform/chat/common/chatDebugFileLoggerService';
 import { INativeEnvService } from '../../../../platform/env/common/envService';
+import { IGitService } from '../../../../platform/git/common/gitService';
 import { ILogService } from '../../../../platform/log/common/logService';
 import { IAuthenticationService } from '../../../../platform/authentication/common/authentication';
 import { IMcpService } from '../../../../platform/mcp/common/mcpService';
@@ -238,10 +239,11 @@ export class ClaudeCodeSession extends Disposable {
 		@IClaudePluginService private readonly claudePluginService: IClaudePluginService,
 		@IOTelService private readonly _otelService: IOTelService,
 		@IChatDebugFileLoggerService private readonly _debugFileLogger: IChatDebugFileLoggerService,
+		@IGitService private readonly _gitService: IGitService,
 	) {
 		super();
 		this._isResumed = !isNewSession;
-		this._otelTracker = new ClaudeOTelTracker(this.sessionId, this._otelService, this.sessionStateService);
+		this._otelTracker = new ClaudeOTelTracker(this.sessionId, this._otelService, this.sessionStateService, this._gitService);
 		this._debugFileLogger.startSession(this.sessionId).catch(err => {
 			this.logService.error('[ClaudeCodeSession] Failed to start debug log session', err);
 		});
@@ -621,6 +623,7 @@ export class ClaudeCodeSession extends Disposable {
 	private async _processMessages(): Promise<void> {
 		const otelToolSpans = new Map<string, ISpanHandle>();
 		const otelHookSpans = new Map<string, ISpanHandle>();
+		const hookStartTimes = new Map<string, number>();
 		const subagentTraceContexts = new Map<string, TraceContext>();
 		try {
 			const unprocessedToolCalls = new Map<string, Anthropic.Beta.Messages.BetaToolUseBlock>();
@@ -662,6 +665,7 @@ export class ClaudeCodeSession extends Disposable {
 						toolStartTimes,
 						otelToolSpans,
 						otelHookSpans,
+						hookStartTimes,
 						parentTraceContext: this._otelTracker.traceContext,
 						subagentTraceContexts,
 					});

--- a/extensions/copilot/src/extension/chatSessions/claude/node/claudeOTelTracker.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/node/claudeOTelTracker.ts
@@ -4,7 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
-import { CopilotChatAttr, emitSessionStartEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, GenAiProviderName, IOTelService, type ISpanHandle, SpanKind, SpanStatusCode, type TraceContext, truncateForOTel } from '../../../../platform/otel/common/index';
+import { IGitService } from '../../../../platform/git/common/gitService';
+import { CopilotChatAttr, emitSessionStartEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, GenAiProviderName, GitHubCopilotAttr, IOTelService, type ISpanHandle, resolveWorkspaceOTelMetadata, SpanKind, SpanStatusCode, type TraceContext, truncateForOTel, workspaceMetadataToOTelAttributes } from '../../../../platform/otel/common/index';
 import { IClaudeSessionStateService } from '../common/claudeSessionStateService';
 
 /**
@@ -29,6 +30,7 @@ export class ClaudeOTelTracker {
 		private readonly _sessionId: string,
 		private readonly _otelService: IOTelService,
 		private readonly _sessionStateService: IClaudeSessionStateService,
+		private readonly _gitService: IGitService,
 	) { }
 
 	/** The trace context of the current invoke_agent span, used to parent child spans. */
@@ -53,6 +55,8 @@ export class ClaudeOTelTracker {
 				[CopilotChatAttr.SESSION_ID]: this._sessionId,
 				[CopilotChatAttr.CHAT_SESSION_ID]: this._sessionId,
 				[GenAiAttr.REQUEST_MODEL]: modelId,
+				[GitHubCopilotAttr.AGENT_TYPE]: 'builtin',
+				...workspaceMetadataToOTelAttributes(resolveWorkspaceOTelMetadata(this._gitService)),
 			},
 		});
 		this._currentTraceContext = this._currentSpan.getSpanContext();

--- a/extensions/copilot/src/platform/otel/common/genAiAttributes.ts
+++ b/extensions/copilot/src/platform/otel/common/genAiAttributes.ts
@@ -252,6 +252,8 @@ export const SHELL_TOOL_NAMES: ReadonlySet<string> = new Set([
 	'local_shell',
 	'runInTerminal',
 	'run_in_terminal',
+	// Claude
+	'Bash',
 ]);
 
 /**
@@ -279,4 +281,10 @@ export const FILE_TOOL_NAMES: ReadonlySet<string> = new Set([
 	'replace_string_in_file',
 	'multi_replace_string_in_file',
 	'edit_notebook_file',
+	// Claude (capitalized)
+	'Read',
+	'Edit',
+	'MultiEdit',
+	'Write',
+	'NotebookEdit',
 ]);

--- a/extensions/copilot/src/platform/otel/node/extractToolParameters.ts
+++ b/extensions/copilot/src/platform/otel/node/extractToolParameters.ts
@@ -102,7 +102,7 @@ function pickFirstString(obj: Record<string, unknown>, keys: readonly string[]):
 }
 
 function classifyEditType(toolName: string, obj: Record<string, unknown>): EditOperationType | undefined {
-	if (toolName === 'create' || toolName === 'createFile' || toolName === 'create_file') {
+	if (toolName === 'create' || toolName === 'createFile' || toolName === 'create_file' || toolName === 'Write') {
 		return 'create';
 	}
 	if (toolName === 'insert') {
@@ -113,7 +113,9 @@ function classifyEditType(toolName: string, obj: Record<string, unknown>): EditO
 		toolName === 'str_replace_editor' ||
 		toolName === 'replaceString' ||
 		toolName === 'replace_string_in_file' ||
-		toolName === 'multi_replace_string_in_file'
+		toolName === 'multi_replace_string_in_file' ||
+		toolName === 'Edit' ||
+		toolName === 'MultiEdit'
 	) {
 		return 'str_replace';
 	}
@@ -122,12 +124,13 @@ function classifyEditType(toolName: string, obj: Record<string, unknown>): EditO
 		toolName === 'applyPatch' ||
 		toolName === 'apply_patch' ||
 		toolName === 'insert_edit_into_file' ||
-		toolName === 'edit_notebook_file'
+		toolName === 'edit_notebook_file' ||
+		toolName === 'NotebookEdit'
 	) {
 		return 'update';
 	}
-	// `view`/`readFile`/`read_file` have no edit_type.
-	if (toolName === 'view' || toolName === 'readFile' || toolName === 'read_file') {
+	// `view`/`readFile`/`read_file`/`Read` have no edit_type.
+	if (toolName === 'view' || toolName === 'readFile' || toolName === 'read_file' || toolName === 'Read') {
 		return undefined;
 	}
 	// Fallback: heuristic on common arg names.

--- a/extensions/copilot/src/platform/otel/node/test/extractToolParameters.spec.ts
+++ b/extensions/copilot/src/platform/otel/node/test/extractToolParameters.spec.ts
@@ -59,4 +59,14 @@ describe('extractToolParameters', () => {
 		expect(extractToolParameters('edit_notebook_file', { filePath: '/a.ipynb' }).attrs[GitHubCopilotAttr.TOOL_PARAM_EDIT_TYPE]).toBe('update');
 		expect(extractToolParameters('read_file', { filePath: '/a.ts' }).attrs[GitHubCopilotAttr.TOOL_PARAM_EDIT_TYPE]).toBeUndefined();
 	});
+
+	it('classifies Claude (capitalized) tool names', () => {
+		expect(extractToolParameters('Write', { file_path: '/a.ts' }).attrs[GitHubCopilotAttr.TOOL_PARAM_EDIT_TYPE]).toBe('create');
+		expect(extractToolParameters('Edit', { file_path: '/a.ts' }).attrs[GitHubCopilotAttr.TOOL_PARAM_EDIT_TYPE]).toBe('str_replace');
+		expect(extractToolParameters('MultiEdit', { file_path: '/a.ts' }).attrs[GitHubCopilotAttr.TOOL_PARAM_EDIT_TYPE]).toBe('str_replace');
+		expect(extractToolParameters('NotebookEdit', { file_path: '/a.ipynb' }).attrs[GitHubCopilotAttr.TOOL_PARAM_EDIT_TYPE]).toBe('update');
+		expect(extractToolParameters('Read', { file_path: '/a.ts' }).attrs[GitHubCopilotAttr.TOOL_PARAM_EDIT_TYPE]).toBeUndefined();
+		const bash = extractToolParameters('Bash', { command: 'ls' });
+		expect(bash.gatedAttrs[GitHubCopilotAttr.TOOL_PARAM_COMMAND]).toBe('ls');
+	});
 });


### PR DESCRIPTION
### Overview

Follow-up to #318031, which introduced the canonical `github.copilot.*` OTel attribute namespace on the foreground Copilot Chat agent. This PR extends the same enrichment to **Claude Code agent sessions** so traces carry parity attributes across agent surfaces.

### What

- **`invoke_agent claude`** (`claudeOTelTracker`) — now emits:
  - `github.copilot.agent.type: 'builtin'`
  - `github.copilot.git.{repository,branch,commit_sha}` and `github.copilot.github.org` (via `workspaceMetadataToOTelAttributes(resolveWorkspaceOTelMetadata(gitService))`, mirroring `toolCallingLoop`).
- **`execute_tool`** for Claude tool calls (`claudeMessageDispatch.handleAssistantMessage`) — now uses an injected tool-parameter extractor (node-layer provided) to emit:
  - Ungated: `github.copilot.tool.parameters.edit_type`, `skill_name`, `mcp_server_name_hash`, `mcp_tool_name`.
  - Content-gated (`captureContent`): `command`, `file_path`, `mcp_server_name`.
- **`execute_hook`** (`claudeMessageDispatch.handleHookResponse`) — now emits:
  - `github.copilot.hook.decision` — `pass` (outcome `success`) / `block` (exit code 2) / `non_blocking_error` (other failure).
  - `github.copilot.hook.duration` — seconds, measured between `hookStarted` and `hookResponse` via a new `hookStartTimes` map on `MessageHandlerState`.
- **`extractToolParameters` / `genAiAttributes`** — added Claude tool-name aliases so the classifier recognises `Bash`, `Read`, `Edit`, `MultiEdit`, `Write`, `NotebookEdit`.
- **Truncation fix** — `gen_ai.tool.call.arguments` now truncates with `otelService.config.maxAttributeSizeChars` to avoid oversized OTel attributes being dropped.

> **Note**: `github.copilot.hook.tool_names` is intentionally **not** emitted for Claude — the Claude SDK's `SDKHookStartedMessage` does not surface a `tool_name` to the extension. The user-facing doc already qualifies this attribute as "When tool-scoped".

### Why

After #318031, dashboards built on the canonical `github.copilot.*` namespace were missing rows for the Claude agent path — its `invoke_agent` / `execute_tool` / `execute_hook` spans were only partially queryable. This brings Claude to parity with the built-in agent's enrichment while preserving extension layering constraints.

### Backwards compatibility

All existing attributes (`gen_ai.*`, `copilot_chat.*`) remain unchanged. Only additive attribute writes; no behavioural change to dispatch or hook handling.

### Docs

Updated `extensions/copilot/docs/monitoring/`:
- `agent_monitoring.md` — Claude `invoke_agent claude` attribute table now lists the new `github.copilot.{agent.type,git.*,github.org}` keys; added a proper attribute table for Claude `execute_tool` listing `tool.parameters.*`.
- `agent_monitoring_arch.md` — corrected the `github.copilot.*` namespace description to reflect that it's the canonical Copilot namespace (extension-emitted enrichment + CLI SDK internal metrics), not just SDK-internal.

### Tests

- `extractToolParameters.spec.ts` — adds Claude-name classification (Bash, Read, Edit, MultiEdit, Write, NotebookEdit).
- `claudeMessageDispatch.spec.ts` — adds `hook.decision` / `hook.duration` cases and `tool.parameters.*` emission.
- `claudeCodeAgentOTel.spec.ts` — exercised via existing end-to-end coverage.
- All 89 tests pass across the three affected spec files; typecheck clean.