### PR TITLE
Avoid backtracking in multiline find regex

### DIFF
--- a/src/vs/editor/common/model/textModelSearch.ts
+++ b/src/vs/editor/common/model/textModelSearch.ts
@@ -39,9 +39,10 @@ export class SearchParams {
 			multiline = (this.searchString.indexOf('\n') >= 0);
 		}
 
+		const searchString = multiline && this.isRegex ? normalizeMultilineRegexSource(this.searchString) : this.searchString;
 		let regex: RegExp | null = null;
 		try {
-			regex = strings.createRegExp(this.searchString, this.isRegex, {
+			regex = strings.createRegExp(searchString, this.isRegex, {
 				matchCase: this.matchCase,
 				wholeWord: false,
 				multiline: multiline,
@@ -96,6 +97,48 @@ export function isMultilineRegexSource(searchString: string): boolean {
 	}
 
 	return false;
+}
+
+export function normalizeMultilineRegexSource(searchString: string): string {
+	let result = '';
+	for (let i = 0; i < searchString.length; i++) {
+		const replacement = getMultilineAnyCharGroupReplacement(searchString, i);
+		if (replacement) {
+			result += replacement.value;
+			i += replacement.length - 1;
+		} else {
+			result += searchString[i];
+		}
+	}
+	return result;
+}
+
+function getMultilineAnyCharGroupReplacement(searchString: string, offset: number): { value: string; length: number } | undefined {
+	if (searchString.charCodeAt(offset) !== CharCode.OpenParen) {
+		return undefined;
+	}
+
+	const prefix = searchString.startsWith('(?:', offset) ? '(?:' : '(';
+	const contentOffset = offset + prefix.length;
+	let contentLength: number;
+	if (searchString.startsWith('.|\\n)', contentOffset) || searchString.startsWith('\\n|.)', contentOffset)) {
+		contentLength = 5;
+	} else if (searchString.startsWith('.+|\\n)', contentOffset) || searchString.startsWith('\\n|.+)', contentOffset)) {
+		contentLength = 6;
+	} else {
+		return undefined;
+	}
+
+	const quantifierOffset = contentOffset + contentLength;
+	const quantifier = searchString[quantifierOffset];
+	if (quantifier !== '*' && quantifier !== '+') {
+		return undefined;
+	}
+
+	return {
+		value: `${prefix}[\\s\\S])${quantifier}`,
+		length: prefix.length + contentLength + 1
+	};
 }
 
 export function createFindMatch(range: Range, rawMatches: RegExpExecArray, captureMatches: boolean): FindMatch {

--- a/src/vs/editor/common/model/textModelSearch.ts
+++ b/src/vs/editor/common/model/textModelSearch.ts
@@ -100,17 +100,51 @@ export function isMultilineRegexSource(searchString: string): boolean {
 }
 
 export function normalizeMultilineRegexSource(searchString: string): string {
-	let result = '';
+	const result: string[] = [];
+	let lastAppendOffset = 0;
+	let inCharacterClass = false;
+	let escaped = false;
+
 	for (let i = 0; i < searchString.length; i++) {
+		const chCode = searchString.charCodeAt(i);
+		if (escaped) {
+			escaped = false;
+			continue;
+		}
+
+		if (chCode === CharCode.Backslash) {
+			escaped = true;
+			continue;
+		}
+
+		if (chCode === CharCode.OpenSquareBracket) {
+			inCharacterClass = true;
+			continue;
+		}
+
+		if (chCode === CharCode.CloseSquareBracket) {
+			inCharacterClass = false;
+			continue;
+		}
+
+		if (inCharacterClass) {
+			continue;
+		}
+
 		const replacement = getMultilineAnyCharGroupReplacement(searchString, i);
 		if (replacement) {
-			result += replacement.value;
+			result.push(searchString.slice(lastAppendOffset, i), replacement.value);
 			i += replacement.length - 1;
-		} else {
-			result += searchString[i];
+			lastAppendOffset = i + 1;
 		}
 	}
-	return result;
+
+	if (result.length === 0) {
+		return searchString;
+	}
+
+	result.push(searchString.slice(lastAppendOffset));
+	return result.join('');
 }
 
 function getMultilineAnyCharGroupReplacement(searchString: string, offset: number): { value: string; length: number } | undefined {

--- a/src/vs/editor/test/common/model/textModelSearch.test.ts
+++ b/src/vs/editor/test/common/model/textModelSearch.test.ts
@@ -800,7 +800,15 @@ suite('TextModelSearch', () => {
 		assert.strictEqual(normalizeMultilineRegexSource('(.|\\n)*'), '([\\s\\S])*');
 		assert.strictEqual(normalizeMultilineRegexSource('(.+|\\n)*'), '([\\s\\S])*');
 		assert.strictEqual(normalizeMultilineRegexSource('(?:\\n|.)+'), '(?:[\\s\\S])+');
+		assert.strictEqual(normalizeMultilineRegexSource('foo((.|\\n)*)bar'), 'foo(([\\s\\S])*)bar');
 		assert.strictEqual(normalizeMultilineRegexSource('(.|\\n)'), '(.|\\n)');
+	});
+
+	test('does not normalize escaped or character-class regex content', () => {
+		assert.strictEqual(normalizeMultilineRegexSource('\\(.|\\n\\)*'), '\\(.|\\n\\)*');
+		assert.strictEqual(normalizeMultilineRegexSource('[()]|(.|\\n)*'), '[()]|([\\s\\S])*');
+		assert.strictEqual(normalizeMultilineRegexSource('[(.|\\n)*]'), '[(.|\\n)*]');
+		assert.strictEqual(normalizeMultilineRegexSource('[\\]](.|\\n)*'), '[\\]]([\\s\\S])*');
 	});
 
 	test('issue #314038. Multiline regex with dot-or-newline alternation finds triple quoted block', () => {

--- a/src/vs/editor/test/common/model/textModelSearch.test.ts
+++ b/src/vs/editor/test/common/model/textModelSearch.test.ts
@@ -11,7 +11,7 @@ import { getMapForWordSeparators } from '../../../common/core/wordCharacterClass
 import { USUAL_WORD_SEPARATORS } from '../../../common/core/wordHelper.js';
 import { EndOfLineSequence, FindMatch, SearchData } from '../../../common/model.js';
 import { TextModel } from '../../../common/model/textModel.js';
-import { SearchParams, TextModelSearch, isMultilineRegexSource } from '../../../common/model/textModelSearch.js';
+import { SearchParams, TextModelSearch, isMultilineRegexSource, normalizeMultilineRegexSource } from '../../../common/model/textModelSearch.js';
 import { createTextModel } from '../testTextModel.js';
 
 // --------- Find
@@ -791,6 +791,33 @@ suite('TextModelSearch', () => {
 			new FindMatch(new Range(1, 8, 1, 10), ['30']),
 			new FindMatch(new Range(1, 10, 1, 10), ['']),
 			new FindMatch(new Range(1, 11, 1, 13), ['10'])
+		]);
+
+		model.dispose();
+	});
+
+	test('normalizes multiline dot-or-newline regex alternation', () => {
+		assert.strictEqual(normalizeMultilineRegexSource('(.|\\n)*'), '([\\s\\S])*');
+		assert.strictEqual(normalizeMultilineRegexSource('(.+|\\n)*'), '([\\s\\S])*');
+		assert.strictEqual(normalizeMultilineRegexSource('(?:\\n|.)+'), '(?:[\\s\\S])+');
+		assert.strictEqual(normalizeMultilineRegexSource('(.|\\n)'), '(.|\\n)');
+	});
+
+	test('issue #314038. Multiline regex with dot-or-newline alternation finds triple quoted block', () => {
+		const model = createTextModel([
+			'class RotaryEmbedding:',
+			'\t"""',
+			'\tLarge docstring line one',
+			'\tLarge docstring line two',
+			'\t"""',
+			'\tdef forward(self):',
+			'\t\tpass'
+		].join('\n'));
+
+		const searchParams = new SearchParams('\\t*"""(.+|\\n)*"""$(?=\\n)', true, false, null);
+		const actual = TextModelSearch.findMatches(model, searchParams, model.getFullModelRange(), false, 100);
+		assert.deepStrictEqual(actual, [
+			new FindMatch(new Range(2, 1, 5, 5), null)
 		]);
 
 		model.dispose();


### PR DESCRIPTION
Fixes #314038

This normalizes a common multiline regex idiom before compiling editor find regexes. Patterns such as `(.|\n)*`, `(.+|\n)*`, and their non-capturing/reversed variants are intended to mean “any character including newline”, but the alternation plus outer quantifier can cause catastrophic backtracking when the find widget searches as the user types.

The normalization rewrites those exact grouped forms to a single `[\s\S]` atom while preserving whether the group was capturing or non-capturing and preserving the outer `*`/`+` quantifier. That keeps the same multiline search intent for these common forms and avoids the explosive `RegExp.exec` path seen in the issue.

Validation:
- `npm run gulp -- compile-client` in `/tmp/vscode-pr-check`
- `./node_modules/.bin/tsgo --project ./src/tsconfig.json --noEmit --skipLibCheck --pretty false` in `/tmp/vscode-pr-check`
- `npm run test-node -- --run src/vs/editor/test/common/model/textModelSearch.test.ts` in `/tmp/vscode-pr-check` (45 passing)
- `npm run eslint -- src/vs/editor/common/model/textModelSearch.ts src/vs/editor/test/common/model/textModelSearch.test.ts` in `/tmp/vscode-pr-check`
- `git diff --check`

Note: the local pre-commit hook could not run in `/Users/vivek/Documents/New project 9/vscode` because that checkout has incomplete dependencies (`event-stream` missing from `node_modules`). The same patch was validated in `/tmp/vscode-pr-check`, which has a complete install.
