### PR TITLE
chat-lib release: add `auto` option to pick version from copilot's package.json

### DIFF
--- a/extensions/copilot/build/npm-package.yml
+++ b/extensions/copilot/build/npm-package.yml
@@ -21,7 +21,7 @@ parameters:
     type: string
     default: 'https://pkgs.dev.azure.com/monacotools/Monaco/_packaging/vscode/npm/registry/'
   - name: nextVersion
-    displayName: '🚀 Release Version (eg: none, major, minor, patch, prerelease, or X.X.X)'
+    displayName: '🚀 Release Version (eg: none, auto, major, minor, patch, prerelease, or X.X.X)'
     type: string
     default: 'none'
 
@@ -51,6 +51,9 @@ extends:
         # Manually triggered → publish to latest or next
         ${{ if eq(parameters.nextVersion, 'none') }}:
           publishPackage: false
+        ${{ elseif eq(parameters.nextVersion, 'auto') }}:
+          # Use the version synced from extensions/copilot/package.json by build-chat-lib.yml
+          publishPackage: true
         ${{ elseif eq(parameters.nextVersion, 'prerelease') }}:
           publishPackage: true
           publishRequiresApproval: false


### PR DESCRIPTION
Adds an `auto` choice to the `nextVersion` parameter of the chat-lib release pipeline (`extensions/copilot/build/npm-package.yml`) that publishes whatever version is already in `chat-lib/package.json` — which `build-chat-lib.yml` already syncs from `extensions/copilot/package.json` before publish. Releasers no longer have to type the version manually.

### Change
New `elseif eq(parameters.nextVersion, 'auto')` branch that sets `publishPackage: true` without passing `nextVersion`, so the parent template publishes the synced version as-is.

### Usage
When manually queuing a release, pick `auto` from the dropdown — no need to type a version.

### Why keep the default as `none`?
The pipeline has a CI trigger on `main` / `release/*`. With `auto` as the default, every push would attempt to publish and would fail on duplicate versions (and risk unintended stable releases). If we want fully automatic publishing on push, that should be a follow-up paired with a trigger limited to version bumps in `extensions/copilot/package.json`.