### PR TITLE
Gate thinking re-attach after summarization on producing-model match

### DIFF
--- a/extensions/copilot/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
@@ -222,6 +222,7 @@ class ConversationHistory extends PromptElement<SummarizedAgentHistoryProps> {
 		// Handle the possibility that we summarized partway through the current turn (e.g. if we accumulated many tool call rounds)
 		let summaryForCurrentTurn: string | undefined = undefined;
 		let thinkingForFirstRoundAfterSummarization: ThinkingData | undefined = undefined;
+		let modelIdForSummarizedRound: string | undefined = undefined;
 		if (this.props.promptContext.toolCallRounds?.length) {
 			const toolCallRounds: IToolCallRound[] = [];
 			for (let i = this.props.promptContext.toolCallRounds.length - 1; i >= 0; i--) {
@@ -230,6 +231,7 @@ class ConversationHistory extends PromptElement<SummarizedAgentHistoryProps> {
 					// This tool call round was summarized
 					summaryForCurrentTurn = toolCallRound.summary;
 					thinkingForFirstRoundAfterSummarization = toolCallRound.thinking;
+					modelIdForSummarizedRound = toolCallRound.modelId ?? (toolCallRound as IToolCallRound & { phaseModelId?: string }).phaseModelId;
 					break;
 				}
 				toolCallRounds.push(toolCallRound);
@@ -239,9 +241,18 @@ class ConversationHistory extends PromptElement<SummarizedAgentHistoryProps> {
 			toolCallRounds.reverse();
 
 			// For Anthropic models with thinking enabled, set the thinking on the first round
-			// so it gets rendered as the first thinking block after summarization
+			// so it gets rendered as the first thinking block after summarization.
+			// Only re-attach when the summarized round was produced by the same model as the
+			// destination round / current endpoint — otherwise we'd replay a foreign provider's
+			// signed/encrypted thinking through the endpoint and fail signature validation
+			// (related: https://github.com/microsoft/vscode/issues/316536).
 			if (isAnthropicFamily(this.props.endpoint) && thinkingForFirstRoundAfterSummarization && toolCallRounds.length > 0 && !toolCallRounds[0].thinking) {
-				toolCallRounds[0].thinking = thinkingForFirstRoundAfterSummarization;
+				const firstRoundModelId = toolCallRounds[0].modelId ?? (toolCallRounds[0] as IToolCallRound & { phaseModelId?: string }).phaseModelId;
+				const sourceMatchesDest = modelIdForSummarizedRound && firstRoundModelId && modelIdForSummarizedRound === firstRoundModelId;
+				const sourceMatchesEndpoint = modelIdForSummarizedRound === this.props.endpoint.model;
+				if (sourceMatchesDest || sourceMatchesEndpoint) {
+					toolCallRounds[0].thinking = thinkingForFirstRoundAfterSummarization;
+				}
 			}
 
 			history.push(<ChatToolCalls priority={899} flexGrow={2} promptContext={this.props.promptContext} toolCallRounds={toolCallRounds} toolCallResults={this.props.promptContext.toolCallResults} enableCacheBreakpoints={this.props.enableCacheBreakpoints} truncateAt={this.props.maxToolResultLength} />);

--- a/extensions/copilot/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
@@ -243,14 +243,13 @@ class ConversationHistory extends PromptElement<SummarizedAgentHistoryProps> {
 			// For Anthropic models with thinking enabled, set the thinking on the first round
 			// so it gets rendered as the first thinking block after summarization.
 			// Only re-attach when the summarized round was produced by the same model as the
-			// destination round / current endpoint — otherwise we'd replay a foreign provider's
-			// signed/encrypted thinking through the endpoint and fail signature validation
+			// destination round — otherwise we'd mutate the live round with a foreign
+			// provider's signed/encrypted thinking, which would replay (and 400) on any
+			// future render whose endpoint matches the destination round's model
 			// (related: https://github.com/microsoft/vscode/issues/316536).
 			if (isAnthropicFamily(this.props.endpoint) && thinkingForFirstRoundAfterSummarization && toolCallRounds.length > 0 && !toolCallRounds[0].thinking) {
 				const firstRoundModelId = toolCallRounds[0].modelId ?? (toolCallRounds[0] as IToolCallRound & { phaseModelId?: string }).phaseModelId;
-				const sourceMatchesDest = modelIdForSummarizedRound && firstRoundModelId && modelIdForSummarizedRound === firstRoundModelId;
-				const sourceMatchesEndpoint = modelIdForSummarizedRound === this.props.endpoint.model;
-				if (sourceMatchesDest || sourceMatchesEndpoint) {
+				if (modelIdForSummarizedRound && firstRoundModelId && modelIdForSummarizedRound === firstRoundModelId) {
 					toolCallRounds[0].thinking = thinkingForFirstRoundAfterSummarization;
 				}
 			}

--- a/extensions/copilot/src/extension/prompts/node/agent/test/summarization.spec.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/summarization.spec.tsx
@@ -595,6 +595,91 @@ suite('Agent Summarization', () => {
 			&& successMeta!.outcome !== 'success';
 		expect(shouldSkipAfterSuccess).toBe(false);
 	});
+
+	// Regression coverage for https://github.com/microsoft/vscode/issues/316536:
+	// the post-summary re-attach must not paste a foreign model's signed/encrypted
+	// thinking onto a destination round whose modelId disagrees with the producer,
+	// otherwise a future render whose endpoint matches the destination model will
+	// replay that foreign thinking and 400.
+	suite('post-summary thinking re-attach (#316536)', () => {
+		function makeRounds(summarizedModelId: string | undefined, nextModelId: string | undefined) {
+			const summarized = ToolCallRound.create({
+				response: 'summarized',
+				toolCalls: [createEditFileToolCall(1)],
+				toolInputRetry: 0,
+				id: 'r1',
+				modelId: summarizedModelId,
+				thinking: { id: 'thinking_0', text: 'reasoning' },
+			});
+			summarized.summary = 'summary text';
+			const next = ToolCallRound.create({
+				response: 'next',
+				toolCalls: [createEditFileToolCall(2)],
+				toolInputRetry: 0,
+				id: 'r2',
+				modelId: nextModelId,
+			});
+			return { summarized, next };
+		}
+
+		async function render(endpointFamily: string, rounds: ToolCallRound[]) {
+			const instaService = accessor.get(IInstantiationService);
+			const endpoint = instaService.createInstance(MockEndpoint, endpointFamily);
+			const turn = new Turn('t', { type: 'user', message: 'hi' });
+			const conv = new Conversation('s', [turn]);
+			const promptContext: IBuildPromptContext = {
+				chatVariables: new ChatVariablesCollection([]),
+				history: [],
+				query: 'q',
+				toolCallRounds: rounds,
+				toolCallResults: createEditFileToolResult(1, 2),
+				tools,
+				conversation: conv,
+			};
+			const renderer = PromptRenderer.create(instaService, endpoint, SummarizedConversationHistory, {
+				priority: 1,
+				endpoint,
+				location: ChatLocation.Panel,
+				promptContext,
+				maxToolResultLength: Infinity,
+			});
+			await renderer.render();
+		}
+
+		test('re-attaches thinking when summarized and destination round share modelId', async () => {
+			const { summarized, next } = makeRounds('claude-4.6', 'claude-4.6');
+			await render('claude-4.6', [summarized, next]);
+			expect(next.thinking?.id).toBe('thinking_0');
+		});
+
+		test('drops thinking when summarized modelId differs from destination modelId', async () => {
+			const { summarized, next } = makeRounds('claude-3.5', 'claude-4.6');
+			await render('claude-4.6', [summarized, next]);
+			expect(next.thinking).toBeUndefined();
+		});
+
+		test('drops thinking when summarized modelId is missing', async () => {
+			const { summarized, next } = makeRounds(undefined, 'claude-4.6');
+			await render('claude-4.6', [summarized, next]);
+			expect(next.thinking).toBeUndefined();
+		});
+
+		test('drops thinking when destination modelId is missing', async () => {
+			const { summarized, next } = makeRounds('claude-4.6', undefined);
+			await render('claude-4.6', [summarized, next]);
+			expect(next.thinking).toBeUndefined();
+		});
+
+		test('drops thinking when source matches endpoint but destination round was produced by a different model', async () => {
+			// The dangerous laundering case: producer == endpoint at this render,
+			// destination round was produced by a different model. Mutating the
+			// live destination round would replay foreign thinking on a future
+			// render whose endpoint matches that destination model.
+			const { summarized, next } = makeRounds('claude-4.6', 'claude-3.5');
+			await render('claude-4.6', [summarized, next]);
+			expect(next.thinking).toBeUndefined();
+		});
+	});
 });
 
 suite('extractSummary', () => {


### PR DESCRIPTION
Follow-up to #316664. The renderer in `toolCalling.tsx` refuses to ship thinking blocks across providers, but `summarizedConversationHistory.tsx` was re-attaching the summarized round's thinking onto the first post-summary round without checking the producing model. A mid-turn model switch or subagent handoff could launder foreign thinking onto a round whose `modelId` matches the endpoint, sneaking past the downstream gate.

Capture the summarized round's `modelId` and only re-attach when it matches either the destination round's `modelId` or the current endpoint's model.

Related: #316536, #316664