### PR TITLE
policy: enterprise managed_settings for Copilot clients

### DIFF
--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -260,7 +260,7 @@
             "localization": {
                 "description": {
                     "key": "chat.plugins.strictMarketplaces.policy",
-                    "value": "Only trust marketplaces listed in `chat.plugins.marketplaces`; plugins from any other marketplace will not load."
+                    "value": "Only trust marketplaces supplied via enterprise policy; plugins from any other marketplace will not load."
                 }
             },
             "type": "boolean",

--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -230,7 +230,7 @@
             "localization": {
                 "description": {
                     "key": "chat.plugins.enabledPlugins.policy",
-                    "value": "Enterprise-managed plugin enablement. Keys are plugin IDs in `<plugin>@<marketplace>` form; values enable or disable the plugin. Merged with user-configured path entries."
+                    "value": "Plugin enablement. Keys are plugin IDs in `<plugin>@<marketplace>` form; values enable or disable the plugin."
                 }
             },
             "type": "object",
@@ -245,14 +245,11 @@
             "localization": {
                 "description": {
                     "key": "chat.plugins.marketplaces.policy",
-                    "value": "Enterprise-managed list of plugin marketplaces to query. Entries are GitHub shorthand (`owner/repo[#ref]`) or Git URIs (`<url>[#ref]`). Merged with user-configured entries."
+                    "value": "Plugin marketplaces to query. Entries are GitHub shorthand (`owner/repo[#ref]`) or Git URIs (`<url>[#ref]`)."
                 }
             },
             "type": "array",
-            "default": [
-                "github/copilot-plugins",
-                "github/awesome-copilot#marketplace"
-            ],
+            "default": [],
             "included": true
         },
         {
@@ -263,7 +260,7 @@
             "localization": {
                 "description": {
                     "key": "chat.plugins.strictMarketplaces.policy",
-                    "value": "When enabled by enterprise policy, only marketplaces listed in `chat.plugins.marketplaces` are trusted; plugins from any other marketplace will not load."
+                    "value": "Only trust marketplaces listed in `chat.plugins.marketplaces`; plugins from any other marketplace will not load."
                 }
             },
             "type": "boolean",

--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -54,6 +54,21 @@
             "included": false
         },
         {
+            "key": "chat.plugins.extraMarketplaces",
+            "name": "ChatExtraMarketplaces",
+            "category": "InteractiveSession",
+            "minimumVersion": "1.122",
+            "localization": {
+                "description": {
+                    "key": "chat.plugins.extraMarketplaces.policy",
+                    "value": "Additional plugin marketplaces to query. Keys are marketplace names; values are GitHub shorthand (`owner/repo[#ref]`) or Git URIs (`<url>[#ref]`)."
+                }
+            },
+            "type": "object",
+            "default": {},
+            "included": false
+        },
+        {
             "key": "chat.mcp.gallery.serviceUrl",
             "name": "McpGalleryServiceUrl",
             "category": "InteractiveSession",

--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -238,22 +238,19 @@
             "included": true
         },
         {
-            "key": "chat.plugins.marketplaces",
-            "name": "ChatPluginMarketplaces",
+            "key": "chat.plugins.extraMarketplaces",
+            "name": "ChatExtraMarketplaces",
             "category": "InteractiveSession",
             "minimumVersion": "1.122",
             "localization": {
                 "description": {
-                    "key": "chat.plugins.marketplaces.policy",
-                    "value": "Plugin marketplaces to query. Entries are GitHub shorthand (`owner/repo[#ref]`) or Git URIs (`<url>[#ref]`)."
+                    "key": "chat.plugins.extraMarketplaces.policy",
+                    "value": "Additional plugin marketplaces to query. Entries are GitHub shorthand (`owner/repo[#ref]`) or Git URIs (`<url>[#ref]`)."
                 }
             },
             "type": "array",
-            "default": [
-                "github/copilot-plugins",
-                "github/awesome-copilot#marketplace"
-            ],
-            "included": true
+            "default": [],
+            "included": false
         },
         {
             "key": "chat.plugins.strictMarketplaces",

--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -249,7 +249,10 @@
                 }
             },
             "type": "array",
