### PR TITLE
sessions: multi-chat support for the local provider

### DIFF
--- a/src/vs/sessions/contrib/providers/localChatSessions/LOCAL_CHAT_SESSIONS_PROVIDER.md
+++ b/src/vs/sessions/contrib/providers/localChatSessions/LOCAL_CHAT_SESSIONS_PROVIDER.md
@@ -121,7 +121,7 @@ A `MutableDisposable` on `LocalSession` ensures repeated `trackModel` calls don'
 - **`renameChat`** — calls `chatService.setSessionTitle()`, updates session title, persists.
 - **`setModel`** — only meaningful for the current new session before send; updates pre-send model id.
 - **`createNewChat`** — for the current new session, returns the already-prepared `IChat` and updates `mainChat`. For an existing committed session, creates a subsequent (child) chat linked to the primary via `parentResource`.
-- **`deleteChat`** — removes a single child chat from a multi-chat session; deleting the primary (or the last remaining chat) removes the whole session.
+- **`deleteChat`** — removes a single child chat from a multi-chat session after a confirmation dialog; deleting the primary (or the last remaining chat) removes the whole session. An unknown/stale chat URI is a no-op.
 
 ## Multi-Chat Support
 

--- a/src/vs/sessions/contrib/providers/localChatSessions/LOCAL_CHAT_SESSIONS_PROVIDER.md
+++ b/src/vs/sessions/contrib/providers/localChatSessions/LOCAL_CHAT_SESSIONS_PROVIDER.md
@@ -55,6 +55,7 @@ interface IStoredLocalSession {
 	readonly lastMessageDate: number;
 	readonly workingDirectory: UriComponents; // mandatory
 	readonly archived?: boolean;
+	readonly parentUri?: UriComponents; // primary chat's URI for child chats
 }
 ```
 
@@ -119,7 +120,18 @@ A `MutableDisposable` on `LocalSession` ensures repeated `trackModel` calls don'
 - **`deleteSession`** — calls `chatService.removeHistoryEntry()`, removes from cache, removes from storage.
 - **`renameChat`** — calls `chatService.setSessionTitle()`, updates session title, persists.
 - **`setModel`** — only meaningful for the current new session before send; updates pre-send model id.
-- **`createNewChat`** — for the current new session, returns the already-prepared `IChat` and updates `mainChat`.
+- **`createNewChat`** — for the current new session, returns the already-prepared `IChat` and updates `mainChat`. For an existing committed session, creates a subsequent (child) chat linked to the primary via `parentResource`.
+- **`deleteChat`** — removes a single child chat from a multi-chat session; deleting the primary (or the last remaining chat) removes the whole session.
+
+## Multi-Chat Support
+
+A local session may host multiple chats. The hierarchy is stored entirely in the provider's own metadata — there is no setting and multi-chat is always enabled.
+
+- Each `LocalSession` has an optional `parentResource`. A session with no `parentResource` is a **primary** chat; one with a `parentResource` pointing at the primary's resource is a **child** chat.
+- The parent→child link is persisted via `IStoredLocalSession.parentUri` so the hierarchy survives reloads.
+- `getSessions()` surfaces only primary chats; children are aggregated into their primary's group. `_buildGroupISession` wraps a primary plus its children into a single `ISession` whose `chats` observable re-derives on group-membership changes, and whose `status`/`updatedAt`/`isRead`/`lastTurnEnd` are aggregated across the group. Such sessions report `capabilities.supportsMultipleChats: true`.
+- The management service sends subsequent messages with the group (primary) `sessionId` and the child's chat resource; `sendRequest` routes these to `_sendChildChat`. A child is added to the cache immediately on `createNewChat` but only persisted once its first send succeeds; a rejected/unsent child is rolled back.
+- On load, a child whose `parentUri` is not present in storage is promoted to a primary (non-destructive orphan handling).
 
 ## Picker Contributions
 
@@ -129,6 +141,6 @@ Local sessions reuse the Copilot provider's pickers (`ModePicker`, `SessionModel
 
 - **No `IAgentSessionsService` dependency.** Uses `IChatService` directly.
 - **No untitled→committed URI swap.** Local session resources never change.
-- **No multi-chat support.** Each local session has exactly one chat.
+- **Multi-chat hierarchy stored in provider metadata.** A local session may host multiple chats; the parent→child link is persisted via `IStoredLocalSession.parentUri` (see Multi-Chat Support above).
 - **Self-managed session list.** Storage owns the source of truth, not the chat history.
 - **No worktree / branch / isolation.** Local sessions run in-process against the workspace folder as-is.

--- a/src/vs/sessions/contrib/providers/localChatSessions/browser/localChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/localChatSessions/browser/localChatSessionsProvider.ts
@@ -25,6 +25,7 @@ import { IConfigurationService } from '../../../../../platform/configuration/com
 import { ILabelService } from '../../../../../platform/label/common/label.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
 import { IFileService } from '../../../../../platform/files/common/files.js';
