### PR TITLE
Avoid full-string ipynb serialization for large outputs

### DIFF
--- a/extensions/ipynb/src/notebookSerializer.ts
+++ b/extensions/ipynb/src/notebookSerializer.ts
@@ -8,7 +8,7 @@ import detectIndent from 'detect-indent';
 import * as vscode from 'vscode';
 import { getPreferredLanguage, jupyterNotebookModelToNotebookData } from './deserializers';
 import * as fnv from '@enonic/fnv-plus';
-import { serializeNotebookToString } from './serializers';
+import { serializeNotebookToBytes } from './serializers';
 
 export abstract class NotebookSerializerBase extends vscode.Disposable implements vscode.NotebookSerializer {
 	protected disposed: boolean = false;
@@ -81,8 +81,7 @@ export abstract class NotebookSerializerBase extends vscode.Disposable implement
 			return new Uint8Array(0);
 		}
 
-		const serialized = serializeNotebookToString(data);
-		return new TextEncoder().encode(serialized);
+		return serializeNotebookToBytes(data);
 	}
 
 }

--- a/extensions/ipynb/src/notebookSerializerWorker.ts
+++ b/extensions/ipynb/src/notebookSerializerWorker.ts
@@ -4,16 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { parentPort } from 'worker_threads';
-import { serializeNotebookToString } from './serializers';
+import { serializeNotebookToBytes } from './serializers';
 import type { NotebookData } from 'vscode';
 
 
 if (parentPort) {
 	parentPort.on('message', ({ id, data }: { id: string; data: NotebookData }) => {
 		if (parentPort) {
-			const json = serializeNotebookToString(data);
-			const bytes = new TextEncoder().encode(json);
-			parentPort.postMessage({ id, data: bytes });
+			parentPort.postMessage({ id, data: serializeNotebookToBytes(data) });
 		}
 	});
 }

--- a/extensions/ipynb/src/notebookSerializerWorker.web.ts
+++ b/extensions/ipynb/src/notebookSerializerWorker.web.ts
@@ -3,12 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { serializeNotebookToString } from './serializers';
+import { serializeNotebookToBytes } from './serializers';
 import type { NotebookData } from 'vscode';
 
 onmessage = (e) => {
 	const data = e.data as { id: string; data: NotebookData };
-	const json = serializeNotebookToString(data.data);
-	const bytes = new TextEncoder().encode(json);
-	postMessage({ id: data.id, data: bytes });
+	postMessage({ id: data.id, data: serializeNotebookToBytes(data.data) });
 };

--- a/extensions/ipynb/src/serializers.ts
+++ b/extensions/ipynb/src/serializers.ts
@@ -9,6 +9,7 @@ import { CellOutputMetadata, hasKey, type CellMetadata } from './common';
 import { textMimeTypes, NotebookCellKindMarkup, CellOutputMimeTypes, defaultNotebookFormat } from './constants';
 
 const textDecoder = new TextDecoder();
