### PR TITLE
Remove disabled toggle from the tab order

### DIFF
--- a/src/vs/base/browser/ui/toggle/toggle.ts
+++ b/src/vs/base/browser/ui/toggle/toggle.ts
@@ -242,11 +242,17 @@ export class Toggle extends Widget {
 	enable(): void {
 		this.domNode.setAttribute('aria-disabled', String(false));
 		this.domNode.classList.remove('disabled');
+		if (!this._opts.notFocusable) {
+			this.domNode.tabIndex = 0;
+		}
 	}
 
 	disable(): void {
 		this.domNode.setAttribute('aria-disabled', String(true));
 		this.domNode.classList.add('disabled');
+		if (!this._opts.notFocusable) {
+			this.domNode.tabIndex = -1;
+		}
 	}
 
 	setTitle(newTitle: string | IMarkdownString | HTMLElement): void {

--- a/src/vs/base/test/browser/ui/toggle/toggle.test.ts
+++ b/src/vs/base/test/browser/ui/toggle/toggle.test.ts
@@ -1,0 +1,46 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Toggle, unthemedToggleStyles } from '../../../../browser/ui/toggle/toggle.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../common/utils.js';
+
+suite('Toggle', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('focusable toggle is removed from the tab order when disabled', () => {
+		const toggle = new Toggle({ title: 'toggle', isChecked: false, ...unthemedToggleStyles });
+
+		// Focusable toggles are tabbable by default.
+		assert.strictEqual(toggle.domNode.tabIndex, 0);
+
+		toggle.disable();
+		assert.strictEqual(toggle.domNode.tabIndex, -1, 'disabled toggle should not be tabbable');
+
+		toggle.enable();
+		assert.strictEqual(toggle.domNode.tabIndex, 0, 'enabled toggle should be tabbable again');
+
+		toggle.dispose();
+	});
+
+	test('notFocusable toggle keeps externally managed tabIndex when enabled/disabled', () => {
+		const toggle = new Toggle({ title: 'toggle', isChecked: false, notFocusable: true, ...unthemedToggleStyles });
+
+		// notFocusable toggles are never tabbable on their own; their tabIndex is managed by the owner.
+		assert.strictEqual(toggle.domNode.tabIndex, -1);
+
+		// The owner (e.g. a toolbar using roving tabindex) may make it focusable.
+		toggle.domNode.tabIndex = 0;
+
+		toggle.disable();
+		assert.strictEqual(toggle.domNode.tabIndex, 0, 'notFocusable toggle tabIndex should be left untouched on disable');
+
+		toggle.enable();
+		assert.strictEqual(toggle.domNode.tabIndex, 0, 'notFocusable toggle tabIndex should be left untouched on enable');
+
+		toggle.dispose();
+	});
+});


### PR DESCRIPTION
Fixes #147299

### Problem

After invoking Find once (or toggling any of the option buttons via their keybinding, e.g. <kbd>Alt</kbd>+<kbd>C</kbd>), the find widget's **Match Case**, **Match Whole Word**, **Use Regular Expression** and **Preserve Case** toggles stay in the editor's tab order even while the find widget is hidden. With `Tab Moves Focus` (<kbd>Ctrl</kbd>+<kbd>M</kbd>) enabled this is easy to observe: tabbing from the editor lands on these hidden toggles instead of going straight to the status bar. The buttons even flash into view when activated with <kbd>Space</kbd>/<kbd>Enter</kbd>.

### Root cause

When the find widget is hidden it disables its find/replace input (`FindInput.setEnabled(false)` → `Toggle.disable()`). However `Toggle.disable()` only set `aria-disabled` and the `disabled` class — it never removed the element from the tab order, so `tabIndex` stayed `0`. A disabled toggle is also a no-op on click/keydown (both handlers early-return when not enabled), so being reachable via Tab serves no purpose.

This differs from `SimpleButton` (the close/prev/next/replace buttons in the same widget), whose `setEnabled` already toggles `tabIndex` between `0` and `-1`.

### Fix

`Toggle.enable()`/`disable()` now manage `tabIndex` so a disabled toggle is taken out of the tab order and restored when re-enabled. Toggles created with `notFocusable` (e.g. toolbar action items that use a roving tabindex via `ToggleActionViewItem`) are left untouched so their externally managed `tabIndex` is preserved.

Added unit tests covering both the focusable and `notFocusable` cases.