### PR TITLE
Add compact icon styling and className option for action lists

### DIFF
--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -597,7 +597,10 @@ export class ActionListWidget<T> extends Disposable {
 			this.domNode.classList.add('inline-description');
 		}
 		if (this._options?.className) {
-			this.domNode.classList.add(this._options.className);
+			const classNames = this._options.className.split(/\s+/).filter(className => className.length > 0);
+			if (classNames.length > 0) {
+				this.domNode.classList.add(...classNames);
+			}
 		}
 		this._actionLineHeight = 24;
 

--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -528,6 +528,11 @@ export interface IActionListOptions {
 	 * Optional text shown below the action list as a footer.
 	 */
 	readonly footerText?: string;
+
+	/**
+	 * Optional CSS class name added to the action list container, for scoped styling.
+	 */
+	readonly className?: string;
 }
 
 /**
@@ -590,6 +595,9 @@ export class ActionListWidget<T> extends Disposable {
 		this.domNode.classList.add('actionList');
 		if (this._options?.inlineDescription) {
 			this.domNode.classList.add('inline-description');
+		}
+		if (this._options?.className) {
+			this.domNode.classList.add(this._options.className);
 		}
 		this._actionLineHeight = 24;
 

--- a/src/vs/platform/actionWidget/browser/actionWidget.css
+++ b/src/vs/platform/actionWidget/browser/actionWidget.css
@@ -149,6 +149,11 @@
 	font-size: var(--vscode-codiconFontSize, 16px);
 }
 
+/* The submenu indicator keeps the regular codicon size even in compact lists */
+.action-widget .actionList.compact-icons .monaco-list-row.action .action-list-submenu-indicator.codicon {
+	font-size: var(--vscode-codiconFontSize, 16px);
+}
+
 .action-widget .monaco-list-row.action.option-disabled,
 .action-widget .monaco-list:focus .monaco-list-row.focused.action.option-disabled,
 .action-widget .monaco-list-row.action.option-disabled .codicon,

--- a/src/vs/platform/actionWidget/browser/actionWidget.css
+++ b/src/vs/platform/actionWidget/browser/actionWidget.css
@@ -139,6 +139,16 @@
 	font-size: 16px;
 }
 
+/* Compact icon modifier: render the leading row codicon at the compact size */
+.action-widget .actionList.compact-icons .monaco-list-row.action .codicon {
+	font-size: var(--vscode-codiconFontSize-compact, 12px);
+}
+
+/* Toolbar codicons keep the regular codicon size even in compact lists */
+.action-widget .actionList.compact-icons .monaco-list-row.action .action-list-item-toolbar .codicon {
+	font-size: var(--vscode-codiconFontSize, 16px);
+}
+
 .action-widget .monaco-list-row.action.option-disabled,
 .action-widget .monaco-list:focus .monaco-list-row.focused.action.option-disabled,
 .action-widget .monaco-list-row.action.option-disabled .codicon,

--- a/src/vs/sessions/contrib/chat/browser/runScriptAction.ts
+++ b/src/vs/sessions/contrib/chat/browser/runScriptAction.ts
@@ -575,6 +575,7 @@ class RunScriptActionViewItem extends BaseActionViewItem {
 			{
 				actionProvider: { getActions: () => this._getDropdownActions() },
 				showItemKeybindings: true,
+				listOptions: { className: 'compact-icons' },
 			},
 			this._actionWidgetService,
 			this._keybindingService,
@@ -742,7 +743,7 @@ class RunScriptActionViewItem extends BaseActionViewItem {
 					? localize('addActionTooltip', "Add a new task")
 					: localize('addActionTooltipDisabled', "Cannot add tasks to this session because workspace storage is unavailable"),
 			},
-			icon: Codicon.add,
+			icon: Codicon.addCompact,
 			enabled: canConfigure,
 			class: undefined,
 			category: tasksCategory,
@@ -763,7 +764,7 @@ class RunScriptActionViewItem extends BaseActionViewItem {
 			hover: {
 				content: localize('generateRunActionTooltip', "Generate a new workspace task"),
 			},
-			icon: Codicon.sparkle,
+			icon: Codicon.sparkleCompact,
 			enabled: true,
 			class: undefined,
 			category: tasksCategory,
@@ -789,7 +790,7 @@ class RunScriptActionViewItem extends BaseActionViewItem {
 					? localize('openBrowserActionTooltip', "Open '{0}' in the integrated browser", browserUrl)
 					: localize('openBrowserActionTooltipUnconfigured', "Open the integrated browser"),
 			},
-			icon: Codicon.browser,
+			icon: Codicon.windowCompact,
 			enabled: true,
 			class: undefined,
 			category: browserCategory,


### PR DESCRIPTION
This pull request introduces improvements to the action list widget and refines the appearance and behavior of icons in the "Run Script" chat session UI. The main changes include support for custom CSS classes in the action list, new compact icon styling, and updates to use compact icon variants in relevant actions.

**Action List Widget Enhancements:**

* Added an optional `className` property to the `IActionListOptions` interface, allowing consumers to specify custom CSS classes for the action list container. (`src/vs/platform/actionWidget/browser/actionList.ts`, [src/vs/platform/actionWidget/browser/actionList.tsR531-R535](diffhunk://#diff-1d3ed28e6e4eb6fb8e00a9b9edaaf30ab7ef7f7d116ddda68fc3292231e3e830R531-R535))
* Updated the `ActionListWidget` to apply any provided `className` values to the DOM node, enabling scoped styling for different action lists. (`src/vs/platform/actionWidget/browser/actionList.ts`, [src/vs/platform/actionWidget/browser/actionList.tsR599-R604](diffhunk://#diff-1d3ed28e6e4eb6fb8e00a9b9edaaf30ab7ef7f7d116ddda68fc3292231e3e830R599-R604))

**Compact Icon Styling:**

* Introduced new CSS rules for `.compact-icons`, reducing the size of leading row icons in compact lists while ensuring toolbar and submenu icons retain their standard size. (`src/vs/platform/actionWidget/browser/actionWidget.css`, [src/vs/platform/actionWidget/browser/actionWidget.cssR142-R156](diffhunk://#diff-ccde3eafe6f1bdf6802118d065818be5cada627f294ffad4af8696cb16015b90R142-R156))
* Updated the "Run Script" action dropdown to use the `compact-icons` class, activating the new compact icon styling. (`src/vs/sessions/contrib/chat/browser/runScriptAction.ts`, [src/vs/sessions/contrib/chat/browser/runScriptAction.tsR578](diffhunk://#diff-a3db9fb11af8736689ddd3da5101a71fd7b6c62534bb30ad988f73a03cc2e739R578))

**Icon Variant Updates:**

* Switched several action icons in the "Run Script" chat UI to their compact variants (`Codicon.addCompact`, `Codicon.sparkleCompact`, `Codicon.windowCompact`) for a more streamlined appearance in compact lists. (`src/vs/sessions/contrib/chat/browser/runScriptAction.ts`, [[1]](diffhunk://#diff-a3db9fb11af8736689ddd3da5101a71fd7b6c62534bb30ad988f73a03cc2e739L745-R746) [[2]](diffhunk://#diff-a3db9fb11af8736689ddd3da5101a71fd7b6c62534bb30ad988f73a03cc2e739L766-R767) [[3]](diffhunk://#diff-a3db9fb11af8736689ddd3da5101a71fd7b6c62534bb30ad988f73a03cc2e739L792-R793)