### PR TITLE
sessions: add setting to open single file diff from Changes view

### DIFF
--- a/src/vs/sessions/contrib/changes/browser/changes.contribution.ts
+++ b/src/vs/sessions/contrib/changes/browser/changes.contribution.ts
@@ -67,6 +67,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 	properties: {
 		[SESSIONS_CHANGES_OPEN_SINGLE_FILE_DIFF_SETTING]: {
 			type: 'boolean',
+			tags: ['preview'],
 			description: localize('sessions.changes.openSingleFileDiff', "Controls whether clicking a file in the Changes view opens a single file diff editor instead of the multi file diff editor."),
 			default: false,
 		},

--- a/src/vs/sessions/contrib/changes/browser/changes.contribution.ts
+++ b/src/vs/sessions/contrib/changes/browser/changes.contribution.ts
@@ -10,13 +10,14 @@ import { Registry } from '../../../../platform/registry/common/platform.js';
 import { registerIcon } from '../../../../platform/theme/common/iconRegistry.js';
 import { registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
 import { IViewContainersRegistry, ViewContainerLocation, IViewsRegistry, Extensions as ViewContainerExtensions, WindowEnablement } from '../../../../workbench/common/views.js';
-import { CHANGES_VIEW_CONTAINER_ID, CHANGES_VIEW_ID } from '../common/changes.js';
+import { CHANGES_VIEW_CONTAINER_ID, CHANGES_VIEW_ID, SESSIONS_CHANGES_OPEN_SINGLE_FILE_DIFF_SETTING } from '../common/changes.js';
 import { ChangesViewPane, ChangesViewPaneContainer } from './changesView.js';
 import { ChangesTitleBarContribution } from './changesTitleBarWidget.js';
 import { IsPhoneLayoutContext } from '../../../common/contextkeys.js';
 import './changesViewActions.js';
 import './checksActions.js';
 import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
+import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
 
 const changesViewIcon = registerIcon('changes-view-icon', Codicon.gitCompare, localize2('changesViewIcon', 'View icon for the Changes view.').value);
 
@@ -60,3 +61,14 @@ viewsRegistry.registerViews([{
 }], changesViewContainer);
 
 registerWorkbenchContribution2(ChangesTitleBarContribution.ID, ChangesTitleBarContribution, WorkbenchPhase.AfterRestored);
+
+Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
+	id: 'sessions',
+	properties: {
+		[SESSIONS_CHANGES_OPEN_SINGLE_FILE_DIFF_SETTING]: {
+			type: 'boolean',
+			description: localize('sessions.changes.openSingleFileDiff', "Controls whether clicking a file in the Changes view opens a single file diff editor instead of the multi file diff editor."),
+			default: false,
+		},
+	},
+});

--- a/src/vs/sessions/contrib/changes/browser/changesView.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesView.ts
@@ -70,7 +70,7 @@ import { logChangesViewFileSelect, logChangesViewVersionModeChange, logChangesVi
 import { ChecksViewModel } from './checksViewModel.js';
 // eslint-disable-next-line local/code-import-patterns -- TODO: move skill button constants out of providers
 import { AGENT_HOST_SKILL_BUTTON_UPDATE_PR_ID, isAgentHostSkillButtonId } from '../../providers/agentHost/browser/agentHostSkillButtons.js';
-import { ActiveSessionContextKeys, CHANGES_VIEW_CONTAINER_ID, CHANGES_VIEW_ID, ChangesContextKeys, ChangesViewMode, IsolationMode } from '../common/changes.js';
+import { ActiveSessionContextKeys, CHANGES_VIEW_CONTAINER_ID, CHANGES_VIEW_ID, ChangesContextKeys, ChangesViewMode, IsolationMode, SESSIONS_CHANGES_OPEN_SINGLE_FILE_DIFF_SETTING } from '../common/changes.js';
 import { buildTreeChildren, ChangesTreeElement, ChangesTreeRenderer, IChangesFileItem, IChangesTreeRootInfo, isChangesFileItem, toIChangesFileItem } from './changesViewRenderer.js';
 import { ChangesViewModel } from './changesViewModel.js';
 import { ResourceTree } from '../../../../base/common/resourceTree.js';
@@ -713,6 +713,12 @@ export class ChangesViewPane extends ViewPane {
 					return;
 				}
 
+				// Open a single file diff editor when configured to do so
+				if (this.configurationService.getValue<boolean>(SESSIONS_CHANGES_OPEN_SINGLE_FILE_DIFF_SETTING)) {
+					void this._openSingleFileDiffEditor(e.element, e.sideBySide, !!e.editorOptions?.preserveFocus, !!e.editorOptions?.pinned);
+					return;
+				}
+
 				// Open multi-file diff editor
 				void this._openMultiFileDiffEditor(e.element.uri);
 			}));
