### PR TITLE
sessions: align chat tabs bar with session header

### DIFF
--- a/src/vs/sessions/browser/parts/media/chatCompositeBar.css
+++ b/src/vs/sessions/browser/parts/media/chatCompositeBar.css
@@ -20,9 +20,14 @@
 	box-sizing: border-box;
 }
 
-/* Tabs host: the chat tab strip, shown only when the session has multiple chats */
+/* Tabs host: the chat tab strip, shown only when the session has multiple chats.
+	Mirrors the header's max-width and centering so the tabs line up horizontally
+	with the session header above them. */
 .chat-composite-bar.session-chat-tabs-bar {
 	padding: 0 10px;
+	max-width: 950px;
+	margin: 0 auto;
+	box-sizing: border-box;
 	container-type: inline-size;
 }
 


### PR DESCRIPTION
Fixes #320310

## What changed
Applied the same `max-width: 950px; margin: 0 auto; box-sizing: border-box` to the chat tabs host (`.session-chat-tabs-bar`) that the session header (`.session-header-bar`) already uses.

## Why
The session header was constrained to `max-width: 950px` and horizontally centered, while the chat tab strip below it spanned the full width of the session view. When the view was wider than 950px, the header content was indented but the tabs stayed flush-left, so the two left edges did not line up (see #320310).

## Notes for reviewers
- CSS-only change contained entirely within `src/vs/sessions/browser/parts/media/chatCompositeBar.css`.
- No layout/spec changes required; both rows now share identical horizontal bounds.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
