### PR TITLE
copilotAgentSession: avoid leaking subscriptions when disposed during init

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -7,6 +7,7 @@ import type { MessageOptions, PermissionRequestResult, SessionConfig, Tool, Tool
 import { DeferredPromise } from '../../../../base/common/async.js';
 import { encodeBase64, VSBuffer } from '../../../../base/common/buffer.js';
 import { Emitter } from '../../../../base/common/event.js';
+import { CancellationError } from '../../../../base/common/errors.js';
 import { Disposable, IReference, toDisposable } from '../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { isAbsolute, join } from '../../../../base/common/path.js';
@@ -757,7 +758,7 @@ export class CopilotAgentSession extends Disposable {
 	 * construction before using the session.
 	 */
 	async initializeSession(): Promise<void> {
-		this._wrapper = this._register(await this._wrapperFactory({
+		const wrapper = await this._wrapperFactory({
 			onPermissionRequest: request => this.handlePermissionRequest(request),
 			onUserInputRequest: (request, invocation) => this.handleUserInputRequest(request, invocation),
 			onElicitationRequest: context => this.handleElicitationRequest(context),
@@ -767,7 +768,15 @@ export class CopilotAgentSession extends Disposable {
 				onPreToolUse: input => this._handlePreToolUse(input),
 				onPostToolUse: input => this._handlePostToolUse(input),
 			},
-		}));
+		});
+		// The session may have been disposed while we were awaiting the
+		// wrapper factory. If so, dispose the freshly-created wrapper and
+		// skip subscribing — registering on a disposed store would leak.
+		if (this._store.isDisposed) {
+			wrapper.dispose();
+			throw new CancellationError();
+		}
+		this._wrapper = this._register(wrapper);
 		this._subscribeToEvents();
 		this._subscribeForLogging();
 	}


### PR DESCRIPTION
## Problem

```
Error: Trying to add a disposable to a DisposableStore that has already been disposed of. The added object will be leaked!
    at DisposableStore.add (lifecycle.js:327)
    at CopilotAgentSession._register (lifecycle.js:391)
    at CopilotAgentSession._subscribeForLogging (copilotAgentSession.js:1714)
    at CopilotAgentSession.initializeSession (copilotAgentSession.js:582)
    ...
    at async CopilotAgent._resumeSession
    at async CopilotAgent.getSessionMessages
    at async AgentService.restoreSession
    at async ChangesetSessionCoordinator.restoreSessionIfChangesetSubscription
```

`CopilotAgentSession.initializeSession()` is async. Between `await this._wrapperFactory(...)` resolving and the subsequent `_subscribeToEvents()` / `_subscribeForLogging()` calls, the session can be disposed (e.g. via `_destroyAndDisposeSession`). The subscribe methods then call `_register` on an already-disposed `DisposableStore`, producing the warning and leaking the freshly-created SDK session wrapper.

## Fix

After the wrapper factory resolves, check `this._store.isDisposed`. If disposed:

- dispose the freshly-created wrapper (otherwise the disposed store warns and drops it on `_register`, leaking it), and
- throw `CancellationError` so callers (`_materializeProvisional` / `_resumeSession`) treat it as a cancellation rather than producing a half-initialized session.

(Written by Copilot)
