### PR TITLE
chat: stop agent host config update loop across windows

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostCustomizationConfig.ts
+++ b/src/vs/platform/agentHost/common/agentHostCustomizationConfig.ts
@@ -20,8 +20,8 @@ export const enum AgentHostConfigKey {
 	 * TODO: revisit magic key in config; refine into a dedicated typed channel. https://github.com/microsoft/vscode/issues/313812
 	 */
 	DefaultShell = 'defaultShell',
-	/** When true, Copilot SDK sessions use the SDK's default terminal behavior instead of Agent Host's terminal tool override. */
-	DisableCustomTerminalTool = 'disableCustomTerminalTool',
+	/** When true, Copilot SDK sessions use Agent Host's custom terminal tool override instead of the SDK's default terminal behavior. Disabled by default. */
+	EnableCustomTerminalTool = 'enableCustomTerminalTool',
 	/** When true, Copilot SDK sessions enable the rubber duck critic subagent. */
 	RubberDuck = 'rubberDuck',
 }
@@ -70,10 +70,10 @@ export const agentHostCustomizationConfigSchema = createSchema({
 		title: localize('agentHost.config.defaultShell.title', "Default Shell"),
 		description: localize('agentHost.config.defaultShell.description', "Absolute path to the shell executable used by host-managed terminals. Normally pushed by the connected VS Code client from `terminal.integrated.agentHostProfile.<os>` (falling back to `terminal.integrated.defaultProfile.<os>`); when unset, the agent host falls back to the system shell. Only the path is supported; `args` and `env` from the workbench profile are not piped through yet. The workbench only pushes this for the local agent host — remote agent host operators should set this directly in the remote machine's `agent-host-config.json`."),
 	}),
