### PR TITLE
Fix WorktreeCreatedTaskDispatcher overfiring (#318241)

### DIFF
--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -103,7 +103,7 @@ Each session operates on an **`ISessionWorkspace`** containing one or more **`IS
 
 Workspaces carry a `group` label (e.g., `"Local"`, `"Remote"`) used by the workspace picker to organize entries into tabs via the `SESSION_WORKSPACE_GROUP_LOCAL` / `SESSION_WORKSPACE_GROUP_REMOTE` constants.
 
-Tasks with `runOptions.runOn === "worktreeCreated"` are dispatched client-side only for newly created sessions, after the session reports a concrete `gitRepository.workTreeUri`. Restored sessions and runtimes that declare `capabilities.runsWorktreeCreatedTasks` are skipped so setup tasks are not re-run on window open or double-run with server-side provisioning; untitled placeholders are deferred until they become committed worktree sessions.
+Tasks with `runOptions.runOn === "worktreeCreated"` are dispatched client-side only for sessions that this window has just started. `SessionsManagementService` emits `onDidStartSession` from `sendNewChatRequest` after `provider.sendRequest(...)` commits, and `WorktreeCreatedTaskDispatcher` tracks only those sessions until they report a concrete `gitRepository.workTreeUri`. Restored/synced catalog sessions and runtimes that declare `capabilities.runsWorktreeCreatedTasks` are skipped so setup tasks are not re-run on window open or double-run with server-side provisioning.
 
 ### Session Types
 
@@ -143,6 +143,7 @@ Sessions produce file changes organized into **`ISessionChangeset`** groups — 
    → Management service opens the chat widget with that chat's resource
    → Delegates to provider.sendRequest(sessionId, chatResource, options)
    → Provider sends request, returns committed session
+   → Management service fires onDidStartSession(committedSession)
    → isNewChatSession context → false
 
 Agent-host providers seed new-session config from the last values picked in the

--- a/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
@@ -89,7 +89,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 	properties: {
 		[AGENT_HOST_RUN_WORKTREE_CREATED_TASKS_SETTING]: {
 			type: 'boolean',
-			default: false,
+			default: true,
 			scope: ConfigurationScope.APPLICATION,
 			description: localize('chat.agentHost.runWorktreeCreatedTasks', "Whether to automatically run tasks tagged with `\"runOptions\": { \"runOn\": \"worktreeCreated\" }` when a new agent host session worktree is created. Manual `Run Task` invocations are unaffected."),
 		},

--- a/src/vs/sessions/contrib/chat/browser/worktreeCreatedTaskDispatcher.ts
+++ b/src/vs/sessions/contrib/chat/browser/worktreeCreatedTaskDispatcher.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable, DisposableMap, DisposableStore } from '../../../../base/common/lifecycle.js';
-import { autorun } from '../../../../base/common/observable.js';
+import { registerAutorunSelfDisposable } from '../../../../base/common/observable.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IWorkbenchContribution } from '../../../../workbench/common/contributions.js';
@@ -18,7 +18,7 @@ const LOG_PREFIX = '[WorktreeCreatedTaskDispatcher]';
 /**
  * Setting that controls whether `runOptions.runOn === 'worktreeCreated'`
  * tasks are auto-dispatched for agent host sessions when a new worktree is
- * created. Defaults to `false`. Manual `Run Task` invocations are unaffected.
+ * created. Defaults to `true`. Manual `Run Task` invocations are unaffected.
  */
 export const AGENT_HOST_RUN_WORKTREE_CREATED_TASKS_SETTING = 'chat.agentHost.runWorktreeCreatedTasks';
 
@@ -73,10 +73,9 @@ export class WorktreeCreatedTaskDispatcher extends Disposable implements IWorkbe
 		this._sessionDisposables.set(session.sessionId, store);
 
 		// Wait for the session to finish loading and report an actual worktree,
