### PR TITLE
Fix Ctrl+Tab/Ctrl+Shift+Tab session navigation in Agents window

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
@@ -129,7 +129,9 @@ registerAction2(class GoBackAction extends Action2 {
 			category: SessionsCategories.Sessions,
 			precondition: CanGoBackContext,
 			keybinding: {
-				weight: KeybindingWeight.WorkbenchContrib,
+				// Higher than `WorkbenchContrib` so the `Ctrl+Shift+Tab` secondary wins over the
+				// editor quick-open actions (which bind the same chord at `WorkbenchContrib`).
+				weight: KeybindingWeight.WorkbenchContrib + 1,
 				win: { primary: KeyMod.Alt | KeyCode.LeftArrow, secondary: [KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Tab] },
 				mac: { primary: KeyMod.WinCtrl | KeyCode.Minus, secondary: [KeyMod.WinCtrl | KeyMod.Shift | KeyCode.Tab] },
 				linux: { primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.Minus, secondary: [KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Tab] },
@@ -169,7 +171,9 @@ registerAction2(class GoForwardAction extends Action2 {
 			category: SessionsCategories.Sessions,
 			precondition: CanGoForwardContext,
 			keybinding: {
-				weight: KeybindingWeight.WorkbenchContrib,
+				// Higher than `WorkbenchContrib` so the `Ctrl+Tab` secondary wins over the
+				// editor quick-open actions (which bind the same chord at `WorkbenchContrib`).
+				weight: KeybindingWeight.WorkbenchContrib + 1,
 				win: { primary: KeyMod.Alt | KeyCode.RightArrow, secondary: [KeyMod.CtrlCmd | KeyCode.Tab] },
 				mac: { primary: KeyMod.WinCtrl | KeyMod.Shift | KeyCode.Minus, secondary: [KeyMod.WinCtrl | KeyCode.Tab] },
 				linux: { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Minus, secondary: [KeyMod.CtrlCmd | KeyCode.Tab] },


### PR DESCRIPTION
## Problem

`Ctrl+Tab` / `Ctrl+Shift+Tab` did not navigate forward/back between sessions in the Agents window.

## Root cause

The `sessions.goBack` / `sessions.goForward` actions register `Ctrl+Shift+Tab` and `Ctrl+Tab` as **secondary** keybindings at weight `KeybindingWeight. the same chords and same weight as the workbench editor quick-open actions:WorkbenchContrib` 

 `Ctrl+Tab`
 `Ctrl+Shift+Tab`

With equal weight, the resolver tiebreaks by command name; `workbench.action.*` sorts after `sessions.*`, so the editor actions were evaluated first and won the conflict in the Agents window. The session chords therefore never fired.

## Fix


Higher-weight bindings on these chords (`quickOpenNavigate*InEditorPicker`, `quickInputBack` at `WorkbenchContrib + 50`) are gated on active picker contexts and intentionally still win while a picker is open.

cc @sandy081

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>