### PR TITLE
cli: bump ahp and ahp-types to 0.3.0

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -19,9 +19,9 @@ dependencies = [
 
 [[package]]
 name = "ahp"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95f2c1c1d2a8428afa4b009abad4801f3b4d559950fc3041b764dc345ec0a855"
+checksum = "6ff1c5fceb94cf9e8a852eb84dd7f835827a7a2a07b8c23916d192075345e0ea"
 dependencies = [
  "ahp-types",
  "serde",
@@ -33,9 +33,9 @@ dependencies = [
 
 [[package]]
 name = "ahp-types"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f33e8d9b2ed87ce94cb6339928b126f6942ebb168e532d47b81ad04dab8e71f3"
+checksum = "b556a5958c99e73aee87d8e638baf648bc902ff0dabc00393522f8e6e88830b2"
 dependencies = [
  "serde",
  "serde_json",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -56,8 +56,8 @@ console = "0.15.7"
 bytes = "1.11.1"
 tar = "0.4.46"
 local-ip-address = "0.6"
-ahp = "0.2"
-ahp-types = "0.2"
+ahp = "0.3"
+ahp-types = "0.3"
 
 [build-dependencies]
 serde = { version="1.0.163", features = ["derive"] }

--- a/cli/src/commands/agent_logs.rs
+++ b/cli/src/commands/agent_logs.rs
@@ -109,13 +109,13 @@ fn print_initial_state(uri: &str, result: &SubscribeResult) {
 				TurnState::Cancelled => Styles::warning().apply_to("⊘"),
 				TurnState::Error => Styles::error().apply_to("✗"),
 			};
-			let msg = truncate(&turn.user_message.text, 80);
+			let msg = truncate(&turn.message.text, 80);
 			println!("    {} {}", state_str, Styles::muted().apply_to(msg));
 		}
 
 		// Print active turn if any.
 		if let Some(ref active) = session.active_turn {
-			let msg = truncate(&active.user_message.text, 80);
+			let msg = truncate(&active.message.text, 80);
 			println!("    {} {}", Style::new().green().bold().apply_to("►"), msg);
 		}
 	}


### PR DESCRIPTION
Bumps \hp\ and \hp-types\ dependencies from 0.1 to 0.3.