### PR TITLE
agentHost: support '#' as a file completion trigger in addition to '@'

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostCompletions.ts
+++ b/src/vs/platform/agentHost/node/agentHostCompletions.ts
@@ -19,6 +19,8 @@ export const IAgentHostCompletions = createDecorator<IAgentHostCompletions>('age
 export const enum CompletionTriggerCharacter {
 	/** File reference, used for `@`-mentions handled by the file completion provider. */
 	File = '@',
+	/** File reference, used for `#`-mentions handled by the file completion provider. */
+	Hash = '#',
 	/** Leading slash command or skill reference. */
 	Slash = '/',
 }

--- a/src/vs/platform/agentHost/node/agentHostFileCompletionProvider.ts
+++ b/src/vs/platform/agentHost/node/agentHostFileCompletionProvider.ts
@@ -23,6 +23,7 @@ const MAX_RESULTS = 50;
  */
 interface IAtToken {
 	readonly token: string;
+	readonly triggerChar: string;
 	readonly rangeStart: number;
 	readonly rangeEnd: number;
 }
@@ -45,8 +46,8 @@ export function extractAtToken(text: string, offset: number): IAtToken | undefin
 		if (ch === 0x20 /* space */ || ch === 0x09 /* tab */ || ch === 0x0a /* \n */ || ch === 0x0d /* \r */) {
 			return undefined;
 		}
-		if (text[i] === CompletionTriggerCharacter.File) {
-			// The '@' must be at start-of-input or preceded by whitespace.
+		if (text[i] === CompletionTriggerCharacter.File || text[i] === CompletionTriggerCharacter.Hash) {
+			// The trigger character must be at start-of-input or preceded by whitespace.
 			if (i > 0) {
 				const prev = text.charCodeAt(i - 1);
 				const prevIsWs = prev === 0x20 || prev === 0x09 || prev === 0x0a || prev === 0x0d;
@@ -54,7 +55,7 @@ export function extractAtToken(text: string, offset: number): IAtToken | undefin
 					return undefined;
 				}
 			}
-			return { token: text.slice(i + 1, offset), rangeStart: i, rangeEnd: offset };
+			return { token: text.slice(i + 1, offset), triggerChar: text[i], rangeStart: i, rangeEnd: offset };
 		}
 	}
 	return undefined;
@@ -102,7 +103,7 @@ export class AgentHostFileCompletionProvider implements IAgentHostCompletionItem
 
 	readonly kinds: ReadonlySet<CompletionItemKind> = new Set([CompletionItemKind.UserMessage]);
 
