### PR TITLE
summary log when archived

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/sessionsTasksService.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionsTasksService.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Emitter, Event } from '../../../../base/common/event.js';
 import { Disposable, DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { IObservable, observableValue, transaction } from '../../../../base/common/observable.js';
 import { joinPath, dirname, isEqual } from '../../../../base/common/resources.js';
@@ -57,6 +58,15 @@ export interface ISessionTaskWithTarget {
 	readonly target: TaskStorageTarget;
 }
 
+/**
+ * Payload fired by {@link ISessionsTasksService.onDidRunTask} after a
+ * session task has been successfully dispatched to its runner.
+ */
+export interface ISessionTaskRunEvent {
+	readonly task: ITaskEntry;
+	readonly session: ISession;
+}
+
 interface ITasksJson {
 	version?: string;
 	tasks?: ITaskEntry[];
@@ -64,6 +74,13 @@ interface ITasksJson {
 
 export interface ISessionsTasksService {
 	readonly _serviceBrand: undefined;
+
+	/**
+	 * Fires after a session task has been successfully dispatched to its
+	 * runner via {@link runTask}. Does not fire when the task throws or when
+	 * no runner is registered for the session.
+	 */
+	readonly onDidRunTask: Event<ISessionTaskRunEvent>;
 
 	/**
 	 * Observable list of tasks with `inAgents: true`, automatically
@@ -173,6 +190,10 @@ export class SessionsTasksService extends Disposable implements ISessionsTasksSe
 	private static readonly _PINNED_TASK_LABELS_KEY = 'agentSessions.pinnedTaskLabels';
 	private static readonly _BROWSER_URLS_KEY = 'agentSessions.browserUrls';
 	private static readonly _PINNED_BROWSERS_KEY = 'agentSessions.pinnedBrowsers';
+
+	private readonly _onDidRunTask = this._register(new Emitter<ISessionTaskRunEvent>());
+	readonly onDidRunTask = this._onDidRunTask.event;
+
 	private readonly _sessionTasks = observableValue<readonly ISessionTaskWithTarget[]>(this, []);
 	private readonly _fileWatcher = this._register(new MutableDisposable());
 	private readonly _pinnedTaskLabels: Map<string, string>;
@@ -370,6 +391,7 @@ export class SessionsTasksService extends Disposable implements ISessionsTasksSe
 			return;
 		}
 		await runner.runTask(task, session);
+		this._onDidRunTask.fire({ task, session });
 	}
 
 	getPinnedTaskLabel(repository: URI | undefined): IObservable<string | undefined> {

--- a/src/vs/sessions/contrib/sessions/browser/sessionsLifecycleTracker.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsLifecycleTracker.ts
@@ -1,0 +1,516 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { hash } from '../../../../base/common/hash.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { Schemas } from '../../../../base/common/network.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+import { ISession } from '../../../services/sessions/common/session.js';
+
+/** Storage key for the cumulative number of times this client has been launched. */
+const APP_LAUNCH_COUNT_KEY = 'agentSessions.telemetry.summary.appLaunchCount';
+/** Storage key for the per-session lifecycle stats map (JSON encoded). Exported for tests. */
+export const SESSIONS_KEY = 'agentSessions.telemetry.summary.sessions';
+/** Storage key for the cumulative number of user requests sent from the Agents window across all workspaces and providers. */
+const TOTAL_REQUESTS_KEY = 'agentSessions.telemetry.totalRequests';
+/** Storage key for the cumulative number of user requests sent in each workspace (JSON encoded map of workspace URI -> count). */
+const WORKSPACE_REQUESTS_KEY = 'agentSessions.telemetry.workspaceRequests';
+/** Storage key for the cumulative number of user requests sent for each sessions provider (JSON encoded map of providerId -> count). */
+const PROVIDER_REQUESTS_KEY = 'agentSessions.telemetry.providerRequests';
+/** Hard cap on the number of tracked sessions to prevent unbounded storage growth. Exported for tests. */
+export const MAX_TRACKED_SESSIONS = 2000;
+
+/** Reason a session is considered "done" and the summary is emitted. */
+export type SessionDoneReason = 'archived' | 'deleted' | 'archivedRemotely' | 'deletedRemotely';
+
+/**
+ * Cumulative user-request counters maintained by {@link SessionsLifecycleTracker}.
+ * The values are returned post-increment by
+ * {@link SessionsLifecycleTracker.incrementAndGetUserRequestCounters}, or read
+ * unchanged via {@link SessionsLifecycleTracker.getUserRequestCounters}.
+ */
+export interface IUserRequestCounters {
+	readonly userRequestsTotal: number;
+	readonly userRequestsInWorkspace: number;
+	readonly userRequestsForProvider: number;
+}
+
+/** Keys of {@link IStoredSessionStats} that hold simple incrementable counters. */
+export type SessionLifecycleCounterKey =
+	| 'feedbackAdded' | 'feedbackConverted' | 'feedbackReplyAdded' | 'feedbackSubmitted'
+	| 'createPullRequest' | 'createDraftPullRequest' | 'updatePullRequest' | 'mergePullRequest' | 'checkoutPullRequest'
+	| 'initializeRepository' | 'commit' | 'commitAndSync'
+	| 'sessionRestored' | 'stickinessToggled' | 'maximizeToggled'
+	| 'chatDeleted' | 'chatRenamed' | 'fixCIChecks' | 'taskRun';
+
+/**
+ * Persisted shape of a single tracked session. Stored as a JSON value in the
+ * application-scoped storage so that tracking survives app restarts and
+ * spans across workspaces.
+ */
+interface IStoredSessionStats {
+	// Identification (captured at first-observed time)
+	providerId: string;
+	providerType: string;
+	sessionResourceUri: string;
+	workspaceUriString: string;
+	isolationKind: 'worktree' | 'folder';
+	hasGitRepository: boolean;
+	isVirtualWorkspace: boolean;
+
+	// Origin
+	firstRequestSentInThisClient: boolean;
+
+	// Task state observed at the time of the first request (only set once).
+	// `undefined` until recorded.
+	hasWorktreeCreatedTask: boolean | undefined;
+	configuredTasksCount: number | undefined;
+
+	// Timing (ms epoch)
+	firstObservedAt: number;
+	firstRequestSentAt: number;
+
+	// App launches
+	appLaunchCountAtFirstObserved: number;
+
+	// Per-event counters
+	requestsSent: number;
+	chatCount: number;
+	feedbackAdded: number;
+	feedbackConverted: number;
+	feedbackReplyAdded: number;
+	feedbackSubmitted: number;
+	createPullRequest: number;
+	createDraftPullRequest: number;
+	updatePullRequest: number;
+	mergePullRequest: number;
+	checkoutPullRequest: number;
+	initializeRepository: number;
+	commit: number;
+	commitAndSync: number;
+	sessionRestored: number;
+	stickinessToggled: number;
+	maximizeToggled: number;
+	chatDeleted: number;
+	chatRenamed: number;
+	fixCIChecks: number;
+	taskRun: number;
+
+	// End state (refreshed on every interaction)
+	filesChanged: number;
+	linesAdded: number;
+	linesDeleted: number;
+}
+
+/**
+ * Flat summary produced by {@link SessionsLifecycleTracker.finalize}. The
+ * shape matches the fields of the `agents/sessionSummary` telemetry event
+ * declared in `sessionsTelemetry.contribution.ts`.
+ */
+export interface ISessionLifecycleSummary {
+	agentSessionId: string;
+	providerId: string;
+	providerType: string;
+	isolationKind: 'worktree' | 'folder';
+	workspaceHash: string;
+	hasGitRepository: boolean;
+	isVirtualWorkspace: boolean;
+	doneReason: SessionDoneReason;
+	firstRequestSentInThisClient: boolean;
+	hasWorktreeCreatedTask: boolean | undefined;
+	configuredTasksCount: number | undefined;
+	timeSinceFirstObservedMs: number;
+	timeSinceFirstRequestMs: number;
+	appLaunchesSinceFirstObserved: number;
+	requestsSent: number;
+	chatCount: number;
+	feedbackAdded: number;
+	feedbackConverted: number;
+	feedbackReplyAdded: number;
+	feedbackSubmitted: number;
+	createPullRequest: number;
+	createDraftPullRequest: number;
+	updatePullRequest: number;
+	mergePullRequest: number;
+	checkoutPullRequest: number;
+	initializeRepository: number;
+	commit: number;
+	commitAndSync: number;
+	sessionRestored: number;
+	stickinessToggled: number;
+	maximizeToggled: number;
+	chatDeleted: number;
+	chatRenamed: number;
+	fixCIChecks: number;
+	taskRun: number;
+	filesChanged: number;
+	linesAdded: number;
+	linesDeleted: number;
+	userRequestsTotal: number;
+	userRequestsInWorkspace: number;
+	userRequestsForProvider: number;
+}
+
+/**
+ * Tracks per-session lifecycle stats for the `agents/sessionSummary` telemetry
+ * event. Tracking starts the first time the user interacts with a session in
+ * this client (sending a request, running a session-scoped command, adding
+ * feedback, …) and ends when the session is considered done — locally
+ * archived/deleted or observed as archived/deleted via the provider (i.e.,
+ * the user finished it in a different client).
+ *
+ * State is persisted in application-scoped storage so a session opened today
+ * and archived next week — possibly across many app launches and in a
+ * different workspace — still produces a single summary event covering the
+ * entire lifetime.
+ */
+export class SessionsLifecycleTracker extends Disposable {
+
+	private readonly _appLaunchCount: number;
+	private readonly _stats: Map<string, IStoredSessionStats>;
+
+	constructor(private readonly _storageService: IStorageService) {
+		super();
+
+		const previousAppLaunches = this._storageService.getNumber(APP_LAUNCH_COUNT_KEY, StorageScope.APPLICATION, 0);
+		this._appLaunchCount = previousAppLaunches + 1;
+		this._storageService.store(APP_LAUNCH_COUNT_KEY, this._appLaunchCount, StorageScope.APPLICATION, StorageTarget.MACHINE);
+
+		this._stats = this._load();
+	}
+
+	/** Record a request that creates a new chat for the given session. Bumps both `requestsSent` and `chatCount`. */
+	recordNewChatRequestSent(session: ISession): void {
+		this._recordRequestSent(session, /* isNewChat */ true);
+	}
+
+	/** Record a follow-up request within an existing chat. Bumps `requestsSent` but not `chatCount`. */
+	recordRequestSent(session: ISession): void {
+		this._recordRequestSent(session, /* isNewChat */ false);
+	}
+
+	private _recordRequestSent(session: ISession, isNewChat: boolean): void {
+		const entry = this._ensure(session);
+		entry.requestsSent++;
+		if (isNewChat) {
+			entry.chatCount++;
+		}
+		if (entry.firstRequestSentAt === 0) {
+			entry.firstRequestSentAt = Date.now();
+			entry.firstRequestSentInThisClient = true;
+		}
+		this._updateChangesSummary(entry, session);
+		this._save();
+	}
+
+	/**
+	 * Records task-related state observed at the time of the first user
+	 * request for the given session. Only the first call per tracked session
+	 * has an effect; subsequent calls are ignored.
+	 */
+	recordFirstRequestTaskInfo(session: ISession, info: { readonly hasWorktreeCreatedTask: boolean; readonly configuredTasksCount: number }): void {
+		const entry = this._stats.get(session.sessionId);
+		if (!entry || entry.hasWorktreeCreatedTask !== undefined) {
+			return;
+		}
+		entry.hasWorktreeCreatedTask = info.hasWorktreeCreatedTask;
+		entry.configuredTasksCount = info.configuredTasksCount;
+		this._save();
+	}
+
+	/** Increment a named counter. Creates a tracking entry if the session is not yet tracked. */
+	bumpCounter(session: ISession, key: SessionLifecycleCounterKey): void {
+		const entry = this._ensure(session);
+		entry[key]++;
+		this._updateChangesSummary(entry, session);
+		this._save();
+	}
+
+	/** Refresh observed change summary for a tracked session. No-op when not tracked. */
+	updateSessionState(session: ISession): void {
+		const entry = this._stats.get(session.sessionId);
+		if (!entry) {
+			return;
+		}
+		this._updateChangesSummary(entry, session);
+		this._save();
+	}
+
+	/**
+	 * Increments the persisted user-request counters (total, per-workspace,
+	 * per-provider) and returns the new values. Should be called once per
+	 * brand-new session the user starts from the Agents window.
+	 */
+	incrementAndGetUserRequestCounters(session: ISession): IUserRequestCounters {
+		const providerId = session.providerId;
+		const workspaceUri = session.workspace.get()?.uri.toString();
+
+		const userRequestsTotal = this._storageService.getNumber(TOTAL_REQUESTS_KEY, StorageScope.APPLICATION, 0) + 1;
+		this._storageService.store(TOTAL_REQUESTS_KEY, userRequestsTotal, StorageScope.APPLICATION, StorageTarget.MACHINE);
+
+		const providerCounts = this._readCounterMap(PROVIDER_REQUESTS_KEY);
+		const userRequestsForProvider = (providerCounts[providerId] ?? 0) + 1;
+		providerCounts[providerId] = userRequestsForProvider;
+		this._storageService.store(PROVIDER_REQUESTS_KEY, JSON.stringify(providerCounts), StorageScope.APPLICATION, StorageTarget.MACHINE);
+
+		let userRequestsInWorkspace = 0;
+		if (workspaceUri) {
+			const workspaceCounts = this._readCounterMap(WORKSPACE_REQUESTS_KEY);
+			userRequestsInWorkspace = (workspaceCounts[workspaceUri] ?? 0) + 1;
+			workspaceCounts[workspaceUri] = userRequestsInWorkspace;
+			this._storageService.store(WORKSPACE_REQUESTS_KEY, JSON.stringify(workspaceCounts), StorageScope.APPLICATION, StorageTarget.MACHINE);
+		}
+
+		return { userRequestsTotal, userRequestsInWorkspace, userRequestsForProvider };
+	}
+
+	/** Reads the persisted user-request counters without incrementing them. */
+	getUserRequestCounters(session: ISession): IUserRequestCounters {
+		return this._readUserRequestCounters(session.providerId, session.workspace.get()?.uri.toString());
+	}
+
+	/** Whether the given session id has a tracking entry. */
+	isTracked(sessionId: string): boolean {
+		return this._stats.has(sessionId);
+	}
+
+	/** Snapshot of tracked session ids. */
+	getTrackedIds(): string[] {
+		return [...this._stats.keys()];
+	}
+
+	/** Snapshot of tracked sessions as `(sessionId, providerId)` pairs. */
+	getTrackedEntries(): readonly { readonly sessionId: string; readonly providerId: string }[] {
+		const result: { sessionId: string; providerId: string }[] = [];
+		for (const [sessionId, entry] of this._stats) {
+			result.push({ sessionId, providerId: entry.providerId });
+		}
+		return result;
+	}
+
+	/**
+	 * Build a summary for the given tracked session and remove its entry.
+	 * Returns `undefined` if the session was not tracked (e.g., already
+	 * finalized by a competing event).
+	 */
+	finalize(sessionId: string, reason: SessionDoneReason, finalSession?: ISession): ISessionLifecycleSummary | undefined {
+		const entry = this._stats.get(sessionId);
+		if (!entry) {
+			return undefined;
+		}
+		if (finalSession) {
+			this._updateChangesSummary(entry, finalSession);
+		}
+		this._stats.delete(sessionId);
+		this._save();
+		return buildSummary(sessionId, entry, reason, this._appLaunchCount, this._readUserRequestCountersForSummary(entry));
+	}
+
+	// -- internals -------------------------------------------------------------
+
+	private _readUserRequestCountersForSummary(entry: IStoredSessionStats): IUserRequestCounters {
+		return this._readUserRequestCounters(entry.providerId, entry.workspaceUriString || undefined);
+	}
+
+	private _readUserRequestCounters(providerId: string, workspaceUri: string | undefined): IUserRequestCounters {
+		const userRequestsTotal = this._storageService.getNumber(TOTAL_REQUESTS_KEY, StorageScope.APPLICATION, 0);
+		const providerCounts = this._readCounterMap(PROVIDER_REQUESTS_KEY);
+		const userRequestsForProvider = providerCounts[providerId] ?? 0;
+		let userRequestsInWorkspace = 0;
+		if (workspaceUri) {
+			const workspaceCounts = this._readCounterMap(WORKSPACE_REQUESTS_KEY);
+			userRequestsInWorkspace = workspaceCounts[workspaceUri] ?? 0;
+		}
+		return { userRequestsTotal, userRequestsInWorkspace, userRequestsForProvider };
+	}
+
+	private _readCounterMap(key: string): Record<string, number> {
+		const raw = this._storageService.get(key, StorageScope.APPLICATION);
+		if (!raw) {
+			return {};
+		}
+		try {
+			const parsed = JSON.parse(raw);
+			return (parsed && typeof parsed === 'object') ? parsed as Record<string, number> : {};
+		} catch {
+			return {};
+		}
+	}
+
+	private _ensure(session: ISession): IStoredSessionStats {
+		const id = session.sessionId;
+		let entry = this._stats.get(id);
+		if (!entry) {
+			if (this._stats.size >= MAX_TRACKED_SESSIONS) {
+				this._evictOldest();
+			}
+			entry = createEntry(session, this._appLaunchCount);
+			this._stats.set(id, entry);
+		}
+		return entry;
+	}
+
+	private _updateChangesSummary(entry: IStoredSessionStats, session: ISession): void {
+		const summary = session.changesSummary?.get();
+		if (summary) {
+			entry.filesChanged = summary.files;
+			entry.linesAdded = summary.additions;
+			entry.linesDeleted = summary.deletions;
+			return;
+		}
+		let files = 0;
+		let additions = 0;
+		let deletions = 0;
+		for (const change of session.changes.get()) {
+			files++;
+			additions += change.insertions;
+			deletions += change.deletions;
+		}
+		entry.filesChanged = files;
+		entry.linesAdded = additions;
+		entry.linesDeleted = deletions;
+	}
+
+	private _evictOldest(): void {
+		let oldestId: string | undefined;
+		let oldestTime = Number.POSITIVE_INFINITY;
+		for (const [id, entry] of this._stats) {
+			if (entry.firstObservedAt < oldestTime) {
+				oldestTime = entry.firstObservedAt;
+				oldestId = id;
+			}
+		}
+		if (oldestId !== undefined) {
+			this._stats.delete(oldestId);
+		}
+	}
+
+	private _load(): Map<string, IStoredSessionStats> {
+		const raw = this._storageService.get(SESSIONS_KEY, StorageScope.APPLICATION);
+		const map = new Map<string, IStoredSessionStats>();
+		if (!raw) {
+			return map;
+		}
+		try {
+			const parsed = JSON.parse(raw);
+			if (parsed && typeof parsed === 'object') {
+				for (const [id, value] of Object.entries(parsed as Record<string, unknown>)) {
+					if (value && typeof value === 'object') {
+						map.set(id, value as IStoredSessionStats);
+					}
+				}
+			}
+		} catch {
+			// Ignore corrupt storage; start fresh.
+		}
+		return map;
+	}
+
+	private _save(): void {
+		if (this._stats.size === 0) {
+			this._storageService.remove(SESSIONS_KEY, StorageScope.APPLICATION);
+			return;
+		}
+		const obj: Record<string, IStoredSessionStats> = {};
+		for (const [id, entry] of this._stats) {
+			obj[id] = entry;
+		}
+		this._storageService.store(SESSIONS_KEY, JSON.stringify(obj), StorageScope.APPLICATION, StorageTarget.MACHINE);
+	}
+}
+
+function createEntry(session: ISession, appLaunchCount: number): IStoredSessionStats {
+	const workspace = session.workspace.get();
+	const workspaceUriString = workspace?.uri.toString() ?? '';
+	const hasWorktree = workspace?.folders.some(folder => folder.gitRepository?.workTreeUri !== undefined) ?? false;
+	const hasGit = workspace?.folders.some(folder => folder.gitRepository !== undefined) ?? false;
+	const isVirtual = workspace ? workspace.uri.scheme !== Schemas.file : false;
+	return {
+		providerId: session.providerId,
+		providerType: session.sessionType,
+		sessionResourceUri: session.resource.toString(),
+		workspaceUriString,
+		isolationKind: hasWorktree ? 'worktree' : 'folder',
+		hasGitRepository: hasGit,
+		isVirtualWorkspace: isVirtual,
+		firstRequestSentInThisClient: false,
+		hasWorktreeCreatedTask: undefined,
+		configuredTasksCount: undefined,
+		firstObservedAt: Date.now(),
+		firstRequestSentAt: 0,
+		appLaunchCountAtFirstObserved: appLaunchCount,
+		requestsSent: 0,
+		chatCount: 0,
+		feedbackAdded: 0,
+		feedbackConverted: 0,
+		feedbackReplyAdded: 0,
+		feedbackSubmitted: 0,
+		createPullRequest: 0,
+		createDraftPullRequest: 0,
+		updatePullRequest: 0,
+		mergePullRequest: 0,
+		checkoutPullRequest: 0,
+		initializeRepository: 0,
+		commit: 0,
+		commitAndSync: 0,
+		sessionRestored: 0,
+		stickinessToggled: 0,
+		maximizeToggled: 0,
+		chatDeleted: 0,
+		chatRenamed: 0,
+		fixCIChecks: 0,
+		taskRun: 0,
+		filesChanged: 0,
+		linesAdded: 0,
+		linesDeleted: 0,
+	};
+}
+
+function buildSummary(sessionId: string, entry: IStoredSessionStats, reason: SessionDoneReason, appLaunchCount: number, requestCounters: IUserRequestCounters): ISessionLifecycleSummary {
+	const now = Date.now();
+	return {
+		agentSessionId: sessionId,
+		providerId: entry.providerId,
+		providerType: entry.providerType,
+		isolationKind: entry.isolationKind,
+		workspaceHash: entry.workspaceUriString ? hash(entry.workspaceUriString).toString(16) : '',
+		hasGitRepository: entry.hasGitRepository,
+		isVirtualWorkspace: entry.isVirtualWorkspace,
+		doneReason: reason,
+		firstRequestSentInThisClient: entry.firstRequestSentInThisClient,
+		hasWorktreeCreatedTask: entry.hasWorktreeCreatedTask,
+		configuredTasksCount: entry.configuredTasksCount,
+		timeSinceFirstObservedMs: now - entry.firstObservedAt,
+		timeSinceFirstRequestMs: entry.firstRequestSentAt > 0 ? (now - entry.firstRequestSentAt) : -1,
+		appLaunchesSinceFirstObserved: appLaunchCount - entry.appLaunchCountAtFirstObserved,
+		requestsSent: entry.requestsSent,
+		chatCount: entry.chatCount,
+		feedbackAdded: entry.feedbackAdded,
+		feedbackConverted: entry.feedbackConverted,
+		feedbackReplyAdded: entry.feedbackReplyAdded,
+		feedbackSubmitted: entry.feedbackSubmitted,
+		createPullRequest: entry.createPullRequest,
+		createDraftPullRequest: entry.createDraftPullRequest,
+		updatePullRequest: entry.updatePullRequest,
+		mergePullRequest: entry.mergePullRequest,
+		checkoutPullRequest: entry.checkoutPullRequest,
+		initializeRepository: entry.initializeRepository,
+		commit: entry.commit,
+		commitAndSync: entry.commitAndSync,
+		sessionRestored: entry.sessionRestored,
+		stickinessToggled: entry.stickinessToggled,
+		maximizeToggled: entry.maximizeToggled,
+		chatDeleted: entry.chatDeleted,
+		chatRenamed: entry.chatRenamed,
+		fixCIChecks: entry.fixCIChecks,
+		taskRun: entry.taskRun,
+		filesChanged: entry.filesChanged,
+		linesAdded: entry.linesAdded,
+		linesDeleted: entry.linesDeleted,
+		userRequestsTotal: requestCounters.userRequestsTotal,
+		userRequestsInWorkspace: requestCounters.userRequestsInWorkspace,
+		userRequestsForProvider: requestCounters.userRequestsForProvider,
+	};
+}

--- a/src/vs/sessions/contrib/sessions/browser/sessionsLifecycleTracker.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsLifecycleTracker.ts
@@ -13,12 +13,12 @@ import { ISession } from '../../../services/sessions/common/session.js';
 const APP_LAUNCH_COUNT_KEY = 'agentSessions.telemetry.summary.appLaunchCount';
 /** Storage key for the per-session lifecycle stats map (JSON encoded). Exported for tests. */
 export const SESSIONS_KEY = 'agentSessions.telemetry.summary.sessions';
-/** Storage key for the cumulative number of user requests sent from the Agents window across all workspaces and providers. */
-const TOTAL_REQUESTS_KEY = 'agentSessions.telemetry.totalRequests';
-/** Storage key for the cumulative number of user requests sent in each workspace (JSON encoded map of workspace URI -> count). */
-const WORKSPACE_REQUESTS_KEY = 'agentSessions.telemetry.workspaceRequests';
-/** Storage key for the cumulative number of user requests sent for each sessions provider (JSON encoded map of providerId -> count). */
-const PROVIDER_REQUESTS_KEY = 'agentSessions.telemetry.providerRequests';
+/** Storage key for the cumulative number of sessions started from the Agents window across all workspaces and providers. */
+const TOTAL_SESSIONS_KEY = 'agentSessions.telemetry.totalSessions';
+/** Storage key for the cumulative number of sessions started in each workspace (JSON encoded map of workspace URI -> count). */
+const WORKSPACE_SESSIONS_KEY = 'agentSessions.telemetry.workspaceSessions';
+/** Storage key for the cumulative number of sessions started for each sessions provider (JSON encoded map of providerId -> count). */
+const PROVIDER_SESSIONS_KEY = 'agentSessions.telemetry.providerSessions';
 /** Hard cap on the number of tracked sessions to prevent unbounded storage growth. Exported for tests. */
 export const MAX_TRACKED_SESSIONS = 2000;
 
@@ -32,9 +32,9 @@ export type SessionDoneReason = 'archived' | 'deleted' | 'archivedRemotely' | 'd
  * unchanged via {@link SessionsLifecycleTracker.getUserRequestCounters}.
  */
 export interface IUserRequestCounters {
-	readonly userRequestsTotal: number;
-	readonly userRequestsInWorkspace: number;
-	readonly userRequestsForProvider: number;
+	readonly userSessionsTotal: number;
+	readonly userSessionsInWorkspace: number;
+	readonly userSessionsForProvider: number;
 }
 
 /** Keys of {@link IStoredSessionStats} that hold simple incrementable counters. */
@@ -148,9 +148,9 @@ export interface ISessionLifecycleSummary {
 	filesChanged: number;
 	linesAdded: number;
 	linesDeleted: number;
-	userRequestsTotal: number;
-	userRequestsInWorkspace: number;
-	userRequestsForProvider: number;
+	userSessionsTotal: number;
+	userSessionsInWorkspace: number;
+	userSessionsForProvider: number;
 }
 
 /**
@@ -247,23 +247,23 @@ export class SessionsLifecycleTracker extends Disposable {
 		const providerId = session.providerId;
 		const workspaceUri = session.workspace.get()?.uri.toString();
 
-		const userRequestsTotal = this._storageService.getNumber(TOTAL_REQUESTS_KEY, StorageScope.APPLICATION, 0) + 1;
-		this._storageService.store(TOTAL_REQUESTS_KEY, userRequestsTotal, StorageScope.APPLICATION, StorageTarget.MACHINE);
+		const userSessionsTotal = this._storageService.getNumber(TOTAL_SESSIONS_KEY, StorageScope.APPLICATION, 0) + 1;
+		this._storageService.store(TOTAL_SESSIONS_KEY, userSessionsTotal, StorageScope.APPLICATION, StorageTarget.MACHINE);
 
-		const providerCounts = this._readCounterMap(PROVIDER_REQUESTS_KEY);
-		const userRequestsForProvider = (providerCounts[providerId] ?? 0) + 1;
-		providerCounts[providerId] = userRequestsForProvider;
-		this._storageService.store(PROVIDER_REQUESTS_KEY, JSON.stringify(providerCounts), StorageScope.APPLICATION, StorageTarget.MACHINE);
+		const providerCounts = this._readCounterMap(PROVIDER_SESSIONS_KEY);
+		const userSessionsForProvider = (providerCounts[providerId] ?? 0) + 1;
+		providerCounts[providerId] = userSessionsForProvider;
+		this._storageService.store(PROVIDER_SESSIONS_KEY, JSON.stringify(providerCounts), StorageScope.APPLICATION, StorageTarget.MACHINE);
 
-		let userRequestsInWorkspace = 0;
+		let userSessionsInWorkspace = 0;
 		if (workspaceUri) {
-			const workspaceCounts = this._readCounterMap(WORKSPACE_REQUESTS_KEY);
-			userRequestsInWorkspace = (workspaceCounts[workspaceUri] ?? 0) + 1;
-			workspaceCounts[workspaceUri] = userRequestsInWorkspace;
-			this._storageService.store(WORKSPACE_REQUESTS_KEY, JSON.stringify(workspaceCounts), StorageScope.APPLICATION, StorageTarget.MACHINE);
+			const workspaceCounts = this._readCounterMap(WORKSPACE_SESSIONS_KEY);
+			userSessionsInWorkspace = (workspaceCounts[workspaceUri] ?? 0) + 1;
+			workspaceCounts[workspaceUri] = userSessionsInWorkspace;
+			this._storageService.store(WORKSPACE_SESSIONS_KEY, JSON.stringify(workspaceCounts), StorageScope.APPLICATION, StorageTarget.MACHINE);
 		}
 
-		return { userRequestsTotal, userRequestsInWorkspace, userRequestsForProvider };
+		return { userSessionsTotal, userSessionsInWorkspace, userSessionsForProvider };
 	}
 
 	/** Reads the persisted user-request counters without incrementing them. */
@@ -315,15 +315,15 @@ export class SessionsLifecycleTracker extends Disposable {
 	}
 
 	private _readUserRequestCounters(providerId: string, workspaceUri: string | undefined): IUserRequestCounters {
-		const userRequestsTotal = this._storageService.getNumber(TOTAL_REQUESTS_KEY, StorageScope.APPLICATION, 0);
-		const providerCounts = this._readCounterMap(PROVIDER_REQUESTS_KEY);
-		const userRequestsForProvider = providerCounts[providerId] ?? 0;
-		let userRequestsInWorkspace = 0;
+		const userSessionsTotal = this._storageService.getNumber(TOTAL_SESSIONS_KEY, StorageScope.APPLICATION, 0);
+		const providerCounts = this._readCounterMap(PROVIDER_SESSIONS_KEY);
+		const userSessionsForProvider = providerCounts[providerId] ?? 0;
+		let userSessionsInWorkspace = 0;
 		if (workspaceUri) {
-			const workspaceCounts = this._readCounterMap(WORKSPACE_REQUESTS_KEY);
-			userRequestsInWorkspace = workspaceCounts[workspaceUri] ?? 0;
+			const workspaceCounts = this._readCounterMap(WORKSPACE_SESSIONS_KEY);
+			userSessionsInWorkspace = workspaceCounts[workspaceUri] ?? 0;
 		}
-		return { userRequestsTotal, userRequestsInWorkspace, userRequestsForProvider };
+		return { userSessionsTotal, userSessionsInWorkspace, userSessionsForProvider };
 	}
 
 	private _readCounterMap(key: string): Record<string, number> {
@@ -509,8 +509,8 @@ function buildSummary(sessionId: string, entry: IStoredSessionStats, reason: Ses
 		filesChanged: entry.filesChanged,
 		linesAdded: entry.linesAdded,
 		linesDeleted: entry.linesDeleted,
-		userRequestsTotal: requestCounters.userRequestsTotal,
-		userRequestsInWorkspace: requestCounters.userRequestsInWorkspace,
-		userRequestsForProvider: requestCounters.userRequestsForProvider,
+		userSessionsTotal: requestCounters.userSessionsTotal,
+		userSessionsInWorkspace: requestCounters.userSessionsInWorkspace,
+		userSessionsForProvider: requestCounters.userSessionsForProvider,
 	};
 }

--- a/src/vs/sessions/contrib/sessions/browser/sessionsTelemetry.contribution.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsTelemetry.contribution.ts
@@ -812,9 +812,9 @@ type SessionRequestSentEvent = {
 	allWorkspacesUnread: number;
 	allWorkspacesWaitingForInput: number;
 	allWorkspacesNotDone: number;
-	userRequestsTotal: number;
-	userRequestsInWorkspace: number;
-	userRequestsForProvider: number;
+	userSessionsTotal: number;
+	userSessionsInWorkspace: number;
+	userSessionsForProvider: number;
 };
 
 // --- Events: session-level lifecycle actions (archive / unarchive / delete /
@@ -871,9 +871,9 @@ type SessionRequestSentClassification = {
 	allWorkspacesUnread: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Unread sessions across all workspaces.' };
 	allWorkspacesWaitingForInput: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Sessions waiting for user input across all workspaces.' };
 	allWorkspacesNotDone: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Sessions not marked as done across all workspaces.' };
-	userRequestsTotal: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Cumulative number of new sessions the user has started from the Agents window across all workspaces and providers. Incremented only when `isNewSession` is true.' };
-	userRequestsInWorkspace: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Cumulative number of new sessions the user has started in the current workspace. Incremented only when `isNewSession` is true.' };
-	userRequestsForProvider: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Cumulative number of new sessions the user has started for this sessions provider across all workspaces. Incremented only when `isNewSession` is true.' };
+	userSessionsTotal: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Cumulative number of new sessions the user has started from the Agents window across all workspaces and providers. Incremented only when `isNewSession` is true.' };
+	userSessionsInWorkspace: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Cumulative number of new sessions the user has started in the current workspace. Incremented only when `isNewSession` is true.' };
+	userSessionsForProvider: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Cumulative number of new sessions the user has started for this sessions provider across all workspaces. Incremented only when `isNewSession` is true.' };
 };
 
 type SessionArchivedClassification = {
@@ -1398,7 +1398,7 @@ type SessionSummaryClassification = {
 	filesChanged: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of changed files in the session at the moment the summary was emitted.' };
 	linesAdded: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Total lines added across all changed files in the session at the moment the summary was emitted.' };
 	linesDeleted: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Total lines deleted across all changed files in the session at the moment the summary was emitted.' };
-	userRequestsTotal: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Cumulative number of new sessions the user has started from the Agents window across all workspaces and providers at the moment the summary was emitted.' };
-	userRequestsInWorkspace: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Cumulative number of new sessions the user has started in the current workspace at the moment the summary was emitted.' };
-	userRequestsForProvider: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Cumulative number of new sessions the user has started for this sessions provider across all workspaces at the moment the summary was emitted.' };
+	userSessionsTotal: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Cumulative number of new sessions the user has started from the Agents window across all workspaces and providers at the moment the summary was emitted.' };
+	userSessionsInWorkspace: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Cumulative number of new sessions the user has started in the current workspace at the moment the summary was emitted.' };
+	userSessionsForProvider: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Cumulative number of new sessions the user has started for this sessions provider across all workspaces at the moment the summary was emitted.' };
 };

--- a/src/vs/sessions/contrib/sessions/browser/sessionsTelemetry.contribution.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsTelemetry.contribution.ts
@@ -3,27 +3,27 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { disposableTimeout } from '../../../../base/common/async.js';
 import { hash } from '../../../../base/common/hash.js';
-import { Disposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableMap } from '../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
-import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+import { IStorageService } from '../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
 import { IWorkbenchContribution } from '../../../../workbench/common/contributions.js';
 import { isChatRequestFileEntry, isImageVariableEntry } from '../../../../workbench/contrib/chat/common/attachments/chatVariableEntries.js';
 import { getExcludes, ISearchConfiguration, ISearchService, QueryType } from '../../../../workbench/services/search/common/search.js';
 import { IAgentFeedbackAddedEvent, IAgentFeedbackConvertedEvent, IAgentFeedbackReplyAddedEvent, IAgentFeedbackService, IAgentFeedbackSubmittedEvent } from '../../agentFeedback/browser/agentFeedbackService.js';
+import { ISessionsTasksService } from '../../chat/browser/sessionsTasksService.js';
 import { IChat, ISession, ISessionWorkspace, SessionStatus } from '../../../services/sessions/common/session.js';
-import { ISendRequestSentEvent, ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
-import { ISendRequestOptions } from '../../../services/sessions/common/sessionsProvider.js';
+import { ISendRequestSentEvent, ISessionsChangeEvent, ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
+import { ISendRequestOptions, ISessionsProvider } from '../../../services/sessions/common/sessionsProvider.js';
+import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
 import { ISessionsPartService } from '../../../browser/parts/sessionsPartService.js';
-
-const TOTAL_REQUESTS_KEY = 'agentSessions.telemetry.totalRequests';
-const WORKSPACE_REQUESTS_KEY = 'agentSessions.telemetry.workspaceRequests';
-const PROVIDER_REQUESTS_KEY = 'agentSessions.telemetry.providerRequests';
+import { ISessionLifecycleSummary, SessionDoneReason, SessionsLifecycleTracker } from './sessionsLifecycleTracker.js';
 
 /**
  * Listens to lifecycle events from {@link ISessionsManagementService} and
@@ -41,6 +41,10 @@ export class SessionsTelemetryContribution extends Disposable implements IWorkbe
 	private readonly _workspaceFileCountCache = new Map<string, number>();
 	/** Pending workspace file-count fetches, keyed by workspace URI so a prewarm started before a session-id assignment can be picked up after. */
 	private readonly _workspaceFileCountInFlight = new Map<string, Promise<number>>();
+	/** Persists per-session lifecycle counters for the `agents/sessionSummary` event. */
+	private readonly _lifecycleTracker: SessionsLifecycleTracker;
+	/** Listener per provider that waits for the provider's first batch of sessions so we can run a one-time reconciliation against tracked entries. */
+	private readonly _providerReconcileListeners = this._register(new DisposableMap<string>());
 
 	constructor(
 		@ISessionsManagementService private readonly _sessionsManagementService: ISessionsManagementService,
@@ -52,17 +56,29 @@ export class SessionsTelemetryContribution extends Disposable implements IWorkbe
 		@ICommandService commandService: ICommandService,
 		@IAgentFeedbackService agentFeedbackService: IAgentFeedbackService,
 		@ISessionsPartService sessionsPartService: ISessionsPartService,
+		@ISessionsProvidersService sessionsProvidersService: ISessionsProvidersService,
+		@ISessionsTasksService private readonly _sessionsTasksService: ISessionsTasksService,
 	) {
 		super();
+
+		this._lifecycleTracker = this._register(new SessionsLifecycleTracker(this._storageService));
 
 		this._register(this._sessionsManagementService.onWillSendRequest(session => {
 			// Kick off the workspace file-count fetch now so it has time to
 			// resolve while the provider sends the request. The result is
 			// picked up under the (possibly updated) session id when
-			// `onDidSendRequest` fires.
+			// `onDidSendNewChatRequest` fires.
 			this._startWorkspaceFileCountFetch(session.workspace.get());
 		}));
-		this._register(this._sessionsManagementService.onDidSendRequest(e => this._logRequestSent(e)));
+		this._register(this._sessionsManagementService.onDidSendRequest(e => {
+			if (e.isNewChat) {
+				this._logNewChatRequestSent(e);
+			} else {
+				// Follow-up request within an existing chat: count it toward
+				// `requestsSent` without incrementing `chatCount`.
+				this._lifecycleTracker.recordRequestSent(e.session);
+			}
+		}));
 		this._register(this._sessionsManagementService.onDidArchiveSession(session => this._logSessionArchived(session)));
 		this._register(this._sessionsManagementService.onDidUnarchiveSession(session => this._logSessionUnarchived(session)));
 		this._register(this._sessionsManagementService.onDidDeleteSession(session => this._logSessionDeleted(session)));
@@ -70,6 +86,22 @@ export class SessionsTelemetryContribution extends Disposable implements IWorkbe
 		this._register(this._sessionsManagementService.onDidRenameChat(session => this._logChatRenamed(session)));
 		this._register(this._sessionsManagementService.onDidToggleSessionStickiness(e => this._logSessionStickinessToggled(e.session, e.sticky)));
 		this._register(sessionsPartService.onDidToggleMaximizeSession(e => this._logSessionMaximizeToggled(e.session, e.maximized)));
+		this._register(this._sessionsManagementService.onDidChangeSessions(e => this._onDidChangeSessions(e)));
+
+		// Reconcile tracked-but-missing entries (sessions deleted while this
+		// client was closed) and tracked-but-already-archived entries (sessions
+		// archived elsewhere) once each provider has loaded its sessions.
+		for (const provider of sessionsProvidersService.getProviders()) {
+			this._trackProviderForReconciliation(provider);
+		}
+		this._register(sessionsProvidersService.onDidChangeProviders(e => {
+			for (const provider of e.added) {
+				this._trackProviderForReconciliation(provider);
+			}
+			for (const provider of e.removed) {
+				this._providerReconcileListeners.deleteAndDispose(provider.id);
+			}
+		}));
 
 		this._register(commandService.onDidExecuteCommand(e => {
 			// Commands fire very frequently. Match on the command id first
@@ -125,6 +157,8 @@ export class SessionsTelemetryContribution extends Disposable implements IWorkbe
 		this._register(agentFeedbackService.onDidConvertFeedback(e => this._logFeedbackConverted(e)));
 		this._register(agentFeedbackService.onDidAddReply(e => this._logFeedbackReplyAdded(e)));
 		this._register(agentFeedbackService.onDidSubmitFeedback(e => this._logFeedbackSubmitted(e)));
+
+		this._register(this._sessionsTasksService.onDidRunTask(e => this._lifecycleTracker.bumpCounter(e.session, 'taskRun')));
 	}
 
 	/**
@@ -146,13 +180,26 @@ export class SessionsTelemetryContribution extends Disposable implements IWorkbe
 
 	// -- event handlers --------------------------------------------------------
 
-	private _logRequestSent(e: ISendRequestSentEvent): void {
+	private _logNewChatRequestSent(e: ISendRequestSentEvent): void {
 		const { session, chat, isNewSession, options } = e;
+
+		const wasTracked = this._lifecycleTracker.isTracked(session.sessionId);
+		this._lifecycleTracker.recordNewChatRequestSent(session);
+		if (!wasTracked) {
+			void this._sessionsTasksService.getAllTasks(session).then(tasks => {
+				const hasWorktreeCreatedTask = tasks.some(t => t.task.runOptions?.runOn === 'worktreeCreated');
+				this._lifecycleTracker.recordFirstRequestTaskInfo(session, { hasWorktreeCreatedTask, configuredTasksCount: tasks.length });
+			});
+		}
+
 		const allSessions = this._sessionsManagementService.getSessions();
 		const visibleSessionsCount = this._sessionsManagementService.visibleSessions.get().filter(s => s !== undefined).length;
 		// Snapshot all synchronous fields now so the event reflects the state at
 		// the time of the send, not when the async file-count fetch resolves.
 		const workspace = session.workspace.get();
+		const requestCounters = isNewSession
+			? this._lifecycleTracker.incrementAndGetUserRequestCounters(session)
+			: this._lifecycleTracker.getUserRequestCounters(session);
 		const sync = {
 			isNewSession,
 			visibleSessionsCount,
@@ -160,7 +207,7 @@ export class SessionsTelemetryContribution extends Disposable implements IWorkbe
 			...this._getSessionFields(session),
 			...this._getChatFields(chat),
 			...this._getAllSessionsFields(session, allSessions),
-			...this._incrementAndGetUserRequestCounters(session.providerId, workspace?.uri.toString()),
+			...requestCounters,
 		};
 		void this._getOrFetchWorkspaceFileCount(session.sessionId, workspace).then(workspaceFileCount => {
 			this._telemetryService.publicLog2<SessionRequestSentEvent, SessionRequestSentClassification>('agents/requestSent', {
@@ -174,6 +221,7 @@ export class SessionsTelemetryContribution extends Disposable implements IWorkbe
 		void this._getSessionActionPayload(session).then(payload => {
 			this._telemetryService.publicLog2<SessionActionEvent, SessionArchivedClassification>('agents/sessionArchived', payload);
 		});
+		this._fireSessionSummary(session, 'archived');
 	}
 
 	private _logSessionUnarchived(session: ISession): void {
@@ -186,21 +234,25 @@ export class SessionsTelemetryContribution extends Disposable implements IWorkbe
 		void this._getSessionActionPayload(session).then(payload => {
 			this._telemetryService.publicLog2<SessionActionEvent, SessionDeletedClassification>('agents/sessionDeleted', payload);
 		});
+		this._fireSessionSummary(session, 'deleted');
 	}
 
 	private _logChatDeleted(session: ISession): void {
+		this._lifecycleTracker.bumpCounter(session, 'chatDeleted');
 		void this._getSessionActionPayload(session).then(payload => {
 			this._telemetryService.publicLog2<SessionActionEvent, ChatDeletedClassification>('agents/chatDeleted', payload);
 		});
 	}
 
 	private _logChatRenamed(session: ISession): void {
+		this._lifecycleTracker.bumpCounter(session, 'chatRenamed');
 		void this._getSessionActionPayload(session).then(payload => {
 			this._telemetryService.publicLog2<SessionActionEvent, ChatRenamedClassification>('agents/chatRenamed', payload);
 		});
 	}
 
 	private _logSessionStickinessToggled(session: ISession, sticky: boolean): void {
+		this._lifecycleTracker.bumpCounter(session, 'stickinessToggled');
 		void this._getSessionActionPayload(session).then(payload => {
 			this._telemetryService.publicLog2<SessionStickinessToggledEvent, SessionStickinessToggledClassification>('agents/sessionStickinessToggled', {
 				...payload,
@@ -210,6 +262,7 @@ export class SessionsTelemetryContribution extends Disposable implements IWorkbe
 	}
 
 	private _logSessionMaximizeToggled(session: ISession, maximized: boolean): void {
+		this._lifecycleTracker.bumpCounter(session, 'maximizeToggled');
 		void this._getSessionActionPayload(session).then(payload => {
 			this._telemetryService.publicLog2<SessionMaximizeToggledEvent, SessionMaximizeToggledClassification>('agents/sessionMaximizeToggled', {
 				...payload,
@@ -219,60 +272,70 @@ export class SessionsTelemetryContribution extends Disposable implements IWorkbe
 	}
 
 	private _logCreatePullRequest(session: ISession): void {
+		this._lifecycleTracker.bumpCounter(session, 'createPullRequest');
 		void this._getSessionActionPayload(session).then(payload => {
 			this._telemetryService.publicLog2<SessionActionEvent, CreatePullRequestClassification>('agents/createPullRequest', payload);
 		});
 	}
 
 	private _logCreateDraftPullRequest(session: ISession): void {
+		this._lifecycleTracker.bumpCounter(session, 'createDraftPullRequest');
 		void this._getSessionActionPayload(session).then(payload => {
 			this._telemetryService.publicLog2<SessionActionEvent, CreateDraftPullRequestClassification>('agents/createDraftPullRequest', payload);
 		});
 	}
 
 	private _logUpdatePullRequest(session: ISession): void {
+		this._lifecycleTracker.bumpCounter(session, 'updatePullRequest');
 		void this._getSessionActionPayload(session).then(payload => {
 			this._telemetryService.publicLog2<SessionActionEvent, UpdatePullRequestClassification>('agents/updatePullRequest', payload);
 		});
 	}
 
 	private _logMergePullRequest(session: ISession): void {
+		this._lifecycleTracker.bumpCounter(session, 'mergePullRequest');
 		void this._getSessionActionPayload(session).then(payload => {
 			this._telemetryService.publicLog2<SessionActionEvent, MergePullRequestClassification>('agents/mergePullRequest', payload);
 		});
 	}
 
 	private _logCheckoutPullRequest(session: ISession): void {
+		this._lifecycleTracker.bumpCounter(session, 'checkoutPullRequest');
 		void this._getSessionActionPayload(session).then(payload => {
 			this._telemetryService.publicLog2<SessionActionEvent, CheckoutPullRequestClassification>('agents/checkoutPullRequest', payload);
 		});
 	}
 
 	private _logInitializeRepository(session: ISession): void {
+		this._lifecycleTracker.bumpCounter(session, 'initializeRepository');
 		void this._getSessionActionPayload(session).then(payload => {
 			this._telemetryService.publicLog2<SessionActionEvent, InitializeRepositoryClassification>('agents/initializeRepository', payload);
 		});
 	}
 
 	private _logCommit(session: ISession): void {
+		this._lifecycleTracker.bumpCounter(session, 'commit');
 		void this._getSessionActionPayload(session).then(payload => {
 			this._telemetryService.publicLog2<SessionActionEvent, CommitClassification>('agents/commit', payload);
 		});
 	}
 
 	private _logCommitAndSync(session: ISession): void {
+		this._lifecycleTracker.bumpCounter(session, 'commitAndSync');
 		void this._getSessionActionPayload(session).then(payload => {
 			this._telemetryService.publicLog2<SessionActionEvent, CommitAndSyncClassification>('agents/commitAndSync', payload);
 		});
 	}
 
 	private _logSessionRestored(session: ISession): void {
+		this._lifecycleTracker.bumpCounter(session, 'sessionRestored');
 		void this._getSessionActionPayload(session).then(payload => {
 			this._telemetryService.publicLog2<SessionActionEvent, SessionRestoredClassification>('agents/sessionRestored', payload);
 		});
 	}
 
 	private _logFixCIChecks(session: ISession): void {
+		this._lifecycleTracker.bumpCounter(session, 'fixCIChecks');
 		void this._getSessionActionPayload(session).then(payload => {
 			this._telemetryService.publicLog2<SessionActionEvent, FixCIChecksClassification>('agents/fixCIChecks', payload);
 		});
@@ -283,6 +346,7 @@ export class SessionsTelemetryContribution extends Disposable implements IWorkbe
 		if (!session) {
 			return;
 		}
+		this._lifecycleTracker.bumpCounter(session, 'feedbackAdded');
 		const hasSuggestion = !!e.feedback.suggestion;
 		const hasExistingFeedbackForFile = e.hasExistingFeedbackForFile;
 		void this._getSessionActionPayload(session).then(payload => {
@@ -299,6 +363,7 @@ export class SessionsTelemetryContribution extends Disposable implements IWorkbe
 		if (!session) {
 			return;
 		}
+		this._lifecycleTracker.bumpCounter(session, 'feedbackConverted');
 		const feedbackKind = e.kind;
 		const hasSuggestion = !!e.feedback.suggestion;
 		const hasExistingFeedbackForFile = e.hasExistingFeedbackForFile;
@@ -317,6 +382,7 @@ export class SessionsTelemetryContribution extends Disposable implements IWorkbe
 		if (!session) {
 			return;
 		}
+		this._lifecycleTracker.bumpCounter(session, 'feedbackReplyAdded');
 		const feedbackKind = e.feedback.kind;
 		const replyCount = e.replyCount;
 		void this._getSessionActionPayload(session).then(payload => {
@@ -333,6 +399,7 @@ export class SessionsTelemetryContribution extends Disposable implements IWorkbe
 		if (!session) {
 			return;
 		}
+		this._lifecycleTracker.bumpCounter(session, 'feedbackSubmitted');
 		const { totalCount, userCount, codeReviewCount, prReviewCount, replyCount } = e;
 		void this._getSessionActionPayload(session).then(payload => {
 			this._telemetryService.publicLog2<FeedbackSubmittedEvent, FeedbackSubmittedClassification>('agents/feedbackSubmitted', {
@@ -344,6 +411,104 @@ export class SessionsTelemetryContribution extends Disposable implements IWorkbe
 				replyCount,
 			});
 		});
+	}
+
+	// -- cross-client session-done detection -----------------------------------
+
+	/**
+	 * Reacts to the session list changing across all providers and emits a
+	 * `agents/sessionSummary` event for tracked sessions that the user
+	 * finished (archived or deleted) in a different client. Local archive /
+	 * delete are handled directly by {@link _logSessionArchived} /
+	 * {@link _logSessionDeleted}; the deferred timer here gives those handlers
+	 * a chance to claim the tracked entry first so the `doneReason` is
+	 * reported as `archived` / `deleted` rather than `archivedRemotely` /
+	 * `deletedRemotely`.
+	 */
+	private _onDidChangeSessions(e: ISessionsChangeEvent): void {
+		for (const session of e.removed) {
+			if (!this._lifecycleTracker.isTracked(session.sessionId)) {
+				continue;
+			}
+			this._register(disposableTimeout(() => {
+				this._fireSessionSummary(session, 'deletedRemotely');
+			}, 100));
+		}
+		for (const session of e.changed) {
+			if (!this._lifecycleTracker.isTracked(session.sessionId)) {
+				continue;
+			}
+			if (session.isArchived.get()) {
+				this._register(disposableTimeout(() => {
+					this._fireSessionSummary(session, 'archivedRemotely');
+				}, 100));
+			} else {
+				this._lifecycleTracker.updateSessionState(session);
+			}
+		}
+	}
+
+	/**
+	 * Schedules a one-time reconciliation of tracked entries for `provider`.
+	 * Reconciliation runs as soon as the provider reports at least one live
+	 * session (its "loaded" signal). If the provider already has sessions at
+	 * registration time, this runs synchronously; otherwise we wait on
+	 * `onDidChangeSessions` and dispose the listener after the first run.
+	 */
+	private _trackProviderForReconciliation(provider: ISessionsProvider): void {
+		if (this._tryReconcileProvider(provider)) {
+			return;
+		}
+		this._providerReconcileListeners.set(provider.id, provider.onDidChangeSessions(() => {
+			if (this._tryReconcileProvider(provider)) {
+				this._providerReconcileListeners.deleteAndDispose(provider.id);
+			}
+		}));
+	}
+
+	/**
+	 * Reconciles tracked entries for `provider` against its current sessions.
+	 * For each tracked entry: finalizes as `deletedRemotely` when missing, or
+	 * `archivedRemotely` when present and archived. Returns `true` once the
+	 * provider has reported at least one session (so the caller can stop
+	 * listening).
+	 */
+	private _tryReconcileProvider(provider: ISessionsProvider): boolean {
+		const sessions = provider.getSessions();
+		if (sessions.length === 0) {
+			return false;
+		}
+		const trackedForProvider = this._lifecycleTracker.getTrackedEntries().filter(e => e.providerId === provider.id);
+		if (trackedForProvider.length === 0) {
+			return true;
+		}
+		const liveById = new Map<string, ISession>();
+		for (const session of sessions) {
+			liveById.set(session.sessionId, session);
+		}
+		for (const { sessionId } of trackedForProvider) {
+			const live = liveById.get(sessionId);
+			if (!live) {
+				const summary = this._lifecycleTracker.finalize(sessionId, 'deletedRemotely');
+				if (summary) {
+					this._logSessionSummary(summary);
+				}
+			} else if (live.isArchived.get()) {
+				this._fireSessionSummary(live, 'archivedRemotely');
+			}
+		}
+		return true;
+	}
+
+	private _fireSessionSummary(session: ISession, reason: SessionDoneReason): void {
+		const summary = this._lifecycleTracker.finalize(session.sessionId, reason, session);
+		if (summary) {
+			this._logSessionSummary(summary);
+		}
+	}
+
+	private _logSessionSummary(summary: ISessionLifecycleSummary): void {
+		this._telemetryService.publicLog2<ISessionLifecycleSummary, SessionSummaryClassification>('agents/sessionSummary', summary);
 	}
 
 	private _getSessionActionPayload(session: ISession): Promise<SessionActionEvent> {
@@ -520,39 +685,6 @@ export class SessionsTelemetryContribution extends Disposable implements IWorkbe
 			allWorkspacesNotDone: all.notDone,
 		};
 	}
-
-	private _incrementAndGetUserRequestCounters(providerId: string, workspaceUri: string | undefined): UserRequestCountersFields {
-		const userRequestsTotal = this._storageService.getNumber(TOTAL_REQUESTS_KEY, StorageScope.APPLICATION, 0) + 1;
-		this._storageService.store(TOTAL_REQUESTS_KEY, userRequestsTotal, StorageScope.APPLICATION, StorageTarget.MACHINE);
-
-		const providerCounts = this._readCounterMap(PROVIDER_REQUESTS_KEY);
-		const userRequestsForProvider = (providerCounts[providerId] ?? 0) + 1;
-		providerCounts[providerId] = userRequestsForProvider;
-		this._storageService.store(PROVIDER_REQUESTS_KEY, JSON.stringify(providerCounts), StorageScope.APPLICATION, StorageTarget.MACHINE);
-
-		let userRequestsInWorkspace = 0;
-		if (workspaceUri) {
-			const workspaceCounts = this._readCounterMap(WORKSPACE_REQUESTS_KEY);
-			userRequestsInWorkspace = (workspaceCounts[workspaceUri] ?? 0) + 1;
-			workspaceCounts[workspaceUri] = userRequestsInWorkspace;
-			this._storageService.store(WORKSPACE_REQUESTS_KEY, JSON.stringify(workspaceCounts), StorageScope.APPLICATION, StorageTarget.MACHINE);
-		}
-
-		return { userRequestsTotal, userRequestsInWorkspace, userRequestsForProvider };
-	}
-
-	private _readCounterMap(key: string): Record<string, number> {
-		const raw = this._storageService.get(key, StorageScope.APPLICATION);
-		if (!raw) {
-			return {};
-		}
-		try {
-			const parsed = JSON.parse(raw);
-			return (parsed && typeof parsed === 'object') ? parsed as Record<string, number> : {};
-		} catch {
-			return {};
-		}
-	}
 }
 
 interface ISessionStatusCounts {
@@ -648,12 +780,6 @@ type AllSessionsFields = {
 	allWorkspacesNotDone: number;
 };
 
-type UserRequestCountersFields = {
-	userRequestsTotal: number;
-	userRequestsInWorkspace: number;
-	userRequestsForProvider: number;
-};
-
 // --- Event: agents/requestSent ---
 
 type SessionRequestSentEvent = {
@@ -745,9 +871,9 @@ type SessionRequestSentClassification = {
 	allWorkspacesUnread: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Unread sessions across all workspaces.' };
 	allWorkspacesWaitingForInput: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Sessions waiting for user input across all workspaces.' };
 	allWorkspacesNotDone: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Sessions not marked as done across all workspaces.' };
-	userRequestsTotal: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Cumulative number of requests the user has sent from the Agents window across all workspaces and providers (including this one).' };
-	userRequestsInWorkspace: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Cumulative number of requests the user has sent in the current workspace (including this one).' };
-	userRequestsForProvider: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Cumulative number of requests the user has sent for this sessions provider across all workspaces (including this one).' };
+	userRequestsTotal: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Cumulative number of new sessions the user has started from the Agents window across all workspaces and providers. Incremented only when `isNewSession` is true.' };
+	userRequestsInWorkspace: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Cumulative number of new sessions the user has started in the current workspace. Incremented only when `isNewSession` is true.' };
+	userRequestsForProvider: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Cumulative number of new sessions the user has started for this sessions provider across all workspaces. Incremented only when `isNewSession` is true.' };
 };
 
 type SessionArchivedClassification = {
@@ -1227,4 +1353,52 @@ type SessionMaximizeToggledClassification = {
 	sessionLinesAdded: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Total number of lines added across all changed files in the session at the time of the action.' };
 	sessionLinesDeleted: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Total number of lines deleted across all changed files in the session at the time of the action.' };
 	maximized: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The session view\'s maximized state after the toggle: true when the view is now maximized, false when it was restored.' };
+};
+
+// --- Event: session summary (emitted once when a session reaches a terminal state) ---
+
+type SessionSummaryClassification = {
+	owner: 'benibenj';
+	comment: 'Single per-session summary emitted when a tracked session is finished (archived, deleted, or observed as archived/deleted in another client). Aggregates everything that happened during the session\'s lifetime.';
+	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Globally unique session id (providerId:resourceUri), used to correlate events for the same session.' };
+	providerId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The sessions provider identifier (e.g., remote agent host or local).' };
+	providerType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The session type identifier provided by the sessions provider.' };
+	isolationKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Isolation mode used by the session (worktree or folder), captured the first time the session was observed in this client.' };
+	workspaceHash: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Non-reversible hash of the workspace URI the session is tied to, used to correlate events across the same workspace without disclosing the path.' };
+	hasGitRepository: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether any of the workspace folders has a git repository, captured the first time the session was observed in this client.' };
+	isVirtualWorkspace: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the workspace URI uses a non-file scheme (virtual/remote), captured the first time the session was observed in this client.' };
+	doneReason: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Why the session is considered done: archived/deleted locally in this client, or archivedRemotely/deletedRemotely meaning the user finished the session in another client.' };
+	firstRequestSentInThisClient: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the very first user request the tracker observed for this session was sent from this client.' };
+	hasWorktreeCreatedTask: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether at least one task with runOptions.runOn = "worktreeCreated" was declared for the session at the time the first user request was sent from this client.' };
+	configuredTasksCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of tasks declared for the session at the time the first user request was sent from this client.' };
+	timeSinceFirstObservedMs: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Wall-clock milliseconds between the first time this client observed the session and the moment the summary was emitted.' };
+	timeSinceFirstRequestMs: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Wall-clock milliseconds between the first user request this client sent for the session and the moment the summary was emitted; -1 if no request was ever sent from this client.' };
+	appLaunchesSinceFirstObserved: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'How many additional times this client was launched between the first time the session was observed here and the moment the summary was emitted.' };
+	requestsSent: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Total number of user requests sent for this session from this client during its lifetime.' };
+	chatCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of new chats started within the session from this client during its lifetime.' };
+	feedbackAdded: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of times the user added a new feedback item to the session in this client.' };
+	feedbackConverted: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of times the user converted feedback (e.g., from code review/PR review into a tracked item) in this client.' };
+	feedbackReplyAdded: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of times the user added a reply to an existing feedback thread in this client.' };
+	feedbackSubmitted: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of times the user submitted feedback for this session in this client.' };
+	createPullRequest: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of times the user ran the Create Pull Request action for this session in this client.' };
+	createDraftPullRequest: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of times the user ran the Create Draft Pull Request action for this session in this client.' };
+	updatePullRequest: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of times the user ran the Update Pull Request action for this session in this client.' };
+	mergePullRequest: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of times the user ran the Merge Pull Request action for this session in this client.' };
+	checkoutPullRequest: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of times the user ran the Checkout Pull Request action for this session in this client.' };
+	initializeRepository: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of times the user ran the Initialize Repository action for this session in this client.' };
+	commit: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of times the user ran the Commit action for this session in this client.' };
+	commitAndSync: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of times the user ran the Commit & Sync action for this session in this client.' };
+	sessionRestored: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of times the user ran the Restore Session action for this session in this client.' };
+	stickinessToggled: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of times the user toggled the session\'s stickiness in this client.' };
+	maximizeToggled: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of times the user toggled the session view\'s maximized state in this client.' };
+	chatDeleted: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of times the user deleted a chat from the session in this client.' };
+	chatRenamed: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of times the user renamed a chat in the session in this client.' };
+	fixCIChecks: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of times the user ran the Fix CI Checks action for this session in this client.' };
+	taskRun: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of times the user ran a task from the session toolbar for this session in this client.' };
+	filesChanged: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of changed files in the session at the moment the summary was emitted.' };
+	linesAdded: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Total lines added across all changed files in the session at the moment the summary was emitted.' };
+	linesDeleted: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Total lines deleted across all changed files in the session at the moment the summary was emitted.' };
+	userRequestsTotal: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Cumulative number of new sessions the user has started from the Agents window across all workspaces and providers at the moment the summary was emitted.' };
+	userRequestsInWorkspace: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Cumulative number of new sessions the user has started in the current workspace at the moment the summary was emitted.' };
+	userRequestsForProvider: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Cumulative number of new sessions the user has started for this sessions provider across all workspaces at the moment the summary was emitted.' };
 };

--- a/src/vs/sessions/contrib/sessions/test/browser/sessionsLifecycleTracker.test.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/sessionsLifecycleTracker.test.ts
@@ -392,10 +392,10 @@ suite('SessionsLifecycleTracker', () => {
 		const b = createSession('b', { providerId: 'p2', workspace: workspaceB });
 		const noWorkspace = createSession('n', { providerId: 'p1' });
 
-		assert.deepStrictEqual(tracker.incrementAndGetUserRequestCounters(a1), { userRequestsTotal: 1, userRequestsInWorkspace: 1, userRequestsForProvider: 1 });
-		assert.deepStrictEqual(tracker.incrementAndGetUserRequestCounters(a2), { userRequestsTotal: 2, userRequestsInWorkspace: 2, userRequestsForProvider: 2 });
-		assert.deepStrictEqual(tracker.incrementAndGetUserRequestCounters(b), { userRequestsTotal: 3, userRequestsInWorkspace: 1, userRequestsForProvider: 1 });
-		assert.deepStrictEqual(tracker.incrementAndGetUserRequestCounters(noWorkspace), { userRequestsTotal: 4, userRequestsInWorkspace: 0, userRequestsForProvider: 3 });
+		assert.deepStrictEqual(tracker.incrementAndGetUserRequestCounters(a1), { userSessionsTotal: 1, userSessionsInWorkspace: 1, userSessionsForProvider: 1 });
+		assert.deepStrictEqual(tracker.incrementAndGetUserRequestCounters(a2), { userSessionsTotal: 2, userSessionsInWorkspace: 2, userSessionsForProvider: 2 });
+		assert.deepStrictEqual(tracker.incrementAndGetUserRequestCounters(b), { userSessionsTotal: 3, userSessionsInWorkspace: 1, userSessionsForProvider: 1 });
+		assert.deepStrictEqual(tracker.incrementAndGetUserRequestCounters(noWorkspace), { userSessionsTotal: 4, userSessionsInWorkspace: 0, userSessionsForProvider: 3 });
 	});
 
 	test('summary includes the request counters as observed at finalize time', () => {
@@ -413,13 +413,13 @@ suite('SessionsLifecycleTracker', () => {
 		const summary = tracker.finalize(sessionToFinalize.sessionId, 'archived', sessionToFinalize);
 		assert.ok(summary);
 		assert.deepStrictEqual({
-			userRequestsTotal: summary!.userRequestsTotal,
-			userRequestsInWorkspace: summary!.userRequestsInWorkspace,
-			userRequestsForProvider: summary!.userRequestsForProvider,
+			userSessionsTotal: summary!.userSessionsTotal,
+			userSessionsInWorkspace: summary!.userSessionsInWorkspace,
+			userSessionsForProvider: summary!.userSessionsForProvider,
 		}, {
-			userRequestsTotal: 3,
-			userRequestsInWorkspace: 2,
-			userRequestsForProvider: 2,
+			userSessionsTotal: 3,
+			userSessionsInWorkspace: 2,
+			userSessionsForProvider: 2,
 		});
 	});
 
@@ -430,21 +430,21 @@ suite('SessionsLifecycleTracker', () => {
 		tracker.incrementAndGetUserRequestCounters(session);
 
 		const secondTracker = disposables.add(new SessionsLifecycleTracker(storage));
-		assert.deepStrictEqual(secondTracker.incrementAndGetUserRequestCounters(session), { userRequestsTotal: 3, userRequestsInWorkspace: 3, userRequestsForProvider: 3 });
+		assert.deepStrictEqual(secondTracker.incrementAndGetUserRequestCounters(session), { userSessionsTotal: 3, userSessionsInWorkspace: 3, userSessionsForProvider: 3 });
 	});
 
 	test('getUserRequestCounters returns current values without incrementing', () => {
 		const workspace = createWorkspace(URI.parse('file:///ws/a'), [createFolder(URI.parse('file:///ws/a'))]);
 		const session = createSession('a1', { providerId: 'p1', workspace });
 
-		assert.deepStrictEqual(tracker.getUserRequestCounters(session), { userRequestsTotal: 0, userRequestsInWorkspace: 0, userRequestsForProvider: 0 });
+		assert.deepStrictEqual(tracker.getUserRequestCounters(session), { userSessionsTotal: 0, userSessionsInWorkspace: 0, userSessionsForProvider: 0 });
 
 		tracker.incrementAndGetUserRequestCounters(session);
 		tracker.incrementAndGetUserRequestCounters(session);
 
-		assert.deepStrictEqual(tracker.getUserRequestCounters(session), { userRequestsTotal: 2, userRequestsInWorkspace: 2, userRequestsForProvider: 2 });
+		assert.deepStrictEqual(tracker.getUserRequestCounters(session), { userSessionsTotal: 2, userSessionsInWorkspace: 2, userSessionsForProvider: 2 });
 		// Repeated reads do not mutate state.
-		assert.deepStrictEqual(tracker.getUserRequestCounters(session), { userRequestsTotal: 2, userRequestsInWorkspace: 2, userRequestsForProvider: 2 });
+		assert.deepStrictEqual(tracker.getUserRequestCounters(session), { userSessionsTotal: 2, userSessionsInWorkspace: 2, userSessionsForProvider: 2 });
 	});
 
 	test('summary reports zero request counters for an untouched provider/workspace', () => {
@@ -454,13 +454,13 @@ suite('SessionsLifecycleTracker', () => {
 		const summary = tracker.finalize(session.sessionId, 'archived', session);
 		assert.ok(summary);
 		assert.deepStrictEqual({
-			userRequestsTotal: summary!.userRequestsTotal,
-			userRequestsInWorkspace: summary!.userRequestsInWorkspace,
-			userRequestsForProvider: summary!.userRequestsForProvider,
+			userSessionsTotal: summary!.userSessionsTotal,
+			userSessionsInWorkspace: summary!.userSessionsInWorkspace,
+			userSessionsForProvider: summary!.userSessionsForProvider,
 		}, {
-			userRequestsTotal: 0,
-			userRequestsInWorkspace: 0,
-			userRequestsForProvider: 0,
+			userSessionsTotal: 0,
+			userSessionsInWorkspace: 0,
+			userSessionsForProvider: 0,
 		});
 	});
 

--- a/src/vs/sessions/contrib/sessions/test/browser/sessionsLifecycleTracker.test.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/sessionsLifecycleTracker.test.ts
@@ -1,0 +1,529 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { hash } from '../../../../../base/common/hash.js';
+import { constObservable, observableValue } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { InMemoryStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
+import { IChat, ISession, ISessionChangesSummary, ISessionFileChange, ISessionFolder, ISessionWorkspace, SessionStatus } from '../../../../services/sessions/common/session.js';
+import { MAX_TRACKED_SESSIONS, SESSIONS_KEY, SessionsLifecycleTracker } from '../../browser/sessionsLifecycleTracker.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
+
+interface ICreateSessionOptions {
+	providerId?: string;
+	sessionType?: string;
+	workspace?: ISessionWorkspace;
+	changes?: readonly ISessionFileChange[];
+	changesSummary?: ISessionChangesSummary;
+}
+
+function createSession(id: string, opts: ICreateSessionOptions = {}): ISession {
+	const providerId = opts.providerId ?? 'test-provider';
+	const sessionType = opts.sessionType ?? 'test-type';
+	return {
+		sessionId: id,
+		resource: URI.parse(`session://${id}`),
+		providerId,
+		sessionType,
+		icon: Codicon.account,
+		createdAt: new Date(),
+		workspace: observableValue(`workspace-${id}`, opts.workspace),
+		title: observableValue(`title-${id}`, id),
+		updatedAt: observableValue(`updatedAt-${id}`, new Date()),
+		status: observableValue(`status-${id}`, SessionStatus.Completed),
+		changesets: observableValue(`changesets-${id}`, []),
+		changes: observableValue(`changes-${id}`, opts.changes ?? []),
+		changesSummary: opts.changesSummary !== undefined ? observableValue(`changesSummary-${id}`, opts.changesSummary as ISessionChangesSummary | undefined) : undefined,
+		modelId: observableValue(`modelId-${id}`, undefined),
+		mode: observableValue(`mode-${id}`, undefined),
+		loading: observableValue(`loading-${id}`, false),
+		isArchived: observableValue(`isArchived-${id}`, false),
+		isRead: observableValue(`isRead-${id}`, true),
+		description: observableValue(`description-${id}`, undefined),
+		lastTurnEnd: observableValue(`lastTurnEnd-${id}`, undefined),
+		chats: observableValue<readonly IChat[]>(`chats-${id}`, []),
+		mainChat: constObservable<IChat>(undefined!),
+		capabilities: { supportsMultipleChats: false },
+	};
+}
+
+function createWorkspace(uri: URI, folders: ISessionFolder[]): ISessionWorkspace {
+	return {
+		uri,
+		label: 'ws',
+		icon: ThemeIcon.fromId('folder'),
+		folders,
+		requiresWorkspaceTrust: false,
+		isVirtualWorkspace: uri.scheme !== 'file',
+	};
+}
+
+function createFolder(uri: URI, opts: { readonly workTreeUri?: URI; readonly withGitRepository?: boolean } = {}): ISessionFolder {
+	return {
+		root: uri,
+		workingDirectory: uri,
+		name: 'folder',
+		description: undefined,
+		gitRepository: (opts.withGitRepository || opts.workTreeUri)
+			? {
+				uri,
+				workTreeUri: opts.workTreeUri,
+				baseBranchName: undefined,
+				gitHubInfo: constObservable(undefined),
+			}
+			: undefined,
+	};
+}
+
+suite('SessionsLifecycleTracker', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+	let storage: InMemoryStorageService;
+	let tracker: SessionsLifecycleTracker;
+
+	setup(() => {
+		storage = disposables.add(new InMemoryStorageService());
+		tracker = disposables.add(new SessionsLifecycleTracker(storage));
+	});
+
+	test('starts untracked until a user interaction is recorded', () => {
+		const session = createSession('s1');
+		assert.strictEqual(tracker.isTracked(session.sessionId), false);
+
+		tracker.recordNewChatRequestSent(session);
+
+		assert.strictEqual(tracker.isTracked(session.sessionId), true);
+	});
+
+	test('finalize emits summary and removes tracking entry', () => {
+		const session = createSession('s1');
+		tracker.recordNewChatRequestSent(session);
+		tracker.bumpCounter(session, 'feedbackAdded');
+		tracker.bumpCounter(session, 'feedbackAdded');
+		tracker.bumpCounter(session, 'commit');
+
+		const summary = tracker.finalize(session.sessionId, 'archived', session);
+
+		assert.ok(summary);
+		assert.strictEqual(summary!.agentSessionId, 's1');
+		assert.strictEqual(summary!.providerId, 'test-provider');
+		assert.strictEqual(summary!.providerType, 'test-type');
+		assert.strictEqual(summary!.doneReason, 'archived');
+		assert.strictEqual(summary!.requestsSent, 1);
+		assert.strictEqual(summary!.feedbackAdded, 2);
+		assert.strictEqual(summary!.commit, 1);
+		assert.strictEqual(summary!.firstRequestSentInThisClient, true);
+		assert.strictEqual(tracker.isTracked(session.sessionId), false);
+	});
+
+	test('finalize returns undefined when session is not tracked', () => {
+		const summary = tracker.finalize('does-not-exist', 'deletedRemotely');
+		assert.strictEqual(summary, undefined);
+	});
+
+	test('state persists across tracker instances and app launch count grows', () => {
+		const session = createSession('s1');
+		tracker.recordNewChatRequestSent(session);
+		tracker.bumpCounter(session, 'feedbackAdded');
+
+		const secondTracker = disposables.add(new SessionsLifecycleTracker(storage));
+
+		assert.strictEqual(secondTracker.isTracked(session.sessionId), true);
+		const summary = secondTracker.finalize(session.sessionId, 'archived', session);
+		assert.ok(summary);
+		assert.strictEqual(summary!.feedbackAdded, 1);
+		assert.strictEqual(summary!.requestsSent, 1);
+		assert.strictEqual(summary!.appLaunchesSinceFirstObserved, 1);
+	});
+
+	test('chatCount increments once per recordRequestSent call', () => {
+		const session = createSession('s1');
+
+		tracker.recordNewChatRequestSent(session);
+		tracker.recordNewChatRequestSent(session);
+		tracker.bumpCounter(session, 'feedbackAdded'); // bumpCounter should not affect chatCount
+		tracker.recordNewChatRequestSent(session);
+
+		const summary = tracker.finalize(session.sessionId, 'archived', session);
+
+		assert.ok(summary);
+		assert.strictEqual(summary!.chatCount, 3);
+		assert.strictEqual(summary!.requestsSent, 3);
+	});
+
+	test('getTrackedEntries returns sessionId plus providerId for each entry', () => {
+		const a = createSession('a', { providerId: 'provider-a' });
+		const b = createSession('b', { providerId: 'provider-b' });
+
+		tracker.recordNewChatRequestSent(a);
+		tracker.bumpCounter(b, 'commit');
+
+		const entries = tracker.getTrackedEntries()
+			.map(e => `${e.providerId}:${e.sessionId}`)
+			.sort();
+
+		assert.deepStrictEqual(entries, ['provider-a:a', 'provider-b:b']);
+	});
+
+	test('local archive then deferred remote signal yields a single summary', () => {
+		const session = createSession('s1');
+		tracker.recordNewChatRequestSent(session);
+
+		const localSummary = tracker.finalize(session.sessionId, 'archived', session);
+		assert.ok(localSummary);
+		assert.strictEqual(localSummary!.doneReason, 'archived');
+
+		const deferredSummary = tracker.finalize(session.sessionId, 'archivedRemotely', session);
+		assert.strictEqual(deferredSummary, undefined);
+	});
+
+	test('bumpCounter creates a tracking entry for previously untracked sessions', () => {
+		const session = createSession('s1');
+
+		tracker.bumpCounter(session, 'commit');
+
+		assert.strictEqual(tracker.isTracked(session.sessionId), true);
+		const summary = tracker.finalize(session.sessionId, 'archived', session);
+		assert.ok(summary);
+		assert.strictEqual(summary!.commit, 1);
+		assert.strictEqual(summary!.requestsSent, 0);
+		assert.strictEqual(summary!.firstRequestSentInThisClient, false);
+	});
+
+	test('bumpCounter increments distinct counter keys independently', () => {
+		const session = createSession('s1');
+
+		tracker.bumpCounter(session, 'chatRenamed');
+		tracker.bumpCounter(session, 'chatRenamed');
+		tracker.bumpCounter(session, 'taskRun');
+		tracker.bumpCounter(session, 'mergePullRequest');
+		tracker.bumpCounter(session, 'fixCIChecks');
+		tracker.bumpCounter(session, 'fixCIChecks');
+		tracker.bumpCounter(session, 'fixCIChecks');
+
+		const summary = tracker.finalize(session.sessionId, 'archived', session);
+		assert.ok(summary);
+		assert.deepStrictEqual({
+			chatRenamed: summary!.chatRenamed,
+			taskRun: summary!.taskRun,
+			mergePullRequest: summary!.mergePullRequest,
+			fixCIChecks: summary!.fixCIChecks,
+			commit: summary!.commit,
+		}, {
+			chatRenamed: 2,
+			taskRun: 1,
+			mergePullRequest: 1,
+			fixCIChecks: 3,
+			commit: 0,
+		});
+	});
+
+	test('updateSessionState is a no-op for untracked sessions', () => {
+		const session = createSession('s1', { changes: [{ modifiedUri: URI.parse('file:///a'), insertions: 5, deletions: 1 }] });
+
+		tracker.updateSessionState(session);
+
+		assert.strictEqual(tracker.isTracked(session.sessionId), false);
+	});
+
+	test('changesSummary observable takes precedence over the changes list', () => {
+		const session = createSession('s1', {
+			changes: [
+				{ modifiedUri: URI.parse('file:///a'), insertions: 5, deletions: 1 },
+				{ modifiedUri: URI.parse('file:///b'), insertions: 2, deletions: 3 },
+			],
+			changesSummary: { files: 17, additions: 99, deletions: 88 },
+		});
+
+		tracker.recordNewChatRequestSent(session);
+		const summary = tracker.finalize(session.sessionId, 'archived', session);
+
+		assert.ok(summary);
+		assert.deepStrictEqual({
+			filesChanged: summary!.filesChanged,
+			linesAdded: summary!.linesAdded,
+			linesDeleted: summary!.linesDeleted,
+		}, {
+			filesChanged: 17,
+			linesAdded: 99,
+			linesDeleted: 88,
+		});
+	});
+
+	test('falls back to aggregating changes when changesSummary is absent', () => {
+		const session = createSession('s1', {
+			changes: [
+				{ modifiedUri: URI.parse('file:///a'), insertions: 5, deletions: 1 },
+				{ modifiedUri: URI.parse('file:///b'), insertions: 2, deletions: 3 },
+			],
+		});
+
+		tracker.recordNewChatRequestSent(session);
+		const summary = tracker.finalize(session.sessionId, 'archived', session);
+
+		assert.ok(summary);
+		assert.deepStrictEqual({
+			filesChanged: summary!.filesChanged,
+			linesAdded: summary!.linesAdded,
+			linesDeleted: summary!.linesDeleted,
+		}, {
+			filesChanged: 2,
+			linesAdded: 7,
+			linesDeleted: 4,
+		});
+	});
+
+	test('summary derives workspace fields from the session workspace at first observation', () => {
+		const workspaceUri = URI.parse('vscode-remote://host/repo');
+		const repoUri = URI.parse('file:///repo');
+		const workspace = createWorkspace(workspaceUri, [
+			createFolder(repoUri, { workTreeUri: URI.parse('file:///repo/.git/worktrees/feature') }),
+		]);
+		const session = createSession('s1', { workspace });
+
+		tracker.recordNewChatRequestSent(session);
+		const summary = tracker.finalize(session.sessionId, 'archived', session);
+
+		assert.ok(summary);
+		assert.deepStrictEqual({
+			isolationKind: summary!.isolationKind,
+			hasGitRepository: summary!.hasGitRepository,
+			isVirtualWorkspace: summary!.isVirtualWorkspace,
+			workspaceHash: summary!.workspaceHash,
+		}, {
+			isolationKind: 'worktree',
+			hasGitRepository: true,
+			isVirtualWorkspace: true,
+			workspaceHash: hash(workspaceUri.toString()).toString(16),
+		});
+	});
+
+	test('summary reports folder isolation for a plain file workspace with no worktree', () => {
+		const workspaceUri = URI.parse('file:///repo');
+		const workspace = createWorkspace(workspaceUri, [
+			createFolder(workspaceUri, { withGitRepository: true }),
+		]);
+		const session = createSession('s1', { workspace });
+
+		tracker.recordNewChatRequestSent(session);
+		const summary = tracker.finalize(session.sessionId, 'archived', session);
+
+		assert.ok(summary);
+		assert.deepStrictEqual({
+			isolationKind: summary!.isolationKind,
+			hasGitRepository: summary!.hasGitRepository,
+			isVirtualWorkspace: summary!.isVirtualWorkspace,
+		}, {
+			isolationKind: 'folder',
+			hasGitRepository: true,
+			isVirtualWorkspace: false,
+		});
+	});
+
+	test('recordFirstRequestTaskInfo is a no-op when the session is not tracked', () => {
+		const session = createSession('s1');
+
+		tracker.recordFirstRequestTaskInfo(session, { hasWorktreeCreatedTask: true, configuredTasksCount: 3 });
+
+		assert.strictEqual(tracker.isTracked(session.sessionId), false);
+	});
+
+	test('recordFirstRequestTaskInfo only records the first call per session', () => {
+		const session = createSession('s1');
+		tracker.recordNewChatRequestSent(session);
+
+		tracker.recordFirstRequestTaskInfo(session, { hasWorktreeCreatedTask: true, configuredTasksCount: 4 });
+		tracker.recordFirstRequestTaskInfo(session, { hasWorktreeCreatedTask: false, configuredTasksCount: 0 });
+
+		const summary = tracker.finalize(session.sessionId, 'archived', session);
+		assert.ok(summary);
+		assert.deepStrictEqual({
+			hasWorktreeCreatedTask: summary!.hasWorktreeCreatedTask,
+			configuredTasksCount: summary!.configuredTasksCount,
+		}, {
+			hasWorktreeCreatedTask: true,
+			configuredTasksCount: 4,
+		});
+	});
+
+	test('recordFirstRequestTaskInfo persists across tracker instances', () => {
+		const session = createSession('s1');
+		tracker.recordNewChatRequestSent(session);
+		tracker.recordFirstRequestTaskInfo(session, { hasWorktreeCreatedTask: false, configuredTasksCount: 2 });
+
+		const secondTracker = disposables.add(new SessionsLifecycleTracker(storage));
+		const summary = secondTracker.finalize(session.sessionId, 'archived', session);
+
+		assert.ok(summary);
+		assert.deepStrictEqual({
+			hasWorktreeCreatedTask: summary!.hasWorktreeCreatedTask,
+			configuredTasksCount: summary!.configuredTasksCount,
+		}, {
+			hasWorktreeCreatedTask: false,
+			configuredTasksCount: 2,
+		});
+	});
+
+	test('summary reports task info as undefined when never recorded', () => {
+		const session = createSession('s1');
+		tracker.recordNewChatRequestSent(session);
+
+		const summary = tracker.finalize(session.sessionId, 'archived', session);
+		assert.ok(summary);
+		assert.deepStrictEqual({
+			hasWorktreeCreatedTask: summary!.hasWorktreeCreatedTask,
+			configuredTasksCount: summary!.configuredTasksCount,
+		}, {
+			hasWorktreeCreatedTask: undefined,
+			configuredTasksCount: undefined,
+		});
+	});
+
+	test('incrementAndGetUserRequestCounters returns post-increment values per provider, workspace and total', () => {
+		const workspaceA = createWorkspace(URI.parse('file:///ws/a'), [createFolder(URI.parse('file:///ws/a'))]);
+		const workspaceB = createWorkspace(URI.parse('file:///ws/b'), [createFolder(URI.parse('file:///ws/b'))]);
+		const a1 = createSession('a1', { providerId: 'p1', workspace: workspaceA });
+		const a2 = createSession('a2', { providerId: 'p1', workspace: workspaceA });
+		const b = createSession('b', { providerId: 'p2', workspace: workspaceB });
+		const noWorkspace = createSession('n', { providerId: 'p1' });
+
+		assert.deepStrictEqual(tracker.incrementAndGetUserRequestCounters(a1), { userRequestsTotal: 1, userRequestsInWorkspace: 1, userRequestsForProvider: 1 });
+		assert.deepStrictEqual(tracker.incrementAndGetUserRequestCounters(a2), { userRequestsTotal: 2, userRequestsInWorkspace: 2, userRequestsForProvider: 2 });
+		assert.deepStrictEqual(tracker.incrementAndGetUserRequestCounters(b), { userRequestsTotal: 3, userRequestsInWorkspace: 1, userRequestsForProvider: 1 });
+		assert.deepStrictEqual(tracker.incrementAndGetUserRequestCounters(noWorkspace), { userRequestsTotal: 4, userRequestsInWorkspace: 0, userRequestsForProvider: 3 });
+	});
+
+	test('summary includes the request counters as observed at finalize time', () => {
+		const workspaceA = createWorkspace(URI.parse('file:///ws/a'), [createFolder(URI.parse('file:///ws/a'))]);
+		const workspaceB = createWorkspace(URI.parse('file:///ws/b'), [createFolder(URI.parse('file:///ws/b'))]);
+		const sessionToFinalize = createSession('a1', { providerId: 'p1', workspace: workspaceA });
+		const otherSameWorkspace = createSession('a2', { providerId: 'p1', workspace: workspaceA });
+		const otherDifferentEverything = createSession('b', { providerId: 'p2', workspace: workspaceB });
+
+		tracker.recordNewChatRequestSent(sessionToFinalize);
+		tracker.incrementAndGetUserRequestCounters(sessionToFinalize);
+		tracker.incrementAndGetUserRequestCounters(otherSameWorkspace);
+		tracker.incrementAndGetUserRequestCounters(otherDifferentEverything);
+
+		const summary = tracker.finalize(sessionToFinalize.sessionId, 'archived', sessionToFinalize);
+		assert.ok(summary);
+		assert.deepStrictEqual({
+			userRequestsTotal: summary!.userRequestsTotal,
+			userRequestsInWorkspace: summary!.userRequestsInWorkspace,
+			userRequestsForProvider: summary!.userRequestsForProvider,
+		}, {
+			userRequestsTotal: 3,
+			userRequestsInWorkspace: 2,
+			userRequestsForProvider: 2,
+		});
+	});
+
+	test('request counters persist across tracker instances', () => {
+		const workspace = createWorkspace(URI.parse('file:///ws/a'), [createFolder(URI.parse('file:///ws/a'))]);
+		const session = createSession('a1', { providerId: 'p1', workspace });
+		tracker.incrementAndGetUserRequestCounters(session);
+		tracker.incrementAndGetUserRequestCounters(session);
+
+		const secondTracker = disposables.add(new SessionsLifecycleTracker(storage));
+		assert.deepStrictEqual(secondTracker.incrementAndGetUserRequestCounters(session), { userRequestsTotal: 3, userRequestsInWorkspace: 3, userRequestsForProvider: 3 });
+	});
+
+	test('getUserRequestCounters returns current values without incrementing', () => {
+		const workspace = createWorkspace(URI.parse('file:///ws/a'), [createFolder(URI.parse('file:///ws/a'))]);
+		const session = createSession('a1', { providerId: 'p1', workspace });
+
+		assert.deepStrictEqual(tracker.getUserRequestCounters(session), { userRequestsTotal: 0, userRequestsInWorkspace: 0, userRequestsForProvider: 0 });
+
+		tracker.incrementAndGetUserRequestCounters(session);
+		tracker.incrementAndGetUserRequestCounters(session);
+
+		assert.deepStrictEqual(tracker.getUserRequestCounters(session), { userRequestsTotal: 2, userRequestsInWorkspace: 2, userRequestsForProvider: 2 });
+		// Repeated reads do not mutate state.
+		assert.deepStrictEqual(tracker.getUserRequestCounters(session), { userRequestsTotal: 2, userRequestsInWorkspace: 2, userRequestsForProvider: 2 });
+	});
+
+	test('summary reports zero request counters for an untouched provider/workspace', () => {
+		const session = createSession('s1');
+		tracker.bumpCounter(session, 'commit');
+
+		const summary = tracker.finalize(session.sessionId, 'archived', session);
+		assert.ok(summary);
+		assert.deepStrictEqual({
+			userRequestsTotal: summary!.userRequestsTotal,
+			userRequestsInWorkspace: summary!.userRequestsInWorkspace,
+			userRequestsForProvider: summary!.userRequestsForProvider,
+		}, {
+			userRequestsTotal: 0,
+			userRequestsInWorkspace: 0,
+			userRequestsForProvider: 0,
+		});
+	});
+
+	test('getTrackedIds returns ids of all tracked sessions', () => {
+		const a = createSession('a');
+		const b = createSession('b');
+
+		tracker.recordNewChatRequestSent(a);
+		tracker.bumpCounter(b, 'commit');
+
+		assert.deepStrictEqual(tracker.getTrackedIds().sort(), ['a', 'b']);
+	});
+
+	test('tracker treats corrupted storage as empty', () => {
+		storage.store(SESSIONS_KEY, '{not valid json', StorageScope.APPLICATION, StorageTarget.MACHINE);
+
+		const recoveredTracker = disposables.add(new SessionsLifecycleTracker(storage));
+
+		assert.deepStrictEqual(recoveredTracker.getTrackedIds(), []);
+	});
+
+	test('evicts the oldest entry when capacity is exceeded', () => {
+		// Pre-populate storage with MAX_TRACKED_SESSIONS entries; the oldest
+		// entry has the smallest firstObservedAt so it should be evicted when
+		// one more session is added.
+		const now = Date.now();
+		const stored: Record<string, unknown> = {};
+		for (let i = 0; i < MAX_TRACKED_SESSIONS; i++) {
+			stored[`existing-${i}`] = {
+				providerId: 'p',
+				providerType: 't',
+				sessionResourceUri: `session://existing-${i}`,
+				workspaceUriString: '',
+				isolationKind: 'folder',
+				hasGitRepository: false,
+				isVirtualWorkspace: false,
+				firstRequestSentInThisClient: false,
+				hasWorktreeCreatedTask: undefined,
+				configuredTasksCount: undefined,
+				firstObservedAt: now + i, // existing-0 is oldest
+				firstRequestSentAt: 0,
+				appLaunchCountAtFirstObserved: 1,
+				requestsSent: 0, chatCount: 0,
+				feedbackAdded: 0, feedbackConverted: 0, feedbackReplyAdded: 0, feedbackSubmitted: 0,
+				createPullRequest: 0, createDraftPullRequest: 0, updatePullRequest: 0, mergePullRequest: 0, checkoutPullRequest: 0,
+				initializeRepository: 0, commit: 0, commitAndSync: 0,
+				sessionRestored: 0, stickinessToggled: 0, maximizeToggled: 0,
+				chatDeleted: 0, chatRenamed: 0, fixCIChecks: 0, taskRun: 0,
+				filesChanged: 0, linesAdded: 0, linesDeleted: 0,
+			};
+		}
+		storage.store(SESSIONS_KEY, JSON.stringify(stored), StorageScope.APPLICATION, StorageTarget.MACHINE);
+
+		const capTracker = disposables.add(new SessionsLifecycleTracker(storage));
+		assert.strictEqual(capTracker.getTrackedIds().length, MAX_TRACKED_SESSIONS);
+
+		const newSession = createSession('brand-new');
+		capTracker.recordNewChatRequestSent(newSession);
+
+		const ids = capTracker.getTrackedIds();
+		assert.strictEqual(ids.length, MAX_TRACKED_SESSIONS);
+		assert.strictEqual(ids.includes('brand-new'), true);
+		assert.strictEqual(ids.includes('existing-0'), false, 'oldest entry should have been evicted');
+		assert.strictEqual(ids.includes('existing-1'), true, 'second-oldest entry should still be tracked');
+	});
+});

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -13,6 +13,7 @@ import { IContextKey, IContextKeyService } from '../../../../platform/contextkey
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { IAgentSessionsService } from '../../../../workbench/contrib/chat/browser/agentSessions/agentSessionsService.js';
+import { IChatService } from '../../../../workbench/contrib/chat/common/chatService/chatService.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
 import { ActiveSessionProviderIdContext, ActiveSessionTypeContext, IsActiveSessionArchivedContext, ActiveSessionWorkspaceIsVirtualContext, IsNewChatSessionContext } from '../../../common/contextkeys.js';
 import { ActiveSessionSupportsMultiChatContext, IActiveSession, ICreateNewSessionOptions, IProviderSessionType, ISendRequestSentEvent, ISessionsChangeEvent, ISessionsManagementService, IToggleSessionStickinessEvent } from '../common/sessionsManagement.js';
@@ -94,6 +95,15 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 	private readonly _sessionStates: ResourceMap<ISessionState>;
 	private readonly _navigation: SessionsNavigation;
 
+	/**
+	 * Chat resources for which this service has just kicked off a
+	 * `provider.sendRequest` and will emit `_onDidSendRequest` manually after
+	 * the provider call resolves. Used to suppress the duplicate event that
+	 * would otherwise arrive via {@link IChatService.onDidSubmitRequest},
+	 * which fires synchronously inside the same provider call.
+	 */
+	private readonly _pendingSendChatResources = new Set<string>();
+
 	constructor(
 		@IStorageService private readonly storageService: IStorageService,
 		@ILogService private readonly logService: ILogService,
@@ -102,6 +112,7 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
 		@IAgentSessionsService private readonly agentSessionsService: IAgentSessionsService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
+		@IChatService private readonly chatService: IChatService,
 	) {
 		super();
 
@@ -150,6 +161,32 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 			this._handleActiveSessionContextKeys(activeSession);
 			if (activeSession) {
 				reader.store.add(this._activeSessionListeners(activeSession));
+			}
+		}));
+
+		// Mirror follow-up chat requests (sent from within an existing chat
+		// widget, not through our own send paths) onto `_onDidSendRequest` so
+		// downstream listeners (e.g., telemetry) can observe every user
+		// request for a session, not just those initiated from the sessions
+		// UI. Sends originating from {@link sendRequest} and
+		// {@link sendNewChatRequest} are deduplicated via
+		// {@link _pendingSendChatResources}.
+		this._register(this.chatService.onDidSubmitRequest(({ chatSessionResource, message }) => {
+			if (this._pendingSendChatResources.has(chatSessionResource.toString())) {
+				return;
+			}
+			for (const session of this.getSessions()) {
+				const chat = session.chats.get().find(c => this.uriIdentityService.extUri.isEqual(c.resource, chatSessionResource));
+				if (chat) {
+					this._onDidSendRequest.fire({
+						session,
+						chat,
+						isNewSession: false,
+						isNewChat: false,
+						options: { query: message?.text ?? '' },
+					});
+					return;
+				}
 			}
 		}));
 	}
@@ -519,7 +556,14 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 			// be sent before the provider hands us the final session.
 			const tmpSession = this._visibility.updateResourceOfSession(session, chat.resource);
 
-			const updatedSession = await provider.sendRequest(session.sessionId, chat.resource, options);
+			const chatResourceKey = chat.resource.toString();
+			this._pendingSendChatResources.add(chatResourceKey);
+			let updatedSession: ISession;
+			try {
+				updatedSession = await provider.sendRequest(session.sessionId, chat.resource, options);
+			} finally {
+				this._pendingSendChatResources.delete(chatResourceKey);
+			}
 			if (updatedSession.sessionId !== session.sessionId) {
 				this.logService.info(`[SessionsManagement] sendRequest: active session replaced: ${session.sessionId} -> ${updatedSession.sessionId}`);
 				this._visibility.updateSession(tmpSession, updatedSession);
@@ -527,7 +571,7 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 			}
 			this._onDidStartSession.fire(updatedSession);
 
-			this._onDidSendRequest.fire({ session: updatedSession, chat: session.mainChat.get(), isNewSession: true, options });
+			this._onDidSendRequest.fire({ session: updatedSession, chat: session.mainChat.get(), isNewSession: true, isNewChat: true, options });
 		} finally {
 			chatsListener.dispose();
 		}
@@ -549,13 +593,20 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 			throw new Error(`Sessions provider '${session.providerId}' not found`);
 		}
 
-		const updatedSession = await provider.sendRequest(session.sessionId, chat.resource, options);
+		const chatResourceKey = chat.resource.toString();
+		this._pendingSendChatResources.add(chatResourceKey);
+		let updatedSession: ISession;
+		try {
+			updatedSession = await provider.sendRequest(session.sessionId, chat.resource, options);
+		} finally {
+			this._pendingSendChatResources.delete(chatResourceKey);
+		}
 		if (updatedSession.sessionId !== session.sessionId) {
 			this.logService.info(`[SessionsManagement] sendRequest: active session replaced: ${session.sessionId} -> ${updatedSession.sessionId}`);
 			this._visibility.updateSession(session, updatedSession);
 		}
 
-		this._onDidSendRequest.fire({ session: updatedSession, chat, isNewSession: false, options });
+		this._onDidSendRequest.fire({ session: updatedSession, chat, isNewSession: false, isNewChat: true, options });
 	}
 
 	openNewSessionView(): void {

--- a/src/vs/sessions/services/sessions/common/sessionsManagement.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsManagement.ts
@@ -59,6 +59,7 @@ export interface ISendRequestSentEvent {
 	readonly session: ISession;
 	readonly chat: IChat;
 	readonly isNewSession: boolean;
+	readonly isNewChat: boolean;
 	readonly options: ISendRequestOptions;
 }
 

--- a/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
@@ -21,6 +21,7 @@ import { IUriIdentityService } from '../../../../../platform/uriIdentity/common/
 import { ChatViewPaneTarget, IChatWidget, IChatWidgetService } from '../../../../../workbench/contrib/chat/browser/chat.js';
 import { IAgentSession, IAgentSessionsModel } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentSessionsModel.js';
 import { IAgentSessionsService } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentSessionsService.js';
+import { IChatService } from '../../../../../workbench/contrib/chat/common/chatService/chatService.js';
 import { IChatEditorOptions } from '../../../../../workbench/contrib/chat/browser/widgetHosts/editor/chatEditor.js';
 import { PreferredGroup } from '../../../../../workbench/services/editor/common/editorService.js';
 import { IChat, ISession, ISessionType, ISessionWorkspace } from '../../common/session.js';
@@ -187,6 +188,9 @@ function createSessionsManagementService(session: ISession, disposables: ReturnT
 	instantiationService.stub(IChatWidgetService, chatWidgetService);
 	instantiationService.stub(IAgentSessionsService, agentSessionsService);
 	instantiationService.stub(IProgressService, new TestProgressService());
+	instantiationService.stub(IChatService, new class extends mock<IChatService>() {
+		override readonly onDidSubmitRequest = Event.None;
+	});
 
 	const service = disposables.add(instantiationService.createInstance(SessionsManagementService));
 	return { service, chatWidgetService, agentSessionsService };
@@ -232,6 +236,9 @@ suite('SessionsManagementService', () => {
 		instantiationService.stub(IChatWidgetService, chatWidgetService);
 		instantiationService.stub(IAgentSessionsService, agentSessionsService);
 		instantiationService.stub(IProgressService, new TestProgressService());
+		instantiationService.stub(IChatService, new class extends mock<IChatService>() {
+			override readonly onDidSubmitRequest = Event.None;
+		});
 
 		const service = disposables.add(instantiationService.createInstance(SessionsManagementService));
 
@@ -282,6 +289,9 @@ suite('SessionsManagementService', () => {
 		instantiationService.stub(IChatWidgetService, chatWidgetService);
 		instantiationService.stub(IAgentSessionsService, agentSessionsService);
 		instantiationService.stub(IProgressService, new TestProgressService());
+		instantiationService.stub(IChatService, new class extends mock<IChatService>() {
+			override readonly onDidSubmitRequest = Event.None;
+		});
 
 		const service = disposables.add(instantiationService.createInstance(SessionsManagementService));
 


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce a new event for session tasks that fires after a task has been successfully dispatched to its runner. Add a flag to indicate whether a chat session is new and update the event emissions accordingly.

