### PR TITLE
Agents - remove title from sessions titlebar widget

### DIFF
--- a/src/vs/sessions/browser/parts/media/titlebarpart.css
+++ b/src/vs/sessions/browser/parts/media/titlebarpart.css
@@ -42,7 +42,7 @@
 	margin: unset;
 }
 
-.agent-sessions-workbench.monaco-workbench.mac .part.titlebar > .sessions-titlebar-container > .titlebar-right {
+.agent-sessions-workbench.monaco-workbench .part.titlebar > .sessions-titlebar-container > .titlebar-right {
 	order: 2;
 	width: fit-content;
 	flex-grow: 0;

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsTitleBarWidget.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsTitleBarWidget.css
@@ -88,18 +88,7 @@
 	color: var(--vscode-icon-foreground);
 }
 
-/* Label (title) — shrinks first so folder/branch/diff stats stay visible. */
-.command-center .agent-sessions-titlebar-container .agent-sessions-titlebar-label {
-	flex: 0 999 auto;
-	min-width: 0;
-	max-width: 400px;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-	font-weight: 500;
-}
-
-/* Repository/worktree metadata shrinks after the primary title. */
+/* Repository/worktree metadata. */
 .command-center .agent-sessions-titlebar-container .agent-sessions-titlebar-details {
 	display: flex;
 	align-items: center;

--- a/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
@@ -38,16 +38,15 @@ import { buildSessionHoverContent, getSessionDiffStats } from './sessionHoverCon
 const titleBarContextKeys = new Set([IsNewChatSessionContext.key]);
 
 /**
- * Sessions Title Bar Widget - renders the active chat session title
+ * Sessions Title Bar Widget - renders the active chat session
  * in the command center of the agent sessions workbench.
  *
- * Shows the current chat session label as a clickable pill with:
+ * Shows the current chat session as a clickable pill with:
  * - Kind icon at the beginning (provider type icon)
- * - Session title
  * - Repository folder name and active branch/worktree name when available
  *
  * Session actions (changes, terminal, etc.) are rendered via the
- * SessionTitleActions menu toolbar next to the session title.
+ * SessionTitleActions menu toolbar next to this widget.
  *
  * On click, opens the sessions picker.
  */
@@ -80,7 +79,6 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 		this._register(autorun(reader => {
 			const sessionData = this.sessionsManagementService.activeSession.read(reader);
 			if (sessionData) {
-				sessionData.title.read(reader);
 				sessionData.status.read(reader);
 				sessionData.workspace.read(reader);
 				sessionData.changes.read(reader);
@@ -151,14 +149,13 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 				return;
 			}
 
-			const label = this._getActiveSessionLabel();
 			const icon = this._getActiveSessionIcon();
 			const repoLabel = this._getRepositoryLabel();
 			const repoBranchLabel = this._getRepositoryBranchLabel();
 			const diffStats = this._getDiffStats();
 
 			// Build a render-state key from all displayed data
-			const renderState = `${icon?.id ?? ''}|${label}|${repoLabel ?? ''}|${repoBranchLabel ?? ''}|${diffStats ? `${diffStats.insertions}/${diffStats.deletions}` : ''}`;
+			const renderState = `${icon?.id ?? ''}|${repoLabel ?? ''}|${repoBranchLabel ?? ''}|${diffStats ? `${diffStats.insertions}/${diffStats.deletions}` : ''}`;
 
 			// Skip re-render if state hasn't changed
 			if (this._lastRenderState === renderState) {
@@ -176,10 +173,10 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 			this._container.setAttribute('aria-label', localize('agentSessionsShowSessions', "Show Sessions"));
 			this._container.tabIndex = 0;
 
-			// Session pill: icon + label + folder together
+			// Session pill: icon + folder together
 			const sessionPill = $('div.agent-sessions-titlebar-pill');
 
-			// Center group: icon + label + folder
+			// Center group: icon + folder
 			const centerGroup = $('div.agent-sessions-titlebar-center');
 
 			// Kind icon at the beginning
@@ -188,12 +185,7 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 				centerGroup.appendChild(iconEl);
 			}
 
-			// Label
-			const labelEl = $('div.agent-sessions-titlebar-label');
-			labelEl.textContent = label;
-			centerGroup.appendChild(labelEl);
-
-			// Folder shown next to the title
+			// Folder shown next to the icon
 			if (repoLabel) {
 				const detailsEl = $('div.agent-sessions-titlebar-details');
 
@@ -266,17 +258,6 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 		} finally {
 			this._isRendering = false;
 		}
-	}
-
-	/**
-	 * Get the label of the active chat session.
-	 */
-	private _getActiveSessionLabel(): string {
-		const sessionData = this.sessionsManagementService.activeSession.get();
-		if (sessionData) {
-			return sessionData.title.get() || localize('agentSessions.newSession', "New Session");
-		}
-		return localize('agentSessions.newSession', "New Session");
 	}
 
 	/**


### PR DESCRIPTION
Removes the session title (`_getActiveSessionLabel`) from the titlebar widget in the sessions window. The rest of the widget — provider icon, repository folder, branch name, and diff stats — keeps rendering as before.

Also fixes the sessions titlebar layout so the **center** section grows and shrinks against the **right** section, instead of the right section taking 2x growth on non-mac platforms (the existing override was scoped to `.mac` only).

### Changes
- `sessionsTitleBarWidget.ts`: remove the title element, drop the now-unused `_getActiveSessionLabel()` helper, and stop reading `sessionData.title` in the autorun / render-state key.
- `sessionsTitleBarWidget.css`: remove the `.agent-sessions-titlebar-label` rule that's no longer used.
- `parts/media/titlebarpart.css`: drop the `.mac` qualifier from the `.titlebar-right` override so the center grows / shrinks to fill available space on all platforms.