### PR TITLE
Add /chronicle:improve prompt for data-driven instructions refinement

### DIFF
--- a/extensions/copilot/assets/prompts/chronicle-improve.prompt.md
+++ b/extensions/copilot/assets/prompts/chronicle-improve.prompt.md
@@ -1,0 +1,5 @@
+---
+name: chronicle:improve
+description: Improve agent instructions based on friction patterns in your session history
+---
+Analyze my recent chat session history for friction patterns and suggest improvements to my agent instructions file. Use the **chronicle** skill — it documents the `copilot_sessionStoreSql` tool, the session-store schema, and the Improve workflow for detecting repeated failures, user corrections, and recurring friction across sessions, then proposing data-grounded additions to the project's agent instructions.

--- a/extensions/copilot/assets/prompts/skills/chronicle/SKILL.md
+++ b/extensions/copilot/assets/prompts/skills/chronicle/SKILL.md
@@ -96,6 +96,8 @@ Analysis dimensions to explore:
 
 If the session store has little data, acknowledge that and suggest features to try based on what configuration you found in the workspace.
 
+When recommending custom skills, agents, or instructions as a tip, consult the **agent-customization** skill for proper file creation patterns — don't give vague "create a custom skill" advice without actionable file structure guidance.
+
 ### Cost Tips
 
 When the user asks for cost tips, ways to reduce token usage, or how to lower Copilot spend (e.g. `/chronicle:cost-tips`):
@@ -169,6 +171,38 @@ Give the user 3-5 specific, actionable tips. Each tip should:
 - **Match the agent type** — if a finding is specific to one `agent_name`, say so. Don't propose CLI-only fixes for findings from Coding Agent sessions, and vice versa.
 
 If the session store has little data (e.g., cloud store is empty, or only a handful of local sessions), say so plainly and offer 2-3 non-obvious cost-saving habits anchored in available features rather than fabricating findings. If the user is on local-only storage, end by noting that enabling `chat.sessionSync.enabled` unlocks per-event token analysis for sharper future tips.
+
+### Improve
+
+When the user asks to improve their agent instructions based on session history (e.g. `/chronicle:improve`):
+
+**Step 1: Read the current instructions file**
+
+Read `.github/copilot-instructions.md` (or `AGENTS.md` in workspace root) to understand what instructions already exist.
+
+If the file does **not** exist, you will create it. In that case, also analyze the codebase first — consult the **init** skill and follow its codebase exploration approach. Combine that analysis with the session history findings from Step 2 to produce a comprehensive instructions file.
+
+**Step 2: Investigate session history**
+
+Use `copilot_sessionStoreSql` to explore. Scope all queries to sessions from the current repository or working directory.
+
+Start by getting an overview of recent sessions for this repo, then dig deeper. You're looking for **friction** — signals that the agent misunderstood something or the user had to course-correct:
+
+- **User messages that correct or redirect** — read the actual conversation turns of suspicious sessions. Look for areas where the user got frustrated.
+- **Dev loop struggles** — did the agent have trouble with tests, linting, building, or type checking? Look for repeated failed commands, test retries, or build errors that required multiple attempts.
+- **Patterns across sessions** — does the same kind of mistake recur?
+
+Use your judgment on what queries to run. Drill into specific sessions when something looks interesting — read the actual turn-by-turn conversation to understand what went wrong.
+
+**Step 3: Present recommendations**
+
+Before presenting, consult the **agent-customization** skill for proper file conventions, content principles (link don't embed, minimal, concise), and anti-patterns — this frames how recommendations should be written.
+
+Based on what you find, succinctly present 3-5 recommendations. Explain both the issue you found and what custom instructions can address it.
+
+Focus on project-specific patterns, not generic advice. Only suggest instructions that address real problems found in the data that happened more than once.
+
+After presenting all recommendations, ask the user which ones they'd like to apply. Then make only the approved edits to `.github/copilot-instructions.md` (or `AGENTS.md`, or create the file if it doesn't exist).
 
 ### Search
 

--- a/extensions/copilot/assets/prompts/skills/chronicle/SKILL.md
+++ b/extensions/copilot/assets/prompts/skills/chronicle/SKILL.md
@@ -178,7 +178,7 @@ When the user asks to improve their agent instructions based on session history 
 
 **Step 1: Read the current instructions file**
 
-Read `.github/copilot-instructions.md` (or `AGENTS.md` in workspace root) to understand what instructions already exist.
+Read whichever instructions file the project uses (`.github/copilot-instructions.md` or `AGENTS.md`) to understand what already exists.
 
 If the file does **not** exist, you will create it. In that case, also analyze the codebase first — consult the **init** skill and follow its codebase exploration approach. Combine that analysis with the session history findings from Step 2 to produce a comprehensive instructions file.
 
