### PR TITLE
Agents - preserve reply draft when feedback widget rebuilds

### DIFF
--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorWidgetContribution.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorWidgetContribution.ts
@@ -16,7 +16,7 @@ import { IEditorContribution, IEditorDecorationsCollection, ScrollType } from '.
 import { EditorContributionInstantiation, registerEditorContribution } from '../../../../editor/browser/editorExtensions.js';
 import { EditorOption } from '../../../../editor/common/config/editorOptions.js';
 import { renderIcon } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
-import { $, addDisposableListener, addStandardDisposableListener, clearNode, getTotalWidth } from '../../../../base/browser/dom.js';
+import { $, addDisposableListener, addStandardDisposableListener, clearNode, getTotalWidth, isHTMLElement } from '../../../../base/browser/dom.js';
 import { URI } from '../../../../base/common/uri.js';
 import { Range } from '../../../../editor/common/core/range.js';
 import { overviewRulerRangeHighlight } from '../../../../editor/common/core/editorColorRegistry.js';
@@ -43,6 +43,17 @@ interface ICommentItemActions {
 	convertAction: Action | undefined;
 	removeAction: Action;
 	addReplyAction: Action;
+}
+
+/**
+ * Shared in-progress reply state that survives widget rebuilds. The contribution
+ * owns the single instance and hands it to each widget so drafts (and focus)
+ * are not lost when widgets are torn down and recreated in response to
+ * unrelated feedback / review changes.
+ */
+interface IReplyDraftState {
+	readonly drafts: Map<string, string>;
+	focusedCommentId: string | undefined;
 }
 
 /**
@@ -77,6 +88,7 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 		private readonly _editor: ICodeEditor,
 		private readonly _commentItems: readonly ISessionEditorComment[],
 		private readonly _sessionResource: URI,
+		private readonly _replyDraftState: IReplyDraftState | undefined,
 		@IAgentFeedbackService private readonly _agentFeedbackService: IAgentFeedbackService,
 		@ICodeReviewService private readonly _codeReviewService: ICodeReviewService,
 		@IMarkdownRendererService private readonly _markdownRendererService: IMarkdownRendererService,
@@ -311,6 +323,15 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 			this._eventStore.add(addDisposableListener(item, 'mousedown', onSelectableMousedown));
 
 			this._bodyNode.appendChild(item);
+
+			// Restore an in-progress reply draft if one exists for this comment.
+			// This keeps the reply input alive across widget rebuilds that
+			// happen while the user is typing (e.g. when an unrelated feedback
+			// or review change fires onDidChangeFeedback).
+			const draft = this._replyDraftState?.drafts.get(comment.id);
+			if (draft !== undefined) {
+				this._startAddingReply(comment, item, itemActions, draft);
+			}
 		}
 	}
 
@@ -436,7 +457,7 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 		textarea.focus();
 	}
 
-	private _startAddingReply(comment: ISessionEditorComment, itemNode: HTMLElement, actions: ICommentItemActions): void {
+	private _startAddingReply(comment: ISessionEditorComment, itemNode: HTMLElement, actions: ICommentItemActions, initialText?: string): void {
 		// If a reply input is already open for this item, just focus it.
 		const existing = this._activeReplyInputs.get(comment.id);
 		if (existing) {
@@ -459,9 +480,16 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 		const textarea = $('textarea.agent-feedback-widget-edit-textarea') as HTMLTextAreaElement;
 		textarea.placeholder = nls.localize('addReplyPlaceholder', "Add a comment\u2026");
 		textarea.rows = 1;
+		if (initialText !== undefined) {
+			textarea.value = initialText;
+		}
 		replyContainer.appendChild(textarea);
 		itemNode.appendChild(replyContainer);
 		this._activeReplyInputs.set(comment.id, { container: replyContainer, textarea });
+
+		// Ensure the draft store has an entry so subsequent rebuilds know to
+		// restore the input even before the user has typed anything.
+		this._replyDraftState?.drafts.set(comment.id, textarea.value);
 
 		const autoSize = () => {
 			textarea.style.height = 'auto';
@@ -470,7 +498,20 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 		};
 		autoSize();
 
-		replyStore.add(addDisposableListener(textarea, 'input', autoSize));
+		replyStore.add(addDisposableListener(textarea, 'input', () => {
+			this._replyDraftState?.drafts.set(comment.id, textarea.value);
+			autoSize();
+		}));
+
+		const clearDraft = () => {
+			if (!this._replyDraftState) {
+				return;
+			}
+			this._replyDraftState.drafts.delete(comment.id);
+			if (this._replyDraftState.focusedCommentId === comment.id) {
+				this._replyDraftState.focusedCommentId = undefined;
+			}
+		};
 
 		const cleanup = () => {
 			replyStore.dispose();
@@ -482,6 +523,7 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 			actions.addReplyAction.enabled = true;
 			this._activeReplyInputs.delete(comment.id);
 			replyContainer.remove();
+			clearDraft();
 			this._editor.layoutOverlayWidget(this);
 		};
 
@@ -491,6 +533,9 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 				e.stopPropagation();
 				const newReply = textarea.value.trim();
 				if (newReply) {
+					// Clear the draft before triggering the change so the
+					// rebuilt widget doesn't re-open the reply input.
+					clearDraft();
 					this._saveReply(comment, newReply);
 					// Widget will be rebuilt by the change event.
 				} else {
@@ -504,13 +549,31 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 		}));
 
 		// Cancel the reply when focus leaves and the textarea is empty.
+		// When the textarea contains text, keep it open so the user doesn't
+		// lose their draft just because focus moved elsewhere.
+		// Skip cleanup entirely if the widget is being disposed — the browser
+		// fires blur as part of removing the textarea from the DOM, and we
+		// don't want that teardown blur to wipe out the draft that the
+		// rebuilt widget needs to restore.
 		replyStore.add(addDisposableListener(textarea, 'blur', () => {
+			if (this._disposed) {
+				return;
+			}
 			if (textarea.value.trim() === '') {
 				cleanup();
 			}
 		}));
 
-		textarea.focus();
+		// Only steal focus when this is an explicit user-triggered open. For
+		// drafts restored across a rebuild, only refocus if the textarea had
+		// focus at the moment the previous widget was torn down.
+		if (initialText === undefined || this._replyDraftState?.focusedCommentId === comment.id) {
+			textarea.focus();
+			// Place caret at the end of any restored text so typing continues
+			// naturally from where the user left off.
+			const len = textarea.value.length;
+			textarea.setSelectionRange(len, len);
+		}
 	}
 
 	private _saveReply(comment: ISessionEditorComment, replyText: string): void {
@@ -714,6 +777,29 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 	}
 
 	/**
+	 * Returns the comment id whose active reply textarea matches the given
+	 * element, or `undefined` if none. Used by the contribution to remember
+	 * which reply input had focus immediately before tearing widgets down,
+	 * so focus can be restored on the new widget.
+	 */
+	findReplyCommentIdForElement(element: HTMLElement): string | undefined {
+		for (const [commentId, { textarea }] of this._activeReplyInputs) {
+			if (textarea === element) {
+				return commentId;
+			}
+		}
+		return undefined;
+	}
+
+	/**
+	 * Ids of the comments rendered by this widget. Used by the contribution
+	 * to prune draft state for comments that no longer exist.
+	 */
+	getCommentIds(): readonly string[] {
+		return this._commentItems.map(comment => comment.id);
+	}
+
+	/**
 	 * Updates the widget position and layout.
 	 */
 	layout(startLineNumber: number): void {
@@ -814,6 +900,16 @@ class AgentFeedbackEditorWidgetContribution extends Disposable implements IEdito
 	private readonly _widgetListeners = this._register(new DisposableStore());
 	private _sessionResource: URI | undefined;
 
+	/**
+	 * Reply input state shared across widget rebuilds. Without this, any
+	 * unrelated feedback / review state change would dispose the active
+	 * widget and discard the textarea the user was typing in.
+	 */
+	private readonly _replyDraftState: IReplyDraftState = {
+		drafts: new Map<string, string>(),
+		focusedCommentId: undefined,
+	};
+
 	constructor(
 		private readonly _editor: ICodeEditor,
 		@IAgentFeedbackService private readonly _agentFeedbackService: IAgentFeedbackService,
@@ -898,7 +994,7 @@ class AgentFeedbackEditorWidgetContribution extends Disposable implements IEdito
 		// further down.
 		for (let i = groups.length - 1; i >= 0; i--) {
 			const group = groups[i];
-			const widget = this._instantiationService.createInstance(AgentFeedbackEditorWidget, this._editor, group, this._sessionResource);
+			const widget = this._instantiationService.createInstance(AgentFeedbackEditorWidget, this._editor, group, this._sessionResource, this._replyDraftState);
 			this._widgets.push(widget);
 
 			// Ensure only one widget is expanded per file at a time: when a
@@ -912,6 +1008,32 @@ class AgentFeedbackEditorWidgetContribution extends Disposable implements IEdito
 			}));
 
 			widget.layout(group[0].range.startLineNumber);
