### PR TITLE
claude: load Agent SDK from companion extension instead of bundling

### DIFF
--- a/extensions/copilot/package-lock.json
+++ b/extensions/copilot/package-lock.json
@@ -3288,6 +3288,9 @@
       "cpu": [
         "arm"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3303,6 +3306,9 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -3320,6 +3326,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3335,6 +3344,9 @@
       "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -3352,6 +3364,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3367,6 +3382,9 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3390,6 +3408,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3411,6 +3432,9 @@
       "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3434,6 +3458,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3455,6 +3482,9 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,

--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -3441,6 +3441,24 @@
             ],
             "markdownDescription": "%github.copilot.config.claudeAgent.allowAutoPermissions%"
           },
+          "github.copilot.chat.claudeAgent.useSdkExtension": {
+            "type": "boolean",
+            "default": false,
+            "tags": [
+              "preview",
+              "onExp"
+            ],
+            "markdownDescription": "%github.copilot.config.claudeAgent.useSdkExtension%"
+          },
+          "github.copilot.chat.claudeAgent.sdkExtensionInstallTimeout": {
+            "type": "number",
+            "default": 120000,
+            "minimum": 1000,
+            "tags": [
+              "preview"
+            ],
+            "markdownDescription": "%github.copilot.config.claudeAgent.sdkExtensionInstallTimeout%"
+          },
           "github.copilot.chat.copilotDebugCommand.enabled": {
             "type": "boolean",
             "default": true,

--- a/extensions/copilot/package.nls.json
+++ b/extensions/copilot/package.nls.json
@@ -407,6 +407,8 @@
 	"github.copilot.config.claudeAgent.enabled": "Enable Claude Agent sessions in VS Code. Start and resume agentic coding sessions powered by Anthropic's Claude Agent SDK directly in the editor. Uses your existing Copilot subscription.",
 	"github.copilot.config.claudeAgent.allowDangerouslySkipPermissions": "Allow bypass permissions mode. Recommended only for sandboxes with no internet access.",
 	"github.copilot.config.claudeAgent.allowAutoPermissions": "Allow auto permission mode, which uses a model classifier to approve or deny tool operations automatically. [Learn more](https://aka.ms/vscode-claude-auto-mode).",
+	"github.copilot.config.claudeAgent.useSdkExtension": "Load the Claude Agent SDK from the `ms-vscode.vscode-claude-sdk` extension (installed on demand) instead of the version bundled with Copilot Chat.",
+	"github.copilot.config.claudeAgent.sdkExtensionInstallTimeout": "Maximum time in milliseconds to wait for the `ms-vscode.vscode-claude-sdk` extension to install and activate when loading the Claude Agent SDK from the marketplace.",
 	"github.copilot.config.cli.mcp.enabled": "Enable Model Context Protocol (MCP) server for Copilot CLI.",
 	"github.copilot.config.cli.branchSupport.enabled": "Enable branch support for Copilot CLI.",
 	"github.copilot.config.cli.forkSessions.enabled": "Enable forking sessions in Copilot CLI.",

--- a/extensions/copilot/package.nls.json
+++ b/extensions/copilot/package.nls.json
@@ -408,7 +408,7 @@
 	"github.copilot.config.claudeAgent.allowDangerouslySkipPermissions": "Allow bypass permissions mode. Recommended only for sandboxes with no internet access.",
 	"github.copilot.config.claudeAgent.allowAutoPermissions": "Allow auto permission mode, which uses a model classifier to approve or deny tool operations automatically. [Learn more](https://aka.ms/vscode-claude-auto-mode).",
 	"github.copilot.config.claudeAgent.useSdkExtension": "Load the Claude Agent SDK from the `ms-vscode.vscode-claude-sdk` extension (installed on demand) instead of the version bundled with Copilot Chat.",
-	"github.copilot.config.claudeAgent.sdkExtensionInstallTimeout": "Maximum time in milliseconds to wait for the `ms-vscode.vscode-claude-sdk` extension to install and activate when loading the Claude Agent SDK from the marketplace.",
+	"github.copilot.config.claudeAgent.sdkExtensionInstallTimeout": "Maximum time in milliseconds to wait for the `ms-vscode.vscode-claude-sdk` extension to be installed and detected when loading the Claude Agent SDK from the marketplace.",
 	"github.copilot.config.cli.mcp.enabled": "Enable Model Context Protocol (MCP) server for Copilot CLI.",
 	"github.copilot.config.cli.branchSupport.enabled": "Enable branch support for Copilot CLI.",
 	"github.copilot.config.cli.forkSessions.enabled": "Enable forking sessions in Copilot CLI.",

--- a/extensions/copilot/src/extension/chatSessions/claude/common/claudeAgentSdkLoaderService.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/common/claudeAgentSdkLoaderService.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type * as AgentSdk from '@anthropic-ai/claude-agent-sdk';
+import type * as vscode from 'vscode';
+import { createServiceIdentifier } from '../../../../util/common/services';
+
+export const CLAUDE_SDK_EXTENSION_ID = 'ms-vscode.vscode-claude-sdk';
+
+export interface IClaudeAgentSdkLoaderService {
+	readonly _serviceBrand: undefined;
+
+	/** Whether the SDK is currently available (extension installed or module present). */
+	readonly isAvailable: boolean;
+
+	/**
+	 * Ensures the SDK is available, installing it if necessary.
+	 * Returns true if the SDK is available after the call.
+	 */
+	install(token: vscode.CancellationToken): Promise<boolean>;
+
+	/** Loads and returns the SDK module. Throws if the SDK cannot be loaded. */
+	load(): Promise<typeof AgentSdk>;
+}
+
+export const IClaudeAgentSdkLoaderService = createServiceIdentifier<IClaudeAgentSdkLoaderService>('IClaudeAgentSdkLoaderService');

--- a/extensions/copilot/src/extension/chatSessions/claude/common/claudeMcpServerRegistry.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/common/claudeMcpServerRegistry.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { McpServerConfig } from '@anthropic-ai/claude-agent-sdk';
+import type { McpServerConfig } from '@anthropic-ai/claude-agent-sdk';
 import { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
 
 /**

--- a/extensions/copilot/src/extension/chatSessions/claude/common/claudeSessionStateService.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/common/claudeSessionStateService.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { EffortLevel, PermissionMode } from '@anthropic-ai/claude-agent-sdk';
+import type { EffortLevel, PermissionMode } from '@anthropic-ai/claude-agent-sdk';
 import type * as vscode from 'vscode';
 import { CapturingToken } from '../../../../platform/requestLogger/common/capturingToken';
 import type { TraceContext } from '../../../../platform/otel/common/otelService';

--- a/extensions/copilot/src/extension/chatSessions/claude/common/claudeToolPermission.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/common/claudeToolPermission.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { PermissionMode, PermissionUpdate } from '@anthropic-ai/claude-agent-sdk';
+import type { PermissionMode, PermissionUpdate } from '@anthropic-ai/claude-agent-sdk';
 import type * as vscode from 'vscode';
 import { ClaudeToolInputMap, ClaudeToolNames } from './claudeTools';
 

--- a/extensions/copilot/src/extension/chatSessions/claude/common/mcpServers/ideMcpServer.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/common/mcpServers/ideMcpServer.ts
@@ -3,11 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { createSdkMcpServer, McpServerConfig, tool } from '@anthropic-ai/claude-agent-sdk';
+import type { McpServerConfig } from '@anthropic-ai/claude-agent-sdk';
 import { z } from 'zod';
 import { ILanguageDiagnosticsService } from '../../../../../platform/languages/common/languageDiagnosticsService';
 import { URI } from '../../../../../util/vs/base/common/uri';
 import { DiagnosticSeverity } from '../../../../../vscodeTypes';
+import { IClaudeAgentSdkLoaderService } from '../claudeAgentSdkLoaderService';
 import { IClaudeMcpServerContributor, registerClaudeMcpServerContributor } from '../claudeMcpServerRegistry';
 
 const severityToString: Record<DiagnosticSeverity, string> = {
@@ -76,9 +77,11 @@ class IdeMcpServerContributor implements IClaudeMcpServerContributor {
 
 	constructor(
 		@ILanguageDiagnosticsService private readonly diagnosticsService: ILanguageDiagnosticsService,
+		@IClaudeAgentSdkLoaderService private readonly sdkLoader: IClaudeAgentSdkLoaderService,
 	) { }
 
 	async getMcpServers(): Promise<Record<string, McpServerConfig>> {
+		const { tool, createSdkMcpServer } = await this.sdkLoader.load();
 		const diagnosticsService = this.diagnosticsService;
 
 		const getDiagnosticsTool = tool(

--- a/extensions/copilot/src/extension/chatSessions/claude/node/bundledClaudeAgentSdkLoaderService.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/node/bundledClaudeAgentSdkLoaderService.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type * as AgentSdk from '@anthropic-ai/claude-agent-sdk';
+import type * as vscode from 'vscode';
+import { IClaudeAgentSdkLoaderService } from '../common/claudeAgentSdkLoaderService';
+
+/**
+ * SDK loader that uses the @anthropic-ai/claude-agent-sdk bundled as a regular
+ * dependency of this extension. The SDK is always available.
+ */
+export class BundledClaudeAgentSdkLoaderService implements IClaudeAgentSdkLoaderService {
+	readonly _serviceBrand: undefined;
+
+	get isAvailable(): boolean {
+		return true;
+	}
+
+	async install(_token: vscode.CancellationToken): Promise<boolean> {
+		return true;
+	}
+
+	async load(): Promise<typeof AgentSdk> {
+		return import('@anthropic-ai/claude-agent-sdk');
+	}
+}

--- a/extensions/copilot/src/extension/chatSessions/claude/node/claudeCodeAgent.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/node/claudeCodeAgent.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { EffortLevel, McpServerConfig, Options, PermissionMode, Query, SDKUserMessage, SdkPluginConfig } from '@anthropic-ai/claude-agent-sdk';
+import type { EffortLevel, McpServerConfig, Options, PermissionMode, Query, SDKUserMessage, SdkPluginConfig } from '@anthropic-ai/claude-agent-sdk';
 import Anthropic from '@anthropic-ai/sdk';
 import * as l10n from '@vscode/l10n';
 import type * as vscode from 'vscode';

--- a/extensions/copilot/src/extension/chatSessions/claude/node/claudeCodeModels.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/node/claudeCodeModels.ts
@@ -14,7 +14,7 @@ import { Emitter } from '../../../../util/vs/base/common/event';
 import { Disposable } from '../../../../util/vs/base/common/lifecycle';
 import type { ParsedClaudeModelId } from '../common/claudeModelId';
 import { tryParseClaudeModelId } from './claudeModelId';
-import { EffortLevel } from '@anthropic-ai/claude-agent-sdk';
+import type { EffortLevel } from '@anthropic-ai/claude-agent-sdk';
 
 export const CLAUDE_REASONING_EFFORT_PROPERTY = 'reasoningEffort';
 

--- a/extensions/copilot/src/extension/chatSessions/claude/node/claudeCodeSdkService.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/node/claudeCodeSdkService.ts
@@ -5,6 +5,7 @@
 
 import type { ForkSessionOptions, ForkSessionResult, GetSubagentMessagesOptions, ListSubagentsOptions, Options, Query, SDKSessionInfo, SDKUserMessage, SessionMessage } from '@anthropic-ai/claude-agent-sdk';
 import { createServiceIdentifier } from '../../../../util/common/services';
+import { IClaudeAgentSdkLoaderService } from '../common/claudeAgentSdkLoaderService';
 
 export interface IClaudeCodeSdkService {
 	readonly _serviceBrand: undefined;
@@ -83,11 +84,12 @@ export const IClaudeCodeSdkService = createServiceIdentifier<IClaudeCodeSdkServi
 export class ClaudeCodeSdkService implements IClaudeCodeSdkService {
 	readonly _serviceBrand: undefined;
 
-	private _sdk: Promise<typeof import('@anthropic-ai/claude-agent-sdk')> | undefined;
+	constructor(
+		@IClaudeAgentSdkLoaderService private readonly _sdkLoader: IClaudeAgentSdkLoaderService,
+	) { }
 
 	private _loadSdk() {
-		this._sdk ??= import('@anthropic-ai/claude-agent-sdk');
-		return this._sdk;
+		return this._sdkLoader.load();
 	}
 
 	public async query(options: {

--- a/extensions/copilot/src/extension/chatSessions/claude/node/claudeSessionStateService.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/node/claudeSessionStateService.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { EffortLevel, PermissionMode } from '@anthropic-ai/claude-agent-sdk';
+import type { EffortLevel, PermissionMode } from '@anthropic-ai/claude-agent-sdk';
 import { CapturingToken } from '../../../../platform/requestLogger/common/capturingToken';
 import type { TraceContext } from '../../../../platform/otel/common/otelService';
 import { arrayEquals } from '../../../../util/vs/base/common/equals';

--- a/extensions/copilot/src/extension/chatSessions/claude/vscode-node/claudeAgentSdkLoaderService.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/vscode-node/claudeAgentSdkLoaderService.ts
@@ -1,0 +1,99 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type * as AgentSdk from '@anthropic-ai/claude-agent-sdk';
+import * as vscode from 'vscode';
+import { ConfigKey, IConfigurationService } from '../../../../platform/configuration/common/configurationService';
+import { ILogService } from '../../../../platform/log/common/logService';
+import { raceCancellation, raceTimeout } from '../../../../util/vs/base/common/async';
+import { Event } from '../../../../util/vs/base/common/event';
+import { DisposableStore } from '../../../../util/vs/base/common/lifecycle';
+import { CLAUDE_SDK_EXTENSION_ID, IClaudeAgentSdkLoaderService } from '../common/claudeAgentSdkLoaderService';
+
+type SDKActivation =
+	| { sdk: typeof AgentSdk; error: null }
+	| { sdk: null; error: Error };
+
+class SdkExtensionNotInstalledError extends Error {
+	constructor() {
+		super('The ms-vscode.vscode-claude-sdk extension is not installed.');
+		this.name = 'SdkExtensionNotInstalledError';
+	}
+}
+
+export class VsCodeClaudeAgentSdkLoaderService implements IClaudeAgentSdkLoaderService {
+	readonly _serviceBrand: undefined;
+
+	// Cached on success; reset to undefined on failure so the next call retries.
+	private _sdk: Promise<typeof AgentSdk> | undefined;
+
+	constructor(
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@ILogService private readonly _logService: ILogService,
+	) { }
+
+	get isAvailable(): boolean {
+		return vscode.extensions.getExtension(CLAUDE_SDK_EXTENSION_ID) !== undefined;
+	}
+
+	async install(token: vscode.CancellationToken): Promise<boolean> {
+		if (token.isCancellationRequested) {
+			return false;
+		}
+
+		try {
+			await vscode.commands.executeCommand('workbench.extensions.installExtension', CLAUDE_SDK_EXTENSION_ID);
+		} catch (err) {
+			// May throw if already installing or on network error; check availability below.
+			this._logService.warn(`[ClaudeAgentSdkLoader] installExtension command failed for ${CLAUDE_SDK_EXTENSION_ID}: ${err}`);
+		}
+
+		if (this.isAvailable) {
+			return true;
+		}
+
+		// The install command may return before the extension is activated — wait for onDidChange.
+		const store = new DisposableStore();
+		try {
+			const onDidChange: Event<void> = listener => vscode.extensions.onDidChange(listener);
+			const ready = Event.toPromise(Event.onceIf(onDidChange, () => this.isAvailable), store);
+			// Re-check after registering the listener: the extension may have become available
+			// between the pre-check above and the listener hookup, in which case onDidChange
+			// will never fire again and we would otherwise hang until the timeout.
+			if (this.isAvailable) {
+				return true;
+			}
+			const timeoutMs = this._configurationService.getConfig(ConfigKey.ClaudeAgentSdkExtensionInstallTimeout);
+			await raceCancellation(raceTimeout(ready, timeoutMs), token);
+			return this.isAvailable;
+		} finally {
+			store.dispose();
+		}
+	}
+
+	load(): Promise<typeof AgentSdk> {
+		if (!this._sdk) {
+			const attempt = this._doLoad();
+			// Only cache on success — reset on failure so the next call retries.
+			this._sdk = attempt.then(
+				sdk => { this._sdk = Promise.resolve(sdk); return sdk; },
+				err => { this._sdk = undefined; throw err; }
+			);
+		}
+		return this._sdk;
+	}
+
+	private async _doLoad(): Promise<typeof AgentSdk> {
+		const ext = vscode.extensions.getExtension<SDKActivation>(CLAUDE_SDK_EXTENSION_ID);
+		if (!ext) {
+			throw new SdkExtensionNotInstalledError();
+		}
+		const result = await ext.activate();
+		if (result.error) {
+			throw result.error;
+		}
+		return result.sdk!;
+	}
+}

--- a/extensions/copilot/src/extension/chatSessions/claude/vscode-node/routingClaudeAgentSdkLoaderService.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/vscode-node/routingClaudeAgentSdkLoaderService.ts
@@ -1,0 +1,47 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type * as AgentSdk from '@anthropic-ai/claude-agent-sdk';
+import type * as vscode from 'vscode';
+import { ConfigKey, IConfigurationService } from '../../../../platform/configuration/common/configurationService';
+import { IExperimentationService } from '../../../../platform/telemetry/common/nullExperimentationService';
+import { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
+import { IClaudeAgentSdkLoaderService } from '../common/claudeAgentSdkLoaderService';
+import { BundledClaudeAgentSdkLoaderService } from '../node/bundledClaudeAgentSdkLoaderService';
+import { VsCodeClaudeAgentSdkLoaderService } from './claudeAgentSdkLoaderService';
+
+/**
+ * Routes SDK loading to either the bundled SDK or the ms-vscode.vscode-claude-sdk
+ * extension, based on the `chat.claudeAgent.useSdkExtension` setting. The choice
+ * is captured once at construction; flipping the setting takes effect on reload.
+ */
+export class RoutingClaudeAgentSdkLoaderService implements IClaudeAgentSdkLoaderService {
+	readonly _serviceBrand: undefined;
+
+	readonly inner: IClaudeAgentSdkLoaderService;
+
+	constructor(
+		@IConfigurationService configurationService: IConfigurationService,
+		@IExperimentationService experimentationService: IExperimentationService,
+		@IInstantiationService instantiationService: IInstantiationService,
+	) {
+		const useExtension = configurationService.getExperimentBasedConfig(ConfigKey.ClaudeAgentUseSdkExtension, experimentationService);
+		this.inner = useExtension
+			? instantiationService.createInstance(VsCodeClaudeAgentSdkLoaderService)
+			: instantiationService.createInstance(BundledClaudeAgentSdkLoaderService);
+	}
+
+	get isAvailable(): boolean {
+		return this.inner.isAvailable;
+	}
+
+	install(token: vscode.CancellationToken): Promise<boolean> {
+		return this.inner.install(token);
+	}
+
+	load(): Promise<typeof AgentSdk> {
+		return this.inner.load();
+	}
+}

--- a/extensions/copilot/src/extension/chatSessions/claude/vscode-node/test/claudeAgentSdkLoaderService.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/vscode-node/test/claudeAgentSdkLoaderService.spec.ts
@@ -1,0 +1,196 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockState } = vi.hoisted(() => ({
+	mockState: {
+		extension: null as { id: string } | null,
+		getExtensionImpl: null as (() => { id: string } | undefined) | null,
+		executeCommand: vi.fn<(command: string, ...args: unknown[]) => Promise<unknown>>().mockResolvedValue(undefined),
+		changeListeners: [] as Array<() => void>,
+	},
+}));
+
+vi.mock('vscode', async (importOriginal) => {
+	const actual = await importOriginal() as Record<string, unknown>;
+	return {
+		...actual,
+		commands: {
+			executeCommand: (command: string, ...args: unknown[]) => mockState.executeCommand(command, ...args),
+		},
+		extensions: {
+			getExtension: (_id: string) => mockState.getExtensionImpl ? mockState.getExtensionImpl() : (mockState.extension ?? undefined),
+			onDidChange: (listener: () => void) => {
+				mockState.changeListeners.push(listener);
+				return { dispose: () => { const i = mockState.changeListeners.indexOf(listener); if (i >= 0) { mockState.changeListeners.splice(i, 1); } } };
+			},
+		},
+	};
+});
+
+import { ConfigKey, IConfigurationService } from '../../../../../platform/configuration/common/configurationService';
+import { DefaultsOnlyConfigurationService } from '../../../../../platform/configuration/common/defaultsOnlyConfigurationService';
+import { InMemoryConfigurationService } from '../../../../../platform/configuration/test/common/inMemoryConfigurationService';
+import { ILogService, LogServiceImpl } from '../../../../../platform/log/common/logService';
+import { CancellationTokenSource } from '../../../../../util/vs/base/common/cancellation';
+import { CLAUDE_SDK_EXTENSION_ID } from '../../common/claudeAgentSdkLoaderService';
+import { VsCodeClaudeAgentSdkLoaderService } from '../claudeAgentSdkLoaderService';
+
+function fireOnDidChange(): void {
+	for (const listener of mockState.changeListeners.slice()) {
+		listener();
+	}
+}
+
+async function waitForListener(): Promise<void> {
+	for (let i = 0; i < 50; i++) {
+		if (mockState.changeListeners.length > 0) { return; }
+		await new Promise(resolve => setTimeout(resolve, 0));
+	}
+	throw new Error('listener was never registered');
+}
+
+describe('VsCodeClaudeAgentSdkLoaderService', () => {
+	let configurationService: InMemoryConfigurationService;
+	let loader: VsCodeClaudeAgentSdkLoaderService;
+
+	beforeEach(async () => {
+		mockState.extension = null;
+		mockState.getExtensionImpl = null;
+		mockState.executeCommand.mockReset().mockResolvedValue(undefined);
+		mockState.changeListeners.length = 0;
+
+		configurationService = new InMemoryConfigurationService(new DefaultsOnlyConfigurationService());
+		await configurationService.setConfig(ConfigKey.ClaudeAgentSdkExtensionInstallTimeout, 50);
+
+		loader = new VsCodeClaudeAgentSdkLoaderService(configurationService as IConfigurationService, new LogServiceImpl([]) as ILogService);
+	});
+
+	describe('isAvailable', () => {
+		it('returns false when the SDK extension is not installed', () => {
+			expect(loader.isAvailable).toBe(false);
+		});
+
+		it('returns true when the SDK extension is present', () => {
+			mockState.extension = { id: CLAUDE_SDK_EXTENSION_ID };
+			expect(loader.isAvailable).toBe(true);
+		});
+	});
+
+	describe('install', () => {
+		it('returns true immediately when the extension is already available after the install command', async () => {
+			mockState.executeCommand.mockImplementation(async () => {
+				mockState.extension = { id: CLAUDE_SDK_EXTENSION_ID };
+			});
+
+			const cts = new CancellationTokenSource();
+			const result = await loader.install(cts.token);
+
+			expect(result).toBe(true);
+			expect(mockState.executeCommand).toHaveBeenCalledWith('workbench.extensions.installExtension', CLAUDE_SDK_EXTENSION_ID);
+		});
+
+		it('resolves true when onDidChange fires with the extension present', async () => {
+			const cts = new CancellationTokenSource();
+			const installPromise = loader.install(cts.token);
+
+			await waitForListener();
+			mockState.extension = { id: CLAUDE_SDK_EXTENSION_ID };
+			fireOnDidChange();
+
+			expect(await installPromise).toBe(true);
+			expect(mockState.changeListeners).toHaveLength(0);
+		});
+
+		it('ignores onDidChange events while the extension is still missing', async () => {
+			const cts = new CancellationTokenSource();
+			const installPromise = loader.install(cts.token);
+
+			await waitForListener();
+			fireOnDidChange();
+			fireOnDidChange();
+
+			const result = await installPromise;
+			expect(result).toBe(false);
+			expect(mockState.changeListeners).toHaveLength(0);
+		});
+
+		it('returns false when the configured timeout elapses before the extension appears', async () => {
+			const cts = new CancellationTokenSource();
+			const result = await loader.install(cts.token);
+
+			expect(result).toBe(false);
+			expect(mockState.changeListeners).toHaveLength(0);
+		});
+
+		it('uses the configured timeout from ClaudeAgentSdkExtensionInstallTimeout', async () => {
+			await configurationService.setConfig(ConfigKey.ClaudeAgentSdkExtensionInstallTimeout, 10);
+			const cts = new CancellationTokenSource();
+			const start = Date.now();
+			const result = await loader.install(cts.token);
+
+			expect(result).toBe(false);
+			expect(Date.now() - start).toBeLessThan(2000);
+		});
+
+		it('returns false and stops waiting when the cancellation token fires', async () => {
+			await configurationService.setConfig(ConfigKey.ClaudeAgentSdkExtensionInstallTimeout, 60_000);
+			const cts = new CancellationTokenSource();
+			const installPromise = loader.install(cts.token);
+
+			await waitForListener();
+			cts.cancel();
+
+			const result = await installPromise;
+			expect(result).toBe(false);
+			expect(mockState.changeListeners).toHaveLength(0);
+		});
+
+		it('swallows errors from the install command and still waits for the extension', async () => {
+			mockState.executeCommand.mockRejectedValue(new Error('install failed'));
+			const cts = new CancellationTokenSource();
+			const installPromise = loader.install(cts.token);
+
+			await waitForListener();
+			mockState.extension = { id: CLAUDE_SDK_EXTENSION_ID };
+			fireOnDidChange();
+
+			expect(await installPromise).toBe(true);
+		});
+
+		it('returns false without invoking the install command when the token is already cancelled', async () => {
+			const cts = new CancellationTokenSource();
+			cts.cancel();
+
+			const result = await loader.install(cts.token);
+
+			expect(result).toBe(false);
+			expect(mockState.executeCommand).not.toHaveBeenCalled();
+			expect(mockState.changeListeners).toHaveLength(0);
+		});
+
+		it('returns true without waiting when the extension becomes available between the pre-check and listener registration', async () => {
+			await configurationService.setConfig(ConfigKey.ClaudeAgentSdkExtensionInstallTimeout, 60_000);
+			// First isAvailable check (line 46) sees no extension. By the time the
+			// listener is hooked up and the post-registration re-check runs, the
+			// extension has appeared — but no onDidChange event will fire to wake
+			// the waiter. The post-registration re-check must catch it.
+			let lookupCount = 0;
+			mockState.getExtensionImpl = () => {
+				lookupCount++;
+				return lookupCount <= 1 ? undefined : { id: CLAUDE_SDK_EXTENSION_ID };
+			};
+
+			const cts = new CancellationTokenSource();
+			const start = Date.now();
+			const result = await loader.install(cts.token);
+
+			expect(result).toBe(true);
+			expect(Date.now() - start).toBeLessThan(2000);
+			expect(mockState.changeListeners).toHaveLength(0);
+		});
+	});
+});

--- a/extensions/copilot/src/extension/chatSessions/claude/vscode-node/test/routingClaudeAgentSdkLoaderService.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/vscode-node/test/routingClaudeAgentSdkLoaderService.spec.ts
@@ -1,0 +1,56 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { ConfigKey, IConfigurationService } from '../../../../../platform/configuration/common/configurationService';
+import { DefaultsOnlyConfigurationService } from '../../../../../platform/configuration/common/defaultsOnlyConfigurationService';
+import { InMemoryConfigurationService } from '../../../../../platform/configuration/test/common/inMemoryConfigurationService';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../util/common/test/testUtils';
+import { IInstantiationService } from '../../../../../util/vs/platform/instantiation/common/instantiation';
+import { createExtensionUnitTestingServices } from '../../../../test/node/services';
+import { BundledClaudeAgentSdkLoaderService } from '../../node/bundledClaudeAgentSdkLoaderService';
+import { VsCodeClaudeAgentSdkLoaderService } from '../claudeAgentSdkLoaderService';
+import { RoutingClaudeAgentSdkLoaderService } from '../routingClaudeAgentSdkLoaderService';
+
+describe('RoutingClaudeAgentSdkLoaderService', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+	let configurationService: InMemoryConfigurationService;
+	let instantiationService: IInstantiationService;
+
+	beforeEach(() => {
+		configurationService = store.add(new InMemoryConfigurationService(store.add(new DefaultsOnlyConfigurationService())));
+
+		const serviceCollection = store.add(createExtensionUnitTestingServices(store));
+		serviceCollection.define(IConfigurationService, configurationService);
+		const accessor = serviceCollection.createTestingAccessor();
+		instantiationService = accessor.get(IInstantiationService);
+	});
+
+	it('uses BundledClaudeAgentSdkLoaderService when useSdkExtension is false (default)', () => {
+		const router = instantiationService.createInstance(RoutingClaudeAgentSdkLoaderService);
+		expect(router.inner).toBeInstanceOf(BundledClaudeAgentSdkLoaderService);
+	});
+
+	it('uses VsCodeClaudeAgentSdkLoaderService when useSdkExtension is true', async () => {
+		await configurationService.setConfig(ConfigKey.ClaudeAgentUseSdkExtension, true);
+		const router = instantiationService.createInstance(RoutingClaudeAgentSdkLoaderService);
+		expect(router.inner).toBeInstanceOf(VsCodeClaudeAgentSdkLoaderService);
+	});
+
+	it('forwards isAvailable to the chosen inner loader', () => {
+		const router = instantiationService.createInstance(RoutingClaudeAgentSdkLoaderService);
+		expect(router.isAvailable).toBe(router.inner.isAvailable);
+	});
+
+	it('captures the loader choice at construction (flipping the setting later does not swap)', async () => {
+		const router = instantiationService.createInstance(RoutingClaudeAgentSdkLoaderService);
+		const initialInner = router.inner;
+		expect(initialInner).toBeInstanceOf(BundledClaudeAgentSdkLoaderService);
+
+		await configurationService.setConfig(ConfigKey.ClaudeAgentUseSdkExtension, true);
+
+		expect(router.inner).toBe(initialInner);
+	});
+});

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/chatSessions.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/chatSessions.ts
@@ -32,6 +32,8 @@ import { ClaudeCodeFolderMruService } from '../claude/node/claudeCodeFolderMru';
 import { ClaudeAgentManager } from '../claude/node/claudeCodeAgent';
 import { ClaudeCodeModels, IClaudeCodeModels } from '../claude/node/claudeCodeModels';
 import { ClaudeCodeSdkService, IClaudeCodeSdkService } from '../claude/node/claudeCodeSdkService';
+import { RoutingClaudeAgentSdkLoaderService } from '../claude/vscode-node/routingClaudeAgentSdkLoaderService';
+import { IClaudeAgentSdkLoaderService } from '../claude/common/claudeAgentSdkLoaderService';
 import { ClaudeRuntimeDataService } from '../claude/node/claudeRuntimeDataService';
 import { ClaudePluginService, IClaudePluginService } from '../claude/node/claudeSkills';
 import { IClaudeSessionStateService } from '../claude/common/claudeSessionStateService';
@@ -138,6 +140,7 @@ export class ChatSessionsContrib extends Disposable implements IExtensionContrib
 		const claudeAgentInstaService = instantiationService.createChild(
 			new ServiceCollection(
 				[IAgentSessionsWorkspace, new SyncDescriptor(AgentSessionsWorkspace)],
+				[IClaudeAgentSdkLoaderService, new SyncDescriptor(RoutingClaudeAgentSdkLoaderService)],
 				[IClaudeCodeSessionService, new SyncDescriptor(ClaudeCodeSessionService)],
 				[IClaudeCodeSdkService, new SyncDescriptor(ClaudeCodeSdkService)],
 				[IClaudeCodeModels, new SyncDescriptor(ClaudeCodeModels)],

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/claudeChatSessionContentProvider.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/claudeChatSessionContentProvider.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode';
 import { ChatExtendedRequestHandler } from 'vscode';
 import type { PermissionMode } from '@anthropic-ai/claude-agent-sdk';
-import { IClaudeAgentSdkLoaderService } from '../claude/common/claudeAgentSdkLoaderService';
+import { CLAUDE_SDK_EXTENSION_ID, IClaudeAgentSdkLoaderService } from '../claude/common/claudeAgentSdkLoaderService';
 import { IAuthenticationService } from '../../../platform/authentication/common/authentication';
 import { IChatQuotaService } from '../../../platform/chat/common/chatQuotaService';
 import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
@@ -134,11 +134,11 @@ export class ClaudeChatSessionContentProvider extends Disposable implements vsco
 					stream.button({
 						command: 'workbench.extensions.installExtension',
 						title: vscode.l10n.t("Install Claude Agent SDK"),
-						arguments: ['ms-vscode.vscode-claude-sdk'],
+						arguments: [CLAUDE_SDK_EXTENSION_ID],
 					});
 					return {
 						errorDetails: {
-							message: vscode.l10n.t("Failed to install ms-vscode.vscode-claude-sdk")
+							message: vscode.l10n.t("Failed to install {0}", CLAUDE_SDK_EXTENSION_ID)
 						}
 					};
 				}

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/claudeChatSessionContentProvider.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/claudeChatSessionContentProvider.ts
@@ -5,7 +5,8 @@
 
 import * as vscode from 'vscode';
 import { ChatExtendedRequestHandler } from 'vscode';
-import { PermissionMode } from '@anthropic-ai/claude-agent-sdk';
+import type { PermissionMode } from '@anthropic-ai/claude-agent-sdk';
+import { IClaudeAgentSdkLoaderService } from '../claude/common/claudeAgentSdkLoaderService';
 import { IAuthenticationService } from '../../../platform/authentication/common/authentication';
 import { IChatQuotaService } from '../../../platform/chat/common/chatQuotaService';
 import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
@@ -88,6 +89,7 @@ export class ClaudeChatSessionContentProvider extends Disposable implements vsco
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IChatQuotaService private readonly _chatQuotaService: IChatQuotaService,
+		@IClaudeAgentSdkLoaderService private readonly _sdkLoader: IClaudeAgentSdkLoaderService,
 	) {
 		super();
 		this._controller = this._register(instantiationService.createInstance(ClaudeChatSessionItemController));
@@ -120,6 +122,27 @@ export class ClaudeChatSessionContentProvider extends Disposable implements vsco
 			const slashResult = await this.slashCommandService.tryHandleCommand(request, stream, token);
 			if (slashResult.handled) {
 				return slashResult.result ?? {};
+			}
+
+			if (!this._sdkLoader.isAvailable) {
+				stream.markdown(vscode.l10n.t("Installing the Claude Agent SDK..."));
+				const installed = await this._sdkLoader.install(token);
+				if (!installed) {
+					if (token.isCancellationRequested) {
+						return {};
+					}
+					stream.button({
+						command: 'workbench.extensions.installExtension',
+						title: vscode.l10n.t("Install Claude Agent SDK"),
+						arguments: ['ms-vscode.vscode-claude-sdk'],
+					});
+					return {
+						errorDetails: {
+							message: vscode.l10n.t("Failed to install ms-vscode.vscode-claude-sdk")
+						}
+					};
+				}
+				stream.markdown(vscode.l10n.t("Done") + '\n\n');
 			}
 
 			const effectiveSessionId = ClaudeSessionUri.getSessionId(chatSessionContext.chatSessionItem.resource);
@@ -300,6 +323,7 @@ export class ClaudeChatSessionItemController extends Disposable {
 		@IClaudeWorkspaceFolderService private readonly _claudeWorkspaceFolderService: IClaudeWorkspaceFolderService,
 		@IAuthenticationService _authenticationService: IAuthenticationService,
 		@IExperimentationService experimentationService: IExperimentationService,
+		@IClaudeAgentSdkLoaderService private readonly _sdkLoader: IClaudeAgentSdkLoaderService,
 	) {
 		super();
 		this._optionBuilder = new ClaudeSessionOptionBuilder(_configurationService, folderMruService, _workspaceService, experimentationService);
@@ -428,6 +452,17 @@ export class ClaudeChatSessionItemController extends Disposable {
 			this._showBadge = this._computeShowBadge();
 			void this._refreshItems(CancellationToken.None);
 		}));
+
+		// When the Claude SDK extension is installed at runtime, refresh the sessions list once
+		if (!this._sdkLoader.isAvailable) {
+			const listener = vscode.extensions.onDidChange(() => {
+				if (this._sdkLoader.isAvailable) {
+					listener.dispose();
+					void this._refreshItems(CancellationToken.None);
+				}
+			});
+			this._register(listener);
+		}
 
 		this._setupInputState();
 	}

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/claudeSessionOptionBuilder.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/claudeSessionOptionBuilder.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { PermissionMode } from '@anthropic-ai/claude-agent-sdk';
+import type { PermissionMode } from '@anthropic-ai/claude-agent-sdk';
 import * as l10n from '@vscode/l10n';
 import * as vscode from 'vscode';
 import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/test/claudeChatSessionContentProvider.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/test/claudeChatSessionContentProvider.spec.ts
@@ -16,17 +16,18 @@ import { ITestingServicesAccessor } from '../../../../platform/test/node/service
 import { TestWorkspaceService } from '../../../../platform/test/node/testWorkspaceService';
 import { IWorkspaceService } from '../../../../platform/workspace/common/workspaceService';
 import { mock } from '../../../../util/common/test/simpleMock';
-import { CancellationToken } from '../../../../util/vs/base/common/cancellation';
+import { CancellationToken, CancellationTokenSource } from '../../../../util/vs/base/common/cancellation';
 import { Emitter, Event } from '../../../../util/vs/base/common/event';
 import { DisposableStore } from '../../../../util/vs/base/common/lifecycle';
 import { observableValue } from '../../../../util/vs/base/common/observableInternal/observables/observableValue';
 import { URI } from '../../../../util/vs/base/common/uri';
 import { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
-import { ChatSessionStatus, MarkdownString, ThemeIcon } from '../../../../vscodeTypes';
+import { ChatSessionStatus, ChatResponseCommandButtonPart, MarkdownString, ThemeIcon } from '../../../../vscodeTypes';
 import { createExtensionUnitTestingServices } from '../../../test/node/services';
 import { MockChatResponseStream, TestChatRequest } from '../../../test/node/testHelpers';
 import { ClaudeFolderInfo } from '../../claude/common/claudeFolderInfo';
 import { ClaudeSessionUri } from '../../claude/common/claudeSessionUri';
+import { IClaudeAgentSdkLoaderService } from '../../claude/common/claudeAgentSdkLoaderService';
 import type { ClaudeAgentManager } from '../../claude/node/claudeCodeAgent';
 import { IClaudeCodeSdkService } from '../../claude/node/claudeCodeSdkService';
 import { parseClaudeModelId } from '../../claude/node/claudeModelId';
@@ -46,11 +47,20 @@ let lastForkHandler: ((sessionResource: vscode.Uri, request: vscode.ChatRequestT
 // Expose the most recently registered getChatSessionInputState handler so tests can invoke it.
 let lastGetChatSessionInputState: vscode.ChatSessionControllerGetInputState | undefined;
 
+// Emitter that backs vscode.extensions.onDidChange for tests that exercise SDK install flows.
+let extensionsDidChangeEmitter: Emitter<void>;
+
 // Patch vscode shim with missing namespaces before any production code imports it.
 beforeAll(() => {
 	(vscodeShim as Record<string, unknown>).commands = {
 		registerCommand: vi.fn().mockReturnValue({ dispose: () => { } }),
 		executeCommand: vi.fn().mockResolvedValue(undefined),
+	};
+	extensionsDidChangeEmitter = new Emitter<void>();
+	(vscodeShim as Record<string, unknown>).extensions = {
+		getExtension: vi.fn().mockReturnValue(undefined),
+		onDidChange: extensionsDidChangeEmitter.event,
+		all: [],
 	};
 	(vscodeShim as Record<string, unknown>).chat = {
 		createChatSessionItemController: () => {
@@ -237,6 +247,7 @@ function createProviderWithServices(
 	mocks: ReturnType<typeof createDefaultMocks>,
 	agentManager?: ClaudeAgentManager,
 	workspaceServiceOverride?: TestWorkspaceService,
+	sdkLoaderOverride?: IClaudeAgentSdkLoaderService,
 ): { provider: ClaudeChatSessionContentProvider; accessor: ITestingServicesAccessor } {
 	const serviceCollection = store.add(createExtensionUnitTestingServices(store));
 
@@ -265,6 +276,13 @@ function createProviderWithServices(
 	serviceCollection.define(IClaudeWorkspaceFolderService, {
 		_serviceBrand: undefined,
 		getWorkspaceChanges: vi.fn().mockResolvedValue([]),
+	});
+
+	serviceCollection.define(IClaudeAgentSdkLoaderService, sdkLoaderOverride ?? {
+		_serviceBrand: undefined,
+		isAvailable: true,
+		install: vi.fn().mockResolvedValue(true),
+		load: vi.fn().mockResolvedValue({}),
 	});
 
 	const accessor = serviceCollection.createTestingAccessor();
@@ -997,6 +1015,88 @@ describe('ChatSessionContentProvider', () => {
 			expect(vi.mocked(mockAgentManager.handleRequest)).not.toHaveBeenCalled();
 			expect(result).toEqual({ metadata: { command: '/test' } });
 		});
+
+		it('streams "Installing..." then "Done" and proceeds when the SDK loader installs successfully', async () => {
+			const installMock = vi.fn().mockResolvedValue(true);
+			const loaderStub: IClaudeAgentSdkLoaderService = {
+				_serviceBrand: undefined,
+				isAvailable: false,
+				install: installMock,
+				load: vi.fn().mockResolvedValue({}),
+			};
+			const mocks = createDefaultMocks();
+			const altAgentManager = createMockAgentManager();
+			const { provider } = createProviderWithServices(store, [workspaceFolderUri], mocks, altAgentManager, undefined, loaderStub);
+
+			seedSessionItem('session-install');
+			const handler = provider.createHandler();
+			const stream = new MockChatResponseStream();
+
+			const result = await handler(createTestRequest('hello'), createChatContext('session-install'), stream, CancellationToken.None);
+
+			expect(installMock).toHaveBeenCalledOnce();
+			expect(stream.output.some(s => s.includes('Installing'))).toBe(true);
+			expect(stream.output.some(s => s.includes('Done'))).toBe(true);
+			expect(vi.mocked(altAgentManager.handleRequest)).toHaveBeenCalledOnce();
+			expect(result).not.toHaveProperty('errorDetails');
+		});
+
+		it('emits an install button and errorDetails when the SDK loader install fails, skipping the agent', async () => {
+			const parts: vscode.ExtendedChatResponsePart[] = [];
+			const installMock = vi.fn().mockResolvedValue(false);
+			const loaderStub: IClaudeAgentSdkLoaderService = {
+				_serviceBrand: undefined,
+				isAvailable: false,
+				install: installMock,
+				load: vi.fn().mockResolvedValue({}),
+			};
+			const mocks = createDefaultMocks();
+			const altAgentManager = createMockAgentManager();
+			const { provider } = createProviderWithServices(store, [workspaceFolderUri], mocks, altAgentManager, undefined, loaderStub);
+
+			seedSessionItem('session-install-fail');
+			const handler = provider.createHandler();
+			const stream = new MockChatResponseStream(part => parts.push(part));
+
+			const result = await handler(createTestRequest('hello'), createChatContext('session-install-fail'), stream, CancellationToken.None);
+
+			expect(installMock).toHaveBeenCalledOnce();
+			expect(vi.mocked(altAgentManager.handleRequest)).not.toHaveBeenCalled();
+			expect((result as vscode.ChatResult).errorDetails?.message).toContain('Failed to install');
+			const buttonPart = parts.find(p => p instanceof ChatResponseCommandButtonPart) as ChatResponseCommandButtonPart | undefined;
+			expect(buttonPart?.value.command).toBe('workbench.extensions.installExtension');
+			expect(buttonPart?.value.arguments).toEqual(['ms-vscode.vscode-claude-sdk']);
+		});
+
+		it('returns empty result (no error, no button) when install resolves false after cancellation', async () => {
+			const parts: vscode.ExtendedChatResponsePart[] = [];
+			const cts = new CancellationTokenSource();
+			store.add(cts);
+			const installMock = vi.fn().mockImplementation(async (token: CancellationToken) => {
+				return !token.isCancellationRequested;
+			});
+			const loaderStub: IClaudeAgentSdkLoaderService = {
+				_serviceBrand: undefined,
+				isAvailable: false,
+				install: installMock,
+				load: vi.fn().mockResolvedValue({}),
+			};
+			const mocks = createDefaultMocks();
+			const altAgentManager = createMockAgentManager();
+			const { provider } = createProviderWithServices(store, [workspaceFolderUri], mocks, altAgentManager, undefined, loaderStub);
+
+			seedSessionItem('session-install-cancel');
+			cts.cancel();
+			const handler = provider.createHandler();
+			const stream = new MockChatResponseStream(part => parts.push(part));
+
+			const result = await handler(createTestRequest('hello'), createChatContext('session-install-cancel'), stream, cts.token);
+
+			expect(installMock).toHaveBeenCalledOnce();
+			expect(vi.mocked(altAgentManager.handleRequest)).not.toHaveBeenCalled();
+			expect((result as vscode.ChatResult).errorDetails).toBeUndefined();
+			expect(parts.find(p => p instanceof ChatResponseCommandButtonPart)).toBeUndefined();
+		});
 	});
 
 	// #endregion
@@ -1321,7 +1421,7 @@ describe('ClaudeChatSessionItemController', () => {
 		return lastCreatedItemsMap.get(ClaudeSessionUri.forSessionId(sessionId).toString());
 	}
 
-	function createController(workspaceFolders: URI[], gitService?: IGitService): ClaudeChatSessionItemController {
+	function createController(workspaceFolders: URI[], gitService?: IGitService, sdkLoaderOverride?: IClaudeAgentSdkLoaderService): ClaudeChatSessionItemController {
 		const serviceCollection = store.add(createExtensionUnitTestingServices());
 		const workspaceService = new TestWorkspaceService(workspaceFolders);
 		serviceCollection.set(IWorkspaceService, workspaceService);
@@ -1343,6 +1443,12 @@ describe('ClaudeChatSessionItemController', () => {
 		serviceCollection.define(IClaudeWorkspaceFolderService, {
 			_serviceBrand: undefined,
 			getWorkspaceChanges: vi.fn().mockResolvedValue([]),
+		});
+		serviceCollection.define(IClaudeAgentSdkLoaderService, sdkLoaderOverride ?? {
+			_serviceBrand: undefined,
+			isAvailable: true,
+			install: vi.fn().mockResolvedValue(true),
+			load: vi.fn().mockResolvedValue({}),
 		});
 		const accessor = serviceCollection.createTestingAccessor();
 		lastControllerAccessor = accessor;
@@ -2244,6 +2350,52 @@ describe('ClaudeChatSessionItemController', () => {
 
 			const resource = ClaudeSessionUri.forSessionId(sessionId);
 			await findCommandHandler('github.copilot.claude.sessions.initializeRepository')(resource);
+		});
+	});
+
+	// #endregion
+
+	// #region SDK install listener
+
+	describe('SDK install listener', () => {
+		it('does not refresh items when the SDK is already available and onDidChange fires', () => {
+			controller = createController([URI.file('/project')], undefined, {
+				_serviceBrand: undefined,
+				isAvailable: true,
+				install: vi.fn(),
+				load: vi.fn(),
+			});
+			vi.mocked(mockSessionService.getAllSessions).mockClear();
+			extensionsDidChangeEmitter.fire();
+			expect(vi.mocked(mockSessionService.getAllSessions)).not.toHaveBeenCalled();
+		});
+
+		it('registers a listener when the SDK is missing and refreshes items once it becomes available', async () => {
+			let available = false;
+			const loaderStub: IClaudeAgentSdkLoaderService = {
+				_serviceBrand: undefined,
+				get isAvailable() { return available; },
+				install: vi.fn(),
+				load: vi.fn(),
+			};
+			controller = createController([URI.file('/project')], undefined, loaderStub);
+
+			vi.mocked(mockSessionService.getAllSessions).mockClear();
+
+			extensionsDidChangeEmitter.fire();
+			await Promise.resolve();
+			expect(vi.mocked(mockSessionService.getAllSessions)).not.toHaveBeenCalled();
+
+			available = true;
+			extensionsDidChangeEmitter.fire();
+			await Promise.resolve();
+			await Promise.resolve();
+			expect(vi.mocked(mockSessionService.getAllSessions)).toHaveBeenCalled();
+
+			vi.mocked(mockSessionService.getAllSessions).mockClear();
+			extensionsDidChangeEmitter.fire();
+			await Promise.resolve();
+			expect(vi.mocked(mockSessionService.getAllSessions)).not.toHaveBeenCalled();
 		});
 	});
 

--- a/extensions/copilot/src/platform/configuration/common/configurationService.ts
+++ b/extensions/copilot/src/platform/configuration/common/configurationService.ts
@@ -1023,6 +1023,8 @@ export namespace ConfigKey {
 	export const ClaudeAgentEnabled = defineSetting<boolean>('chat.claudeAgent.enabled', ConfigType.Simple, true);
 	export const ClaudeAgentAllowDangerouslySkipPermissions = defineSetting<boolean>('chat.claudeAgent.allowDangerouslySkipPermissions', ConfigType.Simple, false);
 	export const ClaudeAgentAllowAutoPermissions = defineSetting<boolean>('chat.claudeAgent.allowAutoPermissions', ConfigType.ExperimentBased, false);
+	export const ClaudeAgentUseSdkExtension = defineSetting<boolean>('chat.claudeAgent.useSdkExtension', ConfigType.ExperimentBased, false);
+	export const ClaudeAgentSdkExtensionInstallTimeout = defineSetting<number>('chat.claudeAgent.sdkExtensionInstallTimeout', ConfigType.Simple, 120_000);
 	export const InlineEditsEnabled = defineSetting<boolean>('nextEditSuggestions.enabled', ConfigType.ExperimentBased, true);
 	export const InlineEditsEnableDiagnosticsProvider = defineSetting<boolean>('nextEditSuggestions.fixes', ConfigType.ExperimentBased, true);
 	export const InlineEditsAllowWhitespaceOnlyChanges = defineSetting<boolean>('nextEditSuggestions.allowWhitespaceOnlyChanges', ConfigType.ExperimentBased, true);


### PR DESCRIPTION
## Summary

Extracts Claude Agent SDK loading behind a new `IClaudeAgentSdkLoaderService` abstraction so the SDK can ship out-of-band via the `ms-vscode.vscode-claude-sdk` extension instead of being bundled into Copilot Chat. A routing implementation picks between the existing bundled loader and the new extension-backed loader once at construction, driven by an experiment-based config flag.

## What's in this PR

**New service layer (`claude/common/claudeAgentSdkLoaderService.ts`)**
- `IClaudeAgentSdkLoaderService` with three methods: `isAvailable`, `install(token)`, `load()`.
- Exported `CLAUDE_SDK_EXTENSION_ID = 'ms-vscode.vscode-claude-sdk'`.

**Implementations**
- `BundledClaudeAgentSdkLoaderService` (`claude/node/`): wraps the existing `require('@anthropic-ai/claude-agent-sdk')` path. `isAvailable` is always true, `install` is a no-op returning true.
- `VsCodeClaudeAgentSdkLoaderService` (`claude/vscode-node/`): looks up the SDK extension, triggers `workbench.extensions.installExtension` on demand, waits for `vscode.extensions.onDidChange` with a configurable timeout, and activates the extension to retrieve its exported SDK.
- `RoutingClaudeAgentSdkLoaderService` (`claude/vscode-node/`): reads `ConfigKey.ClaudeAgentSdkUseExtension` once and delegates to one of the two loaders. Switching loaders requires an extension reload — intentional, to avoid mid-session loader swaps.

**Install-on-demand UX (`claudeChatSessionContentProvider.ts`)**
When the routed loader reports the SDK is missing, the chat handler streams an "Installing the Claude Agent SDK…" message and awaits `install(token)`. On success it proceeds; on failure it surfaces an install button pointing at the marketplace. If the user cancels mid-install, the handler returns an empty result with no error/button (cancellation is not a failure).

**Configuration (`platform/configuration/common/configurationService.ts`)**
- `ClaudeAgentSdkUseExtension` (`ConfigType.ExperimentBased`): controls routing.
- `ClaudeAgentSdkExtensionInstallTimeout`: bounds the install wait (default tuned to give the marketplace flow room without hanging the chat turn).

**Caller migrations**
All SDK consumers (`claudeCodeSdkService`, `claudeCodeAgent`, `claudeCodeModels`, MCP server registration, session state, etc.) now go through the loader service instead of importing the SDK directly. The bundled loader path keeps the existing behavior bit-for-bit when the experiment flag is off.

## Why

1. **Decoupling release cadence**: The Anthropic SDK ships breaking changes regularly; binding our release train to it forces lockstep updates. Out-of-band shipping lets the SDK extension iterate independently.
2. **Bundle size**: The SDK is non-trivial. Moving it out of the Copilot Chat bundle is a net win for download/extract/activation time for users who don't use Claude.
3. **Future flexibility**: A clean `IClaudeAgentSdkLoaderService` boundary lets us swap in alternative loaders (e.g. for tests, for a remote SDK proxy) without touching consumers.

## Notable design points

- **One-shot routing decision**: The router picks bundled vs. extension at construction and sticks with it. Flipping the experiment mid-session would require flushing every cached SDK reference; a reload is simpler and safer.
- **Cancellation correctness**: The extension loader's `install()` checks the token before invoking the install command, re-checks `isAvailable` after registering the `onDidChange` listener (to close a race where the extension becomes available between the pre-check and the listener hookup), and races the wait against both the configured timeout and the caller's token.
- **Error visibility**: The install-command catch logs via `ILogService.warn` so install failures aren't silently swallowed.
- **SDK caching with retry**: `_sdk` caches the activation promise on success but clears it on failure so the next call retries instead of caching a rejected promise.

## Test plan

- [x] `npx vitest run` for both new spec files passes (11 + 90 tests).
- [x] Lint clean on changed files.
- [x] Manually verify with experiment off: behavior unchanged, SDK loads from bundle.
- [ ] Manually verify with experiment on and SDK extension missing: install button appears, install completes, chat proceeds.
- [x] Manually verify with experiment on, SDK extension installed: chat proceeds without prompt.
- [ ] Manually verify cancellation mid-install returns cleanly with no error UI.