### PR TITLE
Mobile chat (4/10): tool confirmation + plan review bottom sheets

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -12,8 +12,6 @@
 		"--vscode-activityBarBadge-background",
 		"--vscode-activityBarBadge-foreground",
 		"--vscode-activityBarTop-activeBackground",
-		"--vscode-activeSessionView-background",
-		"--vscode-activeSessionView-foreground",
 		"--vscode-activityBarTop-activeBorder",
 		"--vscode-activityBarTop-background",
 		"--vscode-activityBarTop-dropBorder",
@@ -27,8 +25,6 @@
 		"--vscode-agentSessionReadIndicator-foreground",
 		"--vscode-agentSessionSelectedBadge-border",
 		"--vscode-agentSessionSelectedUnfocusedBadge-border",
-		"--vscode-inactiveSessionView-background",
-		"--vscode-inactiveSessionView-foreground",
 		"--vscode-agentStatusIndicator-background",
 		"--vscode-badge-background",
 		"--vscode-badge-foreground",
@@ -951,8 +947,6 @@
 		"--mobile-diff-tok-keyword",
 		"--mobile-diff-tok-number",
 		"--chat-editing-last-edit-shift",
-		"--session-view-background",
-		"--session-view-foreground",
 		"--chat-current-response-min-height",
 		"--chat-smooth-delay",
 		"--chat-smooth-duration",
@@ -1081,9 +1075,6 @@
 		"--slide-from-y"
 	],
 	"sizes": [
-		"--vscode-agents-fontWeight-medium",
-		"--vscode-agents-fontWeight-regular",
-		"--vscode-agents-fontWeight-semiBold",
 		"--vscode-agents-fontSize-body1",
 		"--vscode-agents-fontSize-body2",
 		"--vscode-agents-fontSize-heading1",
@@ -1093,6 +1084,9 @@
 		"--vscode-agents-fontSize-label2",
 		"--vscode-agents-fontSize-label3",
 		"--vscode-agents-fontSize-label4",
+		"--vscode-agents-fontWeight-medium",
+		"--vscode-agents-fontWeight-regular",
+		"--vscode-agents-fontWeight-semiBold",
 		"--vscode-bodyFontSize",
 		"--vscode-bodyFontSize-small",
 		"--vscode-bodyFontSize-xSmall",
@@ -1104,6 +1098,7 @@
 		"--vscode-cornerRadius-small",
 		"--vscode-cornerRadius-xLarge",
 		"--vscode-cornerRadius-xSmall",
+		"--vscode-keyboard-height",
 		"--vscode-strokeThickness"
 	]
 }

--- a/src/vs/sessions/browser/parts/mobile/contributions/mobilePulldownDismiss.ts
+++ b/src/vs/sessions/browser/parts/mobile/contributions/mobilePulldownDismiss.ts
@@ -1,0 +1,205 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DisposableStore, IDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
+import { addDisposableListener, EventType } from '../../../../../base/browser/dom.js';
+
+/**
+ * Vertical travel (in px) past which the gesture commits and the overlay
+ * is dismissed on `pointerup`.
+ */
+const COMMIT_THRESHOLD_PX = 120;
+
+/**
+ * Initial dead-zone (in px) before any visual feedback is applied. This
+ * keeps small accidental drags during taps on the back button or chevrons
+ * from briefly translating the overlay.
+ */
+const DEAD_ZONE_PX = 8;
+
+/**
+ * Velocity threshold (in px / ms) past which the gesture commits regardless
+ * of total travel — supports quick flick-down dismissal.
+ */
+const COMMIT_VELOCITY = 0.6;
+
+/**
+ * Animation duration (in ms) for the dismiss slide-down.
+ */
+const DISMISS_ANIM_MS = 250;
+
+/**
+ * Animation duration (in ms) for the snap-back when the gesture is
+ * abandoned without committing.
+ */
+const SNAP_BACK_ANIM_MS = 200;
+
+/**
+ * Installs a pull-down-to-dismiss gesture on a header element. While the
+ * user drags downward on `headerHandle`, `overlayRoot` follows the pointer
+ * via `transform: translateY()` and its opacity fades toward 0.5 of its
+ * original value. On `pointerup`:
+ *
+ * - Above {@link COMMIT_THRESHOLD_PX} of travel **or** flick velocity past
+ *   {@link COMMIT_VELOCITY}, the overlay animates fully off-screen and
+ *   `onDismiss` is invoked.
+ * - Otherwise the overlay snaps back to its original position.
+ *
+ * Horizontal drags and small vertical motions inside the {@link DEAD_ZONE_PX}
+ * window are ignored so the existing tap targets on the header (back
+ * button, chevrons) continue to receive click / tap events normally.
+ *
+ * Returns an {@link IDisposable} that detaches all listeners and resets
+ * inline styles applied to `overlayRoot`.
+ */
+export function installPulldownDismiss(
+	overlayRoot: HTMLElement,
+	headerHandle: HTMLElement,
+	onDismiss: () => void,
+): IDisposable {
+	const store = new DisposableStore();
+
+	let tracking = false;
+	let dragging = false;
+	let dismissed = false;
+	let activePointerId: number | undefined;
+	let startX = 0;
+	let startY = 0;
+	let startTime = 0;
+	let lastY = 0;
+	let lastT = 0;
+	let velocity = 0;
+	let originalTransition = '';
+
+	const applyDragStyles = () => {
+		originalTransition = overlayRoot.style.transition;
+		overlayRoot.style.transition = 'none';
+		overlayRoot.style.willChange = 'transform, opacity';
+	};
+
+	const resetStyles = () => {
+		overlayRoot.style.transform = '';
+		overlayRoot.style.opacity = '';
+		overlayRoot.style.transition = originalTransition;
+		overlayRoot.style.willChange = '';
+	};
+
+	const update = (dy: number) => {
+		const translate = Math.max(0, dy);
+		overlayRoot.style.transform = `translateY(${translate}px)`;
+		const opacity = Math.max(0.5, 1 - Math.min(translate / COMMIT_THRESHOLD_PX, 0.5));
+		overlayRoot.style.opacity = String(opacity);
+	};
+
+	const finish = (commit: boolean) => {
+		if (!commit) {
+			overlayRoot.style.transition = `transform ${SNAP_BACK_ANIM_MS}ms ease, opacity ${SNAP_BACK_ANIM_MS}ms ease`;
+			overlayRoot.style.transform = 'translateY(0)';
+			overlayRoot.style.opacity = '1';
+			const onEnd = () => {
+				resetStyles();
+				overlayRoot.removeEventListener('transitionend', onEnd);
+			};
+			overlayRoot.addEventListener('transitionend', onEnd, { once: true });
+			return;
+		}
+
+		if (dismissed) {
+			return;
+		}
+		dismissed = true;
+		overlayRoot.style.transition = `transform ${DISMISS_ANIM_MS}ms ease, opacity ${DISMISS_ANIM_MS}ms ease`;
+		overlayRoot.style.transform = 'translateY(100%)';
+		overlayRoot.style.opacity = '0';
+		const timeoutId = overlayRoot.ownerDocument.defaultView?.setTimeout(() => {
+			onDismiss();
+		}, DISMISS_ANIM_MS) ?? 0;
+		store.add(toDisposable(() => {
+			overlayRoot.ownerDocument.defaultView?.clearTimeout(timeoutId);
+		}));
+	};
+
+	store.add(addDisposableListener(headerHandle, EventType.POINTER_DOWN, (e: PointerEvent) => {
+		if (tracking || dismissed) {
+			return;
+		}
+		if (e.pointerType !== 'touch' && e.pointerType !== 'pen') {
+			return;
+		}
+		tracking = true;
+		dragging = false;
+		activePointerId = e.pointerId;
+		startX = e.clientX;
+		startY = e.clientY;
+		startTime = Date.now();
+		lastY = startY;
+		lastT = startTime;
+		velocity = 0;
+	}));
+
+	store.add(addDisposableListener(headerHandle, EventType.POINTER_MOVE, (e: PointerEvent) => {
+		if (!tracking || e.pointerId !== activePointerId) {
+			return;
+		}
+		const dy = e.clientY - startY;
+		const dx = e.clientX - startX;
+
+		if (!dragging) {
+			if (Math.abs(dy) < DEAD_ZONE_PX) {
+				return;
+			}
+			if (dy <= 0 || Math.abs(dx) > Math.abs(dy)) {
+				// Not a downward-dominant drag — release the gesture so
+				// regular pointer handlers (e.g. native scroll) can take
+				// over for the remainder of this pointer interaction.
+				tracking = false;
+				activePointerId = undefined;
+				return;
+			}
+			dragging = true;
+			applyDragStyles();
+		}
+
+		// Update running velocity sample for flick detection.
+		const now = Date.now();
+		const dt = now - lastT;
+		if (dt > 0) {
+			velocity = (e.clientY - lastY) / dt;
+		}
+		lastY = e.clientY;
+		lastT = now;
+
+		update(dy);
+		e.preventDefault();
+	}, { passive: false }));
+
+	const release = (e: PointerEvent) => {
+		if (e.pointerId !== activePointerId) {
+			return;
+		}
+		const wasDragging = dragging;
+		const dy = e.clientY - startY;
+		tracking = false;
+		dragging = false;
+		activePointerId = undefined;
+
+		if (!wasDragging) {
+			return;
+		}
+
+		const commit = dy > COMMIT_THRESHOLD_PX || velocity > COMMIT_VELOCITY;
+		finish(commit);
+	};
+	store.add(addDisposableListener(headerHandle, EventType.POINTER_UP, release));
+	store.add(addDisposableListener(headerHandle, 'pointercancel', release));
+
+	store.add(toDisposable(() => {
+		if (!dismissed) {
+			resetStyles();
+		}
+	}));
+
+	return store;
+}

--- a/src/vs/sessions/browser/parts/mobile/longPress.ts
+++ b/src/vs/sessions/browser/parts/mobile/longPress.ts
@@ -1,0 +1,198 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as dom from '../../../../base/browser/dom.js';
+import { DisposableStore, IDisposable } from '../../../../base/common/lifecycle.js';
+import { IWorkbenchLayoutService } from '../../../../workbench/services/layout/browser/layoutService.js';
+import { isPhoneLayout } from './mobileLayout.js';
+
+/** Default hold duration, in milliseconds, before a long-press fires. */
+const DEFAULT_HOLD_TIME_MS = 500;
+
+/** Default pointer movement, in CSS pixels, that cancels a pending long-press. */
+const DEFAULT_MOVE_THRESHOLD_PX = 6;
+
+/**
+ * Options for {@link installLongPress}.
+ */
+export interface IInstallLongPressOptions {
+	/**
+	 * How long the pointer must stay pressed (without moving past
+	 * `moveThresholdPx`) before the long-press fires. Defaults to
+	 * {@link DEFAULT_HOLD_TIME_MS} (500ms).
+	 */
+	holdTimeMs?: number;
+
+	/**
+	 * Pointer movement (in CSS pixels) that cancels a pending
+	 * long-press. Small enough that micro-jitter on touch devices
+	 * doesn't kill the gesture, large enough that an intentional
+	 * scroll/pan does. Defaults to {@link DEFAULT_MOVE_THRESHOLD_PX}.
+	 */
+	moveThresholdPx?: number;
+
+	/**
+	 * If true (the default), the next `click` event after the
+	 * long-press fires is swallowed in capture phase so the
+	 * underlying element's tap handler doesn't also run.
+	 */
+	suppressSyntheticClick?: boolean;
+
+	/**
+	 * Optional layout service used to self-gate the long-press to
+	 * phone layout. When provided, the long-press is a no-op unless
+	 * `isPhoneLayout(layoutService)` returns `true` at pointerdown
+	 * time. Omit for callers that want long-press to fire on all
+	 * form factors.
+	 */
+	layoutService?: IWorkbenchLayoutService;
+}
+
+/**
+ * Wires a long-press gesture on `element`.
+ *
+ * A long-press is defined as the pointer staying down on `element`
+ * for at least `holdTimeMs` (default 500ms) without moving more than
+ * `moveThresholdPx` (default 6px) from the initial down position.
+ * When that happens, `handler(pointerEvent)` is invoked with the
+ * original `pointerdown` event so callers can read `clientX/Y`,
+ * `target`, etc. for things like positioning an action sheet.
+ *
+ * Movement past the threshold, `pointerup`, or `pointercancel` all
+ * cancel the pending long-press; the handler does not fire.
+ *
+ * When `suppressSyntheticClick` is true (the default), the next
+ * `click` event after the long-press fires is captured and
+ * `preventDefault`+`stopPropagation`'d so the underlying element's
+ * tap handler doesn't also run (e.g., long-pressing a chat row
+ * shouldn't also open the session like a tap does). A
+ * next-animation-frame fallback removes the click suppressor in case
+ * no click ever follows (e.g., the user lifted off-screen).
+ *
+ * If an `IWorkbenchLayoutService` is supplied via
+ * `options.layoutService`, the gesture self-gates on phone layout:
+ * on desktop the pointerdown handler returns immediately so
+ * right-click-and-hold doesn't accidentally trigger anything. This
+ * is intentionally opt-in so callers that want a universal
+ * long-press (e.g., a touch test page) can omit it.
+ *
+ * Only primary `touch` and `mouse` pointer types are observed; pen
+ * and non-primary pointers are ignored to avoid fighting other
+ * gesture handlers.
+ *
+ * @example
+ * // Open an action sheet when the user long-presses a chat row.
+ * disposables.add(installLongPress(row, e => {
+ *     actionSheet.show({ x: e.clientX, y: e.clientY });
+ * }, { layoutService }));
+ *
+ * @param element The element to attach pointer listeners to.
+ * @param handler Invoked with the originating pointerdown event
+ *                when a long-press is detected.
+ * @param options See {@link IInstallLongPressOptions}.
+ * @returns Disposable that removes all listeners and clears any
+ *          pending timer.
+ */
+export function installLongPress(
+	element: HTMLElement,
+	handler: (e: PointerEvent) => void,
+	options?: IInstallLongPressOptions
+): IDisposable {
+	const store = new DisposableStore();
+	const holdTimeMs = options?.holdTimeMs ?? DEFAULT_HOLD_TIME_MS;
+	const moveThresholdPx = options?.moveThresholdPx ?? DEFAULT_MOVE_THRESHOLD_PX;
+	const suppressSyntheticClick = options?.suppressSyntheticClick ?? true;
+	const layoutService = options?.layoutService;
+
+	let pointerId: number | undefined;
+	let startX = 0;
+	let startY = 0;
+	let timerId: number | undefined;
+	const targetWindow = dom.getWindow(element);
+
+	const cancelTimer = () => {
+		if (timerId !== undefined) {
+			targetWindow.clearTimeout(timerId);
+			timerId = undefined;
+		}
+	};
+
+	const reset = () => {
+		cancelTimer();
+		pointerId = undefined;
+	};
+
+	store.add(dom.addDisposableListener(element, dom.EventType.POINTER_DOWN, (e: PointerEvent) => {
+		// Self-gate on phone when a layout service was supplied so
+		// desktop right-click-drag and similar don't accidentally
+		// trigger anything. The check is a cheap DOM class read,
+		// evaluated lazily per pointerdown so resize-to-phone keeps
+		// working.
+		if (layoutService && !isPhoneLayout(layoutService)) {
+			return;
+		}
+		// Only react to primary input. Ignore right-clicks and
+		// non-touch/-mouse pointer types (e.g. pen) to avoid
+		// fighting other gesture handlers.
+		if (!e.isPrimary || (e.pointerType !== 'touch' && e.pointerType !== 'mouse')) {
+			return;
+		}
+		// A second pointerdown before the previous gesture ended
+		// supersedes the prior one; clear any stale timer.
+		cancelTimer();
+		pointerId = e.pointerId;
+		startX = e.clientX;
+		startY = e.clientY;
+		timerId = targetWindow.setTimeout(() => {
+			timerId = undefined;
+			pointerId = undefined;
+			handler(e);
+			if (suppressSyntheticClick) {
+				// Swallow the next click in capture phase so the
+				// underlying element's tap handler doesn't also
+				// run. `addEventListener` (not
+				// `addDisposableListener`) is used because the
+				// listener needs to remove itself once it fires.
+				const swallow = (clickEvent: MouseEvent) => {
+					clickEvent.preventDefault();
+					clickEvent.stopPropagation();
+					element.removeEventListener('click', swallow, true);
+				};
+				element.addEventListener('click', swallow, true);
+				// Drop the suppressor on the next frame in case no
+				// click ever follows (e.g. lifted off-screen).
+				targetWindow.setTimeout(() => element.removeEventListener('click', swallow, true), 0);
+			}
+		}, holdTimeMs);
+	}));
+
+	store.add(dom.addDisposableListener(element, dom.EventType.POINTER_MOVE, (e: PointerEvent) => {
+		if (pointerId !== e.pointerId) {
+			return;
+		}
+		const dx = e.clientX - startX;
+		const dy = e.clientY - startY;
+		if (Math.abs(dx) > moveThresholdPx || Math.abs(dy) > moveThresholdPx) {
+			reset();
+		}
+	}));
+
+	const end = (e: PointerEvent) => {
+		if (pointerId !== e.pointerId) {
+			return;
+		}
+		reset();
+	};
+	store.add(dom.addDisposableListener(element, dom.EventType.POINTER_UP, end));
+	// `pointercancel` isn't in the workbench's `EventType` enum (only
+	// the events shared with mouse/touch are), so register it via the
+	// raw literal. Browsers fire it when the pointer leaves the page
+	// or the gesture is interrupted (e.g. iOS scroll/zoom takeover).
+	store.add(dom.addDisposableListener(element, 'pointercancel', end));
+
+	store.add({ dispose: cancelTimer });
+
+	return store;
+}

