### PR TITLE
Prevent signed-out users from seeing GitHub Copilot upgrade recommendations

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -409,6 +409,7 @@ export function buildModelPickerItems(
 	isUBB?: boolean,
 ): IActionListItem<IActionWidgetDropdownAction>[] {
 	const items: IActionListItem<IActionWidgetDropdownAction>[] = [];
+
 	if (models.length === 0) {
 		items.push(createModelItem({
 			id: 'auto',
@@ -1010,8 +1011,11 @@ export class ModelPickerWidget extends Disposable {
 		const models = this._delegate.getModels();
 		const isPro = isProUser(this._entitlementService.entitlement);
 		const isUBB = !!this._entitlementService.quotas.usageBasedBilling;
+		const isSignedOut = this._entitlementService.entitlement === ChatEntitlement.Unknown;
+
 		const manifest = this._languageModelsService.getModelsControlManifest();
-		const controlModelsForTier = isPro ? manifest.paid : manifest.free;
+		// Signed-out users (e.g. offline-BYOK) should not see Copilot control-manifest entries
+		const controlModelsForTier: IStringDictionary<IModelControlEntry> = isSignedOut ? {} : (isPro ? manifest.paid : manifest.free);
 		const canShowManageModelsAction = this._delegate.showManageModelsAction() && shouldShowManageModelsAction(this._entitlementService);
 		const manageModelsAction = canShowManageModelsAction ? createManageModelsAction(this._commandService) : undefined;
 		const logModelPickerInteraction = (interaction: ChatModelPickerInteraction) => {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -409,7 +409,6 @@ export function buildModelPickerItems(
 	isUBB?: boolean,
 ): IActionListItem<IActionWidgetDropdownAction>[] {
 	const items: IActionListItem<IActionWidgetDropdownAction>[] = [];
-
 	if (models.length === 0) {
 		items.push(createModelItem({
 			id: 'auto',
@@ -1012,7 +1011,6 @@ export class ModelPickerWidget extends Disposable {
 		const isPro = isProUser(this._entitlementService.entitlement);
 		const isUBB = !!this._entitlementService.quotas.usageBasedBilling;
 		const isSignedOut = this._entitlementService.entitlement === ChatEntitlement.Unknown;
-
 		const manifest = this._languageModelsService.getModelsControlManifest();
 		// Signed-out users (e.g. offline-BYOK) should not see Copilot control-manifest entries
 		const controlModelsForTier: IStringDictionary<IModelControlEntry> = isSignedOut ? {} : (isPro ? manifest.paid : manifest.free);

--- a/src/vs/workbench/contrib/mcp/node/mcpStdioStateHandler.ts
+++ b/src/vs/workbench/contrib/mcp/node/mcpStdioStateHandler.ts
@@ -62,11 +62,17 @@ export class McpStdioStateHandler implements IDisposable {
 		}
 	}
 
-	private killPolite() {
+	private async killPolite() {
 		this._procState = McpProcessState.KilledPolite;
 		this._nextTimeout = new TimeoutTimer(() => this.killForceful(), this._graceTimeMs);
 
-		if (!isWindows) {
+		if (this._child.pid) {
+			if (!isWindows) {
+				await killTree(this._child.pid, false).catch(() => {
+					this._child.kill('SIGTERM');
+				});
+			}
+		} else {
 			this._child.kill('SIGTERM');
 		}
 	}

--- a/src/vs/workbench/contrib/mcp/node/mcpStdioStateHandler.ts
+++ b/src/vs/workbench/contrib/mcp/node/mcpStdioStateHandler.ts
@@ -62,17 +62,11 @@ export class McpStdioStateHandler implements IDisposable {
 		}
 	}
 
-	private async killPolite() {
+	private killPolite() {
 		this._procState = McpProcessState.KilledPolite;
 		this._nextTimeout = new TimeoutTimer(() => this.killForceful(), this._graceTimeMs);
 
-		if (this._child.pid) {
-			if (!isWindows) {
-				await killTree(this._child.pid, false).catch(() => {
-					this._child.kill('SIGTERM');
-				});
-			}
-		} else {
+		if (!isWindows) {
 			this._child.kill('SIGTERM');
 		}
 	}


### PR DESCRIPTION
Ensure that signed-out users do not have access to Copilot control-manifest entries in the model picker. This change enhances user experience by restricting visibility based on user entitlement status.