### PR TITLE
Mobile chat (5/10): long-press row actions

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -12,8 +12,6 @@
 		"--vscode-activityBarBadge-background",
 		"--vscode-activityBarBadge-foreground",
 		"--vscode-activityBarTop-activeBackground",
-		"--vscode-activeSessionView-background",
-		"--vscode-activeSessionView-foreground",
 		"--vscode-activityBarTop-activeBorder",
 		"--vscode-activityBarTop-background",
 		"--vscode-activityBarTop-dropBorder",
@@ -27,8 +25,6 @@
 		"--vscode-agentSessionReadIndicator-foreground",
 		"--vscode-agentSessionSelectedBadge-border",
 		"--vscode-agentSessionSelectedUnfocusedBadge-border",
-		"--vscode-inactiveSessionView-background",
-		"--vscode-inactiveSessionView-foreground",
 		"--vscode-agentStatusIndicator-background",
 		"--vscode-badge-background",
 		"--vscode-badge-foreground",
@@ -951,8 +947,6 @@
 		"--mobile-diff-tok-keyword",
 		"--mobile-diff-tok-number",
 		"--chat-editing-last-edit-shift",
-		"--session-view-background",
-		"--session-view-foreground",
 		"--chat-current-response-min-height",
 		"--chat-smooth-delay",
 		"--chat-smooth-duration",
@@ -1081,9 +1075,6 @@
 		"--slide-from-y"
 	],
 	"sizes": [
-		"--vscode-agents-fontWeight-medium",
-		"--vscode-agents-fontWeight-regular",
-		"--vscode-agents-fontWeight-semiBold",
 		"--vscode-agents-fontSize-body1",
 		"--vscode-agents-fontSize-body2",
 		"--vscode-agents-fontSize-heading1",
@@ -1093,6 +1084,9 @@
 		"--vscode-agents-fontSize-label2",
 		"--vscode-agents-fontSize-label3",
 		"--vscode-agents-fontSize-label4",
+		"--vscode-agents-fontWeight-medium",
+		"--vscode-agents-fontWeight-regular",
+		"--vscode-agents-fontWeight-semiBold",
 		"--vscode-bodyFontSize",
 		"--vscode-bodyFontSize-small",
 		"--vscode-bodyFontSize-xSmall",
@@ -1104,6 +1098,7 @@
 		"--vscode-cornerRadius-small",
 		"--vscode-cornerRadius-xLarge",
 		"--vscode-cornerRadius-xSmall",
+		"--vscode-keyboard-height",
 		"--vscode-strokeThickness"
 	]
 }

--- a/src/vs/sessions/browser/parts/mobile/contributions/mobilePulldownDismiss.ts
+++ b/src/vs/sessions/browser/parts/mobile/contributions/mobilePulldownDismiss.ts
@@ -1,0 +1,205 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DisposableStore, IDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
+import { addDisposableListener, EventType } from '../../../../../base/browser/dom.js';
+
+/**
+ * Vertical travel (in px) past which the gesture commits and the overlay
+ * is dismissed on `pointerup`.
+ */
+const COMMIT_THRESHOLD_PX = 120;
+
+/**
+ * Initial dead-zone (in px) before any visual feedback is applied. This
+ * keeps small accidental drags during taps on the back button or chevrons
+ * from briefly translating the overlay.
+ */
+const DEAD_ZONE_PX = 8;
+
+/**
+ * Velocity threshold (in px / ms) past which the gesture commits regardless
+ * of total travel — supports quick flick-down dismissal.
+ */
+const COMMIT_VELOCITY = 0.6;
+
+/**
+ * Animation duration (in ms) for the dismiss slide-down.
+ */
+const DISMISS_ANIM_MS = 250;
+
+/**
+ * Animation duration (in ms) for the snap-back when the gesture is
+ * abandoned without committing.
+ */
+const SNAP_BACK_ANIM_MS = 200;
+
+/**
+ * Installs a pull-down-to-dismiss gesture on a header element. While the
+ * user drags downward on `headerHandle`, `overlayRoot` follows the pointer
+ * via `transform: translateY()` and its opacity fades toward 0.5 of its
+ * original value. On `pointerup`:
+ *
+ * - Above {@link COMMIT_THRESHOLD_PX} of travel **or** flick velocity past
+ *   {@link COMMIT_VELOCITY}, the overlay animates fully off-screen and
+ *   `onDismiss` is invoked.
+ * - Otherwise the overlay snaps back to its original position.
+ *
+ * Horizontal drags and small vertical motions inside the {@link DEAD_ZONE_PX}
+ * window are ignored so the existing tap targets on the header (back
+ * button, chevrons) continue to receive click / tap events normally.
+ *
+ * Returns an {@link IDisposable} that detaches all listeners and resets
+ * inline styles applied to `overlayRoot`.
+ */
+export function installPulldownDismiss(
+	overlayRoot: HTMLElement,
+	headerHandle: HTMLElement,
+	onDismiss: () => void,
+): IDisposable {
+	const store = new DisposableStore();
+
+	let tracking = false;
+	let dragging = false;
+	let dismissed = false;
+	let activePointerId: number | undefined;
+	let startX = 0;
+	let startY = 0;
+	let startTime = 0;
+	let lastY = 0;
+	let lastT = 0;
+	let velocity = 0;
+	let originalTransition = '';
+
+	const applyDragStyles = () => {
+		originalTransition = overlayRoot.style.transition;
+		overlayRoot.style.transition = 'none';
+		overlayRoot.style.willChange = 'transform, opacity';
+	};
+
+	const resetStyles = () => {
+		overlayRoot.style.transform = '';
+		overlayRoot.style.opacity = '';
+		overlayRoot.style.transition = originalTransition;
+		overlayRoot.style.willChange = '';
+	};
+
+	const update = (dy: number) => {
+		const translate = Math.max(0, dy);
+		overlayRoot.style.transform = `translateY(${translate}px)`;
+		const opacity = Math.max(0.5, 1 - Math.min(translate / COMMIT_THRESHOLD_PX, 0.5));
+		overlayRoot.style.opacity = String(opacity);
+	};
+
+	const finish = (commit: boolean) => {
+		if (!commit) {
+			overlayRoot.style.transition = `transform ${SNAP_BACK_ANIM_MS}ms ease, opacity ${SNAP_BACK_ANIM_MS}ms ease`;
+			overlayRoot.style.transform = 'translateY(0)';
+			overlayRoot.style.opacity = '1';
+			const onEnd = () => {
+				resetStyles();
+				overlayRoot.removeEventListener('transitionend', onEnd);
+			};
+			overlayRoot.addEventListener('transitionend', onEnd, { once: true });
+			return;
+		}
+
+		if (dismissed) {
+			return;
+		}
+		dismissed = true;
+		overlayRoot.style.transition = `transform ${DISMISS_ANIM_MS}ms ease, opacity ${DISMISS_ANIM_MS}ms ease`;
+		overlayRoot.style.transform = 'translateY(100%)';
+		overlayRoot.style.opacity = '0';
+		const timeoutId = overlayRoot.ownerDocument.defaultView?.setTimeout(() => {
+			onDismiss();
+		}, DISMISS_ANIM_MS) ?? 0;
+		store.add(toDisposable(() => {
+			overlayRoot.ownerDocument.defaultView?.clearTimeout(timeoutId);
+		}));
+	};
+
+	store.add(addDisposableListener(headerHandle, EventType.POINTER_DOWN, (e: PointerEvent) => {
+		if (tracking || dismissed) {
+			return;
+		}
+		if (e.pointerType !== 'touch' && e.pointerType !== 'pen') {
+			return;
+		}
+		tracking = true;
+		dragging = false;
+		activePointerId = e.pointerId;
+		startX = e.clientX;
+		startY = e.clientY;
+		startTime = Date.now();
+		lastY = startY;
+		lastT = startTime;
+		velocity = 0;
+	}));
+
+	store.add(addDisposableListener(headerHandle, EventType.POINTER_MOVE, (e: PointerEvent) => {
+		if (!tracking || e.pointerId !== activePointerId) {
+			return;
+		}
+		const dy = e.clientY - startY;
+		const dx = e.clientX - startX;
+
+		if (!dragging) {
+			if (Math.abs(dy) < DEAD_ZONE_PX) {
+				return;
+			}
+			if (dy <= 0 || Math.abs(dx) > Math.abs(dy)) {
+				// Not a downward-dominant drag — release the gesture so
+				// regular pointer handlers (e.g. native scroll) can take
+				// over for the remainder of this pointer interaction.
+				tracking = false;
+				activePointerId = undefined;
+				return;
+			}
+			dragging = true;
+			applyDragStyles();
+		}
+
+		// Update running velocity sample for flick detection.
+		const now = Date.now();
+		const dt = now - lastT;
+		if (dt > 0) {
+			velocity = (e.clientY - lastY) / dt;
+		}
+		lastY = e.clientY;
+		lastT = now;
+
+		update(dy);
+		e.preventDefault();
+	}, { passive: false }));
+
+	const release = (e: PointerEvent) => {
+		if (e.pointerId !== activePointerId) {
+			return;
+		}
+		const wasDragging = dragging;
+		const dy = e.clientY - startY;
+		tracking = false;
+		dragging = false;
+		activePointerId = undefined;
+
+		if (!wasDragging) {
+			return;
+		}
+
+		const commit = dy > COMMIT_THRESHOLD_PX || velocity > COMMIT_VELOCITY;
+		finish(commit);
+	};
+	store.add(addDisposableListener(headerHandle, EventType.POINTER_UP, release));
+	store.add(addDisposableListener(headerHandle, 'pointercancel', release));
+
+	store.add(toDisposable(() => {
+		if (!dismissed) {
+			resetStyles();
+		}
+	}));
+
+	return store;
+}

