### PR TITLE
sessions: add previous/next session list navigation

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/sessionsChatAccessibilityHelp.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionsChatAccessibilityHelp.ts
@@ -30,6 +30,8 @@ export class SessionsChatAccessibilityHelp implements IAccessibleViewImplementat
 		content.push(localize('sessionsChat.workspace', "Shift+Tab to navigate to the workspace picker and choose a workspace for your session."));
 		content.push(localize('sessionsChat.mobileConfig', "On mobile, the mode and model pickers appear as tappable chips below the input. Tap a chip to open a bottom sheet where you can change the selection."));
 		content.push(localize('sessionsChat.history', "Use up and down arrows to navigate your request history in the input box."));
+		content.push(localize('sessionsChat.navigatePreviousSession', "Navigate to the previous session in the list{0}.", '<keybinding:sessionsViewPane.navigatePreviousSession>'));
+		content.push(localize('sessionsChat.navigateNextSession', "Navigate to the next session in the list{0}.", '<keybinding:sessionsViewPane.navigateNextSession>'));
 		content.push(localize('sessionsChat.changes', "Focus the Changes view{0}.", '<keybinding:workbench.action.agentSessions.focusChangesView>'));
 		content.push(localize('sessionsChat.filesView', "Focus the Files Explorer view{0}.", '<keybinding:workbench.action.agentSessions.focusChangesFileView>'));
 		content.push(localize('sessionsChat.sessionsView', "Focus the Chat Sessions view{0}.", '<keybinding:workbench.action.chat.focusAgentSessionsViewer>'));

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
@@ -132,6 +132,91 @@ for (let visibleIndex = 1; visibleIndex <= 9; visibleIndex++) {
 	});
 }
 
