### PR TITLE
Improve install extension failure diagnostics in sanity test

### DIFF
--- a/test/sanity/src/uiTest.ts
+++ b/test/sanity/src/uiTest.ts
@@ -207,6 +207,7 @@ export class UITest {
 
 		await extensionItem.waitFor();
 
+		let lastFailure: string | undefined;
 		for (let attempt = 0; attempt < 3; attempt++) {
 			try {
 				this.context.log(`Clicking Install on the first extension in the list (attempt ${attempt + 1}/3)`);
@@ -219,14 +220,28 @@ export class UITest {
 				if (installed) {
 					return;
 				}
+				lastFailure = 'Uninstall button did not appear within 5 minutes';
 			} catch (error) {
-				this.context.log(`Extension install attempt ${attempt + 1}/3 failed: ${error instanceof Error ? error.message : String(error)}`);
+				lastFailure = error instanceof Error ? error.message : String(error);
 			}
 
-			this.context.log('Extension install may have failed, retrying');
+			this.context.log(`Extension install attempt ${attempt + 1}/3 failed: ${lastFailure}`);
+
+			const messageVisible = await messageContainer.isVisible().catch(() => false);
+			if (messageVisible) {
+				const message = await messageContainer.locator('.message').innerText().catch(() => '<unavailable>');
+				this.context.log(`Marketplace message visible during failed install: ${message}`);
+			}
+
+			await this.context.captureScreenshot(page);
+
+			if (attempt < 2) {
+				this.context.log('Waiting 5s before retrying install');
+				await page.waitForTimeout(5_000);
+			}
 		}
 
-		throw new Error('Failed to install extension after 3 attempts');
+		throw new Error(`Failed to install extension after 3 attempts; last failure: ${lastFailure ?? '<none captured>'}`);
 	}
 
 	/**


### PR DESCRIPTION
Recurring transient failures of the desktop-linux-arm64 sanity test surface only as `Failed to install extension after 3 attempts` with no per-attempt context, which makes diagnosis hard (see microsoft/vscode-engineering#2877).

This PR enriches the install loop in `test/sanity/src/uiTest.ts`:

- Carries the last per-attempt failure message into the final thrown error.
- Captures a screenshot on each failed install attempt (previously only one outer screenshot was captured).
- Logs any visible Marketplace message-container text on failed install attempts.
- Adds a 5s backoff between install retries (previously they ran back-to-back).

No behavior change for the happy path.

Refs microsoft/vscode-engineering#2877