### PR TITLE
sessions: make session navigation work when editor part is open but unfocused

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
@@ -14,8 +14,7 @@ import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextke
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { IQuickInputService, IQuickPickItem, IQuickPickSeparator } from '../../../../platform/quickinput/common/quickInput.js';
-import { EditorContextKeys } from '../../../../editor/common/editorContextKeys.js';
-import { IsAuxiliaryWindowContext, IsSessionsWindowContext } from '../../../../workbench/common/contextkeys.js';
+import { EditorAreaFocusContext, IsAuxiliaryWindowContext, IsSessionsWindowContext } from '../../../../workbench/common/contextkeys.js';
 import { Menus } from '../../../browser/menus.js';
 import { SessionsCategories } from '../../../common/categories.js';
 import { CanGoBackContext, CanGoForwardContext, MultipleSessionsVisibleContext, SessionIsCreatedContext, SessionIsMaximizedContext, SessionIsStickyContext, SessionsFocusContext, SessionSupportsMultipleChatsContext, SessionsWelcomeVisibleContext } from '../../../common/contextkeys.js';
@@ -201,7 +200,7 @@ registerAction2(class GoBackAction extends Action2 {
 				win: { primary: KeyMod.Alt | KeyCode.LeftArrow, secondary: [KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Tab] },
 				mac: { primary: KeyMod.WinCtrl | KeyCode.Minus, secondary: [KeyMod.WinCtrl | KeyMod.Shift | KeyCode.Tab] },
 				linux: { primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.Minus, secondary: [KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Tab] },
-				when: ContextKeyExpr.and(IsSessionsWindowContext, EditorContextKeys.editorTextFocus.toNegated()),
+				when: ContextKeyExpr.and(IsSessionsWindowContext, EditorAreaFocusContext.toNegated()),
 			},
 			menu: [{
 				id: Menus.TitleBarCenterLeft,
@@ -243,7 +242,7 @@ registerAction2(class GoForwardAction extends Action2 {
 				win: { primary: KeyMod.Alt | KeyCode.RightArrow, secondary: [KeyMod.CtrlCmd | KeyCode.Tab] },
 				mac: { primary: KeyMod.WinCtrl | KeyMod.Shift | KeyCode.Minus, secondary: [KeyMod.WinCtrl | KeyCode.Tab] },
 				linux: { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Minus, secondary: [KeyMod.CtrlCmd | KeyCode.Tab] },
-				when: ContextKeyExpr.and(IsSessionsWindowContext, EditorContextKeys.editorTextFocus.toNegated()),
+				when: ContextKeyExpr.and(IsSessionsWindowContext, EditorAreaFocusContext.toNegated()),
 			},
 			menu: [{
 				id: Menus.TitleBarCenterLeft,


### PR DESCRIPTION
## What

The session navigation keybindings — **Go Back** (`Ctrl+Shift+Tab`) and **Go Forward** (`Ctrl+Tab`) — in the Agents window were gated on `EditorContextKeys.editorTextFocus.toNegated()`. This switches the gate to `EditorAreaFocusContext.toNegated()`.

## Why

`editorTextFocus` evaluates such that the navigation chords were suppressed even when the editor part is open but does **not** have keyboard focus. As a result, `Ctrl+Shift+Tab` / `Ctrl+Tab` did not navigate between sessions whenever an editor was open.

`EditorAreaFocusContext` is `true` only when keyboard focus is genuinely within the editor area (any editor part). Negating it means session navigation works whenever focus is outside the editor area — including when an editor is open but unfocused — while still deferring to the editor's own `Ctrl+Tab` quick-open when the editor area is actually focused.

## Notes for reviewers

- Only the `when` clauses of the two navigation actions change; weights and key chords are untouched.
- `EditorAreaFocusContext` is bound in `editorPart.ts` for all editor parts (main, modal, auxiliary).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>