### PR TITLE
Add border-radius to dropdowns in agent sessions workbench

### DIFF
--- a/src/vs/sessions/browser/media/style.css
+++ b/src/vs/sessions/browser/media/style.css
@@ -12,6 +12,10 @@
 	border-radius: var(--vscode-cornerRadius-small);
 }
 
+.agent-sessions-workbench .monaco-dropdown-with-default {
+	border-radius: var(--vscode-cornerRadius-small);
+}
+
 /* ---- Sidebar & Auxiliary Bar Card Appearance ---- */
 
 .agent-sessions-workbench .part.sidebar {


### PR DESCRIPTION
Enhance the appearance of dropdowns in the agent sessions workbench by adding a border-radius style. This change improves the visual consistency of UI elements. Testing can be done by reviewing the dropdowns in the agent sessions workbench to confirm the updated styling.

