### PR TITLE
Throttle initial Git repository.status() across repositories

### DIFF
--- a/extensions/git/src/model.ts
+++ b/extensions/git/src/model.ts
@@ -7,7 +7,7 @@ import { workspace, WorkspaceFoldersChangeEvent, Uri, window, Event, EventEmitte
 import TelemetryReporter from '@vscode/extension-telemetry';
 import { IRepositoryResolver, Repository, RepositoryState } from './repository';
 import { memoize, sequentialize, debounce } from './decorators';
-import { dispose, anyEvent, filterEvent, isDescendant, pathEquals, toDisposable, eventToPromise } from './util';
+import { dispose, anyEvent, filterEvent, isDescendant, Limiter, pathEquals, toDisposable, eventToPromise } from './util';
 import { Git } from './git';
 import * as path from 'path';
 import * as fs from 'fs';
@@ -280,6 +280,9 @@ export class Model implements IRepositoryResolver, IBranchProtectionProviderRegi
 	get repositoryCache(): RepositoryCache {
 		return this._repositoryCache;
 	}
+
+	// Throttle initial repository.status() across repositories to avoid starving the ext host (#318279).
+	private readonly _initialStatusLimiter = new Limiter<void>(5);
 
 	private disposables: Disposable[] = [];
 
@@ -691,9 +694,8 @@ export class Model implements IRepositoryResolver, IBranchProtectionProviderRegi
 			this.logger.info(`[Model][openRepository] Opened repository (real path): ${repository.rootRealPath ?? repository.root}`);
 			this.logger.info(`[Model][openRepository] Opened repository (kind): ${gitRepository.kind}`);
 
-			// Do not await this, we want SCM
-			// to know about the repo asap
-			repository.status().then(() => {
+			// Do not await this, we want SCM to know about the repo asap.
+			this._initialStatusLimiter.queue(() => repository.status()).then(() => {
 				this._repositoryCache.update(repository.remotes, [], repository.root);
 			});
 		} catch (err) {


### PR DESCRIPTION
Fixes #318279
Fixes #318764

### Problem

In workspaces with many git repositories (~50+ folders in a multi-root `.code-workspace`), the extension host gets killed ~25–30s after startup, auto-restarts, and crashes in a loop. The reporter's `exthost.log` shows thousands of `[Decorations] CAPPING events from decorations provider vscode.git` warnings just before each kill, and the cadence matches the IPC unresponsive watcher firing after missed pings. `git.enabled: false` is a known workaround.

### Root cause

`Model.openRepository()` ends with a fire-and-forget `repository.status()` for every repo discovered during the initial scan. Each `_updateModelState()` fans out ~8 git subprocesses (`HEAD`, `remotes`, `submodules`, `worktrees`, `getStatus`, `getRefs`, ...) and then parses the output on the ext-host's single thread. With N repos opening through `Promise.all(... openRepository ...)` in `doInitialScan`, we get ~N×8 in-flight git subprocesses and a large blocking parse burst. For N≈50 that's enough to starve IPC pings and trip the unresponsive-host kill.

The decoration `CAPPING` warnings are a symptom of the same overload (each completed status fires a large decoration delta), not the cause.

### Fix

Throttle the initial fire-and-forget `repository.status()` calls across repositories via a model-level `Limiter<void>(5)`. The repo is still registered with SCM immediately (`this.open(repository)` runs unchanged); only the resource/decoration population is throttled, which was already async.

Concurrency 5 matches existing uses in [extensions/git/src/repository.ts](extensions/git/src/repository.ts#L1645) and [extensions/git/src/git.ts](extensions/git/src/git.ts#L2290) — enough parallelism to keep cores busy without saturating the host.

Applies to runtime opens too (workspace-folder additions, `eventuallyScanPossibleGitRepositories`), so the same crash can't be reproduced by adding folders incrementally.

### Verification

- Typecheck passes (`tsc -p extensions/git --noEmit`).
- No existing tests depend on unbounded parallelism (smoke test waits on an event).
- Manual repro on the reporter's workspace would be ideal — flagging @lszomoru.

### Not in scope

- The redundant `git rev-parse --show-toplevel` calls for subfolders of already-opened repos (previously explored in #313856) would further cut process count but don't change the crash dynamics; better as a follow-up so each change can be evaluated independently.