### PR TITLE
Add context size picker for Claude Agent models

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/claude/common/claudeSessionStateService.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/common/claudeSessionStateService.ts
@@ -24,6 +24,7 @@ export interface SessionState {
 	folderInfo: ClaudeFolderInfo | undefined;
 	usageHandler: UsageHandler | undefined;
 	reasoningEffort: EffortLevel | undefined;
+	contextSize: number | undefined;
 	traceContext: TraceContext | undefined;
 	turnId: string | undefined;
 }
@@ -105,6 +106,18 @@ export interface IClaudeSessionStateService {
 	 * Sets the reasoning effort for a session.
 	 */
 	setReasoningEffortForSession(sessionId: string, effort: EffortLevel | undefined): void;
+
+	/**
+	 * Gets the context size for a session (user's per-request selection from the model picker).
+	 * When set, the proxy reports this value as the endpoint's modelMaxPromptTokens so internal
+	 * accounting reflects the chosen tier.
+	 */
+	getContextSizeForSession(sessionId: string): number | undefined;
+
+	/**
+	 * Sets the context size for a session.
+	 */
+	setContextSizeForSession(sessionId: string, contextSize: number | undefined): void;
 
 	/**
 	 * Gets the OTel trace context for a session (used to parent chat spans to invoke_agent).

--- a/extensions/copilot/src/extension/chatSessions/claude/node/claudeCodeModels.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/node/claudeCodeModels.ts
@@ -8,7 +8,7 @@ import type * as vscode from 'vscode';
 import { IEndpointProvider } from '../../../../platform/endpoint/common/endpointProvider';
 import { ILogService } from '../../../../platform/log/common/logService';
 import { IChatEndpoint } from '../../../../platform/networking/common/networking';
-import { formatPricingLabel, getModelCapabilitiesDescription } from '../../../conversation/common/languageModelAccess';
+import { formatPricingLabel, formatTokenCount, getModelCapabilitiesDescription } from '../../../conversation/common/languageModelAccess';
 import { createServiceIdentifier } from '../../../../util/common/services';
 import { Emitter } from '../../../../util/vs/base/common/event';
 import { Disposable } from '../../../../util/vs/base/common/lifecycle';
@@ -17,6 +17,7 @@ import { tryParseClaudeModelId } from './claudeModelId';
 import type { EffortLevel } from '@anthropic-ai/claude-agent-sdk';
 
 export const CLAUDE_REASONING_EFFORT_PROPERTY = 'reasoningEffort';
+export const CLAUDE_CONTEXT_SIZE_PROPERTY = 'contextSize';
 
 export interface IClaudeCodeModels {
 	readonly _serviceBrand: undefined;
@@ -214,33 +215,57 @@ export function pickReasoningEffort(endpoint: IChatEndpoint | undefined, request
 }
 
 function buildConfigurationSchema(endpoint: IChatEndpoint): vscode.LanguageModelConfigurationSchema | undefined {
+	const properties: Record<string, NonNullable<vscode.LanguageModelConfigurationSchema['properties']>[string]> = {};
+
+	// Thinking effort
 	const effortLevels = endpoint.supportsReasoningEffort?.filter(
 		(level): level is typeof SUPPORTED_EFFORT_LEVELS[number] =>
 			(SUPPORTED_EFFORT_LEVELS as readonly string[]).includes(level)
 	);
-	if (!effortLevels) {
-		return;
+	if (effortLevels && effortLevels.length > 0) {
+		const defaultEffort = effortLevels.includes('high') ? 'high' : undefined;
+		properties[CLAUDE_REASONING_EFFORT_PROPERTY] = {
+			type: 'string',
+			title: l10n.t('Thinking Effort'),
+			enum: effortLevels,
+			enumItemLabels: effortLevels.map(level => level.charAt(0).toUpperCase() + level.slice(1)),
+			enumDescriptions: effortLevels.map(level => {
+				switch (level) {
+					case 'low': return l10n.t('Faster responses with less reasoning');
+					case 'medium': return l10n.t('Balanced reasoning and speed');
+					case 'high': return l10n.t('Greater reasoning depth but slower');
+				}
+			}),
+			default: defaultEffort,
+			group: 'navigation',
+		};
 	}
 
-	const defaultEffort = effortLevels.includes('high') ? 'high' : undefined;
+	// Context size — only when CAPI provides a default context max, indicating
+	// a meaningful distinction between default and long context tiers.
+	const pricing = endpoint.tokenPricing;
+	const defaultContextMax = pricing?.default.contextMax;
+	const fullMax = endpoint.modelMaxPromptTokens;
+	if (defaultContextMax && defaultContextMax < fullMax) {
+		const hasLongContextSurcharge = !!pricing?.longContext;
+		properties[CLAUDE_CONTEXT_SIZE_PROPERTY] = {
+			type: 'number',
+			title: l10n.t('Context Size'),
+			enum: [defaultContextMax, fullMax],
+			enumItemLabels: [formatTokenCount(defaultContextMax), formatTokenCount(fullMax)],
+			enumDescriptions: [
+				l10n.t('Default'),
+				hasLongContextSurcharge
+					? l10n.t('Longer sessions')
+					: l10n.t('Longer sessions without compaction'),
+			],
+			default: defaultContextMax,
+			group: 'tokens',
+		};
+	}
 
-	return {
-		properties: {
-			[CLAUDE_REASONING_EFFORT_PROPERTY]: {
-				type: 'string',
-				title: l10n.t('Thinking Effort'),
-				enum: effortLevels,
-				enumItemLabels: effortLevels.map(level => level.charAt(0).toUpperCase() + level.slice(1)),
-				enumDescriptions: effortLevels.map(level => {
-					switch (level) {
-						case 'low': return l10n.t('Faster responses with less reasoning');
-						case 'medium': return l10n.t('Balanced reasoning and speed');
-						case 'high': return l10n.t('Greater reasoning depth but slower');
-					}
-				}),
-				default: defaultEffort,
-				group: 'navigation',
-			}
-		}
-	};
+	if (Object.keys(properties).length === 0) {
+		return undefined;
+	}
+	return { properties };
 }

--- a/extensions/copilot/src/extension/chatSessions/claude/node/claudeLanguageModelServer.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/node/claudeLanguageModelServer.ts
@@ -191,14 +191,15 @@ export class ClaudeLanguageModelServer extends Disposable {
 				tokenSource.cancel();
 			});
 
-			// If the user picked a larger context tier in the model picker, raise
-			// the reported prompt token budget so internal accounting and downstream
-			// token-budget computations reflect the chosen tier. CAPI bills tiers
-			// based on actual prompt size, so no other signaling is required.
+			// If the user picked a context tier in the model picker, surface that
+			// value directly as the prompt token budget. CAPI's `tokenPricing.default.contextMax`
+			// is documented as a prompt-token limit (matching `endpoint.modelMaxPromptTokens`),
+			// and CAPI bills the tier based on actual prompt size, so no other signaling is
+			// required. Clamp to the default budget so the override never lowers it.
 			const sessionContextSize = sessionId ? this.sessionStateService.getContextSizeForSession(sessionId) : undefined;
 			const defaultPromptBudget = DEFAULT_MAX_TOKENS - DEFAULT_MAX_OUTPUT_TOKENS;
 			const modelMaxPromptTokens = sessionContextSize !== undefined
-				? Math.max(defaultPromptBudget, sessionContextSize - DEFAULT_MAX_OUTPUT_TOKENS)
+				? Math.max(defaultPromptBudget, sessionContextSize)
 				: defaultPromptBudget;
 
 			const endpointRequestBody = requestBody as IEndpointBody;

--- a/extensions/copilot/src/extension/chatSessions/claude/node/claudeLanguageModelServer.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/node/claudeLanguageModelServer.ts
@@ -191,6 +191,16 @@ export class ClaudeLanguageModelServer extends Disposable {
 				tokenSource.cancel();
 			});
 
+			// If the user picked a larger context tier in the model picker, raise
+			// the reported prompt token budget so internal accounting and downstream
+			// token-budget computations reflect the chosen tier. CAPI bills tiers
+			// based on actual prompt size, so no other signaling is required.
+			const sessionContextSize = sessionId ? this.sessionStateService.getContextSizeForSession(sessionId) : undefined;
+			const defaultPromptBudget = DEFAULT_MAX_TOKENS - DEFAULT_MAX_OUTPUT_TOKENS;
+			const modelMaxPromptTokens = sessionContextSize !== undefined
+				? Math.max(defaultPromptBudget, sessionContextSize - DEFAULT_MAX_OUTPUT_TOKENS)
+				: defaultPromptBudget;
+
 			const endpointRequestBody = requestBody as IEndpointBody;
 			const streamingEndpoint = this.instantiationService.createInstance(
 				ClaudeStreamingPassThroughEndpoint,
@@ -200,7 +210,7 @@ export class ClaudeLanguageModelServer extends Disposable {
 				headers,
 				'vscode_claude_code',
 				{
-					modelMaxPromptTokens: DEFAULT_MAX_TOKENS - DEFAULT_MAX_OUTPUT_TOKENS,
+					modelMaxPromptTokens,
 					maxOutputTokens: DEFAULT_MAX_OUTPUT_TOKENS
 				},
 				sessionId

--- a/extensions/copilot/src/extension/chatSessions/claude/node/claudeSessionStateService.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/node/claudeSessionStateService.ts
@@ -47,6 +47,7 @@ export class ClaudeSessionStateService extends Disposable implements IClaudeSess
 			folderInfo: existing?.folderInfo,
 			usageHandler: existing?.usageHandler,
 			reasoningEffort: existing?.reasoningEffort,
+			contextSize: existing?.contextSize,
 			traceContext: existing?.traceContext,
 			turnId: existing?.turnId,
 		});
@@ -69,6 +70,7 @@ export class ClaudeSessionStateService extends Disposable implements IClaudeSess
 			folderInfo: existing?.folderInfo,
 			usageHandler: existing?.usageHandler,
 			reasoningEffort: existing?.reasoningEffort,
+			contextSize: existing?.contextSize,
 			traceContext: existing?.traceContext,
 			turnId: existing?.turnId,
 		});
@@ -88,6 +90,7 @@ export class ClaudeSessionStateService extends Disposable implements IClaudeSess
 			folderInfo: existing?.folderInfo,
 			usageHandler: existing?.usageHandler,
 			reasoningEffort: existing?.reasoningEffort,
+			contextSize: existing?.contextSize,
 			traceContext: existing?.traceContext,
 			turnId: existing?.turnId,
 		});
@@ -109,6 +112,7 @@ export class ClaudeSessionStateService extends Disposable implements IClaudeSess
 			folderInfo,
 			usageHandler: existing?.usageHandler,
 			reasoningEffort: existing?.reasoningEffort,
+			contextSize: existing?.contextSize,
 			traceContext: existing?.traceContext,
 			turnId: existing?.turnId,
 		});
@@ -128,6 +132,7 @@ export class ClaudeSessionStateService extends Disposable implements IClaudeSess
 			folderInfo: existing?.folderInfo,
 			usageHandler: handler,
 			reasoningEffort: existing?.reasoningEffort,
+			contextSize: existing?.contextSize,
 			traceContext: existing?.traceContext,
 			turnId: existing?.turnId,
 		});
@@ -149,6 +154,29 @@ export class ClaudeSessionStateService extends Disposable implements IClaudeSess
 			folderInfo: existing?.folderInfo,
 			usageHandler: existing?.usageHandler,
 			reasoningEffort: effort,
+			contextSize: existing?.contextSize,
+			traceContext: existing?.traceContext,
+			turnId: existing?.turnId,
+		});
+	}
+
+	getContextSizeForSession(sessionId: string): number | undefined {
+		return this._sessionState.get(sessionId)?.contextSize;
+	}
+
+	setContextSizeForSession(sessionId: string, contextSize: number | undefined): void {
+		const existing = this._sessionState.get(sessionId);
+		if (existing?.contextSize === contextSize) {
+			return;
+		}
+		this._sessionState.set(sessionId, {
+			modelId: existing?.modelId,
+			permissionMode: existing?.permissionMode ?? 'acceptEdits',
+			capturingToken: existing?.capturingToken,
+			folderInfo: existing?.folderInfo,
+			usageHandler: existing?.usageHandler,
+			reasoningEffort: existing?.reasoningEffort,
+			contextSize,
 			traceContext: existing?.traceContext,
 			turnId: existing?.turnId,
 		});
@@ -167,6 +195,7 @@ export class ClaudeSessionStateService extends Disposable implements IClaudeSess
 			folderInfo: existing?.folderInfo,
 			usageHandler: existing?.usageHandler,
 			reasoningEffort: existing?.reasoningEffort,
+			contextSize: existing?.contextSize,
 			traceContext,
 			turnId: existing?.turnId,
 		});
@@ -185,6 +214,7 @@ export class ClaudeSessionStateService extends Disposable implements IClaudeSess
 			folderInfo: existing?.folderInfo,
 			usageHandler: existing?.usageHandler,
 			reasoningEffort: existing?.reasoningEffort,
+			contextSize: existing?.contextSize,
 			traceContext: existing?.traceContext,
 			turnId,
 		});

--- a/extensions/copilot/src/extension/chatSessions/claude/node/test/claudeCodeModels.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/node/test/claudeCodeModels.spec.ts
@@ -6,7 +6,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import type * as vscode from 'vscode';
 import { IEndpointProvider } from '../../../../../platform/endpoint/common/endpointProvider';
-import { IChatEndpoint } from '../../../../../platform/networking/common/networking';
+import { IChatEndpoint, IChatEndpointTokenPricing } from '../../../../../platform/networking/common/networking';
 import { Emitter } from '../../../../../util/vs/base/common/event';
 import { DisposableStore } from '../../../../../util/vs/base/common/lifecycle';
 import { IInstantiationService } from '../../../../../util/vs/platform/instantiation/common/instantiation';
@@ -26,6 +26,8 @@ function createMockEndpoint(overrides: {
 	apiType?: string;
 	modelProvider?: string;
 	supportsReasoningEffort?: string[];
+	tokenPricing?: IChatEndpointTokenPricing;
+	modelMaxPromptTokens?: number;
 }): IChatEndpoint {
 	const isAnthropic = overrides.modelProvider === undefined || overrides.modelProvider === 'Anthropic';
 	return {
@@ -47,7 +49,8 @@ function createMockEndpoint(overrides: {
 		isFallback: false,
 		policy: 'enabled',
 		urlOrRequestMetadata: 'mock://endpoint',
-		modelMaxPromptTokens: 128000,
+		modelMaxPromptTokens: overrides.modelMaxPromptTokens ?? 128000,
+		tokenPricing: overrides.tokenPricing,
 		tokenizer: 'cl100k_base',
 		acquireTokenizer: () => ({ encode: () => [], free: () => { } }) as any,
 		processResponseFromChatEndpoint: () => Promise.resolve({} as any),
@@ -324,6 +327,110 @@ describe('ClaudeCodeModels', () => {
 			const schema = info[0].configurationSchema!;
 			expect(schema.properties?.['reasoningEffort'].enum).toEqual(['high']);
 			expect(schema.properties!['reasoningEffort'].default).toBe('high');
+		});
+
+		it('includes contextSize when endpoint pricing exposes a default context max below modelMaxPromptTokens', async () => {
+			const { service } = createServiceWithRefreshableEndpoints([
+				createMockEndpoint({
+					model: 'claude-sonnet-4-model',
+					name: 'Claude Sonnet 4',
+					family: 'claude-sonnet-4',
+					modelMaxPromptTokens: 1_000_000,
+					tokenPricing: {
+						default: { inputPrice: 3, outputPrice: 15, cacheReadTokenPrice: 0.3, contextMax: 200_000 },
+						longContext: { inputPrice: 6, outputPrice: 22.5, cacheReadTokenPrice: 0.6 },
+					},
+				}),
+			]);
+			const { lm, getCapturedProvider } = createMockLm();
+
+			const info = await getProviderInfo(service, lm, getCapturedProvider);
+			const schema = info[0].configurationSchema!;
+			expect(schema.properties?.['contextSize']).toEqual({
+				type: 'number',
+				title: 'Context Size',
+				enum: [200_000, 1_000_000],
+				enumItemLabels: ['200K', '1M'],
+				enumDescriptions: ['Default', 'Longer sessions'],
+				default: 200_000,
+				group: 'tokens',
+			});
+		});
+
+		it('omits contextSize when pricing has no default context max', async () => {
+			const { service } = createServiceWithRefreshableEndpoints([
+				createMockEndpoint({
+					model: 'claude-sonnet-4-model',
+					name: 'Claude Sonnet 4',
+					family: 'claude-sonnet-4',
+					modelMaxPromptTokens: 1_000_000,
+					tokenPricing: {
+						default: { inputPrice: 3, outputPrice: 15, cacheReadTokenPrice: 0.3 },
+					},
+				}),
+			]);
+			const { lm, getCapturedProvider } = createMockLm();
+
+			const info = await getProviderInfo(service, lm, getCapturedProvider);
+			expect(info[0].configurationSchema).toBeUndefined();
+		});
+
+		it('omits contextSize when default context max equals modelMaxPromptTokens', async () => {
+			const { service } = createServiceWithRefreshableEndpoints([
+				createMockEndpoint({
+					model: 'claude-sonnet-4-model',
+					name: 'Claude Sonnet 4',
+					family: 'claude-sonnet-4',
+					modelMaxPromptTokens: 200_000,
+					tokenPricing: {
+						default: { inputPrice: 3, outputPrice: 15, cacheReadTokenPrice: 0.3, contextMax: 200_000 },
+					},
+				}),
+			]);
+			const { lm, getCapturedProvider } = createMockLm();
+
+			const info = await getProviderInfo(service, lm, getCapturedProvider);
+			expect(info[0].configurationSchema).toBeUndefined();
+		});
+
+		it('describes the long-context option without surcharge when there is no long-context pricing tier', async () => {
+			const { service } = createServiceWithRefreshableEndpoints([
+				createMockEndpoint({
+					model: 'claude-sonnet-4-model',
+					name: 'Claude Sonnet 4',
+					family: 'claude-sonnet-4',
+					modelMaxPromptTokens: 1_000_000,
+					tokenPricing: {
+						default: { inputPrice: 3, outputPrice: 15, cacheReadTokenPrice: 0.3, contextMax: 200_000 },
+					},
+				}),
+			]);
+			const { lm, getCapturedProvider } = createMockLm();
+
+			const info = await getProviderInfo(service, lm, getCapturedProvider);
+			const schema = info[0].configurationSchema!;
+			expect(schema.properties?.['contextSize'].enumDescriptions).toEqual(['Default', 'Longer sessions without compaction']);
+		});
+
+		it('includes both reasoningEffort and contextSize when supported', async () => {
+			const { service } = createServiceWithRefreshableEndpoints([
+				createMockEndpoint({
+					model: 'claude-sonnet-4-model',
+					name: 'Claude Sonnet 4',
+					family: 'claude-sonnet-4',
+					supportsReasoningEffort: ['low', 'medium', 'high'],
+					modelMaxPromptTokens: 1_000_000,
+					tokenPricing: {
+						default: { inputPrice: 3, outputPrice: 15, cacheReadTokenPrice: 0.3, contextMax: 200_000 },
+						longContext: { inputPrice: 6, outputPrice: 22.5, cacheReadTokenPrice: 0.6 },
+					},
+				}),
+			]);
+			const { lm, getCapturedProvider } = createMockLm();
+
+			const info = await getProviderInfo(service, lm, getCapturedProvider);
+			const schema = info[0].configurationSchema!;
+			expect(Object.keys(schema.properties ?? {})).toEqual(['reasoningEffort', 'contextSize']);
 		});
 	});
 

--- a/extensions/copilot/src/extension/chatSessions/claude/node/test/claudeSessionStateService.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/node/test/claudeSessionStateService.spec.ts
@@ -268,6 +268,57 @@ describe('ClaudeSessionStateService', () => {
 		});
 	});
 
+	describe('getContextSizeForSession', () => {
+		it('should return undefined when no context size is set', () => {
+			assert.strictEqual(service.getContextSizeForSession('session-1'), undefined);
+		});
+
+		it('should return the set context size', () => {
+			service.setContextSizeForSession('session-1', 200_000);
+			assert.strictEqual(service.getContextSizeForSession('session-1'), 200_000);
+		});
+
+		it('should return different sizes for different sessions', () => {
+			service.setContextSizeForSession('session-1', 200_000);
+			service.setContextSizeForSession('session-2', 1_000_000);
+
+			assert.strictEqual(service.getContextSizeForSession('session-1'), 200_000);
+			assert.strictEqual(service.getContextSizeForSession('session-2'), 1_000_000);
+		});
+	});
+
+	describe('setContextSizeForSession', () => {
+		it('should allow setting a context size', () => {
+			service.setContextSizeForSession('session-1', 1_000_000);
+			assert.strictEqual(service.getContextSizeForSession('session-1'), 1_000_000);
+		});
+
+		it('should allow clearing a context size', () => {
+			service.setContextSizeForSession('session-1', 1_000_000);
+			service.setContextSizeForSession('session-1', undefined);
+			assert.strictEqual(service.getContextSizeForSession('session-1'), undefined);
+		});
+
+		it('should preserve other state when setting context size', () => {
+			service.setModelIdForSession('session-1', OPUS_4);
+			service.setReasoningEffortForSession('session-1', 'high');
+
+			service.setContextSizeForSession('session-1', 1_000_000);
+
+			assert.strictEqual(service.getModelIdForSession('session-1'), OPUS_4);
+			assert.strictEqual(service.getReasoningEffortForSession('session-1'), 'high');
+		});
+
+		it('should not fire onDidChangeSessionState event', () => {
+			const events: SessionStateChangeEvent[] = [];
+			service.onDidChangeSessionState(e => events.push(e));
+
+			service.setContextSizeForSession('session-1', 1_000_000);
+
+			assert.strictEqual(events.length, 0);
+		});
+	});
+
 	describe('dispose', () => {
 		it('should clear session state on dispose', () => {
 			service.setModelIdForSession('session-1', OPUS_4);

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/claudeChatSessionContentProvider.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/claudeChatSessionContentProvider.ts
@@ -26,7 +26,7 @@ import { IInstantiationService } from '../../../util/vs/platform/instantiation/c
 import { ClaudeFolderInfo } from '../claude/common/claudeFolderInfo';
 import { ClaudeSessionUri } from '../claude/common/claudeSessionUri';
 import { ClaudeAgentManager } from '../claude/node/claudeCodeAgent';
-import { CLAUDE_REASONING_EFFORT_PROPERTY, IClaudeCodeModels, pickReasoningEffort } from '../claude/node/claudeCodeModels';
+import { CLAUDE_CONTEXT_SIZE_PROPERTY, CLAUDE_REASONING_EFFORT_PROPERTY, IClaudeCodeModels, pickReasoningEffort } from '../claude/node/claudeCodeModels';
 import { IClaudeCodeSdkService } from '../claude/node/claudeCodeSdkService';
 import { parseClaudeModelId } from '../claude/node/claudeModelId';
 import { IClaudeSessionStateService } from '../claude/common/claudeSessionStateService';
@@ -176,6 +176,10 @@ export class ClaudeChatSessionContentProvider extends Disposable implements vsco
 			const rawReasoningEffort = request.modelConfiguration?.[CLAUDE_REASONING_EFFORT_PROPERTY];
 			const reasoningEffort = pickReasoningEffort(endpoint, typeof rawReasoningEffort === 'string' ? rawReasoningEffort : undefined);
 			this.sessionStateService.setReasoningEffortForSession(effectiveSessionId, reasoningEffort);
+
+			const rawContextSize = request.modelConfiguration?.[CLAUDE_CONTEXT_SIZE_PROPERTY];
+			const contextSize = typeof rawContextSize === 'number' && rawContextSize > 0 ? rawContextSize : undefined;
+			this.sessionStateService.setContextSizeForSession(effectiveSessionId, contextSize);
 
 			// Set usage handler to report token usage for context window widget
 			this.sessionStateService.setUsageHandlerForSession(effectiveSessionId, (usage) => {


### PR DESCRIPTION
Refs #319039

Surfaces the CAPI tiered context window (e.g. 200K default vs 1M long-context) in the Claude Code model picker, and plumbs the user's selection through session state into the language-model server so its `modelMaxPromptTokens` override reflects the chosen tier. CAPI bills the long-context tier automatically based on actual prompt size, so no extra header or request flag is required.

### Changes

- **Schema** ([claudeCodeModels.ts](https://github.com/microsoft/vscode/blob/tyleonha/claude-context-size-picker/extensions/copilot/src/extension/chatSessions/claude/node/claudeCodeModels.ts)): exports `CLAUDE_CONTEXT_SIZE_PROPERTY` and emits a `Context Size` enum in the model picker when the endpoint has tiered CAPI pricing (`tokenPricing.default.contextMax < modelMaxPromptTokens`). Description differs based on whether CAPI advertises a long-context surcharge ("Longer sessions" vs "Longer sessions without compaction"), mirroring the patterns in the Copilot LM provider and Copilot CLI session.
- **Session state** (`common/claudeSessionStateService.ts` + `node/claudeSessionStateService.ts`): adds `contextSize: number | undefined` to `SessionState` and a `get/setContextSizeForSession` pair, preserved across all existing setters.
- **Write path** (`claudeChatSessionContentProvider.ts`): reads `request.modelConfiguration[CLAUDE_CONTEXT_SIZE_PROPERTY]` per request and stores it via `setContextSizeForSession`, mirroring the existing reasoning-effort flow.
- **Read path** (`claudeLanguageModelServer.ts`): replaces the hardcoded `DEFAULT_MAX_TOKENS - DEFAULT_MAX_OUTPUT_TOKENS` override with `Math.max(defaultPromptBudget, sessionContextSize - DEFAULT_MAX_OUTPUT_TOKENS)` when the session has a selection.
- **Context usage widget**: no changes needed — it already reads `modelConfiguration?.contextSize` directly, so the usage bar reflects the selected tier automatically.

### Open question for review

The current schema sets `default = defaultContextMax` (the smaller tier). The linked issue argues we should default to the full max instead, since for models without a long-context surcharge the user gains capability with no billing downside. Happy to flip the default if that's the preferred behavior — it's a one-line change in `buildConfigurationSchema`.

### Tests

12 new tests across [`claudeCodeModels.spec.ts`](https://github.com/microsoft/vscode/blob/tyleonha/claude-context-size-picker/extensions/copilot/src/extension/chatSessions/claude/node/test/claudeCodeModels.spec.ts) and [`claudeSessionStateService.spec.ts`](https://github.com/microsoft/vscode/blob/tyleonha/claude-context-size-picker/extensions/copilot/src/extension/chatSessions/claude/node/test/claudeSessionStateService.spec.ts) covering schema emission, omission edge cases, surcharge-vs-no-surcharge labeling, coexistence with `reasoningEffort`, and the new session-state getter/setter pair. All 116 tests in the affected suites pass.