### PR TITLE
extensions: delay auto-update for unsigned versions instead of a setting

### DIFF
--- a/extensions/copilot/src/lib/node/chatLibMain.ts
+++ b/extensions/copilot/src/lib/node/chatLibMain.ts
@@ -203,6 +203,13 @@ export interface INESResult {
 			readonly start: number;
 			readonly endExclusive: number;
 		};
+		/**
+		 * URI of the document the edit should be applied to. When omitted, the
+		 * edit targets the document that was passed to {@link INESProvider.getNextEdit}.
+		 * For cross-file suggestions this points at a different document, and the
+		 * {@link range} offsets are resolved against that target document.
+		 */
+		readonly targetDocumentUri?: string;
 	};
 }
 
@@ -332,6 +339,7 @@ class NESProvider extends Disposable implements INESProvider<NESResult> {
 				result: internalResult.result?.edit ? {
 					newText: internalResult.result.edit.newText,
 					range: internalResult.result.edit.replaceRange,
+					...(internalResult.result.targetDocumentId ? { targetDocumentUri: internalResult.result.targetDocumentId.uri } : {}),
 				} : undefined,
 				docId,
 				requestUuid: context.requestUuid,

--- a/extensions/copilot/src/lib/vscode-node/test/nesProvider.spec.ts
+++ b/extensions/copilot/src/lib/vscode-node/test/nesProvider.spec.ts
@@ -180,7 +180,8 @@ describe('NESProvider Facade', () => {
 
 		assert(result.result);
 
-		const { range, newText } = result.result;
+		const { range, newText, targetDocumentUri } = result.result;
+		assert.strictEqual(targetDocumentUri, doc.id.toString(), 'targetDocumentUri should reference the requested document');
 		const offsetRange = OffsetRange.fromTo(range.start, range.endExclusive);
 		const replace = StringReplacement.replace(offsetRange, newText);
 		doc.applyEdit(replace.toEdit());

--- a/src/vs/workbench/contrib/chat/browser/pluginAutoUpdate.ts
+++ b/src/vs/workbench/contrib/chat/browser/pluginAutoUpdate.ts
@@ -22,10 +22,11 @@ import { IPluginMarketplaceService } from '../common/plugins/pluginMarketplaceSe
  * Without this contribution, that signal was never consumed and plugins
  * were never auto-updated (see microsoft/vscode#308563).
  *
- * When the signal becomes `true` and `extensions.autoUpdate` is set to update
- * extensions (`'on'` or `'delayed'`), we silently update all installed plugins.
- * The `'off'` mode gates updates on a per-extension opt-in that has no plugin
- * equivalent, so it is treated the same as disabled for plugins.
+ * When the signal becomes `true` and `extensions.autoUpdate === true`, we
+ * silently update all installed plugins. Other auto-update modes
+ * (`'onlyEnabledExtensions'`, `'onlySelectedExtensions'`) gate updates on a
+ * per-extension opt-in that has no plugin equivalent, so they are treated
+ * the same as `false` for plugins.
  *
  * The flag is cleared after every attempt — including failures — so the
  * next periodic check's `false → true` transition can always re-trigger the
@@ -60,7 +61,7 @@ export class PluginAutoUpdate extends Disposable implements IWorkbenchContributi
 		}
 
 		const autoUpdate = this._extensionsWorkbenchService.getAutoUpdateValue();
-		if (autoUpdate === 'off') {
+		if (autoUpdate !== true) {
 			return;
 		}
 

--- a/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
@@ -741,7 +741,7 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 	// --- Periodic update check ------------------------------------------------
 
 	private _isAutoUpdateEnabled(): boolean {
-		return this._extensionsWorkbenchService.getAutoUpdateValue() !== 'off';
+		return this._extensionsWorkbenchService.getAutoUpdateValue() !== false;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/test/browser/plugins/pluginAutoUpdate.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/plugins/pluginAutoUpdate.test.ts
@@ -66,13 +66,13 @@ suite('PluginAutoUpdate', () => {
 	}
 
 	test('does not trigger update on construction', async () => {
-		const { state } = createContribution('on');
+		const { state } = createContribution(true);
 		await flushMicrotasks();
 		assert.deepStrictEqual(state.updateAllCalls, []);
 	});
 
 	test('triggers silent updateAllPlugins when hasUpdatesAvailable becomes true', async () => {
-		const { state } = createContribution('on');
+		const { state } = createContribution(true);
 
 		state.hasUpdatesAvailable.set(true, undefined);
 		await flushMicrotasks();
@@ -80,8 +80,8 @@ suite('PluginAutoUpdate', () => {
 		assert.deepStrictEqual(state.updateAllCalls, [{ silent: true }]);
 	});
 
-	test('does not trigger update when extensions.autoUpdate is off', async () => {
-		const { state } = createContribution('off');
+	test('does not trigger update when extensions.autoUpdate is false', async () => {
+		const { state } = createContribution(false);
 
 		state.hasUpdatesAvailable.set(true, undefined);
 		await flushMicrotasks();
@@ -89,13 +89,17 @@ suite('PluginAutoUpdate', () => {
 		assert.deepStrictEqual(state.updateAllCalls, []);
 	});
 
-	test('triggers update for the delayed auto-update mode', async () => {
-		const { state } = createContribution('delayed');
+	test('does not trigger update for non-true auto-update values like onlyEnabledExtensions', async () => {
+		// Plugins have no per-item opt-in equivalent to extensions, so only
+		// `true` (update everything) opts plugins into auto-update.
+		for (const value of ['onlyEnabledExtensions', 'onlySelectedExtensions'] as const) {
+			const { state } = createContribution(value);
 
-		state.hasUpdatesAvailable.set(true, undefined);
-		await flushMicrotasks();
+			state.hasUpdatesAvailable.set(true, undefined);
+			await flushMicrotasks();
 
-		assert.deepStrictEqual(state.updateAllCalls, [{ silent: true }]);
+			assert.deepStrictEqual(state.updateAllCalls, [], `expected no update for autoUpdate=${value}`);
+		}
 	});
 
 	test('does not run a second update concurrently with one in flight', async () => {
@@ -103,7 +107,7 @@ suite('PluginAutoUpdate', () => {
 		const pendingUpdate = new Promise<IUpdateAllPluginsResult>(resolve => {
 			resolveUpdate = () => resolve({ updatedNames: [], failedNames: [] });
 		});
-		const { state } = createContribution('on', {
+		const { state } = createContribution(true, {
 			updateAllImpl: () => pendingUpdate,
 		});
 
@@ -123,7 +127,7 @@ suite('PluginAutoUpdate', () => {
 	});
 
 	test('continues running on subsequent cycles after the previous update finished', async () => {
-		const { state } = createContribution('on');
+		const { state } = createContribution(true);
 
 		state.hasUpdatesAvailable.set(true, undefined);
 		await flushMicrotasks();
@@ -140,7 +144,7 @@ suite('PluginAutoUpdate', () => {
 	});
 
 	test('swallows errors from updateAllPlugins', async () => {
-		const { state } = createContribution('on', {
+		const { state } = createContribution(true, {
 			updateAllImpl: async () => { throw new Error('boom'); },
 		});
 
@@ -163,7 +167,7 @@ suite('PluginAutoUpdate', () => {
 		// path in `PluginInstallService.updateAllPlugins`). Without our own
 		// clear in `finally`, the observable would stay stuck at `true` and
 		// the next periodic check's `set(true)` would not notify subscribers.
-		const { state } = createContribution('on', {
+		const { state } = createContribution(true, {
 			updateAllImpl: async () => ({ updatedNames: [], failedNames: ['plugin-a'] }),
 		});
 
@@ -184,7 +188,7 @@ suite('PluginAutoUpdate', () => {
 	});
 
 	test('clears the flag even when updateAllPlugins throws', async () => {
-		const { state } = createContribution('on', {
+		const { state } = createContribution(true, {
 			updateAllImpl: async () => { throw new Error('boom'); },
 		});
 

--- a/src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts
@@ -400,7 +400,7 @@ suite('PluginMarketplaceService - GitHub marketplace refs', () => {
 			onDidChangeTrust: Event.None,
 		} as Partial<IWorkspaceTrustManagementService> as IWorkspaceTrustManagementService);
 		instantiationService.stub(IExtensionsWorkbenchService, {
-			getAutoUpdateValue: () => 'on',
+			getAutoUpdateValue: () => true,
 		} as Partial<IExtensionsWorkbenchService> as IExtensionsWorkbenchService);
 
 		const service = store.add(instantiationService.createInstance(PluginMarketplaceService));
@@ -439,7 +439,7 @@ suite('PluginMarketplaceService - getMarketplacePluginMetadata', () => {
 			onDidChangeTrust: Event.None,
 		} as Partial<IWorkspaceTrustManagementService> as IWorkspaceTrustManagementService);
 		instantiationService.stub(IExtensionsWorkbenchService, {
-			getAutoUpdateValue: () => 'on',
+			getAutoUpdateValue: () => true,
 		} as Partial<IExtensionsWorkbenchService> as IExtensionsWorkbenchService);
 
 		return store.add(instantiationService.createInstance(PluginMarketplaceService));
@@ -518,7 +518,7 @@ suite('PluginMarketplaceService - installed plugins lifecycle', () => {
 			onDidChangeTrust: Event.None,
 		} as Partial<IWorkspaceTrustManagementService> as IWorkspaceTrustManagementService);
 		instantiationService.stub(IExtensionsWorkbenchService, {
-			getAutoUpdateValue: () => 'on',
+			getAutoUpdateValue: () => true,
 		} as Partial<IExtensionsWorkbenchService> as IExtensionsWorkbenchService);
 
 		return store.add(instantiationService.createInstance(PluginMarketplaceService));
@@ -738,7 +738,7 @@ suite('PluginMarketplaceService - hydration after restart', () => {
 			onDidChangeTrust: Event.None,
 		} as Partial<IWorkspaceTrustManagementService> as IWorkspaceTrustManagementService);
 		instantiationService.stub(IExtensionsWorkbenchService, {
-			getAutoUpdateValue: () => 'on',
+			getAutoUpdateValue: () => true,
 		} as Partial<IExtensionsWorkbenchService> as IExtensionsWorkbenchService);
 
 		const service = store.add(instantiationService.createInstance(PluginMarketplaceService));
@@ -791,7 +791,7 @@ suite('PluginMarketplaceService - hydration after restart', () => {
 				onDidChangeTrust: Event.None,
 			} as Partial<IWorkspaceTrustManagementService> as IWorkspaceTrustManagementService);
 			instantiationService.stub(IExtensionsWorkbenchService, {
-				getAutoUpdateValue: () => 'on',
+				getAutoUpdateValue: () => true,
 			} as Partial<IExtensionsWorkbenchService> as IExtensionsWorkbenchService);
 			return store.add(instantiationService.createInstance(PluginMarketplaceService));
 		}

--- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -23,8 +23,7 @@ import { Action2, IAction2Options, IMenuItem, MenuId, MenuRegistry, registerActi
 import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
 import { CommandsRegistry, ICommandService } from '../../../../platform/commands/common/commands.js';
 import { Extensions as ConfigurationExtensions, ConfigurationScope, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
-import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
-import { ContextKeyExpr, IContextKey, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
+import { ContextKeyExpr, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { IDialogService, IFileDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { ExtensionGalleryManifestStatus, ExtensionGalleryResourceType, ExtensionGalleryServiceUrlConfigKey, getExtensionGalleryManifestResourceUri, IExtensionGalleryManifest, IExtensionGalleryManifestService } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
 import { EXTENSION_INSTALL_SOURCE_CONTEXT, ExtensionInstallSource, ExtensionRequestsTimeoutConfigKey, ExtensionsLocalizedLabel, FilterType, IExtensionGalleryService, IExtensionManagementService, PreferencesLocalizedLabel, SortBy, VerifyExtensionSignatureConfigKey } from '../../../../platform/extensionManagement/common/extensionManagement.js';
@@ -138,41 +137,21 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 		type: 'object',
 		properties: {
 			'extensions.autoUpdate': {
-				type: 'string',
-				enum: ['on', 'delayed', 'off'],
+				enum: [true, 'onlyEnabledExtensions', false,],
 				enumItemLabels: [
-					localize('on', "On"),
-					localize('delayed', "Delayed"),
-					localize('off', "Off"),
+					localize('all', "All Extensions"),
+					localize('enabled', "Only Enabled Extensions"),
+					localize('none', "None"),
 				],
 				enumDescriptions: [
-					localize('extensions.autoUpdate.on', 'Enabled extensions are updated automatically.'),
-					localize('extensions.autoUpdate.delayed', 'Enabled extensions are updated automatically, but only 6 hours after a new version has been published.'),
-					localize('extensions.autoUpdate.off', 'Extensions are not updated automatically.'),
+					localize('extensions.autoUpdate.true', 'Download and install updates automatically for all extensions.'),
+					localize('extensions.autoUpdate.enabled', 'Download and install updates automatically only for enabled extensions.'),
+					localize('extensions.autoUpdate.false', 'Extensions are not automatically updated.'),
 				],
 				description: localize('extensions.autoUpdate', "Controls the automatic update behavior of extensions. The updates are fetched from a Microsoft online service."),
-				default: 'on',
+				default: true,
 				scope: ConfigurationScope.APPLICATION,
-				experiment: {
-					mode: 'auto',
-				},
-				tags: ['usesOnlineServices'],
-				policy: {
-					name: 'ExtensionsAutoUpdate',
-					category: PolicyCategory.Extensions,
-					minimumVersion: '1.122',
-					localization: {
-						description: {
-							key: 'extensions.autoUpdate',
-							value: localize('extensions.autoUpdate', "Controls the automatic update behavior of extensions. The updates are fetched from a Microsoft online service."),
-						},
-						enumDescriptions: [
-							{ key: 'extensions.autoUpdate.on', value: localize('extensions.autoUpdate.on', 'Enabled extensions are updated automatically.') },
-							{ key: 'extensions.autoUpdate.delayed', value: localize('extensions.autoUpdate.delayed', 'Enabled extensions are updated automatically, but only 6 hours after a new version has been published.') },
-							{ key: 'extensions.autoUpdate.off', value: localize('extensions.autoUpdate.off', 'Extensions are not updated automatically.') },
-						]
-					}
-				},
+				tags: ['usesOnlineServices']
 			},
 			'extensions.autoCheckUpdates': {
 				type: 'boolean',
@@ -568,7 +547,6 @@ const CONTEXT_GALLERY_FILTER_CAPABILITIES = new RawContextKey<string>('galleryFi
 const CONTEXT_GALLERY_ALL_PUBLIC_REPOSITORY_SIGNED = new RawContextKey<boolean>('galleryAllPublicRepositorySigned', false);
 const CONTEXT_GALLERY_ALL_PRIVATE_REPOSITORY_SIGNED = new RawContextKey<boolean>('galleryAllPrivateRepositorySigned', false);
 const CONTEXT_GALLERY_HAS_EXTENSION_LINK = new RawContextKey<boolean>('galleryHasExtensionLink', false);
-const CONTEXT_EXTENSIONS_AUTO_UPDATE_POLICY = new RawContextKey<boolean>('extensionsAutoUpdatePolicy', false);
 
 async function runAction<T = void>(action: IAction): Promise<T> {
 	try {
@@ -587,8 +565,6 @@ type IExtensionActionOptions = IAction2Options & {
 
 class ExtensionsContributions extends Disposable implements IWorkbenchContribution {
 
-	private readonly autoUpdatePolicyContext: IContextKey<boolean>;
-
 	constructor(
 		@IExtensionManagementService private readonly extensionManagementService: IExtensionManagementService,
 		@IExtensionManagementServerService private readonly extensionManagementServerService: IExtensionManagementServerService,
@@ -602,7 +578,6 @@ class ExtensionsContributions extends Disposable implements IWorkbenchContributi
 		@ICommandService private readonly commandService: ICommandService,
 		@IProductService private readonly productService: IProductService,
 		@IPluginInstallService private readonly pluginInstallService: IPluginInstallService,
-		@IConfigurationService private readonly configurationService: IConfigurationService,
 	) {
 		super();
 		const hasLocalServerContext = CONTEXT_HAS_LOCAL_SERVER.bindTo(contextKeyService);
@@ -622,14 +597,6 @@ class ExtensionsContributions extends Disposable implements IWorkbenchContributi
 
 		this.updateExtensionGalleryStatusContexts();
 		this._register(extensionGalleryManifestService.onDidChangeExtensionGalleryManifestStatus(() => this.updateExtensionGalleryStatusContexts()));
-
-		this.autoUpdatePolicyContext = CONTEXT_EXTENSIONS_AUTO_UPDATE_POLICY.bindTo(contextKeyService);
-		this.updateAutoUpdatePolicyContext();
-		this._register(this.configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration(AutoUpdateConfigurationKey)) {
-				this.updateAutoUpdatePolicyContext();
-			}
-		}));
 		extensionGalleryManifestService.getExtensionGalleryManifest()
 			.then(extensionGalleryManifest => {
 				this.updateGalleryCapabilitiesContexts(extensionGalleryManifest);
@@ -638,10 +605,6 @@ class ExtensionsContributions extends Disposable implements IWorkbenchContributi
 		this.registerGlobalActions();
 		this.registerContextMenuActions();
 		this.registerQuickAccessProvider();
-	}
-
-	private updateAutoUpdatePolicyContext(): void {
-		this.autoUpdatePolicyContext.set(this.configurationService.inspect(AutoUpdateConfigurationKey).policyValue !== undefined);
 	}
 
 	private async updateExtensionGalleryStatusContexts(): Promise<void> {
@@ -770,8 +733,7 @@ class ExtensionsContributions extends Disposable implements IWorkbenchContributi
 			}
 		});
 
-		const notPolicyControlledCondition = CONTEXT_EXTENSIONS_AUTO_UPDATE_POLICY.toNegated();
-		const enableAutoUpdateWhenCondition = ContextKeyExpr.and(ContextKeyExpr.equals(`config.${AutoUpdateConfigurationKey}`, 'off'), notPolicyControlledCondition);
+		const enableAutoUpdateWhenCondition = ContextKeyExpr.equals(`config.${AutoUpdateConfigurationKey}`, false);
 		this.registerExtensionAction({
 			id: 'workbench.extensions.action.enableAutoUpdate',
 			title: localize2('enableAutoUpdate', 'Enable Auto Update for All Extensions'),
@@ -788,7 +750,7 @@ class ExtensionsContributions extends Disposable implements IWorkbenchContributi
 			run: (accessor: ServicesAccessor) => accessor.get(IExtensionsWorkbenchService).updateAutoUpdateForAllExtensions(true)
 		});
 
-		const disableAutoUpdateWhenCondition = ContextKeyExpr.and(ContextKeyExpr.notEquals(`config.${AutoUpdateConfigurationKey}`, 'off'), notPolicyControlledCondition);
+		const disableAutoUpdateWhenCondition = ContextKeyExpr.notEquals(`config.${AutoUpdateConfigurationKey}`, false);
 		this.registerExtensionAction({
 			id: 'workbench.extensions.action.disableAutoUpdate',
 			title: localize2('disableAutoUpdate', 'Disable Auto Update for All Extensions'),
@@ -816,7 +778,7 @@ class ExtensionsContributions extends Disposable implements IWorkbenchContributi
 					when: ContextKeyExpr.and(CONTEXT_HAS_GALLERY, ContextKeyExpr.or(CONTEXT_HAS_LOCAL_SERVER, CONTEXT_HAS_REMOTE_SERVER, CONTEXT_HAS_WEB_SERVER))
 				}, {
 					id: MenuId.ViewContainerTitle,
-					when: ContextKeyExpr.equals('viewContainer', VIEWLET_ID),
+					when: ContextKeyExpr.and(ContextKeyExpr.equals('viewContainer', VIEWLET_ID), ContextKeyExpr.or(ContextKeyExpr.has(`config.${AutoUpdateConfigurationKey}`).negate(), ContextKeyExpr.equals(`config.${AutoUpdateConfigurationKey}`, 'onlyEnabledExtensions'))),
 					group: '1_updates',
 					order: 2
 				}, {
@@ -1483,7 +1445,7 @@ class ExtensionsContributions extends Disposable implements IWorkbenchContributi
 			id: ToggleAutoUpdateForExtensionAction.ID,
 			title: ToggleAutoUpdateForExtensionAction.LABEL,
 			category: ExtensionsLocalizedLabel,
-			precondition: ContextKeyExpr.and(ContextKeyExpr.or(ContextKeyExpr.equals(`config.${AutoUpdateConfigurationKey}`, 'off'), ContextKeyExpr.equals('isExtensionEnabled', true)), ContextKeyExpr.not('extensionDisallowInstall'), ContextKeyExpr.has('isExtensionAllowed')),
+			precondition: ContextKeyExpr.and(ContextKeyExpr.or(ContextKeyExpr.notEquals(`config.${AutoUpdateConfigurationKey}`, 'onlyEnabledExtensions'), ContextKeyExpr.equals('isExtensionEnabled', true)), ContextKeyExpr.not('extensionDisallowInstall'), ContextKeyExpr.has('isExtensionAllowed')),
 			menu: {
 				id: MenuId.ExtensionContext,
 				group: UPDATE_ACTIONS_GROUP,
@@ -1510,7 +1472,7 @@ class ExtensionsContributions extends Disposable implements IWorkbenchContributi
 			id: ToggleAutoUpdatesForPublisherAction.ID,
 			title: { value: ToggleAutoUpdatesForPublisherAction.LABEL, original: 'Auto Update (Publisher)' },
 			category: ExtensionsLocalizedLabel,
-			precondition: ContextKeyExpr.equals(`config.${AutoUpdateConfigurationKey}`, 'off'),
+			precondition: ContextKeyExpr.equals(`config.${AutoUpdateConfigurationKey}`, false),
 			menu: {
 				id: MenuId.ExtensionContext,
 				group: UPDATE_ACTIONS_GROUP,
@@ -2139,11 +2101,8 @@ Registry.as<IConfigurationMigrationRegistry>(ConfigurationMigrationExtensions.Co
 	.registerConfigurationMigrations([{
 		key: AutoUpdateConfigurationKey,
 		migrateFn: (value, accessor) => {
-			if (value === true || value === 'all' || value === 'onlyEnabledExtensions') {
-				return { value: 'on' };
-			}
-			if (value === false || value === 'none' || value === 'onlySelectedExtensions') {
-				return { value: 'off' };
+			if (value === 'onlySelectedExtensions') {
+				return { value: false };
 			}
 			return [];
 		}

--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -1087,7 +1087,7 @@ export class ToggleAutoUpdateForExtensionAction extends ExtensionAction {
 		if (extension && this.allowedExtensionsService.isAllowed(extension) !== true) {
 			return;
 		}
-		if (this.extensionsWorkbenchService.getAutoUpdateValue() !== 'off' && !this.extensionEnablementService.isEnabledEnablementState(this.extension.enablementState)) {
+		if (this.extensionsWorkbenchService.getAutoUpdateValue() === 'onlyEnabledExtensions' && !this.extensionEnablementService.isEnabledEnablementState(this.extension.enablementState)) {
 			return;
 		}
 		this.enabled = true;
@@ -2863,7 +2863,7 @@ export class ExtensionStatusAction extends ExtensionAction {
 			if (this.extensionsWorkbenchService.isAutoUpdateDelayed(this.extension)) {
 				const updateAt = fromNow(Date.now() + this.extensionsWorkbenchService.getAutoUpdateDelayRemaining(this.extension), false, true);
 				// Do not override the higher-priority warning class with the info class.
-				this.updateStatus({ icon: infoIcon, message: new MarkdownString(localize('autoUpdateDelayed', "This extension is not updated yet because extension auto updates are configured to be delayed by 6 hours. It will be auto updated {0}.", updateAt)) }, !hasConsentWarning);
+				this.updateStatus({ icon: infoIcon, message: new MarkdownString(localize('autoUpdateDelayed', "This extension is not updated yet because the new version is not signed. Unsigned versions are auto updated 2 hours after they are published. It will be auto updated {0}.", updateAt)) }, !hasConsentWarning);
 			}
 		}
 

--- a/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
@@ -52,7 +52,7 @@ import { FileAccess } from '../../../../base/common/network.js';
 import { IIgnoredExtensionsManagementService } from '../../../../platform/userDataSync/common/ignoredExtensions.js';
 import { IUserDataAutoSyncService, IUserDataSyncEnablementService, SyncResource } from '../../../../platform/userDataSync/common/userDataSync.js';
 import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
-import { isDefined, isString, isUndefined } from '../../../../base/common/types.js';
+import { isBoolean, isDefined, isString, isUndefined } from '../../../../base/common/types.js';
 import { IExtensionManifestPropertiesService } from '../../../services/extensions/common/extensionManifestPropertiesService.js';
 import { IExtensionService, IExtensionsStatus as IExtensionRuntimeStatus, toExtension, toExtensionDescription } from '../../../services/extensions/common/extensions.js';
 import { isWeb, language } from '../../../../base/common/platform.js';
@@ -80,7 +80,7 @@ interface IExtensionStateProvider<T> {
 	(extension: Extension): T;
 }
 
-const DELAYED_AUTO_UPDATE_PERIOD = 6 * 60 * 60 * 1000; // 6 hours in milliseconds
+const DELAYED_AUTO_UPDATE_PERIOD = 2 * 60 * 60 * 1000; // 2 hours in milliseconds
 
 interface InstalledExtensionsEvent {
 	readonly extensionIds: TelemetryTrustedValue<string>;
@@ -1122,11 +1122,10 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 		// Register listeners for auto updates
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration(AutoUpdateConfigurationKey)) {
-				if (this.getAutoUpdateValue() !== 'delayed') {
-					// No longer delaying — cancel any pending delayed re-check
+				if (!this.isAutoUpdateEnabled()) {
+					// Auto update disabled — cancel any pending delayed re-check
 					this.delayedAutoUpdateCheckTimer.value = undefined;
-				}
-				if (this.isAutoUpdateEnabled()) {
+				} else {
 					this.eventuallyAutoUpdateExtensions();
 				}
 				// The auto update value affects whether an extension is shown as delayed
@@ -1139,7 +1138,7 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 			}
 		}));
 		this._register(this.extensionEnablementService.onEnablementChanged(platformExtensions => {
-			if (this.isAutoCheckUpdatesEnabled() && this.getAutoUpdateValue() !== 'off' && platformExtensions.some(e => this.extensionEnablementService.isEnabled(e))) {
+			if (this.isAutoCheckUpdatesEnabled() && this.getAutoUpdateValue() === 'onlyEnabledExtensions' && platformExtensions.some(e => this.extensionEnablementService.isEnabled(e))) {
 				this.checkForUpdates('Extension enablement changed');
 			}
 		}));
@@ -1197,35 +1196,33 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 		if (this.meteredConnectionService.isConnectionMetered) {
 			return false;
 		}
-		return this.getAutoUpdateValue() !== 'off';
+		return this.getAutoUpdateValue() !== false;
 	}
 
 	getAutoUpdateValue(): AutoUpdateConfigurationValue {
-		const autoUpdate = this.configurationService.getValue<AutoUpdateConfigurationValue | boolean | 'all' | 'none' | 'onlyEnabledExtensions' | 'onlySelectedExtensions'>(AutoUpdateConfigurationKey);
-		// Normalize legacy values
-		if (autoUpdate === true || autoUpdate === 'on' || autoUpdate === 'all' || autoUpdate === 'onlyEnabledExtensions') {
-			return 'on';
+		const autoUpdate = this.configurationService.getValue<AutoUpdateConfigurationValue>(AutoUpdateConfigurationKey);
+		// eslint-disable-next-line local/code-no-any-casts
+		if (<any>autoUpdate === 'onlySelectedExtensions') {
+			return false;
 		}
-		if (autoUpdate === false || autoUpdate === 'off' || autoUpdate === 'none' || autoUpdate === 'onlySelectedExtensions') {
-			return 'off';
-		}
-		if (autoUpdate === 'delayed') {
-			return 'delayed';
-		}
-		return 'on';
+		return isBoolean(autoUpdate) || autoUpdate === 'onlyEnabledExtensions' ? autoUpdate : true;
 	}
 
 	isAutoUpdateDelayed(extension: IExtension): boolean {
 		if (!extension.outdated) {
 			return false;
 		}
-		if (this.getAutoUpdateValue() !== 'delayed') {
+		if (!this.shouldAutoUpdateExtension(extension)) {
 			return false;
 		}
 		return this.getAutoUpdateDelayRemaining(extension) > 0;
 	}
 
 	getAutoUpdateDelayRemaining(extension: IExtension): number {
+		// Signed versions are auto updated immediately; only unsigned versions are delayed.
+		if (extension.gallery?.isSigned) {
+			return 0;
+		}
 		const lastUpdated = extension.gallery?.lastUpdated;
 		if (!Number.isFinite(lastUpdated) || !lastUpdated) {
 			return 0;
@@ -1258,7 +1255,7 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 		// Reset extensions enabled for auto update first to prevent them from being updated
 		this.setEnabledAutoUpdateExtensions([]);
 
-		await this.configurationService.updateValue(AutoUpdateConfigurationKey, isAutoUpdateEnabled ? 'on' : 'off');
+		await this.configurationService.updateValue(AutoUpdateConfigurationKey, isAutoUpdateEnabled);
 
 		this.setDisabledAutoUpdateExtensions([]);
 		await this.updateExtensionsPinnedState(!isAutoUpdateEnabled);
@@ -2177,11 +2174,7 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 	}
 
 	private getUpdatesCheckInterval(): number {
-		if (
-			this.productService.quality === 'insider'
-			&& this.getProductUpdateVersion()
-			&& this.getAutoUpdateValue() !== 'delayed'
-		) {
+		if (this.productService.quality === 'insider' && this.getProductUpdateVersion()) {
 			return 1000 * 60 * 60 * 1; // 1 hour
 		}
 		return ExtensionsWorkbenchService.UpdatesCheckInterval;
@@ -2226,13 +2219,13 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 		const disabledAutoUpdate = [];
 		const consentRequired = [];
 		let soonestDelayRemaining = Number.MAX_SAFE_INTEGER;
-		const isDelayed = this.getAutoUpdateValue() === 'delayed';
 		for (const extension of this.outdated) {
 			if (!this.shouldAutoUpdateExtension(extension)) {
 				disabledAutoUpdate.push(extension.identifier.id);
 				continue;
 			}
-			if (isDelayed && !extension.local?.forceAutoUpdate) {
+			// Unsigned versions are auto updated only after the delay window; signed versions update immediately.
+			if (!extension.local?.forceAutoUpdate) {
 				const delayRemaining = this.getAutoUpdateDelayRemaining(extension);
 				if (delayRemaining > 0) {
 					this.logService.trace('Auto update delayed for extension', extension.identifier.id);
@@ -2304,7 +2297,7 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 
 		const autoUpdateValue = this.getAutoUpdateValue();
 
-		if (autoUpdateValue === 'off') {
+		if (autoUpdateValue === false) {
 			const extensionsToAutoUpdate = this.getEnabledAutoUpdateExtensions();
 			const extensionId = extension.identifier.id.toLowerCase();
 			if (extensionsToAutoUpdate.includes(extensionId)) {
@@ -2325,7 +2318,11 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 			return false;
 		}
 
-		if (autoUpdateValue === 'on' || autoUpdateValue === 'delayed') {
+		if (autoUpdateValue === true) {
+			return true;
+		}
+
+		if (autoUpdateValue === 'onlyEnabledExtensions') {
 			return extension.enablementState !== EnablementState.DisabledGlobally && extension.enablementState !== EnablementState.DisabledWorkspace;
 		}
 

--- a/src/vs/workbench/contrib/extensions/common/extensions.ts
+++ b/src/vs/workbench/contrib/extensions/common/extensions.ts
@@ -191,10 +191,10 @@ export const AutoCheckUpdatesConfigurationKey = 'extensions.autoCheckUpdates';
 export const CloseExtensionDetailsOnViewChangeKey = 'extensions.closeExtensionDetailsOnViewChange';
 export const AutoRestartConfigurationKey = 'extensions.autoRestart';
 
-export type AutoUpdateConfigurationValue = 'on' | 'delayed' | 'off';
+export type AutoUpdateConfigurationValue = boolean | 'onlyEnabledExtensions' | 'onlySelectedExtensions';
 
 export interface IExtensionsConfiguration {
-	autoUpdate: AutoUpdateConfigurationValue;
+	autoUpdate: boolean;
 	autoCheckUpdates: boolean;
 	ignoreRecommendations: boolean;
 	closeExtensionDetailsOnViewChange: boolean;

--- a/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsWorkbenchService.test.ts
+++ b/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsWorkbenchService.test.ts
@@ -424,72 +424,58 @@ suite('ExtensionsWorkbenchServiceTest', () => {
 		assert.ok(!testObject.local[0].outdated);
 	});
 
-	test('test isAutoUpdateDelayed returns false when auto update is not set to delayed', async () => {
-		stubConfiguration('on', true);
-		testObject = await anOutdatedExtensionWorkbenchService(Date.now());
+	test('test isAutoUpdateDelayed returns false for a signed version even if recently published', async () => {
+		testObject = await anOutdatedExtensionWorkbenchService(Date.now(), true);
 
 		assert.strictEqual(testObject.local[0].outdated, true);
 		assert.strictEqual(testObject.isAutoUpdateDelayed(testObject.local[0]), false);
 	});
 
-	test('test isAutoUpdateDelayed returns true for recently published version when auto update is set to delayed', async () => {
-		stubConfiguration('delayed', true);
-		testObject = await anOutdatedExtensionWorkbenchService(Date.now() - (1000 * 60 * 60) /* 1 hour ago */);
+	test('test isAutoUpdateDelayed returns true for a recently published unsigned version', async () => {
+		testObject = await anOutdatedExtensionWorkbenchService(Date.now() - (1000 * 60 * 60) /* 1 hour ago */, false);
 
 		assert.strictEqual(testObject.local[0].outdated, true);
 		assert.strictEqual(testObject.isAutoUpdateDelayed(testObject.local[0]), true);
 	});
 
-	test('test isAutoUpdateDelayed returns false for version published more than 6 hours ago', async () => {
-		stubConfiguration('delayed', true);
-		testObject = await anOutdatedExtensionWorkbenchService(Date.now() - (1000 * 60 * 60 * 7) /* 7 hours ago */);
+	test('test isAutoUpdateDelayed returns false for an unsigned version published more than 2 hours ago', async () => {
+		testObject = await anOutdatedExtensionWorkbenchService(Date.now() - (1000 * 60 * 60 * 3) /* 3 hours ago */, false);
 
 		assert.strictEqual(testObject.local[0].outdated, true);
 		assert.strictEqual(testObject.isAutoUpdateDelayed(testObject.local[0]), false);
 	});
 
-	test('test isAutoUpdateDelayed returns false for version with a future published timestamp', async () => {
-		stubConfiguration('delayed', true);
-		testObject = await anOutdatedExtensionWorkbenchService(Date.now() + (1000 * 60 * 60) /* 1 hour in the future */);
+	test('test isAutoUpdateDelayed returns false for an unsigned version with a future published timestamp', async () => {
+		testObject = await anOutdatedExtensionWorkbenchService(Date.now() + (1000 * 60 * 60) /* 1 hour in the future */, false);
 
 		assert.strictEqual(testObject.local[0].outdated, true);
 		assert.strictEqual(testObject.isAutoUpdateDelayed(testObject.local[0]), false);
 	});
 
-	test('test getAutoUpdateValue normalizes configured and legacy values', async () => {
-		const result: Record<string, string> = {};
-		for (const value of [true, false, 'on', 'off', 'all', 'onlyEnabledExtensions', 'onlySelectedExtensions', 'delayed', 'none', 'unknown']) {
-			stubConfiguration(value);
-			testObject = await aWorkbenchService();
-			result[String(value)] = testObject.getAutoUpdateValue();
-		}
+	test('test isAutoUpdateDelayed returns false when auto update is disabled', async () => {
+		stubConfiguration(false);
+		testObject = await anOutdatedExtensionWorkbenchService(Date.now() - (1000 * 60 * 60) /* 1 hour ago */, false);
 
-		assert.deepStrictEqual(result, {
-			'true': 'on',
-			'false': 'off',
-			'on': 'on',
-			'off': 'off',
-			'all': 'on',
-			'onlyEnabledExtensions': 'on',
-			'onlySelectedExtensions': 'off',
-			'delayed': 'delayed',
-			'none': 'off',
-			'unknown': 'on',
-		});
+		assert.strictEqual(testObject.local[0].outdated, true);
+		assert.strictEqual(testObject.isAutoUpdateDelayed(testObject.local[0]), false);
 	});
 
-	test('test getAutoUpdateDelayRemaining returns remaining time within the delay window', async () => {
-		stubConfiguration('delayed', true);
-		testObject = await anOutdatedExtensionWorkbenchService(Date.now() - (1000 * 60 * 60 * 2) /* 2 hours ago */);
+	test('test getAutoUpdateDelayRemaining returns remaining time within the delay window for an unsigned version', async () => {
+		testObject = await anOutdatedExtensionWorkbenchService(Date.now() - (1000 * 60 * 60) /* 1 hour ago */, false);
 
 		const remaining = testObject.getAutoUpdateDelayRemaining(testObject.local[0]);
-		// Published 2 hours ago, so ~4 hours of the 6 hour window remain.
-		assert.ok(remaining > (1000 * 60 * 60 * 3) && remaining <= (1000 * 60 * 60 * 4), `unexpected remaining time ${remaining}`);
+		// Published 1 hour ago, so ~1 hour of the 2 hour window remains.
+		assert.ok(remaining > (1000 * 60 * 30) && remaining <= (1000 * 60 * 60), `unexpected remaining time ${remaining}`);
+	});
+
+	test('test getAutoUpdateDelayRemaining returns 0 for a signed version', async () => {
+		testObject = await anOutdatedExtensionWorkbenchService(Date.now(), true);
+
+		assert.strictEqual(testObject.getAutoUpdateDelayRemaining(testObject.local[0]), 0);
 	});
 
 	test('test getAutoUpdateDelayRemaining returns 0 when the published timestamp is missing', async () => {
-		stubConfiguration('delayed', true);
-		testObject = await anOutdatedExtensionWorkbenchService(undefined);
+		testObject = await anOutdatedExtensionWorkbenchService(undefined, false);
 
 		assert.strictEqual(testObject.getAutoUpdateDelayRemaining(testObject.local[0]), 0);
 	});
@@ -1586,7 +1572,7 @@ suite('ExtensionsWorkbenchServiceTest', () => {
 	});
 
 	test('Test disable autoupdate for extension when auto update is enabled for enabled extensions', async () => {
-		stubConfiguration('on');
+		stubConfiguration('onlyEnabledExtensions');
 
 		const extension1 = aLocalExtension('a');
 		const extension2 = aLocalExtension('b');
@@ -1765,9 +1751,9 @@ suite('ExtensionsWorkbenchServiceTest', () => {
 		return workbenchService;
 	}
 
-	async function anOutdatedExtensionWorkbenchService(lastUpdated: number | undefined): Promise<ExtensionsWorkbenchService> {
+	async function anOutdatedExtensionWorkbenchService(lastUpdated: number | undefined, isSigned: boolean = true): Promise<ExtensionsWorkbenchService> {
 		const local = aLocalExtension('a', { version: '1.0.1' });
-		const gallery = aGalleryExtension(local.manifest.name, { identifier: local.identifier, version: '1.0.2', lastUpdated });
+		const gallery = aGalleryExtension(local.manifest.name, { identifier: local.identifier, version: '1.0.2', lastUpdated, isSigned });
 		instantiationService.stubPromise(IExtensionManagementService, 'getInstalled', [local]);
 		instantiationService.stubPromise(IExtensionGalleryService, 'query', aPage(gallery));
 		instantiationService.stubPromise(IExtensionGalleryService, 'getCompatibleExtension', gallery);
@@ -1779,7 +1765,7 @@ suite('ExtensionsWorkbenchServiceTest', () => {
 
 	function stubConfiguration(autoUpdateValue?: any, autoCheckUpdatesValue?: any): void {
 		const values: any = {
-			[AutoUpdateConfigurationKey]: autoUpdateValue ?? 'on',
+			[AutoUpdateConfigurationKey]: autoUpdateValue ?? true,
 			[AutoCheckUpdatesConfigurationKey]: autoCheckUpdatesValue ?? true
 		};
 		const emitter = disposableStore.add(new Emitter<IConfigurationChangeEvent>());


### PR DESCRIPTION
## What

Replaces the `delayed` value that was added to the `extensions.autoUpdate` setting (PR #318974) with an **automatic, per-extension** delay based on whether the new version is signed:

- **Signed** new versions are auto updated **immediately**
- **Unsigned** new versions are auto updated **2 hours** after they are published
- **Manual** updates always update immediately (unchanged)

## Why

A global `delayed` setting value (with policy) was heavier than needed. Keying the delay off `extension.gallery.isSigned` targets the actual risk (unsigned versions) without adding user-facing configuration surface.

## Changes

- Reverts `extensions.autoUpdate` back to its original form: boolean enum `[true, 'onlyEnabledExtensions', false]`, default `true`, no policy, no `delayed` value, original migration. Also removes the `experiment` block and the `CONTEXT_EXTENSIONS_AUTO_UPDATE_POLICY` context key wiring that came with the feature.
- Rewires the existing delay infrastructure in `extensionsWorkbenchService.ts`:
  - `DELAYED_AUTO_UPDATE_PERIOD = 2h`.
  - `getAutoUpdateDelayRemaining(ext)` returns `0` for signed (or future-timestamp) versions, else `max(0, 2h - (now - lastUpdated))`.
  - `isAutoUpdateDelayed(ext)` = `outdated && shouldAutoUpdateExtension(ext) && remaining > 0` (no longer gated on a setting value).
  - Auto-update loop always consults the remaining delay (signed gives 0, so updates immediately); keeps the soonest-delay re-check timer.
- Keeps (reworded) the delayed info status, the activity-badge exclusion for delayed extensions, and the time-fresh hover.
- `pluginAutoUpdate` / `pluginMarketplaceService` restore original boolean semantics.
- Tests reworked to drive signed/unsigned + the 2h window.

## Reviewer notes

- Unit tests could not be run locally (corrupted Electron) — relying on CI.
- `policyData.jsonc` is unchanged vs `main`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
