### PR TITLE
[cherry-pick] [WindowsSandboxing]: Updated env and commandline for executing commands using pwsh.exe (#318466)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@microsoft/dev-tunnels-management": "^1.3.41",
         "@microsoft/dev-tunnels-ssh": "^3.12.22",
         "@microsoft/dev-tunnels-ssh-tcp": "^3.12.22",
-        "@microsoft/mxc-sdk": "0.2.0",
+        "@microsoft/mxc-sdk": "0.2.1",
         "@parcel/watcher": "^2.5.6",
         "@types/semver": "^7.5.8",
         "@vscode/codicons": "^0.0.46-12",
@@ -1975,9 +1975,9 @@
       "integrity": "sha512-n1VPsljTSkthsAFYdiWfC+DKzK2WwcRp83Y1YAqdX552BstvsDjft9YXppjUzp11BPsapDoO1LDgrDB0XVsfNQ=="
     },
     "node_modules/@microsoft/mxc-sdk": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/mxc-sdk/-/mxc-sdk-0.2.0.tgz",
-      "integrity": "sha512-xgWTV0nvIzl+IjlIhLGw++/A1eeZYORDoMLGLlDpSE8tMPWLbQIF627Xsb0pkb04MB9vtZl9P+RRNB7fwS3PXA==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/mxc-sdk/-/mxc-sdk-0.2.1.tgz",
+      "integrity": "sha512-1dL42Abc1ocapZR01aPeSEcvuzWuvOslmWNZvdYs6+yTVqAnpWrMk+aFf0Odry9SqJbcW9FABYzPlFtJW6clAQ==",
       "license": "MIT",
       "dependencies": {
         "node-pty": "^1.2.0-beta.12",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@microsoft/dev-tunnels-management": "^1.3.41",
     "@microsoft/dev-tunnels-ssh": "^3.12.22",
     "@microsoft/dev-tunnels-ssh-tcp": "^3.12.22",
-    "@microsoft/mxc-sdk": "0.2.0",
+    "@microsoft/mxc-sdk": "0.2.1",
     "@parcel/watcher": "^2.5.6",
     "@types/semver": "^7.5.8",
     "@vscode/codicons": "^0.0.46-12",

--- a/remote/package-lock.json
+++ b/remote/package-lock.json
@@ -12,7 +12,7 @@
         "@github/copilot-sdk": "1.0.0-beta.4",
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
-        "@microsoft/mxc-sdk": "0.2.0",
+        "@microsoft/mxc-sdk": "0.2.1",
         "@parcel/watcher": "^2.5.6",
         "@vscode/copilot-api": "^0.4.0",
         "@vscode/deviceid": "^0.1.1",
@@ -281,9 +281,9 @@
       "integrity": "sha512-n1VPsljTSkthsAFYdiWfC+DKzK2WwcRp83Y1YAqdX552BstvsDjft9YXppjUzp11BPsapDoO1LDgrDB0XVsfNQ=="
     },
     "node_modules/@microsoft/mxc-sdk": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/mxc-sdk/-/mxc-sdk-0.2.0.tgz",
