### PR TITLE
Refine inactive session styling

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -1059,6 +1059,7 @@
 		"--animation-opacity",
 		"--chat-input-anim-angle",
 		"--chat-input-anim-duration",
+		"--chat-input-working-border-color1",
 		"--chat-send-button-anim-angle",
 		"--chat-setup-dialog-glow-angle",
 		"--vscode-chat-font-family",

--- a/src/vs/sessions/browser/parts/media/sessionView.css
+++ b/src/vs/sessions/browser/parts/media/sessionView.css
@@ -62,8 +62,9 @@
 
 /* Fully desaturate the in-flight chat-input border beam in inactive sessions so
  * it matches the muted treatment of the rest of the inactive input controls.
- * Setting the HSL saturation channel to 0 drops the accent to a neutral gray of
- * the same lightness, so the beam still reads but no longer competes for attention. */
+ * Relative color syntax zeroes the saturation channel while preserving hue and
+ * lightness — unlike mixing toward a fixed gray, this keeps the accent's
+ * lightness intact so high-contrast themes (white/black accents) still read. */
 .session-view:not(.is-active) .interactive-session .chat-input-container.working {
 	--chat-input-working-border-color1: hsl(from var(--vscode-chat-inputWorkingBorderColor1) h 0% l);
 }

--- a/src/vs/sessions/browser/parts/media/sessionView.css
+++ b/src/vs/sessions/browser/parts/media/sessionView.css
@@ -56,6 +56,16 @@
 }
 
 /* Fade the chat input editor (including placeholder/draft text) for inactive sessions. */
+.session-view:not(.is-active) .interactive-session .chat-editor-container {
+	opacity: 0.6;
+}
+
+/* Fully desaturate the in-flight chat-input border beam in inactive sessions so
+ * it matches the muted treatment of the rest of the inactive input controls.
+ * Setting the HSL saturation channel to 0 drops the accent to a neutral gray of
+ * the same lightness, so the beam still reads but no longer competes for attention. */
+.session-view:not(.is-active) .interactive-session .chat-input-container.working {
+	--chat-input-working-border-color1: hsl(from var(--vscode-chat-inputWorkingBorderColor1) h 0% l);
 }
 
 /* Desaturate the send button so it reads as muted while still discoverable. */

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -873,6 +873,9 @@ have to be updated for changes to the rules above, or to support more deeply nes
 		travel speed roughly constant regardless of input width — wider
 		inputs would otherwise feel sluggish at a fixed duration. */
 	--chat-input-anim-duration: 4s;
+	/* Allow host surfaces (like inactive sessions) to tone down the animation
+		accent without overriding the global chat theme token. */
+	--chat-input-working-border-color1: var(--vscode-chat-inputWorkingBorderColor1);
 }
 
 /* Prevent contents from covering border corners. Not applied in compact mode
@@ -929,9 +932,9 @@ have to be updated for changes to the rules above, or to support more deeply nes
 		so the rest of the border stays invisible. */
 	background: conic-gradient(from var(--chat-input-anim-angle),
 			transparent 0deg,
-			color-mix(in srgb, var(--vscode-chat-inputWorkingBorderColor1) 90%, transparent) 20deg,
-			var(--vscode-chat-inputWorkingBorderColor1) 30deg,
-			color-mix(in srgb, var(--vscode-chat-inputWorkingBorderColor1) 60%, transparent) 50deg,
+			color-mix(in srgb, var(--chat-input-working-border-color1) 90%, transparent) 20deg,
+			var(--chat-input-working-border-color1) 30deg,
+			color-mix(in srgb, var(--chat-input-working-border-color1) 60%, transparent) 50deg,
 			transparent 90deg,
 			transparent 360deg);
 	-webkit-mask:
@@ -958,8 +961,8 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	padding: 2px;
 	background: conic-gradient(from var(--chat-input-anim-angle),
 			transparent 0deg,
-			color-mix(in srgb, var(--vscode-chat-inputWorkingBorderColor1) 60%, transparent) 25deg,
-			color-mix(in srgb, var(--vscode-chat-inputWorkingBorderColor1) 35%, transparent) 50deg,
+			color-mix(in srgb, var(--chat-input-working-border-color1) 60%, transparent) 25deg,
+			color-mix(in srgb, var(--chat-input-working-border-color1) 35%, transparent) 50deg,
 			transparent 90deg,
 			transparent 360deg);
 	-webkit-mask:


### PR DESCRIPTION
Enhance the visual treatment of inactive sessions by fading the chat input and desaturating borders to improve usability and aesthetics. The changes ensure that the chat input maintains a consistent appearance while preserving hue and lightness for better contrast in high-contrast themes.

