### PR TITLE
build: keep Copilot VSIX self-contained (don't externalize shared deps)

### DIFF
--- a/build/azure-pipelines/product-copilot.yml
+++ b/build/azure-pipelines/product-copilot.yml
@@ -15,9 +15,13 @@ jobs:
         value: true
       - name: Codeql.SkipTaskAutoInjection
         value: true
-      # Bundled into vscode product, so externalize shared deps from extensions/node_modules/.
-      - name: VSCODE_USE_SHARED_EXTENSION_DEPS
-        value: true
+      # NOTE: Do not set VSCODE_USE_SHARED_EXTENSION_DEPS here. The Copilot
+      # extension ships as a standalone vsce-packaged VSIX built from its own
+      # dependency closure (extensions/copilot/package-lock.json), which can
+      # resolve to different patch versions than the product's shared
+      # extensions/node_modules/. Externalizing shared deps would make the
+      # extension load mismatched/absent modules at runtime and fail to
+      # activate, so the VSIX must stay self-contained (deps inlined).
     templateContext:
       outputParentDirectory: $(Build.ArtifactStagingDirectory)
       outputs:


### PR DESCRIPTION
## Problem

In recent Insiders builds (e.g. `f138cc2fb5`), the **GitHub.copilot-chat** extension activates but fails mid-initialization: it registers **no default chat agent** and **0 language models**. Core then throws:

```
CodeExpectedError: No default agent registered
  at activateDefaultAgent (chatServiceImpl.ts:512)
```

The extension's own command `github.copilot.debug.extensionState` is also reported "not found", confirming activation threw *before* the extension finished wiring up. Build `8d1fba12` (just before #318045 landed) works.

## Root cause

#318045 ("Optimize shared built-in extension dependencies") introduced `VSCODE_USE_SHARED_EXTENSION_DEPS`, which makes built-in extensions stop bundling a set of shared runtime deps (`markdown-it`, `minimatch`, `dompurify`, `jsonc-parser`, `@vscode/extension-telemetry`, `vscode-tas-client`, …) and instead resolve them from the product's shared `extensions/node_modules/` at runtime.

`build/azure-pipelines/product-copilot.yml` sets this flag to `true`. But Copilot is **not** an in-tree built-in like git/markdown — it is packaged as a standalone `vsce` VSIX built from its **own** dependency closure (`extensions/copilot/package-lock.json`) in a separate pipeline, then extracted into `.build/extensions/copilot/` by `downloadCopilotVsix.ts`.

Copilot's lockfile pins **different patch versions** than the shared `extensions/package-lock.json` (e.g. `@vscode/extension-telemetry` 1.5.1 vs 1.5.2, `dompurify` 3.4.1 vs 3.4.5, `minimatch` 10.2.4 vs 10.2.5, `vscode-tas-client` 0.1.84 vs 0.1.86). The postinstall guard added in #318045 only validates declared **ranges**, not resolved versions, so this drift slips through. With the deps externalized, Copilot loads mismatched/unexpected modules from `extensions/node_modules/` at runtime and throws during activation — producing exactly the symptom above.

The `.esbuild.mts` comment already documents the intended invariant this violates: *"Default unset = inlined, so the standalone marketplace .vsix stays self-contained."*

## Fix

Remove `VSCODE_USE_SHARED_EXTENSION_DEPS=true` from the Copilot pipeline so its esbuild inlines the shared deps again and the VSIX is self-contained (the pre-#318045 behavior). The shared-deps optimization remains in effect for the in-tree built-in extensions, which are built and tested against the same dependency closure they resolve from at runtime.

A comment is added so the flag isn't reintroduced.

## Status / verification needed

Marking **draft** — I could not run the full product build to capture the exact failing `require(...)`. To confirm before merge:
- [ ] Extension Host log from a broken build should show a module-resolution / version error thrown from `GitHub.copilot-chat` `dist/` (names the exact dep).
- [ ] Verify a product build with this change restores Copilot activation.

### Possible follow-ups (out of scope here)
- Strengthen the postinstall guard to validate **resolved** lockfile versions, not just ranges, so any future externalizing consumer can't drift.
- Remove `@microsoft/1ds-core-js` / `@microsoft/1ds-post-js` from Copilot's hardcoded external list (they're only transitive via `@vscode/extension-telemetry`, not top-level shared deps).

cc the author of #318045.