### PR TITLE
agents: fix Mark as Done on cancelled new chat session

### DIFF
--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -1581,34 +1581,38 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 	// -- Session Actions --
 
 	async archiveSession(sessionId: string): Promise<void> {
-		const agentSession = this._findAgentSession(sessionId);
-		if (agentSession) {
-			agentSession.setArchived(true);
-			return;
-		}
-
-		// Temp session that hasn't been committed — archive it in-place
-		// so the user can still review whatever content was produced.
+		// Uncommitted (NEW) sessions — including those that were cancelled mid-flight —
+		// must be archived via their chat-adapter directly. Their agent-host entry
+		// (if any, from `getOrCreateChatSession`) has providerType `Local`, which
+		// is filtered out by `_refreshSessionCache`, so changes made through
+		// `agentSession.setArchived(true)` would never propagate to the chat
+		// adapter's `_isArchived` observable. The result would be a no-op tick
+		// in the UI even though the agent-host model thinks the session is archived.
 		const chatSession = this._findChatSession(sessionId);
 		if (chatSession && isNewSession(chatSession)) {
 			chatSession.setArchived(true);
 			this._onDidChangeSessions.fire({ added: [], removed: [], changed: [this._chatToSession(chatSession)] });
 			return;
 		}
+
+		const agentSession = this._findAgentSession(sessionId);
+		if (agentSession) {
+			agentSession.setArchived(true);
+		}
 	}
 
 	async unarchiveSession(sessionId: string): Promise<void> {
-		const agentSession = this._findAgentSession(sessionId);
-		if (agentSession) {
-			agentSession.setArchived(false);
-			return;
-		}
-
-		// Temp session that hasn't been committed — unarchive it in-place
+		// See `archiveSession` for why NEW sessions take a separate path.
 		const chatSession = this._findChatSession(sessionId);
 		if (chatSession && isNewSession(chatSession)) {
 			chatSession.setArchived(false);
 			this._onDidChangeSessions.fire({ added: [], removed: [], changed: [this._chatToSession(chatSession)] });
+			return;
+		}
+
+		const agentSession = this._findAgentSession(sessionId);
+		if (agentSession) {
+			agentSession.setArchived(false);
 		}
 	}
 


### PR DESCRIPTION
Fixes #318550.

## Problem

When the user starts a new chat in the Agents window, cancels the response mid-flight, then clicks **Mark as Done** on the session, the click is a no-op: the session stays in the active list and the UI never refreshes.

## Root cause

`CopilotChatSessionsProvider.archiveSession` tried the agent-host lookup (`_findAgentSession`) first. For untitled sessions started via the chat view, an entry already exists in the agent-host model — it was registered by `getOrCreateChatSession` during the first chat send — but with providerType `Local`.

That providerType is filtered out by `_refreshSessionCache`, so calling `agentSession.setArchived(true)` updates the agent-host model in isolation and never propagates to the chat adapter's `_isArchived` observable that the UI is bound to.

## Fix

Reorder the logic in both `archiveSession` and `unarchiveSession`:

1. Check the chat adapter first. If it is a NEW (uncommitted) session, archive it via the chat adapter and fire `onDidChangeSessions` so the UI updates immediately.
2. Only fall back to the agent-host path for committed sessions (where `AgentSessionAdapter` is the chat adapter and `_refreshSessionCache` does propagate the change).

## Verification

Reproduced the bug in a local Code OSS dev build:

1. Sent a `sleep 90` query
2. Cancelled it mid-flight
3. Clicked **Mark as Done**

Before the fix: session stayed in the active list. After the fix: session is archived correctly and disappears from the active list.