### PR TITLE
sessions: experimental setting for local agent host as default provider

### DIFF
--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -109,6 +109,8 @@ Tasks with `runOptions.runOn === "worktreeCreated"` are dispatched client-side o
 
 An **`ISessionType`** identifies an agent backend (e.g., `'copilot-cli'`, `'copilot-cloud'`). Each provider declares which session types it supports and can dynamically update the list via `onDidChangeSessionTypes`. The management service exposes `getAllSessionTypes()` for UI pickers.
 
+Session types are surfaced ordered by each provider's `order` property (lower first; ties keep registration order). The default `order` is `0`, so the Copilot Chat sessions provider keeps precedence by default. The local agent host provider sets its `order` reactively from the experimental `chat.agentHost.defaultSessionsProvider` setting (default `false`, gated behind `chat.agentHost.enabled`): when enabled it returns a negative order so its session types sort before all other providers; otherwise it sorts after the defaults. The provider fires `onDidChangeSessionTypes` when the setting toggles so the management service re-collects and re-sorts. The sort itself lives in `SessionsManagementService._getOrderedProviders()` and applies to both `getAllSessionTypes()` and `getSessionTypesForFolder()` — the orchestration layer stays provider-agnostic (it sorts purely by `order`, with no knowledge of specific provider ids).
+
 ### Changesets
 
 Sessions produce file changes organized into **`ISessionChangeset`** groups — named, togglable collections of file modifications that let users review and selectively apply changes.

--- a/src/vs/sessions/common/agentHostSessionsProvider.ts
+++ b/src/vs/sessions/common/agentHostSessionsProvider.ts
@@ -135,6 +135,15 @@ export interface IAgentHostSessionsProvider extends ISessionsProvider {
 }
 
 export const LOCAL_AGENT_HOST_PROVIDER_ID = 'local-agent-host';
+
+/**
+ * Experimental setting id controlling whether the local agent host acts as the
+ * default sessions provider. When enabled (and `chat.agentHost.enabled` is
+ * true), the local agent host's session types are surfaced before those of
+ * other providers. Defaults to `false`.
+ */
+export const LocalAgentHostDefaultProviderSettingId = 'chat.agentHost.defaultSessionsProvider';
+
 export const REMOTE_AGENT_HOST_PROVIDER_PREFIX = 'agenthost-';
 export const REMOTE_AGENT_HOST_PROVIDER_RE = /^agenthost-/;
 export const ANY_AGENT_HOST_PROVIDER_RE = /^(local-agent-host|agenthost-)/;