--- a/src/vs/sessions/browser/parts/mobile/longPress.ts
+++ b/src/vs/sessions/browser/parts/mobile/longPress.ts
@@ -1,0 +1,198 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as dom from '../../../../base/browser/dom.js';
+import { DisposableStore, IDisposable } from '../../../../base/common/lifecycle.js';
+import { IWorkbenchLayoutService } from '../../../../workbench/services/layout/browser/layoutService.js';
+import { isPhoneLayout } from './mobileLayout.js';
+
+/** Default hold duration, in milliseconds, before a long-press fires. */
+const DEFAULT_HOLD_TIME_MS = 500;
+
+/** Default pointer movement, in CSS pixels, that cancels a pending long-press. */
+const DEFAULT_MOVE_THRESHOLD_PX = 6;
+
+/**
+ * Options for {@link installLongPress}.
+ */
+export interface IInstallLongPressOptions {
+	/**
+	 * How long the pointer must stay pressed (without moving past
+	 * `moveThresholdPx`) before the long-press fires. Defaults to
+	 * {@link DEFAULT_HOLD_TIME_MS} (500ms).
+	 */
+	holdTimeMs?: number;
+
+	/**
+	 * Pointer movement (in CSS pixels) that cancels a pending
+	 * long-press. Small enough that micro-jitter on touch devices
+	 * doesn't kill the gesture, large enough that an intentional
+	 * scroll/pan does. Defaults to {@link DEFAULT_MOVE_THRESHOLD_PX}.
+	 */
+	moveThresholdPx?: number;
+
+	/**
+	 * If true (the default), the next `click` event after the
+	 * long-press fires is swallowed in capture phase so the
+	 * underlying element's tap handler doesn't also run.
+	 */
+	suppressSyntheticClick?: boolean;
+
+	/**
+	 * Optional layout service used to self-gate the long-press to
+	 * phone layout. When provided, the long-press is a no-op unless
+	 * `isPhoneLayout(layoutService)` returns `true` at pointerdown
+	 * time. Omit for callers that want long-press to fire on all
+	 * form factors.
+	 */
+	layoutService?: IWorkbenchLayoutService;
+}
+
+/**
+ * Wires a long-press gesture on `element`.
+ *
+ * A long-press is defined as the pointer staying down on `element`
+ * for at least `holdTimeMs` (default 500ms) without moving more than
+ * `moveThresholdPx` (default 6px) from the initial down position.
+ * When that happens, `handler(pointerEvent)` is invoked with the
+ * original `pointerdown` event so callers can read `clientX/Y`,
+ * `target`, etc. for things like positioning an action sheet.
+ *
+ * Movement past the threshold, `pointerup`, or `pointercancel` all
+ * cancel the pending long-press; the handler does not fire.
+ *
+ * When `suppressSyntheticClick` is true (the default), the next
+ * `click` event after the long-press fires is captured and
+ * `preventDefault`+`stopPropagation`'d so the underlying element's
+ * tap handler doesn't also run (e.g., long-pressing a chat row
+ * shouldn't also open the session like a tap does). A
+ * next-animation-frame fallback removes the click suppressor in case
+ * no click ever follows (e.g., the user lifted off-screen).
+ *
+ * If an `IWorkbenchLayoutService` is supplied via
+ * `options.layoutService`, the gesture self-gates on phone layout:
+ * on desktop the pointerdown handler returns immediately so
+ * right-click-and-hold doesn't accidentally trigger anything. This
+ * is intentionally opt-in so callers that want a universal
+ * long-press (e.g., a touch test page) can omit it.
+ *
+ * Only primary `touch` and `mouse` pointer types are observed; pen
+ * and non-primary pointers are ignored to avoid fighting other
+ * gesture handlers.
+ *
+ * @example
+ * // Open an action sheet when the user long-presses a chat row.
+ * disposables.add(installLongPress(row, e => {
+ *     actionSheet.show({ x: e.clientX, y: e.clientY });
+ * }, { layoutService }));
+ *
+ * @param element The element to attach pointer listeners to.
+ * @param handler Invoked with the originating pointerdown event
+ *                when a long-press is detected.
+ * @param options See {@link IInstallLongPressOptions}.
+ * @returns Disposable that removes all listeners and clears any
+ *          pending timer.
+ */
+export function installLongPress(
+	element: HTMLElement,
+	handler: (e: PointerEvent) => void,
+	options?: IInstallLongPressOptions
+): IDisposable {
+	const store = new DisposableStore();
+	const holdTimeMs = options?.holdTimeMs ?? DEFAULT_HOLD_TIME_MS;
+	const moveThresholdPx = options?.moveThresholdPx ?? DEFAULT_MOVE_THRESHOLD_PX;
+	const suppressSyntheticClick = options?.suppressSyntheticClick ?? true;
+	const layoutService = options?.layoutService;
+
+	let pointerId: number | undefined;
+	let startX = 0;
+	let startY = 0;
+	let timerId: number | undefined;
+	const targetWindow = dom.getWindow(element);
+
+	const cancelTimer = () => {
+		if (timerId !== undefined) {
+			targetWindow.clearTimeout(timerId);
+			timerId = undefined;
+		}
+	};
+
+	const reset = () => {
+		cancelTimer();
+		pointerId = undefined;
+	};
+
+	store.add(dom.addDisposableListener(element, dom.EventType.POINTER_DOWN, (e: PointerEvent) => {
+		// Self-gate on phone when a layout service was supplied so
+		// desktop right-click-drag and similar don't accidentally
+		// trigger anything. The check is a cheap DOM class read,
+		// evaluated lazily per pointerdown so resize-to-phone keeps
+		// working.
+		if (layoutService && !isPhoneLayout(layoutService)) {
+			return;
+		}
+		// Only react to primary input. Ignore right-clicks and
+		// non-touch/-mouse pointer types (e.g. pen) to avoid
+		// fighting other gesture handlers.
+		if (!e.isPrimary || (e.pointerType !== 'touch' && e.pointerType !== 'mouse')) {
+			return;
+		}
+		// A second pointerdown before the previous gesture ended
+		// supersedes the prior one; clear any stale timer.
+		cancelTimer();
+		pointerId = e.pointerId;
+		startX = e.clientX;
+		startY = e.clientY;
+		timerId = targetWindow.setTimeout(() => {
+			timerId = undefined;
+			pointerId = undefined;
+			handler(e);
+			if (suppressSyntheticClick) {
+				// Swallow the next click in capture phase so the
+				// underlying element's tap handler doesn't also
+				// run. `addEventListener` (not
+				// `addDisposableListener`) is used because the
+				// listener needs to remove itself once it fires.
+				const swallow = (clickEvent: MouseEvent) => {
+					clickEvent.preventDefault();
+					clickEvent.stopPropagation();
+					element.removeEventListener('click', swallow, true);
+				};
+				element.addEventListener('click', swallow, true);
+				// Drop the suppressor on the next frame in case no
+				// click ever follows (e.g. lifted off-screen).
+				targetWindow.setTimeout(() => element.removeEventListener('click', swallow, true), 0);
+			}
+		}, holdTimeMs);
+	}));
+
+	store.add(dom.addDisposableListener(element, dom.EventType.POINTER_MOVE, (e: PointerEvent) => {
+		if (pointerId !== e.pointerId) {
+			return;
+		}
+		const dx = e.clientX - startX;
+		const dy = e.clientY - startY;
+		if (Math.abs(dx) > moveThresholdPx || Math.abs(dy) > moveThresholdPx) {
+			reset();
+		}
+	}));
+
+	const end = (e: PointerEvent) => {
+		if (pointerId !== e.pointerId) {
+			return;
+		}
+		reset();
+	};
+	store.add(dom.addDisposableListener(element, dom.EventType.POINTER_UP, end));
+	// `pointercancel` isn't in the workbench's `EventType` enum (only
+	// the events shared with mouse/touch are), so register it via the
+	// raw literal. Browsers fire it when the pointer leaves the page
+	// or the gesture is interrupted (e.g. iOS scroll/zoom takeover).
+	store.add(dom.addDisposableListener(element, 'pointercancel', end));
+
+	store.add({ dispose: cancelTimer });
+
+	return store;
+}

--- a/src/vs/sessions/browser/parts/mobile/media/mobilePickerSheet.css
+++ b/src/vs/sessions/browser/parts/mobile/media/mobilePickerSheet.css
@@ -236,6 +236,21 @@
 	padding: 4px 8px 12px;
 }
 
+/* Body container for the shell-only `showMobileContentSheet` variant.
+ * Where the picker sheet builds its own scrollable list of rows
+ * (`.mobile-picker-sheet-list`) inside the sheet flex column, the
+ * content sheet hands the body slot over to its caller and only
+ * guarantees the surrounding chrome (drag handle, title row, caption,
+ * dismissal, keyboard avoidance). We set scroll, momentum, and
+ * touch-action on the body slot itself so vertical scrolling works
+ * correctly under iOS regardless of what DOM the caller puts inside. */
+.mobile-content-sheet-body {
+	flex: 1 1 auto;
+	overflow-y: auto;
+	-webkit-overflow-scrolling: touch;
+	touch-action: pan-y;
+}
+
 /* iOS grouped-list section header. The HIG uses a regular-case
  * footnote-sized label in secondary color — not the uppercased small
  * caps that older Settings rows used. */

--- a/src/vs/sessions/browser/parts/mobile/mobileChatShell.css
+++ b/src/vs/sessions/browser/parts/mobile/mobileChatShell.css
@@ -990,3 +990,39 @@
 	height: 36px;
 	padding: 0;
 }
