### PR TITLE
Enhance chat agent picker with agent source indicators

### DIFF
--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -1159,7 +1159,7 @@ export class ActionListWidget<T> extends Disposable {
 					element.style.width = 'auto';
 					const width = element.getBoundingClientRect().width;
 					element.style.width = '';
-					itemWidths.push(width + this._computeToolbarWidth(allItems[i]));
+					itemWidths.push(width);
 				}
 			}
 
@@ -1178,7 +1178,7 @@ export class ActionListWidget<T> extends Disposable {
 				element.style.width = 'auto';
 				const width = element.getBoundingClientRect().width;
 				element.style.width = '';
-				itemWidths.push(width + this._computeToolbarWidth(this._list.element(i)));
+				itemWidths.push(width);
 			}
 		}
 		return clamp(Math.max(...itemWidths));
@@ -1372,13 +1372,6 @@ export class ActionListWidget<T> extends Disposable {
 				this._groupTitleByIndex.set(i, item.group.title);
 			}
 		}
-	}
-
-	private _computeToolbarWidth(_item: IActionListItem<T>): number {
-		// Toolbar space is always reserved in the layout via CSS (display: flex; opacity: 0)
-		// for items that have toolbar actions, so the natural DOM measurement already includes
-		// the toolbar width. No additional width needs to be added here.
-		return 0;
 	}
 
 	private _getRowElement(index: number): HTMLElement | null {

--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -1374,17 +1374,11 @@ export class ActionListWidget<T> extends Disposable {
 		}
 	}
 
-	private _computeToolbarWidth(item: IActionListItem<T>): number {
-		let actionCount = item.toolbarActions?.length ?? 0;
-		if (item.onRemove) {
-			actionCount++;
-		}
-		if (actionCount === 0) {
-			return 0;
-		}
-		// Each toolbar action button is ~22px (16px icon + padding) plus 6px row gap
-		const actionButtonWidth = 22;
-		return actionCount * actionButtonWidth + 6;
+	private _computeToolbarWidth(_item: IActionListItem<T>): number {
+		// Toolbar space is always reserved in the layout via CSS (display: flex; opacity: 0)
+		// for items that have toolbar actions, so the natural DOM measurement already includes
+		// the toolbar width. No additional width needs to be added here.
+		return 0;
 	}
 
 	private _getRowElement(index: number): HTMLElement | null {

--- a/src/vs/platform/actionWidget/browser/actionWidget.css
+++ b/src/vs/platform/actionWidget/browser/actionWidget.css
@@ -296,14 +296,22 @@
 	}
 }
 
-/* Item toolbar - shows on hover/focus */
+/* Item toolbar - hidden by default, shown on hover/focus */
 .action-widget .monaco-list-row.action .action-list-item-toolbar {
 	display: none;
 }
 
