### PR TITLE
Fix system notification command rendering as literal backtick (#318601)

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalHelpers.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalHelpers.ts
@@ -72,11 +72,18 @@ export function normalizeTerminalCommandForDisplay(commandLine: string): string 
 
 /**
  * Builds a single-line display string for a terminal command, suitable for UI messages.
- * Normalizes escape artifacts, collapses newlines to spaces, and truncates to 80 characters.
+ * Normalizes escape artifacts, then keeps only the first line and appends an ellipsis
+ * if the command spans multiple lines or the first line exceeds 80 characters.
  */
 export function buildCommandDisplayText(command: string): string {
-	const normalized = normalizeTerminalCommandForDisplay(command).replace(/\r\n|\r|\n/g, ' ');
-	return normalized.length > 80 ? normalized.substring(0, 77) + '...' : normalized;
+	const normalized = normalizeTerminalCommandForDisplay(command);
+	const firstLineEnd = normalized.search(/\r|\n/);
+	const hasMoreLines = firstLineEnd !== -1;
+	const firstLine = hasMoreLines ? normalized.substring(0, firstLineEnd) : normalized;
+	if (firstLine.length > 80) {
+		return firstLine.substring(0, 77) + '...';
+	}
+	return hasMoreLines ? firstLine + '...' : firstLine;
 }
 
 /**

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalHelpers.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalHelpers.ts
@@ -72,18 +72,11 @@ export function normalizeTerminalCommandForDisplay(commandLine: string): string 
 
 /**
  * Builds a single-line display string for a terminal command, suitable for UI messages.
- * Normalizes escape artifacts, then keeps only the first line and appends an ellipsis
- * if the command spans multiple lines or the first line exceeds 80 characters.
+ * Normalizes escape artifacts, collapses newlines to spaces, and truncates to 80 characters.
  */
 export function buildCommandDisplayText(command: string): string {
-	const normalized = normalizeTerminalCommandForDisplay(command);
-	const firstLineEnd = normalized.search(/\r|\n/);
-	const hasMoreLines = firstLineEnd !== -1;
-	const firstLine = hasMoreLines ? normalized.substring(0, firstLineEnd) : normalized;
-	if (firstLine.length > 80) {
-		return firstLine.substring(0, 77) + '...';
-	}
-	return hasMoreLines ? firstLine + '...' : firstLine;
+	const normalized = normalizeTerminalCommandForDisplay(command).replace(/\r\n|\r|\n/g, ' ');
+	return normalized.length > 80 ? normalized.substring(0, 77) + '...' : normalized;
 }
 
 /**

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -2493,8 +2493,14 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		// command for use in system notification labels. The command may span
 		// multiple lines (and contain blank lines or backticks), which would
 		// break a naive `` `${command}` `` inline code span and render the
-		// backticks literally (#318601).
-		const commandDisplay = appendEscapedMarkdownInlineCode(buildCommandDisplayText(commandName));
+		// backticks literally (#318601). Truncate to the first line + ellipsis
+		// rather than collapsing newlines, since the label is shown on a single
+		// line of UI chrome where additional lines are not useful.
+		const firstNewline = commandName.search(/\r|\n/);
+		const truncatedCommand = firstNewline === -1
+			? commandName
+			: commandName.substring(0, firstNewline) + '...';
+		const commandDisplay = appendEscapedMarkdownInlineCode(truncatedCommand);
 
 		// Acquire a reference to the ChatModel so it stays alive while we wait
 		// for the background terminal to complete. Without this, the model can

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -477,9 +477,9 @@ const altBufferMessage = '\n' + localize('runInTerminalTool.altBufferMessage', "
 /**
  * Builds the short, single-line command string used in the SYSTEM NOTIFICATION
  * label for background terminal completion (#318601). Keeps only the first line
- * of the command and appends an ellipsis if more lines were dropped, then runs
- * the result through {@link buildCommandDisplayText} so escape artifacts are
- * stripped and the text is truncated to 80 characters.
+ * of the command (stripping common escape artifacts) and appends a horizontal
+ * ellipsis (`…`) when content is dropped — either because the command spans
+ * multiple lines or the first line itself is longer than 80 characters.
  *
  * Multi-line commands (with blank lines) used to break the surrounding inline
  * code span; callers must additionally wrap the result with
@@ -489,11 +489,11 @@ export function buildCompletionNotificationCommand(command: string): string {
 	const firstNewline = command.search(/\r|\n/);
 	const hasMoreLines = firstNewline !== -1;
 	const firstLine = hasMoreLines ? command.substring(0, firstNewline) : command;
-	const displayText = buildCommandDisplayText(firstLine);
-	if (hasMoreLines && !displayText.endsWith('...')) {
-		return displayText + '...';
+	const normalized = normalizeTerminalCommandForDisplay(firstLine);
+	if (normalized.length > 80) {
+		return normalized.substring(0, 79) + '…';
 	}
-	return displayText;
+	return hasMoreLines ? normalized + '…' : normalized;
 }
 
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -9,7 +9,7 @@ import { CancellationToken, CancellationTokenSource } from '../../../../../../ba
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { CancellationError } from '../../../../../../base/common/errors.js';
 import { Event } from '../../../../../../base/common/event.js';
-import { escapeMarkdownSyntaxTokens, MarkdownString, type IMarkdownString } from '../../../../../../base/common/htmlContent.js';
+import { appendEscapedMarkdownInlineCode, escapeMarkdownSyntaxTokens, MarkdownString, type IMarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { Disposable, DisposableMap, DisposableStore, IDisposable, MutableDisposable, toDisposable } from '../../../../../../base/common/lifecycle.js';
 import { ResourceMap } from '../../../../../../base/common/map.js';
 import { getMediaMime } from '../../../../../../base/common/mime.js';
@@ -2489,6 +2489,13 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			return;
 		}
 
+		// Build a single-line, safely-fenced inline code representation of the
+		// command for use in system notification labels. The command may span
+		// multiple lines (and contain blank lines or backticks), which would
+		// break a naive `` `${command}` `` inline code span and render the
+		// backticks literally (#318601).
+		const commandDisplay = appendEscapedMarkdownInlineCode(buildCommandDisplayText(commandName));
+
 		// Acquire a reference to the ChatModel so it stays alive while we wait
 		// for the background terminal to complete. Without this, the model can
 		// be disposed if the user navigates away, and sendRequest would throw.
@@ -2630,7 +2637,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 					...sendOptions,
 					queue: ChatRequestQueueKind.Steering,
 					isSystemInitiated: true,
-					systemInitiatedLabel: localize('terminalAssessingOutput', "`{0}` may need input", commandName),
+					systemInitiatedLabel: localize('terminalAssessingOutput', "{0} may need input", commandDisplay),
 					terminalExecutionId: termId,
 				}).catch(e => {
 					this._logService.warn(`RunInTerminalTool: Failed to send input-needed notification for terminal ${termId}`, e);
@@ -2684,7 +2691,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 				...sendOptions,
 				queue: ChatRequestQueueKind.Steering,
 				isSystemInitiated: true,
-				systemInitiatedLabel: localize('terminalCommandCompleted', "`{0}` completed", commandName),
+				systemInitiatedLabel: localize('terminalCommandCompleted', "{0} completed", commandDisplay),
 				terminalExecutionId: termId,
 			}).catch(e => {
 				this._logService.warn(`RunInTerminalTool: Failed to send completion notification for terminal ${termId}`, e);
@@ -2752,7 +2759,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 				...sendOptions,
 				queue: ChatRequestQueueKind.Steering,
 				isSystemInitiated: true,
-				systemInitiatedLabel: localize('terminalProcessExited', "`{0}` terminal exited", commandName),
+				systemInitiatedLabel: localize('terminalProcessExited', "{0} terminal exited", commandDisplay),
 				terminalExecutionId: termId,
 			}).catch(e => {
 				this._logService.warn(`RunInTerminalTool: Failed to send terminal-exited notification for terminal ${termId}`, e);

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -474,6 +474,28 @@ const telemetryIgnoredSequences = [
 
 const altBufferMessage = '\n' + localize('runInTerminalTool.altBufferMessage', "The command opened the alternate buffer.");
 
+/**
+ * Builds the short, single-line command string used in the SYSTEM NOTIFICATION
+ * label for background terminal completion (#318601). Keeps only the first line
+ * of the command and appends an ellipsis if more lines were dropped, then runs
+ * the result through {@link buildCommandDisplayText} so escape artifacts are
+ * stripped and the text is truncated to 80 characters.
+ *
+ * Multi-line commands (with blank lines) used to break the surrounding inline
+ * code span; callers must additionally wrap the result with
+ * {@link appendEscapedMarkdownInlineCode} when interpolating into markdown.
+ */
+export function buildCompletionNotificationCommand(command: string): string {
+	const firstNewline = command.search(/\r|\n/);
+	const hasMoreLines = firstNewline !== -1;
+	const firstLine = hasMoreLines ? command.substring(0, firstNewline) : command;
+	const displayText = buildCommandDisplayText(firstLine);
+	if (hasMoreLines && !displayText.endsWith('...')) {
+		return displayText + '...';
+	}
+	return displayText;
+}
+
 
 export class RunInTerminalTool extends Disposable implements IToolImpl {
 
@@ -2490,17 +2512,8 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		}
 
 		// Build a single-line, safely-fenced inline code representation of the
-		// command for use in system notification labels. The command may span
-		// multiple lines (and contain blank lines or backticks), which would
-		// break a naive `` `${command}` `` inline code span and render the
-		// backticks literally (#318601). Truncate to the first line + ellipsis
-		// rather than collapsing newlines, since the label is shown on a single
-		// line of UI chrome where additional lines are not useful.
-		const firstNewline = commandName.search(/\r|\n/);
-		const truncatedCommand = firstNewline === -1
-			? commandName
-			: commandName.substring(0, firstNewline) + '...';
-		const commandDisplay = appendEscapedMarkdownInlineCode(truncatedCommand);
+		// command for use in the system notification label (#318601).
+		const commandDisplay = appendEscapedMarkdownInlineCode(buildCompletionNotificationCommand(commandName));
 
 		// Acquire a reference to the ChatModel so it stays alive while we wait
 		// for the background terminal to complete. Without this, the model can

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/runInTerminalHelpers.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/runInTerminalHelpers.test.ts
@@ -574,14 +574,9 @@ suite('isMultilineCommand', () => {
 suite('buildCommandDisplayText', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	test('should keep only the first line and append ellipsis for multi-line commands', () => {
-		strictEqual(buildCommandDisplayText('echo a\n\necho b'), 'echo a...');
-		strictEqual(buildCommandDisplayText('echo a\r\necho b'), 'echo a...');
-		strictEqual(buildCommandDisplayText('echo a\recho b'), 'echo a...');
-	});
-
-	test('should leave single-line commands unchanged', () => {
-		strictEqual(buildCommandDisplayText('echo hello'), 'echo hello');
+	test('should collapse newlines (including blank lines) to spaces', () => {
+		strictEqual(buildCommandDisplayText('echo a\n\necho b'), 'echo a  echo b');
+		strictEqual(buildCommandDisplayText('echo a\r\necho b'), 'echo a echo b');
 	});
 
 	test('should truncate long commands to 80 characters', () => {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/runInTerminalHelpers.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/runInTerminalHelpers.test.ts
@@ -612,24 +612,24 @@ suite('buildCompletionNotificationCommand', () => {
 		strictEqual(buildCompletionNotificationCommand('echo hello'), 'echo hello');
 	});
 
-	test('keeps only the first line and appends an ellipsis for multi-line commands', () => {
-		strictEqual(buildCompletionNotificationCommand('echo a\necho b'), 'echo a...');
-		strictEqual(buildCompletionNotificationCommand('echo a\n\necho b'), 'echo a...');
-		strictEqual(buildCompletionNotificationCommand('echo a\r\necho b'), 'echo a...');
-		strictEqual(buildCompletionNotificationCommand('echo a\recho b'), 'echo a...');
+	test('keeps only the first line and appends a horizontal ellipsis for multi-line commands', () => {
+		strictEqual(buildCompletionNotificationCommand('echo a\necho b'), 'echo a…');
+		strictEqual(buildCompletionNotificationCommand('echo a\n\necho b'), 'echo a…');
+		strictEqual(buildCompletionNotificationCommand('echo a\r\necho b'), 'echo a…');
+		strictEqual(buildCompletionNotificationCommand('echo a\recho b'), 'echo a…');
 	});
 
-	test('truncates a long first line to 80 characters and does not add a second ellipsis', () => {
+	test('truncates a long first line to 80 characters using a single horizontal ellipsis', () => {
 		const longFirstLine = 'a'.repeat(200);
 		const multiLine = longFirstLine + '\nignored';
 		const result = buildCompletionNotificationCommand(multiLine);
 		strictEqual(result.length, 80);
-		ok(result.endsWith('...'), `expected ellipsis suffix, got: ${result}`);
-		ok(!result.endsWith('......'), `expected single ellipsis suffix, got: ${result}`);
+		ok(result.endsWith('…'), `expected ellipsis suffix, got: ${result}`);
+		ok(!result.endsWith('……'), `expected single ellipsis suffix, got: ${result}`);
 	});
 
 	test('strips escape artifacts from the first line', () => {
-		strictEqual(buildCompletionNotificationCommand('echo \\"hi\\"\necho ignored'), 'echo "hi"...');
+		strictEqual(buildCompletionNotificationCommand('echo \\"hi\\"\necho ignored'), 'echo "hi"…');
 	});
 
 	// Regression test for #318601: the final label must render as inline code

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/runInTerminalHelpers.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/runInTerminalHelpers.test.ts
@@ -7,6 +7,7 @@ import { ok, strictEqual } from 'assert';
 import * as marked from '../../../../../../base/common/marked/marked.js';
 import { appendEscapedMarkdownInlineCode } from '../../../../../../base/common/htmlContent.js';
 import { generateAutoApproveActions, TRUNCATION_MESSAGE, dedupeRules, isPowerShell, truncateOutputKeepingTail, extractCdPrefix, normalizeTerminalCommandForDisplay, normalizeCommandForExecution, isMultilineCommand, buildCommandDisplayText } from '../../browser/runInTerminalHelpers.js';
+import { buildCompletionNotificationCommand } from '../../browser/tools/runInTerminalTool.js';
 import { OperatingSystem } from '../../../../../../base/common/platform.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { ConfigurationTarget } from '../../../../../../platform/configuration/common/configuration.js';
@@ -597,6 +598,49 @@ suite('buildCommandDisplayText', () => {
 
 		const multilineCommand = 'rm -rf .playwright-cli/\n\nmore text';
 		const label = appendEscapedMarkdownInlineCode(buildCommandDisplayText(multilineCommand)) + ' completed';
+		const html = render(label);
+
+		ok(html.includes('<code>'), `expected a code span, got: ${html}`);
+		ok(!/<p>`/.test(html), `expected no literal leading backtick, got: ${html}`);
+	});
+});
+
+suite('buildCompletionNotificationCommand', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('leaves single-line commands unchanged', () => {
+		strictEqual(buildCompletionNotificationCommand('echo hello'), 'echo hello');
+	});
+
+	test('keeps only the first line and appends an ellipsis for multi-line commands', () => {
+		strictEqual(buildCompletionNotificationCommand('echo a\necho b'), 'echo a...');
+		strictEqual(buildCompletionNotificationCommand('echo a\n\necho b'), 'echo a...');
+		strictEqual(buildCompletionNotificationCommand('echo a\r\necho b'), 'echo a...');
+		strictEqual(buildCompletionNotificationCommand('echo a\recho b'), 'echo a...');
+	});
+
+	test('truncates a long first line to 80 characters and does not add a second ellipsis', () => {
+		const longFirstLine = 'a'.repeat(200);
+		const multiLine = longFirstLine + '\nignored';
+		const result = buildCompletionNotificationCommand(multiLine);
+		strictEqual(result.length, 80);
+		ok(result.endsWith('...'), `expected ellipsis suffix, got: ${result}`);
+		ok(!result.endsWith('......'), `expected single ellipsis suffix, got: ${result}`);
+	});
+
+	test('strips escape artifacts from the first line', () => {
+		strictEqual(buildCompletionNotificationCommand('echo \\"hi\\"\necho ignored'), 'echo "hi"...');
+	});
+
+	// Regression test for #318601: the final label must render as inline code
+	// (no literal backticks) when fed to the markdown renderer wrapped with
+	// `appendEscapedMarkdownInlineCode`.
+	test('result renders as inline code when wrapped with appendEscapedMarkdownInlineCode', () => {
+		const opts: marked.MarkedOptions = { gfm: true, breaks: true };
+		const render = (value: string) => marked.parser(marked.lexer(value, opts), opts);
+
+		const multilineCommand = 'rm -rf .playwright-cli/\n\nmore text';
+		const label = appendEscapedMarkdownInlineCode(buildCompletionNotificationCommand(multilineCommand)) + ' completed';
 		const html = render(label);
 
 		ok(html.includes('<code>'), `expected a code span, got: ${html}`);

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/runInTerminalHelpers.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/runInTerminalHelpers.test.ts
@@ -574,9 +574,14 @@ suite('isMultilineCommand', () => {
 suite('buildCommandDisplayText', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	test('should collapse newlines (including blank lines) to spaces', () => {
-		strictEqual(buildCommandDisplayText('echo a\n\necho b'), 'echo a  echo b');
-		strictEqual(buildCommandDisplayText('echo a\r\necho b'), 'echo a echo b');
+	test('should keep only the first line and append ellipsis for multi-line commands', () => {
+		strictEqual(buildCommandDisplayText('echo a\n\necho b'), 'echo a...');
+		strictEqual(buildCommandDisplayText('echo a\r\necho b'), 'echo a...');
+		strictEqual(buildCommandDisplayText('echo a\recho b'), 'echo a...');
+	});
+
+	test('should leave single-line commands unchanged', () => {
+		strictEqual(buildCommandDisplayText('echo hello'), 'echo hello');
 	});
 
 	test('should truncate long commands to 80 characters', () => {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/runInTerminalHelpers.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/runInTerminalHelpers.test.ts
@@ -4,7 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ok, strictEqual } from 'assert';
-import { generateAutoApproveActions, TRUNCATION_MESSAGE, dedupeRules, isPowerShell, truncateOutputKeepingTail, extractCdPrefix, normalizeTerminalCommandForDisplay, normalizeCommandForExecution, isMultilineCommand } from '../../browser/runInTerminalHelpers.js';
+import * as marked from '../../../../../../base/common/marked/marked.js';
+import { appendEscapedMarkdownInlineCode } from '../../../../../../base/common/htmlContent.js';
+import { generateAutoApproveActions, TRUNCATION_MESSAGE, dedupeRules, isPowerShell, truncateOutputKeepingTail, extractCdPrefix, normalizeTerminalCommandForDisplay, normalizeCommandForExecution, isMultilineCommand, buildCommandDisplayText } from '../../browser/runInTerminalHelpers.js';
 import { OperatingSystem } from '../../../../../../base/common/platform.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { ConfigurationTarget } from '../../../../../../platform/configuration/common/configuration.js';
@@ -569,3 +571,35 @@ suite('isMultilineCommand', () => {
 	});
 });
 
+suite('buildCommandDisplayText', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('should collapse newlines (including blank lines) to spaces', () => {
+		strictEqual(buildCommandDisplayText('echo a\n\necho b'), 'echo a  echo b');
+		strictEqual(buildCommandDisplayText('echo a\r\necho b'), 'echo a echo b');
+	});
+
+	test('should truncate long commands to 80 characters', () => {
+		const long = 'a'.repeat(200);
+		const result = buildCommandDisplayText(long);
+		strictEqual(result.length, 80);
+		ok(result.endsWith('...'));
+	});
+
+	// Regression test for #318601: system notification labels used to wrap the
+	// raw command in a single-backtick inline code span. Multi-line commands
+	// (which contain blank lines) broke the code span and rendered the leading
+	// backtick literally. The command must be collapsed to a single line and
+	// safely fenced so it always renders as inline code.
+	test('multi-line command renders as inline code (not a literal backtick)', () => {
+		const opts: marked.MarkedOptions = { gfm: true, breaks: true };
+		const render = (value: string) => marked.parser(marked.lexer(value, opts), opts);
+
+		const multilineCommand = 'rm -rf .playwright-cli/\n\nmore text';
+		const label = appendEscapedMarkdownInlineCode(buildCommandDisplayText(multilineCommand)) + ' completed';
+		const html = render(label);
+
+		ok(html.includes('<code>'), `expected a code span, got: ${html}`);
+		ok(!/<p>`/.test(html), `expected no literal leading backtick, got: ${html}`);
+	});
+});


### PR DESCRIPTION
Fixes [#318601](https://github.com/microsoft/vscode/issues/318601).

## Problem
In the SYSTEM NOTIFICATION divider, multi-line shell commands rendered with literal leading backticks instead of as inline code. The cause: `runInTerminalTool._registerCompletionNotification` built the steering label as `localize(..., '\`{0}\` completed', commandName)`. When `commandName` contained a blank line, the inline code span in CommonMark cannot span the paragraph break, leaving the opening backtick to render literally.

## Fix
New private helper `buildCompletionNotificationCommand` in `runInTerminalTool.ts`:
- Keeps only the first line of the command
- Strips common escape artifacts via `normalizeTerminalCommandForDisplay`
- Truncates to 80 characters total
- Appends a horizontal `) when content was dropped (multi-line input or first line > 80 chars)ellipsis (`

The result is wrapped with the existing `appendEscapedMarkdownInlineCode` helper before interpolation into the localized label, which fences any backticks in the command text.

The three localize strings (`terminalAssessingOutput`, `terminalCommandCompleted`, `terminalProcessExited`) no longer hardcode backticks around `{0}`; the pre-fenced inline code is interpolated as-is.

## Tests
Added `suite('buildCompletionNotificationCommand', ...)` in `runInTerminalHelpers.test.ts` (5 new tests) covering single-line passthrough, multi-line ellipsis (`\n`, `\n\n`, `\r\n`, `\r`), long-first-line truncation, escape-artifact stripping, and an end-to-end markdown render assertion (the original regression repro).

(Written by Copilot)