### PR TITLE
Browser: Match ExP value for setting `workbench.browser.enableChatTools`

### DIFF
--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -556,7 +556,7 @@
                 }
             },
             "type": "boolean",
-            "default": false,
+            "default": true,
             "included": true
         },
         {

--- a/src/vs/workbench/contrib/browserView/electron-browser/features/browserEditorChatFeatures.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/features/browserEditorChatFeatures.ts
@@ -740,7 +740,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 	properties: {
 		'workbench.browser.enableChatTools': {
 			type: 'boolean',
-			default: false,
+			default: true,
 			experiment: { mode: 'startup' },
 			tags: ['experimental'],
 			markdownDescription: localize(

--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/openBrowserToolNonAgentic.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/openBrowserToolNonAgentic.ts
@@ -74,7 +74,7 @@ export class OpenBrowserToolNonAgentic implements IToolImpl {
 		return {
 			content: [{
 				kind: 'text',
-				value: `Page opened successfully. Note that you do not have access to the page contents while the \`workbench.browser.enableChatTools\` setting is disabled.`,
+				value: `Page opened successfully. Note that you do not have access to the page contents unless the user enables agentic tools via the \`workbench.browser.enableChatTools\` setting.`,
 			}],
 			toolResultMessage: new MarkdownString(localize('browser.open.nonAgentic.result', "Opened {0}", createBrowserPageLink(browserUri)))
 		};

--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/openBrowserToolNonAgentic.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/openBrowserToolNonAgentic.ts
@@ -74,7 +74,7 @@ export class OpenBrowserToolNonAgentic implements IToolImpl {
 		return {
 			content: [{
 				kind: 'text',
-				value: `Page opened successfully. Note that you do not have access to the page contents unless the user enables agentic tools via the \`workbench.browser.enableChatTools\` setting.`,
+				value: `Page opened successfully. Note that you do not have access to the page contents while the \`workbench.browser.enableChatTools\` setting is disabled.`,
 			}],
 			toolResultMessage: new MarkdownString(localize('browser.open.nonAgentic.result', "Opened {0}", createBrowserPageLink(browserUri)))
 		};

--- a/src/vs/workbench/contrib/chat/browser/chatTipCatalog.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatTipCatalog.ts
@@ -343,7 +343,7 @@ export const TIP_CATALOG: readonly ITipDefinition[] = [
 		},
 		when: ContextKeyExpr.and(
 			ChatContextKeys.chatModeKind.isEqualTo(ChatModeKind.Agent),
-			ContextKeyExpr.notEquals('config.workbench.browser.enableChatTools', true),
+			ContextKeyExpr.equals('config.workbench.browser.enableChatTools', false),
 		),
 		excludeWhenSettingsChanged: ['workbench.browser.enableChatTools'],
 		dismissWhenCommandsClicked: ['workbench.action.openSettings'],

--- a/src/vs/workbench/contrib/chat/browser/chatTipCatalog.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatTipCatalog.ts
@@ -330,25 +330,6 @@ export const TIP_CATALOG: readonly ITipDefinition[] = [
 		],
 	},
 	{
-		id: 'tip.agenticBrowser',
-		tier: ChatTipTier.Qol,
-		buildMessage() {
-			return new MarkdownString(
-				localize(
-					'tip.agenticBrowser',
-					"Enable [{0}](command:workbench.action.openSettings?%5B%22workbench.browser.enableChatTools%22%5D \"Open Settings\") to let the agent open and interact with pages in the Integrated Browser.",
-					'agentic browser integration'
-				)
-			);
-		},
-		when: ContextKeyExpr.and(
-			ChatContextKeys.chatModeKind.isEqualTo(ChatModeKind.Agent),
-			ContextKeyExpr.equals('config.workbench.browser.enableChatTools', false),
-		),
-		excludeWhenSettingsChanged: ['workbench.browser.enableChatTools'],
-		dismissWhenCommandsClicked: ['workbench.action.openSettings'],
-	},
-	{
 		id: 'tip.mermaid',
 		tier: ChatTipTier.Qol,
 		buildMessage() {

--- a/src/vs/workbench/contrib/chat/test/browser/chatTipService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatTipService.test.ts
@@ -1445,7 +1445,6 @@ suite('ChatTipService', () => {
 
 	for (const { tipId, settingKey } of [
 		{ tipId: 'tip.thinkingPhrases', settingKey: 'chat.agent.thinking.phrases' },
-		{ tipId: 'tip.agenticBrowser', settingKey: 'workbench.browser.enableChatTools' },
 	]) {
 		test(`shows ${tipId} with correct setting link when setting is at default`, async () => {
 			const service = createService();
@@ -1468,9 +1467,16 @@ suite('ChatTipService', () => {
 		});
 	}
 
+	test('does not show tip.agenticBrowser when setting is at default', async () => {
+		const service = createService();
+		contextKeyService.createKey(ChatContextKeys.chatModeKind.key, ChatModeKind.Agent);
+		await new Promise<void>(r => queueMicrotask(r));
+
+		assertTipNeverShown(service, 'tip.agenticBrowser');
+	});
+
 	for (const tipId of [
 		'tip.thinkingPhrases',
-		'tip.agenticBrowser',
 	]) {
 		test(`dismisses ${tipId} after clicking its settings link`, async () => {
 			const service = createService();

--- a/src/vs/workbench/contrib/chat/test/browser/chatTipService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatTipService.test.ts
@@ -1467,14 +1467,6 @@ suite('ChatTipService', () => {
 		});
 	}
 
-	test('does not show tip.agenticBrowser when setting is at default', async () => {
-		const service = createService();
-		contextKeyService.createKey(ChatContextKeys.chatModeKind.key, ChatModeKind.Agent);
-		await new Promise<void>(r => queueMicrotask(r));
-
-		assertTipNeverShown(service, 'tip.agenticBrowser');
-	});
-
 	for (const tipId of [
 		'tip.thinkingPhrases',
 	]) {


### PR DESCRIPTION
ExP is at 100%, so setting it explicitly in the code too
