### PR TITLE
sessions: surface archived state in session header

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
@@ -17,7 +17,7 @@ import { IQuickInputService, IQuickPickItem, IQuickPickSeparator } from '../../.
 import { EditorAreaFocusContext, IsAuxiliaryWindowContext, IsSessionsWindowContext } from '../../../../workbench/common/contextkeys.js';
 import { Menus } from '../../../browser/menus.js';
 import { SessionsCategories } from '../../../common/categories.js';
-import { CanGoBackContext, CanGoForwardContext, ChatSessionProviderIdContext, MultipleSessionsVisibleContext, SessionIsCreatedContext, SessionIsMaximizedContext, SessionIsStickyContext, SessionsFocusContext, SessionSupportsMultipleChatsContext, SessionsWelcomeVisibleContext } from '../../../common/contextkeys.js';
+import { CanGoBackContext, CanGoForwardContext, ChatSessionProviderIdContext, MultipleSessionsVisibleContext, SessionIsArchivedContext, SessionIsCreatedContext, SessionIsMaximizedContext, SessionIsStickyContext, SessionsFocusContext, SessionSupportsMultipleChatsContext, SessionsWelcomeVisibleContext } from '../../../common/contextkeys.js';
 import { ANY_AGENT_HOST_PROVIDER_RE } from '../../../common/agentHostSessionsProvider.js';
 import { IActiveSession, ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsViewService } from '../../../browser/sessionsViewService.js';
@@ -354,7 +354,7 @@ registerAction2(class AddChatToSessionBarAction extends Action2 {
 			icon: Codicon.add,
 			menu: {
 				id: Menus.SessionBarToolbar,
-				when: ContextKeyExpr.and(SessionIsCreatedContext, SessionSupportsMultipleChatsContext),
+				when: ContextKeyExpr.and(SessionIsCreatedContext, SessionSupportsMultipleChatsContext, SessionIsArchivedContext.negate()),
 				group: 'navigation',
 				order: 10,
 			},
@@ -388,7 +388,7 @@ registerAction2(class TogglePinSessionAction extends Action2 {
 				id: Menus.SessionBarToolbar,
 				group: '1_session',
 				order: 10,
-				when: SessionIsCreatedContext,
+				when: ContextKeyExpr.and(SessionIsCreatedContext, SessionIsArchivedContext.negate()),
 			},
 		});
 	}

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
@@ -589,6 +589,11 @@ registerAction2(class ArchiveSessionAction extends Action2 {
 				group: '1_edit',
 				order: 2,
 				when: ContextKeyExpr.equals(SessionIsArchivedContext.key, false),
+			}, {
+				id: Menus.SessionBarToolbar,
+				group: 'navigation',
+				order: 15,
+				when: ContextKeyExpr.equals(SessionIsArchivedContext.key, false),
 			}]
 		});
 	}

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
@@ -17,10 +17,10 @@ import { IStorageService, StorageScope, StorageTarget } from '../../../../../pla
 import { KeybindingsRegistry, KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { IViewsService } from '../../../../../workbench/services/views/common/viewsService.js';
 import { CLOSE_MOBILE_SIDEBAR_DRAWER_COMMAND_ID } from '../../../../browser/workbench.js';
-import { EditorsVisibleContext, EditorAreaFocusContext, IsAuxiliaryWindowContext, IsSessionsWindowContext } from '../../../../../workbench/common/contextkeys.js';
+import { EditorsVisibleContext, EditorAreaFocusContext, IsSessionsWindowContext } from '../../../../../workbench/common/contextkeys.js';
 import { ANY_AGENT_HOST_PROVIDER_RE } from '../../../../common/agentHostSessionsProvider.js';
 import { SessionsCategories } from '../../../../common/categories.js';
-import { ChatSessionProviderIdContext, IsActiveSessionArchivedContext, IsNewChatSessionContext, SessionIsArchivedContext, SessionIsReadContext, SessionsWelcomeVisibleContext } from '../../../../common/contextkeys.js';
+import { ChatSessionProviderIdContext, IsActiveSessionArchivedContext, IsNewChatSessionContext, SessionIsArchivedContext, SessionIsReadContext } from '../../../../common/contextkeys.js';
 import { SessionItemToolbarMenuId, SessionItemContextMenuId, SessionSectionToolbarMenuId, SessionSectionTypeContext, IsSessionPinnedContext, SessionsGrouping, SessionsSorting, ISessionSection } from './sessionsList.js';
 import { ISession, SessionStatus } from '../../../../services/sessions/common/session.js';
 import { IsWorkspaceGroupCappedContext, SessionsViewFilterOptionsSubMenu, SessionsViewFilterSubMenu, SessionsViewGroupingContext, SessionsViewId, SessionsView, SessionsViewSortingContext, openSessionToTheSide } from './sessionsView.js';
@@ -621,14 +621,10 @@ registerAction2(class UnarchiveSessionAction extends Action2 {
 				order: 2,
 				when: ContextKeyExpr.equals(SessionIsArchivedContext.key, true),
 			}, {
-				id: Menus.CommandCenter,
-				order: 103,
-				when: ContextKeyExpr.and(
-					IsAuxiliaryWindowContext.negate(),
-					SessionsWelcomeVisibleContext.negate(),
-					IsNewChatSessionContext.negate(),
-					IsActiveSessionArchivedContext
-				)
+				id: Menus.SessionBarToolbar,
+				group: 'navigation',
+				order: 5,
+				when: ContextKeyExpr.equals(SessionIsArchivedContext.key, true),
 			}]
 		});
 	}

