### PR TITLE
Update chat session icons and order

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsActions.ts
@@ -232,7 +232,7 @@ export class ArchiveAgentSessionSectionAction extends Action2 {
 		super({
 			id: 'agentSessionSection.archive',
 			title: localize2('archiveSection', "Archive All"),
-			icon: Codicon.archive,
+			icon: Codicon.checkAll,
 			menu: [{
 				id: MenuId.AgentSessionSectionToolbar,
 				group: 'navigation',
@@ -473,7 +473,7 @@ export class ArchiveAgentSessionAction extends BaseAgentSessionAction {
 		super({
 			id: 'agentSession.archive',
 			title: localize2('archive', "Archive"),
-			icon: Codicon.archive,
+			icon: Codicon.check,
 			keybinding: {
 				primary: KeyCode.Delete,
 				mac: { primary: KeyMod.CtrlCmd | KeyCode.Backspace },
@@ -566,7 +566,7 @@ export class PinAgentSessionAction extends BaseAgentSessionAction {
 			menu: [{
 				id: MenuId.AgentSessionItemToolbar,
 				group: 'navigation',
-				order: 0,
+				order: 2,
 				when: ContextKeyExpr.and(
 					ChatContextKeys.isPinnedAgentSession.negate(),
 					ChatContextKeys.isArchivedAgentSession.negate()
@@ -600,7 +600,7 @@ export class UnpinAgentSessionAction extends BaseAgentSessionAction {
 			menu: [{
 				id: MenuId.AgentSessionItemToolbar,
 				group: 'navigation',
-				order: 0,
+				order: 2,
 				when: ContextKeyExpr.and(
 					ChatContextKeys.isPinnedAgentSession,
 					ChatContextKeys.isArchivedAgentSession.negate()

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsPicker.ts
@@ -23,7 +23,7 @@ interface ISessionPickItem extends IQuickPickItem {
 }
 
 export const archiveButton: IQuickInputButton = {
-	iconClass: ThemeIcon.asClassName(Codicon.archive),
+	iconClass: ThemeIcon.asClassName(Codicon.check),
 	tooltip: localize('archiveSession', "Archive")
 };
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Update VS Code core chat session list action buttons so they align with agents window:

- The archive button uses a check icon
- Swap order of archive and pin buttons

<img width="144" height="93" alt="Screenshot 2026-06-01 at 11 41 07 PM" src="https://github.com/user-attachments/assets/a99399b7-c269-4256-b54b-5baee3d8479a" />