### PR TITLE
sessions: remove ignoreFocusOut from sessions picker

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
@@ -131,10 +131,6 @@ registerAction2(class ShowSessionsPickerAction extends Action2 {
 		picker.items = items;
 		picker.placeholder = localize('searchSessions', "Search sessions by name or folder");
 		picker.canAcceptInBackground = true;
-		// Keep the picker open when a background accept moves focus to the opened
-		// session, so the user can continue navigating. It is still dismissed
-		// explicitly on a foreground accept (Enter) or Escape.
-		picker.ignoreFocusOut = true;
 		// Match on the detail row too so sessions can be found by their folder.
 		picker.matchOnDetail = true;
 


### PR DESCRIPTION
The sessions picker (Cmd/Ctrl+R) was setting `picker.ignoreFocusOut = true` so it stayed open across background accepts. Drop this so the picker dismisses on focus loss like other quick pickers.

### Change
- `src/vs/sessions/contrib/sessions/browser/sessionsActions.ts`: remove the `picker.ignoreFocusOut = true` line and its now-obsolete comment from `ShowSessionsPickerAction`.

### Notes for reviewers
- Foreground accept (Enter) and Escape behavior is unchanged.
- Background accept (Right Arrow) will now dismiss the picker as a side effect of focus moving to the opened session, which matches default quick picker behavior.