### PR TITLE
fix: guard against race condition in notebook find revealCellRange (#225578)

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/find/findModel.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/find/findModel.ts
@@ -273,6 +273,11 @@ export class FindModel extends Disposable {
 
 	private async revealCellRange(cellIndex: number, matchIndex: number, outputOffset: number | null) {
 		const findMatch = this._findMatches[cellIndex];
+		// _findMatches can be replaced between cellIndex computation and this
+		// async execution (e.g. via research() triggered by onDidChangeContent).
+		if (!findMatch) {
+			return;
+		}
 		if (matchIndex >= findMatch.contentMatches.length) {
 			// reveal output range
 			this._notebookEditor.focusElement(findMatch.cell);


### PR DESCRIPTION
This PR fixes #225578 — a TypeError where `contentMatches` is read on `undefined` in notebook `findModel.ts`.

## Root Cause

Both callers of `revealCellRange` (`find()` and `refreshCurrentMatch()`) call it inside a `.then()` callback after `highlightCurrentFindMatchDecoration()`. Between the synchronous computation of `cellIndex` and execution of the microtask, `this._findMatches` can be replaced by `research()` → `set()` (triggered by `onDidChangeContent` or other events), making the cached `cellIndex` out of bounds.

## Fix

Added an early return guard in `revealCellRange` when `findMatch` is undefined, matching the defensive pattern used elsewhere in the codebase.

## Validation

- [x] Change is scoped to a single file
- [x] Follows existing defensive coding patterns
- [x] No breaking changes to the public API