### PR TITLE
Fix issue reporter "Preview on GitHub" opening repo root instead of the new-issue form

### DIFF
--- a/src/vs/workbench/contrib/issue/browser/issueFormService.ts
+++ b/src/vs/workbench/contrib/issue/browser/issueFormService.ts
@@ -191,7 +191,7 @@ export class IssueFormService extends Disposable implements IIssueFormService {
 
 		const issueBody = body + mediaMarkdown;
 
-		const baseUrl = this.getIssueUrlWithTitle(title, issueTarget.url, data.issueSource === IssueSource.Extension);
+		const baseUrl = this.getIssueUrlWithTitle(title, issueTarget.url);
 		let previewBody = issueBody;
 		let url = this.createIssuePreviewUrl(baseUrl, previewBody, gitHubDetails, data.issueSource);
 
@@ -378,8 +378,14 @@ export class IssueFormService extends Disposable implements IIssueFormService {
 		return { owner: match[1], repositoryName: match[2] };
 	}
 
-	private getIssueUrlWithTitle(issueTitle: string, issueUrl: string, fileOnExtension: boolean): string {
-		if (fileOnExtension && !/\/issues\/new(?:[?#].*)?$/i.test(issueUrl)) {
+	private getIssueUrlWithTitle(issueTitle: string, issueUrl: string): string {
+		// Point any GitHub target at the new-issue form, not just extensions. The
+		// VS Code / Marketplace targets can be a bare repo URL (e.g. a `data.uri`
+		// override or a `reportIssueUrl` without the `/issues/new` suffix), which
+		// would otherwise open the repo landing page instead of the pre-filled
+		// issue form. The `isGitHubUrl` guard leaves non-GitHub issue trackers
+		// (which open directly as external links) untouched.
+		if (this.isGitHubUrl(issueUrl) && !/\/issues\/new(?:[?#].*)?$/i.test(issueUrl)) {
 			issueUrl = `${normalizeGitHubUrl(issueUrl)}/issues/new`;
 		}
 		const queryStringPrefix = issueUrl.indexOf('?') === -1 ? '?' : '&';


### PR DESCRIPTION
Fixes #319238
Fixes #318374

### Problem
In the wizard issue reporter, "Preview on GitHub" builds a URL like
`https://github.com/microsoft/vscode?title=…&body=…` — the repository **landing page** with query params — instead of the new-issue form `…/microsoft/vscode/issues/new?title=…`. As a result the pre-filled title/body are dropped and the user lands on the repo home.

### Cause
`IssueFormService.getIssueUrlWithTitle` only appended `/issues/new` when filing **on an extension** (`fileOnExtension`). For the VS Code / Marketplace targets it trusted that the target URL already ended in `/issues/new`. That holds for the normal path (`product.reportIssueUrl` = `…/vscode/issues/new`), but the wizard target can be a bare repo URL routed through `data.uri` (e.g. the Agents-window "Report Issue" flow and the "VS Code – Insiders" target), so the suffix was never added.

### Fix
Generalize the `/issues/new` handling to apply to **any** GitHub target URL that doesn't already point at the new-issue form, and drop the now-redundant `fileOnExtension` argument:

```ts
if (this.isGitHubUrl(issueUrl) && !/\/issues\/new(?:[?#].*)?$/i.test(issueUrl)) {
    issueUrl = `${normalizeGitHubUrl(issueUrl)}/issues/new`;
}
```

- The `!/\/issues\/new$/` check prevents double-appending for URLs that already target the form (e.g. the default `product.reportIssueUrl`, and extension URLs which `getExtensionIssueUrl` already normalizes), so already-correct flows are unchanged.
- The `isGitHubUrl` guard leaves non-GitHub external trackers untouched — and those already short-circuit as `external` links before this point.

### Scope
This is intentionally limited to the new wizard reporter (`IssueFormService`), which is the UI both issues exercise. The legacy reporter (`baseIssueReporterService`) derives its VS Code target from `product.reportIssueUrl` (already `…/issues/new`) and does not consume `data.uri`, so it is not affected by these reports. Happy to extend the same hardening there if preferred.

### Verification
- Simulated `getIssueUrlWithTitle` + `normalizeGitHubUrl` over the bug inputs and edge cases: bare `…/vscode` → `…/vscode/issues/new?title=…`; already-`/issues/new` URLs, trailing slash, and extension URLs are unchanged (no double-append).
