### PR TITLE
Refactor chat composite bar styles and icons

### DIFF
--- a/src/vs/sessions/browser/parts/media/chatCompositeBar.css
+++ b/src/vs/sessions/browser/parts/media/chatCompositeBar.css
@@ -68,7 +68,7 @@
 	justify-content: center;
 	flex-shrink: 0;
 	height: 26px;
-	font-size: 16px;
+	font-size: var(--vscode-codiconFontSize, 16px);
 	color: var(--session-view-foreground);
 }
 
@@ -78,8 +78,8 @@
 	overflow: hidden;
 	display: flex;
 	align-items: center;
-	font-weight: 600;
-	font-size: 13px;
+	font-weight: var(--vscode-agents-fontWeight-semiBold, 600);
+	font-size: var(--vscode-agents-fontSize-heading3, 13px);
 	color: var(--chat-tab-active-foreground, var(--session-view-foreground));
 	border-radius: 4px;
 	min-height: 22px;
@@ -155,7 +155,8 @@
 	align-items: center;
 	gap: 6px;
 	height: 22px;
-	font-size: 12px;
+	font-size: var(--vscode-agents-fontSize-label1, 12px);
+	font-weight: var(--vscode-agents-fontWeight-regular, 400);
 	line-height: 18px;
 	color: var(--chat-tab-inactive-foreground, var(--session-view-foreground));
 	overflow: hidden;
@@ -264,8 +265,8 @@
 	padding: 0 8px;
 	cursor: pointer;
 	color: var(--chat-tab-inactive-foreground);
-	font-weight: 500;
-	font-size: 12px;
+	font-weight: var(--vscode-agents-fontWeight-semiBold, 600);
+	font-size: var(--vscode-agents-fontSize-label1, 12px);
 	line-height: 22px;
 	height: 26px;
 	border-radius: var(--vscode-cornerRadius-small);
@@ -343,7 +344,7 @@
 }
 
 .chat-composite-bar-tab.in-progress .chat-composite-bar-tab-indicator-icon {
-	font-size: 12px;
+	font-size: var(--vscode-codiconFontSize-compact, 12px);
 }
 
 .chat-composite-bar-tab:focus-visible {

--- a/src/vs/sessions/browser/parts/media/chatCompositeBar.css
+++ b/src/vs/sessions/browser/parts/media/chatCompositeBar.css
@@ -179,11 +179,11 @@
 	overflow: hidden;
 }
 
-.chat-composite-bar-meta-workspace-icon,
-.chat-composite-bar-meta-branch-icon {
+.monaco-workbench .chat-composite-bar-meta-workspace-icon.codicon[class*='codicon-'],
+.monaco-workbench .chat-composite-bar-meta-branch-icon.codicon[class*='codicon-'] {
 	display: inline-flex;
 	align-items: center;
-	font-size: 14px;
+	font-size: var(--vscode-codiconFontSize-compact, 12px);
 	flex-shrink: 0;
 }
 

--- a/src/vs/sessions/browser/parts/sessionHeader.ts
+++ b/src/vs/sessions/browser/parts/sessionHeader.ts
@@ -285,7 +285,7 @@ export class SessionHeader extends Disposable {
 			// Mirror the sessions list / hover icon logic: cloud for virtual workspaces,
 			// folder when the session runs in the repo checkout, worktree otherwise.
 			const isWorkspaceFolder = workspace.folders.length > 0 && workspace.folders[0]?.gitRepository?.workTreeUri === undefined;
-			const workspaceIcon = workspace.isVirtualWorkspace ? Codicon.cloud : isWorkspaceFolder ? Codicon.folder : Codicon.worktree;
+			const workspaceIcon = workspace.isVirtualWorkspace ? Codicon.cloudCompact : isWorkspaceFolder ? Codicon.folderCompact : Codicon.worktreeCompact;
 			const workspaceEl = $('span.chat-composite-bar-meta-workspace');
 			workspaceEl.appendChild($('span.chat-composite-bar-meta-workspace-icon' + ThemeIcon.asCSSSelector(workspaceIcon)));
 			const workspaceLabel = $('span.chat-composite-bar-meta-workspace-label');
@@ -298,7 +298,7 @@ export class SessionHeader extends Disposable {
 		if (branch) {
 			appendSeparator();
 			const branchEl = $('span.chat-composite-bar-meta-branch');
-			branchEl.appendChild($('span.chat-composite-bar-meta-branch-icon' + ThemeIcon.asCSSSelector(Codicon.gitBranch)));
+			branchEl.appendChild($('span.chat-composite-bar-meta-branch-icon' + ThemeIcon.asCSSSelector(Codicon.gitBranchCompact)));
 			const branchLabel = $('span.chat-composite-bar-meta-branch-label');
 			branchLabel.textContent = branch;
 			branchEl.appendChild(branchLabel);


### PR DESCRIPTION
This pull request focuses on improving the visual consistency and theming flexibility of the chat composite bar in the sessions UI. The main changes involve replacing hardcoded font sizes and weights with CSS variables, and updating the icon styles and types to use more compact variants for a cleaner look.

**Theming and style improvements:**

* Replaced hardcoded font sizes and weights in `chatCompositeBar.css` with CSS variables (e.g., `--vscode-codiconFontSize`, `--vscode-agents-fontWeight-semiBold`, etc.) to allow for better theming and customization. [[1]](diffhunk://#diff-4a1a961fcc2ce31a67667e6b2c46bbad8fb210fb84533d19e355165289e069d2L71-R71) [[2]](diffhunk://#diff-4a1a961fcc2ce31a67667e6b2c46bbad8fb210fb84533d19e355165289e069d2L81-R82) [[3]](diffhunk://#diff-4a1a961fcc2ce31a67667e6b2c46bbad8fb210fb84533d19e355165289e069d2L158-R159) [[4]](diffhunk://#diff-4a1a961fcc2ce31a67667e6b2c46bbad8fb210fb84533d19e355165289e069d2L267-R269) [[5]](diffhunk://#diff-4a1a961fcc2ce31a67667e6b2c46bbad8fb210fb84533d19e355165289e069d2L346-R347)
* Updated selector specificity for workspace and branch icons to target codicon classes within the Monaco workbench, and switched to using a compact codicon font size variable.

**Icon updates:**

* Changed workspace and branch icons in `sessionHeader.ts` to use their respective compact variants (`cloudCompact`, `folderCompact`, `worktreeCompact`, and `gitBranchCompact`) for a more streamlined appearance. [[1]](diffhunk://#diff-9c169a209a7d8ba83ed7b696cac5d24fd4c6de1c4ed5029469ded4cb9b3d79cdL288-R288) [[2]](diffhunk://#diff-9c169a209a7d8ba83ed7b696cac5d24fd4c6de1c4ed5029469ded4cb9b3d79cdL301-R301)