### PR TITLE
Add openIntegratedBrowser option to serverReadyAction.action

### DIFF
--- a/extensions/debug-server-ready/package.json
+++ b/extensions/debug-server-ready/package.json
@@ -47,10 +47,12 @@
                       "action": {
                         "type": "string",
                         "enum": [
-                          "openExternally"
+                          "openExternally",
+                          "openIntegratedBrowser"
                         ],
                         "enumDescriptions": [
-                          "%debug.server.ready.action.openExternally.description%"
+                          "%debug.server.ready.action.openExternally.description%",
+                          "%debug.server.ready.action.openIntegratedBrowser.description%"
                         ],
                         "markdownDescription": "%debug.server.ready.action.description%",
                         "default": "openExternally"

--- a/extensions/debug-server-ready/package.nls.json
+++ b/extensions/debug-server-ready/package.nls.json
@@ -5,6 +5,7 @@
 	"debug.server.ready.serverReadyAction.description": "Act upon a URI when a server program under debugging is ready (indicated by sending output of the form 'listening on port 3000' or 'Now listening on: https://localhost:5001' to the debug console.)",
 	"debug.server.ready.action.description": "What to do with the URI when the server is ready.",
 	"debug.server.ready.action.openExternally.description": "Open URI externally with the default application.",
+	"debug.server.ready.action.openIntegratedBrowser.description": "Open URI in the integrated browser.",
 	"debug.server.ready.action.debugWithChrome.description": "Start debugging with the 'Debugger for Chrome'.",
 	"debug.server.ready.action.startDebugging.description": "Run another launch configuration.",
 	"debug.server.ready.pattern.description": "Server is ready if this pattern appears on the debug console. The first capture group must include a URI or a port number.",

--- a/extensions/debug-server-ready/src/extension.ts
+++ b/extensions/debug-server-ready/src/extension.ts
@@ -14,7 +14,7 @@ const WEB_ROOT = '${workspaceFolder}';
 
 interface ServerReadyAction {
 	pattern: string;
-	action?: 'openExternally' | 'debugWithChrome' | 'debugWithEdge' | 'startDebugging';
+	action?: 'openExternally' | 'openIntegratedBrowser' | 'debugWithChrome' | 'debugWithEdge' | 'startDebugging';
 	uriFormat?: string;
 	webRoot?: string;
 	name?: string;
@@ -191,6 +191,10 @@ class ServerReadyDetector extends vscode.Disposable {
 
 			case 'openExternally':
 				await vscode.env.openExternal(vscode.Uri.parse(uri));
+				break;
+
+			case 'openIntegratedBrowser':
+				vscode.commands.executeCommand('workbench.action.browser.open', uri);
 				break;
 
 			case 'debugWithChrome':


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #319676

Details of the decision making for this pull request are included in the issue.

Testing the changes can be done by creating a new node.js project with the following launch.json:

```json
{
    "configurations": [
        {
            "name": "Launch Program",
            "program": "${workspaceFolder}/index.js",
            "request": "launch",
            "skipFiles": [
                "<node_internals>/**"
            ],
            "type": "node",
            "serverReadyAction": {
                "action": "openIntegratedBrowser",
                "pattern": "listening on port ([0-9]+)",
                "uriFormat": "http://localhost:%s"
            }
        }
    ]
}
```

and app.js

```javascript
const express = require('express');
const app = express();
const port = 3000;

app.get('/', (req, res) => {
  res.send('Hello World!');
});

app.listen(port, () => {
  console.log(`Example app listening on port ${port}`);
});
```