### PR TITLE
Add header request id for ghosttext edit types 

### DIFF
--- a/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/ghostText/completionsFromNetwork.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/ghostText/completionsFromNetwork.ts
@@ -211,6 +211,7 @@ export class CompletionsFromNetwork {
 		) => Promise<GhostTextResultWithTelemetry<T>>
 	): Promise<GhostTextResultWithTelemetry<T>> {
 		const statelessTelemetryBuilder = new StatelessNextEditTelemetryBuilder(requestContext.ourRequestId);
+		telemetryBuilder.setHeaderRequestId(requestContext.ourRequestId);
 		const result = await this._genericGetCompletionsFromNetwork(
 			requestContext,
 			baseTelemetryData,

--- a/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/ghostText/completionsFromNetwork.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/ghostText/completionsFromNetwork.ts
@@ -211,7 +211,6 @@ export class CompletionsFromNetwork {
 		) => Promise<GhostTextResultWithTelemetry<T>>
 	): Promise<GhostTextResultWithTelemetry<T>> {
 		const statelessTelemetryBuilder = new StatelessNextEditTelemetryBuilder(requestContext.ourRequestId);
-		telemetryBuilder.setHeaderRequestId(requestContext.ourRequestId);
 		const result = await this._genericGetCompletionsFromNetwork(
 			requestContext,
 			baseTelemetryData,

--- a/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/ghostText/ghostText.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/ghostText/ghostText.ts
@@ -646,6 +646,11 @@ export class GhostTextComputer {
 				this.currentGhostText.setGhostText(prefix, prompt.prompt.suffix, postProcessedChoicesArray, resultType);
 			}
 
+			// Overwrite the early fallback `headerRequestId` (set to `id` at the top) with the
+			// winning choice's actual `headerRequestId`. They differ when the result came from
+			// a local cache hit or an in-flight async request produced by a different invocation.
+			telemetryBuilder.setHeaderRequestId(postProcessedChoicesArray[0]?.requestId.headerRequestId ?? ourRequestId);
+
 			recordPerformance('complete');
 			logger.trace(`Ghost text computation complete, returning ${results.length} results`);
 

--- a/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/ghostText/ghostText.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/ghostText/ghostText.ts
@@ -148,6 +148,7 @@ export class GhostTextComputer {
 		parentLogger: ILogger,
 	): Promise<GhostTextResultWithTelemetry<[CompletionResult[], ResultType]>> {
 		const id = generateUuid();
+		telemetryBuilder.setHeaderRequestId(id);
 		const logger = parentLogger.createSubLogger(['GhostTextComputer#getGhostText']);
 		this.currentGhostText.currentRequestId = id;
 		const telemetryData = await this.instantiationService.invokeFunction(createTelemetryWithExp, completionState.textDocument, id, options);


### PR DESCRIPTION
It seems we are missing request ids for ghosttext edits which makes it hard to join with CAPI info. I validated I could see my requests in the telemetry output with these changes. 