### PR TITLE
Update checkbox border colors for 2026 themes

### DIFF
--- a/extensions/theme-defaults/themes/2026-dark.json
+++ b/extensions/theme-defaults/themes/2026-dark.json
@@ -25,7 +25,7 @@
 		"button.secondaryHoverBackground": "#FFFFFF10",
 		"button.secondaryBorder": "#333536",
 		"checkbox.background": "#242526",
-		"checkbox.border": "#333536",
+		"checkbox.border": "#707070",
 		"checkbox.foreground": "#8C8C8C",
 		"dropdown.background": "#191A1B",
 		"dropdown.border": "#333536",

--- a/extensions/theme-defaults/themes/2026-light.json
+++ b/extensions/theme-defaults/themes/2026-light.json
@@ -27,7 +27,7 @@
 		"button.secondaryHoverBackground": "#F2F3F4",
 		"button.secondaryBorder": "#EAEAEA",
 		"checkbox.background": "#EAEAEA",
-		"checkbox.border": "#D8D8D8",
+		"checkbox.border": "#868686",
 		"checkbox.foreground": "#606060",
 		"dropdown.background": "#FFFFFF",
 		"dropdown.border": "#D8D8D8",


### PR DESCRIPTION
Adjust checkbox border colors for both dark and light themes to enhance visual consistency and accessibility.

Addresses: https://github.com/microsoft/vscode/issues/319909
