### PR TITLE
Agents + Workbench: Add shared GitHub profile image service

### DIFF
--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -88,7 +88,7 @@ When multiple remote agent hosts are known, a dropdown pill in the left toolbar 
 
 ### Account Widget (Right)
 
-Shows the signed-in GitHub profile image (falls back to the account codicon). Clicking opens a combined account and Copilot status panel with sign-in/sign-out and settings actions.
+Shows the active GitHub or GitHub Enterprise profile image using the shared workbench account profile image service (falls back to the account codicon). Clicking opens a combined account and Copilot status panel with sign-in/sign-out and settings actions.
 
 ---
 

--- a/src/vs/sessions/MOBILE.md
+++ b/src/vs/sessions/MOBILE.md
@@ -64,7 +64,7 @@ On phone-sized viewports (`< 640px` width):
 └──────────────────────────────────┘
 ```
 
-- **MobileTitlebarPart** is a DOM element prepended above the grid. It has a hamburger (☰), session title, and a contextual right slot that swaps between the new session (+) button (when in a chat) and the account indicator 👤 (on the welcome / new session screen).
+- **MobileTitlebarPart** is a DOM element prepended above the grid. It has a hamburger (☰), session title, and a contextual right slot that swaps between the new session (+) button (when in a chat) and the account indicator 👤 (on the welcome / new session screen). The account indicator uses the shared workbench account profile image service so GitHub Enterprise avatars resolve via the authenticated GitHub API instead of a static URL.
 - **Sidebar** is hidden by default and opens as an **85% width drawer overlay** with a backdrop when the hamburger is tapped. CSS makes its `split-view-view` absolutely positioned with `z-index: 250`. The workbench manually calls `sidebarPart.layout()` with drawer dimensions after opening. Closing the drawer clears the navigation stack.
 - **Titlebar** is hidden in the grid (`visible: false`) and via CSS — replaced by MobileTitlebarPart.
 - **SessionCompositeBar** (chat tabs) is hidden via CSS.
@@ -114,7 +114,7 @@ The workbench toggles the `phone-layout` CSS class on `layout()` and creates/des
 
 | File | Purpose |
 |------|---------|
-| `mobileTitlebarPart.ts` | Phone top bar: hamburger (☰), session title, contextual right slot (+ for in-chat, account indicator for welcome). Emits `onDidClickHamburger`, `onDidClickNewSession`, `onDidClickTitle`. Includes account state tracking, avatar loading, and account panel with copilot dashboard. |
+| `mobileTitlebarPart.ts` | Phone top bar: hamburger (☰), session title, contextual right slot (+ for in-chat, account indicator for welcome). Emits `onDidClickHamburger`, `onDidClickNewSession`, `onDidClickTitle`. Includes account state tracking, shared profile-image-service avatar loading, and account panel with copilot dashboard. |
 | `mobileChatShell.css` | **Single source of truth** for all phone-layout CSS: flex column layout, split-view-view absolute positioning, card chrome removal, part/content width overrides, sidebar title hiding, composite bar hiding, welcome page layout, sash hiding, button focus overrides, chip row styling. |
 | `mobilePickerSheet.ts` | Reusable phone-friendly bottom sheet for picker-style choices. Promise-based overlay with backdrop, drag handle, header (title + Done button + optional header actions), sectioned listbox, and optional inline search with debounced cancellable loads. Uses `DisposableStore` for lifecycle. |
 | `media/mobilePickerSheet.css` | Styling for the bottom sheet widget (backdrop, slide-up animation, row layout, search input, section dividers, checkmarks). |

--- a/src/vs/sessions/browser/accountTitleBarState.ts
+++ b/src/vs/sessions/browser/accountTitleBarState.ts
@@ -15,7 +15,6 @@ export interface IResolvedAccountInfo {
 	readonly accountName: string;
 	readonly accountProviderId: string;
 	readonly accountProviderLabel: string;
-	readonly accountSessionId?: string;
 }
 
 /**
@@ -34,7 +33,6 @@ export async function resolveAccountInfo(
 			accountName: account.accountName,
 			accountProviderId: account.authenticationProvider.id,
 			accountProviderLabel: account.authenticationProvider.name,
-			accountSessionId: account.sessionId,
 		};
 	}
 
@@ -49,7 +47,6 @@ export async function resolveAccountInfo(
 					accountName: sessions[0].account.label,
 					accountProviderId: provider.id,
 					accountProviderLabel: provider.label,
-					accountSessionId: sessions[0].id,
 				};
 			}
 		} catch {

--- a/src/vs/sessions/browser/accountTitleBarState.ts
+++ b/src/vs/sessions/browser/accountTitleBarState.ts
@@ -9,11 +9,13 @@ import { localize } from '../../nls.js';
 import { ChatEntitlement, IChatSentiment, IQuotaSnapshot } from '../../workbench/services/chat/common/chatEntitlementService.js';
 import { IDefaultAccountService } from '../../platform/defaultAccount/common/defaultAccount.js';
 import { IAuthenticationService } from '../../workbench/services/authentication/common/authentication.js';
+import { GITHUB_AUTH_PROVIDER_ID, GITHUB_ENTERPRISE_AUTH_PROVIDER_ID } from '../../workbench/services/accounts/common/accountProfileImage.js';
 
 export interface IResolvedAccountInfo {
 	readonly accountName: string;
 	readonly accountProviderId: string;
 	readonly accountProviderLabel: string;
+	readonly accountSessionId?: string;
 }
 
 /**
@@ -32,20 +34,27 @@ export async function resolveAccountInfo(
 			accountName: account.accountName,
 			accountProviderId: account.authenticationProvider.id,
 			accountProviderLabel: account.authenticationProvider.name,
+			accountSessionId: account.sessionId,
 		};
 	}
 
-	try {
-		const sessions = await authenticationService.getSessions('github');
-		if (sessions.length > 0) {
-			return {
-				accountName: sessions[0].account.label,
-				accountProviderId: 'github',
-				accountProviderLabel: 'GitHub',
-			};
+	for (const provider of [
+		{ id: GITHUB_AUTH_PROVIDER_ID, label: localize('github', "GitHub") },
+		{ id: GITHUB_ENTERPRISE_AUTH_PROVIDER_ID, label: localize('githubEnterprise', "GitHub Enterprise") },
+	]) {
+		try {
+			const sessions = await authenticationService.getSessions(provider.id);
+			if (sessions.length > 0) {
+				return {
+					accountName: sessions[0].account.label,
+					accountProviderId: provider.id,
+					accountProviderLabel: provider.label,
+					accountSessionId: sessions[0].id,
+				};
+			}
+		} catch {
+			// Provider not available yet
 		}
-	} catch {
-		// Provider not available yet
 	}
 
 	return undefined;
@@ -75,14 +84,6 @@ export interface IAccountTitleBarState {
 	readonly badge?: string;
 	readonly dotBadge?: 'warning' | 'error';
 	readonly revealLabelOnHover?: boolean;
-}
-
-export function getAccountProfileImageUrl(accountProviderId: string | undefined, accountName: string | undefined): string | undefined {
-	if (accountProviderId !== 'github' || !accountName?.trim()) {
-		return undefined;
-	}
-
-	return `https://github.com/${encodeURIComponent(accountName.trim())}.png?size=64`;
 }
 
 export function getAccountTitleBarBadgeKey(state: IAccountTitleBarState): string | undefined {

--- a/src/vs/sessions/browser/accountTitleBarState.ts
+++ b/src/vs/sessions/browser/accountTitleBarState.ts
@@ -36,10 +36,11 @@ export async function resolveAccountInfo(
 		};
 	}
 