+
+/* ---- Phone Layout: Hide Chat Row Hover Toolbars ----
+ *
+ * On desktop, each chat row exposes its actions through hover-revealed
+ * toolbars: `.request-hover` (top-right of request bubbles, hosts
+ * `MenuId.ChatMessageTitle`) and `.chat-footer-toolbar` (below
+ * response bubbles, hosts `MenuId.ChatMessageFooter`). Both rely on
+ * `:hover` / `:focus-within` to become visible, and on
+ * `.chat-most-recent-response` to pin the footer toolbar on the last
+ * response — none of which are usable on a touch device.
+ *
+ * On phone we hide both toolbars unconditionally and route the same
+ * actions through a long-press → bottom-sheet presented by
+ * `MobileChatRowActionsPresenter` (see
+ * `src/vs/sessions/contrib/chat/browser/mobile/mobileChatRowActions.ts`)
+ * via the workbench-side `IChatRowActionsPhonePresenter`. The
+ * long-press attachment is wired in `chatListRenderer.renderTemplate`
+ * so it is in place whether or not the user has hovered the row.
+ *
+ * We deliberately do NOT hide:
+ *  - `.checkpoint-container` / `.checkpoint-restore-container` — these
+ *    are always-visible status affordances (the checkpoint
+ *    line/dot/label and the "Restore" button), not hover-revealed
+ *    toolbars.
+ *  - `.chat-footer-details` outside the footer toolbar — these are
+ *    independent text affordances elsewhere on the response row.
+ *
+ * The desktop rules in `chat.css` use plain hover/focus selectors and
+ * are lower specificity than `.agent-sessions-workbench.phone-layout`,
+ * so `!important` is not needed here.
+ */
+
+.agent-sessions-workbench.phone-layout .interactive-session .interactive-item-container .request-hover,
+.agent-sessions-workbench.phone-layout .interactive-session .interactive-item-container .chat-footer-toolbar {
+display: none;
+}

--- a/src/vs/sessions/browser/parts/mobile/mobileEdgeSwipe.ts
+++ b/src/vs/sessions/browser/parts/mobile/mobileEdgeSwipe.ts
@@ -1,0 +1,133 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DisposableStore, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { addDisposableListener, EventType } from '../../../../base/browser/dom.js';
+import { IWorkbenchLayoutService, Parts } from '../../../../workbench/services/layout/browser/layoutService.js';
+
+/**
+ * Threshold (in px) from the left viewport edge within which a `pointerdown`
+ * is considered a candidate edge swipe.
+ */
+const EDGE_HIT_ZONE_PX = 16;
+
+/**
+ * Minimum horizontal travel (in px, rightward) required to commit the
+ * sidebar-open gesture.
+ */
+const COMMIT_TRAVEL_PX = 48;
+
+/**
+ * Maximum vertical drift (in px) allowed during the gesture. If the user
+ * moves more than this along Y the gesture is treated as a scroll attempt
+ * and the swipe is cancelled.
+ */
+const VERTICAL_TOLERANCE_PX = 32;
+
+/**
+ * Maximum duration (in ms) within which the commit travel must be reached.
+ * Slower drags are treated as deliberate scrolls / selections and ignored.
+ */
+const COMMIT_WINDOW_MS = 500;
+
+/**
+ * Installs a left-edge swipe gesture on `mainContainer` that opens the
+ * sidebar drawer on phone viewports.
+ *
+ * The gesture starts when `pointerdown` lands within the leftmost
+ * {@link EDGE_HIT_ZONE_PX} pixels of the container while the phone layout
+ * is active. It commits when the pointer travels more than
+ * {@link COMMIT_TRAVEL_PX} rightward within {@link COMMIT_WINDOW_MS} ms
+ * with less than {@link VERTICAL_TOLERANCE_PX} of vertical drift. The
+ * gesture is cancelled on `pointerup` / `pointercancel`, or once the
+ * tracking window elapses.
+ *
+ * Only `touch` and `pen` pointer types are considered — mouse drags from
+ * the edge could conflict with text selection. The gesture also skips if
+ * the sidebar is already visible so we don't replay the open on every
+ * subsequent edge tap.
+ *
+ * Returns an {@link IDisposable} that detaches all listeners.
+ */
+export function installMobileEdgeSwipeToOpenSidebar(
+	mainContainer: HTMLElement,
+	openSidebar: () => void,
+	layoutService: IWorkbenchLayoutService,
+): IDisposable {
+	const store = new DisposableStore();
+
+	let tracking = false;
+	let startX = 0;
+	let startY = 0;
+	let startTime = 0;
+	let activePointerId: number | undefined;
+
+	const reset = () => {
+		tracking = false;
+		activePointerId = undefined;
+	};
+
+	const isPhoneLayout = (): boolean => {
+		return mainContainer.classList.contains('phone-layout');
+	};
+
+	store.add(addDisposableListener(mainContainer, EventType.POINTER_DOWN, (e: PointerEvent) => {
+		if (tracking) {
+			return;
+		}
+		if (e.pointerType !== 'touch' && e.pointerType !== 'pen') {
+			return;
+		}
+		if (!isPhoneLayout()) {
+			return;
+		}
+		const rect = mainContainer.getBoundingClientRect();
+		const localX = e.clientX - rect.left;
+		if (localX >= EDGE_HIT_ZONE_PX) {
+			return;
+		}
+		if (layoutService.isVisible(Parts.SIDEBAR_PART)) {
+			return;
+		}
+
+		tracking = true;
+		activePointerId = e.pointerId;
+		startX = e.clientX;
+		startY = e.clientY;
+		startTime = Date.now();
+	}, true));
+
+	store.add(addDisposableListener(mainContainer, EventType.POINTER_MOVE, (e: PointerEvent) => {
+		if (!tracking || e.pointerId !== activePointerId) {
+			return;
+		}
+
+		const dx = e.clientX - startX;
+		const dy = Math.abs(e.clientY - startY);
+		const elapsed = Date.now() - startTime;
+
+		if (elapsed > COMMIT_WINDOW_MS || dy > VERTICAL_TOLERANCE_PX) {
+			reset();
+			return;
+		}
+
+		if (dx >= COMMIT_TRAVEL_PX) {
+			reset();
+			openSidebar();
+		}
+	}, true));
+
+	const cancel = (e: PointerEvent) => {
+		if (e.pointerId === activePointerId) {
+			reset();
+		}
+	};
+	store.add(addDisposableListener(mainContainer, EventType.POINTER_UP, cancel, true));
+	store.add(addDisposableListener(mainContainer, 'pointercancel', cancel, true));
+
+	store.add(toDisposable(reset));
+
+	return store;
+}

--- a/src/vs/sessions/browser/parts/mobile/mobilePickerSheet.ts
+++ b/src/vs/sessions/browser/parts/mobile/mobilePickerSheet.ts
@@ -9,7 +9,7 @@ import { Codicon } from '../../../../base/common/codicons.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { Gesture, EventType as TouchEventType } from '../../../../base/browser/touch.js';
 import { CancellationToken, CancellationTokenSource } from '../../../../base/common/cancellation.js';
