### PR TITLE
Fix disposable leak warning from in-process node.js file watcher

### DIFF
--- a/src/vs/platform/files/node/watcher/nodejs/nodejsWatcherLib.ts
+++ b/src/vs/platform/files/node/watcher/nodejs/nodejsWatcherLib.ts
@@ -112,11 +112,6 @@ export class NodeJSFileWatcherLibrary extends Disposable {
 				return;
 			}
 
-			// `doWatch` is async and the watcher may be disposed while we
-			// await it. Use `thenRegisterOrDispose` so the resulting handle
-			// is disposed instead of registered (and leaked) when this
-			// happens, avoiding a "disposable added to a disposed store"
-			// warning during teardown.
 			await thenRegisterOrDispose(this.doWatch(stat.isDirectory()), this._store);
 		} catch (error) {
 			if (error.code !== 'ENOENT') {

--- a/src/vs/platform/files/node/watcher/nodejs/nodejsWatcherLib.ts
+++ b/src/vs/platform/files/node/watcher/nodejs/nodejsWatcherLib.ts
@@ -112,7 +112,12 @@ export class NodeJSFileWatcherLibrary extends Disposable {
 				return;
 			}
 
-			this._register(await this.doWatch(stat.isDirectory()));
+			// `doWatch` is async and the watcher may be disposed while we
+			// await it. Use `thenRegisterOrDispose` so the resulting handle
+			// is disposed instead of registered (and leaked) when this
+			// happens, avoiding a "disposable added to a disposed store"
+			// warning during teardown.
+			await thenRegisterOrDispose(this.doWatch(stat.isDirectory()), this._store);
 		} catch (error) {
 			if (error.code !== 'ENOENT') {
 				this.error(error);


### PR DESCRIPTION
Fixes #320245

`NodeJSFileWatcherLibrary.watch()` awaited `doWatch()` and then called `this._register()` on the result. If the watcher instance was disposed while that promise was in flight, `_store` was already disposed by the time `_register` ran, producing:

> Trying to add a disposable to a DisposableStore that has already been disposed of. The added object will be leaked!

and leaking the underlying `fs.watch` handle.

This surfaces frequently in the agent host because non-recursive file watching runs in-process there, and `SessionCustomizationDiscovery` tears down and recreates watchers on the same paths whenever workspace files change.

The fix uses the existing `thenRegisterOrDispose` helper (already used elsewhere in the same file) so the resolved handle is disposed instead of registered + leaked when the watcher is torn down mid-flight.

Type-check (`compile-check-ts-native`) passes.

(Written by Copilot)
