### PR TITLE
sessions: collapse empty picker wrappers on the new-chat page

### DIFF
--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostModePicker.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostModePicker.ts
@@ -47,6 +47,7 @@ export abstract class AgentHostSessionEnumPicker extends Disposable {
 
 	private readonly _renderDisposables = this._register(new DisposableStore());
 	private readonly _providerListeners = this._register(new DisposableMap<string>());
+	private _containerElement: HTMLElement | undefined;
 	private _slotElement: HTMLElement | undefined;
 	protected _triggerElement: HTMLElement | undefined;
 
@@ -79,6 +80,7 @@ export abstract class AgentHostSessionEnumPicker extends Disposable {
 
 	render(container: HTMLElement): void {
 		this._renderDisposables.clear();
+		this._containerElement = container;
 
 		const slot = dom.append(container, dom.$('.sessions-chat-picker-slot'));
 		this._renderDisposables.add({ dispose: () => slot.remove() });
@@ -169,16 +171,24 @@ export abstract class AgentHostSessionEnumPicker extends Disposable {
 	}
 
 	private _updateTrigger(): void {
-		if (!this._triggerElement || !this._slotElement) {
+		if (!this._triggerElement || !this._slotElement || !this._containerElement) {
 			return;
 		}
 
 		const ctx = this._getActiveContext();
+		// Also collapse the wrapping `.action-item` that
+		// `MenuWorkbenchToolBar` created for this picker — hiding only
+		// the inner slot leaves the wrapper occupying its `min-width`
+		// floor and produces a visible empty gap in the chip row when
+		// the active session's schema doesn't expose this property
+		// (e.g. Claude agent host has no `mode`).
 		if (!ctx) {
 			this._slotElement.style.display = 'none';
+			this._containerElement.style.display = 'none';
 			return;
 		}
 		this._slotElement.style.display = '';
+		this._containerElement.style.display = '';
 
 		dom.clearNode(this._triggerElement);
 

--- a/src/vs/sessions/contrib/providers/agentHost/browser/mobile/mobileChatInputConfigPicker.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/mobile/mobileChatInputConfigPicker.ts
@@ -101,6 +101,7 @@ class MobileChatInputConfigPicker extends Disposable {
 
 	private readonly _renderDisposables = this._register(new DisposableStore());
 	private readonly _providerListeners = this._register(new DisposableMap<string>());
+	private _containerElement: HTMLElement | undefined;
 	private _slotElement: HTMLElement | undefined;
 	private _triggerElement: HTMLElement | undefined;
 
@@ -161,6 +162,7 @@ class MobileChatInputConfigPicker extends Disposable {
 
 	render(container: HTMLElement): void {
 		this._renderDisposables.clear();
+		this._containerElement = container;
 
 		const slot = dom.append(container, dom.$('.sessions-chat-picker-slot.sessions-chat-picker-slot-mobile-config'));
 		this._renderDisposables.add({ dispose: () => slot.remove() });
@@ -221,19 +223,24 @@ class MobileChatInputConfigPicker extends Disposable {
 	}
 
 	private _updateTrigger(): void {
-		if (!this._slotElement || !this._triggerElement) {
+		if (!this._slotElement || !this._triggerElement || !this._containerElement) {
 			return;
 		}
 
 		const ctx = this._getContext();
 		// Hide the chip when there's nothing to pick (no mode AND no
 		// models). In that state the toolbar is more compact rather than
-		// showing a no-op trigger.
+		// showing a no-op trigger. Also collapse the wrapping
+		// `.action-item` that `MenuWorkbenchToolBar` created — hiding
+		// only the inner slot leaves the wrapper occupying its
+		// `min-width` floor and produces a visible empty gap.
 		if (!ctx || (ctx.modeItems.length === 0 && ctx.modelItems.length === 0)) {
 			this._slotElement.style.display = 'none';
+			this._containerElement.style.display = 'none';
 			return;
 		}
 		this._slotElement.style.display = '';
+		this._containerElement.style.display = '';
 
 		// Auto-resolve the model: if the session has no explicit model
 		// selection yet, push the remembered model (or first available)

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/permissionPicker.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/permissionPicker.ts
@@ -136,7 +136,15 @@ export class PermissionPicker extends Disposable {
 		const isApplicable = this._delegate.isApplicable;
 		if (isApplicable) {
 			this._renderDisposables.add(autorun(reader => {
-				slot.style.display = isApplicable.read(reader) ? '' : 'none';
+				const visible = isApplicable.read(reader);
+				slot.style.display = visible ? '' : 'none';
+				// Also collapse the wrapping `.action-item` that
+				// `MenuWorkbenchToolBar` created for this picker — hiding only
+				// the inner slot leaves the wrapper occupying its `min-width`
+				// floor and produces a visible empty gap in the chip row when
+				// the picker isn't applicable to the active session (e.g.
+				// Claude agent host has no `autoApprove` in its schema).
+				container.style.display = visible ? '' : 'none';
 			}));
 		}
 


### PR DESCRIPTION
For an agent host session whose config schema omits a property (most visibly Claude, which only exposes `permissionMode` and `permissions`), the corresponding picker on the new-chat page leaves an empty `.sessions-chat-picker-slot` with `display: none`. The wrapping `.action-item` that `MenuWorkbenchToolBar` created keeps its `min-width: 30px` floor (from `chatWidget.css`), so the row reserves space and — since #315599 added dividers between adjacent action-items — the gap is also bordered, making it look like a discrete empty slot.

This affects three pickers, each of which already hides its own slot but not the surrounding wrapper:

- `PermissionPicker` (`Menus.NewSessionControl`) — `isApplicable` is false when the session has no `autoApprove`.
- `AgentHostSessionEnumPicker` (`Menus.NewSessionConfig`) — base class for `AgentHostModePicker` / `AgentHostClaudePermissionModePicker`; hides itself when the property isn't in the schema.
- `MobileChatInputConfigPicker` — hides itself when there are no modes and no models to pick.

Fix: each picker also collapses the wrapping container alongside the slot. This matches the pattern already used by `AgentHostPermissionPickerActionItem.render()`.

No new tests — existing picker tests render into a bare container; the behavior change is purely on the wrapper element that exists only when the picker is wired through `MenuWorkbenchToolBar`.
