### PR TITLE
extensions: skip auto-update delay for trusted publishers

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
@@ -1221,6 +1221,10 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 	}
 
 	getAutoUpdateDelayRemaining(extension: IExtension): number {
+		// Extensions from publishers trusted by the product are auto updated without delay.
+		if (this.isFromTrustedPublisher(extension)) {
+			return 0;
+		}
 		const lastUpdated = extension.gallery?.lastUpdated;
 		if (!Number.isFinite(lastUpdated) || !lastUpdated) {
 			return 0;
@@ -1231,6 +1235,16 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 			return 0;
 		}
 		return Math.max(0, DELAYED_AUTO_UPDATE_PERIOD - elapsed);
+	}
+
+	private isFromTrustedPublisher(extension: IExtension): boolean {
+		const trustedPublishers = this.productService.trustedExtensionPublishers;
+		if (!trustedPublishers?.length) {
+			return false;
+		}
+		const publisher = extension.publisher?.toLowerCase();
+		return (!!publisher && trustedPublishers.includes(publisher))
+			|| (!!extension.publisherDisplayName && trustedPublishers.includes(extension.publisherDisplayName.toLowerCase()));
 	}
 
 	async updateAutoUpdateForAllExtensions(isAutoUpdateEnabled: boolean): Promise<void> {

--- a/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
@@ -1242,9 +1242,9 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 		if (!trustedPublishers?.length) {
 			return false;
 		}
-		const publisher = extension.publisher?.toLowerCase();
-		return (!!publisher && trustedPublishers.includes(publisher))
-			|| (!!extension.publisherDisplayName && trustedPublishers.includes(extension.publisherDisplayName.toLowerCase()));
+		const publisher = extension.publisher.toLowerCase();
+		return trustedPublishers.includes(publisher)
+			|| trustedPublishers.includes(extension.publisherDisplayName.toLowerCase());
 	}
 
 	async updateAutoUpdateForAllExtensions(isAutoUpdateEnabled: boolean): Promise<void> {

--- a/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsWorkbenchService.test.ts
+++ b/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsWorkbenchService.test.ts
@@ -481,6 +481,14 @@ suite('ExtensionsWorkbenchServiceTest', () => {
 		assert.strictEqual(testObject.getAutoUpdateDelayRemaining(testObject.local[0]), 0);
 	});
 
+	test('test getAutoUpdateDelayRemaining returns 0 for a trusted publisher', async () => {
+		instantiationService.stub(IProductService, { ...TestProductService, trustedExtensionPublishers: ['pub'] });
+		testObject = await anOutdatedExtensionWorkbenchService(Date.now() - (1000 * 60 * 60) /* 1 hour ago */);
+
+		assert.strictEqual(testObject.getAutoUpdateDelayRemaining(testObject.local[0]), 0);
+		assert.strictEqual(testObject.isAutoUpdateDelayed(testObject.local[0]), false);
+	});
+
 	test('test getAutoUpdateValue normalizes legacy insiders values', async () => {
 		const expected = new Map<unknown, AutoUpdateConfigurationValue>([
 			['on', true],


### PR DESCRIPTION
## What

Skips the 2 hour auto-update delay for extensions published by publishers that the product trusts via `product.json`'s `trustedExtensionPublishers`. Such extensions are auto updated immediately; all other new versions remain delayed by 2 hours.

## Why

The 2 hour delay (introduced in #319340) gives newly published versions a short bake time to reduce the blast radius of a compromised extension. Publishers explicitly trusted by the product (`trustedExtensionPublishers`) do not need this bake time, so they should continue to auto update without delay.

## Changes

- `getAutoUpdateDelayRemaining` returns `0` when the extension's publisher (or publisher display name, case-insensitively) is listed in `trustedExtensionPublishers`, matching the existing trusted-publisher matching used in `extensions.contribution.ts`.
- Added a unit test covering the trusted-publisher bypass.

## Reviewer notes

- Builds on #319340 (already merged). Unit tests can't be run locally (corrupted Electron) — relying on CI. compile-check and hygiene are clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
