### PR TITLE
feat(copilot/chat): make /review a first-class chat command

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -1387,8 +1387,7 @@
           },
           {
             "name": "review",
-            "description": "%copilot.workspace.review.description%",
-            "when": "github.copilot.advanced.review.intent"
+            "description": "%copilot.workspace.review.description%"
           },
           {
             "name": "tests",
@@ -1517,8 +1516,7 @@
           },
           {
             "name": "review",
-            "description": "%copilot.workspace.review.description%",
-            "when": "github.copilot.advanced.review.intent"
+            "description": "%copilot.workspace.review.description%"
           },
           {
             "name": "tests",

--- a/extensions/copilot/src/extension/inlineChat/vscode-node/inlineChatCommands.ts
+++ b/extensions/copilot/src/extension/inlineChat/vscode-node/inlineChatCommands.ts
@@ -265,9 +265,9 @@ ${message}`,
 	disposables.add(vscode.commands.registerCommand('github.copilot.chat.explain', doExplain));
 	disposables.add(vscode.commands.registerCommand('github.copilot.chat.explain.palette', () => doExplain(undefined, true)));
 	disposables.add(vscode.commands.registerCommand('github.copilot.chat.review', () => instaService.createInstance(ReviewSession).review('selection', vscode.ProgressLocation.Notification)));
-	disposables.add(vscode.commands.registerCommand('github.copilot.chat.review.stagedChanges', () => instaService.createInstance(ReviewSession).review('index', vscode.ProgressLocation.Notification)));
-	disposables.add(vscode.commands.registerCommand('github.copilot.chat.review.unstagedChanges', () => instaService.createInstance(ReviewSession).review('workingTree', vscode.ProgressLocation.Notification)));
-	disposables.add(vscode.commands.registerCommand('github.copilot.chat.review.changes', () => instaService.createInstance(ReviewSession).review('all', vscode.ProgressLocation.Notification)));
+	disposables.add(vscode.commands.registerCommand('github.copilot.chat.review.stagedChanges', () => vscode.commands.executeCommand('workbench.action.chat.open', { query: '/review staged' })));
+	disposables.add(vscode.commands.registerCommand('github.copilot.chat.review.unstagedChanges', () => vscode.commands.executeCommand('workbench.action.chat.open', { query: '/review unstaged' })));
+	disposables.add(vscode.commands.registerCommand('github.copilot.chat.review.changes', () => vscode.commands.executeCommand('workbench.action.chat.open', { query: '/review all' })));
 	disposables.add(vscode.commands.registerCommand('github.copilot.chat.review.stagedFileChange', (resource: vscode.SourceControlResourceState) => {
 		return instaService.createInstance(ReviewSession).review({ group: 'index', file: resource.resourceUri }, vscode.ProgressLocation.Notification);
 	}));
@@ -291,6 +291,30 @@ ${message}`,
 	disposables.add(vscode.commands.registerCommand('github.copilot.chat.review.previous', thread => goToNextReview(thread, -1)));
 	disposables.add(vscode.commands.registerCommand('github.copilot.chat.review.next', thread => goToNextReview(thread, +1)));
 	disposables.add(vscode.commands.registerCommand('github.copilot.chat.review.current', thread => goToNextReview(thread, 0)));
+	disposables.add(vscode.commands.registerCommand('github.copilot.chat.review.nextFromChat', () => {
+		// `getActiveThread()` can return a thread that no longer maps to a known review
+		// comment (e.g. after removeReviewComments or external dispose). In that case,
+		// fall back to `undefined` so `goToNextReview` lands on the first comment
+		// instead of no-oping.
+		const active = reviewService.getActiveThread();
+		const activeComment = active ? reviewService.findReviewComment(active) : undefined;
+		goToNextReview(activeComment ? active : undefined, +1);
+	}));
+	disposables.add(vscode.commands.registerCommand('github.copilot.chat.review.revealComment', (uriStr: string, line: number, _char: number) => {
+		const targetUri = vscode.Uri.parse(uriStr);
+		const comments = reviewService.getReviewComments();
+		const match = comments.find(c =>
+			c.uri.toString() === targetUri.toString() && c.range.start.line === line - 1
+		);
+		if (!match) {
+			return;
+		}
+		const thread = reviewService.findCommentThread(match);
+		if (!thread) {
+			return;
+		}
+		(thread as unknown as vscode.CommentThread2).reveal();
+	}));
 	disposables.add(vscode.commands.registerCommand('github.copilot.chat.generate', doGenerate));
 	disposables.add(vscode.commands.registerCommand('github.copilot.chat.fix', doFix));
 	disposables.add(vscode.commands.registerCommand('github.copilot.chat.generateAltText', doGenerateAltText));

--- a/extensions/copilot/src/extension/intents/node/reviewIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/reviewIntent.ts
@@ -6,17 +6,27 @@
 import * as l10n from '@vscode/l10n';
 import { RenderPromptResult } from '@vscode/prompt-tsx';
 import type * as vscode from 'vscode';
+import { IAuthenticationService } from '../../../platform/authentication/common/authentication';
 import { IResponsePart } from '../../../platform/chat/common/chatMLFetcher';
 import { ChatLocation } from '../../../platform/chat/common/commonTypes';
+import { ICustomInstructionsService } from '../../../platform/customInstructions/common/customInstructionsService';
 import { TextDocumentSnapshot } from '../../../platform/editing/common/textDocumentSnapshot';
+import { ICAPIClientService } from '../../../platform/endpoint/common/capiClient';
+import { IDomainService } from '../../../platform/endpoint/common/domainService';
 import { IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
+import { IEnvService } from '../../../platform/env/common/envService';
 import { IGitExtensionService } from '../../../platform/git/common/gitExtensionService';
+import { IIgnoreService } from '../../../platform/ignore/common/ignoreService';
 import { ILogService } from '../../../platform/log/common/logService';
+import { IFetcherService } from '../../../platform/networking/common/fetcherService';
 import { IChatEndpoint } from '../../../platform/networking/common/networking';
+import { Progress } from '../../../platform/notification/common/notificationService';
 import { IReviewService, ReviewComment, ReviewRequest } from '../../../platform/review/common/reviewService';
 import { ITabsAndEditorsService } from '../../../platform/tabs/common/tabsAndEditorsService';
 import { IWorkspaceService } from '../../../platform/workspace/common/workspaceService';
+import { DeferredPromise } from '../../../util/vs/base/common/async';
 import { CancellationToken } from '../../../util/vs/base/common/cancellation';
+import { DisposableStore } from '../../../util/vs/base/common/lifecycle';
 import * as path from '../../../util/vs/base/common/path';
 import { generateUuid } from '../../../util/vs/base/common/uuid';
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
@@ -26,8 +36,10 @@ import { LinkifiedPart, LinkifiedText, LinkifyLocationAnchor } from '../../linki
 import { IContributedLinkifier, LinkifierContext } from '../../linkify/common/linkifyService';
 import { IBuildPromptContext } from '../../prompt/common/intents';
 import { IDocumentContext } from '../../prompt/node/documentContext';
-import { parseFeedbackResponse, parseReviewComments } from '../../prompt/node/feedbackGenerator';
-import { IIntent, IIntentInvocation, IIntentInvocationContext, IIntentSlashCommandInfo, IResponseProcessorContext, ReplyInterpreter } from '../../prompt/node/intents';
+import { FeedbackResult, parseFeedbackResponse, parseReviewComments } from '../../prompt/node/feedbackGenerator';
+import { IIntent, IIntentInvocation, IIntentInvocationContext, IIntentSlashCommandInfo, IResponseProcessorContext, IntentLinkificationOptions, nullRenderPromptResult, ReplyInterpreter } from '../../prompt/node/intents';
+import { githubReview } from '../../review/node/githubReviewAgent';
+import { ReviewGroup } from '../../review/node/doReview';
 import { PromptRenderer, RendererIntentInvocation } from '../../prompts/node/base/promptRenderer';
 import { CurrentChange, CurrentChangeInput } from '../../prompts/node/feedback/currentChange';
 import { ProvideFeedbackPrompt } from '../../prompts/node/feedback/provideFeedback';
@@ -36,12 +48,18 @@ export const reviewIntentPromptSnippet = 'Review the currently selected code.';
 
 export const reviewLocalChangesMessage = l10n.t('local changes');
 
+export class ReviewIntentInvocation extends RendererIntentInvocation implements IIntentInvocation {
 
-class ReviewIntentInvocation extends RendererIntentInvocation implements IIntentInvocation {
-
-	readonly linkification = {
-		additionaLinkifiers: [{ create: () => new LineLinkifier(this.documentContext.document.uri) }]
-	};
+	get linkification(): IntentLinkificationOptions | undefined {
+		// Only relevant on the inline (editor) path. The chat path renders its own
+		// anchors via markdown headers, so leave linkification disabled there to
+		// avoid `LineLinkifier` mis-anchoring against the SCM-button query.
+		if (this.location !== ChatLocation.Editor || !this.documentContext) {
+			return undefined;
+		}
+		const uri = this.documentContext.document.uri;
+		return { additionaLinkifiers: [{ create: () => new LineLinkifier(uri) }] };
+	}
 
 	constructor(
 		intent: IIntent,
@@ -53,6 +71,14 @@ class ReviewIntentInvocation extends RendererIntentInvocation implements IIntent
 		@ITabsAndEditorsService private readonly tabsAndEditorsService: ITabsAndEditorsService,
 		@ILogService private readonly logService: ILogService,
 		@IGitExtensionService private readonly gitExtensionService: IGitExtensionService,
+		@IAuthenticationService private readonly authService: IAuthenticationService,
+		@ICAPIClientService private readonly capiClientService: ICAPIClientService,
+		@IDomainService private readonly domainService: IDomainService,
+		@IFetcherService private readonly fetcherService: IFetcherService,
+		@IEnvService private readonly envService: IEnvService,
+		@IIgnoreService private readonly ignoreService: IIgnoreService,
+		@ICustomInstructionsService private readonly customInstructionsService: ICustomInstructionsService,
+		@IReviewService private readonly reviewService: IReviewService,
 	) {
 		super(intent, location, endpoint);
 	}
@@ -92,16 +118,288 @@ class ReviewIntentInvocation extends RendererIntentInvocation implements IIntent
 	}
 
 	override async buildPrompt(context: IBuildPromptContext, progress: vscode.Progress<vscode.ChatResponseProgressPart | vscode.ChatResponseReferencePart>, token: vscode.CancellationToken): Promise<RenderPromptResult> {
+		if (this.location === ChatLocation.Panel) {
+			// Chat path skips the legacy LLM render. `processResponse` drives `githubReview()` directly.
+			return nullRenderPromptResult();
+		}
 		if (context.query === '') {
 			context = { ...context, query: reviewIntentPromptSnippet };
 		}
 		return super.buildPrompt(context, progress, token);
 	}
+
+	async processResponse(context: IResponseProcessorContext, _inputStream: AsyncIterable<IResponsePart>, outputStream: vscode.ChatResponseStream, token: CancellationToken): Promise<void> {
+		// Inline (editor) chat overrides this on `InlineReviewIntentInvocation`.
+		if (this.location !== ChatLocation.Panel) {
+			return;
+		}
+		const copilotToken = await this.authService.getCopilotToken();
+		if (!copilotToken.isCopilotCodeReviewEnabled) {
+			outputStream.markdown(l10n.t('Code review is not available for this account.'));
+			return;
+		}
+		const editor = this.tabsAndEditorsService.activeTextEditor;
+		const parsed = parseReviewScope(context.turn.request.message);
+		let group: ReviewGroup;
+		switch (parsed) {
+			case 'selection':
+				if (editor && !editor.selection.isEmpty) {
+					group = 'selection';
+				} else {
+					outputStream.markdown(`> ${l10n.t('No active selection. Reviewing unstaged changes instead.')}\n\n`);
+					group = 'workingTree';
+				}
+				break;
+			case 'file':
+				if (editor) {
+					group = { group: 'workingTree', file: editor.document.uri };
+				} else {
+					outputStream.markdown(`> ${l10n.t('No active file. Reviewing unstaged changes instead.')}\n\n`);
+					group = 'workingTree';
+				}
+				break;
+			default:
+				group = parsed;
+				break;
+		}
+
+		// Scope-aware pre-clear of stale Comments-panel state. A re-run targeting a single
+		// file should only retire entries for that file; broader scopes wipe everything to
+		// match the side-panel behavior in doReview.ts.
+		const scopedUri = group === 'selection'
+			? editor?.document.uri
+			: (typeof group !== 'string' && 'file' in group ? group.file : undefined);
+		const existing = this.reviewService.getReviewComments();
+		const toRemove = scopedUri
+			? existing.filter(c => c.uri.toString() === scopedUri.toString())
+			: existing;
+		if (toRemove.length) {
+			this.reviewService.removeReviewComments(toRemove);
+		}
+
+		const scopeDescription = describeReviewScope(group);
+		outputStream.markdown(l10n.t('Reviewing {0}…\n\n', scopeDescription));
+
+		// Track every comment we hand to the review service so we can roll back on cancel.
+		const addedComments: ReviewComment[] = [];
+		const safeAdd = (comments: ReviewComment[]): void => {
+			try {
+				this.reviewService.addReviewComments(comments, { suppressAutoReveal: true });
+				addedComments.push(...comments);
+			} catch (err) {
+				this.logService.error(err, '[review intent] addReviewComments failed');
+				outputStream.markdown(l10n.t('Note: could not update Comments panel.') + '\n\n');
+			}
+		};
+
+		const reviewComplete = new DeferredPromise<string>();
+		const reviewStore = new DisposableStore();
+		// Cancellation should immediately stop the task-bound spinner; the
+		// `'Review cancelled.'` markdown line is rendered later in the cancel branch.
+		reviewStore.add(token.onCancellationRequested(() => {
+			if (!reviewComplete.isSettled) {
+				reviewComplete.complete(l10n.t('Review cancelled'));
+			}
+		}));
+
+		// Pin a task-bound spinner from the very start so the user sees activity through
+		// the slow `collectChanges` + `fetchComments` phases that fire before any phase
+		// callback. The spinner sustains until `reviewComplete` is settled at any of the
+		// exit paths (cancel / error / success / empty / defensive `finally`).
+		outputStream.progress(l10n.t('Analyzing your changes…'), () => reviewComplete.p);
+
+		const progress: Progress<ReviewComment[]> = {
+			report: comments => {
+				for (const comment of comments) {
+					if (token.isCancellationRequested) {
+						return;
+					}
+					safeAdd([comment]);
+				}
+			}
+		};
+		let result: FeedbackResult;
+		try {
+			result = await githubReview(
+				this.logService, this.gitExtensionService, this.authService,
+				this.capiClientService, this.domainService, this.fetcherService,
+				this.envService, this.ignoreService, this.workspaceService,
+				this.customInstructionsService, group, editor, progress, token
+			);
+			if (result.type === 'cancelled' || token.isCancellationRequested) {
+				if (!reviewComplete.isSettled) {
+					reviewComplete.complete(l10n.t('Review cancelled'));
+				}
+				if (addedComments.length) {
+					this.reviewService.removeReviewComments(addedComments);
+				}
+				outputStream.markdown(l10n.t('Review cancelled.'));
+				return;
+			}
+			if (result.type === 'error') {
+				if (!reviewComplete.isSettled) {
+					reviewComplete.complete(l10n.t('Review failed'));
+				}
+				outputStream.markdown(l10n.t('Review failed: {0}', result.reason));
+				return;
+			}
+			const excluded = result.excludedComments ?? [];
+			if (excluded.length) {
+				safeAdd(excluded);
+			}
+			const filesWithComments = new Set([...result.comments, ...excluded].map(c => c.uri.toString())).size;
+			if (result.comments.length === 0) {
+				if (!reviewComplete.isSettled) {
+					reviewComplete.complete(l10n.t('No issues found'));
+				}
+				outputStream.markdown(l10n.t('No issues found.'));
+				return;
+			}
+			if (!reviewComplete.isSettled) {
+				reviewComplete.complete(l10n.t('Review complete: {0} findings across {1} files', result.comments.length, filesWithComments));
+			}
+			outputStream.markdown(l10n.t('Review complete: {0} findings across {1} files.', result.comments.length, filesWithComments));
+			if (excluded.length) {
+				outputStream.markdown('\n\n' + l10n.t('{0} comments filtered by policy.', excluded.length));
+			}
+			if (result.comments.length + excluded.length >= 5) {
+				outputStream.markdown(buildFindingsByFileSummary(result.comments, excluded, this.workspaceService));
+			}
+			outputStream.button({ command: 'github.copilot.chat.review.nextFromChat', title: l10n.t('Next Comment') });
+		} catch (err) {
+			this.logService.error(err, '[review intent] githubReview threw');
+			if (!reviewComplete.isSettled) {
+				reviewComplete.complete(l10n.t('Review failed'));
+			}
+			outputStream.markdown(l10n.t('Review failed. Please try again.'));
+		} finally {
+			// Defensive: always settle the task-bound progress so the spinner stops,
+			// even if `githubReview` threw before the catch block ran.
+			if (!reviewComplete.isSettled) {
+				reviewComplete.complete(l10n.t('Review failed'));
+			}
+			reviewStore.dispose();
+		}
+	}
+}
+
+/**
+ * Parse the leading scope token from a `/review` chat query. Returns the
+ * scope to use; for `'selection'`/`'file'` the caller must verify an editor
+ * is present and fall back to `'workingTree'` if not. Unrecognised tokens,
+ * empty queries, and the SCM-button sentinel (`reviewLocalChangesMessage`)
+ * all map to `'workingTree'`.
+ */
+export function parseReviewScope(query: string): 'selection' | 'index' | 'workingTree' | 'all' | 'file' {
+	if (query === reviewLocalChangesMessage) {
+		return 'workingTree';
+	}
+	const first = query.trim().split(/\s+/, 1)[0]?.toLowerCase() ?? '';
+	switch (first) {
+		case 'staged': return 'index';
+		case 'unstaged': return 'workingTree';
+		case 'all': return 'all';
+		case 'selection': return 'selection';
+		case 'file': return 'file';
+		default: return 'workingTree';
+	}
+}
+
+/**
+ * Localized human-readable label for a review scope used in the entry narrative.
+ */
+function describeReviewScope(group: ReviewGroup): string {
+	if (typeof group !== 'string') {
+		if ('file' in group) {
+			return l10n.t('the current file');
+		}
+		return l10n.t('the requested changes');
+	}
+	switch (group) {
+		case 'selection': return l10n.t('the current selection');
+		case 'index': return l10n.t('staged changes');
+		case 'workingTree': return l10n.t('unstaged changes');
+		case 'all': return l10n.t('all changes');
+	}
+}
+
+/**
+ * Derive the structured fields needed to render one chat-narrative line for a
+ * streamed review comment. Code fences and collapsed whitespace are stripped so
+ * the excerpt stays on a single line, and long bodies are clipped to ~80
+ * characters with an ellipsis.
+ */
+function buildFindingExcerpt(comment: ReviewComment, workspaceService: IWorkspaceService): { severity: string; kind: string; relativePath: string; line: number; excerpt: string } {
+	const relativePath = workspaceService.asRelativePath(comment.uri);
+	const line = comment.range.start.line + 1;
+	const bodyText = typeof comment.body === 'string' ? comment.body : comment.body.value;
+	const stripped = bodyText.replace(/```[\s\S]*?```/g, '').replace(/\s+/g, ' ').trim();
+	const excerpt = stripped.length > 80 ? `${stripped.slice(0, 77)}…` : stripped;
+	return { severity: comment.severity, kind: comment.kind, relativePath, line, excerpt };
+}
+
+/**
+ * Build a per-file summary listing every finding (included and excluded) grouped
+ * by file as plain markdown. Files are sorted A→Z; within each group findings
+ * are ordered by line then character. Each file group is rendered as a `###`
+ * heading followed by a bullet list of clickable links, always expanded.
+ * Excluded comments are folded into the same group with a `(filtered)` suffix.
+ */
+function buildFindingsByFileSummary(included: readonly ReviewComment[], excluded: readonly ReviewComment[], workspaceService: IWorkspaceService): MarkdownString {
+	type GroupEntry = { comment: ReviewComment; isExcluded: boolean };
+	const groups = new Map<string, { relPath: string; entries: GroupEntry[] }>();
+	const addEntry = (comment: ReviewComment, isExcluded: boolean): void => {
+		const key = comment.uri.toString();
+		let group = groups.get(key);
+		if (!group) {
+			group = { relPath: workspaceService.asRelativePath(comment.uri), entries: [] };
+			groups.set(key, group);
+		}
+		group.entries.push({ comment, isExcluded });
+	};
+	for (const c of included) {
+		addEntry(c, false);
+	}
+	for (const c of excluded) {
+		addEntry(c, true);
+	}
+	const orderedGroups = [...groups.values()].sort((a, b) =>
+		a.relPath.localeCompare(b.relPath, undefined, { sensitivity: 'base' })
+	);
+	const lines: string[] = [];
+	lines.push(`**${l10n.t('Findings by file')}**`);
+	lines.push('');
+	for (const group of orderedGroups) {
+		const entries = group.entries.slice().sort((a, b) => {
+			const lineDiff = a.comment.range.start.line - b.comment.range.start.line;
+			if (lineDiff !== 0) {
+				return lineDiff;
+			}
+			return a.comment.range.start.character - b.comment.range.start.character;
+		});
+		const headingLabel = entries.length === 1
+			? l10n.t('{0} (1 finding)', group.relPath)
+			: l10n.t('{0} ({1} findings)', group.relPath, entries.length);
+		lines.push(`### ${headingLabel}`);
+		lines.push('');
+		for (const entry of entries) {
+			const { line, excerpt } = buildFindingExcerpt(entry.comment, workspaceService);
+			const basename = path.basename(entry.comment.uri.fsPath);
+			const suffix = entry.isExcluded ? ' ' + l10n.t('(filtered)') : '';
+			const ch = entry.comment.range.start.character;
+			const args = encodeURIComponent(JSON.stringify([entry.comment.uri.toString(), line, ch]));
+			lines.push(`- [${basename}:${line}](command:github.copilot.chat.review.revealComment?${args}): ${excerpt}${suffix}`);
+		}
+		lines.push('');
+	}
+	const md = new MarkdownString(lines.join('\n'));
+	md.isTrusted = { enabledCommands: ['github.copilot.chat.review.revealComment'] };
+	return md;
 }
 
 class InlineReviewIntentInvocation extends ReviewIntentInvocation implements IIntentInvocation {
 
-	processResponse(context: IResponseProcessorContext, inputStream: AsyncIterable<IResponsePart>, outputStream: vscode.ChatResponseStream, token: CancellationToken): Promise<void> {
+	override processResponse(context: IResponseProcessorContext, inputStream: AsyncIterable<IResponsePart>, outputStream: vscode.ChatResponseStream, token: CancellationToken): Promise<void> {
 		const replyInterpreter = this.instantiationService.createInstance(ReviewReplyInterpreter, this.documentContext);
 		return replyInterpreter.processResponse(context, inputStream, outputStream, token);
 	}

--- a/extensions/copilot/src/extension/intents/node/test/reviewIntent.spec.ts
+++ b/extensions/copilot/src/extension/intents/node/test/reviewIntent.spec.ts
@@ -1,0 +1,634 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import type * as vscode from 'vscode';
+import { IAuthenticationService } from '../../../../platform/authentication/common/authentication';
+import { CopilotToken, createTestExtendedTokenInfo } from '../../../../platform/authentication/common/copilotToken';
+import { ChatLocation } from '../../../../platform/chat/common/commonTypes';
+import { MockAuthenticationService } from '../../../../platform/ignore/node/test/mockAuthenticationService';
+import { IChatEndpoint } from '../../../../platform/networking/common/networking';
+import { IReviewService, ReviewComment } from '../../../../platform/review/common/reviewService';
+import { ITabsAndEditorsService, TabInfo, TabChangeEvent } from '../../../../platform/tabs/common/tabsAndEditorsService';
+import { ITestingServicesAccessor } from '../../../../platform/test/node/services';
+import { CancellationToken, CancellationTokenSource } from '../../../../util/vs/base/common/cancellation';
+import { DisposableStore } from '../../../../util/vs/base/common/lifecycle';
+import { Event } from '../../../../util/vs/base/common/event';
+import { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
+import { ChatResponseAnchorPart, ChatResponseCommandButtonPart, ChatResponseMarkdownPart, ChatResponseProgressPart2 } from '../../../../vscodeTypes';
+import { ChatResponseStreamImpl } from '../../../../util/common/chatResponseStreamImpl';
+import { Turn } from '../../../prompt/common/conversation';
+import { IResponseProcessorContext } from '../../../prompt/node/intents';
+import { createExtensionUnitTestingServices } from '../../../test/node/services';
+import { MockChatResponseStream, TestChatRequest } from '../../../test/node/testHelpers';
+import { parseReviewScope, ReviewIntent, ReviewIntentInvocation, reviewLocalChangesMessage } from '../reviewIntent';
+
+vi.mock('../../../review/node/githubReviewAgent', async () => {
+	const actual = await vi.importActual<typeof import('../../../review/node/githubReviewAgent')>('../../../review/node/githubReviewAgent');
+	return {
+		...actual,
+		githubReview: vi.fn(),
+	};
+});
+
+import { githubReview } from '../../../review/node/githubReviewAgent';
+
+const mockedGithubReview = vi.mocked(githubReview);
+
+class ControllableAuthService extends MockAuthenticationService {
+	private _token: CopilotToken = new CopilotToken(createTestExtendedTokenInfo({ code_review_enabled: false }));
+	override getCopilotToken(_force?: boolean): Promise<CopilotToken> {
+		return Promise.resolve(this._token);
+	}
+	setToken(token: CopilotToken) {
+		this._token = token;
+	}
+}
+
+describe('parseReviewScope', () => {
+	test('maps tokens (and sentinels) to scope values', () => {
+		assert.deepStrictEqual(
+			{
+				empty: parseReviewScope(''),
+				staged: parseReviewScope('staged'),
+				unstaged: parseReviewScope('unstaged'),
+				all: parseReviewScope('all'),
+				selection: parseReviewScope('selection'),
+				file: parseReviewScope('file'),
+				caseInsensitive: parseReviewScope('STAGED'),
+				withTrailingArg: parseReviewScope('staged extra arg'),
+				unrecognised: parseReviewScope('please review'),
+				scmSentinel: parseReviewScope(reviewLocalChangesMessage),
+			},
+			{
+				empty: 'workingTree',
+				staged: 'index',
+				unstaged: 'workingTree',
+				all: 'all',
+				selection: 'selection',
+				file: 'file',
+				caseInsensitive: 'index',
+				withTrailingArg: 'index',
+				unrecognised: 'workingTree',
+				scmSentinel: 'workingTree',
+			}
+		);
+	});
+});
+
+/**
+ * Minimal `IReviewService` test double tracking lifecycle calls so we can assert
+ * the new chat-narrative wiring without spinning up the real Comments-panel host.
+ */
+class MockReviewService implements IReviewService {
+	declare readonly _serviceBrand: undefined;
+	private comments: ReviewComment[] = [];
+	readonly addedComments: ReviewComment[] = [];
+	readonly removedComments: ReviewComment[] = [];
+	throwOnAdd = false;
+
+	updateContextValues(): void { }
+	isCodeFeedbackEnabled(): boolean { return true; }
+	isReviewDiffEnabled(): boolean { return true; }
+	isIntentEnabled(): boolean { return true; }
+	getDiagnosticCollection() { return { get: () => undefined, set: () => { } }; }
+	getReviewComments(): ReviewComment[] { return this.comments.slice(); }
+	addReviewComments(comments: ReviewComment[], _opts?: { suppressAutoReveal?: boolean }): void {
+		if (this.throwOnAdd) {
+			throw new Error('addReviewComments boom');
+		}
+		this.addedComments.push(...comments);
+		this.comments.push(...comments);
+	}
+	collapseReviewComment(_comment: ReviewComment): void { }
+	removeReviewComments(comments: ReviewComment[]): void {
+		this.removedComments.push(...comments);
+		this.comments = this.comments.filter(c => !comments.includes(c));
+	}
+	updateReviewComment(_comment: ReviewComment): void { }
+	findReviewComment() { return undefined; }
+	findCommentThread() { return undefined; }
+	getActiveThread(): vscode.CommentThread | undefined { return undefined; }
+	/** Test helper: seed pre-existing comments without recording them in `addedComments`. */
+	seed(...comments: ReviewComment[]): void {
+		this.comments.push(...comments);
+	}
+}
+
+function makeComment(uriPath: string, line: number, body: string, kind = 'bug', severity = 'medium'): ReviewComment {
+	return {
+		uri: { fsPath: uriPath, toString: () => `file://${uriPath}` } as unknown as vscode.Uri,
+		range: { start: { line, character: 0 }, end: { line, character: 0 } } as unknown as vscode.Range,
+		body,
+		kind,
+		severity,
+	} as unknown as ReviewComment;
+}
+
+/**
+ * Configurable `ITabsAndEditorsService` test double so tests can drive the
+ * active-editor branch of `processResponse` (e.g. for the `file` scope path).
+ */
+class MockTabsAndEditorsService implements ITabsAndEditorsService {
+	declare readonly _serviceBrand: undefined;
+	activeTextEditor: vscode.TextEditor | undefined = undefined;
+	readonly visibleTextEditors: readonly vscode.TextEditor[] = [];
+	readonly activeNotebookEditor: vscode.NotebookEditor | undefined = undefined;
+	readonly visibleNotebookEditors: readonly vscode.NotebookEditor[] = [];
+	readonly tabs: TabInfo[] = [];
+	readonly onDidChangeActiveTextEditor: vscode.Event<vscode.TextEditor | undefined> = Event.None;
+	readonly onDidChangeTabs: vscode.Event<TabChangeEvent> = Event.None;
+}
+
+describe('ReviewIntentInvocation processResponse (Panel)', () => {
+	let disposables: DisposableStore;
+	let accessor: ITestingServicesAccessor;
+	let instantiationService: IInstantiationService;
+	let authService: ControllableAuthService;
+	let reviewService: MockReviewService;
+	let tabsService: MockTabsAndEditorsService;
+
+	beforeEach(() => {
+		disposables = new DisposableStore();
+		const services = createExtensionUnitTestingServices();
+		authService = new ControllableAuthService();
+		reviewService = new MockReviewService();
+		tabsService = new MockTabsAndEditorsService();
+		services.define(IAuthenticationService, authService);
+		services.define(IReviewService, reviewService);
+		services.define(ITabsAndEditorsService, tabsService);
+		accessor = services.createTestingAccessor();
+		disposables.add(accessor);
+		instantiationService = accessor.get(IInstantiationService);
+		mockedGithubReview.mockReset();
+	});
+
+	afterEach(() => {
+		disposables.dispose();
+	});
+
+	function enableCodeReview() {
+		authService.setToken(new CopilotToken(createTestExtendedTokenInfo({ code_review_enabled: true })));
+	}
+
+	function makeContext(message: string): IResponseProcessorContext {
+		const turn = new Turn('turn-1', { type: 'user', message });
+		return {
+			chatSessionId: 'session-1',
+			turn,
+			messages: [],
+		} as unknown as IResponseProcessorContext;
+	}
+
+	async function createInvocation(): Promise<ReviewIntentInvocation> {
+		const intent = instantiationService.createInstance(ReviewIntent);
+		const invocation = await intent.invoke({
+			location: ChatLocation.Panel,
+			request: new TestChatRequest('') as any,
+			documentContext: undefined,
+		});
+		return invocation as ReviewIntentInvocation;
+	}
+
+	async function emptyStream(): Promise<AsyncIterable<never>> {
+		return (async function* () { })();
+	}
+
+	function makeTrackingStream(): { stream: MockChatResponseStream; getButtons: () => vscode.Command[] } {
+		const parts: vscode.ExtendedChatResponsePart[] = [];
+		const stream = new MockChatResponseStream(part => parts.push(part));
+		const getButtons = () => parts
+			.filter((p): p is ChatResponseCommandButtonPart => p instanceof ChatResponseCommandButtonPart)
+			.map(p => p.value);
+		return { stream, getButtons };
+	}
+
+	/**
+	 * Parts-capturing stream for tests that need to inspect the ordering of
+	 * markdown / anchor / button emissions, or the underlying `MarkdownString`
+	 * instances on the summary block.
+	 */
+	function makePartsStream(): {
+		stream: ChatResponseStreamImpl;
+		parts: vscode.ExtendedChatResponsePart[];
+		output: string[];
+		getButtons: () => vscode.Command[];
+		findSummaryPart: () => ChatResponseMarkdownPart | undefined;
+	} {
+		const parts: vscode.ExtendedChatResponsePart[] = [];
+		const output: string[] = [];
+		const stream = new ChatResponseStreamImpl(
+			part => {
+				parts.push(part);
+				if (part instanceof ChatResponseMarkdownPart) {
+					output.push(part.value.value);
+				}
+			},
+			() => { },
+		);
+		const getButtons = () => parts
+			.filter((p): p is ChatResponseCommandButtonPart => p instanceof ChatResponseCommandButtonPart)
+			.map(p => p.value);
+		const findSummaryPart = () => parts.find((p): p is ChatResponseMarkdownPart =>
+			p instanceof ChatResponseMarkdownPart && p.value.value.includes('**Findings by file**')
+		);
+		return { stream, parts, output, getButtons, findSummaryPart };
+	}
+
+	test('refuses when code review is not enabled', async () => {
+		// Default token has code_review_enabled: false
+		const invocation = await createInvocation();
+		const stream = new MockChatResponseStream();
+		await invocation.processResponse!(makeContext(''), await emptyStream(), stream, CancellationToken.None);
+
+		expect(mockedGithubReview).not.toHaveBeenCalled();
+		expect(stream.output.join('\n')).toMatch(/not available/i);
+	});
+
+	test('happy path: pushes comments to review service, narrates milestones, renders buttons (no markdown dump)', async () => {
+		enableCodeReview();
+		const sampleComments = [makeComment('/workspace/foo.ts', 9, 'Consider renaming this variable.')];
+		mockedGithubReview.mockImplementation(async (...args: any[]) => {
+			const progress = args[12];
+			progress.report(sampleComments);
+			return { type: 'success', comments: sampleComments };
+		});
+
+		const invocation = await createInvocation();
+		const { stream, parts, output, getButtons } = makePartsStream();
+		await invocation.processResponse!(makeContext('staged'), await emptyStream(), stream, CancellationToken.None);
+
+		const out = output.join('');
+		// Phase 1 markdown dump must be gone.
+		expect(out).not.toMatch(/### .*foo\.ts:10/);
+		expect(out).not.toMatch(/\n---\n/);
+		// Phase 4c (Bug 3): per-finding stream block deleted; no anchor parts, no "Found ..." narration.
+		expect(parts.find(p => p instanceof ChatResponseAnchorPart)).toBeUndefined();
+		expect(out).not.toMatch(/Found medium bug in/);
+		// Narrative milestones in order: header → completion summary.
+		const reviewing = out.indexOf('Reviewing');
+		const complete = out.indexOf('Review complete');
+		expect(reviewing).toBeGreaterThanOrEqual(0);
+		expect(complete).toBeGreaterThan(reviewing);
+		expect(out).toMatch(/Review complete: 1 findings across 1 files/);
+		// Comments-panel wiring.
+		expect(reviewService.addedComments).toEqual(sampleComments);
+		// Buttons: single consolidated "Next Comment" button.
+		const buttons = getButtons();
+		expect(buttons).toHaveLength(1);
+		expect(buttons[0].command).toBe('github.copilot.chat.review.nextFromChat');
+		expect(buttons[0].title).toBe('Next Comment');
+	});
+
+	test('regression (Phase 2): addReviewComments is called with each streamed comment in the streaming path', async () => {
+		enableCodeReview();
+		const streamed = [
+			makeComment('/workspace/a.ts', 0, 'a1'),
+			makeComment('/workspace/b.ts', 1, 'b1'),
+			makeComment('/workspace/c.ts', 2, 'c1'),
+		];
+		mockedGithubReview.mockImplementation(async (...args: any[]) => {
+			const progress = args[12];
+			// Report comments in separate batches to exercise the per-batch add path.
+			progress.report([streamed[0]]);
+			progress.report([streamed[1], streamed[2]]);
+			return { type: 'success', comments: streamed };
+		});
+
+		const invocation = await createInvocation();
+		const stream = new MockChatResponseStream();
+		await invocation.processResponse!(makeContext('all'), await emptyStream(), stream, CancellationToken.None);
+
+		expect(reviewService.addedComments).toEqual(streamed);
+	});
+
+	test('summary suppressed when total findings < 5', async () => {
+		enableCodeReview();
+		const four = [
+			makeComment('/workspace/a.ts', 0, 'a1'),
+			makeComment('/workspace/a.ts', 1, 'a2'),
+			makeComment('/workspace/b.ts', 0, 'b1'),
+			makeComment('/workspace/b.ts', 1, 'b2'),
+		];
+		mockedGithubReview.mockImplementation(async (...args: any[]) => {
+			const progress = args[12];
+			progress.report(four);
+			return { type: 'success', comments: four };
+		});
+
+		const invocation = await createInvocation();
+		const { stream, output, findSummaryPart } = makePartsStream();
+		await invocation.processResponse!(makeContext('all'), await emptyStream(), stream, CancellationToken.None);
+
+		expect(findSummaryPart()).toBeUndefined();
+		expect(output.join('')).not.toMatch(/Findings by file/);
+	});
+
+	test('summary emitted when total findings >= 5 with A→Z group ordering', async () => {
+		enableCodeReview();
+		// Emit zzz.ts first so we can assert the summary re-orders to aaa.ts → zzz.ts.
+		const comments = [
+			makeComment('/workspace/zzz.ts', 0, 'z1'),
+			makeComment('/workspace/zzz.ts', 1, 'z2'),
+			makeComment('/workspace/zzz.ts', 2, 'z3'),
+			makeComment('/workspace/aaa.ts', 0, 'a1'),
+			makeComment('/workspace/aaa.ts', 1, 'a2'),
+		];
+		mockedGithubReview.mockImplementation(async (...args: any[]) => {
+			const progress = args[12];
+			progress.report(comments);
+			return { type: 'success', comments };
+		});
+
+		const invocation = await createInvocation();
+		const { stream, findSummaryPart } = makePartsStream();
+		await invocation.processResponse!(makeContext('all'), await emptyStream(), stream, CancellationToken.None);
+
+		const summary = findSummaryPart();
+		expect(summary).toBeDefined();
+		const summaryText = summary!.value.value;
+		const aIdx = summaryText.indexOf('/workspace/aaa.ts');
+		const zIdx = summaryText.indexOf('/workspace/zzz.ts');
+		expect(aIdx).toBeGreaterThan(-1);
+		expect(zIdx).toBeGreaterThan(aIdx);
+	});
+
+	test('per-file `### relPath (N findings)` heading: singular vs plural form, always expanded (no HTML)', async () => {
+		enableCodeReview();
+		const many = [
+			makeComment('/workspace/many.ts', 0, 'm1'),
+			makeComment('/workspace/many.ts', 1, 'm2'),
+			makeComment('/workspace/many.ts', 2, 'm3'),
+			makeComment('/workspace/many.ts', 3, 'm4'),
+		];
+		const few = [makeComment('/workspace/few.ts', 0, 'f1')];
+		const all = [...many, ...few];
+		mockedGithubReview.mockImplementation(async (...args: any[]) => {
+			const progress = args[12];
+			progress.report(all);
+			return { type: 'success', comments: all };
+		});
+
+		const invocation = await createInvocation();
+		const { stream, findSummaryPart } = makePartsStream();
+		await invocation.processResponse!(makeContext('all'), await emptyStream(), stream, CancellationToken.None);
+
+		const summary = findSummaryPart()!;
+		const summaryText = summary.value.value;
+		// Plain-markdown headings (no <details>/<summary> HTML), singular + plural.
+		expect(summaryText).toMatch(/^### [^\n]*few\.ts \(1 finding\)$/m);
+		expect(summaryText).toMatch(/^### [^\n]*many\.ts \(4 findings\)$/m);
+		expect(summaryText).not.toMatch(/<details/);
+		expect(summaryText).not.toMatch(/<summary/);
+		// Summary MarkdownString must NOT opt into HTML rendering.
+		expect(summary.value.supportHtml).not.toBe(true);
+	});
+
+	test('excluded comments folded into the same file group with ` (filtered)` suffix', async () => {
+		enableCodeReview();
+		const kept = [
+			makeComment('/workspace/mixed.ts', 0, 'k1'),
+			makeComment('/workspace/mixed.ts', 1, 'k2'),
+			makeComment('/workspace/mixed.ts', 2, 'k3'),
+		];
+		const dropped = [
+			makeComment('/workspace/mixed.ts', 3, 'd1'),
+			makeComment('/workspace/mixed.ts', 4, 'd2'),
+		];
+		mockedGithubReview.mockImplementation(async (...args: any[]) => {
+			const progress = args[12];
+			progress.report(kept);
+			return { type: 'success', comments: kept, excludedComments: dropped };
+		});
+
+		const invocation = await createInvocation();
+		const { stream, findSummaryPart } = makePartsStream();
+		await invocation.processResponse!(makeContext('all'), await emptyStream(), stream, CancellationToken.None);
+
+		const summaryText = findSummaryPart()!.value.value;
+		// Single group with all 5 entries rendered as a plain markdown heading.
+		expect(summaryText).toMatch(/^### [^\n]*mixed\.ts \(5 findings\)$/m);
+		// Filtered entries get the suffix; kept entries do not. Links use basename:line.
+		expect(summaryText).toMatch(/- \[mixed\.ts:4\].*: d1 \(filtered\)/);
+		expect(summaryText).toMatch(/- \[mixed\.ts:5\].*: d2 \(filtered\)/);
+		expect(summaryText).toMatch(/- \[mixed\.ts:1\].*: k1(?! \(filtered\))/);
+		// Phase 4c (Bug 1): summary links use scoped command URI + isTrusted whitelists only the reveal command.
+		expect(summaryText).toMatch(/command:github\.copilot\.chat\.review\.revealComment\?/);
+		expect(findSummaryPart()!.value.isTrusted).toEqual({ enabledCommands: ['github.copilot.chat.review.revealComment'] });
+	});
+
+	test('propagates the cancellation token to githubReview', async () => {
+		enableCodeReview();
+		mockedGithubReview.mockResolvedValue({ type: 'cancelled' });
+		const cts = new CancellationTokenSource();
+		disposables.add(cts);
+
+		const invocation = await createInvocation();
+		const stream = new MockChatResponseStream();
+		await invocation.processResponse!(makeContext('unstaged'), await emptyStream(), stream, cts.token);
+
+		const [, , , , , , , , , , , , , token] = mockedGithubReview.mock.calls[0];
+		expect(token).toBe(cts.token);
+	});
+
+	test('renders a graceful error message on FeedbackResult error and no buttons', async () => {
+		enableCodeReview();
+		mockedGithubReview.mockResolvedValue({ type: 'error', reason: 'boom' });
+
+		const invocation = await createInvocation();
+		const { stream, getButtons } = makeTrackingStream();
+		await invocation.processResponse!(makeContext(''), await emptyStream(), stream, CancellationToken.None);
+
+		expect(stream.output.join('')).toMatch(/Review failed: boom/);
+		expect(getButtons()).toHaveLength(0);
+	});
+
+	test('empty success renders "no issues" narrative and no buttons', async () => {
+		enableCodeReview();
+		mockedGithubReview.mockResolvedValue({ type: 'success', comments: [] });
+
+		const invocation = await createInvocation();
+		const { stream, getButtons } = makeTrackingStream();
+		await invocation.processResponse!(makeContext('all'), await emptyStream(), stream, CancellationToken.None);
+
+		expect(stream.output.join('')).toMatch(/No issues found/);
+		expect(getButtons()).toHaveLength(0);
+	});
+
+	test('cancel mid-stream: streamed comments are added then rolled back, "Review cancelled." narrated', async () => {
+		enableCodeReview();
+		const cts = new CancellationTokenSource();
+		disposables.add(cts);
+		const streamed = [makeComment('/workspace/a.ts', 0, 'a'), makeComment('/workspace/b.ts', 1, 'b')];
+		mockedGithubReview.mockImplementation(async (...args: any[]) => {
+			const progress = args[12];
+			progress.report([streamed[0]]);
+			progress.report([streamed[1]]);
+			cts.cancel();
+			return { type: 'cancelled' };
+		});
+
+		const invocation = await createInvocation();
+		const stream = new MockChatResponseStream();
+		await invocation.processResponse!(makeContext('all'), await emptyStream(), stream, cts.token);
+
+		expect(reviewService.addedComments).toEqual(streamed);
+		expect(reviewService.removedComments).toEqual(streamed);
+		expect(stream.output.join('')).toMatch(/Review cancelled\./);
+	});
+
+	test('comment reported after cancel: not added to review service', async () => {
+		enableCodeReview();
+		const cts = new CancellationTokenSource();
+		disposables.add(cts);
+		const lateComment = makeComment('/workspace/late.ts', 2, 'late');
+		mockedGithubReview.mockImplementation(async (...args: any[]) => {
+			const progress = args[12];
+			cts.cancel();
+			progress.report([lateComment]);
+			return { type: 'cancelled' };
+		});
+
+		const invocation = await createInvocation();
+		const stream = new MockChatResponseStream();
+		await invocation.processResponse!(makeContext('all'), await emptyStream(), stream, cts.token);
+
+		expect(reviewService.addedComments).toEqual([]);
+	});
+
+	test('addReviewComments throws: degrades to graceful narrative, no unhandled rejection', async () => {
+		enableCodeReview();
+		reviewService.throwOnAdd = true;
+		const comment = makeComment('/workspace/foo.ts', 0, 'foo');
+		mockedGithubReview.mockImplementation(async (...args: any[]) => {
+			const progress = args[12];
+			progress.report([comment]);
+			return { type: 'success', comments: [comment] };
+		});
+
+		const invocation = await createInvocation();
+		const stream = new MockChatResponseStream();
+		await invocation.processResponse!(makeContext('all'), await emptyStream(), stream, CancellationToken.None);
+
+		expect(stream.output.join('')).toMatch(/could not update Comments panel/);
+	});
+
+	test('excludedComments on success: added to review service and a subline narrates the filter count', async () => {
+		enableCodeReview();
+		const kept = makeComment('/workspace/keep.ts', 0, 'keep');
+		const filtered = makeComment('/workspace/filter.ts', 0, 'filter');
+		mockedGithubReview.mockImplementation(async (...args: any[]) => {
+			const progress = args[12];
+			progress.report([kept]);
+			return { type: 'success', comments: [kept], excludedComments: [filtered] };
+		});
+
+		const invocation = await createInvocation();
+		const { stream, getButtons } = makeTrackingStream();
+		await invocation.processResponse!(makeContext('all'), await emptyStream(), stream, CancellationToken.None);
+
+		expect(reviewService.addedComments).toEqual([kept, filtered]);
+		expect(stream.output.join('')).toMatch(/1 comments filtered by policy/);
+		expect(getButtons().map(b => b.command)).toEqual(['github.copilot.chat.review.nextFromChat']);
+	});
+
+	test('scope-aware pre-clear ("file" scope): removes only existing comments matching the active file URI', async () => {
+		enableCodeReview();
+		const fooUri = { fsPath: '/workspace/foo.ts', toString: () => 'file:///workspace/foo.ts' } as unknown as vscode.Uri;
+		const barUri = { fsPath: '/workspace/bar.ts', toString: () => 'file:///workspace/bar.ts' } as unknown as vscode.Uri;
+		const fooComment = { ...makeComment('/workspace/foo.ts', 0, 'foo'), uri: fooUri } as ReviewComment;
+		const barComment = { ...makeComment('/workspace/bar.ts', 0, 'bar'), uri: barUri } as ReviewComment;
+		reviewService.seed(fooComment, barComment);
+		tabsService.activeTextEditor = { document: { uri: fooUri }, selection: { isEmpty: true } } as unknown as vscode.TextEditor;
+		mockedGithubReview.mockResolvedValue({ type: 'success', comments: [] });
+
+		const invocation = await createInvocation();
+		const stream = new MockChatResponseStream();
+		await invocation.processResponse!(makeContext('file'), await emptyStream(), stream, CancellationToken.None);
+
+		expect(reviewService.removedComments).toEqual([fooComment]);
+	});
+
+	test('task-bound progress: emits exactly one ChatResponseProgressPart2 with a task callback, independent of phase callbacks', async () => {
+		enableCodeReview();
+		// Mock returns success without firing any phase callback. The early
+		// task-bound progress must still be emitted because it is pinned at the
+		// top of `processResponse`, before `await githubReview(...)`.
+		mockedGithubReview.mockImplementation(async () => {
+			return { type: 'success', comments: [] };
+		});
+
+		const invocation = await createInvocation();
+		const { stream, parts } = makePartsStream();
+		await invocation.processResponse!(makeContext('all'), await emptyStream(), stream, CancellationToken.None);
+
+		const progressParts = parts.filter((p): p is ChatResponseProgressPart2 => p instanceof ChatResponseProgressPart2);
+		expect(progressParts).toHaveLength(1);
+		expect(progressParts[0].value).toBe('Analyzing your changes…');
+		expect(typeof progressParts[0].task).toBe('function');
+	});
+
+	test('task-bound progress: task callback resolves with the success summary after the review settles', async () => {
+		enableCodeReview();
+		// 3 comments across 3 distinct files → `filesWithComments` = 3.
+		const comments = [
+			makeComment('/workspace/a.ts', 0, 'a1'),
+			makeComment('/workspace/b.ts', 1, 'b1'),
+			makeComment('/workspace/c.ts', 2, 'c1'),
+		];
+		mockedGithubReview.mockImplementation(async () => {
+			return { type: 'success', comments };
+		});
+
+		const invocation = await createInvocation();
+		const { stream, parts } = makePartsStream();
+		await invocation.processResponse!(makeContext('all'), await emptyStream(), stream, CancellationToken.None);
+
+		const part = parts.find((p): p is ChatResponseProgressPart2 => p instanceof ChatResponseProgressPart2);
+		expect(part).toBeDefined();
+		// `reviewComplete` has already been settled by the success branch, so the
+		// task callback resolves immediately with the cached value.
+		const taskResult = await part!.task!({ report: () => { } });
+		expect(taskResult).toBe('Review complete: 3 findings across 3 files');
+	});
+});
+
+describe('ReviewIntentInvocation.buildPrompt (Panel)', () => {
+	let disposables: DisposableStore;
+	let accessor: ITestingServicesAccessor;
+	let instantiationService: IInstantiationService;
+
+	beforeEach(() => {
+		disposables = new DisposableStore();
+		const services = createExtensionUnitTestingServices();
+		services.define(IReviewService, new MockReviewService());
+		services.define(ITabsAndEditorsService, new MockTabsAndEditorsService());
+		accessor = services.createTestingAccessor();
+		disposables.add(accessor);
+		instantiationService = accessor.get(IInstantiationService);
+	});
+
+	afterEach(() => {
+		disposables.dispose();
+	});
+
+	test('returns the null prompt result on the Panel (chat) path', async () => {
+		const invocation = instantiationService.createInstance(
+			ReviewIntentInvocation,
+			{ id: 'review' } as any,
+			ChatLocation.Panel,
+			{} as IChatEndpoint,
+			undefined as any,
+		);
+		const result = await invocation.buildPrompt(
+			{ query: '', history: [], chatVariables: { variables: [] } } as any,
+			{ report: () => { } },
+			CancellationToken.None,
+		);
+		expect(result.messages).toEqual([]);
+		expect(result.references).toEqual([]);
+	});
+});

--- a/extensions/copilot/src/extension/review/node/test/doReview.spec.ts
+++ b/extensions/copilot/src/extension/review/node/test/doReview.spec.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { afterEach, beforeEach, describe, suite, test } from 'vitest';
-import type { Selection, TextEditor } from 'vscode';
+import type { CommentThread, Selection, TextEditor } from 'vscode';
 import { IAuthenticationService } from '../../../../platform/authentication/common/authentication';
 import { CopilotToken, createTestExtendedTokenInfo } from '../../../../platform/authentication/common/copilotToken';
 import { IGitExtensionService } from '../../../../platform/git/common/gitExtensionService';
@@ -60,7 +60,7 @@ suite('doReview', () => {
 					show: () => { tracker.logShown = true; },
 				} as unknown as ILogService,
 				reviewService: {
-					addReviewComments: (comments: ReviewComment[]) => { tracker.addedComments.push(...comments); },
+					addReviewComments: (comments: ReviewComment[], _opts?: { suppressAutoReveal?: boolean }) => { tracker.addedComments.push(...comments); },
 				} as unknown as IReviewService,
 			};
 		}
@@ -337,7 +337,7 @@ suite('doReview', () => {
 			isIntentEnabled(): boolean { return true; }
 			getDiagnosticCollection() { return { get: () => undefined, set: () => { } }; }
 			getReviewComments(): ReviewComment[] { return this.comments; }
-			addReviewComments(comments: ReviewComment[]): void {
+			addReviewComments(comments: ReviewComment[], _opts?: { suppressAutoReveal?: boolean }): void {
 				this.addedComments.push(...comments);
 				this.comments.push(...comments);
 			}
@@ -349,6 +349,7 @@ suite('doReview', () => {
 			updateReviewComment(_comment: ReviewComment): void { }
 			findReviewComment() { return undefined; }
 			findCommentThread() { return undefined; }
+			getActiveThread(): CommentThread | undefined { return undefined; }
 		}
 
 		// Mock authentication service for testing different auth states

--- a/extensions/copilot/src/platform/review/common/reviewService.ts
+++ b/extensions/copilot/src/platform/review/common/reviewService.ts
@@ -61,10 +61,11 @@ export interface IReviewService {
 	isIntentEnabled(): boolean;
 	getDiagnosticCollection(): ReviewDiagnosticCollection;
 	getReviewComments(): ReviewComment[];
-	addReviewComments(comments: ReviewComment[]): void;
+	addReviewComments(comments: ReviewComment[], opts?: { suppressAutoReveal?: boolean }): void;
 	collapseReviewComment(comment: ReviewComment): void;
 	removeReviewComments(comments: ReviewComment[]): void;
 	updateReviewComment(comment: ReviewComment): void;
 	findReviewComment(threadOrComment: vscode.CommentThread | vscode.Comment): ReviewComment | undefined;
 	findCommentThread(comment: ReviewComment): vscode.CommentThread | undefined;
+	getActiveThread(): vscode.CommentThread | undefined;
 }

--- a/extensions/copilot/src/platform/review/vscode/reviewServiceImpl.ts
+++ b/extensions/copilot/src/platform/review/vscode/reviewServiceImpl.ts
@@ -121,7 +121,7 @@ export class ReviewServiceImpl implements IReviewService {
 		return this._comments.map(({ comment }) => comment);
 	}
 
-	addReviewComments(comments: ReviewComment[]) {
+	addReviewComments(comments: ReviewComment[], opts?: { suppressAutoReveal?: boolean }) {
 		for (const comment of comments) {
 			const thread = this._commentController.createCommentThread(comment.uri, comment.range, this.createUIComments(comment));
 			thread.contextValue = 'hasNoSuggestion';
@@ -132,7 +132,6 @@ export class ReviewServiceImpl implements IReviewService {
 			this._comments.push({ comment, thread });
 			this.updateThreadLabels();
 			if (this._comments.length === 1) {
-				vscode.commands.executeCommand('github.copilot.chat.review.next');
 				this._monitorActiveThread = setInterval(() => {
 					const raw = this._commentController.activeCommentThread;
 					const active = raw && this._comments.find(c => c.thread.label === raw.label)?.thread; // https://github.com/microsoft/vscode/issues/223025
@@ -143,6 +142,9 @@ export class ReviewServiceImpl implements IReviewService {
 						}
 					}
 				}, 500);
+				if (!opts?.suppressAutoReveal) {
+					vscode.commands.executeCommand('github.copilot.chat.review.next');
+				}
 			}
 		}
 		vscode.commands.executeCommand('setContext', numberOfReviewCommentsKey, this._comments.length);
@@ -203,9 +205,12 @@ export class ReviewServiceImpl implements IReviewService {
 			}
 		}
 		this.updateThreadLabels();
-		if (this._comments.length === 0 && this._monitorActiveThread) {
-			clearInterval(this._monitorActiveThread);
-			this._monitorActiveThread = undefined;
+		if (this._comments.length === 0) {
+			this._activeThread = undefined;
+			if (this._monitorActiveThread) {
+				clearInterval(this._monitorActiveThread);
+				this._monitorActiveThread = undefined;
+			}
 		}
 		vscode.commands.executeCommand('setContext', numberOfReviewCommentsKey, this._comments.length);
 	}
@@ -224,6 +229,10 @@ export class ReviewServiceImpl implements IReviewService {
 	findCommentThread(comment: ReviewComment): vscode.CommentThread | undefined {
 		const internalComment = this._comments.find(c => c.comment === comment);
 		return internalComment?.thread;
+	}
+
+	getActiveThread(): vscode.CommentThread | undefined {
+		return this._activeThread;
 	}
 
 	dispose(): void {

--- a/extensions/copilot/src/platform/test/node/simulationWorkspaceServices.ts
+++ b/extensions/copilot/src/platform/test/node/simulationWorkspaceServices.ts
@@ -299,7 +299,7 @@ export class SimulationReviewService implements IReviewService {
 		return this._comments.slice();
 	}
 
-	addReviewComments(comments: ReviewComment[]) {
+	addReviewComments(comments: ReviewComment[], _opts?: { suppressAutoReveal?: boolean }) {
 		this._comments.push(...comments);
 	}
 
@@ -323,6 +323,10 @@ export class SimulationReviewService implements IReviewService {
 	}
 
 	findCommentThread(comment: ReviewComment): vscode.CommentThread | undefined {
+		return undefined;
+	}
+
+	getActiveThread(): vscode.CommentThread | undefined {
 		return undefined;
 	}
 }


### PR DESCRIPTION
Unhides the /review slash command and adds a chat-driven entry point from the existing SCM gutter buttons. The chat path:

* accepts scope arguments: staged, unstaged, all, selection, file
* streams findings into the Comments panel with a task-bound spinner
* renders a per-file findings summary with clickable links
* provides a 'Next Comment' button for keyboard-free navigation
* routes the SCM gutter buttons through /review so the chat thread is the canonical entry point and preserves the user's current chat mode (agent/ask)

Existing non-chat flows (selection review via Ctrl+I, per-file SCM context menu, codeReview.run) continue to use the legacy direct-to- Comments-panel path with their original auto-jump-to-first-finding behaviour, gated by an opts.suppressAutoReveal flag on IReviewService.addReviewComments.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
