### PR TITLE
fix: skip desktopCapturer warm-up on Wayland to avoid spurious screen-share dialogs

### DIFF
--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -230,13 +230,14 @@ export class CodeApplication extends Disposable {
 
 		// Without this, starting recording in the issue reporting wizard takes
 		// a few seconds due to overhead of enumerating sources, so we warm up the sources in advance.
-		// Skip on Wayland (Electron 39+): desktopCapturer.getSources triggers the XDG Desktop Portal
-		// screencast dialog there, causing a spurious screen-share picker on every window open even
-		// when the user never opened the Issue Reporter. (#317948, #317955)
+		// Skip on Wayland sessions: on those platforms desktopCapturer.getSources triggers the
+		// XDG Desktop Portal screencast dialog, causing a spurious screen-share picker on every
+		// window open even when the user never opened the Issue Reporter. (#317948, #317955)
 		const isWaylandSession = isLinux && (
 			process.env['XDG_SESSION_TYPE'] === 'wayland' ||
 			!!process.env['WAYLAND_DISPLAY']
 		);
+		const shouldWarmUpScreenSources = !isWaylandSession && (!isMacintosh || systemPreferences.getMediaAccessStatus('screen') === 'granted');
 		let cachedScreenSources: Electron.DesktopCapturerSource[] | undefined;
 		const warmUpScreenSources = () => {
 			desktopCapturer.getSources({
@@ -246,7 +247,7 @@ export class CodeApplication extends Disposable {
 		};
 		const invalidateScreenSourceCache = () => {
 			cachedScreenSources = undefined;
-			if (!isWaylandSession && (!isMacintosh || systemPreferences.getMediaAccessStatus('screen') === 'granted')) {
+			if (shouldWarmUpScreenSources) {
 				warmUpScreenSources();
 			}
 		};
@@ -258,7 +259,7 @@ export class CodeApplication extends Disposable {
 			electronScreen.off('display-removed', invalidateScreenSourceCache);
 			electronScreen.off('display-metrics-changed', invalidateScreenSourceCache);
 		}));
-		if (!isWaylandSession && (!isMacintosh || systemPreferences.getMediaAccessStatus('screen') === 'granted')) {
+		if (shouldWarmUpScreenSources) {
 			warmUpScreenSources();
 		}
 		session.defaultSession.setDisplayMediaRequestHandler(async (request, callback) => {

--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -230,6 +230,13 @@ export class CodeApplication extends Disposable {
 
 		// Without this, starting recording in the issue reporting wizard takes
 		// a few seconds due to overhead of enumerating sources, so we warm up the sources in advance.
+		// Skip on Wayland (Electron 39+): desktopCapturer.getSources triggers the XDG Desktop Portal
+		// screencast dialog there, causing a spurious screen-share picker on every window open even
+		// when the user never opened the Issue Reporter. (#317948, #317955)
+		const isWaylandSession = isLinux && (
+			process.env['XDG_SESSION_TYPE'] === 'wayland' ||
+			!!process.env['WAYLAND_DISPLAY']
+		);
 		let cachedScreenSources: Electron.DesktopCapturerSource[] | undefined;
 		const warmUpScreenSources = () => {
 			desktopCapturer.getSources({
@@ -239,7 +246,7 @@ export class CodeApplication extends Disposable {
 		};
 		const invalidateScreenSourceCache = () => {
 			cachedScreenSources = undefined;
-			if (!isMacintosh || systemPreferences.getMediaAccessStatus('screen') === 'granted') {
+			if (!isWaylandSession && (!isMacintosh || systemPreferences.getMediaAccessStatus('screen') === 'granted')) {
 				warmUpScreenSources();
 			}
 		};
@@ -251,7 +258,7 @@ export class CodeApplication extends Disposable {
 			electronScreen.off('display-removed', invalidateScreenSourceCache);
 			electronScreen.off('display-metrics-changed', invalidateScreenSourceCache);
 		}));
-		if (!isMacintosh || systemPreferences.getMediaAccessStatus('screen') === 'granted') {
+		if (!isWaylandSession && (!isMacintosh || systemPreferences.getMediaAccessStatus('screen') === 'granted')) {
 			warmUpScreenSources();
 		}
 		session.defaultSession.setDisplayMediaRequestHandler(async (request, callback) => {


### PR DESCRIPTION
## Summary

- On Wayland (Electron 39+), `desktopCapturer.getSources({ types: ['screen'] })` triggers the XDG Desktop Portal screencast session, causing the system screen-share picker to appear on every VS Code startup — even when the user never opened the Issue Reporter
- Added a Wayland session guard (`XDG_SESSION_TYPE=wayland` or `WAYLAND_DISPLAY` set) to skip the proactive source warm-up
- On Wayland, the cache is populated lazily on first use inside `setDisplayMediaRequestHandler`, which is the correct place to pay the ~200ms enumeration cost
- Windows, macOS, and X11 Linux are unaffected — warm-up behaviour unchanged

Fixes #317948, #317955

## Test plan

- [ ] Open VS Code on a Wayland session (GNOME/KDE, Fedora/Ubuntu) — screen-share portal dialog must **not** appear at startup
- [ ] Open a new window (`Ctrl+Shift+N`) — no dialog
- [ ] Confirm no `screencast_portal.cc` errors in `journalctl --user`
- [ ] Enable `"issueReporter.wizard.enabled": true`, open **Help → Report Issue**, navigate to the attachments step, click **Record** — portal dialog appears once as expected and recording works
- [ ] Verify no regression on Windows/macOS (warm-up still runs, first recording latency unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)