### PR TITLE
Feat/scm local only

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -768,6 +768,18 @@
         "enablement": "!operationInProgress"
       },
       {
+        "command": "git.addToLocalOnly",
+        "title": "%command.addToLocalOnly%",
+        "category": "Git",
+        "enablement": "!operationInProgress"
+      },
+      {
+        "command": "git.removeFromLocalOnly",
+        "title": "%command.removeFromLocalOnly%",
+        "category": "Git",
+        "enablement": "!operationInProgress"
+      },
+      {
         "command": "git.revealInExplorer",
         "title": "%command.revealInExplorer%",
         "category": "Git"
@@ -1628,6 +1640,14 @@
         {
           "command": "git.ignore",
           "when": "config.git.enabled && !git.missing && gitOpenRepositoryCount != 0 && resourceScheme == file && scmActiveResourceRepository"
+        },
+        {
+          "command": "git.addToLocalOnly",
+          "when": "config.git.enabled && !git.missing && gitOpenRepositoryCount != 0"
+        },
+        {
+          "command": "git.removeFromLocalOnly",
+          "when": "config.git.enabled && !git.missing && gitOpenRepositoryCount != 0"
         },
         {
           "command": "git.stashIncludeUntracked",
@@ -2596,6 +2616,11 @@
           "group": "1_modification@3"
         },
         {
+          "command": "git.addToLocalOnly",
+          "when": "scmProvider == git && scmResourceGroup == workingTree",
+          "group": "1_modification@4"
+        },
+        {
           "command": "git.revealFileInOS.linux",
           "when": "scmProvider == git && scmResourceGroup == workingTree && remoteName == '' && isLinux",
           "group": "2_view@1"
@@ -2664,6 +2689,51 @@
           "command": "git.ignore",
           "when": "scmProvider == git && scmResourceGroup == untracked",
           "group": "1_modification@3"
+        },
+        {
+          "command": "git.addToLocalOnly",
+          "when": "scmProvider == git && scmResourceGroup == untracked",
+          "group": "1_modification@4"
+        },
+        {
+          "command": "git.openChange",
+          "when": "scmProvider == git && scmResourceGroup == localOnly",
+          "group": "navigation"
+        },
+        {
+          "command": "git.openHEADFile",
+          "when": "scmProvider == git && scmResourceGroup == localOnly",
+          "group": "navigation"
+        },
+        {
+          "command": "git.openFile",
+          "when": "scmProvider == git && scmResourceGroup == localOnly",
+          "group": "navigation"
+        },
+        {
+          "command": "git.removeFromLocalOnly",
+          "when": "scmProvider == git && scmResourceGroup == localOnly",
+          "group": "1_modification"
+        },
+        {
+          "command": "git.revealFileInOS.linux",
+          "when": "scmProvider == git && scmResourceGroup == localOnly && remoteName == '' && isLinux",
+          "group": "2_view@1"
+        },
+        {
+          "command": "git.revealFileInOS.mac",
+          "when": "scmProvider == git && scmResourceGroup == localOnly && remoteName == '' && isMac",
+          "group": "2_view@1"
+        },
+        {
+          "command": "git.revealFileInOS.windows",
+          "when": "scmProvider == git && scmResourceGroup == localOnly && remoteName == '' && isWindows",
+          "group": "2_view@1"
+        },
+        {
+          "command": "git.revealInExplorer",
+          "when": "scmProvider == git && scmResourceGroup == localOnly",
+          "group": "2_view@2"
         }
       ],
       "scm/history/title": [

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -109,6 +109,8 @@
 	"command.publish": "Publish Branch...",
 	"command.showOutput": "Show Git Output",
 	"command.ignore": "Add to .gitignore",
+	"command.addToLocalOnly": "Add to Local Only",
+	"command.removeFromLocalOnly": "Remove from Local Only",
 	"command.revealInExplorer": "Reveal in Explorer View",
 	"command.revealFileInOS.linux": "Open Containing Folder",
 	"command.revealFileInOS.mac": "Reveal in Finder",

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -4437,6 +4437,39 @@ export class CommandCenter {
 		await this.runByRepository(resources, async (repository, resources) => repository.ignore(resources));
 	}
 
+	@command('git.addToLocalOnly')
+	async addToLocalOnly(...resourceStates: SourceControlResourceState[]): Promise<void> {
+		await this.executeLocalOnlyCommand('addToLocalOnly', resourceStates);
+	}
+
+	@command('git.removeFromLocalOnly')
+	async removeFromLocalOnly(...resourceStates: SourceControlResourceState[]): Promise<void> {
+		await this.executeLocalOnlyCommand('removeFromLocalOnly', resourceStates);
+	}
+
+	private async executeLocalOnlyCommand(
+		action: 'addToLocalOnly' | 'removeFromLocalOnly',
+		resourceStates: SourceControlResourceState[]
+	): Promise<void> {
+		const resources = this.getResourceUrisFromScmArguments(resourceStates);
+
+		if (resources.length) {
+			await this.runByRepository(
+				resources,
+				async (repository, uris) => repository[action](uris)
+			);
+			return;
+		}
+
+		const resource = this.getSCMResource();
+		if (resource) {
+			await this.runByRepository(
+				resource.resourceUri,
+				async (repository, uri) => repository[action]([uri])
+			);
+		}
+	}
+
 	@command('git.revealInExplorer')
 	async revealInExplorer(resourceState: SourceControlResourceState): Promise<void> {
 		if (!resourceState) {
@@ -5726,10 +5759,34 @@ export class CommandCenter {
 			}
 
 			return repository.workingTreeGroup.resourceStates.filter(r => r.resourceUri.toString() === uriString)[0]
+				|| repository.untrackedGroup.resourceStates.filter(r => r.resourceUri.toString() === uriString)[0]
+				|| repository.localOnlyGroup.resourceStates.filter(r => r.resourceUri.toString() === uriString)[0]
 				|| repository.indexGroup.resourceStates.filter(r => r.resourceUri.toString() === uriString)[0]
 				|| repository.mergeGroup.resourceStates.filter(r => r.resourceUri.toString() === uriString)[0];
 		}
 		return undefined;
+	}
+
+	private getResourceUrisFromScmArguments(args: unknown[]): Uri[] {
+		const flattened = args.flatMap(arg => Array.isArray(arg) ? arg : [arg]).filter(arg => !!arg);
+		const resources: Uri[] = [];
+
+		for (const arg of flattened) {
+			if (arg instanceof Uri) {
+				resources.push(arg);
+				continue;
+			}
+
+			if (typeof arg === 'object' && arg !== null) {
+				const resourceUri = (arg as { resourceUri?: unknown }).resourceUri;
+
+				if (resourceUri instanceof Uri) {
+					resources.push(resourceUri);
+				}
+			}
+		}
+
+		return resources;
 	}
 
 	private runByRepository<T>(resource: Uri, fn: (repository: Repository, resource: Uri) => Promise<T>): Promise<T[]>;

--- a/extensions/git/src/decorationProvider.ts
+++ b/extensions/git/src/decorationProvider.ts
@@ -124,6 +124,7 @@ class GitDecorationProvider implements FileDecorationProvider {
 		this.collectDecorationData(this.repository.indexGroup, newDecorations);
 		this.collectDecorationData(this.repository.untrackedGroup, newDecorations);
 		this.collectDecorationData(this.repository.workingTreeGroup, newDecorations);
+		this.collectDecorationData(this.repository.localOnlyGroup, newDecorations);
 		this.collectDecorationData(this.repository.mergeGroup, newDecorations);
 		this.collectSubmoduleDecorationData(newDecorations);
 

--- a/extensions/git/src/model.ts
+++ b/extensions/git/src/model.ts
@@ -1004,7 +1004,14 @@ export class Model implements IRepositoryResolver, IBranchProtectionProviderRegi
 				return liveRepository;
 			}
 
-			if (hint === repository.mergeGroup || hint === repository.indexGroup || hint === repository.workingTreeGroup || hint === repository.untrackedGroup) {
+			const repositoryStatusGroups =
+				hint === repository.mergeGroup
+				|| hint === repository.indexGroup
+				|| hint === repository.workingTreeGroup
+				|| hint === repository.untrackedGroup
+				|| hint === repository.localOnlyGroup;
+
+			if (repositoryStatusGroups) {
 				return liveRepository;
 			}
 		}

--- a/extensions/git/src/quickDiffProvider.ts
+++ b/extensions/git/src/quickDiffProvider.ts
@@ -57,6 +57,12 @@ export class GitQuickDiffProvider implements QuickDiffProvider {
 			return undefined;
 		}
 
+		// Ignore path that is local only
+		if (this.repository.localOnlyGroup.resourceStates.some(r => pathEquals(r.resourceUri.fsPath, uri.fsPath))) {
+			this.logger.trace(`[Repository][provideOriginalResource] Resource is local only: ${uri.toString()}`);
+			return undefined;
+		}
+
 		// Ignore path that is untracked
 		if (this.repository.untrackedGroup.resourceStates.some(r => pathEquals(r.resourceUri.path, uri.path)) ||
 			this.repository.workingTreeGroup.resourceStates.some(r => pathEquals(r.resourceUri.path, uri.path) && r.type === Status.UNTRACKED)) {

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -1439,7 +1439,8 @@ export class Repository implements Disposable {
 	async commit(message: string | undefined, opts: CommitOptions = Object.create(null)): Promise<void> {
 		const indexResources = [...this.indexGroup.resourceStates.map(r => r.resourceUri.fsPath)];
 		const workingGroupResources = opts.all && opts.all !== 'tracked' ?
-			[...this.workingTreeGroup.resourceStates.map(r => r.resourceUri.fsPath)] : [];
+			[...this.workingTreeGroup.resourceStates, ...this.untrackedGroup.resourceStates].map(r => r.resourceUri.fsPath) : [];
+		const allResources = opts.all ? [...this.workingTreeGroup.resourceStates, ...this.untrackedGroup.resourceStates].map(r => r.resourceUri.fsPath) : [];
 
 		if (this.rebaseCommit) {
 			await this.run(
@@ -1447,7 +1448,13 @@ export class Repository implements Disposable {
 				async () => {
 					if (opts.all) {
 						const addOpts = opts.all === 'tracked' ? { update: true } : {};
-						await this.repository.add([], addOpts);
+						const resources = opts.all === 'tracked'
+							? this.workingTreeGroup.resourceStates
+								.filter(r => r.type !== Status.UNTRACKED && r.type !== Status.IGNORED)
+								.map(r => r.resourceUri.fsPath)
+							: allResources;
+
+						await this.repository.add(resources, addOpts);
 					}
 
 					await this.repository.rebaseContinue();
@@ -1463,7 +1470,13 @@ export class Repository implements Disposable {
 				async () => {
 					if (opts.all) {
 						const addOpts = opts.all === 'tracked' ? { update: true } : {};
-						await this.repository.add([], addOpts);
+						const resources = opts.all === 'tracked'
+							? this.workingTreeGroup.resourceStates
+								.filter(r => r.type !== Status.UNTRACKED && r.type !== Status.IGNORED)
+								.map(r => r.resourceUri.fsPath)
+							: allResources;
+
+						await this.repository.add(resources, addOpts);
 					}
 
 					delete opts.all;
@@ -3353,6 +3366,89 @@ export class Repository implements Disposable {
 	private optimisticUpdateEnabled(): boolean {
 		const config = workspace.getConfiguration('git', Uri.file(this.root));
 		return config.get<boolean>('optimisticUpdate') === true;
+	}
+
+	private getLocalOnlyResource(resourcePath: string): LocalOnlyResource | undefined {
+		return this.localOnlyResources.find(resource => pathEquals(resource.path, resourcePath));
+	}
+
+	private getStatusFromRaw(raw: { x: string; y: string }): Status | undefined {
+		switch (raw.x + raw.y) {
+			case '??': return Status.UNTRACKED;
+			case '!!': return Status.IGNORED;
+			case 'DD': return Status.BOTH_DELETED;
+			case 'AU': return Status.ADDED_BY_US;
+			case 'UD': return Status.DELETED_BY_THEM;
+			case 'UA': return Status.ADDED_BY_THEM;
+			case 'DU': return Status.DELETED_BY_US;
+			case 'AA': return Status.BOTH_ADDED;
+			case 'UU': return Status.BOTH_MODIFIED;
+		}
+		switch (raw.y) {
+			case 'M': return Status.MODIFIED;
+			case 'D': return Status.DELETED;
+			case 'A': return Status.INTENT_TO_ADD;
+			case 'R': return Status.INTENT_TO_RENAME;
+			case 'T': return Status.TYPE_CHANGED;
+		}
+		switch (raw.x) {
+			case 'M': return Status.INDEX_MODIFIED;
+			case 'A': return Status.INDEX_ADDED;
+			case 'D': return Status.INDEX_DELETED;
+			case 'R': return Status.INDEX_RENAMED;
+			case 'C': return Status.INDEX_COPIED;
+		}
+		return undefined;
+	}
+
+	private async updateLocalOnlyResources(resources: LocalOnlyResource[]): Promise<void> {
+		const uniqueResources: LocalOnlyResource[] = [];
+		for (const resource of resources) {
+			if (!uniqueResources.some(existing => pathEquals(existing.path, resource.path))) {
+				uniqueResources.push(resource);
+			}
+		}
+		this.localOnlyResources = uniqueResources;
+		await this.globalState.update(`${Repository.LOCAL_ONLY_STORAGE_KEY}:${this.root}`, uniqueResources.length > 0 ? uniqueResources : undefined);
+	}
+	private getResource(resourcePath: string): Resource | undefined {
+		return [...this.mergeGroup.resourceStates, ...this.indexGroup.resourceStates, ...this.workingTreeGroup.resourceStates, ...this.untrackedGroup.resourceStates, ...this.localOnlyGroup.resourceStates]
+			.find(resource => pathEquals(resource.resourceUri.fsPath, resourcePath));
+	}
+	async addToLocalOnly(resources: Uri[]): Promise<void> {
+		if (resources.length === 0) {
+			return;
+		}
+		const nextResources = [...this.localOnlyResources];
+		for (const resource of resources) {
+			const existingResource = this.getResource(resource.fsPath);
+			const resourceEntry: LocalOnlyResource = {
+				path: resource.fsPath,
+				status: existingResource?.type ?? Status.MODIFIED,
+				renamePath: existingResource?.renameResourceUri?.fsPath
+			};
+			const existingIndex = nextResources.findIndex(existing => pathEquals(existing.path, resourceEntry.path));
+			if (existingIndex === -1) {
+				nextResources.push(resourceEntry);
+			} else {
+				nextResources[existingIndex] = resourceEntry;
+			}
+		}
+		await this.updateLocalOnlyResources(nextResources);
+		await this.updateModelState();
+	}
+
+	async removeFromLocalOnly(resources: Uri[]): Promise<void> {
+		if (resources.length === 0) {
+			return;
+		}
+		const resourcePaths = resources.map(resource => resource.fsPath);
+		const nextResources = this.localOnlyResources.filter(resource => !resourcePaths.some(resourcePath => pathEquals(resource.path, resourcePath)));
+		if (nextResources.length === this.localOnlyResources.length) {
+			return;
+		}
+		await this.updateLocalOnlyResources(nextResources);
+		await this.updateModelState();
 	}
 
 	private async handleTagConflict(remote: string | undefined, raw: string): Promise<boolean> {

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -50,7 +50,8 @@ export const enum ResourceGroupType {
 	Merge,
 	Index,
 	WorkingTree,
-	Untracked
+	Untracked,
+	LocalOnly
 }
 
 export class Resource implements SourceControlResourceState {
@@ -356,6 +357,12 @@ interface GitResourceGroups {
 	untrackedGroup?: Resource[];
 	workingTreeGroup?: Resource[];
 	localOnlyGroup?: Resource[];
+}
+
+interface LocalOnlyResource {
+	path: string;
+	status: Status;
+	renamePath?: string;
 }
 
 class ProgressManager {
@@ -703,6 +710,7 @@ export interface IRepositoryResolver {
 
 export class Repository implements Disposable {
 	static readonly WORKTREE_ROOT_STORAGE_KEY = 'worktreeRoot';
+	static readonly LOCAL_ONLY_STORAGE_KEY = 'localOnlyResources';
 
 	private _onDidChangeRepository = new EventEmitter<Uri>();
 	readonly onDidChangeRepository: Event<Uri> = this._onDidChangeRepository.event;
@@ -904,6 +912,7 @@ export class Repository implements Disposable {
 	private branchProtection = new Map<string, BranchProtectionMatcher[]>();
 	private commitCommandCenter: CommitCommandsCenter;
 	private resourceCommandResolver = new ResourceCommandResolver(this);
+	private localOnlyResources: LocalOnlyResource[] = [];
 	private updateModelStateCancellationTokenSource: CancellationTokenSource | undefined;
 	private disposables: Disposable[] = [];
 
@@ -921,6 +930,7 @@ export class Repository implements Disposable {
 		private readonly repositoryCache: RepositoryCache
 	) {
 		this._operations = new OperationManager(this.logger);
+		this.localOnlyResources = this.globalState.get<LocalOnlyResource[]>(`${Repository.LOCAL_ONLY_STORAGE_KEY}:${this.root}`, []);
 
 		const repositoryWatcher = workspace.createFileSystemWatcher(new RelativePattern(Uri.file(repository.root), '**'));
 		this.disposables.push(repositoryWatcher);
@@ -3055,6 +3065,26 @@ export class Repository implements Disposable {
 			const renameUri = raw.rename
 				? Uri.file(path.join(this.repository.root, raw.rename))
 				: undefined;
+			const localOnlyResource = this.getLocalOnlyResource(uri.fsPath);
+
+			if (localOnlyResource) {
+				if (raw.x === 'M' || raw.x === 'A' || raw.x === 'D' || raw.x === 'R' || raw.x === 'C') {
+					switch (raw.x) {
+						case 'M': indexGroup.push(new Resource(this.resourceCommandResolver, ResourceGroupType.Index, uri, Status.INDEX_MODIFIED, useIcons, undefined, this.kind)); break;
+						case 'A': indexGroup.push(new Resource(this.resourceCommandResolver, ResourceGroupType.Index, uri, Status.INDEX_ADDED, useIcons, undefined, this.kind)); break;
+						case 'D': indexGroup.push(new Resource(this.resourceCommandResolver, ResourceGroupType.Index, uri, Status.INDEX_DELETED, useIcons, undefined, this.kind)); break;
+						case 'R': indexGroup.push(new Resource(this.resourceCommandResolver, ResourceGroupType.Index, uri, Status.INDEX_RENAMED, useIcons, renameUri, this.kind)); break;
+						case 'C': indexGroup.push(new Resource(this.resourceCommandResolver, ResourceGroupType.Index, uri, Status.INDEX_COPIED, useIcons, renameUri, this.kind)); break;
+					}
+				}
+
+				if (raw.y !== ' ') {
+					const localOnlyStatus = this.getStatusFromRaw(raw) ?? localOnlyResource.status;
+					localOnlyGroup.push(new Resource(this.resourceCommandResolver, ResourceGroupType.LocalOnly, uri, localOnlyStatus, useIcons, renameUri ?? (localOnlyResource.renamePath ? Uri.file(localOnlyResource.renamePath) : undefined), this.kind));
+				}
+
+				return undefined;
+			}
 
 			switch (raw.x + raw.y) {
 				case '??': switch (untrackedChanges) {

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -748,6 +748,9 @@ export class Repository implements Disposable {
 	private _untrackedGroup: SourceControlResourceGroup;
 	get untrackedGroup(): GitResourceGroup { return this._untrackedGroup as GitResourceGroup; }
 
+	private _localOnlyGroup: SourceControlResourceGroup;
+	get localOnlyGroup(): GitResourceGroup { return this._localOnlyGroup as GitResourceGroup; }
+
 	private _EMPTY_TREE: string | undefined;
 
 	private _HEAD: Branch | undefined;

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -355,6 +355,7 @@ interface GitResourceGroups {
 	mergeGroup?: Resource[];
 	untrackedGroup?: Resource[];
 	workingTreeGroup?: Resource[];
+	localOnlyGroup?: Resource[];
 }
 
 class ProgressManager {
@@ -862,6 +863,7 @@ export class Repository implements Disposable {
 		this.indexGroup.resourceStates = [];
 		this.workingTreeGroup.resourceStates = [];
 		this.untrackedGroup.resourceStates = [];
+		this.localOnlyGroup.resourceStates = [];
 		this._sourceControl.count = 0;
 	}
 
@@ -1010,6 +1012,7 @@ export class Repository implements Disposable {
 		this._indexGroup = this._sourceControl.createResourceGroup('index', l10n.t('Staged Changes'), { multiDiffEditorEnableViewChanges: true });
 		this._workingTreeGroup = this._sourceControl.createResourceGroup('workingTree', l10n.t('Changes'), { multiDiffEditorEnableViewChanges: true });
 		this._untrackedGroup = this._sourceControl.createResourceGroup('untracked', l10n.t('Untracked Changes'), { multiDiffEditorEnableViewChanges: true });
+		this._localOnlyGroup = this._sourceControl.createResourceGroup('localOnly', l10n.t('Local Only'), { multiDiffEditorEnableViewChanges: true });
 
 		const updateIndexGroupVisibility = () => {
 			const config = workspace.getConfiguration('git', root);
@@ -1046,11 +1049,13 @@ export class Repository implements Disposable {
 
 		this.mergeGroup.hideWhenEmpty = true;
 		this.untrackedGroup.hideWhenEmpty = true;
+		this.localOnlyGroup.hideWhenEmpty = true;
 
 		this.disposables.push(this.mergeGroup);
 		this.disposables.push(this.indexGroup);
 		this.disposables.push(this.workingTreeGroup);
 		this.disposables.push(this.untrackedGroup);
+		this.disposables.push(this.localOnlyGroup);
 
 		// Don't allow auto-fetch in untrusted workspaces
 		if (workspace.isTrusted) {
@@ -2938,6 +2943,7 @@ export class Repository implements Disposable {
 		if (resourcesGroups.mergeGroup) { this.mergeGroup.resourceStates = resourcesGroups.mergeGroup; }
 		if (resourcesGroups.untrackedGroup) { this.untrackedGroup.resourceStates = resourcesGroups.untrackedGroup; }
 		if (resourcesGroups.workingTreeGroup) { this.workingTreeGroup.resourceStates = resourcesGroups.workingTreeGroup; }
+		if (resourcesGroups.localOnlyGroup) { this.localOnlyGroup.resourceStates = resourcesGroups.localOnlyGroup; }
 
 		// clear worktree migrating flag once all conflicts are resolved
 		if (this._isWorktreeMigrating && resourcesGroups.mergeGroup && resourcesGroups.mergeGroup.length === 0) {
@@ -3041,7 +3047,8 @@ export class Repository implements Disposable {
 		const indexGroup: Resource[] = [],
 			mergeGroup: Resource[] = [],
 			untrackedGroup: Resource[] = [],
-			workingTreeGroup: Resource[] = [];
+			workingTreeGroup: Resource[] = [],
+			localOnlyGroup: Resource[] = [];
 
 		status.forEach(raw => {
 			const uri = Uri.file(path.join(this.repository.root, raw.path));
@@ -3088,7 +3095,7 @@ export class Repository implements Disposable {
 			return undefined;
 		});
 
-		return { indexGroup, mergeGroup, untrackedGroup, workingTreeGroup };
+		return { indexGroup, mergeGroup, localOnlyGroup, untrackedGroup, workingTreeGroup };
 	}
 
 	private setCountBadge(): void {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #318681

---

### **Overview**

Introduces a new SCM resource group named Local Only for tracked files that should remain modified locally but never participate in staging or commit workflows.

---

### **Problem**

Developers frequently maintain local modifications in tracked files that should never be committed.

---

### **Solution**

This PR introduces a dedicated SCM resource group called Local Only.

The implementation focuses on improving the Source Control workflow and UX without directly exposing raw Git internals.

---

### **Testing**

Tested manually with the following scenarios:

- Add tracked files to the Local Only group
- Verify files remain modified locally
- Attempt staging operations
- Restart VS Code and validate persistence behavior
- Remove files from the group and validate SCM refresh/update behavior

---

### **Notes**

- This implementation is intentionally local-only.
- No repository-level Git configuration is modified.
- .gitignore remains untouched.
- The feature is designed as a UX/workflow abstraction over existing Git behavior.