### PR TITLE
Fix sticky empty sessions list on agents window startup

### DIFF
--- a/src/vs/platform/agentHost/browser/nullAgentHostService.ts
+++ b/src/vs/platform/agentHost/browser/nullAgentHostService.ts
@@ -31,6 +31,7 @@ export class NullAgentHostService implements IAgentHostService {
 
 	readonly authenticationPending: IObservable<boolean> = constObservable(false);
 	setAuthenticationPending(_pending: boolean): void { /* no-op */ }
+	readonly onDidCompleteAuthentication = Event.None;
 
 	get rootState(): IAgentSubscription<RootState> { return notSupported(); }
 

--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -957,6 +957,18 @@ export interface IAgentHostService extends IAgentConnection {
 	/** Update {@link authenticationPending}. Internal — only the auth driver should call this. */
 	setAuthenticationPending(pending: boolean): void;
 
+	/**
+	 * Fires every time an authentication pass completes (driven by
+	 * {@link setAuthenticationPending}(false)), regardless of the sticky
+	 * behavior of {@link authenticationPending}. Consumers use this to
+	 * refresh state that depends on the latest credentials having been
+	 * pushed to the agent host — even when the first auth pass settled
+	 * without resolving a token (e.g. before the user signed in), so the
+	 * `authenticationPending` observable has already locked to `false` and
+	 * subsequent successful passes do not produce a value change.
+	 */
+	readonly onDidCompleteAuthentication: Event<void>;
+
 	restartAgentHost(): Promise<void>;
 
 	startWebSocketServer(): Promise<IAgentHostSocketInfo>;

--- a/src/vs/platform/agentHost/electron-browser/localAgentHostService.ts
+++ b/src/vs/platform/agentHost/electron-browser/localAgentHostService.ts
@@ -64,10 +64,23 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 	readonly authenticationPending: IObservable<boolean> = this._authenticationPending;
 	private _authenticationSettled = false;
 
+	private readonly _onDidCompleteAuthentication = this._register(new Emitter<void>());
+	readonly onDidCompleteAuthentication = this._onDidCompleteAuthentication.event;
+
 	setAuthenticationPending(pending: boolean): void {
 		// Sticky: once the first authentication pass settles, never surface
 		// pending again. Subsequent re-auths (account/session changes, reconnect)
 		// happen silently in the background and should not flicker the UI.
+		//
+		// We still fire `onDidCompleteAuthentication` on every settle so
+		// consumers (e.g. the sessions list) can refresh in response to
+		// fresh credentials being pushed to the agent host — including the
+		// common startup race where the first pass settles with no token
+		// (locking `authenticationPending` to false) and a later pass
+		// finally pushes the real token.
+		if (!pending) {
+			this._onDidCompleteAuthentication.fire();
+		}
 		if (this._authenticationSettled) {
 			return;
 		}

--- a/src/vs/sessions/contrib/providers/agentHost/browser/localAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/localAgentHostSessionsProvider.ts
@@ -100,6 +100,19 @@ export class LocalAgentHostSessionsProvider extends BaseAgentHostSessionsProvide
 			this._cacheInitialized = true;
 			this._refreshSessions();
 		}));
