### PR TITLE
Don't kill terminal just opened after archiving sessions

### DIFF
--- a/src/vs/sessions/contrib/terminal/browser/sessionsTerminalContribution.ts
+++ b/src/vs/sessions/contrib/terminal/browser/sessionsTerminalContribution.ts
@@ -81,6 +81,16 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 
 	private _activeKey: string | undefined;
 
+	/**
+	 * Session ids already processed as archived. The archive cleanup runs only
+	 * on the not-archived → archived transition: the provider keeps archived
+	 * sessions cached and re-emits them in `changed` on every sync (status/summary
+	 * updates, the archive round-trip), so acting on the current archived state
+	 * would re-run the cwd cleanup each time and sweep terminals the user opened
+	 * afterwards. See #313510, #318645.
+	 */
+	private readonly _archivedSessionIds = new Set<string>();
+
 	constructor(
 		@ISessionsManagementService private readonly _sessionsManagementService: ISessionsManagementService,
 		@ISessionsProvidersService private readonly _sessionsProvidersService: ISessionsProvidersService,
@@ -93,6 +103,15 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 		@IContextKeyService contextKeyService: IContextKeyService,
 	) {
 		super();
+
+		// Seed with sessions that are already archived (e.g. restored archived
+		// from a previous window) so they are not treated as newly archived on
+		// their first change event.
+		for (const session of this._sessionsManagementService.getSessions()) {
+			if (session.isArchived.get()) {
+				this._archivedSessionIds.add(session.sessionId);
+			}
+		}
 
 		const profileOverride = derived(reader => {
 			const session = this._sessionsManagementService.activeSession.read(reader);
@@ -177,12 +196,48 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 		// live session still owns that cwd. Terminals are reused across sessions
 		// at the same cwd, so a plain cwd match would kill a terminal still in use
 		// (e.g. the committed session from `onDidReplaceSession`).
-		// TODO: Consider removing the logic for trying to "delete/clean-up" terminal.
-		// Or consider tag terminals by sessionId + refcount instead of guarding here.
+		//
+		// The archive cleanup runs only on the not-archived → archived transition.
+		// The provider keeps archived sessions cached and re-emits them in
+		// `changed` on every sync; acting on the current archived state would
+		// re-run the cwd cleanup each time and sweep terminals the user opened
+		// after archiving.
+		//
+		// Archiving is also asynchronous (the event can land after the active
+		// session has already flipped to a new/pending one and the user has opened
+		// a terminal). On the archive path we therefore never dispose the terminal
+		// the user is currently focused on — see `_closeTerminalsForPath` and
+		// #313510, #318645. Removal is an explicit user action, so it cleans up
+		// the terminal regardless.
+		// TODO: tag terminals by sessionId (1:1) instead of guarding by cwd here.
 
 		this._register(this._sessionsManagementService.onDidChangeSessions(e => {
-			const archivedChanged = e.changed.filter(s => s.isArchived.get());
-			if (e.removed.length === 0 && archivedChanged.length === 0) {
+			// Only act on the not-archived → archived transition; ignore re-emits
+			// of sessions already known to be archived. Keep the tracked set in
+			// sync: drop ids that were un-archived or removed, and record sessions
+			// that arrive already-archived (e.g. restored from a previous window)
+			// so they never count as a fresh transition.
+			for (const session of e.added) {
+				if (session.isArchived.get()) {
+					this._archivedSessionIds.add(session.sessionId);
+				}
+			}
+			const justArchived: ISession[] = [];
+			for (const session of e.changed) {
+				if (session.isArchived.get()) {
+					if (!this._archivedSessionIds.has(session.sessionId)) {
+						this._archivedSessionIds.add(session.sessionId);
+						justArchived.push(session);
+					}
+				} else {
+					this._archivedSessionIds.delete(session.sessionId);
+				}
+			}
+			for (const session of e.removed) {
+				this._archivedSessionIds.delete(session.sessionId);
+			}
+
+			if (e.removed.length === 0 && justArchived.length === 0) {
 				return;
 			}
 			const removedIds = new Set(e.removed.map(s => s.sessionId));
@@ -196,10 +251,19 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 					liveCwdKeys.add(info.cwd.fsPath.toLowerCase());
 				}
 			}
-			for (const session of [...e.removed, ...archivedChanged]) {
+			this._logService.debug(`[SessionsTerminal] onDidChangeSessions cleanup (removed: ${e.removed.length}, justArchived: ${justArchived.length}, liveCwdKeys: [${[...liveCwdKeys].join(', ')}], activeKey: ${this._activeKey ?? '<none>'})`);
+			for (const session of e.removed) {
 				const info = getSessionTerminalInfo(session);
 				if (info && !liveCwdKeys.has(info.cwd.fsPath.toLowerCase())) {
-					this._closeTerminalsForPath(info.cwd.fsPath);
+					this._logService.debug(`[SessionsTerminal] Closing terminals for ${info.cwd.fsPath} (session ${session.sessionId} removed; no live session owns this cwd)`);
+					this._closeTerminalsForPath(info.cwd.fsPath, false, `session removed (${session.sessionId})`);
+				}
+			}
+			for (const session of justArchived) {
+				const info = getSessionTerminalInfo(session);
+				if (info && !liveCwdKeys.has(info.cwd.fsPath.toLowerCase())) {
+					this._logService.debug(`[SessionsTerminal] Closing terminals for ${info.cwd.fsPath} (session ${session.sessionId} archived; no live session owns this cwd)`);
+					this._closeTerminalsForPath(info.cwd.fsPath, true, `session archived (${session.sessionId})`);
 				}
 			}
 		}));
@@ -368,6 +432,7 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 		for (const instance of toHide) {
 			const availableInstance = this._getAvailableTerminal(instance, 'move terminal to background');
 			if (availableInstance) {
+				this._logService.debug(`[SessionsTerminal] Hiding terminal ${availableInstance.instanceId} (does not belong to active key ${activeKey})`);
 				this._terminalService.moveToBackground(availableInstance);
 			}
 		}
@@ -389,8 +454,20 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 		}
 	}
 
-	private async _closeTerminalsForPath(fsPath: string): Promise<void> {
+	/**
+	 * Disposes terminals whose initial cwd matches {@link fsPath}.
+	 *
+	 * On the archive path ({@link protectActiveInstance} = true) the terminal the
+	 * user is currently focused on is never disposed: archiving is asynchronous
+	 * and can land while the user is typing in a just-opened terminal at this cwd.
+	 * Removal is an explicit user action and disposes everything.
+	 *
+	 * {@link reason} is logged for each killed terminal so unexpected disposals in
+	 * the agents window can be diagnosed from the logs. See #313510, #318645.
+	 */
+	private async _closeTerminalsForPath(fsPath: string, protectActiveInstance: boolean, reason: string): Promise<void> {
 		const key = fsPath.toLowerCase();
+		const protectedInstanceId = protectActiveInstance ? this._terminalService.activeInstance?.instanceId : undefined;
 		for (const instance of [...this._terminalService.instances]) {
 			// Skip hidden tool terminals (e.g. run_in_terminal) — those are
 			// managed by the chat tool lifecycle, not the session terminal
@@ -398,15 +475,19 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 			if (instance.shellLaunchConfig.hideFromUser) {
 				continue;
 			}
+			if (protectedInstanceId !== undefined && instance.instanceId === protectedInstanceId) {
+				this._logService.debug(`[SessionsTerminal] Skipping active terminal ${instance.instanceId} for ${fsPath} (user is working in it)`);
+				continue;
+			}
 			try {
 				const cwd = (await instance.getInitialCwd()).toLowerCase();
 				if (cwd === key) {
-					const availableInstance = this._getAvailableTerminal(instance, `close archived terminal for ${fsPath}`);
+					const availableInstance = this._getAvailableTerminal(instance, `close terminal for ${fsPath}`);
 					if (!availableInstance) {
 						continue;
 					}
+					this._logService.info(`[SessionsTerminal] Killing terminal ${availableInstance.instanceId} (cwd: ${fsPath}, reason: ${reason})`);
 					this._terminalService.safeDisposeTerminal(availableInstance);
-					this._logService.trace(`[SessionsTerminal] Closed archived terminal ${availableInstance.instanceId}`);
 				}
 			} catch {
 				// ignore

--- a/src/vs/sessions/contrib/terminal/test/browser/sessionsTerminalContribution.test.ts
+++ b/src/vs/sessions/contrib/terminal/test/browser/sessionsTerminalContribution.test.ts
@@ -217,6 +217,7 @@ suite('SessionsTerminalContribution', () => {
 
 	let createdTerminals: { cwd: URI }[];
 	let activeInstanceSet: number[];
+	let activeInstanceId: number | undefined;
 	let focusCalls: number;
 	let disposedInstances: ITerminalInstance[];
 	let nextInstanceId: number;
@@ -232,6 +233,7 @@ suite('SessionsTerminalContribution', () => {
 	setup(() => {
 		createdTerminals = [];
 		activeInstanceSet = [];
+		activeInstanceId = undefined;
 		focusCalls = 0;
 		disposedInstances = [];
 		nextInstanceId = 1;
@@ -266,6 +268,9 @@ suite('SessionsTerminalContribution', () => {
 			override get foregroundInstances(): readonly ITerminalInstance[] {
 				return [...terminalInstances.values()].filter(i => !backgroundedInstances.has(i.instanceId));
 			}
+			override get activeInstance(): ITerminalInstance | undefined {
+				return activeInstanceId !== undefined ? terminalInstances.get(activeInstanceId) : undefined;
+			}
 			override async createTerminal(opts?: any): Promise<ITerminalInstance> {
 				const id = nextInstanceId++;
 				const cwdUri: URI | undefined = opts?.config?.cwd;
@@ -284,6 +289,7 @@ suite('SessionsTerminalContribution', () => {
 			}
 			override setActiveInstance(instance: ITerminalInstance): void {
 				activeInstanceSet.push(instance.instanceId);
+				activeInstanceId = instance.instanceId;
 			}
 			override async focusActiveInstance(): Promise<void> {
 				focusCalls++;
@@ -293,6 +299,9 @@ suite('SessionsTerminalContribution', () => {
 				(instance as TestTerminalInstance)._testSetDisposed(true);
 				terminalInstances.delete(instance.instanceId);
 				backgroundedInstances.delete(instance.instanceId);
+				if (activeInstanceId === instance.instanceId) {
+					activeInstanceId = undefined;
+				}
 			}
 			override moveToBackground(instance: ITerminalInstance): void {
 				backgroundedInstances.add(instance.instanceId);
@@ -539,6 +548,12 @@ suite('SessionsTerminalContribution', () => {
 
 		assert.strictEqual(createdTerminals.length, 1);
 
+		// Archiving flips the active session away from the archived one, so the
+		// archived session's terminal is no longer the focused (active) terminal.
+		const otherSession = makeAgentSession({ worktree: URI.file('/other'), providerType: AgentSessionProviders.Background });
+		activeSessionObs.set(otherSession, undefined);
+		await tick();
+
 		const session = makeAgentSession({
 			isArchived: true,
 			worktree: worktreeUri,
@@ -583,6 +598,13 @@ suite('SessionsTerminalContribution', () => {
 
 		assert.strictEqual(createdTerminals.length, 1);
 		assert.strictEqual(createdTerminals[0].cwd.fsPath, repoUri.fsPath);
+
+		// Switch the active session to a different cwd so the repo cwd is no longer
+		// the protected active cwd (mirrors archiving flipping the active session
+		// to a new one), then archive the repo-only session.
+		const otherSession = makeAgentSession({ worktree: URI.file('/other'), providerType: AgentSessionProviders.Background });
+		activeSessionObs.set(otherSession, undefined);
+		await tick();
 
 		const archivedSession = makeAgentSession({ repository: repoUri, providerType: AgentSessionProviders.Background, isArchived: true });
 		onDidChangeSessions.fire({ added: [], removed: [], changed: [archivedSession] });
@@ -646,6 +668,88 @@ suite('SessionsTerminalContribution', () => {
 		await tick();
 
 		assert.strictEqual(disposedInstances.length, 1, 'no live session owns this cwd, terminal should be closed');
+	});
+
+	test('does not close the terminal at the active session cwd when archiving (just-opened terminal is protected)', async () => {
+		// Mirrors the "archive all sessions, then open a terminal" repro (#313510):
+		// a late archive event must not dispose the terminal the user is currently
+		// working in at the active session's cwd.
+		const worktreeUri = URI.file('/worktree');
+		const activeSession = makeAgentSession({ worktree: worktreeUri, providerType: AgentSessionProviders.Background });
+		activeSessionObs.set(activeSession, undefined);
+		await tick();
+
+		assert.strictEqual(createdTerminals.length, 1);
+
+		// A different, now-archived session that happens to share the active cwd.
+		const archivedSession = makeAgentSession({ sessionId: 'test:archived', worktree: worktreeUri, providerType: AgentSessionProviders.Background, isArchived: true });
+		onDidChangeSessions.fire({ added: [], removed: [], changed: [archivedSession] });
+		await tick();
+
+		assert.strictEqual(disposedInstances.length, 0, 'terminal at the active session cwd must not be disposed');
+	});
+
+	test('does not re-close a newly-opened terminal when an already-archived session is re-emitted', async () => {
+		// Mirrors the "every new terminal keeps dying" repro (#313510, #318645):
+		// the provider keeps archived sessions cached and re-emits them in `changed`
+		// on every sync. The archive cleanup must only run on the first archived
+		// transition, not on each re-emit.
+		const worktreeUri = URI.file('/worktree');
+		await contribution.ensureTerminal(worktreeUri, false); // terminal 1 at /worktree
+		await contribution.ensureTerminal(URI.file('/other'), false); // terminal 2 at /other, now active
+
+		const archivedSession = makeAgentSession({ sessionId: 'test:archived', worktree: worktreeUri, providerType: AgentSessionProviders.Background, isArchived: true });
+
+		// First archive event closes the terminal at the archived cwd (not active).
+		onDidChangeSessions.fire({ added: [], removed: [], changed: [archivedSession] });
+		await tick();
+		assert.strictEqual(disposedInstances.length, 1);
+
+		// The user opens a new terminal at the same cwd, then moves focus elsewhere.
+		await contribution.ensureTerminal(worktreeUri, false); // terminal 3 at /worktree, active
+		await contribution.ensureTerminal(URI.file('/other'), false); // reuse terminal 2, active again
+
+		// The provider re-emits the still-archived session on a later sync. The
+		// transition guard makes this a no-op so the newly-opened terminal survives.
+		onDidChangeSessions.fire({ added: [], removed: [], changed: [archivedSession] });
+		await tick();
+		assert.strictEqual(disposedInstances.length, 1, 're-emitted archived session must not close the newly-opened terminal');
+	});
+
+	test('terminal opened after archiving all sessions survives subsequent streamed updates', async () => {
+		const worktreeUri = URI.file('/worktree');
+		const session = makeAgentSession({ isArchived: true, worktree: worktreeUri, providerType: AgentSessionProviders.Background });
+
+		// Archive transition with no live sessions left.
+		onDidChangeSessions.fire({ added: [], removed: [], changed: [session] });
+		await tick();
+		assert.strictEqual(disposedInstances.length, 0, 'no terminal exists yet');
+
+		// User opens a terminal afterwards, then several background updates arrive
+		// for the archived session.
+		await contribution.ensureTerminal(worktreeUri, false);
+		onDidChangeSessions.fire({ added: [], removed: [], changed: [session] });
+		onDidChangeSessions.fire({ added: [], removed: [], changed: [session] });
+		await tick();
+
+		assert.strictEqual(disposedInstances.length, 0, 'terminal opened after archiving must stay open');
+	});
+
+	test('session restored already-archived does not close a terminal on its first change event', async () => {
+		const worktreeUri = URI.file('/worktree');
+		await contribution.ensureTerminal(worktreeUri, false);
+		assert.strictEqual(createdTerminals.length, 1);
+
+		const session = makeAgentSession({ isArchived: true, worktree: worktreeUri, providerType: AgentSessionProviders.Background });
+
+		// Restored sessions arrive as `added`; an already-archived one is not a
+		// transition and must not close a terminal when it later changes.
+		onDidChangeSessions.fire({ added: [session], removed: [], changed: [] });
+		await tick();
+		onDidChangeSessions.fire({ added: [], removed: [], changed: [session] });
+		await tick();
+
+		assert.strictEqual(disposedInstances.length, 0, 'restored already-archived session should not close the terminal');
 	});
 
 	// --- switching back to previously used path reuses terminal ---
@@ -872,6 +976,12 @@ suite('SessionsTerminalContribution', () => {
 		const toolTerminal = makeTerminalInstance(nextInstanceId++, worktreeUri.fsPath);
 		toolTerminal._testSetShellLaunchConfig({ hideFromUser: true } as ITerminalInstance['shellLaunchConfig']);
 		terminalInstances.set(toolTerminal.instanceId, toolTerminal);
+
+		// Archiving flips the active session away, so the archived session's
+		// regular terminal is no longer the focused (active) terminal.
+		const otherSession = makeAgentSession({ worktree: URI.file('/other'), providerType: AgentSessionProviders.Background });
+		activeSessionObs.set(otherSession, undefined);
+		await tick();
 
 		const session = makeAgentSession({
 			isArchived: true,


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/313510
Resolves: https://github.com/microsoft/vscode/issues/318645

- Hide (not kill) terminals when a session is archived, since archiving is reversible and the pty can be reused on unarchive or by another session at the same cwd.
- Kill terminals only when a session is explicitly removed, which is a destructive user action.
- Never touch the focused/active terminal on either the archive or remove path, so a terminal the user just opened is not swept away by an async cleanup.
- Run the archive cleanup only on the not-archived → archived transition: the provider re-emits cached archived sessions in `changed` on every sync, so acting on the current archived state would re-run the cwd cleanup and close terminals opened after archiving.
- Seed the archived-session set at construction and on `e.added` so sessions restored already-archived (e.g. from a previous window) never count as a fresh archive transition.
- Skip the cleanup when another live session still owns the same cwd, covering the untitled → committed graduation case where `onDidReplaceSession` surfaces the skeleton in `removed` while the committed session inherits the cwd.
- Add info-level logging for each hide/kill decision (with the originating reason) to make unexpected terminal lifecycle events diagnosable.

-----------------------------------------
Inspirations from:

- `moveToBackground` hide semantics (pty survives, can be shown again) come from [`ITerminalService.moveToBackground`](https://github.com/microsoft/vscode/blob/98abbd31403aacdf7698d7b8187edb2fd2c4c36a/src/vs/workbench/contrib/terminal/browser/terminal.ts#L553-L559).
- `safeDisposeTerminal` kill semantics come from [`ITerminalService.safeDisposeTerminal`](https://github.com/microsoft/vscode/blob/98abbd31403aacdf7698d7b8187edb2fd2c4c36a/src/vs/workbench/contrib/terminal/browser/terminal.ts#L581).
- Archive/remove session change semantics come from [`ISessionsChangeEvent` (added/removed/changed)](https://github.com/microsoft/vscode/blob/98abbd31403aacdf7698d7b8187edb2fd2c4c36a/src/vs/sessions/services/sessions/common/sessionsManagement.ts#L49).