+//  Navigate Previous / Next Session (list order)
+
+const navigateSessionInList = (accessor: ServicesAccessor, direction: 'previous' | 'next'): void => {
+	const viewsService = accessor.get(IViewsService);
+	const sessionsViewService = accessor.get(ISessionsViewService);
+	const sessionsManagementService = accessor.get(ISessionsManagementService);
+	const view = viewsService.getViewWithId<SessionsView>(SessionsViewId);
+	const visible = view?.sessionsControl?.getVisibleSessions() ?? [];
+	if (visible.length === 0) {
+		return;
+	}
+
+	// Locate the active session within the visible list so navigation follows
+	// what the user sees (respecting grouping, filtering, and collapsed sections).
+	const activeResource = sessionsManagementService.activeSession.get()?.resource.toString();
+	const currentIndex = activeResource === undefined
+		? -1
+		: visible.findIndex(session => session.resource.toString() === activeResource);
+
+	let targetIndex: number;
+	if (currentIndex === -1) {
+		// No active session in the visible list: start from the nearest edge.
+		targetIndex = direction === 'next' ? 0 : visible.length - 1;
+	} else {
+		targetIndex = direction === 'next'
+			? Math.min(currentIndex + 1, visible.length - 1)
+			: Math.max(currentIndex - 1, 0);
+	}
+
+	const target = visible[targetIndex];
+	if (target) {
+		sessionsViewService.openSession(target.resource);
+	}
+};
+
+registerAction2(class NavigatePreviousSessionAction extends Action2 {
+	constructor() {
+		super({
+			id: 'sessionsViewPane.navigatePreviousSession',
+			title: localize2('navigatePreviousSession', "Navigate to Previous Session"),
+			f1: true,
+			category: SessionsCategories.Sessions,
+			keybinding: {
+				// Mirror core "Previous Editor" and browser "Previous Tab". On macOS use
+				// Cmd+Alt+Left (Mac keyboards lack Page keys), matching core editor nav.
+				// Alt+Up is a secondary chord; the `!editorAreaFocus` gate keeps the
+				// editor's "Move Line Up" intact while still navigating from the chat input.
+				weight: KeybindingWeight.WorkbenchContrib + 1,
+				when: ContextKeyExpr.and(IsSessionsWindowContext, EditorAreaFocusContext.toNegated()),
+				primary: KeyMod.CtrlCmd | KeyCode.PageUp,
+				secondary: [KeyMod.Alt | KeyCode.UpArrow],
+				mac: { primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.LeftArrow, secondary: [KeyMod.Alt | KeyCode.UpArrow] },
+			}
+		});
+	}
+	override run(accessor: ServicesAccessor): void {
+		navigateSessionInList(accessor, 'previous');
+	}
+});
+
+registerAction2(class NavigateNextSessionAction extends Action2 {
+	constructor() {
+		super({
+			id: 'sessionsViewPane.navigateNextSession',
+			title: localize2('navigateNextSession', "Navigate to Next Session"),
+			f1: true,
+			category: SessionsCategories.Sessions,
+			keybinding: {
+				// Mirror core "Next Editor" and browser "Next Tab". On macOS use
+				// Cmd+Alt+Right (Mac keyboards lack Page keys), matching core editor nav.
+				// Alt+Down is a secondary chord; the `!editorAreaFocus` gate keeps the
+				// editor's "Move Line Down" intact while still navigating from the chat input.
+				weight: KeybindingWeight.WorkbenchContrib + 1,
+				when: ContextKeyExpr.and(IsSessionsWindowContext, EditorAreaFocusContext.toNegated()),
+				primary: KeyMod.CtrlCmd | KeyCode.PageDown,
+				secondary: [KeyMod.Alt | KeyCode.DownArrow],
+				mac: { primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.RightArrow, secondary: [KeyMod.Alt | KeyCode.DownArrow] },
+			}
+		});
+	}
+	override run(accessor: ServicesAccessor): void {
+		navigateSessionInList(accessor, 'next');
+	}
+});
+
 //  View Title Menu
 
 MenuRegistry.appendMenuItem(Menus.SidebarSessionsHeader, {

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
@@ -134,7 +134,7 @@ for (let visibleIndex = 1; visibleIndex <= 9; visibleIndex++) {
 
 //  Navigate Previous / Next Session (list order)
 
-const navigateSessionInList = (accessor: ServicesAccessor, direction: 'previous' | 'next'): void => {
+const navigateSessionInList = async (accessor: ServicesAccessor, direction: 'previous' | 'next'): Promise<void> => {
 	const viewsService = accessor.get(IViewsService);
 	const sessionsViewService = accessor.get(ISessionsViewService);
 	const sessionsManagementService = accessor.get(ISessionsManagementService);
@@ -161,9 +161,14 @@ const navigateSessionInList = (accessor: ServicesAccessor, direction: 'previous'
 			: Math.max(currentIndex - 1, 0);
 	}
 
+	// At the list edges the target clamps to the active session; don't re-open it.
+	if (targetIndex === currentIndex) {
+		return;
+	}
+
 	const target = visible[targetIndex];
 	if (target) {
-		sessionsViewService.openSession(target.resource);
+		await sessionsViewService.openSession(target.resource);
 	}
 };
 
@@ -177,8 +182,9 @@ registerAction2(class NavigatePreviousSessionAction extends Action2 {
 			keybinding: {
 				// Mirror core "Previous Editor" and browser "Previous Tab". On macOS use
 				// Cmd+Alt+Left (Mac keyboards lack Page keys), matching core editor nav.
-				// Alt+Up is a secondary chord; the `!editorAreaFocus` gate keeps the
-				// editor's "Move Line Up" intact while still navigating from the chat input.
+				// Alt+Up is a secondary (alternate) binding; the `!editorAreaFocus` gate
+				// keeps the editor's "Move Line Up" intact while still navigating from
+				// the chat input.
 				weight: KeybindingWeight.WorkbenchContrib + 1,
 				when: ContextKeyExpr.and(IsSessionsWindowContext, EditorAreaFocusContext.toNegated()),
 				primary: KeyMod.CtrlCmd | KeyCode.PageUp,
@@ -187,8 +193,8 @@ registerAction2(class NavigatePreviousSessionAction extends Action2 {
 			}
 		});
 	}
-	override run(accessor: ServicesAccessor): void {
-		navigateSessionInList(accessor, 'previous');
+	override run(accessor: ServicesAccessor): Promise<void> {
+		return navigateSessionInList(accessor, 'previous');
 	}
 });
 
@@ -202,8 +208,9 @@ registerAction2(class NavigateNextSessionAction extends Action2 {
 			keybinding: {
 				// Mirror core "Next Editor" and browser "Next Tab". On macOS use
 				// Cmd+Alt+Right (Mac keyboards lack Page keys), matching core editor nav.
-				// Alt+Down is a secondary chord; the `!editorAreaFocus` gate keeps the
-				// editor's "Move Line Down" intact while still navigating from the chat input.
+				// Alt+Down is a secondary (alternate) binding; the `!editorAreaFocus` gate
+				// keeps the editor's "Move Line Down" intact while still navigating from
+				// the chat input.
 				weight: KeybindingWeight.WorkbenchContrib + 1,
 				when: ContextKeyExpr.and(IsSessionsWindowContext, EditorAreaFocusContext.toNegated()),
 				primary: KeyMod.CtrlCmd | KeyCode.PageDown,
@@ -212,8 +219,8 @@ registerAction2(class NavigateNextSessionAction extends Action2 {
 			}
 		});
 	}
-	override run(accessor: ServicesAccessor): void {
-		navigateSessionInList(accessor, 'next');
+	override run(accessor: ServicesAccessor): Promise<void> {
+		return navigateSessionInList(accessor, 'next');
 	}
 });
 


### PR DESCRIPTION
Add "Navigate to Previous/Next Session" actions that move through the visible sessions list in display order (respecting grouping, filtering, and collapsed sections), opening the session adjacent to the active one and clamping at the list edges.

Keybindings mirror core "Previous/Next Editor" and browser tab switching: Ctrl+PageUp/PageDown (Cmd+Alt+Left/Right on macOS), with Alt+Up/Down as a secondary chord. All are gated on the sessions window and outside the editor area, so the editor's "Move Line Up/Down" stays intact while navigation still works from the chat input.