### PR TITLE
otel: normalize gen_ai.response.model to match request format

### DIFF
--- a/extensions/copilot/docs/monitoring/agent_monitoring.md
+++ b/extensions/copilot/docs/monitoring/agent_monitoring.md
@@ -640,7 +640,7 @@ copilot-chat invoke_agent claude               [~33s]
 | `gen_ai.agent.name` | `claude` |
 | `gen_ai.provider.name` | `github` |
 | `gen_ai.request.model` | `claude-haiku-4.5` |
-| `gen_ai.response.model` | `claude-haiku-4-5` |
+| `gen_ai.response.model` | `claude-haiku-4.5` |
 | `gen_ai.usage.input_tokens` | `103739` (parent-only, excludes subagent tokens) |
 | `gen_ai.usage.output_tokens` | `1100` |
 | `gen_ai.usage.cache_read.input_tokens` | `64062` |

--- a/extensions/copilot/src/extension/chatSessions/claude/node/claudeOTelTracker.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/node/claudeOTelTracker.ts
@@ -5,7 +5,7 @@
 
 import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
 import { IGitService } from '../../../../platform/git/common/gitService';
-import { CopilotChatAttr, emitSessionStartEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, GenAiProviderName, GitHubCopilotAttr, IOTelService, type ISpanHandle, resolveWorkspaceOTelMetadata, SpanKind, SpanStatusCode, type TraceContext, truncateForOTel, workspaceMetadataToOTelAttributes } from '../../../../platform/otel/common/index';
+import { CopilotChatAttr, emitSessionStartEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, GenAiProviderName, GitHubCopilotAttr, IOTelService, type ISpanHandle, normalizeResponseModel, resolveWorkspaceOTelMetadata, SpanKind, SpanStatusCode, type TraceContext, truncateForOTel, workspaceMetadataToOTelAttributes } from '../../../../platform/otel/common/index';
 import { IClaudeSessionStateService } from '../common/claudeSessionStateService';
 
 /**
@@ -21,6 +21,7 @@ export class ClaudeOTelTracker {
 	private _startTime: number | undefined;
 	private _isFirstRequest = true;
 	private _turnCount = 0;
+	private _currentRequestModel: string | undefined;
 	private _parentInputTokens = 0;
 	private _parentOutputTokens = 0;
 	private _parentCacheReadTokens = 0;
@@ -62,6 +63,7 @@ export class ClaudeOTelTracker {
 		this._currentTraceContext = this._currentSpan.getSpanContext();
 		this._startTime = Date.now();
 		this._turnCount = 0;
+		this._currentRequestModel = modelId;
 		this._parentInputTokens = 0;
 		this._parentOutputTokens = 0;
 		this._parentCacheReadTokens = 0;
@@ -161,6 +163,7 @@ export class ClaudeOTelTracker {
 		this._currentSpan = undefined;
 		this._currentTraceContext = undefined;
 		this._startTime = undefined;
+		this._currentRequestModel = undefined;
 		this._sessionStateService.setTraceContextForSession(this._sessionId, undefined);
 	}
 
@@ -197,7 +200,8 @@ export class ClaudeOTelTracker {
 		if (message.total_cost_usd !== undefined) {
 			this._currentSpan.setAttribute(CopilotChatAttr.TOTAL_COST_USD, message.total_cost_usd);
 		}
-		const responseModel = message.modelUsage ? Object.keys(message.modelUsage)[0] : undefined;
+		const rawResponseModel = message.modelUsage ? Object.keys(message.modelUsage)[0] : undefined;
+		const responseModel = normalizeResponseModel(this._currentRequestModel, rawResponseModel);
 		if (responseModel) {
 			this._currentSpan.setAttribute(GenAiAttr.RESPONSE_MODEL, responseModel);
 		}

--- a/extensions/copilot/src/extension/intents/node/toolCallingLoop.ts
+++ b/extensions/copilot/src/extension/intents/node/toolCallingLoop.ts
@@ -22,7 +22,7 @@ import { ILogService } from '../../../platform/log/common/logService';
 import { isOpenAIContextManagementResponse, OpenAiFunctionDef } from '../../../platform/networking/common/fetch';
 import { IMakeChatRequestOptions } from '../../../platform/networking/common/networking';
 import { OpenAIContextManagementResponse } from '../../../platform/networking/common/openai';
-import { CopilotChatAttr, emitAgentTurnEvent, emitSessionStartEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, GenAiProviderName, GitHubCopilotAttr, resolveWorkspaceOTelMetadata, StdAttr, stringifyToolDefinitionsForOTel, truncateForOTel, workspaceMetadataToOTelAttributes } from '../../../platform/otel/common/index';
+import { CopilotChatAttr, emitAgentTurnEvent, emitSessionStartEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, GenAiProviderName, GitHubCopilotAttr, normalizeResponseModel, resolveWorkspaceOTelMetadata, StdAttr, stringifyToolDefinitionsForOTel, truncateForOTel, workspaceMetadataToOTelAttributes } from '../../../platform/otel/common/index';
 import { IOTelService, ISpanHandle, SpanKind, SpanStatusCode } from '../../../platform/otel/common/otelService';
 import { IRequestLogger } from '../../../platform/requestLogger/common/requestLogger';
 import { getCurrentCapturingToken } from '../../../platform/requestLogger/node/requestLogger';
@@ -825,8 +825,10 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 				}
 
 				// Set request model from the endpoint
+				let requestModel: string | undefined;
 				try {
 					const endpoint = await this._endpointProvider.getChatEndpoint(this.options.request);
+					requestModel = endpoint.model;
 					span.setAttribute(GenAiAttr.REQUEST_MODEL, endpoint.model);
 				} catch { /* endpoint not available yet, will be set on response */ }
 
