### PR TITLE
Agents: don't shadow Ctrl+N when editor area has focus

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
@@ -34,6 +34,7 @@ import { SessionsOpenerParticipantContribution } from './sessionsOpenerParticipa
 import { WorktreeCreatedTaskDispatcher, AGENT_HOST_RUN_WORKTREE_CREATED_TASKS_SETTING } from './worktreeCreatedTaskDispatcher.js';
 import '../../sessions/browser/mobile/mobileOverlayContribution.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
+import { EditorAreaFocusContext } from '../../../../workbench/common/contextkeys.js';
 
 
 class NewChatInSessionsWindowAction extends Action2 {
@@ -45,6 +46,10 @@ class NewChatInSessionsWindowAction extends Action2 {
 			category: CHAT_CATEGORY,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib + 2,
+				// Don't shadow Ctrl/Cmd+N (and Ctrl/Cmd+L) when focus is in the
+				// editor area so the standard editor commands (new untitled file,
+				// expand line selection) handle the shortcut instead.
+				when: EditorAreaFocusContext.negate(),
 				primary: KeyMod.CtrlCmd | KeyCode.KeyN,
 				secondary: [KeyMod.CtrlCmd | KeyCode.KeyL],
 				mac: {

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
@@ -17,7 +17,7 @@ import { IStorageService, StorageScope, StorageTarget } from '../../../../../pla
 import { KeybindingsRegistry, KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { IViewsService } from '../../../../../workbench/services/views/common/viewsService.js';
 import { CLOSE_MOBILE_SIDEBAR_DRAWER_COMMAND_ID } from '../../../../browser/workbench.js';
-import { EditorsVisibleContext, IsAuxiliaryWindowContext, IsSessionsWindowContext } from '../../../../../workbench/common/contextkeys.js';
+import { EditorsVisibleContext, EditorAreaFocusContext, IsAuxiliaryWindowContext, IsSessionsWindowContext } from '../../../../../workbench/common/contextkeys.js';
 import { ANY_AGENT_HOST_PROVIDER_RE } from '../../../../common/agentHostSessionsProvider.js';
 import { SessionsCategories } from '../../../../common/categories.js';
 import { ChatSessionProviderIdContext, IsActiveSessionArchivedContext, IsNewChatSessionContext, SessionsWelcomeVisibleContext } from '../../../../common/contextkeys.js';
@@ -40,6 +40,9 @@ const ACTION_ID_NEW_SESSION = 'workbench.action.chat.newChat';
 KeybindingsRegistry.registerKeybindingRule({
 	id: ACTION_ID_NEW_SESSION,
 	weight: KeybindingWeight.WorkbenchContrib + 1,
+	// Don't shadow Ctrl/Cmd+N when focus is in the editor area so the standard
+	// `workbench.action.files.newUntitledFile` command handles the shortcut.
+	when: EditorAreaFocusContext.negate(),
 	primary: KeyMod.CtrlCmd | KeyCode.KeyN,
 });
 

--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -34,7 +34,7 @@ import { IBoundarySashes } from '../../../../base/browser/ui/sash/sash.js';
 import { IHostService } from '../../../services/host/browser/host.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { ServiceCollection } from '../../../../platform/instantiation/common/serviceCollection.js';
-import { EditorPartMaximizedEditorGroupContext, EditorPartMultipleEditorGroupsContext, EditorTabsVisibleContext, IsTopRightEditorGroupContext } from '../../../common/contextkeys.js';
+import { EditorAreaFocusContext, EditorPartMaximizedEditorGroupContext, EditorPartMultipleEditorGroupsContext, EditorTabsVisibleContext, IsTopRightEditorGroupContext } from '../../../common/contextkeys.js';
 import { mainWindow } from '../../../../base/browser/window.js';
 
 export interface IEditorPartUIState {
@@ -1042,6 +1042,12 @@ export class EditorPart extends Part<IEditorPartMemento> implements IEditorPart,
 	}
 
 	protected handleContextKeys(): void {
+		// Bind `editorAreaFocus` to the editor part's scoped context key service so
+		// it evaluates to `true` only when keyboard focus is within the editor area.
+		// Applies to all editor parts (main, modal, auxiliary) so callers can gate
+		// shortcuts on focus being in any editor area regardless of which part.
+		EditorAreaFocusContext.bindTo(this.scopedContextKeyService).set(true);
+
 		const multipleEditorGroupsContext = EditorPartMultipleEditorGroupsContext.bindTo(this.scopedContextKeyService);
 		const maximizedEditorGroupContext = EditorPartMaximizedEditorGroupContext.bindTo(this.scopedContextKeyService);
 		const editorTabsVisibleContext = EditorTabsVisibleContext.bindTo(this.scopedContextKeyService);

--- a/src/vs/workbench/common/contextkeys.ts
+++ b/src/vs/workbench/common/contextkeys.ts
@@ -104,6 +104,7 @@ export const EditorPartModalSidebarVisibleContext = new RawContextKey<boolean>('
 
 // Editor Layout Context Keys
 export const EditorsVisibleContext = new RawContextKey<boolean>('editorIsOpen', false, localize('editorIsOpen', "Whether an editor is open"));
+export const EditorAreaFocusContext = new RawContextKey<boolean>('editorAreaFocus', false, localize('editorAreaFocus', "Whether the editor area (any editor part) has keyboard focus"));
 export const InEditorZenModeContext = new RawContextKey<boolean>('inZenMode', false, localize('inZenMode', "Whether Zen mode is enabled"));
 export const IsMainEditorCenteredLayoutContext = new RawContextKey<boolean>('isCenteredLayout', false, localize('isMainEditorCenteredLayout', "Whether centered layout is enabled for the main editor"));
 export const SplitEditorsVertically = new RawContextKey<boolean>('splitEditorsVertically', false, localize('splitEditorsVertically', "Whether editors split vertically"));


### PR DESCRIPTION
Adds a workbench-wide `editorAreaFocus` context key bound by the base `EditorPart` so it evaluates to true whenever keyboard focus is inside **any** editor part (main, modal, or auxiliary).

The Agents window's `Ctrl/Cmd+N` keybindings that open a new chat (`workbench.action.sessions.newChat` and the rebound `workbench.action.chat.newChat`) are now gated with `when: EditorAreaFocusContext.negate()`. When focus is inside an editor the keybinding falls through to the standard `workbench.action.files.newUntitledFile` command, matching the behavior users expect from VS Code.

### Changes

- `workbench/common/contextkeys.ts`: new `EditorAreaFocusContext` (`editorAreaFocus`)
- `workbench/browser/parts/editor/editorPart.ts`: bind it in `handleContextKeys()` on the scoped context key service so it applies to every editor part subclass
- `sessions/contrib/chat/browser/chat.contribution.ts`: gate the `New Chat` keybinding on `EditorAreaFocusContext.negate()`
- `sessions/contrib/sessions/browser/views/sessionsViewActions.ts`: same gating on the second Ctrl+N keybinding rule that targets `workbench.action.chat.newChat`