### PR TITLE
mcp: prefer announced server title for tool prefixes and picker labels

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatToolPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatToolPicker.ts
@@ -319,7 +319,7 @@ export async function showToolsPicker(
 					itemType: 'bucket',
 					ordinal: BucketOrdinal.Mcp,
 					id: key,
-					label: source.label,
+					label: source.serverLabel || source.label,
 					checked: undefined,
 					collapsed,
 					children,

--- a/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
@@ -154,7 +154,7 @@ export namespace ToolDataSource {
 		if (source.type === 'internal') {
 			return { ordinal: 1, label: localize('builtin', 'Built-In') };
 		} else if (source.type === 'mcp') {
-			return { ordinal: 2, label: source.label };
+			return { ordinal: 2, label: source.serverLabel || source.label };
 		} else if (source.type === 'user') {
 			return { ordinal: 0, label: localize('user', 'User Defined') };
 		} else {

--- a/src/vs/workbench/contrib/mcp/common/mcpServer.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpServer.ts
@@ -8,11 +8,11 @@ import { CancellationToken, CancellationTokenSource } from '../../../../base/com
 import { Iterable } from '../../../../base/common/iterator.js';
 import * as json from '../../../../base/common/json.js';
 import { normalizeDriveLetter } from '../../../../base/common/labels.js';
-import { Disposable, DisposableStore, IDisposable, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, IDisposable, IReference, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { LRUCache } from '../../../../base/common/map.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { mapValues } from '../../../../base/common/objects.js';
-import { autorun, autorunSelfDisposable, derived, disposableObservableValue, IDerivedReader, IObservable, IReader, ITransaction, observableFromEvent, ObservablePromise, observableValue, transaction } from '../../../../base/common/observable.js';
+import { autorun, autorunSelfDisposable, derived, derivedDisposable, disposableObservableValue, IDerivedReader, IObservable, IReader, ITransaction, observableFromEvent, ObservablePromise, observableValue, transaction } from '../../../../base/common/observable.js';
 import { basename } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import { createURITransformer } from '../../../../base/common/uriTransformer.js';
@@ -211,6 +211,49 @@ export class McpServerMetadataCache extends Disposable {
 			this.extensionServers.delete(collectionId);
 		}
 		this.didChange = true;
+	}
+}
+
+/**
+ * Shared across all {@link McpServer}s. Each server `take`s the name it wants
+ * to base its tool prefix on (announced `serverInfo.title`/`name` when known,
+ * otherwise the mcp.json key) and gets back a stable, collision-resolved prefix
+ * observable. When a server's preferred name changes (e.g. after the live
+ * `serverInfo` arrives), it simply takes again and disposes the previous
+ * reference; other servers that share the name keep the suffix they were
+ * already assigned. See #299749.
+ */
+export class McpPrefixGenerator {
+	private readonly _buckets = new Map<string, { usedIndexes: Set<number>; size: number }>();
+
+	take(name: string): IReference<string> {
+		const safeName = name.toLowerCase().replace(/[^a-z0-9_.-]+/g, '_').slice(0, McpToolName.MaxPrefixLen - McpToolName.Prefix.length - 1);
+		let bucket = this._buckets.get(safeName);
+		if (!bucket) {
+			bucket = { usedIndexes: new Set(), size: 0 };
+			this._buckets.set(safeName, bucket);
+		}
+
+		let index = 1;
+		while (bucket.usedIndexes.has(index)) {
+			index++;
+		}
+		bucket.usedIndexes.add(index);
+		bucket.size++;
+
+		const base = McpToolName.Prefix + safeName;
+		const prefix = index === 1 ? base + '_' : base + index + '_';
+
+		return {
+			object: prefix,
+			dispose: () => {
+				bucket!.usedIndexes.delete(index);
+				bucket!.size--;
+				if (bucket!.size === 0) {
+					this._buckets.delete(safeName);
+				}
+			},
+		};
 	}
 }
 
@@ -433,7 +476,7 @@ export class McpServer extends Disposable implements IMcpServer {
 		explicitRoots: URI[] | undefined,
 		private readonly _requiresExtensionActivation: boolean | undefined,
 		private readonly _primitiveCache: McpServerMetadataCache,
-		toolPrefix: string,
+		prefixGenerator: McpPrefixGenerator,
 		enablementModel: IEnablementModel,
 		@IMcpRegistry private readonly _mcpRegistry: IMcpRegistry,
 		@IWorkspaceContextService workspacesService: IWorkspaceContextService,
@@ -516,6 +559,22 @@ export class McpServer extends Disposable implements IMcpServer {
 			return def && def.cacheNonce !== this._tools.fromCache?.nonce ? def.staticMetadata : undefined;
 		});
 
+		this._serverMetadata = new CachedPrimitive<ServerMetadata, StoredServerMetadata | undefined>(
+			this.definition.id,
+			this._primitiveCache,
+			staticMetadata.map(m => m ? this._toStoredMetadata(m?.serverInfo, m?.instructions) : undefined),
+			(entry) => ({ serverName: entry.serverName, serverInstructions: entry.serverInstructions, serverIcons: entry.serverIcons }),
+			(entry) => ({ serverName: entry?.serverName, serverInstructions: entry?.serverInstructions, icons: McpIcons.fromStored(entry?.serverIcons) }),
+			undefined,
+		);
+
+		// Form the tool prefix from the server-announced name when known so that
+		// registry-style mcp.json keys like `io.github.upstash/context7` don't end
+		// up in `mcp_io_github_ups_*` truncated names. See #299749.
+		const preferredName = derived(reader => this._serverMetadata.value.read(reader)?.serverName || this.definition.label);
+		const prefixRef = derivedDisposable(reader => prefixGenerator.take(preferredName.read(reader)));
+		const toolPrefix = prefixRef.map(ref => ref.object);
+
 		// 3. Publish tools
 		this._tools = new CachedPrimitive<readonly IMcpTool[], readonly ValidatedMcpTool[]>(
 			this.definition.id,
@@ -527,7 +586,7 @@ export class McpServer extends Disposable implements IMcpServer {
 				})
 				.map((o, reader) => o?.promiseResult.read(reader)?.data),
 			(entry) => entry.tools,
-			(entry) => entry.map(def => this._instantiationService.createInstance(McpTool, this, toolPrefix, def)).sort((a, b) => a.compare(b)),
+			(entry, reader) => entry.map(def => this._instantiationService.createInstance(McpTool, this, toolPrefix.read(reader), def)).sort((a, b) => a.compare(b)),
 			[],
 		);
 
@@ -541,15 +600,6 @@ export class McpServer extends Disposable implements IMcpServer {
 			[],
 		);
 
-		this._serverMetadata = new CachedPrimitive<ServerMetadata, StoredServerMetadata | undefined>(
-			this.definition.id,
-			this._primitiveCache,
-			staticMetadata.map(m => m ? this._toStoredMetadata(m?.serverInfo, m?.instructions) : undefined),
-			(entry) => ({ serverName: entry.serverName, serverInstructions: entry.serverInstructions, serverIcons: entry.serverIcons }),
-			(entry) => ({ serverName: entry?.serverName, serverInstructions: entry?.serverInstructions, icons: McpIcons.fromStored(entry?.serverIcons) }),
-			undefined,
-		);
-
 		this._capabilities = new CachedPrimitive<number | undefined, number | undefined>(
 			this.definition.id,
 			this._primitiveCache,
@@ -558,6 +608,10 @@ export class McpServer extends Disposable implements IMcpServer {
 			(entry) => entry,
 			undefined,
 		);
+
+		// Hold the prefix for the lifetime of the server so its tool name stays
+		// stable even when no one is currently observing the tools list.
+		prefixRef.recomputeInitiallyAndOnChange(this._store);
 	}
 
 	public readDefinitions(): IObservable<{ server: McpServerDefinition | undefined; collection: McpCollectionDefinition | undefined }> {

--- a/src/vs/workbench/contrib/mcp/common/mcpServer.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpServer.ts
@@ -241,8 +241,12 @@ export class McpPrefixGenerator {
 		bucket.usedIndexes.add(index);
 		bucket.size++;
 
-		const base = McpToolName.Prefix + safeName;
-		const prefix = index === 1 ? base + '_' : base + index + '_';
+		// Trim safeName for this output if a multi-digit suffix would push us past
+		// MaxPrefixLen. The bucket is keyed on the un-trimmed safeName so collisions
+		// are still detected consistently across indexes.
+		const suffix = (index === 1 ? '' : String(index)) + '_';
+		const maxNameLen = McpToolName.MaxPrefixLen - McpToolName.Prefix.length - suffix.length;
+		const prefix = McpToolName.Prefix + safeName.slice(0, maxNameLen) + suffix;
 
 		return {
 			object: prefix,

--- a/src/vs/workbench/contrib/mcp/common/mcpService.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpService.ts
@@ -16,11 +16,11 @@ import { IStorageService, StorageScope } from '../../../../platform/storage/comm
 import { ContributionEnablementState, EnablementModel, IEnablementModel, isContributionEnabled } from '../../chat/common/enablement.js';
 import { McpCollisionBehavior, mcpServerCollisionBehaviorSection } from './mcpConfiguration.js';
 import { IMcpRegistry } from './mcpRegistryTypes.js';
-import { McpServer, McpServerMetadataCache } from './mcpServer.js';
-import { IAutostartResult, IMcpServer, IMcpService, McpCollectionDefinition, McpConnectionState, McpDefinitionReference, McpServerCacheState, McpServerDefinition, McpStartServerInteraction, McpToolName, UserInteractionRequiredError } from './mcpTypes.js';
+import { McpPrefixGenerator, McpServer, McpServerMetadataCache } from './mcpServer.js';
+import { IAutostartResult, IMcpServer, IMcpService, McpCollectionDefinition, McpConnectionState, McpDefinitionReference, McpServerCacheState, McpServerDefinition, McpStartServerInteraction, UserInteractionRequiredError } from './mcpTypes.js';
 import { startServerAndWaitForLiveTools } from './mcpTypesUtils.js';
 
-type IMcpServerRec = { object: IMcpServer; toolPrefix: string };
+type IMcpServerRec = { object: IMcpServer };
 
 export class McpService extends Disposable implements IMcpService {
 
@@ -29,6 +29,8 @@ export class McpService extends Disposable implements IMcpService {
 	private readonly _currentAutoStarts = new Set<CancellationTokenSource>();
 	private readonly _servers = observableValue<readonly IMcpServerRec[]>(this, []);
 	public readonly servers: IObservable<readonly IMcpServer[]> = this._servers.map(servers => servers.map(s => s.object));
+
+	private readonly _prefixGenerator = new McpPrefixGenerator();
 
 	public get lazyCollectionState() { return this._mcpRegistry.lazyCollectionState; }
 
@@ -174,11 +176,9 @@ export class McpService extends Disposable implements IMcpService {
 	}
 
 	public updateCollectedServers() {
-		const prefixGenerator = new McpPrefixGenerator();
 		const definitions = this._mcpRegistry.collections.get().flatMap(collectionDefinition =>
 			collectionDefinition.serverDefinitions.get().map(serverDefinition => {
-				const toolPrefix = prefixGenerator.generate(serverDefinition.label);
-				return { serverDefinition, collectionDefinition, toolPrefix };
+				return { serverDefinition, collectionDefinition };
 			})
 		);
 
@@ -198,7 +198,7 @@ export class McpService extends Disposable implements IMcpService {
 
 		// Transfer over any servers that are still valid.
 		for (const server of currentServers) {
-			const match = definitions.find(d => defsEqual(server.object, d) && server.toolPrefix === d.toolPrefix);
+			const match = definitions.find(d => defsEqual(server.object, d));
 			if (match) {
 				pushMatch(match, server);
 			} else {
@@ -215,11 +215,11 @@ export class McpService extends Disposable implements IMcpService {
 				def.serverDefinition.roots,
 				!!def.collectionDefinition.lazy,
 				def.collectionDefinition.scope === StorageScope.WORKSPACE ? this.workspaceCache : this.userCache,
-				def.toolPrefix,
+				this._prefixGenerator,
 				this.enablementModel,
 			);
 
-			nextServers.push({ object, toolPrefix: def.toolPrefix });
+			nextServers.push({ object });
 		}
 
 		transaction(tx => {
@@ -235,21 +235,6 @@ export class McpService extends Disposable implements IMcpService {
 
 function defsEqual(server: IMcpServer, def: { serverDefinition: McpServerDefinition; collectionDefinition: McpCollectionDefinition }) {
 	return server.collection.id === def.collectionDefinition.id && server.definition.id === def.serverDefinition.id;
-}
-
-// Helper class for generating unique MCP tool prefixes
-class McpPrefixGenerator {
-	private readonly seenPrefixes = new Set<string>();
-
-	generate(label: string): string {
-		const baseToolPrefix = McpToolName.Prefix + label.toLowerCase().replace(/[^a-z0-9_.-]+/g, '_').slice(0, McpToolName.MaxPrefixLen - McpToolName.Prefix.length - 1);
-		let toolPrefix = baseToolPrefix + '_';
-		for (let i = 2; this.seenPrefixes.has(toolPrefix); i++) {
-			toolPrefix = baseToolPrefix + i + '_';
-		}
-		this.seenPrefixes.add(toolPrefix);
-		return toolPrefix;
-	}
 }
 
 /**

--- a/src/vs/workbench/contrib/mcp/test/common/mcpPrefixGenerator.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpPrefixGenerator.test.ts
@@ -1,0 +1,99 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { McpPrefixGenerator } from '../../common/mcpServer.js';
+import { McpToolName } from '../../common/mcpTypes.js';
+
+suite('McpPrefixGenerator', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('basic prefix uses mcp_ + safe lower-case name', () => {
+		const gen = new McpPrefixGenerator();
+		const ref = gen.take('Context7');
+		assert.strictEqual(ref.object, `${McpToolName.Prefix}context7_`);
+		ref.dispose();
+	});
+
+	test('registry-style names are normalized so context is preserved', () => {
+		const gen = new McpPrefixGenerator();
+		// Used to truncate to `mcp_io_github_ups_` (see #299749). With the announced
+		// title (e.g. "Context7") it now starts from a clean short name.
+		const refLong = gen.take('io.github.upstash/context7');
+		assert.ok(refLong.object.startsWith(McpToolName.Prefix));
+		assert.ok(refLong.object.length <= McpToolName.MaxPrefixLen);
+		refLong.dispose();
+
+		const refTitle = gen.take('Context7');
+		assert.strictEqual(refTitle.object, `${McpToolName.Prefix}context7_`);
+		refTitle.dispose();
+	});
+
+	test('collisions add numeric suffixes', () => {
+		const gen = new McpPrefixGenerator();
+		const a = gen.take('foo');
+		const b = gen.take('foo');
+		const c = gen.take('foo');
+		assert.strictEqual(a.object, `${McpToolName.Prefix}foo_`);
+		assert.strictEqual(b.object, `${McpToolName.Prefix}foo2_`);
+		assert.strictEqual(c.object, `${McpToolName.Prefix}foo3_`);
+		a.dispose();
+		b.dispose();
+		c.dispose();
+	});
+
+	test('dispose releases the slot and the next take reuses the lowest index', () => {
+		const gen = new McpPrefixGenerator();
+		const a = gen.take('foo');
+		const b = gen.take('foo');
+		const c = gen.take('foo');
+		assert.strictEqual(b.object, `${McpToolName.Prefix}foo2_`);
+
+		b.dispose();
+		const d = gen.take('foo');
+		assert.strictEqual(d.object, `${McpToolName.Prefix}foo2_`, 'reuses freed slot');
+
+		a.dispose();
+		c.dispose();
+		d.dispose();
+	});
+
+	test('disposing only consumer cleans up the bucket so the next take starts at index 1', () => {
+		const gen = new McpPrefixGenerator();
+		const a = gen.take('foo');
+		const b = gen.take('foo');
+		a.dispose();
+		b.dispose();
+
+		const c = gen.take('foo');
+		assert.strictEqual(c.object, `${McpToolName.Prefix}foo_`);
+		c.dispose();
+	});
+
+	test('different names live in independent buckets', () => {
+		const gen = new McpPrefixGenerator();
+		const a = gen.take('foo');
+		const b = gen.take('bar');
+		assert.strictEqual(a.object, `${McpToolName.Prefix}foo_`);
+		assert.strictEqual(b.object, `${McpToolName.Prefix}bar_`);
+		a.dispose();
+		b.dispose();
+	});
+
+	test('names are sanitized and lower-cased the same way before bucketing', () => {
+		const gen = new McpPrefixGenerator();
+		const a = gen.take('My Server');
+		const b = gen.take('my server');
+		const c = gen.take('my/server');
+		// All collapse to the same safe name `my_server`, so they collide.
+		assert.strictEqual(a.object, `${McpToolName.Prefix}my_server_`);
+		assert.strictEqual(b.object, `${McpToolName.Prefix}my_server2_`);
+		assert.strictEqual(c.object, `${McpToolName.Prefix}my_server3_`);
+		a.dispose();
+		b.dispose();
+		c.dispose();
+	});
+});

--- a/src/vs/workbench/contrib/mcp/test/common/mcpPrefixGenerator.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpPrefixGenerator.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
+import { IReference } from '../../../../../base/common/lifecycle.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { McpPrefixGenerator } from '../../common/mcpServer.js';
 import { McpToolName } from '../../common/mcpTypes.js';
@@ -18,18 +19,15 @@ suite('McpPrefixGenerator', () => {
 		ref.dispose();
 	});
 
-	test('registry-style names are normalized so context is preserved', () => {
+	test('long registry-style names are clamped to MaxPrefixLen', () => {
 		const gen = new McpPrefixGenerator();
-		// Used to truncate to `mcp_io_github_ups_` (see #299749). With the announced
-		// title (e.g. "Context7") it now starts from a clean short name.
-		const refLong = gen.take('io.github.upstash/context7');
-		assert.ok(refLong.object.startsWith(McpToolName.Prefix));
-		assert.ok(refLong.object.length <= McpToolName.MaxPrefixLen);
-		refLong.dispose();
-
-		const refTitle = gen.take('Context7');
-		assert.strictEqual(refTitle.object, `${McpToolName.Prefix}context7_`);
-		refTitle.dispose();
+		// Repro for #299749: a long registry-style key should at least produce a
+		// valid (length-bounded) prefix. The actual readability fix comes from
+		// callers taking with the announced server title instead of this key.
+		const ref = gen.take('io.github.upstash/context7');
+		assert.ok(ref.object.startsWith(McpToolName.Prefix));
+		assert.ok(ref.object.length <= McpToolName.MaxPrefixLen);
+		ref.dispose();
 	});
 
 	test('collisions add numeric suffixes', () => {
@@ -95,5 +93,26 @@ suite('McpPrefixGenerator', () => {
 		a.dispose();
 		b.dispose();
 		c.dispose();
+	});
+
+	test('prefix length never exceeds MaxPrefixLen, including for multi-digit collision suffixes', () => {
+		const gen = new McpPrefixGenerator();
+		// Pick a name that, once sanitized, sits right at the per-bucket length cap
+		// so that adding a numeric suffix would otherwise blow past MaxPrefixLen.
+		const longName = 'a'.repeat(McpToolName.MaxPrefixLen);
+		const refs: IReference<string>[] = [];
+		for (let i = 0; i < 12; i++) {
+			refs.push(gen.take(longName));
+		}
+		for (const ref of refs) {
+			assert.ok(ref.object.startsWith(McpToolName.Prefix));
+			assert.ok(ref.object.endsWith('_'));
+			assert.ok(ref.object.length <= McpToolName.MaxPrefixLen, `prefix ${ref.object} (length ${ref.object.length}) exceeds MaxPrefixLen ${McpToolName.MaxPrefixLen}`);
+		}
+		// All 12 must be unique so they remain distinguishable.
+		assert.strictEqual(new Set(refs.map(r => r.object)).size, refs.length);
+		for (const ref of refs) {
+			ref.dispose();
+		}
 	});
 });


### PR DESCRIPTION
mcp: prefer announced server title for tool prefixes and picker labels

Reworks how MCP tool prefixes are generated and how MCP servers are labelled
in the Configure Tools picker so that the server-announced `serverInfo.title`
(falling back to `serverInfo.name`) is preferred over the mcp.json key.

- Introduces a shared `McpPrefixGenerator` with a `take(name): IReference<string>`
  API that hands out collision-resolved tool prefixes and releases them on
  dispose. Replaces the eager one-shot generator that used to live in
  McpService.
- McpServer now derives its tool prefix from its preferred name (announced
  title when known, otherwise the mcp.json label) so registry-style names
  like `io.github.upstash/context7` no longer end up as truncated
  `mcp_io_github_ups_*` prefixes.
- Configure Tools picker and `ToolDataSource.classify` for MCP sources now
  prefer `serverLabel` (the announced title) over `label`.
- Adds unit tests for `McpPrefixGenerator` covering collisions, slot reuse on
  dispose, bucket cleanup, and name sanitization.

Fixes https://github.com/microsoft/vscode/issues/299749
Fixes https://github.com/microsoft/vscode/issues/299787

(Commit message generated by Copilot)
