### PR TITLE
extensions: suppress OOM extension crash attribution

### DIFF
--- a/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
@@ -31,7 +31,7 @@ import { IWebWorkerService } from '../../../../platform/webWorker/browser/webWor
 import { IWorkspaceContextService, WorkbenchState } from '../../../../platform/workspace/common/workspace.js';
 import { IBrowserWorkbenchEnvironmentService } from '../../environment/browser/environmentService.js';
 import { IDefaultLogLevelsService } from '../../log/common/defaultLogLevels.js';
-import { ExtensionHostExitCode, IExtensionHostInitData, MessageType, UIKind, createMessageOfType, isMessageOfType } from '../common/extensionHostProtocol.js';
+import { ExtensionHostExitCode, ExtensionHostExitReason, IExtensionHostInitData, MessageType, UIKind, createMessageOfType, isMessageOfType } from '../common/extensionHostProtocol.js';
 import { LocalWebWorkerRunningLocation } from '../common/extensionRunningLocation.js';
 import { ExtensionHostExtensions, ExtensionHostStartup, IExtensionHost } from '../common/extensions.js';
 
@@ -49,8 +49,8 @@ export class WebWorkerExtensionHost extends Disposable implements IExtensionHost
 	public readonly remoteAuthority = null;
 	public extensions: ExtensionHostExtensions | null = null;
 
-	private readonly _onDidExit = this._register(new Emitter<[number, string | null]>());
-	public readonly onExit: Event<[number, string | null]> = this._onDidExit.event;
+	private readonly _onDidExit = this._register(new Emitter<[number, string | null, ExtensionHostExitReason | null]>());
+	public readonly onExit: Event<[number, string | null, ExtensionHostExitReason | null]> = this._onDidExit.event;
 
 	private _isTerminating: boolean;
 	private _protocolPromise: Promise<IMessagePassingProtocol> | null;
@@ -163,7 +163,7 @@ export class WebWorkerExtensionHost extends Disposable implements IExtensionHost
 			barrierHasError = true;
 			onUnexpectedError(barrierError);
 			clearTimeout(startTimeout);
-			this._onDidExit.fire([ExtensionHostExitCode.UnexpectedError, barrierError.message]);
+			this._onDidExit.fire([ExtensionHostExitCode.UnexpectedError, barrierError.message, null]);
 			barrier.open();
 		};
 
@@ -234,7 +234,7 @@ export class WebWorkerExtensionHost extends Disposable implements IExtensionHost
 			const { data } = event;
 			if (!(data instanceof ArrayBuffer)) {
 				console.warn('UNKNOWN data received', data);
-				this._onDidExit.fire([77, 'UNKNOWN data received']);
+				this._onDidExit.fire([77, 'UNKNOWN data received', null]);
 				return;
 			}
 			emitter.fire(VSBuffer.wrap(new Uint8Array(data, 0, data.byteLength)));

--- a/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
+++ b/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
@@ -41,6 +41,7 @@ import { parseExtensionDevOptions } from './extensionDevOptions.js';
 import { ExtensionHostKind, ExtensionRunningPreference, IExtensionHostKindPicker } from './extensionHostKind.js';
 import { ExtensionHostManager } from './extensionHostManager.js';
 import { IExtensionHostManager } from './extensionHostManagers.js';
+import { ExtensionHostExitReason } from './extensionHostProtocol.js';
 import { IResolveAuthorityErrorResult } from './extensionHostProxy.js';
 import { IExtensionManifestPropertiesService } from './extensionManifestPropertiesService.js';
 import { ExtensionRunningLocation, LocalProcessRunningLocation, LocalWebWorkerRunningLocation, RemoteRunningLocation } from './extensionRunningLocation.js';
@@ -847,7 +848,7 @@ export abstract class AbstractExtensionService extends Disposable implements IEx
 
 		const processManager: IExtensionHostManager = this._doCreateExtensionHostManager(extensionHost, initialActivationEvents);
 		const disposableStore = new DisposableStore();
