### PR TITLE
Fix background summarization crash when there is no round to anchor the summary (#319433)

### DIFF
--- a/extensions/copilot/src/extension/intents/node/agentIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/agentIntent.ts
@@ -49,7 +49,7 @@ import { IDefaultIntentRequestHandlerOptions } from '../../prompt/node/defaultIn
 import { IDocumentContext } from '../../prompt/node/documentContext';
 import { IBuildPromptResult, IIntent, IIntentInvocation } from '../../prompt/node/intents';
 import { AgentPrompt, AgentPromptProps } from '../../prompts/node/agent/agentPrompt';
-import { BackgroundSummarizationState, BackgroundSummarizationThresholds, BackgroundSummarizer, IBackgroundSummarizationResult, shouldKickOffBackgroundSummarization } from '../../prompts/node/agent/backgroundSummarizer';
+import { BackgroundSummarizationState, BackgroundSummarizationThresholds, BackgroundSummarizer, IBackgroundSummarizationResult, resolveSummaryAnchorRoundId, shouldKickOffBackgroundSummarization } from '../../prompts/node/agent/backgroundSummarizer';
 import { BackgroundTodoDecision, BackgroundTodoProcessor, IBackgroundTodoExecutionContext } from '../../prompts/node/agent/backgroundTodoProcessor';
 import { AgentPromptCustomizations, PromptRegistry } from '../../prompts/node/agent/promptRegistry';
 import { extractSummary, SummarizationUserMessage, SummarizedConversationHistory, SummarizedConversationHistoryMetadata, SummarizedConversationHistoryPropsBuilder, appendTranscriptHintToSummary, computeSummarizationRoundCounts } from '../../prompts/node/agent/summarizedConversationHistory';
@@ -1013,29 +1013,28 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 		token: vscode.CancellationToken,
 		contextRatio: number,
 	): void {
-		this.logService.debug(`[ConversationHistorySummarizer] context at ${(contextRatio * 100).toFixed(0)}% — starting background compaction`);
-
-		const bgStartTime = Date.now();
-
 		// Snapshot rounds so telemetry reflects state at kick-off time, not at
 		// completion time (the main loop mutates toolCallRounds). History is
 		// stable across a single user turn so a reference is sufficient.
 		const rounds = [...(promptContext.toolCallRounds ?? [])];
 		const history = promptContext.history;
-		let toolCallRoundId: string | undefined;
-		if (rounds.length >= 2) {
-			// Mark the round before the last, preserving the last round verbatim
-			toolCallRoundId = rounds[rounds.length - 2].id;
-		} else if (rounds.length === 1) {
-			toolCallRoundId = rounds[0].id;
-		} else {
-			for (let i = history.length - 1; i >= 0 && !toolCallRoundId; i--) {
-				const lastRound = history[i].rounds.at(-1);
-				if (lastRound) {
-					toolCallRoundId = lastRound.id;
-				}
-			}
+
+		// Resolve the round the summary will attach to up front. Without an
+		// anchor (e.g. an early turn before any tool-call round exists, reached
+		// via a cold-cache emergency kick-off) there is nothing to attach the
+		// result to, so skip *before* firing the expensive summarization request
+		// rather than running it for many seconds only to discard the result —
+		// which, on slow models, also stalls a later budget-exceeded render that
+		// waits on the in-flight request.
+		const toolCallRoundId = resolveSummaryAnchorRoundId(rounds, history);
+		if (!toolCallRoundId) {
+			this.logService.debug(`[ConversationHistorySummarizer] skipping background compaction at ${(contextRatio * 100).toFixed(0)}% — no tool call round to attach summary to (rounds=${rounds.length}, history=${history.length})`);
+			return;
 		}
+
+		this.logService.debug(`[ConversationHistorySummarizer] context at ${(contextRatio * 100).toFixed(0)}% — starting background compaction`);
+
+		const bgStartTime = Date.now();
 
 		// Build tool schemas matching the main agent loop so the prompt
 		// prefix (system + tools + messages) is identical for cache hits.
@@ -1102,9 +1101,6 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 				const rawSummaryText = extractSummary(response.value);
 				if (rawSummaryText === undefined) {
 					throw new Error('Background summarization: no <summary> tags found in response');
-				}
-				if (!toolCallRoundId) {
-					throw new Error('Background summarization: no round ID to apply summary to');
 				}
 				// Flush the transcript before snapshotting the line count so
 				// the baked "N lines" hint matches the on-disk file at this

--- a/extensions/copilot/src/extension/prompts/node/agent/backgroundSummarizer.ts
+++ b/extensions/copilot/src/extension/prompts/node/agent/backgroundSummarizer.ts
@@ -95,6 +95,34 @@ export function shouldKickOffBackgroundSummarization(
 	return postRenderRatio >= jittered;
 }
 
+/** Minimal shape of a tool-call round needed to anchor a summary. */
+export interface ISummaryAnchorRound {
+	readonly id: string;
+}
+
+/** Minimal shape of a history turn needed to anchor a summary. */
+export interface ISummaryAnchorTurn {
+	readonly rounds: readonly ISummaryAnchorRound[];
+}
+
+export function resolveSummaryAnchorRoundId(
+	rounds: readonly ISummaryAnchorRound[],
+	history: readonly ISummaryAnchorTurn[],
+): string | undefined {
+	if (rounds.length >= 2) {
+		return rounds[rounds.length - 2].id;
+	} else if (rounds.length === 1) {
+		return rounds[0].id;
+	}
+	for (let i = history.length - 1; i >= 0; i--) {
+		const lastRound = history[i].rounds.at(-1);
+		if (lastRound) {
+			return lastRound.id;
+		}
+	}
+	return undefined;
+}
+
 /**
  * Tracks a single background summarization pass for one chat session.
  *

--- a/extensions/copilot/src/extension/prompts/node/agent/test/backgroundSummarizer.spec.ts
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/backgroundSummarizer.spec.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { describe, expect, test } from 'vitest';
-import { BackgroundSummarizationState, BackgroundSummarizationThresholds, BackgroundSummarizer, IBackgroundSummarizationResult, shouldKickOffBackgroundSummarization } from '../backgroundSummarizer';
+import { BackgroundSummarizationState, BackgroundSummarizationThresholds, BackgroundSummarizer, IBackgroundSummarizationResult, resolveSummaryAnchorRoundId, shouldKickOffBackgroundSummarization } from '../backgroundSummarizer';
 
 describe('BackgroundSummarizer', () => {
 
@@ -305,5 +305,42 @@ describe('shouldKickOffBackgroundSummarization', () => {
 			// 0.82 meets it.
 			expect(shouldKickOffBackgroundSummarization(warmJitterMin + warmJitterSpan, true, maxRng)).toBe(true);
 		});
+	});
+});
+
+describe('resolveSummaryAnchorRoundId', () => {
+	const round = (id: string) => ({ id });
+	const turn = (...ids: string[]) => ({ rounds: ids.map(round) });
+
+	test('returns undefined with no current rounds and no history', () => {
+		// Regression for #319433: on an early turn (or a cold-cache emergency
+		// kick-off) there is no round to anchor a summary to. Returning undefined
+		// lets the caller skip *before* firing an expensive summarization request
+		// that could only fail with 'no round ID to apply summary to'.
+		expect(resolveSummaryAnchorRoundId([], [])).toBeUndefined();
+	});
+
+	test('returns undefined when there are no current rounds and every history turn is empty', () => {
+		expect(resolveSummaryAnchorRoundId([], [turn(), turn()])).toBeUndefined();
+	});
+
+	test('anchors to the only current-turn round', () => {
+		expect(resolveSummaryAnchorRoundId([round('r1')], [])).toBe('r1');
+	});
+
+	test('anchors to the round before the last so the most recent round is preserved verbatim', () => {
+		expect(resolveSummaryAnchorRoundId([round('r1'), round('r2'), round('r3')], [])).toBe('r2');
+	});
+
+	test('falls back to the most recent history round when the current turn has none', () => {
+		expect(resolveSummaryAnchorRoundId([], [turn('a1', 'a2'), turn('b1', 'b2')])).toBe('b2');
+	});
+
+	test('skips trailing empty history turns when falling back', () => {
+		expect(resolveSummaryAnchorRoundId([], [turn('a1'), turn('b1', 'b2'), turn()])).toBe('b2');
+	});
+
+	test('prefers current-turn rounds over history', () => {
+		expect(resolveSummaryAnchorRoundId([round('c1')], [turn('h1', 'h2')])).toBe('c1');
 	});
 });


### PR DESCRIPTION
Fixes #319433.

Background summarization could fire an expensive request and only discover afterwards that there was no tool-call round to attach the summary to, throwing `no round ID to apply summary to`. On slow models (Claude Sonnet/Opus) this also stalled a later budget-exceeded render that waited on the in-flight request, producing a blank response.

Now we resolve the anchor round up front (`resolveSummaryAnchorRoundId`) and skip the run before any async work when there is none — mirroring the foreground path's existing "no prior content to summarize" behavior. Added unit tests.