--- a/src/vs/sessions/contrib/chat/test/browser/sessionWorkspacePicker.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionWorkspacePicker.test.ts
@@ -66,6 +66,7 @@ function createMockProvider(id: string, opts?: {
 		id,
 		label: `Provider ${id}`,
 		icon: Codicon.remote,
+		order: 0,
 		sessionTypes: [],
 		onDidChangeSessionTypes: Event.None,
 		browseActions: opts?.browseActions ?? [],

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -1049,6 +1049,8 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 	abstract readonly icon: ThemeIcon;
 	abstract readonly browseActions: readonly ISessionWorkspaceBrowseAction[];
 
+	get order(): number { return 0; }
+
 	get sessionTypes(): readonly ISessionType[] { return this._sessionTypes; }
 	protected _sessionTypes: ISessionType[] = [];
 

--- a/src/vs/sessions/contrib/providers/agentHost/browser/localAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/localAgentHost.contribution.ts
@@ -13,7 +13,24 @@ import { IAgentHostSessionWorkingDirectoryResolver } from '../../../../../workbe
 import { AgentHostTerminalContribution } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentHost/agentHostTerminalContribution.js';
 import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
 import { SessionStatus } from '../../../../services/sessions/common/session.js';
+import { LocalAgentHostDefaultProviderSettingId } from '../../../../common/agentHostSessionsProvider.js';
+import { Registry } from '../../../../../platform/registry/common/platform.js';
+import { IConfigurationRegistry, Extensions as ConfigurationExtensions } from '../../../../../platform/configuration/common/configurationRegistry.js';
+import { localize } from '../../../../../nls.js';
 import { LocalAgentHostSessionsProvider } from './localAgentHostSessionsProvider.js';
+
+Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
+	id: 'sessions',
+	properties: {
+		[LocalAgentHostDefaultProviderSettingId]: {
+			type: 'boolean',
+			default: false,
+			tags: ['experimental'],
+			experiment: { mode: 'startup' },
+			markdownDescription: localize('sessions.chat.agentHost.defaultSessionsProvider', "When enabled, the local agent host is used as the default sessions provider and its session types are shown first in the Agents window. Requires `#chat.agentHost.enabled#`."),
+		},
+	},
+});
 
 /**
  * Registers the {@link LocalAgentHostSessionsProvider} as a sessions provider

--- a/src/vs/sessions/contrib/providers/agentHost/browser/localAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/localAgentHost.contribution.ts
@@ -27,7 +27,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			default: false,
 			tags: ['experimental'],
 			experiment: { mode: 'startup' },
-			markdownDescription: localize('sessions.chat.agentHost.defaultSessionsProvider', "When enabled, the local agent host is used as the default sessions provider and its session types are shown first in the Agents window. Requires `#chat.agentHost.enabled#`."),
+			markdownDescription: localize('sessions.chat.agentHost.defaultSessionsProvider', "When enabled, the local agent host is used as the default sessions provider and its session types are shown first in the Agents window. Requires `#{0}#`.", AgentHostEnabledSettingId),
 		},
 	},
 });

--- a/src/vs/sessions/contrib/providers/agentHost/browser/localAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/localAgentHostSessionsProvider.ts
@@ -23,7 +23,7 @@ import { IChatWidgetService } from '../../../../../workbench/contrib/chat/browse
 import { IChatService } from '../../../../../workbench/contrib/chat/common/chatService/chatService.js';
 import { IChatSessionsService } from '../../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { ILanguageModelsService } from '../../../../../workbench/contrib/chat/common/languageModels.js';
-import { LOCAL_AGENT_HOST_PROVIDER_ID } from '../../../../common/agentHostSessionsProvider.js';
+import { LOCAL_AGENT_HOST_PROVIDER_ID, LocalAgentHostDefaultProviderSettingId } from '../../../../common/agentHostSessionsProvider.js';
 import { buildAgentHostSessionWorkspace, readBranchProtectionPatterns } from '../../../../common/agentHostSessionWorkspace.js';
 import { IGitHubInfo, ISessionWorkspace, ISessionWorkspaceBrowseAction, SESSION_WORKSPACE_GROUP_LOCAL } from '../../../../services/sessions/common/session.js';
 import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
@@ -47,6 +47,17 @@ export class LocalAgentHostSessionsProvider extends BaseAgentHostSessionsProvide
 	readonly icon: ThemeIcon = Codicon.vm;
 	readonly browseActions: readonly ISessionWorkspaceBrowseAction[];
 	readonly supportsLocalWorkspaces = true;
+
+	/**
+	 * When the experimental {@link LocalAgentHostDefaultProviderSettingId}
+	 * setting is enabled, the local agent host becomes the default sessions
+	 * provider: its session types sort before every other provider (negative
+	 * order). Otherwise it sorts after the default providers so Copilot Chat
+	 * keeps precedence.
+	 */
+	override get order(): number {
+		return this._configurationService.getValue<boolean>(LocalAgentHostDefaultProviderSettingId) ? -1 : 1;
+	}
 
 	constructor(
 		@IAgentHostService private readonly _agentHostService: IAgentHostService,
@@ -95,6 +106,15 @@ export class LocalAgentHostSessionsProvider extends BaseAgentHostSessionsProvide
 				return;
 			}
 			this._refreshSessions();
+		}));
+
+		// When the "default sessions provider" preference changes, the
+		// provider's `order` flips. Re-fire `onDidChangeSessionTypes` so the
+		// management service re-collects and re-sorts the session types.
+		this._register(this._configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration(LocalAgentHostDefaultProviderSettingId)) {
+				this._onDidChangeSessionTypes.fire();
+			}
 		}));
 	}
 

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -1363,6 +1363,7 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 	readonly id = COPILOT_PROVIDER_ID;
 	readonly label = localize('copilotChatSessionsProvider', "Copilot Chat");
 	readonly icon = Codicon.copilot;
