### PR TITLE
fix(claude): avoid false error log on stale model refresh failure

### DIFF
--- a/src/vs/platform/agentHost/node/claude/claudeAgent.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgent.ts
@@ -317,9 +317,14 @@ export class ClaudeAgent extends Disposable implements IAgent {
 				.map(m => toAgentModelInfo(m, this.id));
 			this._models.set(filtered, undefined);
 		} catch (err) {
-			this._logService.error(err, '[Claude] Failed to refresh models');
 			if (this._githubToken === tokenAtStart) {
+				// Failure is for the current token — surface it and clear stale models.
+				this._logService.error(err, '[Claude] Failed to refresh models');
 				this._models.set([], undefined);
+			} else {
+				// Failure is for a superseded token; the newer refresh has already
+				// published the right model list, so this error is benign.
+				this._logService.debug('[Claude] Stale model refresh failed; a newer refresh is active');
 			}
 		}
 	}


### PR DESCRIPTION
When authenticate() rotates the GitHub token, a new _refreshModels()
call is fired. If the previous (now-superseded) refresh completes with
an error after the token has already changed, the catch block was 
unconditionally logging at error level — even though the model list
published by the newer refresh is correct and the user is unaffected.
 
Move the stale-write guard (this._githubToken === tokenAtStart) to wrap
both the error log and the models.set() clear, so only failures for the
current token surface as errors. Superseded refresh failures are
downgraded to debug level to avoid false alarms during normal token
rotation.

