### PR TITLE
chat (sessions): fix forking AHP chats so the new session opens with a "Forked: " title

### DIFF
--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -15,6 +15,7 @@ import { observableValue } from '../../../base/common/observable.js';
 import { extname as resourcesExtname, isEqual, isEqualOrParent, joinPath } from '../../../base/common/resources.js';
 import { URI } from '../../../base/common/uri.js';
 import { generateUuid } from '../../../base/common/uuid.js';
+import { localize } from '../../../nls.js';
 import { FileChangeType, FileOperationError, FileOperationResult, FileSystemProviderErrorCode, IFileChange, IFileService, toFileSystemProviderErrorCode, type FileChangesEvent } from '../../files/common/files.js';
 import { InstantiationService } from '../../instantiation/common/instantiationService.js';
 import { ServiceCollection } from '../../instantiation/common/serviceCollection.js';
@@ -492,7 +493,16 @@ export class AgentService extends Disposable implements IAgentService {
 					.map(t => ({ ...t, id: config!.fork!.turnIdMapping!.get(t.id) ?? generateUuid() }));
 			}
 
-			const summary = this._buildInitialSummary(provider, session, config, created, sourceState?.summary.title ?? 'Forked Session');
+			// Prefix the forked session's title so consumers (sidebar, chat
+			// model) can distinguish it from the source without each surface
+			// reinventing the convention. Avoid double-prefixing when a user
+			// forks an already-forked session.
+			const forkedTitlePrefix = localize('agentHost.forkedTitlePrefix', "Forked: ");
+			const sourceTitle = sourceState?.summary.title;
+			const forkedTitle = sourceTitle
+				? (sourceTitle.startsWith(forkedTitlePrefix) ? sourceTitle : `${forkedTitlePrefix}${sourceTitle}`)
+				: localize('agentHost.forkedSessionFallback', "Forked Session");
+			const summary = this._buildInitialSummary(provider, session, config, created, forkedTitle);
 			const state = this._stateManager.createSession(summary);
 			state.config = sessionConfig;
 			state.turns = sourceTurns;

