### PR TITLE
sessions: add editor part chevron to toggle the secondary side bar

### DIFF
--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -149,6 +149,10 @@ Editors open as modal overlays rather than occupying grid space. The configurati
 | Editor opens (no explicit group) | Opens in modal overlay |
 | All editors closed / Escape / backdrop click | Modal closes and is disposed |
 
+When the editor part is shown in the grid (not as a modal), its title toolbar hosts layout actions registered in `contrib/editor/browser/editor.contribution.ts`: open in modal editor, maximize / restore editor area, close editor area, and a **chevron** toggle (right of the tabs, `MenuId.EditorTitleLayout`) that expands the editor by collapsing the auxiliary bar: when the auxiliary bar (secondary side bar) is visible a `chevron-right` **Push Editor Right** hides it; once hidden the same slot shows a `chevron-left` **Show Secondary Side Bar** that brings it back. `AuxiliaryBarVisibleContext` drives the flip.
+
+The auxiliary-bar invariant (§10) is only enforced when the editor part *becomes* visible, so this toggle can collapse the side part while the editor stays open.
+
 The main editor part can be explicitly revealed for workflows that target it directly.
 
 ---

--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -149,7 +149,9 @@ Editors open as modal overlays rather than occupying grid space. The configurati
 | Editor opens (no explicit group) | Opens in modal overlay |
 | All editors closed / Escape / backdrop click | Modal closes and is disposed |
 
-When the editor part is shown in the grid (not as a modal), its title toolbar hosts layout actions registered in `contrib/editor/browser/editor.contribution.ts`: open in modal editor, maximize / restore editor area, close editor area, and a **chevron** toggle (right of the tabs, `MenuId.EditorTitleLayout`) that expands the editor by collapsing the auxiliary bar: when the auxiliary bar (secondary side bar) is visible a `chevron-right` **Push Editor Right** hides it; once hidden the same slot shows a `chevron-left` **Show Secondary Side Bar** that brings it back. `AuxiliaryBarVisibleContext` drives the flip.
+When the editor part is shown in the grid (not as a modal), its title toolbar (`MenuId.EditorTitleLayout`, right of the tabs) hosts layout actions registered in `contrib/editor/browser/editor.contribution.ts`, ordered left-to-right as: open in modal editor, **maximize / restore editor area**, a **chevron** toggle for the auxiliary bar, and **close editor area**. The auxiliary-bar chevron sits to the right of maximize/restore because it changes the right-hand side of the layout. When the auxiliary bar (secondary side bar) is visible a `chevron-right` **Push Editor Right** hides it; once hidden the same slot shows a `chevron-left` **Show Secondary Side Bar** that brings it back. `AuxiliaryBarVisibleContext` drives the flip.
+
+When the auxiliary bar is hidden the editor becomes the rightmost card and expands into the freed space; the workbench's 10px right gutter still applies, and a `.noauxiliarybar` rule in `browser/media/style.css` restores the editor's right border and right corner radii so it keeps its card appearance.
 
 The auxiliary-bar invariant (§10) is only enforced when the editor part *becomes* visible, so this toggle can collapse the side part while the editor stays open.
 

--- a/src/vs/sessions/browser/media/style.css
+++ b/src/vs/sessions/browser/media/style.css
@@ -183,6 +183,19 @@
 	overflow: hidden;
 }
 
+/*
+ * When the secondary side bar (auxiliary bar) is hidden, the editor becomes the
+ * rightmost card and takes over the space the auxiliary bar used to occupy. The
+ * 10px workbench gutter on the right edge (see Workbench.layout) already provides
+ * the outer margin, so we only need to restore the right border and the right
+ * corner radii so the editor still looks like a card.
+ */
+.agent-sessions-workbench.noauxiliarybar .monaco-grid-view .part.editor:not(.modal-editor-part) {
+	border-right-width: 1px;
+	border-top-right-radius: 8px;
+	border-bottom-right-radius: 8px;
+}
+
 .agent-sessions-workbench .monaco-grid-view .part.editor:not(.modal-editor-part)::after {
 	box-shadow: none;
 }

--- a/src/vs/sessions/contrib/editor/browser/editor.contribution.ts
+++ b/src/vs/sessions/contrib/editor/browser/editor.contribution.ts
@@ -153,7 +153,7 @@ class PushEditorRightAction extends Action2 {
 			menu: {
 				id: MenuId.EditorTitleLayout,
 				group: 'navigation',
-				order: 97,
+				order: 99.5,
 				when: ContextKeyExpr.and(editorLeftRightWhen, AuxiliaryBarVisibleContext)
 			}
 		});
@@ -179,7 +179,7 @@ class PullEditorLeftAction extends Action2 {
 			menu: {
 				id: MenuId.EditorTitleLayout,
 				group: 'navigation',
-				order: 97,
+				order: 99.5,
 				when: ContextKeyExpr.and(editorLeftRightWhen, AuxiliaryBarVisibleContext.toNegated())
 			}
 		});

--- a/src/vs/sessions/contrib/editor/browser/editor.contribution.ts
+++ b/src/vs/sessions/contrib/editor/browser/editor.contribution.ts
@@ -9,7 +9,7 @@ import { ServicesAccessor } from '../../../../editor/browser/editorExtensions.js
 import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
-import { EditorPartModalContext, IsAuxiliaryWindowContext, IsSessionsWindowContext, IsTopRightEditorGroupContext } from '../../../../workbench/common/contextkeys.js';
+import { AuxiliaryBarVisibleContext, EditorPartModalContext, IsAuxiliaryWindowContext, IsSessionsWindowContext, IsTopRightEditorGroupContext } from '../../../../workbench/common/contextkeys.js';
 import { IAgentWorkbenchLayoutService } from '../../../browser/workbench.js';
 import { EditorMaximizedContext } from '../../../common/contextkeys.js';
 import { IViewsService } from '../../../../workbench/services/views/common/viewsService.js';
