### PR TITLE
Mobile chat (6/10): inline diff routing + inline anchor peek

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -12,8 +12,6 @@
 		"--vscode-activityBarBadge-background",
 		"--vscode-activityBarBadge-foreground",
 		"--vscode-activityBarTop-activeBackground",
-		"--vscode-activeSessionView-background",
-		"--vscode-activeSessionView-foreground",
 		"--vscode-activityBarTop-activeBorder",
 		"--vscode-activityBarTop-background",
 		"--vscode-activityBarTop-dropBorder",
@@ -27,8 +25,6 @@
 		"--vscode-agentSessionReadIndicator-foreground",
 		"--vscode-agentSessionSelectedBadge-border",
 		"--vscode-agentSessionSelectedUnfocusedBadge-border",
-		"--vscode-inactiveSessionView-background",
-		"--vscode-inactiveSessionView-foreground",
 		"--vscode-agentStatusIndicator-background",
 		"--vscode-badge-background",
 		"--vscode-badge-foreground",
@@ -951,8 +947,6 @@
 		"--mobile-diff-tok-keyword",
 		"--mobile-diff-tok-number",
 		"--chat-editing-last-edit-shift",
-		"--session-view-background",
-		"--session-view-foreground",
 		"--chat-current-response-min-height",
 		"--chat-smooth-delay",
 		"--chat-smooth-duration",
@@ -1081,9 +1075,6 @@
 		"--slide-from-y"
 	],
 	"sizes": [
-		"--vscode-agents-fontWeight-medium",
-		"--vscode-agents-fontWeight-regular",
-		"--vscode-agents-fontWeight-semiBold",
 		"--vscode-agents-fontSize-body1",
 		"--vscode-agents-fontSize-body2",
 		"--vscode-agents-fontSize-heading1",
@@ -1093,6 +1084,9 @@
 		"--vscode-agents-fontSize-label2",
 		"--vscode-agents-fontSize-label3",
 		"--vscode-agents-fontSize-label4",
+		"--vscode-agents-fontWeight-medium",
+		"--vscode-agents-fontWeight-regular",
+		"--vscode-agents-fontWeight-semiBold",
 		"--vscode-bodyFontSize",
 		"--vscode-bodyFontSize-small",
 		"--vscode-bodyFontSize-xSmall",
@@ -1104,6 +1098,7 @@
 		"--vscode-cornerRadius-small",
 		"--vscode-cornerRadius-xLarge",
 		"--vscode-cornerRadius-xSmall",
+		"--vscode-keyboard-height",
 		"--vscode-strokeThickness"
 	]
 }

--- a/src/vs/sessions/browser/parts/mobile/contributions/mobilePulldownDismiss.ts
+++ b/src/vs/sessions/browser/parts/mobile/contributions/mobilePulldownDismiss.ts
@@ -1,0 +1,205 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DisposableStore, IDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
+import { addDisposableListener, EventType } from '../../../../../base/browser/dom.js';
+
+/**
+ * Vertical travel (in px) past which the gesture commits and the overlay
+ * is dismissed on `pointerup`.
+ */
+const COMMIT_THRESHOLD_PX = 120;
+
+/**
+ * Initial dead-zone (in px) before any visual feedback is applied. This
+ * keeps small accidental drags during taps on the back button or chevrons
+ * from briefly translating the overlay.
+ */
+const DEAD_ZONE_PX = 8;
+
+/**
+ * Velocity threshold (in px / ms) past which the gesture commits regardless
+ * of total travel — supports quick flick-down dismissal.
+ */
+const COMMIT_VELOCITY = 0.6;
+
+/**
+ * Animation duration (in ms) for the dismiss slide-down.
+ */
+const DISMISS_ANIM_MS = 250;
+
+/**
+ * Animation duration (in ms) for the snap-back when the gesture is
+ * abandoned without committing.
+ */
+const SNAP_BACK_ANIM_MS = 200;
+
+/**
+ * Installs a pull-down-to-dismiss gesture on a header element. While the
+ * user drags downward on `headerHandle`, `overlayRoot` follows the pointer
+ * via `transform: translateY()` and its opacity fades toward 0.5 of its
+ * original value. On `pointerup`:
+ *
+ * - Above {@link COMMIT_THRESHOLD_PX} of travel **or** flick velocity past
+ *   {@link COMMIT_VELOCITY}, the overlay animates fully off-screen and
+ *   `onDismiss` is invoked.
+ * - Otherwise the overlay snaps back to its original position.
+ *
+ * Horizontal drags and small vertical motions inside the {@link DEAD_ZONE_PX}
+ * window are ignored so the existing tap targets on the header (back
+ * button, chevrons) continue to receive click / tap events normally.
+ *
+ * Returns an {@link IDisposable} that detaches all listeners and resets
+ * inline styles applied to `overlayRoot`.
+ */
+export function installPulldownDismiss(
+	overlayRoot: HTMLElement,
+	headerHandle: HTMLElement,
+	onDismiss: () => void,
+): IDisposable {
+	const store = new DisposableStore();
+
+	let tracking = false;
+	let dragging = false;
+	let dismissed = false;
+	let activePointerId: number | undefined;
+	let startX = 0;
+	let startY = 0;
+	let startTime = 0;
+	let lastY = 0;
+	let lastT = 0;
+	let velocity = 0;
+	let originalTransition = '';
+
+	const applyDragStyles = () => {
+		originalTransition = overlayRoot.style.transition;
+		overlayRoot.style.transition = 'none';
+		overlayRoot.style.willChange = 'transform, opacity';
+	};
+
+	const resetStyles = () => {
+		overlayRoot.style.transform = '';
+		overlayRoot.style.opacity = '';
+		overlayRoot.style.transition = originalTransition;
+		overlayRoot.style.willChange = '';
+	};
+
+	const update = (dy: number) => {
+		const translate = Math.max(0, dy);
+		overlayRoot.style.transform = `translateY(${translate}px)`;
+		const opacity = Math.max(0.5, 1 - Math.min(translate / COMMIT_THRESHOLD_PX, 0.5));
+		overlayRoot.style.opacity = String(opacity);
+	};
+
+	const finish = (commit: boolean) => {
+		if (!commit) {
+			overlayRoot.style.transition = `transform ${SNAP_BACK_ANIM_MS}ms ease, opacity ${SNAP_BACK_ANIM_MS}ms ease`;
+			overlayRoot.style.transform = 'translateY(0)';
+			overlayRoot.style.opacity = '1';
+			const onEnd = () => {
+				resetStyles();
+				overlayRoot.removeEventListener('transitionend', onEnd);
+			};
+			overlayRoot.addEventListener('transitionend', onEnd, { once: true });
+			return;
+		}
+
+		if (dismissed) {
+			return;
+		}
+		dismissed = true;
+		overlayRoot.style.transition = `transform ${DISMISS_ANIM_MS}ms ease, opacity ${DISMISS_ANIM_MS}ms ease`;
+		overlayRoot.style.transform = 'translateY(100%)';
+		overlayRoot.style.opacity = '0';
+		const timeoutId = overlayRoot.ownerDocument.defaultView?.setTimeout(() => {
+			onDismiss();
+		}, DISMISS_ANIM_MS) ?? 0;
+		store.add(toDisposable(() => {
+			overlayRoot.ownerDocument.defaultView?.clearTimeout(timeoutId);
+		}));
+	};
+
+	store.add(addDisposableListener(headerHandle, EventType.POINTER_DOWN, (e: PointerEvent) => {
+		if (tracking || dismissed) {
+			return;
+		}
+		if (e.pointerType !== 'touch' && e.pointerType !== 'pen') {
+			return;
+		}
+		tracking = true;
+		dragging = false;
+		activePointerId = e.pointerId;
+		startX = e.clientX;
+		startY = e.clientY;
+		startTime = Date.now();
+		lastY = startY;
+		lastT = startTime;
+		velocity = 0;
+	}));
+
+	store.add(addDisposableListener(headerHandle, EventType.POINTER_MOVE, (e: PointerEvent) => {
+		if (!tracking || e.pointerId !== activePointerId) {
+			return;
+		}
+		const dy = e.clientY - startY;
+		const dx = e.clientX - startX;
+
+		if (!dragging) {
+			if (Math.abs(dy) < DEAD_ZONE_PX) {
+				return;
+			}
+			if (dy <= 0 || Math.abs(dx) > Math.abs(dy)) {
+				// Not a downward-dominant drag — release the gesture so
+				// regular pointer handlers (e.g. native scroll) can take
+				// over for the remainder of this pointer interaction.
+				tracking = false;
+				activePointerId = undefined;
+				return;
+			}
+			dragging = true;
+			applyDragStyles();
+		}
+
+		// Update running velocity sample for flick detection.
+		const now = Date.now();
+		const dt = now - lastT;
+		if (dt > 0) {
+			velocity = (e.clientY - lastY) / dt;
+		}
+		lastY = e.clientY;
+		lastT = now;
+
+		update(dy);
+		e.preventDefault();
+	}, { passive: false }));
+
+	const release = (e: PointerEvent) => {
+		if (e.pointerId !== activePointerId) {
+			return;
+		}
+		const wasDragging = dragging;
+		const dy = e.clientY - startY;
+		tracking = false;
+		dragging = false;
+		activePointerId = undefined;
+
+		if (!wasDragging) {
+			return;
+		}
+
+		const commit = dy > COMMIT_THRESHOLD_PX || velocity > COMMIT_VELOCITY;
+		finish(commit);
+	};
+	store.add(addDisposableListener(headerHandle, EventType.POINTER_UP, release));
+	store.add(addDisposableListener(headerHandle, 'pointercancel', release));
+
+	store.add(toDisposable(() => {
+		if (!dismissed) {
+			resetStyles();
+		}
+	}));
+
+	return store;
+}

