### PR TITLE
Set AI_AGENT env var for agent terminals

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/toolTerminalCreator.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/toolTerminalCreator.ts
@@ -152,6 +152,9 @@ export class ToolTerminalCreator {
 			// This allows programs to adapt their output (e.g. JSON instead of
 			// ANSI, disable interactive prompts, skip animations).
 			// See https://github.com/microsoft/vscode/issues/311734
+			// `AI_AGENT` is the cross-vendor standard; `COPILOT_AGENT` is kept
+			// for back-compat with CLIs that already adopted it.
+			AI_AGENT: 'github_copilot_vscode_agent',
 			COPILOT_AGENT: '1',
 			// Avoid making `git diff` interactive when called from copilot
 			GIT_PAGER: 'cat',


### PR DESCRIPTION
Adopts the cross-vendor `AI_AGENT=github_copilot_vscode_agent` environment variable on agent-initiated terminals. `COPILOT_AGENT=1` is kept alongside it for back-compat with CLIs that already adopted it.

Fixes #320127