### PR TITLE
launch: simple file dialog, monaco-paste helper, parallel session pattern

### DIFF
--- a/.agents/skills/launch/SKILL.md
+++ b/.agents/skills/launch/SKILL.md
@@ -203,7 +203,7 @@ npx @playwright/cli -s=$PW_SESSION attach --cdp=http://127.0.0.1:$CDP
 "$PASTE" "prompt for B"
 ```
 
-Each agent gets its own `cliDaemon` bound to its own CDP, so the pastes / clicks / snapshots don't cross-contaminate. Verified live with two concurrent instances. **Macros-Mach-ports caveat:** on macOS, beyond ~2–3 concurrent Code OSS instances Crashpad's exception handler tends to die with `mach_port_request_notification: invalid capability`. That's a separate, OS-level limit; it's not affected by the session name.
+Each agent gets its own `cliDaemon` bound to its own CDP, so the pastes / clicks / snapshots don't cross-contaminate. Verified live with two concurrent instances. **macOS Mach-ports caveat:** on macOS, beyond ~2–3 concurrent Code OSS instances Crashpad's exception handler tends to die with `mach_port_request_notification: invalid capability`. That's a separate, OS-level limit; it's not affected by the session name.
 
 > **Cleanup for `cliDaemon` processes:** stop your session's daemon with `npx @playwright/cli -s=$PW_SESSION close`, or nuke all stale daemons (after killing all the Code OSS windows) with `npx @playwright/cli kill-all`. Session daemons live under `~/Library/Caches/ms-playwright/daemon/<hash>/`.
 

--- a/.agents/skills/launch/SKILL.md
+++ b/.agents/skills/launch/SKILL.md
@@ -27,6 +27,8 @@ The clone is **slim**: workspace storage, browser caches, file history, cached V
 
 > The launcher **copies** the source profile to a temp dir and never mutates the original. Each launch gets its own isolated `--user-data-dir` and `--extensions-dir`.
 
+> The launcher always sets `files.simpleDialog.enable: true` in the launched profile's `User/settings.json`. This is required for automation: VS Code's native OS file dialogs cannot be driven via `@playwright/cli` over CDP and are completely unreachable over SSH on headless macOS. The simple (quick-input) dialog can be navigated with `press` and clipboard paste. The override is per-launch and only affects throwaway profiles.
+
 ## Launch
 
 The launcher script lives next to this SKILL.md at `scripts/launch.sh`. Resolve it relative to wherever this skill file is installed - do not hardcode an absolute path.
@@ -92,55 +94,118 @@ PID=$(jq -r .pid            <<<"$INFO")
 
 Use the dynamic `cdpPort` from the launch JSON. The normal loop is: attach, confirm the target, snapshot, interact, then re-snapshot after meaningful UI changes.
 
+> **Always pick a unique `PW_SESSION` name and pass it as `-s=$PW_SESSION`** on every `npx @playwright/cli ...` call. The CLI is backed by a persistent daemon (`cliDaemon.js`) keyed by session name; if two shells both omit `-s=`, they share the implicit `"default"` session and the most-recently-attached CDP "wins" for every subsequent command from either shell. The launch skill is built around isolation (per-instance UDD, ports, shared-data-dir), and this pattern keeps that isolation intact at the Playwright-driving layer too. **A note on the alternative `PLAYWRIGHT_CLI_SESSION` env var:** it's documented in the package README and works correctly for `open`-style workflows, but it interacts poorly with `attach --cdp=...` (the daemon ends up with both `--cdp=...` and `--endpoint=<env-value>`, and the latter wins, causing a `connect ENOENT` failure). Confirmed against `@playwright/cli@0.1.13`. Explicit `-s=NAME` works in all modes.
+
 ```bash
+# At the top of your script / subagent prompt:
+PW_SESSION="my-uniq-$$"        # any unique string; $$ is fine for one shell per agent
+
 # launch.sh blocks until CDP is ready, so a single attach is enough.
-npx @playwright/cli attach --cdp=http://127.0.0.1:$CDP
-npx @playwright/cli tab-list
-npx @playwright/cli snapshot
+npx @playwright/cli -s=$PW_SESSION attach --cdp=http://127.0.0.1:$CDP
+npx @playwright/cli -s=$PW_SESSION tab-list
+npx @playwright/cli -s=$PW_SESSION snapshot
 ```
 
-After `attach`, later `@playwright/cli` commands keep using the connected app until you close or reattach.
+After `attach`, later `@playwright/cli` commands keep using the connected app until you close or reattach — as long as you keep passing the same `-s=$PW_SESSION`.
 
 ### Selecting the right Electron target
 
 Electron apps can expose multiple windows or webviews. If `tab-list` shows `about:blank`, a webview, or otherwise the wrong target, switch targets before interacting:
 
 ```bash
