### PR TITLE
Fix suggest model triggering on disposed inline completions model

### DIFF
--- a/src/vs/editor/contrib/suggest/browser/suggestModel.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestModel.ts
@@ -3,37 +3,37 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { TimeoutTimer, disposableTimeout } from '../../../../base/common/async.js';
+import { disposableTimeout, TimeoutTimer } from '../../../../base/common/async.js';
 import { CancellationTokenSource } from '../../../../base/common/cancellation.js';
 import { onUnexpectedError } from '../../../../base/common/errors.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
+import { FuzzyScoreOptions } from '../../../../base/common/filters.js';
 import { DisposableStore, dispose, IDisposable } from '../../../../base/common/lifecycle.js';
+import { autorun } from '../../../../base/common/observable.js';
 import { getLeadingWhitespace, isHighSurrogate, isLowSurrogate } from '../../../../base/common/strings.js';
-import { ICodeEditor } from '../../../browser/editorBrowser.js';
-import { EditorOption } from '../../../common/config/editorOptions.js';
-import { CursorChangeReason, ICursorSelectionChangedEvent } from '../../../common/cursorEvents.js';
-import { IPosition, Position } from '../../../common/core/position.js';
-import { Selection } from '../../../common/core/selection.js';
-import { ITextModel } from '../../../common/model.js';
-import { CompletionContext, CompletionItemKind, CompletionItemProvider, CompletionTriggerKind } from '../../../common/languages.js';
-import { IEditorWorkerService } from '../../../common/services/editorWorker.js';
-import { WordDistance } from './wordDistance.js';
+import { assertType } from '../../../../base/common/types.js';
 import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { IEnvironmentService } from '../../../../platform/environment/common/environment.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
+import { ICodeEditor } from '../../../browser/editorBrowser.js';
+import { EditorOption } from '../../../common/config/editorOptions.js';
+import { IPosition, Position } from '../../../common/core/position.js';
+import { Selection } from '../../../common/core/selection.js';
+import { IWordAtPosition } from '../../../common/core/wordHelper.js';
+import { CursorChangeReason, ICursorSelectionChangedEvent } from '../../../common/cursorEvents.js';
+import { CompletionContext, CompletionItemKind, CompletionItemProvider, CompletionTriggerKind } from '../../../common/languages.js';
+import { ITextModel } from '../../../common/model.js';
+import { IEditorWorkerService } from '../../../common/services/editorWorker.js';
+import { ILanguageFeaturesService } from '../../../common/services/languageFeatures.js';
+import { getInlineCompletionsController } from '../../inlineCompletions/browser/controller/common.js';
+import { InlineCompletionContextKeys } from '../../inlineCompletions/browser/controller/inlineCompletionContextKeys.js';
+import { SnippetController2 } from '../../snippet/browser/snippetController2.js';
 import { CompletionModel } from './completionModel.js';
 import { CompletionDurations, CompletionItem, CompletionOptions, getSnippetSuggestSupport, provideSuggestionItems, QuickSuggestionsOptions, SnippetSortOrder } from './suggest.js';
