### PR TITLE
Fix Copilot AH plugin sync errors on reconnection

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostFileSystemProvider.ts
+++ b/src/vs/platform/agentHost/common/agentHostFileSystemProvider.ts
@@ -4,8 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { decodeBase64, VSBuffer } from '../../../base/common/buffer.js';
+import { disposableTimeout } from '../../../base/common/async.js';
 import { Emitter, Event } from '../../../base/common/event.js';
-import { Disposable, IDisposable, MutableDisposable, toDisposable } from '../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, IDisposable, MutableDisposable, toDisposable } from '../../../base/common/lifecycle.js';
 import { URI } from '../../../base/common/uri.js';
 import { createFileSystemProviderError, FileChangeType, FilePermission, FileSystemProviderCapabilities, FileSystemProviderErrorCode, FileType, IFileChange, IFileDeleteOptions, IFileOverwriteOptions, IFileSystemProvider, IFileWriteOptions, IStat, IWatchOptions } from '../../files/common/files.js';
 import { fromAgentHostUri, toAgentHostUri } from './agentHostUri.js';
@@ -136,6 +137,24 @@ export function agentHostRemotePath(uri: URI): string {
 
 // ---- Abstract base ----------------------------------------------------------
 
+interface IAuthorityEntry {
+	/**
+	 * All currently-registered connections for this authority, oldest
+	 * first. The active connection is the last entry (most recent
+	 * registration wins). Older registrations are kept so that if a
+	 * caller registers `A`, then `B`, then disposes `B`, we transparently
+	 * fall back to `A` instead of entering a grace window.
+	 *
+	 * Empty while the entry is inside the grace window.
+	 */
+	connections: IRemoteFilesystemConnection[];
+	/**
+	 * Pending eviction timer; armed while {@link connections} is empty,
+	 * cleared on re-registration or eviction.
+	 */
+	readonly expiry: MutableDisposable<IDisposable>;
+}
+
 /**
  * {@link IFileSystemProvider} that proxies filesystem operations
  * through a {@link IRemoteFilesystemConnection}.
@@ -161,19 +180,107 @@ export abstract class AHPFileSystemProvider extends Disposable implements IFileS
 	private readonly _onDidWatchError = this._register(new Emitter<string>());
 	readonly onDidWatchError = this._onDidWatchError.event;
 
-	private readonly _authorityToConnection = new Map<string, IRemoteFilesystemConnection>();
+	/**
+	 * Per-authority registration slot. We keep the slot alive for a brief
+	 * grace period after the last registration is disposed, so an
+	 * operation issued during a reconnection window can wait for the
+	 * replacement registration instead of failing immediately.
+	 */
+	private readonly _authorities = new Map<string, IAuthorityEntry>();
+
+	/**
+	 * Fires the authority whose active connection has changed: added,
+	 * replaced, fallen back to an older registration, entered the grace
+	 * window (no active connection), or evicted. Long-lived consumers
+	 * (e.g. {@link watch}) subscribe here so they continue to receive
+	 * notifications across full entry eviction + later re-creation —
+	 * something a per-entry emitter cannot offer.
+	 */
+	private readonly _onDidChangeConnection = this._register(new Emitter<string>());
+
+	/**
+	 * Grace period during which {@link _getConnection} will await a new
+	 * registration after the previous one is disposed. Covers the window
+	 * where a transport is briefly torn down and re-registered (e.g. an
+	 * agent-host client reconnect that races a plugin sync). 5s matches
+	 * the typical reconnect timeout. Consumers should still implement
+	 * logical retries for longer reconnection latencies, but this is a
+	 * low level, best-effort mechanism.
+	 *
+	 * Tests can override this via the constructor parameter.
+	 */
+	private static readonly _DEFAULT_CONNECTION_GRACE_MS = 5000;
+
+	constructor(
+		private readonly _connectionGraceMs: number = AHPFileSystemProvider._DEFAULT_CONNECTION_GRACE_MS,
+	) {
+		super();
+	}
 
 	/**
 	 * Register a mapping from a URI authority to a connection.
-	 * Returns a disposable that unregisters the mapping.
+	 * Returns a disposable that unregisters the mapping. Multiple
+	 * concurrent registrations for the same authority are supported;
+	 * the most recent registration wins, and disposing it falls back to
+	 * the previous one (if any). After the *last* registration is
+	 * disposed the entry is held open for {@link _connectionGraceMs} so
+	 * that a reconnect can replace it without orphaning in-flight
+	 * operations.
 	 */
 	registerAuthority(authority: string, connection: IRemoteFilesystemConnection): IDisposable {
-		this._authorityToConnection.set(authority, connection);
+		let entry = this._authorities.get(authority);
+		if (!entry) {
+			entry = {
+				connections: [connection],
+				expiry: new MutableDisposable<IDisposable>(),
+			};
+			this._authorities.set(authority, entry);
+		} else {
+			entry.expiry.clear();
+			entry.connections.push(connection);
+		}
+		const adopted = entry;
+		this._onDidChangeConnection.fire(authority);
+
 		return toDisposable(() => {
-			if (this._authorityToConnection.get(authority) === connection) {
-				this._authorityToConnection.delete(authority);
+			const idx = adopted.connections.indexOf(connection);
+			if (idx === -1) {
+				return;
+			}
+			const wasActive = idx === adopted.connections.length - 1;
+			adopted.connections.splice(idx, 1);
+			if (adopted.connections.length === 0) {
+				adopted.expiry.value = disposableTimeout(
+					() => this._expireAuthority(authority, adopted),
+					this._connectionGraceMs,
+					this._store,
+				);
+			}
+
+			if (wasActive) {
+				this._onDidChangeConnection.fire(authority); // Falling back to an older connection — surface the change.
 			}
 		});
+	}
+
+	private _expireAuthority(authority: string, entry: IAuthorityEntry): void {
+		// A re-registration may have landed between scheduling and
+		// firing — bail in that case.
+		if (this._authorities.get(authority) !== entry || entry.connections.length > 0) {
+			return;
+		}
+		this._authorities.delete(authority);
+		entry.expiry.dispose();
+		this._onDidChangeConnection.fire(authority);
+	}
+
+	override dispose(): void {
+		for (const entry of this._authorities.values()) {
+			entry.expiry.dispose();
+			entry.connections.length = 0;
+		}
+		this._authorities.clear();
+		super.dispose();
 	}
 
 	/** Decode a provider URI back to the original URI for the remote endpoint. */
@@ -183,16 +290,19 @@ export abstract class AHPFileSystemProvider extends Disposable implements IFileS
 	protected abstract _encodeUri(resource: URI, authority: string): URI;
 
 	watch(resource: URI, opts: IWatchOptions): IDisposable {
-		const connection = this._authorityToConnection.get(resource.authority);
-		if (!connection?.watchResource) {
-			return Disposable.None;
-		}
-		// `IFileSystemProvider.watch` is synchronous but the underlying
-		// AHP `createResourceWatch` + `subscribe` round-trip is not.
-		// Hand back a `MutableDisposable` that holds the handle once it
-		// arrives; if the caller disposes before then, the
-		// MutableDisposable will dispose the handle as soon as it's set.
-		const handleHolder = new MutableDisposable<IDisposable>();
+		// `IFileSystemProvider.watch` is synchronous, but acquiring a
+		// connection may have to wait for a (re)registration and the
+		// underlying AHP `createResourceWatch` + `subscribe` round-trip
+		// is itself async. Additionally, watchers are long-lived: every
+		// time the active connection for `authority` changes (reconnect,
+		// fallback to an older registration, eviction followed by a fresh
+		// registration, ...) we tear down any existing remote handle and
+		// re-attach against the new connection. The class-level
+		// {@link _onDidChangeConnection} event keeps us informed across
+		// the full entry-eviction cycle.
+		const store = new DisposableStore();
+		const handleHolder = store.add(new MutableDisposable<IDisposable>());
+		const authority = resource.authority;
 		const params: CreateResourceWatchParams = {
 			channel: ROOT_STATE_URI,
 			uri: this._decodeUri(resource).toString(),
@@ -202,15 +312,48 @@ export abstract class AHPFileSystemProvider extends Disposable implements IFileS
 				? { includes: { items: opts.includes.map(p => typeof p === 'string' ? p : p.pattern) } }
 				: {}),
 		};
-		let disposed = false;
-		connection.watchResource(params).then(
-			handle => {
-				if (disposed) {
+
+		// Track which connection the current handle was created against
+		// so we ignore spurious change events that don't represent a
+		// real swap (e.g. a stale registration disposal).
+		let attached: IRemoteFilesystemConnection | undefined;
+		let attaching = false;
+		let pendingReattach = false;
+
+		const reattach = async (): Promise<void> => {
+			if (store.isDisposed) {
+				return;
+			}
+			if (attaching) {
+				pendingReattach = true;
+				return;
+			}
+			const entry = this._authorities.get(authority);
+			const next = entry?.connections.at(-1);
+			if (next === attached) {
+				return;
+			}
+			handleHolder.clear();
+			attached = undefined;
+			const watchResource = next?.watchResource;
+			if (!next || !watchResource) {
+				return;
+			}
+			attaching = true;
+			const target = next;
+			try {
+				const handle = await watchResource.call(target, params);
+				if (store.isDisposed) {
 					handle.dispose();
 					return;
 				}
-				// Forward change events through the provider's shared
-				// emitter (uncorrelated watchers all merge here).
+				const current = this._authorities.get(authority);
+				if (!current || current.connections.at(-1) !== target) {
+					// Active connection changed underneath us — toss this
+					// handle and let the pending reattach pick the new one.
+					handle.dispose();
+					return;
+				}
 				const sub = handle.onDidChange(changes => this._onDidChangeFile.fire(changes.map(c => ({
 					resource: this._encodeUri(c.resource, resource.authority),
 					type: c.type,
@@ -219,15 +362,26 @@ export abstract class AHPFileSystemProvider extends Disposable implements IFileS
 					sub.dispose();
 					handle.dispose();
 				});
-			},
-			err => {
+				attached = target;
+			} catch (err) {
 				this._onDidWatchError.fire(err instanceof Error ? err.message : String(err));
-			},
-		);
-		return toDisposable(() => {
-			disposed = true;
-			handleHolder.dispose();
-		});
+			} finally {
+				attaching = false;
+				if (pendingReattach) {
+					pendingReattach = false;
+					reattach();
+				}
+			}
+		};
+
+		store.add(this._onDidChangeConnection.event(a => {
+			if (a === authority) {
+				reattach();
+			}
+		}));
+		reattach();
+
+		return store;
 	}
 
 	async stat(resource: URI): Promise<IStat> {
@@ -245,7 +399,7 @@ export abstract class AHPFileSystemProvider extends Disposable implements IFileS
 			return { type: FileType.Directory, mtime: 0, ctime: 0, size: 0, permissions: FilePermission.Readonly };
 		}
 
-		const connection = this._getConnection(resource.authority);
+		const connection = await this._getConnection(resource.authority);
 		try {
 			const resolved = await connection.resourceResolve({ channel: ROOT_STATE_URI, uri: decoded.toString() });
 			return {
@@ -268,7 +422,7 @@ export abstract class AHPFileSystemProvider extends Disposable implements IFileS
 	}
 
 	async readFile(resource: URI): Promise<Uint8Array> {
-		const connection = this._getConnection(resource.authority);
+		const connection = await this._getConnection(resource.authority);
 		try {
 			const originalUri = this._decodeUri(resource);
 			const result = await connection.resourceRead(originalUri);
@@ -282,7 +436,7 @@ export abstract class AHPFileSystemProvider extends Disposable implements IFileS
 	}
 
 	async writeFile(resource: URI, content: Uint8Array, _opts: IFileWriteOptions): Promise<void> {
-		const connection = this._getConnection(resource.authority);
+		const connection = await this._getConnection(resource.authority);
 		try {
 			const originalUri = this._decodeUri(resource);
 			await connection.resourceWrite({
@@ -297,7 +451,7 @@ export abstract class AHPFileSystemProvider extends Disposable implements IFileS
 	}
 
 	async mkdir(resource: URI): Promise<void> {
-		const connection = this._getConnection(resource.authority);
+		const connection = await this._getConnection(resource.authority);
 		try {
 			const originalUri = this._decodeUri(resource);
 			await connection.resourceMkdir({ channel: ROOT_STATE_URI, uri: originalUri.toString() });
@@ -307,7 +461,7 @@ export abstract class AHPFileSystemProvider extends Disposable implements IFileS
 	}
 
 	async delete(resource: URI, opts: IFileDeleteOptions): Promise<void> {
-		const connection = this._getConnection(resource.authority);
+		const connection = await this._getConnection(resource.authority);
 		try {
 			const originalUri = this._decodeUri(resource);
 			await connection.resourceDelete({ channel: ROOT_STATE_URI, uri: originalUri.toString(), recursive: opts.recursive });
@@ -317,7 +471,7 @@ export abstract class AHPFileSystemProvider extends Disposable implements IFileS
 	}
 
 	async rename(from: URI, to: URI, opts: IFileOverwriteOptions): Promise<void> {
-		const connection = this._getConnection(from.authority);
+		const connection = await this._getConnection(from.authority);
 		try {
 			const originalFrom = this._decodeUri(from);
 			const originalTo = this._decodeUri(to);
@@ -328,7 +482,7 @@ export abstract class AHPFileSystemProvider extends Disposable implements IFileS
 	}
 
 	async copy(from: URI, to: URI, opts: IFileOverwriteOptions): Promise<void> {
-		const connection = this._getConnection(from.authority);
+		const connection = await this._getConnection(from.authority);
 		try {
 			const originalFrom = this._decodeUri(from);
 			const originalTo = this._decodeUri(to);
@@ -347,7 +501,7 @@ export abstract class AHPFileSystemProvider extends Disposable implements IFileS
 	 * is missing, or the connection doesn't implement `resourceRequest`.
 	 */
 	async requestResourceAccess(resource: URI, opts: { readonly read?: boolean; readonly write?: boolean }): Promise<void> {
-		const connection = this._getConnection(resource.authority);
+		const connection = await this._getConnection(resource.authority);
 		if (!connection.resourceRequest) {
 			throw createFileSystemProviderError(
 				`Connection for ${resource.authority} does not support resourceRequest`,
@@ -369,12 +523,44 @@ export abstract class AHPFileSystemProvider extends Disposable implements IFileS
 
 	// ---- Internals ----------------------------------------------------------
 
-	private _getConnection(authority: string): IRemoteFilesystemConnection {
-		const connection = this._authorityToConnection.get(authority);
-		if (!connection) {
-			throw createFileSystemProviderError(`No connection for authority: ${authority}`, FileSystemProviderErrorCode.Unavailable);
+	private _getConnection(authority: string): Promise<IRemoteFilesystemConnection> {
+		const entry = this._authorities.get(authority);
+		if (!entry) {
+			return Promise.reject(createFileSystemProviderError(
+				`No connection for authority: ${authority}`,
+				FileSystemProviderErrorCode.Unavailable,
+			));
 		}
-		return connection;
+
+		const active = entry.connections.at(-1);
+		if (active) {
+			return Promise.resolve(active);
+		}
+		// Entry is inside its grace window after the last registration
+		// was disposed. Wait until either a new registration arrives
+		// (resolve) or the grace timer expires and evicts the entry
+		// (reject).
+		return new Promise((resolve, reject) => {
+			const sub = this._onDidChangeConnection.event(a => {
+				if (a !== authority) {
+					return;
+				}
+				const current = this._authorities.get(authority);
+				if (!current) {
+					sub.dispose();
+					reject(createFileSystemProviderError(
+						`No connection for authority: ${authority}`,
+						FileSystemProviderErrorCode.Unavailable,
+					));
+					return;
+				}
+				const c = current.connections.at(-1);
+				if (c) {
+					sub.dispose();
+					resolve(c);
+				}
+			});
+		});
 	}
 
 	/**
@@ -395,7 +581,7 @@ export abstract class AHPFileSystemProvider extends Disposable implements IFileS
 	}
 
 	private async _listDirectory(authority: string, resource: URI): Promise<readonly DirectoryEntry[]> {
-		const connection = this._getConnection(authority);
+		const connection = await this._getConnection(authority);
 		try {
 			const originalUri = this._decodeUri(resource);
 			const result = await connection.resourceList(originalUri);

--- a/src/vs/platform/agentHost/common/agentHostFileSystemProvider.ts
+++ b/src/vs/platform/agentHost/common/agentHostFileSystemProvider.ts
@@ -369,17 +369,17 @@ export abstract class AHPFileSystemProvider extends Disposable implements IFileS
 				attaching = false;
 				if (pendingReattach) {
 					pendingReattach = false;
-					reattach();
+					void reattach();
 				}
 			}
 		};
 
 		store.add(this._onDidChangeConnection.event(a => {
 			if (a === authority) {
-				reattach();
+				void reattach();
 			}
 		}));
-		reattach();
+		void reattach();
 
 		return store;
 	}
@@ -541,10 +541,7 @@ export abstract class AHPFileSystemProvider extends Disposable implements IFileS
 		// (resolve) or the grace timer expires and evicts the entry
 		// (reject).
 		return new Promise((resolve, reject) => {
-			const sub = this._onDidChangeConnection.event(a => {
-				if (a !== authority) {
-					return;
-				}
+			const settle = (): void => {
 				const current = this._authorities.get(authority);
 				if (!current) {
 					sub.dispose();
@@ -559,7 +556,15 @@ export abstract class AHPFileSystemProvider extends Disposable implements IFileS
 					sub.dispose();
 					resolve(c);
 				}
+			};
+			const sub = this._onDidChangeConnection.event(a => {
+				if (a === authority) {
+					settle();
+				}
 			});
+			// Re-check after subscribing in case the state changed between
+			// our initial check and the listener registration.
+			settle();
 		});
 	}
 

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -11,7 +11,7 @@ import { rgDiskPath } from '../../../../base/node/ripgrep.js';
 import { CancellationError } from '../../../../base/common/errors.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { appendEscapedMarkdownInlineCode } from '../../../../base/common/htmlContent.js';
-import { Disposable, DisposableMap } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableMap, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { ResourceMap } from '../../../../base/common/map.js';
 import { FileAccess, Schemas } from '../../../../base/common/network.js';
 import { equals } from '../../../../base/common/objects.js';
@@ -423,7 +423,9 @@ export class CopilotAgent extends Disposable implements IAgent {
 	}
 
 	async getSessionCustomizations(session: URI): Promise<readonly Customization[]> {
-		return this._plugins.getSessionCustomizationsSettled(await this._getSessionCustomizationDirectory(session));
+		const directory = await this._getSessionCustomizationDirectory(session);
+		const activeClient = this._getOrCreateActiveClient(session, directory);
+		return activeClient.pluginController.getCustomizationsSettled();
 	}
 
 	private async _getSessionCustomizationDirectory(session: URI): Promise<URI | undefined> {
@@ -922,10 +924,14 @@ export class CopilotAgent extends Disposable implements IAgent {
 		// runs identically for provisional and real sessions; the SDK side
 		// of activeClient state isn't engaged until materialization.
 		if (config.activeClient) {
-			const ac = this._getOrCreateActiveClient(sessionUri);
+			const ac = this._getOrCreateActiveClient(sessionUri, config.workingDirectory);
 			ac.updateTools(config.activeClient.clientId, config.activeClient.tools);
 			if (config.activeClient.customizations !== undefined) {
-				await this._plugins.sync(config.activeClient.clientId, config.activeClient.customizations, config.workingDirectory);
+				// Provisional eager-create: no session-state listener is
+				// hooked up yet, so suppress action events. The session
+				// reads the final view via its initial snapshot once it
+				// materializes.
+				await ac.pluginController.sync(config.activeClient.clientId, config.activeClient.customizations, { quiet: true });
 			}
 		}
 
@@ -990,8 +996,8 @@ export class CopilotAgent extends Disposable implements IAgent {
 		// Always create an ActiveClient so the snapshot includes host +
 		// session-discovered customizations, even when no client has called
 		// `setClientCustomizations` / `setClientTools` yet.
-		const activeClient = this._getOrCreateActiveClient(sessionUri);
-		const snapshot = await activeClient.snapshot(customizationDirectory);
+		const activeClient = this._getOrCreateActiveClient(sessionUri, customizationDirectory);
+		const snapshot = await activeClient.snapshot();
 		const workingDirectory = await this._resolveSessionWorkingDirectory(materializedConfig, sessionId, prompt);
 		const shellManager = this._instantiationService.createInstance(ShellManager, sessionUri, workingDirectory);
 		const sessionConfigBuilder = this._buildSessionConfig(snapshot, shellManager, workingDirectory);
@@ -1118,14 +1124,13 @@ export class CopilotAgent extends Disposable implements IAgent {
 
 	async setClientCustomizations(session: URI, clientId: string, customizations: ClientPluginCustomization[]): Promise<ISyncedCustomization[]> {
 		const directory = await this._getSessionCustomizationDirectory(session);
-		return this._plugins.sync(clientId, customizations, directory, action => {
-			this._onDidSessionProgress.fire({ kind: 'action', session, action });
-		});
+		const activeClient = this._getOrCreateActiveClient(session, directory);
+		return activeClient.pluginController.sync(clientId, customizations);
 	}
 
 	setClientTools(session: URI, clientId: string, tools: ToolDefinition[]): void {
 		const sessionId = AgentSession.id(session);
-		const activeClient = this._getOrCreateActiveClient(session);
+		const activeClient = this._getOrCreateActiveClient(session, undefined);
 		const hasCachedEntry = this._sessions.has(sessionId);
 		this._logService.info(`[Copilot:${sessionId}] setClientTools: clientId=${clientId}, tools=[${tools.map(t => t.name).join(', ') || '(none)'}], hasCachedSdkSession=${hasCachedEntry}`);
 		activeClient.updateTools(clientId, tools);
@@ -1145,12 +1150,18 @@ export class CopilotAgent extends Disposable implements IAgent {
 	}
 
 	setCustomizationEnabled(uri: string, enabled: boolean): void {
-		this._plugins.setEnabled(uri, enabled);
+		// Enablement is per-session: fan out to every existing session
+		// controller (provisional + materialized). New sessions start with
+		// the default value baked into their customizations.
+		for (const activeClient of this._activeClients.values()) {
+			activeClient.pluginController.setEnabled(uri, enabled);
+		}
 	}
 
 	async sendMessage(session: URI, prompt: string, attachments?: readonly MessageAttachment[], turnId?: string): Promise<void> {
 		const sessionId = AgentSession.id(session);
 		await this._sessionSequencer.queue(sessionId, async () => {
+			await this._activeClients.get(session)?.pluginController.retryFailedClientSyncIfNeeded();
 
 			// First message on a provisional session: materialize the SDK
 			// session, worktree, and on-disk metadata before continuing. The
@@ -1168,7 +1179,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 			const activeClient = this._activeClients.get(session);
 			const hadCachedEntry = !!entry;
 			this._logService.info(`[Copilot:${sessionId}] sendMessage: cachedEntry=${hadCachedEntry}, hasActiveClient=${!!activeClient}, activeClientId=${activeClient ? '(set)' : '(none)'}`);
-			if (entry && activeClient && await activeClient.isOutdated(entry.appliedSnapshot, entry.customizationDirectory)) {
+			if (entry && activeClient && await activeClient.isOutdated(entry.appliedSnapshot)) {
 				this._logService.info(`[Copilot:${sessionId}] Session config changed (isOutdated=true), refreshing session. snapshotClientId=${entry.appliedSnapshot.clientId}`);
 				this._sessions.deleteAndDispose(sessionId);
 				entry = undefined;
@@ -1517,11 +1528,14 @@ export class CopilotAgent extends Disposable implements IAgent {
 
 	// ---- helpers ------------------------------------------------------------
 
-	private _getOrCreateActiveClient(session: URI): ActiveClient {
+	private _getOrCreateActiveClient(session: URI, directory: URI | undefined): ActiveClient {
 		let client = this._activeClients.get(session);
 		if (!client) {
-			client = new ActiveClient(directory => this._plugins.getAppliedPlugins(directory));
+			const pluginController = this._plugins.createSessionController(directory);
+			client = new ActiveClient(session, pluginController, this._onDidSessionProgress);
 			this._activeClients.set(session, client);
+		} else if (directory) {
+			client.pluginController.setDirectory(directory);
 		}
 		return client;
 	}
@@ -1581,10 +1595,12 @@ export class CopilotAgent extends Disposable implements IAgent {
 		const provisional = this._provisionalSessions.get(sessionId);
 		if (provisional) {
 			this._provisionalSessions.delete(sessionId);
+			this._activeClients.get(provisional.sessionUri)?.dispose();
 			this._activeClients.delete(provisional.sessionUri);
 			return;
 		}
 		const entry = this._sessions.get(sessionId);
+		const sessionUri = AgentSession.uri(this.id, sessionId);
 		if (entry) {
 			try {
 				await entry.destroySession();
@@ -1593,6 +1609,8 @@ export class CopilotAgent extends Disposable implements IAgent {
 			}
 		}
 		this._sessions.deleteAndDispose(sessionId);
+		this._activeClients.get(sessionUri)?.dispose();
+		this._activeClients.delete(sessionUri);
 		await this._removeCreatedWorktree(sessionId);
 	}
 
@@ -1679,8 +1697,8 @@ export class CopilotAgent extends Disposable implements IAgent {
 		// Always create an ActiveClient so the snapshot includes host +
 		// session-discovered customizations, even when no client has called
 		// `setClientCustomizations` / `setClientTools` yet.
-		const activeClient = this._getOrCreateActiveClient(sessionUri);
-		const snapshot = await activeClient.snapshot(customizationDirectory);
+		const activeClient = this._getOrCreateActiveClient(sessionUri, customizationDirectory);
+		const snapshot = await activeClient.snapshot();
 		const sessionMetadata = await client.getSessionMetadata(sessionId).catch(err => {
 			this._logService.warn(`[Copilot:${sessionId}] getSessionMetadata failed`, err);
 			return undefined;
@@ -1987,6 +2005,10 @@ export class CopilotAgent extends Disposable implements IAgent {
 	}
 
 	override dispose(): void {
+		for (const ac of this._activeClients.values()) {
+			ac.dispose();
+		}
+		this._activeClients.clear();
 		this.shutdown().catch(err => {
 			this._logService.warn('[Copilot] Shutdown failed during dispose', err);
 		}).finally(() => super.dispose());
@@ -1997,6 +2019,13 @@ interface IResolvedCustomization {
 	readonly customization: PluginCustomization;
 	readonly pluginDir?: URI;
 	readonly plugin?: IParsedPlugin;
+	/**
+	 * The original client-published input. Retained so a later
+	 * {@link SessionPluginController.retryFailedClientSyncIfNeeded} can
+	 * re-issue the sync without needing the caller to re-supply it (in
+	 * particular, the opaque `nonce` is preserved).
+	 */
+	readonly input?: ClientPluginCustomization;
 }
 
 /**
@@ -2193,32 +2222,58 @@ async function toDiscoveredChildCustomization(file: URI, type: DiscoveredType, f
 	};
 }
 
+/**
+ * Process-wide plugin state shared across all sessions.
+ *
+ * Owns:
+ *  - host-configured customizations (read from root config, watched, parsed)
+ *  - the {@link IAgentPluginManager} that materializes plugin source URIs
+ *    into a nonce-deduped on-disk cache (one shared directory for all
+ *    sessions and clients)
+ *  - parsing + resolution helpers used by both host- and client-side
+ *    customizations
+ *
+ * Per-session state (client-published customizations, on-disk
+ * customization discovery for the session's working directory,
+ * enablement overrides) lives on {@link SessionPluginController},
+ * one per {@link CopilotAgentSession}. Each session controller holds
+ * a reference back to this shared controller for the resolve/sync
+ * helpers it needs.
+ */
+/**
+ * Process-wide plugin state shared across all sessions.
+ *
+ * Owns:
+ *  - host-configured customizations (read from root config, watched, parsed)
+ *  - the {@link IAgentPluginManager} that materializes plugin source URIs
+ *    into a nonce-deduped on-disk cache (one shared directory for all
+ *    sessions and clients)
+ *  - parsing + resolution helpers used by both host- and client-side
+ *    customizations
+ *
+ * Per-session state (client-published customizations, on-disk
+ * customization discovery for the session's working directory,
+ * enablement overrides) lives on {@link SessionPluginController},
+ * one per {@link CopilotAgentSession}. Each session controller holds
+ * a reference back to this shared controller for the resolve/sync
+ * helpers it needs.
+ */
 class PluginController extends Disposable {
 	private readonly _onDidChange = this._register(new Emitter<void>());
+	/** Fires when host customizations change. Session controllers forward this. */
 	readonly onDidChange = this._onDidChange.event;
 
-	private readonly _enablement = new Map<string, boolean>();
-	private _clientCustomizations: readonly IResolvedCustomization[] = [];
 	private _hostCustomizations: readonly IResolvedCustomization[] = [];
-	private _clientSync: Promise<readonly IResolvedCustomization[]> = Promise.resolve([]);
 	private _hostSync: Promise<readonly IResolvedCustomization[]> = Promise.resolve([]);
-	private _clientRevision = 0;
 	private _hostRevision = 0;
 	private _lastAppliedRefs: readonly Customization[] = [];
 
-	/**
-	 * Per-working-directory bundles built from on-disk discovery
-	 * (workspace + user-home conventions). Lazily created on first access
-	 * by {@link _getOrCreateSessionEntry}; lifetime tied to this controller.
-	 */
-	private readonly _sessionDiscovered = new Map<string, SessionDiscoveredEntry>();
-
 	constructor(
-		@IAgentPluginManager private readonly _pluginManager: IAgentPluginManager,
-		@ILogService private readonly _logService: ILogService,
-		@IFileService private readonly _fileService: IFileService,
+		@IAgentPluginManager public readonly pluginManager: IAgentPluginManager,
+		@ILogService public readonly logService: ILogService,
+		@IFileService public readonly fileService: IFileService,
 		@IAgentConfigurationService private readonly _configurationService: IAgentConfigurationService,
-		@IInstantiationService private readonly _instantiationService: IInstantiationService,
+		@IInstantiationService public readonly instantiationService: IInstantiationService,
 	) {
 		super();
 
@@ -2229,110 +2284,35 @@ class PluginController extends Disposable {
 		}));
 	}
 
-	override dispose(): void {
-		for (const entry of this._sessionDiscovered.values()) {
-			entry.dispose();
-		}
-		this._sessionDiscovered.clear();
-		super.dispose();
-	}
-
 	public getConfiguredHostCustomizations(): readonly Customization[] {
 		return this._hostCustomizations.map(item => item.customization);
 	}
 
-	public getSessionCustomizations(directory: URI | undefined): readonly Customization[] {
-		const result: Customization[] = [
-			...this._hostCustomizations.map(item => this._applyEnablement(item.customization)),
-			...this._clientCustomizations.map(item => this._applyEnablement(item.customization)),
-		];
-		const entry = directory ? this._getOrCreateSessionEntry(directory) : undefined;
-		const discovered = entry?.currentCustomizations() ?? [];
-		for (const customization of discovered) {
-			result.push(this._applyEnablement(customization));
-		}
-		return result;
+	/**
+	 * Snapshot the resolved host customizations (loading or loaded). Used by
+	 * {@link SessionPluginController} to compose its per-session view.
+	 */
+	public hostCustomizations(): readonly IResolvedCustomization[] {
+		return this._hostCustomizations;
+	}
+
+	/** In-flight host sync; awaited by `getCustomizationsSettled` consumers. */
+	public hostSync(): Promise<readonly IResolvedCustomization[]> {
+		return this._hostSync;
+	}
+
+	public getUserHome(): string {
+		return process.env['HOME'] ?? process.env['USERPROFILE'] ?? '';
 	}
 
 	/**
-	 * Settled variant of {@link getSessionCustomizations}: awaits the
-	 * in-flight host sync, the in-flight client sync, and (when a directory
-	 * is supplied) the session-discovered entry's initial scan + parse
-	 * before snapshotting the customization list.
-	 *
-	 * Callers that publish customizations into session state at session
-	 * creation time MUST use this — the synchronous variant can return an
-	 * empty list for a brand-new working directory because
-	 * {@link SessionDiscoveredEntry} kicks off its `_refresh()` in its
-	 * constructor without anyone awaiting it.
+	 * Construct a per-session controller bound to the given customization
+	 * directory. The returned controller is a {@link Disposable} owned by
+	 * the caller; disposing it releases the session's disk-discovery
+	 * watchers and detaches from this controller's change event.
 	 */
-	public async getSessionCustomizationsSettled(directory: URI | undefined): Promise<readonly Customization[]> {
-		const entry = directory ? this._getOrCreateSessionEntry(directory) : undefined;
-		await Promise.all([
-			this._hostSync.catch(err => {
-				this._logService.warn('[Copilot:PluginController] Host customization update failed', err);
-			}),
-			this._clientSync.catch(err => {
-				this._logService.warn('[Copilot:PluginController] Customization sync failed', err);
-			}),
-			entry?.whenSettled(),
-		]);
-		return this.getSessionCustomizations(directory);
-	}
-
-	/**
-	 * Returns the current parsed plugins, awaiting any pending sync.
-	 */
-	public async getAppliedPlugins(directory: URI | undefined): Promise<readonly ICopilotPluginInfo[]> {
-		const entry = directory ? this._getOrCreateSessionEntry(directory) : undefined;
-		const [host, client] = await Promise.all([
-			this._hostSync.catch(err => {
-				this._logService.warn('[Copilot:PluginController] Host customization update failed', err);
-				return this._hostCustomizations;
-			}),
-			this._clientSync.catch(err => {
-				this._logService.warn('[Copilot:PluginController] Customization sync failed', err);
-				return this._clientCustomizations;
-			}),
-			entry?.whenSettled(),
-		]);
-
-		const discovered = entry?.currentCustomizations() ?? [];
-		const sessionPlugin = discovered.some(customization => this._isEnabled(customization)) ? entry?.currentPlugin() : undefined;
-		const sessionPlugins: IParsedPlugin[] = sessionPlugin ? [sessionPlugin] : [];
-
-		return [
-			...host.filter(item =>
-				!!item.plugin
-				&& this._isEnabled(item.customization)
-			).map(item => ({ ...item.plugin!, pluginDir: item.pluginDir })),
-			...client.filter(item =>
-				!!item.plugin
-				&& this._isEnabled(item.customization)
-			).map(item => ({ ...item.plugin!, pluginDir: item.pluginDir })),
-			...sessionPlugins,
-		];
-	}
-
-	private _getOrCreateSessionEntry(directory: URI): SessionDiscoveredEntry {
-		const key = directory.toString();
-		let entry = this._sessionDiscovered.get(key);
-		if (!entry) {
-			entry = new SessionDiscoveredEntry(
-				directory,
-				URI.file(this._getUserHome()),
-				uri => this._tryParsePlugin(uri),
-				() => this._onDidChange.fire(),
-				this._logService,
-				this._instantiationService,
-			);
-			this._sessionDiscovered.set(key, entry);
-		}
-		return entry;
-	}
-
-	public setEnabled(pluginProtocolUri: string, enabled: boolean) {
-		this._enablement.set(pluginProtocolUri, enabled);
+	public createSessionController(directory: URI | undefined): SessionPluginController {
+		return new SessionPluginController(this, directory);
 	}
 
 	/**
@@ -2356,7 +2336,7 @@ class PluginController extends Disposable {
 			},
 		}));
 		this._onDidChange.fire();
-		this._hostSync = Promise.all(customizations.map(customization => this._resolveConfiguredCustomization(customization))).then(resolved => {
+		this._hostSync = Promise.all(customizations.map(customization => this.resolveConfiguredCustomization(customization))).then(resolved => {
 			if (revision === this._hostRevision) {
 				this._hostCustomizations = resolved;
 			}
@@ -2368,76 +2348,9 @@ class PluginController extends Disposable {
 		});
 	}
 
-	public sync(clientId: string, customizations: ClientPluginCustomization[], directory: URI | undefined, publish?: (action: SessionAction) => void) {
-		const revision = ++this._clientRevision;
-		this._clientCustomizations = customizations.map(customization => ({
-			customization: {
-				...customization,
-				clientId,
-				load: { kind: CustomizationLoadStatus.Loading },
-			},
-		}));
-		publish?.({
-			type: ActionType.SessionCustomizationsChanged,
-			customizations: [...this.getSessionCustomizations(directory)],
-		});
-		const published = new Map<string, Customization>();
-		for (const customization of this._clientCustomizations) {
-			const enabled = this._applyEnablement(customization.customization);
-			published.set(enabled.uri, enabled);
-		}
-		const publishUpdate = (item: IResolvedCustomization) => {
-			const customization = this._applyEnablement(item.customization);
-			if (equals(published.get(customization.uri), customization)) {
-				return;
-			}
-			published.set(customization.uri, customization);
-			publish?.({
-				type: ActionType.SessionCustomizationUpdated,
-				customization,
-			});
-		};
-
-		const prev = this._clientSync;
-		const promise = this._clientSync = prev.catch(err => {
-			this._logService.warn('[Copilot:PluginController] Previous customization sync failed', err);
-		}).then(async () => {
-			const result = await this._pluginManager.syncCustomizations(clientId, customizations, status => {
-				if (revision !== this._clientRevision) {
-					return;
-				}
-
-				publishUpdate({ customization: { ...status, clientId } });
-			});
-
-			const resolved = await Promise.all(result.map(item => this._resolveSyncedCustomization(item, clientId)));
-			if (revision === this._clientRevision) {
-				this._clientCustomizations = resolved;
-				for (const item of resolved) {
-					publishUpdate(item);
-				}
-			}
-			return resolved;
-		});
-
-		return promise.then(results => results.map(item => ({
-			customization: this._applyEnablement(item.customization),
-			...(item.pluginDir ? { pluginDir: item.pluginDir } : {}),
-		})));
-	}
-
-	private _isEnabled(customization: Customization): boolean {
-		return this._enablement.get(customization.uri) ?? customization.enabled;
-	}
-
-	private _applyEnablement<T extends Customization>(customization: T): T {
-		const enabled = this._isEnabled(customization);
-		return customization.enabled === enabled ? customization : { ...customization, enabled };
-	}
-
-	private async _resolveConfiguredCustomization(customization: PluginCustomization): Promise<IResolvedCustomization> {
+	public async resolveConfiguredCustomization(customization: PluginCustomization): Promise<IResolvedCustomization> {
 		const pluginDir = URI.parse(customization.uri);
-		const parsed = await this._tryParsePlugin(pluginDir);
+		const parsed = await this.tryParsePlugin(pluginDir);
 		if (!parsed) {
 			return {
 				customization: {
@@ -2458,19 +2371,20 @@ class PluginController extends Disposable {
 		};
 	}
 
-	private async _resolveSyncedCustomization(item: ISyncedCustomization, clientId: string): Promise<IResolvedCustomization> {
+	public async resolveSyncedCustomization(item: ISyncedCustomization, clientId: string, input: ClientPluginCustomization | undefined): Promise<IResolvedCustomization> {
 		const baseCustomization: PluginCustomization = { ...item.customization, clientId };
 		if (!item.pluginDir) {
-			return { customization: baseCustomization };
+			return { customization: baseCustomization, input };
 		}
 
-		const parsed = await this._tryParsePlugin(item.pluginDir);
+		const parsed = await this.tryParsePlugin(item.pluginDir);
 		if (!parsed) {
 			return {
 				customization: {
 					...baseCustomization,
 					load: { kind: CustomizationLoadStatus.Error, message: localize('copilotAgent.pluginParseError', "Error parsing plugin.") },
 				},
+				input,
 			};
 		}
 
@@ -2481,48 +2395,313 @@ class PluginController extends Disposable {
 			},
 			pluginDir: item.pluginDir,
 			plugin: parsed,
+			input,
 		};
 	}
 
-	private async _tryParsePlugin(pluginDir: URI): Promise<IParsedPlugin | undefined> {
+	public async tryParsePlugin(pluginDir: URI): Promise<IParsedPlugin | undefined> {
 		try {
-			return await parsePlugin(pluginDir, this._fileService, undefined, this._getUserHome());
+			return await parsePlugin(pluginDir, this.fileService, undefined, this.getUserHome());
 		} catch (error) {
-			this._logService.warn(`[Copilot:PluginController] Error parsing plugin '${pluginDir.toString()}': ${error instanceof Error ? error.message : String(error)}`);
+			this.logService.warn(`[Copilot:PluginController] Error parsing plugin '${pluginDir.toString()}': ${error instanceof Error ? error.message : String(error)}`);
 			return undefined;
 		}
 	}
+}
 
-	private _getUserHome(): string {
-		return process.env['HOME'] ?? process.env['USERPROFILE'] ?? '';
+/**
+ * Per-session view over {@link PluginController}.
+ *
+ * Owns the session-scoped slice of plugin state — published client
+ * customizations, on-disk-discovered customizations under the session's
+ * customization directory, and the user's per-session enablement
+ * overrides — and exposes a {@link onDidPublish} stream of
+ * {@link SessionAction}s targeted at *this* session (no cross-session
+ * routing).
+ *
+ * Created via {@link PluginController.createSessionController}. The
+ * caller owns the returned disposable and disposes it when the session
+ * (provisional or materialized) is torn down.
+ */
+class SessionPluginController extends Disposable {
+	private readonly _onDidPublish = this._register(new Emitter<SessionAction>());
+	/** Per-session action stream (reset + per-item updates). */
+	readonly onDidPublish = this._onDidPublish.event;
+
+	private readonly _enablement = new Map<string, boolean>();
+	private _clientCustomizations: readonly IResolvedCustomization[] = [];
+	private _clientSync: Promise<readonly IResolvedCustomization[]> = Promise.resolve([]);
+	private _clientRevision = 0;
+	/** Last clientId seen via {@link sync}; used by {@link retryFailedClientSyncIfNeeded}. */
+	private _clientId: string | undefined;
+
+	private readonly _sessionDiscovered: MutableDisposable<SessionDiscoveredEntry> = this._register(new MutableDisposable());
+
+	constructor(
+		private readonly _parent: PluginController,
+		private _directory: URI | undefined,
+	) {
+		super();
+	}
+
+	public get directory(): URI | undefined {
+		return this._directory;
+	}
+
+	/**
+	 * Anchor (or re-anchor) the session's customization directory.
+	 * Only ever transitions from `undefined` → set; once a directory has
+	 * been bound the discovered entry is pinned to it for the remainder
+	 * of the session.
+	 */
+	public setDirectory(directory: URI | undefined): void {
+		if (this._directory || !directory) {
+			return;
+		}
+		this._directory = directory;
+	}
+
+	public getCustomizations(): readonly Customization[] {
+		const result: Customization[] = [
+			...this._parent.hostCustomizations().map(item => this._applyEnablement(item.customization)),
+			...this._clientCustomizations.map(item => this._applyEnablement(item.customization)),
+		];
+		const entry = this._discoveredEntry();
+		const discovered = entry?.currentCustomizations() ?? [];
+		for (const customization of discovered) {
+			result.push(this._applyEnablement(customization));
+		}
+		return result;
+	}
+
+	/**
+	 * Settled variant of {@link getCustomizations}: awaits the in-flight
+	 * host sync, the in-flight client sync, and the discovered entry's
+	 * initial scan + parse before snapshotting the list. Callers that
+	 * publish customizations into session state at session creation time
+	 * MUST use this — the synchronous variant can return an empty list
+	 * for a brand-new working directory because {@link SessionDiscoveredEntry}
+	 * kicks off its `_refresh()` without anyone awaiting it.
+	 */
+	public async getCustomizationsSettled(): Promise<readonly Customization[]> {
+		const entry = this._discoveredEntry();
+		await Promise.all([
+			this._parent.hostSync().catch(err => this._parent.logService.warn('[Copilot:SessionPluginController] Host customization update failed', err)),
+			this._clientSync.catch(err => this._parent.logService.warn('[Copilot:SessionPluginController] Client customization sync failed', err)),
+			entry?.whenSettled(),
+		]);
+		return this.getCustomizations();
+	}
+
+	/** Returns the parsed plugins currently enabled for this session, awaiting any pending sync. */
+	public async getAppliedPlugins(): Promise<readonly ICopilotPluginInfo[]> {
+		const entry = this._discoveredEntry();
+		const [host, client] = await Promise.all([
+			this._parent.hostSync().catch(err => {
+				this._parent.logService.warn('[Copilot:SessionPluginController] Host customization update failed', err);
+				return this._parent.hostCustomizations();
+			}),
+			this._clientSync.catch(err => {
+				this._parent.logService.warn('[Copilot:SessionPluginController] Client customization sync failed', err);
+				return this._clientCustomizations;
+			}),
+			entry?.whenSettled(),
+		]);
+
+		const discovered = entry?.currentCustomizations() ?? [];
+		const sessionPlugin = discovered.some(customization => this._isEnabled(customization)) ? entry?.currentPlugin() : undefined;
+		const sessionPlugins: IParsedPlugin[] = sessionPlugin ? [sessionPlugin] : [];
+
+		return [
+			...host.filter(item => !!item.plugin && this._isEnabled(item.customization))
+				.map(item => ({ ...item.plugin!, pluginDir: item.pluginDir })),
+			...client.filter(item => !!item.plugin && this._isEnabled(item.customization))
+				.map(item => ({ ...item.plugin!, pluginDir: item.pluginDir })),
+			...sessionPlugins,
+		];
+	}
+
+	/**
+	 * Set per-session enablement for a customization (by protocol URI).
+	 */
+	public setEnabled(pluginProtocolUri: string, enabled: boolean): void {
+		const prev = this._enablement.get(pluginProtocolUri);
+		if (prev === enabled) {
+			return;
+		}
+		this._enablement.set(pluginProtocolUri, enabled);
+	}
+
+	/**
+	 * Sync the published client customizations for this session.
+	 *
+	 * @param quiet when `true`, suppress {@link onDidPublish} events for
+	 *   this sync. Used during eager-create paths where there is no
+	 *   session listener yet; the session-state snapshot picks up the
+	 *   final view directly when the session materializes.
+	 */
+	public sync(clientId: string, customizations: ClientPluginCustomization[], options?: { quiet?: boolean }) {
+		const quiet = options?.quiet === true;
+		this._clientId = clientId;
+		const revision = ++this._clientRevision;
+		this._clientCustomizations = customizations.map(customization => ({
+			customization: {
+				...customization,
+				clientId,
+				load: { kind: CustomizationLoadStatus.Loading },
+			},
+			input: customization,
+		}));
+		if (!quiet) {
+			this._onDidPublish.fire({
+				type: ActionType.SessionCustomizationsChanged,
+				customizations: [...this.getCustomizations()],
+			});
+		}
+		const published = new Map<string, Customization>();
+		for (const customization of this._clientCustomizations) {
+			const enabled = this._applyEnablement(customization.customization);
+			published.set(enabled.uri, enabled);
+		}
+		const publishUpdate = (item: IResolvedCustomization) => {
+			const customization = this._applyEnablement(item.customization);
+			if (equals(published.get(customization.uri), customization)) {
+				return;
+			}
+			published.set(customization.uri, customization);
+			if (!quiet) {
+				this._onDidPublish.fire({
+					type: ActionType.SessionCustomizationUpdated,
+					customization,
+				});
+			}
+		};
+
+		const prev = this._clientSync;
+		const promise = this._clientSync = prev.catch(err => {
+			this._parent.logService.warn('[Copilot:SessionPluginController] Previous customization sync failed', err);
+		}).then(async () => {
+			const inputByUri = new Map(customizations.map(c => [c.uri, c]));
+			const result = await this._parent.pluginManager.syncCustomizations(clientId, customizations, status => {
+				if (revision !== this._clientRevision) {
+					return;
+				}
+				publishUpdate({
+					customization: { ...status, clientId },
+					input: inputByUri.get(status.uri),
+				});
+			});
+
+			const resolved = await Promise.all(result.map(item => this._parent.resolveSyncedCustomization(item, clientId, inputByUri.get(item.customization.uri))));
+			if (revision === this._clientRevision) {
+				this._clientCustomizations = resolved;
+				for (const item of resolved) {
+					publishUpdate(item);
+				}
+			}
+			return resolved;
+		});
+
+		return promise.then(results => results.map(item => ({
+			customization: this._applyEnablement(item.customization),
+			...(item.pluginDir ? { pluginDir: item.pluginDir } : {}),
+		})));
+	}
+
+	/**
+	 * Re-issue the last client sync if any previously-synced customization
+	 * is currently in an error state. Used to recover from transient
+	 * sync failures (e.g. a `vscode-agent-host://` connection drop during
+	 * reconnection) at message boundaries. Re-syncs **only** the errored
+	 * items and always non-quiet so listeners observe recovery.
+	 */
+	public async retryFailedClientSyncIfNeeded(): Promise<void> {
+		await this._clientSync.catch(() => { });
+		if (!this._clientId) {
+			return;
+		}
+		const errored = this._clientCustomizations.filter(item =>
+			item.customization.load?.kind === CustomizationLoadStatus.Error
+			&& item.input !== undefined
+		);
+		if (errored.length === 0) {
+			return;
+		}
+		const inputs = errored.map(item => item.input!);
+		this._parent.logService.info(`[Copilot:SessionPluginController] Retrying ${inputs.length} previously-failed client customization(s)`);
+		await this.sync(this._clientId, inputs).catch(err => {
+			this._parent.logService.warn('[Copilot:SessionPluginController] Retried client customization sync failed', err);
+		});
+	}
+
+	private _discoveredEntry(): SessionDiscoveredEntry | undefined {
+		if (!this._directory) {
+			return undefined;
+		}
+		if (!this._sessionDiscovered.value) {
+			this._sessionDiscovered.value = new SessionDiscoveredEntry(
+				this._directory,
+				URI.file(this._parent.getUserHome()),
+				uri => this._parent.tryParsePlugin(uri),
+				() => this._onDidPublish.fire({
+					type: ActionType.SessionCustomizationsChanged,
+					customizations: [...this.getCustomizations()],
+				}),
+				this._parent.logService,
+				this._parent.instantiationService,
+			);
+		}
+		return this._sessionDiscovered.value;
+	}
+
+	private _isEnabled(customization: Customization): boolean {
+		return this._enablement.get(customization.uri) ?? customization.enabled;
+	}
+
+	private _applyEnablement<T extends Customization>(customization: T): T {
+		const enabled = this._isEnabled(customization);
+		return customization.enabled === enabled ? customization : { ...customization, enabled };
 	}
 }
 
 /**
  * Tracks per-session active client contributions (tools and plugins).
- * The {@link snapshot} captures the state at session creation time, and
- * {@link isOutdated} detects when the session needs to be refreshed.
+ * Owns the session's {@link SessionPluginController}, which is the
+ * authoritative source for both the plugin snapshot (host + client +
+ * session-discovered) and per-session action events. Disposing this
+ * tears down the controller and any disk watchers it created.
  */
-class ActiveClient {
+class ActiveClient extends Disposable {
 	private _tools: readonly ToolDefinition[] = [];
 	private _clientId = '';
 
+	public readonly pluginController: SessionPluginController;
+
 	constructor(
-		/** Resolves the current set of applied plugins. May block while a sync is in progress. */
-		private readonly _resolvePlugins: (directory: URI | undefined) => Promise<readonly ICopilotPluginInfo[]>,
-	) { }
+		private readonly _sessionUri: URI,
+		pluginController: SessionPluginController,
+		onDidSessionProgress: Emitter<AgentSignal>,
+	) {
+		super();
+		this.pluginController = this._register(pluginController);
+		// Forward per-session publish events into the agent's progress
+		// stream. This replaces the previous clientId-based routing.
+		this._register(this.pluginController.onDidPublish(action => {
+			onDidSessionProgress.fire({ kind: 'action', session: this._sessionUri, action });
+		}));
+	}
 
 	updateTools(clientId: string, tools: readonly ToolDefinition[]): void {
 		this._clientId = clientId;
 		this._tools = tools;
 	}
 
-	async snapshot(directory: URI | undefined): Promise<IActiveClientSnapshot> {
-		return { clientId: this._clientId, tools: this._tools, plugins: await this._resolvePlugins(directory) };
+	async snapshot(): Promise<IActiveClientSnapshot> {
+		return { clientId: this._clientId, tools: this._tools, plugins: await this.pluginController.getAppliedPlugins() };
 	}
 
-	async isOutdated(snap: IActiveClientSnapshot, directory: URI | undefined): Promise<boolean> {
-		const plugins = await this._resolvePlugins(directory);
+	async isOutdated(snap: IActiveClientSnapshot): Promise<boolean> {
+		const plugins = await this.pluginController.getAppliedPlugins();
 		if (!parsedPluginsEqual(snap.plugins, plugins)) {
 			return true;
 		}

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -2240,24 +2240,6 @@ async function toDiscoveredChildCustomization(file: URI, type: DiscoveredType, f
  * a reference back to this shared controller for the resolve/sync
  * helpers it needs.
  */
-/**
- * Process-wide plugin state shared across all sessions.
- *
- * Owns:
- *  - host-configured customizations (read from root config, watched, parsed)
- *  - the {@link IAgentPluginManager} that materializes plugin source URIs
- *    into a nonce-deduped on-disk cache (one shared directory for all
- *    sessions and clients)
- *  - parsing + resolution helpers used by both host- and client-side
- *    customizations
- *
- * Per-session state (client-published customizations, on-disk
- * customization discovery for the session's working directory,
- * enablement overrides) lives on {@link SessionPluginController},
- * one per {@link CopilotAgentSession}. Each session controller holds
- * a reference back to this shared controller for the resolve/sync
- * helpers it needs.
- */
 class PluginController extends Disposable {
 	private readonly _onDidChange = this._register(new Emitter<void>());
 	/** Fires when host customizations change. Session controllers forward this. */

--- a/src/vs/platform/agentHost/test/common/agentHostFileSystemProvider.test.ts
+++ b/src/vs/platform/agentHost/test/common/agentHostFileSystemProvider.test.ts
@@ -226,6 +226,79 @@ suite('AgentHostFileSystemProvider - authority registrations', () => {
 			secondCalls: [URI.file('/workspace').toString()],
 		});
 	});
+
+	test('disposing the newest registration falls back to the previous one without entering grace', async () => {
+		const provider = disposables.add(new AgentHostFileSystemProvider());
+		const first = new NamedConnection('first');
+		const second = new NamedConnection('second');
+		disposables.add(provider.registerAuthority('client', first));
+		const secondRegistration = provider.registerAuthority('client', second);
+
+		secondRegistration.dispose();
+		const entries = await provider.readdir(agentHostUri('client', '/workspace'));
+
+		assert.deepStrictEqual({ entries, firstCalls: first.listCalls.map(uri => uri.toString()), secondCalls: second.listCalls }, {
+			entries: [['first.txt', FileType.File]],
+			firstCalls: [URI.file('/workspace').toString()],
+			secondCalls: [],
+		});
+	});
+
+	test('operation issued during reconnect window waits for the replacement registration', async () => {
+		const provider = disposables.add(new AgentHostFileSystemProvider(50));
+		const first = new NamedConnection('first');
+		const second = new NamedConnection('second');
+
+		// Register, then dispose — we're now inside the grace window.
+		const firstRegistration = provider.registerAuthority('client', first);
+		firstRegistration.dispose();
+
+		// Issue an operation while no connection is bound. It should
+		// queue, waiting for a re-registration.
+		const pending = provider.readdir(agentHostUri('client', '/workspace'));
+
+		// Reconnect within the grace window.
+		disposables.add(provider.registerAuthority('client', second));
+
+		const entries = await pending;
+		assert.deepStrictEqual({ entries, firstCalls: first.listCalls, secondCalls: second.listCalls.map(uri => uri.toString()) }, {
+			entries: [['second.txt', FileType.File]],
+			firstCalls: [],
+			secondCalls: [URI.file('/workspace').toString()],
+		});
+	});
+
+	test('operation issued in the grace window rejects with Unavailable when no reconnect arrives', async () => {
+		const provider = disposables.add(new AgentHostFileSystemProvider(20));
+		const first = new NamedConnection('first');
+
+		const firstRegistration = provider.registerAuthority('client', first);
+		firstRegistration.dispose();
+
+		const pending = provider.readdir(agentHostUri('client', '/workspace'));
+
+		let caught: unknown;
+		try {
+			await pending;
+		} catch (err) {
+			caught = err;
+		}
+		assert.ok(caught instanceof Error, 'expected an error');
+		assert.strictEqual(toFileSystemProviderErrorCode(caught as Error), FileSystemProviderErrorCode.Unavailable);
+	});
+
+	test('operation rejects immediately when no authority was ever registered', async () => {
+		const provider = disposables.add(new AgentHostFileSystemProvider(50));
+
+		let caught: unknown;
+		try {
+			await provider.readdir(agentHostUri('never', '/workspace'));
+		} catch (err) {
+			caught = err;
+		}
+		assert.ok(caught instanceof Error, 'expected an error');
+		assert.strictEqual(toFileSystemProviderErrorCode(caught as Error), FileSystemProviderErrorCode.Unavailable);
+	});
 });
 
 suite('AgentHostFileSystemProvider - synthetic content schemes', () => {
@@ -676,7 +749,9 @@ suite('AgentHostFileSystemProvider - resolve / mkdir / copy / watch', () => {
 		const sub = provider.onDidWatchError(message => errors.push(message));
 
 		const watchDisposable = provider.watch(wrapped, { recursive: false, excludes: [] });
-		await new Promise<void>(resolve => queueMicrotask(resolve));
+		// Yield until the watch's async chain (acquire connection →
+		// watchResource → error propagation) settles.
+		await new Promise<void>(resolve => setImmediate(resolve));
 
 		assert.deepStrictEqual(errors, ['watch setup failed']);
 
@@ -688,17 +763,114 @@ suite('AgentHostFileSystemProvider - resolve / mkdir / copy / watch', () => {
 		const { provider, connection } = setup();
 		const onDidChange = new Emitter<readonly IFileChange[]>();
 		let handleDisposed = false;
+		let handleCreated = false;
 		connection.nextWatchHandle = {
 			onDidChange: onDidChange.event,
 			dispose: () => { handleDisposed = true; onDidChange.dispose(); },
 		};
+		// Defer the watchResource resolution so we can dispose between
+		// `watch()` returning and the handle being assigned.
+		const originalWatchResource = connection.watchResource.bind(connection);
+		connection.watchResource = async params => {
+			handleCreated = true;
+			await new Promise<void>(resolve => setImmediate(resolve));
+			return originalWatchResource(params);
+		};
 		const wrapped = agentHostUri('remote', '/watched');
 
 		const watchDisposable = provider.watch(wrapped, { recursive: false, excludes: [] });
-		// Immediately dispose before the watchResource promise resolves.
+		// Yield until watchResource has begun (so a handle is in flight),
+		// then dispose before it resolves.
+		await new Promise<void>(resolve => setImmediate(resolve));
+		assert.strictEqual(handleCreated, true);
 		watchDisposable.dispose();
 
-		await new Promise<void>(resolve => queueMicrotask(resolve));
+		await new Promise<void>(resolve => setImmediate(resolve));
+		await new Promise<void>(resolve => setImmediate(resolve));
 		assert.strictEqual(handleDisposed, true);
+	});
+
+	test('watch reattaches to the next connection registered for the authority after disconnect', async () => {
+		const provider = disposables.add(new AgentHostFileSystemProvider(20));
+		const first = new FullConnection();
+		const firstChanges = new Emitter<readonly IFileChange[]>();
+		let firstHandleDisposed = false;
+		first.nextWatchHandle = {
+			onDidChange: firstChanges.event,
+			dispose: () => { firstHandleDisposed = true; firstChanges.dispose(); },
+		};
+		const firstReg = provider.registerAuthority('remote', first);
+
+		const wrapped = agentHostUri('remote', '/watched');
+		const received: IFileChange[][] = [];
+		disposables.add(provider.onDidChangeFile(c => received.push([...c])));
+		disposables.add(provider.watch(wrapped, { recursive: false, excludes: [] }));
+
+		await new Promise<void>(r => setImmediate(r));
+		await new Promise<void>(r => setImmediate(r));
+		firstChanges.fire([{ resource: URI.file('/watched/a.txt'), type: FileChangeType.UPDATED }]);
+
+		// Disconnect: a re-registration arrives within the grace window.
+		// The watcher must dispose the old handle and attach to the new
+		// connection without the caller doing anything.
+		firstReg.dispose();
+		const second = new FullConnection();
+		const secondChanges = new Emitter<readonly IFileChange[]>();
+		let secondHandleDisposed = false;
+		second.nextWatchHandle = {
+			onDidChange: secondChanges.event,
+			dispose: () => { secondHandleDisposed = true; secondChanges.dispose(); },
+		};
+		disposables.add(provider.registerAuthority('remote', second));
+
+		await new Promise<void>(r => setImmediate(r));
+		await new Promise<void>(r => setImmediate(r));
+		secondChanges.fire([{ resource: URI.file('/watched/b.txt'), type: FileChangeType.ADDED }]);
+
+		assert.deepStrictEqual({
+			firstWatchCalls: first.watchCalls.length,
+			secondWatchCalls: second.watchCalls.length,
+			firstHandleDisposed,
+			secondHandleDisposed,
+			received: received.map(batch => batch.map(c => [c.resource.toString(), c.type])),
+		}, {
+			firstWatchCalls: 1,
+			secondWatchCalls: 1,
+			firstHandleDisposed: true,
+			secondHandleDisposed: false,
+			received: [
+				[[agentHostUri('remote', '/watched/a.txt').toString(), FileChangeType.UPDATED]],
+				[[agentHostUri('remote', '/watched/b.txt').toString(), FileChangeType.ADDED]],
+			],
+		});
+	});
+
+	test('watch attaches to a freshly-registered authority that did not exist when watch() was called', async () => {
+		const provider = disposables.add(new AgentHostFileSystemProvider(20));
+		const wrapped = agentHostUri('never-registered', '/path');
+
+		const received: IFileChange[][] = [];
+		disposables.add(provider.onDidChangeFile(c => received.push([...c])));
+		disposables.add(provider.watch(wrapped, { recursive: false, excludes: [] }));
+
+		// No authority registered yet — nothing to attach to. Wait long
+		// enough that the grace timer (if any were running) would expire.
+		await new Promise(r => setTimeout(r, 40));
+
+		const connection = new FullConnection();
+		const changes = new Emitter<readonly IFileChange[]>();
+		connection.nextWatchHandle = {
+			onDidChange: changes.event,
+			dispose: () => changes.dispose(),
+		};
+		disposables.add(provider.registerAuthority('never-registered', connection));
+
+		await new Promise<void>(r => setImmediate(r));
+		await new Promise<void>(r => setImmediate(r));
+		changes.fire([{ resource: URI.file('/path/late.txt'), type: FileChangeType.ADDED }]);
+
+		assert.strictEqual(connection.watchCalls.length, 1, 'watch attached after late registration');
+		assert.strictEqual(received.length, 1);
+		assert.strictEqual(received[0][0].resource.toString(), agentHostUri('never-registered', '/path/late.txt').toString());
 	});
 });

--- a/src/vs/platform/agentHost/test/common/agentHostFileSystemProvider.test.ts
+++ b/src/vs/platform/agentHost/test/common/agentHostFileSystemProvider.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { timeout } from '../../../../base/common/async.js';
 import { VSBuffer } from '../../../../base/common/buffer.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -751,7 +752,7 @@ suite('AgentHostFileSystemProvider - resolve / mkdir / copy / watch', () => {
 		const watchDisposable = provider.watch(wrapped, { recursive: false, excludes: [] });
 		// Yield until the watch's async chain (acquire connection →
 		// watchResource → error propagation) settles.
-		await new Promise<void>(resolve => setImmediate(resolve));
+		await timeout(0);
 
 		assert.deepStrictEqual(errors, ['watch setup failed']);
 
@@ -773,7 +774,7 @@ suite('AgentHostFileSystemProvider - resolve / mkdir / copy / watch', () => {
 		const originalWatchResource = connection.watchResource.bind(connection);
 		connection.watchResource = async params => {
 			handleCreated = true;
-			await new Promise<void>(resolve => setImmediate(resolve));
+			await timeout(0);
 			return originalWatchResource(params);
 		};
 		const wrapped = agentHostUri('remote', '/watched');
@@ -781,12 +782,12 @@ suite('AgentHostFileSystemProvider - resolve / mkdir / copy / watch', () => {
 		const watchDisposable = provider.watch(wrapped, { recursive: false, excludes: [] });
 		// Yield until watchResource has begun (so a handle is in flight),
 		// then dispose before it resolves.
-		await new Promise<void>(resolve => setImmediate(resolve));
+		await timeout(0);
 		assert.strictEqual(handleCreated, true);
 		watchDisposable.dispose();
 
-		await new Promise<void>(resolve => setImmediate(resolve));
-		await new Promise<void>(resolve => setImmediate(resolve));
+		await timeout(0);
+		await timeout(0);
 		assert.strictEqual(handleDisposed, true);
 	});
 
@@ -806,8 +807,8 @@ suite('AgentHostFileSystemProvider - resolve / mkdir / copy / watch', () => {
 		disposables.add(provider.onDidChangeFile(c => received.push([...c])));
 		disposables.add(provider.watch(wrapped, { recursive: false, excludes: [] }));
 
-		await new Promise<void>(r => setImmediate(r));
-		await new Promise<void>(r => setImmediate(r));
+		await timeout(0);
+		await timeout(0);
 		firstChanges.fire([{ resource: URI.file('/watched/a.txt'), type: FileChangeType.UPDATED }]);
 
 		// Disconnect: a re-registration arrives within the grace window.
@@ -823,8 +824,8 @@ suite('AgentHostFileSystemProvider - resolve / mkdir / copy / watch', () => {
 		};
 		disposables.add(provider.registerAuthority('remote', second));
 
-		await new Promise<void>(r => setImmediate(r));
-		await new Promise<void>(r => setImmediate(r));
+		await timeout(0);
+		await timeout(0);
 		secondChanges.fire([{ resource: URI.file('/watched/b.txt'), type: FileChangeType.ADDED }]);
 
 		assert.deepStrictEqual({
@@ -865,8 +866,8 @@ suite('AgentHostFileSystemProvider - resolve / mkdir / copy / watch', () => {
 		};
 		disposables.add(provider.registerAuthority('never-registered', connection));
 
-		await new Promise<void>(r => setImmediate(r));
-		await new Promise<void>(r => setImmediate(r));
+		await timeout(0);
+		await timeout(0);
 		changes.fire([{ resource: URI.file('/path/late.txt'), type: FileChangeType.ADDED }]);
 
 		assert.strictEqual(connection.watchCalls.length, 1, 'watch attached after late registration');


### PR DESCRIPTION
Fixes #319744.

Two-part fix:

### 1. Reconnection grace + auto-reattaching watchers in `AHPFileSystemProvider`
Per-authority entries keep a stack of connections (newest = active) and hold open requests across a transient disconnect via a brief grace window. Watchers auto-reattach to any new connection on the authority via a class-level connection-change event, so a watch placed before reconnect stays live across the gap. New tests cover reconnect grace, fallback to a prior connection when the newest goes away, immediate reject for never-registered authorities, and watch reattach across disconnect / late attach.

### 2. `PluginController` split into shared + per-session
- `PluginController` (shared, process-wide): host customizations, parsing helpers, and the `IAgentPluginManager`.
- `SessionPluginController` (per `CopilotAgentSession`): client customizations, session-discovered on-disk customizations, and per-session enablement overrides. Publishes `SessionAction`s directly via `onDidPublish` — no more clientId-based cross-session routing.

`ActiveClient` is now `Disposable`, owns its `SessionPluginController`, and forwards publish events into the session's progress stream. `setCustomizationEnabled` fans out to every session controller, matching Claude's per-session model. `sendMessage` retries any previously-failed client customization sync so a transient connection drop during reconnection doesn't pin the error until the active client changes again.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>