### PR TITLE
Mobile chat (3/10): code-block overlay + pull-down dismiss + edge-swipe + a11y dialog

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -12,8 +12,6 @@
 		"--vscode-activityBarBadge-background",
 		"--vscode-activityBarBadge-foreground",
 		"--vscode-activityBarTop-activeBackground",
-		"--vscode-activeSessionView-background",
-		"--vscode-activeSessionView-foreground",
 		"--vscode-activityBarTop-activeBorder",
 		"--vscode-activityBarTop-background",
 		"--vscode-activityBarTop-dropBorder",
@@ -27,8 +25,6 @@
 		"--vscode-agentSessionReadIndicator-foreground",
 		"--vscode-agentSessionSelectedBadge-border",
 		"--vscode-agentSessionSelectedUnfocusedBadge-border",
-		"--vscode-inactiveSessionView-background",
-		"--vscode-inactiveSessionView-foreground",
 		"--vscode-agentStatusIndicator-background",
 		"--vscode-badge-background",
 		"--vscode-badge-foreground",
@@ -951,8 +947,6 @@
 		"--mobile-diff-tok-keyword",
 		"--mobile-diff-tok-number",
 		"--chat-editing-last-edit-shift",
-		"--session-view-background",
-		"--session-view-foreground",
 		"--chat-current-response-min-height",
 		"--chat-smooth-delay",
 		"--chat-smooth-duration",
@@ -1081,9 +1075,6 @@
 		"--slide-from-y"
 	],
 	"sizes": [
-		"--vscode-agents-fontWeight-medium",
-		"--vscode-agents-fontWeight-regular",
-		"--vscode-agents-fontWeight-semiBold",
 		"--vscode-agents-fontSize-body1",
 		"--vscode-agents-fontSize-body2",
 		"--vscode-agents-fontSize-heading1",
@@ -1093,6 +1084,9 @@
 		"--vscode-agents-fontSize-label2",
 		"--vscode-agents-fontSize-label3",
 		"--vscode-agents-fontSize-label4",
+		"--vscode-agents-fontWeight-medium",
+		"--vscode-agents-fontWeight-regular",
+		"--vscode-agents-fontWeight-semiBold",
 		"--vscode-bodyFontSize",
 		"--vscode-bodyFontSize-small",
 		"--vscode-bodyFontSize-xSmall",
@@ -1104,6 +1098,7 @@
 		"--vscode-cornerRadius-small",
 		"--vscode-cornerRadius-xLarge",
 		"--vscode-cornerRadius-xSmall",
+		"--vscode-keyboard-height",
 		"--vscode-strokeThickness"
 	]
 }

--- a/src/vs/sessions/browser/media/style.css
+++ b/src/vs/sessions/browser/media/style.css
@@ -997,3 +997,122 @@
 		opacity: 1;
 	}
 }
+
+/* -----------------------------------------------------------------------------
+ * Phone Layout: Accessibility Help Dialog
+ *
+ * The accessibility help dialog (Alt+F1) renders through `IAccessibleViewService`
+ * as a context view popup. The desktop chrome (`.accessible-view`) is a small
+ * floating widget anchored under the quickPickTop offset. On phone viewports
+ * we promote it to a full-viewport sheet so the help content is readable on
+ * narrow screens, and we present the existing toolbar close action as a 44px
+ * hit target in the top-right corner.
+ *
+ * This is a CSS-only retarget — the workbench accessible-view widget itself
+ * is untouched. We override layout, sizing, and font scale through descendant
+ * selectors scoped to `.agent-sessions-workbench.phone-layout`.
+ * -------------------------------------------------------------------------- */
+
+.agent-sessions-workbench.phone-layout .context-view:has(.accessible-view-container) {
+position: fixed !important;
+inset: 0 !important;
+width: 100vw !important;
+height: 100dvh !important;
+z-index: 2600;
+display: flex;
+flex-direction: column;
+}
+
+/* Full-viewport backdrop so taps outside the dialog don't fall through to
+ * the workbench. The accessible-view dismisses itself on Escape; the close
+ * action in the toolbar is the primary touch affordance.
+ */
+.agent-sessions-workbench.phone-layout .context-view:has(.accessible-view-container)::before {
+content: '';
+position: fixed;
+inset: 0;
+background: var(--vscode-editor-background, #1e1e1e);
+z-index: -1;
+}
+
+.agent-sessions-workbench.phone-layout .accessible-view-container {
+position: static !important;
+width: 100vw !important;
+height: 100dvh !important;
+max-width: none !important;
+max-height: none !important;
+margin: 0 !important;
+box-sizing: border-box;
+display: flex;
+flex-direction: column;
+padding-top: env(safe-area-inset-top);
+padding-bottom: env(safe-area-inset-bottom);
+padding-left: env(safe-area-inset-left);
+padding-right: env(safe-area-inset-right);
+}
+
+.agent-sessions-workbench.phone-layout .accessible-view {
+position: static !important;
+flex: 1 1 auto;
+width: 100% !important;
+height: 100% !important;
+box-shadow: none !important;
+border: none !important;
+border-radius: 0 !important;
+margin: 0 !important;
+display: flex;
+flex-direction: column;
+background-color: var(--vscode-editor-background);
+}
+
+.agent-sessions-workbench.phone-layout .accessible-view-title-bar {
+flex: 0 0 auto;
+min-height: 56px;
+padding: 0 8px;
+gap: 8px;
+display: flex;
+align-items: center;
+background: var(--vscode-editor-background);
+border-bottom: 1px solid var(--vscode-panel-border, transparent);
+}
+
+.agent-sessions-workbench.phone-layout .accessible-view-title {
+font-size: 16px;
+font-weight: 500;
+text-align: left;
+padding: 0 4px;
+}
+
+/* Promote toolbar buttons (including the close "X") to 44px hit targets so
+ * they meet the touch-target accessibility requirement. The existing toolbar
+ * exposes a Dispose / Close action; we make sure it's visibly large enough.
+ */
+.agent-sessions-workbench.phone-layout .accessible-view-action-bar {
+flex: 0 0 auto;
+margin-right: 0 !important;
+}
+
+.agent-sessions-workbench.phone-layout .accessible-view-action-bar .action-item {
+min-width: 44px;
+min-height: 44px;
+}
+
+.agent-sessions-workbench.phone-layout .accessible-view-action-bar .action-item > .action-label {
+min-width: 44px;
+min-height: 44px;
+display: inline-flex;
+align-items: center;
+justify-content: center;
+}
+
+/* Body editor: bump base font to 16px so text is legible on phone and let
+ * the editor consume the remaining viewport with smooth touch scrolling. */
+.agent-sessions-workbench.phone-layout .accessible-view > .monaco-editor,
+.agent-sessions-workbench.phone-layout .accessible-view .monaco-editor .view-lines {
+font-size: 16px !important;
+line-height: 1.5;
+}
+
+.agent-sessions-workbench.phone-layout .accessible-view .monaco-scrollable-element {
+-webkit-overflow-scrolling: touch;
+}

--- a/src/vs/sessions/browser/parts/mobile/contributions/media/mobileOverlayViews.css
+++ b/src/vs/sessions/browser/parts/mobile/contributions/media/mobileOverlayViews.css
@@ -68,12 +68,6 @@
 	justify-content: center;
 }
 
