### PR TITLE
Register chat.agentHost.* settings outside the renderer

### DIFF
--- a/src/vs/platform/agentHost/common/agentHost.config.contribution.ts
+++ b/src/vs/platform/agentHost/common/agentHost.config.contribution.ts
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { isWeb } from '../../../base/common/platform.js';
+import * as nls from '../../../nls.js';
+import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../configuration/common/configurationRegistry.js';
+import product from '../../product/common/product.js';
+import { Registry } from '../../registry/common/platform.js';
+import { AgentHostEnabledSettingId } from './agentService.js';
+
+// `chat.agentHost.enabled` is read in the desktop main process
+// (`src/vs/code/electron-main/app.ts`) to decide whether to spawn the agent
+// host, and in the renderer for various gating decisions. The remote server
+// does **not** consume this key — it spawns the agent host based on its own
+// `--agent-host-port` / `--agent-host-path` CLI args — so this registration
+// is intentionally not imported there.
+//
+// Side-effect imports of this file:
+//   - `src/vs/platform/agentHost/electron-main/electronAgentHostStarter.ts`
+//     (loaded transitively from `app.ts`).
+//   - `src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts`
+//     (renderer registration for the settings UI).
+
+const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
+configurationRegistry.registerConfiguration({
+	id: 'chatAgentHost',
+	title: nls.localize('chatAgentHostConfigurationTitle', "Chat Agent Host"),
+	type: 'object',
+	properties: {
+		[AgentHostEnabledSettingId]: {
+			type: 'boolean',
+			description: nls.localize('chat.agentHost.enabled', "When enabled, some agents run in a separate agent host process."),
+			default: !isWeb && product.quality !== 'stable',
+			tags: ['experimental', 'advanced'],
+		},
+	}
+});

