### PR TITLE
Use copilot/copilot-utility-small for terminal-tool steering messages

### DIFF
--- a/extensions/copilot/src/extension/prompt/vscode-node/endpointProviderImpl.ts
+++ b/extensions/copilot/src/extension/prompt/vscode-node/endpointProviderImpl.ts
@@ -121,6 +121,14 @@ export class ProductionEndpointProvider extends Disposable implements IEndpointP
 			}
 		}
 
+		// Utility-family aliases (published by LanguageModelAccess under the copilot vendor)
+		// have synthetic ids that don't map to any real CAPI model, so the lookup below
+		// would silently fall back to `copilot-utility`. Route them through the family
+		// resolver so the chat-participant path matches direct `getChatEndpoint(family)` callers.
+		if (model.id === 'copilot-utility-small' || model.id === 'copilot-utility') {
+			return this.getChatEndpoint(model.id);
+		}
+
 		const modelMetadata = await this._modelFetcher.getChatModelFromApiModel(model);
 		// If we fail to resolve a model since this is panel we give copilot utility. This really should never happen as the picker is powered by the same service.
 		return modelMetadata ? this.getOrCreateChatEndpointInstance(modelMetadata) : this.getChatEndpoint('copilot-utility');

--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -1528,7 +1528,7 @@ export class ChatService extends Disposable implements IChatService {
 				this.processNextPendingRequest(model);
 			}
 		});
-		if (options?.userSelectedModelId) {
+		if (options?.userSelectedModelId && !options.isSystemInitiated) {
 			this.languageModelsService.addToRecentlyUsedList(options.userSelectedModelId);
 		}
 		this._onDidSubmitRequest.fire({ chatSessionResource: model.sessionResource, message: parsedRequest });

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -2387,7 +2387,10 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 	}
 
 	/**
-	 * Resolves the `copilot/copilot-utility-small` alias identifier for use as
+	 * Resolves the opaque language-model identifier published under the
+	 * `copilot/copilot-utility-small` alias (vendor `copilot`, id
+	 * `copilot-utility-small`). `selectLanguageModels` returns an array of
+	 * resolved identifier strings; we use the first match directly as
 	 * `userSelectedModelId` on terminal-tool steering messages (background
 	 * completion / input-needed / disposal notifications). The alias is
 	 * published by the copilot extension and already honors the
@@ -2800,7 +2803,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			}
 			return utilitySmallId;
 		}, err => {
-			this._logService.debug(`RunInTerminalTool: Failed to resolve 'copilot/copilot-utility-small' alias for terminal ${termId}; steering messages will use conversation model. Error: ${err}`);
+			this._logService.warn(`RunInTerminalTool: Failed to resolve 'copilot/copilot-utility-small' alias for terminal ${termId}; steering messages will use conversation model`, err);
 			return undefined;
 		});
 		const resolveSendOptions = async (): Promise<typeof sendOptions> => {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -26,7 +26,7 @@ import { ILabelService } from '../../../../../../platform/label/common/label.js'
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../../platform/storage/common/storage.js';
 import { AgentSandboxSettingId } from '../../../../../../platform/sandbox/common/settings.js';
 import { ICommandDetectionCapability, TerminalCapability } from '../../../../../../platform/terminal/common/capabilities/capabilities.js';
-import { ITerminalLogService, ITerminalProfile } from '../../../../../../platform/terminal/common/terminal.js';
+import { ITerminalLogService, ITerminalProfile, TerminalExitReason } from '../../../../../../platform/terminal/common/terminal.js';
 import { IRemoteAgentService } from '../../../../../services/remote/common/remoteAgentService.js';
 import { TerminalToolConfirmationStorageKeys } from '../../../../chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolConfirmationSubPart.js';
 import { IChatService, ChatRequestQueueKind, ElicitationState, type IChatExternalToolInvocationUpdate, type IChatTerminalToolInvocationData } from '../../../../chat/common/chatService/chatService.js';
@@ -80,7 +80,7 @@ import { IOutputAnalyzer } from './outputAnalyzer.js';
 import { SandboxOutputAnalyzer, outputLooksSandboxBlocked, outputLooksSandboxNetworkBlocked } from './sandboxOutputAnalyzer.js';
 import { IAgentSessionsService } from '../../../../chat/browser/agentSessions/agentSessionsService.js';
 import { ITerminalSandboxService, TerminalSandboxPrerequisiteCheck, type ITerminalSandboxPrecheckInputs, type ITerminalSandboxResolvedNetworkDomains } from '../../common/terminalSandboxService.js';
-import { LanguageModelPartAudience } from '../../../../chat/common/languageModels.js';
+import { ILanguageModelsService, LanguageModelPartAudience } from '../../../../chat/common/languageModels.js';
 import { isSessionAutoApproveLevel, isTerminalAutoApproveAllowed, isToolEligibleForTerminalAutoApproval } from './terminalToolAutoApprove.js';
 import type { IJSONSchemaMap } from '../../../../../../base/common/jsonSchema.js';
 import { ChatElicitationRequestPart } from '../../../../chat/common/model/chatProgressTypes/chatElicitationRequestPart.js';
@@ -731,6 +731,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@ILabelService private readonly _labelService: ILabelService,
 		@ILanguageModelToolsService private readonly _languageModelToolsService: ILanguageModelToolsService,
+		@ILanguageModelsService private readonly _languageModelsService: ILanguageModelsService,
 		@IRemoteAgentService private readonly _remoteAgentService: IRemoteAgentService,
 		@IStorageService private readonly _storageService: IStorageService,
 		@ITerminalChatService private readonly _terminalChatService: ITerminalChatService,
@@ -2385,6 +2386,20 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		return lines.join('\n');
 	}
 
+	/**
+	 * Resolves the `copilot/copilot-utility-small` alias identifier for use as
+	 * `userSelectedModelId` on terminal-tool steering messages (background
+	 * completion / input-needed / disposal notifications). The alias is
+	 * published by the copilot extension and already honors the
+	 * `chat.utilitySmallModel` setting. Returns `undefined` if the alias is
+	 * not available, in which case the caller leaves the conversation model
+	 * in place.
+	 */
+	private async _resolveUtilitySmallModelId(): Promise<string | undefined> {
+		const models = await this._languageModelsService.selectLanguageModels({ vendor: 'copilot', id: 'copilot-utility-small' });
+		return models[0];
+	}
+
 	private async _getOutputAnalyzerMessage(exitCode: number | undefined, exitResult: string, commandLine: string, isSandboxWrapped: boolean): Promise<string | undefined> {
 		for (const analyzer of this._outputAnalyzers) {
 			const message = await analyzer.analyze({ exitCode, exitResult, commandLine, isSandboxWrapped });
@@ -2762,8 +2777,11 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			return;
 		}
 
-		// Capture model/mode/tools from the last request so the steering message
-		// uses the same settings as the original conversation (not defaults).
+		// Capture mode/tools from the last request so the steering message uses
+		// the same settings as the original conversation (not defaults). The
+		// model is intentionally not inherited — these steering notifications
+		// are agent-internal turns and should be billed to the copilot utility
+		// small alias when available, falling back to the conversation model.
 		const lastRequest = sessionRef.object.lastRequest;
 		const sendOptions: { userSelectedModelId?: string; modeInfo?: IChatRequestModeInfo; userSelectedTools?: IObservable<UserSelectedTools> } = {};
 		if (lastRequest) {
@@ -2773,6 +2791,22 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 				sendOptions.userSelectedTools = constObservable(lastRequest.userSelectedTools);
 			}
 		}