@@ -135,6 +135,64 @@ class CloseMainEditorPartAction extends Action2 {
 }
 
 registerAction2(CloseMainEditorPartAction);
+
+const editorLeftRightWhen = ContextKeyExpr.and(
+	IsSessionsWindowContext,
+	IsAuxiliaryWindowContext.toNegated(),
+	IsTopRightEditorGroupContext);
+
+class PushEditorRightAction extends Action2 {
+	static readonly ID = 'workbench.action.agentSessions.pushEditorRight';
+
+	constructor() {
+		super({
+			id: PushEditorRightAction.ID,
+			title: localize2('pushEditorRight', "Push Editor Right"),
+			icon: Codicon.chevronRight,
+			f1: false,
+			menu: {
+				id: MenuId.EditorTitleLayout,
+				group: 'navigation',
+				order: 97,
+				when: ContextKeyExpr.and(editorLeftRightWhen, AuxiliaryBarVisibleContext)
+			}
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const layoutService = accessor.get(IAgentWorkbenchLayoutService);
+		layoutService.setPartHidden(true, Parts.AUXILIARYBAR_PART);
+	}
+}
+
+registerAction2(PushEditorRightAction);
+
+class PullEditorLeftAction extends Action2 {
+	static readonly ID = 'workbench.action.agentSessions.pullEditorLeft';
+
+	constructor() {
+		super({
+			id: PullEditorLeftAction.ID,
+			title: localize2('pullEditorLeft', "Show Secondary Side Bar"),
+			icon: Codicon.chevronLeft,
+			f1: false,
+			menu: {
+				id: MenuId.EditorTitleLayout,
+				group: 'navigation',
+				order: 97,
+				when: ContextKeyExpr.and(editorLeftRightWhen, AuxiliaryBarVisibleContext.toNegated())
+			}
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const layoutService = accessor.get(IAgentWorkbenchLayoutService);
+		layoutService.setPartHidden(false, Parts.AUXILIARYBAR_PART);
+	}
+}
+
+registerAction2(PullEditorLeftAction);
+
 
 class OpenEditorInModalEditorAction extends Action2 {
 	static readonly ID = 'workbench.action.agentSessions.openEditorInModal';

--- a/src/vs/sessions/contrib/editor/test/browser/editor.contribution.test.ts
+++ b/src/vs/sessions/contrib/editor/test/browser/editor.contribution.test.ts
@@ -196,4 +196,46 @@ suite('Sessions - Editor Contribution', () => {
 		assert.deepStrictEqual(layoutService.maximizedStates, [true, false]);
 		assert.strictEqual(layoutService.panelVisible, true);
 	});
+
+	test('push editor right hides the auxiliary bar', async () => {
+		const instantiationService = store.add(new TestInstantiationService());
+		const layoutService = new class extends mock<IAgentWorkbenchLayoutService>() {
+			readonly hiddenParts: Parts[] = [];
+
+			override setPartHidden(hidden: boolean, part: Parts): void {
+				if (hidden) {
+					this.hiddenParts.push(part);
+				}
+			}
+		};
+		instantiationService.set(IAgentWorkbenchLayoutService, layoutService);
+
+		const handler = CommandsRegistry.getCommand('workbench.action.agentSessions.pushEditorRight')?.handler;
+		assert.ok(handler, 'Command handler should be registered');
+
+		await handler(instantiationService);
+
+		assert.deepStrictEqual(layoutService.hiddenParts, [Parts.AUXILIARYBAR_PART]);
+	});
+
+	test('pull editor left shows the auxiliary bar', async () => {
+		const instantiationService = store.add(new TestInstantiationService());
+		const layoutService = new class extends mock<IAgentWorkbenchLayoutService>() {
+			readonly shownParts: Parts[] = [];
+
+			override setPartHidden(hidden: boolean, part: Parts): void {
+				if (!hidden) {
+					this.shownParts.push(part);
+				}
+			}
+		};
+		instantiationService.set(IAgentWorkbenchLayoutService, layoutService);
+
+		const handler = CommandsRegistry.getCommand('workbench.action.agentSessions.pullEditorLeft')?.handler;
+		assert.ok(handler, 'Command handler should be registered');
+
+		await handler(instantiationService);
+
+		assert.deepStrictEqual(layoutService.shownParts, [Parts.AUXILIARYBAR_PART]);
+	});
 });


### PR DESCRIPTION
## What

Adds a chevron toggle to the editor part title bar in the Agents window (shown when the editor is in the grid, not as a modal) that expands the editor by collapsing the auxiliary bar (secondary side bar).

- When the auxiliary bar is visible, a `chevron-right` **Push Editor Right** hides it.
- Once hidden, the same slot shows a `chevron-left` **Show Secondary Side Bar** that restores it.
- The direction flip is driven by `AuxiliaryBarVisibleContext`.

The actions live in `MenuId.EditorTitleLayout` (right of the tabs) and are gated to the sessions window / main editor group. The auxiliary-bar invariant is only enforced when the editor part *becomes* visible, so the toggle can collapse the side part while the editor stays open.

## Why

Gives users a quick way to widen the editor area by hiding the secondary side bar directly from the editor title bar.

## Notes for reviewers

- Implementation: `src/vs/sessions/contrib/editor/browser/editor.contribution.ts` (`PushEditorRightAction` / `PullEditorLeftAction`).
- Spec updated in `src/vs/sessions/LAYOUT.md` (§5 Editor Modal).
- Unit tests added in `editor.contribution.test.ts`.
- `compile-check-ts-native` and `valid-layers-check` pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>