+import { IDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
 import { ILanguageModelsService } from '../../../../../workbench/contrib/chat/common/languageModels.js';
 import { ILanguageModelToolsService } from '../../../../../workbench/contrib/chat/common/tools/languageModelToolsService.js';
@@ -425,6 +426,7 @@ export class LocalChatSessionsProvider extends Disposable implements ISessionsPr
 		@ILabelService private readonly labelService: ILabelService,
 		@ILogService private readonly logService: ILogService,
 		@IStorageService private readonly storageService: IStorageService,
+		@IDialogService private readonly dialogService: IDialogService,
 	) {
 		super();
 
@@ -786,6 +788,16 @@ export class LocalChatSessionsProvider extends Disposable implements ISessionsPr
 		// (and any children).
 		if (group.length <= 1 || isEqual(target.resource, primary.resource)) {
 			return this.deleteSession(sessionId);
+		}
+
+		// Confirm before deleting a sub chat from a multi-chat session.
+		const confirmed = await this.dialogService.confirm({
+			message: localize('deleteChat.confirm', "Are you sure you want to delete this chat?"),
+			detail: localize('deleteChat.detail', "This action cannot be undone."),
+			primaryButton: localize('deleteChat.delete', "Delete")
+		});
+		if (!confirmed.confirmed) {
+			return;
 		}
 
 		await this.chatService.removeHistoryEntry(target.resource);

--- a/src/vs/sessions/contrib/providers/localChatSessions/browser/localChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/localChatSessions/browser/localChatSessionsProvider.ts
@@ -776,9 +776,15 @@ export class LocalChatSessionsProvider extends Disposable implements ISessionsPr
 		const group = this._getGroupChats(primary);
 		const target = group.find(chat => isEqual(chat.resource, chatUri));
 
+		// Unknown chat (e.g. a stale or incorrect URI): do nothing rather than
+		// risk wiping the whole session.
+		if (!target) {
+			return;
+		}
+
 		// Deleting the only chat or the primary chat removes the whole session
 		// (and any children).
-		if (group.length <= 1 || !target || isEqual(target.resource, primary.resource)) {
+		if (group.length <= 1 || isEqual(target.resource, primary.resource)) {
 			return this.deleteSession(sessionId);
 		}
 

--- a/src/vs/sessions/contrib/providers/localChatSessions/browser/localChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/localChatSessions/browser/localChatSessionsProvider.ts
@@ -7,7 +7,7 @@ import { Emitter, Event } from '../../../../../base/common/event.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { Disposable, MutableDisposable } from '../../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../../base/common/network.js';
-import { autorun, constObservable, IObservable, ISettableObservable, observableValue, transaction } from '../../../../../base/common/observable.js';
+import { autorun, constObservable, IObservable, IReader, ISettableObservable, observableFromEvent, observableValue, transaction } from '../../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { URI, UriComponents } from '../../../../../base/common/uri.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
@@ -15,7 +15,7 @@ import { IChatService, IChatSendRequestOptions, IChatDetail, convertLegacyChatSe
 import { IChatSessionFileChange2, IChatSessionProviderOptionItem, SessionType } from '../../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { ISession, IChat, ISessionGitRepository, ISessionFolder, ISessionWorkspace, SessionStatus, ISessionType, ISessionFileChange, toSessionId, SESSION_WORKSPACE_GROUP_LOCAL, IChatCheckpoints } from '../../../../services/sessions/common/session.js';
 import { ChatAgentLocation, ChatConfiguration, ChatModeKind, ChatPermissionLevel, isChatPermissionLevel } from '../../../../../workbench/contrib/chat/common/constants.js';
-import { basename, dirname } from '../../../../../base/common/resources.js';
+import { basename, dirname, isEqual } from '../../../../../base/common/resources.js';
 import { ISendRequestOptions, ISessionChangeEvent, ISessionsProvider } from '../../../../services/sessions/common/sessionsProvider.js';
 import { isBuiltinChatMode, IChatMode } from '../../../../../workbench/contrib/chat/common/chatModes.js';
 import { IChatModel } from '../../../../../workbench/contrib/chat/common/model/chatModel.js';
@@ -53,6 +53,12 @@ interface IStoredLocalSession {
 	readonly lastMessageDate: number;
 	readonly workingDirectory: UriComponents;
 	readonly archived?: boolean;
+	/**
+	 * Resource of the primary (parent) chat when this entry is a subsequent
+	 * chat in a multi-chat session. `undefined`/absent for primary chats.
+	 * This is how the chat hierarchy is persisted in the provider metadata.
+	 */
+	readonly parentUri?: UriComponents;
 }
 
 /**
@@ -94,6 +100,14 @@ class LocalSession extends Disposable {
 	readonly sessionType = SessionType.Local;
 	readonly icon: ThemeIcon;
 	readonly createdAt: Date;
+
+	/**
+	 * Resource of the primary (parent) chat when this session is a subsequent
+	 * chat in a multi-chat group. `undefined` for primary chats.
+	 */
+	private _parentResource: URI | undefined;
+	get parentResource(): URI | undefined { return this._parentResource; }
+	setParentResource(resource: URI | undefined): void { this._parentResource = resource; }
 
 	private readonly _title = observableValue(this, '');
 	readonly title: IObservable<string> = this._title;
@@ -391,8 +405,14 @@ export class LocalChatSessionsProvider extends Disposable implements ISessionsPr
 	private readonly _onDidChangeSessions = this._register(new Emitter<ISessionChangeEvent>());
 	readonly onDidChangeSessions: Event<ISessionChangeEvent> = this._onDidChangeSessions.event;
 
-	/** Cache of sessions, keyed by resource URI string. */
+	/** Cache of sessions, keyed by resource URI string. Holds every chat (primary and children). */
 	private readonly _sessionCache = new Map<string, LocalSession>();
+
+	/** Aggregated multi-chat session wrappers, keyed by group (primary) session id. */
+	private readonly _sessionGroupCache = new Map<string, ISession>();
+
+	/** Fires when the set of chats in a group changes (chat added or removed). */
+	private readonly _onDidChangeGroupMembership = this._register(new Emitter<{ readonly groupKey: string }>());
 
 	private readonly _currentNewSession = this._register(new MutableDisposable<LocalSession>());
 
@@ -502,12 +522,26 @@ export class LocalChatSessionsProvider extends Disposable implements ISessionsPr
 	// -- Sessions --
 
 	getSessions(): ISession[] {
-		return Array.from(this._sessionCache.values()).map(session => this._toISession(session));
+		// Only primary chats surface as sessions; children are aggregated into
+		// their primary's group.
+		const sessions: ISession[] = [];
+		for (const session of this._sessionCache.values()) {
+			if (session.parentResource) {
+				continue;
+			}
+			sessions.push(this._toISession(session));
+		}
+		return sessions;
 	}
 
 	/**
 	 * Loads sessions from our own persisted storage. No calls to
 	 * {@link IChatService} are needed — all metadata is stored inline.
+	 *
+	 * All chats are loaded into the cache first so that the chat hierarchy
+	 * (children referencing their primary via `parentUri`) can be resolved.
+	 * A child whose primary is missing from storage is treated as a primary
+	 * (its `parentResource` is left unset) so it is never lost.
 	 */
 	private _loadPersistedSessions(): void {
 		const storedSessions = this._readStoredSessions();
@@ -515,7 +549,8 @@ export class LocalChatSessionsProvider extends Disposable implements ISessionsPr
 			return;
 		}
 
-		const added: ISession[] = [];
+		const storedKeys = new Set(storedSessions.map(s => URI.revive(s.uri).toString()));
+		const loaded: LocalSession[] = [];
 
 		for (const stored of storedSessions) {
 			const uri = URI.revive(stored.uri);
@@ -540,7 +575,24 @@ export class LocalChatSessionsProvider extends Disposable implements ISessionsPr
 			if (stored.archived) {
 				session.setArchived(true);
 			}
+			// Only honour the parent link when the primary is also present in
+			// storage; otherwise promote this orphan child to a primary.
+			if (stored.parentUri) {
+				const parentUri = URI.revive(stored.parentUri);
+				if (storedKeys.has(parentUri.toString())) {
+					session.setParentResource(parentUri);
+				}
+			}
 			this._sessionCache.set(key, session);
+			loaded.push(session);
+		}
+
+		// Fire `added` only for sessions that surface in `getSessions()`.
+		const added: ISession[] = [];
+		for (const session of loaded) {
+			if (session.parentResource) {
+				continue;
+			}
 			added.push(this._toISession(session));
 		}
 
@@ -581,6 +633,7 @@ export class LocalChatSessionsProvider extends Disposable implements ISessionsPr
 			createdAt: session.createdAt.getTime(),
 			lastMessageDate: session.updatedAt.get().getTime(),
 			workingDirectory: workingDirectory.toJSON(),
+			parentUri: session.parentResource?.toJSON(),
 		});
 		this._writeStoredSessions(sessions);
 	}
