### PR TITLE
Exclude box drawing chars from suffix terminal links

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkParsing.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkParsing.ts
@@ -208,7 +208,8 @@ function parseIntOptional(value: string | undefined): number | undefined {
 // This defines valid path characters for a link with a suffix, the first `[]` of the regex includes
 // characters the path is not allowed to _start_ with, the second `[]` includes characters not
 // allowed at all in the path. If the characters show up in both regexes the link will stop at that
-// character, otherwise it will stop at a space character.
+// character, otherwise it will stop at a space character. Box-drawing characters are excluded so
+// terminal UI borders are handled consistently with pipe separators.
 const linkWithSuffixPathCharacters = /(?<path>(?:file:\/\/\/)?[^\s\|\u2500-\u257F<>\[\({][^\s\|\u2500-\u257F<>]*)$/;
 
 export function detectLinks(line: string, os: OperatingSystem) {

--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkParsing.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkParsing.ts
@@ -209,7 +209,7 @@ function parseIntOptional(value: string | undefined): number | undefined {
 // characters the path is not allowed to _start_ with, the second `[]` includes characters not
 // allowed at all in the path. If the characters show up in both regexes the link will stop at that
 // character, otherwise it will stop at a space character.
-const linkWithSuffixPathCharacters = /(?<path>(?:file:\/\/\/)?[^\s\|<>\[\({][^\s\|<>]*)$/;
+const linkWithSuffixPathCharacters = /(?<path>(?:file:\/\/\/)?[^\s\|\u2500-\u257F<>\[\({][^\s\|\u2500-\u257F<>]*)$/;
 
 export function detectLinks(line: string, os: OperatingSystem) {
 	// 1: Detect all links on line via suffixes first

--- a/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkParsing.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkParsing.test.ts
@@ -474,9 +474,10 @@ suite('TerminalLinkParsing', () => {
 				);
 			});
 			test('should exclude pipe characters from link paths with suffixes', () => {
-				deepStrictEqual(
-					detectLinks('|C:\\Github\\microsoft\\vscode:400|', OperatingSystem.Windows),
-					[
+				for (const separator of ['|', '\u2502']) {
+					deepStrictEqual(
+						detectLinks(`${separator}C:\\Github\\microsoft\\vscode:400${separator}`, OperatingSystem.Windows),
+						[
 						{
 							path: {
 								index: 1,
@@ -494,8 +495,9 @@ suite('TerminalLinkParsing', () => {
 								}
 							}
 						}
-					] as IParsedLink[]
-				);
+						] as IParsedLink[]
+					);
+				}
 			});
 		});
 

--- a/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkParsing.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkParsing.test.ts
@@ -473,8 +473,8 @@ suite('TerminalLinkParsing', () => {
 					] as IParsedLink[]
 				);
 			});
-			test('should exclude pipe characters from link paths with suffixes', () => {
-				for (const separator of ['|', '\u2502']) {
+			test('should exclude pipe and box-drawing characters from link paths with suffixes', () => {
+				for (const separator of ['|', '\u2502', '\u2514', '\u251C']) {
 					deepStrictEqual(
 						detectLinks(`${separator}C:\\Github\\microsoft\\vscode:400${separator}`, OperatingSystem.Windows),
 						[


### PR DESCRIPTION
When detecting terminal links with line/column suffixes, ASCII pipe is already treated as a path separator so borders like `|C:\repo\file.ts:10|` link to `C:\repo\file.ts` instead of including the border.

This applies the same behavior to Unicode box-drawing characters. That keeps suffixed path parsing internally consistent for terminal UIs that draw borders with characters like U+2502, avoiding links such as `\u2502C:\repo\file.ts:10` including the border character in the target path.

Changes:
- Exclude the U+2500-U+257F box-drawing range from suffixed terminal link paths.
- Extend the existing pipe suffix-link test to cover U+2502.

Validation:
- `git diff --check`
- Direct Node regex validation of ASCII pipe and U+2502 separator behavior

I could not run the browser unit test locally because dependency installation is blocked in this environment: Playwright Chromium does not support ubuntu26.04-arm64, and `native-keymap` requires the missing system package `xkbfile`. The commit hook was bypassed after human approval; CI should run the full validation.

Disclosure: This PR was generated by GPT-5.5 with human oversight.