### PR TITLE
markdown: don't over-escape dashes in escapeMarkdownSyntaxTokens

### DIFF
--- a/src/vs/base/common/htmlContent.ts
+++ b/src/vs/base/common/htmlContent.ts
@@ -152,7 +152,9 @@ export function markdownStringEqual(a: IMarkdownString, b: IMarkdownString): boo
 
 export function escapeMarkdownSyntaxTokens(text: string): string {
 	// escape markdown syntax tokens: http://daringfireball.net/projects/markdown/syntax#backslash
-	return text.replace(/[\\`*_{}[\]()#+\-!~]/g, '\\$&'); // CodeQL [SM02383] Backslash is escaped in the character class
+	return text
+		.replace(/[\\`*_{}[\]()#+!~]/g, '\\$&') // CodeQL [SM02383] Backslash is escaped in the character class
+		.replace(/^([ \t]*)-/gm, '$1\\-'); // CodeQL [SM02383] Backslash is escaped in the character class
 }
 
 /**

--- a/src/vs/base/test/common/htmlContent.test.ts
+++ b/src/vs/base/test/common/htmlContent.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import assert from 'assert';
-import { appendEscapedMarkdownInlineCode, escapeMarkdownLinkLabel } from '../../common/htmlContent.js';
+import { appendEscapedMarkdownInlineCode, escapeMarkdownLinkLabel, escapeMarkdownSyntaxTokens } from '../../common/htmlContent.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from './utils.js';
 
 suite('htmlContent', () => {
@@ -56,6 +56,24 @@ suite('htmlContent', () => {
 			// these would be escaped by escapeMarkdownSyntaxTokens but must
 			// pass through here since they render literally inside `[...]`.
 			assert.strictEqual(escapeMarkdownLinkLabel('a*b_c#d-e.f!g~h+i(j)k{l}m'), 'a*b_c#d-e.f!g~h+i(j)k{l}m');
+		});
+	});
+
+	suite('escapeMarkdownSyntaxTokens', () => {
+		test('escapes inline syntax tokens anywhere', () => {
+			assert.strictEqual(escapeMarkdownSyntaxTokens('a*b_c`d[e]f(g)h#i+j!k~l{m}'), 'a\\*b\\_c\\`d\\[e\\]f\\(g\\)h\\#i\\+j\\!k\\~l\\{m\\}');
+		});
+
+		test('does not escape mid-line dashes', () => {
+			assert.strictEqual(escapeMarkdownSyntaxTokens('heap-snapshot-analysis'), 'heap-snapshot-analysis');
+			assert.strictEqual(escapeMarkdownSyntaxTokens('npm run foo-bar'), 'npm run foo-bar');
+		});
+
+		test('escapes dashes that start a line', () => {
+			assert.strictEqual(escapeMarkdownSyntaxTokens('- item'), '\\- item');
+			assert.strictEqual(escapeMarkdownSyntaxTokens('  - indented'), '  \\- indented');
+			assert.strictEqual(escapeMarkdownSyntaxTokens('---'), '\\---');
+			assert.strictEqual(escapeMarkdownSyntaxTokens('line one\n- item'), 'line one\n\\- item');
 		});
 	});
 });


### PR DESCRIPTION
Part of #303752

## What

 `\-`). But a dash is only a markdown control character at the **start of a line**, where it can begin a list item, a thematic break, or a setext heading underline. Mid-line, a dash is completely literal.

Escaping every dash added backslashes that leak as **visible characters** whenever the escaped string is shown verbatim instead of being re-parsed as  e.g. inside an inline code span, or when run through `renderAsPlaintext`. This showed up as stray `\` characters in the agent sessions list description (and the terminal "Running ..." invocation message).markdown 

## Change

Only escape dashes that start a line; leave mid-line dashes untouched. Inline tokens (`` ` * _ [ ] ( ) # + ! ~ { } \ ``) are still escaped everywhere, so markdown block rendering is unaffected.

Added focused unit tests in `htmlContent.test.ts`.

(Written by Copilot)