-npx @playwright/cli tab-list
-npx @playwright/cli tab-select 2
-npx @playwright/cli snapshot
+npx @playwright/cli -s=$PW_SESSION tab-list
+npx @playwright/cli -s=$PW_SESSION tab-select 2
+npx @playwright/cli -s=$PW_SESSION snapshot
 ```
 
-If a target looks stale after relaunching, run `npx @playwright/cli close`, attach again with `$CDP`, and re-check `tab-list`.
+If a target looks stale after relaunching, run `npx @playwright/cli -s=$PW_SESSION close`, attach again with `$CDP`, and re-check `tab-list`.
 
 ### Focusing the chat input (works on Code OSS, including the Agents window)
 
 ```bash
 # macOS
-npx @playwright/cli press Control+Meta+i
+npx @playwright/cli -s=$PW_SESSION press Control+Meta+i
 # Linux / Windows
-npx @playwright/cli press Control+Alt+i
+npx @playwright/cli -s=$PW_SESSION press Control+Alt+i
 ```
 
 ### Typing into Monaco (chat input, editors)
 
-`fill` and `type` **silently fail** on Code OSS. Prefer focus-via-shortcut plus either per-key `press` or clipboard paste, and verify text when the scenario depends on the exact prompt.
+`fill` and `type` **silently fail** on Code OSS — Monaco's `native-edit-context` element doesn't react to Playwright's default input pipeline. Use one of these alternatives:
 
-- **Per-key `press`** (universal but slow):
+- **`scripts/monaco-paste.sh` helper** (recommended — fast, no system clipboard, parallel-safe). Reads text from a positional arg or stdin and dispatches a `ClipboardEvent('paste')` with a `DataTransfer` payload into the focused chat-input Monaco editor. Honors `--session NAME` or `$PW_SESSION` env so it stays inside the same `-s=` session as everything else.
+
   ```bash
-  npx @playwright/cli press H
-  npx @playwright/cli press i
-  npx @playwright/cli press Enter
+  LAUNCH_DIR=<dir-of-this-SKILL.md>           # the same dir that holds scripts/launch.sh
+  PASTE="$LAUNCH_DIR/scripts/monaco-paste.sh"
+  export PW_SESSION                            # helper reads this env var
+
+  # Send a prompt:
+  npx @playwright/cli -s=$PW_SESSION press Control+Meta+i  # focus chat input
+  "$PASTE" 'Please run `pwd && ls` using your terminal tool.'
+  npx @playwright/cli -s=$PW_SESSION press Enter
+
+  # Long / arbitrary text via stdin (avoids any shell-quoting headaches):
+  printf 'multi-line prompt\nwith backticks `x`\nand emoji 🎉' | "$PASTE"
+
+  # Append without clearing:
+  "$PASTE" --append " continued text"
+
+  # Skip the read-back check (useful when intentionally pasting more than the
+  # chat input's ~600-character soft cap):
+  "$PASTE" --no-verify "...long text..."
+
+  # Or pass the session explicitly per call (if you don't want to export PW_SESSION):
+  "$PASTE" --session "$PW_SESSION" "..."
   ```
-- **Clipboard paste** (fast, macOS):
+
+  The helper prints a single JSON line on stdout: `{ok, actualLength, expectedLength, viewLineCount, firstViewLine, error?}`. Exit 0 on success, 1 on verify failure, 2 on argument errors. Tested reliable across 20+ sequential pastes including unicode (中文), emoji (🎉), backticks, ampersands, embedded quotes, and newlines.
+
+  **Why a helper script and not just docs:** the inline recipe involves a multi-line `node -e` heredoc with embedded JS template literals, which is exactly the kind of code that gets miscopied. There are also three non-obvious correctness traps the helper handles internally:
+  1. Monaco's `native-edit-context` doesn't react to `fill` or `type`, only to actual paste events (or per-key `press`).
+  2. Monaco renders ASCII spaces as U+00A0 (NBSP) in the view-line DOM, so verification has to normalize before comparing.
+  3. Monaco updates its DOM **asynchronously** after a paste event — a synchronous read-back inside the same `eval` returns stale state. The helper waits two `requestAnimationFrame` ticks before reading.
+
+- **Per-key `press`** (universal but slow — each press is a separate CLI invocation with Node startup cost):
+  ```bash
+  npx @playwright/cli -s=$PW_SESSION press H
+  npx @playwright/cli -s=$PW_SESSION press i
+  npx @playwright/cli -s=$PW_SESSION press Enter
+  ```
+
+- **Clipboard paste via `pbcopy`** (fast on macOS, **but `NSPasteboard` is system-wide so any concurrent shell that touches the pasteboard will collide**). Only use when nothing else on the machine is using the clipboard for the duration of the paste.
   ```bash
   printf '%s' "Your prompt here" | pbcopy