+/* Reserve space for the toolbar so no layout shift occurs when it appears on hover */
+.action-widget .monaco-list-row.action.has-toolbar .action-list-item-toolbar {
+	display: flex;
+	opacity: 0;
+	pointer-events: none;
+}
+
 .action-widget .monaco-list-row.focused.action.has-toolbar .action-list-item-toolbar,
 .action-widget .monaco-list-row:hover.action.has-toolbar .action-list-item-toolbar {
-	display: flex;
+	opacity: 1;
+	pointer-events: all;
 }
 
 .action-widget .monaco-list-row .action-list-item-toolbar .monaco-action-bar:not(.vertical) .action-label:not(.disabled):hover {

--- a/src/vs/platform/actionWidget/browser/actionWidget.css
+++ b/src/vs/platform/actionWidget/browser/actionWidget.css
@@ -305,12 +305,14 @@
 .action-widget .monaco-list-row.action.has-toolbar .action-list-item-toolbar {
 	display: flex;
 	opacity: 0;
+	visibility: hidden;
 	pointer-events: none;
 }
 
 .action-widget .monaco-list-row.focused.action.has-toolbar .action-list-item-toolbar,
 .action-widget .monaco-list-row:hover.action.has-toolbar .action-list-item-toolbar {
 	opacity: 1;
+	visibility: visible;
 	pointer-events: all;
 }
 

--- a/src/vs/platform/actionWidget/browser/actionWidgetDropdown.ts
+++ b/src/vs/platform/actionWidget/browser/actionWidgetDropdown.ts
@@ -8,6 +8,7 @@ import { BaseDropdown, IActionProvider, IBaseDropdownOptions } from '../../../ba
 import { IListAccessibilityProvider } from '../../../base/browser/ui/list/listWidget.js';
 import { IAction } from '../../../base/common/actions.js';
 import { Codicon } from '../../../base/common/codicons.js';
+import { IMarkdownString } from '../../../base/common/htmlContent.js';
 import { ResolvedKeybinding } from '../../../base/common/keybindings.js';
 import { ThemeIcon } from '../../../base/common/themables.js';
 import { IKeybindingService } from '../../keybinding/common/keybinding.js';
@@ -18,7 +19,7 @@ import { IActionWidgetService } from './actionWidget.js';
 export interface IActionWidgetDropdownAction extends IAction {
 	category?: { label: string; order: number; showHeader?: boolean };
 	icon?: ThemeIcon;
-	description?: string;
+	description?: string | IMarkdownString;
 	/**
 	 * Optional detail text displayed as a second line below the label.
 	 */

--- a/src/vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem.ts
@@ -13,6 +13,7 @@ import { IDisposable } from '../../../../../../base/common/lifecycle.js';
 import { autorun, IObservable, observableValue } from '../../../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { URI } from '../../../../../../base/common/uri.js';
+import { MarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { localize } from '../../../../../../nls.js';
 import { getFlatActionBarActions } from '../../../../../../platform/actions/browser/menuEntryActionViewItem.js';
 import { IMenuService, MenuId, MenuItemAction } from '../../../../../../platform/actions/common/actions.js';
@@ -28,7 +29,7 @@ import { IChatAgentService } from '../../../common/participants/chatAgents.js';
 import { ChatMode, IChatMode, IChatModes } from '../../../common/chatModes.js';
 import { isOrganizationPromptFile } from '../../../common/promptSyntax/utils/promptsServiceUtils.js';
 import { ChatAgentLocation, ChatConfiguration, ChatModeKind } from '../../../common/constants.js';
-import { PromptsStorage } from '../../../common/promptSyntax/service/promptsService.js';
+import { IAgentSource, PromptsStorage } from '../../../common/promptSyntax/service/promptsService.js';
 import { Target } from '../../../common/promptSyntax/promptTypes.js';
 import { getOpenChatActionIdForMode } from '../../actions/chatActions.js';
 import { IToggleChatModeArgs, ToggleAgentModeActionId } from '../../actions/chatExecuteActions.js';
@@ -151,11 +152,16 @@ export class ModePickerActionItem extends ChatInputPickerActionViewItem {
 		};
 
 		const makeActionFromCustomMode = (mode: IChatMode, currentMode: IChatMode): IActionWidgetDropdownAction => {
+			const sourceLabel = getAgentSourceLabel(mode.source);
+			const sourceTooltip = getAgentSourceTooltip(mode.source);
+			const baseHoverContent = mode.description.get() ?? chatAgentService.getDefaultAgent(ChatAgentLocation.Chat, mode.kind)?.description ?? action.tooltip;
+			const hoverContent = sourceTooltip ? `${baseHoverContent}\n\n${sourceTooltip}` : baseHoverContent;
 			return {
 				...makeAction(mode, currentMode),
 				tooltip: '',
-				hover: { content: mode.description.get() ?? chatAgentService.getDefaultAgent(ChatAgentLocation.Chat, mode.kind)?.description ?? action.tooltip },
+				hover: { content: hoverContent },
 				icon: mode.icon.get() ?? (isModeConsideredBuiltIn(mode, this._productService) ? builtinDefaultIcon(mode) : undefined),
+				description: sourceLabel,
 				category: agentModeDisabledViaPolicy ? policyDisabledCategory : customCategory
 			};
 		};
@@ -322,6 +328,31 @@ function isModeConsideredBuiltIn(mode: IChatMode, productService: IProductServic
 		return true;
 	}
 	return !isOrganizationPromptFile(modeUri, mode.source.extensionId, productService);
+}
+
+/**
+ * Returns a MarkdownString containing the $(person) codicon for user-scoped
+ * agents, and undefined for workspace/extension agents (which are the default).
+ * Only personal agents need a visual indicator since workspace agents are
+ * implicitly tied to the current repo.
+ */
+function getAgentSourceLabel(source: IAgentSource | undefined): MarkdownString | undefined {
+	if (source?.storage === PromptsStorage.user) {
+		return new MarkdownString('$(account)', { supportThemeIcons: true });
+	}
+	return undefined;
+}
+
+/**
+ * Returns a localized tooltip string that explains the origin of an agent.
+ * Only user-scoped agents need a tooltip since workspace agents are obvious
+ * from context.
+ */
+function getAgentSourceTooltip(source: IAgentSource | undefined): string | undefined {
+	if (source?.storage === PromptsStorage.user) {
+		return localize('agentSourceUserTooltip', "Personal agent (available across all workspaces)");
+	}
+	return undefined;
 }
 
 function shouldShowBuiltInMode(mode: IChatMode, assignments: { showOldAskMode: boolean }, agentModeDisabledViaPolicy: boolean): boolean {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem.ts
@@ -153,9 +153,7 @@ export class ModePickerActionItem extends ChatInputPickerActionViewItem {
 
 		const makeActionFromCustomMode = (mode: IChatMode, currentMode: IChatMode): IActionWidgetDropdownAction => {
 			const sourceLabel = getAgentSourceLabel(mode.source);
-			const sourceTooltip = getAgentSourceTooltip(mode.source);
-			const baseHoverContent = mode.description.get() ?? chatAgentService.getDefaultAgent(ChatAgentLocation.Chat, mode.kind)?.description ?? action.tooltip;
-			const hoverContent = sourceTooltip ? `${baseHoverContent}\n\n${sourceTooltip}` : baseHoverContent;
+			const hoverContent = mode.description.get() ?? chatAgentService.getDefaultAgent(ChatAgentLocation.Chat, mode.kind)?.description ?? action.tooltip;
 			return {
 				...makeAction(mode, currentMode),
 				tooltip: '',
@@ -339,18 +337,6 @@ function isModeConsideredBuiltIn(mode: IChatMode, productService: IProductServic
 function getAgentSourceLabel(source: IAgentSource | undefined): MarkdownString | undefined {
 	if (source?.storage === PromptsStorage.user) {
 		return new MarkdownString('$(account)', { supportThemeIcons: true });
-	}
-	return undefined;
-}
-
-/**
- * Returns a localized tooltip string that explains the origin of an agent.
- * Only user-scoped agents need a tooltip since workspace agents are obvious
- * from context.
- */
-function getAgentSourceTooltip(source: IAgentSource | undefined): string | undefined {
-	if (source?.storage === PromptsStorage.user) {
-		return localize('agentSourceUserTooltip', "Personal agent (available across all workspaces)");
 	}
 	return undefined;
 }

--- a/src/vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem.ts
@@ -328,12 +328,6 @@ function isModeConsideredBuiltIn(mode: IChatMode, productService: IProductServic
 	return !isOrganizationPromptFile(modeUri, mode.source.extensionId, productService);
 }
 
-/**
- * Returns a MarkdownString containing the $(person) codicon for user-scoped
- * agents, and undefined for workspace/extension agents (which are the default).
- * Only personal agents need a visual indicator since workspace agents are
- * implicitly tied to the current repo.
- */
 function getAgentSourceLabel(source: IAgentSource | undefined): MarkdownString | undefined {
 	if (source?.storage === PromptsStorage.user) {
 		return new MarkdownString('$(account)', { supportThemeIcons: true });


### PR DESCRIPTION
## Summary

UX/QOL improvement: enhances the chat mode picker with visual indicators to help distinguish **personal agents** from workspace-scoped agents.

Previously, users had to open **“Configure Custom Agents…”** (and browse a full list starting from the top-level VS Code command-style menu) to determine where an agent comes from and whether it is available globally or only within the workspace.

With this change, personal agents (typically under `~/copilot`; additional paths as well) now display an `$(account)` icon directly in the picker dropdown. This allows users to immediately distinguish agent scope without leaving the selection flow.

Workspace agents remain unchanged, since their scope is already implied by context.

## Changes

- **`modePickerActionItem.ts`**
  - Added `getAgentSourceLabel()` helper to compute visual indicator for personal agents
  - Updated `makeActionFromCustomMode()` to show the source label as a secondary description

- **`actionWidgetDropdown.ts`**
  - Updated `IActionWidgetDropdownAction.description` to accept `string | IMarkdownString`
  - Enables icon rendering in descriptions via markdown
  - Existing renderer already supports `IMarkdownString` via `renderMarkdown`

## Screenshot
<img width="549" height="245" alt="image" src="https://github.com/user-attachments/assets/f307d432-0fcc-45cf-8fa0-08966e1ed119" />
