### PR TITLE
Agents: session header command center and toolbar refactor

### DIFF
--- a/.github/instructions/sessions.instructions.md
+++ b/.github/instructions/sessions.instructions.md
@@ -105,8 +105,23 @@ The Agents window can run on touch-capable platforms (notably iOS). Follow these
 - For custom clickable elements (e.g. picker triggers, title bar pills, or other `<div>`/`<span>` elements styled as buttons) that open pickers or menus on click, listen to **both** `EventType.CLICK` and `TouchEventType.Tap` and call `Gesture.addTarget` on the element. On touch devices, including iOS, VS Code relies on the gesture system to emit `TouchEventType.Tap`, and `EventType.CLICK` alone may not reliably fire there. The base `Button` class already does this correctly, so this rule applies to custom non-`<button>` trigger elements.
 - Add `touch-action: manipulation` in CSS on custom clickable elements (e.g. picker triggers, title bar pills, or other `<div>`/`<span>` elements styled as buttons) to eliminate the 300ms tap delay on touch devices. This is not needed for native `<button>` elements or standard VS Code widgets (quick picks, context menus, action bar items) which already handle touch behavior.
 
+## DOM Traversal & Intent
+
+Do **not** reverse-engineer user intent or component relationships by walking the DOM. Avoid `Element.closest()`, `Element.matches()`, manual `parentElement`/`parentNode` walking, and `contains()`/`isAncestor()` checks that are run **against another component's DOM structure or CSS class names** (e.g. matching `.action-label`, `.monaco-button`, `.action-bar`, editor/list internals). Such code silently couples one component to the private markup of another: there is no compile error or test failure when the foreign classes change, so behavior breaks at runtime in ways that are hard to trace. If you reach for `closest`/`matches` with a selector that names classes you do not own, treat it as a design smell.
+
+Prefer, in order:
+
+1. **Explicit, typed signals.** Have the component that owns the interaction report intent through a method call, an event, or an observable (e.g. a session view tells the part "I was activated"), instead of the part guessing from the DOM. This is the architecturally correct fix and removes the coupling entirely.
+2. **Event ownership.** Let the handler closest to the source decide — e.g. an action handler calls `stopPropagation()` / marks the event — rather than an outer delegated listener re-classifying the target after the fact.
+3. **Semantics the widget already exposes.** Use real focus (`focusin`/`trackFocus`), `tabindex`, ARIA roles, or the widget's own API instead of CSS-class sniffing.
+
+Narrow, self-contained `contains()`/`isAncestor()` checks against an element's **own** subtree (e.g. "is this click inside the widget I created?") are acceptable — the coupling stays within a single component. The smell is reaching **across** component boundaries.
+
+Known anti-pattern to migrate away from: `isActionableControl` in `browser/parts/sessionsPart.ts`, which uses `closest()` with a hardcoded selector of foreign action-bar/button/editor classes to decide whether a click should promote a session to active. The correct design is for the session view / chat content to signal activation explicitly (option 1 above).
+
 ## Learnings
 
 - Always check `src/vs/sessions/LAYERS.md` before adding cross-module imports — layering violations are enforced by ESLint and will fail CI.
+- Do not classify DOM events by matching foreign components' CSS classes (`closest('.action-label')`, etc.). It couples you to markup you don't own and breaks silently. Prefer explicit activation signals, event ownership (`stopPropagation`), or real focus/ARIA semantics. See the "DOM Traversal & Intent" section.
 - When creating new views, remember to import the contribution in the entry point — missing this causes the view to not appear.
 - Session state flows through observables, not events. If you find yourself adding `onDid*` events for session state, convert to `IObservable` instead.

