### PR TITLE
Revert "Restore editor.quickSuggestions.other default to 'on' (#318789)"

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -3764,7 +3764,7 @@ class EditorQuickSuggestions extends BaseEditorOption<EditorOption.quickSuggesti
 
 	constructor() {
 		const defaults: InternalQuickSuggestionsOptions = {
-			other: 'on',
+			other: 'offWhenInlineCompletions',
 			comments: 'off',
 			strings: 'off'
 		};

--- a/src/vs/editor/contrib/inlineCompletions/test/browser/suggestWidgetModel.test.ts
+++ b/src/vs/editor/contrib/inlineCompletions/test/browser/suggestWidgetModel.test.ts
@@ -88,7 +88,7 @@ suite('Suggest Widget Model', () => {
 
 	test('Ghost Text', async () => {
 		await withAsyncTestCodeEditorAndInlineCompletionsModel('',
-			{ fakeClock: true, provider, suggest: { preview: true } },
+			{ fakeClock: true, provider, suggest: { preview: true }, quickSuggestions: { other: 'on', comments: 'off', strings: 'off' } },
 			async ({ editor, editorViewModel, context, model }) => {
 				context.keyboardType('h');
 				const suggestController = (editor.getContribution(SuggestController.ID) as SuggestController);

--- a/src/vs/editor/test/browser/config/editorConfiguration.test.ts
+++ b/src/vs/editor/test/browser/config/editorConfiguration.test.ts
@@ -232,7 +232,7 @@ suite('Common Editor Config', () => {
 		const config = new TestConfiguration({ quickSuggestions: null! });
 		const actual = <Readonly<Required<IQuickSuggestionsOptions>>>config.options.get(EditorOption.quickSuggestions);
 		assert.deepStrictEqual(actual, {
-			other: 'on',
+			other: 'offWhenInlineCompletions',
 			comments: 'off',
 			strings: 'off'
 		});
@@ -244,20 +244,9 @@ suite('Common Editor Config', () => {
 		config.updateOptions({ quickSuggestions: { strings: true } });
 		const actual = <Readonly<Required<IQuickSuggestionsOptions>>>config.options.get(EditorOption.quickSuggestions);
 		assert.deepStrictEqual(actual, {
-			other: 'on',
+			other: 'offWhenInlineCompletions',
 			comments: 'off',
 			strings: 'on'
-		});
-		config.dispose();
-	});
-
-	test('issue #318549: quickSuggestions.other defaults to "on" so snippet completions are not suppressed by inline completions', () => {
-		const config = new TestConfiguration({});
-		const actual = <Readonly<Required<IQuickSuggestionsOptions>>>config.options.get(EditorOption.quickSuggestions);
-		assert.deepStrictEqual(actual, {
-			other: 'on',
-			comments: 'off',
-			strings: 'off'
 		});
 		config.dispose();
 	});


### PR DESCRIPTION
Reverts commit fb72b9be76b694b456c5b15903e1f63457848ec8, which restored the default of `editor.quickSuggestions.other` to `'on'`.

This restores the `'offWhenInlineCompletions'` default from #316900.