### PR TITLE
Agents: Add hover styles to chat session list collapse button

### DIFF
--- a/src/vs/sessions/SESSIONS_LIST.md
+++ b/src/vs/sessions/SESSIONS_LIST.md
@@ -124,7 +124,7 @@ The sessions list defines menu IDs that contributions can target to add actions.
 
 | Menu | Constant | Where it appears | Use for |
 |------|----------|------------------|---------|
-| `SessionSectionToolbar` | `SessionSectionToolbarMenuId` | Toolbar on section headers (Pinned, workspace groups, Done) | Section-scoped actions like "New Session for Workspace", "Archive All", "Restore All". |
+| `SessionSectionToolbar` | `SessionSectionToolbarMenuId` | Toolbar on section headers (Pinned, workspace groups, Done) | Section-scoped actions like "New Session for Workspace", "Archive All", "Restore All". Section headers also show a collapsible chevron on hover/focus; the chevron uses the same ghost icon hover background token as toolbar icon buttons. |
 
 ### View Title Menus
 

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -379,6 +379,10 @@
 		display: none;
 		color: var(--vscode-descriptionForeground);
 		font-size: var(--vscode-codiconFontSize-compact, 12px);
+		width: 22px;
+		height: 22px;
+		border-radius: 5px;
+		justify-content: center;
 	}
 }
 
@@ -391,6 +395,10 @@
 .monaco-list-row.focused .session-section .session-section-chevron.collapsible {
 	display: flex;
 	align-items: center;
+}
+
+.monaco-list-row .session-section .session-section-chevron.collapsible:hover {
+	background-color: var(--vscode-toolbar-hoverBackground);
 }
 
 .sessions-list-control {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Partial fix #319372 

Add hover styles to chevron collapse button in chat session list workspace items:

<img width="133" height="43" alt="Screenshot 2026-06-02 at 4 40 39 PM" src="https://github.com/user-attachments/assets/9c359d64-23af-4801-b5ed-7719384d6e9d" />