@@ -693,19 +746,49 @@ export class LocalChatSessionsProvider extends Disposable implements ISessionsPr
 			return;
 		}
 
-		await this.chatService.removeHistoryEntry(session.resource);
-		this._sessionCache.delete(session.resource.toString());
-		this._removeStoredSession(session.resource);
+		// Resolve the group: deleting a session removes its primary chat and
+		// all child chats. If a child id was passed, resolve to its primary.
+		const primary = this._resolvePrimary(session);
+		const group = this._getGroupChats(primary);
+
+		const groupISession = this._toISession(primary);
+
+		for (const chat of group) {
+			await this.chatService.removeHistoryEntry(chat.resource);
+			this._sessionCache.delete(chat.resource.toString());
+			this._removeStoredSession(chat.resource);
+			chat.dispose();
+		}
+
+		this._sessionGroupCache.delete(primary.sessionId);
 		if (this._currentNewSession.value?.sessionId === sessionId) {
 			this._currentNewSession.clear();
 		}
-		this._onDidChangeSessions.fire({ added: [], removed: [this._toISession(session)], changed: [] });
-		session.dispose();
+		this._onDidChangeSessions.fire({ added: [], removed: [groupISession], changed: [] });
 	}
 
-	async deleteChat(sessionId: string, _chatUri: URI): Promise<void> {
-		// Local sessions have a single chat — deleting the chat deletes the session
-		return this.deleteSession(sessionId);
+	async deleteChat(sessionId: string, chatUri: URI): Promise<void> {
+		const primary = this._findSession(sessionId);
+		if (!primary || primary.parentResource) {
+			return;
+		}
+
+		const group = this._getGroupChats(primary);
+		const target = group.find(chat => isEqual(chat.resource, chatUri));
+
+		// Deleting the only chat or the primary chat removes the whole session
+		// (and any children).
+		if (group.length <= 1 || !target || isEqual(target.resource, primary.resource)) {
+			return this.deleteSession(sessionId);
+		}
+
+		await this.chatService.removeHistoryEntry(target.resource);
+		this._sessionCache.delete(target.resource.toString());
+		this._removeStoredSession(target.resource);
+		target.dispose();
+
+		this._onDidChangeGroupMembership.fire({ groupKey: primary.sessionId });
+		this._onDidChangeSessions.fire({ added: [], removed: [], changed: [this._toISession(primary)] });
 	}
 
 	async renameChat(_sessionId: string, chatUri: URI, title: string): Promise<void> {
@@ -725,46 +808,169 @@ export class LocalChatSessionsProvider extends Disposable implements ISessionsPr
 			session.mainChat.set(chat, undefined);
 			return chat;
 		}
+
+		const primary = this._findSession(sessionId);
+		if (primary && !primary.parentResource) {
+			return this._createNewSubsequentChat(primary);
+		}
+
 		throw new Error(`Session '${sessionId}' not found or is not the current new session`);
+	}
+
+	/**
+	 * Creates a subsequent chat within an existing multi-chat session. The new
+	 * chat is linked to the primary chat via {@link LocalSession.parentResource}
+	 * and added to the cache so it appears in the session's `chats` group. It is
+	 * not persisted until its first {@link sendRequest} succeeds.
+	 */
+	private _createNewSubsequentChat(primary: LocalSession): IChat {
+		const workspace = primary.workspace.get();
+		if (!workspace) {
+			throw new Error('Cannot create a new chat — primary session has no workspace');
+		}
+
+		const child = this.instantiationService.createInstance(LocalSession, undefined, workspace, this.id);
+		child.setParentResource(primary.resource);
+		child.setPermissionLevel(this._defaultPermissionLevel());
+		child.setModelId(primary.modelId.get());
+		child.setTitle(localize('newChat', "New Chat"));
+
+		this._sessionCache.set(child.resource.toString(), child);
+		this._onDidChangeGroupMembership.fire({ groupKey: primary.sessionId });
+		this._onDidChangeSessions.fire({ added: [], removed: [], changed: [this._toISession(primary)] });
+
+		return buildChat(child);
 	}
 
 	// -- Send Request --
 
 	async sendRequest(sessionId: string, chatResource: URI, options: ISendRequestOptions): Promise<ISession> {
+		// First chat of a brand-new session.
 		const newSession = this._currentNewSession.value;
-		if (!newSession || newSession.sessionId !== sessionId) {
-			throw new Error(`Session '${sessionId}' not found`);
-		}
-		if (chatResource.toString() !== newSession.resource.toString()) {
-			throw new Error(`Chat resource ${chatResource.toString()} does not match session resource ${newSession.resource.toString()}`);
+		if (newSession && newSession.sessionId === sessionId) {
+			if (chatResource.toString() !== newSession.resource.toString()) {
+				throw new Error(`Chat resource ${chatResource.toString()} does not match session resource ${newSession.resource.toString()}`);
+			}
+			return this._sendFirstChat(newSession, chatResource, options);
 		}
 
-		const { query, attachedContext } = options;
+		// Subsequent chat in an existing multi-chat session. The management
+		// service sends with the group (primary) session id and the child's
+		// chat resource.
+		const primary = this._findSession(sessionId);
+		const child = this._sessionCache.get(chatResource.toString());
+		if (primary && !primary.parentResource && child && child.parentResource && isEqual(child.parentResource, primary.resource)) {
+			return this._sendChildChat(primary, child, chatResource, options);
+		}
 
-		newSession.setTitle(query.split('\n')[0].substring(0, 100) || localize('newSession', "New Session"));
+		throw new Error(`Session '${sessionId}' not found`);
+	}
+
+	private async _sendFirstChat(newSession: LocalSession, chatResource: URI, options: ISendRequestOptions): Promise<ISession> {
+		newSession.setTitle(options.query.split('\n')[0].substring(0, 100) || localize('newSession', "New Session"));
 		newSession.setStatus(SessionStatus.InProgress);
 
 		const newISession = this._toISession(newSession);
 		this._onDidChangeSessions.fire({ added: [newISession], removed: [], changed: [] });
 
+		this.logService.debug(`[LocalChatSessionsProvider] Sending request for session ${newSession.sessionId}`);
+
+		const result = await this._dispatchSend(newSession, chatResource, options);
+		if (result.kind === 'rejected') {
+			this._currentNewSession.clearAndLeak();
+			this._sessionGroupCache.delete(newSession.sessionId);
+			this._onDidChangeSessions.fire({ added: [], removed: [newISession], changed: [] });
+			newSession.dispose();
+			throw new Error(`[LocalChatSessionsProvider] sendRequest rejected: ${result.reason}`);
+		}
+
+		// Put the new session into the cache and persist its URI.
+		this._sessionCache.set(newSession.resource.toString(), newSession);
+		this._addStoredSession(newSession);
+		this._currentNewSession.clearAndLeak();
+
+		// Track response completion to update session status and persist title
+		if (result.kind === 'sent') {
+			result.data.responseCompletePromise.then(() => {
+				newSession.setStatus(SessionStatus.Completed);
+				this._syncSessionFromModel(newSession);
+			}, error => {
+				// Response failed — still mark session completed so it doesn't appear stuck.
+				this.logService.error(`[LocalChatSessionsProvider] Response failed for session ${newSession.sessionId}:`, error);
+				newSession.setStatus(SessionStatus.Completed);
+				this._updateStoredSession(newSession);
+				this._onDidChangeSessions.fire({ added: [], removed: [], changed: [newISession] });
+			});
+		}
+
+		this._onDidChangeSessions.fire({ added: [], removed: [], changed: [newISession] });
+		return newISession;
+	}
+
+	private async _sendChildChat(primary: LocalSession, child: LocalSession, chatResource: URI, options: ISendRequestOptions): Promise<ISession> {
+		child.setTitle(options.query.split('\n')[0].substring(0, 100) || localize('newChat', "New Chat"));
+		child.setStatus(SessionStatus.InProgress);
+
+		const groupISession = this._toISession(primary);
+		this._onDidChangeSessions.fire({ added: [], removed: [], changed: [groupISession] });
+
+		this.logService.debug(`[LocalChatSessionsProvider] Sending request for chat ${child.sessionId} in session ${primary.sessionId}`);
+
+		const result = await this._dispatchSend(child, chatResource, options);
+		if (result.kind === 'rejected') {
+			// Roll back the unsent child so it does not linger in the group.
+			this._sessionCache.delete(child.resource.toString());
+			this._onDidChangeGroupMembership.fire({ groupKey: primary.sessionId });
+			this._onDidChangeSessions.fire({ added: [], removed: [], changed: [groupISession] });
+			child.dispose();
+			throw new Error(`[LocalChatSessionsProvider] sendRequest rejected: ${result.reason}`);
+		}
+
+		// Persist the now-committed child chat with its parent link.
+		this._addStoredSession(child);
+
+		if (result.kind === 'sent') {
+			result.data.responseCompletePromise.then(() => {
+				child.setStatus(SessionStatus.Completed);
+				this._syncSessionFromModel(child);
+			}, error => {
+				this.logService.error(`[LocalChatSessionsProvider] Response failed for chat ${child.sessionId}:`, error);
+				child.setStatus(SessionStatus.Completed);
+				this._updateStoredSession(child);
+				this._onDidChangeSessions.fire({ added: [], removed: [], changed: [groupISession] });
+			});
+		}
+
+		this._onDidChangeSessions.fire({ added: [], removed: [], changed: [groupISession] });
+		return groupISession;
+	}
+
+	/**
+	 * Applies pre-send configuration to the chat model and dispatches the
+	 * request to {@link IChatService}. Returns the raw send result; commit and
+	 * rollback bookkeeping is left to the caller.
+	 */
+	private async _dispatchSend(session: LocalSession, chatResource: URI, options: ISendRequestOptions): ReturnType<IChatService['sendRequest']> {
+		const { query, attachedContext } = options;
+
 		// Resolve mode
-		const modeKind = newSession.chatMode?.kind ?? ChatModeKind.Agent;
-		const modeIsBuiltin = newSession.chatMode ? isBuiltinChatMode(newSession.chatMode) : true;
+		const modeKind = session.chatMode?.kind ?? ChatModeKind.Agent;
+		const modeIsBuiltin = session.chatMode ? isBuiltinChatMode(session.chatMode) : true;
 		const modeId: 'ask' | 'agent' | 'edit' | 'custom' | undefined = modeIsBuiltin ? modeKind : 'custom';
 
-		const rawModeInstructions = newSession.chatMode?.modeInstructions?.get();
+		const rawModeInstructions = session.chatMode?.modeInstructions?.get();
 		const modeInstructions = rawModeInstructions ? {
-			name: newSession.chatMode!.name.get(),
+			name: session.chatMode!.name.get(),
 			content: rawModeInstructions.content,
 			toolReferences: this.toolsService.toToolReferences(rawModeInstructions.toolReferences),
 			metadata: rawModeInstructions.metadata,
 		} : undefined;
 
-		const permissionLevel = newSession.permissionLevel.get();
+		const permissionLevel = session.permissionLevel.get();
 
 		const sendOptions: IChatSendRequestOptions = {
 			location: ChatAgentLocation.Chat,
-			userSelectedModelId: newSession.selectedModelId,
+			userSelectedModelId: session.selectedModelId,
 			modeInfo: {
 				kind: modeKind,
 				isBuiltin: modeIsBuiltin,
@@ -777,42 +983,9 @@ export class LocalChatSessionsProvider extends Disposable implements ISessionsPr
 		};
 
 		// Set model/mode/permission state on the chat model before sending
-		const modelRef = await this._updateChatSessionState(chatResource, newSession);
-		this.logService.debug(`[LocalChatSessionsProvider] Sending request for session ${newSession.sessionId}`);
-
+		const modelRef = await this._updateChatSessionState(chatResource, session);
 		try {
-			const result = await this.chatService.sendRequest(chatResource, query, sendOptions);
-			if (result.kind === 'rejected') {
-				this._currentNewSession.clearAndLeak();
-				this._onDidChangeSessions.fire({ added: [], removed: [newISession], changed: [] });
-				newSession.dispose();
-				throw new Error(`[LocalChatSessionsProvider] sendRequest rejected: ${result.reason}`);
-			}
-
-			// Put the new session into the cache and persist its URI.
-			this._sessionCache.set(newSession.resource.toString(), newSession);
-			this._addStoredSession(newSession);
-			this._currentNewSession.clearAndLeak();
-
-			// Track response completion to update session status and persist title
-			if (result.kind === 'sent') {
-				result.data.responseCompletePromise.then(() => {
-					newSession.setStatus(SessionStatus.Completed);
-					this._syncSessionFromModel(newSession);
-				}, error => {
-					// Response failed — still mark session completed so it doesn't appear stuck.
-					this.logService.error(`[LocalChatSessionsProvider] Response failed for session ${newSession.sessionId}:`, error);
-					newSession.setStatus(SessionStatus.Completed);
-					this._updateStoredSession(newSession);
-					this._onDidChangeSessions.fire({ added: [], removed: [], changed: [newISession] });
-				});
-			}
-
-			this._onDidChangeSessions.fire({ added: [], removed: [], changed: [newISession] });
-			return newISession;
-		} catch (error) {
-			this.logService.error(`[LocalChatSessionsProvider] Failed to send request for session ${newSession.sessionId}:`, error);
-			throw error;
+			return await this.chatService.sendRequest(chatResource, query, sendOptions);
 		} finally {
 			modelRef?.dispose();
 		}
@@ -825,6 +998,7 @@ export class LocalChatSessionsProvider extends Disposable implements ISessionsPr
 			session.dispose();
 		}
 		this._sessionCache.clear();
+		this._sessionGroupCache.clear();
 		super.dispose();
 	}
 
@@ -890,36 +1064,106 @@ export class LocalChatSessionsProvider extends Disposable implements ISessionsPr
 		return undefined;
 	}
 
