### PR TITLE
sessions: clarify session navigation command naming

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
@@ -190,6 +190,7 @@ registerAction2(class GoBackAction extends Action2 {
 			},
 			f1: true,
 			icon: Codicon.arrowLeft,
+			tooltip: localize('sessionsGoBackTooltip', "Go Back One Session"),
 			category: SessionsCategories.Sessions,
 			precondition: CanGoBackContext,
 			keybinding: {
@@ -231,6 +232,7 @@ registerAction2(class GoForwardAction extends Action2 {
 			},
 			f1: true,
 			icon: Codicon.arrowRight,
+			tooltip: localize('sessionsGoForwardTooltip', "Go Forward One Session"),
 			category: SessionsCategories.Sessions,
 			precondition: CanGoForwardContext,
 			keybinding: {

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
@@ -233,7 +233,7 @@ registerAction2(class NavigateNextSessionAction extends Action2 {
 			menu: [{
 				id: Menus.GoMenu,
 				group: '2_list_nav',
-				order: 1,
+				order: 2,
 			}]
 		});
 	}

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
@@ -176,7 +176,11 @@ registerAction2(class NavigatePreviousSessionAction extends Action2 {
 	constructor() {
 		super({
 			id: 'sessionsViewPane.navigatePreviousSession',
-			title: localize2('navigatePreviousSession', "Navigate to Previous Session"),
+			title: {
+				value: localize('navigatePreviousSession', "Go to Previous Session"),
+				original: 'Go to Previous Session',
+				mnemonicTitle: localize('navigatePreviousSession.mnemonic', "&&Previous Session"),
+			},
 			f1: true,
 			category: SessionsCategories.Sessions,
 			keybinding: {
@@ -190,7 +194,12 @@ registerAction2(class NavigatePreviousSessionAction extends Action2 {
 				primary: KeyMod.CtrlCmd | KeyCode.PageUp,
 				secondary: [KeyMod.Alt | KeyCode.UpArrow],
 				mac: { primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.LeftArrow, secondary: [KeyMod.Alt | KeyCode.UpArrow] },
-			}
+			},
+			menu: [{
+				id: Menus.GoMenu,
+				group: '2_list_nav',
+				order: 2,
+			}]
 		});
 	}
 	override run(accessor: ServicesAccessor): Promise<void> {
@@ -202,7 +211,11 @@ registerAction2(class NavigateNextSessionAction extends Action2 {
 	constructor() {
 		super({
 			id: 'sessionsViewPane.navigateNextSession',
-			title: localize2('navigateNextSession', "Navigate to Next Session"),
+			title: {
+				value: localize('navigateNextSession', "Go to Next Session"),
+				original: 'Go to Next Session',
+				mnemonicTitle: localize('navigateNextSession.mnemonic', "&&Next Session"),
+			},
 			f1: true,
 			category: SessionsCategories.Sessions,
 			keybinding: {
@@ -216,7 +229,12 @@ registerAction2(class NavigateNextSessionAction extends Action2 {
 				primary: KeyMod.CtrlCmd | KeyCode.PageDown,
 				secondary: [KeyMod.Alt | KeyCode.DownArrow],
 				mac: { primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.RightArrow, secondary: [KeyMod.Alt | KeyCode.DownArrow] },
-			}
+			},
+			menu: [{
+				id: Menus.GoMenu,
+				group: '2_list_nav',
+				order: 1,
+			}]
 		});
 	}
 	override run(accessor: ServicesAccessor): Promise<void> {

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
@@ -198,7 +198,7 @@ registerAction2(class NavigatePreviousSessionAction extends Action2 {
 			menu: [{
 				id: Menus.GoMenu,
 				group: '2_list_nav',
-				order: 2,
+				order: 1,
 			}]
 		});
 	}


### PR DESCRIPTION
Fixes #320466

### What changed
There were two distinct pairs of session-navigation commands that were easy to confuse:

- **History navigation** (recency stack): `Go Back` / `Go Forward`
- **List-position navigation** (move up/down the visible list): `Navigate to Previous Session` / `Navigate to Next Session`

This PR keeps all four commands but makes each explicit and surfaces them together in the **Go** menu:

- Added `Go Back One Session` / `Go Forward One Session` **tooltips** to the history Back/Forward titlebar arrow buttons, while keeping the concise `Go Back` / `Go Forward` titles in the Go menu and command palette.
- Renamed the list-position commands to **`Navigate to Previous Session in List`** / **`Navigate to Next Session in List`**.
- Added the list-position commands to `Menus.GoMenu` under a separate `2_list_nav` group (history actions remain in `1_history_nav`), so all four are discoverable together.

### Notes for reviewers
- All changes are confined to `src/vs/sessions/`.
- Keybindings are unchanged.
- `compile-check-ts-native` and `valid-layers-check` pass.