### PR TITLE
Chronicle: Support space-form slash subcommands 

### DIFF
--- a/extensions/copilot/assets/prompts/skills/chronicle/SKILL.md
+++ b/extensions/copilot/assets/prompts/skills/chronicle/SKILL.md
@@ -29,7 +29,7 @@ When the user asks for a standup, daily summary, or "what did I do":
 
 1. Call `copilot_sessionStoreSql` with `action: "standup"` and `description: "Generate standup"`.
 2. The tool returns pre-fetched session data (sessions, turns, files, refs from the last 24 hours).
-3. If the result is empty, tell the user no sessions were found in the last 24h, suggest `/chronicle:reindex`, and stop — do not fabricate a standup.
+3. If the result is empty, tell the user no sessions were found in the last 24h, suggest `/chronicle reindex`, and stop — do not fabricate a standup.
 4. For any PR references in the data, check their current status (open, merged, draft) if possible.
 5. Format the returned data as a standup report grouped by work stream (branch/feature):
 
@@ -100,7 +100,7 @@ When recommending custom skills, agents, or instructions as a tip, consult the *
 
 ### Cost Tips
 
-When the user asks for cost tips, ways to reduce token usage, or how to lower Copilot spend (e.g. `/chronicle:cost-tips`):
+When the user asks for cost tips, ways to reduce token usage, or how to lower Copilot spend (e.g. `/chronicle cost-tips`):
 
 The goal is **personalized, data-grounded recommendations** for reducing token usage — not a generic checklist. Every tip must point to a specific pattern you observed in their data.
 
@@ -178,7 +178,7 @@ If the session store has little data (e.g., cloud store is empty, or only a hand
 
 ### Improve
 
-When the user asks to improve their agent instructions based on session history (e.g. `/chronicle:improve`):
+When the user asks to improve their agent instructions based on session history (e.g. `/chronicle improve`):
 
 **Step 1: Read the current instructions file**
 
@@ -210,7 +210,7 @@ After presenting all recommendations, ask the user which ones they'd like to app
 
 ### Search
 
-When the user asks to search, find, or look up past sessions by keyword (e.g. `/chronicle:search <query>`):
+When the user asks to search, find, or look up past sessions by keyword (e.g. `/chronicle search <query>`):
 
 **Search strategy**
 
@@ -272,8 +272,8 @@ Rules:
 If no rows are returned, tell the user and suggest:
 - Trying different keywords or a broader search term (single word, or a substring instead of a phrase)
 - Widening the time window ("search all time", "include older sessions")
-- Running `/chronicle:reindex` if they haven't indexed their sessions yet
-- Running `/chronicle:standup` to see recent activity
+- Running `/chronicle reindex` if they haven't indexed their sessions yet
+- Running `/chronicle standup` to see recent activity
 
 ### Reindex
 

--- a/extensions/copilot/assets/prompts/skills/init/SKILL.md
+++ b/extensions/copilot/assets/prompts/skills/init/SKILL.md
@@ -47,4 +47,4 @@ When complete, print a table of the added or modified chat customization files, 
 
 Once finalized, propose related agent-customizations to create next (`/create-(agent|hook|instruction|prompt|skill) …`), explaining the customization and how it would be used in practice.
 
-If session history is available, use the **chronicle** skill to check for friction patterns in past sessions — this can surface project-specific conventions or pitfalls that codebase exploration alone wouldn't reveal. Mention `/chronicle:improve` to the user as a way to iteratively refine instructions over time.
+If session history is available, use the **chronicle** skill to check for friction patterns in past sessions — this can surface project-specific conventions or pitfalls that codebase exploration alone wouldn't reveal. Mention `/chronicle improve` to the user as a way to iteratively refine instructions over time.

--- a/extensions/copilot/src/extension/chronicle/vscode-node/remoteSessionExporter.ts
+++ b/extensions/copilot/src/extension/chronicle/vscode-node/remoteSessionExporter.ts
@@ -692,7 +692,7 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 		this._setSyncState({ kind: 'up-to-date', syncedCount: this._getLocalSyncedCount() });
 	}
 
