### PR TITLE
Fixing Remote-SSH Windows to Linux .mcp.json error ENOENT

### DIFF
--- a/src/vs/workbench/contrib/mcp/common/discovery/nativeMcpDiscoveryAdapters.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/nativeMcpDiscoveryAdapters.ts
@@ -21,7 +21,7 @@ export interface NativeMpcDiscoveryAdapter {
 	adaptFile(contents: VSBuffer, details: INativeMcpDiscoveryData): Promise<McpServerDefinition[] | undefined>;
 }
 
-export async function claudeConfigToServerDefinition(idPrefix: string, contents: VSBuffer, cwd?: URI) {
+export async function claudeConfigToServerDefinition(idPrefix: string, contents: VSBuffer) {
 	let parsed: {
 		mcpServers: Record<string, {
 			command: string;
@@ -48,7 +48,7 @@ export async function claudeConfigToServerDefinition(idPrefix: string, contents:
 			command: server.command,
 			env: server.env || {},
 			envFile: undefined,
-			cwd: cwd?.fsPath,
+			cwd: undefined,
 			sandbox: undefined
 		};
 
@@ -82,8 +82,8 @@ export class ClaudeDesktopMpcDiscoveryAdapter implements NativeMpcDiscoveryAdapt
 		}
 	}
 
-	adaptFile(contents: VSBuffer, { homedir }: INativeMcpDiscoveryData): Promise<McpServerDefinition[] | undefined> {
-		return claudeConfigToServerDefinition(this.id, contents, homedir);
+	adaptFile(contents: VSBuffer, _details: INativeMcpDiscoveryData): Promise<McpServerDefinition[] | undefined> {
+		return claudeConfigToServerDefinition(this.id, contents);
 	}
 }
 

--- a/src/vs/workbench/contrib/mcp/common/discovery/workspaceDotMcpDiscovery.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/workspaceDotMcpDiscovery.ts
@@ -12,6 +12,7 @@ import { IFileService } from '../../../../../platform/files/common/files.js';
 import { StorageScope } from '../../../../../platform/storage/common/storage.js';
 import { IWorkspaceContextService, IWorkspaceFolder } from '../../../../../platform/workspace/common/workspace.js';
 import { IRemoteAgentService } from '../../../../services/remote/common/remoteAgentService.js';
+import { mcpConfigurationSection } from '../mcpConfiguration.js';
 import { IMcpRegistry } from '../mcpRegistryTypes.js';
 import { McpCollectionSortOrder, McpServerDefinition, McpServerTrust } from '../mcpTypes.js';
 import { IMcpDiscovery } from './mcpDiscovery.js';
@@ -76,10 +77,15 @@ export class WorkspaceDotMcpDiscovery extends Disposable implements IMcpDiscover
 			let definitions: McpServerDefinition[] = [];
 			try {
 				const contents = await this._fileService.readFile(configFile);
-				const defs = await claudeConfigToServerDefinition(collectionId, contents.value, folder.uri);
+				const defs = await claudeConfigToServerDefinition(collectionId, contents.value);
 				if (defs) {
 					for (const d of defs) {
 						d.roots = [folder.uri];
+						d.variableReplacement = {
+							folder,
+							section: mcpConfigurationSection,
+							target: ConfigurationTarget.WORKSPACE_FOLDER,
+						};
 					}
 					definitions = defs;
 				}

--- a/src/vs/workbench/contrib/mcp/common/discovery/workspaceMcpDiscoveryAdapter.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/workspaceMcpDiscoveryAdapter.ts
@@ -12,7 +12,7 @@ import { IFileService } from '../../../../../platform/files/common/files.js';
 import { StorageScope } from '../../../../../platform/storage/common/storage.js';
 import { IWorkspaceContextService, IWorkspaceFolder } from '../../../../../platform/workspace/common/workspace.js';
 import { IRemoteAgentService } from '../../../../services/remote/common/remoteAgentService.js';
-import { DiscoverySource } from '../mcpConfiguration.js';
+import { DiscoverySource, mcpConfigurationSection } from '../mcpConfiguration.js';
 import { IMcpRegistry } from '../mcpRegistryTypes.js';
 import { McpCollectionSortOrder, McpServerTrust } from '../mcpTypes.js';
 import { IMcpDiscovery } from './mcpDiscovery.js';
@@ -68,8 +68,15 @@ export class CursorWorkspaceMcpDiscoveryAdapter extends FilesystemMcpDiscovery i
 			collection,
 			DiscoverySource.CursorWorkspace,
 			async contents => {
-				const defs = await claudeConfigToServerDefinition(collection.id, contents, folder.uri);
-				defs?.forEach(d => d.roots = [folder.uri]);
+				const defs = await claudeConfigToServerDefinition(collection.id, contents);
+				defs?.forEach(d => {
+					d.roots = [folder.uri];
+					d.variableReplacement = {
+						folder,
+						section: mcpConfigurationSection,
+						target: ConfigurationTarget.WORKSPACE_FOLDER,
+					};
+				});
 				return defs;
 			}
 		));


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Proposes a fix for #320167

## Problem

`.mcp.json` MCP servers fail to start on a Windows VS Code client connected to a Linux remote with `Error: spawn <command> ENOENT` - even though the command is a valid absolute Linux path. `.vscode/mcp.json` works fine on the same setup.

The root cause is in `claudeConfigToServerDefinition`, which runs in the workbench (client) process and assigns `cwd: cwd?.fsPath`. On a Windows client, `URI.fsPath` flips forward slashes to backslashes based on the **client** OS, producing a string like `\path\to\workspace`. That string is shipped to the Linux extension host, used as `cwd` in `spawn()`, `chdir()` fails before `execve`, and Node misreports the failure against the command name.

`.vscode/mcp.json` doesn't hit this because [`installedMcpServersDiscovery`](https://github.com/microsoft/vscode/blob/00a11aeccf327e65177b1ded88fe458a18b79319/src/vs/workbench/contrib/mcp/common/discovery/installedMcpServersDiscovery.ts) leaves `launch.cwd` undefined and propagates the workspace folder as a `URI` via `variableReplacement.folder`. The URI is reconstituted on the ext host where `URI.fsPath` produces the right slashes for the remote.

## Solution in this PR

Make the `.mcp.json` and `.cursor/mcp.json` discovery paths use the same mechanism as `.vscode/mcp.json`:

- **`nativeMcpDiscoveryAdapters.ts`** - drop the `cwd` parameter from `claudeConfigToServerDefinition` and emit stdio entries with `cwd: undefined`.
- **`workspaceDotMcpDiscovery.ts`** and **`workspaceMcpDiscoveryAdapter.ts`** (Cursor) - set `variableReplacement.folder` on each server definition so the ext host's `defaultCwd` fallback resolves the workspace folder on the remote side.

## Notes

- `ClaudeDesktopMpcDiscoveryAdapter.adaptFile` no longer needs its `details` argument but the `NativeMpcDiscoveryAdapter` interface still mandates it (sibling adapters use `details.homedir` in `getFilePath`). Renamed to `_details` to match existing convention for interface-imposed unused parameters - see e.g. `webWorkerFileSystemProvider.ts` and `extensions.ts::activateByEvent`.

## Tests

I didn't add any unit tests, as this spans the workbench and ext-host process boundary, and I don't see any existing test patterns for this. I considered adding a regression test for cwd == undefined but that tests the specific mechanism here instead of the high-level functionality. I'm happy to add any tests that reviewers recommend!

## Manual verification

I tested these changes locally - both in Windows + Remote-SSH and Linux. Both work now with the fix