### PR TITLE
Make Linux desktop sanity tests robust to mid-test failures

### DIFF
--- a/test/sanity/src/context.ts
+++ b/test/sanity/src/context.ts
@@ -884,22 +884,32 @@ export class TestContext {
 	 * @returns The path to the installed VS Code executable.
 	 */
 	public async installDeb(packagePath: string): Promise<string> {
+		const name = this.getLinuxBinaryName();
+		const entryPoint = path.join('/usr/share', name, name);
+		if (fs.existsSync(entryPoint)) {
+			this.error(`Cannot install ${packagePath}: ${name} is already installed at ${entryPoint}. This usually means a previous test run was terminated before cleanup completed; investigate the prior failure rather than silencing this error.`);
+		}
+
 		this.log(`Installing ${packagePath} using DEB package manager`);
 		await this.runDpkgNoErrors('-i', packagePath);
 		this.log(`Installed ${packagePath} successfully`);
 
-		const name = this.getLinuxBinaryName();
-		const entryPoint = path.join('/usr/share', name, name);
 		this.log(`Installed VS Code executable at: ${entryPoint}`);
 		return entryPoint;
 	}
 
 	/**
-	 * Uninstalls VS Code Linux DEB package.
+	 * Uninstalls VS Code Linux DEB package. Safe to call when the package is not
+	 * installed (no-op) so that test cleanup in a `finally` block is always safe.
 	 */
 	public async uninstallDeb() {
 		const name = this.getLinuxBinaryName();
 		const packagePath = path.join('/usr/share', name, name);
+
+		if (!fs.existsSync(packagePath)) {
+			this.log(`DEB package ${name} not installed, skipping uninstall`);
+			return;
+		}
 
 		this.log(`Uninstalling DEB package ${packagePath}`);
 		await this.runDpkgNoErrors('-r', name);
@@ -917,22 +927,33 @@ export class TestContext {
 	 * @returns The path to the installed VS Code executable.
 	 */
 	public installRpm(packagePath: string): string {
+		const name = this.getLinuxBinaryName();
+		const installedBinary = path.join('/usr/bin', name);
+		if (fs.existsSync(installedBinary)) {
+			this.error(`Cannot install ${packagePath}: ${name} is already installed at ${installedBinary}. This usually means a previous test run was terminated before cleanup completed; investigate the prior failure rather than silencing this error.`);
+		}
+
 		this.log(`Installing ${packagePath} using RPM package manager`);
 		this.runSudoNoErrors('rpm', '-i', packagePath);
 		this.log(`Installed ${packagePath} successfully`);
 
-		const name = this.getLinuxBinaryName();
 		const entryPoint = path.join('/usr/share', name, name);
 		this.log(`Installed VS Code executable at: ${entryPoint}`);
 		return entryPoint;
 	}
 
 	/**
-	 * Uninstalls VS Code Linux RPM package.
+	 * Uninstalls VS Code Linux RPM package. Safe to call when the package is not
+	 * installed (no-op) so that test cleanup in a `finally` block is always safe.
 	 */
 	public async uninstallRpm() {
 		const name = this.getLinuxBinaryName();
 		const packagePath = path.join('/usr/bin', name);
+
+		if (!fs.existsSync(packagePath)) {
+			this.log(`RPM package ${name} not installed, skipping uninstall`);
+			return;
+		}
 
 		this.log(`Uninstalling RPM package ${packagePath}`);
 		this.runSudoNoErrors('rpm', '-e', name);
@@ -950,23 +971,34 @@ export class TestContext {
 	 * @returns The path to the installed VS Code executable.
 	 */
 	public installSnap(packagePath: string): string {
+		const name = this.getLinuxBinaryName();
+		const snapWrapper = path.join('/snap/bin', name);
+		if (fs.existsSync(snapWrapper)) {
+			this.error(`Cannot install ${packagePath}: ${name} is already installed at ${snapWrapper}. This usually means a previous test run was terminated before cleanup completed; investigate the prior failure rather than silencing this error.`);
+		}
+
 		this.log(`Installing ${packagePath} using Snap package manager`);
 		this.runSudoNoErrors('snap', 'install', packagePath, '--classic', '--dangerous');
 		this.log(`Installed ${packagePath} successfully`);
 
 		// Snap wrapper scripts are in /snap/bin, but actual Electron binary is in /snap/<package>/current/usr/share/
-		const name = this.getLinuxBinaryName();
 		const entryPoint = `/snap/${name}/current/usr/share/${name}/${name}`;
 		this.log(`Installed VS Code executable at: ${entryPoint}`);
 		return entryPoint;
 	}
 
 	/**
-	 * Uninstalls VS Code Linux Snap package.
+	 * Uninstalls VS Code Linux Snap package. Safe to call when the package is not
+	 * installed (no-op) so that test cleanup in a `finally` block is always safe.
 	 */
 	public async uninstallSnap() {
 		const name = this.getLinuxBinaryName();
 		const packagePath = path.join('/snap/bin', name);
+
+		if (!fs.existsSync(packagePath)) {
+			this.log(`Snap package ${name} not installed, skipping uninstall`);
+			return;
+		}
 
 		this.log(`Uninstalling Snap package ${packagePath}`);
 		this.runSudoNoErrors('snap', 'remove', name);

--- a/test/sanity/src/desktop.test.ts
+++ b/test/sanity/src/desktop.test.ts
@@ -96,8 +96,11 @@ export function setup(context: TestContext) {
 		const packagePath = await context.downloadTarget('linux-deb-arm64');
 		if (!context.options.downloadOnly) {
 			const entryPoint = await context.installDeb(packagePath);
-			await testDesktopApp(entryPoint);
-			await context.uninstallDeb();
+			try {
+				await testDesktopApp(entryPoint);
+			} finally {
+				await context.uninstallDeb();
+			}
 		}
 	});
 
@@ -105,8 +108,11 @@ export function setup(context: TestContext) {
 		const packagePath = await context.downloadTarget('linux-deb-armhf');
 		if (!context.options.downloadOnly) {
 			const entryPoint = await context.installDeb(packagePath);
-			await testDesktopApp(entryPoint);
-			await context.uninstallDeb();
+			try {
+				await testDesktopApp(entryPoint);
+			} finally {
+				await context.uninstallDeb();
+			}
 		}
 	});
 
@@ -114,8 +120,11 @@ export function setup(context: TestContext) {
 		const packagePath = await context.downloadTarget('linux-deb-x64');
 		if (!context.options.downloadOnly) {
 			const entryPoint = await context.installDeb(packagePath);
-			await testDesktopApp(entryPoint);
-			await context.uninstallDeb();
+			try {
+				await testDesktopApp(entryPoint);
+			} finally {
+				await context.uninstallDeb();
+			}
 		}
 	});
 
@@ -123,8 +132,11 @@ export function setup(context: TestContext) {
 		const packagePath = await context.downloadTarget('linux-rpm-arm64');
 		if (!context.options.downloadOnly) {
 			const entryPoint = context.installRpm(packagePath);
-			await testDesktopApp(entryPoint);
-			await context.uninstallRpm();
+			try {
+				await testDesktopApp(entryPoint);
+			} finally {
+				await context.uninstallRpm();
+			}
 		}
 	});
 
@@ -132,8 +144,11 @@ export function setup(context: TestContext) {
 		const packagePath = await context.downloadTarget('linux-rpm-armhf');
 		if (!context.options.downloadOnly) {
 			const entryPoint = context.installRpm(packagePath);
-			await testDesktopApp(entryPoint);
-			await context.uninstallRpm();
+			try {
+				await testDesktopApp(entryPoint);
+			} finally {
+				await context.uninstallRpm();
+			}
 		}
 	});
 
@@ -141,8 +156,11 @@ export function setup(context: TestContext) {
 		const packagePath = await context.downloadTarget('linux-rpm-x64');
 		if (!context.options.downloadOnly) {
 			const entryPoint = context.installRpm(packagePath);
-			await testDesktopApp(entryPoint);
-			await context.uninstallRpm();
+			try {
+				await testDesktopApp(entryPoint);
+			} finally {
+				await context.uninstallRpm();
+			}
 		}
 	});
 
