### PR TITLE
sessions: widen session header so chat reads as inset

### DIFF
--- a/src/vs/sessions/browser/parts/media/chatCompositeBar.css
+++ b/src/vs/sessions/browser/parts/media/chatCompositeBar.css
@@ -15,7 +15,7 @@
 /* Header host: title row + meta row, with the top padding for the whole bar area */
 .chat-composite-bar.session-header-bar {
 	padding: 6px 10px 0;
-	max-width: 950px;
+	max-width: 990px;
 	margin: 0 auto;
 	box-sizing: border-box;
 }
@@ -25,7 +25,7 @@
 	with the session header above them. */
 .chat-composite-bar.session-chat-tabs-bar {
 	padding: 0 10px;
-	max-width: 950px;
+	max-width: 990px;
 	margin: 0 auto;
 	box-sizing: border-box;
 	container-type: inline-size;


### PR DESCRIPTION
## What

Widen the Agents window session header (and the chat tabs bar that aligns with it) from `max-width: 950px` to `990px`.

## Why

The session header previously used the **same** `950px` max-width as the chat content (`.interactive-session`). With identical widths, the header spanned edge-to-edge with the chat and visually read like just another chat message rather than a frame for the session.

By making the header slightly wider than the chat, the chat content now sits inset by ~20px on each side, giving it a little breathing room on the left and right while the header frames it.

## Notes for reviewers

- CSS-only change, scoped entirely to `src/vs/sessions/browser/parts/media/chatCompositeBar.css`.
- The chat tabs bar mirrors the header's max-width so the two stay horizontally aligned.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