-      "integrity": "sha512-xgWTV0nvIzl+IjlIhLGw++/A1eeZYORDoMLGLlDpSE8tMPWLbQIF627Xsb0pkb04MB9vtZl9P+RRNB7fwS3PXA==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/mxc-sdk/-/mxc-sdk-0.2.1.tgz",
+      "integrity": "sha512-1dL42Abc1ocapZR01aPeSEcvuzWuvOslmWNZvdYs6+yTVqAnpWrMk+aFf0Odry9SqJbcW9FABYzPlFtJW6clAQ==",
       "license": "MIT",
       "dependencies": {
         "node-pty": "^1.2.0-beta.12",

--- a/remote/package.json
+++ b/remote/package.json
@@ -7,7 +7,7 @@
     "@github/copilot-sdk": "1.0.0-beta.4",
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",
-    "@microsoft/mxc-sdk": "0.2.0",
+    "@microsoft/mxc-sdk": "0.2.1",
     "@parcel/watcher": "^2.5.6",
     "@vscode/copilot-api": "^0.4.0",
     "@vscode/deviceid": "^0.1.1",

--- a/src/vs/platform/sandbox/common/terminalSandboxEngine.ts
+++ b/src/vs/platform/sandbox/common/terminalSandboxEngine.ts
@@ -584,7 +584,8 @@ export class TerminalSandboxEngine extends Disposable {
 		}
 		const sandboxSettings = this._os === OperatingSystem.Windows ? this._windowsMxcRuntime.createConfig({
 			command: this._commandLine ?? '',
-			cwd: this._commandCwd,
+			shell: this._commandShell,
+			cwd: this._commandCwd ?? this._getDefaultWindowsMxcCwd(),
 			tempDir: this._tempDir,
 			allowNetwork,
 			networkDomains: this.getResolvedNetworkDomains(),
@@ -714,16 +715,14 @@ export class TerminalSandboxEngine extends Disposable {
 
 	private async _resolveFileSystemPath(path: string): Promise<string> {
 		const expandedPath = this._os === OperatingSystem.Linux ? this._expandHomePath(path) : path;
-		if (this._os === OperatingSystem.Windows) {
-			return expandedPath;
-		}
 		if (!this._isAbsoluteFileSystemPath(expandedPath)) {
 			return expandedPath;
 		}
 
 		try {
 			const realpath = await this._fileService.realpath(this._toFileSystemResource(expandedPath));
-			return realpath?.path && realpath.path !== expandedPath ? realpath.path : expandedPath;
+			const resolvedPath = realpath ? this._getUriPath(realpath) : undefined;
+			return resolvedPath && resolvedPath !== expandedPath ? resolvedPath : expandedPath;
 		} catch {
 			return expandedPath;
 		}
@@ -734,7 +733,32 @@ export class TerminalSandboxEngine extends Disposable {
 	}
 
 	private _toFileSystemResource(path: string): URI {
+		if (this._os === OperatingSystem.Windows) {
+			return this._toWindowsFileSystemResource(path);
+		}
 		return this._userHome?.with({ path }) ?? this._tempDir?.with({ path }) ?? this._host.getWriteRoots()[0]?.with({ path }) ?? URI.file(path);
+	}
+
+	private _toWindowsFileSystemResource(path: string): URI {
+		// Normalize Windows separators for URI parsing, e.g. `C:\Users\me` becomes `C:/Users/me`.
+		const normalizedPath = path.replace(/\\/g, '/');
+		// Match UNC paths, e.g. `//server/share/folder` becomes `file://server/share/folder`.
+		if (/^\/\/[^/]/.test(normalizedPath)) {
+			const firstPathSeparator = normalizedPath.indexOf('/', 2);
+			if (firstPathSeparator === -1) {
+				return URI.from({ scheme: 'file', authority: normalizedPath.slice(2), path: '/' });
+			}
+			return URI.from({ scheme: 'file', authority: normalizedPath.slice(2, firstPathSeparator), path: normalizedPath.slice(firstPathSeparator) || '/' });
+		}
+		// Match drive-letter paths, e.g. `C:/Users/me` becomes `file:///c:/Users/me`.
+		if (/^[a-zA-Z]:($|\/)/.test(normalizedPath)) {
+			return URI.from({ scheme: 'file', path: `/${normalizedPath[0].toLowerCase()}${normalizedPath.slice(1)}` });
+		}
+		// Match URI-shaped drive paths, e.g. `/C:/Users/me` becomes `file:///c:/Users/me`.
+		if (/^\/[a-zA-Z]:($|\/)/.test(normalizedPath)) {
+			return URI.from({ scheme: 'file', path: `/${normalizedPath[1].toLowerCase()}${normalizedPath.slice(2)}` });
+		}
+		return URI.from({ scheme: 'file', path: normalizedPath });
 	}
 
 	private _expandHomePath(path: string): string {
@@ -779,6 +803,10 @@ export class TerminalSandboxEngine extends Disposable {
 	private async _getWorkspaceStorageReadPaths(): Promise<string[]> {
 		const root = await this._host.getWorkspaceStorageReadRoot();
 		return root ? [this._getUriPath(root)] : [];
+	}
+
+	private _getDefaultWindowsMxcCwd(): URI | undefined {
+		return this._host.getWriteRoots()[0];
 	}
 
 	private _getSandboxConfiguredEnabledValue(): AgentSandboxEnabledValue {

--- a/src/vs/platform/sandbox/common/terminalSandboxMxcRuntime.ts
+++ b/src/vs/platform/sandbox/common/terminalSandboxMxcRuntime.ts
@@ -30,7 +30,7 @@ export interface IWindowsMxcNetworkConfig {
 export interface IWindowsMxcConfig {
 	version: string;
 	containerId: string;
-	containment: 'process';
+	containment: 'processcontainer';
 	lifecycle: {
 		destroyOnExit: boolean;
 		preservePolicy: boolean;
@@ -42,11 +42,13 @@ export interface IWindowsMxcConfig {
 		disable: boolean;
 		clipboard: 'none';
 		injection: boolean;
+		allowWindows: boolean;
 	};
 }
 
 export interface IWindowsMxcConfigOptions {
 	command: string;
+	shell?: string;
 	cwd: URI | undefined;
 	tempDir: URI;
 	allowNetwork: boolean;
@@ -99,16 +101,19 @@ export class WindowsMxcTerminalSandboxRuntime implements IWindowsMxcTerminalSand
 
 	createConfig(options: IWindowsMxcConfigOptions): IWindowsMxcConfig {
 		const tempDirPath = this.toWindowsPath(options.tempDir);
+		const shell = options.shell
+			? this._quoteWindowsCommandLineArgument(options.shell)
+			: 'pwsh.exe';
 		return {
 			version: this._configVersion,
 			containerId: 'vscode-terminal-sandbox',
-			containment: 'process',
+			containment: 'processcontainer',
 			lifecycle: {
 				destroyOnExit: true,
 				preservePolicy: false,
 			},
 			process: {
-				commandLine: options.command,
+				commandLine: `${shell} -NoProfile -ExecutionPolicy Bypass -Command ${this._quoteWindowsCommandLineArgument(options.command)}`,
 				cwd: options.cwd ? this.toWindowsPath(options.cwd) : tempDirPath,
 				env: [
 					...options.env
@@ -117,7 +122,7 @@ export class WindowsMxcTerminalSandboxRuntime implements IWindowsMxcTerminalSand
 			},
 			filesystem: {
 				readwritePaths: [...new Set([...options.allowWritePaths])],
-				readonlyPaths: [...new Set([tempDirPath, ...options.allowReadPaths])],
+				readonlyPaths: [...new Set([tempDirPath, ...(options.shell && win32.isAbsolute(options.shell) ? [win32.dirname(options.shell)] : []), ...options.allowReadPaths])],
 				deniedPaths: options.denyReadPaths,
 			},
 			network: this._createNetworkConfig(options.allowNetwork, options.networkDomains),
@@ -125,6 +130,7 @@ export class WindowsMxcTerminalSandboxRuntime implements IWindowsMxcTerminalSand
 				disable: false,
 				clipboard: 'none',
 				injection: false,
+				allowWindows: true
 			},
 		};
 	}
@@ -162,5 +168,9 @@ export class WindowsMxcTerminalSandboxRuntime implements IWindowsMxcTerminalSand
 
 	private _quotePowerShellArgument(value: string): string {
 		return `'${value.replace(/'/g, `''`)}'`;
+	}
+
+	private _quoteWindowsCommandLineArgument(value: string): string {
+		return `"${value.replace(/(\\*)"/g, '$1$1\\"').replace(/\\+$/g, '$&$&')}"`;
 	}
 }

--- a/src/vs/platform/sandbox/node/sandboxHelper.ts
+++ b/src/vs/platform/sandbox/node/sandboxHelper.ts
@@ -55,9 +55,23 @@ export class SandboxHelperService implements ISandboxHelperService {
 		}
 
 		const env: string[] = [];
-		const path = getCaseInsensitive(process.env, 'PATH');
-		if (typeof path === 'string' && path) {
-			env.push(`PATH=${path}`);
+		for (const variable of ['SystemRoot', 'PATH', 'ComSpec', 'PATHEXT', 'PSModulePath']) {
+			const value = getCaseInsensitive(process.env, variable);
+			if (typeof value === 'string' && value) {
+				env.push(`${variable}=${value}`);
+			}
+		}
+		const userProfile = getCaseInsensitive(process.env, 'USERPROFILE');
+		if (typeof userProfile === 'string' && userProfile) {
+			env.push(`USERPROFILE=${userProfile}`);
+		}
+		const appData = getCaseInsensitive(process.env, 'APPDATA');
+		if (typeof appData === 'string' && appData) {
+			env.push(`APPDATA=${appData}`);
+		}
+		const localAppData = this._getLocalAppData();
+		if (typeof localAppData === 'string' && localAppData) {
+			env.push(`LOCALAPPDATA=${localAppData}`);
 		}
 
 		const psHome = await this._getPSHome();
@@ -75,6 +89,11 @@ export class SandboxHelperService implements ISandboxHelperService {
 
 		const powerShellPath = await findExecutable('pwsh') ?? await findExecutable('powershell');
 		return powerShellPath ? win32.dirname(powerShellPath) : undefined;
+	}
+
+	private _getLocalAppData(): string | undefined {
+		const localAppData = getCaseInsensitive(process.env, 'LOCALAPPDATA');
+		return typeof localAppData === 'string' && localAppData ? localAppData : undefined;
 	}
 
 	private _getTempReadPaths(): string[] {

--- a/src/vs/platform/sandbox/test/common/terminalSandboxEngine.test.ts
+++ b/src/vs/platform/sandbox/test/common/terminalSandboxEngine.test.ts
@@ -97,7 +97,17 @@ suite('TerminalSandboxEngine', () => {
 			getWorkspaceStorageReadRoot: () => Promise.resolve(URI.from({ scheme: 'file', path: '/c:/Users/user/workspaceStorage/workspace-id' })),
 			getWriteRoots: () => [URI.from({ scheme: 'file', path: '/c:/workspace' })],
 			getWindowsMxcFilesystemPolicy: () => Promise.resolve({ readonlyPaths: ['C:\\tools\\node', 'C:\\tools\\python', 'C:\\Users\\user\\AppData\\Local\\Programs\\Git', 'C:\\Users\\user\\AppData\\Local\\Temp'], readwritePaths: [] }),
-			getWindowsMxcEnvironment: () => Promise.resolve(['PATH=C:\\tools\\node;C:\\Windows\\System32', 'PSHOME=C:\\Program Files\\PowerShell\\7']),
+			getWindowsMxcEnvironment: () => Promise.resolve([
+				'SystemRoot=C:\\Windows',
+				'PATH=C:\\tools\\node;C:\\Windows\\System32',
+				'ComSpec=C:\\Windows\\System32\\cmd.exe',
+				'PATHEXT=.COM;.EXE;.BAT;.CMD;.PS1',
+				'PSModulePath=C:\\Users\\user\\Documents\\PowerShell\\Modules;C:\\Program Files\\PowerShell\\Modules',
+				'USERPROFILE=C:\\Users\\user',
+				'APPDATA=C:\\Users\\user\\AppData\\Roaming',
+				'LOCALAPPDATA=C:\\Users\\user\\AppData\\Local',
+				'PSHOME=C:\\Program Files\\PowerShell\\7'
+			]),
 			...overrides,
 		});
 	}
@@ -291,7 +301,7 @@ suite('TerminalSandboxEngine', () => {
 		const host = createWindowsHost();
 		const engine = store.add(instantiationService.createInstance(TerminalSandboxEngine, host));
 
-		const wrapped = await engine.wrapCommand('echo hello', false, 'pwsh', URI.from({ scheme: 'file', path: '/c:/workspace' }));
+		const wrapped = await engine.wrapCommand('echo hello', false, 'C:\\Program Files\\PowerShell\\7\\pwsh.exe', URI.from({ scheme: 'file', path: '/c:/workspace' }));
 		const configPath = await engine.getSandboxConfigPath();
 		ok(configPath, 'Config path should be defined');
 		const config = JSON.parse(createdFiles.get(configPath)!);
@@ -300,11 +310,18 @@ suite('TerminalSandboxEngine', () => {
 		ok(wrapped.command.startsWith(`& 'C:\\app\\node_modules\\@microsoft\\mxc-sdk\\bin\\x64\\wxc-exec.exe'`), `Expected MXC executable. Actual: ${wrapped.command}`);
 		ok(wrapped.command.includes(` '${configPath}'`), `Expected wrapped command to pass the MXC config path. Actual: ${wrapped.command}`);
 		strictEqual(config.version, '0.4.0-alpha');
-		strictEqual(config.containment, 'process');
-		strictEqual(config.process.commandLine, 'echo hello');
+		strictEqual(config.containment, 'processcontainer');
+		strictEqual(config.process.commandLine, '"C:\\Program Files\\PowerShell\\7\\pwsh.exe" -NoProfile -ExecutionPolicy Bypass -Command "echo hello"');
 		strictEqual(normalizeWindowsPathForAssert(config.process.cwd), 'c:/workspace');
 		strictEqual(config.ui.disable, false);
+		ok(config.process.env.includes('SystemRoot=C:\\Windows'), 'SystemRoot should be injected into the MXC process env');
 		ok(config.process.env.includes('PATH=C:\\tools\\node;C:\\Windows\\System32'), 'PATH should be injected into the MXC process env');
+		ok(config.process.env.includes('ComSpec=C:\\Windows\\System32\\cmd.exe'), 'ComSpec should be injected into the MXC process env');
+		ok(config.process.env.includes('PATHEXT=.COM;.EXE;.BAT;.CMD;.PS1'), 'PATHEXT should be injected into the MXC process env');
+		ok(config.process.env.includes('PSModulePath=C:\\Users\\user\\Documents\\PowerShell\\Modules;C:\\Program Files\\PowerShell\\Modules'), 'PSModulePath should be injected into the MXC process env');
+		ok(config.process.env.includes('USERPROFILE=C:\\Users\\user'), 'USERPROFILE should be injected into the MXC process env');
+		ok(config.process.env.includes('APPDATA=C:\\Users\\user\\AppData\\Roaming'), 'APPDATA should be injected into the MXC process env');
+		ok(config.process.env.includes('LOCALAPPDATA=C:\\Users\\user\\AppData\\Local'), 'LOCALAPPDATA should be injected into the MXC process env');
 		ok(config.process.env.includes('PSHOME=C:\\Program Files\\PowerShell\\7'), 'PSHOME should be injected into the MXC process env');
 		deepStrictEqual(config.network, { defaultPolicy: 'allow' });
 		ok(config.filesystem.readwritePaths.some((path: string) => normalizeWindowsPathForAssert(path) === 'c:/workspace'), 'Workspace should be writable');
@@ -312,6 +329,7 @@ suite('TerminalSandboxEngine', () => {
 		ok(config.filesystem.readonlyPaths.some((path: string) => normalizeWindowsPathForAssert(path).endsWith('/.test-data/tmp')), 'Sandbox temp dir should be readable through readonly paths');
 		ok(config.filesystem.readonlyPaths.some((path: string) => normalizeWindowsPathForAssert(path) === 'c:/app'), 'App root should be readable for MXC');
 		ok(config.filesystem.readonlyPaths.some((path: string) => normalizeWindowsPathForAssert(path) === 'c:/tools/node'), 'MXC available tools policy should add tool paths to readonly paths');
+		ok(config.filesystem.readonlyPaths.some((path: string) => normalizeWindowsPathForAssert(path) === 'c:/program files/powershell/7'), 'Resolved PowerShell executable directory should be readable');
 		ok(config.filesystem.readonlyPaths.some((path: string) => normalizeWindowsPathForAssert(path) === 'c:/users/user/appdata/local/programs/git'), 'MXC user profile policy should add user profile paths to readonly paths');
 		ok(config.filesystem.readonlyPaths.some((path: string) => normalizeWindowsPathForAssert(path) === 'c:/users/user/appdata/local/temp'), 'MXC actual temp policy should add host temp path to readonly paths');
 		ok(!config.filesystem.deniedPaths.some((path: string) => normalizeWindowsPathForAssert(path) === 'c:/users/user'), 'User home should not be denied by default on Windows');
@@ -339,6 +357,35 @@ suite('TerminalSandboxEngine', () => {
 		ok(!config.filesystem.deniedPaths.some((path: string) => normalizeWindowsPathForAssert(path) === 'c:/users/user'), 'User home should not be denied by default on Windows');
 	});
 
+	test('resolves Windows filesystem symlinks when writing MXC config', async () => {
+		enableWindowsSandbox();
+		setSandboxSetting(AgentSandboxSettingId.AgentSandboxWindowsFileSystem, {
+			allowWrite: ['C:\\configured\\write-link'],
+			allowRead: ['C:\\configured\\read-link'],
+			denyRead: ['C:\\configured\\secret-link'],
+		});
+		fileService.setRealpath('/c:/workspace-link', '/c:/real/workspace');
+		fileService.setRealpath('/c:/configured/write-link', '/c:/real/configured-write');
+		fileService.setRealpath('/c:/configured/read-link', '/c:/real/configured-read');
+		fileService.setRealpath('/c:/configured/secret-link', '/c:/real/configured-secret');
+		fileService.setRealpath('/c:/tools/node', '/c:/real/tools-node');
+		const host = createWindowsHost({
+			getWriteRoots: () => [URI.from({ scheme: 'file', path: '/c:/workspace-link' })],
+		});
+		const engine = store.add(instantiationService.createInstance(TerminalSandboxEngine, host));
+
+		await engine.wrapCommand('echo hello', false, 'pwsh');
+		const configPath = await engine.getSandboxConfigPath();
+		ok(configPath, 'Config path should be defined');
+		const config = JSON.parse(createdFiles.get(configPath)!);
+
+		ok(config.filesystem.readwritePaths.some((path: string) => normalizeWindowsPathForAssert(path) === 'c:/real/workspace'), 'Workspace write root symlink should be resolved on Windows');
+		ok(config.filesystem.readwritePaths.some((path: string) => normalizeWindowsPathForAssert(path) === 'c:/real/configured-write'), 'Configured Windows allowWrite symlink should be resolved');
+		ok(config.filesystem.readonlyPaths.some((path: string) => normalizeWindowsPathForAssert(path) === 'c:/real/configured-read'), 'Configured Windows allowRead symlink should be resolved');
+		ok(config.filesystem.readonlyPaths.some((path: string) => normalizeWindowsPathForAssert(path) === 'c:/real/tools-node'), 'Windows policy readonly symlink should be resolved');
+		ok(config.filesystem.deniedPaths.some((path: string) => normalizeWindowsPathForAssert(path) === 'c:/real/configured-secret'), 'Configured Windows denyRead symlink should be resolved');
+	});
+
 	test('wrapCommand uses arm64 MXC executable on Windows arm64', async () => {
 		enableWindowsSandbox();
 		const host = createWindowsHost({
@@ -352,7 +399,7 @@ suite('TerminalSandboxEngine', () => {
 		const config = JSON.parse(createdFiles.get(configPath)!);
 
 		strictEqual(wrapped.command, `& 'C:\\app\\node_modules\\@microsoft\\mxc-sdk\\bin\\arm64\\wxc-exec.exe' '${configPath}'`);
-		strictEqual(normalizeWindowsPathForAssert(config.process.cwd), 'c:/users/user/.test-data/tmp');
+		strictEqual(normalizeWindowsPathForAssert(config.process.cwd), 'c:/workspace');
 	});
 
 	test('wrapCommand rewrites MXC config when Windows command changes', async () => {
@@ -360,17 +407,17 @@ suite('TerminalSandboxEngine', () => {
 		const host = createWindowsHost();
 		const engine = store.add(instantiationService.createInstance(TerminalSandboxEngine, host));
 
-		await engine.wrapCommand('echo first', false, 'pwsh');
+		await engine.wrapCommand('echo first', false, 'C:\\Program Files\\PowerShell\\7\\pwsh.exe');
 		let configPath = await engine.getSandboxConfigPath();
 		ok(configPath, 'Config path should be defined');
 		const firstCommandLine = JSON.parse(createdFiles.get(configPath)!).process.commandLine;
-		strictEqual(firstCommandLine, 'echo first');
+		strictEqual(firstCommandLine, '"C:\\Program Files\\PowerShell\\7\\pwsh.exe" -NoProfile -ExecutionPolicy Bypass -Command "echo first"');
 
-		await engine.wrapCommand('echo second', false, 'pwsh');
+		await engine.wrapCommand('echo second', false, 'C:\\Program Files\\PowerShell\\7\\pwsh.exe');
 		configPath = await engine.getSandboxConfigPath();
 		ok(configPath, 'Config path should be defined');
 		const secondCommandLine = JSON.parse(createdFiles.get(configPath)!).process.commandLine;
-		strictEqual(secondCommandLine, 'echo second');
+		strictEqual(secondCommandLine, '"C:\\Program Files\\PowerShell\\7\\pwsh.exe" -NoProfile -ExecutionPolicy Bypass -Command "echo second"');
 	});
 
 	test('allowNetwork maps to MXC allow network config on Windows', async () => {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts
@@ -166,7 +166,16 @@ suite('TerminalSandboxService - network domains', () => {
 			readonlyPaths: ['c:\\tools\\node'],
 			readwritePaths: [],
 		};
-		environment = ['PATH=c:\\tools\\node;c:\\windows\\system32', 'PSHOME=c:\\program files\\powershell\\7'];
+		environment = [
+			'SystemRoot=c:\\windows',
+			'PATH=c:\\tools\\node;c:\\windows\\system32',
+			'ComSpec=c:\\windows\\system32\\cmd.exe',
+			'PATHEXT=.COM;.EXE;.BAT;.CMD;.PS1',
+			'PSModulePath=c:\\users\\test\\documents\\powershell\\modules;c:\\program files\\powershell\\modules',
+			'USERPROFILE=c:\\users\\test',
+			'APPDATA=c:\\users\\test\\appdata\\roaming',
+			'PSHOME=c:\\program files\\powershell\\7'
+		];
 
 		checkSandboxDependencies(): Promise<ISandboxDependencyStatus> {
 			this.callCount++;
@@ -1221,7 +1230,7 @@ suite('TerminalSandboxService - network domains', () => {
 		const sandboxService = store.add(instantiationService.createInstance(TerminalSandboxService));
 
 		const configPath = await sandboxService.getSandboxConfigPath();
-		const wrapped = await sandboxService.wrapCommand('echo test', false, 'pwsh.exe', URI.file('/c:/workspace-one'));
+		const wrapped = await sandboxService.wrapCommand('echo test', false, 'c:\\program files\\powershell\\7\\pwsh.exe', URI.file('/c:/workspace-one'));
 
 		ok(configPath, 'Config path should be defined for remote Windows');
 		const configContent = createdFiles.get(configPath);
@@ -1232,15 +1241,22 @@ suite('TerminalSandboxService - network domains', () => {
 		ok(wrapped.command.includes('node_modules\\@microsoft\\mxc-sdk\\bin\\arm64\\wxc-exec.exe'), `Wrapped command should use the MXC Windows executable. Actual: ${wrapped.command}`);
 		ok(wrapped.command.includes(configPath), `Wrapped command should pass the MXC config path. Actual: ${wrapped.command}`);
 		strictEqual(config.version, '0.4.0-alpha');
-		strictEqual(config.containment, 'process');
-		strictEqual(config.process.commandLine, 'echo test');
+		strictEqual(config.containment, 'processcontainer');
+		strictEqual(config.process.commandLine, '"c:\\program files\\powershell\\7\\pwsh.exe" -NoProfile -ExecutionPolicy Bypass -Command "echo test"');
 		strictEqual(config.process.cwd, 'c:\\workspace-one');
+		ok(config.process.env.includes('SystemRoot=c:\\windows'), 'SystemRoot should be injected into the MXC process env');
 		ok(config.process.env.includes('PATH=c:\\tools\\node;c:\\windows\\system32'), 'PATH should be injected into the MXC process env');
+		ok(config.process.env.includes('ComSpec=c:\\windows\\system32\\cmd.exe'), 'ComSpec should be injected into the MXC process env');
+		ok(config.process.env.includes('PATHEXT=.COM;.EXE;.BAT;.CMD;.PS1'), 'PATHEXT should be injected into the MXC process env');
+		ok(config.process.env.includes('PSModulePath=c:\\users\\test\\documents\\powershell\\modules;c:\\program files\\powershell\\modules'), 'PSModulePath should be injected into the MXC process env');
+		ok(config.process.env.includes('USERPROFILE=c:\\users\\test'), 'USERPROFILE should be injected into the MXC process env');
+		ok(config.process.env.includes('APPDATA=c:\\users\\test\\appdata\\roaming'), 'APPDATA should be injected into the MXC process env');
 		ok(config.process.env.includes('PSHOME=c:\\program files\\powershell\\7'), 'PSHOME should be injected into the MXC process env');
 		ok(config.filesystem.readwritePaths.includes('c:\\workspace-one'), 'Workspace folder should be writable in the MXC config');
 		ok(config.filesystem.readwritePaths.some((path: string) => path.includes('tmp_vscode_7')), 'Sandbox temp dir should be writable in the MXC config');
 		ok(config.filesystem.readonlyPaths.includes('c:\\app'), 'VS Code app root should be readable in the MXC config');
 		ok(config.filesystem.readonlyPaths.includes('c:\\tools\\node'), 'MXC available tools policy should add tool paths to readonly paths');
+		ok(config.filesystem.readonlyPaths.includes('c:\\program files\\powershell\\7'), 'Resolved PowerShell executable directory should be readable in the MXC config');
 		ok(!config.filesystem.deniedPaths.includes('c:\\Users\\test'), 'User home should not be denied by default in the MXC config on Windows');
 	});
 


### PR DESCRIPTION
Cherry-pick of #318466 to `release/1.122`.

This backports the Windows MXC PowerShell command-line/environment changes and related package and test updates.

Validation:
- `npm run transpile-client`
- `src/vs/platform/sandbox/test/common/terminalSandboxEngine.test.ts`
- `src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts`

Focused test result: 75 passed, 0 failed.