### PR TITLE
Clarify format error message for unsaved files

### DIFF
--- a/src/vs/workbench/contrib/format/browser/formatActionsNone.ts
+++ b/src/vs/workbench/contrib/format/browser/formatActionsNone.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
+import { Schemas } from '../../../../base/common/network.js';
 import { ICodeEditor } from '../../../../editor/browser/editorBrowser.js';
 import { EditorAction, registerEditorAction, ServicesAccessor } from '../../../../editor/browser/editorExtensions.js';
 import { EditorContextKeys } from '../../../../editor/common/editorContextKeys.js';
@@ -54,6 +55,17 @@ registerEditorAction(class FormatDocumentMultipleAction extends EditorAction {
 			notificationService.warn(nls.localize('too.large', "This file cannot be formatted because it is too large"));
 		} else {
 			const langName = model.getLanguageId();
+
+			// A formatter is registered for this language but it didn't match the
+			// current document (e.g. it only targets the `file` scheme while the
+			// document is still untitled). Avoid the misleading "no formatter
+			// installed" message in that case.
+			const hasFormatterForLanguage = languageFeaturesService.documentFormattingEditProvider.registeredLanguageIds.has(langName);
+			if (hasFormatterForLanguage && model.uri.scheme === Schemas.untitled) {
+				notificationService.info(nls.localize('no.provider.untitled', "The installed formatter for '{0}' files does not support unsaved files. Save the file and try again.", langName));
+				return;
+			}
+
 			const message = nls.localize('no.provider', "There is no formatter for '{0}' files installed.", langName);
 			const { confirmed } = await dialogService.confirm({
 				message,


### PR DESCRIPTION
Fixes #150948

### Problem

When triggering **Format Document** on an unsaved (untitled) document, VS Code shows a misleading dialog:

> There is no formatter for 'cpp' files installed.

…even when a formatter *is* installed. Many formatter extensions (e.g. the Microsoft C/C++ extension) register their document-formatting provider only for the `file` scheme:

```ts
{ scheme: 'file', language: 'cpp' }
```

Because an untitled document has the `untitled` scheme, the provider doesn't match, `documentFormattingEditProvider.all(model)` returns an empty list, and the action falls into the "no formatter installed" branch — prompting the user to install a formatter they already have. Saving the file makes formatting work, which is confusing.

### Fix

In `formatActionsNone.ts`, before showing the install prompt, check whether a formatter is registered for the document's language at all (via `registeredLanguageIds`) while the document is still untitled. If so, show an accurate, actionable message instead:

> The installed formatter for 'cpp' files does not support unsaved files. Save the file and try again.

The existing "install formatter" flow is unchanged for the genuine no-formatter case.

### Notes

- Scope is limited to a single workbench file; no behavior change for documents that truly have no registered formatter.
- `registeredLanguageIds` already exists on `LanguageFeatureRegistry` and reflects all registered providers regardless of resource/scheme match.