-		disposableStore.add(processManager.onDidExit(([code, signal]) => this._onExtensionHostCrashOrExit(processManager, code, signal)));
+		disposableStore.add(processManager.onDidExit(([code, signal, reason]) => this._onExtensionHostCrashOrExit(processManager, code, signal, reason)));
 		disposableStore.add(processManager.onDidChangeResponsiveState((responsiveState) => {
 			this._logService.info(`Extension host (${processManager.friendyName}) is ${responsiveState === ResponsiveState.Responsive ? 'responsive' : 'unresponsive'}.`);
 			this._onDidChangeResponsiveChange.fire({
@@ -869,19 +870,19 @@ export abstract class AbstractExtensionService extends Disposable implements IEx
 		return this._instantiationService.createInstance(ExtensionHostManager, extensionHost, initialActivationEvents, internalExtensionService);
 	}
 
-	private _onExtensionHostCrashOrExit(extensionHost: IExtensionHostManager, code: number, signal: string | null): void {
+	private _onExtensionHostCrashOrExit(extensionHost: IExtensionHostManager, code: number, signal: string | null, reason: ExtensionHostExitReason | null): void {
 
 		// Unexpected termination
 		const isExtensionDevHost = parseExtensionDevOptions(this._environmentService).isExtensionDevHost;
 		if (!isExtensionDevHost) {
-			this._onExtensionHostCrashed(extensionHost, code, signal);
+			this._onExtensionHostCrashed(extensionHost, code, signal, reason);
 			return;
 		}
 
 		this._onExtensionHostExit(code);
 	}
 
-	protected _onExtensionHostCrashed(extensionHost: IExtensionHostManager, code: number, signal: string | null): void {
+	protected _onExtensionHostCrashed(extensionHost: IExtensionHostManager, code: number, signal: string | null, reason: ExtensionHostExitReason | null): void {
 		console.error(`Extension host (${extensionHost.friendyName}) terminated unexpectedly. Code: ${code}, Signal: ${signal}`);
 		if (extensionHost.kind === ExtensionHostKind.LocalProcess) {
 			this._doStopExtensionHosts();

--- a/src/vs/workbench/services/extensions/common/extensionHostManager.ts
+++ b/src/vs/workbench/services/extensions/common/extensionHostManager.ts
@@ -24,7 +24,7 @@ import { IWorkbenchEnvironmentService } from '../../environment/common/environme
 import { ExtHostCustomersRegistry, IInternalExtHostContext } from './extHostCustomers.js';
 import { ExtensionHostKind, extensionHostKindToString } from './extensionHostKind.js';
 import { IExtensionHostManager } from './extensionHostManagers.js';
-import { IExtensionDescriptionDelta } from './extensionHostProtocol.js';
+import { ExtensionHostExitReason, IExtensionDescriptionDelta } from './extensionHostProtocol.js';
 import { IExtensionHostProxy, IResolveAuthorityResult } from './extensionHostProxy.js';
 import { ExtensionRunningLocation } from './extensionRunningLocation.js';
 import { ActivationKind, ExtensionActivationReason, ExtensionHostStartup, IExtensionHost, IExtensionInspectInfo, IInternalExtensionService } from './extensions.js';
@@ -57,7 +57,7 @@ type ExtensionHostStartupEvent = {
 
 export class ExtensionHostManager extends Disposable implements IExtensionHostManager {
 
-	public readonly onDidExit: Event<[number, string | null]>;
+	public readonly onDidExit: Event<[number, string | null, ExtensionHostExitReason | null]>;
 
 	private readonly _onDidChangeResponsiveState: Emitter<ResponsiveState> = this._register(new Emitter<ResponsiveState>());
 	public readonly onDidChangeResponsiveState: Event<ResponsiveState> = this._onDidChangeResponsiveState.event;

--- a/src/vs/workbench/services/extensions/common/extensionHostManagers.ts
+++ b/src/vs/workbench/services/extensions/common/extensionHostManagers.ts
@@ -7,7 +7,7 @@ import { Event } from '../../../../base/common/event.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ExtensionIdentifier, IExtensionDescription } from '../../../../platform/extensions/common/extensions.js';
 import { ExtensionHostKind } from './extensionHostKind.js';
-import { IExtensionDescriptionDelta } from './extensionHostProtocol.js';
+import { ExtensionHostExitReason, IExtensionDescriptionDelta } from './extensionHostProtocol.js';
 import { IResolveAuthorityResult } from './extensionHostProxy.js';
 import { ExtensionRunningLocation } from './extensionRunningLocation.js';
 import { ActivationKind, ExtensionActivationReason, ExtensionHostStartup, IExtensionInspectInfo } from './extensions.js';
@@ -18,7 +18,7 @@ export interface IExtensionHostManager {
 	readonly kind: ExtensionHostKind;
 	readonly startup: ExtensionHostStartup;
 	readonly friendyName: string;
-	readonly onDidExit: Event<[number, string | null]>;
+	readonly onDidExit: Event<[number, string | null, ExtensionHostExitReason | null]>;
 	readonly onDidChangeResponsiveState: Event<ResponsiveState>;
 	disconnect(): Promise<void>;
 	dispose(): void;

--- a/src/vs/workbench/services/extensions/common/extensionHostProtocol.ts
+++ b/src/vs/workbench/services/extensions/common/extensionHostProtocol.ts
@@ -104,6 +104,10 @@ export const enum ExtensionHostExitCode {
 	UnexpectedError = 81,
 }
 
+export const enum ExtensionHostExitReason {
+	OutOfMemory = 'OutOfMemory'
+}
+
 export interface IExtHostReadyMessage {
 	type: 'VSCODE_EXTHOST_IPC_READY';
 }

--- a/src/vs/workbench/services/extensions/common/extensions.ts
+++ b/src/vs/workbench/services/extensions/common/extensions.ts
@@ -14,7 +14,7 @@ import { ApiProposalName } from '../../../../platform/extensions/common/extensio
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { IV8Profile } from '../../../../platform/profiling/common/profiling.js';
 import { ExtensionHostKind } from './extensionHostKind.js';
-import { IExtensionDescriptionDelta, IExtensionDescriptionSnapshot } from './extensionHostProtocol.js';
+import { ExtensionHostExitReason, IExtensionDescriptionDelta, IExtensionDescriptionSnapshot } from './extensionHostProtocol.js';
 import { ExtensionRunningLocation } from './extensionRunningLocation.js';
 import { IExtensionPoint } from './extensionsRegistry.js';
 
@@ -130,7 +130,7 @@ export interface IExtensionHost {
 	 * **NOTE**: this will reflect extensions correctly only after `start()` resolves.
 	 */
 	readonly extensions: ExtensionHostExtensions | null;
-	readonly onExit: Event<[number, string | null]>;
+	readonly onExit: Event<[number, string | null, ExtensionHostExitReason | null]>;
 
 	start(): Promise<IMessagePassingProtocol>;
 	getInspectPort(): IExtensionInspectInfo | undefined;

--- a/src/vs/workbench/services/extensions/common/lazyCreateExtensionHostManager.ts
+++ b/src/vs/workbench/services/extensions/common/lazyCreateExtensionHostManager.ts
@@ -14,7 +14,7 @@ import { RemoteAuthorityResolverErrorCode } from '../../../../platform/remote/co
 import { ExtensionHostKind } from './extensionHostKind.js';
 import { ExtensionHostManager, friendlyExtHostName } from './extensionHostManager.js';
 import { IExtensionHostManager } from './extensionHostManagers.js';
-import { IExtensionDescriptionDelta } from './extensionHostProtocol.js';
+import { ExtensionHostExitReason, IExtensionDescriptionDelta } from './extensionHostProtocol.js';
 import { IResolveAuthorityResult } from './extensionHostProxy.js';
 import { ExtensionRunningLocation } from './extensionRunningLocation.js';
 import { ActivationKind, ExtensionActivationReason, ExtensionHostStartup, IExtensionHost, IExtensionInspectInfo, IInternalExtensionService } from './extensions.js';
@@ -25,7 +25,7 @@ import { ResponsiveState } from './rpcProtocol.js';
  */
 export class LazyCreateExtensionHostManager extends Disposable implements IExtensionHostManager {
 
-	public readonly onDidExit: Event<[number, string | null]>;
+	public readonly onDidExit: Event<[number, string | null, ExtensionHostExitReason | null]>;
 	private readonly _onDidChangeResponsiveState: Emitter<ResponsiveState> = this._register(new Emitter<ResponsiveState>());
 	public readonly onDidChangeResponsiveState: Event<ResponsiveState> = this._onDidChangeResponsiveState.event;
 

--- a/src/vs/workbench/services/extensions/common/remoteExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/common/remoteExtensionHost.ts
@@ -25,7 +25,7 @@ import { IWorkspaceContextService, WorkbenchState } from '../../../../platform/w
 import { IWorkbenchEnvironmentService } from '../../environment/common/environmentService.js';
 import { IDefaultLogLevelsService } from '../../log/common/defaultLogLevels.js';
 import { parseExtensionDevOptions } from './extensionDevOptions.js';
-import { IExtensionHostInitData, MessageType, UIKind, createMessageOfType, isMessageOfType } from './extensionHostProtocol.js';
+import { ExtensionHostExitReason, IExtensionHostInitData, MessageType, UIKind, createMessageOfType, isMessageOfType } from './extensionHostProtocol.js';
 import { RemoteRunningLocation } from './extensionRunningLocation.js';
 import { ExtensionHostExtensions, ExtensionHostStartup, IExtensionHost } from './extensions.js';
 
@@ -51,8 +51,8 @@ export class RemoteExtensionHost extends Disposable implements IExtensionHost {
 	public readonly startup = ExtensionHostStartup.EagerAutoStart;
 	public extensions: ExtensionHostExtensions | null = null;
 
-	private _onExit: Emitter<[number, string | null]> = this._register(new Emitter<[number, string | null]>());
-	public readonly onExit: Event<[number, string | null]> = this._onExit.event;
+	private _onExit: Emitter<[number, string | null, ExtensionHostExitReason | null]> = this._register(new Emitter<[number, string | null, ExtensionHostExitReason | null]>());
+	public readonly onExit: Event<[number, string | null, ExtensionHostExitReason | null]> = this._onExit.event;
 
 	private _protocol: PersistentProtocol | null;
 	private _hasLostConnection: boolean;
@@ -200,7 +200,7 @@ export class RemoteExtensionHost extends Disposable implements IExtensionHost {
 			return;
 		}
 
-		this._onExit.fire([0, reconnectionToken]);
+		this._onExit.fire([0, reconnectionToken, null]);
 	}
 
 	private async _createExtHostInitData(isExtensionDevelopmentDebug: boolean): Promise<IExtensionHostInitData> {

--- a/src/vs/workbench/services/extensions/electron-browser/localProcessExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/electron-browser/localProcessExtensionHost.ts
@@ -32,7 +32,7 @@ import { IWorkspaceContextService, WorkbenchState, isUntitledWorkspace } from '.
 import { INativeWorkbenchEnvironmentService } from '../../environment/electron-browser/environmentService.js';
 import { IShellEnvironmentService } from '../../environment/electron-browser/shellEnvironmentService.js';
 import { MessagePortExtHostConnection, writeExtHostConnection } from '../common/extensionHostEnv.js';
-import { createMessageOfType, IExtensionHostInitData, MessageType, NativeLogMarkers, UIKind, isMessageOfType } from '../common/extensionHostProtocol.js';
+import { createMessageOfType, ExtensionHostExitReason, IExtensionHostInitData, MessageType, NativeLogMarkers, UIKind, isMessageOfType } from '../common/extensionHostProtocol.js';
 import { LocalProcessRunningLocation } from '../common/extensionRunningLocation.js';
 import { ExtensionHostExtensions, ExtensionHostStartup, IExtensionHost, IExtensionInspectInfo } from '../common/extensions.js';
 import { IHostService } from '../../host/browser/host.js';
@@ -98,8 +98,8 @@ export class NativeLocalProcessExtensionHost extends Disposable implements IExte
 	public readonly remoteAuthority = null;
 	public extensions: ExtensionHostExtensions | null = null;
 
-	private readonly _onExit: Emitter<[number, string]> = this._register(new Emitter<[number, string]>());
-	public readonly onExit: Event<[number, string]> = this._onExit.event;
+	private readonly _onExit: Emitter<[number, string | null, ExtensionHostExitReason | null]> = this._register(new Emitter<[number, string | null, ExtensionHostExitReason | null]>());
+	public readonly onExit: Event<[number, string | null, ExtensionHostExitReason | null]> = this._onExit.event;
 
 	private readonly _onDidSetInspectPort = this._register(new Emitter<void>());
 
@@ -112,6 +112,7 @@ export class NativeLocalProcessExtensionHost extends Disposable implements IExte
 	// State
 	private _terminating: boolean;
 	private _mainProcessHandlesExtHostShutdown: boolean;
+	private _exitReason: ExtensionHostExitReason | null;
 
 	// Resources, in order they get acquired/created when .start() is called:
 	private _inspectListener: IExtensionInspectInfo | null;
@@ -148,6 +149,7 @@ export class NativeLocalProcessExtensionHost extends Disposable implements IExte
 
 		this._terminating = false;
 		this._mainProcessHandlesExtHostShutdown = false;
+		this._exitReason = null;
 
 		this._inspectListener = null;
 		this._extensionHostProcess = null;
@@ -219,6 +221,8 @@ export class NativeLocalProcessExtensionHost extends Disposable implements IExte
 	}
 
 	private async _start(): Promise<IMessagePassingProtocol> {
+		this._exitReason = null;
+
 		const [extensionHostCreationResult, portNumber, processEnv] = await Promise.all([
 			this._extensionHostStarter.createExtensionHost(),
 			this._tryFindDebugPort(),
@@ -287,6 +291,11 @@ export class NativeLocalProcessExtensionHost extends Disposable implements IExte
 		type Output = { data: string; format: string[] };
 		const onStdout = this._register(this._handleProcessOutputStream(this._extensionHostProcess.onStdout));
 		const onStderr = this._register(this._handleProcessOutputStream(this._extensionHostProcess.onStderr));
+		this._register(onStderr.event(output => {
+			if (isExtensionHostOutOfMemoryError(output)) {
+				this._exitReason = ExtensionHostExitReason.OutOfMemory;
+			}
+		}));
 		const onOutput = Event.any(
 			Event.map(onStdout.event, o => ({ data: `%c${o}`, format: [''] })),
 			Event.map(onStderr.event, o => ({ data: `%c${o}`, format: ['color: red'] }))
@@ -569,7 +578,7 @@ export class NativeLocalProcessExtensionHost extends Disposable implements IExte
 			return;
 		}
 
-		this._onExit.fire([code, signal]);
+		this._onExit.fire([code, signal, this._exitReason]);
 	}
 
 	private _handleProcessOutputStream(stream: Event<string>) {
@@ -637,4 +646,8 @@ export class NativeLocalProcessExtensionHost extends Disposable implements IExte
 			event.join(timeout(100 /* wait a bit for IPC to get delivered */), { id: 'join.extensionDevelopment', label: nls.localize('join.extensionDevelopment', "Terminating extension debug session") });
 		}
 	}
+}
+
+function isExtensionHostOutOfMemoryError(output: string): boolean {
+	return output.includes('JavaScript heap out of memory') || output.includes('Reached heap limit Allocation failed');
 }

--- a/src/vs/workbench/services/extensions/electron-browser/nativeExtensionService.ts
+++ b/src/vs/workbench/services/extensions/electron-browser/nativeExtensionService.ts
@@ -44,7 +44,7 @@ import { ExtensionDescriptionRegistrySnapshot } from '../common/extensionDescrip
 import { parseExtensionDevOptions } from '../common/extensionDevOptions.js';
 import { ExtensionHostKind, ExtensionRunningPreference, IExtensionHostKindPicker, extensionHostKindToString, extensionRunningPreferenceToString } from '../common/extensionHostKind.js';
 import { IExtensionHostManager } from '../common/extensionHostManagers.js';
-import { ExtensionHostExitCode } from '../common/extensionHostProtocol.js';
+import { ExtensionHostExitCode, ExtensionHostExitReason } from '../common/extensionHostProtocol.js';
 import { IExtensionManifestPropertiesService } from '../common/extensionManifestPropertiesService.js';
 import { ExtensionRunningLocation, LocalProcessRunningLocation, LocalWebWorkerRunningLocation } from '../common/extensionRunningLocation.js';
 import { ExtensionRunningLocationTracker, filterExtensionDescriptions } from '../common/extensionRunningLocationTracker.js';
@@ -146,7 +146,7 @@ export class NativeExtensionService extends AbstractExtensionService implements 
 		return this._extensionScanner.scannedExtensions;
 	}
 
-	protected override _onExtensionHostCrashed(extensionHost: IExtensionHostManager, code: number, signal: string | null): void {
+	protected override _onExtensionHostCrashed(extensionHost: IExtensionHostManager, code: number, signal: string | null, reason: ExtensionHostExitReason | null): void {
 
 		const activatedExtensions: ExtensionIdentifier[] = [];
 		const extensionsStatus = this.getExtensionsStatus();
@@ -157,7 +157,7 @@ export class NativeExtensionService extends AbstractExtensionService implements 
 			}
 		}
 
-		super._onExtensionHostCrashed(extensionHost, code, signal);
+		super._onExtensionHostCrashed(extensionHost, code, signal, reason);
 
 		if (extensionHost.kind === ExtensionHostKind.LocalProcess) {
 			if (code === ExtensionHostExitCode.VersionMismatch) {
@@ -178,7 +178,7 @@ export class NativeExtensionService extends AbstractExtensionService implements 
 			}
 
 			this._logExtensionHostCrash(extensionHost);
-			this._sendExtensionHostCrashTelemetry(code, signal, activatedExtensions);
+			this._sendExtensionHostCrashTelemetry(code, signal, reason, activatedExtensions);
 
 			this._localCrashTracker.registerCrash();
 
@@ -227,7 +227,7 @@ export class NativeExtensionService extends AbstractExtensionService implements 
 		}
 	}
 
-	private _sendExtensionHostCrashTelemetry(code: number, signal: string | null, activatedExtensions: ExtensionIdentifier[]): void {
+	private _sendExtensionHostCrashTelemetry(code: number, signal: string | null, reason: ExtensionHostExitReason | null, activatedExtensions: ExtensionIdentifier[]): void {
 		type ExtensionHostCrashClassification = {
 			owner: 'alexdima';
 			comment: 'The extension host has terminated unexpectedly';
@@ -245,6 +245,10 @@ export class NativeExtensionService extends AbstractExtensionService implements 
 			signal,
 			extensionIds: activatedExtensions.map(e => e.value)
 		});
+
+		if (reason === ExtensionHostExitReason.OutOfMemory) {
+			return;
+		}
 
 		for (const extensionId of activatedExtensions) {
 			type ExtensionHostCrashExtensionClassification = {


### PR DESCRIPTION
## Summary

- Detect V8 heap OOM exits from local extension host stderr
- Thread an extension host exit reason through the crash handling path
- Keep aggregate crash telemetry, logs, and notifications, but skip per-extension crash telemetry for OOM exits

## Validation

- Changed-file diagnostics passed
- `node --experimental-strip-types build/hygiene.ts <touched extension files>` passed
- `npm run compile-check-ts-native` still fails on existing unrelated dependency/type drift outside these files

Fixes #319616
