### PR TITLE
Perf: Dedupe tool-definition JSON across telemetry/OTel sites

### DIFF
--- a/extensions/copilot/src/extension/byok/vscode-node/anthropicProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/anthropicProvider.ts
@@ -16,7 +16,7 @@ import { ContextManagementResponse, CUSTOM_TOOL_SEARCH_NAME, getContextManagemen
 import { IToolDeferralService } from '../../../platform/networking/common/toolDeferralService';
 import { IResponseDelta, OpenAiFunctionTool } from '../../../platform/networking/common/fetch';
 import { APIUsage } from '../../../platform/networking/common/openai';
-import { CopilotChatAttr, emitInferenceDetailsEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, GenAiProviderName, type OTelModelOptions, StdAttr, toSystemInstructions, toToolDefinitions, truncateForOTel } from '../../../platform/otel/common/index';
+import { CopilotChatAttr, emitInferenceDetailsEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, GenAiProviderName, type OTelModelOptions, StdAttr, stringifyToolDefinitionsForOTel, toSystemInstructions, truncateForOTel } from '../../../platform/otel/common/index';
 import { IOTelService, SpanKind, SpanStatusCode } from '../../../platform/otel/common/otelService';
 import { IRequestLogger } from '../../../platform/requestLogger/common/requestLogger';
 import { retrieveCapturingTokenByCorrelation, runWithCapturingToken } from '../../../platform/requestLogger/node/requestLogger';
@@ -502,9 +502,9 @@ export class AnthropicLMProvider extends AbstractLanguageModelChatProvider {
 			if (this._otelService.config.captureContent) {
 				// Tool definitions on the chat span (issue #299934) with `parameters`
 				// per OTel GenAI semantic conventions (issue #300318).
-				const toolDefs = toToolDefinitions(options.tools);
-				if (toolDefs) {
-					otelSpan.setAttribute(GenAiAttr.TOOL_DEFINITIONS, truncateForOTel(JSON.stringify(toolDefs), this._otelService.config.maxAttributeSizeChars));
+				const toolDefsJson = stringifyToolDefinitionsForOTel(options.tools);
+				if (toolDefsJson) {
+					otelSpan.setAttribute(GenAiAttr.TOOL_DEFINITIONS, truncateForOTel(toolDefsJson, this._otelService.config.maxAttributeSizeChars));
 				}
 				try {
 					const { systemTexts, inputMsgs } = buildOTelInputFromChatMessages(messages);

--- a/extensions/copilot/src/extension/byok/vscode-node/geminiNativeProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/geminiNativeProvider.ts
@@ -10,7 +10,7 @@ import { ILogService } from '../../../platform/log/common/logService';
 import { IResponseDelta, OpenAiFunctionTool } from '../../../platform/networking/common/fetch';
 import { APIUsage } from '../../../platform/networking/common/openai';
 import { CustomDataPartMimeTypes } from '../../../platform/endpoint/common/endpointTypes';
-import { CopilotChatAttr, emitInferenceDetailsEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, GenAiProviderName, type OTelModelOptions, StdAttr, toSystemInstructions, toToolDefinitions, truncateForOTel } from '../../../platform/otel/common/index';
+import { CopilotChatAttr, emitInferenceDetailsEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, GenAiProviderName, type OTelModelOptions, StdAttr, stringifyToolDefinitionsForOTel, toSystemInstructions, truncateForOTel } from '../../../platform/otel/common/index';
 import { IOTelService, SpanKind, SpanStatusCode } from '../../../platform/otel/common/otelService';
 import { IRequestLogger } from '../../../platform/requestLogger/common/requestLogger';
 import { retrieveCapturingTokenByCorrelation, runWithCapturingToken } from '../../../platform/requestLogger/node/requestLogger';
@@ -363,9 +363,9 @@ export class GeminiNativeBYOKLMProvider extends AbstractLanguageModelChatProvide
 			if (this._otelService.config.captureContent) {
 				// Tool definitions on the chat span (issue #299934) with `parameters`
 				// per OTel GenAI semantic conventions (issue #300318).
-				const toolDefs = toToolDefinitions(options.tools);
-				if (toolDefs) {
-					otelSpan.setAttribute(GenAiAttr.TOOL_DEFINITIONS, truncateForOTel(JSON.stringify(toolDefs), this._otelService.config.maxAttributeSizeChars));
+				const toolDefsJson = stringifyToolDefinitionsForOTel(options.tools);
+				if (toolDefsJson) {
+					otelSpan.setAttribute(GenAiAttr.TOOL_DEFINITIONS, truncateForOTel(toolDefsJson, this._otelService.config.maxAttributeSizeChars));
 				}
 				try {
 					const { systemTexts, inputMsgs } = buildOTelInputFromChatMessages(messages);

--- a/extensions/copilot/src/extension/intents/node/toolCallingLoop.ts
+++ b/extensions/copilot/src/extension/intents/node/toolCallingLoop.ts
@@ -22,7 +22,7 @@ import { ILogService } from '../../../platform/log/common/logService';
 import { isOpenAIContextManagementResponse, OpenAiFunctionDef } from '../../../platform/networking/common/fetch';
 import { IMakeChatRequestOptions } from '../../../platform/networking/common/networking';
 import { OpenAIContextManagementResponse } from '../../../platform/networking/common/openai';
-import { CopilotChatAttr, emitAgentTurnEvent, emitSessionStartEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, GenAiProviderName, GitHubCopilotAttr, resolveWorkspaceOTelMetadata, StdAttr, truncateForOTel, workspaceMetadataToOTelAttributes } from '../../../platform/otel/common/index';
+import { CopilotChatAttr, emitAgentTurnEvent, emitSessionStartEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, GenAiProviderName, GitHubCopilotAttr, resolveWorkspaceOTelMetadata, StdAttr, stringifyToolDefinitionsForOTel, truncateForOTel, workspaceMetadataToOTelAttributes } from '../../../platform/otel/common/index';
 import { IOTelService, ISpanHandle, SpanKind, SpanStatusCode } from '../../../platform/otel/common/otelService';
 import { IRequestLogger } from '../../../platform/requestLogger/common/requestLogger';
 import { getCurrentCapturingToken } from '../../../platform/requestLogger/node/requestLogger';
@@ -893,14 +893,10 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 						// Includes `parameters` (inputSchema) per OTel GenAI semantic convention so
 						// trace viewers can render full tool signatures (issue #300318).
 						if (result.availableTools.length > 0) {
-							span.setAttribute(GenAiAttr.TOOL_DEFINITIONS, truncateForOTel(JSON.stringify(
-								result.availableTools.map(t => ({
-									type: 'function',
-									name: t.name,
-									description: t.description,
-									parameters: t.inputSchema,
-								}))
-							)));
+							const toolDefsJson = stringifyToolDefinitionsForOTel(result.availableTools);
+							if (toolDefsJson) {
+								span.setAttribute(GenAiAttr.TOOL_DEFINITIONS, truncateForOTel(toolDefsJson));
+							}
 						}
 					}
 					span.setStatus(SpanStatusCode.OK);
@@ -1207,15 +1203,13 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 		// starts in fetch(). This lets the debug logger write tools_*.json early.
 		if (!this.toolsAvailableEmitted && this.agentSpan && availableTools.length > 0) {
 			this.toolsAvailableEmitted = true;
-			this.agentSpan.addEvent('tools_available', {
-				toolDefinitions: truncateForOTel(JSON.stringify(availableTools.map(t => ({
-					type: 'function',
-					name: t.name,
-					description: t.description,
-					parameters: t.inputSchema,
-				})))),
-				...(this.chatSessionIdForTools ? { [CopilotChatAttr.CHAT_SESSION_ID]: this.chatSessionIdForTools } : {}),
-			});
+			const toolDefsJson = stringifyToolDefinitionsForOTel(availableTools);
+			if (toolDefsJson) {
+				this.agentSpan.addEvent('tools_available', {
+					toolDefinitions: truncateForOTel(toolDefsJson),
+					...(this.chatSessionIdForTools ? { [CopilotChatAttr.CHAT_SESSION_ID]: this.chatSessionIdForTools } : {}),
+				});
+			}
 		}
 
 		const context = this.createPromptContext(availableTools, outputStream);

--- a/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
+++ b/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
@@ -1171,10 +1171,6 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 			if (key === 'messages' || key === 'input') {
 				continue;
 			} // Skip messages (PII)
-			if (key === 'tools') {
-				telemetryData.properties[`request.option.${key}`] = stringifyToolsRawForTelemetry(value as ReadonlyArray<unknown> | undefined) ?? 'undefined';
-				continue;
-			}
 			telemetryData.properties[`request.option.${key}`] = JSON.stringify(value) ?? 'undefined';
 		}
 		this._telemetryService.sendGHTelemetryEvent('request.sent', telemetryData.properties, telemetryData.measurements);
@@ -1449,10 +1445,6 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 			if (key === 'messages' || key === 'input') {
 				continue;
 			} // Skip messages (PII)
-			if (key === 'tools') {
-				telemetryData.properties[`request.option.${key}`] = stringifyToolsRawForTelemetry(value as ReadonlyArray<unknown> | undefined) ?? 'undefined';
-				continue;
-			}
 			telemetryData.properties[`request.option.${key}`] = JSON.stringify(value) ?? 'undefined';
 		}
 

--- a/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
+++ b/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
@@ -28,7 +28,7 @@ import { sendEngineMessagesTelemetry } from '../../../platform/networking/node/c
 import { CAPIWebSocketErrorEvent, IChatWebSocketManager, isCAPIWebSocketError } from '../../../platform/networking/node/chatWebSocketManager';
 import { sendCommunicationErrorTelemetry } from '../../../platform/networking/node/stream';
 import { ChatFailKind, ChatRequestCanceled, ChatRequestFailed, ChatResults, FetchResponseKind } from '../../../platform/openai/node/fetch';
-import { collectSystemTextsFromRequestBody, CopilotChatAttr, emitInferenceDetailsEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, GenAiProviderName, normalizeProviderMessages, StdAttr, toSystemInstructions, toToolDefinitions, truncateForOTel } from '../../../platform/otel/common/index';
+import { collectSystemTextsFromRequestBody, CopilotChatAttr, emitInferenceDetailsEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, GenAiProviderName, normalizeProviderMessages, StdAttr, stringifyToolDefinitionsForOTel, stringifyToolsRawForTelemetry, toSystemInstructions, truncateForOTel } from '../../../platform/otel/common/index';
 import { IOTelService, ISpanHandle, SpanKind, SpanStatusCode } from '../../../platform/otel/common/otelService';
 import { IRequestLogger } from '../../../platform/requestLogger/common/requestLogger';
 import { getCurrentCapturingToken } from '../../../platform/requestLogger/node/requestLogger';
@@ -295,9 +295,9 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 					// Tool definitions: emit on every chat span so trace viewers can render the
 					// tool catalog per LLM call (issue #299934). Includes `parameters` per
 					// OTel GenAI semantic conventions (issue #300318).
-					const toolDefs = toToolDefinitions(requestBody.tools);
-					if (toolDefs) {
-						otelInferenceSpan.setAttribute(GenAiAttr.TOOL_DEFINITIONS, truncateForOTel(JSON.stringify(toolDefs), this._otelService.config.maxAttributeSizeChars));
+					const toolDefsJson = stringifyToolDefinitionsForOTel(requestBody.tools);
+					if (toolDefsJson) {
+						otelInferenceSpan.setAttribute(GenAiAttr.TOOL_DEFINITIONS, truncateForOTel(toolDefsJson, this._otelService.config.maxAttributeSizeChars));
 					}
 					// Cache-relevant request options. Anything in this blob, when changed
 					// between two requests, will invalidate the prompt cache even when
@@ -1171,6 +1171,10 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 			if (key === 'messages' || key === 'input') {
 				continue;
 			} // Skip messages (PII)
+			if (key === 'tools') {
+				telemetryData.properties[`request.option.${key}`] = stringifyToolsRawForTelemetry(value as ReadonlyArray<unknown> | undefined) ?? 'undefined';
+				continue;
+			}
 			telemetryData.properties[`request.option.${key}`] = JSON.stringify(value) ?? 'undefined';
 		}
 		this._telemetryService.sendGHTelemetryEvent('request.sent', telemetryData.properties, telemetryData.measurements);
@@ -1179,7 +1183,7 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 			this._telemetryService.sendEnhancedGHTelemetryEvent('request.options.tools', multiplexProperties({
 				headerRequestId: ourRequestId,
 				conversationId,
-				messagesJson: JSON.stringify(request.tools),
+				messagesJson: stringifyToolsRawForTelemetry(request.tools) ?? '',
 			}), telemetryData.measurements);
 		}
 
@@ -1445,6 +1449,10 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 			if (key === 'messages' || key === 'input') {
 				continue;
 			} // Skip messages (PII)
+			if (key === 'tools') {
+				telemetryData.properties[`request.option.${key}`] = stringifyToolsRawForTelemetry(value as ReadonlyArray<unknown> | undefined) ?? 'undefined';
+				continue;
+			}
 			telemetryData.properties[`request.option.${key}`] = JSON.stringify(value) ?? 'undefined';
 		}
 
@@ -1459,7 +1467,7 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 			this._telemetryService.sendEnhancedGHTelemetryEvent('request.options.tools', multiplexProperties({
 				headerRequestId: ourRequestId,
 				conversationId: telemetryProperties?.conversationId,
-				messagesJson: JSON.stringify(request.tools),
+				messagesJson: stringifyToolsRawForTelemetry(request.tools) ?? '',
 			}), telemetryData.measurements);
 		}
 

--- a/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
+++ b/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
@@ -1172,7 +1172,7 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 				continue;
 			} // Skip messages (PII)
 			if (key === 'tools') {
-				telemetryData.properties[`request.option.${key}`] = stringifyToolsRawForTelemetry(value as ReadonlyArray<unknown> | undefined) ?? JSON.stringify(value) ?? 'undefined';
+				telemetryData.properties[`request.option.${key}`] = stringifyToolsRawForTelemetry(value as ReadonlyArray<unknown> | undefined) ?? 'undefined';
 				continue;
 			}
 			telemetryData.properties[`request.option.${key}`] = JSON.stringify(value) ?? 'undefined';
@@ -1183,7 +1183,7 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 			this._telemetryService.sendEnhancedGHTelemetryEvent('request.options.tools', multiplexProperties({
 				headerRequestId: ourRequestId,
 				conversationId,
-				messagesJson: stringifyToolsRawForTelemetry(request.tools) ?? '',
+				messagesJson: stringifyToolsRawForTelemetry(request.tools)!,
 			}), telemetryData.measurements);
 		}
 