@@ -1101,6 +1107,37 @@ export class ChangesViewPane extends ViewPane {
 			resource: modifiedFileUri,
 			...labels,
 			options: { preserveFocus, pinned, modal: { sidebar, navigation } }
+		}, group);
+	}
+
+	private async _openSingleFileDiffEditor(item: IChangesFileItem, sideBySide: boolean, preserveFocus: boolean, pinned: boolean): Promise<void> {
+		const { uri: modifiedFileUri, originalUri, isDeletion } = item;
+		const group = sideBySide ? SIDE_GROUP : ACTIVE_GROUP;
+		const labels = getChangesEditorLabels(item.uri, this.labelService);
+
+		if (isDeletion && originalUri) {
+			await this.editorService.openEditor({
+				resource: originalUri,
+				...labels,
+				options: { preserveFocus, pinned }
+			}, group);
+			return;
+		}
+
+		if (originalUri) {
+			await this.editorService.openEditor({
+				original: { resource: originalUri },
+				modified: { resource: modifiedFileUri },
+				...labels,
+				options: { preserveFocus, pinned }
+			}, group);
+			return;
+		}
+
+		await this.editorService.openEditor({
+			resource: modifiedFileUri,
+			...labels,
+			options: { preserveFocus, pinned }
 		}, group);
 	}
 

--- a/src/vs/sessions/contrib/changes/browser/changesView.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesView.ts
@@ -1111,31 +1111,17 @@ export class ChangesViewPane extends ViewPane {
 	}
 
 	private async _openSingleFileDiffEditor(item: IChangesFileItem, sideBySide: boolean, preserveFocus: boolean, pinned: boolean): Promise<void> {
-		const { uri: modifiedFileUri, originalUri, isDeletion } = item;
+		const { uri, originalUri, isDeletion } = item;
 		const group = sideBySide ? SIDE_GROUP : ACTIVE_GROUP;
-		const labels = getChangesEditorLabels(item.uri, this.labelService);
+		const labels = getChangesEditorLabels(uri, this.labelService);
 
-		if (isDeletion && originalUri) {
-			await this.editorService.openEditor({
-				resource: originalUri,
-				...labels,
-				options: { preserveFocus, pinned }
-			}, group);
-			return;
-		}
-
-		if (originalUri) {
-			await this.editorService.openEditor({
-				original: { resource: originalUri },
-				modified: { resource: modifiedFileUri },
-				...labels,
-				options: { preserveFocus, pinned }
-			}, group);
-			return;
-		}
-
+		// Always open a diff editor. Added files (no original) and deleted files
+		// (no modified) are shown as a diff against an empty side, matching the
+		// "Open Changes" action.
+		const modifiedUri = isDeletion ? undefined : uri;
 		await this.editorService.openEditor({
-			resource: modifiedFileUri,
+			original: { resource: originalUri },
+			modified: { resource: modifiedUri },
 			...labels,
 			options: { preserveFocus, pinned }
 		}, group);

--- a/src/vs/sessions/contrib/changes/browser/changesViewActions.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesViewActions.ts
@@ -162,7 +162,8 @@ class OpenFileAction extends Action2 {
 						ChangesContextKeys.ChangeKind.isEqualTo('file'),
 						openSingleFileDiffEnabled)
 				},
