### PR TITLE
Strip codicon glyphs from hover accessible view content

### DIFF
--- a/src/vs/base/common/iconLabels.ts
+++ b/src/vs/base/common/iconLabels.ts
@@ -47,6 +47,17 @@ export function getCodiconAriaLabel(text: string | undefined) {
 	return text.replace(/\$\((.*?)\)/g, (_match, codiconName) => ` ${codiconName} `).trim();
 }
 
+/**
+ * Codicon glyphs live in the Unicode Private Use Area of the codicon font. When such a glyph is
+ * rendered into the DOM (e.g. via an empty `<span class="codicon ...">`) and later read back with
+ * `innerText`/`textContent`, the bare glyph character leaks into the text and is announced as
+ * "space" by screen readers. Use this to strip those glyphs from text destined for assistive
+ * technologies.
+ */
+const codiconGlyphsRegex = /[\uE000-\uF8FF]/g;
+export function stripCodiconGlyphs(text: string): string {
+	return text.replace(codiconGlyphsRegex, '');
+}
 
 export interface IParsedLabelWithIcons {
 	readonly text: string;

--- a/src/vs/base/test/common/iconLabels.test.ts
+++ b/src/vs/base/test/common/iconLabels.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { IMatch } from '../../common/filters.js';
-import { escapeIcons, getCodiconAriaLabel, IParsedLabelWithIcons, markdownEscapeEscapedIcons, matchesFuzzyIconAware, parseLabelWithIcons, stripIcons } from '../../common/iconLabels.js';
+import { escapeIcons, getCodiconAriaLabel, IParsedLabelWithIcons, markdownEscapeEscapedIcons, matchesFuzzyIconAware, parseLabelWithIcons, stripCodiconGlyphs, stripIcons } from '../../common/iconLabels.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from './utils.js';
 
 interface IIconFilter {
@@ -97,6 +97,19 @@ suite('Icon Labels', () => {
 		assert.strictEqual(stripIcons('$(Hello) W$(oi)rld'), ' Wrld');
 	});
 
+
+	test('stripCodiconGlyphs', () => {
+		// Codicon glyphs are stored in the Unicode Private Use Area of the codicon font.
+		const glyph = String.fromCharCode(0xeab4); // drop-down-button
+		const otherGlyph = String.fromCharCode(0xec1f); // a high codicon glyph
+		assert.strictEqual(stripCodiconGlyphs('Hello World'), 'Hello World');
+		assert.strictEqual(stripCodiconGlyphs(`${glyph}Hello`), 'Hello');
+		assert.strictEqual(stripCodiconGlyphs(`Hello ${glyph} World`), 'Hello  World');
+		assert.strictEqual(stripCodiconGlyphs(`${glyph}${otherGlyph}`), '');
+		assert.strictEqual(stripCodiconGlyphs(`a${glyph}b${otherGlyph}c`), 'abc');
+		// Characters outside the Private Use Area are left untouched.
+		assert.strictEqual(stripCodiconGlyphs('café 日本語 😀'), 'café 日本語 😀');
+	});
 
 	test('escapeIcons', () => {
 		assert.strictEqual(escapeIcons('Hello World'), 'Hello World');

--- a/src/vs/editor/contrib/hover/browser/markdownHoverParticipant.ts
+++ b/src/vs/editor/contrib/hover/browser/markdownHoverParticipant.ts
@@ -22,6 +22,7 @@ import { EditorOption } from '../../../common/config/editorOptions.js';
 import { Hover, HoverContext, HoverProvider, HoverVerbosityAction } from '../../../common/languages.js';
 import { registerIcon } from '../../../../platform/theme/common/iconRegistry.js';
 import { Codicon } from '../../../../base/common/codicons.js';
+import { stripCodiconGlyphs } from '../../../../base/common/iconLabels.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { onUnexpectedExternalError } from '../../../../base/common/errors.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
@@ -415,7 +416,10 @@ class MarkdownRenderedHoverParts implements IRenderedHoverParts<MarkdownHover> {
 		if (!renderedHoverPart) {
 			return undefined;
 		}
-		const hoverElementInnerText = renderedHoverPart.hoverElement.innerText;
+		// Codicon glyphs rendered in the hover (e.g. via markdown `$(icon)` syntax) leak into
+		// `innerText` and are announced as "space" by screen readers, so strip them out before
+		// normalizing whitespace (see #217974).
+		const hoverElementInnerText = stripCodiconGlyphs(renderedHoverPart.hoverElement.innerText);
 		const accessibleContent = hoverElementInnerText.replace(/[^\S\n\r]+/gu, ' ');
 		return accessibleContent;
 	}


### PR DESCRIPTION
Fixes #217974

### What is the current behavior?

When keying through the hover accessible view, codicons are announced as "space" by screen readers, giving no indication of what the icon is.

### Root cause

`MarkdownRenderedHoverParts.getAccessibleContent` builds the accessible text from the rendered hover element's `innerText`. Codicons are rendered as empty `<span class="codicon ...">` elements whose glyphs come from the Private Use Area (U+E000–U+F8FF) of the codicon font. Those glyph characters leak into `innerText`, and screen readers read them as "space".

### What is the new behavior?

A small `stripCodiconGlyphs` helper (in `base/common/iconLabels.ts`, alongside the existing icon helpers) removes Private Use Area characters from a string. The hover accessible view now strips codicon glyphs before normalizing whitespace, so screen readers no longer announce decorative icons as "space". Characters outside the Private Use Area (regular text, accented characters, CJK, emoji) are left untouched.

### Testing

Added unit tests for `stripCodiconGlyphs` in `iconLabels.test.ts` covering codicon glyph removal and that non-PUA content is preserved.
