### PR TITLE
Add claude-opus-4.8 to tool search model list

### DIFF
--- a/extensions/copilot/src/extension/tools/node/toolSearchTool.ts
+++ b/extensions/copilot/src/extension/tools/node/toolSearchTool.ts
@@ -87,6 +87,7 @@ ToolRegistry.registerModelSpecificTool(
 			{ family: 'claude-opus-4.7-1m-internal' },
 			{ family: 'claude-opus-4.7-high' },
 			{ family: 'claude-opus-4.7-xhigh' },
+			{ family: 'claude-opus-4.8' },
 		],
 	},
 	ToolSearchTool,


### PR DESCRIPTION
Adds `claude-opus-4.8` to the `models` list for the `ToolSearchTool` . This is already enabled for the model.
This change only makes the tool available in the model picker to toggle.

