### PR TITLE
fix: bump shared memory to support software compositor allocation pressure

### DIFF
--- a/test/sanity/scripts/run-docker.sh
+++ b/test/sanity/scripts/run-docker.sh
@@ -46,6 +46,7 @@ echo "Running sanity tests in container"
 docker run \
 	--rm \
 	--platform "linux/$ARCH" \
+	--shm-size=2g \
 	--volume "$ROOT_DIR:/root" \
 	${GITHUB_ACCOUNT:+--env GITHUB_ACCOUNT} \
 	${GITHUB_PASSWORD:+--env GITHUB_PASSWORD} \


### PR DESCRIPTION
The Fedora and Debian desktop sanity tests crash shortly after launch (SIGTRAP) when run inside the Docker containers.  The aborts originate from two software-compositor allocation paths, both backed by shared memory on Linux:

  ```- gpu::SharedImageInterface::CreateSharedMemoryRegionFromSIInfo
    (cc::TileManager -> ZeroCopyRasterBufferImpl ->
     CreateSharedImageForSoftwareCompositor)
  - base::DiscardableMemoryAllocator::
    AllocateLockedDiscardableMemoryWithRetryOrDie
    (SkMipmap::Build -> SoftwareImageDecodeCache)
  ```

Docker gives a container a default `/dev/shm` of only 64 MB. Once shared memory fills, the SharedImage and discardable allocations fail crashing the process.

Fixes https://github.com/microsoft/vscode/issues/318542
Fixes https://github.com/microsoft/vscode-engineering/issues/2877