### PR TITLE
chat-lib: preserve target document URI on NES results

### DIFF
--- a/extensions/copilot/src/lib/node/chatLibMain.ts
+++ b/extensions/copilot/src/lib/node/chatLibMain.ts
@@ -203,6 +203,13 @@ export interface INESResult {
 			readonly start: number;
 			readonly endExclusive: number;
 		};
+		/**
+		 * URI of the document the edit should be applied to. When omitted, the
+		 * edit targets the document that was passed to {@link INESProvider.getNextEdit}.
+		 * For cross-file suggestions this points at a different document, and the
+		 * {@link range} offsets are resolved against that target document.
+		 */
+		readonly targetDocumentUri?: string;
 	};
 }
 
@@ -332,6 +339,7 @@ class NESProvider extends Disposable implements INESProvider<NESResult> {
 				result: internalResult.result?.edit ? {
 					newText: internalResult.result.edit.newText,
 					range: internalResult.result.edit.replaceRange,
+					...(internalResult.result.targetDocumentId ? { targetDocumentUri: internalResult.result.targetDocumentId.uri } : {}),
 				} : undefined,
 				docId,
 				requestUuid: context.requestUuid,

--- a/extensions/copilot/src/lib/vscode-node/test/nesProvider.spec.ts
+++ b/extensions/copilot/src/lib/vscode-node/test/nesProvider.spec.ts
@@ -180,7 +180,8 @@ describe('NESProvider Facade', () => {
 
 		assert(result.result);
 
-		const { range, newText } = result.result;
+		const { range, newText, targetDocumentUri } = result.result;
+		assert.strictEqual(targetDocumentUri, doc.id.toString(), 'targetDocumentUri should reference the requested document');
 		const offsetRange = OffsetRange.fromTo(range.start, range.endExclusive);
 		const replace = StringReplacement.replace(offsetRange, newText);
 		doc.applyEdit(replace.toEdit());


### PR DESCRIPTION
Fixes microsoft/vscode-internalbacklog#7835.

## What

`chatLibMain` was constructing the public `NESResult` from `internalResult.result.edit` but only copying `newText` and `range`, silently dropping `internalResult.result.targetDocumentId`. As a consequence, every NES suggestion emitted by chat-lib looked like it targeted the active document, so cross-file Next Edit Suggestions couldn't be routed to the correct document downstream (notably the Copilot Language Server in Visual Studio), blocking the diff-patch model rollout in VS.

This PR exposes the target document URI on the public `INESResult` schema:

- Adds an optional `targetDocumentUri?: string` field on `INESResult.result` with a JSDoc explaining the semantics for cross-file suggestions.
- Populates it from `internalResult.result.targetDocumentId.uri` in `NESProvider.getNextEdit`, but **only when the underlying provider actually set it** (the property is omitted entirely otherwise, so existing single-file callers see no observable change).

## Why this matters

- Unblocks shipping the diff-patch / cross-file NES model to VS.
- Brings VS to parity with VS Code, which already supports cross-file suggestions.
- Without this, edits could be silently misapplied to the wrong document.

## Notes for reviewers

- Backward compatible: when `targetDocumentUri` is absent the edit should be applied to the document originally passed to `INESProvider.getNextEdit` (same behavior as before).
- The internal `NextEditProvider` always populates `targetDocumentId` (defaulting to the requested doc id), so in practice the field is always present on successful results today; the conditional spread guards against future providers that may omit it.
- Updated `nesProvider.spec.ts` to assert that `targetDocumentUri` matches the requested document URI for the same-file path.

## Validation

- `npx tsc --noEmit --project extensions/copilot/tsconfig. clean.json` 
- `vitest --run src/lib/vscode-node/test/nesProvider.spec. 3/3 tests pass.ts` 
- Pre-commit hygiene hook passes.