### PR TITLE
Add LanguageModelUsagePart for extension chat providers

### DIFF
--- a/extensions/copilot/src/extension/byok/common/byokProvider.ts
+++ b/extensions/copilot/src/extension/byok/common/byokProvider.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import type { Disposable, LanguageModelChatInformation, LanguageModelDataPart, LanguageModelTextPart, LanguageModelThinkingPart, LanguageModelToolCallPart, LanguageModelToolResultPart } from 'vscode';
+import type { Disposable, LanguageModelChatInformation, LanguageModelDataPart, LanguageModelTextPart, LanguageModelThinkingPart, LanguageModelToolCallPart, LanguageModelToolResultPart, LanguageModelUsagePart } from 'vscode';
 import { CopilotToken } from '../../../platform/authentication/common/copilotToken';
 import { EndpointEditToolName, IChatModelInformation, ModelSupportedEndpoint } from '../../../platform/endpoint/common/endpointProvider';
 import { TokenizerType } from '../../../util/common/tokenizer';
@@ -27,7 +27,7 @@ interface BYOKBaseModelConfig {
 	capabilities?: BYOKModelCapabilities;
 }
 
-export type LMResponsePart = LanguageModelTextPart | LanguageModelToolCallPart | LanguageModelDataPart | LanguageModelThinkingPart | LanguageModelToolResultPart;
+export type LMResponsePart = LanguageModelTextPart | LanguageModelToolCallPart | LanguageModelDataPart | LanguageModelThinkingPart | LanguageModelToolResultPart | LanguageModelUsagePart;
 
 export interface BYOKGlobalKeyModelConfig extends BYOKBaseModelConfig {
 	apiKey: string;

--- a/extensions/copilot/src/platform/endpoint/vscode-node/extChatEndpoint.ts
+++ b/extensions/copilot/src/platform/endpoint/vscode-node/extChatEndpoint.ts
@@ -321,7 +321,6 @@ function normalizeApiUsageTotal(prompt: number, completion: number, total: numbe
 	}
 	return Math.max(total, prompt + completion);
 }