-	[AgentHostConfigKey.DisableCustomTerminalTool]: schemaProperty<boolean>({
+	[AgentHostConfigKey.EnableCustomTerminalTool]: schemaProperty<boolean>({
 		type: 'boolean',
-		title: localize('agentHost.config.disableCustomTerminalTool.title', "Use SDK Terminal Tool"),
-		description: localize('agentHost.config.disableCustomTerminalTool.description', "When enabled, Copilot SDK sessions use the SDK's default terminal behavior instead of Agent Host's terminal tool override."),
+		title: localize('agentHost.config.enableCustomTerminalTool.title', "Use Agent Host Terminal Tool"),
+		description: localize('agentHost.config.enableCustomTerminalTool.description', "When enabled, Copilot SDK sessions use Agent Host's terminal tool override instead of the SDK's default terminal behavior."),
 		default: false,
 	}),
 	[AgentHostConfigKey.RubberDuck]: schemaProperty<boolean>({

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -1563,8 +1563,8 @@ export class CopilotAgent extends Disposable implements IAgent {
 		const plugins = snapshot.plugins;
 
 		return async (callbacks: Parameters<SessionWrapperFactory>[0]) => {
-			const disableCustomTerminalTool = this._configurationService.getRootValue(agentHostCustomizationConfigSchema, AgentHostConfigKey.DisableCustomTerminalTool) === true;
-			const shellTools = disableCustomTerminalTool ? [] : await createShellTools(shellManager, this._terminalManager, this._logService, callbacks.requestUnsandboxedCommandConfirmation);
+			const enableCustomTerminalTool = this._configurationService.getRootValue(agentHostCustomizationConfigSchema, AgentHostConfigKey.EnableCustomTerminalTool) === true;
+			const shellTools = enableCustomTerminalTool ? await createShellTools(shellManager, this._terminalManager, this._logService, callbacks.requestUnsandboxedCommandConfirmation) : [];
 			// Rely on SDK to find all agents/skills & the like from the plugins instead of us feeding them.
 			// Else we could end up with duplicates or the like.
 			const pluginsWithoutDirs = plugins.filter(p => !p.pluginDir || p.pluginDir.scheme !== Schemas.file);

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -1191,14 +1191,15 @@ export class CopilotAgentSession extends Disposable {
 	 * SDK's pre-call permission prompt is redundant in that case.
 	 *
 	 * Returns false when shell tools are not registered (the SDK's built-in
-	 * terminal runs unsandboxed via `AgentHostConfigKey.DisableCustomTerminalTool`)
+	 * terminal runs unsandboxed unless `AgentHostConfigKey.EnableCustomTerminalTool`
+	 * is set)
 	 * so the standard confirmation flow is preserved.
 	 */
 	private async _isShellSandboxedByDefault(): Promise<boolean> {
 		if (!this._shellManager) {
 			return false;
 		}
-		if (this._configurationService.getRootValue(agentHostCustomizationConfigSchema, AgentHostConfigKey.DisableCustomTerminalTool) === true) {
+		if (this._configurationService.getRootValue(agentHostCustomizationConfigSchema, AgentHostConfigKey.EnableCustomTerminalTool) !== true) {
 			return false;
 		}
 		return this._shellManager.getOrCreateSandboxEngine().isEnabled();

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -511,7 +511,7 @@ suite('CopilotAgent', () => {
 				await agent.authenticate('https://api.github.com', 'token');
 				await agent.listSessions();
 
-				configurationService.updateRootConfig({ [AgentHostConfigKey.DisableCustomTerminalTool]: true });
+				configurationService.updateRootConfig({ [AgentHostConfigKey.EnableCustomTerminalTool]: true });
 				await Promise.resolve();
 
 				assert.strictEqual(client.stopCount, 0);
@@ -1010,7 +1010,7 @@ suite('CopilotAgent', () => {
 			const { agent, configurationService } = createTestAgentContext(disposables, { sessionDataService, copilotClient: client });
 			try {
 				await agent.authenticate('https://api.github.com', 'token');
-				configurationService.updateRootConfig({ [AgentHostConfigKey.DisableCustomTerminalTool]: true });
+				configurationService.updateRootConfig({ [AgentHostConfigKey.EnableCustomTerminalTool]: false });
 
 				const result = await agent.createSession({
 					session: AgentSession.uri('copilotcli', 'sdk-terminal-defaults'),

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostTerminalContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostTerminalContribution.ts
@@ -99,8 +99,8 @@ export class AgentHostTerminalContribution extends Disposable implements IWorkbe
 				},
 			},
 			{
-				key: AgentHostConfigKey.DisableCustomTerminalTool,
-				computeValue: () => !this._configurationService.getValue<boolean>(AgentHostCustomTerminalToolEnabledSettingId),
+				key: AgentHostConfigKey.EnableCustomTerminalTool,
+				computeValue: () => this._configurationService.getValue<boolean>(AgentHostCustomTerminalToolEnabledSettingId) === true,
 				registerTriggers: (store, push) => {
 					store.add(this._configurationService.onDidChangeConfiguration(e => {
 						if (e.affectsConfiguration(AgentHostCustomTerminalToolEnabledSettingId)) {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostTerminalContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostTerminalContribution.ts
@@ -30,6 +30,31 @@ const AGENT_HOST_SHELL_DEPENDENT_SETTINGS = [
 ];
 
 /**
+ * A single agent-host root-config key managed by this contribution.
+ *
+ * The shared machinery in {@link AgentHostTerminalContribution} handles the
+ * schema gate, the value-equality guard, the dispatch, and the
+ * hydration-retry. A descriptor only has to say *what* its value is and *when*
+ * to recompute it - adding a new managed key is one entry, no copy/paste.
+ */
+interface IManagedRootConfigKey {
+	/** The root-config key this descriptor owns. */
+	readonly key: AgentHostConfigKey;
+
+	/**
+	 * Compute the desired value for {@link key}. Return `undefined` to skip the
+	 * push (e.g. the value can't be resolved yet). May be async.
+	 */
+	computeValue(): unknown | Promise<unknown>;
+
+	/**
+	 * Wire up the events / settings whose change should re-push this key.
+	 * Disposables go in `store`; call `push` to trigger a re-push.
+	 */
+	registerTriggers(store: DisposableStore, push: () => void): void;
+}
+
+/**
  * Registers local agent host terminal entries with
  * {@link IAgentHostTerminalService} so they appear in the terminal dropdown.
  *
@@ -41,6 +66,16 @@ export class AgentHostTerminalContribution extends Disposable implements IWorkbe
 	private readonly _localEntry = this._register(new MutableDisposable());
 	private readonly _conditionalListeners = this._register(new MutableDisposable<DisposableStore>());
 
+	/** Declarative table of the root-config keys we manage. */
+	private readonly _managedKeys: readonly IManagedRootConfigKey[];
+
+	/**
+	 * Managed keys whose schema the host has already advertised. Used to re-push
+	 * only when a key's schema *first* appears (hydration) rather than on every
+	 * root-state change - see {@link _onRootStateChanged}.
+	 */
+	private readonly _schemaSeen = new Set<AgentHostConfigKey>();
+
 	constructor(
 		@IAgentHostService private readonly _agentHostService: IAgentHostService,
 		@IAgentHostTerminalService private readonly _agentHostTerminalService: IAgentHostTerminalService,
@@ -49,6 +84,32 @@ export class AgentHostTerminalContribution extends Disposable implements IWorkbe
 		@ITerminalProfileResolverService private readonly _terminalProfileResolverService: ITerminalProfileResolverService,
 	) {
 		super();
+
+		this._managedKeys = [
+			{
+				key: AgentHostConfigKey.DefaultShell,
+				computeValue: () => this._resolveDefaultShell(),
+				registerTriggers: (store, push) => {
+					store.add(this._configurationService.onDidChangeConfiguration(e => {
+						if (AGENT_HOST_SHELL_DEPENDENT_SETTINGS.some(s => e.affectsConfiguration(s))) {
+							push();
+						}
+					}));
+					store.add(this._terminalProfileService.onDidChangeAvailableProfiles(() => push()));
+				},
+			},
+			{
+				key: AgentHostConfigKey.DisableCustomTerminalTool,
+				computeValue: () => !this._configurationService.getValue<boolean>(AgentHostCustomTerminalToolEnabledSettingId),
+				registerTriggers: (store, push) => {
+					store.add(this._configurationService.onDidChangeConfiguration(e => {
+						if (e.affectsConfiguration(AgentHostCustomTerminalToolEnabledSettingId)) {
+							push();
+						}
+					}));
+				},
+			},
+		];
 
 		this._register(this._configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration(AgentHostEnabledSettingId)) {
@@ -64,27 +125,34 @@ export class AgentHostTerminalContribution extends Disposable implements IWorkbe
 			if (!this._conditionalListeners.value) {
 				const store = new DisposableStore();
 				store.add(this._agentHostService.onAgentHostStart(() => this._reconcile()));
-				store.add(this._configurationService.onDidChangeConfiguration(e => {
-					if (AGENT_HOST_SHELL_DEPENDENT_SETTINGS.some(s => e.affectsConfiguration(s))) {
-						this._pushDefaultShell();
+				for (const entry of this._managedKeys) {
+					entry.registerTriggers(store, () => this._push(entry));
+				}
+				// Re-push only when the host's root-config *schema* first
+				// advertises a key we manage. The initial push from
+				// `_reconcile()` may race an undefined `rootState.value` (schema
+				// not yet hydrated); this retries once the schema arrives.
+				//
+				// We deliberately do NOT re-push on every root-state change: the
+				// local agent host's root config is shared across windows, so
+				// reacting to *value* changes pushed by another window would
+				// start an infinite update war - each window forcing its own
+				// value back over the other's. See #314385 follow-up.
+				store.add(this._agentHostService.rootState.onDidChange(() => this._onRootStateChanged()));
+				// Seed the schema-seen set from the current state so the
+				// immediate `_reconcile()` below counts as the initial push for
+				// whatever keys are already advertised.
+				this._schemaSeen.clear();
+				for (const entry of this._managedKeys) {
+					if (this._schemaHasKey(entry.key)) {
+						this._schemaSeen.add(entry.key);
 					}
-					if (e.affectsConfiguration(AgentHostCustomTerminalToolEnabledSettingId)) {
-						this._pushCustomTerminalToolEnabled();
-					}
-				}));
-				store.add(this._terminalProfileService.onDidChangeAvailableProfiles(() => this._pushDefaultShell()));
-				// Retry the push when the host's root state hydrates or its schema
-				// changes - the initial push from `_reconcile()` may have raced an
-				// undefined `rootState.value`, in which case the schema gate below
-				// in `_pushDefaultShell` returned early.
-				store.add(this._agentHostService.rootState.onDidChange(() => {
-					this._pushDefaultShell();
-					this._pushCustomTerminalToolEnabled();
-				}));
+				}
 				this._conditionalListeners.value = store;
 				this._reconcile();
 			}
 		} else {
+			this._schemaSeen.clear();
 			this._conditionalListeners.value = undefined;
 			this._localEntry.value = undefined;
 		}
@@ -98,36 +166,94 @@ export class AgentHostTerminalContribution extends Disposable implements IWorkbe
 				getConnection: () => this._agentHostService,
 			});
 		}
-		this._pushDefaultShell();
-		this._pushCustomTerminalToolEnabled();
+		for (const entry of this._managedKeys) {
+			this._push(entry);
+		}
+	}
+
+	/**
+	 * Push managed values only for keys whose schema has just transitioned from
+	 * absent to present (host root-config hydration). Value-only changes - e.g.
+	 * another window writing a different value into the shared root config - are
+	 * intentionally ignored so multiple windows don't fight in an infinite loop.
+	 */
+	private _onRootStateChanged(): void {
+		for (const entry of this._managedKeys) {
+			if (this._schemaHasKey(entry.key)) {
+				if (!this._schemaSeen.has(entry.key)) {
+					this._schemaSeen.add(entry.key);
+					this._push(entry);
+				}
+			} else {
+				this._schemaSeen.delete(entry.key);
+			}
+		}
+	}
+
+	private _schemaHasKey(key: AgentHostConfigKey): boolean {
+		const rootState = this._agentHostService.rootState.value;
+		if (!rootState || rootState instanceof Error) {
+			return false;
+		}
+		return !!rootState.config?.schema.properties[key];
+	}
+
+	/**
+	 * Shared push pipeline for a managed root-config key:
+	 *
+	 * 1. No-op if the host's root-config schema doesn't advertise the key -
+	 *    protects older / third-party agent hosts from receiving keys they
+	 *    don't understand. The push is retried automatically when `rootState`
+	 *    hydrates (see {@link _onRootStateChanged}).
+	 * 2. Compute the desired value (may be async); `undefined` skips the push.
+	 * 3. Skip if the host already holds that value (avoids redundant dispatches
+	 *    and, critically, breaks cross-window update loops - see #314385).
+	 *
+	 * Local agent host only. Remote agent hosts (via
+	 * `IRemoteAgentHostService.connections`) are intentionally not fanned out
+	 * to: e.g. the resolved shell path is local-machine-shaped (a Windows path)
+	 * and not necessarily valid on the remote machine. Remote operators should
+	 * configure such values server-side via the remote's
+	 * `agent-host-config.json`. See
+	 * https://github.com/microsoft/vscode/issues/313160 follow-ups.
+	 */
+	private async _push(entry: IManagedRootConfigKey): Promise<void> {
+		if (!this._schemaHasKey(entry.key)) {
+			return;
+		}
+
+		let value: unknown;
+		try {
+			value = await entry.computeValue();
+		} catch {
+			return;
+		}
+		if (value === undefined) {
+			return;
+		}
+
+		// Re-read after any await: the value may be stale and another change
+		// may have landed while we resolved.
+		const rootState = this._agentHostService.rootState.value;
+		if (!rootState || rootState instanceof Error || !rootState.config) {
+			return;
+		}
+		if (rootState.config.values[entry.key] === value) {
+			return;
+		}
+
+		this._agentHostService.dispatch(ROOT_STATE_URI, {
+			type: ActionType.RootConfigChanged,
+			config: { [entry.key]: value },
+		});
 	}
 
 	/**
 	 * Resolve the agent host terminal profile (with `defaultProfile.<os>`
-	 * fallback) and push the shell path into the agent host's root config so
-	 * its host-managed shells inherit the user's preferred terminal binary.
-	 *
-	 * No-ops if the host's root-config schema doesn't advertise
-	 * `AgentHostConfigKey.DefaultShell` - protects older / third-party
-	 * agent hosts from receiving keys they don't understand. The push is
-	 * retried automatically when `rootState` hydrates (see `_updateEnabled`).
-	 *
-	 * Local agent host only. Remote agent hosts (via
-	 * `IRemoteAgentHostService.connections`) are intentionally not fanned out
-	 * to: the resolved path is local-machine-shaped (e.g. a Windows path) and
-	 * not necessarily valid on the remote machine. Remote operators should
-	 * configure the shell server-side via the remote's `agent-host-config.json`.
-	 * See https://github.com/microsoft/vscode/issues/313160 follow-ups.
+	 * fallback) so its host-managed shells inherit the user's preferred terminal
+	 * binary. Returns `undefined` when no usable path can be resolved.
 	 */
-	private async _pushDefaultShell(): Promise<void> {
-		const rootState = this._agentHostService.rootState.value;
-		if (!rootState || rootState instanceof Error) {
-			return;
-		}
-		if (!rootState.config?.schema.properties[AgentHostConfigKey.DefaultShell]) {
-			return;
-		}
-
+	private async _resolveDefaultShell(): Promise<string | undefined> {
 		let profile;
 		try {
 			profile = await this._terminalProfileResolverService.getDefaultProfile({
@@ -136,46 +262,8 @@ export class AgentHostTerminalContribution extends Disposable implements IWorkbe
 				allowAgentHostShell: true,
 			});
 		} catch {
-			return;
+			return undefined;
 		}
-
-		if (!profile.path) {
-			return;
-		}
-
-		const currentRootState = this._agentHostService.rootState.value;
-		if (!currentRootState || currentRootState instanceof Error) {
-			return;
-		}
-
-		// Fix #314385
-		if (rootState.config.values[AgentHostConfigKey.DefaultShell] === profile.path) {
-			return;
-		}
-
-		this._agentHostService.dispatch(ROOT_STATE_URI, {
-			type: ActionType.RootConfigChanged,
-			config: { [AgentHostConfigKey.DefaultShell]: profile.path },
-		});
-	}
-
-	private _pushCustomTerminalToolEnabled(): void {
-		const rootState = this._agentHostService.rootState.value;
-		if (!rootState || rootState instanceof Error) {
-			return;
-		}
-		if (!rootState.config?.schema.properties[AgentHostConfigKey.DisableCustomTerminalTool]) {
-			return;
-		}
-
-		const disableCustomTerminalTool = !this._configurationService.getValue<boolean>(AgentHostCustomTerminalToolEnabledSettingId);
-		if (rootState.config.values[AgentHostConfigKey.DisableCustomTerminalTool] === disableCustomTerminalTool) {
-			return;
-		}
-
-		this._agentHostService.dispatch(ROOT_STATE_URI, {
-			type: ActionType.RootConfigChanged,
-			config: { [AgentHostConfigKey.DisableCustomTerminalTool]: disableCustomTerminalTool },
-		});
+		return profile.path || undefined;
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostTerminalContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostTerminalContribution.ts
@@ -232,8 +232,13 @@ export class AgentHostTerminalContribution extends Disposable implements IWorkbe
 			return;
 		}
 
-		// Re-read after any await: the value may be stale and another change
-		// may have landed while we resolved.
+		// Re-check after the await: a host restart / schema refresh may have
+		// landed while we resolved. Re-run the schema gate (not just a config
+		// existence check) so we never dispatch a key the *current* schema no
+		// longer advertises - protects older / 3rd-party hosts.
+		if (!this._schemaHasKey(entry.key)) {
+			return;
+		}
 		const rootState = this._agentHostService.rootState.value;
 		if (!rootState || rootState instanceof Error || !rootState.config) {
 			return;

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostTerminalContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostTerminalContribution.test.ts
@@ -143,9 +143,9 @@ function rootStateWithoutDefaultShellKey(): RootState {
 	});
 }
 
-function rootStateWithDisableCustomTerminalToolKey(): RootState {
+function rootStateWithEnableCustomTerminalToolKey(): RootState {
 	return makeRootStateWithSchema({
-		[AgentHostConfigKey.DisableCustomTerminalTool]: { type: 'boolean', title: 'Use SDK Terminal Tool' },
+		[AgentHostConfigKey.EnableCustomTerminalTool]: { type: 'boolean', title: 'Use Agent Host Terminal Tool' },
 	});
 }
 
@@ -333,35 +333,35 @@ suite('AgentHostTerminalContribution', () => {
 		assert.strictEqual(resolver.lastOptions?.remoteAuthority, undefined);
 	});
 
-	test('dispatches inverted disableCustomTerminalTool from the VS Code setting', async () => {
+	test('dispatches enableCustomTerminalTool from the VS Code setting', async () => {
 		const { agentHostService, configurationService } = setup(disposables);
 		configurationService.setUserConfiguration(AgentHostCustomTerminalToolEnabledSettingId, false);
 
-		agentHostService.setRootState(rootStateWithDisableCustomTerminalToolKey());
+		agentHostService.setRootState(rootStateWithEnableCustomTerminalToolKey());
 		await flush();
 
 		assert.strictEqual(agentHostService.dispatchedActions.length, 1);
 		assert.deepStrictEqual((agentHostService.dispatchedActions[0].action as IRootConfigChangedAction).config, {
-			[AgentHostConfigKey.DisableCustomTerminalTool]: true,
+			[AgentHostConfigKey.EnableCustomTerminalTool]: false,
 		});
 	});
 
-	test('dispatches disableCustomTerminalTool false by default', async () => {
+	test('dispatches enableCustomTerminalTool true when the setting is enabled', async () => {
 		const { agentHostService } = setup(disposables);
 
-		agentHostService.setRootState(rootStateWithDisableCustomTerminalToolKey());
+		agentHostService.setRootState(rootStateWithEnableCustomTerminalToolKey());
 		await flush();
 
 		assert.strictEqual(agentHostService.dispatchedActions.length, 1);
 		assert.deepStrictEqual((agentHostService.dispatchedActions[0].action as IRootConfigChangedAction).config, {
-			[AgentHostConfigKey.DisableCustomTerminalTool]: false,
+			[AgentHostConfigKey.EnableCustomTerminalTool]: true,
 		});
 	});
 
-	test('re-dispatches disableCustomTerminalTool when the enabled setting changes', async () => {
+	test('re-dispatches enableCustomTerminalTool when the enabled setting changes', async () => {
 		const { agentHostService, configurationService } = setup(disposables);
-		const rootState = rootStateWithDisableCustomTerminalToolKey();
-		rootState.config!.values[AgentHostConfigKey.DisableCustomTerminalTool] = false;
+		const rootState = rootStateWithEnableCustomTerminalToolKey();
+		rootState.config!.values[AgentHostConfigKey.EnableCustomTerminalTool] = true;
 		agentHostService.setRootState(rootState);
 		await flush();
 		assert.deepStrictEqual(agentHostService.dispatchedActions as readonly unknown[], []);
@@ -377,7 +377,7 @@ suite('AgentHostTerminalContribution', () => {
 
 		assert.strictEqual(agentHostService.dispatchedActions.length, 1);
 		assert.deepStrictEqual((agentHostService.dispatchedActions[0].action as IRootConfigChangedAction).config, {
-			[AgentHostConfigKey.DisableCustomTerminalTool]: true,
+			[AgentHostConfigKey.EnableCustomTerminalTool]: false,
 		});
 	});
 
@@ -401,19 +401,19 @@ suite('AgentHostTerminalContribution', () => {
 		assert.strictEqual(agentHostService.dispatchedActions.length, 1);
 	});
 
-	test('does not re-dispatch disableCustomTerminalTool on a value-only root-state change', async () => {
+	test('does not re-dispatch enableCustomTerminalTool on a value-only root-state change', async () => {
 		const { agentHostService } = setup(disposables);
 
 		// Schema hydrates with our preferred value already present → no push.
-		const rootState = rootStateWithDisableCustomTerminalToolKey();
-		rootState.config!.values[AgentHostConfigKey.DisableCustomTerminalTool] = false;
+		const rootState = rootStateWithEnableCustomTerminalToolKey();
+		rootState.config!.values[AgentHostConfigKey.EnableCustomTerminalTool] = true;
 		agentHostService.setRootState(rootState);
 		await flush();
 		assert.deepStrictEqual(agentHostService.dispatchedActions as readonly unknown[], []);
 
 		// Another window flips the shared value. Schema unchanged → no fight.
-		const updated = rootStateWithDisableCustomTerminalToolKey();
-		updated.config!.values[AgentHostConfigKey.DisableCustomTerminalTool] = true;
+		const updated = rootStateWithEnableCustomTerminalToolKey();
+		updated.config!.values[AgentHostConfigKey.EnableCustomTerminalTool] = false;
 		agentHostService.setRootState(updated);
 		await flush();
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostTerminalContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostTerminalContribution.test.ts
@@ -373,11 +373,51 @@ suite('AgentHostTerminalContribution', () => {
 			source: 1, // ConfigurationTarget.USER
 			change: { keys: [AgentHostCustomTerminalToolEnabledSettingId], overrides: [] },
 		});
+		await flush();
 
 		assert.strictEqual(agentHostService.dispatchedActions.length, 1);
 		assert.deepStrictEqual((agentHostService.dispatchedActions[0].action as IRootConfigChangedAction).config, {
 			[AgentHostConfigKey.DisableCustomTerminalTool]: true,
 		});
+	});
+
+	test('does not re-dispatch when another window changes the shared root config value (no schema change)', async () => {
+		const { agentHostService } = setup(disposables);
+
+		// Schema hydrates → initial push for defaultShell.
+		agentHostService.setRootState(rootStateWithDefaultShellKey());
+		await flush();
+		assert.strictEqual(agentHostService.dispatchedActions.length, 1);
+
+		// Another window writes a *different* value into the shared root config.
+		// The schema is unchanged - only the value differs. This must NOT trigger
+		// a re-push, otherwise two windows with different settings ping-pong
+		// forever (the loop this guards against).
+		const updated = rootStateWithDefaultShellKey();
+		updated.config!.values[AgentHostConfigKey.DefaultShell] = 'C:/other/window/shell.exe';
+		agentHostService.setRootState(updated);
+		await flush();
+
+		assert.strictEqual(agentHostService.dispatchedActions.length, 1);
+	});
+
+	test('does not re-dispatch disableCustomTerminalTool on a value-only root-state change', async () => {
+		const { agentHostService } = setup(disposables);
+
+		// Schema hydrates with our preferred value already present → no push.
+		const rootState = rootStateWithDisableCustomTerminalToolKey();
+		rootState.config!.values[AgentHostConfigKey.DisableCustomTerminalTool] = false;
+		agentHostService.setRootState(rootState);
+		await flush();
+		assert.deepStrictEqual(agentHostService.dispatchedActions as readonly unknown[], []);
+
+		// Another window flips the shared value. Schema unchanged → no fight.
+		const updated = rootStateWithDisableCustomTerminalToolKey();
+		updated.config!.values[AgentHostConfigKey.DisableCustomTerminalTool] = true;
+		agentHostService.setRootState(updated);
+		await flush();
+
+		assert.deepStrictEqual(agentHostService.dispatchedActions as readonly unknown[], []);
 	});
 });
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostTerminalContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostTerminalContribution.test.ts
@@ -91,8 +91,12 @@ class MockTerminalProfileResolverService extends mock<ITerminalProfileResolverSe
 	};
 	public lastOptions: IShellLaunchConfigResolveOptions | undefined;
 
+	/** Optional hook invoked inside getDefaultProfile, before it resolves. */
+	public onResolve: (() => void) | undefined;
+
 	override async getDefaultProfile(options: IShellLaunchConfigResolveOptions): Promise<ITerminalProfile> {
 		this.lastOptions = options;
+		this.onResolve?.();
 		if (this.profile instanceof Error) {
 			throw this.profile;
 		}
@@ -317,6 +321,23 @@ suite('AgentHostTerminalContribution', () => {
 	test('skips dispatch when the resolver throws', async () => {
 		const { agentHostService, resolver } = setup(disposables);
 		resolver.profile = new Error('resolver failed');
+
+		agentHostService.setRootState(rootStateWithDefaultShellKey());
+		await flush();
+
+		assert.deepStrictEqual(agentHostService.dispatchedActions, []);
+	});
+
+	test('skips dispatch when the schema retracts the key while resolving', async () => {
+		const { agentHostService, resolver } = setup(disposables);
+		resolver.profile = { profileName: 'Bash', path: '/usr/bin/bash', args: [], isDefault: true };
+
+		// While getDefaultProfile is in flight (e.g. a host restart / schema
+		// refresh lands), swap to a schema that no longer advertises
+		// defaultShell. The post-await schema gate must catch this and bail.
+		resolver.onResolve = () => {
+			agentHostService.setRootState(rootStateWithoutDefaultShellKey());
+		};
 
 		agentHostService.setRootState(rootStateWithDefaultShellKey());
 		await flush();


### PR DESCRIPTION
Fix https://github.com/microsoft/vscode/issues/320011

## Problem

The local agent host's root config is **shared across all VS Code windows**. `AgentHostTerminalContribution` pushes a couple of host-managed values into  `defaultShell` and ` and listened to `rootState.onDidChange` to re-push them.disableCustomTerminalTool` it 

The bug: that listener re-pushed on **every** root-state change, including value changes made by *other* windows. So two windows with different terminal settings would ping-pong `root/configChanged` actions forever, each forcing its own value back over the other's.

Captured agent-host protocol logs show ~8000 `root/configChanged` dispatches in 25s, alternating between two windows:

| Window | `disableCustomTerminalTool` | `defaultShell` |
|--------|------|------|
| `79ed98fd` | `false` | PowerShell 7 (`pwsh.exe`) |
| `d551eb09` | `true` | Windows PowerShell v1.0 |

## Fix

The `rootState.onDidChange` re-push only ever needed to do one thing: retry the initial push once the host's root-config **schema hydrates** (the first push from `_reconcile()` can race an undefined `rootState.value`). It was never meant to react to value changes.

 present**, tracked via a `Set<AgentHostConfigKey>`. Value-only changes (another window writing a different value) are ignored, which breaks the loop. The existing value-equality guard still prevents redundant self-dispatches.

## Refactor

While here, the two managed keys are now a **data-driven table** (`IManagedRootConfigKey[]`). The schema gate, value-equality guard, dispatch, and hydration-retry are shared in a single generic `_push(entry)`. Adding a new managed root-config key is now one table  no new fields, no copy/pasted push logic.entry 

## Notes for reviewers

- One existing test (`re-dispatches disableCustomTerminalTool when the enabled setting changes`) gained an `await flush()` because the push pipeline is now uniformly async (`computeValue` may be async). The dispatch simply lands a microtask  behavior is otherwise unchanged.later 
- Added 2 regression tests asserting a value-only root-state change from another window does **not** trigger a re-dispatch.
- This stops windows from *fighting*. The underlying design  multiple windows share one singleton root config, so it's last-writer- is unchanged; reconciling divergent per-window settings would be a larger design change.wins reality 

Type-check (`tsgo`), ESLint, and all 15 tests pass.

(Written by Copilot)
