### PR TITLE
agent host: hydrate snapshot controller for Restore Checkpoint

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -6,7 +6,7 @@
 import { encodeBase64, VSBuffer } from '../../../../../../base/common/buffer.js';
 import { CancellationToken, CancellationTokenSource } from '../../../../../../base/common/cancellation.js';
 import { isCancellationError } from '../../../../../../base/common/errors.js';
-import { Emitter, Event } from '../../../../../../base/common/event.js';
+import { Emitter } from '../../../../../../base/common/event.js';
 import { MarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { Disposable, DisposableResourceMap, DisposableStore, IReference, MutableDisposable, toDisposable, type IDisposable } from '../../../../../../base/common/lifecycle.js';
 import { ResourceMap } from '../../../../../../base/common/map.js';
@@ -26,7 +26,7 @@ import { CompletionItemKind as AhpCompletionItemKind, type CompletionItem as Ahp
 import { ConfirmationOptionKind, TerminalClaimKind, ToolResultContentType, type ConfirmationOption, type ProtectedResourceMetadata, type SessionActiveClient } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
 import { ActionType, SessionTurnStartedAction, type ClientSessionAction, type SessionAction, type SessionInputCompletedAction } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
 import { AHP_AUTH_REQUIRED, ProtocolError } from '../../../../../../platform/agentHost/common/state/sessionProtocol.js';
-import { buildSubagentSessionUri, getToolFileEdits, getToolSubagentContent, MessageAttachmentKind, PendingMessageKind, ResponsePartKind, SessionInputAnswerState, SessionInputAnswerValueKind, SessionInputQuestionKind, SessionInputResponseKind, StateComponents, ToolCallCancellationReason, ToolCallConfirmationReason, ToolCallStatus, TurnState, type ClientPluginCustomization, type ICompletedToolCall, type MarkdownResponsePart, type MessageAttachment, type ModelSelection, type ReasoningResponsePart, type RootState, type SessionInputAnswer, type SessionInputRequest, type SessionState, type ToolCallResponsePart, type ToolCallState, type Turn, type UsageInfo } from '../../../../../../platform/agentHost/common/state/sessionState.js';
+import { buildSubagentSessionUri, getToolSubagentContent, MessageAttachmentKind, PendingMessageKind, ResponsePartKind, SessionInputAnswerState, SessionInputAnswerValueKind, SessionInputQuestionKind, SessionInputResponseKind, StateComponents, ToolCallCancellationReason, ToolCallConfirmationReason, ToolCallStatus, TurnState, type ClientPluginCustomization, type ICompletedToolCall, type MarkdownResponsePart, type MessageAttachment, type ModelSelection, type ReasoningResponsePart, type RootState, type SessionInputAnswer, type SessionInputRequest, type SessionState, type ToolCallResponsePart, type ToolCallState, type Turn, type UsageInfo } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { ExtensionIdentifier } from '../../../../../../platform/extensions/common/extensions.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../../../platform/log/common/log.js';
@@ -589,13 +589,12 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 					// its tool calls appear grouped under the parent widget.
 					await this._enrichHistoryWithSubagentCalls(history, resolvedSession);
 
-					// Store turns with file edits so the editing session
-					// can be hydrated when it's created lazily.
-					const hasTurnsWithEdits = sessionState.turns.some(t =>
-						t.responseParts.some(rp => rp.kind === ResponsePartKind.ToolCall
-							&& rp.toolCall.status === ToolCallStatus.Completed
-							&& getToolFileEdits(rp.toolCall).length > 0));
-					if (hasTurnsWithEdits) {
+					// Store historical turns so the editing session can seed
+					// per-request sentinels (and edit checkpoints) when it's
+					// created lazily. We seed for every turn — not just those
+					// with edits — so "Restore Checkpoint" on any historical
+					// request can find a boundary to navigate to.
+					if (sessionState.turns.length > 0) {
 						this._pendingHistoryTurns.set(sessionResource, sessionState.turns);
 					}
 
@@ -673,15 +672,25 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			// leaving the agent picker empty on session open.
 			this._ensureActiveClientForMessage(resolvedSession);
 
-			// If there are historical turns with file edits, eagerly create
-			// the snapshot controller once the ChatModel is available so that
-			// restore-to-checkpoint works after session restore.
+			// Eagerly create the snapshot controller once the ChatModel for
+			// this session is available so that "Restore Checkpoint" works
+			// on historical turns. The model may already exist (in which
+			// case we run synchronously) or it may be created shortly after
+			// this code runs — we keep the listener alive until our session
+			// matches, since `Event.once` would be consumed by an unrelated
+			// model created first.
 			if (this._pendingHistoryTurns.has(sessionResource)) {
-				session.registerDisposable(Event.once(this._chatService.onDidCreateModel)(model => {
-					if (isEqual(model.sessionResource, sessionResource)) {
-						this._ensureSnapshotController(sessionResource);
-					}
-				}));
+				if (this._chatService.getSession(sessionResource)) {
+					this._ensureSnapshotController(sessionResource);
+				} else {
+					const sub = this._chatService.onDidCreateModel(model => {
+						if (isEqual(model.sessionResource, sessionResource)) {
+							sub.dispose();
+							this._ensureSnapshotController(sessionResource);
+						}
+					});
+					session.registerDisposable(sub);
+				}
 			}
 
 			// If reconnecting to an active turn, wire up an ongoing state listener
@@ -2320,11 +2329,15 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		}
 
 		// Hydrate from historical turns if this is the first time
-		// the controller is accessed for this chat session.
+		// the controller is accessed for this chat session. We seed a sentinel
+		// for every turn (not just turns with edits) so "Restore Checkpoint"
+		// on any historical request can find its boundary and mark subsequent
+		// requests as disabled via requestDisablement.
 		const pendingTurns = this._pendingHistoryTurns.get(sessionResource);
 		if (pendingTurns) {
 			this._pendingHistoryTurns.delete(sessionResource);
 			for (const turn of pendingTurns) {
+				editingSession.ensureRequestCheckpoint(turn.id);
 				for (const rp of turn.responseParts) {
 					if (rp.kind === ResponsePartKind.ToolCall) {
 						editingSession.addToolCallEdits(turn.id, rp.toolCall);

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -589,11 +589,12 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 					// its tool calls appear grouped under the parent widget.
 					await this._enrichHistoryWithSubagentCalls(history, resolvedSession);
 
-					// Store historical turns so the editing session can seed
-					// per-request sentinels (and edit checkpoints) when it's
-					// created lazily. We seed for every turn — not just those
-					// with edits — so "Restore Checkpoint" on any historical
-					// request can find a boundary to navigate to.
+					// Store historical turns so the editing session can seed a
+					// request-level checkpoint for each turn (with file edits
+					// folded in) when the controller is created lazily. We seed
+					// for every turn — not just those with edits — so "Restore
+					// Checkpoint" on any historical request can find a boundary
+					// to navigate to.
 					if (sessionState.turns.length > 0) {
 						this._pendingHistoryTurns.set(sessionResource, sessionState.turns);
 					}
@@ -2329,10 +2330,11 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		}
 
 		// Hydrate from historical turns if this is the first time
-		// the controller is accessed for this chat session. We seed a sentinel
-		// for every turn (not just turns with edits) so "Restore Checkpoint"
-		// on any historical request can find its boundary and mark subsequent
-		// requests as disabled via requestDisablement.
+		// the controller is accessed for this chat session. We seed a
+		// request-level checkpoint for every turn (not just turns with
+		// edits) so "Restore Checkpoint" on any historical request can
+		// find a boundary and mark subsequent requests as disabled via
+		// requestDisablement.
 		const pendingTurns = this._pendingHistoryTurns.get(sessionResource);
 		if (pendingTurns) {
 			this._pendingHistoryTurns.delete(sessionResource);

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSnapshotController.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSnapshotController.ts
@@ -153,15 +153,29 @@ export class AgentHostSnapshotController extends Disposable implements IChatEdit
 
 		const authority = this._connectionAuthority;
 		for (const edit of fileEdits) {
-			cp.edits.push({
+			const resource = toAgentHostUri(edit.resource, authority);
+			const entry: IToolCallFileEdit = {
 				kind: edit.kind,
-				resource: toAgentHostUri(edit.resource, authority),
+				resource,
 				originalResource: edit.originalResource ? toAgentHostUri(edit.originalResource, authority) : undefined,
 				beforeContentUri: edit.beforeContentUri ? toAgentHostUri(edit.beforeContentUri, authority) : undefined,
 				afterContentUri: edit.afterContentUri ? toAgentHostUri(edit.afterContentUri, authority) : undefined,
 				undoStopId: edit.undoStopId,
 				diff: edit.diff,
-			});
+			};
+
+			// Multiple tool calls in one request may touch the same file
+			// (e.g. create→edit, edit→delete). Fold each new edit into the
+			// prior one for the same resource so the checkpoint stores a
+			// single net before/after pair per file. Otherwise
+			// _writeCheckpointContent would apply duplicate writes in
+			// parallel and race to leave the file in an undefined state.
+			const existingIdx = cp.edits.findIndex(e => e.resource.toString() === resource.toString());
+			if (existingIdx < 0) {
+				cp.edits.push(entry);
+			} else {
+				cp.edits[existingIdx] = mergeFileEdit(cp.edits[existingIdx], entry);
+			}
 		}
 	}
 
@@ -362,4 +376,43 @@ export class AgentHostSnapshotController extends Disposable implements IChatEdit
 		});
 		await Promise.all(ops);
 	}
+}
+
+/**
+ * Combines two edits to the same file (in arrival order) into a single net
+ * edit. The merged entry keeps the earlier `before` snapshot and the later
+ * `after` snapshot, and derives a net `kind` based on whether the file
+ * exists at the start and end of the combined operation.
+ *
+ * A create-then-delete collapses to a no-op edit (no before, no after) — we
+ * still keep the entry so the file is restored to "absent" on undo, but
+ * `_writeCheckpointContent` will skip the write since both URIs are absent.
+ */
+function mergeFileEdit(prev: IToolCallFileEdit, next: IToolCallFileEdit): IToolCallFileEdit {
+	const startsAbsent = prev.kind === FileEditKind.Create;
+	const endsAbsent = next.kind === FileEditKind.Delete;
+
+	let kind: FileEditKind;
+	if (startsAbsent && endsAbsent) {
+		kind = FileEditKind.Edit; // create+delete collapses to no-op
+	} else if (startsAbsent) {
+		kind = FileEditKind.Create;
+	} else if (endsAbsent) {
+		kind = FileEditKind.Delete;
+	} else {
+		kind = FileEditKind.Edit;
+	}
+
+	return {
+		kind,
+		resource: next.resource,
+		// Renames within a single request are uncommon; if the second edit
+		// is itself a rename keep its originalResource, otherwise carry
+		// forward the first one.
+		originalResource: next.originalResource ?? prev.originalResource,
+		beforeContentUri: prev.beforeContentUri,
+		afterContentUri: next.afterContentUri,
+		undoStopId: prev.undoStopId,
+		diff: next.diff ?? prev.diff,
+	};
 }

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSnapshotController.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSnapshotController.ts
@@ -21,15 +21,15 @@ import { IChatRequestDisablement, IChatResponseModel } from '../../../common/mod
 import { fileEditsToExternalEdits, type IToolCallFileEdit } from './stateToProgressAdapter.js';
 
 /**
- * One checkpoint per tool call (or the sentinel checkpoint for a request
- * that produced no edits). Tracks the before/after content URIs needed to
- * revert / replay the edits on disk during {@link AgentHostSnapshotController.restoreSnapshot}.
+ * One checkpoint per request. Accumulates the before/after content URIs of
+ * every completed tool call's file edits so the request's edits can be
+ * undone/redone on disk during {@link AgentHostSnapshotController.restoreSnapshot}.
  */
 interface IAgentHostCheckpoint {
 	readonly requestId: string;
-	/** Tool-call ID, or `undefined` for the sentinel checkpoint at request start. */
-	readonly undoStopId: string | undefined;
 	readonly edits: IToolCallFileEdit[];
+	/** Tool-call IDs whose edits have already been folded into `edits`. */
+	readonly seenToolCallIds: Set<string>;
 }
 
 /**
@@ -48,8 +48,13 @@ interface IAgentHostCheckpoint {
  * - `entries` is always empty → the global accept/reject UI doesn't appear
  * - no diff computation, no multi-diff editor, no streaming-edits APIs
  *
- * Hydrated by the session handler via {@link addToolCallEdits} as completed
- * tool calls arrive.
+ * Undo/redo granularity is per-request: every request occupies one checkpoint
+ * regardless of how many tool calls it ran. The `stopId` parameters on
+ * {@link restoreSnapshot}, {@link getSnapshotUri}, and {@link getSnapshotContents}
+ * are accepted for interface compatibility but ignored.
+ *
+ * Hydrated by the session handler via {@link ensureRequestCheckpoint} and
+ * {@link addToolCallEdits} as turns and tool calls arrive.
  */
 export class AgentHostSnapshotController extends Disposable implements IChatEditingSession {
 
@@ -60,23 +65,14 @@ export class AgentHostSnapshotController extends Disposable implements IChatEdit
 	readonly entries: IObservable<readonly IModifiedFileEntry[]> = constObservable([]);
 
 	readonly requestDisablement: IObservable<IChatRequestDisablement[]> = derivedOpts(
-		{ equalsFn: (a, b) => a.length === b.length && a.every((v, i) => v.requestId === b[i].requestId && v.afterUndoStop === b[i].afterUndoStop) },
+		{ equalsFn: (a, b) => a.length === b.length && a.every((v, i) => v.requestId === b[i].requestId) },
 		reader => {
 			const currentIdx = this._currentCheckpointIndex.read(reader);
-			if (currentIdx >= this._checkpoints.length - 1) {
-				return [];
-			}
-			// Disable every request whose first checkpoint sits past the current
-			// index. Keep the first entry per request — if that's the sentinel
-			// (undoStopId === undefined) the entire request is disabled.
-			const disabled = new Map<string, string | undefined>();
+			const disabled: IChatRequestDisablement[] = [];
 			for (let i = currentIdx + 1; i < this._checkpoints.length; i++) {
-				const cp = this._checkpoints[i];
-				if (!disabled.has(cp.requestId)) {
-					disabled.set(cp.requestId, cp.undoStopId);
-				}
+				disabled.push({ requestId: this._checkpoints[i].requestId });
 			}
-			return [...disabled].map(([requestId, afterUndoStop]): IChatRequestDisablement => ({ requestId, afterUndoStop }));
+			return disabled;
 		},
 	);
 
@@ -102,41 +98,53 @@ export class AgentHostSnapshotController extends Disposable implements IChatEdit
 	// ---- Hydration from protocol state --------------------------------------
 
 	/**
-	 * Ensures a sentinel checkpoint exists for the given request. Called at the
-	 * start of every turn so {@link requestDisablement} and {@link restoreSnapshot}
-	 * can reference requests that produce no file edits.
+	 * Ensures a checkpoint exists for the given request. Called at the start
+	 * of every turn (and during history hydration) so {@link requestDisablement}
+	 * and {@link restoreSnapshot} can reference every request, even ones that
+	 * produce no file edits.
 	 *
-	 * Also splices away stale checkpoints after the current index (undo branch
+	 * Splices away stale checkpoints past the current index (undo branch
 	 * semantics) when a new request arrives after a checkpoint restore.
 	 */
 	ensureRequestCheckpoint(requestId: string): void {
-		// Splice stale checkpoints if the user restored a checkpoint
+		// Idempotent on existing requests.
+		if (this._checkpoints.some(cp => cp.requestId === requestId)) {
+			return;
+		}
+
+		// Splice the forward branch when starting a brand-new request after
+		// the user restored a checkpoint.
 		const currentIdx = this._currentCheckpointIndex.get();
 		if (currentIdx < this._checkpoints.length - 1) {
 			this._checkpoints.splice(currentIdx + 1);
 		}
 
-		// Insert sentinel for this request if it doesn't exist yet
-		if (!this._checkpoints.some(cp => cp.requestId === requestId)) {
-			this._checkpoints.push({ requestId, undoStopId: undefined, edits: [] });
-		}
+		this._checkpoints.push({ requestId, edits: [], seenToolCallIds: new Set() });
+
+		// Advance the cursor to the new checkpoint. Otherwise the just-added
+		// request would appear in requestDisablement (it would sit forward of
+		// the cursor) and the chat UI would render it as a disabled turn.
+		transaction(tx => {
+			this._currentCheckpointIndex.set(this._checkpoints.length - 1, tx);
+		});
 	}
 
 	/**
-	 * Records the before/after content URIs for a completed tool call so we
-	 * can revert/replay them later. Idempotent on `toolCallId`.
+	 * Folds a completed tool call's file edits into the checkpoint for the
+	 * given request. Idempotent on `toolCallId`.
 	 */
 	addToolCallEdits(requestId: string, tc: ToolCallState): void {
 		if (tc.status !== ToolCallStatus.Completed) {
 			return;
 		}
 
-		// Deduplicate
-		if (this._checkpoints.some(cp => cp.undoStopId === tc.toolCallId)) {
+		this.ensureRequestCheckpoint(requestId);
+
+		const cp = this._checkpoints.find(c => c.requestId === requestId);
+		if (!cp || cp.seenToolCallIds.has(tc.toolCallId)) {
 			return;
 		}
-
-		this.ensureRequestCheckpoint(requestId);
+		cp.seenToolCallIds.add(tc.toolCallId);
 
 		const fileEdits = fileEditsToExternalEdits(tc);
 		if (fileEdits.length === 0) {
@@ -144,62 +152,35 @@ export class AgentHostSnapshotController extends Disposable implements IChatEdit
 		}
 
 		const authority = this._connectionAuthority;
-		const edits: IToolCallFileEdit[] = fileEdits.map(edit => ({
-			kind: edit.kind,
-			resource: toAgentHostUri(edit.resource, authority),
-			originalResource: edit.originalResource ? toAgentHostUri(edit.originalResource, authority) : undefined,
-			beforeContentUri: edit.beforeContentUri ? toAgentHostUri(edit.beforeContentUri, authority) : undefined,
-			afterContentUri: edit.afterContentUri ? toAgentHostUri(edit.afterContentUri, authority) : undefined,
-			undoStopId: edit.undoStopId,
-			diff: edit.diff,
-		}));
-
-		this._checkpoints.push({ requestId, undoStopId: tc.toolCallId, edits });
-
-		transaction(tx => {
-			this._currentCheckpointIndex.set(this._checkpoints.length - 1, tx);
-		});
+		for (const edit of fileEdits) {
+			cp.edits.push({
+				kind: edit.kind,
+				resource: toAgentHostUri(edit.resource, authority),
+				originalResource: edit.originalResource ? toAgentHostUri(edit.originalResource, authority) : undefined,
+				beforeContentUri: edit.beforeContentUri ? toAgentHostUri(edit.beforeContentUri, authority) : undefined,
+				afterContentUri: edit.afterContentUri ? toAgentHostUri(edit.afterContentUri, authority) : undefined,
+				undoStopId: edit.undoStopId,
+				diff: edit.diff,
+			});
+		}
 	}
 
 	// ---- Snapshots ----------------------------------------------------------
 
-	private _findCheckpointIndex(requestId: string, stopId: string | undefined): number {
-		if (stopId !== undefined) {
-			return this._checkpoints.findIndex(cp => cp.requestId === requestId && cp.undoStopId === stopId);
-		}
-		// No specific stop: find the sentinel checkpoint (undoStopId === undefined)
-		// for this request, which marks the request boundary.
-		return this._checkpoints.findIndex(cp => cp.requestId === requestId && cp.undoStopId === undefined);
+	private _findCheckpointIndex(requestId: string): number {
+		return this._checkpoints.findIndex(cp => cp.requestId === requestId);
 	}
 
-	private _findCheckpoint(requestId: string, stopId: string | undefined): IAgentHostCheckpoint | undefined {
-		if (stopId !== undefined) {
-			const idx = this._findCheckpointIndex(requestId, stopId);
-			return idx >= 0 ? this._checkpoints[idx] : undefined;
-		}
-		// No specific stop: find the last non-sentinel checkpoint for this
-		// request (the one with actual edits).
-		for (let i = this._checkpoints.length - 1; i >= 0; i--) {
-			const cp = this._checkpoints[i];
-			if (cp.requestId === requestId && cp.undoStopId !== undefined) {
-				return cp;
-			}
-		}
-		return undefined;
-	}
-
-	async restoreSnapshot(requestId: string, stopId: string | undefined): Promise<void> {
+	async restoreSnapshot(requestId: string, _stopId: string | undefined): Promise<void> {
 		return this._undoRedoSequencer.queue(async () => {
-			const cpIdx = this._findCheckpointIndex(requestId, stopId);
+			const cpIdx = this._findCheckpointIndex(requestId);
 			if (cpIdx < 0) {
-				this._logService.warn(`[AgentHostSnapshotController] No checkpoint found for requestId=${requestId}${stopId ? `, stopId=${stopId}` : ''}`);
+				this._logService.warn(`[AgentHostSnapshotController] No checkpoint found for requestId=${requestId}`);
 				return;
 			}
 
-			// When stopId is undefined we found the sentinel (request boundary).
-			// Navigate to one before it so the request's edits are fully undone.
-			const targetIdx = stopId === undefined ? cpIdx - 1 : cpIdx;
-
+			// Restore to before this request: target one slot before it.
+			const targetIdx = cpIdx - 1;
 			const currentIdx = this._currentCheckpointIndex.get();
 			if (targetIdx < currentIdx) {
 				// Undo forward checkpoints
@@ -219,30 +200,33 @@ export class AgentHostSnapshotController extends Disposable implements IChatEdit
 		});
 	}
 
-	getSnapshotUri(requestId: string, uri: URI, stopId: string | undefined): URI | undefined {
-		const cp = this._findCheckpoint(requestId, stopId);
-		if (!cp) {
-			return undefined;
-		}
-		const uriStr = uri.toString();
-		const edit = cp.edits.find(e => e.resource.toString() === uriStr);
-		if (!edit) {
+	getSnapshotUri(requestId: string, uri: URI, _stopId: string | undefined): URI | undefined {
+		const cp = this._checkpoints.find(c => c.requestId === requestId);
+		if (!cp || !cp.edits.some(e => e.resource.toString() === uri.toString())) {
 			return undefined;
 		}
 		return URI.from({
 			scheme: Schemas.chatEditingSnapshotScheme,
 			path: uri.path,
-			query: JSON.stringify({ session: this.chatSessionResource.toString(), requestId, undoStop: stopId ?? '' }),
+			query: JSON.stringify({ session: this.chatSessionResource.toString(), requestId, undoStop: '' }),
 		});
 	}
 
-	async getSnapshotContents(requestId: string, uri: URI, stopId: string | undefined): Promise<VSBuffer | undefined> {
-		const cp = this._findCheckpoint(requestId, stopId);
+	async getSnapshotContents(requestId: string, uri: URI, _stopId: string | undefined): Promise<VSBuffer | undefined> {
+		const cp = this._checkpoints.find(c => c.requestId === requestId);
 		if (!cp) {
 			return undefined;
 		}
 		const uriStr = uri.toString();
-		const edit = cp.edits.find(e => e.resource.toString() === uriStr);
+		// Use the last edit for this file in the request — that's the
+		// "after-content" the diff viewer wants to display.
+		let edit: IToolCallFileEdit | undefined;
+		for (let i = cp.edits.length - 1; i >= 0; i--) {
+			if (cp.edits[i].resource.toString() === uriStr) {
+				edit = cp.edits[i];
+				break;
+			}
+		}
 		if (!edit) {
 			return undefined;
 		}

--- a/src/vs/workbench/contrib/chat/test/browser/agentHost/agentHostSnapshotController.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentHost/agentHostSnapshotController.test.ts
@@ -184,13 +184,84 @@ suite('AgentHostSnapshotController', () => {
 		assert.deepStrictEqual(controller.requestDisablement.get().map(d => d.requestId), ['req-2']);
 	});
 
-	test('ensureRequestCheckpoint creates sentinel and is idempotent', () => {
+	test('ensureRequestCheckpoint creates a checkpoint and is idempotent', () => {
 		const controller = createController(store, new Map());
 		controller.ensureRequestCheckpoint('req-1');
 		controller.ensureRequestCheckpoint('req-1');
-		// A sentinel alone doesn't enable undo (currentIdx === -1 since
-		// sentinels never advance the cursor on their own).
-		assert.strictEqual(controller.canUndo.get(), false);
+		// Undo is request-level: a checkpoint exists, so we can undo it
+		// (even though the request produced no edits).
+		assert.strictEqual(controller.canUndo.get(), true);
+		assert.strictEqual(controller.canRedo.get(), false);
+	});
+
+	test('ensureRequestCheckpoint does not mark the current request as disabled', () => {
+		const controller = createController(store, new Map());
+		// Simulates the start-of-turn path in the session handler: the
+		// checkpoint for the in-flight request must not appear in
+		// requestDisablement (otherwise the chat UI hides the live turn).
+		controller.ensureRequestCheckpoint('req-1');
+		assert.deepStrictEqual(controller.requestDisablement.get(), []);
+		controller.ensureRequestCheckpoint('req-2');
+		assert.deepStrictEqual(controller.requestDisablement.get(), []);
+	});
+
+	test('restoreSnapshot of a no-edit request marks it disabled', async () => {
+		const controller = createController(store, new Map());
+		// Two requests, neither produced file edits — mirrors a session
+		// hydrated from history where intermediate turns had no tool calls.
+		controller.ensureRequestCheckpoint('req-1');
+		controller.ensureRequestCheckpoint('req-2');
+		await controller.restoreSnapshot('req-2', undefined);
+		assert.deepStrictEqual(
+			controller.requestDisablement.get().map(d => d.requestId),
+			['req-2'],
+		);
+	});
+
+	test('starting a new request after restore-to-start splices stale checkpoints', () => {
+		const before = URI.file('/snap/before-1').toString();
+		const after = URI.file('/snap/after-1').toString();
+		const controller = createController(store, new Map([
+			[before, 'a'], [after, 'b'], [URI.file('/file.ts').toString(), 'a'],
+		]));
+		controller.addToolCallEdits('req-1', makeToolCall({
+			toolCallId: 'tc-1', filePath: '/file.ts',
+			beforeURI: before, afterURI: after,
+		}));
+		return controller.restoreSnapshot('req-1', undefined).then(() => {
+			// After restoring before req-1, the user sends a new request.
+			// The stale forward branch must be spliced or the new checkpoint
+			// would coexist with the discarded one.
+			controller.ensureRequestCheckpoint('req-2');
+			assert.deepStrictEqual(controller.requestDisablement.get(), []);
+			assert.strictEqual(controller.canRedo.get(), false);
+		});
+	});
+
+	test('multiple tool calls in one request share a checkpoint', async () => {
+		const before1 = URI.file('/snap/before-1').toString();
+		const after1 = URI.file('/snap/after-1').toString();
+		const before2 = URI.file('/snap/before-2').toString();
+		const after2 = URI.file('/snap/after-2').toString();
+		const fileA = URI.file('/a.ts').toString();
+		const fileB = URI.file('/b.ts').toString();
+		const contentMap = new Map([
+			[before1, 'a-original'], [after1, 'a-modified'], [fileA, 'a-modified'],
+			[before2, 'b-original'], [after2, 'b-modified'], [fileB, 'b-modified'],
+		]);
+		const controller = createController(store, contentMap);
+		controller.addToolCallEdits('req-1', makeToolCall({
+			toolCallId: 'tc-1', filePath: '/a.ts',
+			beforeURI: before1, afterURI: after1,
+		}));
+		controller.addToolCallEdits('req-1', makeToolCall({
+			toolCallId: 'tc-2', filePath: '/b.ts',
+			beforeURI: before2, afterURI: after2,
+		}));
+		// Restoring before req-1 undoes BOTH tool calls' edits.
+		await controller.restoreSnapshot('req-1', undefined);
+		assert.strictEqual(contentMap.get(fileA), 'a-original');
+		assert.strictEqual(contentMap.get(fileB), 'b-original');
 	});
 
 	test('hasEditsInRequest reflects added tool call edits', () => {

--- a/src/vs/workbench/contrib/chat/test/browser/agentHost/agentHostSnapshotController.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentHost/agentHostSnapshotController.test.ts
@@ -264,6 +264,34 @@ suite('AgentHostSnapshotController', () => {
 		assert.strictEqual(contentMap.get(fileB), 'b-original');
 	});
 
+	test('multiple tool calls editing the same file collapse to one net edit', async () => {
+		// Two sequential edits to /file.ts within the same request: the
+		// second edit's after-content must win on redo, and the first
+		// edit's before-content must win on undo. Without merging, the
+		// two edits would race when applied in parallel.
+		const beforeA = URI.file('/snap/before-a').toString();
+		const afterA = URI.file('/snap/after-a').toString();
+		const beforeB = URI.file('/snap/before-b').toString();
+		const afterB = URI.file('/snap/after-b').toString();
+		const file = URI.file('/file.ts').toString();
+		const contentMap = new Map([
+			[beforeA, 'v0'], [afterA, 'v1'],
+			[beforeB, 'v1'], [afterB, 'v2'],
+			[file, 'v2'],
+		]);
+		const controller = createController(store, contentMap);
+		controller.addToolCallEdits('req-1', makeToolCall({
+			toolCallId: 'tc-1', filePath: '/file.ts',
+			beforeURI: beforeA, afterURI: afterA,
+		}));
+		controller.addToolCallEdits('req-1', makeToolCall({
+			toolCallId: 'tc-2', filePath: '/file.ts',
+			beforeURI: beforeB, afterURI: afterB,
+		}));
+		await controller.restoreSnapshot('req-1', undefined);
+		assert.strictEqual(contentMap.get(file), 'v0');
+	});
+
 	test('hasEditsInRequest reflects added tool call edits', () => {
 		const controller = createController(store, new Map());
 		controller.addToolCallEdits('req-1', makeToolCall({


### PR DESCRIPTION
agent host: hydrate snapshot controller for Restore CheckpointCurrently the AgentHostSnapshotController never has any checkpoints torestore to when "Restore Checkpoint" is invoked, so the removed requeststays visible in the chat UI. This fix wires up hydration end-to-end andsimplifies the controller's bookkeeping along the way.- Seed a request-level checkpoint for every historical turn on session  open, not only turns with file edits. Without this, restoreSnapshot  for any turn that lacked tool calls fell through with "No checkpoint  found" and _setDisabledRequests was never called.- Always populate _pendingHistoryTurns from the protocol state  (previously gated on hasTurnsWithEdits), and stop using Event.once on  onDidCreateModel to wait for the chat model ΓÇö the once subscription  was being consumed by an unrelated model created first, leaving the  controller un-hydrated. Now we synchronously hydrate when the model  already exists, otherwise listen until the matching session arrives.- Make ensureRequestCheckpoint advance _currentCheckpointIndex to the  new checkpoint. Previously the cursor stayed put, so requestDisablement  marked the in-flight request as disabled (the new checkpoint sat  "forward" of the cursor) and the next call would splice it away.- Simplify to one checkpoint per request. Multiple tool calls in the  same request now fold their edits into a single checkpoint via a  seenToolCallIds Set, and restoreSnapshot/getSnapshotUri/  getSnapshotContents ignore the stopId parameter. canUndo/canRedo  derive purely from cursor position ΓÇö undo/redo is request-level,  available whenever any checkpoint exists.- Add tests covering: in-flight request isn't disabled, restore of a  no-edit request marks it disabled, stale forward branch is spliced on  new request after restore-to-start, and multi-tool-call edits undo  together.Fixes https://github.com/microsoft/vscode/issues/318251(Commit message generated by Copilot)