+
+		const utilitySmallIdPromise = this._resolveUtilitySmallModelId().then(utilitySmallId => {
+			if (utilitySmallId) {
+				this._logService.debug(`RunInTerminalTool: Steering messages for background terminal ${termId} will use model '${utilitySmallId}'`);
+			} else {
+				this._logService.debug(`RunInTerminalTool: 'copilot/copilot-utility-small' alias unavailable; steering messages for background terminal ${termId} will use conversation model '${sendOptions.userSelectedModelId ?? '<default>'}'`);
+			}
+			return utilitySmallId;
+		}, err => {
+			this._logService.debug(`RunInTerminalTool: Failed to resolve 'copilot/copilot-utility-small' alias for terminal ${termId}; steering messages will use conversation model. Error: ${err}`);
+			return undefined;
+		});
+		const resolveSendOptions = async (): Promise<typeof sendOptions> => {
+			const utilitySmallId = await utilitySmallIdPromise;
+			return utilitySmallId ? { ...sendOptions, userSelectedModelId: utilitySmallId } : sendOptions;
+		};
 
 		// Continue the output monitor in background mode for prompt-for-input detection.
 		// The monitor wakes only on new terminal data (not on a fixed interval), so
@@ -2889,13 +2923,13 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 
 				this._logService.debug(`RunInTerminalTool: Input needed in background terminal ${termId}, notifying chat session`);
 
-				this._chatService.sendRequest(chatSessionResource, message, {
-					...sendOptions,
+				resolveSendOptions().then(opts => this._chatService.sendRequest(chatSessionResource, message, {
+					...opts,
 					queue: ChatRequestQueueKind.Steering,
 					isSystemInitiated: true,
 					systemInitiatedLabel: localize('terminalAssessingOutput', "{0} may need input", commandDisplay),
 					terminalExecutionId: termId,
-				}).catch(e => {
+				})).catch(e => {
 					this._logService.warn(`RunInTerminalTool: Failed to send input-needed notification for terminal ${termId}`, e);
 				});
 			}));
@@ -2943,13 +2977,13 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 
 			this._logService.debug(`RunInTerminalTool: Command completed in background terminal ${termId}, notifying chat session`);
 
