### PR TITLE
chat: fix bare backtick flicker in streamed agent host markdown

### DIFF
--- a/src/vs/base/browser/markdownRenderer.ts
+++ b/src/vs/base/browser/markdownRenderer.ts
@@ -987,21 +987,32 @@ function fillInIncompleteTokensOnce(tokens: marked.TokensList): marked.TokensLis
 		}
 	}
 
-	const lastToken = tokens.at(-1);
-	if (!newTokens && lastToken?.type === 'list') {
-		const newListToken = completeListItemPattern(lastToken as marked.Tokens.List);
+	// Find the last "interesting" token, skipping trailing `space` and `html`
+	// tokens. Callers like the chat content renderer wrap markdown in
+	// `<body>...</body>` (so dompurify keeps leading comments), which leaves
+	// `</body>` as the literal last token — without this skip, the
+	// paragraph / list fixups never fire for that content.
+	let lastInterestingIdx = tokens.length - 1;
+	while (lastInterestingIdx >= 0 && (tokens[lastInterestingIdx].type === 'space' || tokens[lastInterestingIdx].type === 'html')) {
+		lastInterestingIdx--;
+	}
+	const lastInterestingToken = lastInterestingIdx >= 0 ? tokens[lastInterestingIdx] : undefined;
+	const trailingTokens = tokens.slice(lastInterestingIdx + 1);
+
+	if (!newTokens && lastInterestingToken?.type === 'list') {
+		const newListToken = completeListItemPattern(lastInterestingToken as marked.Tokens.List);
 		if (newListToken) {
-			newTokens = [newListToken];
-			i = tokens.length - 1;
+			newTokens = [newListToken, ...trailingTokens];
+			i = lastInterestingIdx;
 		}
 	}
 
-	if (!newTokens && lastToken?.type === 'paragraph') {
+	if (!newTokens && lastInterestingToken?.type === 'paragraph') {
 		// Only operates on a single token, because any newline that follows this should break these patterns
-		const newToken = completeSingleLinePattern(lastToken as marked.Tokens.Paragraph);
+		const newToken = completeSingleLinePattern(lastInterestingToken as marked.Tokens.Paragraph);
 		if (newToken) {
-			newTokens = [newToken];
-			i = tokens.length - 1;
+			newTokens = [newToken, ...trailingTokens];
+			i = lastInterestingIdx;
 		}
 	}
 
@@ -1014,6 +1025,7 @@ function fillInIncompleteTokensOnce(tokens: marked.TokensList): marked.TokensLis
 		return newTokensList as marked.TokensList;
 	}
 
+	const lastToken = tokens.at(-1);
 	if (lastToken?.type === 'heading') {
 		const completeTokens = completeHeading(lastToken as marked.Tokens.Heading, mergeRawTokenText(tokens));
 		if (completeTokens) {

--- a/src/vs/base/test/browser/markdownRenderer.test.ts
+++ b/src/vs/base/test/browser/markdownRenderer.test.ts
@@ -873,6 +873,20 @@ suite('MarkdownRenderer', () => {
 				const completeTokens = marked.marked.lexer(text + '`');
 				assert.deepStrictEqual(newTokens, completeTokens);
 			});
+
+			test('codespan inside <body> wrapped markdown', () => {
+				// The chat content renderer wraps `supportHtml` markdown in
+				// `<body>...</body>` so dompurify keeps leading comments. That
+				// makes `</body>` the literal last token — the paragraph with
+				// the bare backtick is no longer at the end. The fixup must
+				// still close the codespan while preserving the trailing html.
+				const text = '<body>\n\nCreated isolated worktree for branch `xyz\n\n</body>';
+				const tokens = marked.marked.lexer(text);
+				const newTokens = fillInIncompleteTokens(tokens);
+
+				const completeTokens = marked.marked.lexer('<body>\n\nCreated isolated worktree for branch `xyz`\n\n</body>');
+				assert.deepStrictEqual(newTokens, completeTokens);
+			});
 		});
 
 		suite('star', () => {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -1422,11 +1422,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			}
 			const delta = content.substring(lastEmitted);
 			lastEmitted = content.length;
-			// supportHtml is load bearing. Without this the markdown string
-			// gets merged into the edit part in chatModel.ts which breaks
-			// rendering because the thinking content part does not deal
-			// with this.
-			opts.sink([{ kind: 'markdownContent', content: rawMarkdownToString(delta, this._config.connectionAuthority, { supportHtml: true }) }]);
+			opts.sink([{ kind: 'markdownContent', content: rawMarkdownToString(delta, this._config.connectionAuthority) }]);
 		}));
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
@@ -156,7 +156,7 @@ export function turnsToHistory(backendSession: URI, turns: readonly Turn[], part
 			switch (rp.kind) {
 				case ResponsePartKind.Markdown:
 					if (rp.content) {
-						parts.push({ kind: 'markdownContent', content: rawMarkdownToString(rp.content, connectionAuthority, { supportHtml: true }) });
+						parts.push({ kind: 'markdownContent', content: rawMarkdownToString(rp.content, connectionAuthority) });
 					}
 					break;
 				case ResponsePartKind.ToolCall: {
@@ -724,9 +724,9 @@ function isSkillFileUri(uri: URI): boolean {
  * link URIs through {@link rewriteMarkdownLinks} when a connection authority
  * is provided.
  */
-export function rawMarkdownToString(content: string, connectionAuthority: string | undefined, options?: { supportHtml?: boolean }): MarkdownString {
+export function rawMarkdownToString(content: string, connectionAuthority: string | undefined): MarkdownString {
 	const rewritten = connectionAuthority ? rewriteMarkdownLinks(content, connectionAuthority) : content;
-	return new MarkdownString(rewritten, options);
+	return new MarkdownString(rewritten);
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatMarkdownRenderer.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatMarkdownRenderer.test.ts
@@ -150,4 +150,20 @@ suite('ChatMarkdownRenderer', () => {
 		const textContent = result.element.textContent;
 		assert.ok(!textContent?.includes('</body>'), `Rendered text should not contain </body>, got: ${textContent}`);
 	});
+
+	test('fillInIncompleteTokens closes bare codespan when supportHtml is set', () => {
+		// Regression: the chat content renderer wraps `supportHtml` markdown
+		// in `<body>...</body>`, which produces a trailing html token. The
+		// paragraph/codespan fixup in `fillInIncompleteTokens` must still
+		// fire so streaming a partial backtick (e.g. the agent host
+		// "Created isolated worktree for branch `xyz" announcement) does
+		// not leave a bare ` in the DOM until the closing backtick arrives.
+		const md = new MarkdownString('Created isolated worktree for branch `xyz', { supportHtml: true });
+		const result = store.add(testRenderer.render(md, { fillInIncompleteTokens: true }));
+
+		const codeEl = result.element.querySelector('code');
+		assert.ok(codeEl, `Expected a <code> element in: ${result.element.outerHTML}`);
+		assert.strictEqual(codeEl!.textContent, 'xyz');
+		assert.ok(!result.element.textContent?.includes('`'), `Rendered text should not contain a bare backtick, got: ${result.element.textContent}`);
+	});
 });


### PR DESCRIPTION
Fixes a bare-backtick flicker while streaming agent host responses, plus removes a now-stale `supportHtml: true` from agent host markdown emission.

## Symptom

For agent host (AH) sessions, the initial worktree announcement

> Created isolated worktree for branch `xyz`

briefly rendered as

> Created isolated worktree for branch `xyz

(bare opening backtick, no `<code>`) until the closing backtick word arrived. The progressive word renderer (`chatWordCounter`) deliberately splits at non-backtick boundaries, so the intermediate string ending in a bare `` ` `` is expected — `fillInIncompleteTokens` is supposed to handle that.

## Why `fillInIncompleteTokens` wasn't firing

`ChatContentMarkdownRenderer` wraps any `supportHtml` markdown in `<body>...</body>` (so dompurify keeps leading comments). The lexer then produces:

```
[ html('<body>'), paragraph('…for branch `xyz'), space, html('</body>') ]
```

`fillInIncompleteTokensOnce` only inspects `tokens.at(-1)` for its paragraph / list / heading fix-ups. The trailing `html('</body>')` token meant the codespan fix-up never ran.

## Why AH was opting into `supportHtml` in the first place

The `// supportHtml is load bearing…` comment in `agentHostSessionHandler._setupMarkdownPart` was stale. It dated back to when `AgentHostEditingSession` emitted file edits as a `markdownContent('\n````\n')` + `codeblockUri` + `textEdit` + `markdownContent('\n````\n')` cluster — the `supportHtml: true` tag on model deltas made `canMergeMarkdownStrings` reject merging with those bare fence chunks. After [#318053](https://github.com/microsoft/vscode/pull/318053) (Connor) replaced that whole thing with a dedicated `'externalEdit'` progress part, model deltas have nothing to accidentally merge into.

## Fixes

Both layers are addressed:

**Defensive (base layer).** `fillInIncompleteTokensOnce` now walks past trailing `space` / `html` tokens to find the last paragraph/list, then preserves those trailing tokens around the patched node. The heading branch is intentionally left alone. This means any future consumer of `supportHtml: true` streaming markdown also gets correct fix-ups.

**Root (AH layer).** Drop `supportHtml: true` from:
- `agentHostSessionHandler._setupMarkdownPart` (live streaming sink) — and remove the stale "load bearing" comment.
- `stateToProgressAdapter.turnsToHistory` (`ResponsePartKind.Markdown` case).

Also drops the now-unused `options` parameter from `rawMarkdownToString`. This aligns the streaming and history paths with the already-different `activeTurnToProgress` path (which never set the flag), and with vanilla Copilot chat `stream.markdown(...)` callsites.

## Tests

- **Token-level** (`markdownRenderer.test.ts`): asserts `fillInIncompleteTokens` on the `<body>…\`xyz\n\n</body>` token list matches the lex of the balanced wrapped string.
- **End-to-end** (`chatMarkdownRenderer.test.ts`): renders a `MarkdownString` with `supportHtml: true` containing `Created isolated worktree for branch \`xyz` through the full `ChatContentMarkdownRenderer.render(md, { fillInIncompleteTokens: true })` pipeline and asserts a `<code>xyz</code>` is in the output with no bare backtick in the text content.

All 213 tests pass across the affected suites (markdownRenderer + chatMarkdownRenderer + stateToProgressAdapter); `tsgo --noEmit` is clean.

(Written by Copilot)
