### PR TITLE
fix: add missing IRemoteFilesystemConnection methods in test

### DIFF
--- a/src/vs/platform/agentHost/test/common/agentHostFileSystemProvider.test.ts
+++ b/src/vs/platform/agentHost/test/common/agentHostFileSystemProvider.test.ts
@@ -200,8 +200,14 @@ suite('AgentHostFileSystemProvider - authority registrations', () => {
 
 		async resourceRead(): Promise<ResourceReadResult> { return { data: '', encoding: ContentEncoding.Utf8 }; }
 		async resourceWrite(): Promise<{}> { return {}; }
+		async resourceCopy(): Promise<{}> { return {}; }
 		async resourceDelete(): Promise<{}> { return {}; }
 		async resourceMove(): Promise<{}> { return {}; }
+		async resourceResolve(params: ResourceResolveParams): Promise<ResourceResolveResult> {
+			const uri = typeof params.uri === 'string' ? URI.parse(params.uri) : URI.revive(params.uri)!;
+			return { uri: uri.toString(), type: ResourceType.File };
+		}
+		async resourceMkdir(): Promise<{}> { return {}; }
 	}
 
 	test('disposing a stale registration does not remove a newer registration for the same authority', async () => {


### PR DESCRIPTION
Adds the missing esourceCopy, esourceResolve, and esourceMkdir methods to the NamedConnection stub in agentHostFileSystemProvider.test.ts to fix compile errors after the interface was extended.