--- a/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
+++ b/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
@@ -55,6 +55,13 @@ export interface ISessionEventToolComplete {
 
 export interface ISessionEventMessage {
 	type: 'assistant.message' | 'user.message';
+	/**
+	 * SDK envelope-level event id. This is the same id `setTurnEventId`
+	 * persists into `turns.event_id`, so using it as the protocol turn id
+	 * keeps the live and restored ids aligned with what the SDK fork /
+	 * truncate RPCs need.
+	 */
+	id?: string;
 	data?: {
 		messageId?: string;
 		interactionId?: string;
@@ -351,10 +358,15 @@ export async function mapSessionEvents(
 					}
 				} else {
 					// A new top-level user message starts a new parent turn.
+					// Use the SDK envelope id (the same value
+					// `setTurnEventId` records as `event_id`) so the restored
+					// turn id round-trips back to the SDK boundary id that
+					// fork / truncate RPCs operate on.
 					if (parentBuilder) {
 						turns.push(finalizeTurn(parentBuilder, TurnState.Cancelled));
 					}
-					parentBuilder = newTurnBuilder(messageId, content, attachments);
+					const turnId = (e as ISessionEventMessage).id ?? messageId;
+					parentBuilder = newTurnBuilder(turnId, content, attachments);
 				}
 				break;
 			}
@@ -364,8 +376,14 @@ export async function mapSessionEvents(
 				const content = d?.content ?? '';
 				const reasoningText = d?.reasoningText;
 				const hasToolRequests = !!d?.toolRequests && d.toolRequests.length > 0;
+				// When this is the first event in a turn (no parent builder
+				// yet), seed the builder with the SDK envelope id so the
+				// turn id matches `turns.event_id` for fork/truncate
+				// lookups. See the matching note in the `user.message`
+				// branch above.
+				const fallbackTurnId = (e as ISessionEventMessage).id ?? messageId;
 				const builder = targetBuilderFor(d?.parentToolCallId)
-					?? (parentBuilder = newTurnBuilder(messageId, ''));
+					?? (parentBuilder = newTurnBuilder(fallbackTurnId, ''));
 				if (reasoningText) {
 					builder.responseParts.push({
 						kind: ResponsePartKind.Reasoning,

--- a/src/vs/platform/agentHost/node/sessionDatabase.ts
+++ b/src/vs/platform/agentHost/node/sessionDatabase.ts
@@ -312,9 +312,19 @@ export class SessionDatabase implements ISessionDatabase {
 
 	async getNextTurnEventId(turnId: string): Promise<string | undefined> {
 		const db = await this._ensureDb();
+		// `turns.id` is the canonical turn key — either a live `request_xxx`
+		// dispatched by the client or, for sessions restored from disk, the
+		// SDK envelope id surfaced by `mapSessionEvents`. The `event_id`
+		// fallback covers the case where the caller asks about a turn that
+		// was set up live (id=`request_xxx`) but is now being referenced
+		// via the SDK event id, or vice versa.
 		const row = await dbGet(
 			db,
-			`SELECT event_id FROM turns WHERE rowid > (SELECT rowid FROM turns WHERE id = ?) ORDER BY rowid LIMIT 1`,
+			`SELECT event_id FROM turns
+				WHERE rowid > (
+					SELECT rowid FROM turns WHERE id = ?1 OR event_id = ?1 LIMIT 1
+				)
+				ORDER BY rowid LIMIT 1`,
 			[turnId],
 		);
 		return row?.event_id as string | undefined ?? undefined;

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -383,7 +383,7 @@ suite('CopilotAgentSession', () => {
 		}];
 
 		assert.deepStrictEqual(await session.getMessages(), [{
-			id: 'message-1',
+			id: 'event-1',
 			userMessage: {
 				text: '/act-on-feedback',
 				attachments: [expectedAttachment],
@@ -1771,6 +1771,47 @@ suite('CopilotAgentSession', () => {
 			assert.deepStrictEqual(toolCompletions, [
 				{ parentToolCallId: 'tc-subagent', toolCallId: 'tc-child-tool' },
 			]);
+		});
+
+		test('history replay seeds turn id from the SDK envelope id, matching `turns.event_id`', async () => {
+			// Regression test: fork / truncate look up the SDK boundary
+			// event id via `getNextTurnEventId(turnId)`, which keys on
+			// either `turns.id` (live `request_xxx`) or `turns.event_id`
+			// (SDK envelope id). For sessions restored from disk we want
+			// the restored turn id to be the SDK envelope id so that
+			// lookup succeeds without translation.
+			const { session, mockSession } = await createAgentSession(disposables);
+			mockSession.getEvents = async () => [
+				{
+					type: 'user.message',
+					id: 'sdk-evt-user-1',
+					data: { interactionId: 'capi-interaction-1', content: 'first prompt' },
+				},
+				{
+					type: 'assistant.message',
+					id: 'sdk-evt-asst-1',
+					data: { messageId: 'sdk-msg-1', content: 'first response.' },
+				},
+				{
+					type: 'user.message',
+					id: 'sdk-evt-user-2',
+					data: { interactionId: 'capi-interaction-2', content: 'second prompt' },
+				},
+				{
+					type: 'assistant.message',
+					id: 'sdk-evt-asst-2',
+					data: { messageId: 'sdk-msg-2', content: 'second response.' },
+				},
+			] as SessionEvent[];
+
+			const turns = await session.getMessages();
+			assert.deepStrictEqual(
+				turns.map(t => ({ id: t.id, text: t.userMessage.text })),
+				[
+					{ id: 'sdk-evt-user-1', text: 'first prompt' },
+					{ id: 'sdk-evt-user-2', text: 'second prompt' },
+				],
+			);
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/sessionDatabase.test.ts
+++ b/src/vs/platform/agentHost/test/node/sessionDatabase.test.ts
@@ -401,6 +401,53 @@ suite('SessionDatabase', () => {
 		});
 	});
 
+	// ---- Turn event ids -------------------------------------------------
+
+	suite('turn event ids', () => {
+
+		test('getNextTurnEventId returns the next turn\'s event id by `turns.id`', async () => {
+			db = disposables.add(await SessionDatabase.open(':memory:'));
+			await db.createTurn('turn-1');
+			await db.createTurn('turn-2');
+			await db.setTurnEventId('turn-1', 'evt-1');
+			await db.setTurnEventId('turn-2', 'evt-2');
+
+			assert.strictEqual(await db.getNextTurnEventId('turn-1'), 'evt-2');
+		});
+
+		test('getNextTurnEventId falls back to `event_id` when the key is the SDK event id', async () => {
+			// Sessions restored from disk surface SDK envelope ids as the
+			// protocol turn id (see mapSessionEvents.ts), but `turns.id`
+			// was populated live with the client-side `request_xxx` id.
+			// The fallback lets fork / truncate resolve the boundary
+			// without forcing every caller to translate.
+			db = disposables.add(await SessionDatabase.open(':memory:'));
+			await db.createTurn('request_aaa');
+			await db.createTurn('request_bbb');
+			await db.setTurnEventId('request_aaa', 'sdk-evt-1');
+			await db.setTurnEventId('request_bbb', 'sdk-evt-2');
+
+			assert.strictEqual(await db.getNextTurnEventId('sdk-evt-1'), 'sdk-evt-2');
+		});
+
+		test('getNextTurnEventId returns undefined for the last turn', async () => {
+			db = disposables.add(await SessionDatabase.open(':memory:'));
+			await db.createTurn('turn-1');
+			await db.setTurnEventId('turn-1', 'evt-1');
+
+			assert.strictEqual(await db.getNextTurnEventId('turn-1'), undefined);
+			assert.strictEqual(await db.getNextTurnEventId('evt-1'), undefined);
+		});
+
+		test('getNextTurnEventId returns undefined for an unknown key', async () => {
+			db = disposables.add(await SessionDatabase.open(':memory:'));
+			await db.createTurn('turn-1');
+			await db.setTurnEventId('turn-1', 'evt-1');
+
+			assert.strictEqual(await db.getNextTurnEventId('does-not-exist'), undefined);
+		});
+	});
+
 	// ---- Dispose --------------------------------------------------------
 
 	suite('dispose', () => {

--- a/src/vs/sessions/contrib/providers/localChatSessions/browser/localChatSessions.contribution.ts
+++ b/src/vs/sessions/contrib/providers/localChatSessions/browser/localChatSessions.contribution.ts
@@ -6,7 +6,7 @@
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../../workbench/common/contributions.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { Disposable, IDisposable } from '../../../../../base/common/lifecycle.js';
-import { LocalChatSessionsProvider, LOCAL_SESSION_ENABLED_SETTING, LocalSessionType } from './localChatSessionsProvider.js';
+import { LocalChatSessionsProvider, LOCAL_SESSION_ENABLED_SETTING } from './localChatSessionsProvider.js';
 import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
 import { Registry } from '../../../../../platform/registry/common/platform.js';
 import { IConfigurationRegistry, Extensions as ConfigurationExtensions } from '../../../../../platform/configuration/common/configurationRegistry.js';
@@ -67,12 +67,10 @@ registerAction2(class extends ForkConversationAction {
 				return super._openForkedSession(instantiationService, parentSessionResource, forkedSessionResource);
 			}
 
-			if (parentSession.sessionType !== LocalSessionType.id) {
-				return super._openForkedSession(instantiationService, parentSessionResource, forkedSessionResource);
-			}
-
-			// Local sessions — wait for the forked session to appear, but
-			// bound the wait so a missing session does not hang forever.
+			// Wait for the forked session to appear, but bound the wait so a
+			// missing session does not hang forever. Applies to local and
+			// contributed (agent-host) sessions alike — both surface via
+			// `sessionsManagementService` in the Agents window.
 			if (!sessionsManagementService.getSession(forkedSessionResource)) {
 				let listener: IDisposable | undefined;
 				const appeared = await raceTimeout(new Promise<boolean>(resolve => {

--- a/src/vs/workbench/contrib/chat/browser/actions/chatForkActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatForkActions.ts
@@ -64,7 +64,7 @@ export class ForkConversationAction extends Action2 {
 			// Check if this is a contributed session that supports forking
 			const contentProviderSchemes = chatSessionsService.getContentProviderSchemes();
 			if (contentProviderSchemes.includes(getChatSessionType(sourceSessionResource))) {
-				return await this.forkContributedChatSession(sourceSessionResource, undefined, false, chatSessionsService, chatWidgetService);
+				return await this.forkContributedChatSession(sourceSessionResource, undefined, false, chatSessionsService, instantiationService);
 			}
 
 			const chatModel = chatService.getSession(sourceSessionResource);
@@ -163,7 +163,7 @@ export class ForkConversationAction extends Action2 {
 					}
 				}
 			}
-			return await this.forkContributedChatSession(sessionResource, request, true, chatSessionsService, chatWidgetService);
+			return await this.forkContributedChatSession(sessionResource, request, true, chatSessionsService, instantiationService);
 		}
 
 		const chatModel = chatService.getSession(sessionResource);
@@ -241,35 +241,33 @@ export class ForkConversationAction extends Action2 {
 
 	private pendingFork = new Map<string, Promise<void>>();
 
-	private async forkContributedChatSession(sourceSessionResource: URI, request: IChatSessionRequestHistoryItem | undefined, openForkedSessionImmediately: boolean, chatSessionsService: IChatSessionsService, chatWidgetService: IChatWidgetService) {
+	private async forkContributedChatSession(sourceSessionResource: URI, request: IChatSessionRequestHistoryItem | undefined, openForkedSessionImmediately: boolean, chatSessionsService: IChatSessionsService, instantiationService: IInstantiationService) {
 		const pendingKey = `${sourceSessionResource.toString()}@${request?.id ?? 'full'}`;
 		const pending = this.pendingFork.get(pendingKey);
 		if (pending) {
 			return pending;
 		}
 
-		const forkPromise = forkContributedChatSession(sourceSessionResource, request, openForkedSessionImmediately, chatSessionsService, chatWidgetService);
+		const forkPromise = (async () => {
+			const cts = new CancellationTokenSource();
+			try {
+				const forkedItem = await chatSessionsService.forkChatSession(sourceSessionResource, request, cts.token);
+				const open = () => this._openForkedSession(instantiationService, sourceSessionResource, forkedItem.resource);
+				if (openForkedSessionImmediately) {
+					await open();
+				} else {
+					setTimeout(open, 0);
+				}
+			} finally {
+				cts.dispose();
+			}
+		})();
+
 		this.pendingFork.set(pendingKey, forkPromise);
 		try {
 			await forkPromise;
 		} finally {
 			this.pendingFork.delete(pendingKey);
 		}
-	}
-}
-
-async function forkContributedChatSession(sourceSessionResource: URI, request: IChatSessionRequestHistoryItem | undefined, openForkedSessionImmediately: boolean, chatSessionsService: IChatSessionsService, chatWidgetService: IChatWidgetService) {
-	const cts = new CancellationTokenSource();
-	try {
-		const forkedItem = await chatSessionsService.forkChatSession(sourceSessionResource, request, cts.token);
-		if (openForkedSessionImmediately) {
-			await chatWidgetService.openSession(forkedItem.resource, ChatViewPaneTarget);
-		} else {
-			setTimeout(async () => {
-				await chatWidgetService.openSession(forkedItem.resource, ChatViewPaneTarget);
-			}, 0);
-		}
-	} finally {
-		cts.dispose();
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -2438,11 +2438,12 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		const forkedResource = URI.from({ scheme: this._config.sessionType, path: `/${forkedRawId}` });
 		const now = Date.now();
 
+		const forkedTitle = this._getSessionState(forkedSession.toString())?.summary.title;
+		const forkedLabel = forkedTitle || chatModel?.title || localize('agentHost.forkedSessionLabel', "Forked Session");
+
 		return {
 			resource: forkedResource,
-			label: chatModel?.title
-				? localize('chat.forked.title', "Forked: {0}", chatModel.title)
-				: localize('chat.forked.fallbackTitle', "Forked Session"),
+			label: forkedLabel,
 			iconPath: getAgentHostIcon(this._productService),
 			timing: { created: now, lastRequestStarted: now, lastRequestEnded: now },
 		};


### PR DESCRIPTION
Fixes two user-facing bugs when forking an agent-host (AHP) chat from the Agents
window, and one underlying turn-id mismatch that made forks target the wrong
SDK event boundary on restored sessions:

- agentService: stamp "Forked: <source title>" onto the forked session's
  SessionSummary at create time so the sidebar (which renders from
  SessionSummary.title via sessionAdded / sessionSummaryChanged) shows the
  prefix instead of the auto-generated summary inherited from the source.
  Idempotent so re-forking an already-forked session does not double-prefix.
- agentHostSessionHandler: read the forked title back from the freshly
  hydrated session state for the returned IChatSessionItem and drop the
  client-side SessionTitleChanged dispatch.
- chatForkActions: route the contributed-session fork path through
  ForkConversationAction._openForkedSession so the Agents-window override
  applies; inlines the helper to avoid a callback hop.
- localChatSessions.contribution: in the Agents-window override, wait for
  the forked resource to appear and then open it via
  sessionsManagementService.openSession for every session type (not just
  the local VS Code chat type) -- the previous fallback called
  chatWidgetService.openSession, which is a no-op in the Agents window
  because there is no ChatViewPane.
- mapSessionEvents: when restoring a session from disk, seed the
  protocol turn id from the SDK envelope id (the same value
  setTurnEventId persists to turns.event_id). This makes the restored
  state.turns[].id round-trip back to the SDK boundary id that the
  sessions.fork / history.truncate RPCs operate on.
- sessionDatabase: getNextTurnEventId now resolves the source row by
  either turns.id (live request_xxx) OR turns.event_id (SDK envelope id),
  so fork works for both freshly-dispatched and restored turn ids.

Fixes https://github.com/microsoft/vscode/issues/317839

(Commit message generated by Copilot)
