### PR TITLE
agentHost: avoid rewriting attachment URIs that exist on the agent host

### DIFF
--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -1193,6 +1193,11 @@ export class AgentService extends Disposable implements IAgentService {
 				return this._writeAndRewrite(attachment, bytes, basename, attachmentsRoot);
 			}
 			if (attachment.type === MessageAttachmentKind.Resource && this._isRewritableAttachment(attachment, attachmentsRootStr)) {
+				// If the attachment references a URI that is possibly on the agent host side, don't rewrite (#319314)
+				if (await this._fileService.exists(URI.parse(attachment.uri))) {
+					return attachment;
+				}
+
 				const originalUri = URI.parse(attachment.uri);
 				const bytes = await this._readClientResource(originalUri, clientId);
 				const basename = this._attachmentBasename(attachment.label, getMediaMime(originalUri.path));

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -10,6 +10,7 @@ import { Emitter } from '../../../base/common/event.js';
 import { Disposable, DisposableMap, DisposableResourceMap, DisposableStore, IDisposable, MutableDisposable } from '../../../base/common/lifecycle.js';
 import { ResourceMap } from '../../../base/common/map.js';
 import { getExtensionForMimeType, getMediaMime } from '../../../base/common/mime.js';
+import { Schemas } from '../../../base/common/network.js';
 import { equals as objectEquals } from '../../../base/common/objects.js';
 import { observableValue } from '../../../base/common/observable.js';
 import { extname as resourcesExtname, isEqual, isEqualOrParent, joinPath } from '../../../base/common/resources.js';
@@ -1193,12 +1194,13 @@ export class AgentService extends Disposable implements IAgentService {
 				return this._writeAndRewrite(attachment, bytes, basename, attachmentsRoot);
 			}
 			if (attachment.type === MessageAttachmentKind.Resource && this._isRewritableAttachment(attachment, attachmentsRootStr)) {
-				// If the attachment references a URI that is possibly on the agent host side, don't rewrite (#319314)
-				if (await this._fileService.exists(URI.parse(attachment.uri))) {
+				const originalUri = URI.parse(attachment.uri);
+				// If the attachment references a file that already exists on the agent
+				// host side, leave it untouched rather than snapshotting a client copy (#319314).
+				if (originalUri.scheme === Schemas.file && await this._fileExistsSafe(originalUri)) {
 					return attachment;
 				}
 
-				const originalUri = URI.parse(attachment.uri);
 				const bytes = await this._readClientResource(originalUri, clientId);
 				const basename = this._attachmentBasename(attachment.label, getMediaMime(originalUri.path));
 				return this._writeAndRewrite(attachment, bytes, basename, attachmentsRoot);
@@ -1207,6 +1209,18 @@ export class AgentService extends Disposable implements IAgentService {
 			this._logService.warn(`[AgentService] Failed to rewrite attachment '${attachment.label}': ${toErrorMessage(err)}`);
 		}
 		return attachment;
+	}
+
+	/**
+	 * Like {@link IFileService.exists} but never throws (e.g. when no provider
+	 * is registered for the URI scheme), returning `false` in that case.
+	 */
+	private async _fileExistsSafe(uri: URI): Promise<boolean> {
+		try {
+			return await this._fileService.exists(uri);
+		} catch {
+			return false;
+		}
 	}
 
 	/**

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -304,6 +304,29 @@ suite('AgentService (node dispatcher)', () => {
 			assert.strictEqual(snapshot.value.toString(), 'hello world');
 		});
 
+		test('passes through existing file:// Resource attachments unchanged (#319314)', async () => {
+			const { svc, agent, session } = await setup();
+			// Register a file-scheme provider so the attachment URI resolves to
+			// an existing file on the agent host side.
+			disposables.add(fileService.registerProvider(Schemas.file, disposables.add(new InMemoryFileSystemProvider())));
+			const fileUri = URI.from({ scheme: Schemas.file, path: '/host/source.txt' });
+			await fileService.writeFile(fileUri, VSBuffer.fromString('on host'));
+
+			await dispatchTurnAndWait(svc, agent, session, [{
+				type: MessageAttachmentKind.Resource,
+				uri: fileUri.toString(),
+				label: 'source.txt',
+				displayKind: 'document',
+			}]);
+
+			assert.deepStrictEqual(agent.sendMessageCalls[0].attachments, [{
+				type: MessageAttachmentKind.Resource,
+				uri: fileUri.toString(),
+				label: 'source.txt',
+				displayKind: 'document',
+			}]);
+		});
+
 		test('preserves selection range on Resource rewrite', async () => {
 			const { svc, agent, session, attachmentsRoot } = await setup();
 			const sourceUri = URI.from({ scheme: Schemas.inMemory, path: '/workspace/sel.txt' });


### PR DESCRIPTION
- Attachment URIs that point to files existing on the agent host side were being incorrectly rewritten, breaking references to those files. We now check whether the referenced file exists before rewriting so agent-host-local attachments are preserved as-is.

Fixes #319314

(Commit message generated by Copilot)