@@ -202,7 +202,7 @@ Based on what you find, succinctly present 3-5 recommendations. Explain both the
 
 Focus on project-specific patterns, not generic advice. Only suggest instructions that address real problems found in the data that happened more than once.
 
-After presenting all recommendations, ask the user which ones they'd like to apply. Then make only the approved edits to `.github/copilot-instructions.md` (or `AGENTS.md`, or create the file if it doesn't exist).
+After presenting all recommendations, ask the user which ones they'd like to apply. Then make only the approved edits to the single existing instructions file (or create `AGENTS.md` if none exists).
 
 ### Search
 

--- a/extensions/copilot/assets/prompts/skills/init/SKILL.md
+++ b/extensions/copilot/assets/prompts/skills/init/SKILL.md
@@ -36,7 +36,7 @@ When complete, print a table of the added or modified chat customization files, 
 3. **Generate or merge**
    - New file: Prefer AGENTS.md over `.github/copilot-instructions.md`. If the user already has one of these files, update it instead of creating a new one.
    - Existing file: Preserve valuable content, update outdated sections, remove duplication
-   - Follow the guidelines in the `agent-customization` skill: 
+   - Follow the guidelines in the `agent-customization` skill:
       1. **Link, don't embed** principle. Do not copy existing documentation that exists in the workspace, link to them with a Markdown link instead.
       2. **Minimal by default**: Only what's relevant and can not be easely discovered by an agent should be included. Link to other documentation for details.
       3. **Concise and actionable**: Every line should guide behavior
@@ -46,3 +46,5 @@ When complete, print a table of the added or modified chat customization files, 
    - If the workspace is complex, suggest creating separate instructions files or skills for specific areas (e.g., frontend, backend, tests)
 
 Once finalized, propose related agent-customizations to create next (`/create-(agent|hook|instruction|prompt|skill) …`), explaining the customization and how it would be used in practice.
+
+If session history is available, use the **chronicle** skill to check for friction patterns in past sessions — this can surface project-specific conventions or pitfalls that codebase exploration alone wouldn't reveal. Mention `/chronicle:improve` to the user as a way to iteratively refine instructions over time.

--- a/extensions/copilot/assets/prompts/skills/init/SKILL.md
+++ b/extensions/copilot/assets/prompts/skills/init/SKILL.md
@@ -38,7 +38,7 @@ When complete, print a table of the added or modified chat customization files, 
    - Existing file: Preserve valuable content, update outdated sections, remove duplication
    - Follow the guidelines in the `agent-customization` skill:
       1. **Link, don't embed** principle. Do not copy existing documentation that exists in the workspace, link to them with a Markdown link instead.
-      2. **Minimal by default**: Only what's relevant and can not be easely discovered by an agent should be included. Link to other documentation for details.
+      2. **Minimal by default**: Only what's relevant and cannot be easily discovered by an agent should be included. Link to other documentation for details.
       3. **Concise and actionable**: Every line should guide behavior
 
 4. **Iterate**

--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -6637,6 +6637,13 @@
         ]
       },
       {
+        "path": "./assets/prompts/chronicle-improve.prompt.md",
+        "when": "github.copilot.sessionSearch.enabled",
+        "sessionTypes": [
+          "local"
+        ]
+      },
+      {
         "path": "./assets/prompts/chronicle-reindex.prompt.md",
         "when": "github.copilot.sessionSearch.enabled",
         "sessionTypes": [

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -481,6 +481,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 			}
 			env['COPILOT_CLI_RUN_AS_NODE'] = '1';
 			env['USE_BUILTIN_RIPGREP'] = 'false';
+			env['RUBBER_DUCK_AGENT'] = 'true';
 
 			// Resolve the CLI entry point from node_modules. We can't use require.resolve()
 			// because @github/copilot's exports map blocks direct subpath access.


### PR DESCRIPTION
Adds a new `/chronicle:improve` prompt command that analyzes session history for friction patterns (user corrections, dev loop struggles, recurring issues) and suggests improvements to the project's agent instructions file.

**Changes:**
- New prompt file `chronicle-improve.prompt.md`
- `### Improve` section in chronicle SKILL.md with 3-step workflow: detect existing instructions → investigate session friction → present & apply recommendations
- Cross-reference to agent-customization skill for proper file conventions
- Init skill updated to reference chronicle for session-informed bootstrapping
- Registered in package.json with appropriate feature gate