### PR TITLE
fix: restore right-click rename for sessions in the Agents window (#318819)

### DIFF
--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsActions.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsActions.ts
@@ -7,11 +7,12 @@ import { BaseActionViewItem } from '../../../../../base/browser/ui/actionbar/act
 import { Disposable, IDisposable } from '../../../../../base/common/lifecycle.js';
 import { IReader, autorun, observableValue } from '../../../../../base/common/observable.js';
 import { isWeb } from '../../../../../base/common/platform.js';
-import { localize2 } from '../../../../../nls.js';
+import { localize, localize2 } from '../../../../../nls.js';
 import { IActionViewItemService } from '../../../../../platform/actions/browser/actionViewItemService.js';
 import { Action2, registerAction2 } from '../../../../../platform/actions/common/actions.js';
 import { ContextKeyExpr, IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
+import { IQuickInputService } from '../../../../../platform/quickinput/common/quickInput.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { IWorkbenchContribution, WorkbenchPhase, registerWorkbenchContribution2 } from '../../../../../workbench/common/contributions.js';
@@ -537,6 +538,48 @@ registerAction2(class DeleteSessionAction extends Action2 {
 		const sessionsManagementService = accessor.get(ISessionsManagementService);
 		for (const session of sessions) {
 			await sessionsManagementService.deleteSession(session);
+		}
+	}
+});
+
+registerAction2(class RenameCopilotLocalSessionAction extends Action2 {
+	constructor() {
+		super({
+			id: 'sessionsViewPane.copilot.renameLocalSession',
+			title: localize2('renameSession', "Rename..."),
+			menu: [{
+				id: SessionItemContextMenuId,
+				group: '1_edit',
+				order: 1,
+				when: ContextKeyExpr.and(
+					ContextKeyExpr.equals(ChatSessionProviderIdContext.key, COPILOT_PROVIDER_ID),
+					ContextKeyExpr.equals('chatSessionType', LocalSessionType.id),
+				),
+			}]
+		});
+	}
+	async run(accessor: ServicesAccessor, context?: ISession | ISession[]): Promise<void> {
+		const session = Array.isArray(context) ? context[0] : context;
+		if (!session) {
+			return;
+		}
+		const quickInputService = accessor.get(IQuickInputService);
+		const sessionsManagementService = accessor.get(ISessionsManagementService);
+		const newTitle = await quickInputService.input({
+			value: session.title.get(),
+			prompt: localize('renameCopilotLocalSession.prompt', "New session title"),
+			validateInput: async value => {
+				if (!value.trim()) {
+					return localize('renameCopilotLocalSession.empty', "Title cannot be empty");
+				}
+				return undefined;
+			}
+		});
+		if (newTitle) {
+			const trimmedTitle = newTitle.trim();
+			if (trimmedTitle) {
+				await sessionsManagementService.renameChat(session, session.mainChat.get().resource, trimmedTitle);
+			}
 		}
 	}
 });

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsActions.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsActions.ts
@@ -577,7 +577,7 @@ registerAction2(class RenameCopilotSessionAction extends Action2 {
 		});
 		if (newTitle) {
 			const trimmedTitle = newTitle.trim();
-			if (trimmedTitle) {
+			if (trimmedTitle && trimmedTitle !== session.title.get().trim()) {
 				await sessionsManagementService.renameChat(session, session.mainChat.get().resource, trimmedTitle);
 			}
 		}

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsActions.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsActions.ts
@@ -542,10 +542,10 @@ registerAction2(class DeleteSessionAction extends Action2 {
 	}
 });
 
-registerAction2(class RenameCopilotLocalSessionAction extends Action2 {
+registerAction2(class RenameCopilotSessionAction extends Action2 {
 	constructor() {
 		super({
-			id: 'sessionsViewPane.copilot.renameLocalSession',
+			id: 'sessionsViewPane.copilot.renameSession',
 			title: localize2('renameSession', "Rename..."),
 			menu: [{
 				id: SessionItemContextMenuId,
@@ -553,7 +553,7 @@ registerAction2(class RenameCopilotLocalSessionAction extends Action2 {
 				order: 1,
 				when: ContextKeyExpr.and(
 					ContextKeyExpr.equals(ChatSessionProviderIdContext.key, COPILOT_PROVIDER_ID),
-					ContextKeyExpr.equals('chatSessionType', LocalSessionType.id),
+					ContextKeyExpr.notEquals('chatSessionType', CopilotCloudSessionType.id),
 				),
 			}]
 		});
@@ -567,10 +567,10 @@ registerAction2(class RenameCopilotLocalSessionAction extends Action2 {
 		const sessionsManagementService = accessor.get(ISessionsManagementService);
 		const newTitle = await quickInputService.input({
 			value: session.title.get(),
-			prompt: localize('renameCopilotLocalSession.prompt', "New session title"),
+			prompt: localize('renameCopilotSession.prompt', "New session title"),
 			validateInput: async value => {
 				if (!value.trim()) {
-					return localize('renameCopilotLocalSession.empty', "Title cannot be empty");
+					return localize('renameCopilotSession.empty', "Title cannot be empty");
 				}
 				return undefined;
 			}

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -1659,6 +1659,10 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 			await this.commandService.executeCommand('github.copilot.claude.sessions.rename', { resource: chatUri }, title);
 			return;
 		}
+		if (agentSession?.providerType === AgentSessionProviders.Local) {
+			await this.chatService.setChatSessionTitle(chatUri, title);
+			return;
+		}
 		throw new Error('Renaming is not supported for this session type');
 	}
 


### PR DESCRIPTION
Fixes #318819

## What happened

The right-click rename option was no longer showing in the Agents window session list after the `CopilotSessionContextMenuBridge` was removed.

## What this fixes

Adds a dedicated context menu action `RenameCopilotSessionAction` that registers "Rename..." in the session item context menu for all copilot session types that support rename:

- `local` sessions
- `copilotcli` (background/CLI) sessions
- `claude-code` sessions

Cloud sessions (`copilot-cloud-agent`) are correctly excluded since the backend does not support renaming them.

## Changes

**`copilotChatSessionsActions.ts`**
- Added `RenameCopilotSessionAction` that shows "Rename..." in the context menu when `chatSessionProviderId === 'default-copilot'` and `chatSessionType !== 'copilot-cloud-agent'`
- Action uses `ISessionsManagementService.renameChat()` which already routes to the correct provider implementation per session type

**`copilotChatSessionsProvider.ts`**
- Added handling for `local` session type in `renameChat()` via `chatService.setChatSessionTitle()`

## Verification

Right-clicking a session in the Agents window now shows "Rename..." in the context menu.