### PR TITLE
Fix Responses API reasoning ID round-trip

### DIFF
--- a/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
@@ -567,11 +567,27 @@ function rawContentToResponsesAssistantContent(part: Raw.ChatCompletionContentPa
 	}
 }
 
+/**
+ * The Responses API rejects the entire request with
+ * `400 invalid_request_body: Invalid 'input[N].id': '...'. Expected an ID that begins with 'rs'.`
+ * when a reasoning item is round-tripped with an id it did not issue. Reasoning items
+ * produced by the Responses API always carry an id beginning with `rs`. Thinking blocks
+ * that originated from a different API (e.g. the Anthropic Messages API, whose accumulator
+ * generates `thinking_<index>` ids) can leak into a Responses request — most notably via the
+ * `vscode.lm` access path, which has no model gate — and their `encrypted_content` is not a
+ * valid Responses reasoning blob anyway. Such foreign reasoning items must be dropped, not sent.
+ */
+function isResponsesReasoningId(id: string | undefined): boolean {
+	return typeof id === 'string' && id.startsWith('rs');
+}
+
 function extractThinkingData(content: Raw.ChatCompletionContentPart[]): OpenAI.Responses.ResponseReasoningItem[] {
 	return coalesce(content.map(part => {
 		if (part.type === Raw.ChatCompletionContentPartKind.Opaque) {
 			const thinkingData = rawPartAsThinkingData(part);
-			if (thinkingData) {
+			// Only round-trip genuine Responses API reasoning items. A foreign id (or a thinking
+			// block with no encrypted payload) would otherwise 400 the whole request.
+			if (thinkingData && thinkingData.encrypted && isResponsesReasoningId(thinkingData.id)) {
 				return {
 					type: 'reasoning',
 					id: thinkingData.id,

--- a/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
@@ -19,6 +19,7 @@ import { TelemetryData } from '../../../telemetry/common/telemetryData';
 import { SpyingTelemetryService } from '../../../telemetry/node/spyingTelemetryService';
 import { createFakeStreamResponse } from '../../../test/node/fetcher';
 import { createPlatformServices } from '../../../test/node/services';
+import type { ThinkingData } from '../../../thinking/common/thinking';
 import { CustomDataPartMimeTypes } from '../../common/endpointTypes';
 import { createResponsesRequestBody, getResponsesApiCompactionThresholdFromBody, processResponseFromChatEndpoint, responseApiInputToRawMessagesForLogging } from '../responsesApi';
 
@@ -98,7 +99,7 @@ const createCompactionAssistantMessage = (compaction: OpenAIContextManagementRes
 	}]
 });
 
-const createThinkingAssistantMessage = (thinking: { id: string; text?: string | string[]; encrypted?: string }): Raw.ChatMessage => ({
+const createThinkingAssistantMessage = (thinking: ThinkingData): Raw.ChatMessage => ({
 	role: Raw.ChatRole.Assistant,
 	content: [
 		{

--- a/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
@@ -98,6 +98,17 @@ const createCompactionAssistantMessage = (compaction: OpenAIContextManagementRes
 	}]
 });
 
+const createThinkingAssistantMessage = (thinking: { id: string; text?: string | string[]; encrypted?: string }): Raw.ChatMessage => ({
+	role: Raw.ChatRole.Assistant,
+	content: [
+		{
+			type: Raw.ChatCompletionContentPartKind.Opaque,
+			value: { type: CustomDataPartMimeTypes.ThinkingData, thinking },
+		},
+		{ type: Raw.ChatCompletionContentPartKind.Text, text: 'answer' },
+	],
+});
+
 type ResponseFunctionCallInputItem = OpenAI.Responses.ResponseInputItem & {
 	type: 'function_call';
 	name: string;
@@ -363,6 +374,38 @@ describe('createResponsesRequestBody', () => {
 				compact_threshold: 1234,
 			}]
 		})).toBe(1234);
+	});
+
+	it('round-trips a genuine Responses reasoning item (id begins with "rs")', () => {
+		const services = createPlatformServices();
+		const accessor = services.createTestingAccessor();
+		const instantiationService = accessor.get(IInstantiationService);
+		const messages = [createThinkingAssistantMessage({ id: 'rs_abc123', text: 'reasoning', encrypted: 'enc_blob' })];
+
+		const body = instantiationService.invokeFunction(servicesAccessor => createResponsesRequestBody(servicesAccessor, createRequestOptions(messages, false), testEndpoint.model, testEndpoint));
+
+		expect(body.input).toContainEqual({ type: 'reasoning', id: 'rs_abc123', summary: [], encrypted_content: 'enc_blob' });
+
+		accessor.dispose();
+		services.dispose();
+	});
+
+	it('drops foreign thinking (Messages API "thinking_N" id) so it cannot 400 the Responses request', () => {
+		// Reproduces "400 invalid_request_body: Invalid 'input[N].id': 'thinking_0'. Expected an
+		// ID that begins with 'rs'." Anthropic Messages-API thinking leaks into a Responses
+		// request (e.g. via the vscode.lm path); its id and encrypted payload are foreign and
+		// must not be round-tripped.
+		const services = createPlatformServices();
+		const accessor = services.createTestingAccessor();
+		const instantiationService = accessor.get(IInstantiationService);
+		const messages = [createThinkingAssistantMessage({ id: 'thinking_0', text: '', encrypted: 'sig_from_anthropic' })];
+
+		const body = instantiationService.invokeFunction(servicesAccessor => createResponsesRequestBody(servicesAccessor, createRequestOptions(messages, false), testEndpoint.model, testEndpoint));
+
+		expect(body.input?.some(item => item.type === 'reasoning')).toBe(false);
+
+		accessor.dispose();
+		services.dispose();
 	});
 
 	it('converts PDF document content parts to Responses input_file', () => {


### PR DESCRIPTION
Drop foreign thinking payloads when building Responses API reasoning input.

Only round-trip genuine Responses reasoning items with `rs`-prefixed ids, preventing `invalid_request_body` failures for leaked `thinking_0` ids.

Adds regression coverage for valid `rs_*` reasoning and foreign `thinking_0` dropping.