### PR TITLE
Fix agent session resume failing with virtual workspace folder

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/vscode-node/claudeChatSessionContentProvider.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/claudeChatSessionContentProvider.ts
@@ -643,7 +643,8 @@ export class ClaudeChatSessionItemController extends Disposable {
 	// #region Folder Resolution
 
 	async getFolderInfoForSession(sessionId: string, selectedFolderUri?: URI): Promise<ClaudeFolderInfo> {
-		const workspaceFolders = this._workspaceService.getWorkspaceFolders();
+		const workspaceFolders = this._workspaceService.getWorkspaceFolders()
+			.filter(f => f.scheme === 'file');
 
 		if (workspaceFolders.length === 1) {
 			return {


### PR DESCRIPTION
## Summary

- Filter `getWorkspaceFolders()` to only `file://` scheme URIs in `getFolderInfoForSession()`, excluding virtual workspace folders like `unknown:///`

Fixes #319379

## Problem

When the Agents view opens a CLI-created session without a git repository, `copilotChatSessionsProvider` registers a fallback workspace folder with URI `unknown:///`. On Windows this resolves to `fsPath = "\"`.

`getFolderInfoForSession()` sees one workspace folder and passes `cwd = "\"` to the Claude SDK. The SDK then fails to locate the session file:

```
No conversation found with session ID: <uuid>
```

## Fix

Add `.filter(f => f.scheme === 'file')` to `getWorkspaceFolders()` so that virtual/unknown-scheme folders are excluded. When filtered out, the function falls through to resolve the correct `cwd` from session metadata, MRU, or user home directory.

## Test plan

- [ ] Open VS Code with no workspace
- [ ] Create a Claude Code session via CLI in a non-git directory
- [ ] Open the session in the Agents view and send a message
- [ ] Verify the session resumes correctly instead of showing "Error during execution"

🤖 Generated with [Claude Code](https://claude.com/claude-code)