-}
 
 function normalizeApiUsage(parsed: unknown): APIUsage | undefined {
 	if (!isApiUsage(parsed)) {
@@ -360,7 +359,6 @@ function apiUsageFromLanguageModelUsagePart(usage: vscode.LanguageModelUsagePart
 			? { prompt_tokens_details: { cached_tokens: Math.max(0, cached) } }
 			: {}),
 	};
-}
 }
 
 export function convertToApiChatMessage(messages: Raw.ChatMessage[]): Array<vscode.LanguageModelChatMessage | vscode.LanguageModelChatMessage2> {

--- a/extensions/copilot/src/platform/endpoint/vscode-node/extChatEndpoint.ts
+++ b/extensions/copilot/src/platform/endpoint/vscode-node/extChatEndpoint.ts
@@ -227,6 +227,8 @@ export class ExtensionContributedChatEndpoint implements IChatEndpoint {
 						numToolsCalled++;
 						await streamRecorder.callback(text, 0, { text: '', copilotToolCalls: functionCalls });
 					}
+				} else if (chunk instanceof vscode.LanguageModelUsagePart) {
+					reportedUsage = apiUsageFromLanguageModelUsagePart(chunk);
 				} else if (chunk instanceof vscode.LanguageModelDataPart) {
 					if (chunk.mimeType === CustomDataPartMimeTypes.StatefulMarker) {
 						const decoded = decodeStatefulMarker(chunk.data);
@@ -237,19 +239,9 @@ export class ExtensionContributedChatEndpoint implements IChatEndpoint {
 					} else if (chunk.mimeType === CustomDataPartMimeTypes.Usage) {
 						try {
 							const parsed = JSON.parse(new TextDecoder().decode(chunk.data)) as APIUsage;
-							if (isApiUsage(parsed)) {
-								// Clamp sentinel negative values that some BYOK providers emit
-								// when the API hasn't reported a count yet (e.g. -1).
-								reportedUsage = {
-									...parsed,
-									prompt_tokens: Math.max(0, parsed.prompt_tokens),
-									completion_tokens: Math.max(0, parsed.completion_tokens),
-									total_tokens: Math.max(0, parsed.total_tokens),
-									prompt_tokens_details: {
-										...parsed.prompt_tokens_details,
-										cached_tokens: Math.max(0, parsed.prompt_tokens_details?.cached_tokens ?? 0)
-									}
-								};
+							const normalized = normalizeApiUsage(parsed);
+							if (normalized) {
+								reportedUsage = normalized;
 							}
 						} catch {
 							// ignore malformed usage payload
@@ -321,6 +313,37 @@ function getTelemetryTurnFromProperties(telemetryProperties: IMakeChatRequestOpt
 
 	const turn = Number.parseInt(telemetryProperties.turnIndex, 10);
 	return Number.isSafeInteger(turn) ? turn : undefined;
+}
+
+function normalizeApiUsage(parsed: APIUsage): APIUsage | undefined {
+	if (!isApiUsage(parsed)) {
+		return undefined;
+	}
+	// Clamp sentinel negative values that some BYOK providers emit
+	// when the API hasn't reported a count yet (e.g. -1).
+	return {
+		...parsed,
+		prompt_tokens: Math.max(0, parsed.prompt_tokens),
+		completion_tokens: Math.max(0, parsed.completion_tokens),
+		total_tokens: Math.max(0, parsed.total_tokens),
+		prompt_tokens_details: {
+			...parsed.prompt_tokens_details,
+			cached_tokens: Math.max(0, parsed.prompt_tokens_details?.cached_tokens ?? 0)
+		}
+	};
+}
+
+function apiUsageFromLanguageModelUsagePart(usage: vscode.LanguageModelUsagePart): APIUsage {
+	const cached = usage.cachedInputTokens;
+	return {
+		prompt_tokens: Math.max(0, usage.promptTokens),
+		completion_tokens: Math.max(0, usage.completionTokens),
+		total_tokens: Math.max(0, usage.totalTokens),
+		...(cached !== undefined
+			? { prompt_tokens_details: { cached_tokens: Math.max(0, cached) } }
+			: {}),
+	};
+}
 }
 
 export function convertToApiChatMessage(messages: Raw.ChatMessage[]): Array<vscode.LanguageModelChatMessage | vscode.LanguageModelChatMessage2> {

--- a/extensions/copilot/src/platform/endpoint/vscode-node/extChatEndpoint.ts
+++ b/extensions/copilot/src/platform/endpoint/vscode-node/extChatEndpoint.ts
@@ -321,15 +321,20 @@ function normalizeApiUsage(parsed: unknown): APIUsage | undefined {
 	}
 	// Clamp sentinel negative values that some BYOK providers emit
 	// when the API hasn't reported a count yet (e.g. -1).
+	const cached = parsed.prompt_tokens_details?.cached_tokens;
 	return {
 		...parsed,
 		prompt_tokens: Math.max(0, parsed.prompt_tokens),
 		completion_tokens: Math.max(0, parsed.completion_tokens),
 		total_tokens: Math.max(0, parsed.total_tokens),
-		prompt_tokens_details: {
-			...parsed.prompt_tokens_details,
-			cached_tokens: Math.max(0, parsed.prompt_tokens_details?.cached_tokens ?? 0)
-		}
+		...(cached !== undefined
+			? {
+				prompt_tokens_details: {
+					...parsed.prompt_tokens_details,
+					cached_tokens: Math.max(0, cached),
+				},
+			}
+			: {}),
 	};
 }
 

--- a/extensions/copilot/src/platform/endpoint/vscode-node/extChatEndpoint.ts
+++ b/extensions/copilot/src/platform/endpoint/vscode-node/extChatEndpoint.ts
@@ -238,7 +238,7 @@ export class ExtensionContributedChatEndpoint implements IChatEndpoint {
 						await streamRecorder.callback?.(text, 0, { text: '', contextManagement });
 					} else if (chunk.mimeType === CustomDataPartMimeTypes.Usage) {
 						try {
-							const parsed = JSON.parse(new TextDecoder().decode(chunk.data)) as APIUsage;
+							const parsed: unknown = JSON.parse(new TextDecoder().decode(chunk.data));
 							const normalized = normalizeApiUsage(parsed);
 							if (normalized) {
 								reportedUsage = normalized;
@@ -315,7 +315,7 @@ function getTelemetryTurnFromProperties(telemetryProperties: IMakeChatRequestOpt
 	return Number.isSafeInteger(turn) ? turn : undefined;
 }
 
-function normalizeApiUsage(parsed: APIUsage): APIUsage | undefined {
+function normalizeApiUsage(parsed: unknown): APIUsage | undefined {
 	if (!isApiUsage(parsed)) {
 		return undefined;
 	}

--- a/extensions/copilot/src/platform/endpoint/vscode-node/extChatEndpoint.ts
+++ b/extensions/copilot/src/platform/endpoint/vscode-node/extChatEndpoint.ts
@@ -315,23 +315,33 @@ function getTelemetryTurnFromProperties(telemetryProperties: IMakeChatRequestOpt
 	return Number.isSafeInteger(turn) ? turn : undefined;
 }
 
+function normalizeApiUsageTotal(prompt: number, completion: number, total: number): number {
+	if (total < 0) {
+		return prompt + completion;
+	}
+	return Math.max(total, prompt + completion);
+}
+}
+
 function normalizeApiUsage(parsed: unknown): APIUsage | undefined {
 	if (!isApiUsage(parsed)) {
 		return undefined;
 	}
 	// Clamp sentinel negative values that some BYOK providers emit
 	// when the API hasn't reported a count yet (e.g. -1).
+	const prompt_tokens = Math.max(0, parsed.prompt_tokens);
+	const completion_tokens = Math.max(0, parsed.completion_tokens);
 	const cached = parsed.prompt_tokens_details?.cached_tokens;
 	return {
 		...parsed,
-		prompt_tokens: Math.max(0, parsed.prompt_tokens),
-		completion_tokens: Math.max(0, parsed.completion_tokens),
-		total_tokens: Math.max(0, parsed.total_tokens),
-		...(cached !== undefined
+		prompt_tokens,
+		completion_tokens,
+		total_tokens: normalizeApiUsageTotal(prompt_tokens, completion_tokens, parsed.total_tokens),
+		...(cached !== undefined && cached >= 0
 			? {
 				prompt_tokens_details: {
 					...parsed.prompt_tokens_details,
-					cached_tokens: Math.max(0, cached),
+					cached_tokens: cached,
 				},
 			}
 			: {}),
@@ -339,11 +349,13 @@ function normalizeApiUsage(parsed: unknown): APIUsage | undefined {
 }
 
 function apiUsageFromLanguageModelUsagePart(usage: vscode.LanguageModelUsagePart): APIUsage {
+	const prompt_tokens = Math.max(0, usage.promptTokens);
+	const completion_tokens = Math.max(0, usage.completionTokens);
 	const cached = usage.cachedInputTokens;
 	return {
-		prompt_tokens: Math.max(0, usage.promptTokens),
-		completion_tokens: Math.max(0, usage.completionTokens),
-		total_tokens: Math.max(0, usage.totalTokens),
+		prompt_tokens,
+		completion_tokens,
+		total_tokens: normalizeApiUsageTotal(prompt_tokens, completion_tokens, usage.totalTokens),
 		...(cached !== undefined
 			? { prompt_tokens_details: { cached_tokens: Math.max(0, cached) } }
 			: {}),

--- a/extensions/vscode-api-tests/src/singlefolder-tests/lm.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/lm.test.ts
@@ -192,7 +192,8 @@ suite('lm', function () {
 			async provideLanguageModelChatResponse(_model, _messages, _options, progress, _token) {
 				progress.report(new vscode.LanguageModelTextPart('Hi'));
 				progress.report(new vscode.LanguageModelUsagePart(100, 50, 150, 10));
-				return defer.complete();
+				defer.complete();
+				return defer.p;
 			},
 			async provideTokenCount(_model, _text, _token) {
 				return 1;
@@ -224,6 +225,7 @@ suite('lm', function () {
 		})();
 
 		await Promise.all([textDone, streamDone]);
+		await request.result;
 
 		assert.strictEqual(responseText, 'Hi');
 		const usageParts = streamParts.filter((part): part is vscode.LanguageModelUsagePart => part instanceof vscode.LanguageModelUsagePart);

--- a/extensions/vscode-api-tests/src/singlefolder-tests/lm.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/lm.test.ts
@@ -225,7 +225,6 @@ suite('lm', function () {
 		})();
 
 		await Promise.all([textDone, streamDone]);
-		await request.result;
 
 		assert.strictEqual(responseText, 'Hi');
 		const usageParts = streamParts.filter((part): part is vscode.LanguageModelUsagePart => part instanceof vscode.LanguageModelUsagePart);

--- a/extensions/vscode-api-tests/src/singlefolder-tests/lm.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/lm.test.ts
@@ -181,6 +181,69 @@ suite('lm', function () {
 		}
 	});
 
+	test('lm usage part is streamed and omitted from text', async function () {
+
+		const defer = new DeferredPromise<void>();
+
+		disposables.push(vscode.lm.registerLanguageModelChatProvider('test-lm-usage-vendor', {
+			async provideLanguageModelChatInformation(_options, _token) {
+				return [{ ...testProviderOptions, id: 'test-lm-usage' }];
+			},
+			async provideLanguageModelChatResponse(_model, _messages, _options, progress, _token) {
+				progress.report(new vscode.LanguageModelTextPart('Hi'));
+				progress.report(new vscode.LanguageModelUsagePart(100, 50, 150, 10));
+				return defer.complete();
+			},
+			async provideTokenCount(_model, _text, _token) {
+				return 1;
+			},
+		}));
+
+		const models = await vscode.lm.selectChatModels({ id: 'test-lm-usage' });
+		assert.strictEqual(models.length, 1);
+
+		const request = await models[0].sendRequest([vscode.LanguageModelChatMessage.User('Hello')]);
+
+		let responseText = '';
+		const textDone = (async () => {
+			for await (const chunk of request.text) {
+				responseText += chunk;
+			}
+		})();
+
+		const streamParts: vscode.LanguageModelResponsePart[] = [];
+		const streamDone = (async () => {
+			for await (const chunk of request.stream) {
+				if (chunk instanceof vscode.LanguageModelTextPart
+					|| chunk instanceof vscode.LanguageModelUsagePart
+					|| chunk instanceof vscode.LanguageModelToolCallPart
+					|| chunk instanceof vscode.LanguageModelDataPart) {
+					streamParts.push(chunk);
+				}
+			}
+		})();
+
+		await Promise.all([textDone, streamDone]);
+
+		assert.strictEqual(responseText, 'Hi');
+		const usageParts = streamParts.filter((part): part is vscode.LanguageModelUsagePart => part instanceof vscode.LanguageModelUsagePart);
+		assert.strictEqual(usageParts.length, 1);
+		assert.strictEqual(usageParts[0].promptTokens, 100);
+		assert.strictEqual(usageParts[0].completionTokens, 50);
+		assert.strictEqual(usageParts[0].totalTokens, 150);
+		assert.strictEqual(usageParts[0].cachedInputTokens, 10);
+
+		const fromOpenAI = vscode.LanguageModelUsagePart.fromOpenAICompatible({
+			prompt_tokens: 200,
+			completion_tokens: 80,
+			total_tokens: 280,
+			prompt_tokens_details: { cached_tokens: 5 },
+		});
+		assert.strictEqual(fromOpenAI.promptTokens, 200);
+		assert.strictEqual(fromOpenAI.completionTokens, 80);
+		assert.strictEqual(fromOpenAI.cachedInputTokens, 5);
+	});
+
 	test('LanguageModelError instance is not thrown to extensions#235322 (ASYNC)', async function () {
 
 		disposables.push(vscode.lm.registerLanguageModelChatProvider('test-lm-vendor', {

--- a/extensions/vscode-api-tests/src/singlefolder-tests/lm.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/lm.test.ts
@@ -243,7 +243,15 @@ suite('lm', function () {
 		});
 		assert.strictEqual(fromOpenAI.promptTokens, 200);
 		assert.strictEqual(fromOpenAI.completionTokens, 80);
+		assert.strictEqual(fromOpenAI.totalTokens, 280);
 		assert.strictEqual(fromOpenAI.cachedInputTokens, 5);
+
+		const sentinelTotal = vscode.LanguageModelUsagePart.fromOpenAICompatible({
+			prompt_tokens: 10,
+			completion_tokens: 5,
+			total_tokens: -1,
+		});
+		assert.strictEqual(sentinelTotal.totalTokens, 15);
 	});
 
 	test('LanguageModelError instance is not thrown to extensions#235322 (ASYNC)', async function () {

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -2260,6 +2260,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			LanguageModelToolResult2: extHostTypes.LanguageModelToolResult2,
 			LanguageModelDataPart: extHostTypes.LanguageModelDataPart,
 			LanguageModelDataPart2: extHostTypes.LanguageModelDataPart,
+			LanguageModelUsagePart: extHostTypes.LanguageModelUsagePart,
 			LanguageModelToolExtensionSource: extHostTypes.LanguageModelToolExtensionSource,
 			LanguageModelToolMCPSource: extHostTypes.LanguageModelToolMCPSource,
 			ExtendedLanguageModelToolResult: extHostTypes.ExtendedLanguageModelToolResult,

--- a/src/vs/workbench/api/common/extHostLanguageModels.ts
+++ b/src/vs/workbench/api/common/extHostLanguageModels.ts
@@ -38,8 +38,7 @@ type LanguageModelProviderData = {
 	readonly provider: vscode.LanguageModelChatProvider;
 };
 
-type LMResponsePart = vscode.LanguageModelTextPart | vscode.LanguageModelToolCallPart | vscode.LanguageModelDataPart | vscode.LanguageModelThinkingPart;
-
+type LMResponsePart = vscode.LanguageModelTextPart | vscode.LanguageModelToolCallPart | vscode.LanguageModelDataPart | vscode.LanguageModelThinkingPart | vscode.LanguageModelUsagePart;
 
 class LanguageModelResponse {
 
@@ -88,6 +87,8 @@ class LanguageModelResponse {
 
 			} else if (part.type === 'data') {
 				out = new extHostTypes.LanguageModelDataPart(part.data.buffer, part.mimeType, part.audience);
+			} else if (part.type === 'usage') {
+				out = new extHostTypes.LanguageModelUsagePart(part.promptTokens, part.completionTokens, part.totalTokens, part.cachedInputTokens);
 			} else {
 				out = new extHostTypes.LanguageModelToolCallPart(part.toolCallId, part.name, part.parameters);
 			}
@@ -295,7 +296,7 @@ export class ExtHostLanguageModels implements ExtHostLanguageModelsShape {
 			}
 		};
 
-		const progress = new Progress<vscode.LanguageModelTextPart | vscode.LanguageModelToolCallPart | vscode.LanguageModelDataPart | vscode.LanguageModelThinkingPart>(async fragment => {
+		const progress = new Progress<LMResponsePart>(async fragment => {
 			if (token.isCancellationRequested) {
 				this._logService.warn(`[CHAT](${data.extension.identifier.value}) CANNOT send progress because the REQUEST IS CANCELLED`);
 				return;
@@ -306,6 +307,14 @@ export class ExtHostLanguageModels implements ExtHostLanguageModelsShape {
 				part = { type: 'tool_use', name: fragment.name, parameters: fragment.input, toolCallId: fragment.callId };
 			} else if (fragment instanceof extHostTypes.LanguageModelTextPart) {
 				part = { type: 'text', value: fragment.value, audience: fragment.audience };
+			} else if (fragment instanceof extHostTypes.LanguageModelUsagePart) {
+				part = {
+					type: 'usage',
+					promptTokens: fragment.promptTokens,
+					completionTokens: fragment.completionTokens,
+					totalTokens: fragment.totalTokens,
+					...(fragment.cachedInputTokens !== undefined ? { cachedInputTokens: fragment.cachedInputTokens } : {}),
+				};
 			} else if (fragment instanceof extHostTypes.LanguageModelDataPart) {
 				part = { type: 'data', mimeType: fragment.mimeType, data: VSBuffer.wrap(fragment.data), audience: fragment.audience };
 			} else if (fragment instanceof extHostTypes.LanguageModelThinkingPart) {

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -4017,6 +4017,21 @@ export class LanguageModelTextPart implements vscode.LanguageModelTextPart2 {
 	}
 }
 
+function normalizeLanguageModelUsageTotal(prompt: number, completion: number, total?: number): number {
+	const sum = prompt + completion;
+	if (total === undefined || total < 0) {
+		return sum;
+	}
+	return Math.max(total, sum);
+}
+
+function normalizeLanguageModelCachedInput(cached?: number): number | undefined {
+	if (cached === undefined || cached < 0) {
+		return undefined;
+	}
+	return cached;
+}
+
 export class LanguageModelUsagePart implements vscode.LanguageModelUsagePart {
 	readonly promptTokens: number;
 	readonly completionTokens: number;
@@ -4028,8 +4043,8 @@ export class LanguageModelUsagePart implements vscode.LanguageModelUsagePart {
 		const completion = Math.max(0, completionTokens);
 		this.promptTokens = prompt;
 		this.completionTokens = completion;
-		this.totalTokens = Math.max(0, totalTokens ?? prompt + completion);
-		this.cachedInputTokens = cachedInputTokens !== undefined ? Math.max(0, cachedInputTokens) : undefined;
+		this.totalTokens = normalizeLanguageModelUsageTotal(prompt, completion, totalTokens);
+		this.cachedInputTokens = normalizeLanguageModelCachedInput(cachedInputTokens);
 	}
 
 	static fromOpenAICompatible(usage: {
@@ -4040,10 +4055,12 @@ export class LanguageModelUsagePart implements vscode.LanguageModelUsagePart {
 	}): LanguageModelUsagePart {
 		const promptTokens = Math.max(0, usage.prompt_tokens);
 		const completionTokens = Math.max(0, usage.completion_tokens);
-		const totalTokens = Math.max(0, usage.total_tokens ?? promptTokens + completionTokens);
-		const cached = usage.prompt_tokens_details?.cached_tokens;
-		const cachedInputTokens = cached !== undefined ? Math.max(0, cached) : undefined;
-		return new LanguageModelUsagePart(promptTokens, completionTokens, totalTokens, cachedInputTokens);
+		return new LanguageModelUsagePart(
+			promptTokens,
+			completionTokens,
+			usage.total_tokens,
+			usage.prompt_tokens_details?.cached_tokens,
+		);
 	}
 }
 

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -4017,6 +4017,34 @@ export class LanguageModelTextPart implements vscode.LanguageModelTextPart2 {
 	}
 }
 
+export class LanguageModelUsagePart implements vscode.LanguageModelUsagePart {
+	readonly promptTokens: number;
+	readonly completionTokens: number;
+	readonly totalTokens: number;
+	readonly cachedInputTokens: number | undefined;
+
+	constructor(promptTokens: number, completionTokens: number, totalTokens: number, cachedInputTokens?: number) {
+		this.promptTokens = promptTokens;
+		this.completionTokens = completionTokens;
+		this.totalTokens = totalTokens;
+		this.cachedInputTokens = cachedInputTokens;
+	}
+
+	static fromOpenAICompatible(usage: {
+		prompt_tokens: number;
+		completion_tokens: number;
+		total_tokens?: number;
+		prompt_tokens_details?: { cached_tokens?: number };
+	}): LanguageModelUsagePart {
+		const promptTokens = Math.max(0, usage.prompt_tokens);
+		const completionTokens = Math.max(0, usage.completion_tokens);
+		const totalTokens = Math.max(0, usage.total_tokens ?? promptTokens + completionTokens);
+		const cached = usage.prompt_tokens_details?.cached_tokens;
+		const cachedInputTokens = cached !== undefined ? Math.max(0, cached) : undefined;
+		return new LanguageModelUsagePart(promptTokens, completionTokens, totalTokens, cachedInputTokens);
+	}
+}
+
 export class LanguageModelDataPart implements vscode.LanguageModelDataPart2 {
 	mimeType: string;
 	data: Uint8Array<ArrayBufferLike>;

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -4023,11 +4023,13 @@ export class LanguageModelUsagePart implements vscode.LanguageModelUsagePart {
 	readonly totalTokens: number;
 	readonly cachedInputTokens: number | undefined;
 
-	constructor(promptTokens: number, completionTokens: number, totalTokens: number, cachedInputTokens?: number) {
-		this.promptTokens = promptTokens;
-		this.completionTokens = completionTokens;
-		this.totalTokens = totalTokens;
-		this.cachedInputTokens = cachedInputTokens;
+	constructor(promptTokens: number, completionTokens: number, totalTokens?: number, cachedInputTokens?: number) {
+		const prompt = Math.max(0, promptTokens);
+		const completion = Math.max(0, completionTokens);
+		this.promptTokens = prompt;
+		this.completionTokens = completion;
+		this.totalTokens = Math.max(0, totalTokens ?? prompt + completion);
+		this.cachedInputTokens = cachedInputTokens !== undefined ? Math.max(0, cachedInputTokens) : undefined;
 	}
 
 	static fromOpenAICompatible(usage: {

--- a/src/vs/workbench/api/test/browser/extHostTypes.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostTypes.test.ts
@@ -788,4 +788,25 @@ suite('ExtHostTypes', function () {
 		m.content = 'Hello';
 		assert.deepStrictEqual(m.content, [new types.LanguageModelTextPart('Hello')]);
 	});
+
+	test('LanguageModelUsagePart normalizes sentinel negative totals', function () {
+		const fromCtor = new types.LanguageModelUsagePart(10, 5, -1);
+		assert.strictEqual(fromCtor.promptTokens, 10);
+		assert.strictEqual(fromCtor.completionTokens, 5);
+		assert.strictEqual(fromCtor.totalTokens, 15);
+		assert.strictEqual(fromCtor.cachedInputTokens, undefined);
+
+		const fromOpenAI = types.LanguageModelUsagePart.fromOpenAICompatible({
+			prompt_tokens: 10,
+			completion_tokens: 5,
+			total_tokens: -1,
+		});
+		assert.strictEqual(fromOpenAI.totalTokens, 15);
+
+		const lowTotal = new types.LanguageModelUsagePart(10, 5, 12);
+		assert.strictEqual(lowTotal.totalTokens, 15);
+
+		const negativeCached = new types.LanguageModelUsagePart(10, 5, 15, -1);
+		assert.strictEqual(negativeCached.cachedInputTokens, undefined);
+	});
 });

--- a/src/vs/workbench/contrib/chat/common/languageModels.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModels.ts
@@ -163,6 +163,14 @@ export interface IChatResponseThinkingPart {
 	metadata?: { readonly [key: string]: any };
 }
 
+export interface IChatResponseUsagePart {
+	type: 'usage';
+	promptTokens: number;
+	completionTokens: number;
+	totalTokens: number;
+	cachedInputTokens?: number;
+}
+
 export interface IChatResponsePullRequestPart {
 	type: 'pullRequest';
 	uri: URI;
@@ -172,7 +180,7 @@ export interface IChatResponsePullRequestPart {
 	linkTag: string;
 }
 
-export type IChatResponsePart = IChatResponseTextPart | IChatResponseToolUsePart | IChatResponseDataPart | IChatResponseThinkingPart;
+export type IChatResponsePart = IChatResponseTextPart | IChatResponseToolUsePart | IChatResponseDataPart | IChatResponseThinkingPart | IChatResponseUsagePart;
 
 export type IExtendedChatResponsePart = IChatResponsePullRequestPart;
 

--- a/src/vs/workbench/contrib/chat/common/model/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatModel.ts
@@ -1547,6 +1547,7 @@ export class ChatResponseModel extends Disposable implements IChatResponseModel 
 			timestamp: this._timestamp,
 			timeSpentWaiting: (pendingConfirmation ? Date.now() - pendingConfirmation.startedWaitingAt : 0) + this._timeSpentWaitingAccumulator,
 			completionTokens: this.completionTokenCount,
+			promptTokens: this.usage?.promptTokens,
 			elapsedMs: this.elapsedMs ?? (this.completedAt ? Math.max(0, this.completedAt - this.confirmationAdjustedTimestamp.get()) : undefined),
 		} satisfies WithDefinedProps<ISerializableChatResponseData>;
 	}
@@ -1642,6 +1643,7 @@ interface ISerializableChatResponseData {
 	codeCitations?: ReadonlyArray<IChatCodeCitation>;
 	timeSpentWaiting?: number;
 	completionTokens?: number;
+	promptTokens?: number;
 	elapsedMs?: number;
 }
 
@@ -2605,8 +2607,8 @@ export class ChatModel extends Disposable implements IChatModel {
 				codeBlockInfos: raw.responseMarkdownInfo?.map<ICodeBlockInfo>(info => ({ suggestionId: info.suggestionId })),
 			});
 			request.response.shouldBeRemovedOnSend = raw.isHidden ? { requestId: raw.requestId } : raw.shouldBeRemovedOnSend;
-			if (typeof raw.completionTokens === 'number') {
-				request.response.setUsage({ kind: 'usage', promptTokens: 0, completionTokens: raw.completionTokens });
+			if (typeof raw.completionTokens === 'number' || typeof raw.promptTokens === 'number') {
+				request.response.setUsage({ kind: 'usage', promptTokens: raw.promptTokens ?? 0, completionTokens: raw.completionTokens ?? 0 });
 			}
 			if (raw.usedContext) { // @ulugbekna: if this's a new vscode sessions, doc versions are incorrect anyway?
 				request.response.applyReference(revive(raw.usedContext));

--- a/src/vs/workbench/contrib/chat/common/model/chatSessionOperationLog.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatSessionOperationLog.ts
@@ -154,6 +154,7 @@ const requestSchema = Adapt.object<IChatRequestModel, ISerializableChatRequestDa
 	codeCitations: Adapt.v(m => m.response?.codeCitations, objectsEqual),
 	timeSpentWaiting: Adapt.v(m => m.response?.timestamp), // based on response timestamp
 	completionTokens: Adapt.v(m => m.response?.completionTokenCount),
+	promptTokens: Adapt.v(m => m.response?.usage?.promptTokens),
 	elapsedMs: Adapt.v(m => m.response?.elapsedMs ?? (m.response?.completedAt ? Math.max(0, m.response.completedAt - m.response.confirmationAdjustedTimestamp.get()) : undefined)),
 	modeInfo: Adapt.v(m => m.modeInfo, objectsEqual),
 	isSystemInitiated: Adapt.v(m => m.isSystemInitiated),

--- a/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
@@ -1917,7 +1917,7 @@ function toSnapshotExportData(model: IChatModel) {
 		...exp,
 		requests: exp.requests.map(r => {
 			// Destructure properties after `vote` so we can insert `voteDownReason` in the correct position for snapshot compat
-			const { slashCommand, usedContext, contentReferences, codeCitations, timeSpentWaiting, isSystemInitiated: _isSystemInitiated, systemInitiatedLabel: _systemInitiatedLabel, elapsedMs: _elapsedMs, completionTokens: _completionTokens, ...rest } = r;
+			const { slashCommand, usedContext, contentReferences, codeCitations, timeSpentWaiting, isSystemInitiated: _isSystemInitiated, systemInitiatedLabel: _systemInitiatedLabel, elapsedMs: _elapsedMs, completionTokens: _completionTokens, promptTokens: _promptTokens, ...rest } = r;
 			return {
 				...rest,
 				modelState: {

--- a/src/vs/workbench/contrib/chat/test/common/languageModels.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/languageModels.test.ts
@@ -10,7 +10,7 @@ import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { mock } from '../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { NullLogService } from '../../../../../platform/log/common/log.js';
-import { ChatMessageRole, LanguageModelsService, IChatMessage, IChatResponsePart, ILanguageModelChatMetadata } from '../../common/languageModels.js';
+import { ChatMessageRole, LanguageModelsService, IChatMessage, IChatResponsePart, IChatResponseUsagePart, ILanguageModelChatMetadata } from '../../common/languageModels.js';
 import { IExtensionService, nullExtensionDescription } from '../../../../services/extensions/common/extensions.js';
 import { ExtensionIdentifier } from '../../../../../platform/extensions/common/extensions.js';
 import { TestStorageService } from '../../../../test/common/workbenchTestServices.js';
@@ -129,6 +129,62 @@ suite('LanguageModels', function () {
 
 		const result2 = await languageModels.selectLanguageModels({ vendor: 'test-vendor', family: 'FAKE' });
 		assert.deepStrictEqual(result2.length, 0);
+	});
+
+	test('sendChatRequest streams usage parts from provider', async function () {
+
+		store.add(languageModels.registerLanguageModelProvider('usage-vendor', {
+			onDidChange: Event.None,
+			provideLanguageModelChatInfo: async () => [{
+				metadata: {
+					extension: nullExtensionDescription.identifier,
+					name: 'Usage Model',
+					vendor: 'usage-vendor',
+					family: 'usage-family',
+					version: '1',
+					id: 'usage-lm',
+					maxInputTokens: 100,
+					maxOutputTokens: 100,
+					isDefaultForLocation: {}
+				} satisfies ILanguageModelChatMetadata,
+				identifier: 'usage-lm',
+			}],
+			sendChatRequest: async () => {
+				const stream = new AsyncIterableSource<IChatResponsePart>();
+				stream.emitOne({ type: 'text', value: 'ok' });
+				stream.emitOne({ type: 'usage', promptTokens: 42, completionTokens: 7, totalTokens: 49 });
+				stream.resolve();
+				return {
+					stream: stream.asyncIterable,
+					result: Promise.resolve(undefined),
+				};
+			},
+			provideTokenCount: async () => 0,
+		}));
+
+		languageModels.deltaLanguageModelChatProviderDescriptors([
+			{ vendor: 'usage-vendor', displayName: 'Usage Vendor', configuration: undefined, managementCommand: undefined, when: undefined }
+		], []);
+
+		const models = await languageModels.selectLanguageModels({ id: 'usage-lm' });
+		assert.strictEqual(models.length, 1);
+
+		const request = await languageModels.sendChatRequest(models[0], nullExtensionDescription.identifier, [{ role: ChatMessageRole.User, content: [{ type: 'text', value: 'hello' }] }], {}, CancellationToken.None);
+
+		const parts: IChatResponsePart[] = [];
+		for await (const part of request.stream) {
+			if (Array.isArray(part)) {
+				parts.push(...part);
+			} else {
+				parts.push(part);
+			}
+		}
+		await request.result;
+
+		const usage = parts.find((p): p is IChatResponseUsagePart => p.type === 'usage');
+		assert.ok(usage);
+		assert.strictEqual(usage.promptTokens, 42);
+		assert.strictEqual(usage.completionTokens, 7);
 	});
 
 	test('sendChatRequest returns a response-stream', async function () {

--- a/src/vs/workbench/contrib/chat/test/common/model/chatModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/model/chatModel.test.ts
@@ -343,6 +343,43 @@ suite('ChatModel', () => {
 		assert.strictEqual(exported.requests.length, 1);
 		assert.deepStrictEqual(exported.requests[0].modeInfo, modeInfo);
 	});
+
+	test('usage roundtrips through serialization', async () => {
+		const serializableData: ISerializableChatData3 = {
+			version: 3,
+			sessionId: 'test-usage-session',
+			creationDate: Date.now(),
+			customTitle: undefined,
+			initialLocation: ChatAgentLocation.Chat,
+			responderUsername: 'bot',
+			requests: [{
+				requestId: 'req1',
+				message: { text: 'hello', parts: [] },
+				variableData: { variables: [] },
+				response: [{ value: 'Here is my response', isTrusted: false }],
+				modelState: { value: 1 /* ResponseModelState.Complete */, completedAt: Date.now() },
+				completionTokens: 42,
+				promptTokens: 100,
+			}],
+		};
+
+		const model = testDisposables.add(instantiationService.createInstance(
+			ChatModel,
+			{ value: serializableData, serializer: undefined! },
+			{ initialLocation: ChatAgentLocation.Chat, canUseTools: true }
+		));
+
+		const requests = model.getRequests();
+		assert.strictEqual(requests.length, 1);
+		const usage = requests[0].response?.usage;
+		assert.deepStrictEqual(usage, { kind: 'usage', promptTokens: 100, completionTokens: 42 });
+
+		// Verify roundtrip through toExport
+		const exported = model.toExport();
+		assert.strictEqual(exported.requests.length, 1);
+		assert.strictEqual(exported.requests[0].completionTokens, 42);
+		assert.strictEqual(exported.requests[0].promptTokens, 100);
+	});
 });
 
 suite('Response', () => {

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -20221,7 +20221,7 @@ declare module 'vscode' {
 		 * }
 		 * ```
 		 */
-		stream: AsyncIterable<LanguageModelTextPart | LanguageModelToolCallPart | LanguageModelDataPart | unknown>;
+		stream: AsyncIterable<LanguageModelTextPart | LanguageModelToolCallPart | LanguageModelDataPart | LanguageModelUsagePart | unknown>;
 
 		/**
 		 * This is equivalent to filtering everything except for text parts from a {@link LanguageModelChatResponse.stream}.
@@ -20669,7 +20669,7 @@ declare module 'vscode' {
 	/**
 	 * The various message types which a {@linkcode LanguageModelChatProvider} can emit in the chat response stream
 	 */
-	export type LanguageModelResponsePart = LanguageModelTextPart | LanguageModelToolResultPart | LanguageModelToolCallPart | LanguageModelDataPart;
+	export type LanguageModelResponsePart = LanguageModelTextPart | LanguageModelToolResultPart | LanguageModelToolCallPart | LanguageModelDataPart | LanguageModelUsagePart;
 
 	/**
 	 * The various message types which can be sent via {@linkcode LanguageModelChat.sendRequest } and processed by a {@linkcode LanguageModelChatProvider}
@@ -20698,6 +20698,11 @@ declare module 'vscode' {
 		/**
 		 * Returns the response for a chat request, passing the results to the progress callback.
 		 * The {@linkcode LanguageModelChatProvider} must emit the response parts to the progress callback as they are received from the language model.
+		 *
+		 * When the model backend reports token usage (for example in a final OpenAI-compatible streaming chunk),
+		 * the provider should emit a single {@link LanguageModelUsagePart} after the text stream completes.
+		 * This enables the chat UI to display context window usage for extension-contributed models.
+		 *
 		 * @param model The language model to use
 		 * @param messages The messages to include in the request
 		 * @param options Options for the request
@@ -21009,6 +21014,66 @@ declare module 'vscode' {
 		 * @param content A list of tool result content parts
 		 */
 		constructor(content: Array<LanguageModelTextPart | LanguageModelPromptTsxPart | LanguageModelDataPart | unknown>);
+	}
+
+	/**
+	 * Token usage reported by a {@linkcode LanguageModelChatProvider} for a completed chat request.
+	 */
+	export class LanguageModelUsagePart {
+		/**
+		 * Number of tokens in the prompt (input).
+		 */
+		readonly promptTokens: number;
+
+		/**
+		 * Number of tokens in the generated completion (output).
+		 */
+		readonly completionTokens: number;
+
+		/**
+		 * Total tokens for the request (prompt + completion).
+		 */
+		readonly totalTokens: number;
+
+		/**
+		 * Optional count of prompt tokens served from cache, when reported by the backend.
+		 */
+		readonly cachedInputTokens?: number;
+
+		/**
+		 * @param promptTokens Number of prompt tokens
+		 * @param completionTokens Number of completion tokens
+		 * @param totalTokens Total tokens (defaults to prompt + completion when omitted in factories)
+		 * @param cachedInputTokens Optional cached prompt tokens
+		 */
+		constructor(promptTokens: number, completionTokens: number, totalTokens: number, cachedInputTokens?: number);
+
+		/**
+		 * Create a usage part from an OpenAI-compatible `usage` object (chat completions or streaming final chunk).
+		 */
+		static fromOpenAICompatible(usage: {
+			/**
+			 * Number of tokens in the prompt (input).
+			 */
+			prompt_tokens: number;
+			/**
+			 * Number of tokens in the generated completion (output).
+			 */
+			completion_tokens: number;
+			/**
+			 * Total tokens for the request (prompt + completion).
+			 */
+			total_tokens?: number;
+			/**
+			 * Optional prompt token details from the backend.
+			 */
+			prompt_tokens_details?: {
+				/**
+				 * Optional count of prompt tokens served from cache.
+				 */
+				cached_tokens?: number;
+			};
+		}): LanguageModelUsagePart;
 	}
 
 	/**

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -21046,7 +21046,7 @@ declare module 'vscode' {
 		 * @param totalTokens Total tokens (defaults to prompt + completion when omitted in factories)
 		 * @param cachedInputTokens Optional cached prompt tokens
 		 */
-		constructor(promptTokens: number, completionTokens: number, totalTokens: number, cachedInputTokens?: number);
+		constructor(promptTokens: number, completionTokens: number, totalTokens?: number, cachedInputTokens?: number);
 
 		/**
 		 * Create a usage part from an OpenAI-compatible `usage` object (chat completions or streaming final chunk).

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -21043,7 +21043,7 @@ declare module 'vscode' {
 		/**
 		 * @param promptTokens Number of prompt tokens
 		 * @param completionTokens Number of completion tokens
-		 * @param totalTokens Total tokens (defaults to prompt + completion when omitted in factories)
+		 * @param totalTokens Total tokens; when omitted, defaults to prompt + completion
 		 * @param cachedInputTokens Optional cached prompt tokens
 		 */
 		constructor(promptTokens: number, completionTokens: number, totalTokens?: number, cachedInputTokens?: number);

--- a/src/vscode-dts/vscode.proposed.chatProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatProvider.d.ts
@@ -98,7 +98,7 @@ declare module 'vscode' {
 		readonly editTools?: string[];
 	}
 
-	export type LanguageModelResponsePart2 = LanguageModelResponsePart | LanguageModelDataPart | LanguageModelThinkingPart;
+	export type LanguageModelResponsePart2 = LanguageModelResponsePart | LanguageModelDataPart | LanguageModelThinkingPart | LanguageModelUsagePart;
 
 	/**
 	 * A [JSON Schema](https://json-schema.org) describing configuration options for a language model.


### PR DESCRIPTION
Fixes #317187

## Summary

Extension-contributed language models (`LanguageModelChatProvider`) had no documented way to report token usage back to VS Code, so Chat showed `0` even when the backend returned valid `usage` (e.g. OpenAI-compatible streaming with `stream_options.include_usage`).

This PR adds `LanguageModelUsagePart` to the extension API and wires it through the language model response stream so usage reaches the chat UI for extension-contributed models.

## Changes

- **`LanguageModelUsagePart`** in `vscode.d.ts` with `fromOpenAICompatible()` for OpenAI-style `usage` objects
- Ext host: map usage parts between extension providers and `IChatResponseUsagePart`
- Workbench: `IChatResponseUsagePart` in the language model response stream type
- **Copilot** `extChatEndpoint`: consume `LanguageModelUsagePart` when calling extension-contributed models (legacy `LanguageModelDataPart` + `usage` mime still supported)
- Tests: `languageModels.test.ts`, `vscode-api-tests` `lm.test.ts`

## How to test
   - Configure a `LanguageModelChatProvider` with a model that, after streaming text, sends a usage chunk.
   - Send a chat request with that model and confirm context/token usage in Chat is non-zero.

<img width="816" height="735" alt="image" src="https://github.com/user-attachments/assets/a98210c5-3e71-4297-9ccf-ffa27f52eb0d" />



## Checklist (from contribution guidelines)

- [x] One PR for one issue (`Fixes #317187`)
- [x] Tests included
- [x] Scope limited to usage reporting for `LanguageModelChatProvider`
- [x] CLA signed (required before merge — bot will prompt on first PR)
- [x] Branch rebased on latest `main` if CI asks for it