+	readonly order = 0;
 
 	get sessionTypes(): readonly ISessionType[] {
 		const types: ISessionType[] = [CopilotCLISessionType, CopilotCloudSessionType];

--- a/src/vs/sessions/contrib/providers/localChatSessions/browser/localChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/localChatSessions/browser/localChatSessionsProvider.ts
@@ -397,6 +397,7 @@ export class LocalChatSessionsProvider extends Disposable implements ISessionsPr
 	readonly id = LOCAL_PROVIDER_ID;
 	readonly label = localize('localChatSessionsProvider', "Local Chat");
 	readonly icon = Codicon.vm;
+	readonly order = 0;
 	readonly browseActions: readonly [] = [];
 	readonly supportsLocalWorkspaces = true;
 

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -147,6 +147,7 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 			this._updateSessionTypes();
 		}));
 		this._subscribeToProviders(this.sessionsProvidersService.getProviders());
+		this._sessionTypes = this._collectSessionTypes();
 
 		// Session navigation history
 		this._navigation = this._register(new SessionsNavigation(
@@ -350,7 +351,7 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 
 	getSessionTypesForFolder(folderUri: URI): IProviderSessionType[] {
 		const result: IProviderSessionType[] = [];
-		for (const provider of this.sessionsProvidersService.getProviders()) {
+		for (const provider of this._getOrderedProviders()) {
 			if (!provider.resolveWorkspace(folderUri)) {
 				continue;
 			}
@@ -374,7 +375,7 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 	private _collectSessionTypes(): ISessionType[] {
 		const types: ISessionType[] = [];
 		const seen = new Set<string>();
-		for (const provider of this.sessionsProvidersService.getProviders()) {
+		for (const provider of this._getOrderedProviders()) {
 			for (const type of provider.sessionTypes) {
 				if (!seen.has(type.id)) {
 					seen.add(type.id);
@@ -383,6 +384,16 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 			}
 		}
 		return types;
+	}
+
+	/**
+	 * Returns the registered providers in the order their session types should
+	 * be surfaced, sorted by each provider's {@link ISessionsProvider.order}
+	 * (lower first). The sort is stable, so providers with equal order keep
+	 * their registration order.
+	 */
+	private _getOrderedProviders(): ISessionsProvider[] {
+		return [...this.sessionsProvidersService.getProviders()].sort((a, b) => a.order - b.order);
 	}
 
 	private _updateSessionTypes(): void {

--- a/src/vs/sessions/services/sessions/common/sessionsProvider.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsProvider.ts
@@ -52,6 +52,15 @@ export interface ISessionsProvider {
 	readonly icon: ThemeIcon;
 
 	/**
+	 * Sort order that determines the precedence of this provider's session
+	 * types relative to other providers. Lower values are surfaced first;
+	 * providers with equal order keep their registration order. The default is
+	 * `0`. A provider may change this dynamically (e.g. based on a setting) and
+	 * fire `onDidChangeSessionTypes` to have consumers re-evaluate the order.
+	 */
+	readonly order: number;
+
+	/**
 	 * Session types supported by this provider. The provider is expected to update this list and fire `onDidChangeSessionTypes`
 	 */
 	readonly sessionTypes: readonly ISessionType[];

--- a/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
@@ -29,6 +29,7 @@ import { ISessionChangeEvent, ISendRequestOptions, ISessionsProvider } from '../
 import { SessionsManagementService } from '../../browser/sessionsManagementService.js';
 import { ISessionsManagementService } from '../../common/sessionsManagement.js';
 import { ISessionsProvidersService } from '../../browser/sessionsProvidersService.js';
+import { LOCAL_AGENT_HOST_PROVIDER_ID } from '../../../../common/agentHostSessionsProvider.js';
 
 const stubChat = {
 	resource: URI.parse('test:///chat'),
@@ -149,9 +150,10 @@ class TestSessionsProvidersService extends mock<ISessionsProvidersService>() {
 }
 
 class TestSessionsProvider extends mock<ISessionsProvider>() {
-	override readonly id = 'test';
+	override readonly id: string = 'test';
 	override readonly label = 'Test';
 	override readonly icon = Codicon.vm;
+	override readonly order: number = 0;
 	override readonly sessionTypes: readonly ISessionType[] = [{ id: 'test', label: 'Test', icon: Codicon.vm }];
 	override readonly onDidChangeSessionTypes = Event.None;
 	override readonly onDidChangeSessions = Event.None;
@@ -395,4 +397,48 @@ suite('SessionsManagementService', () => {
 		assert.strictEqual(sendRequestStarted, true);
 		assert.strictEqual(service.activeSession.get(), undefined);
 	});
+
+	test('getAllSessionTypes orders providers by their order property (lower first)', () => {
+		const service = createOrderedTypesService(disposables, 0, 1);
+		assert.deepStrictEqual(service.getAllSessionTypes().map(type => type.id), ['copilot', 'agent-host']);
+	});
+
+	test('getAllSessionTypes surfaces local agent host types first when it has lower order', () => {
+		const service = createOrderedTypesService(disposables, 0, -1);
+		assert.deepStrictEqual(service.getAllSessionTypes().map(type => type.id), ['agent-host', 'copilot']);
+	});
 });
+
+/**
+ * Builds a management service with a Copilot-style provider and a
+ * local-agent-host provider, each with an explicit {@link ISessionsProvider.order}.
+ * Used to assert that the management service surfaces session types ordered by
+ * provider order (lower first).
+ */
+function createOrderedTypesService(disposables: ReturnType<typeof ensureNoDisposablesAreLeakedInTestSuite>, copilotOrder: number, agentHostOrder: number): ISessionsManagementService {
+	const copilotProvider = new class extends TestSessionsProvider {
+		override readonly id = 'default-copilot';
+		override readonly order = copilotOrder;
+		override readonly sessionTypes: readonly ISessionType[] = [{ id: 'copilot', label: 'Copilot', icon: Codicon.vm }];
+	}(stubSession({ sessionId: 'c1', providerId: 'default-copilot' }));
+	const agentHostProvider = new class extends TestSessionsProvider {
+		override readonly id = LOCAL_AGENT_HOST_PROVIDER_ID;
+		override readonly order = agentHostOrder;
+		override readonly sessionTypes: readonly ISessionType[] = [{ id: 'agent-host', label: 'Agent Host', icon: Codicon.vm }];
+	}(stubSession({ sessionId: 'a1', providerId: LOCAL_AGENT_HOST_PROVIDER_ID }));
+
+	const instantiationService = disposables.add(new TestInstantiationService());
+	instantiationService.stub(IStorageService, disposables.add(new InMemoryStorageService()));
+	instantiationService.stub(ILogService, new NullLogService());
+	instantiationService.stub(IContextKeyService, disposables.add(new MockContextKeyService()));
+	instantiationService.stub(ISessionsProvidersService, new TestSessionsProvidersService([copilotProvider, agentHostProvider]));
+	instantiationService.stub(IUriIdentityService, { extUri: extUriBiasedIgnorePathCase });
+	instantiationService.stub(IChatWidgetService, new TestChatWidgetService());
+	instantiationService.stub(IAgentSessionsService, new TestAgentSessionsService());
+	instantiationService.stub(IProgressService, new TestProgressService());
+	instantiationService.stub(IChatService, new class extends mock<IChatService>() {
+		override readonly onDidSubmitRequest = Event.None;
+	});
+
+	return disposables.add(instantiationService.createInstance(SessionsManagementService));
+}


### PR DESCRIPTION
## What

Adds an experimental setting `chat.agentHost.defaultSessionsProvider` (default `false`, gated behind `chat.agentHost.enabled`). When enabled, the **local agent host** becomes the default sessions provider: its session types are surfaced **before** every other provider's in the Agents window (new-session picker, type filter, etc.). When disabled, the Copilot Chat sessions provider keeps precedence (current behavior).

## How

Rather than hardcoding provider ordering in the orchestration layer, ordering now flows through the provider contract:

- **`ISessionsProvider.order`** — new required `number` property. Lower values sort first; default `0`; ties keep registration order.
- **`SessionsManagementService`** — `_getOrderedProviders()` does a stable sort by `order` and is used by both `getAllSessionTypes()` and `getSessionTypesForFolder()`. The management service stays provider-agnostic.
- **Providers own their order:**
  - `BaseAgentHostSessionsProvider` defaults `order` to `0`.
  - `LocalAgentHostSessionsProvider` overrides `order` to return `-1` when the setting is enabled (else `1`), and fires `onDidChangeSessionTypes` when the setting toggles so the list re-sorts live.
  - `CopilotChatSessionsProvider` / `LocalChatSessionsProvider` set explicit `order = 0`.
- The setting is registered as experimental (`tags: ['experimental']` + `experiment: { mode: 'startup' }`).

## Notes for reviewers

- The setting id constant lives in `src/vs/sessions/common/agentHostSessionsProvider.ts`.
- `SessionsManagementService` now initializes its session-types cache at construction.
- Added unit tests asserting session types are ordered by provider `order`. Updated `SESSIONS.md`.

Validated with `compile-check-ts-native`, `valid-layers-check`, hygiene, and the affected browser unit tests.