-	readonly triggerCharacters: readonly string[] = [CompletionTriggerCharacter.File];
+	readonly triggerCharacters: readonly string[] = [CompletionTriggerCharacter.File, CompletionTriggerCharacter.Hash];
 
 	constructor(
 		private readonly _stateManager: AgentHostStateManager,
@@ -159,7 +160,7 @@ export class AgentHostFileCompletionProvider implements IAgentHostCompletionItem
 		return candidates.map((uri): CompletionItem => {
 			const name = basename(uri);
 			return {
-				insertText: CompletionTriggerCharacter.File + name,
+				insertText: at.triggerChar + name,
 				rangeStart: at.rangeStart,
 				rangeEnd: at.rangeEnd,
 				attachment: {

--- a/src/vs/platform/agentHost/test/node/agentHostFileCompletionProvider.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostFileCompletionProvider.test.ts
@@ -38,12 +38,12 @@ suite('AgentHostFileCompletionProvider', () => {
 	teardown(() => disposables.clear());
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	test('announces "@" as a trigger character via IAgentHostCompletions', () => {
+	test('announces "@" and "#" as trigger characters via IAgentHostCompletions', () => {
 		const completions = disposables.add(new AgentHostCompletions(new NullLogService()));
 		const stateManager = disposables.add(new AgentHostStateManager(new NullLogService()));
 		const workspaceFiles = disposables.add(new FakeWorkspaceFiles([]));
 		disposables.add(completions.registerProvider(new AgentHostFileCompletionProvider(stateManager, workspaceFiles)));
-		assert.deepStrictEqual([...completions.triggerCharacters], [CompletionTriggerCharacter.File]);
+		assert.deepStrictEqual([...completions.triggerCharacters], [CompletionTriggerCharacter.File, CompletionTriggerCharacter.Hash]);
 	});
 
 	suite('extractAtToken', () => {
@@ -56,15 +56,15 @@ suite('AgentHostFileCompletionProvider', () => {
 		});
 
 		test('extracts a lone @ at end of string', () => {
-			assert.deepStrictEqual(extractAtToken('look at @', 9), { token: '', rangeStart: 8, rangeEnd: 9 });
+			assert.deepStrictEqual(extractAtToken('look at @', 9), { token: '', triggerChar: '@', rangeStart: 8, rangeEnd: 9 });
 		});
 
 		test('extracts an @-token after a space', () => {
-			assert.deepStrictEqual(extractAtToken('look at @foo', 12), { token: 'foo', rangeStart: 8, rangeEnd: 12 });
+			assert.deepStrictEqual(extractAtToken('look at @foo', 12), { token: 'foo', triggerChar: '@', rangeStart: 8, rangeEnd: 12 });
 		});
 
 		test('extracts an @-token at start of string', () => {
-			assert.deepStrictEqual(extractAtToken('@foo', 4), { token: 'foo', rangeStart: 0, rangeEnd: 4 });
+			assert.deepStrictEqual(extractAtToken('@foo', 4), { token: 'foo', triggerChar: '@', rangeStart: 0, rangeEnd: 4 });
 		});
 
 		test('returns undefined when @ is not preceded by whitespace', () => {
@@ -78,12 +78,28 @@ suite('AgentHostFileCompletionProvider', () => {
 
 		test('honours offset (token = chars between @ and cursor)', () => {
 			// Cursor is mid-token: "look at @fo|o"
-			assert.deepStrictEqual(extractAtToken('look at @foo', 11), { token: 'fo', rangeStart: 8, rangeEnd: 11 });
+			assert.deepStrictEqual(extractAtToken('look at @foo', 11), { token: 'fo', triggerChar: '@', rangeStart: 8, rangeEnd: 11 });
 		});
 
 		test('returns undefined for out-of-range offset', () => {
 			assert.strictEqual(extractAtToken('hi', 99), undefined);
 			assert.strictEqual(extractAtToken('hi', -1), undefined);
+		});
+
+		test('extracts a lone # at end of string', () => {
+			assert.deepStrictEqual(extractAtToken('look at #', 9), { token: '', triggerChar: '#', rangeStart: 8, rangeEnd: 9 });
+		});
+
+		test('extracts a #-token after a space', () => {
+			assert.deepStrictEqual(extractAtToken('look at #foo', 12), { token: 'foo', triggerChar: '#', rangeStart: 8, rangeEnd: 12 });
+		});
+
+		test('extracts a #-token at start of string', () => {
+			assert.deepStrictEqual(extractAtToken('#foo', 4), { token: 'foo', triggerChar: '#', rangeStart: 0, rangeEnd: 4 });
+		});
+
+		test('returns undefined when # is not preceded by whitespace', () => {
+			assert.strictEqual(extractAtToken('foo#bar', 7), undefined);
 		});
 	});
 
@@ -164,6 +180,19 @@ suite('AgentHostFileCompletionProvider', () => {
 					displayKind: 'document',
 				},
 			});
+		});
+
+		test('uses "#" as the insertText prefix when triggered with #', async () => {
+			const wd = URI.file('/wd');
+			const files = [URI.joinPath(wd, 'src/util.ts')];
+			const { sessionUri, provider } = setup({ workingDirectory: wd, files });
+			const result = await provider.provideCompletionItems(
+				{ kind: CompletionItemKind.UserMessage, channel: sessionUri, text: 'see #util', offset: 9 },
+				CancellationToken.None,
+			);
+			assert.strictEqual(result.length, 1);
+			assert.strictEqual(result[0].insertText, '#util.ts');
+			assert.strictEqual(result[0].rangeStart, 4);
 		});
 
 		test('returns the first MAX_RESULTS files in enumeration order for an empty token', async () => {


### PR DESCRIPTION
- Adds '#' as an alternative trigger character for file completions in the agent host message composer, mirroring the '#'-mention convention familiar from VS Code Chat. Users can now type either '@filename' or '#filename' to attach a workspace file reference.
- Extends CompletionTriggerCharacter enum with Hash = '#' so clients learn about both trigger characters during the initialize handshake.
- Preserves the trigger character in the completion result so insert-text uses the same character the user started typing.

Fixes https://github.com/microsoft/vscode/issues/319769

(Commit message generated by Copilot)