### PR TITLE
Regression: Fix execution subagent model setting being ignored (#320231)

### DIFF
--- a/extensions/copilot/src/extension/prompt/node/executionSubagentToolCallingLoop.ts
+++ b/extensions/copilot/src/extension/prompt/node/executionSubagentToolCallingLoop.ts
@@ -10,7 +10,7 @@ import { IChatHookService } from '../../../platform/chat/common/chatHookService'
 import { ChatLocation, ChatResponse } from '../../../platform/chat/common/commonTypes';
 import { ISessionTranscriptService } from '../../../platform/chat/common/sessionTranscriptService';
 import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
-import { ChatEndpointFamily, IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
+import { IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
 import { ProxyAgenticEndpoint } from '../../../platform/endpoint/node/proxyAgenticEndpoint';
 import { IFileSystemService } from '../../../platform/filesystem/common/fileSystemService';
 import { IGitService } from '../../../platform/git/common/gitService';
@@ -113,7 +113,7 @@ export class ExecutionSubagentToolCallingLoop extends ToolCallingLoop<IExecution
 	 * Get the endpoint to use for the execution subagent
 	 */
 	private async getEndpoint() {
-		const modelName = this._configurationService.getExperimentBasedConfig(ConfigKey.Advanced.ExecutionSubagentModel, this._experimentationService) as ChatEndpointFamily | undefined;
+		const modelName = this._configurationService.getExperimentBasedConfig(ConfigKey.Advanced.ExecutionSubagentModel, this._experimentationService);
 		const useAgenticProxy = this._configurationService.getExperimentBasedConfig(ConfigKey.Advanced.ExecutionSubagentUseAgenticProxy, this._experimentationService);
 		const shellType = this.terminalService.terminalShellType;
 

--- a/extensions/copilot/src/extension/prompt/node/searchSubagentToolCallingLoop.ts
+++ b/extensions/copilot/src/extension/prompt/node/searchSubagentToolCallingLoop.ts
@@ -9,7 +9,7 @@ import { IAuthenticationChatUpgradeService } from '../../../platform/authenticat
 import { IChatHookService } from '../../../platform/chat/common/chatHookService';
 import { ChatFetchResponseType, ChatLocation, ChatResponse } from '../../../platform/chat/common/commonTypes';import { ISessionTranscriptService } from '../../../platform/chat/common/sessionTranscriptService';
 import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
-import { ChatEndpointFamily, IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
+import { IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
 import { ProxyAgenticEndpoint } from '../../../platform/endpoint/node/proxyAgenticEndpoint';
 import { IFileSystemService } from '../../../platform/filesystem/common/fileSystemService';
 import { IGitService } from '../../../platform/git/common/gitService';
@@ -98,7 +98,7 @@ export class SearchSubagentToolCallingLoop extends ToolCallingLoop<ISearchSubage
 	 * Get the endpoint to use for the search subagent
 	 */
 	private async getEndpoint() {
-		const modelName = this._configurationService.getExperimentBasedConfig(ConfigKey.Advanced.SearchSubagentModel, this._experimentationService) as ChatEndpointFamily | undefined;
+		const modelName = this._configurationService.getExperimentBasedConfig(ConfigKey.Advanced.SearchSubagentModel, this._experimentationService);
 		const useAgenticProxy = this._configurationService.getExperimentBasedConfig(ConfigKey.Advanced.SearchSubagentUseAgenticProxy, this._experimentationService);
 
 		if (useAgenticProxy) {

--- a/extensions/copilot/src/extension/prompt/node/searchSubagentToolCallingLoop.ts
+++ b/extensions/copilot/src/extension/prompt/node/searchSubagentToolCallingLoop.ts
@@ -110,9 +110,17 @@ export class SearchSubagentToolCallingLoop extends ToolCallingLoop<ISearchSubage
 		if (modelName) {
 			try {
 				// Try to get the specified model
-				return await this.endpointProvider.getChatEndpoint(modelName);
+				const endpoint = await this.endpointProvider.getChatEndpoint(modelName);
+				if (endpoint.supportsToolCalls) {
+					return endpoint;
+				}
+				// Model does not support tool calls, fallback to main agent endpoint.
+				// The search subagent is a tool-calling loop, and the endpoint would
+				// otherwise strip its search tools from the request body.
+				this._logService.warn(`Model ${modelName} does not support tool calls, falling back to main agent endpoint`);
+				return await this.endpointProvider.getChatEndpoint(this.options.request);
 			} catch (error) {
-				// Model not available or doesn't support tool calls, fallback to main agent
+				// Model not available, fallback to main agent
 				this._logService.warn(`Failed to get model ${modelName}, falling back to main agent endpoint: ${error}`);
 				return await this.endpointProvider.getChatEndpoint(this.options.request);
 			}

--- a/extensions/copilot/src/extension/prompt/vscode-node/endpointProviderImpl.ts
+++ b/extensions/copilot/src/extension/prompt/vscode-node/endpointProviderImpl.ts
@@ -6,7 +6,7 @@
 import { LanguageModelChat, lm, type ChatRequest } from 'vscode';
 import { IAuthenticationService } from '../../../platform/authentication/common/authentication';
 import { IConfigurationService } from '../../../platform/configuration/common/configurationService';
-import { ChatEndpointFamily, EmbeddingsEndpointFamily, IChatModelInformation, ICompletionModelInformation, IEmbeddingModelInformation, IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
+import { ChatEndpointFamily, ChatModelFamily, EmbeddingsEndpointFamily, IChatModelInformation, ICompletionModelInformation, IEmbeddingModelInformation, IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
 import { AutoChatEndpoint } from '../../../platform/endpoint/node/autoChatEndpoint';
 import { IAutomodeService } from '../../../platform/endpoint/node/automodeService';
 import { CopilotChatEndpoint, CopilotUtilityChatEndpoint, CopilotUtilitySmallChatEndpoint } from '../../../platform/endpoint/node/copilotChatEndpoint';
@@ -95,7 +95,7 @@ export class ProductionEndpointProvider extends Disposable implements IEndpointP
 		return chatEndpoint;
 	}
 
-	async getChatEndpoint(requestOrFamilyOrModel: LanguageModelChat | ChatRequest | ChatEndpointFamily): Promise<IChatEndpoint> {
+	async getChatEndpoint(requestOrFamilyOrModel: LanguageModelChat | ChatRequest | ChatModelFamily): Promise<IChatEndpoint> {
 		this._logService.trace(`Resolving chat model`);
 
 		if (typeof requestOrFamilyOrModel === 'string') {

--- a/extensions/copilot/src/extension/prompt/vscode-node/endpointProviderImpl.ts
+++ b/extensions/copilot/src/extension/prompt/vscode-node/endpointProviderImpl.ts
@@ -99,7 +99,7 @@ export class ProductionEndpointProvider extends Disposable implements IEndpointP
 		this._logService.trace(`Resolving chat model`);
 
 		if (typeof requestOrFamilyOrModel === 'string') {
-			return this._resolveUtilityFamily(requestOrFamilyOrModel);
+			return this._resolveFamily(requestOrFamilyOrModel);
 		}
 
 		const model = 'model' in requestOrFamilyOrModel ? requestOrFamilyOrModel.model : requestOrFamilyOrModel;
@@ -135,12 +135,28 @@ export class ProductionEndpointProvider extends Disposable implements IEndpointP
 	}
 
 	/**
+	 * Resolves a chat endpoint from a family string. The internal utility
+	 * families (`copilot-utility` / `copilot-utility-small`) are routed through
+	 * their dedicated resolvers; any other value is treated as a CAPI model
+	 * family (e.g. `gemini-3-flash`, `gpt-5-mini`) and resolved directly. This
+	 * lets callers such as the execution and search subagents honor their
+	 * `*.model` override settings rather than silently falling back to the
+	 * parent model.
+	 */
+	private async _resolveFamily(family: string): Promise<IChatEndpoint> {
+		if (family === 'copilot-utility' || family === 'copilot-utility-small') {
+			return this._resolveUtilityFamily(family);
+		}
+		const modelMetadata = await this._modelFetcher.getChatModelFromCapiFamily(family);
+		return this.getOrCreateChatEndpointInstance(modelMetadata);
+	}
+
+	/**
 	 * Resolves an internal utility family (`copilot-utility-small` /
 	 * `copilot-utility`) to a concrete `CopilotChatEndpoint`. The model
 	 * selection for each family lives in the corresponding resolver
 	 * class so callers don't need to know which CAPI family backs each
 	 * purpose.
-
 	 */
 	private async _resolveUtilityFamily(family: ChatEndpointFamily): Promise<IChatEndpoint> {
 		const override = await this._resolveUtilityOverride(family);

--- a/extensions/copilot/src/extension/test/vscode-node/endpoints.test.ts
+++ b/extensions/copilot/src/extension/test/vscode-node/endpoints.test.ts
@@ -9,7 +9,7 @@ import { LanguageModelChat, lm } from 'vscode';
 import { CHAT_MODEL, IConfigurationService } from '../../../platform/configuration/common/configurationService';
 import { InMemoryConfigurationService } from '../../../platform/configuration/test/common/inMemoryConfigurationService';
 import { DefaultsOnlyConfigurationService } from '../../../platform/configuration/common/defaultsOnlyConfigurationService';
-import { IChatModelInformation, ICompletionModelInformation, IEmbeddingModelInformation } from '../../../platform/endpoint/common/endpointProvider';
+import { ChatEndpointFamily, IChatModelInformation, ICompletionModelInformation, IEmbeddingModelInformation } from '../../../platform/endpoint/common/endpointProvider';
 import { IModelMetadataFetcher } from '../../../platform/endpoint/node/modelMetadataFetcher';
 import { CopilotChatEndpoint } from '../../../platform/endpoint/node/copilotChatEndpoint';
 import { ExtensionContributedChatEndpoint } from '../../../platform/endpoint/vscode-node/extChatEndpoint';
@@ -294,5 +294,21 @@ suite('ProductionEndpointProvider — utility model overrides', () => {
 
 		const endpoint = await endpointProvider.getChatEndpoint('copilot-utility');
 		assert.strictEqual(endpoint.model, 'copilot-utility');
+	});
+
+	test('arbitrary CAPI model family resolves to that model (execution/search subagent override)', async () => {
+		// Regression for https://github.com/microsoft/vscode/issues/320231: the
+		// execution and search subagents pass their `*.model` override (e.g.
+		// 'gemini-3-flash') straight to getChatEndpoint(). It must resolve the CAPI
+		// family rather than throwing 'Unrecognized chat endpoint family' and
+		// silently falling back to the parent model.
+		setFetcher([makeChatModel('copilot-utility'), makeChatModel('gemini-3-flash')]);
+
+		// The subagents type the override as a string and cast it to the family
+		// type, so mirror that here.
+		const subagentModel: string = 'gemini-3-flash';
+		const endpoint = await endpointProvider.getChatEndpoint(subagentModel as ChatEndpointFamily);
+		assert.ok(endpoint instanceof CopilotChatEndpoint);
+		assert.strictEqual(endpoint.model, 'gemini-3-flash');
 	});
 });

--- a/extensions/copilot/src/extension/test/vscode-node/endpoints.test.ts
+++ b/extensions/copilot/src/extension/test/vscode-node/endpoints.test.ts
@@ -9,7 +9,7 @@ import { LanguageModelChat, lm } from 'vscode';
 import { CHAT_MODEL, IConfigurationService } from '../../../platform/configuration/common/configurationService';
 import { InMemoryConfigurationService } from '../../../platform/configuration/test/common/inMemoryConfigurationService';
 import { DefaultsOnlyConfigurationService } from '../../../platform/configuration/common/defaultsOnlyConfigurationService';
-import { ChatEndpointFamily, IChatModelInformation, ICompletionModelInformation, IEmbeddingModelInformation } from '../../../platform/endpoint/common/endpointProvider';
+import { IChatModelInformation, ICompletionModelInformation, IEmbeddingModelInformation } from '../../../platform/endpoint/common/endpointProvider';
 import { IModelMetadataFetcher } from '../../../platform/endpoint/node/modelMetadataFetcher';
 import { CopilotChatEndpoint } from '../../../platform/endpoint/node/copilotChatEndpoint';
 import { ExtensionContributedChatEndpoint } from '../../../platform/endpoint/vscode-node/extChatEndpoint';
@@ -302,13 +302,11 @@ suite('ProductionEndpointProvider — utility model overrides', () => {
 		// 'gemini-3-flash') straight to getChatEndpoint(). It must resolve the CAPI
 		// family rather than throwing 'Unrecognized chat endpoint family' and
 		// silently falling back to the parent model.
-		setFetcher([makeChatModel('copilot-utility'), makeChatModel('gemini-3-flash')]);
+		const subagentModel = 'gemini-3-flash';
+		setFetcher([makeChatModel('copilot-utility'), makeChatModel(subagentModel)]);
 
-		// The subagents type the override as a string and cast it to the family
-		// type, so mirror that here.
-		const subagentModel: string = 'gemini-3-flash';
-		const endpoint = await endpointProvider.getChatEndpoint(subagentModel as ChatEndpointFamily);
+		const endpoint = await endpointProvider.getChatEndpoint(subagentModel);
 		assert.ok(endpoint instanceof CopilotChatEndpoint);
-		assert.strictEqual(endpoint.model, 'gemini-3-flash');
+		assert.strictEqual(endpoint.model, subagentModel);
 	});
 });

--- a/extensions/copilot/src/platform/endpoint/common/endpointProvider.ts
+++ b/extensions/copilot/src/platform/endpoint/common/endpointProvider.ts
@@ -154,6 +154,16 @@ export function isCompletionModelInformation(model: IModelAPIResponse): model is
 }
 
 export type ChatEndpointFamily = 'copilot-utility' | 'copilot-utility-small';
+
+/**
+ * A model family accepted by {@link IEndpointProvider.getChatEndpoint}: either
+ * an internal utility alias ({@link ChatEndpointFamily}) or any CAPI model
+ * family id (e.g. `gemini-3-flash`, `gpt-5-mini`). The utility literals are
+ * kept for editor autocomplete while still allowing arbitrary CAPI family
+ * strings.
+ */
+export type ChatModelFamily = ChatEndpointFamily | (string & {});
+
 export type EmbeddingsEndpointFamily = 'text3small' | 'metis';
 
 export interface IEndpointProvider {
@@ -177,9 +187,10 @@ export interface IEndpointProvider {
 
 	/**
 	 * Given a chat request returns the appropriate chat endpoint to serve that request
-	 * @param requestOrFamily The chat request to get the endpoint for, the family you want the endpoint for, or the LanguageModelChat.
+	 * @param requestOrFamily The chat request to get the endpoint for, the model family you want the
+	 * endpoint for (an internal utility alias or any CAPI model family id), or the LanguageModelChat.
 	 */
-	getChatEndpoint(requestOrFamily: LanguageModelChat | ChatRequest | ChatEndpointFamily): Promise<IChatEndpoint>;
+	getChatEndpoint(requestOrFamily: LanguageModelChat | ChatRequest | ChatModelFamily): Promise<IChatEndpoint>;
 
 	/**
 	 * Get the CAPI embedding endpoint information


### PR DESCRIPTION
Fixes #320231

A regression from commit `ef061ccb0fc` ("Rename copilot-fast/copilot-base to copilot-utility-small/copilot-utility"). That change rewrote the string branch of `ProductionEndpointProvider.getChatEndpoint()`:

- **Before:** a family string was resolved against *any* CAPI model family (`getChatModelFromFamily`).
- **After:** it only handled `copilot-utility` / `copilot-utility-small` and **threw** `Unrecognized chat endpoint family` for everything else.

### Fix
Restore arbitrary CAPI family resolution. The string branch now goes through a new `_resolveFamily()` that:
- routes the two internal utility families to their dedicated resolvers, and
- resolves any other family (e.g. `gemini-3-flash`, `gpt-5-mini`) via `getChatModelFromCapiFamily()` — the renamed successor of the old `getChatModelFromFamily()`.
