### PR TITLE
Propagate plugin format to Claude target resolution

### DIFF
--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginService.ts
@@ -9,7 +9,7 @@ import { basename } from '../../../../../base/common/resources.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { SyncDescriptor0 } from '../../../../../platform/instantiation/common/descriptors.js';
 import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
-import { type INamedPluginResource, type IMcpServerDefinition, type IParsedHookCommand } from '../../../../../platform/agentPlugins/common/pluginParsers.js';
+import { type INamedPluginResource, type IMcpServerDefinition, type IParsedHookCommand, type PluginFormat } from '../../../../../platform/agentPlugins/common/pluginParsers.js';
 import { ContributionEnablementState, IEnablementModel } from '../enablement.js';
 import { HookType } from '../promptSyntax/hookTypes.js';
 import { IMarketplacePlugin } from './pluginMarketplaceService.js';
@@ -34,6 +34,8 @@ export interface IAgentPlugin {
 	readonly uri: URI;
 	/** Human-readable display name for the plugin. */
 	readonly label: string;
+	/** Detected on-disk format of the plugin (Copilot, Claude, or Open Plugin). */
+	readonly format: PluginFormat;
 	readonly enablement: IObservable<ContributionEnablementState>;
 	/** Removes this plugin from its discovery source (config or installed storage). */
 	remove(): void;

--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
@@ -347,6 +347,7 @@ export abstract class AbstractAgentPluginDiscovery extends Disposable implements
 		const plugin: PluginEntry = {
 			uri,
 			label: fromMarketplace?.name ?? manifestName ?? basename(uri),
+			format: format.format,
 			enablement,
 			remove: removeCallback,
 			hooks,

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageProviders/promptFileAttributes.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageProviders/promptFileAttributes.ts
@@ -412,7 +412,18 @@ export function isVSCodeOrDefaultTarget(target: Target): boolean {
 	return target === Target.VSCode || target === Target.Undefined;
 }
 
-export function getTarget(promptType: PromptsType, header: PromptHeader | URI): Target {
+/**
+ * Resolves the effective {@link Target} of a prompt file.
+ *
+ * `pluginTarget` is the target implied by the format of the plugin that
+ * contributed the file (e.g. {@link Target.Claude} for a Claude-format
+ * plugin installed via a marketplace or `chat.pluginLocations`). It is
+ * used as a fallback when the target cannot be determined from the file's
+ * on-disk location or its explicit `target` frontmatter, so that
+ * plugin-installed Claude files get the same `mapClaudeModels` /
+ * `mapClaudeTools` / `paths` handling as a hand-placed `.claude/` directory.
+ */
+export function getTarget(promptType: PromptsType, header: PromptHeader | URI, pluginTarget?: Target): Target {
 	const uri = header instanceof URI ? header : header.uri;
 	if (promptType === PromptsType.agent) {
 		const parentDir = dirname(uri);
@@ -425,10 +436,16 @@ export function getTarget(promptType: PromptsType, header: PromptHeader | URI): 
 				return target;
 			}
 		}
+		if (pluginTarget !== undefined && pluginTarget !== Target.Undefined) {
+			return pluginTarget;
+		}
 		return Target.Undefined;
 	} else if (promptType === PromptsType.instructions) {
 		if (isInClaudeRulesFolder(uri)) {
 			return Target.Claude;
+		}
+		if (pluginTarget !== undefined && pluginTarget !== Target.Undefined) {
+			return pluginTarget;
 		}
 	}
 	return Target.Undefined;

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
@@ -190,6 +190,13 @@ export interface IPluginPromptPath extends IPromptPathBase {
 	readonly storage: PromptsStorage.plugin;
 	readonly pluginUri: URI;
 	readonly source: PromptFileSource.Plugin;
+	/**
+	 * Target implied by the contributing plugin's detected format
+	 * (e.g. {@link Target.Claude} for a Claude-format plugin). Used as a
+	 * fallback in {@link getTarget} so plugin-installed Claude files get
+	 * the same frontmatter handling as a hand-placed `.claude/` directory.
+	 */
+	readonly pluginTarget?: Target;
 }
 
 export type IAgentSource = {

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
@@ -36,7 +36,7 @@ import { IAgentInstructions, IAgentSource, IChatPromptSlashCommand, IConfiguredH
 import { Delayer } from '../../../../../../base/common/async.js';
 import { Schemas } from '../../../../../../base/common/network.js';
 import { ChatRequestHooks, parseSubagentHooksFromYaml } from '../hookSchema.js';
-import { type IParsedHookCommand } from '../../../../../../platform/agentPlugins/common/pluginParsers.js';
+import { type IParsedHookCommand, PluginFormat } from '../../../../../../platform/agentPlugins/common/pluginParsers.js';
 import { HookType } from '../hookTypes.js';
 import { HookSourceFormat, parseHooksFromFile } from '../hookCompatibility.js';
 import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
@@ -47,6 +47,17 @@ import { getCanonicalPluginCommandId, IAgentPlugin, IAgentPluginService } from '
 import { isContributionEnabled } from '../../enablement.js';
 import { assertNever } from '../../../../../../base/common/assert.js';
 import { ExtensionPromptFileService } from './extensionPromptFileService.js';
+
+/**
+ * Maps a plugin's detected on-disk format to the prompt {@link Target} its
+ * files should be parsed with. Only Claude-format plugins imply a non-default
+ * target; Copilot and Open Plugin formats already use VS Code semantics, so
+ * they fall back to {@link Target.Undefined} and the existing path/frontmatter
+ * resolution applies.
+ */
+function pluginFormatToTarget(format: PluginFormat): Target {
+	return format === PluginFormat.Claude ? Target.Claude : Target.Undefined;
+}
 
 /**
  * Provides prompt services.
@@ -256,6 +267,7 @@ export class PromptsService extends Disposable implements IPromptsService {
 						type,
 						name: getCanonicalPluginCommandId(plugin, item.name),
 						pluginUri: plugin.uri,
+						pluginTarget: pluginFormatToTarget(plugin.format),
 						source: PromptFileSource.Plugin,
 					});
 				}
@@ -587,13 +599,18 @@ export class PromptsService extends Disposable implements IPromptsService {
 			try {
 				const ast = await this.parseNew(uri, token);
 
+				// Target implied by the contributing plugin's format (Claude-format
+				// plugins installed via marketplace / pluginLocations land outside
+				// `~/.claude/`, so the path-based detection in getTarget misses them).
+				const pluginTarget = promptPath.storage === PromptsStorage.plugin ? promptPath.pluginTarget : undefined;
+
 				// Parse hooks from the frontmatter if present
 				let hooks: ChatRequestHooks | undefined;
 				const hooksRaw = ast.header?.hooksRaw;
 				if (useChatHooks && isWorkspaceTrusted && hooksRaw) {
 					const hookWorkspaceFolder = this.workspaceService.getWorkspaceFolder(uri) ?? defaultFolder;
 					const workspaceRootUri = hookWorkspaceFolder?.uri;
-					const target = getTarget(PromptsType.agent, ast.header ?? promptPath.uri);
+					const target = getTarget(PromptsType.agent, ast.header ?? promptPath.uri, pluginTarget);
 					hooks = parseSubagentHooksFromYaml(hooksRaw, workspaceRootUri, userHome, target);
 				}
 				const extra = {
@@ -602,6 +619,7 @@ export class PromptsService extends Disposable implements IPromptsService {
 					name: promptPath.name,
 					description: promptPath.description,
 					source: IAgentSource.fromPromptPath(promptPath),
+					pluginTarget,
 					enabled: isEnabled,
 				};
 				const agent = CustomAgent.fromParsedPromptFile(ast, extra);
@@ -1297,7 +1315,12 @@ export class PromptsService extends Disposable implements IPromptsService {
 				const parsedPromptFile = await this.parseNew(uri, token);
 				const name = parsedPromptFile?.header?.name ?? promptPath.name ?? getCleanPromptName(uri);
 				const description = parsedPromptFile?.header?.description ?? promptPath.description;
-				const pattern = evaluateApplyToPattern(parsedPromptFile.header, isInClaudeRulesFolder(uri));
+				// Treat rules from a Claude-format plugin as Claude rules even when they
+				// live outside `~/.claude/rules/`, so their `paths` frontmatter maps to
+				// the effective `applyTo` (defaulting to `**`) instead of being dropped.
+				const pluginTarget = promptPath.storage === PromptsStorage.plugin ? promptPath.pluginTarget : undefined;
+				const isClaudeRules = isInClaudeRulesFolder(uri) || pluginTarget === Target.Claude;
+				const pattern = evaluateApplyToPattern(parsedPromptFile.header, isClaudeRules);
 				files.push({
 					status: 'loaded',
 					pattern,
@@ -1414,7 +1437,7 @@ class ModelChangeTracker extends Disposable {
 }
 
 export namespace CustomAgent {
-	export function fromParsedPromptFile(ast: ParsedPromptFile, extra: { name?: string; description?: string; source: IAgentSource; hooks?: ChatRequestHooks; sessionTypes: readonly string[] | undefined; enabled: boolean }): ICustomAgent {
+	export function fromParsedPromptFile(ast: ParsedPromptFile, extra: { name?: string; description?: string; source: IAgentSource; hooks?: ChatRequestHooks; sessionTypes: readonly string[] | undefined; enabled: boolean; pluginTarget?: Target }): ICustomAgent {
 		const uri = ast.uri;
 		const { hooks, sessionTypes, enabled } = extra;
 
@@ -1446,7 +1469,7 @@ export namespace CustomAgent {
 
 		const name = ast.header?.name ?? extra.name ?? getCleanPromptName(uri);
 		const description = ast.header?.description ?? extra.description;
-		const target = getTarget(PromptsType.agent, ast.header ?? uri);
+		const target = getTarget(PromptsType.agent, ast.header ?? uri, extra.pluginTarget);
 
 		const source = extra.source;
 		if (!ast.header) {

--- a/src/vs/workbench/contrib/chat/test/browser/aiCustomization/aiCustomizationItemsModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/aiCustomization/aiCustomizationItemsModel.test.ts
@@ -20,6 +20,7 @@ import { AICustomizationManagementSection, AICustomizationSources, BUILTIN_STORA
 import { ICustomizationHarnessService, ICustomizationItem, ICustomizationItemProvider, ICustomizationSyncProvider, IHarnessDescriptor } from '../../../common/customizationHarnessService.js';
 import { ContributionEnablementState } from '../../../common/enablement.js';
 import { IAgentPluginService, type IAgentPlugin } from '../../../common/plugins/agentPluginService.js';
+import { PluginFormat } from '../../../../../../platform/agentPlugins/common/pluginParsers.js';
 import { PromptsType, Target } from '../../../common/promptSyntax/promptTypes.js';
 import { IAgentSource, ICustomAgent, IPromptPath, IPromptsService, PromptsStorage } from '../../../common/promptSyntax/service/promptsService.js';
 import { getChatSessionType } from '../../../common/model/chatUri.js';
@@ -156,6 +157,7 @@ suite('AICustomizationItemsModel', () => {
 			return {
 				uri: URI.parse(`plugin-test://${name}`),
 				label: name,
+				format: PluginFormat.Copilot,
 				enablement: observableValue('pluginEnablement', ContributionEnablementState.EnabledProfile),
 				remove: () => { },
 				hooks: observableValue('pluginHooks', []),
@@ -604,6 +606,7 @@ suite('AICustomizationItemsModel', () => {
 			return {
 				uri: URI.parse(`plugin-test://${name}`),
 				label: name,
+				format: PluginFormat.Copilot,
 				enablement: observableValue('pluginEnablement', ContributionEnablementState.EnabledProfile),
 				remove: () => { },
 				hooks: observableValue('pluginHooks', []),

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
@@ -41,7 +41,7 @@ import { ComputeAutomaticInstructions, newInstructionsCollectionEvent, newInstru
 import { PromptsConfig } from '../../../../common/promptSyntax/config/config.js';
 import { AGENTS_SOURCE_FOLDER, CLAUDE_CONFIG_FOLDER, HOOKS_SOURCE_FOLDER, INSTRUCTION_FILE_EXTENSION, INSTRUCTIONS_DEFAULT_SOURCE_FOLDER, LEGACY_MODE_DEFAULT_SOURCE_FOLDER, PROMPT_DEFAULT_SOURCE_FOLDER, PROMPT_FILE_EXTENSION } from '../../../../common/promptSyntax/config/promptFileLocations.js';
 import { INSTRUCTIONS_LANGUAGE_ID, PROMPT_LANGUAGE_ID, PromptFileSource, PromptsType, Target } from '../../../../common/promptSyntax/promptTypes.js';
-import { IAgentDiscoveryResult, ICustomAgent, IPromptFileContext, IPromptsService, PromptsStorage } from '../../../../common/promptSyntax/service/promptsService.js';
+import { IAgentDiscoveryResult, ICustomAgent, IInstructionDiscoveryInfo, IInstructionDiscoveryResult, IPromptFileContext, IPromptsService, PromptsStorage } from '../../../../common/promptSyntax/service/promptsService.js';
 import { PromptsService } from '../../../../common/promptSyntax/service/promptsServiceImpl.js';
 import { mockFiles } from '../testUtils/mockFilesystem.js';
 import { InMemoryStorageService, IStorageService } from '../../../../../../../platform/storage/common/storage.js';
@@ -54,6 +54,7 @@ import { HookType } from '../../../../common/promptSyntax/hookTypes.js';
 import { IContextKeyChangeEvent, IContextKeyService } from '../../../../../../../platform/contextkey/common/contextkey.js';
 import { MockContextKeyService } from '../../../../../../../platform/keybinding/test/common/mockKeybindingService.js';
 import { IAgentPlugin, IAgentPluginAgent, IAgentPluginCommand, IAgentPluginHook, IAgentPluginInstruction, IAgentPluginMcpServerDefinition, IAgentPluginService, IAgentPluginSkill } from '../../../../common/plugins/agentPluginService.js';
+import { PluginFormat } from '../../../../../../../platform/agentPlugins/common/pluginParsers.js';
 import { IWorkspaceTrustManagementService } from '../../../../../../../platform/workspace/common/workspaceTrust.js';
 
 class TestPromptContextKeyService extends MockContextKeyService {
@@ -4319,6 +4320,7 @@ suite('PromptsService', () => {
 			const plugin: IAgentPlugin = {
 				uri: URI.file('/plugins/my-plugin'),
 				label: 'my-plugin',
+				format: PluginFormat.Copilot,
 				enablement,
 				remove: () => { },
 				hooks: observableValue('testPluginHooks', []),
@@ -4364,6 +4366,7 @@ suite('PromptsService', () => {
 			const plugin: IAgentPlugin = {
 				uri: URI.file('/plugins/devtools'),
 				label: 'devtools',
+				format: PluginFormat.Copilot,
 				enablement,
 				remove: () => { },
 				hooks: observableValue('testPluginHooks', []),
@@ -4408,6 +4411,7 @@ suite('PromptsService', () => {
 				plugin: {
 					uri: URI.file(path),
 					label: basename(URI.file(path)),
+					format: PluginFormat.Copilot,
 					enablement,
 					remove: () => { },
 					hooks,
@@ -4656,6 +4660,7 @@ suite('PromptsService', () => {
 				plugin: {
 					uri: URI.file(path),
 					label: basename(URI.file(path)),
+					format: PluginFormat.Copilot,
 					enablement,
 					remove: () => { },
 					hooks,
@@ -4742,6 +4747,141 @@ suite('PromptsService', () => {
 			const pluginInstruction = result.find(p => p.uri.toString() === ruleUri.toString());
 			assert.ok(pluginInstruction, 'Plugin instruction should be listed');
 			assert.strictEqual(pluginInstruction!.name, 'deploy-tools:lint-check');
+		});
+	});
+
+	suite('plugin Claude format propagation', () => {
+		function createPlugin(
+			path: string,
+			format: PluginFormat,
+			options: {
+				agents?: readonly IAgentPluginAgent[];
+				instructions?: readonly IAgentPluginInstruction[];
+			} = {},
+		): IAgentPlugin {
+			return {
+				uri: URI.file(path),
+				label: basename(URI.file(path)),
+				format,
+				enablement: observableValue('testPluginEnablement', 2 /* ContributionEnablementState.EnabledProfile */),
+				remove: () => { },
+				hooks: observableValue<readonly IAgentPluginHook[]>('testPluginHooks', []),
+				commands: observableValue<readonly IAgentPluginCommand[]>('testPluginCommands', []),
+				skills: observableValue<readonly IAgentPluginSkill[]>('testPluginSkills', []),
+				agents: observableValue<readonly IAgentPluginAgent[]>('testPluginAgents', options.agents ?? []),
+				instructions: observableValue<readonly IAgentPluginInstruction[]>('testPluginInstructions', options.instructions ?? []),
+				mcpServerDefinitions: observableValue<readonly IAgentPluginMcpServerDefinition[]>('testPluginMcpServerDefinitions', []),
+			};
+		}
+
+		test('Claude-format plugin agent resolves Target.Claude and maps tools/model', async () => {
+			// Plugin installed via marketplace lands outside any .claude/agents folder,
+			// so the Claude target must come from the detected plugin format, not the path.
+			const agentUri = URI.file('/plugins/claude-plugin/agents/deployer.md');
+			await mockFiles(fileService, [
+				{
+					path: agentUri.path,
+					contents: [
+						'---',
+						'description: \'Claude plugin agent.\'',
+						'tools: [ Read, Edit, Bash ]',
+						'model: opus',
+						'---',
+						'I am a Claude plugin agent.',
+					],
+				},
+			]);
+
+			const plugin = createPlugin('/plugins/claude-plugin', PluginFormat.Claude, {
+				agents: [{ uri: agentUri, name: 'deployer' }],
+			});
+			testPluginsObservable.set([plugin], undefined);
+
+			const agents = await service.getCustomAgents(CancellationToken.None);
+			const deployer = agents.find(a => a.uri.toString() === agentUri.toString());
+
+			assert.ok(deployer, 'Claude plugin agent should be discovered');
+			assert.strictEqual(deployer!.target, Target.Claude, 'plugin format should drive Claude target');
+			assert.deepStrictEqual(
+				deployer!.tools,
+				['read/readFile', 'read/getNotebookSummary', 'edit/editNotebook', 'edit/editFiles', 'execute'],
+				'Claude tools must be mapped to VS Code equivalents for plugin agents',
+			);
+			assert.deepStrictEqual(
+				deployer!.model,
+				['Claude Opus 4.6 (copilot)'],
+				'Claude model must be mapped to VS Code equivalent for plugin agents',
+			);
+
+			testPluginsObservable.set([], undefined);
+		});
+
+		test('Copilot-format plugin agent does not map tools/model', async () => {
+			const agentUri = URI.file('/plugins/copilot-plugin/agents/helper.agent.md');
+			await mockFiles(fileService, [
+				{
+					path: agentUri.path,
+					contents: [
+						'---',
+						'description: \'Copilot plugin agent.\'',
+						'tools: [ Read, Edit ]',
+						'model: gpt-4',
+						'---',
+						'I am a Copilot plugin agent.',
+					],
+				},
+			]);
+
+			const plugin = createPlugin('/plugins/copilot-plugin', PluginFormat.Copilot, {
+				agents: [{ uri: agentUri, name: 'helper' }],
+			});
+			testPluginsObservable.set([plugin], undefined);
+
+			const agents = await service.getCustomAgents(CancellationToken.None);
+			const helper = agents.find(a => a.uri.toString() === agentUri.toString());
+
+			assert.ok(helper, 'Copilot plugin agent should be discovered');
+			assert.notStrictEqual(helper!.target, Target.Claude, 'Copilot plugin must not resolve Claude target');
+			assert.deepStrictEqual(helper!.tools, ['Read', 'Edit'], 'Copilot plugin tools must stay unmapped');
+			assert.deepStrictEqual(helper!.model, ['gpt-4'], 'Copilot plugin model must stay unmapped');
+
+			testPluginsObservable.set([], undefined);
+		});
+
+		test('Claude-format plugin rule with paths (no applyTo) is applied', async () => {
+			// Claude rules express scope via `paths`; without Claude semantics the rule
+			// would be skipped for lacking `applyTo`.
+			const ruleUri = URI.file('/plugins/claude-plugin/rules/ts-style.md');
+			await mockFiles(fileService, [
+				{
+					path: ruleUri.path,
+					contents: [
+						'---',
+						'description: \'TypeScript style rule.\'',
+						'paths: [ "**/*.ts" ]',
+						'---',
+						'Prefer const.',
+					],
+				},
+			]);
+
+			const plugin = createPlugin('/plugins/claude-plugin', PluginFormat.Claude, {
+				instructions: [{ uri: ruleUri, name: 'ts-style' }],
+			});
+			testPluginsObservable.set([plugin], undefined);
+
+			const discoveryInfo = await service.getDiscoveryInfo(PromptsType.instructions, CancellationToken.None) as IInstructionDiscoveryInfo;
+			const rule = discoveryInfo.files.find(f => f.promptPath.uri.toString() === ruleUri.toString());
+
+			assert.ok(rule, 'Claude plugin rule should be discovered');
+			assert.strictEqual(rule!.status, 'loaded', 'Claude plugin rule should load');
+			assert.strictEqual(
+				(rule as IInstructionDiscoveryResult).pattern,
+				'**/*.ts',
+				'Claude `paths` must map to applyTo for plugin rules instead of being dropped',
+			);
+
+			testPluginsObservable.set([], undefined);
 		});
 	});
 });


