### PR TITLE
sessions: hide Mark as Done action on new session view

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
@@ -20,7 +20,7 @@ import { CLOSE_MOBILE_SIDEBAR_DRAWER_COMMAND_ID } from '../../../../browser/work
 import { EditorsVisibleContext, EditorAreaFocusContext, IsSessionsWindowContext } from '../../../../../workbench/common/contextkeys.js';
 import { ANY_AGENT_HOST_PROVIDER_RE } from '../../../../common/agentHostSessionsProvider.js';
 import { SessionsCategories } from '../../../../common/categories.js';
-import { ChatSessionProviderIdContext, IsActiveSessionArchivedContext, IsNewChatSessionContext, SessionIsArchivedContext, SessionIsReadContext } from '../../../../common/contextkeys.js';
+import { ChatSessionProviderIdContext, IsActiveSessionArchivedContext, IsNewChatSessionContext, SessionIsArchivedContext, SessionIsCreatedContext, SessionIsReadContext } from '../../../../common/contextkeys.js';
 import { SessionItemToolbarMenuId, SessionItemContextMenuId, SessionSectionToolbarMenuId, SessionSectionTypeContext, IsSessionPinnedContext, SessionsGrouping, SessionsSorting, ISessionSection } from './sessionsList.js';
 import { ISession, SessionStatus } from '../../../../services/sessions/common/session.js';
 import { IsWorkspaceGroupCappedContext, SessionsViewFilterOptionsSubMenu, SessionsViewFilterSubMenu, SessionsViewGroupingContext, SessionsViewId, SessionsView, SessionsViewSortingContext, openSessionToTheSide } from './sessionsView.js';
@@ -685,7 +685,7 @@ registerAction2(class ArchiveSessionAction extends Action2 {
 				id: Menus.SessionBarToolbar,
 				group: 'navigation',
 				order: 15,
-				when: ContextKeyExpr.equals(SessionIsArchivedContext.key, false),
+				when: ContextKeyExpr.and(SessionIsCreatedContext, ContextKeyExpr.equals(SessionIsArchivedContext.key, false)),
 			}]
 		});
 	}


### PR DESCRIPTION
## What

The `ArchiveSessionAction` (titled **"Mark as Done"**, id `sessionsViewPane.archiveSession`) was incorrectly shown on the **new session view**.

## Why

The action renders on the per-session header toolbar (`Menus.SessionBarToolbar`) with a `when` clause that only checked `SessionIsArchivedContext == false`. Since `SessionIsArchivedContext` defaults to `false`, the action also appeared on the new-session view, where no session has been created yet.

## Fix

Gate the `SessionBarToolbar` menu entry with `SessionIsCreatedContext` so the action only appears once the session has actually been created. The list item / context menu entries are unaffected.

## Notes for reviewers

- `SessionIsCreatedContext` is bound in the session view's scoped context key service (`sessionView.ts`) and is `false` until the session is created.
- `compile-check-ts-native` and `valid-layers-check` pass.