### PR TITLE
Skip failing chat smoke tests

### DIFF
--- a/test/smoke/src/areas/chat/chatSessions.test.ts
+++ b/test/smoke/src/areas/chat/chatSessions.test.ts
@@ -84,7 +84,7 @@ export function setup(logger: Logger) {
 			await mockServer?.close();
 		});
 
-		it('Test Copilot CLI session', async function () {
+		it.skip('Test Copilot CLI session', async function () {
 			const app = this.app as Application;
 			const requestsBefore = mockServer.requestCount();
 
@@ -106,7 +106,7 @@ export function setup(logger: Logger) {
 			);
 		});
 
-		it('Test Claude session', async function () {
+		it.skip('Test Claude session', async function () {
 			const app = this.app as Application;
 			const requestsBefore = mockServer.requestCount();
 			logger.log(`Chat Sessions (Claude) mock requests before: ${requestsBefore}`);

--- a/test/smoke/src/areas/chat/copilotCli.test.ts
+++ b/test/smoke/src/areas/chat/copilotCli.test.ts
@@ -66,7 +66,7 @@ export function setup(logger: Logger) {
 			await mockServer?.close();
 		});
 
-		it('opens a Copilot CLI session and receives a response', async function () {
+		it.skip('opens a Copilot CLI session and receives a response', async function () {
 			const app = this.app as Application;
 			const requestsBefore = mockServer.requestCount();
 


### PR DESCRIPTION
## Summary
- Skip the Copilot CLI chat smoke test while the session path is failing.
- Skip the Copilot CLI and Claude chat session coverage in `chatSessions.test.ts` while keeping the Local chat session test active.

## Verification
- Not run; the local pre-commit hook failed before commit because package `event-stream` is missing from this workspace dependency install.

Fixes #2966