### PR TITLE
Agents: Update session list styles and behavior

### DIFF
--- a/src/vs/sessions/SESSIONS_LIST.md
+++ b/src/vs/sessions/SESSIONS_LIST.md
@@ -59,7 +59,7 @@ Archived sessions always go to the "Done" section regardless of grouping mode. A
 When grouping by workspace, the list shows only **primary** workspace sections by default:
 
 - A workspace qualifies as primary if it has recent activity (last 4 days), matches the open window's folder, or contains the most recently updated session
-- Remaining workspaces collapse behind a "Show N more" toggle
+- Remaining workspaces collapse behind a "+N more workspaces" toggle
 - Within each workspace, sessions beyond 5 also show a "Show more" toggle
 - The find widget bypasses all capping
 

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -340,7 +340,6 @@
 	font-size: var(--vscode-agents-fontSize-label2, 11px);
 	font-weight: var(--vscode-agents-fontWeight-medium, 500);
 	color: var(--vscode-descriptionForeground);
-	text-transform: uppercase;
 	/* align left with session item margin; keep extra right padding for section content spacing */
 	padding: 0 16px 0 10px;
 
@@ -364,6 +363,14 @@
 		margin-left: 4px;
 		display: none;
 	}
+
+	.session-section-chevron {
+		flex-shrink: 0;
+		margin-left: 4px;
+		display: none;
+		color: var(--vscode-descriptionForeground);
+		font-size: var(--vscode-codiconFontSize-compact, 12px);
+	}
 }
 
 .monaco-list-row:hover .session-section .session-section-toolbar,
@@ -371,15 +378,23 @@
 	display: block;
 }
 
