### PR TITLE
sessions: focus by number, reveal clipped sessions, close all

### DIFF
--- a/src/vs/sessions/browser/parts/sessionsPart.ts
+++ b/src/vs/sessions/browser/parts/sessionsPart.ts
@@ -15,7 +15,7 @@ import { LayoutPriority } from '../../../base/browser/ui/splitview/splitview.js'
 import { Direction, SerializableGrid, Sizing } from '../../../base/browser/ui/grid/grid.js';
 import { Part } from '../../../workbench/browser/part.js';
 import { ActiveSessionsContext, MultipleSessionsVisibleContext, SessionsFocusContext } from '../../common/contextkeys.js';
-import { $, addDisposableGenericMouseDownListener, addDisposableListener, EventType, isAncestor } from '../../../base/browser/dom.js';
+import { $, addDisposableGenericMouseDownListener, addDisposableListener, EventType, isAncestor, trackFocus } from '../../../base/browser/dom.js';
 import { IActiveSession } from '../../services/sessions/common/sessionsManagement.js';
 import { SessionView } from './sessionView.js';
 import { DisposableStore } from '../../../base/common/lifecycle.js';
@@ -76,6 +76,7 @@ export class SessionsPart extends Part {
 	protected _lastLayout: { readonly width: number; readonly height: number; readonly top: number; readonly left: number } | undefined;
 
 	private readonly _multipleSessionsVisibleKey: IContextKey<boolean>;
+	private readonly _sessionsFocusKey: IContextKey<boolean>;
 
 	get preferredHeight(): number | undefined {
 		return this.layoutService.mainContainerDimension.height * 0.4;
@@ -100,7 +101,7 @@ export class SessionsPart extends Part {
 
 		// Bind context keys for compatibility with existing when-clauses
 		ActiveSessionsContext.bindTo(contextKeyService);
-		SessionsFocusContext.bindTo(contextKeyService);
+		this._sessionsFocusKey = SessionsFocusContext.bindTo(contextKeyService);
 		this._multipleSessionsVisibleKey = MultipleSessionsVisibleContext.bindTo(contextKeyService);
 	}
 
@@ -114,6 +115,12 @@ export class SessionsPart extends Part {
 	protected override createContentArea(parent: HTMLElement): HTMLElement {
 		const contentArea = $('.content');
 		parent.appendChild(contentArea);
+
+		// Track keyboard focus within the sessions content so the `sessionsFocus`
+		// context key reflects whether a session (its chat view) currently has focus.
+		const focusTracker = this._register(trackFocus(contentArea));
+		this._register(focusTracker.onDidFocus(() => this._sessionsFocusKey.set(true)));
+		this._register(focusTracker.onDidBlur(() => this._sessionsFocusKey.set(false)));
 
 		// Progress bar pinned to the top of the content area (see sessionsPart.css
 		// rule `.part.sessionspart > .content > .monaco-progress-container`).
@@ -262,6 +269,39 @@ export class SessionsPart extends Part {
 	 */
 	getSessionView(sessionId: string | undefined): SessionView | undefined {
 		return this._slots.find(s => s.boundSessionId === sessionId)?.view;
+	}
+
+	/**
+	 * Moves keyboard focus into the session view hosting the given session id (or
+	 * the placeholder view when `sessionId` is `undefined`), first revealing it in
+	 * the grid when it is only partially visible. No-op if no matching slot exists.
+	 */
+	focusSession(sessionId: string | undefined): void {
+		const slot = this._slots.find(s => s.boundSessionId === sessionId);
+		if (!slot) {
+			return;
+		}
+		this._revealView(slot.view);
+		slot.view.focus();
+	}
+
+	/**
+	 * Ensures the given view is fully visible within the grid. The grid clips its
+	 * leaves (`overflow: hidden`) and lays them out side by side; when there are
+	 * more sessions than fit, the grid's split view overflows horizontally and
+	 * becomes scrollable, leaving views near the edges partially hidden. When the
+	 * target view is not fully visible, scroll it into view.
+	 */
+	private _revealView(view: SessionView): void {
+		if (!this._gridWidget) {
+			return;
+		}
+		const containerRect = this._gridWidget.element.getBoundingClientRect();
+		const viewRect = view.element.getBoundingClientRect();
+		const isFullyVisible = viewRect.left >= containerRect.left - 1 && viewRect.right <= containerRect.right + 1;
+		if (!isFullyVisible) {
+			view.element.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+		}
 	}
 
 	/**

--- a/src/vs/sessions/browser/parts/sessionsPartService.ts
+++ b/src/vs/sessions/browser/parts/sessionsPartService.ts
@@ -131,7 +131,7 @@ export class SessionsParts extends Disposable implements ISessionsPartService {
 	}
 
 	focusSession(session: IActiveSession | undefined): void {
-		this._mainPart.getSessionView(session?.sessionId)?.focus();
+		this._mainPart.focusSession(session?.sessionId);
 	}
 
 	getSessionView(sessionId: string | undefined): SessionView | undefined {

--- a/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
@@ -5,7 +5,7 @@
 
 import { Codicon } from '../../../../base/common/codicons.js';
 import { fromNow } from '../../../../base/common/date.js';
-import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
+import { KeyChord, KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { localize, localize2 } from '../../../../nls.js';
@@ -18,7 +18,7 @@ import { EditorContextKeys } from '../../../../editor/common/editorContextKeys.j
 import { IsAuxiliaryWindowContext, IsSessionsWindowContext } from '../../../../workbench/common/contextkeys.js';
 import { Menus } from '../../../browser/menus.js';
 import { SessionsCategories } from '../../../common/categories.js';
-import { CanGoBackContext, CanGoForwardContext, MultipleSessionsVisibleContext, SessionIsCreatedContext, SessionIsMaximizedContext, SessionIsStickyContext, SessionSupportsMultipleChatsContext, SessionsWelcomeVisibleContext } from '../../../common/contextkeys.js';
+import { CanGoBackContext, CanGoForwardContext, MultipleSessionsVisibleContext, SessionIsCreatedContext, SessionIsMaximizedContext, SessionIsStickyContext, SessionsFocusContext, SessionSupportsMultipleChatsContext, SessionsWelcomeVisibleContext } from '../../../common/contextkeys.js';
 import { IActiveSession, ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ISession } from '../../../services/sessions/common/session.js';
 import { ISessionsPartService } from '../../../browser/parts/sessionsPartService.js';
@@ -216,6 +216,65 @@ registerAction2(class FocusActiveSessionAction extends Action2 {
 		const sessionsManagementService = accessor.get(ISessionsManagementService);
 		const sessionsPartService = accessor.get(ISessionsPartService);
 		sessionsPartService.focusSession(sessionsManagementService.activeSession.get());
+	}
+});
+
+// -- Focus Nth Session in the Grid (Cmd/Ctrl+1..9) --
+
+for (let index = 0; index < 9; index++) {
+	const position = index + 1;
+	registerAction2(class FocusSessionByPositionAction extends Action2 {
+		constructor() {
+			super({
+				id: `sessions.focusSessionInGrid${position}`,
+				title: localize2('focusSessionInGrid', "Focus Session {0} in Grid", position),
+				f1: true,
+				category: SessionsCategories.Sessions,
+				keybinding: {
+					weight: KeybindingWeight.WorkbenchContrib + 1,
+					primary: KeyMod.CtrlCmd | (KeyCode.Digit1 + index),
+					when: IsSessionsWindowContext,
+				},
+			});
+		}
+
+		override async run(accessor: ServicesAccessor): Promise<void> {
+			const sessionsManagementService = accessor.get(ISessionsManagementService);
+			const sessionsPartService = accessor.get(ISessionsPartService);
+
+			const visible = sessionsManagementService.visibleSessions.get();
+			if (index >= visible.length) {
+				return;
+			}
+
+			const session = visible[index];
+			sessionsManagementService.setActive(session);
+			sessionsPartService.focusSession(session);
+		}
+	});
+}
+
+// -- Close All Sessions --
+
+registerAction2(class CloseAllSessionsAction extends Action2 {
+	constructor() {
+		super({
+			id: 'sessions.closeAllSessions',
+			title: localize2('closeAllSessions', "Close All Sessions"),
+			f1: true,
+			category: SessionsCategories.Sessions,
+			precondition: IsSessionsWindowContext,
+			keybinding: {
+				weight: KeybindingWeight.WorkbenchContrib + 1,
+				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.CtrlCmd | KeyCode.KeyW),
+				// Only fire from the keyboard while a session (its chat view) has focus.
+				when: ContextKeyExpr.and(IsSessionsWindowContext, SessionsFocusContext),
+			},
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		accessor.get(ISessionsManagementService).closeAllSessions();
 	}
 });
 

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -654,6 +654,22 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 		}
 	}
 
+	closeAllSessions(): void {
+		const ids = this._visibility.visibleSessions.get()
+			.filter((s): s is IActiveSession => !!s)
+			.map(s => s.sessionId);
+		if (ids.length === 0) {
+			return;
+		}
+
+		this._pendingNewSession = undefined;
+
+		// Remove every visible session in a single pass; the visibility model
+		// clears the active session, which drives the grid back to the
+		// new-session view via the part's reconciliation.
+		this._visibility.removeMany(ids);
+	}
+
 	private _restoreInitialChat(session: ISession): IChat {
 		const chats = session.chats.get();
 		let initialChat = chats[0];

--- a/src/vs/sessions/services/sessions/common/sessionsManagement.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsManagement.ts
@@ -211,6 +211,13 @@ export interface ISessionsManagementService {
 	 */
 	closeSession(session: ISession | undefined): void;
 
+	/**
+	 * Close all sessions currently shown in the grid. Removes every visible
+	 * session in a single pass and lands on the new-session view. No-op when no
+	 * session is currently visible.
+	 */
+	closeAllSessions(): void;
+
 	setActive(session: IActiveSession | undefined): void;
 
 	/**

--- a/src/vs/sessions/services/sessions/test/browser/sessionNavigation.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionNavigation.test.ts
@@ -179,6 +179,7 @@ class MockSessionStore implements ISessionsManagementService {
 	toggleSessionStickiness(_session: ISession): void { throw new Error('not implemented'); }
 	insertAt(_session: ISession, _targetSessionId: string, _side: 'left' | 'right', _activate?: boolean): void { throw new Error('not implemented'); }
 	closeSession(_session: ISession | undefined): void { throw new Error('not implemented'); }
+	closeAllSessions(): void { throw new Error('not implemented'); }
 	setActive(_session: IActiveSession): void { throw new Error('not implemented'); }
 	archiveSession(_session: ISession): Promise<void> { throw new Error('not implemented'); }
 	unarchiveSession(_session: ISession): Promise<void> { throw new Error('not implemented'); }


### PR DESCRIPTION
## What

Adds keyboard navigation and bulk close support to the Agents/sessions grid:

- **Focus session by position**: `Cmd/Ctrl+1`..`Cmd/Ctrl+9` focus the Nth session in the grid (left-to-right order). Each is also available in the Command Palette.
- **Reveal clipped sessions**: When focusing a session that is partially or fully scrolled out of view (the grid overflows horizontally once sessions no longer fit), the grid now scrolls it into view via `scrollIntoView`.
- **Close All Sessions**: New `sessions.closeAllSessions` command bound to `Cmd/Ctrl+K Cmd/Ctrl+W` (same chord as Close All Editors). The keybinding only fires while a session is focused; the command remains visible in the Command Palette.

## Why

These bring familiar editor-style keyboard ergonomics (focus-by-number, close-all) to the sessions window and fix a usability issue where focusing an off-screen session left it clipped.

## Notes for reviewers

- `SessionsFocusContext` (`sessionsFocus`) was previously bound but never updated. It is now driven by a `trackFocus` on the content area.
- Gotcha: the Command Palette filters by `precondition`/`action.enabled`. Opening the palette moves focus out of the sessions window, flipping `sessionsFocus` to false. So the focus requirement is on the keybinding `when` clause (evaluated at keypress, while focus is still in the session), not the `precondition`. The precondition is `IsSessionsWindowContext` only, keeping the command visible in the palette.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
