### PR TITLE
Quick Open: match queries with leading workspace folder name

### DIFF
--- a/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
@@ -11,11 +11,12 @@ import { IFileQueryBuilderOptions, QueryBuilder } from '../../../services/search
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { getOutOfWorkspaceEditorResources, extractRangeFromFilter, IWorkbenchSearchConfiguration } from '../common/search.js';
 import { ISearchService, ISearchComplete } from '../../../services/search/common/search.js';
-import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
+import { IWorkspaceContextService, IWorkspaceFolder } from '../../../../platform/workspace/common/workspace.js';
 import { untildify } from '../../../../base/common/labels.js';
 import { IPathService } from '../../../services/path/common/pathService.js';
 import { URI } from '../../../../base/common/uri.js';
 import { toLocalResource, dirname, basenameOrAuthority } from '../../../../base/common/resources.js';
+import { equalsIgnoreCase } from '../../../../base/common/strings.js';
 import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
@@ -775,32 +776,52 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 		// and return them as results if the absolute paths exist
 		const isAbsolutePathQuery = (await this.pathService.path).isAbsolute(query.original);
 		if (!isAbsolutePathQuery) {
-			const resources: URI[] = [];
+			const resources = new ResourceMap<URI>(uri => this.uriIdentityService.extUri.getComparisonKey(uri));
 			for (const folder of this.contextService.getWorkspace().folders) {
 				if (token.isCancellationRequested) {
 					break;
 				}
 
-				const resource = toLocalResource(
-					folder.toResource(query.original),
-					this.environmentService.remoteAuthority,
-					this.pathService.defaultUriScheme
-				);
+				// Try the query as-is relative to the folder
+				await this.tryAddRelativePathFileResult(folder.toResource(query.original), resources);
 
-				try {
-					const stat = await this.fileService.stat(resource);
-					if (stat.isFile) {
-						resources.push(await this.matchFilenameCasing(resource));
-					}
-				} catch (error) {
-					// ignore if file does not exist
+				// Also try the query with a leading workspace folder name prefix stripped. This helps
+				// when users paste fully-qualified paths (e.g. from GitHub or a multi-root workspace
+				// where the folder's display name or basename is part of the path) such as
+				// `folderName/path/to/file.txt`. Without this, `folder.toResource(...)` would produce
+				// `<folderUri>/folderName/path/to/file.txt` which does not exist.
+				const stripped = stripWorkspaceFolderPrefix(query.original, folder);
+				if (stripped !== undefined) {
+					await this.tryAddRelativePathFileResult(folder.toResource(stripped), resources);
 				}
 			}
 
-			return resources;
+			return [...resources.values()];
 		}
 
 		return;
+	}
+
+	private async tryAddRelativePathFileResult(uri: URI, resources: ResourceMap<URI>): Promise<void> {
+		const resource = toLocalResource(
+			uri,
+			this.environmentService.remoteAuthority,
+			this.pathService.defaultUriScheme
+		);
+
+		if (resources.has(resource)) {
+			return;
+		}
+
+		try {
+			const stat = await this.fileService.stat(resource);
+			if (stat.isFile) {
+				const cased = await this.matchFilenameCasing(resource);
+				resources.set(cased, cased);
+			}
+		} catch (error) {
+			// ignore if file does not exist
+		}
 	}
 
 	/**
@@ -1147,4 +1168,31 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 	}
 
 	//#endregion
+}
+
+/**
+ * If `query` starts with a path segment that matches the workspace folder's
+ * `name` or the basename of its URI (case-insensitive), returns the remainder
+ * of the query with that segment removed. Otherwise returns `undefined`.
+ *
+ * This enables matching queries like `folderName/path/to/file.txt` against
+ * workspace folders whose name (or basename) matches the first path segment.
+ */
+export function stripWorkspaceFolderPrefix(query: string, folder: IWorkspaceFolder): string | undefined {
+	// Find the first path separator (either / or \)
+	const separatorIndex = query.search(/[\\/]/);
+	if (separatorIndex <= 0) {
+		return undefined;
+	}
+
+	const firstSegment = query.substring(0, separatorIndex);
+	const folderBasename = basenameOrAuthority(folder.uri);
+
+	if (!equalsIgnoreCase(firstSegment, folder.name) && !equalsIgnoreCase(firstSegment, folderBasename)) {
+		return undefined;
+	}
+
+	const remainder = query.substring(separatorIndex + 1);
+	// Avoid producing an empty path which would just match the folder itself.
+	return remainder.length > 0 ? remainder : undefined;
 }

