### PR TITLE
agentHost: add generic /rename slash command for agent sessions

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostRenameCommand.ts
+++ b/src/vs/platform/agentHost/node/agentHostRenameCommand.ts
@@ -1,0 +1,81 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../base/common/cancellation.js';
+import { localize } from '../../../nls.js';
+import type { URI } from '../common/state/protocol/common/state.js';
+import { CompletionItem, CompletionItemKind, CompletionsParams } from '../common/state/protocol/commands.js';
+import { MessageAttachmentKind } from '../common/state/protocol/state.js';
+import { CompletionTriggerCharacter, IAgentHostCompletionItemProvider } from './agentHostCompletions.js';
+import { extractLeadingSlashToken } from './agentHostSlashCompletion.js';
+
+/** The generic, agent-agnostic `/rename` slash command name. */
+export const RENAME_SLASH_COMMAND = 'rename';
+
+/**
+ * Parses a leading `/rename [title]` command at the very start of `prompt`.
+ *
+ * Mirrors `parseLeadingSlashCommand` (the Copilot CLI slash parser): the
+ * command must be `/rename`, followed either by end-of-input or at least one
+ * whitespace character. `/renamed`, `/rename-foo`, or a leading-space
+ * `/rename` all return `undefined`. Match is case-sensitive.
+ *
+ * Returns the trimmed new title (possibly an empty string when no title is
+ * supplied) when the prompt is a rename command, or `undefined` when it is not.
+ * Callers MUST distinguish "not a rename command" (`undefined`) from "rename
+ * with empty title" (`''`).
+ */
+export function parseRenameCommand(prompt: string): string | undefined {
+	const match = /^\/rename(?:$|\s+([\s\S]*))/.exec(prompt);
+	if (!match) {
+		return undefined;
+	}
+	return (match[1] ?? '').trim();
+}
+
+/**
+ * Generic completion provider that contributes the `/rename` slash command
+ * for every agent-host session type. Unlike agent-specific slash commands
+ * (e.g. Copilot's `/compact`), `/rename` is not forwarded to any agent SDK;
+ * it is intercepted in the agent-host send path and redirected to a
+ * `SessionTitleChanged` action (see the rename handling in `AgentSideEffects`).
+ *
+ * The completion is only offered for sessions that already have history —
+ * renaming a session before the first turn has no meaningful target.
+ */
+export class AgentHostRenameCompletionProvider implements IAgentHostCompletionItemProvider {
+	readonly kinds: ReadonlySet<CompletionItemKind> = new Set([CompletionItemKind.UserMessage]);
+	readonly triggerCharacters = [CompletionTriggerCharacter.Slash] as const;
+
+	constructor(private readonly _hasHistory: (session: URI) => boolean) { }
+
+	async provideCompletionItems(params: CompletionsParams, _token: CancellationToken): Promise<readonly CompletionItem[]> {
+		const leading = extractLeadingSlashToken(params.text, params.offset);
+		if (!leading) {
+			return [];
+		}
+		if (!this._hasHistory(params.channel)) {
+			return [];
+		}
+		// `/abc` → typed = 'abc'; empty after just '/' → typed = ''.
+		const typed = leading.typed;
+		if (typed.length > 0 && !RENAME_SLASH_COMMAND.startsWith(typed)) {
+			return [];
+		}
+		return [{
+			insertText: '/' + RENAME_SLASH_COMMAND + ' ',
+			rangeStart: leading.rangeStart,
+			rangeEnd: leading.rangeEnd,
+			attachment: {
+				type: MessageAttachmentKind.Simple,
+				label: '/' + RENAME_SLASH_COMMAND,
+				_meta: {
+					command: RENAME_SLASH_COMMAND,
+					description: localize('agentHostSlashCommand.rename.description', "Rename this chat"),
+				},
+			},
+		}];
+	}
+}

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -44,6 +44,7 @@ import { IAgentHostCheckpointService, NULL_CHECKPOINT_SERVICE } from '../common/
 import { CHANGESET_DB_METADATA_KEYS, ChangesetSessionCoordinator } from './agentHostChangesetCoordinator.js';
 import { AgentHostCompletions, IAgentHostCompletions } from './agentHostCompletions.js';
 import { AgentHostFileCompletionProvider } from './agentHostFileCompletionProvider.js';
