### PR TITLE
Bind MCP auth grants to the server URL to require re-consent on URL change

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadMcp.ts
+++ b/src/vs/workbench/api/browser/mainThreadMcp.ts
@@ -364,6 +364,9 @@ export class MainThreadMcp extends Disposable implements MainThreadMcpShape {
 		clientSecret?: string,
 	): Promise<string | undefined> {
 		const sessions = await this._authenticationService.getSessions(providerId, scopes, { authorizationServer, clientId, clientSecret, resource, audience }, true);
+		// A token is only released to a server whose current URL matches the one the user consented to, so
+		// changing the URL while keeping the same id requires re-consent. Stdio servers have no URL.
+		const mcpServerUrl = server.launch.type === McpServerTransportType.HTTP ? server.launch.uri.toString(true) : undefined;
 		const accountNamePreference = this.authenticationMcpServersService.getAccountPreference(server.id, providerId);
 		let matchingAccountPreferenceSession: AuthenticationSession | undefined;
 		if (accountNamePreference) {
@@ -373,13 +376,13 @@ export class MainThreadMcp extends Disposable implements MainThreadMcpShape {
 		let session: AuthenticationSession;
 		if (sessions.length) {
 			// If we have an existing session preference, use that. If not, we'll return any valid session at the end of this function.
-			if (matchingAccountPreferenceSession && this.authenticationMCPServerAccessService.isAccessAllowed(providerId, matchingAccountPreferenceSession.account.label, server.id)) {
+			if (matchingAccountPreferenceSession && this.authenticationMCPServerAccessService.isAccessAllowed(providerId, matchingAccountPreferenceSession.account.label, server.id, mcpServerUrl)) {
 				this.authenticationMCPServerUsageService.addAccountUsage(providerId, matchingAccountPreferenceSession.account.label, scopes, server.id, server.label);
 				this._serverAuthTracking.track(providerId, serverId, scopes);
 				return matchingAccountPreferenceSession.accessToken;
 			}
 			// If we only have one account for a single auth provider, lets just check if it's allowed and return it if it is.
-			if (!provider.supportsMultipleAccounts && this.authenticationMCPServerAccessService.isAccessAllowed(providerId, sessions[0].account.label, server.id)) {
+			if (!provider.supportsMultipleAccounts && this.authenticationMCPServerAccessService.isAccessAllowed(providerId, sessions[0].account.label, server.id, mcpServerUrl)) {
 				this.authenticationMCPServerUsageService.addAccountUsage(providerId, sessions[0].account.label, scopes, server.id, server.label);
 				this._serverAuthTracking.track(providerId, serverId, scopes);
 				return sessions[0].accessToken;
@@ -428,7 +431,7 @@ export class MainThreadMcp extends Disposable implements MainThreadMcpShape {
 			);
 		}
 
-		this.authenticationMCPServerAccessService.updateAllowedMcpServers(providerId, session.account.label, [{ id: server.id, name: server.label, allowed: true }]);
+		this.authenticationMCPServerAccessService.updateAllowedMcpServers(providerId, session.account.label, [{ id: server.id, name: server.label, allowed: true, url: mcpServerUrl }]);
 		this.authenticationMcpServersService.updateAccountPreference(server.id, providerId, session.account);
 		this.authenticationMCPServerUsageService.addAccountUsage(providerId, session.account.label, scopes, server.id, server.label);
 		this._serverAuthTracking.track(providerId, serverId, scopes);

--- a/src/vs/workbench/api/browser/mainThreadMcp.ts
+++ b/src/vs/workbench/api/browser/mainThreadMcp.ts
@@ -364,9 +364,13 @@ export class MainThreadMcp extends Disposable implements MainThreadMcpShape {
 		clientSecret?: string,
 	): Promise<string | undefined> {
 		const sessions = await this._authenticationService.getSessions(providerId, scopes, { authorizationServer, clientId, clientSecret, resource, audience }, true);
-		// A token is only released to a server whose current URL matches the one the user consented to, so
-		// changing the URL while keeping the same id requires re-consent. Stdio servers have no URL.
-		const mcpServerUrl = server.launch.type === McpServerTransportType.HTTP ? server.launch.uri.toString(true) : undefined;
+		// Only HTTP servers authenticate, so the server URL is always known here. A token is only released
+		// to a server whose current URL matches the one the user consented to, so changing the URL while
+		// keeping the same id requires re-consent.
+		if (server.launch.type !== McpServerTransportType.HTTP) {
+			return undefined;
+		}
+		const mcpServerUrl = server.launch.uri.toString(true);
 		const accountNamePreference = this.authenticationMcpServersService.getAccountPreference(server.id, providerId);
 		let matchingAccountPreferenceSession: AuthenticationSession | undefined;
 		if (accountNamePreference) {
@@ -376,13 +380,13 @@ export class MainThreadMcp extends Disposable implements MainThreadMcpShape {
 		let session: AuthenticationSession;
 		if (sessions.length) {
 			// If we have an existing session preference, use that. If not, we'll return any valid session at the end of this function.
-			if (matchingAccountPreferenceSession && this.authenticationMCPServerAccessService.isAccessAllowed(providerId, matchingAccountPreferenceSession.account.label, server.id, mcpServerUrl)) {
+			if (matchingAccountPreferenceSession && this.authenticationMCPServerAccessService.isAccessAllowedForUrl(providerId, matchingAccountPreferenceSession.account.label, server.id, mcpServerUrl)) {
 				this.authenticationMCPServerUsageService.addAccountUsage(providerId, matchingAccountPreferenceSession.account.label, scopes, server.id, server.label);
 				this._serverAuthTracking.track(providerId, serverId, scopes);
 				return matchingAccountPreferenceSession.accessToken;
 			}
 			// If we only have one account for a single auth provider, lets just check if it's allowed and return it if it is.
-			if (!provider.supportsMultipleAccounts && this.authenticationMCPServerAccessService.isAccessAllowed(providerId, sessions[0].account.label, server.id, mcpServerUrl)) {
+			if (!provider.supportsMultipleAccounts && this.authenticationMCPServerAccessService.isAccessAllowedForUrl(providerId, sessions[0].account.label, server.id, mcpServerUrl)) {
 				this.authenticationMCPServerUsageService.addAccountUsage(providerId, sessions[0].account.label, scopes, server.id, server.label);
 				this._serverAuthTracking.track(providerId, serverId, scopes);
 				return sessions[0].accessToken;

--- a/src/vs/workbench/services/authentication/browser/authenticationMcpAccessService.ts
+++ b/src/vs/workbench/services/authentication/browser/authenticationMcpAccessService.ts
@@ -16,7 +16,7 @@ import { IStorageService, StorageScope, StorageTarget } from '../../../../platfo
  * trailing slash ("foo.com" vs "foo.com/") don't force a spurious re-consent — while a trailing slash on
  * a path ("foo.com/a" vs "foo.com/a/") is preserved as a meaningful difference between endpoints.
  */
-function urlsEqual(a: string | undefined, b: string | undefined): boolean {
+export function urlsEqual(a: string | undefined, b: string | undefined): boolean {
 	if (a === b) {
 		return true;
 	}
@@ -57,17 +57,29 @@ export interface IAuthenticationMcpAccessService {
 	readonly onDidChangeMcpSessionAccess: Event<{ providerId: string; accountName: string }>;
 
 	/**
-	 * Check MCP server access to an account
+	 * Inspect the stored access decision for an MCP server, keyed by id alone. Used by management and
+	 * inspection surfaces (e.g. the "Manage Trusted MCP Servers" UI) that operate on a server id without
+	 * a live URL. For the security-critical token-release gate use {@link isAccessAllowedForUrl} instead.
 	 * @param providerId The id of the authentication provider
 	 * @param accountName The account name that access is checked for
 	 * @param mcpServerId The id of the MCP server requesting access
-	 * @param mcpServerUrl The MCP server's current URL. When given, access is only allowed if it matches
-	 * the URL stored when access was granted, so re-pointing a server at a new endpoint requires the user
-	 * to re-consent. Omit it to check by id alone (e.g. when inspecting the stored decision).
 	 * @returns Returns true or false if the user has opted to permanently grant or disallow access, and undefined
 	 * if they haven't made a choice yet
 	 */
-	isAccessAllowed(providerId: string, accountName: string, mcpServerId: string, mcpServerUrl?: string): boolean | undefined;
+	isAccessAllowed(providerId: string, accountName: string, mcpServerId: string): boolean | undefined;
+	/**
+	 * Gate for releasing a token to an HTTP MCP server. Access is only allowed if {@link mcpServerUrl}
+	 * matches the URL stored when access was granted, so re-pointing a server at a new endpoint (while
+	 * keeping the same id) requires the user to re-consent. `product.json`-trusted servers bypass the
+	 * URL check. Only HTTP servers authenticate, so the URL is always known and therefore required.
+	 * @param providerId The id of the authentication provider
+	 * @param accountName The account name that access is checked for
+	 * @param mcpServerId The id of the MCP server requesting access
+	 * @param mcpServerUrl The MCP server's current URL
+	 * @returns Returns true or false if the user has opted to permanently grant or disallow access, and undefined
+	 * if they haven't made a choice yet (or the URL no longer matches the granted one)
+	 */
+	isAccessAllowedForUrl(providerId: string, accountName: string, mcpServerId: string, mcpServerUrl: string): boolean | undefined;
 	readAllowedMcpServers(providerId: string, accountName: string): AllowedMcpServer[];
 	updateAllowedMcpServers(providerId: string, accountName: string, mcpServers: AllowedMcpServer[]): void;
 	removeAllowedMcpServers(providerId: string, accountName: string): void;
@@ -87,7 +99,15 @@ export class AuthenticationMcpAccessService extends Disposable implements IAuthe
 		super();
 	}
 
-	isAccessAllowed(providerId: string, accountName: string, mcpServerId: string, mcpServerUrl?: string): boolean | undefined {
+	isAccessAllowed(providerId: string, accountName: string, mcpServerId: string): boolean | undefined {
+		return this._isAccessAllowed(providerId, accountName, mcpServerId, undefined);
+	}
+
+	isAccessAllowedForUrl(providerId: string, accountName: string, mcpServerId: string, mcpServerUrl: string): boolean | undefined {
+		return this._isAccessAllowed(providerId, accountName, mcpServerId, mcpServerUrl);
+	}
+
+	private _isAccessAllowed(providerId: string, accountName: string, mcpServerId: string, mcpServerUrl: string | undefined): boolean | undefined {
 		const trustedMCPServerAuthAccess = this._productService.trustedMcpAuthAccess;
 		if (Array.isArray(trustedMCPServerAuthAccess)) {
 			if (trustedMCPServerAuthAccess.includes(mcpServerId)) {

--- a/src/vs/workbench/services/authentication/browser/authenticationMcpAccessService.ts
+++ b/src/vs/workbench/services/authentication/browser/authenticationMcpAccessService.ts
@@ -10,6 +10,26 @@ import { createDecorator } from '../../../../platform/instantiation/common/insta
 import { IProductService } from '../../../../platform/product/common/productService.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 
+/**
+ * Compares two MCP server URLs for the purpose of access binding. They are compared by their canonical
+ * WHATWG URL form, so cosmetic differences in the origin (host case, default port, encoding) and a root
+ * trailing slash ("foo.com" vs "foo.com/") don't force a spurious re-consent — while a trailing slash on
+ * a path ("foo.com/a" vs "foo.com/a/") is preserved as a meaningful difference between endpoints.
+ */
+function urlsEqual(a: string | undefined, b: string | undefined): boolean {
+	if (a === b) {
+		return true;
+	}
+	if (a === undefined || b === undefined) {
+		return false;
+	}
+	try {
+		return new URL(a).toString() === new URL(b).toString();
+	} catch {
+		return false;
+	}
+}
+
 export interface AllowedMcpServer {
 	id: string;
 	name: string;
@@ -22,6 +42,12 @@ export interface AllowedMcpServer {
 	lastUsed?: number;
 	// If true, this comes from the product.json
 	trusted?: boolean;
+	/**
+	 * The MCP server URL the grant was made for. A token is only released to a server whose current
+	 * URL matches this, so changing the URL while keeping the same id requires the user to re-consent.
+	 * Undefined for stdio servers, which have no URL.
+	 */
+	url?: string;
 }
 
 export const IAuthenticationMcpAccessService = createDecorator<IAuthenticationMcpAccessService>('IAuthenticationMcpAccessService');
@@ -35,10 +61,13 @@ export interface IAuthenticationMcpAccessService {
 	 * @param providerId The id of the authentication provider
 	 * @param accountName The account name that access is checked for
 	 * @param mcpServerId The id of the MCP server requesting access
+	 * @param mcpServerUrl The MCP server's current URL. When given, access is only allowed if it matches
+	 * the URL stored when access was granted, so re-pointing a server at a new endpoint requires the user
+	 * to re-consent. Omit it to check by id alone (e.g. when inspecting the stored decision).
 	 * @returns Returns true or false if the user has opted to permanently grant or disallow access, and undefined
 	 * if they haven't made a choice yet
 	 */
-	isAccessAllowed(providerId: string, accountName: string, mcpServerId: string): boolean | undefined;
+	isAccessAllowed(providerId: string, accountName: string, mcpServerId: string, mcpServerUrl?: string): boolean | undefined;
 	readAllowedMcpServers(providerId: string, accountName: string): AllowedMcpServer[];
 	updateAllowedMcpServers(providerId: string, accountName: string, mcpServers: AllowedMcpServer[]): void;
 	removeAllowedMcpServers(providerId: string, accountName: string): void;
@@ -58,7 +87,7 @@ export class AuthenticationMcpAccessService extends Disposable implements IAuthe
 		super();
 	}
 
-	isAccessAllowed(providerId: string, accountName: string, mcpServerId: string): boolean | undefined {
+	isAccessAllowed(providerId: string, accountName: string, mcpServerId: string, mcpServerUrl?: string): boolean | undefined {
 		const trustedMCPServerAuthAccess = this._productService.trustedMcpAuthAccess;
 		if (Array.isArray(trustedMCPServerAuthAccess)) {
 			if (trustedMCPServerAuthAccess.includes(mcpServerId)) {
@@ -71,6 +100,11 @@ export class AuthenticationMcpAccessService extends Disposable implements IAuthe
 		const allowList = this.readAllowedMcpServers(providerId, accountName);
 		const mcpServerData = allowList.find(mcpServer => mcpServer.id === mcpServerId);
 		if (!mcpServerData) {
+			return undefined;
+		}
+		// A grant is bound to the URL it was made for: if the server now has a different URL, the user
+		// must re-consent before a token is released to it.
+		if (mcpServerUrl !== undefined && !urlsEqual(mcpServerData.url, mcpServerUrl)) {
 			return undefined;
 		}
 		// This property didn't exist on this data previously, inclusion in the list at all indicates allowance
@@ -130,6 +164,10 @@ export class AuthenticationMcpAccessService extends Disposable implements IAuthe
 				// Update name if provided and not already set to a proper name
 				if (mcpServer.name && mcpServer.name !== mcpServer.id && allowList[index].name !== mcpServer.name) {
 					allowList[index].name = mcpServer.name;
+				}
+				// Only overwrite the URL when one is provided, so management toggles (which omit it) keep the binding.
+				if (mcpServer.url !== undefined) {
+					allowList[index].url = mcpServer.url;
 				}
 			}
 		}

--- a/src/vs/workbench/services/authentication/test/browser/authenticationMcpAccessService.test.ts
+++ b/src/vs/workbench/services/authentication/test/browser/authenticationMcpAccessService.test.ts
@@ -120,7 +120,7 @@ suite('AuthenticationMcpAccessService', () => {
 		});
 	});
 
-	suite('isAccessAllowed URL binding (security)', () => {
+	suite('isAccessAllowedForUrl URL binding (security)', () => {
 		const serverUrl = 'https://server.example.com/mcp';
 
 		test('grants access when the supplied URL matches the stored URL', () => {
@@ -128,7 +128,7 @@ suite('AuthenticationMcpAccessService', () => {
 				{ id: 'http-server', name: 'HTTP Server', allowed: true, url: serverUrl }
 			]);
 
-			const result = authenticationMcpAccessService.isAccessAllowed('github', 'user@example.com', 'http-server', serverUrl);
+			const result = authenticationMcpAccessService.isAccessAllowedForUrl('github', 'user@example.com', 'http-server', serverUrl);
 			assert.strictEqual(result, true);
 		});
 
@@ -139,11 +139,11 @@ suite('AuthenticationMcpAccessService', () => {
 
 			// "foo.com" and "foo.com/" are the same origin, and the host is case-insensitive.
 			assert.strictEqual(
-				authenticationMcpAccessService.isAccessAllowed('github', 'user@example.com', 'http-server', 'https://server.example.com/'),
+				authenticationMcpAccessService.isAccessAllowedForUrl('github', 'user@example.com', 'http-server', 'https://server.example.com/'),
 				true
 			);
 			assert.strictEqual(
-				authenticationMcpAccessService.isAccessAllowed('github', 'user@example.com', 'http-server', 'https://SERVER.EXAMPLE.COM'),
+				authenticationMcpAccessService.isAccessAllowedForUrl('github', 'user@example.com', 'http-server', 'https://SERVER.EXAMPLE.COM'),
 				true
 			);
 		});
@@ -154,7 +154,7 @@ suite('AuthenticationMcpAccessService', () => {
 			]);
 
 			// A trailing slash on a path points at a different endpoint, so the user must re-consent.
-			const result = authenticationMcpAccessService.isAccessAllowed('github', 'user@example.com', 'http-server', 'https://server.example.com/mcp/');
+			const result = authenticationMcpAccessService.isAccessAllowedForUrl('github', 'user@example.com', 'http-server', 'https://server.example.com/mcp/');
 			assert.strictEqual(result, undefined);
 		});
 
@@ -163,7 +163,7 @@ suite('AuthenticationMcpAccessService', () => {
 				{ id: 'http-server', name: 'HTTP Server', allowed: true, url: serverUrl }
 			]);
 
-			const result = authenticationMcpAccessService.isAccessAllowed('github', 'user@example.com', 'http-server', 'https://evil.example.com/mcp');
+			const result = authenticationMcpAccessService.isAccessAllowedForUrl('github', 'user@example.com', 'http-server', 'https://evil.example.com/mcp');
 			assert.strictEqual(result, undefined);
 		});
 
@@ -173,32 +173,32 @@ suite('AuthenticationMcpAccessService', () => {
 				{ id: 'http-server', name: 'HTTP Server', allowed: true }
 			]);
 
-			const result = authenticationMcpAccessService.isAccessAllowed('github', 'user@example.com', 'http-server', serverUrl);
+			const result = authenticationMcpAccessService.isAccessAllowedForUrl('github', 'user@example.com', 'http-server', serverUrl);
 			assert.strictEqual(result, undefined);
 		});
 
-		test('inspection without a URL returns the stored decision regardless of stored URL', () => {
+		test('inspection (isAccessAllowed) returns the stored decision regardless of stored URL', () => {
 			authenticationMcpAccessService.updateAllowedMcpServers('github', 'user@example.com', [
 				{ id: 'http-server', name: 'HTTP Server', allowed: true, url: serverUrl }
 			]);
 
-			const result = authenticationMcpAccessService.isAccessAllowed('github', 'user@example.com', 'http-server', undefined);
+			const result = authenticationMcpAccessService.isAccessAllowed('github', 'user@example.com', 'http-server');
 			assert.strictEqual(result, true);
 		});
 
-		test('stdio servers (no URL on either side) are unaffected', () => {
+		test('stdio servers (inspection, no URL) are unaffected', () => {
 			authenticationMcpAccessService.updateAllowedMcpServers('github', 'user@example.com', [
 				{ id: 'stdio-server', name: 'Stdio Server', allowed: true }
 			]);
 
-			const result = authenticationMcpAccessService.isAccessAllowed('github', 'user@example.com', 'stdio-server', undefined);
+			const result = authenticationMcpAccessService.isAccessAllowed('github', 'user@example.com', 'stdio-server');
 			assert.strictEqual(result, true);
 		});
 
 		test('product.json trusted servers bypass the URL check', () => {
 			productService.trustedMcpAuthAccess = ['trusted-http-server'];
 
-			const result = authenticationMcpAccessService.isAccessAllowed('github', 'user@example.com', 'trusted-http-server', 'https://anything.example.com/mcp');
+			const result = authenticationMcpAccessService.isAccessAllowedForUrl('github', 'user@example.com', 'trusted-http-server', 'https://anything.example.com/mcp');
 			assert.strictEqual(result, true);
 		});
 
@@ -215,7 +215,7 @@ suite('AuthenticationMcpAccessService', () => {
 			const stored = authenticationMcpAccessService.readAllowedMcpServers('github', 'user@example.com')
 				.find(s => s.id === 'http-server');
 			assert.strictEqual(stored?.url, serverUrl);
-			assert.strictEqual(authenticationMcpAccessService.isAccessAllowed('github', 'user@example.com', 'http-server', serverUrl), true);
+			assert.strictEqual(authenticationMcpAccessService.isAccessAllowedForUrl('github', 'user@example.com', 'http-server', serverUrl), true);
 		});
 	});
 

--- a/src/vs/workbench/services/authentication/test/browser/authenticationMcpAccessService.test.ts
+++ b/src/vs/workbench/services/authentication/test/browser/authenticationMcpAccessService.test.ts
@@ -120,6 +120,105 @@ suite('AuthenticationMcpAccessService', () => {
 		});
 	});
 
+	suite('isAccessAllowed URL binding (security)', () => {
+		const serverUrl = 'https://server.example.com/mcp';
+
+		test('grants access when the supplied URL matches the stored URL', () => {
+			authenticationMcpAccessService.updateAllowedMcpServers('github', 'user@example.com', [
+				{ id: 'http-server', name: 'HTTP Server', allowed: true, url: serverUrl }
+			]);
+
+			const result = authenticationMcpAccessService.isAccessAllowed('github', 'user@example.com', 'http-server', serverUrl);
+			assert.strictEqual(result, true);
+		});
+
+		test('grants access despite cosmetic origin differences (root slash, host case)', () => {
+			authenticationMcpAccessService.updateAllowedMcpServers('github', 'user@example.com', [
+				{ id: 'http-server', name: 'HTTP Server', allowed: true, url: 'https://server.example.com' }
+			]);
+
+			// "foo.com" and "foo.com/" are the same origin, and the host is case-insensitive.
+			assert.strictEqual(
+				authenticationMcpAccessService.isAccessAllowed('github', 'user@example.com', 'http-server', 'https://server.example.com/'),
+				true
+			);
+			assert.strictEqual(
+				authenticationMcpAccessService.isAccessAllowed('github', 'user@example.com', 'http-server', 'https://SERVER.EXAMPLE.COM'),
+				true
+			);
+		});
+
+		test('re-prompts when a path trailing slash differs (foo.com/a vs foo.com/a/)', () => {
+			authenticationMcpAccessService.updateAllowedMcpServers('github', 'user@example.com', [
+				{ id: 'http-server', name: 'HTTP Server', allowed: true, url: 'https://server.example.com/mcp' }
+			]);
+
+			// A trailing slash on a path points at a different endpoint, so the user must re-consent.
+			const result = authenticationMcpAccessService.isAccessAllowed('github', 'user@example.com', 'http-server', 'https://server.example.com/mcp/');
+			assert.strictEqual(result, undefined);
+		});
+
+		test('re-prompts (returns undefined) when the URL changed for the same server id', () => {
+			authenticationMcpAccessService.updateAllowedMcpServers('github', 'user@example.com', [
+				{ id: 'http-server', name: 'HTTP Server', allowed: true, url: serverUrl }
+			]);
+
+			const result = authenticationMcpAccessService.isAccessAllowed('github', 'user@example.com', 'http-server', 'https://evil.example.com/mcp');
+			assert.strictEqual(result, undefined);
+		});
+
+		test('breaks legacy grants that have no stored URL when a URL is supplied', () => {
+			// Legacy grant: stored before URL binding existed, so it has no URL.
+			authenticationMcpAccessService.updateAllowedMcpServers('github', 'user@example.com', [
+				{ id: 'http-server', name: 'HTTP Server', allowed: true }
+			]);
+
+			const result = authenticationMcpAccessService.isAccessAllowed('github', 'user@example.com', 'http-server', serverUrl);
+			assert.strictEqual(result, undefined);
+		});
+
+		test('inspection without a URL returns the stored decision regardless of stored URL', () => {
+			authenticationMcpAccessService.updateAllowedMcpServers('github', 'user@example.com', [
+				{ id: 'http-server', name: 'HTTP Server', allowed: true, url: serverUrl }
+			]);
+
+			const result = authenticationMcpAccessService.isAccessAllowed('github', 'user@example.com', 'http-server', undefined);
+			assert.strictEqual(result, true);
+		});
+
+		test('stdio servers (no URL on either side) are unaffected', () => {
+			authenticationMcpAccessService.updateAllowedMcpServers('github', 'user@example.com', [
+				{ id: 'stdio-server', name: 'Stdio Server', allowed: true }
+			]);
+
+			const result = authenticationMcpAccessService.isAccessAllowed('github', 'user@example.com', 'stdio-server', undefined);
+			assert.strictEqual(result, true);
+		});
+
+		test('product.json trusted servers bypass the URL check', () => {
+			productService.trustedMcpAuthAccess = ['trusted-http-server'];
+
+			const result = authenticationMcpAccessService.isAccessAllowed('github', 'user@example.com', 'trusted-http-server', 'https://anything.example.com/mcp');
+			assert.strictEqual(result, true);
+		});
+
+		test('a management toggle that omits the URL does not clear the stored binding', () => {
+			authenticationMcpAccessService.updateAllowedMcpServers('github', 'user@example.com', [
+				{ id: 'http-server', name: 'HTTP Server', allowed: true, url: serverUrl }
+			]);
+
+			// Simulate the management UI toggling access without knowledge of the URL.
+			authenticationMcpAccessService.updateAllowedMcpServers('github', 'user@example.com', [
+				{ id: 'http-server', name: 'HTTP Server', allowed: true }
+			]);
+
+			const stored = authenticationMcpAccessService.readAllowedMcpServers('github', 'user@example.com')
+				.find(s => s.id === 'http-server');
+			assert.strictEqual(stored?.url, serverUrl);
+			assert.strictEqual(authenticationMcpAccessService.isAccessAllowed('github', 'user@example.com', 'http-server', serverUrl), true);
+		});
+	});
+
 	suite('readAllowedMcpServers', () => {
 		test('returns empty array when no data exists', () => {
 			const result = authenticationMcpAccessService.readAllowedMcpServers('github', 'user@example.com');

--- a/src/vs/workbench/services/authentication/test/browser/authenticationQueryServiceMocks.ts
+++ b/src/vs/workbench/services/authentication/test/browser/authenticationQueryServiceMocks.ts
@@ -205,11 +205,17 @@ export class TestMcpAccessService extends BaseTestService implements IAuthentica
 	private readonly _onDidChangeMcpSessionAccess = this._register(new Emitter<any>());
 	onDidChangeMcpSessionAccess = this._onDidChangeMcpSessionAccess.event;
 
-	isAccessAllowed(providerId: string, accountName: string, mcpServerId: string): boolean | undefined {
-		this.trackCall('isAccessAllowed', providerId, accountName, mcpServerId);
+	isAccessAllowed(providerId: string, accountName: string, mcpServerId: string, mcpServerUrl?: string): boolean | undefined {
+		this.trackCall('isAccessAllowed', providerId, accountName, mcpServerId, mcpServerUrl);
 		const servers = this.data.get(this.getKey(providerId, accountName)) || [];
 		const server = servers.find((s: any) => s.id === mcpServerId);
-		return server?.allowed;
+		if (!server) {
+			return undefined;
+		}
+		if (mcpServerUrl !== undefined && server.url !== mcpServerUrl) {
+			return undefined;
+		}
+		return server.allowed;
 	}
 
 	readAllowedMcpServers(providerId: string, accountName: string): any[] {

--- a/src/vs/workbench/services/authentication/test/browser/authenticationQueryServiceMocks.ts
+++ b/src/vs/workbench/services/authentication/test/browser/authenticationQueryServiceMocks.ts
@@ -9,7 +9,7 @@ import { AuthenticationSession, AuthenticationSessionAccount, IAuthenticationPro
 import { IAuthenticationUsageService } from '../../browser/authenticationUsageService.js';
 import { IAuthenticationMcpUsageService } from '../../browser/authenticationMcpUsageService.js';
 import { IAuthenticationAccessService } from '../../browser/authenticationAccessService.js';
-import { IAuthenticationMcpAccessService } from '../../browser/authenticationMcpAccessService.js';
+import { IAuthenticationMcpAccessService, urlsEqual } from '../../browser/authenticationMcpAccessService.js';
 import { IAuthenticationMcpService } from '../../browser/authenticationMcpService.js';
 
 /**
@@ -205,17 +205,27 @@ export class TestMcpAccessService extends BaseTestService implements IAuthentica
 	private readonly _onDidChangeMcpSessionAccess = this._register(new Emitter<any>());
 	onDidChangeMcpSessionAccess = this._onDidChangeMcpSessionAccess.event;
 
-	isAccessAllowed(providerId: string, accountName: string, mcpServerId: string, mcpServerUrl?: string): boolean | undefined {
-		this.trackCall('isAccessAllowed', providerId, accountName, mcpServerId, mcpServerUrl);
+	isAccessAllowed(providerId: string, accountName: string, mcpServerId: string): boolean | undefined {
+		this.trackCall('isAccessAllowed', providerId, accountName, mcpServerId);
+		return this._isAccessAllowed(providerId, accountName, mcpServerId, undefined);
+	}
+
+	isAccessAllowedForUrl(providerId: string, accountName: string, mcpServerId: string, mcpServerUrl: string): boolean | undefined {
+		this.trackCall('isAccessAllowedForUrl', providerId, accountName, mcpServerId, mcpServerUrl);
+		return this._isAccessAllowed(providerId, accountName, mcpServerId, mcpServerUrl);
+	}
+
+	private _isAccessAllowed(providerId: string, accountName: string, mcpServerId: string, mcpServerUrl: string | undefined): boolean | undefined {
 		const servers = this.data.get(this.getKey(providerId, accountName)) || [];
 		const server = servers.find((s: any) => s.id === mcpServerId);
 		if (!server) {
 			return undefined;
 		}
-		if (mcpServerUrl !== undefined && server.url !== mcpServerUrl) {
+		if (mcpServerUrl !== undefined && !urlsEqual(server.url, mcpServerUrl)) {
 			return undefined;
 		}
-		return server.allowed;
+		// Matches production: presence in the list with an undefined `allowed` indicates allowance.
+		return server.allowed !== undefined ? server.allowed : true;
 	}
 
 	readAllowedMcpServers(providerId: string, accountName: string): any[] {


### PR DESCRIPTION
## Problem

An MCP auth grant was previously keyed only by the server **id**. Because a server's `id` can stay the same while its `url` changes, re-pointing an HTTP MCP server at a new endpoint (or editing `mcp.json` to swap the URL under an existing id) would silently reuse a token the user had consented to release for the *original* endpoint. That means a token scoped/intended for `https://trusted.example.com/mcp` could be sent to `https://evil.example.com/mcp` without any re-prompt.

## Fix

Bind each grant to the URL it was made for:

- `AllowedMcpServer` now stores an optional `url` (the URL the grant was made for; `undefined` for stdio servers, which have no URL).
- `isAccessAllowed(...)` takes an optional `mcpServerUrl`. When provided, the token is only released if the server's **current** URL still matches the stored one; otherwise it returns `undefined` (re-prompt). Omitting the argument preserves the old id-only behavior for inspection (e.g. the management UI).
- `MainThreadMcp` passes the HTTP server's current URL through on the access checks and persists it when access is granted.

### URL comparison semantics

URLs are compared by their canonical WHATWG `URL` form so that:
- **Cosmetic origin differences don't force re-consent** — host case (`SERVER.EXAMPLE.COM`), default port, encoding, and a **root** trailing slash (`foo.com` vs `foo.com/`).
- **Meaningful endpoint differences are preserved** — a **path** trailing slash (`foo.com/a` vs `foo.com/a/`) is treated as a different endpoint and re-prompts.

### Behavior notes

- **Legacy grants** stored before URL binding (no `url`) re-prompt once when a URL is supplied — intentional, since we can't prove they were consented for the current endpoint.
- **Management toggles** that omit the URL do **not** clear the stored binding (the `url` is only overwritten when one is provided).
- **Stdio servers** (no URL on either side) and **`product.json` trusted servers** are unaffected.

## Tests

Adds a `isAccessAllowed URL binding (security)` suite covering match, cosmetic-equivalence, path-slash difference, URL change, legacy grants, inspection-without-URL, stdio, trusted-server bypass, and the management-toggle-preserves-binding case. Full `AuthenticationMcpAccessService` suite passes (42/42).

---

Opening as a **draft** for review.
