### PR TITLE
Strip redundant cd prefix from multi-line shell commands

### DIFF
--- a/src/vs/platform/agentHost/common/commandLineHelpers.ts
+++ b/src/vs/platform/agentHost/common/commandLineHelpers.ts
@@ -21,7 +21,7 @@ export interface IExtractedCdPrefix {
  * the directory matches anything — callers do that comparison themselves.
  *
  * The separator between the `cd` and the remaining command may be `&&` or a
- * newline (bash treats a bare newline as a command separator just like `&&`).
+ * newline (bash treats a bare newline as a command separator like `;`).
  * PowerShell additionally accepts `;`. The remaining command may span multiple
  * lines (the model frequently emits `cd <dir>` on its own line followed by a
  * multi-line script).

--- a/src/vs/platform/agentHost/common/commandLineHelpers.ts
+++ b/src/vs/platform/agentHost/common/commandLineHelpers.ts
@@ -20,9 +20,15 @@ export interface IExtractedCdPrefix {
  * line, returning the directory and remaining command. Does not check whether
  * the directory matches anything — callers do that comparison themselves.
  *
+ * The separator between the `cd` and the remaining command may be `&&` or a
+ * newline (bash treats a bare newline as a command separator just like `&&`).
+ * PowerShell additionally accepts `;`. The remaining command may span multiple
+ * lines (the model frequently emits `cd <dir>` on its own line followed by a
+ * multi-line script).
+ *
  * Recognized forms:
- * - bash:       `cd <dir> && <suffix>`
- * - powershell: `cd <dir> && <suffix>`, `cd <dir>; <suffix>`
+ * - bash:       `cd <dir> && <suffix>`, `cd <dir>\n<suffix>`
+ * - powershell: `cd <dir> && <suffix>`, `cd <dir>; <suffix>`, `cd <dir>\n<suffix>`
  *               `cd /d <dir> && <suffix>`, `cd /d <dir>; <suffix>`
  *               `Set-Location <dir> && <suffix>`, `Set-Location <dir>; <suffix>`
  *               `Set-Location -Path <dir> && <suffix>`, `Set-Location -Path <dir>; <suffix>`
@@ -32,8 +38,8 @@ export interface IExtractedCdPrefix {
 export function extractCdPrefix(commandLine: string, isPowerShell: boolean): IExtractedCdPrefix | undefined {
 	const cdPrefixMatch = commandLine.match(
 		isPowerShell
-			? /^(?:cd(?: \/d)?|Set-Location(?: -Path)?) (?<dir>"[^"]*"|[^\s]+) ?(?:&&|;)\s+(?<suffix>.+)$/i
-			: /^cd (?<dir>"[^"]*"|[^\s]+) &&\s+(?<suffix>.+)$/
+			? /^(?:cd(?: \/d)?|Set-Location(?: -Path)?) (?<dir>"[^"]*"|[^\s]+) *(?:&&|;|\r?\n)\s*(?<suffix>[\s\S]+)$/i
+			: /^cd (?<dir>"[^"]*"|[^\s]+) *(?:&&|\r?\n)\s*(?<suffix>[\s\S]+)$/
 	);
 	const cdDir = cdPrefixMatch?.groups?.dir;
 	const cdSuffix = cdPrefixMatch?.groups?.suffix;
@@ -118,4 +124,3 @@ function sameDirectory(extractedDir: string, workingDirectory: URI): boolean {
 	}
 	return extUriBiasedIgnorePathCase.isEqual(extractedUri, wdUri);
 }
-

--- a/src/vs/platform/agentHost/test/common/commandLineHelpers.test.ts
+++ b/src/vs/platform/agentHost/test/common/commandLineHelpers.test.ts
@@ -124,6 +124,13 @@ suite('stripRedundantCdPrefix', () => {
 		assert.strictEqual(params.command, 'dir');
 	});
 
+	test('rewrites powershell with newline separator', () => {
+		const params: Record<string, unknown> = { command: 'cd /repo/project\nWrite-Host hi\ndir' };
+		const changed = stripRedundantCdPrefix('powershell', params, wd);
+		assert.strictEqual(changed, true);
+		assert.strictEqual(params.command, 'Write-Host hi\ndir');
+	});
+
 	test('matches mixed path separators (forward-slash extracted vs native fsPath wd)', () => {
 		// On Windows, the model may emit `cd C:/repo/project && …` while
 		// URI.file('C:\\repo\\project').fsPath uses backslashes. The helper

--- a/src/vs/platform/agentHost/test/common/commandLineHelpers.test.ts
+++ b/src/vs/platform/agentHost/test/common/commandLineHelpers.test.ts
@@ -23,6 +23,9 @@ suite('extractCdPrefix', () => {
 			{ name: 'bash: simple cd', commandLine: 'cd /tmp && ls', isPowerShell: false, expected: { directory: '/tmp', command: 'ls' } },
 			{ name: 'bash: quoted dir', commandLine: 'cd "/path with spaces" && ls -la', isPowerShell: false, expected: { directory: '/path with spaces', command: 'ls -la' } },
 			{ name: 'bash: extra spaces after &&', commandLine: 'cd /tmp &&  echo hi', isPowerShell: false, expected: { directory: '/tmp', command: 'echo hi' } },
+			{ name: 'bash: newline separator', commandLine: 'cd /tmp\nls', isPowerShell: false, expected: { directory: '/tmp', command: 'ls' } },
+			{ name: 'bash: newline separator multi-line suffix', commandLine: 'cd /tmp\necho hi\nls -la', isPowerShell: false, expected: { directory: '/tmp', command: 'echo hi\nls -la' } },
+			{ name: 'bash: && separator multi-line suffix', commandLine: 'cd /tmp &&\necho hi\nls -la', isPowerShell: false, expected: { directory: '/tmp', command: 'echo hi\nls -la' } },
 
 			// bash non-matches
 			{ name: 'bash: no cd prefix', commandLine: 'ls -la', isPowerShell: false, expected: undefined },
@@ -38,6 +41,8 @@ suite('extractCdPrefix', () => {
 			{ name: 'pwsh: Set-Location -Path', commandLine: 'Set-Location -Path C:\\foo && dir', isPowerShell: true, expected: { directory: 'C:\\foo', command: 'dir' } },
 			{ name: 'pwsh: quoted dir', commandLine: 'cd "C:\\path with spaces"; dir', isPowerShell: true, expected: { directory: 'C:\\path with spaces', command: 'dir' } },
 			{ name: 'pwsh: case insensitive', commandLine: 'CD C:\\foo && dir', isPowerShell: true, expected: { directory: 'C:\\foo', command: 'dir' } },
+			{ name: 'pwsh: newline separator', commandLine: 'cd C:\\foo\ndir', isPowerShell: true, expected: { directory: 'C:\\foo', command: 'dir' } },
+			{ name: 'pwsh: newline separator multi-line suffix', commandLine: 'cd C:\\foo\nWrite-Host hi\ndir', isPowerShell: true, expected: { directory: 'C:\\foo', command: 'Write-Host hi\ndir' } },
 
 			// powershell non-matches
 			{ name: 'pwsh: no cd prefix', commandLine: 'dir', isPowerShell: true, expected: undefined },
@@ -70,6 +75,15 @@ suite('stripRedundantCdPrefix', () => {
 		const changed = stripRedundantCdPrefix('bash', params, wd);
 		assert.strictEqual(changed, true);
 		assert.strictEqual(params.command, 'ls');
+	});
+
+	test('rewrites multi-line bash command with newline separator', () => {
+		// The model frequently emits `cd <dir>` on its own line followed by a
+		// multi-line script rather than `cd <dir> && …` on a single line.
+		const params: Record<string, unknown> = { command: 'cd /repo/project\necho "=== start ==="\ngrep -n foo src/*.ts | head' };
+		const changed = stripRedundantCdPrefix('bash', params, wd);
+		assert.strictEqual(changed, true);
+		assert.strictEqual(params.command, 'echo "=== start ==="\ngrep -n foo src/*.ts | head');
 	});
 
 	test('does not rewrite when cd target differs', () => {


### PR DESCRIPTION
Fixes #320247

The SDK bash tool frequently emits multi-line commands that start with a redundant `cd <workingDirectory>` even though the tool already runs in that directory. The agent host has code to strip this redundant prefix for display, but the extraction regex only matched the single-line `cd <dir> && <cmd>` form. When the model put `cd <dir>` on its own line followed by a newline-separated script, the regex never matched and the redundant `cd` was shown verbatim.

### Change

`extractCdPrefix` in `src/vs/platform/agentHost/common/commandLineHelpers.ts` now:

- accepts a **newline** as a separator after the directory (in addition to `&&`, and `;` for PowerShell) — bash treats a bare newline as a command separator just like `&&`;
- allows the remaining command to span **multiple lines** (`[\s\S]+` instead of `.+`).

Display-only: the full multi-line command still runs verbatim in the PTY, so runtime semantics are unchanged. The bash variant continues to exclude `;` per existing behavior.

### Tests

Added coverage in `commandLineHelpers.test.ts` for newline-separated and multi-line suffix cases (bash + pwsh), plus a `stripRedundantCdPrefix` test mirroring the real reported command. All existing regressions still pass.

> Note: the same extraction regex is duplicated in `runInTerminalHelpers.ts` (workbench) and `copilotCLITools.ts` (extension) and still has the multi-line blind spot — left out of this fix to keep it scoped to the agent host path.

(Written by Copilot)
