### PR TITLE
agentHost: speed up opening cold sessions with subagent history

### DIFF
--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -9,6 +9,7 @@ import { toErrorMessage } from '../../../base/common/errorMessage.js';
 import { Emitter } from '../../../base/common/event.js';
 import { Disposable, DisposableMap, DisposableResourceMap, DisposableStore, IDisposable, MutableDisposable } from '../../../base/common/lifecycle.js';
 import { ResourceMap } from '../../../base/common/map.js';
+import { StopWatch } from '../../../base/common/stopwatch.js';
 import { getExtensionForMimeType, getMediaMime } from '../../../base/common/mime.js';
 import { Schemas } from '../../../base/common/network.js';
 import { observableValue } from '../../../base/common/observable.js';
@@ -1247,6 +1248,7 @@ export class AgentService extends Disposable implements IAgentService {
 			return;
 		}
 
+		const sw = StopWatch.create();
 		const agent = this._findProviderForSession(session);
 		if (!agent) {
 			throw new ProtocolError(AHP_SESSION_NOT_FOUND, `No agent for session: ${sessionStr}`);
@@ -1256,6 +1258,7 @@ export class AgentService extends Disposable implements IAgentService {
 		if (!meta) {
 			throw new ProtocolError(AHP_SESSION_NOT_FOUND, `Session not found on backend: ${sessionStr}`);
 		}
+		const metadataMs = sw.elapsed();
 
 		let turns: readonly Turn[];
 		try {
@@ -1267,6 +1270,7 @@ export class AgentService extends Disposable implements IAgentService {
 			const message = err instanceof Error ? err.message : String(err);
 			throw new ProtocolError(JSON_RPC_INTERNAL_ERROR, `Failed to restore session ${sessionStr}: ${message}`);
 		}
+		const messagesMs = sw.elapsed() - metadataMs;
 
 		// Check for persisted metadata in the session database
 		let title = meta.summary ?? 'Session';
@@ -1367,6 +1371,7 @@ export class AgentService extends Disposable implements IAgentService {
 		// sessions that were not created in the current process lifetime.
 		// Overlay any values the user previously selected (persisted via
 		// `SessionConfigChanged`) on top of the provider's resolved defaults.
+		const configStart = sw.elapsed();
 		const restoredConfig = await this._resolveCreatedSessionConfig(agent, {
 			workingDirectory: meta.workingDirectory,
 			config: persistedConfigValues,
@@ -1377,8 +1382,9 @@ export class AgentService extends Disposable implements IAgentService {
 				restoredState.config = restoredConfig;
 			}
 		}
+		const configMs = sw.elapsed() - configStart;
 
-		this._logService.info(`[AgentService] Restored session ${sessionStr} with ${turns.length} turns`);
+		this._logService.info(`[AgentService] Restored session ${sessionStr} with ${turns.length} turns in ${Math.round(sw.elapsed())}ms (metadata ${Math.round(metadataMs)}ms, messages ${Math.round(messagesMs)}ms, resolveConfig ${Math.round(configMs)}ms)`);
 
 		// Lazily compute git state for sessions with a working directory;
 		// attaches under `state._meta.git` once ready.
@@ -1908,11 +1914,13 @@ export class AgentService extends Disposable implements IAgentService {
 		let childTurns: readonly Turn[] = [];
 		const agent = this._findProviderForSession(parentSession);
 		if (agent) {
+			const sw = StopWatch.create();
 			try {
 				childTurns = await agent.getSessionMessages(URI.parse(subagentUri));
 			} catch (err) {
 				this._logService.warn(`[AgentService] Failed to load subagent turns for ${subagentUri}`, err);
 			}
+			this._logService.info(`[AgentService] Loaded subagent turns for ${subagentUri} in ${Math.round(sw.elapsed())}ms`);
 		}
 
 		// Use metadata from subagent content if available, otherwise synthesize

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -41,6 +41,7 @@ import type { IUnsandboxedCommandConfirmationRequest, ShellManager } from './cop
 import { getEditFilePaths, getInvocationMessage, getPastTenseMessage, getPermissionDisplay, getShellLanguage, getSubagentMetadata, getToolDisplayName, getToolInputString, getToolKind, isEditTool, isHiddenTool, isShellTool, synthesizeSkillToolCall, tryStringify, type ITypedPermissionRequest } from './copilotToolDisplay.js';
 import { FileEditTracker } from '../shared/fileEditTracker.js';
 import { mapSessionEvents } from './mapSessionEvents.js';
+import { StopWatch } from '../../../../base/common/stopwatch.js';
 import { buildPendingEditContentUri } from './pendingEditContentStore.js';
 
 /**
@@ -350,6 +351,19 @@ export class CopilotAgentSession extends Disposable {
 	private _wrapper!: CopilotSessionWrapper;
 	/** Last agent mode pushed to the SDK via {@link applyMode}, to elide redundant `rpc.mode.set` calls. */
 	private _lastAppliedMode: CopilotSdkMode | undefined;
+	/**
+	 * Memoized result of {@link getEvents}+{@link mapSessionEvents}, shared by
+	 * {@link getMessages} and {@link getSubagentMessages}. When a session is
+	 * opened for viewing, the workbench enriches history by subscribing to every
+	 * subagent child session, each of which calls back into
+	 * {@link getSubagentMessages}. Without this cache, each call re-fetches the
+	 * full SDK event log and re-runs the full mapping just to extract one
+	 * subagent's turns — O(subagents · events). The cache collapses that burst
+	 * into a single mapping. It is invalidated by {@link _invalidateMappedEvents}
+	 * on any live activity ({@link _emitAction}) and on dispose, so it only
+	 * serves the idle session-open window.
+	 */
+	private _mappedSessionEvents: Promise<{ turns: Turn[]; subagentTurnsByToolCallId: ReadonlyMap<string, Turn[]> }> | undefined;
 	private readonly _steeringMessagesInFlight = new Set<string>();
 	/**
 	 * Steering messages that have been accepted by the SDK but not yet
@@ -461,6 +475,8 @@ export class CopilotAgentSession extends Disposable {
 
 	/** Wraps a {@link SessionAction} in an {@link AgentSignal} envelope and emits it. */
 	private _emitAction(action: SessionAction, parentToolCallId?: string): void {
+		// Any live state mutation makes the memoized event mapping stale.
+		this._invalidateMappedSessionEvents();
 		this._onDidSessionProgress.fire({
 			kind: 'action',
 			session: this.sessionUri,
@@ -955,19 +971,32 @@ export class CopilotAgentSession extends Disposable {
 	}
 
 	async getMessages(): Promise<readonly Turn[]> {
-		const events = await this._wrapper.session.getEvents();
-		let db: ISessionDatabase | undefined;
-		try {
-			db = this._databaseRef.object;
-		} catch {
-			// Database may not exist yet — that's fine
-		}
-		const result = await mapSessionEvents(this.sessionUri, db, events, this._workingDirectory);
+		const result = await this._getMappedSessionEvents();
 		return result.turns;
 	}
 
 	async getSubagentMessages(parentToolCallId: string): Promise<readonly Turn[]> {
+		const result = await this._getMappedSessionEvents();
+		return result.subagentTurnsByToolCallId.get(parentToolCallId) ?? [];
+	}
+
+	/**
+	 * Fetches the SDK event log and maps it to protocol turns, memoizing the
+	 * result so a burst of {@link getMessages}/{@link getSubagentMessages} calls
+	 * during session open shares a single fetch+map. See
+	 * {@link _mappedSessionEvents}.
+	 */
+	private _getMappedSessionEvents(): Promise<{ turns: Turn[]; subagentTurnsByToolCallId: ReadonlyMap<string, Turn[]> }> {
+		if (!this._mappedSessionEvents) {
+			this._mappedSessionEvents = this._computeMappedSessionEvents();
+		}
+		return this._mappedSessionEvents;
+	}
+
+	private async _computeMappedSessionEvents(): Promise<{ turns: Turn[]; subagentTurnsByToolCallId: ReadonlyMap<string, Turn[]> }> {
+		const sw = StopWatch.create();
 		const events = await this._wrapper.session.getEvents();
+		const getEventsMs = sw.elapsed();
 		let db: ISessionDatabase | undefined;
 		try {
 			db = this._databaseRef.object;
@@ -975,7 +1004,12 @@ export class CopilotAgentSession extends Disposable {
 			// Database may not exist yet — that's fine
 		}
 		const result = await mapSessionEvents(this.sessionUri, db, events, this._workingDirectory);
-		return result.subagentTurnsByToolCallId.get(parentToolCallId) ?? [];
+		this._logService.info(`[Copilot:${this.sessionId}] mapped session events: ${events.length} event(s) → ${result.turns.length} turn(s), ${result.subagentTurnsByToolCallId.size} subagent(s) (getEvents ${Math.round(getEventsMs)}ms, total ${Math.round(sw.elapsed())}ms)`);
+		return result;
+	}
+
+	private _invalidateMappedSessionEvents(): void {
+		this._mappedSessionEvents = undefined;
 	}
 
 	async abort(): Promise<void> {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -6,6 +6,7 @@
 import { encodeBase64, VSBuffer } from '../../../../../../base/common/buffer.js';
 import { CancellationToken, CancellationTokenSource } from '../../../../../../base/common/cancellation.js';
 import { isCancellationError } from '../../../../../../base/common/errors.js';
+import { StopWatch } from '../../../../../../base/common/stopwatch.js';
 import { Emitter } from '../../../../../../base/common/event.js';
 import { MarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { Disposable, DisposableResourceMap, DisposableStore, IReference, MutableDisposable, toDisposable, type IDisposable } from '../../../../../../base/common/lifecycle.js';
@@ -2169,70 +2170,120 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 	): Promise<void> {
 		const parentSessionStr = parentSession.toString();
 
+		// Collect every subagent tool call across all response items. Each one
+		// requires a round-trip to the host to restore the child session, so we
+		// resolve them concurrently rather than serially — a session with many
+		// subagent calls (task / rubber-duck / research) otherwise pays N
+		// sequential restores on open.
+		interface ISubagentInsertion {
+			readonly item: IChatSessionHistoryItem & { type: 'response' };
+			readonly index: number;
+			readonly toolCallId: string;
+		}
+		const insertions: ISubagentInsertion[] = [];
 		for (const item of history) {
 			if (item.type !== 'response') {
 				continue;
 			}
-
-			// Collect subagent tool calls from this response's parts
-			const subagentInsertions: { index: number; toolCallId: string }[] = [];
 			for (let i = 0; i < item.parts.length; i++) {
 				const part = item.parts[i];
 				if (part.kind === 'toolInvocationSerialized' && part.toolSpecificData?.kind === 'subagent') {
-					subagentInsertions.push({ index: i, toolCallId: part.toolCallId });
+					insertions.push({ item, index: i, toolCallId: part.toolCallId });
 				}
 			}
+		}
 
-			// Process insertions in reverse order so indices remain valid
-			for (let j = subagentInsertions.length - 1; j >= 0; j--) {
-				const { index, toolCallId } = subagentInsertions[j];
-				const childSessionUri = buildSubagentSessionUri(parentSessionStr, toolCallId);
+		if (insertions.length === 0) {
+			return;
+		}
 
-				try {
-					const childSub = this._ensureSessionSubscription(childSessionUri);
-					let childState = this._getSessionState(childSessionUri);
-					if (!childState) {
-						if (childSub.value instanceof Error) {
-							throw childSub.value;
-						}
-						await new Promise<void>(resolve => {
-							const d = childSub.onDidChange(() => { d.dispose(); resolve(); });
-						});
-						if (childSub.value instanceof Error) {
-							throw childSub.value;
-						}
-						childState = this._getSessionState(childSessionUri);
+		const sw = StopWatch.create();
+		const resolved = await Promise.all(insertions.map(async insertion => {
+			const innerParts = await this._loadSubagentInnerParts(parentSessionStr, insertion.toolCallId);
+			return { insertion, innerParts };
+		}));
+
+		// Apply insertions per response item in reverse index order so the
+		// splice points computed above remain valid as earlier inserts grow the
+		// array.
+		const byItem = new Map<IChatSessionHistoryItem, { index: number; innerParts: IChatProgress[] }[]>();
+		for (const { insertion, innerParts } of resolved) {
+			if (innerParts.length === 0) {
+				continue;
+			}
+			let list = byItem.get(insertion.item);
+			if (!list) {
+				list = [];
+				byItem.set(insertion.item, list);
+			}
+			list.push({ index: insertion.index, innerParts });
+		}
+		for (const [item, list] of byItem) {
+			if (item.type !== 'response') {
+				continue;
+			}
+			list.sort((a, b) => b.index - a.index);
+			for (const { index, innerParts } of list) {
+				item.parts.splice(index + 1, 0, ...innerParts);
+			}
+		}
+
+		this._logService.info(`[AgentHost] Enriched ${insertions.length} subagent call(s) for ${parentSessionStr} in ${Math.round(sw.elapsed())}ms`);
+	}
+
+	/**
+	 * Restores a single subagent child session and returns its completed tool
+	 * calls (plus any file-edit parts) as progress parts to splice into the
+	 * parent response. Returns an empty array on failure or when the child has
+	 * no renderable tool calls. Always releases the child subscription it
+	 * acquires.
+	 */
+	private async _loadSubagentInnerParts(parentSessionStr: string, toolCallId: string): Promise<IChatProgress[]> {
+		const childSessionUri = buildSubagentSessionUri(parentSessionStr, toolCallId);
+		try {
+			const childSub = this._ensureSessionSubscription(childSessionUri);
+			try {
+				let childState = this._getSessionState(childSessionUri);
+				if (!childState) {
+					if (childSub.value instanceof Error) {
+						throw childSub.value;
 					}
-					if (childState) {
-						const innerParts: IChatProgress[] = [];
-						for (const turn of childState.turns) {
-							for (const rp of turn.responseParts) {
-								if (rp.kind === ResponsePartKind.ToolCall) {
-									const tc = rp.toolCall;
-									if (tc.status === ToolCallStatus.Completed || tc.status === ToolCallStatus.Cancelled) {
-										const completedTc = tc as ICompletedToolCall;
-										const fileEditParts = completedToolCallToEditParts(completedTc, this._config.connectionAuthority);
-										const serialized = completedToolCallToSerialized(completedTc, toolCallId, URI.parse(childSessionUri), this._config.connectionAuthority);
-										if (fileEditParts.length > 0) {
-											serialized.presentation = ToolInvocationPresentation.Hidden;
-										}
-										innerParts.push(serialized);
-										innerParts.push(...fileEditParts);
-									}
+					await new Promise<void>(resolve => {
+						const d = childSub.onDidChange(() => { d.dispose(); resolve(); });
+					});
+					if (childSub.value instanceof Error) {
+						throw childSub.value;
+					}
+					childState = this._getSessionState(childSessionUri);
+				}
+				if (!childState) {
+					return [];
+				}
+				const innerParts: IChatProgress[] = [];
+				for (const turn of childState.turns) {
+					for (const rp of turn.responseParts) {
+						if (rp.kind === ResponsePartKind.ToolCall) {
+							const tc = rp.toolCall;
+							if (tc.status === ToolCallStatus.Completed || tc.status === ToolCallStatus.Cancelled) {
+								const completedTc = tc as ICompletedToolCall;
+								const fileEditParts = completedToolCallToEditParts(completedTc, this._config.connectionAuthority);
+								const serialized = completedToolCallToSerialized(completedTc, toolCallId, URI.parse(childSessionUri), this._config.connectionAuthority);
+								if (fileEditParts.length > 0) {
+									serialized.presentation = ToolInvocationPresentation.Hidden;
 								}
+								innerParts.push(serialized);
+								innerParts.push(...fileEditParts);
 							}
 						}
-						if (innerParts.length > 0) {
-							// Insert inner tool calls right after the subagent tool call
-							item.parts.splice(index + 1, 0, ...innerParts);
-						}
 					}
-				} catch (err) {
-					this._logService.warn(`[AgentHost] Failed to enrich history with subagent calls: ${childSessionUri}`, err);
-				} finally {
-					this._releaseSessionSubscription(childSessionUri);
 				}
+				return innerParts;
+			} finally {
+				this._releaseSessionSubscription(childSessionUri);
 			}
+		} catch (err) {
+			this._logService.warn(`[AgentHost] Failed to enrich history with subagent calls: ${childSessionUri}`, err);
+			return [];
 		}
 	}
 


### PR DESCRIPTION
## Problem

Switching to a cold (previously-evicted) local Agent Host session was slow to render. `AgentHostSessionHandler.provideChatSessionContent` blocks on `_enrichHistoryWithSubagentCalls`, which subscribed to each subagent child session **serially**. On the server, every subagent restore re-fetched the full SDK event log and re-ran `mapSessionEvents` over the entire parent transcript just to pull out one subagent's  so a session with N subagent tool calls (task / rubber-duck / research) paid N serial round-trips and N full re-mappings of the  O(       events)). The enrichment was introduced in #308592.N log (turns 

## Changes

- **Memoize** `getEvents()` + `mapSessionEvents()` on `CopilotAgentSession`, shared by `getMessages`/`getSubagentMessages` and invalidated on any live activity (`_emitAction`) and on dispose. The open-time burst of subagent reads collapses from N full mappings to one.
- **Parallelize** subagent history enrichment in `_enrichHistoryWithSubagentCalls` (`Promise.all`), preserving insertion order.
- **Timing logs** around the restore phases (`restoreSession` metadata/messages/resolveConfig, per-subagent restore, mapped-events build, client-side enrich) so the breakdown is visible when diagnosing open latency.

## Validation

- `compile-check-ts-native` clean
- Unit: CopilotAgentSession (111), CopilotAgent (46), AgentHost browser suite (922) passing
- Integration: `turnExecution.integrationTest` including the subagent routing test passing

## Follow-ups (not in this PR)

- `restoreSession` still awaits `_resolveCreatedSessionConfig` (git branch probing) before returning the snapshot, though it's only needed for the auto-approve/session-config picker, not for rendering  could be deferred off the critical path like `_attachGitState`.history 
- Duplicate `getSessionMetadata` SDK call (once in `_getSessionMetadataForRestore`, again inside `_resumeSession`).

(Written by Copilot)