### PR TITLE
Fix out-of-bounds exception in `viewModelLines` for cross-file-suggestions

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/longDistanceHint/longDistancePreviewEditor.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/longDistanceHint/longDistancePreviewEditor.ts
@@ -96,8 +96,9 @@ export class LongDistancePreviewEditor extends Disposable {
 				return;
 			}
 			const cursorPosition = this._parentEditorObs.cursorPosition.read(reader);
-			if (cursorPosition) {
-				this.previewEditor.setPosition(this._previewTextModel.validatePosition(cursorPosition), 'longDistanceHintPreview');
+			const currentModel = this._previewEditorObs.model.read(reader);
+			if (cursorPosition && currentModel) {
+				this.previewEditor.setPosition(currentModel.validatePosition(cursorPosition), 'longDistanceHintPreview');
 			}
 		}));
 
@@ -224,7 +225,15 @@ export class LongDistancePreviewEditor extends Disposable {
 
 	public readonly updatePreviewEditorEffect = derived(this, reader => {
 		// this._widgetContent.readEffect(reader);
-		this._previewEditorObs.model.read(reader); // update when the model is set
+		const currentModel = this._previewEditorObs.model.read(reader); // update when the model is set
+		const expectedModel = this._state.read(reader)?.textModel;
+
+		// Guard against the race condition where the effect evaluates before setModel autorun has executed
+		if (!expectedModel || !currentModel || expectedModel.dangerouslyGetUnderlyingModel() !== currentModel) {
+			// Clear hidden areas on the stale model so it doesn't retain invalid ranges when modified
+			this.previewEditor.setHiddenAreas([], undefined, true);
+			return;
+		}
 
 		const range = this._state.read(reader)?.visibleLineRange;
 		if (!range) {
@@ -234,8 +243,8 @@ export class LongDistancePreviewEditor extends Disposable {
 		if (range.startLineNumber > 1) {
 			hiddenAreas.push(new Range(1, 1, range.startLineNumber - 1, 1));
 		}
-		if (range.endLineNumberExclusive < this._previewTextModel.getLineCount() + 1) {
-			hiddenAreas.push(new Range(range.endLineNumberExclusive, 1, this._previewTextModel.getLineCount() + 1, 1));
+		if (range.endLineNumberExclusive < currentModel.getLineCount() + 1) {
+			hiddenAreas.push(new Range(range.endLineNumberExclusive, 1, currentModel.getLineCount() + 1, 1));
 		}
 		this.previewEditor.setHiddenAreas(hiddenAreas, undefined, true);
 	});


### PR DESCRIPTION
Fixes #318567

### Problem
When navigating between cross-file inline edit suggestions, Monaco's internal view model occasionally throws a fatal `TypeError` (`this.modelLineProjections[...] is undefined`) in `viewModelLines.ts`.

This occurs due to a race condition when switching suggestions between the modified scratch buffer (`_previewTextModel`) and an original cross-file target buffer (`props.target`). When `props` updates, the derived observable `updatePreviewEditorEffect` can evaluate before the asynchronous `setModel` autorun has finished attaching the new `ITextModel` to the preview widget. As a result, the effect attempts to apply hidden area ranges intended for the new target file onto the stale, previously attached model, leading to out-of-bounds line projection lookups in the view model.

### Solution
1. **Synchronization Guard:** Added a check in `updatePreviewEditorEffect` (`expectedModel.dangerouslyGetUnderlyingModel() !== currentModel`) to detect when the widget model is out of sync with the expected state. If out of sync, it clears hidden areas and halts execution until `setModel` completes.
2. **Dynamic Line Bounding:** Replaced hardcoded references to `_previewTextModel.getLineCount()` with `currentModel.getLineCount()` to ensure hidden area calculations are bounded correctly when displaying cross-file targets.
3. **Model Position Validation:** Updated the cursor position autorun to validate coordinates against `currentModel` rather than `_previewTextModel`.