+		}
+
+		this._pruneOrphanedReplyDrafts();
+	}
+
+	/**
+	 * Remove draft entries for comments that no longer exist in any widget.
+	 * Without this, deleted comments would leave drafts in the map forever.
+	 */
+	private _pruneOrphanedReplyDrafts(): void {
+		if (this._replyDraftState.drafts.size === 0 && this._replyDraftState.focusedCommentId === undefined) {
+			return;
+		}
+		const knownCommentIds = new Set<string>();
+		for (const widget of this._widgets) {
+			for (const commentId of widget.getCommentIds()) {
+				knownCommentIds.add(commentId);
+			}
+		}
+		for (const commentId of [...this._replyDraftState.drafts.keys()]) {
+			if (!knownCommentIds.has(commentId)) {
+				this._replyDraftState.drafts.delete(commentId);
+			}
+		}
+		if (this._replyDraftState.focusedCommentId !== undefined && !knownCommentIds.has(this._replyDraftState.focusedCommentId)) {
+			this._replyDraftState.focusedCommentId = undefined;
 		}
 	}
 
@@ -1012,11 +1134,37 @@ class AgentFeedbackEditorWidgetContribution extends Disposable implements IEdito
 	}
 
 	private _clearWidgets(): void {
+		// Capture which reply textarea (if any) currently has focus so the
+		// rebuilt widget can refocus it. The textarea's own blur event would
+		// fire as part of the teardown below and clear this state, so we
+		// snapshot it synchronously here instead of relying on focus tracking.
+		this._captureFocusedReplyCommentId();
+
 		this._widgetListeners.clear();
 		for (const widget of this._widgets) {
 			widget.dispose();
 		}
 		this._widgets.length = 0;
+	}
+
+	private _captureFocusedReplyCommentId(): void {
+		// Always recompute from scratch — the previously-captured value may
+		// be stale (e.g. the user clicked elsewhere after typing).
+		this._replyDraftState.focusedCommentId = undefined;
+		if (this._widgets.length === 0) {
+			return;
+		}
+		const activeElement = this._editor.getDomNode()?.ownerDocument.activeElement;
+		if (!isHTMLElement(activeElement)) {
+			return;
+		}
+		for (const widget of this._widgets) {
+			const commentId = widget.findReplyCommentIdForElement(activeElement);
+			if (commentId !== undefined) {
+				this._replyDraftState.focusedCommentId = commentId;
+				return;
+			}
+		}
 	}
 
 	override dispose(): void {

--- a/src/vs/sessions/contrib/agentFeedback/test/browser/agentFeedbackEditorWidget.fixture.ts
+++ b/src/vs/sessions/contrib/agentFeedback/test/browser/agentFeedbackEditorWidget.fixture.ts
@@ -220,6 +220,7 @@ function renderWidget(context: ComponentFixtureContext, options: IFixtureOptions
 		editor,
 		options.commentItems,
 		sessionResource,
+		undefined,
 	));
 
 	widget.layout(options.commentItems[0].range.startLineNumber);