@@ -150,8 +168,11 @@ export function setup(context: TestContext) {
 		const packagePath = await context.downloadTarget('linux-snap-x64');
 		if (!context.options.downloadOnly) {
 			const entryPoint = context.installSnap(packagePath);
-			await testDesktopApp(entryPoint);
-			await context.uninstallSnap();
+			try {
+				await testDesktopApp(entryPoint);
+			} finally {
+				await context.uninstallSnap();
+			}
 		}
 	});
 


### PR DESCRIPTION
Fixes microsoft/vscode-engineering#2878. Supersedes #318810.

### What was actually wrong

The Linux desktop sanity tests (deb / rpm / snap) install the package, run `testDesktopApp`, then uninstall — but the three steps were not wrapped in `try` / `finally`. When `testDesktopApp` threw (typically the "Failed to install extension after 3 attempts" flake tracked in microsoft/vscode-engineering#2877), the uninstall step was skipped.

Mocha is configured with `retries: 1`, so the test ran a second time. On the retry the install step hit `package code-insiders-... is already installed` and the run failed with that error instead of the original one. The build failure investigator picked up the misleading message and filed #2878 against the RPM install path, even though the real failure happened one attempt earlier in `testDesktopApp`.

### Fix

1. **Wrap install / test / uninstall in `try` / `finally`** so cleanup runs even when the test body throws. This is the actual bug.
2. **Make the uninstall helpers idempotent** by checking whether the binary exists before invoking the package manager. This is needed for two cases:
   - The `finally` block runs after a failed install, where nothing is actually installed yet.
   - The `finally` block runs after a successful pass through `testDesktopApp` that already cleaned up internally (not currently the case, but keeps the contract safe).
3. **Add a pre-install assertion** to each install helper that fails fast with a clear diagnostic when the package is already present. This is per @dbaeumer's review feedback on #318810 — leftover state should be surfaced as a real bug pointing at the *prior* failure, not silently worked around. The error message explicitly tells the reader to investigate the previous run instead of suppressing the error.

### Why not the previous PR (#318810)

The first PR swapped `rpm -i` for `rpm -U --replacepkgs` to make the install itself idempotent. That worked around the symptom but, as @dbaeumer pointed out, hid the underlying bug: a test should not be silently recovering from leftover state from a previous run. This PR addresses the root cause (missing cleanup on failure) and makes leftover state loud instead.

### Validation

- `npm run compile` in `test/sanity` passes.
- The change is test-infrastructure only; no production code is touched.
- Manual reasoning over the retry flow: with the `try` / `finally`, the retry now starts from a clean slate; if a future regression leaves the package installed across runs, the pre-install check fails immediately with a diagnostic pointing at the actual problem.
