### PR TITLE
Pass remoteSession per-session to actually enable session sync export

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -1560,6 +1560,11 @@ export class CopilotAgent extends Disposable implements IAgent {
 				// it, `rpc.plan.read()` returns `path: null` and the SDK
 				// never emits `exit_plan_mode.requested`.
 				infiniteSessions: { enabled: true },
+				// Per-session remote export: the client-level `--remote` flag
+				// (enableRemoteSessions) enables the CLI *capability*, but each
+				// session must opt in via `remoteSession` to actually export
+				// events. Without this, sessions default to "off".
+				remoteSession: this._isSessionSyncEnabled() ? 'export' : undefined,
 			};
 		};
 	}


### PR DESCRIPTION
## Problem

PR #317390 enabled session sync by passing `enableRemoteSessions: true` at the **client level** (`CopilotClientOptions`). This starts the CLI with `--remote`, which enables the *capability* for remote sessions.

However, the SDK requires **each individual session** to opt in via the `remoteSession` field on `SessionConfig` / `ResumeSessionConfig`. Without it, sessions default to `"off"` and no events are exported.

## Fix

Add `remoteSession: 'export'` to `_buildSessionConfig` (the shared config builder used by both create and resume paths) so sessions opt in when `chat.sessionSync.enabled` is true.

The `RemoteSessionMode` values are:
- `"off"` — no export (default)
- `"export"` — export session events to GitHub without remote steering
- `"on"` — export AND enable remote steering