### PR TITLE
Insert paragraph separator between Copilot CLI assistant messages

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
@@ -1214,6 +1214,28 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 
 		const chunkMessageIds = new Set<string>();
 		const assistantMessageChunks: string[] = [];
+		// Tracks the `messageId` of the last assistant text we forwarded to
+		// the stream (via `assistant.message_delta` or `assistant.message`).
+		// When the next text emission carries a different `messageId` — i.e.
+		// the model emitted a new assistant message in the same turn (e.g.
+		// after a tool call, or as a second phase) — we prepend `\n\n` so the
+		// two messages don't fuse into a single run-on paragraph
+		// (e.g. `"...wiring:Now add..."`). Only triggers when both sides have
+		// a defined messageId, so message emissions without an id (rare /
+		// legacy) keep their current behavior.
+		let lastEmittedAssistantMessageId: string | undefined;
+		const maybeEmitMessageSeparator = (incomingMessageId: string | undefined) => {
+			if (
+				incomingMessageId !== undefined &&
+				lastEmittedAssistantMessageId !== undefined &&
+				incomingMessageId !== lastEmittedAssistantMessageId
+			) {
+				requestStream?.markdown('\n\n');
+			}
+			if (incomingMessageId !== undefined) {
+				lastEmittedAssistantMessageId = incomingMessageId;
+			}
+		};
 		let lastUsageInfo: UsageInfoData | undefined;
 		const reportUsage = (promptTokens: number, completionTokens: number) => {
 			if (token.isCancellationRequested || !requestStream) {
@@ -1420,6 +1442,7 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 					if (event.data.parentToolCallId) {
 						return;
 					}
+					maybeEmitMessageSeparator(event.data.messageId);
 					chunkMessageIds.add(event.data.messageId);
 					assistantMessageChunks.push(event.data.deltaContent);
 					wroteResponseContent = true;
@@ -1434,6 +1457,7 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 					}
 					assistantMessageChunks.push(event.data.content);
 					flushPendingInvocationMessages();
+					maybeEmitMessageSeparator(event.data.messageId);
 					wroteResponseContent = true;
 					requestStream?.markdown(event.data.content);
 				}

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotcliSession.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotcliSession.spec.ts
@@ -1818,6 +1818,31 @@ describe('CopilotCLISession', () => {
 			resolveSend!();
 			await requestPromise;
 		});
