### PR TITLE
chat: recover from V8 max-string-length when persisting session state

### DIFF
--- a/src/vs/workbench/contrib/chat/common/model/objectMutationLog.ts
+++ b/src/vs/workbench/contrib/chat/common/model/objectMutationLog.ts
@@ -217,6 +217,68 @@ type Entry =
 const LF = VSBuffer.fromString('\n');
 
 /**
+ * Per-string cap applied when {@link stringifyEntryWithFallback} retries after
+ * `JSON.stringify` throws `RangeError: Invalid string length` (V8's max string
+ * length is ~512 MiB on 64-bit). Any single string longer than this is
+ * replaced with a marker on retry. Generous so it triggers only on outliers.
+ */
+export const PERSIST_ENTRY_MAX_STRING_BYTES = 1 * 1024 * 1024;
+
+/**
+ * Total-size budget for the retry of {@link stringifyEntryWithFallback}. Once
+ * cumulative tracked size during serialization exceeds this, remaining values
+ * are replaced with a marker. Sized well under V8's max string length so the
+ * retry is guaranteed to succeed even on pathologically large entries.
+ */
+export const PERSIST_ENTRY_MAX_TOTAL_BYTES = 100 * 1024 * 1024;
+
+const TRUNCATION_MARKER_PREFIX = '[VS Code: value truncated for persistence';
+const TRUNCATION_MARKER_TOTAL = `${TRUNCATION_MARKER_PREFIX}; entry exceeded size budget]`;
+
+/**
+ * Wraps `JSON.stringify(entry)` with a safety net for the V8 max-string-length
+ * limit. The common path is a single `JSON.stringify` with zero overhead. If
+ * stringification throws `RangeError` (the resulting JSON would exceed V8's
+ * ~512 MiB max string length — see microsoft/vscode#308843), retry with a
+ * replacer that truncates oversized strings. Extensions sometimes put very
+ * large content (browser dumps, command output, …) into chat result metadata;
+ * losing the tail of one such value is dramatically better than losing the
+ * entire chat session.
+ */
+export function stringifyEntryWithFallback(entry: unknown): string {
+	try {
+		return JSON.stringify(entry);
+	} catch (e) {
+		if (!(e instanceof RangeError)) {
+			throw e;
+		}
+		return JSON.stringify(entry, makeTruncatingReplacer(PERSIST_ENTRY_MAX_STRING_BYTES, PERSIST_ENTRY_MAX_TOTAL_BYTES));
+	}
+}
+
+/**
+ * Exported for testing only. Builds the stateful `JSON.stringify` replacer
+ * used by {@link stringifyEntryWithFallback} on its retry path.
+ */
+export function makeTruncatingReplacer(maxStringBytes: number, maxTotalBytes: number): (key: string, value: unknown) => unknown {
+	let total = 0;
+	return (_key, val) => {
+		if (total >= maxTotalBytes) {
+			return TRUNCATION_MARKER_TOTAL;
+		}
+		if (typeof val === 'string') {
+			if (val.length > maxStringBytes) {
+				const marker = `${TRUNCATION_MARKER_PREFIX}; original ${val.length} chars]`;
+				total += marker.length + 2;
+				return marker;
+			}
+			total += val.length + 2;
+		}
+		return val;
+	};
+}
+
+/**
  * An implementation of an append-based mutation logger. Given a `Transform`
  * definition of an object, it can recreate it from a file on disk. It is
  * then stateful, and given a `write` call it can update the log in a minimal
@@ -255,7 +317,7 @@ export class ObjectMutationLog<TFrom, TTo> {
 		this._entryCount = 1;
 		this._clearPending();
 		const entry: Entry = { kind: EntryKind.Initial, v: value };
-		return VSBuffer.fromString(JSON.stringify(entry) + '\n');
+		return VSBuffer.fromString(stringifyEntryWithFallback(entry) + '\n');
 	}
 
 	/**
@@ -335,7 +397,7 @@ export class ObjectMutationLog<TFrom, TTo> {
 			this._pendingPrevious = currentValue;
 			this._pendingEntryCount = 1;
 			const entry: Entry = { kind: EntryKind.Initial, v: currentValue };
-			return { op: 'replace', data: VSBuffer.fromString(JSON.stringify(entry) + '\n') };
+			return { op: 'replace', data: VSBuffer.fromString(stringifyEntryWithFallback(entry) + '\n') };
 		}
 
 		// Generate diff entries
@@ -364,7 +426,7 @@ export class ObjectMutationLog<TFrom, TTo> {
 		// Append entries - build string directly
 		let data = '';
 		for (const e of entries) {
-			data += JSON.stringify(e) + '\n';
+			data += stringifyEntryWithFallback(e) + '\n';
 		}
 		return { op: 'append', data: VSBuffer.fromString(data) };
 	}

--- a/src/vs/workbench/contrib/chat/common/model/objectMutationLog.ts
+++ b/src/vs/workbench/contrib/chat/common/model/objectMutationLog.ts
@@ -217,20 +217,26 @@ type Entry =
 const LF = VSBuffer.fromString('\n');
 
 /**
- * Per-string cap applied when {@link stringifyEntryWithFallback} retries after
- * `JSON.stringify` throws `RangeError: Invalid string length` (V8's max string
- * length is ~512 MiB on 64-bit). Any single string longer than this is
- * replaced with a marker on retry. Generous so it triggers only on outliers.
+ * Per-string cap (in UTF-16 code units, matching `string.length`) applied when
+ * {@link stringifyEntryWithFallback} retries after `JSON.stringify` throws
+ * `RangeError: Invalid string length` (V8's max string length is ~512 MiB on
+ * 64-bit). Any single string longer than this is replaced with a marker on
+ * retry. Generous so it triggers only on outliers.
  */
