### PR TITLE
Fix markdown cell not re-rendering when re-executed (#151151)

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/notebookBrowser.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookBrowser.ts
@@ -836,7 +836,7 @@ export interface INotebookEditorDelegate extends INotebookEditor {
 	readonly creationOptions: INotebookEditorCreationOptions;
 	readonly onDidChangeOptions: Event<void>;
 	readonly onDidChangeDecorations: Event<void>;
-	createMarkupPreview(cell: ICellViewModel): Promise<void>;
+	createMarkupPreview(cell: ICellViewModel, forceRerender?: boolean): Promise<void>;
 	unhideMarkupPreviews(cells: readonly ICellViewModel[]): Promise<void>;
 	hideMarkupPreviews(cells: readonly ICellViewModel[]): Promise<void>;
 

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -2732,7 +2732,12 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		};
 	}
 
-	async createMarkupPreview(cell: MarkupCellViewModel) {
+	/**
+	 * @param forceRerender re-render the markup preview even when its content and metadata are
+	 * unchanged (e.g. after the cell is re-rendered/executed) so that resources such as <img>
+	 * tags are re-fetched. See #151151.
+	 */
+	async createMarkupPreview(cell: MarkupCellViewModel, forceRerender = false) {
 		if (!this._webview) {
 			return;
 		}
@@ -2769,7 +2774,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 			offset: cellTop + top,
 			visible: true,
 			metadata: cell.metadata,
-		});
+		}, forceRerender);
 	}
 
 	private cellIsHidden(cell: ICellViewModel): boolean {

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/markupCell.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/markupCell.ts
@@ -132,7 +132,10 @@ export class MarkupCell extends Disposable {
 
 		this._register(this.viewCell.onDidChangeState((e) => {
 			if (e.editStateChanged || e.contentChanged) {
-				this.viewUpdate();
+				// When the cell leaves edit mode (e.g. it was rendered/executed via Enter, the
+				// toolbar, or Escape) force the preview to re-render even if the markdown source is
+				// unchanged, so that resources such as <img> tags are re-fetched. See #151151.
+				this.viewUpdate(e.editStateChanged);
 			}
 
 			if (e.focusModeChanged) {
@@ -240,13 +243,13 @@ export class MarkupCell extends Disposable {
 		this.templateData.foldingIndicator.classList.add(showFoldingIcon);
 	}
 
-	private viewUpdate(): void {
+	private viewUpdate(forceRerender = false): void {
 		if (this.viewCell.isInputCollapsed) {
 			this.viewUpdateCollapsed();
 		} else if (this.viewCell.getEditState() === CellEditState.Editing) {
 			this.viewUpdateEditing();
 		} else {
-			this.viewUpdatePreview();
+			this.viewUpdatePreview(forceRerender);
 		}
 	}
 
@@ -393,7 +396,7 @@ export class MarkupCell extends Disposable {
 		this.renderedEditors.set(this.viewCell, this.editor);
 	}
 
-	private viewUpdatePreview(): void {
+	private viewUpdatePreview(forceRerender = false): void {
 		this.viewCell.detachTextEditor();
 		DOM.hide(this.editorPart);
 		DOM.hide(this.templateData.cellInputCollapsedContainer);
@@ -412,7 +415,7 @@ export class MarkupCell extends Disposable {
 			}
 		}
 
-		this.notebookEditor.createMarkupPreview(this.viewCell);
+		this.notebookEditor.createMarkupPreview(this.viewCell, forceRerender);
 	}
 
 	private focusEditorIfNeeded() {

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -1344,7 +1344,7 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 		});
 	}
 
-	async showMarkupPreview(newContent: IMarkupCellInitialization) {
+	async showMarkupPreview(newContent: IMarkupCellInitialization, forceRerender = false) {
 		if (this._disposed) {
 			return;
 		}
@@ -1354,8 +1354,10 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 			return this.createMarkupPreview(newContent);
 		}
 
-		const sameContent = newContent.content === entry.content;
-		const sameMetadata = (equals(newContent.metadata, entry.metadata));
+		// When `forceRerender` is set the preview must be re-rendered even if the content and
+		// metadata are unchanged, so that resources such as <img> tags are re-fetched (see #151151).
+		const sameContent = !forceRerender && newContent.content === entry.content;
+		const sameMetadata = !forceRerender && (equals(newContent.metadata, entry.metadata));
 		if (!sameContent || !sameMetadata || !entry.visible) {
 			this._sendMessageToWebview({
 				type: 'showMarkupCell',


### PR DESCRIPTION
A markdown cell with an `<img>` pointing to a missing file shows a broken image. After the file is created and the cell is re-executed/re-rendered without editing its text, the image stayed broken because the preview was not re-rendered when its content was unchanged.

Thread a `forceRerender` flag from the view layer down to the webview: `MarkupCell` now forces a re-render whenever the cell leaves edit mode (`editStateChanged`) — covering Enter, the toolbar, and Escape — so that `showMarkupPreview` bypasses its unchanged-content short-circuit and the webview re-fetches resources such as `<img>` tags. Content/metadata-only, layout, scroll and selection changes are unaffected.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
