### PR TITLE
editor: prevent duplicate block comment end symbol when converting bl…

### DIFF
--- a/src/vs/editor/common/cursor/cursorTypeEditOperations.ts
+++ b/src/vs/editor/common/cursor/cursorTypeEditOperations.ts
@@ -199,13 +199,14 @@ export class AutoClosingOpenCharTypeOperation {
 		}
 		let autoCloseConfig: EditorAutoClosingStrategy;
 		let shouldAutoCloseBefore: (ch: string) => boolean;
+		let pairIsForComments = false;
 
 		const chIsQuote = isQuote(ch);
 		if (chIsQuote) {
 			autoCloseConfig = config.autoClosingQuotes;
 			shouldAutoCloseBefore = config.shouldAutoCloseBefore.quote;
 		} else {
-			const pairIsForComments = config.blockCommentStartToken ? pair.open.includes(config.blockCommentStartToken) : false;
+			pairIsForComments = config.blockCommentStartToken ? pair.open.includes(config.blockCommentStartToken) : false;
 			if (pairIsForComments) {
 				autoCloseConfig = config.autoClosingComments;
 				shouldAutoCloseBefore = config.shouldAutoCloseBefore.comment;
@@ -233,6 +234,13 @@ export class AutoClosingOpenCharTypeOperation {
 
 			if (!lineAfter.startsWith(containedPairClose)) {
 				isContainedPairPresent = false;
+			}
+			if (pairIsForComments
+				&& autoCloseConfig === 'languageDefined'
+				&& pair.close.length > 0
+				&& lineAfter.trimStart().startsWith(pair.close.trimStart())
+			) {
+				return null;
 			}
 			// Only consider auto closing the pair if an allowed character follows or if another autoclosed pair closing brace follows
 			if (lineAfter.length > 0) {

--- a/src/vs/editor/test/browser/controller/cursor.test.ts
+++ b/src/vs/editor/test/browser/controller/cursor.test.ts
@@ -5390,6 +5390,21 @@ suite('Editor Controller', () => {
 		});
 	});
 
+	test('issue #156031: doc comments do not autoclose before an existing block comment end', () => {
+		usingCursor({
+			text: [
+				'',
+			],
+			languageId: autoClosingLanguageId
+		}, (editor, model, viewModel) => {
+
+			model.setValue('/* */');
+			viewModel.setSelections('test', [new Selection(1, 3, 1, 3)]);
+			viewModel.type('*', 'keyboard');
+			assert.strictEqual(model.getLineContent(1), '/** */');
+		});
+	});
+
 	test('issue #72177: multi-character autoclose with conflicting patterns', () => {
 		const languageId = 'autoClosingModeMultiChar';
 


### PR DESCRIPTION
# Prevent duplicate block comment end symbol when converting block comment to doc comment

Checks if the comment closing delimiter is already present directly after the cursor when auto-closing language-defined comments. This prevents inserting an extra block comment end symbol (e.g. producing `/** */ */`) when converting an existing comment block `/* */` into a doc comment `/**`.

Fixes #156031

## Proposed Changes

- **Targeted Fix**: Inside `cursorTypeEditOperations.ts`, when deciding whether to auto-close a comment block pair, we now check if the closing sequence (e.g. `*/` or ` */`) is already present directly ahead of the cursor. If so, we prevent appending a duplicate closing sequence.
- **Fixed Scope Issue**: Fixed a block-scoping bug by declaring `pairIsForComments` in the outer block of `getAutoClosingPairClose`.
- **Zero Side-Effects**: Unlike general comment-token checks, this only intercepts comment-specific auto-closing pairs. Auto-closing rules for brackets, parentheses, and quotes remain fully operational inside comments.

## How to Test

1. Add a comment block: `/* */`
2. Place the cursor after the start token: `/*| */`
3. Type a `*` to make it a doc comment.
4. Verify it converts cleanly to `/** */` and does not insert an extra closing symbol (producing `/** */ */`).
5. Run automated unit tests to verify:
   ```bash
   ./scripts/test.sh --grep "156031"
