### PR TITLE
build: pin node-addon-api 6.x at root to avoid MSBuild tlog race

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "minimist": "^1.2.8",
         "native-is-elevated": "0.9.0",
         "native-keymap": "^3.3.5",
+        "node-addon-api": "^6.0.0",
         "node-pty": "^1.2.0-beta.13",
         "open": "^10.1.2",
         "playwright-core": "1.59.1",
@@ -2794,6 +2795,12 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@parcel/watcher/node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
     "node_modules/@parcel/watcher/node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
@@ -4332,6 +4339,15 @@
         "node-addon-api": "7.1.0"
       }
     },
+    "node_modules/@vscode/spdlog/node_modules/node-addon-api": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.0.tgz",
+      "integrity": "sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==",
+      "license": "MIT",
+      "engines": {
+        "node": "^16 || ^18 || >= 20"
+      }
+    },
     "node_modules/@vscode/sqlite3": {
       "version": "5.1.12-vscode",
       "resolved": "https://registry.npmjs.org/@vscode/sqlite3/-/sqlite3-5.1.12-vscode.tgz",
@@ -4565,6 +4581,15 @@
         "node-addon-api": "7.1.0"
       }
     },
+    "node_modules/@vscode/windows-mutex/node_modules/node-addon-api": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.0.tgz",
+      "integrity": "sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==",
+      "license": "MIT",
+      "engines": {
+        "node": "^16 || ^18 || >= 20"
+      }
+    },
     "node_modules/@vscode/windows-process-tree": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@vscode/windows-process-tree/-/windows-process-tree-0.7.0.tgz",
@@ -4573,6 +4598,15 @@
       "license": "MIT",
       "dependencies": {
         "node-addon-api": "7.1.0"
+      }
+    },
+    "node_modules/@vscode/windows-process-tree/node_modules/node-addon-api": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.0.tgz",
+      "integrity": "sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==",
+      "license": "MIT",
+      "engines": {
+        "node": "^16 || ^18 || >= 20"
       }
     },
     "node_modules/@vscode/windows-registry": {
@@ -12951,6 +12985,15 @@
         "node": ">=12.9.0"
       }
     },
+    "node_modules/kerberos/node_modules/node-addon-api": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.0.tgz",
+      "integrity": "sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==",
+      "license": "MIT",
+      "engines": {
+        "node": "^16 || ^18 || >= 20"
+      }
+    },
     "node_modules/keygrip": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
@@ -14300,13 +14343,10 @@
       }
     },
     "node_modules/node-addon-api": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.0.tgz",
-      "integrity": "sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==",
-      "license": "MIT",
-      "engines": {
-        "node": "^16 || ^18 || >= 20"
-      }
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
+      "license": "MIT"
     },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
@@ -14399,6 +14439,12 @@
       "dependencies": {
         "node-addon-api": "^7.1.0"
       }
+    },
+    "node_modules/node-pty/node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.38",

--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "minimist": "^1.2.8",
     "native-is-elevated": "0.9.0",
     "native-keymap": "^3.3.5",
+    "node-addon-api": "^6.0.0",
     "node-pty": "^1.2.0-beta.13",
     "open": "^10.1.2",
     "playwright-core": "1.59.1",

--- a/remote/package-lock.json
+++ b/remote/package-lock.json
@@ -44,6 +44,7 @@
         "katex": "^0.16.22",
         "kerberos": "2.1.1",
         "minimist": "^1.2.8",
+        "node-addon-api": "^6.0.0",
         "node-pty": "^1.2.0-beta.13",
         "ssh2": "^1.16.0",
         "tas-client": "0.3.1",
@@ -603,6 +604,12 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@parcel/watcher/node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
     "node_modules/@pondwader/socks5-server": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/@pondwader/socks5-server/-/socks5-server-1.0.10.tgz",
@@ -714,6 +721,15 @@
         "node-addon-api": "7.1.0"
       }
     },
+    "node_modules/@vscode/spdlog/node_modules/node-addon-api": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.0.tgz",
+      "integrity": "sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==",
+      "license": "MIT",
+      "engines": {
+        "node": "^16 || ^18 || >= 20"
+      }
+    },
     "node_modules/@vscode/sqlite3": {
       "version": "5.1.12-vscode",
       "resolved": "https://registry.npmjs.org/@vscode/sqlite3/-/sqlite3-5.1.12-vscode.tgz",
@@ -781,6 +797,15 @@
       "license": "MIT",
       "dependencies": {
         "node-addon-api": "7.1.0"
+      }
+    },
+    "node_modules/@vscode/windows-process-tree/node_modules/node-addon-api": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.0.tgz",
+      "integrity": "sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==",
+      "license": "MIT",
+      "engines": {
+        "node": "^16 || ^18 || >= 20"
       }
     },
     "node_modules/@vscode/windows-registry": {
@@ -1234,6 +1259,15 @@
         "node": ">=12.9.0"
       }
     },
+    "node_modules/kerberos/node_modules/node-addon-api": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.0.tgz",
+      "integrity": "sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==",
+      "license": "MIT",
+      "engines": {
+        "node": "^16 || ^18 || >= 20"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -1331,13 +1365,10 @@
       }
     },
     "node_modules/node-addon-api": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.0.tgz",
-      "integrity": "sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==",
-      "license": "MIT",
-      "engines": {
-        "node": "^16 || ^18 || >= 20"
-      }
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
+      "license": "MIT"
     },
     "node_modules/node-pty": {
       "version": "1.2.0-beta.13",
@@ -1348,6 +1379,12 @@
       "dependencies": {
         "node-addon-api": "^7.1.0"
       }
+    },
+    "node_modules/node-pty/node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
     },
     "node_modules/once": {
       "version": "1.4.0",

--- a/remote/package.json
+++ b/remote/package.json
@@ -39,6 +39,7 @@
     "katex": "^0.16.22",
     "kerberos": "2.1.1",
     "minimist": "^1.2.8",
+    "node-addon-api": "^6.0.0",
     "node-pty": "^1.2.0-beta.13",
     "ssh2": "^1.16.0",
     "tas-client": "0.3.1",


### PR DESCRIPTION
@vscode/spdlog, @vscode/windows-mutex, and @vscode/windows-process-tree all depend on node-addon-api ^7.1.0, so npm hoists a single copy to node_modules/node-addon-api. node-gyp then references it via a relative path that is one level too shallow, landing MSBuild artifacts under `node_modules/@vscode/node-addon-api/` — a directory written to in parallel by every consumer. This races with tlog file generation

```
error MSB3501: Could not read lines from file "Release\obj\node_addon_api_except\node_add.C12341F3.tlog\node_addon_api_except.lastbuildstate". The process cannot access the file 'C:\Users\..\vscode\node_modules\@vscode\node-addon-api\Release\obj\node_addon_api_except\node_add.C12341F3.tlog\node_addon_api_except.lastbuildstate' because it is being used by another process.
```

After reading https://github.com/dotnet/msbuild/issues/10814 msbuild already generates a unique folder under the parent directory. Adding an unused node-addon-api ^6.0.0 dep at the root occupies the hoisted slot without matching any real consumer, forcing each 7.1.0 consumer into its own private nested copy avoiding any file locks.