--- a/src/vs/workbench/contrib/search/test/browser/anythingQuickAccess.test.ts
+++ b/src/vs/workbench/contrib/search/test/browser/anythingQuickAccess.test.ts
@@ -1,0 +1,82 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import assert from 'assert';
+import { URI } from '../../../../../base/common/uri.js';
+import { IWorkspaceFolder } from '../../../../../platform/workspace/common/workspace.js';
+import { stripWorkspaceFolderPrefix } from '../../browser/anythingQuickAccess.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+
+suite('AnythingQuickAccess - stripWorkspaceFolderPrefix', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function makeFolder(uri: string, name?: string): IWorkspaceFolder {
+		const folderUri = URI.file(uri);
+		return {
+			uri: folderUri,
+			name: name ?? folderUri.path.split('/').pop() ?? '',
+			index: 0,
+			toResource(relativePath: string): URI {
+				return URI.joinPath(folderUri, relativePath);
+			}
+		};
+	}
+
+	test('returns undefined when no path separator is present', () => {
+		const folder = makeFolder('/repo/workspace_1');
+		assert.strictEqual(stripWorkspaceFolderPrefix('workspace_1', folder), undefined);
+	});
+
+	test('returns undefined when the separator is the first character', () => {
+		const folder = makeFolder('/repo/workspace_1');
+		// Note: a leading '/' would be an absolute path; the caller never calls us in that case,
+		// but for defense in depth we still return undefined.
+		assert.strictEqual(stripWorkspaceFolderPrefix('/test_file.txt', folder), undefined);
+	});
+
+	test('strips matching folder basename from forward-slash path', () => {
+		const folder = makeFolder('/repo/workspace_1');
+		assert.strictEqual(stripWorkspaceFolderPrefix('workspace_1/test_file.txt', folder), 'test_file.txt');
+	});
+
+	test('strips matching folder basename from backslash path', () => {
+		const folder = makeFolder('/repo/workspace_1');
+		assert.strictEqual(stripWorkspaceFolderPrefix('workspace_1\\test_file.txt', folder), 'test_file.txt');
+	});
+
+	test('strips matching folder display name (different from basename)', () => {
+		const folder = makeFolder('/repo/code', 'Source');
+		assert.strictEqual(stripWorkspaceFolderPrefix('Source/main.py', folder), 'main.py');
+		assert.strictEqual(stripWorkspaceFolderPrefix('code/main.py', folder), 'main.py');
+	});
+
+	test('matches case-insensitively', () => {
+		const folder = makeFolder('/repo/Workspace_1');
+		assert.strictEqual(stripWorkspaceFolderPrefix('workspace_1/test.txt', folder), 'test.txt');
+		assert.strictEqual(stripWorkspaceFolderPrefix('WORKSPACE_1/test.txt', folder), 'test.txt');
+	});
+
+	test('returns undefined when first segment does not match', () => {
+		const folder = makeFolder('/repo/workspace_1');
+		assert.strictEqual(stripWorkspaceFolderPrefix('workspace_2/test.txt', folder), undefined);
+		assert.strictEqual(stripWorkspaceFolderPrefix('other/test.txt', folder), undefined);
+	});
+
+	test('does not strip on a partial-name match', () => {
+		const folder = makeFolder('/repo/workspace_1');
+		// "workspace" is a prefix but the segment is "workspace_12" which is not equal.
+		assert.strictEqual(stripWorkspaceFolderPrefix('workspace_12/test.txt', folder), undefined);
+	});
+
+	test('preserves nested path remainder', () => {
+		const folder = makeFolder('/repo/workspace_1');
+		assert.strictEqual(stripWorkspaceFolderPrefix('workspace_1/sub/dir/file.ts', folder), 'sub/dir/file.ts');
+	});
+
+	test('returns undefined when nothing is left after stripping', () => {
+		const folder = makeFolder('/repo/workspace_1');
+		assert.strictEqual(stripWorkspaceFolderPrefix('workspace_1/', folder), undefined);
+	});
+});


### PR DESCRIPTION
Fixes #208840

## What this PR does

In a multi-root workspace (or any workspace whose folder display name / basename appears in the path the user pastes), typing a fully-qualified relative path such as `workspace_1/test_file.txt` or `Source/main.py` returns no results from Quick Open's file picker.

The relative-path resolver in `AnythingQuickAccessProvider.getRelativePathFileResults` resolves each query against every workspace folder via `folder.toResource(query.original)`, which produces `<folderUri>/workspace_1/test_file.txt` — a path that does not exist when the workspace folder itself is `workspace_1`.

This PR adds a second resolution attempt that strips a leading path segment when it matches the workspace folder's `name` or the basename of its URI (case-insensitively). For example:

- Multi-root workspace with `workspace_1`, `workspace_2`. User types `workspace_1/test_file.txt` → file is now found.
- Workspace folder `{ "name": "Source", "path": "code" }`. User types `Source/main.py` *or* `code/main.py` → file is now found.

The original behavior (using `query.original` as-is) is preserved, so single-root relative queries that already work continue to work. Results are de-duplicated via a `ResourceMap` so a file matched by both the original and the stripped query is returned only once.

Stripping only fires when the first segment is an *exact, case-insensitive* match to the folder's name or basename — `workspace_12/x.ts` against folder `workspace_1` does not strip. Empty remainders (e.g. `workspace_1/`) are ignored to avoid matching the folder itself.

## Implementation

- `getRelativePathFileResults` now uses a `ResourceMap` instead of a `URI[]` to handle the dedup.
- A new private helper `tryAddRelativePathFileResult` factors out the stat + casing-resolution step so it can be reused for both the as-typed and prefix-stripped queries.
- A new exported pure helper `stripWorkspaceFolderPrefix(query, folder)` performs the prefix check. It is exported so it can be unit-tested without the full Quick Access scaffolding.

## Testing

- Added focused unit tests in `src/vs/workbench/contrib/search/test/browser/anythingQuickAccess.test.ts` covering:
  - no separator in the query
  - leading separator
  - basename match with both `/` and `\` separators
  - display-name match where it differs from the URI basename (`Source` vs `code`)
  - case-insensitive match
  - partial-prefix non-match (`workspace_12` against folder `workspace_1`)
  - nested path remainders
  - empty-remainder rejection