### PR TITLE
vscode-api-tests: use explicit `types` instead of `typeRoots`

### DIFF
--- a/extensions/vscode-api-tests/tsconfig.json
+++ b/extensions/vscode-api-tests/tsconfig.json
@@ -3,8 +3,9 @@
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./out",
-		"typeRoots": [
-			"./node_modules/@types"
+		"types": [
+			"node",
+			"mocha"
 		],
 		"skipLibCheck": true
 	},


### PR DESCRIPTION
Refs [microsoft/vscode-engineering#2912](https://github.com/microsoft/vscode-engineering/issues/2912).

## What

Swap `typeRoots: ["./node_modules/@types"]` for `types: ["node", "mocha"]` in `extensions/vscode-api-tests/tsconfig.json`.

```diff
-    "typeRoots": [
-        "./node_modules/@types"
+    "types": [
+        "node",
+        "mocha"
     ],
```

## Why

After [#319389](https://github.com/microsoft/vscode/pull/319389) bumped the build TS versions / lockfile, one build agent hit:

```
extensions/vscode-api-tests/src/workspace-tests/index.ts(21,12): error TS2591:
  Cannot find name `process`. Do you need to install type definitions for node?
extensions/vscode-api-tests/src/workspace-tests/workspace.test.ts(6,25): error TS2591:
  Cannot find name `assert`. Do you need to install type definitions for node?
```

`TS2591` means `tsgo` could not find `@types/node` ambient types. The current config relies on `typeRoots` auto-discovery, which only scans the literal path `extensions/vscode-api-tests/node_modules/@types`. When npm hoists `@types/node` to the workspace root (which can flip when the lockfile changes), that folder is empty and TS resolves nothing.

Switching to an explicit `types` list resolves each package via normal Node module resolution, which walks up the directory tree the same way `require()` does — so it works whether `@types/node` ends up hoisted or extension-local.

This was a one-time flake on build [#20260601.36](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=443890); subsequent builds were green without any code change, so this is hardening rather than a regression fix.

## Convention

Already the pattern used by `extensions/github`, `extensions/copilot`, `extensions/ipynb`, `extensions/configuration-editing`, `extensions/git-base`, and ~half a dozen others. The remaining `typeRoots`-only extensions are candidates for the same treatment in a follow-up.

## Risk

Minimal. `@types/node` and `@types/mocha` are already declared `devDependencies` in [extensions/vscode-api-tests/package.json](https://github.com/microsoft/vscode/blob/main/extensions/vscode-api-tests/package.json), so the explicit list matches what was being implicitly picked up before. Draft PR — would appreciate a green CI run on this branch as the validation step.
