### PR TITLE
Fix Anthropic 400 on empty-text thinking blocks

### DIFF
--- a/extensions/copilot/src/extension/prompt/common/toolCallRound.ts
+++ b/extensions/copilot/src/extension/prompt/common/toolCallRound.ts
@@ -70,6 +70,7 @@ export class ThinkingDataItem implements ThinkingData {
 	public metadata?: { [key: string]: any };
 	public tokens?: number;
 	public encrypted?: string;
+	public redacted?: boolean;
 
 	static createOrUpdate(item: ThinkingDataItem | undefined, delta: ThinkingDelta) {
 		if (!item) {
@@ -90,6 +91,9 @@ export class ThinkingDataItem implements ThinkingData {
 		}
 		if (isEncryptedThinkingDelta(delta)) {
 			this.encrypted = delta.encrypted;
+			if (delta.redacted !== undefined) {
+				this.redacted = delta.redacted;
+			}
 		}
 		if (delta.text !== undefined) {
 

--- a/extensions/copilot/src/platform/endpoint/node/messagesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/messagesApi.ts
@@ -458,23 +458,27 @@ function rawContentToAnthropicContent(content: readonly Raw.ChatCompletionConten
 			}
 			case Raw.ChatCompletionContentPartKind.Opaque: {
 				if (part.value && typeof part.value === 'object' && 'type' in part.value) {
-					const opaqueValue = part.value as { type: string; thinking?: { id: string; text?: string | string[]; encrypted?: string } };
+					const opaqueValue = part.value as { type: string; thinking?: { id: string; text?: string | string[]; encrypted?: string; redacted?: boolean } };
 					if (opaqueValue.type === 'thinking' && opaqueValue.thinking) {
 						const thinkingText = Array.isArray(opaqueValue.thinking.text)
 							? opaqueValue.thinking.text.join('')
 							: opaqueValue.thinking.text;
-						if (thinkingText && opaqueValue.thinking.encrypted) {
-							// Regular thinking block: text is present, encrypted field contains the signature
-							convertedContent.push({
-								type: 'thinking',
-								thinking: thinkingText,
-								signature: opaqueValue.thinking.encrypted,
-							});
-						} else if (opaqueValue.thinking.encrypted && !thinkingText) {
-							// Redacted thinking block: no text, only encrypted data from Claude
+						if (opaqueValue.thinking.redacted && opaqueValue.thinking.encrypted) {
+							// Genuine redacted_thinking block: `encrypted` holds the opaque `data` blob.
 							convertedContent.push({
 								type: 'redacted_thinking',
 								data: opaqueValue.thinking.encrypted,
+							});
+						} else if (opaqueValue.thinking.encrypted) {
+							// Regular thinking block: `encrypted` holds the signature. The text may be
+							// empty (e.g. `display: "omitted"` or pruned under token budget); the Anthropic
+							// API still accepts a thinking block with an empty `thinking` field as long as
+							// the signature is intact. We must NEVER ship the signature as redacted `data`,
+							// which the API rejects with "Invalid 'data' in 'redacted_thinking' block".
+							convertedContent.push({
+								type: 'thinking',
+								thinking: thinkingText || '',
+								signature: opaqueValue.thinking.encrypted,
 							});
 						}
 					}
@@ -1113,6 +1117,7 @@ export class AnthropicMessagesProcessor {
 						thinking: {
 							id: `thinking_${chunk.index}`,
 							encrypted: data,
+							redacted: true,
 						}
 					});
 				}

--- a/extensions/copilot/src/platform/endpoint/test/node/messagesApi.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/test/node/messagesApi.spec.ts
@@ -11,6 +11,7 @@ import { IInstantiationService } from '../../../../util/vs/platform/instantiatio
 import { ChatLocation } from '../../../chat/common/commonTypes';
 import { AnthropicMessagesTool, CUSTOM_TOOL_SEARCH_NAME, isExtendedCacheTtlEnabled, isExtendedCacheTtlMessagesEnabled, modelSupportsExtendedCacheTtl, modelSupportsMemory } from '../../../networking/common/anthropic';
 import { IChatEndpoint, ICreateEndpointBodyOptions } from '../../../networking/common/networking';
+import { FinishedCallback, IResponseDelta } from '../../../networking/common/fetch';
 import { IToolDeferralService } from '../../../networking/common/toolDeferralService';
 import { createPlatformServices } from '../../../test/node/services';
 import { addMessagesApiCacheControl, addToolsAndSystemCacheControl, AnthropicMessagesProcessor, buildToolInputSchema, clearAllCacheControl, createMessagesRequestBody, processNonStreamingResponseFromMessagesEndpoint, processResponseFromMessagesEndpoint, rawMessagesToMessagesAPI } from '../../node/messagesApi';
@@ -408,6 +409,43 @@ suite('rawMessagesToMessagesAPI', function () {
 			type: 'text',
 			text: 'hello world',
 			cache_control: { type: 'ephemeral' },
+		});
+	});
+
+	suite('thinking blocks', function () {
+		function assistantWithThinking(thinking: { id: string; text?: string | string[]; encrypted?: string; redacted?: boolean }): Raw.ChatMessage[] {
+			return [
+				{
+					role: Raw.ChatRole.Assistant,
+					content: [
+						{ type: Raw.ChatCompletionContentPartKind.Opaque, value: { type: 'thinking', thinking } },
+						{ type: Raw.ChatCompletionContentPartKind.Text, text: 'answer' },
+					],
+				},
+			];
+		}
+
+		test('regular thinking block with text + signature emits a thinking block', function () {
+			const result = rawMessagesToMessagesAPI(assistantWithThinking({ id: 't1', text: 'reasoning', encrypted: 'sig123' }));
+			const content = assertContentArray(result.messages[0].content);
+			expect(content[0]).toEqual({ type: 'thinking', thinking: 'reasoning', signature: 'sig123' });
+		});
+
+		test('empty-text block with a signature stays a thinking block (never redacted_thinking)', function () {
+			// Regression: `display: "omitted"` or budget-pruned thinking has an empty `thinking`
+			// field but a valid signature. Previously this was misclassified as a redacted_thinking
+			// block and shipped the signature as `data`, which the Anthropic API rejects with
+			// "Invalid 'data' in 'redacted_thinking' block".
+			const result = rawMessagesToMessagesAPI(assistantWithThinking({ id: 't1', text: '', encrypted: 'sig123' }));
+			const content = assertContentArray(result.messages[0].content);
+			expect(content[0]).toEqual({ type: 'thinking', thinking: '', signature: 'sig123' });
+			expect(content.some(b => b.type === 'redacted_thinking')).toBe(false);
+		});
+
+		test('genuine redacted block (redacted=true) emits a redacted_thinking block with data', function () {
+			const result = rawMessagesToMessagesAPI(assistantWithThinking({ id: 't1', text: '', encrypted: 'blob123', redacted: true }));
+			const content = assertContentArray(result.messages[0].content);
+			expect(content[0]).toEqual({ type: 'redacted_thinking', data: 'blob123' });
 		});
 	});
 });
@@ -1703,6 +1741,39 @@ suite('AnthropicMessagesProcessor streaming cache_creation', () => {
 			new NullTelemetryService(),
 		);
 	}
+
+	test('redacted_thinking content block propagates redacted:true on the thinking delta', () => {
+		// Regression: the converter relies on an explicit `redacted` flag (not empty text)
+		// to decide redacted_thinking vs thinking. The streaming accumulator must set it.
+		const processor = makeProcessor();
+		const deltas: IResponseDelta[] = [];
+		const capture: FinishedCallback = async (_text, _idx, delta) => { deltas.push(delta); return undefined; };
+
+		processor.push({
+			type: 'content_block_start',
+			index: 0,
+			content_block: { type: 'redacted_thinking', data: 'blob123' },
+		} as Parameters<typeof processor.push>[0], capture);
+
+		const thinkingDeltas = deltas.filter(d => d.thinking).map(d => d.thinking);
+		expect(thinkingDeltas).toHaveLength(1);
+		expect(thinkingDeltas[0]).toEqual({ id: 'thinking_0', encrypted: 'blob123', redacted: true });
+	});
+
+	test('regular thinking content block emits a signature without the redacted flag', () => {
+		const processor = makeProcessor();
+		const deltas: IResponseDelta[] = [];
+		const capture: FinishedCallback = async (_text, _idx, delta) => { deltas.push(delta); return undefined; };
+
+		processor.push({ type: 'content_block_start', index: 0, content_block: { type: 'thinking', thinking: '', signature: '' } } as Parameters<typeof processor.push>[0], capture);
+		processor.push({ type: 'content_block_delta', index: 0, delta: { type: 'signature_delta', signature: 'sig123' } } as Parameters<typeof processor.push>[0], capture);
+		processor.push({ type: 'content_block_stop', index: 0 } as Parameters<typeof processor.push>[0], capture);
+
+		const thinkingDeltas = deltas.filter(d => d.thinking).map(d => d.thinking);
+		expect(thinkingDeltas).toHaveLength(1);
+		expect(thinkingDeltas[0]).toEqual({ id: 'thinking_0', encrypted: 'sig123' });
+		expect((thinkingDeltas[0] as { redacted?: boolean }).redacted).toBeUndefined();
+	});
 
 	test('message_start cache_creation survives a message_delta that omits the breakdown', () => {
 		// Production happy path: Anthropic only emits the cache_creation breakdown

--- a/extensions/copilot/src/platform/thinking/common/thinking.ts
+++ b/extensions/copilot/src/platform/thinking/common/thinking.ts
@@ -56,6 +56,13 @@ export type EncryptedThinkingDelta = {
 	id: string;
 	text?: string;
 	encrypted: string;
+	/**
+	 * True only for genuine Anthropic `redacted_thinking` blocks, where `encrypted`
+	 * holds the opaque `data` blob. For regular thinking blocks `encrypted` holds the
+	 * signature and this is false/undefined, even when the thinking text is empty
+	 * (e.g. `display: "omitted"` or pruned under token budget).
+	 */
+	redacted?: boolean;
 };
 
 export function isEncryptedThinkingDelta(delta: ThinkingDelta | EncryptedThinkingDelta): delta is EncryptedThinkingDelta {
@@ -68,4 +75,10 @@ export interface ThinkingData {
 	metadata?: { [key: string]: any };
 	tokens?: number;
 	encrypted?: string;
+	/**
+	 * True only for genuine Anthropic `redacted_thinking` blocks, where `encrypted`
+	 * holds the opaque `data` blob. For regular thinking blocks `encrypted` holds the
+	 * signature and this is false/undefined, even when the thinking text is empty.
+	 */
+	redacted?: boolean;
 }


### PR DESCRIPTION
A regular Anthropic `thinking` block with an empty text field but a valid signature (`display: "omitted"` or pruned) was misclassified as `redacted_thinking` and shipped the signature in the `data` field, which Anthropic rejects with `Invalid 'data' in 'redacted_thinking' block` (and the generic `invalid_request_body`).

Track redacted-ness with an explicit `redacted` flag instead of inferring it from missing text. Empty-text-with-signature now stays a valid `thinking` block; only genuine redacted blocks emit `redacted_thinking`.

Observed when switching models -> auto mode.

Adds regression tests for both the converter and the streaming accumulator.