### PR TITLE
agentHost: fix Claude agent window showing only Haiku 4.5 in model picker

### DIFF
--- a/src/vs/platform/agentHost/node/claude/claudeAgent.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgent.ts
@@ -48,16 +48,20 @@ import { ClaudeSessionMetadataStore, IClaudeSessionOverlay } from './claudeSessi
  * Returns true if `m` is a Claude-family model that should be advertised
  * to clients picking a model for the Claude provider.
  *
- * Combines the same surface checks the extension uses (vendor, picker
- * eligibility, tool-call support, `/v1/messages` endpoint) with a parse
- * of the model id via {@link tryParseClaudeModelId}, which excludes
- * synthetic ids like `auto` that aren't real Claude endpoints.
+ * Intentionally does NOT check `model_picker_enabled`: CAPI sets that flag
+ * conservatively (false for many models), and the Copilot extension overrides
+ * it via an A/B experiment (`copilotchat.showInModelPicker`) so the normal
+ * Claude Code window shows all capable models. The agent host has no access
+ * to that experiment service, so relying on the raw flag would cause it to
+ * show a much smaller set than the extension window does. The remaining four
+ * conditions (Anthropic vendor, `/v1/messages` endpoint, tool-call support,
+ * parseable model ID) are sufficient guards against synthetic or ineligible
+ * entries.
  */
 function isClaudeModel(m: CCAModel): boolean {
 	return (
 		m.vendor === 'Anthropic' &&
 		!!m.supported_endpoints?.includes('/v1/messages') &&
-		!!m.model_picker_enabled &&
 		!!m.capabilities?.supports?.tool_calls &&
 		tryParseClaudeModelId(m.id) !== undefined
 	);

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -694,6 +694,12 @@ suite('ClaudeAgent', () => {
 	});
 
 	test('authenticate populates models filtered to Claude family', async () => {
+		// model_picker_enabled is intentionally NOT checked — CAPI sets it
+		// conservatively and the Copilot extension overrides it via
+		// experiments; the agent host has no experiment service, so we rely
+		// on vendor/endpoint/tool-call/model-id guards instead.
+		// ANTHROPIC_PICKER_DISABLED (claude-opus-4.5, model_picker_enabled:false)
+		// must appear here alongside the other Claude models.
 		const { agent, proxy } = createTestContext(disposables);
 
 		const accepted = await agent.authenticate('https://api.github.com', 'tok');
@@ -709,6 +715,7 @@ suite('ClaudeAgent', () => {
 			models: [
 				{ provider: 'claude', id: 'claude-opus-4.6', name: 'Claude Opus 4.6', maxContextWindow: 200_000, supportsVision: false, policyState: 'enabled', _meta: { multiplierNumeric: 1 } },
 				{ provider: 'claude', id: 'claude-sonnet-4.6', name: 'Claude Sonnet 4.6', maxContextWindow: 200_000, supportsVision: false, policyState: 'enabled', _meta: { multiplierNumeric: 1 } },
+				{ provider: 'claude', id: 'claude-opus-4.5', name: 'Claude Opus 4.5', maxContextWindow: 200_000, supportsVision: false, policyState: 'enabled', _meta: { multiplierNumeric: 1 } },
 			],
 		});
 	});
@@ -940,20 +947,22 @@ suite('ClaudeAgent', () => {
 			accepted: true,
 			startTokens: ['tok', 'tok'],
 			disposeCount: 0,
-			modelIds: [CLAUDE_OPUS.id, CLAUDE_SONNET.id],
+			modelIds: [CLAUDE_OPUS.id, CLAUDE_SONNET.id, ANTHROPIC_PICKER_DISABLED.id],
 		});
 	});
 
 	test('model filter excludes non-Claude entries', async () => {
 		// Same fixture set as the populate test, but assert on ids only —
 		// catches every exclusion criterion in one snapshot.
+		// Note: model_picker_enabled is NOT a filter criterion (see isClaudeModel);
+		// ANTHROPIC_PICKER_DISABLED (claude-opus-4.5) therefore appears here.
 		const { agent } = createTestContext(disposables);
 		await agent.authenticate('https://api.github.com', 'tok');
 		await tick();
 
 		assert.deepStrictEqual(
 			agent.models.get().map(m => m.id),
-			['claude-opus-4.6', 'claude-sonnet-4.6'],
+			['claude-opus-4.6', 'claude-sonnet-4.6', 'claude-opus-4.5'],
 		);
 	});
 