-  npx @playwright/cli press Control+Meta+i   # focus chat input
-  npx @playwright/cli press Meta+v           # paste
-  npx @playwright/cli press Enter
+  npx @playwright/cli -s=$PW_SESSION press Control+Meta+i
+  npx @playwright/cli -s=$PW_SESSION press Meta+v
+  npx @playwright/cli -s=$PW_SESSION press Enter
   ```
 
 The focus shortcut should leave `document.activeElement` on VS Code's `native-edit-context` editing surface. That is a useful sanity check when key presses appear to do nothing.
+
+### Parallel multi-instance pattern
+
+Because the launch skill is built around isolation, the natural workload is **many agents on one machine, each driving their own Code OSS**. The pattern boils down to giving each agent a unique `PW_SESSION` and passing it everywhere:
+
+```bash
+# In agent A's shell:
+PW_SESSION="agent-A-$$"
+INFO=$("$LAUNCH" --agents -- --use-mock-keychain | tail -n1)
+CDP=$(jq -r .cdpPort <<<"$INFO")
+npx @playwright/cli -s=$PW_SESSION attach --cdp=http://127.0.0.1:$CDP
+"$PASTE" "prompt for A"   # helper picks up $PW_SESSION
+
+# In agent B's shell (running concurrently):
+PW_SESSION="agent-B-$$"
+INFO=$("$LAUNCH" --agents -- --use-mock-keychain | tail -n1)
+CDP=$(jq -r .cdpPort <<<"$INFO")
+npx @playwright/cli -s=$PW_SESSION attach --cdp=http://127.0.0.1:$CDP
+"$PASTE" "prompt for B"
+```
+
+Each agent gets its own `cliDaemon` bound to its own CDP, so the pastes / clicks / snapshots don't cross-contaminate. Verified live with two concurrent instances. **Macros-Mach-ports caveat:** on macOS, beyond ~2–3 concurrent Code OSS instances Crashpad's exception handler tends to die with `mach_port_request_notification: invalid capability`. That's a separate, OS-level limit; it's not affected by the session name.
+
+> **Cleanup for `cliDaemon` processes:** stop your session's daemon with `npx @playwright/cli -s=$PW_SESSION close`, or nuke all stale daemons (after killing all the Code OSS windows) with `npx @playwright/cli kill-all`. Session daemons live under `~/Library/Caches/ms-playwright/daemon/<hash>/`.
 
 ### Agents window selector differences
 
@@ -162,7 +227,7 @@ The `Control+Meta+i` / `Control+Alt+i` focus shortcut still works; only the DOM 
 For the regular workbench sidebar, this confirms that text landed in the Monaco input:
 
 ```bash
