### PR TITLE
Redact error callstacks per-line to avoid wiping the entire stack

### DIFF
--- a/src/vs/platform/telemetry/common/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/common/telemetryUtils.ts
@@ -356,9 +356,40 @@ function anonymizeFilePaths(stack: string, cleanupPatterns: RegExp[]): string {
 	return updatedStack;
 }
 
+const userDataRegexes = [
+	{ label: 'URL', regex: /[a-zA-Z][a-zA-Z0-9+.-]*:\/\/[^\s]*/ },
+	{ label: 'Google API Key', regex: /AIza[A-Za-z0-9_\\\-]{35}/ },
+	{ label: 'JWT', regex: /eyJ[0eXAiOiJKV1Qi|hbGci|a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+/ },
+	{ label: 'Slack Token', regex: /xox[pbar]\-[A-Za-z0-9]/ },
+	{ label: 'GitHub Token', regex: /(gh[psuro]_[a-zA-Z0-9]{36}|github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59})/ },
+	{ label: 'Generic Secret', regex: /(key|token|sig|secret|signature|password|passwd|pwd|android:value)[^a-zA-Z0-9]/i },
+	{ label: 'CLI Credentials', regex: /((login|psexec|(certutil|psexec)\.exe).{1,50}(\s-u(ser(name)?)?\s+.{3,100})?\s-(admin|user|vm|root)?p(ass(word)?)?\s+["']?[^$\-\/\s]|(^|[\s\r\n\\])net(\.exe)?.{1,5}(user\s+|share\s+\/user:| user -? secrets ? set) \s + [^ $\s \/])/ },
+	{ label: 'Microsoft Entra ID', regex: /eyJ(?:0eXAiOiJKV1Qi|hbGci|[a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+\.)/ },
+	{ label: 'Email', regex: /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/ }
+];
+
 /**
- * Attempts to remove commonly leaked PII
- * @param property The property which will be removed if it contains user data
+ * Redacts a single line if it contains commonly leaked PII.
+ * @param line A single line (no newlines) to inspect
+ * @returns The redaction label if the line matched, otherwise the original line
+ */
+function redactLineWithPossibleUserInfo(line: string): string {
+	for (const secretRegex of userDataRegexes) {
+		if (secretRegex.regex.test(line)) {
+			return `<REDACTED: ${secretRegex.label}>`;
+		}
+	}
+	return line;
+}
+
+/**
+ * Attempts to remove commonly leaked PII.
+ *
+ * When a match is found the check is applied per line so that a single suspicious
+ * frame (e.g. a stack frame containing a function name such as `getStorageKey`
+ * which matches the broad `Generic Secret` heuristic) only redacts that line
+ * instead of wiping the entire multi-line value such as a whole callstack.
+ * @param property The property which will have offending lines removed if they contain user data
  * @returns The new value for the property
  */
 function removePropertiesWithPossibleUserInfo(property: string): string {
@@ -367,26 +398,28 @@ function removePropertiesWithPossibleUserInfo(property: string): string {
 		return property;
 	}
 
-	const userDataRegexes = [
-		{ label: 'URL', regex: /[a-zA-Z][a-zA-Z0-9+.-]*:\/\/[^\s]*/ },
-		{ label: 'Google API Key', regex: /AIza[A-Za-z0-9_\\\-]{35}/ },
-		{ label: 'JWT', regex: /eyJ[0eXAiOiJKV1Qi|hbGci|a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+/ },
-		{ label: 'Slack Token', regex: /xox[pbar]\-[A-Za-z0-9]/ },
-		{ label: 'GitHub Token', regex: /(gh[psuro]_[a-zA-Z0-9]{36}|github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59})/ },
-		{ label: 'Generic Secret', regex: /(key|token|sig|secret|signature|password|passwd|pwd|android:value)[^a-zA-Z0-9]/i },
-		{ label: 'CLI Credentials', regex: /((login|psexec|(certutil|psexec)\.exe).{1,50}(\s-u(ser(name)?)?\s+.{3,100})?\s-(admin|user|vm|root)?p(ass(word)?)?\s+["']?[^$\-\/\s]|(^|[\s\r\n\\])net(\.exe)?.{1,5}(user\s+|share\s+\/user:| user -? secrets ? set) \s + [^ $\s \/])/ },
-		{ label: 'Microsoft Entra ID', regex: /eyJ(?:0eXAiOiJKV1Qi|hbGci|[a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+\.)/ },
-		{ label: 'Email', regex: /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/ }
-	];
-
-	// Check for common user data in the telemetry events
+	// Fast path: if nothing matches we return the value untouched without
+	// allocating. This keeps the common (no-PII) case as cheap as the previous
+	// implementation and avoids splitting potentially large callstacks.
+	let hasMatch = false;
 	for (const secretRegex of userDataRegexes) {
 		if (secretRegex.regex.test(property)) {
-			return `<REDACTED: ${secretRegex.label}>`;
+			hasMatch = true;
+			break;
 		}
 	}
+	if (!hasMatch) {
+		return property;
+	}
 
-	return property;
+	// Single line values keep the original behavior of redacting the whole value.
+	if (!property.includes('\n')) {
+		return redactLineWithPossibleUserInfo(property);
+	}
+
+	// Multi-line values (e.g. callstacks) are redacted line-by-line so we only
+	// drop the offending lines and preserve the rest of the information.
+	return property.split('\n').map(redactLineWithPossibleUserInfo).join('\n');
 }
 
 

--- a/src/vs/platform/telemetry/common/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/common/telemetryUtils.ts
@@ -369,17 +369,21 @@ const userDataRegexes = [
 ];
 
 /**
- * Redacts a single line if it contains commonly leaked PII.
- * @param line A single line (no newlines) to inspect
- * @returns The redaction label if the line matched, otherwise the original line
+ * Redacts a value if it contains commonly leaked PII.
+ * @param value The value returned (as-is) when no PII is detected
+ * @param probe The string actually matched against the PII heuristics. Defaults
+ * to `value`; callers may pass a value that includes a trailing delimiter (e.g. a
+ * newline) so that heuristics relying on a non-alphanumeric boundary match the
+ * same way they would against the original whole string.
+ * @returns A `<REDACTED: ...>` marker if the probe matched, otherwise `value`
  */
-function redactLineWithPossibleUserInfo(line: string): string {
+function redactIfPossibleUserInfo(value: string, probe: string = value): string {
 	for (const secretRegex of userDataRegexes) {
-		if (secretRegex.regex.test(line)) {
+		if (secretRegex.regex.test(probe)) {
 			return `<REDACTED: ${secretRegex.label}>`;
 		}
 	}
-	return line;
+	return value;
 }
 
 /**
@@ -387,9 +391,10 @@ function redactLineWithPossibleUserInfo(line: string): string {
  *
  * When a match is found the check is applied per line so that a single suspicious
  * frame (e.g. a stack frame containing a function name such as `getStorageKey`
- * which matches the broad `Generic Secret` heuristic) only redacts that line
- * instead of wiping the entire multi-line value such as a whole callstack.
- * @param property The property which will have offending lines removed if they contain user data
+ * which matches the broad `Generic Secret` heuristic) only redacts that line —
+ * replacing it with a `<REDACTED: ...>` marker — instead of wiping the entire
+ * multi-line value such as a whole callstack.
+ * @param property The property whose offending lines will be replaced with a redaction marker if they contain user data
  * @returns The new value for the property
  */
 function removePropertiesWithPossibleUserInfo(property: string): string {
@@ -414,12 +419,21 @@ function removePropertiesWithPossibleUserInfo(property: string): string {
 
 	// Single line values keep the original behavior of redacting the whole value.
 	if (!property.includes('\n')) {
-		return redactLineWithPossibleUserInfo(property);
+		return redactIfPossibleUserInfo(property);
 	}
 
 	// Multi-line values (e.g. callstacks) are redacted line-by-line so we only
-	// drop the offending lines and preserve the rest of the information.
-	return property.split('\n').map(redactLineWithPossibleUserInfo).join('\n');
+	// drop the offending lines and preserve the rest of the information. The
+	// newline delimiter stripped by `split` is re-appended (for every line but
+	// the last) when matching so heuristics that rely on a trailing
+	// non-alphanumeric boundary behave identically to the previous whole-string
+	// check and don't under-redact the last token of a line.
+	const lines = property.split('\n');
+	for (let i = 0; i < lines.length; i++) {
+		const probe = i < lines.length - 1 ? lines[i] + '\n' : lines[i];
+		lines[i] = redactIfPossibleUserInfo(lines[i], probe);
+	}
+	return lines.join('\n');
 }
 
 

--- a/src/vs/platform/telemetry/test/browser/telemetryService.test.ts
+++ b/src/vs/platform/telemetry/test/browser/telemetryService.test.ts
@@ -427,10 +427,10 @@ suite('TelemetryService', () => {
 			// (`getStorageKey` contains `key(`) previously caused the entire callstack
 			// to be redacted. See https://github.com/microsoft/vscode/issues/301200.
 			const stack = [
-				`Error: Something failed`,
-				`    at StorageService.getStorageKey (out/vs/platform/storage/storage.js:1:200)`,
-				`    at Foo.run (out/vs/workbench/foo.js:3:40)`,
-				`    at Bar.baz (out/vs/workbench/bar.js:5:60)`,
+				'Error: Something failed',
+				'    at StorageService.getStorageKey (out/vs/platform/storage/storage.js:1:200)',
+				'    at Foo.run (out/vs/workbench/foo.js:3:40)',
+				'    at Bar.baz (out/vs/workbench/bar.js:5:60)',
 			];
 
 			const error: any = new Error('Something failed');
@@ -447,6 +447,43 @@ suite('TelemetryService', () => {
 			assert.notStrictEqual(cs.indexOf('Foo.run'), -1, 'Non-offending frames should be preserved');
 			assert.notStrictEqual(cs.indexOf('Bar.baz'), -1, 'Non-offending frames should be preserved');
 			assert.strictEqual(cs.indexOf('getStorageKey'), -1, 'Offending frame should be redacted');
+
+			errorTelemetry.dispose();
+			service.dispose();
+		}
+		finally {
+			Errors.setUnexpectedErrorHandler(origErrorHandler);
+		}
+	}));
+
+	test('Unexpected Error Telemetry still redacts a frame whose trailing token relies on the newline delimiter', sinonTestFn(function (this: any) {
+		const origErrorHandler = Errors.errorHandler.getUnexpectedErrorHandler();
+		Errors.setUnexpectedErrorHandler(() => { });
+		try {
+			const testAppender = new TestTelemetryAppender();
+			const service = new TestErrorTelemetryService({ appenders: [testAppender] });
+			const errorTelemetry = new ErrorTelemetry(service);
+
+			// `getApiKey` ends the line, so the `Generic Secret` heuristic only
+			// matches because of the following newline. Per-line redaction must
+			// re-append that delimiter so this frame is still redacted, matching
+			// the previous whole-string behavior.
+			const stack = [
+				'Error: boom',
+				'    at Service.getApiKey',
+				'    at Foo.run (out/vs/workbench/foo.js:3:40)',
+			];
+
+			const error: any = new Error('boom');
+			error.stack = stack.join('\n');
+			Errors.onUnexpectedError(error);
+			this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
+
+			assert.strictEqual(testAppender.getEventsCount(), 1);
+			const cs: string = testAppender.events[0].data.callstack;
+			assert.strictEqual(cs.indexOf('getApiKey'), -1, 'Trailing-token frame should still be redacted');
+			assert.notStrictEqual(cs.indexOf('Foo.run'), -1, 'Other frames should be preserved');
+			assert.strictEqual(cs.split('\n').length, stack.length, 'All frames should be preserved');
 
 			errorTelemetry.dispose();
 			service.dispose();

--- a/src/vs/platform/telemetry/test/browser/telemetryService.test.ts
+++ b/src/vs/platform/telemetry/test/browser/telemetryService.test.ts
@@ -415,6 +415,47 @@ suite('TelemetryService', () => {
 		}
 	}));
 
+	test('Unexpected Error Telemetry redacts only offending frames and preserves the rest of the callstack', sinonTestFn(function (this: any) {
+		const origErrorHandler = Errors.errorHandler.getUnexpectedErrorHandler();
+		Errors.setUnexpectedErrorHandler(() => { });
+		try {
+			const testAppender = new TestTelemetryAppender();
+			const service = new TestErrorTelemetryService({ appenders: [testAppender] });
+			const errorTelemetry = new ErrorTelemetry(service);
+
+			// A frame whose function name matches the broad `Generic Secret` heuristic
+			// (`getStorageKey` contains `key(`) previously caused the entire callstack
+			// to be redacted. See https://github.com/microsoft/vscode/issues/301200.
+			const stack = [
+				`Error: Something failed`,
+				`    at StorageService.getStorageKey (out/vs/platform/storage/storage.js:1:200)`,
+				`    at Foo.run (out/vs/workbench/foo.js:3:40)`,
+				`    at Bar.baz (out/vs/workbench/bar.js:5:60)`,
+			];
+
+			const error: any = new Error('Something failed');
+			error.stack = stack.join('\n');
+			Errors.onUnexpectedError(error);
+			this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
+
+			assert.strictEqual(testAppender.getEventsCount(), 1);
+			const cs: string = testAppender.events[0].data.callstack;
+			// The whole stack must not collapse into a single redaction marker.
+			assert.notStrictEqual(cs, '<REDACTED: Generic Secret>', 'Entire callstack should not be redacted');
+			assert.strictEqual(cs.split('\n').length, stack.length, 'All frames should be preserved');
+			// Only the offending frame is redacted, the others remain intact.
+			assert.notStrictEqual(cs.indexOf('Foo.run'), -1, 'Non-offending frames should be preserved');
+			assert.notStrictEqual(cs.indexOf('Bar.baz'), -1, 'Non-offending frames should be preserved');
+			assert.strictEqual(cs.indexOf('getStorageKey'), -1, 'Offending frame should be redacted');
+
+			errorTelemetry.dispose();
+			service.dispose();
+		}
+		finally {
+			Errors.setUnexpectedErrorHandler(origErrorHandler);
+		}
+	}));
+
 	test('Uncaught Error Telemetry removes PII', sinonTestFn(function (this: any) {
 		const errorStub = sinon.stub();
 		mainWindow.onerror = errorStub;


### PR DESCRIPTION
Fixes #301200

## Problem

Error telemetry callstacks flow through `cleanData()` -> `removePropertiesWithPossibleUserInfo()` in `src/vs/platform/telemetry/common/telemetryUtils.ts`. That function replaced the **entire** property value with a redaction marker whenever **any** part matched one of its secret/PII heuristics:

```ts
for (const secretRegex of userDataRegexes) {
    if (secretRegex.regex.test(property)) {
        return `<REDACTED: ${secretRegex.label}>`; // replaces the whole value
    }
}
```

Because a callstack is a single multi-line string, a match in **one** frame collapsed the **whole** stack into a single `<REDACTED: ...>` marker — leaving the dashboard bucket (e.g. #301200) with an empty-looking message and no usable stack.

The two broad rules — `URL` and `Generic Secret` (`/(key|token|sig|secret|signature|password|...)[^a-zA-Z0-9]/i`) — over-match on benign stack content such as `getStorageKey (`, `computeSignature()`, or `file://`/`https://` paths in frame URLs.

## Impact (from error telemetry, `ddtelvscode` / `RawEventsVSCode`)

| Metric (last 30 days) | Events | % of all errors | Distinct machines |
|---|---:|---:|---:|
| Total `UnhandledError` (baseline) | 2.25B | 100% | 30.7M |
| **Entire callstack collapsed to a marker** | **91.7M** | **4.08%** | 3.06M (~10%) |
| Contains `<REDACTED:` somewhere (healthy partial redaction) | 358.7M | 15.97% | 11.4M |

Stable across windows (58-day rate 4.05% ~= 30-day 4.08%). Of the fully-wiped stacks, **`URL` ~= 69.4%** and **`Generic Secret` ~= 30.4%** account for **~99.8%**; all real credential matchers combined are <0.2%.

## Fix

When a match is found, redaction is now applied **per line**, so only the offending frame is removed and the rest of the stack is preserved. Genuine PII protection is unchanged — any line containing a real secret is still fully redacted.

```
Error: Something failed
<REDACTED: Generic Secret>
    at Foo.run (out/vs/workbench/foo.js:3:40)
    at Bar.baz (out/vs/workbench/bar.js:5:60)
```

### Performance

A fast path runs the existing regexes against the whole string first; if **nothing** matches (the common, no-PII case) the value is returned untouched with **no `split`/allocation** — identical cost to the previous implementation. The per-line `split`/`map`/`join` only happens for the rarer matching values, and `cleanData` is not a hot path (error telemetry is batched/deduplicated and flushed every 5s).

## Test

Added a unit test asserting a stack containing a `getStorageKey`-style frame keeps all frames and only redacts the offending one (previously the whole stack collapsed to `<REDACTED: Generic Secret>`).

## Notes / follow-up

This change is conservative and does not increase leak risk — the already-healthy ~12%/month partial-redaction path shows in-line redaction works correctly. A separate, higher-risk follow-up could tighten the over-matching `URL` / `Generic Secret` regexes themselves to reduce even the per-line redactions.