-		// then dispatch any pending worktreeCreated tasks once. Set
-		// `dispatched` synchronously before the await so any re-firing of the
-		// autorun observes it and bails.
-		store.add(autorun(reader => {
+		// then dispatch any pending worktreeCreated tasks once. When dispatched,
+		// dispose the per-session subscription store to tear down this autorun.
+		registerAutorunSelfDisposable(store, reader => {
 			if (session.loading.read(reader)) {
 				return;
 			}
@@ -88,7 +87,7 @@ export class WorktreeCreatedTaskDispatcher extends Disposable implements IWorkbe
 			}
 			this._sessionDisposables.deleteAndDispose(session.sessionId);
 			this._dispatchWorktreeCreatedTasks(session);
-		}));
+		});
 	}
 
 	private async _dispatchWorktreeCreatedTasks(session: ISession): Promise<void> {

--- a/src/vs/sessions/contrib/chat/browser/worktreeCreatedTaskDispatcher.ts
+++ b/src/vs/sessions/contrib/chat/browser/worktreeCreatedTaskDispatcher.ts
@@ -10,7 +10,7 @@ import { ILogService } from '../../../../platform/log/common/log.js';
 import { IWorkbenchContribution } from '../../../../workbench/common/contributions.js';
 import { isAgentHostProviderId } from '../../../common/agentHostSessionsProvider.js';
 import { ISession, SessionStatus } from '../../../services/sessions/common/session.js';
-import { ISessionsChangeEvent, ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
+import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsTasksService } from './sessionsTasksService.js';
 
 const LOG_PREFIX = '[WorktreeCreatedTaskDispatcher]';
@@ -41,7 +41,6 @@ export class WorktreeCreatedTaskDispatcher extends Disposable implements IWorkbe
 	// Track per-session disposables (one per in-flight session subscription) so
 	// we tear them down when the session is removed.
 	private readonly _sessionDisposables = this._register(new DisposableMap<string>());
-	private readonly _dispatchedSessions = new Set<string>();
 
 	constructor(
 		@ISessionsManagementService private readonly _sessionsManagementService: ISessionsManagementService,
@@ -51,42 +50,22 @@ export class WorktreeCreatedTaskDispatcher extends Disposable implements IWorkbe
 	) {
 		super();
 
-		for (const session of this._sessionsManagementService.getSessions()) {
-			this._trackSession(session);
-		}
-
-		this._register(this._sessionsManagementService.onDidChangeSessions(e => this._onDidChangeSessions(e)));
+		this._register(this._sessionsManagementService.onDidStartSession(session => this._trackSession(session)));
+		this._register(this._sessionsManagementService.onDidChangeSessions(e => this._onDidRemoveSessions(e.removed)));
 	}
 
-	private _onDidChangeSessions(e: ISessionsChangeEvent): void {
-		const removedTrackedSessions: ISession[] = [];
-		for (const session of e.removed) {
-			if (this._sessionDisposables.get(session.sessionId) && !this._dispatchedSessions.has(session.sessionId)) {
-				removedTrackedSessions.push(session);
-			}
+	private _onDidRemoveSessions(removed: readonly ISession[]): void {
+		for (const session of removed) {
 			this._sessionDisposables.deleteAndDispose(session.sessionId);
-			this._dispatchedSessions.delete(session.sessionId);
-		}
-		for (const session of e.added) {
-			this._trackSession(session);
-		}
-		const replacement = e.added.length === 0 && e.changed.length === 1 && removedTrackedSessions.length === 1
-			? removedTrackedSessions[0]
-			: undefined;
-		for (const session of e.changed) {
-			this._trackSession(session, replacement?.providerId === session.providerId && replacement.sessionType === session.sessionType);
 		}
 	}
 
-	private _trackSession(session: ISession, allowReadySession = false): void {
+	private _trackSession(session: ISession): void {
 		if (session.capabilities.runsWorktreeCreatedTasks) {
 			// The session's runtime already runs these tasks itself.
 			return;
 		}
 		if (this._sessionDisposables.get(session.sessionId)) {
-			return;
-		}
-		if (!allowReadySession && !this._isPendingWorktreeSession(session)) {
 			return;
 		}
 
@@ -97,9 +76,8 @@ export class WorktreeCreatedTaskDispatcher extends Disposable implements IWorkbe
 		// then dispatch any pending worktreeCreated tasks once. Set
 		// `dispatched` synchronously before the await so any re-firing of the
 		// autorun observes it and bails.
-		let dispatched = false;
 		store.add(autorun(reader => {
-			if (session.loading.read(reader) || dispatched) {
+			if (session.loading.read(reader)) {
 				return;
 			}
 			if (session.status.read(reader) === SessionStatus.Untitled) {
@@ -108,18 +86,9 @@ export class WorktreeCreatedTaskDispatcher extends Disposable implements IWorkbe
 			if (!session.workspace.read(reader)?.folders.some(folder => !!folder.gitRepository?.workTreeUri)) {
 				return;
 			}
-			dispatched = true;
-			this._dispatchedSessions.add(session.sessionId);
-			void this._dispatchWorktreeCreatedTasks(session);
+			this._sessionDisposables.deleteAndDispose(session.sessionId);
+			this._dispatchWorktreeCreatedTasks(session);
 		}));
-	}
-
-	private _isPendingWorktreeSession(session: ISession): boolean {
-		return session.status.get() === SessionStatus.Untitled || session.loading.get() || !this._hasWorktree(session);
-	}
-
-	private _hasWorktree(session: ISession): boolean {
-		return session.workspace.get()?.folders.some(folder => !!folder.gitRepository?.workTreeUri) ?? false;
 	}
 
 	private async _dispatchWorktreeCreatedTasks(session: ISession): Promise<void> {

--- a/src/vs/sessions/contrib/chat/test/browser/worktreeCreatedTaskDispatcher.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/worktreeCreatedTaskDispatcher.test.ts
@@ -255,7 +255,8 @@ suite('WorktreeCreatedTaskDispatcher', () => {
 		assert.deepStrictEqual(tasks.ranTasks, []);
 	});
 
-	test('skips agent host sessions when the setting is disabled (default)', async () => {
+	test('skips agent host sessions when the setting is disabled', async () => {
+		await configurationService.setUserConfiguration(AGENT_HOST_RUN_WORKTREE_CREATED_TASKS_SETTING, false);
 		createDispatcher();
 		const { session, workspace } = makeSession({ id: 'a', providerId: LOCAL_AGENT_HOST_PROVIDER_ID, hasWorktree: false });
 		tasks.setTasks(session.sessionId, [entry('setup', 'worktreeCreated')]);

--- a/src/vs/sessions/contrib/chat/test/browser/worktreeCreatedTaskDispatcher.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/worktreeCreatedTaskDispatcher.test.ts
@@ -112,10 +112,11 @@ class FakeSessionsTasksService implements Partial<ISessionsTasksService> {
 
 class FakeSessionsManagementService implements Partial<ISessionsManagementService> {
 	declare readonly _serviceBrand: undefined;
-	readonly emitter = new Emitter<ISessionsChangeEvent>();
-	readonly onDidChangeSessions = this.emitter.event;
-	sessions: ISession[] = [];
-	getSessions(): ISession[] { return this.sessions; }
+	readonly sessionStartedEmitter = new Emitter<ISession>();
+	readonly sessionsChangedEmitter = new Emitter<ISessionsChangeEvent>();
+	readonly onDidStartSession = this.sessionStartedEmitter.event;
+	readonly onDidChangeSessions = this.sessionsChangedEmitter.event;
+	getSessions(): ISession[] { return []; }
 }
 
 suite('WorktreeCreatedTaskDispatcher', () => {
@@ -141,7 +142,8 @@ suite('WorktreeCreatedTaskDispatcher', () => {
 	});
 
 	teardown(() => {
-		mgmt.emitter.dispose();
+		mgmt.sessionStartedEmitter.dispose();
+		mgmt.sessionsChangedEmitter.dispose();
 		store.clear();
 	});
 
@@ -151,19 +153,31 @@ suite('WorktreeCreatedTaskDispatcher', () => {
 		await new Promise(r => setTimeout(r, 0));
 	}
 
-	test('runs worktreeCreated tasks once for a newly added session', async () => {
+	test('runs worktreeCreated tasks once for a newly started session', async () => {
 		createDispatcher();
 		const { session, workspace } = makeSession({ id: 'a', hasWorktree: false });
 		tasks.setTasks(session.sessionId, [
 			entry('setup', 'worktreeCreated'),
 			entry('lint'),
 		]);
-		mgmt.emitter.fire({ added: [session], removed: [], changed: [] });
+
+		mgmt.sessionStartedEmitter.fire(session);
 		await settle();
 		workspace.set(makeWorkspace(true), undefined);
 		await settle();
 
 		assert.deepStrictEqual(tasks.ranTasks, [{ label: 'setup', sessionId: 'a' }]);
+	});
+
+	test('does not run for sessions only reported via onDidChangeSessions.added', async () => {
+		createDispatcher();
+		const { session } = makeSession({ id: 'restored' });
+		tasks.setTasks(session.sessionId, [entry('setup', 'worktreeCreated')]);
+
+		mgmt.sessionsChangedEmitter.fire({ added: [session], removed: [], changed: [] });
+		await settle();
+
+		assert.deepStrictEqual(tasks.ranTasks, []);
 	});
 
 	test('runTask failures are logged but do not abort the loop', async () => {
@@ -174,11 +188,11 @@ suite('WorktreeCreatedTaskDispatcher', () => {
 			entry('setup-a', 'worktreeCreated'),
 			entry('setup-b', 'worktreeCreated'),
 		]);
-		mgmt.emitter.fire({ added: [session], removed: [], changed: [] });
+
+		mgmt.sessionStartedEmitter.fire(session);
 		workspace.set(makeWorkspace(true), undefined);
 		await settle();
 
-		// Both tasks are attempted even though each throws.
 		assert.deepStrictEqual(tasks.ranTasks, [
 			{ label: 'setup-a', sessionId: 'a' },
 			{ label: 'setup-b', sessionId: 'a' },
@@ -189,12 +203,12 @@ suite('WorktreeCreatedTaskDispatcher', () => {
 		createDispatcher();
 		const { session, loading } = makeSession({ id: 'a', loading: true });
 		tasks.setTasks(session.sessionId, [entry('setup', 'worktreeCreated')]);
-		mgmt.emitter.fire({ added: [session], removed: [], changed: [] });
+
+		mgmt.sessionStartedEmitter.fire(session);
 		await settle();
 
 		loading.set(false, undefined);
 		await settle();
-		// Flip loading back to true and false again — dispatch must not retrigger.
 		loading.set(true, undefined);
 		await settle();
 		loading.set(false, undefined);
@@ -203,208 +217,63 @@ suite('WorktreeCreatedTaskDispatcher', () => {
 		assert.deepStrictEqual(tasks.ranTasks, [{ label: 'setup', sessionId: 'a' }]);
 	});
 
-	test('per-session task lists do not cross-contaminate', async () => {
+	test('waits for untitled sessions to start before running', async () => {
 		createDispatcher();
-		const { session: sessionA, workspace: workspaceA } = makeSession({ id: 'a', hasWorktree: false });
-		const { session: sessionB, workspace: workspaceB } = makeSession({ id: 'b', hasWorktree: false });
-		tasks.setTasks(sessionA.sessionId, [entry('setup-a', 'worktreeCreated')]);
-		tasks.setTasks(sessionB.sessionId, [entry('setup-b', 'worktreeCreated')]);
-		mgmt.emitter.fire({ added: [sessionA, sessionB], removed: [], changed: [] });
-		workspaceA.set(makeWorkspace(true), undefined);
-		workspaceB.set(makeWorkspace(true), undefined);
+		const { session, status } = makeSession({ id: 'a', status: SessionStatus.Untitled });
+		tasks.setTasks(session.sessionId, [entry('setup', 'worktreeCreated')]);
+
+		mgmt.sessionStartedEmitter.fire(session);
+		await settle();
+		assert.deepStrictEqual(tasks.ranTasks, []);
+
+		status.set(SessionStatus.InProgress, undefined);
+		await settle();
+		assert.deepStrictEqual(tasks.ranTasks, [{ label: 'setup', sessionId: 'a' }]);
+	});
+
+	test('tears down subscription when a started session is removed', async () => {
+		createDispatcher();
+		const { session, workspace } = makeSession({ id: 'a', hasWorktree: false });
+		tasks.setTasks(session.sessionId, [entry('setup', 'worktreeCreated')]);
+
+		mgmt.sessionStartedEmitter.fire(session);
+		mgmt.sessionsChangedEmitter.fire({ added: [], removed: [session], changed: [] });
+		workspace.set(makeWorkspace(true), undefined);
 		await settle();
 
-		// Each task fires against its own session.
-		assert.deepStrictEqual(
-			[...tasks.ranTasks].sort((x, y) => x.label.localeCompare(y.label)),
-			[
-				{ label: 'setup-a', sessionId: 'a' },
-				{ label: 'setup-b', sessionId: 'b' },
-			]
-		);
+		assert.deepStrictEqual(tasks.ranTasks, []);
 	});
 
 	test('skips sessions whose runtime already runs worktreeCreated tasks', async () => {
 		createDispatcher();
 		const { session } = makeSession({ id: 'a', runsWorktreeCreatedTasks: true });
 		tasks.setTasks(session.sessionId, [entry('setup', 'worktreeCreated')]);
-		mgmt.emitter.fire({ added: [session], removed: [], changed: [] });
+
+		mgmt.sessionStartedEmitter.fire(session);
 		await settle();
 
 		assert.deepStrictEqual(tasks.ranTasks, []);
 	});
 
-	test('waits for loading to flip to false before running', async () => {
-		createDispatcher();
-		const { session, loading } = makeSession({ id: 'a', loading: true });
-		tasks.setTasks(session.sessionId, [entry('setup', 'worktreeCreated')]);
-		mgmt.emitter.fire({ added: [session], removed: [], changed: [] });
-		await settle();
-		assert.deepStrictEqual(tasks.ranTasks, []);
-
-		loading.set(false, undefined);
-		await settle();
-		assert.deepStrictEqual(tasks.ranTasks, [{ label: 'setup', sessionId: 'a' }]);
-	});
-
-	test('ignores tasks without runOn worktreeCreated', async () => {
-		createDispatcher();
-		const { session } = makeSession({ id: 'a' });
-		tasks.setTasks(session.sessionId, [
-			entry('default'),
-			entry('on-open', 'folderOpen'),
-			entry('explicit-default', 'default'),
-		]);
-		mgmt.emitter.fire({ added: [session], removed: [], changed: [] });
-		await settle();
-
-		assert.deepStrictEqual(tasks.ranTasks, []);
-	});
-
-	test('does not run for sessions present at startup', async () => {
-		const { session } = makeSession({ id: 'a' });
-		tasks.setTasks(session.sessionId, [entry('setup', 'worktreeCreated')]);
-		mgmt.sessions = [session];
-
-		createDispatcher();
-		await settle();
-
-		assert.deepStrictEqual(tasks.ranTasks, []);
-	});
-
-	test('tracks pending untitled sessions present at startup', async () => {
-		const { session, status, workspace } = makeSession({
-			id: 'a',
-			status: SessionStatus.Untitled,
-			hasWorktree: false
-		});
-		tasks.setTasks(session.sessionId, [entry('setup', 'worktreeCreated')]);
-		mgmt.sessions = [session];
-
-		createDispatcher();
-		await settle();
-		assert.deepStrictEqual(tasks.ranTasks, []);
-
-		status.set(SessionStatus.InProgress, undefined);
-		workspace.set(makeWorkspace(true), undefined);
-		await settle();
-		assert.deepStrictEqual(tasks.ranTasks, [{ label: 'setup', sessionId: 'a' }]);
-	});
-
-	test('does not run for restored sessions reported as added after startup', async () => {
-		createDispatcher();
-		const { session } = makeSession({ id: 'a' });
-		tasks.setTasks(session.sessionId, [entry('setup', 'worktreeCreated')]);
-		mgmt.emitter.fire({ added: [session], removed: [], changed: [] });
-		await settle();
-
-		assert.deepStrictEqual(tasks.ranTasks, []);
-	});
-
-	test('runs for committed replacement of tracked pending session', async () => {
-		createDispatcher();
-		const { session: pending } = makeSession({ id: 'pending', hasWorktree: false });
-		const { session: committed } = makeSession({ id: 'committed', hasWorktree: true });
-		tasks.setTasks(committed.sessionId, [entry('setup', 'worktreeCreated')]);
-
-		mgmt.emitter.fire({ added: [pending], removed: [], changed: [] });
-		await settle();
-		mgmt.emitter.fire({ added: [], removed: [pending], changed: [committed] });
-		await settle();
-
-		assert.deepStrictEqual(tasks.ranTasks, [{ label: 'setup', sessionId: 'committed' }]);
-	});
-
-	test('does not treat mixed changed sessions as pending replacements', async () => {
-		createDispatcher();
-		const { session: pending } = makeSession({ id: 'pending', hasWorktree: false });
-		const { session: committed } = makeSession({ id: 'committed', hasWorktree: true });
-		const { session: restored } = makeSession({ id: 'restored', hasWorktree: true });
-		tasks.setTasks(committed.sessionId, [entry('setup-committed', 'worktreeCreated')]);
-		tasks.setTasks(restored.sessionId, [entry('setup-restored', 'worktreeCreated')]);
-
-		mgmt.emitter.fire({ added: [pending], removed: [], changed: [] });
-		await settle();
-		mgmt.emitter.fire({ added: [], removed: [pending], changed: [committed, restored] });
-		await settle();
-
-		assert.deepStrictEqual(tasks.ranTasks, []);
-	});
-
-	test('does not treat dispatched sessions as pending replacements', async () => {
-		createDispatcher();
-		const { session: dispatched, workspace } = makeSession({ id: 'dispatched', hasWorktree: false });
-		const { session: changed } = makeSession({ id: 'changed', hasWorktree: true });
-		tasks.setTasks(dispatched.sessionId, [entry('setup-dispatched', 'worktreeCreated')]);
-		tasks.setTasks(changed.sessionId, [entry('setup-changed', 'worktreeCreated')]);
-
-		mgmt.emitter.fire({ added: [dispatched], removed: [], changed: [] });
-		workspace.set(makeWorkspace(true), undefined);
-		await settle();
-		mgmt.emitter.fire({ added: [], removed: [dispatched], changed: [changed] });
-		await settle();
-
-		assert.deepStrictEqual(tasks.ranTasks, [{ label: 'setup-dispatched', sessionId: 'dispatched' }]);
-	});
-
-	test('waits for a worktree before running', async () => {
-		createDispatcher();
-		const { session, workspace } = makeSession({ id: 'a', hasWorktree: false });
-		tasks.setTasks(session.sessionId, [entry('setup', 'worktreeCreated')]);
-		mgmt.emitter.fire({ added: [session], removed: [], changed: [] });
-		await settle();
-		assert.deepStrictEqual(tasks.ranTasks, []);
-
-		workspace.set(makeWorkspace(true), undefined);
-		await settle();
-		assert.deepStrictEqual(tasks.ranTasks, [{ label: 'setup', sessionId: 'a' }]);
-	});
-
-	test('waits for untitled sessions to start before running', async () => {
-		createDispatcher();
-		const { session, status } = makeSession({ id: 'a', status: SessionStatus.Untitled });
-		tasks.setTasks(session.sessionId, [entry('setup', 'worktreeCreated')]);
-		mgmt.emitter.fire({ added: [session], removed: [], changed: [] });
-		await settle();
-		assert.deepStrictEqual(tasks.ranTasks, []);
-
-		status.set(SessionStatus.InProgress, undefined);
-		await settle();
-		assert.deepStrictEqual(tasks.ranTasks, [{ label: 'setup', sessionId: 'a' }]);
-	});
-
-	test('tears down subscription when a session is removed', async () => {
-		createDispatcher();
-		const { session } = makeSession({ id: 'a' });
-		// No tasks yet — autorun should be subscribed but inert.
-		mgmt.emitter.fire({ added: [session], removed: [], changed: [] });
-		await settle();
-
-		mgmt.emitter.fire({ added: [], removed: [session], changed: [] });
-		// Now publish tasks; if the subscription still exists, it would run.
-		tasks.setTasks(session.sessionId, [entry('setup', 'worktreeCreated')]);
-		await settle();
-
-		assert.deepStrictEqual(tasks.ranTasks, []);
-	});
-
-	test('skips agent host sessions when the agent host setting is disabled (default)', async () => {
+	test('skips agent host sessions when the setting is disabled (default)', async () => {
 		createDispatcher();
 		const { session, workspace } = makeSession({ id: 'a', providerId: LOCAL_AGENT_HOST_PROVIDER_ID, hasWorktree: false });
 		tasks.setTasks(session.sessionId, [entry('setup', 'worktreeCreated')]);
-		mgmt.emitter.fire({ added: [session], removed: [], changed: [] });
+
+		mgmt.sessionStartedEmitter.fire(session);
 		workspace.set(makeWorkspace(true), undefined);
 		await settle();
 
 		assert.deepStrictEqual(tasks.ranTasks, []);
 	});
 
-	test('runs agent host sessions when the agent host setting is enabled', async () => {
+	test('runs agent host sessions when the setting is enabled', async () => {
 		await configurationService.setUserConfiguration(AGENT_HOST_RUN_WORKTREE_CREATED_TASKS_SETTING, true);
 		createDispatcher();
 		const { session, workspace } = makeSession({ id: 'a', providerId: LOCAL_AGENT_HOST_PROVIDER_ID, hasWorktree: false });
 		tasks.setTasks(session.sessionId, [entry('setup', 'worktreeCreated')]);
-		mgmt.emitter.fire({ added: [session], removed: [], changed: [] });
+
+		mgmt.sessionStartedEmitter.fire(session);
 		workspace.set(makeWorkspace(true), undefined);
 		await settle();
 
@@ -412,11 +281,11 @@ suite('WorktreeCreatedTaskDispatcher', () => {
 	});
 
 	test('does not gate non-agent-host sessions on the agent host setting', async () => {
-		// Setting is `false` by default; non-agent-host sessions should still run.
 		createDispatcher();
 		const { session, workspace } = makeSession({ id: 'a', providerId: 'non-agent-host', hasWorktree: false });
 		tasks.setTasks(session.sessionId, [entry('setup', 'worktreeCreated')]);
-		mgmt.emitter.fire({ added: [session], removed: [], changed: [] });
+
+		mgmt.sessionStartedEmitter.fire(session);
 		workspace.set(makeWorkspace(true), undefined);
 		await settle();
 

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -48,6 +48,8 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 
 	private readonly _onDidChangeSessions = this._register(new Emitter<ISessionsChangeEvent>());
 	readonly onDidChangeSessions: Event<ISessionsChangeEvent> = this._onDidChangeSessions.event;
+	private readonly _onDidStartSession = this._register(new Emitter<ISession>());
+	readonly onDidStartSession: Event<ISession> = this._onDidStartSession.event;
 
 	private readonly _onDidChangeSessionTypes = this._register(new Emitter<void>());
 	readonly onDidChangeSessionTypes: Event<void> = this._onDidChangeSessionTypes.event;
@@ -512,6 +514,7 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 				this._visibility.updateSession(tmpSession, updatedSession);
 				setActiveChatToLast();
 			}
+			this._onDidStartSession.fire(updatedSession);
 
 			this._logRequestSent(updatedSession, session.mainChat.get(), true, options);
 		} finally {

--- a/src/vs/sessions/services/sessions/common/sessionsManagement.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsManagement.ts
@@ -114,6 +114,11 @@ export interface ISessionsManagementService {
 	 * Fires when sessions change across any provider.
 	 */
 	readonly onDidChangeSessions: Event<ISessionsChangeEvent>;
+	/**
+	 * Fires when a brand-new session is started by this window via
+	 * {@link sendNewChatRequest}.
+	 */
+	readonly onDidStartSession: Event<ISession>;
 
 	// -- Active Session --
 

--- a/src/vs/sessions/services/sessions/test/browser/sessionNavigation.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionNavigation.test.ts
@@ -86,6 +86,7 @@ class MockSessionStore implements ISessionsManagementService {
 	readonly activeSession = observableValue<IActiveSession | undefined>('test.activeSession', undefined);
 	readonly visibleSessions = observableValue<readonly IActiveSession[]>('test.visibleSessions', []);
 	readonly onDidChangeSessions = Event.None;
+	readonly onDidStartSession = Event.None;
 	readonly onDidChangeSessionTypes = Event.None;
 
 	private readonly _sessions = new Map<string, ISession>();


### PR DESCRIPTION

## Problem

WorktreeCreatedTaskDispatcher fires 'Install & Watch' worktree tasks excessively for restored/synced sessions instead of only for newly-started ones.

### Root Cause

The dispatcher listened to `onDidChangeSessions` and tried to filter on `status === Untitled` to identify newly started sessions. This was fundamentally wrong:

1. **Agent-host sessions are never Untitled** when arriving via change events:
   - Skeletons get `setStatus(InProgress)` **before** the change event fires (baseAgentHostSessionsProvider.ts:1854-1859)
   - Real sessions from `_refreshSessions` are constructed with server metadata status (baseAgentHostSessionsProvider.ts:2106-2147)

2. **`onDidChangeSessions` is a catalog-change event**, not a 'we started this' event:
   - Fires whenever any provider updates the catalog: added/removed/changed
   - Includes cloud-synced sessions, restored sessions, sessions from other devices
   - This caused tasks to run for existing sessions on every catalog update

## Solution

Introduce an explicit `onDidStartSession` event that fires only from `sendNewChatRequest` after `provider.sendRequest()` resolves with the committed session.

### Changes

- **ISessionsManagementService**: Add `readonly onDidStartSession: Event<ISession>` declaration
- **SessionsManagementService**: Implement emitter + fire call in `sendNewChatRequest` (after session is committed)
- **WorktreeCreatedTaskDispatcher**: Rewrite to listen ONLY to `onDidStartSession` instead of `added/changed` events
- **Tests**: Comprehensive rewrite with regression test for #318241
- **Docs**: Update SESSIONS.md spec

### Why This is Correct

Sessions that flow through `sendNewChatRequest` are exactly the ones 'we just started locally'. Cloud-synced / restored / refreshed sessions appear via `provider._onDidChangeSessions` from `_refreshSessions`, which the dispatcher no longer listens to.

This correctly distinguishes:
- 'Sessions we just started' → runs worktree tasks ✓
- 'Sessions in the catalog from any other reason' → ignored ✓

Fixes #318241