--- a/src/vs/sessions/browser/parts/mobile/longPress.ts
+++ b/src/vs/sessions/browser/parts/mobile/longPress.ts
@@ -1,0 +1,198 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as dom from '../../../../base/browser/dom.js';
+import { DisposableStore, IDisposable } from '../../../../base/common/lifecycle.js';
+import { IWorkbenchLayoutService } from '../../../../workbench/services/layout/browser/layoutService.js';
+import { isPhoneLayout } from './mobileLayout.js';
+
+/** Default hold duration, in milliseconds, before a long-press fires. */
+const DEFAULT_HOLD_TIME_MS = 500;
+
+/** Default pointer movement, in CSS pixels, that cancels a pending long-press. */
+const DEFAULT_MOVE_THRESHOLD_PX = 6;
+
+/**
+ * Options for {@link installLongPress}.
+ */
+export interface IInstallLongPressOptions {
+	/**
+	 * How long the pointer must stay pressed (without moving past
+	 * `moveThresholdPx`) before the long-press fires. Defaults to
+	 * {@link DEFAULT_HOLD_TIME_MS} (500ms).
+	 */
+	holdTimeMs?: number;
+
+	/**
+	 * Pointer movement (in CSS pixels) that cancels a pending
+	 * long-press. Small enough that micro-jitter on touch devices
+	 * doesn't kill the gesture, large enough that an intentional
+	 * scroll/pan does. Defaults to {@link DEFAULT_MOVE_THRESHOLD_PX}.
+	 */
+	moveThresholdPx?: number;
+
+	/**
+	 * If true (the default), the next `click` event after the
+	 * long-press fires is swallowed in capture phase so the
+	 * underlying element's tap handler doesn't also run.
+	 */
+	suppressSyntheticClick?: boolean;
+
+	/**
+	 * Optional layout service used to self-gate the long-press to
+	 * phone layout. When provided, the long-press is a no-op unless
+	 * `isPhoneLayout(layoutService)` returns `true` at pointerdown
+	 * time. Omit for callers that want long-press to fire on all
+	 * form factors.
+	 */
+	layoutService?: IWorkbenchLayoutService;
+}
+
+/**
+ * Wires a long-press gesture on `element`.
+ *
+ * A long-press is defined as the pointer staying down on `element`
+ * for at least `holdTimeMs` (default 500ms) without moving more than
+ * `moveThresholdPx` (default 6px) from the initial down position.
+ * When that happens, `handler(pointerEvent)` is invoked with the
+ * original `pointerdown` event so callers can read `clientX/Y`,
+ * `target`, etc. for things like positioning an action sheet.
+ *
+ * Movement past the threshold, `pointerup`, or `pointercancel` all
+ * cancel the pending long-press; the handler does not fire.
+ *
+ * When `suppressSyntheticClick` is true (the default), the next
+ * `click` event after the long-press fires is captured and
+ * `preventDefault`+`stopPropagation`'d so the underlying element's
+ * tap handler doesn't also run (e.g., long-pressing a chat row
+ * shouldn't also open the session like a tap does). A
+ * next-animation-frame fallback removes the click suppressor in case
+ * no click ever follows (e.g., the user lifted off-screen).
+ *
+ * If an `IWorkbenchLayoutService` is supplied via
+ * `options.layoutService`, the gesture self-gates on phone layout:
+ * on desktop the pointerdown handler returns immediately so
+ * right-click-and-hold doesn't accidentally trigger anything. This
+ * is intentionally opt-in so callers that want a universal
+ * long-press (e.g., a touch test page) can omit it.
+ *
+ * Only primary `touch` and `mouse` pointer types are observed; pen
+ * and non-primary pointers are ignored to avoid fighting other
+ * gesture handlers.
+ *
+ * @example
+ * // Open an action sheet when the user long-presses a chat row.
+ * disposables.add(installLongPress(row, e => {
+ *     actionSheet.show({ x: e.clientX, y: e.clientY });
+ * }, { layoutService }));
+ *
+ * @param element The element to attach pointer listeners to.
+ * @param handler Invoked with the originating pointerdown event
+ *                when a long-press is detected.
+ * @param options See {@link IInstallLongPressOptions}.
+ * @returns Disposable that removes all listeners and clears any
+ *          pending timer.
+ */
+export function installLongPress(
+	element: HTMLElement,
+	handler: (e: PointerEvent) => void,
+	options?: IInstallLongPressOptions
+): IDisposable {
+	const store = new DisposableStore();
+	const holdTimeMs = options?.holdTimeMs ?? DEFAULT_HOLD_TIME_MS;
+	const moveThresholdPx = options?.moveThresholdPx ?? DEFAULT_MOVE_THRESHOLD_PX;
+	const suppressSyntheticClick = options?.suppressSyntheticClick ?? true;
+	const layoutService = options?.layoutService;
+
+	let pointerId: number | undefined;
+	let startX = 0;
+	let startY = 0;
+	let timerId: number | undefined;
+	const targetWindow = dom.getWindow(element);
+
+	const cancelTimer = () => {
+		if (timerId !== undefined) {
+			targetWindow.clearTimeout(timerId);
+			timerId = undefined;
+		}
+	};
+
+	const reset = () => {
+		cancelTimer();
+		pointerId = undefined;
+	};
+
+	store.add(dom.addDisposableListener(element, dom.EventType.POINTER_DOWN, (e: PointerEvent) => {
+		// Self-gate on phone when a layout service was supplied so
+		// desktop right-click-drag and similar don't accidentally
+		// trigger anything. The check is a cheap DOM class read,
+		// evaluated lazily per pointerdown so resize-to-phone keeps
+		// working.
+		if (layoutService && !isPhoneLayout(layoutService)) {
+			return;
+		}
+		// Only react to primary input. Ignore right-clicks and
+		// non-touch/-mouse pointer types (e.g. pen) to avoid
+		// fighting other gesture handlers.
+		if (!e.isPrimary || (e.pointerType !== 'touch' && e.pointerType !== 'mouse')) {
+			return;
+		}
+		// A second pointerdown before the previous gesture ended
+		// supersedes the prior one; clear any stale timer.
+		cancelTimer();
+		pointerId = e.pointerId;
+		startX = e.clientX;
+		startY = e.clientY;
+		timerId = targetWindow.setTimeout(() => {
+			timerId = undefined;
+			pointerId = undefined;
+			handler(e);
+			if (suppressSyntheticClick) {
+				// Swallow the next click in capture phase so the
+				// underlying element's tap handler doesn't also
+				// run. `addEventListener` (not
+				// `addDisposableListener`) is used because the
+				// listener needs to remove itself once it fires.
+				const swallow = (clickEvent: MouseEvent) => {
+					clickEvent.preventDefault();
+					clickEvent.stopPropagation();
+					element.removeEventListener('click', swallow, true);
+				};
+				element.addEventListener('click', swallow, true);
+				// Drop the suppressor on the next frame in case no
+				// click ever follows (e.g. lifted off-screen).
+				targetWindow.setTimeout(() => element.removeEventListener('click', swallow, true), 0);
+			}
+		}, holdTimeMs);
+	}));
+
+	store.add(dom.addDisposableListener(element, dom.EventType.POINTER_MOVE, (e: PointerEvent) => {
+		if (pointerId !== e.pointerId) {
+			return;
+		}
+		const dx = e.clientX - startX;
+		const dy = e.clientY - startY;
+		if (Math.abs(dx) > moveThresholdPx || Math.abs(dy) > moveThresholdPx) {
+			reset();
+		}
+	}));
+
+	const end = (e: PointerEvent) => {
+		if (pointerId !== e.pointerId) {
+			return;
+		}
+		reset();
+	};
+	store.add(dom.addDisposableListener(element, dom.EventType.POINTER_UP, end));
+	// `pointercancel` isn't in the workbench's `EventType` enum (only
+	// the events shared with mouse/touch are), so register it via the
+	// raw literal. Browsers fire it when the pointer leaves the page
+	// or the gesture is interrupted (e.g. iOS scroll/zoom takeover).
+	store.add(dom.addDisposableListener(element, 'pointercancel', end));
+
+	store.add({ dispose: cancelTimer });
+
+	return store;
+}

--- a/src/vs/sessions/browser/parts/mobile/media/mobilePickerSheet.css
+++ b/src/vs/sessions/browser/parts/mobile/media/mobilePickerSheet.css
@@ -236,6 +236,21 @@
 	padding: 4px 8px 12px;
 }
 
+/* Body container for the shell-only `showMobileContentSheet` variant.
+ * Where the picker sheet builds its own scrollable list of rows
+ * (`.mobile-picker-sheet-list`) inside the sheet flex column, the
+ * content sheet hands the body slot over to its caller and only
+ * guarantees the surrounding chrome (drag handle, title row, caption,
+ * dismissal, keyboard avoidance). We set scroll, momentum, and
+ * touch-action on the body slot itself so vertical scrolling works
+ * correctly under iOS regardless of what DOM the caller puts inside. */
+.mobile-content-sheet-body {
+	flex: 1 1 auto;
+	overflow-y: auto;
+	-webkit-overflow-scrolling: touch;
+	touch-action: pan-y;
+}
+
 /* iOS grouped-list section header. The HIG uses a regular-case
  * footnote-sized label in secondary color — not the uppercased small
  * caps that older Settings rows used. */

--- a/src/vs/sessions/browser/parts/mobile/mobileChatShell.css
+++ b/src/vs/sessions/browser/parts/mobile/mobileChatShell.css
@@ -990,3 +990,129 @@
 	height: 36px;
 	padding: 0;
 }
+
+/* =========================================================================
+ * Phone Layout: Inline Anchor Peek Sheet
+ * -------------------------------------------------------------------------
+ * Bottom-sheet body styles for the inline file/symbol anchor peek (see
+ * `mobileInlineAnchorPeek.ts`). The sheet shell itself comes from
+ * `mobilePickerSheet.css`; this section just shapes the body the peek
+ * renders (metadata rows, snippet preview, action row).
+ * ========================================================================= */
+
+.mobile-inline-anchor-peek {
+display: flex;
+flex-direction: column;
+gap: 12px;
+padding: 4px 16px 16px;
+}
+
+.mobile-inline-anchor-peek-meta {
+display: flex;
+flex-direction: column;
+gap: 8px;
+}
+
+.mobile-inline-anchor-peek-row {
+display: flex;
+flex-direction: column;
+gap: 2px;
+}
+
+.mobile-inline-anchor-peek-row-label {
+font-size: 12px;
+font-weight: 600;
+text-transform: uppercase;
+letter-spacing: 0.04em;
+color: var(--vscode-descriptionForeground);
+}
+
+.mobile-inline-anchor-peek-row-value {
+font-size: 14px;
+line-height: 1.4;
+word-break: break-all;
+overflow-wrap: anywhere;
+user-select: text;
+-webkit-user-select: text;
+}
+
+.mobile-inline-anchor-peek-snippet {
+display: flex;
+flex-direction: column;
+gap: 4px;
+}
+
+.mobile-inline-anchor-peek-code {
+margin: 0;
+padding: 12px;
+border-radius: var(--vscode-cornerRadius-medium, 6px);
+background: var(--vscode-textCodeBlock-background, var(--vscode-editor-background));
+color: var(--vscode-editor-foreground, var(--vscode-foreground));
+font-family: var(--monaco-monospace-font);
+font-size: 13px;
+line-height: 1.5;
+white-space: pre;
+overflow: auto;
+max-height: 40vh;
+touch-action: pan-x pan-y;
+-webkit-overflow-scrolling: touch;
+user-select: text;
+-webkit-user-select: text;
+}
+
+.mobile-inline-anchor-peek-snippet-hint {
+font-size: 12px;
+color: var(--vscode-descriptionForeground);
+}
+
+.mobile-inline-anchor-peek-actions {
+display: flex;
+flex-direction: row;
+gap: 8px;
+margin-top: 4px;
+}
+
+.mobile-inline-anchor-peek-action {
+flex: 1;
+min-height: 44px;
+display: inline-flex;
+align-items: center;
+justify-content: center;
+gap: 8px;
+padding: 8px 12px;
+border: 1px solid var(--vscode-button-border, transparent);
+border-radius: var(--vscode-cornerRadius-medium, 6px);
+background: var(--vscode-button-secondaryBackground, var(--vscode-button-background));
+color: var(--vscode-button-secondaryForeground, var(--vscode-button-foreground));
+font-size: 14px;
+font-weight: 500;
+cursor: pointer;
+touch-action: manipulation;
+-webkit-tap-highlight-color: transparent;
+}
+
+.mobile-inline-anchor-peek-action:first-child {
+background: var(--vscode-button-background);
+color: var(--vscode-button-foreground);
+}
+
+.mobile-inline-anchor-peek-action:active {
+transform: scale(0.98);
+}
+
+.mobile-inline-anchor-peek-action:focus-visible {
+outline: 2px solid var(--vscode-focusBorder);
+outline-offset: 2px;
+}
+
+.mobile-inline-anchor-peek-action-icon {
+display: inline-flex;
+align-items: center;
+justify-content: center;
+}
+
+.mobile-inline-anchor-peek-action-label {
+white-space: nowrap;
+overflow: hidden;
+text-overflow: ellipsis;
+}

