### PR TITLE
sessions: unify session recency history for picker and navigation

### DIFF
--- a/src/vs/sessions/SESSIONS_LIST.md
+++ b/src/vs/sessions/SESSIONS_LIST.md
@@ -14,7 +14,7 @@ The sessions list (`SessionsView` + `SessionsList`) displays every session known
 |------|---------|
 | `contrib/sessions/browser/views/sessionsView.ts` | `SessionsView` — ViewPane with header, new-session button, sort/group/filter persistence |
 | `contrib/sessions/browser/views/sessionsList.ts` | `SessionsList` — tree control, grouping/filtering logic, menu IDs, context keys |
-| `contrib/sessions/browser/views/sessionsListModelService.ts` | `ISessionsListModelService` — pin/read state (UI-only, not synced to providers) |
+| `services/sessions/browser/sessionsListModelService.ts` | `ISessionsListModelService` — pin/read state + shared status icon (UI-only, not synced to providers) |
 | `contrib/sessions/browser/views/sessionsViewActions.ts` | All registered actions (sort, group, filter, pin, archive, rename, navigate) |
 
 ---

--- a/src/vs/sessions/browser/parts/sessionHeader.ts
+++ b/src/vs/sessions/browser/parts/sessionHeader.ts
@@ -7,14 +7,14 @@ import './media/chatCompositeBar.css';
 import { Disposable, DisposableStore, MutableDisposable } from '../../../base/common/lifecycle.js';
 import { Emitter, Event } from '../../../base/common/event.js';
 import { $, addDisposableListener, DisposableResizeObserver, EventType, reset } from '../../../base/browser/dom.js';
-import { autorun, IReader } from '../../../base/common/observable.js';
+import { autorun, IObservable, IReader, observableSignalFromEvent } from '../../../base/common/observable.js';
 import { IThemeService } from '../../../platform/theme/common/themeService.js';
 import { Codicon } from '../../../base/common/codicons.js';
-import { ThemeIcon, themeColorFromId } from '../../../base/common/themables.js';
+import { ThemeIcon } from '../../../base/common/themables.js';
 import { asCssVariable } from '../../../platform/theme/common/colorUtils.js';
 import { localize } from '../../../nls.js';
-import { SessionStatus } from '../../services/sessions/common/session.js';
 import { IActiveSession } from '../../services/sessions/common/sessionsManagement.js';
+import { ISessionsListModelService } from '../../services/sessions/browser/sessionsListModelService.js';
 import { IInstantiationService } from '../../../platform/instantiation/common/instantiation.js';
 import { HiddenItemStrategy, MenuWorkbenchToolBar } from '../../../platform/actions/browser/toolbar.js';
 import { Menus } from '../menus.js';
