### PR TITLE
sessions: inherit active session workspace for new session view

### DIFF
--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -167,8 +167,8 @@ of the last composed new session. Inheritance is skipped when the active
 session's workspace already matches the current pending new session (so an
 in-progress draft for that same workspace is preserved) and falls back to the
 default behavior if the workspace cannot be resolved. Internal callers (restore
-fallback, archive, background reseed) invoke `openNewSessionView()` without the
-flag and keep the prior behavior.
+fallback, archive, background reseed, and the close-session fallback) invoke
+`openNewSessionView()` without the flag and keep the prior behavior.
 
 `sendNewChatRequest(session, options)` accepts a `background` flag: a background
 new-session send returns the agents window to a fresh new-session view (via

--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -157,6 +157,19 @@ Follow-up messages to an existing chat go through
 `SessionsManagementService.sendRequest(session, chat, options)`. This always
 makes the sent chat the active chat.
 
+Explicit user-initiated "new session" gestures (Ctrl/Cmd+N, the **New** button,
+the mobile titlebar "+" button, and the sessions quick picker's "New Session"
+item) call `openNewSessionView({ inheritWorkspaceFromActiveSession: true })`.
+When a session is already active, the new session view inherits that session's
+workspace — a fresh pending new session is created via `createNewSession` for
+the active session's workspace folder — instead of defaulting to the workspace
+of the last composed new session. Inheritance is skipped when the active
+session's workspace already matches the current pending new session (so an
+in-progress draft for that same workspace is preserved) and falls back to the
+default behavior if the workspace cannot be resolved. Internal callers (restore
+fallback, archive, background reseed) invoke `openNewSessionView()` without the
+flag and keep the prior behavior.
+
 `sendNewChatRequest(session, options)` accepts a `background` flag: a background
 new-session send returns the agents window to a fresh new-session view (via
 `openNewSessionView`) **before** creating and sending the session, and skips the

--- a/src/vs/sessions/browser/workbench.ts
+++ b/src/vs/sessions/browser/workbench.ts
@@ -785,7 +785,7 @@ export class Workbench extends Disposable implements IAgentWorkbenchLayoutServic
 		// so the new session view becomes visible. createMobileTitlebar() is
 		// only invoked in phone layout, so closing the drawer here is safe.
 		this.mobileTopBarDisposables.add(mobileTitlebar.onDidClickNewSession(() => {
-			this.sessionsManagementService.openNewSessionView();
+			this.sessionsManagementService.openNewSessionView({ inheritWorkspaceFromActiveSession: true });
 			this.closeMobileSidebarDrawer();
 			this.sessionsPartService.focusSession(this.sessionsManagementService.activeSession.get());
 		}));

--- a/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
@@ -66,7 +66,7 @@ class NewChatInSessionsWindowAction extends Action2 {
 	override run(accessor: ServicesAccessor): void {
 		const sessionsManagementService = accessor.get(ISessionsManagementService);
 		const sessionsPartService = accessor.get(ISessionsPartService);
-		sessionsManagementService.openNewSessionView();
+		sessionsManagementService.openNewSessionView({ inheritWorkspaceFromActiveSession: true });
 		sessionsPartService.focusSession(sessionsManagementService.activeSession.get());
 	}
 }