+
+		// Re-fetch sessions whenever an authentication pass completes — even
+		// after the sticky `authenticationPending` observable has locked.
+		// This covers the startup race where the very first auth pass
+		// settles with no token (e.g. the GitHub session isn't ready yet)
+		// and a later pass finally pushes the real token. Without this, the
+		// initial `_refreshSessions()` above silently fails with
+		// `AHP_AUTH_REQUIRED` and we never retry until some unrelated event
+		// (e.g. the user starting a new session) forces a refresh.
+		this._register(this._agentHostService.onDidCompleteAuthentication(() => {
+			this._cacheInitialized = true;
+			this._refreshSessions();
+		}));
 	}
 
 	// -- BaseAgentHostSessionsProvider hooks ---------------------------------

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
@@ -60,8 +60,13 @@ class MockAgentHostService extends mock<IAgentHostService>() {
 
 	private readonly _authenticationPending: ISettableObservable<boolean> = observableValue('authenticationPending', false);
 	override readonly authenticationPending: IObservable<boolean> = this._authenticationPending;
+	private readonly _onDidCompleteAuthentication = new Emitter<void>();
+	override readonly onDidCompleteAuthentication = this._onDidCompleteAuthentication.event;
 	override setAuthenticationPending(pending: boolean): void {
 		this._authenticationPending.set(pending, undefined);
+		if (!pending) {
+			this._onDidCompleteAuthentication.fire();
+		}
 	}
 
 	private _nextSeq = 0;

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Codicon } from '../../../../../../base/common/codicons.js';
+import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { Disposable, DisposableMap, DisposableStore, toDisposable } from '../../../../../../base/common/lifecycle.js';
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { localize } from '../../../../../../nls.js';
@@ -103,6 +104,21 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 			this._authTokenCache.clear();
 			for (const controller of this._listControllers.values()) {
 				controller.resetCache();
+			}
+		}));
+
+		// Re-fetch session lists whenever an authentication pass completes.
+		// This catches the startup race where the first auth pass settles
+		// without resolving a token (e.g. before the GitHub session is
+		// ready); any initial `listSessions()` that fired in parallel will
+		// have rejected with `AHP_AUTH_REQUIRED` and left the chat session
+		// list empty. Once a later pass pushes a real token the controllers
+		// would otherwise stay empty until the user forced a refresh
+		// (e.g. by starting a new session).
+		this._register(this._agentHostService.onDidCompleteAuthentication(() => {
+			for (const controller of this._listControllers.values()) {
+				controller.resetCache();
+				void controller.refresh(CancellationToken.None);
 			}
 		}));
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -81,8 +81,13 @@ class MockAgentHostService extends mock<IAgentHostService>() {
 
 	private readonly _authenticationPending: ISettableObservable<boolean> = observableValue('authenticationPending', false);
 	override readonly authenticationPending: IObservable<boolean> = this._authenticationPending;
+	private readonly _onDidCompleteAuthentication = new Emitter<void>();
+	override readonly onDidCompleteAuthentication = this._onDidCompleteAuthentication.event;
 	override setAuthenticationPending(pending: boolean): void {
 		this._authenticationPending.set(pending, undefined);
+		if (!pending) {
+			this._onDidCompleteAuthentication.fire();
+		}
 	}
 
 	// Track live subscriptions so fireAction can route to them

--- a/src/vs/workbench/services/agentHost/browser/editorRemoteAgentHostServiceClient.ts
+++ b/src/vs/workbench/services/agentHost/browser/editorRemoteAgentHostServiceClient.ts
@@ -50,6 +50,9 @@ export class EditorRemoteAgentHostServiceClient extends Disposable implements IA
 	readonly authenticationPending: IObservable<boolean> = this._authenticationPending;
 	private _authenticationSettled = false;
 
+	private readonly _onDidCompleteAuthentication = this._register(new Emitter<void>());
+	readonly onDidCompleteAuthentication: Event<void> = this._onDidCompleteAuthentication.event;
+
 	private readonly _protocolClient: RemoteAgentHostProtocolClient | undefined;
 	private _connectStarted = false;
 
@@ -115,6 +118,9 @@ export class EditorRemoteAgentHostServiceClient extends Disposable implements IA
 	// ---- IAgentHostService local-only surface (stubs) -----------------------
 
 	setAuthenticationPending(pending: boolean): void {
+		if (!pending) {
+			this._onDidCompleteAuthentication.fire();
+		}
 		if (this._authenticationSettled) {
 			return;
 		}


### PR DESCRIPTION
## Problem

When opening the agents window, the local agent host sessions list sometimes appears empty until the user manually starts a new session, which 'unsticks' the list.

## Root cause

\`LocalAgentHostServiceClient.setAuthenticationPending\` sets a sticky \`_authenticationSettled\` flag on the first settle (to avoid loading-spinner flicker during background re-auths). If \`listSessions\` runs after the agent registers but before \`_githubToken\` is pushed:

1. It fails with \`AHP_AUTH_REQUIRED\` and the error is swallowed.
2. The later real-token auth pass becomes a no-op on the observable (sticky-settled), so no autorun re-fires.
 list stays empty until something else triggers a refresh (e.g. starting a new session).

## Fix

Add a new \`onDidCompleteAuthentication: Event<void>\` to \`IAgentHostService\` that fires on **every** \`setAuthenticationPending(false)\` call, **before** the sticky early-return. Two consumers listen and retry:

- \`LocalAgentHostSessionsProvider\` re-runs \`_refreshSessions\`
- \`AgentHostContribution\` resets each list controller cache and calls \`refresh\`

The sticky observable behavior is  only a new side-channel event is added.preserved 

## Verification

Verified manually via the launch skill with a synthetic skip-first-auth-pass patch that forces the no-token-then-token sequence. Logs showed \`onDidCompleteAuthentication\` firing on every settle and both consumers  even when the observable transition is suppressed by the sticky flag. Sessions list populated as expected.refreshing 

(Written by Copilot)