### PR TITLE
Allow string lineComment in language configuration schema

### DIFF
--- a/src/vs/workbench/contrib/codeEditor/common/languageConfigurationExtensionPoint.ts
+++ b/src/vs/workbench/contrib/codeEditor/common/languageConfigurationExtensionPoint.ts
@@ -547,8 +547,8 @@ const schema: IJSONSchema = {
 					}]
 				},
 				lineComment: {
-					type: 'object',
-					description: nls.localize('schema.lineComment.object', 'Configuration for line comments.'),
+					type: ['string', 'object'],
+					description: nls.localize('schema.lineComment.object', 'Defines how line comments are marked. Use a string for the comment token, or an object with comment and optional noIndent properties.'),
 					properties: {
 						comment: {
 							type: 'string',


### PR DESCRIPTION
## Summary
- Allow `comments.lineComment` in `language-configuration.json` schemas to be either a string or an object
- Update the schema description to match the runtime parser and extension API contract

## Related Issues
Fixes microsoft/vscode#285594
Related to microsoft/vscode-extension-samples#1254

## Test plan
- [x] `git diff --check`
- [ ] Open a `language-configuration.json` using lineComment: //` and verify it no longer reports `Incorrect type. Expected object`