### PR TITLE
Update @vscode/codicons to version 0.0.46-14 and add cloudCompact icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@microsoft/mxc-sdk": "0.2.1",
         "@parcel/watcher": "^2.5.6",
         "@types/semver": "^7.5.8",
-        "@vscode/codicons": "^0.0.46-13",
+        "@vscode/codicons": "^0.0.46-14",
         "@vscode/copilot-api": "^0.4.1",
         "@vscode/deviceid": "^0.1.1",
         "@vscode/diff": "^0.0.2-0",
@@ -3521,9 +3521,9 @@
       }
     },
     "node_modules/@vscode/codicons": {
-      "version": "0.0.46-13",
-      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-13.tgz",
-      "integrity": "sha512-2nlRwaYDGiP19+GRPuoOx6DMDLBc35BsiLjCxKZPTNtHnS6rNpdm/Apa4HGt5+mFPB43nfxL2rcbAczso9KxQQ==",
+      "version": "0.0.46-14",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-14.tgz",
+      "integrity": "sha512-jeiVtypLqoytNMG62mvWDRFBx76lGiJDbuXVdnJJmZAZ9DVXbanTWlsyIvaAtoGhMMgONYYvZbdZfS90VMdr2Q==",
       "license": "CC-BY-4.0"
     },
     "node_modules/@vscode/component-explorer": {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@microsoft/mxc-sdk": "0.2.1",
     "@parcel/watcher": "^2.5.6",
     "@types/semver": "^7.5.8",
-    "@vscode/codicons": "^0.0.46-13",
+    "@vscode/codicons": "^0.0.46-14",
     "@vscode/copilot-api": "^0.4.1",
     "@vscode/deviceid": "^0.1.1",
     "@vscode/diff": "^0.0.2-0",

--- a/remote/web/package-lock.json
+++ b/remote/web/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
-        "@vscode/codicons": "^0.0.46-13",
+        "@vscode/codicons": "^0.0.46-14",
         "@vscode/iconv-lite-umd": "0.7.1",
         "@vscode/tree-sitter-wasm": "^0.3.1",
         "@vscode/vscode-languagedetection": "1.0.23",
@@ -73,9 +73,9 @@
       "integrity": "sha512-n1VPsljTSkthsAFYdiWfC+DKzK2WwcRp83Y1YAqdX552BstvsDjft9YXppjUzp11BPsapDoO1LDgrDB0XVsfNQ=="
     },
     "node_modules/@vscode/codicons": {
-      "version": "0.0.46-13",
-      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-13.tgz",
-      "integrity": "sha512-2nlRwaYDGiP19+GRPuoOx6DMDLBc35BsiLjCxKZPTNtHnS6rNpdm/Apa4HGt5+mFPB43nfxL2rcbAczso9KxQQ==",
+      "version": "0.0.46-14",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-14.tgz",
+      "integrity": "sha512-jeiVtypLqoytNMG62mvWDRFBx76lGiJDbuXVdnJJmZAZ9DVXbanTWlsyIvaAtoGhMMgONYYvZbdZfS90VMdr2Q==",
       "license": "CC-BY-4.0"
     },
     "node_modules/@vscode/iconv-lite-umd": {

--- a/remote/web/package.json
+++ b/remote/web/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",
-    "@vscode/codicons": "^0.0.46-13",
+    "@vscode/codicons": "^0.0.46-14",
     "@vscode/iconv-lite-umd": "0.7.1",
     "@vscode/tree-sitter-wasm": "^0.3.1",
     "@vscode/vscode-languagedetection": "1.0.23",

--- a/src/vs/base/common/codiconsLibrary.ts
+++ b/src/vs/base/common/codiconsLibrary.ts
@@ -714,4 +714,5 @@ export const codiconsLibrary = {
 	vmPending: register('vm-pending', 0xecbc),
 	worktreeCompact: register('worktree-compact', 0xecbd),
 	developerTools: register('developer-tools', 0xecbe),
+	cloudCompact: register('cloud-compact', 0xecbf),
 } as const;


### PR DESCRIPTION
Upgrade the @vscode/codicons package to the latest version and introduce a new icon, cloudCompact, to the codicons library. This enhances the icon set available for use.

