### PR TITLE
Use per-action min-widths for short agent-host pickers

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -2659,14 +2659,18 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			toolbarSide.context = { widget } satisfies IChatExecuteActionContext;
 		}
 
-		// Secondary toolbar (permissions) — below the input box
-		const agentHostShortPickerIds = new Set<string>([
-			OpenAgentHostModePickerAction.ID,
-			OpenAgentHostAutoApprovePickerAction.ID,
-			OpenAgentHostPermissionModePickerAction.ID,
-			OpenAgentHostBranchPickerAction.ID,
-			OpenAgentHostIsolationPickerAction.ID,
-			'sessions.tunnelHost.toggleSharing'
+		// Secondary toolbar (permissions) — below the input box.
+		// Per-action minimum widths (in pixels) for pickers that collapse to an
+		// icon-only label via a CSS container query in `AgentHostChatInputPicker`.
+		// Most pickers reserve ~22px for the icon; the tunnel-sharing toggle has
+		// no chevron, so it can collapse further to 16px.
+		const agentHostShortPickerMinWidths = new Map<string, number>([
+			[OpenAgentHostModePickerAction.ID, 22],
+			[OpenAgentHostAutoApprovePickerAction.ID, 22],
+			[OpenAgentHostPermissionModePickerAction.ID, 22],
+			[OpenAgentHostBranchPickerAction.ID, 22],
+			[OpenAgentHostIsolationPickerAction.ID, 22],
+			['sessions.tunnelHost.toggleSharing', 16],
 		]);
 		// Direct-rendered chip lane for agent-host config properties that
 		// are advertised by the agent's schema but not handled by a
@@ -2694,7 +2698,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 				// container query in `AgentHostChatInputPicker` when narrow.
 				// Report a smaller min-width for them so the responsive layout
 				// keeps them visible instead of overflowing into the menu.
-				getActionMinWidth: action => agentHostShortPickerIds.has(action.id) ? 22 : undefined,
+				getActionMinWidth: action => agentHostShortPickerMinWidths.get(action.id),
 			},
 			actionViewItemProvider: (action, options) => {
 				if ((action.id === OpenSessionTargetPickerAction.ID || action.id === OpenDelegationPickerAction.ID) && action instanceof MenuItemAction) {


### PR DESCRIPTION
In the chat input's secondary toolbar, agent-host pickers report a smaller `actionMinWidth` (22px) so they can collapse to icon-only and stay visible instead of overflowing into the `…` menu. The tunnel-sharing toggle has no chevron, so 22px is still too wide — it should collapse further to 16px.

`getActionMinWidth` only accepts a `number | undefined`, so the existing `Set<string>` is replaced with a `Map<string, number>` mapping each action id to its own min-width:

- `sessions.tunnelHost.toggleSharing` → 16
- Other agent-host pickers → 22 (unchanged)

Unlisted actions fall through to the default `actionMinWidth: 48`.

(Written by Copilot)