-export const PERSIST_ENTRY_MAX_STRING_BYTES = 1 * 1024 * 1024;
+export const PERSIST_ENTRY_MAX_STRING_CHARS = 1 * 1024 * 1024;
 
 /**
- * Total-size budget for the retry of {@link stringifyEntryWithFallback}. Once
+ * Total-size budget (sum of `string.length` for tracked strings, in UTF-16
+ * code units) for the retry of {@link stringifyEntryWithFallback}. Once the
  * cumulative tracked size during serialization exceeds this, remaining values
- * are replaced with a marker. Sized well under V8's max string length so the
- * retry is guaranteed to succeed even on pathologically large entries.
+ * are replaced with a marker.
+ *
+ * This is an approximation: JSON escaping, property keys, and non-string
+ * payload are not counted, so the actual output may be moderately larger.
+ * The cap is sized well under V8's max string length to leave ample headroom
+ * for that overhead.
  */
-export const PERSIST_ENTRY_MAX_TOTAL_BYTES = 100 * 1024 * 1024;
+export const PERSIST_ENTRY_MAX_TOTAL_CHARS = 100 * 1024 * 1024;
 
 const TRUNCATION_MARKER_PREFIX = '[VS Code: value truncated for persistence';
 const TRUNCATION_MARKER_TOTAL = `${TRUNCATION_MARKER_PREFIX}; entry exceeded size budget]`;
@@ -252,27 +258,32 @@ export function stringifyEntryWithFallback(entry: unknown): string {
 		if (!(e instanceof RangeError)) {
 			throw e;
 		}
-		return JSON.stringify(entry, makeTruncatingReplacer(PERSIST_ENTRY_MAX_STRING_BYTES, PERSIST_ENTRY_MAX_TOTAL_BYTES));
+		return JSON.stringify(entry, makeTruncatingReplacer(PERSIST_ENTRY_MAX_STRING_CHARS, PERSIST_ENTRY_MAX_TOTAL_CHARS));
 	}
 }
 
 /**
  * Exported for testing only. Builds the stateful `JSON.stringify` replacer
  * used by {@link stringifyEntryWithFallback} on its retry path.
+ *
+ * Sizes are tracked in UTF-16 code units (`string.length`); JSON escaping,
+ * property keys, and non-string payload are not counted.
  */