-.mobile-overlay-header-info.inline {
-	flex-direction: row;
-	align-items: baseline;
-	gap: 8px;
-}
-
 .mobile-overlay-header-title {
 	font-size: 14px;
 	font-weight: 500;
@@ -279,8 +273,8 @@
 .mobile-diff-hunk-header {
 	display: block;
 	color: var(--vscode-descriptionForeground);
-	background: var(--vscode-editor-background, #1e1e1e);
-	padding: 4px 12px;
+	background: color-mix(in srgb, var(--vscode-foreground) 6%, transparent);
+	padding: 4px 16px;
 	font-size: 11px;
 	user-select: none;
 	-webkit-user-select: none;
@@ -308,20 +302,19 @@
 
 .mobile-diff-line-num {
 	flex-shrink: 0;
-	width: 28px;
-	padding: 0 4px;
+	width: 40px;
+	padding: 0 8px;
 	color: var(--vscode-editorLineNumber-foreground);
 	text-align: right;
 	user-select: none;
 	-webkit-user-select: none;
-	font-variant-numeric: tabular-nums;
 }
 
 .mobile-diff-gutter {
 	flex-shrink: 0;
-	width: 14px;
+	width: 16px;
 	text-align: center;
-	padding: 0;
+	padding: 0 2px;
 	user-select: none;
 	-webkit-user-select: none;
 }
@@ -338,7 +331,7 @@
 	 * token color CSS automatically.
 	 */
 	flex: 0 0 auto;
-	padding: 0 16px 0 2px;
+	padding: 0 16px 0 4px;
 	user-select: text;
 	-webkit-user-select: text;
 	white-space: pre;
@@ -579,4 +572,115 @@
 
 .mobile-changes-row-removed {
 	color: var(--vscode-agentsMobileDiff-deletedForeground);
+}
+
+/* -- Code-block overlay (chat tap-to-expand) ----------------------------- */
+
+.mobile-codeblock-overlay-header-trailing {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	flex-shrink: 0;
+	padding-right: 4px;
+}
+
+.mobile-codeblock-overlay-copy-btn {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	height: 36px;
+	min-width: 44px;
+	padding: 0 10px;
+	border: none;
+	background: none;
+	color: var(--vscode-foreground);
+	cursor: pointer;
+	border-radius: 4px;
+	font-size: 13px;
+	white-space: nowrap;
+	touch-action: manipulation;
+}
+
+.mobile-codeblock-overlay-copy-btn:active {
+	background: var(--vscode-toolbar-hoverBackground);
+}
+
+.mobile-codeblock-overlay-copy-btn .copy-btn-label {
+	font-size: 13px;
+	color: var(--vscode-foreground);
+}
+
+.mobile-codeblock-overlay-copied-badge {
+	display: inline-flex;
+	align-items: center;
+	padding: 2px 8px;
+	border-radius: 10px;
+	font-size: 11px;
+	font-weight: 500;
+	background-color: color-mix(in srgb, var(--vscode-testing-iconPassed) 20%, transparent);
+	color: var(--vscode-testing-iconPassed);
+	white-space: nowrap;
+}
+
+.mobile-codeblock-overlay-pre {
+	/*
+	 * `<pre>` carries margin/padding by default — strip it so the
+	 * `mobile-overlay-scroll` container owns the spacing and the code
+	 * aligns with the diff view's hunk content.
+	 *
+	 * `min-width: max-content` + `white-space: pre` pairs with the
+	 * parent's `overflow-x: auto` so long lines become horizontally
+	 * scrollable instead of clipping at the viewport width — same
+	 * treatment as `.mobile-diff-output`.
+	 */
+	margin: 0;
+	padding: 12px 16px;
+	font-family: var(--monaco-monospace-font, 'SF Mono', Menlo, Monaco, Consolas, monospace);
+	font-size: 13px;
+	line-height: 1.5;
+	white-space: pre;
+	min-width: max-content;
+	color: var(--vscode-editor-foreground, var(--vscode-foreground));
+	user-select: text;
+	-webkit-user-select: text;
+	box-sizing: border-box;
+}
+
+.mobile-codeblock-overlay-code {
+	font-family: inherit;
+	font-size: inherit;
+	color: inherit;
+}
+
+/* -----------------------------------------------------------------------------
+ * Pull-down dismiss affordance.
+ *
+ * The header acts as a drag handle. We surface a small grab pill via a
+ * `::before` pseudo-element so users see the affordance, and we set
+ * `touch-action: pan-x` so vertical drags are claimed by the JS gesture
+ * helper (`installPulldownDismiss`) and not by native scroll.
+ *
+ * Existing horizontal interactions inside the header (back-button presses,
+ * chevron taps) stay responsive because:
+ *  - The pseudo-element does not intercept events (`pointer-events: none`).
+ *  - The gesture helper applies a small dead-zone before claiming the
+ *    pointer and only commits on dominant downward motion.
+ * -------------------------------------------------------------------------- */
+
+.mobile-overlay-header {
+position: relative;
+touch-action: pan-x;
+}
+
+.mobile-overlay-header::before {
+content: '';
+position: absolute;
+top: calc(env(safe-area-inset-top) + 4px);
+left: 50%;
+transform: translateX(-50%);
+width: 36px;
+height: 4px;
+border-radius: 2px;
+background: color-mix(in srgb, var(--vscode-foreground) 35%, transparent);
+pointer-events: none;
 }

--- a/src/vs/sessions/browser/parts/mobile/contributions/mobileChangesView.ts
+++ b/src/vs/sessions/browser/parts/mobile/contributions/mobileChangesView.ts
@@ -20,6 +20,7 @@ import { IInstantiationService } from '../../../../../platform/instantiation/com
 import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
 import { ISessionFileChange } from '../../../../services/sessions/common/session.js';
 import { IFileDiffViewData } from './mobileDiffView.js';
+import { installPulldownDismiss } from './mobilePulldownDismiss.js';
 
 const $ = DOM.$;
 
@@ -173,6 +174,11 @@ export class MobileChangesView extends Disposable {
 		this.emptyEl = DOM.append(body, $('div.mobile-overlay-empty-state'));
 		this.emptyEl.style.display = 'none';
 		this.emptyEl.textContent = localize('changesView.empty', "No changes in this session yet.");
+
+		// Pull-down dismiss on the header drag handle. Back-button taps
+		// still work normally — only downward drags past a small dead
+		// zone are claimed by the gesture.
+		this.viewStore.add(installPulldownDismiss(overlay, header, () => this.dispose()));
 
 		// -- Subscribe to live changes -----------------------------
 		this.viewStore.add(autorun(reader => {

--- a/src/vs/sessions/browser/parts/mobile/contributions/mobileDiffView.ts
+++ b/src/vs/sessions/browser/parts/mobile/contributions/mobileDiffView.ts
@@ -17,48 +17,12 @@ import { URI } from '../../../../../base/common/uri.js';
 import { basename } from '../../../../../base/common/resources.js';
 import { linesDiffComputers } from '../../../../../editor/common/diff/linesDiffComputers.js';
 import { ILanguageService } from '../../../../../editor/common/languages/language.js';
-import { tokenizeToString } from '../../../../../editor/common/languages/textToHtmlTokenizer.js';
 import { TokenizationRegistry } from '../../../../../editor/common/languages.js';
 import { generateTokensCSSForColorMap } from '../../../../../editor/common/languages/supports/tokenization.js';
+import { EXTENSION_LANGUAGE_MAP, hasMultipleTokenClasses, regexTokenizeLines, tokenizeFileLines } from './mobileSyntaxHighlight.js';
+import { installPulldownDismiss } from './mobilePulldownDismiss.js';
 
 const $ = DOM.$;
-
-/** Hardcoded extension→languageId fallback for common languages.
- *
- * The agents window does not load language services / built-in language
- * extensions yet, so `ILanguageService.guessLanguageIdByFilepathOrFirstLine`
- * returns `'unknown'` for everything except a small core set. Once the
- * agents window starts loading language services this map becomes a
- * pure fallback for the leftover `'unknown'` cases. The IDs match
- * VS Code's built-in extension `package.json` contributions. */
-const EXTENSION_LANGUAGE_MAP: Record<string, string> = {
-	'.js': 'javascript', '.mjs': 'javascript', '.cjs': 'javascript',
-	'.jsx': 'javascriptreact',
-	'.ts': 'typescript', '.mts': 'typescript', '.cts': 'typescript',
-	'.tsx': 'typescriptreact',
-	'.py': 'python', '.pyw': 'python',
-	'.java': 'java',
-	'.c': 'c', '.h': 'c',
-	'.cpp': 'cpp', '.cc': 'cpp', '.cxx': 'cpp', '.hpp': 'cpp',
-	'.cs': 'csharp',
-	'.go': 'go',
-	'.rs': 'rust',
-	'.rb': 'ruby',
-	'.php': 'php',
-	'.html': 'html', '.htm': 'html',
-	'.css': 'css', '.scss': 'scss', '.less': 'less',
-	'.json': 'json', '.jsonc': 'jsonc',
-	'.md': 'markdown',
-	'.sh': 'shellscript', '.bash': 'shellscript', '.zsh': 'shellscript',
-	'.yaml': 'yaml', '.yml': 'yaml',
-	'.xml': 'xml',
-	'.sql': 'sql',
-	'.swift': 'swift',
-	'.kt': 'kotlin', '.kts': 'kotlin',
-	'.r': 'r',
-	'.lua': 'lua',
-	'.dart': 'dart',
-};
 
 /**
  * Command ID for opening the {@link MobileDiffView}.
@@ -177,11 +141,12 @@ export class MobileDiffView extends Disposable {
 		const backBtn = DOM.append(header, $('button.mobile-overlay-back-btn', { type: 'button' })) as HTMLButtonElement;
 		backBtn.setAttribute('aria-label', localize('diffView.back', "Back"));
 		DOM.append(backBtn, $('span')).classList.add(...ThemeIcon.asClassNameArray(Codicon.chevronLeft));
+		DOM.append(backBtn, $('span.back-btn-label')).textContent = localize('diffView.backLabel', "Back");
 		this.viewStore.add(Gesture.addTarget(backBtn));
 		this.viewStore.add(DOM.addDisposableListener(backBtn, DOM.EventType.CLICK, () => this.dispose()));
 		this.viewStore.add(DOM.addDisposableListener(backBtn, TouchEventType.Tap, () => this.dispose()));
 
-		const info = DOM.append(header, $('div.mobile-overlay-header-info.inline'));
+		const info = DOM.append(header, $('div.mobile-overlay-header-info'));
 		this.titleEl = DOM.append(info, $('div.mobile-overlay-header-title'));
 		this.subtitleEl = DOM.append(info, $('div.mobile-overlay-header-subtitle'));
 
@@ -217,6 +182,11 @@ export class MobileDiffView extends Disposable {
 		// wrapper so vertical scrolling continues to work normally; the
 		// gesture only activates when horizontal motion clearly dominates.
 		this.viewStore.add(this.attachSwipeNavigation(this.scrollWrapper));
+
+		// Pull-down dismiss on the header drag handle. Only downward
+		// drags past a small dead-zone are claimed; back-button and
+		// chevron taps continue to work normally.
+		this.viewStore.add(installPulldownDismiss(overlay, header, () => this.dispose()));
 	}
 
 	private attachSwipeNavigation(target: HTMLElement): { dispose(): void } {
@@ -491,228 +461,6 @@ export class MobileDiffView extends Disposable {
 		this.viewStore.dispose();
 		super.dispose();
 	}
-}
-
-// -- Tokenization helpers -----------------------------------------------------
-
-/**
- * Tokenize a full text and return the per-line HTML (one entry per
- * source line, in order). Uses `tokenizeToString` which awaits
- * `TokenizationRegistry.getOrCreate(languageId)` — without that, sync
- * tokenization returns null highlighting for any language whose
- * textmate grammar hasn't been activated yet (common in agents
- * workbench, where no editor has opened the file).
- *
- * Tokenization runs over the whole text so state (open string,
- * template literal, block comment) propagates correctly across lines.
- */
-async function tokenizeFileLines(languageService: ILanguageService, text: string, languageId: string): Promise<string[]> {
-	if (!text) {
-		return [''];
-	}
-	const html = await tokenizeToString(languageService, text, languageId);
-	const inner = stripTokenizedWrapper(html);
-	// `_tokenizeToString` separates lines with `<br/>` (no closing tag,
-	// always lower-case in the upstream implementation). Splitting on
-	// the literal preserves the inner `<span class="mtkN">…</span>`
-	// markup that gives us the syntax-highlight colours.
-	return inner.split('<br/>');
-}
-
-/**
- * `tokenizeToString` returns HTML wrapped in
- * `<div class="monaco-tokenized-source">…</div>`. We render per-line into
- * an inline `<span>`, so we strip the wrapper and keep just the inner
- * `<span class="mtkN">` token spans.
- */
-function stripTokenizedWrapper(html: string): string {
-	const openTag = '<div class="monaco-tokenized-source">';
-	const closeTag = '</div>';
-	if (html.startsWith(openTag) && html.endsWith(closeTag)) {
-		return html.slice(openTag.length, html.length - closeTag.length);
-	}
-	return html;
-}
-
-/**
- * Returns true when the Monaco tokenizer produced real syntax tokens,
- * i.e. the HTML contains more than just `mtk1` class spans. When the
- * TextMate grammar for the language isn't loaded (common on the agents
- * workbench which doesn't load built-in language extensions), every
- * token falls back to `mtk1` (default foreground).
- */
-function hasMultipleTokenClasses(lines: readonly string[]): boolean {
-	for (const line of lines) {
-		if (line && /class="mtk[2-9]|class="mtk[1-9][0-9]/.test(line)) {
-			return true;
-		}
-	}
-	return false;
-}
-
-// -- Regex-based syntax highlighter ------------------------------------------
-// Used when the Monaco TextMate grammar isn't available (the agents window
-// doesn't load built-in language extensions yet; this fallback fires for any
-// language without a registered grammar). Produces CSS-class spans rather than
-// inline `style` spans so token colors adapt to the active theme without
-// needing to read any color map here. The classes (`mobile-diff-tok-comment`,
-// `mobile-diff-tok-string`, `mobile-diff-tok-keyword`, `mobile-diff-tok-number`)
-// are styled in `media/mobileOverlayViews.css` using per-theme CSS variables
-// defined against the `.vs`, `.hc-black`, and `.hc-light` body class selectors,
-// keeping all theme-specific values in the stylesheet rather than in JS.
-type RegexTokenKind = 'comment' | 'string' | 'keyword' | 'number' | 'default';
-
-interface IRegexToken {
-	start: number;
-	end: number;
-	kind: RegexTokenKind;
-}
-
-type LangFamily = 'js' | 'python' | 'css' | 'html' | 'json' | 'shell' | 'generic';
-
-const LANG_FAMILY: Record<string, LangFamily> = {
-	javascript: 'js', javascriptreact: 'js',
-	typescript: 'js', typescriptreact: 'js',
-	java: 'js', csharp: 'js', go: 'js', rust: 'js',
-	cpp: 'js', c: 'js', swift: 'js', kotlin: 'js', dart: 'js', php: 'js', ruby: 'js',
-	python: 'python',
-	css: 'css', scss: 'css', less: 'css',
-	html: 'html', xml: 'html',
-	json: 'json', jsonc: 'json',
-	shellscript: 'shell', powershell: 'shell',
-};
-
-const JS_KEYWORDS = new Set([
-	'break', 'case', 'catch', 'class', 'const', 'continue', 'debugger', 'default',
-	'delete', 'do', 'else', 'export', 'extends', 'false', 'finally', 'for',
-	'function', 'if', 'import', 'in', 'instanceof', 'let', 'new', 'null',
-	'of', 'return', 'static', 'super', 'switch', 'this', 'throw', 'true',
-	'try', 'typeof', 'undefined', 'var', 'void', 'while', 'with', 'yield',
-	'async', 'await', 'from', 'as', 'interface', 'type', 'enum', 'declare',
-	'abstract', 'override', 'readonly', 'namespace', 'module', 'public', 'private', 'protected',
-]);
-
-const PY_KEYWORDS = new Set([
-	'False', 'None', 'True', 'and', 'as', 'assert', 'async', 'await',
-	'break', 'class', 'continue', 'def', 'del', 'elif', 'else', 'except',
-	'finally', 'for', 'from', 'global', 'if', 'import', 'in', 'is',
-	'lambda', 'nonlocal', 'not', 'or', 'pass', 'raise', 'return',
-	'try', 'while', 'with', 'yield',
-]);
-
-function escapeHtml(s: string): string {
-	return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-}
-
-function buildSpan(kind: RegexTokenKind, text: string): string {
-	if (kind === 'default' || !text) {
-		return escapeHtml(text);
-	}
-	return `<span class="mobile-diff-tok-${kind}">${escapeHtml(text)}</span>`;
-}
-
-/** Tokenize a single line using simple regex rules. Returns HTML. */
-function regexTokenizeLine(line: string, lang: LangFamily): string {
-	const tokens: IRegexToken[] = [];
-	let pos = 0;
-	const len = line.length;
-
-	while (pos < len) {
-		let matched = false;
-
-		// Line comments
-		const commentPfx = lang === 'python' ? '#' : lang === 'shell' ? '#' : '//';
-		if (line.startsWith(commentPfx, pos) || (lang === 'generic' && line.startsWith('#', pos))) {
-			tokens.push({ start: pos, end: len, kind: 'comment' });
-			pos = len;
-			matched = true;
-		}
-
-		// Block comments /* ... */
-		if (!matched && lang !== 'python' && lang !== 'shell' && line.startsWith('/*', pos)) {
-			const end = line.indexOf('*/', pos + 2);
-			const tokenEnd = end === -1 ? len : end + 2;
-			tokens.push({ start: pos, end: tokenEnd, kind: 'comment' });
-			pos = tokenEnd;
-			matched = true;
-		}
-
-		// Template literals
-		if (!matched && (lang === 'js') && line[pos] === '`') {
-			let i = pos + 1;
-			while (i < len) {
-				if (line[i] === '\\') { i += 2; continue; }
-				if (line[i] === '`') { i++; break; }
-				i++;
-			}
-			tokens.push({ start: pos, end: i, kind: 'string' });
-			pos = i;
-			matched = true;
-		}
-
-		// Strings
-		if (!matched && (line[pos] === '"' || line[pos] === '\'')) {
-			const q = line[pos];
-			let i = pos + 1;
-			while (i < len) {
-				if (line[i] === '\\') { i += 2; continue; }
-				if (line[i] === q) { i++; break; }
-				i++;
-			}
-			tokens.push({ start: pos, end: i, kind: 'string' });
-			pos = i;
-			matched = true;
-		}
-
-		// Numbers
-		if (!matched && /[0-9]/.test(line[pos])) {
-			const m = line.slice(pos).match(/^0x[0-9a-fA-F]+|^[0-9]+\.?[0-9]*(?:[eE][+-]?[0-9]+)?/);
-			if (m) {
-				tokens.push({ start: pos, end: pos + m[0].length, kind: 'number' });
-				pos += m[0].length;
-				matched = true;
-			}
-		}
-
-		// Keywords and identifiers
-		if (!matched && /[a-zA-Z_$]/.test(line[pos])) {
-			const m = line.slice(pos).match(/^[a-zA-Z_$][a-zA-Z0-9_$]*/);
-			if (m) {
-				const word = m[0];
-				const keywords = lang === 'python' ? PY_KEYWORDS : JS_KEYWORDS;
-				const kind: RegexTokenKind = keywords.has(word) ? 'keyword' : 'default';
-				tokens.push({ start: pos, end: pos + word.length, kind });
-				pos += word.length;
-				matched = true;
-			}
-		}
-
-		if (!matched) {
-			// Advance one character (operator/punctuation/whitespace)
-			const prevTok = tokens[tokens.length - 1];
-			// Coalesce consecutive default-colored chars to avoid span bloat
-			if (prevTok && prevTok.kind === 'default') {
-				prevTok.end = pos + 1;
-			} else {
-				tokens.push({ start: pos, end: pos + 1, kind: 'default' });
-			}
-			pos++;
-		}
-	}
-
-	return tokens.map(t => buildSpan(t.kind, line.slice(t.start, t.end))).join('');
-}
-
-/**
- * Tokenize all lines of `text` using the regex highlighter.
- * Returns one HTML string per source line (same shape as `tokenizeFileLines`).
- */
-function regexTokenizeLines(text: string, languageId: string): string[] {
-	if (!text) {
-		return [''];
-	}
-	const lang: LangFamily = LANG_FAMILY[languageId] ?? 'generic';
-	return text.split(/\r?\n/).map(line => regexTokenizeLine(line, lang));
 }
 
 // -- Unified diff hunk rendering ---------------------------------------------

--- a/src/vs/sessions/browser/parts/mobile/contributions/mobilePulldownDismiss.ts
+++ b/src/vs/sessions/browser/parts/mobile/contributions/mobilePulldownDismiss.ts
@@ -1,0 +1,205 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DisposableStore, IDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
+import { addDisposableListener, EventType } from '../../../../../base/browser/dom.js';
+
+/**
+ * Vertical travel (in px) past which the gesture commits and the overlay
+ * is dismissed on `pointerup`.
+ */
+const COMMIT_THRESHOLD_PX = 120;
+
+/**
+ * Initial dead-zone (in px) before any visual feedback is applied. This
+ * keeps small accidental drags during taps on the back button or chevrons
+ * from briefly translating the overlay.
+ */
+const DEAD_ZONE_PX = 8;
+
+/**
+ * Velocity threshold (in px / ms) past which the gesture commits regardless
+ * of total travel — supports quick flick-down dismissal.
+ */
+const COMMIT_VELOCITY = 0.6;
+
+/**
+ * Animation duration (in ms) for the dismiss slide-down.
+ */
+const DISMISS_ANIM_MS = 250;
+
+/**
+ * Animation duration (in ms) for the snap-back when the gesture is
+ * abandoned without committing.
+ */
+const SNAP_BACK_ANIM_MS = 200;
+
+/**
+ * Installs a pull-down-to-dismiss gesture on a header element. While the
+ * user drags downward on `headerHandle`, `overlayRoot` follows the pointer
+ * via `transform: translateY()` and its opacity fades toward 0.5 of its
+ * original value. On `pointerup`:
+ *
+ * - Above {@link COMMIT_THRESHOLD_PX} of travel **or** flick velocity past
+ *   {@link COMMIT_VELOCITY}, the overlay animates fully off-screen and
+ *   `onDismiss` is invoked.
+ * - Otherwise the overlay snaps back to its original position.
+ *
+ * Horizontal drags and small vertical motions inside the {@link DEAD_ZONE_PX}
+ * window are ignored so the existing tap targets on the header (back
+ * button, chevrons) continue to receive click / tap events normally.
+ *
+ * Returns an {@link IDisposable} that detaches all listeners and resets
+ * inline styles applied to `overlayRoot`.
+ */
+export function installPulldownDismiss(
+	overlayRoot: HTMLElement,
+	headerHandle: HTMLElement,
+	onDismiss: () => void,
+): IDisposable {
+	const store = new DisposableStore();
+
+	let tracking = false;
+	let dragging = false;
+	let dismissed = false;
+	let activePointerId: number | undefined;
+	let startX = 0;
+	let startY = 0;
+	let startTime = 0;
+	let lastY = 0;
+	let lastT = 0;
+	let velocity = 0;
+	let originalTransition = '';
+
+	const applyDragStyles = () => {
+		originalTransition = overlayRoot.style.transition;
+		overlayRoot.style.transition = 'none';
+		overlayRoot.style.willChange = 'transform, opacity';
+	};
+
+	const resetStyles = () => {
+		overlayRoot.style.transform = '';
+		overlayRoot.style.opacity = '';
+		overlayRoot.style.transition = originalTransition;
+		overlayRoot.style.willChange = '';
+	};
+
+	const update = (dy: number) => {
+		const translate = Math.max(0, dy);
+		overlayRoot.style.transform = `translateY(${translate}px)`;
+		const opacity = Math.max(0.5, 1 - Math.min(translate / COMMIT_THRESHOLD_PX, 0.5));
+		overlayRoot.style.opacity = String(opacity);
+	};
+
+	const finish = (commit: boolean) => {
+		if (!commit) {
+			overlayRoot.style.transition = `transform ${SNAP_BACK_ANIM_MS}ms ease, opacity ${SNAP_BACK_ANIM_MS}ms ease`;
+			overlayRoot.style.transform = 'translateY(0)';
+			overlayRoot.style.opacity = '1';
+			const onEnd = () => {
+				resetStyles();
+				overlayRoot.removeEventListener('transitionend', onEnd);
+			};
+			overlayRoot.addEventListener('transitionend', onEnd, { once: true });
+			return;
+		}
+
+		if (dismissed) {
+			return;
+		}
+		dismissed = true;
+		overlayRoot.style.transition = `transform ${DISMISS_ANIM_MS}ms ease, opacity ${DISMISS_ANIM_MS}ms ease`;
+		overlayRoot.style.transform = 'translateY(100%)';
+		overlayRoot.style.opacity = '0';
+		const timeoutId = overlayRoot.ownerDocument.defaultView?.setTimeout(() => {
+			onDismiss();
+		}, DISMISS_ANIM_MS) ?? 0;
+		store.add(toDisposable(() => {
+			overlayRoot.ownerDocument.defaultView?.clearTimeout(timeoutId);
+		}));
+	};
+
+	store.add(addDisposableListener(headerHandle, EventType.POINTER_DOWN, (e: PointerEvent) => {
+		if (tracking || dismissed) {
+			return;
+		}
+		if (e.pointerType !== 'touch' && e.pointerType !== 'pen') {
+			return;
+		}
+		tracking = true;
+		dragging = false;
+		activePointerId = e.pointerId;
+		startX = e.clientX;
+		startY = e.clientY;
+		startTime = Date.now();
+		lastY = startY;
+		lastT = startTime;
+		velocity = 0;
+	}));
+
+	store.add(addDisposableListener(headerHandle, EventType.POINTER_MOVE, (e: PointerEvent) => {
+		if (!tracking || e.pointerId !== activePointerId) {
+			return;
+		}
+		const dy = e.clientY - startY;
+		const dx = e.clientX - startX;
+
+		if (!dragging) {
+			if (Math.abs(dy) < DEAD_ZONE_PX) {
+				return;
+			}
+			if (dy <= 0 || Math.abs(dx) > Math.abs(dy)) {
+				// Not a downward-dominant drag — release the gesture so
+				// regular pointer handlers (e.g. native scroll) can take
+				// over for the remainder of this pointer interaction.
+				tracking = false;
+				activePointerId = undefined;
+				return;
+			}
+			dragging = true;
+			applyDragStyles();
+		}
+
+		// Update running velocity sample for flick detection.
+		const now = Date.now();
+		const dt = now - lastT;
+		if (dt > 0) {
+			velocity = (e.clientY - lastY) / dt;
+		}
+		lastY = e.clientY;
+		lastT = now;
+
+		update(dy);
+		e.preventDefault();
+	}, { passive: false }));
+
+	const release = (e: PointerEvent) => {
+		if (e.pointerId !== activePointerId) {
+			return;
+		}
+		const wasDragging = dragging;
+		const dy = e.clientY - startY;
+		tracking = false;
+		dragging = false;
+		activePointerId = undefined;
+
+		if (!wasDragging) {
+			return;
+		}
+
+		const commit = dy > COMMIT_THRESHOLD_PX || velocity > COMMIT_VELOCITY;
+		finish(commit);
+	};
+	store.add(addDisposableListener(headerHandle, EventType.POINTER_UP, release));
+	store.add(addDisposableListener(headerHandle, 'pointercancel', release));
+
+	store.add(toDisposable(() => {
+		if (!dismissed) {
+			resetStyles();
+		}
+	}));
+
+	return store;
+}

--- a/src/vs/sessions/browser/parts/mobile/contributions/mobileSyntaxHighlight.ts
+++ b/src/vs/sessions/browser/parts/mobile/contributions/mobileSyntaxHighlight.ts
@@ -1,0 +1,305 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Shared syntax-highlighting helpers for the phone-layout mobile overlays
+// (diff view, code-block overlay). Two-stage approach:
+//
+//  1. Try Monaco's `tokenizeToString` against the registered TextMate
+//     grammar for the language. The agents window does not load built-in
+//     language extensions yet, so `TokenizationRegistry.getOrCreate`
+//     resolves to null for most languages and every token comes back as
+//     `mtk1` (default foreground). We detect that with
+//     `hasMultipleTokenClasses` and fall through.
+//
+//  2. Regex fallback that emits `<span class="mobile-diff-tok-*">` spans.
+//     Per-theme colors are defined in `mobileOverlayViews.css` so token
+//     colours adapt to the active theme without needing to read any
+//     color map in JS.
+//
+// Both consumers (mobileDiffView, mobileCodeBlockOverlay) share the same
+// classes so a single CSS palette covers both surfaces.
+
+import { ILanguageService } from '../../../../../editor/common/languages/language.js';
+import { tokenizeToString } from '../../../../../editor/common/languages/textToHtmlTokenizer.js';
+
+/** Hardcoded extension→languageId fallback for common languages.
+ *
+ * The agents window does not load language services / built-in language
+ * extensions yet, so `ILanguageService.guessLanguageIdByFilepathOrFirstLine`
+ * returns `'unknown'` for everything except a small core set. Once the
+ * agents window starts loading language services this map becomes a
+ * pure fallback for the leftover `'unknown'` cases. The IDs match
+ * VS Code's built-in extension `package.json` contributions. */
+export const EXTENSION_LANGUAGE_MAP: Record<string, string> = {
+	'.js': 'javascript', '.mjs': 'javascript', '.cjs': 'javascript',
+	'.jsx': 'javascriptreact',
+	'.ts': 'typescript', '.mts': 'typescript', '.cts': 'typescript',
+	'.tsx': 'typescriptreact',
+	'.py': 'python', '.pyw': 'python',
+	'.java': 'java',
+	'.c': 'c', '.h': 'c',
+	'.cpp': 'cpp', '.cc': 'cpp', '.cxx': 'cpp', '.hpp': 'cpp',
+	'.cs': 'csharp',
+	'.go': 'go',
+	'.rs': 'rust',
+	'.rb': 'ruby',
+	'.php': 'php',
+	'.html': 'html', '.htm': 'html',
+	'.css': 'css', '.scss': 'scss', '.less': 'less',
+	'.json': 'json', '.jsonc': 'jsonc',
+	'.md': 'markdown',
+	'.sh': 'shellscript', '.bash': 'shellscript', '.zsh': 'shellscript',
+	'.yaml': 'yaml', '.yml': 'yaml',
+	'.xml': 'xml',
+	'.sql': 'sql',
+	'.swift': 'swift',
+	'.kt': 'kotlin', '.kts': 'kotlin',
+	'.r': 'r',
+	'.lua': 'lua',
+	'.dart': 'dart',
+};
+
+/** Aliases for short language hints commonly emitted by chat code fences
+ *  (e.g. ```ts, ```py, ```sh). Mapped to the same canonical IDs used by
+ *  `EXTENSION_LANGUAGE_MAP` so the same regex-fallback lang-family
+ *  lookup applies to both surfaces. */
+export const LANGUAGE_ID_ALIAS: Record<string, string> = {
+	js: 'javascript',
+	ts: 'typescript',
+	jsx: 'javascriptreact',
+	tsx: 'typescriptreact',
+	py: 'python',
+	rb: 'ruby',
+	cs: 'csharp',
+	sh: 'shellscript',
+	bash: 'shellscript',
+	zsh: 'shellscript',
+	shell: 'shellscript',
+	yml: 'yaml',
+	md: 'markdown',
+	'c++': 'cpp',
+	rs: 'rust',
+	kt: 'kotlin',
+};
+
+/**
+ * Tokenize a full text and return the per-line HTML (one entry per
+ * source line, in order). Uses `tokenizeToString` which awaits
+ * `TokenizationRegistry.getOrCreate(languageId)` — without that, sync
+ * tokenization returns null highlighting for any language whose
+ * textmate grammar hasn't been activated yet (common in agents
+ * workbench, where no editor has opened the file).
+ *
+ * Tokenization runs over the whole text so state (open string,
+ * template literal, block comment) propagates correctly across lines.
+ */
+export async function tokenizeFileLines(languageService: ILanguageService, text: string, languageId: string): Promise<string[]> {
+	if (!text) {
+		return [''];
+	}
+	const html = await tokenizeToString(languageService, text, languageId);
+	const inner = stripTokenizedWrapper(html);
+	// `_tokenizeToString` separates lines with `<br/>` (no closing tag,
+	// always lower-case in the upstream implementation). Splitting on
+	// the literal preserves the inner `<span class="mtkN">…</span>`
+	// markup that gives us the syntax-highlight colours.
+	return inner.split('<br/>');
+}
+
+/**
+ * `tokenizeToString` returns HTML wrapped in
+ * `<div class="monaco-tokenized-source">…</div>`. We render per-line into
+ * an inline `<span>`, so we strip the wrapper and keep just the inner
+ * `<span class="mtkN">` token spans.
+ */
+function stripTokenizedWrapper(html: string): string {
+	const openTag = '<div class="monaco-tokenized-source">';
+	const closeTag = '</div>';
+	if (html.startsWith(openTag) && html.endsWith(closeTag)) {
+		return html.slice(openTag.length, html.length - closeTag.length);
+	}
+	return html;
+}
+
+/**
+ * Returns true when the Monaco tokenizer produced real syntax tokens,
+ * i.e. the HTML contains more than just `mtk1` class spans. When the
+ * TextMate grammar for the language isn't loaded (common on the agents
+ * workbench which doesn't load built-in language extensions), every
+ * token falls back to `mtk1` (default foreground).
+ */
+export function hasMultipleTokenClasses(lines: readonly string[]): boolean {
+	for (const line of lines) {
+		if (line && /class="mtk[2-9]|class="mtk[1-9][0-9]/.test(line)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+// -- Regex-based syntax highlighter ------------------------------------------
+// Used when the Monaco TextMate grammar isn't available (the agents window
+// doesn't load built-in language extensions yet; this fallback fires for any
+// language without a registered grammar). Produces CSS-class spans rather than
+// inline `style` spans so token colors adapt to the active theme without
+// needing to read any color map here. The classes (`mobile-diff-tok-comment`,
+// `mobile-diff-tok-string`, `mobile-diff-tok-keyword`, `mobile-diff-tok-number`)
+// are styled in `media/mobileOverlayViews.css` using per-theme CSS variables
+// defined against the `.vs`, `.hc-black`, and `.hc-light` body class selectors,
+// keeping all theme-specific values in the stylesheet rather than in JS.
+type RegexTokenKind = 'comment' | 'string' | 'keyword' | 'number' | 'default';
+
+interface IRegexToken {
+	start: number;
+	end: number;
+	kind: RegexTokenKind;
+}
+
+type LangFamily = 'js' | 'python' | 'css' | 'html' | 'json' | 'shell' | 'generic';
+
+const LANG_FAMILY: Record<string, LangFamily> = {
+	javascript: 'js', javascriptreact: 'js',
+	typescript: 'js', typescriptreact: 'js',
+	java: 'js', csharp: 'js', go: 'js', rust: 'js',
+	cpp: 'js', c: 'js', swift: 'js', kotlin: 'js', dart: 'js', php: 'js', ruby: 'js',
+	python: 'python',
+	css: 'css', scss: 'css', less: 'css',
+	html: 'html', xml: 'html',
+	json: 'json', jsonc: 'json',
+	shellscript: 'shell', powershell: 'shell',
+};
+
+const JS_KEYWORDS = new Set([
+	'break', 'case', 'catch', 'class', 'const', 'continue', 'debugger', 'default',
+	'delete', 'do', 'else', 'export', 'extends', 'false', 'finally', 'for',
+	'function', 'if', 'import', 'in', 'instanceof', 'let', 'new', 'null',
+	'of', 'return', 'static', 'super', 'switch', 'this', 'throw', 'true',
+	'try', 'typeof', 'undefined', 'var', 'void', 'while', 'with', 'yield',
+	'async', 'await', 'from', 'as', 'interface', 'type', 'enum', 'declare',
+	'abstract', 'override', 'readonly', 'namespace', 'module', 'public', 'private', 'protected',
+]);
+
+const PY_KEYWORDS = new Set([
+	'False', 'None', 'True', 'and', 'as', 'assert', 'async', 'await',
+	'break', 'class', 'continue', 'def', 'del', 'elif', 'else', 'except',
+	'finally', 'for', 'from', 'global', 'if', 'import', 'in', 'is',
+	'lambda', 'nonlocal', 'not', 'or', 'pass', 'raise', 'return',
+	'try', 'while', 'with', 'yield',
+]);
+
+function escapeHtml(s: string): string {
+	return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function buildSpan(kind: RegexTokenKind, text: string): string {
+	if (kind === 'default' || !text) {
+		return escapeHtml(text);
+	}
+	return `<span class="mobile-diff-tok-${kind}">${escapeHtml(text)}</span>`;
+}
+
+/** Tokenize a single line using simple regex rules. Returns HTML. */
+function regexTokenizeLine(line: string, lang: LangFamily): string {
+	const tokens: IRegexToken[] = [];
+	let pos = 0;
+	const len = line.length;
+
+	while (pos < len) {
+		let matched = false;
+
+		// Line comments
+		const commentPfx = lang === 'python' ? '#' : lang === 'shell' ? '#' : '//';
+		if (line.startsWith(commentPfx, pos) || (lang === 'generic' && line.startsWith('#', pos))) {
+			tokens.push({ start: pos, end: len, kind: 'comment' });
+			pos = len;
+			matched = true;
+		}
+
+		// Block comments /* ... */
+		if (!matched && lang !== 'python' && lang !== 'shell' && line.startsWith('/*', pos)) {
+			const end = line.indexOf('*/', pos + 2);
+			const tokenEnd = end === -1 ? len : end + 2;
+			tokens.push({ start: pos, end: tokenEnd, kind: 'comment' });
+			pos = tokenEnd;
+			matched = true;
+		}
+
+		// Template literals
+		if (!matched && (lang === 'js') && line[pos] === '`') {
+			let i = pos + 1;
+			while (i < len) {
+				if (line[i] === '\\') { i += 2; continue; }
+				if (line[i] === '`') { i++; break; }
+				i++;
+			}
+			tokens.push({ start: pos, end: i, kind: 'string' });
+			pos = i;
+			matched = true;
+		}
+
+		// Strings
+		if (!matched && (line[pos] === '"' || line[pos] === '\'')) {
+			const q = line[pos];
+			let i = pos + 1;
+			while (i < len) {
+				if (line[i] === '\\') { i += 2; continue; }
+				if (line[i] === q) { i++; break; }
+				i++;
+			}
+			tokens.push({ start: pos, end: i, kind: 'string' });
+			pos = i;
+			matched = true;
+		}
+
+		// Numbers
+		if (!matched && /[0-9]/.test(line[pos])) {
+			const m = line.slice(pos).match(/^0x[0-9a-fA-F]+|^[0-9]+\.?[0-9]*(?:[eE][+-]?[0-9]+)?/);
+			if (m) {
+				tokens.push({ start: pos, end: pos + m[0].length, kind: 'number' });
+				pos += m[0].length;
+				matched = true;
+			}
+		}
+
+		// Keywords and identifiers
+		if (!matched && /[a-zA-Z_$]/.test(line[pos])) {
+			const m = line.slice(pos).match(/^[a-zA-Z_$][a-zA-Z0-9_$]*/);
+			if (m) {
+				const word = m[0];
+				const keywords = lang === 'python' ? PY_KEYWORDS : JS_KEYWORDS;
+				const kind: RegexTokenKind = keywords.has(word) ? 'keyword' : 'default';
+				tokens.push({ start: pos, end: pos + word.length, kind });
+				pos += word.length;
+				matched = true;
+			}
+		}
+
+		if (!matched) {
+			// Advance one character (operator/punctuation/whitespace)
+			const prevTok = tokens[tokens.length - 1];
+			// Coalesce consecutive default-colored chars to avoid span bloat
+			if (prevTok && prevTok.kind === 'default') {
+				prevTok.end = pos + 1;
+			} else {
+				tokens.push({ start: pos, end: pos + 1, kind: 'default' });
+			}
+			pos++;
+		}
+	}
+
+	return tokens.map(t => buildSpan(t.kind, line.slice(t.start, t.end))).join('');
+}
+
+/**
+ * Tokenize all lines of `text` using the regex highlighter.
+ * Returns one HTML string per source line (same shape as `tokenizeFileLines`).
+ */
+export function regexTokenizeLines(text: string, languageId: string): string[] {
+	if (!text) {
+		return [''];
+	}
+	const lang: LangFamily = LANG_FAMILY[languageId] ?? 'generic';
+	return text.split(/\r?\n/).map(line => regexTokenizeLine(line, lang));
+}

--- a/src/vs/sessions/browser/parts/mobile/longPress.ts
+++ b/src/vs/sessions/browser/parts/mobile/longPress.ts
@@ -1,0 +1,198 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as dom from '../../../../base/browser/dom.js';
+import { DisposableStore, IDisposable } from '../../../../base/common/lifecycle.js';
+import { IWorkbenchLayoutService } from '../../../../workbench/services/layout/browser/layoutService.js';
+import { isPhoneLayout } from './mobileLayout.js';
+
+/** Default hold duration, in milliseconds, before a long-press fires. */
+const DEFAULT_HOLD_TIME_MS = 500;
+
+/** Default pointer movement, in CSS pixels, that cancels a pending long-press. */
+const DEFAULT_MOVE_THRESHOLD_PX = 6;
+
+/**
+ * Options for {@link installLongPress}.
+ */
+export interface IInstallLongPressOptions {
+	/**
+	 * How long the pointer must stay pressed (without moving past
+	 * `moveThresholdPx`) before the long-press fires. Defaults to
+	 * {@link DEFAULT_HOLD_TIME_MS} (500ms).
+	 */
+	holdTimeMs?: number;
+
+	/**
+	 * Pointer movement (in CSS pixels) that cancels a pending
+	 * long-press. Small enough that micro-jitter on touch devices
+	 * doesn't kill the gesture, large enough that an intentional
+	 * scroll/pan does. Defaults to {@link DEFAULT_MOVE_THRESHOLD_PX}.
+	 */
+	moveThresholdPx?: number;
+
+	/**
+	 * If true (the default), the next `click` event after the
+	 * long-press fires is swallowed in capture phase so the
+	 * underlying element's tap handler doesn't also run.
+	 */
+	suppressSyntheticClick?: boolean;
+
+	/**
+	 * Optional layout service used to self-gate the long-press to
+	 * phone layout. When provided, the long-press is a no-op unless
+	 * `isPhoneLayout(layoutService)` returns `true` at pointerdown
+	 * time. Omit for callers that want long-press to fire on all
+	 * form factors.
+	 */
+	layoutService?: IWorkbenchLayoutService;
+}
+
+/**
+ * Wires a long-press gesture on `element`.
+ *
+ * A long-press is defined as the pointer staying down on `element`
+ * for at least `holdTimeMs` (default 500ms) without moving more than
+ * `moveThresholdPx` (default 6px) from the initial down position.
+ * When that happens, `handler(pointerEvent)` is invoked with the
+ * original `pointerdown` event so callers can read `clientX/Y`,
+ * `target`, etc. for things like positioning an action sheet.
+ *
+ * Movement past the threshold, `pointerup`, or `pointercancel` all
+ * cancel the pending long-press; the handler does not fire.
+ *
+ * When `suppressSyntheticClick` is true (the default), the next
+ * `click` event after the long-press fires is captured and
+ * `preventDefault`+`stopPropagation`'d so the underlying element's
+ * tap handler doesn't also run (e.g., long-pressing a chat row
+ * shouldn't also open the session like a tap does). A
+ * next-animation-frame fallback removes the click suppressor in case
+ * no click ever follows (e.g., the user lifted off-screen).
+ *
+ * If an `IWorkbenchLayoutService` is supplied via
+ * `options.layoutService`, the gesture self-gates on phone layout:
+ * on desktop the pointerdown handler returns immediately so
+ * right-click-and-hold doesn't accidentally trigger anything. This
+ * is intentionally opt-in so callers that want a universal
+ * long-press (e.g., a touch test page) can omit it.
+ *
+ * Only primary `touch` and `mouse` pointer types are observed; pen
+ * and non-primary pointers are ignored to avoid fighting other
+ * gesture handlers.
+ *
+ * @example
+ * // Open an action sheet when the user long-presses a chat row.
+ * disposables.add(installLongPress(row, e => {
+ *     actionSheet.show({ x: e.clientX, y: e.clientY });
+ * }, { layoutService }));
+ *
+ * @param element The element to attach pointer listeners to.
+ * @param handler Invoked with the originating pointerdown event
+ *                when a long-press is detected.
+ * @param options See {@link IInstallLongPressOptions}.
+ * @returns Disposable that removes all listeners and clears any
+ *          pending timer.
+ */
+export function installLongPress(
+	element: HTMLElement,
+	handler: (e: PointerEvent) => void,
+	options?: IInstallLongPressOptions
+): IDisposable {
+	const store = new DisposableStore();
+	const holdTimeMs = options?.holdTimeMs ?? DEFAULT_HOLD_TIME_MS;
+	const moveThresholdPx = options?.moveThresholdPx ?? DEFAULT_MOVE_THRESHOLD_PX;
+	const suppressSyntheticClick = options?.suppressSyntheticClick ?? true;
+	const layoutService = options?.layoutService;
+
+	let pointerId: number | undefined;
+	let startX = 0;
+	let startY = 0;
+	let timerId: number | undefined;
+	const targetWindow = dom.getWindow(element);
+
+	const cancelTimer = () => {
+		if (timerId !== undefined) {
+			targetWindow.clearTimeout(timerId);
+			timerId = undefined;
+		}
+	};
+
+	const reset = () => {
+		cancelTimer();
+		pointerId = undefined;
+	};
+
+	store.add(dom.addDisposableListener(element, dom.EventType.POINTER_DOWN, (e: PointerEvent) => {
+		// Self-gate on phone when a layout service was supplied so
+		// desktop right-click-drag and similar don't accidentally
+		// trigger anything. The check is a cheap DOM class read,
+		// evaluated lazily per pointerdown so resize-to-phone keeps
+		// working.
+		if (layoutService && !isPhoneLayout(layoutService)) {
+			return;
+		}
+		// Only react to primary input. Ignore right-clicks and
+		// non-touch/-mouse pointer types (e.g. pen) to avoid
+		// fighting other gesture handlers.
+		if (!e.isPrimary || (e.pointerType !== 'touch' && e.pointerType !== 'mouse')) {
+			return;
+		}
+		// A second pointerdown before the previous gesture ended
+		// supersedes the prior one; clear any stale timer.
+		cancelTimer();
+		pointerId = e.pointerId;
+		startX = e.clientX;
+		startY = e.clientY;
+		timerId = targetWindow.setTimeout(() => {
+			timerId = undefined;
+			pointerId = undefined;
+			handler(e);
+			if (suppressSyntheticClick) {
+				// Swallow the next click in capture phase so the
+				// underlying element's tap handler doesn't also
+				// run. `addEventListener` (not
+				// `addDisposableListener`) is used because the
+				// listener needs to remove itself once it fires.
+				const swallow = (clickEvent: MouseEvent) => {
+					clickEvent.preventDefault();
+					clickEvent.stopPropagation();
+					element.removeEventListener('click', swallow, true);
+				};
+				element.addEventListener('click', swallow, true);
+				// Drop the suppressor on the next frame in case no
+				// click ever follows (e.g. lifted off-screen).
+				targetWindow.setTimeout(() => element.removeEventListener('click', swallow, true), 0);
+			}
+		}, holdTimeMs);
+	}));
+
+	store.add(dom.addDisposableListener(element, dom.EventType.POINTER_MOVE, (e: PointerEvent) => {
+		if (pointerId !== e.pointerId) {
+			return;
+		}
+		const dx = e.clientX - startX;
+		const dy = e.clientY - startY;
+		if (Math.abs(dx) > moveThresholdPx || Math.abs(dy) > moveThresholdPx) {
+			reset();
+		}
+	}));
+
+	const end = (e: PointerEvent) => {
+		if (pointerId !== e.pointerId) {
+			return;
+		}
+		reset();
+	};
+	store.add(dom.addDisposableListener(element, dom.EventType.POINTER_UP, end));
+	// `pointercancel` isn't in the workbench's `EventType` enum (only
+	// the events shared with mouse/touch are), so register it via the
+	// raw literal. Browsers fire it when the pointer leaves the page
+	// or the gesture is interrupted (e.g. iOS scroll/zoom takeover).
+	store.add(dom.addDisposableListener(element, 'pointercancel', end));
+
+	store.add({ dispose: cancelTimer });
+
+	return store;
+}

--- a/src/vs/sessions/browser/parts/mobile/media/mobilePickerSheet.css
+++ b/src/vs/sessions/browser/parts/mobile/media/mobilePickerSheet.css
@@ -236,6 +236,21 @@
 	padding: 4px 8px 12px;
 }
 
+/* Body container for the shell-only `showMobileContentSheet` variant.
+ * Where the picker sheet builds its own scrollable list of rows
+ * (`.mobile-picker-sheet-list`) inside the sheet flex column, the
+ * content sheet hands the body slot over to its caller and only
+ * guarantees the surrounding chrome (drag handle, title row, caption,
+ * dismissal, keyboard avoidance). We set scroll, momentum, and
+ * touch-action on the body slot itself so vertical scrolling works
+ * correctly under iOS regardless of what DOM the caller puts inside. */
+.mobile-content-sheet-body {
+	flex: 1 1 auto;
+	overflow-y: auto;
+	-webkit-overflow-scrolling: touch;
+	touch-action: pan-y;
+}
+
 /* iOS grouped-list section header. The HIG uses a regular-case
  * footnote-sized label in secondary color — not the uppercased small
  * caps that older Settings rows used. */

--- a/src/vs/sessions/browser/parts/mobile/mobileChatShell.css
+++ b/src/vs/sessions/browser/parts/mobile/mobileChatShell.css
@@ -990,3 +990,151 @@
 	height: 36px;
 	padding: 0;
 }
+
+/* ===========================================================================
+ * Phone Layout: Chat Code Blocks
+ * ---------------------------------------------------------------------------
+ *
+ * Code blocks inside chat are rendered by `codeBlockPart.ts` as:
+ *   .interactive-result-code-block
+ *     .interactive-result-editor                 (Monaco editor wrapper)
+ *     .interactive-result-code-block-toolbar
+ *       > .monaco-toolbar / .monaco-action-bar    (copy / insert / run)
+ *
+ * Desktop styling (`codeBlockPart.css`) positions the toolbar absolutely
+ * with `top: -15px` and reveals it on hover. On phone we can't hover, and
+ * floating overlays on small viewports are hard to reach with a thumb. We:
+ *   - Make the toolbar `position: sticky; top: 0` so it stays reachable
+ *     while scrolling vertically through a long block.
+ *   - Force its action buttons to a 44px x 44px hit target.
+ *   - Set `touch-action: pan-y pan-x` on the editor wrapper so iOS doesn't
+ *     claim the gesture for pinch-zoom; both axes are needed because long
+ *     code lines scroll horizontally inside the editor.
+ *   - Provide a horizontal scroll fallback for non-Monaco markdown code.
+ * ========================================================================= */
+
+/* The code block container becomes the sticky positioning context. */
+.agent-sessions-workbench.phone-layout .interactive-session .interactive-result-code-block {
+	position: relative;
+}
+
+/* Toolbar: pinned to the top of the code block, full-width, always
+ * visible (no hover-reveal on phone). The background matches the editor
+ * so the toolbar reads as part of the block rather than floating above. */
+.agent-sessions-workbench.phone-layout .interactive-session .interactive-result-code-block .interactive-result-code-block-toolbar {
+	opacity: 1;
+	pointer-events: auto;
+}
+
+.agent-sessions-workbench.phone-layout .interactive-session .interactive-result-code-block .interactive-result-code-block-toolbar > .monaco-toolbar,
+.agent-sessions-workbench.phone-layout .interactive-session .interactive-result-code-block .interactive-result-code-block-toolbar > .monaco-action-bar {
+	position: sticky;
+	top: 0;
+	left: auto;
+	right: auto;
+	height: auto;
+	max-width: 100%;
+	z-index: 1;
+	background-color: var(--vscode-editor-background);
+	border-radius: 0 0 var(--vscode-cornerRadius-medium) var(--vscode-cornerRadius-medium);
+}
+
+/* Each action button in the code-block toolbar gets a 44px hit area.
+ * Desktop pins them to 24x24, which is far too small for a thumb. */
+.agent-sessions-workbench.phone-layout .interactive-session .interactive-result-code-block .monaco-toolbar .action-item,
+.agent-sessions-workbench.phone-layout .interactive-session .interactive-result-code-block .monaco-action-bar .action-item {
+	min-width: 44px;
+	min-height: 44px;
+	width: auto;
+	height: auto;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	touch-action: manipulation;
+}
+
+.agent-sessions-workbench.phone-layout .interactive-session .interactive-result-code-block .monaco-toolbar .action-item .action-label,
+.agent-sessions-workbench.phone-layout .interactive-session .interactive-result-code-block .monaco-action-bar .action-item .action-label {
+	min-width: 44px;
+	min-height: 44px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+}
+
+/* Monaco editor wrapper: explicit `pan-y pan-x` so iOS doesn't hijack
+ * either axis for pinch-zoom. Monaco handles its own pointer events; this
+ * just tells the browser not to compete for the gesture. */
+.agent-sessions-workbench.phone-layout .interactive-session .interactive-result-code-block .interactive-result-editor {
+	touch-action: pan-y pan-x;
+}
+
+/* Non-Monaco fallback: pre-rendered markdown code blocks (e.g. inside
+ * confirmation message bodies) need their own horizontal scroll affordance
+ * so long lines don't push the content column wider than the viewport. */
+.agent-sessions-workbench.phone-layout .interactive-session .rendered-markdown pre,
+.agent-sessions-workbench.phone-layout .interactive-session .rendered-markdown pre > code {
+	overflow-x: auto;
+	-webkit-overflow-scrolling: touch;
+	touch-action: pan-x pan-y;
+	max-width: 100%;
+}
+
+/* ===========================================================================
+ * Phone Layout: Code Block Tap-to-Expand
+ * ---------------------------------------------------------------------------
+ *
+ * Long chat code blocks become unwieldy on phone — Monaco's inline scroll
+ * gestures fight the page scroll, and tall code pushes downstream content
+ * far below the fold. `codeBlockPart.ts` appends a `.chat-code-block-mobile-expand`
+ * row at the bottom of every (non-simple) code block; on phone, that row is
+ * revealed when the rendered model exceeds the line-count threshold (see
+ * `MOBILE_EXPAND_LINE_THRESHOLD`). Tapping the row dispatches
+ * `sessions.mobile.openCodeBlockOverlay`, which mounts the full-viewport
+ * `MobileCodeBlockOverlay` with syntax-highlighted content and a copy
+ * action.
+ *
+ * The row is created unconditionally (on every CodeBlockPart, including
+ * desktop), but `display: none` keeps it invisible off-phone and below
+ * threshold. We don't need a phone-class guard on the visible-state rules
+ * here because the workbench code only sets `display: ''` when the phone
+ * context key is true — but we still scope the styling under
+ * `.phone-layout` so accidental fall-through on desktop is harmless.
+ * ========================================================================= */
+
+.chat-code-block-mobile-expand {
+	display: none;
+	align-items: center;
+	justify-content: center;
+	gap: 6px;
+	width: 100%;
+	min-height: 44px;
+	padding: 8px 12px;
+	box-sizing: border-box;
+	background-color: var(--vscode-toolbar-hoverBackground, rgba(127, 127, 127, 0.08));
+	color: var(--vscode-textLink-foreground);
+	border-top: 1px solid var(--vscode-panel-border, rgba(127, 127, 127, 0.2));
+	font-size: 13px;
+	cursor: pointer;
+	user-select: none;
+	-webkit-tap-highlight-color: transparent;
+	touch-action: manipulation;
+}
+
+.chat-code-block-mobile-expand:active {
+	background-color: var(--vscode-toolbar-activeBackground, rgba(127, 127, 127, 0.15));
+}
+
+.chat-code-block-mobile-expand:focus-visible {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: -1px;
+}
+
+.chat-code-block-mobile-expand .chat-code-block-mobile-expand-icon {
+	font-size: 14px;
+	line-height: 1;
+}
+
+.chat-code-block-mobile-expand .chat-code-block-mobile-expand-label {
+	font-weight: 500;
+}

--- a/src/vs/sessions/browser/parts/mobile/mobileEdgeSwipe.ts
+++ b/src/vs/sessions/browser/parts/mobile/mobileEdgeSwipe.ts
@@ -1,0 +1,133 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DisposableStore, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { addDisposableListener, EventType } from '../../../../base/browser/dom.js';
+import { IWorkbenchLayoutService, Parts } from '../../../../workbench/services/layout/browser/layoutService.js';
+
+/**
+ * Threshold (in px) from the left viewport edge within which a `pointerdown`
+ * is considered a candidate edge swipe.
+ */
+const EDGE_HIT_ZONE_PX = 16;
+
+/**
+ * Minimum horizontal travel (in px, rightward) required to commit the
+ * sidebar-open gesture.
+ */
+const COMMIT_TRAVEL_PX = 48;
+
+/**
+ * Maximum vertical drift (in px) allowed during the gesture. If the user
+ * moves more than this along Y the gesture is treated as a scroll attempt
+ * and the swipe is cancelled.
+ */
+const VERTICAL_TOLERANCE_PX = 32;
+
+/**
+ * Maximum duration (in ms) within which the commit travel must be reached.
+ * Slower drags are treated as deliberate scrolls / selections and ignored.
+ */
+const COMMIT_WINDOW_MS = 500;
+
+/**
+ * Installs a left-edge swipe gesture on `mainContainer` that opens the
+ * sidebar drawer on phone viewports.
+ *
+ * The gesture starts when `pointerdown` lands within the leftmost
+ * {@link EDGE_HIT_ZONE_PX} pixels of the container while the phone layout
+ * is active. It commits when the pointer travels more than
+ * {@link COMMIT_TRAVEL_PX} rightward within {@link COMMIT_WINDOW_MS} ms
+ * with less than {@link VERTICAL_TOLERANCE_PX} of vertical drift. The
+ * gesture is cancelled on `pointerup` / `pointercancel`, or once the
+ * tracking window elapses.
+ *
+ * Only `touch` and `pen` pointer types are considered — mouse drags from
+ * the edge could conflict with text selection. The gesture also skips if
+ * the sidebar is already visible so we don't replay the open on every
+ * subsequent edge tap.
+ *
+ * Returns an {@link IDisposable} that detaches all listeners.
+ */
+export function installMobileEdgeSwipeToOpenSidebar(
+	mainContainer: HTMLElement,
+	openSidebar: () => void,
+	layoutService: IWorkbenchLayoutService,
+): IDisposable {
+	const store = new DisposableStore();
+
+	let tracking = false;
+	let startX = 0;
+	let startY = 0;
+	let startTime = 0;
+	let activePointerId: number | undefined;
+
+	const reset = () => {
+		tracking = false;
+		activePointerId = undefined;
+	};
+
+	const isPhoneLayout = (): boolean => {
+		return mainContainer.classList.contains('phone-layout');
+	};
+
+	store.add(addDisposableListener(mainContainer, EventType.POINTER_DOWN, (e: PointerEvent) => {
+		if (tracking) {
+			return;
+		}
+		if (e.pointerType !== 'touch' && e.pointerType !== 'pen') {
+			return;
+		}
+		if (!isPhoneLayout()) {
+			return;
+		}
+		const rect = mainContainer.getBoundingClientRect();
+		const localX = e.clientX - rect.left;
+		if (localX >= EDGE_HIT_ZONE_PX) {
+			return;
+		}
+		if (layoutService.isVisible(Parts.SIDEBAR_PART)) {
+			return;
+		}
+
+		tracking = true;
+		activePointerId = e.pointerId;
+		startX = e.clientX;
+		startY = e.clientY;
+		startTime = Date.now();
+	}, true));
+
+	store.add(addDisposableListener(mainContainer, EventType.POINTER_MOVE, (e: PointerEvent) => {
+		if (!tracking || e.pointerId !== activePointerId) {
+			return;
+		}
+
+		const dx = e.clientX - startX;
+		const dy = Math.abs(e.clientY - startY);
+		const elapsed = Date.now() - startTime;
+
+		if (elapsed > COMMIT_WINDOW_MS || dy > VERTICAL_TOLERANCE_PX) {
+			reset();
+			return;
+		}
+
+		if (dx >= COMMIT_TRAVEL_PX) {
+			reset();
+			openSidebar();
+		}
+	}, true));
+
+	const cancel = (e: PointerEvent) => {
+		if (e.pointerId === activePointerId) {
+			reset();
+		}
+	};
+	store.add(addDisposableListener(mainContainer, EventType.POINTER_UP, cancel, true));
+	store.add(addDisposableListener(mainContainer, 'pointercancel', cancel, true));
+
+	store.add(toDisposable(reset));
+
+	return store;
+}

--- a/src/vs/sessions/browser/parts/mobile/mobilePickerSheet.ts
+++ b/src/vs/sessions/browser/parts/mobile/mobilePickerSheet.ts
@@ -9,7 +9,7 @@ import { Codicon } from '../../../../base/common/codicons.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { Gesture, EventType as TouchEventType } from '../../../../base/browser/touch.js';
 import { CancellationToken, CancellationTokenSource } from '../../../../base/common/cancellation.js';
-import { DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
+import { DisposableStore, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { localize } from '../../../../nls.js';
 
 const $ = DOM.$;
@@ -122,6 +122,53 @@ export interface IMobilePickerSheetSearchSource {
 }
 
 /**
+ * Renderer API passed into the {@link showMobileContentSheet} body
+ * callback. The renderer fills {@link bodyContainer} with arbitrary DOM
+ * and may call {@link close} to dismiss the sheet (e.g. after a confirm
+ * button is tapped, or after a sub-view navigation completes).
+ */
+export interface IMobileContentSheetApi {
+	/**
+	 * The same element passed as the first argument to the body
+	 * renderer; exposed here for convenience so callbacks can capture
+	 * the API object without also closing over the body element.
+	 */
+	readonly bodyContainer: HTMLElement;
+
+	/** Dismiss the sheet (plays the close animation). Idempotent. */
+	close(): void;
+}
+
+/**
+ * Options for {@link showMobileContentSheet}.
+ */
+export interface IMobileContentSheetOptions {
+	/**
+	 * Optional caption shown beneath the title (single-line, muted).
+	 * Mirrors {@link IMobilePickerSheetOptions.caption}.
+	 */
+	readonly caption?: string;
+
+	/**
+	 * Optional set of icon buttons rendered in the sheet's title row
+	 * to the left of the Done button. Tapping a header action resolves
+	 * the promise (the same dismissal semantics as the Done button).
+	 */
+	readonly headerActions?: readonly IMobilePickerSheetHeaderAction[];
+
+	/** Optional override for the Done button label (defaults to "Done"). */
+	readonly doneLabel?: string;
+
+	/**
+	 * When true, the Done button is hidden. Use this for sheets where
+	 * the body itself provides primary dismissal (e.g. a confirm widget
+	 * with explicit Approve / Reject buttons that call `api.close()`).
+	 * The user can still dismiss via the backdrop or Escape.
+	 */
+	readonly hideDoneButton?: boolean;
+}
+
+/**
  * Prefix used on the resolved id when a header action is invoked from a
  * mobile picker sheet, so callers can disambiguate header taps from
  * regular row selections.
@@ -149,82 +196,24 @@ export function showMobilePickerSheet(
 	options?: IMobilePickerSheetOptions,
 ): Promise<string | undefined> {
 	return new Promise<string | undefined>(resolve => {
-		const disposables = new DisposableStore();
 		let resolved = false;
+		let shell!: IMobileSheetShell;
 
 		const finish = (id: string | undefined) => {
 			if (resolved) {
 				return;
 			}
 			resolved = true;
-			sheet.classList.add('closing');
-			backdrop.classList.add('closing');
-			// Dispose all event listeners and inflight queries immediately
-			// so nothing fires during the 180ms close animation. The DOM
-			// node itself is removed at the end of the animation.
-			disposables.dispose();
-			DOM.getWindow(workbenchContainer).setTimeout(() => {
-				overlay.remove();
-				resolve(id);
-			}, 180);
+			shell.close(() => resolve(id));
 		};
 
-		// -- DOM: backdrop + sheet -------------------------------------
-		const overlay = DOM.append(workbenchContainer, $('div.mobile-picker-sheet-overlay'));
-		const backdrop = DOM.append(overlay, $('div.mobile-picker-sheet-backdrop'));
-		const sheet = DOM.append(overlay, $('div.mobile-picker-sheet'));
-		sheet.setAttribute('role', 'dialog');
-		sheet.setAttribute('aria-modal', 'true');
-		sheet.setAttribute('aria-label', title);
-
-		// -- Header (drag handle + title row + caption) ----------------
-		DOM.append(sheet, $('div.mobile-picker-sheet-handle'));
-
-		const titleRow = DOM.append(sheet, $('div.mobile-picker-sheet-title-row'));
-		const titleEl = DOM.append(titleRow, $('div.mobile-picker-sheet-title'));
-		titleEl.textContent = title;
-
-		// Optional header actions (icon buttons) rendered between the
-		// title and the Done button. Useful for sheet-level shortcuts
-		// like "browse for a folder" that aren't a single picker row.
-		if (options?.headerActions) {
-			for (const action of options.headerActions) {
-				const btn = DOM.append(titleRow, $('button.mobile-picker-sheet-header-action', { type: 'button' })) as HTMLButtonElement;
-				btn.setAttribute('aria-label', action.label);
-				btn.title = action.label;
-				const iconHost = DOM.append(btn, $('span.mobile-picker-sheet-header-action-icon'));
-				const iconEl = DOM.append(iconHost, $('span.mobile-picker-sheet-header-action-icon-glyph'));
-				iconEl.classList.add(...ThemeIcon.asClassNameArray(action.icon));
-				const btnGesture = Gesture.addTarget(btn);
-				disposables.add(btnGesture);
-				const onActivate = () => finish(`${MOBILE_PICKER_SHEET_HEADER_ACTION_PREFIX}${action.id}`);
-				const btnClick = DOM.addDisposableListener(btn, DOM.EventType.CLICK, (e: MouseEvent) => {
-					e.preventDefault();
-					onActivate();
-				});
-				disposables.add(btnClick);
-				const btnTap = DOM.addDisposableListener(btn, TouchEventType.Tap, onActivate);
-				disposables.add(btnTap);
-			}
-		}
-
-		const doneBtn = DOM.append(titleRow, $('button.mobile-picker-sheet-done', { type: 'button' })) as HTMLButtonElement;
-		doneBtn.textContent = localize('mobilePickerSheet.done', "Done");
-		doneBtn.setAttribute('aria-label', localize('mobilePickerSheet.doneAriaLabel', "Close {0}", title));
-		const doneGesture = Gesture.addTarget(doneBtn);
-		disposables.add(doneGesture);
-		const doneClick = DOM.addDisposableListener(doneBtn, DOM.EventType.CLICK, (e: MouseEvent) => {
-			e.preventDefault();
-			finish(undefined);
+		shell = buildMobileSheetShell(workbenchContainer, title, {
+			caption: options?.caption,
+			headerActions: options?.headerActions,
+			onDismiss: () => finish(undefined),
+			onHeaderAction: actionId => finish(`${MOBILE_PICKER_SHEET_HEADER_ACTION_PREFIX}${actionId}`),
 		});
-		disposables.add(doneClick);
-		const doneTap = DOM.addDisposableListener(doneBtn, TouchEventType.Tap, () => finish(undefined));
-		disposables.add(doneTap);
-
-		if (options?.caption) {
-			const caption = DOM.append(sheet, $('div.mobile-picker-sheet-caption'));
-			caption.textContent = options.caption;
-		}
+		const { sheet, disposables } = shell;
 
 		// -- Optional inline search input ------------------------------
 		// Sits between the title row and the scrollable list. Its value
@@ -371,59 +360,6 @@ export function showMobilePickerSheet(
 			setSearchQuery = (query: string) => renderResults(query);
 		}
 
-		// -- Dismissal: backdrop + Escape ------------------------------
-		const backdropClick = DOM.addDisposableListener(backdrop, DOM.EventType.CLICK, () => finish(undefined));
-		disposables.add(backdropClick);
-		const backdropGesture = Gesture.addTarget(backdrop);
-		disposables.add(backdropGesture);
-		const backdropTap = DOM.addDisposableListener(backdrop, TouchEventType.Tap, () => finish(undefined));
-		disposables.add(backdropTap);
-
-		const keyHandler = DOM.addDisposableListener(DOM.getWindow(workbenchContainer), DOM.EventType.KEY_DOWN, (e: KeyboardEvent) => {
-			if (e.key === 'Escape') {
-				e.preventDefault();
-				e.stopPropagation();
-				finish(undefined);
-			}
-		}, true);
-		disposables.add(keyHandler);
-
-		// -- iOS keyboard avoidance -----------------------------------
-		// On iOS Safari, when the virtual keyboard opens the layout
-		// viewport (`vh` units) does NOT shrink — only the visual
-		// viewport changes. The sheet uses `position: fixed` which
-		// positions against the layout viewport, so without correction
-		// the keyboard covers the bottom portion of the sheet (including
-		// the search input the user is actively typing into).
-		//
-		// `window.visualViewport` exposes the real visible area. We
-		// listen for `resize` and `scroll` events on it and translate
-		// the sheet upward by the keyboard height so the search input
-		// remains visible.
-		const win = DOM.getWindow(workbenchContainer);
-		const vv = win.visualViewport;
-		if (vv) {
-			const adjustForKeyboard = () => {
-				// The keyboard height is the difference between the
-				// layout viewport height and the visual viewport height,
-				// plus any scroll offset the browser applied.
-				const keyboardHeight = win.innerHeight - vv.height;
-				overlay.style.bottom = `${Math.max(0, keyboardHeight)}px`;
-				overlay.style.height = `${vv.height}px`;
-			};
-			vv.addEventListener('resize', adjustForKeyboard);
-			vv.addEventListener('scroll', adjustForKeyboard);
-			disposables.add(toDisposable(() => {
-				vv.removeEventListener('resize', adjustForKeyboard);
-				vv.removeEventListener('scroll', adjustForKeyboard);
-				overlay.style.bottom = '';
-				overlay.style.height = '';
-			}));
-			// Run once immediately in case the keyboard is already
-			// visible (e.g., sheet opened while another input had focus).
-			adjustForKeyboard();
-		}
-
 		// Focus the search input if present, otherwise focus the first
 		// checked row (or the first row) for keyboard users.
 		if (searchInput) {
@@ -432,6 +368,282 @@ export function showMobilePickerSheet(
 			(renderState.firstCheckedRow ?? renderState.firstRow)?.focus();
 		}
 	});
+}
+
+/**
+ * Show a phone-friendly bottom sheet that hosts arbitrary body content.
+ *
+ * Reuses the same shell as {@link showMobilePickerSheet} — translucent
+ * backdrop, slide-up animation, drag handle, title row with Done button,
+ * optional caption, optional icon header actions, iOS visual-viewport
+ * keyboard avoidance, and `Escape` / backdrop dismissal — but leaves the
+ * scrollable body to the caller. Use this for overlays that don't fit
+ * the picker's row-list shape: tool-confirmation carousels, plan
+ * reviews, anchor previews, code-block expand views, and so on.
+ *
+ * The {@link renderBody} callback is invoked once after the sheet shell
+ * mounts. The caller fills the supplied `bodyElement` with whatever DOM
+ * they like and may return an {@link IDisposable} whose `dispose()` runs
+ * when the sheet closes (alongside the shell's own listeners).
+ *
+ * The body container has `overflow-y: auto`,
+ * `-webkit-overflow-scrolling: touch`, and `touch-action: pan-y` applied
+ * via the `.mobile-content-sheet-body` class so vertical scrolling works
+ * correctly under iOS.
+ *
+ * The returned promise resolves with `void` when the sheet closes for
+ * any reason: Done button, backdrop tap, Escape, a header action tap,
+ * or an explicit `api.close()` from inside `renderBody`.
+ *
+ * @example
+ * ```ts
+ * await showMobileContentSheet(
+ *     this._layoutService.mainContainer,
+ *     localize('confirm.title', "Confirm Tool Use"),
+ *     (body, api) => {
+ *         const store = new DisposableStore();
+ *         const summary = DOM.append(body, DOM.$('div.tool-confirm-summary'));
+ *         summary.textContent = toolDescription;
+ *
+ *         const approve = DOM.append(body, DOM.$('button.tool-confirm-approve'));
+ *         approve.textContent = localize('confirm.approve', "Approve");
+ *         store.add(DOM.addDisposableListener(approve, 'click', () => {
+ *             writeApproval();
+ *             api.close();
+ *         }));
+ *
+ *         return store;
+ *     },
+ *     { caption: localize('confirm.caption', "This will modify your workspace.") },
+ * );
+ * ```
+ */
+export function showMobileContentSheet(
+	workbenchContainer: HTMLElement,
+	title: string,
+	renderBody: (bodyElement: HTMLElement, api: IMobileContentSheetApi) => IDisposable | void,
+	options?: IMobileContentSheetOptions,
+): Promise<void> {
+	return new Promise<void>(resolve => {
+		let resolved = false;
+		let shell!: IMobileSheetShell;
+
+		const close = () => {
+			if (resolved) {
+				return;
+			}
+			resolved = true;
+			shell.close(() => resolve());
+		};
+
+		shell = buildMobileSheetShell(workbenchContainer, title, {
+			caption: options?.caption,
+			headerActions: options?.headerActions,
+			doneLabel: options?.doneLabel,
+			hideDoneButton: options?.hideDoneButton,
+			onDismiss: close,
+			onHeaderAction: () => close(),
+		});
+
+		const bodyContainer = DOM.append(shell.sheet, $('div.mobile-content-sheet-body'));
+
+		const api: IMobileContentSheetApi = { bodyContainer, close };
+		const bodyDisposable = renderBody(bodyContainer, api);
+		if (bodyDisposable) {
+			shell.disposables.add(bodyDisposable);
+		}
+	});
+}
+
+/** Options consumed by {@link buildMobileSheetShell}. */
+interface IMobileSheetShellOptions {
+	readonly caption?: string;
+	readonly headerActions?: readonly IMobilePickerSheetHeaderAction[];
+	readonly doneLabel?: string;
+	readonly hideDoneButton?: boolean;
+	/**
+	 * Called when the user dismisses the sheet via the Done button,
+	 * backdrop tap, or Escape key. The shell does NOT close itself in
+	 * response to dismissal — the caller is expected to invoke
+	 * {@link IMobileSheetShell.close} from this callback.
+	 */
+	readonly onDismiss: () => void;
+	/**
+	 * Called when a header action button is tapped. If omitted, header
+	 * action taps fall through to {@link onDismiss}.
+	 */
+	readonly onHeaderAction?: (actionId: string) => void;
+}
+
+/** Primitives returned by {@link buildMobileSheetShell}. */
+interface IMobileSheetShell {
+	readonly overlay: HTMLElement;
+	readonly backdrop: HTMLElement;
+	/** The sheet container — append body content here. */
+	readonly sheet: HTMLElement;
+	/** Disposable store tied to the sheet's lifetime; cleared on close. */
+	readonly disposables: DisposableStore;
+	/**
+	 * Play the close animation, dispose listeners, and remove the DOM
+	 * node after the animation completes. Idempotent — subsequent
+	 * calls are no-ops. The optional callback fires once the node has
+	 * been removed.
+	 */
+	close(onAnimationEnd?: () => void): void;
+}
+
+/**
+ * Build the shared shell for {@link showMobilePickerSheet} and
+ * {@link showMobileContentSheet}: overlay, backdrop, sheet (drag handle,
+ * title row with Done button and optional header actions, optional
+ * caption), backdrop / Escape dismissal, and iOS visual-viewport
+ * keyboard avoidance. Callers append their own content children to
+ * `sheet`.
+ */
+function buildMobileSheetShell(
+	workbenchContainer: HTMLElement,
+	title: string,
+	options: IMobileSheetShellOptions,
+): IMobileSheetShell {
+	const disposables = new DisposableStore();
+	let closed = false;
+
+	// -- DOM: backdrop + sheet -------------------------------------
+	const overlay = DOM.append(workbenchContainer, $('div.mobile-picker-sheet-overlay'));
+	const backdrop = DOM.append(overlay, $('div.mobile-picker-sheet-backdrop'));
+	const sheet = DOM.append(overlay, $('div.mobile-picker-sheet'));
+	sheet.setAttribute('role', 'dialog');
+	sheet.setAttribute('aria-modal', 'true');
+	sheet.setAttribute('aria-label', title);
+
+	// -- Header (drag handle + title row + caption) ----------------
+	DOM.append(sheet, $('div.mobile-picker-sheet-handle'));
+
+	const titleRow = DOM.append(sheet, $('div.mobile-picker-sheet-title-row'));
+	const titleEl = DOM.append(titleRow, $('div.mobile-picker-sheet-title'));
+	titleEl.textContent = title;
+
+	// Optional header actions (icon buttons) rendered between the
+	// title and the Done button. Useful for sheet-level shortcuts
+	// like "browse for a folder" that aren't a single picker row.
+	if (options.headerActions) {
+		for (const action of options.headerActions) {
+			const btn = DOM.append(titleRow, $('button.mobile-picker-sheet-header-action', { type: 'button' })) as HTMLButtonElement;
+			btn.setAttribute('aria-label', action.label);
+			btn.title = action.label;
+			const iconHost = DOM.append(btn, $('span.mobile-picker-sheet-header-action-icon'));
+			const iconEl = DOM.append(iconHost, $('span.mobile-picker-sheet-header-action-icon-glyph'));
+			iconEl.classList.add(...ThemeIcon.asClassNameArray(action.icon));
+			const btnGesture = Gesture.addTarget(btn);
+			disposables.add(btnGesture);
+			const onActivate = () => {
+				if (options.onHeaderAction) {
+					options.onHeaderAction(action.id);
+				} else {
+					options.onDismiss();
+				}
+			};
+			const btnClick = DOM.addDisposableListener(btn, DOM.EventType.CLICK, (e: MouseEvent) => {
+				e.preventDefault();
+				onActivate();
+			});
+			disposables.add(btnClick);
+			const btnTap = DOM.addDisposableListener(btn, TouchEventType.Tap, onActivate);
+			disposables.add(btnTap);
+		}
+	}
+
+	if (!options.hideDoneButton) {
+		const doneBtn = DOM.append(titleRow, $('button.mobile-picker-sheet-done', { type: 'button' })) as HTMLButtonElement;
+		doneBtn.textContent = options.doneLabel ?? localize('mobilePickerSheet.done', "Done");
+		doneBtn.setAttribute('aria-label', localize('mobilePickerSheet.doneAriaLabel', "Close {0}", title));
+		const doneGesture = Gesture.addTarget(doneBtn);
+		disposables.add(doneGesture);
+		const doneClick = DOM.addDisposableListener(doneBtn, DOM.EventType.CLICK, (e: MouseEvent) => {
+			e.preventDefault();
+			options.onDismiss();
+		});
+		disposables.add(doneClick);
+		const doneTap = DOM.addDisposableListener(doneBtn, TouchEventType.Tap, () => options.onDismiss());
+		disposables.add(doneTap);
+	}
+
+	if (options.caption) {
+		const caption = DOM.append(sheet, $('div.mobile-picker-sheet-caption'));
+		caption.textContent = options.caption;
+	}
+
+	// -- Dismissal: backdrop + Escape ------------------------------
+	const backdropClick = DOM.addDisposableListener(backdrop, DOM.EventType.CLICK, () => options.onDismiss());
+	disposables.add(backdropClick);
+	const backdropGesture = Gesture.addTarget(backdrop);
+	disposables.add(backdropGesture);
+	const backdropTap = DOM.addDisposableListener(backdrop, TouchEventType.Tap, () => options.onDismiss());
+	disposables.add(backdropTap);
+
+	const keyHandler = DOM.addDisposableListener(DOM.getWindow(workbenchContainer), DOM.EventType.KEY_DOWN, (e: KeyboardEvent) => {
+		if (e.key === 'Escape') {
+			e.preventDefault();
+			e.stopPropagation();
+			options.onDismiss();
+		}
+	}, true);
+	disposables.add(keyHandler);
+
+	// -- iOS keyboard avoidance -----------------------------------
+	// On iOS Safari, when the virtual keyboard opens the layout
+	// viewport (`vh` units) does NOT shrink — only the visual
+	// viewport changes. The sheet uses `position: fixed` which
+	// positions against the layout viewport, so without correction
+	// the keyboard covers the bottom portion of the sheet (including
+	// any input the user is actively typing into).
+	//
+	// `window.visualViewport` exposes the real visible area. We
+	// listen for `resize` and `scroll` events on it and translate
+	// the sheet upward by the keyboard height so the focused input
+	// remains visible.
+	const win = DOM.getWindow(workbenchContainer);
+	const vv = win.visualViewport;
+	if (vv) {
+		const adjustForKeyboard = () => {
+			// The keyboard height is the difference between the
+			// layout viewport height and the visual viewport height,
+			// plus any scroll offset the browser applied.
+			const keyboardHeight = win.innerHeight - vv.height;
+			overlay.style.bottom = `${Math.max(0, keyboardHeight)}px`;
+			overlay.style.height = `${vv.height}px`;
+		};
+		vv.addEventListener('resize', adjustForKeyboard);
+		vv.addEventListener('scroll', adjustForKeyboard);
+		disposables.add(toDisposable(() => {
+			vv.removeEventListener('resize', adjustForKeyboard);
+			vv.removeEventListener('scroll', adjustForKeyboard);
+			overlay.style.bottom = '';
+			overlay.style.height = '';
+		}));
+		// Run once immediately in case the keyboard is already
+		// visible (e.g., sheet opened while another input had focus).
+		adjustForKeyboard();
+	}
+
+	const close = (onAnimationEnd?: () => void) => {
+		if (closed) {
+			return;
+		}
+		closed = true;
+		sheet.classList.add('closing');
+		backdrop.classList.add('closing');
+		// Dispose all event listeners and inflight queries immediately
+		// so nothing fires during the 180ms close animation. The DOM
+		// node itself is removed at the end of the animation.
+		disposables.dispose();
+		DOM.getWindow(workbenchContainer).setTimeout(() => {
+			overlay.remove();
+			onAnimationEnd?.();
+		}, 180);
+	};
+
+	return { overlay, backdrop, sheet, disposables, close };
 }
 
 /** Mutable bookkeeping passed through {@link renderRow} so we can track section dividers and the row to focus. */

--- a/src/vs/sessions/browser/parts/mobile/mobileVisualViewport.ts
+++ b/src/vs/sessions/browser/parts/mobile/mobileVisualViewport.ts
@@ -1,0 +1,166 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as DOM from '../../../../base/browser/dom.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { derived, IObservable, observableValue } from '../../../../base/common/observable.js';
+import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+import { ILayoutService } from '../../../../platform/layout/browser/layoutService.js';
+import { KeyboardVisibleContext } from '../../../common/contextkeys.js';
+
+/**
+ * Threshold (in CSS pixels) above which the visual viewport delta is
+ * treated as a virtual keyboard being visible. A few dozen pixels can
+ * appear briefly during URL-bar collapse / address-bar shrink, so we
+ * require a clearly keyboard-sized delta before flipping the context.
+ */
+export const KEYBOARD_VISIBLE_THRESHOLD_PX = 50;
+
+/**
+ * CSS custom property exposed on the workbench main container that
+ * reflects the current virtual keyboard height in pixels (e.g.
+ * `--vscode-keyboard-height: 320px`). Consumers can read this from
+ * CSS (`bottom: var(--vscode-keyboard-height, 0px)`) when they need
+ * to keep UI above the keyboard without subscribing to the observable.
+ */
+const KEYBOARD_HEIGHT_CSS_VAR = '--vscode-keyboard-height';
+
+/**
+ * Service decorator for {@link MobileVisualViewport}. Consumers inject
+ * this to observe the virtual keyboard height of the agents workbench
+ * window or to gate behaviour on whether the keyboard is currently
+ * visible.
+ */
+export const IMobileVisualViewport = createDecorator<IMobileVisualViewport>('mobileVisualViewport');
+
+/**
+ * Service interface for {@link MobileVisualViewport}. See the class for
+ * a full description of the publishing surface.
+ */
+export interface IMobileVisualViewport {
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * Observable: the current virtual keyboard height in CSS pixels,
+	 * computed as `max(0, window.innerHeight - visualViewport.height)`.
+	 * Always `0` on platforms without `visualViewport` support.
+	 */
+	readonly keyboardHeight: IObservable<number>;
+
+	/**
+	 * Observable: `true` when {@link keyboardHeight} exceeds
+	 * {@link KEYBOARD_VISIBLE_THRESHOLD_PX}. Cheaper for consumers than
+	 * subscribing to `keyboardHeight` directly when they only care
+	 * about the keyboard-visible transition (it only fires on the
+	 * boolean flip, not on every height micro-change during the
+	 * keyboard open/close animation).
+	 */
+	readonly isKeyboardVisible: IObservable<boolean>;
+}
+
+/**
+ * Tracks the virtual keyboard height of the agents workbench window via
+ * the `window.visualViewport` API and exposes it to consumers in three
+ * complementary forms:
+ *
+ *  1. As an {@link IObservable} (`keyboardHeight`) for code that wants
+ *     to react to keyboard changes via `autorun` / `derived`.
+ *  2. As a CSS custom property (`--vscode-keyboard-height`) set on the
+ *     workbench main container, so styles can position fixed UI above
+ *     the keyboard without touching JavaScript at all.
+ *  3. As a reactive {@link KeyboardVisibleContext} context key (`true`
+ *     when the keyboard height exceeds {@link KEYBOARD_VISIBLE_THRESHOLD_PX}),
+ *     so `when:` clauses on commands/menus can adapt to the keyboard.
+ *
+ * # Why this helper exists
+ *
+ * On iOS Safari (and to a lesser extent some Android browsers), the
+ * *layout viewport* — what `vh` units, `window.innerHeight`, and
+ * `position: fixed` resolve against — does NOT shrink when the virtual
+ * keyboard opens. Only the *visual viewport* (the actually visible
+ * area) shrinks. As a consequence, naive layouts that anchor to the
+ * bottom of the layout viewport end up hidden behind the keyboard.
+ *
+ * The standard `window.visualViewport` API exposes the real visible
+ * area and fires `resize` / `scroll` events when the keyboard opens
+ * or closes. This helper subscribes to those events once for the
+ * lifetime of the workbench window and publishes the keyboard height
+ * (`max(0, window.innerHeight - visualViewport.height)`).
+ *
+ * # Auxiliary windows
+ *
+ * The helper uses {@link DOM.getWindow} to resolve the correct window
+ * object for the layout-service main container, so it works correctly
+ * when the workbench is hosted inside an auxiliary window (each aux
+ * window has its own `visualViewport`).
+ *
+ * # Graceful degradation
+ *
+ * Browsers that do not implement `visualViewport` (very old engines,
+ * some embedded webviews) get a constant `keyboardHeight` of `0`, no
+ * CSS variable update, and a context key that stays `false`. Consumers
+ * never need to check for the API themselves.
+ */
+export class MobileVisualViewport extends Disposable implements IMobileVisualViewport {
+
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _keyboardHeight = observableValue<number>(this, 0);
+
+	readonly keyboardHeight: IObservable<number> = this._keyboardHeight;
+
+	readonly isKeyboardVisible: IObservable<boolean> = derived(this, reader =>
+		this._keyboardHeight.read(reader) > KEYBOARD_VISIBLE_THRESHOLD_PX
+	);
+
+	private readonly _keyboardVisibleCtx: IContextKey<boolean>;
+	private readonly mainContainer: HTMLElement;
+
+	constructor(
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@ILayoutService layoutService: ILayoutService,
+	) {
+		super();
+
+		this.mainContainer = layoutService.mainContainer;
+		this._keyboardVisibleCtx = KeyboardVisibleContext.bindTo(contextKeyService);
+
+		const targetWindow = DOM.getWindow(this.mainContainer);
+		const visualViewport = targetWindow.visualViewport;
+
+		if (!visualViewport) {
+			// No visualViewport API available — keep observables/context
+			// keys at their default zero/false state.
+			return;
+		}
+
+		const update = () => {
+			const height = Math.max(0, targetWindow.innerHeight - visualViewport.height);
+			if (this._keyboardHeight.get() !== height) {
+				this._keyboardHeight.set(height, undefined);
+			}
+			this.mainContainer.style.setProperty(KEYBOARD_HEIGHT_CSS_VAR, `${height}px`);
+			this._keyboardVisibleCtx.set(height > KEYBOARD_VISIBLE_THRESHOLD_PX);
+		};
+
+		this._register(DOM.addDisposableListener(visualViewport, 'resize', update));
+		this._register(DOM.addDisposableListener(visualViewport, 'scroll', update));
+
+		// Seed the initial value so consumers see the current state on
+		// startup (e.g., the workbench was opened while the keyboard
+		// was already visible).
+		update();
+	}
+
+	override dispose(): void {
+		this.mainContainer.style.removeProperty(KEYBOARD_HEIGHT_CSS_VAR);
+		this._keyboardVisibleCtx.reset();
+		super.dispose();
+	}
+}
+
+registerSingleton(IMobileVisualViewport, MobileVisualViewport, InstantiationType.Eager);

--- a/src/vs/sessions/browser/workbench.ts
+++ b/src/vs/sessions/browser/workbench.ts
@@ -72,6 +72,7 @@ import {
 import { SessionsLayoutPolicy } from './layoutPolicy.js';
 import { MobileNavigationStack } from './mobileNavigationStack.js';
 import { MobileTitlebarPart } from './parts/mobile/mobileTitlebarPart.js';
+import { installMobileEdgeSwipeToOpenSidebar } from './parts/mobile/mobileEdgeSwipe.js';
 import { IMobileVisualViewport } from './parts/mobile/mobileVisualViewport.js';
 import { autorun } from '../../base/common/observable.js';
 import { ISessionsManagementService } from '../services/sessions/common/sessionsManagement.js';
@@ -788,6 +789,16 @@ export class Workbench extends Disposable implements IAgentWorkbenchLayoutServic
 			this.sessionsManagementService.openNewSessionView();
 			this.closeMobileSidebarDrawer();
 		}));
+
+		// Left-edge swipe alternate-open for the sidebar drawer. The gesture
+		// listens on the main workbench container and only fires when the
+		// phone-layout class is present and the sidebar isn't already open,
+		// so it is safe to keep installed alongside the hamburger button.
+		this.mobileTopBarDisposables.add(installMobileEdgeSwipeToOpenSidebar(
+			this.mainContainer,
+			() => this.openMobileSidebarDrawer(),
+			this,
+		));
 	}
 
 	private toggleMobileSidebarDrawer(): void {

--- a/src/vs/sessions/browser/workbench.ts
+++ b/src/vs/sessions/browser/workbench.ts
@@ -63,7 +63,7 @@ import { EditorMarkdownCodeBlockRenderer } from '../../editor/browser/widget/mar
 import { SyncDescriptor } from '../../platform/instantiation/common/descriptors.js';
 import { TitleService } from './parts/titlebarPart.js';
 import { IContextKeyService } from '../../platform/contextkey/common/contextkey.js';
-import { EditorMaximizedContext, IsPhoneLayoutContext, KeyboardVisibleContext } from '../common/contextkeys.js';
+import { EditorMaximizedContext, IsPhoneLayoutContext } from '../common/contextkeys.js';
 import {
 	NotificationsPosition,
 	NotificationsSettings,
@@ -72,6 +72,7 @@ import {
 import { SessionsLayoutPolicy } from './layoutPolicy.js';
 import { MobileNavigationStack } from './mobileNavigationStack.js';
 import { MobileTitlebarPart } from './parts/mobile/mobileTitlebarPart.js';
+import { IMobileVisualViewport } from './parts/mobile/mobileVisualViewport.js';
 import { autorun } from '../../base/common/observable.js';
 import { ISessionsManagementService } from '../services/sessions/common/sessionsManagement.js';
 import { ISessionsPartService } from './parts/sessionsPartService.js';
@@ -456,28 +457,15 @@ export class Workbench extends Disposable implements IAgentWorkbenchLayoutServic
 					isPhoneLayoutCtx.set(this.layoutPolicy.viewportClass.read(reader) === 'phone');
 				}));
 
-				// Virtual keyboard detection via visualViewport API.
-				// Use `window.innerHeight` (layout viewport) as the baseline
-				// rather than a captured initial height. Layout viewport
-				// updates on orientation change and split-screen resizes, so
-				// comparing against it avoids stale baselines on landscape
-				// launches, Android split-screen, and iOS URL-bar collapse.
-				if (mainWindow.visualViewport) {
-					const keyboardVisibleCtx = KeyboardVisibleContext.bindTo(contextKeyService);
-					const KEYBOARD_HEIGHT_THRESHOLD_PX = 100;
-
-					const onViewportResize = () => {
-						const vp = mainWindow.visualViewport;
-						if (!vp) {
-							return;
-						}
-						const heightDiff = mainWindow.innerHeight - vp.height;
-						keyboardVisibleCtx.set(heightDiff > KEYBOARD_HEIGHT_THRESHOLD_PX);
-					};
-
-					mainWindow.visualViewport.addEventListener('resize', onViewportResize);
-					this._register({ dispose: () => mainWindow.visualViewport?.removeEventListener('resize', onViewportResize) });
-				}
+				// Virtual keyboard tracking (visualViewport): publishes the
+				// keyboard height as an observable, mirrors it onto the
+				// `--vscode-keyboard-height` CSS variable on the main
+				// container, and drives the `KeyboardVisibleContext`
+				// context key. The service is an eager singleton, so
+				// resolving it here is what triggers its constructor —
+				// the registry hands ownership/disposal to the
+				// instantiation service so we don't `_register` it.
+				accessor.get(IMobileVisualViewport);
 
 				// Orientation changes produce a window `resize` event which
 				// is already handled by `registerLayoutListeners()`. No

--- a/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
@@ -33,6 +33,7 @@ import { SessionsChatAccessibilityHelp } from './sessionsChatAccessibilityHelp.j
 import { SessionsOpenerParticipantContribution } from './sessionsOpenerParticipant.js';
 import { WorktreeCreatedTaskDispatcher, AGENT_HOST_RUN_WORKTREE_CREATED_TASKS_SETTING } from './worktreeCreatedTaskDispatcher.js';
 import '../../sessions/browser/mobile/mobileOverlayContribution.js';
+import './mobile/mobileCodeBlockOverlay.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 
 

--- a/src/vs/sessions/contrib/chat/browser/mobile/mobileCodeBlockOverlay.ts
+++ b/src/vs/sessions/contrib/chat/browser/mobile/mobileCodeBlockOverlay.ts
@@ -1,0 +1,352 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import '../../../../browser/parts/mobile/contributions/media/mobileOverlayViews.css';
+import * as DOM from '../../../../../base/browser/dom.js';
+import { Disposable, DisposableStore, MutableDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
+import { Emitter, Event } from '../../../../../base/common/event.js';
+import { Gesture, EventType as TouchEventType } from '../../../../../base/browser/touch.js';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
+import { localize, localize2 } from '../../../../../nls.js';
+import { Action2, registerAction2 } from '../../../../../platform/actions/common/actions.js';
+import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
+import { ILayoutService } from '../../../../../platform/layout/browser/layoutService.js';
+import { ILanguageService } from '../../../../../editor/common/languages/language.js';
+import { TokenizationRegistry } from '../../../../../editor/common/languages.js';
+import { generateTokensCSSForColorMap } from '../../../../../editor/common/languages/supports/tokenization.js';
+import {
+	hasMultipleTokenClasses,
+	LANGUAGE_ID_ALIAS,
+	regexTokenizeLines,
+	tokenizeFileLines,
+} from '../../../../browser/parts/mobile/contributions/mobileSyntaxHighlight.js';
+import { installPulldownDismiss } from '../../../../browser/parts/mobile/contributions/mobilePulldownDismiss.js';
+import { IsPhoneLayoutContext } from '../../../../common/contextkeys.js';
+
+const $ = DOM.$;
+
+/**
+ * Command id for opening the {@link MobileCodeBlockOverlay}.
+ *
+ * Accepts {@link IMobileCodeBlockOverlayData} as the single argument.
+ * Phone-only. Mirrors `sessions.mobile.openDiffView` in shape and
+ * lifecycle (module-level slot, self-dispose on Back tap).
+ */
+export const MOBILE_OPEN_CODEBLOCK_OVERLAY_COMMAND_ID = 'sessions.mobile.openCodeBlockOverlay';
+
+/**
+ * Data passed to {@link MobileCodeBlockOverlay} when opening the
+ * overlay. `code` is the raw text content; `languageId` is the chat
+ * code fence's language hint (e.g. `'typescript'`, `'ts'`, `'python'`)
+ * — we normalise it against {@link LANGUAGE_ID_ALIAS} before handing
+ * off to the tokenizer. `title` overrides the default header label
+ * (which is the resolved language id or the localized fallback).
+ */
+export interface IMobileCodeBlockOverlayData {
+	readonly code: string;
+	readonly languageId: string | undefined;
+	readonly title?: string;
+}
+
+/**
+ * Full-viewport overlay for a single chat code block on phone-layout
+ * viewports.
+ *
+ * Mirrors the {@link MobileDiffView} pattern — same `mobile-overlay-*`
+ * chrome (header with back button + title + trailing action, scrollable
+ * body) — but renders a single `<pre>` with Monaco-quality syntax
+ * highlighting (or a regex fallback for languages whose TextMate
+ * grammar is not loaded in the agents window). Header carries a copy
+ * action that writes the raw code to the clipboard and shows a brief
+ * "Copied" badge.
+ *
+ * The header doubles as a pull-down drag handle: dragging it past the
+ * commit threshold dismisses the overlay.
+ */
+export class MobileCodeBlockOverlay extends Disposable {
+
+	private readonly _onDidDispose = this._register(new Emitter<void>());
+	/**
+	 * Fires when this overlay has been disposed (either externally or
+	 * because the user tapped Back). Used by the contribution to clear
+	 * its `MutableDisposable<MobileCodeBlockOverlay>` slot so the slot
+	 * value tracks "no overlay open" correctly.
+	 */
+	readonly onDidDispose: Event<void> = this._onDidDispose.event;
+
+	private readonly viewStore = this._register(new DisposableStore());
+
+	private disposed = false;
+	/**
+	 * Bumped on every body render so late-arriving `tokenizeFileLines`
+	 * promises know to drop their results when the overlay has been
+	 * disposed before tokenization finished.
+	 */
+	private renderGeneration = 0;
+
+	private readonly code: string;
+	private readonly resolvedLanguageId: string;
+	private readonly displayTitle: string;
+
+	private contentArea!: HTMLElement;
+	private copyBadgeEl!: HTMLElement;
+	private copyBadgeTimer = this._register(new MutableDisposable());
+
+	constructor(
+		workbenchContainer: HTMLElement,
+		data: IMobileCodeBlockOverlayData,
+		private readonly languageService: ILanguageService,
+	) {
+		super();
+
+		this.code = data.code;
+		this.resolvedLanguageId = this.resolveLanguageId(data.languageId);
+		this.displayTitle = data.title ?? (this.resolvedLanguageId !== 'plaintext'
+			? this.resolvedLanguageId
+			: localize('codeBlockOverlay.defaultTitle', "Code block"));
+
+		this.render(workbenchContainer);
+		void this.renderBody();
+	}
+
+	private render(workbenchContainer: HTMLElement): void {
+		// -- Root overlay -----------------------------------------
+		const overlay = DOM.append(workbenchContainer, $('div.mobile-overlay-view'));
+		this.viewStore.add(DOM.addDisposableListener(overlay, DOM.EventType.CONTEXT_MENU, e => e.preventDefault()));
+		this.viewStore.add(toDisposable(() => overlay.remove()));
+
+		// -- Header -----------------------------------------------
+		const header = DOM.append(overlay, $('div.mobile-overlay-header'));
+
+		const backBtn = DOM.append(header, $('button.mobile-overlay-back-btn', { type: 'button' })) as HTMLButtonElement;
+		backBtn.setAttribute('aria-label', localize('codeBlockOverlay.back', "Back"));
+		DOM.append(backBtn, $('span')).classList.add(...ThemeIcon.asClassNameArray(Codicon.chevronLeft));
+		DOM.append(backBtn, $('span.back-btn-label')).textContent = localize('codeBlockOverlay.backLabel', "Back");
+		this.viewStore.add(Gesture.addTarget(backBtn));
+		this.viewStore.add(DOM.addDisposableListener(backBtn, DOM.EventType.CLICK, () => this.dispose()));
+		this.viewStore.add(DOM.addDisposableListener(backBtn, TouchEventType.Tap, () => this.dispose()));
+
+		const info = DOM.append(header, $('div.mobile-overlay-header-info'));
+		DOM.append(info, $('div.mobile-overlay-header-title')).textContent = this.displayTitle;
+
+		// Copy action sits on the trailing edge of the header. The
+		// "Copied" badge is mounted alongside the button and toggled
+		// visible for ~1.5s on successful copy. Both controls live in
+		// the same flex slot so the badge appears in-place when shown.
+		const trailing = DOM.append(header, $('div.mobile-codeblock-overlay-header-trailing'));
+
+		this.copyBadgeEl = DOM.append(trailing, $('span.mobile-codeblock-overlay-copied-badge'));
+		this.copyBadgeEl.textContent = localize('codeBlockOverlay.copied', "Copied");
+		this.copyBadgeEl.style.display = 'none';
+		this.copyBadgeEl.setAttribute('aria-live', 'polite');
+
+		const copyBtn = DOM.append(trailing, $('button.mobile-codeblock-overlay-copy-btn', { type: 'button' })) as HTMLButtonElement;
+		copyBtn.setAttribute('aria-label', localize('codeBlockOverlay.copyAria', "Copy code"));
+		DOM.append(copyBtn, $('span')).classList.add(...ThemeIcon.asClassNameArray(Codicon.copy));
+		DOM.append(copyBtn, $('span.copy-btn-label')).textContent = localize('codeBlockOverlay.copyLabel', "Copy");
+		this.viewStore.add(Gesture.addTarget(copyBtn));
+		const onCopy = () => this.copyToClipboard();
+		this.viewStore.add(DOM.addDisposableListener(copyBtn, DOM.EventType.CLICK, onCopy));
+		this.viewStore.add(DOM.addDisposableListener(copyBtn, TouchEventType.Tap, onCopy));
+
+		// -- Body -------------------------------------------------
+		const body = DOM.append(overlay, $('div.mobile-overlay-body'));
+		const scrollWrapper = DOM.append(body, $('div.mobile-overlay-scroll'));
+		this.contentArea = DOM.append(scrollWrapper, $('pre.mobile-codeblock-overlay-pre'));
+
+		// Pull-down dismiss on the header drag handle. Back- and copy-
+		// button taps still work normally — only downward drags past a
+		// small dead zone are claimed by the gesture.
+		this.viewStore.add(installPulldownDismiss(overlay, header, () => this.dispose()));
+	}
+
+	private async renderBody(): Promise<void> {
+		this.renderGeneration++;
+		const generation = this.renderGeneration;
+
+		// Show plain text immediately so the user sees content while
+		// the async tokenizer warms up. Tokenized HTML replaces this
+		// once `tokenizeFileLines` resolves.
+		this.contentArea.textContent = this.code;
+
+		const tokenized = await tokenizeFileLines(this.languageService, this.code, this.resolvedLanguageId);
+		if (this.disposed || generation !== this.renderGeneration) {
+			return;
+		}
+
+		// Real tokenization produces multiple distinct mtk* classes; if
+		// every non-empty line collapses to `mtk1`, the grammar is not
+		// loaded and we fall back to the regex tokenizer that emits
+		// `mobile-diff-tok-*` classes (themed in mobileOverlayViews.css).
+		const hasRealTokens = hasMultipleTokenClasses(tokenized);
+		const lines = hasRealTokens ? tokenized : regexTokenizeLines(this.code, this.resolvedLanguageId);
+
+		// Inject a per-overlay <style> block carrying the Monaco token
+		// colour-map so `mtkN` classes resolve to colours. Not needed
+		// for the regex fallback (which uses themed CSS classes), but
+		// we still nest the style element inside the content area so
+		// it's torn down when the overlay is disposed.
+		DOM.clearNode(this.contentArea);
+		if (hasRealTokens) {
+			const colorMap = TokenizationRegistry.getColorMap();
+			if (colorMap) {
+				const styleEl = document.createElement('style');
+				styleEl.textContent = generateTokensCSSForColorMap(colorMap);
+				this.contentArea.appendChild(styleEl);
+			}
+		}
+
+		const code = DOM.append(this.contentArea, $('code.mobile-codeblock-overlay-code'));
+		// Newline-join the per-line HTML — `<pre>` preserves the breaks
+		// in the rendered text without needing per-line wrapper divs.
+		code.innerHTML = lines.join('\n');
+	}
+
+	private resolveLanguageId(raw: string | undefined): string {
+		if (!raw) {
+			return 'plaintext';
+		}
+		const normalized = raw.toLowerCase().trim();
+		if (!normalized) {
+			return 'plaintext';
+		}
+		// Aliases (`ts`, `py`, `sh`) map to the canonical id used by
+		// both the TextMate grammar registry and the regex fallback's
+		// lang-family table.
+		const aliased = LANGUAGE_ID_ALIAS[normalized] ?? normalized;
+		if (this.languageService.isRegisteredLanguageId(aliased)) {
+			return aliased;
+		}
+		// Case-insensitive name lookup (`JavaScript` → `javascript`).
+		const byName = this.languageService.getLanguageIdByLanguageName(aliased);
+		if (byName) {
+			return byName;
+		}
+		// Unknown id — pass through to the regex fallback. The
+		// tokenizer's `LANG_FAMILY` table will pick this up if it's a
+		// known family; otherwise it falls back to `'generic'`.
+		return aliased;
+	}
+
+	private async copyToClipboard(): Promise<void> {
+		// Prefer `navigator.clipboard.writeText` on browsers that grant
+		// the permission in this context; fall back to a transient
+		// textarea + `execCommand('copy')` for older / restricted
+		// environments. The fallback mirrors the workbench
+		// `BrowserClipboardService` behaviour without pulling that
+		// service in for a single string write.
+		let ok = false;
+		try {
+			await navigator.clipboard.writeText(this.code);
+			ok = true;
+		} catch {
+			ok = this.copyViaExecCommand();
+		}
+		if (ok) {
+			this.showCopiedBadge();
+		}
+	}
+
+	private copyViaExecCommand(): boolean {
+		const activeDocument = this.contentArea.ownerDocument ?? document;
+		const textArea = activeDocument.createElement('textarea');
+		// Off-screen but still in the DOM so `select()` works.
+		textArea.style.position = 'fixed';
+		textArea.style.top = '0';
+		textArea.style.left = '0';
+		textArea.style.width = '1px';
+		textArea.style.height = '1px';
+		textArea.style.opacity = '0';
+		textArea.style.pointerEvents = 'none';
+		textArea.setAttribute('aria-hidden', 'true');
+		textArea.value = this.code;
+		activeDocument.body.appendChild(textArea);
+		try {
+			textArea.select();
+			return activeDocument.execCommand('copy');
+		} catch {
+			return false;
+		} finally {
+			textArea.remove();
+		}
+	}
+
+	private showCopiedBadge(): void {
+		this.copyBadgeEl.style.display = '';
+		const handle = setTimeout(() => {
+			if (this.disposed) {
+				return;
+			}
+			this.copyBadgeEl.style.display = 'none';
+		}, 1500);
+		this.copyBadgeTimer.value = toDisposable(() => clearTimeout(handle));
+	}
+
+	override dispose(): void {
+		this.disposed = true;
+		// Notify external slot-holders before any registered disposables
+		// (including the emitter itself) get torn down by `super.dispose()`.
+		this._onDidDispose.fire();
+		this.viewStore.dispose();
+		super.dispose();
+	}
+}
+
+/**
+ * Opens a {@link MobileCodeBlockOverlay} for the given code block.
+ * Returns the overlay instance; dispose it to close.
+ */
+export function openMobileCodeBlockOverlay(
+	container: HTMLElement,
+	data: IMobileCodeBlockOverlayData,
+	languageService: ILanguageService,
+): MobileCodeBlockOverlay {
+	return new MobileCodeBlockOverlay(container, data, languageService);
+}
+
+// -- Command registration -----------------------------------------------------
+
+// Module-level slot for the active overlay so a re-invocation of the
+// command (e.g. a stray double-tap on the expand affordance) closes the
+// prior overlay before opening a new one. The overlay self-disposes
+// when the user taps Back; we listen for `onDidDispose` to clear the
+// slot so `MutableDisposable.value === undefined` correctly tracks
+// "no overlay open" and stale references are never kept around.
+const activeOverlay = new MutableDisposable<MobileCodeBlockOverlay>();
+
+class MobileOpenCodeBlockOverlayAction extends Action2 {
+	constructor() {
+		super({
+			id: MOBILE_OPEN_CODEBLOCK_OVERLAY_COMMAND_ID,
+			title: localize2('mobileOpenCodeBlock', 'Open Code Block'),
+			precondition: IsPhoneLayoutContext,
+			f1: false,
+		});
+	}
+
+	run(accessor: ServicesAccessor, data: IMobileCodeBlockOverlayData): void {
+		if (!data || typeof data.code !== 'string') {
+			return;
+		}
+		const layoutService = accessor.get(ILayoutService);
+		const languageService = accessor.get(ILanguageService);
+
+		activeOverlay.value = openMobileCodeBlockOverlay(layoutService.mainContainer, data, languageService);
+		// Clear the slot when the overlay tears itself down (back tap)
+		// so the slot value tracks "no overlay open" correctly. The
+		// equality guard ensures a newer overlay that has already
+		// replaced `value` doesn't get stomped on by the prior
+		// overlay's `onDidDispose` firing late.
+		const view = activeOverlay.value;
+		Event.once(view.onDidDispose)(() => {
+			if (activeOverlay.value === view) {
+				activeOverlay.clear();
+			}
+		});
+	}
+}
+
+registerAction2(MobileOpenCodeBlockOverlayAction);

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/codeBlockPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/codeBlockPart.ts
@@ -14,6 +14,7 @@ import { Event } from '../../../../../../base/common/event.js';
 import { combinedDisposable, Disposable, MutableDisposable, thenRegisterOrDispose } from '../../../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../../../base/common/network.js';
 import { isEqual } from '../../../../../../base/common/resources.js';
+import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { assertType } from '../../../../../../base/common/types.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { generateUuid } from '../../../../../../base/common/uuid.js';
@@ -50,6 +51,7 @@ import { IAccessibilityService } from '../../../../../../platform/accessibility/
 import { ILogService } from '../../../../../../platform/log/common/log.js';
 import { MenuWorkbenchToolBar } from '../../../../../../platform/actions/browser/toolbar.js';
 import { MenuId } from '../../../../../../platform/actions/common/actions.js';
+import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { IDialogService } from '../../../../../../platform/dialogs/common/dialogs.js';
@@ -120,6 +122,25 @@ export interface ICodeBlockRenderOptions {
 
 const defaultCodeblockPadding = 10;
 const defaultChatScrollbarSize = 7;
+
+/**
+ * Number of lines above which the phone-layout "Tap to expand" affordance
+ * is shown beneath the code block. Twelve lines comfortably fits on a
+ * portrait phone viewport without the user having to scroll the code
+ * block in place; anything longer benefits from the full-viewport
+ * overlay (see `MobileCodeBlockOverlay`).
+ */
+const MOBILE_EXPAND_LINE_THRESHOLD = 12;
+
+/**
+ * Command id of the phone-only code-block overlay. Referenced by string
+ * to keep `vs/workbench` from depending on `vs/sessions` (the overlay
+ * lives in the sessions layer, which is allowed to depend on workbench
+ * but not the other way around). The shape of the argument mirrors
+ * `IMobileCodeBlockOverlayData` in `mobileCodeBlockOverlay.ts`.
+ */
+const MOBILE_OPEN_CODEBLOCK_OVERLAY_COMMAND_ID = 'sessions.mobile.openCodeBlockOverlay';
+
 export class CodeBlockPart extends Disposable {
 
 	/**
@@ -152,6 +173,20 @@ export class CodeBlockPart extends Disposable {
 	private _isDropdownVisible = false;
 	private _toolbarElement!: HTMLElement;
 
+	/**
+	 * Phone-only "Tap to expand" affordance row appended at the bottom of
+	 * the code block. Shown only when the rendered code exceeds
+	 * {@link MOBILE_EXPAND_LINE_THRESHOLD} lines AND the phone layout
+	 * context key is set; tapping it opens the {@link MobileCodeBlockOverlay}
+	 * via the `sessions.mobile.openCodeBlockOverlay` command (referenced
+	 * by string to avoid a cross-layer import from `vs/sessions`).
+	 *
+	 * Skipped entirely when {@link isSimpleWidget} is true — the simple
+	 * variant is used for embedded edit-pill / input-bar code blocks that
+	 * neither need nor have room for a tap-to-expand row.
+	 */
+	private _mobileExpandRow: HTMLElement | undefined;
+
 	private isDisposed = false;
 
 	private resourceContextKey: StaticResourceContextKey;
@@ -174,6 +209,7 @@ export class CodeBlockPart extends Disposable {
 		@IAccessibilityService private readonly accessibilityService: IAccessibilityService,
 		@ILogService private readonly logService: ILogService,
 		@ITextModelService private readonly textModelService: ITextModelService,
+		@ICommandService private readonly commandService: ICommandService,
 	) {
 		super();
 		this.element = $('.interactive-result-code-block');
@@ -238,6 +274,43 @@ export class CodeBlockPart extends Disposable {
 		}));
 
 		this.vulnsListElement = dom.append(vulnsContainer, $('ul.interactive-result-vulns-list'));
+
+		// Phone-only "Tap to expand" affordance. Created lazily here so the
+		// DOM cost is paid once per pooled CodeBlockPart instance; the row
+		// is shown/hidden per render based on line count + phone context.
+		// Skipped entirely for the simple-widget variant (input bar / edit
+		// pill embeddings) which doesn't need a separate expand surface.
+		if (!this.isSimpleWidget) {
+			const expandRow = dom.append(this.element, $('.chat-code-block-mobile-expand'));
+			expandRow.setAttribute('role', 'button');
+			expandRow.setAttribute('tabindex', '0');
+			const expandLabel = localize('chat.codeBlockExpand', "Tap to expand");
+			expandRow.setAttribute('aria-label', expandLabel);
+			const expandIcon = dom.append(expandRow, $('span.chat-code-block-mobile-expand-icon'));
+			expandIcon.classList.add(...ThemeIcon.asClassNameArray(Codicon.chevronDown));
+			dom.append(expandRow, $('span.chat-code-block-mobile-expand-label')).textContent = expandLabel;
+			expandRow.style.display = 'none';
+			this._mobileExpandRow = expandRow;
+			const openOverlay = (e: MouseEvent | KeyboardEvent) => {
+				const data = this.currentCodeBlockData;
+				if (!data) {
+					return;
+				}
+				e.preventDefault();
+				e.stopPropagation();
+				const code = this._textModel.getValue(EndOfLinePreference.LF);
+				this.commandService.executeCommand(MOBILE_OPEN_CODEBLOCK_OVERLAY_COMMAND_ID, {
+					code,
+					languageId: this._textModel.getLanguageId(),
+				});
+			};
+			this._register(dom.addDisposableListener(expandRow, dom.EventType.CLICK, openOverlay));
+			this._register(dom.addDisposableListener(expandRow, dom.EventType.KEY_DOWN, (e: KeyboardEvent) => {
+				if (e.key === 'Enter' || e.key === ' ') {
+					openOverlay(e);
+				}
+			}));
+		}
 
 		this._register(this.vulnsButton.onDidClick(() => {
 			const element = this.currentCodeBlockData!.element as IChatResponseViewModel;
@@ -556,12 +629,34 @@ export class CodeBlockPart extends Disposable {
 
 		this.layout();
 
+		// Update the phone-only expand affordance based on the freshly-set
+		// model. Re-evaluated on every render pass so streaming content
+		// reveals the affordance once the line threshold is crossed, and
+		// hides it again on a pool-reuse with a shorter snippet. No model
+		// change-subscription — we deliberately snapshot the line count
+		// at render time per the design (see field doc).
+		this.updateMobileExpandAffordance();
+
 		// The editor element is typically not yet connected to the live DOM at
 		// this point (the caller still needs to attach it). Any render pass
 		// scheduled by setText/setLanguage/layout is silently dropped by the
 		// editor view when `isConnected` is false. Schedule a deferred render
 		// so the view lines are painted once the element is in the document.
 		this.editor.renderAsync(true);
+	}
+
+	private updateMobileExpandAffordance(): void {
+		const row = this._mobileExpandRow;
+		if (!row) {
+			return;
+		}
+		const lineCount = this._textModel.getLineCount();
+		const isPhone = this.contextKeyService.getContextKeyValue<boolean>('sessionsIsPhoneLayout') === true;
+		if (isPhone && lineCount > MOBILE_EXPAND_LINE_THRESHOLD) {
+			row.style.display = '';
+		} else {
+			row.style.display = 'none';
+		}
 	}
 
 	reset() {


### PR DESCRIPTION
## Mobile chat (3/10) — overlays polish

Stacked on #318647 (PR 1: mobile infra primitives).

### Scope

This PR wires the previously-introduced infra primitives into the mobile chat surface and adds the code-block overlay surface.

**Code-block overlay (new):**
- `mobileCodeBlockOverlay.ts` — full-viewport overlay surface with syntax highlighting and copy action
- `mobileSyntaxHighlight.ts` — shared tokenizer extracted for reuse between diff view and code-block overlay
- `codeBlockPart.ts` — tap-to-expand affordance: long chat code blocks get a 44px expand row that opens the overlay
- `chat.contribution.ts` — side-effect import to register the overlay action

**Pull-down dismiss wiring:**
- `mobileDiffView.ts` — refactored to use the extracted highlighter and install pull-down dismiss
- `mobileChangesView.ts` — install pull-down dismiss
- `mobileOverlayViews.css` — overlay container styles + pull-down handle visuals

**Edge-swipe install:**
- `workbench.ts` — install left-edge swipe to open the sidebar drawer on phone layout

**Accessibility help dialog:**
- `style.css` — phone-viewport styling for the `IAccessibleViewService` help dialog (full-viewport sheet, 44px close target)

**Phone-layout code-block CSS:**
- `mobileChatShell.css` — two new sections: sticky toolbar / 44px hit targets / `touch-action: pan-x pan-y` and the tap-to-expand row styling

### Validation

- `npm run compile-check-ts-native` — exit 0
- `npm run valid-layers-check` — exit 0
