### PR TITLE
xtab: add PatchBased02 line-number variants and strategy-defaults map

### DIFF
--- a/extensions/copilot/src/extension/xtab/common/promptCrafting.ts
+++ b/extensions/copilot/src/extension/xtab/common/promptCrafting.ts
@@ -109,7 +109,9 @@ ${PromptTags.EDIT_HISTORY.end}`;
 		case PromptingStrategy.PatchBased01:
 			mainPrompt = basePrompt;
 			break;
-		case PromptingStrategy.PatchBased02: {
+		case PromptingStrategy.PatchBased02:
+		case PromptingStrategy.PatchBased02WithRecentLineNumbers:
+		case PromptingStrategy.PatchBased02WithoutRecentLineNumbers: {
 			const currentDocument = promptPieces.currentDocument;
 			const cursorLine = currentDocument.lineWithCursor();
 			const cursorLineWithTag = cursorLine.substring(0, currentDocument.cursorPosition.column - 1) + PromptTags.CURSOR + cursorLine.substring(currentDocument.cursorPosition.column - 1);
@@ -144,7 +146,9 @@ ${PromptTags.EDIT_HISTORY.end}`;
 	const includeBackticks = opts.promptingStrategy !== PromptingStrategy.Nes41Miniv3 &&
 		opts.promptingStrategy !== PromptingStrategy.Codexv21NesUnified &&
 		opts.promptingStrategy !== PromptingStrategy.PatchBased01 &&
-		opts.promptingStrategy !== PromptingStrategy.PatchBased02;
+		opts.promptingStrategy !== PromptingStrategy.PatchBased02 &&
+		opts.promptingStrategy !== PromptingStrategy.PatchBased02WithRecentLineNumbers &&
+		opts.promptingStrategy !== PromptingStrategy.PatchBased02WithoutRecentLineNumbers;
 
 	const packagedPrompt = includeBackticks ? wrapInBackticks(mainPrompt) : mainPrompt;
 	const packagedPromptWithRelatedInfo = addRelatedInformation(relatedInformation, packagedPrompt, opts.languageContext.traitPosition);
