### PR TITLE
sessions: add background send and createAndSendNewChatRequest API

### DIFF
--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -150,6 +150,40 @@ Agent-host providers seed new-session config from the last values picked in the
 session-config UI (stored in profile storage), while `chat.permissions.default`
 takes precedence for `autoApprove` (with policy-safe normalization).
 ```
+Follow-up messages to an existing chat go through
+`SessionsManagementService.sendRequest(session, chat, options)`. This always
+makes the sent chat the active chat.
+
+`sendNewChatRequest(session, options)` accepts a `background` flag: a background
+new-session send returns the agents window to a fresh new-session view (via
+`openNewSessionView`) **before** creating and sending the session, and skips the
+visible-slot swap (`updateResourceOfSession`/`updateSession`) that the foreground
+path uses. This keeps the composer in view the whole time — the started session is
+never momentarily shown in the chat view — and it just appears in the sessions
+list once the provider commits it.
+
+Background sends are **fire-and-forget** at the management layer: the composer is
+allowed to reset and reseed immediately while the provider commit continues
+asynchronously. Providers are therefore required to support multiple concurrent
+new sessions. If that async commit fails, the management service calls
+`deleteNewSession(sessionId)` to dispose the stranded draft because it is no
+longer referenced by `_pendingNewSession`.
+
+`background` lives on the management-layer `ISendRequestOptions` (which extends
+the provider's send-request options). Providers do not interpret the flag; it is
+purely a management/UI concern. In the new-session composer the gesture is
+**Alt+Enter** (or **Alt-click** the Send button); plain Enter / click sends in
+the foreground. The background gesture is only offered for the new-session
+composer, not when sending a new chat within an existing session.
+
+For callers outside the new-session composer,
+`createAndSendNewChatRequest(folderUri, options, createOptions?)` creates a fresh
+session for the folder and sends the request in one call, **without** touching
+the pending/active session or navigating the current view — the started session
+just appears in the sessions list once the provider commits it. It shares the
+underlying commit helper with the composer's background send; if the send fails
+it disposes the stranded draft via `deleteNewSession` and rejects so the caller
+can react.
 
 ### Session Change Propagation
 

--- a/src/vs/sessions/contrib/chat/browser/newChatInSessionWidget.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInSessionWidget.ts
@@ -51,7 +51,7 @@ export class NewChatInSessionWidget extends Disposable {
 
 		this._newChatInput = this._register(this.instantiationService.createInstance(NewChatInputWidget, {
 			getContextFolderUri: () => this._getContextFolderUri(),
-			sendRequest: async (text: string, attachedContext?: IChatRequestVariableEntry[]) => this._send(text, attachedContext),
+			sendRequest: async ({ query, attachments }) => this._send(query, attachments),
 			canSendRequest,
 			loading,
 			minEditorHeight: 64,

--- a/src/vs/sessions/contrib/chat/browser/newChatInput.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInput.ts
@@ -68,6 +68,16 @@ interface IDraftState {
 }
 
 /**
+ * Options passed to the {@link NewChatInputWidget}'s `sendRequest` callback when
+ * the user submits the input.
+ */
+export interface INewChatInputSendRequest {
+	readonly query: string;
+	readonly attachments?: IChatRequestVariableEntry[];
+	readonly background?: boolean;
+}
+
+/**
  * Randomized, friendly placeholders shown in the new-session chat input
  * to add a bit of personality. One is picked per widget instance, avoiding
  * an immediate repeat of the previous pick.
@@ -146,12 +156,13 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 	constructor(
 		private readonly options: {
 			getContextFolderUri: () => URI | undefined;
-			sendRequest: (query: string, attachments?: IChatRequestVariableEntry[]) => Promise<void>;
+			sendRequest: (request: INewChatInputSendRequest) => Promise<void>;
 			canSendRequest: IObservable<boolean>;
 			loading: IObservable<boolean>;
 			minEditorHeight?: number;
 			placeholder?: string;
 			renderSessionTypePickerInControls?: boolean;
+			supportsBackground?: boolean;
 		},
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IModelService private readonly modelService: IModelService,
@@ -365,10 +376,11 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 				e.stopPropagation();
 				this._send();
 			}
-			if (e.keyCode === KeyCode.Enter && !e.shiftKey && !e.ctrlKey && e.altKey) {
+			// Alt+Enter — send in the background without navigating into the session
+			if (this.options.supportsBackground && e.keyCode === KeyCode.Enter && !e.shiftKey && !e.ctrlKey && e.altKey) {
 				e.preventDefault();
 				e.stopPropagation();
-				this._send();
+				this._send(true);
 			}
 			// Cmd+/ / Ctrl+/ — open the context picker (same as the attach button)
 			if (e.equals(KeyMod.CtrlCmd | KeyCode.Slash)) {
@@ -464,11 +476,14 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 		const sendButtonContainer = dom.append(toolbar, dom.$('.sessions-chat-send-button'));
 		const sendButton = this._sendButton = this._register(new Button(sendButtonContainer, {
 			secondary: true,
-			title: localize('send', "Send"),
+			title: this.options.supportsBackground
+				? localize('sendWithBackgroundHint', "Send (Alt-click to start in the background)")
+				: localize('send', "Send"),
 			ariaLabel: localize('send', "Send"),
 		}));
 		sendButton.icon = Codicon.arrowUp;
-		this._register(sendButton.onDidClick(() => this._send()));
+		// Hold Alt while clicking Send to start the session in the background.
+		this._register(sendButton.onDidClick(e => this._send(!!this.options.supportsBackground && !!(e as MouseEvent | KeyboardEvent | undefined)?.altKey)));
 	}
 
 	// --- Input History (IHistoryNavigationWidget) ---
@@ -532,7 +547,7 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 	// --- Send ---
 
 
-	private async _send(): Promise<void> {
+	private async _send(background = false): Promise<void> {
 		const query = this._editor.getModel()?.getValue().trim() ?? '';
 		const hasSendableAttachment = this._contextAttachments.attachments.some(isExplicitFileOrImageVariableEntry);
 		if ((!query && !hasSendableAttachment) || this._sending) {
@@ -561,7 +576,7 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 		this._updateInputLoadingState();
 
 		try {
-			await this.options.sendRequest(request, attachedContext);
+			await this.options.sendRequest({ query: request, attachments: attachedContext, background });
 			this._contextAttachments.clear();
 			this._editor.getModel()?.setValue('');
 		} catch (e) {

--- a/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
@@ -74,10 +74,11 @@ export class NewChatWidget extends Disposable {
 
 		this._newChatInput = this._register(this.instantiationService.createInstance(NewChatInputWidget, {
 			getContextFolderUri: () => this._getContextFolderUri(),
-			sendRequest: async (text: string, attachedContext?: IChatRequestVariableEntry[]) => this._send(text, attachedContext),
+			sendRequest: async ({ query, attachments, background }) => this._send(query, attachments, background),
 			canSendRequest,
 			loading,
 			renderSessionTypePickerInControls: false,
+			supportsBackground: true,
 		}));
 
 		this._register(this._workspacePicker.onDidSelectWorkspace(async folderUri => {
@@ -329,16 +330,34 @@ export class NewChatWidget extends Disposable {
 
 	// --- Send ---
 
-	private async _send(query: string, attachedContext?: IChatRequestVariableEntry[]): Promise<void> {
+	private async _send(query: string, attachedContext?: IChatRequestVariableEntry[], background?: boolean): Promise<void> {
 		const session = this.sessionsManagementService.activeSession.get();
 		if (!session) {
 			this._workspacePicker.showPicker();
 			return;
 		}
+
+		// Capture the composer's workspace/session-type selection before the
+		// send: a background send consumes the in-flight new session and resets
+		// the new-session view, so we re-seed a fresh pending session afterwards
+		// (see below) to keep the composer's pickers functional.
+		const reseedFolderUri = background ? this._workspacePicker.selectedFolderUri : undefined;
+		const reseedPick = background ? this._newChatInput.sessionTypePicker.selectedPick : undefined;
+
 		try {
-			await this.sessionsManagementService.sendNewChatRequest(session, { query, attachedContext });
+			await this.sessionsManagementService.sendNewChatRequest(session, { query, attachedContext, background });
 		} catch (e) {
 			this.logService.error('Failed to send request:', e);
+		}
+
+		// A background send graduated the composer's in-flight session and
+		// returned the view to a fresh (but session-less) new-session composer.
+		// The send now commits in the background, so reseed a replacement draft
+		// immediately — providers are multi-new-session aware, so the graduating
+		// session and this new draft coexist. This restores the
+		// session-type/model pickers for the next message.
+		if (background && reseedFolderUri) {
+			this._createNewSession(reseedFolderUri, reseedPick);
 		}
 	}
 

--- a/src/vs/sessions/contrib/chat/browser/sessionsChatAccessibilityHelp.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionsChatAccessibilityHelp.ts
@@ -26,6 +26,7 @@ export class SessionsChatAccessibilityHelp implements IAccessibleViewImplementat
 		const content: string[] = [];
 		content.push(localize('sessionsChat.overview', "You are in the Agents window. The Agents window is a dedicated workspace for working with AI agents. It provides a chat interface, a changes view for reviewing agent-generated changes, a file explorer, and customization options."));
 		content.push(localize('sessionsChat.input', "You are in the chat input. Type a message and press Enter to send it."));
+		content.push(localize('sessionsChat.inputBackground', "Press Alt+Enter to start the session in the background without navigating into it. The started session appears in the Chat Sessions view."));
 		content.push(localize('sessionsChat.workspace', "Shift+Tab to navigate to the workspace picker and choose a workspace for your session."));
 		content.push(localize('sessionsChat.mobileConfig', "On mobile, the mode and model pickers appear as tappable chips below the input. Tap a chip to open a bottom sheet where you can change the selection."));
 		content.push(localize('sessionsChat.history', "Use up and down arrows to navigate your request history in the input box."));

--- a/src/vs/sessions/contrib/chat/test/browser/sessionWorkspacePicker.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionWorkspacePicker.test.ts
@@ -91,6 +91,7 @@ function createMockProvider(id: string, opts?: {
 		onDidChangeSessions: Event.None,
 		getSessions: () => [],
 		createNewSession: () => { throw new Error('Not implemented'); },
+		deleteNewSession: () => { },
 		getSessionTypes: () => [],
 		renameChat: async () => { },
 		setModel: () => { },

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -1069,17 +1069,38 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 	protected _pendingSession: ISession | undefined;
 
 	/**
-	 * The at-most-one in-flight new session — the session being composed in
-	 * the new-chat view before the first message is sent. See
+	 * In-flight new sessions — sessions being composed in the new-chat view
+	 * before their first message is sent, keyed by `sessionId`. See
 	 * {@link NewSession} for the encapsulated state and lifecycle.
 	 *
-	 * Held as a {@link MutableDisposable} so reassigning or clearing the
-	 * field automatically disposes the previous instance, and the field is
-	 * cleaned up when the provider itself is disposed.
+	 * Held as a {@link DisposableMap} so multiple new sessions can be tracked
+	 * concurrently (e.g. while one is sending in the background and the composer
+	 * re-seeds a fresh one). Entries are disposed individually when sent
+	 * ({@link deleteAndDispose}/{@link deleteAndLeak}) or abandoned (via
+	 * {@link deleteNewSession}), and all remaining entries are cleaned up when
+	 * the provider itself is disposed.
 	 */
-	private readonly _newSessionRef = this._register(new MutableDisposable<NewSession>());
-	protected get _newSession(): NewSession | undefined { return this._newSessionRef.value; }
-	protected set _newSession(value: NewSession | undefined) { this._newSessionRef.value = value; }
+	private readonly _newSessions = this._register(new DisposableMap<string, NewSession>());
+
+	/** The in-flight new session with the given id, if any. */
+	protected _getNewSession(sessionId: string): NewSession | undefined {
+		return this._newSessions.get(sessionId);
+	}
+
+	/**
+	 * Dispose every in-flight new session, firing each one's `disposeSession`
+	 * sentinel so the eagerly-created backend records are freed. Used when the
+	 * connection drops and the composed-but-unsent drafts can no longer commit.
+	 */
+	protected _disposeAllNewSessions(): void {
+		this._newSessions.clearAndDisposeAll();
+	}
+
+	deleteNewSession(sessionId: string): void {
+		if (this._newSessions.has(sessionId)) {
+			this._newSessions.deleteAndDispose(sessionId);
+		}
+	}
 
 	/** Full resolved config (schema + values) for running sessions, keyed by session ID. */
 	protected readonly _runningSessionConfigs = new Map<string, ResolveSessionConfigResult>();
@@ -1284,8 +1305,10 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 	}
 
 	getSessionByResource(resource: URI): ISession | undefined {
-		if (this._newSession?.session.resource.toString() === resource.toString()) {
-			return this._newSession.session;
+		for (const newSession of this._newSessions.values()) {
+			if (newSession.session.resource.toString() === resource.toString()) {
+				return newSession.session;
+			}
 		}
 
 		if (this._pendingSession?.resource.toString() === resource.toString()) {
@@ -1328,12 +1351,11 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			throw new Error(`Cannot resolve workspace for URI: ${workspaceUri.toString()}`);
 		}
 
-		// Tear down any previous in-flight new session (workspace switch
-		// or back-to-back create). The MutableDisposable setter below
-		// disposes the previous instance, which fires `disposeSession`
-		// against the eagerly created agent-host record so it's freed
-		// immediately rather than waiting for the server-side
-		// empty-session GC.
+		// Tear-down of superseded drafts is handled by the management layer
+		// (it calls `deleteNewSession` on the previous pending session). Each
+		// new session is tracked independently in `_newSessions` so several can
+		// be in flight at once (e.g. one sending in the background while the
+		// composer re-seeds a fresh draft).
 		const connection = this.connection;
 		const newSession = new NewSession({
 			workspace,
@@ -1352,7 +1374,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 				? this._activeClientService.getActiveClient(this.resourceSchemeForProvider(sessionType.id), connection.clientId)
 				: undefined,
 		});
-		this._newSession = newSession;
+		this._newSessions.set(newSession.sessionId, newSession);
 		this._onDidChangeSessionConfig.fire(newSession.sessionId);
 
 		// Kick off the initial config resolve and the eager backend session
@@ -1386,7 +1408,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 		session.setLoading(true);
 		const applied = await session.resolveConfig(connection);
 		// Bail if a newer call superseded us — its own pulse will take over.
-		if (!applied || this._newSession !== session) {
+		if (!applied || this._newSessions.get(session.sessionId) !== session) {
 			return;
 		}
 		const config = session.getConfig();
@@ -1449,8 +1471,9 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 		// that weren't created in this window. Each query bumps the idle timer
 		// so the subscription stays alive while the picker (or any other UI
 		// surface) is repeatedly reading the running config.
-		if (this._newSession?.sessionId === sessionId) {
-			return this._newSession.getConfig();
+		const newSession = this._getNewSession(sessionId);
+		if (newSession) {
+			return newSession.getConfig();
 		}
 		this._keepSessionStateAlive(sessionId);
 		return this._runningSessionConfigs.get(sessionId);
@@ -1463,8 +1486,9 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 	 * interactive when the user has to fill in required values.
 	 */
 	isSessionConfigResolving(sessionId: string): IObservable<boolean> {
-		return this._newSession?.sessionId === sessionId
-			? this._newSession.isResolvingConfig
+		const newSession = this._getNewSession(sessionId);
+		return newSession
+			? newSession.isResolvingConfig
 			: constObservable(false);
 	}
 
@@ -1489,7 +1513,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 		// resolving flag and `loading` *before* firing the change event
 		// so the first picker re-render already observes the in-flight
 		// state.
-		const newSession = this._newSession?.sessionId === sessionId ? this._newSession : undefined;
+		const newSession = this._getNewSession(sessionId);
 		if (newSession) {
 			// Defense-in-depth: pickers render disabled during a resolve,
 			// but keyboard dropdown and mobile sheet paths bypass that.
@@ -1584,7 +1608,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 	}
 
 	async getSessionConfigCompletions(sessionId: string, property: string, query?: string) {
-		const newSession = this._newSession?.sessionId === sessionId ? this._newSession : undefined;
+		const newSession = this._getNewSession(sessionId);
 		const connection = this.connection;
 		if (!newSession || !connection) {
 			return [];
@@ -1594,13 +1618,12 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 	}
 
 	getCreateSessionConfig(sessionId: string): Record<string, unknown> | undefined {
-		return this._newSession?.sessionId === sessionId ? this._newSession.getConfigValues() : undefined;
+		return this._getNewSession(sessionId)?.getConfigValues();
 	}
 
 	clearSessionConfig(sessionId: string): void {
-		if (this._newSession?.sessionId === sessionId) {
-			// Setter on the MutableDisposable handles disposal of the old value.
-			this._newSession = undefined;
+		if (this._newSessions.has(sessionId)) {
+			this._newSessions.deleteAndDispose(sessionId);
 		}
 	}
 
@@ -1668,8 +1691,9 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 	// -- Model selection ------------------------------------------------------
 
 	setModel(sessionId: string, modelId: string): void {
-		if (this._newSession?.sessionId === sessionId) {
-			this._newSession.setSelectedModelId(modelId);
+		const newSession = this._getNewSession(sessionId);
+		if (newSession) {
+			newSession.setSelectedModelId(modelId);
 			return;
 		}
 
@@ -1689,8 +1713,9 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 	}
 
 	setAgent(sessionId: string, agent: ISessionAgentRef | undefined): void {
-		if (this._newSession?.sessionId === sessionId) {
-			this._newSession.setSelectedAgent(agent);
+		const newSession = this._getNewSession(sessionId);
+		if (newSession) {
+			newSession.setSelectedAgent(agent);
 			// The selection is forwarded to the host at first-message time
 			// via `sendOptions.agentHostSessionAgent` (see `sendRequest`),
 			// mirroring how `userSelectedModelId` flows.
@@ -1791,8 +1816,8 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			throw new Error(this._notConnectedSendErrorMessage());
 		}
 
-		const newSession = this._newSession;
-		if (!newSession || newSession.sessionId !== chatId) {
+		const newSession = this._getNewSession(chatId);
+		if (!newSession) {
 			throw new Error(`Session '${chatId}' not found or not a new session`);
 		}
 
@@ -1802,8 +1827,8 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 	}
 
 	async sendRequest(chatId: string, chatResource: URI, options: ISendRequestOptions): Promise<ISession> {
-		const newSession = this._newSession;
-		if (!newSession || newSession.sessionId !== chatId) {
+		const newSession = this._getNewSession(chatId);
+		if (!newSession) {
 			throw new Error(`Session '${chatId}' not found or not a new session`);
 		}
 
@@ -1902,8 +1927,8 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 				// acquired its own subscription (chat widget was opened
 				// earlier), so the wire-level refcount stays positive.
 				newSession.graduate();
-				if (this._newSession === newSession) {
-					this._newSession = undefined;
+				if (this._newSessions.get(newSession.sessionId) === newSession) {
+					this._newSessions.deleteAndDispose(newSession.sessionId);
 				}
 				// Clear the pending session before firing the replace event so
 				// that any synchronous listener calling getSessions() sees only
@@ -1925,8 +1950,8 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 		// the provisional session if it remains; we lean on the GC rather
 		// than risking a double-dispose race on transient failures.
 		newSession.graduate();
-		if (this._newSession === newSession) {
-			this._newSession = undefined;
+		if (this._newSessions.get(newSession.sessionId) === newSession) {
+			this._newSessions.deleteAndDispose(newSession.sessionId);
 		}
 		return skeleton;
 	}

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
@@ -1093,9 +1093,11 @@ suite('LocalAgentHostSessionsProvider', () => {
 		let fired = 0;
 		disposables.add(provider.onDidChangeCustomAgents(() => { fired++; }));
 
-		// Trigger disposal of the first NewSession by creating a second one
-		// (the MutableDisposable holding `_newSession` disposes the previous).
+		// Trigger disposal of the first NewSession explicitly. Providers no
+		// longer dispose drafts implicitly when a new one is created, so the
+		// management layer (modeled here) disposes the abandoned draft.
 		provider.createNewSession(URI.parse('file:///home/user/b'), sessionTypeId);
+		provider.deleteNewSession(first.sessionId);
 		await timeout(0);
 
 		assert.deepStrictEqual(provider.getCustomAgents(first.sessionId), []);
@@ -1306,9 +1308,11 @@ suite('LocalAgentHostSessionsProvider', () => {
 		const firstRawId = first.resource.path.substring(1);
 		const firstBackendUri = AgentSession.uri(sessionTypeId, firstRawId);
 
-		// Switch workspace: should dispose the first backend session and
-		// release its subscription before creating the second.
+		// Switch workspace: the management layer disposes the abandoned draft
+		// (providers no longer do so implicitly), which disposes the first
+		// backend session and releases its subscription.
 		const second = provider.createNewSession(URI.parse('file:///home/user/b'), sessionTypeId);
+		provider.deleteNewSession(first.sessionId);
 		await timeout(0);
 		const secondRawId = second.resource.path.substring(1);
 		const secondBackendUri = AgentSession.uri(sessionTypeId, secondRawId);
@@ -1367,8 +1371,11 @@ suite('LocalAgentHostSessionsProvider', () => {
 	test('workspace switch mid-createSession does not open a stale subscription', async () => {
 		// Models the race where the user switches workspaces while the eager
 		// `createSession` for the previous workspace is still in flight on
-		// the wire. Once that create eventually resolves, we must not open
-		// a subscription for it — it has already been disposed.
+		// the wire. Providers now track multiple new sessions, so abandoning
+		// the previous draft is explicit: the management layer calls
+		// `deleteNewSession` on workspace switch. Once the parked create
+		// eventually resolves, we must not open a subscription for it — it has
+		// already been disposed.
 		const provider = createProvider(disposables, agentHost);
 		const sessionTypeId = provider.sessionTypes[0].id;
 
@@ -1381,9 +1388,11 @@ suite('LocalAgentHostSessionsProvider', () => {
 		await timeout(0);
 
 		// Switch workspace while the first createSession is still parked.
-		// Disposing the first NewSession should clear its backend URI
-		// before the second eager-create runs.
 		const second = provider.createNewSession(URI.parse('file:///home/user/b'), sessionTypeId);
+		// Abandon the first draft (what the management layer does on a
+		// workspace switch). Disposing the first NewSession clears its backend
+		// URI before the second eager-create runs.
+		provider.deleteNewSession(first.sessionId);
 		await timeout(0);
 
 		// Now release the first createSession. The async IIFE in

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -8,7 +8,7 @@ import { raceCancellationError, raceTimeout } from '../../../../../base/common/a
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { CancellationError } from '../../../../../base/common/errors.js';
 import { IMarkdownString, MarkdownString } from '../../../../../base/common/htmlContent.js';
-import { Disposable, DisposableStore, IDisposable, MutableDisposable } from '../../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, IDisposable, DisposableMap, MutableDisposable } from '../../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../../base/common/network.js';
 import { autorun, constObservable, derived, IObservable, IReader, ISettableObservable, observableFromEvent, observableValue, observableValueOpts, transaction } from '../../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
@@ -1493,32 +1493,39 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 
 	// -- Session Lifecycle --
 
-	private readonly _currentNewSession = this._register(new MutableDisposable<NewSession>());
+	private readonly _newSessions = this._register(new DisposableMap<string, NewSession>());
 
 	/**
-	 * Clear {@link _currentNewSession} only if it still holds the given
-	 * session. Async flows (commit wait, cache population) may complete
-	 * after a newer session has been assigned — unconditionally clearing
-	 * would dispose the newer session and leave it dangling.
+	 * Clear the tracked new session with the given session's id, but only if
+	 * the map still holds exactly that instance. Async flows (commit wait,
+	 * cache population) may complete after the entry was already replaced or
+	 * removed — acting unconditionally would dispose an unrelated session.
 	 *
 	 * @param session The session that initiated the async flow.
-	 * @param leak When `true` use {@link MutableDisposable.clearAndLeak}
-	 *             (the session is still referenced elsewhere); otherwise
-	 *             use {@link MutableDisposable.clear} which also disposes.
+	 * @param leak When `true` use {@link DisposableMap.deleteAndLeak}
+	 *             (the session is still referenced elsewhere, e.g. the session
+	 *             cache); otherwise use {@link DisposableMap.deleteAndDispose}.
 	 */
 	private _clearCurrentNewSessionIfMatch(session: NewSession, leak?: boolean): void {
-		if (this._currentNewSession.value === session) {
+		if (this._newSessions.get(session.sessionId) === session) {
 			if (leak) {
-				this._currentNewSession.clearAndLeak();
+				this._newSessions.deleteAndLeak(session.sessionId);
 			} else {
-				this._currentNewSession.clear();
+				this._newSessions.deleteAndDispose(session.sessionId);
 			}
 		}
 	}
 
+	deleteNewSession(sessionId: string): void {
+		if (this._newSessions.has(sessionId)) {
+			this._newSessions.deleteAndDispose(sessionId);
+		}
+	}
+
 	getSession(sessionId: string): ICopilotChatSession | undefined {
-		if (this._currentNewSession.value?.sessionId === sessionId) {
-			return this._currentNewSession.value;
+		const newSession = this._newSessions.get(sessionId);
+		if (newSession) {
+			return newSession;
 		}
 		return this._findChatSession(sessionId);
 	}
@@ -1535,14 +1542,14 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 			}
 			const resource = URI.from({ scheme: AgentSessionProviders.Cloud, path: `/untitled-${generateUuid()}` });
 			const session = this.instantiationService.createInstance(RemoteNewSession, resource, workspace, AgentSessionProviders.Cloud, this.id);
-			this._currentNewSession.value = session;
+			this._newSessions.set(session.sessionId, session);
 			return this._chatToSession(session);
 		}
 
 		if (sessionTypeId === ClaudeCodeSessionType.id) {
 			const resource = URI.from({ scheme: AgentSessionProviders.Claude, path: `/untitled-${generateUuid()}` });
 			const session = this.instantiationService.createInstance(ClaudeCodeNewSession, resource, workspace, this.id);
-			this._currentNewSession.value = session;
+			this._newSessions.set(session.sessionId, session);
 			return this._chatToSession(session);
 		}
 
@@ -1552,7 +1559,7 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 		const resource = URI.from({ scheme: AgentSessionProviders.Background, path: `/untitled-${generateUuid()}` });
 		const session = this.instantiationService.createInstance(CopilotCLISession, resource, workspace, this.id);
 		session.setPermissionLevel(this._defaultPermissionLevel());
-		this._currentNewSession.value = session;
+		this._newSessions.set(session.sessionId, session);
 		return this._chatToSession(session);
 	}
 
@@ -1571,8 +1578,9 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 	}
 
 	setModel(sessionId: string, modelId: string): void {
-		if (this._currentNewSession.value?.sessionId === sessionId) {
-			this._currentNewSession.value.setModelId(modelId);
+		const newSession = this._newSessions.get(sessionId);
+		if (newSession) {
+			newSession.setModelId(modelId);
 			return;
 		}
 
@@ -1714,8 +1722,8 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 				const key = chat.resource.toString();
 				this._sessionCache.delete(key);
 				this._invalidateGroupingCaches();
-				if (this._currentNewSession.value?.sessionId === chatId) {
-					this._currentNewSession.clear();
+				if (this._newSessions.has(chatId)) {
+					this._newSessions.deleteAndDispose(chatId);
 				}
 			}
 			this._sessionGroupCache.delete(sessionId);
@@ -1744,8 +1752,9 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 	}
 
 	async createNewChat(sessionId: string, prompt?: string): Promise<IChat> {
-		if (this._currentNewSession.value?.sessionId === sessionId) {
-			const session = this._currentNewSession.value;
+		const currentNewSession = this._newSessions.get(sessionId);
+		if (currentNewSession) {
+			const session = currentNewSession;
 			let newChat: IChat;
 			// new session
 			if (session instanceof ClaudeCodeNewSession) {
@@ -1809,7 +1818,7 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 		session.setOption(PARENT_SESSION_OPTION_ID, chat.resource.path.slice(1));
 		session.setPermissionLevel(this._defaultPermissionLevel());
 		session.setTitle(localize('new chat', "New Chat"));
-		this._currentNewSession.value = session;
+		this._newSessions.set(session.sessionId, session);
 
 		(await this._createChatSession(session.resource, session)).dispose();
 
@@ -1824,8 +1833,8 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 	}
 
 	async sendRequest(sessionId: string, chatResource: URI, options: ISendRequestOptions): Promise<ISession> {
-		const newSession = this._currentNewSession.value;
-		if (newSession && newSession.sessionId === sessionId) {
+		const newSession = this._newSessions.get(sessionId);
+		if (newSession) {
 			if (!this.uriIdentityService.extUri.isEqual(newSession.mainChat.get().resource, chatResource)) {
 				throw new Error('Chat resource does not match the main chat of the current new session');
 			}
@@ -2399,8 +2408,8 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 		this._sessionCache.delete(key);
 		this._invalidateGroupingCaches();
 		this._sessionGroupCache.delete(chatSession.sessionId);
-		if (this._currentNewSession.value?.sessionId === chatSession.sessionId) {
-			this._currentNewSession.clearAndLeak();
+		if (this._newSessions.has(chatSession.sessionId)) {
+			this._newSessions.deleteAndLeak(chatSession.sessionId);
 		}
 		const removedSession = this._chatToSession(chatSession);
 		this._sessionGroupCache.delete(chatSession.sessionId);

--- a/src/vs/sessions/contrib/providers/localChatSessions/browser/localChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/localChatSessions/browser/localChatSessionsProvider.ts
@@ -5,7 +5,7 @@
 
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
-import { Disposable, MutableDisposable } from '../../../../../base/common/lifecycle.js';
+import { Disposable, DisposableMap, MutableDisposable } from '../../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../../base/common/network.js';
 import { autorun, constObservable, IObservable, IReader, ISettableObservable, observableFromEvent, observableValue, transaction } from '../../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
@@ -415,7 +415,7 @@ export class LocalChatSessionsProvider extends Disposable implements ISessionsPr
 	/** Fires when the set of chats in a group changes (chat added or removed). */
 	private readonly _onDidChangeGroupMembership = this._register(new Emitter<{ readonly groupKey: string }>());
 
-	private readonly _currentNewSession = this._register(new MutableDisposable<LocalSession>());
+	private readonly _newSessions = this._register(new DisposableMap<string, LocalSession>());
 
 	constructor(
 		@IChatService private readonly chatService: IChatService,
@@ -712,13 +712,20 @@ export class LocalChatSessionsProvider extends Disposable implements ISessionsPr
 
 		const session = this.instantiationService.createInstance(LocalSession, undefined, workspace, this.id);
 		session.setPermissionLevel(this._defaultPermissionLevel());
-		this._currentNewSession.value = session;
+		this._newSessions.set(session.sessionId, session);
 		return this._toISession(session);
 	}
 
+	deleteNewSession(sessionId: string): void {
+		if (this._newSessions.has(sessionId)) {
+			this._newSessions.deleteAndDispose(sessionId);
+		}
+	}
+
 	setModel(sessionId: string, modelId: string): void {
-		if (this._currentNewSession.value?.sessionId === sessionId) {
-			this._currentNewSession.value.setModelId(modelId);
+		const newSession = this._newSessions.get(sessionId);
+		if (newSession) {
+			newSession.setModelId(modelId);
 		}
 	}
 
@@ -763,8 +770,8 @@ export class LocalChatSessionsProvider extends Disposable implements ISessionsPr
 		}
 
 		this._sessionGroupCache.delete(primary.sessionId);
-		if (this._currentNewSession.value?.sessionId === sessionId) {
-			this._currentNewSession.clear();
+		if (this._newSessions.has(sessionId)) {
+			this._newSessions.deleteAndDispose(sessionId);
 		}
 		this._onDidChangeSessions.fire({ added: [], removed: [groupISession], changed: [] });
 	}
@@ -820,8 +827,9 @@ export class LocalChatSessionsProvider extends Disposable implements ISessionsPr
 	}
 
 	async createNewChat(sessionId: string, _prompt?: string): Promise<IChat> {
-		if (this._currentNewSession.value?.sessionId === sessionId) {
-			const session = this._currentNewSession.value;
+		const currentNewSession = this._newSessions.get(sessionId);
+		if (currentNewSession) {
+			const session = currentNewSession;
 			const chat = buildChat(session);
 			session.mainChat.set(chat, undefined);
 			return chat;
@@ -864,8 +872,8 @@ export class LocalChatSessionsProvider extends Disposable implements ISessionsPr
 
 	async sendRequest(sessionId: string, chatResource: URI, options: ISendRequestOptions): Promise<ISession> {
 		// First chat of a brand-new session.
-		const newSession = this._currentNewSession.value;
-		if (newSession && newSession.sessionId === sessionId) {
+		const newSession = this._newSessions.get(sessionId);
+		if (newSession) {
 			if (chatResource.toString() !== newSession.resource.toString()) {
 				throw new Error(`Chat resource ${chatResource.toString()} does not match session resource ${newSession.resource.toString()}`);
 			}
@@ -895,7 +903,7 @@ export class LocalChatSessionsProvider extends Disposable implements ISessionsPr
 
 		const result = await this._dispatchSend(newSession, chatResource, options);
 		if (result.kind === 'rejected') {
-			this._currentNewSession.clearAndLeak();
+			this._newSessions.deleteAndLeak(newSession.sessionId);
 			this._sessionGroupCache.delete(newSession.sessionId);
 			this._onDidChangeSessions.fire({ added: [], removed: [newISession], changed: [] });
 			newSession.dispose();
@@ -905,7 +913,7 @@ export class LocalChatSessionsProvider extends Disposable implements ISessionsPr
 		// Put the new session into the cache and persist its URI.
 		this._sessionCache.set(newSession.resource.toString(), newSession);
 		this._addStoredSession(newSession);
-		this._currentNewSession.clearAndLeak();
+		this._newSessions.deleteAndLeak(newSession.sessionId);
 
 		// Track response completion to update session status and persist title
 		if (result.kind === 'sent') {
@@ -1060,8 +1068,9 @@ export class LocalChatSessionsProvider extends Disposable implements ISessionsPr
 	}
 
 	private _findSession(sessionId: string): LocalSession | undefined {
-		if (this._currentNewSession.value?.sessionId === sessionId) {
-			return this._currentNewSession.value;
+		const newSession = this._newSessions.get(sessionId);
+		if (newSession) {
+			return newSession;
 		}
 		for (const session of this._sessionCache.values()) {
 			if (session.sessionId === sessionId) {
@@ -1076,8 +1085,10 @@ export class LocalChatSessionsProvider extends Disposable implements ISessionsPr
 		if (cached) {
 			return cached;
 		}
-		if (this._currentNewSession.value?.resource.toString() === resource.toString()) {
-			return this._currentNewSession.value;
+		for (const session of this._newSessions.values()) {
+			if (session.resource.toString() === resource.toString()) {
+				return session;
+			}
 		}
 		return undefined;
 	}

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
@@ -407,10 +407,7 @@ export class RemoteAgentHostSessionsProvider extends BaseAgentHostSessionsProvid
 		this._onDidDisconnect.fire();
 		this._connection = undefined;
 		this._defaultDirectory = undefined;
-		if (this._newSession) {
-			// Setter on the MutableDisposable handles disposal of the old value.
-			this._newSession = undefined;
-		}
+		this._disposeAllNewSessions();
 
 		if (this._sessionTypes.length > 0) {
 			this._sessionTypes = [];

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -16,9 +16,9 @@ import { IAgentSessionsService } from '../../../../workbench/contrib/chat/browse
 import { IChatService } from '../../../../workbench/contrib/chat/common/chatService/chatService.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
 import { ActiveSessionProviderIdContext, ActiveSessionTypeContext, IsActiveSessionArchivedContext, ActiveSessionWorkspaceIsVirtualContext, IsNewChatSessionContext } from '../../../common/contextkeys.js';
-import { ActiveSessionSupportsMultiChatContext, IActiveSession, ICreateNewSessionOptions, IProviderSessionType, ISendRequestSentEvent, ISessionsChangeEvent, ISessionsManagementService, IToggleSessionStickinessEvent } from '../common/sessionsManagement.js';
+import { ActiveSessionSupportsMultiChatContext, IActiveSession, ICreateNewSessionOptions, IProviderSessionType, ISendRequestOptions, ISendRequestSentEvent, ISessionsChangeEvent, ISessionsManagementService, IToggleSessionStickinessEvent } from '../common/sessionsManagement.js';
 import { ISessionsProvidersChangeEvent, ISessionsProvidersService } from './sessionsProvidersService.js';
-import { ISendRequestOptions, ISessionChangeEvent, ISessionsProvider } from '../common/sessionsProvider.js';
+import { ISessionChangeEvent, ISessionsProvider } from '../common/sessionsProvider.js';
 import { IChat, ISession, ISessionWorkspace, SessionStatus, ISessionType } from '../common/session.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { SessionsNavigation } from './sessionNavigation.js';
@@ -300,7 +300,8 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 		this._onDidChangeSessions.fire(e);
 		const currentActive = this._visibility.activeSession.get();
 
-		// Clear stale pending session if the provider removed it
+		// Clear stale pending session if the provider removed it. The provider
+		// already disposed it, so just drop the pointer (do not dispose again).
 		if (e.removed.length && this._pendingNewSession) {
 			if (e.removed.some(r => r.sessionId === this._pendingNewSession!.sessionId)) {
 				this._pendingNewSession = undefined;
@@ -458,14 +459,37 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 		this.logService.trace(`[SessionsManagement] openSession done total=${Date.now() - t0}ms uri=${sessionResource.toString()}`);
 	}
 
-	unsetNewSession(): void {
+	/**
+	 * Delete the currently pending (composed-but-not-sent) new session.
+	 *
+	 * Providers track new sessions themselves and no longer dispose them
+	 * implicitly when a newer one is created, so abandoning a pending session
+	 * must explicitly dispose it through its own provider to release the
+	 * eagerly-acquired backend session.
+	 *
+	 * This is only for abandonment. When a pending session is graduating (being
+	 * sent) or was already removed by its provider, just clear
+	 * {@link _pendingNewSession} directly so the session is left intact.
+	 */
+	private _deletePendingNewSession(): void {
+		const pending = this._pendingNewSession;
 		this._pendingNewSession = undefined;
+		if (pending) {
+			this._getProvider(pending)?.deleteNewSession(pending.sessionId);
+		}
+	}
+
+	unsetNewSession(): void {
+		this._deletePendingNewSession();
 		this.setActiveSession(undefined);
 	}
 
-	createNewSession(folderUri: URI, options?: ICreateNewSessionOptions): ISession {
-		this._startOpenSession();
-
+	/**
+	 * Resolve the provider and session type to use for a new session in the
+	 * given folder, applying the same selection rules as
+	 * {@link createNewSession}. Throws when no provider/type can be resolved.
+	 */
+	private _resolveProviderForNewSession(folderUri: URI, options?: ICreateNewSessionOptions): { provider: ISessionsProvider; sessionTypeId: string } {
 		const providers = this.sessionsProvidersService.getProviders();
 		let provider: ISessionsProvider | undefined;
 
@@ -502,20 +526,60 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 				throw new Error(`No session types available for provider '${provider.id}'`);
 			}
 		}
+		return { provider, sessionTypeId };
+	}
 
+	createNewSession(folderUri: URI, options?: ICreateNewSessionOptions): ISession {
+		this._startOpenSession();
+
+		const { provider, sessionTypeId } = this._resolveProviderForNewSession(folderUri, options);
+
+		const previousPending = this._pendingNewSession;
 		const session = provider.createNewSession(folderUri, sessionTypeId);
 		this._pendingNewSession = session;
 		this.setActiveSession(session);
+
+		// Providers no longer dispose the previous new session implicitly, so
+		// dispose the one this composer just replaced. Use its own provider
+		// because switching workspace can switch providers. Done after a
+		// successful create so a throw above leaves the previous one intact.
+		if (previousPending && previousPending.sessionId !== session.sessionId) {
+			this._getProvider(previousPending)?.deleteNewSession(previousPending.sessionId);
+		}
 		return session;
 	}
 
 	async sendNewChatRequest(session: ISession, options: ISendRequestOptions): Promise<void> {
+		// The session is graduating into the list (being sent),
+		// so the provider keeps owning it — just drop the pointer, do not delete.
 		this._pendingNewSession = undefined;
 		this._isNewChatSessionContext.set(false);
 
-		// Notify listeners that a send is starting. Listeners (e.g., telemetry)
-		// can use this to prewarm caches whose result is consumed when
-		// `onDidSendRequest` fires below.
+		const provider = this._getProvider(session);
+		if (!provider) {
+			throw new Error(`Sessions provider '${session.providerId}' not found`);
+		}
+
+		if (options.background) {
+			// Restore the new-session view synchronously so the composer stays
+			// put, then run the send fire-and-forget so the composer can reset
+			// and reseed immediately while the request commits. If the commit
+			// fails, the graduating draft is stranded (no longer in
+			// `_pendingNewSession`), so dispose it through its provider to
+			// release the eager backend session. Safe no-op if the provider
+			// already graduated/removed it.
+			this.openNewSessionView();
+			this._sendNewChatRequestInBackground(provider, session, options).catch(e => {
+				provider.deleteNewSession(session.sessionId);
+				this.logService.error('[SessionsManagement] Failed to send background request:', e);
+			});
+			return;
+		}
+
+		// Foreground send: notify listeners that a send is starting. Listeners
+		// (e.g., telemetry) can use this to prewarm caches whose result is
+		// consumed when `onDidSendRequest` fires below. The background path
+		// fires this from within `_sendNewChatRequestInBackground`.
 		this._onWillSendRequest.fire(session);
 
 		const setActiveChatToLast = () => {
@@ -536,11 +600,6 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 		});
 
 		try {
-			const provider = this._getProvider(session);
-			if (!provider) {
-				throw new Error(`Sessions provider '${session.providerId}' not found`);
-			}
-
 			// Ask the provider to create the new chat; open its widget before sending
 			const chat = await provider.createNewChat(session.sessionId, options.query);
 			// Swap in a transient session whose resource is the new chat
@@ -569,8 +628,68 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 		}
 	}
 
+	/**
+	 * Create a new session for the given folder and send a chat request to it,
+	 * without navigating into the started session. The started session appears
+	 * in the sessions list once the provider commits it, while the user's
+	 * current view is left untouched.
+	 *
+	 * Unlike {@link sendNewChatRequest} with `background`, this does not go
+	 * through the new-session composer: it creates a fresh session purely for
+	 * this request and never sets it as pending/active. Intended for callers
+	 * outside the composer that want to kick off a session programmatically.
+	 *
+	 * If the send fails, the stranded draft is disposed through its provider and
+	 * the error is rethrown so the caller can react.
+	 */
+	async createAndSendNewChatRequest(folderUri: URI, options: ISendRequestOptions, createOptions?: ICreateNewSessionOptions): Promise<void> {
+		const { provider, sessionTypeId } = this._resolveProviderForNewSession(folderUri, createOptions);
+		const session = provider.createNewSession(folderUri, sessionTypeId);
+
+		try {
+			await this._sendNewChatRequestInBackground(provider, session, options);
+		} catch (e) {
+			// The send never committed, so the draft is stranded. Dispose it
+			// through its provider to release the eager backend session before
+			// rethrowing. Safe no-op if the provider already removed it.
+			provider.deleteNewSession(session.sessionId);
+			throw e;
+		}
+	}
+
+	/**
+	 * Commit a new-session request: fire {@link _onWillSendRequest}, create the
+	 * new chat via the provider, send the request, and—on success—fire
+	 * {@link _onDidStartSession} and {@link _onDidSendRequest}. The started
+	 * session is never swapped into the visible chat slot, so it simply appears
+	 * in the sessions list once the provider commits it.
+	 *
+	 * Owns the full will/did send lifecycle so callers do not fire the paired
+	 * events themselves. Errors are propagated to the caller; this method does
+	 * not clean up the stranded draft, so callers own any view handling and the
+	 * error handling (e.g. disposing the stranded draft via
+	 * {@link ISessionsProvider.deleteNewSession}).
+	 *
+	 * Providers are multi-new-session aware, so the graduating session and a
+	 * concurrently reseeded composer draft coexist without conflict.
+	 */
+	private async _sendNewChatRequestInBackground(provider: ISessionsProvider, session: ISession, options: ISendRequestOptions): Promise<void> {
+		// Notify listeners (e.g., telemetry) that a send is starting so they can
+		// prewarm caches whose result is consumed when `onDidSendRequest` fires.
+		this._onWillSendRequest.fire(session);
+		const chat = await provider.createNewChat(session.sessionId, options.query);
+		const updatedSession = await provider.sendRequest(session.sessionId, chat.resource, options);
+		if (this._store.isDisposed) {
+			return;
+		}
+		this._onDidStartSession.fire(updatedSession);
+		this._onDidSendRequest.fire({ session: updatedSession, chat: session.mainChat.get(), isNewSession: true, isNewChat: true, options });
+	}
+
 	async sendRequest(session: ISession, chat: IChat, options: ISendRequestOptions): Promise<void> {
-		this._pendingNewSession = undefined;
+		// Sending into an existing session abandons any pending composer, so
+		// dispose it to release its eager backend session.
+		this._deletePendingNewSession();
 
 		// Notify listeners that a send is starting. Listeners (e.g., telemetry)
 		// can use this to prewarm caches whose result is consumed when
@@ -680,7 +799,7 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 		const wasActive = activeSessionId === sessionId;
 
 		if (sessionId === undefined || this._pendingNewSession?.sessionId === sessionId) {
-			this._pendingNewSession = undefined;
+			this._deletePendingNewSession();
 		}
 
 		this._visibility.removeMany([sessionId]);

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -622,7 +622,7 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 			}
 			this._onDidStartSession.fire(updatedSession);
 
-			this._onDidSendRequest.fire({ session: updatedSession, chat: session.mainChat.get(), isNewSession: true, isNewChat: true, options });
+			this._onDidSendRequest.fire({ session: updatedSession, chat, isNewSession: true, isNewChat: true, options });
 		} finally {
 			chatsListener.dispose();
 		}
@@ -678,12 +678,23 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 		// prewarm caches whose result is consumed when `onDidSendRequest` fires.
 		this._onWillSendRequest.fire(session);
 		const chat = await provider.createNewChat(session.sessionId, options.query);
-		const updatedSession = await provider.sendRequest(session.sessionId, chat.resource, options);
+
+		// Suppress the `chatService.onDidSubmitRequest` mirror for this send so
+		// `_onDidSendRequest` is not fired twice for providers that dispatch
+		// through `chatService.sendRequest` (see the mirror in the constructor).
+		const chatResourceKey = chat.resource.toString();
+		this._pendingSendChatResources.add(chatResourceKey);
+		let updatedSession: ISession;
+		try {
+			updatedSession = await provider.sendRequest(session.sessionId, chat.resource, options);
+		} finally {
+			this._pendingSendChatResources.delete(chatResourceKey);
+		}
 		if (this._store.isDisposed) {
 			return;
 		}
 		this._onDidStartSession.fire(updatedSession);
-		this._onDidSendRequest.fire({ session: updatedSession, chat: session.mainChat.get(), isNewSession: true, isNewChat: true, options });
+		this._onDidSendRequest.fire({ session: updatedSession, chat, isNewSession: true, isNewChat: true, options });
 	}
 
 	async sendRequest(session: ISession, chat: IChat, options: ISendRequestOptions): Promise<void> {

--- a/src/vs/sessions/services/sessions/common/sessionsManagement.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsManagement.ts
@@ -10,7 +10,22 @@ import { localize } from '../../../../nls.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { IChat, ISession, ISessionType, ISessionWorkspace } from './session.js';
-import { ISendRequestOptions } from './sessionsProvider.js';
+import { ISendRequestOptions as ISessionsProviderSendRequestOptions } from './sessionsProvider.js';
+
+/**
+ * Options for sending a request through the sessions management service.
+ *
+ * Extends the provider-level {@link ISessionsProviderSendRequestOptions} with
+ * management-only concerns that the provider is not aware of.
+ */
+export interface ISendRequestOptions extends ISessionsProviderSendRequestOptions {
+	/**
+	 * Start the session without navigating into it: the new-session composer
+	 * stays put and the started session shows up in the sessions list. Only
+	 * honored by {@link ISessionsManagementService.sendNewChatRequest}.
+	 */
+	readonly background?: boolean;
+}
 
 /**
  * A (provider, session-type) pair returned by
@@ -265,8 +280,24 @@ export interface ISessionsManagementService {
 
 	/**
 	 * Send a request, creating a new chat in the session.
+	 *
+	 * When {@link ISendRequestOptions.background} is set, the new-session view
+	 * is kept in place (the composer does not navigate into the started
+	 * session); the started session still appears in the sessions list.
 	 */
 	sendNewChatRequest(session: ISession, options: ISendRequestOptions): Promise<void>;
+
+	/**
+	 * Create a new session for the given folder and send a chat request to it,
+	 * without navigating into the started session.
+	 *
+	 * The started session appears in the sessions list once the provider
+	 * commits it, while the user's current view is left untouched. Intended for
+	 * callers outside the new-session composer that want to kick off a session
+	 * programmatically. Rejects (after disposing the stranded draft) if the send
+	 * fails.
+	 */
+	createAndSendNewChatRequest(folderUri: URI, options: ISendRequestOptions, createOptions?: ICreateNewSessionOptions): Promise<void>;
 
 	/**
 	 * Send a request for an existing chat within a session.

--- a/src/vs/sessions/services/sessions/common/sessionsProvider.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsProvider.ts
@@ -100,10 +100,22 @@ export interface ISessionsProvider {
 	/**
 	 * Create a new session for the given workspace URI.
 	 * The provider should not add this session to its session list until the first request is sent.
+	 * Multiple new sessions may be created and tracked concurrently; each is
+	 * identified by its `sessionId` and lives until it is either sent (graduating
+	 * into the session list) or disposed via {@link deleteNewSession}.
 	 * @param workspaceUri The URI of the repository to create the session for.
 	 * @param sessionTypeId The ID of the session type to create.
 	 */
 	createNewSession(workspaceUri: URI, sessionTypeId: string): ISession;
+
+	/**
+	 * Delete a new (untitled, not-yet-sent) session previously created via
+	 * {@link createNewSession}, removing it from the provider's tracking and
+	 * releasing any resources it eagerly acquired (e.g. a backend session).
+	 * No-op when the id is unknown or the session has already been sent.
+	 * @param sessionId The id of the new session to delete.
+	 */
+	deleteNewSession(sessionId: string): void;
 
 	/**
 	 * Get the session types supported for a given workspace URI.

--- a/src/vs/sessions/services/sessions/test/browser/sessionNavigation.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionNavigation.test.ts
@@ -172,6 +172,7 @@ class MockSessionStore implements ISessionsManagementService {
 	createNewSession(_folderUri: URI, _options?: ICreateNewSessionOptions): ISession { throw new Error('not implemented'); }
 	unsetNewSession(): void { throw new Error('not implemented'); }
 	sendNewChatRequest(_session: ISession, _options: ISendRequestOptions): Promise<void> { throw new Error('not implemented'); }
+	createAndSendNewChatRequest(_folderUri: URI, _options: ISendRequestOptions, _createOptions?: ICreateNewSessionOptions): Promise<void> { throw new Error('not implemented'); }
 	sendRequest(_session: ISession, _chat: IChat, _options: ISendRequestOptions): Promise<void> { throw new Error('not implemented'); }
 	openNewChatInSession(_session: ISession): Promise<void> { throw new Error('not implemented'); }
 	openPreviousSession(): Promise<void> { throw new Error('not implemented'); }

--- a/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
@@ -171,11 +171,12 @@ class TestSessionsProvider extends mock<ISessionsProvider>() {
 	override async unarchiveSession(): Promise<void> { }
 	override async deleteSession(): Promise<void> { }
 	override async deleteChat(): Promise<void> { }
+	override deleteNewSession(): void { }
 	override async sendRequest(_sessionId: string, _chatResource: URI, _options: ISendRequestOptions): Promise<ISession> { return this._session; }
 	override async createNewChat(): Promise<IChat> { return this._session.mainChat.get(); }
 }
 
-function createSessionsManagementService(session: ISession, disposables: ReturnType<typeof ensureNoDisposablesAreLeakedInTestSuite>): { service: ISessionsManagementService; chatWidgetService: TestChatWidgetService; agentSessionsService: TestAgentSessionsService } {
+function createSessionsManagementService(session: ISession, disposables: ReturnType<typeof ensureNoDisposablesAreLeakedInTestSuite>, provider: ISessionsProvider = new TestSessionsProvider(session)): { service: ISessionsManagementService; chatWidgetService: TestChatWidgetService; agentSessionsService: TestAgentSessionsService } {
 	const instantiationService = disposables.add(new TestInstantiationService());
 	const chatWidgetService = new TestChatWidgetService();
 	const agentSessionsService = new TestAgentSessionsService();
@@ -183,7 +184,7 @@ function createSessionsManagementService(session: ISession, disposables: ReturnT
 	instantiationService.stub(IStorageService, disposables.add(new InMemoryStorageService()));
 	instantiationService.stub(ILogService, new NullLogService());
 	instantiationService.stub(IContextKeyService, disposables.add(new MockContextKeyService()));
-	instantiationService.stub(ISessionsProvidersService, new TestSessionsProvidersService([new TestSessionsProvider(session)]));
+	instantiationService.stub(ISessionsProvidersService, new TestSessionsProvidersService([provider]));
 	instantiationService.stub(IUriIdentityService, { extUri: extUriBiasedIgnorePathCase });
 	instantiationService.stub(IChatWidgetService, chatWidgetService);
 	instantiationService.stub(IAgentSessionsService, agentSessionsService);
@@ -310,5 +311,88 @@ suite('SessionsManagementService', () => {
 		await restorePromise;
 		assert.deepStrictEqual(agentSessionsService.observed.map(uri => uri.toString()), [targetSession.resource.toString()]);
 	});
-});
 
+	test('sendNewChatRequest with background returns to the new-session view', async () => {
+		const chat: IChat = { ...stubChat, resource: URI.parse('test:///chat') };
+		const session = stubSession({
+			sessionId: 's1',
+			providerId: 'test',
+			chats: constObservable([chat]),
+			mainChat: constObservable(chat),
+		});
+		const { service } = createSessionsManagementService(session, disposables);
+
+		// Open the session so it becomes the active session.
+		await service.openSession(session.resource);
+		assert.strictEqual(service.activeSession.get()?.sessionId, 's1');
+
+		// A background new-chat send resets to the new-session view (no active session).
+		await service.sendNewChatRequest(session, { query: 'hi', background: true });
+		assert.strictEqual(service.activeSession.get(), undefined);
+
+		// A normal new-chat send keeps the started session active.
+		await service.openSession(session.resource);
+		await service.sendNewChatRequest(session, { query: 'hi' });
+		assert.strictEqual(service.activeSession.get()?.sessionId, 's1');
+	});
+
+	test('sendNewChatRequest with background resolves before provider send commits', async () => {
+		const chat: IChat = { ...stubChat, resource: URI.parse('test:///chat') };
+		const session = stubSession({
+			sessionId: 's1',
+			providerId: 'test',
+			chats: constObservable([chat]),
+			mainChat: constObservable(chat),
+		});
+		let completeSendRequest: (() => void) | undefined;
+		let sendRequestStarted = false;
+		const provider = new class extends TestSessionsProvider {
+			override async sendRequest(_sessionId: string, _chatResource: URI, _options: ISendRequestOptions): Promise<ISession> {
+				sendRequestStarted = true;
+				await new Promise<void>(resolve => {
+					completeSendRequest = resolve;
+				});
+				return session;
+			}
+		}(session);
+		const { service } = createSessionsManagementService(session, disposables, provider);
+
+		await service.openSession(session.resource);
+
+		const sendPromise = service.sendNewChatRequest(session, { query: 'hi', background: true });
+		await sendPromise;
+
+		assert.strictEqual(sendRequestStarted, true);
+		assert.strictEqual(service.activeSession.get(), undefined);
+
+		completeSendRequest?.();
+	});
+
+	test('createAndSendNewChatRequest sends without changing the active view', async () => {
+		const chat: IChat = { ...stubChat, resource: URI.parse('test:///chat') };
+		const session = stubSession({
+			sessionId: 's1',
+			providerId: 'test',
+			chats: constObservable([chat]),
+			mainChat: constObservable(chat),
+		});
+		let sendRequestStarted = false;
+		const provider = new class extends TestSessionsProvider {
+			override resolveWorkspace(): ISessionWorkspace { return { folderUri: URI.parse('test:///folder') } as unknown as ISessionWorkspace; }
+			override async sendRequest(_sessionId: string, _chatResource: URI, _options: ISendRequestOptions): Promise<ISession> {
+				sendRequestStarted = true;
+				return session;
+			}
+		}(session);
+		const { service } = createSessionsManagementService(session, disposables, provider);
+
+		// No active session and no pending composer before the headless send.
+		assert.strictEqual(service.activeSession.get(), undefined);
+
+		await service.createAndSendNewChatRequest(URI.parse('test:///folder'), { query: 'hi' });
+
+		// The request was sent, but the user's view was not navigated into the session.
+		assert.strictEqual(sendRequestStarted, true);
+		assert.strictEqual(service.activeSession.get(), undefined);
+	});
+});


### PR DESCRIPTION
## What

Adds a **background send** capability to new-session chat requests in the Agents window, plus a new public management-service API for sending a new chat programmatically.

### `sendNewChatRequest(session, { background: true })`
- Keeps the new-session composer in place instead of navigating into the started session. The composer returns to a fresh new-session view (`openNewSessionView`) **before** the provider round-trip, so the started session never flashes into the chat view — it just appears in the sessions list once committed.
- Fire-and-forget at the management layer: the composer can reset/reseed immediately while the provider commit continues async (the composer-side `_send` keeps the input read-only + spinner until the awaited send resolves, so returning fast is required).
- Composer gesture: **Alt+Enter** (or **Alt-click** Send); plain Enter/click still sends in the foreground. Offered only for the new-session composer.

### New API: `ISessionsManagementService.createAndSendNewChatRequest(folderUri, options, createOptions?)`
- Creates a fresh session for the folder and sends a chat request in one call, **without** touching the pending/active session or navigating the current view — intended for callers outside the composer.
- Rejects (after disposing the stranded draft) if the send fails.

### Multi-new-session aware providers
- Providers now track new sessions in a `DisposableMap` (instead of a single `MutableDisposable`) and expose `deleteNewSession(sessionId)`, so a graduating session and a freshly reseeded composer draft coexist without conflict.
- The management service explicitly disposes abandoned/failed drafts through their owning provider (previous-pending replacement, abandonment, and failed background sends).

## Why

Lets users start a session and immediately compose another without waiting for the round-trip, and gives core/workbench callers a way to kick off sessions programmatically.

## Notes for reviewers

- `_sendNewChatRequestInBackground` is a shared private helper owning the full `onWillSendRequest` → `onDidSendRequest` lifecycle; both the composer background branch and `createAndSendNewChatRequest` go through it. Error handling (draft cleanup) lives in the callers.
- `ISendRequestEvent` requires both `isNewSession` and `isNewChat`; the background new-session fire site matches the foreground path (both `true`).
- Spec updated: `src/vs/sessions/SESSIONS.md` ("Creating a New Session").
- Validated: `compile-check-ts-native`, `valid-layers-check`, and `SessionsManagementService` unit tests (6 passing).