-import { DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
+import { DisposableStore, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { localize } from '../../../../nls.js';
 
 const $ = DOM.$;
@@ -122,6 +122,53 @@ export interface IMobilePickerSheetSearchSource {
 }
 
 /**
+ * Renderer API passed into the {@link showMobileContentSheet} body
+ * callback. The renderer fills {@link bodyContainer} with arbitrary DOM
+ * and may call {@link close} to dismiss the sheet (e.g. after a confirm
+ * button is tapped, or after a sub-view navigation completes).
+ */
+export interface IMobileContentSheetApi {
+	/**
+	 * The same element passed as the first argument to the body
+	 * renderer; exposed here for convenience so callbacks can capture
+	 * the API object without also closing over the body element.
+	 */
+	readonly bodyContainer: HTMLElement;
+
+	/** Dismiss the sheet (plays the close animation). Idempotent. */
+	close(): void;
+}
+
+/**
+ * Options for {@link showMobileContentSheet}.
+ */
+export interface IMobileContentSheetOptions {
+	/**
+	 * Optional caption shown beneath the title (single-line, muted).
+	 * Mirrors {@link IMobilePickerSheetOptions.caption}.
+	 */
+	readonly caption?: string;
+
+	/**
+	 * Optional set of icon buttons rendered in the sheet's title row
+	 * to the left of the Done button. Tapping a header action resolves
+	 * the promise (the same dismissal semantics as the Done button).
+	 */
+	readonly headerActions?: readonly IMobilePickerSheetHeaderAction[];
+
+	/** Optional override for the Done button label (defaults to "Done"). */
+	readonly doneLabel?: string;
+
+	/**
+	 * When true, the Done button is hidden. Use this for sheets where
+	 * the body itself provides primary dismissal (e.g. a confirm widget
+	 * with explicit Approve / Reject buttons that call `api.close()`).
+	 * The user can still dismiss via the backdrop or Escape.
+	 */
+	readonly hideDoneButton?: boolean;
+}
+
+/**
  * Prefix used on the resolved id when a header action is invoked from a
  * mobile picker sheet, so callers can disambiguate header taps from
  * regular row selections.
@@ -149,82 +196,24 @@ export function showMobilePickerSheet(
 	options?: IMobilePickerSheetOptions,
 ): Promise<string | undefined> {
 	return new Promise<string | undefined>(resolve => {
-		const disposables = new DisposableStore();
 		let resolved = false;
+		let shell!: IMobileSheetShell;
 
 		const finish = (id: string | undefined) => {
 			if (resolved) {
 				return;
 			}
 			resolved = true;
-			sheet.classList.add('closing');
-			backdrop.classList.add('closing');
-			// Dispose all event listeners and inflight queries immediately
-			// so nothing fires during the 180ms close animation. The DOM
-			// node itself is removed at the end of the animation.
-			disposables.dispose();
-			DOM.getWindow(workbenchContainer).setTimeout(() => {
-				overlay.remove();
-				resolve(id);
-			}, 180);
+			shell.close(() => resolve(id));
 		};
 
-		// -- DOM: backdrop + sheet -------------------------------------
-		const overlay = DOM.append(workbenchContainer, $('div.mobile-picker-sheet-overlay'));
-		const backdrop = DOM.append(overlay, $('div.mobile-picker-sheet-backdrop'));
-		const sheet = DOM.append(overlay, $('div.mobile-picker-sheet'));
-		sheet.setAttribute('role', 'dialog');
-		sheet.setAttribute('aria-modal', 'true');
-		sheet.setAttribute('aria-label', title);
-
-		// -- Header (drag handle + title row + caption) ----------------
-		DOM.append(sheet, $('div.mobile-picker-sheet-handle'));
-
-		const titleRow = DOM.append(sheet, $('div.mobile-picker-sheet-title-row'));
-		const titleEl = DOM.append(titleRow, $('div.mobile-picker-sheet-title'));
-		titleEl.textContent = title;
-
-		// Optional header actions (icon buttons) rendered between the
-		// title and the Done button. Useful for sheet-level shortcuts
-		// like "browse for a folder" that aren't a single picker row.
-		if (options?.headerActions) {
-			for (const action of options.headerActions) {
-				const btn = DOM.append(titleRow, $('button.mobile-picker-sheet-header-action', { type: 'button' })) as HTMLButtonElement;
-				btn.setAttribute('aria-label', action.label);
-				btn.title = action.label;
-				const iconHost = DOM.append(btn, $('span.mobile-picker-sheet-header-action-icon'));
-				const iconEl = DOM.append(iconHost, $('span.mobile-picker-sheet-header-action-icon-glyph'));
-				iconEl.classList.add(...ThemeIcon.asClassNameArray(action.icon));
-				const btnGesture = Gesture.addTarget(btn);
-				disposables.add(btnGesture);
-				const onActivate = () => finish(`${MOBILE_PICKER_SHEET_HEADER_ACTION_PREFIX}${action.id}`);
-				const btnClick = DOM.addDisposableListener(btn, DOM.EventType.CLICK, (e: MouseEvent) => {
-					e.preventDefault();
-					onActivate();
-				});
-				disposables.add(btnClick);
-				const btnTap = DOM.addDisposableListener(btn, TouchEventType.Tap, onActivate);
-				disposables.add(btnTap);
-			}
-		}
-
-		const doneBtn = DOM.append(titleRow, $('button.mobile-picker-sheet-done', { type: 'button' })) as HTMLButtonElement;
-		doneBtn.textContent = localize('mobilePickerSheet.done', "Done");
-		doneBtn.setAttribute('aria-label', localize('mobilePickerSheet.doneAriaLabel', "Close {0}", title));
-		const doneGesture = Gesture.addTarget(doneBtn);
-		disposables.add(doneGesture);
-		const doneClick = DOM.addDisposableListener(doneBtn, DOM.EventType.CLICK, (e: MouseEvent) => {
-			e.preventDefault();
-			finish(undefined);
+		shell = buildMobileSheetShell(workbenchContainer, title, {
+			caption: options?.caption,
+			headerActions: options?.headerActions,
+			onDismiss: () => finish(undefined),
+			onHeaderAction: actionId => finish(`${MOBILE_PICKER_SHEET_HEADER_ACTION_PREFIX}${actionId}`),
 		});
-		disposables.add(doneClick);
-		const doneTap = DOM.addDisposableListener(doneBtn, TouchEventType.Tap, () => finish(undefined));
-		disposables.add(doneTap);
-
-		if (options?.caption) {
-			const caption = DOM.append(sheet, $('div.mobile-picker-sheet-caption'));
-			caption.textContent = options.caption;
-		}
+		const { sheet, disposables } = shell;
 
 		// -- Optional inline search input ------------------------------
 		// Sits between the title row and the scrollable list. Its value
@@ -371,59 +360,6 @@ export function showMobilePickerSheet(
 			setSearchQuery = (query: string) => renderResults(query);
 		}
 
-		// -- Dismissal: backdrop + Escape ------------------------------
-		const backdropClick = DOM.addDisposableListener(backdrop, DOM.EventType.CLICK, () => finish(undefined));
-		disposables.add(backdropClick);
-		const backdropGesture = Gesture.addTarget(backdrop);
-		disposables.add(backdropGesture);
-		const backdropTap = DOM.addDisposableListener(backdrop, TouchEventType.Tap, () => finish(undefined));
-		disposables.add(backdropTap);
-
-		const keyHandler = DOM.addDisposableListener(DOM.getWindow(workbenchContainer), DOM.EventType.KEY_DOWN, (e: KeyboardEvent) => {
-			if (e.key === 'Escape') {
-				e.preventDefault();
-				e.stopPropagation();
-				finish(undefined);
-			}
-		}, true);
-		disposables.add(keyHandler);
-
-		// -- iOS keyboard avoidance -----------------------------------
-		// On iOS Safari, when the virtual keyboard opens the layout
-		// viewport (`vh` units) does NOT shrink — only the visual
-		// viewport changes. The sheet uses `position: fixed` which
-		// positions against the layout viewport, so without correction
-		// the keyboard covers the bottom portion of the sheet (including
-		// the search input the user is actively typing into).
-		//
-		// `window.visualViewport` exposes the real visible area. We
-		// listen for `resize` and `scroll` events on it and translate
-		// the sheet upward by the keyboard height so the search input
-		// remains visible.
-		const win = DOM.getWindow(workbenchContainer);
-		const vv = win.visualViewport;
-		if (vv) {
-			const adjustForKeyboard = () => {
-				// The keyboard height is the difference between the
-				// layout viewport height and the visual viewport height,
-				// plus any scroll offset the browser applied.
-				const keyboardHeight = win.innerHeight - vv.height;
-				overlay.style.bottom = `${Math.max(0, keyboardHeight)}px`;
-				overlay.style.height = `${vv.height}px`;
-			};
-			vv.addEventListener('resize', adjustForKeyboard);
-			vv.addEventListener('scroll', adjustForKeyboard);
-			disposables.add(toDisposable(() => {
-				vv.removeEventListener('resize', adjustForKeyboard);
-				vv.removeEventListener('scroll', adjustForKeyboard);
-				overlay.style.bottom = '';
-				overlay.style.height = '';
-			}));
-			// Run once immediately in case the keyboard is already
-			// visible (e.g., sheet opened while another input had focus).
-			adjustForKeyboard();
-		}
-
 		// Focus the search input if present, otherwise focus the first
 		// checked row (or the first row) for keyboard users.
 		if (searchInput) {
@@ -432,6 +368,282 @@ export function showMobilePickerSheet(
 			(renderState.firstCheckedRow ?? renderState.firstRow)?.focus();
 		}
 	});
+}
+
+/**
+ * Show a phone-friendly bottom sheet that hosts arbitrary body content.
+ *
+ * Reuses the same shell as {@link showMobilePickerSheet} — translucent
+ * backdrop, slide-up animation, drag handle, title row with Done button,
+ * optional caption, optional icon header actions, iOS visual-viewport
+ * keyboard avoidance, and `Escape` / backdrop dismissal — but leaves the
+ * scrollable body to the caller. Use this for overlays that don't fit
+ * the picker's row-list shape: tool-confirmation carousels, plan
+ * reviews, anchor previews, code-block expand views, and so on.
+ *
+ * The {@link renderBody} callback is invoked once after the sheet shell
+ * mounts. The caller fills the supplied `bodyElement` with whatever DOM
+ * they like and may return an {@link IDisposable} whose `dispose()` runs
+ * when the sheet closes (alongside the shell's own listeners).
+ *
+ * The body container has `overflow-y: auto`,
+ * `-webkit-overflow-scrolling: touch`, and `touch-action: pan-y` applied
+ * via the `.mobile-content-sheet-body` class so vertical scrolling works
+ * correctly under iOS.
+ *
+ * The returned promise resolves with `void` when the sheet closes for
+ * any reason: Done button, backdrop tap, Escape, a header action tap,
+ * or an explicit `api.close()` from inside `renderBody`.
+ *
+ * @example
+ * ```ts
+ * await showMobileContentSheet(
+ *     this._layoutService.mainContainer,
+ *     localize('confirm.title', "Confirm Tool Use"),
+ *     (body, api) => {
+ *         const store = new DisposableStore();
+ *         const summary = DOM.append(body, DOM.$('div.tool-confirm-summary'));
+ *         summary.textContent = toolDescription;
+ *
+ *         const approve = DOM.append(body, DOM.$('button.tool-confirm-approve'));
+ *         approve.textContent = localize('confirm.approve', "Approve");
+ *         store.add(DOM.addDisposableListener(approve, 'click', () => {
+ *             writeApproval();
+ *             api.close();
+ *         }));
+ *
+ *         return store;
+ *     },
+ *     { caption: localize('confirm.caption', "This will modify your workspace.") },
+ * );
+ * ```
+ */
+export function showMobileContentSheet(
+	workbenchContainer: HTMLElement,
+	title: string,
+	renderBody: (bodyElement: HTMLElement, api: IMobileContentSheetApi) => IDisposable | void,
+	options?: IMobileContentSheetOptions,
+): Promise<void> {
+	return new Promise<void>(resolve => {
+		let resolved = false;
+		let shell!: IMobileSheetShell;
+
+		const close = () => {
+			if (resolved) {
+				return;
+			}
+			resolved = true;
+			shell.close(() => resolve());
+		};
+
+		shell = buildMobileSheetShell(workbenchContainer, title, {
+			caption: options?.caption,
+			headerActions: options?.headerActions,
+			doneLabel: options?.doneLabel,
+			hideDoneButton: options?.hideDoneButton,
+			onDismiss: close,
+			onHeaderAction: () => close(),
+		});
+
+		const bodyContainer = DOM.append(shell.sheet, $('div.mobile-content-sheet-body'));
+
+		const api: IMobileContentSheetApi = { bodyContainer, close };
+		const bodyDisposable = renderBody(bodyContainer, api);
+		if (bodyDisposable) {
+			shell.disposables.add(bodyDisposable);
+		}
+	});
+}
+
+/** Options consumed by {@link buildMobileSheetShell}. */
+interface IMobileSheetShellOptions {
+	readonly caption?: string;
+	readonly headerActions?: readonly IMobilePickerSheetHeaderAction[];
+	readonly doneLabel?: string;
+	readonly hideDoneButton?: boolean;
+	/**
+	 * Called when the user dismisses the sheet via the Done button,
+	 * backdrop tap, or Escape key. The shell does NOT close itself in
+	 * response to dismissal — the caller is expected to invoke
+	 * {@link IMobileSheetShell.close} from this callback.
+	 */
+	readonly onDismiss: () => void;
+	/**
+	 * Called when a header action button is tapped. If omitted, header
+	 * action taps fall through to {@link onDismiss}.
+	 */
+	readonly onHeaderAction?: (actionId: string) => void;
+}
+
+/** Primitives returned by {@link buildMobileSheetShell}. */
+interface IMobileSheetShell {
+	readonly overlay: HTMLElement;
+	readonly backdrop: HTMLElement;
+	/** The sheet container — append body content here. */
+	readonly sheet: HTMLElement;
+	/** Disposable store tied to the sheet's lifetime; cleared on close. */
+	readonly disposables: DisposableStore;
+	/**
+	 * Play the close animation, dispose listeners, and remove the DOM
+	 * node after the animation completes. Idempotent — subsequent
+	 * calls are no-ops. The optional callback fires once the node has
+	 * been removed.
+	 */
+	close(onAnimationEnd?: () => void): void;
+}
+
+/**
+ * Build the shared shell for {@link showMobilePickerSheet} and
+ * {@link showMobileContentSheet}: overlay, backdrop, sheet (drag handle,
+ * title row with Done button and optional header actions, optional
+ * caption), backdrop / Escape dismissal, and iOS visual-viewport
+ * keyboard avoidance. Callers append their own content children to
+ * `sheet`.
+ */
+function buildMobileSheetShell(
+	workbenchContainer: HTMLElement,
+	title: string,
+	options: IMobileSheetShellOptions,
+): IMobileSheetShell {
+	const disposables = new DisposableStore();
+	let closed = false;
+
+	// -- DOM: backdrop + sheet -------------------------------------
+	const overlay = DOM.append(workbenchContainer, $('div.mobile-picker-sheet-overlay'));
+	const backdrop = DOM.append(overlay, $('div.mobile-picker-sheet-backdrop'));
+	const sheet = DOM.append(overlay, $('div.mobile-picker-sheet'));
+	sheet.setAttribute('role', 'dialog');
+	sheet.setAttribute('aria-modal', 'true');
+	sheet.setAttribute('aria-label', title);
+
+	// -- Header (drag handle + title row + caption) ----------------
+	DOM.append(sheet, $('div.mobile-picker-sheet-handle'));
+
+	const titleRow = DOM.append(sheet, $('div.mobile-picker-sheet-title-row'));
+	const titleEl = DOM.append(titleRow, $('div.mobile-picker-sheet-title'));
+	titleEl.textContent = title;
+
+	// Optional header actions (icon buttons) rendered between the
+	// title and the Done button. Useful for sheet-level shortcuts
+	// like "browse for a folder" that aren't a single picker row.
+	if (options.headerActions) {
+		for (const action of options.headerActions) {
+			const btn = DOM.append(titleRow, $('button.mobile-picker-sheet-header-action', { type: 'button' })) as HTMLButtonElement;
+			btn.setAttribute('aria-label', action.label);
+			btn.title = action.label;
+			const iconHost = DOM.append(btn, $('span.mobile-picker-sheet-header-action-icon'));
+			const iconEl = DOM.append(iconHost, $('span.mobile-picker-sheet-header-action-icon-glyph'));
+			iconEl.classList.add(...ThemeIcon.asClassNameArray(action.icon));
+			const btnGesture = Gesture.addTarget(btn);
+			disposables.add(btnGesture);
+			const onActivate = () => {
+				if (options.onHeaderAction) {
+					options.onHeaderAction(action.id);
+				} else {
+					options.onDismiss();
+				}
+			};
+			const btnClick = DOM.addDisposableListener(btn, DOM.EventType.CLICK, (e: MouseEvent) => {
+				e.preventDefault();
+				onActivate();
+			});
+			disposables.add(btnClick);
+			const btnTap = DOM.addDisposableListener(btn, TouchEventType.Tap, onActivate);
+			disposables.add(btnTap);
+		}
+	}
+
+	if (!options.hideDoneButton) {
+		const doneBtn = DOM.append(titleRow, $('button.mobile-picker-sheet-done', { type: 'button' })) as HTMLButtonElement;
+		doneBtn.textContent = options.doneLabel ?? localize('mobilePickerSheet.done', "Done");
+		doneBtn.setAttribute('aria-label', localize('mobilePickerSheet.doneAriaLabel', "Close {0}", title));
+		const doneGesture = Gesture.addTarget(doneBtn);
+		disposables.add(doneGesture);
+		const doneClick = DOM.addDisposableListener(doneBtn, DOM.EventType.CLICK, (e: MouseEvent) => {
+			e.preventDefault();
+			options.onDismiss();
+		});
+		disposables.add(doneClick);
+		const doneTap = DOM.addDisposableListener(doneBtn, TouchEventType.Tap, () => options.onDismiss());
+		disposables.add(doneTap);
+	}
+
+	if (options.caption) {
+		const caption = DOM.append(sheet, $('div.mobile-picker-sheet-caption'));
+		caption.textContent = options.caption;
+	}
+
+	// -- Dismissal: backdrop + Escape ------------------------------
+	const backdropClick = DOM.addDisposableListener(backdrop, DOM.EventType.CLICK, () => options.onDismiss());
+	disposables.add(backdropClick);
+	const backdropGesture = Gesture.addTarget(backdrop);
+	disposables.add(backdropGesture);
+	const backdropTap = DOM.addDisposableListener(backdrop, TouchEventType.Tap, () => options.onDismiss());
+	disposables.add(backdropTap);
+
+	const keyHandler = DOM.addDisposableListener(DOM.getWindow(workbenchContainer), DOM.EventType.KEY_DOWN, (e: KeyboardEvent) => {
+		if (e.key === 'Escape') {
+			e.preventDefault();
+			e.stopPropagation();
+			options.onDismiss();
+		}
+	}, true);
+	disposables.add(keyHandler);
+
+	// -- iOS keyboard avoidance -----------------------------------
+	// On iOS Safari, when the virtual keyboard opens the layout
+	// viewport (`vh` units) does NOT shrink — only the visual
+	// viewport changes. The sheet uses `position: fixed` which
+	// positions against the layout viewport, so without correction
+	// the keyboard covers the bottom portion of the sheet (including
+	// any input the user is actively typing into).
+	//
+	// `window.visualViewport` exposes the real visible area. We
+	// listen for `resize` and `scroll` events on it and translate
+	// the sheet upward by the keyboard height so the focused input
+	// remains visible.
+	const win = DOM.getWindow(workbenchContainer);
+	const vv = win.visualViewport;
+	if (vv) {
+		const adjustForKeyboard = () => {
+			// The keyboard height is the difference between the
+			// layout viewport height and the visual viewport height,
+			// plus any scroll offset the browser applied.
+			const keyboardHeight = win.innerHeight - vv.height;
+			overlay.style.bottom = `${Math.max(0, keyboardHeight)}px`;
+			overlay.style.height = `${vv.height}px`;
+		};
+		vv.addEventListener('resize', adjustForKeyboard);
+		vv.addEventListener('scroll', adjustForKeyboard);
+		disposables.add(toDisposable(() => {
+			vv.removeEventListener('resize', adjustForKeyboard);
+			vv.removeEventListener('scroll', adjustForKeyboard);
+			overlay.style.bottom = '';
+			overlay.style.height = '';
+		}));
+		// Run once immediately in case the keyboard is already
+		// visible (e.g., sheet opened while another input had focus).
+		adjustForKeyboard();
+	}
+
+	const close = (onAnimationEnd?: () => void) => {
+		if (closed) {
+			return;
+		}
+		closed = true;
+		sheet.classList.add('closing');
+		backdrop.classList.add('closing');
+		// Dispose all event listeners and inflight queries immediately
+		// so nothing fires during the 180ms close animation. The DOM
+		// node itself is removed at the end of the animation.
+		disposables.dispose();
+		DOM.getWindow(workbenchContainer).setTimeout(() => {
+			overlay.remove();
+			onAnimationEnd?.();
+		}, 180);
+	};
+
+	return { overlay, backdrop, sheet, disposables, close };
 }
 
 /** Mutable bookkeeping passed through {@link renderRow} so we can track section dividers and the row to focus. */

--- a/src/vs/sessions/browser/parts/mobile/mobileVisualViewport.ts
+++ b/src/vs/sessions/browser/parts/mobile/mobileVisualViewport.ts
@@ -1,0 +1,166 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as DOM from '../../../../base/browser/dom.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { derived, IObservable, observableValue } from '../../../../base/common/observable.js';
+import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+import { ILayoutService } from '../../../../platform/layout/browser/layoutService.js';
+import { KeyboardVisibleContext } from '../../../common/contextkeys.js';
+
+/**
+ * Threshold (in CSS pixels) above which the visual viewport delta is
+ * treated as a virtual keyboard being visible. A few dozen pixels can
+ * appear briefly during URL-bar collapse / address-bar shrink, so we
+ * require a clearly keyboard-sized delta before flipping the context.
+ */
+export const KEYBOARD_VISIBLE_THRESHOLD_PX = 50;
+
+/**
+ * CSS custom property exposed on the workbench main container that
+ * reflects the current virtual keyboard height in pixels (e.g.
+ * `--vscode-keyboard-height: 320px`). Consumers can read this from
+ * CSS (`bottom: var(--vscode-keyboard-height, 0px)`) when they need
+ * to keep UI above the keyboard without subscribing to the observable.
+ */
+const KEYBOARD_HEIGHT_CSS_VAR = '--vscode-keyboard-height';
+
+/**
+ * Service decorator for {@link MobileVisualViewport}. Consumers inject
+ * this to observe the virtual keyboard height of the agents workbench
+ * window or to gate behaviour on whether the keyboard is currently
+ * visible.
+ */
+export const IMobileVisualViewport = createDecorator<IMobileVisualViewport>('mobileVisualViewport');
+
+/**
+ * Service interface for {@link MobileVisualViewport}. See the class for
+ * a full description of the publishing surface.
+ */
+export interface IMobileVisualViewport {
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * Observable: the current virtual keyboard height in CSS pixels,
+	 * computed as `max(0, window.innerHeight - visualViewport.height)`.
+	 * Always `0` on platforms without `visualViewport` support.
+	 */
+	readonly keyboardHeight: IObservable<number>;
+
+	/**
+	 * Observable: `true` when {@link keyboardHeight} exceeds
+	 * {@link KEYBOARD_VISIBLE_THRESHOLD_PX}. Cheaper for consumers than
+	 * subscribing to `keyboardHeight` directly when they only care
+	 * about the keyboard-visible transition (it only fires on the
+	 * boolean flip, not on every height micro-change during the
+	 * keyboard open/close animation).
+	 */
+	readonly isKeyboardVisible: IObservable<boolean>;
+}
+
+/**
+ * Tracks the virtual keyboard height of the agents workbench window via
+ * the `window.visualViewport` API and exposes it to consumers in three
+ * complementary forms:
+ *
+ *  1. As an {@link IObservable} (`keyboardHeight`) for code that wants
+ *     to react to keyboard changes via `autorun` / `derived`.
+ *  2. As a CSS custom property (`--vscode-keyboard-height`) set on the
+ *     workbench main container, so styles can position fixed UI above
+ *     the keyboard without touching JavaScript at all.
+ *  3. As a reactive {@link KeyboardVisibleContext} context key (`true`
+ *     when the keyboard height exceeds {@link KEYBOARD_VISIBLE_THRESHOLD_PX}),
+ *     so `when:` clauses on commands/menus can adapt to the keyboard.
+ *
+ * # Why this helper exists
+ *
+ * On iOS Safari (and to a lesser extent some Android browsers), the
+ * *layout viewport* — what `vh` units, `window.innerHeight`, and
+ * `position: fixed` resolve against — does NOT shrink when the virtual
+ * keyboard opens. Only the *visual viewport* (the actually visible
+ * area) shrinks. As a consequence, naive layouts that anchor to the
+ * bottom of the layout viewport end up hidden behind the keyboard.
+ *
+ * The standard `window.visualViewport` API exposes the real visible
+ * area and fires `resize` / `scroll` events when the keyboard opens
+ * or closes. This helper subscribes to those events once for the
+ * lifetime of the workbench window and publishes the keyboard height
+ * (`max(0, window.innerHeight - visualViewport.height)`).
+ *
+ * # Auxiliary windows
+ *
+ * The helper uses {@link DOM.getWindow} to resolve the correct window
+ * object for the layout-service main container, so it works correctly
+ * when the workbench is hosted inside an auxiliary window (each aux
+ * window has its own `visualViewport`).
+ *
+ * # Graceful degradation
+ *
+ * Browsers that do not implement `visualViewport` (very old engines,
+ * some embedded webviews) get a constant `keyboardHeight` of `0`, no
+ * CSS variable update, and a context key that stays `false`. Consumers
+ * never need to check for the API themselves.
+ */
+export class MobileVisualViewport extends Disposable implements IMobileVisualViewport {
+
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _keyboardHeight = observableValue<number>(this, 0);
+
+	readonly keyboardHeight: IObservable<number> = this._keyboardHeight;
+
+	readonly isKeyboardVisible: IObservable<boolean> = derived(this, reader =>
+		this._keyboardHeight.read(reader) > KEYBOARD_VISIBLE_THRESHOLD_PX
+	);
+
+	private readonly _keyboardVisibleCtx: IContextKey<boolean>;
+	private readonly mainContainer: HTMLElement;
+
+	constructor(
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@ILayoutService layoutService: ILayoutService,
+	) {
+		super();
+
+		this.mainContainer = layoutService.mainContainer;
+		this._keyboardVisibleCtx = KeyboardVisibleContext.bindTo(contextKeyService);
+
+		const targetWindow = DOM.getWindow(this.mainContainer);
+		const visualViewport = targetWindow.visualViewport;
+
+		if (!visualViewport) {
+			// No visualViewport API available — keep observables/context
+			// keys at their default zero/false state.
+			return;
+		}
+
+		const update = () => {
+			const height = Math.max(0, targetWindow.innerHeight - visualViewport.height);
+			if (this._keyboardHeight.get() !== height) {
+				this._keyboardHeight.set(height, undefined);
+			}
+			this.mainContainer.style.setProperty(KEYBOARD_HEIGHT_CSS_VAR, `${height}px`);
+			this._keyboardVisibleCtx.set(height > KEYBOARD_VISIBLE_THRESHOLD_PX);
+		};
+
+		this._register(DOM.addDisposableListener(visualViewport, 'resize', update));
+		this._register(DOM.addDisposableListener(visualViewport, 'scroll', update));
+
+		// Seed the initial value so consumers see the current state on
+		// startup (e.g., the workbench was opened while the keyboard
+		// was already visible).
+		update();
+	}
+
+	override dispose(): void {
+		this.mainContainer.style.removeProperty(KEYBOARD_HEIGHT_CSS_VAR);
+		this._keyboardVisibleCtx.reset();
+		super.dispose();
+	}
+}
+
+registerSingleton(IMobileVisualViewport, MobileVisualViewport, InstantiationType.Eager);

--- a/src/vs/sessions/browser/workbench.ts
+++ b/src/vs/sessions/browser/workbench.ts
@@ -63,7 +63,7 @@ import { EditorMarkdownCodeBlockRenderer } from '../../editor/browser/widget/mar
 import { SyncDescriptor } from '../../platform/instantiation/common/descriptors.js';
 import { TitleService } from './parts/titlebarPart.js';
 import { IContextKeyService } from '../../platform/contextkey/common/contextkey.js';
-import { EditorMaximizedContext, IsPhoneLayoutContext, KeyboardVisibleContext } from '../common/contextkeys.js';
+import { EditorMaximizedContext, IsPhoneLayoutContext } from '../common/contextkeys.js';
 import {
 	NotificationsPosition,
 	NotificationsSettings,
@@ -72,6 +72,7 @@ import {
 import { SessionsLayoutPolicy } from './layoutPolicy.js';
 import { MobileNavigationStack } from './mobileNavigationStack.js';
 import { MobileTitlebarPart } from './parts/mobile/mobileTitlebarPart.js';
+import { IMobileVisualViewport } from './parts/mobile/mobileVisualViewport.js';
 import { autorun } from '../../base/common/observable.js';
 import { ISessionsManagementService } from '../services/sessions/common/sessionsManagement.js';
 import { ISessionsPartService } from './parts/sessionsPartService.js';
@@ -456,28 +457,15 @@ export class Workbench extends Disposable implements IAgentWorkbenchLayoutServic
 					isPhoneLayoutCtx.set(this.layoutPolicy.viewportClass.read(reader) === 'phone');
 				}));
 
-				// Virtual keyboard detection via visualViewport API.
-				// Use `window.innerHeight` (layout viewport) as the baseline
-				// rather than a captured initial height. Layout viewport
-				// updates on orientation change and split-screen resizes, so
-				// comparing against it avoids stale baselines on landscape
-				// launches, Android split-screen, and iOS URL-bar collapse.
-				if (mainWindow.visualViewport) {
-					const keyboardVisibleCtx = KeyboardVisibleContext.bindTo(contextKeyService);
-					const KEYBOARD_HEIGHT_THRESHOLD_PX = 100;
-
-					const onViewportResize = () => {
-						const vp = mainWindow.visualViewport;
-						if (!vp) {
-							return;
-						}
-						const heightDiff = mainWindow.innerHeight - vp.height;
-						keyboardVisibleCtx.set(heightDiff > KEYBOARD_HEIGHT_THRESHOLD_PX);
-					};
-
-					mainWindow.visualViewport.addEventListener('resize', onViewportResize);
-					this._register({ dispose: () => mainWindow.visualViewport?.removeEventListener('resize', onViewportResize) });
-				}
+				// Virtual keyboard tracking (visualViewport): publishes the
+				// keyboard height as an observable, mirrors it onto the
+				// `--vscode-keyboard-height` CSS variable on the main
+				// container, and drives the `KeyboardVisibleContext`
+				// context key. The service is an eager singleton, so
+				// resolving it here is what triggers its constructor —
+				// the registry hands ownership/disposal to the
+				// instantiation service so we don't `_register` it.
+				accessor.get(IMobileVisualViewport);
 
 				// Orientation changes produce a window `resize` event which
 				// is already handled by `registerLayoutListeners()`. No

--- a/src/vs/sessions/contrib/chat/browser/mobile/mobileChatRowActions.ts
+++ b/src/vs/sessions/contrib/chat/browser/mobile/mobileChatRowActions.ts
@@ -1,0 +1,191 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IAction, Separator } from '../../../../../base/common/actions.js';
+import { Disposable, IDisposable, MutableDisposable } from '../../../../../base/common/lifecycle.js';
+import { derived, IObservable } from '../../../../../base/common/observable.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
+import { localize } from '../../../../../nls.js';
+import { MenuItemAction } from '../../../../../platform/actions/common/actions.js';
+import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { observableContextKey } from '../../../../../platform/observable/common/platformObservableUtils.js';
+import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../../workbench/common/contributions.js';
+import { IChatRowActionsPhonePresenter, IChatRowActionsPhonePresenterImpl } from '../../../../../workbench/contrib/chat/browser/widget/chatRowActionsPhonePresenter.js';
+import { IWorkbenchLayoutService } from '../../../../../workbench/services/layout/browser/layoutService.js';
+import { installLongPress } from '../../../../browser/parts/mobile/longPress.js';
+import { IMobilePickerSheetItem, showMobilePickerSheet } from '../../../../browser/parts/mobile/mobilePickerSheet.js';
+
+/**
+ * Match the `codicon-<id>` token inside an `IAction.class` string (which
+ * `MenuItemAction` builds via {@link ThemeIcon.asClassName}). Captures
+ * the icon id and an optional `~modifier` suffix (`spin`, `disabled`)
+ * so animated icons round-trip through the bottom sheet.
+ */
+const CODICON_CLASS_REGEX = /codicon-([\w-]+)(?:~([a-z]+))?/;
+
+/**
+ * Best-effort recovery of a {@link ThemeIcon} for an arbitrary
+ * {@link IAction}. The chat-message menus mostly produce
+ * {@link MenuItemAction}s, which carry the original `ThemeIcon` on
+ * `item.icon`; for everything else we fall back to parsing the codicon
+ * class name out of {@link IAction.class}. Returns `undefined` when no
+ * icon can be recovered, in which case the sheet renders a row without
+ * a leading glyph.
+ */
+function getIconForAction(action: IAction): ThemeIcon | undefined {
+	if (action instanceof MenuItemAction && ThemeIcon.isThemeIcon(action.item.icon)) {
+		return action.item.icon;
+	}
+	if (action.class) {
+		const match = CODICON_CLASS_REGEX.exec(action.class);
+		if (match) {
+			const [, id, modifier] = match;
+			return modifier ? ThemeIcon.fromId(`${id}~${modifier}`) : ThemeIcon.fromId(id);
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Sessions-side implementation of {@link IChatRowActionsPhonePresenter}.
+ *
+ * On phone-layout viewports of the agents window, replaces the chat
+ * row's hover-only toolbar with a long-press → bottom-sheet
+ * presentation. The hover toolbar is hidden via CSS in
+ * `mobileChatShell.css` (Phone Layout: Hide Chat Row Hover Toolbars),
+ * and {@link MobileChatRowActionsPresenter.attachToRow} wires a
+ * long-press handler on each row container that surfaces the same
+ * actions through {@link showMobilePickerSheet}. Workbench code does
+ * not depend on the sheet or long-press primitives — it only sees the
+ * {@link IChatRowActionsPhonePresenter} decorator interface — so this
+ * wiring stays out of the workbench layer.
+ */
+class MobileChatRowActionsPresenter extends Disposable implements IChatRowActionsPhonePresenterImpl {
+
+	readonly enabled: IObservable<boolean>;
+
+	constructor(
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IWorkbenchLayoutService private readonly _layoutService: IWorkbenchLayoutService,
+	) {
+		super();
+
+		// Track the phone-layout context key (`sessionsIsPhoneLayout`)
+		// so the chat list renderer's `enabled.get()` check flips the
+		// moment we cross the phone breakpoint. This key is the source
+		// of truth for "is this viewport phone-classified" — the layout
+		// policy updates it through the workbench's main `layout()` pass.
+		const isPhoneCtx = observableContextKey<boolean>('sessionsIsPhoneLayout', contextKeyService);
+		this.enabled = derived(this, reader => isPhoneCtx.read(reader) === true);
+	}
+
+	attachToRow(rowElement: HTMLElement, getActions: () => readonly IAction[]): IDisposable {
+		// `installLongPress` self-gates on phone layout via the
+		// `layoutService` option, so the gesture is a no-op on
+		// desktop/tablet — `enabled` only controls whether
+		// `attachToRow` is even called by the workbench, but the
+		// self-gate keeps things safe if the viewport flips between
+		// the workbench's enabled check and a pending pointerdown.
+		return installLongPress(
+			rowElement,
+			() => { this._openSheet(getActions); },
+			{ layoutService: this._layoutService },
+		);
+	}
+
+	private async _openSheet(getActions: () => readonly IAction[]): Promise<void> {
+		// Re-query actions on every open so the sheet reflects the
+		// row's current menu state (enablement, toggled state, dynamic
+		// items). The desktop hover toolbar gets the same treatment
+		// implicitly via its `MenuWorkbenchToolBar` listening to menu
+		// change events.
+		const actions = getActions();
+		if (actions.length === 0) {
+			return;
+		}
+
+		// Build the sheet item list. `Separator` actions are translated
+		// into rows with `sectionTitle: ''`, which the picker renders
+		// as a divider without a heading — the same convention used by
+		// {@link MobileAccountMenu} in `mobileTitlebarPart.ts`.
+		const sheetItems: IMobilePickerSheetItem[] = [];
+		const idToAction = new Map<string, IAction>();
+		let separatorPending = false;
+		for (const action of actions) {
+			if (action instanceof Separator) {
+				// Only insert a divider before the next real row;
+				// leading / consecutive separators are collapsed so
+				// the sheet doesn't open with an empty divider on top.
+				separatorPending = sheetItems.length > 0;
+				continue;
+			}
+			// Use a synthetic row id so action ids containing `:` or
+			// other separator-unsafe characters round-trip safely
+			// through the sheet's string-id contract.
+			const rowId = `chat-row-action-${idToAction.size}`;
+			idToAction.set(rowId, action);
+			sheetItems.push({
+				id: rowId,
+				label: action.label || action.tooltip || action.id,
+				icon: getIconForAction(action),
+				disabled: !action.enabled,
+				sectionTitle: separatorPending ? '' : undefined,
+			});
+			separatorPending = false;
+		}
+
+		if (sheetItems.length === 0) {
+			return;
+		}
+
+		const pickedId = await showMobilePickerSheet(
+			this._layoutService.mainContainer,
+			localize('chatRowActions.title', "Message Actions"),
+			sheetItems,
+		);
+		if (pickedId === undefined) {
+			return;
+		}
+		const picked = idToAction.get(pickedId);
+		if (picked) {
+			// Errors here are non-fatal: the desktop toolbar swallows
+			// action-run rejections the same way, and we don't want a
+			// busted action to take down the chat list.
+			Promise.resolve(picked.run()).catch(() => { /* best-effort */ });
+		}
+	}
+}
+
+/**
+ * Workbench contribution that mounts {@link MobileChatRowActionsPresenter}
+ * as the phone-layout impl for the workbench-layer
+ * {@link IChatRowActionsPhonePresenter}. The presenter's `enabled`
+ * observable gates the actual long-press wiring on phone layout, so no
+ * dynamic mount/unmount is needed here — the registration stays in
+ * place for the lifetime of the agents window.
+ */
+class MobileChatRowActionsContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'mobileChatRowActions';
+
+	private readonly _registration = this._register(new MutableDisposable<IDisposable>());
+
+	constructor(
+		@IChatRowActionsPhonePresenter presenter: IChatRowActionsPhonePresenter,
+		@IInstantiationService instantiationService: IInstantiationService,
+	) {
+		super();
+
+		const impl = this._register(instantiationService.createInstance(MobileChatRowActionsPresenter));
+		this._registration.value = presenter.setImpl(impl);
+	}
+}
+
+registerWorkbenchContribution2(
+	MobileChatRowActionsContribution.ID,
+	MobileChatRowActionsContribution,
+	WorkbenchPhase.BlockStartup,
+);

--- a/src/vs/sessions/sessions.web.main.ts
+++ b/src/vs/sessions/sessions.web.main.ts
@@ -181,6 +181,14 @@ import './contrib/providers/agentHost/browser/mobile/mobileChatPhoneInputPresent
 // without duplicate-registration conflicts.
 import './contrib/providers/copilotChatSessions/browser/mobilePermissionPicker.contribution.js';
 
+// Phone-only presenter for chat row actions. Replaces the desktop
+// hover toolbars (`.request-hover` / `.chat-footer-toolbar`, hidden
+// via the "Phone Layout: Hide Chat Row Hover Toolbars" section in
+// `mobileChatShell.css`) with a long-press → bottom-sheet picker that
+// surfaces the same `ChatMessageTitle` / `ChatMessageFooter` actions.
+// Web-only — desktop keeps the hover toolbars.
+import './contrib/chat/browser/mobile/mobileChatRowActions.js';
+
 // TODO: support agent feedback in web
 import './contrib/agentFeedback/browser/nullAgentFeedbackService.contribution.js';
 import '../workbench/contrib/webview/browser/webview.web.contribution.js';

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -29,9 +29,9 @@ import { clamp } from '../../../../../base/common/numbers.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { localize } from '../../../../../nls.js';
-import { MenuEntryActionViewItem, createActionViewItem } from '../../../../../platform/actions/browser/menuEntryActionViewItem.js';
+import { fillInActionBarActions, MenuEntryActionViewItem, createActionViewItem } from '../../../../../platform/actions/browser/menuEntryActionViewItem.js';
 import { MenuWorkbenchToolBar } from '../../../../../platform/actions/browser/toolbar.js';
-import { MenuId, MenuItemAction } from '../../../../../platform/actions/common/actions.js';
+import { IMenuService, MenuId, MenuItemAction } from '../../../../../platform/actions/common/actions.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
@@ -65,6 +65,7 @@ import { MarkHelpfulActionId } from '../actions/chatTitleActions.js';
 import { ChatTreeItem, IChatCodeBlockInfo, IChatFileTreeInfo, IChatListItemRendererOptions, IChatWidgetService } from '../chat.js';
 import { ChatAgentHover, getChatAgentHoverOptions } from './chatAgentHover.js';
 import { ChatContentMarkdownRenderer } from './chatContentMarkdownRenderer.js';
+import { IChatRowActionsPhonePresenter } from './chatRowActionsPhonePresenter.js';
 import { ChatAgentCommandContentPart } from './chatContentParts/chatAgentCommandContentPart.js';
 import { ChatAnonymousRateLimitedPart } from './chatContentParts/chatAnonymousRateLimitedPart.js';
 import { ChatAttachmentsContentPart } from './chatContentParts/chatAttachmentsContentPart.js';
@@ -274,6 +275,8 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		@IAccessibilityService private readonly accessibilityService: IAccessibilityService,
 		@IWorkbenchEnvironmentService private readonly environmentService: IWorkbenchEnvironmentService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
+		@IMenuService private readonly menuService: IMenuService,
+		@IChatRowActionsPhonePresenter private readonly chatRowActionsPhonePresenter: IChatRowActionsPhonePresenter,
 	) {
 		super();
 
@@ -667,7 +670,47 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		}));
 		templateDisposables.add(resizeObserver.observe(rowContainer));
 
