### PR TITLE
smoke: wait for copilot-chat extension before writing its settings

### DIFF
--- a/test/smoke/extensions/vscode-smoketest-ext-host/extension.js
+++ b/test/smoke/extensions/vscode-smoketest-ext-host/extension.js
@@ -30,6 +30,28 @@ async function waitForCommand(command, timeoutMs) {
 }
 
 /**
+ * Wait for an extension to be installed and activated so its contributed
+ * configuration keys are registered and its commands are available.
+ * @param {string} extensionId
+ * @param {number} timeoutMs
+ */
+async function waitForExtension(extensionId, timeoutMs) {
+	const started = Date.now();
+	while (Date.now() - started < timeoutMs) {
+		const ext = vscode.extensions.getExtension(extensionId);
+		if (ext) {
+			if (!ext.isActive) {
+				await ext.activate();
+			}
+			return ext;
+		}
+		await new Promise(resolve => setTimeout(resolve, 250));
+	}
+
+	throw new Error(`Timed out waiting for extension '${extensionId}'`);
+}
+
+/**
  * @param {vscode.ExtensionContext} context
  */
 function activate(context) {
@@ -94,6 +116,9 @@ function activate(context) {
 	context.subscriptions.push(
 		vscode.commands.registerCommand('smoketest.openCopilotCliChat', async () => {
 			const command = 'workbench.action.chat.openNewSessionEditor.copilotcli';
+			// Wait for copilot-chat extension to be installed & activated so its
+			// contributed configuration keys are registered before we write them.
+			await waitForExtension('GitHub.copilot-chat', 60_000);
 			await vscode.workspace.getConfiguration('chat').update('disableAIFeatures', false, vscode.ConfigurationTarget.Global);
 			await vscode.workspace.getConfiguration('github.copilot.chat').update('backgroundAgent.enabled', true, vscode.ConfigurationTarget.Global);
 			await vscode.commands.executeCommand('github.copilot.debug.extensionState');
@@ -106,6 +131,9 @@ function activate(context) {
 	context.subscriptions.push(
 		vscode.commands.registerCommand('smoketest.openClaudeChat', async () => {
 			const command = 'workbench.action.chat.openNewSessionEditor.claude-code';
+			// Wait for copilot-chat extension to be installed & activated so its
+			// contributed configuration keys are registered before we write them.
+			await waitForExtension('GitHub.copilot-chat', 60_000);
 			await vscode.workspace.getConfiguration('chat').update('disableAIFeatures', false, vscode.ConfigurationTarget.Global);
 			await vscode.workspace.getConfiguration('github.copilot.chat').update('claudeAgent.enabled', true, vscode.ConfigurationTarget.Global);
 			await vscode.commands.executeCommand('github.copilot.debug.extensionState');


### PR DESCRIPTION
## Problem

The Chat Sessions smoke tests (`Test Copilot CLI session`, `Test Claude session`) fail on macOS arm64 Electron with:

> `Unable to write to User Settings because github.copilot.chat.backgroundAgent.enabled is not a registered configuration.`

The smoke test helper writes copilot-chat–contributed config keys **before** the `GitHub.copilot-chat` extension is installed in the ext host. The rejected write surfaces a blocking error dialog, which makes the test time out.

## Fix

Add a `waitForExtension` helper that polls `vscode.extensions.getExtension()` until the extension is visible, then activates it. Both `smoketest.openCopilotCliChat` and `smoketest.openClaudeChat` now call `waitForExtension('GitHub.copilot-chat', 60_000)` **before** writing any `github.copilot.chat.*` settings, ensuring the contributed configuration keys are registered first.