### PR TITLE
feat: add /research slash command to agent host

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -800,6 +800,9 @@ export class CopilotAgentSession extends Disposable {
 			}
 			return;
 		}
+		if (slashCommand?.command === 'research') {
+			prompt = slashCommand.rest ? `/research ${slashCommand.rest}` : '/research';
+		}
 		if (slashCommand?.command === 'plan') {
 			mode = 'plan';
 			prompt = slashCommand.rest;

--- a/src/vs/platform/agentHost/node/copilot/copilotSlashCommandCompletionProvider.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSlashCommandCompletionProvider.ts
@@ -48,9 +48,10 @@ export interface IParsedLeadingSlashCommand {
 /**
  * Parses a Copilot CLI slash command at the very start of `prompt`.
  *
- * The command must be `/plan` or `/compact`, followed either by end-of-input
- * or by at least one whitespace character. `/compact-hello`, `/plans`, or a
- * leading-space `/compact` all return `undefined`. Match is case-sensitive.
+ * The command must be `/plan`, `/compact`, or `/research`, followed either by
+ * end-of-input or by at least one whitespace character. `/compact-hello`,
+ * `/plans`, or a leading-space `/compact` all return `undefined`. Match is
+ * case-sensitive.
  */
 export function parseLeadingSlashCommand(prompt: string): IParsedLeadingSlashCommand | undefined {
 	const match = /^\/(plan|compact|research)(?:$|\s+([\s\S]*))/.exec(prompt);

--- a/src/vs/platform/agentHost/node/copilot/copilotSlashCommandCompletionProvider.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSlashCommandCompletionProvider.ts
@@ -15,13 +15,14 @@ import { extractLeadingSlashToken } from '../agentHostSlashCompletion.js';
  * Slash-command name and the token we surface to the user / round-trip on
  * the {@link MessageAttachmentKind.Simple} attachment's `_meta`.
  */
-export type CopilotSlashCommandName = 'plan' | 'compact';
+export type CopilotSlashCommandName = 'plan' | 'compact' | 'research';
 
-const COMMANDS: readonly CopilotSlashCommandName[] = ['plan', 'compact'];
+const COMMANDS: readonly CopilotSlashCommandName[] = ['plan', 'compact', 'research'];
 function getCommandDescription(command: CopilotSlashCommandName): string {
 	switch (command) {
 		case 'plan': return localize('copilotSlashCommand.plan.description', "Create an implementation plan before coding");
 		case 'compact': return localize('copilotSlashCommand.compact.description', "Free up context by compacting the conversation history");
+		case 'research': return localize('copilotSlashCommand.research.description', "Run deep research on a topic using search and web sources");
 	}
 }
 /**
@@ -52,7 +53,7 @@ export interface IParsedLeadingSlashCommand {
  * leading-space `/compact` all return `undefined`. Match is case-sensitive.
  */
 export function parseLeadingSlashCommand(prompt: string): IParsedLeadingSlashCommand | undefined {
-	const match = /^\/(plan|compact)(?:$|\s+([\s\S]*))/.exec(prompt);
+	const match = /^\/(plan|compact|research)(?:$|\s+([\s\S]*))/.exec(prompt);
 	if (!match) {
 		return undefined;
 	}
@@ -104,7 +105,7 @@ export class CopilotSlashCommandCompletionProvider implements IAgentHostCompleti
 				continue;
 			}
 			items.push({
-				insertText: command === 'plan' ? '/' + command + ' ' : '/' + command,
+				insertText: command === 'compact' ? '/' + command : '/' + command + ' ',
 				rangeStart: 0,
 				rangeEnd: leading.rangeEnd,
 				attachment: {

--- a/src/vs/platform/agentHost/test/node/copilotSlashCommandCompletionProvider.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotSlashCommandCompletionProvider.test.ts
@@ -23,6 +23,14 @@ suite('CopilotSlashCommandCompletionProvider', () => {
 			assert.deepStrictEqual(parseLeadingSlashCommand('/compact'), { command: 'compact', rest: '' });
 		});
 
+		test('matches lone /research', () => {
+			assert.deepStrictEqual(parseLeadingSlashCommand('/research'), { command: 'research', rest: '' });
+		});
+
+		test('captures trailing text after a space for /research', () => {
+			assert.deepStrictEqual(parseLeadingSlashCommand('/research How does React work?'), { command: 'research', rest: 'How does React work?' });
+		});
+
 		test('captures trailing text after a space', () => {
 			assert.deepStrictEqual(parseLeadingSlashCommand('/plan build a hello world'), { command: 'plan', rest: 'build a hello world' });
 		});
@@ -66,9 +74,9 @@ suite('CopilotSlashCommandCompletionProvider', () => {
 			assert.deepStrictEqual(items, []);
 		});
 
-		test('returns both items for lone "/"', async () => {
+		test('returns all items for lone "/"', async () => {
 			const items = await run('/');
-			assert.deepStrictEqual(items.map(i => i.insertText), ['/plan ', '/compact']);
+			assert.deepStrictEqual(items.map(i => i.insertText), ['/plan ', '/compact', '/research ']);
 		});
 
 		test('filters to /plan when "/p" typed', async () => {
@@ -79,6 +87,11 @@ suite('CopilotSlashCommandCompletionProvider', () => {
 		test('filters to /compact when "/c" typed', async () => {
 			const items = await run('/c');
 			assert.deepStrictEqual(items.map(i => i.insertText), ['/compact']);
+		});
+
+		test('filters to /research when "/r" typed', async () => {
+			const items = await run('/r');
+			assert.deepStrictEqual(items.map(i => i.insertText), ['/research ']);
 		});
 
 		test('returns nothing when /word does not match any command prefix', async () => {
@@ -121,6 +134,13 @@ suite('CopilotSlashCommandCompletionProvider', () => {
 						description: 'Free up context by compacting the conversation history',
 					},
 				},
+				{
+					type: MessageAttachmentKind.Simple,
+					meta: {
+						command: 'research',
+						description: 'Run deep research on a topic using search and web sources',
+					},
+				},
 			]);
 		});
 
@@ -129,7 +149,7 @@ suite('CopilotSlashCommandCompletionProvider', () => {
 			const items = await gated.provideCompletionItems({
 				kind: CompletionItemKind.UserMessage, channel: session, text: '/', offset: 1,
 			}, CancellationToken.None);
-			assert.deepStrictEqual(items.map(i => i.insertText), ['/plan ']);
+			assert.deepStrictEqual(items.map(i => i.insertText), ['/plan ', '/research ']);
 		});
 
 		test('passes raw session id (no scheme/slash) to hasHistory', async () => {


### PR DESCRIPTION
## Summary

Add `/research` as a recognized slash command in the Copilot agent host, alongside `/plan` and `/compact`. When users type `/research <topic>`, the command is passed through to the Copilot CLI runtime which handles topic validation, research directory creation, and orchestration prompt injection.

## Changes

- **`copilotSlashCommandCompletionProvider.ts`**: Add `'research'` to the type union, command list, regex pattern, and description. Insert text includes trailing space (like `/plan`) since the command takes a required topic argument.
- **`copilotAgentSession.ts`**: Pass `/research <topic>` through to `session.send()` so the runtime recognizes and handles it via its built-in `/research` handler.
- **Tests**: Add parsing, filtering, and completion tests for the new command.

## How it works

1. User types `/research How does React concurrent rendering work?`
2. VS Code recognizes the slash command and passes it through to the CLI runtime
3. The runtime's `invokeResearch()` handler validates the topic, creates a research directory, and injects the full orchestrator prompt
4. The orchestrator prompt forces the agent to delegate research to parallel subagents and synthesize a structured report with citations

## Companion PR

- github/copilot-agent-runtime#9090: moves the CLI's rich orchestrator prompt to the core layer so SDK consumers get the full research experience