### PR TITLE
Update @vscode/codicons to version 0.0.46-15 and add new compact icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@microsoft/mxc-sdk": "0.6.0",
         "@parcel/watcher": "^2.5.6",
         "@types/semver": "^7.5.8",
-        "@vscode/codicons": "^0.0.46-14",
+        "@vscode/codicons": "^0.0.46-15",
         "@vscode/copilot-api": "^0.4.2",
         "@vscode/deviceid": "^0.1.1",
         "@vscode/diff": "0.0.2-7",
@@ -1167,9 +1167,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -1185,9 +1182,6 @@
       "integrity": "sha512-EOOnU4Y+vZHfxVl8eBAP7JtSTmu5d4ZDUC9wCGpAA5k703lEnpu8UOv04mTHRn8KTzb8gj+ijNhxDWe3Xljbaw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -1205,9 +1199,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -1223,9 +1214,6 @@
       "integrity": "sha512-AMIBN830yOvNcrj2Q0tGMImqat/V24wZS/4m5BaUssELM7r7KrT9ZBnBs+nWDZYeQaRoblFWL3f4AfxE3t94lQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -3646,9 +3634,9 @@
       }
     },
     "node_modules/@vscode/codicons": {
-      "version": "0.0.46-14",
-      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-14.tgz",
-      "integrity": "sha512-jeiVtypLqoytNMG62mvWDRFBx76lGiJDbuXVdnJJmZAZ9DVXbanTWlsyIvaAtoGhMMgONYYvZbdZfS90VMdr2Q==",
+      "version": "0.0.46-15",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-15.tgz",
+      "integrity": "sha512-yC2AdGcCoJQR0fgrUJLBRo/KfZzz+aM7z+3LYw9/9IwUuKC8goUxnlWd1rcZzDQXSfj1xwtVyUn0fTzTCAhdJg==",
       "license": "CC-BY-4.0"
     },
     "node_modules/@vscode/component-explorer": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@microsoft/mxc-sdk": "0.6.0",
     "@parcel/watcher": "^2.5.6",
     "@types/semver": "^7.5.8",
-    "@vscode/codicons": "^0.0.46-14",
+    "@vscode/codicons": "^0.0.46-15",
     "@vscode/copilot-api": "^0.4.2",
     "@vscode/deviceid": "^0.1.1",
     "@vscode/diff": "0.0.2-7",

--- a/remote/web/package-lock.json
+++ b/remote/web/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
-        "@vscode/codicons": "^0.0.46-14",
+        "@vscode/codicons": "^0.0.46-15",
         "@vscode/iconv-lite-umd": "0.7.1",
         "@vscode/tree-sitter-wasm": "^0.3.1",
         "@vscode/vscode-languagedetection": "1.0.23",
@@ -73,9 +73,9 @@
       "integrity": "sha512-n1VPsljTSkthsAFYdiWfC+DKzK2WwcRp83Y1YAqdX552BstvsDjft9YXppjUzp11BPsapDoO1LDgrDB0XVsfNQ=="
     },
     "node_modules/@vscode/codicons": {
-      "version": "0.0.46-14",
-      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-14.tgz",
-      "integrity": "sha512-jeiVtypLqoytNMG62mvWDRFBx76lGiJDbuXVdnJJmZAZ9DVXbanTWlsyIvaAtoGhMMgONYYvZbdZfS90VMdr2Q==",
+      "version": "0.0.46-15",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-15.tgz",
+      "integrity": "sha512-yC2AdGcCoJQR0fgrUJLBRo/KfZzz+aM7z+3LYw9/9IwUuKC8goUxnlWd1rcZzDQXSfj1xwtVyUn0fTzTCAhdJg==",
       "license": "CC-BY-4.0"
     },
     "node_modules/@vscode/iconv-lite-umd": {

--- a/remote/web/package.json
+++ b/remote/web/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",
-    "@vscode/codicons": "^0.0.46-14",
+    "@vscode/codicons": "^0.0.46-15",
     "@vscode/iconv-lite-umd": "0.7.1",
     "@vscode/tree-sitter-wasm": "^0.3.1",
     "@vscode/vscode-languagedetection": "1.0.23",

--- a/src/vs/base/common/codiconsLibrary.ts
+++ b/src/vs/base/common/codiconsLibrary.ts
@@ -715,4 +715,8 @@ export const codiconsLibrary = {
 	worktreeCompact: register('worktree-compact', 0xecbd),
 	developerTools: register('developer-tools', 0xecbe),
 	cloudCompact: register('cloud-compact', 0xecbf),
+	agentCompact: register('agent-compact', 0xecc0),
+	askCompact: register('ask-compact', 0xecc1),
+	settingsCompact: register('settings-compact', 0xecc2),
+	vmCompact: register('vm-compact', 0xecc3),
 } as const;


### PR DESCRIPTION
Upgrade the @vscode/codicons package to version 0.0.46-15 and introduce new compact icons for improved UI consistency. No issues are associated with this update. Testing can be done by verifying the availability of the new icons in the application.

