### PR TITLE
sessions: use updatedAt timestamp to show last active relative time

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -449,7 +449,7 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 			const hideDetails = sessionStatus === SessionStatus.InProgress || sessionStatus === SessionStatus.NeedsInput;
 
 			if (!hideDetails) {
-				timeDate = this.options.sorting() === SessionsSorting.Updated ? element.updatedAt.read(reader) : element.createdAt;
+				timeDate = element.updatedAt.read(reader);
 			}
 			// Clear and rebuild details row
 			DOM.clearNode(template.detailsRow);

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -554,9 +554,11 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 				}
 				const timeEl = DOM.append(template.detailsRow, $('span.session-time'));
 				const definiteTimeDate = timeDate;
+				const isCreatedSort = this.options.sorting() === SessionsSorting.Created;
 				const formatTime = () => {
 					const seconds = Math.round((Date.now() - definiteTimeDate.getTime()) / 1000);
-					return seconds < 60 ? localize('secondsDuration', "now") : fromNow(definiteTimeDate, true);
+					const relativeTime = seconds < 60 ? localize('secondsDuration', "now") : fromNow(definiteTimeDate, true);
+					return isCreatedSort ? localize('sessionUpdated', "Updated {0}", relativeTime) : relativeTime;
 				};
 				timeEl.textContent = formatTime();
 				const targetWindow = DOM.getWindow(timeEl);


### PR DESCRIPTION
Fixes #319520

## Proposed Changes
- Updates the sessions list to always use `element.updatedAt` for displaying the relative time of the session's last activity.
- Previously, when the sessions list was sorted by the default `Created` order, the UI would use `element.createdAt`, which is a static `Date` object. This caused the relative time display to become "stuck" on the creation time and not update after new activity in the session.
- By always observing `element.updatedAt` (which is an `IObservable<Date>`) within the `autorun` context, the relative time text (e.g. "now", "10 mins ago") updates reactively on any new activity regardless of the selected sort order, while keeping the actual list sorting behavior perfectly intact.

## How to Test
1. Open the Sessions view.
2. Ensure the sort order of the view is set to the default ("Created").
3. Perform an action that updates an existing session (or observe an active session).
4. Verify that the relative time text in the sessions list updates reactively (e.g., changes to "now" after new activity) instead of remaining static.
