### PR TITLE
Auto: redirect deprecated gpt-4.1 base model to gpt-5.3-codex

### DIFF
--- a/extensions/copilot/src/platform/configuration/common/configurationService.ts
+++ b/extensions/copilot/src/platform/configuration/common/configurationService.ts
@@ -520,6 +520,7 @@ export const HARD_TOOL_LIMIT = 128;
 // It is also not recommended to use this as a type as it will never be an exhaustive list
 export const enum CHAT_MODEL {
 	GPT41 = 'gpt-4.1-2025-04-14',
+	GPT53CODEX = 'gpt-5.3-codex',
 	GPT4OMINI = 'gpt-4o-mini',
 	NES_XTAB = 'copilot-nes-xtab', // xtab model hosted in prod in proxy
 	CUSTOM_NES = 'custom-nes',

--- a/extensions/copilot/src/platform/endpoint/node/automodeService.ts
+++ b/extensions/copilot/src/platform/endpoint/node/automodeService.ts
@@ -11,7 +11,7 @@ import { Disposable, DisposableMap } from '../../../util/vs/base/common/lifecycl
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
 import { ChatLocation } from '../../../vscodeTypes';
 import { IAuthenticationService } from '../../authentication/common/authentication';
-import { ConfigKey, IConfigurationService } from '../../configuration/common/configurationService';
+import { CHAT_MODEL, ConfigKey, IConfigurationService } from '../../configuration/common/configurationService';
 import { IEnvService } from '../../env/common/envService';
 import { getImageTelemetryEventMeasurements, getImageTelemetryMeasurementsFromReferences, type ImageTelemetryMeasurements } from '../../image/common/imageTelemetry';
 import { ILogService } from '../../log/common/logService';
@@ -237,6 +237,9 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 			selectedModel = this._selectDefaultModel(entry?.endpoint?.modelProvider, token.available_models, knownEndpoints);
 		}
 
+		const preOverrideModel = selectedModel.model;
+		selectedModel = this._applyBaseModelRedirect(selectedModel, token.available_models, knownEndpoints);
+		const redirectedModel = selectedModel.model !== preOverrideModel ? selectedModel.model : undefined;
 		selectedModel = this._applyVisionFallback(chatRequest, selectedModel, token.available_models, knownEndpoints);
 
 		// Emit the final model selection alongside the router's recommendation
@@ -249,7 +252,7 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 					"conversationId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The conversation ID" },
 					"candidateModel": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The router's top candidate model (candidate_models[0])" },
 					"actualModel": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The model actually selected after all client-side overrides" },
-					"overrideReason": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Why the actual model differs from the candidate: none or clientOverride" },
+					"overrideReason": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Why the actual model differs from the candidate: none, baseModelRedirect (the deprecated gpt-4.1 base model was redirected to gpt-5.3-codex), or clientOverride (any other client-side override, e.g. vision fallback)" },
 					"imageCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Number of input images attached to the request", "isMeasurement": true },
 					"totalImageBytes": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Sum of byte sizes for attached input images when known", "isMeasurement": true },
 					"maxImageBytes": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Largest known input image byte size in the request", "isMeasurement": true },
@@ -270,7 +273,15 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 				}
 			*/
 			const candidateModel = routerResult.candidateModel;
-			const overrideReason = candidateModel === selectedModel.model ? 'none' : 'clientOverride';
+			// Surface the base-model redirect (deprecated gpt-4.1 -> gpt-5.3-codex)
+			// as its own reason so it can be measured independently, but only when
+			// it actually produced the final model. If a later override (e.g. the
+			// vision fallback, which runs after the redirect) swapped the model
+			// again, the redirect is no longer the reason `actualModel` differs, so
+			// we fall back to the generic 'clientOverride'.
+			const overrideReason = redirectedModel === selectedModel.model
+				? 'baseModelRedirect'
+				: (candidateModel === selectedModel.model ? 'none' : 'clientOverride');
 			this._telemetryService.sendMSFTTelemetryEvent('automode.routerModelSelection', {
 				conversationId: conversationId ?? '',
 				candidateModel,
@@ -468,6 +479,41 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 			}
 		}
 		return undefined;