@@ -1450,7 +1450,7 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 				continue;
 			} // Skip messages (PII)
 			if (key === 'tools') {
-				telemetryData.properties[`request.option.${key}`] = stringifyToolsRawForTelemetry(value as ReadonlyArray<unknown> | undefined) ?? JSON.stringify(value) ?? 'undefined';
+				telemetryData.properties[`request.option.${key}`] = stringifyToolsRawForTelemetry(value as ReadonlyArray<unknown> | undefined) ?? 'undefined';
 				continue;
 			}
 			telemetryData.properties[`request.option.${key}`] = JSON.stringify(value) ?? 'undefined';
@@ -1467,7 +1467,7 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 			this._telemetryService.sendEnhancedGHTelemetryEvent('request.options.tools', multiplexProperties({
 				headerRequestId: ourRequestId,
 				conversationId: telemetryProperties?.conversationId,
-				messagesJson: stringifyToolsRawForTelemetry(request.tools) ?? '',
+				messagesJson: stringifyToolsRawForTelemetry(request.tools)!,
 			}), telemetryData.measurements);
 		}
 

--- a/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
+++ b/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
@@ -1171,6 +1171,10 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 			if (key === 'messages' || key === 'input') {
 				continue;
 			} // Skip messages (PII)
+			if (key === 'tools') {
+				telemetryData.properties[`request.option.${key}`] = stringifyToolsRawForTelemetry(value as ReadonlyArray<unknown> | undefined) ?? JSON.stringify(value) ?? 'undefined';
+				continue;
+			}
 			telemetryData.properties[`request.option.${key}`] = JSON.stringify(value) ?? 'undefined';
 		}
 		this._telemetryService.sendGHTelemetryEvent('request.sent', telemetryData.properties, telemetryData.measurements);
