### PR TITLE
Split TerminalInstance.onDisposed: add onWillDispose for pre-xterm cleanup

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -961,6 +961,15 @@ export interface ITerminalInstance extends IBaseTerminalInstance {
 	readonly onIconChanged: Event<{ instance: ITerminalInstance; userInitiated: boolean }>;
 
 	/**
+	 * An event that fires just before the terminal instance is disposed, while
+	 * `xterm.js` and other instance-owned resources are still alive. Subscribe
+	 * here if you need to clean up state that depends on those resources (e.g.
+	 * xterm.js addons). For "the instance is gone" notifications, use
+	 * {@link onDisposed} instead.
+	 */
+	readonly onWillDispose: Event<ITerminalInstance>;
+
+	/**
 	 * An event that fires when the terminal instance is disposed.
 	 */
 	readonly onDisposed: Event<ITerminalInstance>;

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -319,6 +319,8 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 	// itself is disposed
 	private readonly _onExit = new Emitter<number | ITerminalLaunchError | undefined>();
 	readonly onExit = this._onExit.event;
+	private readonly _onWillDispose = this._register(new Emitter<ITerminalInstance>());
+	readonly onWillDispose = this._onWillDispose.event;
 	private readonly _onDisposed = this._register(new Emitter<ITerminalInstance>());
 	readonly onDisposed = this._onDisposed.event;
 	private readonly _onProcessIdReady = this._register(new Emitter<ITerminalInstance>());
@@ -654,7 +656,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 					contribution.xtermReady?.(xterm);
 				}
 			});
-			this._register(this.onDisposed(() => {
+			this._register(this.onWillDispose(() => {
 				contribution.dispose();
 				this._contributions.delete(desc.id);
 			}));
@@ -1324,12 +1326,12 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		// hasn't happened yet
 		this._onProcessExit(undefined);
 
-		// Fire onDisposed before disposing xterm so that contributions can clean
+		// Fire onWillDispose before disposing xterm so that contributions can clean
 		// up their xterm addons while the raw terminal is still alive. Disposing
 		// xterm first would cause AddonManager to remove addons from its list,
 		// and subsequent contribution disposal would fail with "Could not dispose
 		// an addon that has not been loaded".
-		this._onDisposed.fire(this);
+		this._onWillDispose.fire(this);
 
 		try {
 			this.xterm?.dispose();
@@ -1346,6 +1348,11 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 			this._terminalHasTextContextKey.reset();
 			this._onDidBlur.fire(this);
 		}
+
+		// Fire onDisposed only after xterm and any side-effects of its teardown
+		// (e.g. Firefox blur fallback) have run, so subscribers observe a fully
+		// disposed instance.
+		this._onDisposed.fire(this);
 
 		super.dispose();
 	}

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -1307,25 +1307,6 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 			this._horizontalScrollbar = undefined;
 		}
 
-		if (this._pressAnyKeyToCloseListener) {
-			this._pressAnyKeyToCloseListener.dispose();
-			this._pressAnyKeyToCloseListener = undefined;
-		}
-
-		if (this._exitReason === undefined) {
-			this._exitReason = reason ?? TerminalExitReason.Unknown;
-		}
-
-		// Dispose the resize debouncer before the process manager so that no
-		// resize callbacks can fire after ptyProcessReady has been nulled.
-		this._resizeDebouncer?.dispose();
-		this._resizeDebouncer = undefined;
-
-		this._processManager.dispose();
-		// Process manager dispose/shutdown doesn't fire process exit, trigger with undefined if it
-		// hasn't happened yet
-		this._onProcessExit(undefined);
-
 		// Fire onWillDispose before disposing xterm so that contributions can clean
 		// up their xterm addons while the raw terminal is still alive. Disposing
 		// xterm first would cause AddonManager to remove addons from its list,
@@ -1348,6 +1329,25 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 			this._terminalHasTextContextKey.reset();
 			this._onDidBlur.fire(this);
 		}
+
+		if (this._pressAnyKeyToCloseListener) {
+			this._pressAnyKeyToCloseListener.dispose();
+			this._pressAnyKeyToCloseListener = undefined;
+		}
+
+		if (this._exitReason === undefined) {
+			this._exitReason = reason ?? TerminalExitReason.Unknown;
+		}
+
+		// Dispose the resize debouncer before the process manager so that no
+		// resize callbacks can fire after ptyProcessReady has been nulled.
+		this._resizeDebouncer?.dispose();
+		this._resizeDebouncer = undefined;
+
+		this._processManager.dispose();
+		// Process manager dispose/shutdown doesn't fire process exit, trigger with undefined if it
+		// hasn't happened yet
+		this._onProcessExit(undefined);
 
 		// Fire onDisposed only after xterm and any side-effects of its teardown
 		// (e.g. Firefox blur fallback) have run, so subscribers observe a fully