-import { IWordAtPosition } from '../../../common/core/wordHelper.js';
-import { ILanguageFeaturesService } from '../../../common/services/languageFeatures.js';
-import { FuzzyScoreOptions } from '../../../../base/common/filters.js';
-import { assertType } from '../../../../base/common/types.js';
-import { InlineCompletionContextKeys } from '../../inlineCompletions/browser/controller/inlineCompletionContextKeys.js';
-import { getInlineCompletionsController } from '../../inlineCompletions/browser/controller/common.js';
-import { SnippetController2 } from '../../snippet/browser/snippetController2.js';
-import { IEnvironmentService } from '../../../../platform/environment/common/environment.js';
-import { autorun } from '../../../../base/common/observable.js';
+import { WordDistance } from './wordDistance.js';
 
 export interface ICancelEvent {
 	readonly retrigger: boolean;
@@ -459,7 +459,7 @@ export class SuggestModel implements IDisposable {
 		const initialModelVersion = initialModel.getVersionId();
 		const inlineController = getInlineCompletionsController(this._editor);
 		const inlineModel = inlineController?.model.get();
-		if (!inlineModel) {
+		if (!inlineController || !inlineModel) {
 			this.trigger({ auto: true });
 			return;
 		}
@@ -495,13 +495,21 @@ export class SuggestModel implements IDisposable {
 			}
 		};
 
-		// Race: observe inline completions state vs 750ms timeout
+		// Reading `inlineController.model` first in a single autorun binds the
+		// wait to the model's lifetime: nested autoruns would have no defined
+		// run order, so an inner state-watcher could fire on a disposed model
+		// before the outer model-watcher cleaned it up.
 		disposableTimeout(() => {
 			triggerAndCleanUp(true);
 			inlineModel.stop('automatic');
 		}, 750, store);
 
 		store.add(autorun(reader => {
+			const currentInlineModel = inlineController.model.read(reader);
+			if (currentInlineModel !== inlineModel) {
+				triggerAndCleanUp(false);
+				return;
+			}
 			const status = inlineModel.status.read(reader);
 			const currentState = inlineModel.state.read(reader);
 			if (!currentState && status === 'loading') {

--- a/src/vs/editor/contrib/suggest/test/browser/suggestModel.test.ts
+++ b/src/vs/editor/contrib/suggest/test/browser/suggestModel.test.ts
@@ -3,54 +3,54 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import assert from 'assert';
+import { ModifierKeyEmitter } from '../../../../../base/browser/dom.js';
+import { timeout } from '../../../../../base/common/async.js';
 import { Event } from '../../../../../base/common/event.js';
 import { Disposable, DisposableStore, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { mock } from '../../../../../base/test/common/mock.js';
+import { runWithFakedTimers } from '../../../../../base/test/common/timeTravelScheduler.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IAccessibilitySignalService } from '../../../../../platform/accessibilitySignal/browser/accessibilitySignalService.js';
+import { IMenu, IMenuService } from '../../../../../platform/actions/common/actions.js';
+import { IDefaultAccountService } from '../../../../../platform/defaultAccount/common/defaultAccount.js';
+import { IEnvironmentService } from '../../../../../platform/environment/common/environment.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { ServiceCollection } from '../../../../../platform/instantiation/common/serviceCollection.js';
+import { IKeybindingService } from '../../../../../platform/keybinding/common/keybinding.js';
+import { MockKeybindingService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
+import { ILabelService } from '../../../../../platform/label/common/label.js';
+import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
+import { InMemoryStorageService, IStorageService } from '../../../../../platform/storage/common/storage.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { NullTelemetryService } from '../../../../../platform/telemetry/common/telemetryUtils.js';
+import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { CoreEditingCommands } from '../../../../browser/coreCommands.js';
 import { EditOperation } from '../../../../common/core/editOperation.js';
 import { Position } from '../../../../common/core/position.js';
 import { Range } from '../../../../common/core/range.js';
 import { Selection } from '../../../../common/core/selection.js';
 import { Handler } from '../../../../common/editorCommon.js';
-import { ITextModel } from '../../../../common/model.js';
-import { TextModel } from '../../../../common/model/textModel.js';
-import { CompletionItemKind, CompletionItemProvider, CompletionList, CompletionTriggerKind, EncodedTokenizationResult, InlineCompletionsProvider, IState, TokenizationRegistry } from '../../../../common/languages.js';
 import { MetadataConsts } from '../../../../common/encodedTokenAttributes.js';
+import { CompletionItemKind, CompletionItemProvider, CompletionList, CompletionTriggerKind, EncodedTokenizationResult, InlineCompletionsProvider, IState, TokenizationRegistry } from '../../../../common/languages.js';
+import { ILanguageService } from '../../../../common/languages/language.js';
 import { ILanguageConfigurationService } from '../../../../common/languages/languageConfigurationRegistry.js';
 import { NullState } from '../../../../common/languages/nullTokenize.js';
-import { ILanguageService } from '../../../../common/languages/language.js';
+import { ITextModel } from '../../../../common/model.js';
+import { TextModel } from '../../../../common/model/textModel.js';
+import { IEditorWorkerService } from '../../../../common/services/editorWorker.js';
+import { ILanguageFeaturesService } from '../../../../common/services/languageFeatures.js';
+import { LanguageFeaturesService } from '../../../../common/services/languageFeaturesService.js';
+import { createTestCodeEditor, ITestCodeEditor, withAsyncTestCodeEditor } from '../../../../test/browser/testCodeEditor.js';
+import { createModelServices, createTextModel, instantiateTextModel } from '../../../../test/common/testTextModel.js';
+import { InlineCompletionsController } from '../../../inlineCompletions/browser/controller/inlineCompletionsController.js';
+import { InlineSuggestionsView } from '../../../inlineCompletions/browser/view/inlineSuggestionsView.js';
 import { SnippetController2 } from '../../../snippet/browser/snippetController2.js';
+import { getSnippetSuggestSupport, setSnippetSuggestSupport } from '../../browser/suggest.js';
 import { SuggestController } from '../../browser/suggestController.js';
 import { ISuggestMemoryService } from '../../browser/suggestMemory.js';
 import { LineContext, SuggestModel } from '../../browser/suggestModel.js';
 import { ISelectedSuggestion } from '../../browser/suggestWidget.js';
-import { createTestCodeEditor, ITestCodeEditor, withAsyncTestCodeEditor } from '../../../../test/browser/testCodeEditor.js';
-import { createModelServices, createTextModel, instantiateTextModel } from '../../../../test/common/testTextModel.js';
-import { ServiceCollection } from '../../../../../platform/instantiation/common/serviceCollection.js';
-import { IKeybindingService } from '../../../../../platform/keybinding/common/keybinding.js';
-import { MockKeybindingService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
-import { ILabelService } from '../../../../../platform/label/common/label.js';
-import { InMemoryStorageService, IStorageService } from '../../../../../platform/storage/common/storage.js';
-import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
-import { NullTelemetryService } from '../../../../../platform/telemetry/common/telemetryUtils.js';
-import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
-import { LanguageFeaturesService } from '../../../../common/services/languageFeaturesService.js';
-import { ILanguageFeaturesService } from '../../../../common/services/languageFeatures.js';
-import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
-import { getSnippetSuggestSupport, setSnippetSuggestSupport } from '../../browser/suggest.js';
-import { IEnvironmentService } from '../../../../../platform/environment/common/environment.js';
-import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { runWithFakedTimers } from '../../../../../base/test/common/timeTravelScheduler.js';
-import { timeout } from '../../../../../base/common/async.js';
-import { InlineCompletionsController } from '../../../inlineCompletions/browser/controller/inlineCompletionsController.js';
-import { InlineSuggestionsView } from '../../../inlineCompletions/browser/view/inlineSuggestionsView.js';
-import { IAccessibilitySignalService } from '../../../../../platform/accessibilitySignal/browser/accessibilitySignalService.js';
-import { IMenuService, IMenu } from '../../../../../platform/actions/common/actions.js';
-import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
-import { IEditorWorkerService } from '../../../../common/services/editorWorker.js';
-import { IDefaultAccountService } from '../../../../../platform/defaultAccount/common/defaultAccount.js';
-import { ModifierKeyEmitter } from '../../../../../base/browser/dom.js';
 
 
 function createMockEditor(model: TextModel, languageFeaturesService: ILanguageFeaturesService): ITestCodeEditor {
@@ -1544,6 +1544,46 @@ suite('SuggestModel - offWhenInlineCompletions with InlineCompletionsController'
 
 			sub.dispose();
 			assert.strictEqual(didSuggest, true, 'Quick suggestions should have been triggered when inlineSuggest is disabled');
+		});
+	});
+
+	test('does not trigger after the inline model is disposed mid-wait (e.g., readonly toggled)', async function () {
+		// Provider that only resolves when its cancellation token fires. This keeps the
+		// wait in the loading state until either the inline model is disposed
+		// (cancelling the token) or the 750ms timeout fires.
+		const inlineProvider: InlineCompletionsProvider = {
+			provideInlineCompletions: (_model, _pos, _ctx, token) => new Promise(resolve => {
+				const d = token.onCancellationRequested(() => {
+					d.dispose();
+					resolve({ items: [] });
+				});
+			}),
+			disposeInlineCompletions: () => { }
+		};
+
+		await withSuggestModelAndInlineCompletions('abc def', inlineProvider, async (suggestModel, editor) => {
+			let didSuggest = false;
+			const sub = suggestModel.onDidSuggest(() => { didSuggest = true; });
+
+			editor.setPosition({ lineNumber: 1, column: 4 });
+			editor.trigger('keyboard', Handler.Type, { text: 'd' });
+
+			// Let _waitForInlineCompletionsAndTrigger be scheduled and set up.
+			await timeout(50);
+
+			// Toggling readonly causes the controller's `model` derivedDisposable to
+			// recompute and dispose the InlineCompletionsModel. SuggestModel does NOT
+			// cancel on configuration change, so without binding the wait to the
+			// model's lifetime, the 750ms timeout would still fire and call
+			// `this.trigger({ auto: true })` (and `stop()` on the disposed model).
+			editor.updateOptions({ readOnly: true });
+
+			// Advance past the 750ms timeout window.
+			await timeout(1000);
+
+			sub.dispose();
+			assert.strictEqual(didSuggest, false,
+				'Quick suggest should not fire after the inline model is disposed mid-wait');
 		});
 	});
 });


### PR DESCRIPTION
## Problem

The wait inside `SuggestModel._waitForInlineCompletionsAndTrigger` snapshotted `inlineController.model.get()` and then subscribed long-term to that snapshot's `state` / `status` derived observables.

Those derived observables are owned only for debug — they are **not** registered to the `InlineCompletionsModel._store`. The model itself is produced by a `derivedDisposable` in `InlineCompletionsController` and is **disposed and recreated** whenever its dependencies change:

- the editor's text model is replaced (peek opens, diff editor mode switch, programmatic `editor.setModel(...)`, etc.)
- `readOnly` is toggled
- the controller is disposed (editor disposal)

After the model is disposed, its `state` / `status` derived keep observing live external dependencies (`_editorObs.versionId`, config observables, …) and continue to fire. `SuggestModel` does **not** call `cancel()` on `onDidChangeConfiguration`, so a `readOnly` toggle (concrete reproducer) leaves the wait running against a dead model:

- the unconditional 750 ms timeout calls `inlineModel.stop('automatic')` on a disposed instance (mutates `_isActive` on a dead model);
- the autorun fires `triggerAndCleanUp(true)` and can spuriously call `this.trigger({ auto: true })`.

## Fix

Read `inlineController.model` as the **first** dependency of a single autorun. If the value differs from the snapshot we got at the start of the wait, the controller has swapped or disposed the model — bail out before any read on `state` / `status`.

A single autorun (rather than a nested outer/inner pair) is deliberate: independent autoruns share no run-ordering guarantee, so an inner state watcher could otherwise run on a disposed model before the outer model watcher cleaned it up.

## Test

Added a regression test that:
1. registers a hanging inline completions provider that only resolves on cancellation,
2. types a character so the wait is set up,
3. toggles `readOnly: true` mid-wait (disposes the model),
4. advances past the 750 ms timeout and asserts that quick suggest is **not** fired.

Verified the test fails on the original code and passes on the fix.
