### PR TITLE
Fix empty editor group layout actions and visibility

### DIFF
--- a/src/vs/sessions/browser/parts/media/editorPart.css
+++ b/src/vs/sessions/browser/parts/media/editorPart.css
@@ -69,6 +69,31 @@
 	display: none;
 }
 
+/* Empty Editor Group */
+
+/* Keep the tab bar visible for empty editor groups so the editor layout actions
+   (e.g. close editor area, maximize) remain accessible when there are no editors. */
+.agent-sessions-workbench .part.editor > .content .editor-group-container.empty > .title {
+	display: block;
+}
+
+.agent-sessions-workbench .part.editor > .content .editor-group-container.empty > .title > .tabs-and-actions-container.empty {
+	display: flex;
+}
+
+/* Shrink the watermark to leave room for the visible tab bar above. The watermark
+   would otherwise overlap the title. When there is only one (empty) group, only
+   the title takes space. When there are multiple groups (or an auxiliary editor
+   part), the editor-group-container-toolbar (35px) is also shown above the title. */
+.agent-sessions-workbench .part.editor > .content.empty .editor-group-container.empty > .editor-group-watermark {
+	height: calc(100% - var(--editor-group-tab-height));
+}
+
+.agent-sessions-workbench .part.editor > .content:not(.empty) .editor-group-container.empty > .editor-group-watermark,
+.agent-sessions-workbench .part.editor > .content.auxiliary .editor-group-container.empty > .editor-group-watermark {
+	height: calc(100% - 35px - var(--editor-group-tab-height));
+}
+
 /* Modal Editor Part */
 
 .agent-sessions-workbench .part.editor.modal-editor-part .modal-editor-action-container .action-label.codicon.codicon-open-in-window {

--- a/src/vs/workbench/browser/parts/editor/editorGroupView.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupView.ts
@@ -2103,6 +2103,16 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 				'navigation',
 				shouldInlineGroup
 			);
+		} else if (menuId === MenuId.EditorTitleLayout) {
+			// Layout actions are tied to the editor group/area (e.g. close/maximize editor area)
+			// and should remain available even when the group has no active editor pane.
+			const layoutMenu = disposables.add(this.menuService.createMenu(menuId, this.scopedContextKeyService, { emitEventsForSubmenuChanges: true, eventDebounceDelay: 0 }));
+			onDidChange = layoutMenu.onDidChange;
+
+			actions = getActionBarActions(
+				layoutMenu.getActions({ arg: this.resourceContext.get(), shouldForwardArgs: true, renderShortTitle: true }),
+				'navigation'
+			);
 		} else {
 			// If there is no active pane in the group (it's the last group and it's empty)
 			// Trigger the change event when the active editor changes

--- a/src/vs/workbench/browser/parts/editor/editorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorTabsControl.ts
@@ -374,10 +374,10 @@ export abstract class EditorTabsControl extends Themable implements IEditorTabsC
 		const editorActionsToolbar = assertReturnsDefined(this.editorActionsToolbar);
 		editorActionsToolbar.setActions([], []);
 
-		this.editorLayoutActionsToolbar?.setActions([], []);
-		if (this.editorLayoutActionsSeparator) {
-			setVisibility(false, this.editorLayoutActionsSeparator);
-		}
+		// Refresh the layout actions toolbar so that actions tied to the editor group
+		// (e.g. close/maximize editor area) remain available even when the per-editor
+		// actions are cleared because the group is empty.
+		this.updateEditorLayoutActionsToolbar();
 	}
 
 	protected onGroupDragStart(e: DragEvent, element: HTMLElement): boolean {

--- a/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
@@ -193,6 +193,10 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 		// Create Editor Toolbar
 		this.createEditorActionsToolBar(this.tabsAndActionsContainer, ['editor-actions']);
 
+		// Populate the toolbars so the layout actions (e.g. close editor area) are
+		// visible even when the group is initially empty.
+		this.updateEditorActionsToolbar();
+
 		// Set tabs control visibility
 		this.updateTabsControlVisibility();
 


### PR DESCRIPTION
```Copilot Generated Description:``` Ensure layout actions remain accessible for empty editor groups by updating the CSS and refreshing the editor layout actions toolbar when the group is empty.