--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -100,9 +100,12 @@ The Sessions Part (`SessionsPart` in [browser/parts/sessionsPart.ts](src/vs/sess
 
 A `SessionView` ([browser/parts/sessionView.ts](src/vs/sessions/browser/parts/sessionView.ts)) is a single leaf in the Sessions Part's internal grid. It hosts:
 
-- A **chat composite bar** at the top (tabs for the chats in the bound session — hidden when the session has no chat yet).
-- A **chat view** below the bar, swapped in/out based on session state.
-- A floating toolbar overlay.
+- A **session header** at the top ([browser/parts/sessionHeader.ts](src/vs/sessions/browser/parts/sessionHeader.ts)) — the session status icon + title, a meta row (workspace · branch · diff stats), and the session toolbars (Run, Open in VS Code, New Chat). Visible once the bound session is created. It is also the drag handle for the session.
+- A **chat composite bar** below the header ([browser/parts/chatCompositeBar.ts](src/vs/sessions/browser/parts/chatCompositeBar.ts)) — the chat tab strip, shown only when the session has more than one chat. A single chat is already represented by the header title.
+- A **chat view** below the bars, swapped in/out based on session state.
+- A floating toolbar overlay ([browser/parts/sessionHeader.ts](src/vs/sessions/browser/parts/sessionHeader.ts), `SessionViewFloatingToolbar`) shown for not-yet-created sessions in place of the header.
+
+The header and the composite bar are deliberately separate widgets: the header represents the session identity/actions and is always present, while the tab strip is a per-chat navigation concern that only appears with multiple chats. They share visual tokens via `applySessionBarThemeColors` ([browser/parts/sessionBarStyles.ts](src/vs/sessions/browser/parts/sessionBarStyles.ts)) and stylesheet ([browser/parts/media/chatCompositeBar.css](src/vs/sessions/browser/parts/media/chatCompositeBar.css)). `SessionView` sums each widget's reported height to lay out the chat view below them.
 
 The chat view inside a session view is one of three kinds (`ChatViewKind` in [browser/parts/chatView.ts](src/vs/sessions/browser/parts/chatView.ts)), selected per autorun based on the bound session:
 

--- a/src/vs/sessions/browser/actions/vscodeActions.ts
+++ b/src/vs/sessions/browser/actions/vscodeActions.ts
@@ -38,7 +38,7 @@ export class OpenInVSCodeAction extends Action2 {
 			icon: Codicon.vscodeInsiders,
 			precondition: ContextKeyExpr.and(IsAuxiliaryWindowContext.toNegated(), SessionsWelcomeVisibleContext.toNegated()),
 			menu: [{
-				id: Menus.TitleBarSessionMenu,
+				id: Menus.TitleBarCenterRight,
 				group: 'navigation',
 				order: 7,
 				when: ContextKeyExpr.and(IsAuxiliaryWindowContext.toNegated(), SessionsWelcomeVisibleContext.toNegated(), IsPhoneLayoutContext.negate()),
@@ -116,7 +116,7 @@ export class OpenInVSCodeWidgetContribution extends Disposable implements IWorkb
 		@IInstantiationService instantiationService: IInstantiationService,
 	) {
 		super();
-		this._register(actionViewItemService.register(Menus.TitleBarSessionMenu, OpenInVSCodeAction.ID, (action, options) => {
+		this._register(actionViewItemService.register(Menus.TitleBarCenterRight, OpenInVSCodeAction.ID, (action, options) => {
 			return instantiationService.createInstance(OpenInVSCodeTitleBarWidget, action, options);
 		}, undefined));
 	}

--- a/src/vs/sessions/browser/media/openInVSCode.css
+++ b/src/vs/sessions/browser/media/openInVSCode.css
@@ -19,17 +19,6 @@
 	touch-action: manipulation;
 }
 
-.monaco-workbench .open-in-vscode-titlebar-widget::after {
-	content: '';
-	position: absolute;
-	right: -6px;
-	top: 4px;
-	bottom: 4px;
-	width: 1px;
-	background-color: var(--vscode-widget-border, rgba(128, 128, 128, 0.5));
-	pointer-events: none;
-}
-
 .monaco-workbench .open-in-vscode-titlebar-widget > .open-in-vscode-titlebar-widget-icon {
 	width: 16px;
 	height: 16px;

--- a/src/vs/sessions/browser/menus.ts
+++ b/src/vs/sessions/browser/menus.ts
@@ -14,6 +14,8 @@ export const Menus = {
 	CommandCenterCenter: new MenuId('SessionsCommandCenterCenter'),
 	TitleBarContext: new MenuId('SessionsTitleBarContext'),
 	TitleBarLeftLayout: new MenuId('SessionsTitleBarLeftLayout'),
+	TitleBarCenterLeft: new MenuId('SessionsTitleBarCenterLeft'),
+	TitleBarCenterRight: new MenuId('SessionsTitleBarCenterRight'),
 	TitleBarSessionTitle: new MenuId('SessionsTitleBarSessionTitle'),
 	TitleBarSessionMenu: new MenuId('SessionsTitleBarSessionMenu'),
 	TitleBarRightLayout: new MenuId('SessionsTitleBarRightLayout'),

--- a/src/vs/sessions/browser/parts/chatCompositeBar.ts
+++ b/src/vs/sessions/browser/parts/chatCompositeBar.ts
@@ -11,8 +11,6 @@ import { ScrollableElement } from '../../../base/browser/ui/scrollbar/scrollable
 import { ScrollbarVisibility } from '../../../base/common/scrollable.js';
 import { autorun } from '../../../base/common/observable.js';
 import { IThemeService } from '../../../platform/theme/common/themeService.js';
-import { PANEL_ACTIVE_TITLE_BORDER, PANEL_ACTIVE_TITLE_FOREGROUND, PANEL_INACTIVE_TITLE_FOREGROUND } from '../../../workbench/common/theme.js';
-import { agentsPanelBackground } from '../../common/theme.js';
 import { Action } from '../../../base/common/actions.js';
 import { ActionBar } from '../../../base/browser/ui/actionbar/actionbar.js';
 import { Codicon } from '../../../base/common/codicons.js';
@@ -23,14 +21,9 @@ import { localize } from '../../../nls.js';
 import { IQuickInputService } from '../../../platform/quickinput/common/quickInput.js';
 import { IChat, SessionStatus } from '../../services/sessions/common/session.js';
 import { IActiveSession, ISessionsManagementService } from '../../services/sessions/common/sessionsManagement.js';
-import { IInstantiationService } from '../../../platform/instantiation/common/instantiation.js';
-import { HiddenItemStrategy, MenuWorkbenchToolBar } from '../../../platform/actions/browser/toolbar.js';
-import { Menus } from '../menus.js';
-import { LocalSelectionTransfer } from '../../../platform/dnd/browser/dnd.js';
-import { DraggedSessionIdentifier, SessionsDataTransfers } from '../dnd.js';
-import { applyDragImage } from '../../../base/browser/ui/dnd/dnd.js';
 import { IHoverService } from '../../../platform/hover/browser/hover.js';
 import { getDefaultHoverDelegate } from '../../../base/browser/ui/hover/hoverDelegateFactory.js';
+import { applySessionBarThemeColors } from './sessionBarStyles.js';
 
 interface IChatTab {
 	readonly chat: IChat;
@@ -38,20 +31,20 @@ interface IChatTab {
 }
 
 /**
- * A composite bar that displays chats within an agent session as tabs.
+ * A composite bar that displays the chats within an agent session as tabs.
  * Selecting a tab loads that chat in the chat view pane instead of switching view containers.
  *
- * The bar auto-hides when there is only one chat in the session and shows when there are multiple.
+ * The bar is shown only when the session has multiple chats; a single chat is already
+ * represented by the {@link SessionHeader} title.
  *
  * The hosting view tells the bar which session is relevant via {@link setSession}.
  */
 export class ChatCompositeBar extends Disposable {
 
 	private readonly _container: HTMLElement;
+	private readonly _tabsRow: HTMLElement;
 	private readonly _tabsContainer: HTMLElement;
 	private readonly _tabsScrollbar: ScrollableElement;
-	private readonly _toolbar: MenuWorkbenchToolBar;
-	private readonly _inlineToolbar: MenuWorkbenchToolBar;
 	private readonly _tabs: IChatTab[] = [];
 	private readonly _tabDisposables = this._register(new DisposableStore());
 
@@ -61,9 +54,10 @@ export class ChatCompositeBar extends Disposable {
 	private readonly _onDidChangeVisibility = this._register(new Emitter<boolean>());
 	readonly onDidChangeVisibility: Event<boolean> = this._onDidChangeVisibility.event;
 
-	private _visible = false;
+	private readonly _onDidChangeHeight = this._register(new Emitter<void>());
+	readonly onDidChangeHeight: Event<void> = this._onDidChangeHeight.event;
 
-	private readonly _sessionTransfer = LocalSelectionTransfer.getInstance<DraggedSessionIdentifier>();
+	private _visible = false;
 
 	get element(): HTMLElement {
 		return this._container;
@@ -73,26 +67,33 @@ export class ChatCompositeBar extends Disposable {
 		return this._visible;
 	}
 
+	get height(): number {
+		return this._visible ? this._container.offsetHeight : 0;
+	}
+
 	constructor(
 		@IThemeService private readonly _themeService: IThemeService,
 		@ISessionsManagementService private readonly _sessionsManagementService: ISessionsManagementService,
 		@IContextMenuService private readonly _contextMenuService: IContextMenuService,
 		@IQuickInputService private readonly _quickInputService: IQuickInputService,
 		@IHoverService private readonly _hoverService: IHoverService,
-		@IInstantiationService instantiationService: IInstantiationService,
 	) {
 		super();
 
-		this._container = $('.chat-composite-bar');
-		this._tabsContainer = $('.chat-composite-bar-tabs');
+		this._container = $('.chat-composite-bar.session-chat-tabs-bar');
 
+		// Tabs row — only shown when the session has multiple chats.
+		this._tabsRow = $('.chat-composite-bar-tabs-row');
+		this._container.appendChild(this._tabsRow);
+
+		this._tabsContainer = $('.chat-composite-bar-tabs');
 		this._tabsScrollbar = this._register(new ScrollableElement(this._tabsContainer, {
 			horizontal: ScrollbarVisibility.Hidden,
 			vertical: ScrollbarVisibility.Hidden,
 			scrollYToX: true,
 			useShadows: false,
 		}));
-		this._container.appendChild(this._tabsScrollbar.getDomNode());
+		this._tabsRow.appendChild(this._tabsScrollbar.getDomNode());
 
 		// Keep the visual scrollbar in sync with native scrolling inside the tabs container
 		this._register(addDisposableListener(this._tabsContainer, EventType.SCROLL, () => {
@@ -106,22 +107,6 @@ export class ChatCompositeBar extends Disposable {
 			}
 		}));
 
-		const inlineToolbarContainer = $('.chat-composite-bar-inline-toolbar');
-		this._container.appendChild(inlineToolbarContainer);
-		this._inlineToolbar = this._register(instantiationService.createInstance(MenuWorkbenchToolBar, inlineToolbarContainer, Menus.SessionBarInlineToolbar, {
-			hiddenItemStrategy: HiddenItemStrategy.Ignore,
-			menuOptions: { shouldForwardArgs: true },
-			highlightToggledItems: true,
-		}));
-
-		const toolbarContainer = $('.chat-composite-bar-toolbar');
-		this._container.appendChild(toolbarContainer);
-		this._toolbar = this._register(instantiationService.createInstance(MenuWorkbenchToolBar, toolbarContainer, Menus.SessionBarToolbar, {
-			hiddenItemStrategy: HiddenItemStrategy.Ignore,
-			menuOptions: { shouldForwardArgs: true },
-			highlightToggledItems: true,
-		}));
-
 		// Scroll active tab into view + update scroll dimensions on resize
 		const resizeObserver = this._register(new DisposableResizeObserver('ChatCompositeBar.activeTabReveal', () => {
 			this._updateScrollDimensions();
@@ -129,38 +114,15 @@ export class ChatCompositeBar extends Disposable {
 		}));
 		this._register(resizeObserver.observe(this._tabsContainer));
 
+		// Report height changes so the host can re-layout
+		const heightObserver = this._register(new DisposableResizeObserver('ChatCompositeBar.height', () => {
+			this._onDidChangeHeight.fire();
+		}));
+		this._register(heightObserver.observe(this._container));
+
 		this._setVisible(false);
 		this._updateStyles();
 		this._register(this._themeService.onDidColorThemeChange(() => this._updateStyles()));
-
-		this._registerDragSource();
-	}
-
-	private _registerDragSource(): void {
-		this._container.draggable = true;
-
-		this._register(addDisposableListener(this._container, EventType.DRAG_START, (e: DragEvent) => {
-			const session = this._session;
-			if (!session || !e.dataTransfer) {
-				e.preventDefault();
-				return;
-			}
-
-			this._sessionTransfer.setData(
-				[new DraggedSessionIdentifier(session.sessionId, session.resource)],
-				DraggedSessionIdentifier.prototype,
-			);
-
-			const payload = JSON.stringify({ sessionId: session.sessionId, resource: session.resource.toString() });
-			e.dataTransfer.setData(SessionsDataTransfers.SESSION, payload);
-			e.dataTransfer.effectAllowed = 'move';
-
-			applyDragImage(e, this._container, session.title.get());
-		}));
-
-		this._register(addDisposableListener(this._container, EventType.DRAG_END, () => {
-			this._sessionTransfer.clearData(DraggedSessionIdentifier.prototype);
-		}));
 	}
 
 	/**
@@ -172,8 +134,6 @@ export class ChatCompositeBar extends Disposable {
 			return;
 		}
 		this._session = session;
-		this._toolbar.context = session;
-		this._inlineToolbar.context = session;
 
 		const store = new DisposableStore();
 		this._sessionDisposables.value = store;
@@ -189,10 +149,9 @@ export class ChatCompositeBar extends Disposable {
 			const activeChatUri = session.activeChat.read(reader)?.resource.toString() ?? '';
 			const mainChatUri = session.mainChat.read(reader).resource.toString();
 			this._rebuildTabs(chats, activeChatUri, mainChatUri);
-		}));
 
-		store.add(autorun(reader => {
-			this._setVisible(session.isCreated.read(reader));
+			// Only show the tab strip once the session is created and has multiple chats.
+			this._setVisible(session.isCreated.read(reader) && chats.length > 1);
 		}));
 	}
 
@@ -207,6 +166,8 @@ export class ChatCompositeBar extends Disposable {
 
 		this._updateActiveTab(activeChatId);
 		this._updateScrollDimensions();
+
+		this._onDidChangeHeight.fire();
 	}
 
 	private _updateScrollDimensions(): void {
@@ -368,78 +329,6 @@ export class ChatCompositeBar extends Disposable {
 	}
 
 	private _updateStyles(): void {
-		const theme = this._themeService.getColorTheme();
-
-		const bg = theme.getColor(agentsPanelBackground);
-		const activeFg = theme.getColor(PANEL_ACTIVE_TITLE_FOREGROUND);
-		const inactiveFg = theme.getColor(PANEL_INACTIVE_TITLE_FOREGROUND);
-		const activeBorder = theme.getColor(PANEL_ACTIVE_TITLE_BORDER);
-
-		this._container.style.setProperty('--chat-bar-background', bg?.toString() ?? '');
-		this._container.style.setProperty('--chat-tab-active-foreground', activeFg?.toString() ?? '');
-		this._container.style.setProperty('--chat-tab-inactive-foreground', inactiveFg?.toString() ?? '');
-		this._container.style.setProperty('--chat-tab-active-border', activeBorder?.toString() ?? '');
-	}
-}
-
-/**
- * A lightweight variant of {@link ChatCompositeBar} that renders only the
- * {@link Menus.SessionBarToolbar} menu using the same `.chat-composite-bar-toolbar`
- * styling. Unlike the full composite bar, this toolbar is absolutely positioned
- * at the top-right of the session view and does not allocate any vertical space.
- *
- * It is shown only when the hosted session exists but has not yet been created.
- */
-export class SessionViewFloatingToolbar extends Disposable {
-
-	private readonly _container: HTMLElement;
-	private readonly _toolbar: MenuWorkbenchToolBar;
-	private _session: IActiveSession | undefined;
-	private readonly _sessionDisposables = this._register(new MutableDisposable<DisposableStore>());
-
-	get element(): HTMLElement {
-		return this._container;
-	}
-
-	constructor(
-		@IInstantiationService instantiationService: IInstantiationService,
-	) {
-		super();
-
-		this._container = $('.chat-composite-bar.chat-composite-bar-toolbar-floating');
-		const toolbar = $('.chat-composite-bar-toolbar');
-		this._container.appendChild(toolbar);
-
-		this._toolbar = this._register(instantiationService.createInstance(MenuWorkbenchToolBar, toolbar, Menus.SessionBarToolbar, {
-			hiddenItemStrategy: HiddenItemStrategy.Ignore,
-			menuOptions: { shouldForwardArgs: true },
-			highlightToggledItems: true,
-		}));
-
-		this._setVisible(false);
-	}
-
-	setSession(session: IActiveSession | undefined): void {
-		if (this._session === session) {
-			return;
-		}
-		this._session = session;
-		this._toolbar.context = session;
-
-		const store = new DisposableStore();
-		this._sessionDisposables.value = store;
-
-		if (!session) {
-			this._setVisible(false);
-			return;
-		}
-
-		store.add(autorun(reader => {
-			this._setVisible(!session.isCreated.read(reader));
-		}));
-	}
-
-	private _setVisible(visible: boolean): void {
-		this._container.style.display = visible ? '' : 'none';
+		applySessionBarThemeColors(this._container, this._themeService.getColorTheme());
 	}
 }

--- a/src/vs/sessions/browser/parts/chatCompositeBar.ts
+++ b/src/vs/sessions/browser/parts/chatCompositeBar.ts
@@ -87,6 +87,8 @@ export class ChatCompositeBar extends Disposable {
 		this._container.appendChild(this._tabsRow);
 
 		this._tabsContainer = $('.chat-composite-bar-tabs');
+		this._tabsContainer.setAttribute('role', 'tablist');
+		this._tabsContainer.setAttribute('aria-label', localize('chatTabsAriaLabel', "Chats"));
 		this._tabsScrollbar = this._register(new ScrollableElement(this._tabsContainer, {
 			horizontal: ScrollbarVisibility.Hidden,
 			vertical: ScrollbarVisibility.Hidden,

--- a/src/vs/sessions/browser/parts/media/chatCompositeBar.css
+++ b/src/vs/sessions/browser/parts/media/chatCompositeBar.css
@@ -5,18 +5,153 @@
 
 .chat-composite-bar {
 	display: flex;
-	align-items: center;
+	flex-direction: column;
 	background-color: var(--session-view-background);
 	color: var(--session-view-foreground);
-	padding: 0 4px;
-	height: 35px;
 	flex-shrink: 0;
 	overflow: hidden;
+}
+
+/* Header host: title row + meta row, with the top padding for the whole bar area */
+.chat-composite-bar.session-header-bar {
+	padding: 6px 10px 0;
+}
+
+/* Tabs host: the chat tab strip, shown only when the session has multiple chats */
+.chat-composite-bar.session-chat-tabs-bar {
+	padding: 0 10px;
 	container-type: inline-size;
 }
 
+/* Header: a status icon column next to a main column (title row + meta row).
+	Mirrors the sessions list so the meta row aligns under the title. */
+.chat-composite-bar-header {
+	display: flex;
+	flex-direction: row;
+	align-items: flex-start;
+	gap: 6px;
+	padding-bottom: 6px;
+	border-bottom: 1px solid color-mix(in srgb, var(--session-view-foreground) 12%, transparent);
+}
+
+/* Main column stacks the title row and the meta row */
+.chat-composite-bar-header-main {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	flex: 1 1 auto;
+	min-width: 0;
+}
+
+/* Title row: title + actions */
+.chat-composite-bar-title-row {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	height: 26px;
+}
+
+/* Status icon column — sits beside the main column, centered on the title line.
+	The compound selector (with .session-header-bar) raises specificity above the
+	base `.codicon { display: inline-block }` rule so the flex centering wins. */
+.session-header-bar .chat-composite-bar-session-icon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-shrink: 0;
+	height: 26px;
+	font-size: 16px;
+	color: var(--session-view-foreground);
+}
+
+.chat-composite-bar-session-title {
+	flex: 1 1 auto;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-weight: 600;
+	font-size: 13px;
+	color: var(--chat-tab-active-foreground, var(--session-view-foreground));
+}
+
+.chat-composite-bar-title-actions {
+	display: flex;
+	align-items: center;
+	gap: 2px;
+	flex-shrink: 0;
+	margin-left: auto;
+}
+
+/* Meta row: workspace · branch · diff stats */
+.chat-composite-bar-meta-row {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	height: 22px;
+	font-size: 12px;
+	line-height: 18px;
+	color: var(--chat-tab-inactive-foreground, var(--session-view-foreground));
+	overflow: hidden;
+	white-space: nowrap;
+}
+
+.chat-composite-bar-meta-workspace-label,
+.chat-composite-bar-meta-branch-label {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	min-width: 0;
+}
+
+.chat-composite-bar-meta-workspace,
+.chat-composite-bar-meta-branch {
+	display: inline-flex;
+	align-items: center;
+	gap: 3px;
+	min-width: 0;
+	overflow: hidden;
+}
+
+.chat-composite-bar-meta-workspace-icon,
+.chat-composite-bar-meta-branch-icon {
+	display: inline-flex;
+	align-items: center;
+	font-size: 14px;
+	flex-shrink: 0;
+}
+
+.chat-composite-bar-meta-separator::before {
+	content: '\00B7';
+	opacity: 0.8;
+}
+
+.chat-composite-bar-meta-diff {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	flex-shrink: 0;
+	font-variant-numeric: tabular-nums;
+}
+
+.chat-composite-bar-meta-added {
+	color: var(--vscode-chat-linesAddedForeground);
+}
+
+.chat-composite-bar-meta-removed {
+	color: var(--vscode-chat-linesRemovedForeground);
+}
+
+/* Tabs row */
+.chat-composite-bar-tabs-row {
+	display: flex;
+	align-items: center;
+	height: 35px;
+	overflow: hidden;
+}
+
 /* The ScrollableElement wrapper holding the tabs is the shrinkable flex item */
-.chat-composite-bar > .monaco-scrollable-element {
+.chat-composite-bar-tabs-row > .monaco-scrollable-element {
 	flex: 0 1 auto;
 	min-width: 0;
 	height: 100%;
@@ -33,21 +168,32 @@
 	display: flex;
 	align-items: center;
 	flex-shrink: 0;
-	margin-left: 4px;
 }
 
 .chat-composite-bar-toolbar {
 	display: flex;
 	align-items: center;
 	flex-shrink: 0;
-	margin-left: auto;
-	padding-left: 4px;
 }
 
+/* Keep header toolbar buttons from dictating the row height */
+.chat-composite-bar-title-actions .action-item .action-label,
+.chat-composite-bar-meta-row .chat-composite-bar-inline-toolbar .action-item .action-label {
+	height: 20px;
+	line-height: 20px;
+	padding: 0 2px;
+}
+
+/* Floating variant: a lightweight, absolutely positioned toolbar with no header chrome */
 .chat-composite-bar.chat-composite-bar-toolbar-floating {
 	position: absolute;
 	top: 0px;
 	right: 0px;
+	flex-direction: row;
+	align-items: center;
+	padding: 0 4px;
+	border-bottom: none;
+	background: transparent;
 	container-type: unset;
 }
 

--- a/src/vs/sessions/browser/parts/media/titlebarpart.css
+++ b/src/vs/sessions/browser/parts/media/titlebarpart.css
@@ -29,24 +29,74 @@
 }
 
 .agent-sessions-workbench.monaco-workbench .part.titlebar > .sessions-titlebar-container > .titlebar-left {
-	width: fit-content;
-	flex-grow: 0;
+	width: auto;
+	flex: 1 1 0;
 }
 
 .agent-sessions-workbench.monaco-workbench .part.titlebar > .sessions-titlebar-container > .titlebar-center {
-	flex: 1;
+	flex: 0 1 auto;
 	max-width: none;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 4px;
+	min-width: 0;
 }
 
 .agent-sessions-workbench.monaco-workbench .part.titlebar > .sessions-titlebar-container > .titlebar-center .window-title {
 	margin: unset;
+	/* Match the VS Code window command center font size. */
+	font-size: 12px;
 }
 
 .agent-sessions-workbench.monaco-workbench .part.titlebar > .sessions-titlebar-container > .titlebar-right {
 	order: 2;
-	width: fit-content;
-	flex-grow: 0;
+	width: auto;
+	flex: 1 1 0;
 	justify-content: flex-end;
+}
+
+/* Center navigation / actions toolbars that flank the command center box. */
+.monaco-workbench .part.titlebar > .sessions-titlebar-container > .titlebar-center > .titlebar-actions-container {
+	display: none;
+	flex-shrink: 0;
+	-webkit-app-region: no-drag;
+	height: 100%;
+	align-items: center;
+}
+
+.monaco-workbench .part.titlebar > .sessions-titlebar-container > .titlebar-center > .titlebar-actions-container:not(.has-no-actions) {
+	display: flex;
+}
+
+/* The right-hand center actions (Open in VS Code) take no horizontal space in the
+ * centered cluster: the container is zero-width and overflows to the right. This way
+ * the widget's hover expansion grows rightward without widening the cluster, so the
+ * window-centered command center box never gets pushed. */
+.monaco-workbench .part.titlebar > .sessions-titlebar-container > .titlebar-center > .titlebar-center-actions-container {
+	width: 0;
+	flex: 0 0 0;
+	overflow: visible;
+	/* The buttons overflow rightward into the area painted by .titlebar-right (a
+	 * later, static drag region). Lift this container above it so the overflowing
+	 * actions (Run, Open in VS Code) stay interactive — matching .left-toolbar-container. */
+	position: relative;
+	z-index: 2500;
+	-webkit-app-region: no-drag;
+}
+
+/* The container itself is zero-width, so its -webkit-app-region: no-drag carves out a
+ * zero-width hole and the overflowing buttons would otherwise sit inside the titlebar's
+ * OS drag region (no pointer cursor, swallowed clicks). Re-declare no-drag on the action
+ * items, which have real content width, so each button gets a proper no-drag hit region.
+ * (The Open in VS Code widget already does this on its own element; this covers Run and
+ * any other action hosted here.) */
+.monaco-workbench .part.titlebar > .sessions-titlebar-container > .titlebar-center > .titlebar-center-actions-container .monaco-action-bar .action-item {
+	-webkit-app-region: no-drag;
+}
+
+.monaco-workbench .part.titlebar > .sessions-titlebar-container > .titlebar-center > .titlebar-actions-container .monaco-action-bar .action-item:not(.disabled) .codicon {
+	color: var(--vscode-icon-foreground);
 }
 
 /* Session Title Actions Container (before right toolbar) */

--- a/src/vs/sessions/browser/parts/sessionBarStyles.ts
+++ b/src/vs/sessions/browser/parts/sessionBarStyles.ts
@@ -1,0 +1,26 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IColorTheme } from '../../../platform/theme/common/themeService.js';
+import { PANEL_ACTIVE_TITLE_BORDER, PANEL_ACTIVE_TITLE_FOREGROUND, PANEL_INACTIVE_TITLE_FOREGROUND } from '../../../workbench/common/theme.js';
+import { agentsPanelBackground } from '../../common/theme.js';
+
+/**
+ * Applies the shared session bar CSS custom properties onto the given container.
+ *
+ * These tokens drive the foreground/background/border treatment that the session
+ * header and the chat tab strip share, so both surfaces stay visually in sync.
+ */
+export function applySessionBarThemeColors(container: HTMLElement, theme: IColorTheme): void {
+	const bg = theme.getColor(agentsPanelBackground);
+	const activeFg = theme.getColor(PANEL_ACTIVE_TITLE_FOREGROUND);
+	const inactiveFg = theme.getColor(PANEL_INACTIVE_TITLE_FOREGROUND);
+	const activeBorder = theme.getColor(PANEL_ACTIVE_TITLE_BORDER);
+
+	container.style.setProperty('--chat-bar-background', bg?.toString() ?? '');
+	container.style.setProperty('--chat-tab-active-foreground', activeFg?.toString() ?? '');
+	container.style.setProperty('--chat-tab-inactive-foreground', inactiveFg?.toString() ?? '');
+	container.style.setProperty('--chat-tab-active-border', activeBorder?.toString() ?? '');
+}

--- a/src/vs/sessions/browser/parts/sessionHeader.ts
+++ b/src/vs/sessions/browser/parts/sessionHeader.ts
@@ -1,0 +1,364 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import './media/chatCompositeBar.css';
+import { Disposable, DisposableStore, MutableDisposable } from '../../../base/common/lifecycle.js';
+import { Emitter, Event } from '../../../base/common/event.js';
+import { $, addDisposableListener, DisposableResizeObserver, EventType, reset } from '../../../base/browser/dom.js';
+import { autorun, IReader } from '../../../base/common/observable.js';
+import { IThemeService } from '../../../platform/theme/common/themeService.js';
+import { Codicon } from '../../../base/common/codicons.js';
+import { ThemeIcon, themeColorFromId } from '../../../base/common/themables.js';
+import { asCssVariable } from '../../../platform/theme/common/colorUtils.js';
+import { localize } from '../../../nls.js';
+import { SessionStatus } from '../../services/sessions/common/session.js';
+import { IActiveSession } from '../../services/sessions/common/sessionsManagement.js';
+import { IInstantiationService } from '../../../platform/instantiation/common/instantiation.js';
+import { HiddenItemStrategy, MenuWorkbenchToolBar } from '../../../platform/actions/browser/toolbar.js';
+import { Menus } from '../menus.js';
+import { LocalSelectionTransfer } from '../../../platform/dnd/browser/dnd.js';
+import { DraggedSessionIdentifier, SessionsDataTransfers } from '../dnd.js';
+import { applyDragImage } from '../../../base/browser/ui/dnd/dnd.js';
+import { applySessionBarThemeColors } from './sessionBarStyles.js';
+
+/**
+ * The session header shown at the top of a session view. It surfaces the session
+ * identity (status icon + title), a meta row (workspace · branch · diff stats),
+ * and the session toolbars (e.g. Run, Open in VS Code, New Chat).
+ *
+ * It is intentionally decoupled from the {@link ChatCompositeBar} (the chat tab
+ * strip) so the two surfaces evolve independently. The hosting view tells the
+ * header which session is relevant via {@link setSession}.
+ */
+export class SessionHeader extends Disposable {
+
+	private readonly _container: HTMLElement;
+	private readonly _iconEl: HTMLElement;
+	private readonly _titleEl: HTMLElement;
+	private readonly _metaRow: HTMLElement;
+	private readonly _toolbar: MenuWorkbenchToolBar;
+	private readonly _inlineToolbar: MenuWorkbenchToolBar;
+	private readonly _inlineToolbarContainer: HTMLElement;
+
+	private readonly _sessionDisposables = this._register(new MutableDisposable<DisposableStore>());
+	private _session: IActiveSession | undefined;
+
+	private readonly _onDidChangeVisibility = this._register(new Emitter<boolean>());
+	readonly onDidChangeVisibility: Event<boolean> = this._onDidChangeVisibility.event;
+
+	private readonly _onDidChangeHeight = this._register(new Emitter<void>());
+	readonly onDidChangeHeight: Event<void> = this._onDidChangeHeight.event;
+
+	private _visible = false;
+
+	private readonly _sessionTransfer = LocalSelectionTransfer.getInstance<DraggedSessionIdentifier>();
+
+	get element(): HTMLElement {
+		return this._container;
+	}
+
+	get visible(): boolean {
+		return this._visible;
+	}
+
+	get height(): number {
+		return this._visible ? this._container.offsetHeight : 0;
+	}
+
+	constructor(
+		@IThemeService private readonly _themeService: IThemeService,
+		@IInstantiationService instantiationService: IInstantiationService,
+	) {
+		super();
+
+		this._container = $('.chat-composite-bar.session-header-bar');
+
+		// Header: a status icon column alongside a main column that stacks the title
+		// row (title + actions) and the meta row (workspace · branch · diff). This
+		// mirrors the sessions list so the meta row aligns under the title rather
+		// than under the status icon.
+		const header = $('.chat-composite-bar-header');
+		this._container.appendChild(header);
+
+		this._iconEl = $('.chat-composite-bar-session-icon');
+		header.appendChild(this._iconEl);
+
+		const main = $('.chat-composite-bar-header-main');
+		header.appendChild(main);
+
+		const titleRow = $('.chat-composite-bar-title-row');
+		main.appendChild(titleRow);
+
+		this._titleEl = $('.chat-composite-bar-session-title');
+		titleRow.appendChild(this._titleEl);
+
+		const titleActions = $('.chat-composite-bar-title-actions');
+		titleRow.appendChild(titleActions);
+
+		this._inlineToolbarContainer = $('.chat-composite-bar-inline-toolbar');
+		this._inlineToolbar = this._register(instantiationService.createInstance(MenuWorkbenchToolBar, this._inlineToolbarContainer, Menus.SessionBarInlineToolbar, {
+			hiddenItemStrategy: HiddenItemStrategy.Ignore,
+			menuOptions: { shouldForwardArgs: true },
+			highlightToggledItems: true,
+		}));
+
+		const toolbarContainer = $('.chat-composite-bar-toolbar');
+		titleActions.appendChild(toolbarContainer);
+		this._toolbar = this._register(instantiationService.createInstance(MenuWorkbenchToolBar, toolbarContainer, Menus.SessionBarToolbar, {
+			hiddenItemStrategy: HiddenItemStrategy.Ignore,
+			menuOptions: { shouldForwardArgs: true },
+			highlightToggledItems: true,
+		}));
+
+		this._metaRow = $('.chat-composite-bar-meta-row');
+		main.appendChild(this._metaRow);
+
+		// Report height changes (e.g. meta row content wrapping) so the host can re-layout
+		const heightObserver = this._register(new DisposableResizeObserver('SessionHeader.height', () => {
+			this._onDidChangeHeight.fire();
+		}));
+		this._register(heightObserver.observe(this._container));
+
+		this._setVisible(false);
+		this._updateStyles();
+		this._register(this._themeService.onDidColorThemeChange(() => this._updateStyles()));
+
+		this._registerDragSource();
+	}
+
+	private _registerDragSource(): void {
+		this._container.draggable = true;
+
+		this._register(addDisposableListener(this._container, EventType.DRAG_START, (e: DragEvent) => {
+			const session = this._session;
+			if (!session || !e.dataTransfer) {
+				e.preventDefault();
+				return;
+			}
+
+			this._sessionTransfer.setData(
+				[new DraggedSessionIdentifier(session.sessionId, session.resource)],
+				DraggedSessionIdentifier.prototype,
+			);
+
+			const payload = JSON.stringify({ sessionId: session.sessionId, resource: session.resource.toString() });
+			e.dataTransfer.setData(SessionsDataTransfers.SESSION, payload);
+			e.dataTransfer.effectAllowed = 'move';
+
+			applyDragImage(e, this._container, session.title.get());
+		}));
+
+		this._register(addDisposableListener(this._container, EventType.DRAG_END, () => {
+			this._sessionTransfer.clearData(DraggedSessionIdentifier.prototype);
+		}));
+	}
+
+	/**
+	 * Tells the header which session is currently relevant. Pass `undefined` to clear.
+	 */
+	setSession(session: IActiveSession | undefined): void {
+		if (this._session === session) {
+			return;
+		}
+		this._session = session;
+		this._toolbar.context = session;
+		this._inlineToolbar.context = session;
+
+		const store = new DisposableStore();
+		this._sessionDisposables.value = store;
+
+		if (!session) {
+			this._setVisible(false);
+			return;
+		}
+
+		store.add(autorun(reader => {
+			this._updateHeader(session, reader);
+		}));
+
+		store.add(autorun(reader => {
+			this._setVisible(session.isCreated.read(reader));
+		}));
+	}
+
+	private _updateHeader(session: IActiveSession, reader: IReader): void {
+		// Session icon — mirror the status-based icon shown in the sessions list.
+		const status = session.status.read(reader);
+		const isRead = session.isRead.read(reader);
+		const isArchived = session.isArchived.read(reader);
+		const pullRequestIcon = session.workspace.read(reader)?.folders[0]?.gitRepository?.gitHubInfo.read(reader)?.pullRequest?.icon;
+		const icon = this._getStatusIcon(status, isRead, isArchived, pullRequestIcon);
+		this._iconEl.className = 'chat-composite-bar-session-icon';
+		this._iconEl.classList.add(...ThemeIcon.asClassNameArray(icon));
+		this._iconEl.style.color = icon.color ? asCssVariable(icon.color.id) : '';
+
+		// Session title
+		this._titleEl.textContent = session.title.read(reader) || localize('agentSessions.newSession', "New Session");
+
+		// Meta row: workspace · branch · diff stats
+		reset(this._metaRow);
+		const workspace = session.workspace.read(reader);
+		const branch = workspace?.folders.find(folder => folder.gitRepository?.branchName)?.gitRepository?.branchName?.trim();
+
+		let hasMeta = false;
+		const appendSeparator = () => {
+			if (hasMeta) {
+				this._metaRow.appendChild($('span.chat-composite-bar-meta-separator'));
+			}
+		};
+
+		if (workspace?.label) {
+			// Mirror the sessions list / hover icon logic: cloud for virtual workspaces,
+			// folder when the session runs in the repo checkout, worktree otherwise.
+			const isWorkspaceFolder = workspace.folders.length > 0 && workspace.folders[0]?.gitRepository?.workTreeUri === undefined;
+			const workspaceIcon = workspace.isVirtualWorkspace ? Codicon.cloud : isWorkspaceFolder ? Codicon.folder : Codicon.worktree;
+			const workspaceEl = $('span.chat-composite-bar-meta-workspace');
+			workspaceEl.appendChild($('span.chat-composite-bar-meta-workspace-icon' + ThemeIcon.asCSSSelector(workspaceIcon)));
+			const workspaceLabel = $('span.chat-composite-bar-meta-workspace-label');
+			workspaceLabel.textContent = workspace.label;
+			workspaceEl.appendChild(workspaceLabel);
+			this._metaRow.appendChild(workspaceEl);
+			hasMeta = true;
+		}
+
+		if (branch) {
+			appendSeparator();
+			const branchEl = $('span.chat-composite-bar-meta-branch');
+			branchEl.appendChild($('span.chat-composite-bar-meta-branch-icon' + ThemeIcon.asCSSSelector(Codicon.gitBranch)));
+			const branchLabel = $('span.chat-composite-bar-meta-branch-label');
+			branchLabel.textContent = branch;
+			branchEl.appendChild(branchLabel);
+			this._metaRow.appendChild(branchEl);
+			hasMeta = true;
+		}
+
+		// Aggregate insertions/deletions across all of the session's changes.
+		const changes = session.changes.read(reader);
+		let insertions = 0;
+		let deletions = 0;
+		for (const change of changes) {
+			insertions += change.insertions;
+			deletions += change.deletions;
+		}
+		if (insertions > 0 || deletions > 0) {
+			appendSeparator();
+			const diffEl = $('span.chat-composite-bar-meta-diff');
+			const addedEl = $('span.chat-composite-bar-meta-added');
+			addedEl.textContent = `+${insertions}`;
+			const removedEl = $('span.chat-composite-bar-meta-removed');
+			removedEl.textContent = `-${deletions}`;
+			diffEl.appendChild(addedEl);
+			diffEl.appendChild(removedEl);
+			this._metaRow.appendChild(diffEl);
+			hasMeta = true;
+		}
+
+		// The New Chat (`+`) toolbar always lives in the meta row (next to the diff
+		// stats), so the meta row is never empty.
+		this._metaRow.appendChild(this._inlineToolbarContainer);
+
+		this._onDidChangeHeight.fire();
+	}
+
+	/**
+	 * The status-based icon shown next to the session title. Mirrors the icon logic used by
+	 * the sessions list (`SessionsListRenderer.getStatusIcon`) so both surfaces stay in sync.
+	 * Replicated inline because the list renderer lives in the `contrib/` layer, which the
+	 * core `browser/parts/` layer must not import from.
+	 */
+	private _getStatusIcon(status: SessionStatus, isRead: boolean, isArchived: boolean, pullRequestIcon?: ThemeIcon): ThemeIcon {
+		switch (status) {
+			case SessionStatus.InProgress:
+				return { ...Codicon.sessionInProgress, color: themeColorFromId('textLink.foreground') };
+			case SessionStatus.NeedsInput:
+				return { ...Codicon.circleFilled, color: themeColorFromId('list.warningForeground') };
+			case SessionStatus.Error:
+				return { ...Codicon.error, color: themeColorFromId('errorForeground') };
+			default:
+				if (pullRequestIcon) {
+					return pullRequestIcon;
+				}
+				if (!isRead && !isArchived) {
+					return { ...Codicon.circleFilled, color: themeColorFromId('textLink.foreground') };
+				}
+				return { ...Codicon.circleSmallFilled, color: themeColorFromId('agentSessionReadIndicator.foreground') };
+		}
+	}
+
+	private _setVisible(visible: boolean): void {
+		const wasVisible = this._visible;
+		this._visible = visible;
+		this._container.style.display = this._visible ? '' : 'none';
+		if (wasVisible !== this._visible) {
+			this._onDidChangeVisibility.fire(this._visible);
+		}
+	}
+
+	private _updateStyles(): void {
+		applySessionBarThemeColors(this._container, this._themeService.getColorTheme());
+	}
+}
+
+/**
+ * A lightweight toolbar that renders only the {@link Menus.SessionBarToolbar} menu
+ * using the same `.chat-composite-bar-toolbar` styling. Unlike the full
+ * {@link SessionHeader}, this toolbar is absolutely positioned at the top-right of
+ * the session view and does not allocate any vertical space.
+ *
+ * It is shown only when the hosted session exists but has not yet been created.
+ */
+export class SessionViewFloatingToolbar extends Disposable {
+
+	private readonly _container: HTMLElement;
+	private readonly _toolbar: MenuWorkbenchToolBar;
+	private _session: IActiveSession | undefined;
+	private readonly _sessionDisposables = this._register(new MutableDisposable<DisposableStore>());
+
+	get element(): HTMLElement {
+		return this._container;
+	}
+
+	constructor(
+		@IInstantiationService instantiationService: IInstantiationService,
+	) {
+		super();
+
+		this._container = $('.chat-composite-bar.chat-composite-bar-toolbar-floating');
+		const toolbar = $('.chat-composite-bar-toolbar');
+		this._container.appendChild(toolbar);
+
+		this._toolbar = this._register(instantiationService.createInstance(MenuWorkbenchToolBar, toolbar, Menus.SessionBarToolbar, {
+			hiddenItemStrategy: HiddenItemStrategy.Ignore,
+			menuOptions: { shouldForwardArgs: true },
+			highlightToggledItems: true,
+		}));
+
+		this._setVisible(false);
+	}
+
+	setSession(session: IActiveSession | undefined): void {
+		if (this._session === session) {
+			return;
+		}
+		this._session = session;
+		this._toolbar.context = session;
+
+		const store = new DisposableStore();
+		this._sessionDisposables.value = store;
+
+		if (!session) {
+			this._setVisible(false);
+			return;
+		}
+
+		store.add(autorun(reader => {
+			this._setVisible(!session.isCreated.read(reader));
+		}));
+	}
+
+	private _setVisible(visible: boolean): void {
+		this._container.style.display = visible ? '' : 'none';
+	}
+}

--- a/src/vs/sessions/browser/parts/sessionHeader.ts
+++ b/src/vs/sessions/browser/parts/sessionHeader.ts
@@ -41,6 +41,7 @@ export class SessionHeader extends Disposable {
 	private readonly _toolbar: MenuWorkbenchToolBar;
 	private readonly _inlineToolbar: MenuWorkbenchToolBar;
 	private readonly _inlineToolbarContainer: HTMLElement;
+	private readonly _titleActionsEl: HTMLElement;
 
 	private readonly _sessionDisposables = this._register(new MutableDisposable<DisposableStore>());
 	private _session: IActiveSession | undefined;
@@ -96,6 +97,7 @@ export class SessionHeader extends Disposable {
 
 		const titleActions = $('.chat-composite-bar-title-actions');
 		titleRow.appendChild(titleActions);
+		this._titleActionsEl = titleActions;
 
 		this._inlineToolbarContainer = $('.chat-composite-bar-inline-toolbar');
 		this._inlineToolbar = this._register(instantiationService.createInstance(MenuWorkbenchToolBar, this._inlineToolbarContainer, Menus.SessionBarInlineToolbar, {
@@ -134,6 +136,16 @@ export class SessionHeader extends Disposable {
 		this._register(addDisposableListener(this._container, EventType.DRAG_START, (e: DragEvent) => {
 			const session = this._session;
 			if (!session || !e.dataTransfer) {
+				e.preventDefault();
+				return;
+			}
+
+			// Don't initiate a drag when the gesture starts inside one of the
+			// header toolbars (Run, Open in VS Code, New Chat). A small pointer
+			// move during a button click would otherwise start a session drag
+			// and swallow the click.
+			const target = e.target as Node | null;
+			if (target && (this._titleActionsEl.contains(target) || this._inlineToolbarContainer.contains(target))) {
 				e.preventDefault();
 				return;
 			}

--- a/src/vs/sessions/browser/parts/sessionView.ts
+++ b/src/vs/sessions/browser/parts/sessionView.ts
@@ -16,7 +16,8 @@ import { asCssVariable } from '../../../platform/theme/common/colorUtils.js';
 import { IActiveSession } from '../../services/sessions/common/sessionsManagement.js';
 import { IChatViewFactory } from '../../services/chatView/browser/chatViewFactory.js';
 import { AbstractChatView, ChatViewKind } from './chatView.js';
-import { ChatCompositeBar, SessionViewFloatingToolbar } from './chatCompositeBar.js';
+import { ChatCompositeBar } from './chatCompositeBar.js';
+import { SessionHeader, SessionViewFloatingToolbar } from './sessionHeader.js';
 import { autorun } from '../../../base/common/observable.js';
 import { SessionIsCreatedContext, SessionIsMaximizedContext, SessionIsStickyContext, SessionSupportsMultipleChatsContext } from '../../common/contextkeys.js';
 import { activeSessionViewBackground, activeSessionViewForeground, inactiveSessionViewBackground, inactiveSessionViewForeground } from '../../common/theme.js';
@@ -28,8 +29,8 @@ import { SessionStatus } from '../../services/sessions/common/session.js';
  * this host so it no longer needs to remove/add grid views when the active
  * chat view kind changes.
  *
- * Also hosts the {@link ChatCompositeBar} so that the bar lives alongside
- * the chat view it relates to.
+ * Also hosts the {@link SessionHeader} and {@link ChatCompositeBar} so that they
+ * live alongside the chat view they relate to.
  */
 export class SessionView extends Disposable implements ISerializableView {
 
@@ -38,9 +39,6 @@ export class SessionView extends Disposable implements ISerializableView {
 	private static readonly ACTIVE_FOREGROUND = asCssVariable(activeSessionViewForeground);
 	private static readonly INACTIVE_BACKGROUND = asCssVariable(inactiveSessionViewBackground);
 	private static readonly INACTIVE_FOREGROUND = asCssVariable(inactiveSessionViewForeground);
-
-	/** Height of the chat composite bar when visible. */
-	private static readonly BAR_HEIGHT = 35;
 
 	readonly element: HTMLElement = $('.session-view');
 
@@ -52,6 +50,7 @@ export class SessionView extends Disposable implements ISerializableView {
 	private readonly _onDidChange = this._register(new Emitter<IViewSize | undefined>());
 	readonly onDidChange: Event<IViewSize | undefined> = this._onDidChange.event;
 
+	private readonly _header: SessionHeader;
 	private readonly _compositeBar: ChatCompositeBar;
 	private readonly _floatingToolbar: SessionViewFloatingToolbar;
 	private readonly _contentContainer: HTMLElement;
@@ -88,6 +87,9 @@ export class SessionView extends Disposable implements ISerializableView {
 
 		const scopedInstantiationService = this._register(instantiationService.createChild(new ServiceCollection([IContextKeyService, scopedContextKeyService])));
 
+		this._header = this._register(scopedInstantiationService.createInstance(SessionHeader));
+		this.element.appendChild(this._header.element);
+
 		this._compositeBar = this._register(scopedInstantiationService.createInstance(ChatCompositeBar));
 		this.element.appendChild(this._compositeBar.element);
 
@@ -99,8 +101,11 @@ export class SessionView extends Disposable implements ISerializableView {
 
 		this._applyActiveSessionStyles();
 
-		// Re-layout children when the composite bar becomes visible/hidden
+		// Re-layout children when the header or composite bar changes visibility/height
+		this._register(this._header.onDidChangeVisibility(() => this._layoutChildren()));
+		this._register(this._header.onDidChangeHeight(() => this._layoutChildren()));
 		this._register(this._compositeBar.onDidChangeVisibility(() => this._layoutChildren()));
+		this._register(this._compositeBar.onDidChangeHeight(() => this._layoutChildren()));
 	}
 
 	openSession(session: IActiveSession | undefined): void {
@@ -138,6 +143,7 @@ export class SessionView extends Disposable implements ISerializableView {
 				view.setChat(session.activeChat.read(reader));
 			}
 
+			this._header.setSession(session);
 			this._compositeBar.setSession(session);
 			this._floatingToolbar.setSession(session);
 			this._layoutChildren();
@@ -177,7 +183,9 @@ export class SessionView extends Disposable implements ISerializableView {
 			return;
 		}
 		const { width, height, top, left } = this._lastLayout;
-		const barHeight = this._compositeBar.visible ? SessionView.BAR_HEIGHT : 0;
+		const headerHeight = this._header.visible ? this._header.height : 0;
+		const tabsHeight = this._compositeBar.visible ? this._compositeBar.height : 0;
+		const barHeight = headerHeight + tabsHeight;
 		this._currentView.value?.layout(width, height - barHeight, top + barHeight, left);
 	}
 

--- a/src/vs/sessions/browser/parts/titlebarPart.ts
+++ b/src/vs/sessions/browser/parts/titlebarPart.ts
@@ -16,7 +16,7 @@ import { DisposableStore } from '../../../base/common/lifecycle.js';
 import { IThemeService } from '../../../platform/theme/common/themeService.js';
 import { agentsBackground, agentsPanelForeground } from '../../common/theme.js';
 import { isMacintosh, isWeb, isNative, platformLocale } from '../../../base/common/platform.js';
-import { EventType, EventHelper, append, $, addDisposableListener, prepend, getWindow, getWindowId, getContentWidth } from '../../../base/browser/dom.js';
+import { EventType, EventHelper, append, $, addDisposableListener, prepend, getWindow, getWindowId } from '../../../base/browser/dom.js';
 import { IInstantiationService } from '../../../platform/instantiation/common/instantiation.js';
 import { Emitter, Event } from '../../../base/common/event.js';
 import { IStorageService } from '../../../platform/storage/common/storage.js';
@@ -88,9 +88,6 @@ export class TitlebarPart extends Part implements ITitlebarPart {
 	get rightContainer(): HTMLElement { return this.rightContent; }
 	get rightWindowControlsContainer(): HTMLElement | undefined { return this.windowControlsContainer; }
 
-	private sideBarPartResizeObserver: ResizeObserver | undefined;
-	private leftToolbarContentWidth: number = 0;
-	private lastSideBarWidth: number = 0;
 	private leftSpacerWidth: number = 0;
 
 	private readonly titleBarStyle: TitlebarStyle;
@@ -181,7 +178,6 @@ export class TitlebarPart extends Part implements ITitlebarPart {
 				this._register(onDidChangeFullscreen(windowId => {
 					if (windowId === getWindowId(mainWindow)) {
 						updateSpacerVisibility();
-						this.updateLeftContentWidth();
 					}
 				}));
 			} else if (getWindowControlsStyle(this.configurationService) === WindowControlsStyle.HIDDEN) {
@@ -200,17 +196,23 @@ export class TitlebarPart extends Part implements ITitlebarPart {
 
 		// Left toolbar (driven by Menus.TitleBarLeft, rendered after window controls via CSS order)
 		this.leftToolbarContainer = append(this.leftContent, $('div.left-toolbar-container'));
-		const leftToolbar = this._register(this.instantiationService.createInstance(MenuWorkbenchToolBar, this.leftToolbarContainer, Menus.TitleBarLeftLayout, {
+		this._register(this.instantiationService.createInstance(MenuWorkbenchToolBar, this.leftToolbarContainer, Menus.TitleBarLeftLayout, {
 			contextMenu: Menus.TitleBarContext,
 			telemetrySource: 'titlePart.left',
 			hiddenItemStrategy: HiddenItemStrategy.NoHide,
 			toolbarOptions: { primaryGroup: () => true },
 		}));
-		this.leftToolbarContentWidth = getContentWidth(this.leftToolbarContainer);
-		this.updateLeftContentWidth();
-		this._register(leftToolbar.onDidChangeMenuItems(() => {
-			this.leftToolbarContentWidth = getContentWidth(this.leftToolbarContainer);
-			this.updateLeftContentWidth();
+
+		// Center section: [nav toolbar] [command center box] [actions toolbar]
+		// All live inside .titlebar-center so the cluster is window-centered.
+
+		// Navigation toolbar (Back/Forward), rendered left of the command center.
+		const centerNavContainer = append(this.centerContent, $('div.titlebar-actions-container.titlebar-center-nav-container'));
+		this._register(this.instantiationService.createInstance(MenuWorkbenchToolBar, centerNavContainer, Menus.TitleBarCenterLeft, {
+			contextMenu: Menus.TitleBarContext,
+			hiddenItemStrategy: HiddenItemStrategy.NoHide,
+			telemetrySource: 'titlePart.centerLeft',
+			toolbarOptions: { primaryGroup: () => true },
 		}));
 
 		// Center toolbar - command center (renders session picker via IActionViewItemService)
@@ -227,6 +229,15 @@ export class TitlebarPart extends Part implements ITitlebarPart {
 			if (e.affectsSome(commandCenterContextKeys)) {
 				centerToolbar.refresh();
 			}
+		}));
+
+		// Actions toolbar (Open in VS Code), rendered right of the command center.
+		const centerActionsContainer = append(this.centerContent, $('div.titlebar-actions-container.titlebar-center-actions-container'));
+		this._register(this.instantiationService.createInstance(MenuWorkbenchToolBar, centerActionsContainer, Menus.TitleBarCenterRight, {
+			contextMenu: Menus.TitleBarContext,
+			hiddenItemStrategy: HiddenItemStrategy.NoHide,
+			telemetrySource: 'titlePart.centerRight',
+			toolbarOptions: { primaryGroup: () => true },
 		}));
 
 		// Right toolbar (driven by Menus.TitleBarRightLayout - includes layout actions)
@@ -296,36 +307,6 @@ export class TitlebarPart extends Part implements ITitlebarPart {
 	override layout(width: number, height: number): void {
 		this.updateLayout();
 		super.layoutContents(width, height);
-		this.installSideBarPartResizeObserver();
-	}
-
-	private installSideBarPartResizeObserver(): void {
-		if (this.sideBarPartResizeObserver) {
-			return;
-		}
-
-		const sideBarContainer = this.layoutService.getContainer(getWindow(this.element), Parts.SIDEBAR_PART);
-		if (!sideBarContainer) {
-			return;
-		}
-
-		this.sideBarPartResizeObserver = new ResizeObserver(entries => {
-			this.lastSideBarWidth = entries[0].contentRect.width;
-			this.updateLeftContentWidth();
-		});
-		this.sideBarPartResizeObserver.observe(sideBarContainer);
-		this._register({ dispose: () => this.sideBarPartResizeObserver?.disconnect() });
-	}
-
-	private getLeftContentWidth(): number {
-		if (this.leftToolbarContentWidth === 0) {
-			this.leftToolbarContentWidth = getContentWidth(this.leftToolbarContainer);
-		}
-		return this.leftToolbarContentWidth + this.leftSpacerWidth;
-	}
-
-	private updateLeftContentWidth(): void {
-		this.leftContent.style.width = `${Math.max(this.getLeftContentWidth(), this.lastSideBarWidth)}px`;
 	}
 
 	private updateLayout(): void {

--- a/src/vs/sessions/contrib/chat/browser/runScriptAction.ts
+++ b/src/vs/sessions/contrib/chat/browser/runScriptAction.ts
@@ -177,7 +177,7 @@ export class RunScriptContribution extends Disposable implements IWorkbenchContr
 	private _registerActionViewItemProvider(): void {
 		const that = this;
 		this._register(this._actionViewItemService.register(
-			Menus.TitleBarSessionMenu,
+			Menus.TitleBarCenterRight,
 			RunScriptDropdownMenuId,
 			(action, options, instantiationService) => {
 				if (!(action instanceof SubmenuItemAction)) {
@@ -837,14 +837,15 @@ class ChevronActionWidgetDropdown extends ActionWidgetDropdownActionViewItem {
 	}
 }
 
-// Register the Run split button submenu on the workbench title bar (background sessions only)
-MenuRegistry.appendMenuItem(Menus.TitleBarSessionMenu, {
+// Register the Run split button submenu on the workbench title bar (background sessions only).
+// Placed in the center-right toolbar, immediately before the "Open in VS Code" action (order 7).
+MenuRegistry.appendMenuItem(Menus.TitleBarCenterRight, {
 	submenu: RunScriptDropdownMenuId,
 	isSplitButton: true,
 	title: localize2('run', "Run"),
 	icon: Codicon.play,
 	group: 'navigation',
-	order: 8,
+	order: 6,
 	when: ContextKeyExpr.and(IsAuxiliaryWindowContext.toNegated(), SessionsWelcomeVisibleContext.toNegated(), ActiveSessionWorkspaceIsVirtualContext.toNegated())
 });
 
@@ -858,9 +859,9 @@ class RunScriptNotAvailableAction extends Action2 {
 			icon: Codicon.play,
 			precondition: ContextKeyExpr.false(),
 			menu: [{
-				id: Menus.TitleBarSessionMenu,
+				id: Menus.TitleBarCenterRight,
 				group: 'navigation',
-				order: 8,
+				order: 6,
 				when: ContextKeyExpr.and(IsAuxiliaryWindowContext.toNegated(), SessionsWelcomeVisibleContext.toNegated(), ActiveSessionWorkspaceIsVirtualContext)
 			}]
 		});

--- a/src/vs/sessions/contrib/chat/test/browser/runScriptAction.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/runScriptAction.test.ts
@@ -14,18 +14,18 @@ import { isISubmenuItem, MenuId, MenuRegistry } from '../../../../../platform/ac
 // KeybindingsRegistry in this lightweight test context.
 import '../../browser/runScriptAction.js';
 
-const titleBarSessionMenu = MenuId.for('SessionsTitleBarSessionMenu');
+const titleBarCenterRightMenu = MenuId.for('SessionsTitleBarCenterRight');
 
 suite('RunScriptContribution', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	test('contributes run dropdown to TitleBarSessionMenu', () => {
-		const items = MenuRegistry.getMenuItems(titleBarSessionMenu);
+	test('contributes run dropdown to TitleBarCenterRight before Open in VS Code', () => {
+		const items = MenuRegistry.getMenuItems(titleBarCenterRightMenu);
 
 		const runAction = items.find(item => isISubmenuItem(item) && item.submenu.id === 'AgentSessionsRunScriptDropdown');
 
-		assert.ok(runAction, 'run dropdown should be contributed to TitleBarSessionMenu');
-		assert.strictEqual(runAction.order, 8);
+		assert.ok(runAction, 'run dropdown should be contributed to TitleBarCenterRight');
+		assert.strictEqual(runAction.order, 6);
 	});
 });

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsTitleBarWidget.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsTitleBarWidget.css
@@ -15,15 +15,18 @@
 
 .command-center .agent-sessions-titlebar-container {
 	display: flex;
-	flex: 1;
+	flex: 0 1 auto;
 	flex-direction: row;
 	flex-wrap: nowrap;
 	align-items: center;
 	justify-content: flex-start;
 	min-width: 0;
-	margin-left: 16px;
+	width: 38vw;
+	max-width: 600px;
 	height: 22px;
-	border-radius: 4px;
+	border: 1px solid var(--vscode-commandCenter-border);
+	background-color: transparent;
+	border-radius: var(--vscode-cornerRadius-medium);
 	-webkit-app-region: no-drag;
 	overflow: hidden;
 	color: var(--vscode-commandCenter-foreground);
@@ -33,32 +36,34 @@
 	transition: opacity 120ms ease-out;
 }
 
-.agent-sessions-workbench:not(.nosidebar) .command-center .agent-sessions-titlebar-container {
-	margin-left: 0;
+.command-center .agent-sessions-titlebar-container:hover {
+	color: var(--vscode-commandCenter-activeForeground);
+	background-color: var(--vscode-commandCenter-activeBackground);
+	border-color: var(--vscode-commandCenter-activeBorder);
 }
 
 .command-center .agent-sessions-titlebar-container.agent-sessions-titlebar-hidden {
 	flex: 0 1 0;
 	width: 0;
+	min-width: 0;
+	border-color: transparent;
+	background-color: transparent;
 	margin-left: 0;
 	opacity: 0;
 	pointer-events: none;
 }
 
-/* Session pill - clickable area for session picker */
+/* Session pill - clickable area for session picker, fills the command center box */
 .command-center .agent-sessions-titlebar-container .agent-sessions-titlebar-pill {
 	display: flex;
 	align-items: center;
-	padding: 0 4px;
-	border-radius: 4px;
+	flex: 1 1 auto;
+	padding: 0 8px;
 	min-width: 0;
 	max-width: 100%;
+	height: 100%;
 	cursor: pointer;
 	touch-action: manipulation;
-}
-
-.command-center .agent-sessions-titlebar-container .agent-sessions-titlebar-pill:hover {
-	background-color: var(--vscode-toolbar-hoverBackground);
 }
 
 .command-center .agent-sessions-titlebar-container:focus {
@@ -84,65 +89,37 @@
 	font-size: 14px;
 }
 
-.command-center > .monaco-toolbar > .monaco-action-bar > .actions-container > .action-item:not(.disabled) > .action-label {
-	color: var(--vscode-icon-foreground);
-}
-
-/* Repository/worktree metadata. */
-.command-center .agent-sessions-titlebar-container .agent-sessions-titlebar-details {
-	display: flex;
-	align-items: center;
+/* Session title - primary label in the command center box. */
+.command-center .agent-sessions-titlebar-container .agent-sessions-titlebar-title {
 	flex: 0 1 auto;
-	gap: 6px;
-	min-width: 0;
-	overflow: hidden;
-	opacity: 0.7;
-}
-
-.command-center .agent-sessions-titlebar-container .agent-sessions-titlebar-repo {
-	flex: 1 1 auto;
 	min-width: 0;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+	/* Match the VS Code window command center title which is dimmed. */
+	opacity: 0.6;
 }
 
+/* Workspace name - secondary, dimmed label shown after the session title.
+	It must not be cropped: when space is tight the session title truncates
+	first while the workspace name stays fully visible. */
+.command-center .agent-sessions-titlebar-container .agent-sessions-titlebar-workspace {
+	flex: 0 0 auto;
+	white-space: nowrap;
+	opacity: 0.7;
+}
+
+.command-center > .monaco-toolbar > .monaco-action-bar > .actions-container > .action-item:not(.disabled) > .action-label {
+	color: var(--vscode-icon-foreground);
+}
+
+/* Separator between the session title and the workspace name. */
 .command-center .agent-sessions-titlebar-container .agent-sessions-titlebar-separator {
+	flex-shrink: 0;
+
 	&::before {
 		content: '\00B7';
 	}
-}
-
-.command-center .agent-sessions-titlebar-container .agent-sessions-titlebar-branch {
-	display: flex;
-	align-items: center;
-	gap: 2px;
-	flex-shrink: 0;
-	white-space: nowrap;
-
-	.codicon {
-		font-size: 13px;
-		width: 13px;
-		height: 13px;
-	}
-}
-
-/* Diff stats (+insertions -deletions) shown for sessions with pending changes. */
-.command-center .agent-sessions-titlebar-container .agent-sessions-titlebar-diff {
-	display: flex;
-	align-items: center;
-	gap: 2px;
-	flex-shrink: 0;
-	font-variant-numeric: tabular-nums;
-	white-space: nowrap;
-}
-
-.command-center .agent-sessions-titlebar-container .agent-sessions-titlebar-diff-added {
-	color: var(--vscode-chat-linesAddedForeground);
-}
-
-.command-center .agent-sessions-titlebar-container .agent-sessions-titlebar-diff-removed {
-	color: var(--vscode-chat-linesRemovedForeground);
 }
 
 /* Sidebar toggle unread badge */

--- a/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
@@ -136,7 +136,7 @@ registerAction2(class GoBackAction extends Action2 {
 				when: ContextKeyExpr.and(IsSessionsWindowContext, EditorContextKeys.editorTextFocus.toNegated()),
 			},
 			menu: [{
-				id: Menus.TitleBarLeftLayout,
+				id: Menus.TitleBarCenterLeft,
 				group: 'navigation',
 				order: 1,
 				when: ContextKeyExpr.and(IsAuxiliaryWindowContext.toNegated(), SessionsWelcomeVisibleContext.toNegated()),
@@ -176,7 +176,7 @@ registerAction2(class GoForwardAction extends Action2 {
 				when: ContextKeyExpr.and(IsSessionsWindowContext, EditorContextKeys.editorTextFocus.toNegated()),
 			},
 			menu: [{
-				id: Menus.TitleBarLeftLayout,
+				id: Menus.TitleBarCenterLeft,
 				group: 'navigation',
 				order: 2,
 				when: ContextKeyExpr.and(IsAuxiliaryWindowContext.toNegated(), SessionsWelcomeVisibleContext.toNegated()),

--- a/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
@@ -74,14 +74,12 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 	) {
 		super(undefined, action, options);
 
-		// Re-render when the active session or its data changes
+		// Re-render when the active session's title or workspace changes
 		this._register(autorun(reader => {
 			const sessionData = this.sessionsManagementService.activeSession.read(reader);
 			if (sessionData) {
 				sessionData.title.read(reader);
-				sessionData.status.read(reader);
 				sessionData.workspace.read(reader);
-				sessionData.changes.read(reader);
 			}
 			this._lastRenderState = undefined;
 			this._render();

--- a/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
@@ -31,9 +31,8 @@ import { ISessionsListModelService } from './views/sessionsListModelService.js';
 import { SHOW_SESSIONS_PICKER_COMMAND_ID } from './sessionsActions.js';
 import { IsSessionArchivedContext, IsSessionPinnedContext, IsSessionReadContext, SessionItemContextMenuId, SessionItemHasBranchNameContext } from './views/sessionsList.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
-import { renderLabelWithIcons } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
 import { IMarkdownString, MarkdownString } from '../../../../base/common/htmlContent.js';
-import { buildSessionHoverContent, getSessionDiffStats } from './sessionHoverContent.js';
+import { buildSessionHoverContent } from './sessionHoverContent.js';
 
 const titleBarContextKeys = new Set([IsNewChatSessionContext.key]);
 
@@ -79,6 +78,7 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 		this._register(autorun(reader => {
 			const sessionData = this.sessionsManagementService.activeSession.read(reader);
 			if (sessionData) {
+				sessionData.title.read(reader);
 				sessionData.status.read(reader);
 				sessionData.workspace.read(reader);
 				sessionData.changes.read(reader);
@@ -150,12 +150,11 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 			}
 
 			const icon = this._getActiveSessionIcon();
-			const repoLabel = this._getRepositoryLabel();
-			const repoBranchLabel = this._getRepositoryBranchLabel();
-			const diffStats = this._getDiffStats();
+			const sessionTitle = this._getSessionTitle();
+			const workspaceLabel = this._getRepositoryLabel();
 
 			// Build a render-state key from all displayed data
-			const renderState = `${icon?.id ?? ''}|${repoLabel ?? ''}|${repoBranchLabel ?? ''}|${diffStats ? `${diffStats.insertions}/${diffStats.deletions}` : ''}`;
+			const renderState = `${icon?.id ?? ''}|${sessionTitle ?? ''}|${workspaceLabel ?? ''}`;
 
 			// Skip re-render if state hasn't changed
 			if (this._lastRenderState === renderState) {
@@ -173,10 +172,10 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 			this._container.setAttribute('aria-label', localize('agentSessionsShowSessions', "Show Sessions"));
 			this._container.tabIndex = 0;
 
-			// Session pill: icon + folder together
+			// Session pill: icon + title + workspace together
 			const sessionPill = $('div.agent-sessions-titlebar-pill');
 
-			// Center group: icon + folder
+			// Center group: icon + title + workspace name
 			const centerGroup = $('div.agent-sessions-titlebar-center');
 
 			// Kind icon at the beginning
@@ -185,38 +184,21 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 				centerGroup.appendChild(iconEl);
 			}
 
-			// Folder shown next to the icon
-			if (repoLabel) {
-				const detailsEl = $('div.agent-sessions-titlebar-details');
+			// Session title shown next to the icon
+			if (sessionTitle) {
+				const titleEl = $('div.agent-sessions-titlebar-title');
+				titleEl.textContent = sessionTitle;
+				centerGroup.appendChild(titleEl);
+			}
 
-				const repoEl = $('div.agent-sessions-titlebar-repo');
-				repoEl.textContent = repoLabel;
-				detailsEl.appendChild(repoEl);
+			// Workspace name shown after the session title
+			if (workspaceLabel) {
+				const separatorEl = $('div.agent-sessions-titlebar-separator');
+				centerGroup.appendChild(separatorEl);
 
-				if (repoBranchLabel) {
-					const separatorEl = $('div.agent-sessions-titlebar-separator');
-					detailsEl.appendChild(separatorEl);
-
-					const branchEl = $('div.agent-sessions-titlebar-branch');
-					branchEl.append(...renderLabelWithIcons(`$(git-branch) ${repoBranchLabel}`));
-					detailsEl.appendChild(branchEl);
-				}
-
-				if (diffStats) {
-					const separatorEl = $('div.agent-sessions-titlebar-separator');
-					detailsEl.appendChild(separatorEl);
-
-					const diffEl = $('div.agent-sessions-titlebar-diff');
-					const addedEl = $('span.agent-sessions-titlebar-diff-added');
-					addedEl.textContent = `+${diffStats.insertions}`;
-					diffEl.appendChild(addedEl);
-					const removedEl = $('span.agent-sessions-titlebar-diff-removed');
-					removedEl.textContent = `-${diffStats.deletions}`;
-					diffEl.appendChild(removedEl);
-					detailsEl.appendChild(diffEl);
-				}
-
-				centerGroup.appendChild(detailsEl);
+				const workspaceEl = $('div.agent-sessions-titlebar-workspace');
+				workspaceEl.textContent = workspaceLabel;
+				centerGroup.appendChild(workspaceEl);
 			}
 
 			sessionPill.appendChild(centerGroup);
@@ -283,6 +265,14 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 	}
 
 	/**
+	 * Get the display title for the active session.
+	 */
+	private _getSessionTitle(): string | undefined {
+		const sessionData = this.sessionsManagementService.activeSession.get();
+		return sessionData?.title.get()?.trim() || undefined;
+	}
+
+	/**
 	 * Get the repository label for the active session.
 	 */
 	private _getRepositoryLabel(): string | undefined {
@@ -294,23 +284,6 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 			}
 		}
 		return undefined;
-	}
-
-	/**
-	 * Get the branch label for the active session.
-	 */
-	private _getRepositoryBranchLabel(): string | undefined {
-		const sessionData = this.sessionsManagementService.activeSession.get();
-		return sessionData?.workspace.get()?.folders[0]?.gitRepository?.branchName?.trim() || undefined;
-	}
-
-	/**
-	 * Get the aggregated insertions/deletions for the active session, or
-	 * undefined when there are no changes.
-	 */
-	private _getDiffStats(): { insertions: number; deletions: number } | undefined {
-		const sessionData = this.sessionsManagementService.activeSession.get();
-		return sessionData ? getSessionDiffStats(sessionData) : undefined;
 	}
 
 	private _showContextMenu(e: MouseEvent): void {

--- a/src/vs/sessions/electron-browser/actions/vscodeActions.ts
+++ b/src/vs/sessions/electron-browser/actions/vscodeActions.ts
@@ -41,7 +41,7 @@ export class OpenSessionInVSCodeAction extends Action2 {
 			icon: Codicon.vscodeInsiders,
 			precondition: ContextKeyExpr.and(IsAuxiliaryWindowContext.toNegated(), SessionsWelcomeVisibleContext.toNegated()),
 			menu: [{
-				id: Menus.TitleBarSessionMenu,
+				id: Menus.TitleBarCenterRight,
 				group: 'navigation',
 				order: 7,
 				when: ContextKeyExpr.and(IsAuxiliaryWindowContext.toNegated(), SessionsWelcomeVisibleContext.toNegated(), IsPhoneLayoutContext.negate()),
@@ -130,7 +130,7 @@ export class OpenInVSCodeWidgetContribution extends Disposable implements IWorkb
 		@IInstantiationService instantiationService: IInstantiationService,
 	) {
 		super();
-		this._register(actionViewItemService.register(Menus.TitleBarSessionMenu, OpenSessionInVSCodeAction.ID, (action, options) => {
+		this._register(actionViewItemService.register(Menus.TitleBarCenterRight, OpenSessionInVSCodeAction.ID, (action, options) => {
 			return instantiationService.createInstance(OpenInVSCodeTitleBarWidget, action, options);
 		}, undefined));
 	}


### PR DESCRIPTION
## What

Restructures the Agents window titlebar and session-view header.

### Titlebar command center
- Adds a VS Code editor-style command center to the Agents titlebar showing the **session kind icon**, **session title** and **workspace name**.
- When the title is long, the **title truncates** with an ellipsis while the **workspace name stays fully visible** (no longer cropped).
- Moves the **Open in VS Code** action next to the titlebar center; terminal and run actions stay where they were.

### Session header / composite bar split
- Splits the monolithic `ChatCompositeBar` into:
  - `SessionHeader` — session identity (status icon, title, meta row of workspace · branch · diff) plus the Run / Open in VS Code / `+` toolbars.
  - `ChatCompositeBar` — a tabs-only strip, shown only when a session has more than one chat.
- Shared theme tokens are extracted into `sessionBarStyles.ts`.
- The session header alignment mirrors the sessions list (status icon as a left column with title + meta stacked beside it), and shows a **folder / worktree / cloud** icon before the workspace name.

### Architecture
- Adds a guideline discouraging direct DOM-traversal helpers (`closest`, etc.) on HTML elements.

## Why
The previous header packed session identity and chat tabs into one widget with inconsistent alignment and a titlebar that cropped the workspace name. This separates concerns, matches the sessions-list visual language, and keeps the workspace name readable.

## Notes for reviewers
- Changes are scoped to `src/vs/sessions/` (plus a sessions instructions doc).
- `LAYOUT.md` §4.1 updated to document the header / tab-strip split.
- Validated with `compile-check-ts-native` and `valid-layers-check`; hygiene runs clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