@@ -331,6 +335,8 @@ function getPostScript(strategy: PromptingStrategy | undefined, currentFilePath:
 		case PromptingStrategy.Codexv21NesUnified:
 			break;
 		case PromptingStrategy.PatchBased02:
+		case PromptingStrategy.PatchBased02WithRecentLineNumbers:
+		case PromptingStrategy.PatchBased02WithoutRecentLineNumbers:
 			postScript = `The developer was working on a section of code within the \`current_file_content\` - carefully note their \`cursor_location\` marked with \`<|cursor|>\`. Using the given \`recently_viewed_code_snippets\`, \`current_file_content\`, \`edit_diff_history\`, and \`cursor_location\`, please continue the developer's work. Output a modified diff format with a sequence of intuitive next changes, where each patch must start with \`<filename>:<line number>\`. Order changes by priority and flow; for instance, edits adjacent to the user's cursor should always be prioritized, followed by lines near the cursor, followed by lines farther away. If there are no good edit candidates, output the empty string "". Avoid undoing or reverting the developer's last change unless there are obvious typos or errors. Adhere meticulously to the diff format.`;
 			break;
 		case PromptingStrategy.UnifiedModel:

--- a/extensions/copilot/src/extension/xtab/node/xtabProvider.ts
+++ b/extensions/copilot/src/extension/xtab/node/xtabProvider.ts
@@ -1451,10 +1451,7 @@ export class XtabProvider implements IStatelessNextEditProvider {
 		};
 
 		const selectedModelConfig = this.modelService.selectedModelConfiguration();
-		// proxy /models doesn't know about includeTagsInCurrentFile field as of now, so hard code it to true for CopilotNesXtab strategy
-		const modelConfig: xtabPromptOptions.ModelConfiguration = selectedModelConfig.promptingStrategy === xtabPromptOptions.PromptingStrategy.CopilotNesXtab
-			? { ...selectedModelConfig, includeTagsInCurrentFile: true }
-			: selectedModelConfig;
+		const modelConfig = xtabPromptOptions.applyStrategyConfig(selectedModelConfig);
 		return {
 			promptOptions: overrideModelConfig(sourcedModelConfig, modelConfig),
 			modelServiceConfig: modelConfig
@@ -1654,6 +1651,8 @@ export function pickSystemPrompt(promptingStrategy: xtabPromptOptions.PromptingS
 		case xtabPromptOptions.PromptingStrategy.PatchBased:
 		case xtabPromptOptions.PromptingStrategy.PatchBased01:
 		case xtabPromptOptions.PromptingStrategy.PatchBased02:
+		case xtabPromptOptions.PromptingStrategy.PatchBased02WithRecentLineNumbers:
+		case xtabPromptOptions.PromptingStrategy.PatchBased02WithoutRecentLineNumbers:
 		case xtabPromptOptions.PromptingStrategy.Xtab275:
 		case xtabPromptOptions.PromptingStrategy.XtabAggressiveness:
 		case xtabPromptOptions.PromptingStrategy.Xtab275Aggressiveness:

--- a/extensions/copilot/src/extension/xtab/test/node/xtabProvider.spec.ts
+++ b/extensions/copilot/src/extension/xtab/test/node/xtabProvider.spec.ts
@@ -162,6 +162,8 @@ describe('pickSystemPrompt', () => {
 		PromptingStrategy.PatchBased,
 		PromptingStrategy.PatchBased01,
 		PromptingStrategy.PatchBased02,
+		PromptingStrategy.PatchBased02WithRecentLineNumbers,
+		PromptingStrategy.PatchBased02WithoutRecentLineNumbers,
 		PromptingStrategy.Xtab275,
 		PromptingStrategy.XtabAggressiveness,
 		PromptingStrategy.Xtab275Aggressiveness,

--- a/extensions/copilot/src/platform/inlineEdits/common/dataTypes/xtabPromptOptions.ts
+++ b/extensions/copilot/src/platform/inlineEdits/common/dataTypes/xtabPromptOptions.ts
@@ -343,6 +343,10 @@ export enum PromptingStrategy {
 	PatchBased = 'patchBased',
 	PatchBased01 = 'patchBased01',
 	PatchBased02 = 'patchBased02',
+	/** PatchBased02 variant: line numbers on recent docs. */
+	PatchBased02WithRecentLineNumbers = 'patchBased02WithRecentLineNumbers',
+	/** PatchBased02 variant: no line numbers on recent docs. */
+	PatchBased02WithoutRecentLineNumbers = 'patchBased02WithoutRecentLineNumbers',
 	/**
 	 * Xtab275-based strategy with edit intent tag parsing.
 	 * Response format: <|edit_intent|>low|medium|high|no_edit<|/edit_intent|>
@@ -393,6 +397,8 @@ export namespace ResponseFormat {
 			case PromptingStrategy.PatchBased:
 			case PromptingStrategy.PatchBased01:
 			case PromptingStrategy.PatchBased02:
+			case PromptingStrategy.PatchBased02WithRecentLineNumbers:
+			case PromptingStrategy.PatchBased02WithoutRecentLineNumbers:
 				return ResponseFormat.CustomDiffPatch;
 			case PromptingStrategy.Xtab275EditIntent:
 				return ResponseFormat.EditWindowWithEditIntent;
@@ -471,6 +477,49 @@ export interface ModelConfiguration {
 	recentlyViewedDocuments?: Partial<RecentlyViewedDocumentsOptions>;
 	lintOptions: Partial<LintOptions> | undefined;
 	supportsNextCursorLinePrediction?: boolean;
+}
+
+/**
+ * Per-strategy configuration baked into the strategy itself. When a strategy
+ * declares values here, those values override anything provided by the upstream
+ * model configuration. A strategy without an entry contributes no overrides.
+ */
+const STRATEGY_CONFIG: Partial<Record<PromptingStrategy, Partial<ModelConfiguration>>> = {
+	// proxy /models doesn't know about includeTagsInCurrentFile field as of now, so hard-code it for CopilotNesXtab
+	[PromptingStrategy.CopilotNesXtab]: {
+		includeTagsInCurrentFile: true,
+	},
+	[PromptingStrategy.PatchBased02WithRecentLineNumbers]: {
+		includeTagsInCurrentFile: false,
+		includePostScript: true,
+		currentFile: { includeLineNumbers: IncludeLineNumbersOption.WithoutSpace },
+		recentlyViewedDocuments: { includeLineNumbers: IncludeLineNumbersOption.WithoutSpace },
+		supportsNextCursorLinePrediction: false,
+	},
+	[PromptingStrategy.PatchBased02WithoutRecentLineNumbers]: {
+		includeTagsInCurrentFile: false,
+		includePostScript: true,
+		currentFile: { includeLineNumbers: IncludeLineNumbersOption.WithoutSpace },
+		recentlyViewedDocuments: { includeLineNumbers: IncludeLineNumbersOption.None },
+		supportsNextCursorLinePrediction: false,
+	},
+};
+
+/** Apply per-strategy baked-in config; strategy values override `config`. */
+export function applyStrategyConfig(config: ModelConfiguration): ModelConfiguration {
+	const overrides = config.promptingStrategy === undefined ? undefined : STRATEGY_CONFIG[config.promptingStrategy];
+	if (!overrides) {
+		return config;
+	}
+	return {
+		...config,
+		...overrides,
+		currentFile: { ...config.currentFile, ...overrides.currentFile },
+		recentlyViewedDocuments: { ...config.recentlyViewedDocuments, ...overrides.recentlyViewedDocuments },
+		lintOptions: config.lintOptions || overrides.lintOptions
+			? { ...config.lintOptions, ...overrides.lintOptions }
+			: undefined,
+	};
 }
 
 export const LINT_OPTIONS_VALIDATOR: IValidator<Partial<LintOptions>> = vObj({

--- a/extensions/copilot/src/platform/inlineEdits/common/dataTypes/xtabPromptOptions.ts
+++ b/extensions/copilot/src/platform/inlineEdits/common/dataTypes/xtabPromptOptions.ts
@@ -511,14 +511,15 @@ export function applyStrategyConfig(config: ModelConfiguration): ModelConfigurat
 	if (!overrides) {
 		return config;
 	}
+	const hasCurrentFile = config.currentFile !== undefined || overrides.currentFile !== undefined;
+	const hasRecentlyViewed = config.recentlyViewedDocuments !== undefined || overrides.recentlyViewedDocuments !== undefined;
+	const hasLintOptions = config.lintOptions !== undefined || overrides.lintOptions !== undefined;
 	return {
 		...config,
 		...overrides,
-		currentFile: { ...config.currentFile, ...overrides.currentFile },
-		recentlyViewedDocuments: { ...config.recentlyViewedDocuments, ...overrides.recentlyViewedDocuments },
-		lintOptions: config.lintOptions || overrides.lintOptions
-			? { ...config.lintOptions, ...overrides.lintOptions }
-			: undefined,
+		currentFile: hasCurrentFile ? { ...config.currentFile, ...overrides.currentFile } : undefined,
+		recentlyViewedDocuments: hasRecentlyViewed ? { ...config.recentlyViewedDocuments, ...overrides.recentlyViewedDocuments } : undefined,
+		lintOptions: hasLintOptions ? { ...config.lintOptions, ...overrides.lintOptions } : undefined,
 	};
 }
 

--- a/extensions/copilot/src/platform/inlineEdits/test/common/xtabPromptOptions.spec.ts
+++ b/extensions/copilot/src/platform/inlineEdits/test/common/xtabPromptOptions.spec.ts
@@ -1,0 +1,75 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it } from 'vitest';
+import { applyStrategyConfig, IncludeLineNumbersOption, ModelConfiguration, PromptingStrategy } from '../../common/dataTypes/xtabPromptOptions';
+
+function baseConfig(overrides: Partial<ModelConfiguration> = {}): ModelConfiguration {
+	return {
+		modelName: 'test-model',
+		promptingStrategy: undefined,
+		includeTagsInCurrentFile: true,
+		lintOptions: undefined,
+		...overrides,
+	};
+}
+
+describe('applyStrategyConfig', () => {
+
+	it('returns config unchanged when strategy has no entry', () => {
+		const config = baseConfig({ promptingStrategy: PromptingStrategy.Xtab275 });
+		expect(applyStrategyConfig(config)).toBe(config);
+	});
+
+	it('returns config unchanged when strategy is undefined', () => {
+		const config = baseConfig();
+		expect(applyStrategyConfig(config)).toBe(config);
+	});
+
+	it('forces includeTagsInCurrentFile=true for CopilotNesXtab', () => {
+		const result = applyStrategyConfig(baseConfig({
+			promptingStrategy: PromptingStrategy.CopilotNesXtab,
+			includeTagsInCurrentFile: false,
+		}));
+		expect(result.includeTagsInCurrentFile).toBe(true);
+	});
+
+	it('forces baked-in fields for PatchBased02WithRecentLineNumbers', () => {
+		const result = applyStrategyConfig(baseConfig({
+			promptingStrategy: PromptingStrategy.PatchBased02WithRecentLineNumbers,
+			includeTagsInCurrentFile: true,
+			includePostScript: false,
+			currentFile: { includeLineNumbers: IncludeLineNumbersOption.None, maxTokens: 42 },
+			recentlyViewedDocuments: { includeLineNumbers: IncludeLineNumbersOption.None, maxTokens: 99 },
+			supportsNextCursorLinePrediction: true,
+		}));
+		expect(result).toMatchObject({
+			includeTagsInCurrentFile: false,
+			includePostScript: true,
+			currentFile: { includeLineNumbers: IncludeLineNumbersOption.WithoutSpace, maxTokens: 42 },
+			recentlyViewedDocuments: { includeLineNumbers: IncludeLineNumbersOption.WithoutSpace, maxTokens: 99 },
+			supportsNextCursorLinePrediction: false,
+		});
+	});
+
+	it('forces recentlyViewedDocuments.includeLineNumbers=None for PatchBased02WithoutRecentLineNumbers', () => {
+		const result = applyStrategyConfig(baseConfig({
+			promptingStrategy: PromptingStrategy.PatchBased02WithoutRecentLineNumbers,
+			recentlyViewedDocuments: { includeLineNumbers: IncludeLineNumbersOption.WithSpaceAfter },
+		}));
+		expect(result.recentlyViewedDocuments?.includeLineNumbers).toBe(IncludeLineNumbersOption.None);
+		expect(result.currentFile?.includeLineNumbers).toBe(IncludeLineNumbersOption.WithoutSpace);
+	});
+
+	it('preserves undefined for option bags neither side specifies', () => {
+		const result = applyStrategyConfig(baseConfig({
+			promptingStrategy: PromptingStrategy.CopilotNesXtab,
+		}));
+		// CopilotNesXtab only sets includeTagsInCurrentFile; nested option bags should stay undefined.
+		expect(result.currentFile).toBeUndefined();
+		expect(result.recentlyViewedDocuments).toBeUndefined();
+		expect(result.lintOptions).toBeUndefined();
+	});
+});


### PR DESCRIPTION
Introduce two new prompting strategies that bake their configuration into
the strategy itself:

- PatchBased02WithRecentLineNumbers
- PatchBased02WithoutRecentLineNumbers

Both share the PatchBased02 prompt/response format with currentFile line
numbers in 'withoutSpaceAfter' style, no current-file tags, postscript
enabled, and next-cursor-line prediction disabled. They differ only in
whether recently-viewed documents include line numbers.

Add a STRATEGY_CONFIG map and applyStrategyConfig() helper that overlay
strategy-specific defaults onto the upstream model configuration. Fold
the existing CopilotNesXtab includeTagsInCurrentFile hack into this map
so there is a single source of truth for per-strategy baked-in defaults.


fixes https://github.com/microsoft/vscode-internalbacklog/issues/7826