### PR TITLE
Fix terminal-editor shift-drop firing on detached instances

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -1047,6 +1047,8 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 	detachFromElement(): void {
 		this._wrapperElement.remove();
 		this._container = undefined;
+		// Stop listening on the old container so drops there don't reach this instance after another terminal attaches.
+		this._dndObserver.clear();
 	}
 
 	attachToElement(container: HTMLElement): void {


### PR DESCRIPTION
## Summary

Fixes #311164.

`TerminalInstance._dndObserver` (a `MutableDisposable<IDisposable>` holding the per-container `DragAndDropObserver`) was set by `_initDragAndDrop` but never cleared by `detachFromElement`. Because a `TerminalEditor` pane reuses its `_overflowGuardElement` across tab switches (`setInput` calls `detachFromElement` on the old instance and `attachToElement` on the new one against the same container — see `terminalEditor.ts:77-80`), each newly-attached terminal stacked another `DragAndDropObserver` on top of the leaked ones.

When the user shift-dropped a file onto the active editor-area terminal, the `EditorDropTarget` overlay correctly disposed itself in dragover (so the path was not opened as an editor), and the drop bubbled to the shared container — where every previously-attached terminal's observer fired and called `sendPath`, inserting the path into all of them.

Disposing the observer on detach removes the listeners from the prior container, so only the currently-attached instance receives the drop.

## Test plan

- [x] Build dev VS Code (`./scripts/code.sh`)
- [x] Open two terminals in the editor area (same pane)
- [x] Confirm they have different shell PIDs (`echo $$`)
- [x] Drag a file from the Explorer onto the active terminal with Shift held — path appears in the active terminal only
- [x] Switch to the other tab — no path inserted there
- [x] Without Shift, drag still opens the file in the editor (unchanged behavior)