### PR TITLE
cli: drop ahp-ws dependency in favor of direct tungstenite

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -19,9 +19,9 @@ dependencies = [
 
 [[package]]
 name = "ahp"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c974ae2da70e455e9e72de59ccc5279afc660ce267ab994474734d3310401f0"
+checksum = "95f2c1c1d2a8428afa4b009abad4801f3b4d559950fc3041b764dc345ec0a855"
 dependencies = [
  "ahp-types",
  "serde",
@@ -33,28 +33,13 @@ dependencies = [
 
 [[package]]
 name = "ahp-types"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299233ec34afadd8dd8c24fc63c50e24eb376c9588dd5b48804e33f60b1ecaf5"
+checksum = "f33e8d9b2ed87ce94cb6339928b126f6942ebb168e532d47b81ad04dab8e71f3"
 dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
-]
-
-[[package]]
-name = "ahp-ws"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516267592f4f77df2cecb21b4945ae6eb5a7cf2b2d07062e6423fa2e56a1caa6"
-dependencies = [
- "ahp",
- "futures-util",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
- "tokio-tungstenite",
- "url",
 ]
 
 [[package]]
@@ -427,7 +412,6 @@ version = "0.1.0"
 dependencies = [
  "ahp",
  "ahp-types",
- "ahp-ws",
  "base64",
  "bytes",
  "cfg-if",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -56,9 +56,8 @@ console = "0.15.7"
 bytes = "1.11.1"
 tar = "0.4.46"
 local-ip-address = "0.6"
-ahp = "0.1"
-ahp-types = "0.1"
-ahp-ws = "0.1"
+ahp = "0.2"
+ahp-types = "0.2"
 
 [build-dependencies]
 serde = { version="1.0.163", features = ["derive"] }

--- a/cli/src/commands/agent.rs
+++ b/cli/src/commands/agent.rs
@@ -9,9 +9,11 @@ use ahp::{Client, Transport, TransportError, TransportMessage};
 use ahp_types::commands::{AuthenticateParams, AuthenticateResult};
 use ahp_types::errors::ahp_error_codes;
 use ahp_types::state::ProtectedResourceMetadata;
-use ahp_types::PROTOCOL_VERSION;
+use ahp_types::{ROOT_RESOURCE_URI, PROTOCOL_VERSION};
 use futures::{SinkExt, StreamExt};
+use tokio::net::TcpStream;
 use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
 
 use crate::auth::{Auth, AuthProvider};
 use crate::constants::AGENT_HOST_PORT;
@@ -46,7 +48,7 @@ pub async fn connect(
 	};
 
 	client
-		.initialize("code-cli".into(), PROTOCOL_VERSION as i64, vec![])
+		.initialize("code-cli".into(), vec![PROTOCOL_VERSION.to_string()], vec![])
 		.await
 		.map_err(|e| wrap(e, "AHP initialize failed"))?;
 
@@ -55,13 +57,62 @@ pub async fn connect(
 
 /// Opens a WebSocket connection and creates an AHP client.
 async fn connect_ws(address: &str) -> Result<Client, AnyError> {
-	let transport = ahp_ws::WebSocketTransport::connect(address)
+	let (ws_stream, _) = connect_async(address)
 		.await
 		.map_err(|e| wrap(e, format!("Failed to connect to agent host at {address}")))?;
+
+	let transport = WsTransport { inner: ws_stream };
 
 	Client::connect(transport, ahp::ClientConfig::default())
 		.await
 		.map_err(|e| wrap(e, "Failed to establish AHP session").into())
+}
+
+/// A [`Transport`] backed by a `tokio-tungstenite` WebSocket stream.
+struct WsTransport {
+	inner: WebSocketStream<MaybeTlsStream<TcpStream>>,
+}
+
+impl Transport for WsTransport {
+	async fn send(&mut self, msg: TransportMessage) -> Result<(), TransportError> {
+		let frame = match msg {
+			TransportMessage::Parsed(m) => {
+				let s = serde_json::to_string(&m)
+					.map_err(|e| TransportError::Protocol(e.to_string()))?;
+				Message::Text(s.into())
+			}
+			TransportMessage::Text(s) => Message::Text(s.into()),
+			TransportMessage::Binary(b) => Message::Binary(b.into()),
+		};
+		self.inner
+			.send(frame)
+			.await
+			.map_err(|e| TransportError::Io(e.to_string()))
+	}
+
+	async fn recv(&mut self) -> Result<Option<TransportMessage>, TransportError> {
+		loop {
+			match self.inner.next().await {
+				None => return Ok(None),
+				Some(Err(e)) => return Err(TransportError::Io(e.to_string())),
+				Some(Ok(Message::Text(s))) => {
+					return Ok(Some(TransportMessage::Text(s.to_string())))
+				}
+				Some(Ok(Message::Binary(b))) => {
+					return Ok(Some(TransportMessage::Binary(b.to_vec())))
+				}
+				Some(Ok(Message::Close(_))) => return Ok(None),
+				Some(Ok(_)) => continue,
+			}
+		}
+	}
+
+	async fn close(&mut self) -> Result<(), TransportError> {
+		self.inner
+			.close(None)
+			.await
+			.map_err(|e| TransportError::Io(e.to_string()))
+	}
 }
 
 /// Connects to an agent host over a dev tunnel relay. Looks up the tunnel
@@ -236,6 +287,7 @@ async fn authenticate_from_error(
 			.request(
 				"authenticate",
 				AuthenticateParams {
+					channel: ROOT_RESOURCE_URI.to_string(),
 					resource: resource.resource.clone(),
 					token: credential.access_token().to_string(),
 				},

--- a/cli/src/commands/agent.rs
+++ b/cli/src/commands/agent.rs
@@ -11,9 +11,9 @@ use ahp_types::errors::ahp_error_codes;
 use ahp_types::state::ProtectedResourceMetadata;
 use ahp_types::{ROOT_RESOURCE_URI, PROTOCOL_VERSION};
 use futures::{SinkExt, StreamExt};
-use tokio::net::TcpStream;
+use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_tungstenite::tungstenite::Message;
-use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
+use tokio_tungstenite::{connect_async, WebSocketStream};
 
 use crate::auth::{Auth, AuthProvider};
 use crate::constants::AGENT_HOST_PORT;
@@ -61,7 +61,7 @@ async fn connect_ws(address: &str) -> Result<Client, AnyError> {
 		.await
 		.map_err(|e| wrap(e, format!("Failed to connect to agent host at {address}")))?;
 
-	let transport = WsTransport { inner: ws_stream };
+	let transport = WsTransport::new(ws_stream, ());
 
 	Client::connect(transport, ahp::ClientConfig::default())
 		.await
@@ -69,11 +69,27 @@ async fn connect_ws(address: &str) -> Result<Client, AnyError> {
 }
 
 /// A [`Transport`] backed by a `tokio-tungstenite` WebSocket stream.
-struct WsTransport {
-	inner: WebSocketStream<MaybeTlsStream<TcpStream>>,
+///
+/// `_guard` keeps an auxiliary resource alive for the lifetime of the
+/// transport; the tunnel connection uses it to retain the relay handle so
+/// the underlying SSH session isn't dropped. Use `()` when no such
+/// resource is needed.
+struct WsTransport<S, G = ()> {
+	inner: WebSocketStream<S>,
+	_guard: G,
 }
 
-impl Transport for WsTransport {
+impl<S, G> WsTransport<S, G> {
+	fn new(inner: WebSocketStream<S>, guard: G) -> Self {
+		Self { inner, _guard: guard }
+	}
+}
+
+impl<S, G> Transport for WsTransport<S, G>
+where
+	S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+	G: Send + 'static,
+{
 	async fn send(&mut self, msg: TransportMessage) -> Result<(), TransportError> {
 		let frame = match msg {
 			TransportMessage::Parsed(m) => {
@@ -122,73 +138,19 @@ async fn connect_via_tunnel(ctx: &CommandContext, name: &str) -> Result<Client, 
 	let auth = Auth::new(&ctx.paths, ctx.log.clone());
 	let mut dt = DevTunnels::new_remote_tunnel(&ctx.log, auth, &ctx.paths);
 
-	let (port_conn, _relay_handle) = dt.connect_to_tunnel_port(name, AGENT_HOST_PORT).await?;
+	let (port_conn, relay_handle) = dt.connect_to_tunnel_port(name, AGENT_HOST_PORT).await?;
 
 	let rw = port_conn.into_rw();
 	let (ws_stream, _) = tokio_tungstenite::client_async("ws://localhost/", rw)
 		.await
 		.map_err(|e| wrap(e, "WebSocket handshake over tunnel failed"))?;
 
-	let transport = TunnelWsTransport {
-		inner: ws_stream,
-		// Keep the relay handle alive so the SSH session isn't dropped.
-		_relay_handle,
-	};
+	// Keep the relay handle alive so the SSH session isn't dropped.
+	let transport = WsTransport::new(ws_stream, relay_handle);
 
 	Client::connect(transport, ahp::ClientConfig::default())
 		.await
 		.map_err(|e| wrap(e, "Failed to establish AHP session over tunnel").into())
-}
-
-/// A [`Transport`] backed by a WebSocket stream running over a tunnel
-/// relay channel (via `PortConnectionRW`).
-struct TunnelWsTransport {
-	inner: tokio_tungstenite::WebSocketStream<tunnels::connections::PortConnectionRW>,
-	/// Prevent the relay handle from being dropped, which would close the
-	/// underlying SSH session.
-	_relay_handle: tunnels::connections::ClientRelayHandle,
-}
-
-impl Transport for TunnelWsTransport {
-	async fn send(&mut self, msg: TransportMessage) -> Result<(), TransportError> {
-		let frame = match msg {
-			TransportMessage::Parsed(m) => {
-				let s = serde_json::to_string(&m)
-					.map_err(|e| TransportError::Protocol(e.to_string()))?;
-				Message::Text(s.into())
-			}
-			TransportMessage::Text(s) => Message::Text(s.into()),
-			TransportMessage::Binary(b) => Message::Binary(b.into()),
-		};
-		self.inner
-			.send(frame)
-			.await
-			.map_err(|e| TransportError::Io(e.to_string()))
-	}
-
-	async fn recv(&mut self) -> Result<Option<TransportMessage>, TransportError> {
-		loop {
-			match self.inner.next().await {
-				None => return Ok(None),
-				Some(Err(e)) => return Err(TransportError::Io(e.to_string())),
-				Some(Ok(Message::Text(s))) => {
-					return Ok(Some(TransportMessage::Text(s.to_string())))
-				}
-				Some(Ok(Message::Binary(b))) => {
-					return Ok(Some(TransportMessage::Binary(b.to_vec())))
-				}
-				Some(Ok(Message::Close(_))) => return Ok(None),
-				Some(Ok(_)) => continue,
-			}
-		}
-	}
-
-	async fn close(&mut self) -> Result<(), TransportError> {
-		self.inner
-			.close(None)
-			.await
-			.map_err(|e| TransportError::Io(e.to_string()))
-	}
 }
 
 /// Issues a JSON-RPC request, automatically handling `-32007` auth errors

--- a/cli/src/commands/agent_logs.rs
+++ b/cli/src/commands/agent_logs.rs
@@ -27,7 +27,7 @@ pub async fn agent_logs(ctx: CommandContext, args: AgentLogsArgs) -> Result<i32,
 			&client,
 			"subscribe",
 			SubscribeParams {
-				resource: args.session.clone(),
+				channel: args.session.clone(),
 			},
 		)
 		.await?;
@@ -54,9 +54,9 @@ pub async fn agent_logs(ctx: CommandContext, args: AgentLogsArgs) -> Result<i32,
 				Some(SubscriptionEvent::Action(envelope)) => {
 					print_action(envelope.server_seq, &envelope.action);
 				}
-				Some(SubscriptionEvent::Notification(notif)) => {
+				Some(other) => {
 					let notif_style = Style::new().magenta();
-					println!("{}", notif_style.apply_to(format!("notification: {notif:?}")));
+					println!("{}", notif_style.apply_to(format!("notification: {other:?}")));
 				}
 				None => {
 					println!("{}", Styles::muted().apply_to("Subscription closed."));
@@ -85,7 +85,11 @@ fn print_initial_state(uri: &str, result: &SubscribeResult) {
 		uri_style.apply_to(uri)
 	);
 
-	if let SnapshotState::Session(ref session) = result.snapshot.state {
+	let Some(ref snapshot) = result.snapshot else {
+		return;
+	};
+
+	if let SnapshotState::Session(ref session) = snapshot.state {
 		let s = &session.summary;
 		if !s.title.is_empty() {
 			println!("  {} {}", label.apply_to("title:"), s.title);
@@ -116,7 +120,7 @@ fn print_initial_state(uri: &str, result: &SubscribeResult) {
 		}
 	}
 
-	println!("  {} {}", label.apply_to("seq:"), result.snapshot.from_seq);
+	println!("  {} {}", label.apply_to("seq:"), snapshot.from_seq);
 }
 
 fn print_action(seq: u64, action: &StateAction) {

--- a/cli/src/commands/agent_ps.rs
+++ b/cli/src/commands/agent_ps.rs
@@ -5,6 +5,7 @@
 
 use ahp_types::commands::{ListSessionsParams, ListSessionsResult};
 use ahp_types::state::{SessionStatus, SessionSummary};
+use ahp_types::ROOT_RESOURCE_URI;
 
 use crate::util::errors::AnyError;
 
@@ -17,9 +18,16 @@ use super::CommandContext;
 pub async fn agent_ps(ctx: CommandContext, args: AgentPsArgs) -> Result<i32, AnyError> {
 	let client = agent::connect(&ctx, args.address.as_deref(), args.tunnel.as_deref()).await?;
 
-	let result: ListSessionsResult =
-		agent::request_with_auth(&ctx, &client, "listSessions", ListSessionsParams::default())
-			.await?;
+	let result: ListSessionsResult = agent::request_with_auth(
+		&ctx,
+		&client,
+		"listSessions",
+		ListSessionsParams {
+			channel: ROOT_RESOURCE_URI.to_string(),
+			filter: None,
+		},
+	)
+	.await?;
 
 	client.shutdown().await;
 

--- a/cli/src/commands/agent_stop.rs
+++ b/cli/src/commands/agent_stop.rs
@@ -24,13 +24,13 @@ pub async fn agent_stop(ctx: CommandContext, args: AgentStopArgs) -> Result<i32,
 		&client,
 		"subscribe",
 		SubscribeParams {
-			resource: args.session.clone(),
+			channel: args.session.clone(),
 		},
 	)
 	.await?;
 
-	let turn_id = match result.snapshot.state {
-		SnapshotState::Session(session) => session.active_turn.map(|t| t.id),
+	let turn_id = match result.snapshot.map(|s| s.state) {
+		Some(SnapshotState::Session(session)) => session.active_turn.map(|t| t.id),
 		_ => None,
 	};
 
@@ -46,12 +46,12 @@ pub async fn agent_stop(ctx: CommandContext, args: AgentStopArgs) -> Result<i32,
 	debug!(ctx.log, "Cancelling turn {} on {}", turn_id, args.session);
 
 	client
-		.dispatch(StateAction::SessionTurnCancelled(
-			SessionTurnCancelledAction {
-				session: args.session.clone(),
+		.dispatch(
+			args.session.clone(),
+			StateAction::SessionTurnCancelled(SessionTurnCancelledAction {
 				turn_id: turn_id.clone(),
-			},
-		))
+			}),
+		)
 		.await
 		.map_err(|e| wrap(e, "Failed to dispatch turn cancellation"))?;
 


### PR DESCRIPTION
- Removes the external ahp-ws crate so the CLI owns its WebSocket transport directly, avoiding a thin wrapper dependency and keeping the transport logic alongside the existing tunnel transport.
- Updates the agent commands to the ahp 0.2 API (channel-based params, optional snapshots, and the two-argument dispatch signature) so the CLI compiles against the pinned crate versions again.

(Commit message generated by Copilot)