### PR TITLE
Issue 316597: fix terminal name overflow issue

### DIFF
--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -7066,7 +7066,6 @@ declare namespace monaco.languages {
 	 * Describes language specific folding markers such as '#region' and '#endregion'.
 	 * The start and end regexes will be tested against the contents of all lines and must be designed efficiently:
 	 * - the regex should start with '^'
-	 * - regexp flags (i, g) are ignored
 	 */
 	export interface FoldingMarkers {
 		start: RegExp;

--- a/src/vs/workbench/contrib/terminal/browser/media/terminal.css
+++ b/src/vs/workbench/contrib/terminal/browser/media/terminal.css
@@ -477,14 +477,21 @@
 .monaco-action-bar .action-item .single-terminal-tab {
 	display: flex !important;
 	align-items: center;
-	overflow: hidden;
 }
 
 .monaco-action-bar .action-item .single-terminal-tab .codicon:first-child {
 	margin-right: 4px;
 }
 
-.monaco-action-bar .action-item .single-terminal-tab .codicon:nth-child(2) {
+.monaco-action-bar .action-item .single-terminal-tab .single-terminal-tab-label {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	min-width: 0;
+	flex: 1;
+}
+
+.monaco-action-bar .action-item .single-terminal-tab .codicon:nth-child(3) {
 	margin-left: 4px;
 	color: inherit;
 }

--- a/src/vs/workbench/contrib/terminal/browser/media/terminal.css
+++ b/src/vs/workbench/contrib/terminal/browser/media/terminal.css
@@ -477,6 +477,7 @@
 .monaco-action-bar .action-item .single-terminal-tab {
 	display: flex !important;
 	align-items: center;
+	overflow: hidden;
 }
 
 .monaco-action-bar .action-item .single-terminal-tab .codicon:first-child {

--- a/src/vs/workbench/contrib/terminal/browser/terminalView.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalView.ts
@@ -515,7 +515,16 @@ class SingleTerminalTabActionViewItem extends MenuEntryActionViewItem {
 				}
 			}
 			label.style.color = colorStyle;
-			dom.reset(label, ...renderLabelWithIcons(this._instantiationService.invokeFunction(getSingleTabLabel, instance, this._terminaConfigurationService.config.tabs.separator, ThemeIcon.isThemeIcon(this._commandAction.item.icon) ? this._commandAction.item.icon : undefined)));
+			const labelNodes = renderLabelWithIcons(this._instantiationService.invokeFunction(getSingleTabLabel, instance, this._terminaConfigurationService.config.tabs.separator, ThemeIcon.isThemeIcon(this._commandAction.item.icon) ? this._commandAction.item.icon : undefined)).map(node => {
+				if (typeof node === 'string') {
+					const span = dom.$('span');
+					span.className = 'single-terminal-tab-label';
+					span.textContent = node;
+					return span;
+				}
+				return node;
+			});
+			dom.reset(label, ...labelNodes);
 
 			if (this._altCommand) {
 				label.classList.remove(this._altCommand);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fix for #316597. Set the terminal tab text `overflow: hidden` so it doesn't hide the other buttons above the terminal.