### PR TITLE
fix: remove awaits inside Promise.race in shell integration test

### DIFF
--- a/src/vs/workbench/contrib/terminal/test/browser/xterm/shellIntegrationAddon.integrationTest.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/xterm/shellIntegrationAddon.integrationTest.ts
@@ -221,8 +221,8 @@ suite('Terminal Contrib Shell Integration Recordings', () => {
 						const promptInputModel = capabilities.get(TerminalCapability.CommandDetection)?.promptInputModel;
 						if (promptInputModel && promptInputModel.getCombinedString() !== event.data) {
 							await Promise.race([
-								await timeout(1000).then(() => { throw new Error(`Prompt input change timed out current="${promptInputModel.getCombinedString()}", expected="${event.data}"`); }),
-								await new Promise<void>(r => {
+								timeout(1000).then(() => { throw new Error(`Prompt input change timed out current="${promptInputModel.getCombinedString()}", expected="${event.data}"`); }),
+								new Promise<void>(r => {
 									const d = promptInputModel.onDidChangeInput(() => {
 										if (promptInputModel.getCombinedString() === event.data) {
 											d.dispose();


### PR DESCRIPTION
Awaiting promises before passing them to Promise.race serializes the competitors and defeats the race. Pass the timeout and onDidChangeInput promises directly so the timeout can fire while waiting for input.

@meganrogge @anthonykim1 