### PR TITLE
Fix icon color clash in focused session list

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -36,6 +36,11 @@
 		color: unset;
 	}
 
+	.monaco-list:focus .monaco-list-row.selected .session-icon > .codicon,
+	.monaco-list:focus .monaco-list-row.selected .session-icon > .monaco-pixel-spinner {
+		color: var(--vscode-list-activeSelectionForeground) !important;
+	}
+
 	.monaco-list:not(:focus) .monaco-list-row.selected .session-details-row {
 		color: var(--vscode-descriptionForeground);
 	}


### PR DESCRIPTION
Resolve the color clash of icons on selected rows in the focused session list by updating the CSS styles. This change ensures better visibility and consistency in the user interface.

Addresses: https://github.com/microsoft/vscode/issues/313135