--- a/src/vs/sessions/browser/parts/mobile/media/mobilePickerSheet.css
+++ b/src/vs/sessions/browser/parts/mobile/media/mobilePickerSheet.css
@@ -236,6 +236,21 @@
 	padding: 4px 8px 12px;
 }
 
+/* Body container for the shell-only `showMobileContentSheet` variant.
+ * Where the picker sheet builds its own scrollable list of rows
+ * (`.mobile-picker-sheet-list`) inside the sheet flex column, the
+ * content sheet hands the body slot over to its caller and only
+ * guarantees the surrounding chrome (drag handle, title row, caption,
+ * dismissal, keyboard avoidance). We set scroll, momentum, and
+ * touch-action on the body slot itself so vertical scrolling works
+ * correctly under iOS regardless of what DOM the caller puts inside. */
+.mobile-content-sheet-body {
+	flex: 1 1 auto;
+	overflow-y: auto;
+	-webkit-overflow-scrolling: touch;
+	touch-action: pan-y;
+}
+
 /* iOS grouped-list section header. The HIG uses a regular-case
  * footnote-sized label in secondary color — not the uppercased small
  * caps that older Settings rows used. */

--- a/src/vs/sessions/browser/parts/mobile/mobileChatShell.css
+++ b/src/vs/sessions/browser/parts/mobile/mobileChatShell.css
@@ -990,3 +990,207 @@
 	height: 36px;
 	padding: 0;
 }
+
+/* ===========================================================================
+ * Phone Layout: Chat Confirmation Widgets
+ * ---------------------------------------------------------------------------
+ *
+ * The chat confirmation widget (used by SimpleChatConfirmationWidget /
+ * BaseChatConfirmationWidget and by tool confirmation subparts) renders as a
+ * compact card on desktop with horizontal button rows. On phone we need:
+ *   - Edge-to-edge width inside the chat message column.
+ *   - 44px-tall buttons stacked vertically when there are 3+ choices
+ *     (matches iOS confirm-sheet pattern).
+ *   - A scrollable message body so a long markdown explanation never pushes
+ *     the action buttons off-screen.
+ *   - Touch-friendly subpart variants for terminal command previews and
+ *     modified-files lists.
+ *
+ * DOM (from chatConfirmationWidget.ts):
+ *   .chat-confirmation-widget-container
+ *     .chat-confirmation-widget   (Simple variant) or .chat-confirmation-widget2 (Base)
+ *       .chat-confirmation-widget-title
+ *       .chat-confirmation-widget-message[-container]
+ *         .chat-confirmation-widget-message-scrollable
+ *       .chat-buttons-container  (Simple) or .chat-confirmation-widget-buttons (Base)
+ *         .chat-buttons > .monaco-button[]
+ *         .chat-toolbar
+ *
+ * Specificity: every selector below prepends
+ * `.agent-sessions-workbench.phone-layout` so we beat the desktop sheet in
+ * `chatConfirmationWidget.css` without `!important`.
+ * ========================================================================= */
+
+/* Make the widget fill the chat message column edge-to-edge on phone. */
+.agent-sessions-workbench.phone-layout .interactive-session .chat-confirmation-widget-container,
+.agent-sessions-workbench.phone-layout .interactive-session .chat-confirmation-widget-container .chat-confirmation-widget,
+.agent-sessions-workbench.phone-layout .interactive-session .chat-confirmation-widget-container .chat-confirmation-widget2 {
+	width: 100%;
+	max-width: 100%;
+	box-sizing: border-box;
+}
+
+/* Title row: bigger type and generous padding so the heading reads as a
+ * focused-sheet title on small viewports. */
+.agent-sessions-workbench.phone-layout .interactive-session .chat-confirmation-widget-container .chat-confirmation-widget-title,
+.agent-sessions-workbench.phone-layout .interactive-session .chat-confirmation-widget-container .chat-confirmation-widget2 .chat-confirmation-widget-title {
+	padding: 10px 12px;
+	font-size: 15px;
+	line-height: 1.35;
+	min-height: 44px;
+	box-sizing: border-box;
+}
+
+/* Cap the message body's height so a very long explanation can scroll
+ * inside the widget instead of pushing the buttons below the viewport.
+ * `dvh` is used so the cap shrinks when the iOS URL bar collapses. */
+.agent-sessions-workbench.phone-layout .interactive-session .chat-confirmation-widget-container .chat-confirmation-widget-message-scrollable,
+.agent-sessions-workbench.phone-layout .interactive-session .chat-confirmation-widget-container .chat-confirmation-widget-message {
+	max-height: 45dvh;
+	overflow-y: auto;
+	-webkit-overflow-scrolling: touch;
+	overscroll-behavior: contain;
+	touch-action: pan-y;
+}
+
+/* Buttons container fills the full row and adopts a comfortable gap. */
+.agent-sessions-workbench.phone-layout .interactive-session .chat-confirmation-widget-container .chat-buttons-container,
+.agent-sessions-workbench.phone-layout .interactive-session .chat-confirmation-widget-container .chat-confirmation-widget-buttons {
+	padding: 8px 12px 10px;
+	gap: 8px;
+}
+
+/* All buttons inside the confirmation widget are at least 44px tall to
+ * meet thumb-target guidelines. Row layout (2 or fewer buttons) stays
+ * horizontal and lets each button breathe with min-width. */
+.agent-sessions-workbench.phone-layout .interactive-session .chat-confirmation-widget-container .chat-buttons {
+	display: flex;
+	flex-direction: row;
+	gap: 8px;
+	width: 100%;
+}
+
+.agent-sessions-workbench.phone-layout .interactive-session .chat-confirmation-widget-container .chat-buttons > .monaco-button,
+.agent-sessions-workbench.phone-layout .interactive-session .chat-confirmation-widget-container .chat-buttons > .monaco-button-dropdown {
+	min-height: 44px;
+	min-width: 44px;
+	box-sizing: border-box;
+	touch-action: manipulation;
+}
+
+/* When there are 3 or more buttons, stack them vertically. `:has()` lets
+ * us detect the third child without any TS-side class toggling. The
+ * leaf-button selector is `.monaco-button` AND `.monaco-button-dropdown`
+ * because dropdowns wrap the leaf button in an extra element. */
+.agent-sessions-workbench.phone-layout .interactive-session .chat-confirmation-widget-container .chat-buttons:has(> .monaco-button:nth-child(3)),
+.agent-sessions-workbench.phone-layout .interactive-session .chat-confirmation-widget-container .chat-buttons:has(> .monaco-button-dropdown:nth-child(3)) {
+	flex-direction: column;
+	align-items: stretch;
+}
+
+.agent-sessions-workbench.phone-layout .interactive-session .chat-confirmation-widget-container .chat-buttons:has(> .monaco-button:nth-child(3)) > .monaco-button,
+.agent-sessions-workbench.phone-layout .interactive-session .chat-confirmation-widget-container .chat-buttons:has(> .monaco-button-dropdown:nth-child(3)) > .monaco-button,
+.agent-sessions-workbench.phone-layout .interactive-session .chat-confirmation-widget-container .chat-buttons:has(> .monaco-button:nth-child(3)) > .monaco-button-dropdown,
+.agent-sessions-workbench.phone-layout .interactive-session .chat-confirmation-widget-container .chat-buttons:has(> .monaco-button-dropdown:nth-child(3)) > .monaco-button-dropdown {
+	width: 100%;
+}
+
+/* Terminal subpart: the embedded code preview is a monospace editor that
+ * may render a very wide command line. Allow horizontal scrolling and pin
+ * `touch-action: pan-x` so the user can swipe the command without iOS
+ * stealing the gesture for pinch-to-zoom. */
+.agent-sessions-workbench.phone-layout .interactive-session .chat-confirmation-message-terminal .chat-confirmation-message-terminal-editor,
+.agent-sessions-workbench.phone-layout .interactive-session .chat-confirmation-message-terminal .chat-confirmation-message-terminal-editor .interactive-result-code-block {
+	overflow-x: auto;
+	-webkit-overflow-scrolling: touch;
+	touch-action: pan-x;
+	font-size: 13px;
+}
+
+/* Disclaimer / footer text under the terminal preview gets a touch-friendly
+ * minimum target so risk-badge hovers and "see details" links are tappable. */
+.agent-sessions-workbench.phone-layout .interactive-session .chat-confirmation-message-terminal .chat-confirmation-message-terminal-disclaimer {
+	min-height: 44px;
+	padding: 6px 8px;
+	display: flex;
+	align-items: center;
+}
+
+/* Modified-files subpart: turn the overview row and per-file list rows into
+ * 44px touch targets. The overview row already uses flex; we just expand
+ * its vertical bounds and beef up the embedded action buttons. */
+.agent-sessions-workbench.phone-layout .interactive-session .chat-modified-files-confirmation-list .chat-editing-session-overview {
+	min-height: 44px;
+	padding: 4px 8px;
+	gap: 8px;
+}
+
+.agent-sessions-workbench.phone-layout .interactive-session .chat-modified-files-confirmation-list .chat-editing-session-list .monaco-list-row {
+	min-height: 44px;
+	padding: 4px 0;
+}
+
+/* Per-file accept / reject buttons (the inline diff toolbar). */
+.agent-sessions-workbench.phone-layout .interactive-session .chat-modified-files-confirmation-list .chat-editing-session-actions .monaco-button,
+.agent-sessions-workbench.phone-layout .interactive-session .chat-modified-files-confirmation-list .chat-collapsible-list-action-bar .action-label {
+	min-width: 44px;
+	min-height: 44px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	touch-action: manipulation;
+}
+
+/* On phone the per-row action bar is always visible — the desktop UX of
+ * "show on hover" doesn't translate to touch (there is no hover). */
+.agent-sessions-workbench.phone-layout .interactive-session .chat-modified-files-confirmation-list .chat-collapsible-list-action-bar:not(.has-no-actions) {
+	display: inherit;
+}
+
+/* ===========================================================================
+ * Phone Layout: Chat Elicitation
+ * ---------------------------------------------------------------------------
+ *
+ * `ChatElicitationContentPart` reuses `ChatConfirmationWidget` under the hood
+ * (see chatElicitationContentPart.ts), so the DOM is the same as a
+ * confirmation widget. The unique phone work here is:
+ *   - Form `input` / `textarea` / `select` inside the elicitation get a
+ *     16px font (iOS auto-zoom block) and a 44px min-height.
+ *   - Title row tuned for a focused-dialog feel (larger type, generous
+ *     padding). Button-row stacking is already handled by the
+ *     "Chat Confirmation Widgets" section above.
+ *
+ * The selectors target `.chat-confirmation-widget-container` because that's
+ * the elicitation's root in the rendered DOM. Other confirmation widgets
+ * benefit from the same iOS-zoom block harmlessly.
+ * ========================================================================= */
+
+/* Block iOS auto-zoom on focus by keeping all form-control text at 16px+.
+ * The 44px min-height makes the field a comfortable touch target. */
+.agent-sessions-workbench.phone-layout .interactive-session .chat-confirmation-widget-container input:not([type='checkbox']):not([type='radio']),
+.agent-sessions-workbench.phone-layout .interactive-session .chat-confirmation-widget-container textarea,
+.agent-sessions-workbench.phone-layout .interactive-session .chat-confirmation-widget-container select {
+	font-size: 16px;
+	min-height: 44px;
+	box-sizing: border-box;
+	padding: 8px 10px;
+	touch-action: manipulation;
+}
+
+/* Checkbox / radio variants stay compact but get a bigger hit-area via
+ * padding on the surrounding label (handled by Monaco styles). Still
+ * pin a 24px minimum on the control itself so the tap is unambiguous. */
+.agent-sessions-workbench.phone-layout .interactive-session .chat-confirmation-widget-container input[type='checkbox'],
+.agent-sessions-workbench.phone-layout .interactive-session .chat-confirmation-widget-container input[type='radio'] {
+	min-width: 24px;
+	min-height: 24px;
+}
+
+/* Elicitation title row: nudge a notch larger than a confirmation widget's
+ * title so the question reads as the primary thing on screen. */
+.agent-sessions-workbench.phone-layout .interactive-session .chat-confirmation-widget-container .chat-confirmation-widget-title .chat-query-title-part,
+.agent-sessions-workbench.phone-layout .interactive-session .chat-confirmation-widget-container .chat-confirmation-widget-title .rendered-markdown {
+	font-size: 16px;
+	line-height: 1.4;
+}
+