-	for (const provider of [
+	const fallbackGitHubAccountProviders = [
 		{ id: GITHUB_AUTH_PROVIDER_ID, label: localize('github', "GitHub") },
 		{ id: GITHUB_ENTERPRISE_AUTH_PROVIDER_ID, label: localize('githubEnterprise', "GitHub Enterprise") },
-	]) {
+	];
+	for (const provider of fallbackGitHubAccountProviders) {
 		try {
 			const sessions = await authenticationService.getSessions(provider.id);
 			if (sessions.length > 0) {

--- a/src/vs/sessions/browser/parts/mobile/mobileTitlebarPart.ts
+++ b/src/vs/sessions/browser/parts/mobile/mobileTitlebarPart.ts
@@ -82,9 +82,7 @@ export class MobileTitlebarPart extends Disposable {
 	private readonly accountIconElement: HTMLElement;
 	private readonly accountBadgeElement: HTMLElement;
 	private accountName: string | undefined;
-	private accountProviderId: string | undefined;
 	private accountProviderLabel: string | undefined;
-	private accountSessionId: string | undefined;
 	private isAccountLoading = true;
 	private accountRequestCounter = 0;
 	private avatarRequestCounter = 0;
@@ -325,9 +323,7 @@ export class MobileTitlebarPart extends Disposable {
 		}
 
 		this.accountName = info?.accountName;
-		this.accountProviderId = info?.accountProviderId;
 		this.accountProviderLabel = info?.accountProviderLabel;
-		this.accountSessionId = info?.accountSessionId;
 		this.isAccountLoading = false;
 		this.refreshAvatar();
 		this.renderAccountState();
@@ -384,11 +380,7 @@ export class MobileTitlebarPart extends Disposable {
 		const requestId = ++this.avatarRequestCounter;
 
 		try {
-			const avatarUrl = await this.accountProfileImageService.getProfileImageUrl({
-				providerId: this.accountProviderId,
-				accountName: this.accountName,
-				sessionId: this.accountSessionId,
-			});
+			const avatarUrl = await this.accountProfileImageService.getDefaultProfileImageUrl();
 			if (requestId !== this.avatarRequestCounter) {
 				return;
 			}

--- a/src/vs/sessions/browser/parts/mobile/mobileTitlebarPart.ts
+++ b/src/vs/sessions/browser/parts/mobile/mobileTitlebarPart.ts
@@ -20,15 +20,17 @@ import { fillInActionBarActions } from '../../../../platform/actions/browser/men
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IDefaultAccountService } from '../../../../platform/defaultAccount/common/defaultAccount.js';
 import { IAuthenticationService } from '../../../../workbench/services/authentication/common/authentication.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ISessionFileChange } from '../../../services/sessions/common/session.js';
 import { IsNewChatSessionContext } from '../../../common/contextkeys.js';
 import { SideBarVisibleContext } from '../../../../workbench/common/contextkeys.js';
 import { Menus } from '../../menus.js';
 import { ChatEntitlement, ChatEntitlementService, IChatEntitlementService } from '../../../../workbench/services/chat/common/chatEntitlementService.js';
-import { getAccountTitleBarState, getAccountProfileImageUrl, getAccountTitleBarBadgeKey, resolveAccountInfo } from '../../accountTitleBarState.js';
+import { getAccountTitleBarState, getAccountTitleBarBadgeKey, resolveAccountInfo } from '../../accountTitleBarState.js';
 import { IChatDashboardService } from '../../chatDashboardService.js';
 import { MOBILE_OPEN_CHANGES_VIEW_COMMAND_ID } from './contributions/mobileChangesView.js';
+import { IAccountProfileImageService } from '../../../../workbench/services/accounts/common/accountProfileImage.js';
 
 /**
  * Mobile titlebar — prepended above the workbench grid on phone viewports
@@ -82,6 +84,7 @@ export class MobileTitlebarPart extends Disposable {
 	private accountName: string | undefined;
 	private accountProviderId: string | undefined;
 	private accountProviderLabel: string | undefined;
+	private accountSessionId: string | undefined;
 	private isAccountLoading = true;
 	private accountRequestCounter = 0;
 	private avatarRequestCounter = 0;
@@ -109,6 +112,8 @@ export class MobileTitlebarPart extends Disposable {
 		@IMenuService private readonly menuService: IMenuService,
 		@IChatDashboardService private readonly chatDashboardService: IChatDashboardService,
 		@ICommandService private readonly commandService: ICommandService,
+		@IAccountProfileImageService private readonly accountProfileImageService: IAccountProfileImageService,
+		@ILogService private readonly logService: ILogService,
 	) {
 		super();
 
@@ -322,6 +327,7 @@ export class MobileTitlebarPart extends Disposable {
 		this.accountName = info?.accountName;
 		this.accountProviderId = info?.accountProviderId;
 		this.accountProviderLabel = info?.accountProviderLabel;
+		this.accountSessionId = info?.accountSessionId;
 		this.isAccountLoading = false;
 		this.refreshAvatar();
 		this.renderAccountState();
@@ -374,39 +380,52 @@ export class MobileTitlebarPart extends Disposable {
 		this.accountButton.setAttribute('aria-label', state.ariaLabel);
 	}
 
-	private refreshAvatar(): void {
-		const avatarUrl = getAccountProfileImageUrl(this.accountProviderId, this.accountName);
-		if (avatarUrl === this.currentAvatarUrl) {
-			return;
-		}
-
-		this.currentAvatarUrl = avatarUrl;
-		this.loadedAvatarUrl = undefined;
-		this.avatarLoadDisposable.clear();
+	private async refreshAvatar(): Promise<void> {
 		const requestId = ++this.avatarRequestCounter;
 
-		if (!avatarUrl) {
-			this.renderAccountState();
-			return;
-		}
+		try {
+			const avatarUrl = await this.accountProfileImageService.getProfileImageUrl({
+				providerId: this.accountProviderId,
+				accountName: this.accountName,
+				sessionId: this.accountSessionId,
+			});
+			if (requestId !== this.avatarRequestCounter) {
+				return;
+			}
 
-		const image = new Image();
-		image.referrerPolicy = 'no-referrer';
-		const clearHandlers = () => { image.onload = null; image.onerror = null; };
-		image.onload = () => {
-			if (requestId !== this.avatarRequestCounter) { return; }
-			this.loadedAvatarUrl = avatarUrl;
-			this.renderAccountState();
-			clearHandlers();
-		};
-		image.onerror = () => {
-			if (requestId !== this.avatarRequestCounter) { return; }
+			if (avatarUrl === this.currentAvatarUrl && this.loadedAvatarUrl) {
+				return;
+			}
+
+			this.currentAvatarUrl = avatarUrl;
 			this.loadedAvatarUrl = undefined;
-			this.renderAccountState();
-			clearHandlers();
-		};
-		this.avatarLoadDisposable.value = toDisposable(() => { clearHandlers(); image.src = ''; });
-		image.src = avatarUrl;
+			this.avatarLoadDisposable.clear();
+
+			if (!avatarUrl) {
+				this.renderAccountState();
+				return;
+			}
+
+			const image = new Image();
+			image.referrerPolicy = 'no-referrer';
+			const clearHandlers = () => { image.onload = null; image.onerror = null; };
+			image.onload = () => {
+				if (requestId !== this.avatarRequestCounter) { return; }
+				this.loadedAvatarUrl = avatarUrl;
+				this.renderAccountState();
+				clearHandlers();
+			};
+			image.onerror = () => {
+				if (requestId !== this.avatarRequestCounter) { return; }
+				this.loadedAvatarUrl = undefined;
+				this.renderAccountState();
+				clearHandlers();
+			};
+			this.avatarLoadDisposable.value = toDisposable(() => { clearHandlers(); image.src = ''; });
+			image.src = avatarUrl;
+		} catch (error) {
+			this.logService.error(error);
+		}
 	}
 
 	// --- Account Sheet --- //

--- a/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
+++ b/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
@@ -27,12 +27,13 @@ import { IAction, Separator } from '../../../../base/common/actions.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
 import { registerUpdateTitleBarMenuPlacement } from '../../../../workbench/contrib/update/browser/updateTitleBarEntry.js';
 import { ChatEntitlement, ChatEntitlementService, IChatEntitlementService } from '../../../../workbench/services/chat/common/chatEntitlementService.js';
 import { ChatStatusDashboard, IChatStatusDashboardOptions } from '../../../../workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.js';
 import { HoverPosition } from '../../../../base/browser/ui/hover/hoverWidget.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
-import { getAccountProfileImageUrl, getAccountTitleBarBadgeKey, getAccountTitleBarState, resolveAccountInfo } from '../../../browser/accountTitleBarState.js';
+import { getAccountTitleBarBadgeKey, getAccountTitleBarState, resolveAccountInfo } from '../../../browser/accountTitleBarState.js';
 import { IsPhoneLayoutContext, SessionsWelcomeVisibleContext } from '../../../common/contextkeys.js';
 import { IsAuxiliaryWindowContext } from '../../../../workbench/common/contextkeys.js';
 import { IAuthenticationAccessService } from '../../../../workbench/services/authentication/browser/authenticationAccessService.js';
@@ -40,6 +41,7 @@ import { IAuthenticationUsageService } from '../../../../workbench/services/auth
 import { IAuthenticationService } from '../../../../workbench/services/authentication/common/authentication.js';
 import { IChatDashboardService } from '../../../browser/chatDashboardService.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { IAccountProfileImageService, isGitHubAuthenticationProvider } from '../../../../workbench/services/accounts/common/accountProfileImage.js';
 
 // --- Account Menu Items --- //
 const AccountMenu = Menus.AccountMenu;
@@ -152,6 +154,7 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 	private accountName: string | undefined;
 	private accountProviderId: string | undefined;
 	private accountProviderLabel: string | undefined;
+	private accountSessionId: string | undefined;
 	private isAccountLoading = true;
 	private accountRequestCounter = 0;
 	private avatarRequestCounter = 0;
@@ -175,6 +178,8 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 		@IHoverService private readonly hoverService: IHoverService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IChatEntitlementService private readonly chatEntitlementService: ChatEntitlementService,
+		@IAccountProfileImageService private readonly accountProfileImageService: IAccountProfileImageService,
+		@ILogService private readonly logService: ILogService,
 	) {
 		super(undefined, action, options);
 		this.lastState = getAccountTitleBarState({
@@ -237,6 +242,7 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 		this.accountName = info?.accountName;
 		this.accountProviderId = info?.accountProviderId;
 		this.accountProviderLabel = info?.accountProviderLabel;
+		this.accountSessionId = info?.accountSessionId;
 		this.isAccountLoading = false;
 		this.refreshAvatar();
 		this.renderState();
@@ -300,59 +306,72 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 	}
 
 	private getAvatarAltText(hasLoadedAvatar: boolean): string {
-		if (hasLoadedAvatar && this.accountProviderId === 'github' && this.accountName) {
+		if (hasLoadedAvatar && isGitHubAuthenticationProvider(this.accountProviderId) && this.accountName) {
 			return localize('accountAvatarAlt', "GitHub profile image for {0}", this.accountName);
 		}
 
 		return localize('accountAvatarAltFallback', "Account profile image");
 	}
 
-	private refreshAvatar(): void {
-		const avatarUrl = getAccountProfileImageUrl(this.accountProviderId, this.accountName);
-		if (avatarUrl === this.currentAvatarUrl) {
-			return;
-		}
-
-		this.currentAvatarUrl = avatarUrl;
-		this.loadedAvatarUrl = undefined;
-		this.avatarLoadDisposable.clear();
+	private async refreshAvatar(): Promise<void> {
 		const requestId = ++this.avatarRequestCounter;
 
-		if (!avatarUrl) {
-			this.renderState();
-			return;
-		}
-
-		const image = new Image();
-		image.referrerPolicy = 'no-referrer';
-		const clearHandlers = () => {
-			image.onload = null;
-			image.onerror = null;
-		};
-		image.onload = () => {
+		try {
+			const avatarUrl = await this.accountProfileImageService.getProfileImageUrl({
+				providerId: this.accountProviderId,
+				accountName: this.accountName,
+				sessionId: this.accountSessionId,
+			});
 			if (requestId !== this.avatarRequestCounter) {
 				return;
 			}
 
-			this.loadedAvatarUrl = avatarUrl;
-			this.renderState();
-			clearHandlers();
-		};
-		image.onerror = () => {
-			if (requestId !== this.avatarRequestCounter) {
+			if (avatarUrl === this.currentAvatarUrl && this.loadedAvatarUrl) {
 				return;
 			}
 
+			this.currentAvatarUrl = avatarUrl;
 			this.loadedAvatarUrl = undefined;
+			this.avatarLoadDisposable.clear();
+
+			if (!avatarUrl) {
+				this.renderState();
+				return;
+			}
+
+			const image = new Image();
+			image.referrerPolicy = 'no-referrer';
+			const clearHandlers = () => {
+				image.onload = null;
+				image.onerror = null;
+			};
+			image.onload = () => {
+				if (requestId !== this.avatarRequestCounter) {
+					return;
+				}
+
+				this.loadedAvatarUrl = avatarUrl;
+				this.renderState();
+				clearHandlers();
+			};
+			image.onerror = () => {
+				if (requestId !== this.avatarRequestCounter) {
+					return;
+				}
+
+				this.loadedAvatarUrl = undefined;
+				this.renderState();
+				clearHandlers();
+			};
+			this.avatarLoadDisposable.value = toDisposable(() => {
+				clearHandlers();
+				image.src = '';
+			});
+			image.src = avatarUrl;
 			this.renderState();
-			clearHandlers();
-		};
-		this.avatarLoadDisposable.value = toDisposable(() => {
-			clearHandlers();
-			image.src = '';
-		});
-		image.src = avatarUrl;
-		this.renderState();
+		} catch (error) {
+			this.logService.error(error);
+		}
 	}
 
 	private getHoverTarget(): { targetElements: HTMLElement[]; x: number } {

--- a/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
+++ b/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
@@ -154,7 +154,6 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 	private accountName: string | undefined;
 	private accountProviderId: string | undefined;
 	private accountProviderLabel: string | undefined;
-	private accountSessionId: string | undefined;
 	private isAccountLoading = true;
 	private accountRequestCounter = 0;
 	private avatarRequestCounter = 0;
@@ -242,7 +241,6 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 		this.accountName = info?.accountName;
 		this.accountProviderId = info?.accountProviderId;
 		this.accountProviderLabel = info?.accountProviderLabel;
-		this.accountSessionId = info?.accountSessionId;
 		this.isAccountLoading = false;
 		this.refreshAvatar();
 		this.renderState();
@@ -317,11 +315,7 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 		const requestId = ++this.avatarRequestCounter;
 
 		try {
-			const avatarUrl = await this.accountProfileImageService.getProfileImageUrl({
-				providerId: this.accountProviderId,
-				accountName: this.accountName,
-				sessionId: this.accountSessionId,
-			});
+			const avatarUrl = await this.accountProfileImageService.getDefaultProfileImageUrl();
 			if (requestId !== this.avatarRequestCounter) {
 				return;
 			}

--- a/src/vs/sessions/contrib/accountMenu/test/browser/accountTitleBarState.test.ts
+++ b/src/vs/sessions/contrib/accountMenu/test/browser/accountTitleBarState.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { ChatEntitlement } from '../../../../../workbench/services/chat/common/chatEntitlementService.js';
-import { getAccountProfileImageUrl, getAccountTitleBarBadgeKey, getAccountTitleBarState, IAccountTitleBarStateContext } from '../../../../browser/accountTitleBarState.js';
+import { getAccountTitleBarBadgeKey, getAccountTitleBarState, IAccountTitleBarStateContext } from '../../../../browser/accountTitleBarState.js';
 
 suite('Sessions - Account Title Bar State', () => {
 
@@ -144,16 +144,4 @@ suite('Sessions - Account Title Bar State', () => {
 		});
 	});
 
-	test('returns a GitHub profile image URL for GitHub accounts', () => {
-		assert.strictEqual(
-			getAccountProfileImageUrl('github', 'mona lisa'),
-			'https://github.com/mona%20lisa.png?size=64'
-		);
-	});
-
-	test('falls back to the codicon when no GitHub profile image URL is available', () => {
-		assert.strictEqual(getAccountProfileImageUrl(undefined, 'octocat'), undefined);
-		assert.strictEqual(getAccountProfileImageUrl('github-enterprise', 'octocat'), undefined);
-		assert.strictEqual(getAccountProfileImageUrl('github', undefined), undefined);
-	});
 });

--- a/src/vs/sessions/sessions.common.main.ts
+++ b/src/vs/sessions/sessions.common.main.ts
@@ -123,6 +123,7 @@ import '../workbench/services/authentication/browser/authenticationMcpAccessServ
 import '../workbench/services/authentication/browser/authenticationMcpService.js';
 import '../workbench/services/authentication/browser/dynamicAuthenticationProviderStorageService.js';
 import '../workbench/services/authentication/browser/authenticationQueryService.js';
+import '../workbench/services/accounts/common/accountProfileImageService.js';
 import '../platform/hover/browser/hoverService.js';
 import '../platform/userInteraction/browser/userInteractionServiceImpl.js';
 import '../workbench/services/assignment/common/assignmentService.js';

--- a/src/vs/workbench/browser/parts/activitybar/media/activityaction.css
+++ b/src/vs/workbench/browser/parts/activitybar/media/activityaction.css
@@ -53,7 +53,7 @@
 
 }
 
-.monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-label:not(.codicon) {
+.monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-label:not(.codicon):not(.workbench-account-profile-image-container) {
 	font-size: 15px;
 	line-height: var(--activity-bar-action-height, 48px);
 	padding: 0 0 0 var(--activity-bar-width, 48px);
@@ -63,6 +63,24 @@
 	font-size: var(--activity-bar-icon-size, 24px);
 	align-items: center;
 	justify-content: center;
+}
+
+.monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-label.workbench-account-profile-image-container {
+	align-items: center;
+	justify-content: center;
+	padding: 0;
+}
+
+.monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-label .workbench-account-profile-image {
+	display: none;
+	width: var(--activity-bar-icon-size, 24px);
+	height: var(--activity-bar-icon-size, 24px);
+	border-radius: 50%;
+	object-fit: cover;
+}
+
+.monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-label.workbench-account-profile-image-container .workbench-account-profile-image {
+	display: block;
 }
 
 .monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item.active .action-label.codicon,

--- a/src/vs/workbench/browser/parts/globalCompositeBar.ts
+++ b/src/vs/workbench/browser/parts/globalCompositeBar.ts
@@ -275,6 +275,7 @@ export class AccountsActivityActionViewItem extends AbstractGlobalActivityAction
 	private accountProfileImageElement: HTMLImageElement | undefined;
 	private currentProfileImageUrl: string | undefined;
 	private loadedProfileImageUrl: string | undefined;
+	private profileImageLoadState: 'idle' | 'loading' | 'loaded' | 'failed' = 'idle';
 	private profileImageResolveRequestCounter = 0;
 	private profileImageLoadRequestCounter = 0;
 
@@ -613,57 +614,65 @@ export class AccountsActivityActionViewItem extends AbstractGlobalActivityAction
 	}
 
 	private async refreshAccountProfileImage(): Promise<void> {
-		const requestId = ++this.profileImageResolveRequestCounter;
-		const account = await this.resolveGitHubAccountProfileImageInfo();
-		if (requestId !== this.profileImageResolveRequestCounter) {
-			return;
-		}
-
-		const profileImageUrl = getGitHubAccountProfileImageUrl(account?.accountName, account?.baseUrl);
-		if (profileImageUrl === this.currentProfileImageUrl) {
-			return;
-		}
-
-		this.currentProfileImageUrl = profileImageUrl;
-		this.loadedProfileImageUrl = undefined;
-		this.avatarLoadDisposable.clear();
-		const loadRequestId = ++this.profileImageLoadRequestCounter;
-
-		if (!profileImageUrl) {
-			this.updateAccountProfileImage();
-			return;
-		}
-
-		const image = new Image();
-		image.referrerPolicy = 'no-referrer';
-		const clearHandlers = () => {
-			image.onload = null;
-			image.onerror = null;
-		};
-		image.onload = () => {
-			if (loadRequestId !== this.profileImageLoadRequestCounter) {
+		try {
+			const requestId = ++this.profileImageResolveRequestCounter;
+			const account = await this.resolveGitHubAccountProfileImageInfo();
+			if (requestId !== this.profileImageResolveRequestCounter) {
 				return;
 			}
 
-			this.loadedProfileImageUrl = profileImageUrl;
-			this.updateAccountProfileImage();
-			clearHandlers();
-		};
-		image.onerror = () => {
-			if (loadRequestId !== this.profileImageLoadRequestCounter) {
+			const profileImageUrl = getGitHubAccountProfileImageUrl(account?.accountName, account?.baseUrl);
+			if (profileImageUrl === this.currentProfileImageUrl && this.profileImageLoadState !== 'failed') {
 				return;
 			}
 
+			this.currentProfileImageUrl = profileImageUrl;
 			this.loadedProfileImageUrl = undefined;
+			this.avatarLoadDisposable.clear();
+			const loadRequestId = ++this.profileImageLoadRequestCounter;
+
+			if (!profileImageUrl) {
+				this.profileImageLoadState = 'idle';
+				this.updateAccountProfileImage();
+				return;
+			}
+
+			this.profileImageLoadState = 'loading';
+			const image = new Image();
+			image.referrerPolicy = 'no-referrer';
+			const clearHandlers = () => {
+				image.onload = null;
+				image.onerror = null;
+			};
+			image.onload = () => {
+				if (loadRequestId !== this.profileImageLoadRequestCounter) {
+					return;
+				}
+
+				this.profileImageLoadState = 'loaded';
+				this.loadedProfileImageUrl = profileImageUrl;
+				this.updateAccountProfileImage();
+				clearHandlers();
+			};
+			image.onerror = () => {
+				if (loadRequestId !== this.profileImageLoadRequestCounter) {
+					return;
+				}
+
+				this.profileImageLoadState = 'failed';
+				this.loadedProfileImageUrl = undefined;
+				this.updateAccountProfileImage();
+				clearHandlers();
+			};
+			this.avatarLoadDisposable.value = toDisposable(() => {
+				clearHandlers();
+				image.src = '';
+			});
+			image.src = profileImageUrl;
 			this.updateAccountProfileImage();
-			clearHandlers();
-		};
-		this.avatarLoadDisposable.value = toDisposable(() => {
-			clearHandlers();
-			image.src = '';
-		});
-		image.src = profileImageUrl;
-		this.updateAccountProfileImage();
+		} catch (error) {
+			this.logService.error(error);
+		}
 	}
 
 	private async resolveGitHubAccountProfileImageInfo(): Promise<{ accountName: string; baseUrl: string } | undefined> {
@@ -699,7 +708,12 @@ export class AccountsActivityActionViewItem extends AbstractGlobalActivityAction
 		}
 
 		if (providerId === GITHUB_ENTERPRISE_AUTH_PROVIDER_ID) {
-			const value = this.configurationService.getValue<string | undefined>(this.productService.defaultChatAgent.providerUriSetting);
+			const providerUriSetting = this.productService.defaultChatAgent.providerUriSetting;
+			if (!providerUriSetting) {
+				return GITHUB_DOTCOM_URL;
+			}
+
+			const value = this.configurationService.getValue<string | undefined>(providerUriSetting);
 			if (value) {
 				try {
 					const enterpriseUrl = new URL(value);

--- a/src/vs/workbench/browser/parts/globalCompositeBar.ts
+++ b/src/vs/workbench/browser/parts/globalCompositeBar.ts
@@ -293,7 +293,7 @@ export class AccountsActivityActionViewItem extends AbstractGlobalActivityAction
 		@IDefaultAccountService private readonly defaultAccountService: IDefaultAccountService,
 		@IWorkbenchEnvironmentService environmentService: IWorkbenchEnvironmentService,
 		@IProductService private readonly productService: IProductService,
-		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IConfigurationService configurationService: IConfigurationService,
 		@IKeybindingService keybindingService: IKeybindingService,
 		@ISecretStorageService private readonly secretStorageService: ISecretStorageService,
 		@ILogService private readonly logService: ILogService,

--- a/src/vs/workbench/browser/parts/globalCompositeBar.ts
+++ b/src/vs/workbench/browser/parts/globalCompositeBar.ts
@@ -45,12 +45,7 @@ import { KeyCode } from '../../../base/common/keyCodes.js';
 import { ACTIVITY_BAR_BADGE_BACKGROUND, ACTIVITY_BAR_BADGE_FOREGROUND } from '../../common/theme.js';
 import { IBaseActionViewItemOptions } from '../../../base/browser/ui/actionbar/actionViewItems.js';
 import { ICommandService } from '../../../platform/commands/common/commands.js';
-
-const GITHUB_PROFILE_IMAGE_SIZE = 64;
-const GITHUB_AUTH_PROVIDER_ID = 'github';
-const GITHUB_ENTERPRISE_AUTH_PROVIDER_ID = 'github-enterprise';
-const GITHUB_AUTH_PROVIDER_IDS = new Set([GITHUB_AUTH_PROVIDER_ID, GITHUB_ENTERPRISE_AUTH_PROVIDER_ID]);
-const GITHUB_DOTCOM_URL = 'https://github.com/';
+import { IAccountProfileImageService, GITHUB_AUTH_PROVIDER_ID, GITHUB_ENTERPRISE_AUTH_PROVIDER_ID, isGitHubAuthenticationProvider } from '../../services/accounts/common/accountProfileImage.js';
 
 export class GlobalCompositeBar extends Disposable {
 
@@ -298,6 +293,7 @@ export class AccountsActivityActionViewItem extends AbstractGlobalActivityAction
 		@IKeybindingService keybindingService: IKeybindingService,
 		@ISecretStorageService private readonly secretStorageService: ISecretStorageService,
 		@ILogService private readonly logService: ILogService,
+		@IAccountProfileImageService private readonly accountProfileImageService: IAccountProfileImageService,
 		@IActivityService activityService: IActivityService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@ICommandService private readonly commandService: ICommandService
@@ -316,7 +312,7 @@ export class AccountsActivityActionViewItem extends AbstractGlobalActivityAction
 	private registerListeners(): void {
 		this._register(this.authenticationService.onDidRegisterAuthenticationProvider(async (e) => {
 			await this.addAccountsFromProvider(e.id);
-			if (this.isGitHubProvider(e.id)) {
+			if (isGitHubAuthenticationProvider(e.id)) {
 				this.refreshAccountProfileImage();
 			}
 		}));
@@ -324,7 +320,7 @@ export class AccountsActivityActionViewItem extends AbstractGlobalActivityAction
 		this._register(this.authenticationService.onDidUnregisterAuthenticationProvider((e) => {
 			this.groupedAccounts.delete(e.id);
 			this.problematicProviders.delete(e.id);
-			if (this.isGitHubProvider(e.id)) {
+			if (isGitHubAuthenticationProvider(e.id)) {
 				this.refreshAccountProfileImage();
 			}
 		}));
@@ -342,7 +338,7 @@ export class AccountsActivityActionViewItem extends AbstractGlobalActivityAction
 					this.logService.error(e);
 				}
 			}
-			if (this.isGitHubProvider(e.providerId)) {
+			if (isGitHubAuthenticationProvider(e.providerId)) {
 				this.refreshAccountProfileImage();
 			}
 		}));
@@ -616,12 +612,11 @@ export class AccountsActivityActionViewItem extends AbstractGlobalActivityAction
 	private async refreshAccountProfileImage(): Promise<void> {
 		try {
 			const requestId = ++this.profileImageResolveRequestCounter;
-			const account = await this.resolveGitHubAccountProfileImageInfo();
+			const profileImageUrl = await this.resolveAccountProfileImageUrl();
 			if (requestId !== this.profileImageResolveRequestCounter) {
 				return;
 			}
 
-			const profileImageUrl = getGitHubAccountProfileImageUrl(account?.accountName, account?.baseUrl);
 			if (profileImageUrl === this.currentProfileImageUrl && this.profileImageLoadState !== 'failed') {
 				return;
 			}
@@ -675,56 +670,29 @@ export class AccountsActivityActionViewItem extends AbstractGlobalActivityAction
 		}
 	}
 
-	private async resolveGitHubAccountProfileImageInfo(): Promise<{ accountName: string; baseUrl: string } | undefined> {
-		const defaultAccount = await this.defaultAccountService.getDefaultAccount();
-		if (defaultAccount && this.isGitHubProvider(defaultAccount.authenticationProvider.id)) {
-			return {
-				accountName: defaultAccount.accountName,
-				baseUrl: this.defaultAccountService.resolveGitHubUrl(''),
-			};
+	private async resolveAccountProfileImageUrl(): Promise<string | undefined> {
+		const defaultProfileImageUrl = await this.accountProfileImageService.getDefaultProfileImageUrl();
+		if (defaultProfileImageUrl) {
+			return defaultProfileImageUrl;
 		}
 
 		const defaultAccountProvider = this.defaultAccountService.getDefaultAccountAuthenticationProvider();
-		const preferredProviderIds = this.isGitHubProvider(defaultAccountProvider.id)
-			? [defaultAccountProvider.id, ...[...GITHUB_AUTH_PROVIDER_IDS].filter(providerId => providerId !== defaultAccountProvider.id)]
-			: [...GITHUB_AUTH_PROVIDER_IDS];
+		const providerIds = [GITHUB_AUTH_PROVIDER_ID, GITHUB_ENTERPRISE_AUTH_PROVIDER_ID];
+		const preferredProviderIds = isGitHubAuthenticationProvider(defaultAccountProvider.id)
+			? [defaultAccountProvider.id, ...providerIds.filter(providerId => providerId !== defaultAccountProvider.id)]
+			: providerIds;
 
 		for (const providerId of preferredProviderIds) {
 			const accounts = this.groupedAccounts.get(providerId);
 			if (accounts?.length) {
-				return {
+				return this.accountProfileImageService.getProfileImageUrl({
+					providerId,
 					accountName: accounts[0].label,
-					baseUrl: this.getGitHubProviderBaseUrl(providerId),
-				};
+				});
 			}
 		}
 
 		return undefined;
-	}
-
-	private getGitHubProviderBaseUrl(providerId: string): string {
-		if (providerId === this.defaultAccountService.getDefaultAccountAuthenticationProvider().id) {
-			return this.defaultAccountService.resolveGitHubUrl('');
-		}
-
-		if (providerId === GITHUB_ENTERPRISE_AUTH_PROVIDER_ID) {
-			const providerUriSetting = this.productService.defaultChatAgent.providerUriSetting;
-			if (!providerUriSetting) {
-				return GITHUB_DOTCOM_URL;
-			}
-
-			const value = this.configurationService.getValue<string | undefined>(providerUriSetting);
-			if (value) {
-				try {
-					const enterpriseUrl = new URL(value);
-					return `${enterpriseUrl.protocol}//${enterpriseUrl.host}/`;
-				} catch (error) {
-					this.logService.error(error);
-				}
-			}
-		}
-
-		return GITHUB_DOTCOM_URL;
 	}
 
 	private updateAccountProfileImage(): void {
@@ -756,17 +724,6 @@ export class AccountsActivityActionViewItem extends AbstractGlobalActivityAction
 
 	//#endregion
 
-	private isGitHubProvider(providerId: string): boolean {
-		return GITHUB_AUTH_PROVIDER_IDS.has(providerId);
-	}
-}
-
-function getGitHubAccountProfileImageUrl(accountName: string | undefined, baseUrl = GITHUB_DOTCOM_URL): string | undefined {
-	if (!accountName?.trim()) {
-		return undefined;
-	}
-
-	return new URL(`${encodeURIComponent(accountName.trim())}.png?size=${GITHUB_PROFILE_IMAGE_SIZE}`, baseUrl).toString();
 }
 
 export class GlobalActivityActionViewItem extends AbstractGlobalActivityActionViewItem {
@@ -868,6 +825,7 @@ export class SimpleAccountActivityActionViewItem extends AccountsActivityActionV
 		@ISecretStorageService secretStorageService: ISecretStorageService,
 		@IStorageService storageService: IStorageService,
 		@ILogService logService: ILogService,
+		@IAccountProfileImageService accountProfileImageService: IAccountProfileImageService,
 		@IActivityService activityService: IActivityService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@ICommandService commandService: ICommandService
@@ -881,7 +839,7 @@ export class SimpleAccountActivityActionViewItem extends AccountsActivityActionV
 				}),
 				hoverOptions,
 				compact: true,
-			}, () => undefined, actions => actions, themeService, lifecycleService, hoverService, contextMenuService, menuService, contextKeyService, authenticationService, defaultAccountService, environmentService, productService, configurationService, keybindingService, secretStorageService, logService, activityService, instantiationService, commandService);
+			}, () => undefined, actions => actions, themeService, lifecycleService, hoverService, contextMenuService, menuService, contextKeyService, authenticationService, defaultAccountService, environmentService, productService, configurationService, keybindingService, secretStorageService, logService, accountProfileImageService, activityService, instantiationService, commandService);
 	}
 }
 

--- a/src/vs/workbench/browser/parts/globalCompositeBar.ts
+++ b/src/vs/workbench/browser/parts/globalCompositeBar.ts
@@ -28,6 +28,7 @@ import { getActionBarActions } from '../../../platform/actions/browser/menuEntry
 import { IConfigurationService } from '../../../platform/configuration/common/configuration.js';
 import { IContextKeyService } from '../../../platform/contextkey/common/contextkey.js';
 import { IContextMenuService } from '../../../platform/contextview/browser/contextView.js';
+import { IDefaultAccountService } from '../../../platform/defaultAccount/common/defaultAccount.js';
 import { IKeybindingService } from '../../../platform/keybinding/common/keybinding.js';
 import { ILogService } from '../../../platform/log/common/log.js';
 import { IProductService } from '../../../platform/product/common/productService.js';
@@ -45,8 +46,11 @@ import { ACTIVITY_BAR_BADGE_BACKGROUND, ACTIVITY_BAR_BADGE_FOREGROUND } from '..
 import { IBaseActionViewItemOptions } from '../../../base/browser/ui/actionbar/actionViewItems.js';
 import { ICommandService } from '../../../platform/commands/common/commands.js';
 
-const GITHUB_AUTH_PROVIDER_ID = 'github';
 const GITHUB_PROFILE_IMAGE_SIZE = 64;
+const GITHUB_AUTH_PROVIDER_ID = 'github';
+const GITHUB_ENTERPRISE_AUTH_PROVIDER_ID = 'github-enterprise';
+const GITHUB_AUTH_PROVIDER_IDS = new Set([GITHUB_AUTH_PROVIDER_ID, GITHUB_ENTERPRISE_AUTH_PROVIDER_ID]);
+const GITHUB_DOTCOM_URL = 'https://github.com/';
 
 export class GlobalCompositeBar extends Disposable {
 
@@ -271,7 +275,8 @@ export class AccountsActivityActionViewItem extends AbstractGlobalActivityAction
 	private accountProfileImageElement: HTMLImageElement | undefined;
 	private currentProfileImageUrl: string | undefined;
 	private loadedProfileImageUrl: string | undefined;
-	private profileImageRequestCounter = 0;
+	private profileImageResolveRequestCounter = 0;
+	private profileImageLoadRequestCounter = 0;
 
 	constructor(
 		contextMenuActionsProvider: () => IAction[],
@@ -285,9 +290,10 @@ export class AccountsActivityActionViewItem extends AbstractGlobalActivityAction
 		@IMenuService menuService: IMenuService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IAuthenticationService private readonly authenticationService: IAuthenticationService,
+		@IDefaultAccountService private readonly defaultAccountService: IDefaultAccountService,
 		@IWorkbenchEnvironmentService environmentService: IWorkbenchEnvironmentService,
 		@IProductService private readonly productService: IProductService,
-		@IConfigurationService configurationService: IConfigurationService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IKeybindingService keybindingService: IKeybindingService,
 		@ISecretStorageService private readonly secretStorageService: ISecretStorageService,
 		@ILogService private readonly logService: ILogService,
@@ -309,7 +315,7 @@ export class AccountsActivityActionViewItem extends AbstractGlobalActivityAction
 	private registerListeners(): void {
 		this._register(this.authenticationService.onDidRegisterAuthenticationProvider(async (e) => {
 			await this.addAccountsFromProvider(e.id);
-			if (e.id === GITHUB_AUTH_PROVIDER_ID) {
+			if (this.isGitHubProvider(e.id)) {
 				this.refreshAccountProfileImage();
 			}
 		}));
@@ -317,7 +323,7 @@ export class AccountsActivityActionViewItem extends AbstractGlobalActivityAction
 		this._register(this.authenticationService.onDidUnregisterAuthenticationProvider((e) => {
 			this.groupedAccounts.delete(e.id);
 			this.problematicProviders.delete(e.id);
-			if (e.id === GITHUB_AUTH_PROVIDER_ID) {
+			if (this.isGitHubProvider(e.id)) {
 				this.refreshAccountProfileImage();
 			}
 		}));
@@ -335,10 +341,12 @@ export class AccountsActivityActionViewItem extends AbstractGlobalActivityAction
 					this.logService.error(e);
 				}
 			}
-			if (e.providerId === GITHUB_AUTH_PROVIDER_ID) {
+			if (this.isGitHubProvider(e.providerId)) {
 				this.refreshAccountProfileImage();
 			}
 		}));
+
+		this._register(this.defaultAccountService.onDidChangeDefaultAccount(() => this.refreshAccountProfileImage()));
 	}
 
 	// This function exists to ensure that the accounts are added for auth providers that had already been registered
@@ -604,8 +612,14 @@ export class AccountsActivityActionViewItem extends AbstractGlobalActivityAction
 		this.updateAccountProfileImage();
 	}
 
-	private refreshAccountProfileImage(): void {
-		const profileImageUrl = getGitHubAccountProfileImageUrl(this.groupedAccounts.get(GITHUB_AUTH_PROVIDER_ID)?.[0]?.label);
+	private async refreshAccountProfileImage(): Promise<void> {
+		const requestId = ++this.profileImageResolveRequestCounter;
+		const account = await this.resolveGitHubAccountProfileImageInfo();
+		if (requestId !== this.profileImageResolveRequestCounter) {
+			return;
+		}
+
+		const profileImageUrl = getGitHubAccountProfileImageUrl(account?.accountName, account?.baseUrl);
 		if (profileImageUrl === this.currentProfileImageUrl) {
 			return;
 		}
@@ -613,7 +627,7 @@ export class AccountsActivityActionViewItem extends AbstractGlobalActivityAction
 		this.currentProfileImageUrl = profileImageUrl;
 		this.loadedProfileImageUrl = undefined;
 		this.avatarLoadDisposable.clear();
-		const requestId = ++this.profileImageRequestCounter;
+		const loadRequestId = ++this.profileImageLoadRequestCounter;
 
 		if (!profileImageUrl) {
 			this.updateAccountProfileImage();
@@ -627,7 +641,7 @@ export class AccountsActivityActionViewItem extends AbstractGlobalActivityAction
 			image.onerror = null;
 		};
 		image.onload = () => {
-			if (requestId !== this.profileImageRequestCounter) {
+			if (loadRequestId !== this.profileImageLoadRequestCounter) {
 				return;
 			}
 
@@ -636,7 +650,7 @@ export class AccountsActivityActionViewItem extends AbstractGlobalActivityAction
 			clearHandlers();
 		};
 		image.onerror = () => {
-			if (requestId !== this.profileImageRequestCounter) {
+			if (loadRequestId !== this.profileImageLoadRequestCounter) {
 				return;
 			}
 
@@ -650,6 +664,53 @@ export class AccountsActivityActionViewItem extends AbstractGlobalActivityAction
 		});
 		image.src = profileImageUrl;
 		this.updateAccountProfileImage();
+	}
+
+	private async resolveGitHubAccountProfileImageInfo(): Promise<{ accountName: string; baseUrl: string } | undefined> {
+		const defaultAccount = await this.defaultAccountService.getDefaultAccount();
+		if (defaultAccount && this.isGitHubProvider(defaultAccount.authenticationProvider.id)) {
+			return {
+				accountName: defaultAccount.accountName,
+				baseUrl: this.defaultAccountService.resolveGitHubUrl(''),
+			};
+		}
+
+		const defaultAccountProvider = this.defaultAccountService.getDefaultAccountAuthenticationProvider();
+		const preferredProviderIds = this.isGitHubProvider(defaultAccountProvider.id)
+			? [defaultAccountProvider.id, ...[...GITHUB_AUTH_PROVIDER_IDS].filter(providerId => providerId !== defaultAccountProvider.id)]
+			: [...GITHUB_AUTH_PROVIDER_IDS];
+
+		for (const providerId of preferredProviderIds) {
+			const accounts = this.groupedAccounts.get(providerId);
+			if (accounts?.length) {
+				return {
+					accountName: accounts[0].label,
+					baseUrl: this.getGitHubProviderBaseUrl(providerId),
+				};
+			}
+		}
+
+		return undefined;
+	}
+
+	private getGitHubProviderBaseUrl(providerId: string): string {
+		if (providerId === this.defaultAccountService.getDefaultAccountAuthenticationProvider().id) {
+			return this.defaultAccountService.resolveGitHubUrl('');
+		}
+
+		if (providerId === GITHUB_ENTERPRISE_AUTH_PROVIDER_ID) {
+			const value = this.configurationService.getValue<string | undefined>(this.productService.defaultChatAgent.providerUriSetting);
+			if (value) {
+				try {
+					const enterpriseUrl = new URL(value);
+					return `${enterpriseUrl.protocol}//${enterpriseUrl.host}/`;
+				} catch (error) {
+					this.logService.error(error);
+				}
+			}
+		}
+
+		return GITHUB_DOTCOM_URL;
 	}
 
 	private updateAccountProfileImage(): void {
@@ -680,14 +741,18 @@ export class AccountsActivityActionViewItem extends AbstractGlobalActivityAction
 	}
 
 	//#endregion
+
+	private isGitHubProvider(providerId: string): boolean {
+		return GITHUB_AUTH_PROVIDER_IDS.has(providerId);
+	}
 }
 
-function getGitHubAccountProfileImageUrl(accountName: string | undefined): string | undefined {
+function getGitHubAccountProfileImageUrl(accountName: string | undefined, baseUrl = GITHUB_DOTCOM_URL): string | undefined {
 	if (!accountName?.trim()) {
 		return undefined;
 	}
 
-	return `https://github.com/${encodeURIComponent(accountName.trim())}.png?size=${GITHUB_PROFILE_IMAGE_SIZE}`;
+	return new URL(`${encodeURIComponent(accountName.trim())}.png?size=${GITHUB_PROFILE_IMAGE_SIZE}`, baseUrl).toString();
 }
 
 export class GlobalActivityActionViewItem extends AbstractGlobalActivityActionViewItem {
@@ -781,6 +846,7 @@ export class SimpleAccountActivityActionViewItem extends AccountsActivityActionV
 		@IMenuService menuService: IMenuService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IAuthenticationService authenticationService: IAuthenticationService,
+		@IDefaultAccountService defaultAccountService: IDefaultAccountService,
 		@IWorkbenchEnvironmentService environmentService: IWorkbenchEnvironmentService,
 		@IProductService productService: IProductService,
 		@IConfigurationService configurationService: IConfigurationService,
@@ -801,7 +867,7 @@ export class SimpleAccountActivityActionViewItem extends AccountsActivityActionV
 				}),
 				hoverOptions,
 				compact: true,
-			}, () => undefined, actions => actions, themeService, lifecycleService, hoverService, contextMenuService, menuService, contextKeyService, authenticationService, environmentService, productService, configurationService, keybindingService, secretStorageService, logService, activityService, instantiationService, commandService);
+			}, () => undefined, actions => actions, themeService, lifecycleService, hoverService, contextMenuService, menuService, contextKeyService, authenticationService, defaultAccountService, environmentService, productService, configurationService, keybindingService, secretStorageService, logService, activityService, instantiationService, commandService);
 	}
 }
 

--- a/src/vs/workbench/browser/parts/globalCompositeBar.ts
+++ b/src/vs/workbench/browser/parts/globalCompositeBar.ts
@@ -45,7 +45,7 @@ import { KeyCode } from '../../../base/common/keyCodes.js';
 import { ACTIVITY_BAR_BADGE_BACKGROUND, ACTIVITY_BAR_BADGE_FOREGROUND } from '../../common/theme.js';
 import { IBaseActionViewItemOptions } from '../../../base/browser/ui/actionbar/actionViewItems.js';
 import { ICommandService } from '../../../platform/commands/common/commands.js';
-import { IAccountProfileImageService, GITHUB_AUTH_PROVIDER_ID, GITHUB_ENTERPRISE_AUTH_PROVIDER_ID, isGitHubAuthenticationProvider } from '../../services/accounts/common/accountProfileImage.js';
+import { IAccountProfileImageService, isGitHubAuthenticationProvider } from '../../services/accounts/common/accountProfileImage.js';
 
 export class GlobalCompositeBar extends Disposable {
 
@@ -603,7 +603,7 @@ export class AccountsActivityActionViewItem extends AbstractGlobalActivityAction
 	override render(container: HTMLElement): void {
 		super.render(container);
 
-		this.accountProfileImageElement = append(this.label, $('img.workbench-account-profile-image', { 'aria-hidden': 'true', draggable: 'false' })) as HTMLImageElement;
+		this.accountProfileImageElement = append(this.label, $('img.workbench-account-profile-image', { 'aria-hidden': 'true', alt: '', draggable: 'false' })) as HTMLImageElement;
 		this.accountProfileImageElement.decoding = 'async';
 		this.accountProfileImageElement.referrerPolicy = 'no-referrer';
 		this.updateAccountProfileImage();
@@ -671,28 +671,7 @@ export class AccountsActivityActionViewItem extends AbstractGlobalActivityAction
 	}
 
 	private async resolveAccountProfileImageUrl(): Promise<string | undefined> {
-		const defaultProfileImageUrl = await this.accountProfileImageService.getDefaultProfileImageUrl();
-		if (defaultProfileImageUrl) {
-			return defaultProfileImageUrl;
-		}
-
-		const defaultAccountProvider = this.defaultAccountService.getDefaultAccountAuthenticationProvider();
-		const providerIds = [GITHUB_AUTH_PROVIDER_ID, GITHUB_ENTERPRISE_AUTH_PROVIDER_ID];
-		const preferredProviderIds = isGitHubAuthenticationProvider(defaultAccountProvider.id)
-			? [defaultAccountProvider.id, ...providerIds.filter(providerId => providerId !== defaultAccountProvider.id)]
-			: providerIds;
-
-		for (const providerId of preferredProviderIds) {
-			const accounts = this.groupedAccounts.get(providerId);
-			if (accounts?.length) {
-				return this.accountProfileImageService.getProfileImageUrl({
-					providerId,
-					accountName: accounts[0].label,
-				});
-			}
-		}
-
-		return undefined;
+		return this.accountProfileImageService.getDefaultProfileImageUrl();
 	}
 
 	private updateAccountProfileImage(): void {

--- a/src/vs/workbench/browser/parts/globalCompositeBar.ts
+++ b/src/vs/workbench/browser/parts/globalCompositeBar.ts
@@ -8,7 +8,7 @@ import { ActionBar, ActionsOrientation } from '../../../base/browser/ui/actionba
 import { ACCOUNTS_ACTIVITY_ID, GLOBAL_ACTIVITY_ID } from '../../common/activity.js';
 import { IActivityService } from '../../services/activity/common/activity.js';
 import { IInstantiationService } from '../../../platform/instantiation/common/instantiation.js';
-import { DisposableStore, Disposable } from '../../../base/common/lifecycle.js';
+import { DisposableStore, Disposable, MutableDisposable, toDisposable } from '../../../base/common/lifecycle.js';
 import { IColorTheme, IThemeService } from '../../../platform/theme/common/themeService.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../platform/storage/common/storage.js';
 import { IExtensionService } from '../../services/extensions/common/extensions.js';
@@ -44,6 +44,9 @@ import { KeyCode } from '../../../base/common/keyCodes.js';
 import { ACTIVITY_BAR_BADGE_BACKGROUND, ACTIVITY_BAR_BADGE_FOREGROUND } from '../../common/theme.js';
 import { IBaseActionViewItemOptions } from '../../../base/browser/ui/actionbar/actionViewItems.js';
 import { ICommandService } from '../../../platform/commands/common/commands.js';
+
+const GITHUB_AUTH_PROVIDER_ID = 'github';
+const GITHUB_PROFILE_IMAGE_SIZE = 64;
 
 export class GlobalCompositeBar extends Disposable {
 
@@ -261,9 +264,14 @@ export class AccountsActivityActionViewItem extends AbstractGlobalActivityAction
 
 	private readonly groupedAccounts: Map<string, (AuthenticationSessionAccount & { canSignOut: boolean })[]> = new Map();
 	private readonly problematicProviders: Set<string> = new Set();
+	private readonly avatarLoadDisposable = this._register(new MutableDisposable());
 
 	private initialized = false;
 	private sessionFromEmbedder = new Lazy<Promise<AuthenticationSessionInfo | undefined>>(() => getCurrentAuthenticationSessionInfo(this.secretStorageService, this.productService));
+	private accountProfileImageElement: HTMLImageElement | undefined;
+	private currentProfileImageUrl: string | undefined;
+	private loadedProfileImageUrl: string | undefined;
+	private profileImageRequestCounter = 0;
 
 	constructor(
 		contextMenuActionsProvider: () => IAction[],
@@ -301,11 +309,17 @@ export class AccountsActivityActionViewItem extends AbstractGlobalActivityAction
 	private registerListeners(): void {
 		this._register(this.authenticationService.onDidRegisterAuthenticationProvider(async (e) => {
 			await this.addAccountsFromProvider(e.id);
+			if (e.id === GITHUB_AUTH_PROVIDER_ID) {
+				this.refreshAccountProfileImage();
+			}
 		}));
 
 		this._register(this.authenticationService.onDidUnregisterAuthenticationProvider((e) => {
 			this.groupedAccounts.delete(e.id);
 			this.problematicProviders.delete(e.id);
+			if (e.id === GITHUB_AUTH_PROVIDER_ID) {
+				this.refreshAccountProfileImage();
+			}
 		}));
 
 		this._register(this.authenticationService.onDidChangeSessions(async e => {
@@ -320,6 +334,9 @@ export class AccountsActivityActionViewItem extends AbstractGlobalActivityAction
 				} catch (e) {
 					this.logService.error(e);
 				}
+			}
+			if (e.providerId === GITHUB_AUTH_PROVIDER_ID) {
+				this.refreshAccountProfileImage();
 			}
 		}));
 	}
@@ -351,6 +368,7 @@ export class AccountsActivityActionViewItem extends AbstractGlobalActivityAction
 		}
 
 		this.initialized = true;
+		this.refreshAccountProfileImage();
 	}
 
 	//#region overrides
@@ -577,7 +595,99 @@ export class AccountsActivityActionViewItem extends AbstractGlobalActivityAction
 		}
 	}
 
+	override render(container: HTMLElement): void {
+		super.render(container);
+
+		this.accountProfileImageElement = append(this.label, $('img.workbench-account-profile-image', { 'aria-hidden': 'true', draggable: 'false' })) as HTMLImageElement;
+		this.accountProfileImageElement.decoding = 'async';
+		this.accountProfileImageElement.referrerPolicy = 'no-referrer';
+		this.updateAccountProfileImage();
+	}
+
+	private refreshAccountProfileImage(): void {
+		const profileImageUrl = getGitHubAccountProfileImageUrl(this.groupedAccounts.get(GITHUB_AUTH_PROVIDER_ID)?.[0]?.label);
+		if (profileImageUrl === this.currentProfileImageUrl) {
+			return;
+		}
+
+		this.currentProfileImageUrl = profileImageUrl;
+		this.loadedProfileImageUrl = undefined;
+		this.avatarLoadDisposable.clear();
+		const requestId = ++this.profileImageRequestCounter;
+
+		if (!profileImageUrl) {
+			this.updateAccountProfileImage();
+			return;
+		}
+
+		const image = new Image();
+		image.referrerPolicy = 'no-referrer';
+		const clearHandlers = () => {
+			image.onload = null;
+			image.onerror = null;
+		};
+		image.onload = () => {
+			if (requestId !== this.profileImageRequestCounter) {
+				return;
+			}
+
+			this.loadedProfileImageUrl = profileImageUrl;
+			this.updateAccountProfileImage();
+			clearHandlers();
+		};
+		image.onerror = () => {
+			if (requestId !== this.profileImageRequestCounter) {
+				return;
+			}
+
+			this.loadedProfileImageUrl = undefined;
+			this.updateAccountProfileImage();
+			clearHandlers();
+		};
+		this.avatarLoadDisposable.value = toDisposable(() => {
+			clearHandlers();
+			image.src = '';
+		});
+		image.src = profileImageUrl;
+		this.updateAccountProfileImage();
+	}
+
+	private updateAccountProfileImage(): void {
+		if (!this.accountProfileImageElement) {
+			return;
+		}
+
+		const action = this.action as CompositeBarAction;
+		const hasLoadedProfileImage = !!this.loadedProfileImageUrl;
+		const classNames = hasLoadedProfileImage
+			? ['workbench-account-profile-image-container']
+			: ThemeIcon.asClassNameArray(GlobalCompositeBar.ACCOUNTS_ICON);
+
+		if (action.compositeBarActionItem.classNames?.join(' ') !== classNames.join(' ')) {
+			action.compositeBarActionItem = {
+				...action.compositeBarActionItem,
+				classNames,
+			};
+		}
+
+		if (this.loadedProfileImageUrl) {
+			if (this.accountProfileImageElement.src !== this.loadedProfileImageUrl) {
+				this.accountProfileImageElement.src = this.loadedProfileImageUrl;
+			}
+		} else {
+			this.accountProfileImageElement.removeAttribute('src');
+		}
+	}
+
 	//#endregion
+}
+
+function getGitHubAccountProfileImageUrl(accountName: string | undefined): string | undefined {
+	if (!accountName?.trim()) {
+		return undefined;
+	}
+
+	return `https://github.com/${encodeURIComponent(accountName.trim())}.png?size=${GITHUB_PROFILE_IMAGE_SIZE}`;
 }
 
 export class GlobalActivityActionViewItem extends AbstractGlobalActivityActionViewItem {

--- a/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
+++ b/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
@@ -440,6 +440,23 @@
 	color: inherit;
 }
 
+.monaco-workbench .part.titlebar > .titlebar-container > .titlebar-right > .action-toolbar-container .action-label.workbench-account-profile-image-container {
+	align-items: center;
+	justify-content: center;
+}
+
+.monaco-workbench .part.titlebar > .titlebar-container > .titlebar-right > .action-toolbar-container .action-label .workbench-account-profile-image {
+	display: none;
+	width: 16px;
+	height: 16px;
+	border-radius: 50%;
+	object-fit: cover;
+}
+
+.monaco-workbench .part.titlebar > .titlebar-container > .titlebar-right > .action-toolbar-container .action-label.workbench-account-profile-image-container .workbench-account-profile-image {
+	display: block;
+}
+
 .monaco-workbench .part.titlebar > .titlebar-container > .titlebar-right > .action-toolbar-container .monaco-action-bar .action-item {
 	display: flex;
 }

--- a/src/vs/workbench/services/accounts/common/accountProfileImage.ts
+++ b/src/vs/workbench/services/accounts/common/accountProfileImage.ts
@@ -12,16 +12,9 @@ export function isGitHubAuthenticationProvider(providerId: string | undefined): 
 	return providerId === GITHUB_AUTH_PROVIDER_ID || providerId === GITHUB_ENTERPRISE_AUTH_PROVIDER_ID;
 }
 
-export interface IAccountProfileImageRequest {
-	readonly providerId: string | undefined;
-	readonly accountName: string | undefined;
-	readonly sessionId?: string;
-}
-
 export const IAccountProfileImageService = createDecorator<IAccountProfileImageService>('accountProfileImageService');
 
 export interface IAccountProfileImageService {
 	readonly _serviceBrand: undefined;
-	getProfileImageUrl(request: IAccountProfileImageRequest): Promise<string | undefined>;
 	getDefaultProfileImageUrl(): Promise<string | undefined>;
 }

--- a/src/vs/workbench/services/accounts/common/accountProfileImage.ts
+++ b/src/vs/workbench/services/accounts/common/accountProfileImage.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+
+export const GITHUB_AUTH_PROVIDER_ID = 'github';
+export const GITHUB_ENTERPRISE_AUTH_PROVIDER_ID = 'github-enterprise';
+
+export function isGitHubAuthenticationProvider(providerId: string | undefined): boolean {
+	return providerId === GITHUB_AUTH_PROVIDER_ID || providerId === GITHUB_ENTERPRISE_AUTH_PROVIDER_ID;
+}
+
+export interface IAccountProfileImageRequest {
+	readonly providerId: string | undefined;
+	readonly accountName: string | undefined;
+	readonly sessionId?: string;
+}
+
+export const IAccountProfileImageService = createDecorator<IAccountProfileImageService>('accountProfileImageService');
+
+export interface IAccountProfileImageService {
+	readonly _serviceBrand: undefined;
+	getProfileImageUrl(request: IAccountProfileImageRequest): Promise<string | undefined>;
+	getDefaultProfileImageUrl(): Promise<string | undefined>;
+}

--- a/src/vs/workbench/services/accounts/common/accountProfileImageService.ts
+++ b/src/vs/workbench/services/accounts/common/accountProfileImageService.ts
@@ -1,0 +1,187 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IDefaultAccountService } from '../../../../platform/defaultAccount/common/defaultAccount.js';
+import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { IProductService } from '../../../../platform/product/common/productService.js';
+import { asJson, IRequestService, isSuccess } from '../../../../platform/request/common/request.js';
+import { AuthenticationSession, IAuthenticationService } from '../../authentication/common/authentication.js';
+import { GITHUB_AUTH_PROVIDER_ID, GITHUB_ENTERPRISE_AUTH_PROVIDER_ID, IAccountProfileImageRequest, IAccountProfileImageService, isGitHubAuthenticationProvider } from './accountProfileImage.js';
+
+const GITHUB_PROFILE_IMAGE_SIZE = 64;
+const GITHUB_DOTCOM_URL = 'https://github.com/';
+const GITHUB_DOTCOM_API_URL = 'https://api.github.com/';
+
+interface IGitHubUserResponse {
+	readonly avatar_url?: string;
+}
+
+class AccountProfileImageService extends Disposable implements IAccountProfileImageService {
+
+	declare readonly _serviceBrand: undefined;
+
+	private readonly profileImageUrlCache = new Map<string, string>();
+	private readonly profileImageUrlRequestCache = new Map<string, Promise<string | undefined>>();
+
+	constructor(
+		@IAuthenticationService private readonly authenticationService: IAuthenticationService,
+		@IDefaultAccountService private readonly defaultAccountService: IDefaultAccountService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@ILogService private readonly logService: ILogService,
+		@IProductService private readonly productService: IProductService,
+		@IRequestService private readonly requestService: IRequestService,
+	) {
+		super();
+	}
+
+	async getDefaultProfileImageUrl(): Promise<string | undefined> {
+		try {
+			const defaultAccount = await this.defaultAccountService.getDefaultAccount();
+			if (!defaultAccount || !isGitHubAuthenticationProvider(defaultAccount.authenticationProvider.id)) {
+				return undefined;
+			}
+
+			return this.getProfileImageUrl({
+				providerId: defaultAccount.authenticationProvider.id,
+				accountName: defaultAccount.accountName,
+				sessionId: defaultAccount.sessionId,
+			});
+		} catch (error) {
+			this.logService.error(error);
+			return undefined;
+		}
+	}
+
+	async getProfileImageUrl(request: IAccountProfileImageRequest): Promise<string | undefined> {
+		try {
+			const accountName = request.accountName?.trim();
+			const providerId = request.providerId;
+			if (!accountName || (providerId !== GITHUB_AUTH_PROVIDER_ID && providerId !== GITHUB_ENTERPRISE_AUTH_PROVIDER_ID)) {
+				return undefined;
+			}
+
+			if (providerId === GITHUB_AUTH_PROVIDER_ID) {
+				return getGitHubAccountProfileImageUrl(accountName, GITHUB_DOTCOM_URL);
+			}
+
+			const apiBaseUrl = this.getGitHubProviderApiBaseUrl(providerId);
+			if (!apiBaseUrl) {
+				return undefined;
+			}
+
+			const cacheKey = `${providerId}:${request.sessionId ?? accountName}:${apiBaseUrl}`;
+			const cached = this.profileImageUrlCache.get(cacheKey);
+			if (cached) {
+				return cached;
+			}
+
+			let pendingRequest = this.profileImageUrlRequestCache.get(cacheKey);
+			if (!pendingRequest) {
+				pendingRequest = this.resolveEnterpriseProfileImageUrl({
+					providerId,
+					accountName,
+					sessionId: request.sessionId,
+				}, apiBaseUrl);
+				this.profileImageUrlRequestCache.set(cacheKey, pendingRequest);
+			}
+
+			try {
+				const avatarUrl = await pendingRequest;
+				if (avatarUrl) {
+					this.profileImageUrlCache.set(cacheKey, avatarUrl);
+				}
+				return avatarUrl;
+			} finally {
+				this.profileImageUrlRequestCache.delete(cacheKey);
+			}
+		} catch (error) {
+			this.logService.error(error);
+			return undefined;
+		}
+	}
+
+	private async resolveEnterpriseProfileImageUrl(request: { readonly providerId: string; readonly accountName: string; readonly sessionId?: string }, apiBaseUrl: string): Promise<string | undefined> {
+		const session = await this.getAccountSession(request.providerId, request.accountName, request.sessionId);
+		if (!session) {
+			return undefined;
+		}
+
+		const response = await this.requestService.request({
+			type: 'GET',
+			url: new URL('user', apiBaseUrl).toString(),
+			disableCache: true,
+			headers: {
+				'Accept': 'application/vnd.github+json',
+				'Authorization': `Bearer ${session.accessToken}`,
+			},
+			callSite: 'accountProfileImage.githubAvatar',
+		}, CancellationToken.None);
+
+		if (!isSuccess(response)) {
+			return undefined;
+		}
+
+		const data = await asJson<IGitHubUserResponse>(response);
+		return data?.avatar_url;
+	}
+
+	private async getAccountSession(providerId: string, accountName: string, sessionId: string | undefined): Promise<AuthenticationSession | undefined> {
+		const sessions = await this.authenticationService.getSessions(providerId);
+		return sessionId
+			? sessions.find(session => session.id === sessionId)
+			: sessions.find(session => session.account.label === accountName);
+	}
+
+	private getGitHubProviderApiBaseUrl(providerId: string): string | undefined {
+		if (providerId === GITHUB_AUTH_PROVIDER_ID) {
+			return GITHUB_DOTCOM_API_URL;
+		}
+
+		const baseUrl = this.getGitHubProviderBaseUrl(providerId);
+		try {
+			const url = new URL(baseUrl);
+			return `${url.protocol}//api.${url.hostname}${url.port ? ':' + url.port : ''}/`;
+		} catch (error) {
+			this.logService.error(error);
+		}
+
+		return undefined;
+	}
+
+	private getGitHubProviderBaseUrl(providerId: string): string {
+		if (providerId === this.defaultAccountService.getDefaultAccountAuthenticationProvider().id) {
+			return this.defaultAccountService.resolveGitHubUrl('');
+		}
+
+		if (providerId === GITHUB_ENTERPRISE_AUTH_PROVIDER_ID) {
+			const providerUriSetting = this.productService.defaultChatAgent.providerUriSetting;
+			if (!providerUriSetting) {
+				return GITHUB_DOTCOM_URL;
+			}
+
+			const value = this.configurationService.getValue<string | undefined>(providerUriSetting);
+			if (value) {
+				try {
+					const enterpriseUrl = new URL(value);
+					return `${enterpriseUrl.protocol}//${enterpriseUrl.host}/`;
+				} catch (error) {
+					this.logService.error(error);
+				}
+			}
+		}
+
+		return GITHUB_DOTCOM_URL;
+	}
+}
+
+function getGitHubAccountProfileImageUrl(accountName: string, baseUrl: string): string {
+	return new URL(`${encodeURIComponent(accountName.trim())}.png?size=${GITHUB_PROFILE_IMAGE_SIZE}`, baseUrl).toString();
+}
+
+registerSingleton(IAccountProfileImageService, AccountProfileImageService, InstantiationType.Delayed);

--- a/src/vs/workbench/services/accounts/common/accountProfileImageService.ts
+++ b/src/vs/workbench/services/accounts/common/accountProfileImageService.ts
@@ -12,7 +12,7 @@ import { ILogService } from '../../../../platform/log/common/log.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
 import { asJson, IRequestService, isSuccess } from '../../../../platform/request/common/request.js';
 import { AuthenticationSession, IAuthenticationService } from '../../authentication/common/authentication.js';
-import { GITHUB_AUTH_PROVIDER_ID, GITHUB_ENTERPRISE_AUTH_PROVIDER_ID, IAccountProfileImageRequest, IAccountProfileImageService, isGitHubAuthenticationProvider } from './accountProfileImage.js';
+import { GITHUB_AUTH_PROVIDER_ID, GITHUB_ENTERPRISE_AUTH_PROVIDER_ID, IAccountProfileImageService, isGitHubAuthenticationProvider } from './accountProfileImage.js';
 
 const GITHUB_PROFILE_IMAGE_SIZE = 64;
 const GITHUB_DOTCOM_URL = 'https://github.com/';
@@ -22,7 +22,13 @@ interface IGitHubUserResponse {
 	readonly avatar_url?: string;
 }
 
-class AccountProfileImageService extends Disposable implements IAccountProfileImageService {
+interface IAccountProfileImageRequest {
+	readonly providerId: string | undefined;
+	readonly accountName: string | undefined;
+	readonly sessionId?: string;
+}
+
+export class AccountProfileImageService extends Disposable implements IAccountProfileImageService {
 
 	declare readonly _serviceBrand: undefined;
 
@@ -58,7 +64,7 @@ class AccountProfileImageService extends Disposable implements IAccountProfileIm
 		}
 	}
 
-	async getProfileImageUrl(request: IAccountProfileImageRequest): Promise<string | undefined> {
+	private async getProfileImageUrl(request: IAccountProfileImageRequest): Promise<string | undefined> {
 		try {
 			const accountName = request.accountName?.trim();
 			const providerId = request.providerId;
@@ -160,7 +166,7 @@ class AccountProfileImageService extends Disposable implements IAccountProfileIm
 		}
 
 		if (providerId === GITHUB_ENTERPRISE_AUTH_PROVIDER_ID) {
-			const providerUriSetting = this.productService.defaultChatAgent.providerUriSetting;
+			const providerUriSetting = this.productService.defaultChatAgent?.providerUriSetting;
 			if (!providerUriSetting) {
 				return GITHUB_DOTCOM_URL;
 			}

--- a/src/vs/workbench/services/accounts/test/browser/accountProfileImageService.test.ts
+++ b/src/vs/workbench/services/accounts/test/browser/accountProfileImageService.test.ts
@@ -1,0 +1,193 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { bufferToStream, VSBuffer } from '../../../../../base/common/buffer.js';
+import { Event } from '../../../../../base/common/event.js';
+import { IDefaultAccount, IDefaultAccountAuthenticationProvider, IPolicyData } from '../../../../../base/common/defaultAccount.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { IDefaultAccountService, ManagedSettingsFetchStatus } from '../../../../../platform/defaultAccount/common/defaultAccount.js';
+import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
+import { IProductService } from '../../../../../platform/product/common/productService.js';
+import { IRequestContext, IRequestOptions } from '../../../../../base/parts/request/common/request.js';
+import { IRequestCompleteEvent, IRequestService } from '../../../../../platform/request/common/request.js';
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { AuthenticationProviderInformation, AuthenticationSession, AuthenticationSessionAccount, AuthenticationSessionsChangeEvent, IAuthenticationCreateSessionOptions, IAuthenticationGetSessionsOptions, IAuthenticationProvider, IAuthenticationService, IAuthenticationWwwAuthenticateRequest } from '../../../authentication/common/authentication.js';
+import { TestProductService } from '../../../../test/common/workbenchTestServices.js';
+import { AccountProfileImageService } from '../../common/accountProfileImageService.js';
+
+suite('AccountProfileImageService', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('returns static GitHub.com profile image URL for github accounts', async () => {
+		const service = createService({
+			defaultAccountService: new TestDefaultAccountService({
+				accountName: 'mona lisa',
+				authenticationProvider: { id: 'github', name: 'GitHub', enterprise: false },
+				sessionId: 'session',
+				enterprise: false,
+			}),
+		});
+
+		assert.strictEqual(
+			await service.getDefaultProfileImageUrl(),
+			'https://github.com/mona%20lisa.png?size=64'
+		);
+	});
+
+	test('fetches and caches GitHub Enterprise avatar URL from API', async () => {
+		const requestService = new TestRequestService({ avatar_url: 'https://ghe.example.com/avatar.png' });
+		const service = createService({
+			requestService,
+			defaultAccountService: new TestDefaultAccountService({
+				accountName: 'mona',
+				authenticationProvider: { id: 'github-enterprise', name: 'GitHub Enterprise', enterprise: true },
+				sessionId: 'session',
+				enterprise: true,
+			}),
+			configurationService: new TestConfigurationService({ 'github-enterprise.uri': 'https://ghe.example.com' }),
+			authService: new TestAuthenticationService([{
+				id: 'session',
+				accessToken: 'token',
+				account: { label: 'mona', id: '1' },
+				scopes: ['read:user'],
+			}])
+		});
+
+		assert.strictEqual(
+			await service.getDefaultProfileImageUrl(),
+			'https://ghe.example.com/avatar.png'
+		);
+		assert.strictEqual(
+			await service.getDefaultProfileImageUrl(),
+			'https://ghe.example.com/avatar.png'
+		);
+		assert.deepStrictEqual(requestService.requests.map(request => request.url), ['https://api.ghe.example.com/user']);
+	});
+
+	test('handles missing default chat agent when resolving enterprise profile image', async () => {
+		const requestService = new TestRequestService({ avatar_url: 'https://api.github.com/avatar.png' });
+		const service = createService({
+			requestService,
+			defaultAccountService: new TestDefaultAccountService({
+				accountName: 'mona',
+				authenticationProvider: { id: 'github-enterprise', name: 'GitHub Enterprise', enterprise: true },
+				sessionId: 'session',
+				enterprise: true,
+			}),
+			productService: { ...TestProductService, defaultChatAgent: undefined } as unknown as IProductService,
+			authService: new TestAuthenticationService([{
+				id: 'session',
+				accessToken: 'token',
+				account: { label: 'mona', id: '1' },
+				scopes: ['read:user'],
+			}])
+		});
+
+		assert.strictEqual(
+			await service.getDefaultProfileImageUrl(),
+			'https://api.github.com/avatar.png'
+		);
+		assert.deepStrictEqual(requestService.requests.map(request => request.url), ['https://api.github.com/user']);
+	});
+});
+
+function createService(options: {
+	authService?: IAuthenticationService;
+	defaultAccountService?: IDefaultAccountService;
+	configurationService?: IConfigurationService;
+	logService?: ILogService;
+	productService?: IProductService;
+	requestService?: IRequestService;
+} = {}): AccountProfileImageService {
+	return new AccountProfileImageService(
+		options.authService ?? new TestAuthenticationService(),
+		options.defaultAccountService ?? new TestDefaultAccountService(),
+		options.configurationService ?? new TestConfigurationService(),
+		options.logService ?? new NullLogService(),
+		options.productService ?? TestProductService,
+		options.requestService ?? new TestRequestService({}),
+	);
+}
+
+class TestRequestService implements IRequestService {
+	declare readonly _serviceBrand: undefined;
+	readonly onDidCompleteRequest: Event<IRequestCompleteEvent> = Event.None;
+	readonly requests: IRequestOptions[] = [];
+
+	constructor(private readonly responseBody: object) { }
+
+	async request(options: IRequestOptions, _token: CancellationToken): Promise<IRequestContext> {
+		this.requests.push(options);
+		return {
+			res: { headers: {}, statusCode: 200 },
+			stream: bufferToStream(VSBuffer.fromString(JSON.stringify(this.responseBody)))
+		};
+	}
+
+	async resolveProxy(_url: string): Promise<string | undefined> { return undefined; }
+	async lookupAuthorization(): Promise<undefined> { return undefined; }
+	async lookupKerberosAuthorization(_url: string): Promise<string | undefined> { return undefined; }
+	async loadCertificates(): Promise<string[]> { return []; }
+}
+
+class TestDefaultAccountService implements IDefaultAccountService {
+	declare readonly _serviceBrand: undefined;
+	readonly onDidChangeDefaultAccount: Event<IDefaultAccount | null> = Event.None;
+	readonly onDidChangePolicyData: Event<IPolicyData | null> = Event.None;
+	readonly onDidChangeCopilotTokenInfo: Event<null> = Event.None;
+	readonly policyData = null;
+	readonly currentDefaultAccount = null;
+	readonly copilotTokenInfo = null;
+	readonly managedSettingsFetchStatus: ManagedSettingsFetchStatus = null;
+	readonly managedSettingsFetchedAt = null;
+
+	constructor(private readonly defaultAccount: IDefaultAccount | null = null) { }
+
+	async getDefaultAccount(): Promise<IDefaultAccount | null> { return this.defaultAccount; }
+	getDefaultAccountAuthenticationProvider(): IDefaultAccountAuthenticationProvider {
+		return { id: 'github', name: 'GitHub', enterprise: false };
+	}
+	setDefaultAccountProvider(): void { }
+	async refresh(): Promise<IDefaultAccount | null> { return null; }
+	async signIn(): Promise<IDefaultAccount | null> { return null; }
+	async signOut(): Promise<void> { }
+	resolveGitHubUrl(path: string): string { return `https://github.com/${path}`; }
+}
+
+class TestAuthenticationService implements IAuthenticationService {
+	declare readonly _serviceBrand: undefined;
+	readonly onDidRegisterAuthenticationProvider: Event<AuthenticationProviderInformation> = Event.None;
+	readonly onDidUnregisterAuthenticationProvider: Event<AuthenticationProviderInformation> = Event.None;
+	readonly onDidChangeSessions: Event<{ providerId: string; label: string; event: AuthenticationSessionsChangeEvent }> = Event.None;
+	readonly onDidChangeDeclaredProviders: Event<void> = Event.None;
+	readonly declaredProviders = [];
+
+	constructor(private readonly sessions: readonly AuthenticationSession[] = []) { }
+
+	registerDeclaredAuthenticationProvider(): void { }
+	unregisterDeclaredAuthenticationProvider(): void { }
+	isAuthenticationProviderRegistered(): boolean { return true; }
+	isDynamicAuthenticationProvider(): boolean { return false; }
+	registerAuthenticationProvider(): void { }
+	unregisterAuthenticationProvider(): void { }
+	getProviderIds(): string[] { return ['github-enterprise']; }
+	getProvider(): IAuthenticationProvider { throw new Error('Not implemented'); }
+	async getAccounts(): Promise<ReadonlyArray<AuthenticationSessionAccount>> { return this.sessions.map(session => session.account); }
+	async getSessions(_id: string, _scopeListOrRequest?: ReadonlyArray<string> | IAuthenticationWwwAuthenticateRequest, options?: IAuthenticationGetSessionsOptions): Promise<ReadonlyArray<AuthenticationSession>> {
+		return options?.account
+			? this.sessions.filter(session => session.account.label === options.account?.label)
+			: this.sessions;
+	}
+	async createSession(_providerId: string, _scopeListOrRequest: ReadonlyArray<string> | IAuthenticationWwwAuthenticateRequest, _options?: IAuthenticationCreateSessionOptions): Promise<AuthenticationSession> { throw new Error('Not implemented'); }
+	async removeSession(): Promise<void> { }
+	async getOrActivateProviderIdForServer(): Promise<string | undefined> { return undefined; }
+	registerAuthenticationProviderHostDelegate(): { dispose(): void } { return { dispose() { } }; }
+	async createDynamicAuthenticationProvider(): Promise<IAuthenticationProvider | undefined> { return undefined; }
+	async createOrGetXaaProvider(): Promise<string | undefined> { return undefined; }
+}

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -125,6 +125,7 @@ import './services/authentication/browser/authenticationMcpAccessService.js';
 import './services/authentication/browser/authenticationMcpService.js';
 import './services/authentication/browser/dynamicAuthenticationProviderStorageService.js';
 import './services/authentication/browser/authenticationQueryService.js';
+import './services/accounts/common/accountProfileImageService.js';
 import '../platform/hover/browser/hoverService.js';
 import '../platform/userInteraction/browser/userInteractionServiceImpl.js';
 import './services/assignment/common/assignmentService.js';


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes https://github.com/microsoft/vscode/issues/136889

In alignment with agents window start rendering GitHub profile image instead of default user icon in VS Code core when logged into GitHub account. Fallback to default user icon when logged out or logged into other non-GitHub accounts.

Also implement a shared `AccountProfileImageService` that supports fetching GitHub and Github Enterprise profile images and wire it into agents window and workbench.

<img width="500" height="auto" alt="Screenshot 2026-06-01 at 11 53 51 PM" src="https://github.com/user-attachments/assets/a7353d31-5c33-49ea-8cb1-0eb15d900eaa" />
<img width="500" height="auto" alt="Screenshot 2026-06-01 at 11 54 07 PM" src="https://github.com/user-attachments/assets/fd1b0cfd-4f15-4d3a-9e52-4065e5ebde08" />