### PR TITLE
Respect user preference for modal editors in RequiresModal capability

### DIFF
--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -859,7 +859,8 @@ export const enum EditorInputCapabilities {
 
 	/**
 	 * Signals that the editor must be opened in a modal editor
-	 * part, overriding the `workbench.editor.useModal` setting.
+	 * part. This is honored unless the user has explicitly opted
+	 * out of modal editors via `workbench.editor.useModal: 'off'`.
 	 */
 	RequiresModal = 1 << 11
 }

--- a/src/vs/workbench/services/editor/common/editorGroupFinder.ts
+++ b/src/vs/workbench/services/editor/common/editorGroupFinder.ts
@@ -41,7 +41,10 @@ function handleGroupResult(group: IEditorGroup, editor: EditorInputWithOptions |
 	const modalEditorPart = editorGroupService.activeModalEditorPart;
 	const modalEditorMode = configurationService.getValue<string>('workbench.editor.useModal');
 	const editorInput = isEditorInputWithOptions(editor) ? editor.editor : isEditorInput(editor) ? editor : undefined;
-	const requiresModal = editorInput instanceof EditorInput && editorInput.hasCapability(EditorInputCapabilities.RequiresModal);
+	// The `RequiresModal` capability is honored unless the user has explicitly
+	// disabled modal editors via `workbench.editor.useModal: 'off'`, in which
+	// case the user preference wins.
+	const requiresModal = editorInput instanceof EditorInput && editorInput.hasCapability(EditorInputCapabilities.RequiresModal) && modalEditorMode !== 'off';
 	if (modalEditorPart && preferredGroup !== MODAL_GROUP && modalEditorMode !== 'all' && !requiresModal) {
 		// Only allow to open in modal group if MODAL_GROUP is explicitly requested
 		// or when the setting is configured to open all editors modal or when the
@@ -100,8 +103,9 @@ function doFindGroup(input: EditorInputWithOptions | IUntypedEditorInput, prefer
 	const editor = isEditorInputWithOptions(input) ? input.editor : input;
 	const options = input.options;
 
-	// Group: Force modal if the editor has the RequiresModal capability
-	if (isEditorInput(editor) && editor.hasCapability(EditorInputCapabilities.RequiresModal)) {
+	// Group: Force modal if the editor has the RequiresModal capability,
+	// but respect `workbench.editor.useModal: 'off'` as an explicit opt-out.
+	if (isEditorInput(editor) && editor.hasCapability(EditorInputCapabilities.RequiresModal) && configurationService.getValue<string>('workbench.editor.useModal') !== 'off') {
 		group = editorGroupService.createModalEditorPart(options?.modal)
 			.then(part => part.activeGroup);
 	}

--- a/src/vs/workbench/services/editor/test/browser/modalEditorGroup.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/modalEditorGroup.test.ts
@@ -768,11 +768,32 @@ suite('Modal Editor Group', () => {
 
 	suite('RequiresModal capability', () => {
 
-		test('findGroup opens modal for editor with RequiresModal even when setting is off', async () => {
+		test('findGroup respects useModal: off for editor with RequiresModal', async () => {
 			const instantiationService = workbenchInstantiationService({ contextKeyService: instantiationService => instantiationService.createInstance(MockScopableContextKeyService) }, disposables);
 			instantiationService.invokeFunction(accessor => Registry.as<IEditorFactoryRegistry>(EditorExtensions.EditorFactory).start(accessor));
 			const configurationService = new TestConfigurationService();
 			await configurationService.setUserConfiguration('workbench.editor.useModal', 'off');
+			instantiationService.stub(IConfigurationService, configurationService);
+			const parts = await createEditorParts(instantiationService, disposables);
+			instantiationService.stub(IEditorGroupsService, parts);
+
+			const input = createTestFileEditorInput(URI.file('foo/bar'), TEST_EDITOR_INPUT_ID);
+			input.capabilities = EditorInputCapabilities.RequiresModal;
+
+			const result = instantiationService.invokeFunction(accessor => findGroup(accessor, { editor: input, options: {} }, undefined));
+
+			const [group] = result instanceof Promise ? await result : result;
+
+			// With useModal: off, the user preference wins and no modal part is created
+			assert.strictEqual(parts.activeModalEditorPart, undefined);
+			assert.strictEqual(group.id, parts.mainPart.activeGroup.id);
+		});
+
+		test('findGroup opens modal for editor with RequiresModal when useModal is some', async () => {
+			const instantiationService = workbenchInstantiationService({ contextKeyService: instantiationService => instantiationService.createInstance(MockScopableContextKeyService) }, disposables);
+			instantiationService.invokeFunction(accessor => Registry.as<IEditorFactoryRegistry>(EditorExtensions.EditorFactory).start(accessor));
+			const configurationService = new TestConfigurationService();
+			await configurationService.setUserConfiguration('workbench.editor.useModal', 'some');
 			instantiationService.stub(IConfigurationService, configurationService);
 			const parts = await createEditorParts(instantiationService, disposables);
 			instantiationService.stub(IEditorGroupsService, parts);


### PR DESCRIPTION
```Copilot Generated Description:``` Adjust the RequiresModal capability to honor user settings for modal editors, ensuring that the preference to disable modal editors is respected. Update tests to verify this behavior.