### PR TITLE
Cap get_terminal_output first-poll and non-prefix responses to a tail

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/getTerminalOutputTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/getTerminalOutputTool.ts
@@ -113,7 +113,7 @@ export class GetTerminalOutputTool extends Disposable implements IToolImpl {
 			return this._formatTailOrFull(output, `Output of terminal ${id}`);
 		}
 		if (currentOutputSnapshot.length === previousOutputSnapshot.length && currentOutputSnapshot.hash === previousOutputSnapshot.hash) {
-			return `Output of terminal ${id} unchanged since previous poll (${output.length} characters already shown). No new output.`;
+			return `Output of terminal ${id} unchanged since previous poll (${output.length} total characters in buffer). No new output.`;
 		}
 
 		if (output.length > previousOutputSnapshot.length && this._hashOutput(output, previousOutputSnapshot.length) === previousOutputSnapshot.hash) {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/getTerminalOutputTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/getTerminalOutputTool.ts
@@ -129,7 +129,7 @@ export class GetTerminalOutputTool extends Disposable implements IToolImpl {
 		}
 		const tail = this._tailOf(output, GetTerminalOutputTool._tailCharBudget);
 		const omitted = output.length - tail.length;
-		return `${prefix}; showing last ${tail.length} of ${output.length} characters (${omitted} earlier characters omitted):\n${tail}`;
+		return `${prefix}; showing last ${tail.length} of ${output.length} characters (${omitted} earlier characters omitted). If you need the omitted earlier output, re-run the command and redirect output to a file, then read that file:\n${tail}`;
 	}
 
 	private _tailOf(output: string, charBudget: number): string {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/getTerminalOutputTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/getTerminalOutputTool.ts
@@ -49,6 +49,7 @@ interface IOutputSnapshot {
 export class GetTerminalOutputTool extends Disposable implements IToolImpl {
 
 	private static readonly _maxOutputSnapshots = 100;
+	private static readonly _tailCharBudget = 8000;
 	private readonly _lastOutputSnapshotByExecutionId = new Map<string, IOutputSnapshot>();
 
 	constructor(
@@ -109,7 +110,7 @@ export class GetTerminalOutputTool extends Disposable implements IToolImpl {
 		this._rememberOutput(id, currentOutputSnapshot);
 
 		if (previousOutputSnapshot === undefined) {
-			return `Output of terminal ${id}:\n${output}`;
+			return this._formatTailOrFull(output, `Output of terminal ${id}`);
 		}
 		if (currentOutputSnapshot.length === previousOutputSnapshot.length && currentOutputSnapshot.hash === previousOutputSnapshot.hash) {
 			return `Output of terminal ${id} unchanged since previous poll (${output.length} characters already shown). No new output.`;
@@ -119,7 +120,28 @@ export class GetTerminalOutputTool extends Disposable implements IToolImpl {
 			const delta = output.slice(previousOutputSnapshot.length);
 			return `Output of terminal ${id} since previous poll (${delta.length} new characters, ${output.length} total characters):\n${delta}`;
 		}
-		return `Output of terminal ${id} changed since previous poll; returning current output (${output.length} characters):\n${output}`;
+		return this._formatTailOrFull(output, `Output of terminal ${id} changed since previous poll`);
+	}
+
+	private _formatTailOrFull(output: string, prefix: string): string {
+		if (output.length <= GetTerminalOutputTool._tailCharBudget) {
+			return `${prefix}:\n${output}`;
+		}
+		const tail = this._tailOf(output, GetTerminalOutputTool._tailCharBudget);
+		const omitted = output.length - tail.length;
+		return `${prefix}; showing last ${tail.length} of ${output.length} characters (${omitted} earlier characters omitted):\n${tail}`;
+	}
+
+	private _tailOf(output: string, charBudget: number): string {
+		if (output.length <= charBudget) {
+			return output;
+		}
+		const startIndex = output.length - charBudget;
+		const newlineIndex = output.indexOf('\n', startIndex);
+		if (newlineIndex !== -1 && newlineIndex < output.length - 1) {
+			return output.slice(newlineIndex + 1);
+		}
+		return output.slice(startIndex);
 	}
 
 	private _rememberOutput(id: string, snapshot: IOutputSnapshot): void {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/getTerminalOutputTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/getTerminalOutputTool.ts
@@ -102,7 +102,7 @@ export class GetTerminalOutputTool extends Disposable implements IToolImpl {
 	private _formatOutput(id: string, terminalInstanceId: number, output: string): string {
 		if (!this._configurationService.getValue<boolean>(TerminalChatAgentToolsSettingId.OutputDeltas)) {
 			this._lastOutputSnapshotByExecutionId.clear();
-			return `Output of terminal ${id}:\n${output}`;
+			return this._formatTailOrFull(output, `Output of terminal ${id}`);
 		}
 
 		const previousOutputSnapshot = this._lastOutputSnapshotByExecutionId.get(id);

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/getTerminalOutputTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/getTerminalOutputTool.test.ts
@@ -245,4 +245,63 @@ suite('GetTerminalOutputTool', () => {
 		assert.ok(value.includes('changed since previous poll'));
 		assert.ok(value.endsWith('\nnew screen'));
 	});
+
+	test('returns only the tail on first poll when output exceeds the tail budget', async () => {
+		configurationService.setUserConfiguration(TerminalChatAgentToolsSettingId.OutputDeltas, true);
+		const bigLine = 'x'.repeat(200);
+		const lines: string[] = [];
+		for (let i = 0; i < 100; i++) {
+			lines.push(`${i}-${bigLine}`);
+		}
+		const output = lines.join('\n');
+		RunInTerminalTool.getExecution = () => createMockExecution(output);
+
+		const result = await tool.invoke(
+			createInvocation(KNOWN_TERMINAL_ID),
+			async () => 0,
+			{ report: () => { } },
+			CancellationToken.None,
+		);
+
+		const value = (result.content[0] as { value: string }).value;
+		assert.ok(value.includes(`showing last `));
+		assert.ok(value.includes(`of ${output.length} characters`));
+		assert.ok(value.includes('earlier characters omitted'));
+		assert.ok(value.endsWith(`\n${lines[lines.length - 1]}`));
+		assert.ok(value.length < output.length);
+	});
+
+	test('returns only the tail on non-prefix fallback when output exceeds the tail budget', async () => {
+		configurationService.setUserConfiguration(TerminalChatAgentToolsSettingId.OutputDeltas, true);
+		const execution = createMutableMockExecution('seed');
+		RunInTerminalTool.getExecution = () => execution;
+
+		await tool.invoke(
+			createInvocation(KNOWN_TERMINAL_ID),
+			async () => 0,
+			{ report: () => { } },
+			CancellationToken.None,
+		);
+
+		const bigLine = 'y'.repeat(200);
+		const lines: string[] = [];
+		for (let i = 0; i < 100; i++) {
+			lines.push(`${i}-${bigLine}`);
+		}
+		const replaced = lines.join('\n');
+		execution.setOutput(replaced);
+
+		const result = await tool.invoke(
+			createInvocation(KNOWN_TERMINAL_ID),
+			async () => 0,
+			{ report: () => { } },
+			CancellationToken.None,
+		);
+
+		const value = (result.content[0] as { value: string }).value;
+		assert.ok(value.includes('changed since previous poll'));
+		assert.ok(value.includes(`of ${replaced.length} characters`));
+		assert.ok(value.endsWith(`\n${lines[lines.length - 1]}`));
+		assert.ok(value.length < replaced.length);
+	});
 });

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/getTerminalOutputTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/getTerminalOutputTool.test.ts
@@ -145,7 +145,7 @@ suite('GetTerminalOutputTool', () => {
 		assert.strictEqual(result.content.length, 1);
 		assert.strictEqual(result.content[0].kind, 'text');
 		const value = (result.content[0] as { value: string }).value;
-		assert.strictEqual(value, `Output of terminal ${KNOWN_TERMINAL_ID} unchanged since previous poll (11 characters already shown). No new output.`);
+		assert.strictEqual(value, `Output of terminal ${KNOWN_TERMINAL_ID} unchanged since previous poll (11 total characters in buffer). No new output.`);
 	});
 
 	test('returns only new output when output deltas experiment is enabled', async () => {


### PR DESCRIPTION
Fixes the spillover side of microsoft/vscode-internalbacklog#7869.

PR #315543 already shrinks **repeated** `get_terminal_output` polls by returning only the delta. But the **first** poll and the **non-prefix fallback** still returned the full buffer (up to the ~60 KB upstream cap in `outputHelpers.ts`), which is well above the Copilot SDK's ~10 KB spillover threshold and causes the agent to thrash with `read_file` calls on the spillover temp file.

This change adds a second, tighter cap inside the tool itself: when the full output exceeds 8 KB, return only the last 8 KB (line-aligned). The truncation marker includes both the omitted character count and a hint telling the agent how to recover the head if it needs to: re-run the command and redirect output to a file, then read that file.

Snapshot tracking (length + hash) still uses the full buffer, so subsequent delta polls work unchanged.

### Behavior

The tail cap applies on every code path (always on — not gated by an experiment), because the SDK spillover issue affects all users regardless of whether `chat.tools.terminal.outputDeltas` is enabled. The delta-tracking semantics introduced by #315543 remain gated by that experiment.

- Experiment off: full output if ≤ 8 KB; otherwise tail + recovery hint.
- Experiment on, first poll: same.
- Experiment on, unchanged poll: `unchanged since previous poll` marker (no output).
- Experiment on, pure-prefix delta poll: only the new characters (already small).
- Experiment on, non-prefix fallback: same tail treatment as first poll.

### Risks / follow-ups

- **8 KB is a tuned guess.** Picked to stay under the ~10 KB SDK spillover threshold with headroom for the prefix text. If the SDK threshold changes we may need to retune.
- **No telemetry** on how often truncation kicks in or whether the agent successfully recovers via the redirect hint. Worth adding to validate.
- **Line-alignment edge case**: single-line outputs with no `\n` in the last 8 KB fall back to a raw character cut, which could land mid-ANSI-escape. Rare.

### Tests

`getTerminalOutputTool.test.ts` — all 11 tests pass, including two added for the new behavior:
- `returns only the tail on first poll when output exceeds the tail budget`
- `returns only the tail on non-prefix fallback when output exceeds the tail budget`
