### PR TITLE
Align NES recording bookmark with prompt-build snapshot

### DIFF
--- a/extensions/copilot/src/extension/inlineEdits/node/nextEditProvider.ts
+++ b/extensions/copilot/src/extension/inlineEdits/node/nextEditProvider.ts
@@ -698,12 +698,18 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 		const curDocId = doc.id;
 		const logger = parentLogger.createSubLogger('_executeNewNextEditRequest');
 
-		const recording = this._debugRecorder?.getRecentLog();
-
 		const logContext = req.log;
+
+		// Refresh the recording bookmark to the moment we snapshot document/selection state
+		// for the prompt. The bookmark created at provider entry can be stale by the time
+		// we reach here (after debounce/awaits)
+		if (this._debugRecorder) {
+			logContext.recordingBookmark = this._debugRecorder.createBookmark();
+		}
 
 		const activeDocAndIdx = assertDefined(historyContext.getDocumentAndIdx(curDocId));
 		const activeDocSelection = doc.selection.get()[0] as OffsetRange | undefined;
+		const recording = this._debugRecorder?.getRecentLog();
 
 		const projectedDocuments = historyContext.documents.map(doc => this._processDoc(doc));
 
@@ -726,7 +732,7 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 			nLinesEditWindow,
 			false, // isSpeculative
 			logContext,
-			req.log.recordingBookmark,
+			logContext.recordingBookmark,
 			recording,
 			req.providerRequestStartDateTime,
 		);

--- a/extensions/copilot/src/extension/inlineEdits/node/nextEditProvider.ts
+++ b/extensions/copilot/src/extension/inlineEdits/node/nextEditProvider.ts
@@ -704,7 +704,9 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 		// for the prompt. The bookmark created at provider entry can be stale by the time
 		// we reach here (after debounce/awaits)
 		if (this._debugRecorder) {
-			logContext.recordingBookmark = this._debugRecorder.createBookmark();
+			const refreshedBookmark = this._debugRecorder.createBookmark();
+			logContext.recordingBookmark = refreshedBookmark;
+			telemetryBuilder.setRequestBookmark(refreshedBookmark);
 		}
 
 		const activeDocAndIdx = assertDefined(historyContext.getDocumentAndIdx(curDocId));

--- a/extensions/copilot/src/extension/inlineEdits/node/nextEditProviderTelemetry.ts
+++ b/extensions/copilot/src/extension/inlineEdits/node/nextEditProviderTelemetry.ts
@@ -272,6 +272,12 @@ export class LlmNESTelemetryBuilder extends Disposable {
 		return this.editCollectingInfo?.originalSelectionLine;
 	}
 
+	/** Refresh the request bookmark so the telemetry `requestTime` lines up with the
+	 * moment the document/selection were snapshotted for prompt construction. */
+	public setRequestBookmark(bookmark: DebugRecorderBookmark): void {
+		this._requestBookmark = bookmark;
+	}
+
 	/**
 	 * @param _doc passing an observable document allows to track edits and selections
 	 */
@@ -282,7 +288,7 @@ export class LlmNESTelemetryBuilder extends Disposable {
 		private readonly _providerId: string,
 		private readonly _doc: IObservableDocument | undefined,
 		private readonly _debugRecorder?: DebugRecorder,
-		private readonly _requestBookmark?: DebugRecorderBookmark,
+		private _requestBookmark?: DebugRecorderBookmark,
 	) {
 		super();
 		this._startTime = Date.now();


### PR DESCRIPTION
The recording bookmark used as requestTime in alternative-action telemetry
was created at provider entry time, but document/selection state used to
build the prompt is snapshotted later in _executeNewNextEditRequest. This
caused replay tools to miss selection-change events that were actually
reflected in the prompt.
