### PR TITLE
Agent host: suppress Copilot-Integration-Id on Claude/Codex proxy requests

### DIFF
--- a/src/vs/platform/agentHost/node/claude/claudeAgent.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgent.ts
@@ -17,6 +17,7 @@ import { generateUuid } from '../../../../base/common/uuid.js';
 import { localize } from '../../../../nls.js';
 import { IInstantiationService } from '../../../instantiation/common/instantiation.js';
 import { ILogService } from '../../../log/common/log.js';
+import { IProductService } from '../../../product/common/productService.js';
 import { IAgentPluginManager, ISyncedCustomization } from '../../common/agentPluginManager.js';
 import { createSchema, platformSessionSchema, schemaProperty } from '../../common/agentHostSchema.js';
 import { ClaudePermissionMode, ClaudeSessionConfigKey, narrowClaudePermissionMode } from '../../common/claudeSessionConfigKeys.js';
@@ -43,6 +44,8 @@ import { resolvePromptToContentBlocks } from './claudePromptResolver.js';
 import { IClaudeProxyHandle, IClaudeProxyService } from './claudeProxyService.js';
 import { readClaudePermissionMode } from './claudeSessionPermissionMode.js';
 import { ClaudeSessionMetadataStore, IClaudeSessionOverlay } from './claudeSessionMetadataStore.js';
+
+const USER_AGENT_PREFIX = 'vscode_claude_code';
 
 /**
  * Returns true if `m` is a Claude-family model that should be advertised
@@ -229,6 +232,7 @@ export class ClaudeAgent extends Disposable implements IAgent {
 		@IAgentConfigurationService private readonly _configurationService: IAgentConfigurationService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@IAgentPluginManager private readonly _pluginManager: IAgentPluginManager,
+		@IProductService private readonly _productService: IProductService,
 	) {
 		super();
 		this._metadataStore = _instantiationService.createInstance(ClaudeSessionMetadataStore, this.id);
@@ -298,7 +302,8 @@ export class ClaudeAgent extends Disposable implements IAgent {
 			return;
 		}
 		try {
-			const all = await this._copilotApiService.models(tokenAtStart);
+			const userAgent = `${USER_AGENT_PREFIX}/${this._productService.version}`;
+			const all = await this._copilotApiService.models(tokenAtStart, { headers: { 'User-Agent': userAgent } });
 			// Stale-write guard: if `authenticate()` rotated the token
 			// while we were awaiting the model list, a newer refresh has
 			// already published the right value — don't overwrite it.
@@ -315,6 +320,8 @@ export class ClaudeAgent extends Disposable implements IAgent {
 				.filter(isClaudeModel)
 				.sort((a, b) => Number(b.is_chat_default) - Number(a.is_chat_default))
 				.map(m => toAgentModelInfo(m, this.id));
+
+			this._logService.info(`[Claude] Models refreshed. Count: ${filtered.length}`);
 			this._models.set(filtered, undefined);
 		} catch (err) {
 			this._logService.error(err, '[Claude] Failed to refresh models');

--- a/src/vs/platform/agentHost/node/claude/claudeProxyService.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeProxyService.ts
@@ -105,6 +105,7 @@ interface IProxyRuntime {
 const KNOWN_CLAUDE_VENDORS = new Set(['anthropic']);
 const ANTHROPIC_MESSAGES_ENDPOINT = '/v1/messages';
 const PROXY_USER_FACING_NAME = 'ClaudeProxyService';
+const USER_AGENT_PREFIX = 'vscode_claude_code';
 
 /**
  * Build the 256-bit hex nonce embedded in the `Bearer <nonce>.<sessionId>`
@@ -340,7 +341,7 @@ export class ClaudeProxyService implements IClaudeProxyService {
 		}
 
 		if (method === 'GET' && pathname === '/v1/models') {
-			await this._handleModels(res, runtime);
+			await this._handleModels(req, res, runtime);
 			return;
 		}
 
@@ -361,10 +362,11 @@ export class ClaudeProxyService implements IClaudeProxyService {
 
 	// #region GET /v1/models
 
-	private async _handleModels(res: http.ServerResponse, runtime: IProxyRuntime): Promise<void> {
+	private async _handleModels(req: http.IncomingMessage, res: http.ServerResponse, runtime: IProxyRuntime): Promise<void> {
+		const headers = buildOutboundHeaders(req.headers);
 		let models: CCAModel[];
 		try {
-			models = await this._copilotApiService.models(runtime.githubToken);
+			models = await this._copilotApiService.models(runtime.githubToken, { headers });
 		} catch (err) {
 			this._writeUpstreamErrorResponse(res, err);
 			return;
@@ -495,7 +497,7 @@ export class ClaudeProxyService implements IClaudeProxyService {
 		runtime: IProxyRuntime,
 		originalSdkModelId: string,
 	): Promise<void> {
-		const options: ICopilotApiServiceRequestOptions = { headers, signal: entry.ac.signal };
+		const options: ICopilotApiServiceRequestOptions = { headers, signal: entry.ac.signal, suppressIntegrationId: true };
 		let message: Anthropic.Message;
 		try {
 			message = await this._copilotApiService.messages(runtime.githubToken, body, options);
@@ -528,7 +530,7 @@ export class ClaudeProxyService implements IClaudeProxyService {
 		runtime: IProxyRuntime,
 		_originalSdkModelId: string,
 	): Promise<void> {
-		const options: ICopilotApiServiceRequestOptions = { headers, signal: entry.ac.signal };
+		const options: ICopilotApiServiceRequestOptions = { headers, signal: entry.ac.signal, suppressIntegrationId: true };
 		let stream: AsyncGenerator<Anthropic.MessageStreamEvent>;
 		try {
 			stream = this._copilotApiService.messages(runtime.githubToken, body, options);
@@ -711,9 +713,9 @@ function rewriteEventModel(
 
 /**
  * Build the headers we forward to {@link ICopilotApiService.messages}
- * from the inbound request. Drops everything except `anthropic-version`
- * (verbatim) and `anthropic-beta` (filtered through
- * {@link filterSupportedBetas}).
+ * from the inbound request. Forwards `anthropic-version` (verbatim),
+ * `anthropic-beta` (filtered through {@link filterSupportedBetas}), and
+ * `user-agent` (transformed via {@link transformUserAgent}).
  */
 function buildOutboundHeaders(inbound: http.IncomingHttpHeaders): Record<string, string> {
 	const out: Record<string, string> = {};
@@ -728,7 +730,31 @@ function buildOutboundHeaders(inbound: http.IncomingHttpHeaders): Record<string,
 			out['anthropic-beta'] = filtered;
 		}
 	}