@@ -1445,6 +1449,10 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 			if (key === 'messages' || key === 'input') {
 				continue;
 			} // Skip messages (PII)
+			if (key === 'tools') {
+				telemetryData.properties[`request.option.${key}`] = stringifyToolsRawForTelemetry(value as ReadonlyArray<unknown> | undefined) ?? JSON.stringify(value) ?? 'undefined';
+				continue;
+			}
 			telemetryData.properties[`request.option.${key}`] = JSON.stringify(value) ?? 'undefined';
 		}
 

--- a/extensions/copilot/src/platform/otel/common/genAiEvents.ts
+++ b/extensions/copilot/src/platform/otel/common/genAiEvents.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { GenAiAttr, GenAiOperationName, StdAttr } from './genAiAttributes';
-import { normalizeProviderMessages, toSystemInstructions, truncateForOTel } from './messageFormatters';
+import { normalizeProviderMessages, stringifyToolsRawForTelemetry, toSystemInstructions, truncateForOTel } from './messageFormatters';
 import type { IOTelService } from './otelService';
 import { type WorkspaceOTelMetadata, workspaceMetadataToOTelAttributes } from './workspaceOTelMetadata';
 
@@ -71,7 +71,10 @@ export function emitInferenceDetailsEvent(
 			}
 		}
 		if (request.tools !== undefined) {
-			attributes[GenAiAttr.TOOL_DEFINITIONS] = truncateForOTel(JSON.stringify(request.tools), maxLen);
+			const toolsJson = stringifyToolsRawForTelemetry(request.tools as ReadonlyArray<unknown> | undefined);
+			if (toolsJson !== undefined) {
+				attributes[GenAiAttr.TOOL_DEFINITIONS] = truncateForOTel(toolsJson, maxLen);
+			}
 		}
 	}
 