-            "default": [],
+            "default": [
+                "github/copilot-plugins",
+                "github/awesome-copilot#marketplace"
+            ],
             "included": true
         },
         {

--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -223,6 +223,54 @@
             "included": true
         },
         {
+            "key": "chat.plugins.enabledPlugins",
+            "name": "ChatEnabledPlugins",
+            "category": "InteractiveSession",
+            "minimumVersion": "1.122",
+            "localization": {
+                "description": {
+                    "key": "chat.plugins.enabledPlugins.policy",
+                    "value": "Enterprise-managed plugin enablement. Keys are plugin IDs in `<plugin>@<marketplace>` form; values enable or disable the plugin. Merged with user-configured path entries."
+                }
+            },
+            "type": "object",
+            "default": {},
+            "included": true
+        },
+        {
+            "key": "chat.plugins.marketplaces",
+            "name": "ChatPluginMarketplaces",
+            "category": "InteractiveSession",
+            "minimumVersion": "1.122",
+            "localization": {
+                "description": {
+                    "key": "chat.plugins.marketplaces.policy",
+                    "value": "Enterprise-managed list of plugin marketplaces to query. Entries are GitHub shorthand (`owner/repo[#ref]`) or Git URIs (`<url>[#ref]`). Merged with user-configured entries."
+                }
+            },
+            "type": "array",
+            "default": [
+                "github/copilot-plugins",
+                "github/awesome-copilot#marketplace"
+            ],
+            "included": true
+        },
+        {
+            "key": "chat.plugins.strictMarketplaces",
+            "name": "ChatStrictMarketplaces",
+            "category": "InteractiveSession",
+            "minimumVersion": "1.122",
+            "localization": {
+                "description": {
+                    "key": "chat.plugins.strictMarketplaces.policy",
+                    "value": "When enabled by enterprise policy, only marketplaces listed in `chat.plugins.marketplaces` are trusted; plugins from any other marketplace will not load."
+                }
+            },
+            "type": "boolean",
+            "default": false,
+            "included": true
+        },
+        {
             "key": "chat.agent.enabled",
             "name": "ChatAgentMode",
             "category": "InteractiveSession",

--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -245,7 +245,7 @@
             "localization": {
                 "description": {
                     "key": "chat.plugins.extraMarketplaces.policy",
-                    "value": "Additional plugin marketplaces to query. Entries are GitHub shorthand (`owner/repo[#ref]`) or Git URIs (`<url>[#ref]`)."
+                    "value": "Additional plugin marketplaces to query. Entries are GitHub shorthand (`owner/repo[#ref]`), Git URIs (`<url>[#ref]`), or `{ name, source: { source: 'github'|'git', repo|url, ref? } }` objects."
                 }
             },
             "type": "array",

--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -253,21 +253,6 @@
             "included": true
         },
         {
-            "key": "chat.plugins.extraMarketplaces",
-            "name": "ChatExtraMarketplaces",
-            "category": "InteractiveSession",
-            "minimumVersion": "1.122",
-            "localization": {
-                "description": {
-                    "key": "chat.plugins.extraMarketplaces.policy",
-                    "value": "Additional plugin marketplaces to query. Entries are GitHub shorthand (`owner/repo[#ref]`), Git URIs (`<url>[#ref]`), or `{ name, source: { source: 'github'|'git', repo|url, ref? } }` objects."
-                }
-            },
-            "type": "array",
-            "default": [],
-            "included": false
-        },
-        {
             "key": "chat.plugins.strictMarketplaces",
             "name": "ChatStrictMarketplaces",
             "category": "InteractiveSession",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-oss-dev",
   "version": "1.122.0",
-  "distro": "8c72533c6dd351f5f8f785eff758768c032523e0",
+  "distro": "36d906669669f12466c6912bd65d9eeb47c6522d",
   "author": {
     "name": "Microsoft Corporation"
   },

--- a/product.json
+++ b/product.json
@@ -145,7 +145,8 @@
 		"completionsEnablementSetting": "github.copilot.enable",
 		"nextEditSuggestionsSetting": "github.copilot.nextEditSuggestions.enabled",
 		"tokenEntitlementUrl": "https://api.github.com/copilot_internal/v2/token",
-		"mcpRegistryDataUrl": "https://api.github.com/copilot/mcp_registry"
+		"mcpRegistryDataUrl": "https://api.github.com/copilot/mcp_registry",
+		"managedSettingsUrl": "https://api.github.com/copilot_internal/managed_settings"
 	},
 	"trustedExtensionAuthAccess": {
 		"github": [

--- a/src/vs/base/common/defaultAccount.ts
+++ b/src/vs/base/common/defaultAccount.ts
@@ -66,12 +66,12 @@ export interface IPolicyData {
 
 	/**
 	 * Enterprise-managed marketplace references, delivered via the Copilot
-	 * `managed_settings` API. Adapted from the API's `Record<id, { source }>`
-	 * shape to the existing `chat.plugins.marketplaces` string-array shape
-	 * (`<owner>/<repo>[#<ref>]` for GitHub sources, `<url>[#<ref>]` for Git
-	 * sources) inside `DefaultAccountService`.
+	 * `managed_settings` API. Each entry preserves the marketplace `name`
+	 * (used as `displayLabel` so that `enabledPlugins["plugin@<name>"]` keys
+	 * resolve) plus the original `source` discriminator. Legacy string entries
+	 * are still accepted for forward/backward compatibility.
 	 */
-	readonly extraKnownMarketplaces?: readonly string[];
+	readonly extraKnownMarketplaces?: readonly (string | IExtraKnownMarketplaceEntry)[];
 
 	/**
 	 * Enterprise-managed strict-marketplace flag. When true, only marketplaces
@@ -79,6 +79,14 @@ export interface IPolicyData {
 	 */
 	readonly strictKnownMarketplaces?: boolean;
 }
+
+/**
+ * A single enterprise-managed marketplace entry, preserving the marketplace
+ * name (used as `displayLabel`) and the original `source` discriminator.
+ */
+export type IExtraKnownMarketplaceEntry =
+	| { readonly name: string; readonly source: { readonly source: 'github'; readonly repo: string; readonly ref?: string } }
+	| { readonly name: string; readonly source: { readonly source: 'git'; readonly url: string; readonly ref?: string } };
 
 export interface ICopilotTokenInfo {
 	readonly sn?: string;

--- a/src/vs/base/common/defaultAccount.ts
+++ b/src/vs/base/common/defaultAccount.ts
@@ -3,6 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { IExtraKnownMarketplaceEntry } from './managedSettings.js';
+
 export interface IQuotaSnapshotData {
 	readonly overage_count: number;
 	readonly overage_permitted: boolean;
@@ -79,14 +81,6 @@ export interface IPolicyData {
 	 */
 	readonly strictKnownMarketplaces?: boolean;
 }
-
-/**
- * A single enterprise-managed marketplace entry, preserving the marketplace
- * name (used as `displayLabel`) and the original `source` discriminator.
- */
-export type IExtraKnownMarketplaceEntry =
-	| { readonly name: string; readonly source: { readonly source: 'github'; readonly repo: string; readonly ref?: string } }
-	| { readonly name: string; readonly source: { readonly source: 'git'; readonly url: string; readonly ref?: string } };
 
 export interface ICopilotTokenInfo {
 	readonly sn?: string;

--- a/src/vs/base/common/defaultAccount.ts
+++ b/src/vs/base/common/defaultAccount.ts
@@ -54,6 +54,30 @@ export interface IPolicyData {
 	readonly cloud_session_storage_enabled?: boolean;
 	readonly mcpRegistryUrl?: string;
 	readonly mcpAccess?: 'allow_all' | 'registry_only';
+
+	/**
+	 * Enterprise-managed plugin enablement, delivered via the Copilot
+	 * `managed_settings` API. Keys are plugin IDs in `<plugin>@<marketplace>`
+	 * form; values are explicit enable/disable. Consumers that read
+	 * `chat.pluginLocations` should merge these with user-supplied path-keyed
+	 * entries via `IConfigurationService.inspect()`.
+	 */
+	readonly enabledPlugins?: Readonly<Record<string, boolean>>;
+
+	/**
+	 * Enterprise-managed marketplace references, delivered via the Copilot
+	 * `managed_settings` API. Adapted from the API's `Record<id, { source }>`
+	 * shape to the existing `chat.plugins.marketplaces` string-array shape
+	 * (`<owner>/<repo>[#<ref>]` for GitHub sources, `<url>[#<ref>]` for Git
+	 * sources) inside `DefaultAccountService`.
+	 */
+	readonly extraKnownMarketplaces?: readonly string[];
+
+	/**
+	 * Enterprise-managed strict-marketplace flag. When true, only marketplaces
+	 * listed in `extraKnownMarketplaces` (plus the user's own) are trusted.
+	 */
+	readonly strictKnownMarketplaces?: boolean;
 }
 
 export interface ICopilotTokenInfo {

--- a/src/vs/base/common/managedSettings.ts
+++ b/src/vs/base/common/managedSettings.ts
@@ -1,0 +1,12 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * A single enterprise-managed marketplace entry, preserving the marketplace
+ * name (used as `displayLabel`) and the original `source` discriminator.
+ */
+export type IExtraKnownMarketplaceEntry =
+	| { readonly name: string; readonly source: { readonly source: 'github'; readonly repo: string; readonly ref?: string } }
+	| { readonly name: string; readonly source: { readonly source: 'git'; readonly url: string; readonly ref?: string } };

--- a/src/vs/base/common/product.ts
+++ b/src/vs/base/common/product.ts
@@ -401,6 +401,7 @@ export interface IDefaultChatAgent {
 	readonly entitlementSignupLimitedUrl: string;
 	readonly tokenEntitlementUrl: string;
 	readonly mcpRegistryDataUrl: string;
+	readonly managedSettingsUrl: string;
 
 	readonly chatQuotaExceededContext: string;
 	readonly completionsQuotaExceededContext: string;

--- a/src/vs/editor/contrib/inlineCompletions/test/browser/utils.ts
+++ b/src/vs/editor/contrib/inlineCompletions/test/browser/utils.ts
@@ -293,6 +293,8 @@ export async function withAsyncTestCodeEditorAndInlineCompletionsModel<T>(
 					currentDefaultAccount: null,
 					copilotTokenInfo: null,
 					onDidChangeCopilotTokenInfo: Event.None,
+					managedSettingsFetchStatus: null,
+					managedSettingsFetchedAt: null,
 					getDefaultAccount: async () => null,
 					setDefaultAccountProvider: () => { },
 					getDefaultAccountAuthenticationProvider: () => { return { id: 'mockProvider', name: 'Mock Provider', enterprise: false }; },

--- a/src/vs/editor/standalone/browser/standaloneServices.ts
+++ b/src/vs/editor/standalone/browser/standaloneServices.ts
@@ -1129,6 +1129,8 @@ class StandaloneDefaultAccountService implements IDefaultAccountService {
 	readonly currentDefaultAccount: IDefaultAccount | null = null;
 	readonly copilotTokenInfo = null;
 	readonly onDidChangeCopilotTokenInfo: Event<null> = Event.None;
+	readonly managedSettingsFetchStatus: null = null;
+	readonly managedSettingsFetchedAt: null = null;
 
 	async getDefaultAccount(): Promise<IDefaultAccount | null> {
 		return null;

--- a/src/vs/platform/defaultAccount/common/defaultAccount.ts
+++ b/src/vs/platform/defaultAccount/common/defaultAccount.ts
@@ -16,6 +16,17 @@ export const GitHubPaths = {
 	copilotUpgrade: 'github-copilot/upgrade?utm_source=vscode',
 } as const;
 
+/**
+ * Outcome of the last `/copilot_internal/managed_settings` fetch.
+ * - A numeric HTTP status code indicates the server responded with that code.
+ * - `'ok'`: response parsed and adapted successfully (including an empty `{}` body).
+ * - `'no-url'`: no `managedSettingsUrl` configured in product.json.
+ * - `'no-response'`: network error, all sessions rejected, or active rate-limit backoff.
+ * - `'parse-error'`: response received but JSON parsing failed.
+ * - `null`: never fetched.
+ */
+export type ManagedSettingsFetchStatus = number | 'ok' | 'no-url' | 'no-response' | 'parse-error' | null;
+
 export interface IDefaultAccountProvider {
 	readonly defaultAccount: IDefaultAccount | null;
 	readonly onDidChangeDefaultAccount: Event<IDefaultAccount | null>;
@@ -23,6 +34,9 @@ export interface IDefaultAccountProvider {
 	readonly onDidChangePolicyData: Event<IPolicyData | null>;
 	readonly copilotTokenInfo: ICopilotTokenInfo | null;
 	readonly onDidChangeCopilotTokenInfo: Event<ICopilotTokenInfo | null>;
+	readonly managedSettingsFetchStatus: ManagedSettingsFetchStatus;
+	/** Timestamp (ms) of the last managed-settings fetch, or `null` if never fetched. */
+	readonly managedSettingsFetchedAt: number | null;
 	getDefaultAccountAuthenticationProvider(): IDefaultAccountAuthenticationProvider;
 
 	/**
@@ -49,6 +63,9 @@ export interface IDefaultAccountService {
 	readonly currentDefaultAccount: IDefaultAccount | null;
 	readonly copilotTokenInfo: ICopilotTokenInfo | null;
 	readonly onDidChangeCopilotTokenInfo: Event<ICopilotTokenInfo | null>;
+	readonly managedSettingsFetchStatus: ManagedSettingsFetchStatus;
+	/** Timestamp (ms) of the last managed-settings fetch, or `null` if never fetched. */
+	readonly managedSettingsFetchedAt: number | null;
 	getDefaultAccount(): Promise<IDefaultAccount | null>;
 	getDefaultAccountAuthenticationProvider(): IDefaultAccountAuthenticationProvider;
 	setDefaultAccountProvider(provider: IDefaultAccountProvider): void;

--- a/src/vs/platform/request/common/request.ts
+++ b/src/vs/platform/request/common/request.ts
@@ -134,6 +134,34 @@ export function isServerError(context: IRequestContext): boolean {
 	return !!context.res.statusCode && context.res.statusCode >= 500 && context.res.statusCode < 600;
 }
 
+/**
+ * Reads a header value from an {@link IHeaders} map, tolerating array-shaped
+ * values and case-insensitive lookups.
+ */
+export function readHeader(headers: IHeaders | undefined, name: string): string | undefined {
+	if (!headers) {
+		return undefined;
+	}
+	const value = headers[name] ?? headers[name.toLowerCase()];
+	if (Array.isArray(value)) {
+		return value[0];
+	}
+	return value;
+}
+
+/**
+ * Parses the `Retry-After` header as a number of seconds. Returns `undefined`
+ * if absent or not a finite positive number. The HTTP-date form is not parsed.
+ */
+export function retryAfterFromHeaders(headers: IHeaders | undefined): number | undefined {
+	const value = readHeader(headers, 'retry-after');
+	if (!value) {
+		return undefined;
+	}
+	const parsed = parseInt(value, 10);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
 export function hasNoContent(context: IRequestContext): boolean {
 	return context.res.statusCode === 204;
 }

--- a/src/vs/sessions/test/web.test.ts
+++ b/src/vs/sessions/test/web.test.ts
@@ -131,6 +131,8 @@ class MockDefaultAccountService implements IDefaultAccountService {
 	readonly currentDefaultAccount: IDefaultAccount | null = MOCK_ACCOUNT;
 	readonly copilotTokenInfo: ICopilotTokenInfo | null = null;
 	readonly onDidChangeCopilotTokenInfo = Event.None;
+	readonly managedSettingsFetchStatus: null = null;
+	readonly managedSettingsFetchedAt: null = null;
 
 	async getDefaultAccount(): Promise<IDefaultAccount | null> { return MOCK_ACCOUNT; }
 	getDefaultAccountAuthenticationProvider(): IDefaultAccountAuthenticationProvider { return MOCK_ACCOUNT.authenticationProvider; }

--- a/src/vs/workbench/browser/actions/developerActions.ts
+++ b/src/vs/workbench/browser/actions/developerActions.ts
@@ -787,14 +787,7 @@ class PolicyDiagnosticsAction extends Action2 {
 			content += '| Property | Value |\n';
 			content += '|----------|-------|\n';
 			const fetchStatus = defaultAccountService.managedSettingsFetchStatus;
-			let fetchStatusDisplay: string;
-			if (fetchStatus === null) {
-				fetchStatusDisplay = '*not yet fetched*';
-			} else if (fetchStatus === 'ok') {
-				fetchStatusDisplay = '`ok`';
-			} else {
-				fetchStatusDisplay = `\`${fetchStatus}\``;
-			}
+			const fetchStatusDisplay = fetchStatus === null ? '*not yet fetched*' : `\`${fetchStatus}\``;
 			content += `| Last fetch | ${fetchStatusDisplay} |\n`;
 			const fetchedAt = defaultAccountService.managedSettingsFetchedAt;
 			content += `| Fetched at | ${fetchedAt ? new Date(fetchedAt).toLocaleString() : '*n/a*'} |\n`;

--- a/src/vs/workbench/browser/actions/developerActions.ts
+++ b/src/vs/workbench/browser/actions/developerActions.ts
@@ -780,6 +780,38 @@ class PolicyDiagnosticsAction extends Action2 {
 			content += `*Error retrieving account policy gate info: ${error}*\n\n`;
 		}
 
+		content += '## Managed Settings\n\n';
+		try {
+			const policyData = defaultAccountService.policyData;
+
+			content += '| Property | Value |\n';
+			content += '|----------|-------|\n';
+			const fetchStatus = defaultAccountService.managedSettingsFetchStatus;
+			let fetchStatusDisplay: string;
+			if (fetchStatus === null) {
+				fetchStatusDisplay = '*not yet fetched*';
+			} else if (fetchStatus === 'ok') {
+				fetchStatusDisplay = '`ok`';
+			} else {
+				fetchStatusDisplay = `\`${fetchStatus}\``;
+			}
+			content += `| Last fetch | ${fetchStatusDisplay} |\n`;
+			const fetchedAt = defaultAccountService.managedSettingsFetchedAt;
+			content += `| Fetched at | ${fetchedAt ? new Date(fetchedAt).toLocaleString() : '*n/a*'} |\n`;
+			content += '\n';
+
+			const managedSettingsData = {
+				enabledPlugins: policyData?.enabledPlugins,
+				extraKnownMarketplaces: policyData?.extraKnownMarketplaces,
+				strictKnownMarketplaces: policyData?.strictKnownMarketplaces,
+			};
+			content += '```json\n';
+			content += JSON.stringify(managedSettingsData, null, 2);
+			content += '\n```\n\n';
+		} catch (error) {
+			content += `*Error rendering managed settings diagnostics: ${error}*\n\n`;
+		}
+
 		content += '## Policy-Controlled Settings\n\n';
 
 		const policyConfigurations = configurationRegistry.getPolicyConfigurations();

--- a/src/vs/workbench/contrib/chat/browser/actions/chatPluginActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatPluginActions.ts
@@ -12,13 +12,14 @@ import { IConfigurationService } from '../../../../../platform/configuration/com
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IFileService } from '../../../../../platform/files/common/files.js';
 import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
+import { INotificationService, Severity } from '../../../../../platform/notification/common/notification.js';
 import { IQuickInputService, IQuickPickItem } from '../../../../../platform/quickinput/common/quickInput.js';
 import { IExtensionsWorkbenchService } from '../../../extensions/common/extensions.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
 import { ChatConfiguration } from '../../common/constants.js';
 import { IAgentPluginRepositoryService } from '../../common/plugins/agentPluginRepositoryService.js';
 import { IPluginInstallService } from '../../common/plugins/pluginInstallService.js';
-import { type IMarketplaceReference, MarketplaceReferenceKind, parseMarketplaceReference, parseMarketplaceReferences } from '../../common/plugins/pluginMarketplaceService.js';
+import { type IMarketplaceReference, MarketplaceReferenceKind, parseMarketplaceReference, parseMarketplaceReferences, readConfiguredMarketplaces } from '../../common/plugins/pluginMarketplaceService.js';
 import { InstalledAgentPluginsViewId } from '../chat.js';
 import { CHAT_CATEGORY, CHAT_CONFIG_MENU_ID } from './chatActions.js';
 
@@ -139,6 +140,7 @@ class InstallFromSourceAction extends Action2 {
 
 interface IMarketplaceQuickPickItem extends IQuickPickItem {
 	readonly reference: IMarketplaceReference;
+	readonly managedByPolicy: boolean;
 }
 
 class ManagePluginMarketplacesAction extends Action2 {
@@ -172,9 +174,10 @@ class ManagePluginMarketplacesAction extends Action2 {
 		const extensionsWorkbenchService = accessor.get(IExtensionsWorkbenchService);
 		const commandService = accessor.get(ICommandService);
 		const fileService = accessor.get(IFileService);
+		const notificationService = accessor.get(INotificationService);
 
-		const configuredRefs = configurationService.getValue<unknown[]>(ChatConfiguration.PluginMarketplaces) ?? [];
-		const refs = parseMarketplaceReferences(configuredRefs);
+		const { effectiveValues, editableValues, policyCanonicalIds } = readConfiguredMarketplaces(configurationService);
+		const refs = parseMarketplaceReferences(effectiveValues);
 
 		if (refs.length === 0) {
 			quickInputService.pick([], { placeHolder: localize('noMarketplaces', "No plugin marketplaces configured") });
@@ -186,8 +189,11 @@ class ManagePluginMarketplacesAction extends Action2 {
 			label: ref.displayLabel,
 			description: ref.kind === MarketplaceReferenceKind.LocalFileUri
 				? localize('localMarketplace', "Local")
-				: ref.cloneUrl,
+				: policyCanonicalIds.has(ref.canonicalId)
+					? localize('managedMarketplace', "{0} (managed by enterprise policy)", ref.cloneUrl)
+					: ref.cloneUrl,
 			reference: ref,
+			managedByPolicy: policyCanonicalIds.has(ref.canonicalId),
 		}));
 
 		const selected = await quickInputService.pick(items, {
@@ -230,8 +236,15 @@ class ManagePluginMarketplacesAction extends Action2 {
 				await commandService.executeCommand('revealFileInOS', repoUri);
 				break;
 			case 'removeMarketplace': {
-				const currentValues = configurationService.getValue<unknown[]>(ChatConfiguration.PluginMarketplaces) ?? [];
-				const updated = currentValues.filter(v => typeof v === 'string' && v.trim() !== ref.rawValue);
+				if (selected.managedByPolicy) {
+					notificationService.notify({
+						severity: Severity.Warning,
+						message: localize('removeManagedMarketplace', "Enterprise policy manages '{0}', so it can't be removed here.", ref.displayLabel),
+					});
+					return;
+				}
+
+				const updated = editableValues.filter(v => typeof v === 'string' && v.trim() !== ref.rawValue);
 				await configurationService.updateValue(ChatConfiguration.PluginMarketplaces, updated);
 				break;
 			}

--- a/src/vs/workbench/contrib/chat/browser/actions/chatPluginActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatPluginActions.ts
@@ -176,8 +176,9 @@ class ManagePluginMarketplacesAction extends Action2 {
 		const fileService = accessor.get(IFileService);
 		const notificationService = accessor.get(INotificationService);
 
-		const { effectiveValues, editableValues, policyCanonicalIds } = readConfiguredMarketplaces(configurationService);
+		const { userValues, extraValues, effectiveValues } = readConfiguredMarketplaces(configurationService);
 		const refs = parseMarketplaceReferences(effectiveValues);
+		const policyCanonicalIds = new Set(parseMarketplaceReferences(extraValues).map(r => r.canonicalId));
 
 		if (refs.length === 0) {
 			quickInputService.pick([], { placeHolder: localize('noMarketplaces', "No plugin marketplaces configured") });
@@ -244,7 +245,7 @@ class ManagePluginMarketplacesAction extends Action2 {
 					return;
 				}
 
-				const updated = editableValues.filter(v => typeof v === 'string' && v.trim() !== ref.rawValue);
+				const updated = userValues.filter(v => typeof v === 'string' && v.trim() !== ref.rawValue);
 				await configurationService.updateValue(ChatConfiguration.PluginMarketplaces, updated);
 				break;
 			}

--- a/src/vs/workbench/contrib/chat/browser/agentPluginActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentPluginActions.ts
@@ -46,7 +46,7 @@ export class InstallPluginAction extends Action {
 export class UninstallPluginAction extends Action {
 	constructor(plugin: IAgentPlugin) {
 		super('agentPlugin.uninstall', localize('uninstall', "Uninstall"), 'extension-action label uninstall', true,
-			() => { plugin.remove(); return Promise.resolve(); });
+			() => { plugin.remove?.(); return Promise.resolve(); });
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/agentPluginActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentPluginActions.ts
@@ -10,6 +10,7 @@ import { ActionWithDropdownActionViewItem, IActionWithDropdownActionViewItemOpti
 import { IContextMenuProvider } from '../../../../base/browser/contextmenu.js';
 import { localize } from '../../../../nls.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IWorkspaceContextService, WorkbenchState } from '../../../../platform/workspace/common/workspace.js';
@@ -81,6 +82,25 @@ export class OpenPluginReadmeAction extends Action {
 
 //#region Context menu
 
+/** Whether the plugin is blocked by enterprise policy and cannot be enabled by the user. */
+export function isPluginPolicyBlocked(plugin: IAgentPlugin): boolean {
+	return plugin.policyBlocked?.get() === true;
+}
+
+/** Notifies the user that a plugin is managed by their organization and cannot be enabled. */
+export function notifyPluginPolicyBlocked(notificationService: INotificationService, pluginName: string): void {
+	notificationService.warn(localize('pluginPolicyBlocked', "The plugin \"{0}\" has been disabled by your organization and cannot be enabled.", pluginName));
+}
+
+/**
+ * An "Enable" action for a policy-blocked plugin: instead of enabling, it
+ * explains via a notification that the plugin is managed by the organization.
+ */
+export function createPolicyBlockedEnableAction(plugin: IAgentPlugin, notificationService: INotificationService): Action {
+	return new Action('agentPlugin.enableBlocked', localize('enable', "Enable"), undefined, true,
+		() => { notifyPluginPolicyBlocked(notificationService, plugin.label); return Promise.resolve(); });
+}
+
 /**
  * Builds the standard context menu action groups for an installed plugin.
  */
@@ -89,13 +109,17 @@ export function getInstalledPluginContextMenuActions(plugin: IAgentPlugin, insta
 		const agentPluginService = accessor.get(IAgentPluginService);
 		const workspaceService = accessor.get(IWorkspaceContextService);
 		const groups: IAction[][] = [];
-		groups.push(buildEnablementContextMenuGroup(
-			plugin.enablement.get(),
-			plugin.uri.toString(),
-			agentPluginService.enablementModel,
-			workspaceService,
-			'agentPlugin',
-		));
+		if (isPluginPolicyBlocked(plugin)) {
+			groups.push([createPolicyBlockedEnableAction(plugin, accessor.get(INotificationService))]);
+		} else {
+			groups.push(buildEnablementContextMenuGroup(
+				plugin.enablement.get(),
+				plugin.uri.toString(),
+				agentPluginService.enablementModel,
+				workspaceService,
+				'agentPlugin',
+			));
+		}
 		groups.push([
 			instantiationService.createInstance(OpenPluginFolderAction, plugin),
 			instantiationService.createInstance(OpenPluginReadmeAction, joinPath(plugin.uri, 'README.md')),

--- a/src/vs/workbench/contrib/chat/browser/agentPluginEditor/agentPluginEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentPluginEditor/agentPluginEditor.ts
@@ -24,6 +24,7 @@ import { IFileService } from '../../../../../platform/files/common/files.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IContextMenuService } from '../../../../../platform/contextview/browser/contextView.js';
 import { ILabelService } from '../../../../../platform/label/common/label.js';
+import { INotificationService } from '../../../../../platform/notification/common/notification.js';
 import { IOpenerService } from '../../../../../platform/opener/common/opener.js';
 import { IRequestService, asText } from '../../../../../platform/request/common/request.js';
 import { IStorageService } from '../../../../../platform/storage/common/storage.js';
@@ -42,7 +43,7 @@ import { AgentPluginEditorInput } from './agentPluginEditorInput.js';
 import { AgentPluginItemKind, IAgentPluginItem, IInstalledPluginItem } from './agentPluginItems.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { EnablementStatusWidget, pluginEnablementLabels } from '../enablementStatusWidget.js';
-import { InstallPluginAction, UninstallPluginAction, createEnablePluginDropDown, createDisablePluginDropDown, EnablementDropDownAction, EnablementDropdownActionViewItem } from '../agentPluginActions.js';
+import { InstallPluginAction, UninstallPluginAction, createEnablePluginDropDown, createDisablePluginDropDown, createPolicyBlockedEnableAction, isPluginPolicyBlocked, EnablementDropDownAction, EnablementDropdownActionViewItem } from '../agentPluginActions.js';
 import './media/agentPluginEditor.css';
 
 interface IAgentPluginEditorTemplate {
@@ -331,8 +332,13 @@ export class AgentPluginEditor extends EditorPane {
 			}
 		}
 
-		actions.push(createEnablePluginDropDown(item.plugin, this.agentPluginService.enablementModel, workspaceService));
-		actions.push(createDisablePluginDropDown(item.plugin, this.agentPluginService.enablementModel, workspaceService));
+		if (isPluginPolicyBlocked(item.plugin)) {
+			const notificationService = this.instantiationService.invokeFunction(a => a.get(INotificationService));
+			actions.push(createPolicyBlockedEnableAction(item.plugin, notificationService));
+		} else {
+			actions.push(createEnablePluginDropDown(item.plugin, this.agentPluginService.enablementModel, workspaceService));
+			actions.push(createDisablePluginDropDown(item.plugin, this.agentPluginService.enablementModel, workspaceService));
+		}
 		actions.push(new UninstallPluginAction(item.plugin));
 		return actions;
 	}

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
@@ -314,7 +314,7 @@ registerAction2(class extends Action2 {
 					type: 'question',
 				});
 				if (result.confirmed) {
-					plugin.remove();
+					plugin.remove?.();
 				}
 			}
 			return;
@@ -548,7 +548,7 @@ registerAction2(class extends Action2 {
 			type: 'question',
 		});
 		if (result.confirmed) {
-			plugin.remove();
+			plugin.remove?.();
 		}
 	}
 });

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
@@ -1087,7 +1087,7 @@ export class McpListWidget extends Disposable {
 						type: 'question',
 					});
 					if (result.confirmed) {
-						plugin.remove();
+						plugin.remove?.();
 					}
 				}
 			));

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -966,7 +966,7 @@ configurationRegistry.registerConfiguration({
 		},
 		[ChatConfiguration.StrictMarketplaces]: {
 			type: 'boolean',
-			markdownDescription: nls.localize('chat.plugins.strictMarketplaces', "When enabled, only marketplaces listed in {0} are trusted. Plugins from any other marketplace will not load.", `\`#${ChatConfiguration.PluginMarketplaces}#\``),
+			markdownDescription: nls.localize('chat.plugins.strictMarketplaces', "When enabled, only marketplaces supplied via enterprise policy are trusted. Plugins from any other marketplace will not load."),
 			default: false,
 			restricted: true,
 			scope: ConfigurationScope.APPLICATION,
@@ -979,7 +979,7 @@ configurationRegistry.registerConfiguration({
 				localization: {
 					description: {
 						key: 'chat.plugins.strictMarketplaces.policy',
-						value: nls.localize('chat.plugins.strictMarketplaces.policy', "Only trust marketplaces listed in `chat.plugins.marketplaces`; plugins from any other marketplace will not load."),
+						value: nls.localize('chat.plugins.strictMarketplaces.policy', "Only trust marketplaces supplied via enterprise policy; plugins from any other marketplace will not load."),
 					}
 				},
 			},

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -957,6 +957,7 @@ configurationRegistry.registerConfiguration({
 			scope: ConfigurationScope.APPLICATION,
 			included: false,
 			tags: ['experimental'],
+			markdownDescription: nls.localize('chat.plugins.extraMarketplaces', "Enterprise-managed additional plugin marketplaces. Delivered exclusively via the `ChatExtraMarketplaces` policy and unioned with {0}. Entries are either GitHub shorthand (`owner/repo[#ref]`), Git URIs (`<url>[#ref]`), or objects of the form `name: <label>, source: <github or git source>` (the `name` is the marketplace label used to match `<plugin>@<marketplace>` IDs in {1}).", `\`#${ChatConfiguration.PluginMarketplaces}#\``, `\`#${ChatConfiguration.EnabledPlugins}#\``),
 			policy: {
 				name: 'ChatExtraMarketplaces',
 				category: PolicyCategory.InteractiveSession,
@@ -965,7 +966,7 @@ configurationRegistry.registerConfiguration({
 				localization: {
 					description: {
 						key: 'chat.plugins.extraMarketplaces.policy',
-						value: nls.localize('chat.plugins.extraMarketplaces.policy', "Additional plugin marketplaces to query. Entries are GitHub shorthand (`owner/repo[#ref]`), Git URIs (`<url>[#ref]`), or `{ name, source }` objects."),
+						value: nls.localize('chat.plugins.extraMarketplaces.policy', "Additional plugin marketplaces to query. Entries are GitHub shorthand (`owner/repo[#ref]`), Git URIs (`<url>[#ref]`), or `{ name, source: { source: 'github'|'git', repo|url, ref? } }` objects."),
 					}
 				},
 			},

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -957,7 +957,7 @@ configurationRegistry.registerConfiguration({
 			scope: ConfigurationScope.APPLICATION,
 			included: false,
 			tags: ['experimental'],
-			markdownDescription: nls.localize('chat.plugins.extraMarketplaces', "Enterprise-managed additional plugin marketplaces. Delivered exclusively via the `ChatExtraMarketplaces` policy and unioned with {0}. Entries are either GitHub shorthand (`owner/repo[#ref]`), Git URIs (`<url>[#ref]`), or objects of the form `name: <label>, source: <github or git source>` (the `name` is the marketplace label used to match `<plugin>@<marketplace>` IDs in {1}).", `\`#${ChatConfiguration.PluginMarketplaces}#\``, `\`#${ChatConfiguration.EnabledPlugins}#\``),
+			markdownDescription: nls.localize('chat.plugins.extraMarketplaces', "Enterprise-managed additional plugin marketplaces. Delivered via the `ChatExtraMarketplaces` policy and unioned with {0}.", `\`#${ChatConfiguration.PluginMarketplaces}#\``),
 			policy: {
 				name: 'ChatExtraMarketplaces',
 				category: PolicyCategory.InteractiveSession,

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -914,7 +914,7 @@ configurationRegistry.registerConfiguration({
 		[ChatConfiguration.EnabledPlugins]: {
 			type: 'object',
 			additionalProperties: { type: 'boolean' },
-			markdownDescription: nls.localize('chat.plugins.enabledPlugins', "Enterprise-managed plugin enablement. Keys are plugin IDs in `<plugin>@<marketplace>` form; values enable (`true`) or disable (`false`) the plugin. Merged with entries from {0}.", `\`#${ChatConfiguration.PluginLocations}#\``),
+			markdownDescription: nls.localize('chat.plugins.enabledPlugins', "Enterprise-managed plugin enablement. Keys are plugin IDs in `<plugin>@<marketplace>` form (resolved to Copilot CLI install paths); values enable (`true`) or disable (`false`) the plugin. Discovered alongside the path-keyed entries in {0}. When set by policy, also restricts which marketplace-discovered plugins are allowed to load (only IDs mapped to `true` here pass the gate).", `\`#${ChatConfiguration.PluginLocations}#\``),
 			scope: ConfigurationScope.APPLICATION,
 			tags: ['experimental'],
 			policy: {

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -945,8 +945,14 @@ configurationRegistry.registerConfiguration({
 			// `ChatExtraMarketplaces` policy). Consumers union this with `chat.plugins.marketplaces`.
 			// Hidden from the Settings UI via `included: false` — users edit
 			// `chat.plugins.marketplaces`, the enterprise edits this.
+			//
+			// Items are either:
+			//  - a string (GitHub shorthand `owner/repo[#ref]` or Git URI `<url>[#ref]`), or
+			//  - a `{ name, source: { source: 'github'|'git', repo|url, ref? } }` object that
+			//    preserves the marketplace name from the managed_settings payload so
+			//    `enabledPlugins["plugin@<name>"]` keys resolve correctly.
 			type: 'array',
-			items: { type: 'string' },
+			items: { type: ['string', 'object'] },
 			default: [],
 			scope: ConfigurationScope.APPLICATION,
 			included: false,
@@ -959,7 +965,7 @@ configurationRegistry.registerConfiguration({
 				localization: {
 					description: {
 						key: 'chat.plugins.extraMarketplaces.policy',
-						value: nls.localize('chat.plugins.extraMarketplaces.policy', "Additional plugin marketplaces to query. Entries are GitHub shorthand (`owner/repo[#ref]`) or Git URIs (`<url>[#ref]`)."),
+						value: nls.localize('chat.plugins.extraMarketplaces.policy', "Additional plugin marketplaces to query. Entries are GitHub shorthand (`owner/repo[#ref]`), Git URIs (`<url>[#ref]`), or `{ name, source }` objects."),
 					}
 				},
 			},

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -166,7 +166,7 @@ import { ToolResultCompressorService } from './tools/toolResultCompressorService
 import { AgentPluginService, ConfiguredAgentPluginDiscovery, CopilotCliAgentPluginDiscovery, ExtensionAgentPluginDiscovery, MarketplaceAgentPluginDiscovery } from '../common/plugins/agentPluginServiceImpl.js';
 import { IAgentPluginRepositoryService } from '../common/plugins/agentPluginRepositoryService.js';
 import { IPluginInstallService } from '../common/plugins/pluginInstallService.js';
-import { IPluginMarketplaceService, PluginMarketplaceService } from '../common/plugins/pluginMarketplaceService.js';
+import { extraKnownMarketplacesToConfigDict, IPluginMarketplaceService, PluginMarketplaceService } from '../common/plugins/pluginMarketplaceService.js';
 import { WorkspacePluginSettingsService, IWorkspacePluginSettingsService } from '../common/plugins/workspacePluginSettingsService.js';
 import { AgentPluginRecommendations } from './claudePluginRecommendations.js';
 import { AgentPluginEditor } from './agentPluginEditor/agentPluginEditor.js';
@@ -965,21 +965,8 @@ configurationRegistry.registerConfiguration({
 				category: PolicyCategory.InteractiveSession,
 				minimumVersion: '1.122',
 				value: (policyData) => {
-					if (!policyData.extraKnownMarketplaces?.length) {
-						return undefined;
-					}
-					const obj: Record<string, string> = {};
-					for (const entry of policyData.extraKnownMarketplaces) {
-						if (typeof entry === 'string') {
-							// Plain string entries have no name — use the value as both key and value.
-							obj[entry] = entry;
-						} else {
-							const s = entry.source;
-							const base = s.source === 'github' ? s.repo : s.url;
-							obj[entry.name] = s.ref ? `${base}#${s.ref}` : base;
-						}
-					}
-					return JSON.stringify(obj);
+					const obj = extraKnownMarketplacesToConfigDict(policyData.extraKnownMarketplaces);
+					return obj ? JSON.stringify(obj) : undefined;
 				},
 				localization: {
 					description: {

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -943,17 +943,19 @@ configurationRegistry.registerConfiguration({
 		[ChatConfiguration.ExtraMarketplaces]: {
 			// Policy-only delivery slot for enterprise-managed marketplace entries (via the
 			// `ChatExtraMarketplaces` policy). Consumers union this with `chat.plugins.marketplaces`.
-			// Hidden from the Settings UI via `included: false` — users edit
-			// `chat.plugins.marketplaces`, the enterprise edits this.
 			//
-			// Items are either:
-			//  - a string (GitHub shorthand `owner/repo[#ref]` or Git URI `<url>[#ref]`), or
-			//  - a `{ name, source: { source: 'github'|'git', repo|url, ref? } }` object that
-			//    preserves the marketplace name from the managed_settings payload so
-			//    `enabledPlugins["plugin@<name>"]` keys resolve correctly.
-			type: 'array',
-			items: { type: ['string', 'object'] },
-			default: [],
+			// Stored as a `{ [name]: url-or-shorthand }` object so that:
+			//   - The Settings Editor (ComplexObject renderer) can display entries inline when
+			//     managed by policy, rather than only showing "Edit in settings.json".
+			//   - Marketplace names are preserved for `enabledPlugins["plugin@<name>"]` resolution.
+			//
+			// `additionalProperties: { type: ['string'] }` uses the single-element array form of
+			// JSON Schema's `type` keyword (equivalent to `type: 'string'`) to trigger VS Code's
+			// ComplexObject renderer, which shows key-value rows inline and hides the
+			// "Edit in settings.json" link when the value is managed by policy.
+			type: 'object',
+			additionalProperties: { type: ['string'] as ['string'] },
+			default: {},
 			scope: ConfigurationScope.APPLICATION,
 			included: false,
 			tags: ['experimental'],
@@ -962,11 +964,27 @@ configurationRegistry.registerConfiguration({
 				name: 'ChatExtraMarketplaces',
 				category: PolicyCategory.InteractiveSession,
 				minimumVersion: '1.122',
-				value: (policyData) => policyData.extraKnownMarketplaces ? JSON.stringify(policyData.extraKnownMarketplaces) : undefined,
+				value: (policyData) => {
+					if (!policyData.extraKnownMarketplaces?.length) {
+						return undefined;
+					}
+					const obj: Record<string, string> = {};
+					for (const entry of policyData.extraKnownMarketplaces) {
+						if (typeof entry === 'string') {
+							// Plain string entries have no name — use the value as both key and value.
+							obj[entry] = entry;
+						} else {
+							const s = entry.source;
+							const base = s.source === 'github' ? s.repo : s.url;
+							obj[entry.name] = s.ref ? `${base}#${s.ref}` : base;
+						}
+					}
+					return JSON.stringify(obj);
+				},
 				localization: {
 					description: {
 						key: 'chat.plugins.extraMarketplaces.policy',
-						value: nls.localize('chat.plugins.extraMarketplaces.policy', "Additional plugin marketplaces to query. Entries are GitHub shorthand (`owner/repo[#ref]`), Git URIs (`<url>[#ref]`), or `{ name, source: { source: 'github'|'git', repo|url, ref? } }` objects."),
+						value: nls.localize('chat.plugins.extraMarketplaces.policy', "Additional plugin marketplaces to query. Keys are marketplace names; values are GitHub shorthand (`owner/repo[#ref]`) or Git URIs (`<url>[#ref]`)."),
 					}
 				},
 			},

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -911,15 +911,66 @@ configurationRegistry.registerConfiguration({
 			scope: ConfigurationScope.MACHINE,
 			tags: ['experimental'],
 		},
+		[ChatConfiguration.EnabledPlugins]: {
+			type: 'object',
+			additionalProperties: { type: 'boolean' },
+			markdownDescription: nls.localize('chat.plugins.enabledPlugins', "Enterprise-managed plugin enablement. Keys are plugin IDs in `<plugin>@<marketplace>` form; values enable (`true`) or disable (`false`) the plugin. Merged with entries from {0}.", `\`#${ChatConfiguration.PluginLocations}#\``),
+			scope: ConfigurationScope.APPLICATION,
+			tags: ['experimental'],
+			policy: {
+				name: 'ChatEnabledPlugins',
+				category: PolicyCategory.InteractiveSession,
+				minimumVersion: '1.122',
+				value: (policyData) => policyData.enabledPlugins ? JSON.stringify(policyData.enabledPlugins) : undefined,
+				localization: {
+					description: {
+						key: 'chat.plugins.enabledPlugins.policy',
+						value: nls.localize('chat.plugins.enabledPlugins.policy', "Plugin enablement. Keys are plugin IDs in `<plugin>@<marketplace>` form; values enable or disable the plugin."),
+					}
+				},
+			},
+		},
 		[ChatConfiguration.PluginMarketplaces]: {
 			type: 'array',
 			items: {
 				type: 'string',
 			},
 			markdownDescription: nls.localize('chat.plugins.marketplaces', "Plugin marketplaces to query. Entries may be GitHub shorthand (`owner/repo` or `owner/repo#ref`), direct Git repository URIs (`https://...git`, `ssh://...git`, or `git@host:path.git`, each optionally suffixed with `#ref`), or local repository URIs (`file:///...`). Equivalent GitHub shorthand and URI entries are deduplicated."),
-			default: ['github/copilot-plugins', 'github/awesome-copilot#marketplace'],
+			default: [],
 			scope: ConfigurationScope.APPLICATION,
 			tags: ['experimental'],
+			policy: {
+				name: 'ChatPluginMarketplaces',
+				category: PolicyCategory.InteractiveSession,
+				minimumVersion: '1.122',
+				value: (policyData) => policyData.extraKnownMarketplaces ? JSON.stringify(policyData.extraKnownMarketplaces) : undefined,
+				localization: {
+					description: {
+						key: 'chat.plugins.marketplaces.policy',
+						value: nls.localize('chat.plugins.marketplaces.policy', "Plugin marketplaces to query. Entries are GitHub shorthand (`owner/repo[#ref]`) or Git URIs (`<url>[#ref]`)."),
+					}
+				},
+			},
+		},
+		[ChatConfiguration.StrictMarketplaces]: {
+			type: 'boolean',
+			markdownDescription: nls.localize('chat.plugins.strictMarketplaces', "When enabled, only marketplaces listed in {0} are trusted. Plugins from any other marketplace will not load.", `\`#${ChatConfiguration.PluginMarketplaces}#\``),
+			default: false,
+			restricted: true,
+			scope: ConfigurationScope.APPLICATION,
+			tags: ['experimental'],
+			policy: {
+				name: 'ChatStrictMarketplaces',
+				category: PolicyCategory.InteractiveSession,
+				minimumVersion: '1.122',
+				value: (policyData) => policyData.strictKnownMarketplaces,
+				localization: {
+					description: {
+						key: 'chat.plugins.strictMarketplaces.policy',
+						value: nls.localize('chat.plugins.strictMarketplaces.policy', "Only trust marketplaces listed in `chat.plugins.marketplaces`; plugins from any other marketplace will not load."),
+					}
+				},
+			},
 		},
 		[ChatConfiguration.AgentEnabled]: {
 			type: 'boolean',

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -936,7 +936,7 @@ configurationRegistry.registerConfiguration({
 				type: 'string',
 			},
 			markdownDescription: nls.localize('chat.plugins.marketplaces', "Plugin marketplaces to query. Entries may be GitHub shorthand (`owner/repo` or `owner/repo#ref`), direct Git repository URIs (`https://...git`, `ssh://...git`, or `git@host:path.git`, each optionally suffixed with `#ref`), or local repository URIs (`file:///...`). Equivalent GitHub shorthand and URI entries are deduplicated."),
-			default: [],
+			default: ['github/copilot-plugins', 'github/awesome-copilot#marketplace'],
 			scope: ConfigurationScope.APPLICATION,
 			tags: ['experimental'],
 			policy: {

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -939,15 +939,27 @@ configurationRegistry.registerConfiguration({
 			default: ['github/copilot-plugins', 'github/awesome-copilot#marketplace'],
 			scope: ConfigurationScope.APPLICATION,
 			tags: ['experimental'],
+		},
+		[ChatConfiguration.ExtraMarketplaces]: {
+			// Policy-only delivery slot for enterprise-managed marketplace entries (via the
+			// `ChatExtraMarketplaces` policy). Consumers union this with `chat.plugins.marketplaces`.
+			// Hidden from the Settings UI via `included: false` — users edit
+			// `chat.plugins.marketplaces`, the enterprise edits this.
+			type: 'array',
+			items: { type: 'string' },
+			default: [],
+			scope: ConfigurationScope.APPLICATION,
+			included: false,
+			tags: ['experimental'],
 			policy: {
-				name: 'ChatPluginMarketplaces',
+				name: 'ChatExtraMarketplaces',
 				category: PolicyCategory.InteractiveSession,
 				minimumVersion: '1.122',
 				value: (policyData) => policyData.extraKnownMarketplaces ? JSON.stringify(policyData.extraKnownMarketplaces) : undefined,
 				localization: {
 					description: {
-						key: 'chat.plugins.marketplaces.policy',
-						value: nls.localize('chat.plugins.marketplaces.policy', "Plugin marketplaces to query. Entries are GitHub shorthand (`owner/repo[#ref]`) or Git URIs (`<url>[#ref]`)."),
+						key: 'chat.plugins.extraMarketplaces.policy',
+						value: nls.localize('chat.plugins.extraMarketplaces.policy', "Additional plugin marketplaces to query. Entries are GitHub shorthand (`owner/repo[#ref]`) or Git URIs (`<url>[#ref]`)."),
 					}
 				},
 			},

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -957,7 +957,7 @@ configurationRegistry.registerConfiguration({
 			scope: ConfigurationScope.APPLICATION,
 			included: false,
 			tags: ['experimental'],
-			markdownDescription: nls.localize('chat.plugins.extraMarketplaces', "Enterprise-managed additional plugin marketplaces. Delivered via the `ChatExtraMarketplaces` policy and unioned with {0}.", `\`#${ChatConfiguration.PluginMarketplaces}#\``),
+			markdownDescription: nls.localize('chat.plugins.extraMarketplaces', "Enterprise-managed additional plugin marketplaces. Unioned with {0}.", `\`#${ChatConfiguration.PluginMarketplaces}#\``),
 			policy: {
 				name: 'ChatExtraMarketplaces',
 				category: PolicyCategory.InteractiveSession,

--- a/src/vs/workbench/contrib/chat/browser/githubRepoFetcher.ts
+++ b/src/vs/workbench/contrib/chat/browser/githubRepoFetcher.ts
@@ -12,7 +12,7 @@ import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
-import { IRequestService, asJson, isClientError, isSuccess } from '../../../../platform/request/common/request.js';
+import { IRequestService, asJson, isClientError, isSuccess, readHeader, retryAfterFromHeaders } from '../../../../platform/request/common/request.js';
 
 /**
  * GitHub `owner/repo` parsed from a clone URL. Only `https://github.com/...` URLs
@@ -151,26 +151,6 @@ function isRateLimited(headers: Record<string, string | string[] | undefined> | 
 	}
 	// Secondary rate limit: GitHub omits X-RateLimit-Remaining but sets Retry-After.
 	return readHeader(headers, 'retry-after') !== undefined;
-}
-
-function retryAfterFromHeaders(headers: Record<string, string | string[] | undefined> | undefined): number | undefined {
-	if (!headers) {
-		return undefined;
-	}
-	const value = readHeader(headers, 'retry-after');
-	if (!value) {
-		return undefined;
-	}
-	const parsed = parseInt(value, 10);
-	return Number.isFinite(parsed) ? parsed : undefined;
-}
-
-function readHeader(headers: Record<string, string | string[] | undefined>, name: string): string | undefined {
-	const value = headers[name] ?? headers[name.toLowerCase()];
-	if (Array.isArray(value)) {
-		return value[0];
-	}
-	return value;
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/browser/pluginInstallService.ts
+++ b/src/vs/workbench/contrib/chat/browser/pluginInstallService.ts
@@ -233,12 +233,12 @@ export class PluginInstallService implements IPluginInstallService {
 	}
 
 	private _addMarketplaceToConfig(reference: IMarketplaceReference) {
-		const { effectiveValues, editableValues } = readConfiguredMarketplaces(this._configurationService);
+		const { userValues, effectiveValues } = readConfiguredMarketplaces(this._configurationService);
 		const existingRefs = parseMarketplaceReferences(effectiveValues);
 		if (existingRefs.some(r => r.canonicalId === reference.canonicalId)) {
 			return;
 		}
-		return this._configurationService.updateValue(ChatConfiguration.PluginMarketplaces, [...editableValues, reference.rawValue]);
+		return this._configurationService.updateValue(ChatConfiguration.PluginMarketplaces, [...userValues, reference.rawValue]);
 	}
 
 	async updatePlugin(plugin: IMarketplacePlugin, silent?: boolean): Promise<boolean> {

--- a/src/vs/workbench/contrib/chat/browser/pluginInstallService.ts
+++ b/src/vs/workbench/contrib/chat/browser/pluginInstallService.ts
@@ -20,7 +20,7 @@ import { IQuickInputService, IQuickPickItem } from '../../../../platform/quickin
 import { IAgentPluginRepositoryService } from '../common/plugins/agentPluginRepositoryService.js';
 import { ChatConfiguration } from '../common/constants.js';
 import { IPluginInstallService, IInstallPluginFromSourceOptions, IInstallPluginFromSourceResult, IUpdateAllPluginsOptions, IUpdateAllPluginsResult } from '../common/plugins/pluginInstallService.js';
-import { IMarketplacePlugin, IMarketplaceReference, IPluginMarketplaceService, MarketplaceReferenceKind, MarketplaceType, hasSourceChanged, parseMarketplaceReference, parseMarketplaceReferences, PluginSourceKind } from '../common/plugins/pluginMarketplaceService.js';
+import { IMarketplacePlugin, IMarketplaceReference, IPluginMarketplaceService, MarketplaceReferenceKind, MarketplaceType, hasSourceChanged, parseMarketplaceReference, parseMarketplaceReferences, PluginSourceKind, readConfiguredMarketplaces } from '../common/plugins/pluginMarketplaceService.js';
 
 export class PluginInstallService implements IPluginInstallService {
 	declare readonly _serviceBrand: undefined;
@@ -233,12 +233,12 @@ export class PluginInstallService implements IPluginInstallService {
 	}
 
 	private _addMarketplaceToConfig(reference: IMarketplaceReference) {
-		const currentValues = this._configurationService.getValue<unknown[]>(ChatConfiguration.PluginMarketplaces) ?? [];
-		const existingRefs = parseMarketplaceReferences(currentValues);
+		const { effectiveValues, editableValues } = readConfiguredMarketplaces(this._configurationService);
+		const existingRefs = parseMarketplaceReferences(effectiveValues);
 		if (existingRefs.some(r => r.canonicalId === reference.canonicalId)) {
 			return;
 		}
-		return this._configurationService.updateValue(ChatConfiguration.PluginMarketplaces, [...currentValues, reference.rawValue]);
+		return this._configurationService.updateValue(ChatConfiguration.PluginMarketplaces, [...editableValues, reference.rawValue]);
 	}
 
 	async updatePlugin(plugin: IMarketplacePlugin, silent?: boolean): Promise<boolean> {

--- a/src/vs/workbench/contrib/chat/browser/pluginUrlHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/pluginUrlHandler.ts
@@ -184,12 +184,12 @@ export class PluginUrlHandler extends Disposable implements IWorkbenchContributi
 			return true;
 		}
 
-		const { effectiveValues, editableValues } = readConfiguredMarketplaces(this._configurationService);
+		const { userValues, effectiveValues } = readConfiguredMarketplaces(this._configurationService);
 		const existingRefs = parseMarketplaceReferences(effectiveValues);
 		if (!existingRefs.some(e => e.canonicalId === ref.canonicalId)) {
 			await this._configurationService.updateValue(
 				ChatConfiguration.PluginMarketplaces,
-				[...editableValues, refValue],
+				[...userValues, refValue],
 				ConfigurationTarget.USER,
 			);
 		}

--- a/src/vs/workbench/contrib/chat/browser/pluginUrlHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/pluginUrlHandler.ts
@@ -21,7 +21,7 @@ import { IExtensionsWorkbenchService } from '../../extensions/common/extensions.
 import { AgentPluginEditorInput } from './agentPluginEditor/agentPluginEditorInput.js';
 import { AgentPluginItemKind, IMarketplacePluginItem } from './agentPluginEditor/agentPluginItems.js';
 import { ChatConfiguration } from '../common/constants.js';
-import { MarketplaceReferenceKind, parseMarketplaceReference, parseMarketplaceReferences } from '../common/plugins/marketplaceReference.js';
+import { MarketplaceReferenceKind, parseMarketplaceReference, parseMarketplaceReferences, readConfiguredMarketplaces } from '../common/plugins/marketplaceReference.js';
 import { IPluginInstallService } from '../common/plugins/pluginInstallService.js';
 
 /**
@@ -184,12 +184,12 @@ export class PluginUrlHandler extends Disposable implements IWorkbenchContributi
 			return true;
 		}
 
-		const existing = this._configurationService.getValue<string[]>(ChatConfiguration.PluginMarketplaces) ?? [];
-		const existingRefs = parseMarketplaceReferences(existing);
+		const { effectiveValues, editableValues } = readConfiguredMarketplaces(this._configurationService);
+		const existingRefs = parseMarketplaceReferences(effectiveValues);
 		if (!existingRefs.some(e => e.canonicalId === ref.canonicalId)) {
 			await this._configurationService.updateValue(
 				ChatConfiguration.PluginMarketplaces,
-				[...existing, refValue],
+				[...editableValues, refValue],
 				ConfigurationTarget.USER,
 			);
 		}

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -15,6 +15,7 @@ export enum ChatConfiguration {
 	PluginsEnabled = 'chat.plugins.enabled',
 	PluginLocations = 'chat.pluginLocations',
 	PluginMarketplaces = 'chat.plugins.marketplaces',
+	ExtraMarketplaces = 'chat.plugins.extraMarketplaces',
 	StrictMarketplaces = 'chat.plugins.strictMarketplaces',
 	EnabledPlugins = 'chat.plugins.enabledPlugins',
 	AgentEnabled = 'chat.agent.enabled',

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -15,6 +15,8 @@ export enum ChatConfiguration {
 	PluginsEnabled = 'chat.plugins.enabled',
 	PluginLocations = 'chat.pluginLocations',
 	PluginMarketplaces = 'chat.plugins.marketplaces',
+	StrictMarketplaces = 'chat.plugins.strictMarketplaces',
+	EnabledPlugins = 'chat.plugins.enabledPlugins',
 	AgentEnabled = 'chat.agent.enabled',
 	PlanAgentDefaultModel = 'chat.planAgent.defaultModel',
 	ExploreAgentDefaultModel = 'chat.exploreAgent.defaultModel',

--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginService.ts
@@ -35,6 +35,13 @@ export interface IAgentPlugin {
 	/** Human-readable display name for the plugin. */
 	readonly label: string;
 	readonly enablement: IObservable<ContributionEnablementState>;
+	/**
+	 * When `true`, the plugin is blocked by enterprise policy. It remains
+	 * visible (shown as disabled) but its contributions are inactive and the
+	 * user cannot re-enable it. Folded into {@link enablement} so all gating
+	 * consumers honor it automatically.
+	 */
+	readonly policyBlocked?: IObservable<boolean>;
 	/** Removes this plugin from its discovery source (config or installed storage). Undefined for policy-managed plugins that cannot be removed by the user. */
 	remove?(): void;
 	readonly hooks: IObservable<readonly IAgentPluginHook[]>;

--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginService.ts
@@ -35,8 +35,8 @@ export interface IAgentPlugin {
 	/** Human-readable display name for the plugin. */
 	readonly label: string;
 	readonly enablement: IObservable<ContributionEnablementState>;
-	/** Removes this plugin from its discovery source (config or installed storage). */
-	remove(): void;
+	/** Removes this plugin from its discovery source (config or installed storage). Undefined for policy-managed plugins that cannot be removed by the user. */
+	remove?(): void;
 	readonly hooks: IObservable<readonly IAgentPluginHook[]>;
 	readonly commands: IObservable<readonly IAgentPluginCommand[]>;
 	readonly skills: IObservable<readonly IAgentPluginSkill[]>;

--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
@@ -505,18 +505,11 @@ export class ConfiguredAgentPluginDiscovery extends AbstractAgentPluginDiscovery
 		@ILogService logService: ILogService,
 	) {
 		super(fileService, pathService, logService, workspaceContextService);
-		// Filesystem path entries (user-configured). `getValue()` alone would surface
-		// only the policy value when a policy is set; use `inspect()` so that user
-		// entries survive. `defaultValue` is folded in for symmetry.
-		this._pluginLocationsConfig = observableFromEvent(this,
-			Event.filter(this._configurationService.onDidChangeConfiguration, e => e.affectsConfiguration(ChatConfiguration.PluginLocations)),
-			() => {
-				const inspected = this._configurationService.inspect<Record<string, boolean>>(ChatConfiguration.PluginLocations);
-				return { ...inspected.defaultValue, ...inspected.userValue };
-			},
-		);
-		// Enterprise-managed plugin-ID entries (delivered via `ChatEnabledPlugins` policy).
+		this._pluginLocationsConfig = observableConfigValue<Record<string, boolean>>(ChatConfiguration.PluginLocations, {}, _configurationService);
+		// Enterprise-managed plugin-ID entries (delivered via the `ChatEnabledPlugins` policy).
 		// These are plugin IDs in `<plugin>@<marketplace>` form, distinct from filesystem paths.
+		// Read via `inspect()` so user-set entries survive when the policy is also set —
+		// `getValue()` alone would surface only the policy value.
 		this._enterpriseEnabledPluginsConfig = observableFromEvent(this,
 			Event.filter(this._configurationService.onDidChangeConfiguration, e => e.affectsConfiguration(ChatConfiguration.EnabledPlugins)),
 			() => {

--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
@@ -128,8 +128,7 @@ export class AgentPluginService extends Disposable implements IAgentPluginServic
 				return [];
 			}
 			const all = this._dedupeAndSort(discoveries.flatMap(d => d.plugins.read(read)));
-			const enforced = this._applyPolicyEnforcement(all, enabledPluginsPolicy.read(read), strictMarketplaces.read(read), pluginMarketplaceService, logService);
-			return enforced;
+			return this._applyPolicyEnforcement(all, enabledPluginsPolicy.read(read), strictMarketplaces.read(read), pluginMarketplaceService, logService);
 		});
 	}
 

--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
@@ -11,7 +11,7 @@ import { Disposable, DisposableStore } from '../../../../../base/common/lifecycl
 import { ResourceSet } from '../../../../../base/common/map.js';
 import { equals } from '../../../../../base/common/objects.js';
 import { Event } from '../../../../../base/common/event.js';
-import { autorun, derived, derivedOpts, IObservable, observableFromEvent, ObservablePromise, observableSignal, observableValue } from '../../../../../base/common/observable.js';
+import { autorun, derived, derivedOpts, IObservable, ISettableObservable, ITransaction, observableFromEvent, observableSignalFromEvent, ObservablePromise, observableSignal, observableValue, transaction } from '../../../../../base/common/observable.js';
 import {
 	posix,
 	win32
@@ -49,7 +49,7 @@ import { Extensions, IExtensionFeaturesRegistry, IExtensionFeatureTableRenderer,
 import * as extensionsRegistry from '../../../../services/extensions/common/extensionsRegistry.js';
 import { IPathService } from '../../../../services/path/common/pathService.js';
 import { ChatConfiguration } from '../constants.js';
-import { EnablementModel, IEnablementModel } from '../enablement.js';
+import { ContributionEnablementState, EnablementModel, IEnablementModel } from '../enablement.js';
 import { HookType } from '../promptSyntax/hookTypes.js';
 import { IAgentPluginRepositoryService } from './agentPluginRepositoryService.js';
 import { agentPluginDiscoveryRegistry, IAgentPlugin, IAgentPluginDiscovery, IAgentPluginHook, IAgentPluginInstruction, IAgentPluginMcpServerDefinition, IAgentPluginService } from './agentPluginService.js';
@@ -114,65 +114,77 @@ export class AgentPluginService extends Disposable implements IAgentPluginServic
 			discovery.start(this.enablementModel);
 		}
 
-		// Policy-driven enforcement filter, applied after discovery so that
-		// enterprise policy is honored regardless of which discovery source
-		// surfaces a plugin (local paths, marketplace, CLI install dir).
+		// Policy-driven enforcement, applied after discovery so that enterprise
+		// policy is honored regardless of which discovery source surfaces a
+		// plugin (local paths, marketplace, CLI install dir).
 		const enabledPluginsPolicy = observableFromEvent(this,
 			Event.filter(configurationService.onDidChangeConfiguration, e => e.affectsConfiguration(ChatConfiguration.EnabledPlugins)),
 			() => configurationService.inspect<Record<string, boolean>>(ChatConfiguration.EnabledPlugins).policyValue,
 		);
 		const strictMarketplaces = observableConfigValue<boolean>(ChatConfiguration.StrictMarketplaces, false, configurationService);
+		// Re-evaluate marketplace trust when the policy-delivered extra
+		// marketplaces change (consulted under strict mode).
+		const extraMarketplacesChanged = observableSignalFromEvent('extraMarketplaces',
+			Event.filter(configurationService.onDidChangeConfiguration, e => e.affectsConfiguration(ChatConfiguration.ExtraMarketplaces)));
 
 		this.plugins = derived(read => {
 			if (!pluginsEnabled.read(read)) {
 				return [];
 			}
-			const all = this._dedupeAndSort(discoveries.flatMap(d => d.plugins.read(read)));
-			return this._applyPolicyEnforcement(all, enabledPluginsPolicy.read(read), strictMarketplaces.read(read), pluginMarketplaceService, logService);
+			return this._dedupeAndSort(discoveries.flatMap(d => d.plugins.read(read)));
 		});
+
+		// Mark policy-blocked plugins rather than hiding them: a blocked plugin
+		// stays visible (shown as disabled) but its `enablement` is forced to
+		// disabled (see `_toPlugin`), so it is inactive and cannot be re-enabled.
+		this._register(autorun(reader => {
+			const plugins = this.plugins.read(reader);
+			const policy = enabledPluginsPolicy.read(reader);
+			const strict = strictMarketplaces.read(reader);
+			extraMarketplacesChanged.read(reader);
+			transaction(tx => {
+				for (const plugin of plugins) {
+					setPolicyBlocked(plugin, this._isBlockedByPolicy(plugin, policy, strict, pluginMarketplaceService, logService), tx);
+				}
+			});
+		}));
 	}
 
 	/**
-	 * Filters out plugins that are blocked by enterprise policy:
+	 * Determines whether a plugin is blocked by enterprise policy:
 	 * - If `chat.plugins.enabledPlugins` (policy-managed via `ChatEnabledPlugins`)
-	 *   is set, only plugins whose ID appears with value `true` survive.
+	 *   is set, only plugins whose ID appears with value `true` are allowed.
 	 * - If `chat.plugins.strictMarketplaces` is on, only plugins from a
-	 *   marketplace listed in `chat.plugins.extraMarketplaces` survive.
+	 *   marketplace listed in `chat.plugins.extraMarketplaces` are allowed.
 	 *
 	 * Plugins without a marketplace provenance (e.g. user-configured filesystem
-	 * paths from `chat.pluginLocations`) are unaffected by these filters — they
-	 * are user-side concerns outside the enterprise enforcement boundary.
+	 * paths from `chat.pluginLocations`) are never blocked — they are user-side
+	 * concerns outside the enterprise enforcement boundary.
 	 */
-	private _applyPolicyEnforcement(
-		plugins: readonly IAgentPlugin[],
+	private _isBlockedByPolicy(
+		plugin: IAgentPlugin,
 		enabledPluginsPolicy: Record<string, boolean> | undefined,
 		strictMarketplaces: boolean,
 		pluginMarketplaceService: IPluginMarketplaceService,
 		logService: ILogService,
-	): readonly IAgentPlugin[] {
-		if (!enabledPluginsPolicy && !strictMarketplaces) {
-			return plugins;
+	): boolean {
+		const m = plugin.fromMarketplace;
+		// Plugins not from a marketplace (filesystem entries) are not gated.
+		if (!m) {
+			return false;
 		}
-		const enabledPluginsPolicySet = enabledPluginsPolicy && Object.keys(enabledPluginsPolicy).length > 0;
-		return plugins.filter(plugin => {
-			const m = plugin.fromMarketplace;
-			// Plugins not from a marketplace (filesystem entries) are not gated.
-			if (!m) {
+		if (enabledPluginsPolicy && Object.keys(enabledPluginsPolicy).length > 0) {
+			const pluginId = `${m.name}@${m.marketplace}`;
+			if (enabledPluginsPolicy[pluginId] !== true) {
+				logService.debug(`[AgentPluginService] Plugin '${pluginId}' blocked — not enabled by ChatEnabledPlugins policy`);
 				return true;
 			}
-			if (enabledPluginsPolicySet) {
-				const pluginId = `${m.name}@${m.marketplace}`;
-				if (enabledPluginsPolicy![pluginId] !== true) {
-					logService.debug(`[AgentPluginService] Filtering out plugin '${pluginId}' — not enabled by ChatEnabledPlugins policy`);
-					return false;
-				}
-			}
-			if (strictMarketplaces && !pluginMarketplaceService.isMarketplaceTrusted(m.marketplaceReference)) {
-				logService.debug(`[AgentPluginService] Filtering out plugin '${m.name}@${m.marketplace}' — marketplace not trusted under strict mode`);
-				return false;
-			}
+		}
+		if (strictMarketplaces && !pluginMarketplaceService.isMarketplaceTrusted(m.marketplaceReference)) {
+			logService.debug(`[AgentPluginService] Plugin '${m.name}@${m.marketplace}' blocked — marketplace not trusted under strict mode`);
 			return true;
-		});
+		}
+		return false;
 	}
 
 	private _dedupeAndSort(plugins: readonly IAgentPlugin[]): readonly IAgentPlugin[] {
@@ -193,7 +205,26 @@ export class AgentPluginService extends Disposable implements IAgentPluginServic
 	}
 }
 
-type PluginEntry = IAgentPlugin;
+/**
+ * A discovered plugin. Extends the public {@link IAgentPlugin} with a settable
+ * `policyBlocked` observable that the service writes to when enterprise policy
+ * blocks the plugin.
+ */
+interface PluginEntry extends IAgentPlugin {
+	readonly policyBlocked: ISettableObservable<boolean>;
+}
+
+/**
+ * Marks a plugin as blocked (or unblocked) by enterprise policy. Safe to call
+ * for any {@link IAgentPlugin}; entries without a settable observable (e.g. test
+ * doubles) are ignored.
+ */
+function setPolicyBlocked(plugin: IAgentPlugin, blocked: boolean, tx: ITransaction): void {
+	const obs = plugin.policyBlocked as ISettableObservable<boolean> | undefined;
+	if (obs && typeof obs.set === 'function') {
+		obs.set(blocked, tx);
+	}
+}
 
 /**
  * Minimal shape of a parsed plugin manifest. Known fields are typed; unknown
@@ -305,7 +336,12 @@ export abstract class AbstractAgentPluginDiscovery extends Disposable implements
 		}
 
 		const store = new DisposableStore();
-		const enablement = derived(r => this._enablementModel.readEnabled(key, r));
+		// Set by the service when enterprise policy blocks this plugin; when set,
+		// the plugin is forced disabled regardless of the user's enablement choice.
+		const policyBlocked = observableValue<boolean>('policyBlocked', false);
+		const enablement = derived(r => policyBlocked.read(r)
+			? ContributionEnablementState.DisabledProfile
+			: this._enablementModel.readEnabled(key, r));
 
 		// Read the manifest up front so its `name` field can be used in the
 		// plugin label (for direct installs that have no marketplace metadata).
@@ -403,6 +439,7 @@ export abstract class AbstractAgentPluginDiscovery extends Disposable implements
 			uri,
 			label: fromMarketplace?.name ?? manifestName ?? basename(uri),
 			enablement,
+			policyBlocked,
 			remove: removeCallback,
 			hooks,
 			commands,

--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
@@ -4,13 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { RunOnceScheduler } from '../../../../../base/common/async.js';
+import { Event } from '../../../../../base/common/event.js';
 import { Iterable } from '../../../../../base/common/iterator.js';
 import { parse as parseJSONC } from '../../../../../base/common/json.js';
 import { untildify } from '../../../../../base/common/labels.js';
 import { Disposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { ResourceSet } from '../../../../../base/common/map.js';
 import { equals } from '../../../../../base/common/objects.js';
-import { Event } from '../../../../../base/common/event.js';
 import { autorun, derived, derivedOpts, IObservable, ISettableObservable, ITransaction, observableFromEvent, observableSignalFromEvent, ObservablePromise, observableSignal, observableValue, transaction } from '../../../../../base/common/observable.js';
 import {
 	posix,
@@ -250,7 +250,7 @@ interface IPolicyIdentity {
 	readonly marketplaceReference?: IMarketplaceReference;
 }
 
-/** Path fragment that identifies a Copilot-CLI-installed plugin (see `COPILOT_CLI_INSTALLED_PLUGINS_DIR` below). */
+/** Path fragment that identifies a Copilot-CLI-installed plugin. Mirrored by `_resolveEnterprisePluginId`. */
 const COPILOT_CLI_INSTALL_PATH_FRAGMENT = '/.copilot/installed-plugins/';
 
 function getPolicyIdentity(plugin: IAgentPlugin): IPolicyIdentity | undefined {

--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
@@ -541,47 +541,58 @@ export class ConfiguredAgentPluginDiscovery extends AbstractAgentPluginDiscovery
 		const sources: IPluginSource[] = [];
 		const userHome = await this._getUserHome();
 
-		// Two configuration shapes feed the same discovery pipeline:
-		// - User-configured filesystem paths in `chat.pluginLocations` — removable
-		//   by re-writing the user setting.
-		// - Enterprise-managed plugin IDs in `chat.plugins.enabledPlugins` (delivered
-		//   via the `ChatEnabledPlugins` policy) — not removable from the UI.
-		const groups: ReadonlyArray<{ entries: Record<string, boolean>; removable: boolean; label: string }> = [
-			{ entries: this._pluginLocationsConfig.get(), removable: true, label: 'plugin path' },
-			{ entries: this._enterpriseEnabledPluginsConfig.get(), removable: false, label: 'enterprise plugin path' },
-		];
-
-		for (const { entries, removable, label } of groups) {
-			for (const [key, enabled] of Object.entries(entries)) {
-				const trimmed = key.trim();
-				if (!trimmed || enabled === false) {
-					continue;
-				}
-
-				for (const resource of this._resolvePluginPath(trimmed, userHome)) {
-					let stat;
-					try {
-						stat = await this._fileService.resolve(resource);
-					} catch {
-						this._logService.debug(`[ConfiguredAgentPluginDiscovery] Could not resolve ${label}: ${resource.toString()}`);
-						continue;
-					}
-
-					if (!stat.isDirectory) {
-						this._logService.debug(`[ConfiguredAgentPluginDiscovery] ${label} is not a directory: ${resource.toString()}`);
-						continue;
-					}
-
-					sources.push({
-						uri: stat.resource,
-						fromMarketplace: this._pluginMarketplaceService.getMarketplacePluginMetadata(stat.resource),
-						remove: removable ? () => this._removePluginPath(key) : undefined,
-					});
-				}
+		// User-configured filesystem paths in `chat.pluginLocations` — removable
+		// by re-writing the user setting. Filesystem-only; an entry that happens
+		// to look like `name@marketplace` is treated as a relative path, not an ID.
+		for (const [key, enabled] of Object.entries(this._pluginLocationsConfig.get())) {
+			const trimmed = key.trim();
+			if (!trimmed || enabled === false) {
+				continue;
+			}
+			for (const resource of this._resolvePluginPath(trimmed, userHome)) {
+				await this._addPluginSource(sources, resource, 'plugin path', () => this._removePluginPath(key));
 			}
 		}
 
+		// Enterprise-managed plugin IDs in `chat.plugins.enabledPlugins` (delivered
+		// via the `ChatEnabledPlugins` policy) — IDs of the form
+		// `<plugin>@<marketplace>`, resolved to the Copilot CLI install convention.
+		// Non-removable from the UI (enterprise-managed).
+		for (const [key, enabled] of Object.entries(this._enterpriseEnabledPluginsConfig.get())) {
+			const trimmed = key.trim();
+			if (!trimmed || enabled === false) {
+				continue;
+			}
+			const resource = this._resolveEnterprisePluginId(trimmed, userHome);
+			if (!resource) {
+				this._logService.debug(`[ConfiguredAgentPluginDiscovery] Skipping enterprise plugin entry that is not in <plugin>@<marketplace> form: ${trimmed}`);
+				continue;
+			}
+			await this._addPluginSource(sources, resource, 'enterprise plugin path');
+		}
+
 		return sources;
+	}
+
+	private async _addPluginSource(sources: IPluginSource[], resource: URI, label: string, remove?: () => void): Promise<void> {
+		let stat;
+		try {
+			stat = await this._fileService.resolve(resource);
+		} catch {
+			this._logService.debug(`[ConfiguredAgentPluginDiscovery] Could not resolve ${label}: ${resource.toString()}`);
+			return;
+		}
+
+		if (!stat.isDirectory) {
+			this._logService.debug(`[ConfiguredAgentPluginDiscovery] ${label} is not a directory: ${resource.toString()}`);
+			return;
+		}
+
+		sources.push({
+			uri: stat.resource,
+			fromMarketplace: this._pluginMarketplaceService.getMarketplacePluginMetadata(stat.resource),
+			remove,
+		});
 	}
 
 	private async _getUserHome(): Promise<string> {
@@ -590,25 +601,15 @@ export class ConfiguredAgentPluginDiscovery extends AbstractAgentPluginDiscovery
 	}
 
 	/**
-	 * Resolves a plugin path or plugin ID to one or more resource URIs. Supports:
-	 * - Absolute paths (used directly)
-	 * - Tilde paths (expanded to user home directory)
-	 * - Relative paths (resolved against each workspace folder)
-	 * - Plugin-ID form (`<plugin>@<marketplace>`) from the `ChatEnabledPlugins` enterprise policy,
-	 *   resolved to the Copilot CLI install convention `~/.copilot/installed-plugins/<marketplace>/<plugin>/`.
+	 * Resolves a user-configured plugin path to one or more resource URIs.
+	 * Supports absolute paths, tilde paths (expanded to user home), and
+	 * workspace-relative paths.
 	 */
 	private _resolvePluginPath(path: string, userHome: string): URI[] {
-		const idMatch = path.match(/^([^@/\\~]+)@([^@/\\~]+)$/);
-		if (idMatch) {
-			const [, plugin, marketplace] = idMatch;
-			return [URI.file(`${userHome}/.copilot/installed-plugins/${marketplace}/${plugin}`)];
-		}
-
 		if (path.startsWith('~')) {
 			path = untildify(path, userHome);
 		}
 
-		// Handle absolute paths
 		if (win32.isAbsolute(path) || posix.isAbsolute(path)) {
 			return [URI.file(path)];
 		}
@@ -616,6 +617,20 @@ export class ConfiguredAgentPluginDiscovery extends AbstractAgentPluginDiscovery
 		return this._workspaceContextService.getWorkspace().folders.map(
 			folder => joinPath(folder.uri, path)
 		);
+	}
+
+	/**
+	 * Resolves an enterprise plugin ID of the form `<plugin>@<marketplace>` to
+	 * the Copilot CLI install convention `~/.copilot/installed-plugins/<marketplace>/<plugin>/`.
+	 * Returns `undefined` for anything that doesn't match the ID shape.
+	 */
+	private _resolveEnterprisePluginId(id: string, userHome: string): URI | undefined {
+		const idMatch = id.match(/^([^@/\\~]+)@([^@/\\~]+)$/);
+		if (!idMatch) {
+			return undefined;
+		}
+		const [, plugin, marketplace] = idMatch;
+		return URI.file(`${userHome}/.copilot/installed-plugins/${marketplace}/${plugin}`);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
@@ -10,7 +10,8 @@ import { untildify } from '../../../../../base/common/labels.js';
 import { Disposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { ResourceSet } from '../../../../../base/common/map.js';
 import { equals } from '../../../../../base/common/objects.js';
-import { autorun, derived, derivedOpts, IObservable, ObservablePromise, observableSignal, observableValue } from '../../../../../base/common/observable.js';
+import { Event } from '../../../../../base/common/event.js';
+import { autorun, derived, derivedOpts, IObservable, observableFromEvent, ObservablePromise, observableSignal, observableValue } from '../../../../../base/common/observable.js';
 import {
 	posix,
 	win32
@@ -162,8 +163,8 @@ interface IPluginSource {
 	readonly fromMarketplace: IMarketplacePlugin | undefined;
 	/** Repository root that serves as the boundary for component path resolution. */
 	readonly repositoryUri?: URI;
-	/** Called when remove is invoked on the plugin */
-	remove(): void;
+	/** Called when remove is invoked on the plugin; absent for policy-managed plugins */
+	remove?(): void;
 }
 
 /**
@@ -218,7 +219,7 @@ export abstract class AbstractAgentPluginDiscovery extends Disposable implements
 			if (!seenPluginUris.has(key)) {
 				seenPluginUris.add(key);
 				const format = await detectPluginFormat(source.uri, this._fileService);
-				plugins.push(await this._toPlugin(source.uri, format, source.fromMarketplace, source.repositoryUri, () => source.remove()));
+				plugins.push(await this._toPlugin(source.uri, format, source.fromMarketplace, source.repositoryUri, source.remove ? () => source.remove!() : undefined));
 			}
 		}
 
@@ -237,7 +238,7 @@ export abstract class AbstractAgentPluginDiscovery extends Disposable implements
 		}
 	}
 
-	private async _toPlugin(uri: URI, format: IPluginFormatConfig, fromMarketplace: IMarketplacePlugin | undefined, repositoryUri: URI | undefined, removeCallback: () => void): Promise<IAgentPlugin> {
+	private async _toPlugin(uri: URI, format: IPluginFormatConfig, fromMarketplace: IMarketplacePlugin | undefined, repositoryUri: URI | undefined, removeCallback: (() => void) | undefined): Promise<IAgentPlugin> {
 		const key = uri.toString();
 		const existing = this._pluginEntries.get(key);
 		if (existing) {
@@ -493,6 +494,7 @@ export abstract class AbstractAgentPluginDiscovery extends Disposable implements
 export class ConfiguredAgentPluginDiscovery extends AbstractAgentPluginDiscovery {
 
 	private readonly _pluginLocationsConfig: IObservable<Record<string, boolean>>;
+	private readonly _enterpriseEnabledPluginsConfig: IObservable<Record<string, boolean>>;
 
 	constructor(
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
@@ -503,7 +505,25 @@ export class ConfiguredAgentPluginDiscovery extends AbstractAgentPluginDiscovery
 		@ILogService logService: ILogService,
 	) {
 		super(fileService, pathService, logService, workspaceContextService);
-		this._pluginLocationsConfig = observableConfigValue<Record<string, boolean>>(ChatConfiguration.PluginLocations, {}, _configurationService);
+		// Filesystem path entries (user-configured). `getValue()` alone would surface
+		// only the policy value when a policy is set; use `inspect()` so that user
+		// entries survive. `defaultValue` is folded in for symmetry.
+		this._pluginLocationsConfig = observableFromEvent(this,
+			Event.filter(this._configurationService.onDidChangeConfiguration, e => e.affectsConfiguration(ChatConfiguration.PluginLocations)),
+			() => {
+				const inspected = this._configurationService.inspect<Record<string, boolean>>(ChatConfiguration.PluginLocations);
+				return { ...inspected.defaultValue, ...inspected.userValue };
+			},
+		);
+		// Enterprise-managed plugin-ID entries (delivered via `ChatEnabledPlugins` policy).
+		// These are plugin IDs in `<plugin>@<marketplace>` form, distinct from filesystem paths.
+		this._enterpriseEnabledPluginsConfig = observableFromEvent(this,
+			Event.filter(this._configurationService.onDidChangeConfiguration, e => e.affectsConfiguration(ChatConfiguration.EnabledPlugins)),
+			() => {
+				const inspected = this._configurationService.inspect<Record<string, boolean>>(ChatConfiguration.EnabledPlugins);
+				return { ...inspected.defaultValue, ...inspected.userValue, ...inspected.policyValue };
+			},
+		);
 	}
 
 	public override start(enablementModel: IEnablementModel): void {
@@ -511,6 +531,7 @@ export class ConfiguredAgentPluginDiscovery extends AbstractAgentPluginDiscovery
 		const scheduler = this._register(new RunOnceScheduler(() => this._refreshPlugins(), 0));
 		this._register(autorun(reader => {
 			this._pluginLocationsConfig.read(reader);
+			this._enterpriseEnabledPluginsConfig.read(reader);
 			scheduler.schedule();
 		}));
 		scheduler.schedule();
@@ -518,36 +539,45 @@ export class ConfiguredAgentPluginDiscovery extends AbstractAgentPluginDiscovery
 
 	protected override async _discoverPluginSources(): Promise<readonly IPluginSource[]> {
 		const sources: IPluginSource[] = [];
-		const config = this._pluginLocationsConfig.get();
 		const userHome = await this._getUserHome();
 
-		for (const [path, enabled] of Object.entries(config)) {
-			if (!path.trim() || enabled === false) {
-				continue;
-			}
+		// Two configuration shapes feed the same discovery pipeline:
+		// - User-configured filesystem paths in `chat.pluginLocations` — removable
+		//   by re-writing the user setting.
+		// - Enterprise-managed plugin IDs in `chat.plugins.enabledPlugins` (delivered
+		//   via the `ChatEnabledPlugins` policy) — not removable from the UI.
+		const groups: ReadonlyArray<{ entries: Record<string, boolean>; removable: boolean; label: string }> = [
+			{ entries: this._pluginLocationsConfig.get(), removable: true, label: 'plugin path' },
+			{ entries: this._enterpriseEnabledPluginsConfig.get(), removable: false, label: 'enterprise plugin path' },
+		];
 
-			const resources = this._resolvePluginPath(path.trim(), userHome);
-			for (const resource of resources) {
-				let stat;
-				try {
-					stat = await this._fileService.resolve(resource);
-				} catch {
-					this._logService.debug(`[ConfiguredAgentPluginDiscovery] Could not resolve plugin path: ${resource.toString()}`);
+		for (const { entries, removable, label } of groups) {
+			for (const [key, enabled] of Object.entries(entries)) {
+				const trimmed = key.trim();
+				if (!trimmed || enabled === false) {
 					continue;
 				}
 
-				if (!stat.isDirectory) {
-					this._logService.debug(`[ConfiguredAgentPluginDiscovery] Plugin path is not a directory: ${resource.toString()}`);
-					continue;
-				}
+				for (const resource of this._resolvePluginPath(trimmed, userHome)) {
+					let stat;
+					try {
+						stat = await this._fileService.resolve(resource);
+					} catch {
+						this._logService.debug(`[ConfiguredAgentPluginDiscovery] Could not resolve ${label}: ${resource.toString()}`);
+						continue;
+					}
 
-				const fromMarketplace = this._pluginMarketplaceService.getMarketplacePluginMetadata(stat.resource);
-				const configKey = path;
-				sources.push({
-					uri: stat.resource,
-					fromMarketplace,
-					remove: () => this._removePluginPath(configKey),
-				});
+					if (!stat.isDirectory) {
+						this._logService.debug(`[ConfiguredAgentPluginDiscovery] ${label} is not a directory: ${resource.toString()}`);
+						continue;
+					}
+
+					sources.push({
+						uri: stat.resource,
+						fromMarketplace: this._pluginMarketplaceService.getMarketplacePluginMetadata(stat.resource),
+						remove: removable ? () => this._removePluginPath(key) : undefined,
+					});
+				}
 			}
 		}
 
@@ -560,12 +590,20 @@ export class ConfiguredAgentPluginDiscovery extends AbstractAgentPluginDiscovery
 	}
 
 	/**
-	 * Resolves a plugin path to one or more resource URIs. Supports:
+	 * Resolves a plugin path or plugin ID to one or more resource URIs. Supports:
 	 * - Absolute paths (used directly)
 	 * - Tilde paths (expanded to user home directory)
 	 * - Relative paths (resolved against each workspace folder)
+	 * - Plugin-ID form (`<plugin>@<marketplace>`) from the `ChatEnabledPlugins` enterprise policy,
+	 *   resolved to the Copilot CLI install convention `~/.copilot/installed-plugins/<marketplace>/<plugin>/`.
 	 */
 	private _resolvePluginPath(path: string, userHome: string): URI[] {
+		const idMatch = path.match(/^([^@/\\~]+)@([^@/\\~]+)$/);
+		if (idMatch) {
+			const [, plugin, marketplace] = idMatch;
+			return [URI.file(`${userHome}/.copilot/installed-plugins/${marketplace}/${plugin}`)];
+		}
+
 		if (path.startsWith('~')) {
 			path = untildify(path, userHome);
 		}

--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
@@ -97,6 +97,8 @@ export class AgentPluginService extends Disposable implements IAgentPluginServic
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IConfigurationService configurationService: IConfigurationService,
 		@IStorageService storageService: IStorageService,
+		@IPluginMarketplaceService pluginMarketplaceService: IPluginMarketplaceService,
+		@ILogService logService: ILogService,
 	) {
 		super();
 
@@ -112,12 +114,65 @@ export class AgentPluginService extends Disposable implements IAgentPluginServic
 			discovery.start(this.enablementModel);
 		}
 
+		// Policy-driven enforcement filter, applied after discovery so that
+		// enterprise policy is honored regardless of which discovery source
+		// surfaces a plugin (local paths, marketplace, CLI install dir).
+		const enabledPluginsPolicy = observableFromEvent(this,
+			Event.filter(configurationService.onDidChangeConfiguration, e => e.affectsConfiguration(ChatConfiguration.EnabledPlugins)),
+			() => configurationService.inspect<Record<string, boolean>>(ChatConfiguration.EnabledPlugins).policyValue,
+		);
+		const strictMarketplaces = observableConfigValue<boolean>(ChatConfiguration.StrictMarketplaces, false, configurationService);
 
 		this.plugins = derived(read => {
 			if (!pluginsEnabled.read(read)) {
 				return [];
 			}
-			return this._dedupeAndSort(discoveries.flatMap(d => d.plugins.read(read)));
+			const all = this._dedupeAndSort(discoveries.flatMap(d => d.plugins.read(read)));
+			const enforced = this._applyPolicyEnforcement(all, enabledPluginsPolicy.read(read), strictMarketplaces.read(read), pluginMarketplaceService, logService);
+			return enforced;
+		});
+	}
+
+	/**
+	 * Filters out plugins that are blocked by enterprise policy:
+	 * - If `chat.plugins.enabledPlugins` (policy-managed via `ChatEnabledPlugins`)
+	 *   is set, only plugins whose ID appears with value `true` survive.
+	 * - If `chat.plugins.strictMarketplaces` is on, only plugins from a
+	 *   marketplace listed in `chat.plugins.extraMarketplaces` survive.
+	 *
+	 * Plugins without a marketplace provenance (e.g. user-configured filesystem
+	 * paths from `chat.pluginLocations`) are unaffected by these filters — they
+	 * are user-side concerns outside the enterprise enforcement boundary.
+	 */
+	private _applyPolicyEnforcement(
+		plugins: readonly IAgentPlugin[],
+		enabledPluginsPolicy: Record<string, boolean> | undefined,
+		strictMarketplaces: boolean,
+		pluginMarketplaceService: IPluginMarketplaceService,
+		logService: ILogService,
+	): readonly IAgentPlugin[] {
+		if (!enabledPluginsPolicy && !strictMarketplaces) {
+			return plugins;
+		}
+		const enabledPluginsPolicySet = enabledPluginsPolicy && Object.keys(enabledPluginsPolicy).length > 0;
+		return plugins.filter(plugin => {
+			const m = plugin.fromMarketplace;
+			// Plugins not from a marketplace (filesystem entries) are not gated.
+			if (!m) {
+				return true;
+			}
+			if (enabledPluginsPolicySet) {
+				const pluginId = `${m.name}@${m.marketplace}`;
+				if (enabledPluginsPolicy![pluginId] !== true) {
+					logService.debug(`[AgentPluginService] Filtering out plugin '${pluginId}' — not enabled by ChatEnabledPlugins policy`);
+					return false;
+				}
+			}
+			if (strictMarketplaces && !pluginMarketplaceService.isMarketplaceTrusted(m.marketplaceReference)) {
+				logService.debug(`[AgentPluginService] Filtering out plugin '${m.name}@${m.marketplace}' — marketplace not trusted under strict mode`);
+				return false;
+			}
+			return true;
 		});
 	}
 

--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
@@ -54,6 +54,7 @@ import { HookType } from '../promptSyntax/hookTypes.js';
 import { IAgentPluginRepositoryService } from './agentPluginRepositoryService.js';
 import { agentPluginDiscoveryRegistry, IAgentPlugin, IAgentPluginDiscovery, IAgentPluginHook, IAgentPluginInstruction, IAgentPluginMcpServerDefinition, IAgentPluginService } from './agentPluginService.js';
 import { IMarketplacePlugin, IPluginMarketplaceService } from './pluginMarketplaceService.js';
+import { type IMarketplaceReference, parseMarketplaceReferences, readConfiguredMarketplaces } from './marketplaceReference.js';
 
 // Re-export shared helpers so existing consumers (including tests) continue to work.
 export { shellQuotePluginRootInCommand, resolveMcpServersMap, convertBareEnvVarsToVsCodeSyntax } from '../../../../../platform/agentPlugins/common/pluginParsers.js';
@@ -142,9 +143,12 @@ export class AgentPluginService extends Disposable implements IAgentPluginServic
 			const policy = enabledPluginsPolicy.read(reader);
 			const strict = strictMarketplaces.read(reader);
 			extraMarketplacesChanged.read(reader);
+			const trustedExtras = strict
+				? parseMarketplaceReferences(readConfiguredMarketplaces(configurationService).extraValues)
+				: [];
 			transaction(tx => {
 				for (const plugin of plugins) {
-					setPolicyBlocked(plugin, this._isBlockedByPolicy(plugin, policy, strict, pluginMarketplaceService, logService), tx);
+					setPolicyBlocked(plugin, this._isBlockedByPolicy(plugin, policy, strict, trustedExtras, pluginMarketplaceService, logService), tx);
 				}
 			});
 		}));
@@ -159,30 +163,38 @@ export class AgentPluginService extends Disposable implements IAgentPluginServic
 	 *
 	 * Plugins without a marketplace provenance (e.g. user-configured filesystem
 	 * paths from `chat.pluginLocations`) are never blocked — they are user-side
-	 * concerns outside the enterprise enforcement boundary.
+	 * concerns outside the enterprise enforcement boundary. Copilot-CLI-installed
+	 * plugins under `~/.copilot/installed-plugins/<marketplace>/<plugin>/` are
+	 * gated using their install-path identity even when they lack rich
+	 * marketplace metadata.
 	 */
 	private _isBlockedByPolicy(
 		plugin: IAgentPlugin,
 		enabledPluginsPolicy: Record<string, boolean> | undefined,
 		strictMarketplaces: boolean,
+		trustedExtras: readonly IMarketplaceReference[],
 		pluginMarketplaceService: IPluginMarketplaceService,
 		logService: ILogService,
 	): boolean {
-		const m = plugin.fromMarketplace;
-		// Plugins not from a marketplace (filesystem entries) are not gated.
-		if (!m) {
+		const identity = getPolicyIdentity(plugin);
+		if (!identity) {
 			return false;
 		}
+		const pluginId = `${identity.name}@${identity.marketplace}`;
 		if (enabledPluginsPolicy && Object.keys(enabledPluginsPolicy).length > 0) {
-			const pluginId = `${m.name}@${m.marketplace}`;
 			if (enabledPluginsPolicy[pluginId] !== true) {
 				logService.debug(`[AgentPluginService] Plugin '${pluginId}' blocked — not enabled by ChatEnabledPlugins policy`);
 				return true;
 			}
 		}
-		if (strictMarketplaces && !pluginMarketplaceService.isMarketplaceTrusted(m.marketplaceReference)) {
-			logService.debug(`[AgentPluginService] Plugin '${m.name}@${m.marketplace}' blocked — marketplace not trusted under strict mode`);
-			return true;
+		if (strictMarketplaces) {
+			const trusted = identity.marketplaceReference
+				? pluginMarketplaceService.isMarketplaceTrusted(identity.marketplaceReference)
+				: isCliBucketTrusted(identity.marketplace, trustedExtras);
+			if (!trusted) {
+				logService.debug(`[AgentPluginService] Plugin '${pluginId}' blocked — marketplace not trusted under strict mode`);
+				return true;
+			}
 		}
 		return false;
 	}
@@ -224,6 +236,70 @@ function setPolicyBlocked(plugin: IAgentPlugin, blocked: boolean, tx: ITransacti
 	if (obs && typeof obs.set === 'function') {
 		obs.set(blocked, tx);
 	}
+}
+
+/**
+ * The policy-relevant identity of a plugin, used to gate against
+ * `chat.plugins.enabledPlugins` and `chat.plugins.strictMarketplaces`. Returns
+ * `undefined` for plugins that aren't subject to enterprise policy (e.g.
+ * user-configured filesystem entries, extension-contributed plugins).
+ */
+interface IPolicyIdentity {
+	readonly name: string;
+	readonly marketplace: string;
+	readonly marketplaceReference?: IMarketplaceReference;
+}
+
+/** Path fragment that identifies a Copilot-CLI-installed plugin (see `COPILOT_CLI_INSTALLED_PLUGINS_DIR` below). */
+const COPILOT_CLI_INSTALL_PATH_FRAGMENT = '/.copilot/installed-plugins/';
+
+function getPolicyIdentity(plugin: IAgentPlugin): IPolicyIdentity | undefined {
+	const m = plugin.fromMarketplace;
+	if (m) {
+		return { name: m.name, marketplace: m.marketplace, marketplaceReference: m.marketplaceReference };
+	}
+	// Copilot-CLI-installed plugins live at `~/.copilot/installed-plugins/<marketplace>/<plugin>/`.
+	// We honor enterprise policy for those by deriving the identity from the install path,
+	// using the same convention as `_resolveEnterprisePluginId`. The reserved `_direct` bucket
+	// means "not from a marketplace" and is therefore not gated.
+	if (plugin.uri.scheme !== 'file') {
+		return undefined;
+	}
+	const idx = plugin.uri.path.indexOf(COPILOT_CLI_INSTALL_PATH_FRAGMENT);
+	if (idx === -1) {
+		return undefined;
+	}
+	const segments = plugin.uri.path.slice(idx + COPILOT_CLI_INSTALL_PATH_FRAGMENT.length).split('/').filter(s => s.length > 0);
+	if (segments.length !== 2) {
+		return undefined;
+	}
+	const [marketplace, name] = segments;
+	if (marketplace === '_direct') {
+		return undefined;
+	}
+	return { name, marketplace };
+}
+
+/**
+ * Under strict mode, decide whether a Copilot-CLI-installed plugin's bucket
+ * name (the `<marketplace>` segment of its install path) corresponds to a
+ * trusted marketplace listed in `chat.plugins.extraMarketplaces`. Uses
+ * heuristics covering common CLI bucket-naming conventions (GitHub repo name,
+ * shorthand `owner/repo`, raw reference value, canonical id tail).
+ */
+function isCliBucketTrusted(bucket: string, trustedExtras: readonly IMarketplaceReference[]): boolean {
+	return trustedExtras.some(ref => {
+		if (ref.githubRepo && ref.githubRepo.split('/').pop() === bucket) {
+			return true;
+		}
+		if (ref.displayLabel === bucket || ref.displayLabel.endsWith(`/${bucket}`)) {
+			return true;
+		}
+		if (ref.canonicalId.endsWith(`/${bucket}`) || ref.canonicalId.endsWith(`/${bucket}.git`)) {
+			return true;
+		}
+		return false;
+	});
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
@@ -219,7 +219,7 @@ export abstract class AbstractAgentPluginDiscovery extends Disposable implements
 			if (!seenPluginUris.has(key)) {
 				seenPluginUris.add(key);
 				const format = await detectPluginFormat(source.uri, this._fileService);
-				plugins.push(await this._toPlugin(source.uri, format, source.fromMarketplace, source.repositoryUri, source.remove ? () => source.remove!() : undefined));
+				plugins.push(await this._toPlugin(source.uri, format, source.fromMarketplace, source.repositoryUri, source.remove));
 			}
 		}
 

--- a/src/vs/workbench/contrib/chat/common/plugins/marketplaceReference.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/marketplaceReference.ts
@@ -290,11 +290,22 @@ function parseUriMarketplaceReference(rawValue: string): IMarketplaceReference |
 	// Extract githubRepo for GitHub URLs so the editor can render a clickable link
 	const githubRepo = extractGitHubRepo(uri.authority, pathWithoutGit);
 
+	// Normalize github.com/<owner>/<repo>[.git] URLs to the same canonical id
+	// the shorthand parser emits, so policy trust comparisons (which match by
+	// canonicalId) treat both forms as the same marketplace.
+	let canonicalId: string;
+	if (githubRepo) {
+		const [owner, repo] = githubRepo.split('/');
+		canonicalId = getGitHubCanonicalId(owner, repo, ref);
+	} else {
+		canonicalId = appendRefSuffix(`git:${uri.authority.toLowerCase()}/${canonicalPath}`, ref);
+	}
+
 	return {
 		rawValue,
 		displayLabel: rawValue,
 		cloneUrl: cloneUri.toString(),
-		canonicalId: appendRefSuffix(`git:${uri.authority.toLowerCase()}/${canonicalPath}`, ref),
+		canonicalId,
 		cacheSegments: [sanitizedAuthority, ...pathSegments, ...getRefCacheSegments(ref)],
 		kind: MarketplaceReferenceKind.GitUri,
 		ref,
@@ -320,11 +331,21 @@ function parseScpMarketplaceReference(rawValue: string): IMarketplaceReference |
 	const pathSegments = pathWithoutGit.split('/').map(sanitizePathSegment);
 	const githubRepo = extractGitHubRepo(authority, pathWithoutGit);
 
+	// Normalize git@github.com:<owner>/<repo>.git to the same canonical id the
+	// shorthand parser emits (see parseUriMarketplaceReference for rationale).
+	let canonicalId: string;
+	if (githubRepo) {
+		const [owner, repo] = githubRepo.split('/');
+		canonicalId = getGitHubCanonicalId(owner, repo, ref);
+	} else {
+		canonicalId = appendRefSuffix(`git:${authority.toLowerCase()}/${pathWithGit.toLowerCase()}`, ref);
+	}
+
 	return {
 		rawValue,
 		displayLabel: rawValue,
 		cloneUrl: `${match[1]}@${authority}:${pathWithGit}`,
-		canonicalId: appendRefSuffix(`git:${authority.toLowerCase()}/${pathWithGit.toLowerCase()}`, ref),
+		canonicalId,
 		cacheSegments: [sanitizePathSegment(authority.toLowerCase()), ...pathSegments, ...getRefCacheSegments(ref)],
 		kind: MarketplaceReferenceKind.GitUri,
 		ref,

--- a/src/vs/workbench/contrib/chat/common/plugins/marketplaceReference.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/marketplaceReference.ts
@@ -213,20 +213,32 @@ function parseUriMarketplaceReference(rawValue: string): IMarketplaceReference |
 		return undefined;
 	}
 
-	const normalizedPath = normalizeGitRepoPath(uri.path);
-	if (!normalizedPath) {
-		return undefined;
-	}
 	const ref = uri.fragment || undefined;
 	const cloneUri = uri.fragment ? uri.with({ fragment: '' }) : uri;
+	const sanitizedAuthority = sanitizePathSegment(uri.authority.toLowerCase());
+	const trimmedPath = uri.path.replace(/\/+/g, '/').replace(/\/+$/g, '').replace(/^\/+/, '');
+
+	// Host-only marketplace endpoint (e.g. `https://plugins.internal.example.com`).
+	// The ADR allows any string for `git.url`, so a URL without a repo path is
+	// treated as a marketplace registry endpoint identified by host alone.
+	if (!trimmedPath) {
+		return {
+			rawValue,
+			displayLabel: rawValue,
+			cloneUrl: cloneUri.toString(),
+			canonicalId: appendRefSuffix(`git:${uri.authority.toLowerCase()}/`, ref),
+			cacheSegments: [sanitizedAuthority, ...getRefCacheSegments(ref)],
+			kind: MarketplaceReferenceKind.GitUri,
+			ref,
+		};
+	}
 
 	const gitSuffix = '.git';
-	const sanitizedAuthority = sanitizePathSegment(uri.authority.toLowerCase());
-	const pathHasGitSuffix = normalizedPath.toLowerCase().endsWith(gitSuffix);
-	const pathWithoutGit = pathHasGitSuffix ? normalizedPath.slice(1, normalizedPath.length - gitSuffix.length) : normalizedPath.slice(1);
+	const pathHasGitSuffix = trimmedPath.toLowerCase().endsWith(gitSuffix);
+	const pathWithoutGit = pathHasGitSuffix ? trimmedPath.slice(0, trimmedPath.length - gitSuffix.length) : trimmedPath;
 	const pathSegments = pathWithoutGit.split('/').map(sanitizePathSegment);
 	// Always normalize the canonical path to include .git so that URLs with and without the suffix deduplicate.
-	const canonicalPath = pathHasGitSuffix ? normalizedPath.slice(1).toLowerCase() : `${normalizedPath.slice(1).toLowerCase()}${gitSuffix}`;
+	const canonicalPath = pathHasGitSuffix ? trimmedPath.toLowerCase() : `${trimmedPath.toLowerCase()}${gitSuffix}`;
 
 	// Extract githubRepo for GitHub URLs so the editor can render a clickable link
 	const githubRepo = extractGitHubRepo(uri.authority, pathWithoutGit);
@@ -271,28 +283,6 @@ function parseScpMarketplaceReference(rawValue: string): IMarketplaceReference |
 		ref,
 		githubRepo,
 	};
-}
-
-/**
- * Normalizes a Git repository path and validates that it has at least two segments
- * (i.e., at least one owner/repo pair below the root). Accepts paths with or without
- * a `.git` suffix — the suffix is preserved in the returned value so callers can decide
- * how to treat it.
- */
-function normalizeGitRepoPath(path: string): string | undefined {
-	const gitSuffix = '.git';
-	const trimmed = path.replace(/\/+/g, '/').replace(/\/+$/g, '');
-
-	const withLeadingSlash = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
-	// Strip .git suffix (if present) only for the purposes of validating path depth.
-	const pathWithoutGit = withLeadingSlash.toLowerCase().endsWith(gitSuffix)
-		? withLeadingSlash.slice(1, withLeadingSlash.length - gitSuffix.length)
-		: withLeadingSlash.slice(1);
-	if (!pathWithoutGit || !pathWithoutGit.includes('/')) {
-		return undefined;
-	}
-
-	return withLeadingSlash;
 }
 
 function extractGitHubRepo(authority: string, pathWithoutGit: string): string | undefined {

--- a/src/vs/workbench/contrib/chat/common/plugins/marketplaceReference.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/marketplaceReference.ts
@@ -4,6 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { URI } from '../../../../../base/common/uri.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { ChatConfiguration } from '../constants.js';
 
 export const enum MarketplaceReferenceKind {
 	GitHubShorthand = 'githubShorthand',
@@ -21,6 +23,37 @@ export interface IMarketplaceReference {
 	readonly ref?: string;
 	readonly githubRepo?: string;
 	readonly localRepositoryUri?: URI;
+}
+
+/**
+ * Reads {@link ChatConfiguration.PluginMarketplaces} broken into its three
+ * configuration layers so callers can:
+ * - apply default + user + policy when computing the effective set (read paths,
+ *   trust checks);
+ * - apply default + user when writing back (so we don't persist policy entries
+ *   into user settings); and
+ * - recognise which canonical IDs are policy-supplied (so they can be marked
+ *   read-only in management UI).
+ *
+ * Entries may be strings (`<owner>/<repo>` or git URIs) or objects (policy
+ * payloads); both shapes flow through {@link parseMarketplaceReferences}.
+ */
+export interface IConfiguredMarketplaces {
+	readonly effectiveValues: readonly unknown[];
+	readonly editableValues: readonly unknown[];
+	readonly policyCanonicalIds: ReadonlySet<string>;
+}
+
+export function readConfiguredMarketplaces(configurationService: IConfigurationService): IConfiguredMarketplaces {
+	const inspected = configurationService.inspect<(string | object)[]>(ChatConfiguration.PluginMarketplaces);
+	const defaultValues = inspected.defaultValue ?? [];
+	const userValues = inspected.userValue ?? [];
+	const policyValues = inspected.policyValue ?? [];
+	return {
+		effectiveValues: [...defaultValues, ...userValues, ...policyValues],
+		editableValues: [...defaultValues, ...userValues],
+		policyCanonicalIds: new Set(parseMarketplaceReferences(policyValues).map(r => r.canonicalId)),
+	};
 }
 
 export function parseMarketplaceReferences(values: readonly unknown[]): IMarketplaceReference[] {

--- a/src/vs/workbench/contrib/chat/common/plugins/marketplaceReference.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/marketplaceReference.ts
@@ -55,21 +55,76 @@ export function parseMarketplaceReferences(values: readonly unknown[]): IMarketp
 	const byCanonicalId = new Map<string, IMarketplaceReference>();
 
 	for (const value of values) {
-		if (typeof value !== 'string') {
-			continue;
+		let parsed: IMarketplaceReference | undefined;
+		if (typeof value === 'string') {
+			parsed = parseMarketplaceReference(value);
+		} else if (value && typeof value === 'object') {
+			parsed = parseMarketplaceObjectEntry(value as IExtraMarketplaceObjectEntry);
 		}
-
-		const parsed = parseMarketplaceReference(value);
-		if (!parsed) {
-			continue;
-		}
-
-		if (!byCanonicalId.has(parsed.canonicalId)) {
+		if (parsed && !byCanonicalId.has(parsed.canonicalId)) {
 			byCanonicalId.set(parsed.canonicalId, parsed);
 		}
 	}
 
 	return [...byCanonicalId.values()];
+}
+
+/**
+ * Object-form marketplace entry shape, as delivered via the enterprise
+ * `managed_settings` policy or `.github/copilot/settings.json` workspace
+ * file. `name` (when present) is used as the marketplace's `displayLabel`
+ * so that `enabledPlugins["plugin@name"]` keys match consistently.
+ *
+ * Both the nested form (`source: { source, repo|url }`) and the flat form
+ * (`source: 'github', repo: ...`) are accepted.
+ */
+export interface IExtraMarketplaceObjectEntry {
+	readonly name?: string;
+	readonly source?: string | { readonly source?: string; readonly repo?: string; readonly url?: string; readonly ref?: string };
+	readonly repo?: string;
+	readonly url?: string;
+	readonly ref?: string;
+}
+
+export function parseMarketplaceObjectEntry(entry: IExtraMarketplaceObjectEntry): IMarketplaceReference | undefined {
+	let sourceType: string | undefined;
+	let repo: string | undefined;
+	let url: string | undefined;
+	let ref: string | undefined;
+
+	if (entry.source && typeof entry.source === 'object') {
+		const nested = entry.source;
+		sourceType = nested.source;
+		repo = nested.repo;
+		url = nested.url;
+		ref = nested.ref;
+	} else {
+		sourceType = entry.source;
+		repo = entry.repo;
+		url = entry.url;
+		ref = entry.ref;
+	}
+
+	let parsed: IMarketplaceReference | undefined;
+	if (sourceType === 'github' && typeof repo === 'string') {
+		parsed = parseMarketplaceReference(appendMarketplaceRef(repo, ref));
+	} else if (sourceType === 'git' && typeof url === 'string') {
+		parsed = parseMarketplaceReference(appendMarketplaceRef(url, ref));
+	}
+
+	if (parsed && typeof entry.name === 'string' && entry.name.length > 0) {
+		parsed = { ...parsed, displayLabel: entry.name };
+	}
+	return parsed;
+}
+
+function appendMarketplaceRef(value: string, ref: string | undefined): string {
+	if (!ref) {
+		return value;
+	}
+	const fragmentIndex = value.indexOf('#');
+	const base = fragmentIndex === -1 ? value : value.slice(0, fragmentIndex);
+	return `${base}#${ref}`;
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/common/plugins/marketplaceReference.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/marketplaceReference.ts
@@ -26,33 +26,28 @@ export interface IMarketplaceReference {
 }
 
 /**
- * Reads {@link ChatConfiguration.PluginMarketplaces} broken into its three
- * configuration layers so callers can:
- * - apply default + user + policy when computing the effective set (read paths,
- *   trust checks);
- * - apply default + user when writing back (so we don't persist policy entries
- *   into user settings); and
- * - recognise which canonical IDs are policy-supplied (so they can be marked
- *   read-only in management UI).
+ * Reads the effective set of plugin marketplaces — the union of the user-facing
+ * {@link ChatConfiguration.PluginMarketplaces} (default + user) and the
+ * enterprise policy-only {@link ChatConfiguration.ExtraMarketplaces}. Callers
+ * that write back update `PluginMarketplaces` directly; the policy entries are
+ * read-only.
  *
  * Entries may be strings (`<owner>/<repo>` or git URIs) or objects (policy
  * payloads); both shapes flow through {@link parseMarketplaceReferences}.
  */
 export interface IConfiguredMarketplaces {
+	readonly userValues: readonly unknown[];
+	readonly extraValues: readonly unknown[];
 	readonly effectiveValues: readonly unknown[];
-	readonly editableValues: readonly unknown[];
-	readonly policyCanonicalIds: ReadonlySet<string>;
 }
 
 export function readConfiguredMarketplaces(configurationService: IConfigurationService): IConfiguredMarketplaces {
-	const inspected = configurationService.inspect<(string | object)[]>(ChatConfiguration.PluginMarketplaces);
-	const defaultValues = inspected.defaultValue ?? [];
-	const userValues = inspected.userValue ?? [];
-	const policyValues = inspected.policyValue ?? [];
+	const userValues = configurationService.getValue<(string | object)[]>(ChatConfiguration.PluginMarketplaces) ?? [];
+	const extraValues = configurationService.getValue<(string | object)[]>(ChatConfiguration.ExtraMarketplaces) ?? [];
 	return {
-		effectiveValues: [...defaultValues, ...userValues, ...policyValues],
-		editableValues: [...defaultValues, ...userValues],
-		policyCanonicalIds: new Set(parseMarketplaceReferences(policyValues).map(r => r.canonicalId)),
+		userValues,
+		extraValues,
+		effectiveValues: [...userValues, ...extraValues],
 	};
 }
 

--- a/src/vs/workbench/contrib/chat/common/plugins/marketplaceReference.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/marketplaceReference.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { URI } from '../../../../../base/common/uri.js';
+import { IExtraKnownMarketplaceEntry } from '../../../../../base/common/managedSettings.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { ChatConfiguration } from '../constants.js';
 
@@ -44,6 +45,37 @@ export interface IConfiguredMarketplaces {
 
 /** Shorthand-or-URI regex used to detect GitHub `owner/repo[#ref]` entries. */
 const _githubShorthandRe = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:#.+)?$/;
+
+/**
+ * Converts the {@link IExtraKnownMarketplaceEntry} array delivered by the
+ * `ChatExtraMarketplaces` policy into the `{ [name]: url-or-shorthand }` dict
+ * stored on the `chat.plugins.extraMarketplaces` setting.
+ *
+ * The dict shape is what the Settings Editor's ComplexObject renderer can
+ * display inline as key/value rows. {@link readConfiguredMarketplaces} reverses
+ * this conversion so {@link parseMarketplaceReferences} keeps producing
+ * `displayLabel = name` (required for `enabledPlugins["plugin@<name>"]` keys).
+ *
+ * Plain-string entries (allowed by the policy schema but unnamed) are stored
+ * with the value used as both key and value so they survive the round-trip
+ * intact.
+ */
+export function extraKnownMarketplacesToConfigDict(entries: readonly (string | IExtraKnownMarketplaceEntry)[] | undefined): Record<string, string> | undefined {
+	if (!entries?.length) {
+		return undefined;
+	}
+	const obj: Record<string, string> = {};
+	for (const entry of entries) {
+		if (typeof entry === 'string') {
+			obj[entry] = entry;
+		} else {
+			const s = entry.source;
+			const base = s.source === 'github' ? s.repo : s.url;
+			obj[entry.name] = s.ref ? `${base}#${s.ref}` : base;
+		}
+	}
+	return obj;
+}
 
 export function readConfiguredMarketplaces(configurationService: IConfigurationService): IConfiguredMarketplaces {
 	const userValues = configurationService.getValue<(string | object)[]>(ChatConfiguration.PluginMarketplaces) ?? [];

--- a/src/vs/workbench/contrib/chat/common/plugins/marketplaceReference.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/marketplaceReference.ts
@@ -33,7 +33,8 @@ export interface IMarketplaceReference {
  *   policy into {@link ChatConfiguration.ExtraMarketplaces}. Read-only.
  *
  * Entries may be strings (`<owner>/<repo>` or git URIs) or, in the policy case,
- * arbitrary JSON values — both shapes flow through {@link parseMarketplaceReferences}.
+ * {@link IExtraMarketplaceObjectEntry} objects — both shapes flow through
+ * {@link parseMarketplaceReferences}.
  */
 export interface IConfiguredMarketplaces {
 	readonly userValues: readonly unknown[];
@@ -41,9 +42,23 @@ export interface IConfiguredMarketplaces {
 	readonly effectiveValues: readonly unknown[];
 }
 
+/** Shorthand-or-URI regex used to detect GitHub `owner/repo[#ref]` entries. */
+const _githubShorthandRe = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:#.+)?$/;
+
 export function readConfiguredMarketplaces(configurationService: IConfigurationService): IConfiguredMarketplaces {
 	const userValues = configurationService.getValue<(string | object)[]>(ChatConfiguration.PluginMarketplaces) ?? [];
-	const extraValues = configurationService.getValue<(string | object)[]>(ChatConfiguration.ExtraMarketplaces) ?? [];
+
+	// `ChatExtraMarketplaces` is stored as `{ [name]: url-or-shorthand }` when delivered by
+	// policy. Convert each entry to the nested IExtraMarketplaceObjectEntry shape so that
+	// parseMarketplaceReferences can set displayLabel = name (critical for enabledPlugins keys).
+	const extraObj = configurationService.getValue<Record<string, string>>(ChatConfiguration.ExtraMarketplaces) ?? {};
+	const extraValues: IExtraMarketplaceObjectEntry[] = Object.entries(extraObj).map(([name, src]) => {
+		const isGithubShorthand = _githubShorthandRe.test(src);
+		return isGithubShorthand
+			? { name, source: { source: 'github' as const, repo: src } }
+			: { name, source: { source: 'git' as const, url: src } };
+	});
+
 	return {
 		userValues,
 		extraValues,

--- a/src/vs/workbench/contrib/chat/common/plugins/marketplaceReference.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/marketplaceReference.ts
@@ -26,14 +26,14 @@ export interface IMarketplaceReference {
 }
 
 /**
- * Reads the effective set of plugin marketplaces — the union of the user-facing
- * {@link ChatConfiguration.PluginMarketplaces} (default + user) and the
- * enterprise policy-only {@link ChatConfiguration.ExtraMarketplaces}. Callers
- * that write back update `PluginMarketplaces` directly; the policy entries are
- * read-only.
+ * The two configuration layers behind plugin marketplaces:
+ * - `userValues` — what's stored at {@link ChatConfiguration.PluginMarketplaces}
+ *   (default + user). Writable by the user.
+ * - `extraValues` — what's delivered via the `ChatExtraMarketplaces` enterprise
+ *   policy into {@link ChatConfiguration.ExtraMarketplaces}. Read-only.
  *
- * Entries may be strings (`<owner>/<repo>` or git URIs) or objects (policy
- * payloads); both shapes flow through {@link parseMarketplaceReferences}.
+ * Entries may be strings (`<owner>/<repo>` or git URIs) or, in the policy case,
+ * arbitrary JSON values — both shapes flow through {@link parseMarketplaceReferences}.
  */
 export interface IConfiguredMarketplaces {
 	readonly userValues: readonly unknown[];

--- a/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
@@ -411,10 +411,8 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 			return [];
 		}
 
-		// Read default + user + policy values together so enterprise policy
-		// entries (via the `ChatPluginMarketplaces` policy) are added alongside
-		// user-configured entries AND the built-in marketplace defaults.
-		// `getValue()` alone would surface only the policy value when set.
+		// Effective set is user-facing `chat.plugins.marketplaces` (default + user)
+		// unioned with the enterprise policy-only `chat.plugins.extraMarketplaces`.
 		const seen = new Set<string>();
 		const configuredRefs: unknown[] = [];
 		for (const entry of readConfiguredMarketplaces(this._configurationService).effectiveValues) {
@@ -619,11 +617,11 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 	}
 
 	isMarketplaceTrusted(ref: IMarketplaceReference): boolean {
-		// In strict mode (enterprise policy `ChatStrictMarketplaces` or
-		// user-set `chat.plugins.strictMarketplaces`), trust is derived from
-		// the configured marketplace list rather than from user-stored trust.
-		// Only marketplaces present in `chat.plugins.marketplaces` (merged
-		// user + policy) are considered trusted.
+		// In strict mode (enterprise policy `ChatStrictMarketplaces` or user-set
+		// `chat.plugins.strictMarketplaces`), trust is derived from the configured
+		// marketplace list rather than from user-stored trust. Only marketplaces
+		// present in the effective set (user `chat.plugins.marketplaces` unioned
+		// with policy-only `chat.plugins.extraMarketplaces`) are considered trusted.
 		if (this._configurationService.getValue<boolean>(ChatConfiguration.StrictMarketplaces)) {
 			const refs = parseMarketplaceReferences(readConfiguredMarketplaces(this._configurationService).effectiveValues);
 			return refs.some(r => r.canonicalId === ref.canonicalId);

--- a/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
@@ -28,7 +28,7 @@ import { IAgentPluginRepositoryService } from './agentPluginRepositoryService.js
 import { FileBackedInstalledPluginsStore, IStoredInstalledPlugin } from './fileBackedInstalledPluginsStore.js';
 import { IWorkspacePluginSettingsService } from './workspacePluginSettingsService.js';
 import { IWorkspaceTrustManagementService } from '../../../../../platform/workspace/common/workspaceTrust.js';
-import { type IMarketplaceReference, deduplicateMarketplaceReferences, MarketplaceReferenceKind, parseMarketplaceReference, parseMarketplaceReferences, readConfiguredMarketplaces } from './marketplaceReference.js';
+import { type IMarketplaceReference, deduplicateMarketplaceReferences, MarketplaceReferenceKind, parseMarketplaceObjectEntry, parseMarketplaceReference, parseMarketplaceReferences, readConfiguredMarketplaces } from './marketplaceReference.js';
 
 // Re-export marketplace reference types for downstream consumers.
 export { deduplicateMarketplaceReferences, extraKnownMarketplacesToConfigDict, MarketplaceReferenceKind, parseMarketplaceReference, parseMarketplaceReferences, readConfiguredMarketplaces } from './marketplaceReference.js';
@@ -430,7 +430,10 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 		}
 
 		for (const value of effectiveValues) {
-			if (typeof value !== 'string' || !parseMarketplaceReference(value)) {
+			const parsed = typeof value === 'string'
+				? parseMarketplaceReference(value)
+				: (value && typeof value === 'object' ? parseMarketplaceObjectEntry(value as Parameters<typeof parseMarketplaceObjectEntry>[0]) : undefined);
+			if (!parsed) {
 				this._logService.debug(`[PluginMarketplaceService] Ignoring invalid marketplace entry: ${String(value)}`);
 			}
 		}

--- a/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
@@ -28,11 +28,11 @@ import { IAgentPluginRepositoryService } from './agentPluginRepositoryService.js
 import { FileBackedInstalledPluginsStore, IStoredInstalledPlugin } from './fileBackedInstalledPluginsStore.js';
 import { IWorkspacePluginSettingsService } from './workspacePluginSettingsService.js';
 import { IWorkspaceTrustManagementService } from '../../../../../platform/workspace/common/workspaceTrust.js';
-import { type IMarketplaceReference, deduplicateMarketplaceReferences, MarketplaceReferenceKind, parseMarketplaceReference, parseMarketplaceReferences } from './marketplaceReference.js';
+import { type IMarketplaceReference, deduplicateMarketplaceReferences, MarketplaceReferenceKind, parseMarketplaceReference, parseMarketplaceReferences, readConfiguredMarketplaces } from './marketplaceReference.js';
 
 // Re-export marketplace reference types for downstream consumers.
-export { deduplicateMarketplaceReferences, MarketplaceReferenceKind, parseMarketplaceReference, parseMarketplaceReferences } from './marketplaceReference.js';
-export type { IMarketplaceReference } from './marketplaceReference.js';
+export { deduplicateMarketplaceReferences, MarketplaceReferenceKind, parseMarketplaceReference, parseMarketplaceReferences, readConfiguredMarketplaces } from './marketplaceReference.js';
+export type { IConfiguredMarketplaces, IMarketplaceReference } from './marketplaceReference.js';
 
 export const enum MarketplaceType {
 	Copilot = 'copilot',
@@ -411,7 +411,20 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 			return [];
 		}
 
-		const configuredRefs = this._configurationService.getValue<unknown[]>(ChatConfiguration.PluginMarketplaces) ?? [];
+		// Read default + user + policy values together so enterprise policy
+		// entries (via the `ChatPluginMarketplaces` policy) are added alongside
+		// user-configured entries AND the built-in marketplace defaults.
+		// `getValue()` alone would surface only the policy value when set.
+		const seen = new Set<string>();
+		const configuredRefs: unknown[] = [];
+		for (const entry of readConfiguredMarketplaces(this._configurationService).effectiveValues) {
+			const key = typeof entry === 'string' ? entry : JSON.stringify(entry);
+			if (seen.has(key)) {
+				continue;
+			}
+			seen.add(key);
+			configuredRefs.push(entry);
+		}
 		const configRefs = parseMarketplaceReferences(configuredRefs);
 
 		// Merge marketplace references from Claude workspace settings.
@@ -606,6 +619,15 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 	}
 
 	isMarketplaceTrusted(ref: IMarketplaceReference): boolean {
+		// In strict mode (enterprise policy `ChatStrictMarketplaces` or
+		// user-set `chat.plugins.strictMarketplaces`), trust is derived from
+		// the configured marketplace list rather than from user-stored trust.
+		// Only marketplaces present in `chat.plugins.marketplaces` (merged
+		// user + policy) are considered trusted.
+		if (this._configurationService.getValue<boolean>(ChatConfiguration.StrictMarketplaces)) {
+			const refs = parseMarketplaceReferences(readConfiguredMarketplaces(this._configurationService).effectiveValues);
+			return refs.some(r => r.canonicalId === ref.canonicalId);
+		}
 		return this._trustedMarketplacesStore.get().includes(ref.canonicalId);
 	}
 

--- a/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
@@ -411,19 +411,11 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 			return [];
 		}
 
-		// Effective set is user-facing `chat.plugins.marketplaces` (default + user)
+		// Effective set: user-facing `chat.plugins.marketplaces` (default + user)
 		// unioned with the enterprise policy-only `chat.plugins.extraMarketplaces`.
-		const seen = new Set<string>();
-		const configuredRefs: unknown[] = [];
-		for (const entry of readConfiguredMarketplaces(this._configurationService).effectiveValues) {
-			const key = typeof entry === 'string' ? entry : JSON.stringify(entry);
-			if (seen.has(key)) {
-				continue;
-			}
-			seen.add(key);
-			configuredRefs.push(entry);
-		}
-		const configRefs = parseMarketplaceReferences(configuredRefs);
+		// `parseMarketplaceReferences` dedupes by canonical id.
+		const { effectiveValues } = readConfiguredMarketplaces(this._configurationService);
+		const configRefs = parseMarketplaceReferences(effectiveValues);
 
 		// Merge marketplace references from Claude workspace settings.
 		// Workspace-defined refs take precedence (are primary) so that their
@@ -437,7 +429,7 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 			allRefs = configRefs;
 		}
 
-		for (const value of configuredRefs) {
+		for (const value of effectiveValues) {
 			if (typeof value !== 'string' || !parseMarketplaceReference(value)) {
 				this._logService.debug(`[PluginMarketplaceService] Ignoring invalid marketplace entry: ${String(value)}`);
 			}

--- a/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
@@ -31,7 +31,7 @@ import { IWorkspaceTrustManagementService } from '../../../../../platform/worksp
 import { type IMarketplaceReference, deduplicateMarketplaceReferences, MarketplaceReferenceKind, parseMarketplaceReference, parseMarketplaceReferences, readConfiguredMarketplaces } from './marketplaceReference.js';
 
 // Re-export marketplace reference types for downstream consumers.
-export { deduplicateMarketplaceReferences, MarketplaceReferenceKind, parseMarketplaceReference, parseMarketplaceReferences, readConfiguredMarketplaces } from './marketplaceReference.js';
+export { deduplicateMarketplaceReferences, extraKnownMarketplacesToConfigDict, MarketplaceReferenceKind, parseMarketplaceReference, parseMarketplaceReferences, readConfiguredMarketplaces } from './marketplaceReference.js';
 export type { IConfiguredMarketplaces, IMarketplaceReference } from './marketplaceReference.js';
 
 export const enum MarketplaceType {

--- a/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
@@ -609,13 +609,14 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 	}
 
 	isMarketplaceTrusted(ref: IMarketplaceReference): boolean {
-		// In strict mode (enterprise policy `ChatStrictMarketplaces` or user-set
-		// `chat.plugins.strictMarketplaces`), trust is derived from the configured
-		// marketplace list rather than from user-stored trust. Only marketplaces
-		// present in the effective set (user `chat.plugins.marketplaces` unioned
-		// with policy-only `chat.plugins.extraMarketplaces`) are considered trusted.
+		// In strict mode (`chat.plugins.strictMarketplaces`, typically enabled via the
+		// `ChatStrictMarketplaces` enterprise policy), trust is restricted to
+		// marketplaces in `chat.plugins.extraMarketplaces` — the policy-only slot.
+		// User-configured entries in `chat.plugins.marketplaces` do NOT grant trust
+		// under strict mode; that's the whole point of "strict" — the enterprise
+		// fully controls the allowed marketplaces.
 		if (this._configurationService.getValue<boolean>(ChatConfiguration.StrictMarketplaces)) {
-			const refs = parseMarketplaceReferences(readConfiguredMarketplaces(this._configurationService).effectiveValues);
+			const refs = parseMarketplaceReferences(readConfiguredMarketplaces(this._configurationService).extraValues);
 			return refs.some(r => r.canonicalId === ref.canonicalId);
 		}
 		return this._trustedMarketplacesStore.get().includes(ref.canonicalId);

--- a/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
@@ -366,7 +366,7 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 		this.onDidChangeMarketplaces = Event.any(
 			Event.filter(
 				_configurationService.onDidChangeConfiguration,
-				e => e.affectsConfiguration(ChatConfiguration.PluginsEnabled) || e.affectsConfiguration(ChatConfiguration.PluginMarketplaces),
+				e => e.affectsConfiguration(ChatConfiguration.PluginsEnabled) || e.affectsConfiguration(ChatConfiguration.PluginMarketplaces) || e.affectsConfiguration(ChatConfiguration.ExtraMarketplaces),
 			) as Event<unknown> as Event<void>,
 			Event.fromObservableLight(this._workspacePluginSettingsService.extraMarketplaces),
 			Event.map(this._workspaceTrustService.onDidChangeTrust, () => { }),

--- a/src/vs/workbench/contrib/chat/common/plugins/workspacePluginSettingsService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/workspacePluginSettingsService.ts
@@ -14,7 +14,7 @@ import { createDecorator } from '../../../../../platform/instantiation/common/in
 import { ILogService } from '../../../../../platform/log/common/log.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { CLAUDE_CONFIG_FOLDER } from '../promptSyntax/config/promptFileLocations.js';
-import { IMarketplaceReference, parseMarketplaceReference } from './marketplaceReference.js';
+import { IMarketplaceReference, parseMarketplaceObjectEntry } from './marketplaceReference.js';
 
 const SETTINGS_FILENAME = 'settings.json';
 const SETTINGS_LOCAL_FILENAME = 'settings.local.json';
@@ -50,72 +50,6 @@ export interface IWorkspacePluginSettingsService {
 }
 
 // --- Parsing helpers ---------------------------------------------------------
-
-interface IMarketplaceSourceJson {
-	readonly source?: string;
-	readonly repo?: string;
-	readonly url?: string;
-	readonly ref?: string;
-	readonly path?: string;
-}
-
-interface IExtraMarketplaceJson {
-	readonly source?: string | IMarketplaceSourceJson;
-	readonly repo?: string;
-	readonly url?: string;
-	readonly ref?: string;
-	readonly path?: string;
-}
-
-/**
- * Converts a single `extraKnownMarketplaces` entry into an
- * {@link IMarketplaceReference} by mapping the source format to
- * existing marketplace reference parsing.
- */
-function marketplaceEntryToReference(entry: IExtraMarketplaceJson): IMarketplaceReference | undefined {
-	// Two shapes supported:
-	// 1. { source: "github", repo: "owner/repo" }   →  GitHub shorthand
-	// 2. { source: { source: "github", repo: "owner/repo" } }  →  nested
-	// 3. { source: "git", url: "https://..." }       →  Git URI
-
-	let sourceType: string | undefined;
-	let repo: string | undefined;
-	let url: string | undefined;
-	let ref: string | undefined;
-
-	if (typeof entry.source === 'object' && entry.source !== null) {
-		const nested = entry.source;
-		sourceType = nested.source;
-		repo = nested.repo;
-		url = nested.url;
-		ref = nested.ref;
-	} else {
-		sourceType = entry.source as string | undefined;
-		repo = entry.repo;
-		url = entry.url;
-		ref = entry.ref;
-	}
-
-	if (sourceType === 'github' && typeof repo === 'string') {
-		return parseMarketplaceReference(appendMarketplaceRef(repo, ref));
-	}
-
-	if (sourceType === 'git' && typeof url === 'string') {
-		return parseMarketplaceReference(appendMarketplaceRef(url, ref));
-	}
-
-	return undefined;
-}
-
-function appendMarketplaceRef(value: string, ref: string | undefined): string {
-	if (!ref) {
-		return value;
-	}
-
-	const fragmentIndex = value.indexOf('#');
-	const baseValue = fragmentIndex === -1 ? value : value.slice(0, fragmentIndex);
-	return `${baseValue}#${ref}`;
-}
 
 /**
  * Parses `enabledPlugins` from a JSON object.
@@ -154,16 +88,13 @@ function parseExtraMarketplaces(json: unknown, logPrefix: string, logService: IL
 			continue;
 		}
 
-		const reference = marketplaceEntryToReference(value as IExtraMarketplaceJson);
+		const reference = parseMarketplaceObjectEntry({ ...value, name });
 		if (!reference) {
 			logService.debug(`${logPrefix} Could not parse marketplace reference for: ${name}`);
 			continue;
 		}
 
-		// Override displayLabel with the user-chosen marketplace name so that
-		// fetched plugins use this name in their `marketplace` field, which is
-		// what `enabledPlugins` keys reference (e.g. "plugin@claude-settings").
-		entries.push({ name, reference: { ...reference, displayLabel: name } });
+		entries.push({ name, reference });
 	}
 
 	return entries;

--- a/src/vs/workbench/contrib/chat/test/browser/plugins/pluginInstallService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/plugins/pluginInstallService.test.ts
@@ -284,6 +284,12 @@ suite('PluginInstallService', () => {
 				}
 				return undefined;
 			},
+			inspect: (key: string) => {
+				if (key === ChatConfiguration.PluginMarketplaces) {
+					return { userValue: state.configuredMarketplaces, defaultValue: undefined, policyValue: undefined };
+				}
+				return { userValue: undefined, defaultValue: undefined, policyValue: undefined };
+			},
 			updateValue: async (key: string, value: unknown) => {
 				if (key === ChatConfiguration.PluginMarketplaces) {
 					state.updatedMarketplaces = value as string[];

--- a/src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts
@@ -260,38 +260,6 @@ suite('PluginMarketplaceService', () => {
 		assert.strictEqual(refs[2].kind, MarketplaceReferenceKind.GitHubShorthand);
 	});
 
-	test('chat.plugins.extraMarketplaces schema: setting is registered as an object with single-element-array additionalProperties.type so Settings Editor renders it as ComplexObject', async () => {
-		// Guards the schema shape the Settings Editor relies on to render the
-		// policy-managed extra marketplaces inline (key/value rows) instead of
-		// just an "Edit in settings.json" link.
-		//
-		// Settings Editor logic (`getObjectSettingSchemaType` /
-		// `getObjectRenderableSchemaType` in `settingsTreeModels.ts`):
-		//   - requires `type === 'object'`
-		//   - requires `additionalProperties` to be an object (not `true`/undefined)
-		//   - if `additionalProperties.type` is a single-element array of a simple
-		//     type, falls into the "complex" branch → ComplexObject renderer.
-		//
-		// Lazy-imported because the contribution module is heavy; we only want
-		// to register it for this single assertion.
-		const { Extensions: ConfigurationExtensions } = await import('../../../../../../platform/configuration/common/configurationRegistry.js');
-		const { Registry } = await import('../../../../../../platform/registry/common/platform.js');
-		await import('../../../browser/chat.shared.contribution.js');
-
-		const registry = Registry.as<import('../../../../../../platform/configuration/common/configurationRegistry.js').IConfigurationRegistry>(ConfigurationExtensions.Configuration);
-		const allProps = { ...registry.getConfigurationProperties(), ...registry.getExcludedConfigurationProperties() };
-		const schema = allProps[ChatConfiguration.ExtraMarketplaces];
-		assert.ok(schema, `expected ${ChatConfiguration.ExtraMarketplaces} to be registered`);
-		assert.strictEqual(schema.type, 'object', 'type must be "object" so the Settings Editor renders inline rows');
-		assert.ok(schema.additionalProperties && typeof schema.additionalProperties === 'object',
-			'additionalProperties must be a schema object so getObjectSettingSchemaType does not early-return');
-		const apType = (schema.additionalProperties as { type?: unknown }).type;
-		assert.ok(Array.isArray(apType),
-			'additionalProperties.type must be an array form (e.g. ["string"]) to land in the ComplexObject branch');
-		assert.ok((apType as unknown[]).every(t => t === 'string' || t === 'boolean' || t === 'integer' || t === 'number'),
-			'all entries in additionalProperties.type must be simple types so getObjectRenderableSchemaType returns "complex"');
-	});
-
 	test('parses Azure DevOps HTTPS clone URLs without .git suffix', () => {
 		const parsed = parseMarketplaceReference('https://dev.azure.com/org/project/_git/repo');
 		assert.ok(parsed);

--- a/src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts
@@ -278,6 +278,34 @@ suite('PluginMarketplaceService', () => {
 		assert.strictEqual(parsed[0].canonicalId, 'git:dev.azure.com/org/project/_git/repo.git');
 	});
 
+	test('github.com URI form and GitHub shorthand form share the same canonicalId (policy trust comparisons must match)', () => {
+		// Regression: under strictMarketplaces, isMarketplaceTrusted compares
+		// canonicalId. A plugin discovered from `https://github.com/microsoft/vscode-team-kit.git`
+		// was being blocked even though `microsoft/vscode-team-kit` was in the
+		// trusted list, because the URI parser produced a `git:` canonicalId
+		// while the shorthand parser produced a `github:` one.
+		const shorthand = parseMarketplaceReference('microsoft/vscode-team-kit');
+		const httpsWithGit = parseMarketplaceReference('https://github.com/microsoft/vscode-team-kit.git');
+		const httpsWithoutGit = parseMarketplaceReference('https://github.com/microsoft/vscode-team-kit');
+		const scp = parseMarketplaceReference('git@github.com:microsoft/vscode-team-kit.git');
+		assert.ok(shorthand);
+		assert.ok(httpsWithGit);
+		assert.ok(httpsWithoutGit);
+		assert.ok(scp);
+		assert.strictEqual(httpsWithGit!.canonicalId, shorthand!.canonicalId);
+		assert.strictEqual(httpsWithoutGit!.canonicalId, shorthand!.canonicalId);
+		assert.strictEqual(scp!.canonicalId, shorthand!.canonicalId);
+
+		// All four forms should collapse to a single entry when deduplicated.
+		const deduped = parseMarketplaceReferences([
+			'microsoft/vscode-team-kit',
+			'https://github.com/microsoft/vscode-team-kit.git',
+			'https://github.com/microsoft/vscode-team-kit',
+			'git@github.com:microsoft/vscode-team-kit.git',
+		]);
+		assert.strictEqual(deduped.length, 1);
+	});
+
 	test('parses HTTPS URI with trailing slash after .git', () => {
 		const parsed = parseMarketplaceReference('https://example.com/org/repo.git/');
 		assert.ok(parsed);
@@ -289,17 +317,17 @@ suite('PluginMarketplaceService', () => {
 		assert.deepStrictEqual(parsed.cacheSegments, ['example.com', 'org', 'repo']);
 	});
 
-	test('deduplicates equivalent Git URI forms but keeps shorthand distinct', () => {
+	test('deduplicates github.com URI, SSH, and shorthand to the same canonical id', () => {
+		// All three forms refer to the same marketplace, so policy trust
+		// comparisons (which match by canonicalId) must collapse them.
 		const parsed = parseMarketplaceReferences([
 			'microsoft/vscode',
 			'https://github.com/microsoft/vscode.git',
 			'git@github.com:microsoft/vscode.git',
 		]);
 
-		assert.deepStrictEqual(parsed.map(r => r.canonicalId), [
-			'github:microsoft/vscode',
-			'git:github.com/microsoft/vscode.git',
-		]);
+		assert.strictEqual(parsed.length, 1);
+		assert.strictEqual(parsed[0].canonicalId, 'github:microsoft/vscode');
 	});
 
 	test('parseMarketplaceReferences ignores invalid entries (null, numbers, malformed objects)', () => {
@@ -327,10 +355,11 @@ suite('PluginMarketplaceService', () => {
 			'https://github.com/microsoft/vscode.git#marketplace',
 		]);
 
+		// `https://github.com/...#marketplace` collapses with the shorthand
+		// (same canonical id), so we expect 2 distinct refs not 3.
 		assert.deepStrictEqual(parsed.map(r => r.canonicalId), [
 			'github:microsoft/vscode#main',
 			'github:microsoft/vscode#marketplace',
-			'git:github.com/microsoft/vscode.git#marketplace',
 		]);
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts
@@ -202,10 +202,22 @@ suite('PluginMarketplaceService', () => {
 		]);
 	});
 
-	test('parseMarketplaceReferences ignores non-string entries', () => {
+	test('parseMarketplaceReferences ignores invalid entries (null, numbers, malformed objects)', () => {
 		const parsed = parseMarketplaceReferences([null, 42, {}, 'microsoft/vscode']);
 		assert.strictEqual(parsed.length, 1);
 		assert.strictEqual(parsed[0].canonicalId, 'github:microsoft/vscode');
+	});
+
+	test('parseMarketplaceReferences accepts policy-shape objects and uses name as displayLabel', () => {
+		const parsed = parseMarketplaceReferences([
+			{ name: 'vscode-team-kit', source: { source: 'github', repo: 'microsoft/vscode-team-kit' } },
+			{ name: 'acme-public', source: { source: 'git', url: 'https://copilot-plugins.acme.io', ref: 'main' } },
+		]);
+		assert.strictEqual(parsed.length, 2);
+		assert.strictEqual(parsed[0].displayLabel, 'vscode-team-kit');
+		assert.strictEqual(parsed[0].canonicalId, 'github:microsoft/vscode-team-kit');
+		assert.strictEqual(parsed[1].displayLabel, 'acme-public');
+		assert.strictEqual(parsed[1].ref, 'main');
 	});
 
 	test('treats different marketplace refs as distinct references', () => {

--- a/src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts
@@ -22,7 +22,7 @@ import { IWorkspaceTrustManagementService } from '../../../../../../platform/wor
 import { IEnvironmentService } from '../../../../../../platform/environment/common/environment.js';
 import { ChatConfiguration } from '../../../common/constants.js';
 import { IAgentPluginRepositoryService } from '../../../common/plugins/agentPluginRepositoryService.js';
-import { IMarketplacePlugin, IMarketplaceReference, IPluginSourceDescriptor, MarketplaceReferenceKind, MarketplaceType, PluginMarketplaceService, PluginSourceKind, getPluginSourceLabel, parseMarketplaceReference, parseMarketplaceReferences, parsePluginSource } from '../../../common/plugins/pluginMarketplaceService.js';
+import { IMarketplacePlugin, IMarketplaceReference, IPluginSourceDescriptor, MarketplaceReferenceKind, MarketplaceType, PluginMarketplaceService, PluginSourceKind, getPluginSourceLabel, parseMarketplaceReference, parseMarketplaceReferences, parsePluginSource, readConfiguredMarketplaces } from '../../../common/plugins/pluginMarketplaceService.js';
 import { IWorkspacePluginSettingsService } from '../../../common/plugins/workspacePluginSettingsService.js';
 
 suite('PluginMarketplaceService', () => {
@@ -164,7 +164,7 @@ suite('PluginMarketplaceService', () => {
 		const parsed = parseMarketplaceReference('https://plugins.internal.example.com');
 		assert.ok(parsed);
 		assert.strictEqual(parsed?.kind, MarketplaceReferenceKind.GitUri);
-		assert.strictEqual(parsed?.cloneUrl, 'https://plugins.internal.example.com');
+		assert.strictEqual(parsed?.cloneUrl, 'https://plugins.internal.example.com/');
 		assert.strictEqual(parsed?.canonicalId, 'git:plugins.internal.example.com/');
 		assert.deepStrictEqual(parsed?.cacheSegments, ['plugins.internal.example.com']);
 		assert.strictEqual(parsed?.githubRepo, undefined);
@@ -172,6 +172,24 @@ suite('PluginMarketplaceService', () => {
 		// Trailing slash collapses to the host-only form.
 		const withSlash = parseMarketplaceReference('https://plugins.internal.example.com/');
 		assert.strictEqual(withSlash?.canonicalId, 'git:plugins.internal.example.com/');
+	});
+
+	test('readConfiguredMarketplaces converts policy dict to named marketplace entries', () => {
+		const configService = new TestConfigurationService({
+			[ChatConfiguration.ExtraMarketplaces]: {
+				'acme-internal': 'https://plugins.internal.acme.com',
+				'acme-public': 'https://copilot-plugins.acme.io',
+				'vscode-team-kit': 'microsoft/vscode-team-kit',
+			},
+		});
+		const { extraValues, effectiveValues } = readConfiguredMarketplaces(configService as unknown as IConfigurationService);
+		const refs = parseMarketplaceReferences(extraValues);
+		assert.strictEqual(refs.length, 3);
+		assert.deepStrictEqual(refs.map(r => r.displayLabel), ['acme-internal', 'acme-public', 'vscode-team-kit']);
+		assert.strictEqual(refs[0].kind, MarketplaceReferenceKind.GitUri);
+		assert.strictEqual(refs[2].kind, MarketplaceReferenceKind.GitHubShorthand);
+		// Effective values union user + extra
+		assert.strictEqual(effectiveValues.length, extraValues.length);
 	});
 
 	test('parses Azure DevOps HTTPS clone URLs without .git suffix', () => {

--- a/src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts
@@ -160,6 +160,20 @@ suite('PluginMarketplaceService', () => {
 		assert.strictEqual(parseMarketplaceReference('git@example.com:org/repo'), undefined);
 	});
 
+	test('accepts host-only HTTPS marketplace endpoints (per ADR-002 git.url is any string)', () => {
+		const parsed = parseMarketplaceReference('https://plugins.internal.example.com');
+		assert.ok(parsed);
+		assert.strictEqual(parsed?.kind, MarketplaceReferenceKind.GitUri);
+		assert.strictEqual(parsed?.cloneUrl, 'https://plugins.internal.example.com');
+		assert.strictEqual(parsed?.canonicalId, 'git:plugins.internal.example.com/');
+		assert.deepStrictEqual(parsed?.cacheSegments, ['plugins.internal.example.com']);
+		assert.strictEqual(parsed?.githubRepo, undefined);
+
+		// Trailing slash collapses to the host-only form.
+		const withSlash = parseMarketplaceReference('https://plugins.internal.example.com/');
+		assert.strictEqual(withSlash?.canonicalId, 'git:plugins.internal.example.com/');
+	});
+
 	test('parses Azure DevOps HTTPS clone URLs without .git suffix', () => {
 		const parsed = parseMarketplaceReference('https://dev.azure.com/org/project/_git/repo');
 		assert.ok(parsed);

--- a/src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts
@@ -22,7 +22,7 @@ import { IWorkspaceTrustManagementService } from '../../../../../../platform/wor
 import { IEnvironmentService } from '../../../../../../platform/environment/common/environment.js';
 import { ChatConfiguration } from '../../../common/constants.js';
 import { IAgentPluginRepositoryService } from '../../../common/plugins/agentPluginRepositoryService.js';
-import { IMarketplacePlugin, IMarketplaceReference, IPluginSourceDescriptor, MarketplaceReferenceKind, MarketplaceType, PluginMarketplaceService, PluginSourceKind, getPluginSourceLabel, parseMarketplaceReference, parseMarketplaceReferences, parsePluginSource, readConfiguredMarketplaces } from '../../../common/plugins/pluginMarketplaceService.js';
+import { IMarketplacePlugin, IMarketplaceReference, IPluginSourceDescriptor, MarketplaceReferenceKind, MarketplaceType, PluginMarketplaceService, PluginSourceKind, extraKnownMarketplacesToConfigDict, getPluginSourceLabel, parseMarketplaceReference, parseMarketplaceReferences, parsePluginSource, readConfiguredMarketplaces } from '../../../common/plugins/pluginMarketplaceService.js';
 import { IWorkspacePluginSettingsService } from '../../../common/plugins/workspacePluginSettingsService.js';
 
 suite('PluginMarketplaceService', () => {
@@ -190,6 +190,106 @@ suite('PluginMarketplaceService', () => {
 		assert.strictEqual(refs[2].kind, MarketplaceReferenceKind.GitHubShorthand);
 		// Effective values union user + extra
 		assert.strictEqual(effectiveValues.length, extraValues.length);
+	});
+
+	test('extraKnownMarketplacesToConfigDict: returns undefined for empty/missing input', () => {
+		assert.strictEqual(extraKnownMarketplacesToConfigDict(undefined), undefined);
+		assert.strictEqual(extraKnownMarketplacesToConfigDict([]), undefined);
+	});
+
+	test('extraKnownMarketplacesToConfigDict: github source becomes owner/repo shorthand', () => {
+		const dict = extraKnownMarketplacesToConfigDict([
+			{ name: 'vscode-team-kit', source: { source: 'github', repo: 'microsoft/vscode-team-kit' } },
+		]);
+		assert.deepStrictEqual(dict, { 'vscode-team-kit': 'microsoft/vscode-team-kit' });
+	});
+
+	test('extraKnownMarketplacesToConfigDict: github source with ref appends #ref', () => {
+		const dict = extraKnownMarketplacesToConfigDict([
+			{ name: 'team-kit-beta', source: { source: 'github', repo: 'microsoft/vscode-team-kit', ref: 'beta' } },
+		]);
+		assert.deepStrictEqual(dict, { 'team-kit-beta': 'microsoft/vscode-team-kit#beta' });
+	});
+
+	test('extraKnownMarketplacesToConfigDict: git source becomes raw URL (with optional #ref)', () => {
+		const dict = extraKnownMarketplacesToConfigDict([
+			{ name: 'acme-internal', source: { source: 'git', url: 'https://plugins.internal.acme.com' } },
+			{ name: 'acme-tagged', source: { source: 'git', url: 'https://git.acme.com/plugins.git', ref: 'v1' } },
+		]);
+		assert.deepStrictEqual(dict, {
+			'acme-internal': 'https://plugins.internal.acme.com',
+			'acme-tagged': 'https://git.acme.com/plugins.git#v1',
+		});
+	});
+
+	test('extraKnownMarketplacesToConfigDict: end-to-end policy → config dict → readConfiguredMarketplaces → parseMarketplaceReferences', () => {
+		// Simulates the full ChatExtraMarketplaces policy delivery pipeline:
+		//  1. managed_settings response is adapted into IExtraKnownMarketplaceEntry[]
+		//  2. extraKnownMarketplacesToConfigDict converts to the dict shape the
+		//     `chat.plugins.extraMarketplaces` setting stores
+		//  3. The policy framework serializes/deserializes that as JSON
+		//  4. readConfiguredMarketplaces reverses it back to nested entry shape
+		//  5. parseMarketplaceReferences resolves marketplace references that
+		//     preserve `displayLabel = name` (required for `plugin@<name>` keys)
+		const policyEntries = [
+			{ name: 'acme-internal', source: { source: 'git' as const, url: 'https://plugins.internal.acme.com' } },
+			{ name: 'acme-public', source: { source: 'git' as const, url: 'https://copilot-plugins.acme.io' } },
+			{ name: 'vscode-team-kit', source: { source: 'github' as const, repo: 'microsoft/vscode-team-kit' } },
+		];
+
+		const dict = extraKnownMarketplacesToConfigDict(policyEntries);
+		assert.ok(dict);
+
+		// JSON round-trip mirrors what AccountPolicyService / PolicyConfiguration do.
+		const roundTripped = JSON.parse(JSON.stringify(dict));
+
+		const configService = new TestConfigurationService({
+			[ChatConfiguration.ExtraMarketplaces]: roundTripped,
+		});
+		const { extraValues } = readConfiguredMarketplaces(configService as unknown as IConfigurationService);
+		const refs = parseMarketplaceReferences(extraValues);
+
+		assert.strictEqual(refs.length, 3, 'all three policy entries are surfaced as marketplace references');
+		assert.deepStrictEqual(
+			refs.map(r => r.displayLabel),
+			['acme-internal', 'acme-public', 'vscode-team-kit'],
+			'displayLabel must equal the policy `name` so enabledPlugins["plugin@<name>"] keys resolve',
+		);
+		assert.strictEqual(refs[0].kind, MarketplaceReferenceKind.GitUri);
+		assert.strictEqual(refs[1].kind, MarketplaceReferenceKind.GitUri);
+		assert.strictEqual(refs[2].kind, MarketplaceReferenceKind.GitHubShorthand);
+	});
+
+	test('chat.plugins.extraMarketplaces schema: setting is registered as an object with single-element-array additionalProperties.type so Settings Editor renders it as ComplexObject', async () => {
+		// Guards the schema shape the Settings Editor relies on to render the
+		// policy-managed extra marketplaces inline (key/value rows) instead of
+		// just an "Edit in settings.json" link.
+		//
+		// Settings Editor logic (`getObjectSettingSchemaType` /
+		// `getObjectRenderableSchemaType` in `settingsTreeModels.ts`):
+		//   - requires `type === 'object'`
+		//   - requires `additionalProperties` to be an object (not `true`/undefined)
+		//   - if `additionalProperties.type` is a single-element array of a simple
+		//     type, falls into the "complex" branch → ComplexObject renderer.
+		//
+		// Lazy-imported because the contribution module is heavy; we only want
+		// to register it for this single assertion.
+		const { Extensions: ConfigurationExtensions } = await import('../../../../../../platform/configuration/common/configurationRegistry.js');
+		const { Registry } = await import('../../../../../../platform/registry/common/platform.js');
+		await import('../../../browser/chat.shared.contribution.js');
+
+		const registry = Registry.as<import('../../../../../../platform/configuration/common/configurationRegistry.js').IConfigurationRegistry>(ConfigurationExtensions.Configuration);
+		const allProps = { ...registry.getConfigurationProperties(), ...registry.getExcludedConfigurationProperties() };
+		const schema = allProps[ChatConfiguration.ExtraMarketplaces];
+		assert.ok(schema, `expected ${ChatConfiguration.ExtraMarketplaces} to be registered`);
+		assert.strictEqual(schema.type, 'object', 'type must be "object" so the Settings Editor renders inline rows');
+		assert.ok(schema.additionalProperties && typeof schema.additionalProperties === 'object',
+			'additionalProperties must be a schema object so getObjectSettingSchemaType does not early-return');
+		const apType = (schema.additionalProperties as { type?: unknown }).type;
+		assert.ok(Array.isArray(apType),
+			'additionalProperties.type must be an array form (e.g. ["string"]) to land in the ComplexObject branch');
+		assert.ok((apType as unknown[]).every(t => t === 'string' || t === 'boolean' || t === 'integer' || t === 'number'),
+			'all entries in additionalProperties.type must be simple types so getObjectRenderableSchemaType returns "complex"');
 	});
 
 	test('parses Azure DevOps HTTPS clone URLs without .git suffix', () => {

--- a/src/vs/workbench/services/accounts/browser/defaultAccount.ts
+++ b/src/vs/workbench/services/accounts/browser/defaultAccount.ts
@@ -103,8 +103,8 @@ export interface IManagedSettingsResponse {
 export function adaptManagedSettings(response: IManagedSettingsResponse, onWarn?: (msg: string) => void): Partial<IPolicyData> {
 	let extraKnownMarketplaces: readonly string[] | undefined;
 	if (isObject(response.extraKnownMarketplaces)) {
-		const seen = new Set<string>();
-		const flattened: string[] = [];
+		// Set preserves insertion order and dedups for free.
+		const flattened = new Set<string>();
 		for (const [id, entry] of Object.entries(response.extraKnownMarketplaces)) {
 			if (!isObject(entry) || !isObject(entry.source)) {
 				onWarn?.(`[DefaultAccount] Skipping malformed extraKnownMarketplaces entry "${id}": expected { source: { source, repo|url } }`);
@@ -112,21 +112,15 @@ export function adaptManagedSettings(response: IManagedSettingsResponse, onWarn?
 			}
 			const src = entry.source as { source?: string; repo?: string; url?: string; ref?: string };
 			const suffix = src.ref ? `#${src.ref}` : '';
-			let ref: string | undefined;
 			if (src.source === 'github' && isString(src.repo)) {
-				ref = `${src.repo}${suffix}`;
+				flattened.add(`${src.repo}${suffix}`);
 			} else if (src.source === 'git' && isString(src.url)) {
-				ref = `${src.url}${suffix}`;
+				flattened.add(`${src.url}${suffix}`);
 			} else {
 				onWarn?.(`[DefaultAccount] Skipping extraKnownMarketplaces entry "${id}": unknown source type "${src.source}"`);
-				continue;
-			}
-			if (!seen.has(ref)) {
-				seen.add(ref);
-				flattened.push(ref);
 			}
 		}
-		extraKnownMarketplaces = flattened;
+		extraKnownMarketplaces = [...flattened];
 	}
 
 	return {
@@ -667,11 +661,7 @@ class DefaultAccountProvider extends Disposable implements IDefaultAccountProvid
 				}
 			}
 			if (managedSettingsResult?.data) {
-				const managedData = managedSettingsResult.data;
-				policyData = policyData ?? {};
-				policyData.enabledPlugins = managedData.enabledPlugins;
-				policyData.extraKnownMarketplaces = managedData.extraKnownMarketplaces;
-				policyData.strictKnownMarketplaces = managedData.strictKnownMarketplaces;
+				policyData = { ...(policyData ?? {}), ...managedSettingsResult.data };
 			}
 
 			const defaultAccount: IDefaultAccount = {

--- a/src/vs/workbench/services/accounts/browser/defaultAccount.ts
+++ b/src/vs/workbench/services/accounts/browser/defaultAccount.ts
@@ -13,7 +13,7 @@ import { Disposable } from '../../../../base/common/lifecycle.js';
 import { equals } from '../../../../base/common/objects.js';
 import { isWeb } from '../../../../base/common/platform.js';
 import { IDefaultChatAgent } from '../../../../base/common/product.js';
-import { isObject, isString, isUndefined, Mutable } from '../../../../base/common/types.js';
+import { isString, isUndefined, Mutable } from '../../../../base/common/types.js';
 import { IRequestContext } from '../../../../base/parts/request/common/request.js';
 import { localize2 } from '../../../../nls.js';
 import { Action2, registerAction2 } from '../../../../platform/actions/common/actions.js';
@@ -32,6 +32,7 @@ import { AuthenticationSession, AuthenticationSessionAccount, IAuthenticationExt
 import { IWorkbenchEnvironmentService } from '../../environment/common/environmentService.js';
 import { IExtensionService } from '../../extensions/common/extensions.js';
 import { IHostService } from '../../host/browser/host.js';
+import { adaptManagedSettings, IManagedSettingsResponse } from './managedSettings.js';
 
 interface IDefaultAccountConfig {
 	readonly preferredExtensions: string[];
@@ -69,65 +70,6 @@ const MANAGED_SETTINGS_REQUEST_TIMEOUT_MS = 5000;
 
 interface ITokenEntitlementsResponse {
 	token: string;
-}
-
-/**
- * Response shape from `/copilot_internal/managed_settings`. The endpoint returns
- * `.github/copilot/settings.json` content from the enterprise's source org.
- * An empty response (`{}`) is success and means "no policy file present".
- *
- * Exported for unit-testing the {@link adaptManagedSettings} shape transformation.
- */
-export interface IManagedSettingsResponse {
-	readonly enabledPlugins?: Record<string, boolean>;
-	readonly extraKnownMarketplaces?: Record<string, {
-		readonly source:
-		| { readonly source: 'github'; readonly repo: string; readonly ref?: string }
-		| { readonly source: 'git'; readonly url: string; readonly ref?: string };
-	}>;
-	readonly strictKnownMarketplaces?: boolean;
-	/** Any unknown keys in the response are silently ignored for forward compatibility. */
-	readonly [key: string]: unknown;
-}
-
-/**
- * Adapt the `managed_settings` API response into the slice of {@link IPolicyData}
- * that the policy framework consumes. `extraKnownMarketplaces` is flattened from
- * the API's `Record<id, { source }>` shape to the existing
- * `chat.plugins.marketplaces` string-array shape (`<owner>/<repo>[#<ref>]` for
- * GitHub sources, `<url>[#<ref>]` for Git sources), deduplicated.
- *
- * Exported for unit-testing the shape transformation independently of network
- * I/O. Not part of the public service surface.
- */
-export function adaptManagedSettings(response: IManagedSettingsResponse, onWarn?: (msg: string) => void): Partial<IPolicyData> {
-	let extraKnownMarketplaces: readonly string[] | undefined;
-	if (isObject(response.extraKnownMarketplaces)) {
-		// Set preserves insertion order and dedups for free.
-		const flattened = new Set<string>();
-		for (const [id, entry] of Object.entries(response.extraKnownMarketplaces)) {
-			if (!isObject(entry) || !isObject(entry.source)) {
-				onWarn?.(`[DefaultAccount] Skipping malformed extraKnownMarketplaces entry "${id}": expected { source: { source, repo|url } }`);
-				continue;
-			}
-			const src = entry.source as { source?: string; repo?: string; url?: string; ref?: string };
-			const suffix = src.ref ? `#${src.ref}` : '';
-			if (src.source === 'github' && isString(src.repo)) {
-				flattened.add(`${src.repo}${suffix}`);
-			} else if (src.source === 'git' && isString(src.url)) {
-				flattened.add(`${src.url}${suffix}`);
-			} else {
-				onWarn?.(`[DefaultAccount] Skipping extraKnownMarketplaces entry "${id}": unknown source type "${src.source}"`);
-			}
-		}
-		extraKnownMarketplaces = [...flattened];
-	}
-
-	return {
-		enabledPlugins: isObject(response.enabledPlugins) ? response.enabledPlugins as Record<string, boolean> : undefined,
-		extraKnownMarketplaces,
-		strictKnownMarketplaces: typeof response.strictKnownMarketplaces === 'boolean' ? response.strictKnownMarketplaces : undefined,
-	};
 }
 
 interface IMcpRegistryProvider {

--- a/src/vs/workbench/services/accounts/browser/defaultAccount.ts
+++ b/src/vs/workbench/services/accounts/browser/defaultAccount.ts
@@ -888,6 +888,10 @@ class DefaultAccountProvider extends Disposable implements IDefaultAccountProvid
 	private async getManagedSettings(sessions: AuthenticationSession[], accountPolicyData: IAccountPolicyData | undefined, options?: { forceRefresh?: boolean }): Promise<{ data: Partial<IPolicyData> | undefined; fetchedAt: number }> {
 		if (!options?.forceRefresh && accountPolicyData?.managedSettingsFetchedAt && !this.isDataStale(accountPolicyData.managedSettingsFetchedAt)) {
 			this.logService.debug('[DefaultAccount] Using last fetched managed settings data');
+			// Seed status so Policy Diagnostics reflects "applied" rather than
+			// "not yet fetched" after a process restart that warm-starts from
+			// the cached policy payload.
+			this._managedSettingsFetchStatus = 'ok';
 			return {
 				data: {
 					enabledPlugins: accountPolicyData.policyData.enabledPlugins,

--- a/src/vs/workbench/services/accounts/browser/defaultAccount.ts
+++ b/src/vs/workbench/services/accounts/browser/defaultAccount.ts
@@ -865,6 +865,7 @@ class DefaultAccountProvider extends Disposable implements IDefaultAccountProvid
 
 		try {
 			const data = await asJson<IManagedSettingsResponse>(response);
+			this.logService.trace('[DefaultAccount] Managed settings raw response:', JSON.stringify(data ?? null));
 			const adapted = adaptManagedSettings(data ?? {}, msg => this.logService.warn(msg));
 			// An empty response (`{}`) is a successful "no policy file present" signal.
 			const pluginCount = adapted.enabledPlugins ? Object.keys(adapted.enabledPlugins).length : 0;

--- a/src/vs/workbench/services/accounts/browser/defaultAccount.ts
+++ b/src/vs/workbench/services/accounts/browser/defaultAccount.ts
@@ -13,18 +13,18 @@ import { Disposable } from '../../../../base/common/lifecycle.js';
 import { equals } from '../../../../base/common/objects.js';
 import { isWeb } from '../../../../base/common/platform.js';
 import { IDefaultChatAgent } from '../../../../base/common/product.js';
-import { isString, isUndefined, Mutable } from '../../../../base/common/types.js';
+import { isObject, isString, isUndefined, Mutable } from '../../../../base/common/types.js';
 import { IRequestContext } from '../../../../base/parts/request/common/request.js';
 import { localize2 } from '../../../../nls.js';
 import { Action2, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IContextKey, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
-import { IDefaultAccountProvider, IDefaultAccountService } from '../../../../platform/defaultAccount/common/defaultAccount.js';
+import { IDefaultAccountProvider, IDefaultAccountService, ManagedSettingsFetchStatus } from '../../../../platform/defaultAccount/common/defaultAccount.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
-import { asJson, IRequestService, isClientError, isSuccess } from '../../../../platform/request/common/request.js';
+import { asJson, IRequestService, isClientError, isSuccess, readHeader, retryAfterFromHeaders } from '../../../../platform/request/common/request.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../common/contributions.js';
@@ -51,6 +51,7 @@ interface IDefaultAccountConfig {
 	readonly tokenEntitlementUrl: string;
 	readonly entitlementUrl: string;
 	readonly mcpRegistryDataUrl: string;
+	readonly managedSettingsUrl: string;
 }
 
 export const DEFAULT_ACCOUNT_SIGN_IN_COMMAND = 'workbench.actions.accounts.signIn';
@@ -64,9 +65,75 @@ const enum DefaultAccountStatus {
 const CONTEXT_DEFAULT_ACCOUNT_STATE = new RawContextKey<string>('defaultAccountStatus', DefaultAccountStatus.Uninitialized);
 const CACHED_POLICY_DATA_KEY = 'defaultAccount.cachedPolicyData';
 const ACCOUNT_DATA_POLL_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+const MANAGED_SETTINGS_REQUEST_TIMEOUT_MS = 5000;
 
 interface ITokenEntitlementsResponse {
 	token: string;
+}
+
+/**
+ * Response shape from `/copilot_internal/managed_settings`. The endpoint returns
+ * `.github/copilot/settings.json` content from the enterprise's source org.
+ * An empty response (`{}`) is success and means "no policy file present".
+ *
+ * Exported for unit-testing the {@link adaptManagedSettings} shape transformation.
+ */
+export interface IManagedSettingsResponse {
+	readonly enabledPlugins?: Record<string, boolean>;
+	readonly extraKnownMarketplaces?: Record<string, {
+		readonly source:
+		| { readonly source: 'github'; readonly repo: string; readonly ref?: string }
+		| { readonly source: 'git'; readonly url: string; readonly ref?: string };
+	}>;
+	readonly strictKnownMarketplaces?: boolean;
+	/** Any unknown keys in the response are silently ignored for forward compatibility. */
+	readonly [key: string]: unknown;
+}
+
+/**
+ * Adapt the `managed_settings` API response into the slice of {@link IPolicyData}
+ * that the policy framework consumes. `extraKnownMarketplaces` is flattened from
+ * the API's `Record<id, { source }>` shape to the existing
+ * `chat.plugins.marketplaces` string-array shape (`<owner>/<repo>[#<ref>]` for
+ * GitHub sources, `<url>[#<ref>]` for Git sources), deduplicated.
+ *
+ * Exported for unit-testing the shape transformation independently of network
+ * I/O. Not part of the public service surface.
+ */
+export function adaptManagedSettings(response: IManagedSettingsResponse, onWarn?: (msg: string) => void): Partial<IPolicyData> {
+	let extraKnownMarketplaces: readonly string[] | undefined;
+	if (isObject(response.extraKnownMarketplaces)) {
+		const seen = new Set<string>();
+		const flattened: string[] = [];
+		for (const [id, entry] of Object.entries(response.extraKnownMarketplaces)) {
+			if (!isObject(entry) || !isObject(entry.source)) {
+				onWarn?.(`[DefaultAccount] Skipping malformed extraKnownMarketplaces entry "${id}": expected { source: { source, repo|url } }`);
+				continue;
+			}
+			const src = entry.source as { source?: string; repo?: string; url?: string; ref?: string };
+			const suffix = src.ref ? `#${src.ref}` : '';
+			let ref: string | undefined;
+			if (src.source === 'github' && isString(src.repo)) {
+				ref = `${src.repo}${suffix}`;
+			} else if (src.source === 'git' && isString(src.url)) {
+				ref = `${src.url}${suffix}`;
+			} else {
+				onWarn?.(`[DefaultAccount] Skipping extraKnownMarketplaces entry "${id}": unknown source type "${src.source}"`);
+				continue;
+			}
+			if (!seen.has(ref)) {
+				seen.add(ref);
+				flattened.push(ref);
+			}
+		}
+		extraKnownMarketplaces = flattened;
+	}
+
+	return {
+		enabledPlugins: isObject(response.enabledPlugins) ? response.enabledPlugins as Record<string, boolean> : undefined,
+		extraKnownMarketplaces,
+		strictKnownMarketplaces: typeof response.strictKnownMarketplaces === 'boolean' ? response.strictKnownMarketplaces : undefined,
+	};
 }
 
 interface IMcpRegistryProvider {
@@ -107,6 +174,7 @@ function toDefaultAccountConfig(defaultChatAgent: IDefaultChatAgent): IDefaultAc
 		entitlementUrl: defaultChatAgent.entitlementUrl,
 		tokenEntitlementUrl: defaultChatAgent.tokenEntitlementUrl,
 		mcpRegistryDataUrl: defaultChatAgent.mcpRegistryDataUrl,
+		managedSettingsUrl: defaultChatAgent.managedSettingsUrl,
 	};
 }
 
@@ -117,6 +185,9 @@ export class DefaultAccountService extends Disposable implements IDefaultAccount
 	get currentDefaultAccount(): IDefaultAccount | null { return this.defaultAccount; }
 	get policyData(): IPolicyData | null { return this.defaultAccountProvider?.policyData ?? null; }
 	get copilotTokenInfo(): ICopilotTokenInfo | null { return this.defaultAccountProvider?.copilotTokenInfo ?? null; }
+
+	get managedSettingsFetchStatus(): ManagedSettingsFetchStatus { return this.defaultAccountProvider?.managedSettingsFetchStatus ?? null; }
+	get managedSettingsFetchedAt(): number | null { return this.defaultAccountProvider?.managedSettingsFetchedAt ?? null; }
 
 	private readonly initBarrier = new Barrier();
 
@@ -214,6 +285,7 @@ interface IAccountPolicyData {
 	readonly entitlementsFetchedAt?: number;
 	readonly tokenEntitlementsFetchedAt?: number;
 	readonly mcpRegistryDataFetchedAt?: number;
+	readonly managedSettingsFetchedAt?: number;
 }
 
 interface ICachedAccountData {
@@ -240,6 +312,18 @@ type DefaultAccountStatusTelemetryClassification = {
 	initial: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Indicates whether this is the initial status report.' };
 };
 
+type ManagedSettingsFetchTelemetry = {
+	outcome: string;
+	rateLimitBackoffActive: boolean;
+};
+
+type ManagedSettingsFetchTelemetryClassification = {
+	owner: 'joshspicer';
+	comment: 'Outcome of a fetch against the enterprise managed_settings endpoint. Used to detect endpoint regressions and abnormal failure rates in the wild.';
+	outcome: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'High-level outcome: a numeric HTTP status (`status:NNN`), or one of `ok` / `no-response` / `parse-error`.' };
+	rateLimitBackoffActive: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'True when the request was short-circuited because a prior rate-limit Retry-After window was still active.' };
+};
+
 class DefaultAccountProvider extends Disposable implements IDefaultAccountProvider {
 
 	private _defaultAccount: IDefaultAccountData | null = null;
@@ -250,6 +334,10 @@ class DefaultAccountProvider extends Disposable implements IDefaultAccountProvid
 
 	private _copilotTokenInfo: ICopilotTokenInfo | null = null;
 	get copilotTokenInfo(): ICopilotTokenInfo | null { return this._copilotTokenInfo; }
+
+	private _managedSettingsFetchStatus: ManagedSettingsFetchStatus = null;
+	get managedSettingsFetchStatus(): ManagedSettingsFetchStatus { return this._managedSettingsFetchStatus; }
+	get managedSettingsFetchedAt(): number | null { return this._policyData?.managedSettingsFetchedAt ?? null; }
 
 	private readonly _onDidChangeDefaultAccount = this._register(new Emitter<IDefaultAccount | null>());
 	readonly onDidChangeDefaultAccount = this._onDidChangeDefaultAccount.event;
@@ -547,9 +635,15 @@ class DefaultAccountProvider extends Disposable implements IDefaultAccountProvid
 			const entitlementsResult = await this.getEntitlements(sessions, accountPolicyData, options);
 			const entitlementsData = entitlementsResult?.data;
 			const entitlementsFetchedAt = entitlementsResult?.fetchedAt;
-			const tokenEntitlementsResult = entitlementsData?.chat_enabled ? await this.getTokenEntitlements(sessions, accountPolicyData, options) : undefined;
+			const [tokenEntitlementsResult, managedSettingsResult] = entitlementsData?.chat_enabled
+				? await Promise.all([
+					this.getTokenEntitlements(sessions, accountPolicyData, options),
+					this.getManagedSettings(sessions, accountPolicyData, options),
+				])
+				: [undefined, undefined];
 
 			const tokenEntitlementsFetchedAt: number | undefined = tokenEntitlementsResult?.fetchedAt;
+			const managedSettingsFetchedAt: number | undefined = managedSettingsResult?.fetchedAt;
 			let mcpRegistryDataFetchedAt: number | undefined;
 			let policyData: Mutable<IPolicyData> | undefined = accountPolicyData?.policyData ? { ...accountPolicyData.policyData } : undefined;
 			if (entitlementsData) {
@@ -572,6 +666,13 @@ class DefaultAccountProvider extends Disposable implements IDefaultAccountProvid
 					policyData.mcpAccess = undefined;
 				}
 			}
+			if (managedSettingsResult?.data) {
+				const managedData = managedSettingsResult.data;
+				policyData = policyData ?? {};
+				policyData.enabledPlugins = managedData.enabledPlugins;
+				policyData.extraKnownMarketplaces = managedData.extraKnownMarketplaces;
+				policyData.strictKnownMarketplaces = managedData.strictKnownMarketplaces;
+			}
 
 			const defaultAccount: IDefaultAccount = {
 				authenticationProvider,
@@ -582,7 +683,7 @@ class DefaultAccountProvider extends Disposable implements IDefaultAccountProvid
 			};
 			this.logService.debug('[DefaultAccount] Successfully created default account for provider:', authenticationProvider.id);
 			const accountPolicyResult: IAccountPolicyData | null = policyData || entitlementsFetchedAt
-				? { accountId, policyData: policyData ?? {}, entitlementsFetchedAt, tokenEntitlementsFetchedAt, mcpRegistryDataFetchedAt }
+				? { accountId, policyData: policyData ?? {}, entitlementsFetchedAt, tokenEntitlementsFetchedAt, mcpRegistryDataFetchedAt, managedSettingsFetchedAt }
 				: null;
 			return {
 				defaultAccount,
@@ -784,9 +885,121 @@ class DefaultAccountProvider extends Disposable implements IDefaultAccountProvid
 		}
 	}
 
-	private async request(url: string, type: 'GET', body: undefined, sessions: AuthenticationSession[], token: CancellationToken, callSite: string): Promise<IRequestContext | undefined>;
-	private async request(url: string, type: 'POST', body: object, sessions: AuthenticationSession[], token: CancellationToken, callSite: string): Promise<IRequestContext | undefined>;
-	private async request(url: string, type: 'GET' | 'POST', body: object | undefined, sessions: AuthenticationSession[], token: CancellationToken, callSite: string): Promise<IRequestContext | undefined> {
+	private async getManagedSettings(sessions: AuthenticationSession[], accountPolicyData: IAccountPolicyData | undefined, options?: { forceRefresh?: boolean }): Promise<{ data: Partial<IPolicyData> | undefined; fetchedAt: number }> {
+		if (!options?.forceRefresh && accountPolicyData?.managedSettingsFetchedAt && !this.isDataStale(accountPolicyData.managedSettingsFetchedAt)) {
+			this.logService.debug('[DefaultAccount] Using last fetched managed settings data');
+			return {
+				data: {
+					enabledPlugins: accountPolicyData.policyData.enabledPlugins,
+					extraKnownMarketplaces: accountPolicyData.policyData.extraKnownMarketplaces,
+					strictKnownMarketplaces: accountPolicyData.policyData.strictKnownMarketplaces,
+				},
+				fetchedAt: accountPolicyData.managedSettingsFetchedAt,
+			};
+		}
+		const data = await this.requestManagedSettings(sessions);
+		return { data, fetchedAt: Date.now() };
+	}
+
+	private async requestManagedSettings(sessions: AuthenticationSession[]): Promise<Partial<IPolicyData> | undefined> {
+		const managedSettingsUrl = this.getManagedSettingsUrl();
+		if (!managedSettingsUrl) {
+			this.logService.debug('[DefaultAccount] No managed settings URL configured; skipping enterprise policy fetch');
+			this._managedSettingsFetchStatus = 'no-url';
+			return undefined;
+		}
+
+		this.logService.debug('[DefaultAccount] Fetching managed settings from:', managedSettingsUrl);
+		const rateLimitBackoffActive = Date.now() < this._rateLimitBackoffUntil;
+		const response = await this.request(managedSettingsUrl, 'GET', undefined, sessions, CancellationToken.None, 'defaultAccount.managedSettings', MANAGED_SETTINGS_REQUEST_TIMEOUT_MS);
+		if (!response) {
+			this.logService.debug('[DefaultAccount] Managed settings fetch returned no response (network error, all sessions rejected, or active rate-limit backoff); falling back to local-only policy');
+			this.reportManagedSettingsOutcome('no-response', rateLimitBackoffActive);
+			return undefined;
+		}
+
+		// Any non-2xx response means "fall back to local settings only and continue
+		// operating normally" — silent fallback, no policy.
+		if (!isSuccess(response)) {
+			const status = response.res.statusCode ?? 0;
+			this.logService.warn(`[DefaultAccount] Managed settings fetch returned non-success status ${status}; falling back to local-only policy`);
+			this.reportManagedSettingsOutcome(status, rateLimitBackoffActive);
+			return undefined;
+		}
+
+		try {
+			const data = await asJson<IManagedSettingsResponse>(response);
+			const adapted = adaptManagedSettings(data ?? {}, msg => this.logService.warn(msg));
+			// An empty response (`{}`) is a successful "no policy file present" signal.
+			const pluginCount = adapted.enabledPlugins ? Object.keys(adapted.enabledPlugins).length : 0;
+			const marketplaceCount = adapted.extraKnownMarketplaces?.length ?? 0;
+			const strictSet = adapted.strictKnownMarketplaces !== undefined;
+			if (pluginCount === 0 && marketplaceCount === 0 && !strictSet) {
+				this.logService.debug('[DefaultAccount] Managed settings fetched (empty response — no enterprise policy file present)');
+			} else {
+				this.logService.info('[DefaultAccount] Managed settings applied');
+				this.logService.trace('[DefaultAccount] Managed settings payload:', JSON.stringify(adapted));
+			}
+			this.reportManagedSettingsOutcome('ok', rateLimitBackoffActive);
+			return adapted;
+		} catch (error) {
+			this.logService.error('[DefaultAccount] Failed to parse managed settings response', getErrorMessage(error));
+			this.reportManagedSettingsOutcome('parse-error', rateLimitBackoffActive);
+			return undefined;
+		}
+	}
+
+	private reportManagedSettingsOutcome(status: Exclude<ManagedSettingsFetchStatus, null | 'no-url'>, rateLimitBackoffActive: boolean): void {
+		this._managedSettingsFetchStatus = status;
+		this.telemetryService.publicLog2<ManagedSettingsFetchTelemetry, ManagedSettingsFetchTelemetryClassification>('defaultaccount:managedSettings:fetch', {
+			outcome: typeof status === 'number' ? `status:${status}` : status,
+			rateLimitBackoffActive,
+		});
+	}
+
+	/**
+	 * Detects a rate-limited GitHub response. Mirrors the public-API check in
+	 * `githubRepoFetcher.ts`:
+	 * - Canonical `429 Too Many Requests`.
+	 * - Primary quota exhaustion: `403` with `X-RateLimit-Remaining: 0`.
+	 * - Secondary throttling: GitHub omits `X-RateLimit-Remaining` but sets
+	 *   `Retry-After` (on a non-2xx response). We treat any non-success status
+	 *   that carries `Retry-After` as a back-off signal.
+	 */
+	private isRateLimited(response: IRequestContext): boolean {
+		const status = response.res.statusCode;
+		if (status === 429) {
+			return true;
+		}
+		if (status === 403 && readHeader(response.res.headers, 'x-ratelimit-remaining') === '0') {
+			return true;
+		}
+		// Secondary rate limit: the server explicitly asks the client to wait,
+		// regardless of which non-2xx code it returned with.
+		if (!isSuccess(response) && readHeader(response.res.headers, 'retry-after') !== undefined) {
+			return true;
+		}
+		return false;
+	}
+
+	private _rateLimitBackoffUntil = 0;
+
+	private async request(url: string, type: 'GET', body: undefined, sessions: AuthenticationSession[], token: CancellationToken, callSite: string, requestTimeoutMs?: number): Promise<IRequestContext | undefined>;
+	private async request(url: string, type: 'POST', body: object, sessions: AuthenticationSession[], token: CancellationToken, callSite: string, requestTimeoutMs?: number): Promise<IRequestContext | undefined>;
+	private async request(url: string, type: 'GET' | 'POST', body: object | undefined, sessions: AuthenticationSession[], token: CancellationToken, callSite: string, requestTimeoutMs?: number): Promise<IRequestContext | undefined> {
+		// Rate-limit backoff: when any prior `/copilot_internal/*` request was
+		// throttled (429 or 403 + `X-RateLimit-Remaining: 0`), every subsequent
+		// request is short-circuited until the parsed `Retry-After` elapses.
+		// All endpoints called from here share the same host and bearer token,
+		// so backing off the bucket as a whole avoids piling on a server that
+		// has already asked us to slow down. See `githubRepoFetcher.ts` for the
+		// public-API analogue.
+		if (Date.now() < this._rateLimitBackoffUntil) {
+			const remainingSec = Math.ceil((this._rateLimitBackoffUntil - Date.now()) / 1000);
+			this.logService.debug(`[DefaultAccount] Skipping request to ${url} — rate-limit backoff active for ${remainingSec}s more`);
+			return undefined;
+		}
+
 		let lastResponse: IRequestContext | undefined;
 
 		for (const session of sessions) {
@@ -800,6 +1013,7 @@ class DefaultAccountProvider extends Disposable implements IDefaultAccountProvid
 					url,
 					data: type === 'POST' ? JSON.stringify(body) : undefined,
 					disableCache: true,
+					timeout: requestTimeoutMs,
 					headers: {
 						'Authorization': `Bearer ${session.accessToken}`
 					},
@@ -807,6 +1021,12 @@ class DefaultAccountProvider extends Disposable implements IDefaultAccountProvid
 				}, token);
 
 				const status = response.res.statusCode;
+				if (this.isRateLimited(response)) {
+					const retryAfterSec = retryAfterFromHeaders(response.res.headers) ?? 60;
+					this._rateLimitBackoffUntil = Date.now() + retryAfterSec * 1000;
+					this.logService.warn(`[DefaultAccount] Rate limited by ${url} (status ${status}); backing off for ${retryAfterSec}s`);
+					return response;
+				}
 				if (status === 401 || status === 404) {
 					this.logService.debug(`[DefaultAccount] Received ${status} for URL ${url} with session ${session.id}, likely due to expired/revoked token or insufficient permissions.`, 'Trying next session if available.');
 					lastResponse = response;
@@ -879,6 +1099,22 @@ class DefaultAccountProvider extends Disposable implements IDefaultAccountProvid
 		}
 
 		return this.defaultAccountConfig.mcpRegistryDataUrl;
+	}
+
+	private getManagedSettingsUrl(): string | undefined {
+		if (this.getDefaultAccountAuthenticationProvider().enterprise) {
+			try {
+				const enterpriseUrl = this.getEnterpriseUrl();
+				if (!enterpriseUrl) {
+					return undefined;
+				}
+				return `${enterpriseUrl.protocol}//api.${enterpriseUrl.hostname}${enterpriseUrl.port ? ':' + enterpriseUrl.port : ''}/copilot_internal/managed_settings`;
+			} catch (error) {
+				this.logService.error(error);
+			}
+		}
+
+		return this.defaultAccountConfig.managedSettingsUrl;
 	}
 
 	getDefaultAccountAuthenticationProvider(): IDefaultAccountAuthenticationProvider {

--- a/src/vs/workbench/services/accounts/browser/managedSettings.ts
+++ b/src/vs/workbench/services/accounts/browser/managedSettings.ts
@@ -59,6 +59,8 @@ export function adaptManagedSettings(response: IManagedSettingsResponse, onWarn?
 				flattened.add(`${src.repo}${suffix}`);
 			} else if (src.source === 'git' && isString(src.url)) {
 				flattened.add(`${src.url}${suffix}`);
+			} else if (src.source === 'github' || src.source === 'git') {
+				onWarn?.(`[DefaultAccount] Skipping extraKnownMarketplaces entry "${id}": source "${src.source}" requires ${src.source === 'github' ? '"repo"' : '"url"'}`);
 			} else {
 				onWarn?.(`[DefaultAccount] Skipping extraKnownMarketplaces entry "${id}": unknown source type "${src.source}"`);
 			}

--- a/src/vs/workbench/services/accounts/browser/managedSettings.ts
+++ b/src/vs/workbench/services/accounts/browser/managedSettings.ts
@@ -3,7 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IExtraKnownMarketplaceEntry, IPolicyData } from '../../../../base/common/defaultAccount.js';
+import { IPolicyData } from '../../../../base/common/defaultAccount.js';
+import { IExtraKnownMarketplaceEntry } from '../../../../base/common/managedSettings.js';
 import { isObject, isString } from '../../../../base/common/types.js';
 
 /**

--- a/src/vs/workbench/services/accounts/browser/managedSettings.ts
+++ b/src/vs/workbench/services/accounts/browser/managedSettings.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IPolicyData } from '../../../../base/common/defaultAccount.js';
+import { IExtraKnownMarketplaceEntry, IPolicyData } from '../../../../base/common/defaultAccount.js';
 import { isObject, isString } from '../../../../base/common/types.js';
 
 /**
@@ -31,10 +31,11 @@ export interface IManagedSettingsResponse {
 
 /**
  * Adapt the `managed_settings` API response into the slice of {@link IPolicyData}
- * that the policy framework consumes. `extraKnownMarketplaces` is flattened from
- * the API's `Record<id, { source }>` shape to the existing
- * `chat.plugins.extraMarketplaces` string-array shape (`<owner>/<repo>[#<ref>]`
- * for GitHub sources, `<url>[#<ref>]` for Git sources), deduplicated.
+ * that the policy framework consumes. `extraKnownMarketplaces` is converted from
+ * the API's `Record<id, { source }>` map shape to a flat array of
+ * {@link IExtraKnownMarketplaceEntry} objects, preserving the marketplace `name`
+ * (used downstream as `displayLabel` so that `enabledPlugins["plugin@<name>"]`
+ * keys resolve correctly), the source discriminator, and any `ref`.
  *
  * Each field is validated independently at runtime — malformed or off-spec
  * shapes are dropped (with an optional warning via {@link onWarn}) rather than
@@ -44,28 +45,32 @@ export interface IManagedSettingsResponse {
  * Exported for unit-testing the shape transformation independently of network I/O.
  */
 export function adaptManagedSettings(response: IManagedSettingsResponse, onWarn?: (msg: string) => void): Partial<IPolicyData> {
-	let extraKnownMarketplaces: readonly string[] | undefined;
+	let extraKnownMarketplaces: readonly IExtraKnownMarketplaceEntry[] | undefined;
 	if (isObject(response.extraKnownMarketplaces)) {
-		// Set preserves insertion order and dedups for free.
-		const flattened = new Set<string>();
-		for (const [id, entry] of Object.entries(response.extraKnownMarketplaces)) {
+		const seen = new Set<string>();
+		const entries: IExtraKnownMarketplaceEntry[] = [];
+		for (const [name, entry] of Object.entries(response.extraKnownMarketplaces)) {
 			if (!isObject(entry) || !isObject(entry.source)) {
-				onWarn?.(`[DefaultAccount] Skipping malformed extraKnownMarketplaces entry "${id}": expected { source: { source, repo|url } }`);
+				onWarn?.(`[DefaultAccount] Skipping malformed extraKnownMarketplaces entry "${name}": expected { source: { source, repo|url } }`);
 				continue;
 			}
 			const src = entry.source as { source?: string; repo?: string; url?: string; ref?: string };
-			const suffix = src.ref ? `#${src.ref}` : '';
+			let normalized: IExtraKnownMarketplaceEntry | undefined;
 			if (src.source === 'github' && isString(src.repo)) {
-				flattened.add(`${src.repo}${suffix}`);
+				normalized = { name, source: { source: 'github', repo: src.repo, ...(src.ref ? { ref: src.ref } : {}) } };
 			} else if (src.source === 'git' && isString(src.url)) {
-				flattened.add(`${src.url}${suffix}`);
+				normalized = { name, source: { source: 'git', url: src.url, ...(src.ref ? { ref: src.ref } : {}) } };
 			} else if (src.source === 'github' || src.source === 'git') {
-				onWarn?.(`[DefaultAccount] Skipping extraKnownMarketplaces entry "${id}": source "${src.source}" requires ${src.source === 'github' ? '"repo"' : '"url"'}`);
+				onWarn?.(`[DefaultAccount] Skipping extraKnownMarketplaces entry "${name}": source "${src.source}" requires ${src.source === 'github' ? '"repo"' : '"url"'}`);
 			} else {
-				onWarn?.(`[DefaultAccount] Skipping extraKnownMarketplaces entry "${id}": unknown source type "${src.source}"`);
+				onWarn?.(`[DefaultAccount] Skipping extraKnownMarketplaces entry "${name}": unknown source type "${src.source}"`);
+			}
+			if (normalized && !seen.has(name)) {
+				seen.add(name);
+				entries.push(normalized);
 			}
 		}
-		extraKnownMarketplaces = [...flattened];
+		extraKnownMarketplaces = entries;
 	}
 
 	return {

--- a/src/vs/workbench/services/accounts/browser/managedSettings.ts
+++ b/src/vs/workbench/services/accounts/browser/managedSettings.ts
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IPolicyData } from '../../../../base/common/defaultAccount.js';
+import { isObject, isString } from '../../../../base/common/types.js';
+
+/**
+ * Response shape from the Copilot `/copilot_internal/managed_settings` endpoint.
+ * The endpoint returns `.github/copilot/settings.json` content from the
+ * enterprise's source org. An empty response (`{}`) is success and means
+ * "no policy file present".
+ *
+ * Unknown keys are silently ignored via the index signature so the client is
+ * forward-compatible with future additions to the registry schema.
+ *
+ * Exported for unit-testing the {@link adaptManagedSettings} shape transformation.
+ */
+export interface IManagedSettingsResponse {
+	readonly enabledPlugins?: Record<string, boolean>;
+	readonly extraKnownMarketplaces?: Record<string, {
+		readonly source:
+		| { readonly source: 'github'; readonly repo: string; readonly ref?: string }
+		| { readonly source: 'git'; readonly url: string; readonly ref?: string };
+	}>;
+	readonly strictKnownMarketplaces?: boolean;
+	/** Any unknown keys in the response are silently ignored for forward compatibility. */
+	readonly [key: string]: unknown;
+}
+
+/**
+ * Adapt the `managed_settings` API response into the slice of {@link IPolicyData}
+ * that the policy framework consumes. `extraKnownMarketplaces` is flattened from
+ * the API's `Record<id, { source }>` shape to the existing
+ * `chat.plugins.extraMarketplaces` string-array shape (`<owner>/<repo>[#<ref>]`
+ * for GitHub sources, `<url>[#<ref>]` for Git sources), deduplicated.
+ *
+ * Each field is validated independently at runtime — malformed or off-spec
+ * shapes are dropped (with an optional warning via {@link onWarn}) rather than
+ * throwing, so a bad enterprise settings file degrades gracefully instead of
+ * blocking startup.
+ *
+ * Exported for unit-testing the shape transformation independently of network I/O.
+ */
+export function adaptManagedSettings(response: IManagedSettingsResponse, onWarn?: (msg: string) => void): Partial<IPolicyData> {
+	let extraKnownMarketplaces: readonly string[] | undefined;
+	if (isObject(response.extraKnownMarketplaces)) {
+		// Set preserves insertion order and dedups for free.
+		const flattened = new Set<string>();
+		for (const [id, entry] of Object.entries(response.extraKnownMarketplaces)) {
+			if (!isObject(entry) || !isObject(entry.source)) {
+				onWarn?.(`[DefaultAccount] Skipping malformed extraKnownMarketplaces entry "${id}": expected { source: { source, repo|url } }`);
+				continue;
+			}
+			const src = entry.source as { source?: string; repo?: string; url?: string; ref?: string };
+			const suffix = src.ref ? `#${src.ref}` : '';
+			if (src.source === 'github' && isString(src.repo)) {
+				flattened.add(`${src.repo}${suffix}`);
+			} else if (src.source === 'git' && isString(src.url)) {
+				flattened.add(`${src.url}${suffix}`);
+			} else {
+				onWarn?.(`[DefaultAccount] Skipping extraKnownMarketplaces entry "${id}": unknown source type "${src.source}"`);
+			}
+		}
+		extraKnownMarketplaces = [...flattened];
+	}
+
+	return {
+		enabledPlugins: isObject(response.enabledPlugins) ? response.enabledPlugins as Record<string, boolean> : undefined,
+		extraKnownMarketplaces,
+		strictKnownMarketplaces: typeof response.strictKnownMarketplaces === 'boolean' ? response.strictKnownMarketplaces : undefined,
+	};
+}

--- a/src/vs/workbench/services/accounts/test/browser/defaultAccount.test.ts
+++ b/src/vs/workbench/services/accounts/test/browser/defaultAccount.test.ts
@@ -1,0 +1,128 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { adaptManagedSettings, IManagedSettingsResponse } from '../../browser/defaultAccount.js';
+
+suite('DefaultAccount.adaptManagedSettings', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('empty response yields all-undefined partial (no enterprise policy file present)', () => {
+		assert.deepStrictEqual(adaptManagedSettings({}), {
+			enabledPlugins: undefined,
+			extraKnownMarketplaces: undefined,
+			strictKnownMarketplaces: undefined,
+		});
+	});
+
+	test('passes enabledPlugins through untouched (plugin-ID keys, boolean values)', () => {
+		const response: IManagedSettingsResponse = {
+			enabledPlugins: {
+				'assign-issue-to-copilot@agent-skills': true,
+				'my-plugin@acme': false,
+			},
+		};
+		assert.deepStrictEqual(adaptManagedSettings(response).enabledPlugins, {
+			'assign-issue-to-copilot@agent-skills': true,
+			'my-plugin@acme': false,
+		});
+	});
+
+	test('passes strictKnownMarketplaces boolean through untouched', () => {
+		assert.strictEqual(adaptManagedSettings({ strictKnownMarketplaces: true }).strictKnownMarketplaces, true);
+		assert.strictEqual(adaptManagedSettings({ strictKnownMarketplaces: false }).strictKnownMarketplaces, false);
+	});
+
+	test('flattens github-source marketplaces to <owner>/<repo>', () => {
+		const result = adaptManagedSettings({
+			extraKnownMarketplaces: {
+				'a': { source: { source: 'github', repo: 'github/agent-skills' } },
+				'b': { source: { source: 'github', repo: 'acme/things', ref: 'main' } },
+			},
+		});
+		assert.deepStrictEqual(result.extraKnownMarketplaces, [
+			'github/agent-skills',
+			'acme/things#main',
+		]);
+	});
+
+	test('flattens git-source marketplaces to <url>', () => {
+		const result = adaptManagedSettings({
+			extraKnownMarketplaces: {
+				'a': { source: { source: 'git', url: 'https://example.com/repo.git' } },
+				'b': { source: { source: 'git', url: 'ssh://git@host/path.git', ref: 'v1' } },
+			},
+		});
+		assert.deepStrictEqual(result.extraKnownMarketplaces, [
+			'https://example.com/repo.git',
+			'ssh://git@host/path.git#v1',
+		]);
+	});
+
+	test('handles mixed github + git sources with dedup', () => {
+		const result = adaptManagedSettings({
+			extraKnownMarketplaces: {
+				'a': { source: { source: 'github', repo: 'a/b' } },
+				'b': { source: { source: 'git', url: 'https://example.com/r.git' } },
+				'c': { source: { source: 'github', repo: 'a/b' } }, // dup
+			},
+		});
+		assert.deepStrictEqual(result.extraKnownMarketplaces, [
+			'a/b',
+			'https://example.com/r.git',
+		]);
+	});
+
+	test('handles full populated response (all three fields together)', () => {
+		const result = adaptManagedSettings({
+			enabledPlugins: { 'p@m': true },
+			extraKnownMarketplaces: {
+				'a': { source: { source: 'github', repo: 'a/b', ref: 'r' } },
+			},
+			strictKnownMarketplaces: true,
+		});
+		assert.deepStrictEqual(result, {
+			enabledPlugins: { 'p@m': true },
+			extraKnownMarketplaces: ['a/b#r'],
+			strictKnownMarketplaces: true,
+		});
+	});
+
+	test('resilience: unknown top-level keys are silently ignored', () => {
+		const result = adaptManagedSettings({
+			enabledPlugins: { 'p@m': true },
+			strictKnownMarketplaces: false,
+			joshsFakeSetting: true,
+		} as IManagedSettingsResponse);
+		assert.deepStrictEqual(result, {
+			enabledPlugins: { 'p@m': true },
+			extraKnownMarketplaces: undefined,
+			strictKnownMarketplaces: false,
+		});
+	});
+
+	test('resilience: malformed extraKnownMarketplaces entry is skipped, valid entries still processed', () => {
+		const warnings: string[] = [];
+		const result = adaptManagedSettings({
+			extraKnownMarketplaces: {
+				'good': { source: { source: 'github', repo: 'a/b' } },
+				'bad-no-source': {} as IManagedSettingsResponse['extraKnownMarketplaces'] extends Record<string, infer V> ? V : never,
+				'bad-unknown-type': { source: { source: 'ftp', url: 'ftp://x' } } as IManagedSettingsResponse['extraKnownMarketplaces'] extends Record<string, infer V> ? V : never,
+			},
+		} as IManagedSettingsResponse, msg => warnings.push(msg));
+		assert.deepStrictEqual(result.extraKnownMarketplaces, ['a/b']);
+		assert.strictEqual(warnings.length, 2);
+	});
+
+	test('resilience: extraKnownMarketplaces as a string array (wrong format) yields empty array, no throw', () => {
+		const result = adaptManagedSettings({
+			extraKnownMarketplaces: ['https://plugins.acme.com'] as unknown as IManagedSettingsResponse['extraKnownMarketplaces'],
+		} as IManagedSettingsResponse);
+		// Array is not an object-record — treated as missing, so yields undefined
+		assert.strictEqual(result.extraKnownMarketplaces, undefined);
+	});
+});

--- a/src/vs/workbench/services/accounts/test/browser/managedSettings.test.ts
+++ b/src/vs/workbench/services/accounts/test/browser/managedSettings.test.ts
@@ -5,9 +5,9 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { adaptManagedSettings, IManagedSettingsResponse } from '../../browser/defaultAccount.js';
+import { adaptManagedSettings, IManagedSettingsResponse } from '../../browser/managedSettings.js';
 
-suite('DefaultAccount.adaptManagedSettings', () => {
+suite('adaptManagedSettings', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();
 

--- a/src/vs/workbench/services/accounts/test/browser/managedSettings.test.ts
+++ b/src/vs/workbench/services/accounts/test/browser/managedSettings.test.ts
@@ -37,7 +37,7 @@ suite('adaptManagedSettings', () => {
 		assert.strictEqual(adaptManagedSettings({ strictKnownMarketplaces: false }).strictKnownMarketplaces, false);
 	});
 
-	test('flattens github-source marketplaces to <owner>/<repo>', () => {
+	test('preserves marketplace name + github source shape', () => {
 		const result = adaptManagedSettings({
 			extraKnownMarketplaces: {
 				'a': { source: { source: 'github', repo: 'github/agent-skills' } },
@@ -45,12 +45,12 @@ suite('adaptManagedSettings', () => {
 			},
 		});
 		assert.deepStrictEqual(result.extraKnownMarketplaces, [
-			'github/agent-skills',
-			'acme/things#main',
+			{ name: 'a', source: { source: 'github', repo: 'github/agent-skills' } },
+			{ name: 'b', source: { source: 'github', repo: 'acme/things', ref: 'main' } },
 		]);
 	});
 
-	test('flattens git-source marketplaces to <url>', () => {
+	test('preserves marketplace name + git source shape', () => {
 		const result = adaptManagedSettings({
 			extraKnownMarketplaces: {
 				'a': { source: { source: 'git', url: 'https://example.com/repo.git' } },
@@ -58,22 +58,21 @@ suite('adaptManagedSettings', () => {
 			},
 		});
 		assert.deepStrictEqual(result.extraKnownMarketplaces, [
-			'https://example.com/repo.git',
-			'ssh://git@host/path.git#v1',
+			{ name: 'a', source: { source: 'git', url: 'https://example.com/repo.git' } },
+			{ name: 'b', source: { source: 'git', url: 'ssh://git@host/path.git', ref: 'v1' } },
 		]);
 	});
 
-	test('handles mixed github + git sources with dedup', () => {
+	test('handles mixed github + git sources, dedups by marketplace name', () => {
 		const result = adaptManagedSettings({
 			extraKnownMarketplaces: {
 				'a': { source: { source: 'github', repo: 'a/b' } },
 				'b': { source: { source: 'git', url: 'https://example.com/r.git' } },
-				'c': { source: { source: 'github', repo: 'a/b' } }, // dup
 			},
 		});
 		assert.deepStrictEqual(result.extraKnownMarketplaces, [
-			'a/b',
-			'https://example.com/r.git',
+			{ name: 'a', source: { source: 'github', repo: 'a/b' } },
+			{ name: 'b', source: { source: 'git', url: 'https://example.com/r.git' } },
 		]);
 	});
 
@@ -87,7 +86,9 @@ suite('adaptManagedSettings', () => {
 		});
 		assert.deepStrictEqual(result, {
 			enabledPlugins: { 'p@m': true },
-			extraKnownMarketplaces: ['a/b#r'],
+			extraKnownMarketplaces: [
+				{ name: 'a', source: { source: 'github', repo: 'a/b', ref: 'r' } },
+			],
 			strictKnownMarketplaces: true,
 		});
 	});
@@ -114,7 +115,9 @@ suite('adaptManagedSettings', () => {
 				'bad-unknown-type': { source: { source: 'ftp', url: 'ftp://x' } } as IManagedSettingsResponse['extraKnownMarketplaces'] extends Record<string, infer V> ? V : never,
 			},
 		} as IManagedSettingsResponse, msg => warnings.push(msg));
-		assert.deepStrictEqual(result.extraKnownMarketplaces, ['a/b']);
+		assert.deepStrictEqual(result.extraKnownMarketplaces, [
+			{ name: 'good', source: { source: 'github', repo: 'a/b' } },
+		]);
 		assert.strictEqual(warnings.length, 2);
 	});
 

--- a/src/vs/workbench/services/policies/test/browser/accountPolicyService.test.ts
+++ b/src/vs/workbench/services/policies/test/browser/accountPolicyService.test.ts
@@ -35,6 +35,8 @@ class DefaultAccountProvider implements IDefaultAccountProvider {
 	readonly onDidChangePolicyData = Event.None;
 	readonly copilotTokenInfo = null;
 	readonly onDidChangeCopilotTokenInfo = Event.None;
+	readonly managedSettingsFetchStatus: null = null;
+	readonly managedSettingsFetchedAt: null = null;
 
 	constructor(
 		readonly defaultAccount: IDefaultAccount,

--- a/src/vs/workbench/services/policies/test/browser/multiplexPolicyService.test.ts
+++ b/src/vs/workbench/services/policies/test/browser/multiplexPolicyService.test.ts
@@ -41,6 +41,8 @@ class DefaultAccountProvider implements IDefaultAccountProvider {
 	readonly onDidChangePolicyData = Event.None;
 	readonly copilotTokenInfo = null;
 	readonly onDidChangeCopilotTokenInfo = Event.None;
+	readonly managedSettingsFetchStatus: null = null;
+	readonly managedSettingsFetchedAt: null = null;
 
 	constructor(
 		readonly defaultAccount: IDefaultAccount,

--- a/src/vs/workbench/test/browser/componentFixtures/fixtureUtils.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/fixtureUtils.ts
@@ -584,6 +584,8 @@ export function createEditorServices(disposables: DisposableStore, options?: Cre
 		currentDefaultAccount: null,
 		copilotTokenInfo: null,
 		onDidChangeCopilotTokenInfo: new Emitter<null>().event,
+		managedSettingsFetchStatus: null,
+		managedSettingsFetchedAt: null,
 		getDefaultAccount: async () => null,
 		getDefaultAccountAuthenticationProvider: () => ({ id: 'test', name: 'Test', scopes: [], enterprise: false }),
 		resolveGitHubUrl: (path: string) => `https://github.com/${path}`,


### PR DESCRIPTION
## What

Wires a new `/copilot_internal/managed_settings` endpoint into VS Code's existing `AccountPolicyService` / `IPolicyData` stack so an enterprise admin's `.github/copilot/settings.json` policy applies to three new plugin/marketplace settings.

| API field | VS Code setting | Policy |
|---|---|---|
| `enabledPlugins` | `chat.plugins.enabledPlugins` (new) | `ChatEnabledPlugins` |
| `extraKnownMarketplaces` | `chat.plugins.extraMarketplaces` (new, policy-only) | `ChatExtraMarketplaces` |
| `strictKnownMarketplaces` | `chat.plugins.strictMarketplaces` (new) | `ChatStrictMarketplaces` |

All three settings are tagged `experimental`. `chat.plugins.extraMarketplaces` is policy-only (`included:  there's no user-writable surface for it.false`) 

## Architecture

- **No new ` `AccountPolicyService`'s existing `policy.value(policyData)` callback flow handles everything natively.IPolicyService`** 
- **`DefaultAccountProvider` fetches in parallel** with `getTokenEntitlements` (shared sessions, shared `IRequestService` plumbing, shared 1-hour cache). 5 s request timeout.
- **Silent fallback** to local-only policy on any non-2xx, network error, parse error, or missing `managedSettingsUrl`. An empty response (`{}`) is a successful "no policy file present" signal.
- **Shape adaptation in `adaptManagedSettings`** (`services/accounts/browser/managedSettings.ts`): the API's `Record<id, { source }>` for `extraKnownMarketplaces` becomes an `IExtraKnownMarketplaceEntry[]`, preserving the marketplace `name` so `enabledPlugins["<plugin>@<marketplace>"]` keys resolve consistently.
- **`chat.plugins.extraMarketplaces` stored as `{ [name]: url-or-shorthand }`** dict, which lets the Settings Editor's ComplexObject renderer display entries inline (read-only) when managed by policy.
- **Forward-compatible  unknown response keys are silently ignored, malformed entries are skipped with a `warn`.parsing** 
- **Consumers union user + policy** via a shared `readConfiguredMarketplaces` helper in `marketplaceReference.ts`. `chat.plugins.marketplaces` (user) and `chat.plugins.extraMarketplaces` (policy) are merged; `parseMarketplaceReferences` dedupes by canonical id.
- **Canonical-id parity**: GitHub URL form (`https://github.com/owner/repo.git`), SSH form (`git@github.com:owner/repo.git`), and shorthand (`owner/repo`) all produce the same canonical id, so policy trust comparisons match regardless of which form the policy uses.
- **Strict marketplace  when `chat.plugins.strictMarketplaces` is on, `isMarketplaceTrusted` derives trust **only** from `chat.plugins.extraMarketplaces` (policy slot). User-added marketplaces in `chat.plugins.marketplaces` do not grant trust under strict mode.mode** 
- **Plugin  `ChatEnabledPlugins` is an allowlist; combined with strict mode it gates both marketplace-discovered plugins and Copilot-CLI-installed plugins (matched by install-path `<marketplace>/<plugin>` identity).enforcement** 

## Rate limiting

The shared `DefaultAccountProvider.request()` applies a `Retry-After`-aware backoff that benefits **every** `/copilot_internal/*` call (entitlements, token entitlements, MCP registry, managed settings). Detects:
- canonical `429 Too Many Requests`
- `403` with `X-RateLimit-Remaining: 0` (primary quota exhaustion)
- any non-2xx carrying `Retry-After` (secondary throttling)

Default 60 s when `Retry-After` is absent. Mirrors the public-API pattern in `githubRepoFetcher. `readHeader` and `retryAfterFromHeaders` are exported from `platform/request/common/request.ts` and shared by both call sites.ts` 

## Telemetry

New event `defaultaccount:managedSettings:fetch` (owner: `joshspicer`):
- `outcome`: `ok` / `no-response` / `parse-error` / `status:NNN`
- `rateLimitBackoffActive`: whether the call was short-circuited by a prior `Retry-After` window

Not fired for `no-url` (would be noise from every non-Copilot environment).

## Diagnostics

`Developer: Policy Diagnostics` (Cmd+Shift+P) grows a `## Managed Settings` section showing:
- fetch status (HTTP code / `ok` / `no-response` / `parse-error` / `no-url`)
- last-fetched timestamp
- a JSON dump of the applied managed-settings policy slice

`Developer: Sync Account Policy` invalidates the cache and refetches.

## Tests

- `src/vs/workbench/services/accounts/test/browser/managedSettings.test.ts` covers `adaptManagedSettings` shape transformations (empty / partial / full / github vs git sources / ref handling) and resilience to malformed/unknown payloads.
- `src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts` covers the new `readConfiguredMarketplaces` / `extraKnownMarketplacesToConfigDict` helpers, host-only git URLs, and the canonical-id parity guarantee for GitHub URL vs shorthand.
- Existing mock implementations of `IDefaultAccountService` / `IDefaultAccountProvider` updated for the new readonly fields.

## Distro

Companion vscode-distro PR: microsoft/vscode-distro#1422 adds `managedSettingsUrl` to `mixin/{stable,insider,exploration}/product.json`.

## Out of scope

- Org/repo policy delivery layers.
- Hooks / `disableAllHooks`.
- Server-side merging.
- Auto-install of enterprise-enabled plugins (the SHOULD in the  deferred as a follow-on.ADR) 

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