--- a/src/vs/platform/agentHost/common/agentHostStarter.config.contribution.ts
+++ b/src/vs/platform/agentHost/common/agentHostStarter.config.contribution.ts
@@ -1,0 +1,87 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as nls from '../../../nls.js';
+import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../configuration/common/configurationRegistry.js';
+import product from '../../product/common/product.js';
+import { Registry } from '../../registry/common/platform.js';
+import {
+	AgentHostClaudeAgentSdkPathSettingId,
+	AgentHostOTelCaptureContentSettingId,
+	AgentHostOTelDbSpanExporterEnabledSettingId,
+	AgentHostOTelEnabledSettingId,
+	AgentHostOTelExporterTypeSettingId,
+	AgentHostOTelOtlpEndpointSettingId,
+	AgentHostOTelOutfileSettingId,
+} from './agentService.js';
+
+// Settings consumed by the agent host starter (`electronAgentHostStarter.ts`
+// and `nodeAgentHostStarter.ts`) to populate the spawned agent host process's
+// environment. The starter exists in both the desktop main process and the
+// remote server process, so this registration has to be visible to both —
+// each starter file side-effect-imports this contribution, which causes the
+// registration to run as soon as the starter module is loaded. The renderer
+// also imports this so the same defaults show up in the settings UI.
+//
+// Side-effect imports of this file:
+//   - `src/vs/platform/agentHost/electron-main/electronAgentHostStarter.ts`
+//     (main process, loaded transitively from `app.ts`).
+//   - `src/vs/platform/agentHost/node/nodeAgentHostStarter.ts`
+//     (remote server, loaded transitively from `serverServices.ts`).
+//   - `src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts`
+//     (renderer registration for the settings UI).
+
+const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
+configurationRegistry.registerConfiguration({
+	id: 'chatAgentHostStarter',
+	title: nls.localize('chatAgentHostStarterConfigurationTitle', "Chat Agent Host Starter"),
+	type: 'object',
+	properties: {
+		[AgentHostClaudeAgentSdkPathSettingId]: {
+			type: 'string',
+			description: nls.localize('chat.agentHost.claudeAgent.path', "Experimental, for local testing only. Absolute path to a locally-installed `@anthropic-ai/claude-agent-sdk` package. When set, the Claude agent provider is registered inside the agent host and the SDK is loaded from this path. Requires `#chat.agentHost.enabled#`. The agent host process must be restarted for changes to take effect. This setting will be removed once the SDK is delivered through the Extension Marketplace."),
+			default: '',
+			tags: ['experimental', 'advanced'],
+			included: product.quality !== 'stable',
+		},
+		[AgentHostOTelEnabledSettingId]: {
+			type: 'boolean',
+			markdownDescription: nls.localize('chat.agentHost.otel.enabled', "When enabled, the agent host emits OpenTelemetry traces from the Copilot SDK. Requires `#chat.agentHost.enabled#`. Either configure `#chat.agentHost.otel.otlpEndpoint#` to ship traces to an external collector or enable `#chat.agentHost.otel.dbSpanExporter.enabled#` to capture them locally."),
+			default: false,
+			tags: ['experimental', 'advanced'],
+		},
+		[AgentHostOTelExporterTypeSettingId]: {
+			type: 'string',
+			enum: ['otlp-http', 'otlp-grpc', 'console', 'file'],
+			markdownDescription: nls.localize('chat.agentHost.otel.exporterType', "Exporter backend used by the Copilot SDK when `#chat.agentHost.otel.enabled#` is on. `otlp-grpc` is downgraded to `otlp-http` transparently in the CLI runtime."),
+			default: 'otlp-http',
+			tags: ['experimental', 'advanced'],
+		},
+		[AgentHostOTelOtlpEndpointSettingId]: {
+			type: 'string',
+			markdownDescription: nls.localize('chat.agentHost.otel.otlpEndpoint', "OTLP endpoint URL when exporter type is `otlp-http` or `otlp-grpc`. Sets `OTEL_EXPORTER_OTLP_ENDPOINT` inside the agent host process."),
+			default: '',
+			tags: ['experimental', 'advanced'],
+		},
+		[AgentHostOTelCaptureContentSettingId]: {
+			type: 'boolean',
+			markdownDescription: nls.localize('chat.agentHost.otel.captureContent', "When enabled, includes prompt and response content in OTel span attributes. Sets `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`. Privacy-sensitive: do not enable in environments that ship spans to shared sinks."),
+			default: false,
+			tags: ['experimental', 'advanced'],
+		},
+		[AgentHostOTelOutfileSettingId]: {
+			type: 'string',
+			markdownDescription: nls.localize('chat.agentHost.otel.outfile', "Output path for span JSON lines when exporter type is `file`. Sets `COPILOT_OTEL_FILE_EXPORTER_PATH`."),
+			default: '',
+			tags: ['experimental', 'advanced'],
+		},
+		[AgentHostOTelDbSpanExporterEnabledSettingId]: {
+			type: 'boolean',
+			markdownDescription: nls.localize('chat.agentHost.otel.dbSpanExporter.enabled', "When enabled, the agent host persists every emitted OTel span to a local SQLite database. Spans can be inspected via the `Export Agent Host Traces Database` command. Compatible with external exporters: spans are written to SQLite *and* forwarded to the user-configured sink."),
+			default: false,
+			tags: ['experimental', 'advanced'],
+		},
+	}
+});

--- a/src/vs/platform/agentHost/electron-main/electronAgentHostStarter.ts
+++ b/src/vs/platform/agentHost/electron-main/electronAgentHostStarter.ts
@@ -21,14 +21,6 @@ import { UtilityProcess } from '../../utilityProcess/electron-main/utilityProces
 import { IAgentHostConnection, IAgentHostStarter } from '../common/agent.js';
 import { AgentHostClaudeAgentSdkPathSettingId, AgentHostClaudeSdkPathEnvVar, AgentHostOTelCaptureContentSettingId, AgentHostOTelDbSpanExporterEnabledSettingId, AgentHostOTelEnabledSettingId, AgentHostOTelExporterTypeSettingId, AgentHostOTelOtlpEndpointSettingId, AgentHostOTelOutfileSettingId, buildAgentHostOTelEnv } from '../common/agentService.js';
 import { deepClone } from '../../../base/common/objects.js';
-
-// Side-effect imports: register the workbench settings consumed in the main
-// process for agent host startup. `chat.agentHost.enabled` is read by
-// `src/vs/code/electron-main/app.ts` to decide whether to construct this
-// starter at all; the starter settings below (`chat.agentHost.claudeAgent.path`
-// and `chat.agentHost.otel.*`) are read by `start()` to populate env vars on
-// the spawned utility process. The registrations live with the consumer rather
-// than at the process entry so it's discoverable from this file.
 import '../common/agentHost.config.contribution.js';
 import '../common/agentHostStarter.config.contribution.js';
 