--- a/src/vs/sessions/browser/parts/mobile/mobileEdgeSwipe.ts
+++ b/src/vs/sessions/browser/parts/mobile/mobileEdgeSwipe.ts
@@ -1,0 +1,133 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DisposableStore, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { addDisposableListener, EventType } from '../../../../base/browser/dom.js';
+import { IWorkbenchLayoutService, Parts } from '../../../../workbench/services/layout/browser/layoutService.js';
+
+/**
+ * Threshold (in px) from the left viewport edge within which a `pointerdown`
+ * is considered a candidate edge swipe.
+ */
+const EDGE_HIT_ZONE_PX = 16;
+
+/**
+ * Minimum horizontal travel (in px, rightward) required to commit the
+ * sidebar-open gesture.
+ */
+const COMMIT_TRAVEL_PX = 48;
+
+/**
+ * Maximum vertical drift (in px) allowed during the gesture. If the user
+ * moves more than this along Y the gesture is treated as a scroll attempt
+ * and the swipe is cancelled.
+ */
+const VERTICAL_TOLERANCE_PX = 32;
+
+/**
+ * Maximum duration (in ms) within which the commit travel must be reached.
+ * Slower drags are treated as deliberate scrolls / selections and ignored.
+ */
+const COMMIT_WINDOW_MS = 500;
+
+/**
+ * Installs a left-edge swipe gesture on `mainContainer` that opens the
+ * sidebar drawer on phone viewports.
+ *
+ * The gesture starts when `pointerdown` lands within the leftmost
+ * {@link EDGE_HIT_ZONE_PX} pixels of the container while the phone layout
+ * is active. It commits when the pointer travels more than
+ * {@link COMMIT_TRAVEL_PX} rightward within {@link COMMIT_WINDOW_MS} ms
+ * with less than {@link VERTICAL_TOLERANCE_PX} of vertical drift. The
+ * gesture is cancelled on `pointerup` / `pointercancel`, or once the
+ * tracking window elapses.
+ *
+ * Only `touch` and `pen` pointer types are considered — mouse drags from
+ * the edge could conflict with text selection. The gesture also skips if
+ * the sidebar is already visible so we don't replay the open on every
+ * subsequent edge tap.
+ *
+ * Returns an {@link IDisposable} that detaches all listeners.
+ */
+export function installMobileEdgeSwipeToOpenSidebar(
+	mainContainer: HTMLElement,
+	openSidebar: () => void,
+	layoutService: IWorkbenchLayoutService,
+): IDisposable {
+	const store = new DisposableStore();
+
+	let tracking = false;
+	let startX = 0;
+	let startY = 0;
+	let startTime = 0;
+	let activePointerId: number | undefined;
+
+	const reset = () => {
+		tracking = false;
+		activePointerId = undefined;
+	};
+
+	const isPhoneLayout = (): boolean => {
+		return mainContainer.classList.contains('phone-layout');
+	};
+
+	store.add(addDisposableListener(mainContainer, EventType.POINTER_DOWN, (e: PointerEvent) => {
+		if (tracking) {
+			return;
+		}
+		if (e.pointerType !== 'touch' && e.pointerType !== 'pen') {
+			return;
+		}
+		if (!isPhoneLayout()) {
+			return;
+		}
+		const rect = mainContainer.getBoundingClientRect();
+		const localX = e.clientX - rect.left;
+		if (localX >= EDGE_HIT_ZONE_PX) {
+			return;
+		}
+		if (layoutService.isVisible(Parts.SIDEBAR_PART)) {
+			return;
+		}
+
+		tracking = true;
+		activePointerId = e.pointerId;
+		startX = e.clientX;
+		startY = e.clientY;
+		startTime = Date.now();
+	}, true));
+
+	store.add(addDisposableListener(mainContainer, EventType.POINTER_MOVE, (e: PointerEvent) => {
+		if (!tracking || e.pointerId !== activePointerId) {
+			return;
+		}
+
+		const dx = e.clientX - startX;
+		const dy = Math.abs(e.clientY - startY);
+		const elapsed = Date.now() - startTime;
+
+		if (elapsed > COMMIT_WINDOW_MS || dy > VERTICAL_TOLERANCE_PX) {
+			reset();
+			return;
+		}
+
+		if (dx >= COMMIT_TRAVEL_PX) {
+			reset();
+			openSidebar();
+		}
+	}, true));
+
+	const cancel = (e: PointerEvent) => {
+		if (e.pointerId === activePointerId) {
+			reset();
+		}
+	};
+	store.add(addDisposableListener(mainContainer, EventType.POINTER_UP, cancel, true));
+	store.add(addDisposableListener(mainContainer, 'pointercancel', cancel, true));
+
+	store.add(toDisposable(reset));
+
+	return store;
+}

--- a/src/vs/sessions/browser/parts/mobile/mobilePickerSheet.ts
+++ b/src/vs/sessions/browser/parts/mobile/mobilePickerSheet.ts
@@ -9,7 +9,7 @@ import { Codicon } from '../../../../base/common/codicons.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { Gesture, EventType as TouchEventType } from '../../../../base/browser/touch.js';
 import { CancellationToken, CancellationTokenSource } from '../../../../base/common/cancellation.js';