-	// ── Cloud reindex (called from /chronicle:reindex) ──────────────────────────
+	// ── Cloud reindex (called from /chronicle reindex) ─────────────────────────
 
 	/**
 	 * Reindex all local sessions to the cloud. Creates cloud sessions for

--- a/extensions/copilot/src/extension/chronicle/vscode-node/sessionSyncStatus.ts
+++ b/extensions/copilot/src/extension/chronicle/vscode-node/sessionSyncStatus.ts
@@ -90,13 +90,13 @@ export class SessionSyncStatus extends Disposable {
 
 			case 'on':
 				this._statusItem.description = `$(check) ${l10n.t('Enabled')}`;
-				this._statusItem.detail = `[${l10n.t('Show insights?')}](command:workbench.action.chat.open?%7B%22query%22%3A%22%2Fchronicle%3Atips%22%7D)`;
+				this._statusItem.detail = `[${l10n.t('Show insights?')}](command:workbench.action.chat.open?%7B%22query%22%3A%22%2Fchronicle%20tips%22%7D)`;
 				this._statusItem.tooltip = l10n.t('Your sessions are being synced and available across devices.');
 				break;
 
 			case 'up-to-date':
 				this._statusItem.description = `$(check) [${l10n.t('{0} sessions synced', state.syncedCount)}](${sessionsOnGitHubLink})`;
-				this._statusItem.detail = `[${l10n.t('Show insights?')}](command:workbench.action.chat.open?%7B%22query%22%3A%22%2Fchronicle%3Atips%22%7D)`;
+				this._statusItem.detail = `[${l10n.t('Show insights?')}](command:workbench.action.chat.open?%7B%22query%22%3A%22%2Fchronicle%20tips%22%7D)`;
 				this._statusItem.tooltip = l10n.t('Your sessions are being synced and available across devices. Click to view them on GitHub.');
 				break;
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/editor/chatInputCompletions.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/editor/chatInputCompletions.ts
@@ -269,13 +269,18 @@ class SlashCommandCompletions extends Disposable {
 
 				return {
 					suggestions: userInvocableCommands.map((c, i): CompletionItem => {
-						const label = `/${c.name}`;
+						const colonLabel = `/${c.name}`;
+						const hasSubcommand = c.name.includes(':');
+						const displayLabel = hasSubcommand ? `/${c.name.replace(/:/g, ' ')}` : colonLabel;
 						const description = c.description;
 						return {
-							label: { label, description },
-							insertText: `${label} `,
+							label: { label: displayLabel, description },
+							insertText: `${displayLabel} `,
 							documentation: c.description,
 							range,
+							// Allow matching by either the space form (what the user sees) or the
+							// colon form (so legacy `/chronicle:tips` typing still filters).
+							filterText: hasSubcommand ? `${colonLabel} ${displayLabel}` : undefined,
 							sortText: 'a'.repeat(i + 1),
 							kind: CompletionItemKind.Text, // The icons are disabled here anyway,
 						};

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
@@ -593,8 +593,10 @@ export interface IPromptsService extends IDisposable {
 
 	/**
 	 * Synchronously checks whether `name` matches a discovered prompt slash command.
-	 * Backed by the cached slash-command list, which is populated asynchronously, so
-	 * this may return `false` for known commands before the first discovery completes.
+	 * Backed by a cache that is populated lazily on the first call and refreshed on
+	 * subsequent {@link onDidChangeSlashCommands} firings, so the very first call after
+	 * service creation may return `false` for known commands until the first discovery
+	 * completes.
 	 */
 	hasPromptSlashCommand(name: string): boolean;
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
@@ -592,6 +592,13 @@ export interface IPromptsService extends IDisposable {
 	isValidSlashCommandName(name: string): boolean;
 
 	/**
+	 * Synchronously checks whether `name` matches a discovered prompt slash command.
+	 * Backed by the cached slash-command list, which is populated asynchronously, so
+	 * this may return `false` for known commands before the first discovery completes.
+	 */
+	hasPromptSlashCommand(name: string): boolean;
+
+	/**
 	 * Gets the prompt file for a slash command.
 	 */
 	resolvePromptSlashCommand(command: string, sessionType: string | undefined, token: CancellationToken): Promise<IResolvedChatPromptSlashCommand | undefined>;

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
@@ -204,9 +204,6 @@ export class PromptsService extends Disposable implements IPromptsService {
 			)
 		));
 
