### PR TITLE
terminal-suggest: add 'agent' subcommand completions for code CLI

### DIFF
--- a/extensions/terminal-suggest/src/completions/code.ts
+++ b/extensions/terminal-suggest/src/completions/code.ts
@@ -460,26 +460,22 @@ const agentHostOptions: Fig.Option[] = [
 	{
 		name: '--host',
 		description: 'Host the agent host should bind on. Defaults to \'localhost\'',
-		isRepeatable: true,
-		args: { name: 'host', isOptional: true },
+		args: { name: 'host' },
 	},
 	{
 		name: '--port',
 		description: 'Port the agent host should bind on. If 0 the OS picks a free ephemeral port',
-		isRepeatable: true,
-		args: { name: 'port', isOptional: true },
+		args: { name: 'port' },
 	},
 	{
 		name: '--connection-token',
 		description: 'A secret that must be included with all requests',
-		isRepeatable: true,
-		args: { name: 'connection_token', isOptional: true },
+		args: { name: 'connection_token' },
 	},
 	{
 		name: '--connection-token-file',
 		description: 'A file containing a secret that must be included with all requests',
-		isRepeatable: true,
-		args: { name: 'connection_token_file', isOptional: true },
+		args: { name: 'connection_token_file' },
 	},
 	{
 		name: '--without-connection-token',
@@ -488,8 +484,7 @@ const agentHostOptions: Fig.Option[] = [
 	{
 		name: '--server-data-dir',
 		description: 'Specifies the directory that server data is kept in',
-		isRepeatable: true,
-		args: { name: 'server_data_dir', isOptional: true },
+		args: { name: 'server_data_dir' },
 	},
 	{
 		name: '--replace',
@@ -502,8 +497,7 @@ const agentHostOptions: Fig.Option[] = [
 	{
 		name: '--name',
 		description: 'Sets the machine name for the tunnel',
-		isRepeatable: true,
-		args: { name: 'name', isOptional: true },
+		args: { name: 'name' },
 	},
 	{
 		name: '--random-name',
@@ -515,14 +509,12 @@ const agentConnectionOptions: Fig.Option[] = [
 	{
 		name: '--address',
 		description: 'WebSocket address of a running agent host (e.g. ws://127.0.0.1:1234?tkn=secret). If omitted, the CLI discovers a locally running agent host automatically',
-		isRepeatable: true,
-		args: { name: 'address', isOptional: true },
+		args: { name: 'address' },
 	},
 	{
 		name: '--tunnel',
 		description: 'Connect via a named dev tunnel instead of the local address',
-		isRepeatable: true,
-		args: { name: 'tunnel', isOptional: true },
+		args: { name: 'tunnel' },
 	},
 ];
 

--- a/extensions/terminal-suggest/src/completions/code.ts
+++ b/extensions/terminal-suggest/src/completions/code.ts
@@ -456,6 +456,76 @@ export const globalTunnelOptions: Fig.Option[] = [
 ];
 
 
+const agentHostOptions: Fig.Option[] = [
+	{
+		name: '--host',
+		description: 'Host the agent host should bind on. Defaults to \'localhost\'',
+		isRepeatable: true,
+		args: { name: 'host', isOptional: true },
+	},
+	{
+		name: '--port',
+		description: 'Port the agent host should bind on. If 0 the OS picks a free ephemeral port',
+		isRepeatable: true,
+		args: { name: 'port', isOptional: true },
+	},
+	{
+		name: '--connection-token',
+		description: 'A secret that must be included with all requests',
+		isRepeatable: true,
+		args: { name: 'connection_token', isOptional: true },
+	},
+	{
+		name: '--connection-token-file',
+		description: 'A file containing a secret that must be included with all requests',
+		isRepeatable: true,
+		args: { name: 'connection_token_file', isOptional: true },
+	},
+	{
+		name: '--without-connection-token',
+		description: 'Run without a connection token. Only use this if the connection is secured by other means',
+	},
+	{
+		name: '--server-data-dir',
+		description: 'Specifies the directory that server data is kept in',
+		isRepeatable: true,
+		args: { name: 'server_data_dir', isOptional: true },
+	},
+	{
+		name: '--replace',
+		description: 'Stop any agent host already running on this machine and start a fresh one',
+	},
+	{
+		name: '--tunnel',
+		description: 'Expose the agent host over a dev tunnel',
+	},
+	{
+		name: '--name',
+		description: 'Sets the machine name for the tunnel',
+		isRepeatable: true,
+		args: { name: 'name', isOptional: true },
+	},
+	{
+		name: '--random-name',
+		description: 'Randomly name the machine for the tunnel',
+	},
+];
+
+const agentConnectionOptions: Fig.Option[] = [
+	{
+		name: '--address',
+		description: 'WebSocket address of a running agent host (e.g. ws://127.0.0.1:1234?tkn=secret). If omitted, the CLI discovers a locally running agent host automatically',
+		isRepeatable: true,
+		args: { name: 'address', isOptional: true },
+	},
+	{
+		name: '--tunnel',
+		description: 'Connect via a named dev tunnel instead of the local address',
+		isRepeatable: true,
+		args: { name: 'tunnel', isOptional: true },
+	},
+];
+
 export const codeTunnelOptions = [
 	{
 		name: '--extensions-dir',
@@ -852,6 +922,69 @@ export const codeTunnelSubcommands: Fig.Subcommand[] = [
 		options: [...globalTunnelOptions, ...tunnelHelpOptions],
 	},
 	{
+		name: 'agent',
+		description: 'Manage agent host sessions',
+		subcommands: [
+			{
+				name: 'host',
+				description: 'Start a local agent host server',
+				options: [...agentHostOptions, ...globalTunnelOptions, ...tunnelHelpOptions],
+			},
+			{
+				name: 'ps',
+				description: 'List active sessions on a running agent host',
+				options: [
+					...agentConnectionOptions,
+					{
+						name: '--json',
+						description: 'Output results as JSON instead of a human-readable table',
+					},
+					{
+						name: ['-a', '--all'],
+						description: 'Show all sessions, including idle and archived ones',
+					},
+					...globalTunnelOptions, ...tunnelHelpOptions,
+				],
+			},
+			{
+				name: 'stop',
+				description: 'Cancel the active turn of a session',
+				args: {
+					name: 'session',
+					description: 'Session URI to cancel the active turn of (e.g. copilot:/<uuid>)',
+				},
+				options: [...agentConnectionOptions, ...globalTunnelOptions, ...tunnelHelpOptions],
+			},
+			{
+				name: 'kill',
+				description: 'Forcefully kill the running agent host process tree',
+				options: [...globalTunnelOptions, ...tunnelHelpOptions],
+			},
+			{
+				name: 'logs',
+				description: 'Stream live session events',
+				args: {
+					name: 'session',
+					description: 'Session URI to stream events for (e.g. copilot:/<uuid>)',
+				},
+				options: [...agentConnectionOptions, ...globalTunnelOptions, ...tunnelHelpOptions],
+			},
+			{
+				name: 'help',
+				description: 'Print this message or the help of the given subcommand(s)',
+				subcommands: [
+					{ name: 'host', description: 'Start a local agent host server' },
+					{ name: 'ps', description: 'List active sessions on a running agent host' },
+					{ name: 'stop', description: 'Cancel the active turn of a session' },
+					{ name: 'kill', description: 'Forcefully kill the running agent host process tree' },
+					{ name: 'logs', description: 'Stream live session events' },
+					{ name: 'help', description: 'Print this message or the help of the given subcommand(s)' },
+				],
+			},
+		],
+		options: [...agentHostOptions, ...globalTunnelOptions, ...tunnelHelpOptions],
+	},
+	{
 		name: 'version',
 		description: `Changes the version of the editor you're using`,
 		options: [...globalTunnelOptions, ...tunnelHelpOptions],
@@ -1028,6 +1161,17 @@ export const codeTunnelSubcommands: Fig.Subcommand[] = [
 			{
 				name: 'serve-web',
 				description: 'Runs a local web version of Code - OSS',
+			},
+			{
+				name: 'agent',
+				description: 'Manage agent host sessions',
+				subcommands: [
+					{ name: 'host', description: 'Start a local agent host server' },
+					{ name: 'ps', description: 'List active sessions on a running agent host' },
+					{ name: 'stop', description: 'Cancel the active turn of a session' },
+					{ name: 'kill', description: 'Forcefully kill the running agent host process tree' },
+					{ name: 'logs', description: 'Stream live session events' },
+				],
 			},
 			{
 				name: 'command-shell',

--- a/extensions/terminal-suggest/src/test/completions/code.test.ts
+++ b/extensions/terminal-suggest/src/test/completions/code.test.ts
@@ -78,7 +78,8 @@ export function createCodeTestSpecs(executable: string): ITestSpec[] {
 	const agentCommonFlags = ['--cli-data-dir <cli_data_dir>', '--log [<log>]', '--verbose', '--help', '-h'];
 	const agentHostFlags = ['--host <host>', '--port <port>', '--connection-token <connection_token>', '--connection-token-file <connection_token_file>', '--without-connection-token', '--server-data-dir <server_data_dir>', '--replace', '--tunnel', '--name <name>', '--random-name'];
 	const agentConnectionFlags = ['--address <address>', '--tunnel <tunnel>'];
-	const agentSubcommands = ['host', 'ps', 'stop', 'kill', 'logs', 'help'];
+	const agentSubcommands = ['host', 'ps', 'stop <session>', 'kill', 'logs <session>', 'help'];
+	const agentHelpSubcommands = ['host', 'ps', 'stop', 'kill', 'logs', 'help'];
 
 	const typingTests: ITestSpec[] = [];
 	for (let i = 1; i < executable.length; i++) {
@@ -139,7 +140,7 @@ export function createCodeTestSpecs(executable: string): ITestSpec[] {
 		{ input: `${executable} agent stop |`, expectedCompletions: [...agentConnectionFlags, ...agentCommonFlags] },
 		{ input: `${executable} agent logs |`, expectedCompletions: [...agentConnectionFlags, ...agentCommonFlags] },
 		{ input: `${executable} agent kill |`, expectedCompletions: [...agentCommonFlags] },
-		{ input: `${executable} agent help |`, expectedCompletions: agentSubcommands },
+		{ input: `${executable} agent help |`, expectedCompletions: agentHelpSubcommands },
 
 		// Middle of command
 		{ input: `${executable} | --locale`, expectedCompletions: codeSpecOptionsAndSubcommands, expectedResourceRequests: { type: 'both', cwd: testPaths.cwd } },
@@ -280,7 +281,8 @@ export function createCodeTunnelTestSpecs(executable: string): ITestSpec[] {
 
 	const agentHostFlags: string[] = ['--host <host>', '--port <port>', '--connection-token <connection_token>', '--connection-token-file <connection_token_file>', '--without-connection-token', '--server-data-dir <server_data_dir>', '--replace', '--tunnel', '--name <name>', '--random-name'];
 	const agentConnectionFlags: string[] = ['--address <address>', '--tunnel <tunnel>'];
-	const agentSubcommands: string[] = ['host', 'ps', 'stop', 'kill', 'logs', 'help'];
+	const agentSubcommands: string[] = ['host', 'ps', 'stop <session>', 'kill', 'logs <session>', 'help'];
+	const agentHelpSubcommands: string[] = ['host', 'ps', 'stop', 'kill', 'logs', 'help'];
 
 	const typingTests: ITestSpec[] = [];
 	for (let i = 1; i < executable.length; i++) {
@@ -318,7 +320,7 @@ export function createCodeTunnelTestSpecs(executable: string): ITestSpec[] {
 		{ input: `${executable} agent stop |`, expectedCompletions: [...agentConnectionFlags, ...commonFlags] },
 		{ input: `${executable} agent logs |`, expectedCompletions: [...agentConnectionFlags, ...commonFlags] },
 		{ input: `${executable} agent kill |`, expectedCompletions: [...commonFlags] },
-		{ input: `${executable} agent help |`, expectedCompletions: agentSubcommands },
+		{ input: `${executable} agent help |`, expectedCompletions: agentHelpSubcommands },
 
 	];
 }

--- a/extensions/terminal-suggest/src/test/completions/code.test.ts
+++ b/extensions/terminal-suggest/src/test/completions/code.test.ts
@@ -63,6 +63,7 @@ export const codeSpecOptionsAndSubcommands = [
 	'tunnel',
 	'chat [<prompt>]',
 	'serve-web',
+	'agent',
 	'help',
 	'status',
 	'version'
@@ -74,6 +75,10 @@ export function createCodeTestSpecs(executable: string): ITestSpec[] {
 	const logOptions = ['critical', 'error', 'warn', 'info', 'debug', 'trace', 'off'];
 	const syncOptions = ['on', 'off'];
 	const chatOptions = ['--add-file <file>', '--help', '--maximize', '--mode <mode>', '--new-window', '--reuse-window', '-a <file>', '-h', '-m <mode>', '-n', '-r'];
+	const agentCommonFlags = ['--cli-data-dir <cli_data_dir>', '--log [<log>]', '--verbose', '--help', '-h'];
+	const agentHostFlags = ['--host <host>', '--port <port>', '--connection-token <connection_token>', '--connection-token-file <connection_token_file>', '--without-connection-token', '--server-data-dir <server_data_dir>', '--replace', '--tunnel', '--name <name>', '--random-name'];
+	const agentConnectionFlags = ['--address <address>', '--tunnel <tunnel>'];
+	const agentSubcommands = ['host', 'ps', 'stop', 'kill', 'logs', 'help'];
 
 	const typingTests: ITestSpec[] = [];
 	for (let i = 1; i < executable.length; i++) {
@@ -126,6 +131,15 @@ export function createCodeTestSpecs(executable: string): ITestSpec[] {
 		{ input: `${executable} chat |`, expectedCompletions: chatOptions },
 		{ input: `${executable} chat --mode |`, expectedCompletions: ['agent', 'ask', 'edit'] },
 		{ input: `${executable} chat --add-file |`, expectedResourceRequests: { type: 'files', cwd: testPaths.cwd } },
+
+		// Agent subcommand tests
+		{ input: `${executable} agent |`, expectedCompletions: [...agentSubcommands, ...agentHostFlags, ...agentCommonFlags] },
+		{ input: `${executable} agent host |`, expectedCompletions: [...agentHostFlags, ...agentCommonFlags] },
+		{ input: `${executable} agent ps |`, expectedCompletions: [...agentConnectionFlags, '--json', '--all', '-a', ...agentCommonFlags] },
+		{ input: `${executable} agent stop |`, expectedCompletions: [...agentConnectionFlags, ...agentCommonFlags] },
+		{ input: `${executable} agent logs |`, expectedCompletions: [...agentConnectionFlags, ...agentCommonFlags] },
+		{ input: `${executable} agent kill |`, expectedCompletions: [...agentCommonFlags] },
+		{ input: `${executable} agent help |`, expectedCompletions: agentSubcommands },
 
 		// Middle of command
 		{ input: `${executable} | --locale`, expectedCompletions: codeSpecOptionsAndSubcommands, expectedResourceRequests: { type: 'both', cwd: testPaths.cwd } },
@@ -186,6 +200,7 @@ export function createCodeTunnelTestSpecs(executable: string): ITestSpec[] {
 		'-s',
 		'-v',
 		'-w',
+		'agent',
 		'chat [<prompt>]',
 		'ext',
 		'help',
@@ -263,6 +278,10 @@ export function createCodeTunnelTestSpecs(executable: string): ITestSpec[] {
 		'-h'
 	];
 
+	const agentHostFlags: string[] = ['--host <host>', '--port <port>', '--connection-token <connection_token>', '--connection-token-file <connection_token_file>', '--without-connection-token', '--server-data-dir <server_data_dir>', '--replace', '--tunnel', '--name <name>', '--random-name'];
+	const agentConnectionFlags: string[] = ['--address <address>', '--tunnel <tunnel>'];
+	const agentSubcommands: string[] = ['host', 'ps', 'stop', 'kill', 'logs', 'help'];
+
 	const typingTests: ITestSpec[] = [];
 	for (let i = 1; i < executable.length; i++) {
 		const expectedCompletions = [{ label: executable, description: executable === codeCompletionSpec.name || executable === codeTunnelCompletionSpec.name ? (codeCompletionSpec as Fig.Subcommand).description : (codeInsidersCompletionSpec as Fig.Subcommand).description }];
@@ -293,6 +312,13 @@ export function createCodeTunnelTestSpecs(executable: string): ITestSpec[] {
 		{ input: `${executable} ext update |`, expectedCompletions: [...commonFlags] },
 		{ input: `${executable} status |`, expectedCompletions: commonFlags },
 		{ input: `${executable} version |`, expectedCompletions: commonFlags },
+		{ input: `${executable} agent |`, expectedCompletions: [...agentSubcommands, ...agentHostFlags, ...commonFlags] },
+		{ input: `${executable} agent host |`, expectedCompletions: [...agentHostFlags, ...commonFlags] },
+		{ input: `${executable} agent ps |`, expectedCompletions: [...agentConnectionFlags, '--json', '--all', '-a', ...commonFlags] },
+		{ input: `${executable} agent stop |`, expectedCompletions: [...agentConnectionFlags, ...commonFlags] },
+		{ input: `${executable} agent logs |`, expectedCompletions: [...agentConnectionFlags, ...commonFlags] },
+		{ input: `${executable} agent kill |`, expectedCompletions: [...commonFlags] },
+		{ input: `${executable} agent help |`, expectedCompletions: agentSubcommands },
 
 	];
 }


### PR DESCRIPTION
Adds completions for the \code agent\ subcommand and its sub-subcommands (\host\, \ps\, \stop\, \kill\, \logs\) based on the definitions in \cli/src/commands/args.rs\.