### PR TITLE
Also drop keypress/link events if webview isn't focused

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewElement.ts
@@ -205,6 +205,9 @@ export class WebviewElement extends Disposable implements IWebviewElement, Webvi
 		}));
 
 		this._register(this.on('did-click-link', ({ uri }) => {
+			if (!this.isActiveElement()) {
+				return;
+			}
 			this._onDidClickLink.fire(uri);
 		}));
 
@@ -714,8 +717,12 @@ export class WebviewElement extends Disposable implements IWebviewElement, Webvi
 		return event.isTrusted || !!this._content.options.forwardUntrustedKeypressEvents;
 	}
 
+	private isActiveElement(): boolean {
+		return !!this.element && this.window?.document.activeElement === this.element;
+	}
+
 	private handleKeyEvent(type: 'keydown' | 'keyup', event: KeyEvent) {
-		if (!this.shouldForwardKeyEvent(event)) {
+		if (!this.shouldForwardKeyEvent(event) || !this.isActiveElement()) {
 			return;
 		}
 


### PR DESCRIPTION
Again doesn't seem to be a good use case for forwarding unless the webview is active. Should be true even if you're focused into an iframe in the webview
