### PR TITLE
Keep RPC channel alive during extension deactivation to allow state updates to flush.

### DIFF
--- a/src/vs/workbench/api/common/extHostExtensionService.ts
+++ b/src/vs/workbench/api/common/extHostExtensionService.ts
@@ -261,13 +261,14 @@ export abstract class AbstractExtHostExtensionService extends Disposable impleme
 			this._logService.error(err);
 		});
 
-		// Invalidate all proxies
-		this._extHostContext.dispose();
-
+		// Keep RPC alive while deactivating so extension state writes can still flush.
 		const extensionsDeactivated = this._deactivateAll();
+		const deactivationTimeout = timeout(5000);
 
 		// Give extensions at most 5 seconds to wrap up any async deactivate, then exit
-		Promise.race([timeout(5000), extensionsDeactivated]).finally(() => {
+		Promise.race([deactivationTimeout, extensionsDeactivated]).finally(() => {
+			deactivationTimeout.cancel();
+			this._extHostContext.dispose();
 			if (this._hostUtils.pid) {
 				this._logService.info(`Extension host with pid ${this._hostUtils.pid} exiting with code ${code}`);
 			} else {

--- a/src/vs/workbench/api/test/common/extHostExtensionService.test.ts
+++ b/src/vs/workbench/api/test/common/extHostExtensionService.test.ts
@@ -1,0 +1,146 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import * as sinon from 'sinon';
+import { promiseWithResolvers, timeout } from '../../../../base/common/async.js';
+import { AbstractExtHostExtensionService } from '../../common/extHostExtensionService.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+
+suite('ExtHostExtensionService', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('terminate keeps RPC alive during extension deactivation', async () => {
+		const log: string[] = [];
+		const deactivation = promiseWithResolvers<void>();
+		const exited = promiseWithResolvers<void>();
+
+		interface ITerminateHarness {
+			terminate(reason: string, code?: number): void;
+			_isTerminating: boolean;
+			_logService: {
+				info: (message: string) => void;
+				flush: () => void;
+				dispose: () => void;
+				error: (message: unknown) => void;
+			};
+			_extHostTerminalService: { dispose: () => void };
+			_activator: { dispose: () => void };
+			_extHostContext: { dispose: () => void };
+			_deactivateAll: () => Promise<void>;
+			_hostUtils: { pid: number | undefined; exit: (code: number) => void };
+		}
+
+		const service = Object.create(AbstractExtHostExtensionService.prototype) as ITerminateHarness;
+		service._isTerminating = false;
+		service._logService = {
+			info: message => log.push(`info:${message}`),
+			flush: () => log.push('flush'),
+			dispose: () => log.push('log:dispose'),
+			error: _message => log.push('error')
+		};
+		service._extHostTerminalService = {
+			dispose: () => log.push('terminal:dispose')
+		};
+		service._activator = {
+			dispose: () => log.push('activator:dispose')
+		};
+		service._extHostContext = {
+			dispose: () => log.push('rpc:dispose')
+		};
+		service._deactivateAll = async () => {
+			log.push('deactivate:start');
+			await deactivation.promise;
+			log.push('deactivate:done');
+		};
+		service._hostUtils = {
+			pid: undefined,
+			exit: (_code: number) => {
+				log.push('host:exit');
+				exited.resolve();
+			}
+		};
+
+		service.terminate('test-shutdown', 0);
+		await timeout(0);
+
+		assert.strictEqual(log.includes('deactivate:start'), true);
+		assert.strictEqual(log.includes('rpc:dispose'), false);
+
+		deactivation.resolve();
+		await exited.promise;
+
+		assert.strictEqual(log.includes('deactivate:done'), true);
+		assert.strictEqual(log.includes('rpc:dispose'), true);
+		assert.ok(log.indexOf('rpc:dispose') > log.indexOf('deactivate:done'));
+	});
+
+	test('terminate exits after timeout when extension deactivation hangs', async () => {
+		const log: string[] = [];
+		const exited = promiseWithResolvers<void>();
+
+		interface ITerminateHarness {
+			terminate(reason: string, code?: number): void;
+			_isTerminating: boolean;
+			_logService: {
+				info: (message: string) => void;
+				flush: () => void;
+				dispose: () => void;
+				error: (message: unknown) => void;
+			};
+			_extHostTerminalService: { dispose: () => void };
+			_activator: { dispose: () => void };
+			_extHostContext: { dispose: () => void };
+			_deactivateAll: () => Promise<void>;
+			_hostUtils: { pid: number | undefined; exit: (code: number) => void };
+		}
+
+		const service = Object.create(AbstractExtHostExtensionService.prototype) as ITerminateHarness;
+		service._isTerminating = false;
+		service._logService = {
+			info: message => log.push(`info:${message}`),
+			flush: () => log.push('flush'),
+			dispose: () => log.push('log:dispose'),
+			error: _message => log.push('error')
+		};
+		service._extHostTerminalService = {
+			dispose: () => log.push('terminal:dispose')
+		};
+		service._activator = {
+			dispose: () => log.push('activator:dispose')
+		};
+		service._extHostContext = {
+			dispose: () => log.push('rpc:dispose')
+		};
+		service._deactivateAll = async () => {
+			log.push('deactivate:start');
+			await new Promise<void>(() => { });
+		};
+		service._hostUtils = {
+			pid: undefined,
+			exit: (_code: number) => {
+				log.push('host:exit');
+				exited.resolve();
+			}
+		};
+
+		const clock = sinon.useFakeTimers();
+		try {
+			service.terminate('test-timeout', 0);
+
+			clock.tick(4999);
+			assert.strictEqual(log.includes('host:exit'), false);
+
+			clock.tick(1);
+			await exited.promise;
+
+			assert.strictEqual(log.includes('deactivate:start'), true);
+			assert.strictEqual(log.includes('rpc:dispose'), true);
+			assert.ok(log.indexOf('rpc:dispose') < log.indexOf('host:exit'));
+		} finally {
+			clock.restore();
+		}
+	});
+});

--- a/src/vs/workbench/api/test/common/extHostExtensionService.test.ts
+++ b/src/vs/workbench/api/test/common/extHostExtensionService.test.ts
@@ -6,6 +6,7 @@
 import assert from 'assert';
 import * as sinon from 'sinon';
 import { promiseWithResolvers, timeout } from '../../../../base/common/async.js';
+import { errorHandler, setUnexpectedErrorHandler } from '../../../../base/common/errors.js';
 import { AbstractExtHostExtensionService } from '../../common/extHostExtensionService.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 
@@ -16,6 +17,7 @@ suite('ExtHostExtensionService', () => {
 		const log: string[] = [];
 		const deactivation = promiseWithResolvers<void>();
 		const exited = promiseWithResolvers<void>();
+		const originalErrorHandler = errorHandler.getUnexpectedErrorHandler();
 
 		interface ITerminateHarness {
 			terminate(reason: string, code?: number): void;
@@ -63,23 +65,28 @@ suite('ExtHostExtensionService', () => {
 			}
 		};
 
-		service.terminate('test-shutdown', 0);
-		await timeout(0);
+		try {
+			service.terminate('test-shutdown', 0);
+			await timeout(0);
 
-		assert.strictEqual(log.includes('deactivate:start'), true);
-		assert.strictEqual(log.includes('rpc:dispose'), false);
+			assert.strictEqual(log.includes('deactivate:start'), true);
+			assert.strictEqual(log.includes('rpc:dispose'), false);
 
-		deactivation.resolve();
-		await exited.promise;
+			deactivation.resolve();
+			await exited.promise;
 
-		assert.strictEqual(log.includes('deactivate:done'), true);
-		assert.strictEqual(log.includes('rpc:dispose'), true);
-		assert.ok(log.indexOf('rpc:dispose') > log.indexOf('deactivate:done'));
+			assert.strictEqual(log.includes('deactivate:done'), true);
+			assert.strictEqual(log.includes('rpc:dispose'), true);
+			assert.ok(log.indexOf('rpc:dispose') > log.indexOf('deactivate:done'));
+		} finally {
+			setUnexpectedErrorHandler(originalErrorHandler);
+		}
 	});
 
 	test('terminate exits after timeout when extension deactivation hangs', async () => {
 		const log: string[] = [];
 		const exited = promiseWithResolvers<void>();
+		const originalErrorHandler = errorHandler.getUnexpectedErrorHandler();
 
 		interface ITerminateHarness {
 			terminate(reason: string, code?: number): void;
@@ -140,6 +147,7 @@ suite('ExtHostExtensionService', () => {
 			assert.strictEqual(log.includes('rpc:dispose'), true);
 			assert.ok(log.indexOf('rpc:dispose') < log.indexOf('host:exit'));
 		} finally {
+			setUnexpectedErrorHandler(originalErrorHandler);
 			clock.restore();
 		}
 	});


### PR DESCRIPTION
Fixes #310150
