### PR TITLE
Show new local chat sessions in list without manual refresh

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentSessionsController.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentSessionsController.ts
@@ -132,6 +132,13 @@ export class LocalAgentsSessionsController extends Disposable implements IChatSe
 	}
 
 	private async tryUpdateLiveSessionItem(model: IChatModel): Promise<void> {
+		// Cheap gate first: a model that has no requests is never listable, so
+		// skip building the full detail (which awaits potentially expensive
+		// diff stats via `chatModelToChatDetail`) on every model change.
+		if (!model.hasRequests) {
+			return;
+		}
+
 		// Build the item from the current model state. `toChatSessionItem`
 		// applies the same qualification rules as the full refresh (e.g. a
 		// session only becomes listable once it has requests). Doing this here

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentSessionsController.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentSessionsController.ts
@@ -132,17 +132,23 @@ export class LocalAgentsSessionsController extends Disposable implements IChatSe
 	}
 
 	private async tryUpdateLiveSessionItem(model: IChatModel): Promise<void> {
+		// Build the item from the current model state. `toChatSessionItem`
+		// applies the same qualification rules as the full refresh (e.g. a
+		// session only becomes listable once it has requests). Doing this here
+		// also covers the case where a brand-new session becomes listable after
+		// its first request is sent: previously we bailed out when no item
+		// existed yet, so such sessions were missed until a manual refresh.
+		const updated = this.toChatSessionItem(await chatModelToChatDetail(model));
+		if (!updated) {
+			return;
+		}
+
 		const existing = this._items.get(model.sessionResource);
-		if (!existing) {
+		if (existing && existing.isEqual(updated)) {
 			return;
 		}
 
-		const updated = new LocalChatSessionItem(await chatModelToChatDetail(model), model);
-		if (existing.isEqual(updated)) {
-			return;
-		}
-
-		this._items.set(existing.resource, updated);
+		this._items.set(updated.resource, updated);
 		this._onDidChangeChatSessionItems.fire({ addedOrUpdated: [updated] });
 	}
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/localAgentSessionsController.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/localAgentSessionsController.test.ts
@@ -39,6 +39,7 @@ function createTestTiming(options?: {
 interface MockChatModel extends IChatModel {
 	setCustomTitle(title: string): void;
 	setRequestInProgress(inProgress: boolean): void;
+	setHasRequests(hasRequests: boolean): void;
 }
 
 function createMockChatModel(options: {
@@ -63,25 +64,28 @@ function createMockChatModel(options: {
 }): MockChatModel {
 	const requests: IChatRequestModel[] = [];
 
-	if (options.hasRequests !== false) {
-		const mockResponse: Partial<IChatResponseModel> = {
-			isComplete: options.lastResponseComplete ?? true,
-			isCanceled: options.lastResponseCanceled ?? false,
-			result: options.lastResponseHasError ? { errorDetails: { message: 'error' } } : undefined,
-			timestamp: options.lastResponseTimestamp ?? Date.now(),
-			completedAt: options.lastResponseCompletedAt,
-			response: {
-				value: [],
-				getMarkdown: () => '',
-				getFinalResponse: () => '',
-				toString: () => options.customTitle ? '' : 'Test response content'
-			}
-		};
+	const mockResponse: Partial<IChatResponseModel> = {
+		isComplete: options.lastResponseComplete ?? true,
+		isCanceled: options.lastResponseCanceled ?? false,
+		result: options.lastResponseHasError ? { errorDetails: { message: 'error' } } : undefined,
+		timestamp: options.lastResponseTimestamp ?? Date.now(),
+		completedAt: options.lastResponseCompletedAt,
+		response: {
+			value: [],
+			getMarkdown: () => '',
+			getFinalResponse: () => '',
+			toString: () => options.customTitle ? '' : 'Test response content'
+		}
+	};
 
-		requests.push({
-			id: 'request-1',
-			response: mockResponse as IChatResponseModel
-		} as IChatRequestModel);
+	const mockRequest = {
+		id: 'request-1',
+		response: mockResponse as IChatResponseModel
+	} as IChatRequestModel;
+
+	let hasRequests = options.hasRequests !== false;
+	if (hasRequests) {
+		requests.push(mockRequest);
 	}
 
 	const editingSessionEntries = options.editingSession?.entries.map(entry => ({
@@ -106,7 +110,9 @@ function createMockChatModel(options: {
 			return title;
 		},
 		sessionResource: options.sessionResource,
-		hasRequests: options.hasRequests !== false,
+		get hasRequests() {
+			return hasRequests;
+		},
 		timestamp: options.timestamp ?? Date.now(),
 		timing: createTestTiming({ created: options.timestamp }),
 		requestInProgress,
@@ -126,6 +132,17 @@ function createMockChatModel(options: {
 			}
 			requestInProgress.set(inProgress, undefined);
 			_onDidChange.fire({ kind: 'changedRequest' } as IChatChangedRequestEvent);
+		},
+		setHasRequests: (value: boolean) => {
+			if (hasRequests === value) {
+				return;
+			}
+			hasRequests = value;
+			requests.length = 0;
+			if (value) {
+				requests.push(mockRequest);
+			}
+			_onDidChange.fire({ kind: 'addRequest' } as IChatChangeEvent);
 		},
 	} as Partial<IChatModel> as MockChatModel;
 }
@@ -603,7 +620,10 @@ suite('LocalAgentsSessionsController', () => {
 				mockModel.setRequestInProgress(true);
 				await onDidChangeChatSessionItems;
 
-				assert.strictEqual(changeEventCount, 3);
+				// The session is now added as soon as the model is seen with
+				// requests (via the model-change path), so the subsequent
+				// refresh dedupes instead of firing a separate add event.
+				assert.strictEqual(changeEventCount, 2);
 			});
 		});
 
@@ -670,6 +690,37 @@ suite('LocalAgentsSessionsController', () => {
 				const addedResources = fired.flatMap(d => d.addedOrUpdated ?? []).map(i => i.resource.toString());
 				assert.ok(addedResources.includes(sessionResource2.toString()), 'forked session should appear in addedOrUpdated');
 				assert.ok(!addedResources.includes(sessionResource1.toString()), 'existing session should not appear in addedOrUpdated');
+			});
+		});
+
+		test('should add a new session once it gains its first request (without manual refresh)', async () => {
+			return runWithFakedTimers({}, async () => {
+				const controller = createController();
+
+				// Brand-new session: a model exists but has no requests yet, so
+				// it should not be listed initially.
+				const sessionResource = LocalChatSessionUri.forSession('new-empty-session');
+				const mockModel = createMockChatModel({
+					sessionResource,
+					hasRequests: false
+				});
+
+				mockChatService.addSession(mockModel);
+				await controller.refresh(CancellationToken.None);
+				assert.strictEqual(controller.items.length, 0, 'session without requests should not be listed');
+
+				const fired: { addedOrUpdated?: readonly IChatSessionItem[]; removed?: readonly URI[] }[] = [];
+				disposables.add(controller.onDidChangeChatSessionItems(delta => fired.push(delta)));
+
+				// User sends the first request: the session becomes listable.
+				const onChange = Event.toPromise(controller.onDidChangeChatSessionItems);
+				mockChatService.setLiveSessionItems([await chatModelToChatDetail(mockModel)]);
+				mockModel.setHasRequests(true);
+				await onChange;
+
+				assert.strictEqual(controller.items.length, 1, 'session should be listed after first request');
+				const addedResources = fired.flatMap(d => d.addedOrUpdated ?? []).map(i => i.resource.toString());
+				assert.ok(addedResources.includes(sessionResource.toString()), 'new session should be reported via addedOrUpdated');
 			});
 		});
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/localAgentSessionsController.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/localAgentSessionsController.test.ts
@@ -18,7 +18,7 @@ import { IChatService, ResponseModelState } from '../../../common/chatService/ch
 import { chatModelToChatDetail } from '../../../common/chatService/chatServiceImpl.js';
 import { ChatSessionStatus, IChatSessionItem, IChatSessionsService, localChatSessionType } from '../../../common/chatSessionsService.js';
 import { ChatEditingSessionState, ModifiedFileEntryState } from '../../../common/editing/chatEditingService.js';
-import { IChatChangedRequestEvent, IChatChangeEvent, IChatModel, IChatRequestModel, IChatResponseModel } from '../../../common/model/chatModel.js';
+import { IChatAddRequestEvent, IChatChangedRequestEvent, IChatChangeEvent, IChatModel, IChatRequestModel, IChatResponseModel } from '../../../common/model/chatModel.js';
 import { LocalChatSessionUri } from '../../../common/model/chatUri.js';
 import { MockChatService } from '../../common/chatService/mockChatService.js';
 import { MockChatSessionsService } from '../../common/mockChatSessionsService.js';
@@ -141,8 +141,8 @@ function createMockChatModel(options: {
 			requests.length = 0;
 			if (value) {
 				requests.push(mockRequest);
+				_onDidChange.fire({ kind: 'addRequest', request: mockRequest } as IChatAddRequestEvent);
 			}
-			_onDidChange.fire({ kind: 'addRequest' } as IChatChangeEvent);
 		},
 	} as Partial<IChatModel> as MockChatModel;
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/306169

## Problem

When starting a session in the VS Code editor window (the "local" harness), the new session often didn't appear in the Chat Sessions list until the **Refresh** button was clicked.

## Root cause

The list is driven by `LocalAgentsSessionsController`. A brand-new local session has no requests when its chat model is created, so the initial `refresh()` correctly excludes it (a session only becomes listable once it `hasRequests`).

Adding a session to the list could **only** happen via `refresh()`. The per-model change listener `tryUpdateLiveSessionItem` could only *update* items already present in `_items` — it returned early with `if (!existing) return;`, so it could never add a newly-qualifying session.

This made the outcome an event-ordering race between `refresh()` reading live items and the model's first-request event:

- If the first request was observed by `refresh()` then the session was added.
- If the request landed after `refresh()` read the items, the only follow-up event (the model change listener) bailed for the not-yet-listed session, so it stayed invisible until a manual refresh.

That timing dependence is why it worked *sometimes*. In the common flow where the chat model is created empty when the view opens and the request is sent later, `refresh()` always loses the race, so it consistently failed.

## Fix

`tryUpdateLiveSessionItem` now builds the item from the current model state using `toChatSessionItem` (the same qualification rules as the full refresh) and adds it when the model becomes listable, regardless of whether an item already existed — while still deduping unchanged items via `isEqual`. The session now appears the moment its first request is sent, independent of refresh timing.

## Tests

- Added a regression test ("should add a new session once it gains its first request (without manual refresh)") and extended the mock model with a `setHasRequests` helper to simulate the no-requests to has-requests transition.
- Updated the pre-existing "model progress changes" event count from 3 to 2: the session is now added via the model-change path, so the later `refresh()` dedupes instead of firing a separate add event.

All 22 tests in the suite pass; type-check and full client compile are clean.

Note: a user reported the same symptom for the agent-host harness, but that path goes through a different provider and couldn't be reproduced — this change specifically addresses the reproducible local-harness case.

(Written by Copilot)
