### PR TITLE
Add speech recognition context hints

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadSpeech.ts
+++ b/src/vs/workbench/api/browser/mainThreadSpeech.ts
@@ -57,7 +57,7 @@ export class MainThreadSpeech implements MainThreadSpeechShape {
 				const disposables = new DisposableStore();
 				const session = Math.random();
 
-				this.proxy.$createSpeechToTextSession(handle, session, options?.language);
+				this.proxy.$createSpeechToTextSession(handle, session, options);
 
 				const onDidChange = disposables.add(new Emitter<ISpeechToTextEvent>());
 				this.speechToTextSessions.set(session, { onDidChange });

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -76,7 +76,7 @@ import { ISCMHistoryOptions } from '../../contrib/scm/common/history.js';
 import { InputValidationType } from '../../contrib/scm/common/scm.js';
 import { IWorkspaceSymbol, NotebookPriorityInfo } from '../../contrib/search/common/search.js';
 import { IRawClosedNotebookFileMatch } from '../../contrib/search/common/searchNotebookHelpers.js';
-import { IKeywordRecognitionEvent, ISpeechProviderMetadata, ISpeechToTextEvent, ITextToSpeechEvent } from '../../contrib/speech/common/speechService.js';
+import { IKeywordRecognitionEvent, ISpeechProviderMetadata, ISpeechToTextEvent, ISpeechToTextSessionOptions, ITextToSpeechEvent } from '../../contrib/speech/common/speechService.js';
 import { CoverageDetails, ExtensionRunTestsRequest, ICallProfileRunHandler, IFileCoverage, ISerializedTestResults, IStartControllerTests, ITestItem, ITestMessage, ITestRunProfile, ITestRunTask, ResolvedTestRunRequest, TestControllerCapability, TestMessageFollowupRequest, TestMessageFollowupResponse, TestResultState, TestsDiffOp } from '../../contrib/testing/common/testTypes.js';
 import { Timeline, TimelineChangeEvent, TimelineOptions, TimelineProviderDescriptor } from '../../contrib/timeline/common/timeline.js';
 import { TypeHierarchyItem } from '../../contrib/typeHierarchy/common/typeHierarchy.js';
@@ -1386,7 +1386,7 @@ export interface MainThreadSpeechShape extends IDisposable {
 }
 
 export interface ExtHostSpeechShape {
-	$createSpeechToTextSession(handle: number, session: number, language?: string): Promise<void>;
+	$createSpeechToTextSession(handle: number, session: number, options?: ISpeechToTextSessionOptions): Promise<void>;
 	$cancelSpeechToTextSession(session: number): Promise<void>;
 
 	$createTextToSpeechSession(handle: number, session: number, language?: string): Promise<void>;

--- a/src/vs/workbench/api/common/extHostSpeech.ts
+++ b/src/vs/workbench/api/common/extHostSpeech.ts
@@ -8,6 +8,7 @@ import { DisposableStore, IDisposable, toDisposable } from '../../../base/common
 import { ExtHostSpeechShape, IMainContext, MainContext, MainThreadSpeechShape } from './extHost.protocol.js';
 import type * as vscode from 'vscode';
 import { ExtensionIdentifier } from '../../../platform/extensions/common/extensions.js';
+import type { ISpeechToTextSessionOptions } from '../../contrib/speech/common/speechService.js';
 
 export class ExtHostSpeech implements ExtHostSpeechShape {
 
@@ -25,7 +26,7 @@ export class ExtHostSpeech implements ExtHostSpeechShape {
 		this.proxy = mainContext.getProxy(MainContext.MainThreadSpeech);
 	}
 
-	async $createSpeechToTextSession(handle: number, session: number, language?: string): Promise<void> {
+	async $createSpeechToTextSession(handle: number, session: number, options?: ISpeechToTextSessionOptions): Promise<void> {
 		const provider = this.providers.get(handle);
 		if (!provider) {
 			return;
@@ -36,7 +37,7 @@ export class ExtHostSpeech implements ExtHostSpeechShape {
 		const cts = new CancellationTokenSource();
 		this.sessions.set(session, cts);
 
-		const speechToTextSession = await provider.provideSpeechToTextSession(cts.token, language ? { language } : undefined);
+		const speechToTextSession = await provider.provideSpeechToTextSession(cts.token, options);
 		if (!speechToTextSession) {
 			return;
 		}

--- a/src/vs/workbench/contrib/chat/common/voiceChatService.ts
+++ b/src/vs/workbench/contrib/chat/common/voiceChatService.ts
@@ -113,6 +113,20 @@ export class VoiceChatService extends Disposable implements IVoiceChatService {
 		return phrases;
 	}
 
+	private createPhraseHints(phrases: Map<string, IPhraseValue>): string[] {
+		const phraseHints = new Set<string>();
+
+		for (const [phrase, value] of phrases) {
+			phraseHints.add(phrase);
+			phraseHints.add(value.agent);
+			if (value.command) {
+				phraseHints.add(value.command);
+			}
+		}
+
+		return Array.from(phraseHints);
+	}
+
 	private toText(value: IPhraseValue, type: PhraseTextType): string {
 		switch (type) {
 			case PhraseTextType.AGENT:
@@ -144,13 +158,13 @@ export class VoiceChatService extends Disposable implements IVoiceChatService {
 		let detectedSlashCommand = false;
 
 		const emitter = disposables.add(new Emitter<IVoiceChatTextEvent>());
-		const session = await this.speechService.createSpeechToTextSession(token, 'chat');
+		const phrases = this.createPhrases(options.model);
+		const session = await this.speechService.createSpeechToTextSession(token, 'chat', { phraseHints: this.createPhraseHints(phrases) });
 
 		if (token.isCancellationRequested) {
 			onSessionStoppedOrCanceled(true);
 		}
 
-		const phrases = this.createPhrases(options.model);
 		disposables.add(session.onDidChange(e => {
 			switch (e.status) {
 				case SpeechToTextStatus.Recognizing:

--- a/src/vs/workbench/contrib/chat/test/common/voiceChatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/voiceChatService.test.ts
@@ -11,7 +11,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/tes
 import { ExtensionIdentifier } from '../../../../../platform/extensions/common/extensions.js';
 import { MockContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
 import { nullExtensionDescription } from '../../../../services/extensions/common/extensions.js';
-import { ISpeechProvider, ISpeechService, ISpeechToTextEvent, ISpeechToTextSession, ITextToSpeechSession, KeywordRecognitionStatus, SpeechToTextStatus } from '../../../speech/common/speechService.js';
+import { ISpeechProvider, ISpeechService, ISpeechToTextEvent, ISpeechToTextSession, ISpeechToTextSessionOptions, ITextToSpeechSession, KeywordRecognitionStatus, SpeechToTextStatus } from '../../../speech/common/speechService.js';
 import { IChatAgent, IChatAgentCommand, IChatAgentCompletionItem, IChatAgentData, IChatAgentHistoryEntry, IChatAgentImplementation, IChatAgentMetadata, IChatAgentRequest, IChatAgentResult, IChatAgentService, IChatParticipantDetectionProvider, UserSelectedTools } from '../../common/participants/chatAgents.js';
 import { IChatModel } from '../../common/model/chatModel.js';
 import { IChatFollowup, IChatProgress } from '../../common/chatService/chatService.js';
@@ -103,6 +103,8 @@ suite('VoiceChat', () => {
 
 	class TestSpeechService implements ISpeechService {
 		_serviceBrand: undefined;
+		lastSpeechToTextContext: string | undefined;
+		lastSpeechToTextSessionOptions: ISpeechToTextSessionOptions | undefined;
 
 		onDidChangeHasSpeechProvider = Event.None;
 
@@ -115,7 +117,10 @@ suite('VoiceChat', () => {
 		onDidStartSpeechToTextSession = Event.None;
 		onDidEndSpeechToTextSession = Event.None;
 
-		async createSpeechToTextSession(token: CancellationToken): Promise<ISpeechToTextSession> {
+		async createSpeechToTextSession(token: CancellationToken, context?: string, options?: ISpeechToTextSessionOptions): Promise<ISpeechToTextSession> {
+			this.lastSpeechToTextContext = context;
+			this.lastSpeechToTextSessionOptions = options;
+
 			return {
 				onDidChange: emitter.event
 			};
@@ -140,6 +145,7 @@ suite('VoiceChat', () => {
 	let emitter: Emitter<ISpeechToTextEvent>;
 
 	let service: VoiceChatService;
+	let speechService: TestSpeechService;
 	let event: IVoiceChatTextEvent | undefined;
 
 	async function createSession(options: IVoiceChatSessionOptions) {
@@ -153,7 +159,8 @@ suite('VoiceChat', () => {
 
 	setup(() => {
 		emitter = disposables.add(new Emitter<ISpeechToTextEvent>());
-		service = disposables.add(new VoiceChatService(new TestSpeechService(), new TestChatAgentService(), new MockContextKeyService()));
+		speechService = new TestSpeechService();
+		service = disposables.add(new VoiceChatService(speechService, new TestChatAgentService(), new MockContextKeyService()));
 	});
 
 	teardown(() => {
@@ -166,6 +173,32 @@ suite('VoiceChat', () => {
 
 	test('Agent and slash command detection (useAgents: true)', async () => {
 		await testAgentsAndSlashCommandsDetection({ usesAgents: true, model: {} as IChatModel });
+	});
+
+	test('passes chat phrase hints to speech recognition', async () => {
+		await createSession({ usesAgents: true, model: {} as IChatModel });
+
+		assert.deepStrictEqual({
+			context: speechService.lastSpeechToTextContext,
+			phraseHints: [...speechService.lastSpeechToTextSessionOptions?.phraseHints ?? []].sort()
+		}, {
+			context: 'chat',
+			phraseHints: [
+				'at code',
+				'at code slash search',
+				'at workspace',
+				'at workspace slash explain',
+				'at workspace slash fix',
+				'explain',
+				'fix',
+				'search',
+				'slash explain',
+				'slash fix',
+				'slash search',
+				'vscode',
+				'workspace'
+			].sort()
+		});
 	});
 
 	async function testAgentsAndSlashCommandsDetection(options: IVoiceChatSessionOptions) {

--- a/src/vs/workbench/contrib/speech/browser/speechService.ts
+++ b/src/vs/workbench/contrib/speech/browser/speechService.ts
@@ -11,7 +11,7 @@ import { IContextKey, IContextKeyService } from '../../../../platform/contextkey
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IHostService } from '../../../services/host/browser/host.js';
 import { DeferredPromise } from '../../../../base/common/async.js';
-import { ISpeechService, ISpeechProvider, HasSpeechProvider, ISpeechToTextSession, SpeechToTextInProgress, KeywordRecognitionStatus, SpeechToTextStatus, speechLanguageConfigToLanguage, SPEECH_LANGUAGE_CONFIG, ITextToSpeechSession, TextToSpeechInProgress, TextToSpeechStatus } from '../common/speechService.js';
+import { ISpeechService, ISpeechProvider, HasSpeechProvider, ISpeechToTextSession, SpeechToTextInProgress, KeywordRecognitionStatus, SpeechToTextStatus, speechLanguageConfigToLanguage, SPEECH_LANGUAGE_CONFIG, ITextToSpeechSession, TextToSpeechInProgress, TextToSpeechStatus, ISpeechToTextSessionOptions } from '../common/speechService.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { ExtensionsRegistry } from '../../../services/extensions/common/extensionsRegistry.js';
@@ -142,11 +142,11 @@ export class SpeechService extends Disposable implements ISpeechService {
 
 	private readonly speechToTextInProgress: IContextKey<boolean>;
 
-	async createSpeechToTextSession(token: CancellationToken, context: string = 'speech'): Promise<ISpeechToTextSession> {
+	async createSpeechToTextSession(token: CancellationToken, context: string = 'speech', options?: ISpeechToTextSessionOptions): Promise<ISpeechToTextSession> {
 		const provider = await this.getProvider();
 
 		const language = speechLanguageConfigToLanguage(this.configurationService.getValue<unknown>(SPEECH_LANGUAGE_CONFIG));
-		const session = provider.createSpeechToTextSession(token, typeof language === 'string' ? { language } : undefined);
+		const session = provider.createSpeechToTextSession(token, { ...options, context, language });
 
 		const sessionStart = Date.now();
 		let sessionRecognized = false;

--- a/src/vs/workbench/contrib/speech/common/speechService.ts
+++ b/src/vs/workbench/contrib/speech/common/speechService.ts
@@ -73,7 +73,9 @@ export interface IKeywordRecognitionSession {
 }
 
 export interface ISpeechToTextSessionOptions {
+	readonly context?: string;
 	readonly language?: string;
+	readonly phraseHints?: readonly string[];
 }
 
 export interface ITextToSpeechSessionOptions {
@@ -107,7 +109,7 @@ export interface ISpeechService {
 	 * Starts to transcribe speech from the default microphone. The returned
 	 * session object provides an event to subscribe for transcribed text.
 	 */
-	createSpeechToTextSession(token: CancellationToken, context?: string): Promise<ISpeechToTextSession>;
+	createSpeechToTextSession(token: CancellationToken, context?: string, options?: ISpeechToTextSessionOptions): Promise<ISpeechToTextSession>;
 
 	readonly onDidStartTextToSpeechSession: Event<void>;
 	readonly onDidEndTextToSpeechSession: Event<void>;

--- a/src/vscode-dts/vscode.proposed.speech.d.ts
+++ b/src/vscode-dts/vscode.proposed.speech.d.ts
@@ -6,7 +6,17 @@
 declare module 'vscode' {
 
 	export interface SpeechToTextOptions {
+		/**
+		 * The context in which speech recognition is being requested.
+		 */
+		readonly context?: string;
+
 		readonly language?: string;
+
+		/**
+		 * Phrases that are expected to appear in the speech recognition result.
+		 */
+		readonly phraseHints?: readonly string[];
 	}
 
 	export enum SpeechToTextStatus {


### PR DESCRIPTION
## Why

Voice chat uses the generic speech-to-text path with little context about what the user is likely to say, so developer phrases like chat participant names and slash commands ("at workspace slash fix") are often misheard. This PR adds a way to pass contextual hints to speech providers so they recognize these phrases.

## Before and After

The rewrite from spoken words to chat syntax ("at workspace" → `@workspace`) already existed. What was missing was feeding the vocabulary *into* the recognizer so it hears the phrases right in the first place.

**Before:** You say _"at workspace slash fix this bug"_ → recognizer mishears it (_"that workspace flash fix..."_) → the rewrite can't match → you get garbled text.

**After:** You say _"at workspace slash fix this bug"_ → recognizer is biased by hints (`at workspace`, `slash fix`) → transcribes it correctly → the existing rewrite turns it into **`@workspace /fix this bug`**.

Same end result, now reliable, because the recognizer knows which developer phrases to expect.

## Changes

- Add optional `context` and `phraseHints` to proposed `SpeechToTextOptions`.
- Thread speech-to-text options through the main thread/ext host speech provider boundary.
- Have voice chat supply agent and slash-command phrase hints from its existing phrase map.
- Add coverage for chat phrase hint propagation.

Refs: https://github.com/microsoft/vscode-internalbacklog/issues/7918

## Validation

- `VS Code - Build` / Core Typecheck: 0 errors
- `./scripts/test.sh --run src/vs/workbench/contrib/chat/test/common/voiceChatService.test.ts --grep VoiceChat`: 4 passing
- `git diff --check`
