### PR TITLE
Add "vp" (Vite+) to npm.scriptRunner enum

### DIFF
--- a/extensions/npm/package.json
+++ b/extensions/npm/package.json
@@ -266,7 +266,8 @@
             "yarn",
             "pnpm",
             "bun",
-            "node"
+            "node",
+            "vp"
           ],
           "enumDescriptions": [
             "%config.npm.scriptRunner.auto%",
@@ -274,7 +275,8 @@
             "%config.npm.scriptRunner.yarn%",
             "%config.npm.scriptRunner.pnpm%",
             "%config.npm.scriptRunner.bun%",
-            "%config.npm.scriptRunner.node%"
+            "%config.npm.scriptRunner.node%",
+            "%config.npm.scriptRunner.vp%"
           ],
           "default": "auto",
           "description": "%config.npm.scriptRunner%"

--- a/extensions/npm/package.nls.json
+++ b/extensions/npm/package.nls.json
@@ -17,6 +17,7 @@
 	"config.npm.scriptRunner.pnpm": "Use pnpm as the script runner.",
 	"config.npm.scriptRunner.bun": "Use bun as the script runner.",
 	"config.npm.scriptRunner.node": "Use Node.js as the script runner.",
+	"config.npm.scriptRunner.vp": "Use Vite+ (vp) as the script runner.",
 	"config.npm.scriptRunner.auto": "Auto-detect which script runner to use based on lock files and installed package managers.",
 	"config.npm.exclude": "Configure glob patterns for folders that should be excluded from automatic script detection.",
 	"config.npm.enableScriptExplorer": "Enable an explorer view for npm scripts when there is no top-level `package.json` file.",


### PR DESCRIPTION
This PR replicates the changes from #308794 (originally proposed by @jong-kyung), opened from a contributor account so it can be merged.

## Summary
- Add `vp` (Vite+) as a new option to the `npm.scriptRunner` setting enum
- Add localization string for the new option

## Why
[Vite+](https://github.com/voidzero-dev/vite-plus) is the unified toolchain and entry point for web development. It provides a `vp` CLI that manages runtime, package manager, and frontend toolchain in one place. When `npm.scriptRunner` is set to `vp`, VS Codes NPM Scripts panel executes scripts via `vp run <script>`, which enables intelligent caching and dependency-aware task execution.

Currently, setting `"npm.scriptRunner": "vp"` works because VS Code treats unknown values as `<runner> run <script>`, but `vp` is not an officially declared enum value. This PR adds it as a first-class option.

## Changes
- `extensions/npm/package.json` — Add `"vp"` to the `npm.scriptRunner` enum and enumDescriptions
- `extensions/npm/package.nls.json` — Add description string: "Use Vite+ (vp) as the script runner."

Credit: @jong-kyung (original author of #308794).