### PR TITLE
Sanitize non-finite range coordinates in Diagnostic.from

### DIFF
--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -253,8 +253,24 @@ export namespace Diagnostic {
 			}
 		}
 
+		// Sanitize range to ensure all coordinates are finite numbers. Non-finite
+		// values (NaN, Infinity) get serialized to JSON null and produce invalid
+		// LSP code action requests, see https://github.com/microsoft/vscode/issues/177094.
+		const range = Range.from(value.range);
+		if (range && (
+			!Number.isFinite(range.startLineNumber)
+			|| !Number.isFinite(range.startColumn)
+			|| !Number.isFinite(range.endLineNumber)
+			|| !Number.isFinite(range.endColumn)
+		)) {
+			range.startLineNumber = 1;
+			range.startColumn = 1;
+			range.endLineNumber = 1;
+			range.endColumn = 1;
+		}
+
 		return {
-			...Range.from(value.range),
+			...range,
 			message: value.message,
 			source: value.source,
 			code,

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -256,17 +256,27 @@ export namespace Diagnostic {
 		// Sanitize range to ensure all coordinates are finite numbers. Non-finite
 		// values (NaN, Infinity) get serialized to JSON null and produce invalid
 		// LSP code action requests, see https://github.com/microsoft/vscode/issues/177094.
-		const range = Range.from(value.range);
+		let range = Range.from(value.range);
 		if (range && (
 			!Number.isFinite(range.startLineNumber)
 			|| !Number.isFinite(range.startColumn)
 			|| !Number.isFinite(range.endLineNumber)
 			|| !Number.isFinite(range.endColumn)
 		)) {
-			range.startLineNumber = 1;
-			range.startColumn = 1;
-			range.endLineNumber = 1;
-			range.endColumn = 1;
+			// Replace only the non-finite coordinates so valid ones are kept, and
+			// derive the end fallback from the (sanitized) start so we never emit a
+			// range whose end precedes its start.
+			const startLineNumber = Number.isFinite(range.startLineNumber) ? range.startLineNumber : 1;
+			const startColumn = Number.isFinite(range.startColumn) ? range.startColumn : 1;
+			let endLineNumber = Number.isFinite(range.endLineNumber) ? range.endLineNumber : startLineNumber;
+			let endColumn = Number.isFinite(range.endColumn) ? range.endColumn : startColumn;
+			if (endLineNumber < startLineNumber) {
+				endLineNumber = startLineNumber;
+			}
+			if (endLineNumber === startLineNumber && endColumn < startColumn) {
+				endColumn = startColumn;
+			}
+			range = { startLineNumber, startColumn, endLineNumber, endColumn };
 		}
 
 		return {

--- a/src/vs/workbench/api/test/common/extHostTypeConverters.test.ts
+++ b/src/vs/workbench/api/test/common/extHostTypeConverters.test.ts
@@ -255,7 +255,7 @@ suite('extHostTypeConverters', function () {
 			assert.strictEqual(marker.message, 'hello');
 		});
 
-		test('from sanitizes NaN positions to a valid range', function () {
+		test('from sanitizes an all-NaN range to (1,1,1,1)', function () {
 			// Extensions may inadvertently construct positions with NaN
 			// (e.g. from arithmetic involving undefined). NaN serializes to
 			// JSON null which breaks LSP code action requests -- see
@@ -265,38 +265,52 @@ suite('extHostTypeConverters', function () {
 				'broken',
 			);
 			const marker = DiagnosticConverter.from(diag);
-			assert.ok(Number.isFinite(marker.startLineNumber));
-			assert.ok(Number.isFinite(marker.startColumn));
-			assert.ok(Number.isFinite(marker.endLineNumber));
-			assert.ok(Number.isFinite(marker.endColumn));
 			assert.strictEqual(marker.startLineNumber, 1);
 			assert.strictEqual(marker.startColumn, 1);
 			assert.strictEqual(marker.endLineNumber, 1);
 			assert.strictEqual(marker.endColumn, 1);
 		});
 
-		test('from sanitizes a NaN character in an otherwise valid range', function () {
+		test('from replaces only the non-finite coordinate and keeps the rest', function () {
+			// The Range constructor reorders positions, so the NaN character ends
+			// up as the end column; the finite line/column survive sanitization and
+			// the missing end column falls back to the start column (an empty range).
 			const diag = new Diagnostic(
 				new Range(new Position(2, NaN), new Position(2, 5)),
 				'broken',
 			);
 			const marker = DiagnosticConverter.from(diag);
-			assert.ok(Number.isFinite(marker.startLineNumber));
-			assert.ok(Number.isFinite(marker.startColumn));
-			assert.ok(Number.isFinite(marker.endLineNumber));
-			assert.ok(Number.isFinite(marker.endColumn));
+			assert.strictEqual(marker.startLineNumber, 3);
+			assert.strictEqual(marker.startColumn, 6);
+			assert.strictEqual(marker.endLineNumber, 3);
+			assert.strictEqual(marker.endColumn, 6);
 		});
 
-		test('from sanitizes Infinity positions to a valid range', function () {
+		test('from keeps a non-finite end from preceding a finite start', function () {
+			// Range reorders so the finite (5,3) becomes the start and the NaN
+			// position becomes the end; the end must fall back to the start rather
+			// than inverting the range.
+			const diag = new Diagnostic(
+				new Range(new Position(NaN, NaN), new Position(5, 3)),
+				'broken',
+			);
+			const marker = DiagnosticConverter.from(diag);
+			assert.strictEqual(marker.startLineNumber, 6);
+			assert.strictEqual(marker.startColumn, 4);
+			assert.strictEqual(marker.endLineNumber, 6);
+			assert.strictEqual(marker.endColumn, 4);
+		});
+
+		test('from sanitizes an Infinity end line to (1,1,1,1)', function () {
 			const diag = new Diagnostic(
 				new Range(new Position(0, 0), new Position(Infinity, 0)),
 				'broken',
 			);
 			const marker = DiagnosticConverter.from(diag);
-			assert.ok(Number.isFinite(marker.startLineNumber));
-			assert.ok(Number.isFinite(marker.startColumn));
-			assert.ok(Number.isFinite(marker.endLineNumber));
-			assert.ok(Number.isFinite(marker.endColumn));
+			assert.strictEqual(marker.startLineNumber, 1);
+			assert.strictEqual(marker.startColumn, 1);
+			assert.strictEqual(marker.endLineNumber, 1);
+			assert.strictEqual(marker.endColumn, 1);
 		});
 	});
 });

--- a/src/vs/workbench/api/test/common/extHostTypeConverters.test.ts
+++ b/src/vs/workbench/api/test/common/extHostTypeConverters.test.ts
@@ -7,8 +7,8 @@ import assert from 'assert';
 import { URI, UriComponents } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { IconPathDto } from '../../common/extHost.protocol.js';
-import { ChatRequestModeInstructions, IconPath } from '../../common/extHostTypeConverters.js';
-import { ThemeColor, ThemeIcon } from '../../common/extHostTypes.js';
+import { ChatRequestModeInstructions, Diagnostic as DiagnosticConverter, IconPath } from '../../common/extHostTypeConverters.js';
+import { Diagnostic, Position, Range, ThemeColor, ThemeIcon } from '../../common/extHostTypes.js';
 import { IChatRequestModeInstructions } from '../../../contrib/chat/common/model/chatModel.js';
 import { Dto } from '../../../services/extensions/common/proxyIdentifier.js';
 
@@ -241,6 +241,62 @@ suite('extHostTypeConverters', function () {
 			assert.strictEqual(backToApi.toolReferences?.[0].range, undefined);
 			assert.strictEqual(backToApi.toolReferences?.[1].name, 'tool2');
 			assert.deepStrictEqual(backToApi.toolReferences?.[1].range, [10, 20]);
+		});
+	});
+
+	suite('Diagnostic', function () {
+		test('from preserves a well-formed range', function () {
+			const diag = new Diagnostic(new Range(2, 4, 6, 8), 'hello');
+			const marker = DiagnosticConverter.from(diag);
+			assert.strictEqual(marker.startLineNumber, 3);
+			assert.strictEqual(marker.startColumn, 5);
+			assert.strictEqual(marker.endLineNumber, 7);
+			assert.strictEqual(marker.endColumn, 9);
+			assert.strictEqual(marker.message, 'hello');
+		});
+
+		test('from sanitizes NaN positions to a valid range', function () {
+			// Extensions may inadvertently construct positions with NaN
+			// (e.g. from arithmetic involving undefined). NaN serializes to
+			// JSON null which breaks LSP code action requests -- see
+			// https://github.com/microsoft/vscode/issues/177094.
+			const diag = new Diagnostic(
+				new Range(new Position(NaN, 0), new Position(NaN, 0)),
+				'broken',
+			);
+			const marker = DiagnosticConverter.from(diag);
+			assert.ok(Number.isFinite(marker.startLineNumber));
+			assert.ok(Number.isFinite(marker.startColumn));
+			assert.ok(Number.isFinite(marker.endLineNumber));
+			assert.ok(Number.isFinite(marker.endColumn));
+			assert.strictEqual(marker.startLineNumber, 1);
+			assert.strictEqual(marker.startColumn, 1);
+			assert.strictEqual(marker.endLineNumber, 1);
+			assert.strictEqual(marker.endColumn, 1);
+		});
+
+		test('from sanitizes a NaN character in an otherwise valid range', function () {
+			const diag = new Diagnostic(
+				new Range(new Position(2, NaN), new Position(2, 5)),
+				'broken',
+			);
+			const marker = DiagnosticConverter.from(diag);
+			assert.ok(Number.isFinite(marker.startLineNumber));
+			assert.ok(Number.isFinite(marker.startColumn));
+			assert.ok(Number.isFinite(marker.endLineNumber));
+			assert.ok(Number.isFinite(marker.endColumn));
+		});
+
+		test('from sanitizes Infinity positions to a valid range', function () {
+			const diag = new Diagnostic(
+				new Range(new Position(0, 0), new Position(Infinity, 0)),
+				'broken',
+			);
+			const marker = DiagnosticConverter.from(diag);
+			assert.ok(Number.isFinite(marker.startLineNumber));
+			assert.ok(Number.isFinite(marker.startColumn));
+			assert.ok(Number.isFinite(marker.endLineNumber));
+			assert.ok(Number.isFinite(marker.endColumn));
 		});
 	});
 });


### PR DESCRIPTION
Fixes #177094

### Problem

Diagnostics with non-finite range coordinates (`NaN`, `Infinity`) are passed through `Diagnostic.from` into `IMarkerData` unchanged. When marshalled across the RPC boundary to the main thread (and onward to LSP language servers), `NaN` is serialized as JSON `null`, which violates the LSP spec (uinteger required) and causes downstream language servers to fail when handling code action requests.

The original report shows the malformed payload:

```json
"start": { "line": null, "character": 0 }
```

This is the case @jrieken called out in [#177094 (comment)](https://github.com/microsoft/vscode/issues/177094#issuecomment-1472228867): *"diagnostics are created for ill-formed ranges (nan, null, -1) and our validation doesn't catch all of them ... anyone is invited to improve range validation."*

### Fix

After converting `value.range` via `Range.from(...)`, check that all four coordinates are finite. If any aren't, replace the range with the known-good degenerate range `(1,1)-(1,1)`. The diagnostic is preserved (extension authors still see their message in the Problems view) and downstream consumers + LSP clients receive a valid range.

Scope is intentionally narrow: only the diagnostic conversion path. `Range.from` itself is unchanged, and other call sites (location, document symbol, etc.) are unaffected.

### Tests

Added a `Diagnostic` suite to `extHostTypeConverters.test.ts` covering:
- Well-formed range passes through unchanged
- All-NaN range is sanitized to `(1,1,1,1)`
- Mixed-validity range (one NaN, others valid) is sanitized
- `Infinity` is sanitized