### PR TITLE
Git: show hint when Git operations may be waiting for SSH authentication

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -205,14 +205,9 @@ export interface SpawnOptions extends cp.SpawnOptions {
 	log?: boolean;
 	cancellationToken?: CancellationToken;
 	onSpawn?: (childProcess: cp.ChildProcess) => void;
-	onStderr?: (data: string) => void;
 }
 
-async function exec(
-	child: cp.ChildProcess,
-	cancellationToken?: CancellationToken,
-	onStderr?: (data: string) => void
-): Promise<IExecutionResult<Buffer>> {
+async function exec(child: cp.ChildProcess, cancellationToken?: CancellationToken): Promise<IExecutionResult<Buffer>> {
 	if (!child.stdout || !child.stderr) {
 		throw new GitError({ message: 'Failed to get stdout or stderr from git process.' });
 	}
@@ -245,10 +240,7 @@ async function exec(
 		}),
 	new Promise<string>(c => {
 		const buffers: Buffer[] = [];
-		on(child.stderr!, 'data', (b: Buffer) => {
-			buffers.push(b);
-			onStderr?.(b.toString('utf8'));
-		});
+		on(child.stderr!, 'data', (b: Buffer) => buffers.push(b));
 		once(child.stderr!, 'close', () => c(Buffer.concat(buffers).toString('utf8')));
 	})
 	]) as Promise<[number, Buffer, string]>;