-import { DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
+import { DisposableStore, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { localize } from '../../../../nls.js';
 
 const $ = DOM.$;
@@ -122,6 +122,53 @@ export interface IMobilePickerSheetSearchSource {
 }
 
 /**
+ * Renderer API passed into the {@link showMobileContentSheet} body
+ * callback. The renderer fills {@link bodyContainer} with arbitrary DOM
+ * and may call {@link close} to dismiss the sheet (e.g. after a confirm
+ * button is tapped, or after a sub-view navigation completes).
+ */
+export interface IMobileContentSheetApi {
+	/**
+	 * The same element passed as the first argument to the body
+	 * renderer; exposed here for convenience so callbacks can capture
+	 * the API object without also closing over the body element.
+	 */
+	readonly bodyContainer: HTMLElement;
+
+	/** Dismiss the sheet (plays the close animation). Idempotent. */
+	close(): void;
+}
+
+/**
+ * Options for {@link showMobileContentSheet}.
+ */
+export interface IMobileContentSheetOptions {
+	/**
+	 * Optional caption shown beneath the title (single-line, muted).
+	 * Mirrors {@link IMobilePickerSheetOptions.caption}.
+	 */
+	readonly caption?: string;
+
+	/**
+	 * Optional set of icon buttons rendered in the sheet's title row
+	 * to the left of the Done button. Tapping a header action resolves
+	 * the promise (the same dismissal semantics as the Done button).
+	 */
+	readonly headerActions?: readonly IMobilePickerSheetHeaderAction[];
+
+	/** Optional override for the Done button label (defaults to "Done"). */
+	readonly doneLabel?: string;
+
+	/**
+	 * When true, the Done button is hidden. Use this for sheets where
+	 * the body itself provides primary dismissal (e.g. a confirm widget
+	 * with explicit Approve / Reject buttons that call `api.close()`).
+	 * The user can still dismiss via the backdrop or Escape.
+	 */
+	readonly hideDoneButton?: boolean;
+}
+
+/**
  * Prefix used on the resolved id when a header action is invoked from a
  * mobile picker sheet, so callers can disambiguate header taps from
  * regular row selections.
@@ -149,82 +196,24 @@ export function showMobilePickerSheet(
 	options?: IMobilePickerSheetOptions,
 ): Promise<string | undefined> {
 	return new Promise<string | undefined>(resolve => {
-		const disposables = new DisposableStore();
 		let resolved = false;
+		let shell!: IMobileSheetShell;
 
 		const finish = (id: string | undefined) => {
 			if (resolved) {
 				return;
 			}
 			resolved = true;
-			sheet.classList.add('closing');
-			backdrop.classList.add('closing');
-			// Dispose all event listeners and inflight queries immediately
-			// so nothing fires during the 180ms close animation. The DOM
-			// node itself is removed at the end of the animation.
-			disposables.dispose();
-			DOM.getWindow(workbenchContainer).setTimeout(() => {
-				overlay.remove();
-				resolve(id);
-			}, 180);
+			shell.close(() => resolve(id));
 		};
 
-		// -- DOM: backdrop + sheet -------------------------------------
-		const overlay = DOM.append(workbenchContainer, $('div.mobile-picker-sheet-overlay'));
-		const backdrop = DOM.append(overlay, $('div.mobile-picker-sheet-backdrop'));
-		const sheet = DOM.append(overlay, $('div.mobile-picker-sheet'));
-		sheet.setAttribute('role', 'dialog');
-		sheet.setAttribute('aria-modal', 'true');
-		sheet.setAttribute('aria-label', title);
-
-		// -- Header (drag handle + title row + caption) ----------------
-		DOM.append(sheet, $('div.mobile-picker-sheet-handle'));
-
-		const titleRow = DOM.append(sheet, $('div.mobile-picker-sheet-title-row'));
-		const titleEl = DOM.append(titleRow, $('div.mobile-picker-sheet-title'));
-		titleEl.textContent = title;
-
-		// Optional header actions (icon buttons) rendered between the
-		// title and the Done button. Useful for sheet-level shortcuts
-		// like "browse for a folder" that aren't a single picker row.
-		if (options?.headerActions) {
-			for (const action of options.headerActions) {
-				const btn = DOM.append(titleRow, $('button.mobile-picker-sheet-header-action', { type: 'button' })) as HTMLButtonElement;
-				btn.setAttribute('aria-label', action.label);
-				btn.title = action.label;
-				const iconHost = DOM.append(btn, $('span.mobile-picker-sheet-header-action-icon'));
-				const iconEl = DOM.append(iconHost, $('span.mobile-picker-sheet-header-action-icon-glyph'));
-				iconEl.classList.add(...ThemeIcon.asClassNameArray(action.icon));
-				const btnGesture = Gesture.addTarget(btn);
-				disposables.add(btnGesture);
-				const onActivate = () => finish(`${MOBILE_PICKER_SHEET_HEADER_ACTION_PREFIX}${action.id}`);
-				const btnClick = DOM.addDisposableListener(btn, DOM.EventType.CLICK, (e: MouseEvent) => {
-					e.preventDefault();
-					onActivate();
-				});
-				disposables.add(btnClick);
-				const btnTap = DOM.addDisposableListener(btn, TouchEventType.Tap, onActivate);
-				disposables.add(btnTap);
-			}
-		}
-
-		const doneBtn = DOM.append(titleRow, $('button.mobile-picker-sheet-done', { type: 'button' })) as HTMLButtonElement;
-		doneBtn.textContent = localize('mobilePickerSheet.done', "Done");
-		doneBtn.setAttribute('aria-label', localize('mobilePickerSheet.doneAriaLabel', "Close {0}", title));
-		const doneGesture = Gesture.addTarget(doneBtn);
-		disposables.add(doneGesture);
-		const doneClick = DOM.addDisposableListener(doneBtn, DOM.EventType.CLICK, (e: MouseEvent) => {
-			e.preventDefault();
-			finish(undefined);
+		shell = buildMobileSheetShell(workbenchContainer, title, {
+			caption: options?.caption,
+			headerActions: options?.headerActions,
+			onDismiss: () => finish(undefined),
+			onHeaderAction: actionId => finish(`${MOBILE_PICKER_SHEET_HEADER_ACTION_PREFIX}${actionId}`),
 		});
-		disposables.add(doneClick);
-		const doneTap = DOM.addDisposableListener(doneBtn, TouchEventType.Tap, () => finish(undefined));
-		disposables.add(doneTap);
-
-		if (options?.caption) {
-			const caption = DOM.append(sheet, $('div.mobile-picker-sheet-caption'));
-			caption.textContent = options.caption;
-		}
+		const { sheet, disposables } = shell;
 
 		// -- Optional inline search input ------------------------------
 		// Sits between the title row and the scrollable list. Its value
@@ -371,59 +360,6 @@ export function showMobilePickerSheet(
 			setSearchQuery = (query: string) => renderResults(query);
 		}
 
-		// -- Dismissal: backdrop + Escape ------------------------------
-		const backdropClick = DOM.addDisposableListener(backdrop, DOM.EventType.CLICK, () => finish(undefined));
-		disposables.add(backdropClick);
-		const backdropGesture = Gesture.addTarget(backdrop);
-		disposables.add(backdropGesture);
-		const backdropTap = DOM.addDisposableListener(backdrop, TouchEventType.Tap, () => finish(undefined));
-		disposables.add(backdropTap);
-
-		const keyHandler = DOM.addDisposableListener(DOM.getWindow(workbenchContainer), DOM.EventType.KEY_DOWN, (e: KeyboardEvent) => {
-			if (e.key === 'Escape') {
-				e.preventDefault();
-				e.stopPropagation();
-				finish(undefined);
-			}
-		}, true);
-		disposables.add(keyHandler);
-
-		// -- iOS keyboard avoidance -----------------------------------
-		// On iOS Safari, when the virtual keyboard opens the layout
-		// viewport (`vh` units) does NOT shrink — only the visual
-		// viewport changes. The sheet uses `position: fixed` which
-		// positions against the layout viewport, so without correction
-		// the keyboard covers the bottom portion of the sheet (including
-		// the search input the user is actively typing into).
-		//
-		// `window.visualViewport` exposes the real visible area. We
-		// listen for `resize` and `scroll` events on it and translate
-		// the sheet upward by the keyboard height so the search input
-		// remains visible.
-		const win = DOM.getWindow(workbenchContainer);
-		const vv = win.visualViewport;
-		if (vv) {
-			const adjustForKeyboard = () => {
-				// The keyboard height is the difference between the
-				// layout viewport height and the visual viewport height,
-				// plus any scroll offset the browser applied.
-				const keyboardHeight = win.innerHeight - vv.height;
-				overlay.style.bottom = `${Math.max(0, keyboardHeight)}px`;
-				overlay.style.height = `${vv.height}px`;
-			};
-			vv.addEventListener('resize', adjustForKeyboard);
-			vv.addEventListener('scroll', adjustForKeyboard);
-			disposables.add(toDisposable(() => {
-				vv.removeEventListener('resize', adjustForKeyboard);
-				vv.removeEventListener('scroll', adjustForKeyboard);
-				overlay.style.bottom = '';
-				overlay.style.height = '';
-			}));
-			// Run once immediately in case the keyboard is already
-			// visible (e.g., sheet opened while another input had focus).
-			adjustForKeyboard();
-		}
-
 		// Focus the search input if present, otherwise focus the first
 		// checked row (or the first row) for keyboard users.
 		if (searchInput) {
@@ -432,6 +368,282 @@ export function showMobilePickerSheet(
 			(renderState.firstCheckedRow ?? renderState.firstRow)?.focus();
 		}
 	});
+}
+
+/**
+ * Show a phone-friendly bottom sheet that hosts arbitrary body content.
+ *
+ * Reuses the same shell as {@link showMobilePickerSheet} — translucent
+ * backdrop, slide-up animation, drag handle, title row with Done button,
+ * optional caption, optional icon header actions, iOS visual-viewport
+ * keyboard avoidance, and `Escape` / backdrop dismissal — but leaves the
+ * scrollable body to the caller. Use this for overlays that don't fit
+ * the picker's row-list shape: tool-confirmation carousels, plan
+ * reviews, anchor previews, code-block expand views, and so on.
+ *
+ * The {@link renderBody} callback is invoked once after the sheet shell
+ * mounts. The caller fills the supplied `bodyElement` with whatever DOM
+ * they like and may return an {@link IDisposable} whose `dispose()` runs
+ * when the sheet closes (alongside the shell's own listeners).
+ *
+ * The body container has `overflow-y: auto`,
+ * `-webkit-overflow-scrolling: touch`, and `touch-action: pan-y` applied
+ * via the `.mobile-content-sheet-body` class so vertical scrolling works
+ * correctly under iOS.
+ *
+ * The returned promise resolves with `void` when the sheet closes for
+ * any reason: Done button, backdrop tap, Escape, a header action tap,
+ * or an explicit `api.close()` from inside `renderBody`.
+ *
+ * @example
+ * ```ts
+ * await showMobileContentSheet(
+ *     this._layoutService.mainContainer,
+ *     localize('confirm.title', "Confirm Tool Use"),
+ *     (body, api) => {
+ *         const store = new DisposableStore();
+ *         const summary = DOM.append(body, DOM.$('div.tool-confirm-summary'));
+ *         summary.textContent = toolDescription;
+ *
+ *         const approve = DOM.append(body, DOM.$('button.tool-confirm-approve'));
+ *         approve.textContent = localize('confirm.approve', "Approve");
+ *         store.add(DOM.addDisposableListener(approve, 'click', () => {
+ *             writeApproval();
+ *             api.close();
+ *         }));
+ *
+ *         return store;
+ *     },
+ *     { caption: localize('confirm.caption', "This will modify your workspace.") },
+ * );
+ * ```
+ */
+export function showMobileContentSheet(
+	workbenchContainer: HTMLElement,
+	title: string,
+	renderBody: (bodyElement: HTMLElement, api: IMobileContentSheetApi) => IDisposable | void,
+	options?: IMobileContentSheetOptions,
+): Promise<void> {
+	return new Promise<void>(resolve => {
+		let resolved = false;
+		let shell!: IMobileSheetShell;
+
+		const close = () => {
+			if (resolved) {
+				return;
+			}
+			resolved = true;
+			shell.close(() => resolve());
+		};
+
+		shell = buildMobileSheetShell(workbenchContainer, title, {
+			caption: options?.caption,
+			headerActions: options?.headerActions,
+			doneLabel: options?.doneLabel,
+			hideDoneButton: options?.hideDoneButton,
+			onDismiss: close,
+			onHeaderAction: () => close(),
+		});
+
+		const bodyContainer = DOM.append(shell.sheet, $('div.mobile-content-sheet-body'));
+
+		const api: IMobileContentSheetApi = { bodyContainer, close };
+		const bodyDisposable = renderBody(bodyContainer, api);
+		if (bodyDisposable) {
+			shell.disposables.add(bodyDisposable);
+		}
+	});
+}
+
+/** Options consumed by {@link buildMobileSheetShell}. */
+interface IMobileSheetShellOptions {
+	readonly caption?: string;
+	readonly headerActions?: readonly IMobilePickerSheetHeaderAction[];
+	readonly doneLabel?: string;
+	readonly hideDoneButton?: boolean;
+	/**
+	 * Called when the user dismisses the sheet via the Done button,
+	 * backdrop tap, or Escape key. The shell does NOT close itself in
+	 * response to dismissal — the caller is expected to invoke
+	 * {@link IMobileSheetShell.close} from this callback.
+	 */
+	readonly onDismiss: () => void;
+	/**
+	 * Called when a header action button is tapped. If omitted, header
+	 * action taps fall through to {@link onDismiss}.
+	 */
+	readonly onHeaderAction?: (actionId: string) => void;
+}
+
+/** Primitives returned by {@link buildMobileSheetShell}. */
+interface IMobileSheetShell {
+	readonly overlay: HTMLElement;
+	readonly backdrop: HTMLElement;
+	/** The sheet container — append body content here. */
+	readonly sheet: HTMLElement;
+	/** Disposable store tied to the sheet's lifetime; cleared on close. */
+	readonly disposables: DisposableStore;
+	/**
+	 * Play the close animation, dispose listeners, and remove the DOM
+	 * node after the animation completes. Idempotent — subsequent
+	 * calls are no-ops. The optional callback fires once the node has
+	 * been removed.
+	 */
+	close(onAnimationEnd?: () => void): void;
+}
+
+/**
+ * Build the shared shell for {@link showMobilePickerSheet} and
+ * {@link showMobileContentSheet}: overlay, backdrop, sheet (drag handle,
+ * title row with Done button and optional header actions, optional
+ * caption), backdrop / Escape dismissal, and iOS visual-viewport
+ * keyboard avoidance. Callers append their own content children to
+ * `sheet`.
+ */
+function buildMobileSheetShell(
+	workbenchContainer: HTMLElement,
+	title: string,
+	options: IMobileSheetShellOptions,
+): IMobileSheetShell {
+	const disposables = new DisposableStore();
+	let closed = false;
+
+	// -- DOM: backdrop + sheet -------------------------------------
+	const overlay = DOM.append(workbenchContainer, $('div.mobile-picker-sheet-overlay'));
+	const backdrop = DOM.append(overlay, $('div.mobile-picker-sheet-backdrop'));
+	const sheet = DOM.append(overlay, $('div.mobile-picker-sheet'));
+	sheet.setAttribute('role', 'dialog');
+	sheet.setAttribute('aria-modal', 'true');
+	sheet.setAttribute('aria-label', title);
+
+	// -- Header (drag handle + title row + caption) ----------------
+	DOM.append(sheet, $('div.mobile-picker-sheet-handle'));
+
+	const titleRow = DOM.append(sheet, $('div.mobile-picker-sheet-title-row'));
+	const titleEl = DOM.append(titleRow, $('div.mobile-picker-sheet-title'));
+	titleEl.textContent = title;
+
+	// Optional header actions (icon buttons) rendered between the
+	// title and the Done button. Useful for sheet-level shortcuts
+	// like "browse for a folder" that aren't a single picker row.
+	if (options.headerActions) {
+		for (const action of options.headerActions) {
+			const btn = DOM.append(titleRow, $('button.mobile-picker-sheet-header-action', { type: 'button' })) as HTMLButtonElement;
+			btn.setAttribute('aria-label', action.label);
+			btn.title = action.label;
+			const iconHost = DOM.append(btn, $('span.mobile-picker-sheet-header-action-icon'));
+			const iconEl = DOM.append(iconHost, $('span.mobile-picker-sheet-header-action-icon-glyph'));
+			iconEl.classList.add(...ThemeIcon.asClassNameArray(action.icon));
+			const btnGesture = Gesture.addTarget(btn);
+			disposables.add(btnGesture);
+			const onActivate = () => {
+				if (options.onHeaderAction) {
+					options.onHeaderAction(action.id);
+				} else {
+					options.onDismiss();
+				}
+			};
+			const btnClick = DOM.addDisposableListener(btn, DOM.EventType.CLICK, (e: MouseEvent) => {
+				e.preventDefault();
+				onActivate();
+			});
+			disposables.add(btnClick);
+			const btnTap = DOM.addDisposableListener(btn, TouchEventType.Tap, onActivate);
+			disposables.add(btnTap);
+		}
+	}
+
+	if (!options.hideDoneButton) {
+		const doneBtn = DOM.append(titleRow, $('button.mobile-picker-sheet-done', { type: 'button' })) as HTMLButtonElement;
+		doneBtn.textContent = options.doneLabel ?? localize('mobilePickerSheet.done', "Done");
+		doneBtn.setAttribute('aria-label', localize('mobilePickerSheet.doneAriaLabel', "Close {0}", title));
+		const doneGesture = Gesture.addTarget(doneBtn);
+		disposables.add(doneGesture);
+		const doneClick = DOM.addDisposableListener(doneBtn, DOM.EventType.CLICK, (e: MouseEvent) => {
+			e.preventDefault();
+			options.onDismiss();
+		});
+		disposables.add(doneClick);
+		const doneTap = DOM.addDisposableListener(doneBtn, TouchEventType.Tap, () => options.onDismiss());
+		disposables.add(doneTap);
+	}
+
+	if (options.caption) {
+		const caption = DOM.append(sheet, $('div.mobile-picker-sheet-caption'));
+		caption.textContent = options.caption;
+	}
+
+	// -- Dismissal: backdrop + Escape ------------------------------
+	const backdropClick = DOM.addDisposableListener(backdrop, DOM.EventType.CLICK, () => options.onDismiss());
+	disposables.add(backdropClick);
+	const backdropGesture = Gesture.addTarget(backdrop);
+	disposables.add(backdropGesture);
+	const backdropTap = DOM.addDisposableListener(backdrop, TouchEventType.Tap, () => options.onDismiss());
+	disposables.add(backdropTap);
+
+	const keyHandler = DOM.addDisposableListener(DOM.getWindow(workbenchContainer), DOM.EventType.KEY_DOWN, (e: KeyboardEvent) => {
+		if (e.key === 'Escape') {
+			e.preventDefault();
+			e.stopPropagation();
+			options.onDismiss();
+		}
+	}, true);
+	disposables.add(keyHandler);
+
+	// -- iOS keyboard avoidance -----------------------------------
+	// On iOS Safari, when the virtual keyboard opens the layout
+	// viewport (`vh` units) does NOT shrink — only the visual
+	// viewport changes. The sheet uses `position: fixed` which
+	// positions against the layout viewport, so without correction
+	// the keyboard covers the bottom portion of the sheet (including
+	// any input the user is actively typing into).
+	//
+	// `window.visualViewport` exposes the real visible area. We
+	// listen for `resize` and `scroll` events on it and translate
+	// the sheet upward by the keyboard height so the focused input
+	// remains visible.
+	const win = DOM.getWindow(workbenchContainer);
+	const vv = win.visualViewport;
+	if (vv) {
+		const adjustForKeyboard = () => {
+			// The keyboard height is the difference between the
+			// layout viewport height and the visual viewport height,
+			// plus any scroll offset the browser applied.
+			const keyboardHeight = win.innerHeight - vv.height;
+			overlay.style.bottom = `${Math.max(0, keyboardHeight)}px`;
+			overlay.style.height = `${vv.height}px`;
+		};
+		vv.addEventListener('resize', adjustForKeyboard);
+		vv.addEventListener('scroll', adjustForKeyboard);
+		disposables.add(toDisposable(() => {
+			vv.removeEventListener('resize', adjustForKeyboard);
+			vv.removeEventListener('scroll', adjustForKeyboard);
+			overlay.style.bottom = '';
+			overlay.style.height = '';
+		}));
+		// Run once immediately in case the keyboard is already
+		// visible (e.g., sheet opened while another input had focus).
+		adjustForKeyboard();
+	}
+
+	const close = (onAnimationEnd?: () => void) => {
+		if (closed) {
+			return;
+		}
+		closed = true;
+		sheet.classList.add('closing');
+		backdrop.classList.add('closing');
+		// Dispose all event listeners and inflight queries immediately
+		// so nothing fires during the 180ms close animation. The DOM
+		// node itself is removed at the end of the animation.
+		disposables.dispose();
+		DOM.getWindow(workbenchContainer).setTimeout(() => {
+			overlay.remove();
+			onAnimationEnd?.();
+		}, 180);
+	};
+
+	return { overlay, backdrop, sheet, disposables, close };
 }
 
 /** Mutable bookkeeping passed through {@link renderRow} so we can track section dividers and the row to focus. */

--- a/src/vs/sessions/browser/parts/mobile/mobileVisualViewport.ts
+++ b/src/vs/sessions/browser/parts/mobile/mobileVisualViewport.ts
@@ -1,0 +1,166 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as DOM from '../../../../base/browser/dom.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { derived, IObservable, observableValue } from '../../../../base/common/observable.js';
+import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+import { ILayoutService } from '../../../../platform/layout/browser/layoutService.js';
+import { KeyboardVisibleContext } from '../../../common/contextkeys.js';
+
+/**
+ * Threshold (in CSS pixels) above which the visual viewport delta is
+ * treated as a virtual keyboard being visible. A few dozen pixels can
+ * appear briefly during URL-bar collapse / address-bar shrink, so we
+ * require a clearly keyboard-sized delta before flipping the context.
+ */
+export const KEYBOARD_VISIBLE_THRESHOLD_PX = 50;
+
+/**
+ * CSS custom property exposed on the workbench main container that
+ * reflects the current virtual keyboard height in pixels (e.g.
+ * `--vscode-keyboard-height: 320px`). Consumers can read this from
+ * CSS (`bottom: var(--vscode-keyboard-height, 0px)`) when they need
+ * to keep UI above the keyboard without subscribing to the observable.
+ */
+const KEYBOARD_HEIGHT_CSS_VAR = '--vscode-keyboard-height';
+
+/**
+ * Service decorator for {@link MobileVisualViewport}. Consumers inject
+ * this to observe the virtual keyboard height of the agents workbench
+ * window or to gate behaviour on whether the keyboard is currently
+ * visible.
+ */
+export const IMobileVisualViewport = createDecorator<IMobileVisualViewport>('mobileVisualViewport');
+
+/**
+ * Service interface for {@link MobileVisualViewport}. See the class for
+ * a full description of the publishing surface.
+ */
+export interface IMobileVisualViewport {
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * Observable: the current virtual keyboard height in CSS pixels,
+	 * computed as `max(0, window.innerHeight - visualViewport.height)`.
+	 * Always `0` on platforms without `visualViewport` support.
+	 */
+	readonly keyboardHeight: IObservable<number>;
+
+	/**
+	 * Observable: `true` when {@link keyboardHeight} exceeds
+	 * {@link KEYBOARD_VISIBLE_THRESHOLD_PX}. Cheaper for consumers than
+	 * subscribing to `keyboardHeight` directly when they only care
+	 * about the keyboard-visible transition (it only fires on the
+	 * boolean flip, not on every height micro-change during the
+	 * keyboard open/close animation).
+	 */
+	readonly isKeyboardVisible: IObservable<boolean>;
+}
+
+/**
+ * Tracks the virtual keyboard height of the agents workbench window via
+ * the `window.visualViewport` API and exposes it to consumers in three
+ * complementary forms:
+ *
+ *  1. As an {@link IObservable} (`keyboardHeight`) for code that wants
+ *     to react to keyboard changes via `autorun` / `derived`.
+ *  2. As a CSS custom property (`--vscode-keyboard-height`) set on the
+ *     workbench main container, so styles can position fixed UI above
+ *     the keyboard without touching JavaScript at all.
+ *  3. As a reactive {@link KeyboardVisibleContext} context key (`true`
+ *     when the keyboard height exceeds {@link KEYBOARD_VISIBLE_THRESHOLD_PX}),
+ *     so `when:` clauses on commands/menus can adapt to the keyboard.
+ *
+ * # Why this helper exists
+ *
+ * On iOS Safari (and to a lesser extent some Android browsers), the
+ * *layout viewport* — what `vh` units, `window.innerHeight`, and
+ * `position: fixed` resolve against — does NOT shrink when the virtual
+ * keyboard opens. Only the *visual viewport* (the actually visible
+ * area) shrinks. As a consequence, naive layouts that anchor to the
+ * bottom of the layout viewport end up hidden behind the keyboard.
+ *
+ * The standard `window.visualViewport` API exposes the real visible
+ * area and fires `resize` / `scroll` events when the keyboard opens
+ * or closes. This helper subscribes to those events once for the
+ * lifetime of the workbench window and publishes the keyboard height
+ * (`max(0, window.innerHeight - visualViewport.height)`).
+ *
+ * # Auxiliary windows
+ *
+ * The helper uses {@link DOM.getWindow} to resolve the correct window
+ * object for the layout-service main container, so it works correctly
+ * when the workbench is hosted inside an auxiliary window (each aux
+ * window has its own `visualViewport`).
+ *
+ * # Graceful degradation
+ *
+ * Browsers that do not implement `visualViewport` (very old engines,
+ * some embedded webviews) get a constant `keyboardHeight` of `0`, no
+ * CSS variable update, and a context key that stays `false`. Consumers
+ * never need to check for the API themselves.
+ */
+export class MobileVisualViewport extends Disposable implements IMobileVisualViewport {
+
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _keyboardHeight = observableValue<number>(this, 0);
+
+	readonly keyboardHeight: IObservable<number> = this._keyboardHeight;
+
+	readonly isKeyboardVisible: IObservable<boolean> = derived(this, reader =>
+		this._keyboardHeight.read(reader) > KEYBOARD_VISIBLE_THRESHOLD_PX
+	);
+
+	private readonly _keyboardVisibleCtx: IContextKey<boolean>;
+	private readonly mainContainer: HTMLElement;
+
+	constructor(
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@ILayoutService layoutService: ILayoutService,
+	) {
+		super();
+
+		this.mainContainer = layoutService.mainContainer;
+		this._keyboardVisibleCtx = KeyboardVisibleContext.bindTo(contextKeyService);
+
+		const targetWindow = DOM.getWindow(this.mainContainer);
+		const visualViewport = targetWindow.visualViewport;
+
+		if (!visualViewport) {
+			// No visualViewport API available — keep observables/context
+			// keys at their default zero/false state.
+			return;
+		}
+
+		const update = () => {
+			const height = Math.max(0, targetWindow.innerHeight - visualViewport.height);
+			if (this._keyboardHeight.get() !== height) {
+				this._keyboardHeight.set(height, undefined);
+			}
+			this.mainContainer.style.setProperty(KEYBOARD_HEIGHT_CSS_VAR, `${height}px`);
+			this._keyboardVisibleCtx.set(height > KEYBOARD_VISIBLE_THRESHOLD_PX);
+		};
+
+		this._register(DOM.addDisposableListener(visualViewport, 'resize', update));
+		this._register(DOM.addDisposableListener(visualViewport, 'scroll', update));
+
+		// Seed the initial value so consumers see the current state on
+		// startup (e.g., the workbench was opened while the keyboard
+		// was already visible).
+		update();
+	}
+
+	override dispose(): void {
+		this.mainContainer.style.removeProperty(KEYBOARD_HEIGHT_CSS_VAR);
+		this._keyboardVisibleCtx.reset();
+		super.dispose();
+	}
+}
+
+registerSingleton(IMobileVisualViewport, MobileVisualViewport, InstantiationType.Eager);

--- a/src/vs/sessions/browser/workbench.ts
+++ b/src/vs/sessions/browser/workbench.ts
@@ -63,7 +63,7 @@ import { EditorMarkdownCodeBlockRenderer } from '../../editor/browser/widget/mar
 import { SyncDescriptor } from '../../platform/instantiation/common/descriptors.js';
 import { TitleService } from './parts/titlebarPart.js';
 import { IContextKeyService } from '../../platform/contextkey/common/contextkey.js';
-import { EditorMaximizedContext, IsPhoneLayoutContext, KeyboardVisibleContext } from '../common/contextkeys.js';
+import { EditorMaximizedContext, IsPhoneLayoutContext } from '../common/contextkeys.js';
 import {
 	NotificationsPosition,
 	NotificationsSettings,
@@ -72,6 +72,7 @@ import {
 import { SessionsLayoutPolicy } from './layoutPolicy.js';
 import { MobileNavigationStack } from './mobileNavigationStack.js';
 import { MobileTitlebarPart } from './parts/mobile/mobileTitlebarPart.js';
+import { IMobileVisualViewport } from './parts/mobile/mobileVisualViewport.js';
 import { autorun } from '../../base/common/observable.js';
 import { ISessionsManagementService } from '../services/sessions/common/sessionsManagement.js';
 import { ISessionsPartService } from './parts/sessionsPartService.js';
@@ -456,28 +457,15 @@ export class Workbench extends Disposable implements IAgentWorkbenchLayoutServic
 					isPhoneLayoutCtx.set(this.layoutPolicy.viewportClass.read(reader) === 'phone');
 				}));
 
-				// Virtual keyboard detection via visualViewport API.
-				// Use `window.innerHeight` (layout viewport) as the baseline
-				// rather than a captured initial height. Layout viewport
-				// updates on orientation change and split-screen resizes, so
-				// comparing against it avoids stale baselines on landscape
-				// launches, Android split-screen, and iOS URL-bar collapse.
-				if (mainWindow.visualViewport) {
-					const keyboardVisibleCtx = KeyboardVisibleContext.bindTo(contextKeyService);
-					const KEYBOARD_HEIGHT_THRESHOLD_PX = 100;
-
-					const onViewportResize = () => {
-						const vp = mainWindow.visualViewport;
-						if (!vp) {
-							return;
-						}
-						const heightDiff = mainWindow.innerHeight - vp.height;
-						keyboardVisibleCtx.set(heightDiff > KEYBOARD_HEIGHT_THRESHOLD_PX);
-					};
-
-					mainWindow.visualViewport.addEventListener('resize', onViewportResize);
-					this._register({ dispose: () => mainWindow.visualViewport?.removeEventListener('resize', onViewportResize) });
-				}
+				// Virtual keyboard tracking (visualViewport): publishes the
+				// keyboard height as an observable, mirrors it onto the
+				// `--vscode-keyboard-height` CSS variable on the main
+				// container, and drives the `KeyboardVisibleContext`
+				// context key. The service is an eager singleton, so
+				// resolving it here is what triggers its constructor —
+				// the registry hands ownership/disposal to the
+				// instantiation service so we don't `_register` it.
+				accessor.get(IMobileVisualViewport);
 
 				// Orientation changes produce a window `resize` event which
 				// is already handled by `registerLayoutListeners()`. No

--- a/src/vs/sessions/contrib/chat/browser/mobile/mobileConfirmationCarouselPresenter.ts
+++ b/src/vs/sessions/contrib/chat/browser/mobile/mobileConfirmationCarouselPresenter.ts
@@ -1,0 +1,102 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable, IDisposable, MutableDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
+import { derived, IObservable } from '../../../../../base/common/observable.js';
+import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { observableContextKey } from '../../../../../platform/observable/common/platformObservableUtils.js';
+import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../../workbench/common/contributions.js';
+import { IChatConfirmationPhonePresenter, IChatConfirmationPhonePresenterImpl } from '../../../../../workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatConfirmationPhonePresenter.js';
+import { IWorkbenchLayoutService } from '../../../../../workbench/services/layout/browser/layoutService.js';
+import { IMobileContentSheetApi, showMobileContentSheet } from '../../../../browser/parts/mobile/mobilePickerSheet.js';
+
+/**
+ * Sessions-side implementation of {@link IChatConfirmationPhonePresenter}.
+ *
+ * On phone-layout viewports of the agents window, hands the workbench
+ * tool-confirmation carousel DOM (created by
+ * {@link ChatToolConfirmationCarouselPart}) over to the shared mobile
+ * bottom sheet primitive ({@link showMobileContentSheet}) instead of
+ * letting it render inline in the chat message column. Workbench code
+ * does not depend on the sheet primitive: it only sees the
+ * {@link IChatConfirmationPhonePresenter} decorator interface, so this
+ * wiring stays out of the workbench layer.
+ */
+class MobileConfirmationCarouselPresenter extends Disposable implements IChatConfirmationPhonePresenterImpl {
+
+	readonly enabled: IObservable<boolean>;
+
+	constructor(
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IWorkbenchLayoutService private readonly _layoutService: IWorkbenchLayoutService,
+	) {
+		super();
+
+		// Track the phone-layout context key (`sessionsIsPhoneLayout`)
+		// so the carousel part re-renders the moment we cross the phone
+		// breakpoint. This key is the source of truth for "is this
+		// viewport phone-classified" — the layout policy updates it
+		// through the workbench's main `layout()` pass.
+		const isPhoneCtx = observableContextKey<boolean>('sessionsIsPhoneLayout', contextKeyService);
+		this.enabled = derived(this, reader => isPhoneCtx.read(reader) === true);
+	}
+
+	showCarousel(carouselElement: HTMLElement, title: string): IDisposable {
+		// Capture the sheet API in a local closure so the outer
+		// `IDisposable` we hand back to the carousel part can close the
+		// sheet on demand. `showMobileContentSheet` calls `renderBody`
+		// synchronously inside its promise constructor, so `apiRef` is
+		// assigned before the outer disposable is observed.
+		let apiRef: IMobileContentSheetApi | undefined;
+		showMobileContentSheet(
+			this._layoutService.mainContainer,
+			title,
+			(bodyContainer, api) => {
+				apiRef = api;
+				bodyContainer.appendChild(carouselElement);
+				// Detach the carousel element when the sheet tears
+				// down so the (workbench-owned) DOM survives sheet
+				// dismissal and can be re-mounted on the next tap or
+				// when the viewport flips back to desktop.
+				return toDisposable(() => {
+					if (carouselElement.parentElement === bodyContainer) {
+						bodyContainer.removeChild(carouselElement);
+					}
+				});
+			},
+		);
+		// `api.close()` is idempotent in `showMobileContentSheet`, so
+		// it's safe for the caller to dispose this handle after the
+		// sheet has already auto-closed (Done / backdrop / Escape).
+		return toDisposable(() => apiRef?.close());
+	}
+}
+
+class MobileConfirmationCarouselPresenterContribution extends Disposable implements IWorkbenchContribution {
+
+	private readonly _registration = this._register(new MutableDisposable<IDisposable>());
+
+	constructor(
+		@IChatConfirmationPhonePresenter presenter: IChatConfirmationPhonePresenter,
+		@IInstantiationService instantiationService: IInstantiationService,
+	) {
+		super();
+
+		const impl = this._register(instantiationService.createInstance(MobileConfirmationCarouselPresenter));
+
+		// Keep the registration mounted for the lifetime of the
+		// contribution. The workbench presenter's `enabled` observable
+		// already gates the actual sheet path on phone layout, so no
+		// dynamic mount/unmount is needed here.
+		this._registration.value = presenter.setImpl(impl);
+	}
+}
+
+registerWorkbenchContribution2(
+	'mobileConfirmationCarouselPresenter',
+	MobileConfirmationCarouselPresenterContribution,
+	WorkbenchPhase.BlockStartup,
+);

--- a/src/vs/sessions/contrib/chat/browser/mobile/mobilePlanReviewPresenter.ts
+++ b/src/vs/sessions/contrib/chat/browser/mobile/mobilePlanReviewPresenter.ts
@@ -1,0 +1,102 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable, IDisposable, MutableDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
+import { derived, IObservable } from '../../../../../base/common/observable.js';
+import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { observableContextKey } from '../../../../../platform/observable/common/platformObservableUtils.js';
+import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../../workbench/common/contributions.js';
+import { IChatPlanReviewPhonePresenter, IChatPlanReviewPhonePresenterImpl } from '../../../../../workbench/contrib/chat/browser/widget/chatContentParts/chatPlanReviewPhonePresenter.js';
+import { IWorkbenchLayoutService } from '../../../../../workbench/services/layout/browser/layoutService.js';
+import { IMobileContentSheetApi, showMobileContentSheet } from '../../../../browser/parts/mobile/mobilePickerSheet.js';
+
+/**
+ * Sessions-side implementation of {@link IChatPlanReviewPhonePresenter}.
+ *
+ * On phone-layout viewports of the agents window, hands the workbench
+ * chat plan-review widget DOM (created by {@link ChatPlanReviewPart})
+ * over to the shared mobile bottom sheet primitive
+ * ({@link showMobileContentSheet}) instead of letting it render inline
+ * in the chat message column. Workbench code does not depend on the
+ * sheet primitive: it only sees the {@link IChatPlanReviewPhonePresenter}
+ * decorator interface, so this wiring stays out of the workbench layer.
+ */
+class MobilePlanReviewPresenter extends Disposable implements IChatPlanReviewPhonePresenterImpl {
+
+	readonly enabled: IObservable<boolean>;
+
+	constructor(
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IWorkbenchLayoutService private readonly _layoutService: IWorkbenchLayoutService,
+	) {
+		super();
+
+		// Track the phone-layout context key (`sessionsIsPhoneLayout`)
+		// so the plan-review part re-renders the moment we cross the
+		// phone breakpoint. This key is the source of truth for "is
+		// this viewport phone-classified" — the layout policy updates
+		// it through the workbench's main `layout()` pass.
+		const isPhoneCtx = observableContextKey<boolean>('sessionsIsPhoneLayout', contextKeyService);
+		this.enabled = derived(this, reader => isPhoneCtx.read(reader) === true);
+	}
+
+	showPlanReview(planReviewElement: HTMLElement, title: string): IDisposable {
+		// Capture the sheet API in a local closure so the outer
+		// `IDisposable` we hand back to the plan-review part can close
+		// the sheet on demand. `showMobileContentSheet` calls
+		// `renderBody` synchronously inside its promise constructor,
+		// so `apiRef` is assigned before the outer disposable is
+		// observed.
+		let apiRef: IMobileContentSheetApi | undefined;
+		showMobileContentSheet(
+			this._layoutService.mainContainer,
+			title,
+			(bodyContainer, api) => {
+				apiRef = api;
+				bodyContainer.appendChild(planReviewElement);
+				// Detach the plan-review element when the sheet tears
+				// down so the (workbench-owned) DOM survives sheet
+				// dismissal and can be re-mounted on the next tap or
+				// when the viewport flips back to desktop.
+				return toDisposable(() => {
+					if (planReviewElement.parentElement === bodyContainer) {
+						bodyContainer.removeChild(planReviewElement);
+					}
+				});
+			},
+		);
+		// `api.close()` is idempotent in `showMobileContentSheet`, so
+		// it's safe for the caller to dispose this handle after the
+		// sheet has already auto-closed (Done / backdrop / Escape).
+		return toDisposable(() => apiRef?.close());
+	}
+}
+
+class MobilePlanReviewPresenterContribution extends Disposable implements IWorkbenchContribution {
+
+	private readonly _registration = this._register(new MutableDisposable<IDisposable>());
+
+	constructor(
+		@IChatPlanReviewPhonePresenter presenter: IChatPlanReviewPhonePresenter,
+		@IInstantiationService instantiationService: IInstantiationService,
+	) {
+		super();
+
+		const impl = this._register(instantiationService.createInstance(MobilePlanReviewPresenter));
+
+		// Keep the registration mounted for the lifetime of the
+		// contribution. The workbench presenter's `enabled` observable
+		// already gates the actual sheet path on phone layout, so no
+		// dynamic mount/unmount is needed here.
+		this._registration.value = presenter.setImpl(impl);
+	}
+}
+
+registerWorkbenchContribution2(
+	'mobilePlanReviewPresenter',
+	MobilePlanReviewPresenterContribution,
+	WorkbenchPhase.BlockStartup,
+);

--- a/src/vs/sessions/sessions.web.main.ts
+++ b/src/vs/sessions/sessions.web.main.ts
@@ -181,6 +181,18 @@ import './contrib/providers/agentHost/browser/mobile/mobileChatPhoneInputPresent
 // without duplicate-registration conflicts.
 import './contrib/providers/copilotChatSessions/browser/mobilePermissionPicker.contribution.js';
 
+// Phone-only presenter for the workbench tool-confirmation carousel.
+// Replaces the inline carousel in the chat message column with a
+// tap-to-review placeholder backed by a bottom sheet on phone-layout
+// viewports. Web-only — desktop keeps the inline carousel.
+import './contrib/chat/browser/mobile/mobileConfirmationCarouselPresenter.js';
+
+// Phone-only presenter for the workbench chat plan-review widget.
+// Replaces the inline plan-review widget in the chat message column
+// with a tap-to-open placeholder backed by a bottom sheet on
+// phone-layout viewports. Web-only — desktop keeps the inline widget.
+import './contrib/chat/browser/mobile/mobilePlanReviewPresenter.js';
+
 // TODO: support agent feedback in web
 import './contrib/agentFeedback/browser/nullAgentFeedbackService.contribution.js';
 import '../workbench/contrib/webview/browser/webview.web.contribution.js';

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatPlanReviewPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatPlanReviewPart.ts
@@ -13,6 +13,7 @@ import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { MarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { KeyCode } from '../../../../../../base/common/keyCodes.js';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable, toDisposable } from '../../../../../../base/common/lifecycle.js';
+import { autorun } from '../../../../../../base/common/observable.js';
 import { ScrollbarVisibility } from '../../../../../../base/common/scrollable.js';
 import Severity from '../../../../../../base/common/severity.js';
 import { basename } from '../../../../../../base/common/resources.js';
@@ -42,6 +43,7 @@ import { IChatRendererContent, isResponseVM } from '../../../common/model/chatVi
 import { ChatTreeItem } from '../../chat.js';
 import { ChatConfiguration } from '../../../common/constants.js';
 import { IChatContentPart, IChatContentPartRenderContext } from './chatContentParts.js';
+import { IChatPlanReviewPhonePresenter } from './chatPlanReviewPhonePresenter.js';
 import './media/chatPlanReview.css';
 
 // Sub-path for the embedded editor's in-memory model. Uses `inmemory:` so
@@ -95,6 +97,17 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 	private _initialEditorContent: string | undefined;
 	private readonly _messageEditorDisposables = this._register(new DisposableStore());
 
+	// Phone-only members. The plan-review root element (`_planReviewRoot`)
+	// lives either inside `this.domNode` (desktop) or parked under
+	// `_hiddenHost` (phone, sheet closed) or temporarily reparented into
+	// the bottom-sheet body by the phone presenter (phone, sheet open).
+	// The placeholder (`_phonePlaceholder`) is shown in `this.domNode` in
+	// place of the plan-review root when in phone mode.
+	private readonly _planReviewRoot: HTMLElement;
+	private readonly _hiddenHost: HTMLElement;
+	private readonly _phonePlaceholder: HTMLElement;
+	private readonly _openSheet = this._register(new MutableDisposable<IDisposable>());
+
 	constructor(
 		public readonly review: IChatPlanReview,
 		context: IChatContentPartRenderContext,
@@ -111,6 +124,7 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 		@ITextModelService private readonly _textModelService: ITextModelService,
 		@ILanguageService private readonly _languageService: ILanguageService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IChatPlanReviewPhonePresenter private readonly _phonePresenter: IChatPlanReviewPhonePresenter,
 	) {
 		super();
 
@@ -170,6 +184,44 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 		this.domNode.id = generateUuid();
 		this.domNode.setAttribute('role', 'region');
 		this.domNode.setAttribute('aria-label', localize('chat.planReview.ariaLabel', 'Plan review: {0}', review.title));
+
+		this._planReviewRoot = elements.root;
+
+		// Off-screen host that keeps the plan-review root DOM (and its
+		// observers, editor instance, feedback handlers, etc.) alive
+		// while the root is mounted into a phone bottom sheet rather
+		// than into `domNode`. The host is itself a child of `domNode`
+		// so it disposes along with the part. Using `display:none`
+		// would suppress layout/resize callbacks, so we keep it
+		// visually hidden via `visibility:hidden` + zero size.
+		this._hiddenHost = dom.$('.chat-plan-review-host');
+		this._hiddenHost.style.position = 'absolute';
+		this._hiddenHost.style.visibility = 'hidden';
+		this._hiddenHost.style.pointerEvents = 'none';
+		this._hiddenHost.style.width = '0';
+		this._hiddenHost.style.height = '0';
+		this._hiddenHost.style.overflow = 'hidden';
+		this._hiddenHost.setAttribute('aria-hidden', 'true');
+		this.domNode.appendChild(this._hiddenHost);
+
+		// Phone-only trigger that replaces the inline plan-review root.
+		// Tapping it hands the (still-live) plan-review root to the
+		// phone presenter, which mounts it into a bottom sheet.
+		this._phonePlaceholder = dom.$('.chat-plan-review-mobile-trigger');
+		this._phonePlaceholder.setAttribute('role', 'button');
+		this._phonePlaceholder.tabIndex = 0;
+		this._phonePlaceholder.textContent = localize('chat.planReview.mobileTrigger', "Review plan — tap to open");
+		this._phonePlaceholder.setAttribute('aria-label', localize('chat.planReview.mobileTriggerAria', "Open plan review for {0}", review.title));
+		this._register(dom.addDisposableListener(this._phonePlaceholder, dom.EventType.CLICK, e => {
+			dom.EventHelper.stop(e, true);
+			this._openPhoneSheet();
+		}));
+		this._register(dom.addDisposableListener(this._phonePlaceholder, dom.EventType.KEY_DOWN, e => {
+			if (e.key === 'Enter' || e.key === ' ') {
+				dom.EventHelper.stop(e, true);
+				this._openPhoneSheet();
+			}
+		}));
 
 		this._titleActionsEl = elements.titleActions;
 		this._inlineActionsEl = elements.inlineActions;
@@ -268,6 +320,60 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 		if (!this._isSubmitted && this.getInlineFeedbackItems().length > 0) {
 			void this.enterFeedbackMode({ focus: false });
 		}
+
+		// Swap the mount between the inline plan-review root (desktop)
+		// and the tap-to-open placeholder (phone) whenever the
+		// presenter's `enabled` observable flips. Runs once on
+		// construction, then on every viewport rotation across the
+		// phone breakpoint.
+		this._register(autorun(reader => {
+			const isPhone = this._phonePresenter.enabled.read(reader);
+			this._applyMount(isPhone);
+		}));
+	}
+
+	/**
+	 * Swap the plan-review root between its inline desktop mount and
+	 * the phone tap-to-open placeholder. The plan-review root always
+	 * remains alive — when in phone mode, it parks under
+	 * {@link _hiddenHost} so its embedded editor, feedback observers,
+	 * and registered listeners keep running until the user either taps
+	 * the placeholder (mount into the bottom sheet) or the viewport
+	 * flips back to desktop (re-mount inline).
+	 */
+	private _applyMount(isPhone: boolean): void {
+		// On every flip, close any open phone sheet so we don't leave
+		// the plan-review root parented to a stale sheet body across a
+		// breakpoint change.
+		this._openSheet.clear();
+
+		if (isPhone) {
+			if (this._planReviewRoot.parentElement !== this._hiddenHost) {
+				this._hiddenHost.appendChild(this._planReviewRoot);
+			}
+			if (this._phonePlaceholder.parentElement !== this.domNode) {
+				this.domNode.appendChild(this._phonePlaceholder);
+			}
+		} else {
+			if (this._phonePlaceholder.parentElement === this.domNode) {
+				this.domNode.removeChild(this._phonePlaceholder);
+			}
+			// Re-attach the plan-review root as the visible child.
+			// Order relative to `_hiddenHost` doesn't matter since the
+			// host is zero-size + visibility-hidden, but keep the
+			// plan-review root last so it paints in the usual position.
+			this.domNode.appendChild(this._planReviewRoot);
+		}
+	}
+
+	private _openPhoneSheet(): void {
+		if (!this._phonePresenter.enabled.get() || this._isSubmitted) {
+			return;
+		}
+		// `MutableDisposable.value = ...` disposes the previous handle,
+		// so re-tapping after an auto-dismissed sheet (Done / backdrop /
+		// Escape) collapses to "dispose stale + open fresh" in one step.
+		this._openSheet.value = this._phonePresenter.showPlanReview(this._planReviewRoot, this.review.title);
 	}
 
 	hasSameContent(other: IChatRendererContent, _followingContent: IChatRendererContent[], _element: ChatTreeItem): boolean {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatPlanReviewPhonePresenter.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatPlanReviewPhonePresenter.ts
@@ -1,0 +1,116 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable, IDisposable, toDisposable } from '../../../../../../base/common/lifecycle.js';
+import { derived, IObservable, observableValue } from '../../../../../../base/common/observable.js';
+import { InstantiationType, registerSingleton } from '../../../../../../platform/instantiation/common/extensions.js';
+import { createDecorator } from '../../../../../../platform/instantiation/common/instantiation.js';
+
+/**
+ * Implementation of the phone-only chat plan-review presenter, registered
+ * by the agents-window (sessions) layer. Stays in `vs/workbench` as an
+ * interface so the workbench chat content parts can compile and run with
+ * no sessions dependency; the default singleton is a no-op (sees
+ * `enabled === false`).
+ */
+export interface IChatPlanReviewPhonePresenterImpl {
+	/**
+	 * Whether the phone presenter is currently active. Workbench code
+	 * consults this to decide between rendering the multi-step plan
+	 * review widget inline in the chat message column (desktop) and
+	 * surfacing a tap-to-open placeholder backed by a bottom sheet
+	 * (phone). Drives a re-render of the plan-review mount on every flip.
+	 */
+	readonly enabled: IObservable<boolean>;
+
+	/**
+	 * Move {@link planReviewElement} into a bottom-sheet body and
+	 * display it. The returned {@link IDisposable} closes the sheet
+	 * (idempotent), and the implementation MUST detach
+	 * `planReviewElement` from the sheet body before the shell tears
+	 * down so the workbench-owned plan-review DOM survives sheet
+	 * dismissal and can be re-mounted on the next tap or on a
+	 * phone→desktop transition.
+	 *
+	 * @param planReviewElement Workbench-owned plan-review root. The
+	 *   presenter only re-parents it; the element's lifetime is owned
+	 *   by the calling chat content part.
+	 * @param title Sheet header title (already localized).
+	 */
+	showPlanReview(planReviewElement: HTMLElement, title: string): IDisposable;
+}
+
+export const IChatPlanReviewPhonePresenter = createDecorator<IChatPlanReviewPhonePresenter>('chatPlanReviewPhonePresenter');
+
+/**
+ * Workbench-layer hook for phone-only chat plan-review presentation.
+ *
+ * The default singleton is a no-op (`enabled === false`,
+ * {@link showPlanReview} is a no-op disposable). The agents-window layer
+ * (`vs/sessions`) registers a real implementation via {@link setImpl}
+ * that mounts the plan-review root into the shared mobile bottom sheet
+ * (see `showMobileContentSheet` in
+ * `vs/sessions/browser/parts/mobile/mobilePickerSheet`).
+ *
+ * Workbench callers should:
+ *   1. Read `enabled.get()` to decide whether to mount the plan-review
+ *      root inline (desktop) or render the tap-to-open placeholder
+ *      (phone).
+ *   2. Subscribe to `enabled` (e.g. via `autorun`) so the mount swaps
+ *      automatically when the viewport crosses the phone breakpoint
+ *      (e.g. rotation).
+ *   3. Treat the disposable returned by {@link showPlanReview} as the
+ *      "is the sheet open" handle: dispose it to close, and on tap
+ *      always overwrite the stored handle so re-tap after sheet
+ *      dismissal opens a fresh sheet (the underlying `close()` call is
+ *      idempotent for the auto-closed case).
+ */
+export interface IChatPlanReviewPhonePresenter {
+	readonly _serviceBrand: undefined;
+
+	/** `true` when an impl is registered AND it reports phone layout. */
+	readonly enabled: IObservable<boolean>;
+
+	/**
+	 * Mount the plan-review root into the phone bottom sheet. No-ops
+	 * (returns `Disposable.None`) when {@link enabled} is `false`.
+	 */
+	showPlanReview(planReviewElement: HTMLElement, title: string): IDisposable;
+
+	/**
+	 * Register the phone implementation. Returns a disposable that
+	 * removes the registration. Only one impl is active at a time; the
+	 * most recent registration wins.
+	 */
+	setImpl(impl: IChatPlanReviewPhonePresenterImpl): IDisposable;
+}
+
+class ChatPlanReviewPhonePresenterService extends Disposable implements IChatPlanReviewPhonePresenter {
+
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _impl = observableValue<IChatPlanReviewPhonePresenterImpl | undefined>(this, undefined);
+
+	readonly enabled: IObservable<boolean> = derived(this, reader => {
+		const impl = this._impl.read(reader);
+		return impl ? impl.enabled.read(reader) : false;
+	});
+
+	showPlanReview(planReviewElement: HTMLElement, title: string): IDisposable {
+		const impl = this._impl.get();
+		return impl ? impl.showPlanReview(planReviewElement, title) : Disposable.None;
+	}
+
+	setImpl(impl: IChatPlanReviewPhonePresenterImpl): IDisposable {
+		this._impl.set(impl, undefined);
+		return toDisposable(() => {
+			if (this._impl.get() === impl) {
+				this._impl.set(undefined, undefined);
+			}
+		});
+	}
+}
+
+registerSingleton(IChatPlanReviewPhonePresenter, ChatPlanReviewPhonePresenterService, InstantiationType.Delayed);

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatConfirmationPhonePresenter.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatConfirmationPhonePresenter.ts
@@ -1,0 +1,114 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable, IDisposable, toDisposable } from '../../../../../../../base/common/lifecycle.js';
+import { derived, IObservable, observableValue } from '../../../../../../../base/common/observable.js';
+import { InstantiationType, registerSingleton } from '../../../../../../../platform/instantiation/common/extensions.js';
+import { createDecorator } from '../../../../../../../platform/instantiation/common/instantiation.js';
+
+/**
+ * Implementation of the phone-only tool-confirmation carousel presenter,
+ * registered by the agents-window (sessions) layer. Stays in
+ * `vs/workbench` as an interface so the workbench chat content parts can
+ * compile and run with no sessions dependency; the default singleton is
+ * a no-op (sees `enabled === false`).
+ */
+export interface IChatConfirmationPhonePresenterImpl {
+	/**
+	 * Whether the phone presenter is currently active. Workbench code
+	 * consults this to decide between rendering the carousel inline in
+	 * the chat message column (desktop) and surfacing a tap-to-review
+	 * placeholder backed by a bottom sheet (phone). Drives a re-render
+	 * of the carousel mount on every flip.
+	 */
+	readonly enabled: IObservable<boolean>;
+
+	/**
+	 * Move {@link carouselElement} into a bottom-sheet body and display
+	 * it. The returned {@link IDisposable} closes the sheet (idempotent),
+	 * and the implementation MUST detach `carouselElement` from the sheet
+	 * body before the shell tears down so the workbench-owned carousel
+	 * DOM survives sheet dismissal and can be re-mounted on the next
+	 * tap or on a phone→desktop transition.
+	 *
+	 * @param carouselElement Workbench-owned carousel root. The presenter
+	 *   only re-parents it; the carousel's lifetime is owned by the
+	 *   calling chat content part.
+	 * @param title Sheet header title (already localized).
+	 */
+	showCarousel(carouselElement: HTMLElement, title: string): IDisposable;
+}
+
+export const IChatConfirmationPhonePresenter = createDecorator<IChatConfirmationPhonePresenter>('chatConfirmationPhonePresenter');
+
+/**
+ * Workbench-layer hook for phone-only tool-confirmation carousel
+ * presentation.
+ *
+ * The default singleton is a no-op (`enabled === false`, {@link showCarousel}
+ * is a no-op disposable). The agents-window layer (`vs/sessions`)
+ * registers a real implementation via {@link setImpl} that mounts the
+ * carousel into the shared mobile bottom sheet (see
+ * `showMobileContentSheet` in `vs/sessions/browser/parts/mobile/mobilePickerSheet`).
+ *
+ * Workbench callers should:
+ *   1. Read `enabled.get()` to decide whether to mount the carousel
+ *      inline (desktop) or render the tap-to-review placeholder (phone).
+ *   2. Subscribe to `enabled` (e.g. via `autorun`) so the mount swaps
+ *      automatically when the viewport crosses the phone breakpoint
+ *      (e.g. rotation).
+ *   3. Treat the disposable returned by {@link showCarousel} as the
+ *      "is the sheet open" handle: dispose it to close, and on tap
+ *      always overwrite the stored handle so re-tap after sheet
+ *      dismissal opens a fresh sheet (the underlying `close()` call is
+ *      idempotent for the auto-closed case).
+ */
+export interface IChatConfirmationPhonePresenter {
+	readonly _serviceBrand: undefined;
+
+	/** `true` when an impl is registered AND it reports phone layout. */
+	readonly enabled: IObservable<boolean>;
+
+	/**
+	 * Mount the carousel into the phone bottom sheet. No-ops (returns
+	 * `Disposable.None`) when {@link enabled} is `false`.
+	 */
+	showCarousel(carouselElement: HTMLElement, title: string): IDisposable;
+
+	/**
+	 * Register the phone implementation. Returns a disposable that
+	 * removes the registration. Only one impl is active at a time; the
+	 * most recent registration wins.
+	 */
+	setImpl(impl: IChatConfirmationPhonePresenterImpl): IDisposable;
+}
+
+class ChatConfirmationPhonePresenterService extends Disposable implements IChatConfirmationPhonePresenter {
+
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _impl = observableValue<IChatConfirmationPhonePresenterImpl | undefined>(this, undefined);
+
+	readonly enabled: IObservable<boolean> = derived(this, reader => {
+		const impl = this._impl.read(reader);
+		return impl ? impl.enabled.read(reader) : false;
+	});
+
+	showCarousel(carouselElement: HTMLElement, title: string): IDisposable {
+		const impl = this._impl.get();
+		return impl ? impl.showCarousel(carouselElement, title) : Disposable.None;
+	}
+
+	setImpl(impl: IChatConfirmationPhonePresenterImpl): IDisposable {
+		this._impl.set(impl, undefined);
+		return toDisposable(() => {
+			if (this._impl.get() === impl) {
+				this._impl.set(undefined, undefined);
+			}
+		});
+	}
+}
+
+registerSingleton(IChatConfirmationPhonePresenter, ChatConfirmationPhonePresenterService, InstantiationType.Delayed);

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolConfirmationCarouselPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolConfirmationCarouselPart.ts
@@ -10,13 +10,14 @@ import { Codicon } from '../../../../../../../base/common/codicons.js';
 import { Emitter } from '../../../../../../../base/common/event.js';
 import { IMarkdownString } from '../../../../../../../base/common/htmlContent.js';
 import { KeyCode } from '../../../../../../../base/common/keyCodes.js';
