### PR TITLE
fix: hide redundant Disable option when extension is already disabled globally

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -1781,6 +1781,7 @@ export class DisableGloballyAction extends ExtensionAction {
 			}
 			this.enabled = this.extension.state === ExtensionState.Installed
 				&& (this.extension.enablementState === EnablementState.EnabledGlobally || this.extension.enablementState === EnablementState.EnabledWorkspace)
+				&& !this.extensionEnablementService.isDisabledGlobally(this.extension.local)
 				&& this.extensionEnablementService.canChangeEnablement(this.extension.local);
 		}
 	}


### PR DESCRIPTION
Fixes #244138

## Problem

When an extension is disabled globally but enabled for a specific workspace, the Disable button dropdown incorrectly shows both "Disable" and "Disable (Workspace)" options.

**Steps to reproduce:**
1. Install an extension and disable it globally.
2. Enable the extension for the current workspace.
3. Observe the Disable button dropdown - it shows both "Disable" and "Disable (Workspace)".

**Expected:** Only "Disable (Workspace)" should appear, since the extension is already disabled at the global level.

## Root Cause

`DisableGloballyAction.update()` checks if `enablementState` is `EnabledGlobally` or `EnabledWorkspace`, but does not check whether the extension is _already_ disabled globally. When an extension is disabled globally but workspace-enabled, its `enablementState` is `EnabledWorkspace`, which passes the existing check and incorrectly enables the "Disable" (globally) action.

## Fix

Added `!this.extensionEnablementService.isDisabledGlobally(this.extension.local)` to `DisableGloballyAction.update()`. This prevents the action from being enabled when the extension is already disabled at the global scope, so only "Disable (Workspace)" appears in the dropdown.