### PR TITLE
fix(agentHost): gracefully handle disconnected client during plugin sync

### DIFF
--- a/src/vs/platform/agentHost/node/agentPluginManager.ts
+++ b/src/vs/platform/agentHost/node/agentPluginManager.ts
@@ -6,7 +6,7 @@
 import { VSBuffer } from '../../../base/common/buffer.js';
 import { SequencerByKey } from '../../../base/common/async.js';
 import { URI } from '../../../base/common/uri.js';
-import { IFileService } from '../../files/common/files.js';
+import { IFileService, FileSystemProviderErrorCode, toFileSystemProviderErrorCode } from '../../files/common/files.js';
 import { ILogService } from '../../log/common/log.js';
 import { IAgentPluginManager, type ISyncedCustomization } from '../common/agentPluginManager.js';
 import { CustomizationLoadStatus, type ClientPluginCustomization, type Customization } from '../common/state/sessionState.js';
@@ -113,7 +113,16 @@ export class AgentPluginManager implements IAgentPluginManager {
 
 		this._logService.info(`[AgentPluginManager] Syncing plugin: ${ref.uri} → ${destDir.toString()}`);
 
-		await this._fileService.copy(pluginUri, destDir, true);
+		try {
+			await this._fileService.copy(pluginUri, destDir, true);
+		} catch (err) {
+			// Gracefully handle connection errors when the client is no longer connected
+			if (err instanceof Error && toFileSystemProviderErrorCode(err) === FileSystemProviderErrorCode.Unavailable) {
+				this._logService.warn(`[AgentPluginManager] Client ${clientId} is not connected, cannot sync plugin ${ref.uri}`);
+				throw new Error(`Client is not connected`, { cause: err });
+			}
+			throw err;
+		}
 
 		if (ref.nonce) {
 			this._cachedNonces.set(ref.uri, ref.nonce);

--- a/src/vs/platform/agentHost/test/node/agentPluginManager.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentPluginManager.test.ts
@@ -108,6 +108,15 @@ suite('AgentPluginManager', () => {
 			assert.deepStrictEqual(progressCalls.map(call => call.load?.kind), ['loaded']);
 		});
 
+		test('returns error status when client is not connected', async () => {
+			const ref = makeRef('disconnected-client', 'n1');
+			const results = await manager.syncCustomizations('disconnected-client', [ref]);
+			assert.strictEqual(results.length, 1);
+			assert.strictEqual(results[0].customization.load?.kind, 'error');
+			assert.strictEqual(results[0].customization.load?.message, 'Client is not connected');
+			assert.strictEqual(results[0].pluginDir, undefined);
+		});
+
 		test('skips copy when nonce matches', async () => {
 			await seedPluginDir('cached', { 'index.js': 'v1' });
 			const ref = makeRef('cached', 'nonce-abc');


### PR DESCRIPTION
## Problem

When  is called for a client that has already disconnected, the  call throws:



This happens because  cannot find the authority after the client disconnects, and the raw error bubbles up unhandled.

Fixes #318907

## Solution

Catch the  error in  and re-throw a clear  error. The existing  error handler already converts any thrown error into a  result, so the sync continues gracefully for remaining plugins.

## Changes

- : Added try/catch around  to detect disconnected client errors
- : Added test verifying error status when client is not connected

## Testing

- New unit test: 
- Existing tests continue to pass