### PR TITLE
chat: fix Agent Host shutdown warning

### DIFF
--- a/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
@@ -249,18 +249,31 @@ export namespace SessionType {
 }
 
 /**
- * Returns whether the given session type is an agent host target.
- * Matches the local agent host (`agent-host-*`) and remote agent hosts (`remote-*`).
+ * Returns whether the given session type is a local agent host target.
+ */
+export function isLocalAgentHostTarget(target: string): boolean {
+	return target === SessionType.AgentHostCopilot ||
+		target.startsWith('agent-host-');
+}
+
+/**
+ * Returns whether the given session type is a remote agent host target.
  *
  * Note: The `remote-` prefix convention is established by
  * `RemoteAgentHostContribution` which generates session types as
  * `remote-{sanitizedAddress}-{provider}`. If future remote providers that
  * are NOT agent hosts need a different prefix, this function must be updated.
  */
+export function isRemoteAgentHostTarget(target: string): boolean {
+	return target.startsWith('remote-');
+}
+
+/**
+ * Returns whether the given session type is an agent host target.
+ * Matches the local agent host (`agent-host-*`) and remote agent hosts (`remote-*`).
+ */
 export function isAgentHostTarget(target: string): boolean {
-	return target === SessionType.AgentHostCopilot ||
-		target.startsWith('agent-host-') ||
-		target.startsWith('remote-');
+	return isLocalAgentHostTarget(target) || isRemoteAgentHostTarget(target);
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/electron-browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/chat.contribution.ts
@@ -34,7 +34,6 @@ import { ACTION_ID_NEW_CHAT, CHAT_OPEN_ACTION_ID, IChatViewOpenOptions } from '.
 import { AgentHostContribution } from '../browser/agentSessions/agentHost/agentHostChatContribution.js';
 import { AgentHostTerminalContribution } from '../browser/agentSessions/agentHost/agentHostTerminalContribution.js';
 import { AgentSessionProviders, getAgentSessionProviderName } from '../browser/agentSessions/agentSessions.js';
-import { isSessionInProgressStatus } from '../browser/agentSessions/agentSessionsModel.js';
 import { IAgentSessionsService } from '../browser/agentSessions/agentSessionsService.js';
 import { ChatViewPaneTarget, IChatWidgetService } from '../browser/chat.js';
 import { ChatSessionPosition, openChatSession } from '../browser/chatSessions/chatSessions.contribution.js';
@@ -47,6 +46,7 @@ import { IPluginGitService } from '../common/plugins/pluginGitService.js';
 import { registerChatDeveloperActions } from './actions/chatDeveloperActions.js';
 import { registerChatExportZipAction } from './actions/chatExportZip.js';
 import { registerExportAgentTracesDbAction } from './actions/exportAgentTracesDb.js';
+import { shouldWarnForSessionShutdown } from './chatLifecycle.js';
 import { HoldToVoiceChatInChatViewAction, InlineVoiceChatAction, KeywordActivationContribution, QuickVoiceChatAction, ReadChatResponseAloud, StartVoiceChatAction, StopListeningAction, StopListeningAndSubmitAction, StopReadAloud, StopReadChatItemAloud, VoiceChatInChatViewAction } from './actions/voiceChatActions.js';
 import { OpenWorkspaceInAgentsWindowAction, OpenWorkspaceInAgentsContribution, OpenAgentsWindowAction, OpenChatSessionInAgentsWindowAction, AgentsHandoffInputTipContribution, ToggleOpenInAgentsWindowTitleBarAction } from './agentSessions/agentSessionsActions.js';
 import { NativeBuiltinToolsContribution } from './builtInTools/tools.js';
@@ -173,20 +173,16 @@ class ChatLifecycleHandler extends Disposable {
 		}));
 
 		this._register(extensionService.onWillStop(e => {
-			e.veto(this.hasNonCloudSessionInProgress(), localize('chatRequestInProgress', "A session is in progress."));
+			e.veto(this.hasSessionThatWillStop(ShutdownReason.CLOSE), localize('chatRequestInProgress', "A session is in progress."));
 		}));
 	}
 
