### PR TITLE
Improve menu item selection border for themes

### DIFF
--- a/extensions/theme-defaults/themes/2026-dark.json
+++ b/extensions/theme-defaults/themes/2026-dark.json
@@ -95,6 +95,7 @@
 		"menu.foreground": "#bfbfbf",
 		"menu.selectionBackground": "#3994BC26",
 		"menu.selectionForeground": "#bfbfbf",
+		"menu.selectionBorder": "#3994BC",
 		"menu.separatorBackground": "#2A2B2C",
 		"menu.border": "#2A2B2CFF",
 		"commandCenter.foreground": "#bfbfbf",

--- a/extensions/theme-defaults/themes/2026-light.json
+++ b/extensions/theme-defaults/themes/2026-light.json
@@ -104,6 +104,7 @@
 		"menu.foreground": "#202020",
 		"menu.selectionBackground": "#0069CC1A",
 		"menu.selectionForeground": "#202020",
+		"menu.selectionBorder": "#0069CC",
 		"menu.separatorBackground": "#EEEEF1",
 		"menu.border": "#E4E5E6FF",
 		"commandCenter.foreground": "#202020",

--- a/src/vs/base/browser/ui/menu/menu.ts
+++ b/src/vs/base/browser/ui/menu/menu.ts
@@ -1266,6 +1266,21 @@ ${formatRule(Codicon.menuSubmenu)}
 	background: none;
 }
 
+/* Show the menu item selection border only for keyboard navigation. A mouse-focused item is always under the pointer (:hover), so the border is suppressed there and the selection background indicates focus instead. A keyboard-focused item is not under the pointer, so the inline selection border remains visible. */
+.monaco-menu .monaco-action-bar.vertical .action-item.focused:hover .action-menu-item {
+	outline: none !important;
+	outline-offset: 0 !important;
+}
+
+/* High contrast themes always show the selection border to indicate the focused item, regardless of input modality. */
+.hc-black .monaco-menu .monaco-action-bar.vertical .action-item.focused .action-menu-item,
+.hc-light .monaco-menu .monaco-action-bar.vertical .action-item.focused .action-menu-item,
+:host-context(.hc-black) .monaco-menu .monaco-action-bar.vertical .action-item.focused .action-menu-item,
+:host-context(.hc-light) .monaco-menu .monaco-action-bar.vertical .action-item.focused .action-menu-item {
+	outline: 1px solid var(--vscode-menu-selectionBorder) !important;
+	outline-offset: -1px !important;
+}
+
 /* Vertical Action Bar Styles */
 
 .monaco-menu .monaco-action-bar.vertical {

--- a/src/vs/base/browser/ui/menu/menu.ts
+++ b/src/vs/base/browser/ui/menu/menu.ts
@@ -1272,11 +1272,11 @@ ${formatRule(Codicon.menuSubmenu)}
 	outline-offset: 0 !important;
 }
 
-/* High contrast themes always show the selection border to indicate the focused item, regardless of input modality. */
-.hc-black .monaco-menu .monaco-action-bar.vertical .action-item.focused .action-menu-item,
-.hc-light .monaco-menu .monaco-action-bar.vertical .action-item.focused .action-menu-item,
-:host-context(.hc-black) .monaco-menu .monaco-action-bar.vertical .action-item.focused .action-menu-item,
-:host-context(.hc-light) .monaco-menu .monaco-action-bar.vertical .action-item.focused .action-menu-item {
+/* High contrast themes always show the selection border to indicate the focused item, regardless of input modality. The duplicated .monaco-menu raises specificity above the keyboard-only suppression rule above so this wins independent of declaration order. */
+.hc-black .monaco-menu.monaco-menu .monaco-action-bar.vertical .action-item.focused .action-menu-item,
+.hc-light .monaco-menu.monaco-menu .monaco-action-bar.vertical .action-item.focused .action-menu-item,
+:host-context(.hc-black) .monaco-menu.monaco-menu .monaco-action-bar.vertical .action-item.focused .action-menu-item,
+:host-context(.hc-light) .monaco-menu.monaco-menu .monaco-action-bar.vertical .action-item.focused .action-menu-item {
 	outline: 1px solid var(--vscode-menu-selectionBorder) !important;
 	outline-offset: -1px !important;
 }

--- a/src/vs/base/browser/ui/menu/menu.ts
+++ b/src/vs/base/browser/ui/menu/menu.ts
@@ -1266,8 +1266,8 @@ ${formatRule(Codicon.menuSubmenu)}
 	background: none;
 }
 
-/* Show the menu item selection border only for keyboard navigation. A mouse-focused item is always under the pointer (:hover), so the border is suppressed there and the selection background indicates focus instead. A keyboard-focused item is not under the pointer, so the inline selection border remains visible. */
-.monaco-menu .monaco-action-bar.vertical .action-item.focused:hover .action-menu-item {
+/* Show the menu item selection border only for keyboard navigation. Pointer-driven focus typically does not set :focus-visible, so suppress the border in that case. */
+.monaco-menu .monaco-action-bar.vertical .action-menu-item:focus:not(:focus-visible) {
 	outline: none !important;
 	outline-offset: 0 !important;
 }


### PR DESCRIPTION
Enhance the menu item selection border for both light and dark themes, ensuring better visibility during keyboard navigation and high contrast scenarios. This update improves user experience by providing a clear indication of the focused menu item.

Fixes https://github.com/microsoft/vscode/issues/314929