-			this._chatService.sendRequest(chatSessionResource, message, {
-				...sendOptions,
+			resolveSendOptions().then(opts => this._chatService.sendRequest(chatSessionResource, message, {
+				...opts,
 				queue: ChatRequestQueueKind.Steering,
 				isSystemInitiated: true,
 				systemInitiatedLabel: localize('terminalCommandCompleted', "{0} completed", commandDisplay),
 				terminalExecutionId: termId,
-			}).catch(e => {
+			})).catch(e => {
 				this._logService.warn(`RunInTerminalTool: Failed to send completion notification for terminal ${termId}`, e);
 			});
 
@@ -3002,6 +3036,16 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 				disposeNotification();
 				return;
 			}
+			// When the user manually closes the terminal (e.g. killing a
+			// long-running dev server they no longer want), do not send a
+			// steering message. The user has signaled they are done with
+			// the terminal; auto-triggering another agent turn would burn
+			// credits for an action the user didn't request (#317059).
+			if (terminalInstance.exitReason === TerminalExitReason.User) {
+				this._logService.debug(`RunInTerminalTool: Background terminal ${termId} closed by user, suppressing steering message`);
+				disposeNotification();
+				return;
+			}
 			if (handleSessionCancelled()) {
 				return;
 			}
@@ -3011,13 +3055,13 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			disposeNotification();
 			const message = `[Terminal ${termId} notification: terminal exited${exitCodeText}. The terminal process ended before the command could complete normally; further commands cannot be sent to this terminal ID.]\nTerminal output:\n${currentOutput}`;
 			this._logService.debug(`RunInTerminalTool: Background terminal ${termId} disposed${exitCodeText}, notifying chat session`);
-			this._chatService.sendRequest(chatSessionResource, message, {
-				...sendOptions,
+			resolveSendOptions().then(opts => this._chatService.sendRequest(chatSessionResource, message, {
+				...opts,
 				queue: ChatRequestQueueKind.Steering,
 				isSystemInitiated: true,
 				systemInitiatedLabel: localize('terminalProcessExited', "{0} terminal exited", commandDisplay),
 				terminalExecutionId: termId,
-			}).catch(e => {
+			})).catch(e => {
 				this._logService.warn(`RunInTerminalTool: Failed to send terminal-exited notification for terminal ${termId}`, e);
 			});
 		}));

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -2387,16 +2387,15 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 	}
 
 	/**
-	 * Resolves the opaque language-model identifier published under the
-	 * `copilot/copilot-utility-small` alias (vendor `copilot`, id
-	 * `copilot-utility-small`). `selectLanguageModels` returns an array of
-	 * resolved identifier strings; we use the first match directly as
-	 * `userSelectedModelId` on terminal-tool steering messages (background
-	 * completion / input-needed / disposal notifications). The alias is
-	 * published by the copilot extension and already honors the
-	 * `chat.utilitySmallModel` setting. Returns `undefined` if the alias is
-	 * not available, in which case the caller leaves the conversation model
-	 * in place.
+	 * Resolves a language-model identifier for terminal-tool steering messages
+	 * (background completion / input-needed / disposal notifications).
+	 *
+	 * Calls `selectLanguageModels({ vendor: 'copilot', id: 'copilot-utility-small' })`
+	 * which returns an array of opaque identifier strings matching the filter.
+	 * We take the first match and pass it as `userSelectedModelId` on steering
+	 * requests. The alias is published by the Copilot extension and already
+	 * honors the `chat.utilitySmallModel` setting. Returns `undefined` if no
+	 * model matches, in which case the caller falls back to the conversation model.
 	 */
 	private async _resolveUtilitySmallModelId(): Promise<string | undefined> {
 		const models = await this._languageModelsService.selectLanguageModels({ vendor: 'copilot', id: 'copilot-utility-small' });

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -2387,15 +2387,8 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 	}
 
 	/**
-	 * Resolves a language-model identifier for terminal-tool steering messages
-	 * (background completion / input-needed / disposal notifications).
-	 *
-	 * Calls `selectLanguageModels({ vendor: 'copilot', id: 'copilot-utility-small' })`
-	 * which returns an array of opaque identifier strings matching the filter.
-	 * We take the first match and pass it as `userSelectedModelId` on steering
-	 * requests. The alias is published by the Copilot extension and already
-	 * honors the `chat.utilitySmallModel` setting. Returns `undefined` if no
-	 * model matches, in which case the caller falls back to the conversation model.
+	 * Resolves the `copilot/copilot-utility-small` model identifier for
+	 * steering messages. Returns `undefined` if unavailable.
 	 */
 	private async _resolveUtilitySmallModelId(): Promise<string | undefined> {
 		const models = await this._languageModelsService.selectLanguageModels({ vendor: 'copilot', id: 'copilot-utility-small' });
@@ -2779,11 +2772,8 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			return;
 		}
 
-		// Capture mode/tools from the last request so the steering message uses
-		// the same settings as the original conversation (not defaults). The
-		// model is intentionally not inherited — these steering notifications
-		// are agent-internal turns and should be billed to the copilot utility
-		// small alias when available, falling back to the conversation model.
+		// Capture mode/tools from the last request. The model is resolved
+		// separately via the utility-small alias (falling back to conversation model).
 		const lastRequest = sessionRef.object.lastRequest;
 		const sendOptions: { userSelectedModelId?: string; modeInfo?: IChatRequestModeInfo; userSelectedTools?: IObservable<UserSelectedTools> } = {};
 		if (lastRequest) {
@@ -3038,11 +3028,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 				disposeNotification();
 				return;
 			}
-			// When the user manually closes the terminal (e.g. killing a
-			// long-running dev server they no longer want), do not send a
-			// steering message. The user has signaled they are done with
-			// the terminal; auto-triggering another agent turn would burn
-			// credits for an action the user didn't request (#317059).
+			// Skip steering message when user manually closed the terminal (#317059).
 			if (terminalInstance.exitReason === TerminalExitReason.User) {
 				this._logService.debug(`RunInTerminalTool: Background terminal ${termId} closed by user, suppressing steering message`);
 				disposeNotification();

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -2784,20 +2784,23 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			}
 		}
 
