### PR TITLE
Make sure permission modes are correct across chat kinds for Claude ext host

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/vscode-node/claudeChatSessionContentProvider.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/claudeChatSessionContentProvider.ts
@@ -319,7 +319,9 @@ export class ClaudeChatSessionItemController extends Disposable {
 				_authenticationService.onDidAuthenticationChange,
 			),
 			() => _configurationService.getExperimentBasedConfig(ConfigKey.ClaudeAgentAllowAutoPermissions, experimentationService)
-				&& (_authenticationService.copilotToken?.isEditorPreviewFeaturesEnabled() ?? false),
+				// True is a fallback because the inputgroup state currently doesn't support updating the values after initialization
+				// This is a temporary workaround until the inputgroup state can be updated dynamically.
+				&& (_authenticationService.copilotToken?.isEditorPreviewFeaturesEnabled() ?? true),
 		);
 
 		// Bridge vscode.Event → internal Event for workspace folder changes

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/claudeChatSessionContentProvider.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/claudeChatSessionContentProvider.ts
@@ -319,8 +319,8 @@ export class ClaudeChatSessionItemController extends Disposable {
 				_authenticationService.onDidAuthenticationChange,
 			),
 			() => _configurationService.getExperimentBasedConfig(ConfigKey.ClaudeAgentAllowAutoPermissions, experimentationService)