--- a/extensions/copilot/src/platform/otel/common/index.ts
+++ b/extensions/copilot/src/platform/otel/common/index.ts
@@ -7,7 +7,7 @@ export { CopilotChatAttr, CopilotCliSdkAttr, FILE_TOOL_NAMES, GenAiAttr, GenAiOp
 export type { AgentType, EditOperationType, HookDecision } from './genAiAttributes';
 export { emitAgentTurnEvent, emitCloudSessionInvokeEvent, emitEditFeedbackEvent, emitEditHunkActionEvent, emitEditSurvivalEvent, emitInferenceDetailsEvent, emitInlineDoneEvent, emitSessionStartEvent, emitToolCallEvent, emitUserFeedbackEvent } from './genAiEvents';
 export { GenAiMetrics } from './genAiMetrics';
-export { collectSystemTextsFromRequestBody, extractTextFromContent, normalizeProviderMessages, toInputMessages, toOutputMessages, toSystemInstructions, toToolDefinitions, truncateForOTel } from './messageFormatters';
+export { collectSystemTextsFromRequestBody, extractTextFromContent, normalizeProviderMessages, stringifyToolDefinitionsForOTel, stringifyToolsRawForTelemetry, toInputMessages, toOutputMessages, toSystemInstructions, toToolDefinitions, truncateForOTel } from './messageFormatters';
 export { NoopOTelService } from './noopOtelService';
 export { resolveOTelConfig, DEFAULT_OTLP_ENDPOINT, type OTelConfig, type OTelConfigInput } from './otelConfig';
 export { IOTelService, SpanKind, SpanStatusCode, type ICompletedSpanData, type ISpanEventData, type ISpanEventRecord, type ISpanHandle, type OTelModelOptions, type SpanOptions, type TraceContext } from './otelService';

--- a/extensions/copilot/src/platform/otel/common/messageFormatters.ts
+++ b/extensions/copilot/src/platform/otel/common/messageFormatters.ts
@@ -513,10 +513,12 @@ export function stringifyToolDefinitionsForOTel(tools: Parameters<typeof toToolD
  * Return `JSON.stringify(tools)` memoized by array reference, with a
  * single-slot content intern so consecutive rounds producing identical content
  * share one string instance. Used for telemetry sinks that consume the raw
- * tools shape rather than the OTel-normalized one.
+ * tools shape rather than the OTel-normalized one. Mirrors `JSON.stringify`
+ * exactly: returns `'[]'` for an empty array and `undefined` only when
+ * `tools` itself is `undefined`.
  */
 export function stringifyToolsRawForTelemetry(tools: ReadonlyArray<unknown> | undefined): string | undefined {
-	if (!tools || tools.length === 0) {
+	if (!tools) {
 		return undefined;
 	}
 	const cached = toolsRawJsonByRef.get(tools);

--- a/extensions/copilot/src/platform/otel/common/messageFormatters.ts
+++ b/extensions/copilot/src/platform/otel/common/messageFormatters.ts
@@ -459,3 +459,80 @@ export function toToolDefinitions(tools: ReadonlyArray<{
 	}
 	return out.length > 0 ? out : undefined;
 }
+
+// Tool-definition arrays are frequently several MB once serialized, are reused
+// across many telemetry/log/OTel sites within a single LLM round, and are often
+// content-identical across consecutive rounds of an agent loop. Without
+// deduplication the ext host can retain ~10 copies of the same multi-MB string
+// (one per buffered OTel span / log entry). The helpers below intern the
+// stringified form so all callers share a single instance.
+//
+// - WeakMap fast path: if the same `tools` array reference is reused, return
+//   the cached string immediately.
+// - Single-slot content intern: if a fresh array produces a string equal to
+//   the previously interned one, reuse that prior instance. This covers the
+//   common agent-loop case where each round receives a freshly-built tools
+//   array with identical content.
+
+const toolDefsJsonByRef = new WeakMap<object, string>();
+const toolsRawJsonByRef = new WeakMap<object, string>();
+let lastToolDefsJson: string | undefined;
+let lastToolsRawJson: string | undefined;
+
+function internToolDefsString(s: string): string {
+	if (lastToolDefsJson !== undefined && lastToolDefsJson === s) {
+		return lastToolDefsJson;
+	}
+	lastToolDefsJson = s;
+	return s;
+}
+
+function internToolsRawString(s: string): string {
+	if (lastToolsRawJson !== undefined && lastToolsRawJson === s) {
+		return lastToolsRawJson;
+	}
+	lastToolsRawJson = s;
+	return s;
+}
+
+/**
+ * Return the OTel-normalized JSON string for a tools array, memoized so all
+ * telemetry/span sites within (and across consecutive identical rounds of) an
+ * LLM call share a single string instance. Returns `undefined` if no
+ * normalized tools would be emitted.
+ */
+export function stringifyToolDefinitionsForOTel(tools: Parameters<typeof toToolDefinitions>[0]): string | undefined {
+	if (!tools || tools.length === 0) {
+		return undefined;
+	}
+	const cached = toolDefsJsonByRef.get(tools);
+	if (cached !== undefined) {
+		return cached;
+	}
+	const defs = toToolDefinitions(tools);
+	if (!defs) {
+		return undefined;
+	}
+	const s = internToolDefsString(JSON.stringify(defs));
+	toolDefsJsonByRef.set(tools, s);
+	return s;
+}
+
+/**
+ * Return `JSON.stringify(tools)` memoized by array reference, with a
+ * single-slot content intern so consecutive rounds producing identical content
+ * share one string instance. Used for telemetry sinks that consume the raw
+ * tools shape rather than the OTel-normalized one.
+ */
+export function stringifyToolsRawForTelemetry(tools: ReadonlyArray<unknown> | undefined): string | undefined {
+	if (!tools || tools.length === 0) {
+		return undefined;
+	}
+	const cached = toolsRawJsonByRef.get(tools);
+	if (cached !== undefined) {
+		return cached;
+	}
+	const s = internToolsRawString(JSON.stringify(tools));
+	toolsRawJsonByRef.set(tools, s);
+	return s;
+}

--- a/extensions/copilot/src/platform/otel/common/messageFormatters.ts
+++ b/extensions/copilot/src/platform/otel/common/messageFormatters.ts
@@ -460,19 +460,10 @@ export function toToolDefinitions(tools: ReadonlyArray<{
 	return out.length > 0 ? out : undefined;
 }
 
-// Tool-definition arrays are frequently several MB once serialized, are reused
-// across many telemetry/log/OTel sites within a single LLM round, and are often
-// content-identical across consecutive rounds of an agent loop. Without
-// deduplication the ext host can retain ~10 copies of the same multi-MB string
-// (one per buffered OTel span / log entry). The helpers below intern the
-// stringified form so all callers share a single instance.
-//
-// - WeakMap fast path: if the same `tools` array reference is reused, return
-//   the cached string immediately.
-// - Single-slot content intern: if a fresh array produces a string equal to
-//   the previously interned one, reuse that prior instance. This covers the
-//   common agent-loop case where each round receives a freshly-built tools
-//   array with identical content.
+// Tool-definition JSON is multi-MB and reused across many telemetry/OTel sites
+// per LLM round, often byte-identical across consecutive agent-loop rounds.
+// Intern by array reference (WeakMap) plus a single-slot last-string cache so
+// content-equal serializations from distinct refs collapse to one instance.
 
 const toolDefsJsonByRef = new WeakMap<object, string>();
 const toolsRawJsonByRef = new WeakMap<object, string>();

--- a/extensions/copilot/src/platform/otel/common/test/messageFormatters.spec.ts
+++ b/extensions/copilot/src/platform/otel/common/test/messageFormatters.spec.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { collectSystemTextsFromRequestBody, extractTextFromContent, normalizeProviderMessages, stringifyToolDefinitionsForOTel, stringifyToolsRawForTelemetry, toInputMessages, toOutputMessages, toSystemInstructions, toToolDefinitions, truncateForOTel } from '../messageFormatters';
 
 describe('toInputMessages', () => {
@@ -503,45 +503,73 @@ describe('stringifyToolDefinitionsForOTel', () => {
 		expect(stringifyToolDefinitionsForOTel([])).toBeUndefined();
 	});
 
-	it('returns the same string instance when called with the same array reference', () => {
-		const tools = [{ name: 'readFile', description: 'd', inputSchema: { type: 'object' } }];
-		const a = stringifyToolDefinitionsForOTel(tools);
-		const b = stringifyToolDefinitionsForOTel(tools);
-		expect(a).toBeDefined();
-		// Same reference, same string instance from the WeakMap cache.
-		expect(a).toBe(b);
-		expect(JSON.parse(a!)).toEqual([{ type: 'function', name: 'readFile', description: 'd', parameters: { type: 'object' } }]);
+	it('skips re-stringification on repeated calls with the same array reference', () => {
+		const tools = [{ name: 'readFile_byref_' + Math.random(), description: 'd', inputSchema: { type: 'object' } }];
+		stringifyToolDefinitionsForOTel(tools); // prime the WeakMap
+		const spy = vi.spyOn(JSON, 'stringify');
+		try {
+			const a = stringifyToolDefinitionsForOTel(tools);
+			const b = stringifyToolDefinitionsForOTel(tools);
+			expect(spy).not.toHaveBeenCalled();
+			expect(a).toBe(b);
+			expect(JSON.parse(a!)).toEqual([{ type: 'function', name: tools[0].name, description: 'd', parameters: { type: 'object' } }]);
+		} finally {
+			spy.mockRestore();
+		}
 	});
 
-	it('intern collapses content-equal serializations across distinct array references', () => {
-		const t1 = [{ name: 'readFile', description: 'd', inputSchema: { type: 'object' } }];
-		const t2 = [{ name: 'readFile', description: 'd', inputSchema: { type: 'object' } }];
+	it('content-interns across distinct references (one stringify per new ref, same instance returned)', () => {
+		const unique = 'readFile_intern_' + Math.random();
+		const t1 = [{ name: unique, description: 'd', inputSchema: { type: 'object' } }];
+		const t2 = [{ name: unique, description: 'd', inputSchema: { type: 'object' } }];
 		const a = stringifyToolDefinitionsForOTel(t1);
-		const b = stringifyToolDefinitionsForOTel(t2);
-		expect(a).toBe(b);
+		const spy = vi.spyOn(JSON, 'stringify');
+		try {
+			const b = stringifyToolDefinitionsForOTel(t2);
+			// Distinct ref forces one new JSON.stringify; intern then collapses the result.
+			expect(spy).toHaveBeenCalledTimes(1);
+			expect(Object.is(a, b)).toBe(true);
+		} finally {
+			spy.mockRestore();
+		}
 	});
 });
 
 describe('stringifyToolsRawForTelemetry', () => {
-	it('returns undefined for empty / undefined input', () => {
+	it('mirrors JSON.stringify for empty / undefined input', () => {
 		expect(stringifyToolsRawForTelemetry(undefined)).toBeUndefined();
-		expect(stringifyToolsRawForTelemetry([])).toBeUndefined();
+		expect(stringifyToolsRawForTelemetry([])).toBe('[]');
 	});
 
-	it('returns JSON.stringify(tools) and memoizes by reference', () => {
-		const tools = [{ type: 'function', name: 'x' }];
-		const a = stringifyToolsRawForTelemetry(tools);
-		const b = stringifyToolsRawForTelemetry(tools);
-		expect(a).toBe(JSON.stringify(tools));
-		expect(a).toBe(b);
+	it('skips re-stringification on repeated calls with the same array reference', () => {
+		const tools = [{ type: 'function', name: 'raw_byref_' + Math.random() }];
+		const expected = JSON.stringify(tools);
+		stringifyToolsRawForTelemetry(tools); // prime the WeakMap
+		const spy = vi.spyOn(JSON, 'stringify');
+		try {
+			const a = stringifyToolsRawForTelemetry(tools);
+			const b = stringifyToolsRawForTelemetry(tools);
+			expect(spy).not.toHaveBeenCalled();
+			expect(a).toBe(expected);
+			expect(a).toBe(b);
+		} finally {
+			spy.mockRestore();
+		}
 	});
 
-	it('intern collapses content-equal raw serializations across distinct references', () => {
-		const t1 = [{ type: 'function', name: 'x' }];
-		const t2 = [{ type: 'function', name: 'x' }];
+	it('content-interns across distinct references (one stringify per new ref, same instance returned)', () => {
+		const unique = 'raw_intern_' + Math.random();
+		const t1 = [{ type: 'function', name: unique }];
+		const t2 = [{ type: 'function', name: unique }];
 		const a = stringifyToolsRawForTelemetry(t1);
-		const b = stringifyToolsRawForTelemetry(t2);
-		expect(a).toBe(b);
+		const spy = vi.spyOn(JSON, 'stringify');
+		try {
+			const b = stringifyToolsRawForTelemetry(t2);
+			expect(spy).toHaveBeenCalledTimes(1);
+			expect(Object.is(a, b)).toBe(true);
+		} finally {
+			spy.mockRestore();
+		}
 	});
 });
 

--- a/extensions/copilot/src/platform/otel/common/test/messageFormatters.spec.ts
+++ b/extensions/copilot/src/platform/otel/common/test/messageFormatters.spec.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { describe, expect, it } from 'vitest';
-import { collectSystemTextsFromRequestBody, extractTextFromContent, normalizeProviderMessages, toInputMessages, toOutputMessages, toSystemInstructions, toToolDefinitions, truncateForOTel } from '../messageFormatters';
+import { collectSystemTextsFromRequestBody, extractTextFromContent, normalizeProviderMessages, stringifyToolDefinitionsForOTel, stringifyToolsRawForTelemetry, toInputMessages, toOutputMessages, toSystemInstructions, toToolDefinitions, truncateForOTel } from '../messageFormatters';
 
 describe('toInputMessages', () => {
 	it('converts a simple text message', () => {
@@ -494,6 +494,54 @@ describe('toToolDefinitions', () => {
 
 	it('returns undefined for undefined input', () => {
 		expect(toToolDefinitions(undefined)).toBeUndefined();
+	});
+});
+
+describe('stringifyToolDefinitionsForOTel', () => {
+	it('returns undefined for empty / undefined input', () => {
+		expect(stringifyToolDefinitionsForOTel(undefined)).toBeUndefined();
+		expect(stringifyToolDefinitionsForOTel([])).toBeUndefined();
+	});
+
+	it('returns the same string instance when called with the same array reference', () => {
+		const tools = [{ name: 'readFile', description: 'd', inputSchema: { type: 'object' } }];
+		const a = stringifyToolDefinitionsForOTel(tools);
+		const b = stringifyToolDefinitionsForOTel(tools);
+		expect(a).toBeDefined();
+		// Same reference, same string instance from the WeakMap cache.
+		expect(a).toBe(b);
+		expect(JSON.parse(a!)).toEqual([{ type: 'function', name: 'readFile', description: 'd', parameters: { type: 'object' } }]);
+	});
+
+	it('intern collapses content-equal serializations across distinct array references', () => {
+		const t1 = [{ name: 'readFile', description: 'd', inputSchema: { type: 'object' } }];
+		const t2 = [{ name: 'readFile', description: 'd', inputSchema: { type: 'object' } }];
+		const a = stringifyToolDefinitionsForOTel(t1);
+		const b = stringifyToolDefinitionsForOTel(t2);
+		expect(a).toBe(b);
+	});
+});
+
+describe('stringifyToolsRawForTelemetry', () => {
+	it('returns undefined for empty / undefined input', () => {
+		expect(stringifyToolsRawForTelemetry(undefined)).toBeUndefined();
+		expect(stringifyToolsRawForTelemetry([])).toBeUndefined();
+	});
+
+	it('returns JSON.stringify(tools) and memoizes by reference', () => {
+		const tools = [{ type: 'function', name: 'x' }];
+		const a = stringifyToolsRawForTelemetry(tools);
+		const b = stringifyToolsRawForTelemetry(tools);
+		expect(a).toBe(JSON.stringify(tools));
+		expect(a).toBe(b);
+	});
+
+	it('intern collapses content-equal raw serializations across distinct references', () => {
+		const t1 = [{ type: 'function', name: 'x' }];
+		const t2 = [{ type: 'function', name: 'x' }];
+		const a = stringifyToolsRawForTelemetry(t1);
+		const b = stringifyToolsRawForTelemetry(t2);
+		expect(a).toBe(b);
 	});
 });
 


### PR DESCRIPTION
### Problem

Heap dumps of the extension host showed ~35 MB retained by ~10 duplicate copies of the same ~3.49 MB tool-definition JSON string. Each LLM round serialized the tool list **multiple** times — once for the OTel inference span, once for the OTel agent span, once for the `tools_available` event, once for the GH `request.options.tools` enhanced telemetry event, and once again from the per-key `Object.entries(request)` loop into `request.option.tools`. Each call produced an independent multi-MB `string` and was retained by buffered spans / telemetry queues.

### Fix

Add two memoized stringifiers in `messageFormatters` and route every producer through them:

- `stringifyToolDefinitionsForOTel(tools)` — normalizes via `toToolDefinitions` then `JSON.stringify`; used for `gen_ai.tool.definitions`.
- `stringifyToolsRawForTelemetry(tools)` — raw `JSON.stringify(tools)`; used by legacy GH telemetry that needs exact request-shape preservation. Mirrors `JSON.stringify` semantics: returns `undefined` only when the input is `undefined`, and `'[]'` for an empty array.

Both use:
1. **WeakMap by-reference cache** — repeated calls with the same array return the same string instance instantly.
2. **Single-slot content intern** — if a freshly produced JSON equals the last produced JSON (very common across consecutive agent-loop rounds even when the array reference changes), return the previously interned instance so only one copy stays alive.

Wired sites:
- `chatMLFetcher.ts` — both GH `request.options.tools` calls + both `Object.entries(request)` loops (helper drives the `tools` branch; `?? 'undefined'` preserves prior byte-for-byte output).
- `toolCallingLoop.ts` — agent-span `gen_ai.tool.definitions` + `tools_available` event.
- `genAiEvents.ts` — inference details event.
- `byok/anthropicProvider.ts`, `byok/geminiNativeProvider.ts` — per-request span attribute.

### Behavioral notes

- `toolCallingLoop`'s `tools_available` event is now suppressed when no nameable tools are present (previously emitted with possibly nameless entries). This matches OTel spec and the other call sites.
- Test in `genAiEvents.spec.ts` asserting `attrs[TOOL_DEFINITIONS] === JSON.stringify(tools)` still passes — the raw helper returns exactly that.

### Tests

`messageFormatters.spec.ts` — added coverage for the helpers, including:
- Empty input / undefined input parity with `JSON.stringify`.
- By-reference identity (same array returns the same string instance).
- Cross-reference content intern (distinct arrays with equal JSON share one interned string).
- Spy-based assertions on `JSON.stringify` confirming repeated same-ref calls do **not** re-serialize, and equal-content distinct-ref calls re-serialize exactly once before interning.

All 65 tests in `messageFormatters.spec.ts` pass.
