### PR TITLE
fix: Add selection to next Find match does not work with Regex Find Mode

### DIFF
--- a/src/vs/editor/contrib/multicursor/browser/multicursor.ts
+++ b/src/vs/editor/contrib/multicursor/browser/multicursor.ts
@@ -286,7 +286,7 @@ export class MultiCursorSession {
 		//  - and the search string is non-empty
 		if (!editor.hasTextFocus() && findState.isRevealed && findState.searchString.length > 0) {
 			// Find widget owns what is searched for
-			return new MultiCursorSession(editor, findController, false, findState.searchString, findState.wholeWord, findState.matchCase, null);
+			return new MultiCursorSession(editor, findController, false, findState.searchString, findState.wholeWord, findState.matchCase, findState.isRegex, null);
 		}
 
 		// Otherwise, the selection gives the search text, and the find widget gives the search settings
@@ -294,14 +294,17 @@ export class MultiCursorSession {
 		let isDisconnectedFromFindController = false;
 		let wholeWord: boolean;
 		let matchCase: boolean;
+		let isRegex: boolean;
 		const selections = editor.getSelections();
 		if (selections.length === 1 && selections[0].isEmpty()) {
 			isDisconnectedFromFindController = true;
 			wholeWord = true;
 			matchCase = true;
+			isRegex = false;
 		} else {
 			wholeWord = findState.wholeWord;
 			matchCase = findState.matchCase;
+			isRegex = findState.isRegex;
 		}
 
 		// Selection owns what is searched for
@@ -322,7 +325,7 @@ export class MultiCursorSession {
 			searchText = editor.getModel().getValueInRange(s).replace(/\r\n/g, '\n');
 		}
 
-		return new MultiCursorSession(editor, findController, isDisconnectedFromFindController, searchText, wholeWord, matchCase, currentMatch);
+		return new MultiCursorSession(editor, findController, isDisconnectedFromFindController, searchText, wholeWord, matchCase, isRegex, currentMatch);
 	}
 
 	constructor(
@@ -332,6 +335,7 @@ export class MultiCursorSession {
 		public readonly searchText: string,
 		public readonly wholeWord: boolean,
 		public readonly matchCase: boolean,
+		public readonly isRegex: boolean,
 		public currentMatch: Selection | null
 	) { }
 
@@ -378,7 +382,7 @@ export class MultiCursorSession {
 
 		const allSelections = this._editor.getSelections();
 		const lastAddedSelection = allSelections[allSelections.length - 1];
-		const nextMatch = this._editor.getModel().findNextMatch(this.searchText, lastAddedSelection.getEndPosition(), false, this.matchCase, this.wholeWord ? this._editor.getOption(EditorOption.wordSeparators) : null, false);
+		const nextMatch = this._editor.getModel().findNextMatch(this.searchText, lastAddedSelection.getEndPosition(), this.isRegex, this.matchCase, this.wholeWord ? this._editor.getOption(EditorOption.wordSeparators) : null, false);
 
 		if (!nextMatch) {
 			return null;
@@ -429,7 +433,7 @@ export class MultiCursorSession {
 
 		const allSelections = this._editor.getSelections();
 		const lastAddedSelection = allSelections[allSelections.length - 1];
-		const previousMatch = this._editor.getModel().findPreviousMatch(this.searchText, lastAddedSelection.getStartPosition(), false, this.matchCase, this.wholeWord ? this._editor.getOption(EditorOption.wordSeparators) : null, false);
+		const previousMatch = this._editor.getModel().findPreviousMatch(this.searchText, lastAddedSelection.getStartPosition(), this.isRegex, this.matchCase, this.wholeWord ? this._editor.getOption(EditorOption.wordSeparators) : null, false);
 
 		if (!previousMatch) {
 			return null;
@@ -446,9 +450,9 @@ export class MultiCursorSession {
 
 		const editorModel = this._editor.getModel();
 		if (searchScope) {
-			return editorModel.findMatches(this.searchText, searchScope, false, this.matchCase, this.wholeWord ? this._editor.getOption(EditorOption.wordSeparators) : null, false, Constants.MAX_SAFE_SMALL_INTEGER);
+			return editorModel.findMatches(this.searchText, searchScope, this.isRegex, this.matchCase, this.wholeWord ? this._editor.getOption(EditorOption.wordSeparators) : null, false, Constants.MAX_SAFE_SMALL_INTEGER);
 		}
-		return editorModel.findMatches(this.searchText, true, false, this.matchCase, this.wholeWord ? this._editor.getOption(EditorOption.wordSeparators) : null, false, Constants.MAX_SAFE_SMALL_INTEGER);
+		return editorModel.findMatches(this.searchText, true, this.isRegex, this.matchCase, this.wholeWord ? this._editor.getOption(EditorOption.wordSeparators) : null, false, Constants.MAX_SAFE_SMALL_INTEGER);
 	}
 }
 

--- a/src/vs/editor/contrib/multicursor/test/browser/multicursor.test.ts
+++ b/src/vs/editor/contrib/multicursor/test/browser/multicursor.test.ts
@@ -502,7 +502,37 @@ suite('Multicursor selection', () => {
 		});
 	});
 
-	suite('Find state disassociation', () => {
+	test('issue #107090: AddSelectionToNextFindMatchAction respects regex mode', () => {
+		const text = [
+			'a.b',
+			'acb',
+			'a-b',
+		];
+		testAddSelectionToNextFindMatchAction(text, (editor, action, findController) => {
+			// Enable regex mode in the find widget
+			findController.getState().change({ isRegex: true }, false);
+
+			// Select 'a.b' (which as a regex also matches 'acb' and 'a-b')
+			editor.setSelections([
+				new Selection(1, 1, 1, 4),
+			]);
+
+			action.run(null!, editor);
+			assert.deepStrictEqual(editor.getSelections(), [
+				new Selection(1, 1, 1, 4),
+				new Selection(2, 1, 2, 4),
+			]);
+
+			action.run(null!, editor);
+			assert.deepStrictEqual(editor.getSelections(), [
+				new Selection(1, 1, 1, 4),
+				new Selection(2, 1, 2, 4),
+				new Selection(3, 1, 3, 4),
+			]);
+		});
+	});
+
+
 
 		const text = [
 			'app',

--- a/src/vs/editor/contrib/multicursor/test/browser/multicursor.test.ts
+++ b/src/vs/editor/contrib/multicursor/test/browser/multicursor.test.ts
@@ -532,7 +532,7 @@ suite('Multicursor selection', () => {
 		});
 	});
 
-
+	suite('Find state disassociation', () => {
 
 		const text = [
 			'app',


### PR DESCRIPTION
## Summary

## Root Cause

In `MultiCursorSession` (`src/vs/editor/contrib/multicursor/browser/multicursor.ts`), the `isRegex` flag from the find widget state was never stored or used. All three search calls hardcoded `false` for the `isRegex` parameter:

- `findNextMatch(..., false, ...)` in `_getNextMatch()`
- `findPreviousMatch(..., false, ...)` in `_getPreviousMatch()`
- `findMatches(..., false, ...)` in `selectAll()`

Additionally, `MultiCursorSession.create()` never read `findState.isRegex`, so even if the find widget had regex mode enabled, it was always ignored when Ctrl+D (Add Selection to Next Find Match) was pressed.

## Change Made

**File:** `src/vs/editor/contrib/multicursor/browser/multicursor.ts`

1. Added `isRegex: boolean` property to `MultiCursorSession` constructor.
2. In `MultiCursorSession.create()`:
   - When find widget owns the search (not editor-focused): pass `findState.isRegex`
   - When selection owns the search with non-empty selection: set `isRegex = findState.isRegex`
   - When disconnected from find controller (collapsed cursor, word-under-cursor expansion): set `isRegex = false` (consistent with existing behavior of forcing word-boundary, case-sensitive, no-regex for this path)
3. Updated `_getNextMatch()`, `_getPreviousMatch()`, and `selectAll()` to pass `this.isRegex` instead of the hardcoded `false`.



## Issue

Fixes #107090

**Issue URL:** https://github.com/microsoft/vscode/issues/107090


## Changes

```
AGENTS.md                                          | 34 ++++++++++++++++++++--
 .../contrib/multicursor/browser/multicursor.ts     | 16 ++++++----
 .../multicursor/test/browser/multicursor.test.ts   | 32 +++++++++++++++++++-
 3 files changed, 72 insertions(+), 10 deletions(-)
```


## Testing


- Agent ran relevant tests during development

- Linting checks passed

- Changes are minimal and focused on the issue


## AI Assistance Disclosure


This pull request was prepared with the assistance of AI coding tools (GitHub Copilot). The change has been read, understood, and is owned by the human contributor submitting it, who will respond to review feedback.
