### PR TITLE
Don't dispose cached chat session when returning existing reference

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
@@ -1107,7 +1107,6 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 		{
 			const existingSessionData = this._sessions.get(sessionResource);
 			if (existingSessionData) {
-				session.dispose();
 				return existingSessionData.session;
 			}
 		}

--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -608,7 +608,6 @@ export class ChatService extends Disposable implements IChatService {
 		{
 			const existingRef = this.acquireExistingSession(sessionResource, debugOwner);
 			if (existingRef) {
-				providedSession.dispose();
 				return existingRef;
 			}
 		}


### PR DESCRIPTION
getOrCreateChatSession returns the cached session object when one already exists, so the concurrent-creation guards in ChatService#loadRemoteSession and ChatSessionsService#getOrCreateChatSession were disposing the shared, live session instead of a throwaway. This left the session unavailable when its options were later read or updated (e.g. while sending a request). The session lifecycle is owned by ContributedChatSessionData, so drop the incorrect dispose() calls.

Fixes #318849