### PR TITLE
NES: more detailed speculation prediction for patch-based prompts

### DIFF
--- a/extensions/copilot/src/extension/xtab/node/responseFormatHandlers.ts
+++ b/extensions/copilot/src/extension/xtab/node/responseFormatHandlers.ts
@@ -94,7 +94,7 @@ export async function handleEditWindowWithEditIntent(
 export interface UnifiedXmlInsertContext {
 	readonly editWindowLines: string[];
 	readonly editWindowLineRange: OffsetRange;
-	readonly cursorOriginalLinesOffset: number;
+	readonly cursorLineInEditWindowOffset: number;
 	readonly cursorColumnZeroBased: number;
 	readonly editWindow: OffsetRange;
 	readonly originalEditWindow: OffsetRange | undefined;
@@ -150,18 +150,18 @@ async function* generateInsertEdits(
 	ctx: UnifiedXmlInsertContext,
 	documentBeforeEdits: StringText,
 ): AsyncGenerator<StreamedEdit, NoNextEditReason, void> {
-	const { editWindowLines, editWindowLineRange, cursorOriginalLinesOffset, cursorColumnZeroBased, editWindow, originalEditWindow, targetDocument, isFromCursorJump } = ctx;
+	const { editWindowLines, editWindowLineRange, cursorLineInEditWindowOffset, cursorColumnZeroBased, editWindow, originalEditWindow, targetDocument, isFromCursorJump } = ctx;
 
 	const lineWithCursorContinued = await linesIter.next();
 	if (lineWithCursorContinued.done || lineWithCursorContinued.value.includes(ResponseTags.INSERT.end)) {
 		return new NoNextEditReason.NoSuggestions(documentBeforeEdits, editWindow);
 	}
 
-	const cursorLineContent = editWindowLines[cursorOriginalLinesOffset];
+	const cursorLineContent = editWindowLines[cursorLineInEditWindowOffset];
 	const edit = new LineReplacement(
 		new LineRange(
-			editWindowLineRange.start + cursorOriginalLinesOffset + 1 /* 0-based to 1-based */,
-			editWindowLineRange.start + cursorOriginalLinesOffset + 2,
+			editWindowLineRange.start + cursorLineInEditWindowOffset + 1 /* 0-based to 1-based */,
+			editWindowLineRange.start + cursorLineInEditWindowOffset + 2,
 		),
 		[cursorLineContent.slice(0, cursorColumnZeroBased) + lineWithCursorContinued.value + cursorLineContent.slice(cursorColumnZeroBased)],
 	);
@@ -178,7 +178,7 @@ async function* generateInsertEdits(
 		v = await linesIter.next();
 	}
 
-	const line = editWindowLineRange.start + cursorOriginalLinesOffset + 2;
+	const line = editWindowLineRange.start + cursorLineInEditWindowOffset + 2;
 	yield {
 		edit: new LineReplacement(
 			new LineRange(line, line),

--- a/extensions/copilot/src/extension/xtab/node/xtabProvider.ts
+++ b/extensions/copilot/src/extension/xtab/node/xtabProvider.ts
@@ -961,7 +961,7 @@ export class XtabProvider implements IStatelessNextEditProvider {
 						{
 							editWindowLines,
 							editWindowLineRange,
-							cursorOriginalLinesOffset: cursorLineInEditWindowOffset,
+							cursorLineInEditWindowOffset,
 							cursorColumnZeroBased: promptPieces.currentDocument.cursorPosition.column - 1,
 							editWindow,
 							originalEditWindow,
@@ -1482,7 +1482,10 @@ export class XtabProvider implements IStatelessNextEditProvider {
 		if (!usePrediction) {
 			return undefined;
 		}
-		const patchModelPredictionKind = this.configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsXtabProviderPatchModelPredictionKind, this.expService);
+		// Only the CustomDiffPatch shape consults `patchModelPredictionKind`; skip the experiment lookup otherwise.
+		const patchModelPredictionKind = responseFormat === xtabPromptOptions.ResponseFormat.CustomDiffPatch
+			? this.configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsXtabProviderPatchModelPredictionKind, this.expService)
+			: xtabPromptOptions.PatchModelPrediction.FilePath;
 		return {
 			type: 'content',
 			content: getPredictionContents(doc, cursorLineOffset, editWindowLines, cursorLineInEditWindowOffset, responseFormat, patchModelPredictionKind)

--- a/extensions/copilot/src/extension/xtab/node/xtabProvider.ts
+++ b/extensions/copilot/src/extension/xtab/node/xtabProvider.ts
@@ -107,7 +107,7 @@ interface RequestTracingContext {
 interface EditWindowInfo {
 	editWindow: OffsetRange;
 	editWindowLines: string[];
-	cursorOriginalLinesOffset: number;
+	cursorLineInEditWindowOffset: number;
 	editWindowLineRange: OffsetRange;
 }
 
@@ -289,7 +289,7 @@ export class XtabProvider implements IStatelessNextEditProvider {
 
 		const editWindowLinesRange = this.computeEditWindowLinesRange(currentDocument, request, tracer, telemetry);
 
-		const cursorOriginalLinesOffset = Math.max(0, currentDocument.cursorLineOffset - editWindowLinesRange.start);
+		const cursorLineInEditWindowOffset = Math.max(0, currentDocument.cursorLineOffset - editWindowLinesRange.start);
 		const editWindowLastLineLength = currentDocument.transformer.getLineLength(editWindowLinesRange.endExclusive);
 		const editWindow = currentDocument.transformer.getOffsetRange(new Range(editWindowLinesRange.start + 1, 1, editWindowLinesRange.endExclusive, editWindowLastLineLength + 1));
 
@@ -401,7 +401,7 @@ export class XtabProvider implements IStatelessNextEditProvider {
 
 		const responseFormat = xtabPromptOptions.ResponseFormat.fromPromptingStrategy(promptOptions.promptingStrategy);
 
-		const prediction = this.getPredictedOutput(activeDocument, editWindowLines, responseFormat);
+		const prediction = this.getPredictedOutput(activeDocument, currentDocument.cursorLineOffset, editWindowLines, cursorLineInEditWindowOffset, responseFormat);
 
 		const messages = constructMessages({
 			systemMsg: pickSystemPrompt(promptOptions.promptingStrategy),
@@ -448,7 +448,7 @@ export class XtabProvider implements IStatelessNextEditProvider {
 			editWindowInfo: {
 				editWindow,
 				editWindowLines,
-				cursorOriginalLinesOffset,
+				cursorLineInEditWindowOffset,
 				editWindowLineRange: editWindowLinesRange,
 			},
 			promptPieces,
@@ -891,7 +891,7 @@ export class XtabProvider implements IStatelessNextEditProvider {
 	): EditStreaming {
 		const { tracer, logContext, telemetry } = tracing;
 		const { endpoint, messages, clippedTaggedCurrentDoc, editWindowInfo, promptPieces, prediction, originalEditWindow } = editStreamCtx;
-		const { editWindow, editWindowLines, cursorOriginalLinesOffset, editWindowLineRange } = editWindowInfo;
+		const { editWindow, editWindowLines, cursorLineInEditWindowOffset, editWindowLineRange } = editWindowInfo;
 
 		const targetDocument = request.getActiveDocument().id;
 
@@ -961,7 +961,7 @@ export class XtabProvider implements IStatelessNextEditProvider {
 						{
 							editWindowLines,
 							editWindowLineRange,
-							cursorOriginalLinesOffset,
+							cursorOriginalLinesOffset: cursorLineInEditWindowOffset,
 							cursorColumnZeroBased: promptPieces.currentDocument.cursorPosition.column - 1,
 							editWindow,
 							originalEditWindow,
@@ -1042,7 +1042,7 @@ export class XtabProvider implements IStatelessNextEditProvider {
 				? cleanedLinesStream
 				: linesWithIntermediateEditDivergenceCheck(
 					cleanedLinesStream,
-					cursorOriginalLinesOffset,
+					cursorLineInEditWindowOffset,
 					request,
 					editWindowLineRange,
 					editWindowLines,
@@ -1054,7 +1054,7 @@ export class XtabProvider implements IStatelessNextEditProvider {
 
 			let i = 0;
 			let hasBeenDelayed = false;
-			for await (const edit of ResponseProcessor.diff(editWindowLines, divergenceCheckedStream, cursorOriginalLinesOffset, diffOptions)) {
+			for await (const edit of ResponseProcessor.diff(editWindowLines, divergenceCheckedStream, cursorLineInEditWindowOffset, diffOptions)) {
 
 				if (lineDiverged) {
 					break;
@@ -1477,13 +1477,16 @@ export class XtabProvider implements IStatelessNextEditProvider {
 		return createProxyXtabEndpoint(this.instaService, configuredModelName);
 	}
 
-	private getPredictedOutput(doc: StatelessNextEditDocument, editWindowLines: string[], responseFormat: xtabPromptOptions.ResponseFormat): Prediction | undefined {
-		return this.configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsXtabProviderUsePrediction, this.expService)
-			? {
-				type: 'content',
-				content: getPredictionContents(doc, editWindowLines, responseFormat)
-			}
-			: undefined;
+	private getPredictedOutput(doc: StatelessNextEditDocument, cursorLineOffset: number, editWindowLines: string[], cursorLineInEditWindowOffset: number, responseFormat: xtabPromptOptions.ResponseFormat): Prediction | undefined {
+		const usePrediction = this.configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsXtabProviderUsePrediction, this.expService);
+		if (!usePrediction) {
+			return undefined;
+		}
+		const patchModelPredictionKind = this.configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsXtabProviderPatchModelPredictionKind, this.expService);
+		return {
+			type: 'content',
+			content: getPredictionContents(doc, cursorLineOffset, editWindowLines, cursorLineInEditWindowOffset, responseFormat, patchModelPredictionKind)
+		};
 	}
 
 	private async debounce(delaySession: DelaySession, retryState: RetryState.t, logger: ILogger, telemetry: StatelessNextEditTelemetryBuilder, cancellationToken: CancellationToken) {
@@ -1682,7 +1685,7 @@ export function determineLanguageContextOptions(languageId: LanguageId, { enable
 	return { enabled, maxTokens, traitPosition };
 }
 
-export function getPredictionContents(doc: StatelessNextEditDocument, editWindowLines: readonly string[], responseFormat: xtabPromptOptions.ResponseFormat): string {
+export function getPredictionContents(doc: StatelessNextEditDocument, cursorLineOffset: number, editWindowLines: readonly string[], cursorLineInEditWindowOffset: number, responseFormat: xtabPromptOptions.ResponseFormat, patchModelPredictionKind: xtabPromptOptions.PatchModelPrediction): string {
 	if (responseFormat === xtabPromptOptions.ResponseFormat.UnifiedWithXml) {
 		return ['<EDIT>', ...editWindowLines, '</EDIT>'].join('\n');
 	} else if (responseFormat === xtabPromptOptions.ResponseFormat.EditWindowOnly) {
@@ -1698,7 +1701,29 @@ export function getPredictionContents(doc: StatelessNextEditDocument, editWindow
 	} else if (responseFormat === xtabPromptOptions.ResponseFormat.CustomDiffPatch) {
 		const workspacePath = doc.workspaceRoot?.path;
 		const workspaceRelativeDocPath = toUniquePath(doc.id, workspacePath);
-		return `${workspaceRelativeDocPath}:`;
+
+		if (patchModelPredictionKind === xtabPromptOptions.PatchModelPrediction.FilePath) {
+			return `${workspaceRelativeDocPath}:`;
+		}
+
+		// Guard the upper bound so we never emit a literal `-undefined` into the prompt.
+		const lineWithCursor = editWindowLines[cursorLineInEditWindowOffset];
+		if (lineWithCursor === undefined) {
+			return `${workspaceRelativeDocPath}:`;
+		}
+
+		// 0-based, matching `Patch.lineNumZeroBased` parsed by `XtabCustomDiffPatchResponseHandler`.
+		const lineLocation = `${workspaceRelativeDocPath}:${cursorLineOffset}`;
+		switch (patchModelPredictionKind) {
+			case xtabPromptOptions.PatchModelPrediction.CurrentLine:
+				return [lineLocation, `-${lineWithCursor}`].join('\n');
+			case xtabPromptOptions.PatchModelPrediction.CurrentLineReplaced:
+				return [lineLocation, `-${lineWithCursor}`, `+`].join('\n');
+			case xtabPromptOptions.PatchModelPrediction.CurrentLineCompleted:
+				return [lineLocation, `-${lineWithCursor}`, `+${lineWithCursor}`].join('\n');
+			default:
+				assertNever(patchModelPredictionKind);
+		}
 	} else {
 		assertNever(responseFormat);
 	}
@@ -1706,7 +1731,7 @@ export function getPredictionContents(doc: StatelessNextEditDocument, editWindow
 
 async function* linesWithIntermediateEditDivergenceCheck(
 	cleanedLinesStream: AsyncIterable<string>,
-	cursorOriginalLinesOffset: number,
+	cursorLineInEditWindowOffset: number,
 	request: StatelessNextEditRequest,
 	editWindowLineRange: OffsetRange,
 	editWindowLines: readonly string[],
@@ -1734,7 +1759,7 @@ async function* linesWithIntermediateEditDivergenceCheck(
 		}
 		switch (mode) {
 			case EarlyDivergenceCancellationMode.Cursor:
-				return lineIdx === cursorOriginalLinesOffset;
+				return lineIdx === cursorLineInEditWindowOffset;
 			case EarlyDivergenceCancellationMode.EditWindow:
 				return true;
 		}

--- a/extensions/copilot/src/extension/xtab/test/node/responseFormatHandlers.spec.ts
+++ b/extensions/copilot/src/extension/xtab/test/node/responseFormatHandlers.spec.ts
@@ -44,7 +44,7 @@ function makeInsertContext(overrides?: Partial<UnifiedXmlInsertContext>): Unifie
 	return {
 		editWindowLines: ['line0', 'cursor_line', 'line2'],
 		editWindowLineRange: new OffsetRange(10, 13),
-		cursorOriginalLinesOffset: 1,
+		cursorLineInEditWindowOffset: 1,
 		cursorColumnZeroBased: 6,
 		editWindow: new OffsetRange(0, 100),
 		originalEditWindow: undefined,

--- a/extensions/copilot/src/extension/xtab/test/node/xtabProvider.spec.ts
+++ b/extensions/copilot/src/extension/xtab/test/node/xtabProvider.spec.ts
@@ -13,7 +13,7 @@ import { InMemoryConfigurationService } from '../../../../platform/configuration
 import { DocumentId } from '../../../../platform/inlineEdits/common/dataTypes/documentId';
 import { Edits } from '../../../../platform/inlineEdits/common/dataTypes/edit';
 import { LanguageId } from '../../../../platform/inlineEdits/common/dataTypes/languageId';
-import { DEFAULT_OPTIONS, EarlyDivergenceCancellationMode, LanguageContextLanguages, LintOptionShowCode, LintOptionWarning, ModelConfiguration, PromptingStrategy, ResponseFormat } from '../../../../platform/inlineEdits/common/dataTypes/xtabPromptOptions';
+import { DEFAULT_OPTIONS, EarlyDivergenceCancellationMode, LanguageContextLanguages, LintOptionShowCode, LintOptionWarning, ModelConfiguration, PatchModelPrediction, PromptingStrategy, ResponseFormat } from '../../../../platform/inlineEdits/common/dataTypes/xtabPromptOptions';
 import { InlineEditRequestLogContext } from '../../../../platform/inlineEdits/common/inlineEditLogContext';
 import { IInlineEditsModelService } from '../../../../platform/inlineEdits/common/inlineEditsModelService';
 import { NoNextEditReason, StatelessNextEditDocument, StatelessNextEditRequest, StreamedEdit, WithStatelessProviderTelemetry } from '../../../../platform/inlineEdits/common/statelessNextEditProvider';
@@ -454,8 +454,22 @@ describe('getPredictionContents', () => {
 	const editWindowLines = ['const x = 1;', 'const y = 2;'];
 	const doc = makeActiveDocument(['line0', ...editWindowLines, 'line3']);
 
+	// Defaults for response formats that ignore the cursor/patch args.
+	const call = (
+		lines: readonly string[],
+		format: ResponseFormat,
+		opts?: { cursorLineOffset?: number; cursorLineInEditWindowOffset?: number; patchModelPredictionKind?: PatchModelPrediction; doc?: StatelessNextEditDocument },
+	) => getPredictionContents(
+		opts?.doc ?? doc,
+		opts?.cursorLineOffset ?? 0,
+		lines,
+		opts?.cursorLineInEditWindowOffset ?? 0,
+		format,
+		opts?.patchModelPredictionKind ?? PatchModelPrediction.FilePath,
+	);
+
 	it('returns correct content for UnifiedWithXml', () => {
-		expect(getPredictionContents(doc, editWindowLines, ResponseFormat.UnifiedWithXml)).toMatchInlineSnapshot(`
+		expect(call(editWindowLines, ResponseFormat.UnifiedWithXml)).toMatchInlineSnapshot(`
 			"<EDIT>
 			const x = 1;
 			const y = 2;
@@ -464,14 +478,14 @@ describe('getPredictionContents', () => {
 	});
 
 	it('returns correct content for EditWindowOnly', () => {
-		expect(getPredictionContents(doc, editWindowLines, ResponseFormat.EditWindowOnly)).toMatchInlineSnapshot(`
+		expect(call(editWindowLines, ResponseFormat.EditWindowOnly)).toMatchInlineSnapshot(`
 			"const x = 1;
 			const y = 2;"
 		`);
 	});
 
 	it('returns correct content for EditWindowWithEditIntent', () => {
-		expect(getPredictionContents(doc, editWindowLines, ResponseFormat.EditWindowWithEditIntent)).toMatchInlineSnapshot(`
+		expect(call(editWindowLines, ResponseFormat.EditWindowWithEditIntent)).toMatchInlineSnapshot(`
 			"<|edit_intent|>high<|/edit_intent|>
 			const x = 1;
 			const y = 2;"
@@ -479,7 +493,7 @@ describe('getPredictionContents', () => {
 	});
 
 	it('returns correct content for EditWindowWithEditIntentShort', () => {
-		expect(getPredictionContents(doc, editWindowLines, ResponseFormat.EditWindowWithEditIntentShort)).toMatchInlineSnapshot(`
+		expect(call(editWindowLines, ResponseFormat.EditWindowWithEditIntentShort)).toMatchInlineSnapshot(`
 			"H
 			const x = 1;
 			const y = 2;"
@@ -487,7 +501,7 @@ describe('getPredictionContents', () => {
 	});
 
 	it('returns correct content for CodeBlock', () => {
-		expect(getPredictionContents(doc, editWindowLines, ResponseFormat.CodeBlock)).toMatchInlineSnapshot(`
+		expect(call(editWindowLines, ResponseFormat.CodeBlock)).toMatchInlineSnapshot(`
 			"\`\`\`
 			const x = 1;
 			const y = 2;
@@ -500,21 +514,66 @@ describe('getPredictionContents', () => {
 			['line0', 'line1'],
 			{ workspaceRoot: URI.file('/workspace/project') },
 		);
-		const result = getPredictionContents(docWithRoot, ['line0'], ResponseFormat.CustomDiffPatch);
+		const result = call(['line0'], ResponseFormat.CustomDiffPatch, { doc: docWithRoot });
 		expect(result.endsWith(':')).toBe(true);
 	});
 
 	it('returns correct content for CustomDiffPatch without workspace root', () => {
-		const result = getPredictionContents(doc, editWindowLines, ResponseFormat.CustomDiffPatch);
+		const result = call(editWindowLines, ResponseFormat.CustomDiffPatch);
 		expect(result.endsWith(':')).toBe(true);
 	});
 
+	it('CustomDiffPatch / CurrentLine emits path:line and a `-` deletion', () => {
+		expect(call(editWindowLines, ResponseFormat.CustomDiffPatch, {
+			cursorLineOffset: 7,
+			cursorLineInEditWindowOffset: 1,
+			patchModelPredictionKind: PatchModelPrediction.CurrentLine,
+		})).toMatchInlineSnapshot(`
+			"/test/file.ts:7
+			-const y = 2;"
+		`);
+	});
+
+	it('CustomDiffPatch / CurrentLineReplaced emits a deletion plus an empty `+`', () => {
+		expect(call(editWindowLines, ResponseFormat.CustomDiffPatch, {
+			cursorLineOffset: 7,
+			cursorLineInEditWindowOffset: 1,
+			patchModelPredictionKind: PatchModelPrediction.CurrentLineReplaced,
+		})).toMatchInlineSnapshot(`
+			"/test/file.ts:7
+			-const y = 2;
+			+"
+		`);
+	});
+
+	it('CustomDiffPatch / CurrentLineCompleted echoes the line as a `+`', () => {
+		expect(call(editWindowLines, ResponseFormat.CustomDiffPatch, {
+			cursorLineOffset: 7,
+			cursorLineInEditWindowOffset: 1,
+			patchModelPredictionKind: PatchModelPrediction.CurrentLineCompleted,
+		})).toMatchInlineSnapshot(`
+			"/test/file.ts:7
+			-const y = 2;
+			+const y = 2;"
+		`);
+	});
+
+	it('CustomDiffPatch falls back to path-only when the cursor is past the edit window', () => {
+		const result = call(editWindowLines, ResponseFormat.CustomDiffPatch, {
+			cursorLineOffset: 99,
+			cursorLineInEditWindowOffset: 99,
+			patchModelPredictionKind: PatchModelPrediction.CurrentLine,
+		});
+		expect(result.endsWith(':')).toBe(true);
+		expect(result.includes('undefined')).toBe(false);
+	});
+
 	it('handles empty editWindowLines', () => {
-		expect(getPredictionContents(doc, [], ResponseFormat.EditWindowOnly)).toBe('');
+		expect(call([], ResponseFormat.EditWindowOnly)).toBe('');
 	});
 
 	it('handles single-line editWindowLines', () => {
-		expect(getPredictionContents(doc, ['only line'], ResponseFormat.EditWindowOnly)).toBe('only line');
+		expect(call(['only line'], ResponseFormat.EditWindowOnly)).toBe('only line');
 	});
 });
 
@@ -2231,7 +2290,7 @@ describe('XtabProvider integration', () => {
 			//  Doc at request time: "const a = 1;\nfunction fi\n}"
 			//  Offsets: "const a = 1;" = 0..11, \n = 12, "function fi" = 13..23, \n = 24, "}" = 25
 			//  Cursor on line 1 (0-based), insertionOffset 23 = last 'i' of "function fi"
-			//  Edit window: all 3 lines, cursorOriginalLinesOffset = 1
+			//  Edit window: all 3 lines, cursorLineInEditWindowOffset = 1
 			//
 			//  User typed "x" at offset 24 (end of "function fi") → "function fix"
 			//  Model responds with "function fibonacci(n): number"
@@ -2395,7 +2454,7 @@ describe('XtabProvider integration', () => {
 			const provider = createProvider();
 
 			//  Doc: "const a = 1;\nfunction fi\n}"
-			//  Cursor on line 1 (0-indexed), cursorOriginalLinesOffset = 1
+			//  Cursor on line 1 (0-indexed), cursorLineInEditWindowOffset = 1
 			//  Lines before cursor (line 0) should be yielded normally.
 			//  Cursor line should trigger divergence cancellation.
 			const request = createDivergenceRequest(

--- a/extensions/copilot/src/platform/configuration/common/configurationService.ts
+++ b/extensions/copilot/src/platform/configuration/common/configurationService.ts
@@ -12,6 +12,7 @@ import * as objects from '../../../util/vs/base/common/objects';
 import { IObservable, observableFromEventOpts } from '../../../util/vs/base/common/observable';
 import * as types from '../../../util/vs/base/common/types';
 import { ICopilotTokenStore } from '../../authentication/common/copilotTokenStore';
+import type { IModelCapabilityOverride } from '../../endpoint/common/chatModelCapabilities';
 import { packageJson } from '../../env/common/packagejson';
 import { ImportChanges } from '../../inlineEdits/common/dataTypes/importFilteringOptions';
 import { JointCompletionsProviderStrategy, JointCompletionsProviderTriggerChangeStrategy } from '../../inlineEdits/common/dataTypes/jointCompletionsProviderOptions';
@@ -22,7 +23,6 @@ import { DuplicateAdditionsMode, EarlyDivergenceCancellationMode, LANGUAGE_CONTE
 import { ResponseProcessor } from '../../inlineEdits/common/responseProcessor';
 import { FetcherId } from '../../networking/common/fetcherService';
 import { AlternativeNotebookFormat } from '../../notebook/common/alternativeContentFormat';
-import type { IModelCapabilityOverride } from '../../endpoint/common/chatModelCapabilities';
 import { IExperimentationService } from '../../telemetry/common/nullExperimentationService';
 import { IValidator, vBoolean, vNumber, vString } from './validator';
 
@@ -795,6 +795,7 @@ export namespace ConfigKey {
 		 */
 		export const InlineEditsNesMimicGhostTextBehavior = defineTeamInternalSetting<boolean>('chat.advanced.inlineEdits.nesMimicGhostTextBehavior', ConfigType.ExperimentBased, false, vBoolean());
 		export const InlineEditsXtabProviderUsePrediction = defineTeamInternalSetting<boolean>('chat.advanced.inlineEdits.xtabProvider.usePrediction', ConfigType.ExperimentBased, true, vBoolean());
+		export const InlineEditsXtabProviderPatchModelPredictionKind = defineTeamInternalSetting<xtabPromptOptions.PatchModelPrediction>('chat.advanced.inlineEdits.xtabProvider.patchModelPredictionKind', ConfigType.ExperimentBased, xtabPromptOptions.PatchModelPrediction.FilePath, xtabPromptOptions.PatchModelPrediction.VALIDATOR);
 		export const InlineEditsXtabLanguageContextEnabledLanguages = defineTeamInternalSetting<LanguageContextLanguages>('chat.advanced.inlineEdits.xtabProvider.languageContext.enabledLanguages', ConfigType.Simple, LANGUAGE_CONTEXT_ENABLED_LANGUAGES);
 		export const InlineEditsXtabLanguageContextTraitsPosition = defineTeamInternalSetting<'before' | 'after'>('chat.advanced.inlineEdits.xtabProvider.languageContext.traitsPosition', ConfigType.ExperimentBased, 'before');
 		export const InlineEditsDiagnosticsExplorationEnabled = defineTeamInternalSetting<boolean | undefined>('chat.advanced.inlineEdits.inlineEditsDiagnosticsExplorationEnabled', ConfigType.Simple, false);

--- a/extensions/copilot/src/platform/inlineEdits/common/dataTypes/xtabPromptOptions.ts
+++ b/extensions/copilot/src/platform/inlineEdits/common/dataTypes/xtabPromptOptions.ts
@@ -755,3 +755,61 @@ export enum SpeculativeRequestsAutoExpandEditWindowLines {
 export namespace SpeculativeRequestsAutoExpandEditWindowLines {
 	export const VALIDATOR = vEnum(SpeculativeRequestsAutoExpandEditWindowLines.Off, SpeculativeRequestsAutoExpandEditWindowLines.Smart, SpeculativeRequestsAutoExpandEditWindowLines.Always);
 }
+
+export enum PatchModelPrediction {
+	/**
+		Expects changes in the current file but doesn't expect where (line number is not specified).
+
+		Example:
+
+		```
+		path/to/file:
+		```
+	*/
+	FilePath = 'filePath',
+	/**
+		Predicts the file path, cursor line number, and a deletion of the current line.
+		The model is free to follow with further `-`/`+` lines as needed.
+
+		Example:
+
+		```
+		path/to/file:{currentLineNumber}
+		-	class Foo {
+		```
+	*/
+	CurrentLine = 'currentLine',
+	/**
+		Expects the current line to be replaced.
+
+		Example:
+
+		```
+		path/to/file:{currentLineNumber}
+		-	class Foo {
+		+
+		```
+	*/
+	CurrentLineReplaced = 'currentLineReplaced',
+	/**
+		Expects the current line to be completed.
+
+		Example:
+
+		```
+		path/to/file:{currentLineNumber}
+		-	class Foo
+		+	class Foo
+		```
+	*/
+	CurrentLineCompleted = 'currentLineCompleted',
+}
+
+export namespace PatchModelPrediction {
+	export const VALIDATOR = vEnum(
+		PatchModelPrediction.FilePath,
+		PatchModelPrediction.CurrentLine,
+		PatchModelPrediction.CurrentLineReplaced,
+		PatchModelPrediction.CurrentLineCompleted
+	);
+}

--- a/extensions/copilot/src/platform/inlineEdits/common/dataTypes/xtabPromptOptions.ts
+++ b/extensions/copilot/src/platform/inlineEdits/common/dataTypes/xtabPromptOptions.ts
@@ -756,52 +756,57 @@ export namespace SpeculativeRequestsAutoExpandEditWindowLines {
 	export const VALIDATOR = vEnum(SpeculativeRequestsAutoExpandEditWindowLines.Off, SpeculativeRequestsAutoExpandEditWindowLines.Smart, SpeculativeRequestsAutoExpandEditWindowLines.Always);
 }
 
+/**
+ * Shape of the predicted output we send to the patch-based model along with the prompt.
+ * In every example below, `{currentLineNumber}` is 0-based — matching `Patch.lineNumZeroBased`
+ * parsed by `XtabCustomDiffPatchResponseHandler`.
+ */
 export enum PatchModelPrediction {
 	/**
-		Expects changes in the current file but doesn't expect where (line number is not specified).
-
-		Example:
-
-		```
-		path/to/file:
-		```
-	*/
+	 * Expects changes in the current file but doesn't expect where (line number is not specified).
+	 *
+	 * Example:
+	 *
+	 * ```
+	 * path/to/file:
+	 * ```
+	 */
 	FilePath = 'filePath',
 	/**
-		Predicts the file path, cursor line number, and a deletion of the current line.
-		The model is free to follow with further `-`/`+` lines as needed.
-
-		Example:
-
-		```
-		path/to/file:{currentLineNumber}
-		-	class Foo {
-		```
-	*/
+	 * Predicts the file path, cursor line number, and a deletion of the current line.
+	 * The model is free to follow with further `-`/`+` lines as needed.
+	 *
+	 * Example:
+	 *
+	 * ```
+	 * path/to/file:{currentLineNumber}
+	 * -	class Foo {
+	 * ```
+	 */
 	CurrentLine = 'currentLine',
 	/**
-		Expects the current line to be replaced.
-
-		Example:
-
-		```
-		path/to/file:{currentLineNumber}
-		-	class Foo {
-		+
-		```
-	*/
+	 * Expects the current line to be replaced.
+	 *
+	 * Example:
+	 *
+	 * ```
+	 * path/to/file:{currentLineNumber}
+	 * -	class Foo {
+	 * +
+	 * ```
+	 */
 	CurrentLineReplaced = 'currentLineReplaced',
 	/**
-		Expects the current line to be completed.
-
-		Example:
-
-		```
-		path/to/file:{currentLineNumber}
-		-	class Foo
-		+	class Foo
-		```
-	*/
+	 * Expects the current line to be completed.
+	 *
+	 * Example:
+	 *
+	 * ```
+	 * path/to/file:{currentLineNumber}
+	 * -	class Foo
+	 * +	class Foo
+	 * ```
+	 */
 	CurrentLineCompleted = 'currentLineCompleted',
 }
 


### PR DESCRIPTION
Adds an experiment-based knob to vary the "predicted output" speculation we send to the patch-based xtab model, so we can measure whether a richer hint improves first-token latency or accuracy.

### What changed

- New `PatchModelPrediction` enum + experiment config `github.copilot.chat.advanced.inlineEdits.xtabProvider.patchModelPredictionKind` with four variants:
  - `FilePath` (today's behavior, default) — `path/to/file:`
  - `CurrentLine` — `path:N\n-<line>`
  - `CurrentLineReplaced` — `path:N\n-<line>\n+`
  - `CurrentLineCompleted` — `path:N\n-<line>\n+<line>`
- `getPredictionContents` plumbs `cursorLineOffset` (0-based, matching `Patch.lineNumZeroBased` parsed by `XtabCustomDiffPatchResponseHandler`) and `cursorLineInEditWindowOffset` through to the `CustomDiffPatch` branch.
- Guards against out-of-range `cursorLineInEditWindowOffset` so we never emit a literal `-undefined` into the prompt — falls back to the `FilePath` shape in that case.
- Renames `cursorOriginalLinesOffset` → `cursorLineInEditWindowOffset` across `xtabProvider.ts` to match what the value actually represents.
- Tests for all four `CustomDiffPatch` variants plus the fallback path.


fixes https://github.com/microsoft/vscode-internalbacklog/issues/7871