### PR TITLE
Stop exporting RunInTerminalTool from terminalContribChatExports (#318160)

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuestionCarouselPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuestionCarouselPart.ts
@@ -36,7 +36,7 @@ import { AccessibilityVerbositySettingId } from '../../../../accessibility/brows
 import { ScrollbarVisibility } from '../../../../../../base/common/scrollable.js';
 import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
-import { RunInTerminalTool } from '../../../../terminal/terminalContribChatExports.js';
+import { ITerminalChatService } from '../../../../terminal/browser/terminal.js';
 import './media/chatQuestionCarousel.css';
 
 const PREVIOUS_QUESTION_ACTION_ID = 'workbench.action.chat.previousQuestion';
@@ -105,6 +105,7 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 		@IKeybindingService private readonly _keybindingService: IKeybindingService,
 		@ICommandService private readonly _commandService: ICommandService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@ITerminalChatService private readonly _terminalChatService: ITerminalChatService,
 	) {
 		super();
 
@@ -207,9 +208,9 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 
 			// Dismiss the carousel when the user types directly in the terminal,
 			// since they are answering the prompt themselves.
-			const execution = RunInTerminalTool.getExecution(carousel.terminalId);
-			if (execution) {
-				interactiveStore.add(execution.instance.onDidInputData(() => {
+			const terminalInstance = this._terminalChatService.getTerminalInstanceByExecutionId(carousel.terminalId);
+			if (terminalInstance) {
+				interactiveStore.add(terminalInstance.onDidInputData(() => {
 					if (!this._isSkipped) {
 						if (carousel instanceof ChatQuestionCarouselData) {
 							carousel.dismissedByTerminalInput = true;

--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -153,6 +153,19 @@ export interface ITerminalChatService {
 	getTerminalInstanceByToolSessionId(terminalToolSessionId: string): Promise<ITerminalInstance | undefined>;
 
 	/**
+	 * Associate a terminal execution id (the per-invocation id used by `RunInTerminalTool`)
+	 * with a terminal instance. The association is automatically cleared when the instance is
+	 * disposed or when the returned disposable is disposed.
+	 */
+	registerTerminalInstanceWithExecutionId(terminalExecutionId: string, instance: ITerminalInstance): IDisposable;
+
+	/**
+	 * Resolve a terminal instance by its execution id (the per-invocation id used by
+	 * `RunInTerminalTool`). Returns undefined if no active execution exists for the id.
+	 */
+	getTerminalInstanceByExecutionId(terminalExecutionId: string): ITerminalInstance | undefined;
+
+	/**
 	 * Returns the list of terminal instances that have been registered with a tool session id.
 	 * This is used for surfacing tool-driven/background terminals in UI (eg. quick picks).
 	 */

--- a/src/vs/workbench/contrib/terminal/terminalContribChatExports.ts
+++ b/src/vs/workbench/contrib/terminal/terminalContribChatExports.ts
@@ -8,4 +8,3 @@
 // difficulties in removing the dependency. These are explicitly defined here to avoid an eslint
 // line override.
 export { MENU_CHAT_TERMINAL_TOOL_PROGRESS, TerminalChatContextKeys } from '../terminalContrib/chat/browser/terminalChat.js';
-export { RunInTerminalTool } from '../terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.js';

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatService.ts
@@ -175,14 +175,21 @@ export class TerminalChatService extends Disposable implements ITerminalChatServ
 	}
 
 	registerTerminalInstanceWithExecutionId(terminalExecutionId: string, instance: ITerminalInstance): IDisposable {
+		// If this id is already registered (re-registration), dispose the previous listener
+		// store first so we don't leak listeners. The new registration replaces the mapping
+		// and installs its own onDisposed listener below.
+		this._terminalInstanceListenersByExecutionId.deleteAndDispose(terminalExecutionId);
 		this._terminalInstancesByExecutionId.set(terminalExecutionId, instance);
+		const instanceStore = new DisposableStore();
 		const unregister = () => {
-			if (this._terminalInstancesByExecutionId.get(terminalExecutionId) === instance) {
-				this._terminalInstancesByExecutionId.delete(terminalExecutionId);
+			// Only tear down the mapping/listener if it still points at this instance.
+			// If a newer registration has replaced us, leave its state alone.
+			if (this._terminalInstancesByExecutionId.get(terminalExecutionId) !== instance) {
+				return;
 			}
+			this._terminalInstancesByExecutionId.delete(terminalExecutionId);
 			this._terminalInstanceListenersByExecutionId.deleteAndDispose(terminalExecutionId);
 		};
-		const instanceStore = new DisposableStore();
 		instanceStore.add(instance.onDisposed(unregister));
 		this._terminalInstanceListenersByExecutionId.set(terminalExecutionId, instanceStore);
 		return toDisposable(unregister);

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatService.ts
@@ -33,6 +33,8 @@ export class TerminalChatService extends Disposable implements ITerminalChatServ
 	private readonly _chatSessionResourceByTerminalInstance = new Map<ITerminalInstance, URI>();
 	private readonly _terminalInstanceListenersByToolSessionId = this._register(new DisposableMap<string, IDisposable>());
 	private readonly _chatSessionListenersByTerminalInstance = this._register(new DisposableMap<ITerminalInstance, IDisposable>());
+	private readonly _terminalInstancesByExecutionId = new Map<string, ITerminalInstance>();
+	private readonly _terminalInstanceListenersByExecutionId = this._register(new DisposableMap<string, IDisposable>());
 	private readonly _ahpCommandSources = new Map<string, IAhpTerminalCommandSource>();
 
 	private readonly _onDidContinueInBackground = this._register(new Emitter<string>());
@@ -170,6 +172,24 @@ export class TerminalChatService extends Disposable implements ITerminalChatServ
 
 	getToolSessionIdForInstance(instance: ITerminalInstance): string | undefined {
 		return this._toolSessionIdByTerminalInstance.get(instance);
+	}
+
+	registerTerminalInstanceWithExecutionId(terminalExecutionId: string, instance: ITerminalInstance): IDisposable {
+		this._terminalInstancesByExecutionId.set(terminalExecutionId, instance);
+		const unregister = () => {
+			if (this._terminalInstancesByExecutionId.get(terminalExecutionId) === instance) {
+				this._terminalInstancesByExecutionId.delete(terminalExecutionId);
+			}
+			this._terminalInstanceListenersByExecutionId.deleteAndDispose(terminalExecutionId);
+		};
+		const instanceStore = new DisposableStore();
+		instanceStore.add(instance.onDisposed(unregister));
+		this._terminalInstanceListenersByExecutionId.set(terminalExecutionId, instanceStore);
+		return toDisposable(unregister);
+	}
+
+	getTerminalInstanceByExecutionId(terminalExecutionId: string): ITerminalInstance | undefined {
+		return this._terminalInstancesByExecutionId.get(terminalExecutionId);
 	}
 
 	registerTerminalInstanceWithChatSession(chatSessionResource: URI, instance: ITerminalInstance): void {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -615,6 +615,23 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 	private static readonly _activeExecutions = new Map<string, IActiveTerminalExecution & { dispose(): void }>();
 
 	/**
+	 * Per-instance disposables that unregister `_activeExecutions` entries from the
+	 * `ITerminalChatService` execution-id map. Keyed by the same `termId` as `_activeExecutions`
+	 * so registrations and active executions share a lifecycle.
+	 */
+	private readonly _executionRegistrations = this._register(new DisposableMap<string, IDisposable>());
+
+	private _setActiveExecution(termId: string, execution: IActiveTerminalExecution & { dispose(): void }): void {
+		RunInTerminalTool._activeExecutions.set(termId, execution);
+		this._executionRegistrations.set(termId, this._terminalChatService.registerTerminalInstanceWithExecutionId(termId, execution.instance));
+	}
+
+	private _deleteActiveExecution(termId: string): boolean {
+		this._executionRegistrations.deleteAndDispose(termId);
+		return RunInTerminalTool._activeExecutions.delete(termId);
+	}
+
+	/**
 	 * Terminal IDs being programmatically disposed (by `kill_terminal` or
 	 * automatic background-terminal cleanup). Used to suppress the redundant
 	 * "terminal exited" steering message in `_registerCompletionNotification`'s
@@ -1850,7 +1867,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			);
 			this._logService.info(`RunInTerminalTool: Using \`${execution.strategy.type}\` execute strategy for command \`${command}\``);
 			store.add(execution);
-			RunInTerminalTool._activeExecutions.set(termId, execution);
+			this._setActiveExecution(termId, execution);
 
 			// Set up OutputMonitor when start marker is created
 			const startMarkerPromise = Event.toPromise(execution.strategy.onDidCreateStartMarker);
@@ -2152,7 +2169,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 				}
 				// Clean up the execution on error
 				RunInTerminalTool._activeExecutions.get(termId)?.dispose();
-				RunInTerminalTool._activeExecutions.delete(termId);
+				this._deleteActiveExecution(termId);
 				toolTerminal.instance.dispose();
 				error = e instanceof CancellationError ? 'canceled' : 'unexpectedException';
 				throw e;
@@ -2183,7 +2200,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			} else {
 				// Foreground completed or error - clean up execution and output monitor
 				RunInTerminalTool._activeExecutions.get(termId)?.dispose();
-				RunInTerminalTool._activeExecutions.delete(termId);
+				this._deleteActiveExecution(termId);
 				outputMonitor?.dispose();
 			}
 			store.dispose();
@@ -2567,7 +2584,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 						this._addSessionTerminalAssociation(chatSessionResource, toolTerminal);
 						this._terminalChatService.registerTerminalInstanceWithChatSession(chatSessionResource, instance);
 						if (association.id) {
-							RunInTerminalTool._activeExecutions.set(association.id, this._register(new RestoredTerminalExecution(instance)));
+							this._setActiveExecution(association.id, this._register(new RestoredTerminalExecution(instance)));
 						}
 
 						// Listen for terminal disposal to clean up storage
@@ -2666,7 +2683,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			}
 		}
 		for (const termId of terminalToRemove) {
-			RunInTerminalTool._activeExecutions.delete(termId);
+			this._deleteActiveExecution(termId);
 		}
 	}
 
@@ -2732,7 +2749,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			}
 		}
 		for (const termId of executionIdsToRemove) {
-			RunInTerminalTool._activeExecutions.delete(termId);
+			this._deleteActiveExecution(termId);
 		}
 	}
 
@@ -3001,7 +3018,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 				// send a redundant "terminal exited" steering message.
 				RunInTerminalTool._killedByTool.add(termId);
 				execution.dispose();
-				RunInTerminalTool._activeExecutions.delete(termId);
+				this._deleteActiveExecution(termId);
 				terminalInstance.dispose();
 			});
 		}));
@@ -3064,7 +3081,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			if (e.kind === 'removeRequest') {
 				this._logService.debug(`RunInTerminalTool: Request removed from session, cleaning up background terminal ${termId}`);
 				RunInTerminalTool._activeExecutions.get(termId)?.dispose();
-				RunInTerminalTool._activeExecutions.delete(termId);
+				this._deleteActiveExecution(termId);
 				disposeNotification();
 				terminalInstance.dispose();
 			}

--- a/src/vs/workbench/test/browser/componentFixtures/chat/chatQuestionCarousel.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/chat/chatQuestionCarousel.fixture.ts
@@ -13,6 +13,7 @@ import { mock, upcastPartial } from '../../../../../base/test/common/mock.js';
 import { Event } from '../../../../../base/common/event.js';
 import { observableValue } from '../../../../../base/common/observable.js';
 import { IChatRequestViewModel } from '../../../../contrib/chat/common/model/chatViewModel.js';
+import { ITerminalChatService } from '../../../../contrib/terminal/browser/terminal.js';
 import '../../../../contrib/chat/browser/widget/chatContentParts/media/chatQuestionCarousel.css';
 
 function createCarousel(questions: IChatQuestion[], allowSkip: boolean = true): IChatQuestionCarousel {
@@ -53,6 +54,9 @@ function renderCarousel(context: ComponentFixtureContext, carousel: IChatQuestio
 	const instantiationService = createEditorServices(disposableStore, {
 		additionalServices: (reg) => {
 			reg.define(IMarkdownRendererService, MarkdownRendererService);
+			reg.definePartialInstance(ITerminalChatService, {
+				getTerminalInstanceByExecutionId: () => undefined,
+			});
 		},
 	});
 


### PR DESCRIPTION
Fixes #318160

Stops exporting `RunInTerminalTool` from `terminalContribChatExports.ts`. The only outside consumer (`chatQuestionCarouselPart`) just needed the underlying `ITerminalInstance` for a given execution id in order to attach an `onDidInputData` listener, so I exposed that on `ITerminalChatService` instead.
