### PR TITLE
Forward GitHub token in createSession/resumeSession RPC

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -1542,6 +1542,14 @@ export class CopilotAgent extends Disposable implements IAgent {
 				instructionDirectories: toSdkInstructionDirectories(plugins.flatMap(p => p.instructions)),
 				systemMessage: COPILOT_AGENT_HOST_SYSTEM_MESSAGE,
 				tools: [...shellTools, ...callbacks.clientTools],
+				// Pass the GitHub token at the session level. The SDK's
+				// client-level `gitHubToken` authenticates the CLI process,
+				// but each session also needs its own token resolved into a
+				// GitHub identity (login, Copilot plan, endpoints) to drive
+				// model routing and quota — without this the session
+				// errors with "Session was not created with authentication
+				// info or custom provider" on first send. See #318693.
+				gitHubToken: this._githubToken,
 				// Enable infinite sessions so the SDK provisions a workspace
 				// directory (containing `plan.md`, `checkpoints/`, `files/`).
 				// The workspace is required for plan mode to work — without

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -888,6 +888,34 @@ suite('CopilotAgent', () => {
 			}
 		});
 
+		test('materialization forwards the GitHub token to the SDK at the session level (#318693)', async () => {
+			const sessionDataService = disposables.add(new TestSessionDataService());
+			const client = new TestCopilotClient([]);
+			let capturedConfig: Parameters<ITestCopilotClient['createSession']>[0] | undefined;
+			client.createSession = async config => {
+				capturedConfig = config;
+				return new MockCopilotSession() as unknown as CopilotSession;
+			};
+
+			const agent = createTestAgent(disposables, { sessionDataService, copilotClient: client });
+			try {
+				await agent.authenticate('https://api.github.com', 'gh-token-abc');
+
+				const result = await agent.createSession({
+					session: AgentSession.uri('copilotcli', 'session-level-token'),
+					workingDirectory: URI.file('/workspace'),
+				});
+				assert.strictEqual(result.provisional, true);
+
+				await agent.sendMessage(result.session, 'hello');
+
+				assert.strictEqual(capturedConfig?.gitHubToken, 'gh-token-abc',
+					'createSession should receive the GitHub token at session level so the SDK can resolve a per-session GitHub identity');
+			} finally {
+				await disposeAgent(agent);
+			}
+		});
+
 		test('materialization skips managed shell tools when root config disables the custom terminal tool', async () => {
 			const sessionDataService = disposables.add(new TestSessionDataService());
 			const client = new TestCopilotClient([]);


### PR DESCRIPTION
Fixes [#318693](https://github.com/microsoft/vscode/issues/318693)

## Background

The Copilot SDK exposes two GitHub-token slots:

- **Client-level** (`CopilotClientOptions. hands the token to the spawned CLI subprocess via an environment variable. The CLI then does its own HTTP fetch to `api.github.com` to turn the bytes into an `AuthInfo`. If that fetch fails (slow / proxied network on the SSH host, transient 401, etc.) the CLI is left permanently unauthenticated, because we also pass `useLoggedInUser: false` to disable the stored-OAuth fallback. Sessions created against that CLI inherit no `AuthInfo` and fail on first send with:gitHubToken`) 

  > Session was not created with authentication info or custom provider

- **Session-level** (`SessionConfig. the token travels **inside the `createSession` RPC payload itself**. The CLI resolves it as part of the create handler, so the session always carries its own `AuthInfo` regardless of whether the env-var bootstrap settled.gitHubToken`) 

The reporter's log (Amazon Linux 2023 remote over SSH) shows exactly this shape: `models.list` fails with *"Not authenticated. Please authenticate first."* shortly after CLI startup, then `listSessions` later succeeds, but the session that was created in between has no auth stamped on it and dies on first send.

## Change

Pass the cached `_githubToken` through `_buildSessionConfig` so both `client.createSession` and `client.resumeSession` get session-level auth. Session start no longer depends on the env-var bootstrap that fails for users with slow / proxied paths to `api.github.com` from the remote.

A regression test asserts the token is forwarded to `createSession`.

The client-level env-var path is left in place because client-scoped SDK calls (`listModels`, `listSessions`, etc.) have no per-call token override. Those calls are tolerant of transient auth failures and are not user-facing; we can revisit the bootstrap separately.

(Written by Copilot)