+	/** Resolves the primary (parent) chat of a session's group. */
+	private _resolvePrimary(session: LocalSession): LocalSession {
+		if (session.parentResource) {
+			return this._sessionCache.get(session.parentResource.toString()) ?? session;
+		}
+		return session;
+	}
+
+	/** Returns the primary chat followed by its children, ordered by creation time. */
+	private _getGroupChats(primary: LocalSession): LocalSession[] {
+		const children: LocalSession[] = [];
+		for (const session of this._sessionCache.values()) {
+			if (session.parentResource && isEqual(session.parentResource, primary.resource)) {
+				children.push(session);
+			}
+		}
+		children.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+		return [primary, ...children];
+	}
+
 	private _toISession(session: LocalSession): ISession {
-		const mainChat = session.mainChat;
-		const chatsObs = mainChat.map(c => [c] as readonly IChat[]);
-		const changesets = createChangesets(session.sessionType, session.workspace, chatsObs, this.instantiationService);
+		const primary = this._resolvePrimary(session);
+
+		const cached = this._sessionGroupCache.get(primary.sessionId);
+		if (cached) {
+			return cached;
+		}
+
+		const groupISession = this._buildGroupISession(primary);
+		this._sessionGroupCache.set(primary.sessionId, groupISession);
+		return groupISession;
+	}
+
+	/**
+	 * Wraps a primary {@link LocalSession} and its child chats into an
+	 * aggregated {@link ISession}. The `chats` observable re-derives whenever
+	 * group membership changes; per-chat state flows through each chat's own
+	 * observables captured by {@link buildChat}.
+	 */
+	private _buildGroupISession(primary: LocalSession): ISession {
+		const groupKey = primary.sessionId;
+
+		const chatsObs: IObservable<readonly IChat[]> = observableFromEvent(
+			this,
+			Event.filter(this._onDidChangeGroupMembership.event, e => e.groupKey === groupKey),
+			() => this._getGroupChats(primary).map(buildChat),
+		);
+
+		const changesets = createChangesets(primary.sessionType, primary.workspace, chatsObs, this.instantiationService);
 
 		return {
-			sessionId: session.sessionId,
-			resource: session.resource,
-			providerId: session.providerId,
-			sessionType: session.sessionType,
-			icon: session.icon,
-			createdAt: session.createdAt,
-			workspace: session.workspace,
-			title: session.title,
-			updatedAt: session.updatedAt,
-			status: session.status,
+			sessionId: primary.sessionId,
+			resource: primary.resource,
+			providerId: primary.providerId,
+			sessionType: primary.sessionType,
+			icon: primary.icon,
+			createdAt: primary.createdAt,
+			workspace: primary.workspace,
+			title: primary.title,
+			updatedAt: chatsObs.map((chats, reader) => this._latestDate(chats, c => c.updatedAt.read(reader)) ?? primary.updatedAt.read(reader)),
+			status: chatsObs.map((chats, reader) => this._aggregateStatus(chats, reader)),
 			changesets,
-			changes: session.changes,
-			modelId: session.modelId,
-			mode: session.mode,
-			loading: session.loading,
-			isArchived: session.isArchived,
-			isRead: session.isRead,
-			description: session.description,
-			lastTurnEnd: session.lastTurnEnd,
+			changes: primary.changes,
+			modelId: primary.modelId,
+			mode: primary.mode,
+			loading: primary.loading,
+			isArchived: primary.isArchived,
+			isRead: chatsObs.map((chats, reader) => chats.every(c => c.isRead.read(reader))),
+			description: primary.description,
+			lastTurnEnd: chatsObs.map((chats, reader) => this._latestDate(chats, c => c.lastTurnEnd.read(reader))),
 			chats: chatsObs,
-			mainChat,
+			mainChat: primary.mainChat,
 			capabilities: {
-				supportsMultipleChats: false,
+				supportsMultipleChats: true,
 			},
 		};
+	}
+
+	private _latestDate(chats: readonly IChat[], getter: (chat: IChat) => Date | undefined): Date | undefined {
+		let latest: Date | undefined;
+		for (const chat of chats) {
+			const date = getter(chat);
+			if (date && (!latest || date > latest)) {
+				latest = date;
+			}
+		}
+		return latest;
+	}
+
+	private _aggregateStatus(chats: readonly IChat[], reader: IReader): SessionStatus {
+		for (const chat of chats) {
+			if (chat.status.read(reader) === SessionStatus.NeedsInput) {
+				return SessionStatus.NeedsInput;
+			}
+		}
+		for (const chat of chats) {
+			if (chat.status.read(reader) === SessionStatus.InProgress) {
+				return SessionStatus.InProgress;
+			}
+		}
+		return chats[0].status.read(reader);
 	}
 }

