### PR TITLE
fix: allow shell integration in PowerShell audit mode

### DIFF
--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1
@@ -8,9 +8,14 @@ if ((Test-Path variable:global:__VSCodeState) -and $null -ne $Global:__VSCodeSta
 	return;
 }
 
-# Disable shell integration when the language mode is restricted
+# Disable shell integration when the language mode is restricted.
+# Allow ConstrainedLanguage when the system lockdown policy is Audit (PS 7.4+), as audit mode
+# does not actually enforce restrictions - it only logs what would be blocked.
 if ($ExecutionContext.SessionState.LanguageMode -ne "FullLanguage") {
-	return;
+	if ($ExecutionContext.SessionState.LanguageMode -ne "ConstrainedLanguage" -or
+		[System.Management.Automation.Security.SystemPolicy]::GetSystemLockdownPolicy() -ne [System.Management.Automation.Security.SystemEnforcementMode]::Audit) {
+		return;
+	}
 }
 
 $Global:__VSCodeState = @{


### PR DESCRIPTION
Fixes #283151.

## Summary
- allow terminal shell integration when PowerShell reports `ConstrainedLanguage` but the system lockdown policy is audit-only
- continue to return early for enforced constrained or restricted language modes

## Testing
- Not run locally; PowerShell script-only change and CI will verify.

Note: This overlaps with existing PR #283178, but opening as requested.