### PR TITLE
Fix double-escaped entities in renderAsPlaintext code spans

### DIFF
--- a/src/vs/base/browser/markdownRenderer.ts
+++ b/src/vs/base/browser/markdownRenderer.ts
@@ -756,7 +756,7 @@ function createPlainTextRenderer(): marked.Renderer {
 		return text;
 	};
 	renderer.codespan = ({ text }: marked.Tokens.Codespan): string => {
-		return escape(text);
+		return text;
 	};
 	renderer.br = (_: marked.Tokens.Br): string => {
 		return '\n';

--- a/src/vs/base/test/browser/markdownRenderer.test.ts
+++ b/src/vs/base/test/browser/markdownRenderer.test.ts
@@ -388,6 +388,11 @@ suite('MarkdownRenderer', () => {
 			const result: string = renderAsPlaintext(markdown, { includeCodeBlocksFences: true });
 			assert.strictEqual(result, expected);
 		});
+
+		test('does not double-escape entities inside code spans', () => {
+			assert.strictEqual(renderAsPlaintext({ value: 'Run `tests & build`' }), 'Run tests & build');
+			assert.strictEqual(renderAsPlaintext({ value: 'Use `<form>` tag' }), 'Use <form> tag');
+		});
 	});
 
 	suite('supportHtml', () => {


### PR DESCRIPTION
For #303752

I think this is ok but please take a quick look @mjbvz 

## Problem

Text inside markdown code spans (e.g. ````foo & bar````) rendered through `renderAsPlaintext` came out **double-escaped** — `&` appeared as `&amp;`, `<`/`>` as `&lt;`/`&gt;`. This surfaced in the agent sessions list, where a local (VS Code harness) session's in-progress description is derived from a tool invocation message via `getInProgressSessionDescription` → `renderAsPlaintext`.

## Root cause

In `createPlainTextRenderer`, the `codespan` handler called `escape(text)`. But marked already HTML-escapes code span text during tokenization. The trailing unescape pass in `renderAsPlaintext` only reverses a single level, so the extra `escape()` left entities double-escaped. Code blocks were unaffected because marked passes their text raw (escaped exactly once).

| Input | Before | After |
|---|---|---|
| `Run \`tests & build\`` | `Run tests &amp; build` | `Run tests & build` |
| `Use \`<form>\`` | `Use &lt;form&gt;` | `Use <form>` |

## Fix

Remove the redundant `escape()` from the `codespan` plaintext renderer so it matches code-block behavior. Added a regression test.

This is a shared low-level helper, so the fix corrects the same double-escaping for all `renderAsPlaintext` callers (hovers, pickers, etc.), not just the agent sessions list.

(Written by Copilot)