### PR TITLE
Send repoInfo telemetry for each repo in multi-repo workspaces

### DIFF
--- a/extensions/copilot/src/extension/prompt/node/repoInfoTelemetry.ts
+++ b/extensions/copilot/src/extension/prompt/node/repoInfoTelemetry.ts
@@ -6,6 +6,7 @@
 import { ICopilotTokenStore } from '../../../platform/authentication/common/copilotTokenStore';
 import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
 import { IFileSystemService } from '../../../platform/filesystem/common/fileSystemService';
+import { RelativePattern } from '../../../platform/filesystem/common/fileTypes';
 import { IGitDiffService } from '../../../platform/git/common/gitDiffService';
 import { IGitExtensionService } from '../../../platform/git/common/gitExtensionService';
 import { getOrderedRepoInfosFromContext, IGitService, normalizeFetchUrl, RepoContext, ResolvedRepoRemoteInfo } from '../../../platform/git/common/gitService';
@@ -52,6 +53,11 @@ const MAX_MERGE_BASE_AGE_DAYS = 30;
 // Max number of commits between merge base and HEAD before we skip the diff
 const MAX_DIFF_COMMITS = 30;
 
+// Cap on the number of repositories we collect/send telemetry for per request.
+// Covers >p90 of real-world multi-repo workspaces in long-tail cases (e.g. git.autoRepositoryDetection: 'subFolders' with many submodules).
+// The active repository is always included; remaining slots are filled from the workspace repo list.
+const MAX_REPOS_FOR_TELEMETRY = 5;
+
 // EVENT: repoInfo
 type RepoInfoTelemetryResult = 'success' | 'filesChanged' | 'diffTooLarge' | 'noChanges' | 'tooManyChanges' | 'mergeBaseTooOld' | 'virtualFileSystem' | 'tooManyCommits';
 
