### PR TITLE
Chronicle: fold search_subagent trajectory into parent session

### DIFF
--- a/extensions/copilot/src/extension/tools/node/searchSubagentTool.ts
+++ b/extensions/copilot/src/extension/tools/node/searchSubagentTool.ts
@@ -141,7 +141,7 @@ class SearchSubagentTool implements ICopilotTool<ISearchSubagentParams> {
 		// Create a new capturing token to group this search subagent and all its nested tool calls
 		// Similar to how DefaultIntentRequestHandler does it
 		// Pass the subAgentInvocationId so the trajectory uses this ID for explicit linking
-		const parentChatSessionId = getCurrentCapturingToken()?.chatSessionId;
+		const parentChatSessionId = getCurrentCapturingToken()?.chatSessionId ?? parentSessionId;
 		const searchSubagentToken = new CapturingToken(
 			`Search: ${options.input.query.substring(0, 50)}${options.input.query.length > 50 ? '...' : ''}`,
 			'search',
@@ -149,7 +149,7 @@ class SearchSubagentTool implements ICopilotTool<ISearchSubagentParams> {
 			'search',  // subAgentName for trajectory tracking
 			// Use invocation ID as chatSessionId so spans get their own log file
 			subAgentInvocationId,
-			// Link back to the parent session for debug log grouping
+			// Link back to the parent session for debug log grouping and cloud session folding
 			parentChatSessionId,
 			'searchSubagent',
 		);


### PR DESCRIPTION
Follow-up fix for #318463.

Ensures the search subagent's `parentChatSessionId` is always set by falling back to the conversation's `sessionId` when the capturing token's `chatSessionId` is unavailable. Without this fallback, search subagent spans lacked `PARENT_CHAT_SESSION_ID` and were uploaded as independent cloud sessions instead of folding into the parent.

Same pattern as #318475 (which fixes execution_subagent).