### PR TITLE
Enable 'Manage Models' action in Agent Host Model Picker

### DIFF
--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostModelPicker.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostModelPicker.ts
@@ -142,7 +142,7 @@ class AgentHostModelPickerContribution extends Disposable implements IWorkbenchC
 					},
 					getModels: () => getAgentHostModels(languageModelsService, sessionsManagementService.activeSession.get()),
 					useGroupedModelPicker: () => true,
-					showManageModelsAction: () => true,
+					showManageModelsAction: () => false,
 					showUnavailableFeatured: () => false,
 					showFeatured: () => true,
 				};

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostModelPicker.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostModelPicker.ts
@@ -142,7 +142,7 @@ class AgentHostModelPickerContribution extends Disposable implements IWorkbenchC
 					},
 					getModels: () => getAgentHostModels(languageModelsService, sessionsManagementService.activeSession.get()),
 					useGroupedModelPicker: () => true,
-					showManageModelsAction: () => false,
+					showManageModelsAction: () => true,
 					showUnavailableFeatured: () => false,
 					showFeatured: () => true,
 				};

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsActions.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsActions.ts
@@ -287,7 +287,7 @@ export function modelPickerStorageKey(sessionType: string): string {
 
 export function shouldShowSessionManageModelsAction(sessionsManagementService: ISessionsManagementService): boolean {
 	const session = sessionsManagementService.activeSession.get();
-	return session?.providerId === COPILOT_PROVIDER_ID && session.sessionType === SessionType.Local;
+	return session?.sessionType === SessionType.Local;
 }
 
 function getVendorFromModelIdentifier(modelIdentifier: string): string | undefined {

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/modelPickerDelegate.test.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/modelPickerDelegate.test.ts
@@ -170,7 +170,7 @@ suite('shouldShowSessionManageModelsAction', () => {
 			shouldShowSessionManageModelsAction(localServices.get(ISessionsManagementService)),
 			shouldShowSessionManageModelsAction(cliServices.get(ISessionsManagementService)),
 			shouldShowSessionManageModelsAction(otherProviderServices.get(ISessionsManagementService)),
-		], [true, false, false]);
+		], [true, false, true]);
 	});
 });
 


### PR DESCRIPTION
The 'Manage Models' action is now enabled in the Agent Host Model Picker, allowing users to manage models directly from the picker interface.