### PR TITLE
otel: emit reasoning_tokens on invoke_agent root span for foreground agent

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/claude/node/claudeOTelTracker.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/node/claudeOTelTracker.ts
@@ -171,6 +171,15 @@ export class ClaudeOTelTracker {
 	 * Accumulates parent-only token usage from an assistant message.
 	 * Excludes subagent turns so gen_ai.usage.* on the root span is comparable
 	 * with the foreground agent.
+	 *
+	 * NOTE: Anthropic SDK `Usage` does not surface reasoning/thinking tokens
+	 * separately (they are folded into `output_tokens`). The per-turn chat spans
+	 * emitted by `chatMLFetcher` (via `ClaudeStreamingPassThroughEndpoint`) do
+	 * carry `gen_ai.usage.reasoning_tokens` / `gen_ai.usage.reasoning.output_tokens`
+	 * because CAPI normalizes the response. To populate reasoning tokens on this
+	 * root `invoke_agent claude` span we would need to bridge that count from the
+	 * pass-through endpoint into this tracker. See toolCallingLoop.ts for the
+	 * pattern used by the foreground agent.
 	 */
 	private _accumulateParentTokenUsage(message: SDKMessage & { type: 'assistant' }): void {
 		if (message.parent_tool_use_id) {

--- a/extensions/copilot/src/extension/intents/node/toolCallingLoop.ts
+++ b/extensions/copilot/src/extension/intents/node/toolCallingLoop.ts
@@ -861,6 +861,7 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 				let totalOutputTokens = 0;
 				let totalCacheReadTokens = 0;
 				let totalCacheCreationTokens = 0;
+				let totalReasoningTokens = 0;
 				let lastResolvedModel: string | undefined;
 				let turnIndex = 0;
 				const tokenListener = this.onDidReceiveResponse(({ response }) => {
@@ -871,6 +872,7 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 						totalOutputTokens += turnOutputTokens;
 						totalCacheReadTokens += (response.usage.prompt_tokens_details?.cached_tokens || 0);
 						totalCacheCreationTokens += (response.usage.prompt_tokens_details?.cache_creation_input_tokens || 0);
+						totalReasoningTokens += (response.usage.completion_tokens_details?.reasoning_tokens || 0);
 					}
 					if (response.type === ChatFetchResponseType.Success && response.resolvedModel) {
 						lastResolvedModel = response.resolvedModel;
@@ -887,6 +889,14 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 						[GenAiAttr.USAGE_OUTPUT_TOKENS]: totalOutputTokens,
 						...(totalCacheReadTokens ? { [GenAiAttr.USAGE_CACHE_READ_INPUT_TOKENS]: totalCacheReadTokens } : {}),
 						...(totalCacheCreationTokens ? { [GenAiAttr.USAGE_CACHE_CREATION_INPUT_TOKENS]: totalCacheCreationTokens } : {}),
+						// Dual-emit reasoning tokens under both the legacy and semconv-aligned keys.
+						// Reasoning tokens are a SUBSET of USAGE_OUTPUT_TOKENS (mirrors OpenAI
+						// completion_tokens_details.reasoning_tokens), so the invoke_agent root
+						// span matches the per-turn chat spans emitted by chatMLFetcher.
+						...(totalReasoningTokens ? {
+							[GenAiAttr.USAGE_REASONING_TOKENS]: totalReasoningTokens,
+							[GenAiAttr.USAGE_REASONING_OUTPUT_TOKENS]: totalReasoningTokens,
+						} : {}),
 						...(lastResolvedModel ? { [GenAiAttr.RESPONSE_MODEL]: normalizeResponseModel(requestModel, lastResolvedModel) ?? lastResolvedModel } : {}),
 					});
 					// Always capture agent output message and tool definitions for the debug panel

--- a/extensions/copilot/src/extension/intents/node/toolCallingLoop.ts
+++ b/extensions/copilot/src/extension/intents/node/toolCallingLoop.ts
@@ -889,14 +889,10 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 						[GenAiAttr.USAGE_OUTPUT_TOKENS]: totalOutputTokens,
 						...(totalCacheReadTokens ? { [GenAiAttr.USAGE_CACHE_READ_INPUT_TOKENS]: totalCacheReadTokens } : {}),
 						...(totalCacheCreationTokens ? { [GenAiAttr.USAGE_CACHE_CREATION_INPUT_TOKENS]: totalCacheCreationTokens } : {}),
-						// Dual-emit reasoning tokens under both the legacy and semconv-aligned keys.
 						// Reasoning tokens are a SUBSET of USAGE_OUTPUT_TOKENS (mirrors OpenAI
-						// completion_tokens_details.reasoning_tokens), so the invoke_agent root
-						// span matches the per-turn chat spans emitted by chatMLFetcher.
-						...(totalReasoningTokens ? {
-							[GenAiAttr.USAGE_REASONING_TOKENS]: totalReasoningTokens,
-							[GenAiAttr.USAGE_REASONING_OUTPUT_TOKENS]: totalReasoningTokens,
-						} : {}),
+						// completion_tokens_details.reasoning_tokens), so this is a sub-breakdown
+						// of output, not an addition.
+						...(totalReasoningTokens ? { [GenAiAttr.USAGE_REASONING_OUTPUT_TOKENS]: totalReasoningTokens } : {}),
 						...(lastResolvedModel ? { [GenAiAttr.RESPONSE_MODEL]: normalizeResponseModel(requestModel, lastResolvedModel) ?? lastResolvedModel } : {}),
 					});
 					// Always capture agent output message and tool definitions for the debug panel


### PR DESCRIPTION
`chatMLFetcher` already sets `gen_ai.usage.reasoning.output_tokens` on every `chat` span, but the `invoke_agent` root span in `toolCallingLoop` didn't aggregate it. App Insights queries reading parent-only totals were missing reasoning.

- Accumulate `response.usage.completion_tokens_details.reasoning_tokens` across turns.
- Emit on the span when non-zero. Reasoning is a **subset** of `output_tokens`, not an addition.

`vscode-claude` has the same gap; Anthropic SDK `Usage` doesn't expose thinking tokens, so it needs a bridge from `ClaudeStreamingPassThroughEndpoint`. Inline TODO left.
