### PR TITLE
Improve border visibility for key bindings in light/dark themes

### DIFF
--- a/src/vs/platform/quickinput/browser/media/quickInput.css
+++ b/src/vs/platform/quickinput/browser/media/quickInput.css
@@ -380,6 +380,14 @@
 	border-color: var(--vscode-widget-shadow);
 }
 
+/* In light/dark themes the widget shadow can be transparent, leaving the key borders invisible
+	against the focus/hover background. Derive the border from the foreground instead. High contrast
+	themes are excluded so their stronger borders are preserved. */
+:is(.vs, .vs-dark) .quick-input-list .monaco-list-row.focused .monaco-keybinding-key,
+:is(.vs, .vs-dark) .quick-input-list .monaco-list-row:hover .monaco-keybinding-key {
+	border-color: color-mix(in srgb, currentColor 30%, transparent);
+}
+
 .quick-input-list .quick-input-list-separator-as-item {
 	padding: 4px 6px;
 	font-size: 12px;


### PR DESCRIPTION
Enhance the visibility of key binding borders in light and dark themes by deriving the border color from the foreground, addressing issues with transparency that made borders invisible against certain backgrounds. High contrast themes remain unaffected.

Addresses: https://github.com/microsoft/vscode-internalbacklog/issues/7676