### PR TITLE
chat: add Inspect Agent Host Subscriptions developer command

### DIFF
--- a/src/vs/platform/agentHost/browser/nullAgentHostService.ts
+++ b/src/vs/platform/agentHost/browser/nullAgentHostService.ts
@@ -36,7 +36,7 @@ export class NullAgentHostService implements IAgentHostService {
 
 	get rootState(): IAgentSubscription<RootState> { return notSupported(); }
 
-	getSubscription<T extends StateComponents>(_kind: T, _resource: URI): IReference<IAgentSubscription<ComponentToState[T]>> { return notSupported(); }
+	getSubscription<T extends StateComponents>(_kind: T, _resource: URI, _owner: string): IReference<IAgentSubscription<ComponentToState[T]>> { return notSupported(); }
 	getSubscriptionUnmanaged<T extends StateComponents>(_kind: T, _resource: URI): IAgentSubscription<ComponentToState[T]> | undefined { return undefined; }
 	getActiveSubscriptions(): readonly IActiveSubscriptionInfo[] { return []; }
 	dispatch(_channel: string, _action: SessionAction | TerminalAction | IRootConfigChangedAction): void { notSupported(); }

--- a/src/vs/platform/agentHost/browser/nullAgentHostService.ts
+++ b/src/vs/platform/agentHost/browser/nullAgentHostService.ts
@@ -8,7 +8,7 @@ import { IReference } from '../../../base/common/lifecycle.js';
 import { constObservable, IObservable } from '../../../base/common/observable.js';
 import { URI } from '../../../base/common/uri.js';
 import type { IAgentCreateSessionConfig, IAgentHostInspectInfo, IAgentHostService, IAgentHostSocketInfo, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, AuthenticateParams, AuthenticateResult } from '../common/agentService.js';
-import type { IAgentSubscription } from '../common/state/agentSubscription.js';
+import type { IActiveSubscriptionInfo, IAgentSubscription } from '../common/state/agentSubscription.js';
 import type { CompletionsParams, CompletionsResult, CreateTerminalParams, ResolveSessionConfigResult, SessionConfigCompletionsResult } from '../common/state/protocol/commands.js';
 import type { InvokeChangesetOperationParams, InvokeChangesetOperationResult } from '../common/state/protocol/channels-changeset/commands.js';
 import type { ActionEnvelope, INotification, IRootConfigChangedAction, SessionAction, TerminalAction } from '../common/state/sessionActions.js';
@@ -38,6 +38,7 @@ export class NullAgentHostService implements IAgentHostService {
 
 	getSubscription<T extends StateComponents>(_kind: T, _resource: URI): IReference<IAgentSubscription<ComponentToState[T]>> { return notSupported(); }
 	getSubscriptionUnmanaged<T extends StateComponents>(_kind: T, _resource: URI): IAgentSubscription<ComponentToState[T]> | undefined { return undefined; }
+	getActiveSubscriptions(): readonly IActiveSubscriptionInfo[] { return []; }
 	dispatch(_channel: string, _action: SessionAction | TerminalAction | IRootConfigChangedAction): void { notSupported(); }
 
 	async restartAgentHost(): Promise<void> { notSupported(); }

--- a/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
@@ -666,8 +666,8 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 		return this._subscriptionManager.rootState;
 	}
 
-	getSubscription<T>(kind: StateComponents, resource: URI): IReference<IAgentSubscription<T>> {
-		return this._subscriptionManager.getSubscription<T>(kind, resource);
+	getSubscription<T>(kind: StateComponents, resource: URI, owner: string): IReference<IAgentSubscription<T>> {
+		return this._subscriptionManager.getSubscription<T>(kind, resource, owner);
 	}
 
 	getSubscriptionUnmanaged<T>(_kind: StateComponents, resource: URI): IAgentSubscription<T> | undefined {

--- a/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
@@ -20,7 +20,7 @@ import { FileSystemProviderErrorCode, toFileSystemProviderErrorCode } from '../.
 import { IConfigurationService } from '../../configuration/common/configuration.js';
 import { AgentSession, IAgentConnection, IAgentCreateSessionConfig, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, AuthenticateParams, AuthenticateResult } from '../common/agentService.js';
 import { createRemoteWatchHandle, type IRemoteWatchHandle } from '../common/agentHostFileSystemProvider.js';
-import { AgentSubscriptionManager, type IAgentSubscription } from '../common/state/agentSubscription.js';
+import { AgentSubscriptionManager, type IActiveSubscriptionInfo, type IAgentSubscription } from '../common/state/agentSubscription.js';
 import { agentHostAuthority, fromAgentHostUri, toAgentHostUri } from '../common/agentHostUri.js';
 import { AgentHostResourcePermissionError, IAgentHostResourceService } from '../common/agentHostResourceService.js';
 import type { ClientNotificationMap, CommandMap, JsonRpcErrorResponse, JsonRpcRequest } from '../common/state/protocol/messages.js';
@@ -672,6 +672,10 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 
 	getSubscriptionUnmanaged<T>(_kind: StateComponents, resource: URI): IAgentSubscription<T> | undefined {
 		return this._subscriptionManager.getSubscriptionUnmanaged<T>(resource);
+	}
+
+	getActiveSubscriptions(): readonly IActiveSubscriptionInfo[] {
+		return this._subscriptionManager.getActiveSubscriptions();
 	}
 
 	dispatch(channel: string, action: SessionAction | TerminalAction | IRootConfigChangedAction): void {

--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -1004,7 +1004,13 @@ export interface IAgentConnection {
 
 	// ---- State subscriptions ------------------------------------------------
 	readonly rootState: IAgentSubscription<RootState>;
-	getSubscription<T extends StateComponents>(kind: T, resource: URI): IReference<IAgentSubscription<ComponentToState[T]>>;
+	/**
+	 * Acquire a refcounted subscription to `resource`. `owner` names the
+	 * caller holding the reference so inspection surfaces can attribute who
+	 * is retaining a subscription; use a stable identifier such as the
+	 * acquiring class name.
+	 */
+	getSubscription<T extends StateComponents>(kind: T, resource: URI, owner: string): IReference<IAgentSubscription<ComponentToState[T]>>;
 	getSubscriptionUnmanaged<T extends StateComponents>(kind: T, resource: URI): IAgentSubscription<ComponentToState[T]> | undefined;
 
 	/**

--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -13,7 +13,7 @@ import { URI } from '../../../base/common/uri.js';
 import type { IConfigurationService } from '../../configuration/common/configuration.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
 import type { ISyncedCustomization } from './agentPluginManager.js';
-import type { IAgentSubscription } from './state/agentSubscription.js';
+import type { IActiveSubscriptionInfo, IAgentSubscription } from './state/agentSubscription.js';
 import type { IRemoteWatchHandle } from './agentHostFileSystemProvider.js';
 import type { CompletionsParams, CompletionsResult, CreateTerminalParams, ResolveSessionConfigResult, SessionConfigCompletionsResult } from './state/protocol/commands.js';
 import type { InvokeChangesetOperationParams, InvokeChangesetOperationResult } from './state/protocol/channels-changeset/commands.js';
@@ -1006,6 +1006,13 @@ export interface IAgentConnection {
 	readonly rootState: IAgentSubscription<RootState>;
 	getSubscription<T extends StateComponents>(kind: T, resource: URI): IReference<IAgentSubscription<ComponentToState[T]>>;
 	getSubscriptionUnmanaged<T extends StateComponents>(kind: T, resource: URI): IAgentSubscription<ComponentToState[T]> | undefined;
+
+	/**
+	 * Read-only descriptors of every active resource subscription on this
+	 * connection, for inspection/debug surfaces. Excludes the always-live
+	 * {@link rootState}.
+	 */
+	getActiveSubscriptions(): readonly IActiveSubscriptionInfo[];
 
 	// ---- Action dispatch ----------------------------------------------------
 	/**

--- a/src/vs/platform/agentHost/common/state/agentSubscription.ts
+++ b/src/vs/platform/agentHost/common/state/agentSubscription.ts
@@ -53,6 +53,26 @@ export interface IAgentSubscription<T> {
 	readonly onDidApplyAction: Event<ActionEnvelope>;
 }
 
+/**
+ * Read-only snapshot describing a single active resource subscription. Used by
+ * inspection/debug surfaces that enumerate everything a connection is currently
+ * subscribed to. Does not include the always-live root state.
+ */
+export interface IActiveSubscriptionInfo {
+	/** The protocol resource URI subscribed to. */
+	readonly resource: URI;
+	/** Which state component this subscription tracks. */
+	readonly kind: StateComponents;
+	/** Number of outstanding {@link IReference} holders. */
+	readonly refCount: number;
+	/**
+	 * Lifecycle status derived from the subscription's value:
+	 * `pending` before the first snapshot, `error` if it failed, otherwise
+	 * `snapshot`.
+	 */
+	readonly status: 'pending' | 'snapshot' | 'error';
+}
+
 // --- Base Implementation -----------------------------------------------------
 
 /**
@@ -424,7 +444,7 @@ export class ChangesetStateSubscription extends BaseAgentSubscription<ChangesetS
 
 type ManagedSubscription = SessionStateSubscription | TerminalStateSubscription | ChangesetStateSubscription;
 
-type ManagedSubscriptionEntry = { sub: ManagedSubscription; refCount: number };
+type ManagedSubscriptionEntry = { sub: ManagedSubscription; kind: StateComponents; refCount: number };
 
 // --- Subscription Manager ----------------------------------------------------
 
@@ -512,7 +532,7 @@ export class AgentSubscriptionManager extends Disposable {
 		// Create new subscription based on caller-specified kind
 		const key = resource.toString();
 		const sub = this._createSubscription(kind, key);
-		const entry = { sub, refCount: 1 };
+		const entry = { sub, kind, refCount: 1 };
 		this._subscriptions.set(resource, entry);
 
 		// Kick off server subscription asynchronously.
@@ -590,6 +610,21 @@ export class AgentSubscriptionManager extends Disposable {
 	 */
 	currentSubscriptionUris(): URI[] {
 		return [...this._subscriptions.keys()];
+	}
+
+	/**
+	 * Read-only descriptors of every active resource subscription, for
+	 * inspection/debug surfaces. Does NOT include the always-live root
+	 * state, which the connection exposes separately via {@link rootState}.
+	 */
+	getActiveSubscriptions(): IActiveSubscriptionInfo[] {
+		const out: IActiveSubscriptionInfo[] = [];
+		for (const [resource, entry] of this._subscriptions) {
+			const value = entry.sub.value;
+			const status = value === undefined ? 'pending' : value instanceof Error ? 'error' : 'snapshot';
+			out.push({ resource, kind: entry.kind, refCount: entry.refCount, status });
+		}
+		return out;
 	}
 
 	/**

--- a/src/vs/platform/agentHost/common/state/agentSubscription.ts
+++ b/src/vs/platform/agentHost/common/state/agentSubscription.ts
@@ -653,7 +653,7 @@ export class AgentSubscriptionManager extends Disposable {
 	 * inspection/debug surfaces. Does NOT include the always-live root
 	 * state, which the connection exposes separately via {@link rootState}.
 	 */
-	getActiveSubscriptions(): IActiveSubscriptionInfo[] {
+	getActiveSubscriptions(): readonly IActiveSubscriptionInfo[] {
 		const out: IActiveSubscriptionInfo[] = [];
 		for (const [resource, entry] of this._subscriptions) {
 			const value = entry.sub.value;

--- a/src/vs/platform/agentHost/common/state/agentSubscription.ts
+++ b/src/vs/platform/agentHost/common/state/agentSubscription.ts
@@ -66,11 +66,23 @@ export interface IActiveSubscriptionInfo {
 	/** Number of outstanding {@link IReference} holders. */
 	readonly refCount: number;
 	/**
+	 * The named owners currently holding a reference to this subscription,
+	 * with how many references each holds. Names come from the `owner`
+	 * argument passed to {@link AgentSubscriptionManager.getSubscription}.
+	 */
+	readonly holders: readonly IActiveSubscriptionHolder[];
+	/**
 	 * Lifecycle status derived from the subscription's value:
 	 * `pending` before the first snapshot, `error` if it failed, otherwise
 	 * `snapshot`.
 	 */
 	readonly status: 'pending' | 'snapshot' | 'error';
+}
+
+/** A named owner holding one or more references to a subscription. */
+export interface IActiveSubscriptionHolder {
+	readonly owner: string;
+	readonly count: number;
 }
 
 // --- Base Implementation -----------------------------------------------------
@@ -444,7 +456,7 @@ export class ChangesetStateSubscription extends BaseAgentSubscription<ChangesetS
 
 type ManagedSubscription = SessionStateSubscription | TerminalStateSubscription | ChangesetStateSubscription;
 
-type ManagedSubscriptionEntry = { sub: ManagedSubscription; kind: StateComponents; refCount: number };
+type ManagedSubscriptionEntry = { sub: ManagedSubscription; kind: StateComponents; refCount: number; holders: Map<number, string> };
 
 // --- Subscription Manager ----------------------------------------------------
 
@@ -462,6 +474,7 @@ type ManagedSubscriptionEntry = { sub: ManagedSubscription; kind: StateComponent
 export class AgentSubscriptionManager extends Disposable {
 
 	private readonly _subscriptions = new ResourceMap<ManagedSubscriptionEntry>();
+	private _referenceOwnerIds = 0;
 	private readonly _rootState: RootStateSubscription;
 	private readonly _clientId: string;
 	private readonly _seqAllocator: () => number;
@@ -511,8 +524,13 @@ export class AgentSubscriptionManager extends Disposable {
 	 * Get or create a refcounted subscription to any resource. Disposing
 	 * the returned reference decrements the refcount; when it reaches zero
 	 * the subscription is torn down and the server is notified.
+	 *
+	 * `owner` names the caller holding the reference so inspection surfaces
+	 * (see {@link getActiveSubscriptions}) can attribute who is retaining a
+	 * subscription. Use a stable, human-readable identifier such as the
+	 * acquiring class name.
 	 */
-	getSubscription<T>(kind: StateComponents, resource: URI): IReference<IAgentSubscription<T>> {
+	getSubscription<T>(kind: StateComponents, resource: URI, owner: string): IReference<IAgentSubscription<T>> {
 		const existing = this._subscriptions.get(resource);
 		if (existing) {
 			if (existing.sub.value instanceof Error) {
@@ -522,17 +540,14 @@ export class AgentSubscriptionManager extends Disposable {
 				this._disposeSubscriptionEntry(resource, existing);
 			} else {
 				existing.refCount++;
-				return {
-					object: existing.sub as unknown as IAgentSubscription<T>,
-					dispose: () => this._releaseSubscription(resource, existing),
-				};
+				return this._acquireReference<T>(resource, existing, owner);
 			}
 		}
 
 		// Create new subscription based on caller-specified kind
 		const key = resource.toString();
 		const sub = this._createSubscription(kind, key);
-		const entry = { sub, kind, refCount: 1 };
+		const entry: ManagedSubscriptionEntry = { sub, kind, refCount: 1, holders: new Map() };
 		this._subscriptions.set(resource, entry);
 
 		// Kick off server subscription asynchronously.
@@ -548,9 +563,30 @@ export class AgentSubscriptionManager extends Disposable {
 			}
 		});
 
+		return this._acquireReference<T>(resource, entry, owner);
+	}
+
+	/**
+	 * Register `owner` as a holder of `entry` and return a reference whose
+	 * disposal removes that holder and releases the subscription. The
+	 * caller is responsible for the matching refcount increment (a fresh
+	 * entry starts at 1; an existing entry is bumped before calling this).
+	 */
+	private _acquireReference<T>(resource: URI, entry: ManagedSubscriptionEntry, owner: string): IReference<IAgentSubscription<T>> {
+		const ownerId = ++this._referenceOwnerIds;
+		entry.holders.set(ownerId, owner);
+
+		let isDisposed = false;
 		return {
-			object: sub as unknown as IAgentSubscription<T>,
-			dispose: () => this._releaseSubscription(resource, entry),
+			object: entry.sub as unknown as IAgentSubscription<T>,
+			dispose: () => {
+				if (isDisposed) {
+					return;
+				}
+				isDisposed = true;
+				entry.holders.delete(ownerId);
+				this._releaseSubscription(resource, entry);
+			},
 		};
 	}
 
@@ -622,9 +658,20 @@ export class AgentSubscriptionManager extends Disposable {
 		for (const [resource, entry] of this._subscriptions) {
 			const value = entry.sub.value;
 			const status = value === undefined ? 'pending' : value instanceof Error ? 'error' : 'snapshot';
-			out.push({ resource, kind: entry.kind, refCount: entry.refCount, status });
+			out.push({ resource, kind: entry.kind, refCount: entry.refCount, holders: this._summarizeHolders(entry), status });
 		}
 		return out;
+	}
+
+	/** Group an entry's holders by owner name, sorted by descending count. */
+	private _summarizeHolders(entry: ManagedSubscriptionEntry): IActiveSubscriptionHolder[] {
+		const counts = new Map<string, number>();
+		for (const owner of entry.holders.values()) {
+			counts.set(owner, (counts.get(owner) ?? 0) + 1);
+		}
+		return [...counts.entries()]
+			.map(([owner, count]) => ({ owner, count }))
+			.sort((a, b) => b.count - a.count);
 	}
 
 	/**

--- a/src/vs/platform/agentHost/electron-browser/localAgentHostService.ts
+++ b/src/vs/platform/agentHost/electron-browser/localAgentHostService.ts
@@ -18,7 +18,7 @@ import { ILogService } from '../../log/common/log.js';
 import { AgentHostAhpJsonlLoggingSettingId, AgentHostIpcChannels, IAgentCreateSessionConfig, IAgentHostInspectInfo, IAgentHostService, IAgentResolveSessionConfigParams, IAgentService, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, AuthenticateParams, AuthenticateResult, IAgentHostSocketInfo, IConnectionTrackerService, isAgentHostEnabled } from '../common/agentService.js';
 import { AhpJsonlLogger } from '../common/ahpJsonlLogger.js';
 import { wrapAgentServiceWithAhpLogging } from './localAhpJsonlLogging.js';
-import { AgentSubscriptionManager, type IAgentSubscription } from '../common/state/agentSubscription.js';
+import { AgentSubscriptionManager, type IActiveSubscriptionInfo, type IAgentSubscription } from '../common/state/agentSubscription.js';
 import type { CompletionsParams, CompletionsResult, CreateTerminalParams, ResolveSessionConfigResult, SessionConfigCompletionsResult } from '../common/state/protocol/commands.js';
 import type { InvokeChangesetOperationParams, InvokeChangesetOperationResult } from '../common/state/protocol/channels-changeset/commands.js';
 import { ActionType, type ActionEnvelope, type INotification, type IRootConfigChangedAction, type SessionAction, type TerminalAction } from '../common/state/sessionActions.js';
@@ -253,6 +253,10 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 
 	getSubscriptionUnmanaged<T>(_kind: StateComponents, resource: URI): IAgentSubscription<T> | undefined {
 		return this._subscriptionManager.getSubscriptionUnmanaged<T>(resource);
+	}
+
+	getActiveSubscriptions(): readonly IActiveSubscriptionInfo[] {
+		return this._subscriptionManager.getActiveSubscriptions();
 	}
 
 	dispatch(channel: string, action: SessionAction | TerminalAction | IRootConfigChangedAction): void {

--- a/src/vs/platform/agentHost/electron-browser/localAgentHostService.ts
+++ b/src/vs/platform/agentHost/electron-browser/localAgentHostService.ts
@@ -247,8 +247,8 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 		return this._subscriptionManager.rootState;
 	}
 
-	getSubscription<T>(kind: StateComponents, resource: URI): IReference<IAgentSubscription<T>> {
-		return this._subscriptionManager.getSubscription<T>(kind, resource);
+	getSubscription<T>(kind: StateComponents, resource: URI, owner: string): IReference<IAgentSubscription<T>> {
+		return this._subscriptionManager.getSubscription<T>(kind, resource, owner);
 	}
 
 	getSubscriptionUnmanaged<T>(_kind: StateComponents, resource: URI): IAgentSubscription<T> | undefined {

--- a/src/vs/platform/agentHost/test/common/agentSubscription.test.ts
+++ b/src/vs/platform/agentHost/test/common/agentSubscription.test.ts
@@ -718,4 +718,49 @@ suite('AgentSubscriptionManager', () => {
 		retryRef.dispose();
 		assert.strictEqual(mgr.getSubscriptionUnmanaged<SessionState>(uri), undefined);
 	});
+
+	test('getActiveSubscriptions reports kind, refCount and status per active subscription', async () => {
+		const mgr = createManager();
+		const sUri = URI.parse(sessionUri);
+		const tUri = URI.parse(terminalUri);
+
+		const sessionRef = mgr.getSubscription<SessionState>(StateComponents.Session, sUri);
+		const sessionRef2 = mgr.getSubscription<SessionState>(StateComponents.Session, sUri);
+		const terminalRef = mgr.getSubscription<TerminalState>(StateComponents.Terminal, tUri);
+
+		const pending = mgr.getActiveSubscriptions().map(s => ({ resource: s.resource.toString(), kind: s.kind, refCount: s.refCount, status: s.status }));
+
+		await new Promise(r => setTimeout(r, 0));
+
+		const active = mgr.getActiveSubscriptions().map(s => ({ resource: s.resource.toString(), kind: s.kind, refCount: s.refCount, status: s.status }));
+
+		assert.deepStrictEqual({ pending, active }, {
+			pending: [
+				{ resource: sessionUri, kind: StateComponents.Session, refCount: 2, status: 'pending' },
+				{ resource: terminalUri, kind: StateComponents.Terminal, refCount: 1, status: 'pending' },
+			],
+			active: [
+				{ resource: sessionUri, kind: StateComponents.Session, refCount: 2, status: 'snapshot' },
+				{ resource: terminalUri, kind: StateComponents.Terminal, refCount: 1, status: 'snapshot' },
+			],
+		});
+
+		sessionRef.dispose();
+		sessionRef2.dispose();
+		terminalRef.dispose();
+
+		assert.strictEqual(mgr.getActiveSubscriptions().length, 0);
+	});
+
+	test('getActiveSubscriptions reports error status for a failed subscription', async () => {
+		const mgr = createManager(async () => { throw new Error('nope'); });
+		const ref = mgr.getSubscription<SessionState>(StateComponents.Session, URI.parse(sessionUri));
+		await new Promise(r => setTimeout(r, 0));
+
+		assert.deepStrictEqual(
+			mgr.getActiveSubscriptions().map(s => ({ kind: s.kind, status: s.status })),
+			[{ kind: StateComponents.Session, status: 'error' }],
+		);
+		ref.dispose();
+	});
 });

--- a/src/vs/platform/agentHost/test/common/agentSubscription.test.ts
+++ b/src/vs/platform/agentHost/test/common/agentSubscription.test.ts
@@ -524,7 +524,7 @@ suite('AgentSubscriptionManager', () => {
 	test('getSubscription returns IReference with subscription', async () => {
 		const mgr = createManager();
 		const uri = URI.parse(sessionUri);
-		const ref = mgr.getSubscription<SessionState>(StateComponents.Session, uri);
+		const ref = mgr.getSubscription<SessionState>(StateComponents.Session, uri, 'test');
 
 		assert.ok(ref.object);
 		assert.strictEqual(ref.object.value, undefined); // not yet initialized (async)
@@ -539,8 +539,8 @@ suite('AgentSubscriptionManager', () => {
 	test('second call for same resource increments refcount', async () => {
 		const mgr = createManager();
 		const uri = URI.parse(sessionUri);
-		const ref1 = mgr.getSubscription<SessionState>(StateComponents.Session, uri);
-		const ref2 = mgr.getSubscription<SessionState>(StateComponents.Session, uri);
+		const ref1 = mgr.getSubscription<SessionState>(StateComponents.Session, uri, 'test');
+		const ref2 = mgr.getSubscription<SessionState>(StateComponents.Session, uri, 'test');
 
 		await new Promise(r => setTimeout(r, 0));
 
@@ -559,7 +559,7 @@ suite('AgentSubscriptionManager', () => {
 	test('disposing last ref calls unsubscribe callback', async () => {
 		const mgr = createManager();
 		const uri = URI.parse(sessionUri);
-		const ref = mgr.getSubscription<SessionState>(StateComponents.Session, uri);
+		const ref = mgr.getSubscription<SessionState>(StateComponents.Session, uri, 'test');
 
 		await new Promise(r => setTimeout(r, 0));
 
@@ -572,7 +572,7 @@ suite('AgentSubscriptionManager', () => {
 		mgr.handleRootSnapshot(makeRootState(), 0);
 
 		const uri = URI.parse(sessionUri);
-		const ref = mgr.getSubscription<SessionState>(StateComponents.Session, uri);
+		const ref = mgr.getSubscription<SessionState>(StateComponents.Session, uri, 'test');
 		await new Promise(r => setTimeout(r, 0));
 
 		// Send a root action
@@ -595,7 +595,7 @@ suite('AgentSubscriptionManager', () => {
 	test('creating session subscription for copilot: URI', async () => {
 		const mgr = createManager();
 		const mySessionUri = URI.from({ scheme: 'copilot', path: '/my-session' });
-		const ref = mgr.getSubscription<SessionState>(StateComponents.Session, mySessionUri);
+		const ref = mgr.getSubscription<SessionState>(StateComponents.Session, mySessionUri, 'test');
 		await new Promise(r => setTimeout(r, 0));
 
 		assert.ok(ref.object.value);
@@ -607,7 +607,7 @@ suite('AgentSubscriptionManager', () => {
 	test('creating terminal subscription for terminal URI', async () => {
 		const mgr = createManager();
 		const uri = URI.parse(terminalUri);
-		const ref = mgr.getSubscription<TerminalState>(StateComponents.Terminal, uri);
+		const ref = mgr.getSubscription<TerminalState>(StateComponents.Terminal, uri, 'test');
 		await new Promise(r => setTimeout(r, 0));
 
 		assert.ok(ref.object.value);
@@ -619,7 +619,7 @@ suite('AgentSubscriptionManager', () => {
 	test('dispatchOptimistic applies to matching session subscription', async () => {
 		const mgr = createManager();
 		const uri = URI.parse(sessionUri);
-		const ref = mgr.getSubscription<SessionState>(StateComponents.Session, uri);
+		const ref = mgr.getSubscription<SessionState>(StateComponents.Session, uri, 'test');
 		await new Promise(r => setTimeout(r, 0));
 
 		const clientSeq = mgr.dispatchOptimistic(uri.toString(), {
@@ -638,8 +638,8 @@ suite('AgentSubscriptionManager', () => {
 	test('dispose clears all subscriptions and calls unsubscribe for each', async () => {
 		const mgr = createManager();
 
-		const ref1 = mgr.getSubscription<SessionState>(StateComponents.Session, URI.parse(sessionUri));
-		const ref2 = mgr.getSubscription<TerminalState>(StateComponents.Terminal, URI.parse(terminalUri));
+		const ref1 = mgr.getSubscription<SessionState>(StateComponents.Session, URI.parse(sessionUri), 'test');
+		const ref2 = mgr.getSubscription<TerminalState>(StateComponents.Terminal, URI.parse(terminalUri), 'test');
 		await new Promise(r => setTimeout(r, 0));
 
 		// Remove the manager from disposables so we can dispose it manually
@@ -666,7 +666,7 @@ suite('AgentSubscriptionManager', () => {
 		const uri = URI.parse(sessionUri);
 
 		// Create a subscription via getSubscription
-		const ref = mgr.getSubscription<SessionState>(StateComponents.Session, uri);
+		const ref = mgr.getSubscription<SessionState>(StateComponents.Session, uri, 'test');
 		await new Promise(r => setTimeout(r, 0));
 
 		// Get it unmanaged
@@ -694,12 +694,12 @@ suite('AgentSubscriptionManager', () => {
 		});
 		const uri = URI.parse(sessionUri);
 
-		const failedRef = mgr.getSubscription<SessionState>(StateComponents.Session, uri);
+		const failedRef = mgr.getSubscription<SessionState>(StateComponents.Session, uri, 'test');
 		await new Promise(r => setTimeout(r, 0));
 
 		assert.ok(failedRef.object.value instanceof Error);
 
-		const retryRef = mgr.getSubscription<SessionState>(StateComponents.Session, uri);
+		const retryRef = mgr.getSubscription<SessionState>(StateComponents.Session, uri, 'test');
 		await new Promise(r => setTimeout(r, 0));
 
 		assert.deepStrictEqual({
@@ -719,29 +719,30 @@ suite('AgentSubscriptionManager', () => {
 		assert.strictEqual(mgr.getSubscriptionUnmanaged<SessionState>(uri), undefined);
 	});
 
-	test('getActiveSubscriptions reports kind, refCount and status per active subscription', async () => {
+	test('getActiveSubscriptions reports kind, refCount, holders and status per active subscription', async () => {
 		const mgr = createManager();
 		const sUri = URI.parse(sessionUri);
 		const tUri = URI.parse(terminalUri);
 
-		const sessionRef = mgr.getSubscription<SessionState>(StateComponents.Session, sUri);
-		const sessionRef2 = mgr.getSubscription<SessionState>(StateComponents.Session, sUri);
-		const terminalRef = mgr.getSubscription<TerminalState>(StateComponents.Terminal, tUri);
+		const sessionRef = mgr.getSubscription<SessionState>(StateComponents.Session, sUri, 'SessionHolder');
+		const sessionRef2 = mgr.getSubscription<SessionState>(StateComponents.Session, sUri, 'SessionHolder');
+		const terminalRef = mgr.getSubscription<TerminalState>(StateComponents.Terminal, tUri, 'TerminalHolder');
 
-		const pending = mgr.getActiveSubscriptions().map(s => ({ resource: s.resource.toString(), kind: s.kind, refCount: s.refCount, status: s.status }));
+		const map = () => mgr.getActiveSubscriptions().map(s => ({ resource: s.resource.toString(), kind: s.kind, refCount: s.refCount, holders: s.holders, status: s.status }));
+		const pending = map();
 
 		await new Promise(r => setTimeout(r, 0));
 
-		const active = mgr.getActiveSubscriptions().map(s => ({ resource: s.resource.toString(), kind: s.kind, refCount: s.refCount, status: s.status }));
+		const active = map();
 
 		assert.deepStrictEqual({ pending, active }, {
 			pending: [
-				{ resource: sessionUri, kind: StateComponents.Session, refCount: 2, status: 'pending' },
-				{ resource: terminalUri, kind: StateComponents.Terminal, refCount: 1, status: 'pending' },
+				{ resource: sessionUri, kind: StateComponents.Session, refCount: 2, holders: [{ owner: 'SessionHolder', count: 2 }], status: 'pending' },
+				{ resource: terminalUri, kind: StateComponents.Terminal, refCount: 1, holders: [{ owner: 'TerminalHolder', count: 1 }], status: 'pending' },
 			],
 			active: [
-				{ resource: sessionUri, kind: StateComponents.Session, refCount: 2, status: 'snapshot' },
-				{ resource: terminalUri, kind: StateComponents.Terminal, refCount: 1, status: 'snapshot' },
+				{ resource: sessionUri, kind: StateComponents.Session, refCount: 2, holders: [{ owner: 'SessionHolder', count: 2 }], status: 'snapshot' },
+				{ resource: terminalUri, kind: StateComponents.Terminal, refCount: 1, holders: [{ owner: 'TerminalHolder', count: 1 }], status: 'snapshot' },
 			],
 		});
 
@@ -752,9 +753,39 @@ suite('AgentSubscriptionManager', () => {
 		assert.strictEqual(mgr.getActiveSubscriptions().length, 0);
 	});
 
+	test('getActiveSubscriptions tracks distinct holders and drops them as references are disposed', async () => {
+		const mgr = createManager();
+		const sUri = URI.parse(sessionUri);
+
+		const refA = mgr.getSubscription<SessionState>(StateComponents.Session, sUri, 'HolderA');
+		const refB = mgr.getSubscription<SessionState>(StateComponents.Session, sUri, 'HolderB');
+		const refB2 = mgr.getSubscription<SessionState>(StateComponents.Session, sUri, 'HolderB');
+		await new Promise(r => setTimeout(r, 0));
+
+		const withAll = mgr.getActiveSubscriptions()[0].holders;
+
+		refB.dispose();
+		const afterOneB = mgr.getActiveSubscriptions()[0].holders;
+
+		// Disposing the same reference twice must not over-remove holders.
+		refB.dispose();
+		const afterDoubleDispose = mgr.getActiveSubscriptions()[0].holders;
+
+		refA.dispose();
+		refB2.dispose();
+
+		assert.deepStrictEqual({ withAll, afterOneB, afterDoubleDispose, remaining: mgr.getActiveSubscriptions().length }, {
+			// Sorted by descending count, so HolderB (2) precedes HolderA (1).
+			withAll: [{ owner: 'HolderB', count: 2 }, { owner: 'HolderA', count: 1 }],
+			afterOneB: [{ owner: 'HolderA', count: 1 }, { owner: 'HolderB', count: 1 }],
+			afterDoubleDispose: [{ owner: 'HolderA', count: 1 }, { owner: 'HolderB', count: 1 }],
+			remaining: 0,
+		});
+	});
+
 	test('getActiveSubscriptions reports error status for a failed subscription', async () => {
 		const mgr = createManager(async () => { throw new Error('nope'); });
-		const ref = mgr.getSubscription<SessionState>(StateComponents.Session, URI.parse(sessionUri));
+		const ref = mgr.getSubscription<SessionState>(StateComponents.Session, URI.parse(sessionUri), 'test');
 		await new Promise(r => setTimeout(r, 0));
 
 		assert.deepStrictEqual(

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
@@ -892,7 +892,7 @@ suite('RemoteAgentHostProtocolClient', () => {
 
 				// Establish a session subscription so dispatch() can apply optimistically.
 				const sessionUri = URI.parse('copilot:/test-session');
-				const subRef = client.getSubscription(StateComponents.Session, sessionUri);
+				const subRef = client.getSubscription(StateComponents.Session, sessionUri, 'test');
 				const subscribeReq = await waitForRequest(transports[0], 'subscribe');
 				transports[0].fireMessage({
 					jsonrpc: '2.0', id: subscribeReq.id,
@@ -940,7 +940,7 @@ suite('RemoteAgentHostProtocolClient', () => {
 				await completeHandshake(transports[0], connectPromise);
 
 				const sessionUri = URI.parse('copilot:/test-session');
-				const subRef = client.getSubscription(StateComponents.Session, sessionUri);
+				const subRef = client.getSubscription(StateComponents.Session, sessionUri, 'test');
 				const subscribeReq = await waitForRequest(transports[0], 'subscribe');
 				transports[0].fireMessage({
 					jsonrpc: '2.0', id: subscribeReq.id,
@@ -1030,7 +1030,7 @@ suite('RemoteAgentHostProtocolClient', () => {
 				await completeHandshake(transports[0], connectPromise);
 
 				const sessionUri = URI.parse('copilot:/test-session');
-				const subRef = client.getSubscription<{ summary: { title: string } }>(StateComponents.Session, sessionUri);
+				const subRef = client.getSubscription<{ summary: { title: string } }>(StateComponents.Session, sessionUri, 'test');
 				const subscribeReq = await waitForRequest(transports[0], 'subscribe');
 				transports[0].fireMessage({
 					jsonrpc: '2.0', id: subscribeReq.id,

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionChangesets.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionChangesets.ts
@@ -64,7 +64,7 @@ function createActiveSessionSubscriptionObs<TValue>(
 			return constObservable(undefined);
 		}
 
-		const subscriptionRef = connection.getSubscription(component, resource);
+		const subscriptionRef = connection.getSubscription(component, resource, 'AgentHostSessionChangesets');
 		reader.store.add(subscriptionRef);
 
 		return observableFromEvent(subscriptionRef.object.onDidChange,

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -362,7 +362,7 @@ export class AgentHostSessionAdapter implements ISession {
 			}
 
 			const branchChangesUri = URI.parse(buildSessionChangesetUri(sessionUri.toString()));
-			const subscriptionRef = connection.getSubscription(StateComponents.Changeset, branchChangesUri);
+			const subscriptionRef = connection.getSubscription(StateComponents.Changeset, branchChangesUri, 'BaseAgentHostSessionsProvider.changesets');
 			reader.store.add(subscriptionRef);
 
 			return observableFromEvent(subscriptionRef.object.onDidChange, () => subscriptionRef.object.value);
@@ -976,7 +976,7 @@ class NewSession extends Disposable {
 			// handler refcounts the same subscription via `getSubscription`
 			// when chat content opens, so when we release this ref on
 			// graduation the wire-level refcount stays positive.
-			const ref = connection.getSubscription(StateComponents.Session, backendUri);
+			const ref = connection.getSubscription(StateComponents.Session, backendUri, 'BaseAgentHostSessionsProvider.session');
 			this._subscription = ref;
 
 			// Forward `SessionState` updates back to the provider so
@@ -2191,7 +2191,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			return;
 		}
 		const sessionUri = AgentSession.uri(cached.agentProvider, rawId);
-		const ref = connection.getSubscription(StateComponents.Session, sessionUri);
+		const ref = connection.getSubscription(StateComponents.Session, sessionUri, 'BaseAgentHostSessionsProvider.summary');
 		const store = new DisposableStore();
 		store.add(ref);
 		store.add(ref.object.onDidChange(state => {

--- a/src/vs/workbench/contrib/chat/browser/actions/chatDeveloperActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatDeveloperActions.ts
@@ -21,6 +21,9 @@ import { IStorageService, StorageScope } from '../../../../../platform/storage/c
 import { AUTOPILOT_DONT_SHOW_AGAIN_KEY, AUTO_APPROVE_DONT_SHOW_AGAIN_KEY } from '../../common/chatPermissionStorageKeys.js';
 import { resetShownWarnings } from '../../common/chatPermissionWarnings.js';
 import { OpenCopilotCliStateFileAction } from './openCopilotCliStateFileAction.js';
+import { IAgentConnection, IAgentHostService } from '../../../../../platform/agentHost/common/agentService.js';
+import { IRemoteAgentHostService } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { StateComponents } from '../../../../../platform/agentHost/common/state/sessionState.js';
 
 function uriReplacer(_key: string, value: unknown): unknown {
 	if (URI.isUri(value)) {
@@ -40,6 +43,7 @@ export function registerChatDeveloperActions() {
 	registerAction2(LogChatIndexAction);
 	registerAction2(InspectChatModelAction);
 	registerAction2(InspectChatModelReferencesAction);
+	registerAction2(InspectAgentHostSubscriptionsAction);
 	registerAction2(ClearRecentlyUsedLanguageModelsAction);
 	registerAction2(ResetChatPermissionWarningDialogsAction);
 	registerAction2(OpenCopilotCliStateFileAction);
@@ -214,6 +218,107 @@ class InspectChatModelReferencesAction extends Action2 {
 		await editorService.openEditor({
 			resource: undefined,
 			contents: instantiationService.invokeFunction(formatChatModelReferenceInspection),
+			languageId: 'markdown',
+			options: {
+				pinned: true
+			}
+		});
+	}
+}
+
+function subscriptionKindLabel(kind: StateComponents): string {
+	switch (kind) {
+		case StateComponents.Root: return 'root';
+		case StateComponents.Session: return 'session';
+		case StateComponents.Terminal: return 'terminal';
+		case StateComponents.Changeset: return 'changeset';
+		default: return `unknown(${kind})`;
+	}
+}
+
+function formatConnectionSubscriptions(label: string, details: string, connection: IAgentConnection | undefined): string {
+	let output = `## ${label}\n\n`;
+	output += `- ${details}\n`;
+
+	if (!connection) {
+		output += '- Not connected.\n\n';
+		return output;
+	}
+
+	const root = connection.rootState.value;
+	if (root === undefined) {
+		output += '- Root state: pending (no snapshot yet)\n';
+	} else if (root instanceof Error) {
+		output += `- Root state: error (${root.message})\n`;
+	} else {
+		const agents = root.agents?.map(a => a.displayName).join(', ') || 'none';
+		output += `- Root state: agents=[${agents}], activeSessions=${root.activeSessions ?? 0}, terminals=${root.terminals?.length ?? 0}\n`;
+	}
+
+	const subscriptions = connection.getActiveSubscriptions();
+	output += `- Active subscriptions: ${subscriptions.length}\n\n`;
+
+	if (subscriptions.length) {
+		const sorted = [...subscriptions].sort((a, b) => a.resource.toString().localeCompare(b.resource.toString()));
+		output += '| Resource | Kind | Refs | Status |\n';
+		output += '| --- | --- | --- | --- |\n';
+		for (const subscription of sorted) {
+			output += `| ${subscription.resource.toString()} | ${subscriptionKindLabel(subscription.kind)} | ${subscription.refCount} | ${subscription.status} |\n`;
+		}
+		output += '\n';
+	}
+
+	return output;
+}
+
+function formatAgentHostSubscriptionsInspection(accessor: ServicesAccessor): string {
+	const agentHostService = accessor.get(IAgentHostService);
+	const remoteAgentHostService = accessor.get(IRemoteAgentHostService);
+
+	const remoteConnections = remoteAgentHostService.connections;
+
+	let output = '# Agent Host Subscriptions\n\n';
+	output += `- Connections: ${1 + remoteConnections.length} (1 local, ${remoteConnections.length} remote)\n`;
+	output += 'Lists every resource each connected agent host is currently subscribed to. The always-live root state is summarized separately from the per-resource subscription table.\n\n';
+
+	output += formatConnectionSubscriptions(
+		'Local agent host',
+		`clientId: ${agentHostService.clientId || '(none)'}`,
+		agentHostService,
+	);
+
+	for (const info of remoteConnections) {
+		output += formatConnectionSubscriptions(
+			`Remote: ${info.name}`,
+			`address: ${info.address} · status: ${info.status} · clientId: ${info.clientId || '(none)'}`,
+			remoteAgentHostService.getConnection(info.address),
+		);
+	}
+
+	return output;
+}
+
+class InspectAgentHostSubscriptionsAction extends Action2 {
+	static readonly ID = 'workbench.action.chat.inspectAgentHostSubscriptions';
+
+	constructor() {
+		super({
+			id: InspectAgentHostSubscriptionsAction.ID,
+			title: localize2('workbench.action.chat.inspectAgentHostSubscriptions.label', "Inspect Agent Host Subscriptions"),
+			icon: Codicon.inspect,
+			category: Categories.Developer,
+			f1: true,
+			precondition: ChatContextKeys.enabled
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		const instantiationService = accessor.get(IInstantiationService);
+		const editorService = accessor.get(IEditorService);
+
+		await editorService.openEditor({
+			resource: undefined,
+			contents: instantiationService.invokeFunction(formatAgentHostSubscriptionsInspection),
 			languageId: 'markdown',
 			options: {
 				pinned: true

--- a/src/vs/workbench/contrib/chat/browser/actions/chatDeveloperActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatDeveloperActions.ts
@@ -236,6 +236,11 @@ function subscriptionKindLabel(kind: StateComponents): string {
 	}
 }
 
+/** Escape a value so it is safe to embed in a markdown table cell. */
+function escapeMarkdownTableCell(value: string): string {
+	return value.replace(/\r?\n/g, '<br>').replace(/\|/g, '\\|');
+}
+
 function formatConnectionSubscriptions(label: string, details: string, connection: IAgentConnection | undefined): string {
 	let output = `## ${label}\n\n`;
 	output += `- ${details}\n`;
@@ -266,7 +271,14 @@ function formatConnectionSubscriptions(label: string, details: string, connectio
 			const holders = subscription.holders.length
 				? subscription.holders.map(h => h.count > 1 ? `${h.owner} (${h.count})` : h.owner).join(', ')
 				: '(none)';
-			output += `| ${subscription.resource.toString()} | ${subscriptionKindLabel(subscription.kind)} | ${subscription.refCount} | ${holders} | ${subscription.status} |\n`;
+			const cells = [
+				subscription.resource.toString(),
+				subscriptionKindLabel(subscription.kind),
+				String(subscription.refCount),
+				holders,
+				subscription.status,
+			].map(escapeMarkdownTableCell);
+			output += `| ${cells.join(' | ')} |\n`;
 		}
 		output += '\n';
 	}

--- a/src/vs/workbench/contrib/chat/browser/actions/chatDeveloperActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatDeveloperActions.ts
@@ -260,10 +260,13 @@ function formatConnectionSubscriptions(label: string, details: string, connectio
 
 	if (subscriptions.length) {
 		const sorted = [...subscriptions].sort((a, b) => a.resource.toString().localeCompare(b.resource.toString()));
-		output += '| Resource | Kind | Refs | Status |\n';
-		output += '| --- | --- | --- | --- |\n';
+		output += '| Resource | Kind | Refs | Holders | Status |\n';
+		output += '| --- | --- | --- | --- | --- |\n';
 		for (const subscription of sorted) {
-			output += `| ${subscription.resource.toString()} | ${subscriptionKindLabel(subscription.kind)} | ${subscription.refCount} | ${subscription.status} |\n`;
+			const holders = subscription.holders.length
+				? subscription.holders.map(h => h.count > 1 ? `${h.owner} (${h.count})` : h.owner).join(', ')
+				: '(none)';
+			output += `| ${subscription.resource.toString()} | ${subscriptionKindLabel(subscription.kind)} | ${subscription.refCount} | ${holders} | ${subscription.status} |\n`;
 		}
 		output += '\n';
 	}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker.ts
@@ -265,7 +265,7 @@ export class AgentHostChatInputPicker extends Disposable {
 
 		this._initialResolved = undefined;
 		this._cancelInitialResolve();
-		const ref = this._agentHostService.getSubscription(StateComponents.Session, backendSession);
+		const ref = this._agentHostService.getSubscription(StateComponents.Session, backendSession, 'AgentHostChatInputPicker');
 		const sub = ref.object;
 		const listener = sub.onDidChange(() => this._renderChip());
 		this._subRef.value = {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostCustomizationService.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostCustomizationService.ts
@@ -124,7 +124,7 @@ class WorkbenchAgentHostCustomizationService extends Disposable implements IAgen
 			return existing;
 		}
 
-		const ref = this._agentHostService.getSubscription(StateComponents.Session, backendSession);
+		const ref = this._agentHostService.getSubscription(StateComponents.Session, backendSession, 'AgentHostCustomizationService');
 		const sub = ref.object;
 		const listener = sub.onDidChange(() => {
 			this._fireCustomizationsChanged();

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostGenericConfigChips.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostGenericConfigChips.ts
@@ -100,7 +100,7 @@ export class AgentHostGenericConfigChips extends Disposable {
 
 		this._initialResolved = undefined;
 		this._cancelInitialResolve();
-		const ref = this._agentHostService.getSubscription(StateComponents.Session, backendSession);
+		const ref = this._agentHostService.getSubscription(StateComponents.Session, backendSession, 'AgentHostGenericConfigChips');
 		const sub = ref.object;
 		const listener = sub.onDidChange(() => this._sync());
 		this._subRef.value = {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -2953,7 +2953,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			ref = undefined;
 		}
 		if (!ref) {
-			ref = this._config.connection.getSubscription(StateComponents.Session, URI.parse(sessionUri));
+			ref = this._config.connection.getSubscription(StateComponents.Session, URI.parse(sessionUri), 'AgentHostSessionHandler');
 			this._sessionSubscriptions.set(sessionUri, ref);
 		}
 		return ref.object;

--- a/src/vs/workbench/contrib/terminal/browser/agentHostPty.ts
+++ b/src/vs/workbench/contrib/terminal/browser/agentHostPty.ts
@@ -143,7 +143,7 @@ export class AgentHostPty extends BasePty implements ITerminalChildProcess {
 			}
 
 			// 2. Get a subscription for the terminal URI (auto-subscribes)
-			this._subscriptionRef = this._connection.getSubscription(StateComponents.Terminal, this._terminalUri);
+			this._subscriptionRef = this._connection.getSubscription(StateComponents.Terminal, this._terminalUri, 'AgentHostPty');
 			const subscription = this._subscriptionRef.object;
 
 			// 3. Wait for hydration via onDidChange, then replay snapshot
@@ -400,7 +400,7 @@ export class AgentHostPty extends BasePty implements ITerminalChildProcess {
 
 		try {
 			// Re-subscribe to the terminal state
-			this._subscriptionRef = this._connection.getSubscription(StateComponents.Terminal, this._terminalUri);
+			this._subscriptionRef = this._connection.getSubscription(StateComponents.Terminal, this._terminalUri, 'AgentHostPty');
 			const subscription = this._subscriptionRef.object;
 
 			// Wait for hydration with a timeout — the terminal may no longer

--- a/src/vs/workbench/contrib/terminal/test/browser/agentHostPty.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/agentHostPty.test.ts
@@ -16,7 +16,7 @@ import type { ActionEnvelope, IRootConfigChangedAction, SessionAction, TerminalA
 import type { ResourceCopyParams, ResourceCopyResult, ResourceDeleteParams, ResourceDeleteResult, ResourceListResult, ResourceMoveParams, ResourceMoveResult, ResourceReadResult, ResourceResolveParams, ResourceResolveResult, ResourceWriteParams, ResourceWriteResult, CreateResourceWatchParams, CreateResourceWatchResult, ResourceMkdirParams, ResourceMkdirResult } from '../../../../../platform/agentHost/common/state/sessionProtocol.js';
 
 import { AgentHostPty } from '../../browser/agentHostPty.js';
-import { IAgentSubscription } from '../../../../../platform/agentHost/common/state/agentSubscription.js';
+import { IActiveSubscriptionInfo, IAgentSubscription } from '../../../../../platform/agentHost/common/state/agentSubscription.js';
 import { StateComponents } from '../../../../../platform/agentHost/common/state/sessionState.js';
 import type { IRemoteWatchHandle } from '../../../../../platform/agentHost/common/agentHostFileSystemProvider.js';
 // ---- Mock IAgentConnection --------------------------------------------------
@@ -110,6 +110,9 @@ class MockAgentConnection implements IAgentConnection {
 	}
 	getSubscriptionUnmanaged<T>(_kind: StateComponents, _resource: URI): IAgentSubscription<T> | undefined {
 		return undefined;
+	}
+	getActiveSubscriptions(): readonly IActiveSubscriptionInfo[] {
+		return [];
 	}
 	dispatch(channel: string, action: SessionAction | TerminalAction | IRootConfigChangedAction): void {
 		this.dispatchedActions.push({ channel, action });

--- a/src/vs/workbench/services/agentHost/browser/editorRemoteAgentHostServiceClient.ts
+++ b/src/vs/workbench/services/agentHost/browser/editorRemoteAgentHostServiceClient.ts
@@ -19,7 +19,7 @@ import { ILogService } from '../../../../platform/log/common/log.js';
 import { AgentHostEnabledSettingId, AgentHostIpcChannels, IAgentCreateSessionConfig, IAgentHostInspectInfo, IAgentHostService, IAgentHostSocketInfo, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, AuthenticateParams, AuthenticateResult, isAgentHostEnabled } from '../../../../platform/agentHost/common/agentService.js';
 import { AgentHostIpcChannelTransport } from '../../../../platform/agentHost/browser/agentHostIpcChannelTransport.js';
 import { RemoteAgentHostProtocolClient } from '../../../../platform/agentHost/browser/remoteAgentHostProtocolClient.js';
-import type { IAgentSubscription } from '../../../../platform/agentHost/common/state/agentSubscription.js';
+import type { IActiveSubscriptionInfo, IAgentSubscription } from '../../../../platform/agentHost/common/state/agentSubscription.js';
 import type { CompletionsParams, CompletionsResult, CreateTerminalParams, ResolveSessionConfigResult, SessionConfigCompletionsResult } from '../../../../platform/agentHost/common/state/protocol/commands.js';
 import type { InvokeChangesetOperationParams, InvokeChangesetOperationResult } from '../../../../platform/agentHost/common/state/protocol/channels-changeset/commands.js';
 import type { ActionEnvelope, INotification, IRootConfigChangedAction, SessionAction, TerminalAction } from '../../../../platform/agentHost/common/state/sessionActions.js';
@@ -171,6 +171,10 @@ export class EditorRemoteAgentHostServiceClient extends Disposable implements IA
 
 	getSubscriptionUnmanaged<T extends StateComponents>(kind: T, resource: URI): IAgentSubscription<ComponentToState[T]> | undefined {
 		return this._protocolClient?.getSubscriptionUnmanaged<ComponentToState[T]>(kind, resource);
+	}
+
+	getActiveSubscriptions(): readonly IActiveSubscriptionInfo[] {
+		return this._protocolClient?.getActiveSubscriptions() ?? [];
 	}
 
 	dispatch(channel: string, action: SessionAction | TerminalAction | IRootConfigChangedAction): void {

--- a/src/vs/workbench/services/agentHost/browser/editorRemoteAgentHostServiceClient.ts
+++ b/src/vs/workbench/services/agentHost/browser/editorRemoteAgentHostServiceClient.ts
@@ -165,8 +165,8 @@ export class EditorRemoteAgentHostServiceClient extends Disposable implements IA
 		return this._protocolClient?.onDidAction ?? Event.None;
 	}
 
-	getSubscription<T extends StateComponents>(kind: T, resource: URI): IReference<IAgentSubscription<ComponentToState[T]>> {
-		return this._requireClient().getSubscription<ComponentToState[T]>(kind, resource);
+	getSubscription<T extends StateComponents>(kind: T, resource: URI, owner: string): IReference<IAgentSubscription<ComponentToState[T]>> {
+		return this._requireClient().getSubscription<ComponentToState[T]>(kind, resource, owner);
 	}
 
 	getSubscriptionUnmanaged<T extends StateComponents>(kind: T, resource: URI): IAgentSubscription<ComponentToState[T]> | undefined {


### PR DESCRIPTION
## What

Adds a Developer command, **Inspect Agent Host Subscriptions**, that opens a read-only markdown editor listing every resource we are subscribed to across all connected agent hosts — the local host plus every remote host in the Agents window. It's modeled on the existing **Inspect Chat Model References** command.

For each connection the editor shows a root-state summary (advertised agents, active session count, terminal count) and a table of active subscriptions (resource URI, kind, reference count, status).

## Why

There was no way to see, at runtime, what each agent host connection is actually subscribed to. This is a useful diagnostic when investigating subscription leaks, stuck/pending subscriptions, or reconnect behavior — across both the local utility-process host and remote hosts.

## How

- `AgentSubscriptionManager.getActiveSubscriptions()` returns read-only `IActiveSubscriptionInfo` descriptors (`resource` / `kind` / `refCount` / `status`). Status is derived from the subscription value: `pending` before the first snapshot, `error` if it failed, otherwise `snapshot`. The always-live root state is intentionally excluded (it's reported separately by the command).
- The subscription `kind` is now retained on the managed entry so it can be reported without inspecting subclass types.
- The accessor is exposed on the consumer-facing `IAgentConnection` interface and implemented by the local, remote-protocol, editor-remote, and null clients — each a one-line delegation matching the existing `getSubscription` / `getSubscriptionUnmanaged` pass-throughs.
- The command itself is registered once in the shared chat developer actions, so it appears in **both** VS Code and the Agents window. It is gated on `ChatContextKeys.enabled`.

## Notes for reviewers

- Adding a method to `IAgentConnection` ripples to all implementers; the four production implementations plus one test stub (`MockAgentConnection`) are updated. The other agent-connection test doubles extend `mock<…>()` and don't need the method.
- New unit tests in `agentSubscription.test.ts` cover the pending→snapshot transition (with reference counts) and the error status.
- Validated: `compile-check-ts-native` clean, full `npm run compile` with 0 errors, ESLint clean on changed files, `AgentSubscriptionManager` suite (15 passing incl. 2 new) and `AgentHostPty` suite (18 passing).

(Written by Copilot)
