### PR TITLE
Dispose notebook output toolbar on detach

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput.ts
@@ -96,6 +96,7 @@ class CellOutputElement extends Disposable {
 	}
 
 	detach() {
+		this._clearToolbar();
 		this.renderedOutputContainer?.remove();
 
 		let count = 0;
@@ -152,7 +153,7 @@ class CellOutputElement extends Disposable {
 		} else {
 			// Another mimetype or renderer is picked, we need to clear the current output and re-render
 			const nextElement = this.innerContainer.nextElementSibling;
-			this.toolbarDisposables.clear();
+			this._clearToolbar();
 			const element = this.innerContainer;
 			if (element) {
 				element.remove();
@@ -216,7 +217,7 @@ class CellOutputElement extends Disposable {
 				if (visible && !this.toolbarAttached) {
 					this._attachToolbar(innerContainer, notebookTextModel, this.notebookEditor.activeKernel, index, currentMimeType, mimeTypes);
 				} else if (!visible) {
-					this.toolbarDisposables.clear();
+					this._clearToolbar();
 				}
 				this.cellOutputContainer.checkForHiddenOutputs();
 			}));
@@ -309,6 +310,7 @@ class CellOutputElement extends Disposable {
 		const mimeTypePicker = DOM.$('.cell-output-toolbar');
 
 		outputItemDiv.appendChild(mimeTypePicker);
+		this.toolbarAttached = true;
 
 		const toolbar = this.toolbarDisposables.add(this.instantiationService.createInstance(WorkbenchToolBar, mimeTypePicker, {
 			renderDropdownAsChildElement: false
@@ -409,7 +411,7 @@ class CellOutputElement extends Disposable {
 
 		// user chooses another mimetype
 		const nextElement = outputItemDiv.nextElementSibling;
-		this.toolbarDisposables.clear();
+		this._clearToolbar();
 		const element = this.innerContainer;
 		if (element) {
 			element.remove();
@@ -461,7 +463,13 @@ class CellOutputElement extends Disposable {
 		this.notebookEditor.layoutNotebookCell(this.viewCell, this.viewCell.layoutInfo.totalHeight);
 	}
 
+	private _clearToolbar() {
+		this.toolbarAttached = false;
+		this.toolbarDisposables.clear();
+	}
+
 	override dispose() {
+		this.detach();
 		if (this._outputHeightTimer) {
 			this.viewCell.unlockOutputHeight();
 			clearTimeout(this._outputHeightTimer);

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput.ts
@@ -68,6 +68,7 @@ class CellOutputElement extends Disposable {
 
 	private readonly contextKeyService: IContextKeyService;
 	private toolbarAttached = false;
+	private toolbarContainer: HTMLElement | undefined;
 
 	constructor(
 		private notebookEditor: INotebookEditorDelegate,
@@ -310,45 +311,51 @@ class CellOutputElement extends Disposable {
 		const mimeTypePicker = DOM.$('.cell-output-toolbar');
 
 		outputItemDiv.appendChild(mimeTypePicker);
-		this.toolbarAttached = true;
+		this.toolbarContainer = mimeTypePicker;
 
-		const toolbar = this.toolbarDisposables.add(this.instantiationService.createInstance(WorkbenchToolBar, mimeTypePicker, {
-			renderDropdownAsChildElement: false
-		}));
-		toolbar.context = {
-			ui: true,
-			cell: this.output.cellViewModel as ICellViewModel,
-			outputViewModel: this.output,
-			notebookEditor: this.notebookEditor,
-			$mid: MarshalledId.NotebookCellActionContext
-		};
+		try {
+			const toolbar = this.toolbarDisposables.add(this.instantiationService.createInstance(WorkbenchToolBar, mimeTypePicker, {
+				renderDropdownAsChildElement: false
+			}));
+			toolbar.context = {
+				ui: true,
+				cell: this.output.cellViewModel as ICellViewModel,
+				outputViewModel: this.output,
+				notebookEditor: this.notebookEditor,
+				$mid: MarshalledId.NotebookCellActionContext
+			};
 
-		// TODO: This could probably be a real registered action, but it has to talk to this output element
-		const pickAction = this.toolbarDisposables.add(new Action('notebook.output.pickMimetype', nls.localize('pickMimeType', "Change Presentation"), ThemeIcon.asClassName(mimetypeIcon), undefined,
-			async _context => this._pickActiveMimeTypeRenderer(outputItemDiv, notebookTextModel, kernel, this.output)));
+			// TODO: This could probably be a real registered action, but it has to talk to this output element
+			const pickAction = this.toolbarDisposables.add(new Action('notebook.output.pickMimetype', nls.localize('pickMimeType', "Change Presentation"), ThemeIcon.asClassName(mimetypeIcon), undefined,
+				async _context => this._pickActiveMimeTypeRenderer(outputItemDiv, notebookTextModel, kernel, this.output)));
 
-		const menuContextKeyService = this.toolbarDisposables.add(this.contextKeyService.createScoped(outputItemDiv));
-		const hasHiddenOutputs = NOTEBOOK_CELL_HAS_HIDDEN_OUTPUTS.bindTo(menuContextKeyService);
-		const isFirstCellOutput = NOTEBOOK_CELL_IS_FIRST_OUTPUT.bindTo(menuContextKeyService);
-		const cellOutputMimetype = NOTEBOOK_CELL_OUTPUT_MIMETYPE.bindTo(menuContextKeyService);
-		isFirstCellOutput.set(index === 0);
-		cellOutputMimetype.set(currentMimeType.mimeType);
-		this.toolbarDisposables.add(autorun((r) => { hasHiddenOutputs.set(this.cellOutputContainer.hasHiddenOutputs.read(r)); }));
-		const menu = this.toolbarDisposables.add(this.menuService.createMenu(MenuId.NotebookOutputToolbar, menuContextKeyService));
+			const menuContextKeyService = this.toolbarDisposables.add(this.contextKeyService.createScoped(outputItemDiv));
+			const hasHiddenOutputs = NOTEBOOK_CELL_HAS_HIDDEN_OUTPUTS.bindTo(menuContextKeyService);
+			const isFirstCellOutput = NOTEBOOK_CELL_IS_FIRST_OUTPUT.bindTo(menuContextKeyService);
+			const cellOutputMimetype = NOTEBOOK_CELL_OUTPUT_MIMETYPE.bindTo(menuContextKeyService);
+			isFirstCellOutput.set(index === 0);
+			cellOutputMimetype.set(currentMimeType.mimeType);
+			this.toolbarDisposables.add(autorun((r) => { hasHiddenOutputs.set(this.cellOutputContainer.hasHiddenOutputs.read(r)); }));
+			const menu = this.toolbarDisposables.add(this.menuService.createMenu(MenuId.NotebookOutputToolbar, menuContextKeyService));
 
-		const updateMenuToolbar = () => {
-			let { secondary } = getActionBarActions(menu!.getActions({ shouldForwardArgs: true }), () => false);
-			if (!isCopyEnabled) {
-				secondary = secondary.filter((action) => action.id !== COPY_OUTPUT_COMMAND_ID);
-			}
-			if (hasMultipleMimeTypes) {
-				secondary = [pickAction, ...secondary];
-			}
+			const updateMenuToolbar = () => {
+				let { secondary } = getActionBarActions(menu!.getActions({ shouldForwardArgs: true }), () => false);
+				if (!isCopyEnabled) {
+					secondary = secondary.filter((action) => action.id !== COPY_OUTPUT_COMMAND_ID);
+				}
+				if (hasMultipleMimeTypes) {
+					secondary = [pickAction, ...secondary];
+				}
 
-			toolbar.setActions([], secondary);
-		};
-		updateMenuToolbar();
-		this.toolbarDisposables.add(menu.onDidChange(updateMenuToolbar));
+				toolbar.setActions([], secondary);
+			};
+			updateMenuToolbar();
+			this.toolbarDisposables.add(menu.onDidChange(updateMenuToolbar));
+			this.toolbarAttached = true;
+		} catch (error) {
+			this._clearToolbar();
+			throw error;
+		}
 	}
 
 	private async _pickActiveMimeTypeRenderer(outputItemDiv: HTMLElement, notebookTextModel: NotebookTextModel, kernel: INotebookKernel | undefined, viewModel: ICellOutputViewModel) {
@@ -466,6 +473,8 @@ class CellOutputElement extends Disposable {
 	private _clearToolbar() {
 		this.toolbarAttached = false;
 		this.toolbarDisposables.clear();
+		this.toolbarContainer?.remove();
+		this.toolbarContainer = undefined;
 	}
 
 	override dispose() {


### PR DESCRIPTION
Fixes #186361

## Summary

Notebook output toolbars were not fully reset when an output element was detached, hidden, re-rendered, or switched to another mime type. The toolbar attachment flag also was never set after attaching a toolbar, so reactive visibility changes could keep creating toolbar/action item resources across notebook scroll and render cycles.

This change:
- marks output toolbars as attached when they are created
- centralizes toolbar cleanup so the attached flag and disposable store stay in sync
- clears toolbar disposables on detach, hide, re-render, and mime type switch
- detaches owned output DOM and webview inset resources during disposal

## Validation

Validated in a clean checkout at `/tmp/vscode-pr-check` because this local working checkout cannot run the pre-commit hook due to missing `event-stream` in its incomplete dependency install.

- `npm run gulp -- compile-client`
- `./node_modules/.bin/tsgo --project ./src/tsconfig.json --noEmit --skipLibCheck --pretty false`
- `npm run eslint -- src/vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput.ts`
- `git diff --check`
