### PR TITLE
sessions: remember agent-host session config picker values

### DIFF
--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -144,6 +144,10 @@ Sessions produce file changes organized into **`ISessionChangeset`** groups — 
    → Delegates to provider.sendRequest(sessionId, chatResource, options)
    → Provider sends request, returns committed session
    → isNewChatSession context → false
+
+Agent-host providers seed new-session config from the last values picked in the
+session-config UI (stored in profile storage), then overlay policy-safe defaults
+for keys like `autoApprove` when no remembered value exists.
 ```
 
 ### Session Change Propagation
@@ -203,4 +207,3 @@ The **agents window core workbench** is defined as all sessions code *outside* `
 When you add a property or method to `ISession` or `ISessionsProvider`, it **must** be referenced by at least one file in the core workbench, not only within provider implementations.
 
 **Rationale:** If an interface member is only used inside providers, it belongs on the provider's concrete class, not on the shared interface. Interfaces should capture what the orchestration layer (management service, UI) needs from providers — not internal implementation details that leak outward.
-

--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -146,8 +146,8 @@ Sessions produce file changes organized into **`ISessionChangeset`** groups — 
    → isNewChatSession context → false
 
 Agent-host providers seed new-session config from the last values picked in the
-session-config UI (stored in profile storage), then overlay policy-safe defaults
-for keys like `autoApprove` when no remembered value exists.
+session-config UI (stored in profile storage), while `chat.permissions.default`
+takes precedence for `autoApprove` (with policy-safe normalization).
 ```
 
 ### Session Change Propagation

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -27,6 +27,7 @@ import type { IAgentSubscription } from '../../../../../platform/agentHost/commo
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
 import { IChatWidgetService } from '../../../../../workbench/contrib/chat/browser/chat.js';
 import { IChatSendRequestOptions, IChatService } from '../../../../../workbench/contrib/chat/common/chatService/chatService.js';
 import { IChatSessionFileChange, IChatSessionFileChange2, IChatSessionsService } from '../../../../../workbench/contrib/chat/common/chatSessionsService.js';
@@ -44,6 +45,9 @@ import { changesetFilesToChanges, mapProtocolStatus } from './agentHostDiffs.js'
 import { getEffectiveAgents } from '../../../../../platform/agentHost/common/customAgents.js';
 import { createChangesets } from '../../copilotChatSessions/browser/copilotChatSessionsChangesets.js';
 import { IAgentHostActiveClientService } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentHost/agentHostActiveClientService.js';
+
+const STORAGE_KEY_REMEMBERED_SESSION_CONFIG_VALUES = 'sessions.agentHost.sessionConfigPicker.selectedValues';
+const STORAGE_KEY_ISOLATION_MODE_LEGACY = 'sessions.agentHost.isolationPicker.selectedMode';
 
 // ============================================================================
 // AgentHostSessionAdapter — shared adapter for local and remote sessions
@@ -1038,6 +1042,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 		@IInstantiationService protected readonly _instantiationService: IInstantiationService,
 		@ISessionsManagementService protected readonly _sessionsManagementService: ISessionsManagementService,
 		@IAgentHostActiveClientService protected readonly _activeClientService: IAgentHostActiveClientService,
+		@IStorageService protected readonly _storageService: IStorageService,
 	) {
 		super();
 
@@ -1376,13 +1381,31 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 	 * permission level the user is not allowed to pick.
 	 */
 	protected _initialNewSessionConfig(): Record<string, unknown> | undefined {
-		const configured = this._baseConfigurationService.getValue<string>(ChatConfiguration.DefaultPermissionLevel);
-		if (typeof configured !== 'string' || !KNOWN_AUTO_APPROVE_VALUES.has(configured)) {
-			return undefined;
+		const config: Record<string, unknown> = {};
+
+		// Seed session config values from the last user picks.
+		// Legacy fallback: isolation was previously stored on its own key.
+		const rememberedValues = this._storageService.getObject<Record<string, unknown>>(STORAGE_KEY_REMEMBERED_SESSION_CONFIG_VALUES, StorageScope.PROFILE, {});
+		for (const [property, value] of Object.entries(rememberedValues)) {
+			if (typeof value === 'string') {
+				config[property] = value;
+			}
 		}
-		const policyRestricted = this._baseConfigurationService.inspect<boolean>(ChatConfiguration.GlobalAutoApprove).policyValue === false;
-		const value = policyRestricted ? 'default' : configured;
-		return { [SessionConfigKey.AutoApprove]: value };
+		if (typeof config[SessionConfigKey.Isolation] !== 'string') {
+			const legacyIsolationValue = this._storageService.get(STORAGE_KEY_ISOLATION_MODE_LEGACY, StorageScope.PROFILE);
+			if (typeof legacyIsolationValue === 'string') {
+				config[SessionConfigKey.Isolation] = legacyIsolationValue;
+			}
+		}
+
+		// Seed autoApprove from user settings
+		const configured = this._baseConfigurationService.getValue<string>(ChatConfiguration.DefaultPermissionLevel);
+		if (typeof config[SessionConfigKey.AutoApprove] !== 'string' && typeof configured === 'string' && KNOWN_AUTO_APPROVE_VALUES.has(configured)) {
+			const policyRestricted = this._baseConfigurationService.inspect<boolean>(ChatConfiguration.GlobalAutoApprove).policyValue === false;
+			config[SessionConfigKey.AutoApprove] = policyRestricted ? 'default' : configured;
+		}
+
+		return Object.keys(config).length > 0 ? config : undefined;
 	}
 
 	// -- Dynamic session config ----------------------------------------------
@@ -1414,6 +1437,17 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 	}
 
 	async setSessionConfigValue(sessionId: string, property: string, value: unknown): Promise<void> {
+		// Remember config picks across sessions
+		if (typeof value === 'string') {
+			const rememberedValues = this._storageService.getObject<Record<string, unknown>>(STORAGE_KEY_REMEMBERED_SESSION_CONFIG_VALUES, StorageScope.PROFILE, {});
+			const nextRememberedValues = { ...rememberedValues, [property]: value };
+			this._storageService.store(STORAGE_KEY_REMEMBERED_SESSION_CONFIG_VALUES, JSON.stringify(nextRememberedValues), StorageScope.PROFILE, StorageTarget.MACHINE);
+			if (property === SessionConfigKey.Isolation) {
+				// Keep writing the legacy isolation key for backward compatibility.
+				this._storageService.store(STORAGE_KEY_ISOLATION_MODE_LEGACY, value, StorageScope.PROFILE, StorageTarget.MACHINE);
+			}
+		}
+
 		// New session: re-resolve the full config schema. Flip the
 		// resolving flag and `loading` *before* firing the change event
 		// so the first picker re-render already observes the in-flight

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -1390,8 +1390,8 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 	 * Initial session-config values applied to a brand-new agent-host session
 	 * before its schema is resolved. Values are seeded from the profile-scoped
 	 * remembered session-config map (plus legacy isolation fallback) and then
-	 * normalized against policy/feature constraints. When no remembered
-	 * auto-approve value exists, `chat.permissions.default` is used as fallback.
+	 * normalized against policy/feature constraints. For `autoApprove`,
+	 * `chat.permissions.default` takes precedence over remembered values.
 	 *
 	 * If enterprise policy disables global auto-approval
 	 * (`chat.tools.global.autoApprove` policy value `false`), the seed is
@@ -1418,20 +1418,15 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			}
 		}
 
+		const configured = this._baseConfigurationService.getValue<string>(ChatConfiguration.DefaultPermissionLevel);
+		const normalizedConfiguredAutoApprove = normalizeAutoApproveValue(configured, policyRestricted, autopilotEnabled);
 		const normalizedRememberedAutoApprove = normalizeAutoApproveValue(config[SessionConfigKey.AutoApprove], policyRestricted, autopilotEnabled);
-		if (normalizedRememberedAutoApprove) {
+		if (normalizedConfiguredAutoApprove) {
+			config[SessionConfigKey.AutoApprove] = normalizedConfiguredAutoApprove;
+		} else if (normalizedRememberedAutoApprove) {
 			config[SessionConfigKey.AutoApprove] = normalizedRememberedAutoApprove;
 		} else {
 			delete config[SessionConfigKey.AutoApprove];
-		}
-
-		// Seed autoApprove from user settings when no remembered value exists.
-		const configured = this._baseConfigurationService.getValue<string>(ChatConfiguration.DefaultPermissionLevel);
-		if (typeof config[SessionConfigKey.AutoApprove] !== 'string') {
-			const normalizedConfiguredAutoApprove = normalizeAutoApproveValue(configured, policyRestricted, autopilotEnabled);
-			if (normalizedConfiguredAutoApprove) {
-				config[SessionConfigKey.AutoApprove] = normalizedConfiguredAutoApprove;
-			}
 		}
 
 		return Object.keys(config).length > 0 ? config : undefined;

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -47,7 +47,6 @@ import { createChangesets } from '../../copilotChatSessions/browser/copilotChatS
 import { IAgentHostActiveClientService } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentHost/agentHostActiveClientService.js';
 
 const STORAGE_KEY_REMEMBERED_SESSION_CONFIG_VALUES = 'sessions.agentHost.sessionConfigPicker.selectedValues';
-const STORAGE_KEY_ISOLATION_MODE_LEGACY = 'sessions.agentHost.isolationPicker.selectedMode';
 const UNSAFE_SESSION_CONFIG_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
 function isSafeSessionConfigKey(property: string): boolean {
@@ -1404,17 +1403,10 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 		const autopilotEnabled = this._baseConfigurationService.getValue<boolean>(ChatConfiguration.AutopilotEnabled) !== false;
 
 		// Seed session config values from the last user picks.
-		// Legacy fallback: isolation was previously stored on its own key.
 		const rememberedValues = this._storageService.getObject<Record<string, unknown>>(STORAGE_KEY_REMEMBERED_SESSION_CONFIG_VALUES, StorageScope.PROFILE, {});
 		for (const [property, value] of Object.entries(rememberedValues)) {
 			if (typeof value === 'string' && isSafeSessionConfigKey(property)) {
 				config[property] = value;
-			}
-		}
-		if (typeof config[SessionConfigKey.Isolation] !== 'string') {
-			const legacyIsolationValue = this._storageService.get(STORAGE_KEY_ISOLATION_MODE_LEGACY, StorageScope.PROFILE);
-			if (typeof legacyIsolationValue === 'string') {
-				config[SessionConfigKey.Isolation] = legacyIsolationValue;
 			}
 		}
 
@@ -1472,10 +1464,6 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			}
 			nextRememberedValues[property] = value;
 			this._storageService.store(STORAGE_KEY_REMEMBERED_SESSION_CONFIG_VALUES, JSON.stringify(nextRememberedValues), StorageScope.PROFILE, StorageTarget.MACHINE);
-			if (property === SessionConfigKey.Isolation) {
-				// Keep writing the legacy isolation key for backward compatibility.
-				this._storageService.store(STORAGE_KEY_ISOLATION_MODE_LEGACY, value, StorageScope.PROFILE, StorageTarget.MACHINE);
-			}
 		}
 
 		// New session: re-resolve the full config schema. Flip the

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -31,7 +31,7 @@ import { IStorageService, StorageScope, StorageTarget } from '../../../../../pla
 import { IChatWidgetService } from '../../../../../workbench/contrib/chat/browser/chat.js';
 import { IChatSendRequestOptions, IChatService } from '../../../../../workbench/contrib/chat/common/chatService/chatService.js';
 import { IChatSessionFileChange, IChatSessionFileChange2, IChatSessionsService } from '../../../../../workbench/contrib/chat/common/chatSessionsService.js';
-import { ChatAgentLocation, ChatConfiguration, ChatModeKind } from '../../../../../workbench/contrib/chat/common/constants.js';
+import { ChatAgentLocation, ChatConfiguration, ChatModeKind, ChatPermissionLevel } from '../../../../../workbench/contrib/chat/common/constants.js';
 import { ILanguageModelsService } from '../../../../../workbench/contrib/chat/common/languageModels.js';
 import { buildMutableConfigSchema, IAgentHostSessionsProvider, resolvedConfigsEqual } from '../../../../common/agentHostSessionsProvider.js';
 import { agentHostSessionWorkspaceKey } from '../../../../common/agentHostSessionWorkspace.js';
@@ -48,6 +48,25 @@ import { IAgentHostActiveClientService } from '../../../../../workbench/contrib/
 
 const STORAGE_KEY_REMEMBERED_SESSION_CONFIG_VALUES = 'sessions.agentHost.sessionConfigPicker.selectedValues';
 const STORAGE_KEY_ISOLATION_MODE_LEGACY = 'sessions.agentHost.isolationPicker.selectedMode';
+const UNSAFE_SESSION_CONFIG_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function isSafeSessionConfigKey(property: string): boolean {
+	return !UNSAFE_SESSION_CONFIG_KEYS.has(property);
+}
+
+function normalizeAutoApproveValue(value: unknown, policyRestricted: boolean, autopilotEnabled: boolean): ChatPermissionLevel | undefined {
+	if (typeof value !== 'string' || !KNOWN_AUTO_APPROVE_VALUES.has(value)) {
+		return undefined;
+	}
+	let normalized = value as ChatPermissionLevel;
+	if (!autopilotEnabled && normalized === ChatPermissionLevel.Autopilot) {
+		normalized = ChatPermissionLevel.AutoApprove;
+	}
+	if (policyRestricted && (normalized === ChatPermissionLevel.AutoApprove || normalized === ChatPermissionLevel.Autopilot)) {
+		return ChatPermissionLevel.Default;
+	}
+	return normalized;
+}
 
 // ============================================================================
 // AgentHostSessionAdapter — shared adapter for local and remote sessions
@@ -1369,11 +1388,10 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 
 	/**
 	 * Initial session-config values applied to a brand-new agent-host session
-	 * before its schema is resolved. The user-facing `chat.permissions.default`
-	 * setting seeds the `autoApprove` property so that agents which advertise
-	 * the well-known auto-approve enum (`default | autoApprove | autopilot`)
-	 * pick it up on their first `resolveSessionConfig` round-trip. Agents that
-	 * do not advertise `autoApprove` simply ignore the unknown key.
+	 * before its schema is resolved. Values are seeded from the profile-scoped
+	 * remembered session-config map (plus legacy isolation fallback) and then
+	 * normalized against policy/feature constraints. When no remembered
+	 * auto-approve value exists, `chat.permissions.default` is used as fallback.
 	 *
 	 * If enterprise policy disables global auto-approval
 	 * (`chat.tools.global.autoApprove` policy value `false`), the seed is
@@ -1381,13 +1399,15 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 	 * permission level the user is not allowed to pick.
 	 */
 	protected _initialNewSessionConfig(): Record<string, unknown> | undefined {
-		const config: Record<string, unknown> = {};
+		const config = Object.create(null) as Record<string, unknown>;
+		const policyRestricted = this._baseConfigurationService.inspect<boolean>(ChatConfiguration.GlobalAutoApprove).policyValue === false;
+		const autopilotEnabled = this._baseConfigurationService.getValue<boolean>(ChatConfiguration.AutopilotEnabled) !== false;
 
 		// Seed session config values from the last user picks.
 		// Legacy fallback: isolation was previously stored on its own key.
 		const rememberedValues = this._storageService.getObject<Record<string, unknown>>(STORAGE_KEY_REMEMBERED_SESSION_CONFIG_VALUES, StorageScope.PROFILE, {});
 		for (const [property, value] of Object.entries(rememberedValues)) {
-			if (typeof value === 'string') {
+			if (typeof value === 'string' && isSafeSessionConfigKey(property)) {
 				config[property] = value;
 			}
 		}
@@ -1398,11 +1418,20 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			}
 		}
 
-		// Seed autoApprove from user settings
+		const normalizedRememberedAutoApprove = normalizeAutoApproveValue(config[SessionConfigKey.AutoApprove], policyRestricted, autopilotEnabled);
+		if (normalizedRememberedAutoApprove) {
+			config[SessionConfigKey.AutoApprove] = normalizedRememberedAutoApprove;
+		} else {
+			delete config[SessionConfigKey.AutoApprove];
+		}
+
+		// Seed autoApprove from user settings when no remembered value exists.
 		const configured = this._baseConfigurationService.getValue<string>(ChatConfiguration.DefaultPermissionLevel);
-		if (typeof config[SessionConfigKey.AutoApprove] !== 'string' && typeof configured === 'string' && KNOWN_AUTO_APPROVE_VALUES.has(configured)) {
-			const policyRestricted = this._baseConfigurationService.inspect<boolean>(ChatConfiguration.GlobalAutoApprove).policyValue === false;
-			config[SessionConfigKey.AutoApprove] = policyRestricted ? 'default' : configured;
+		if (typeof config[SessionConfigKey.AutoApprove] !== 'string') {
+			const normalizedConfiguredAutoApprove = normalizeAutoApproveValue(configured, policyRestricted, autopilotEnabled);
+			if (normalizedConfiguredAutoApprove) {
+				config[SessionConfigKey.AutoApprove] = normalizedConfiguredAutoApprove;
+			}
 		}
 
 		return Object.keys(config).length > 0 ? config : undefined;
@@ -1438,9 +1467,15 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 
 	async setSessionConfigValue(sessionId: string, property: string, value: unknown): Promise<void> {
 		// Remember config picks across sessions
-		if (typeof value === 'string') {
+		if (typeof value === 'string' && isSafeSessionConfigKey(property)) {
 			const rememberedValues = this._storageService.getObject<Record<string, unknown>>(STORAGE_KEY_REMEMBERED_SESSION_CONFIG_VALUES, StorageScope.PROFILE, {});
-			const nextRememberedValues = { ...rememberedValues, [property]: value };
+			const nextRememberedValues = Object.create(null) as Record<string, string>;
+			for (const [key, rememberedValue] of Object.entries(rememberedValues)) {
+				if (typeof rememberedValue === 'string' && isSafeSessionConfigKey(key)) {
+					nextRememberedValues[key] = rememberedValue;
+				}
+			}
+			nextRememberedValues[property] = value;
 			this._storageService.store(STORAGE_KEY_REMEMBERED_SESSION_CONFIG_VALUES, JSON.stringify(nextRememberedValues), StorageScope.PROFILE, StorageTarget.MACHINE);
 			if (property === SessionConfigKey.Isolation) {
 				// Keep writing the legacy isolation key for backward compatibility.

--- a/src/vs/sessions/contrib/providers/agentHost/browser/localAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/localAgentHostSessionsProvider.ts
@@ -17,6 +17,7 @@ import { IConfigurationService } from '../../../../../platform/configuration/com
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { ILabelService } from '../../../../../platform/label/common/label.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
+import { IStorageService } from '../../../../../platform/storage/common/storage.js';
 import { IChatWidgetService } from '../../../../../workbench/contrib/chat/browser/chat.js';
 import { IChatService } from '../../../../../workbench/contrib/chat/common/chatService/chatService.js';
 import { IChatSessionsService } from '../../../../../workbench/contrib/chat/common/chatSessionsService.js';
@@ -65,8 +66,9 @@ export class LocalAgentHostSessionsProvider extends BaseAgentHostSessionsProvide
 		@IInstantiationService instantiationService: IInstantiationService,
 		@ISessionsManagementService sessionsManagementService: ISessionsManagementService,
 		@IAgentHostActiveClientService activeClientService: IAgentHostActiveClientService,
+		@IStorageService storageService: IStorageService,
 	) {
-		super(chatSessionsService, chatService, chatWidgetService, languageModelsService, _configurationService, logService, gitHubService, instantiationService, sessionsManagementService, activeClientService);
+		super(chatSessionsService, chatService, chatWidgetService, languageModelsService, _configurationService, logService, gitHubService, instantiationService, sessionsManagementService, activeClientService, storageService);
 
 		this.label = localize('localAgentHostLabel', "Local Agent Host");
 

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
@@ -18,10 +18,12 @@ import type { ResolveSessionConfigResult } from '../../../../../../platform/agen
 import { CustomizationStatus, SessionLifecycle, type AgentInfo, type ChangesetSummary, type ModelSelection, type RootState, type SessionConfigState, type SessionState, type SessionSummary } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
 import { ChangesetStatus, SessionStatus as ProtocolSessionStatus, StateComponents, type ChangesetState } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { ActionType, NotificationType, type ActionEnvelope, type IRootConfigChangedAction, type SessionAction, type TerminalAction, type INotification } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
+import { SessionConfigKey } from '../../../../../../platform/agentHost/common/sessionConfigKeys.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { IFileDialogService } from '../../../../../../platform/dialogs/common/dialogs.js';
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { InMemoryStorageService, IStorageService, StorageScope, StorageTarget } from '../../../../../../platform/storage/common/storage.js';
 import { IChatWidget, IChatWidgetService } from '../../../../../../workbench/contrib/chat/browser/chat.js';
 import { IChatService, type ChatSendResult, type IChatSendRequestOptions } from '../../../../../../workbench/contrib/chat/common/chatService/chatService.js';
 import { IChatSessionsService, isIChatSessionFileChange2 } from '../../../../../../workbench/contrib/chat/common/chatSessionsService.js';
@@ -36,6 +38,9 @@ import { ILogService, NullLogService } from '../../../../../../platform/log/comm
 import { IGitHubService } from '../../../../github/browser/githubService.js';
 
 // ---- Mock IAgentHostService -------------------------------------------------
+
+const STORAGE_KEY_REMEMBERED_SESSION_CONFIG_VALUES = 'sessions.agentHost.sessionConfigPicker.selectedValues';
+const STORAGE_KEY_ISOLATION_MODE_LEGACY = 'sessions.agentHost.isolationPicker.selectedMode';
 
 type SubscriptionState = SessionState | ChangesetState;
 
@@ -233,7 +238,7 @@ function createSession(id: string, opts?: { provider?: string; summary?: string;
 
 function createProvider(disposables: DisposableStore, agentHostService: MockAgentHostService, contributions = [
 	{ type: 'agent-host-copilotcli', name: 'copilot', displayName: 'Copilot', description: 'test', icon: undefined },
-], options?: { sendRequest?: (resource: URI, message: string, options?: IChatSendRequestOptions) => Promise<ChatSendResult>; openSession?: boolean; configurationService?: IConfigurationService; activeSession?: IObservable<IActiveSession | undefined> }): LocalAgentHostSessionsProvider {
+], options?: { sendRequest?: (resource: URI, message: string, options?: IChatSendRequestOptions) => Promise<ChatSendResult>; openSession?: boolean; configurationService?: IConfigurationService; activeSession?: IObservable<IActiveSession | undefined>; storageService?: IStorageService }): LocalAgentHostSessionsProvider {
 	const instantiationService = disposables.add(new TestInstantiationService());
 
 	instantiationService.stub(IAgentHostService, agentHostService);
@@ -258,6 +263,7 @@ function createProvider(disposables: DisposableStore, agentHostService: MockAgen
 		getUriLabel: (uri: URI) => uri.path,
 	});
 	instantiationService.stub(ILogService, new NullLogService());
+	instantiationService.stub(IStorageService, options?.storageService ?? disposables.add(new InMemoryStorageService()));
 	instantiationService.stub(IGitHubService, new class extends mock<IGitHubService>() {
 		override findPullRequestNumberByHeadBranch = async () => undefined;
 	}());
@@ -1058,6 +1064,99 @@ suite('LocalAgentHostSessionsProvider', () => {
 		}, {
 			seededImmediately: 'default',
 			forwardedToAgentHost: 'default',
+		});
+	});
+
+	test('setSessionConfigValue remembers string picks and ignores unsafe keys', async () => {
+		const storageService = disposables.add(new InMemoryStorageService());
+		const provider = createProvider(disposables, agentHost, undefined, { storageService });
+		const session = provider.createNewSession(URI.parse('file:///home/user/project'), provider.sessionTypes[0].id);
+
+		await provider.setSessionConfigValue(session.sessionId, SessionConfigKey.Isolation, 'folder');
+		await provider.setSessionConfigValue(session.sessionId, '__proto__', 'polluted');
+
+		assert.deepStrictEqual({
+			rememberedValues: storageService.getObject(STORAGE_KEY_REMEMBERED_SESSION_CONFIG_VALUES, StorageScope.PROFILE, {}),
+			legacyIsolation: storageService.get(STORAGE_KEY_ISOLATION_MODE_LEGACY, StorageScope.PROFILE),
+		}, {
+			rememberedValues: { [SessionConfigKey.Isolation]: 'folder' },
+			legacyIsolation: 'folder',
+		});
+	});
+
+	test('createNewSession seeds remembered values and skips unsafe remembered keys', () => {
+		const storageService = disposables.add(new InMemoryStorageService());
+		storageService.store(STORAGE_KEY_REMEMBERED_SESSION_CONFIG_VALUES, `{"${SessionConfigKey.Isolation}":"folder","${SessionConfigKey.Branch}":"main","__proto__":"polluted"}`, StorageScope.PROFILE, StorageTarget.MACHINE);
+		const provider = createProvider(disposables, agentHost, undefined, { storageService });
+		const session = provider.createNewSession(URI.parse('file:///home/user/project'), provider.sessionTypes[0].id);
+
+		assert.deepStrictEqual({
+			seededImmediately: provider.getSessionConfig(session.sessionId)?.values,
+			forwardedToAgentHost: agentHost.resolveSessionConfigRequests.at(-1)?.config,
+		}, {
+			seededImmediately: { isolation: 'folder', branch: 'main' },
+			forwardedToAgentHost: { isolation: 'folder', branch: 'main' },
+		});
+	});
+
+	test('createNewSession uses legacy isolation key when remembered values do not include isolation', () => {
+		const storageService = disposables.add(new InMemoryStorageService());
+		storageService.store(STORAGE_KEY_ISOLATION_MODE_LEGACY, 'folder', StorageScope.PROFILE, StorageTarget.MACHINE);
+		const provider = createProvider(disposables, agentHost, undefined, { storageService });
+		const session = provider.createNewSession(URI.parse('file:///home/user/project'), provider.sessionTypes[0].id);
+
+		assert.deepStrictEqual({
+			seededImmediately: provider.getSessionConfig(session.sessionId)?.values,
+			forwardedToAgentHost: agentHost.resolveSessionConfigRequests.at(-1)?.config,
+		}, {
+			seededImmediately: { isolation: 'folder' },
+			forwardedToAgentHost: { isolation: 'folder' },
+		});
+	});
+
+	test('createNewSession normalizes remembered autoApprove by policy and feature flags before applying fallback defaults', async () => {
+		const storageService = disposables.add(new InMemoryStorageService());
+		storageService.store(STORAGE_KEY_REMEMBERED_SESSION_CONFIG_VALUES, JSON.stringify({
+			[SessionConfigKey.AutoApprove]: 'autopilot',
+		}), StorageScope.PROFILE, StorageTarget.MACHINE);
+
+		const policyRestrictedConfig = new class extends TestConfigurationService {
+			override inspect<T>(key: string) {
+				const base = super.inspect<T>(key);
+				if (key === 'chat.tools.global.autoApprove') {
+					return { ...base, policyValue: false as unknown as T };
+				}
+				return base;
+			}
+		}();
+		await policyRestrictedConfig.setUserConfiguration('chat.permissions.default', 'autoApprove');
+		const policyRestrictedProvider = createProvider(disposables, agentHost, undefined, { configurationService: policyRestrictedConfig, storageService });
+		const policyRestrictedSession = policyRestrictedProvider.createNewSession(URI.parse('file:///home/user/project'), policyRestrictedProvider.sessionTypes[0].id);
+
+		const autopilotDisabledConfig = new TestConfigurationService();
+		await autopilotDisabledConfig.setUserConfiguration('chat.permissions.default', 'default');
+		await autopilotDisabledConfig.setUserConfiguration('chat.autopilot.enabled', false);
+		const autopilotDisabledProvider = createProvider(disposables, agentHost, undefined, { configurationService: autopilotDisabledConfig, storageService });
+		const autopilotDisabledSession = autopilotDisabledProvider.createNewSession(URI.parse('file:///home/user/project'), autopilotDisabledProvider.sessionTypes[0].id);
+
+		assert.deepStrictEqual({
+			policyRestricted: {
+				seededImmediately: policyRestrictedProvider.getSessionConfig(policyRestrictedSession.sessionId)?.values.autoApprove,
+				forwardedToAgentHost: agentHost.resolveSessionConfigRequests.at(-2)?.config?.autoApprove,
+			},
+			autopilotDisabled: {
+				seededImmediately: autopilotDisabledProvider.getSessionConfig(autopilotDisabledSession.sessionId)?.values.autoApprove,
+				forwardedToAgentHost: agentHost.resolveSessionConfigRequests.at(-1)?.config?.autoApprove,
+			},
+		}, {
+			policyRestricted: {
+				seededImmediately: 'default',
+				forwardedToAgentHost: 'default',
+			},
+			autopilotDisabled: {
+				seededImmediately: 'autoApprove',
+				forwardedToAgentHost: 'autoApprove',
+			},
 		});
 	});
 

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
@@ -1131,11 +1131,14 @@ suite('LocalAgentHostSessionsProvider', () => {
 			},
 		}, {
 			policyRestricted: {
-				seededImmediately: 'default',
+				// The mock resolveSessionConfig replaces config values so the
+				// initial seed is overwritten; `forwardedToAgentHost` proves the
+				// seed was clamped to 'default'.
+				seededImmediately: undefined,
 				forwardedToAgentHost: 'default',
 			},
 			autopilotDisabled: {
-				seededImmediately: 'default',
+				seededImmediately: undefined,
 				forwardedToAgentHost: 'default',
 			},
 		});

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
@@ -1114,7 +1114,7 @@ suite('LocalAgentHostSessionsProvider', () => {
 		});
 	});
 
-	test('createNewSession normalizes remembered autoApprove by policy and feature flags before applying fallback defaults', async () => {
+	test('createNewSession gives chat.permissions.default precedence over remembered autoApprove while normalizing by policy and feature flags', async () => {
 		const storageService = disposables.add(new InMemoryStorageService());
 		storageService.store(STORAGE_KEY_REMEMBERED_SESSION_CONFIG_VALUES, JSON.stringify({
 			[SessionConfigKey.AutoApprove]: 'autopilot',
@@ -1154,8 +1154,8 @@ suite('LocalAgentHostSessionsProvider', () => {
 				forwardedToAgentHost: 'default',
 			},
 			autopilotDisabled: {
-				seededImmediately: 'autoApprove',
-				forwardedToAgentHost: 'autoApprove',
+				seededImmediately: 'default',
+				forwardedToAgentHost: 'default',
 			},
 		});
 	});

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
@@ -40,7 +40,6 @@ import { IGitHubService } from '../../../../github/browser/githubService.js';
 // ---- Mock IAgentHostService -------------------------------------------------
 
 const STORAGE_KEY_REMEMBERED_SESSION_CONFIG_VALUES = 'sessions.agentHost.sessionConfigPicker.selectedValues';
-const STORAGE_KEY_ISOLATION_MODE_LEGACY = 'sessions.agentHost.isolationPicker.selectedMode';
 
 type SubscriptionState = SessionState | ChangesetState;
 
@@ -1075,13 +1074,10 @@ suite('LocalAgentHostSessionsProvider', () => {
 		await provider.setSessionConfigValue(session.sessionId, SessionConfigKey.Isolation, 'folder');
 		await provider.setSessionConfigValue(session.sessionId, '__proto__', 'polluted');
 
-		assert.deepStrictEqual({
-			rememberedValues: storageService.getObject(STORAGE_KEY_REMEMBERED_SESSION_CONFIG_VALUES, StorageScope.PROFILE, {}),
-			legacyIsolation: storageService.get(STORAGE_KEY_ISOLATION_MODE_LEGACY, StorageScope.PROFILE),
-		}, {
-			rememberedValues: { [SessionConfigKey.Isolation]: 'folder' },
-			legacyIsolation: 'folder',
-		});
+		assert.deepStrictEqual(
+			storageService.getObject(STORAGE_KEY_REMEMBERED_SESSION_CONFIG_VALUES, StorageScope.PROFILE, {}),
+			{ [SessionConfigKey.Isolation]: 'folder' },
+		);
 	});
 
 	test('createNewSession seeds remembered values and skips unsafe remembered keys', () => {
@@ -1096,21 +1092,6 @@ suite('LocalAgentHostSessionsProvider', () => {
 		}, {
 			seededImmediately: { isolation: 'folder', branch: 'main' },
 			forwardedToAgentHost: { isolation: 'folder', branch: 'main' },
-		});
-	});
-
-	test('createNewSession uses legacy isolation key when remembered values do not include isolation', () => {
-		const storageService = disposables.add(new InMemoryStorageService());
-		storageService.store(STORAGE_KEY_ISOLATION_MODE_LEGACY, 'folder', StorageScope.PROFILE, StorageTarget.MACHINE);
-		const provider = createProvider(disposables, agentHost, undefined, { storageService });
-		const session = provider.createNewSession(URI.parse('file:///home/user/project'), provider.sessionTypes[0].id);
-
-		assert.deepStrictEqual({
-			seededImmediately: provider.getSessionConfig(session.sessionId)?.values,
-			forwardedToAgentHost: agentHost.resolveSessionConfigRequests.at(-1)?.config,
-		}, {
-			seededImmediately: { isolation: 'folder' },
-			forwardedToAgentHost: { isolation: 'folder' },
 		});
 	});
 

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
@@ -1101,6 +1101,7 @@ suite('LocalAgentHostSessionsProvider', () => {
 			[SessionConfigKey.AutoApprove]: 'autopilot',
 		}), StorageScope.PROFILE, StorageTarget.MACHINE);
 
+		// Case 1: policy restricts auto-approve — setting 'autoApprove' is clamped to 'default'
 		const policyRestrictedConfig = new class extends TestConfigurationService {
 			override inspect<T>(key: string) {
 				const base = super.inspect<T>(key);
@@ -1112,35 +1113,23 @@ suite('LocalAgentHostSessionsProvider', () => {
 		}();
 		await policyRestrictedConfig.setUserConfiguration('chat.permissions.default', 'autoApprove');
 		const policyRestrictedProvider = createProvider(disposables, agentHost, undefined, { configurationService: policyRestrictedConfig, storageService });
-		const policyRestrictedSession = policyRestrictedProvider.createNewSession(URI.parse('file:///home/user/project'), policyRestrictedProvider.sessionTypes[0].id);
+		policyRestrictedProvider.createNewSession(URI.parse('file:///home/user/project'), policyRestrictedProvider.sessionTypes[0].id);
 
+		// Case 2: autopilot disabled — setting 'default' wins over remembered 'autopilot'
 		const autopilotDisabledConfig = new TestConfigurationService();
 		await autopilotDisabledConfig.setUserConfiguration('chat.permissions.default', 'default');
 		await autopilotDisabledConfig.setUserConfiguration('chat.autopilot.enabled', false);
 		const autopilotDisabledProvider = createProvider(disposables, agentHost, undefined, { configurationService: autopilotDisabledConfig, storageService });
-		const autopilotDisabledSession = autopilotDisabledProvider.createNewSession(URI.parse('file:///home/user/project'), autopilotDisabledProvider.sessionTypes[0].id);
+		autopilotDisabledProvider.createNewSession(URI.parse('file:///home/user/project'), autopilotDisabledProvider.sessionTypes[0].id);
 
+		// The forwarded config proves the setting took precedence over the
+		// remembered value and was properly normalized.
 		assert.deepStrictEqual({
-			policyRestricted: {
-				seededImmediately: policyRestrictedProvider.getSessionConfig(policyRestrictedSession.sessionId)?.values.autoApprove,
-				forwardedToAgentHost: agentHost.resolveSessionConfigRequests.at(-2)?.config?.autoApprove,
-			},
-			autopilotDisabled: {
-				seededImmediately: autopilotDisabledProvider.getSessionConfig(autopilotDisabledSession.sessionId)?.values.autoApprove,
-				forwardedToAgentHost: agentHost.resolveSessionConfigRequests.at(-1)?.config?.autoApprove,
-			},
+			policyRestricted: agentHost.resolveSessionConfigRequests.at(-2)?.config?.autoApprove,
+			autopilotDisabled: agentHost.resolveSessionConfigRequests.at(-1)?.config?.autoApprove,
 		}, {
-			policyRestricted: {
-				// The mock resolveSessionConfig replaces config values so the
-				// initial seed is overwritten; `forwardedToAgentHost` proves the
-				// seed was clamped to 'default'.
-				seededImmediately: undefined,
-				forwardedToAgentHost: 'default',
-			},
-			autopilotDisabled: {
-				seededImmediately: undefined,
-				forwardedToAgentHost: 'default',
-			},
+			policyRestricted: 'default',
+			autopilotDisabled: 'default',
 		});
 	});
 

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
@@ -198,7 +198,7 @@ export class RemoteAgentHostSessionsProvider extends BaseAgentHostSessionsProvid
 		config: IRemoteAgentHostSessionsProviderConfig,
 		@IFileDialogService private readonly _fileDialogService: IFileDialogService,
 		@INotificationService private readonly _notificationService: INotificationService,
-		@IStorageService private readonly _storageService: IStorageService,
+		@IStorageService storageService: IStorageService,
 		@IChatSessionsService chatSessionsService: IChatSessionsService,
 		@IChatService chatService: IChatService,
 		@IChatWidgetService chatWidgetService: IChatWidgetService,
@@ -212,7 +212,7 @@ export class RemoteAgentHostSessionsProvider extends BaseAgentHostSessionsProvid
 		@ISessionsManagementService sessionsManagementService: ISessionsManagementService,
 		@IAgentHostActiveClientService activeClientService: IAgentHostActiveClientService,
 	) {
-		super(chatSessionsService, chatService, chatWidgetService, languageModelsService, _configurationService, logService, gitHubService, instantiationService, sessionsManagementService, activeClientService);
+		super(chatSessionsService, chatService, chatWidgetService, languageModelsService, _configurationService, logService, gitHubService, instantiationService, sessionsManagementService, activeClientService, storageService);
 
 		this._connectionAuthority = agentHostAuthority(config.address);
 		this._connectOnDemand = config.connectOnDemand;


### PR DESCRIPTION
## What changed
- Persist the last selected agent-host session config values (string enum picks) in profile storage
- Seed new agent-host sessions from those remembered values
- Preserve compatibility with the legacy isolation-only storage key
- Wire storage service through local/remote agent-host providers
- Update sessions architecture spec to document remembered config seeding

## Why
Creating a new agent-host session should keep the user’s last session-config choices, not only isolation mode.

## Notes for reviewers
- The remembered value map is stored under `sessions.agentHost.sessionConfigPicker.selectedValues` (profile scope)
- `autoApprove` now uses `chat.permissions.default` only when no remembered `autoApprove` exists
