### PR TITLE
Refactor CSS to use `--vscode-shadow-lg`

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -1020,7 +1020,6 @@
 		"--vscode-shadow-active-tab",
 		"--vscode-shadow-depth-x",
 		"--vscode-shadow-depth-y",
-		"--vscode-shadow-hover",
 		"--vscode-shadow-lg",
 		"--vscode-shadow-md",
 		"--vscode-shadow-sm",

--- a/src/vs/editor/contrib/hover/browser/hover.css
+++ b/src/vs/editor/contrib/hover/browser/hover.css
@@ -25,7 +25,7 @@
 	border-radius: var(--vscode-cornerRadius-large);
 	color: var(--vscode-editorHoverWidget-foreground);
 	background-color: var(--vscode-editorHoverWidget-background);
-	box-shadow: var(--vscode-shadow-hover);
+	box-shadow: var(--vscode-shadow-lg);
 }
 
 .monaco-editor .monaco-hover a {

--- a/src/vs/editor/contrib/peekView/browser/media/peekViewWidget.css
+++ b/src/vs/editor/contrib/peekView/browser/media/peekViewWidget.css
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 .monaco-editor .peekview-widget {
-	box-shadow: var(--vscode-shadow-hover);
+	box-shadow: var(--vscode-shadow-lg);
 }
 
 .monaco-editor .peekview-widget .head {

--- a/src/vs/editor/contrib/rename/browser/renameWidget.css
+++ b/src/vs/editor/contrib/rename/browser/renameWidget.css
@@ -7,7 +7,7 @@
 	z-index: 100;
 	color: inherit;
 	border-radius: 4px;
-	box-shadow: var(--vscode-shadow-hover);
+	box-shadow: var(--vscode-shadow-lg);
 }
 
 .monaco-editor .rename-box.preview {

--- a/src/vs/platform/hover/browser/hover.css
+++ b/src/vs/platform/hover/browser/hover.css
@@ -17,7 +17,7 @@
 	border: 1px solid var(--vscode-editorHoverWidget-border);
 	border-radius: 5px;
 	color: var(--vscode-editorHoverWidget-foreground);
-	box-shadow: var(--vscode-shadow-hover);
+	box-shadow: var(--vscode-shadow-lg);
 }
 
 .monaco-hover.workbench-hover.with-pointer {

--- a/src/vs/workbench/browser/media/style.css
+++ b/src/vs/workbench/browser/media/style.css
@@ -59,7 +59,6 @@ body {
 	--vscode-shadow-md: 0 0 6px rgba(0, 0, 0, 0.08);
 	--vscode-shadow-lg: 0 0 12px rgba(0, 0, 0, 0.14);
 	--vscode-shadow-xl: 0 0 20px rgba(0, 0, 0, 0.15);
-	--vscode-shadow-hover: 0 0 8px rgba(0, 0, 0, 0.12);
 	--vscode-shadow-active-tab: 0 8px 12px rgba(0, 0, 0, 0.02);
 
 	/* Panel depth shadows cast onto the editor surface */


### PR DESCRIPTION
This pull request updates the way shadows are applied to several UI widgets by standardizing on the `--vscode-shadow-lg` variable and removing the now-unused `--vscode-shadow-hover` variable. This change ensures a more consistent visual appearance across the editor and simplifies the shadow variable set.

**Theme and variable cleanup:**

* Removed the `--vscode-shadow-hover` CSS variable from the global style definitions in `style.css` and from the list of known variables in `vscode-known-variables.json`. [[1]](diffhunk://#diff-1e97d559578d54bdecb2a3b479c30f9a7ad3a403c6ebbcf70e58f4b56cbd0a42L62) [[2]](diffhunk://#diff-57580bfa2d192c3c9eb714af64b8b9eb3891cfd7cf14a62a4cf9b5774b8d1b64L1023)

**UI consistency improvements:**

* Updated the `box-shadow` property in multiple widget styles (`hover.css`, `peekViewWidget.css`, `renameWidget.css`, and `hover.css` in the platform directory) to use `--vscode-shadow-lg` instead of the removed `--vscode-shadow-hover` variable. This change affects the hover widget, peek view widget, and rename widget, ensuring they all use the same shadow style. [[1]](diffhunk://#diff-1592c4d1ed803e7ad695294f164514263db715f161e54ee643c95d67f58db00fL28-R28) [[2]](diffhunk://#diff-5f8442f2c742c3e8c75f6d31687e73b39570ba9fde3aff7780ad3255a3f27d45L7-R7) [[3]](diffhunk://#diff-0318b5099b71c556c8e7f64c0ea4690c1c7ba8993b99fdb2e9ce9c88a9cf87fbL10-R10) [[4]](diffhunk://#diff-6ea1d97ce080ec3bba3566f33088be6c3185ca0205d15e5a6cd7dbcc5c39ccb6L20-R20)