--- a/src/vs/sessions/contrib/providers/localChatSessions/test/browser/localChatSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/localChatSessions/test/browser/localChatSessionsProvider.test.ts
@@ -7,7 +7,7 @@ import assert from 'assert';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { Disposable, DisposableStore } from '../../../../../../base/common/lifecycle.js';
 import { IObservable, observableValue } from '../../../../../../base/common/observable.js';
-import { URI } from '../../../../../../base/common/uri.js';
+import { URI, UriComponents } from '../../../../../../base/common/uri.js';
 import { mock } from '../../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
@@ -16,7 +16,7 @@ import { IInstantiationService } from '../../../../../../platform/instantiation/
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { ILabelService } from '../../../../../../platform/label/common/label.js';
 import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
-import { IStorageService } from '../../../../../../platform/storage/common/storage.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../../../platform/storage/common/storage.js';
 import { TestStorageService } from '../../../../../../workbench/test/common/workbenchTestServices.js';
 import { ChatAgentLocation } from '../../../../../../workbench/contrib/chat/common/constants.js';
 import { IChatModel } from '../../../../../../workbench/contrib/chat/common/model/chatModel.js';
@@ -50,6 +50,9 @@ class MockChatService extends Disposable {
 
 	readonly sendRequestCalls: { resource: URI; query: string }[] = [];
 
+	/** When a query matches an entry here, sendRequest reports a rejection. */
+	readonly rejectQueries = new Set<string>();
+
 	private readonly _onDidDisposeSession = this._register(new Emitter<{ readonly sessionResources: readonly URI[]; readonly reason: 'cleared' }>());
 	readonly onDidDisposeSession = this._onDidDisposeSession.event;
 
@@ -77,6 +80,9 @@ class MockChatService extends Disposable {
 
 	async sendRequest(resource: URI, query: string) {
 		this.sendRequestCalls.push({ resource, query });
+		if (this.rejectQueries.has(query)) {
+			return { kind: 'rejected', reason: 'test-rejected' };
+		}
 		return { kind: 'sent', data: { responseCompletePromise: Promise.resolve(), responseCreatedPromise: Promise.resolve({}) } };
 	}
 
@@ -124,11 +130,31 @@ function createFixture(store: DisposableStore): ITestFixture {
 
 const TEST_FOLDER = URI.file('/test/folder');
 
+/** Storage key used by the provider to persist the session list. */
+const STORAGE_KEY_SESSIONS = 'sessions.localChat.sessions';
+
+interface IReadStoredSession {
+	readonly uri: UriComponents;
+	readonly parentUri?: UriComponents;
+}
+
+function readStoredSessions(storage: TestStorageService): IReadStoredSession[] {
+	const raw = storage.get(STORAGE_KEY_SESSIONS, StorageScope.PROFILE);
+	return raw ? JSON.parse(raw) as IReadStoredSession[] : [];
+}
+
 async function commitNewSession(provider: LocalChatSessionsProvider): Promise<ISession> {
 	const newSession = provider.createNewSession(TEST_FOLDER, LocalSessionType.id);
 	const chat = await provider.createNewChat(newSession.sessionId);
 	await provider.sendRequest(newSession.sessionId, chat.resource, { query: 'hello' });
 	return newSession;
+}
+
+/** Adds and sends a subsequent chat to an already-committed multi-chat session. */
+async function addChat(provider: LocalChatSessionsProvider, session: ISession, query = 'second'): Promise<URI> {
+	const chat = await provider.createNewChat(session.sessionId);
+	await provider.sendRequest(session.sessionId, chat.resource, { query });
+	return chat.resource;
 }
 
 // ---- Suite ----------------------------------------------------------------
@@ -268,5 +294,170 @@ suite('LocalChatSessionsProvider', () => {
 		assert.strictEqual(LocalSessionType.id, 'local');
 		assert.strictEqual(LOCAL_SESSION_ENABLED_SETTING, 'sessions.chat.localAgent.enabled');
 		assert.ok(Event.None);
+	});
+
+	// ---- Multi-chat ---------------------------------------------------------
+
+	test('committed sessions advertise supportsMultipleChats', async () => {
+		const store = leaks.add(new DisposableStore());
+		const { instantiationService } = createFixture(store);
+		const provider = store.add(instantiationService.createInstance(LocalChatSessionsProvider));
+
+		const session = await commitNewSession(provider);
+		assert.strictEqual(session.capabilities.supportsMultipleChats, true);
+		assert.strictEqual(session.chats.get().length, 1);
+	});
+
+	test('createNewChat adds a second chat to an existing session', async () => {
+		const store = leaks.add(new DisposableStore());
+		const { instantiationService } = createFixture(store);
+		const provider = store.add(instantiationService.createInstance(LocalChatSessionsProvider));
+
+		const session = await commitNewSession(provider);
+		await addChat(provider, session);
+
+		// Still one session (the group), now with two chats.
+		assert.strictEqual(provider.getSessions().length, 1);
+		assert.strictEqual(provider.getSessions()[0].chats.get().length, 2);
+	});
+
+	test('persists the chat hierarchy and restores it grouped', async () => {
+		const store = leaks.add(new DisposableStore());
+		const { instantiationService } = createFixture(store);
+
+		const provider = store.add(instantiationService.createInstance(LocalChatSessionsProvider));
+		const session = await commitNewSession(provider);
+		await addChat(provider, session);
+
+		const provider2 = store.add(instantiationService.createInstance(LocalChatSessionsProvider));
+		await Event.toPromise(provider2.onDidChangeSessions);
+
+		const restored = provider2.getSessions();
+		assert.strictEqual(restored.length, 1);
+		assert.strictEqual(restored[0].resource.toString(), session.resource.toString());
+		assert.strictEqual(restored[0].chats.get().length, 2);
+	});
+
+	test('deleteChat removes a child chat but keeps the session', async () => {
+		const store = leaks.add(new DisposableStore());
+		const { instantiationService } = createFixture(store);
+		const provider = store.add(instantiationService.createInstance(LocalChatSessionsProvider));
+
+		const session = await commitNewSession(provider);
+		const childResource = await addChat(provider, session);
+		assert.strictEqual(provider.getSessions()[0].chats.get().length, 2);
+
+		await provider.deleteChat(session.sessionId, childResource);
+		assert.strictEqual(provider.getSessions().length, 1);
+		assert.strictEqual(provider.getSessions()[0].chats.get().length, 1);
+	});
+
+	test('deleteSession removes the primary chat and all children', async () => {
+		const store = leaks.add(new DisposableStore());
+		const { instantiationService } = createFixture(store);
+		const provider = store.add(instantiationService.createInstance(LocalChatSessionsProvider));
+
+		const session = await commitNewSession(provider);
+		await addChat(provider, session);
+
+		await provider.deleteSession(session.sessionId);
+		assert.strictEqual(provider.getSessions().length, 0);
+
+		const provider2 = store.add(instantiationService.createInstance(LocalChatSessionsProvider));
+		await Promise.resolve();
+		await Promise.resolve();
+		assert.strictEqual(provider2.getSessions().length, 0);
+	});
+
+	test('a rejected subsequent chat send is rolled back', async () => {
+		const store = leaks.add(new DisposableStore());
+		const { instantiationService, chatService } = createFixture(store);
+		const provider = store.add(instantiationService.createInstance(LocalChatSessionsProvider));
+
+		const session = await commitNewSession(provider);
+		chatService.rejectQueries.add('boom');
+
+		const chat = await provider.createNewChat(session.sessionId);
+		assert.strictEqual(provider.getSessions()[0].chats.get().length, 2);
+
+		await assert.rejects(provider.sendRequest(session.sessionId, chat.resource, { query: 'boom' }));
+
+		// The unsent child is rolled back, leaving a single chat.
+		assert.strictEqual(provider.getSessions().length, 1);
+		assert.strictEqual(provider.getSessions()[0].chats.get().length, 1);
+	});
+
+	test('persists the parent link in the child chat metadata', async () => {
+		const store = leaks.add(new DisposableStore());
+		const { instantiationService, storage } = createFixture(store);
+		const provider = store.add(instantiationService.createInstance(LocalChatSessionsProvider));
+
+		const session = await commitNewSession(provider);
+		const childResource = await addChat(provider, session);
+
+		const stored = readStoredSessions(storage);
+		const primaryEntry = stored.find(s => URI.revive(s.uri).toString() === session.resource.toString());
+		const childEntry = stored.find(s => URI.revive(s.uri).toString() === childResource.toString());
+
+		assert.strictEqual(primaryEntry?.parentUri, undefined);
+		assert.ok(childEntry?.parentUri);
+		assert.strictEqual(URI.revive(childEntry.parentUri!).toString(), session.resource.toString());
+	});
+
+	test('promotes an orphaned child to a primary when its parent is missing', async () => {
+		const store = leaks.add(new DisposableStore());
+		const { instantiationService, storage } = createFixture(store);
+		const provider = store.add(instantiationService.createInstance(LocalChatSessionsProvider));
+
+		const session = await commitNewSession(provider);
+		const childResource = await addChat(provider, session);
+
+		// Simulate corrupted/partial storage where the primary entry is gone.
+		const withoutPrimary = readStoredSessions(storage).filter(s => URI.revive(s.uri).toString() !== session.resource.toString());
+		storage.store(STORAGE_KEY_SESSIONS, JSON.stringify(withoutPrimary), StorageScope.PROFILE, StorageTarget.MACHINE);
+
+		const provider2 = store.add(instantiationService.createInstance(LocalChatSessionsProvider));
+		await Event.toPromise(provider2.onDidChangeSessions);
+
+		// The orphan surfaces as its own single-chat primary session rather than disappearing.
+		const sessions = provider2.getSessions();
+		assert.strictEqual(sessions.length, 1);
+		assert.strictEqual(sessions[0].resource.toString(), childResource.toString());
+		assert.strictEqual(sessions[0].chats.get().length, 1);
+	});
+
+	test('deleteChat on the primary chat deletes the whole session', async () => {
+		const store = leaks.add(new DisposableStore());
+		const { instantiationService } = createFixture(store);
+		const provider = store.add(instantiationService.createInstance(LocalChatSessionsProvider));
+
+		const session = await commitNewSession(provider);
+		await addChat(provider, session);
+
+		await provider.deleteChat(session.sessionId, session.resource);
+		assert.strictEqual(provider.getSessions().length, 0);
+	});
+
+	test('group status aggregates across child chats', async () => {
+		const store = leaks.add(new DisposableStore());
+		const { instantiationService, chatService } = createFixture(store);
+		const provider = store.add(instantiationService.createInstance(LocalChatSessionsProvider));
+
+		const session = await commitNewSession(provider);
+		const childResource = await addChat(provider, session);
+
+		// Drive the child chat's request state; the group must reflect it.
+		const childInProgress = observableValue<boolean>('childInProgress', false);
+		chatService.registerModel(createMockModel(childResource, { requestInProgress: childInProgress }));
+		chatService.fireSubmitRequest(childResource);
+
+		const group = provider.getSessions()[0];
+		assert.strictEqual(group.status.get(), SessionStatus.Completed);
+
+		childInProgress.set(true, undefined);
+		assert.strictEqual(group.status.get(), SessionStatus.InProgress);
+
+		childInProgress.set(false, undefined);
+		assert.strictEqual(group.status.get(), SessionStatus.Completed);
 	});
 });

--- a/src/vs/sessions/contrib/providers/localChatSessions/test/browser/localChatSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/localChatSessions/test/browser/localChatSessionsProvider.test.ts
@@ -11,6 +11,7 @@ import { URI, UriComponents } from '../../../../../../base/common/uri.js';
 import { mock } from '../../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
+import { IDialogService } from '../../../../../../platform/dialogs/common/dialogs.js';
 import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
@@ -102,6 +103,7 @@ interface ITestFixture {
 	chatService: MockChatService;
 	storage: TestStorageService;
 	config: TestConfigurationService;
+	dialog: { confirmResult: boolean; confirmCount: number };
 }
 
 function createFixture(store: DisposableStore): ITestFixture {
@@ -111,10 +113,15 @@ function createFixture(store: DisposableStore): ITestFixture {
 	const config = new TestConfigurationService();
 	config.setUserConfiguration(LOCAL_SESSION_ENABLED_SETTING, true);
 
+	const dialog = { confirmResult: true, confirmCount: 0 };
+
 	instantiationService.stub(IChatService, chatService as unknown as IChatService);
 	instantiationService.stub(IStorageService, storage);
 	instantiationService.stub(IConfigurationService, config);
 	instantiationService.stub(ILogService, new NullLogService());
+	instantiationService.stub(IDialogService, new class extends mock<IDialogService>() {
+		override async confirm() { dialog.confirmCount++; return { confirmed: dialog.confirmResult }; }
+	}());
 	instantiationService.stub(ILabelService, new class extends mock<ILabelService>() {
 		override getUriLabel(uri: URI): string { return uri.fsPath; }
 	}());
@@ -125,7 +132,7 @@ function createFixture(store: DisposableStore): ITestFixture {
 	}());
 	instantiationService.stub(IFileService, new class extends mock<IFileService>() { }());
 	instantiationService.stub(IInstantiationService, instantiationService);
-	return { instantiationService, chatService, storage, config };
+	return { instantiationService, chatService, storage, config, dialog };
 }
 
 const TEST_FOLDER = URI.file('/test/folder');
@@ -338,9 +345,9 @@ suite('LocalChatSessionsProvider', () => {
 		assert.strictEqual(restored[0].chats.get().length, 2);
 	});
 
-	test('deleteChat removes a child chat but keeps the session', async () => {
+	test('deleteChat removes a child chat but keeps the session after confirmation', async () => {
 		const store = leaks.add(new DisposableStore());
-		const { instantiationService } = createFixture(store);
+		const { instantiationService, dialog } = createFixture(store);
 		const provider = store.add(instantiationService.createInstance(LocalChatSessionsProvider));
 
 		const session = await commitNewSession(provider);
@@ -348,8 +355,24 @@ suite('LocalChatSessionsProvider', () => {
 		assert.strictEqual(provider.getSessions()[0].chats.get().length, 2);
 
 		await provider.deleteChat(session.sessionId, childResource);
+		assert.strictEqual(dialog.confirmCount, 1);
 		assert.strictEqual(provider.getSessions().length, 1);
 		assert.strictEqual(provider.getSessions()[0].chats.get().length, 1);
+	});
+
+	test('deleteChat keeps the child chat when the confirmation is cancelled', async () => {
+		const store = leaks.add(new DisposableStore());
+		const { instantiationService, dialog } = createFixture(store);
+		const provider = store.add(instantiationService.createInstance(LocalChatSessionsProvider));
+
+		const session = await commitNewSession(provider);
+		const childResource = await addChat(provider, session);
+		assert.strictEqual(provider.getSessions()[0].chats.get().length, 2);
+
+		dialog.confirmResult = false;
+		await provider.deleteChat(session.sessionId, childResource);
+		assert.strictEqual(dialog.confirmCount, 1);
+		assert.strictEqual(provider.getSessions()[0].chats.get().length, 2);
 	});
 
 	test('deleteChat with an unknown chat URI is a no-op', async () => {

--- a/src/vs/sessions/contrib/providers/localChatSessions/test/browser/localChatSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/localChatSessions/test/browser/localChatSessionsProvider.test.ts
@@ -352,6 +352,21 @@ suite('LocalChatSessionsProvider', () => {
 		assert.strictEqual(provider.getSessions()[0].chats.get().length, 1);
 	});
 
+	test('deleteChat with an unknown chat URI is a no-op', async () => {
+		const store = leaks.add(new DisposableStore());
+		const { instantiationService } = createFixture(store);
+		const provider = store.add(instantiationService.createInstance(LocalChatSessionsProvider));
+
+		const session = await commitNewSession(provider);
+		await addChat(provider, session);
+		assert.strictEqual(provider.getSessions()[0].chats.get().length, 2);
+
+		// A stale/incorrect chat URI must not wipe the whole session.
+		await provider.deleteChat(session.sessionId, URI.parse('vscode-local-chat://chat/does-not-exist'));
+		assert.strictEqual(provider.getSessions().length, 1);
+		assert.strictEqual(provider.getSessions()[0].chats.get().length, 2);
+	});
+
 	test('deleteSession removes the primary chat and all children', async () => {
 		const store = leaks.add(new DisposableStore());
 		const { instantiationService } = createFixture(store);


### PR DESCRIPTION
## Multi-chat support for the local provider

Local sessions (the `local-chat` provider / "local harness") can now host **multiple chats**. The parent→child hierarchy is stored entirely in the provider's own `IStorageService` metadata via a new `parentUri` field on the stored session, so it survives reloads with no extra dependencies. Multi-chat is **always on** — there is no setting.

### What changed
- **`getSessions()`** surfaces only primary chats; children are aggregated into their primary's group via a cached, live `ISession` whose `chats` observable re-derives on group-membership changes, and whose `status` / `updatedAt` / `isRead` / `lastTurnEnd` are aggregated across the group. Such sessions report `capabilities.supportsMultipleChats: true`.
- **`createNewChat(sessionId)`** on a committed session creates a child chat linked to the primary via `parentResource`. The management service routes follow-ups as `sendRequest(groupId, childResource, …)` to the child. A rejected/unsent child is **rolled back** and never persisted.
- **`deleteChat`** removes a single child; deleting the primary (or the last remaining chat) tears down the whole group. On load, an **orphaned** child (whose `parentUri` is missing from storage) is promoted to a primary (non-destructive).
- **Persistence**: `IStoredLocalSession` gains `parentUri?: UriComponents`, written by `_addStoredSession`.

### Why
Brings the local provider to parity with `CopilotChatSessionsProvider`'s multi-chat capability, adapted to the simpler storage-based local provider where the hierarchy lives in provider metadata rather than chat history.

### Tests
Adds 10 unit tests covering: capability flag, add-chat grouping, persist/restore grouped, `deleteChat` (child and primary), `deleteSession` cascade, rejected-send rollback, `parentUri` metadata correctness, orphan promotion, and group status aggregation. All 21 tests in the suite pass; no disposable leaks.

### Notes for reviewers
- Scoped to `src/vs/sessions/contrib/providers/localChatSessions/` only (provider, its test, and the `LOCAL_CHAT_SESSIONS_PROVIDER.md` spec).
- `compile-check-ts-native`, `valid-layers-check`, hygiene, and ESLint all pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