--- a/src/vs/workbench/contrib/terminal/test/browser/terminalInstance.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/terminalInstance.test.ts
@@ -221,6 +221,20 @@ suite('Workbench - TerminalInstance', () => {
 			strictEqual(instance.shellType, PosixShellType.Zsh);
 		});
 
+		test('should fire onWillDispose before xterm disposal and onDisposed after disposal', async () => {
+			const instance = await createTerminalInstance();
+			const xterm = await instance.xtermReadyPromise;
+			const disposalOrder: string[] = [];
+
+			store.add(instance.onWillDispose(() => disposalOrder.push('onWillDispose')));
+			store.add(xterm!.onDidDispose(() => disposalOrder.push('xterm')));
+			store.add(instance.onDisposed(() => disposalOrder.push('onDisposed')));
+
+			instance.dispose();
+
+			deepStrictEqual(disposalOrder, ['onWillDispose', 'xterm', 'onDisposed']);
+		});
+
 		test('custom key event handler should handle commands in DEFAULT_COMMANDS_TO_SKIP_SHELL in VS Code and not xterm when sendKeybindingsToShell is disabled', async () => {
 			const instance = await createTerminalInstance();
 			const keybindingService = instance['_keybindingService'];


### PR DESCRIPTION
## What

Split `TerminalInstance.onDisposed` into two events:

- **`onWillDispose`** — fires before `xterm.dispose()`, while xterm and other instance-owned resources are still alive.
- **`onDisposed`** — fires after xterm has been disposed and the Firefox blur fallback has run. Original "instance is fully gone" semantics restored.

Contribution disposal (the only consumer that needed the early hook) is moved to `onWillDispose`.

## Why

PR #315737 fixed [#315722](https://github.com/microsoft/vscode/issues/315722) ("Could not dispose an addon that has not been loaded") by reordering `dispose()` so that `_onDisposed.fire()` ran *before* `xterm.dispose()`. That kept xterm's `AddonManager` alive long enough for contributions to dispose their addons cleanly.

But it changed the meaning of `onDisposed` for every other subscriber. As Daniel pointed out in review:

> `onDisposed` should fire when the instance is actually disposed (or as close to it as possible, ie. xterm.js is disposed as well). Splitting out a separate event for something like this (`onWillDispose`, `onWillDisposeXterm`?) would be better. How are you sure that this doesn't introduce other regressions by having `onDisposed` fire before xterm.js is disposed now?

External subscribers — `TerminalEditorInput`, `TerminalEditorService`, `TerminalGroup`, `TerminalGroupService`, `AgentHostTerminalService` — all use `onDisposed` to mean "the instance is gone." Firing it mid-teardown silently violates that contract.

Splitting the event addresses both concerns:
- Contributions get an explicit "clean up xterm-owned state now" hook.
- `onDisposed` keeps its original meaning for everyone else.

## Changes

`terminal.ts`:
- Add `onWillDispose: Event<ITerminalInstance>` to the `ITerminalInstance` interface, documented as "for cleanup that depends on xterm being alive."

`terminalInstance.ts`:
- Add `_onWillDispose` emitter and expose as `onWillDispose`.
- Move the contribution-disposal subscription from `this.onDisposed(...)` to `this.onWillDispose(...)`.
- In `dispose()`:
  - Fire `_onWillDispose` before `xterm.dispose()` (replaces the previous `_onDisposed.fire()` at that position).
  - Fire `_onDisposed` after the Firefox blur fallback, immediately before `super.dispose()`.

## How to test

1. Open a terminal and run a task that creates one (so contributions register addons).
2. Terminate the task / kill the terminal.
3. Verify no `Could not dispose an addon that has not been loaded` errors in DevTools console (the original #315722 fix is preserved).
4. Telemetry: bucket `b48dea42-c9c8-17be-22a3-9003b11af322` should stay at zero.

## Risk

- **Behavioral change for direct `onDisposed` subscribers**: the event now fires *later* than it did between PR #315737 and this PR — i.e. it fires when the instance is truly gone, as it did before #315737. All current callers (`TerminalEditorInput`, `TerminalEditorService`, `TerminalGroup`, `TerminalGroupService`, `AgentHostTerminalService`) treat `onDisposed` as "instance is gone," so this is the desired contract; they observed an unintended early-fire between #315737 and now.
- **New event surface**: `onWillDispose` is additive; only the in-class contribution subscription consumes it. No external code depends on it yet.
- No test changes; the disposal-ordering race is timing-dependent and verified via telemetry.

Refs #315722, #315737.