+.monaco-list-row:hover .session-section .session-section-chevron,
+.monaco-list-row.focused .session-section .session-section-chevron {
+	display: flex;
+	align-items: center;
+}
+
 .sessions-list-control {
 
-	.monaco-list:focus .monaco-list-row.focused.selected .session-section-label,
-	.monaco-list:focus .monaco-list-row.selected .session-section-label {
-		color: var(--vscode-list-activeSelectionForeground);
+	/* Hovering a workspace header changes the label color instead of painting a row background fill. */
+	.monaco-list-row:has(.session-section):hover,
+	.monaco-list-row.focused:has(.session-section) {
+		background: transparent !important;
 	}
 
-	.monaco-list:not(:focus) .monaco-list-row.selected .session-section-label {
-		color: var(--vscode-list-inactiveSelectionForeground);
+	.monaco-list-row:hover .session-section .session-section-label,
+	.monaco-list-row.focused .session-section .session-section-label {
+		color: var(--vscode-strongForeground);
 	}
 }
 

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -390,15 +390,20 @@
 
 .sessions-list-control {
 
-	/* Workspace headers use label color changes instead of row background fills for hover/focus/selection. */
+	/* Workspace headers and folder toggles use label color changes instead of row background fills for hover/focus/selection. */
 	.monaco-list-row:has(.session-section):hover,
+	.monaco-list-row:has(.session-show-more-folders):hover,
 	.monaco-list-row.focused:has(.session-section),
-	.monaco-list-row.selected:has(.session-section) {
+	.monaco-list-row.focused:has(.session-show-more-folders),
+	.monaco-list-row.selected:has(.session-section),
+	.monaco-list-row.selected:has(.session-show-more-folders) {
 		background: transparent !important;
 	}
 
 	.monaco-list-row:hover .session-section .session-section-label,
-	.monaco-list-row.focused .session-section .session-section-label {
+	.monaco-list-row.focused .session-section .session-section-label,
+	.monaco-list-row:hover .session-show-more-folders .session-show-more-label,
+	.monaco-list-row.focused .session-show-more-folders .session-show-more-label {
 		color: var(--vscode-strongForeground);
 	}
 

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -378,8 +378,8 @@
 	display: block;
 }
 
-.monaco-list-row:hover .session-section .session-section-chevron,
-.monaco-list-row.focused .session-section .session-section-chevron {
+.monaco-list-row:hover .session-section .session-section-chevron.collapsible,
+.monaco-list-row.focused .session-section .session-section-chevron.collapsible {
 	display: flex;
 	align-items: center;
 }
@@ -395,6 +395,13 @@
 	.monaco-list-row:hover .session-section .session-section-label,
 	.monaco-list-row.focused .session-section .session-section-label {
 		color: var(--vscode-strongForeground);
+	}
+
+	&.session-section-focus-from-pointer {
+		.monaco-list-row.focused:has(.session-section),
+		.monaco-list-row.selected:has(.session-section) {
+			outline: none !important;
+		}
 	}
 }
 

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -320,10 +320,14 @@
 	color: var(--vscode-foreground);
 }
 
-/* Folders show-more/show-less: match the folder section header style */
+/* Folders show-more/show-less: align with workspace section headers. */
 .session-show-more.session-show-more-folders {
+	justify-content: flex-start;
 	font-weight: var(--vscode-agents-fontWeight-medium, 500);
-	text-transform: uppercase;
+
+	.session-show-more-label {
+		padding: 0;
+	}
 
 	/* No surrounding separator lines for the folders show-more/less item */
 	&::before,
@@ -386,9 +390,10 @@
 
 .sessions-list-control {
 
-	/* Hovering a workspace header changes the label color instead of painting a row background fill. */
+	/* Workspace headers use label color changes instead of row background fills for hover/focus/selection. */
 	.monaco-list-row:has(.session-section):hover,
-	.monaco-list-row.focused:has(.session-section) {
+	.monaco-list-row.focused:has(.session-section),
+	.monaco-list-row.selected:has(.session-section) {
 		background: transparent !important;
 	}
 

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -70,6 +70,8 @@ const PIXEL_SPINNER_RING_KEY = '__pixel_spinner_ring__';
 // Duration of the cross-fade when the icon swaps to a different glyph/variant.
 const ICON_SWAP_FADE_MS = 180;
 
+const SESSION_SECTION_FOCUS_FROM_POINTER_CLASS = 'session-section-focus-from-pointer';
+
 // Marker dataset key on the outgoing element during a cross-fade swap. Lets a
 // follow-up swap (before the previous fade finishes) skip re-processing it.
 const ICON_FADING_OUT_ATTR = 'iconFadingOut';
@@ -699,7 +701,7 @@ class SessionSectionRenderer implements ITreeRenderer<SessionListItem, FuzzyScor
 	static readonly TEMPLATE_ID = 'session-section';
 	readonly templateId = SessionSectionRenderer.TEMPLATE_ID;
 
-	private readonly templatesByElement = new Map<SessionListItem, ISessionSectionTemplate>();
+	private readonly templatesByElement = new WeakMap<ISessionSection, ISessionSectionTemplate>();
 
 	constructor(
 		private readonly hideSectionCount: boolean,
@@ -715,6 +717,7 @@ class SessionSectionRenderer implements ITreeRenderer<SessionListItem, FuzzyScor
 		const count = DOM.append(container, $('span.session-section-count'));
 		const toolbarContainer = DOM.append(container, $('.session-section-toolbar'));
 		const chevron = DOM.append(container, $('span.session-section-chevron'));
+		chevron.setAttribute('aria-hidden', 'true');
 
 		const contextKeyService = disposables.add(this.contextKeyService.createScoped(container));
 		const scopedInstantiationService = disposables.add(this.instantiationService.createChild(new ServiceCollection([IContextKeyService, contextKeyService])));
@@ -753,7 +756,7 @@ class SessionSectionRenderer implements ITreeRenderer<SessionListItem, FuzzyScor
 	 * tree only re-invokes `renderTwistie` (not `renderElement`) when a section's
 	 * collapse state toggles, so the owning list forwards collapse changes here.
 	 */
-	updateCollapseState(element: SessionListItem, collapsed: boolean): void {
+	updateCollapseState(element: ISessionSection, collapsed: boolean): void {
 		const template = this.templatesByElement.get(element);
 		if (template) {
 			this.updateChevron(template, true, collapsed);
@@ -763,13 +766,16 @@ class SessionSectionRenderer implements ITreeRenderer<SessionListItem, FuzzyScor
 	private updateChevron(template: ISessionSectionTemplate, collapsible: boolean, collapsed: boolean): void {
 		template.chevron.className = 'session-section-chevron';
 		if (collapsible) {
+			template.chevron.classList.add('collapsible');
 			const icon = collapsed ? Codicon.chevronRight : Codicon.chevronDown;
 			template.chevron.classList.add(...ThemeIcon.asClassNameArray(icon));
 		}
 	}
 
 	disposeElement(node: ITreeNode<SessionListItem, FuzzyScore>, _index: number, _template: ISessionSectionTemplate): void {
-		this.templatesByElement.delete(node.element);
+		if (isSessionSection(node.element)) {
+			this.templatesByElement.delete(node.element);
+		}
 	}
 
 	disposeTemplate(template: ISessionSectionTemplate): void {
@@ -1013,6 +1019,12 @@ export class SessionsList extends Disposable implements ISessionsList {
 		this.workspaceGroupCapped = this.storageService.getBoolean(SessionsList.WORKSPACE_GROUP_CAPPED_KEY, StorageScope.PROFILE, true);
 
 		this.listContainer = DOM.append(container, $('.sessions-list-control'));
+		this._register(DOM.addDisposableListener(this.listContainer, DOM.EventType.POINTER_DOWN, () => {
+			this.listContainer.classList.add(SESSION_SECTION_FOCUS_FROM_POINTER_CLASS);
+		}));
+		this._register(DOM.addDisposableListener(this.listContainer.ownerDocument, DOM.EventType.KEY_DOWN, () => {
+			this.listContainer.classList.remove(SESSION_SECTION_FOCUS_FROM_POINTER_CLASS);
+		}, true));
 
 		const approvalModel = this._register(instantiationService.createInstance(AgentSessionApprovalModel));
 		const markdownRendererService = instantiationService.invokeFunction(accessor => accessor.get(IMarkdownRendererService));

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -690,6 +690,7 @@ interface ISessionSectionTemplate {
 	readonly label: HTMLElement;
 	readonly count: HTMLElement;
 	readonly toolbar: MenuWorkbenchToolBar;
+	readonly chevron: HTMLElement;
 	readonly contextKeyService: IContextKeyService;
 	readonly disposables: DisposableStore;
 }
@@ -697,6 +698,8 @@ interface ISessionSectionTemplate {
 class SessionSectionRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, ISessionSectionTemplate> {
 	static readonly TEMPLATE_ID = 'session-section';
 	readonly templateId = SessionSectionRenderer.TEMPLATE_ID;
+
+	private readonly templatesByElement = new Map<SessionListItem, ISessionSectionTemplate>();
 
 	constructor(
 		private readonly hideSectionCount: boolean,
@@ -711,6 +714,7 @@ class SessionSectionRenderer implements ITreeRenderer<SessionListItem, FuzzyScor
 		const label = DOM.append(container, $('span.session-section-label'));
 		const count = DOM.append(container, $('span.session-section-count'));
 		const toolbarContainer = DOM.append(container, $('.session-section-toolbar'));
+		const chevron = DOM.append(container, $('span.session-section-chevron'));
 
 		const contextKeyService = disposables.add(this.contextKeyService.createScoped(container));
 		const scopedInstantiationService = disposables.add(this.instantiationService.createChild(new ServiceCollection([IContextKeyService, contextKeyService])));
@@ -718,7 +722,7 @@ class SessionSectionRenderer implements ITreeRenderer<SessionListItem, FuzzyScor
 			menuOptions: { shouldForwardArgs: true },
 		}));
 
-		return { container, label, count, toolbar, contextKeyService, disposables };
+		return { container, label, count, toolbar, chevron, contextKeyService, disposables };
 	}
 
 	renderElement(node: ITreeNode<SessionListItem, FuzzyScore>, _index: number, template: ISessionSectionTemplate): void {
@@ -726,6 +730,7 @@ class SessionSectionRenderer implements ITreeRenderer<SessionListItem, FuzzyScor
 		if (!isSessionSection(element)) {
 			return;
 		}
+		this.templatesByElement.set(element, template);
 		template.label.textContent = element.label;
 		if (this.hideSectionCount) {
 			template.count.textContent = '';
@@ -735,10 +740,36 @@ class SessionSectionRenderer implements ITreeRenderer<SessionListItem, FuzzyScor
 			template.count.style.display = '';
 		}
 
+		this.updateChevron(template, node.collapsible, node.collapsed);
+
 		// Set context key for section type so toolbar actions can use when clauses
 		const sectionType = element.id.startsWith('workspace:') ? 'workspace' : element.id;
 		SessionSectionTypeContext.bindTo(template.contextKeyService).set(sectionType);
 		template.toolbar.context = element;
+	}
+
+	/**
+	 * Updates the expand/collapse chevron for an already-rendered section. The
+	 * tree only re-invokes `renderTwistie` (not `renderElement`) when a section's
+	 * collapse state toggles, so the owning list forwards collapse changes here.
+	 */
+	updateCollapseState(element: SessionListItem, collapsed: boolean): void {
+		const template = this.templatesByElement.get(element);
+		if (template) {
+			this.updateChevron(template, true, collapsed);
+		}
+	}
+
+	private updateChevron(template: ISessionSectionTemplate, collapsible: boolean, collapsed: boolean): void {
+		template.chevron.className = 'session-section-chevron';
+		if (collapsible) {
+			const icon = collapsed ? Codicon.chevronRight : Codicon.chevronDown;
+			template.chevron.classList.add(...ThemeIcon.asClassNameArray(icon));
+		}
+	}
+
+	disposeElement(node: ITreeNode<SessionListItem, FuzzyScore>, _index: number, _template: ISessionSectionTemplate): void {
+		this.templatesByElement.delete(node.element);
 	}
 
 	disposeTemplate(template: ISessionSectionTemplate): void {
@@ -1002,6 +1033,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 		);
 
 		const showMoreRenderer = new SessionShowMoreRenderer();
+		const sectionRenderer = new SessionSectionRenderer(true /* hideSectionCount */, instantiationService, contextKeyService);
 
 		// Read (don't bind) `IsPhoneLayoutContext` from the parent context so we
 		// observe the workbench's value rather than shadowing it with a fresh
@@ -1016,7 +1048,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 			delegate,
 			[
 				sessionRenderer,
-				new SessionSectionRenderer(true /* hideSectionCount */, instantiationService, contextKeyService),
+				sectionRenderer,
 				showMoreRenderer,
 			],
 			{
@@ -1115,12 +1147,12 @@ export class SessionsList extends Disposable implements ISessionsList {
 		this._register(this.tree.onContextMenu(e => this.onContextMenu(e)));
 
 		this._register(this.tree.onDidChangeCollapseState(e => {
-			if (this.suspendCollapseStatePersistence) {
-				return;
-			}
 			const element = e.node.element;
 			if (element && isSessionSection(element)) {
-				this.saveSectionCollapseState(element.id, e.node.collapsed);
+				sectionRenderer.updateCollapseState(element, e.node.collapsed);
+				if (!this.suspendCollapseStatePersistence) {
+					this.saveSectionCollapseState(element.id, e.node.collapsed);
+				}
 			}
 		}));
 

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -810,8 +810,8 @@ class SessionShowMoreRenderer implements ITreeRenderer<SessionListItem, FuzzySco
 		} else {
 			template.textContent = element.kind === 'folders'
 				? element.remainingCount === 1
-					? localize('showMoreWorkspaceCompact', "+{0} workspace", element.remainingCount)
-					: localize('showMoreWorkspacesCompact', "+{0} workspaces", element.remainingCount)
+					? localize('showMoreWorkspaceCompact', "+{0} more workspace", element.remainingCount)
+					: localize('showMoreWorkspacesCompact', "+{0} more workspaces", element.remainingCount)
 				: localize('showMoreCompact', "+{0} more", element.remainingCount);
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/317698
Fixes https://github.com/microsoft/vscode/issues/317694

Update several parts of session list styling and behavior:

1. Stop using all caps for workspace title
2. Remove the 'selected' state from workspace titles
3. Instead of showing a background fill color when hovering over workspace title, the title text color is set to be the intense foreground variant
4. Show a chevron icon on hover to reinforce expanded/collapsed states of a workspace in the session list
5. Update "+N WORKSPACES" / "SHOW FEWER WORKSPACES" button/toggle so the text is left aligned, the text now says "+N more workspaces", and the text is no longer uppercase