--- a/src/vs/sessions/browser/parts/mobile/mobileEdgeSwipe.ts
+++ b/src/vs/sessions/browser/parts/mobile/mobileEdgeSwipe.ts
@@ -1,0 +1,133 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DisposableStore, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { addDisposableListener, EventType } from '../../../../base/browser/dom.js';
+import { IWorkbenchLayoutService, Parts } from '../../../../workbench/services/layout/browser/layoutService.js';
+
+/**
+ * Threshold (in px) from the left viewport edge within which a `pointerdown`
+ * is considered a candidate edge swipe.
+ */
+const EDGE_HIT_ZONE_PX = 16;
+
+/**
+ * Minimum horizontal travel (in px, rightward) required to commit the
+ * sidebar-open gesture.
+ */
+const COMMIT_TRAVEL_PX = 48;
+
+/**
+ * Maximum vertical drift (in px) allowed during the gesture. If the user
+ * moves more than this along Y the gesture is treated as a scroll attempt
+ * and the swipe is cancelled.
+ */
+const VERTICAL_TOLERANCE_PX = 32;
+
+/**
+ * Maximum duration (in ms) within which the commit travel must be reached.
+ * Slower drags are treated as deliberate scrolls / selections and ignored.
+ */
+const COMMIT_WINDOW_MS = 500;
+
+/**
+ * Installs a left-edge swipe gesture on `mainContainer` that opens the
+ * sidebar drawer on phone viewports.
+ *
+ * The gesture starts when `pointerdown` lands within the leftmost
+ * {@link EDGE_HIT_ZONE_PX} pixels of the container while the phone layout
+ * is active. It commits when the pointer travels more than
+ * {@link COMMIT_TRAVEL_PX} rightward within {@link COMMIT_WINDOW_MS} ms
+ * with less than {@link VERTICAL_TOLERANCE_PX} of vertical drift. The
+ * gesture is cancelled on `pointerup` / `pointercancel`, or once the
+ * tracking window elapses.
+ *
+ * Only `touch` and `pen` pointer types are considered — mouse drags from
+ * the edge could conflict with text selection. The gesture also skips if
+ * the sidebar is already visible so we don't replay the open on every
+ * subsequent edge tap.
+ *
+ * Returns an {@link IDisposable} that detaches all listeners.
+ */
+export function installMobileEdgeSwipeToOpenSidebar(
+	mainContainer: HTMLElement,
+	openSidebar: () => void,
+	layoutService: IWorkbenchLayoutService,
+): IDisposable {
+	const store = new DisposableStore();
+
+	let tracking = false;
+	let startX = 0;
+	let startY = 0;
+	let startTime = 0;
+	let activePointerId: number | undefined;
+
+	const reset = () => {
+		tracking = false;
+		activePointerId = undefined;
+	};
+
+	const isPhoneLayout = (): boolean => {
+		return mainContainer.classList.contains('phone-layout');
+	};
+
+	store.add(addDisposableListener(mainContainer, EventType.POINTER_DOWN, (e: PointerEvent) => {
+		if (tracking) {
+			return;
+		}
+		if (e.pointerType !== 'touch' && e.pointerType !== 'pen') {
+			return;
+		}
+		if (!isPhoneLayout()) {
+			return;
+		}
+		const rect = mainContainer.getBoundingClientRect();
+		const localX = e.clientX - rect.left;
+		if (localX >= EDGE_HIT_ZONE_PX) {
+			return;
+		}
+		if (layoutService.isVisible(Parts.SIDEBAR_PART)) {
+			return;
+		}
+
+		tracking = true;
+		activePointerId = e.pointerId;
+		startX = e.clientX;
+		startY = e.clientY;
+		startTime = Date.now();
+	}, true));
+
+	store.add(addDisposableListener(mainContainer, EventType.POINTER_MOVE, (e: PointerEvent) => {
+		if (!tracking || e.pointerId !== activePointerId) {
+			return;
+		}
+
+		const dx = e.clientX - startX;
+		const dy = Math.abs(e.clientY - startY);
+		const elapsed = Date.now() - startTime;
+
+		if (elapsed > COMMIT_WINDOW_MS || dy > VERTICAL_TOLERANCE_PX) {
+			reset();
+			return;
+		}
+
+		if (dx >= COMMIT_TRAVEL_PX) {
+			reset();
+			openSidebar();
+		}
+	}, true));
+
+	const cancel = (e: PointerEvent) => {
+		if (e.pointerId === activePointerId) {
+			reset();
+		}
+	};
+	store.add(addDisposableListener(mainContainer, EventType.POINTER_UP, cancel, true));
+	store.add(addDisposableListener(mainContainer, 'pointercancel', cancel, true));
+
+	store.add(toDisposable(reset));
+
+	return store;
+}

--- a/src/vs/sessions/browser/parts/mobile/mobilePickerSheet.ts
+++ b/src/vs/sessions/browser/parts/mobile/mobilePickerSheet.ts
@@ -9,7 +9,7 @@ import { Codicon } from '../../../../base/common/codicons.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { Gesture, EventType as TouchEventType } from '../../../../base/browser/touch.js';
 import { CancellationToken, CancellationTokenSource } from '../../../../base/common/cancellation.js';