-		const utilitySmallIdPromise = this._resolveUtilitySmallModelId().then(utilitySmallId => {
+		// Resolve the utility-small alias eagerly and cache it so steering
+		// dispatch stays synchronous. Falls back to the conversation model if
+		// an event fires before resolution completes (rare — events require
+		// the terminal to produce output first).
+		let cachedUtilitySmallId: string | undefined;
+		this._resolveUtilitySmallModelId().then(utilitySmallId => {
+			cachedUtilitySmallId = utilitySmallId;
 			if (utilitySmallId) {
 				this._logService.debug(`RunInTerminalTool: Steering messages for background terminal ${termId} will use model '${utilitySmallId}'`);
 			} else {
 				this._logService.debug(`RunInTerminalTool: 'copilot/copilot-utility-small' alias unavailable; steering messages for background terminal ${termId} will use conversation model '${sendOptions.userSelectedModelId ?? '<default>'}'`);
 			}
-			return utilitySmallId;
 		}, err => {
 			this._logService.warn(`RunInTerminalTool: Failed to resolve 'copilot/copilot-utility-small' alias for terminal ${termId}; steering messages will use conversation model`, err);
-			return undefined;
 		});
-		const resolveSendOptions = async (): Promise<typeof sendOptions> => {
-			const utilitySmallId = await utilitySmallIdPromise;
-			return utilitySmallId ? { ...sendOptions, userSelectedModelId: utilitySmallId } : sendOptions;
+		const buildSendOptions = (): typeof sendOptions => {
+			return cachedUtilitySmallId ? { ...sendOptions, userSelectedModelId: cachedUtilitySmallId } : sendOptions;
 		};
 
 		// Continue the output monitor in background mode for prompt-for-input detection.
@@ -2915,13 +2918,13 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 
 				this._logService.debug(`RunInTerminalTool: Input needed in background terminal ${termId}, notifying chat session`);
 
-				resolveSendOptions().then(opts => this._chatService.sendRequest(chatSessionResource, message, {
-					...opts,
+				this._chatService.sendRequest(chatSessionResource, message, {
+					...buildSendOptions(),
 					queue: ChatRequestQueueKind.Steering,
 					isSystemInitiated: true,
 					systemInitiatedLabel: localize('terminalAssessingOutput', "{0} may need input", commandDisplay),
 					terminalExecutionId: termId,
-				})).catch(e => {
+				}).catch(e => {
 					this._logService.warn(`RunInTerminalTool: Failed to send input-needed notification for terminal ${termId}`, e);
 				});
 			}));
@@ -2969,13 +2972,13 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 
 			this._logService.debug(`RunInTerminalTool: Command completed in background terminal ${termId}, notifying chat session`);
 
-			resolveSendOptions().then(opts => this._chatService.sendRequest(chatSessionResource, message, {
-				...opts,
+			this._chatService.sendRequest(chatSessionResource, message, {
+				...buildSendOptions(),
 				queue: ChatRequestQueueKind.Steering,
 				isSystemInitiated: true,
 				systemInitiatedLabel: localize('terminalCommandCompleted', "{0} completed", commandDisplay),
 				terminalExecutionId: termId,
-			})).catch(e => {
+			}).catch(e => {
 				this._logService.warn(`RunInTerminalTool: Failed to send completion notification for terminal ${termId}`, e);
 			});
 
@@ -3043,13 +3046,13 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			disposeNotification();
 			const message = `[Terminal ${termId} notification: terminal exited${exitCodeText}. The terminal process ended before the command could complete normally; further commands cannot be sent to this terminal ID.]\nTerminal output:\n${currentOutput}`;
 			this._logService.debug(`RunInTerminalTool: Background terminal ${termId} disposed${exitCodeText}, notifying chat session`);
-			resolveSendOptions().then(opts => this._chatService.sendRequest(chatSessionResource, message, {
-				...opts,
+			this._chatService.sendRequest(chatSessionResource, message, {
+				...buildSendOptions(),
 				queue: ChatRequestQueueKind.Steering,
 				isSystemInitiated: true,
 				systemInitiatedLabel: localize('terminalProcessExited', "{0} terminal exited", commandDisplay),
 				terminalExecutionId: termId,
-			})).catch(e => {
+			}).catch(e => {
 				this._logService.warn(`RunInTerminalTool: Failed to send terminal-exited notification for terminal ${termId}`, e);
 			});
 		}));

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -87,6 +87,13 @@ suite('RunInTerminalTool', () => {
 	let chatServiceDisposeEmitter: Emitter<{ sessionResources: URI[]; reason: 'cleared' }>;
 	let chatSessionArchivedEmitter: Emitter<IAgentSession>;
 	let capturedSteeringRequests: { sessionResource: URI; message: string }[];
+	let sendRequestSignal: { promise: Promise<void>; resolve: () => void };
+	let lastUtilityAliasResolution: Promise<unknown> = Promise.resolve();
+	function renewSendRequestSignal() {
+		let resolve!: () => void;
+		const promise = new Promise<void>(r => { resolve = r; });
+		sendRequestSignal = { promise, resolve };
+	}
 	let sandboxEnabled: boolean;
 	let sandboxPrereqResult: ITerminalSandboxPrerequisiteCheckResult;
 	let terminalSandboxService: ITerminalSandboxService;
@@ -151,6 +158,8 @@ suite('RunInTerminalTool', () => {
 		chatServiceDisposeEmitter = new Emitter<{ sessionResources: URI[]; reason: 'cleared' }>();
 		chatSessionArchivedEmitter = new Emitter<IAgentSession>();
 		capturedSteeringRequests = [];
+		renewSendRequestSignal();
+		lastUtilityAliasResolution = Promise.resolve();
 		chatSessions = new Map<string, ChatModel>();
 
 		instantiationService = workbenchInstantiationService({
@@ -163,6 +172,9 @@ suite('RunInTerminalTool', () => {
 			getSession: (sessionResource: URI) => chatSessions.get(sessionResource.toString()),
 			sendRequest: async (sessionResource: URI, message: string) => {
 				capturedSteeringRequests.push({ sessionResource, message });
+				const signal = sendRequestSignal;
+				renewSendRequestSignal();
+				signal.resolve();
 				return { kind: 'rejected', reason: 'test' };
 			},
 			acquireExistingSession: () => ({
@@ -234,7 +246,11 @@ suite('RunInTerminalTool', () => {
 			},
 		});
 		instantiationService.stub(ILanguageModelsService, {
-			selectLanguageModels: async () => [],
+			selectLanguageModels: async () => {
+				const p = Promise.resolve([] as string[]);
+				lastUtilityAliasResolution = p;
+				return p;
+			},
 		} as unknown as ILanguageModelsService);
 		instantiationService.stub(ITerminalProfileResolverService, {
 			getDefaultProfile: async () => ({ path: 'bash' } as ITerminalProfile)
@@ -250,12 +266,26 @@ suite('RunInTerminalTool', () => {
 		setConfig(TerminalChatAgentToolsSettingId.AutoApprove, value);
 	}
 
-	// Flush microtasks so async steering-request dispatch (which awaits the
-	// utility-small model resolution) completes before assertions.
-	async function flushSteeringRequests() {
-		for (let i = 0; i < 5; i++) {
-			await Promise.resolve();
+	// Wait until at least `count` steering requests have been dispatched.
+	// Synchronizes on a deferred resolved by the stubbed `sendRequest`, so the
+	// assertion doesn't depend on a fixed number of microtask hops.
+	async function waitForSteeringRequest(count = 1) {
+		while (capturedSteeringRequests.length < count) {
+			await sendRequestSignal.promise;
 		}
+	}
+
+	// For "no request expected" assertions: ensure the steering dispatch path
+	// has had a chance to run and decide not to send. Anchors on the
+	// utility-small alias resolution promise (which the dispatch chain awaits)
+	// rather than a fixed microtask count.
+	async function waitForSteeringDispatchToSettle() {
+		await lastUtilityAliasResolution;
+		// Drain the small chain of .then() callbacks (utilitySmallIdPromise →
+		// resolveSendOptions → sendRequest) that follow the alias resolution.
+		await Promise.resolve();
+		await Promise.resolve();
+		await Promise.resolve();
 	}
 
 	function setConfig(key: string, value: unknown) {
@@ -2573,12 +2603,12 @@ suite('RunInTerminalTool', () => {
 
 		inputNeededEmitter.fire();
 		inputNeededEmitter.fire();
-		await flushSteeringRequests();
+		await waitForSteeringRequest(1);
 		strictEqual(capturedSteeringRequests.length, 1, 'Expected duplicate rapid input-needed events to be suppressed');
 
 		output = 'Confirm (y/N):';
 		inputNeededEmitter.fire();
-		await flushSteeringRequests();
+		await waitForSteeringRequest(2);
 		strictEqual(capturedSteeringRequests.length, 2, 'Expected a changed prompt to trigger a new notification');
 	});
 
@@ -2625,7 +2655,7 @@ suite('RunInTerminalTool', () => {
 		// terminal is gone.
 		isDisposed = true;
 		inputNeededEmitter.fire();
-		await flushSteeringRequests();
+		await waitForSteeringDispatchToSettle();
 		strictEqual(capturedSteeringRequests.length, 0, 'Closing the terminal should not produce a spurious input-needed chat turn');
 	});
 
@@ -2669,14 +2699,14 @@ suite('RunInTerminalTool', () => {
 			._registerCompletionNotification(terminalInstance, termId, sessionResource, 'mkdir -p foo && cd foo && npm init', toolSpecificData, outputMonitor, output);
 
 		inputNeededEmitter.fire();
-		await flushSteeringRequests();
+		await waitForSteeringDispatchToSettle();
 		strictEqual(capturedSteeringRequests.length, 0, 'Should not re-notify for output the agent already received via the foreground inputNeeded race');
 
 		// Once the prompt actually changes (new data has arrived), a fresh notification
 		// should be sent so the agent learns about the new prompt state.
 		output = 'version: (1.0.0) ';
 		inputNeededEmitter.fire();
-		await flushSteeringRequests();
+		await waitForSteeringRequest(1);
 		strictEqual(capturedSteeringRequests.length, 1, 'Expected a new notification once the prompt output changes');
 	});
 
@@ -2728,7 +2758,7 @@ suite('RunInTerminalTool', () => {
 
 		// Fire inputNeeded — this simulates the output monitor detecting a prompt
 		inputNeededEmitter.fire();
-		await flushSteeringRequests();
+		await waitForSteeringRequest(1);
 		strictEqual(capturedSteeringRequests.length, 1, 'Should send steering request for input needed');
 
 		// The key assertion: fg terminal association is preserved (not deleted)

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -42,6 +42,7 @@ import { LocalChatSessionUri } from '../../../../chat/common/model/chatUri.js';
 import { ChatRequestTextPart } from '../../../../chat/common/requestParser/chatParserTypes.js';
 import { ITerminalSandboxService, TerminalSandboxPrerequisiteCheck, type ITerminalSandboxCommand, type ITerminalSandboxPrecheckInputs, type ITerminalSandboxPrerequisiteCheckResult } from '../../common/terminalSandboxService.js';
 import { ILanguageModelToolsService, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolInvocationPreparationContext, IToolResult, ToolDataSource, ToolProgress, ToolSet, type ToolConfirmationAction } from '../../../../chat/common/tools/languageModelToolsService.js';
+import { ILanguageModelsService } from '../../../../chat/common/languageModels.js';
 import { IToolResultCompressor } from '../../../../chat/common/tools/toolResultCompressor.js';
 import { ITerminalChatService, ITerminalService, type ITerminalInstance } from '../../../../terminal/browser/terminal.js';
 import { ITerminalProfileResolverService } from '../../../../terminal/common/terminal.js';
@@ -232,6 +233,9 @@ suite('RunInTerminalTool', () => {
 				return [];
 			},
 		});
+		instantiationService.stub(ILanguageModelsService, {
+			selectLanguageModels: async () => [],
+		} as unknown as ILanguageModelsService);
 		instantiationService.stub(ITerminalProfileResolverService, {
 			getDefaultProfile: async () => ({ path: 'bash' } as ITerminalProfile)
 		});
@@ -244,6 +248,14 @@ suite('RunInTerminalTool', () => {
 
 	function setAutoApprove(value: { [key: string]: { approve: boolean; matchCommandLine?: boolean } | boolean }) {
 		setConfig(TerminalChatAgentToolsSettingId.AutoApprove, value);
+	}
+
+	// Flush microtasks so async steering-request dispatch (which awaits the
+	// utility-small model resolution) completes before assertions.
+	async function flushSteeringRequests() {
+		for (let i = 0; i < 5; i++) {
+			await Promise.resolve();
+		}
 	}
 
 	function setConfig(key: string, value: unknown) {
@@ -2524,7 +2536,7 @@ suite('RunInTerminalTool', () => {
 		});
 	});
 
-	test('should dedupe rapid repeated background input-needed notifications', () => {
+	test('should dedupe rapid repeated background input-needed notifications', async () => {
 		const termId = 'test-input-needed-term';
 		const sessionResource = LocalChatSessionUri.forSession('test-input-needed-session');
 		let output = 'Enter value:';
@@ -2561,14 +2573,16 @@ suite('RunInTerminalTool', () => {
 
 		inputNeededEmitter.fire();
 		inputNeededEmitter.fire();
+		await flushSteeringRequests();
 		strictEqual(capturedSteeringRequests.length, 1, 'Expected duplicate rapid input-needed events to be suppressed');
 
 		output = 'Confirm (y/N):';
 		inputNeededEmitter.fire();
+		await flushSteeringRequests();
 		strictEqual(capturedSteeringRequests.length, 2, 'Expected a changed prompt to trigger a new notification');
 	});
 
-	test('should suppress background input-needed notification when the terminal is disposed', () => {
+	test('should suppress background input-needed notification when the terminal is disposed', async () => {
 		const termId = 'test-input-needed-disposed-term';
 		const sessionResource = LocalChatSessionUri.forSession('test-input-needed-disposed-session');
 		const output = 'Press ENTER or type command to continue';
@@ -2611,10 +2625,11 @@ suite('RunInTerminalTool', () => {
 		// terminal is gone.
 		isDisposed = true;
 		inputNeededEmitter.fire();
+		await flushSteeringRequests();
 		strictEqual(capturedSteeringRequests.length, 0, 'Closing the terminal should not produce a spurious input-needed chat turn');
 	});
 
-	test('should suppress redundant input-needed notification for output already returned via foreground inputNeeded', () => {
+	test('should suppress redundant input-needed notification for output already returned via foreground inputNeeded', async () => {
 		const termId = 'test-input-needed-already-notified-term';
 		const sessionResource = LocalChatSessionUri.forSession('test-input-needed-already-notified-session');
 		let output = 'package name: (test_npm_init) ';
@@ -2654,16 +2669,18 @@ suite('RunInTerminalTool', () => {
 			._registerCompletionNotification(terminalInstance, termId, sessionResource, 'mkdir -p foo && cd foo && npm init', toolSpecificData, outputMonitor, output);
 
 		inputNeededEmitter.fire();
+		await flushSteeringRequests();
 		strictEqual(capturedSteeringRequests.length, 0, 'Should not re-notify for output the agent already received via the foreground inputNeeded race');
 
 		// Once the prompt actually changes (new data has arrived), a fresh notification
 		// should be sent so the agent learns about the new prompt state.
 		output = 'version: (1.0.0) ';
 		inputNeededEmitter.fire();
+		await flushSteeringRequests();
 		strictEqual(capturedSteeringRequests.length, 1, 'Expected a new notification once the prompt output changes');
 	});
 
-	test('should preserve session terminal association after inputNeeded so fg terminal is reused', () => {
+	test('should preserve session terminal association after inputNeeded so fg terminal is reused', async () => {
 		const termId = 'test-input-cleanup-term';
 		const sessionResource = LocalChatSessionUri.forSession('test-input-cleanup-session');
 
@@ -2711,6 +2728,7 @@ suite('RunInTerminalTool', () => {
 
 		// Fire inputNeeded — this simulates the output monitor detecting a prompt
 		inputNeededEmitter.fire();
+		await flushSteeringRequests();
 		strictEqual(capturedSteeringRequests.length, 1, 'Should send steering request for input needed');
 
 		// The key assertion: fg terminal association is preserved (not deleted)

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -42,7 +42,6 @@ import { LocalChatSessionUri } from '../../../../chat/common/model/chatUri.js';
 import { ChatRequestTextPart } from '../../../../chat/common/requestParser/chatParserTypes.js';
 import { ITerminalSandboxService, TerminalSandboxPrerequisiteCheck, type ITerminalSandboxCommand, type ITerminalSandboxPrecheckInputs, type ITerminalSandboxPrerequisiteCheckResult } from '../../common/terminalSandboxService.js';
 import { ILanguageModelToolsService, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolInvocationPreparationContext, IToolResult, ToolDataSource, ToolProgress, ToolSet, type ToolConfirmationAction } from '../../../../chat/common/tools/languageModelToolsService.js';
-import { ILanguageModelsService } from '../../../../chat/common/languageModels.js';
 import { IToolResultCompressor } from '../../../../chat/common/tools/toolResultCompressor.js';
 import { ITerminalChatService, ITerminalService, type ITerminalInstance } from '../../../../terminal/browser/terminal.js';
 import { ITerminalProfileResolverService } from '../../../../terminal/common/terminal.js';
@@ -87,13 +86,6 @@ suite('RunInTerminalTool', () => {
 	let chatServiceDisposeEmitter: Emitter<{ sessionResources: URI[]; reason: 'cleared' }>;
 	let chatSessionArchivedEmitter: Emitter<IAgentSession>;
 	let capturedSteeringRequests: { sessionResource: URI; message: string }[];
-	let sendRequestSignal: { promise: Promise<void>; resolve: () => void };
-	let lastUtilityAliasResolution: Promise<unknown> = Promise.resolve();
-	function renewSendRequestSignal() {
-		let resolve!: () => void;
-		const promise = new Promise<void>(r => { resolve = r; });
-		sendRequestSignal = { promise, resolve };
-	}
 	let sandboxEnabled: boolean;
 	let sandboxPrereqResult: ITerminalSandboxPrerequisiteCheckResult;
 	let terminalSandboxService: ITerminalSandboxService;
@@ -158,8 +150,6 @@ suite('RunInTerminalTool', () => {
 		chatServiceDisposeEmitter = new Emitter<{ sessionResources: URI[]; reason: 'cleared' }>();
 		chatSessionArchivedEmitter = new Emitter<IAgentSession>();
 		capturedSteeringRequests = [];
-		renewSendRequestSignal();
-		lastUtilityAliasResolution = Promise.resolve();
 		chatSessions = new Map<string, ChatModel>();
 
 		instantiationService = workbenchInstantiationService({
@@ -172,9 +162,6 @@ suite('RunInTerminalTool', () => {
 			getSession: (sessionResource: URI) => chatSessions.get(sessionResource.toString()),
 			sendRequest: async (sessionResource: URI, message: string) => {
 				capturedSteeringRequests.push({ sessionResource, message });
-				const signal = sendRequestSignal;
-				renewSendRequestSignal();
-				signal.resolve();
 				return { kind: 'rejected', reason: 'test' };
 			},
 			acquireExistingSession: () => ({
@@ -245,13 +232,6 @@ suite('RunInTerminalTool', () => {
 				return [];
 			},
 		});
-		instantiationService.stub(ILanguageModelsService, {
-			selectLanguageModels: async () => {
-				const p = Promise.resolve([] as string[]);
-				lastUtilityAliasResolution = p;
-				return p;
-			},
-		} as unknown as ILanguageModelsService);
 		instantiationService.stub(ITerminalProfileResolverService, {
 			getDefaultProfile: async () => ({ path: 'bash' } as ITerminalProfile)
 		});
@@ -264,28 +244,6 @@ suite('RunInTerminalTool', () => {
 
 	function setAutoApprove(value: { [key: string]: { approve: boolean; matchCommandLine?: boolean } | boolean }) {
 		setConfig(TerminalChatAgentToolsSettingId.AutoApprove, value);
-	}
-
-	// Wait until at least `count` steering requests have been dispatched.
-	// Synchronizes on a deferred resolved by the stubbed `sendRequest`, so the
-	// assertion doesn't depend on a fixed number of microtask hops.
-	async function waitForSteeringRequest(count = 1) {
-		while (capturedSteeringRequests.length < count) {
-			await sendRequestSignal.promise;
-		}
-	}
-
-	// For "no request expected" assertions: ensure the steering dispatch path
-	// has had a chance to run and decide not to send. Anchors on the
-	// utility-small alias resolution promise (which the dispatch chain awaits)
-	// rather than a fixed microtask count.
-	async function waitForSteeringDispatchToSettle() {
-		await lastUtilityAliasResolution;
-		// Drain the small chain of .then() callbacks (utilitySmallIdPromise →
-		// resolveSendOptions → sendRequest) that follow the alias resolution.
-		await Promise.resolve();
-		await Promise.resolve();
-		await Promise.resolve();
 	}
 
 	function setConfig(key: string, value: unknown) {
@@ -2566,7 +2524,7 @@ suite('RunInTerminalTool', () => {
 		});
 	});
 
-	test('should dedupe rapid repeated background input-needed notifications', async () => {
+	test('should dedupe rapid repeated background input-needed notifications', () => {
 		const termId = 'test-input-needed-term';
 		const sessionResource = LocalChatSessionUri.forSession('test-input-needed-session');
 		let output = 'Enter value:';
@@ -2603,16 +2561,14 @@ suite('RunInTerminalTool', () => {
 
 		inputNeededEmitter.fire();
 		inputNeededEmitter.fire();
-		await waitForSteeringRequest(1);
 		strictEqual(capturedSteeringRequests.length, 1, 'Expected duplicate rapid input-needed events to be suppressed');
 
 		output = 'Confirm (y/N):';
 		inputNeededEmitter.fire();
-		await waitForSteeringRequest(2);
 		strictEqual(capturedSteeringRequests.length, 2, 'Expected a changed prompt to trigger a new notification');
 	});
 
-	test('should suppress background input-needed notification when the terminal is disposed', async () => {
+	test('should suppress background input-needed notification when the terminal is disposed', () => {
 		const termId = 'test-input-needed-disposed-term';
 		const sessionResource = LocalChatSessionUri.forSession('test-input-needed-disposed-session');
 		const output = 'Press ENTER or type command to continue';
@@ -2655,11 +2611,10 @@ suite('RunInTerminalTool', () => {
 		// terminal is gone.
 		isDisposed = true;
 		inputNeededEmitter.fire();
-		await waitForSteeringDispatchToSettle();
 		strictEqual(capturedSteeringRequests.length, 0, 'Closing the terminal should not produce a spurious input-needed chat turn');
 	});
 
-	test('should suppress redundant input-needed notification for output already returned via foreground inputNeeded', async () => {
+	test('should suppress redundant input-needed notification for output already returned via foreground inputNeeded', () => {
 		const termId = 'test-input-needed-already-notified-term';
 		const sessionResource = LocalChatSessionUri.forSession('test-input-needed-already-notified-session');
 		let output = 'package name: (test_npm_init) ';
@@ -2699,18 +2654,16 @@ suite('RunInTerminalTool', () => {
 			._registerCompletionNotification(terminalInstance, termId, sessionResource, 'mkdir -p foo && cd foo && npm init', toolSpecificData, outputMonitor, output);
 
 		inputNeededEmitter.fire();
-		await waitForSteeringDispatchToSettle();
 		strictEqual(capturedSteeringRequests.length, 0, 'Should not re-notify for output the agent already received via the foreground inputNeeded race');
 
 		// Once the prompt actually changes (new data has arrived), a fresh notification
 		// should be sent so the agent learns about the new prompt state.
 		output = 'version: (1.0.0) ';
 		inputNeededEmitter.fire();
-		await waitForSteeringRequest(1);
 		strictEqual(capturedSteeringRequests.length, 1, 'Expected a new notification once the prompt output changes');
 	});
 
-	test('should preserve session terminal association after inputNeeded so fg terminal is reused', async () => {
+	test('should preserve session terminal association after inputNeeded so fg terminal is reused', () => {
 		const termId = 'test-input-cleanup-term';
 		const sessionResource = LocalChatSessionUri.forSession('test-input-cleanup-session');
 
@@ -2758,7 +2711,6 @@ suite('RunInTerminalTool', () => {
 
 		// Fire inputNeeded — this simulates the output monitor detecting a prompt
 		inputNeededEmitter.fire();
-		await waitForSteeringRequest(1);
 		strictEqual(capturedSteeringRequests.length, 1, 'Should send steering request for input needed');
 
 		// The key assertion: fg terminal association is preserved (not deleted)


### PR DESCRIPTION
Addresses microsoft/vscode-internalbacklog#7870.

## Changes

### Use `copilot/copilot-utility-small` for steering messages

Steering messages (background completion, input-needed, terminal-disposed notifications) now resolve the `copilot/copilot-utility-small` model alias and pass it as `userSelectedModelId` instead of inheriting the conversation model. Falls back to the conversation model if the alias is unavailable.

### Route the utility-small alias to the free endpoint in `endpointProviderImpl`

The workbench-side override above sets `userSelectedModelId = 'copilot/copilot-utility-small'`, but inside the Copilot extension the request arrives at `EndpointProviderImpl.getChatEndpoint(request)` with `model.id === 'copilot-utility-small'` — a synthetic alias with no matching CAPI model. The downstream `getChatModelFromApiModel` lookup returns `undefined` and we silently fall back to `copilot-utility` (currently GPT-4.1, 1.2× multiplier).

Short-circuit `copilot-utility-small` and `copilot-utility` model ids to `_resolveUtilityFamily()` so the chat-participant path produces the same `CopilotUtilitySmallChatEndpoint` (gpt-4o-mini, 0× multiplier) that direct `getChatEndpoint(family)` callers already get. Without this, the workbench override above doesn't actually land on the free utility model.

### Prevent `isSystemInitiated` steering messages from polluting recent models

Adds `!options.isSystemInitiated` guard to the `addToRecentlyUsedList` call in `chatServiceImpl.ts` so steering turns do not surface the utility-small model in the user-facing model picker.

### Suppress steering on user-initiated terminal close (#317059)

When `terminalInstance.exitReason === TerminalExitReason.User`, skip the terminal-exited steering message to avoid burning credits on an action the user did not request.

<img width="598" height="261" alt="Screenshot 2026-06-05 at 3 51 13 PM" src="https://github.com/user-attachments/assets/5fdb7a34-aedb-4517-a0ff-cde991e0070e" />
