### PR TITLE
Report Anthropic thinking_tokens as reasoning tokens in telemetry

### DIFF
--- a/extensions/copilot/src/platform/endpoint/node/messagesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/messagesApi.ts
@@ -70,6 +70,9 @@ interface AnthropicStreamEvent {
 				ephemeral_1h_input_tokens?: number;
 				ephemeral_5m_input_tokens?: number;
 			};
+			output_tokens_details?: {
+				thinking_tokens?: number;
+			};
 		};
 	};
 	index?: number;
@@ -99,6 +102,9 @@ interface AnthropicStreamEvent {
 		cache_creation?: {
 			ephemeral_1h_input_tokens?: number;
 			ephemeral_5m_input_tokens?: number;
+		};
+		output_tokens_details?: {
+			thinking_tokens?: number;
 		};
 	};
 	copilot_usage?: {
@@ -677,6 +683,13 @@ interface AnthropicCompletionState {
 	readonly cacheCreation1hTokens: number | undefined;
 	readonly cacheCreation5mTokens: number | undefined;
 	readonly cacheReadTokens: number;
+	/**
+	 * Anthropic-reported thinking (reasoning) tokens, a subset of
+	 * `output_tokens`. Surfaced as `completion_tokens_details.reasoning_tokens`
+	 * to match the OpenAI/CAPI naming used elsewhere in telemetry. Undefined
+	 * when the server did not include `output_tokens_details`.
+	 */
+	readonly thinkingTokens: number | undefined;
 	readonly requestId: string;
 	readonly ghRequestId: string;
 	readonly serverExperiments: string;
@@ -744,7 +757,7 @@ function buildAnthropicCompletion(state: AnthropicCompletionState, logService: I
 					: {}),
 			},
 			completion_tokens_details: {
-				reasoning_tokens: 0,
+				reasoning_tokens: state.thinkingTokens ?? 0,
 				accepted_prediction_tokens: 0,
 				rejected_prediction_tokens: 0,
 			},
@@ -797,6 +810,9 @@ type AnthropicNonStreamingResponse =
 			cache_creation?: {
 				ephemeral_1h_input_tokens?: number;
 				ephemeral_5m_input_tokens?: number;
+			};
+			output_tokens_details?: {
+				thinking_tokens?: number;
 			};
 		};
 	}
