### PR TITLE
agents: fix duplicate workspace created tasks firing

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/worktreeCreatedTaskDispatcher.ts
+++ b/src/vs/sessions/contrib/chat/browser/worktreeCreatedTaskDispatcher.ts
@@ -72,9 +72,6 @@ export class WorktreeCreatedTaskDispatcher extends Disposable implements IWorkbe
 		const store = new DisposableStore();
 		this._sessionDisposables.set(session.sessionId, store);
 
-		// Wait for the session to finish loading and report an actual worktree,
-		// then dispatch any pending worktreeCreated tasks once. When dispatched,
-		// dispose the per-session subscription store to tear down this autorun.
 		registerAutorunSelfDisposable(store, reader => {
 			if (session.loading.read(reader)) {
 				return;
@@ -85,7 +82,7 @@ export class WorktreeCreatedTaskDispatcher extends Disposable implements IWorkbe
 			if (!session.workspace.read(reader)?.folders.some(folder => !!folder.gitRepository?.workTreeUri)) {
 				return;
 			}
-			this._sessionDisposables.deleteAndDispose(session.sessionId);
+			reader.dispose();
 			this._dispatchWorktreeCreatedTasks(session);
 		});
 	}


### PR DESCRIPTION
agents: fix duplicate workspace created tasks firing

The autorun in WorktreeCreatedTaskDispatcher previously disposed its own store via _sessionDisposables.deleteAndDispose, which could synchronously remove the entry while the autorun was still mid-run and allow a re-entrant _trackSession call to install a fresh autorun that fires again.

- Switch to reader.dispose() so the autorun tears itself down cleanly without racing _sessionDisposables bookkeeping, preventing the worktreeCreated tasks from being dispatched more than once per session.

(Commit message generated by Copilot)