### PR TITLE
fix: surface missing Git LFS git errors

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostGitService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitService.ts
@@ -661,9 +661,13 @@ export function summarizeStderrForError(stderr: string): string {
 	if (lines.length === 0) {
 		return '';
 	}
-	const last = lines[lines.length - 1];
 	const MAX = 200;
-	return last.length > MAX ? `${last.slice(0, MAX - 1)}…` : last;
+	const gitLfsMissing = lines.find(line =>
+		/\bgit-lfs\b/i.test(line) &&
+		/(command not found|not recognized|no such file)/i.test(line)
+	);
+	const summary = gitLfsMissing ?? lines[lines.length - 1];
+	return summary.length > MAX ? `${summary.slice(0, MAX - 1)}…` : summary;
 }
 
 /**

--- a/src/vs/platform/agentHost/test/node/agentHostGitService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitService.test.ts
@@ -296,6 +296,19 @@ suite('AgentHostGitService', () => {
 			);
 		});
 
+		test('keeps missing git-lfs error over the later generic fatal line', () => {
+			const err = Object.assign(new Error('Command failed'), { code: 128 });
+			const stderr = [
+				"Preparing worktree (new branch 'agents/example')",
+				'git-lfs filter-process: git-lfs: command not found',
+				'fatal: the remote end hung up unexpectedly',
+			].join('\n');
+			assert.strictEqual(
+				formatGitError(['worktree', 'add', '--no-track', '-b', 'agents/example', '/tmp/worktree', 'origin/main'], 60_000, false, err, stderr),
+				'git worktree exited with code 128: git-lfs filter-process: git-lfs: command not found',
+			);
+		});
+
 		test('falls back to error message when there is no signal or exit code', () => {
 			const err = new Error('spawn git ENOENT');
 			assert.strictEqual(

--- a/src/vs/platform/agentHost/test/node/agentHostGitService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitService.test.ts
@@ -299,7 +299,7 @@ suite('AgentHostGitService', () => {
 		test('keeps missing git-lfs error over the later generic fatal line', () => {
 			const err = Object.assign(new Error('Command failed'), { code: 128 });
 			const stderr = [
-				"Preparing worktree (new branch 'agents/example')",
+				'Preparing worktree (new branch \'agents/example\')',
 				'git-lfs filter-process: git-lfs: command not found',
 				'fatal: the remote end hung up unexpectedly',
 			].join('\n');


### PR DESCRIPTION
## Summary

Fixes #319824.

When `git worktree add` fails because Git LFS is missing, stderr can include a useful line followed by a generic fatal line:

- `git-lfs filter-process: git-lfs: command not found`
- `fatal: the remote end hung up unexpectedly`

The agent host Git error formatter summarized only the last stderr line, so users saw the generic fatal message instead of the actionable missing Git LFS cause.

This change keeps the existing last-line behavior for ordinary multi-line/progress stderr, but prefers a `git-lfs` missing-command line when present. It also adds a regression test for the issue shape.

## Validation

- `node -e` sanity check for the formatter behavior and existing progress-meter behavior
- `git diff --check`

I did not run the full VS Code unit test harness in this sparse checkout.