### PR DESCRIPTION
Descrição:
  
  Fixes #316454
  Related: https://github.com/anthropics/claude-code/issues/59136
  
  ## Problem

  The Claude agent window (`agents-window`) model picker shows only **Claude Haiku 4.5**,
  while the normal Claude Code window correctly shows all available models (Sonnet 4.6,
  Opus 4.8, Haiku 4.5, etc.).

  ## Root Cause

  Two code paths exist for populating the Claude model list:
  
  **Normal Claude Code window** (extension path):
  - `ClaudeCodeModels` fetches via `endpointProvider.getAllChatEndpoints()`
  - `modelMetadataFetcher` applies the `copilotchat.showInModelPicker` A/B experiment
    override, which sets `showInModelPicker = true` for models CAPI has as `false`
  - Result: all capable Claude models are shown

  **Claude agent window** (agent host path):
  - `ClaudeAgent._refreshModels()` fetches directly from `copilotApiService.models()`
    (raw CAPI response)
  - `isClaudeModel()` required `model_picker_enabled: true` from the **raw** CAPI value —
    with no experiment override applied
  - Result: only models CAPI explicitly flags as picker-eligible (Haiku 4.5) are shown

  CAPI /models
      │
      ├── Extension path  →  modelMetadataFetcher  →  showInModelPicker override  →  ALL models ✓
      │
      └── Agent host path  →  isClaudeModel()  →  raw model_picker_enabled  →  only Haiku 4.5 ✗

  ## Fix

  Removed the `!!m.model_picker_enabled` check from `isClaudeModel()` in
  `src/vs/platform/agentHost/node/claude/claudeAgent.ts`.

  ## Root Cause

  Two code paths exist for populating the Claude model list:

  **Normal Claude Code window** (extension path):
  - `ClaudeCodeModels` fetches via `endpointProvider.getAllChatEndpoints()`
  - `modelMetadataFetcher` applies the `copilotchat.showInModelPicker` A/B experiment
    override, which sets `showInModelPicker = true` for models CAPI has as `false`
  - Result: all capable Claude models are shown

  **Claude agent window** (agent host path):
  - `ClaudeAgent._refreshModels()` fetches directly from `copilotApiService.models()`
    (raw CAPI response)
  - `isClaudeModel()` required `model_picker_enabled: true` from the **raw** CAPI value —
    with no experiment override applied
  - Result: only models CAPI explicitly flags as picker-eligible (Haiku 4.5) are shown

  CAPI /models
      │
      ├── Extension path  →  modelMetadataFetcher  →  showInModelPicker override  →  ALL models ✓
      │
      └── Agent host path  →  isClaudeModel()  →  raw model_picker_enabled  →  only Haiku 4.5 ✗

  ## Fix

  Removed the `!!m.model_picker_enabled` check from `isClaudeModel()` in
  `src/vs/platform/agentHost/node/claude/claudeAgent.ts`.

  The agent host has no access to the experiment service that drives the override.
  The remaining four conditions are sufficient guards against synthetic or ineligible entries:

  | Condition | Guards against |
  |---|---|
  | `vendor === 'Anthropic'` | Non-Anthropic models (e.g. GPT-5, `auto`) |
  | `supported_endpoints.includes('/v1/messages')` | Models without Messages API support |
  | `capabilities.supports.tool_calls` | Models that cannot run tools |
  | `tryParseClaudeModelId(id) !== undefined` | Synthetic IDs like `nectarine`, `auto` |

  ## Changes


  - `src/vs/platform/agentHost/node/claude/claudeAgent.ts` — removed `!!m.model_picker_enabled`
    from `isClaudeModel()`; updated JSDoc explaining why the flag is intentionally excluded
  - `src/vs/platform/agentHost/test/node/claudeAgent.test.ts` — updated three test assertions

  CAPI /models
      │
      ├── Extension path  →  modelMetadataFetcher  →  showInModelPicker override  →  ALL models ✓
      │
      └── Agent host path  →  isClaudeModel()  →  raw model_picker_enabled  →  only Haiku 4.5 ✗

  ## Fix

  Removed the `!!m.model_picker_enabled` check from `isClaudeModel()` in
  `src/vs/platform/agentHost/node/claude/claudeAgent.ts`.

  The agent host has no access to the experiment service that drives the override.
  The remaining four conditions are sufficient guards against synthetic or ineligible entries:

  | Condition | Guards against |
  |---|---|
  | `vendor === 'Anthropic'` | Non-Anthropic models (e.g. GPT-5, `auto`) |
  | `supported_endpoints.includes('/v1/messages')` | Models without Messages API support |
  | `capabilities.supports.tool_calls` | Models that cannot run tools |
  | `tryParseClaudeModelId(id) !== undefined` | Synthetic IDs like `nectarine`, `auto` |

  ## Changes

  - `src/vs/platform/agentHost/node/claude/claudeAgent.ts` — removed `!!m.model_picker_enabled`
    from `isClaudeModel()`; updated JSDoc explaining why the flag is intentionally excluded
  - `src/vs/platform/agentHost/test/node/claudeAgent.test.ts` — updated three test assertions
    to reflect that `model_picker_enabled: false` models now correctly appear in the agent
    window picker

  ## Testing

  ### Unit tests

  The existing test suite covers the fix directly. Key tests updated:

  - `'authenticate populates models filtered to Claude family'` — now asserts that
    `ANTHROPIC_PICKER_DISABLED` (claude-opus-4.5, `model_picker_enabled: false`) appears
    alongside the other Claude models
  - `'model filter excludes non-Claude entries'` — confirms non-Anthropic, no-tool-calls,
    and no-messages-endpoint models are still excluded
  | `capabilities.supports.tool_calls` | Models that cannot run tools |
  | `tryParseClaudeModelId(id) !== undefined` | Synthetic IDs like `nectarine`, `auto` |

  ## Changes

  - `src/vs/platform/agentHost/node/claude/claudeAgent.ts` — removed `!!m.model_picker_enabled`
    from `isClaudeModel()`; updated JSDoc explaining why the flag is intentionally excluded
  - `src/vs/platform/agentHost/test/node/claudeAgent.test.ts` — updated three test assertions
    to reflect that `model_picker_enabled: false` models now correctly appear in the agent
    window picker

  ## Testing

  ### Unit tests

  The existing test suite covers the fix directly. Key tests updated:

  - `'authenticate populates models filtered to Claude family'` — now asserts that
    `ANTHROPIC_PICKER_DISABLED` (claude-opus-4.5, `model_picker_enabled: false`) appears
    alongside the other Claude models
  - `'model filter excludes non-Claude entries'` — confirms non-Anthropic, no-tool-calls,
    and no-messages-endpoint models are still excluded
  - `'authenticate retries proxy startup after a transient failure'` — updated model ID
    list to include the formerly-excluded model

  npm run test-node -- --run src/vs/platform/agentHost/test/node/claudeAgent.test.ts



  **Before** — Claude agent window model picker (only Haiku 4.5):