-		this.hydrateKnownPromptSlashCommandNames();
-		this._register(this.onDidChangeSlashCommands(() => this.hydrateKnownPromptSlashCommandNames()));
-
 		this._register(this.watchPluginPromptFilesForType(
 			PromptsType.prompt,
 			(plugin, reader) => plugin.commands.read(reader),
@@ -508,10 +505,17 @@ export class PromptsService extends Disposable implements IPromptsService {
 	}
 
 	public hasPromptSlashCommand(name: string): boolean {
+		if (!this.knownPromptSlashCommandsHydrationStarted) {
+			this.knownPromptSlashCommandsHydrationStarted = true;
+			this.refreshKnownPromptSlashCommandNames();
+			this._register(this.onDidChangeSlashCommands(() => this.refreshKnownPromptSlashCommandNames()));
+		}
 		return this.knownPromptSlashCommandNames.has(name);
 	}
 
-	private hydrateKnownPromptSlashCommandNames(): void {
+	private knownPromptSlashCommandsHydrationStarted = false;
+
+	private refreshKnownPromptSlashCommandNames(): void {
 		this.getPromptSlashCommands(CancellationToken.None).then(commands => {
 			this.knownPromptSlashCommandNames.clear();
 			for (const cmd of commands) {

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
@@ -85,6 +85,13 @@ export class PromptsService extends Disposable implements IPromptsService {
 	private readonly cachedInstructions: CachedPromise<IInstructionDiscoveryInfo>;
 
 	/**
+	 * Synchronous mirror of the names exposed by {@link getPromptSlashCommands},
+	 * maintained for {@link hasPromptSlashCommand} so callers (e.g. the chat request
+	 * parser) can disambiguate `<cmd>:<sub>` vs bare `<cmd>` without an async hop.
+	 */
+	private readonly knownPromptSlashCommandNames = new Set<string>();
+
+	/**
 	 * Cache for parsed prompt files keyed by URI.
 	 * The number in the returned tuple is textModel.getVersionId(), which is an internal VS Code counter that increments every time the text model's content changes.
 	 */
@@ -196,6 +203,9 @@ export class PromptsService extends Disposable implements IPromptsService {
 				Event.filter(this._onDidPluginPromptFilesChange.event, t => t === PromptsType.instructions),
 			)
 		));
+
+		this.hydrateKnownPromptSlashCommandNames();
+		this._register(this.onDidChangeSlashCommands(() => this.hydrateKnownPromptSlashCommandNames()));
 
 		this._register(this.watchPluginPromptFilesForType(
 			PromptsType.prompt,
@@ -495,6 +505,19 @@ export class PromptsService extends Disposable implements IPromptsService {
 
 	public isValidSlashCommandName(command: string): boolean {
 		return command.match(/^[\p{L}\d_\-\.:]+$/u) !== null;
+	}
+
+	public hasPromptSlashCommand(name: string): boolean {
+		return this.knownPromptSlashCommandNames.has(name);
+	}
+
+	private hydrateKnownPromptSlashCommandNames(): void {
+		this.getPromptSlashCommands(CancellationToken.None).then(commands => {
+			this.knownPromptSlashCommandNames.clear();
+			for (const cmd of commands) {
+				this.knownPromptSlashCommandNames.add(cmd.name);
+			}
+		}, () => { /* discovery failures already logged; sync cache stays as-is */ });
 	}
 
 	public async resolvePromptSlashCommand(name: string, sessionType: string | undefined, token: CancellationToken): Promise<IResolvedChatPromptSlashCommand | undefined> {

--- a/src/vs/workbench/contrib/chat/common/requestParser/chatParserTypes.ts
+++ b/src/vs/workbench/contrib/chat/common/requestParser/chatParserTypes.ts
@@ -183,14 +183,22 @@ export class ChatRequestSlashCommandPart implements IParsedChatRequestPart {
 export class ChatRequestSlashPromptPart implements IParsedChatRequestPart {
 	static readonly Kind = 'prompt';
 	readonly kind = ChatRequestSlashPromptPart.Kind;
-	constructor(readonly range: OffsetRange, readonly editorRange: IRange, readonly name: string) { }
+	readonly displayText?: string;
+	constructor(readonly range: OffsetRange, readonly editorRange: IRange, readonly name: string, displayText?: string) {
+		// Only set the own property when provided so the canonical
+		// form (no `displayText` field) stays compatible with snapshots
+		// and existing serialization.
+		if (displayText !== undefined) {
+			this.displayText = displayText;
+		}
+	}
 
 	get text(): string {
-		return `${chatSubcommandLeader}${this.name}`;
+		return this.displayText ?? `${chatSubcommandLeader}${this.name}`;
 	}
 
 	get promptText(): string {
-		return `${chatSubcommandLeader}${this.name}`;
+		return this.displayText ?? `${chatSubcommandLeader}${this.name}`;
 	}
 }
 
@@ -280,7 +288,8 @@ export function reviveParsedChatRequest(serialized: IParsedChatRequest): IParsed
 				return new ChatRequestSlashPromptPart(
 					new OffsetRange(part.range.start, part.range.endExclusive),
 					part.editorRange,
-					(part as ChatRequestSlashPromptPart).name
+					(part as ChatRequestSlashPromptPart).name,
+					(part as ChatRequestSlashPromptPart).displayText
 				);
 			} else if (part.kind === ChatRequestDynamicVariablePart.Kind) {
 				return new ChatRequestDynamicVariablePart(

--- a/src/vs/workbench/contrib/chat/common/requestParser/chatRequestParser.ts
+++ b/src/vs/workbench/contrib/chat/common/requestParser/chatRequestParser.ts
@@ -249,8 +249,26 @@ export class ChatRequestParser {
 				}
 			}
 
-			// if there's no agent or attachments are supported, asume it is a prompt slash command
+			// Fallback: try `<cmd>:<sub>` if the bare command isn't itself a known prompt.
+			// Supports the space-form subcommand grammar (e.g. `/chronicle tips` resolves to
+			// the `chronicle:tips` prompt) so users don't need to type the colon separator.
 			const isPromptCommand = this.promptsService.isValidSlashCommandName(command);
+			if (!isPromptCommand) {
+				const afterSlash = remainingMessage.slice(full.length);
+				const subMatch = afterSlash.match(/^[ \t]+([\p{L}\d_\-\.]+)/u);
+				if (subMatch) {
+					const candidate = `${command}:${subMatch[1]}`;
+					if (this.promptsService.isValidSlashCommandName(candidate)) {
+						const consumedLength = full.length + subMatch[0].length;
+						const extendedRange = new OffsetRange(offset, offset + consumedLength);
+						const extendedEditorRange = new Range(position.lineNumber, position.column, position.lineNumber, position.column + consumedLength);
+						const displayText = remainingMessage.slice(0, consumedLength);
+						return new ChatRequestSlashPromptPart(extendedRange, extendedEditorRange, candidate, displayText);
+					}
+				}
+			}
+
+			// if there's no agent or attachments are supported, asume it is a prompt slash command
 			if (isPromptCommand) {
 				return new ChatRequestSlashPromptPart(slashRange, slashEditorRange, command);
 			}

--- a/src/vs/workbench/contrib/chat/common/requestParser/chatRequestParser.ts
+++ b/src/vs/workbench/contrib/chat/common/requestParser/chatRequestParser.ts
@@ -249,27 +249,27 @@ export class ChatRequestParser {
 				}
 			}
 
-			// Fallback: try `<cmd>:<sub>` if the bare command isn't itself a known prompt.
+			// Fallback: try `<cmd>:<sub>` if a prompt with that combined name exists.
 			// Supports the space-form subcommand grammar (e.g. `/chronicle tips` resolves to
 			// the `chronicle:tips` prompt) so users don't need to type the colon separator.
-			const isPromptCommand = this.promptsService.isValidSlashCommandName(command);
-			if (!isPromptCommand) {
-				const afterSlash = remainingMessage.slice(full.length);
-				const subMatch = afterSlash.match(/^[ \t]+([\p{L}\d_\-\.]+)/u);
-				if (subMatch) {
-					const candidate = `${command}:${subMatch[1]}`;
-					if (this.promptsService.isValidSlashCommandName(candidate)) {
-						const consumedLength = full.length + subMatch[0].length;
-						const extendedRange = new OffsetRange(offset, offset + consumedLength);
-						const extendedEditorRange = new Range(position.lineNumber, position.column, position.lineNumber, position.column + consumedLength);
-						const displayText = remainingMessage.slice(0, consumedLength);
-						return new ChatRequestSlashPromptPart(extendedRange, extendedEditorRange, candidate, displayText);
-					}
+			// Checked before bare-command interpretation because `isValidSlashCommandName` is
+			// syntactic only — bare `<cmd>` always passes, so we must commit to the longer
+			// match here when the discovered prompt list contains it.
+			const afterSlash = remainingMessage.slice(full.length);
+			const subMatch = afterSlash.match(/^[ \t]+([\p{L}\d_\-\.]+)/u);
+			if (subMatch) {
+				const candidate = `${command}:${subMatch[1]}`;
+				if (this.promptsService.hasPromptSlashCommand(candidate)) {
+					const consumedLength = full.length + subMatch[0].length;
+					const extendedRange = new OffsetRange(offset, offset + consumedLength);
+					const extendedEditorRange = new Range(position.lineNumber, position.column, position.lineNumber, position.column + consumedLength);
+					const displayText = remainingMessage.slice(0, consumedLength);
+					return new ChatRequestSlashPromptPart(extendedRange, extendedEditorRange, candidate, displayText);
 				}
 			}
 
 			// if there's no agent or attachments are supported, asume it is a prompt slash command
-			if (isPromptCommand) {
+			if (this.promptsService.isValidSlashCommandName(command)) {
 				return new ChatRequestSlashPromptPart(slashRange, slashEditorRange, command);
 			}
 		}

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/mockPromptsService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/mockPromptsService.ts
@@ -43,6 +43,7 @@ export class MockPromptsService implements IPromptsService {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	getResolvedSourceFolders(_type: any): Promise<readonly any[]> { throw new Error('Not implemented'); }
 	isValidSlashCommandName(_command: string): boolean { return false; }
+	hasPromptSlashCommand(_name: string): boolean { return false; }
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	resolvePromptSlashCommand(command: string, _sessionType: string | undefined, _token: CancellationToken): Promise<any> { throw new Error('Not implemented'); }
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/vs/workbench/contrib/chat/test/common/requestParser/chatRequestParser.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/requestParser/chatRequestParser.test.ts
@@ -196,6 +196,80 @@ suite('ChatRequestParser', () => {
 		await assertSnapshot(result);
 	});
 
+	test('prompt subcommand via space form resolves to colon-named prompt', () => {
+		const slashCommandService = mockObject<IChatSlashCommandService>()({ _serviceBrand: undefined });
+		slashCommandService.getCommands.returns([]);
+		instantiationService.stub(IChatSlashCommandService, slashCommandService);
+
+		const promptsService = mockObject<IPromptsService>()({ _serviceBrand: undefined });
+		promptsService.isValidSlashCommandName.callsFake((command: string) => command === 'chronicle:tips');
+		instantiationService.stub(IPromptsService, promptsService);
+
+		parser = instantiationService.createInstance(ChatRequestParser);
+		const result = parser.parseChatRequest(testSessionUri, '/chronicle tips show me insights');
+
+		const slashPart = result.parts.find(part => part.kind === 'prompt');
+		assert.deepStrictEqual({
+			kinds: result.parts.map(part => part.kind),
+			kind: slashPart?.kind,
+			name: (slashPart as { name?: string } | undefined)?.name,
+			text: slashPart?.text,
+			trailing: result.parts[result.parts.length - 1]?.text,
+		}, {
+			kinds: ['prompt', 'text'],
+			kind: 'prompt',
+			name: 'chronicle:tips',
+			text: '/chronicle tips',
+			trailing: ' show me insights',
+		});
+	});
+
+	test('prompt subcommand via colon form is unchanged', () => {
+		const slashCommandService = mockObject<IChatSlashCommandService>()({ _serviceBrand: undefined });
+		slashCommandService.getCommands.returns([]);
+		instantiationService.stub(IChatSlashCommandService, slashCommandService);
+
+		const promptsService = mockObject<IPromptsService>()({ _serviceBrand: undefined });
+		promptsService.isValidSlashCommandName.callsFake((command: string) => command === 'chronicle:tips');
+		instantiationService.stub(IPromptsService, promptsService);
+
+		parser = instantiationService.createInstance(ChatRequestParser);
+		const result = parser.parseChatRequest(testSessionUri, '/chronicle:tips show me insights');
+
+		const slashPart = result.parts.find(part => part.kind === 'prompt');
+		assert.deepStrictEqual({
+			kinds: result.parts.map(part => part.kind),
+			kind: slashPart?.kind,
+			name: (slashPart as { name?: string } | undefined)?.name,
+			text: slashPart?.text,
+			trailing: result.parts[result.parts.length - 1]?.text,
+		}, {
+			kinds: ['prompt', 'text'],
+			kind: 'prompt',
+			name: 'chronicle:tips',
+			text: '/chronicle:tips',
+			trailing: ' show me insights',
+		});
+	});
+
+	test('space form does not extend when no `<cmd>:<sub>` matches', () => {
+		const slashCommandService = mockObject<IChatSlashCommandService>()({ _serviceBrand: undefined });
+		slashCommandService.getCommands.returns([]);
+		instantiationService.stub(IChatSlashCommandService, slashCommandService);
+
+		const promptsService = mockObject<IPromptsService>()({ _serviceBrand: undefined });
+		promptsService.isValidSlashCommandName.returns(false);
+		instantiationService.stub(IPromptsService, promptsService);
+
+		parser = instantiationService.createInstance(ChatRequestParser);
+		const result = parser.parseChatRequest(testSessionUri, '/nonexistent tips');
+
+		assert.deepStrictEqual(
+			result.parts.map(part => part.kind),
+			['text'],
+		);
+	});
+
 	// test('variables', async () => {
 	// 	varService.hasVariable.returns(true);
 	// 	varService.getVariable.returns({ id: 'copilot.selection' });

--- a/src/vs/workbench/contrib/chat/test/common/requestParser/chatRequestParser.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/requestParser/chatRequestParser.test.ts
@@ -202,7 +202,8 @@ suite('ChatRequestParser', () => {
 		instantiationService.stub(IChatSlashCommandService, slashCommandService);
 
 		const promptsService = mockObject<IPromptsService>()({ _serviceBrand: undefined });
-		promptsService.isValidSlashCommandName.callsFake((command: string) => command === 'chronicle:tips');
+		promptsService.isValidSlashCommandName.returns(true);
+		promptsService.hasPromptSlashCommand.callsFake((name: string) => name === 'chronicle:tips');
 		instantiationService.stub(IPromptsService, promptsService);
 
 		parser = instantiationService.createInstance(ChatRequestParser);
@@ -230,7 +231,8 @@ suite('ChatRequestParser', () => {
 		instantiationService.stub(IChatSlashCommandService, slashCommandService);
 
 		const promptsService = mockObject<IPromptsService>()({ _serviceBrand: undefined });
-		promptsService.isValidSlashCommandName.callsFake((command: string) => command === 'chronicle:tips');
+		promptsService.isValidSlashCommandName.returns(true);
+		promptsService.hasPromptSlashCommand.callsFake((name: string) => name === 'chronicle:tips');
 		instantiationService.stub(IPromptsService, promptsService);
 
 		parser = instantiationService.createInstance(ChatRequestParser);
@@ -258,16 +260,25 @@ suite('ChatRequestParser', () => {
 		instantiationService.stub(IChatSlashCommandService, slashCommandService);
 
 		const promptsService = mockObject<IPromptsService>()({ _serviceBrand: undefined });
-		promptsService.isValidSlashCommandName.returns(false);
+		promptsService.isValidSlashCommandName.returns(true);
+		promptsService.hasPromptSlashCommand.returns(false);
 		instantiationService.stub(IPromptsService, promptsService);
 
 		parser = instantiationService.createInstance(ChatRequestParser);
 		const result = parser.parseChatRequest(testSessionUri, '/nonexistent tips');
 
-		assert.deepStrictEqual(
-			result.parts.map(part => part.kind),
-			['text'],
-		);
+		const slashPart = result.parts.find(part => part.kind === 'prompt');
+		assert.deepStrictEqual({
+			kinds: result.parts.map(part => part.kind),
+			name: (slashPart as { name?: string } | undefined)?.name,
+			text: slashPart?.text,
+			trailing: result.parts[result.parts.length - 1]?.text,
+		}, {
+			kinds: ['prompt', 'text'],
+			name: 'nonexistent',
+			text: '/nonexistent',
+			trailing: ' tips',
+		});
 	});
 
 	// test('variables', async () => {


### PR DESCRIPTION
## Summary

Lets users invoke prompt-file subcommands using the CLI-aligned space-form (`/chronicle tips`) This resolves to the same underlying prompt file (`chronicle:tips`) — no prompt files were renamed or duplicated.

## Approach

Convention-based, zero schema change. The parser treats `:` in a prompt name as a parent/child marker only at lookup time; prompt frontmatter (`name: chronicle:tips`) is untouched.

### 1. Parser fallback — `chatRequestParser.ts`

When `/<cmd>` is not itself a valid prompt, peek the next whitespace-separated word and try `<cmd>:<sub>`. If that resolves, consume both tokens as a single slash-prompt part.

### 2. Faithful transcript rendering — `chatParserTypes.ts`

Added an optional `displayText` on `ChatRequestSlashPromptPart` so the rendered text matches what the user typed (`/chronicle tips`) instead of the synthesized colon form. The field is only set when the new fallback branch fires — bit-identical behavior for all existing flows (verified by unchanged snapshots).

### 3. Completion cosmetics — `chatInputCompletions.ts`

Picker labels for `<cmd>:<sub>` prompts show as `/<cmd> <sub>`; `filterText` keeps both forms matchable so legacy typing still filters.


## Backward compatibility

- `/chronicle:tips` still parses identically (legacy path untouched).
- No prompt files renamed, no proposed API changes, no new completion provider.
- Snapshot tests confirm zero behavior change for non-`:` commands.


## Auto-complete UI

<img width="771" height="298" alt="image" src="https://github.com/user-attachments/assets/4e9444fe-81f9-4d5c-97bc-89df292dace3" />
