### PR TITLE
Remove agent-host branch and isolation pickers

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker.contribution.ts
@@ -5,12 +5,10 @@
 
 import { localize2 } from '../../../../../../nls.js';
 import { Action2, MenuId, registerAction2 } from '../../../../../../platform/actions/common/actions.js';
-import { ContextKeyExpr } from '../../../../../../platform/contextkey/common/contextkey.js';
-import { IsSessionsWindowContext } from '../../../../../common/contextkeys.js';
 import { ChatContextKeys, ChatContextKeyExprs } from '../../../common/actions/chatContextKeys.js';
 
 /**
- * All three agent-host pickers live under `MenuId.ChatInputSecondary` group
+ * Agent-host pickers live under `MenuId.ChatInputSecondary` group
  * `'navigation'` because non-navigation groups are routed to the overflow
  * menu by VS Code's menu/toolbar convention.
  *
@@ -22,11 +20,6 @@ import { ChatContextKeys, ChatContextKeyExprs } from '../../../common/actions/ch
  *   0.8  OpenAgentHostAutoApprovePickerAction (NEW — Auto-Approve)
  *   0.9  OpenAgentHostPermissionModePickerAction (NEW — Claude Approvals)
  *   1    OpenPermissionPickerAction           (Default Approvals)
- *   100  OpenAgentHostBranchPickerAction      (NEW — Branch)
- *   101  OpenAgentHostIsolationPickerAction   (NEW — Isolation)
- *
- * Branch + Isolation are pushed to the right of the row by CSS
- * (`margin-left: auto` on the first of the two; see picker CSS).
  */
 
 export class OpenAgentHostModePickerAction extends Action2 {
@@ -86,51 +79,6 @@ export class OpenAgentHostPermissionModePickerAction extends Action2 {
 	override async run(): Promise<void> { /* the action view item handles interaction */ }
 }
 
-export class OpenAgentHostBranchPickerAction extends Action2 {
-	static readonly ID = 'workbench.action.chat.openAgentHostBranchPicker';
-	constructor() {
-		super({
-			id: OpenAgentHostBranchPickerAction.ID,
-			title: localize2('agentHost.branchPicker', "Branch"),
-			f1: false,
-			precondition: ChatContextKeys.enabled,
-			menu: [{
-				id: MenuId.ChatInputSecondary,
-				group: 'navigation',
-				// Large order so Branch always sorts after the existing
-				// secondary chips (SessionTarget, Mode, Approvals, ...).
-				order: 100,
-				// Workbench is locked to `isolation: 'folder'` (no worktrees /
-				// branch picking yet); only expose this chip in the dedicated
-				// agent sessions window.
-				when: ContextKeyExpr.and(ChatContextKeyExprs.isAgentHostSession, IsSessionsWindowContext),
-			}],
-		});
-	}
-	override async run(): Promise<void> { /* the action view item handles interaction */ }
-}
-
-export class OpenAgentHostIsolationPickerAction extends Action2 {
-	static readonly ID = 'workbench.action.chat.openAgentHostIsolationPicker';
-	constructor() {
-		super({
-			id: OpenAgentHostIsolationPickerAction.ID,
-			title: localize2('agentHost.isolationPicker', "Isolation"),
-			f1: false,
-			precondition: ChatContextKeys.enabled,
-			menu: [{
-				id: MenuId.ChatInputSecondary,
-				group: 'navigation',
-				order: 101,
-				when: ContextKeyExpr.and(ChatContextKeyExprs.isAgentHostSession, IsSessionsWindowContext),
-			}],
-		});
-	}
-	override async run(): Promise<void> { /* the action view item handles interaction */ }
-}
-
 registerAction2(OpenAgentHostModePickerAction);
 registerAction2(OpenAgentHostAutoApprovePickerAction);
 registerAction2(OpenAgentHostPermissionModePickerAction);
-registerAction2(OpenAgentHostBranchPickerAction);
-registerAction2(OpenAgentHostIsolationPickerAction);

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker.ts
@@ -48,14 +48,6 @@ interface IConfigPickerItem {
 }
 
 function getConfigIcon(property: string, value: unknown | undefined): ThemeIcon | undefined {
-	if (property === SessionConfigKey.Isolation) {
-		if (value === 'folder') { return Codicon.folder; }
-		if (value === 'worktree') { return Codicon.worktree; }
-		return undefined;
-	}
-	if (property === SessionConfigKey.Branch) {
-		return Codicon.gitBranch;
-	}
 	if (property === SessionConfigKey.Mode) {
 		switch (value) {
 			case 'plan': return Codicon.checklist;
@@ -149,11 +141,10 @@ export function isWellKnownAutoApproveSchema(schema: SessionConfigPropertySchema
 }
 
 /**
- * The set of well-known session-config property names that have a dedicated
- * picker chip in the secondary toolbar (registered as `MenuId.ChatInputSecondary`
- * actions). The generic-fallback chip lane filters these out so unknown
- * properties advertised by an agent get their own chip without duplicating
- * the dedicated ones.
+ * The set of well-known session-config property names that are either handled
+ * by dedicated UI or intentionally hidden from the workbench chat-input chip
+ * lane. The generic-fallback chip lane filters these out so unknown properties
+ * advertised by an agent get their own chip.
  *
  * `Permissions` has no chip — it is surfaced through other UI — but is
  * included so the generic lane does not invent a chip for it.
@@ -161,6 +152,8 @@ export function isWellKnownAutoApproveSchema(schema: SessionConfigPropertySchema
 export const WELL_KNOWN_PICKER_PROPERTIES: ReadonlySet<string> = new Set<string>([
 	SessionConfigKey.Mode,
 	SessionConfigKey.AutoApprove,
+	SessionConfigKey.Isolation,
+	SessionConfigKey.Branch,
 	SessionConfigKey.Permissions,
 	ClaudeSessionConfigKey.PermissionMode,
 ]);

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker.ts
@@ -159,14 +159,14 @@ export const WELL_KNOWN_PICKER_PROPERTIES: ReadonlySet<string> = new Set<string>
 ]);
 
 /**
- * Whether the given `(property, schema)` pair will be rendered by a dedicated
- * chip widget on the secondary toolbar. Used by the generic-fallback chip
- * lane to decide whether to render a chip for `property`.
+ * Whether the given `(property, schema)` pair is handled outside the
+ * generic-fallback chip lane. This includes properties rendered by dedicated
+ * chip widgets and properties intentionally hidden from workbench chat.
  *
- * For most well-known keys this is purely a property-name check. AutoApprove
- * is special: only well-known schema shapes are claimed by the dedicated
- * picker; non-conforming schemas (e.g. Claude's approval mode) fall through
- * to the generic lane.
+ * For most well-known keys this is purely a property-name check. AutoApprove is
+ * special: only well-known schema shapes are claimed by the dedicated picker;
+ * non-conforming schemas (e.g. Claude's approval mode) fall through to the
+ * generic lane.
  */
 export function isClaimedByDedicatedPicker(property: string, schema: SessionConfigPropertySchema): boolean {
 	if (property === SessionConfigKey.AutoApprove) {
@@ -178,9 +178,8 @@ export function isClaimedByDedicatedPicker(property: string, schema: SessionConf
 /**
  * One workbench chat-input chip bound to a single agent-host session-config
  * property. Used both for dedicated well-known property chips
- * (`SessionConfigKey.Mode`, `.Isolation`, `.Branch`, `.AutoApprove`) and for
- * generic per-property chips advertised by an agent's config schema but not
- * known to VS Code.
+ * (`SessionConfigKey.Mode`, `.AutoApprove`) and for generic per-property chips
+ * advertised by an agent's config schema but not known to VS Code.
  */
 export class AgentHostChatInputPicker extends Disposable {
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/media/agentHostChatInputPicker.css
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/media/agentHostChatInputPicker.css
@@ -141,29 +141,3 @@
 	text-overflow: ellipsis;
 	white-space: nowrap;
 }
-
-/*
- * Right-align the Branch + Isolation chips within the secondary chat-input
- * toolbar. The picker tags its host element with a per-property modifier
- * class (`agent-host-chat-input-picker-host-branch`) so these selectors can
- * target just the right-aligned pair without affecting Mode. Branch (when
- * present) takes the leading `margin-left: auto`; Isolation otherwise. With
- * both present the Isolation rule is suppressed by the general-sibling
- * selector below that detects a preceding (visible) Branch chip.
- */
-.chat-secondary-input-toolbar .monaco-action-bar .actions-container > .action-item.agent-host-chat-input-picker-host-branch {
-	margin-left: auto;
-}
-
-.chat-secondary-input-toolbar .monaco-action-bar .actions-container > .action-item.agent-host-chat-input-picker-host-isolation {
-	margin-left: auto;
-}
-
-/*
- * Suppress Isolation's leading-margin only when a *visible* Branch chip
- * precedes it. Hidden chips keep the `agent-host-chat-input-picker-host-hidden`
- * marker so this selector can ignore them.
- */
-.chat-secondary-input-toolbar .monaco-action-bar .actions-container > .action-item.agent-host-chat-input-picker-host-branch:not(.agent-host-chat-input-picker-host-hidden) ~ .action-item.agent-host-chat-input-picker-host-isolation {
-	margin-left: 0;
-}

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -107,7 +107,7 @@ import { ChatEditingShowChangesAction, ViewPreviousEditsAction } from '../../cha
 import { resizeImage } from '../../chatImageUtils.js';
 import { ChatSessionPickerActionItem, IChatSessionPickerDelegate } from '../../chatSessions/chatSessionPickerActionItem.js';
 import { AgentHostChatInputPicker, AgentHostChatInputPickerActionViewItem } from '../../agentSessions/agentHost/agentHostChatInputPicker.js';
-import { OpenAgentHostAutoApprovePickerAction, OpenAgentHostBranchPickerAction, OpenAgentHostIsolationPickerAction, OpenAgentHostModePickerAction, OpenAgentHostPermissionModePickerAction } from '../../agentSessions/agentHost/agentHostChatInputPicker.contribution.js';
+import { OpenAgentHostAutoApprovePickerAction, OpenAgentHostModePickerAction, OpenAgentHostPermissionModePickerAction } from '../../agentSessions/agentHost/agentHostChatInputPicker.contribution.js';
 import { AgentHostGenericConfigChips } from '../../agentSessions/agentHost/agentHostGenericConfigChips.js';
 import { SessionConfigKey } from '../../../../../../platform/agentHost/common/sessionConfigKeys.js';
 import { ClaudeSessionConfigKey } from '../../../../../../platform/agentHost/common/claudeSessionConfigKeys.js';
@@ -2760,8 +2760,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			[OpenAgentHostModePickerAction.ID, 22],
 			[OpenAgentHostAutoApprovePickerAction.ID, 22],
 			[OpenAgentHostPermissionModePickerAction.ID, 22],
-			[OpenAgentHostBranchPickerAction.ID, 22],
-			[OpenAgentHostIsolationPickerAction.ID, 22],
 			['sessions.tunnelHost.toggleSharing', 16],
 		]);
 		// Direct-rendered chip lane for agent-host config properties that
@@ -2871,23 +2869,17 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 				} else if (
 					(action.id === OpenAgentHostModePickerAction.ID
 						|| action.id === OpenAgentHostAutoApprovePickerAction.ID
-						|| action.id === OpenAgentHostPermissionModePickerAction.ID
-						|| action.id === OpenAgentHostBranchPickerAction.ID
-						|| action.id === OpenAgentHostIsolationPickerAction.ID)
+						|| action.id === OpenAgentHostPermissionModePickerAction.ID)
 					&& action instanceof MenuItemAction
 				) {
 					if (this.options.isSessionsWindow) {
 						return new HiddenActionViewItem(action);
 					}
-					const property = action.id === OpenAgentHostBranchPickerAction.ID
-						? SessionConfigKey.Branch
-						: action.id === OpenAgentHostIsolationPickerAction.ID
-							? SessionConfigKey.Isolation
-							: action.id === OpenAgentHostAutoApprovePickerAction.ID
-								? SessionConfigKey.AutoApprove
-								: action.id === OpenAgentHostPermissionModePickerAction.ID
-									? ClaudeSessionConfigKey.PermissionMode
-									: SessionConfigKey.Mode;
+					const property = action.id === OpenAgentHostAutoApprovePickerAction.ID
+						? SessionConfigKey.AutoApprove
+						: action.id === OpenAgentHostPermissionModePickerAction.ID
+							? ClaudeSessionConfigKey.PermissionMode
+							: SessionConfigKey.Mode;
 					const picker = this.instantiationService.createInstance(AgentHostChatInputPicker, widget, property);
 					return new AgentHostChatInputPickerActionViewItem(action, picker);
 				} else if (action.id === ChatSessionPrimaryPickerAction.ID && action instanceof MenuItemAction) {


### PR DESCRIPTION
## Summary
- remove the Branch and Isolation picker actions from workbench agent-host chat sessions
- remove their chat input wiring and CSS
- keep Branch and Isolation filtered from generic config chips so they do not reappear from schema-driven config

## Validation
- npm run compile-check-ts-native
- node --experimental-strip-types build/hygiene.ts src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker.contribution.ts src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker.ts src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/media/agentHostChatInputPicker.css src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts

(Written by Copilot)