### PR TITLE
agentHost: move rubber duck flag to agent host config

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostCustomizationConfig.ts
+++ b/src/vs/platform/agentHost/common/agentHostCustomizationConfig.ts
@@ -22,6 +22,8 @@ export const enum AgentHostConfigKey {
 	DefaultShell = 'defaultShell',
 	/** When true, Copilot SDK sessions use the SDK's default terminal behavior instead of Agent Host's terminal tool override. */
 	DisableCustomTerminalTool = 'disableCustomTerminalTool',
+	/** When true, Copilot SDK sessions enable the rubber duck critic subagent. */
+	RubberDuck = 'rubberDuck',
 }
 
 /**
@@ -72,6 +74,12 @@ export const agentHostCustomizationConfigSchema = createSchema({
 		type: 'boolean',
 		title: localize('agentHost.config.disableCustomTerminalTool.title', "Use SDK Terminal Tool"),
 		description: localize('agentHost.config.disableCustomTerminalTool.description', "When enabled, Copilot SDK sessions use the SDK's default terminal behavior instead of Agent Host's terminal tool override."),
+		default: false,
+	}),
+	[AgentHostConfigKey.RubberDuck]: schemaProperty<boolean>({
+		type: 'boolean',
+		title: localize('agentHost.config.rubberDuck.title', "Rubber Duck Agent"),
+		description: localize('agentHost.config.rubberDuck.description', "When enabled, the coding agent uses a rubber duck critic subagent to review code changes using a complementary model."),
 		default: false,
 	}),
 });

--- a/src/vs/platform/agentHost/common/agentHostStarter.config.contribution.ts
+++ b/src/vs/platform/agentHost/common/agentHostStarter.config.contribution.ts
@@ -15,7 +15,6 @@ import {
 	AgentHostOTelExporterTypeSettingId,
 	AgentHostOTelOtlpEndpointSettingId,
 	AgentHostOTelOutfileSettingId,
-	AgentHostRubberDuckEnabledSettingId,
 } from './agentService.js';
 
 // Settings consumed by the agent host starter (`electronAgentHostStarter.ts`
@@ -40,13 +39,6 @@ configurationRegistry.registerConfiguration({
 	title: nls.localize('chatAgentHostStarterConfigurationTitle', "Chat Agent Host Starter"),
 	type: 'object',
 	properties: {
-		[AgentHostRubberDuckEnabledSettingId]: {
-			type: 'boolean',
-			description: nls.localize('chat.agentHost.rubberDuck.enabled', "When enabled, the coding agent uses a rubber duck critic subagent to review code changes using a complementary model. Requires `#chat.agentHost.enabled#`."),
-			default: false,
-			tags: ['experimental', 'advanced'],
-			included: product.quality !== 'stable',
-		},
 		[AgentHostClaudeAgentSdkPathSettingId]: {
 			type: 'string',
 			description: nls.localize('chat.agentHost.claudeAgent.path', "Experimental, for local testing only. Absolute path to a locally-installed `@anthropic-ai/claude-agent-sdk` package. When set, the Claude agent provider is registered inside the agent host and the SDK is loaded from this path. Requires `#chat.agentHost.enabled#`. The agent host process must be restarted for changes to take effect. This setting will be removed once the SDK is delivered through the Extension Marketplace."),

--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -57,9 +57,6 @@ export const AgentHostAhpJsonlLoggingSettingId = 'chat.agentHost.ahpJsonlLogging
 /** Configuration key that controls whether Agent Host uses its terminal tool override for Copilot SDK sessions. */
 export const AgentHostCustomTerminalToolEnabledSettingId = 'chat.agentHost.customTerminalTool.enabled';
 
