### PR TITLE
Suppress GitHubLoginFailed from unhandled-error telemetry

### DIFF
--- a/extensions/copilot/src/platform/authentication/vscode-node/copilotTokenManager.ts
+++ b/extensions/copilot/src/platform/authentication/vscode-node/copilotTokenManager.ts
@@ -14,6 +14,7 @@ import { ILogService } from '../../log/common/logService';
 import { IFetcherService } from '../../networking/common/fetcherService';
 import { ITelemetryService } from '../../telemetry/common/telemetry';
 import { CopilotToken, ExtendedTokenInfo, TokenErrorNotificationId, TokenInfoOrError } from '../common/copilotToken';
+import { ErrorNoTelemetry } from '../../../util/vs/base/common/errors';
 import { nowSeconds } from '../common/copilotTokenManager';
 import { BaseCopilotTokenManager } from '../node/copilotTokenManager';
 import { getAnyAuthSession } from './session';
@@ -27,7 +28,11 @@ export class ContactSupportError extends Error { }
 export class EnterpriseManagedError extends Error { }
 export class InvalidTokenError extends Error { }
 export class RateLimitedError extends Error { }
-export class GitHubLoginFailedError extends Error { }
+// Not signing in to GitHub is an expected condition (e.g. BYOK / air-gapped / anonymous
+// flows). Extend ErrorNoTelemetry so it does not pollute the unhandled-error telemetry
+// dashboard when it escapes as an unhandled rejection. The intentional
+// `auth.github_login_failed` GitHub telemetry event is still sent at the failure site.
+export class GitHubLoginFailedError extends ErrorNoTelemetry { }
 
 export class VSCodeCopilotTokenManager extends BaseCopilotTokenManager {
 	private _taskSingler = new TaskSingler<TokenInfoOrError>();

--- a/extensions/copilot/src/platform/authentication/vscode-node/copilotTokenManager.ts
+++ b/extensions/copilot/src/platform/authentication/vscode-node/copilotTokenManager.ts
@@ -28,10 +28,6 @@ export class ContactSupportError extends Error { }
 export class EnterpriseManagedError extends Error { }
 export class InvalidTokenError extends Error { }
 export class RateLimitedError extends Error { }
-// Not signing in to GitHub is an expected condition (e.g. BYOK / air-gapped / anonymous
-// flows). Extend ErrorNoTelemetry so it does not pollute the unhandled-error telemetry
-// dashboard when it escapes as an unhandled rejection. The intentional
-// `auth.github_login_failed` GitHub telemetry event is still sent at the failure site.
 export class GitHubLoginFailedError extends ErrorNoTelemetry { }
 
 export class VSCodeCopilotTokenManager extends BaseCopilotTokenManager {


### PR DESCRIPTION
Fixes #284532

## What

GitHubLoginFailedError (message GitHubLoginFailed) is thrown by getCopilotToken() whenever the user is **not signed in to GitHub** — BYOK, air-gapped, anonymous, or not-yet-signed-in flows. The code already documents this as an expected condition (see `contextKeys.contribution.ts` "Expected in BYOK / air-gapped flows..." and `completionsCoreContribution.ts` "would just fail with GitHubLoginFailedError on every keystroke").

When this error escapes as an unhandled rejection, the extension-host error handler attributes it to `GitHub.copilot-chat` and reports it through the core unhandled-error pipeline, flooding the Errors dashboard (1187.6M hits / 1.5M users, with an empty stack trace — i.e. non-actionable).

## Change

Make GitHubLoginFailedError extend ErrorNoTelemetry so the core unhandled-error pipeline filters it out (`errorTelemetry.ts`), matching how CancellationError / FileOperationError / PendingMigrationError are already handled. The flag round-trips across the ext-host RPC boundary via 	ransformErrorForSerialization (name-based CodeExpectedError check).

## Notes

- The intentional uth.github_login_failed GitHub telemetry event is **still** sent at the failure site — only the noisy core UnhandledError reporting is suppressed.
- The only consumer of this error uses instanceof, which is unaffected by the new base class.
- No core change is required: copilot-chat's own telemetry loggers already set ignoreUnhandledErrors: true, so the telemetry was coming solely from the core path that honors ErrorNoTelemetry.