-				// True is a fallback because the inputgroup state currently doesn't support updating the values after initialization
-				// This is a temporary workaround until the inputgroup state can be updated dynamically.
+				// True is a fallback because the input group state currently doesn't support updating the values after initialization
+				// This is a temporary workaround until the input group state can be updated dynamically.
 				&& (_authenticationService.copilotToken?.isEditorPreviewFeaturesEnabled() ?? true),
 		);
 

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/claudePermissionModePicker.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/claudePermissionModePicker.ts
@@ -16,7 +16,6 @@ import { ActionListItemKind, IActionListDelegate, IActionListItem, IActionListOp
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { observableConfigValue } from '../../../../../platform/observable/common/platformObservableUtils.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
-import { IChatEntitlementService } from '../../../../../workbench/services/chat/common/chatEntitlementService.js';
 import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
 import { CopilotChatSessionsProvider } from './copilotChatSessionsProvider.js';
@@ -25,6 +24,7 @@ import { IChatSessionsService } from '../../../../../workbench/contrib/chat/comm
 
 const PERMISSION_MODE_OPTION_ID = 'permissionMode';
 const ALLOW_AUTO_PERMISSIONS_SETTING = 'github.copilot.chat.claudeAgent.allowAutoPermissions';
+const ALLOW_BYPASS_PERMISSIONS_SETTING = 'github.copilot.chat.claudeAgent.allowDangerouslySkipPermissions';
 
 interface IClaudePermissionModeItem {
 	readonly id: string;
@@ -61,10 +61,18 @@ const autoPermissionMode: IClaudePermissionModeItem = {
 	icon: Codicon.sparkle,
 };
 
+const bypassPermissionMode: IClaudePermissionModeItem = {
+	id: 'bypassPermissions',
+	label: localize('claude.permissionMode.bypass', "Bypass Permissions"),
+	description: localize('claude.permissionMode.bypass.description', "All tools run without any confirmation"),
+	icon: Codicon.warning,
+};
+
 export class ClaudePermissionModePicker extends Disposable {
 
 	private _currentModeId = 'acceptEdits';
 	private readonly _autoPermissionsEnabled: IObservable<boolean>;
+	private readonly _bypassPermissionsEnabled: IObservable<boolean>;
 	private _triggerElement: HTMLElement | undefined;
 	private readonly _renderDisposables = this._register(new DisposableStore());
 
@@ -74,11 +82,11 @@ export class ClaudePermissionModePicker extends Disposable {
 		@ISessionsProvidersService private readonly sessionsProvidersService: ISessionsProvidersService,
 		@IChatSessionsService private readonly chatSessionsService: IChatSessionsService,
 		@IConfigurationService configurationService: IConfigurationService,
-		@IChatEntitlementService private readonly chatEntitlementService: IChatEntitlementService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
 	) {
 		super();
 		this._autoPermissionsEnabled = observableConfigValue<boolean>(ALLOW_AUTO_PERMISSIONS_SETTING, false, configurationService);
+		this._bypassPermissionsEnabled = observableConfigValue<boolean>(ALLOW_BYPASS_PERMISSIONS_SETTING, false, configurationService);
 	}
 
 	render(container: HTMLElement): HTMLElement {
@@ -117,8 +125,15 @@ export class ClaudePermissionModePicker extends Disposable {
 			return;
 		}
 
-		const autoAvailable = this._autoPermissionsEnabled.get() && !this.chatEntitlementService.previewFeaturesDisabled;
-		const availableModes = autoAvailable ? [...permissionModes, autoPermissionMode] : permissionModes;
+		const autoAvailable = this._autoPermissionsEnabled.get();
+		const bypassAvailable = this._bypassPermissionsEnabled.get();
+		const availableModes = [...permissionModes];
+		if (autoAvailable) {
+			availableModes.push(autoPermissionMode);
+		}
+		if (bypassAvailable) {
+			availableModes.push(bypassPermissionMode);
+		}
 		const items: IActionListItem<IClaudePermissionModeItem>[] = availableModes.map(mode => ({
 			kind: ActionListItemKind.Action,
 			group: { kind: ActionListItemKind.Header, title: '', icon: mode.icon },
@@ -155,7 +170,7 @@ export class ClaudePermissionModePicker extends Disposable {
 
 	private _selectMode(mode: IClaudePermissionModeItem): void {
 		const beforeId = this._currentModeId;
-		const beforeLabel = [...permissionModes, autoPermissionMode].find(m => m.id === beforeId)?.label;
+		const beforeLabel = [...permissionModes, autoPermissionMode, bypassPermissionMode].find(m => m.id === beforeId)?.label;
 		reportNewChatPickerClosed(this.telemetryService, {
 			id: 'NewChatClaudePermissionModePicker',
 			name: 'NewChatClaudePermissionModePicker',
@@ -194,7 +209,7 @@ export class ClaudePermissionModePicker extends Disposable {
 		}
 
 		dom.clearNode(trigger);
-		const currentMode = [...permissionModes, autoPermissionMode].find(m => m.id === this._currentModeId) ?? permissionModes[1];
+		const currentMode = [...permissionModes, autoPermissionMode, bypassPermissionMode].find(m => m.id === this._currentModeId) ?? permissionModes[1];
 
 		dom.append(trigger, renderIcon(currentMode.icon));
 		const labelSpan = dom.append(trigger, dom.$('span.sessions-chat-dropdown-label'));

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/claudePermissionModePicker.test.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/claudePermissionModePicker.test.ts
@@ -19,7 +19,6 @@ import { CopilotChatSessionsProvider, ICopilotChatSession } from '../../browser/
 import { ClaudePermissionModePicker } from '../../browser/claudePermissionModePicker.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
-import { IChatEntitlementService } from '../../../../../../workbench/services/chat/common/chatEntitlementService.js';
 
 interface IPermissionModeItem {
 	readonly id: string;
@@ -78,7 +77,6 @@ function createPicker(
 	} as unknown as ISessionsProvidersService);
 	instantiationService.stub(ITelemetryService, NullTelemetryService);
 	instantiationService.stub(IConfigurationService, new TestConfigurationService());
-	instantiationService.stub(IChatEntitlementService, { previewFeaturesDisabled: false } as IChatEntitlementService);
 
 	const picker = disposables.add(instantiationService.createInstance(ClaudePermissionModePicker));
 

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/claudePermissionModePicker.test.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/claudePermissionModePicker.test.ts
@@ -36,6 +36,7 @@ function createPicker(
 	opts?: {
 		setOptionSpy?: (optionId: string, value: { id: string; name: string }) => void;
 		hasActiveSession?: boolean;
+		configValues?: Record<string, unknown>;
 	},
 ): { picker: ClaudePermissionModePicker; actionWidgetItems: IActionListItem<IPermissionModeItem>[]; onSelect: (item: IPermissionModeItem) => void } {
 	const instantiationService = disposables.add(new TestInstantiationService());
@@ -76,7 +77,11 @@ function createPicker(
 		getProvider: () => provider,
 	} as unknown as ISessionsProvidersService);
 	instantiationService.stub(ITelemetryService, NullTelemetryService);
-	instantiationService.stub(IConfigurationService, new TestConfigurationService());
+	const configService = new TestConfigurationService();
+	for (const [key, value] of Object.entries(opts?.configValues ?? {})) {
+		configService.setUserConfiguration(key, value);
+	}
+	instantiationService.stub(IConfigurationService, configService);
 
 	const picker = disposables.add(instantiationService.createInstance(ClaudePermissionModePicker));
 
@@ -160,5 +165,42 @@ suite('ClaudePermissionModePicker', () => {
 		assert.ok(trigger);
 		// Default mode is 'acceptEdits' → "Edit Automatically"
 		assert.ok(trigger.ariaLabel?.includes('Edit Automatically'));
+	});
+
+	test('shows bypass permissions option when setting is enabled', () => {
+		const { picker, actionWidgetItems } = createPicker(disposables, {
+			configValues: { 'github.copilot.chat.claudeAgent.allowDangerouslySkipPermissions': true },
+		});
+		const container = document.createElement('div');
+		picker.render(container);
+		showPicker(container);
+
+		assert.deepStrictEqual(
+			actionWidgetItems.map(item => ({ id: item.item?.id, label: item.label })),
+			[
+				{ id: 'default', label: 'Ask Before Edits' },
+				{ id: 'acceptEdits', label: 'Edit Automatically' },
+				{ id: 'plan', label: 'Plan Mode' },
+				{ id: 'bypassPermissions', label: 'Bypass Permissions' },
+			],
+		);
+	});
+
+	test('selecting bypass permissions writes expected permissionMode option', () => {
+		const calls: { optionId: string; value: { id: string; name: string } }[] = [];
+		const result = createPicker(disposables, {
+			configValues: { 'github.copilot.chat.claudeAgent.allowDangerouslySkipPermissions': true },
+			setOptionSpy: (optionId, value) => calls.push({ optionId, value }),
+		});
+		const container = document.createElement('div');
+		result.picker.render(container);
+		showPicker(container);
+
+		result.onSelect({ id: 'bypassPermissions', label: 'Bypass Permissions' } as IPermissionModeItem);
+
+		assert.deepStrictEqual(calls, [{
+			optionId: 'permissionMode',
+			value: { id: 'bypassPermissions', name: 'Bypass Permissions' },
+		}]);
 	});
 });


### PR DESCRIPTION
* Allow yolo in Agents window for Claude welcome chat
* Allow auto mode in Agents window for Claude chat sessions

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
