### PR TITLE
Confirm before restarting to install an update

### DIFF
--- a/src/vs/platform/menubar/electron-main/menubar.ts
+++ b/src/vs/platform/menubar/electron-main/menubar.ts
@@ -670,7 +670,9 @@ export class Menubar extends Disposable {
 				return [new MenuItem({
 					label: this.mnemonicLabel(nls.localize('miRestartToUpdate', "Restart to &&Update")), click: () => {
 						this.reportMenuActionTelemetry('RestartToUpdate');
-						this.updateService.quitAndInstall();
+						if (!this.runActionInRenderer({ type: 'commandId', commandId: 'update.restart' })) {
+							this.updateService.quitAndInstall();
+						}
 					}
 				})];
 

--- a/src/vs/workbench/contrib/update/browser/update.contribution.ts
+++ b/src/vs/workbench/contrib/update/browser/update.contribution.ts
@@ -11,7 +11,7 @@ import { Categories } from '../../../../platform/action/common/actionCommonCateg
 import { MenuId, registerAction2, Action2 } from '../../../../platform/actions/common/actions.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IQuickInputService } from '../../../../platform/quickinput/common/quickInput.js';
-import { ProductContribution, UpdateContribution, CONTEXT_UPDATE_STATE, SwitchProductQualityContribution, showReleaseNotesInEditor, DefaultAccountUpdateContribution } from './update.js';
+import { ProductContribution, UpdateContribution, CONTEXT_UPDATE_STATE, SwitchProductQualityContribution, showReleaseNotesInEditor, DefaultAccountUpdateContribution, confirmAndRestartToUpdate } from './update.js';
 import { UpdateTitleBarContribution } from './updateTitleBarEntry.js';
 import { PostUpdateWidgetContribution } from './postUpdateWidget.js';
 import { LifecyclePhase } from '../../../services/lifecycle/common/lifecycle.js';
@@ -172,7 +172,7 @@ class RestartToUpdateAction extends Action2 {
 	}
 
 	async run(accessor: ServicesAccessor): Promise<void> {
-		await accessor.get(IUpdateService).quitAndInstall();
+		await confirmAndRestartToUpdate(accessor);
 	}
 }
 

--- a/src/vs/workbench/contrib/update/browser/update.ts
+++ b/src/vs/workbench/contrib/update/browser/update.ts
@@ -36,6 +36,8 @@ import { IVersion, tryParseVersion } from '../common/updateUtils.js';
 export const CONTEXT_UPDATE_STATE = new RawContextKey<string>('updateState', StateType.Uninitialized);
 export const MAJOR_MINOR_UPDATE_AVAILABLE = new RawContextKey<boolean>('majorMinorUpdateAvailable', false);
 