-export function makeTruncatingReplacer(maxStringBytes: number, maxTotalBytes: number): (key: string, value: unknown) => unknown {
+export function makeTruncatingReplacer(maxStringChars: number, maxTotalChars: number): (key: string, value: unknown) => unknown {
 	let total = 0;
 	return (_key, val) => {
-		if (total >= maxTotalBytes) {
-			return TRUNCATION_MARKER_TOTAL;
-		}
 		if (typeof val === 'string') {
-			if (val.length > maxStringBytes) {
-				const marker = `${TRUNCATION_MARKER_PREFIX}; original ${val.length} chars]`;
-				total += marker.length + 2;
-				return marker;
+			let emitted: string;
+			if (val.length > maxStringChars) {
+				emitted = `${TRUNCATION_MARKER_PREFIX}; original ${val.length} chars]`;
+			} else if (total + val.length + 2 > maxTotalChars) {
+				emitted = TRUNCATION_MARKER_TOTAL;
+			} else {
+				total += val.length + 2;
+				return val;
 			}
-			total += val.length + 2;
+			total += emitted.length + 2;
+			return emitted;
 		}
 		return val;
 	};

--- a/src/vs/workbench/contrib/chat/test/common/model/chatSessionOperationLog.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/model/chatSessionOperationLog.test.ts
@@ -685,15 +685,21 @@ suite('ChatSessionOperationLog', () => {
 			assert.strictEqual(parsed.label, 'ok');
 		});
 
-		test('makeTruncatingReplacer respects total budget', () => {
+		test('makeTruncatingReplacer respects total budget without overshooting', () => {
+			const STRING_CAP = 1024 * 1024;
+			const TOTAL_CAP = 1024 * 1024;
 			const medium = 'y'.repeat(200 * 1024); // under per-string cap
 			const obj: any = {};
 			for (let i = 0; i < 20; i++) {
 				obj[`k${i}`] = medium;
 			}
-			const json = JSON.stringify(obj, Adapt.makeTruncatingReplacer(1024 * 1024, 1024 * 1024));
+			const json = JSON.stringify(obj, Adapt.makeTruncatingReplacer(STRING_CAP, TOTAL_CAP));
 			const parsed = JSON.parse(json);
-			assert.ok(json.length < 2 * 1024 * 1024, `expected < 2 MiB, got ${json.length}`);
+			// Sum of preserved strings must not exceed the total budget.
+			const preservedChars = Object.values(parsed)
+				.filter((v): v is string => typeof v === 'string' && v === medium)
+				.reduce((sum, v) => sum + v.length, 0);
+			assert.ok(preservedChars <= TOTAL_CAP, `preserved ${preservedChars} chars exceeded budget ${TOTAL_CAP}`);
 			// Leading keys intact, later replaced with total-budget marker
 			assert.strictEqual(parsed.k0, medium);
 			assert.ok(Object.values(parsed).some(v => typeof v === 'string' && (v as string).includes('entry exceeded size budget')));

--- a/src/vs/workbench/contrib/chat/test/common/model/chatSessionOperationLog.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/model/chatSessionOperationLog.test.ts
@@ -673,4 +673,81 @@ suite('ChatSessionOperationLog', () => {
 			assert.strictEqual(result.count, 2);
 		});
 	});
+
+	suite('persistence size safety net', () => {
+		test('makeTruncatingReplacer truncates an oversized string', () => {
+			const big = 'x'.repeat(2 * 1024 * 1024);
+			const obj = { content: big, label: 'ok' };
+			const json = JSON.stringify(obj, Adapt.makeTruncatingReplacer(1024 * 1024, 10 * 1024 * 1024));
+			const parsed = JSON.parse(json);
+			assert.notStrictEqual(parsed.content, big);
+			assert.ok(parsed.content.startsWith('[VS Code:'));
+			assert.strictEqual(parsed.label, 'ok');
+		});
+
+		test('makeTruncatingReplacer respects total budget', () => {
+			const medium = 'y'.repeat(200 * 1024); // under per-string cap
+			const obj: any = {};
+			for (let i = 0; i < 20; i++) {
+				obj[`k${i}`] = medium;
+			}
+			const json = JSON.stringify(obj, Adapt.makeTruncatingReplacer(1024 * 1024, 1024 * 1024));
+			const parsed = JSON.parse(json);
+			assert.ok(json.length < 2 * 1024 * 1024, `expected < 2 MiB, got ${json.length}`);
+			// Leading keys intact, later replaced with total-budget marker
+			assert.strictEqual(parsed.k0, medium);
+			assert.ok(Object.values(parsed).some(v => typeof v === 'string' && (v as string).includes('entry exceeded size budget')));
+		});
+
+		test('stringifyEntryWithFallback succeeds with no overhead on small entries', () => {
+			const entry = { kind: 0, v: { foo: 'bar', n: 42 } };
+			const out = Adapt.stringifyEntryWithFallback(entry);
+			assert.strictEqual(out, JSON.stringify(entry));
+		});
+
+		test('stringifyEntryWithFallback rethrows non-RangeError', () => {
+			const circular: any = {};
+			circular.self = circular; // JSON.stringify throws TypeError on circulars
+			assert.throws(() => Adapt.stringifyEntryWithFallback(circular), TypeError);
+		});
+
+		test('stringifyEntryWithFallback recovers when JSON.stringify throws RangeError', () => {
+			// Use toJSON to force a RangeError on the first stringify pass,
+			// then succeed on the retry. Avoids needing 500+ MiB of allocations.
+			let calls = 0;
+			const entry = {
+				toJSON() {
+					calls++;
+					if (calls === 1) {
+						throw new RangeError('Invalid string length');
+					}
+					return { content: 'recovered' };
+				},
+			};
+			const out = Adapt.stringifyEntryWithFallback(entry);
+			assert.strictEqual(calls, 2, 'should have been called twice (initial + retry)');
+			assert.deepStrictEqual(JSON.parse(out), { content: 'recovered' });
+		});
+
+		test('stringifyEntryWithFallback applies truncating replacer on RangeError retry', () => {
+			// Same trick, but the recovered payload contains an oversized
+			// string that must be truncated by the replacer on the retry.
+			const big = 'x'.repeat(2 * 1024 * 1024); // 2 MiB, over the 1 MiB per-string cap
+			let calls = 0;
+			const entry = {
+				toJSON() {
+					calls++;
+					if (calls === 1) {
+						throw new RangeError('Invalid string length');
+					}
+					return { content: big, label: 'ok' };
+				},
+			};
+			const out = Adapt.stringifyEntryWithFallback(entry);
+			const parsed = JSON.parse(out);
+			assert.notStrictEqual(parsed.content, big);
+			assert.ok(parsed.content.startsWith('[VS Code:'), `unexpected: ${parsed.content.slice(0, 80)}`);
+			assert.strictEqual(parsed.label, 'ok');
+		});
+	});
 });


### PR DESCRIPTION
Fixes #308843.

## Problem

`JSON.stringify` of the full chat session state could throw `RangeError: Invalid string length` during compaction, losing the entire chat session. The session-store mutation log compacts every 1024 entries by writing a single `Initial` entry containing the full serialized state; with multiple large tool result values stored under `IChatAgentResult.metadata.toolCallResults` (notably Copilot's `read_page` tool, whose results can be ~60 MiB each), the combined JSON exceeded V8's ~512 MiB max string length.

Field forensics in the issue showed one tool result alone at ~61 MiB and a JSONL log file at ~640 MiB with one line at ~503 MiB before serialization eventually failed.

## Fix

Wrap the three `JSON.stringify(entry)` call sites in `ObjectMutationLog` with `stringifyEntryWithFallback`, which:

- **Common path**: a single `JSON.stringify` — zero overhead.
- **Failure path**: on `RangeError`, retry with a truncating replacer that caps individual strings at 1 MiB and the total tracked size at 100 MiB. Oversized values are replaced with a clear marker (e.g. `[VS Code: value truncated for persistence; original 314572800 chars]`).
- Non-`RangeError` exceptions (circular refs, etc.) propagate unchanged.

The fix lives at the engine level rather than in the chat schema, so:
- The common path doesn't pay any pre-walk cost.
- It's generic — defends against any future schema field that could grow unbounded, not just `result`.
- The schema and live `ChatModel` are unchanged.

Copilot's prompt path already replaces tool results > 8 KiB with on-disk file references when building prompts, so a truncated persisted copy has no functional impact on conversation resume — only the unbounded "for the record" copy is affected.

## Notes for reviewers

- Cap sizing rationale: 1 MiB per string is dramatically larger than any legitimate single string in chat state; 100 MiB total leaves ample headroom under V8's ~512 MiB limit even on extreme sessions.
- Tests use a `toJSON()` hook to trigger a real `RangeError` mid-stringify without requiring 300+ MiB allocations — fast (<10 ms) and exercises the actual catch+retry path. I also verified end-to-end against an actual V8 RangeError locally (allocating a 300 MiB string referenced twice in an object) and confirmed full recovery through `createInitial` + `read` round-trip.
- Truncation only takes effect on actual failure; sessions in normal use are byte-for-byte identical to before.

(Written by Copilot)