### PR TITLE
debug: Log errors when loading stored breakpoints/watch expressions (#319805)

### DIFF
--- a/src/vs/workbench/contrib/debug/common/debugStorage.ts
+++ b/src/vs/workbench/contrib/debug/common/debugStorage.ts
@@ -80,7 +80,9 @@ export class DebugStorage extends Disposable {
 				breakpoint.uri = URI.revive(breakpoint.uri);
 				return new Breakpoint(breakpoint, this.textFileService, this.uriIdentityService, this.logService, breakpoint.id);
 			});
-		} catch (e) { }
+		} catch (e) {
+			this.logService.error('Failed to load breakpoints from storage', e);
+		}
 
 		return result || [];
 	}
@@ -91,7 +93,9 @@ export class DebugStorage extends Disposable {
 			result = JSON.parse(this.storageService.get(DEBUG_FUNCTION_BREAKPOINTS_KEY, StorageScope.WORKSPACE, '[]')).map((fb: ReturnType<FunctionBreakpoint['toJSON']>) => {
 				return new FunctionBreakpoint(fb, fb.id);
 			});
-		} catch (e) { }
+		} catch (e) {
+			this.logService.error('Failed to load function breakpoints from storage', e);
+		}
 
 		return result || [];
 	}
@@ -102,7 +106,9 @@ export class DebugStorage extends Disposable {
 			result = JSON.parse(this.storageService.get(DEBUG_EXCEPTION_BREAKPOINTS_KEY, StorageScope.WORKSPACE, '[]')).map((exBreakpoint: ReturnType<ExceptionBreakpoint['toJSON']>) => {
 				return new ExceptionBreakpoint(exBreakpoint, exBreakpoint.id);
 			});
-		} catch (e) { }
+		} catch (e) {
+			this.logService.error('Failed to load exception breakpoints from storage', e);
+		}
 
 		return result || [];
 	}
@@ -113,7 +119,9 @@ export class DebugStorage extends Disposable {
 			result = JSON.parse(this.storageService.get(DEBUG_DATA_BREAKPOINTS_KEY, StorageScope.WORKSPACE, '[]')).map((dbp: ReturnType<DataBreakpoint['toJSON']>) => {
 				return new DataBreakpoint(dbp, dbp.id);
 			});
-		} catch (e) { }
+		} catch (e) {
+			this.logService.error('Failed to load data breakpoints from storage', e);
+		}
 
 		return result || [];
 	}
@@ -124,7 +132,9 @@ export class DebugStorage extends Disposable {
 			result = JSON.parse(this.storageService.get(DEBUG_WATCH_EXPRESSIONS_KEY, StorageScope.WORKSPACE, '[]')).map((watchStoredData: { name: string; id: string }) => {
 				return new Expression(watchStoredData.name, watchStoredData.id);
 			});
-		} catch (e) { }
+		} catch (e) {
+			this.logService.error('Failed to load watch expressions from storage', e);
+		}
 
 		return result || [];
 	}


### PR DESCRIPTION
## Summary

Five methods in `DebugStorage` silently swallowed JSON parse and object construction errors with **empty catch blocks**. If stored debug data gets corrupted, users lose **all** their breakpoints, function breakpoints, exception breakpoints, data breakpoints, **and** watch expressions — with zero indication of failure.

## Problem

In `src/vs/workbench/contrib/debug/common/debugStorage.ts`, these five methods had empty `catch (e) { }` blocks:

| Method | Affected Data |
|---|---|
| `loadBreakpoints()` | All user breakpoints |
| `loadFunctionBreakpoints()` | All function breakpoints |
| `loadExceptionBreakpoints()` | All exception breakpoints |
| `loadDataBreakpoints()` | All data breakpoints |
| `loadWatchExpressions()` | All watch expressions |

**Corruption scenario:** If IndexedDB/localStorage data becomes corrupted due to sync conflicts, disk errors, crash mid-write, or a serialization bug, `JSON.parse()` throws — the empty catch drops the exception, the method returns `[]`, and the user is left wondering why all their carefully-set breakpoints just disappeared.

## Fix

Replace each empty `catch (e) { }` with `this.logService.error('message', e)`. The class already has `ILogService` injected in its constructor but was not using it in these catch blocks.

```diff
- } catch (e) { }
+ } catch (e) {
+     this.logService.error('Failed to load breakpoints from storage', e);
+ }
```

### Why this is the right fix

1. **Surfaces corruption** — Errors are logged to the developer console and log service, enabling diagnosis
2. **No behavior change** — Still returns empty arrays on parse failure (graceful degradation)
3. **Minimal and low-risk** — `logService` is already injected via DI, no new dependencies
4. **Follows existing patterns** — The `loadBreakpoints` method already passes `this.logService` to `new Breakpoint()`, so the infrastructure is already wired

## Testing

- Existing behavior preserved — errors still caught, empty arrays returned
- Log output appears in developer console when data is corrupted
- No functional change to debug workflows

Closes #319805

Co-authored-by: Muhammad Ishaq Khan <muhammadishaqkhan.2321@gmail.com>