### PR TITLE
Forward reasoning/thinking parameters to extension-contributed model providers

### DIFF
--- a/extensions/copilot/src/platform/endpoint/vscode-node/extChatEndpoint.ts
+++ b/extensions/copilot/src/platform/endpoint/vscode-node/extChatEndpoint.ts
@@ -199,7 +199,7 @@ export class ExtensionContributedChatEndpoint implements IChatEndpoint {
 				...(modelCapabilities?.enableThinking !== undefined
 					? { enableThinking: modelCapabilities.enableThinking }
 					: {}),
-				...(modelCapabilities?.reasoningEffort
+				...(modelCapabilities?.reasoningEffort !== undefined
 					? { reasoningEffort: modelCapabilities.reasoningEffort }
 					: {}),
 			}

--- a/extensions/copilot/src/platform/endpoint/vscode-node/extChatEndpoint.ts
+++ b/extensions/copilot/src/platform/endpoint/vscode-node/extChatEndpoint.ts
@@ -330,15 +330,15 @@ function getTelemetryTurnFromProperties(telemetryProperties: IMakeChatRequestOpt
 }
 
 /** Pick defined properties from an object, returning a new object with only those keys whose values are not `undefined`. */
-function pickDefined<T extends object, K extends keyof T>(source: T | undefined, ...keys: K[]): Pick<T, K> {
-	const result = {} as Pick<T, K>;
+function pickDefined<T extends object, K extends keyof T>(source: T | undefined, ...keys: K[]): Partial<Pick<T, K>> {
+	const result = {} as Partial<Pick<T, K>>;
+	if (!source) return result;
 	for (const key of keys) {
-		if (source?.[key] !== undefined) {
+		if (source[key] !== undefined) {
 			result[key] = source[key];
 		}
 	}
 	return result;
-}
 }
 
 export function convertToApiChatMessage(messages: Raw.ChatMessage[]): Array<vscode.LanguageModelChatMessage | vscode.LanguageModelChatMessage2> {

--- a/extensions/copilot/src/platform/endpoint/vscode-node/extChatEndpoint.ts
+++ b/extensions/copilot/src/platform/endpoint/vscode-node/extChatEndpoint.ts
@@ -196,12 +196,7 @@ export class ExtensionContributedChatEndpoint implements IChatEndpoint {
 				...(telemetryTurn !== undefined ? { _telemetryTurn: telemetryTurn } : {}),
 				// Forward reasoning/thinking settings so the extension provider can use them.
 				// The provider receives these via ProvideLanguageModelChatResponseOptions.modelOptions.
-				...(modelCapabilities?.enableThinking !== undefined
-					? { enableThinking: modelCapabilities.enableThinking }
-					: {}),
-				...(modelCapabilities?.reasoningEffort !== undefined
-					? { reasoningEffort: modelCapabilities.reasoningEffort }
-					: {}),
+				...pickDefined(modelCapabilities, 'enableThinking', 'reasoningEffort'),
 			}
 		};
 
@@ -332,6 +327,18 @@ function getTelemetryTurnFromProperties(telemetryProperties: IMakeChatRequestOpt
 
 	const turn = Number.parseInt(telemetryProperties.turnIndex, 10);
 	return Number.isSafeInteger(turn) ? turn : undefined;
+}
+
+/** Pick defined properties from an object, returning a new object with only those keys whose values are not `undefined`. */
+function pickDefined<T extends object, K extends keyof T>(source: T | undefined, ...keys: K[]): Pick<T, K> {
+	const result = {} as Pick<T, K>;
+	for (const key of keys) {
+		if (source?.[key] !== undefined) {
+			result[key] = source[key];
+		}
+	}
+	return result;
+}
 }
 
 export function convertToApiChatMessage(messages: Raw.ChatMessage[]): Array<vscode.LanguageModelChatMessage | vscode.LanguageModelChatMessage2> {

--- a/extensions/copilot/src/platform/endpoint/vscode-node/extChatEndpoint.ts
+++ b/extensions/copilot/src/platform/endpoint/vscode-node/extChatEndpoint.ts
@@ -170,6 +170,7 @@ export class ExtensionContributedChatEndpoint implements IChatEndpoint {
 		location,
 		source,
 		telemetryProperties,
+		modelCapabilities,
 	}: IMakeChatRequestOptions, token: CancellationToken): Promise<ChatResponse> {
 		const vscodeMessages = convertToApiChatMessage(messages);
 		const ourRequestId = generateUuid();
@@ -193,6 +194,14 @@ export class ExtensionContributedChatEndpoint implements IChatEndpoint {
 				_capturingTokenCorrelationId: ourRequestId,
 				_otelTraceContext: activeTraceCtx ?? null,
 				...(telemetryTurn !== undefined ? { _telemetryTurn: telemetryTurn } : {}),
+				// Forward reasoning/thinking settings so the extension provider can use them.
+				// The provider receives these via ProvideLanguageModelChatResponseOptions.modelOptions.
+				...(modelCapabilities?.enableThinking !== undefined
+					? { enableThinking: modelCapabilities.enableThinking }
+					: {}),
+				...(modelCapabilities?.reasoningEffort
+					? { reasoningEffort: modelCapabilities.reasoningEffort }
+					: {}),
 			}
 		};
 

--- a/extensions/copilot/src/platform/endpoint/vscode-node/test/extChatEndpoint.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/vscode-node/test/extChatEndpoint.spec.ts
@@ -68,13 +68,12 @@ describe('ExtensionContributedChatEndpoint', () => {
 
 	it('forwards enableThinking and reasoningEffort to modelOptions', async () => {
 		const stream = (async function* () {
-			const part = { value: 'ok', kind: 1 } as vscode.LanguageModelTextPart;
-			yield part;
+			yield { value: 'ok' };
 		})();
 
 		const sendRequestSpy = vi.fn(async () => ({
 			stream,
-		}));
+		} as unknown as any);
 
 		const mockLanguageModel = {
 			id: 'test',
@@ -106,7 +105,7 @@ describe('ExtensionContributedChatEndpoint', () => {
 			},
 		}, token);
 
-		const modelOptions = sendRequestSpy.mock.calls[0][1].modelOptions;
+		const modelOptions = sendRequestSpy.mock.calls[0][1]!.modelOptions!;
 		expect(modelOptions.enableThinking).toBe(true);
 		expect(modelOptions.reasoningEffort).toBe('high');
 	});

--- a/extensions/copilot/src/platform/endpoint/vscode-node/test/extChatEndpoint.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/vscode-node/test/extChatEndpoint.spec.ts
@@ -8,7 +8,7 @@ import { describe, expect, it, vi } from 'vitest';
 import * as vscode from 'vscode';
 import { ChatFetchResponseType, ChatLocation } from '../../../chat/common/commonTypes';
 import { NoopOTelService, resolveOTelConfig } from '../../../otel/common/index';
-import type { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
+import type { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
 import { IOTelService } from '../../../otel/common/otelService';
 import { ExtensionContributedChatEndpoint } from '../extChatEndpoint';
 
@@ -73,7 +73,7 @@ describe('ExtensionContributedChatEndpoint', () => {
 
 		const sendRequestSpy = vi.fn(async () => ({
 			stream,
-		} as unknown as any);
+		} as unknown as any));
 
 		const mockLanguageModel = {
 			id: 'test',
@@ -105,9 +105,11 @@ describe('ExtensionContributedChatEndpoint', () => {
 			},
 		}, token);
 
-		const modelOptions = sendRequestSpy.mock.calls[0][1]!.modelOptions!;
-		expect(modelOptions.enableThinking).toBe(true);
-		expect(modelOptions.reasoningEffort).toBe('high');
+		const callArgs = sendRequestSpy.mock.calls[0] as unknown[];
+		const modelOptions = (callArgs[1] as vscode.LanguageModelChatRequestOptions).modelOptions;
+		expect(modelOptions).toBeDefined();
+		expect((modelOptions as Record<string, unknown>)['enableThinking']).toBe(true);
+		expect((modelOptions as Record<string, unknown>)['reasoningEffort']).toBe('high');
 	});
 });
 

