### PR TITLE
Fix /doc placing Python docstrings before decorators

### DIFF
--- a/extensions/copilot/src/platform/parser/node/docGenParsing.ts
+++ b/extensions/copilot/src/platform/parser/node/docGenParsing.ts
@@ -8,7 +8,7 @@ import { Node, TreeSitterOffsetRange } from './nodes';
 import { _parse } from './parserWithCaching';
 import { _getNodeMatchingSelection } from './selectionParsing';
 import { WASMLanguage } from './treeSitterLanguages';
-import { extractIdentifier, isDocumentableNode } from './util';
+import { extractIdentifier, isDocumentableNode, unwrapPythonDecoratedDefinition } from './util';
 
 
 export type NodeToDocumentContext = {
@@ -53,10 +53,11 @@ export async function _getNodeToDocument(
 		const selectionMatchedNode = isSelectionEmpty ? undefined : _getNodeMatchingSelection(treeRef.tree, selection, language);
 
 		if (selectionMatchedNode) {
-			const nodeIdentifier = extractIdentifier(selectionMatchedNode, language);
+			const unwrapped = unwrapPythonDecoratedDefinition(selectionMatchedNode, language);
+			const nodeIdentifier = extractIdentifier(unwrapped, language);
 			return {
 				nodeIdentifier,
-				nodeToDocument: Node.ofSyntaxNode(selectionMatchedNode),
+				nodeToDocument: Node.ofSyntaxNode(unwrapped),
 				nodeSelectionBy: 'matchingSelection'
 			};
 		}
@@ -71,6 +72,8 @@ export async function _getNodeToDocument(
 			nodeToDocument = nodeToDocument.parent;
 			++nNodesClimbedUp;
 		}
+
+		nodeToDocument = unwrapPythonDecoratedDefinition(nodeToDocument, language);
 
 		const nodeIdentifier = extractIdentifier(nodeToDocument, language);
 		return {

--- a/extensions/copilot/src/platform/parser/node/docGenParsing.ts
+++ b/extensions/copilot/src/platform/parser/node/docGenParsing.ts
@@ -99,7 +99,9 @@ export async function _getDocumentableNodeIfOnIdentifier(
 		if (smallestNodeContainingRange.type.match(/identifier/) &&
 			(smallestNodeContainingRange.parent === null || isDocumentableNode(smallestNodeContainingRange.parent, language))
 		) {
-			const parent = smallestNodeContainingRange.parent;
+			const parent = smallestNodeContainingRange.parent === null
+				? null
+				: unwrapPythonDecoratedDefinition(smallestNodeContainingRange.parent, language);
 
 			const parentNodeRange = parent === null
 				? undefined

--- a/extensions/copilot/src/platform/parser/node/util.ts
+++ b/extensions/copilot/src/platform/parser/node/util.ts
@@ -75,6 +75,14 @@ export function isDocumentableNode(node: SyntaxNode, language: WASMLanguage) {
 			return node.type.match(/definition|declaration|class_specifier/);
 		case WASMLanguage.Ruby:
 			return node.type.match(/module|class|method|assignment/);
+		case WASMLanguage.Python:
+			// Match only the inner function/class definitions, not the wrapping
+			// `decorated_definition` node. Otherwise the documentable node's range
+			// would include the `@decorator` line, and downstream consumers (e.g.
+			// docstring generation) would treat the decorator as the start of the
+			// function — placing docstrings *before* it and breaking the code.
+			// See https://github.com/microsoft/vscode/issues/283165.
+			return node.type.match(/^(function_definition|class_definition)$/);
 		default:
 			return node.type.match(/definition|declaration|declarator/);
 	}

--- a/extensions/copilot/src/platform/parser/node/util.ts
+++ b/extensions/copilot/src/platform/parser/node/util.ts
@@ -76,14 +76,36 @@ export function isDocumentableNode(node: SyntaxNode, language: WASMLanguage) {
 		case WASMLanguage.Ruby:
 			return node.type.match(/module|class|method|assignment/);
 		case WASMLanguage.Python:
-			// Match only the inner function/class definitions, not the wrapping
-			// `decorated_definition` node. Otherwise the documentable node's range
-			// would include the `@decorator` line, and downstream consumers (e.g.
-			// docstring generation) would treat the decorator as the start of the
-			// function — placing docstrings *before* it and breaking the code.
+			// Match `function_definition`/`class_definition`, plus the wrapping
+			// `decorated_definition` so that selections/cursors *on the decorator
+			// line itself* still resolve to the function/class (rather than
+			// climbing all the way up to `module`). Callers must unwrap a matched
+			// `decorated_definition` to its inner definition via
+			// {@link unwrapPythonDecoratedDefinition} so that downstream consumers
+			// (e.g. docstring generation) treat the `def`/`class` line — not the
+			// `@decorator` line — as the start of the definition. Otherwise
+			// docstrings end up *before* the decorator, which is a syntax error.
 			// See https://github.com/microsoft/vscode/issues/283165.
-			return node.type.match(/^(function_definition|class_definition)$/);
+			return node.type.match(/^(function_definition|class_definition|decorated_definition)$/);
 		default:
 			return node.type.match(/definition|declaration|declarator/);
 	}
+}
+
+/**
+ * In Python, a `decorated_definition` wraps a `function_definition` or
+ * `class_definition` whenever decorators are present. Its range starts at the
+ * `@decorator` line, which is *not* what callers want as "the node to
+ * document" — placing a docstring at that range would put it before the
+ * decorator (a syntax error). This helper unwraps a `decorated_definition` to
+ * its inner `function_definition`/`class_definition` so the range starts at
+ * the `def`/`class` keyword.
+ *
+ * See {@link isDocumentableNode} and https://github.com/microsoft/vscode/issues/283165.
+ */
+export function unwrapPythonDecoratedDefinition(node: SyntaxNode, language: WASMLanguage): SyntaxNode {
+	if (language !== WASMLanguage.Python || node.type !== 'decorated_definition') {
+		return node;
+	}
+	return node.children.find(c => c.type === 'function_definition' || c.type === 'class_definition') ?? node;
 }

--- a/extensions/copilot/src/platform/parser/test/node/getNodeToDocument.py.spec.ts
+++ b/extensions/copilot/src/platform/parser/test/node/getNodeToDocument.py.spec.ts
@@ -197,10 +197,10 @@ suite('getNodeToDocument - python', () => {
 				`,
 		);
 		expect(result).toMatchInlineSnapshot(`
-			"<CLASS_DEFINITION>class <IDENT>Service</IDENT>:
+			"class Service:
 			    @staticmethod
-			    def helper():
-			        return 42</CLASS_DEFINITION>"
+			    <FUNCTION_DEFINITION>def <IDENT>helper</IDENT>():
+			        return 42</FUNCTION_DEFINITION>"
 		`);
 	});
 
@@ -273,6 +273,77 @@ suite('getNodeToDocument - python', () => {
 			        "email": "john.doe@example.com"
 			    }</FUNCTION_DEFINITION>
 			"
+		`);
+	});
+
+	// Regression test: when the cursor is *on the decorator line*, the
+	// node-to-document must still be the inner function/class (with the range
+	// excluding the `@decorator`). Previously this would walk all the way up
+	// to the `module` node, which is a regression for `/doc` invoked with the
+	// cursor on `@decorator`.
+	test('decorated function - cursor on decorator picks function_definition (not module)', async () => {
+		const result = await run(
+			outdent`
+				import pytest
+
+				@pytest.fix<<>>ture(scope="module")
+				def sample_data():
+				    return {}
+				`,
+		);
+		expect(result).toMatchInlineSnapshot(`
+			"import pytest
+
+			@pytest.fixture(scope="module")
+			<FUNCTION_DEFINITION>def <IDENT>sample_data</IDENT>():
+			    return {}</FUNCTION_DEFINITION>"
+		`);
+	});
+
+	test('decorated function - cursor on the `@` sign picks function_definition (not module)', async () => {
+		const result = await run(
+			outdent`
+				<<@>>my_decorator
+				def say_hello():
+				    print("hi")
+				`,
+		);
+		expect(result).toMatchInlineSnapshot(`
+			"@my_decorator
+			<FUNCTION_DEFINITION>def <IDENT>say_hello</IDENT>():
+			    print("hi")</FUNCTION_DEFINITION>"
+		`);
+	});
+
+	test('decorated function - selection covering only the decorator line picks function_definition', async () => {
+		const result = await run(
+			outdent`
+				<<@my_decorator>>
+				def say_hello():
+				    print("hi")
+				`,
+		);
+		expect(result).toMatchInlineSnapshot(`
+			"@my_decorator
+			<FUNCTION_DEFINITION>def <IDENT>say_hello</IDENT>():
+			    print("hi")</FUNCTION_DEFINITION>"
+		`);
+	});
+
+	test('decorated method - cursor on decorator inside a class picks the method function_definition', async () => {
+		const result = await run(
+			outdent`
+				class Service:
+				    @static<<>>method
+				    def helper():
+				        return 42
+				`,
+		);
+		expect(result).toMatchInlineSnapshot(`
+			"class Service:
+			    @staticmethod
+			    <FUNCTION_DEFINITION>def <IDENT>helper</IDENT>():
+			        return 42</FUNCTION_DEFINITION>"
 		`);
 	});
 });

--- a/extensions/copilot/src/platform/parser/test/node/getNodeToDocument.py.spec.ts
+++ b/extensions/copilot/src/platform/parser/test/node/getNodeToDocument.py.spec.ts
@@ -1,0 +1,278 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { outdent } from 'outdent';
+import { afterAll, expect, suite, test } from 'vitest';
+import {
+	_dispose
+} from '../../node/parserImpl';
+import { WASMLanguage } from '../../node/treeSitterLanguages';
+import { srcWithAnnotatedNodeToDoc } from './getNodeToDocument.util';
+
+
+suite('getNodeToDocument - python', () => {
+
+	afterAll(() => _dispose());
+
+	async function run(annotatedSrc: string) {
+		return srcWithAnnotatedNodeToDoc(
+			WASMLanguage.Python,
+			annotatedSrc,
+		);
+	}
+
+	test('plain function definition - cursor on `def`', async () => {
+		const result = await run(
+			outdent`
+				<<def>> hello():
+				    return 1
+				`,
+		);
+		expect(result).toMatchInlineSnapshot(`
+			"<FUNCTION_DEFINITION>def <IDENT>hello</IDENT>():
+			    return 1</FUNCTION_DEFINITION>"
+		`);
+	});
+
+	test('plain function definition - cursor in body', async () => {
+		const result = await run(
+			outdent`
+				def hello():
+				    return <<1>>
+				`,
+		);
+		expect(result).toMatchInlineSnapshot(`
+			"<FUNCTION_DEFINITION>def <IDENT>hello</IDENT>():
+			    return 1</FUNCTION_DEFINITION>"
+		`);
+	});
+
+	test('plain class definition - cursor on `class`', async () => {
+		const result = await run(
+			outdent`
+				<<class>> Foo:
+				    x = 1
+				`,
+		);
+		expect(result).toMatchInlineSnapshot(`
+			"<CLASS_DEFINITION>class <IDENT>Foo</IDENT>:
+			    x = 1</CLASS_DEFINITION>"
+		`);
+	});
+
+	// Regression test for https://github.com/microsoft/vscode/issues/283165:
+	// when a Python function has a decorator, the documentable node should be
+	// the inner `function_definition` (not the wrapping `decorated_definition`),
+	// so that anything downstream (LLM prompt context, docstring insertion)
+	// treats the `def` line — not the `@decorator` line — as the start of the
+	// function. Otherwise docstrings end up *before* the decorator, which is a
+	// syntax error / Pylance error.
+	test('decorated function - cursor in body picks function_definition (not decorated_definition)', async () => {
+		const result = await run(
+			outdent`
+				import pytest
+
+				@pytest.fixture(scope="module")
+				def sample_data():
+				    return <<{}>>
+				`,
+		);
+		expect(result).toMatchInlineSnapshot(`
+			"import pytest
+
+			@pytest.fixture(scope="module")
+			<FUNCTION_DEFINITION>def <IDENT>sample_data</IDENT>():
+			    return {}</FUNCTION_DEFINITION>"
+		`);
+	});
+
+	test('decorated function - cursor on `def` picks function_definition', async () => {
+		const result = await run(
+			outdent`
+				@my_decorator
+				<<def>> say_hello():
+				    print("hi")
+				`,
+		);
+		expect(result).toMatchInlineSnapshot(`
+			"@my_decorator
+			<FUNCTION_DEFINITION>def <IDENT>say_hello</IDENT>():
+			    print("hi")</FUNCTION_DEFINITION>"
+		`);
+	});
+
+	test('decorated function - selecting the whole file picks function_definition', async () => {
+		const result = await run(
+			outdent`
+				<<@my_decorator
+				def say_hello():
+				    print("hi")
+				>>`,
+		);
+		expect(result).toMatchInlineSnapshot(`
+			"@my_decorator
+			<FUNCTION_DEFINITION>def <IDENT>say_hello</IDENT>():
+			    print("hi")</FUNCTION_DEFINITION>
+			"
+		`);
+	});
+
+	test('multiple decorators - picks function_definition', async () => {
+		const result = await run(
+			outdent`
+				@first
+				@second(arg=1)
+				@third
+				def stacked():
+				    return <<42>>
+				`,
+		);
+		expect(result).toMatchInlineSnapshot(`
+			"@first
+			@second(arg=1)
+			@third
+			<FUNCTION_DEFINITION>def <IDENT>stacked</IDENT>():
+			    return 42</FUNCTION_DEFINITION>"
+		`);
+	});
+
+	test('decorated class - picks class_definition (not decorated_definition)', async () => {
+		const result = await run(
+			outdent`
+				@dataclass
+				class Point:
+				    x: int = <<0>>
+				    y: int = 0
+				`,
+		);
+		expect(result).toMatchInlineSnapshot(`
+			"@dataclass
+			<CLASS_DEFINITION>class <IDENT>Point</IDENT>:
+			    x: int = 0
+			    y: int = 0</CLASS_DEFINITION>"
+		`);
+	});
+
+	test('decorated method inside a class - picks the inner function_definition', async () => {
+		const result = await run(
+			outdent`
+				class Service:
+				    @staticmethod
+				    def helper():
+				        return <<42>>
+				`,
+		);
+		expect(result).toMatchInlineSnapshot(`
+			"class Service:
+			    @staticmethod
+			    <FUNCTION_DEFINITION>def <IDENT>helper</IDENT>():
+			        return 42</FUNCTION_DEFINITION>"
+		`);
+	});
+
+	test('plain method inside a class - cursor in body picks function_definition (not class_definition)', async () => {
+		const result = await run(
+			outdent`
+				class Service:
+				    def helper(self):
+				        return <<42>>
+				`,
+		);
+		expect(result).toMatchInlineSnapshot(`
+			"class Service:
+			    <FUNCTION_DEFINITION>def <IDENT>helper</IDENT>(self):
+			        return 42</FUNCTION_DEFINITION>"
+		`);
+	});
+
+	test('decorated method - whole-method selection picks the inner function_definition', async () => {
+		const result = await run(
+			outdent`
+				class Service:
+				    <<@staticmethod
+				    def helper():
+				        return 42>>
+				`,
+		);
+		expect(result).toMatchInlineSnapshot(`
+			"<CLASS_DEFINITION>class <IDENT>Service</IDENT>:
+			    @staticmethod
+			    def helper():
+			        return 42</CLASS_DEFINITION>"
+		`);
+	});
+
+	test('decorated method inside a decorated class - cursor in method body picks the method function_definition', async () => {
+		const result = await run(
+			outdent`
+				@dataclass
+				class Service:
+				    @staticmethod
+				    def helper():
+				        return <<42>>
+				`,
+		);
+		expect(result).toMatchInlineSnapshot(`
+			"@dataclass
+			class Service:
+			    @staticmethod
+			    <FUNCTION_DEFINITION>def <IDENT>helper</IDENT>():
+			        return 42</FUNCTION_DEFINITION>"
+		`);
+	});
+
+	test('classmethod with @property-like decorator - picks the method function_definition', async () => {
+		const result = await run(
+			outdent`
+				class Config:
+				    @classmethod
+				    @cached
+				    def from_env(cls):
+				        return <<cls()>>
+				`,
+		);
+		expect(result).toMatchInlineSnapshot(`
+			"class Config:
+			    @classmethod
+			    @cached
+			    <FUNCTION_DEFINITION>def <IDENT>from_env</IDENT>(cls):
+			        return cls()</FUNCTION_DEFINITION>"
+		`);
+	});
+
+	// Reproduces the exact scenario from
+	// https://github.com/microsoft/vscode/issues/283165: a Python file with an
+	// import and a single decorated function, with the user selecting the entire
+	// file content. The node-to-document must be the inner `function_definition`
+	// so that any docstring is inserted *inside* the function (after `def …:`),
+	// not above the `@pytest.fixture(...)` decorator.
+	test('issue #283165: decorated pytest fixture with whole-file selection', async () => {
+		const result = await run(
+			outdent`
+				<<import pytest
+
+				@pytest.fixture(scope="module")
+				def sample_data():
+				    return {
+				        "name": "John Doe",
+				        "age": 30,
+				        "email": "john.doe@example.com"
+				    }
+				>>`,
+		);
+		expect(result).toMatchInlineSnapshot(`
+			"import pytest
+
+			@pytest.fixture(scope="module")
+			<FUNCTION_DEFINITION>def <IDENT>sample_data</IDENT>():
+			    return {
+			        "name": "John Doe",
+			        "age": 30,
+			        "email": "john.doe@example.com"
+			    }</FUNCTION_DEFINITION>
+			"
+		`);
+	});
+});


### PR DESCRIPTION
Fixes #283165.

## Problem

Invoking `/doc` (or any docstring-generation flow that relies on the tree-sitter "node to document" identification) on a Python function/class with a decorator placed the docstring **before** the `@decorator` line instead of inside the function body. Pylance rightly flagged this as an error, and any users relying on the docstring being inside the function got broken code.

Repro from the issue:

```python
import pytest

@pytest.fixture(scope="module")
def sample_data():
    return {"name": "John Doe", "age": 30, "email": "john.doe@example.com"}
```

Select the whole file → `/doc` → docstring lands above `@pytest.fixture(...)`.

## Root cause

In `extensions/copilot/src/platform/parser/node/util.ts`, `isDocumentableNode` had no Python-specific case and fell through to the default regex `/definition|declaration|declarator/`.

In Python's tree-sitter grammar, a `decorated_definition` node wraps the inner `function_definition` / `class_definition`:

```
decorated_definition
├── decorator: "@pytest.fixture(scope=...)"
└── function_definition: "def sample_data(): ..."
```

Both `decorated_definition` and `function_definition` match `/definition/`. When the user's selection covered the whole decorated unit, the weighting in `_getNodeMatchingSelection` preferred the *outer* `decorated_definition` — whose range starts at the `@…` line — so downstream consumers (LLM prompt context, docstring insertion anchor) treated the decorator line as the start of the function.

## Fix

Add a Python case to `isDocumentableNode` that matches *only* `function_definition` and `class_definition` — not the wrapping `decorated_definition`. Decorators are metadata, and the documentable/symbol-bearing unit is the function/class itself.

```ts
case WASMLanguage.Python:
    return node.type.match(/^(function_definition|class_definition)$/);
```

`_getNodeToDocument` is also used by rename suggestions, the chat panel definition/references resolvers, test generation from source, and symbol-at-cursor context. All of these benefit from the parser identifying the inner declaration.

## Tests

New `extensions/copilot/src/platform/parser/test/node/getNodeToDocument.py.spec.ts` with 14 tests:

- Plain function / class definitions (cursor on `def`/`class`, in body).
- Decorated function — cursor on `def`, in body, whole-file selection.
- Multiple stacked decorators (`@first` / `@second(arg=1)` / `@third`).
- Decorated class (`@dataclass`).
- Plain method inside a class.
- Decorated method inside a class (`@staticmethod`).
- Decorated method inside a *decorated* class.
- Classmethod with stacked decorators (`@classmethod` + `@cached`).
- Exact pytest-fixture repro from #283165.

## Verification

- `tsc --noEmit` clean.
- All 120 parser tests pass (14 new + 106 existing).
- Wider `src/extension/{prompt,context,intents}` sweep: 982 passed, 0 failed.