+
+		it('does NOT insert a separator when messageId is undefined on both sides (legacy)', async () => {
+			// Defensive regression test: if an SDK build ever emits message
+			// events without a `messageId`, we should fall back to the
+			// pre-fix behavior (no separator) rather than inserting one
+			// between every chunk — that would produce spurious blank
+			// paragraphs.
+			let resolveSend: () => void;
+			sdkSession.send = async () => new Promise<void>(r => { resolveSend = r; });
+			const session = await createSession();
+			const stream = new MockChatResponseStream();
+			session.attachStream(stream);
+
+			const requestPromise = session.handleRequest({ id: '', toolInvocationToken: undefined as never }, { prompt: 'Legacy' }, [], undefined, authInfo, CancellationToken.None);
+			await new Promise(r => setTimeout(r, 0));
+
+			sdkSession.emit('assistant.message_delta', { deltaContent: 'wiring:', messageId: undefined });
+			sdkSession.emit('assistant.message_delta', { deltaContent: 'Now add', messageId: undefined });
+			await new Promise(r => setTimeout(r, 0));
+
+			expect(stream.output).not.toContain('\n\n');
+
+			resolveSend!();
+			await requestPromise;
+		});
 	});
 
 	describe('/compact command', () => {

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotcliSession.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotcliSession.spec.ts
@@ -1708,6 +1708,118 @@ describe('CopilotCLISession', () => {
 		await requestPromise;
 	});
 
+	describe('assistant message text separation', () => {
+		// The bug we're guarding against: when the CLI emits multiple
+		// assistant messages in a single turn (e.g. text → tool_call → more
+		// text, or two distinct phases), the markdown chunks were being
+		// concatenated directly producing run-on text like
+		// `"...wiring:Now add..."`. Each emission carries its own `messageId`
+		// from the SDK, so we insert `\n\n` whenever the id changes.
+
+		const allText = (stream: MockChatResponseStream) => stream.output.join('');
+
+		it('inserts paragraph break between assistant.message_delta events with different messageIds', async () => {
+			let resolveSend: () => void;
+			sdkSession.send = async () => new Promise<void>(r => { resolveSend = r; });
+			const session = await createSession();
+			const stream = new MockChatResponseStream();
+			session.attachStream(stream);
+
+			const requestPromise = session.handleRequest({ id: '', toolInvocationToken: undefined as never }, { prompt: 'Two phases' }, [], undefined, authInfo, CancellationToken.None);
+			await new Promise(r => setTimeout(r, 0));
+
+			sdkSession.emit('assistant.message_delta', { deltaContent: 'wiring:', messageId: 'msg-1' });
+			sdkSession.emit('assistant.message_delta', { deltaContent: 'Now add', messageId: 'msg-2' });
+			await new Promise(r => setTimeout(r, 0));
+
+			expect(allText(stream)).toContain('wiring:\n\nNow add');
+			expect(allText(stream)).not.toContain('wiring:Now add');
+
+			resolveSend!();
+			await requestPromise;
+		});
+
+		it('does NOT insert paragraph break between assistant.message_delta events with the same messageId', async () => {
+			let resolveSend: () => void;
+			sdkSession.send = async () => new Promise<void>(r => { resolveSend = r; });
+			const session = await createSession();
+			const stream = new MockChatResponseStream();
+			session.attachStream(stream);
+
+			const requestPromise = session.handleRequest({ id: '', toolInvocationToken: undefined as never }, { prompt: 'Streamed' }, [], undefined, authInfo, CancellationToken.None);
+			await new Promise(r => setTimeout(r, 0));
+
+			sdkSession.emit('assistant.message_delta', { deltaContent: 'Hello ', messageId: 'msg-1' });
+			sdkSession.emit('assistant.message_delta', { deltaContent: 'world', messageId: 'msg-1' });
+			await new Promise(r => setTimeout(r, 0));
+
+			expect(allText(stream)).toContain('Hello world');
+			expect(allText(stream)).not.toContain('Hello \n\nworld');
+
+			resolveSend!();
+			await requestPromise;
+		});
+
+		it('inserts paragraph break between assistant.message events with different messageIds', async () => {
+			let resolveSend: () => void;
+			sdkSession.send = async () => new Promise<void>(r => { resolveSend = r; });
+			const session = await createSession();
+			const stream = new MockChatResponseStream();
+			session.attachStream(stream);
+
+			const requestPromise = session.handleRequest({ id: '', toolInvocationToken: undefined as never }, { prompt: 'Two messages' }, [], undefined, authInfo, CancellationToken.None);
+			await new Promise(r => setTimeout(r, 0));
+
+			sdkSession.emit('assistant.message', { content: 'First phase.', messageId: 'msg-a' });
+			sdkSession.emit('assistant.message', { content: 'Second phase.', messageId: 'msg-b' });
+			await new Promise(r => setTimeout(r, 0));
+
+			expect(allText(stream)).toContain('First phase.\n\nSecond phase.');
+
+			resolveSend!();
+			await requestPromise;
+		});
+
+		it('inserts paragraph break between a delta-streamed message and a subsequent full message', async () => {
+			let resolveSend: () => void;
+			sdkSession.send = async () => new Promise<void>(r => { resolveSend = r; });
+			const session = await createSession();
+			const stream = new MockChatResponseStream();
+			session.attachStream(stream);
+
+			const requestPromise = session.handleRequest({ id: '', toolInvocationToken: undefined as never }, { prompt: 'Mixed' }, [], undefined, authInfo, CancellationToken.None);
+			await new Promise(r => setTimeout(r, 0));
+
+			sdkSession.emit('assistant.message_delta', { deltaContent: 'wiring:', messageId: 'msg-1' });
+			sdkSession.emit('assistant.message', { content: 'Now add', messageId: 'msg-2' });
+			await new Promise(r => setTimeout(r, 0));
+
+			expect(allText(stream)).toContain('wiring:\n\nNow add');
+
+			resolveSend!();
+			await requestPromise;
+		});
+
+		it('does NOT prepend a separator before the very first text emission', async () => {
+			let resolveSend: () => void;
+			sdkSession.send = async () => new Promise<void>(r => { resolveSend = r; });
+			const session = await createSession();
+			const stream = new MockChatResponseStream();
+			session.attachStream(stream);
+
+			const requestPromise = session.handleRequest({ id: '', toolInvocationToken: undefined as never }, { prompt: 'First' }, [], undefined, authInfo, CancellationToken.None);
+			await new Promise(r => setTimeout(r, 0));
+
+			sdkSession.emit('assistant.message_delta', { deltaContent: 'Hello', messageId: 'msg-1' });
+			await new Promise(r => setTimeout(r, 0));
+
+			expect(stream.output[0]).toBe('Hello');
+
+			resolveSend!();
+			await requestPromise;
+		});
+	});
+
 	describe('/compact command', () => {
 		it('compacts the conversation and reports success', async () => {
 			const session = await createSession();


### PR DESCRIPTION
## Problem

In the Agents window, multiple assistant messages emitted by the Copilot CLI in a single turn fuse into a single run-on paragraph. Notice in the screenshot from the original report: `wiring:Now  no space, no paragraph break. Each phase boundary is missing its separator.add` 

## Root cause

 more text, or back-to-back  the markdown chunks concatenate.phases 

Structurally identical to the OpenAI Responses API issue fixed in #312173.

## Fix

Track `lastEmittedAssistantMessageId`; when the incoming event carries a different (defined) `messageId`, prepend `stream.markdown('\n\n')` before the new content. Streaming deltas that share a `messageId` are unaffected, so within-message streaming continues to work as before. Emissions without a defined `messageId` (rare/legacy) keep their current behavior.

The helper is wired into both the `assistant.message_delta` and `assistant.message` handlers so the protection holds regardless of whether the SDK is streaming deltas or sending whole messages.

## Tests

New `describe('assistant message text separation')` with 5 cases in `copilotcliSession.spec.ts`:

1. Separator inserted between deltas with different `messageId`s (the bug)
2. NO separator between deltas with the same `messageId` (don't break streaming within one message)
3. Separator inserted between full `assistant.message` events with different `messageId`s
 subsequent full message
5. NO separator before the very first emission

Verified the 3 bug-exercising tests fail on baseline and all 5 pass with the fix.

## Verification

- `tsgo -- cleannoEmit` 
- 158/159 relevant tests pass; the 1 failure (`preserves order of edit toolCallIds and permissions...`) is pre-existing on baseline and unrelated.
