### PR TITLE
Git - strip host:user prefix when deriving clone folder name

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -434,7 +434,7 @@ export class Git {
 	}
 
 	async clone(url: string, options: ICloneOptions, cancellationToken?: CancellationToken): Promise<string> {
-		const baseFolderName = options.targetName || decodeURI(url).replace(/[\/]+$/, '').replace(/^.*[\/\\]/, '').replace(/\.git$/, '') || 'repository';
+		const baseFolderName = options.targetName || getCloneTargetFolderName(url);
 		let folderName = baseFolderName;
 		let folderPath = path.join(options.parentPath, folderName);
 		let count = 1;
@@ -1029,6 +1029,25 @@ export function parseLsFiles(raw: string): LsFilesElement[] {
 		.map(line => /^(\S+)\s+(\S+)\s+(\S+)\s+(.*)$/.exec(line)!)
 		.filter(m => !!m)
 		.map(([, mode, object, stage, file]) => ({ mode, object, stage, file }));
+}
+
+/**
+ * Derives a folder name from a git remote URL for use as a clone target.
+ *
+ * Handles three URL shapes:
+ *  - Standard URLs (https://, ssh://, git://, file://): take the basename of the path.
+ *  - SCP-style SSH URLs ([user@]host:path) where the path may not contain a slash
+ *    (e.g. `git@host.example:repo`): strip the `host:` prefix so the folder name
+ *    is just `repo` rather than `git@host.example:repo` (which contains `:` and is
+ *    invalid on Windows). See https://github.com/microsoft/vscode/issues/175062
+ *  - Anything else: fall back to `'repository'`.
+ */
+export function getCloneTargetFolderName(url: string): string {
+	return decodeURI(url)
+		.replace(/[\/]+$/, '')
+		.replace(/^.*[\/\\]/, '')
+		.replace(/^.*:/, '')
+		.replace(/\.git$/, '') || 'repository';
 }
 
 const stashRegex = /([0-9a-f]{40})\n(.*)\nstash@{(\d+)}\n(WIP\s)?on\s([^:]+):\s(.*)\n(\d+)\n(\d+)(?:\x00)/gmi;

--- a/extensions/git/src/test/git.test.ts
+++ b/extensions/git/src/test/git.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import 'mocha';
-import { GitStatusParser, parseGitCommits, parseGitmodules, parseLsTree, parseLsFiles, parseGitRemotes, parseCoAuthors } from '../git';
+import { getCloneTargetFolderName, GitStatusParser, parseGitCommits, parseGitmodules, parseLsTree, parseLsFiles, parseGitRemotes, parseCoAuthors } from '../git';
 import * as assert from 'assert';
 import { splitInChunks } from '../util';
 
@@ -715,6 +715,50 @@ suite('git', () => {
 				[...splitInChunks(['0', '01', '012', '0', '01', '012', '0', '01', '012'], 9)],
 				[['0', '01', '012', '0', '01'], ['012', '0', '01', '012']]
 			);
+		});
+	});
+
+	suite('getCloneTargetFolderName', () => {
+		test('https URL', () => {
+			assert.strictEqual(getCloneTargetFolderName('https://github.com/microsoft/vscode.git'), 'vscode');
+		});
+
+		test('https URL without .git suffix', () => {
+			assert.strictEqual(getCloneTargetFolderName('https://github.com/microsoft/vscode'), 'vscode');
+		});
+
+		test('https URL with trailing slashes', () => {
+			assert.strictEqual(getCloneTargetFolderName('https://github.com/microsoft/vscode///'), 'vscode');
+		});
+
+		test('ssh:// URL', () => {
+			assert.strictEqual(getCloneTargetFolderName('ssh://git@github.com:22/microsoft/vscode.git'), 'vscode');
+		});
+
+		test('git:// URL', () => {
+			assert.strictEqual(getCloneTargetFolderName('git://github.com/microsoft/vscode.git'), 'vscode');
+		});
+
+		test('SCP-style SSH URL with path containing slash', () => {
+			assert.strictEqual(getCloneTargetFolderName('git@github.com:microsoft/vscode.git'), 'vscode');
+		});
+
+		test('SCP-style SSH URL without slash in path (issue #175062)', () => {
+			assert.strictEqual(getCloneTargetFolderName('git@versions.somedomain.net:climate-project'), 'climate-project');
+		});
+
+		test('SCP-style SSH URL without slash in path and .git suffix', () => {
+			assert.strictEqual(getCloneTargetFolderName('git@host.example:repo.git'), 'repo');
+		});
+
+		test('Windows file path with backslashes', () => {
+			assert.strictEqual(getCloneTargetFolderName('C:\\Users\\me\\repo.git'), 'repo');
+		});
+
+		test('empty / unparseable URL falls back to repository', () => {
+			assert.strictEqual(getCloneTargetFolderName(''), 'repository');
+			assert.strictEqual(getCloneTargetFolderName('/'), 'repository');
+			assert.strictEqual(getCloneTargetFolderName('git@host:'), 'repository');
 		});
 	});
 });


### PR DESCRIPTION
Fixes #175062

### Problem

Cloning an SCP-style SSH URL whose path contains no slash – for example `git@versions.somedomain.net:climate-project` – fails on Windows (and is awkward on macOS/Linux) because the derived clone folder name keeps the `user@host:` prefix verbatim:

```
git clone git@versions.somedomain.net:climate-project c:\Users\kit\New folder\git@versions.somedomain.net:climate-project --progress
fatal: could not create work tree dir 'c:\…\git@versions.somedomain.net:climate-project': Invalid argument
```

The literal `:` is reserved in Windows paths, and the `git@host.example:` prefix is meaningless inside a target directory name on any platform.

### Cause

`Git.clone` in `extensions/git/src/git.ts` derives `baseFolderName` from the URL with:

```ts
decodeURI(url).replace(/[\/]+$/, '').replace(/^.*[\/\]/, '').replace(/\.git$/, '')
```

For `git@host.example:repo` there is no `/` (or `\`) at all, so the second replace leaves the string unchanged and the SCP `[user@]host:` prefix survives into the folder name.

### Fix

Strip everything up to the last `:` as an additional step (after the slash-strip):

```ts
decodeURI(url)
    .replace(/[\/]+$/, '')
    .replace(/^.*[\/\]/, '')
    .replace(/^.*:/, '')        // NEW
    .replace(/\.git$/, '') || 'repository'
```

For every URL shape that previously worked, the slash-strip has already collapsed the value to the final path segment (which contains no `:`), so the new step is a no-op. Only SCP-style URLs without a slash in the path – the broken case – are affected.

The derivation is extracted into an exported `getCloneTargetFolderName(url)` helper alongside the other parsers in `git.ts`, and 12 unit tests are added in `git.test.ts` covering https, ssh://, git://, SCP-style with and without a path slash, Windows-style backslash paths, trailing slashes, and the fallback to `'repository'`.

### Out of scope

Full SCP-vs-URL parsing (port handling, scheme-aware logic, `git-url-parse`-style dependencies) is intentionally not introduced – the goal is to repair the one well-defined broken shape without changing behavior for any already-working URL.