### PR TITLE
fix: preserve cell metadata (tags) when copying notebook cells

### DIFF
--- a/src/vs/workbench/contrib/notebook/common/model/notebookCellTextModel.ts
+++ b/src/vs/workbench/contrib/notebook/common/model/notebookCellTextModel.ts
@@ -518,7 +518,9 @@ export function cloneNotebookCellTextModel(cell: NotebookCellTextModel) {
 			outputs: output.outputs,
 			/* paste should generate new outputId */ outputId: UUID.generateUuid()
 		})),
-		metadata: {}
+		// Preserve user-authored metadata (e.g. Jupyter cell `tags`) so it survives copy/paste.
+		// Execution/run state lives in `internalMetadata` and is intentionally not cloned.
+		metadata: { ...cell.metadata }
 	};
 }
 

--- a/src/vs/workbench/contrib/notebook/test/browser/notebookCommon.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/notebookCommon.test.ts
@@ -10,6 +10,7 @@ import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { ILanguageService } from '../../../../../editor/common/languages/language.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { cloneNotebookCellTextModel } from '../../common/model/notebookCellTextModel.js';
 import { CellKind, CellUri, diff, MimeTypeDisplayOrder, NotebookWorkingCopyTypeIdentifier } from '../../common/notebookCommon.js';
 import { cellIndexesToRanges, cellRangesToIndexes, reduceCellRanges } from '../../common/notebookRange.js';
 import { setupInstantiationService, TestCell } from './testNotebookEditor.js';
@@ -314,6 +315,19 @@ suite('NotebookCommon', () => {
 				}
 			]
 		);
+
+		disposables.dispose();
+	});
+
+	test('cloneNotebookCellTextModel preserves user metadata (e.g. cell tags) #237160', function () {
+		const cell = disposables.add(new TestCell('notebook', 0, 'var a = 1;', 'javascript', CellKind.Code, [], languageService));
+		cell.metadata = { tags: ['myTag'], custom: { foo: 'bar' } };
+
+		const clone = cloneNotebookCellTextModel(cell);
+
+		assert.deepStrictEqual(clone.metadata, { tags: ['myTag'], custom: { foo: 'bar' } });
+		// Ensure it is a copy, not a shared reference to the original metadata object.
+		assert.notStrictEqual(clone.metadata, cell.metadata);
 
 		disposables.dispose();
 	});


### PR DESCRIPTION
Fixes #237160

### Problem

Copying and pasting a notebook cell drops its metadata. In particular, Jupyter cell **tags** (stored in `cell.metadata.tags`) are lost: the pasted cell has no tags.

### Root cause

`cloneNotebookCellTextModel` blanks all metadata:

```ts
metadata: {}
```

This was introduced in #103881 ("copy/paste cell should not copy metadata") to avoid copying **execution/run state**. However, run/execution state (`executionOrder`, `runStartTime`, `lastRunSuccess`, `error`, …) lives in `internalMetadata`, which is **already** excluded from the clone. The `metadata` bag instead holds user-authored properties such as `tags` (and `custom`, collapse state, etc.), so blanking it was an over-correction that needlessly discards user data.

### Fix

Restore copying of `metadata` (shallow copy) while continuing to exclude `internalMetadata`:

```ts
metadata: { ...cell.metadata }
```

This keeps #103881 fixed (no run state is copied, since that is in `internalMetadata`) while preserving user metadata like `tags` across copy/paste.

### Test

Adds a unit test in `notebookCommon.test.ts` asserting that `cloneNotebookCellTextModel` preserves user metadata and returns a distinct object (not a shared reference).