### PR TITLE
Make sanity RPM install idempotent

### DIFF
--- a/test/sanity/src/context.ts
+++ b/test/sanity/src/context.ts
@@ -918,7 +918,10 @@ export class TestContext {
 	 */
 	public installRpm(packagePath: string): string {
 		this.log(`Installing ${packagePath} using RPM package manager`);
-		this.runSudoNoErrors('rpm', '-i', packagePath);
+		// Use `-U --replacepkgs` (install-or-upgrade, allow same-version reinstall)
+		// instead of `-i` so the step is idempotent if a previous run left the
+		// package installed on a non-ephemeral agent.
+		this.runSudoNoErrors('rpm', '-U', '--replacepkgs', packagePath);
 		this.log(`Installed ${packagePath} successfully`);
 
 		const name = this.getLinuxBinaryName();


### PR DESCRIPTION
Make the Linux desktop sanity RPM install step idempotent so it doesn't fail when `code-insiders` is already installed on a non-ephemeral agent (observed on Fedora 43 amd64 + arm64).

### Problem

`test/sanity/src/context.ts` calls:

```ts
this.runSudoNoErrors('rpm', '-i', packagePath);
```

`rpm -i` exits 1 with `package code-insiders-... is already installed` whenever the package is present. The companion `installDeb` doesn't have this problem because `dpkg -i` is install-or-upgrade.

Recent failure (from microsoft/vscode-engineering#2878):

```
Running command: rpm -i /tmp/vscode-sanity.../code-insiders-1.122.0-...el8.aarch64.rpm
ERROR: Command exited with code 1: warning: ...NOKEY
    package code-insiders-1.122.0-...el8.aarch64 is already installed
```

The `NOKEY` line is just a warning — the non-zero exit comes from `already installed`.

### Fix

Switch to `rpm -U --replacepkgs`:

- `-U` — install if absent, upgrade if present (mirrors `dpkg -i` semantics).
- `--replacepkgs` — also allow reinstalling the same version (covers the case in the failure above).

This is a strict superset of `-i` for the fresh-install case, so it can't regress clean runs.

### Out of scope

- Companion extension-install retry failures tracked in microsoft/vscode-engineering#2877.
- The `NOKEY` log noise — orthogonal and would require importing the VS Code GPG key on the agents.
- Investigating why the agent state leaks between runs (filing separately if it persists after this fix).

Refs microsoft/vscode-engineering#2878