-	private hasNonCloudSessionInProgress(): boolean {
+	private hasSessionThatWillStop(reason: ShutdownReason): boolean {
 		if (this.chatEntitlementService.sentiment.hidden) {
 			return false; // AI features are disabled
 		}
 
-		return this.agentSessionsService.model.sessions.some(session =>
-			isSessionInProgressStatus(session.status) &&
-			session.providerType !== AgentSessionProviders.Cloud &&
-			!session.isArchived()
-		);
+		return this.agentSessionsService.model.sessions.some(session => shouldWarnForSessionShutdown(session, reason));
 	}
 
 	private shouldVetoShutdown(reason: ShutdownReason): boolean | Promise<boolean> {
@@ -194,7 +190,7 @@ class ChatLifecycleHandler extends Disposable {
 			return false;
 		}
 
-		if (!this.hasNonCloudSessionInProgress()) {
+		if (!this.hasSessionThatWillStop(reason)) {
 			return false;
 		}
 

--- a/src/vs/workbench/contrib/chat/electron-browser/chatLifecycle.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/chatLifecycle.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ShutdownReason } from '../../../services/lifecycle/common/lifecycle.js';
+import { AgentSessionProviders } from '../browser/agentSessions/agentSessions.js';
+import { type IAgentSession, isSessionInProgressStatus } from '../browser/agentSessions/agentSessionsModel.js';
+import { isLocalAgentHostTarget, isRemoteAgentHostTarget } from '../common/chatSessionsService.js';
+
+type ShutdownWarningSession = Pick<IAgentSession, 'isArchived' | 'providerType' | 'status'>;
+
+export function shouldWarnForSessionShutdown(session: ShutdownWarningSession, reason: ShutdownReason): boolean {
+	if (!isSessionInProgressStatus(session.status) || session.providerType === AgentSessionProviders.Cloud || session.isArchived()) {
+		return false;
+	}
+
+	if (isRemoteAgentHostTarget(session.providerType)) {
+		return false;
+	}
+
+	if (isLocalAgentHostTarget(session.providerType)) {
+		return reason === ShutdownReason.QUIT;
+	}
+
+	return true;
+}

--- a/src/vs/workbench/contrib/chat/test/electron-browser/chatLifecycle.test.ts
+++ b/src/vs/workbench/contrib/chat/test/electron-browser/chatLifecycle.test.ts
@@ -1,0 +1,60 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { ShutdownReason } from '../../../../services/lifecycle/common/lifecycle.js';
+import { AgentSessionProviders } from '../../browser/agentSessions/agentSessions.js';
+import { AgentSessionStatus } from '../../browser/agentSessions/agentSessionsModel.js';
+import { shouldWarnForSessionShutdown } from '../../electron-browser/chatLifecycle.js';
+
+suite('ChatLifecycle', () => {
+	type TestSession = Parameters<typeof shouldWarnForSessionShutdown>[0];
+
+	function createSession(providerType: string, status = AgentSessionStatus.InProgress, archived = false): TestSession {
+		return {
+			providerType,
+			status,
+			isArchived: () => archived
+		};
+	}
+
+	function warningsByReason(session: TestSession): Record<string, boolean> {
+		return {
+			close: shouldWarnForSessionShutdown(session, ShutdownReason.CLOSE),
+			load: shouldWarnForSessionShutdown(session, ShutdownReason.LOAD),
+			reload: shouldWarnForSessionShutdown(session, ShutdownReason.RELOAD),
+			quit: shouldWarnForSessionShutdown(session, ShutdownReason.QUIT)
+		};
+	}
+
+	test('shouldWarnForSessionShutdown', () => {
+		assert.deepStrictEqual([
+			{ name: 'local', warnings: warningsByReason(createSession(AgentSessionProviders.Local)) },
+			{ name: 'background', warnings: warningsByReason(createSession(AgentSessionProviders.Background)) },
+			{ name: 'cloud', warnings: warningsByReason(createSession(AgentSessionProviders.Cloud)) },
+			{ name: 'local agent host', warnings: warningsByReason(createSession(AgentSessionProviders.AgentHostCopilot)) },
+			{ name: 'dynamic local agent host', warnings: warningsByReason(createSession('agent-host-foo')) },
+			{ name: 'remote agent host', warnings: warningsByReason(createSession('remote-host-copilotcli')) },
+			{ name: 'dynamic remote agent host', warnings: warningsByReason(createSession('remote-foo')) },
+			{ name: 'archived', warnings: warningsByReason(createSession(AgentSessionProviders.Local, AgentSessionStatus.InProgress, true)) },
+			{ name: 'completed', warnings: warningsByReason(createSession(AgentSessionProviders.Local, AgentSessionStatus.Completed)) },
+			{ name: 'needs input', warnings: warningsByReason(createSession(AgentSessionProviders.Local, AgentSessionStatus.NeedsInput)) },
+		], [
+			{ name: 'local', warnings: { close: true, load: true, reload: true, quit: true } },
+			{ name: 'background', warnings: { close: true, load: true, reload: true, quit: true } },
+			{ name: 'cloud', warnings: { close: false, load: false, reload: false, quit: false } },
+			{ name: 'local agent host', warnings: { close: false, load: false, reload: false, quit: true } },
+			{ name: 'dynamic local agent host', warnings: { close: false, load: false, reload: false, quit: true } },
+			{ name: 'remote agent host', warnings: { close: false, load: false, reload: false, quit: false } },
+			{ name: 'dynamic remote agent host', warnings: { close: false, load: false, reload: false, quit: false } },
+			{ name: 'archived', warnings: { close: false, load: false, reload: false, quit: false } },
+			{ name: 'completed', warnings: { close: false, load: false, reload: false, quit: false } },
+			{ name: 'needs input', warnings: { close: true, load: true, reload: true, quit: true } },
+		]);
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+});


### PR DESCRIPTION
Fixes #320122

This updates the chat shutdown warning so Agent Host sessions only participate when the shutdown will actually stop them. Local Agent Host sessions still warn on full app quit, but not on window close, reload, or workspace load. Remote Agent Host sessions are excluded from this stop warning entirely.

The existing behavior is preserved for non-cloud, non-Agent-Host sessions, and cloud sessions remain excluded.

Validation:
- npm run compile-check-ts-native
- node --experimental-strip-types build/hygiene.ts src/vs/workbench/contrib/chat/common/chatSessionsService.ts src/vs/workbench/contrib/chat/electron-browser/chat.contribution.ts src/vs/workbench/contrib/chat/electron-browser/chatLifecycle.ts src/vs/workbench/contrib/chat/test/electron-browser/chatLifecycle.test.ts
- ./scripts/test.sh --run src/vs/workbench/contrib/chat/test/electron-browser/chatLifecycle.test.ts --grep "ChatLifecycle"
- npm run valid-layers-check