### PR TITLE
Fix: Linkify markdown links with no space before `[` when link text contains spaces

### DIFF
--- a/extensions/copilot/src/extension/linkify/common/linkifier.ts
+++ b/extensions/copilot/src/extension/linkify/common/linkifier.ts
@@ -187,6 +187,21 @@ export class Linkifier implements ILinkifier {
 						break;
 					} else if (this._state.accumulationType === LinkifierState.AccumulationType.Word && /\s/.test(part)) {
 						const toAppend = this._state.pendingText + part;
+
+						// Check if the accumulated text contains an unclosed `[` that could be
+						// the start of a markdown link, e.g. "abc[src/main.ts " → split into
+						// "abc" (complete word) + "[src/main.ts " (continue as PotentialLink).
+						const bracketIndex = toAppend.indexOf('[');
+						if (bracketIndex !== -1 && !toAppend.includes(']', bracketIndex)) {
+							const beforeBracket = toAppend.slice(0, bracketIndex);
+							if (beforeBracket) {
+								const r = await this.doLinkifyAndAppend(beforeBracket, {}, token);
+								out.push(...r.parts);
+							}
+							this._state = new LinkifierState.Accumulating(toAppend.slice(bracketIndex), LinkifierState.AccumulationType.PotentialLink);
+							break;
+						}
+
 						this._state = LinkifierState.Default;
 
 						// Check if we've found special tokens

--- a/extensions/copilot/src/extension/linkify/test/node/linkifier.spec.ts
+++ b/extensions/copilot/src/extension/linkify/test/node/linkifier.spec.ts
@@ -5,6 +5,7 @@
 
 import { suite, test } from 'vitest';
 import { CancellationToken } from '../../../../util/vs/base/common/cancellation';
+import { Location, Position, Range } from '../../../../vscodeTypes';
 import { coalesceParts, LinkifiedPart, LinkifyLocationAnchor } from '../../common/linkifiedText';
 import { ILinkifier, LinkifierContext } from '../../common/linkifyService';
 import { assertPartsEqual, createTestLinkifierService, workspaceFile } from './util';
@@ -411,6 +412,77 @@ suite('Stateful Linkifier', () => {
 			]);
 			assertPartsEqual(result, [
 				'a $c [g](x) d$ x',
+			]);
+		}
+	});
+
+	test(`Should handle markdown links immediately preceded by text (no space before '[')`, async () => {
+		{
+			// "abc[file.ts](file.ts)" — no space before `[`, no space in link text
+			const linkifier = createTestLinkifierService(
+				'file.ts',
+				'src/file.ts',
+			).createLinkifier(emptyContext);
+
+			const result = await runLinkifier(linkifier, [
+				'abc[file.ts](file.ts)',
+			]);
+			assertPartsEqual(result, [
+				'abc',
+				new LinkifyLocationAnchor(workspaceFile('file.ts')),
+			]);
+		}
+		{
+			// "abc[src/main.ts 17](src/main.ts#L17)" — no space before `[`, space in link text
+			const linkifier = createTestLinkifierService(
+				'src/main.ts',
+			).createLinkifier(emptyContext);
+
+			const result = await runLinkifier(linkifier, [
+				'abc[src/main.ts 17](src/main.ts#L17)',
+			]);
+			assertPartsEqual(result, [
+				'abc',
+				new LinkifyLocationAnchor(new Location(workspaceFile('src/main.ts'), new Range(new Position(16, 0), new Position(16, 0)))),
+			]);
+		}
+	});
+
+	test(`Should handle markdown links preceded by text when tokenized incrementally`, async () => {
+		{
+			// Simulates streaming tokenization: "abc[src/main.ts " arrives as one token
+			const linkifier = createTestLinkifierService(
+				'src/main.ts',
+			).createLinkifier(emptyContext);
+
+			const parts: string[] = [
+				'abc[src/main.ts ',
+				'17](src/main.ts',
+				'#L17)',
+			];
+
+			const result = await runLinkifier(linkifier, parts);
+			assertPartsEqual(result, [
+				'abc',
+				new LinkifyLocationAnchor(new Location(workspaceFile('src/main.ts'), new Range(new Position(16, 0), new Position(16, 0)))),
+			]);
+		}
+		{
+			// Split before the `[`: "abc" then "[src/main.ts 17](...)"
+			const linkifier = createTestLinkifierService(
+				'src/main.ts',
+			).createLinkifier(emptyContext);
+
+			const parts: string[] = [
+				'abc[src',
+				'/main.ts 17](src/main.ts',
+				'#L17)',
+			];
+
+			const result = await runLinkifier(linkifier, parts);
+			assertPartsEqual(result, [
+				'abc',
+				new LinkifyLocationAnchor(new Location(workspaceFile('src/main.ts'), new Range(new Position(16, 0), new Position(16, 0)))),
 			]);
 		}
 	});


### PR DESCRIPTION
Close #318866

Fix: Linkify markdown links with no space before `[` when link text contains spaces

When a markdown link is immediately preceded by text (e.g. `abc[src/main.ts 17](src/main.ts#L17)`), the Linkifier's whitespace-based tokenization splits the input such that the `[` never lands at the start of a token, preventing the state machine from entering `PotentialLink` mode. This fix detects an unclosed `[` within accumulated `Word` state tokens, splits the text at the bracket, linkifies the prefix as a normal word, and transitions the remainder into `PotentialLink` state.

Created with GitHub Copilot + MiMO-V2.5-Pro

CC: @vijayupadya @justschen 