@@ -878,7 +880,7 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 						[GenAiAttr.USAGE_OUTPUT_TOKENS]: totalOutputTokens,
 						...(totalCacheReadTokens ? { [GenAiAttr.USAGE_CACHE_READ_INPUT_TOKENS]: totalCacheReadTokens } : {}),
 						...(totalCacheCreationTokens ? { [GenAiAttr.USAGE_CACHE_CREATION_INPUT_TOKENS]: totalCacheCreationTokens } : {}),
-						...(lastResolvedModel ? { [GenAiAttr.RESPONSE_MODEL]: lastResolvedModel } : {}),
+						...(lastResolvedModel ? { [GenAiAttr.RESPONSE_MODEL]: normalizeResponseModel(requestModel, lastResolvedModel) ?? lastResolvedModel } : {}),
 					});
 					// Always capture agent output message and tool definitions for the debug panel
 					{

--- a/extensions/copilot/src/extension/intents/node/toolCallingLoop.ts
+++ b/extensions/copilot/src/extension/intents/node/toolCallingLoop.ts
@@ -813,24 +813,19 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 					}
 				}
 
-				// Emit session start event and metric for top-level agent invocations (not subagents)
-				if (!parentTraceContext) {
-					GenAiMetrics.incrementSessionCount(this._otelService);
-					try {
-						const endpoint = await this._endpointProvider.getChatEndpoint(this.options.request);
-						emitSessionStartEvent(this._otelService, this.options.conversation.sessionId, endpoint.model, agentName);
-					} catch {
-						emitSessionStartEvent(this._otelService, this.options.conversation.sessionId, 'unknown', agentName);
-					}
-				}
-
-				// Set request model from the endpoint
+				// Resolve the endpoint once for session start + request model attribute.
 				let requestModel: string | undefined;
 				try {
 					const endpoint = await this._endpointProvider.getChatEndpoint(this.options.request);
 					requestModel = endpoint.model;
 					span.setAttribute(GenAiAttr.REQUEST_MODEL, endpoint.model);
-				} catch { /* endpoint not available yet, will be set on response */ }
+				} catch { /* endpoint not yet available */ }
+
+				// Emit session start event and metric for top-level agent invocations (not subagents)
+				if (!parentTraceContext) {
+					GenAiMetrics.incrementSessionCount(this._otelService);
+					emitSessionStartEvent(this._otelService, this.options.conversation.sessionId, requestModel ?? 'unknown', agentName);
+				}
 
 				// Always capture user input message for the debug panel
 				{

--- a/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
+++ b/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
@@ -390,11 +390,15 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 							this._chatQuotaService.setLastCopilotUsage(result.usage.copilot_usage.total_nano_aiu, topLevelTurnId ?? turnId);
 						}
 