@@ -647,7 +639,7 @@ export class Git {
 		}
 
 		try {
-			bufferResult = await exec(child, options.cancellationToken, options.onStderr);
+			bufferResult = await exec(child, options.cancellationToken);
 		} catch (ex) {
 			throw ex;
 		} finally {

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -649,10 +649,6 @@ export class Git {
 		try {
 			bufferResult = await exec(child, options.cancellationToken, options.onStderr);
 		} catch (ex) {
-			if (ex instanceof CancellationError) {
-				this.log(`> git ${args.join(' ')} [${Date.now() - startExec}ms] (cancelled)\n`);
-			}
-
 			throw ex;
 		} finally {
 			if (securityKeyAuthenticationHintTimer) {

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -383,7 +383,6 @@ function sanitizeRelativePath(path: string): string {
 
 const COMMIT_FORMAT = '%H%n%aN%n%aE%n%at%n%ct%n%P%n%D%n%B';
 const STASH_FORMAT = '%H%n%P%n%gd%n%gs%n%at%n%ct';
-const SSH_SECURITY_KEY_CONFIRMATION_REGEX = /Confirm user presence for key|Touch your security key/i;
 
 export interface ICloneOptions {
 	readonly parentPath: string;
@@ -636,28 +635,29 @@ export class Git {
 		const startExec = Date.now();
 		let bufferResult: IExecutionResult<Buffer>;
 
-		let didShowSecurityKeyConfirmationNotification = false;
+		const isRemoteOperation = ['fetch', 'push', 'pull'].includes(args[0]);
+
+		let securityKeyAuthenticationHintTimer: NodeJS.Timeout | undefined;
+		if (isRemoteOperation) {
+			securityKeyAuthenticationHintTimer = setTimeout(() => {
+				void window.showInformationMessage(
+					l10n.t('Git may be waiting for SSH authentication. If you use a security key, touch it to continue.')
+				);
+			}, 3000);
+		}
 
 		try {
-			bufferResult = await exec(child, options.cancellationToken, stderr => {
-			if (
-				!didShowSecurityKeyConfirmationNotification &&
-				SSH_SECURITY_KEY_CONFIRMATION_REGEX.test(stderr)
-			) {
-				didShowSecurityKeyConfirmationNotification = true;
-				void window.showInformationMessage(
-					l10n.t('Git is waiting for security key confirmation. Touch your security key to continue.')
-				);
-			}
-
-			options.onStderr?.(stderr);
-			});
-		} catch (ex)  {
+			bufferResult = await exec(child, options.cancellationToken, options.onStderr);
+		} catch (ex) {
 			if (ex instanceof CancellationError) {
 				this.log(`> git ${args.join(' ')} [${Date.now() - startExec}ms] (cancelled)\n`);
 			}
 
 			throw ex;
+		} finally {
+			if (securityKeyAuthenticationHintTimer) {
+				clearTimeout(securityKeyAuthenticationHintTimer);
+			}
 		}
 
 		if (options.log !== false) {

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -12,7 +12,7 @@ import which from 'which';
 import { EventEmitter } from 'events';
 import { fileTypeFromBuffer } from 'file-type';
 import { assign, groupBy, IDisposable, toDisposable, dispose, mkdirp, readBytes, detectUnicodeEncoding, Encoding, onceEvent, splitInChunks, Limiter, Versions, isWindows, pathEquals, isMacintosh, isDescendant, relativePathWithNoFallback, Mutable } from './util';
-import { CancellationError, CancellationToken, ConfigurationChangeEvent, LogOutputChannel, Progress, Uri, workspace } from 'vscode';
+import { CancellationError, CancellationToken, ConfigurationChangeEvent, LogOutputChannel, Progress, Uri, workspace, window, l10n } from 'vscode';
 import type { Commit as ApiCommit, Ref, Branch, Remote, LogOptions, Change, CommitOptions, RefQuery as ApiRefQuery, InitOptions, DiffChange, Worktree as ApiWorktree } from './api/git';
 import { RefType, ForcePushMode, GitErrorCodes, Status } from './api/git.constants';
 import * as byline from 'byline';
@@ -205,9 +205,14 @@ export interface SpawnOptions extends cp.SpawnOptions {
 	log?: boolean;
 	cancellationToken?: CancellationToken;
 	onSpawn?: (childProcess: cp.ChildProcess) => void;
+	onStderr?: (data: string) => void;
 }
 
-async function exec(child: cp.ChildProcess, cancellationToken?: CancellationToken): Promise<IExecutionResult<Buffer>> {
+async function exec(
+	child: cp.ChildProcess,
+	cancellationToken?: CancellationToken,
+	onStderr?: (data: string) => void
+): Promise<IExecutionResult<Buffer>> {
 	if (!child.stdout || !child.stderr) {
 		throw new GitError({ message: 'Failed to get stdout or stderr from git process.' });
 	}
@@ -238,11 +243,14 @@ async function exec(child: cp.ChildProcess, cancellationToken?: CancellationToke
 			on(child.stdout!, 'data', (b: Buffer) => buffers.push(b));
 			once(child.stdout!, 'close', () => c(Buffer.concat(buffers)));
 		}),
-		new Promise<string>(c => {
-			const buffers: Buffer[] = [];
-			on(child.stderr!, 'data', (b: Buffer) => buffers.push(b));
-			once(child.stderr!, 'close', () => c(Buffer.concat(buffers).toString('utf8')));
-		})
+	new Promise<string>(c => {
+		const buffers: Buffer[] = [];
+		on(child.stderr!, 'data', (b: Buffer) => {
+			buffers.push(b);
+			onStderr?.(b.toString('utf8'));
+		});
+		once(child.stderr!, 'close', () => c(Buffer.concat(buffers).toString('utf8')));
+	})
 	]) as Promise<[number, Buffer, string]>;
 
 	if (cancellationToken) {
@@ -375,6 +383,7 @@ function sanitizeRelativePath(path: string): string {
 
 const COMMIT_FORMAT = '%H%n%aN%n%aE%n%at%n%ct%n%P%n%D%n%B';
 const STASH_FORMAT = '%H%n%P%n%gd%n%gs%n%at%n%ct';
+const SSH_SECURITY_KEY_CONFIRMATION_REGEX = /Confirm user presence for key|Touch your security key/i;
 
 export interface ICloneOptions {
 	readonly parentPath: string;
@@ -627,9 +636,23 @@ export class Git {
 		const startExec = Date.now();
 		let bufferResult: IExecutionResult<Buffer>;
 
+		let didShowSecurityKeyConfirmationNotification = false;
+
 		try {
-			bufferResult = await exec(child, options.cancellationToken);
-		} catch (ex) {
+			bufferResult = await exec(child, options.cancellationToken, stderr => {
+			if (
+				!didShowSecurityKeyConfirmationNotification &&
+				SSH_SECURITY_KEY_CONFIRMATION_REGEX.test(stderr)
+			) {
+				didShowSecurityKeyConfirmationNotification = true;
+				void window.showInformationMessage(
+					l10n.t('Git is waiting for security key confirmation. Touch your security key to continue.')
+				);
+			}
+
+			options.onStderr?.(stderr);
+			});
+		} catch (ex)  {
 			if (ex instanceof CancellationError) {
 				this.log(`> git ${args.join(' ')} [${Date.now() - startExec}ms] (cancelled)\n`);
 			}


### PR DESCRIPTION
This implementation shows a notification when Git operations such as
push, pull, or fetch take longer than expected and may be waiting for
SSH authentication.

This is particularly helpful for users who authenticate using SSH
security keys (FIDO/U2F/WebAuthn), where user interaction may be
required but is not clearly surfaced in the VS Code UI.