+const SKIP_RESTART_CONFIRMATION_STORAGE_KEY = 'update.skipRestartConfirmation';
+
 let releaseNotesManager: ReleaseNotesManager | undefined = undefined;
 
 export function showReleaseNotesInEditor(instantiationService: IInstantiationService, version: string, useCurrentFile: boolean) {
@@ -44,6 +46,35 @@ export function showReleaseNotesInEditor(instantiationService: IInstantiationSer
 	}
 
 	return releaseNotesManager.show(version, useCurrentFile);
+}
+
+export async function confirmAndRestartToUpdate(accessor: ServicesAccessor): Promise<void> {
+	const updateService = accessor.get(IUpdateService);
+	const dialogService = accessor.get(IDialogService);
+	const storageService = accessor.get(IStorageService);
+	const productService = accessor.get(IProductService);
+
+	if (storageService.getBoolean(SKIP_RESTART_CONFIRMATION_STORAGE_KEY, StorageScope.APPLICATION, false)) {
+		return updateService.quitAndInstall();
+	}
+
+	const { confirmed, checkboxChecked } = await dialogService.confirm({
+		type: 'warning',
+		message: nls.localize('confirmRestartToUpdate.message', "Restart {0} to install the update?", productService.nameLong),
+		detail: nls.localize('confirmRestartToUpdate.detail', "{0} will close and restart immediately. Any unsaved work in terminals, debug sessions, and other in-progress tasks will be lost.", productService.nameLong),
+		primaryButton: nls.localize({ key: 'confirmRestartToUpdate.restart', comment: ['&& denotes a mnemonic'] }, "&&Restart and Update"),
+		checkbox: { label: nls.localize('confirmRestartToUpdate.dontAskAgain', "Don't ask me again"), checked: false }
+	});
+
+	if (!confirmed) {
+		return;
+	}
+
+	if (checkboxChecked) {
+		storageService.store(SKIP_RESTART_CONFIRMATION_STORAGE_KEY, true, StorageScope.APPLICATION, StorageTarget.USER);
+	}
+
+	return updateService.quitAndInstall();
 }
 
 async function openLatestReleaseNotesInBrowser(accessor: ServicesAccessor) {
@@ -289,7 +320,7 @@ export class UpdateContribution extends Disposable implements IWorkbenchContribu
 		CommandsRegistry.registerCommand('update.downloading', () => { });
 		CommandsRegistry.registerCommand('update.install', () => this.updateService.applyUpdate());
 		CommandsRegistry.registerCommand('update.updating', () => { });
-		CommandsRegistry.registerCommand('update.restart', () => this.updateService.quitAndInstall());
+		CommandsRegistry.registerCommand('update.restart', accessor => confirmAndRestartToUpdate(accessor));
 		CommandsRegistry.registerCommand('_update.state', () => {
 			return this.state;
 		});

--- a/src/vs/workbench/contrib/update/browser/update.ts
+++ b/src/vs/workbench/contrib/update/browser/update.ts
@@ -36,7 +36,7 @@ import { IVersion, tryParseVersion } from '../common/updateUtils.js';
 export const CONTEXT_UPDATE_STATE = new RawContextKey<string>('updateState', StateType.Uninitialized);
 export const MAJOR_MINOR_UPDATE_AVAILABLE = new RawContextKey<boolean>('majorMinorUpdateAvailable', false);
 
-const SKIP_RESTART_CONFIRMATION_STORAGE_KEY = 'update.skipRestartConfirmation';
+export const SKIP_RESTART_CONFIRMATION_STORAGE_KEY = 'update.skipRestartConfirmation';
 
 let releaseNotesManager: ReleaseNotesManager | undefined = undefined;
 

--- a/src/vs/workbench/contrib/update/test/browser/confirmAndRestartToUpdate.test.ts
+++ b/src/vs/workbench/contrib/update/test/browser/confirmAndRestartToUpdate.test.ts
@@ -14,9 +14,7 @@ import product from '../../../../../platform/product/common/product.js';
 import { IProductService } from '../../../../../platform/product/common/productService.js';
 import { InMemoryStorageService, IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
 import { IUpdateService } from '../../../../../platform/update/common/update.js';
-import { confirmAndRestartToUpdate } from '../../browser/update.js';
-
-const SKIP_KEY = 'update.skipRestartConfirmation';
+import { confirmAndRestartToUpdate, SKIP_RESTART_CONFIRMATION_STORAGE_KEY } from '../../browser/update.js';
 
 suite('confirmAndRestartToUpdate', () => {
 
@@ -50,9 +48,9 @@ suite('confirmAndRestartToUpdate', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
 
 	test('skips dialog and quits when skip flag is set', async () => {
-		storage.store(SKIP_KEY, true, StorageScope.APPLICATION, StorageTarget.USER);
+		storage.store(SKIP_RESTART_CONFIRMATION_STORAGE_KEY, true, StorageScope.APPLICATION, StorageTarget.USER);
 
-		await confirmAndRestartToUpdate(instantiationService);
+		await instantiationService.invokeFunction(confirmAndRestartToUpdate);
 
 		assert.strictEqual(quitAndInstallCalls, 1);
 	});
@@ -60,27 +58,27 @@ suite('confirmAndRestartToUpdate', () => {
 	test('does not quit when user cancels', async () => {
 		dialog.setConfirmResult({ confirmed: false, checkboxChecked: false });
 
-		await confirmAndRestartToUpdate(instantiationService);
+		await instantiationService.invokeFunction(confirmAndRestartToUpdate);
 
 		assert.strictEqual(quitAndInstallCalls, 0);
-		assert.strictEqual(storage.getBoolean(SKIP_KEY, StorageScope.APPLICATION, false), false);
+		assert.strictEqual(storage.getBoolean(SKIP_RESTART_CONFIRMATION_STORAGE_KEY, StorageScope.APPLICATION, false), false);
 	});
 
 	test('quits without persisting skip flag when user confirms without checkbox', async () => {
 		dialog.setConfirmResult({ confirmed: true, checkboxChecked: false });
 
-		await confirmAndRestartToUpdate(instantiationService);
+		await instantiationService.invokeFunction(confirmAndRestartToUpdate);
 
 		assert.strictEqual(quitAndInstallCalls, 1);
-		assert.strictEqual(storage.getBoolean(SKIP_KEY, StorageScope.APPLICATION, false), false);
+		assert.strictEqual(storage.getBoolean(SKIP_RESTART_CONFIRMATION_STORAGE_KEY, StorageScope.APPLICATION, false), false);
 	});
 
 	test('quits and persists skip flag when user confirms with checkbox', async () => {
 		dialog.setConfirmResult({ confirmed: true, checkboxChecked: true });
 
-		await confirmAndRestartToUpdate(instantiationService);
+		await instantiationService.invokeFunction(confirmAndRestartToUpdate);
 
 		assert.strictEqual(quitAndInstallCalls, 1);
-		assert.strictEqual(storage.getBoolean(SKIP_KEY, StorageScope.APPLICATION, false), true);
+		assert.strictEqual(storage.getBoolean(SKIP_RESTART_CONFIRMATION_STORAGE_KEY, StorageScope.APPLICATION, false), true);
 	});
 });

--- a/src/vs/workbench/contrib/update/test/browser/confirmAndRestartToUpdate.test.ts
+++ b/src/vs/workbench/contrib/update/test/browser/confirmAndRestartToUpdate.test.ts
@@ -1,0 +1,86 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { mock } from '../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
+import { TestDialogService } from '../../../../../platform/dialogs/test/common/testDialogService.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import product from '../../../../../platform/product/common/product.js';
+import { IProductService } from '../../../../../platform/product/common/productService.js';
+import { InMemoryStorageService, IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
+import { IUpdateService } from '../../../../../platform/update/common/update.js';
+import { confirmAndRestartToUpdate } from '../../browser/update.js';
+
+const SKIP_KEY = 'update.skipRestartConfirmation';
+
+suite('confirmAndRestartToUpdate', () => {
+
+	const store = new DisposableStore();
+	let instantiationService: TestInstantiationService;
+	let storage: InMemoryStorageService;
+	let dialog: TestDialogService;
+	let quitAndInstallCalls: number;
+
+	setup(() => {
+		quitAndInstallCalls = 0;
+		storage = store.add(new InMemoryStorageService());
+		dialog = new TestDialogService();
+
+		const updateService = new class extends mock<IUpdateService>() {
+			override async quitAndInstall(): Promise<void> { quitAndInstallCalls++; }
+		};
+		const productService: IProductService = { _serviceBrand: undefined, ...product };
+
+		instantiationService = store.add(new TestInstantiationService());
+		instantiationService.set(IDialogService, dialog);
+		instantiationService.set(IStorageService, storage);
+		instantiationService.set(IUpdateService, updateService);
+		instantiationService.set(IProductService, productService);
+	});
+
+	teardown(() => {
+		store.clear();
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('skips dialog and quits when skip flag is set', async () => {
+		storage.store(SKIP_KEY, true, StorageScope.APPLICATION, StorageTarget.USER);
+
+		await confirmAndRestartToUpdate(instantiationService);
+
+		assert.strictEqual(quitAndInstallCalls, 1);
+	});
+
+	test('does not quit when user cancels', async () => {
+		dialog.setConfirmResult({ confirmed: false, checkboxChecked: false });
+
+		await confirmAndRestartToUpdate(instantiationService);
+
+		assert.strictEqual(quitAndInstallCalls, 0);
+		assert.strictEqual(storage.getBoolean(SKIP_KEY, StorageScope.APPLICATION, false), false);
+	});
+
+	test('quits without persisting skip flag when user confirms without checkbox', async () => {
+		dialog.setConfirmResult({ confirmed: true, checkboxChecked: false });
+
+		await confirmAndRestartToUpdate(instantiationService);
+
+		assert.strictEqual(quitAndInstallCalls, 1);
+		assert.strictEqual(storage.getBoolean(SKIP_KEY, StorageScope.APPLICATION, false), false);
+	});
+
+	test('quits and persists skip flag when user confirms with checkbox', async () => {
+		dialog.setConfirmResult({ confirmed: true, checkboxChecked: true });
+
+		await confirmAndRestartToUpdate(instantiationService);
+
+		assert.strictEqual(quitAndInstallCalls, 1);
+		assert.strictEqual(storage.getBoolean(SKIP_KEY, StorageScope.APPLICATION, false), true);
+	});
+});


### PR DESCRIPTION
Fixes #318121

Clicking the Update indicator used to call `quitAndInstall()` directly, so an accidental click would close the window and any in-progress terminal / debug / unsaved state would be lost. This adds a warning dialog before the restart, with a "Don't ask me again" checkbox.

The new helper `confirmAndRestartToUpdate(accessor)` in `src/vs/workbench/contrib/update/browser/update.ts` is wired into both UI entry points that ultimately call `quitAndInstall`:

- `update.restart` command — fires from the title bar update indicator, the update tooltip's Restart button, and the global activity menu.
- `update.restartToUpdate` action — fires from the command palette and the Help menu.

The macOS app menu "Restart to Update" item in `src/vs/platform/menubar/electron-main/menubar.ts` now routes through the workbench command (via `runActionInRenderer`) so it inherits the confirmation; it falls back to the direct call if no renderer is available.

### Tests

Added `src/vs/workbench/contrib/update/test/browser/confirmAndRestartToUpdate.test.ts` covering the four paths:

- Skip flag set in storage → calls `quitAndInstall` without showing the dialog.
- User cancels → no quit, storage untouched.
- User confirms without checkbox → quits, skip flag NOT persisted.
- User confirms with checkbox → quits AND skip flag persisted.

Run with: `./scripts/test.sh --grep confirmAndRestartToUpdate`

### Manual verification

1. Temporarily remove the `precondition: CONTEXT_UPDATE_STATE.isEqualTo(StateType.Ready)` on `RestartToUpdateAction` so the action appears in the command palette in the dev build.
2. Run `Restart to Update` from the command palette → warning dialog appears with the "Don't ask me again" checkbox.
3. Cancel → no quit attempted.
4. Confirm → proceeds to `quitAndInstall` (no-op in dev because state is `Disabled`).
5. Confirm with "Don't ask me again" checked → next invocation skips the dialog.