-npx @playwright/cli eval '
+npx @playwright/cli -s=$PW_SESSION eval '
 (() => {
   const sidebar = document.querySelector(".part.auxiliarybar");
   const viewLines = sidebar?.querySelectorAll(".interactive-input-editor .view-line") ?? [];
@@ -176,10 +241,10 @@ To clear the focused Monaco input:
 
 ```bash
 # macOS
-npx @playwright/cli press Meta+a
+npx @playwright/cli -s=$PW_SESSION press Meta+a
 # Linux / Windows
-npx @playwright/cli press Control+a
-npx @playwright/cli press Backspace
+npx @playwright/cli -s=$PW_SESSION press Control+a
+npx @playwright/cli -s=$PW_SESSION press Backspace
 ```
 
 If the keyboard shortcut cannot focus chat because the surface is not available yet, take a snapshot and navigate the UI into a state where chat exists before retrying. Avoid treating completed CLI commands as proof that text was entered.
@@ -189,7 +254,7 @@ If the keyboard shortcut cannot focus chat because the surface is not available 
 ```bash
 SHOTS="$PWD/screenshots/$(date +%Y-%m-%dT%H-%M-%S)"
 mkdir -p "$SHOTS"
-npx @playwright/cli screenshot --filename="$SHOTS/after-launch.png"
+npx @playwright/cli -s=$PW_SESSION screenshot --filename="$SHOTS/after-launch.png"
 ```
 
 > Keep screenshots inside the workspace, not `/tmp`, so they survive for review.
@@ -197,8 +262,8 @@ npx @playwright/cli screenshot --filename="$SHOTS/after-launch.png"
 For wide windows, `--full-page` can make layout easier to inspect, and element screenshots are useful when a snapshot gives a stable ref for the panel you care about:
 
 ```bash
-npx @playwright/cli screenshot --full-page --filename="$SHOTS/full-window.png"
-npx @playwright/cli screenshot e42 --filename="$SHOTS/panel.png"
+npx @playwright/cli -s=$PW_SESSION screenshot --full-page --filename="$SHOTS/full-window.png"
+npx @playwright/cli -s=$PW_SESSION screenshot e42 --filename="$SHOTS/panel.png"
 ```
 
 On macOS, a screenshot "Permission denied" failure usually means the terminal lacks Screen Recording permission. Use text/state verification while resolving that permission issue.
@@ -231,9 +296,9 @@ kill "$PID" 2>/dev/null || true
 INFO=$("$LAUNCH" | tail -n1)
 CDP=$(jq -r .cdpPort <<<"$INFO")
 PID=$(jq -r .pid <<<"$INFO")
-npx @playwright/cli attach --cdp=http://127.0.0.1:$CDP
-npx @playwright/cli tab-list
-npx @playwright/cli snapshot
+npx @playwright/cli -s=$PW_SESSION attach --cdp=http://127.0.0.1:$CDP
+npx @playwright/cli -s=$PW_SESSION tab-list
+npx @playwright/cli -s=$PW_SESSION snapshot
 ```
 
 If you are iterating frequently, keep the repo build/watch task running separately so relaunches pick up already-generated output.
@@ -243,8 +308,11 @@ If you are iterating frequently, keep the repo build/watch task running separate
 The launcher writes everything under a temp `runDir` (printed in the JSON). When you're done:
 
 ```bash
-# Disconnect playwright
-npx @playwright/cli close
+# Disconnect this session's playwright daemon (leaves other sessions' daemons alone)
+npx @playwright/cli -s=$PW_SESSION close
+
+# Or nuke any stale daemons left behind by crashed callers across all sessions:
+# npx @playwright/cli kill-all
 
 # Kill the Code OSS instance
 kill "$PID" 2>/dev/null || true

--- a/.agents/skills/launch/scripts/launch.sh
+++ b/.agents/skills/launch/scripts/launch.sh
@@ -120,6 +120,30 @@ if [[ "$FULL" != "1" && "$CLONE_EXTENSIONS" == "1" ]]; then
 	rsync -a "$SOURCE_UDD/extensions/" "$EXT_DIR/"
 fi
 
+# Force the simple (quick-input) file dialog so automation can drive
+# "Open Folder" / workspace pickers. The native OS file dialog cannot be
+# controlled by @playwright/cli over CDP (and is completely unreachable
+# over SSH on headless macOS). The setting overlay is per-launch and
+# always applied because every launched instance under this skill is
+# a throwaway used for automation.
+SETTINGS_FILE="$DEST_UDD/User/settings.json"
+mkdir -p "$(dirname "$SETTINGS_FILE")"
+node - "$SETTINGS_FILE" <<'NODE' || true
+const fs = require('fs');
+const f = process.argv[2];
+let txt = '';
+try { txt = fs.readFileSync(f, 'utf8'); } catch { /* file missing - fine */ }
+// VS Code settings.json is JSONC. Strip line + block comments before parsing.
+const stripped = txt
+	.replace(/\/\*[\s\S]*?\*\//g, '')
+	.replace(/(^|[^:"'])\/\/[^\n]*/g, '$1');
+let settings = {};
+try { settings = JSON.parse(stripped || '{}') || {}; } catch { settings = {}; }
+settings['files.simpleDialog.enable'] = true;
+fs.writeFileSync(f, JSON.stringify(settings, null, 2));
+console.error('[launch.sh] forced files.simpleDialog.enable=true in ' + f);
+NODE
+
 # Strip ELECTRON_RUN_AS_NODE, commonly inherited from VS Code's integrated
 # terminal / agent runtimes; it breaks ./scripts/code.sh.
 unset ELECTRON_RUN_AS_NODE

--- a/.agents/skills/launch/scripts/launch.sh
+++ b/.agents/skills/launch/scripts/launch.sh
@@ -128,21 +128,70 @@ fi
 # a throwaway used for automation.
 SETTINGS_FILE="$DEST_UDD/User/settings.json"
 mkdir -p "$(dirname "$SETTINGS_FILE")"
-node - "$SETTINGS_FILE" <<'NODE' || true
+# Data-preserving text-based merge: insert/update `files.simpleDialog.enable`
+# without reparsing the whole file. Avoids dropping user comments and
+# string values containing `//` (e.g. URLs). Fails loudly if the file
+# exists but has no recognizable JSON object shape — never silently
+# overwrites with `{}`.
+if ! node - "$SETTINGS_FILE" <<'NODE'
 const fs = require('fs');
 const f = process.argv[2];
-let txt = '';
-try { txt = fs.readFileSync(f, 'utf8'); } catch { /* file missing - fine */ }
-// VS Code settings.json is JSONC. Strip line + block comments before parsing.
-const stripped = txt
+const KEY = 'files.simpleDialog.enable';
+
+let text;
+try { text = fs.readFileSync(f, 'utf8'); }
+catch (e) {
+	if (e.code === 'ENOENT') text = '';
+	else { console.error('[launch.sh] cannot read ' + f + ': ' + e.message); process.exit(1); }
+}
+
+// Empty file → write a fresh object.
+if (text.trim() === '') {
+	fs.writeFileSync(f, '{\n  "' + KEY + '": true\n}\n');
+	process.exit(0);
+}
+
+// Key already present (with any value) → update its value to `true`
+// via a targeted regex on the value slot only.
+const keyValueRe = new RegExp('("' + KEY.replace(/\./g, '\\.') + '"\\s*:\\s*)(true|false|null|"[^"\\n]*"|-?\\d+(?:\\.\\d+)?)', 'g');
+if (keyValueRe.test(text)) {
+	const updated = text.replace(keyValueRe, '$1true');
+	fs.writeFileSync(f, updated);
+	process.exit(0);
+}
+
+// Otherwise: find the LAST `}` and insert the new key before it.
+// We deliberately don't parse JSONC — this preserves comments and
+// any other content the source profile had.
+const lastBrace = text.lastIndexOf('}');
+if (lastBrace === -1) {
+	console.error('[launch.sh] settings.json has no closing brace — refusing to clobber it: ' + f);
+	process.exit(1);
+}
+
+// Decide whether to add a leading comma. If the only thing between the
+// first `{` and the last `}` is whitespace and comments, the object is
+// empty for our purposes and no comma is needed.
+const firstBrace = text.indexOf('{');
+if (firstBrace === -1 || firstBrace >= lastBrace) {
+	console.error('[launch.sh] settings.json has no opening brace — refusing to clobber it: ' + f);
+	process.exit(1);
+}
+const between = text.slice(firstBrace + 1, lastBrace)
 	.replace(/\/\*[\s\S]*?\*\//g, '')
-	.replace(/(^|[^:"'])\/\/[^\n]*/g, '$1');
-let settings = {};
-try { settings = JSON.parse(stripped || '{}') || {}; } catch { settings = {}; }
-settings['files.simpleDialog.enable'] = true;
-fs.writeFileSync(f, JSON.stringify(settings, null, 2));
-console.error('[launch.sh] forced files.simpleDialog.enable=true in ' + f);
+	.replace(/\/\/[^\n]*/g, '')
+	.trim();
+const insertion = between.length === 0
+	? '\n  "' + KEY + '": true\n'
+	: ',\n  "' + KEY + '": true\n';
+
+fs.writeFileSync(f, text.slice(0, lastBrace) + insertion + text.slice(lastBrace));
 NODE
+then
+	echo "[launch.sh] failed to ensure files.simpleDialog.enable=true in $SETTINGS_FILE — automation may need to fall back to per-key input" >&2
+	exit 1
+fi
+echo "[launch.sh] ensured files.simpleDialog.enable=true in $SETTINGS_FILE" >&2
 
 # Strip ELECTRON_RUN_AS_NODE, commonly inherited from VS Code's integrated
 # terminal / agent runtimes; it breaks ./scripts/code.sh.

--- a/.agents/skills/launch/scripts/monaco-paste.sh
+++ b/.agents/skills/launch/scripts/monaco-paste.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# monaco-paste.sh — insert text into the Code OSS chat input (Monaco) via
+# the currently-attached @playwright/cli connection. Synthesizes a
+# ClipboardEvent('paste') with a DataTransfer payload — no system
+# clipboard involved, so safe to use against multiple parallel Code OSS
+# instances (each subagent's @playwright/cli attaches to its own CDP).
+#
+# Why this exists: VS Code Monaco's `native-edit-context` element doesn't
+# react to `@playwright/cli`'s `fill` or `type`. The pbcopy+press alternative
+# works for one instance but `pbcopy` writes the system-wide NSPasteboard,
+# so two parallel callers can stomp each other's clipboards.
+#
+# Usage:
+#   echo "the prompt text" | scripts/monaco-paste.sh
+#   scripts/monaco-paste.sh "the prompt text"
+#   scripts/monaco-paste.sh --append "additional text"   # don't clear first
+#   scripts/monaco-paste.sh --no-verify "..."            # skip read-back check
+#   scripts/monaco-paste.sh --session NAME "..."         # use a named @playwright/cli session
+#                                                        # (also honored via $PW_SESSION env var;
+#                                                        #  required for parallel multi-instance runs
+#                                                        #  — see SKILL.md "Typing into Monaco")
+#
+# Stdout: a single JSON line, e.g.
+#   {"ok":true,"actualLength":47,"expectedLength":47,"viewLineCount":1,"firstViewLine":"..."}
+# Stderr: diagnostic noise from @playwright/cli (suppressed unless caller wants it).
+# Exit code: 0 on success, 1 on failure.
+#
+# Assumes:
+#   - You have already run `npx @playwright/cli [-s=NAME] attach --cdp=http://127.0.0.1:$CDP`
+#     in the same session this script reads (--session arg, $PW_SESSION env, or "default").
+#   - The Agents window is open and a new-chat / chat view with a Monaco
+#     editor is on screen. The script auto-focuses the first
+#     `.new-chat-input-area .native-edit-context`, falling back to any
+#     `.native-edit-context`.
+
+set -u
+umask 077
+
+APPEND=0
+VERIFY=1
+TEXT_ARG=""
+PW_SESSION_OVERRIDE=""
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--append) APPEND=1; shift ;;
+		--no-verify) VERIFY=0; shift ;;
+		--session) PW_SESSION_OVERRIDE="$2"; shift 2 ;;
+		--session=*) PW_SESSION_OVERRIDE="${1#--session=}"; shift ;;
+		-h|--help)
+			sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
+			exit 0 ;;
+		--) shift; TEXT_ARG="${*-}"; break ;;
+		-*) echo "monaco-paste.sh: unknown flag $1" >&2; exit 2 ;;
+		*) TEXT_ARG="$1"; shift ;;
+	esac
+done
+
+# Resolve session: --session arg wins, then $PW_SESSION, then empty (cli default).
+SESSION="${PW_SESSION_OVERRIDE:-${PW_SESSION:-}}"
+PW_ARGS=()
+[[ -n "$SESSION" ]] && PW_ARGS=("-s=$SESSION")
+
+# Text: prefer the positional arg; otherwise read all of stdin.
+# Stdin is preferred for arbitrary text because it avoids any shell
+# quoting issues with backticks, $, ", newlines, etc.
+if [[ -n "${TEXT_ARG:-}" ]]; then
+	TEXT="$TEXT_ARG"
+else
+	TEXT=$(cat)
+fi
+
+if [[ -z "$TEXT" ]]; then
+	echo '{"ok":false,"error":"empty input"}' >&2
+	exit 2
+fi
+
+# Sanity: is @playwright/cli on PATH?
+if ! command -v npx >/dev/null 2>&1; then
+	echo '{"ok":false,"error":"npx not on PATH"}' >&2
+	exit 2
+fi
+
+# Step 1 (optional): clear the focused Monaco editor by select-all + delete.
+# Done via the CLI's `press` so the keys flow through Monaco's real key
+# handler. Stays inside the CDP connection — no system clipboard.
+if [[ "$APPEND" != "1" ]]; then
+	npx @playwright/cli "${PW_ARGS[@]}" press Meta+a >/dev/null 2>&1 || true
+	npx @playwright/cli "${PW_ARGS[@]}" press Backspace >/dev/null 2>&1 || true
+fi
+
+# Step 2: build the eval payload via node so JSON escaping is automatic.
+# The async IIFE waits two requestAnimationFrames after dispatch — Monaco
+# updates its view-line DOM asynchronously, so a same-tick read-back
+# returns stale state. Two rAFs = full paint cycle.
+JS=$(node -e '
+	const text = process.argv[1];
+	const verify = process.argv[2] === "1";
+	console.log(`(async () => {
+		const root = document.querySelector(".new-chat-input-area .native-edit-context")
+				  || document.querySelector(".sessions-chat-editor .native-edit-context")
+				  || document.querySelector(".native-edit-context");
+		if (!root) return JSON.stringify({ ok: false, error: "no native-edit-context found on page" });
+		root.focus();
+		const dt = new DataTransfer();
+		dt.setData("text/plain", ${JSON.stringify(text)});
+		root.dispatchEvent(new ClipboardEvent("paste", { clipboardData: dt, bubbles: true, cancelable: true }));
+		await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)));
+		const editor = root.closest(".monaco-editor");
+		const viewLines = Array.from(editor.querySelectorAll(".view-line")).map(l => l.textContent);
+		// Monaco renders regular ASCII spaces as U+00A0 (NBSP) in view-lines for
+		// visual fidelity. Also, joining view-lines drops the logical newlines
+		// between them. Normalize both sides before comparing.
+		// (Note: \\u00A0 and \\r\\n are double-escaped because this string lives
+		// inside a node template literal that would otherwise resolve them.)
+		const norm = s => s.replace(/\\u00A0/g, " ").replace(/\\r?\\n/g, "");
+		const joined = norm(viewLines.join(""));
+		const actualLength = joined.length;
+		const expectedFull = norm(${JSON.stringify(text)});
+		const expectedPrefix = expectedFull.slice(0, Math.min(40, expectedFull.length));
+		const prefixMatched = joined.startsWith(expectedPrefix) || joined.includes(expectedPrefix.slice(0, 20));
+		const verifyEnabled = ${verify ? "true" : "false"};
+		return JSON.stringify({
+			ok: !verifyEnabled || prefixMatched,
+			actualLength,
+			expectedLength: ${JSON.stringify(text)}.length,
+			viewLineCount: viewLines.length,
+			firstViewLine: (viewLines[0] || "").slice(0, 80),
+			error: (!verifyEnabled || prefixMatched) ? undefined : "paste read-back did not match expected prefix"
+		});
+	})()`);
+' "$TEXT" "$VERIFY")
+
+# Step 3: run the eval. The CLI prints "### Result" then a JSON-encoded
+# string on the next line, followed by "### Ran Playwright code" noise.
+RAW=$(npx @playwright/cli "${PW_ARGS[@]}" eval "$JS" 2>&1) || {
+	echo "{\"ok\":false,\"error\":\"@playwright/cli eval failed\"}"
+	echo "$RAW" >&2
+	exit 1
+}
+
+RESULT_LINE=$(echo "$RAW" | grep -A 1 '### Result' | tail -n1)
+if [[ -z "$RESULT_LINE" ]]; then
+	echo '{"ok":false,"error":"no ### Result section in eval output"}'
+	echo "$RAW" >&2
+	exit 1
+fi
+
+# RESULT_LINE is a JSON-encoded string containing our inner JSON.
+# Unwrap once with jq.
+CLEAN=$(echo "$RESULT_LINE" | jq -r 'fromjson' 2>/dev/null) || {
+	echo "{\"ok\":false,\"error\":\"failed to parse result line\",\"raw\":$(echo "$RESULT_LINE" | jq -Rs .)}"
+	exit 1
+}
+
+echo "$CLEAN"
+OK=$(echo "$CLEAN" | jq -r '.ok')
+[[ "$OK" == "true" ]]

--- a/.agents/skills/launch/scripts/monaco-paste.sh
+++ b/.agents/skills/launch/scripts/monaco-paste.sh
@@ -23,7 +23,12 @@
 # Stdout: a single JSON line, e.g.
 #   {"ok":true,"actualLength":47,"expectedLength":47,"viewLineCount":1,"firstViewLine":"..."}
 # Stderr: diagnostic noise from @playwright/cli (suppressed unless caller wants it).
-# Exit code: 0 on success, 1 on failure.
+# Exit code:
+#   0  success
+#   1  paste verify failed, eval failed, or the page had no native-edit-context
+#   2  argument/usage error (empty input, missing tools)
+#
+# Required tools on PATH: npx (with @playwright/cli reachable), node, jq.
 #
 # Assumes:
 #   - You have already run `npx @playwright/cli [-s=NAME] attach --cdp=http://127.0.0.1:$CDP`
@@ -74,18 +79,30 @@ if [[ -z "$TEXT" ]]; then
 	exit 2
 fi
 
-# Sanity: is @playwright/cli on PATH?
-if ! command -v npx >/dev/null 2>&1; then
-	echo '{"ok":false,"error":"npx not on PATH"}' >&2
-	exit 2
-fi
+# Sanity: required tools on PATH.
+for tool in npx node jq; do
+	if ! command -v "$tool" >/dev/null 2>&1; then
+		printf '{"ok":false,"error":"%s not on PATH"}\n' "$tool"
+		echo "monaco-paste.sh: required tool '$tool' not on PATH" >&2
+		exit 2
+	fi
+done
+
+# Pick the platform-appropriate "select all" modifier. macOS uses Cmd
+# (Meta), everything else uses Ctrl. Done in the host shell so it
+# applies to the `press` calls below — Monaco itself respects both
+# bindings, but @playwright/cli only sends what we ask it to.
+case "${OSTYPE:-$(uname -s)}" in
+	darwin*|Darwin*) SELECT_ALL_MOD="Meta" ;;
+	*)               SELECT_ALL_MOD="Control" ;;
+esac
 
 # Step 1 (optional): clear the focused Monaco editor by select-all + delete.
 # Done via the CLI's `press` so the keys flow through Monaco's real key
 # handler. Stays inside the CDP connection — no system clipboard.
 if [[ "$APPEND" != "1" ]]; then
-	npx @playwright/cli "${PW_ARGS[@]}" press Meta+a >/dev/null 2>&1 || true
-	npx @playwright/cli "${PW_ARGS[@]}" press Backspace >/dev/null 2>&1 || true
+	npx @playwright/cli ${PW_ARGS[@]+"${PW_ARGS[@]}"} press "${SELECT_ALL_MOD}+a" >/dev/null 2>&1 || true
+	npx @playwright/cli ${PW_ARGS[@]+"${PW_ARGS[@]}"} press Backspace >/dev/null 2>&1 || true
 fi
 
 # Step 2: build the eval payload via node so JSON escaping is automatic.
@@ -132,7 +149,7 @@ JS=$(node -e '
 
 # Step 3: run the eval. The CLI prints "### Result" then a JSON-encoded
 # string on the next line, followed by "### Ran Playwright code" noise.
-RAW=$(npx @playwright/cli "${PW_ARGS[@]}" eval "$JS" 2>&1) || {
+RAW=$(npx @playwright/cli ${PW_ARGS[@]+"${PW_ARGS[@]}"} eval "$JS" 2>&1) || {
 	echo "{\"ok\":false,\"error\":\"@playwright/cli eval failed\"}"
 	echo "$RAW" >&2
 	exit 1


### PR DESCRIPTION
Surfaced while running a bug bash over the Agents window terminal tool — the `launch` skill needed three improvements before subagents could drive multiple Code OSS instances cleanly.

### 1. `launch.sh`: force `files.simpleDialog.enable: true` in the launched profile
Native macOS file dialogs cannot be driven via `@playwright/cli` over CDP / SSH; the simple (quick-input style) dialog can. Without this, the new-session workspace picker's `Select...` button is a dead end for automation on a fresh slim-copied UDD.

### 2. New `scripts/monaco-paste.sh` helper
Inserts text into the focused Code OSS chat-input Monaco editor by dispatching a synthetic `ClipboardEvent('paste')` with a `DataTransfer` payload. Why a helper instead of just docs:

- **Avoids `pbcopy`'s system-wide `NSPasteboard` collision** — any other process touching the clipboard during the paste window can stomp the prompt. The synthetic event stays inside the CDP connection.
- **Handles unicode / emoji / backticks / quotes / newlines** including the case where the input has embedded `\"` and ``\` ``.
- **Waits two `requestAnimationFrame`s before read-back** — Monaco updates its view-line DOM asynchronously after a paste event; a same-tick read returns stale state.
- **Normalizes U+00A0 (NBSP) → ASCII space** when verifying — Monaco renders regular spaces as NBSP in the view-line DOM for visual fidelity, which breaks naive `startsWith` checks.
- **Honors `--session NAME` or `$PW_SESSION`** so it stays in the same `@playwright/cli` session as the rest of the agent's calls.

Tested across 20+ pastes with all the awkward characters and parallel multi-instance runs (`-s=sessA` / `-s=sessB`) — no cross-contamination.

### 3. `SKILL.md` updates
- Documents the new `simpleDialog` default and the `monaco-paste.sh` helper.
- **Makes `-s=$PW_SESSION` the default convention** on every `@playwright/cli` example. The skill is built around per-instance isolation (UDD, ports, shared-data-dir), and this pattern extends that isolation to the Playwright-driving layer. Without `-s=`, parallel shells share the implicit `"default"` session daemon and the most-recently-attached CDP wins for every subsequent command from either shell.
- New "Parallel multi-instance pattern" subsection showing the full attach / paste / cleanup loop with per-session names.
- Notes that `PLAYWRIGHT_CLI_SESSION` env var works for `open`-style workflows but interacts poorly with `attach --cdp=` due to an upstream behavior in `playwright-core/cli-client/session.ts:142-143` (the env var is pushed as `--endpoint=…` even when `--cdp=…` is already set, and the daemon ends up trying to connect to the env var value as a socket path). Explicit `-s=` is safe in all modes.

### Test plan
- Sequential 20+ pastes with varied content (unicode, emoji, backticks, ampersands, embedded quotes, newlines) — all verified.
- Parallel 2-instance run with `-s=sessA` / `-s=sessB`; pastes landed in their respective windows with no cross-contamination.
- Used as the test infra for an end-to-end bug bash across 10 scenarios on the Agents window terminal tool.

### Not in this PR
- The underlying `@playwright/cli` `attach --cdp=` + `PLAYWRIGHT_CLI_SESSION` interaction. Worth a separate issue against [microsoft/playwright](https://github.com/microsoft/playwright/blob/main/packages/playwright-core/src/tools/cli-client/session.ts#L141-L143); the `-s=` flag is a clean workaround for now.

🤖 Generated with Copilot CLI

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>