### PR DESCRIPTION
## Problem

When typing a reply on a feedback item in the agent feedback editor widget, the reply input could close even though it had text in it. This happened because any unrelated `onDidChangeFeedback` (or code/PR review state change) tears down all widgets via `_clearWidgets` and rebuilds them, throwing away the textarea the user was typing in.

## Fix

Persist in-progress reply state on the contribution (which survives rebuilds) and have each widget restore it:

- `IReplyDraftState` is owned by `AgentFeedbackEditorWidgetContribution` and passed to every `AgentFeedbackEditorWidget`.
- `_startAddingReply` writes the textarea value to the shared drafts map on every `input` event, and clears it on submit / cancel.
- Before disposing widgets, `_clearWidgets` snapshots whether one of the reply textareas was the active element so the rebuilt widget can refocus it.
- `_buildFeedbackItems` re-opens the reply input for any comment that has a saved draft, restoring the text and focus.
- Orphaned drafts (whose comment no longer exists) are pruned after each rebuild.
- The teardown blur is ignored (`this._disposed`) so it doesn't wipe the draft as part of widget disposal.

## Behaviour

- Reply input stays open when focus moves elsewhere if it contains text (existing behaviour, now actually upheld across rebuilds).
- Empty reply input still auto-cancels on blur (unchanged).
- `Escape` and `Enter` on empty text still cancel (unchanged).
- Caret is placed at the end of restored text so typing continues naturally.