### PR TITLE
Fix suggest widget color contrast issue

### DIFF
--- a/src/vs/editor/contrib/suggest/browser/media/suggest.css
+++ b/src/vs/editor/contrib/suggest/browser/media/suggest.css
@@ -179,10 +179,14 @@
 	opacity: 1;
 }
 
-/** signature, qualifier, type/details opacity **/
+/** signature, qualifier, type/details styling **/
 
 .monaco-editor .suggest-widget .monaco-list .monaco-list-row > .contents > .main > .right > .details-label {
-	opacity: 0.7;
+	color: var(--vscode-editorSuggestWidget-foreground);
+}
+
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row.focused > .contents > .main > .right > .details-label {
+	color: var(--vscode-editorSuggestWidget-selectedForeground);
 }
 
 .monaco-editor .suggest-widget .monaco-list .monaco-list-row > .contents > .main > .left > .signature-label {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes https://github.com/microsoft/monaco-editor/issues/5307

Update token usage to fix a11y contrast bug in editor suggest widget description text.

Before:

<img width="502" height="145" alt="Screenshot 2026-06-08 at 3 55 55 PM" src="https://github.com/user-attachments/assets/c57b3e72-7969-4bd2-a438-9136ec52507d" />

After:

<img width="617" height="288" alt="Screenshot 2026-06-08 at 3 50 41 PM" src="https://github.com/user-attachments/assets/8acc7430-eed1-4bae-a781-bd04797caa0a" />