-/** Configuration key that controls whether the rubber duck critic subagent is enabled for Copilot SDK sessions. */
-export const AgentHostRubberDuckEnabledSettingId = 'chat.agentHost.rubberDuck.enabled';
-
 /**
  * Configuration key that holds the absolute path to a locally-installed
  * `@anthropic-ai/claude-agent-sdk` package. When non-empty, the Claude agent

--- a/src/vs/platform/agentHost/electron-main/electronAgentHostStarter.ts
+++ b/src/vs/platform/agentHost/electron-main/electronAgentHostStarter.ts
@@ -19,7 +19,7 @@ import { getResolvedShellEnv } from '../../shell/node/shellEnv.js';
 import { NullTelemetryService } from '../../telemetry/common/telemetryUtils.js';
 import { UtilityProcess } from '../../utilityProcess/electron-main/utilityProcess.js';
 import { IAgentHostConnection, IAgentHostStarter } from '../common/agent.js';
-import { AgentHostClaudeAgentSdkPathSettingId, AgentHostClaudeSdkPathEnvVar, AgentHostOTelCaptureContentSettingId, AgentHostOTelDbSpanExporterEnabledSettingId, AgentHostOTelEnabledSettingId, AgentHostOTelExporterTypeSettingId, AgentHostOTelOtlpEndpointSettingId, AgentHostOTelOutfileSettingId, AgentHostRubberDuckEnabledSettingId, buildAgentHostOTelEnv } from '../common/agentService.js';
+import { AgentHostClaudeAgentSdkPathSettingId, AgentHostClaudeSdkPathEnvVar, AgentHostOTelCaptureContentSettingId, AgentHostOTelDbSpanExporterEnabledSettingId, AgentHostOTelEnabledSettingId, AgentHostOTelExporterTypeSettingId, AgentHostOTelOtlpEndpointSettingId, AgentHostOTelOutfileSettingId, buildAgentHostOTelEnv } from '../common/agentService.js';
 import { deepClone } from '../../../base/common/objects.js';
 import '../common/agentHost.config.contribution.js';
 import '../common/agentHostStarter.config.contribution.js';
@@ -87,9 +87,6 @@ export class ElectronAgentHostStarter extends Disposable implements IAgentHostSt
 			dbSpanExporterEnabled: this._configurationService.getValue<boolean>(AgentHostOTelDbSpanExporterEnabledSettingId),
 		}, process.env);
 
-		// Enable rubber duck critic subagent when the setting is on.
-		const rubberDuckEnabled = this._configurationService.getValue<boolean>(AgentHostRubberDuckEnabledSettingId);
-
 		const args = [
 			'--logsPath', this._environmentMainService.logsHome.with({ scheme: Schemas.file }).fsPath,
 			'--user-data-dir', this._environmentMainService.userDataPath,
@@ -112,7 +109,6 @@ export class ElectronAgentHostStarter extends Disposable implements IAgentHostSt
 				VSCODE_VERBOSE_LOGGING: 'true',
 				...(claudeSdkPath ? { [AgentHostClaudeSdkPathEnvVar]: claudeSdkPath } : {}),
 				...otelEnv,
-				...(rubberDuckEnabled ? { RUBBER_DUCK_AGENT: 'true' } : {}),
 			}
 		});
 

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -299,30 +299,53 @@ export class CopilotAgent extends Disposable implements IAgent {
 		this.onDidCustomizationsChange = this._plugins.onDidChange;
 		this._register(completions.registerProvider(new CopilotSlashCommandCompletionProvider(this.id, {
 			hasHistory: (sessionId) => !this._provisionalSessions.has(sessionId) && this._sessions.has(sessionId),
+			isRubberDuckEnabled: () => this._isRubberDuckEnabled(),
 		})));
 
-		// Restart the CLI client when session sync setting changes (only if idle)
+		// Restart the CLI client when a setting baked into the client/subprocess at
+		// startup changes (only if idle). Both session sync (a client option) and the
+		// rubber duck flag (a subprocess env var) are applied in `_ensureClient`, so
+		// they only take effect on the next client start.
 		this._register(this._configurationService.onDidRootConfigChange(() => {
-			this._restartClientIfSessionSyncChanged().catch(err =>
-				this._logService.error('[Copilot] Failed to restart client after session sync change', err)
+			this._restartClientIfStartupConfigChanged().catch(err =>
+				this._logService.error('[Copilot] Failed to restart client after config change', err)
 			);
 		}));
 	}
 
 	private _lastSessionSyncEnabled: boolean = this._isSessionSyncEnabled();
+	private _lastRubberDuckEnabled: boolean = this._isRubberDuckEnabled();
 
 	private _isSessionSyncEnabled(): boolean {
 		return this._configurationService.getRootValue(platformRootSchema, AgentHostSessionSyncEnabledConfigKey) === true;
 	}
 
-	private async _restartClientIfSessionSyncChanged(): Promise<void> {
-		const current = this._isSessionSyncEnabled();
-		if (this._lastSessionSyncEnabled === current) {
+	private _isRubberDuckEnabled(): boolean {
+		return this._configurationService.getRootValue(agentHostCustomizationConfigSchema, AgentHostConfigKey.RubberDuck) === true;
+	}
+
+	/**
+	 * Restarts the CLI client when a config value that is only read at client
+	 * startup ({@link _isSessionSyncEnabled} client option, {@link _isRubberDuckEnabled}
+	 * subprocess env var) has changed. Any active sessions are disposed before
+	 * the client is stopped; the latest values are picked up the next time
+	 * {@link _ensureClient} runs.
+	 */
+	private async _restartClientIfStartupConfigChanged(): Promise<void> {
+		const sessionSync = this._isSessionSyncEnabled();
+		const rubberDuck = this._isRubberDuckEnabled();
+		if (this._lastSessionSyncEnabled === sessionSync && this._lastRubberDuckEnabled === rubberDuck) {
 			return;
 		}
-		this._lastSessionSyncEnabled = current;
-		if (this._client && this._sessions.size === 0) {
-			this._logService.info(`[Copilot] Session sync changed to ${current}, restarting CopilotClient`);
+		const changed = [
+			this._lastSessionSyncEnabled !== sessionSync ? `sessionSync=${sessionSync}` : undefined,
+			this._lastRubberDuckEnabled !== rubberDuck ? `rubberDuck=${rubberDuck}` : undefined,
+		].filter((v): v is string => v !== undefined).join(', ');
+		this._lastSessionSyncEnabled = sessionSync;
+		this._lastRubberDuckEnabled = rubberDuck;
+		if (this._client) {
+			this._logService.info(`[Copilot] Startup config changed (${changed}), restarting CopilotClient`);
+			this._sessions.clearAndDisposeAll();
 			await this._stopClient();
 		}
 	}
@@ -493,6 +516,15 @@ export class CopilotAgent extends Disposable implements IAgent {
 			}
 			env['COPILOT_CLI_RUN_AS_NODE'] = '1';
 			env['USE_BUILTIN_RIPGREP'] = 'false';
+
+			// Enable the rubber duck critic subagent in the CLI when the agent host
+			// config opts in. `RUBBER_DUCK_AGENT` is the SDK's required interface for
+			// gating this experimental feature
+			if (this._isRubberDuckEnabled()) {
+				env['RUBBER_DUCK_AGENT'] = 'true';
+			} else {
+				delete env['RUBBER_DUCK_AGENT'];
+			}
 
 			// Resolve the CLI entry point from node_modules. We can't use require.resolve()
 			// because @github/copilot's exports map blocks direct subpath access.

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -303,9 +303,9 @@ export class CopilotAgent extends Disposable implements IAgent {
 		})));
 
 		// Restart the CLI client when a setting baked into the client/subprocess at
