### PR TITLE
Fix `handleEndOfLifetime` `supersededBy` tracking for inline completions

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
@@ -1415,7 +1415,7 @@ class ExtensionBackedInlineCompletionsProvider extends Disposable implements lan
 		}
 
 		if (this._supportsHandleEvents) {
-			await this._proxy.$handleInlineCompletionEndOfLifetime(this.handle, completions.pid, item.idx, mapReason(reason, i => ({ pid: completions.pid, idx: i.idx })));
+			await this._proxy.$handleInlineCompletionEndOfLifetime(this.handle, completions.pid, item.idx, mapReason(reason, i => ({ pid: i.pid, idx: i.idx })));
 		}
 
 		if (reason.kind === languages.InlineCompletionEndOfLifeReasonKind.Accepted) {

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -491,6 +491,7 @@ export interface IdentifiableInlineCompletions extends languages.InlineCompletio
 }
 
 export interface IdentifiableInlineCompletion extends languages.InlineCompletion {
+	pid: number;
 	idx: number;
 	suggestionId: EditSuggestionId | undefined;
 }

--- a/src/vs/workbench/api/common/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/common/extHostLanguageFeatures.ts
@@ -1478,6 +1478,7 @@ class InlineCompletionAdapter {
 					showRange: (this._isAdditionsProposedApiEnabled && item.showRange) ? typeConvert.Range.from(item.showRange) : undefined,
 					command,
 					gutterMenuLinkAction: action,
+					pid: pid,
 					idx: idx,
 					completeBracketPairs: this._isAdditionsProposedApiEnabled ? item.completeBracketPairs : false,
 					isInlineEdit: this._isAdditionsProposedApiEnabled ? item.isInlineEdit : false,


### PR DESCRIPTION
### Problem
When an inline completion item is superseded by a newer suggestion (e.g., from a subsequent completion request), the extension host provider's `handleEndOfLifetime` callback should receive the superseding completion item via `reason.supersededBy`. Instead, providers were receiving the old completion item itself (essentially being told the item superseded itself).
  
### Root Cause
  When the main thread processes `handleEndOfLifetime` in `mainThreadLanguageFeatures.ts`, it maps `reason.supersededBy` into an IPC reference `{ pid, idx }`. Because individual `IdentifiableInlineCompletion` items only tracked `idx` and not `pid`, `mapReason` incorrectly fell back to using `completions.pid`:
  ```typescript
  mapReason(reason, i => ({ pid: completions.pid, idx: i.idx }))
  ```
  
Since `completions.pid` refers to the old completion list being disposed, it paired the old list's PID with the new item's index (`0`). When this arrived at the extension host, it resolved `this._references.get(oldPid)?.items[0]`, incorrectly fetching the old item instead of the new one.

### Solution
1. Protocol Definition: Added `pid: number` to the `IdentifiableInlineCompletion` DTO interface in `extHost.protocol.ts`.
2. Extension Host: Updated `InlineCompletionAdapter.provideInlineCompletions` in `extHostLanguageFeatures.ts` to include `pid` on every completion item DTO sent across the IPC bridge.
1. Main Thread: Updated `mapReason` in `mainThreadLanguageFeatures.ts` to use `i.pid` instead of `completions.pid`.

### Impact
This change is entirely scoped to the internal Core <-> Extension Host RPC boundary. The public vscode extension API remains 100% unchanged.