--- a/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
@@ -146,7 +146,7 @@ registerAction2(class ShowSessionsPickerAction extends Action2 {
 
 		const openSelected = (selected: ISessionPickItem, inBackground: boolean, toSide: boolean): void => {
 			if (!selected.session) {
-				sessionsManagementService.openNewSessionView();
+				sessionsManagementService.openNewSessionView({ inheritWorkspaceFromActiveSession: true });
 				sessionsPartService.focusSession(sessionsManagementService.activeSession.get());
 				return;
 			}

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsView.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsView.ts
@@ -338,7 +338,7 @@ export class SessionsView extends ViewPane {
 		newSessionButton.element.classList.add('agent-sessions-compact-new-button');
 		this._register(newSessionButton.onDidClick(() => {
 			logSessionsInteraction(this.telemetryService, 'newSession');
-			this.sessionsManagementService.openNewSessionView();
+			this.sessionsManagementService.openNewSessionView({ inheritWorkspaceFromActiveSession: true });
 			this.sessionsPartService.focusSession(this.sessionsManagementService.activeSession.get());
 		}));
 

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -832,7 +832,7 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 
 	openNewSessionView(options?: { inheritWorkspaceFromActiveSession?: boolean }): void {
 		const current = this._visibility.activeSession.get();
-		// No-op if the current session is already a new session
+		// No-op when no session is active (empty new-session placeholder showing).
 		if (current === undefined) {
 			return;
 		}

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -830,12 +830,36 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 		this._onDidSendRequest.fire({ session: updatedSession, chat, isNewSession: false, isNewChat: true, options });
 	}
 
-	openNewSessionView(): void {
+	openNewSessionView(options?: { inheritWorkspaceFromActiveSession?: boolean }): void {
+		const current = this._visibility.activeSession.get();
 		// No-op if the current session is already a new session
-		if (this._visibility.activeSession.get() === undefined) {
+		if (current === undefined) {
 			return;
 		}
 		this._startOpenSession();
+
+		// When explicitly requested, inherit the workspace of the session being
+		// switched away from so the new session view opens in the same workspace
+		// rather than defaulting to the last composed new session's workspace.
+		// Only inherit from an established session (not the pending new session)
+		// and only when its workspace differs from any pending new session, so
+		// an existing in-progress draft for that same workspace is preserved.
+		if (options?.inheritWorkspaceFromActiveSession && current.sessionId !== this._pendingNewSession?.sessionId) {
+			const inheritUri = current.workspace.get()?.folders[0]?.root;
+			const pendingUri = this._pendingNewSession?.workspace.get()?.folders[0]?.root;
+			if (inheritUri && !this.uriIdentityService.extUri.isEqual(inheritUri, pendingUri)) {
+				try {
+					// Creates a fresh pending new session for the inherited
+					// workspace and makes it active, disposing the previous one.
+					this.createNewSession(inheritUri);
+					this._onDidOpenNewSessionView.fire();
+					return;
+				} catch (e) {
+					this.logService.warn(`[SessionsManagement] openNewSessionView: failed to inherit workspace '${inheritUri.toString()}', falling back to default`, e);
+				}
+			}
+		}
+
 		// Restore the pending new session if one exists, so pickers
 		// re-derive their state from the still-alive session object.
 		// Otherwise clear active session (first time / after send).

--- a/src/vs/sessions/services/sessions/common/sessionsManagement.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsManagement.ts
@@ -282,8 +282,14 @@ export interface ISessionsManagementService {
 	/**
 	 * Switch to the new-session view.
 	 * No-op if the current session is already a new session.
+	 *
+	 * When `options.inheritWorkspaceFromActiveSession` is set, the new session
+	 * view inherits the workspace of the session that is currently active
+	 * (the one being switched away from) instead of defaulting to the
+	 * workspace of the last composed new session. Use this for explicit
+	 * user-initiated "new session" gestures (e.g. Ctrl/Cmd+N, the New button).
 	 */
-	openNewSessionView(): void;
+	openNewSessionView(options?: { inheritWorkspaceFromActiveSession?: boolean }): void;
 
 	/**
 	 * Create a new session for the given folder.

--- a/src/vs/sessions/services/sessions/common/sessionsManagement.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsManagement.ts
@@ -281,7 +281,8 @@ export interface ISessionsManagementService {
 
 	/**
 	 * Switch to the new-session view.
-	 * No-op if the current session is already a new session.
+	 * No-op when no session is active (the empty new-session placeholder is
+	 * already showing).
 	 *
 	 * When `options.inheritWorkspaceFromActiveSession` is set, the new session
 	 * view inherits the workspace of the session that is currently active

--- a/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
@@ -424,6 +424,93 @@ suite('SessionsManagementService', () => {
 		});
 	});
 
+	test('openNewSessionView inherits the active session workspace when requested', async () => {
+		const makeWorkspace = (uri: URI): ISessionWorkspace => ({
+			uri,
+			label: 'ws',
+			icon: Codicon.vm,
+			folders: [{ root: uri, workingDirectory: uri, name: 'ws', description: undefined }],
+			requiresWorkspaceTrust: false,
+			isVirtualWorkspace: false,
+		});
+
+		const workspaceB = URI.parse('file:///workspaceB');
+		const openSession = stubSession({ sessionId: 'open', providerId: 'test', workspace: constObservable(makeWorkspace(workspaceB)) });
+
+		let createdFolderUri: URI | undefined;
+		const provider = new class extends TestSessionsProvider {
+			constructor() { super(openSession); }
+			override getSessions(): ISession[] { return [openSession]; }
+			override resolveWorkspace(folderUri?: URI): ISessionWorkspace { return makeWorkspace(folderUri!); }
+			override createNewSession(folderUri?: URI): ISession {
+				createdFolderUri = folderUri;
+				return stubSession({ sessionId: 'inherited', providerId: 'test', workspace: constObservable(makeWorkspace(folderUri!)) });
+			}
+		};
+
+		const { service } = createSessionsManagementService(openSession, disposables, provider);
+
+		// Make the established session active.
+		await service.openSession(openSession.resource);
+		assert.strictEqual(service.activeSession.get()?.sessionId, 'open');
+
+		// Opening a new session view inherits the active session's workspace.
+		service.openNewSessionView({ inheritWorkspaceFromActiveSession: true });
+
+		assert.deepStrictEqual({
+			createdFor: createdFolderUri?.toString() ?? null,
+			activeSession: service.activeSession.get()?.sessionId ?? null,
+			activeWorkspace: service.activeSession.get()?.workspace.get()?.folders[0]?.root.toString() ?? null,
+		}, {
+			createdFor: workspaceB.toString(),
+			activeSession: 'inherited',
+			activeWorkspace: workspaceB.toString(),
+		});
+	});
+
+	test('openNewSessionView does not inherit the active session workspace by default', async () => {
+		const workspaceB = URI.parse('file:///workspaceB');
+		const openSession = stubSession({
+			sessionId: 'open',
+			providerId: 'test',
+			workspace: constObservable({
+				uri: workspaceB,
+				label: 'ws',
+				icon: Codicon.vm,
+				folders: [{ root: workspaceB, workingDirectory: workspaceB, name: 'ws', description: undefined }],
+				requiresWorkspaceTrust: false,
+				isVirtualWorkspace: false,
+			} satisfies ISessionWorkspace),
+		});
+
+		let createNewSessionCalled = false;
+		const provider = new class extends TestSessionsProvider {
+			constructor() { super(openSession); }
+			override getSessions(): ISession[] { return [openSession]; }
+			override createNewSession(): ISession {
+				createNewSessionCalled = true;
+				return openSession;
+			}
+		};
+
+		const { service } = createSessionsManagementService(openSession, disposables, provider);
+
+		await service.openSession(openSession.resource);
+		assert.strictEqual(service.activeSession.get()?.sessionId, 'open');
+
+		// Without the inherit option, no new session is created from the active
+		// session's workspace; the empty new-session view is shown instead.
+		service.openNewSessionView();
+
+		assert.deepStrictEqual({
+			createNewSessionCalled,
+			activeSession: service.activeSession.get()?.sessionId ?? null,
+		}, {
+			createNewSessionCalled: false,
+			activeSession: null,
+		});
+	});
+
 	test('restoreVisibleSessions restores the grid order, sticky and active state', async () => {
 		const sessionA = stubSession({ sessionId: 'a', providerId: 'test' });
 		const sessionB = stubSession({ sessionId: 'b', providerId: 'test' });

--- a/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
@@ -511,6 +511,55 @@ suite('SessionsManagementService', () => {
 		});
 	});
 
+	test('openNewSessionView preserves an in-progress draft when the active session shares its workspace', async () => {
+		const makeWorkspace = (uri: URI): ISessionWorkspace => ({
+			uri,
+			label: 'ws',
+			icon: Codicon.vm,
+			folders: [{ root: uri, workingDirectory: uri, name: 'ws', description: undefined }],
+			requiresWorkspaceTrust: false,
+			isVirtualWorkspace: false,
+		});
+
+		const workspaceA = URI.parse('file:///workspaceA');
+		const openSession = stubSession({ sessionId: 'open', providerId: 'test', workspace: constObservable(makeWorkspace(workspaceA)) });
+		const pendingSession = stubSession({ sessionId: 'pending', providerId: 'test', workspace: constObservable(makeWorkspace(workspaceA)) });
+
+		let createNewSessionCount = 0;
+		const provider = new class extends TestSessionsProvider {
+			constructor() { super(openSession); }
+			override getSessions(): ISession[] { return [openSession]; }
+			override resolveWorkspace(folderUri?: URI): ISessionWorkspace { return makeWorkspace(folderUri!); }
+			override createNewSession(): ISession {
+				createNewSessionCount++;
+				return pendingSession;
+			}
+		};
+
+		const { service } = createSessionsManagementService(openSession, disposables, provider);
+
+		// Compose an in-progress new session (pending draft) for workspace A.
+		service.createNewSession(workspaceA);
+		assert.strictEqual(service.activeSession.get()?.sessionId, 'pending');
+
+		// Navigate to the established session, which shares workspace A.
+		await service.openSession(openSession.resource);
+		assert.strictEqual(service.activeSession.get()?.sessionId, 'open');
+
+		// Opening a new session view inherits workspace A, which matches the
+		// pending draft's workspace, so the existing draft is restored rather
+		// than recreated (createNewSession is not called a second time).
+		service.openNewSessionView({ inheritWorkspaceFromActiveSession: true });
+
+		assert.deepStrictEqual({
+			createNewSessionCount,
+			activeSession: service.activeSession.get()?.sessionId ?? null,
+		}, {
+			createNewSessionCount: 1,
+			activeSession: 'pending',
+		});
+	});
+
 	test('restoreVisibleSessions restores the grid order, sticky and active state', async () => {
 		const sessionA = stubSession({ sessionId: 'a', providerId: 'test' });
 		const sessionB = stubSession({ sessionId: 'b', providerId: 'test' });


### PR DESCRIPTION
When pressing **Ctrl/Cmd+N** (or using the **New** button, the mobile titlebar "+" button, or the sessions quick picker's **New Session** item) in the Agents window while a session is already open, the new session view now inherits the **currently open session's workspace** instead of defaulting to the workspace of the last composed new session.

### Changes
- `openNewSessionView` accepts an optional `{ inheritWorkspaceFromActiveSession }` flag. When set and an established session is active, a fresh pending new session is created for that session's workspace folder.
- An in-progress draft for the **same** workspace is preserved (via the `isEqual` guard); the change falls back to the prior behavior when the workspace cannot be resolved.
- Wired the flag into all explicit user-initiated "new session" gestures: Ctrl/Cmd+N action, the New button, the mobile titlebar "+", and the sessions quick picker.
- Internal callers (restore fallback, archive, background reseed, close-session fallback) keep the previous behavior.
- Updated `SESSIONS.md` and added unit tests covering inheritance-on and default-off behavior.

### Validation
- `npm run compile-check-ts-native` :white_check_mark:
- `npm run valid-layers-check` :white_check_mark:
- `SessionsManagementService` browser unit suite (incl. 2 new tests) :white_check_mark:

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
