### PR TITLE
Gate subagents for BYOK endpoints and require gemini-3-flash for execution subagent

### DIFF
--- a/extensions/copilot/src/extension/intents/node/agentIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/agentIntent.ts
@@ -180,21 +180,27 @@ export const getAgentTools = async (accessor: ServicesAccessor, request: vscode.
 	allowTools[ToolName.CoreRunTest] = await testService.hasAnyTests();
 	allowTools[ToolName.CoreRunTask] = tasksService.getTasks().length > 0;
 
-	const searchSubagentEnabled = configurationService.getExperimentBasedConfig(ConfigKey.Advanced.SearchSubagentToolEnabled, experimentationService);
-	const exploreAgentEnabled = configurationService.getExperimentBasedConfig(ConfigKey.ExploreAgentEnabled, experimentationService);
-	const isGptOrAnthropic = isGptFamily(model) || isAnthropicFamily(model);
-	allowTools[ToolName.SearchSubagent] = isGptOrAnthropic && searchSubagentEnabled && exploreAgentEnabled;
-	allowTools[ToolName.ExploreSubagent] = isGptOrAnthropic && searchSubagentEnabled && !exploreAgentEnabled;
+	// BYOK endpoints that own their `Authorization` have no Copilot token for the
+	// agentic proxy or override models the subagents rely on, so disable them
+	// entirely and skip the (otherwise unnecessary) config and endpoint lookups.
+	if (model.ownsAuthorization) {
+		allowTools[ToolName.SearchSubagent] = false;
+		allowTools[ToolName.ExploreSubagent] = false;
+		allowTools[ToolName.ExecutionSubagent] = false;
+	} else {
+		const searchSubagentEnabled = configurationService.getExperimentBasedConfig(ConfigKey.Advanced.SearchSubagentToolEnabled, experimentationService);
+		const exploreAgentEnabled = configurationService.getExperimentBasedConfig(ConfigKey.ExploreAgentEnabled, experimentationService);
+		const isGptOrAnthropic = isGptFamily(model) || isAnthropicFamily(model);
+		allowTools[ToolName.SearchSubagent] = isGptOrAnthropic && searchSubagentEnabled && exploreAgentEnabled;
+		allowTools[ToolName.ExploreSubagent] = isGptOrAnthropic && searchSubagentEnabled && !exploreAgentEnabled;
 
-	const executionSubagentEnabled = configurationService.getExperimentBasedConfig(ConfigKey.Advanced.ExecutionSubagentToolEnabled, experimentationService);
-	const executionSubagentModel = configurationService.getExperimentBasedConfig(ConfigKey.Advanced.ExecutionSubagentModel, experimentationService);
-	if (executionSubagentModel.toLowerCase().includes('gemini-3-flash')) {
+		const executionSubagentEnabled = configurationService.getExperimentBasedConfig(ConfigKey.Advanced.ExecutionSubagentToolEnabled, experimentationService);
+		// The execution subagent is powered by gemini-3-flash, so it can only be
+		// offered when that model is actually available to the user. If it isn't
+		// in the user's endpoints, keep the tool disabled regardless of the setting.
 		const allEndpoints = await endpointProvider.getAllChatEndpoints();
 		const hasGemini3Flash = allEndpoints.some(ep => ep.family.toLowerCase().includes('gemini-3-flash'));
 		allowTools[ToolName.ExecutionSubagent] = isGptOrAnthropic && executionSubagentEnabled && hasGemini3Flash;
-	}
-	else {
-		allowTools[ToolName.ExecutionSubagent] = isGptOrAnthropic && executionSubagentEnabled;
 	}
 
 	const skillToolEnabled = configurationService.getExperimentBasedConfig(ConfigKey.Advanced.SkillToolEnabled, experimentationService);


### PR DESCRIPTION
## Changes

Refines subagent tool gating in `getAgentTools` (`agentIntent.ts`):

- **BYOK endpoints:** When `model.ownsAuthorization` is true (BYOK endpoints that supply their own `Authorization`), the search, explore, and execution subagents are now all disabled. These endpoints have no Copilot token for the agentic proxy or the override models the subagents rely on. This also short-circuits the (otherwise unnecessary) config and endpoint lookups for BYOK.

- **Execution subagent requires gemini-3-flash:** The execution subagent is powered by `gemini-3-flash`, so it is now only offered when that model is actually available in the user's `getAllChatEndpoints()` — for all main models, regardless of the `chat.executionSubagent.model` setting. Previously the availability check was only applied when the configured model name matched.
