### PR TITLE
Fix separator for open in agents window action

### DIFF
--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -698,6 +698,7 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 					actionGroup => actionGroup === TitleBarLeadingActionsGroup
 				);
 				actions.primary.push(...leading.primary);
+				actions.primary.push(new Separator());
 			}
 
 			// --- Editor Actions
@@ -710,10 +711,7 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 
 					actions.primary.push(...editorActions.actions.primary);
 					actions.secondary.push(...editorActions.actions.secondary);
-
-					if (editorActions.actions.primary.length > 0) {
-						actions.primary.push(new Separator());
-					}
+					actions.primary.push(new Separator());
 
 					this.editorActionsChangeDisposable.add(editorActions.onDidChange(() => updateToolBarActions()));
 				}

--- a/src/vs/workbench/contrib/chat/electron-browser/agentSessions/media/openInAgents.css
+++ b/src/vs/workbench/contrib/chat/electron-browser/agentSessions/media/openInAgents.css
@@ -9,25 +9,11 @@
 	align-items: center;
 	height: 22px;
 	padding: 0 4px;
-	margin: 0 10px 0 2px;
 	border-radius: 5px;
 	cursor: pointer;
 	color: var(--vscode-titleBar-activeForeground);
 	-webkit-app-region: no-drag;
 	white-space: nowrap;
-	position: relative;
-}
-
-/* Vertical separator drawn as an absolutely positioned pseudo-element so it isn't clipped by any ancestor `overflow: hidden`. */
-.monaco-workbench .open-in-agents-titlebar-widget::after {
-	content: '';
-	position: absolute;
-	right: -6px;
-	top: 4px;
-	bottom: 4px;
-	width: 1px;
-	background-color: var(--vscode-widget-border, rgba(128, 128, 128, 0.5));
-	pointer-events: none;
 }
 
 .monaco-workbench .open-in-agents-titlebar-widget > .open-in-agents-titlebar-widget-icon {


### PR DESCRIPTION
```Copilot Generated Description:``` Adjust the toolbar actions to include a separator for the "Open in Agents" window action. Remove the previous vertical separator styling and ensure a new separator is added consistently in the action group.

