### PR TITLE
Propagate error from zipfile to the caller of read()

### DIFF
--- a/src/vs/base/node/zip.ts
+++ b/src/vs/base/node/zip.ts
@@ -230,6 +230,7 @@ export function extract(zipPath: string, targetPath: string, options: IExtractOp
 function read(zipPath: string, filePath: string): Promise<Readable> {
 	return openZip(zipPath).then(zipfile => {
 		return new Promise<Readable>((c, e) => {
+			zipfile.once('error', e);
 			zipfile.on('entry', (entry: Entry) => {
 				if (entry.fileName === filePath) {
 					openZipStream(zipfile, entry).then(stream => c(stream), err => e(err));

--- a/src/vs/base/node/zip.ts
+++ b/src/vs/base/node/zip.ts
@@ -230,7 +230,7 @@ export function extract(zipPath: string, targetPath: string, options: IExtractOp
 function read(zipPath: string, filePath: string): Promise<Readable> {
 	return openZip(zipPath).then(zipfile => {
 		return new Promise<Readable>((c, e) => {
-			zipfile.once('error', e);
+			zipfile.once('error', err => e(toExtractError(err)));
 			zipfile.on('entry', (entry: Entry) => {
 				if (entry.fileName === filePath) {
 					openZipStream(zipfile, entry).then(stream => c(stream), err => e(err));


### PR DESCRIPTION
This will make errors like #314359 be reported more nicely.
