### PR TITLE
use `[Agent Host]` suffix instead of [Local]

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
@@ -134,7 +134,7 @@ export class SessionTypePicker extends Disposable {
 			refresh(this.sessionsManagementService.activeSession.get());
 		}));
 		// Re-read when the stored preference changes (e.g. handoff IPC from
-		// the main vscode window pre-seeds Copilot CLI [Local] when opening
+		// the main vscode window pre-seeds Copilot CLI when opening
 		// the agents window from an empty workspace).
 		this._register(this.storageService.onDidChangeValue(StorageScope.PROFILE, STORAGE_KEY_LAST_SESSION_TYPE, this._register(new DisposableStore()))(() => {
 			if (!this.sessionsManagementService.activeSession.get()) {

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -1216,7 +1216,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 	 */
 	protected abstract resourceSchemeForProvider(provider: string): string;
 
-	/** Format the human-readable label for a session type entry (e.g. `Copilot [Local]`). */
+	/** Format the human-readable label for a session type entry (e.g. `Copilot CLI`). */
 	protected abstract _formatSessionTypeLabel(agentLabel: string): string;
 
 	/**

--- a/src/vs/sessions/contrib/providers/agentHost/browser/localAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/localAgentHostSessionsProvider.ts
@@ -128,9 +128,9 @@ export class LocalAgentHostSessionsProvider extends BaseAgentHostSessionsProvide
 
 	protected _formatSessionTypeLabel(agentLabel: string): string {
 		// Use the unadorned agent label (e.g. "Copilot") rather than tagging it
-		// with `[Local]`. The session type id is shared with the extension-host
+		// with `[Agent Host]`. The session type id is shared with the extension-host
 		// Copilot CLI provider, so the filter menu / new-session picker entry
-		// covers both sets of sessions; the `[Local]` tag belongs on the
+		// covers both sets of sessions; the `[Agent Host]` tag belongs on the
 		// per-session workspace label, not the type label.
 		return agentLabel;
 	}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
@@ -174,10 +174,10 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 		const syncProvider = agentRegistration.syncProvider;
 
 		const itemProvider = store.add(this._instantiationService.createInstance(AgentCustomizationItemProvider, 'local', undefined));
-		// `[Local]` suffix disambiguates from the extension-host Copilot CLI harness, which uses the same displayName.
+		// `[Agent Host]` suffix disambiguates from the extension-host Copilot CLI harness, which uses the same displayName.
 		store.add(this._customizationHarnessService.registerExternalHarness({
 			id: sessionType,
-			label: localize('agentHostHarnessLabel.local', "{0} [Local]", agent.displayName),
+			label: localize('agentHostHarnessLabel.local', "{0} [Agent Host]", agent.displayName),
 			icon: ThemeIcon.fromId(Codicon.server.id),
 			hiddenSections: [],
 			hideGenerateButton: true,

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessions.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessions.ts
@@ -67,7 +67,7 @@ export function getAgentSessionProviderName(provider: AgentSessionTarget): strin
 		case AgentSessionProviders.Growth:
 			return 'Growth';
 		case AgentSessionProviders.AgentHostCopilot:
-			return 'Copilot CLI [Local]';
+			return 'Copilot CLI [Agent Host]';
 		default:
 			return provider;
 	}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessions.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessions.ts
@@ -67,7 +67,7 @@ export function getAgentSessionProviderName(provider: AgentSessionTarget): strin
 		case AgentSessionProviders.Growth:
 			return 'Growth';
 		case AgentSessionProviders.AgentHostCopilot:
-			return 'Copilot CLI [Agent Host]';
+			return localize('chat.session.providerLabel.agentHostCopilot', "Copilot CLI [Agent Host]");
 		default:
 			return provider;
 	}

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -2220,7 +2220,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		if (!this._notificationWidget.value) {
 			// Fall back to `getCurrentSessionType()` so the session-type
 			// picker delegate is consulted before any real session exists
-			// (e.g. empty workspace + Copilot CLI [Local] selected). Without
+			// (e.g. empty workspace + Copilot CLI [Agent Host] selected). Without
 			// this fallback, `_currentSessionType` stays undefined until
 			// the user creates a session and `sessionTypes`-gated
 			// notifications never render.

--- a/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts
@@ -170,7 +170,7 @@ export class OpenChatSessionInAgentsWindowAction extends Action2 {
 
 		// No real session URI to hand off (empty-workspace path triggered
 		// from the input tip): pre-seed the agents window's session-type
-		// picker so it lands on Copilot CLI [Local].
+		// picker so it lands on Copilot CLI [Agent Host].
 		let preferredSessionType: { providerId?: string; sessionTypeId: string } | undefined;
 		const hasRealSession = sessionResource && !isUntitledChatSession(sessionResource);
 		if (!hasRealSession) {
@@ -437,7 +437,7 @@ export class AgentsHandoffInputTipContribution extends Disposable implements IWo
 		// than a generic "continue in agents" upsell.
 		const useEmptyWorkspaceCopy = emptyWorkspaceEligible && !eligible;
 		const message = useEmptyWorkspaceCopy
-			? localize('chat.agentsHandoff.tip.emptyWorkspace.message', "Copilot CLI [Local] isn't available without an open folder")
+			? localize('chat.agentsHandoff.tip.emptyWorkspace.message', "Copilot CLI [Agent Host] isn't available without an open folder")
 			: localize('chat.agentsHandoff.tip.message', "Continue this session in the Agents Window");
 		const description = useEmptyWorkspaceCopy
 			? localize('chat.agentsHandoff.tip.emptyWorkspace.description', "Open the Agents Window to start a Copilot CLI session.")

--- a/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts
@@ -170,7 +170,7 @@ export class OpenChatSessionInAgentsWindowAction extends Action2 {
 
 		// No real session URI to hand off (empty-workspace path triggered
 		// from the input tip): pre-seed the agents window's session-type
-		// picker so it lands on Copilot CLI [Agent Host].
+		// picker so it lands on Copilot CLI.
 		let preferredSessionType: { providerId?: string; sessionTypeId: string } | undefined;
 		const hasRealSession = sessionResource && !isUntitledChatSession(sessionResource);
 		if (!hasRealSession) {


### PR DESCRIPTION
@roblourens Feel free to close if you disagree
Currently only shows up in the editor window and in customization dialogs

<img width="314" height="251" alt="image" src="https://github.com/user-attachments/assets/abb4a907-b20e-4319-b537-111e62b046be" />

<img width="508" height="170" alt="image" src="https://github.com/user-attachments/assets/d5b2127c-5d32-4df1-bac5-cc0663604e5d" />