+	}
+
+	/**
+	 * GPT-4.1 was the former base model; GPT-5.3 Codex becomes the new base
+	 * model. Any auto selection that lands on GPT-4.1 is transparently
+	 * redirected to GPT-5.3 Codex.
+	 *
+	 * The redirect target is restricted to `availableModels` (the models the
+	 * current session token is authorized to serve) so we never swap to a model
+	 * the token wasn't minted for. `availableModels` and `knownEndpoints` are
+	 * independent CAPI calls that can drift; honouring the token here keeps the
+	 * discount lookup and server-side authorization consistent, mirroring
+	 * {@link _applyVisionFallback}. If no authorized GPT-5.3 Codex endpoint is
+	 * available we leave the original selection untouched so the user can still
+	 * get a response.
+	 */
+	private _applyBaseModelRedirect(selectedModel: IChatEndpoint, availableModels: string[], knownEndpoints: IChatEndpoint[]): IChatEndpoint {
+		const isGpt41 = selectedModel.model === CHAT_MODEL.GPT41 || selectedModel.model === 'gpt-4.1' || selectedModel.family === 'gpt-4.1';
+		if (!isGpt41) {
+			return selectedModel;
+		}
+		// Match the canonical base model by exact id, or by `family` for dated
+		// ids whose family is the canonical 'gpt-5.3-codex'. We deliberately do
+		// not prefix-match the id (unlike `isGpt53Codex`) so we never redirect
+		// onto an id-only preview/spark variant like 'gpt-5.3-codex-spark-preview'
+		// that doesn't carry the canonical family.
+		const redirectTarget = availableModels
+			.map(model => knownEndpoints.find(e => e.model === model))
+			.find((e): e is IChatEndpoint => !!e && (e.model === CHAT_MODEL.GPT53CODEX || e.family === CHAT_MODEL.GPT53CODEX));
+		if (!redirectTarget) {
+			this._logService.warn(`[AutomodeService] Auto selected deprecated base model '${selectedModel.model}' but no available '${CHAT_MODEL.GPT53CODEX}' endpoint is authorized; keeping original selection.`);
+			return selectedModel;
+		}
+		this._logService.trace(`[AutomodeService] Redirecting deprecated base model '${selectedModel.model}' to new base model '${redirectTarget.model}'.`);
+		return redirectTarget;
 	}
 
 	/**

--- a/extensions/copilot/src/platform/endpoint/node/test/automodeService.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/automodeService.spec.ts
@@ -1158,6 +1158,69 @@ describe('AutomodeService', () => {
 			});
 		});
 
+		it('should emit overrideReason=baseModelRedirect when the router picks gpt-4.1', async () => {
+			enableRouter();
+			const gpt41Endpoint = createEndpoint('gpt-4.1', 'OpenAI');
+			const codexEndpoint = createEndpoint('gpt-5.3-codex', 'OpenAI');
+
+			mockRouterResponse(
+				['gpt-4.1', 'gpt-5.3-codex'],
+				{ chosen_model: 'gpt-4.1', candidate_models: ['gpt-4.1', 'gpt-5.3-codex'] }
+			);
+
+			automodeService = createService();
+			const chatRequest: Partial<ChatRequest> = {
+				location: ChatLocation.Panel,
+				prompt: 'test prompt',
+				sessionId: 'session-telemetry-redirect'
+			};
+
+			await automodeService.resolveAutoModeEndpoint(chatRequest as ChatRequest, [gpt41Endpoint, codexEndpoint]);
+
+			const telemetryCalls = mockTelemetryService.sendMSFTTelemetryEvent.mock.calls;
+			const selectionEvent = telemetryCalls.find((call: unknown[]) => call[0] === 'automode.routerModelSelection');
+			expect(selectionEvent).toBeDefined();
+			expect(selectionEvent![1]).toMatchObject({
+				candidateModel: 'gpt-4.1',
+				actualModel: 'gpt-5.3-codex',
+				overrideReason: 'baseModelRedirect',
+			});
+		});
+
+		it('should emit overrideReason=clientOverride when vision fallback swaps the redirected model', async () => {
+			enableRouter();
+			// Router picks gpt-4.1 -> redirected to gpt-5.3-codex (no vision) ->
+			// vision fallback to a vision-capable model. The final model is the
+			// vision model, so the redirect must NOT own the override reason.
+			const gpt41Endpoint = createEndpoint('gpt-4.1', 'OpenAI');
+			const codexEndpoint = createEndpoint('gpt-5.3-codex', 'OpenAI', { supportsVision: false });
+			const visionEndpoint = createEndpoint('gpt-4o', 'OpenAI', { supportsVision: true });
+
+			mockRouterResponse(
+				['gpt-4.1', 'gpt-5.3-codex', 'gpt-4o'],
+				{ chosen_model: 'gpt-4.1', candidate_models: ['gpt-4.1', 'gpt-5.3-codex', 'gpt-4o'] }
+			);
+
+			automodeService = createService();
+			const chatRequest: Partial<ChatRequest> = {
+				location: ChatLocation.Panel,
+				prompt: 'describe this image',
+				sessionId: 'session-telemetry-redirect-vision',
+				references: [{ id: 'img', value: { mimeType: 'image/png', data: createPngBytes(7, 11), isPasted: true } }] as any
+			};
+
+			await automodeService.resolveAutoModeEndpoint(chatRequest as ChatRequest, [gpt41Endpoint, codexEndpoint, visionEndpoint]);
+
+			const telemetryCalls = mockTelemetryService.sendMSFTTelemetryEvent.mock.calls;
+			const selectionEvent = telemetryCalls.find((call: unknown[]) => call[0] === 'automode.routerModelSelection');
+			expect(selectionEvent).toBeDefined();
+			expect(selectionEvent![1]).toMatchObject({
+				candidateModel: 'gpt-4.1',
+				actualModel: 'gpt-4o',
+				overrideReason: 'clientOverride',
+			});
+		});
+
 		it('should not emit routerModelSelection when router fails', async () => {
 			enableRouter();
 			const gpt4oEndpoint = createEndpoint('gpt-4o', 'OpenAI');
@@ -1312,4 +1375,76 @@ describe('AutomodeService', () => {
 			);
 		});
 	});
+
+	describe('base model redirect (gpt-4.1 -> gpt-5.3-codex)', () => {
+		it('redirects an auto-selected gpt-4.1 to an authorized gpt-5.3-codex', async () => {
+			const gpt41Endpoint = createEndpoint('gpt-4.1', 'OpenAI');
+			const codexEndpoint = createEndpoint('gpt-5.3-codex', 'OpenAI');
+			mockApiResponse(['gpt-4.1', 'gpt-5.3-codex']);
+
+			automodeService = createService();
+			const chatRequest: Partial<ChatRequest> = {
+				location: ChatLocation.Panel,
+				prompt: 'test prompt',
+				sessionId: 'session-redirect-basic'
+			};
+
+			const result = await automodeService.resolveAutoModeEndpoint(chatRequest as ChatRequest, [gpt41Endpoint, codexEndpoint]);
+			expect(result.model).toBe('gpt-5.3-codex');
+		});
+
+		it('leaves a non-gpt-4.1 selection untouched', async () => {
+			const gpt4oEndpoint = createEndpoint('gpt-4o', 'OpenAI');
+			const codexEndpoint = createEndpoint('gpt-5.3-codex', 'OpenAI');
+			mockApiResponse(['gpt-4o', 'gpt-5.3-codex']);
+
+			automodeService = createService();
+			const chatRequest: Partial<ChatRequest> = {
+				location: ChatLocation.Panel,
+				prompt: 'test prompt',
+				sessionId: 'session-redirect-noop'
+			};
+
+			const result = await automodeService.resolveAutoModeEndpoint(chatRequest as ChatRequest, [gpt4oEndpoint, codexEndpoint]);
+			expect(result.model).toBe('gpt-4o');
+		});
+
+		it('keeps gpt-4.1 when gpt-5.3-codex is known but not authorized by the session token', async () => {
+			const gpt41Endpoint = createEndpoint('gpt-4.1', 'OpenAI');
+			const codexEndpoint = createEndpoint('gpt-5.3-codex', 'OpenAI');
+			// gpt-5.3-codex is a known endpoint but is NOT in available_models, so the
+			// session token was not minted for it and the redirect must not fire.
+			mockApiResponse(['gpt-4.1']);
+
+			automodeService = createService();
+			const chatRequest: Partial<ChatRequest> = {
+				location: ChatLocation.Panel,
+				prompt: 'test prompt',
+				sessionId: 'session-redirect-unauthorized'
+			};
+
+			const result = await automodeService.resolveAutoModeEndpoint(chatRequest as ChatRequest, [gpt41Endpoint, codexEndpoint]);
+			expect(result.model).toBe('gpt-4.1');
+			expect(mockLogService.warn).toHaveBeenCalledWith(
+				expect.stringContaining('keeping original selection')
+			);
+		});
+
+		it('matches the dated gpt-4.1 id and resolves the codex target by family', async () => {
+			const gpt41Endpoint = createEndpoint('gpt-4.1-2025-04-14', 'OpenAI');
+			const codexEndpoint = createEndpoint('gpt-5.3-codex-2026', 'OpenAI', { family: 'gpt-5.3-codex' });
+			mockApiResponse(['gpt-4.1-2025-04-14', 'gpt-5.3-codex-2026']);
+
+			automodeService = createService();
+			const chatRequest: Partial<ChatRequest> = {
+				location: ChatLocation.Panel,
+				prompt: 'test prompt',
+				sessionId: 'session-redirect-family'
+			};
+
+			const result = await automodeService.resolveAutoModeEndpoint(chatRequest as ChatRequest, [gpt41Endpoint, codexEndpoint]);
+			expect(result.model).toBe('gpt-5.3-codex-2026');
+		});
+	});
 });
+


### PR DESCRIPTION
## What

GPT-4.1 was the former Copilot "base model"; **GPT-5.3 Codex becomes the new base model**. This makes the chat **Auto** model router transparently redirect any auto-selected `gpt-4.1` endpoint to `gpt-5.3-codex`.

# How

- Adds `CHAT_MODEL.GPT53CODEX = 'gpt-5.3-codex'`.
- New `_applyBaseModelRedirect` in `AutomodeService.resolveAutoModeEndpoint`, run **before** the vision fallback.
- The redirect target is **restricted to `available_models`** (the models the current session token authorizes), mirroring `_applyVisionFallback`. This keeps server-side authorization and the discount lookup consistent — we never swap to a model the token wasn't minted for. If no authorized `gpt-5.3-codex` endpoint is available, the original selection is kept and a warning is logged.
- Target match is **exact id or canonical `family`** (not a prefix), so we never redirect onto a preview/spark variant like `gpt-5.3-codex-spark-preview`.

### Scope
Limited to the **Auto endpoint path only** — explicit user model picks are unaffected.

## Telemetry

`automode.routerModelSelection.overrideReason` now reports `none` | `baseModelRedirect` | `clientOverride`. `baseModelRedirect` is emitted **only when the redirect produced the final model**; if a later vision fallback swaps it again, it correctly collapses back to `clientOverride`. GDPR comment updated.
