### PR TITLE
Allow summarization threshold setting to be a ratio or token count

### DIFF
--- a/extensions/copilot/package.nls.json
+++ b/extensions/copilot/package.nls.json
@@ -396,7 +396,7 @@
 	"github.copilot.config.agent.largeToolResultsToDisk.thresholdBytes": "The size threshold in bytes above which tool results are written to disk. Only applies when largeToolResultsToDisk.enabled is true.",
 	"github.copilot.config.instantApply.shortContextModelName": "Model name for short context instant apply.",
 	"github.copilot.config.instantApply.shortContextLimit": "Token limit for short context instant apply.",
-	"github.copilot.config.summarizeAgentConversationHistoryThreshold": "Threshold for compacting agent conversation history.",
+	"github.copilot.config.summarizeAgentConversationHistoryThreshold": "Threshold at which agent conversation history is compacted. Specify either a ratio of the model's context window (a value between `0` and `1`, e.g. `0.8` to compact at 80%) or an absolute token count (a value of `100` or greater, e.g. `60000`). Leave unset to use the model's full context window.",
 	"github.copilot.config.agentHistorySummarizationMode": "Mode for agent history summarization.",
 	"github.copilot.config.useResponsesApiTruncation": "Use Responses API for truncation.",
 	"github.copilot.config.enableReadFileV2": "Enable version 2 of the read file tool.",

--- a/extensions/copilot/package.nls.json
+++ b/extensions/copilot/package.nls.json
@@ -396,7 +396,7 @@
 	"github.copilot.config.agent.largeToolResultsToDisk.thresholdBytes": "The size threshold in bytes above which tool results are written to disk. Only applies when largeToolResultsToDisk.enabled is true.",
 	"github.copilot.config.instantApply.shortContextModelName": "Model name for short context instant apply.",
 	"github.copilot.config.instantApply.shortContextLimit": "Token limit for short context instant apply.",
-	"github.copilot.config.summarizeAgentConversationHistoryThreshold": "Threshold at which agent conversation history is compacted. Specify either a ratio of the model's context window (a value between `0` and `1`, e.g. `0.8` to compact at 80%) or an absolute token count (a value of `100` or greater, e.g. `60000`). Leave unset to use the model's full context window.",
+	"github.copilot.config.summarizeAgentConversationHistoryThreshold": "Threshold at which agent conversation history is compacted. Specify either a ratio of the model's context window (a value greater than `0` and at most `1`, e.g. `0.8` to compact at 80%) or an absolute token count (a value of `100` or greater, e.g. `60000`). Leave unset to use the model's full context window.",
 	"github.copilot.config.agentHistorySummarizationMode": "Mode for agent history summarization.",
 	"github.copilot.config.useResponsesApiTruncation": "Use Responses API for truncation.",
 	"github.copilot.config.enableReadFileV2": "Enable version 2 of the read file tool.",

--- a/extensions/copilot/src/extension/intents/node/agentIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/agentIntent.ts
@@ -134,7 +134,7 @@ export function resolveSummarizeThresholdTokens(value: number | undefined, effec
 		return Math.max(1, Math.floor(effectiveMaxTokens * value));
 	}
 	if (value < 100) {
-		throw new Error(`Setting github.copilot.${settingId} is too low; use a ratio between 0 and 1 (e.g. 0.8 for 80%) or an absolute token count of at least 100.`);
+		throw new Error(`Setting github.copilot.${settingId} is too low; use a ratio in the range (0, 1] (e.g. 0.8 for 80%) or an absolute token count of at least 100.`);
 	}
 	// Absolute token count.
 	return value;

--- a/extensions/copilot/src/extension/intents/node/agentIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/agentIntent.ts
@@ -104,6 +104,42 @@ export function isBackgroundTodoAgentEnabled(configurationService: IConfiguratio
 		&& !isTodoToolExplicitlyEnabled(request);
 }
 
