### PR TITLE
agentHost: extract Copilot session launcher

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CopilotClient, ResumeSessionConfig, RuntimeConnection, type CopilotClientOptions, type SessionConfig } from '@github/copilot-sdk';
+import { CopilotClient, RuntimeConnection, type CopilotClientOptions } from '@github/copilot-sdk';
 import * as fs from 'fs/promises';
 import { Limiter, SequencerByKey, Throttler } from '../../../../base/common/async.js';
 import { CancellationTokenSource, type CancellationToken } from '../../../../base/common/cancellation.js';
@@ -13,7 +13,7 @@ import { Emitter, Event } from '../../../../base/common/event.js';
 import { appendEscapedMarkdownInlineCode } from '../../../../base/common/htmlContent.js';
 import { Disposable, DisposableMap, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { ResourceMap } from '../../../../base/common/map.js';
-import { FileAccess, Schemas } from '../../../../base/common/network.js';
+import { FileAccess } from '../../../../base/common/network.js';
 import { equals } from '../../../../base/common/objects.js';
 import { observableValue } from '../../../../base/common/observable.js';
 import { basename, delimiter, dirname } from '../../../../base/common/path.js';
@@ -41,65 +41,19 @@ import { IAgentHostOTelService } from '../../common/otel/agentHostOTelService.js
 import { IAgentHostCompletions } from '../agentHostCompletions.js';
 import { IAgentHostGitService, META_DIFF_BASE_BRANCH } from '../agentHostGitService.js';
 import { IAgentHostCheckpointService } from '../../common/agentHostCheckpointService.js';
-import { IAgentHostTerminalManager } from '../agentHostTerminalManager.js';
-import { CopilotAgentSession, SessionWrapperFactory, type CopilotSdkMode, type IActiveClientSnapshot } from './copilotAgentSession.js';
+import { CopilotAgentSession, type CopilotSdkMode } from './copilotAgentSession.js';
 import { ICopilotSessionContext, projectFromCopilotContext } from './copilotGitProject.js';
-import { parsedPluginsEqual, toChildCustomizations, toSdkCustomAgents, toSdkHooks, toSdkInstructionDirectories, toSdkMcpServers, toSdkSkillDirectories } from './copilotPluginConverters.js';
-import { CopilotSessionWrapper } from './copilotSessionWrapper.js';
-import { ShellManager, createShellTools } from './copilotShellTools.js';
+import { parsedPluginsEqual, toChildCustomizations } from './copilotPluginConverters.js';
+import { ShellManager } from './copilotShellTools.js';
+import { CopilotSessionLauncher, ThinkingLevelConfigKey, getCopilotReasoningEffort, type CopilotSessionLaunchPlan, type IActiveClientSnapshot } from './copilotSessionLauncher.js';
 import { DiscoveredType, SessionCustomizationDiscovery, type IDiscoveredDirectory } from './sessionCustomizationDiscovery.js';
 import { SessionPluginBundler } from '../shared/sessionPluginBundler.js';
 import { CopilotSlashCommandCompletionProvider } from './copilotSlashCommandCompletionProvider.js';
 import { getEffectiveAgents } from '../../common/customAgents.js';
-import { coalesce } from '../../../../base/common/arrays.js';
 
 interface ICreatedWorktree {
 	readonly repositoryRoot: URI;
 	readonly worktree: URI;
-}
-
-function getCopilotSdkErrorCode(err: unknown): number | undefined {
-	if (typeof err !== 'object' || err === null) {
-		return undefined;
-	}
-	const code = Object.getOwnPropertyDescriptor(err, 'code')?.value;
-	return typeof code === 'number' ? code : undefined;
-}
-
-function getErrorMessage(err: unknown): string {
-	if (err instanceof Error) {
-		return err.message;
-	}
-	if (typeof err === 'object' && err !== null) {
-		const message = Object.getOwnPropertyDescriptor(err, 'message')?.value;
-		if (typeof message === 'string') {
-			return message;
-		}
-	}
-	return String(err);
-}
-
-/**
- * Decide whether a Copilot SDK `resumeSession` failure should fall back to
- * `createSession({ sessionId })`. We want to preserve the original
- * recovery for empty / truncated sessions (e.g. after the user invoked
- * "Start Over", which calls `truncateSession` and leaves the on-disk
- * session with zero events — the SDK then refuses to resume it), but we
- * must NOT silently swallow corruption / schema-validation / parse
- * failures: those should surface so the user sees the real error and the
- * original session contents are not masked by a fresh empty session.
- *
- * Heuristic: any `-32603` Internal Error is treated as the empty-session
- * case UNLESS the message clearly indicates corruption, schema
- * validation, parse failure, or malformed input.
- */
-function shouldCreateEmptySessionAfterResumeError(err: unknown): boolean {
-	if (getCopilotSdkErrorCode(err) !== -32603) {
-		return false;
-	}
-
-	const message = getErrorMessage(err);
-	return !/\b(corrupt|corrupted|invalid|validation|schema|must be|parse|malformed|unexpected token)\b/i.test(message);
 }
 
 export type ICopilotPluginInfo = IParsedPlugin & { readonly pluginDir?: URI };
@@ -140,19 +94,7 @@ interface IProvisionalSession {
 	readonly project: IAgentSessionProjectInfo | undefined;
 }
 
-const ThinkingLevelConfigKey = 'thinkingLevel';
-const ReasoningEfforts = ['low', 'medium', 'high', 'xhigh'] as const;
-type ReasoningEffort = NonNullable<SessionConfig['reasoningEffort']>;
-
-export const COPILOT_AGENT_HOST_SYSTEM_MESSAGE = {
-	mode: 'customize',
-	sections: {
-		identity: {
-			action: 'replace',
-			content: 'You are an AI assistant using Copilot CLI runtime in VS Code. You help users with software engineering tasks. When asked about your identity, you must state that you are an AI assistant using Copilot CLI runtime in VS Code.',
-		},
-	},
-} satisfies NonNullable<ResumeSessionConfig['systemMessage']>;
+export { COPILOT_AGENT_HOST_SYSTEM_MESSAGE } from './copilotSessionLauncher.js';
 
 interface ISerializedModelSelection {
 	id?: unknown;
@@ -191,10 +133,6 @@ export interface IExitPlanModeResponse {
 	readonly selectedAction?: string;
 	readonly autoApproveEdits?: boolean;
 	readonly feedback?: string;
-}
-
-function isReasoningEffort(value: string | undefined): value is ReasoningEffort {
-	return ReasoningEfforts.some(reasoningEffort => reasoningEffort === value);
 }
 
 export function getCopilotWorktreesRoot(repositoryRoot: URI): URI {
@@ -326,6 +264,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 	private readonly _sessionSequencer = new SequencerByKey<string>();
 	private _shutdownPromise: Promise<void> | undefined;
 	private readonly _plugins: PluginController;
+	private readonly _sessionLauncher: CopilotSessionLauncher;
 	readonly onDidCustomizationsChange: Event<void>;
 	/** Per-session active client state for tools + plugin snapshot tracking. */
 	private readonly _activeClients = new ResourceMap<ActiveClient>();
@@ -333,10 +272,8 @@ export class CopilotAgent extends Disposable implements IAgent {
 	constructor(
 		@ILogService private readonly _logService: ILogService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
-		@IFileService private readonly _fileService: IFileService,
 		@ISessionDataService private readonly _sessionDataService: ISessionDataService,
 		@IAgentHostGitService private readonly _gitService: IAgentHostGitService,
-		@IAgentHostTerminalManager private readonly _terminalManager: IAgentHostTerminalManager,
 		@IAgentConfigurationService private readonly _configurationService: IAgentConfigurationService,
 		@IAgentHostOTelService private readonly _otelService: IAgentHostOTelService,
 		@IAgentHostCompletions completions: IAgentHostCompletions,
@@ -344,6 +281,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 	) {
 		super();
 		this._plugins = this._register(this._instantiationService.createInstance(PluginController));
+		this._sessionLauncher = this._instantiationService.createInstance(CopilotSessionLauncher);
 		this.onDidCustomizationsChange = this._plugins.onDidChange;
 		this._register(completions.registerProvider(new CopilotSlashCommandCompletionProvider(this.id, {
 			hasHistory: (sessionId) => !this._provisionalSessions.has(sessionId) && this._sessions.has(sessionId),
@@ -646,11 +584,6 @@ export class CopilotAgent extends Disposable implements IAgent {
 				},
 			},
 		};
-	}
-
-	private _getReasoningEffort(model: ModelSelection | undefined): SessionConfig['reasoningEffort'] {
-		const thinkingLevel = model?.config?.[ThinkingLevelConfigKey];
-		return isReasoningEffort(thinkingLevel) ? thinkingLevel : undefined;
 	}
 
 	private _serializeModelSelection(model: ModelSelection): string {
@@ -1000,25 +933,22 @@ export class CopilotAgent extends Disposable implements IAgent {
 		const snapshot = await activeClient.snapshot();
 		const workingDirectory = await this._resolveSessionWorkingDirectory(materializedConfig, sessionId, prompt);
 		const shellManager = this._instantiationService.createInstance(ShellManager, sessionUri, workingDirectory);
-		const sessionConfigBuilder = this._buildSessionConfig(snapshot, shellManager, workingDirectory);
-
-		const factory: SessionWrapperFactory = async callbacks => {
-			const resolvedAgentName = provisional.agent ? await this._resolveAgentName(provisional.sessionUri, snapshot, provisional.agent) : undefined;
-			const raw = await client.createSession({
-				model: provisional.model?.id,
-				reasoningEffort: this._getReasoningEffort(provisional.model),
-				...(resolvedAgentName ? { agent: resolvedAgentName } : {}),
-				sessionId,
-				streaming: true,
-				workingDirectory: workingDirectory?.fsPath,
-				...await sessionConfigBuilder(callbacks),
-			});
-			return new CopilotSessionWrapper(raw);
-		};
 
 		let agentSession: CopilotAgentSession | undefined;
 		try {
-			agentSession = this._createAgentSession(factory, sessionId, shellManager, workingDirectory, customizationDirectory, snapshot);
+			const resolvedAgentName = provisional.agent ? await this._resolveAgentName(provisional.sessionUri, snapshot, provisional.agent) : undefined;
+			const launchPlan: CopilotSessionLaunchPlan = {
+				kind: 'create',
+				client,
+				sessionId,
+				workingDirectory,
+				resolvedAgentName,
+				snapshot,
+				shellManager,
+				githubToken: this._githubToken,
+				model: provisional.model,
+			};
+			agentSession = this._createAgentSession(launchPlan, customizationDirectory);
 			await agentSession.initializeSession();
 			this._registerInitializedSession(sessionId, agentSession);
 		} catch (error) {
@@ -1464,7 +1394,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 		}
 		const entry = this._sessions.get(sessionId);
 		if (entry) {
-			await entry.setModel(model.id, this._getReasoningEffort(model));
+			await entry.setModel(model.id, getCopilotReasoningEffort(model));
 		}
 		await this._storeSessionMetadata(session, model, undefined, undefined, undefined);
 	}
@@ -1548,20 +1478,21 @@ export class CopilotAgent extends Disposable implements IAgent {
 	 * {@link _resumeSession} for the same id cannot dispose this entry mid-init
 	 * via {@link DisposableMap.set}.
 	 */
-	private _createAgentSession(wrapperFactory: SessionWrapperFactory, sessionId: string, shellManager: ShellManager, workingDirectory: URI | undefined, customizationDirectory: URI | undefined, snapshot?: IActiveClientSnapshot): CopilotAgentSession {
-		const sessionUri = AgentSession.uri(this.id, sessionId);
+	private _createAgentSession(launchPlan: CopilotSessionLaunchPlan, customizationDirectory: URI | undefined): CopilotAgentSession {
+		const sessionUri = AgentSession.uri(this.id, launchPlan.sessionId);
 
 		const agentSession = this._instantiationService.createInstance(
 			CopilotAgentSession,
 			{
 				sessionUri,
-				rawSessionId: sessionId,
+				rawSessionId: launchPlan.sessionId,
 				onDidSessionProgress: this._onDidSessionProgress,
-				wrapperFactory,
-				shellManager,
-				workingDirectory,
+				sessionLauncher: this._sessionLauncher,
+				launchPlan,
+				shellManager: launchPlan.shellManager,
+				workingDirectory: launchPlan.workingDirectory,
 				customizationDirectory,
-				clientSnapshot: snapshot,
+				clientSnapshot: launchPlan.snapshot,
 			},
 		);
 
@@ -1614,63 +1545,6 @@ export class CopilotAgent extends Disposable implements IAgent {
 		await this._removeCreatedWorktree(sessionId);
 	}
 
-	/**
-	 * Builds the common session configuration (plugins + shell tools) shared
-	 * by both {@link createSession} and {@link _resumeSession}.
-	 *
-	 * Returns an async function that resolves the final config given the
-	 * session's permission/hook callbacks, so it can be called lazily
-	 * inside the {@link SessionWrapperFactory}.
-	 */
-	private _buildSessionConfig(snapshot: IActiveClientSnapshot, shellManager: ShellManager, workingDirectory: URI | undefined): (args: Parameters<SessionWrapperFactory>[0]) => Promise<ResumeSessionConfig> {
-		const plugins = snapshot.plugins;
-
-		return async (callbacks: Parameters<SessionWrapperFactory>[0]) => {
-			const enableCustomTerminalTool = this._configurationService.getRootValue(agentHostCustomizationConfigSchema, AgentHostConfigKey.EnableCustomTerminalTool) === true;
-			const shellTools = enableCustomTerminalTool ? await createShellTools(shellManager, this._terminalManager, this._logService, callbacks.requestUnsandboxedCommandConfirmation) : [];
-			// Rely on SDK to find all agents/skills & the like from the plugins instead of us feeding them.
-			// Else we could end up with duplicates or the like.
-			const pluginsWithoutDirs = plugins.filter(p => !p.pluginDir || p.pluginDir.scheme !== Schemas.file);
-			const customAgents = await toSdkCustomAgents(pluginsWithoutDirs.flatMap(p => p.agents), this._fileService);
-			return {
-				clientName: 'vscode',
-				onPermissionRequest: callbacks.onPermissionRequest,
-				onUserInputRequest: callbacks.onUserInputRequest,
-				onElicitationRequest: callbacks.onElicitationRequest,
-				hooks: toSdkHooks(pluginsWithoutDirs.flatMap(p => p.hooks), callbacks.hooks),
-				mcpServers: toSdkMcpServers(pluginsWithoutDirs.flatMap(p => p.mcpServers)),
-				onExitPlanModeRequest: callbacks.onExitPlanModeRequest,
-				workingDirectory: workingDirectory?.fsPath,
-				customAgents,
-				skillDirectories: toSdkSkillDirectories(pluginsWithoutDirs.flatMap(p => p.skills)),
-				instructionDirectories: toSdkInstructionDirectories(plugins.flatMap(p => p.instructions)),
-				systemMessage: COPILOT_AGENT_HOST_SYSTEM_MESSAGE,
-				pluginDirectories: coalesce(plugins.map(p => p.pluginDir))
-					.filter(d => d.scheme === Schemas.file).map(d => d.fsPath),
-				tools: [...shellTools, ...callbacks.clientTools],
-				// Pass the GitHub token at the session level. The SDK's
-				// client-level `gitHubToken` authenticates the CLI process,
-				// but each session also needs its own token resolved into a
-				// GitHub identity (login, Copilot plan, endpoints) to drive
-				// model routing and quota — without this the session
-				// errors with "Session was not created with authentication
-				// info or custom provider" on first send. See #318693.
-				gitHubToken: this._githubToken,
-				// Enable infinite sessions so the SDK provisions a workspace
-				// directory (containing `plan.md`, `checkpoints/`, `files/`).
-				// The workspace is required for plan mode to work — without
-				// it, `rpc.plan.read()` returns `path: null` and the SDK
-				// never emits `exit_plan_mode.requested`.
-				infiniteSessions: { enabled: true },
-				// Per-session remote export: the client-level `--remote` flag
-				// (enableRemoteSessions) enables the CLI *capability*, but each
-				// session must opt in via `remoteSession` to actually export
-				// events. Without this, sessions default to "off".
-				remoteSession: this._isSessionSyncEnabled() ? 'export' : undefined,
-			};
-		};
-	}
-
 	protected _resumeSession(sessionId: string): Promise<CopilotAgentSession> {
 		const existing = this._resumingSessions.get(sessionId);
 		if (existing) {
@@ -1709,48 +1583,22 @@ export class CopilotAgent extends Disposable implements IAgent {
 		}
 
 		const shellManager = this._instantiationService.createInstance(ShellManager, sessionUri, workingDirectory);
-		const sessionConfig = this._buildSessionConfig(snapshot, shellManager, workingDirectory);
-
-		const factory: SessionWrapperFactory = async callbacks => {
-			const config = await sessionConfig(callbacks);
-			const resolvedAgentName = storedMetadata.agent ? await this._resolveAgentName(sessionUri, snapshot, storedMetadata.agent) : undefined;
-			try {
-				this._logService.info(`[Copilot:${sessionId}] Calling SDK resumeSession...`);
-				const raw = await client.resumeSession(sessionId, {
-					...config,
-					workingDirectory: workingDirectory?.fsPath,
-					...(resolvedAgentName ? { agent: resolvedAgentName } : {}),
-				});
-				this._logService.info(`[Copilot:${sessionId}] SDK resumeSession succeeded`);
-				return new CopilotSessionWrapper(raw);
-			} catch (err) {
-				const errCode = getCopilotSdkErrorCode(err);
-				const errMsg = getErrorMessage(err);
-				this._logService.warn(`[Copilot:${sessionId}] SDK resumeSession failed: code=${errCode}, message=${errMsg}`);
-				// The SDK fails to resume sessions that have no messages.
-				// Fall back to creating a new session with the same ID,
-				// seeding model & working directory from stored metadata.
-				if (!shouldCreateEmptySessionAfterResumeError(err)) {
-					throw err;
-				}
-
-				this._logService.warn(`[Copilot:${sessionId}] Resume failed (code=-32603), falling back to createSession with same ID`);
-				const raw = await client.createSession({
-					...config,
-					sessionId,
-					streaming: true,
-					model: storedMetadata.model?.id,
-					reasoningEffort: this._getReasoningEffort(storedMetadata.model),
-					...(resolvedAgentName ? { agent: resolvedAgentName } : {}),
-					workingDirectory: workingDirectory?.fsPath,
-				});
-				this._logService.info(`[Copilot:${sessionId}] Fallback createSession succeeded`);
-
-				return new CopilotSessionWrapper(raw);
-			}
+		const resolvedAgentName = storedMetadata.agent ? await this._resolveAgentName(sessionUri, snapshot, storedMetadata.agent) : undefined;
+		const launchPlan: CopilotSessionLaunchPlan = {
+			kind: 'resume',
+			client,
+			sessionId,
+			workingDirectory,
+			resolvedAgentName,
+			snapshot,
+			shellManager,
+			githubToken: this._githubToken,
+			fallback: {
+				model: storedMetadata.model,
+			},
 		};
 
-		const agentSession = this._createAgentSession(factory, sessionId, shellManager, workingDirectory, customizationDirectory, snapshot);
+		const agentSession = this._createAgentSession(launchPlan, customizationDirectory);
 		try {
 			await agentSession.initializeSession();
 		} catch (err) {

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { ExitPlanModeRequest, ExitPlanModeResult, MessageOptions, PermissionRequestResult, SessionConfig, Tool, ToolResultObject } from '@github/copilot-sdk';
+import type { ExitPlanModeRequest, MessageOptions, PermissionRequestResult, SessionConfig, Tool, ToolResultObject } from '@github/copilot-sdk';
 import { DeferredPromise } from '../../../../base/common/async.js';
 import { encodeBase64, VSBuffer } from '../../../../base/common/buffer.js';
 import { Emitter } from '../../../../base/common/event.js';
@@ -29,12 +29,13 @@ import { stripRedundantCdPrefix } from '../../common/commandLineHelpers.js';
 import type { LanguageModelToolInvokedClassification, LanguageModelToolInvokedEvent } from '../../../telemetry/common/languageModelToolTelemetry.js';
 import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
 import { ISessionDatabase, ISessionDataService, SESSION_ATTACHMENTS_DIRNAME } from '../../common/sessionDataService.js';
-import { MessageAttachmentKind, ToolCallContributorKind, type FileEdit, type MessageAttachment, type ToolDefinition } from '../../common/state/protocol/state.js';
+import { MessageAttachmentKind, ToolCallContributorKind, type FileEdit, type MessageAttachment } from '../../common/state/protocol/state.js';
 import { ActionType, type SessionAction } from '../../common/state/sessionActions.js';
 import { MessageKind, ResponsePartKind, SessionInputAnswerState, SessionInputAnswerValueKind, SessionInputQuestionKind, SessionInputResponseKind, ToolCallConfirmationReason, ToolCallStatus, ToolResultContentType, type PendingMessage, type SessionInputAnswer, type SessionInputOption, type SessionInputQuestion, type SessionInputRequest, type ToolCallResult, type ToolResultContent, type Turn, type UsageInfo } from '../../common/state/sessionState.js';
 import { IAgentConfigurationService } from '../agentConfigurationService.js';
-import type { ICopilotPluginInfo, IExitPlanModeResponse } from './copilotAgent.js';
+import type { IExitPlanModeResponse } from './copilotAgent.js';
 import { CopilotSessionWrapper } from './copilotSessionWrapper.js';
+import type { CopilotSessionLaunchPlan, IActiveClientSnapshot, ICopilotSessionLauncher, ICopilotSessionRuntime } from './copilotSessionLauncher.js';
 import { buildCopilotSystemNotification } from './copilotSystemNotification.js';
 import { parseLeadingSlashCommand } from './copilotSlashCommandCompletionProvider.js';
 import type { IUnsandboxedCommandConfirmationRequest, ShellManager } from './copilotShellTools.js';
@@ -247,46 +248,14 @@ function isCopilotSdkToolOutputTempFile(filePath: string, tmpDir: string): boole
 }
 
 /**
- * Immutable snapshot of the active client's contributions at session creation
- * time. Used to detect when the session needs to be refreshed.
- */
-export interface IActiveClientSnapshot {
-	readonly clientId: string;
-	readonly tools: readonly ToolDefinition[];
-	readonly plugins: readonly ICopilotPluginInfo[];
-}
-
-/**
- * Factory function that produces a {@link CopilotSessionWrapper}.
- * Called by {@link CopilotAgentSession.initializeSession} with the
- * session's permission handler and edit-tracking hooks so the factory
- * can wire them into the SDK session it creates.
- *
- * In production, the factory calls `CopilotClient.createSession()` or
- * `resumeSession()`. In tests, it returns a mock wrapper directly.
- */
-export type SessionWrapperFactory = (callbacks: {
-	readonly onPermissionRequest: (request: ITypedPermissionRequest) => Promise<PermissionRequestResult>;
-	readonly onUserInputRequest: (request: UserInputRequest, invocation: { sessionId: string }) => Promise<UserInputResponse>;
-	readonly onElicitationRequest: (context: ElicitationContext) => Promise<ElicitationResult>;
-	readonly onExitPlanModeRequest: (request: ExitPlanModeRequest, invocation: { sessionId: string }) => Promise<ExitPlanModeResult>;
-	readonly requestUnsandboxedCommandConfirmation: (request: IUnsandboxedCommandConfirmationRequest) => Promise<boolean>;
-	readonly hooks: {
-		readonly onPreToolUse: (input: PreToolUseHookInput) => Promise<void>;
-		readonly onPostToolUse: (input: PostToolUseHookInput) => Promise<void>;
-	};
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	readonly clientTools: Tool<any>[];
-}) => Promise<CopilotSessionWrapper>;
-
-/**
  * Options for constructing a {@link CopilotAgentSession}.
  */
 export interface ICopilotAgentSessionOptions {
 	readonly sessionUri: URI;
 	readonly rawSessionId: string;
 	readonly onDidSessionProgress: Emitter<AgentSignal>;
-	readonly wrapperFactory: SessionWrapperFactory;
+	readonly sessionLauncher: ICopilotSessionLauncher;
+	readonly launchPlan: CopilotSessionLaunchPlan;
 	readonly shellManager: ShellManager | undefined;
 	/** Working directory associated with the session, used to strip redundant `cd` prefixes from shell commands. */
 	readonly workingDirectory?: URI;
@@ -378,7 +347,8 @@ export class CopilotAgentSession extends Disposable {
 	private readonly _pendingEditContentUris = new Map<string, URI>();
 
 	private readonly _onDidSessionProgress: Emitter<AgentSignal>;
-	private readonly _wrapperFactory: SessionWrapperFactory;
+	private readonly _sessionLauncher: ICopilotSessionLauncher;
+	private readonly _launchPlan: CopilotSessionLaunchPlan;
 	private readonly _shellManager: ShellManager | undefined;
 	private readonly _workingDirectory: URI | undefined;
 	private readonly _customizationDirectory: URI | undefined;
@@ -409,7 +379,8 @@ export class CopilotAgentSession extends Disposable {
 		this.sessionId = options.rawSessionId;
 		this.sessionUri = options.sessionUri;
 		this._onDidSessionProgress = options.onDidSessionProgress;
-		this._wrapperFactory = options.wrapperFactory;
+		this._sessionLauncher = options.sessionLauncher;
+		this._launchPlan = options.launchPlan;
 		this._shellManager = options.shellManager;
 		this._workingDirectory = options.workingDirectory;
 		this._customizationDirectory = options.customizationDirectory;
@@ -701,7 +672,7 @@ export class CopilotAgentSession extends Disposable {
 	 * for the client to dispatch `session/toolCallComplete`.
 	 */
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	createClientSdkTools(): Tool<any>[] {
+	private _createClientSdkTools(): Tool<any>[] {
 		const tools = this._appliedSnapshot.tools;
 		if (tools.length === 0) {
 			return [];
@@ -765,25 +736,14 @@ export class CopilotAgentSession extends Disposable {
 	}
 
 	/**
-	 * Creates (or resumes) the SDK session via the injected factory and
+	 * Creates (or resumes) the SDK session via the injected launcher and
 	 * wires up all event listeners. Must be called exactly once after
 	 * construction before using the session.
 	 */
 	async initializeSession(): Promise<void> {
-		const wrapper = await this._wrapperFactory({
-			onPermissionRequest: request => this.handlePermissionRequest(request),
-			onExitPlanModeRequest: (request, invocation) => this.handleExitPlanModeRequest(request, invocation),
-			onUserInputRequest: (request, invocation) => this.handleUserInputRequest(request, invocation),
-			onElicitationRequest: context => this.handleElicitationRequest(context),
-			requestUnsandboxedCommandConfirmation: request => this.requestUnsandboxedCommandConfirmation(request),
-			clientTools: this.createClientSdkTools(),
-			hooks: {
-				onPreToolUse: input => this._handlePreToolUse(input),
-				onPostToolUse: input => this._handlePostToolUse(input),
-			},
-		});
+		const wrapper = await this._sessionLauncher.launch(this._launchPlan, this._createRuntimeAdapter());
 		// The session may have been disposed while we were awaiting the
-		// wrapper factory. If so, dispose the freshly-created wrapper and
+		// launcher. If so, dispose the freshly-created wrapper and
 		// skip subscribing — registering on a disposed store would leak.
 		if (this._store.isDisposed) {
 			wrapper.dispose();
@@ -792,6 +752,19 @@ export class CopilotAgentSession extends Disposable {
 		this._wrapper = this._register(wrapper);
 		this._subscribeToEvents();
 		this._subscribeForLogging();
+	}
+
+	private _createRuntimeAdapter(): ICopilotSessionRuntime {
+		return {
+			handlePermissionRequest: request => this._handlePermissionRequest(request),
+			handleExitPlanModeRequest: (request, invocation) => this._handleExitPlanModeRequest(request, invocation),
+			handleUserInputRequest: (request, invocation) => this._handleUserInputRequest(request, invocation),
+			handleElicitationRequest: context => this._handleElicitationRequest(context),
+			requestUnsandboxedCommandConfirmation: request => this._requestUnsandboxedCommandConfirmation(request),
+			createClientSdkTools: () => this._createClientSdkTools(),
+			handlePreToolUse: input => this._handlePreToolUse(input),
+			handlePostToolUse: input => this._handlePostToolUse(input),
+		};
 	}
 
 	// ---- session operations -------------------------------------------------
@@ -1032,7 +1005,7 @@ export class CopilotAgentSession extends Disposable {
 	 * (which transitions the tool to PendingConfirmation) and waiting for the
 	 * side-effects layer to respond via {@link respondToPermissionRequest}.
 	 */
-	async handlePermissionRequest(
+	private async _handlePermissionRequest(
 		request: ITypedPermissionRequest,
 	): Promise<PermissionRequestResult> {
 		this._logService.info(`[Copilot:${this.sessionId}] Permission request: kind=${request.kind}`);
@@ -1278,7 +1251,7 @@ export class CopilotAgentSession extends Disposable {
 		return false;
 	}
 
-	async requestUnsandboxedCommandConfirmation(request: IUnsandboxedCommandConfirmationRequest): Promise<boolean> {
+	private async _requestUnsandboxedCommandConfirmation(request: IUnsandboxedCommandConfirmationRequest): Promise<boolean> {
 		const deferred = new DeferredPromise<boolean>();
 		this._pendingPermissions.set(request.toolCallId, deferred);
 
@@ -1324,7 +1297,7 @@ export class CopilotAgentSession extends Disposable {
 	 * `user_input_request` progress event and waiting for the renderer to
 	 * respond via {@link respondToUserInputRequest}.
 	 */
-	async handleUserInputRequest(
+	private async _handleUserInputRequest(
 		request: UserInputRequest,
 		_invocation: { sessionId: string },
 	): Promise<UserInputResponse> {
@@ -1415,7 +1388,7 @@ export class CopilotAgentSession extends Disposable {
 	 * available to fill in a form, and accepting with empty content would
 	 * be misleading to the MCP server.
 	 */
-	async handleElicitationRequest(context: ElicitationContext): Promise<ElicitationResult> {
+	private async _handleElicitationRequest(context: ElicitationContext): Promise<ElicitationResult> {
 		const isAutopilot = this._configurationService.getEffectiveValue(this.sessionUri.toString(), platformSessionSchema, SessionConfigKey.AutoApprove) === 'autopilot';
 		if (isAutopilot) {
 			return { action: 'cancel' };
@@ -2030,7 +2003,7 @@ export class CopilotAgentSession extends Disposable {
 	 * paused `exit_plan_mode` tool call and (on accept) updates the SDK's
 	 * `currentMode` so the model can continue with implementation.
 	 */
-	async handleExitPlanModeRequest(data: ExitPlanModeRequest, _invocation: { sessionId: string }): Promise<IExitPlanModeResponse> {
+	private async _handleExitPlanModeRequest(data: ExitPlanModeRequest, _invocation: { sessionId: string }): Promise<IExitPlanModeResponse> {
 		const requestId = generateUuid();
 		const questionId = generateUuid();
 		this._logService.info(`[Copilot:${this.sessionId}] exitPlanMode.request: rpcId=${requestId}, actions=[${data.actions.join(',')}], recommended=${data.recommendedAction}`);

--- a/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
@@ -1,0 +1,276 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { CopilotClient, ExitPlanModeRequest, ExitPlanModeResult, PermissionRequestResult, ResumeSessionConfig, SessionConfig, Tool } from '@github/copilot-sdk';
+import { coalesce } from '../../../../base/common/arrays.js';
+import { Schemas } from '../../../../base/common/network.js';
+import { URI } from '../../../../base/common/uri.js';
+import { IFileService } from '../../../files/common/files.js';
+import { ILogService } from '../../../log/common/log.js';
+import { AgentHostConfigKey, agentHostCustomizationConfigSchema } from '../../common/agentHostCustomizationConfig.js';
+import { AgentHostSessionSyncEnabledConfigKey, platformRootSchema } from '../../common/agentHostSchema.js';
+import { IAgentConfigurationService } from '../agentConfigurationService.js';
+import { IAgentHostTerminalManager } from '../agentHostTerminalManager.js';
+import type { ModelSelection, ToolDefinition } from '../../common/state/protocol/state.js';
+import { CopilotSessionWrapper } from './copilotSessionWrapper.js';
+import { ShellManager, createShellTools, type IUnsandboxedCommandConfirmationRequest } from './copilotShellTools.js';
+import { toSdkCustomAgents, toSdkHooks, toSdkInstructionDirectories, toSdkMcpServers, toSdkSkillDirectories } from './copilotPluginConverters.js';
+import type { ITypedPermissionRequest } from './copilotToolDisplay.js';
+import type { ICopilotPluginInfo } from './copilotAgent.js';
+
+export const ThinkingLevelConfigKey = 'thinkingLevel';
+
+const ReasoningEfforts = ['low', 'medium', 'high', 'xhigh'] as const;
+type ReasoningEffort = NonNullable<SessionConfig['reasoningEffort']>;
+
+type UserInputHandler = NonNullable<SessionConfig['onUserInputRequest']>;
+type UserInputRequest = Parameters<UserInputHandler>[0];
+type UserInputInvocation = Parameters<UserInputHandler>[1];
+type UserInputResponse = Awaited<ReturnType<UserInputHandler>>;
+type ElicitationHandler = NonNullable<SessionConfig['onElicitationRequest']>;
+type ElicitationContext = Parameters<ElicitationHandler>[0];
+type ElicitationResult = Awaited<ReturnType<ElicitationHandler>>;
+type SessionHooks = NonNullable<SessionConfig['hooks']>;
+type PreToolUseHookInput = Parameters<NonNullable<SessionHooks['onPreToolUse']>>[0];
+type PostToolUseHookInput = Parameters<NonNullable<SessionHooks['onPostToolUse']>>[0];
+type CopilotSessionLaunchConfig = ResumeSessionConfig & {
+	readonly pluginDirectories?: string[];
+	readonly remoteSession?: 'export';
+};
+
+export const COPILOT_AGENT_HOST_SYSTEM_MESSAGE = {
+	mode: 'customize',
+	sections: {
+		identity: {
+			action: 'replace',
+			content: 'You are an AI assistant using Copilot CLI runtime in VS Code. You help users with software engineering tasks. When asked about your identity, you must state that you are an AI assistant using Copilot CLI runtime in VS Code.',
+		},
+	},
+} satisfies NonNullable<ResumeSessionConfig['systemMessage']>;
+
+/**
+ * Immutable snapshot of the active client's contributions at session creation
+ * time. Used to detect when the session needs to be refreshed.
+ */
+export interface IActiveClientSnapshot {
+	readonly clientId: string;
+	readonly tools: readonly ToolDefinition[];
+	readonly plugins: readonly ICopilotPluginInfo[];
+}
+
+export interface ICopilotSessionRuntime {
+	handlePermissionRequest(request: ITypedPermissionRequest): Promise<PermissionRequestResult>;
+	handleExitPlanModeRequest(request: ExitPlanModeRequest, invocation: { sessionId: string }): Promise<ExitPlanModeResult>;
+	handleUserInputRequest(request: UserInputRequest, invocation: UserInputInvocation): Promise<UserInputResponse>;
+	handleElicitationRequest(context: ElicitationContext): Promise<ElicitationResult>;
+	requestUnsandboxedCommandConfirmation(request: IUnsandboxedCommandConfirmationRequest): Promise<boolean>;
+	handlePreToolUse(input: PreToolUseHookInput): Promise<void>;
+	handlePostToolUse(input: PostToolUseHookInput): Promise<void>;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	createClientSdkTools(): Tool<any>[];
+}
+
+export interface ICopilotSessionLauncher {
+	/**
+	 * Creates an unowned SDK session wrapper. The caller is responsible for
+	 * registering or disposing the returned wrapper.
+	 */
+	launch(plan: CopilotSessionLaunchPlan, runtime: ICopilotSessionRuntime): Promise<CopilotSessionWrapper>;
+}
+
+type CopilotSessionClient = Pick<CopilotClient, 'createSession' | 'resumeSession'>;
+
+interface ICopilotSessionLaunchBase {
+	readonly client: CopilotSessionClient;
+	readonly sessionId: string;
+	readonly workingDirectory: URI | undefined;
+	readonly resolvedAgentName: string | undefined;
+	readonly snapshot: IActiveClientSnapshot;
+	readonly shellManager: ShellManager | undefined;
+	readonly githubToken: string | undefined;
+}
+
+export interface ICopilotCreateSessionLaunchPlan extends ICopilotSessionLaunchBase {
+	readonly kind: 'create';
+	readonly model: ModelSelection | undefined;
+}
+
+export interface ICopilotResumeSessionLaunchPlan extends ICopilotSessionLaunchBase {
+	readonly kind: 'resume';
+	readonly workingDirectory: URI;
+	readonly fallback: {
+		readonly model: ModelSelection | undefined;
+	};
+}
+
+export type CopilotSessionLaunchPlan = ICopilotCreateSessionLaunchPlan | ICopilotResumeSessionLaunchPlan;
+
+function isReasoningEffort(value: string | undefined): value is ReasoningEffort {
+	return ReasoningEfforts.some(reasoningEffort => reasoningEffort === value);
+}
+
+function getCopilotSdkErrorCode(err: unknown): number | undefined {
+	if (typeof err !== 'object' || err === null) {
+		return undefined;
+	}
+	const code = Object.getOwnPropertyDescriptor(err, 'code')?.value;
+	return typeof code === 'number' ? code : undefined;
+}
+
+function getErrorMessage(err: unknown): string {
+	if (err instanceof Error) {
+		return err.message;
+	}
+	if (typeof err === 'object' && err !== null) {
+		const message = Object.getOwnPropertyDescriptor(err, 'message')?.value;
+		if (typeof message === 'string') {
+			return message;
+		}
+	}
+	return String(err);
+}
+
+/**
+ * Decide whether a Copilot SDK `resumeSession` failure should fall back to
+ * `createSession({ sessionId })`. We want to preserve the original
+ * recovery for empty / truncated sessions (e.g. after the user invoked
+ * "Start Over", which calls `truncateSession` and leaves the on-disk
+ * session with zero events - the SDK then refuses to resume it), but we
+ * must NOT silently swallow corruption / schema-validation / parse
+ * failures: those should surface so the user sees the real error and the
+ * original session contents are not masked by a fresh empty session.
+ *
+ * Heuristic: any `-32603` Internal Error is treated as the empty-session
+ * case UNLESS the message clearly indicates corruption, schema
+ * validation, parse failure, or malformed input.
+ */
+function shouldCreateEmptySessionAfterResumeError(err: unknown): boolean {
+	if (getCopilotSdkErrorCode(err) !== -32603) {
+		return false;
+	}
+
+	const message = getErrorMessage(err);
+	return !/\b(corrupt|corrupted|invalid|validation|schema|must be|parse|malformed|unexpected token)\b/i.test(message);
+}
+
+export function getCopilotReasoningEffort(model: ModelSelection | undefined): SessionConfig['reasoningEffort'] {
+	const thinkingLevel = model?.config?.[ThinkingLevelConfigKey];
+	return isReasoningEffort(thinkingLevel) ? thinkingLevel : undefined;
+}
+
+export class CopilotSessionLauncher implements ICopilotSessionLauncher {
+
+	constructor(
+		@IAgentConfigurationService private readonly _configurationService: IAgentConfigurationService,
+		@IAgentHostTerminalManager private readonly _terminalManager: IAgentHostTerminalManager,
+		@ILogService private readonly _logService: ILogService,
+		@IFileService private readonly _fileService: IFileService,
+	) { }
+
+	async launch(plan: CopilotSessionLaunchPlan, runtime: ICopilotSessionRuntime): Promise<CopilotSessionWrapper> {
+		const config = await this._buildSessionConfig(plan, runtime);
+		if (plan.kind === 'create') {
+			return this._createSession(plan, config);
+		}
+
+		try {
+			this._logService.info(`[Copilot:${plan.sessionId}] Calling SDK resumeSession...`);
+			const raw = await plan.client.resumeSession(plan.sessionId, {
+				...config,
+				workingDirectory: plan.workingDirectory.fsPath,
+				...(plan.resolvedAgentName ? { agent: plan.resolvedAgentName } : {}),
+			});
+			this._logService.info(`[Copilot:${plan.sessionId}] SDK resumeSession succeeded`);
+			return new CopilotSessionWrapper(raw);
+		} catch (err) {
+			const errCode = getCopilotSdkErrorCode(err);
+			const errMsg = getErrorMessage(err);
+			this._logService.warn(`[Copilot:${plan.sessionId}] SDK resumeSession failed: code=${errCode}, message=${errMsg}`);
+			// The SDK fails to resume sessions that have no messages.
+			// Fall back to creating a new session with the same ID,
+			// seeding model & working directory from stored metadata.
+			if (!shouldCreateEmptySessionAfterResumeError(err)) {
+				throw err;
+			}
+
+			this._logService.warn(`[Copilot:${plan.sessionId}] Resume failed (code=-32603), falling back to createSession with same ID`);
+			const wrapper = await this._createSession({
+				...plan,
+				kind: 'create',
+				model: plan.fallback.model,
+			}, config);
+			this._logService.info(`[Copilot:${plan.sessionId}] Fallback createSession succeeded`);
+			return wrapper;
+		}
+	}
+
+	private async _createSession(plan: ICopilotCreateSessionLaunchPlan, config: CopilotSessionLaunchConfig): Promise<CopilotSessionWrapper> {
+		const raw = await plan.client.createSession({
+			...config,
+			sessionId: plan.sessionId,
+			streaming: true,
+			model: plan.model?.id,
+			reasoningEffort: getCopilotReasoningEffort(plan.model),
+			...(plan.resolvedAgentName ? { agent: plan.resolvedAgentName } : {}),
+			workingDirectory: plan.workingDirectory?.fsPath,
+		});
+		return new CopilotSessionWrapper(raw);
+	}
+
+	private async _buildSessionConfig(plan: CopilotSessionLaunchPlan, runtime: ICopilotSessionRuntime): Promise<CopilotSessionLaunchConfig> {
+		const plugins = plan.snapshot.plugins;
+		const enableCustomTerminalTool = this._configurationService.getRootValue(agentHostCustomizationConfigSchema, AgentHostConfigKey.EnableCustomTerminalTool) === true;
+		let shellTools: Awaited<ReturnType<typeof createShellTools>> = [];
+		if (enableCustomTerminalTool) {
+			if (!plan.shellManager) {
+				throw new Error(`ShellManager is required to launch Copilot session '${plan.sessionId}'`);
+			}
+			shellTools = await createShellTools(plan.shellManager, this._terminalManager, this._logService, request => runtime.requestUnsandboxedCommandConfirmation(request));
+		}
+		// Rely on SDK to find all agents/skills & the like from the plugins instead of us feeding them.
+		// Else we could end up with duplicates or the like.
+		const pluginsWithoutDirs = plugins.filter(p => !p.pluginDir || p.pluginDir.scheme !== Schemas.file);
+		const customAgents = await toSdkCustomAgents(pluginsWithoutDirs.flatMap(p => p.agents), this._fileService);
+		return {
+			clientName: 'vscode',
+			onPermissionRequest: request => runtime.handlePermissionRequest(request),
+			onUserInputRequest: (request, invocation) => runtime.handleUserInputRequest(request, invocation),
+			onElicitationRequest: context => runtime.handleElicitationRequest(context),
+			hooks: toSdkHooks(pluginsWithoutDirs.flatMap(p => p.hooks), {
+				onPreToolUse: input => runtime.handlePreToolUse(input),
+				onPostToolUse: input => runtime.handlePostToolUse(input),
+			}),
+			mcpServers: toSdkMcpServers(pluginsWithoutDirs.flatMap(p => p.mcpServers)),
+			onExitPlanModeRequest: (request, invocation) => runtime.handleExitPlanModeRequest(request, invocation),
+			workingDirectory: plan.workingDirectory?.fsPath,
+			customAgents,
+			skillDirectories: toSdkSkillDirectories(pluginsWithoutDirs.flatMap(p => p.skills)),
+			instructionDirectories: toSdkInstructionDirectories(plugins.flatMap(p => p.instructions)),
+			systemMessage: COPILOT_AGENT_HOST_SYSTEM_MESSAGE,
+			pluginDirectories: coalesce(plugins.map(p => p.pluginDir))
+				.filter(d => d.scheme === Schemas.file).map(d => d.fsPath),
+			tools: [...shellTools, ...runtime.createClientSdkTools()],
+			// Pass the GitHub token at the session level. The SDK's
+			// client-level `gitHubToken` authenticates the CLI process,
+			// but each session also needs its own token resolved into a
+			// GitHub identity (login, Copilot plan, endpoints) to drive
+			// model routing and quota — without this the session
+			// errors with "Session was not created with authentication
+			// info or custom provider" on first send. See #318693.
+			gitHubToken: plan.githubToken,
+			// Enable infinite sessions so the SDK provisions a workspace
+			// directory (containing `plan.md`, `checkpoints/`, `files/`).
+			// The workspace is required for plan mode to work — without
+			// it, `rpc.plan.read()` returns `path: null` and the SDK
+			// never emits `exit_plan_mode.requested`.
+			infiniteSessions: { enabled: true },
+			// Per-session remote export: the client-level `--remote` flag
+			// (enableRemoteSessions) enables the CLI capability, but each
+			// session must opt in via `remoteSession` to actually export
+			// events. Without this, sessions default to "off".
+			remoteSession: this._configurationService.getRootValue(platformRootSchema, AgentHostSessionSyncEnabledConfigKey) === true ? 'export' : undefined,
+		};
+	}
+}

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -43,8 +43,8 @@ import { IAgentHostOTelService } from '../../common/otel/agentHostOTelService.js
 import { AgentHostCompletions, IAgentHostCompletions } from '../../node/agentHostCompletions.js';
 import { COPILOT_AGENT_HOST_SYSTEM_MESSAGE, CopilotAgent, getCopilotBranchNameHintFromMessage, getCopilotWorktreeBranchName, getCopilotWorktreeName, getCopilotWorktreesRoot } from '../../node/copilot/copilotAgent.js';
 import { NULL_CHECKPOINT_SERVICE } from '../../common/agentHostCheckpointService.js';
-import { CopilotAgentSession, type SessionWrapperFactory } from '../../node/copilot/copilotAgentSession.js';
-import { CopilotSessionWrapper } from '../../node/copilot/copilotSessionWrapper.js';
+import { CopilotAgentSession } from '../../node/copilot/copilotAgentSession.js';
+import type { CopilotSessionLaunchPlan } from '../../node/copilot/copilotSessionLauncher.js';
 import { ShellManager } from '../../node/copilot/copilotShellTools.js';
 import { SessionDatabase } from '../../node/sessionDatabase.js';
 import { createNullSessionDataService } from '../common/sessionTestHelpers.js';
@@ -265,14 +265,12 @@ class ResumePathCopilotAgent extends CopilotAgent {
 		private readonly _copilotClient: ITestCopilotClient,
 		@ILogService logService: ILogService,
 		@IInstantiationService instantiationService: IInstantiationService,
-		@IFileService fileService: IFileService,
 		@ISessionDataService sessionDataService: ISessionDataService,
 		@IAgentHostGitService gitService: IAgentHostGitService,
-		@IAgentHostTerminalManager terminalManager: IAgentHostTerminalManager,
 		@IAgentConfigurationService configurationService: IAgentConfigurationService,
 		@IAgentHostCompletions completions: IAgentHostCompletions,
 	) {
-		super(logService, instantiationService, fileService, sessionDataService, gitService, terminalManager, configurationService, new MockAgentHostOTelService(), completions, NULL_CHECKPOINT_SERVICE);
+		super(logService, instantiationService, sessionDataService, gitService, configurationService, new MockAgentHostOTelService(), completions, NULL_CHECKPOINT_SERVICE);
 		this._enablePlanModeOnClient(this._copilotClient as CopilotClient);
 	}
 
@@ -289,14 +287,12 @@ class TestableCopilotAgent extends CopilotAgent {
 		private readonly _copilotClient: ITestCopilotClient,
 		@ILogService logService: ILogService,
 		@IInstantiationService instantiationService: IInstantiationService,
-		@IFileService fileService: IFileService,
 		@ISessionDataService sessionDataService: ISessionDataService,
 		@IAgentHostGitService gitService: IAgentHostGitService,
-		@IAgentHostTerminalManager terminalManager: IAgentHostTerminalManager,
 		@IAgentConfigurationService configurationService: IAgentConfigurationService,
 		@IAgentHostCompletions completions: IAgentHostCompletions,
 	) {
-		super(logService, instantiationService, fileService, sessionDataService, gitService, terminalManager, configurationService, new MockAgentHostOTelService(), completions, NULL_CHECKPOINT_SERVICE);
+		super(logService, instantiationService, sessionDataService, gitService, configurationService, new MockAgentHostOTelService(), completions, NULL_CHECKPOINT_SERVICE);
 		this._enablePlanModeOnClient(this._copilotClient as CopilotClient);
 	}
 
@@ -386,13 +382,33 @@ function createTestAgent(disposables: Pick<DisposableStore, 'add'>, options?: { 
 	return createTestAgentContext(disposables, options).agent;
 }
 
-function createAgentSessionThroughAgent(agent: CopilotAgent, instantiationService: IInstantiationService): CopilotAgentSession {
+type CopilotCreateSessionOptions = Parameters<CopilotClient['createSession']>[0];
+
+function createAgentSessionThroughAgent(agent: CopilotAgent, instantiationService: IInstantiationService): { readonly session: CopilotAgentSession; readonly createOptions: () => CopilotCreateSessionOptions | undefined } {
 	const sessionUri = AgentSession.uri('copilotcli', 'test-session-1');
 	const shellManager = instantiationService.createInstance(ShellManager, sessionUri, undefined);
-	const wrapperFactory: SessionWrapperFactory = async () => new CopilotSessionWrapper(new MockCopilotSession() as unknown as CopilotSession);
-	return (agent as unknown as {
-		_createAgentSession: (wrapperFactory: SessionWrapperFactory, sessionId: string, shellManager: ShellManager) => CopilotAgentSession;
-	})._createAgentSession(wrapperFactory, 'test-session-1', shellManager);
+	let createOptions: CopilotCreateSessionOptions | undefined;
+	const launchPlan: CopilotSessionLaunchPlan = {
+		kind: 'create',
+		client: {
+			createSession: async options => {
+				createOptions = options;
+				return new MockCopilotSession() as unknown as CopilotSession;
+			},
+			resumeSession: async () => new MockCopilotSession() as unknown as CopilotSession,
+		},
+		sessionId: 'test-session-1',
+		workingDirectory: undefined,
+		resolvedAgentName: undefined,
+		snapshot: { clientId: '', tools: [], plugins: [] },
+		shellManager,
+		githubToken: 'token',
+		model: undefined,
+	};
+	const session = (agent as unknown as {
+		_createAgentSession: (launchPlan: CopilotSessionLaunchPlan, customizationDirectory: URI | undefined) => CopilotAgentSession;
+	})._createAgentSession(launchPlan, undefined);
+	return { session, createOptions: () => createOptions };
 }
 
 function withoutUndefinedProperties(metadata: IAgentSessionMetadata): Record<string, unknown> {
@@ -585,14 +601,18 @@ suite('CopilotAgent', () => {
 		const previousXdgStateHome = process.env['XDG_STATE_HOME'];
 		delete process.env['XDG_STATE_HOME'];
 		try {
-			const agentSession = disposables.add(createAgentSessionThroughAgent(agent, instantiationService));
+			const createdSession = createAgentSessionThroughAgent(agent, instantiationService);
+			const agentSession = disposables.add(createdSession.session);
 			await agentSession.initializeSession();
+			const onPermissionRequest = createdSession.createOptions()?.onPermissionRequest;
+			assert.ok(onPermissionRequest);
 
-			const result = await agentSession.handlePermissionRequest({
+			const result = await onPermissionRequest({
 				kind: 'read',
+				intention: 'read plan',
 				path: URI.file('/mock-home/.copilot/session-state/test-session-1/plan.md').fsPath,
 				toolCallId: 'tc-read-plan-agent-composition',
-			});
+			}, { sessionId: 'test-session-1' });
 
 			assert.strictEqual(result.kind, 'approve-once');
 		} finally {

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -25,7 +25,8 @@ import { IDiffComputeService } from '../../common/diffComputeService.js';
 import { ISessionDataService } from '../../common/sessionDataService.js';
 import { ActionType, type SessionDeltaAction, type SessionErrorAction, type SessionInputRequestedAction, type SessionResponsePartAction, type SessionToolCallCompleteAction, type SessionToolCallReadyAction, type SessionToolCallStartAction } from '../../common/state/sessionActions.js';
 import { MessageAttachmentKind, MessageKind, ResponsePartKind, SessionInputAnswerState, SessionInputAnswerValueKind, SessionInputQuestionKind, SessionInputResponseKind, ToolCallContributorKind, ToolCallStatus, ToolResultContentType, type ToolResultFileEditContent } from '../../common/state/sessionState.js';
-import { CopilotAgentSession, IActiveClientSnapshot, SessionWrapperFactory } from '../../node/copilot/copilotAgentSession.js';
+import { CopilotAgentSession } from '../../node/copilot/copilotAgentSession.js';
+import { type CopilotSessionLaunchPlan, type IActiveClientSnapshot, type ICopilotSessionLauncher, type ICopilotSessionRuntime } from '../../node/copilot/copilotSessionLauncher.js';
 import { CopilotSessionWrapper } from '../../node/copilot/copilotSessionWrapper.js';
 import { buildCopilotSystemNotification } from '../../node/copilot/copilotSystemNotification.js';
 import { IAgentConfigurationService } from '../../node/agentConfigurationService.js';
@@ -188,7 +189,7 @@ async function createAgentSession(disposables: DisposableStore, options?: {
 	environmentServiceRegistration?: 'native' | 'none';
 	logService?: ILogService;
 	telemetryService?: ITelemetryService;
-	captureWrapperCallbacks?: { current?: Parameters<SessionWrapperFactory>[0] };
+	captureRuntime?: { current?: ICopilotSessionRuntime };
 	workingDirectory?: URI;
 	/** Per-key effective config values returned by the fake configuration service. */
 	configValues?: Record<string, unknown>;
@@ -196,6 +197,7 @@ async function createAgentSession(disposables: DisposableStore, options?: {
 	fileReadErrors?: readonly string[];
 }): Promise<{
 	session: CopilotAgentSession;
+	runtime: ICopilotSessionRuntime;
 	mockSession: MockCopilotSession;
 	signals: AgentSignal[];
 	waitForSignal: (predicate: (signal: AgentSignal) => boolean) => Promise<AgentSignal>;
@@ -229,11 +231,29 @@ async function createAgentSession(disposables: DisposableStore, options?: {
 	const sessionUri = AgentSession.uri('copilot', 'test-session-1');
 	const mockSession = new MockCopilotSession();
 
-	const factory: SessionWrapperFactory = async callbacks => {
-		if (options?.captureWrapperCallbacks) {
-			options.captureWrapperCallbacks.current = callbacks;
+	const launchPlan: CopilotSessionLaunchPlan = {
+		kind: 'create',
+		client: {
+			createSession: async () => mockSession as unknown as CopilotSession,
+			resumeSession: async () => mockSession as unknown as CopilotSession,
+		},
+		sessionId: 'test-session-1',
+		workingDirectory: options?.workingDirectory,
+		resolvedAgentName: undefined,
+		snapshot: options?.clientSnapshot ?? { clientId: '', tools: [], plugins: [] },
+		shellManager: undefined,
+		githubToken: undefined,
+		model: undefined,
+	};
+	let launchedRuntime: ICopilotSessionRuntime | undefined;
+	const sessionLauncher: ICopilotSessionLauncher = {
+		launch: async (_plan, runtime) => {
+			launchedRuntime = runtime;
+			if (options?.captureRuntime) {
+				options.captureRuntime.current = runtime;
+			}
+			return new CopilotSessionWrapper(mockSession as unknown as CopilotSession);
 		}
-		return new CopilotSessionWrapper(mockSession as unknown as CopilotSession);
 	};
 
 	const services = new ServiceCollection();
@@ -284,7 +304,8 @@ async function createAgentSession(disposables: DisposableStore, options?: {
 			sessionUri,
 			rawSessionId: 'test-session-1',
 			onDidSessionProgress: progressEmitter,
-			wrapperFactory: factory,
+			sessionLauncher,
+			launchPlan,
 			shellManager: undefined,
 			clientSnapshot: options?.clientSnapshot,
 			workingDirectory: options?.workingDirectory,
@@ -292,8 +313,9 @@ async function createAgentSession(disposables: DisposableStore, options?: {
 	));
 
 	await session.initializeSession();
+	assert.ok(launchedRuntime);
 
-	return { session, mockSession, signals, waitForSignal, sessionConfigUpdates };
+	return { session, runtime: launchedRuntime, mockSession, signals, waitForSignal, sessionConfigUpdates };
 }
 
 // ---- Tests ------------------------------------------------------------------
@@ -549,8 +571,8 @@ suite('CopilotAgentSession', () => {
 	suite('permission handling', () => {
 
 		test('read permission fires tool_ready (deferred to side effects)', async () => {
-			const { session, signals, waitForSignal } = await createAgentSession(disposables);
-			const resultPromise = session.handlePermissionRequest({
+			const { session, runtime, signals, waitForSignal } = await createAgentSession(disposables);
+			const resultPromise = runtime.handlePermissionRequest({
 				kind: 'read',
 				path: '/workspace/src/file.ts',
 				toolCallId: 'tc-1',
@@ -568,8 +590,8 @@ suite('CopilotAgentSession', () => {
 			const previousXdgStateHome = process.env['XDG_STATE_HOME'];
 			process.env['XDG_STATE_HOME'] = '/mock-state-home';
 			try {
-				const { session, signals } = await createAgentSession(disposables);
-				const result = await session.handlePermissionRequest({
+				const { runtime, signals } = await createAgentSession(disposables);
+				const result = await runtime.handlePermissionRequest({
 					kind: 'read',
 					path: join('/mock-state-home', '.copilot', 'session-state', 'test-session-1', 'plan.md'),
 					toolCallId: 'tc-read-plan',
@@ -590,8 +612,8 @@ suite('CopilotAgentSession', () => {
 			const previousXdgStateHome = process.env['XDG_STATE_HOME'];
 			delete process.env['XDG_STATE_HOME'];
 			try {
-				const { session, signals } = await createAgentSession(disposables, { environmentServiceRegistration: 'native' });
-				const result = await session.handlePermissionRequest({
+				const { runtime, signals } = await createAgentSession(disposables, { environmentServiceRegistration: 'native' });
+				const result = await runtime.handlePermissionRequest({
 					kind: 'read',
 					path: join('/mock-home', '.copilot', 'session-state', 'test-session-1', 'plan.md'),
 					toolCallId: 'tc-read-plan-native-env',
@@ -613,13 +635,13 @@ suite('CopilotAgentSession', () => {
 			delete process.env['XDG_STATE_HOME'];
 			const logService = new CapturingLogService();
 			try {
-				const { session } = await createAgentSession(disposables, {
+				const { runtime } = await createAgentSession(disposables, {
 					environmentServiceRegistration: 'none',
 					logService,
 				});
 
 				await assert.rejects(
-					session.handlePermissionRequest({
+					runtime.handlePermissionRequest({
 						kind: 'read',
 						path: join('/mock-home', '.copilot', 'session-state', 'test-session-1', 'plan.md'),
 						toolCallId: 'tc-read-plan-missing-env',
@@ -640,8 +662,8 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('write permission fires tool_ready (deferred to side effects)', async () => {
-			const { session, signals, waitForSignal } = await createAgentSession(disposables);
-			const resultPromise = session.handlePermissionRequest({
+			const { session, runtime, signals, waitForSignal } = await createAgentSession(disposables);
+			const resultPromise = runtime.handlePermissionRequest({
 				kind: 'write',
 				fileName: '/workspace/src/file.ts',
 				toolCallId: 'tc-1',
@@ -659,8 +681,8 @@ suite('CopilotAgentSession', () => {
 			const previousXdgStateHome = process.env['XDG_STATE_HOME'];
 			process.env['XDG_STATE_HOME'] = '/mock-state-home';
 			try {
-				const { session, signals } = await createAgentSession(disposables);
-				const result = await session.handlePermissionRequest({
+				const { runtime, signals } = await createAgentSession(disposables);
+				const result = await runtime.handlePermissionRequest({
 					kind: 'write',
 					fileName: join('/mock-state-home', '.copilot', 'session-state', 'test-session-1', 'plan.md'),
 					toolCallId: 'tc-write-plan',
@@ -681,8 +703,8 @@ suite('CopilotAgentSession', () => {
 			const previousXdgStateHome = process.env['XDG_STATE_HOME'];
 			process.env['XDG_STATE_HOME'] = '/mock-state-home';
 			try {
-				const { session, signals, waitForSignal } = await createAgentSession(disposables);
-				const resultPromise = session.handlePermissionRequest({
+				const { session, runtime, signals, waitForSignal } = await createAgentSession(disposables);
+				const resultPromise = runtime.handlePermissionRequest({
 					kind: 'write',
 					fileName: join('/mock-state-home', '.copilot', 'session-state', 'different-session', 'plan.md'),
 					toolCallId: 'tc-write-other-plan',
@@ -707,9 +729,9 @@ suite('CopilotAgentSession', () => {
 			const previousXdgStateHome = process.env['XDG_STATE_HOME'];
 			process.env['XDG_STATE_HOME'] = '/mock-state-home';
 			try {
-				const { session, signals, waitForSignal } = await createAgentSession(disposables);
+				const { session, runtime, signals, waitForSignal } = await createAgentSession(disposables);
 				const sessionDir = join('/mock-state-home', '.copilot', 'session-state', 'test-session-1');
-				const resultPromise = session.handlePermissionRequest({
+				const resultPromise = runtime.handlePermissionRequest({
 					kind: 'write',
 					fileName: `${sessionDir}${sep}..${sep}outside.md`,
 					toolCallId: 'tc-write-traversal',
@@ -731,10 +753,10 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('auto-approves read of Copilot SDK large-tool-output temp files', async () => {
-			const { session, signals } = await createAgentSession(disposables);
+			const { runtime, signals } = await createAgentSession(disposables);
 
 			// Layout 1: <timestamp>-copilot-tool-output-<id>.txt
-			const result1 = await session.handlePermissionRequest({
+			const result1 = await runtime.handlePermissionRequest({
 				kind: 'read',
 				path: join('/mock-tmp', '1730000000000-copilot-tool-output-abc123.txt'),
 				toolCallId: 'tc-tool-output-1',
@@ -742,7 +764,7 @@ suite('CopilotAgentSession', () => {
 			assert.strictEqual(result1.kind, 'approve-once');
 
 			// Layout 2: copilot-tool-output-<timestamp>-<id>.txt
-			const result2 = await session.handlePermissionRequest({
+			const result2 = await runtime.handlePermissionRequest({
 				kind: 'read',
 				path: join('/mock-tmp', 'copilot-tool-output-1730000000000-abc123.txt'),
 				toolCallId: 'tc-tool-output-2',
@@ -753,8 +775,8 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('does not auto-approve tool-output-named files outside tmpdir', async () => {
-			const { session, signals, waitForSignal } = await createAgentSession(disposables);
-			const resultPromise = session.handlePermissionRequest({
+			const { session, runtime, signals, waitForSignal } = await createAgentSession(disposables);
+			const resultPromise = runtime.handlePermissionRequest({
 				kind: 'read',
 				path: join('/some/other/dir', 'copilot-tool-output-1730000000000-abc123.txt'),
 				toolCallId: 'tc-tool-output-outside',
@@ -769,8 +791,8 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('does not auto-approve unrelated files inside tmpdir', async () => {
-			const { session, signals, waitForSignal } = await createAgentSession(disposables);
-			const resultPromise = session.handlePermissionRequest({
+			const { session, runtime, signals, waitForSignal } = await createAgentSession(disposables);
+			const resultPromise = runtime.handlePermissionRequest({
 				kind: 'read',
 				path: join('/mock-tmp', 'something-else.txt'),
 				toolCallId: 'tc-tmp-other',
@@ -785,8 +807,8 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('does not auto-approve write to a tool-output temp path', async () => {
-			const { session, signals, waitForSignal } = await createAgentSession(disposables);
-			const resultPromise = session.handlePermissionRequest({
+			const { session, runtime, signals, waitForSignal } = await createAgentSession(disposables);
+			const resultPromise = runtime.handlePermissionRequest({
 				kind: 'write',
 				fileName: join('/mock-tmp', 'copilot-tool-output-1730000000000-abc123.txt'),
 				toolCallId: 'tc-tool-output-write',
@@ -801,9 +823,9 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('write permission outside working directory fires tool_ready', async () => {
-			const { session, signals, waitForSignal } = await createAgentSession(disposables);
+			const { session, runtime, signals, waitForSignal } = await createAgentSession(disposables);
 
-			const resultPromise = session.handlePermissionRequest({
+			const resultPromise = runtime.handlePermissionRequest({
 				kind: 'write',
 				fileName: '/other/file.ts',
 				toolCallId: 'tc-write-outside',
@@ -818,10 +840,10 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('read permission outside working directory fires tool_ready', async () => {
-			const { session, signals, waitForSignal } = await createAgentSession(disposables);
+			const { session, runtime, signals, waitForSignal } = await createAgentSession(disposables);
 
 			// Kick off permission request but don't await — it will block
-			const resultPromise = session.handlePermissionRequest({
+			const resultPromise = runtime.handlePermissionRequest({
 				kind: 'read',
 				path: '/other/file.ts',
 				toolCallId: 'tc-2',
@@ -838,14 +860,14 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('denies permission when no toolCallId', async () => {
-			const { session } = await createAgentSession(disposables);
-			const result = await session.handlePermissionRequest({ kind: 'write' });
+			const { runtime } = await createAgentSession(disposables);
+			const result = await runtime.handlePermissionRequest({ kind: 'write' });
 			assert.strictEqual(result.kind, 'reject');
 		});
 
 		test('denied-interactively when user denies', async () => {
-			const { session, signals, waitForSignal } = await createAgentSession(disposables);
-			const resultPromise = session.handlePermissionRequest({
+			const { session, runtime, signals, waitForSignal } = await createAgentSession(disposables);
+			const resultPromise = runtime.handlePermissionRequest({
 				kind: 'shell',
 				toolCallId: 'tc-3',
 			});
@@ -858,8 +880,8 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('pending permissions are denied on dispose', async () => {
-			const { session } = await createAgentSession(disposables);
-			const resultPromise = session.handlePermissionRequest({
+			const { session, runtime } = await createAgentSession(disposables);
+			const resultPromise = runtime.handlePermissionRequest({
 				kind: 'write',
 				toolCallId: 'tc-4',
 			});
@@ -870,8 +892,8 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('pending permissions are denied on abort', async () => {
-			const { session } = await createAgentSession(disposables);
-			const resultPromise = session.handlePermissionRequest({
+			const { session, runtime } = await createAgentSession(disposables);
+			const resultPromise = runtime.handlePermissionRequest({
 				kind: 'write',
 				toolCallId: 'tc-5',
 			});
@@ -1375,10 +1397,10 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('edit hooks resolve relative apply_patch file paths against workingDirectory', async () => {
-			const capturedCallbacks: { current?: Parameters<SessionWrapperFactory>[0] } = {};
+			const capturedRuntime: { current?: ICopilotSessionRuntime } = {};
 			const workingDirectory = URI.file('/repo/project');
 			const absolutePath = URI.file('/tmp/absolute.ts').fsPath;
-			const { session } = await createAgentSession(disposables, { workingDirectory, captureWrapperCallbacks: capturedCallbacks });
+			const { session } = await createAgentSession(disposables, { workingDirectory, captureRuntime: capturedRuntime });
 			const sessionInternals = session as unknown as ISessionInternalsForTest;
 			const started: string[] = [];
 			const completed: string[] = [];
@@ -1398,14 +1420,14 @@ suite('CopilotAgentSession', () => {
 				'*** End Patch',
 			].join('\n');
 
-			await capturedCallbacks.current!.hooks.onPreToolUse({
+			await capturedRuntime.current!.handlePreToolUse({
 				sessionId: 'test-session-1',
 				timestamp: new Date(0),
 				workingDirectory: '/repo/project',
 				toolName: 'apply_patch',
 				toolArgs: patch,
 			});
-			await capturedCallbacks.current!.hooks.onPostToolUse({
+			await capturedRuntime.current!.handlePostToolUse({
 				sessionId: 'test-session-1',
 				timestamp: new Date(0),
 				workingDirectory: '/repo/project',
@@ -1975,10 +1997,10 @@ suite('CopilotAgentSession', () => {
 	suite('user input handling', () => {
 
 		test('handleUserInputRequest fires user_input_request progress event', async () => {
-			const { session, signals } = await createAgentSession(disposables);
+			const { session, runtime, signals } = await createAgentSession(disposables);
 
 			// Start the request (don't await — it blocks waiting for response)
-			const resultPromise = session.handleUserInputRequest(
+			const resultPromise = runtime.handleUserInputRequest(
 				{ question: 'What is your name?' },
 				{ sessionId: 'test-session-1' }
 			);
@@ -2005,9 +2027,9 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('handleUserInputRequest with choices generates SingleSelect question', async () => {
-			const { session, signals } = await createAgentSession(disposables);
+			const { session, runtime, signals } = await createAgentSession(disposables);
 
-			const resultPromise = session.handleUserInputRequest(
+			const resultPromise = runtime.handleUserInputRequest(
 				{ question: 'Pick a color', choices: ['red', 'blue', 'green'] },
 				{ sessionId: 'test-session-1' }
 			);
@@ -2037,9 +2059,9 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('handleUserInputRequest returns empty answer on cancel', async () => {
-			const { session, signals } = await createAgentSession(disposables);
+			const { session, runtime, signals } = await createAgentSession(disposables);
 
-			const resultPromise = session.handleUserInputRequest(
+			const resultPromise = runtime.handleUserInputRequest(
 				{ question: 'Cancel me' },
 				{ sessionId: 'test-session-1' }
 			);
@@ -2058,9 +2080,9 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('handleUserInputRequest returns empty answer on skipped question', async () => {
-			const { session, signals } = await createAgentSession(disposables);
+			const { session, runtime, signals } = await createAgentSession(disposables);
 
-			const resultPromise = session.handleUserInputRequest(
+			const resultPromise = runtime.handleUserInputRequest(
 				{ question: 'Skip me' },
 				{ sessionId: 'test-session-1' }
 			);
@@ -2079,9 +2101,9 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('pending user inputs are cancelled on dispose', async () => {
-			const { session } = await createAgentSession(disposables);
+			const { session, runtime } = await createAgentSession(disposables);
 
-			const resultPromise = session.handleUserInputRequest(
+			const resultPromise = runtime.handleUserInputRequest(
 				{ question: 'Will be cancelled' },
 				{ sessionId: 'test-session-1' }
 			);
@@ -2093,11 +2115,11 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('autopilot auto-answers a free-form question without firing a progress event', async () => {
-			const { session, signals } = await createAgentSession(disposables, {
+			const { runtime, signals } = await createAgentSession(disposables, {
 				configValues: { [SessionConfigKey.AutoApprove]: 'autopilot' },
 			});
 
-			const result = await session.handleUserInputRequest(
+			const result = await runtime.handleUserInputRequest(
 				{ question: 'Pick a color', choices: ['red', 'blue', 'green'] },
 				{ sessionId: 'test-session-1' }
 			);
@@ -2113,11 +2135,11 @@ suite('CopilotAgentSession', () => {
 		test('autopilot does not auto-answer when autoApprove is not "autopilot"', async () => {
 			// Sanity check: with autoApprove=default the question must
 			// still be surfaced as a progress event (the existing behavior).
-			const { session, signals } = await createAgentSession(disposables, {
+			const { runtime, signals } = await createAgentSession(disposables, {
 				configValues: { [SessionConfigKey.AutoApprove]: 'default' },
 			});
 
-			session.handleUserInputRequest(
+			runtime.handleUserInputRequest(
 				{ question: 'Need user input' },
 				{ sessionId: 'test-session-1' }
 			);
@@ -2135,9 +2157,9 @@ suite('CopilotAgentSession', () => {
 	suite('elicitation handling', () => {
 
 		test('form-mode request projects schema fields to questions and accept round-trips content', async () => {
-			const { session, signals } = await createAgentSession(disposables);
+			const { session, runtime, signals } = await createAgentSession(disposables);
 
-			const resultPromise = session.handleElicitationRequest({
+			const resultPromise = runtime.handleElicitationRequest({
 				sessionId: 'test-session-1',
 				message: 'Configure deployment',
 				mode: 'form',
@@ -2195,9 +2217,9 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('skipped and missing answers are omitted from accept content', async () => {
-			const { session, signals } = await createAgentSession(disposables);
+			const { session, runtime, signals } = await createAgentSession(disposables);
 
-			const resultPromise = session.handleElicitationRequest({
+			const resultPromise = runtime.handleElicitationRequest({
 				sessionId: 'test-session-1',
 				message: 'Partial form',
 				mode: 'form',
@@ -2220,9 +2242,9 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('url-mode request surfaces url and accept returns no content', async () => {
-			const { session, signals } = await createAgentSession(disposables);
+			const { session, runtime, signals } = await createAgentSession(disposables);
 
-			const resultPromise = session.handleElicitationRequest({
+			const resultPromise = runtime.handleElicitationRequest({
 				sessionId: 'test-session-1',
 				message: 'Open this link',
 				mode: 'url',
@@ -2238,9 +2260,9 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('free-form request (no schema) returns submitted text as content.answer', async () => {
-			const { session, signals } = await createAgentSession(disposables);
+			const { session, runtime, signals } = await createAgentSession(disposables);
 
-			const resultPromise = session.handleElicitationRequest({
+			const resultPromise = runtime.handleElicitationRequest({
 				sessionId: 'test-session-1',
 				message: 'What is your favorite color?',
 				mode: 'form',
@@ -2258,9 +2280,9 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('decline response maps to action=decline', async () => {
-			const { session, signals } = await createAgentSession(disposables);
+			const { session, runtime, signals } = await createAgentSession(disposables);
 
-			const resultPromise = session.handleElicitationRequest({
+			const resultPromise = runtime.handleElicitationRequest({
 				sessionId: 'test-session-1',
 				message: 'Please confirm',
 				mode: 'form',
@@ -2273,9 +2295,9 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('cancel response maps to action=cancel', async () => {
-			const { session, signals } = await createAgentSession(disposables);
+			const { session, runtime, signals } = await createAgentSession(disposables);
 
-			const resultPromise = session.handleElicitationRequest({
+			const resultPromise = runtime.handleElicitationRequest({
 				sessionId: 'test-session-1',
 				message: 'Please confirm',
 				mode: 'form',
@@ -2288,11 +2310,11 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('autopilot auto-cancels without firing a progress event', async () => {
-			const { session, signals } = await createAgentSession(disposables, {
+			const { runtime, signals } = await createAgentSession(disposables, {
 				configValues: { [SessionConfigKey.AutoApprove]: 'autopilot' },
 			});
 
-			const result = await session.handleElicitationRequest({
+			const result = await runtime.handleElicitationRequest({
 				sessionId: 'test-session-1',
 				message: 'Need input',
 				mode: 'form',
@@ -2304,9 +2326,9 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('pending elicitations are cancelled on dispose', async () => {
-			const { session } = await createAgentSession(disposables);
+			const { session, runtime } = await createAgentSession(disposables);
 
-			const resultPromise = session.handleElicitationRequest({
+			const resultPromise = runtime.handleElicitationRequest({
 				sessionId: 'test-session-1',
 				message: 'Will be cancelled',
 				mode: 'form',
@@ -2322,14 +2344,14 @@ suite('CopilotAgentSession', () => {
 
 		test('logs and rethrows user input callback failures', async () => {
 			const logService = new CapturingLogService();
-			const { session } = await createAgentSession(disposables, { logService });
+			const { session, runtime } = await createAgentSession(disposables, { logService });
 			const sessionInternals = session as unknown as ISessionInternalsForTest;
 			sessionInternals._onDidSessionProgress.fire = () => {
 				throw new Error('user input boom');
 			};
 
 			await assert.rejects(
-				session.handleUserInputRequest(
+				runtime.handleUserInputRequest(
 					{ question: 'Need input' },
 					{ sessionId: 'test-session-1' },
 				),
@@ -2345,15 +2367,15 @@ suite('CopilotAgentSession', () => {
 
 		test('logs and rethrows onPreToolUse failures', async () => {
 			const logService = new CapturingLogService();
-			const capturedCallbacks: { current?: Parameters<SessionWrapperFactory>[0] } = {};
-			const { session } = await createAgentSession(disposables, { logService, captureWrapperCallbacks: capturedCallbacks });
+			const capturedRuntime: { current?: ICopilotSessionRuntime } = {};
+			const { session } = await createAgentSession(disposables, { logService, captureRuntime: capturedRuntime });
 			const sessionInternals = session as unknown as ISessionInternalsForTest;
 			sessionInternals._editTracker.trackEditStart = async () => {
 				throw new Error('pre tool boom');
 			};
 
 			await assert.rejects(
-				capturedCallbacks.current!.hooks.onPreToolUse({
+				capturedRuntime.current!.handlePreToolUse({
 					sessionId: 'test-session-1',
 					timestamp: new Date(0),
 					workingDirectory: '/tmp',
@@ -2372,15 +2394,15 @@ suite('CopilotAgentSession', () => {
 
 		test('logs and rethrows onPostToolUse failures', async () => {
 			const logService = new CapturingLogService();
-			const capturedCallbacks: { current?: Parameters<SessionWrapperFactory>[0] } = {};
-			const { session } = await createAgentSession(disposables, { logService, captureWrapperCallbacks: capturedCallbacks });
+			const capturedRuntime: { current?: ICopilotSessionRuntime } = {};
+			const { session } = await createAgentSession(disposables, { logService, captureRuntime: capturedRuntime });
 			const sessionInternals = session as unknown as ISessionInternalsForTest;
 			sessionInternals._editTracker.completeEdit = async () => {
 				throw new Error('post tool boom');
 			};
 
 			await assert.rejects(
-				capturedCallbacks.current!.hooks.onPostToolUse({
+				capturedRuntime.current!.handlePostToolUse({
 					sessionId: 'test-session-1',
 					timestamp: new Date(0),
 					workingDirectory: '/tmp',
@@ -2414,7 +2436,7 @@ suite('CopilotAgentSession', () => {
 		};
 
 		test('client tool handler waits for completion without emitting tool_ready', async () => {
-			const { session, mockSession, signals } = await createAgentSession(disposables, { clientSnapshot: snapshot });
+			const { session, runtime, mockSession, signals } = await createAgentSession(disposables, { clientSnapshot: snapshot });
 
 			// SDK emits tool.execution_start — tool_start fires immediately
 			mockSession.fire('tool.execution_start', {
@@ -2433,7 +2455,7 @@ suite('CopilotAgentSession', () => {
 
 			// SDK invokes the handler — it creates a deferred and waits,
 			// but does NOT fire tool_ready (that comes from the permission flow).
-			const tools = session.createClientSdkTools();
+			const tools = runtime.createClientSdkTools();
 			const handlerPromise = invokeClientToolHandler(tools[0], 'tc-client-1', { file: 'test.ts' });
 
 			// No pending_confirmation or tool_ready should have been emitted by the handler
@@ -2452,7 +2474,7 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('client tool handler does not emit tool_ready (permission flow owns it)', async () => {
-			const { session, mockSession, signals, waitForSignal } = await createAgentSession(disposables, { clientSnapshot: snapshot });
+			const { session, runtime, mockSession, signals, waitForSignal } = await createAgentSession(disposables, { clientSnapshot: snapshot });
 
 			// SDK emits tool.execution_start — tool_start fires immediately
 			mockSession.fire('tool.execution_start', {
@@ -2466,7 +2488,7 @@ suite('CopilotAgentSession', () => {
 			assert.strictEqual(signals.filter(s => s.kind === 'pending_confirmation').length, 0);
 
 			// Permission request fires — pending_confirmation from permission flow.
-			const resultPromise = session.handlePermissionRequest({
+			const resultPromise = runtime.handlePermissionRequest({
 				kind: 'custom-tool',
 				toolCallId: 'tc-client-perm',
 				toolName: 'my_tool',
@@ -2479,7 +2501,7 @@ suite('CopilotAgentSession', () => {
 			assert.strictEqual(permSignals[0].state.toolCallId, 'tc-client-perm');
 			assert.ok(permSignals[0].state.confirmationTitle);
 
-			const tools = session.createClientSdkTools();
+			const tools = runtime.createClientSdkTools();
 			const handlerPromise = invokeClientToolHandler(tools[0], 'tc-client-perm');
 
 			// The handler should NOT emit its own pending_confirmation — only the
@@ -2505,7 +2527,7 @@ suite('CopilotAgentSession', () => {
 			// SessionToolCallReady to the subagent session and emits a
 			// stray ready against the parent session (no preceding
 			// SessionToolCallStart).
-			const { session, mockSession, signals, waitForSignal } = await createAgentSession(disposables, { clientSnapshot: snapshot });
+			const { session, runtime, mockSession, signals, waitForSignal } = await createAgentSession(disposables, { clientSnapshot: snapshot });
 
 			mockSession.fire('subagent.started', {
 				toolCallId: 'tc-parent-subagent',
@@ -2520,7 +2542,7 @@ suite('CopilotAgentSession', () => {
 				arguments: {},
 			} as SessionEventPayload<'tool.execution_start'>['data'], { agentId: 'agent-client-tool' });
 
-			const resultPromise = session.handlePermissionRequest({
+			const resultPromise = runtime.handlePermissionRequest({
 				kind: 'custom-tool',
 				toolCallId: 'tc-sub-client',
 				toolName: 'my_tool',
@@ -2536,7 +2558,7 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('handleClientToolCallComplete pre-completes when no handler is waiting yet', async () => {
-			const { session } = await createAgentSession(disposables, { clientSnapshot: snapshot });
+			const { session, runtime } = await createAgentSession(disposables, { clientSnapshot: snapshot });
 
 			// Completion arrives before handler — pre-creates deferred
 			session.handleClientToolCallComplete('tc-unknown', {
@@ -2545,15 +2567,15 @@ suite('CopilotAgentSession', () => {
 			});
 
 			// Handler picks up the pre-completed result
-			const tools = session.createClientSdkTools();
+			const tools = runtime.createClientSdkTools();
 			const result = await invokeClientToolHandler(tools[0], 'tc-unknown');
 			assert.strictEqual(result.resultType, 'success');
 		});
 
 		test('handleClientToolCallComplete with failure result', async () => {
-			const { session } = await createAgentSession(disposables, { clientSnapshot: snapshot });
+			const { session, runtime } = await createAgentSession(disposables, { clientSnapshot: snapshot });
 
-			const tools = session.createClientSdkTools();
+			const tools = runtime.createClientSdkTools();
 			const handlerPromise = invokeClientToolHandler(tools[0], 'tc-client-3');
 
 			session.handleClientToolCallComplete('tc-client-3', {
@@ -2568,9 +2590,9 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('pending client tool calls are cancelled on dispose', async () => {
-			const { session } = await createAgentSession(disposables, { clientSnapshot: snapshot });
+			const { session, runtime } = await createAgentSession(disposables, { clientSnapshot: snapshot });
 
-			const tools = session.createClientSdkTools();
+			const tools = runtime.createClientSdkTools();
 			const handlerPromise = invokeClientToolHandler(tools[0], 'tc-client-4');
 
 			session.dispose();
@@ -2580,9 +2602,9 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('multiple concurrent client tool calls resolve independently', async () => {
-			const { session } = await createAgentSession(disposables, { clientSnapshot: snapshot });
+			const { session, runtime } = await createAgentSession(disposables, { clientSnapshot: snapshot });
 
-			const tools = session.createClientSdkTools();
+			const tools = runtime.createClientSdkTools();
 			const promise1 = invokeClientToolHandler(tools[0], 'tc-multi-1');
 			const promise2 = invokeClientToolHandler(tools[0], 'tc-multi-2');
 
@@ -2604,9 +2626,9 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('handler cleans up deferred after consuming result', async () => {
-			const { session } = await createAgentSession(disposables, { clientSnapshot: snapshot });
+			const { session, runtime } = await createAgentSession(disposables, { clientSnapshot: snapshot });
 
-			const tools = session.createClientSdkTools();
+			const tools = runtime.createClientSdkTools();
 			const handlerPromise = invokeClientToolHandler(tools[0], 'tc-cleanup');
 
 			session.handleClientToolCallComplete('tc-cleanup', {
@@ -2627,8 +2649,8 @@ suite('CopilotAgentSession', () => {
 
 		test('client tool handler logs and rethrows failures', async () => {
 			const logService = new CapturingLogService();
-			const { session } = await createAgentSession(disposables, { clientSnapshot: snapshot, logService });
-			const tools = session.createClientSdkTools();
+			const { session, runtime } = await createAgentSession(disposables, { clientSnapshot: snapshot, logService });
+			const tools = runtime.createClientSdkTools();
 			const sessionInternals = session as unknown as ISessionInternalsForTest;
 			sessionInternals._pendingClientToolCalls.get = () => {
 				throw new Error('client tool boom');
@@ -2647,7 +2669,7 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('permission request before client tool handler emits only confirmation ready', async () => {
-			const { session, mockSession, signals, waitForSignal } = await createAgentSession(disposables, { clientSnapshot: snapshot });
+			const { session, runtime, mockSession, signals, waitForSignal } = await createAgentSession(disposables, { clientSnapshot: snapshot });
 
 			mockSession.fire('tool.execution_start', {
 				toolCallId: 'tc-ready-data',
@@ -2660,7 +2682,7 @@ suite('CopilotAgentSession', () => {
 
 			// Permission before the handler should produce only the confirmation
 			// pending_confirmation, not a synthetic auto-ready.
-			const resultPromise = session.handlePermissionRequest({
+			const resultPromise = runtime.handlePermissionRequest({
 				kind: 'custom-tool',
 				toolCallId: 'tc-ready-data',
 				toolName: 'my_tool',
@@ -2676,9 +2698,9 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('handleClientToolCallComplete with content containing embedded resources', async () => {
-			const { session } = await createAgentSession(disposables, { clientSnapshot: snapshot });
+			const { session, runtime } = await createAgentSession(disposables, { clientSnapshot: snapshot });
 
-			const tools = session.createClientSdkTools();
+			const tools = runtime.createClientSdkTools();
 			const handlerPromise = invokeClientToolHandler(tools[0], 'tc-embedded');
 
 			session.handleClientToolCallComplete('tc-embedded', {
@@ -2734,11 +2756,11 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('handleExitPlanModeRequest produces a single-select input request with options and recommended', async () => {
-			const { session, mockSession, signals, waitForSignal } = await createAgentSession(disposables);
+			const { session, runtime, mockSession, signals, waitForSignal } = await createAgentSession(disposables);
 
 			mockSession.planReadResult = { exists: true, content: '## Plan', path: '/sessions/abc/plan.md' };
 
-			const responsePromise = session.handleExitPlanModeRequest(planRequestParams(), { sessionId: 'test-session-1' });
+			const responsePromise = runtime.handleExitPlanModeRequest(planRequestParams(), { sessionId: 'test-session-1' });
 
 			const signal = await waitForSignal(s => isAction(s, ActionType.SessionInputRequested));
 			const request = getInputRequest(signal);
@@ -2775,9 +2797,9 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('completing the input request with autopilot resolves with approved + autopilot + autoApproveEdits', async () => {
-			const { session, waitForSignal } = await createAgentSession(disposables);
+			const { session, runtime, waitForSignal } = await createAgentSession(disposables);
 
-			const responsePromise = session.handleExitPlanModeRequest(planRequestParams({ actions: ['autopilot', 'interactive'], recommendedAction: 'autopilot' }), { sessionId: 'test-session-1' });
+			const responsePromise = runtime.handleExitPlanModeRequest(planRequestParams({ actions: ['autopilot', 'interactive'], recommendedAction: 'autopilot' }), { sessionId: 'test-session-1' });
 			const signal = await waitForSignal(s => isAction(s, ActionType.SessionInputRequested));
 			const request = getInputRequest(signal);
 			const requestId = request.id;
@@ -2794,9 +2816,9 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('completing the input request with interactive resolves with approved + interactive (no autoApprove)', async () => {
-			const { session, waitForSignal } = await createAgentSession(disposables);
+			const { session, runtime, waitForSignal } = await createAgentSession(disposables);
 
-			const responsePromise = session.handleExitPlanModeRequest(planRequestParams({ actions: ['autopilot', 'interactive'], recommendedAction: 'interactive' }), { sessionId: 'test-session-1' });
+			const responsePromise = runtime.handleExitPlanModeRequest(planRequestParams({ actions: ['autopilot', 'interactive'], recommendedAction: 'interactive' }), { sessionId: 'test-session-1' });
 			const signal = await waitForSignal(s => isAction(s, ActionType.SessionInputRequested));
 			const request = getInputRequest(signal);
 			const requestId = request.id;
@@ -2813,9 +2835,9 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('declining the input request resolves with approved=false', async () => {
-			const { session, waitForSignal } = await createAgentSession(disposables);
+			const { session, runtime, waitForSignal } = await createAgentSession(disposables);
 
-			const responsePromise = session.handleExitPlanModeRequest(planRequestParams(), { sessionId: 'test-session-1' });
+			const responsePromise = runtime.handleExitPlanModeRequest(planRequestParams(), { sessionId: 'test-session-1' });
 			const signal = await waitForSignal(s => isAction(s, ActionType.SessionInputRequested));
 
 			session.respondToUserInputRequest(getInputRequest(signal).id, SessionInputResponseKind.Decline);
@@ -2824,9 +2846,9 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('exit_only resolves as approved + interactive without autoApproveEdits', async () => {
-			const { session, waitForSignal } = await createAgentSession(disposables);
+			const { session, runtime, waitForSignal } = await createAgentSession(disposables);
 
-			const responsePromise = session.handleExitPlanModeRequest(planRequestParams({ actions: ['autopilot', 'interactive', 'exit_only'], recommendedAction: 'exit_only' }), { sessionId: 'test-session-1' });
+			const responsePromise = runtime.handleExitPlanModeRequest(planRequestParams({ actions: ['autopilot', 'interactive', 'exit_only'], recommendedAction: 'exit_only' }), { sessionId: 'test-session-1' });
 			const signal = await waitForSignal(s => isAction(s, ActionType.SessionInputRequested));
 			const request = getInputRequest(signal);
 			const requestId = request.id;
@@ -2843,9 +2865,9 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('freeform feedback alongside a selected action becomes a revision request', async () => {
-			const { session, waitForSignal } = await createAgentSession(disposables);
+			const { session, runtime, waitForSignal } = await createAgentSession(disposables);
 
-			const responsePromise = session.handleExitPlanModeRequest(planRequestParams({ actions: ['autopilot', 'interactive'], recommendedAction: 'interactive' }), { sessionId: 'test-session-1' });
+			const responsePromise = runtime.handleExitPlanModeRequest(planRequestParams({ actions: ['autopilot', 'interactive'], recommendedAction: 'interactive' }), { sessionId: 'test-session-1' });
 			const signal = await waitForSignal(s => isAction(s, ActionType.SessionInputRequested));
 			const request = getInputRequest(signal);
 			const requestId = request.id;
@@ -2870,9 +2892,9 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('selectedAction not in offered actions falls back to recommendedAction', async () => {
-			const { session, waitForSignal } = await createAgentSession(disposables);
+			const { session, runtime, waitForSignal } = await createAgentSession(disposables);
 
-			const responsePromise = session.handleExitPlanModeRequest(planRequestParams({ actions: ['interactive', 'exit_only'], recommendedAction: 'interactive' }), { sessionId: 'test-session-1' });
+			const responsePromise = runtime.handleExitPlanModeRequest(planRequestParams({ actions: ['interactive', 'exit_only'], recommendedAction: 'interactive' }), { sessionId: 'test-session-1' });
 			const signal = await waitForSignal(s => isAction(s, ActionType.SessionInputRequested));
 			const request = getInputRequest(signal);
 			const requestId = request.id;
@@ -2893,12 +2915,12 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('selectedAction not in offered actions and no fallback resolves to approved=false', async () => {
-			const { session, waitForSignal } = await createAgentSession(disposables);
+			const { session, runtime, waitForSignal } = await createAgentSession(disposables);
 
 			// SDK offered `exit_only` only and recommended a value not in
 			// the offered set. The client picked something invalid. With
 			// no usable selectedAction and no feedback, decline.
-			const responsePromise = session.handleExitPlanModeRequest(planRequestParams({ actions: ['exit_only'], recommendedAction: 'autopilot' }), { sessionId: 'test-session-1' });
+			const responsePromise = runtime.handleExitPlanModeRequest(planRequestParams({ actions: ['exit_only'], recommendedAction: 'autopilot' }), { sessionId: 'test-session-1' });
 			const signal = await waitForSignal(s => isAction(s, ActionType.SessionInputRequested));
 			const request = getInputRequest(signal);
 			const requestId = request.id;
@@ -2915,9 +2937,9 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('text answer with feedback becomes a revision request without selectedAction', async () => {
-			const { session, waitForSignal } = await createAgentSession(disposables);
+			const { session, runtime, waitForSignal } = await createAgentSession(disposables);
 
-			const responsePromise = session.handleExitPlanModeRequest(planRequestParams({ actions: ['autopilot', 'interactive'], recommendedAction: 'interactive' }), { sessionId: 'test-session-1' });
+			const responsePromise = runtime.handleExitPlanModeRequest(planRequestParams({ actions: ['autopilot', 'interactive'], recommendedAction: 'interactive' }), { sessionId: 'test-session-1' });
 			const signal = await waitForSignal(s => isAction(s, ActionType.SessionInputRequested));
 			const request = getInputRequest(signal);
 			const requestId = request.id;
@@ -2942,9 +2964,9 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('whitespace-only freeform feedback is ignored', async () => {
-			const { session, waitForSignal } = await createAgentSession(disposables);
+			const { session, runtime, waitForSignal } = await createAgentSession(disposables);
 
-			const responsePromise = session.handleExitPlanModeRequest(planRequestParams({ actions: ['autopilot', 'interactive'], recommendedAction: 'interactive' }), { sessionId: 'test-session-1' });
+			const responsePromise = runtime.handleExitPlanModeRequest(planRequestParams({ actions: ['autopilot', 'interactive'], recommendedAction: 'interactive' }), { sessionId: 'test-session-1' });
 			const signal = await waitForSignal(s => isAction(s, ActionType.SessionInputRequested));
 			const request = getInputRequest(signal);
 			const requestId = request.id;
@@ -3008,11 +3030,11 @@ suite('CopilotAgentSession', () => {
 		// ---- autopilot fast-path -------------------------------------------
 
 		test('handleExitPlanModeRequest auto-accepts when autoApprove=autopilot (recommended action)', async () => {
-			const { session, signals } = await createAgentSession(disposables, {
+			const { runtime, signals } = await createAgentSession(disposables, {
 				configValues: { [SessionConfigKey.AutoApprove]: 'autopilot' },
 			});
 
-			const response = await session.handleExitPlanModeRequest(planRequestParams({
+			const response = await runtime.handleExitPlanModeRequest(planRequestParams({
 				actions: ['autopilot', 'interactive', 'exit_only'],
 				recommendedAction: 'autopilot',
 			}), { sessionId: 'test-session-1' });
@@ -3023,14 +3045,14 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('handleExitPlanModeRequest auto-accepts with priority order when no recommended action available', async () => {
-			const { session } = await createAgentSession(disposables, {
+			const { runtime } = await createAgentSession(disposables, {
 				configValues: { [SessionConfigKey.AutoApprove]: 'autopilot' },
 			});
 
 			// SDK proposes a recommended action that's NOT in the offered set —
 			// fall back to the priority order (autopilot > autopilot_fleet >
 			// interactive > exit_only).
-			const response = await session.handleExitPlanModeRequest(planRequestParams({
+			const response = await runtime.handleExitPlanModeRequest(planRequestParams({
 				actions: ['interactive', 'exit_only'],
 				recommendedAction: 'autopilot_fleet',
 			}), { sessionId: 'test-session-1' });
@@ -3039,11 +3061,11 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('handleExitPlanModeRequest does NOT auto-accept when autoApprove=default', async () => {
-			const { session, waitForSignal } = await createAgentSession(disposables, {
+			const { session, runtime, waitForSignal } = await createAgentSession(disposables, {
 				configValues: { [SessionConfigKey.AutoApprove]: 'default' },
 			});
 
-			const responsePromise = session.handleExitPlanModeRequest(planRequestParams(), { sessionId: 'test-session-1' });
+			const responsePromise = runtime.handleExitPlanModeRequest(planRequestParams(), { sessionId: 'test-session-1' });
 
 			// The user-input request fires — the user must respond.
 			const signal = await waitForSignal(s => isAction(s, ActionType.SessionInputRequested));


### PR DESCRIPTION
## Summary
- move Copilot SDK create/resume configuration into `CopilotSessionLauncher`
- keep `CopilotAgentSession` runtime callbacks behind a private adapter instead of public session methods
- update Copilot agent/session tests to exercise the launcher/runtime seam

## Validation
- `npm run compile-check-ts-native`
- `env -u ELECTRON_RUN_AS_NODE ./scripts/test.sh src/vs/platform/agentHost/test/node/copilotAgent.test.ts src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts`
- `npm run valid-layers-check`
- `node --experimental-strip-types build/hygiene.ts src/vs/platform/agentHost/node/copilot/copilotAgent.ts src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts src/vs/platform/agentHost/test/node/copilotAgent.test.ts src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts`

(Written by Copilot)