+		// Phone-only: hand the row to the agents-window long-press
+		// presenter so users get a bottom-sheet action list instead of
+		// the desktop hover toolbar (which is hidden via CSS on phone).
+		// `attachToRow` is a no-op on desktop; on phone it wires a
+		// long-press handler that lazily re-queries the row's menu
+		// each open via `getRowActions(template)`.
+		templateDisposables.add(this.chatRowActionsPhonePresenter.attachToRow(rowContainer, () => this.getRowActions(template)));
+
 		return template;
+	}
+
+	/**
+	 * Collect the menu actions for the currently-rendered row, used by
+	 * the phone long-press presenter to populate its bottom sheet. The
+	 * menu id depends on the element kind: request rows surface
+	 * {@link MenuId.ChatMessageTitle} (the same menu the desktop hover
+	 * toolbar reads), response rows surface
+	 * {@link MenuId.ChatMessageFooter} (the upvote/copy/etc toolbar
+	 * below the response). The menu is created with the row's scoped
+	 * context-key service so the same when-clauses that gate the
+	 * desktop toolbar apply here too, and the element is forwarded as
+	 * an action arg so action handlers see the same context they do
+	 * when invoked from the desktop toolbar.
+	 */
+	private getRowActions(templateData: IChatListItemTemplate): readonly IAction[] {
+		const element = templateData.currentElement;
+		if (!element) {
+			return [];
+		}
+		const menuId = isRequestVM(element) ? MenuId.ChatMessageTitle : isResponseVM(element) ? MenuId.ChatMessageFooter : undefined;
+		if (!menuId) {
+			return [];
+		}
+		const menu = this.menuService.createMenu(menuId, templateData.contextKeyService);
+		try {
+			const actions: IAction[] = [];
+			fillInActionBarActions(menu.getActions({ shouldForwardArgs: true, arg: element }), actions);
+			return actions;
+		} finally {
+			menu.dispose();
+		}
 	}
 
 	renderElement(node: ITreeNode<ChatTreeItem, FuzzyScore>, index: number, templateData: IChatListItemTemplate): void {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatRowActionsPhonePresenter.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatRowActionsPhonePresenter.ts
@@ -1,0 +1,123 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IAction } from '../../../../../base/common/actions.js';
+import { Disposable, IDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
+import { derived, IObservable, observableValue } from '../../../../../base/common/observable.js';
+import { InstantiationType, registerSingleton } from '../../../../../platform/instantiation/common/extensions.js';
+import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
+
+/**
+ * Implementation of the phone-only chat-row actions presenter, registered
+ * by the agents-window (sessions) layer. Stays in `vs/workbench` as an
+ * interface so the chat list renderer can compile and run with no
+ * sessions dependency; the default singleton is a no-op.
+ *
+ * On desktop/tablet viewports every chat row exposes its toolbar through
+ * a hover affordance (see `chatListRenderer.ts`). On phone viewports
+ * there is no hover, and the existing row-level toolbar is too small a
+ * tap target to be usable. The sessions-layer implementation replaces
+ * that hover toolbar with a long-press handler that opens a bottom-sheet
+ * action list, while leaving the rest of the chat list renderer
+ * untouched.
+ */
+export interface IChatRowActionsPhonePresenterImpl {
+	/**
+	 * Whether the phone presenter is currently active. Workbench code
+	 * consults this to decide between the standard hover toolbar and the
+	 * long-press → bottom-sheet presentation. Flips reactively with the
+	 * viewport (rotation, window resize, etc.).
+	 */
+	readonly enabled: IObservable<boolean>;
+
+	/**
+	 * Wire a long-press handler on `rowElement` that opens a bottom-sheet
+	 * action list for the chat row. `getActions` is invoked lazily each
+	 * time the sheet is opened so the items reflect the row's current
+	 * state (e.g. enablement, toggled state, dynamic menu items) at the
+	 * moment of the gesture rather than at attach time.
+	 *
+	 * The returned disposable removes the long-press wiring and any
+	 * presenter-owned listeners on the row.
+	 */
+	attachToRow(rowElement: HTMLElement, getActions: () => readonly IAction[]): IDisposable;
+}
+
+export const IChatRowActionsPhonePresenter = createDecorator<IChatRowActionsPhonePresenter>('chatRowActionsPhonePresenter');
+
+/**
+ * Workbench-layer hook for phone-only chat-row action presentation.
+ *
+ * The default singleton is a no-op (`enabled === false`, {@link attachToRow}
+ * returns an empty disposable). The agents-window layer (`vs/sessions`)
+ * registers a real implementation via {@link setImpl} that intercepts
+ * long-press on each chat row and presents the row's actions through a
+ * bottom sheet, replacing the hover-only toolbar used on desktop.
+ *
+ * This indirection keeps `vs/workbench` free of any dependency on
+ * `vs/sessions`: the chat list renderer can call into the presenter
+ * unconditionally, and when no impl is registered the calls collapse to
+ * no-ops so non-phone surfaces behave exactly as before.
+ *
+ * Workbench callers should:
+ *   1. Read `enabled.get()` (or subscribe via `autorun`) to decide
+ *      whether to suppress the row's hover toolbar in favour of the
+ *      long-press presentation.
+ *   2. Call {@link attachToRow} once per rendered row, registering the
+ *      returned disposable so the wiring is torn down when the row is
+ *      recycled or disposed.
+ */
+export interface IChatRowActionsPhonePresenter {
+	readonly _serviceBrand: undefined;
+
+	/** `true` when an impl is registered AND it reports phone layout. */
+	readonly enabled: IObservable<boolean>;
+
+	/**
+	 * Attach the phone long-press handler to a chat row. Returns a
+	 * no-op disposable when {@link enabled} is `false`; otherwise
+	 * delegates to the registered impl. `getActions` is called lazily
+	 * each time the sheet is opened.
+	 */
+	attachToRow(rowElement: HTMLElement, getActions: () => readonly IAction[]): IDisposable;
+
+	/**
+	 * Register the phone implementation. Returns a disposable that removes
+	 * the registration. Only one impl is active at a time; the most recent
+	 * registration wins.
+	 */
+	setImpl(impl: IChatRowActionsPhonePresenterImpl): IDisposable;
+}
+
+class ChatRowActionsPhonePresenterService extends Disposable implements IChatRowActionsPhonePresenter {
+
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _impl = observableValue<IChatRowActionsPhonePresenterImpl | undefined>(this, undefined);
+
+	readonly enabled: IObservable<boolean> = derived(this, reader => {
+		const impl = this._impl.read(reader);
+		return impl ? impl.enabled.read(reader) : false;
+	});
+
+	attachToRow(rowElement: HTMLElement, getActions: () => readonly IAction[]): IDisposable {
+		const impl = this._impl.get();
+		if (!impl || !impl.enabled.get()) {
+			return Disposable.None;
+		}
+		return impl.attachToRow(rowElement, getActions);
+	}
+
+	setImpl(impl: IChatRowActionsPhonePresenterImpl): IDisposable {
+		this._impl.set(impl, undefined);
+		return toDisposable(() => {
+			if (this._impl.get() === impl) {
+				this._impl.set(undefined, undefined);
+			}
+		});
+	}
+}
+
+registerSingleton(IChatRowActionsPhonePresenter, ChatRowActionsPhonePresenterService, InstantiationType.Delayed);


### PR DESCRIPTION
Part 5 of the 10-PR mobile chat stack. Stacked on #318647.

## What

Routes chat row actions on phone viewports through a long-press → bottom-sheet picker, replacing the desktop hover toolbars that aren't usable on touch.

## Why

On desktop, each chat row exposes its actions through hover-revealed toolbars:
- `.request-hover` (top-right of request bubbles, hosts `MenuId.ChatMessageTitle`)
- `.chat-footer-toolbar` (below response bubbles, hosts `MenuId.ChatMessageFooter`)

Both rely on `:hover` / `:focus-within` to become visible — neither work on touch. The existing row toolbar is also too small a tap target on phone.

## How

### `IChatRowActionsPhonePresenter` seam (workbench)

`src/vs/workbench/contrib/chat/browser/widget/chatRowActionsPhonePresenter.ts` is a new platform service interface registered with a **no-op default singleton**, so the chat list renderer can compile and run with no sessions dependency. Desktop keeps using the hover toolbars; the presenter does nothing.

`chatListRenderer.ts`:
- Injects `IChatRowActionsPhonePresenter` and `IMenuService`.
- In `renderTemplate`, calls `presenter.attachToRow(rowContainer, () => this.getRowActions(template))` — a no-op on desktop, a long-press handler on phone.
- New `getRowActions(templateData)` lazily collects the row's menu actions each open:
  - Request rows → `MenuId.ChatMessageTitle`
  - Response rows → `MenuId.ChatMessageFooter`
  - Menu is created with the row's scoped `IContextKeyService` so the same when-clauses gate the sheet entries.
  - Element is forwarded as the action arg, matching desktop semantics.

### Long-press → bottom sheet (sessions)

`src/vs/sessions/contrib/chat/browser/mobile/mobileChatRowActions.ts` registers `MobileChatRowActionsPresenter` as the phone implementation. It wires:
- `installLongPress` (from PR #318647 / 01-infra primitives) on each row.
- On trigger → `showMobilePickerSheet` with items derived from the workbench-side action accessor (lazy re-query each open).
- Separators map to sheet section breaks; `MenuItemAction`s carry their icon/title/checked state through.

### CSS

`mobileChatShell.css` gets a new "**Phone Layout: Hide Chat Row Hover Toolbars**" section that hides `.request-hover` and `.chat-footer-toolbar` under `.agent-sessions-workbench.phone-layout`. Specificity beats the desktop hover/focus rules in `chat.css`, so no `!important`. We deliberately do NOT hide `.checkpoint-container` / `.checkpoint-restore-container` (always-visible status affordances) or `.chat-footer-details` outside the footer toolbar.

### Wiring

`sessions.web.main.ts` adds the side-effect import for `mobileChatRowActions.js`. Web-only — desktop never registers the phone presenter and keeps the hover toolbars.

## Validation

- ✅ `npm run compile-check-ts-native`
- ✅ `npm run valid-layers-check`

Stacked on #318647.