--- a/src/vs/platform/agentHost/electron-main/electronAgentHostStarter.ts
+++ b/src/vs/platform/agentHost/electron-main/electronAgentHostStarter.ts
@@ -22,6 +22,16 @@ import { IAgentHostConnection, IAgentHostStarter } from '../common/agent.js';
 import { AgentHostClaudeAgentSdkPathSettingId, AgentHostClaudeSdkPathEnvVar, AgentHostOTelCaptureContentSettingId, AgentHostOTelDbSpanExporterEnabledSettingId, AgentHostOTelEnabledSettingId, AgentHostOTelExporterTypeSettingId, AgentHostOTelOtlpEndpointSettingId, AgentHostOTelOutfileSettingId, buildAgentHostOTelEnv } from '../common/agentService.js';
 import { deepClone } from '../../../base/common/objects.js';
 
+// Side-effect imports: register the workbench settings consumed in the main
+// process for agent host startup. `chat.agentHost.enabled` is read by
+// `src/vs/code/electron-main/app.ts` to decide whether to construct this
+// starter at all; the starter settings below (`chat.agentHost.claudeAgent.path`
+// and `chat.agentHost.otel.*`) are read by `start()` to populate env vars on
+// the spawned utility process. The registrations live with the consumer rather
+// than at the process entry so it's discoverable from this file.
+import '../common/agentHost.config.contribution.js';
+import '../common/agentHostStarter.config.contribution.js';
+
 export class ElectronAgentHostStarter extends Disposable implements IAgentHostStarter {
 
 	private utilityProcess: UtilityProcess | undefined = undefined;

--- a/src/vs/platform/agentHost/node/nodeAgentHostStarter.ts
+++ b/src/vs/platform/agentHost/node/nodeAgentHostStarter.ts
@@ -14,12 +14,6 @@ import { ILogService } from '../../log/common/log.js';
 import { getResolvedShellEnv } from '../../shell/node/shellEnv.js';
 import { IAgentHostConnection, IAgentHostStarter } from '../common/agent.js';
 import { AgentHostClaudeAgentSdkPathSettingId, AgentHostClaudeSdkPathEnvVar, AgentHostOTelCaptureContentSettingId, AgentHostOTelDbSpanExporterEnabledSettingId, AgentHostOTelEnabledSettingId, AgentHostOTelExporterTypeSettingId, AgentHostOTelOtlpEndpointSettingId, AgentHostOTelOutfileSettingId, buildAgentHostOTelEnv } from '../common/agentService.js';
-
-// Side-effect import: registers the workbench settings consumed by `start()`
-// below (`chat.agentHost.claudeAgent.path` and `chat.agentHost.otel.*`) so
-// that `IConfigurationService.getValue()` returns their declared defaults in
-// the remote server process. The registration lives with the consumer rather
-// than at the server entry point so it's discoverable from this file.
 import '../common/agentHostStarter.config.contribution.js';
 
 /**

--- a/src/vs/platform/agentHost/node/nodeAgentHostStarter.ts
+++ b/src/vs/platform/agentHost/node/nodeAgentHostStarter.ts
@@ -15,6 +15,13 @@ import { getResolvedShellEnv } from '../../shell/node/shellEnv.js';
 import { IAgentHostConnection, IAgentHostStarter } from '../common/agent.js';
 import { AgentHostClaudeAgentSdkPathSettingId, AgentHostClaudeSdkPathEnvVar, AgentHostOTelCaptureContentSettingId, AgentHostOTelDbSpanExporterEnabledSettingId, AgentHostOTelEnabledSettingId, AgentHostOTelExporterTypeSettingId, AgentHostOTelOtlpEndpointSettingId, AgentHostOTelOutfileSettingId, buildAgentHostOTelEnv } from '../common/agentService.js';
 
+// Side-effect import: registers the workbench settings consumed by `start()`
+// below (`chat.agentHost.claudeAgent.path` and `chat.agentHost.otel.*`) so
+// that `IConfigurationService.getValue()` returns their declared defaults in
+// the remote server process. The registration lives with the consumer rather
+// than at the server entry point so it's discoverable from this file.
+import '../common/agentHostStarter.config.contribution.js';
+
 /**
  * Options for configuring the agent host WebSocket server in the child process.
  * When set, the agent host exposes a WebSocket endpoint for external clients.

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -7,9 +7,11 @@ import { Event } from '../../../../base/common/event.js';
 import { Disposable, DisposableMap, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { autorun, observableFromEvent } from '../../../../base/common/observable.js';
-import { isMacintosh, isWeb } from '../../../../base/common/platform.js';
+import { isMacintosh } from '../../../../base/common/platform.js';
 import { PolicyCategory } from '../../../../base/common/policy.js';
-import { AgentHostAhpJsonlLoggingSettingId, AgentHostClaudeAgentSdkPathSettingId, AgentHostCustomTerminalToolEnabledSettingId, AgentHostEnabledSettingId, AgentHostIpcLoggingSettingId, AgentHostOTelCaptureContentSettingId, AgentHostOTelDbSpanExporterEnabledSettingId, AgentHostOTelEnabledSettingId, AgentHostOTelExporterTypeSettingId, AgentHostOTelOtlpEndpointSettingId, AgentHostOTelOutfileSettingId } from '../../../../platform/agentHost/common/agentService.js';
+import '../../../../platform/agentHost/common/agentHost.config.contribution.js';
+import '../../../../platform/agentHost/common/agentHostStarter.config.contribution.js';
+import { AgentHostAhpJsonlLoggingSettingId, AgentHostCustomTerminalToolEnabledSettingId, AgentHostIpcLoggingSettingId } from '../../../../platform/agentHost/common/agentService.js';
 import { AgentNetworkFilterService, IAgentNetworkFilterService } from '../../../../platform/networkFilter/common/networkFilterService.js';
 import { AgentNetworkDomainSettingId } from '../../../../platform/networkFilter/common/settings.js';
 import { AgentSandboxEnabledValue, AgentSandboxSettingId } from '../../../../platform/sandbox/common/settings.js';
@@ -983,19 +985,6 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.newSession.defaultMode', "The default mode for new chat sessions. When empty, the chat view's default mode is used."),
 			default: '',
 		},
-		[AgentHostEnabledSettingId]: {
-			type: 'boolean',
-			description: nls.localize('chat.agentHost.enabled', "When enabled, some agents run in a separate agent host process."),
-			default: !isWeb && product.quality !== 'stable',
-			tags: ['experimental', 'advanced'],
-		},
-		[AgentHostClaudeAgentSdkPathSettingId]: {
-			type: 'string',
-			description: nls.localize('chat.agentHost.claudeAgent.path', "Experimental, for local testing only. Absolute path to a locally-installed `@anthropic-ai/claude-agent-sdk` package. When set, the Claude agent provider is registered inside the agent host and the SDK is loaded from this path. Requires `#chat.agentHost.enabled#`. The agent host process must be restarted for changes to take effect. This setting will be removed once the SDK is delivered through the Extension Marketplace."),
-			default: '',
-			tags: ['experimental', 'advanced'],
-			included: product.quality !== 'stable',
-		},
 		[AgentHostIpcLoggingSettingId]: {
 			type: 'boolean',
 			description: nls.localize('chat.agentHost.ipcLogging', "When enabled, logs all IPC traffic for each agent host to a dedicated output channel."),
@@ -1011,43 +1000,6 @@ configurationRegistry.registerConfiguration({
 		[AgentHostCustomTerminalToolEnabledSettingId]: {
 			type: 'boolean',
 			description: nls.localize('chat.agentHost.customTerminalTool.enabled', "When enabled, Copilot SDK sessions use the Agent Host terminal tool override instead of the SDK's default terminal behavior."),
-			default: false,
-			tags: ['experimental', 'advanced'],
-		},
-		[AgentHostOTelEnabledSettingId]: {
-			type: 'boolean',
-			markdownDescription: nls.localize('chat.agentHost.otel.enabled', "When enabled, the agent host emits OpenTelemetry traces from the Copilot SDK. Requires `#chat.agentHost.enabled#`. Either configure `#chat.agentHost.otel.otlpEndpoint#` to ship traces to an external collector or enable `#chat.agentHost.otel.dbSpanExporter.enabled#` to capture them locally."),
-			default: false,
-			tags: ['experimental', 'advanced'],
-		},
-		[AgentHostOTelExporterTypeSettingId]: {
-			type: 'string',
-			enum: ['otlp-http', 'otlp-grpc', 'console', 'file'],
-			markdownDescription: nls.localize('chat.agentHost.otel.exporterType', "Exporter backend used by the Copilot SDK when `#chat.agentHost.otel.enabled#` is on. `otlp-grpc` is downgraded to `otlp-http` transparently in the CLI runtime."),
-			default: 'otlp-http',
-			tags: ['experimental', 'advanced'],
-		},
-		[AgentHostOTelOtlpEndpointSettingId]: {
-			type: 'string',
-			markdownDescription: nls.localize('chat.agentHost.otel.otlpEndpoint', "OTLP endpoint URL when exporter type is `otlp-http` or `otlp-grpc`. Sets `OTEL_EXPORTER_OTLP_ENDPOINT` inside the agent host process."),
-			default: '',
-			tags: ['experimental', 'advanced'],
-		},
-		[AgentHostOTelCaptureContentSettingId]: {
-			type: 'boolean',
-			markdownDescription: nls.localize('chat.agentHost.otel.captureContent', "When enabled, includes prompt and response content in OTel span attributes. Sets `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`. Privacy-sensitive: do not enable in environments that ship spans to shared sinks."),
-			default: false,
-			tags: ['experimental', 'advanced'],
-		},
-		[AgentHostOTelOutfileSettingId]: {
-			type: 'string',
-			markdownDescription: nls.localize('chat.agentHost.otel.outfile', "Output path for span JSON lines when exporter type is `file`. Sets `COPILOT_OTEL_FILE_EXPORTER_PATH`."),
-			default: '',
-			tags: ['experimental', 'advanced'],
-		},
-		[AgentHostOTelDbSpanExporterEnabledSettingId]: {
-			type: 'boolean',
-			markdownDescription: nls.localize('chat.agentHost.otel.dbSpanExporter.enabled', "When enabled, the agent host persists every emitted OTel span to a local SQLite database. Spans can be inspected via the `Export Agent Host Traces Database` command. Compatible with external exporters: spans are written to SQLite *and* forwarded to the user-configured sink."),
 			default: false,
 			tags: ['experimental', 'advanced'],
 		},


### PR DESCRIPTION
## Problem

The `chat.agentHost.*` settings were only registered in `chat.shared.contribution.ts` (renderer). Several of them are read in non-renderer processes:

- **Desktop main process** — `src/vs/code/electron-main/app.ts` reads `chat.agentHost.enabled` via `isAgentHostEnabled()` to decide whether to spawn the agent host. Without the registration in this process, `getValue()` returned `undefined` and the declared default (`!isWeb && product.quality !== 'stable'`) was silently ignored.
- **Electron-main and remote-server agent host starters** — both read `chat.agentHost.claudeAgent.path` and the six `chat.agentHost.otel.*` settings to populate env vars on the spawned agent host process. Same issue: `undefined` everywhere, defaults ignored.

## Approach

Two platform-level contribution files, each imported only by code that consumes those keys:

- **`agentHost.config.contribution.ts`** — registers `chat.agentHost.enabled`. Side-effect-imported from `electronAgentHostStarter.ts` so it's picked up transitively from `app.ts`. The remote server does **not** consume `enabled` (it spawns the agent host based on `--agent-host-port` / `--agent-host-path` CLI args), so the server's registry intentionally stays empty for it — an accidental future read will fail loudly rather than silently picking up a workbench default.

- **`agentHostStarter.config.contribution.ts`** — registers the seven starter-consumed settings (`claudeAgent.path` + 6 `otel.*`). Side-effect-imported by both starter files (`electronAgentHostStarter.ts` and `nodeAgentHostStarter.ts`) so the registration travels with the consumer and is discoverable from either end.

Both files are also side-effect-imported from `chat.shared.contribution.ts` so the renderer settings UI still shows every key.

The three renderer-only keys (`ipcLogging`, `ahpJsonl`, `customTerminalTool`) stay inline in `chat.shared.contribution.ts` — they have no consumers outside the renderer, so registering them elsewhere would only pollute those processes' registries.

## Agent host process check

Verified that the agent host process itself does **not** read `chat.agentHost.*` via the workbench `IConfigurationService`. The starters translate settings into env vars (`buildAgentHostOTelEnv`, `VSCODE_AGENT_HOST_CLAUDE_SDK_PATH`) which the agent host reads on startup, and runtime knobs flow through the agent host's own root/session config service — a separate abstraction from workbench settings.

## Validation

- `npm run compile-check-ts-native` — clean.
- `npm run valid-layers-check` — clean.