+						// Normalize once so span attributes, metric attributes, and the inference
+						// details event all report the same value (issue #318805).
+						const normalizedResponseModel = normalizeResponseModel(chatEndpoint.model, result.resolvedModel);
+
 						const metricAttrs = {
 							operationName: GenAiOperationName.CHAT,
 							providerName: GenAiProviderName.GITHUB,
 							requestModel: chatEndpoint.model,
-							responseModel: result.resolvedModel,
+							responseModel: normalizedResponseModel,
 						};
 						if (result.usage.prompt_tokens) {
 							GenAiMetrics.recordTokenUsage(this._otelService, result.usage.prompt_tokens, 'input', metricAttrs);
@@ -407,7 +411,7 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 						otelInferenceSpan?.setAttributes({
 							[GenAiAttr.USAGE_INPUT_TOKENS]: result.usage.prompt_tokens ?? 0,
 							[GenAiAttr.USAGE_OUTPUT_TOKENS]: result.usage.completion_tokens ?? 0,
-							[GenAiAttr.RESPONSE_MODEL]: normalizeResponseModel(chatEndpoint.model, result.resolvedModel) ?? chatEndpoint.model,
+							[GenAiAttr.RESPONSE_MODEL]: normalizedResponseModel ?? chatEndpoint.model,
 							[GenAiAttr.RESPONSE_ID]: result.requestId,
 							[GenAiAttr.RESPONSE_FINISH_REASONS]: ['stop'],
 							...(result.usage.prompt_tokens_details?.cached_tokens
@@ -471,7 +475,7 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 						},
 						result.type === ChatFetchResponseType.Success ? {
 							id: result.requestId,
-							model: result.resolvedModel,
+							model: normalizeResponseModel(chatEndpoint.model, result.resolvedModel),
 							finishReasons: ['stop'],
 							inputTokens: result.usage?.prompt_tokens,
 							outputTokens: result.usage?.completion_tokens,

--- a/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
+++ b/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
@@ -28,7 +28,7 @@ import { sendEngineMessagesTelemetry } from '../../../platform/networking/node/c
 import { CAPIWebSocketErrorEvent, IChatWebSocketManager, isCAPIWebSocketError } from '../../../platform/networking/node/chatWebSocketManager';
 import { sendCommunicationErrorTelemetry } from '../../../platform/networking/node/stream';
 import { ChatFailKind, ChatRequestCanceled, ChatRequestFailed, ChatResults, FetchResponseKind } from '../../../platform/openai/node/fetch';
-import { collectSystemTextsFromRequestBody, CopilotChatAttr, emitInferenceDetailsEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, GenAiProviderName, normalizeProviderMessages, StdAttr, stringifyToolDefinitionsForOTel, stringifyToolsRawForTelemetry, toSystemInstructions, truncateForOTel } from '../../../platform/otel/common/index';
+import { collectSystemTextsFromRequestBody, CopilotChatAttr, emitInferenceDetailsEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, GenAiProviderName, normalizeProviderMessages, normalizeResponseModel, StdAttr, stringifyToolDefinitionsForOTel, stringifyToolsRawForTelemetry, toSystemInstructions, truncateForOTel } from '../../../platform/otel/common/index';
 import { IOTelService, ISpanHandle, SpanKind, SpanStatusCode } from '../../../platform/otel/common/otelService';
 import { IRequestLogger } from '../../../platform/requestLogger/common/requestLogger';
 import { getCurrentCapturingToken } from '../../../platform/requestLogger/node/requestLogger';
@@ -407,7 +407,7 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 						otelInferenceSpan?.setAttributes({
 							[GenAiAttr.USAGE_INPUT_TOKENS]: result.usage.prompt_tokens ?? 0,
 							[GenAiAttr.USAGE_OUTPUT_TOKENS]: result.usage.completion_tokens ?? 0,
-							[GenAiAttr.RESPONSE_MODEL]: result.resolvedModel ?? chatEndpoint.model,
+							[GenAiAttr.RESPONSE_MODEL]: normalizeResponseModel(chatEndpoint.model, result.resolvedModel) ?? chatEndpoint.model,
 							[GenAiAttr.RESPONSE_ID]: result.requestId,
 							[GenAiAttr.RESPONSE_FINISH_REASONS]: ['stop'],
 							...(result.usage.prompt_tokens_details?.cached_tokens

--- a/extensions/copilot/src/platform/otel/common/index.ts
+++ b/extensions/copilot/src/platform/otel/common/index.ts
@@ -11,5 +11,6 @@ export { collectSystemTextsFromRequestBody, extractTextFromContent, normalizePro
 export { NoopOTelService } from './noopOtelService';
 export { resolveOTelConfig, DEFAULT_OTLP_ENDPOINT, type OTelConfig, type OTelConfigInput } from './otelConfig';
 export { IOTelService, SpanKind, SpanStatusCode, type ICompletedSpanData, type ISpanEventData, type ISpanEventRecord, type ISpanHandle, type OTelModelOptions, type SpanOptions, type TraceContext } from './otelService';
+export { normalizeResponseModel } from './responseModel';
 export { resolveWorkspaceOTelMetadata, workspaceMetadataToOTelAttributes, type WorkspaceOTelMetadata } from './workspaceOTelMetadata';
 

--- a/extensions/copilot/src/platform/otel/common/responseModel.ts
+++ b/extensions/copilot/src/platform/otel/common/responseModel.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Normalizes `gen_ai.response.model` so it stays consistent with
+ * `gen_ai.request.model` when they refer to the same logical model and only
+ * differ in `.` vs `-` (e.g. `claude-opus-4.6` vs `claude-opus-4-6`).
+ * Returns the resolved value unchanged when it adds real specificity
+ * (e.g. `gpt-5.4-mini` → `gpt-5.4-mini-2026-03-17`).
+ */
+export function normalizeResponseModel(requestModel: string | undefined, responseModel: string | undefined): string | undefined {
+	if (!responseModel) {
+		return undefined;
+	}
+	if (!requestModel) {
+		return responseModel;
+	}
+	const canonical = (s: string) => s.replace(/\./g, '-').toLowerCase();
+	return canonical(requestModel) === canonical(responseModel) ? requestModel : responseModel;
+}

--- a/extensions/copilot/src/platform/otel/common/responseModel.ts
+++ b/extensions/copilot/src/platform/otel/common/responseModel.ts
@@ -5,10 +5,18 @@
 
 /**
  * Normalizes `gen_ai.response.model` so it stays consistent with
- * `gen_ai.request.model` when they refer to the same logical model and only
- * differ in `.` vs `-` (e.g. `claude-opus-4.6` vs `claude-opus-4-6`).
- * Returns the resolved value unchanged when it adds real specificity
- * (e.g. `gpt-5.4-mini` → `gpt-5.4-mini-2026-03-17`).
+ * `gen_ai.request.model` when they refer to the same logical model.
+ *
+ * Returns the request model when:
+ * - Their canonical forms (lowercase, `.`→`-`) are equal, e.g.
+ *   `claude-opus-4.6` vs `claude-opus-4-6`.
+ * - The response is a less specific prefix of the request (server stripped a
+ *   variant suffix like reasoning effort), e.g. request
+ *   `claude-opus-4.7-high` vs response `claude-opus-4-7`.
+ *
+ * Returns the response model unchanged when it adds real specificity
+ * (e.g. `gpt-5.4-mini` → `gpt-5.4-mini-2026-03-17`) or refers to a
+ * genuinely different model.
  */
 export function normalizeResponseModel(requestModel: string | undefined, responseModel: string | undefined): string | undefined {
 	if (!responseModel) {
@@ -18,5 +26,16 @@ export function normalizeResponseModel(requestModel: string | undefined, respons
 		return responseModel;
 	}
 	const canonical = (s: string) => s.replace(/\./g, '-').toLowerCase();
-	return canonical(requestModel) === canonical(responseModel) ? requestModel : responseModel;
+	const cReq = canonical(requestModel);
+	const cRes = canonical(responseModel);
+	if (cReq === cRes) {
+		return requestModel;
+	}
+	// Response is a less specific form of the request (e.g. request adds
+	// a reasoning-effort suffix that the server strips). Require a `-`
+	// boundary so `gpt-4` is not treated as a prefix of `gpt-40`.
+	if (cReq.startsWith(cRes + '-')) {
+		return requestModel;
+	}
+	return responseModel;
 }

--- a/extensions/copilot/src/platform/otel/common/test/responseModel.spec.ts
+++ b/extensions/copilot/src/platform/otel/common/test/responseModel.spec.ts
@@ -18,6 +18,17 @@ describe('normalizeResponseModel', () => {
 		expect(normalizeResponseModel('gpt-4o', 'gpt-4o-2024-08-06')).toBe('gpt-4o-2024-08-06');
 	});
 
+	it('echoes the request model when the response strips a request-only suffix (e.g. reasoning effort)', () => {
+		// Server strips the `-high` reasoning-effort qualifier and uses `-` punctuation.
+		expect(normalizeResponseModel('claude-opus-4.7-high', 'claude-opus-4-7')).toBe('claude-opus-4.7-high');
+		expect(normalizeResponseModel('claude-opus-4.6-medium', 'claude-opus-4-6')).toBe('claude-opus-4.6-medium');
+	});
+
+	it('does not treat unrelated models that share a numeric-looking prefix as the same', () => {
+		// `gpt-4` is not a prefix of `gpt-40` because we require a `-` boundary.
+		expect(normalizeResponseModel('gpt-4', 'gpt-40')).toBe('gpt-40');
+	});
+
 	it('returns the response model unchanged when it equals the request model', () => {
 		expect(normalizeResponseModel('gpt-4o-mini-2024-07-18', 'gpt-4o-mini-2024-07-18')).toBe('gpt-4o-mini-2024-07-18');
 	});

--- a/extensions/copilot/src/platform/otel/common/test/responseModel.spec.ts
+++ b/extensions/copilot/src/platform/otel/common/test/responseModel.spec.ts
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it } from 'vitest';
+import { normalizeResponseModel } from '../responseModel';
+
+describe('normalizeResponseModel', () => {
+	it('echoes the request model when the response model only differs by `.` vs `-` (issue #318805)', () => {
+		expect(normalizeResponseModel('claude-opus-4.6', 'claude-opus-4-6')).toBe('claude-opus-4.6');
+		expect(normalizeResponseModel('claude-haiku-4.5', 'claude-haiku-4-5')).toBe('claude-haiku-4.5');
+		expect(normalizeResponseModel('claude-sonnet-4.6', 'claude-sonnet-4-6')).toBe('claude-sonnet-4.6');
+	});
+
+	it('returns the resolved model when it adds specificity (e.g. dated snapshot)', () => {
+		expect(normalizeResponseModel('gpt-5.4-mini', 'gpt-5.4-mini-2026-03-17')).toBe('gpt-5.4-mini-2026-03-17');
+		expect(normalizeResponseModel('gpt-4o', 'gpt-4o-2024-08-06')).toBe('gpt-4o-2024-08-06');
+	});
+
+	it('returns the response model unchanged when it equals the request model', () => {
+		expect(normalizeResponseModel('gpt-4o-mini-2024-07-18', 'gpt-4o-mini-2024-07-18')).toBe('gpt-4o-mini-2024-07-18');
+	});
+
+	it('is case-insensitive when comparing logical model identity', () => {
+		expect(normalizeResponseModel('Claude-Opus-4.6', 'claude-opus-4-6')).toBe('Claude-Opus-4.6');
+	});
+
+	it('returns undefined when no response model is provided', () => {
+		expect(normalizeResponseModel('claude-opus-4.6', undefined)).toBeUndefined();
+		expect(normalizeResponseModel(undefined, undefined)).toBeUndefined();
+	});
+
+	it('returns the response model when no request model is available', () => {
+		expect(normalizeResponseModel(undefined, 'claude-opus-4-6')).toBe('claude-opus-4-6');
+	});
+});

--- a/extensions/copilot/src/platform/otel/common/test/responseModel.spec.ts
+++ b/extensions/copilot/src/platform/otel/common/test/responseModel.spec.ts
@@ -22,6 +22,8 @@ describe('normalizeResponseModel', () => {
 		// Server strips the `-high` reasoning-effort qualifier and uses `-` punctuation.
 		expect(normalizeResponseModel('claude-opus-4.7-high', 'claude-opus-4-7')).toBe('claude-opus-4.7-high');
 		expect(normalizeResponseModel('claude-opus-4.6-medium', 'claude-opus-4-6')).toBe('claude-opus-4.6-medium');
+		// Server strips variant qualifiers like `-1m-internal`.
+		expect(normalizeResponseModel('claude-opus-4.7-1m-internal', 'claude-opus-4-7')).toBe('claude-opus-4.7-1m-internal');
 	});
 
 	it('does not treat unrelated models that share a numeric-looking prefix as the same', () => {


### PR DESCRIPTION
Fixes #318805.

Anthropic responses echo the same logical model with a different separator (e.g. request `claude-opus-4.6` resolves to `claude-opus-4-6`), causing `GROUP BY` / `DISTINCT` on `gen_ai.response.model` to produce duplicate rows downstream.

### Change

Add `normalizeResponseModel(requestModel, responseModel)` that echoes the request value when the two strings only differ in `.` vs `-` (case-insensitive), and returns the resolved value unchanged when it adds real specificity.

| request | response (before) | response (after) |
|---|---|---|
| \`claude-opus-4.6\` | \`claude-opus-4-6\` | \`claude-opus-4.6\` |
| \`gpt-5.4-mini\` | \`gpt-5.4-mini-2026-03-17\` | \`gpt-5.4-mini-2026-03-17\` (unchanged) |
| \`gpt-4o-mini-2024-07-18\` | \`gpt-4o-mini-2024-07-18\` | \`gpt-4o-mini-2024-07-18\` (unchanged) |

Wired into the three call sites that set \`gen_ai.response.model\`:
- \`chatMLFetcher.ts\` — \`chat\` spans
- \`toolCallingLoop.ts\` — foreground \`invoke_agent\` spans
- \`claudeOTelTracker.ts\` — Claude \`invoke_agent\` spans (stashes request model so the result message can normalize against it)

### Tests

- New: \`responseModel.spec.ts\` (6 tests covering the issue's observed cases)
- All 216 tests in \`platform/otel/\` pass