### PR TITLE
Replace animation frame queue sort with binary heap

### DIFF
--- a/src/vs/base/browser/dom.ts
+++ b/src/vs/base/browser/dom.ts
@@ -395,13 +395,15 @@ export class WindowIntervalTimer extends IntervalTimer {
 
 class AnimationFrameQueueItem implements IDisposable {
 
-	private _runner: () => void;
-	public priority: number;
+	private readonly _runner: () => void;
+	private readonly _priority: number;
+	private _order: number;
 	private _canceled: boolean;
 
 	constructor(runner: () => void, priority: number = 0) {
 		this._runner = runner;
-		this.priority = priority;
+		this._priority = priority;
+		this._order = 0;
 		this._canceled = false;
 	}
 
@@ -421,9 +423,78 @@ class AnimationFrameQueueItem implements IDisposable {
 		}
 	}
 
-	// Sort by priority (largest to lowest)
-	static sort(a: AnimationFrameQueueItem, b: AnimationFrameQueueItem): number {
-		return b.priority - a.priority;
+	setOrder(order: number): void {
+		this._order = order;
+	}
+
+	runsBefore(other: AnimationFrameQueueItem): boolean {
+		return this._priority > other._priority || (this._priority === other._priority && this._order < other._order);
+	}
+
+}
+
+class AnimationFrameQueue {
+
+	private readonly _items: AnimationFrameQueueItem[] = [];
+	private _order = 0;
+
+	get length(): number {
+		return this._items.length;
+	}
+
+	push(item: AnimationFrameQueueItem): void {
+		item.setOrder(this._order++);
+		this._items.push(item);
+		this._bubbleUp(this._items.length - 1);
+	}
+
+	pop(): AnimationFrameQueueItem | undefined {
+		if (this._items.length === 0) {
+			return undefined;
+		}
+		if (this._items.length === 1) {
+			return this._items.pop();
+		}
+
+		const result = this._items[0];
+		this._items[0] = this._items.pop()!;
+		this._bubbleDown(0);
+		return result;
+	}
+
+	private _bubbleUp(index: number): void {
+		const item = this._items[index];
+		while (index > 0) {
+			const parentIndex = ((index - 1) / 2) | 0;
+			const parent = this._items[parentIndex];
+			if (!item.runsBefore(parent)) {
+				break;
+			}
+			this._items[index] = parent;
+			index = parentIndex;
+		}
+		this._items[index] = item;
+	}
+
+	private _bubbleDown(index: number): void {
+		const item = this._items[index];
+		while (true) {
+			const leftIndex = index * 2 + 1;
+			if (leftIndex >= this._items.length) {
+				break;
+			}
+			const rightIndex = leftIndex + 1;
+			let childIndex = leftIndex;
+			if (rightIndex < this._items.length && this._items[rightIndex].runsBefore(this._items[leftIndex])) {
+				childIndex = rightIndex;
+			}
+			if (!this._items[childIndex].runsBefore(item)) {
+				break;
+			}
+			this._items[index] = this._items[childIndex];
+			index = childIndex;
+		}
+		this._items[index] = item;
 	}
 }
 
@@ -431,11 +502,11 @@ class AnimationFrameQueueItem implements IDisposable {
 	/**
 	 * The runners scheduled at the next animation frame
 	 */
-	const NEXT_QUEUE = new Map<number /* window ID */, AnimationFrameQueueItem[]>();
+	const NEXT_QUEUE = new Map<number /* window ID */, AnimationFrameQueue>();
 	/**
 	 * The runners scheduled at the current animation frame
 	 */
-	const CURRENT_QUEUE = new Map<number /* window ID */, AnimationFrameQueueItem[]>();
+	const CURRENT_QUEUE = new Map<number /* window ID */, AnimationFrameQueue>();
 	/**
 	 * A flag to keep track if the native requestAnimationFrame was already called
 	 */
@@ -448,14 +519,13 @@ class AnimationFrameQueueItem implements IDisposable {
 	const animationFrameRunner = (targetWindowId: number) => {
 		animFrameRequested.set(targetWindowId, false);
 
-		const currentQueue = NEXT_QUEUE.get(targetWindowId) ?? [];
+		const currentQueue = NEXT_QUEUE.get(targetWindowId) ?? new AnimationFrameQueue();
 		CURRENT_QUEUE.set(targetWindowId, currentQueue);
-		NEXT_QUEUE.set(targetWindowId, []);
+		NEXT_QUEUE.set(targetWindowId, new AnimationFrameQueue());
 
 		inAnimationFrameRunner.set(targetWindowId, true);
 		while (currentQueue.length > 0) {
-			currentQueue.sort(AnimationFrameQueueItem.sort);
-			const top = currentQueue.shift()!;
+			const top = currentQueue.pop()!;
 			top.execute();
 		}
 		inAnimationFrameRunner.set(targetWindowId, false);
@@ -467,7 +537,7 @@ class AnimationFrameQueueItem implements IDisposable {
 
 		let nextQueue = NEXT_QUEUE.get(targetWindowId);
 		if (!nextQueue) {
-			nextQueue = [];
+			nextQueue = new AnimationFrameQueue();
 			NEXT_QUEUE.set(targetWindowId, nextQueue);
 		}
 		nextQueue.push(item);
@@ -486,7 +556,7 @@ class AnimationFrameQueueItem implements IDisposable {
 			const item = new AnimationFrameQueueItem(runner, priority);
 			let currentQueue = CURRENT_QUEUE.get(targetWindowId);
 			if (!currentQueue) {
-				currentQueue = [];
+				currentQueue = new AnimationFrameQueue();
 				CURRENT_QUEUE.set(targetWindowId, currentQueue);
 			}
 			currentQueue.push(item);

--- a/src/vs/base/browser/dom.ts
+++ b/src/vs/base/browser/dom.ts
@@ -403,7 +403,7 @@ class AnimationFrameQueueItem implements IDisposable {
 	constructor(runner: () => void, priority: number = 0) {
 		this._runner = runner;
 		this._priority = priority;
-		this._order = 0;
+		this._order = -1;
 		this._canceled = false;
 	}
 
@@ -424,6 +424,9 @@ class AnimationFrameQueueItem implements IDisposable {
 	}
 
 	setOrder(order: number): void {
+		if (this._order !== -1) {
+			return;
+		}
 		this._order = order;
 	}
 

--- a/src/vs/base/test/browser/dom.test.ts
+++ b/src/vs/base/test/browser/dom.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { $, h, trackAttributes, copyAttributes, disposableWindowInterval, getWindows, getWindowsCount, getWindowId, getWindowById, hasWindow, getWindow, getDocument, isHTMLElement, SafeTriangle, AnimationFrameScheduler, DisposableResizeObserver, getRecentDisposableResizeObserverAttributionForLoopError } from '../../browser/dom.js';
+import { $, h, trackAttributes, copyAttributes, disposableWindowInterval, getWindows, getWindowsCount, getWindowId, getWindowById, hasWindow, getWindow, getDocument, isHTMLElement, SafeTriangle, AnimationFrameScheduler, DisposableResizeObserver, getRecentDisposableResizeObserverAttributionForLoopError, scheduleAtNextAnimationFrame, runAtThisOrScheduleAtNextAnimationFrame } from '../../browser/dom.js';
 import { asCssValueWithDefault } from '../../../base/browser/cssValue.js';
 import { ensureCodeWindow, isAuxiliaryWindow, mainWindow } from '../../browser/window.js';
 import { DeferredPromise, timeout } from '../../common/async.js';
@@ -530,6 +530,65 @@ suite('dom', () => {
 			assert.strictEqual(callCount, 2);
 
 			scheduler.dispose();
+		});
+	});
+
+	suite('AnimationFrameQueue', () => {
+		const waitForAnimationFrame = () => new Promise<void>(resolve => mainWindow.requestAnimationFrame(() => resolve()));
+
+		test('runs callbacks by priority while preserving insertion order for equal priorities', async () => {
+			const calls: string[] = [];
+
+			scheduleAtNextAnimationFrame(mainWindow, () => calls.push('low'), -1);
+			scheduleAtNextAnimationFrame(mainWindow, () => calls.push('high-1'), 1);
+			scheduleAtNextAnimationFrame(mainWindow, () => calls.push('high-2'), 1);
+			scheduleAtNextAnimationFrame(mainWindow, () => calls.push('default'));
+			await waitForAnimationFrame();
+
+			assert.deepStrictEqual(calls, ['high-1', 'high-2', 'default', 'low']);
+		});
+
+		test('keeps larger priority queues stable', async () => {
+			const calls: number[] = [];
+			const items = Array.from({ length: 128 }, (_, index) => ({
+				index,
+				priority: (index * 17) % 9
+			}));
+
+			for (const item of items) {
+				scheduleAtNextAnimationFrame(mainWindow, () => calls.push(item.index), item.priority);
+			}
+			await waitForAnimationFrame();
+
+			assert.deepStrictEqual(
+				calls,
+				items.toSorted((a, b) => b.priority - a.priority || a.index - b.index).map(item => item.index)
+			);
+		});
+
+		test('does not run canceled callbacks', async () => {
+			const calls: string[] = [];
+
+			const disposable = scheduleAtNextAnimationFrame(mainWindow, () => calls.push('canceled'), 10);
+			scheduleAtNextAnimationFrame(mainWindow, () => calls.push('kept'), 0);
+			disposable.dispose();
+			await waitForAnimationFrame();
+
+			assert.deepStrictEqual(calls, ['kept']);
+		});
+
+		test('keeps the current frame queue ordered when callbacks add more work', async () => {
+			const calls: string[] = [];
+
+			runAtThisOrScheduleAtNextAnimationFrame(mainWindow, () => {
+				calls.push('first');
+				runAtThisOrScheduleAtNextAnimationFrame(mainWindow, () => calls.push('middle'), 0);
+				runAtThisOrScheduleAtNextAnimationFrame(mainWindow, () => calls.push('next-high'), 2);
+			}, 1);
+			runAtThisOrScheduleAtNextAnimationFrame(mainWindow, () => calls.push('last'), -1);
+			await waitForAnimationFrame();
+
+			assert.deepStrictEqual(calls, ['first', 'next-high', 'middle', 'last']);
 		});
 	});
 

--- a/src/vs/base/test/browser/dom.test.ts
+++ b/src/vs/base/test/browser/dom.test.ts
@@ -562,7 +562,7 @@ suite('dom', () => {
 
 			assert.deepStrictEqual(
 				calls,
-				items.toSorted((a, b) => b.priority - a.priority || a.index - b.index).map(item => item.index)
+				[...items].sort((a, b) => b.priority - a.priority || a.index - b.index).map(item => item.index)
 			);
 		});
 


### PR DESCRIPTION
## Summary
- Replace the per-frame `Array.sort()` + `Array.shift()` pattern in the animation frame runner with a max-heap (`AnimationFrameQueue`), reducing queue operations from O(n log n) to O(log n) per push/pop.
- Add an insertion-order counter (`_order`) to `AnimationFrameQueueItem` so callbacks with the same priority execute in FIFO order — the previous sort was not stable.
- Make `_runner` and `_priority` `readonly` since they never change after construction.

## Motivation
Every animation frame, the runner called `currentQueue.sort()` on the entire queue and then `shift()` the first element. For workloads that schedule many animation frame callbacks (e.g. editor rendering, cursor blinking, overlays), this is wasteful: a heap provides O(log n) insertion and extraction while naturally maintaining priority order.

## Changes
- **`src/vs/base/browser/dom.ts`**: New `AnimationFrameQueue` class backed by a binary max-heap with `runsBefore()` comparison (priority desc, then insertion order asc). `NEXT_QUEUE` and `CURRENT_QUEUE` now hold `AnimationFrameQueue` instances instead of plain arrays.
- **`src/vs/base/test/browser/dom.test.ts`**: Four new tests covering priority ordering, FIFO stability with 128 items, cancellation, and mid-frame scheduling.

## Verification
- [x] `tsgo --project ./src/tsconfig.json --noEmit --skipLibCheck` — passed
- [x] `node build/eslint.ts` — passed
- [x] `scripts/test.sh --grep "AnimationFrameQueue"` — 4/4 passing
- [x] Full `dom` test suite — 41/41 passing, no regressions
- [x] Pre-commit hygiene hook — passed

## Test plan
- [ ] CI compile & hygiene checks pass
- [ ] All unit tests pass on Linux / macOS / Windows (Electron + Browser)
- [ ] No regressions in animation frame scheduling behavior