+import { AgentHostRenameCompletionProvider } from './agentHostRenameCommand.js';
 import { AgentHostSkillCompletionProvider } from './agentHostSkillCompletionProvider.js';
 import { AgentHostWorkspaceFiles } from './agentHostWorkspaceFiles.js';
 import { toAgentClientUri } from '../common/agentClientUri.js';
@@ -248,6 +249,14 @@ export class AgentService extends Disposable implements IAgentService {
 		const workspaceFiles = this._register(instantiationService.createInstance(AgentHostWorkspaceFiles));
 		this._register(this._completions.registerProvider(
 			new AgentHostFileCompletionProvider(this._stateManager, workspaceFiles),
+		));
+		// Built-in generic provider: offers the `/rename` slash command for any
+		// session that already has history. Execution is handled server-side in
+		// AgentSideEffects (redirected to a SessionTitleChanged action).
+		this._register(this._completions.registerProvider(
+			new AgentHostRenameCompletionProvider(
+				session => (this._stateManager.getSessionState(session)?.turns.length ?? 0) > 0,
+			),
 		));
 
 		this._sideEffects = this._register(instantiationService.createInstance(AgentSideEffects, this._stateManager, {

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -9,6 +9,7 @@ import { autorun, IObservable, IReader } from '../../../base/common/observable.j
 import { hasKey } from '../../../base/common/types.js';
 import { URI } from '../../../base/common/uri.js';
 import { generateUuid } from '../../../base/common/uuid.js';
+import { localize } from '../../../nls.js';
 import { IInstantiationService } from '../../instantiation/common/instantiation.js';
 import { ILogService } from '../../log/common/log.js';
 import { AgentSignal, IAgent, IAgentToolPendingConfirmationSignal } from '../common/agentService.js';
@@ -33,6 +34,7 @@ import {
 	type ToolResultContent
 } from '../common/state/sessionState.js';
 import { AgentHostStateManager } from './agentHostStateManager.js';
+import { parseRenameCommand } from './agentHostRenameCommand.js';
 import { SessionPermissionManager } from './sessionPermissions.js';
 import { ITelemetryService } from '../../telemetry/common/telemetry.js';
 import { updateAgentHostTelemetryLevelFromConfig } from './agentHostTelemetryService.js';
@@ -701,6 +703,15 @@ export class AgentSideEffects extends Disposable {
 				// Per-turn streaming part tracking is owned by the agent
 				// (e.g. CopilotAgentSession) and reset on its `send()` call.
 
+				// `/rename [title]` is a generic, agent-agnostic slash command:
+				// it is intercepted here and redirected to a title change rather
+				// than forwarded to the agent SDK. Mirrors the per-agent text-side
+				// dispatch (`parseLeadingSlashCommand` in CopilotAgentSession), but
+				// applies to every session type.
+				if (this._tryHandleRenameCommand(channel, action.turnId, action.message.text)) {
+					break;
+				}
+
 				// On the very first turn, immediately set the session title to the
 				// user's message so the UI shows a meaningful title right away
 				// while waiting for the AI-generated title. Only apply when the
@@ -873,6 +884,55 @@ export class AgentSideEffects extends Disposable {
 	}
 
 	/**
+	 * Handles the generic `/rename [title]` slash command. When `text` is a
+	 * rename command it is redirected to a {@link ActionType.SessionTitleChanged}
+	 * action (when a non-empty title is supplied) and the just-started turn is
+	 * immediately completed, so the command is never forwarded to the agent SDK.
+	 *
+	 * @returns `true` when the message was a rename command and was handled here
+	 * (the caller MUST NOT forward it to the agent), `false` otherwise.
+	 */
+	private _tryHandleRenameCommand(channel: ProtocolURI, turnId: string, text: string): boolean {
+		const title = parseRenameCommand(text);
+		if (title === undefined) {
+			return false;
+		}
+		if (title.length > 0) {
+			this._stateManager.dispatchServerAction(channel, {
+				type: ActionType.SessionTitleChanged,
+				title,
+			});
+			// Server-dispatched actions bypass `handleAction`, so persist the
+			// new title here directly (the client-dispatched rename path relies
+			// on the `SessionTitleChanged` case in `handleAction` instead).
+			this._persistSessionFlag(channel, 'customTitle', title);
+			// Acknowledge the rename with a brief response so the turn has
+			// visible content in the transcript.
+			this._stateManager.dispatchServerAction(channel, {
+				type: ActionType.SessionResponsePart,
+				turnId,
+				part: {
+					kind: ResponsePartKind.Markdown,
+					id: generateUuid(),
+					content: localize('agentHostRename.renamed', "Renamed: {0}", title),
+				},
+			});
+		}
+		// Close out the turn that the reducer opened for this message so the
+		// session returns to idle instead of waiting on an agent response.
+		this._stateManager.dispatchServerAction(channel, {
+			type: ActionType.SessionTurnComplete,
+			turnId,
+		});
+		// This turn was completed via a direct server dispatch rather than
+		// `_runTurnCompleteSideEffects`, so drain any messages queued behind
+		// the rename ourselves; otherwise they would stall until the next
+		// unrelated state change re-triggers consumption.
+		this._tryConsumeNextQueuedMessage(channel);
+		return true;
+	}
+
+	/**
 	 * Persists a session metadata key/value pair to the session database.
 	 * Used for fields the host needs to remember across restarts (custom
 	 * title, isRead/isArchived flags, merged config values).
@@ -947,6 +1007,12 @@ export class AgentSideEffects extends Disposable {
 			message: msg.message,
 			queuedMessageId: msg.id,
 		});
+
+		// `/rename` is intercepted generically (see the SessionTurnStarted
+		// handler) and must not reach the agent SDK even when queued.
+		if (this._tryHandleRenameCommand(session, turnId, msg.message.text)) {
+			return;
+		}
 
 		// Send the message to the agent backend
 		const agent = this._options.getAgent(session);

--- a/src/vs/platform/agentHost/test/node/agentHostRenameCommand.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostRenameCommand.test.ts
@@ -1,0 +1,89 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { CompletionItemKind } from '../../common/state/protocol/commands.js';
+import { MessageAttachmentKind } from '../../common/state/protocol/state.js';
+import { AgentHostRenameCompletionProvider, parseRenameCommand } from '../../node/agentHostRenameCommand.js';
+
+suite('agentHostRenameCommand', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	suite('parseRenameCommand', () => {
+		test('matches lone /rename as empty title', () => {
+			assert.strictEqual(parseRenameCommand('/rename'), '');
+		});
+
+		test('captures the trimmed title after a space', () => {
+			assert.strictEqual(parseRenameCommand('/rename My New Title'), 'My New Title');
+		});
+
+		test('trims surrounding whitespace from the title', () => {
+			assert.strictEqual(parseRenameCommand('/rename   spaced   '), 'spaced');
+		});
+
+		test('rejects /renamed (longer command)', () => {
+			assert.strictEqual(parseRenameCommand('/renamed'), undefined);
+		});
+
+		test('rejects /rename-foo (no separator)', () => {
+			assert.strictEqual(parseRenameCommand('/rename-foo'), undefined);
+		});
+
+		test('rejects leading whitespace', () => {
+			assert.strictEqual(parseRenameCommand(' /rename x'), undefined);
+		});
+
+		test('case-sensitive', () => {
+			assert.strictEqual(parseRenameCommand('/RENAME x'), undefined);
+		});
+	});
+
+	suite('AgentHostRenameCompletionProvider', () => {
+		const session = 'mock:/abc';
+
+		function run(text: string, hasHistory = true, offset = text.length) {
+			const provider = new AgentHostRenameCompletionProvider(() => hasHistory);
+			return provider.provideCompletionItems({ kind: CompletionItemKind.UserMessage, channel: session, text, offset }, CancellationToken.None);
+		}
+
+		test('offers /rename for a lone "/" when the session has history', async () => {
+			const items = await run('/');
+			assert.deepStrictEqual(items.map(i => i.insertText), ['/rename ']);
+		});
+
+		test('offers /rename when "/r" is typed', async () => {
+			const items = await run('/r');
+			assert.deepStrictEqual(items.map(i => i.insertText), ['/rename ']);
+		});
+
+		test('omits /rename when the session has no history', async () => {
+			const items = await run('/', false);
+			assert.deepStrictEqual(items, []);
+		});
+
+		test('returns nothing when the typed prefix does not match', async () => {
+			const items = await run('/zz');
+			assert.deepStrictEqual(items, []);
+		});
+
+		test('returns nothing when input does not start with /', async () => {
+			const items = await run('hello', true, 5);
+			assert.deepStrictEqual(items, []);
+		});
+
+		test('attachment is Simple with command + description meta', async () => {
+			const items = await run('/');
+			assert.deepStrictEqual(items.map(i => i.attachment), [{
+				type: MessageAttachmentKind.Simple,
+				label: '/rename',
+				_meta: { command: 'rename', description: 'Rename this chat' },
+			}]);
+		});
+	});
+});

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -326,6 +326,78 @@ suite('AgentSideEffects', () => {
 		});
 	});
 
+	// ---- handleAction: generic /rename slash command ---------------------
+
+	suite('handleAction — /rename slash command', () => {
+
+		// `/rename` persists the new title, so these tests need a session data
+		// service whose `openDatabase` actually returns a database (the default
+		// null service throws).
+		function createRenameSideEffects(): AgentSideEffects {
+			return createTestSideEffects(disposables, stateManager, {
+				getAgent: () => agent,
+				agents: agentList,
+				sessionDataService: createSessionDataService(),
+				onTurnComplete: () => { },
+			});
+		}
+
+		test('redirects /rename to a title change and completes the turn without calling the agent', async () => {
+			setupSession();
+			const renameSideEffects = createRenameSideEffects();
+			const action: SessionAction = {
+				type: ActionType.SessionTurnStarted,
+				turnId: 'turn-1',
+				message: { text: '/rename Renamed Session', origin: { kind: MessageKind.User } },
+			};
+			// Mirror production: the reducer applies the turn, then side effects run.
+			stateManager.dispatchClientAction(sessionUri.toString(), action, { clientId: 'test', clientSeq: 1 });
+			renameSideEffects.handleAction(sessionUri.toString(), action);
+			await new Promise(r => setTimeout(r, 10));
+
+			assert.deepStrictEqual(agent.sendMessageCalls, []);
+			const state = stateManager.getSessionState(sessionUri.toString());
+			assert.strictEqual(state?.summary.title, 'Renamed Session');
+			assert.strictEqual(stateManager.getActiveTurnId(sessionUri.toString()), undefined);
+			const part = state?.turns.at(-1)?.responseParts[0];
+			assert.strictEqual(part?.kind, ResponsePartKind.Markdown);
+			assert.strictEqual(part?.kind === ResponsePartKind.Markdown ? part.content : undefined, 'Renamed: Renamed Session');
+		});
+
+		test('/rename without a title completes the turn and leaves the title unchanged', async () => {
+			setupSession();
+			const renameSideEffects = createRenameSideEffects();
+			const action: SessionAction = {
+				type: ActionType.SessionTurnStarted,
+				turnId: 'turn-1',
+				message: { text: '/rename', origin: { kind: MessageKind.User } },
+			};
+			stateManager.dispatchClientAction(sessionUri.toString(), action, { clientId: 'test', clientSeq: 1 });
+			renameSideEffects.handleAction(sessionUri.toString(), action);
+			await new Promise(r => setTimeout(r, 10));
+
+			assert.deepStrictEqual(agent.sendMessageCalls, []);
+			const state = stateManager.getSessionState(sessionUri.toString());
+			assert.strictEqual(state?.summary.title, 'Test');
+			assert.strictEqual(stateManager.getActiveTurnId(sessionUri.toString()), undefined);
+		});
+
+		test('a message that merely starts with /rename text (no separator) is sent to the agent', async () => {
+			setupSession();
+			const renameSideEffects = createRenameSideEffects();
+			const action: SessionAction = {
+				type: ActionType.SessionTurnStarted,
+				turnId: 'turn-1',
+				message: { text: '/renamed thing', origin: { kind: MessageKind.User } },
+			};
+			stateManager.dispatchClientAction(sessionUri.toString(), action, { clientId: 'test', clientSeq: 1 });
+			renameSideEffects.handleAction(sessionUri.toString(), action);
+			await new Promise(r => setTimeout(r, 10));
+
+			assert.deepStrictEqual(agent.sendMessageCalls, [{ session: URI.parse(sessionUri.toString()), prompt: '/renamed thing', attachments: undefined }]);
+		});
+	});
+
 	// ---- immediate title on first turn -----------------------------------
 
 	suite('immediate title on first turn', () => {
@@ -795,6 +867,52 @@ suite('AgentSideEffects', () => {
 			// Queued message should be removed from state
 			const state = stateManager.getSessionState(sessionUri.toString());
 			assert.strictEqual(state?.queuedMessages, undefined);
+		});
+
+		test('intercepts queued /rename and drains the message queued behind it', () => {
+			setupSession();
+			// `/rename` persists the new title, so use a side effects instance
+			// whose `openDatabase` returns a real database (the suite default
+			// throws).
+			const renameSideEffects = createTestSideEffects(disposables, stateManager, {
+				getAgent: () => agent,
+				agents: agentList,
+				sessionDataService: createSessionDataService(),
+				onTurnComplete: () => { },
+			});
+			disposables.add(renameSideEffects.registerProgressListener(agent));
+
+			// Queue a `/rename` followed by a normal message while a turn is active
+			startTurn('turn-1');
+			for (const msg of [
+				{ id: 'q-rename', text: '/rename Queued Title' },
+				{ id: 'q-after', text: 'after rename' },
+			]) {
+				const setAction = {
+					type: ActionType.SessionPendingMessageSet as const,
+					kind: PendingMessageKind.Queued,
+					id: msg.id,
+					message: { text: msg.text, origin: { kind: MessageKind.User } },
+				};
+				stateManager.dispatchClientAction(sessionUri.toString(), setAction, { clientId: 'test', clientSeq: 1 });
+				renameSideEffects.handleAction(sessionUri.toString(), setAction);
+			}
+
+			// Fire idle → turn completes → `/rename` is consumed and intercepted,
+			// then the message queued behind it must be drained to the agent.
+			agent.fireProgress({
+				kind: 'action', session: sessionUri,
+				action: { type: ActionType.SessionTurnComplete, turnId: 'turn-1' },
+			});
+
+			// The `/rename` must not reach the agent; only the message behind it does
+			assert.strictEqual(agent.sendMessageCalls.length, 1);
+			assert.strictEqual(agent.sendMessageCalls[0].prompt, 'after rename');
+
+			// Both queued messages should be drained from state
+			const state = stateManager.getSessionState(sessionUri.toString());
+			assert.strictEqual(state?.queuedMessages, undefined);
+			assert.strictEqual(state?.summary.title, 'Queued Title');
 		});
 
 		test('does not consume queued message while a turn is active', () => {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -248,11 +248,14 @@ class AgentHostChatSession extends Disposable implements IChatSession {
 
 	readonly interruptActiveResponseCallback: IChatSession['interruptActiveResponseCallback'];
 	readonly forkSession: IChatSession['forkSession'];
+	readonly renameSession: IChatSession['renameSession'];
 
 	constructor(
 		readonly sessionResource: URI,
 		readonly history: readonly IChatSessionHistoryItem[],
+		readonly title: string | undefined,
 		private readonly _forkSession: ((request: IChatSessionRequestHistoryItem | undefined, token: CancellationToken) => Promise<IChatSessionItem>),
+		private readonly _renameSession: ((title: string, token: CancellationToken) => Promise<void>),
 		initialProgress: IChatProgress[] | undefined,
 		onDispose: () => void,
 		interruptActiveResponse: () => boolean,
@@ -274,6 +277,7 @@ class AgentHostChatSession extends Disposable implements IChatSession {
 		this.interruptActiveResponseCallback = async () => interruptActiveResponse();
 
 		this.forkSession = this._forkSession;
+		this.renameSession = this._renameSession;
 	}
 
 	override dispose(): void {
@@ -583,6 +587,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		const history: IChatSessionHistoryItem[] = [];
 		let initialProgress: IChatProgress[] | undefined;
 		let activeTurnId: string | undefined;
+		let sessionTitle: string | undefined;
 		if (!isNewSession) {
 			try {
 				const sub = this._ensureSessionSubscription(resolvedSession.toString());
@@ -594,6 +599,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 				}
 				const sessionState = this._getSessionState(resolvedSession.toString());
 				if (sessionState) {
+					sessionTitle = sessionState.summary.title;
 					const fallbackRawModelId = sessionState.summary.model?.id;
 					const lookup = this._createTurnModelLookup(sessionResource, fallbackRawModelId);
 					history.push(...turnsToHistory(resolvedSession, sessionState.turns, this._config.agentId, this._config.connectionAuthority, lookup));
@@ -646,12 +652,20 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			AgentHostChatSession,
 			sessionResource,
 			history,
+			sessionTitle,
 			(request: IChatSessionRequestHistoryItem | undefined, token: CancellationToken) => {
 				if (!this._getSessionState(resolvedSession.toString())) {
 					throw new Error('Cannot fork session before the initial request');
 				}
 
 				return this._forkSession(sessionResource, resolvedSession, request, token);
+			},
+			(title: string, _token: CancellationToken) => {
+				this._config.connection.dispatch(resolvedSession.toString(), {
+					type: ActionType.SessionTitleChanged,
+					title,
+				});
+				return Promise.resolve();
 			},
 			initialProgress,
 			() => {
@@ -983,6 +997,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		let lastSeenTurnId: string | undefined = currentState?.activeTurn?.id;
 		let previousQueuedIds: Set<string> | undefined;
 		let previousSteeringId: string | undefined = currentState?.steeringMessage?.id;
+		let previousTitle: string | undefined = currentState?.summary.title;
 
 		const disposables = new DisposableStore();
 
@@ -1003,6 +1018,12 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 				this._chatService.removePendingRequest(sessionResource, previousSteeringId);
 			}
 			previousSteeringId = currentSteeringId;
+
+			const currentTitle = e.state.summary.title;
+			if (currentTitle && currentTitle !== previousTitle) {
+				this._chatService.setChatSessionTitle(sessionResource, currentTitle);
+			}
+			previousTitle = currentTitle;
 
 			const activeTurn = e.state.activeTurn;
 			if (!activeTurn || activeTurn.id === lastSeenTurnId) {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsActions.ts
@@ -4,13 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize, localize2 } from '../../../../../nls.js';
-import { AgentSessionSection, IAgentSession, IAgentSessionSection, IMarshalledAgentSessionContext, isAgentSessionSection, isLocalAgentSessionItem, isMarshalledAgentSessionContext } from './agentSessionsModel.js';
+import { AgentSessionSection, IAgentSession, IAgentSessionSection, IMarshalledAgentSessionContext, isAgentHostAgentSessionItem, isAgentSessionSection, isLocalAgentSessionItem, isMarshalledAgentSessionContext } from './agentSessionsModel.js';
 import { Action2, MenuId, MenuRegistry } from '../../../../../platform/actions/common/actions.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { ServicesAccessor } from '../../../../../editor/browser/editorExtensions.js';
 import { AGENT_SESSION_DELETE_ACTION_ID, AGENT_SESSION_RENAME_ACTION_ID, AgentSessionProviders, AgentSessionsViewerOrientation, IAgentSessionsControl } from './agentSessions.js';
 import { IChatService } from '../../common/chatService/chatService.js';
-import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
+import { IChatSessionsService } from '../../common/chatSessionsService.js';
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { ChatContextKeyExprs, ChatContextKeys } from '../../common/actions/chatContextKeys.js';
 import { LocalChatSessionUri } from '../../common/model/chatUri.js';
 import { IChatEditorOptions } from '../widgetHosts/editor/chatEditor.js';
 import { ChatViewId, IChatWidgetService } from '../chat.js';
@@ -624,6 +626,16 @@ export class UnpinAgentSessionAction extends BaseAgentSessionAction {
 	}
 }
 
+/**
+ * Matches every session type that supports renaming: local sessions and all
+ * agent-host session types (`agent-host-*` and `remote-*`), mirroring the
+ * generic `isAgentHostTarget` check used by the rename action body.
+ */
+const renameSupportedSessionTypes = ContextKeyExpr.or(
+	ChatContextKeys.agentSessionType.isEqualTo(AgentSessionProviders.Local),
+	ChatContextKeyExprs.isAgentHostSessionItem,
+);
+
 export class RenameAgentSessionAction extends BaseAgentSessionAction {
 
 	constructor() {
@@ -639,14 +651,14 @@ export class RenameAgentSessionAction extends BaseAgentSessionAction {
 				weight: KeybindingWeight.WorkbenchContrib + 1,
 				when: ContextKeyExpr.and(
 					ChatContextKeys.agentSessionsViewerFocused,
-					ChatContextKeys.agentSessionType.isEqualTo(AgentSessionProviders.Local)
+					renameSupportedSessionTypes
 				),
 			},
 			menu: {
 				id: MenuId.AgentSessionsContext,
 				group: '1_edit',
 				order: 3,
-				when: ChatContextKeys.agentSessionType.isEqualTo(AgentSessionProviders.Local)
+				when: renameSupportedSessionTypes
 			}
 		});
 	}
@@ -659,10 +671,15 @@ export class RenameAgentSessionAction extends BaseAgentSessionAction {
 
 		const quickInputService = accessor.get(IQuickInputService);
 		const chatService = accessor.get(IChatService);
+		const chatSessionsService = accessor.get(IChatSessionsService);
 
 		const title = await quickInputService.input({ prompt: localize('newChatTitle', "New agent session title"), value: session.label });
 		if (title) {
-			chatService.setChatSessionTitle(session.resource, title);
+			if (isAgentHostAgentSessionItem(session)) {
+				await chatSessionsService.renameChatSession(session.resource, title, CancellationToken.None);
+			} else {
+				chatService.setChatSessionTitle(session.resource, title);
+			}
 		}
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsModel.ts
@@ -29,7 +29,7 @@ import { Extensions, IOutputChannelRegistry, IOutputService } from '../../../../
 import { ChatSessionStatus as AgentSessionStatus, IChatSessionFileChange, IChatSessionFileChange2, IChatSessionItem, IChatSessionsService, isSessionInProgressStatus, ResolvedChatSessionsExtensionPoint } from '../../common/chatSessionsService.js';
 import { getChatSessionType } from '../../common/model/chatUri.js';
 import { IChatWidgetService } from '../chat.js';
-import { AgentSessionProviders, getAgentSessionProvider, getAgentSessionProviderIcon, getAgentSessionProviderName, isBuiltInAgentSessionProvider } from './agentSessions.js';
+import { AgentSessionProviders, getAgentSessionProvider, getAgentSessionProviderIcon, getAgentSessionProviderName, isAgentHostTarget, isBuiltInAgentSessionProvider } from './agentSessions.js';
 
 //#region Interfaces, Types
 
@@ -150,6 +150,10 @@ interface IInternalAgentSession extends IAgentSession, IInternalAgentSessionData
 
 export function isLocalAgentSessionItem(session: IAgentSession): boolean {
 	return session.providerType === AgentSessionProviders.Local;
+}
+
+export function isAgentHostAgentSessionItem(session: IAgentSession): boolean {
+	return isAgentHostTarget(session.providerType);
 }
 
 export function isAgentSession(obj: unknown): obj is IAgentSession {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsPicker.ts
@@ -12,7 +12,7 @@ import { ICommandService } from '../../../../../platform/commands/common/command
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IQuickInputButton, IQuickInputService, IQuickPickItem, IQuickPickSeparator } from '../../../../../platform/quickinput/common/quickInput.js';
 import { ISessionOpenOptions, openSession } from './agentSessionsOpener.js';
-import { IAgentSession, isLocalAgentSessionItem } from './agentSessionsModel.js';
+import { IAgentSession, isAgentHostAgentSessionItem, isLocalAgentSessionItem } from './agentSessionsModel.js';
 import { IAgentSessionsService } from './agentSessionsService.js';
 import { AgentSessionsSorter, groupAgentSessionsByDate, type IAgentSessionsFilter, sessionDateFromNow } from './agentSessionsViewer.js';
 import { AGENT_SESSION_DELETE_ACTION_ID, AGENT_SESSION_RENAME_ACTION_ID } from './agentSessions.js';
@@ -56,6 +56,8 @@ export function getSessionButtons(session: IAgentSession): IQuickInputButton[] {
 	if (isLocalAgentSessionItem(session)) {
 		buttons.push(renameButton);
 		buttons.push(deleteButton);
+	} else if (isAgentHostAgentSessionItem(session)) {
+		buttons.push(renameButton);
 	}
 	buttons.push(session.isArchived() ? unarchiveButton : archiveButton);
 

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
@@ -1271,6 +1271,23 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 		return session.session.forkSession(request, token);
 	}
 
+	public sessionSupportsRename(sessionResource: URI): boolean {
+		const session = this._sessions.get(sessionResource)
+			// Try to resolve in case an alias was used
+			?? this._sessions.get(this._resolveResource(sessionResource));
+		return !!session?.session.renameSession;
+	}
+
+	public async renameChatSession(sessionResource: URI, title: string, token: CancellationToken): Promise<void> {
+		// Resolve the session (creating it if necessary) so that rename works
+		// even when the session is not currently open in an editor.
+		const session = await this.getOrCreateChatSession(sessionResource, token);
+		if (!session.renameSession) {
+			throw new Error(`Session ${sessionResource.toString()} does not support renaming`);
+		}
+		return session.renameSession(title, token);
+	}
+
 	public getContentProviderSchemes(): string[] {
 		return Array.from(this._contentProviders.keys());
 	}

--- a/src/vs/workbench/contrib/chat/common/actions/chatContextKeys.ts
+++ b/src/vs/workbench/contrib/chat/common/actions/chatContextKeys.ts
@@ -175,4 +175,14 @@ export namespace ChatContextKeyExprs {
 		ContextKeyExpr.regex(ChatContextKeys.lockedCodingAgentId.key, /^agent-host-/),
 		ContextKeyExpr.regex(ChatContextKeys.lockedCodingAgentId.key, /^remote-/),
 	);
+
+	/**
+	 * True when an agent session item (e.g. in the sessions viewer) is an agent
+	 * host session (agent-host-* or remote-*). Keyed on {@link ChatContextKeys.agentSessionType}
+	 * rather than the locked coding agent, for use in session item menus and keybindings.
+	 */
+	export const isAgentHostSessionItem = ContextKeyExpr.or(
+		ContextKeyExpr.regex(ChatContextKeys.agentSessionType.key, /^agent-host-/),
+		ContextKeyExpr.regex(ChatContextKeys.agentSessionType.key, /^remote-/),
+	);
 }

--- a/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
@@ -314,6 +314,14 @@ export interface IChatSession extends IDisposable {
 	 * @returns The forked session item. The promise is rejected if forking fails.
 	 */
 	forkSession?: (request: IChatSessionRequestHistoryItem | undefined, token: CancellationToken) => Promise<IChatSessionItem>;
+
+	/**
+	 * Renames the session.
+	 * @param title The new title for the session.
+	 * @param token Cancellation token.
+	 * @returns A promise that resolves once the rename has been dispatched. The promise is rejected if renaming fails.
+	 */
+	renameSession?: (title: string, token: CancellationToken) => Promise<void>;
 }
 
 export interface IChatSessionContentProvider {
@@ -681,6 +689,19 @@ export interface IChatSessionsService {
 	 * @returns The forked session item, or undefined if forking failed.
 	 */
 	forkChatSession(sessionResource: URI, request: IChatSessionRequestHistoryItem | undefined, token: CancellationToken): Promise<IChatSessionItem>;
+
+	/**
+	 * Returns whether the loaded session supports renaming.
+	 */
+	sessionSupportsRename(sessionResource: URI): boolean;
+
+	/**
+	 * Renames a contributed chat session.
+	 * @param sessionResource The session resource to rename.
+	 * @param title The new title for the session.
+	 * @param token Cancellation token.
+	 */
+	renameChatSession(sessionResource: URI, title: string, token: CancellationToken): Promise<void>;
 
 	readonly onDidChangeOptionGroups: Event<string>;
 

--- a/src/vs/workbench/contrib/chat/test/common/mockChatSessionsService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/mockChatSessionsService.ts
@@ -250,6 +250,14 @@ export class MockChatSessionsService implements IChatSessionsService {
 		throw new Error('Not implemented');
 	}
 
+	sessionSupportsRename(_sessionResource: URI): boolean {
+		return false;
+	}
+
+	async renameChatSession(_sessionResource: URI, _title: string, _token: CancellationToken): Promise<void> {
+		throw new Error('Not implemented');
+	}
+
 	getContentProviderSchemes(): string[] {
 		return Array.from(this.contentProviders.keys());
 	}


### PR DESCRIPTION
- Lets users rename any agent-host chat session directly from the message
  input via `/rename [title]`, without depending on a specific agent SDK to
  implement renaming — the command is intercepted server-side and redirected
  to a title change, so it works uniformly across every session type.
- Surfaces a brief "Renamed: {name}" turn response so the rename is visible
  in the transcript and the user gets clear feedback.
- Propagates server-side title changes to the live chat model so the view
  title updates immediately, and exposes the persisted title on reopen so the
  stale auto-generated title no longer reappears.
- Broadens the sessions viewer rename affordance (context menu, F2, picker
  pencil) to all agent-host session types instead of only Copilot, matching
  the now-generic rename capability.

Fixes #319814

(Commit message generated by Copilot)