<img width="512" height="236" alt="image" src="https://github.com/user-attachments/assets/e3a31246-6a3a-43b7-82cf-e5d8182e6989" />


  **After** — tests are passing :

<img width="1141" height="1026" alt="screenshot-2026-06-07_13-06-51" src="https://github.com/user-attachments/assets/bb5055ff-0f54-456d-a753-bef50c911f37" />
<img width="1176" height="1049" alt="screenshot-2026-06-07_13-07-14" src="https://github.com/user-attachments/assets/6c18efc8-05ea-4948-9d45-d4b9677f7a6e" />
<img width="1135" height="637" alt="screenshot-2026-06-07_13-07-23" src="https://github.com/user-attachments/assets/651073f5-5fc9-4a10-8249-3132d7b0e13c" />


  ## Related

  - Tracking issue: microsoft/vscode#316454
  - Upstream report: anthropics/claude-code#59136
  - Normal window model fetch path:
    `extensions/copilot/src/extension/chatSessions/claude/node/claudeCodeModels.ts`
  - Agent host model fetch path:
    `src/vs/platform/agentHost/node/claude/claudeAgent.ts` (`_refreshModels`)
  - Experiment override that the agent host cannot access:
    `extensions/copilot/src/platform/endpoint/node/modelMetadataFetcher.ts`
    (`_getShowInModelPickerOverride`)