### PR TITLE
Restore editor.quickSuggestions.other default to 'on'

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -3764,7 +3764,7 @@ class EditorQuickSuggestions extends BaseEditorOption<EditorOption.quickSuggesti
 
 	constructor() {
 		const defaults: InternalQuickSuggestionsOptions = {
-			other: 'offWhenInlineCompletions',
+			other: 'on',
 			comments: 'off',
 			strings: 'off'
 		};

--- a/src/vs/editor/contrib/inlineCompletions/test/browser/suggestWidgetModel.test.ts
+++ b/src/vs/editor/contrib/inlineCompletions/test/browser/suggestWidgetModel.test.ts
@@ -88,7 +88,7 @@ suite('Suggest Widget Model', () => {
 
 	test('Ghost Text', async () => {
 		await withAsyncTestCodeEditorAndInlineCompletionsModel('',
-			{ fakeClock: true, provider, suggest: { preview: true }, quickSuggestions: { other: 'on', comments: 'off', strings: 'off' } },
+			{ fakeClock: true, provider, suggest: { preview: true } },
 			async ({ editor, editorViewModel, context, model }) => {
 				context.keyboardType('h');
 				const suggestController = (editor.getContribution(SuggestController.ID) as SuggestController);

--- a/src/vs/editor/test/browser/config/editorConfiguration.test.ts
+++ b/src/vs/editor/test/browser/config/editorConfiguration.test.ts
@@ -232,7 +232,7 @@ suite('Common Editor Config', () => {
 		const config = new TestConfiguration({ quickSuggestions: null! });
 		const actual = <Readonly<Required<IQuickSuggestionsOptions>>>config.options.get(EditorOption.quickSuggestions);
 		assert.deepStrictEqual(actual, {
-			other: 'offWhenInlineCompletions',
+			other: 'on',
 			comments: 'off',
 			strings: 'off'
 		});
@@ -244,9 +244,20 @@ suite('Common Editor Config', () => {
 		config.updateOptions({ quickSuggestions: { strings: true } });
 		const actual = <Readonly<Required<IQuickSuggestionsOptions>>>config.options.get(EditorOption.quickSuggestions);
 		assert.deepStrictEqual(actual, {
-			other: 'offWhenInlineCompletions',
+			other: 'on',
 			comments: 'off',
 			strings: 'on'
+		});
+		config.dispose();
+	});
+
+	test('issue #318549: quickSuggestions.other defaults to "on" so snippet completions are not suppressed by inline completions', () => {
+		const config = new TestConfiguration({});
+		const actual = <Readonly<Required<IQuickSuggestionsOptions>>>config.options.get(EditorOption.quickSuggestions);
+		assert.deepStrictEqual(actual, {
+			other: 'on',
+			comments: 'off',
+			strings: 'off'
 		});
 		config.dispose();
 	});


### PR DESCRIPTION
## Summary

Restores the default of `editor.quickSuggestions.other` to `'on'`, reverting the default change introduced in [#316900](https://github.com/microsoft/vscode/pull/316900) (commit ef680109cc3) which set it to `'offWhenInlineCompletions'`.

## Regression

With Copilot inline completions enabled (the case for the vast majority of users), `'offWhenInlineCompletions'` suppresses the suggest widget almost permanently. As a result, the following stop working until users discover and override the setting manually:

- Snippet completions (user, workspace, language-defined)
- IntelliSense word-character triggers
- Emmet abbreviation expansion
- IME composition flows (long-lived ghost text blocks the IME)

The `offWhenInlineCompletions` value remains available as an opt-in.

## Test

Added a regression test in [editorConfiguration.test.ts](https://github.com/microsoft/vscode/blob/main/src/vs/editor/test/browser/config/editorConfiguration.test.ts) that asserts the default for `quickSuggestions.other` is `'on'`. Verified the test fails before the production change and passes after. Reverted the override added to the `Ghost Text` test in `suggestWidgetModel.test.ts` since it is no longer needed.

## Fixes

Fixes #317916
Fixes #318380
Fixes #318549
Fixes #318735
Fixes #318522
Fixes #317863
Fixes #318694
Fixes #314220