--- a/extensions/copilot/src/platform/endpoint/vscode-node/test/extChatEndpoint.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/vscode-node/test/extChatEndpoint.spec.ts
@@ -8,7 +8,8 @@ import { describe, expect, it, vi } from 'vitest';
 import * as vscode from 'vscode';
 import { ChatFetchResponseType, ChatLocation } from '../../../chat/common/commonTypes';
 import { NoopOTelService, resolveOTelConfig } from '../../../otel/common/index';
-import type { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
+import type { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
+import { IOTelService } from '../../../otel/common/otelService';
 import { ExtensionContributedChatEndpoint } from '../extChatEndpoint';
 
 describe('ExtensionContributedChatEndpoint', () => {
@@ -64,6 +65,51 @@ describe('ExtensionContributedChatEndpoint', () => {
 
 		expect(capturedOptions.map(options => options.modelOptions?._telemetryTurn)).toEqual([undefined, undefined, undefined, undefined, undefined, undefined]);
 	});
+
+	it('forwards enableThinking and reasoningEffort to modelOptions', async () => {
+		const stream = (async function* () {
+			const part = { value: 'ok', kind: 1 } as vscode.LanguageModelTextPart;
+			yield part;
+		})();
+
+		const sendRequestSpy = vi.fn(async () => ({
+			stream,
+		}));
+
+		const mockLanguageModel = {
+			id: 'test',
+			vendor: 'test',
+			name: 'Test',
+			family: 'test',
+			version: '1',
+			maxInputTokens: 8192,
+			capabilities: {},
+			sendRequest: sendRequestSpy,
+		} as unknown as vscode.LanguageModelChat;
+
+		const endpoint = new ExtensionContributedChatEndpoint(
+			mockLanguageModel,
+			{} as IInstantiationService,
+			{ getActiveTraceContext: vi.fn(() => null) } as unknown as IOTelService,
+		);
+
+		const token = { isCancellationRequested: false, onCancellationRequested: vi.fn() } as unknown as vscode.CancellationToken;
+
+		await endpoint.makeChatRequest2({
+			debugName: 'test',
+			messages: [],
+			finishedCb: undefined,
+			location: ChatLocation.Panel,
+			modelCapabilities: {
+				enableThinking: true,
+				reasoningEffort: 'high',
+			},
+		}, token);
+
+		const modelOptions = sendRequestSpy.mock.calls[0][1].modelOptions;
+		expect(modelOptions.enableThinking).toBe(true);
+		expect(modelOptions.reasoningEffort).toBe('high');
+	});
 });
 
 function createLanguageModel(captureOptions: (options: vscode.LanguageModelChatRequestOptions) => void): vscode.LanguageModelChat {
@@ -89,3 +135,4 @@ function createLanguageModel(captureOptions: (options: vscode.LanguageModelChatR
 function createInstantiationService(): IInstantiationService {
 	return { createInstance: vi.fn() } as unknown as IInstantiationService;
 }
+


### PR DESCRIPTION
## Problem

When using custom model providers (extension-contributed models via the VS Code Language Model API), reasoning/thinking parameters (`enableThinking`, `reasoningEffort`) are not forwarded through the request pipeline to the actual model API call.

The `extChatEndpoint` (which wraps VS Code API language models) completely ignores `modelCapabilities` from `IMakeChatRequestOptions`, so extension-contributed models never receive these settings.

## Fix

In `extChatEndpoint.makeChatRequest2`, forward `modelCapabilities.enableThinking` and `modelCapabilities.reasoningEffort` into `vscodeOptions.modelOptions`. The extension provider receives these via `ProvideLanguageModelChatResponseOptions.modelOptions`.

## Impact

- **Extension-contributed models**: Now receive reasoning/thinking settings correctly
- **BYOK models**: No change (already work correctly via `OpenAIEndpoint`)
- **Cloud models**: No change (already work correctly via `OpenAIEndpoint`/`responsesApi`)

## Testing

A regression test was added in `extChatEndpoint.spec.ts` that verifies `enableThinking` and `reasoningEffort` are correctly forwarded from `modelCapabilities` into `modelOptions` when `makeChatRequest2` is called.

## Files Changed

- `extensions/copilot/src/platform/endpoint/vscode-node/extChatEndpoint.ts`
- `extensions/copilot/src/platform/endpoint/vscode-node/test/extChatEndpoint.spec.ts`

Fixes #319794