@@ -64,12 +70,15 @@ type RepoInfoTelemetryProperties = {
 	fileRelativePaths: string | undefined;
 	diffsJSON: string | undefined;
 	result: RepoInfoTelemetryResult;
+	isActiveRepository: 'true' | 'false';
 };
 
 type RepoInfoTelemetryMeasurements = {
 	workspaceFileCount: number;
 	changedFileCount: number;
 	diffSizeBytes: number;
+	repoIndex: number;
+	repoCount: number;
 };
 
 type RepoInfoTelemetryData = {
@@ -94,8 +103,8 @@ function shouldSendEndTelemetry(result: RepoInfoTelemetryResult | undefined): bo
 */
 export class RepoInfoTelemetry {
 	private _beginTelemetrySent = false;
-	private _beginTelemetryPromise: Promise<RepoInfoTelemetryData | undefined> | undefined;
-	private _beginTelemetryResult: RepoInfoTelemetryResult | undefined;
+	private _beginTelemetryPromise: Promise<Map<string, RepoInfoTelemetryData | undefined>> | undefined;
+	private readonly _beginTelemetryResults = new Map<string, RepoInfoTelemetryResult | undefined>();
 
 	constructor(
 		private readonly _telemetryMessageId: string,
@@ -124,8 +133,10 @@ export class RepoInfoTelemetry {
 		try {
 			this._beginTelemetrySent = true;
 			this._beginTelemetryPromise = this._sendRepoInfoTelemetry('begin');
-			const gitInfo = await this._beginTelemetryPromise;
-			this._beginTelemetryResult = gitInfo?.properties.result;
+			const repoResults = await this._beginTelemetryPromise;
+			for (const [key, value] of repoResults) {
+				this._beginTelemetryResults.set(key, value?.properties.result);
+			}
 		} catch (error) {
 			this._logService.warn(`Failed to send begin repo info telemetry ${error}`);
 		}
@@ -137,8 +148,9 @@ export class RepoInfoTelemetry {
 	public async sendEndTelemetry(): Promise<void> {
 		await this._beginTelemetryPromise;
 
-		// Skip end telemetry if begin wasn't successful
-		if (!shouldSendEndTelemetry(this._beginTelemetryResult)) {
+		// Skip end telemetry if no repos had a result that warrants an end event
+		const hasAnyEndCandidate = Array.from(this._beginTelemetryResults.values()).some(shouldSendEndTelemetry);
+		if (!hasAnyEndCandidate) {
 			return;
 		}
 
@@ -149,38 +161,88 @@ export class RepoInfoTelemetry {
 		}
 	}
 
-	private async _sendRepoInfoTelemetry(location: 'begin' | 'end'): Promise<RepoInfoTelemetryData | undefined> {
+	private async _sendRepoInfoTelemetry(location: 'begin' | 'end'): Promise<Map<string, RepoInfoTelemetryData | undefined>> {
+		const results = new Map<string, RepoInfoTelemetryData | undefined>();
 		if (this._configurationService.getConfig(ConfigKey.TeamInternal.DisableRepoInfoTelemetry)) {
-			return undefined;
+			return results;
 		}
 
-		const repoInfo = await this._getRepoInfoTelemetry();
-		if (!repoInfo) {
-			return undefined;
+		const allRepositories = this._gitService.repositories;
+		const totalRepoCount = allRepositories.length;
+		if (totalRepoCount === 0) {
+			return results;
 		}
 
-		const internalProperties: RepoInfoInternalTelemetryProperties = {
-			...repoInfo.properties,
-			location,
-			telemetryMessageId: this._telemetryMessageId
-		};
-
+		const activeRepoUri = this._gitService.activeRepository?.get()?.rootUri;
 		const isInternal = !!this._copilotTokenStore.copilotToken?.isInternal;
-		if (isInternal) {
-			const { headBranchName: _, fileRelativePaths: _2, ...msftProperties } = internalProperties;
-			this._telemetryService.sendInternalMSFTTelemetryEvent('request.repoInfo', msftProperties, repoInfo.measurements);
-		}
-		this._telemetryService.sendEnhancedGHTelemetryEvent('request.repoInfo', internalProperties, repoInfo.measurements);
 
-		return repoInfo;
+		// Cap the number of repos we process per request. Always include the active repo, then fill
+		// remaining slots from the workspace order. `repoCount` in measurements reports the TRUE total
+		// so dashboards can detect sampling.
+		const repositories: RepoContext[] = [];
+		if (activeRepoUri) {
+			const active = allRepositories.find(r => extUriBiasedIgnorePathCase.isEqual(r.rootUri, activeRepoUri));
+			if (active) {
+				repositories.push(active);
+			}
+		}
+		for (const r of allRepositories) {
+			if (repositories.length >= MAX_REPOS_FOR_TELEMETRY) {
+				break;
+			}
+			if (!repositories.includes(r)) {
+				repositories.push(r);
+			}
+		}
+
+		// Use allSettled so a failure on one repo does not drop telemetry for siblings.
+		const settled = await Promise.allSettled(repositories.map(async (repoContext, repoIndex) => {
+			const rootUriKey = repoContext.rootUri.toString();
+			const isActiveRepository = !!activeRepoUri && extUriBiasedIgnorePathCase.isEqual(repoContext.rootUri, activeRepoUri);
+
+			// For end events, only emit for repos whose begin result warranted an end event.
+			if (location === 'end' && !shouldSendEndTelemetry(this._beginTelemetryResults.get(rootUriKey))) {
+				return { rootUriKey, data: undefined };
+			}
+
+			const data = await this._getRepoInfoTelemetryForRepo(repoContext, repoIndex, totalRepoCount, isActiveRepository);
+			return { rootUriKey, data };
+		}));
+
+		const perRepo: { rootUriKey: string; data: RepoInfoTelemetryData | undefined }[] = [];
+		for (let i = 0; i < settled.length; i++) {
+			const outcome = settled[i];
+			if (outcome.status === 'fulfilled') {
+				perRepo.push(outcome.value);
+			} else {
+				this._logService.warn(`Failed to compute repo info telemetry for repo ${repositories[i].rootUri.toString()}: ${outcome.reason}`);
+				perRepo.push({ rootUriKey: repositories[i].rootUri.toString(), data: undefined });
+			}
+		}
+
+		for (const { rootUriKey, data } of perRepo) {
+			results.set(rootUriKey, data);
+			if (!data) {
+				continue;
+			}
+
+			const internalProperties: RepoInfoInternalTelemetryProperties = {
+				...data.properties,
+				location,
+				telemetryMessageId: this._telemetryMessageId
+			};
+
+			if (isInternal) {
+				const { headBranchName: _, fileRelativePaths: _2, ...msftProperties } = internalProperties;
+				this._telemetryService.sendInternalMSFTTelemetryEvent('request.repoInfo', msftProperties, data.measurements);
+			}
+			this._telemetryService.sendEnhancedGHTelemetryEvent('request.repoInfo', internalProperties, data.measurements);
+		}
+
+		return results;
 	}
 
-	private async _resolveRepoContext(): Promise<{ repoContext: RepoContext; repoInfo: ResolvedRepoRemoteInfo; repository: Repository; upstreamCommit: string; headBranchName: string | undefined } | undefined> {
-		const repoContext = this._gitService.activeRepository?.get();
-		if (!repoContext) {
-			return;
-		}
-
+	private async _resolveRepoContext(repoContext: RepoContext): Promise<{ repoInfo: ResolvedRepoRemoteInfo; repository: Repository; upstreamCommit: string; headBranchName: string | undefined } | undefined> {
 		const repoInfo = Array.from(getOrderedRepoInfosFromContext(repoContext))[0];
 		if (!repoInfo || !repoInfo.fetchUrl) {
 			return;
@@ -206,16 +268,16 @@ export class RepoInfoTelemetry {
 		}
 
 		const headBranchName = repository.state.HEAD?.name;
-		return { repoContext, repoInfo, repository, upstreamCommit, headBranchName };
+		return { repoInfo, repository, upstreamCommit, headBranchName };
 	}
 
-	private async _getRepoInfoTelemetry(): Promise<RepoInfoTelemetryData | undefined> {
-		const ctx = await this._resolveRepoContext();
+	private async _getRepoInfoTelemetryForRepo(repoContext: RepoContext, repoIndex: number, repoCount: number, isActiveRepository: boolean): Promise<RepoInfoTelemetryData | undefined> {
+		const ctx = await this._resolveRepoContext(repoContext);
 		if (!ctx) {
 			return;
 		}
 
-		const { repoContext, repoInfo, repository, upstreamCommit, headBranchName } = ctx;
+		const { repoInfo, repository, upstreamCommit, headBranchName } = ctx;
 		const normalizedFetchUrl = normalizeFetchUrl(repoInfo.fetchUrl!);
 
 		const skipDiffResult = (result: RepoInfoTelemetryResult): RepoInfoTelemetryData => ({
@@ -228,11 +290,14 @@ export class RepoInfoTelemetry {
 				fileRelativePaths: undefined,
 				diffsJSON: undefined,
 				result,
+				isActiveRepository: isActiveRepository ? 'true' : 'false',
 			},
 			measurements: {
 				workspaceFileCount: 0,
 				changedFileCount: 0,
 				diffSizeBytes: 0,
+				repoIndex,
+				repoCount,
 			}
 		});
 
@@ -280,10 +345,9 @@ export class RepoInfoTelemetry {
 			return skipDiffResult('tooManyCommits');
 		}
 
-		// Before we calculate our async diffs, sign up for file system change events
-		// Any changes during the async operations will invalidate our diff data and we send it
-		// as a failure without a diffs
-		const watcher = this._fileSystemService.createFileSystemWatcher('**/*');
+		// Before we calculate our async diffs, sign up for file system change events scoped to this repo.
+		// A change in another repo should not invalidate this repo's diff.
+		const watcher = this._fileSystemService.createFileSystemWatcher(new RelativePattern(repoContext.rootUri, '**/*'));
 		let filesChanged = false;
 		const createDisposable = watcher.onDidCreate(() => filesChanged = true);
 		const changeDisposable = watcher.onDidChange(() => filesChanged = true);
@@ -296,6 +360,7 @@ export class RepoInfoTelemetry {
 				repoType: repoInfo.repoId.type,
 				headCommitHash: upstreamCommit,
 				headBranchName,
+				isActiveRepository: isActiveRepository ? 'true' : 'false',
 			};
 
 			// Workspace file index will be used to get a rough count of files in the repository
@@ -306,6 +371,8 @@ export class RepoInfoTelemetry {
 				workspaceFileCount: this._workspaceFileIndex.fileCount,
 				changedFileCount: 0, // Will be updated
 				diffSizeBytes: 0, // Will be updated
+				repoIndex,
+				repoCount,
 			};
 
 			// Combine our diff against the upstream commit with untracked changes, and working tree changes

--- a/extensions/copilot/src/extension/prompt/node/repoInfoTelemetry.ts
+++ b/extensions/copilot/src/extension/prompt/node/repoInfoTelemetry.ts
@@ -164,7 +164,7 @@ export class RepoInfoTelemetry {
 			return results;
 		}
 
-		const allRepositories = this._gitService.repositories;
+		const allRepositories = this._gitService.repositories ?? [];
 		const totalRepoCount = allRepositories.length;
 		if (totalRepoCount === 0) {
 			return results;

--- a/extensions/copilot/src/extension/prompt/node/repoInfoTelemetry.ts
+++ b/extensions/copilot/src/extension/prompt/node/repoInfoTelemetry.ts
@@ -133,10 +133,7 @@ export class RepoInfoTelemetry {
 		try {
 			this._beginTelemetrySent = true;
 			this._beginTelemetryPromise = this._sendRepoInfoTelemetry('begin');
-			const repoResults = await this._beginTelemetryPromise;
-			for (const [key, value] of repoResults) {
-				this._beginTelemetryResults.set(key, value?.properties.result);
-			}
+			await this._beginTelemetryPromise;
 		} catch (error) {
 			this._logService.warn(`Failed to send begin repo info telemetry ${error}`);
 		}
@@ -222,6 +219,11 @@ export class RepoInfoTelemetry {
 
 		for (const { rootUriKey, data } of perRepo) {
 			results.set(rootUriKey, data);
+			if (location === 'begin') {
+				// Populate begin-results within the same promise so any awaiter of `_beginTelemetryPromise`
+				// is guaranteed to see populated results without relying on continuation ordering.
+				this._beginTelemetryResults.set(rootUriKey, data?.properties.result);
+			}
 			if (!data) {
 				continue;
 			}

--- a/extensions/copilot/src/extension/prompt/node/test/repoInfoTelemetry.spec.ts
+++ b/extensions/copilot/src/extension/prompt/node/test/repoInfoTelemetry.spec.ts
@@ -71,13 +71,19 @@ suite('RepoInfoTelemetry', () => {
 		services.define(IWorkspaceFileIndex, new SyncDescriptor(NullWorkspaceFileIndex));
 
 		// Override IGitService with a proper mock that has an observable activeRepository
+		const activeRepository = observableValue<any>('test-git-activeRepo', undefined);
 		const mockGitService: IGitService = {
 			_serviceBrand: undefined,
-			activeRepository: observableValue('test-git-activeRepo', undefined),
+			activeRepository,
 			onDidOpenRepository: Event.None,
 			onDidCloseRepository: Event.None,
 			onDidFinishInitialization: Event.None,
-			repositories: [],
+			get repositories() {
+				// Mirror activeRepository so existing tests that only set activeRepository
+				// continue to work after the multi-repo refactor of RepoInfoTelemetry.
+				const repo = activeRepository.get();
+				return repo ? [repo] : [];
+			},
 			isInitialized: true,
 			initRepository: vi.fn(),
 			openRepository: vi.fn(),
@@ -1949,6 +1955,162 @@ suite('RepoInfoTelemetry', () => {
 	});
 
 	// ========================================
+	// Multi-Repository Tests
+	// ========================================
+
+	test('should send one telemetry event per repository in a multi-repo workspace', async () => {
+		setupInternalUser();
+
+		const repoAUri = URI.file('/test/repoA');
+		const repoBUri = URI.file('/test/repoB');
+		mockMultiRepoSetup([
+			{ rootUri: repoAUri, remoteUrl: 'https://github.com/microsoft/vscode.git' },
+			{ rootUri: repoBUri, remoteUrl: 'https://github.com/microsoft/typescript.git' },
+		], repoAUri);
+
+		const repoTelemetry = new RepoInfoTelemetry(
+			'test-message-id',
+			telemetryService,
+			gitService,
+			gitDiffService,
+			gitExtensionService,
+			logService,
+			fileSystemService,
+			workspaceFileIndex,
+			configurationService,
+			copilotTokenStore
+		);
+
+		await repoTelemetry.sendBeginTelemetryIfNeeded();
+
+		const calls = (telemetryService.sendInternalMSFTTelemetryEvent as any).mock.calls;
+		assert.strictEqual(calls.length, 2, 'should emit one event per repo');
+
+		const propsByRepoIndex = new Map<number, any>();
+		for (const call of calls) {
+			assert.strictEqual(call[0], 'request.repoInfo');
+			propsByRepoIndex.set(call[2].repoIndex, { props: call[1], measurements: call[2] });
+		}
+
+		const first = propsByRepoIndex.get(0)!;
+		const second = propsByRepoIndex.get(1)!;
+		assert.strictEqual(first.measurements.repoCount, 2);
+		assert.strictEqual(second.measurements.repoCount, 2);
+		assert.strictEqual(first.props.isActiveRepository, 'true');
+		assert.strictEqual(second.props.isActiveRepository, 'false');
+		assert.strictEqual(first.props.remoteUrl, 'https://github.com/microsoft/vscode.git');
+		assert.strictEqual(second.props.remoteUrl, 'https://github.com/microsoft/typescript.git');
+	});
+
+	test('should include repoIndex/repoCount/isActiveRepository for single-repo workspace', async () => {
+		setupInternalUser();
+		mockGitServiceWithRepository();
+		mockGitExtensionWithUpstream('abc123');
+		mockGitDiffService([{ uri: '/test/repo/file.ts', diff: 'some diff' }]);
+
+		const repoTelemetry = new RepoInfoTelemetry(
+			'test-message-id',
+			telemetryService,
+			gitService,
+			gitDiffService,
+			gitExtensionService,
+			logService,
+			fileSystemService,
+			workspaceFileIndex,
+			configurationService,
+			copilotTokenStore
+		);
+
+		await repoTelemetry.sendBeginTelemetryIfNeeded();
+
+		assert.strictEqual((telemetryService.sendInternalMSFTTelemetryEvent as any).mock.calls.length, 1);
+		const call = (telemetryService.sendInternalMSFTTelemetryEvent as any).mock.calls[0];
+		assert.strictEqual(call[2].repoIndex, 0);
+		assert.strictEqual(call[2].repoCount, 1);
+		assert.strictEqual(call[1].isActiveRepository, 'true');
+	});
+
+	test('should gate end telemetry per repo', async () => {
+		setupInternalUser();
+
+		const repoAUri = URI.file('/test/repoA');
+		const repoBUri = URI.file('/test/repoB');
+		// Repo A: success path (1 change). Repo B: tooManyChanges (101 changes).
+		mockMultiRepoSetup([
+			{ rootUri: repoAUri, remoteUrl: 'https://github.com/microsoft/vscode.git' },
+			{ rootUri: repoBUri, remoteUrl: 'https://github.com/microsoft/typescript.git', changeCount: 101 },
+		], repoAUri);
+
+		const repoTelemetry = new RepoInfoTelemetry(
+			'test-message-id',
+			telemetryService,
+			gitService,
+			gitDiffService,
+			gitExtensionService,
+			logService,
+			fileSystemService,
+			workspaceFileIndex,
+			configurationService,
+			copilotTokenStore
+		);
+
+		await repoTelemetry.sendBeginTelemetryIfNeeded();
+		await repoTelemetry.sendEndTelemetry();
+
+		// 2 begin events (one per repo) + 1 end event (only the success repo)
+		const calls = (telemetryService.sendInternalMSFTTelemetryEvent as any).mock.calls;
+		assert.strictEqual(calls.length, 3);
+
+		const beginCalls = calls.filter((c: any) => c[1].location === 'begin');
+		const endCalls = calls.filter((c: any) => c[1].location === 'end');
+		assert.strictEqual(beginCalls.length, 2);
+		assert.strictEqual(endCalls.length, 1);
+		assert.strictEqual(endCalls[0][1].remoteUrl, 'https://github.com/microsoft/vscode.git');
+		assert.strictEqual(endCalls[0][1].result, 'success');
+	});
+
+	test('should cap telemetry at 5 repos with active repo always included', async () => {
+		setupInternalUser();
+
+		// 7 repos total; active repo is the 6th one (would normally be excluded by a naive slice).
+		const repos = Array.from({ length: 7 }, (_, i) => ({
+			rootUri: URI.file(`/test/repo${i}`),
+			remoteUrl: `https://github.com/microsoft/repo${i}.git`,
+		}));
+		const activeRepoUri = repos[5].rootUri;
+		mockMultiRepoSetup(repos, activeRepoUri);
+
+		const repoTelemetry = new RepoInfoTelemetry(
+			'test-message-id',
+			telemetryService,
+			gitService,
+			gitDiffService,
+			gitExtensionService,
+			logService,
+			fileSystemService,
+			workspaceFileIndex,
+			configurationService,
+			copilotTokenStore
+		);
+
+		await repoTelemetry.sendBeginTelemetryIfNeeded();
+
+		const calls = (telemetryService.sendInternalMSFTTelemetryEvent as any).mock.calls;
+		// Capped at 5 events even though 7 repos exist.
+		assert.strictEqual(calls.length, 5);
+
+		// Every event reports the TRUE repoCount (7), not the capped count.
+		for (const call of calls) {
+			assert.strictEqual(call[2].repoCount, 7);
+		}
+
+		// Active repo must be present exactly once and marked as active.
+		const activeCalls = calls.filter((c: any) => c[1].isActiveRepository === 'true');
+		assert.strictEqual(activeCalls.length, 1);
+		assert.strictEqual(activeCalls[0][1].remoteUrl, 'https://github.com/microsoft/repo5.git');
+	});
+
+	// ========================================
 	// Helper Functions
 	// ========================================
 
@@ -2062,6 +2224,96 @@ suite('RepoInfoTelemetry', () => {
 				diff: d.diff || 'test diff'
 			}))
 		);
+	}
+
+	function mockMultiRepoSetup(
+		repos: Array<{ rootUri: URI; remoteUrl: string; upstreamCommit?: string; changeCount?: number }>,
+		activeRootUri: URI
+	) {
+		const repoContexts = repos.map(r => ({
+			rootUri: r.rootUri,
+			changes: {
+				mergeChanges: [],
+				indexChanges: [],
+				workingTree: [{
+					uri: URI.joinPath(r.rootUri, 'file.ts'),
+					originalUri: URI.joinPath(r.rootUri, 'file.ts'),
+					renameUri: undefined,
+					status: Status.MODIFIED
+				}],
+				untrackedChanges: []
+			},
+			remotes: ['origin'],
+			remoteFetchUrls: [r.remoteUrl],
+			upstreamRemote: 'origin',
+			headBranchName: 'main',
+			headCommitHash: r.upstreamCommit ?? 'abc123',
+			upstreamBranchName: 'origin/main',
+			isRebasing: false,
+		}));
+
+		const active = repoContexts.find(r => r.rootUri.toString() === activeRootUri.toString());
+		vi.spyOn(gitService.activeRepository, 'get').mockReturnValue(active as any);
+		Object.defineProperty(gitService, 'repositories', {
+			configurable: true,
+			get: () => repoContexts,
+		});
+
+		// Per-repo git extension API: getRepository(uri) returns a mock repo with the upstream
+		// configured to point at <remoteUrl>.
+		const reposByPath = new Map<string, any>();
+		for (const ctx of repoContexts) {
+			const r = repos.find(x => x.rootUri.toString() === ctx.rootUri.toString())!;
+			const upstreamCommit = r.upstreamCommit ?? 'abc123';
+			const mockRepo: any = {
+				getMergeBase: vi.fn(async (ref1: string, ref2: string) =>
+					(ref1 === 'HEAD' && ref2 === '@{upstream}') ? upstreamCommit : undefined
+				),
+				getBranchBase: vi.fn().mockResolvedValue(undefined),
+				getCommit: vi.fn().mockResolvedValue({
+					hash: upstreamCommit,
+					message: 'test commit',
+					commitDate: new Date(),
+				}),
+				getConfig: vi.fn().mockResolvedValue(''),
+				log: vi.fn().mockResolvedValue([]),
+				state: {
+					HEAD: { upstream: { commit: upstreamCommit, remote: 'origin' } },
+					remotes: [{ name: 'origin', fetchUrl: r.remoteUrl, pushUrl: r.remoteUrl, isReadOnly: false }],
+					workingTreeChanges: [],
+					untrackedChanges: [],
+				},
+			};
+			reposByPath.set(ctx.rootUri.toString(), mockRepo);
+		}
+		vi.spyOn(gitExtensionService, 'getExtensionApi').mockReturnValue({
+			getRepository: (uri: URI) => reposByPath.get(uri.toString()),
+		} as any);
+
+		// diffWith: synthesize <changeCount> changes for this repo
+		vi.spyOn(gitService, 'diffWith').mockImplementation(async (uri: URI) => {
+			const r = repos.find(x => x.rootUri.toString() === uri.toString());
+			const count = r?.changeCount ?? 1;
+			return Array.from({ length: count }, (_, i) => ({
+				uri: URI.joinPath(uri, `file${i}.ts`),
+				originalUri: URI.joinPath(uri, `file${i}.ts`),
+				renameUri: undefined,
+				status: Status.MODIFIED,
+			})) as any;
+		});
+
+		vi.spyOn(gitDiffService, 'getWorkingTreeDiffsFromRef').mockImplementation(async (repositoryOrUri: any) => {
+			const uri: URI = URI.isUri(repositoryOrUri) ? repositoryOrUri : repositoryOrUri.rootUri;
+			const r = repos.find(x => x.rootUri.toString() === uri.toString());
+			const count = r?.changeCount ?? 1;
+			return Array.from({ length: count }, (_, i) => ({
+				uri: URI.joinPath(uri, `file${i}.ts`),
+				originalUri: URI.joinPath(uri, `file${i}.ts`),
+				renameUri: undefined,
+				status: Status.MODIFIED,
+				diff: 'test diff',
+			})) as any;
+		});
 	}
 });
 


### PR DESCRIPTION
The repoInfo telemetry event was previously emitted only for the active repository on each chat request. In multi-repo workspaces (and especially long-tail cases like git.autoRepositoryDetection: 'subFolders' with many submodules), this dropped visibility into all the other repos in scope. This PR extends RepoInfoTelemetry to emit one event per repository, while bounding cost and preserving all existing behavior for single-repo workspaces.