-import { DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
+import { DisposableStore, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { localize } from '../../../../nls.js';
 
 const $ = DOM.$;
@@ -122,6 +122,53 @@ export interface IMobilePickerSheetSearchSource {
 }
 
 /**
+ * Renderer API passed into the {@link showMobileContentSheet} body
+ * callback. The renderer fills {@link bodyContainer} with arbitrary DOM
+ * and may call {@link close} to dismiss the sheet (e.g. after a confirm
+ * button is tapped, or after a sub-view navigation completes).
+ */
+export interface IMobileContentSheetApi {
+	/**
+	 * The same element passed as the first argument to the body
+	 * renderer; exposed here for convenience so callbacks can capture
+	 * the API object without also closing over the body element.
+	 */
+	readonly bodyContainer: HTMLElement;
+
+	/** Dismiss the sheet (plays the close animation). Idempotent. */
+	close(): void;
+}
+
+/**
+ * Options for {@link showMobileContentSheet}.
+ */
+export interface IMobileContentSheetOptions {
+	/**
+	 * Optional caption shown beneath the title (single-line, muted).
+	 * Mirrors {@link IMobilePickerSheetOptions.caption}.
+	 */
+	readonly caption?: string;
+
+	/**
+	 * Optional set of icon buttons rendered in the sheet's title row
+	 * to the left of the Done button. Tapping a header action resolves
+	 * the promise (the same dismissal semantics as the Done button).
+	 */
+	readonly headerActions?: readonly IMobilePickerSheetHeaderAction[];
+
+	/** Optional override for the Done button label (defaults to "Done"). */
+	readonly doneLabel?: string;
+
+	/**
+	 * When true, the Done button is hidden. Use this for sheets where
+	 * the body itself provides primary dismissal (e.g. a confirm widget
+	 * with explicit Approve / Reject buttons that call `api.close()`).
+	 * The user can still dismiss via the backdrop or Escape.
+	 */
+	readonly hideDoneButton?: boolean;
+}
+
+/**
  * Prefix used on the resolved id when a header action is invoked from a
  * mobile picker sheet, so callers can disambiguate header taps from
  * regular row selections.
@@ -149,82 +196,24 @@ export function showMobilePickerSheet(
 	options?: IMobilePickerSheetOptions,
 ): Promise<string | undefined> {
 	return new Promise<string | undefined>(resolve => {
-		const disposables = new DisposableStore();
 		let resolved = false;
+		let shell!: IMobileSheetShell;
 
 		const finish = (id: string | undefined) => {
 			if (resolved) {
 				return;
 			}
 			resolved = true;
-			sheet.classList.add('closing');
-			backdrop.classList.add('closing');
-			// Dispose all event listeners and inflight queries immediately
-			// so nothing fires during the 180ms close animation. The DOM
-			// node itself is removed at the end of the animation.
-			disposables.dispose();
-			DOM.getWindow(workbenchContainer).setTimeout(() => {
-				overlay.remove();
-				resolve(id);
-			}, 180);
+			shell.close(() => resolve(id));
 		};
 
-		// -- DOM: backdrop + sheet -------------------------------------
-		const overlay = DOM.append(workbenchContainer, $('div.mobile-picker-sheet-overlay'));
-		const backdrop = DOM.append(overlay, $('div.mobile-picker-sheet-backdrop'));
-		const sheet = DOM.append(overlay, $('div.mobile-picker-sheet'));
-		sheet.setAttribute('role', 'dialog');
-		sheet.setAttribute('aria-modal', 'true');
-		sheet.setAttribute('aria-label', title);
-
-		// -- Header (drag handle + title row + caption) ----------------
-		DOM.append(sheet, $('div.mobile-picker-sheet-handle'));
-
-		const titleRow = DOM.append(sheet, $('div.mobile-picker-sheet-title-row'));
-		const titleEl = DOM.append(titleRow, $('div.mobile-picker-sheet-title'));
-		titleEl.textContent = title;
-
-		// Optional header actions (icon buttons) rendered between the
-		// title and the Done button. Useful for sheet-level shortcuts
-		// like "browse for a folder" that aren't a single picker row.
-		if (options?.headerActions) {
-			for (const action of options.headerActions) {
-				const btn = DOM.append(titleRow, $('button.mobile-picker-sheet-header-action', { type: 'button' })) as HTMLButtonElement;
-				btn.setAttribute('aria-label', action.label);
-				btn.title = action.label;
-				const iconHost = DOM.append(btn, $('span.mobile-picker-sheet-header-action-icon'));
-				const iconEl = DOM.append(iconHost, $('span.mobile-picker-sheet-header-action-icon-glyph'));
-				iconEl.classList.add(...ThemeIcon.asClassNameArray(action.icon));
-				const btnGesture = Gesture.addTarget(btn);
-				disposables.add(btnGesture);
-				const onActivate = () => finish(`${MOBILE_PICKER_SHEET_HEADER_ACTION_PREFIX}${action.id}`);
-				const btnClick = DOM.addDisposableListener(btn, DOM.EventType.CLICK, (e: MouseEvent) => {
-					e.preventDefault();
-					onActivate();
-				});
-				disposables.add(btnClick);
-				const btnTap = DOM.addDisposableListener(btn, TouchEventType.Tap, onActivate);
-				disposables.add(btnTap);
-			}
-		}
-
-		const doneBtn = DOM.append(titleRow, $('button.mobile-picker-sheet-done', { type: 'button' })) as HTMLButtonElement;
-		doneBtn.textContent = localize('mobilePickerSheet.done', "Done");
-		doneBtn.setAttribute('aria-label', localize('mobilePickerSheet.doneAriaLabel', "Close {0}", title));
-		const doneGesture = Gesture.addTarget(doneBtn);
-		disposables.add(doneGesture);
-		const doneClick = DOM.addDisposableListener(doneBtn, DOM.EventType.CLICK, (e: MouseEvent) => {
-			e.preventDefault();
-			finish(undefined);
+		shell = buildMobileSheetShell(workbenchContainer, title, {
+			caption: options?.caption,
+			headerActions: options?.headerActions,
+			onDismiss: () => finish(undefined),
+			onHeaderAction: actionId => finish(`${MOBILE_PICKER_SHEET_HEADER_ACTION_PREFIX}${actionId}`),
 		});
-		disposables.add(doneClick);
-		const doneTap = DOM.addDisposableListener(doneBtn, TouchEventType.Tap, () => finish(undefined));
-		disposables.add(doneTap);
-
-		if (options?.caption) {
-			const caption = DOM.append(sheet, $('div.mobile-picker-sheet-caption'));
-			caption.textContent = options.caption;
-		}
+		const { sheet, disposables } = shell;
 
 		// -- Optional inline search input ------------------------------
 		// Sits between the title row and the scrollable list. Its value
@@ -371,59 +360,6 @@ export function showMobilePickerSheet(
 			setSearchQuery = (query: string) => renderResults(query);
 		}
 
-		// -- Dismissal: backdrop + Escape ------------------------------
-		const backdropClick = DOM.addDisposableListener(backdrop, DOM.EventType.CLICK, () => finish(undefined));
-		disposables.add(backdropClick);
-		const backdropGesture = Gesture.addTarget(backdrop);
-		disposables.add(backdropGesture);
-		const backdropTap = DOM.addDisposableListener(backdrop, TouchEventType.Tap, () => finish(undefined));
-		disposables.add(backdropTap);
-
-		const keyHandler = DOM.addDisposableListener(DOM.getWindow(workbenchContainer), DOM.EventType.KEY_DOWN, (e: KeyboardEvent) => {
-			if (e.key === 'Escape') {
-				e.preventDefault();
-				e.stopPropagation();
-				finish(undefined);
-			}
-		}, true);
-		disposables.add(keyHandler);
-
-		// -- iOS keyboard avoidance -----------------------------------
-		// On iOS Safari, when the virtual keyboard opens the layout
-		// viewport (`vh` units) does NOT shrink — only the visual
-		// viewport changes. The sheet uses `position: fixed` which
-		// positions against the layout viewport, so without correction
-		// the keyboard covers the bottom portion of the sheet (including
-		// the search input the user is actively typing into).
-		//
-		// `window.visualViewport` exposes the real visible area. We
-		// listen for `resize` and `scroll` events on it and translate
-		// the sheet upward by the keyboard height so the search input
-		// remains visible.
-		const win = DOM.getWindow(workbenchContainer);
-		const vv = win.visualViewport;
-		if (vv) {
-			const adjustForKeyboard = () => {
-				// The keyboard height is the difference between the
-				// layout viewport height and the visual viewport height,
-				// plus any scroll offset the browser applied.
-				const keyboardHeight = win.innerHeight - vv.height;
-				overlay.style.bottom = `${Math.max(0, keyboardHeight)}px`;
-				overlay.style.height = `${vv.height}px`;
-			};
-			vv.addEventListener('resize', adjustForKeyboard);
-			vv.addEventListener('scroll', adjustForKeyboard);
-			disposables.add(toDisposable(() => {
-				vv.removeEventListener('resize', adjustForKeyboard);
-				vv.removeEventListener('scroll', adjustForKeyboard);
-				overlay.style.bottom = '';
-				overlay.style.height = '';
-			}));
-			// Run once immediately in case the keyboard is already
-			// visible (e.g., sheet opened while another input had focus).
-			adjustForKeyboard();
-		}
-
 		// Focus the search input if present, otherwise focus the first
 		// checked row (or the first row) for keyboard users.
 		if (searchInput) {
@@ -432,6 +368,282 @@ export function showMobilePickerSheet(
 			(renderState.firstCheckedRow ?? renderState.firstRow)?.focus();
 		}
 	});
+}
+
+/**
+ * Show a phone-friendly bottom sheet that hosts arbitrary body content.
+ *
+ * Reuses the same shell as {@link showMobilePickerSheet} — translucent
+ * backdrop, slide-up animation, drag handle, title row with Done button,
+ * optional caption, optional icon header actions, iOS visual-viewport
+ * keyboard avoidance, and `Escape` / backdrop dismissal — but leaves the
+ * scrollable body to the caller. Use this for overlays that don't fit
+ * the picker's row-list shape: tool-confirmation carousels, plan
+ * reviews, anchor previews, code-block expand views, and so on.
+ *
+ * The {@link renderBody} callback is invoked once after the sheet shell
+ * mounts. The caller fills the supplied `bodyElement` with whatever DOM
+ * they like and may return an {@link IDisposable} whose `dispose()` runs
+ * when the sheet closes (alongside the shell's own listeners).
+ *
+ * The body container has `overflow-y: auto`,
+ * `-webkit-overflow-scrolling: touch`, and `touch-action: pan-y` applied
+ * via the `.mobile-content-sheet-body` class so vertical scrolling works
+ * correctly under iOS.
+ *
+ * The returned promise resolves with `void` when the sheet closes for
+ * any reason: Done button, backdrop tap, Escape, a header action tap,
+ * or an explicit `api.close()` from inside `renderBody`.
+ *
+ * @example
+ * ```ts
+ * await showMobileContentSheet(
+ *     this._layoutService.mainContainer,
+ *     localize('confirm.title', "Confirm Tool Use"),
+ *     (body, api) => {
+ *         const store = new DisposableStore();
+ *         const summary = DOM.append(body, DOM.$('div.tool-confirm-summary'));
+ *         summary.textContent = toolDescription;
+ *
+ *         const approve = DOM.append(body, DOM.$('button.tool-confirm-approve'));
+ *         approve.textContent = localize('confirm.approve', "Approve");
+ *         store.add(DOM.addDisposableListener(approve, 'click', () => {
+ *             writeApproval();
+ *             api.close();
+ *         }));
+ *
+ *         return store;
+ *     },
+ *     { caption: localize('confirm.caption', "This will modify your workspace.") },
+ * );
+ * ```
+ */
+export function showMobileContentSheet(
+	workbenchContainer: HTMLElement,
+	title: string,
+	renderBody: (bodyElement: HTMLElement, api: IMobileContentSheetApi) => IDisposable | void,
+	options?: IMobileContentSheetOptions,
+): Promise<void> {
+	return new Promise<void>(resolve => {
+		let resolved = false;
+		let shell!: IMobileSheetShell;
+
+		const close = () => {
+			if (resolved) {
+				return;
+			}
+			resolved = true;
+			shell.close(() => resolve());
+		};
+
+		shell = buildMobileSheetShell(workbenchContainer, title, {
+			caption: options?.caption,
+			headerActions: options?.headerActions,
+			doneLabel: options?.doneLabel,
+			hideDoneButton: options?.hideDoneButton,
+			onDismiss: close,
+			onHeaderAction: () => close(),
+		});
+
+		const bodyContainer = DOM.append(shell.sheet, $('div.mobile-content-sheet-body'));
+
+		const api: IMobileContentSheetApi = { bodyContainer, close };
+		const bodyDisposable = renderBody(bodyContainer, api);
+		if (bodyDisposable) {
+			shell.disposables.add(bodyDisposable);
+		}
+	});
+}
+
+/** Options consumed by {@link buildMobileSheetShell}. */
+interface IMobileSheetShellOptions {
+	readonly caption?: string;
+	readonly headerActions?: readonly IMobilePickerSheetHeaderAction[];
+	readonly doneLabel?: string;
+	readonly hideDoneButton?: boolean;
+	/**
+	 * Called when the user dismisses the sheet via the Done button,
+	 * backdrop tap, or Escape key. The shell does NOT close itself in
+	 * response to dismissal — the caller is expected to invoke
+	 * {@link IMobileSheetShell.close} from this callback.
+	 */
+	readonly onDismiss: () => void;
+	/**
+	 * Called when a header action button is tapped. If omitted, header
+	 * action taps fall through to {@link onDismiss}.
+	 */
+	readonly onHeaderAction?: (actionId: string) => void;
+}
+
+/** Primitives returned by {@link buildMobileSheetShell}. */
+interface IMobileSheetShell {
+	readonly overlay: HTMLElement;
+	readonly backdrop: HTMLElement;
+	/** The sheet container — append body content here. */
+	readonly sheet: HTMLElement;
+	/** Disposable store tied to the sheet's lifetime; cleared on close. */
+	readonly disposables: DisposableStore;
+	/**
+	 * Play the close animation, dispose listeners, and remove the DOM
+	 * node after the animation completes. Idempotent — subsequent
+	 * calls are no-ops. The optional callback fires once the node has
+	 * been removed.
+	 */
+	close(onAnimationEnd?: () => void): void;
+}
+
+/**
+ * Build the shared shell for {@link showMobilePickerSheet} and
+ * {@link showMobileContentSheet}: overlay, backdrop, sheet (drag handle,
+ * title row with Done button and optional header actions, optional
+ * caption), backdrop / Escape dismissal, and iOS visual-viewport
+ * keyboard avoidance. Callers append their own content children to
+ * `sheet`.
+ */
+function buildMobileSheetShell(
+	workbenchContainer: HTMLElement,
+	title: string,
+	options: IMobileSheetShellOptions,
+): IMobileSheetShell {
+	const disposables = new DisposableStore();
+	let closed = false;
+
+	// -- DOM: backdrop + sheet -------------------------------------
+	const overlay = DOM.append(workbenchContainer, $('div.mobile-picker-sheet-overlay'));
+	const backdrop = DOM.append(overlay, $('div.mobile-picker-sheet-backdrop'));
+	const sheet = DOM.append(overlay, $('div.mobile-picker-sheet'));
+	sheet.setAttribute('role', 'dialog');
+	sheet.setAttribute('aria-modal', 'true');
+	sheet.setAttribute('aria-label', title);
+
+	// -- Header (drag handle + title row + caption) ----------------
+	DOM.append(sheet, $('div.mobile-picker-sheet-handle'));
+
+	const titleRow = DOM.append(sheet, $('div.mobile-picker-sheet-title-row'));
+	const titleEl = DOM.append(titleRow, $('div.mobile-picker-sheet-title'));
+	titleEl.textContent = title;
+
+	// Optional header actions (icon buttons) rendered between the
+	// title and the Done button. Useful for sheet-level shortcuts
+	// like "browse for a folder" that aren't a single picker row.
+	if (options.headerActions) {
+		for (const action of options.headerActions) {
+			const btn = DOM.append(titleRow, $('button.mobile-picker-sheet-header-action', { type: 'button' })) as HTMLButtonElement;
+			btn.setAttribute('aria-label', action.label);
+			btn.title = action.label;
+			const iconHost = DOM.append(btn, $('span.mobile-picker-sheet-header-action-icon'));
+			const iconEl = DOM.append(iconHost, $('span.mobile-picker-sheet-header-action-icon-glyph'));
+			iconEl.classList.add(...ThemeIcon.asClassNameArray(action.icon));
+			const btnGesture = Gesture.addTarget(btn);
+			disposables.add(btnGesture);
+			const onActivate = () => {
+				if (options.onHeaderAction) {
+					options.onHeaderAction(action.id);
+				} else {
+					options.onDismiss();
+				}
+			};
+			const btnClick = DOM.addDisposableListener(btn, DOM.EventType.CLICK, (e: MouseEvent) => {
+				e.preventDefault();
+				onActivate();
+			});
+			disposables.add(btnClick);
+			const btnTap = DOM.addDisposableListener(btn, TouchEventType.Tap, onActivate);
+			disposables.add(btnTap);
+		}
+	}
+
+	if (!options.hideDoneButton) {
+		const doneBtn = DOM.append(titleRow, $('button.mobile-picker-sheet-done', { type: 'button' })) as HTMLButtonElement;
+		doneBtn.textContent = options.doneLabel ?? localize('mobilePickerSheet.done', "Done");
+		doneBtn.setAttribute('aria-label', localize('mobilePickerSheet.doneAriaLabel', "Close {0}", title));
+		const doneGesture = Gesture.addTarget(doneBtn);
+		disposables.add(doneGesture);
+		const doneClick = DOM.addDisposableListener(doneBtn, DOM.EventType.CLICK, (e: MouseEvent) => {
+			e.preventDefault();
+			options.onDismiss();
+		});
+		disposables.add(doneClick);
+		const doneTap = DOM.addDisposableListener(doneBtn, TouchEventType.Tap, () => options.onDismiss());
+		disposables.add(doneTap);
+	}
+
+	if (options.caption) {
+		const caption = DOM.append(sheet, $('div.mobile-picker-sheet-caption'));
+		caption.textContent = options.caption;
+	}
+
+	// -- Dismissal: backdrop + Escape ------------------------------
+	const backdropClick = DOM.addDisposableListener(backdrop, DOM.EventType.CLICK, () => options.onDismiss());
+	disposables.add(backdropClick);
+	const backdropGesture = Gesture.addTarget(backdrop);
+	disposables.add(backdropGesture);
+	const backdropTap = DOM.addDisposableListener(backdrop, TouchEventType.Tap, () => options.onDismiss());
+	disposables.add(backdropTap);
+
+	const keyHandler = DOM.addDisposableListener(DOM.getWindow(workbenchContainer), DOM.EventType.KEY_DOWN, (e: KeyboardEvent) => {
+		if (e.key === 'Escape') {
+			e.preventDefault();
+			e.stopPropagation();
+			options.onDismiss();
+		}
+	}, true);
+	disposables.add(keyHandler);
+
+	// -- iOS keyboard avoidance -----------------------------------
+	// On iOS Safari, when the virtual keyboard opens the layout
+	// viewport (`vh` units) does NOT shrink — only the visual
+	// viewport changes. The sheet uses `position: fixed` which
+	// positions against the layout viewport, so without correction
+	// the keyboard covers the bottom portion of the sheet (including
+	// any input the user is actively typing into).
+	//
+	// `window.visualViewport` exposes the real visible area. We
+	// listen for `resize` and `scroll` events on it and translate
+	// the sheet upward by the keyboard height so the focused input
+	// remains visible.
+	const win = DOM.getWindow(workbenchContainer);
+	const vv = win.visualViewport;
+	if (vv) {
+		const adjustForKeyboard = () => {
+			// The keyboard height is the difference between the
+			// layout viewport height and the visual viewport height,
+			// plus any scroll offset the browser applied.
+			const keyboardHeight = win.innerHeight - vv.height;
+			overlay.style.bottom = `${Math.max(0, keyboardHeight)}px`;
+			overlay.style.height = `${vv.height}px`;
+		};
+		vv.addEventListener('resize', adjustForKeyboard);
+		vv.addEventListener('scroll', adjustForKeyboard);
+		disposables.add(toDisposable(() => {
+			vv.removeEventListener('resize', adjustForKeyboard);
+			vv.removeEventListener('scroll', adjustForKeyboard);
+			overlay.style.bottom = '';
+			overlay.style.height = '';
+		}));
+		// Run once immediately in case the keyboard is already
+		// visible (e.g., sheet opened while another input had focus).
+		adjustForKeyboard();
+	}
+
+	const close = (onAnimationEnd?: () => void) => {
+		if (closed) {
+			return;
+		}
+		closed = true;
+		sheet.classList.add('closing');
+		backdrop.classList.add('closing');
+		// Dispose all event listeners and inflight queries immediately
+		// so nothing fires during the 180ms close animation. The DOM
+		// node itself is removed at the end of the animation.
+		disposables.dispose();
+		DOM.getWindow(workbenchContainer).setTimeout(() => {
+			overlay.remove();
+			onAnimationEnd?.();
+		}, 180);
+	};
+
+	return { overlay, backdrop, sheet, disposables, close };
 }
 
 /** Mutable bookkeeping passed through {@link renderRow} so we can track section dividers and the row to focus. */

--- a/src/vs/sessions/browser/parts/mobile/mobileVisualViewport.ts
+++ b/src/vs/sessions/browser/parts/mobile/mobileVisualViewport.ts
@@ -1,0 +1,166 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as DOM from '../../../../base/browser/dom.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { derived, IObservable, observableValue } from '../../../../base/common/observable.js';
+import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+import { ILayoutService } from '../../../../platform/layout/browser/layoutService.js';
+import { KeyboardVisibleContext } from '../../../common/contextkeys.js';
+
+/**
+ * Threshold (in CSS pixels) above which the visual viewport delta is
+ * treated as a virtual keyboard being visible. A few dozen pixels can
+ * appear briefly during URL-bar collapse / address-bar shrink, so we
+ * require a clearly keyboard-sized delta before flipping the context.
+ */
+export const KEYBOARD_VISIBLE_THRESHOLD_PX = 50;
+
+/**
+ * CSS custom property exposed on the workbench main container that
+ * reflects the current virtual keyboard height in pixels (e.g.
+ * `--vscode-keyboard-height: 320px`). Consumers can read this from
+ * CSS (`bottom: var(--vscode-keyboard-height, 0px)`) when they need
+ * to keep UI above the keyboard without subscribing to the observable.
+ */
+const KEYBOARD_HEIGHT_CSS_VAR = '--vscode-keyboard-height';
+
+/**
+ * Service decorator for {@link MobileVisualViewport}. Consumers inject
+ * this to observe the virtual keyboard height of the agents workbench
+ * window or to gate behaviour on whether the keyboard is currently
+ * visible.
+ */
+export const IMobileVisualViewport = createDecorator<IMobileVisualViewport>('mobileVisualViewport');
+
+/**
+ * Service interface for {@link MobileVisualViewport}. See the class for
+ * a full description of the publishing surface.
+ */
+export interface IMobileVisualViewport {
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * Observable: the current virtual keyboard height in CSS pixels,
+	 * computed as `max(0, window.innerHeight - visualViewport.height)`.
+	 * Always `0` on platforms without `visualViewport` support.
+	 */
+	readonly keyboardHeight: IObservable<number>;
+
+	/**
+	 * Observable: `true` when {@link keyboardHeight} exceeds
+	 * {@link KEYBOARD_VISIBLE_THRESHOLD_PX}. Cheaper for consumers than
+	 * subscribing to `keyboardHeight` directly when they only care
+	 * about the keyboard-visible transition (it only fires on the
+	 * boolean flip, not on every height micro-change during the
+	 * keyboard open/close animation).
+	 */
+	readonly isKeyboardVisible: IObservable<boolean>;
+}
+
+/**
+ * Tracks the virtual keyboard height of the agents workbench window via
+ * the `window.visualViewport` API and exposes it to consumers in three
+ * complementary forms:
+ *
+ *  1. As an {@link IObservable} (`keyboardHeight`) for code that wants
+ *     to react to keyboard changes via `autorun` / `derived`.
+ *  2. As a CSS custom property (`--vscode-keyboard-height`) set on the
+ *     workbench main container, so styles can position fixed UI above
+ *     the keyboard without touching JavaScript at all.
+ *  3. As a reactive {@link KeyboardVisibleContext} context key (`true`
+ *     when the keyboard height exceeds {@link KEYBOARD_VISIBLE_THRESHOLD_PX}),
+ *     so `when:` clauses on commands/menus can adapt to the keyboard.
+ *
+ * # Why this helper exists
+ *
+ * On iOS Safari (and to a lesser extent some Android browsers), the
+ * *layout viewport* — what `vh` units, `window.innerHeight`, and
+ * `position: fixed` resolve against — does NOT shrink when the virtual
+ * keyboard opens. Only the *visual viewport* (the actually visible
+ * area) shrinks. As a consequence, naive layouts that anchor to the
+ * bottom of the layout viewport end up hidden behind the keyboard.
+ *
+ * The standard `window.visualViewport` API exposes the real visible
+ * area and fires `resize` / `scroll` events when the keyboard opens
+ * or closes. This helper subscribes to those events once for the
+ * lifetime of the workbench window and publishes the keyboard height
+ * (`max(0, window.innerHeight - visualViewport.height)`).
+ *
+ * # Auxiliary windows
+ *
+ * The helper uses {@link DOM.getWindow} to resolve the correct window
+ * object for the layout-service main container, so it works correctly
+ * when the workbench is hosted inside an auxiliary window (each aux
+ * window has its own `visualViewport`).
+ *
+ * # Graceful degradation
+ *
+ * Browsers that do not implement `visualViewport` (very old engines,
+ * some embedded webviews) get a constant `keyboardHeight` of `0`, no
+ * CSS variable update, and a context key that stays `false`. Consumers
+ * never need to check for the API themselves.
+ */
+export class MobileVisualViewport extends Disposable implements IMobileVisualViewport {
+
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _keyboardHeight = observableValue<number>(this, 0);
+
+	readonly keyboardHeight: IObservable<number> = this._keyboardHeight;
+
+	readonly isKeyboardVisible: IObservable<boolean> = derived(this, reader =>
+		this._keyboardHeight.read(reader) > KEYBOARD_VISIBLE_THRESHOLD_PX
+	);
+
+	private readonly _keyboardVisibleCtx: IContextKey<boolean>;
+	private readonly mainContainer: HTMLElement;
+
+	constructor(
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@ILayoutService layoutService: ILayoutService,
+	) {
+		super();
+
+		this.mainContainer = layoutService.mainContainer;
+		this._keyboardVisibleCtx = KeyboardVisibleContext.bindTo(contextKeyService);
+
+		const targetWindow = DOM.getWindow(this.mainContainer);
+		const visualViewport = targetWindow.visualViewport;
+
+		if (!visualViewport) {
+			// No visualViewport API available — keep observables/context
+			// keys at their default zero/false state.
+			return;
+		}
+
+		const update = () => {
+			const height = Math.max(0, targetWindow.innerHeight - visualViewport.height);
+			if (this._keyboardHeight.get() !== height) {
+				this._keyboardHeight.set(height, undefined);
+			}
+			this.mainContainer.style.setProperty(KEYBOARD_HEIGHT_CSS_VAR, `${height}px`);
+			this._keyboardVisibleCtx.set(height > KEYBOARD_VISIBLE_THRESHOLD_PX);
+		};
+
+		this._register(DOM.addDisposableListener(visualViewport, 'resize', update));
+		this._register(DOM.addDisposableListener(visualViewport, 'scroll', update));
+
+		// Seed the initial value so consumers see the current state on
+		// startup (e.g., the workbench was opened while the keyboard
+		// was already visible).
+		update();
+	}
+
+	override dispose(): void {
+		this.mainContainer.style.removeProperty(KEYBOARD_HEIGHT_CSS_VAR);
+		this._keyboardVisibleCtx.reset();
+		super.dispose();
+	}
+}
+
+registerSingleton(IMobileVisualViewport, MobileVisualViewport, InstantiationType.Eager);

--- a/src/vs/sessions/browser/workbench.ts
+++ b/src/vs/sessions/browser/workbench.ts
@@ -63,7 +63,7 @@ import { EditorMarkdownCodeBlockRenderer } from '../../editor/browser/widget/mar
 import { SyncDescriptor } from '../../platform/instantiation/common/descriptors.js';
 import { TitleService } from './parts/titlebarPart.js';
 import { IContextKeyService } from '../../platform/contextkey/common/contextkey.js';
-import { EditorMaximizedContext, IsPhoneLayoutContext, KeyboardVisibleContext } from '../common/contextkeys.js';
+import { EditorMaximizedContext, IsPhoneLayoutContext } from '../common/contextkeys.js';
 import {
 	NotificationsPosition,
 	NotificationsSettings,
@@ -72,6 +72,7 @@ import {
 import { SessionsLayoutPolicy } from './layoutPolicy.js';
 import { MobileNavigationStack } from './mobileNavigationStack.js';
 import { MobileTitlebarPart } from './parts/mobile/mobileTitlebarPart.js';
+import { IMobileVisualViewport } from './parts/mobile/mobileVisualViewport.js';
 import { autorun } from '../../base/common/observable.js';
 import { ISessionsManagementService } from '../services/sessions/common/sessionsManagement.js';
 import { ISessionsPartService } from './parts/sessionsPartService.js';
@@ -456,28 +457,15 @@ export class Workbench extends Disposable implements IAgentWorkbenchLayoutServic
 					isPhoneLayoutCtx.set(this.layoutPolicy.viewportClass.read(reader) === 'phone');
 				}));
 
-				// Virtual keyboard detection via visualViewport API.
-				// Use `window.innerHeight` (layout viewport) as the baseline
-				// rather than a captured initial height. Layout viewport
-				// updates on orientation change and split-screen resizes, so
-				// comparing against it avoids stale baselines on landscape
-				// launches, Android split-screen, and iOS URL-bar collapse.
-				if (mainWindow.visualViewport) {
-					const keyboardVisibleCtx = KeyboardVisibleContext.bindTo(contextKeyService);
-					const KEYBOARD_HEIGHT_THRESHOLD_PX = 100;
-
-					const onViewportResize = () => {
-						const vp = mainWindow.visualViewport;
-						if (!vp) {
-							return;
-						}
-						const heightDiff = mainWindow.innerHeight - vp.height;
-						keyboardVisibleCtx.set(heightDiff > KEYBOARD_HEIGHT_THRESHOLD_PX);
-					};
-
-					mainWindow.visualViewport.addEventListener('resize', onViewportResize);
-					this._register({ dispose: () => mainWindow.visualViewport?.removeEventListener('resize', onViewportResize) });
-				}
+				// Virtual keyboard tracking (visualViewport): publishes the
+				// keyboard height as an observable, mirrors it onto the
+				// `--vscode-keyboard-height` CSS variable on the main
+				// container, and drives the `KeyboardVisibleContext`
+				// context key. The service is an eager singleton, so
+				// resolving it here is what triggers its constructor —
+				// the registry hands ownership/disposal to the
+				// instantiation service so we don't `_register` it.
+				accessor.get(IMobileVisualViewport);
 
 				// Orientation changes produce a window `resize` event which
 				// is already handled by `registerLayoutListeners()`. No

--- a/src/vs/sessions/contrib/chat/browser/mobile/mobileInlineAnchorPeek.ts
+++ b/src/vs/sessions/contrib/chat/browser/mobile/mobileInlineAnchorPeek.ts
@@ -1,0 +1,301 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as DOM from '../../../../../base/browser/dom.js';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { Disposable, DisposableStore, IDisposable, MutableDisposable } from '../../../../../base/common/lifecycle.js';
+import { derived, IObservable } from '../../../../../base/common/observable.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
+import { ILanguageService } from '../../../../../editor/common/languages/language.js';
+import { localize } from '../../../../../nls.js';
+import { IClipboardService } from '../../../../../platform/clipboard/common/clipboardService.js';
+import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { ILabelService } from '../../../../../platform/label/common/label.js';
+import { INotificationService } from '../../../../../platform/notification/common/notification.js';
+import { observableContextKey } from '../../../../../platform/observable/common/platformObservableUtils.js';
+import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../../workbench/common/contributions.js';
+import { IChatInlineAnchorPeekTarget, IChatInlineAnchorPhonePresenter, IChatInlineAnchorPhonePresenterImpl } from '../../../../../workbench/contrib/chat/browser/widget/chatContentParts/chatInlineAnchorPhonePresenter.js';
+import { IEditorService } from '../../../../../workbench/services/editor/common/editorService.js';
+import { IWorkbenchLayoutService } from '../../../../../workbench/services/layout/browser/layoutService.js';
+import { ITextFileService } from '../../../../../workbench/services/textfile/common/textfiles.js';
+import { IMobileContentSheetApi, showMobileContentSheet } from '../../../../browser/parts/mobile/mobilePickerSheet.js';
+
+const $ = DOM.$;
+
+/**
+ * Maximum number of context lines shown around the anchor's range
+ * inside the peek sheet. Keeps the snippet readable on a phone screen
+ * without forcing a giant scroll surface.
+ */
+const PEEK_CONTEXT_LINES = 3;
+
+/**
+ * Hard cap on the snippet length read from the file. Anchors usually
+ * point at a single function or a few-line region, but we guard
+ * against pathological cases (e.g. a one-line minified file) so the
+ * sheet body never grows unbounded.
+ */
+const PEEK_MAX_SNIPPET_CHARS = 4_000;
+
+/**
+ * Sessions-side implementation of {@link IChatInlineAnchorPhonePresenter}.
+ *
+ * On phone-layout viewports of the agents window, intercepts taps on
+ * inline file/symbol anchors (rendered by `InlineAnchorWidget` inside
+ * chat markdown) and surfaces a bottom-sheet "peek" of the target:
+ * the resource path, its language label, an optional snippet preview
+ * read via {@link ITextFileService}, and quick actions to open the
+ * file in the editor or copy a link to it. Workbench code does not
+ * depend on the sheet primitive: it only sees the
+ * {@link IChatInlineAnchorPhonePresenter} decorator interface, so this
+ * wiring stays out of the workbench layer.
+ */
+class MobileInlineAnchorPeekPresenter extends Disposable implements IChatInlineAnchorPhonePresenterImpl {
+
+	readonly enabled: IObservable<boolean>;
+
+	constructor(
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IWorkbenchLayoutService private readonly _layoutService: IWorkbenchLayoutService,
+		@ITextFileService private readonly _textFileService: ITextFileService,
+		@IEditorService private readonly _editorService: IEditorService,
+		@IClipboardService private readonly _clipboardService: IClipboardService,
+		@ILabelService private readonly _labelService: ILabelService,
+		@ILanguageService private readonly _languageService: ILanguageService,
+		@INotificationService private readonly _notificationService: INotificationService,
+	) {
+		super();
+
+		// Track the phone-layout context key (`sessionsIsPhoneLayout`)
+		// so the inline-anchor click handler re-evaluates `enabled`
+		// the moment the viewport crosses the phone breakpoint. This
+		// key is the source of truth for "is this viewport
+		// phone-classified" — the layout policy updates it through the
+		// workbench's main `layout()` pass.
+		const isPhoneCtx = observableContextKey<boolean>('sessionsIsPhoneLayout', contextKeyService);
+		this.enabled = derived(this, reader => isPhoneCtx.read(reader) === true);
+	}
+
+	async showAnchorPeek(anchor: IChatInlineAnchorPeekTarget): Promise<void> {
+		// Read the snippet asynchronously BEFORE opening the sheet so
+		// we don't show an empty placeholder while the file load is in
+		// flight. If the read fails (binary, scheme without provider,
+		// permissions error, …) we just skip the preview and keep the
+		// path / language header + action buttons.
+		const snippet = await this._tryReadSnippet(anchor);
+
+		await showMobileContentSheet(
+			this._layoutService.mainContainer,
+			anchor.symbolName ?? this._labelService.getUriBasenameLabel(anchor.uri),
+			(bodyContainer, api) => this._renderBody(bodyContainer, api, anchor, snippet),
+			{
+				caption: this._labelService.getUriLabel(anchor.uri, { relative: true }),
+			},
+		);
+	}
+
+	private _renderBody(
+		bodyContainer: HTMLElement,
+		api: IMobileContentSheetApi,
+		anchor: IChatInlineAnchorPeekTarget,
+		snippet: IAnchorSnippet | undefined,
+	): IDisposable {
+		const store = new DisposableStore();
+		const root = DOM.append(bodyContainer, $('div.mobile-inline-anchor-peek'));
+
+		// -- Metadata header ------------------------------------------
+		// File path (full fsPath when available, otherwise the URI's
+		// label) plus the resolved language id. Both rows are
+		// selectable so the user can long-press to copy on iOS.
+		const meta = DOM.append(root, $('div.mobile-inline-anchor-peek-meta'));
+
+		const pathRow = DOM.append(meta, $('div.mobile-inline-anchor-peek-row'));
+		DOM.append(pathRow, $('span.mobile-inline-anchor-peek-row-label')).textContent = localize('mobileInlineAnchorPeek.path', "Path");
+		const pathValue = DOM.append(pathRow, $('span.mobile-inline-anchor-peek-row-value'));
+		pathValue.textContent = this._formatPath(anchor);
+
+		const languageRow = DOM.append(meta, $('div.mobile-inline-anchor-peek-row'));
+		DOM.append(languageRow, $('span.mobile-inline-anchor-peek-row-label')).textContent = localize('mobileInlineAnchorPeek.language', "Language");
+		DOM.append(languageRow, $('span.mobile-inline-anchor-peek-row-value')).textContent = this._resolveLanguageLabel(anchor);
+
+		if (anchor.range) {
+			const rangeRow = DOM.append(meta, $('div.mobile-inline-anchor-peek-row'));
+			DOM.append(rangeRow, $('span.mobile-inline-anchor-peek-row-label')).textContent = localize('mobileInlineAnchorPeek.range', "Range");
+			const rangeValue = DOM.append(rangeRow, $('span.mobile-inline-anchor-peek-row-value'));
+			rangeValue.textContent = this._formatRange(anchor);
+		}
+
+		// -- Snippet preview ------------------------------------------
+		if (snippet) {
+			const snippetWrap = DOM.append(root, $('div.mobile-inline-anchor-peek-snippet'));
+			snippetWrap.setAttribute('aria-label', localize('mobileInlineAnchorPeek.snippet', "Preview"));
+			const pre = DOM.append(snippetWrap, $('pre.mobile-inline-anchor-peek-code'));
+			pre.textContent = snippet.text;
+			if (snippet.startLine > 1 || snippet.truncated) {
+				const hint = DOM.append(snippetWrap, $('div.mobile-inline-anchor-peek-snippet-hint'));
+				hint.textContent = snippet.truncated
+					? localize('mobileInlineAnchorPeek.snippetTruncatedFrom', "Lines {0}+ (truncated)", snippet.startLine)
+					: localize('mobileInlineAnchorPeek.snippetFrom', "Starting at line {0}", snippet.startLine);
+			}
+		}
+
+		// -- Action row -----------------------------------------------
+		const actions = DOM.append(root, $('div.mobile-inline-anchor-peek-actions'));
+
+		const openButton = this._createActionButton(
+			actions,
+			Codicon.goToFile,
+			localize('mobileInlineAnchorPeek.openInEditor', "Open in Editor"),
+		);
+		store.add(DOM.addDisposableListener(openButton, 'click', e => {
+			e.preventDefault();
+			api.close();
+			void this._openInEditor(anchor);
+		}));
+
+		const copyButton = this._createActionButton(
+			actions,
+			Codicon.copy,
+			localize('mobileInlineAnchorPeek.copyLink', "Copy Link"),
+		);
+		store.add(DOM.addDisposableListener(copyButton, 'click', e => {
+			e.preventDefault();
+			void this._copyLink(anchor);
+			api.close();
+		}));
+
+		return store;
+	}
+
+	private _createActionButton(parent: HTMLElement, icon: ThemeIcon, label: string): HTMLButtonElement {
+		const button = DOM.append(parent, $('button.mobile-inline-anchor-peek-action', { type: 'button' })) as HTMLButtonElement;
+		button.setAttribute('aria-label', label);
+		const iconHost = DOM.append(button, $('span.mobile-inline-anchor-peek-action-icon'));
+		iconHost.classList.add(...ThemeIcon.asClassNameArray(icon));
+		DOM.append(button, $('span.mobile-inline-anchor-peek-action-label')).textContent = label;
+		return button;
+	}
+
+	private _formatPath(anchor: IChatInlineAnchorPeekTarget): string {
+		// Prefer the full fsPath for local resources (gives the user
+		// the most context on iOS Files-style mental models); fall
+		// back to the URI's friendly label for non-file schemes.
+		if (anchor.uri.scheme === 'file') {
+			return anchor.uri.fsPath;
+		}
+		return this._labelService.getUriLabel(anchor.uri);
+	}
+
+	private _formatRange(anchor: IChatInlineAnchorPeekTarget): string {
+		const range = anchor.range!;
+		if (range.startLineNumber === range.endLineNumber) {
+			return localize('mobileInlineAnchorPeek.singleLine', "Line {0}", range.startLineNumber);
+		}
+		return localize('mobileInlineAnchorPeek.multiLine', "Lines {0}-{1}", range.startLineNumber, range.endLineNumber);
+	}
+
+	private _resolveLanguageLabel(anchor: IChatInlineAnchorPeekTarget): string {
+		const languageId = this._languageService.guessLanguageIdByFilepathOrFirstLine(anchor.uri);
+		if (!languageId) {
+			return localize('mobileInlineAnchorPeek.languageUnknown', "Plain Text");
+		}
+		return this._languageService.getLanguageName(languageId) ?? languageId;
+	}
+
+	private async _tryReadSnippet(anchor: IChatInlineAnchorPeekTarget): Promise<IAnchorSnippet | undefined> {
+		try {
+			const content = await this._textFileService.read(anchor.uri, { acceptTextOnly: true });
+			const lines = content.value.split(/\r?\n/);
+			if (lines.length === 0) {
+				return undefined;
+			}
+
+			let startLine: number;
+			let endLine: number;
+			if (anchor.range) {
+				startLine = Math.max(1, anchor.range.startLineNumber - PEEK_CONTEXT_LINES);
+				endLine = Math.min(lines.length, anchor.range.endLineNumber + PEEK_CONTEXT_LINES);
+			} else {
+				// No range — show the first chunk of the file so the
+				// user gets a sense of what the file holds.
+				startLine = 1;
+				endLine = Math.min(lines.length, 2 * PEEK_CONTEXT_LINES + 1);
+			}
+
+			let snippetText = lines.slice(startLine - 1, endLine).join('\n');
+			let truncated = false;
+			if (snippetText.length > PEEK_MAX_SNIPPET_CHARS) {
+				snippetText = snippetText.slice(0, PEEK_MAX_SNIPPET_CHARS);
+				truncated = true;
+			}
+
+			return { text: snippetText, startLine, truncated };
+		} catch {
+			return undefined;
+		}
+	}
+
+	private async _openInEditor(anchor: IChatInlineAnchorPeekTarget): Promise<void> {
+		try {
+			await this._editorService.openEditor({
+				resource: anchor.uri,
+				options: anchor.range
+					? { selection: anchor.range, pinned: true }
+					: { pinned: true },
+			});
+		} catch (err) {
+			this._notificationService.warn(localize('mobileInlineAnchorPeek.openError', "Could not open file: {0}", err instanceof Error ? err.message : String(err)));
+		}
+	}
+
+	private async _copyLink(anchor: IChatInlineAnchorPeekTarget): Promise<void> {
+		// Web clipboard support is limited — `writeResources` typically
+		// no-ops in browsers and `writeText` is the only universally
+		// available primitive. Write the formatted string so a plain
+		// paste into another app (Notes, Mail, …) lands the
+		// human-readable label. We do not also call `writeResources`
+		// because on iOS Safari calling it after `writeText` clears
+		// the pasteboard.
+		try {
+			const text = anchor.uri.scheme === 'file' ? anchor.uri.fsPath : anchor.uri.toString();
+			await this._clipboardService.writeText(text);
+		} catch (err) {
+			this._notificationService.warn(localize('mobileInlineAnchorPeek.copyError', "Could not copy link: {0}", err instanceof Error ? err.message : String(err)));
+		}
+	}
+}
+
+interface IAnchorSnippet {
+	readonly text: string;
+	readonly startLine: number;
+	readonly truncated: boolean;
+}
+
+class MobileInlineAnchorPeekContribution extends Disposable implements IWorkbenchContribution {
+
+	private readonly _registration = this._register(new MutableDisposable<IDisposable>());
+
+	constructor(
+		@IChatInlineAnchorPhonePresenter presenter: IChatInlineAnchorPhonePresenter,
+		@IInstantiationService instantiationService: IInstantiationService,
+	) {
+		super();
+
+		const impl = this._register(instantiationService.createInstance(MobileInlineAnchorPeekPresenter));
+
+		// Keep the registration mounted for the lifetime of the
+		// contribution. The workbench presenter's `enabled` observable
+		// already gates the actual peek sheet path on phone layout,
+		// so no dynamic mount/unmount is needed here.
+		this._registration.value = presenter.setImpl(impl);
+	}
+}
+
+registerWorkbenchContribution2(
+	'mobileInlineAnchorPeek',
+	MobileInlineAnchorPeekContribution,
+	WorkbenchPhase.BlockStartup,
+);

--- a/src/vs/sessions/sessions.web.main.ts
+++ b/src/vs/sessions/sessions.web.main.ts
@@ -181,6 +181,14 @@ import './contrib/providers/agentHost/browser/mobile/mobileChatPhoneInputPresent
 // without duplicate-registration conflicts.
 import './contrib/providers/copilotChatSessions/browser/mobilePermissionPicker.contribution.js';
 
+// Phone-only peek sheet for inline file/symbol anchors in chat
+// markdown. Replaces the desktop hover-preview / open-on-click flow
+// with a bottom sheet that shows the path, language, an optional
+// snippet preview (via `ITextFileService`), and "Open in Editor" /
+// "Copy Link" actions. Web-only — desktop keeps the inline anchor
+// hover widget.
+import './contrib/chat/browser/mobile/mobileInlineAnchorPeek.js';
+
 // TODO: support agent feedback in web
 import './contrib/agentFeedback/browser/nullAgentFeedbackService.contribution.js';
 import '../workbench/contrib/webview/browser/webview.web.contribution.js';

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatChangesSummaryPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatChangesSummaryPart.ts
@@ -15,6 +15,8 @@ import { isEqual } from '../../../../../../base/common/resources.js';
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { localize2 } from '../../../../../../nls.js';
+import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
+import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { FileKind } from '../../../../../../platform/files/common/files.js';
 import { IHoverService } from '../../../../../../platform/hover/browser/hover.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
@@ -53,6 +55,8 @@ export class ChatCheckpointFileChangesSummaryContentPart extends Disposable impl
 		@IChatService private readonly chatService: IChatService,
 		@IEditorService private readonly editorService: IEditorService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
+		@IContextKeyService private readonly contextKeyService: IContextKeyService,
+		@ICommandService private readonly commandService: ICommandService,
 	) {
 		super();
 
@@ -151,6 +155,29 @@ export class ChatCheckpointFileChangesSummaryContentPart extends Disposable impl
 		store.add(this.list.onDidOpen((item) => {
 			const diff = item.element;
 			if (!diff) {
+				return;
+			}
+
+			// Phone-layout shortcut: open the MobileDiffView overlay (registered in
+			// vs/sessions) instead of the inline diff editor. The command id is
+			// referenced by string to avoid a cross-layer import.
+			if (this.contextKeyService.getContextKeyValue<boolean>('sessionsIsPhoneLayout') === true) {
+				const diffs = this.fileChangesDiffsObservable.get();
+				// Shape mirrors IFileDiffViewData in
+				// vs/sessions/browser/parts/mobile/contributions/mobileDiffView.ts.
+				const siblings = diffs.map(d => ({
+					originalURI: d.originalURI,
+					modifiedURI: d.modifiedURI,
+					identical: d.identical,
+					added: d.added,
+					removed: d.removed,
+				}));
+				const index = Math.max(0, diffs.indexOf(diff));
+				this.commandService.executeCommand('sessions.mobile.openDiffView', {
+					diff: siblings[index] ?? siblings[0],
+					siblings,
+					index,
+				});
 				return;
 			}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatDiffBlockPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatDiffBlockPart.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as dom from '../../../../../../base/browser/dom.js';
 import { CancellationTokenSource } from '../../../../../../base/common/cancellation.js';
 import { hashAsync } from '../../../../../../base/common/hash.js';
 import { Disposable, IReference, MutableDisposable, toDisposable } from '../../../../../../base/common/lifecycle.js';
@@ -13,6 +14,8 @@ import { ILanguageService } from '../../../../../../editor/common/languages/lang
 import { ITextModel } from '../../../../../../editor/common/model.js';
 import { IModelService } from '../../../../../../editor/common/services/model.js';
 import { IResolvedTextEditorModel, ITextModelService } from '../../../../../../editor/common/services/resolverService.js';
+import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
+import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { EditorModel } from '../../../../../common/editor/editorModel.js';
 import { IChatResponseViewModel } from '../../../common/model/chatViewModel.js';
 import { IDisposableReference } from './chatCollections.js';
@@ -105,6 +108,8 @@ export class MarkdownDiffBlockPart extends Disposable {
 		@IModelService private readonly modelService: IModelService,
 		@ITextModelService private readonly textModelService: ITextModelService,
 		@ILanguageService private readonly languageService: ILanguageService,
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@ICommandService commandService: ICommandService,
 	) {
 		super();
 
@@ -195,6 +200,33 @@ export class MarkdownDiffBlockPart extends Disposable {
 
 		this.comparePart.object.render(compareData, currentWidth, cts.token);
 		this.element = this.comparePart.object.element;
+
+		// Phone-layout shortcut: open the MobileDiffView overlay (registered in
+		// vs/sessions) instead of the inline diff editor. The command id is
+		// referenced by string to avoid a cross-layer import.
+		//
+		// Note: the inline `before`/`after` content here lives only in
+		// in-memory text models (`vscodeChatCodeBlock://...`) which the mobile
+		// diff view cannot read via `textFileService`. We still route the tap
+		// so that the user always lands in the overlay on phone; the overlay
+		// degrades to its empty/no-changes state when the URIs are unreadable.
+		this._register(dom.addDisposableListener(this.element, 'click', e => {
+			if (contextKeyService.getContextKeyValue<boolean>('sessionsIsPhoneLayout') !== true) {
+				return;
+			}
+			e.preventDefault();
+			e.stopPropagation();
+			// Shape mirrors IFileDiffViewData in
+			// vs/sessions/browser/parts/mobile/contributions/mobileDiffView.ts.
+			const diff = {
+				originalURI: data.codeBlockResource ?? originalUri,
+				modifiedURI: data.codeBlockResource ?? modifiedUri,
+				identical: false,
+				added: 0,
+				removed: 0,
+			};
+			commandService.executeCommand('sessions.mobile.openDiffView', { diff });
+		}, /* useCapture */ true));
 	}
 
 	layout(width: number): void {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatInlineAnchorPhonePresenter.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatInlineAnchorPhonePresenter.ts
@@ -1,0 +1,117 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable, IDisposable, toDisposable } from '../../../../../../base/common/lifecycle.js';
+import { derived, IObservable, observableValue } from '../../../../../../base/common/observable.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { IRange } from '../../../../../../editor/common/core/range.js';
+import { InstantiationType, registerSingleton } from '../../../../../../platform/instantiation/common/extensions.js';
+import { createDecorator } from '../../../../../../platform/instantiation/common/instantiation.js';
+
+/**
+ * Payload describing the inline anchor that should be surfaced in the
+ * phone-only peek sheet. Mirrors the parts of `ContentRefData` that
+ * make sense to a mobile user: a resource URI plus an optional editor
+ * range or symbol name. The presenter implementation reads the file
+ * (when possible) and renders a path / language / snippet preview
+ * inside the shared bottom sheet.
+ */
+export interface IChatInlineAnchorPeekTarget {
+	readonly uri: URI;
+	readonly range?: IRange;
+	readonly symbolName?: string;
+}
+
+/**
+ * Implementation of the phone-only inline-anchor peek presenter,
+ * registered by the agents-window (sessions) layer. Stays in
+ * `vs/workbench` as an interface so the workbench chat content parts
+ * can compile and run with no sessions dependency; the default
+ * singleton is a no-op (sees `enabled === false`).
+ */
+export interface IChatInlineAnchorPhonePresenterImpl {
+	/**
+	 * Whether the phone presenter is currently active. Workbench code
+	 * consults this in the inline-anchor click handler to decide
+	 * between the desktop "open in editor" path and a tap-to-open peek
+	 * sheet (phone).
+	 */
+	readonly enabled: IObservable<boolean>;
+
+	/**
+	 * Open a phone-friendly peek bottom sheet for the given anchor.
+	 * The returned promise resolves once the sheet has closed (Done,
+	 * backdrop, Escape, or a body action invoking `close()`).
+	 */
+	showAnchorPeek(anchor: IChatInlineAnchorPeekTarget): Promise<void>;
+}
+
+export const IChatInlineAnchorPhonePresenter = createDecorator<IChatInlineAnchorPhonePresenter>('chatInlineAnchorPhonePresenter');
+
+/**
+ * Workbench-layer hook for phone-only inline-anchor peek presentation.
+ *
+ * The default singleton is a no-op (`enabled === false`,
+ * {@link showAnchorPeek} resolves immediately). The agents-window
+ * layer (`vs/sessions`) registers a real implementation via
+ * {@link setImpl} that renders the anchor metadata into the shared
+ * mobile bottom sheet (see `showMobileContentSheet` in
+ * `vs/sessions/browser/parts/mobile/mobilePickerSheet`) with quick
+ * actions to open the file in the editor or copy a link to it.
+ *
+ * Workbench callers should:
+ *   1. Read `enabled.get()` inside the inline-anchor click handler.
+ *      When `true`, call {@link showAnchorPeek} and return early so
+ *      the desktop hover/open path does not also fire.
+ *   2. Never assume the returned promise resolves quickly — the user
+ *      controls the sheet's lifetime.
+ */
+export interface IChatInlineAnchorPhonePresenter {
+	readonly _serviceBrand: undefined;
+
+	/** `true` when an impl is registered AND it reports phone layout. */
+	readonly enabled: IObservable<boolean>;
+
+	/**
+	 * Open the phone peek sheet for the given anchor. No-ops (resolves
+	 * immediately) when {@link enabled} is `false`.
+	 */
+	showAnchorPeek(anchor: IChatInlineAnchorPeekTarget): Promise<void>;
+
+	/**
+	 * Register the phone implementation. Returns a disposable that
+	 * removes the registration. Only one impl is active at a time; the
+	 * most recent registration wins.
+	 */
+	setImpl(impl: IChatInlineAnchorPhonePresenterImpl): IDisposable;
+}
+
+class ChatInlineAnchorPhonePresenterService extends Disposable implements IChatInlineAnchorPhonePresenter {
+
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _impl = observableValue<IChatInlineAnchorPhonePresenterImpl | undefined>(this, undefined);
+
+	readonly enabled: IObservable<boolean> = derived(this, reader => {
+		const impl = this._impl.read(reader);
+		return impl ? impl.enabled.read(reader) : false;
+	});
+
+	showAnchorPeek(anchor: IChatInlineAnchorPeekTarget): Promise<void> {
+		const impl = this._impl.get();
+		return impl ? impl.showAnchorPeek(anchor) : Promise.resolve();
+	}
+
+	setImpl(impl: IChatInlineAnchorPhonePresenterImpl): IDisposable {
+		this._impl.set(impl, undefined);
+		return toDisposable(() => {
+			if (this._impl.get() === impl) {
+				this._impl.set(undefined, undefined);
+			}
+		});
+	}
+}
+
+registerSingleton(IChatInlineAnchorPhonePresenter, ChatInlineAnchorPhonePresenterService, InstantiationType.Delayed);

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatInlineAnchorWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatInlineAnchorWidget.ts
@@ -46,6 +46,7 @@ import { IChatContentInlineReference } from '../../../common/chatService/chatSer
 import { IChatWidgetService } from '../../chat.js';
 import { IChatImageCarouselService } from '../../chatImageCarouselService.js';
 import { chatAttachmentResourceContextKey, hookUpSymbolAttachmentDragAndContextMenu } from '../../attachments/chatAttachmentWidgets.js';
+import { IChatInlineAnchorPhonePresenter } from './chatInlineAnchorPhonePresenter.js';
 import { IChatMarkdownAnchorService } from './chatMarkdownAnchorService.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { ChatConfiguration } from '../../../common/constants.js';
@@ -158,6 +159,7 @@ export class InlineAnchorWidget extends Disposable {
 		@INotebookDocumentService private readonly notebookDocumentService: INotebookDocumentService,
 		@IOpenerService private readonly openerService: IOpenerService,
 		@IEditorService private readonly editorService: IEditorService,
+		@IChatInlineAnchorPhonePresenter private readonly chatInlineAnchorPhonePresenter: IChatInlineAnchorPhonePresenter,
 	) {
 		super();
 
@@ -306,6 +308,25 @@ export class InlineAnchorWidget extends Disposable {
 		// Click handler to open with custom editor association from chat.editorAssociations setting
 		this._register(dom.addDisposableListener(element, 'click', async (e) => {
 			dom.EventHelper.stop(e, true);
+
+			// Phone-layout takeover: when the agents-window has
+			// registered a phone presenter that reports itself as
+			// active, route the tap into a bottom-sheet peek instead
+			// of the desktop "open in editor" flow. The peek shows the
+			// file path, language, an optional snippet preview, and
+			// "Open in editor" / "Copy link" actions so the user can
+			// inspect the target without losing the chat scroll
+			// position. Desktop behavior is unchanged because the
+			// default presenter reports `enabled === false`.
+			if (this.chatInlineAnchorPhonePresenter.enabled.get()) {
+				const symbolName = this.data.kind === 'symbol' ? this.data.symbol.name : undefined;
+				await this.chatInlineAnchorPhonePresenter.showAnchorPeek({
+					uri: location.uri,
+					range: location.range,
+					symbolName,
+				});
+				return;
+			}
 
 			// If the reference is an image file and the carousel is enabled, open the carousel
 			const mimeType = getMediaMime(location.uri.path);

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMultiDiffContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMultiDiffContentPart.ts
@@ -16,6 +16,7 @@ import { URI } from '../../../../../../base/common/uri.js';
 import { localize } from '../../../../../../nls.js';
 import { MenuWorkbenchToolBar } from '../../../../../../platform/actions/browser/toolbar.js';
 import { MenuId } from '../../../../../../platform/actions/common/actions.js';
+import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
 import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { FileKind } from '../../../../../../platform/files/common/files.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
@@ -60,6 +61,7 @@ export class ChatMultiDiffContentPart extends Disposable implements IChatContent
 		@IEditorService private readonly editorService: IEditorService,
 		@IThemeService private readonly themeService: IThemeService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
+		@ICommandService private readonly commandService: ICommandService,
 	) {
 		super();
 
@@ -231,6 +233,34 @@ export class ChatMultiDiffContentPart extends Disposable implements IChatContent
 		if (!this.readOnly) {
 			store.add(this.list.onDidOpen((e) => {
 				if (!e.element) {
+					return;
+				}
+
+				// Phone-layout shortcut: open the MobileDiffView overlay (registered in
+				// vs/sessions) instead of the inline diff editor. The command id is
+				// referenced by string to avoid a cross-layer import.
+				if (this.contextKeyService.getContextKeyValue<boolean>('sessionsIsPhoneLayout') === true && e.element.diff) {
+					const items = this.list.length > 0
+						? Array.from({ length: this.list.length }, (_, i) => this.list.element(i))
+						: [];
+					// Shape mirrors IFileDiffViewData in
+					// vs/sessions/browser/parts/mobile/contributions/mobileDiffView.ts.
+					const siblings = items
+						.filter(it => it.diff)
+						.map(it => ({
+							originalURI: it.diff!.originalURI,
+							modifiedURI: it.diff!.modifiedURI,
+							identical: it.diff!.identical,
+							added: it.diff!.added,
+							removed: it.diff!.removed,
+						}));
+					const tappedUri = e.element.diff.modifiedURI;
+					const index = Math.max(0, siblings.findIndex(s => s.modifiedURI?.toString() === tappedUri.toString()));
+					this.commandService.executeCommand('sessions.mobile.openDiffView', {
+						diff: siblings[index] ?? siblings[0],
+						siblings,
+						index,
+					});
 					return;
 				}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTextEditContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTextEditContentPart.ts
@@ -19,6 +19,8 @@ import { IModelService } from '../../../../../../editor/common/services/model.js
 import { DefaultModelSHA1Computer } from '../../../../../../editor/common/services/modelService.js';
 import { IResolvedTextEditorModel, ITextModelService } from '../../../../../../editor/common/services/resolverService.js';
 import { localize } from '../../../../../../nls.js';
+import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
+import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { InstantiationType, registerSingleton } from '../../../../../../platform/instantiation/common/extensions.js';
 import { createDecorator } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { IChatProgressRenderableResponseContent, IChatTextEditGroup } from '../../../common/model/chatModel.js';
@@ -49,7 +51,9 @@ export class ChatTextEditContentPart extends Disposable implements IChatContentP
 		rendererOptions: IChatListItemRendererOptions,
 		diffEditorPool: DiffEditorPool,
 		currentWidth: number,
-		@ICodeCompareModelService private readonly codeCompareModelService: ICodeCompareModelService
+		@ICodeCompareModelService private readonly codeCompareModelService: ICodeCompareModelService,
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@ICommandService commandService: ICommandService,
 	) {
 		super();
 		const element = context.element;
@@ -107,6 +111,35 @@ export class ChatTextEditContentPart extends Disposable implements IChatContentP
 			this.comparePart.object.render(data, currentWidth, cts.token);
 
 			this.domNode = this.comparePart.object.element;
+
+			// Phone-layout shortcut: open the MobileDiffView overlay (registered in
+			// vs/sessions) instead of the inline diff editor. The command id is
+			// referenced by string to avoid a cross-layer import.
+			//
+			// Note: only `chatTextEdit.uri` is available as a real file URI here —
+			// the "modified" side lives in an in-memory text model
+			// (`vscodeChatCodeBlock://...`). Pass the file URI for both sides so
+			// the overlay opens deterministically; the diff content there will
+			// reflect the file's current on-disk state, which is acceptable as a
+			// routing target. Refining the per-edit content is out of scope for
+			// this phase.
+			this._register(dom.addDisposableListener(this.domNode, 'click', e => {
+				if (contextKeyService.getContextKeyValue<boolean>('sessionsIsPhoneLayout') !== true) {
+					return;
+				}
+				e.preventDefault();
+				e.stopPropagation();
+				// Shape mirrors IFileDiffViewData in
+				// vs/sessions/browser/parts/mobile/contributions/mobileDiffView.ts.
+				const diff = {
+					originalURI: chatTextEdit.uri,
+					modifiedURI: chatTextEdit.uri,
+					identical: false,
+					added: 0,
+					removed: 0,
+				};
+				commandService.executeCommand('sessions.mobile.openDiffView', { diff });
+			}, /* useCapture */ true));
 		}
 	}
 


### PR DESCRIPTION
Part 6 of the mobile-chat split. Stacked on #318647.

## What this does

Replaces inline diff/edit/anchor content parts in chat with phone-friendly bottom-sheet flows when running in the Agents window's phone layout. Desktop behavior is unchanged.

### Inline diff routing → `MobileDiffView`

Four workbench-layer chat content parts now phone-gate their interactive surfaces and re-route taps to the existing `MobileDiffView` command (registered in the sessions layer in an earlier PR):

- `chatChangesSummaryPart.ts` — file-row taps open the per-file diff view instead of the desktop hover/peek.
- `chatDiffBlockPart.ts` — inline single-file diff block becomes a tap-to-open sheet.
- `chatTextEditContentPart.ts` — text-edit groups open in the mobile diff view.
- `chatMultiDiffContentPart.ts` — multi-file diff button routes through the same command.

All four parts only divert on phone layout; the desktop code paths are untouched.

### Inline anchor peek sheet

Introduces a workbench-layer hook for file/symbol inline anchors:

- **`chatInlineAnchorPhonePresenter.ts`** (NEW, workbench) — defines `IChatInlineAnchorPhonePresenter` + `IChatInlineAnchorPhonePresenterImpl` + `IChatInlineAnchorPeekTarget`. Default singleton is a no-op (`enabled === false`), so workbench compiles without depending on the sessions layer.
- **`chatInlineAnchorWidget.ts`** — click handler consults `presenter.enabled.get()`; when true, opens the peek sheet and returns early before the desktop "open in editor" / hover path runs.
- **`mobileInlineAnchorPeek.ts`** (NEW, sessions) — registers the real impl. Renders the anchor's resource path, language label, an optional snippet preview read via `ITextFileService` (capped at ~3 context lines / 4 KB), and quick actions ("Open in Editor", "Copy Link") inside the shared `showMobileContentSheet` bottom sheet.

### Styling

Appends one section to `mobileChatShell.css` — "Phone Layout: Inline Anchor Peek Sheet" — shaping the metadata rows, snippet preview, and action row that the peek body renders. The sheet shell itself comes from `mobilePickerSheet.css`.

### Wiring

Adds the side-effect import `'./contrib/chat/browser/mobile/mobileInlineAnchorPeek.js'` to `sessions.web.main.ts` so the implementation is registered in the web bundle.

## Validation

- `npm run compile-check-ts-native` ✅
- `npm run valid-layers-check` ✅