### PR TITLE
Fade inactive session controls

### DIFF
--- a/src/vs/sessions/browser/parts/media/sessionView.css
+++ b/src/vs/sessions/browser/parts/media/sessionView.css
@@ -55,10 +55,7 @@
 	pointer-events: none;
 }
 
-/* Fade out the placeholder text (rendered as an editor decoration inside the
- * chat editor) for inactive sessions. */
-.session-view:not(.is-active) .interactive-session .chat-editor-container {
-	opacity: 0.4;
+/* Fade the chat input editor (including placeholder/draft text) for inactive sessions. */
 }
 
 /* Desaturate the send button so it reads as muted while still discoverable. */

--- a/src/vs/sessions/browser/parts/media/sessionView.css
+++ b/src/vs/sessions/browser/parts/media/sessionView.css
@@ -6,11 +6,30 @@
 /* ------------------------------------------------------------------------- *
  * Inactive session chat input state
  *
- * When a session column is not the active/focused/selected one, quiet all of
- * its chat input controls (attach, mode/model pickers, etc.) and keep only
+ * When a session column is not the active/focused/selected one, fade out all
+ * of its chat input controls (attach, mode/model pickers, etc.) and keep only
  * the send button visible in a desaturated state. This reduces visual noise
  * across the multi-session grid so attention stays on the active session.
  * ------------------------------------------------------------------------- */
+
+/* Transitions apply to both active and inactive states so controls fade
+ * smoothly in either direction. Only declared when the user has not requested
+ * reduced motion so we never need to unset them. */
+@media (prefers-reduced-motion: no-preference) {
+	.session-view .chat-composite-bar-inline-toolbar,
+	.session-view .chat-composite-bar-toolbar,
+	.session-view .interactive-session .chat-input-toolbars > .chat-input-toolbar,
+	.session-view .interactive-session .chat-secondary-toolbar,
+	.session-view .interactive-session .chat-attachments-container,
+	.session-view .interactive-session .interactive-input-followups,
+	.session-view .interactive-session .chat-editor-container {
+		transition: opacity 0.15s ease;
+	}
+
+	.session-view .interactive-session .chat-input-toolbars > .chat-execute-toolbar {
+		transition: filter 0.15s ease, opacity 0.15s ease;
+	}
+}
 
 /* Quiet the session toolbar controls in the top-right of inactive sessions so
  * the active session's controls stand out, while keeping them legible. */
@@ -27,7 +46,7 @@
 	pointer-events: none;
 }
 
-/* Hide the controls that sit below the input box (secondary toolbar,
+/* Fade out the controls that sit below the input box (secondary toolbar,
  * attachments row and followups) so the inactive input reads as quiet. */
 .session-view:not(.is-active) .interactive-session .chat-secondary-toolbar,
 .session-view:not(.is-active) .interactive-session .chat-attachments-container,
@@ -36,7 +55,7 @@
 	pointer-events: none;
 }
 
-/* Quiet the placeholder text (rendered as an editor decoration inside the
+/* Fade out the placeholder text (rendered as an editor decoration inside the
  * chat editor) for inactive sessions. */
 .session-view:not(.is-active) .interactive-session .chat-editor-container {
 	opacity: 0.4;


### PR DESCRIPTION
```Copilot Generated Description:``` Implement fading effects for inactive session controls, including chat input and toolbars, to reduce visual noise and maintain focus on the active session.

