### PR TITLE
 thinking: generate synthetic ID for reasoning_content without explicit ID

### DIFF
--- a/extensions/copilot/src/platform/thinking/common/thinkingUtils.ts
+++ b/extensions/copilot/src/platform/thinking/common/thinkingUtils.ts
@@ -5,6 +5,8 @@
 
 import { EncryptedThinkingDelta, RawThinkingDelta, ThinkingDelta } from './thinking';
 
+let _thinkingIdCounter = 0;
+
 function getThinkingDeltaText(thinking: RawThinkingDelta | undefined): string | undefined {
 	if (!thinking) {
 		return '';
@@ -39,6 +41,14 @@ function getThinkingDeltaId(thinking: RawThinkingDelta | undefined): string | un
 	}
 	if (thinking.signature) {
 		return thinking.signature;
+	}
+	// DeepSeek / Moonshot / Minimax send reasoning_content without an explicit ID.
+	// Generate a synthetic monotonic ID so the thinking data flows through the
+	// pipeline and reasoning_content is echoed back on subsequent turns.
+	// Without this, the callback guard `if (data && data.id)` in OpenAIEndpoint
+	// is always false and DeepSeek rejects the next turn with HTTP 400.
+	if (thinking.reasoning_content) {
+		return `reasoning-${++_thinkingIdCounter}`;
 	}
 	return undefined;
 }


### PR DESCRIPTION

PR  #318809 partially fixes HTTP 400 for BYOK reasoning models but misses a critical piece: getThinkingDeltaId() does not handle reasoning_content without an explicit id field.

DeepSeek/Moonshot/Minimax streaming responses include reasoning_content (text only) but do not provide cot_id, reasoning_opaque, or signature. This causes getThinkingDeltaId() to return undefined, which means extractThinkingDeltaFromChoice() returns { text } without an id.

Then in openAIEndpoint.ts, the callback guard 'if (data && data.id)' is always false, so reasoning_content is never written to the assistant message, and the second turn still fails with HTTP 400: 'The reasoning_content in the thinking mode must be passed back to the API'

Fix: Generate a synthetic monotonic ID (reasoning-1, reasoning-2, ...) when reasoning_content is present but no explicit id exists. This allows the thinking data to flow through the full pipeline and be echoed back on subsequent turns.

Fixes：
- #312746 
- #318920 

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
