### PR TITLE
Continue // line comment on Enter in SCSS

### DIFF
--- a/extensions/scss/language-configuration.json
+++ b/extensions/scss/language-configuration.json
@@ -40,6 +40,19 @@
 				"indent": "none",
 				"appendText": "/// "
 			}
-		}
+		},
+		// Add // when pressing enter from inside line comment
+		{
+			"beforeText": {
+				"pattern": "\/\/.*"
+			},
+			"afterText": {
+				"pattern": "^(?!\\s*$).+"
+			},
+			"action": {
+				"indent": "none",
+				"appendText": "// "
+			}
+		},
 	]
 }


### PR DESCRIPTION
@
Pressing <kbd>Enter</kbd> from within a `//` line comment in an SCSS file does not continue the comment, even though SCSS uses `//` as its line comment (`"lineComment": "//"`).

This behavior was added for languages using `//` line comments in #235407 (which fixed #118929), covering `cpp`, `csharp`, `go`, `groovy`, `java`, `json`, `less`, `objective-c`, `php`, `rust` and `swift` — but SCSS was missed.

This PR adds the same `onEnterRule` to `extensions/scss/language-configuration.json`, matching the form already used in the sibling LESS configuration, so SCSS gets parity. The existing `///` doc-comment rule is kept and placed first so the more specific rule still wins.

Refs #118929
@