+/**
+ * Resolve the configured summarization threshold into an absolute token count.
+ *
+ * The setting accepts two interchangeable units so users can express the
+ * compaction trigger however is most natural:
+ *
+ *  - **Ratio** (`0 < value <= 1`): a fraction of the model's context window,
+ *    e.g. `0.8` means "compact at 80% of the window". This is resolved against
+ *    `effectiveMaxTokens` so it automatically tracks model/context-size changes.
+ *  - **Absolute tokens** (`value >= 100`): a fixed token budget, e.g. `60000`.
+ *
+ * Values in the ambiguous `(1, 100)` gap (too large to be a sensible ratio, too
+ * small to be a useful token budget) are rejected so a typo like `80` — which a
+ * user likely meant as "80%" — fails loudly instead of silently compacting after
+ * 80 tokens.
+ *
+ * Returns `undefined` when unset (or non-positive), meaning "use the model's full
+ * context window".
+ *
+ * @internal - exported for testing
+ */
+export function resolveSummarizeThresholdTokens(value: number | undefined, effectiveMaxTokens: number, settingId: string): number | undefined {
+	if (typeof value !== 'number' || value <= 0) {
+		return undefined;
+	}
+	if (value <= 1) {
+		// Ratio of the model's context window.
+		return Math.max(1, Math.floor(effectiveMaxTokens * value));
+	}
+	if (value < 100) {
+		throw new Error(`Setting github.copilot.${settingId} is too low; use a ratio between 0 and 1 (e.g. 0.8 for 80%) or an absolute token count of at least 100.`);
+	}
+	// Absolute token count.
+	return value;
+}
+
 export const getAgentTools = async (accessor: ServicesAccessor, request: vscode.ChatRequest, model?: IChatEndpoint) => {
 	const toolsService = accessor.get<IToolsService>(IToolsService);
 	const testService = accessor.get<ITestProvider>(ITestProvider);
@@ -549,9 +585,6 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 		const toolTokens = tools?.length ? await this.endpoint.acquireTokenizer().countToolTokens(tools) : 0;
 
 		const summarizeThresholdOverride = this.configurationService.getConfig<number | undefined>(ConfigKey.Advanced.SummarizeAgentConversationHistoryThreshold);
-		if (typeof summarizeThresholdOverride === 'number' && summarizeThresholdOverride < 100 && summarizeThresholdOverride > 0) {
-			throw new Error(`Setting github.copilot.${ConfigKey.Advanced.SummarizeAgentConversationHistoryThreshold.id} is too low`);
-		}
 
 		// Apply context size override if configured by the user in the model picker
 		const configuredContextSize = this.request.modelConfiguration?.contextSize;
@@ -559,8 +592,12 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 			? configuredContextSize
 			: this.endpoint.modelMaxPromptTokens;
 
+		// The override may be expressed as a ratio of the context window (0-1) or
+		// an absolute token count (>= 100); resolve it to tokens before clamping.
+		const summarizeThresholdTokens = resolveSummarizeThresholdTokens(summarizeThresholdOverride, effectiveMaxTokens, ConfigKey.Advanced.SummarizeAgentConversationHistoryThreshold.id);
+
 		const baseBudget = Math.min(
-			this.configurationService.getConfig<number | undefined>(ConfigKey.Advanced.SummarizeAgentConversationHistoryThreshold) ?? effectiveMaxTokens,
+			summarizeThresholdTokens ?? effectiveMaxTokens,
 			effectiveMaxTokens
 		);
 		const useTruncation = this.endpoint.apiType === 'responses' && this.configurationService.getConfig(ConfigKey.Advanced.UseResponsesApiTruncation);

--- a/extensions/copilot/src/extension/intents/node/test/summarizeThreshold.spec.ts
+++ b/extensions/copilot/src/extension/intents/node/test/summarizeThreshold.spec.ts
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, test } from 'vitest';
+import { ConfigKey } from '../../../../platform/configuration/common/configurationService';
+import { resolveSummarizeThresholdTokens } from '../agentIntent';
+
+describe('resolveSummarizeThresholdTokens', () => {
+	const settingId = ConfigKey.Advanced.SummarizeAgentConversationHistoryThreshold.id;
+	const maxTokens = 200_000;
+
+	test('undefined / non-positive values mean "use full window"', () => {
+		expect(resolveSummarizeThresholdTokens(undefined, maxTokens, settingId)).toBe(undefined);
+		expect(resolveSummarizeThresholdTokens(0, maxTokens, settingId)).toBe(undefined);
+		expect(resolveSummarizeThresholdTokens(-1, maxTokens, settingId)).toBe(undefined);
+	});
+
+	test('ratio values (0 < value <= 1) resolve against the effective window', () => {
+		expect(resolveSummarizeThresholdTokens(0.8, maxTokens, settingId)).toBe(160_000);
+		expect(resolveSummarizeThresholdTokens(0.5, maxTokens, settingId)).toBe(100_000);
+		// value === 1 is a valid ratio (the whole window), not an absolute count.
+		expect(resolveSummarizeThresholdTokens(1, maxTokens, settingId)).toBe(maxTokens);
+		// Always at least 1 token so the budget never collapses to 0.
+		expect(resolveSummarizeThresholdTokens(0.000001, 100, settingId)).toBe(1);
+	});
+
+	test('absolute token counts (value >= 100) are passed through unchanged', () => {
+		expect(resolveSummarizeThresholdTokens(60_000, maxTokens, settingId)).toBe(60_000);
+		expect(resolveSummarizeThresholdTokens(100, maxTokens, settingId)).toBe(100);
+	});
+
+	test('ambiguous values in (1, 100) are rejected', () => {
+		expect(() => resolveSummarizeThresholdTokens(80, maxTokens, settingId)).toThrow(/too low/);
+		expect(() => resolveSummarizeThresholdTokens(99, maxTokens, settingId)).toThrow(/too low/);
+	});
+});


### PR DESCRIPTION
`chat.advanced.summarizeAgentConversationHistoryThreshold` previously only accepted an absolute token count. This makes it accept **either**:

- a **ratio** of the model's context window — `0 < value <= 1` (e.g. `0.8` to compact at 80%), or
- an **absolute token count** — `value >= 100` (e.g. `60000`).

A new `resolveSummarizeThresholdTokens()` helper resolves the configured value against the effective context window. Ratios automatically track model / context-size changes, so users no longer have to recompute a token number when the window grows.

Values in the ambiguous `(1, 100)` gap are rejected with a clear error, so a typo like `80` (meant as 80%) fails loudly instead of silently compacting after 80 tokens.

Tests: 4 new specs in `summarizeThreshold.spec.ts` covering undefined/non-positive → undefined, ratio resolution, absolute passthrough, and rejection of the ambiguous range. All pass.