+const textEncoder = new TextEncoder();
 
 export function createJupyterCellFromNotebookCell(
 	vscCell: NotebookCellData,
@@ -474,6 +475,59 @@ export function serializeNotebookToString(data: NotebookData): string {
 
 	return serializeNotebookToJSON(notebookContent, indentAmount);
 }
+
+export function serializeNotebookToBytes(data: NotebookData): Uint8Array {
+	const notebookContent = getNotebookMetadata(data);
+	// use the preferred language from document metadata or the first cell language as the notebook preferred cell language
+	const preferredCellLanguage = notebookContent.metadata?.language_info?.name ?? data.cells.find(cell => cell.kind === 2)?.languageId;
+
+	const cells = data.cells
+		.map(cell => createJupyterCellFromNotebookCell(cell, preferredCellLanguage))
+		.map(pruneCell);
+
+	const indentAmount = data.metadata && typeof data.metadata.indentAmount === 'string' ?
+		data.metadata.indentAmount :
+		' ';
+
+	const chunks: Uint8Array[] = [];
+	let totalLength = 0;
+	const append = (value: string) => {
+		const chunk = textEncoder.encode(value);
+		chunks.push(chunk);
+		totalLength += chunk.byteLength;
+	};
+
+	append('{\n');
+	append(`${indentAmount}"cells": [`);
+	if (cells.length > 0) {
+		append('\n');
+		for (let i = 0; i < cells.length; i++) {
+			if (i > 0) {
+				append(',\n');
+			}
+			append(indentLines(JSON.stringify(sortObjectPropertiesRecursively(cells[i]), undefined, indentAmount), indentAmount + indentAmount));
+		}
+		append(`\n${indentAmount}`);
+	}
+	append('],\n');
+	append(`${indentAmount}"metadata": ${indentLines(JSON.stringify(sortObjectPropertiesRecursively(notebookContent.metadata || {}), undefined, indentAmount), indentAmount).trimStart()},\n`);
+	append(`${indentAmount}"nbformat": ${JSON.stringify(notebookContent.nbformat || defaultNotebookFormat.major)},\n`);
+	append(`${indentAmount}"nbformat_minor": ${JSON.stringify(notebookContent.nbformat_minor ?? defaultNotebookFormat.minor)}\n`);
+	append('}\n');
+
+	const result = new Uint8Array(totalLength);
+	let offset = 0;
+	for (const chunk of chunks) {
+		result.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+	return result;
+}
+
+function indentLines(value: string, indent: string): string {
+	return value.split('\n').map(line => indent + line).join('\n');
+}
+
 function serializeNotebookToJSON(notebookContent: Partial<nbformat.INotebookContent>, indentAmount: string): string {
 	// ipynb always ends with a trailing new line (we add this so that SCMs do not show unnecessary changes, resulting from a missing trailing new line).
 	const sorted = sortObjectPropertiesRecursively(notebookContent);

--- a/extensions/ipynb/src/serializers.ts
+++ b/extensions/ipynb/src/serializers.ts
@@ -6,7 +6,7 @@
 import type * as nbformat from '@jupyterlab/nbformat';
 import type { NotebookCell, NotebookCellData, NotebookCellOutput, NotebookData, NotebookDocument } from 'vscode';
 import { CellOutputMetadata, hasKey, type CellMetadata } from './common';
-import { textMimeTypes, NotebookCellKindMarkup, CellOutputMimeTypes, defaultNotebookFormat } from './constants';
+import { textMimeTypes, NotebookCellKindMarkup, NotebookCellKindCode, CellOutputMimeTypes, defaultNotebookFormat } from './constants';
 
 const textDecoder = new TextDecoder();
 const textEncoder = new TextEncoder();
@@ -463,7 +463,7 @@ function fixupOutput(output: nbformat.IOutput): nbformat.IOutput {
 export function serializeNotebookToString(data: NotebookData): string {
 	const notebookContent = getNotebookMetadata(data);
 	// use the preferred language from document metadata or the first cell language as the notebook preferred cell language
-	const preferredCellLanguage = notebookContent.metadata?.language_info?.name ?? data.cells.find(cell => cell.kind === 2)?.languageId;
+	const preferredCellLanguage = notebookContent.metadata?.language_info?.name ?? data.cells.find(cell => cell.kind === NotebookCellKindCode)?.languageId;
 
 	notebookContent.cells = data.cells
 		.map(cell => createJupyterCellFromNotebookCell(cell, preferredCellLanguage))
@@ -488,6 +488,7 @@ export function serializeNotebookToBytes(data: NotebookData): Uint8Array {
 	const indentAmount = data.metadata && typeof data.metadata.indentAmount === 'string' ?
 		data.metadata.indentAmount :
 		' ';
+	const effectiveIndentAmount = indentAmount.slice(0, 10);
 
 	const chunks: Uint8Array[] = [];
 	let totalLength = 0;
@@ -498,21 +499,21 @@ export function serializeNotebookToBytes(data: NotebookData): Uint8Array {
 	};
 
 	append('{\n');
-	append(`${indentAmount}"cells": [`);
+	append(`${effectiveIndentAmount}"cells": [`);
 	if (cells.length > 0) {
 		append('\n');
 		for (let i = 0; i < cells.length; i++) {
 			if (i > 0) {
 				append(',\n');
 			}
-			append(indentLines(JSON.stringify(sortObjectPropertiesRecursively(cells[i]), undefined, indentAmount), indentAmount + indentAmount));
+			append(indentLines(JSON.stringify(sortObjectPropertiesRecursively(cells[i]), undefined, indentAmount), effectiveIndentAmount + effectiveIndentAmount));
 		}
-		append(`\n${indentAmount}`);
+		append(`\n${effectiveIndentAmount}`);
 	}
 	append('],\n');
-	append(`${indentAmount}"metadata": ${indentLines(JSON.stringify(sortObjectPropertiesRecursively(notebookContent.metadata || {}), undefined, indentAmount), indentAmount).trimStart()},\n`);
-	append(`${indentAmount}"nbformat": ${JSON.stringify(notebookContent.nbformat || defaultNotebookFormat.major)},\n`);
-	append(`${indentAmount}"nbformat_minor": ${JSON.stringify(notebookContent.nbformat_minor ?? defaultNotebookFormat.minor)}\n`);
+	append(`${effectiveIndentAmount}"metadata": ${indentFollowingLines(JSON.stringify(sortObjectPropertiesRecursively(notebookContent.metadata || {}), undefined, indentAmount), effectiveIndentAmount)},\n`);
+	append(`${effectiveIndentAmount}"nbformat": ${JSON.stringify(notebookContent.nbformat || defaultNotebookFormat.major)},\n`);
+	append(`${effectiveIndentAmount}"nbformat_minor": ${JSON.stringify(notebookContent.nbformat_minor ?? defaultNotebookFormat.minor)}\n`);
 	append('}\n');
 
 	const result = new Uint8Array(totalLength);
@@ -525,7 +526,11 @@ export function serializeNotebookToBytes(data: NotebookData): Uint8Array {
 }
 
 function indentLines(value: string, indent: string): string {
-	return value.split('\n').map(line => indent + line).join('\n');
+	return indent + value.replace(/\n/g, `\n${indent}`);
+}
+
+function indentFollowingLines(value: string, indent: string): string {
+	return value.replace(/\n/g, `\n${indent}`);
 }
 
 function serializeNotebookToJSON(notebookContent: Partial<nbformat.INotebookContent>, indentAmount: string): string {

--- a/extensions/ipynb/src/test/serializers.test.ts
+++ b/extensions/ipynb/src/test/serializers.test.ts
@@ -8,7 +8,7 @@ import type * as nbformat from '@jupyterlab/nbformat';
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import { jupyterCellOutputToCellOutput, jupyterNotebookModelToNotebookData } from '../deserializers';
-import { createMarkdownCellFromNotebookCell, getCellMetadata } from '../serializers';
+import { createMarkdownCellFromNotebookCell, getCellMetadata, serializeNotebookToBytes, serializeNotebookToString } from '../serializers';
 
 function deepStripProperties(obj: any, props: string[]) {
 	for (const prop in obj) {
@@ -180,6 +180,34 @@ suite(`ipynb serializer`, () => {
 			},
 			id: '123'
 		});
+	});
+
+	test('Serialize bytes matches string serialization', async () => {
+		const data = new vscode.NotebookData([
+			new vscode.NotebookCellData(vscode.NotebookCellKind.Markup, '# header1', 'markdown'),
+			new vscode.NotebookCellData(vscode.NotebookCellKind.Code, 'print(1)', 'python')
+		]);
+		data.metadata = {
+			indentAmount: ' ',
+			metadata: {
+				language_info: {
+					name: 'python'
+				}
+			},
+			nbformat: 4,
+			nbformat_minor: 5
+		};
+		data.cells[1].outputs = [
+			new vscode.NotebookCellOutput([
+				vscode.NotebookCellOutputItem.text('hello\nworld', 'text/plain'),
+				new vscode.NotebookCellOutputItem(new Uint8Array([1, 2, 3]), 'image/png')
+			], {
+				outputType: 'display_data',
+				metadata: {}
+			})
+		];
+
+		assert.strictEqual(new TextDecoder().decode(serializeNotebookToBytes(data)), serializeNotebookToString(data));
 	});
 
 	suite('Outputs', () => {

--- a/extensions/ipynb/src/test/serializers.test.ts
+++ b/extensions/ipynb/src/test/serializers.test.ts
@@ -183,31 +183,33 @@ suite(`ipynb serializer`, () => {
 	});
 
 	test('Serialize bytes matches string serialization', async () => {
-		const data = new vscode.NotebookData([
-			new vscode.NotebookCellData(vscode.NotebookCellKind.Markup, '# header1', 'markdown'),
-			new vscode.NotebookCellData(vscode.NotebookCellKind.Code, 'print(1)', 'python')
-		]);
-		data.metadata = {
-			indentAmount: ' ',
-			metadata: {
-				language_info: {
-					name: 'python'
-				}
-			},
-			nbformat: 4,
-			nbformat_minor: 5
-		};
-		data.cells[1].outputs = [
-			new vscode.NotebookCellOutput([
-				vscode.NotebookCellOutputItem.text('hello\nworld', 'text/plain'),
-				new vscode.NotebookCellOutputItem(new Uint8Array([1, 2, 3]), 'image/png')
-			], {
-				outputType: 'display_data',
-				metadata: {}
-			})
-		];
+		for (const indentAmount of [' ', '01234567890']) {
+			const data = new vscode.NotebookData([
+				new vscode.NotebookCellData(vscode.NotebookCellKind.Markup, '# header1', 'markdown'),
+				new vscode.NotebookCellData(vscode.NotebookCellKind.Code, 'print(1)', 'python')
+			]);
+			data.metadata = {
+				indentAmount,
+				metadata: {
+					language_info: {
+						name: 'python'
+					}
+				},
+				nbformat: 4,
+				nbformat_minor: 5
+			};
+			data.cells[1].outputs = [
+				new vscode.NotebookCellOutput([
+					vscode.NotebookCellOutputItem.text('hello\nworld', 'text/plain'),
+					new vscode.NotebookCellOutputItem(new Uint8Array([1, 2, 3]), 'image/png')
+				], {
+					outputType: 'display_data',
+					metadata: {}
+				})
+			];
 
-		assert.strictEqual(new TextDecoder().decode(serializeNotebookToBytes(data)), serializeNotebookToString(data));
+			assert.strictEqual(new TextDecoder().decode(serializeNotebookToBytes(data)), serializeNotebookToString(data));
+		}
 	});
 
 	suite('Outputs', () => {


### PR DESCRIPTION
Fixes #314942

This changes the built-in ipynb serializer save path to encode the notebook JSON in chunks instead of first building one full notebook-sized string and then encoding that string. The existing string serializer remains available, while normal save and both worker serializer paths now use the byte serializer.

The previous path called `serializeNotebookToString()` for the whole notebook. For notebooks with many large outputs, that requires one very large JavaScript string and can hit string-size limits before the save can produce bytes. The new path serializes cells independently into encoded chunks, preserves the same sorted/pretty JSON shape, and then combines those bytes for the VS Code serializer API.

Validation:
- `npm run gulp -- compile-extension:ipynb` in `/tmp/vscode-pr-check`
- `npm run compile-check-ts-native -- --pretty false` in `/tmp/vscode-pr-check`
- Direct compiled serializer check in `/tmp/vscode-pr-check` confirming `TextDecoder().decode(serializeNotebookToBytes(data)) === serializeNotebookToString(data)`
- `git diff --check`

Note: the local pre-commit hook could not run in `/Users/vivek/Documents/New project 9/vscode` because that checkout has incomplete dependencies (`event-stream` missing from `node_modules`). The same patch was validated in `/tmp/vscode-pr-check`, which has a complete install.