+	const userAgent = inbound['user-agent'];
+	if (typeof userAgent === 'string' && userAgent.length > 0) {
+		out['User-Agent'] = transformUserAgent(userAgent);
+	}
 	return out;
+}
+
+/**
+ * Transform an incoming user-agent string by replacing the client name
+ * portion (before the first `/`) with {@link USER_AGENT_PREFIX}. This
+ * mirrors the pattern used by `claudeLanguageModelServer.ts` in the
+ * extension, ensuring all Claude requests are tagged with a consistent
+ * prefix for server-side identification.
+ *
+ * Examples:
+ * - `claude-code/1.2.3` → `vscode_claude_code/1.2.3`
+ * - `Anthropic/Python/1.0` → `vscode_claude_code/Python/1.0`
+ * - `unknown` → `vscode_claude_code/unknown`
+ */
+function transformUserAgent(userAgent: string): string {
+	const slashIndex = userAgent.indexOf('/');
+	if (slashIndex === -1) {
+		return `${USER_AGENT_PREFIX}/${userAgent}`;
+	}
+	return `${USER_AGENT_PREFIX}${userAgent.substring(slashIndex)}`;
 }
 
 function readRequestBody(req: http.IncomingMessage): Promise<string> {

--- a/src/vs/platform/agentHost/node/codex/codexProxyService.ts
+++ b/src/vs/platform/agentHost/node/codex/codexProxyService.ts
@@ -407,7 +407,7 @@ export class CodexProxyService implements ICodexProxyService {
 
 		try {
 			this._logService.info(`[${PROXY_USER_FACING_NAME}] forwarding to CAPI responses...`);
-			const upstream = await this._copilotApiService.responses(dispatchedToken, body, { signal: entry.ac.signal });
+			const upstream = await this._copilotApiService.responses(dispatchedToken, body, { signal: entry.ac.signal, suppressIntegrationId: true });
 			const contentType = upstream.headers.get('content-type') ?? 'application/json';
 			const upstreamHeaders = [...upstream.headers.entries()].map(([k, v]) => `${k}: ${v}`).join(', ');
 			this._logService.info(`[${PROXY_USER_FACING_NAME}] <<< CAPI response: status=${upstream.status}, contentType=${contentType}, headers=[${upstreamHeaders}]`);

--- a/src/vs/platform/agentHost/node/shared/copilotApiService.ts
+++ b/src/vs/platform/agentHost/node/shared/copilotApiService.ts
@@ -27,6 +27,19 @@ import { IProductService } from '../../../product/common/productService.js';
 export interface ICopilotApiServiceRequestOptions {
 	readonly headers?: Readonly<Record<string, string>>;
 	readonly signal?: AbortSignal;
+
+	/**
+	 * Suppress the `Copilot-Integration-Id` header on this request.
+	 *
+	 * When unset, `@vscode/copilot-api` derives the integration id from the
+	 * discovered Copilot SKU: a `no_auth_limited_copilot` SKU maps to
+	 * `vscode-nl`, which the CAPI backend treats as the limited/no-auth
+	 * integration and refuses premium models such as `claude-opus-4.7`.
+	 * Setting this to `true` omits the header so CAPI authorizes against the
+	 * token's real entitlement. Mirrors the Copilot Chat extension's
+	 * `ClaudeStreamingPassThroughEndpoint.getEndpointFetchOptions()`.
+	 */
+	readonly suppressIntegrationId?: boolean;
 }
 
 /**
@@ -535,6 +548,9 @@ export class CopilotApiService implements ICopilotApiService {
 					'X-Request-Id': requestId,
 					'OpenAI-Intent': 'conversation',
 				},
+				// Opt-in per request — see
+				// `ICopilotApiServiceRequestOptions.suppressIntegrationId`.
+				suppressIntegrationId: options?.suppressIntegrationId,
 				body,
 				signal: options?.signal,
 			},
@@ -707,8 +723,19 @@ export class CopilotApiService implements ICopilotApiService {
 					'Content-Type': 'application/json',
 					'Authorization': `Bearer ${githubToken}`,
 					'X-Request-Id': requestId,
-					'OpenAI-Intent': 'conversation',
+					'X-GitHub-Api-Version': '2026-01-09',
+					// Should these be parameterized?
+					'OpenAI-Intent': 'messages-proxy',
+					'X-Interaction-Type': 'messages-proxy',
+					// `X-Initiator` (user|agent) is intentionally omitted: the
+					// user-vs-agent turn origin known to `ClaudeAgentSession` is not
+					// plumbed across the SDK subprocess to this proxy, so a hardcoded
+					// value would mislabel most agent-loop traffic. CAPI accepts the
+					// request without it (the `responses()` and `utilityChatCompletion()`
+					// paths already omit it). Thread a real per-turn initiator here if
+					// that signal ever becomes available at the proxy boundary.
 				},
+				suppressIntegrationId: options?.suppressIntegrationId,
 				body,
 				signal: options?.signal,
 			},

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -118,6 +118,11 @@ class FakeCopilotApiService implements ICopilotApiService {
 	utilityChatCompletion(): Promise<never> { throw new Error('not used in ClaudeAgent tests'); }
 }
 
+const FakeProductService: IProductService = {
+	_serviceBrand: undefined,
+	version: '1.0.0-test',
+} as IProductService;
+
 // FakeClaudeSubagentResolver removed in the Phase 12 refactor (the
 // IClaudeSubagentResolver service no longer exists). Per-session
 // subagent state lives on `ClaudeAgentSession.subagents`
@@ -638,6 +643,7 @@ function createTestContext(
 		[IAgentPluginManager, new FakeAgentPluginManager()],
 		[IAgentHostGitService, createNoopGitService()],
 		[IAgentConfigurationService, configService],
+		[IProductService, FakeProductService],
 	);
 	const instantiationService: IInstantiationService = disposables.add(new InstantiationService(services));
 	const agent = disposables.add(instantiationService.createInstance(ClaudeAgent));
@@ -917,6 +923,7 @@ suite('ClaudeAgent', () => {
 			[IClaudeAgentSdkService, new FakeClaudeAgentSdkService()],
 			[IAgentPluginManager, new FakeAgentPluginManager()],
 			[IAgentHostGitService, createNoopGitService()],
+			[IProductService, FakeProductService],
 		);
 		const instantiationService: IInstantiationService = disposables.add(new InstantiationService(services));
 		const agent = disposables.add(instantiationService.createInstance(ClaudeAgent));
@@ -978,6 +985,7 @@ suite('ClaudeAgent', () => {
 			[ISessionDataService, createNullSessionDataService()],
 			[IClaudeAgentSdkService, new FakeClaudeAgentSdkService()],
 			[IAgentPluginManager, new FakeAgentPluginManager()],
+			[IProductService, FakeProductService],
 		);
 		const instantiationService: IInstantiationService = disposables.add(new InstantiationService(services));
 		const agent = instantiationService.createInstance(ClaudeAgent);
@@ -1045,6 +1053,7 @@ suite('ClaudeAgent', () => {
 			[ISessionDataService, createNullSessionDataService()],
 			[IClaudeAgentSdkService, new FakeClaudeAgentSdkService()],
 			[IAgentPluginManager, new FakeAgentPluginManager()],
+			[IProductService, FakeProductService],
 		);
 		const instantiationService: IInstantiationService = disposables.add(new InstantiationService(services));
 		const agent = disposables.add(instantiationService.createInstance(ClaudeAgent));
@@ -1981,6 +1990,7 @@ suite('ClaudeAgent', () => {
 			[IAgentPluginManager, new FakeAgentPluginManager()],
 			[IAgentHostGitService, createNoopGitService()],
 			[IAgentConfigurationService, configService],
+			[IProductService, FakeProductService],
 		);
 		const instantiationService: IInstantiationService = disposables.add(new InstantiationService(services));
 		const agent: ClaudeAgent = disposables.add(instantiationService.createInstance(ClaudeAgent));
@@ -2578,6 +2588,7 @@ suite('ClaudeAgent', () => {
 			[ISessionDataService, sessionData],
 			[IClaudeAgentSdkService, sdk],
 			[IAgentPluginManager, new FakeAgentPluginManager()],
+			[IProductService, FakeProductService],
 		);
 		const instantiationService = disposables.add(new InstantiationService(services));
 		const agent = disposables.add(instantiationService.createInstance(ClaudeAgent));
@@ -2648,6 +2659,7 @@ suite('ClaudeAgent', () => {
 			[ISessionDataService, sessionData],
 			[IClaudeAgentSdkService, sdk],
 			[IAgentPluginManager, new FakeAgentPluginManager()],
+			[IProductService, FakeProductService],
 		);
 		const instantiationService = disposables.add(new InstantiationService(services));
 		const agent = disposables.add(instantiationService.createInstance(ClaudeAgent));
@@ -2731,6 +2743,7 @@ suite('ClaudeAgent', () => {
 			[ISessionDataService, createNullSessionDataService()],
 			[IClaudeAgentSdkService, sdk],
 			[IAgentPluginManager, new FakeAgentPluginManager()],
+			[IProductService, FakeProductService],
 		);
 		const instantiationService = disposables.add(new InstantiationService(services));
 		const agent = disposables.add(instantiationService.createInstance(ClaudeAgent));
@@ -2777,6 +2790,7 @@ suite('ClaudeAgent', () => {
 			[ISessionDataService, sessionData],
 			[IClaudeAgentSdkService, sdk],
 			[IAgentPluginManager, new FakeAgentPluginManager()],
+			[IProductService, FakeProductService],
 		);
 		const instantiationService = disposables.add(new InstantiationService(services));
 		const agent = disposables.add(instantiationService.createInstance(ClaudeAgent));
@@ -3082,6 +3096,7 @@ suite('ClaudeAgent', () => {
 			[ISessionDataService, createNullSessionDataService()],
 			[IClaudeAgentSdkService, new FakeClaudeAgentSdkService()],
 			[IAgentPluginManager, new FakeAgentPluginManager()],
+			[IProductService, FakeProductService],
 		);
 		const instantiationService = disposables.add(new InstantiationService(services));
 		const agent = instantiationService.createInstance(ClaudeAgent);
@@ -3134,6 +3149,7 @@ suite('ClaudeAgent', () => {
 			[IAgentPluginManager, new FakeAgentPluginManager()],
 			[IAgentHostGitService, createNoopGitService()],
 			[IAgentConfigurationService, configService],
+			[IProductService, FakeProductService],
 		);
 		const instantiationService: IInstantiationService = disposables.add(new InstantiationService(services));
 		const agent: ClaudeAgent = instantiationService.createInstance(ClaudeAgent);
@@ -4763,6 +4779,7 @@ suite('ClaudeAgent — Phase 11 customizations', () => {
 			[IAgentPluginManager, pluginManager],
 			[IAgentHostGitService, createNoopGitService()],
 			[IAgentConfigurationService, configService],
+			[IProductService, FakeProductService],
 		);
 		const instantiationService: IInstantiationService = disposables.add(new InstantiationService(services));
 		const agent = disposables.add(instantiationService.createInstance(ClaudeAgent));

--- a/src/vs/platform/agentHost/test/node/shared/copilotApiService.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/copilotApiService.test.ts
@@ -463,7 +463,8 @@ suite('CopilotApiService', () => {
 
 			assert.strictEqual(headers['Content-Type'], 'application/json');
 			assert.strictEqual(headers['Authorization'], 'Bearer gh-tok');
-			assert.strictEqual(headers['OpenAI-Intent'], 'conversation');
+			assert.strictEqual(headers['OpenAI-Intent'], 'messages-proxy');
+			assert.strictEqual(headers['X-Interaction-Type'], 'messages-proxy');
 			assert.ok(headers['X-Request-Id'], 'should have a request id');
 			assert.ok(headers['X-GitHub-Api-Version'], 'CAPIClient should inject API version');
 			assert.ok(headers['VScode-SessionId'], 'CAPIClient should inject session id');
@@ -535,7 +536,26 @@ suite('CopilotApiService', () => {
 			assert.strictEqual(headers['Authorization'], 'Bearer gh-tok');
 			assert.strictEqual(headers['Content-Type'], 'application/json');
 			assert.notStrictEqual(headers['X-Request-Id'], 'attacker-id');
-			assert.strictEqual(headers['OpenAI-Intent'], 'conversation');
+			assert.strictEqual(headers['OpenAI-Intent'], 'messages-proxy');
+		});
+
+		test('suppressIntegrationId opt-in controls the Copilot-Integration-Id header', async () => {
+			const { fetch: fetchFn, captured } = routingFetch(
+				() => anthropicResponse([{ type: 'text', text: 'ok' }]),
+			);
+			const service = createService(fetchFn);
+
+			// Default (no opt-in): @vscode/copilot-api derives and sends the header.
+			await service.messages('gh-tok', baseRequest);
+			const withHeader = captured().init?.headers as Record<string, string>;
+
+			// Opt-in: the header is omitted entirely so CAPI authorizes against
+			// the token's real entitlement instead of the derived integration id.
+			await service.messages('gh-tok', baseRequest, { suppressIntegrationId: true });
+			const suppressed = captured().init?.headers as Record<string, string>;
+
+			assert.ok(withHeader['Copilot-Integration-Id'], 'integration id should be present by default');
+			assert.strictEqual(suppressed['Copilot-Integration-Id'], undefined, 'integration id should be suppressed when opted in');
 		});
 	});
 


### PR DESCRIPTION
## Problem

When starting a Claude (or Codex) agent-host session, premium models such as `claude-opus-4.7` fail to respond on accounts whose Copilot SKU is `no_auth_limited_copilot`.

## Root cause

The agent host's `CopilotApiService` builds its `CAPIClient` without an explicit integration id, so `@vscode/copilot-api` derives one from the discovered Copilot SKU. For a `no_auth_limited_copilot` SKU that derivation produces `Copilot-Integration-Id: vscode-nl` — the limited/no-auth integration — and CAPI refuses premium models for that integration. The Claude `/v1/messages` and Codex `/responses` proxy paths both sent this header.

The Copilot Chat extension avoids this on its equivalent passthrough endpoints by setting `suppressIntegrationId: true` (`ClaudeStreamingPassThroughEndpoint.getEndpointFetchOptions()` / `oaiLanguageModelServer`). The agent host did not.

## Fix

- Add an opt-in `suppressIntegrationId` to `ICopilotApiServiceRequestOptions`, threaded through `messages()` and `responses()`. When set, the `Copilot-Integration-Id` header is omitted so CAPI authorizes against the token's real entitlement.
- Opt in at the inference proxy call sites: Claude streaming + non-streaming `messages`, and Codex `responses`. Model discovery (`models()`) intentionally does **not** suppress — it isn't entitlement-gated the same way and should reflect the account's real catalog.

## Also in this PR

- Forward a transformed `vscode_claude_code/<version>` User-Agent on the Claude models + messages proxy paths, for consistent server-side identification (mirrors the extension).
- Tag the messages proxy with `OpenAI-Intent` / `X-Interaction-Type: messages-proxy`, and **omit** `X-Initiator`: the user-vs-agent turn origin known to `ClaudeAgentSession` isn't plumbed across the SDK subprocess to the proxy, so a hardcoded value would mislabel agent-loop traffic. (`responses()` / `utilityChatCompletion()` already omit it.)

## Testing

- **Unit:** `copilotApiService.test.ts` (84) and `claudeAgent.test.ts` (125) pass. Adds a `suppressIntegrationId` opt-in test and updates the messages-path header assertions.
- **E2E:** drove a Claude session through the Agents window against live CAPI — `POST /v1/messages` succeeded, the assistant streamed a response, no 4xx/5xx or `CopilotApiError`.

> **Repro caveat:** verified end-to-end on an **enterprise** account (SKU → `code-oss`), which cannot itself reproduce the `vscode-nl` downgrade. The fix is verified by the suppressed-header behavior (unit assertion + transpiled output) and a clean live round-trip; the `no_auth_limited_copilot` rejection path was not exercised directly on this account.