--- a/src/vs/sessions/services/sessions/browser/sessionsListModelService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsListModelService.ts
@@ -208,10 +208,13 @@ export class SessionsListModelService extends Disposable implements ISessionsLis
 			case SessionStatus.Error:
 				return { ...Codicon.error, color: themeColorFromId('errorForeground') };
 			default:
+				if (isArchived) {
+					return { ...Codicon.passFilled, color: themeColorFromId('agentSessionReadIndicator.foreground') };
+				}
 				if (pullRequestIcon) {
 					return pullRequestIcon;
 				}
-				if (!isRead && !isArchived) {
+				if (!isRead) {
 					return { ...Codicon.circleFilled, color: themeColorFromId('textLink.foreground') };
 				}
 				return { ...Codicon.circleSmallFilled, color: themeColorFromId('agentSessionReadIndicator.foreground') };


### PR DESCRIPTION
## What

In the Agents window, an archived ("done") session is currently almost invisible — the only signals are missing actions and the Restore button hidden away in the title bar's command center.

This PR consolidates the archived-session UI on the **session header**:

- **Distinct "done" glyph in the status icon.** `getStatusIcon` now returns `Codicon.passFilled` (in the muted read-indicator color) for archived sessions, instead of reusing the plain read dot. Applies wherever the shared status icon is used (header, sessions list, picker).
- **Restore action moved to the session header toolbar.** Previously contributed to `Menus.CommandCenter` (title bar pill area); now contributed to `Menus.SessionBarToolbar`, `navigation` group (order 5), so it sits where New Chat would otherwise be. Gated by the session-scoped `SessionIsArchivedContext`, which is the right scope for a per-session header toolbar.
- **Hide New Chat and Pin/Unpin in the header when archived.** These actions don't apply to a done session — `SessionIsArchivedContext.negate()` added to both `when` clauses.

## Why

A done session now reads as done at a glance (check glyph in the header), and the Restore affordance lives next to the session it acts on, rather than across the window in the title bar. The header toolbar stays focused on actions that are actually meaningful for the current state.

## Notes for reviewers

- No new menu IDs or context keys — reuses the existing per-session `SessionIsArchivedContext` already bound in `sessionView.ts` (and used elsewhere for header context-menu gating).
- The Restore action still appears in the sessions-list per-item toolbar and the list item context menu (unchanged); only the title-bar command-center contribution moved.
- Title text is intentionally not dimmed — the glyph + hidden-actions combination conveys the state without changing typography.
- Type-check (`compile-check-ts-native`) and layers check both pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>