@@ -54,6 +54,8 @@ export class SessionHeader extends Disposable {
 
 	private readonly _sessionTransfer = LocalSelectionTransfer.getInstance<DraggedSessionIdentifier>();
 
+	private readonly _readStateSignal: IObservable<void>;
+
 	get element(): HTMLElement {
 		return this._container;
 	}
@@ -69,8 +71,11 @@ export class SessionHeader extends Disposable {
 	constructor(
 		@IThemeService private readonly _themeService: IThemeService,
 		@IInstantiationService instantiationService: IInstantiationService,
+		@ISessionsListModelService private readonly _sessionsListModelService: ISessionsListModelService,
 	) {
 		super();
+
+		this._readStateSignal = observableSignalFromEvent(this, this._sessionsListModelService.onDidChange);
 
 		this._container = $('.chat-composite-bar.session-header-bar');
 
@@ -180,6 +185,7 @@ export class SessionHeader extends Disposable {
 		}
 
 		store.add(autorun(reader => {
+			this._readStateSignal.read(reader);
 			this._updateHeader(session, reader);
 		}));
 
@@ -191,10 +197,10 @@ export class SessionHeader extends Disposable {
 	private _updateHeader(session: IActiveSession, reader: IReader): void {
 		// Session icon — mirror the status-based icon shown in the sessions list.
 		const status = session.status.read(reader);
-		const isRead = session.isRead.read(reader);
+		const isRead = this._sessionsListModelService.isSessionRead(session);
 		const isArchived = session.isArchived.read(reader);
 		const pullRequestIcon = session.workspace.read(reader)?.folders[0]?.gitRepository?.gitHubInfo.read(reader)?.pullRequest?.icon;
-		const icon = this._getStatusIcon(status, isRead, isArchived, pullRequestIcon);
+		const icon = this._sessionsListModelService.getStatusIcon(status, isRead, isArchived, pullRequestIcon);
 		this._iconEl.className = 'chat-composite-bar-session-icon';
 		this._iconEl.classList.add(...ThemeIcon.asClassNameArray(icon));
 		this._iconEl.style.color = icon.color ? asCssVariable(icon.color.id) : '';
@@ -262,31 +268,6 @@ export class SessionHeader extends Disposable {
 
 		this._metaRow.style.display = hasMeta ? '' : 'none';
 		this._onDidChangeHeight.fire();
-	}
-
-	/**
-	 * The status-based icon shown next to the session title. Mirrors the icon logic used by
-	 * the sessions list (`SessionsListRenderer.getStatusIcon`) so both surfaces stay in sync.
-	 * Replicated inline because the list renderer lives in the `contrib/` layer, which the
-	 * core `browser/parts/` layer must not import from.
-	 */
-	private _getStatusIcon(status: SessionStatus, isRead: boolean, isArchived: boolean, pullRequestIcon?: ThemeIcon): ThemeIcon {
-		switch (status) {
-			case SessionStatus.InProgress:
-				return { ...Codicon.sessionInProgress, color: themeColorFromId('textLink.foreground') };
-			case SessionStatus.NeedsInput:
-				return { ...Codicon.circleFilled, color: themeColorFromId('list.warningForeground') };
-			case SessionStatus.Error:
-				return { ...Codicon.error, color: themeColorFromId('errorForeground') };
-			default:
-				if (pullRequestIcon) {
-					return pullRequestIcon;
-				}
-				if (!isRead && !isArchived) {
-					return { ...Codicon.circleFilled, color: themeColorFromId('textLink.foreground') };
-				}
-				return { ...Codicon.circleSmallFilled, color: themeColorFromId('agentSessionReadIndicator.foreground') };
-		}
 	}
 
 	private _setVisible(visible: boolean): void {

--- a/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
@@ -22,6 +22,7 @@ import { CanGoBackContext, CanGoForwardContext, MultipleSessionsVisibleContext, 
 import { IActiveSession, ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ISession } from '../../../services/sessions/common/session.js';
 import { ISessionsPartService } from '../../../browser/parts/sessionsPartService.js';
+import { ISessionsListModelService } from '../../../services/sessions/browser/sessionsListModelService.js';
 
 // -- Show Sessions Picker --
 
@@ -47,10 +48,11 @@ registerAction2(class ShowSessionsPickerAction extends Action2 {
 		const sessionsManagementService = accessor.get(ISessionsManagementService);
 		const quickInputService = accessor.get(IQuickInputService);
 		const sessionsPartService = accessor.get(ISessionsPartService);
+		const sessionsListModelService = accessor.get(ISessionsListModelService);
 
-		const sessions = sessionsManagementService.getSessions()
-			.filter(s => !s.isArchived.get())
-			.sort((a, b) => b.updatedAt.get().getTime() - a.updatedAt.get().getTime());
+		const { recent, other } = sessionsManagementService.getRecentlyOpenedSessions();
+		const recentSessions = recent.filter(s => !s.isArchived.get());
+		const otherSessions = other.filter(s => !s.isArchived.get());
 
 		const activeSessionId = sessionsManagementService.activeSession.get()?.sessionId;
 
@@ -66,47 +68,111 @@ registerAction2(class ShowSessionsPickerAction extends Action2 {
 			session: undefined,
 		});
 
-		if (sessions.length > 0) {
-			items.push({ type: 'separator', label: localize('recentSessions', "Recent Sessions") });
+		let activeItem: ISessionPickItem | undefined;
 
-			for (const session of sessions) {
-				const title = session.title.get() || localize('untitledSession', "New Session");
-				const workspace = session.workspace.get();
-				const parts: string[] = [];
-				if (workspace) {
-					parts.push(workspace.label);
-				}
-				parts.push(fromNow(session.updatedAt.get(), true, true));
+		const toPickItem = (session: ISession): ISessionPickItem => {
+			const title = session.title.get() || localize('untitledSession', "New Session");
 
-				items.push({
-					label: title,
-					description: parts.join(' \u00B7 '),
-					iconClass: ThemeIcon.asClassName(session.icon),
-					session,
-					picked: activeSessionId !== undefined && session.sessionId === activeSessionId,
-				});
+			// Status icon, mirroring the sessions list and session header. Use the
+			// list model service's read state (not session.isRead) so the icon
+			// matches what the sessions list shows.
+			const status = session.status.get();
+			const isRead = sessionsListModelService.isSessionRead(session);
+			const isArchived = session.isArchived.get();
+			const workspace = session.workspace.get();
+			const pullRequestIcon = workspace?.folders[0]?.gitRepository?.gitHubInfo.get()?.pullRequest?.icon;
+			const icon = sessionsListModelService.getStatusIcon(status, isRead, isArchived, pullRequestIcon);
+
+			// Second row: workspace (with its icon, like the session header /
+			// list) and the relative time. A leading blank icon aligns the
+			// workspace icon under the title text (the status icon sits in the
+			// left gutter).
+			const detailParts: string[] = [];
+			if (workspace?.label) {
+				const isWorkspaceFolder = workspace.folders.length > 0 && workspace.folders[0]?.gitRepository?.workTreeUri === undefined;
+				const workspaceIcon = workspace.isVirtualWorkspace ? Codicon.cloud : isWorkspaceFolder ? Codicon.folder : Codicon.worktree;
+				detailParts.push(`$(${Codicon.blank.id}) $(${workspaceIcon.id}) ${workspace.label}`);
+			} else {
+				detailParts.push(`$(${Codicon.blank.id})`);
+			}
+			detailParts.push(fromNow(session.updatedAt.get(), true, true));
+
+			const isActive = activeSessionId !== undefined && session.sessionId === activeSessionId;
+			const item: ISessionPickItem = {
+				label: title,
+				detail: detailParts.join(' \u00B7 '),
+				iconClass: ThemeIcon.asClassName(icon),
+				session,
+				picked: isActive,
+			};
+			if (isActive) {
+				activeItem = item;
+			}
+			return item;
+		};
+
+		if (recentSessions.length > 0) {
+			items.push({ type: 'separator', label: localize('recentlyOpened', "recently opened") });
+			for (const session of recentSessions) {
+				items.push(toPickItem(session));
+			}
+		}
+
+		if (otherSessions.length > 0) {
+			items.push({ type: 'separator', label: localize('otherSessions', "other sessions") });
+			for (const session of otherSessions) {
+				items.push(toPickItem(session));
 			}
 		}
 
 		const picker = quickInputService.createQuickPick<ISessionPickItem>({ useSeparators: true });
 		picker.items = items;
-		picker.placeholder = localize('searchSessions', "Search sessions by name");
+		picker.placeholder = localize('searchSessions', "Search sessions by name or folder");
 		picker.canAcceptInBackground = true;
+		// Keep the picker open when a background accept moves focus to the opened
+		// session, so the user can continue navigating. It is still dismissed
+		// explicitly on a foreground accept (Enter) or Escape.
+		picker.ignoreFocusOut = true;
+		// Match on the detail row too so sessions can be found by their folder.
+		picker.matchOnDetail = true;
+
+		// Default to the currently active session so it is selected on open.
+		if (activeItem) {
+			picker.activeItems = [activeItem];
+		}
 
 		const disposables = new DisposableStore();
 		disposables.add(picker);
 
-		disposables.add(picker.onDidAccept(() => {
+		const openSelected = (selected: ISessionPickItem, inBackground: boolean, toSide: boolean): void => {
+			if (!selected.session) {
+				sessionsManagementService.openNewSessionView();
+				sessionsPartService.focusSession(sessionsManagementService.activeSession.get());
+				return;
+			}
+
+			// Open to the side: place the session in a new grid slot next to the
+			// currently active session instead of replacing it. Falls back to a
+			// normal open when there is no active session to anchor against or the
+			// session is already the active one.
+			if (toSide && activeSessionId !== undefined && selected.session.sessionId !== activeSessionId) {
+				sessionsManagementService.insertAt(selected.session, activeSessionId, 'right', !inBackground);
+			} else {
+				sessionsManagementService.openSession(selected.session.resource, { preserveFocus: inBackground });
+			}
+		};
+
+		disposables.add(picker.onDidAccept(e => {
 			const [selected] = picker.selectedItems;
 			if (selected) {
-				if (selected.session) {
-					sessionsManagementService.openSession(selected.session.resource);
-				} else {
-					sessionsManagementService.openNewSessionView();
-					sessionsPartService.focusSession(sessionsManagementService.activeSession.get());
-				}
+				const toSide = picker.keyMods.ctrlCmd || picker.keyMods.alt;
+				openSelected(selected, e.inBackground, toSide);
 			}
-			picker.hide();
+			// Background accept (e.g. Right Arrow) keeps the picker open so the
+			// user can continue navigating, mirroring editor quick open.
+			if (!e.inBackground) {
+				picker.hide();
+			}
 		}));
 		disposables.add(picker.onDidHide(() => disposables.dispose()));
 

--- a/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
@@ -10,9 +10,6 @@ import { MarshalledId } from '../../../../base/common/marshallingIds.js';
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { StandardMouseEvent } from '../../../../base/browser/mouseEvent.js';
 import { localize } from '../../../../nls.js';
-import { HoverStyle } from '../../../../base/browser/ui/hover/hover.js';
-import { HoverPosition } from '../../../../base/browser/ui/hover/hoverWidget.js';
-import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { BaseActionViewItem, IBaseActionViewItemOptions } from '../../../../base/browser/ui/actionbar/actionViewItems.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IMenuService, MenuItemAction, MenuRegistry, SubmenuItemAction } from '../../../../platform/actions/common/actions.js';
@@ -27,12 +24,10 @@ import { ThemeIcon } from '../../../../base/common/themables.js';
 import { IsAuxiliaryWindowContext } from '../../../../workbench/common/contextkeys.js';
 import { ChatSessionProviderIdContext, SessionsWelcomeVisibleContext } from '../../../common/contextkeys.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
-import { ISessionsListModelService } from './views/sessionsListModelService.js';
+import { ISessionsListModelService } from '../../../services/sessions/browser/sessionsListModelService.js';
 import { SHOW_SESSIONS_PICKER_COMMAND_ID } from './sessionsActions.js';
 import { IsSessionArchivedContext, IsSessionPinnedContext, IsSessionReadContext, SessionItemContextMenuId, SessionItemHasBranchNameContext } from './views/sessionsList.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
-import { IMarkdownString, MarkdownString } from '../../../../base/common/htmlContent.js';
-import { buildSessionHoverContent } from './sessionHoverContent.js';
 
 /**
  * Sessions Title Bar Widget - renders the active chat session
@@ -61,7 +56,6 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 	constructor(
 		action: SubmenuItemAction,
 		options: IBaseActionViewItemOptions | undefined,
-		@IHoverService private readonly hoverService: IHoverService,
 		@ISessionsManagementService private readonly sessionsManagementService: ISessionsManagementService,
 		@ISessionsListModelService private readonly sessionsListModelService: ISessionsListModelService,
 		@IContextMenuService private readonly contextMenuService: IContextMenuService,
@@ -199,14 +193,6 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 
 			this._container.appendChild(sessionPill);
 
-			// Beacon-style hover with session details, positioned below center
-			this._dynamicDisposables.add(this.hoverService.setupDelayedHover(sessionPill, () => ({
-				content: this._buildSessionHoverContent(),
-				style: HoverStyle.Pointer,
-				position: { hoverPosition: HoverPosition.BELOW },
-				persistence: { hideOnHover: false },
-			})));
-
 			// Keyboard handler
 			this._dynamicDisposables.add(addDisposableListener(this._container, EventType.KEY_DOWN, (e: KeyboardEvent) => {
 				if (e.key === 'Enter' || e.key === ' ') {
@@ -229,17 +215,6 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 			return sessionData.icon;
 		}
 		return undefined;
-	}
-
-	/**
-	 * Build a compact hover markdown for the active session.
-	 */
-	private _buildSessionHoverContent(): IMarkdownString {
-		const sessionData = this.sessionsManagementService.activeSession.get();
-		if (!sessionData) {
-			return new MarkdownString('');
-		}
-		return buildSessionHoverContent(sessionData, this.sessionsProvidersService);
 	}
 
 	/**

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -18,7 +18,7 @@ import { createMatches, FuzzyScore, IMatch } from '../../../../../base/common/fi
 import { Disposable, DisposableStore, MutableDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { MarkdownString } from '../../../../../base/common/htmlContent.js';
 import { IObservable, IReader, autorun, observableSignalFromEvent } from '../../../../../base/common/observable.js';
-import { ThemeIcon, themeColorFromId } from '../../../../../base/common/themables.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { fromNow } from '../../../../../base/common/date.js';
 import { disposableTimeout } from '../../../../../base/common/async.js';
@@ -48,7 +48,7 @@ import { HoverPosition } from '../../../../../base/browser/ui/hover/hoverWidget.
 import { ISessionsManagementService, IActiveSession } from '../../../../services/sessions/common/sessionsManagement.js';
 import { IAgentSessionsService } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentSessionsService.js';
 import { IAccessibilityService } from '../../../../../platform/accessibility/common/accessibility.js';
-import { ISessionsListModelService } from './sessionsListModelService.js';
+import { ISessionsListModelService } from '../../../../services/sessions/browser/sessionsListModelService.js';
 import { IAgentHostFilterService } from '../../../../services/agentHostFilter/common/agentHostFilter.js';
 import { LocalSelectionTransfer } from '../../../../../platform/dnd/browser/dnd.js';
 import { DraggedSessionIdentifier, SessionsDataTransfers } from '../../../../browser/dnd.js';
@@ -253,7 +253,7 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 	private readonly _motionReducedSignal;
 
 	constructor(
-		private readonly options: { grouping: () => SessionsGrouping; sorting: () => SessionsSorting; isPinned: (session: ISession) => boolean; isRead: (session: ISession) => boolean; visibleSessions: IObservable<readonly (IActiveSession | undefined)[]> },
+		private readonly options: { grouping: () => SessionsGrouping; sorting: () => SessionsSorting; isPinned: (session: ISession) => boolean; isRead: (session: ISession) => boolean; getStatusIcon: (status: SessionStatus, isRead: boolean, isArchived: boolean, pullRequestIcon?: ThemeIcon) => ThemeIcon; visibleSessions: IObservable<readonly (IActiveSession | undefined)[]> },
 		private readonly approvalModel: AgentSessionApprovalModel | undefined,
 		private readonly instantiationService: IInstantiationService,
 		private readonly contextKeyService: IContextKeyService,
@@ -412,7 +412,7 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 					recolorActiveIcon(iconColor);
 				}
 			} else {
-				const icon = this.getStatusIcon(sessionStatus, isRead, isArchived, gitHubInfo?.pullRequest?.icon);
+				const icon = this.options.getStatusIcon(sessionStatus, isRead, isArchived, gitHubInfo?.pullRequest?.icon);
 				const iconSelector = ThemeIcon.asCSSSelector(icon);
 				const iconColor = icon.color ? asCssVariable(icon.color.id) : '';
 				const swapped = applyIconSwap(iconSelector, () => {
@@ -635,28 +635,6 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 				this._onDidChangeItemHeight.fire(element);
 			}
 		}));
-	}
-
-	private getStatusIcon(status: SessionStatus, isRead: boolean, isArchived: boolean, pullRequestIcon?: ThemeIcon): ThemeIcon {
-		switch (status) {
-			case SessionStatus.InProgress:
-				// When motion is allowed, the pixel spinner is rendered directly in renderSession
-				// and this method is not consulted; here we only provide the reduced-motion fallback.
-				return { ...Codicon.sessionInProgress, color: themeColorFromId('textLink.foreground') };
-			case SessionStatus.NeedsInput:
-				// Same as above — pixel spinner replaces the pulsing dot when motion is allowed.
-				return { ...Codicon.circleFilled, color: themeColorFromId('list.warningForeground') };
-			case SessionStatus.Error: return { ...Codicon.error, color: themeColorFromId('errorForeground') };
-			default:
-				if (pullRequestIcon) {
-					return pullRequestIcon;
-				}
-
-				if (!isRead && !isArchived) {
-					return { ...Codicon.circleFilled, color: themeColorFromId('textLink.foreground') };
-				}
-				return { ...Codicon.circleSmallFilled, color: themeColorFromId('agentSessionReadIndicator.foreground') };
-		}
 	}
 
 	private getWorkspaceBadgeLabel(workspace: ISessionWorkspace): string | undefined {
@@ -1033,7 +1011,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 		const accessibilityService = instantiationService.invokeFunction(accessor => accessor.get(IAccessibilityService));
 		const sessionsProvidersService = instantiationService.invokeFunction(accessor => accessor.get(ISessionsProvidersService));
 		const sessionRenderer = new SessionItemRenderer(
-			{ grouping: this.options.grouping, sorting: this.options.sorting, isPinned: s => this.isSessionPinned(s), isRead: s => this.isSessionRead(s), visibleSessions: this._sessionsManagementService.visibleSessions },
+			{ grouping: this.options.grouping, sorting: this.options.sorting, isPinned: s => this.isSessionPinned(s), isRead: s => this.isSessionRead(s), getStatusIcon: (status, isRead, isArchived, pullRequestIcon) => this._sessionsListModelService.getStatusIcon(status, isRead, isArchived, pullRequestIcon), visibleSessions: this._sessionsManagementService.visibleSessions },
 			approvalModel,
 			instantiationService,
 			contextKeyService,

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
@@ -26,7 +26,7 @@ import { ISession, SessionStatus } from '../../../../services/sessions/common/se
 import { IsWorkspaceGroupCappedContext, SessionsViewFilterOptionsSubMenu, SessionsViewFilterSubMenu, SessionsViewGroupingContext, SessionsViewId, SessionsView, SessionsViewSortingContext, openSessionToTheSide } from './sessionsView.js';
 import { Menus } from '../../../../browser/menus.js';
 import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
-import { ISessionsListModelService } from './sessionsListModelService.js';
+import { ISessionsListModelService } from '../../../../services/sessions/browser/sessionsListModelService.js';
 import { ChatContextKeys } from '../../../../../workbench/contrib/chat/common/actions/chatContextKeys.js';
 import { ActiveSessionContextKeys } from '../../../changes/common/changes.js';
 import { hasActiveSessionFailedCIChecks } from '../../../changes/browser/checksActions.js';

--- a/src/vs/sessions/services/sessions/browser/sessionNavigation.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionNavigation.ts
@@ -4,34 +4,40 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable } from '../../../../base/common/lifecycle.js';
-import { autorun, derived, IObservable, observableValue } from '../../../../base/common/observable.js';
+import { autorun, derived, IObservable, IReader, observableValue } from '../../../../base/common/observable.js';
 import { URI } from '../../../../base/common/uri.js';
 import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { CanGoBackContext, CanGoForwardContext } from '../../../common/contextkeys.js';
 import { SessionStatus } from '../common/session.js';
 import { ISessionsChangeEvent, ISessionsManagementService } from '../common/sessionsManagement.js';
+import { IRecencyEntry, SessionsRecencyHistory } from './sessionsRecencyHistory.js';
 
-const MAX_HISTORY_SIZE = 50;
-
-/**
- * A navigation history entry. Stores the session and optionally the chat
- * resource URI so that back/forward also restores the active chat.
- */
-interface INavigationEntry {
-	readonly sessionResource: URI;
-	readonly chatResource: URI | undefined;
+function entryKey(sessionResource: URI, chatResource: URI | undefined): string {
+	return `${sessionResource.toString()}::${chatResource?.toString() ?? ''}`;
 }
 
 /**
- * Tracks session navigation history and provides back/forward navigation.
- * Created and owned by {@link SessionsManagementService}.
+ * Provides Back/Forward navigation over the shared session recency history
+ * ({@link SessionsRecencyHistory}). Created and owned by
+ * {@link SessionsManagementService}.
+ *
+ * The recency history is the single source of truth for ordering. Navigation
+ * keeps only a cursor (the currently-navigated entry) and walks the history:
+ * - Going Back/Forward moves the cursor over the existing order; it never
+ *   re-promotes entries (that would break Forward).
+ * - Only explicit opens (recorded by the feeder autorun via
+ *   {@link SessionsRecencyHistory.markOpened}) re-promote an entry to the front
+ *   and reset the cursor to it.
+ *
+ * Because the history is MRU-ordered and not truncated, going somewhere new
+ * after a Back does not discard the previously-newer entries; they remain
+ * reachable as older entries (Alt+Tab-style rather than browser-style).
  */
 export class SessionsNavigation extends Disposable {
 
-	private readonly _history: INavigationEntry[] = [];
-	private readonly _currentIndex = observableValue<number>(this, -1);
-	private readonly _historySize = observableValue<number>(this, 0);
+	/** Identity of the entry the cursor currently points at. */
+	private readonly _currentKey = observableValue<string | undefined>(this, undefined);
 
 	/** Guard: true while we are performing a back/forward navigation. */
 	private _navigating = false;
@@ -39,7 +45,7 @@ export class SessionsNavigation extends Disposable {
 	/**
 	 * True when the user has explicitly navigated to the new-session view after
 	 * having been on a real session. Enables going back to the last real session
-	 * without storing a new-session view entry in the history stack.
+	 * without storing a new-session view entry in the history.
 	 */
 	private readonly _beyondHistory = observableValue<boolean>(this, false);
 
@@ -47,20 +53,22 @@ export class SessionsNavigation extends Disposable {
 	private readonly _canGoForwardCtx: IContextKey<boolean>;
 
 	private readonly _canGoBack: IObservable<boolean> = derived(this, reader => {
-		const idx = this._currentIndex.read(reader);
+		const idx = this._indexOfCurrent(reader);
+		const entries = this._recency.entries;
 		const beyond = this._beyondHistory.read(reader);
-		return idx > 0 || (beyond && idx >= 0);
+		return (idx >= 0 && idx < entries.length - 1) || (beyond && entries.length > 0);
 	});
 
 	private readonly _canGoForward: IObservable<boolean> = derived(this, reader => {
 		if (this._beyondHistory.read(reader)) {
 			return false;
 		}
-		return this._currentIndex.read(reader) < this._historySize.read(reader) - 1;
+		return this._indexOfCurrent(reader) > 0;
 	});
 
 	constructor(
 		private readonly _sessionsManagementService: ISessionsManagementService,
+		private readonly _recency: SessionsRecencyHistory,
 		contextKeyService: IContextKeyService,
 		private readonly _logService: ILogService,
 	) {
@@ -69,7 +77,7 @@ export class SessionsNavigation extends Disposable {
 		this._canGoBackCtx = CanGoBackContext.bindTo(contextKeyService);
 		this._canGoForwardCtx = CanGoForwardContext.bindTo(contextKeyService);
 
-		// Track active session/chat changes to record history entries.
+		// Track active session/chat changes to record recency entries.
 		// Skip undefined (new-session view) and Untitled sessions — only record
 		// sessions that have been saved/submitted. Also tracks active chat changes
 		// within a session so that switching chats is navigable.
@@ -86,7 +94,7 @@ export class SessionsNavigation extends Disposable {
 			if (!activeSession || sessionStatus === SessionStatus.Untitled) {
 				// User navigated to new-session view: if we have history, remember we're
 				// beyond the stack so Back can return to the last real session.
-				if (this._history.length > 0) {
+				if (this._recency.entries.length > 0) {
 					this._beyondHistory.set(true, undefined);
 				}
 				return;
@@ -98,7 +106,22 @@ export class SessionsNavigation extends Disposable {
 				: undefined;
 
 			this._beyondHistory.set(false, undefined);
-			this._pushEntry({ sessionResource: activeSession.resource, chatResource });
+			this._recency.markOpened(activeSession.resource, chatResource);
+			this._currentKey.set(entryKey(activeSession.resource, chatResource), undefined);
+		}));
+
+		// Reconcile the cursor when entries are removed externally (e.g. a
+		// session deletion). If the current entry is gone, fall back to the most
+		// recent remaining entry.
+		this._register(autorun(reader => {
+			this._recency.version.read(reader);
+			// Untracked: we react to entry changes (version) only, not to our own
+			// cursor writes below, which would otherwise re-trigger this autorun.
+			const key = this._currentKey.read(undefined);
+			if (key !== undefined && this._indexOf(key) < 0) {
+				const front = this._recency.entries[0];
+				this._currentKey.set(front ? entryKey(front.sessionResource, front.chatResource) : undefined, undefined);
+			}
 		}));
 
 		// Sync context keys with observables
@@ -113,67 +136,50 @@ export class SessionsNavigation extends Disposable {
 			return;
 		}
 		const removedUris = new Set(e.removed.map(s => s.resource.toString()));
-		this._removeEntriesMatching(uri => removedUris.has(uri.toString()));
+		this._recency.remove(entry => removedUris.has(entry.sessionResource.toString()));
 	}
 
 	async goBack(): Promise<void> {
 		if (this._beyondHistory.get()) {
 			// User is on new-session view — go back to the last real session
 			this._beyondHistory.set(false, undefined);
-			await this._navigateTo(this._currentIndex.get());
+			const idx = this._indexOfCurrent();
+			await this._navigateTo(idx < 0 ? 0 : idx);
 			return;
 		}
-		const idx = this._currentIndex.get();
+		const idx = this._indexOfCurrent();
+		if (idx < 0 || idx >= this._recency.entries.length - 1) {
+			return;
+		}
+		await this._navigateTo(idx + 1);
+	}
+
+	async goForward(): Promise<void> {
+		const idx = this._indexOfCurrent();
 		if (idx <= 0) {
 			return;
 		}
 		await this._navigateTo(idx - 1);
 	}
 
-	async goForward(): Promise<void> {
-		const idx = this._currentIndex.get();
-		if (idx >= this._history.length - 1) {
-			return;
+	/** Index of the current cursor entry in the recency history, or -1. */
+	private _indexOfCurrent(reader?: IReader): number {
+		const key = reader ? this._currentKey.read(reader) : this._currentKey.get();
+		if (reader) {
+			this._recency.version.read(reader);
 		}
-		await this._navigateTo(idx + 1);
+		if (key === undefined) {
+			return -1;
+		}
+		return this._indexOf(key);
 	}
 
-	private _pushEntry(entry: INavigationEntry): void {
-		const currentIdx = this._currentIndex.get();
-
-		// Check if the new entry is the same as the current one
-		if (currentIdx >= 0 && currentIdx < this._history.length) {
-			const current = this._history[currentIdx];
-			if (this._isSameEntry(current, entry)) {
-				return;
-			}
-		}
-
-		// Truncate forward history
-		if (currentIdx < this._history.length - 1) {
-			this._history.splice(currentIdx + 1);
-		}
-
-		// Remove any existing entry for the same session to avoid duplicates
-		const existingIdx = this._history.findIndex(e => this._isSameEntry(e, entry));
-		if (existingIdx >= 0) {
-			this._history.splice(existingIdx, 1);
-		}
-
-		// Enforce max size by removing oldest entries
-		if (this._history.length >= MAX_HISTORY_SIZE) {
-			this._history.splice(0, this._history.length - MAX_HISTORY_SIZE + 1);
-		}
-
-		this._history.push(entry);
-		this._currentIndex.set(this._history.length - 1, undefined);
-		this._historySize.set(this._history.length, undefined);
-
-		this._logService.trace(`[SessionNavigation] pushed entry idx=${this._history.length - 1} session=${entry.sessionResource.toString()} chat=${entry.chatResource?.toString()} historySize=${this._history.length}`);
+	private _indexOf(key: string): number {
+		return this._recency.entries.findIndex(e => entryKey(e.sessionResource, e.chatResource) === key);
 	}
 
 	private async _navigateTo(targetIdx: number): Promise<void> {
-		const entry = this._history[targetIdx];
+		const entry: IRecencyEntry | undefined = this._recency.entries[targetIdx];
 		if (!entry) {
 			return;
 		}
@@ -182,7 +188,7 @@ export class SessionsNavigation extends Disposable {
 
 		this._navigating = true;
 		try {
-			this._currentIndex.set(targetIdx, undefined);
+			this._currentKey.set(entryKey(entry.sessionResource, entry.chatResource), undefined);
 
 			const session = this._sessionsManagementService.getSession(entry.sessionResource);
 			if (session) {
@@ -197,49 +203,12 @@ export class SessionsNavigation extends Disposable {
 					await this._sessionsManagementService.openSession(entry.sessionResource);
 				}
 			} else {
-				// Session no longer exists, remove from history
-				this._history.splice(targetIdx, 1);
-				this._historySize.set(this._history.length, undefined);
-				if (targetIdx <= this._currentIndex.get()) {
-					this._currentIndex.set(Math.max(0, this._currentIndex.get() - 1), undefined);
-				}
+				// Session no longer exists, remove its entries from history
+				const sessionUri = entry.sessionResource.toString();
+				this._recency.remove(e => e.sessionResource.toString() === sessionUri);
 			}
 		} finally {
 			this._navigating = false;
 		}
-	}
-
-	private _isSameEntry(a: INavigationEntry, b: INavigationEntry): boolean {
-		if (a.sessionResource.toString() !== b.sessionResource.toString()) {
-			return false;
-		}
-		const aChatStr = a.chatResource?.toString();
-		const bChatStr = b.chatResource?.toString();
-		return aChatStr === bChatStr;
-	}
-
-	private _removeEntriesMatching(predicate: (uri: URI) => boolean): void {
-		const currentIdx = this._currentIndex.get();
-		let newCurrentIdx = currentIdx;
-		let i = 0;
-
-		while (i < this._history.length) {
-			const entry = this._history[i];
-			if (predicate(entry.sessionResource)) {
-				this._history.splice(i, 1);
-				if (i < newCurrentIdx) {
-					newCurrentIdx--;
-				} else if (i === newCurrentIdx) {
-					newCurrentIdx = Math.min(newCurrentIdx, this._history.length - 1);
-				}
-			} else {
-				i++;
-			}
-		}
-
-		if (newCurrentIdx !== currentIdx) {
-			this._currentIndex.set(Math.max(0, newCurrentIdx), undefined);
-		}
-		this._historySize.set(this._history.length, undefined);
 	}
 }

--- a/src/vs/sessions/services/sessions/browser/sessionsListModelService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsListModelService.ts
@@ -3,13 +3,15 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Emitter, Event } from '../../../../../base/common/event.js';
-import { Disposable } from '../../../../../base/common/lifecycle.js';
-import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
-import { InstantiationType, registerSingleton } from '../../../../../platform/instantiation/common/extensions.js';
-import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
-import { ISession, SessionStatus } from '../../../../services/sessions/common/session.js';
-import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
+import { Emitter, Event } from '../../../../base/common/event.js';
+import { Codicon } from '../../../../base/common/codicons.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { ThemeIcon, themeColorFromId } from '../../../../base/common/themables.js';
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+import { ISession, SessionStatus } from '../common/session.js';
+import { ISessionsManagementService } from '../common/sessionsManagement.js';
 
 export const enum SessionListModelChangeKind {
 	Pinned = 'pinned',
@@ -45,6 +47,19 @@ export interface ISessionsListModelService {
 	markUnread(session: ISession): void;
 	isSessionRead(session: ISession): boolean;
 	markAllRead(sessions: ISession[]): void;
+
+	// -- Status icon --
+
+	/**
+	 * The status-based icon shown next to a session's title across the sessions
+	 * UI (sessions list, sessions picker, session header). Centralized here so
+	 * all surfaces stay in sync.
+	 *
+	 * Note: when motion is allowed, the sessions list renders a pixel spinner for
+	 * the `InProgress`/`NeedsInput` states instead of consulting this method; the
+	 * icons returned here are the reduced-motion fallbacks.
+	 */
+	getStatusIcon(status: SessionStatus, isRead: boolean, isArchived: boolean, pullRequestIcon?: ThemeIcon): ThemeIcon;
 }
 
 export const ISessionsListModelService = createDecorator<ISessionsListModelService>('sessionsListModelService');
@@ -177,6 +192,27 @@ export class SessionsListModelService extends Disposable implements ISessionsLis
 		if (changed.length > 0) {
 			this.saveSet(SessionsListModelService.READ_SESSIONS_KEY, this._readSessionIds);
 			this._onDidChange.fire({ changes: changed });
+		}
+	}
+
+	// -- Status icon --
+
+	getStatusIcon(status: SessionStatus, isRead: boolean, isArchived: boolean, pullRequestIcon?: ThemeIcon): ThemeIcon {
+		switch (status) {
+			case SessionStatus.InProgress:
+				return { ...Codicon.sessionInProgress, color: themeColorFromId('textLink.foreground') };
+			case SessionStatus.NeedsInput:
+				return { ...Codicon.circleFilled, color: themeColorFromId('list.warningForeground') };
+			case SessionStatus.Error:
+				return { ...Codicon.error, color: themeColorFromId('errorForeground') };
+			default:
+				if (pullRequestIcon) {
+					return pullRequestIcon;
+				}
+				if (!isRead && !isArchived) {
+					return { ...Codicon.circleFilled, color: themeColorFromId('textLink.foreground') };
+				}
+				return { ...Codicon.circleSmallFilled, color: themeColorFromId('agentSessionReadIndicator.foreground') };
 		}
 	}
 

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -19,12 +19,13 @@ import { ChatAgentLocation } from '../../../../workbench/contrib/chat/common/con
 import { IChatWidgetHistoryService } from '../../../../workbench/contrib/chat/common/widget/chatWidgetHistoryService.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
 import { ActiveSessionProviderIdContext, ActiveSessionTypeContext, IsActiveSessionArchivedContext, ActiveSessionWorkspaceIsVirtualContext, IsNewChatSessionContext } from '../../../common/contextkeys.js';
-import { ActiveSessionSupportsMultiChatContext, IActiveSession, ICreateNewSessionOptions, IProviderSessionType, ISendRequestOptions, ISendRequestSentEvent, ISessionsChangeEvent, ISessionsManagementService, IToggleSessionStickinessEvent } from '../common/sessionsManagement.js';
+import { ActiveSessionSupportsMultiChatContext, IActiveSession, ICreateNewSessionOptions, IProviderSessionType, IRecentlyOpenedSessions, ISendRequestOptions, ISendRequestSentEvent, ISessionsChangeEvent, ISessionsManagementService, IToggleSessionStickinessEvent } from '../common/sessionsManagement.js';
 import { ISessionsProvidersChangeEvent, ISessionsProvidersService } from './sessionsProvidersService.js';
 import { ISessionChangeEvent, ISessionsProvider } from '../common/sessionsProvider.js';
 import { IChat, ISession, ISessionWorkspace, SessionStatus, ISessionType } from '../common/session.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { SessionsNavigation } from './sessionNavigation.js';
+import { SessionsRecencyHistory } from './sessionsRecencyHistory.js';
 import { VisibleSessions } from './visibleSessions.js';
 
 const ACTIVE_SESSION_STATES_KEY = 'agentSessions.activeSessionStates';
@@ -36,6 +37,9 @@ const ACTIVE_SESSION_STATES_KEY = 'agentSessions.activeSessionStates';
  * listeners — alive indefinitely.
  */
 const RESTORE_SESSION_WAIT_TIMEOUT = 30_000;
+
+/** Maximum number of recently opened sessions reported by {@link SessionsManagementService.getRecentlyOpenedSessions}. */
+const MAX_RECENTLY_OPENED_SESSIONS = 10;
 
 /**
  * Persisted state for a session.
@@ -118,6 +122,13 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 	private readonly _providerListeners = this._register(new DisposableMap<string, IDisposable>());
 	private readonly _sessionStates: ResourceMap<ISessionState>;
 	private readonly _navigation: SessionsNavigation;
+	/**
+	 * The single source of truth for session recency (most-recently-opened
+	 * first), persisted across restarts. Both the recent-sessions picker (via
+	 * {@link getRecentlyOpenedSessions}) and {@link SessionsNavigation} build on
+	 * top of it.
+	 */
+	private readonly _recencyHistory: SessionsRecencyHistory;
 
 	/**
 	 * Chat resources for which this service has just kicked off a
@@ -173,13 +184,22 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 		this._subscribeToProviders(this.sessionsProvidersService.getProviders());
 		this._sessionTypes = this._collectSessionTypes();
 
-		// Session navigation history
+		// Session recency history — the single source of truth for "recently
+		// opened" ordering, shared by the picker and navigation.
+		this._recencyHistory = this._register(new SessionsRecencyHistory(
+			this.storageService,
+			this.logService,
+		));
+
+		// Session navigation history (Back/Forward) builds on the recency history.
 		this._navigation = this._register(new SessionsNavigation(
 			this,
+			this._recencyHistory,
 			contextKeyService,
 			this.logService,
 		));
 		this._register(this.onDidChangeSessions(e => this._navigation.onDidRemoveSessions(e)));
+		this._register(this.onDidDeleteSession(session => this._recencyHistory.remove(entry => entry.sessionResource.toString() === session.resource.toString())));
 
 		this._register(autorun(reader => {
 			const activeSession = this._visibility.activeSession.read(reader);
@@ -365,6 +385,37 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 		return this.getSessions().find(s =>
 			this.uriIdentityService.extUri.isEqual(s.resource, resource)
 		);
+	}
+
+	getRecentlyOpenedSessions(): IRecentlyOpenedSessions {
+		const seen = new Set<string>();
+		const recent: ISession[] = [];
+
+		// Sessions in recency order (most-recently-opened first), deduplicated by
+		// session so a session with multiple opened chats appears only once and
+		// capped at the most recent {@link MAX_RECENTLY_OPENED_SESSIONS}.
+		for (const entry of this._recencyHistory.entries) {
+			if (recent.length >= MAX_RECENTLY_OPENED_SESSIONS) {
+				break;
+			}
+			const key = entry.sessionResource.toString();
+			if (seen.has(key)) {
+				continue;
+			}
+			seen.add(key);
+			const session = this.getSession(entry.sessionResource);
+			if (session) {
+				recent.push(session);
+			}
+		}
+
+		// Sessions that have not been included in the recently opened group,
+		// sorted by most recently updated first.
+		const other = this.getSessions()
+			.filter(s => !seen.has(s.resource.toString()))
+			.sort((a, b) => b.updatedAt.get().getTime() - a.updatedAt.get().getTime());
+
+		return { recent, other };
 	}
 
 	getAllSessionTypes(): ISessionType[] {

--- a/src/vs/sessions/services/sessions/browser/sessionsRecencyHistory.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsRecencyHistory.ts
@@ -1,0 +1,140 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { IObservable, observableValue } from '../../../../base/common/observable.js';
+import { URI } from '../../../../base/common/uri.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+
+/** A single recently-opened entry: a chat within a session, or a session when no specific chat applies. */
+export interface IRecencyEntry {
+	readonly sessionResource: URI;
+	readonly chatResource: URI | undefined;
+}
+
+interface ISerializedRecencyEntry {
+	readonly session: string;
+	readonly chat?: string;
+}
+
+/** Identity of an entry, used for de-duplication: a (session, chat) pair. */
+function entryKey(sessionResource: URI, chatResource: URI | undefined): string {
+	return `${sessionResource.toString()}::${chatResource?.toString() ?? ''}`;
+}
+
+/**
+ * The single source of truth for "recently opened" ordering across the sessions
+ * UI. Maintains an MRU-ordered list of `(session, chat)` entries (index 0 is the
+ * most recently opened), deduplicated by the `(session, chat)` pair and capped at
+ * {@link MAX_RECENCY_ENTRIES}. The list is persisted so recency survives reloads.
+ *
+ * Both the sessions picker (via
+ * {@link ISessionsManagementService.getRecentlyOpenedSessions}) and the
+ * Back/Forward navigation ({@link SessionsNavigation}) build on top of this.
+ */
+export class SessionsRecencyHistory extends Disposable {
+
+	private static readonly STORAGE_KEY = 'agentSessions.recencyHistory';
+	private static readonly MAX_RECENCY_ENTRIES = 50;
+
+	private _entries: IRecencyEntry[] = [];
+
+	private readonly _version = observableValue<number>(this, 0);
+
+	/** Bumped whenever {@link entries} changes, so observers can react. */
+	get version(): IObservable<number> {
+		return this._version;
+	}
+
+	/** The recency entries in MRU order (index 0 is the most recently opened). */
+	get entries(): readonly IRecencyEntry[] {
+		return this._entries;
+	}
+
+	constructor(
+		private readonly _storageService: IStorageService,
+		private readonly _logService: ILogService,
+	) {
+		super();
+
+		this._entries = this._load();
+	}
+
+	/**
+	 * Record that the given session (optionally a specific chat within it) was
+	 * explicitly opened, promoting it to the front of the MRU list.
+	 */
+	markOpened(sessionResource: URI, chatResource: URI | undefined): void {
+		const key = entryKey(sessionResource, chatResource);
+		const existingIndex = this._entries.findIndex(e => entryKey(e.sessionResource, e.chatResource) === key);
+		if (existingIndex === 0) {
+			// Already at the front: nothing to do.
+			return;
+		}
+
+		if (existingIndex > 0) {
+			this._entries.splice(existingIndex, 1);
+		}
+
+		this._entries.unshift({ sessionResource, chatResource });
+
+		if (this._entries.length > SessionsRecencyHistory.MAX_RECENCY_ENTRIES) {
+			this._entries.length = SessionsRecencyHistory.MAX_RECENCY_ENTRIES;
+		}
+
+		this._save();
+		this._bumpVersion();
+	}
+
+	/** Remove every entry matching the given predicate. */
+	remove(predicate: (entry: IRecencyEntry) => boolean): void {
+		const next = this._entries.filter(e => !predicate(e));
+		if (next.length === this._entries.length) {
+			return;
+		}
+		this._entries = next;
+		this._save();
+		this._bumpVersion();
+	}
+
+	private _bumpVersion(): void {
+		this._version.set(this._version.get() + 1, undefined);
+	}
+
+	private _load(): IRecencyEntry[] {
+		const raw = this._storageService.get(SessionsRecencyHistory.STORAGE_KEY, StorageScope.WORKSPACE);
+		if (!raw) {
+			return [];
+		}
+		try {
+			const parsed = JSON.parse(raw) as ISerializedRecencyEntry[];
+			if (!Array.isArray(parsed)) {
+				return [];
+			}
+			return parsed
+				.filter(e => e && typeof e.session === 'string')
+				.map(e => ({
+					sessionResource: URI.parse(e.session),
+					chatResource: e.chat ? URI.parse(e.chat) : undefined,
+				}));
+		} catch (error) {
+			this._logService.warn('[SessionsRecencyHistory] failed to parse persisted recency history', error);
+			return [];
+		}
+	}
+
+	private _save(): void {
+		if (this._entries.length === 0) {
+			this._storageService.remove(SessionsRecencyHistory.STORAGE_KEY, StorageScope.WORKSPACE);
+			return;
+		}
+		const serialized: ISerializedRecencyEntry[] = this._entries.map(e => ({
+			session: e.sessionResource.toString(),
+			chat: e.chatResource?.toString(),
+		}));
+		this._storageService.store(SessionsRecencyHistory.STORAGE_KEY, JSON.stringify(serialized), StorageScope.WORKSPACE, StorageTarget.MACHINE);
+	}
+}

--- a/src/vs/sessions/services/sessions/common/sessionsManagement.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsManagement.ts
@@ -101,6 +101,17 @@ export interface IActiveSession extends ISession {
 }
 
 /**
+ * Sessions split into recently opened and other (never opened) groups, used to
+ * populate the sessions picker.
+ */
+export interface IRecentlyOpenedSessions {
+	/** Sessions opened in this workspace, most recently opened first. */
+	readonly recent: ISession[];
+	/** Sessions never opened in this workspace, most recently updated first. */
+	readonly other: ISession[];
+}
+
+/**
  * An active session item extends IChatSessionItem with repository information.
  * - For agent session items: repository is the workingDirectory from metadata
  * - For new sessions: repository comes from the session option with id 'repository'
@@ -119,6 +130,18 @@ export interface ISessionsManagementService {
 	 * Get a session by its resource URI.
 	 */
 	getSession(resource: URI): ISession | undefined;
+
+	/**
+	 * Get all sessions from all registered providers, split into two groups:
+	 * - `recent`: sessions that have been opened in this workspace, ordered by
+	 *   how recently they were opened (most recently opened first), capped at a
+	 *   fixed maximum.
+	 * - `other`: the remaining sessions, sorted by their last update time (most
+	 *   recently updated first).
+	 *
+	 * Used to populate the sessions picker.
+	 */
+	getRecentlyOpenedSessions(): IRecentlyOpenedSessions;
 
 	/**
 	 * Get all session types from all registered providers.

--- a/src/vs/sessions/services/sessions/test/browser/sessionNavigation.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionNavigation.test.ts
@@ -10,10 +10,12 @@ import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { InMemoryStorageService } from '../../../../../platform/storage/common/storage.js';
 import { MockContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
-import { IActiveSession, ICreateNewSessionOptions, IProviderSessionType, ISessionsManagementService } from '../../common/sessionsManagement.js';
+import { IActiveSession, ICreateNewSessionOptions, IProviderSessionType, IRecentlyOpenedSessions, ISessionsManagementService } from '../../common/sessionsManagement.js';
 import { IChat, ISession, ISessionType, ISessionWorkspace, SessionStatus } from '../../common/session.js';
 import { SessionsNavigation } from '../../browser/sessionNavigation.js';
+import { SessionsRecencyHistory } from '../../browser/sessionsRecencyHistory.js';
 import { Event } from '../../../../../base/common/event.js';
 import { ISendRequestOptions } from '../../common/sessionsProvider.js';
 
@@ -134,6 +136,8 @@ class MockSessionStore implements ISessionsManagementService {
 
 	getSessions(): ISession[] { return [...this._sessions.values()]; }
 
+	getRecentlyOpenedSessions(): IRecentlyOpenedSessions { return { recent: [...this._sessions.values()], other: [] }; }
+
 	getSession(resource: URI): ISession | undefined {
 		return this._sessions.get(resource.toString());
 	}
@@ -202,8 +206,12 @@ suite('SessionsNavigation', () => {
 
 		contextKeyService = disposables.add(new MockContextKeyService());
 
+		const storageService = disposables.add(new InMemoryStorageService());
+		const recency = disposables.add(new SessionsRecencyHistory(storageService, new NullLogService()));
+
 		nav = disposables.add(new SessionsNavigation(
 			store,
+			recency,
 			contextKeyService,
 			new NullLogService(),
 		));
@@ -268,7 +276,7 @@ suite('SessionsNavigation', () => {
 		assert.strictEqual(canGoForward(), false);
 	});
 
-	test('navigating to a new session after goBack clears forward history', async () => {
+	test('opening a new session after goBack keeps older entries reachable (MRU, no truncation)', async () => {
 		const s1 = stubSession('s1');
 		const s2 = stubSession('s2');
 		const s3 = stubSession('s3');
@@ -276,24 +284,29 @@ suite('SessionsNavigation', () => {
 		store.addSession(s2);
 		store.addSession(s3);
 
-		store.setActiveSession(s1);
-		store.setActiveSession(s2);
+		store.setActiveSession(s1); // recency=[s1]
+		store.setActiveSession(s2); // recency=[s2, s1], cursor=s2
 
-		await nav.goBack();
-		// Now navigate to s3 instead of going forward
+		await nav.goBack(); // cursor=s1
+		// Now open s3 explicitly: s3 is promoted to the front -> recency=[s3, s2, s1]
 		store.setActiveSession(s3);
 
 		assert.strictEqual(canGoBack(), true);
 		assert.strictEqual(canGoForward(), false);
 
-		// Going back should go to s1 (s2 is no longer in forward history)
+		// Unlike browser-style truncation, s2 is NOT discarded; going back from
+		// s3 lands on the next most-recent entry, s2.
+		await nav.goBack();
+		assert.strictEqual(store.lastOpenedResource?.toString(), s2.resource.toString());
+
+		// And s1 remains reachable one step further back.
 		await nav.goBack();
 		assert.strictEqual(store.lastOpenedResource?.toString(), s1.resource.toString());
 	});
 
-	test('reopening an earlier session removes it from history and appends at end (no duplicates)', async () => {
-		// Regression: A→B→C, back→back→fwd→fwd, open A again
-		// should produce history [B,C,A] not [A,B,C,A]
+	test('reopening an earlier session moves it to the front of recency (no duplicates)', async () => {
+		// A→B→C, back→back→fwd→fwd, open A again
+		// should move A to the front: recency=[A,C,B] (no duplicate A)
 		const s1 = stubSession('s1');
 		const s2 = stubSession('s2');
 		const s3 = stubSession('s3');
@@ -301,16 +314,16 @@ suite('SessionsNavigation', () => {
 		store.addSession(s2);
 		store.addSession(s3);
 
-		store.setActiveSession(s1); // history=[s1], idx=0
-		store.setActiveSession(s2); // history=[s1,s2], idx=1
-		store.setActiveSession(s3); // history=[s1,s2,s3], idx=2
+		store.setActiveSession(s1); // recency=[s1]
+		store.setActiveSession(s2); // recency=[s2,s1]
+		store.setActiveSession(s3); // recency=[s3,s2,s1]
 
-		await nav.goBack();  // idx=1
-		await nav.goBack();  // idx=0
-		await nav.goForward(); // idx=1
-		await nav.goForward(); // idx=2
+		await nav.goBack();  // cursor=s2
+		await nav.goBack();  // cursor=s1
+		await nav.goForward(); // cursor=s2
+		await nav.goForward(); // cursor=s3
 
-		// Now open s1 again — should deduplicate: history=[s2,s3,s1]
+		// Now open s1 again — moves to front: recency=[s1,s3,s2]
 		store.setActiveSession(s1);
 
 		// Back once: s3

--- a/src/vs/sessions/services/sessions/test/browser/sessionsListModelService.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionsListModelService.test.ts
@@ -10,9 +10,9 @@ import { constObservable, ISettableObservable, observableValue } from '../../../
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { IStorageService, InMemoryStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
-import { IChat, ISession, SessionStatus } from '../../../../services/sessions/common/session.js';
-import { IActiveSession, ISessionsChangeEvent, ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
-import { ISessionListModelChangeEvent, SessionListModelChangeKind, SessionsListModelService } from '../../browser/views/sessionsListModelService.js';
+import { IChat, ISession, SessionStatus } from '../../common/session.js';
+import { IActiveSession, ISessionsChangeEvent, ISessionsManagementService } from '../../common/sessionsManagement.js';
+import { ISessionListModelChangeEvent, SessionListModelChangeKind, SessionsListModelService } from '../../browser/sessionsListModelService.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { mock } from '../../../../../base/test/common/mock.js';
 

--- a/src/vs/sessions/sessions.common.main.ts
+++ b/src/vs/sessions/sessions.common.main.ts
@@ -460,7 +460,7 @@ import './contrib/chat/browser/customizationsDebugLog.contribution.js';
 import './contrib/providers/copilotChatSessions/browser/copilotChatSessions.contribution.js';
 import './contrib/providers/localChatSessions/browser/localChatSessions.contribution.js';
 import './contrib/sessions/browser/sessions.contribution.js';
-import './contrib/sessions/browser/views/sessionsListModelService.js';
+import './services/sessions/browser/sessionsListModelService.js';
 import './services/agentHostFilter/browser/agentHostFilterService.js';
 import './contrib/sessions/browser/customizationsToolbar.contribution.js';
 import './contrib/changes/browser/changes.contribution.js';


### PR DESCRIPTION
## What

Builds a single source of truth for session recency in the Agents window and wires the sessions picker, Back/Forward navigation, and session header on top of it.

### Recency history (single source of truth)
- New `SessionsRecencyHistory` (`services/sessions/browser/sessionsRecencyHistory.ts`): MRU-ordered, de-duplicated list of `(session, chat)` entries, capped at 50, persisted across reloads.
- `SessionsNavigation` (Back/Forward) is rebuilt on top of it: traversal moves a cursor only and never re-promotes entries; explicit opens promote to the front. This changes navigation from browser-style (forward-truncating) to MRU/Alt+Tab-style, and makes history survive reloads.
- `getRecentlyOpenedSessions()` returns `{ recent, other }`: `recent` is recency-ordered and de-duplicated by session (a session opened via multiple chats appears once), capped at 10; `other` is the remaining sessions sorted by last update.

### Shared read-state and status icon
- Moved `SessionsListModelService` (+ test) from `contrib/sessions/browser/views/` down to `services/sessions/browser/` so the core session header can consume it (layering-feasible — only depends on `IStorageService` + `ISessionsManagementService`).
- Added a shared `getStatusIcon()` to the service so the sessions list, picker, and header all render the same status icon.
- The session header now uses `isSessionRead(session)` instead of the always-`true` `session.isRead`, fixing the inconsistency where a session showed read in the list but unread in the header/picker.

### Sessions picker UI/keyboard
- Two groups: **recently opened** / **other sessions**.
- Search across both title and folder (`matchOnDetail`).
- Pre-selects the active session on open.
- Open to the side via Cmd/Ctrl/Alt; background accept (Right Arrow) opens in the background and keeps the picker open (`ignoreFocusOut`).
- Removed the hover on the command-center title widget.

## Why

Previously the picker and navigation had independent notions of recency, and read-state was read from different sources across surfaces, causing inconsistent ordering and read/unread indicators.

## Notes for reviewers

- Navigation semantics intentionally change to MRU/no-truncation; persisted entries (not the cursor) survive reload.
- `SessionsRecencyHistory` persists at `StorageScope.WORKSPACE` under key `agentSessions.recencyHistory`.

## Validation

- `compile-check-ts-native`, `valid-layers-check`, ESLint: clean
- Tests: `SessionsNavigation` (17), `SessionsManagementService` (12), `SessionsListModelService` (58) all pass
