### PR TITLE
Parse headers for native MCP discovery server launch configuration

### DIFF
--- a/src/vs/workbench/contrib/mcp/common/discovery/nativeMcpDiscoveryAdapters.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/nativeMcpDiscoveryAdapters.ts
@@ -28,6 +28,7 @@ export async function claudeConfigToServerDefinition(idPrefix: string, contents:
 			args?: string[];
 			env?: Record<string, string>;
 			url?: string;
+			headers?: Record<string, string>;
 		}>;
 	};
 
@@ -41,7 +42,7 @@ export async function claudeConfigToServerDefinition(idPrefix: string, contents:
 		const launch: McpServerLaunch = server.url ? {
 			type: McpServerTransportType.HTTP,
 			uri: URI.parse(server.url),
-			headers: [],
+			headers: Object.entries(server.headers ?? {}),
 		} : {
 			type: McpServerTransportType.Stdio,
 			args: server.args || [],

--- a/src/vs/workbench/contrib/mcp/test/common/nativeMcpDiscoveryAdapters.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/nativeMcpDiscoveryAdapters.test.ts
@@ -1,0 +1,55 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { VSBuffer } from '../../../../../base/common/buffer.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { claudeConfigToServerDefinition } from '../../common/discovery/nativeMcpDiscoveryAdapters.js';
+import { McpServerTransportType } from '../../common/mcpTypes.js';
+
+suite('MCP Discovery - nativeMcpDiscoveryAdapters', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('claudeConfigToServerDefinition forwards HTTP headers', async () => {
+		const contents = VSBuffer.fromString(JSON.stringify({
+			mcpServers: {
+				'with-headers': {
+					type: 'http',
+					url: 'https://example.com/mcp',
+					headers: { 'X-Custom-Header': 'my-value', 'Authorization': 'Bearer abc' },
+				},
+				'no-headers': {
+					type: 'http',
+					url: 'https://example.com/other',
+				},
+				'stdio': {
+					command: 'my-cmd',
+					args: ['--foo'],
+				},
+			},
+		}));
+
+		const defs = await claudeConfigToServerDefinition('prefix', contents);
+		assert.ok(defs);
+		assert.strictEqual(defs.length, 3);
+
+		const withHeaders = defs.find(d => d.label === 'with-headers')!;
+		assert.strictEqual(withHeaders.launch.type, McpServerTransportType.HTTP);
+		assert.deepStrictEqual(
+			(withHeaders.launch as { headers: [string, string][] }).headers,
+			[['X-Custom-Header', 'my-value'], ['Authorization', 'Bearer abc']],
+		);
+
+		const noHeaders = defs.find(d => d.label === 'no-headers')!;
+		assert.strictEqual(noHeaders.launch.type, McpServerTransportType.HTTP);
+		assert.deepStrictEqual(
+			(noHeaders.launch as { headers: [string, string][] }).headers,
+			[],
+		);
+
+		const stdio = defs.find(d => d.label === 'stdio')!;
+		assert.strictEqual(stdio.launch.type, McpServerTransportType.Stdio);
+	});
+});


### PR DESCRIPTION
Fixes #319528

Per https://code.claude.com/docs/en/mcp