-				// Default behavior: the alt action opens the single file diff.
+				// Default behavior: the alt action ("Open Changes") opens a diff
+				// editor for the selected change(s).
 				{
 					id: MenuId.AgentsChangeInlineToolbar,
 					group: 'navigation',

--- a/src/vs/sessions/contrib/changes/browser/changesViewActions.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesViewActions.ts
@@ -13,7 +13,7 @@ import { IViewsService } from '../../../../workbench/services/views/common/views
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ContextKeyExpr, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { bindContextKey } from '../../../../platform/observable/common/platformObservableUtils.js';
-import { ActiveSessionContextKeys, CHANGES_VIEW_ID, ChangesContextKeys } from '../common/changes.js';
+import { ActiveSessionContextKeys, CHANGES_VIEW_ID, ChangesContextKeys, SESSIONS_CHANGES_OPEN_SINGLE_FILE_DIFF_SETTING } from '../common/changes.js';
 import { IsSessionsWindowContext } from '../../../../workbench/common/contextkeys.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { ChangesViewPane } from './changesView.js';
@@ -107,39 +107,6 @@ class OpenPullRequestAction extends Action2 {
 
 registerAction2(OpenPullRequestAction);
 
-class OpenFileAction extends Action2 {
-	static readonly ID = 'workbench.action.agentSessions.openFile';
-
-	constructor() {
-		super({
-			id: OpenFileAction.ID,
-			title: localize2('openFile', "Open File"),
-			icon: Codicon.goToFile,
-			f1: false,
-			menu: {
-				id: MenuId.AgentsChangeInlineToolbar,
-				group: 'navigation',
-				order: 1,
-				alt: {
-					id: 'workbench.action.agentSessions.openChanges',
-					title: localize2('openChanges', "Open Changes"),
-					icon: Codicon.gitCompare,
-				},
-				when: ContextKeyExpr.and(
-					IsSessionsWindowContext,
-					ChangesContextKeys.ChangeKind.isEqualTo('file'))
-			}
-		});
-	}
-
-	async run(accessor: ServicesAccessor, _sessionResource: URI, _ref: string, ...resources: URI[]): Promise<void> {
-		const editorService = accessor.get(IEditorService);
-		await Promise.all(resources.map(resource => editorService.openEditor({ resource })));
-	}
-}
-
-registerAction2(OpenFileAction);
-
 class OpenChangesAction extends Action2 {
 	static readonly ID = 'workbench.action.agentSessions.openChanges';
 
@@ -171,3 +138,55 @@ class OpenChangesAction extends Action2 {
 }
 
 registerAction2(OpenChangesAction);
+
+const openSingleFileDiffEnabled = ContextKeyExpr.equals(`config.${SESSIONS_CHANGES_OPEN_SINGLE_FILE_DIFF_SETTING}`, true);
+
+class OpenFileAction extends Action2 {
+	static readonly ID = 'workbench.action.agentSessions.openFile';
+
+	constructor() {
+		super({
+			id: OpenFileAction.ID,
+			title: localize2('openFile', "Open File"),
+			icon: Codicon.goToFile,
+			f1: false,
+			menu: [
+				// When opening a file already shows a single file diff, the "Open
+				// Changes" alt action is redundant and is therefore omitted.
+				{
+					id: MenuId.AgentsChangeInlineToolbar,
+					group: 'navigation',
+					order: 1,
+					when: ContextKeyExpr.and(
+						IsSessionsWindowContext,
+						ChangesContextKeys.ChangeKind.isEqualTo('file'),
+						openSingleFileDiffEnabled)
+				},
+				// Default behavior: the alt action opens the single file diff.
+				{
+					id: MenuId.AgentsChangeInlineToolbar,
+					group: 'navigation',
+					order: 1,
+					alt: {
+						id: OpenChangesAction.ID,
+						title: localize2('openChanges', "Open Changes"),
+						icon: Codicon.gitCompare,
+					},
+					when: ContextKeyExpr.and(
+						IsSessionsWindowContext,
+						ChangesContextKeys.ChangeKind.isEqualTo('file'),
+						openSingleFileDiffEnabled.negate())
+				}
+			]
+		});
+	}
+
+	async run(accessor: ServicesAccessor, _sessionResource: URI, _ref: string, ...resources: URI[]): Promise<void> {
+		const editorService = accessor.get(IEditorService);
+		await Promise.all(resources.map(resource => editorService.openEditor({ resource })));
+	}
+}
+
+registerAction2(OpenFileAction);
+
+

--- a/src/vs/sessions/contrib/changes/common/changes.ts
+++ b/src/vs/sessions/contrib/changes/common/changes.ts
@@ -8,6 +8,14 @@ import { RawContextKey } from '../../../../platform/contextkey/common/contextkey
 export const CHANGES_VIEW_ID = 'workbench.view.agentSessions.changes';
 export const CHANGES_VIEW_CONTAINER_ID = 'workbench.view.agentSessions.changesContainer';
 
+/**
+ * Setting key that controls whether clicking a file in the Changes view opens a
+ * single file diff editor instead of the multi file diff editor.
+ *
+ * This setting is registered (and only meaningful) in the Agents app.
+ */
+export const SESSIONS_CHANGES_OPEN_SINGLE_FILE_DIFF_SETTING = 'sessions.changes.openSingleFileDiff';
+
 export const enum ChangesViewMode {
 	List = 'list',
 	Tree = 'tree'


### PR DESCRIPTION
## What & why

At present, clicking a file in the **Changes** view of the Agents window always opens the multi file diff editor. This adds a setting for users who prefer a focused, single file diff.

## Changes

- Introduce the `sessions.changes.openSingleFileDiff` setting (boolean, default `false`, `preview`).
- When enabled, clicking a file in the Changes view opens a **single file diff editor** (handles added / modified / deleted cases) instead of the multi file diff editor.
- When the setting is enabled, the redundant **Open Changes** alt action on the changes inline toolbar is hidden (the single diff is already the default click behavior). The alt action is gated declaratively via the `config.sessions.changes.openSingleFileDiff` context key, so it updates live.

## Notes for reviewers

- All changes are scoped to `src/vs/sessions/contrib/changes/`.
- The two inline toolbar menu variants live in the `OpenFileAction` `menu` array (the `alt` sub-action has no `when` of its own, so two variants are needed).
