### PR TITLE
Agent feedback fixes

### DIFF
--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorActions.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorActions.ts
@@ -14,9 +14,8 @@ import { GroupsOrder, IEditorGroupsService } from '../../../../workbench/service
 import { ChatContextKeys } from '../../../../workbench/contrib/chat/common/actions/chatContextKeys.js';
 import { CHAT_CATEGORY } from '../../../../workbench/contrib/chat/browser/actions/chatActions.js';
 import { IAgentFeedbackService } from './agentFeedbackService.js';
-import { getActiveResourceCandidates, getSessionForResource } from './agentFeedbackEditorUtils.js';
+import { getActiveResourceCandidates } from './agentFeedbackEditorUtils.js';
 import { Menus } from '../../../browser/menus.js';
-import { IChatEditingService } from '../../../../workbench/contrib/chat/common/editing/chatEditingService.js';
 import { ICodeReviewService } from '../../codeReview/browser/codeReviewService.js';
 import { getSessionEditorComments } from './sessionEditorComments.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
@@ -43,8 +42,6 @@ abstract class AgentFeedbackEditorAction extends Action2 {
 	override async run(accessor: ServicesAccessor): Promise<void> {
 		const editorService = accessor.get(IEditorService);
 		const agentFeedbackService = accessor.get(IAgentFeedbackService);
-		const chatEditingService = accessor.get(IChatEditingService);
-		const sessionsManagementService = accessor.get(ISessionsManagementService);
 		const codeReviewService = accessor.get(ICodeReviewService);
 
 		const editorGroupsService = accessor.get(IEditorGroupsService);
@@ -54,7 +51,7 @@ abstract class AgentFeedbackEditorAction extends Action2 {
 			?? editorService.visibleEditorPanes[0];
 		const candidates = getActiveResourceCandidates(activePane?.input);
 		for (const candidate of candidates) {
-			const sessionResource = getSessionForResource(candidate, chatEditingService, sessionsManagementService)
+			const sessionResource = agentFeedbackService.getSessionForFile(candidate)?.resource
 				?? agentFeedbackService.getMostRecentSessionForResource(candidate);
 			if (!sessionResource) {
 				continue;

--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorInputContribution.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorInputContribution.ts
@@ -11,19 +11,17 @@ import { EditorContributionInstantiation, registerEditorContribution } from '../
 import { ICodeEditorService } from '../../../../editor/browser/services/codeEditorService.js';
 import { EditorOption } from '../../../../editor/common/config/editorOptions.js';
 import { Selection, SelectionDirection } from '../../../../editor/common/core/selection.js';
-import { URI } from '../../../../base/common/uri.js';
 import { addStandardDisposableListener, getWindow, ModifierKeyEmitter } from '../../../../base/browser/dom.js';
 import { KeyCode } from '../../../../base/common/keyCodes.js';
 import { IAgentFeedbackService } from './agentFeedbackService.js';
-import { IChatEditingService } from '../../../../workbench/contrib/chat/common/editing/chatEditingService.js';
-import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
-import { createAgentFeedbackContext, getSessionForResource } from './agentFeedbackEditorUtils.js';
+import { createAgentFeedbackContext } from './agentFeedbackEditorUtils.js';
 import { localize } from '../../../../nls.js';
 import { ActionBar } from '../../../../base/browser/ui/actionbar/actionbar.js';
 import { Action } from '../../../../base/common/actions.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
+import { ISession } from '../../../services/sessions/common/session.js';
 
 class AgentFeedbackInputWidget extends Disposable implements IOverlayWidget {
 
@@ -163,6 +161,14 @@ class AgentFeedbackInputWidget extends Disposable implements IOverlayWidget {
 		this._autoSize();
 	}
 
+	setPlaceholder(placeholder: string): void {
+		if (this._inputElement.placeholder === placeholder) {
+			return;
+		}
+		this._inputElement.placeholder = placeholder;
+		this._autoSize();
+	}
+
 	autoSize(): void {
 		this._autoSize();
 	}
@@ -204,15 +210,13 @@ export class AgentFeedbackEditorInputContribution extends Disposable implements 
 	private _visible = false;
 	private _mouseDown = false;
 	private _suppressSelectionChangeOnce = false;
-	private _sessionResource: URI | undefined;
+	private _session: ISession | undefined;
 	private _pinnedSelection: Selection | undefined;
 	private readonly _widgetListeners = this._store.add(new DisposableStore());
 
 	constructor(
 		private readonly _editor: ICodeEditor,
 		@IAgentFeedbackService private readonly _agentFeedbackService: IAgentFeedbackService,
-		@IChatEditingService private readonly _chatEditingService: IChatEditingService,
-		@ISessionsManagementService private readonly _sessionsManagementService: ISessionsManagementService,
 		@ICodeEditorService private readonly _codeEditorService: ICodeEditorService,
 	) {
 		super();
@@ -273,7 +277,7 @@ export class AgentFeedbackEditorInputContribution extends Disposable implements 
 	private _onModelChanged(): void {
 		this._hide();
 		this._suppressSelectionChangeOnce = false;
-		this._sessionResource = undefined;
+		this._session = undefined;
 	}
 
 	private _onSelectionChanged(): void {
@@ -305,13 +309,13 @@ export class AgentFeedbackEditorInputContribution extends Disposable implements 
 			return;
 		}
 
-		const sessionResource = getSessionForResource(model.uri, this._chatEditingService, this._sessionsManagementService);
-		if (!sessionResource) {
+		const session = this._agentFeedbackService.getSessionForFile(model.uri);
+		if (!session) {
 			this._autoHide();
 			return;
 		}
 
-		this._sessionResource = sessionResource;
+		this._session = session;
 		this._show();
 	}
 
@@ -323,10 +327,18 @@ export class AgentFeedbackEditorInputContribution extends Disposable implements 
 			this._registerWidgetListeners(widget);
 		}
 
+		widget.setPlaceholder(this._getPlaceholder());
 		widget.clearInput();
 		widget.show();
 		this._pinnedSelection = this._editor.getSelection() ?? undefined;
 		this._updatePosition();
+	}
+
+	private _getPlaceholder(): string {
+		const hasChanges = !!this._session && this._session.changes.get().length > 0;
+		return hasChanges
+			? localize('agentFeedback.addFeedback', "Add Feedback")
+			: localize('agentFeedback.addComment', "Add Comment");
 	}
 
 	private _hide(): void {
@@ -502,11 +514,11 @@ export class AgentFeedbackEditorInputContribution extends Disposable implements 
 
 		const selection = this._pinnedSelection ?? this._editor.getSelection();
 		const model = this._editor.getModel();
-		if (!selection || !model || !this._sessionResource) {
+		if (!selection || !model || !this._session) {
 			return false;
 		}
 
-		this._agentFeedbackService.addFeedback(this._sessionResource, model.uri, selection, text, undefined, createAgentFeedbackContext(this._editor, this._codeEditorService, model.uri, selection));
+		this._agentFeedbackService.addFeedback(this._session.resource, model.uri, selection, text, undefined, createAgentFeedbackContext(this._editor, this._codeEditorService, model.uri, selection));
 		this._hideAndRefocusEditor();
 		return true;
 	}
@@ -523,11 +535,11 @@ export class AgentFeedbackEditorInputContribution extends Disposable implements 
 
 		const selection = this._pinnedSelection ?? this._editor.getSelection();
 		const model = this._editor.getModel();
-		if (!selection || !model || !this._sessionResource) {
+		if (!selection || !model || !this._session) {
 			return;
 		}
 
-		const sessionResource = this._sessionResource;
+		const sessionResource = this._session.resource;
 		this._hideAndRefocusEditor();
 		this._agentFeedbackService.addFeedbackAndSubmit(sessionResource, model.uri, selection, text, undefined, createAgentFeedbackContext(this._editor, this._codeEditorService, model.uri, selection));
 	}

--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorOverlay.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorOverlay.ts
@@ -21,12 +21,10 @@ import { IAgentFeedbackService } from './agentFeedbackService.js';
 import { hasSessionAgentFeedback, hasSessionEditorComments, navigateNextFeedbackActionId, navigatePreviousFeedbackActionId, navigationBearingFakeActionId, submitFeedbackActionId } from './agentFeedbackEditorActions.js';
 import { assertType } from '../../../../base/common/types.js';
 import { localize } from '../../../../nls.js';
-import { getActiveResourceCandidates, getSessionForResource } from './agentFeedbackEditorUtils.js';
+import { getActiveResourceCandidates } from './agentFeedbackEditorUtils.js';
 import { Menus } from '../../../browser/menus.js';
-import { IChatEditingService } from '../../../../workbench/contrib/chat/common/editing/chatEditingService.js';
 import { ICodeReviewService } from '../../codeReview/browser/codeReviewService.js';
 import { getSessionEditorComments, hasAgentFeedbackComments } from './sessionEditorComments.js';
-import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 
 class AgentFeedbackActionViewItem extends ActionViewItem {
 
@@ -144,9 +142,7 @@ class AgentFeedbackOverlayController {
 		container: HTMLElement,
 		group: IEditorGroup,
 		@IAgentFeedbackService agentFeedbackService: IAgentFeedbackService,
-		@ISessionsManagementService sessionsManagementService: ISessionsManagementService,
 		@IInstantiationService instaService: IInstantiationService,
-		@IChatEditingService chatEditingService: IChatEditingService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@ICodeReviewService codeReviewService: ICodeReviewService,
 	) {
@@ -189,7 +185,7 @@ class AgentFeedbackOverlayController {
 			let navigationBearings = undefined;
 			let hasAgentFeedback = false;
 			for (const candidate of candidates) {
-				const sessionResource = getSessionForResource(candidate, chatEditingService, sessionsManagementService);
+				const sessionResource = agentFeedbackService.getSessionForFile(candidate)?.resource;
 				if (!sessionResource) {
 					continue;
 				}

--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorUtils.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorUtils.ts
@@ -10,36 +10,10 @@ import { ICodeEditorService } from '../../../../editor/browser/services/codeEdit
 import { IRange } from '../../../../editor/common/core/range.js';
 import { DetailedLineRangeMapping } from '../../../../editor/common/diff/rangeMapping.js';
 import { EditorResourceAccessor, SideBySideEditor } from '../../../../workbench/common/editor.js';
-import { IChatEditingService } from '../../../../workbench/contrib/chat/common/editing/chatEditingService.js';
-import { editingEntriesContainResource } from '../../../../workbench/contrib/chat/browser/sessionResourceMatching.js';
 import { isIChatSessionFileChange2 } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { MultiDiffEditorInput } from '../../../../workbench/contrib/multiDiffEditor/browser/multiDiffEditorInput.js';
 import { ISessionFileChange } from '../../../services/sessions/common/session.js';
-
-/**
- * Find the session that contains the given resource by checking editing sessions,
- * sessions providers, and agent sessions.
- */
-export function getSessionForResource(
-	resourceUri: URI,
-	chatEditingService: IChatEditingService,
-	sessionsManagementService: ISessionsManagementService,
-): URI | undefined {
-	for (const editingSession of chatEditingService.editingSessionsObs.get()) {
-		if (editingEntriesContainResource(editingSession.entries.get(), resourceUri)) {
-			return editingSession.chatSessionResource;
-		}
-	}
-	for (const session of sessionsManagementService.getSessions()) {
-		const changes = session.changes.get();
-		if (changes.some(change => changeMatchesResource(change, resourceUri))) {
-			return session.resource;
-		}
-	}
-
-	return undefined;
-}
 
 export interface IAgentFeedbackContext {
 	readonly codeSelection?: string;

--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorWidgetContribution.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorWidgetContribution.ts
@@ -25,10 +25,9 @@ import { themeColorFromId } from '../../../../platform/theme/common/themeService
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import * as nls from '../../../../nls.js';
 import { IAgentFeedbackService } from './agentFeedbackService.js';
-import { IChatEditingService } from '../../../../workbench/contrib/chat/common/editing/chatEditingService.js';
 import { isIChatSessionFileChange2 } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
-import { createAgentFeedbackContext, getSessionForResource } from './agentFeedbackEditorUtils.js';
+import { createAgentFeedbackContext } from './agentFeedbackEditorUtils.js';
 import { ICodeReviewService, IPRReviewState } from '../../codeReview/browser/codeReviewService.js';
 import { getSessionEditorComments, groupNearbySessionEditorComments, ISessionEditorComment, SessionEditorCommentSource, toSessionEditorCommentId } from './sessionEditorComments.js';
 import { ActionBar } from '../../../../base/browser/ui/actionbar/actionbar.js';
@@ -818,7 +817,6 @@ class AgentFeedbackEditorWidgetContribution extends Disposable implements IEdito
 	constructor(
 		private readonly _editor: ICodeEditor,
 		@IAgentFeedbackService private readonly _agentFeedbackService: IAgentFeedbackService,
-		@IChatEditingService private readonly _chatEditingService: IChatEditingService,
 		@ISessionsManagementService private readonly _sessionsManagementService: ISessionsManagementService,
 		@ICodeReviewService private readonly _codeReviewService: ICodeReviewService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
@@ -864,7 +862,7 @@ class AgentFeedbackEditorWidgetContribution extends Disposable implements IEdito
 			this._sessionResource = undefined;
 			return;
 		}
-		this._sessionResource = getSessionForResource(model.uri, this._chatEditingService, this._sessionsManagementService);
+		this._sessionResource = this._agentFeedbackService.getSessionForFile(model.uri)?.resource;
 	}
 
 	private _rebuildWidgets(

--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackOverviewRulerContribution.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackOverviewRulerContribution.ts
@@ -14,9 +14,6 @@ import { registerColor } from '../../../../platform/theme/common/colorRegistry.j
 import { localize } from '../../../../nls.js';
 import { URI } from '../../../../base/common/uri.js';
 import { IAgentFeedbackService } from './agentFeedbackService.js';
-import { IChatEditingService } from '../../../../workbench/contrib/chat/common/editing/chatEditingService.js';
-import { getSessionForResource } from './agentFeedbackEditorUtils.js';
-import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 
 const overviewRulerAgentFeedbackForeground = registerColor(
 	'editorOverviewRuler.agentFeedbackForeground',
@@ -34,8 +31,6 @@ export class AgentFeedbackOverviewRulerContribution extends Disposable implement
 	constructor(
 		private readonly _editor: ICodeEditor,
 		@IAgentFeedbackService private readonly _agentFeedbackService: IAgentFeedbackService,
-		@IChatEditingService private readonly _chatEditingService: IChatEditingService,
-		@ISessionsManagementService private readonly _sessionsManagementService: ISessionsManagementService,
 	) {
 		super();
 
@@ -57,7 +52,7 @@ export class AgentFeedbackOverviewRulerContribution extends Disposable implement
 			this._sessionResource = undefined;
 			return;
 		}
-		this._sessionResource = getSessionForResource(model.uri, this._chatEditingService, this._sessionsManagementService);
+		this._sessionResource = this._agentFeedbackService.getSessionForFile(model.uri)?.resource;
 	}
 
 	private _updateDecorations(): void {

--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackService.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackService.ts
@@ -5,6 +5,7 @@
 
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
+import { ResourceMap } from '../../../../base/common/map.js';
 import { URI } from '../../../../base/common/uri.js';
 import { IRange } from '../../../../editor/common/core/range.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
@@ -14,12 +15,12 @@ import { IChatEditingService } from '../../../../workbench/contrib/chat/common/e
 import { isIChatSessionFileChange2 } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { editingEntriesContainResource } from '../../../../workbench/contrib/chat/browser/sessionResourceMatching.js';
-import { changeMatchesResource, IAgentFeedbackContext } from './agentFeedbackEditorUtils.js';
+import { changeMatchesResource, getActiveResourceCandidates, IAgentFeedbackContext } from './agentFeedbackEditorUtils.js';
 import { IEditorService } from '../../../../workbench/services/editor/common/editorService.js';
 import { IChatWidgetService } from '../../../../workbench/contrib/chat/browser/chat.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { ICodeReviewSuggestion } from '../../codeReview/browser/codeReviewService.js';
-import { ISessionFileChange } from '../../../services/sessions/common/session.js';
+import { ISession, ISessionFileChange, SessionStatus } from '../../../services/sessions/common/session.js';
 
 // --- Types --------------------------------------------------------------------
 
@@ -145,6 +146,13 @@ export interface IAgentFeedbackService {
 	getFeedback(sessionResource: URI): readonly IAgentFeedback[];
 
 	/**
+	 * Resolve the session that owns the given file resource. Returns the
+	 * session that was active when the file's editor was first opened; if the
+	 * file has never been tracked, falls back to the currently active session.
+	 */
+	getSessionForFile(resourceUri: URI): ISession | undefined;
+
+	/**
 	 * Resolve the most recently updated session that has feedback for a given resource.
 	 */
 	getMostRecentSessionForResource(resourceUri: URI): URI | undefined;
@@ -216,6 +224,9 @@ export class AgentFeedbackService extends Disposable implements IAgentFeedbackSe
 	private _sessionUpdatedSequence = 0;
 	private readonly _navigationAnchorBySession = new Map<string, string>();
 
+	/** fileResource → sessionResource active when the editor for that file was first seen */
+	private readonly _fileToSession = new ResourceMap<URI>();
+
 	constructor(
 		@IChatEditingService private readonly _chatEditingService: IChatEditingService,
 		@ISessionsManagementService private readonly _sessionsManagementService: ISessionsManagementService,
@@ -224,6 +235,34 @@ export class AgentFeedbackService extends Disposable implements IAgentFeedbackSe
 		@ILogService private readonly _logService: ILogService,
 	) {
 		super();
+
+		this._register(this._editorService.onDidVisibleEditorsChange(() => this._trackVisibleEditorResources()));
+		this._trackVisibleEditorResources();
+	}
+
+	private _trackVisibleEditorResources(): void {
+		const activeSession = this._sessionsManagementService.activeSession.get();
+		if (!activeSession) {
+			return;
+		}
+
+		for (const pane of this._editorService.visibleEditorPanes) {
+			for (const candidate of getActiveResourceCandidates(pane.input)) {
+				this._fileToSession.set(candidate, activeSession.resource);
+			}
+		}
+	}
+
+	getSessionForFile(resourceUri: URI): ISession | undefined {
+		const sessionResource = this._fileToSession.get(resourceUri) ?? this._sessionsManagementService.activeSession.get()?.resource;
+		if (!sessionResource) {
+			return undefined;
+		}
+		const session = this._sessionsManagementService.getSession(sessionResource);
+		if (!session || session.status.get() === SessionStatus.Untitled) {
+			return undefined;
+		}
+		return session;
 	}
 
 	addFeedback(sessionResource: URI, resourceUri: URI, range: IRange, text: string, suggestion?: ICodeReviewSuggestion, context?: IAgentFeedbackContext, sourcePRReviewCommentId?: string, kind: AgentFeedbackKind = 'user'): IAgentFeedback {

--- a/src/vs/sessions/contrib/agentFeedback/browser/nullAgentFeedbackService.contribution.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/nullAgentFeedbackService.contribution.ts
@@ -44,6 +44,7 @@ class NullAgentFeedbackService extends Disposable implements IAgentFeedbackServi
 	updateFeedback(_sessionResource: URI, _feedbackId: string, _text: string): void { }
 	addReply(_sessionResource: URI, _feedbackId: string, _replyText: string): void { }
 	getFeedback(_sessionResource: URI): readonly IAgentFeedback[] { return []; }
+	getSessionForFile(_resourceUri: URI): undefined { return undefined; }
 	getMostRecentSessionForResource(_resourceUri: URI): URI | undefined { return undefined; }
 	async revealFeedback(_sessionResource: URI, _feedbackId: string): Promise<void> { }
 	async revealSessionComment(): Promise<void> { }

--- a/src/vs/sessions/contrib/agentFeedback/test/browser/agentFeedbackService.test.ts
+++ b/src/vs/sessions/contrib/agentFeedback/test/browser/agentFeedbackService.test.ts
@@ -5,6 +5,8 @@
 
 import assert from 'assert';
 import { URI } from '../../../../../base/common/uri.js';
+import { Emitter, Event } from '../../../../../base/common/event.js';
+import { ISettableObservable, observableValue } from '../../../../../base/common/observable.js';
 import { Range } from '../../../../../editor/common/core/range.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
@@ -15,6 +17,9 @@ import { IAgentSessionsService } from '../../../../../workbench/contrib/chat/bro
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { NullTelemetryService } from '../../../../../platform/telemetry/common/telemetryUtils.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { IEditorService, IVisibleEditorsChangeEvent } from '../../../../../workbench/services/editor/common/editorService.js';
+import { IActiveSession, ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
+import { ISession, SessionStatus } from '../../../../services/sessions/common/session.js';
 
 function r(startLine: number, endLine: number = startLine): Range {
 	return new Range(startLine, 1, endLine, 1);
@@ -39,6 +44,13 @@ suite('AgentFeedbackService - Ordering', () => {
 		instantiationService.stub(IChatEditingService, new class extends mock<IChatEditingService>() { });
 		instantiationService.stub(IAgentSessionsService, new class extends mock<IAgentSessionsService>() { });
 		instantiationService.stub(ITelemetryService, NullTelemetryService);
+		instantiationService.stub(IEditorService, new class extends mock<IEditorService>() {
+			override onDidVisibleEditorsChange = Event.None;
+			override visibleEditorPanes = [];
+		});
+		instantiationService.stub(ISessionsManagementService, new class extends mock<ISessionsManagementService>() {
+			override activeSession = observableValue<IActiveSession | undefined>('activeSession', undefined);
+		});
 
 		service = store.add(instantiationService.createInstance(AgentFeedbackService));
 		session = URI.parse('test://session/1');
@@ -232,5 +244,159 @@ suite('AgentFeedbackService - Ordering', () => {
 
 		const items = service.getFeedback(session);
 		assert.strictEqual(items[0].replies, undefined);
+	});
+});
+
+suite('AgentFeedbackService - getSessionForFile', () => {
+
+	const store = new DisposableStore();
+
+	let service: IAgentFeedbackService;
+	let visibleEditorsEmitter: Emitter<IVisibleEditorsChangeEvent>;
+	let visiblePanes: any[];
+	let activeSessionObs: ISettableObservable<IActiveSession | undefined>;
+	let sessions: Map<string, ISession>;
+
+	let sessionS1: URI;
+	let sessionS2: URI;
+	let fileA: URI;
+	let fileB: URI;
+
+	function pane(...resources: URI[]): any {
+		// Single resource: a plain editor input with `.resource`.
+		// Two resources: a resource-side-by-side shaped input so that
+		// `EditorResourceAccessor.getOriginalUri(..., supportSideBySide: BOTH)`
+		// surfaces both URIs.
+		const input = resources.length === 1
+			? { resource: resources[0] }
+			: { primary: { resource: resources[0] }, secondary: { resource: resources[1] } };
+		return { input };
+	}
+
+	function makeSession(resource: URI, status: SessionStatus = SessionStatus.InProgress): ISession {
+		return {
+			resource,
+			status: observableValue<SessionStatus>('status', status),
+		} as unknown as ISession;
+	}
+
+	function setActiveSession(s: ISession | undefined): void {
+		activeSessionObs.set(s as IActiveSession | undefined, undefined);
+	}
+
+	function setVisibleEditors(panes: any[]): void {
+		visiblePanes.length = 0;
+		visiblePanes.push(...panes);
+		visibleEditorsEmitter.fire({} as IVisibleEditorsChangeEvent);
+	}
+
+	setup(() => {
+		visibleEditorsEmitter = store.add(new Emitter<IVisibleEditorsChangeEvent>());
+		visiblePanes = [];
+		activeSessionObs = observableValue<IActiveSession | undefined>('activeSession', undefined);
+		sessions = new Map<string, ISession>();
+
+		const instantiationService = store.add(new TestInstantiationService());
+
+		instantiationService.stub(IChatEditingService, new class extends mock<IChatEditingService>() { });
+		instantiationService.stub(IAgentSessionsService, new class extends mock<IAgentSessionsService>() { });
+		instantiationService.stub(ITelemetryService, NullTelemetryService);
+		instantiationService.stub(IEditorService, new class extends mock<IEditorService>() {
+			override onDidVisibleEditorsChange = visibleEditorsEmitter.event;
+			override get visibleEditorPanes() { return visiblePanes; }
+		});
+		instantiationService.stub(ISessionsManagementService, new class extends mock<ISessionsManagementService>() {
+			override activeSession = activeSessionObs;
+			override getSession(resource: URI) { return sessions.get(resource.toString()); }
+		});
+
+		service = store.add(instantiationService.createInstance(AgentFeedbackService));
+
+		sessionS1 = URI.parse('test://session/1');
+		sessionS2 = URI.parse('test://session/2');
+		fileA = URI.parse('file:///a.ts');
+		fileB = URI.parse('file:///b.ts');
+
+		sessions.set(sessionS1.toString(), makeSession(sessionS1));
+		sessions.set(sessionS2.toString(), makeSession(sessionS2));
+	});
+
+	teardown(() => {
+		store.clear();
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('returns undefined when there is no active session and no tracked file', () => {
+		assert.strictEqual(service.getSessionForFile(fileA), undefined);
+	});
+
+	test('untracked file falls back to the active session', () => {
+		setActiveSession(sessions.get(sessionS1.toString())!);
+		assert.strictEqual(service.getSessionForFile(fileA)?.resource.toString(), sessionS1.toString());
+	});
+
+	test('captures active session when file becomes visible', () => {
+		setActiveSession(sessions.get(sessionS1.toString())!);
+		setVisibleEditors([pane(fileA)]);
+
+		assert.strictEqual(service.getSessionForFile(fileA)?.resource.toString(), sessionS1.toString());
+	});
+
+	test('preserves captured session after active session switches without a visibility change', () => {
+		setActiveSession(sessions.get(sessionS1.toString())!);
+		setVisibleEditors([pane(fileA)]);
+
+		// Switch active session without firing a visibility change
+		setActiveSession(sessions.get(sessionS2.toString())!);
+
+		assert.strictEqual(service.getSessionForFile(fileA)?.resource.toString(), sessionS1.toString());
+		// Untracked file falls back to the current active session
+		assert.strictEqual(service.getSessionForFile(fileB)?.resource.toString(), sessionS2.toString());
+	});
+
+	test('most recent visibility wins when the same file is seen under a different session', () => {
+		setActiveSession(sessions.get(sessionS1.toString())!);
+		setVisibleEditors([pane(fileA)]);
+
+		setActiveSession(sessions.get(sessionS2.toString())!);
+		setVisibleEditors([pane(fileA)]);
+
+		assert.strictEqual(service.getSessionForFile(fileA)?.resource.toString(), sessionS2.toString());
+	});
+
+	test('distinct files captured under different active sessions retain their own mapping', () => {
+		setActiveSession(sessions.get(sessionS1.toString())!);
+		setVisibleEditors([pane(fileA)]);
+
+		setActiveSession(sessions.get(sessionS2.toString())!);
+		setVisibleEditors([pane(fileB)]);
+
+		assert.strictEqual(service.getSessionForFile(fileA)?.resource.toString(), sessionS1.toString());
+		assert.strictEqual(service.getSessionForFile(fileB)?.resource.toString(), sessionS2.toString());
+	});
+
+	test('multi-resource editor pane tracks every resource under the active session', () => {
+		setActiveSession(sessions.get(sessionS1.toString())!);
+		setVisibleEditors([pane(fileA, fileB)]);
+
+		assert.strictEqual(service.getSessionForFile(fileA)?.resource.toString(), sessionS1.toString());
+		assert.strictEqual(service.getSessionForFile(fileB)?.resource.toString(), sessionS1.toString());
+	});
+
+	test('returns undefined when the active session has Untitled status', () => {
+		sessions.set(sessionS1.toString(), makeSession(sessionS1, SessionStatus.Untitled));
+		setActiveSession(sessions.get(sessionS1.toString())!);
+
+		assert.strictEqual(service.getSessionForFile(fileA), undefined);
+	});
+
+	test('returns undefined when the mapped session is unknown to the management service', () => {
+		setActiveSession(sessions.get(sessionS1.toString())!);
+		setVisibleEditors([pane(fileA)]);
+		sessions.delete(sessionS1.toString());
+		setActiveSession(undefined);
+
+		assert.strictEqual(service.getSessionForFile(fileA), undefined);
 	});
 });

--- a/src/vs/workbench/test/browser/componentFixtures/fixtureUtils.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/fixtureUtils.ts
@@ -633,6 +633,7 @@ export function createEditorServices(disposables: DisposableStore, options?: Cre
 		updateFeedback: () => { },
 		addReply: () => { },
 		getFeedback: () => [],
+		getSessionForFile: () => undefined,
 		getMostRecentSessionForResource: () => undefined,
 		revealFeedback: async () => { },
 		revealSessionComment: async () => { },


### PR DESCRIPTION
```Copilot Generated Description:``` Add a method to retrieve the session for a file in the agent feedback service and update related components to use this method instead of the removed session retrieval logic. Remove unused imports and dependencies related to chat editing and session management services.

