### PR TITLE
fix: add overrideAuthType=token to CLI smoke tests and re-enable them

### DIFF
--- a/test/smoke/src/areas/chat/chatSessions.test.ts
+++ b/test/smoke/src/areas/chat/chatSessions.test.ts
@@ -66,6 +66,9 @@ export function setup(logger: Logger) {
 			await app.workbench.settingsEditor.addUserSettings([
 				['github.copilot.advanced.debug.overrideProxyUrl', JSON.stringify(mockServer.url)],
 				['github.copilot.advanced.debug.overrideCapiUrl', JSON.stringify(mockServer.url)],
+				// Use token auth (not HMAC) so the CLI SDK can call /models and
+				// /models/session against the mock server without HMAC validation.
+				['github.copilot.advanced.debug.overrideAuthType', '"token"'],
 				['chat.allowAnonymousAccess', 'true'],
 				['github.copilot.chat.githubMcpServer.enabled', 'false'],
 				['chat.mcp.discovery.enabled', 'false'],
@@ -81,7 +84,7 @@ export function setup(logger: Logger) {
 			await mockServer?.close();
 		});
 
-		it.skip('Test Copilot CLI session', async function () {
+		it('Test Copilot CLI session', async function () {
 			const app = this.app as Application;
 			const requestsBefore = mockServer.requestCount();
 

--- a/test/smoke/src/areas/chat/copilotCli.test.ts
+++ b/test/smoke/src/areas/chat/copilotCli.test.ts
@@ -52,6 +52,9 @@ export function setup(logger: Logger) {
 			await app.workbench.settingsEditor.addUserSettings([
 				['github.copilot.advanced.debug.overrideProxyUrl', JSON.stringify(mockServer.url)],
 				['github.copilot.advanced.debug.overrideCapiUrl', JSON.stringify(mockServer.url)],
+				// Use token auth (not HMAC) so the CLI SDK can call /models and
+				// /models/session against the mock server without HMAC validation.
+				['github.copilot.advanced.debug.overrideAuthType', '"token"'],
 				['chat.allowAnonymousAccess', 'true'],
 				['github.copilot.chat.githubMcpServer.enabled', 'false'],
 				['chat.mcp.discovery.enabled', 'false'],
@@ -63,7 +66,7 @@ export function setup(logger: Logger) {
 			await mockServer?.close();
 		});
 
-		it.skip('opens a Copilot CLI session and receives a response', async function () {
+		it('opens a Copilot CLI session and receives a response', async function () {
 			const app = this.app as Application;
 			const requestsBefore = mockServer.requestCount();
 


### PR DESCRIPTION
The Copilot CLI smoke tests were failing because overrideAuthType was not set, causing the CLI SDK to use HMAC auth (the default) against the mock LLM server. The mock server cannot validate HMAC signatures, so /models calls returned 401, model fetching failed, and prompt rendering threw "Unexpected generated prompt structure".

Add the missing ['github.copilot.advanced.debug.overrideAuthType', '"token"'] setting to both chatSessions.test.ts and copilotCli.test.ts (matching what agentsWindow.test.ts already does), and remove the it.skip that was added as a temporary workaround.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
