### PR TITLE
fix(server): robustly parse OS_ID from /etc/os-release

### DIFF
--- a/resources/server/bin/helpers/check-requirements-linux.sh
+++ b/resources/server/bin/helpers/check-requirements-linux.sh
@@ -30,7 +30,7 @@ MIN_GLIBCXX_VERSION="3.4.25"
 
 # Extract the ID value from /etc/os-release
 if [ -f /etc/os-release ]; then
-    OS_ID="$(cat /etc/os-release | grep -Eo 'ID=([^"]+)' | sed -n '1s/ID=//p')"
+    OS_ID=$(source /etc/os-release && echo "$ID")
     if [ "$OS_ID" = "nixos" ]; then
         echo "Warning: NixOS detected, skipping GLIBC check"
         exit 0


### PR DESCRIPTION
Fixes #232159

The previous grep-based parser failed when `ID` was quoted, e.g.
`ID=\"rocky\"` on Rocky Linux 8.5, leaving `OS_ID` empty and causing
the script to exit with code 1.

Sourcing `/etc/os-release` in a subshell and echoing `$ID` handles
both quoted and unquoted values correctly. This approach also aligns
with the format specification for `os-release` files.