-		// startup changes (only if idle). Both session sync (a client option) and the
-		// rubber duck flag (a subprocess env var) are applied in `_ensureClient`, so
-		// they only take effect on the next client start.
+		// startup changes, disposing any active sessions. Both session sync (a client
+		// option) and the rubber duck flag (a subprocess env var) are applied in
+		// `_ensureClient`, so they only take effect on the next client start.
 		this._register(this._configurationService.onDidRootConfigChange(() => {
 			this._restartClientIfStartupConfigChanged().catch(err =>
 				this._logService.error('[Copilot] Failed to restart client after config change', err)
@@ -329,7 +329,9 @@ export class CopilotAgent extends Disposable implements IAgent {
 	 * startup ({@link _isSessionSyncEnabled} client option, {@link _isRubberDuckEnabled}
 	 * subprocess env var) has changed. Any active sessions are disposed before
 	 * the client is stopped; the latest values are picked up the next time
-	 * {@link _ensureClient} runs.
+	 * {@link _ensureClient} runs. If the client is still starting up, the
+	 * in-flight start detects the change against {@link _lastSessionSyncEnabled} /
+	 * {@link _lastRubberDuckEnabled} and aborts so it never comes up stale.
 	 */
 	private async _restartClientIfStartupConfigChanged(): Promise<void> {
 		const sessionSync = this._isSessionSyncEnabled();
@@ -496,6 +498,11 @@ export class CopilotAgent extends Disposable implements IAgent {
 		if (this._clientStarting) {
 			return this._clientStarting;
 		}
+		// Snapshot the startup config so we can detect a change that lands while the
+		// client is still starting and abort the stale start (the values are baked
+		// into the client options / subprocess env below).
+		const sessionSyncAtStartup = this._isSessionSyncEnabled();
+		const rubberDuckAtStartup = this._isRubberDuckEnabled();
 		const clientStarting = (async () => {
 			this._logService.info('[Copilot] Starting CopilotClient... (with token)');
 
@@ -556,6 +563,10 @@ export class CopilotAgent extends Disposable implements IAgent {
 			if (this._githubToken !== tokenAtStartup) {
 				await client.stop();
 				throw new Error('Copilot authentication changed while the client was starting');
+			}
+			if (this._isSessionSyncEnabled() !== sessionSyncAtStartup || this._isRubberDuckEnabled() !== rubberDuckAtStartup) {
+				await client.stop();
+				throw new Error('Copilot startup config changed while the client was starting');
 			}
 			this._logService.info('[Copilot] CopilotClient started successfully');
 			this._enablePlanModeOnClient(client);

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -819,7 +819,7 @@ export class CopilotAgentSession extends Disposable {
 			prompt = slashCommand.rest;
 		}
 		if (slashCommand?.command === 'rubber-duck') {
-			if (!process.env['RUBBER_DUCK_AGENT']) {
+			if (this._configurationService.getRootValue(agentHostCustomizationConfigSchema, AgentHostConfigKey.RubberDuck) !== true) {
 				// Feature not enabled — pass the remaining text through as a plain
 				// message rather than injecting agent instructions for an unavailable agent.
 				prompt = slashCommand.rest;

--- a/src/vs/platform/agentHost/node/copilot/copilotSlashCommandCompletionProvider.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSlashCommandCompletionProvider.ts
@@ -35,6 +35,11 @@ function getCommandDescription(command: CopilotSlashCommandName): string {
 export interface ICopilotSlashCommandSessionInfo {
 	/** `sessionId` is the raw id (URI path without the leading slash). */
 	hasHistory(sessionId: string): boolean;
+	/**
+	 * Whether the experimental rubber duck critic subagent is enabled via
+	 * the agent host config. When absent or `false`, `/rubber-duck` is hidden.
+	 */
+	isRubberDuckEnabled?(): boolean;
 }
 
 /**
@@ -97,6 +102,7 @@ export class CopilotSlashCommandCompletionProvider implements IAgentHostCompleti
 
 		// `/abc` → typed = 'abc'; empty after just '/' → typed = ''.
 		const typed = leading.typed;
+		const rubberDuckEnabled = this._sessionInfo?.isRubberDuckEnabled?.() ?? false;
 		const items: CompletionItem[] = [];
 		for (const command of COMMANDS) {
 			if (typed.length > 0 && !command.startsWith(typed)) {
@@ -107,7 +113,7 @@ export class CopilotSlashCommandCompletionProvider implements IAgentHostCompleti
 				continue;
 			}
 			// `/rubber-duck` is only available when the feature is enabled.
-			if (command === 'rubber-duck' && !process.env['RUBBER_DUCK_AGENT']) {
+			if (command === 'rubber-duck' && !rubberDuckEnabled) {
 				continue;
 			}
 			items.push({

--- a/src/vs/platform/agentHost/node/nodeAgentHostStarter.ts
+++ b/src/vs/platform/agentHost/node/nodeAgentHostStarter.ts
@@ -13,7 +13,7 @@ import { parseAgentHostDebugPort } from '../../environment/node/environmentServi
 import { ILogService } from '../../log/common/log.js';
 import { getResolvedShellEnv } from '../../shell/node/shellEnv.js';
 import { IAgentHostConnection, IAgentHostStarter } from '../common/agent.js';
-import { AgentHostClaudeAgentSdkPathSettingId, AgentHostClaudeSdkPathEnvVar, AgentHostOTelCaptureContentSettingId, AgentHostOTelDbSpanExporterEnabledSettingId, AgentHostOTelEnabledSettingId, AgentHostOTelExporterTypeSettingId, AgentHostOTelOtlpEndpointSettingId, AgentHostOTelOutfileSettingId, AgentHostRubberDuckEnabledSettingId, buildAgentHostOTelEnv } from '../common/agentService.js';
+import { AgentHostClaudeAgentSdkPathSettingId, AgentHostClaudeSdkPathEnvVar, AgentHostOTelCaptureContentSettingId, AgentHostOTelDbSpanExporterEnabledSettingId, AgentHostOTelEnabledSettingId, AgentHostOTelExporterTypeSettingId, AgentHostOTelOtlpEndpointSettingId, AgentHostOTelOutfileSettingId, buildAgentHostOTelEnv } from '../common/agentService.js';
 import '../common/agentHostStarter.config.contribution.js';
 
 /**
@@ -98,11 +98,6 @@ export class NodeAgentHostStarter extends Disposable implements IAgentHostStarte
 			dbSpanExporterEnabled: this._configurationService.getValue<boolean>(AgentHostOTelDbSpanExporterEnabledSettingId),
 		}, process.env);
 		Object.assign(env, otelEnv);
-
-		// Enable rubber duck critic subagent when the setting is on.
-		if (this._configurationService.getValue<boolean>(AgentHostRubberDuckEnabledSettingId)) {
-			env['RUBBER_DUCK_AGENT'] = 'true';
-		}
 
 		// Forward WebSocket server configuration to the child process via env vars
 		if (this._wsConfig) {

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -453,6 +453,71 @@ suite('CopilotAgent', () => {
 		}
 	});
 
+	suite('restart on startup config change', () => {
+
+		class StopCountingClient extends TestCopilotClient {
+			stopCount = 0;
+			override async stop(): ReturnType<ITestCopilotClient['stop']> {
+				this.stopCount++;
+				return super.stop();
+			}
+		}
+
+		test('restarts the idle client when the rubber duck config changes', async () => {
+			const client = new StopCountingClient([]);
+			const { agent, configurationService } = createTestAgentContext(disposables, { copilotClient: client });
+			try {
+				await agent.authenticate('https://api.github.com', 'token');
+				// Force the client to start so a subsequent config change has something to restart.
+				await agent.listSessions();
+
+				configurationService.updateRootConfig({ [AgentHostConfigKey.RubberDuck]: true });
+				await Promise.resolve();
+
+				assert.strictEqual(client.stopCount, 1);
+			} finally {
+				await disposeAgent(agent);
+			}
+		});
+
+		test('restarts and disposes active sessions when the config changes', async () => {
+			const client = new StopCountingClient([]);
+			const { agent, configurationService } = createTestAgentContext(disposables, { copilotClient: client });
+			try {
+				await agent.authenticate('https://api.github.com', 'token');
+				await agent.listSessions();
+
+				let disposed = false;
+				const sessions = (agent as unknown as { _sessions: { set(k: string, v: { dispose(): void }): void } })._sessions;
+				sessions.set('active', { dispose() { disposed = true; } });
+
+				configurationService.updateRootConfig({ [AgentHostConfigKey.RubberDuck]: true });
+				await Promise.resolve();
+
+				assert.strictEqual(client.stopCount, 1);
+				assert.strictEqual(disposed, true);
+			} finally {
+				await disposeAgent(agent);
+			}
+		});
+
+		test('does not restart when an unrelated config key changes', async () => {
+			const client = new StopCountingClient([]);
+			const { agent, configurationService } = createTestAgentContext(disposables, { copilotClient: client });
+			try {
+				await agent.authenticate('https://api.github.com', 'token');
+				await agent.listSessions();
+
+				configurationService.updateRootConfig({ [AgentHostConfigKey.DisableCustomTerminalTool]: true });
+				await Promise.resolve();
+
+				assert.strictEqual(client.stopCount, 0);
+			} finally {
+				await disposeAgent(agent);
+			}
+		});
+	});
+
 	test('models include billing multiplier metadata when SDK provides it', async () => {
 		const agent = createTestAgent(disposables, {
 			copilotClient: new TestCopilotClient([], [{

--- a/src/vs/platform/agentHost/test/node/copilotSlashCommandCompletionProvider.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotSlashCommandCompletionProvider.test.ts
@@ -12,20 +12,6 @@ import { CopilotSlashCommandCompletionProvider, parseLeadingSlashCommand } from 
 
 suite('CopilotSlashCommandCompletionProvider', () => {
 
-	let _savedRubberDuckEnv: string | undefined;
-	suiteSetup(() => {
-		_savedRubberDuckEnv = process.env['RUBBER_DUCK_AGENT'];
-		process.env['RUBBER_DUCK_AGENT'] = 'true';
-	});
-
-	suiteTeardown(() => {
-		if (_savedRubberDuckEnv === undefined) {
-			delete process.env['RUBBER_DUCK_AGENT'];
-		} else {
-			process.env['RUBBER_DUCK_AGENT'] = _savedRubberDuckEnv;
-		}
-	});
-
 	ensureNoDisposablesAreLeakedInTestSuite();
 
 	suite('parseLeadingSlashCommand', () => {
@@ -87,7 +73,7 @@ suite('CopilotSlashCommandCompletionProvider', () => {
 	});
 
 	suite('provideCompletionItems', () => {
-		const provider = new CopilotSlashCommandCompletionProvider('copilotcli');
+		const provider = new CopilotSlashCommandCompletionProvider('copilotcli', { hasHistory: () => true, isRubberDuckEnabled: () => true });
 		const session = 'copilotcli:/abc';
 
 		async function run(text: string, offset = text.length) {
@@ -182,30 +168,26 @@ suite('CopilotSlashCommandCompletionProvider', () => {
 		});
 
 		test('omits /compact when session has no history', async () => {
-			const gated = new CopilotSlashCommandCompletionProvider('copilotcli', { hasHistory: () => false });
+			const gated = new CopilotSlashCommandCompletionProvider('copilotcli', { hasHistory: () => false, isRubberDuckEnabled: () => true });
 			const items = await gated.provideCompletionItems({
 				kind: CompletionItemKind.UserMessage, channel: session, text: '/', offset: 1,
 			}, CancellationToken.None);
 			assert.deepStrictEqual(items.map(i => i.insertText), ['/plan ', '/research ', '/rubber-duck ']);
 		});
 
-		test('omits /rubber-duck when env var is unset', async () => {
-			const saved = process.env['RUBBER_DUCK_AGENT'];
-			delete process.env['RUBBER_DUCK_AGENT'];
-			try {
-				const items = await run('/');
-				assert.deepStrictEqual(items.map(i => i.insertText), ['/plan ', '/compact', '/research ']);
-			} finally {
-				if (saved !== undefined) {
-					process.env['RUBBER_DUCK_AGENT'] = saved;
-				}
-			}
+		test('omits /rubber-duck when not enabled', async () => {
+			const gated = new CopilotSlashCommandCompletionProvider('copilotcli', { hasHistory: () => true, isRubberDuckEnabled: () => false });
+			const items = await gated.provideCompletionItems({
+				kind: CompletionItemKind.UserMessage, channel: session, text: '/', offset: 1,
+			}, CancellationToken.None);
+			assert.deepStrictEqual(items.map(i => i.insertText), ['/plan ', '/compact', '/research ']);
 		});
 
 		test('passes raw session id (no scheme/slash) to hasHistory', async () => {
 			let seen: string | undefined;
 			const gated = new CopilotSlashCommandCompletionProvider('copilotcli', {
 				hasHistory: (id: string) => { seen = id; return true; },
+				isRubberDuckEnabled: () => true,
 			});
 			await gated.provideCompletionItems({
 				kind: CompletionItemKind.UserMessage, channel: 'copilotcli:/abc', text: '/', offset: 1,


### PR DESCRIPTION
- Migrates the rubber duck agent toggle off environment variables and VS Code settings so it lives with the other agent host customization config, giving it a single consistent source of truth that the host owns rather than scattering the flag across starter processes.
- Applies the flag to the Copilot CLI subprocess env at client startup and restarts the client (disposing any active sessions) when the config changes, so toggling it actually takes effect without a manual restart.

Supplants https://github.com/microsoft/vscode/pull/319347

(Commit message generated by Copilot)