### PR TITLE
Fix duplicate Rename action in Sessions window context menu

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -6177,12 +6177,12 @@
       "chatSessions/item/context": [
         {
           "command": "github.copilot.claude.sessions.rename",
-          "when": "chatSessionType == claude-code",
+          "when": "chatSessionType == claude-code && chatSessionProviderId == default-copilot",
           "group": "1_edit@4"
         },
         {
           "command": "github.copilot.cli.sessions.rename",
-          "when": "chatSessionType == copilotcli",
+          "when": "chatSessionType == copilotcli && chatSessionProviderId == default-copilot",
           "group": "1_edit@4"
         }
       ],


### PR DESCRIPTION
Fixes #319388

The Copilot extension's `chatSessions/item/context` rename entries were gated only on `chatSessionType` (`copilotcli` / `claude-code`), but agent host sessions reuse the same session type values via different providers (`local-agent-host`, `agenthost-*`). This caused both the workbench's built-in rename action and the extension's rename to appear on agent host session items in the Sessions window list.

Scoped both rename entries to `chatSessionProviderId == default-copilot` so they only show for sessions provided by the Copilot extension. This mirrors the pattern already used for `DeleteSessionAction` in `copilotChatSessionsActions.ts`.

The `chatSessionProviderId` overlay is set on both context-menu sites (`sessionsList.ts` and `sessionsTitleBarWidget.ts`), so the fix applies uniformly.