### PR TITLE
chat: avoid session switch height flicker

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -168,7 +168,7 @@ interface IItemHeightChangeParams {
 }
 
 export function shouldScheduleInitialHeightChange(normalizedHeight: number, allocatedHeight: number | undefined): boolean {
-	return typeof allocatedHeight !== 'number' || normalizedHeight > Math.ceil(allocatedHeight);
+	return typeof allocatedHeight !== 'number' || normalizedHeight > allocatedHeight;
 }
 
 const forceVerboseLayoutTracing = false

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -139,6 +139,8 @@ export interface IChatListItemTemplate {
 	dragHandle?: HTMLElement;
 
 	readonly rowContainer: HTMLElement;
+	/** Height allocated by the list for the currently rendered row. */
+	allocatedHeight?: number;
 	readonly titleToolbar?: MenuWorkbenchToolBar;
 	readonly header?: HTMLElement;
 	readonly footerToolbar: MenuWorkbenchToolBar;
@@ -163,6 +165,10 @@ export interface IChatListItemTemplate {
 interface IItemHeightChangeParams {
 	element: ChatTreeItem;
 	height: number;
+}
+
+export function shouldScheduleInitialHeightChange(normalizedHeight: number, allocatedHeight: number | undefined): boolean {
+	return typeof allocatedHeight !== 'number' || normalizedHeight > Math.ceil(allocatedHeight);
 }
 
 const forceVerboseLayoutTracing = false
@@ -363,6 +369,12 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		if (typeof originalStoredHeight === 'number') {
 			this._onDidChangeItemHeight.fire({ element: template.currentElement, height: normalizedHeight });
 		} else {
+			// First measurements that already fit are just initialization. Only schedule
+			// a first update when the row would otherwise clip newly rendered content.
+			if (!shouldScheduleInitialHeightChange(normalizedHeight, template.allocatedHeight)) {
+				return;
+			}
+
 			const element = template.currentElement;
 			const scheduledHeight = normalizedHeight;
 			dom.scheduleAtNextAnimationFrame(dom.getWindow(template.rowContainer), () => {
@@ -670,7 +682,8 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		return template;
 	}
 
-	renderElement(node: ITreeNode<ChatTreeItem, FuzzyScore>, index: number, templateData: IChatListItemTemplate): void {
+	renderElement(node: ITreeNode<ChatTreeItem, FuzzyScore>, index: number, templateData: IChatListItemTemplate, details?: IListElementRenderDetails): void {
+		templateData.allocatedHeight = details?.height;
 		this._elementBeingRendered = node.element;
 		try {
 			this.renderChatTreeItem(node.element, index, templateData);

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatListRenderer.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatListRenderer.test.ts
@@ -21,7 +21,7 @@ suite('ChatListRenderer', () => {
 			], [
 				true,
 				false,
-				false,
+				true,
 				true,
 				false,
 			]);

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatListRenderer.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatListRenderer.test.ts
@@ -21,9 +21,9 @@ suite('ChatListRenderer', () => {
 			], [
 				true,
 				false,
-				true,
-				true,
 				false,
+				true,
+				true,
 			]);
 		});
 	});

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatListRenderer.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatListRenderer.test.ts
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { shouldScheduleInitialHeightChange } from '../../../browser/widget/chatListRenderer.js';
+
+suite('ChatListRenderer', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	suite('shouldScheduleInitialHeightChange', () => {
+		test('only schedules first measurement updates when needed to avoid clipping', () => {
+			assert.deepStrictEqual([
+				shouldScheduleInitialHeightChange(120, undefined),
+				shouldScheduleInitialHeightChange(120, 120),
+				shouldScheduleInitialHeightChange(120, 120.1),
+				shouldScheduleInitialHeightChange(121, 120),
+				shouldScheduleInitialHeightChange(121, 120.1),
+			], [
+				true,
+				false,
+				false,
+				true,
+				false,
+			]);
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- avoid deferred first-measurement chat row height updates when the row already fits its allocated height
- preserve the cutoff fix by still scheduling an update when the initial measured height would clip
- add focused unit coverage for the height scheduling decision

## Validation
- npm run compile-check-ts-native -- --pretty false
- node --experimental-strip-types build/hygiene.ts src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts src/vs/workbench/contrib/chat/test/browser/widget/chatListRenderer.test.ts
- npm run valid-layers-check
- npm run test-browser-no-install -- --run src/vs/workbench/contrib/chat/test/browser/widget/chatListRenderer.test.ts --grep "shouldScheduleInitialHeightChange"

(Written by Copilot)