### PR TITLE
fix: add white-space: nowrap to browser-emulation-toolbar-label

### DIFF
--- a/src/vs/workbench/contrib/browserView/electron-browser/media/browser.css
+++ b/src/vs/workbench/contrib/browserView/electron-browser/media/browser.css
@@ -160,6 +160,7 @@
 		.browser-emulation-toolbar-label {
 			opacity: 0.8;
 			user-select: none;
+			white-space: nowrap;
 		}
 
 		.browser-emulation-toolbar-input {


### PR DESCRIPTION
Fixes #318929

**Problem:**
In the browser emulation toolbar, labels like "Dimensions" and "DPR" can wrap to multiple lines in certain locales (e.g., Chinese), causing the toolbar height to expand and breaking the layout.

**Fix:**
Add  to  to keep labels on a single line.

**Verification:**
- The CSS rule is scoped to  inside .
- No other UI elements are affected.
- This matches the existing pattern used for  and  in the same file.

**Before (Chinese locale):**
Labels wrap, toolbar expands.

**After:**
Labels stay on one line, toolbar maintains consistent height.
