### PR TITLE
Read cloud_session_storage_enabled from /copilot_internal/user instead of /v2/token

### DIFF
--- a/src/vs/base/common/defaultAccount.ts
+++ b/src/vs/base/common/defaultAccount.ts
@@ -39,6 +39,7 @@ export interface IEntitlementsData extends ILegacyQuotaSnapshotData {
 	readonly quota_reset_date_utc?: string; 	// for all other Copilot SKUs (includes time)
 	readonly token_based_billing?: boolean;
 	readonly can_upgrade_plan?: boolean;
+	readonly cloud_session_storage_enabled?: boolean;
 	readonly quota_snapshots?: {
 		chat?: IQuotaSnapshotData;
 		completions?: IQuotaSnapshotData;

--- a/src/vs/workbench/services/accounts/browser/defaultAccount.ts
+++ b/src/vs/workbench/services/accounts/browser/defaultAccount.ts
@@ -552,12 +552,15 @@ class DefaultAccountProvider extends Disposable implements IDefaultAccountProvid
 			const tokenEntitlementsFetchedAt: number | undefined = tokenEntitlementsResult?.fetchedAt;
 			let mcpRegistryDataFetchedAt: number | undefined;
 			let policyData: Mutable<IPolicyData> | undefined = accountPolicyData?.policyData ? { ...accountPolicyData.policyData } : undefined;
+			if (entitlementsData) {
+				policyData = policyData ?? {};
+				policyData.cloud_session_storage_enabled = entitlementsData.cloud_session_storage_enabled;
+			}
 			if (tokenEntitlementsResult?.data) {
 				const tokenEntitlementsData = tokenEntitlementsResult.data;
 				policyData = policyData ?? {};
 				policyData.chat_agent_enabled = tokenEntitlementsData.policyData.chat_agent_enabled;
 				policyData.chat_preview_features_enabled = tokenEntitlementsData.policyData.chat_preview_features_enabled;
-				policyData.cloud_session_storage_enabled = tokenEntitlementsData.policyData.cloud_session_storage_enabled;
 				policyData.mcp = tokenEntitlementsData.policyData.mcp;
 				if (policyData.mcp) {
 					const mcpRegistryResult = await this.getMcpRegistryProvider(sessions, accountPolicyData, options);
@@ -679,8 +682,6 @@ class DefaultAccountProvider extends Disposable implements IDefaultAccountProvid
 						chat_agent_enabled: tokenMap.get('agent_mode') !== '0',
 						// MCP is only enabled if the flag is explicitly present and set to 1
 						mcp: tokenMap.get('mcp') === '1',
-						// Cloud session storage policy boolean from Copilot token; undefined when not present
-						cloud_session_storage_enabled: tokenMap.has('cloud_session_storage_enabled') ? tokenMap.get('cloud_session_storage_enabled') === '1' : undefined,
 					},
 					copilotTokenInfo: {
 						sn: tokenMap.get('sn'),


### PR DESCRIPTION
Moves the source of the `cloud_session_storage_enabled` policy flag from the Copilot `/v2/token` endpoint to the `/copilot_internal/user` (entitlements) endpoint, matching the server team's contract.