### PR DESCRIPTION
Fixes #314020

## Problem

Claude-format plugins installed via `chat.pluginMarketplaces` or `chat.pluginLocations` are extracted to `~/.vscode/agent-plugins/<owner>__<repo>/<plugin>/`, outside any `.claude/` folder. The plugin loader already detects the on-disk format via `detectPluginFormat()`, but that result was only used to locate the manifest/hooks — it was never propagated to the prompt-file parsing path.

As a consequence, plugin-distributed Claude customizations were parsed with Copilot semantics:

- `getTarget()` returned `Target.Undefined` (it only recognizes Claude via a literal `.claude/agents` path or explicit frontmatter `target`), so `mapClaudeTools`/`mapClaudeModels` never ran. Agent `tools: [Read, Edit, Bash]` and `model: opus` were left unmapped.
- Rules that scope via Claude's `paths` frontmatter (instead of `applyTo`) were dropped, because `evaluateApplyToPattern` only honors `paths` when `isClaudeRules` is true, and that flag was computed solely from a literal `/.claude/rules/` path.

## Fix

Thread the detected `PluginFormat` downstream:

- `IAgentPlugin` now carries the detected `format`, populated in `AgentPluginService._toPlugin`.
- `IPluginPromptPath` gains an optional `pluginTarget: Target`, derived from the plugin format when building plugin prompt paths.
- `getTarget()` accepts an optional `pluginTarget` hint and falls back to it for plugin-distributed agents and instructions.
- `getInstructionsDiscoveryInfo` treats rules from a Claude-format plugin as Claude rules, so their `paths` map to the effective `applyTo` instead of being dropped.

A `Target`-typed hint is used (rather than coupling the language-provider layer to the platform `PluginFormat` enum) to keep layering clean.

## Tests

Added coverage in `promptsService.test.ts`:

- Claude-format plugin agent resolves `Target.Claude` and maps tools/model to VS Code equivalents.
- Copilot-format plugin agent leaves tools/model unmapped.
- Claude-format plugin rule with `paths` (no `applyTo`) produces a non-dropped `applyTo` pattern via `getDiscoveryInfo`.
