### PR TITLE
sessions: scope chat "card style" to chat panel and chat editor only

### DIFF
--- a/src/vs/sessions/browser/media/style.css
+++ b/src/vs/sessions/browser/media/style.css
@@ -474,20 +474,26 @@
 	background: transparent !important;
 }
 
-/* Constrain content items to the same max-width, centered */
-.agent-sessions-workbench .interactive-session .interactive-item-container {
+/* Constrain content items to the same max-width, centered.
+ * Scoped to the chat panel (`.part.sessionspart`) and the chat editor host
+ * (`.chat-editor-relative`) so the "card style" doesn't leak into other chat
+ * surfaces that reuse `.interactive-item-container` — notably the terminal
+ * and editor inline chat widgets and the agent-session hover widget. */
+.agent-sessions-workbench .part.sessionspart .interactive-session .interactive-item-container,
+.agent-sessions-workbench .chat-editor-relative .interactive-session .interactive-item-container {
 	max-width: 950px;
 	margin: 0 auto;
-	padding-left: 12px !important;
-	padding-right: 12px !important;
+	padding-left: 12px;
+	padding-right: 12px;
 	box-sizing: border-box;
 }
 
-.agent-sessions-workbench .interactive-session > .chat-suggest-next-widget {
+.agent-sessions-workbench .part.sessionspart .interactive-session > .chat-suggest-next-widget,
+.agent-sessions-workbench .chat-editor-relative .interactive-session > .chat-suggest-next-widget {
 	max-width: 950px;
 	margin: 0 auto;
-	padding-left: 12px !important;
-	padding-right: 12px !important;
+	padding-left: 12px;
+	padding-right: 12px;
 	box-sizing: border-box;
 }
 
@@ -542,13 +548,17 @@
 	background-color: transparent !important;
 }
 
-.agent-sessions-workbench .interactive-session .interactive-input-part {
+/* Scoped to the chat panel (`.part.sessionspart`) and the chat editor host
+ * (`.chat-editor-relative`) to avoid leaking into other chat surfaces such as
+ * the inline chat widgets and agent-session hover widget. */
+.agent-sessions-workbench .part.sessionspart .interactive-session .interactive-input-part,
+.agent-sessions-workbench .chat-editor-relative .interactive-session .interactive-input-part {
 	width: 100%;
 	max-width: 950px;
-	margin: 0 auto !important;
-	display: inherit !important;
+	margin: 0 auto;
+	display: inherit;
 	/* Align with panel (terminal) card margin */
-	padding: 4px 10px !important;
+	padding: 4px 10px;
 	box-sizing: border-box;
 }
 


### PR DESCRIPTION
## Problem

In the Agents window, the terminal inline chat (`Ctrl/Cmd+I` in the terminal) was visually broken: chat content boxes were shifted right with a large empty area on the left and the right side overflowed past the terminal panel.

Root cause: three rules in `sessions/browser/media/style.css` targeted `.agent-sessions-workbench .interactive-session ...` (selectors `.interactive-item-container`, `> .chat-suggest-next-widget`, and `.interactive-input-part`) and applied a 950px-wide centered "card" layout. These rules were intended for the chat panel and chat editor surfaces, but they also matched every other chat surface that reuses the chat widget components — notably:

1. The terminal inline chat (visible bug in the screenshot).
2. The editor inline chat (`Ctrl/Cmd+I` in any editor open in the Agents window — the Agents window has a fully functional editor area).
3. The agent-session hover widget (`padding: 0` was being silently overridden by the rule's `!important` 12px padding).

### Before 

<img width="3024" height="1964" alt="CleanShot 2026-05-28 at 14 18 06@2x" src="https://github.com/user-attachments/assets/2478be8d-cd74-4cce-a6ce-0ca39887df92" />

### After

<img width="3024" height="1964" alt="CleanShot 2026-05-28 at 14 17 43@2x" src="https://github.com/user-attachments/assets/eddc43a0-6da8-497f-ab36-5c76ad54dd7b" />

## Fix

Narrow the three rules at the source to only target `.part.sessionspart` (chat panel — `sessionsPart.ts:109`) and `.chat-editor-relative` (chat editor host — `chatEditor.ts:97`).

Also dropped the now-unnecessary `!important` markers on padding/margin/display: with the narrowed scope there are no competing rules at the targeted selectors, so the markers were already redundant. (The `!important` on `background-color: transparent` for the inner monaco-editor inside `.interactive-input-part` is unchanged — that one really does need to override the editor's own background.)

## Verification

Verified via CDP-injected test DOM against the running Agents window. Computed styles after the fix:

| Surface | `max-width` | `margin` | Outcome |
|---|---|---|---|
| `.part.sessionspart` (chat panel) | `950px` | auto-centered | card layout preserved |
| `.chat-editor-relative` (chat editor) | `950px` | auto-centered | card layout preserved |
| `.terminal-inline-chat` (terminal inline chat) | `none` | `0` | fixed |
| `.zone-widget.inline-chat-widget` (editor inline chat) | `none` | `0` | fixed |
| `.agent-session-hover` (hover widget) | `none` | `0` | fixed |

## Notes for reviewers

- This was originally going to live as a defensive override in `workbench/contrib/terminalContrib/chat/browser/media/terminalChatWidget.css`, but two subagent reviewers flagged it as wrong-layer (inverts the workbench → sessions dependency) and as fixing only the symptom (the editor inline chat and hover widget have the same leak). Moving the fix to the source addresses all three surfaces in one change.
- The mobile/phone-layout rules at `mobileChatShell.css:248-256` already use `!important` to re-relax `max-width` on phone — those still work because phone's `.phone-layout` selectors have equal or higher specificity than the (now narrower) source rules.
- **Items within the input box are not vertically centered but that's outside the scope of this repo**