-import { Disposable, DisposableStore, MutableDisposable, toDisposable } from '../../../../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, IDisposable, MutableDisposable, toDisposable } from '../../../../../../../base/common/lifecycle.js';
 import { autorun } from '../../../../../../../base/common/observable.js';
 import { generateUuid } from '../../../../../../../base/common/uuid.js';
 import { localize } from '../../../../../../../nls.js';
 import { defaultButtonStyles } from '../../../../../../../platform/theme/browser/defaultStyles.js';
 import { IChatToolInvocation, ToolConfirmKind } from '../../../../common/chatService/chatService.js';
 import { ChatToolInvocationPart } from './chatToolInvocationPart.js';
+import { IChatConfirmationPhonePresenter } from './chatConfirmationPhonePresenter.js';
 import '../media/chatToolConfirmationCarousel.css';
 
 const COLLAPSED_CAROUSEL_MAX_HEIGHT = 300;
@@ -50,6 +51,10 @@ export class ChatToolConfirmationCarouselPart extends Disposable {
 	private readonly toolCallIds = new Set<string>();
 	private activeIndex = 0;
 
+	private readonly _carouselRoot: HTMLElement;
+	private readonly _hiddenHost: HTMLElement;
+	private readonly _phonePlaceholder: HTMLElement;
+	private readonly _openSheet = this._register(new MutableDisposable<IDisposable>());
 	private readonly collapsedTitle: HTMLElement;
 	private readonly agentLabel: HTMLButtonElement;
 	private readonly contentContainer: HTMLElement;
@@ -69,11 +74,18 @@ export class ChatToolConfirmationCarouselPart extends Disposable {
 	constructor(
 		private readonly toolPartFactory: ToolInvocationPartFactory,
 		initialTools: IChatToolInvocation[],
-		private readonly scrollToSubagent?: ScrollToSubagentCallback,
-		private readonly initialSubAgentInvocationId?: string,
-		private readonly initialAgentName?: string,
+		private readonly scrollToSubagent: ScrollToSubagentCallback | undefined,
+		private readonly initialSubAgentInvocationId: string | undefined,
+		private readonly initialAgentName: string | undefined,
+		@IChatConfirmationPhonePresenter private readonly _phonePresenter: IChatConfirmationPhonePresenter,
 	) {
 		super();
+
+		// Outer wrapper appended to the chat message column by the
+		// caller. Its single child is swapped between the inline
+		// carousel root (desktop) and the tap-to-review placeholder
+		// (phone) — see the `_phonePresenter.enabled` autorun below.
+		this.domNode = dom.$('.chat-tool-confirmation-carousel-wrapper');
 
 		const elements = dom.h('.chat-tool-confirmation-carousel@root', [
 			dom.h('.chat-tool-carousel-overlay@overlay', [
@@ -89,17 +101,53 @@ export class ChatToolConfirmationCarouselPart extends Disposable {
 			dom.h('.chat-tool-carousel-content@content'),
 		]);
 
-		this.domNode = elements.root;
-		this.domNode.tabIndex = -1;
-		this.domNode.setAttribute('role', 'group');
-		this.domNode.setAttribute('aria-label', localize('toolConfirmationCarousel', "Tool confirmation carousel"));
+		this._carouselRoot = elements.root;
+		this._carouselRoot.tabIndex = -1;
+		this._carouselRoot.setAttribute('role', 'group');
+		this._carouselRoot.setAttribute('aria-label', localize('toolConfirmationCarousel', "Tool confirmation carousel"));
+
+		// Off-screen host that keeps the carousel DOM (and its
+		// observers) alive while the carousel is mounted into a phone
+		// bottom sheet rather than into `domNode`. The host is itself a
+		// child of `domNode` so it disposes along with the part. Using
+		// `display:none` would suppress layout/resize callbacks, so we
+		// keep it visually hidden via `visibility:hidden` + zero size.
+		this._hiddenHost = dom.$('.chat-tool-confirmation-carousel-host');
+		this._hiddenHost.style.position = 'absolute';
+		this._hiddenHost.style.visibility = 'hidden';
+		this._hiddenHost.style.pointerEvents = 'none';
+		this._hiddenHost.style.width = '0';
+		this._hiddenHost.style.height = '0';
+		this._hiddenHost.style.overflow = 'hidden';
+		this._hiddenHost.setAttribute('aria-hidden', 'true');
+		this.domNode.appendChild(this._hiddenHost);
+
+		// Phone-only trigger that replaces the inline carousel. Clicking
+		// hands the (still-live) carousel root to the phone presenter,
+		// which mounts it into a bottom sheet.
+		this._phonePlaceholder = dom.$('.chat-confirmation-mobile-trigger');
+		this._phonePlaceholder.setAttribute('role', 'button');
+		this._phonePlaceholder.tabIndex = 0;
+		this._phonePlaceholder.textContent = localize('chatToolConfirmationCarousel.mobileTrigger', "Tap to review");
+		this._phonePlaceholder.setAttribute('aria-label', localize('chatToolConfirmationCarousel.mobileTriggerAria', "Review pending tool confirmation"));
+		this._register(dom.addDisposableListener(this._phonePlaceholder, dom.EventType.CLICK, e => {
+			dom.EventHelper.stop(e, true);
+			this._openPhoneSheet();
+		}));
+		this._register(dom.addDisposableListener(this._phonePlaceholder, dom.EventType.KEY_DOWN, e => {
+			if (e.key === 'Enter' || e.key === ' ') {
+				dom.EventHelper.stop(e, true);
+				this._openPhoneSheet();
+			}
+		}));
+
 		this.collapsedTitle = elements.collapsedTitle;
 		this.agentLabel = elements.agentLabel;
 		this.contentContainer = elements.content;
 		this.contentContainer.id = generateUuid();
 		this.stepIndicator = elements.stepIndicator;
 		this.activeContentDisposables = this._register(new DisposableStore());
-		this.updateContentExpansionStateScheduler = this._register(new dom.AnimationFrameScheduler(this.domNode, () => this.updateContentExpansionState()));
+		this.updateContentExpansionStateScheduler = this._register(new dom.AnimationFrameScheduler(this._carouselRoot, () => this.updateContentExpansionState()));
 		this.contentResizeObserver = this._register(new dom.DisposableResizeObserver('ChatToolConfirmationCarouselPart.contentExpansion', () => this.updateContentExpansionStateScheduler.schedule()));
 		this._register(this.contentResizeObserver.observe(this.contentContainer));
 
@@ -150,7 +198,16 @@ export class ChatToolConfirmationCarouselPart extends Disposable {
 			this.scrollToActiveSubagent();
 		}));
 
-		this._register(dom.addDisposableListener(this.domNode, 'keydown', e => this.onKeydown(e)));
+		this._register(dom.addDisposableListener(this._carouselRoot, 'keydown', e => this.onKeydown(e)));
+
+		// Swap the mount between inline carousel (desktop) and the
+		// tap-to-review placeholder (phone) whenever the presenter's
+		// `enabled` observable flips. Runs once on construction, then
+		// on every viewport rotation across the phone breakpoint.
+		this._register(autorun(reader => {
+			const isPhone = this._phonePresenter.enabled.read(reader);
+			this._applyMount(isPhone);
+		}));
 
 		for (const tool of initialTools) {
 			this.addToolInvocation(tool, this.initialSubAgentInvocationId, this.initialAgentName, this.scrollToSubagent);
@@ -276,6 +333,7 @@ export class ChatToolConfirmationCarouselPart extends Disposable {
 
 		if (this.items.length === 0) {
 			dom.hide(this.domNode);
+			this._openSheet.clear();
 			this._onDidEmpty.fire();
 			return;
 		}
@@ -355,7 +413,7 @@ export class ChatToolConfirmationCarouselPart extends Disposable {
 	}
 
 	private focusActiveContent(): void {
-		this.domNode.focus();
+		this._carouselRoot.focus();
 	}
 
 	private updateUI(): void {
@@ -434,7 +492,7 @@ export class ChatToolConfirmationCarouselPart extends Disposable {
 			this._isContentExpanded = false;
 		}
 
-		this.domNode.classList.toggle('chat-tool-carousel-content-expanded', this.canExpandContent && this._isContentExpanded);
+		this._carouselRoot.classList.toggle('chat-tool-carousel-content-expanded', this.canExpandContent && this._isContentExpanded);
 		this.updateMaxHeightStyle();
 		dom.setVisibility(this.canExpandContent, this.expandContentButton.element);
 		this.updateExpandContentButton();
@@ -442,13 +500,13 @@ export class ChatToolConfirmationCarouselPart extends Disposable {
 
 	private updateMaxHeightStyle(): void {
 		if (this.maxHeight === undefined) {
-			this.domNode.style.removeProperty('max-height');
+			this._carouselRoot.style.removeProperty('max-height');
 			return;
 		}
 
 		const expanded = this.canExpandContent && this._isContentExpanded;
 		const maxHeight = expanded ? Math.max(MIN_CAROUSEL_MAX_HEIGHT, this.maxHeight) : this.getCollapsedMaxHeight();
-		this.domNode.style.maxHeight = `${Math.floor(maxHeight)}px`;
+		this._carouselRoot.style.maxHeight = `${Math.floor(maxHeight)}px`;
 	}
 
 	private updateExpandContentButton(): void {
@@ -512,7 +570,7 @@ export class ChatToolConfirmationCarouselPart extends Disposable {
 	}
 
 	private getExpandableContentHeightLimit(element: HTMLElement): number {
-		const window = dom.getWindow(this.domNode);
+		const window = dom.getWindow(this._carouselRoot);
 		if (element.classList.contains('interactive-result-editor')) {
 			return Math.min(COLLAPSED_CODE_BLOCK_MAX_HEIGHT, window.innerHeight * 0.25);
 		}
@@ -522,7 +580,7 @@ export class ChatToolConfirmationCarouselPart extends Disposable {
 
 	private getCollapsedMaxHeight(): number {
 		const configuredMaxHeight = this.maxHeight === undefined ? Number.POSITIVE_INFINITY : Math.max(MIN_CAROUSEL_MAX_HEIGHT, this.maxHeight);
-		return Math.min(configuredMaxHeight, COLLAPSED_CAROUSEL_MAX_HEIGHT, dom.getWindow(this.domNode).innerHeight * 0.45);
+		return Math.min(configuredMaxHeight, COLLAPSED_CAROUSEL_MAX_HEIGHT, dom.getWindow(this._carouselRoot).innerHeight * 0.45);
 	}
 
 	allowAll(): void {
@@ -586,5 +644,50 @@ export class ChatToolConfirmationCarouselPart extends Disposable {
 		if (index >= 0) {
 			this.setActiveIndex(index);
 		}
+	}
+
+	/**
+	 * Swap the carousel between its inline desktop mount and the phone
+	 * tap-to-review placeholder. The carousel root always remains alive
+	 * — when in phone mode, it parks under {@link _hiddenHost} so its
+	 * observers and tool subscriptions keep running until the user
+	 * either taps the placeholder (mount into the bottom sheet) or the
+	 * viewport flips back to desktop (re-mount inline).
+	 */
+	private _applyMount(isPhone: boolean): void {
+		// On every flip, close any open phone sheet so we don't leave
+		// the carousel parented to a stale sheet body across a
+		// breakpoint change.
+		this._openSheet.clear();
+
+		if (isPhone) {
+			if (this._carouselRoot.parentElement !== this._hiddenHost) {
+				this._hiddenHost.appendChild(this._carouselRoot);
+			}
+			if (this._phonePlaceholder.parentElement !== this.domNode) {
+				this.domNode.appendChild(this._phonePlaceholder);
+			}
+		} else {
+			if (this._phonePlaceholder.parentElement === this.domNode) {
+				this.domNode.removeChild(this._phonePlaceholder);
+			}
+			// Re-attach the carousel root as the visible child. Order
+			// relative to `_hiddenHost` doesn't matter since the host
+			// is zero-size + visibility-hidden, but keep the carousel
+			// last so it paints in the usual position.
+			this.domNode.appendChild(this._carouselRoot);
+		}
+	}
+
+	private _openPhoneSheet(): void {
+		if (!this._phonePresenter.enabled.get() || this.items.length === 0) {
+			return;
+		}
+		const item = this.items[this.activeIndex];
+		const title = this.getToolTitle(item) ?? localize('chatToolConfirmationCarousel.sheetTitle', "Tool Confirmation");
+		// `MutableDisposable.value = ...` disposes the previous handle,
+		// so re-tapping after an auto-dismissed sheet (Done / backdrop /
+		// Escape) collapses to "dispose stale + open fresh" in one step.
+		this._openSheet.value = this._phonePresenter.showCarousel(this._carouselRoot, title);
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -3351,7 +3351,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			throw new Error('Cannot render tool confirmation carousel without an active session');
 		}
 
-		const part = new ChatToolConfirmationCarouselPart(factory, [], scrollToSubagent, subAgentInvocationId, agentName);
+		const part = this.instantiationService.createInstance(ChatToolConfirmationCarouselPart, factory, [], scrollToSubagent, subAgentInvocationId, agentName);
 		part.addToolInvocation(tool, subAgentInvocationId, agentName, scrollToSubagent, toolPart);
 		this._chatToolConfirmationCarousels.set(key, part);
 		dom.append(this.chatToolConfirmationCarouselContainer, part.domNode);


### PR DESCRIPTION
Stacked on #318647.

Part 4 of a 10-PR series breaking up the mobile chat work. This PR introduces the bottom-sheet treatments for the two long-form inline widgets in the chat message column — tool-confirmation carousels and plan-review widgets — on phone-layout viewports, via two new presenter seams that desktop ignores.

## Scope

### Workbench seams (consumed on desktop unchanged)
- **`IChatConfirmationPhonePresenter`** — optional service consulted by `ChatToolConfirmationCarouselPart`. When unregistered (desktop, non-phone), the carousel renders inline as today. When registered (phone via sessions side), the carousel emits a tap-to-review placeholder and defers the actual confirmation UI to a presenter-owned bottom sheet.
  - `chatConfirmationPhonePresenter.ts` — service identifier + presenter contract.
  - `chatToolConfirmationCarouselPart.ts` — DI-converted (`new` → `createInstance`) and consumes the optional presenter.
  - `chatInputPart.ts` — single hunk: the inline construction of `ChatToolConfirmationCarouselPart` now goes through `IInstantiationService.createInstance` so the new optional service injection actually runs.
- **`IChatPlanReviewPhonePresenter`** — equivalent seam for `ChatPlanReviewPart` (todo plan widgets).
  - `chatPlanReviewPhonePresenter.ts` — service identifier + presenter contract.
  - `chatPlanReviewPart.ts` — consumes the optional presenter.

### Sessions-side phone implementations (web-only)
- `mobileConfirmationCarouselPresenter.ts` — registers `IChatConfirmationPhonePresenter` and drives the bottom sheet for tool confirmations.
- `mobilePlanReviewPresenter.ts` — registers `IChatPlanReviewPhonePresenter` and drives the bottom sheet for plan-review widgets.
- `sessions.web.main.ts` — side-effect imports for both new presenters (next to the existing mobile chat input presenters).

### CSS
Two appended sections in `mobileChatShell.css`, both behind `.agent-sessions-workbench.phone-layout`:
- **Phone Layout: Chat Confirmation Widgets** — stacked button rows, tap-target sizing, modified-files list affordances (`chat-collapsible-list-action-bar` always shown because "show on hover" doesn't translate to touch).
- **Phone Layout: Chat Elicitation** — iOS auto-zoom block (`font-size: 16px` floor on inputs / textareas / selects), 44px min-height for form controls, 24px min for checkbox/radio, and a larger title row so elicitation reads as the primary on-screen thing.

## Desktop impact
None. Both seams are optional services; without a phone-side registration the carousel and plan-review widgets render exactly as before. The only structural workbench change is the `new ChatToolConfirmationCarouselPart(...)` → `instantiationService.createInstance(ChatToolConfirmationCarouselPart, ...)` swap, which is required for the optional injection to be resolved and is otherwise behavior-preserving.

## Validation
- `npm run compile-check-ts-native` — clean.
- `npm run valid-layers-check` — clean.