@@ -933,6 +949,7 @@ export async function processNonStreamingResponseFromMessagesEndpoint(
 			cacheCreation1hTokens: usage?.cache_creation?.ephemeral_1h_input_tokens,
 			cacheCreation5mTokens: usage?.cache_creation?.ephemeral_5m_input_tokens,
 			cacheReadTokens: usage?.cache_read_input_tokens ?? 0,
+			thinkingTokens: usage?.output_tokens_details?.thinking_tokens,
 			requestId,
 			ghRequestId,
 			serverExperiments,
@@ -983,6 +1000,7 @@ export class AnthropicMessagesProcessor {
 	private cacheCreation1hTokens: number | undefined;
 	private cacheCreation5mTokens: number | undefined;
 	private cacheReadTokens: number = 0;
+	private thinkingTokens: number | undefined;
 	private copilotUsage?: { total_nano_aiu: number };
 	private contextManagementResponse?: ContextManagementResponse;
 	private stopReason: string | undefined;
@@ -1065,6 +1083,7 @@ export class AnthropicMessagesProcessor {
 					this.cacheCreation1hTokens = chunk.message.usage.cache_creation?.ephemeral_1h_input_tokens ?? this.cacheCreation1hTokens;
 					this.cacheCreation5mTokens = chunk.message.usage.cache_creation?.ephemeral_5m_input_tokens ?? this.cacheCreation5mTokens;
 					this.cacheReadTokens = chunk.message.usage.cache_read_input_tokens ?? 0;
+					this.thinkingTokens = chunk.message.usage.output_tokens_details?.thinking_tokens ?? this.thinkingTokens;
 				}
 				return;
 			case 'content_block_start':
@@ -1177,6 +1196,7 @@ export class AnthropicMessagesProcessor {
 					this.cacheCreation1hTokens = chunk.usage.cache_creation?.ephemeral_1h_input_tokens ?? this.cacheCreation1hTokens;
 					this.cacheCreation5mTokens = chunk.usage.cache_creation?.ephemeral_5m_input_tokens ?? this.cacheCreation5mTokens;
 					this.cacheReadTokens = chunk.usage.cache_read_input_tokens ?? this.cacheReadTokens;
+					this.thinkingTokens = chunk.usage.output_tokens_details?.thinking_tokens ?? this.thinkingTokens;
 				}
 				if (chunk.copilot_usage && typeof chunk.copilot_usage.total_nano_aiu === 'number') {
 					this.copilotUsage = chunk.copilot_usage;
@@ -1272,6 +1292,7 @@ export class AnthropicMessagesProcessor {
 					cacheCreation1hTokens: this.cacheCreation1hTokens,
 					cacheCreation5mTokens: this.cacheCreation5mTokens,
 					cacheReadTokens: this.cacheReadTokens,
+					thinkingTokens: this.thinkingTokens,
 					requestId: this.requestId,
 					ghRequestId: this.ghRequestId,
 					serverExperiments: this.serverExperiments,

--- a/extensions/copilot/src/platform/endpoint/test/node/messagesApi.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/test/node/messagesApi.spec.ts
@@ -1479,6 +1479,67 @@ suite('processNonStreamingResponseFromMessagesEndpoint', () => {
 		expect(details?.anthropic_cache_creation).toBeUndefined();
 	});
 
+	test('surfaces thinking_tokens as completion_tokens_details.reasoning_tokens', async () => {
+		const response = createNonStreamingResponse({
+			id: 'msg_thinking',
+			type: 'message',
+			role: 'assistant',
+			content: [{ type: 'text', text: 'thought' }],
+			model: 'claude-sonnet-4-20250514',
+			stop_reason: 'end_turn',
+			usage: {
+				input_tokens: 10,
+				output_tokens: 1140,
+				output_tokens_details: { thinking_tokens: 580 },
+			},
+		});
+
+		const telemetryData = TelemetryData.createAndMarkAsIssued();
+		const completions = await processNonStreamingResponseFromMessagesEndpoint(
+			new NullTelemetryService(),
+			new TestLogService(),
+			response,
+			async () => undefined,
+			telemetryData,
+		);
+
+		const results = [];
+		for await (const c of completions) {
+			results.push(c);
+		}
+
+		expect(results[0].usage?.completion_tokens).toBe(1140);
+		expect(results[0].usage?.completion_tokens_details?.reasoning_tokens).toBe(580);
+	});
+
+	test('reasoning_tokens defaults to 0 when output_tokens_details is absent', async () => {
+		const response = createNonStreamingResponse({
+			id: 'msg_no_thinking',
+			type: 'message',
+			role: 'assistant',
+			content: [{ type: 'text', text: 'no thinking' }],
+			model: 'claude-sonnet-4-20250514',
+			stop_reason: 'end_turn',
+			usage: { input_tokens: 10, output_tokens: 50 },
+		});
+
+		const telemetryData = TelemetryData.createAndMarkAsIssued();
+		const completions = await processNonStreamingResponseFromMessagesEndpoint(
+			new NullTelemetryService(),
+			new TestLogService(),
+			response,
+			async () => undefined,
+			telemetryData,
+		);
+
+		const results = [];
+		for await (const c of completions) {
+			results.push(c);
+		}
+
+		expect(results[0].usage?.completion_tokens_details?.reasoning_tokens).toBe(0);
+	});
+
 	test('rejects on malformed JSON', async () => {
 		const response = Response.fromText(200, 'OK', createNonStreamingHeaders(), 'not json at all', 'node-fetch');
 		const telemetryData = TelemetryData.createAndMarkAsIssued();
@@ -1746,5 +1807,44 @@ suite('AnthropicMessagesProcessor streaming cache_creation', () => {
 		const details = completion!.usage?.prompt_tokens_details;
 		expect(details?.anthropic_cache_creation?.ephemeral_1h_input_tokens).toBe(5000);
 		expect(details?.anthropic_cache_creation?.ephemeral_5m_input_tokens).toBe(10000);
+	});
+
+	test('streaming thinking_tokens from message_delta surfaces as reasoning_tokens', () => {
+		// Anthropic typically reports thinking_tokens in the final message_delta
+		// (after the cumulative output_tokens count is known). Matches the
+		// observed payload shape from CAPI/Anthropic 1P/Bedrock/Vertex.
+		const processor = makeProcessor();
+		const noop = async () => undefined;
+
+		processor.push({
+			type: 'message_start',
+			message: {
+				id: 'msg_thinking_stream',
+				type: 'message',
+				role: 'assistant',
+				content: [],
+				model: 'claude-sonnet-4-20250514',
+				stop_reason: null,
+				stop_sequence: null,
+				usage: {
+					input_tokens: 5,
+					output_tokens: 1,
+				},
+			},
+		}, noop);
+
+		processor.push({
+			type: 'message_delta',
+			delta: { type: 'message_delta', stop_reason: 'end_turn' },
+			usage: {
+				output_tokens: 2024,
+				input_tokens: 5,
+				output_tokens_details: { thinking_tokens: 639 },
+			},
+		}, noop);
+
+		const completion = processor.push({ type: 'message_stop' }, noop);
+		expect(completion!.usage?.completion_tokens).toBe(2024);
+		expect(completion!.usage?.completion_tokens_details?.reasoning_tokens).toBe(639);
 	});
 });


### PR DESCRIPTION

This change parses `output_tokens_details.thinking_tokens` from both streaming (`message_start` / `message_delta`) and non-streaming responses and surfaces it as the standard `completion_tokens_details.reasoning_tokens` field on `APIUsage`, matching the Chat Completions and Responses API paths.

Because the standard field is used, existing reporting picks it up automatically:
- `response.success` telemetry `reasoningTokens` measurement
- OTel inference span `gen_ai.usage.reasoning_tokens` / `gen_ai.usage.reasoning_output_tokens`
- engine messages GH telemetry and per-tool-call-round token accounting
