### PR TITLE
Fix WSL remote agent host lifecycle

### DIFF
--- a/src/vs/platform/agentHost/browser/nullWslRemoteAgentHostService.ts
+++ b/src/vs/platform/agentHost/browser/nullWslRemoteAgentHostService.ts
@@ -7,6 +7,7 @@ import { Event } from '../../../base/common/event.js';
 import type {
 	IWSLAgentHostConfig,
 	IWSLAgentHostConnection,
+	IWSLCachedDistro,
 	IWSLConnectProgress,
 	IWSLDistro,
 	IWSLRemoteAgentHostService,
@@ -44,5 +45,9 @@ export class NullWSLRemoteAgentHostService implements IWSLRemoteAgentHostService
 
 	async reconnect(_distro: string, _name: string): Promise<IWSLAgentHostConnection> {
 		throw new Error('WSL is not available on this platform.');
+	}
+
+	getCachedDistros(): readonly IWSLCachedDistro[] {
+		return [];
 	}
 }

--- a/src/vs/platform/agentHost/common/remoteAgentHostService.ts
+++ b/src/vs/platform/agentHost/common/remoteAgentHostService.ts
@@ -423,21 +423,9 @@ export interface IRawRemoteAgentHostEntry {
 	readonly sshHostName?: string;
 	readonly sshUser?: string;
 	readonly sshPort?: number;
-	readonly wslDistro?: string;
 }
 
 export function rawEntryToEntry(raw: IRawRemoteAgentHostEntry): IRemoteAgentHostEntry | undefined {
-	if (raw.wslDistro) {
-		return {
-			name: raw.name,
-			connectionToken: raw.connectionToken,
-			connection: {
-				type: RemoteAgentHostEntryType.WSL,
-				address: raw.address,
-				distro: raw.wslDistro,
-			},
-		};
-	}
 	if (raw.sshConfigHost || raw.sshHostName || raw.sshUser || raw.sshPort) {
 		return {
 			name: raw.name,
@@ -474,19 +462,13 @@ export function entryToRawEntry(entry: IRemoteAgentHostEntry): IRawRemoteAgentHo
 				sshUser: entry.connection.user,
 				sshPort: entry.connection.port,
 			};
-		case RemoteAgentHostEntryType.WSL:
-			return {
-				address: entry.connection.address,
-				name: entry.name,
-				connectionToken: entry.connectionToken,
-				wslDistro: entry.connection.distro,
-			};
 		case RemoteAgentHostEntryType.WebSocket:
 			return {
 				address: entry.connection.address,
 				name: entry.name,
 				connectionToken: entry.connectionToken,
 			};
+		case RemoteAgentHostEntryType.WSL:
 		case RemoteAgentHostEntryType.Tunnel:
 			return undefined;
 	}

--- a/src/vs/platform/agentHost/common/wslRemoteAgentHost.ts
+++ b/src/vs/platform/agentHost/common/wslRemoteAgentHost.ts
@@ -16,6 +16,13 @@ export const WSL_REMOTE_AGENT_HOST_CHANNEL = 'wslRemoteAgentHost';
 export const WSL_INSTALL_DOCS_URL = 'https://aka.ms/vscode-remote/wsl/install-wsl';
 
 /**
+ * Prefix for WSL display addresses (`wsl:<distro>`). This is NOT a `ws://`
+ * URL — it identifies a managed WSL connection and must never be funneled
+ * into the raw WebSocket connect path.
+ */
+export const WSL_ADDRESS_PREFIX = 'wsl:';
+
+/**
  * A WSL distribution discovered via `wsl --list`. Only WSL 2 distros are
  * surfaced — WSL 1 lacks the kernel features needed to host the agent.
  */
@@ -55,6 +62,19 @@ export interface IWSLAgentHostConnection extends IDisposable {
 	readonly onDidClose: Event<void>;
 }
 
+/**
+ * A WSL distro the user has connected to during this or a previous window.
+ * Persisted by {@link IWSLRemoteAgentHostService} so the startup
+ * auto-reconnect loop knows which running distros to re-attach to. This is
+ * the WSL analogue of the tunnel service's cached-tunnels list — WSL
+ * connections are managed in-memory and are never written to the remote
+ * agent hosts setting.
+ */
+export interface IWSLCachedDistro {
+	readonly distro: string;
+	readonly name: string;
+}
+
 export const IWSLRemoteAgentHostService = createDecorator<IWSLRemoteAgentHostService>('wslRemoteAgentHostService');
 
 /**
@@ -78,6 +98,12 @@ export interface IWSLRemoteAgentHostService {
 	disconnect(distro: string): Promise<void>;
 	/** Used by the contribution's auto-reconnect loop on startup. */
 	reconnect(distro: string, name: string): Promise<IWSLAgentHostConnection>;
+	/**
+	 * Distros the user has connected to, persisted across windows. Drives the
+	 * startup auto-reconnect loop. WSL connections themselves live in-memory,
+	 * mirroring how tunnels are handled.
+	 */
+	getCachedDistros(): readonly IWSLCachedDistro[];
 }
 
 export const IWSLRemoteAgentHostMainService = createDecorator<IWSLRemoteAgentHostMainService>('wslRemoteAgentHostMainService');

--- a/src/vs/platform/agentHost/electron-browser/wslRemoteAgentHostServiceImpl.ts
+++ b/src/vs/platform/agentHost/electron-browser/wslRemoteAgentHostServiceImpl.ts
@@ -4,11 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Emitter, Event } from '../../../base/common/event.js';
+import { localize } from '../../../nls.js';
 import { Disposable, IDisposable, toDisposable } from '../../../base/common/lifecycle.js';
 import { ILogService } from '../../log/common/log.js';
 import { IConfigurationService } from '../../configuration/common/configuration.js';
 import { IEnvironmentService } from '../../environment/common/environment.js';
 import { ISharedProcessService } from '../../ipc/electron-browser/services.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../storage/common/storage.js';
 import { ProxyChannel } from '../../../base/parts/ipc/common/ipc.js';
 import { IRemoteAgentHostService, RemoteAgentHostEntryType, RemoteAgentHostsEnabledSettingId, type IRemoteAgentHostEntry } from '../common/remoteAgentHostService.js';
 import { createDecorator, IInstantiationService } from '../../instantiation/common/instantiation.js';
@@ -21,6 +23,7 @@ import {
 	WSL_REMOTE_AGENT_HOST_CHANNEL,
 	type IWSLAgentHostConfig,
 	type IWSLAgentHostConnection,
+	type IWSLCachedDistro,
 	type IWSLConnectProgress,
 	type IWSLConnectResult,
 	type IWSLDistro,
@@ -55,6 +58,13 @@ export class WSLRelayClientFactory implements IWSLRelayClientFactory {
 }
 
 /**
+ * Storage key for the list of WSL distros the user has connected to. Lives
+ * at application scope so it is shared across windows, mirroring the tunnel
+ * service's cached-tunnels list.
+ */
+const CACHED_WSL_DISTROS_KEY = 'agentHost.wsl.cachedDistros';
+
+/**
  * Renderer-side implementation of {@link IWSLRemoteAgentHostService} that
  * delegates the actual WSL work to the main process via IPC, then registers
  * the resulting connection with the renderer-local {@link IRemoteAgentHostService}.
@@ -67,6 +77,7 @@ export class WSLRemoteAgentHostService extends Disposable implements IWSLRemoteA
 	private readonly _onDidChangeConnections = this._register(new Emitter<void>());
 	readonly onDidChangeConnections: Event<void> = this._onDidChangeConnections.event;
 
+	private readonly _onDidReportLocalConnectProgress = this._register(new Emitter<IWSLConnectProgress>());
 	readonly onDidReportConnectProgress: Event<IWSLConnectProgress>;
 
 	private readonly _connections = new Map<string, WSLAgentHostConnectionHandle>();
@@ -77,6 +88,7 @@ export class WSLRemoteAgentHostService extends Disposable implements IWSLRemoteA
 		@ILogService private readonly _logService: ILogService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IWSLRelayClientFactory private readonly _relayClientFactory: IWSLRelayClientFactory,
+		@IStorageService private readonly _storageService: IStorageService,
 	) {
 		super();
 
@@ -84,7 +96,7 @@ export class WSLRemoteAgentHostService extends Disposable implements IWSLRemoteA
 			sharedProcessService.getChannel(WSL_REMOTE_AGENT_HOST_CHANNEL),
 		);
 
-		this.onDidReportConnectProgress = this._mainService.onDidReportConnectProgress;
+		this.onDidReportConnectProgress = Event.any(this._mainService.onDidReportConnectProgress, this._onDidReportLocalConnectProgress.event);
 
 		this._register(this._mainService.onDidCloseConnection(connectionId => {
 			this._logService.info(`[WSLRemoteAgentHost] onDidCloseConnection: connectionId=${connectionId}`);
@@ -117,7 +129,9 @@ export class WSLRemoteAgentHostService extends Disposable implements IWSLRemoteA
 	}
 
 	async listDistros(): Promise<IWSLDistro[]> {
-		return this._mainService.listDistros();
+		const distros = await this._mainService.listDistros();
+		this._evictMissingCachedDistros(distros);
+		return distros;
 	}
 
 	async listRunningDistros(): Promise<string[]> {
@@ -137,6 +151,7 @@ export class WSLRemoteAgentHostService extends Disposable implements IWSLRemoteA
 	}
 
 	async disconnect(distro: string): Promise<void> {
+		this._removeCachedDistro(distro);
 		await this._mainService.disconnect(distro);
 	}
 
@@ -159,17 +174,33 @@ export class WSLRemoteAgentHostService extends Disposable implements IWSLRemoteA
 	private async _setupConnection(result: IWSLConnectResult): Promise<IWSLAgentHostConnection> {
 		const existing = this._connections.get(result.connectionId);
 		if (existing) {
-			this._logService.trace('[WSLRemoteAgentHost] Returning existing connection handle');
-			return existing;
+			if (this._remoteAgentHostService.getConnection(result.address)) {
+				this._logService.trace(`[WSLRemoteAgentHost] Returning existing connection handle for ${result.address}, connectionId=${result.connectionId}`);
+				return existing;
+			}
+			this._logService.info(`[WSLRemoteAgentHost] Replacing stale connection handle for ${result.address}, connectionId=${result.connectionId}`);
+			this._connections.delete(result.connectionId);
+			existing.fireClose();
+			existing.dispose();
+			this._onDidChangeConnections.fire();
 		}
 
 		let protocolClient: RemoteAgentHostProtocolClient | undefined;
 		let handle: WSLAgentHostConnectionHandle | undefined;
 		let registeredHandle = false;
 		try {
+			this._onDidReportLocalConnectProgress.fire({
+				connectionKey: result.address,
+				message: localize('wslProgressHandshake', "Establishing connection to {0}...", result.name),
+			});
 			protocolClient = this._relayClientFactory.createClient(this._mainService, result.connectionId, result.address);
 			await protocolClient.connect();
 			this._logService.trace('[WSLRemoteAgentHost] Protocol handshake completed');
+
+			this._onDidReportLocalConnectProgress.fire({
+				connectionKey: result.address,
+				message: localize('wslProgressFinalizing', "Provisioning agent host in {0}...", result.name),
+			});
 
 			handle = new WSLAgentHostConnectionHandle(
 				result.distro,
@@ -192,6 +223,8 @@ export class WSLRemoteAgentHostService extends Disposable implements IWSLRemoteA
 				},
 			};
 
+			this._cacheDistro(result.distro, result.name);
+
 			await this._remoteAgentHostService.addManagedConnection(entry, protocolClient, this._createTransportDisposable(result.connectionId, result.distro, handle));
 
 			return handle;
@@ -205,6 +238,61 @@ export class WSLRemoteAgentHostService extends Disposable implements IWSLRemoteA
 			protocolClient?.dispose();
 			this._mainService.disconnect(result.distro).catch(() => { /* best effort */ });
 			throw err;
+		}
+	}
+
+	getCachedDistros(): readonly IWSLCachedDistro[] {
+		const raw = this._storageService.get(CACHED_WSL_DISTROS_KEY, StorageScope.APPLICATION);
+		if (!raw) {
+			return [];
+		}
+		try {
+			const parsed: unknown = JSON.parse(raw);
+			if (!Array.isArray(parsed)) {
+				return [];
+			}
+			return parsed.filter((item): item is IWSLCachedDistro =>
+				!!item && typeof item.distro === 'string' && typeof item.name === 'string');
+		} catch {
+			return [];
+		}
+	}
+
+	private _cacheDistro(distro: string, name: string): void {
+		const cached = this.getCachedDistros().filter(d => d.distro !== distro);
+		this._storeCachedDistros([{ distro, name }, ...cached]);
+	}
+
+	private _removeCachedDistro(distro: string): void {
+		const cached = this.getCachedDistros();
+		const filtered = cached.filter(d => d.distro !== distro);
+		if (filtered.length !== cached.length) {
+			this._storeCachedDistros(filtered);
+		}
+	}
+
+	/**
+	 * Drop cached distros that no longer exist (e.g. uninstalled). We only
+	 * prune when we actually observed some distros, so a transient probe
+	 * failure (which surfaces as an empty list) never wipes the cache.
+	 */
+	private _evictMissingCachedDistros(distros: readonly IWSLDistro[]): void {
+		if (distros.length === 0) {
+			return;
+		}
+		const existing = new Set(distros.map(d => d.name));
+		const cached = this.getCachedDistros();
+		const filtered = cached.filter(d => existing.has(d.distro));
+		if (filtered.length !== cached.length) {
+			this._storeCachedDistros(filtered);
+		}
+	}
+
+	private _storeCachedDistros(distros: readonly IWSLCachedDistro[]): void {
+		if (distros.length === 0) {
+			this._storageService.remove(CACHED_WSL_DISTROS_KEY, StorageScope.APPLICATION);
+		} else {
+			this._storageService.store(CACHED_WSL_DISTROS_KEY, JSON.stringify(distros), StorageScope.APPLICATION, StorageTarget.USER);
 		}
 	}
 

--- a/src/vs/platform/agentHost/node/wslRemoteAgentHostService.ts
+++ b/src/vs/platform/agentHost/node/wslRemoteAgentHostService.ts
@@ -327,17 +327,6 @@ export class WSLRemoteAgentHostMainService extends Disposable implements IWSLRem
 		this._connections.set(connectionId, connection);
 		this._distroToConnectionId.set(distro, connectionId);
 
-		// Defense-in-depth: if the child dies after we've registered, surface
-		// the close. The ws will usually emit `close` first when the agent
-		// host exits cleanly, but a hard kill (e.g. WSL shutdown) can take
-		// the child down without a clean WebSocket close frame.
-		// Registered after `_connections.set` so a synchronous exit on the
-		// same tick can't race the map insert.
-		child.on('exit', (code, signal) => {
-			this._logService.info(`${LOG_PREFIX} Agent host child for ${connectionKey} exited (code=${code}, signal=${signal})`);
-			this._closeConnection(connectionId);
-		});
-
 		this._onDidChangeConnections.fire();
 
 		return {
@@ -419,7 +408,7 @@ export class WSLRemoteAgentHostMainService extends Disposable implements IWSLRem
 	private async _resolvePlatform(distro: string): Promise<{ os: string; arch: string }> {
 		const result = await runWslCommand(['-e', 'uname', '-s', '-m'], { distro, timeout: 10_000 });
 		if (result.exitCode !== 0) {
-			throw new Error(`${LOG_PREFIX} Failed to detect platform in '${distro}' (exit ${result.exitCode}): ${result.stderr.trim()}`);
+			throw new Error(`${LOG_PREFIX} Failed to detect platform in '${distro}' (exit ${result.exitCode}): ${result.stderr.trim() || result.stdout.trim()}`);
 		}
 		const tokens = result.stdout.trim().split(/\s+/);
 		if (tokens.length < 2) {

--- a/src/vs/sessions/common/agentHostSessionsProvider.ts
+++ b/src/vs/sessions/common/agentHostSessionsProvider.ts
@@ -13,6 +13,14 @@ import { ISessionsProvider } from '../services/sessions/common/sessionsProvider.
 import { ISessionAgentRef } from '../services/sessions/common/session.js';
 
 /**
+ * Progress emitted while an agent-host provider is establishing a connection.
+ */
+export interface IAgentHostConnectProgress {
+	readonly connectionKey: string;
+	readonly message: string;
+}
+
+/**
  * Extended sessions provider for agent host providers (local and remote).
  * Adds remote connection properties and dynamic session configuration.
  */
@@ -20,6 +28,8 @@ export interface IAgentHostSessionsProvider extends ISessionsProvider {
 	// -- Remote Connection (optional, used by remote agent host providers) --
 	/** Connection status observable, present on remote providers. */
 	readonly connectionStatus?: IObservable<RemoteAgentHostConnectionStatus>;
+	/** Progress messages during on-demand connect. */
+	readonly onDidReportConnectProgress?: Event<IAgentHostConnectProgress>;
 	/** Remote address string, present on remote providers. */
 	readonly remoteAddress?: string;
 	/**

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -5,6 +5,7 @@
 
 import * as dom from '../../../../base/browser/dom.js';
 import * as touch from '../../../../base/browser/touch.js';
+import { status } from '../../../../base/browser/ui/aria/aria.js';
 import { IAction, toAction } from '../../../../base/common/actions.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
@@ -26,6 +27,7 @@ import { IContextKeyService, IContextKey } from '../../../../platform/contextkey
 import { IFileDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
+import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
 import { renderIcon } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { ISessionWorkspace, ISessionWorkspaceBrowseAction, SESSION_WORKSPACE_GROUP_LOCAL, SESSION_WORKSPACE_GROUP_REMOTE } from '../../../services/sessions/common/session.js';
@@ -190,6 +192,7 @@ export class WorkspacePicker extends Disposable {
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IFileDialogService private readonly fileDialogService: IFileDialogService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
+		@INotificationService private readonly notificationService: INotificationService,
 	) {
 		super();
 
@@ -382,7 +385,7 @@ export class WorkspacePicker extends Disposable {
 		return {
 			onSelect: (item) => {
 				hide();
-				this._dispatchPickerItem(item);
+				void this._dispatchPickerItem(item);
 			},
 			onHide: () => {
 				triggerElement.setAttribute('aria-expanded', 'false');
@@ -472,7 +475,7 @@ export class WorkspacePicker extends Disposable {
 	 * subclass that opts to render a different UI but reuse the
 	 * selection semantics. Treats unavailable workspaces as a no-op.
 	 */
-	protected _dispatchPickerItem(item: IWorkspacePickerItem): void {
+	protected async _dispatchPickerItem(item: IWorkspacePickerItem): Promise<void> {
 		this._reportPickerClosed(item);
 		if (item.run) {
 			item.run();
@@ -485,6 +488,9 @@ export class WorkspacePicker extends Disposable {
 		if (item.browseActionIndex !== undefined) {
 			this._executeBrowseAction(item.browseActionIndex);
 		} else if (item.folderUri) {
+			if (item.providerId && !await this._connectProviderOnDemand(item.providerId)) {
+				return;
+			}
 			this._selectFolder(item.folderUri);
 		}
 	}
@@ -730,9 +736,6 @@ export class WorkspacePicker extends Disposable {
 		for (let i = 0; i < recentWorkspaces.length; i++) {
 			const { workspace, providerId } = recentWorkspaces[i];
 			const isOwnRecent = i < ownRecentCount;
-			const provider = allProviders.find(p => p.id === providerId);
-			const connectionStatus = provider && isAgentHostProvider(provider) ? provider.connectionStatus?.get() : undefined;
-			const isDisconnected = RemoteAgentHostConnectionStatus.isDisconnected(connectionStatus) || RemoteAgentHostConnectionStatus.isIncompatible(connectionStatus);
 			const folderUri = workspace.folders[0]?.root;
 			if (!folderUri) {
 				continue;
@@ -743,7 +746,7 @@ export class WorkspacePicker extends Disposable {
 				label: workspace.label,
 				description: workspace.description,
 				group: { title: '', icon: workspace.icon },
-				disabled: isDisconnected,
+				disabled: this._isProviderUnavailable(providerId),
 				item: { folderUri, providerId, checked: selected || undefined },
 				onRemove: isOwnRecent ? () => this._removeRecentWorkspace(folderUri) : () => this._removeVSCodeRecentWorkspace(folderUri),
 			});
@@ -879,7 +882,7 @@ export class WorkspacePicker extends Disposable {
 
 	/**
 	 * Returns whether the given provider is a remote that is currently unavailable
-	 * (disconnected or still connecting).
+	 * (incompatible, or disconnected/still connecting without on-demand connect).
 	 * Returns false for providers without connection status (e.g. local providers).
 	 */
 	protected _isProviderUnavailable(providerId: string): boolean {
@@ -887,7 +890,52 @@ export class WorkspacePicker extends Disposable {
 		if (!provider || !isAgentHostProvider(provider) || !provider.connectionStatus) {
 			return false;
 		}
-		return !RemoteAgentHostConnectionStatus.isConnected(provider.connectionStatus.get());
+		const connectionStatus = provider.connectionStatus.get();
+		return RemoteAgentHostConnectionStatus.isIncompatible(connectionStatus)
+			|| (!RemoteAgentHostConnectionStatus.isConnected(connectionStatus) && !provider.canConnectOnDemand);
+	}
+
+	private async _connectProviderOnDemand(providerId: string): Promise<boolean> {
+		const provider = this.sessionsProvidersService.getProvider(providerId);
+		if (!provider || !isAgentHostProvider(provider) || !provider.connectionStatus) {
+			return true;
+		}
+		const connectionStatus = provider.connectionStatus.get();
+		if (RemoteAgentHostConnectionStatus.isConnected(connectionStatus)) {
+			return true;
+		}
+		if (RemoteAgentHostConnectionStatus.isIncompatible(connectionStatus) || !provider.canConnectOnDemand || !provider.connect) {
+			return false;
+		}
+		const initialMessage = localize('workspacePicker.connectingRemoteAgentHost', "Connecting to {0}...", provider.label);
+		const handle = this.notificationService.notify({
+			severity: Severity.Info,
+			message: initialMessage,
+			progress: { infinite: true },
+		});
+		status(initialMessage);
+		const progressListener = provider.onDidReportConnectProgress?.(progress => {
+			if (!provider.remoteAddress || progress.connectionKey === provider.remoteAddress) {
+				handle.updateMessage(progress.message);
+				status(progress.message);
+			}
+		});
+		let connected = false;
+		try {
+			await provider.connect();
+			connected = RemoteAgentHostConnectionStatus.isConnected(provider.connectionStatus.get());
+		} catch {
+		} finally {
+			progressListener?.dispose();
+			handle.close();
+		}
+		if (connected) {
+			return true;
+		}
+		const message = localize('workspacePicker.connectRemoteAgentHostFailed', "Failed to connect to {0}.", provider.label);
+		this.notificationService.error(message);
+		status(message);
+		return false;
 	}
 
 	protected _isSelectedFolder(folderUri: URI | undefined): boolean {

--- a/src/vs/sessions/contrib/chat/browser/webWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/webWorkspacePicker.ts
@@ -18,12 +18,12 @@ import { INotificationService } from '../../../../platform/notification/common/n
 import { IStorageService } from '../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
+import { IWorkspacesService } from '../../../../platform/workspaces/common/workspaces.js';
 import { IWorkbenchLayoutService } from '../../../../workbench/services/layout/browser/layoutService.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
 import { IAgentHostFilterService } from '../../../services/agentHostFilter/common/agentHostFilter.js';
 import { IWorkspacePickerItem, WorkspacePicker } from './sessionWorkspacePicker.js';
 import { showMobileWorkspacePickerSheet, shouldUseMobileWorkspacePickerSheet } from './mobile/mobileWorkspacePickerSheet.js';
-import { IWorkspacesService } from '../../../../platform/workspaces/common/workspaces.js';
 
 /**
  * Web variant of {@link WorkspacePicker} for the Agents window's

--- a/src/vs/sessions/contrib/chat/browser/webWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/webWorkspacePicker.ts
@@ -14,6 +14,7 @@ import { IConfigurationService } from '../../../../platform/configuration/common
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { IFileDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { IStorageService } from '../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
@@ -58,6 +59,7 @@ export class WebWorkspacePicker extends WorkspacePicker {
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IFileDialogService fileDialogService: IFileDialogService,
 		@ITelemetryService telemetryService: ITelemetryService,
+		@INotificationService notificationService: INotificationService,
 		@IAgentHostFilterService private readonly _agentHostFilterService: IAgentHostFilterService,
 		@IWorkbenchLayoutService private readonly _layoutService: IWorkbenchLayoutService,
 	) {
@@ -75,6 +77,7 @@ export class WebWorkspacePicker extends WorkspacePicker {
 			instantiationService,
 			fileDialogService,
 			telemetryService,
+			notificationService,
 		);
 
 		// When the scoped host changes, if the current selection no longer

--- a/src/vs/sessions/contrib/chat/test/browser/sessionWorkspacePicker.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionWorkspacePicker.test.ts
@@ -39,6 +39,8 @@ import { IFileDialogService } from '../../../../../platform/dialogs/common/dialo
 import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { MockContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
 import { IMenuService } from '../../../../../platform/actions/common/actions.js';
+import { INotification, INotificationHandle, INotificationService, NoOpNotification, NotificationMessage } from '../../../../../platform/notification/common/notification.js';
+import { TestNotificationService } from '../../../../../platform/notification/test/common/testNotificationService.js';
 
 // ---- Storage key (must match the one in sessionWorkspacePicker.ts) ----------
 const STORAGE_KEY_RECENT_WORKSPACES = 'sessions.recentlyPickedWorkspaces';
@@ -59,6 +61,10 @@ const MOCK_PROVIDER_PATH_PREFIXES: Record<string, string> = {
 function createMockProvider(id: string, opts?: {
 	connectionStatus?: ISettableObservable<RemoteAgentHostConnectionStatus>;
 	browseActions?: readonly ISessionWorkspaceBrowseAction[];
+	canConnectOnDemand?: boolean;
+	connect?: () => Promise<void>;
+	onDidReportConnectProgress?: Event<{ readonly connectionKey: string; readonly message: string }>;
+	remoteAddress?: string;
 }): ISessionsProvider {
 	const pathPrefix = MOCK_PROVIDER_PATH_PREFIXES[id];
 	const canResolve = (uri: URI) => !pathPrefix || uri.path === pathPrefix || uri.path.startsWith(`${pathPrefix}/`);
@@ -109,7 +115,11 @@ function createMockProvider(id: string, opts?: {
 	if (opts?.connectionStatus) {
 		return {
 			...base,
+			canConnectOnDemand: opts.canConnectOnDemand,
+			connect: opts.connect,
 			connectionStatus: opts.connectionStatus,
+			onDidReportConnectProgress: opts.onDidReportConnectProgress,
+			remoteAddress: opts.remoteAddress,
 			onDidChangeSessionConfig: Event.None,
 			getSessionConfig: () => undefined,
 			setSessionConfigValue: async () => { },
@@ -154,6 +164,46 @@ class MockSessionsProvidersService extends Disposable {
 	}
 }
 
+class RecordingNotificationHandle extends NoOpNotification {
+	closed = false;
+	messages: NotificationMessage[] = [];
+
+	constructor(message: NotificationMessage) {
+		super();
+		this.messages.push(message);
+	}
+
+	override updateMessage(message: NotificationMessage): void {
+		this.messages.push(message);
+	}
+
+	override close(): void {
+		this.closed = true;
+	}
+}
+
+class RecordingNotificationService extends TestNotificationService {
+	readonly handles: RecordingNotificationHandle[] = [];
+	readonly errors: Array<string | Error> = [];
+
+	override notify(notification: INotification): INotificationHandle {
+		const handle = new RecordingNotificationHandle(notification.message);
+		this.handles.push(handle);
+		return handle;
+	}
+
+	override error(error: string | Error): INotificationHandle {
+		this.errors.push(error);
+		return super.error(error);
+	}
+}
+
+class DispatchingWorkspacePicker extends WorkspacePicker {
+	dispatchFolder(folderUri: URI, providerId: string): Promise<void> {
+		return this._dispatchPickerItem({ folderUri, providerId });
+	}
+}
+
 // ---- Test helpers -----------------------------------------------------------
 
 function seedStorage(storageService: IStorageService, entries: { uri: URI; providerId: string; checked: boolean }[]): void {
@@ -169,6 +219,8 @@ function createTestPicker(
 	disposables: DisposableStore,
 	providersService: MockSessionsProvidersService,
 	storageService?: IStorageService,
+	notificationService: INotificationService = new TestNotificationService(),
+	pickerCtor: typeof WorkspacePicker = WorkspacePicker,
 ): WorkspacePicker {
 	const instantiationService = disposables.add(new TestInstantiationService());
 	const storage = storageService ?? disposables.add(new TestStorageService());
@@ -188,13 +240,14 @@ function createTestPicker(
 	instantiationService.stub(IFileDialogService, {});
 	instantiationService.stub(IContextKeyService, new MockContextKeyService());
 	instantiationService.stub(IMenuService, { createMenu: () => ({ onDidChange: Event.None, getActions: () => [], dispose: () => { } }) });
+	instantiationService.stub(INotificationService, notificationService);
 	instantiationService.stub(IWorkspacesService, {
 		getRecentlyOpened: async () => ({ workspaces: [], files: [] }),
 		onDidChangeRecentlyOpened: Event.None,
 	});
 	instantiationService.stub(ITelemetryService, NullTelemetryService);
 
-	return disposables.add(instantiationService.createInstance(WorkspacePicker));
+	return disposables.add(instantiationService.createInstance(pickerCtor));
 }
 
 // ---- Assertion helpers ------------------------------------------------------
@@ -407,6 +460,44 @@ suite('WorkspacePicker - Connection Status', () => {
 		// Disconnect — selection is preserved (the user picked it; we keep honoring it).
 		remoteStatus.set(RemoteAgentHostConnectionStatus.disconnected, undefined);
 		assertSelectedProvider(picker, 'agenthost-remote-1', 'Selection should be preserved on disconnect');
+	});
+
+	test('failed on-demand recent connect closes progress notification and reports error', async () => {
+		const remoteStatus = observableValue<RemoteAgentHostConnectionStatus>('status', RemoteAgentHostConnectionStatus.disconnected);
+		const progress = new Emitter<{ readonly connectionKey: string; readonly message: string }>();
+		disposables.add(progress);
+		let connectCalls = 0;
+		const remoteProvider = createMockProvider('agenthost-remote-1', {
+			connectionStatus: remoteStatus,
+			canConnectOnDemand: true,
+			remoteAddress: 'wsl:Ubuntu-24.04',
+			onDidReportConnectProgress: progress.event,
+			connect: async () => {
+				connectCalls++;
+				progress.fire({ connectionKey: 'wsl:Ubuntu-24.04', message: 'Opening WSL...' });
+				throw new Error('boom');
+			},
+		});
+		const notifications = new RecordingNotificationService();
+
+		providersService.setProviders([remoteProvider]);
+		const picker = createTestPicker(disposables, providersService, undefined, notifications, DispatchingWorkspacePicker) as DispatchingWorkspacePicker;
+
+		await picker.dispatchFolder(URI.file('/remote/project'), 'agenthost-remote-1');
+
+		assert.deepStrictEqual({
+			connectCalls,
+			progressClosed: notifications.handles[0]?.closed,
+			progressMessages: notifications.handles[0]?.messages,
+			errors: notifications.errors.map(error => String(error)),
+			selectedProvider: picker.selectedResolved?.providerId,
+		}, {
+			connectCalls: 1,
+			progressClosed: true,
+			progressMessages: ['Connecting to Provider agenthost-remote-1...', 'Opening WSL...'],
+			errors: ['Failed to connect to Provider agenthost-remote-1.'],
+			selectedProvider: undefined,
+		});
 	});
 
 	test('reconnect keeps the selection (no extra event fires)', () => {

--- a/src/vs/sessions/contrib/chat/test/browser/sessionWorkspacePicker.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionWorkspacePicker.test.ts
@@ -663,6 +663,7 @@ function createTestablePicker(disposables: DisposableStore, providersService: Mo
 	instantiationService.stub(IFileDialogService, {});
 	instantiationService.stub(IContextKeyService, new MockContextKeyService());
 	instantiationService.stub(IMenuService, { createMenu: () => ({ onDidChange: Event.None, getActions: () => [], dispose: () => { } }) });
+	instantiationService.stub(INotificationService, new TestNotificationService());
 	instantiationService.stub(IWorkspacesService, {
 		getRecentlyOpened: async () => ({ workspaces: [], files: [] }),
 		onDidChangeRecentlyOpened: Event.None,

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/managedReconnectAgentHostContribution.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/managedReconnectAgentHostContribution.ts
@@ -1,0 +1,268 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { disposableTimeout } from '../../../../../base/common/async.js';
+import { Event } from '../../../../../base/common/event.js';
+import { Disposable, DisposableMap, DisposableStore, MutableDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
+import { IRemoteAgentHostService, RemoteAgentHostConnectionStatus, RemoteAgentHostsEnabledSettingId } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { PROTOCOL_VERSION } from '../../../../../platform/agentHost/common/state/protocol/version/registry.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
+import { INotificationService } from '../../../../../platform/notification/common/notification.js';
+import { IAgentHostConnectProgress } from '../../../../common/agentHostSessionsProvider.js';
+import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
+import { RemoteAgentHostSessionsProvider } from './remoteAgentHostSessionsProvider.js';
+import { watchForIncompatibleNotifications } from './remoteHostOptions.js';
+
+/**
+ * Per-host auto-reconnect state for a managed (in-renderer relay) remote
+ * agent host. Owned by a {@link DisposableMap} on the contribution, which
+ * disposes the entry — and therefore the pending timer — when the host is no
+ * longer present or the contribution itself is disposed.
+ */
+export class ManagedReconnectState extends Disposable {
+	private readonly _timer = this._register(new MutableDisposable());
+
+	/** Consecutive failed reconnect attempts. */
+	attempts = 0;
+	/** True after we've given up auto-reconnecting until something resumes us. */
+	paused = false;
+	/** Wall-clock timestamp when {@link paused} was last set to true. */
+	pausedAt = 0;
+
+	get hasPendingTimer(): boolean {
+		return !!this._timer.value;
+	}
+
+	scheduleRetry(delayMs: number, handler: () => void): void {
+		this._timer.value = disposableTimeout(() => {
+			// Drop the disposable now that the timer has fired so
+			// `hasPendingTimer` reflects reality even if `handler` returns
+			// early without scheduling a follow-up attempt.
+			this._timer.value = undefined;
+			handler();
+		}, delayMs);
+	}
+
+	cancelTimer(): void {
+		this._timer.clear();
+	}
+
+	resetForResume(): void {
+		this.attempts = 0;
+		this.paused = false;
+		this._timer.clear();
+	}
+}
+
+/** Options controlling a single managed-reconnect attempt. */
+export interface IManagedReconnectAttemptOptions {
+	/** Human-readable connection kind for logging (e.g. `SSH`, `WSL`). */
+	readonly kind: string;
+	/** Reconnect-state key (e.g. `sshConfigHost`, `distro`). */
+	readonly key: string;
+	/** Display address used to look up the provider and live connection. */
+	readonly address: string;
+	/** Whether the attempt was triggered by an explicit user action. */
+	readonly userInitiated: boolean;
+	/** Consecutive failures before pausing auto-reconnect. */
+	readonly maxAttempts: number;
+	/** Whether the given error should pause (rather than retry) auto-reconnect. */
+	readonly shouldPause: (err: unknown) => boolean;
+	/**
+	 * Optional pre-flight gate. Return `{ skip: true }` to bail WITHOUT
+	 * incrementing the attempt counter (so a long-unavailable host can't burn
+	 * the retry budget).
+	 */
+	readonly preCheck?: (userInitiated: boolean) => Promise<{ readonly skip: boolean; readonly reason?: string } | undefined>;
+	/** Perform the actual (re)connect. */
+	readonly doConnect: () => Promise<void>;
+	/** Schedule the next retry after a non-terminal failure. */
+	readonly schedule: (state: ManagedReconnectState) => void;
+}
+
+/**
+ * Shared base for contributions that own in-renderer relay remote agent hosts
+ * (WSL, and conceptually SSH/tunnels). Encapsulates the sessions-provider
+ * registry and the managed auto-reconnect state machine so concrete
+ * contributions only implement their type-specific discovery/connect logic.
+ */
+export abstract class ManagedReconnectAgentHostContribution extends Disposable {
+
+	/** Per-address sessions provider stores. */
+	protected readonly _providerStores = this._register(new DisposableMap<string, DisposableStore>());
+	protected readonly _providerInstances = new Map<string, RemoteAgentHostSessionsProvider>();
+
+	/** Per-key auto-reconnect state (timer + attempts + paused). */
+	protected readonly _reconnectStates = this._register(new DisposableMap<string, ManagedReconnectState>());
+
+	/**
+	 * In-flight reconnect attempts keyed by reconnect-state key. Stored so
+	 * concurrent on-demand callers join the existing attempt rather than
+	 * racing it.
+	 */
+	protected readonly _pendingReconnects = new Map<string, Promise<void>>();
+
+	constructor(
+		protected readonly _remoteAgentHostService: IRemoteAgentHostService,
+		protected readonly _configurationService: IConfigurationService,
+		protected readonly _logService: ILogService,
+		protected readonly _instantiationService: IInstantiationService,
+		protected readonly _sessionsProvidersService: ISessionsProvidersService,
+		protected readonly _notificationService: INotificationService,
+	) {
+		super();
+	}
+
+	protected get _enabled(): boolean {
+		return this._configurationService.getValue<boolean>(RemoteAgentHostsEnabledSettingId);
+	}
+
+	// -- Provider registry --
+
+	protected _createProvider(address: string, name: string, options: {
+		readonly connectOnDemand?: () => Promise<void>;
+		readonly disconnectOnDemand?: () => Promise<void>;
+		readonly onDidReportConnectProgress?: Event<IAgentHostConnectProgress>;
+		readonly initialStatus?: RemoteAgentHostConnectionStatus;
+	}): RemoteAgentHostSessionsProvider {
+		const store = new DisposableStore();
+		const provider = this._instantiationService.createInstance(
+			RemoteAgentHostSessionsProvider, {
+			address,
+			name,
+			connectOnDemand: options.connectOnDemand,
+			disconnectOnDemand: options.disconnectOnDemand,
+			onDidReportConnectProgress: options.onDidReportConnectProgress,
+		});
+		if (options.initialStatus !== undefined) {
+			provider.setConnectionStatus(options.initialStatus);
+		}
+		store.add(provider);
+		store.add(this._sessionsProvidersService.registerProvider(provider));
+		store.add(watchForIncompatibleNotifications(provider, this._instantiationService, this._notificationService));
+		this._providerInstances.set(address, provider);
+		store.add(toDisposable(() => this._providerInstances.delete(address)));
+		this._providerStores.set(address, store);
+		return provider;
+	}
+
+	// -- Managed auto-reconnect --
+
+	protected _getOrCreateReconnectState(key: string): ManagedReconnectState {
+		let state = this._reconnectStates.get(key);
+		if (!state) {
+			state = new ManagedReconnectState();
+			this._reconnectStates.set(key, state);
+		}
+		return state;
+	}
+
+	/**
+	 * Resume auto-reconnect for any paused entries. Called when a fresh
+	 * trigger (config change, new connection event) gives paused hosts another
+	 * chance. Returns the number of entries resumed.
+	 */
+	protected _resumeReconnects(logKind: string): number {
+		let resumed = 0;
+		for (const [, state] of this._reconnectStates) {
+			if (state.paused) {
+				state.resetForResume();
+				resumed++;
+			}
+		}
+		if (resumed > 0) {
+			this._logService.info(`[RemoteAgentHost] Resuming ${logKind} auto-reconnect for ${resumed} paused host(s)`);
+		}
+		return resumed;
+	}
+
+	/**
+	 * Shared retry-loop body for managed-reconnect entries. Handles
+	 * `connecting`/`disconnected`/`incompatible` provider status, cached-session
+	 * unpublishing on failure, pause-on-cancel, and pause-after-max-attempts.
+	 * Type-specific behaviour is provided via {@link IManagedReconnectAttemptOptions}.
+	 */
+	protected async _attemptManagedReconnect(opts: IManagedReconnectAttemptOptions): Promise<void> {
+		// Wrap the body so we can store our own promise in `_pendingReconnects`
+		// for concurrent on-demand callers to join.
+		const runPromise = (async () => {
+			const state = this._getOrCreateReconnectState(opts.key);
+			const attempt = state.attempts;
+			const provider = this._providerInstances.get(opts.address);
+			if (opts.userInitiated) {
+				provider?.setConnectionStatus(RemoteAgentHostConnectionStatus.connecting);
+			}
+			this._logService.info(`[RemoteAgentHost] Re-establishing ${opts.kind} connection for ${opts.key} (attempt ${attempt + 1})`);
+			try {
+				if (opts.preCheck) {
+					const result = await opts.preCheck(opts.userInitiated);
+					if (result?.skip) {
+						if (result.reason) {
+							this._logService.info(`[RemoteAgentHost] ${opts.kind} reconnect for ${opts.key}: ${result.reason}; skipping`);
+						}
+						return;
+					}
+				}
+				await opts.doConnect();
+				this._reconnectStates.deleteAndDispose(opts.key);
+				this._logService.info(`[RemoteAgentHost] ${opts.kind} connection re-established for ${opts.key}`);
+			} catch (err) {
+				if (!this._enabled) {
+					this._reconnectStates.deleteAndDispose(opts.key);
+					return;
+				}
+				if (opts.userInitiated) {
+					provider?.setConnectionStatus(RemoteAgentHostConnectionStatus.disconnected);
+				}
+				if (opts.shouldPause(err)) {
+					this._logService.info(`[RemoteAgentHost] Pausing ${opts.kind} auto-reconnect for ${opts.key} after user cancellation`);
+					provider?.unpublishCachedSessions();
+					const liveState = this._getOrCreateReconnectState(opts.key);
+					liveState.paused = true;
+					liveState.pausedAt = Date.now();
+					return;
+				}
+				this._logService.error(`[RemoteAgentHost] ${opts.kind} reconnect failed for ${opts.key}`, err);
+				// Surface protocol-version mismatches on the provider so the
+				// workspace picker can show the host's message. Other errors
+				// stay as the existing disconnected state.
+				const incompatible = RemoteAgentHostConnectionStatus.fromConnectError(err, [PROTOCOL_VERSION]);
+				if (incompatible) {
+					provider?.setConnectionStatus(incompatible);
+					// Don't keep retrying on incompatible — user needs to
+					// upgrade/downgrade. Drop retry state instead of pausing.
+					this._reconnectStates.deleteAndDispose(opts.key);
+					return;
+				}
+				// Host is unreachable — unpublish any cached sessions we were
+				// showing so the UI doesn't list stale entries for a host we
+				// cannot currently reach.
+				provider?.unpublishCachedSessions();
+				// State may have been cleared (e.g. host removed) while the
+				// reconnect was in flight — re-resolve to be safe.
+				const liveState = this._getOrCreateReconnectState(opts.key);
+				liveState.attempts = attempt + 1;
+				if (liveState.attempts >= opts.maxAttempts) {
+					this._logService.info(`[RemoteAgentHost] Pausing ${opts.kind} auto-reconnect for ${opts.key} after ${liveState.attempts} consecutive failures`);
+					liveState.paused = true;
+					liveState.pausedAt = Date.now();
+					return;
+				}
+				if (opts.userInitiated) {
+					return;
+				}
+				opts.schedule(liveState);
+			}
+		})();
+		this._pendingReconnects.set(opts.key, runPromise);
+		try {
+			await runPromise;
+		} finally {
+			this._pendingReconnects.delete(opts.key);
+		}
+	}
+}

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/managedReconnectAgentHostContribution.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/managedReconnectAgentHostContribution.ts
@@ -132,12 +132,12 @@ export abstract class ManagedReconnectAgentHostContribution extends Disposable {
 		const store = new DisposableStore();
 		const provider = this._instantiationService.createInstance(
 			RemoteAgentHostSessionsProvider, {
-			address,
-			name,
-			connectOnDemand: options.connectOnDemand,
-			disconnectOnDemand: options.disconnectOnDemand,
-			onDidReportConnectProgress: options.onDidReportConnectProgress,
-		});
+				address,
+				name,
+				connectOnDemand: options.connectOnDemand,
+				disconnectOnDemand: options.disconnectOnDemand,
+				onDidReportConnectProgress: options.onDidReportConnectProgress,
+			});
 		if (options.initialStatus !== undefined) {
 			provider.setConnectionStatus(options.initialStatus);
 		}

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/managedReconnectAgentHostContribution.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/managedReconnectAgentHostContribution.ts
@@ -132,12 +132,12 @@ export abstract class ManagedReconnectAgentHostContribution extends Disposable {
 		const store = new DisposableStore();
 		const provider = this._instantiationService.createInstance(
 			RemoteAgentHostSessionsProvider, {
-				address,
-				name,
-				connectOnDemand: options.connectOnDemand,
-				disconnectOnDemand: options.disconnectOnDemand,
-				onDidReportConnectProgress: options.onDidReportConnectProgress,
-			});
+			address,
+			name,
+			connectOnDemand: options.connectOnDemand,
+			disconnectOnDemand: options.disconnectOnDemand,
+			onDidReportConnectProgress: options.onDidReportConnectProgress,
+		});
 		if (options.initialStatus !== undefined) {
 			provider.setConnectionStatus(options.initialStatus);
 		}

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution.ts
@@ -6,14 +6,12 @@
 import { Disposable, DisposableMap, DisposableStore, MutableDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { disposableTimeout, IntervalTimer } from '../../../../../base/common/async.js';
 import { isCancellationError } from '../../../../../base/common/errors.js';
-import { isWindows } from '../../../../../base/common/platform.js';
 import { URI } from '../../../../../base/common/uri.js';
 import * as nls from '../../../../../nls.js';
 import { agentHostAuthority } from '../../../../../platform/agentHost/common/agentHostUri.js';
 import { RemoteAgentHostProtocolClient } from '../../../../../platform/agentHost/browser/remoteAgentHostProtocolClient.js';
 import { type AgentProvider, type IAgentConnection } from '../../../../../platform/agentHost/common/agentService.js';
-import { IRemoteAgentHostConnectionInfo, IRemoteAgentHostEntry, IRemoteAgentHostService, type IRemoteAgentHostSSHConnection, type IRemoteAgentHostWSLConnection, RemoteAgentHostAutoConnectSettingId, RemoteAgentHostConnectionStatus, RemoteAgentHostEntryType, RemoteAgentHostsEnabledSettingId, RemoteAgentHostsSettingId, getEntryAddress } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
-import { IWSLRemoteAgentHostService } from '../../../../../platform/agentHost/common/wslRemoteAgentHost.js';
+import { IRemoteAgentHostConnectionInfo, IRemoteAgentHostEntry, IRemoteAgentHostService, type IRemoteAgentHostSSHConnection, RemoteAgentHostAutoConnectSettingId, RemoteAgentHostConnectionStatus, RemoteAgentHostEntryType, RemoteAgentHostsEnabledSettingId, RemoteAgentHostsSettingId, getEntryAddress } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { TunnelAgentHostsSettingId } from '../../../../../platform/agentHost/common/tunnelAgentHost.js';
 import { PROTOCOL_VERSION } from '../../../../../platform/agentHost/common/state/protocol/version/registry.js';
 import { AgentHostLocalFilePermissionsSettingId } from '../../../../../platform/agentHost/common/agentHostResourceService.js';
@@ -76,18 +74,6 @@ const SSH_RECONNECT_PAUSE_AUTO_RESUME_MS = 5 * 60 * 1000; // 5 minutes
  * disconnected indefinitely.
  */
 const SSH_RECONNECT_PERIODIC_INTERVAL_MS = 60_000; // 1 minute
-
-/** Initial auto-reconnect delay for WSL. Mirrors SSH. */
-const WSL_RECONNECT_INITIAL_DELAY = 1000;
-const WSL_RECONNECT_MAX_DELAY = 30_000;
-const WSL_RECONNECT_MAX_ATTEMPTS = 10;
-const WSL_RECONNECT_PAUSE_AUTO_RESUME_MS = 5 * 60 * 1000;
-/**
- * Background poll for `wsl --list --running` so a user-initiated WSL boot
- * can be detected and a stored entry reconnected without waiting for an
- * unrelated event.
- */
-const WSL_RUNNING_POLL_MS = 5 * 60 * 1000;
 
 /**
  * Per-host SSH auto-reconnect state. Owned by {@link RemoteAgentHostContribution._sshReconnectStates}
@@ -171,64 +157,6 @@ export async function disconnectSSHEntry(
 	await sshService.disconnect(sshConnectionKey(connection));
 }
 
-/**
- * Per-distro WSL auto-reconnect state. Intentionally mirrors
- * {@link SSHReconnectState} — kept as a twin (rather than a shared base) so
- * the two backoff state machines remain independent and the call sites stay
- * readable.
- */
-export class WSLReconnectState extends Disposable {
-	private readonly _timer = this._register(new MutableDisposable());
-
-	attempts = 0;
-	paused = false;
-	pausedAt = 0;
-
-	get hasPendingTimer(): boolean {
-		return !!this._timer.value;
-	}
-
-	scheduleRetry(delayMs: number, handler: () => void): void {
-		this._timer.value = disposableTimeout(() => {
-			this._timer.value = undefined;
-			handler();
-		}, delayMs);
-	}
-
-	cancelTimer(): void {
-		this._timer.clear();
-	}
-
-	resetForResume(): void {
-		this.attempts = 0;
-		this.paused = false;
-		this._timer.clear();
-	}
-}
-
-export function shouldPauseWSLReconnectAfterFailure(err: unknown): boolean {
-	return isCancellationError(err);
-}
-
-/** Address is the natural key — WSL distros are unique per machine. */
-export function wslConnectionKey(connection: IRemoteAgentHostWSLConnection): string {
-	return connection.address;
-}
-
-/**
- * Sequence the steps to disconnect a WSL-backed remote agent host entry.
- * Mirrors {@link disconnectSSHEntry}: tear down the stored entry first so the
- * subsequent close event from the WSL service can't trip auto-reconnect.
- */
-export async function disconnectWSLEntry(
-	connection: IRemoteAgentHostWSLConnection,
-	remoteAgentHostService: Pick<IRemoteAgentHostService, 'removeRemoteAgentHost'>,
-	wslService: Pick<IWSLRemoteAgentHostService, 'disconnect'>,
-): Promise<void> {
-	await remoteAgentHostService.removeRemoteAgentHost(connection.address);
-	await wslService.disconnect(connection.distro);
-}
-
 /** Per-connection state bundle, disposed when a connection is removed. */
 class ConnectionState extends Disposable {
 	readonly store = this._register(new DisposableStore());
@@ -276,12 +204,6 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 	/** Per-host SSH auto-reconnect state (timer + attempts + paused). */
 	private readonly _sshReconnectStates = this._register(new DisposableMap<string, SSHReconnectState>());
 
-	private readonly _pendingWSLReconnects = new Map<string /* distro */, Promise<void>>();
-	/** Per-distro WSL auto-reconnect state (timer + attempts + paused). */
-	private readonly _wslReconnectStates = this._register(new DisposableMap<string /* distro */, WSLReconnectState>());
-	/** Distros that were running at the last poll; used to detect newly-running distros. */
-	private _lastKnownRunningDistros = new Set<string>();
-
 	constructor(
 		@IRemoteAgentHostService private readonly _remoteAgentHostService: IRemoteAgentHostService,
 		@IChatSessionsService private readonly _chatSessionsService: IChatSessionsService,
@@ -295,7 +217,6 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IAgentHostFileSystemService private readonly _agentHostFileSystemService: IAgentHostFileSystemService,
 		@ISSHRemoteAgentHostService private readonly _sshService: ISSHRemoteAgentHostService,
-		@IWSLRemoteAgentHostService private readonly _wslService: IWSLRemoteAgentHostService,
 		@ICustomizationHarnessService private readonly _customizationHarnessService: ICustomizationHarnessService,
 		@IAgentHostTerminalService private readonly _agentHostTerminalService: IAgentHostTerminalService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
@@ -308,7 +229,6 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 			if (e.affectsConfiguration(RemoteAgentHostsSettingId) || e.affectsConfiguration(RemoteAgentHostsEnabledSettingId) || e.affectsConfiguration(RemoteAgentHostAutoConnectSettingId)) {
 				// User changed config — give paused auto-reconnect a fresh chance.
 				this._resumeSSHReconnects();
-				this._resumeWSLReconnects();
 				this._reconcile();
 			}
 		}));
@@ -318,7 +238,6 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 			// New/removed connection — paused auto-reconnect may have been
 			// caused by a transient outage that's now resolved.
 			this._resumeSSHReconnects();
-			this._resumeWSLReconnects();
 			this._reconcile();
 		}));
 
@@ -342,21 +261,12 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 			},
 			SSH_RECONNECT_PERIODIC_INTERVAL_MS,
 		);
-
-		// Dedicated WSL backstop: catches user-initiated WSL boots even when
-		// no other event fires. Cheap (`wsl --list --running --quiet`) so the
-		// 5-minute cadence has no measurable cost.
-		this._register(new IntervalTimer()).cancelAndSet(
-			() => void this._reconnectWSLEntriesIfRunning(),
-			WSL_RUNNING_POLL_MS,
-		);
 	}
 
 	private _reconcile(): void {
 		this._reconcileProviders();
 		this._reconcileConnections();
 		this._reconnectSSHEntries();
-		void this._reconnectWSLEntriesIfRunning();
 
 		// Ensure every live connection is wired to its provider. This covers
 		// the case where a provider was recreated (e.g. name change) while a
@@ -418,18 +328,11 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 	private _createProvider(entry: IRemoteAgentHostEntry): void {
 		const address = getEntryAddress(entry);
 		const sshConnection = entry.connection.type === RemoteAgentHostEntryType.SSH ? entry.connection : undefined;
-		const wslConnection = entry.connection.type === RemoteAgentHostEntryType.WSL ? entry.connection : undefined;
 		let connectOnDemand: (() => Promise<void>) | undefined;
 		let disconnectOnDemand: (() => Promise<void>) | undefined;
 		if (sshConnection) {
 			connectOnDemand = () => this._connectSSHOnDemand(sshConnection, entry.name, address);
 			disconnectOnDemand = () => this._disconnectSSHOnDemand(sshConnection);
-		} else if (wslConnection) {
-			// WSL: explicit user click should boot a stopped distro
-			// (`wsl.exe -d <distro>` boots it). The "never auto-boot"
-			// rule only applies to the periodic auto-reconnect path.
-			connectOnDemand = () => this._connectWSLOnDemand(wslConnection, entry.name);
-			disconnectOnDemand = () => this._disconnectWSLOnDemand(wslConnection);
 		}
 		const store = new DisposableStore();
 		const provider = this._instantiationService.createInstance(
@@ -607,170 +510,26 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 	}
 
 	/**
-	 * Re-establish WSL connections for configured entries whose distro is
-	 * already running. Never auto-boots a distro; only acts on user-initiated
-	 * boots observed via {@link IWSLRemoteAgentHostService.listRunningDistros}.
-	 * Mirrors the shape of {@link _reconnectSSHEntries}, with an added
-	 * running-distro gate.
-	 */
-	private async _reconnectWSLEntriesIfRunning(): Promise<void> {
-		if (!isWindows) {
-			return;
-		}
-		if (!this._configurationService.getValue<boolean>(RemoteAgentHostsEnabledSettingId)) {
-			this._wslReconnectStates.clearAndDisposeAll();
-			return;
-		}
-
-		const running = new Set<string>(await this._wslService.listRunningDistros().catch(() => []));
-		const newlyRunning: string[] = [];
-		for (const distro of running) {
-			if (!this._lastKnownRunningDistros.has(distro)) {
-				newlyRunning.push(distro);
-			}
-		}
-		this._lastKnownRunningDistros = running;
-		if (newlyRunning.length > 0) {
-			this._logService.info(`[RemoteAgentHost] Newly running WSL distro(s): ${newlyRunning.join(', ')}`);
-		}
-
-		const autoConnect = this._configurationService.getValue<boolean>(RemoteAgentHostAutoConnectSettingId);
-		const entries = this._getConfiguredWSLEntries();
-		const stillConfigured = new Set<string>();
-		for (const entry of entries) {
-			stillConfigured.add(entry.distro);
-			if (!running.has(entry.distro)) {
-				continue;
-			}
-			const hasConnection = this._remoteAgentHostService.connections.some(
-				c => c.address === entry.address && RemoteAgentHostConnectionStatus.isConnected(c.status)
-			);
-			if (hasConnection) {
-				this._wslReconnectStates.deleteAndDispose(entry.distro);
-				continue;
-			}
-			if (this._pendingWSLReconnects.has(entry.distro)) {
-				this._logService.trace(`[RemoteAgentHost] WSL reconnect for ${entry.distro}: reconnect already in progress, skipping`);
-				continue;
-			}
-			const state = this._wslReconnectStates.get(entry.distro);
-			if (state?.hasPendingTimer) {
-				this._logService.trace(`[RemoteAgentHost] WSL reconnect for ${entry.distro}: retry timer already scheduled, skipping`);
-				continue;
-			}
-			if (state?.paused) {
-				const pausedMs = Date.now() - state.pausedAt;
-				if (pausedMs < WSL_RECONNECT_PAUSE_AUTO_RESUME_MS) {
-					this._logService.trace(`[RemoteAgentHost] WSL reconnect for ${entry.distro}: paused (${Math.round(pausedMs / 1000)}s ago), skipping`);
-					continue;
-				}
-				this._logService.info(`[RemoteAgentHost] WSL reconnect for ${entry.distro}: auto-resuming after ${Math.round(pausedMs / 1000)}s pause`);
-				state.resetForResume();
-			}
-			if (!autoConnect) {
-				this._logService.trace(`[RemoteAgentHost] WSL reconnect for ${entry.distro}: auto-connect disabled, skipping`);
-				continue;
-			}
-			void this._attemptWSLReconnect(entry.distro, entry.name, entry.address);
-		}
-
-		// Drop retry state for distros that are no longer configured.
-		for (const distro of [...this._wslReconnectStates.keys()]) {
-			if (!stillConfigured.has(distro)) {
-				this._wslReconnectStates.deleteAndDispose(distro);
-			}
-		}
-	}
-
-	private _getConfiguredWSLEntries(): readonly { distro: string; name: string; address: string }[] {
-		const result: { distro: string; name: string; address: string }[] = [];
-		for (const entry of this._remoteAgentHostService.configuredEntries) {
-			if (entry.connection.type === RemoteAgentHostEntryType.WSL) {
-				result.push({ distro: entry.connection.distro, name: entry.name, address: entry.connection.address });
-			}
-		}
-		return result;
-	}
-
-	private async _attemptWSLReconnect(distro: string, name: string, address: string, options: { userInitiated?: boolean } = {}): Promise<void> {
-		await this._attemptManagedReconnect({
-			kind: 'WSL',
-			key: distro,
-			address,
-			userInitiated: !!options.userInitiated,
-			maxAttempts: WSL_RECONNECT_MAX_ATTEMPTS,
-			shouldPause: shouldPauseWSLReconnectAfterFailure,
-			pending: this._pendingWSLReconnects,
-			states: this._wslReconnectStates,
-			getOrCreateState: key => this._getOrCreateWSLReconnectState(key),
-			// WSL-specific gate: never auto-boot a stopped distro. The
-			// gate is skipped on user-initiated attempts (the user
-			// explicitly clicked Reconnect — `wsl.exe -d <distro>` will
-			// boot the distro on their behalf). When the gate triggers
-			// we return WITHOUT incrementing `attempts` so a long stop
-			// doesn't burn the retry budget.
-			preCheck: async userInitiated => {
-				if (userInitiated) {
-					return undefined;
-				}
-				const stillConfigured = this._remoteAgentHostService.configuredEntries.some(
-					e => e.connection.type === RemoteAgentHostEntryType.WSL && e.connection.distro === distro
-				);
-				if (!stillConfigured) {
-					this._wslReconnectStates.deleteAndDispose(distro);
-					return { skip: true };
-				}
-				const running = new Set<string>(await this._wslService.listRunningDistros().catch(() => []));
-				this._lastKnownRunningDistros = running;
-				if (!running.has(distro)) {
-					return { skip: true, reason: `distro ${distro} not running` };
-				}
-				return undefined;
-			},
-			doConnect: () => this._wslService.reconnect(distro, name).then(() => undefined),
-			schedule: state => this._scheduleWSLReconnect(distro, name, address, state as WSLReconnectState),
-		});
-	}
-
-	private async _connectWSLOnDemand(connection: IRemoteAgentHostWSLConnection, name: string): Promise<void> {
-		const inFlight = this._pendingWSLReconnects.get(connection.distro);
-		if (inFlight) {
-			await inFlight.catch(() => undefined);
-			return;
-		}
-		this._wslReconnectStates.get(connection.distro)?.resetForResume();
-		await this._attemptWSLReconnect(connection.distro, name, connection.address, { userInitiated: true });
-	}
-
-	private async _disconnectWSLOnDemand(connection: IRemoteAgentHostWSLConnection): Promise<void> {
-		this._wslReconnectStates.deleteAndDispose(connection.distro);
-		await disconnectWSLEntry(connection, this._remoteAgentHostService, this._wslService);
-	}
-
-	/**
-	 * Shared retry-loop body for managed-reconnect entries (SSH, WSL).
+	 * Shared retry-loop body for SSH managed-reconnect entries.
 	 *
-	 * Both SSH and WSL want identical handling of `connecting`/`disconnected`/
-	 * `incompatible` provider status, cached-session unpublishing on failure,
-	 * pause-on-cancel, and pause-after-max-attempts. The differences are
-	 * type-specific: SSH has no pre-check, WSL gates on
-	 * `listRunningDistros`. The pre-check returns `{ skip: true }` to bail
-	 * out without incrementing the attempt counter (so a long-stopped WSL
-	 * distro can't burn the retry budget); SSH passes no pre-check at all.
+	 * Handles `connecting`/`disconnected`/`incompatible` provider status,
+	 * cached-session unpublishing on failure, pause-on-cancel, and
+	 * pause-after-max-attempts. An optional pre-check can bail out without
+	 * incrementing the attempt counter (returns `{ skip: true }`).
 	 */
 	private async _attemptManagedReconnect(opts: {
-		readonly kind: 'SSH' | 'WSL';
+		readonly kind: 'SSH';
 		readonly key: string;
 		readonly address: string;
 		readonly userInitiated: boolean;
 		readonly maxAttempts: number;
 		readonly shouldPause: (err: unknown) => boolean;
 		readonly pending: Map<string, Promise<void>>;
-		readonly states: DisposableMap<string, SSHReconnectState | WSLReconnectState>;
-		readonly getOrCreateState: (key: string) => SSHReconnectState | WSLReconnectState;
+		readonly states: DisposableMap<string, SSHReconnectState>;
+		readonly getOrCreateState: (key: string) => SSHReconnectState;
 		readonly preCheck?: (userInitiated: boolean) => Promise<{ readonly skip: boolean; readonly reason?: string } | undefined>;
 		readonly doConnect: () => Promise<void>;
-		readonly schedule: (state: SSHReconnectState | WSLReconnectState) => void;
+		readonly schedule: (state: SSHReconnectState) => void;
 	}): Promise<void> {
 		// Wrap the body so we can store our own promise in `opts.pending` for
 		// concurrent on-demand callers to join. The inner IIFE keeps the
@@ -850,51 +609,6 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 			await runPromise;
 		} finally {
 			opts.pending.delete(opts.key);
-		}
-	}
-
-	private _scheduleWSLReconnect(distro: string, name: string, address: string, state: WSLReconnectState): void {
-		const delay = Math.min(WSL_RECONNECT_INITIAL_DELAY * Math.pow(2, state.attempts - 1), WSL_RECONNECT_MAX_DELAY);
-		this._logService.info(`[RemoteAgentHost] Scheduling WSL reconnect for ${distro} in ${delay}ms (attempt ${state.attempts + 1}/${WSL_RECONNECT_MAX_ATTEMPTS})`);
-		state.scheduleRetry(delay, () => {
-			if (!this._configurationService.getValue<boolean>(RemoteAgentHostsEnabledSettingId)) {
-				this._wslReconnectStates.deleteAndDispose(distro);
-				return;
-			}
-			if (!this._configurationService.getValue<boolean>(RemoteAgentHostAutoConnectSettingId)) {
-				return;
-			}
-			const live = this._remoteAgentHostService.connections.find(c => c.address === address);
-			if (live && RemoteAgentHostConnectionStatus.isConnected(live.status)) {
-				this._wslReconnectStates.deleteAndDispose(distro);
-				return;
-			}
-			if (this._pendingWSLReconnects.has(distro)) {
-				return;
-			}
-			void this._attemptWSLReconnect(distro, name, address);
-		});
-	}
-
-	private _getOrCreateWSLReconnectState(distro: string): WSLReconnectState {
-		let state = this._wslReconnectStates.get(distro);
-		if (!state) {
-			state = new WSLReconnectState();
-			this._wslReconnectStates.set(distro, state);
-		}
-		return state;
-	}
-
-	private _resumeWSLReconnects(): void {
-		let resumed = 0;
-		for (const [, state] of this._wslReconnectStates) {
-			if (state.paused) {
-				state.resetForResume();
-				resumed++;
-			}
-		}
-		if (resumed > 0) {
-			this._logService.info(`[RemoteAgentHost] Resuming WSL auto-reconnect for ${resumed} paused distro(s)`);
 		}
 	}
 

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostActions.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostActions.ts
@@ -1088,6 +1088,13 @@ async function promptToConnectViaWSL(
 		progress: { infinite: true },
 	});
 
+	const expectedKey = `wsl:${picked.distro.name}`;
+	const progressListener = wslService.onDidReportConnectProgress?.(progress => {
+		if (progress.connectionKey === expectedKey) {
+			handle.updateMessage(progress.message);
+		}
+	});
+
 	try {
 		await wslService.connect({ distro: picked.distro.name, name: picked.distro.name });
 		handle.close();
@@ -1099,6 +1106,8 @@ async function promptToConnectViaWSL(
 		logService.error(`[WSL] Connect to '${picked.distro.name}' failed`, err);
 		notificationService.error(localize('wslConnectFailed', "Failed to connect to WSL distribution '{0}': {1}", picked.distro.name, toErrorMessage(err)));
 		return;
+	} finally {
+		progressListener?.dispose();
 	}
 
 	await instantiationService.invokeFunction(accessor => promptForWSLFolder(accessor, picked.distro.name));

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
@@ -31,6 +31,7 @@ import { IChatWidgetService } from '../../../../../workbench/contrib/chat/browse
 import { IChatService } from '../../../../../workbench/contrib/chat/common/chatService/chatService.js';
 import { IChatSessionsService } from '../../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { ILanguageModelsService } from '../../../../../workbench/contrib/chat/common/languageModels.js';
+import { IAgentHostConnectProgress } from '../../../../common/agentHostSessionsProvider.js';
 import { buildAgentHostSessionWorkspace, readBranchProtectionPatterns } from '../../../../common/agentHostSessionWorkspace.js';
 import { IGitHubInfo, ISession, ISessionType, ISessionWorkspace, ISessionWorkspaceBrowseAction, SESSION_WORKSPACE_GROUP_REMOTE } from '../../../../services/sessions/common/session.js';
 import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
@@ -107,6 +108,8 @@ export interface IRemoteAgentHostSessionsProviderConfig {
 	readonly connectOnDemand?: () => Promise<void>;
 	/** Optional hook to tear down the active connection on demand (e.g. tunnel relay). */
 	readonly disconnectOnDemand?: () => Promise<void>;
+	/** Optional progress messages during on-demand connect. */
+	readonly onDidReportConnectProgress?: Event<IAgentHostConnectProgress>;
 }
 
 /**
@@ -136,6 +139,7 @@ export class RemoteAgentHostSessionsProvider extends BaseAgentHostSessionsProvid
 	readonly remoteAddress: string;
 	readonly browseActions: readonly ISessionWorkspaceBrowseAction[];
 	readonly canConnectOnDemand: boolean;
+	readonly onDidReportConnectProgress: Event<IAgentHostConnectProgress> | undefined;
 
 	private readonly _connectionStatus = observableValue<RemoteAgentHostConnectionStatus>('connectionStatus', RemoteAgentHostConnectionStatus.disconnected);
 	readonly connectionStatus: IObservable<RemoteAgentHostConnectionStatus> = this._connectionStatus;
@@ -214,6 +218,7 @@ export class RemoteAgentHostSessionsProvider extends BaseAgentHostSessionsProvid
 		this._connectionAuthority = agentHostAuthority(config.address);
 		this._connectOnDemand = config.connectOnDemand;
 		this._disconnectOnDemand = config.disconnectOnDemand;
+		this.onDidReportConnectProgress = config.onDidReportConnectProgress;
 		this.canConnectOnDemand = !!config.connectOnDemand;
 		const displayName = config.name || config.address;
 

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/wslAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/wslAgentHost.contribution.ts
@@ -1,0 +1,345 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IntervalTimer } from '../../../../../base/common/async.js';
+import { isCancellationError } from '../../../../../base/common/errors.js';
+import { isWindows } from '../../../../../base/common/platform.js';
+import { IRemoteAgentHostService, RemoteAgentHostAutoConnectSettingId, RemoteAgentHostConnectionStatus, RemoteAgentHostsEnabledSettingId } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { IWSLRemoteAgentHostService, WSL_ADDRESS_PREFIX } from '../../../../../platform/agentHost/common/wslRemoteAgentHost.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
+import { INotificationService } from '../../../../../platform/notification/common/notification.js';
+import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../../workbench/common/contributions.js';
+import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
+import { ManagedReconnectAgentHostContribution, ManagedReconnectState } from './managedReconnectAgentHostContribution.js';
+
+/** Initial auto-reconnect delay after a failed WSL reconnect attempt. */
+const WSL_RECONNECT_INITIAL_DELAY = 1000;
+/** Maximum auto-reconnect backoff delay for WSL. */
+const WSL_RECONNECT_MAX_DELAY = 30_000;
+/** Consecutive WSL reconnect failures before pausing auto-reconnect. */
+const WSL_RECONNECT_MAX_ATTEMPTS = 10;
+/** After this much wall-clock time, a paused auto-reconnect is auto-resumed. */
+const WSL_RECONNECT_PAUSE_AUTO_RESUME_MS = 5 * 60 * 1000;
+/**
+ * Background poll for `wsl --list --running` so a user-initiated WSL boot can
+ * be detected and a cached distro reconnected without waiting for an unrelated
+ * event.
+ */
+const WSL_RUNNING_POLL_MS = 5 * 60 * 1000;
+
+export function shouldPauseWSLReconnectAfterFailure(err: unknown): boolean {
+	return isCancellationError(err);
+}
+
+/**
+ * Manages sessions providers and auto-reconnect for WSL-backed remote agent
+ * hosts. Mirrors {@link TunnelAgentHostContribution}: providers are sourced
+ * from the WSL service's in-memory cache ({@link IWSLRemoteAgentHostService.getCachedDistros})
+ * rather than from persisted settings, and live connections are wired back to
+ * their providers as connection events arrive.
+ *
+ * The per-connection agent registration (chat sessions, language models) is
+ * handled by {@link RemoteAgentHostContribution} reacting to
+ * `onDidChangeConnections` — exactly as it does for tunnels.
+ */
+export class WSLAgentHostContribution extends ManagedReconnectAgentHostContribution implements IWorkbenchContribution {
+
+	static readonly ID = 'sessions.contrib.wslAgentHostContribution';
+
+	/** Distros that were running at the last poll; used to detect newly-running distros. */
+	private _lastKnownRunningDistros = new Set<string>();
+
+	constructor(
+		@IRemoteAgentHostService remoteAgentHostService: IRemoteAgentHostService,
+		@IWSLRemoteAgentHostService private readonly _wslService: IWSLRemoteAgentHostService,
+		@IConfigurationService configurationService: IConfigurationService,
+		@ILogService logService: ILogService,
+		@IInstantiationService instantiationService: IInstantiationService,
+		@ISessionsProvidersService sessionsProvidersService: ISessionsProvidersService,
+		@INotificationService notificationService: INotificationService,
+	) {
+		super(remoteAgentHostService, configurationService, logService, instantiationService, sessionsProvidersService, notificationService);
+
+		// Reconcile providers when connections change (added/removed/reconnected).
+		this._register(this._remoteAgentHostService.onDidChangeConnections(() => {
+			// New/removed connection — paused auto-reconnect may have been
+			// caused by a transient outage that's now resolved.
+			this._resumeReconnects('WSL');
+			this._reconcile();
+		}));
+
+		// Reconcile when enablement / auto-connect config changes.
+		this._register(this._configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration(RemoteAgentHostsEnabledSettingId) || e.affectsConfiguration(RemoteAgentHostAutoConnectSettingId)) {
+				this._resumeReconnects('WSL');
+				this._reconcile();
+			}
+		}));
+
+		// Initial setup for cached distros and connected remotes.
+		this._reconcile();
+
+		// Periodic backstop: catches user-initiated WSL boots even when no
+		// other event fires. Cheap (`wsl --list --running --quiet`) so the
+		// 5-minute cadence has no measurable cost.
+		this._register(new IntervalTimer()).cancelAndSet(
+			() => void this._reconnectWSLEntriesIfRunning(),
+			WSL_RUNNING_POLL_MS,
+		);
+	}
+
+	private _reconcile(): void {
+		this._reconcileProviders();
+		this._wireConnections();
+		this._updateConnectionStatuses();
+		void this._reconnectWSLEntriesIfRunning();
+	}
+
+	// -- Provider management --
+
+	private _reconcileProviders(): void {
+		const entries = this._enabled ? this._getCachedWSLEntries() : [];
+		const desiredAddresses = new Set(entries.map(e => e.address));
+
+		// Remove providers whose distro is no longer cached.
+		for (const [address] of this._providerStores) {
+			if (!desiredAddresses.has(address)) {
+				this._providerStores.deleteAndDispose(address);
+			}
+		}
+
+		// Add or recreate providers for cached distros.
+		for (const entry of entries) {
+			const existing = this._providerInstances.get(entry.address);
+			if (existing && existing.label !== (entry.name || entry.address)) {
+				// Name changed — recreate since ISessionsProvider.label is readonly.
+				this._providerStores.deleteAndDispose(entry.address);
+			}
+			if (!this._providerStores.has(entry.address)) {
+				this._createProvider(entry.address, entry.name, {
+					// WSL: an explicit user click should boot a stopped distro
+					// (`wsl.exe -d <distro>` boots it). The "never auto-boot"
+					// rule only applies to the periodic auto-reconnect path.
+					connectOnDemand: () => this._connectWSLOnDemand(entry.distro, entry.name, entry.address),
+					disconnectOnDemand: () => this._disconnectWSLOnDemand(entry.distro, entry.address),
+					onDidReportConnectProgress: this._wslService.onDidReportConnectProgress,
+				});
+			}
+		}
+	}
+
+	/** Wire live connections to their providers so session operations work. */
+	private _wireConnections(): void {
+		for (const [address, provider] of this._providerInstances) {
+			const connectionInfo = this._remoteAgentHostService.connections.find(
+				c => c.address === address && RemoteAgentHostConnectionStatus.isConnected(c.status)
+			);
+			if (connectionInfo) {
+				const connection = this._remoteAgentHostService.getConnection(address);
+				if (connection) {
+					provider.setConnection(connection, connectionInfo.defaultDirectory);
+				}
+			}
+		}
+	}
+
+	private _updateConnectionStatuses(): void {
+		for (const [address, provider] of this._providerInstances) {
+			const connectionInfo = this._remoteAgentHostService.connections.find(c => c.address === address);
+			if (connectionInfo) {
+				// Service has an entry for this address — its status is
+				// authoritative (including `incompatible` from the WebSocket
+				// connect failure path and `connecting` from a fresh reconnect).
+				provider.setConnectionStatus(connectionInfo.status);
+			} else if (this._pendingReconnects.has(this._distroForAddress(address))) {
+				provider.setConnectionStatus(RemoteAgentHostConnectionStatus.connecting);
+			} else if (!RemoteAgentHostConnectionStatus.isIncompatible(provider.connectionStatus.get())) {
+				// No service entry. Preserve incompatible state set by the
+				// reconnect catch; otherwise fall back to disconnected.
+				provider.setConnectionStatus(RemoteAgentHostConnectionStatus.disconnected);
+			}
+		}
+	}
+
+	private _distroForAddress(address: string): string {
+		return address.startsWith(WSL_ADDRESS_PREFIX) ? address.slice(WSL_ADDRESS_PREFIX.length) : address;
+	}
+
+	private _getCachedWSLEntries(): readonly { distro: string; name: string; address: string }[] {
+		return this._wslService.getCachedDistros().map(({ distro, name }) => ({
+			distro,
+			name,
+			address: `${WSL_ADDRESS_PREFIX}${distro}`,
+		}));
+	}
+
+	// -- Auto-reconnect --
+
+	/**
+	 * Re-establish WSL connections for cached distros that are already
+	 * running. Never auto-boots a distro; only acts on user-initiated boots
+	 * observed via {@link IWSLRemoteAgentHostService.listRunningDistros}.
+	 */
+	private async _reconnectWSLEntriesIfRunning(): Promise<void> {
+		if (!isWindows) {
+			return;
+		}
+		if (!this._enabled) {
+			this._reconnectStates.clearAndDisposeAll();
+			return;
+		}
+
+		const running = new Set<string>(await this._wslService.listRunningDistros().catch(() => []));
+		const newlyRunning: string[] = [];
+		for (const distro of running) {
+			if (!this._lastKnownRunningDistros.has(distro)) {
+				newlyRunning.push(distro);
+			}
+		}
+		this._lastKnownRunningDistros = running;
+		if (newlyRunning.length > 0) {
+			this._logService.info(`[WSLAgentHost] Newly running WSL distro(s): ${newlyRunning.join(', ')}`);
+		}
+
+		const autoConnect = this._configurationService.getValue<boolean>(RemoteAgentHostAutoConnectSettingId);
+		const entries = this._getCachedWSLEntries();
+		const stillCached = new Set<string>();
+		for (const entry of entries) {
+			stillCached.add(entry.distro);
+			if (!running.has(entry.distro)) {
+				continue;
+			}
+			const hasConnection = this._remoteAgentHostService.connections.some(
+				c => c.address === entry.address && RemoteAgentHostConnectionStatus.isConnected(c.status)
+			);
+			if (hasConnection) {
+				this._reconnectStates.deleteAndDispose(entry.distro);
+				continue;
+			}
+			if (this._pendingReconnects.has(entry.distro)) {
+				this._logService.trace(`[WSLAgentHost] WSL reconnect for ${entry.distro}: reconnect already in progress, skipping`);
+				continue;
+			}
+			const state = this._reconnectStates.get(entry.distro);
+			if (state?.hasPendingTimer) {
+				this._logService.trace(`[WSLAgentHost] WSL reconnect for ${entry.distro}: retry timer already scheduled, skipping`);
+				continue;
+			}
+			if (state?.paused) {
+				const pausedMs = Date.now() - state.pausedAt;
+				if (pausedMs < WSL_RECONNECT_PAUSE_AUTO_RESUME_MS) {
+					this._logService.trace(`[WSLAgentHost] WSL reconnect for ${entry.distro}: paused (${Math.round(pausedMs / 1000)}s ago), skipping`);
+					continue;
+				}
+				this._logService.info(`[WSLAgentHost] WSL reconnect for ${entry.distro}: auto-resuming after ${Math.round(pausedMs / 1000)}s pause`);
+				state.resetForResume();
+			}
+			if (!autoConnect) {
+				this._logService.trace(`[WSLAgentHost] WSL reconnect for ${entry.distro}: auto-connect disabled, skipping`);
+				continue;
+			}
+			void this._attemptWSLReconnect(entry.distro, entry.name, entry.address);
+		}
+
+		// Drop retry state for distros that are no longer cached.
+		for (const distro of [...this._reconnectStates.keys()]) {
+			if (!stillCached.has(distro)) {
+				this._reconnectStates.deleteAndDispose(distro);
+			}
+		}
+	}
+
+	private async _attemptWSLReconnect(distro: string, name: string, address: string, options: { userInitiated?: boolean } = {}): Promise<void> {
+		await this._attemptManagedReconnect({
+			kind: 'WSL',
+			key: distro,
+			address,
+			userInitiated: !!options.userInitiated,
+			maxAttempts: WSL_RECONNECT_MAX_ATTEMPTS,
+			shouldPause: shouldPauseWSLReconnectAfterFailure,
+			// WSL-specific gate: never auto-boot a stopped distro. The gate is
+			// skipped on user-initiated attempts (the user explicitly clicked
+			// Reconnect — `wsl.exe -d <distro>` will boot it). When the gate
+			// triggers we return WITHOUT incrementing `attempts` so a long stop
+			// doesn't burn the retry budget.
+			preCheck: async userInitiated => {
+				if (userInitiated) {
+					return undefined;
+				}
+				const stillCached = this._wslService.getCachedDistros().some(d => d.distro === distro);
+				if (!stillCached) {
+					this._reconnectStates.deleteAndDispose(distro);
+					return { skip: true };
+				}
+				const running = new Set<string>(await this._wslService.listRunningDistros().catch(() => []));
+				this._lastKnownRunningDistros = running;
+				if (!running.has(distro)) {
+					return { skip: true, reason: `distro ${distro} not running` };
+				}
+				return undefined;
+			},
+			doConnect: () => this._wslService.reconnect(distro, name).then(() => undefined),
+			schedule: state => this._scheduleWSLReconnect(distro, name, address, state),
+		});
+	}
+
+	private _scheduleWSLReconnect(distro: string, name: string, address: string, state: ManagedReconnectState): void {
+		const delay = Math.min(WSL_RECONNECT_INITIAL_DELAY * Math.pow(2, state.attempts - 1), WSL_RECONNECT_MAX_DELAY);
+		this._logService.info(`[WSLAgentHost] Scheduling WSL reconnect for ${distro} in ${delay}ms (attempt ${state.attempts + 1}/${WSL_RECONNECT_MAX_ATTEMPTS})`);
+		state.scheduleRetry(delay, () => {
+			if (!this._enabled) {
+				this._reconnectStates.deleteAndDispose(distro);
+				return;
+			}
+			if (!this._configurationService.getValue<boolean>(RemoteAgentHostAutoConnectSettingId)) {
+				return;
+			}
+			const live = this._remoteAgentHostService.connections.find(c => c.address === address);
+			if (live && RemoteAgentHostConnectionStatus.isConnected(live.status)) {
+				this._reconnectStates.deleteAndDispose(distro);
+				return;
+			}
+			if (this._pendingReconnects.has(distro)) {
+				return;
+			}
+			void this._attemptWSLReconnect(distro, name, address);
+		});
+	}
+
+	// -- On-demand connection --
+
+	private async _connectWSLOnDemand(distro: string, name: string, address: string): Promise<void> {
+		while (true) {
+			const inFlight = this._pendingReconnects.get(distro);
+			if (!inFlight) {
+				break;
+			}
+			await inFlight.catch(() => undefined);
+			const live = this._remoteAgentHostService.connections.find(c => c.address === address);
+			if (live && RemoteAgentHostConnectionStatus.isConnected(live.status)) {
+				return;
+			}
+		}
+		this._reconnectStates.get(distro)?.resetForResume();
+		await this._attemptWSLReconnect(distro, name, address, { userInitiated: true });
+	}
+
+	/**
+	 * Tear down the active WSL connection for {@link distro} and cancel any
+	 * pending auto-reconnect. Removes the cached distro so it won't auto-reconnect.
+	 *
+	 * Order matters: `removeRemoteAgentHost` MUST run before the WSL service
+	 * teardown so the subsequent close event can't trip auto-reconnect.
+	 */
+	private async _disconnectWSLOnDemand(distro: string, address: string): Promise<void> {
+		this._reconnectStates.deleteAndDispose(distro);
+		await this._remoteAgentHostService.removeRemoteAgentHost(address);
+		await this._wslService.disconnect(distro);
+	}
+}
+
+registerWorkbenchContribution2(WSLAgentHostContribution.ID, WSLAgentHostContribution, WorkbenchPhase.AfterRestored);

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/managedReconnectAgentHostContribution.test.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/managedReconnectAgentHostContribution.test.ts
@@ -1,0 +1,102 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { timeout } from '../../../../../../base/common/async.js';
+import { runWithFakedTimers } from '../../../../../../base/test/common/timeTravelScheduler.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { ManagedReconnectState } from '../../browser/managedReconnectAgentHostContribution.js';
+
+suite('ManagedReconnectState', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('scheduleRetry fires the handler after the requested delay', async () => {
+		return runWithFakedTimers({ useFakeTimers: true, maxTaskCount: 10_000 }, async () => {
+			const state = store.add(new ManagedReconnectState());
+			let fired = 0;
+			state.scheduleRetry(1000, () => fired++);
+
+			assert.strictEqual(state.hasPendingTimer, true);
+			await timeout(500);
+			assert.strictEqual(fired, 0);
+			await timeout(600);
+			assert.strictEqual(fired, 1);
+		});
+	});
+
+	test('hasPendingTimer becomes false once the handler has run', async () => {
+		// The timer disposable must be cleared inside scheduleRetry's tick so
+		// observers that check hasPendingTimer after the handler runs (e.g. the
+		// reconnect loop's "retry timer already scheduled, skipping" guard) see
+		// the right value.
+		return runWithFakedTimers({ useFakeTimers: true, maxTaskCount: 10_000 }, async () => {
+			const state = store.add(new ManagedReconnectState());
+			state.scheduleRetry(1000, () => { /* no follow-up */ });
+			await timeout(1100);
+			assert.strictEqual(state.hasPendingTimer, false, 'timer should be cleared after firing');
+		});
+	});
+
+	test('cancelTimer prevents the handler from firing', async () => {
+		return runWithFakedTimers({ useFakeTimers: true, maxTaskCount: 10_000 }, async () => {
+			const state = store.add(new ManagedReconnectState());
+			let fired = 0;
+			state.scheduleRetry(1000, () => fired++);
+			state.cancelTimer();
+			assert.strictEqual(state.hasPendingTimer, false);
+			await timeout(2000);
+			assert.strictEqual(fired, 0);
+		});
+	});
+
+	test('scheduling a second retry replaces the first', async () => {
+		// MutableDisposable contract: assigning a new value disposes the old.
+		// If two retries were scheduled simultaneously the contribution would
+		// double-fire reconnect attempts and inflate the attempt counter.
+		return runWithFakedTimers({ useFakeTimers: true, maxTaskCount: 10_000 }, async () => {
+			const state = store.add(new ManagedReconnectState());
+			let firstFired = 0;
+			let secondFired = 0;
+			state.scheduleRetry(5000, () => firstFired++);
+			state.scheduleRetry(1000, () => secondFired++);
+			await timeout(6000);
+			assert.strictEqual(firstFired, 0, 'replaced timer must not fire');
+			assert.strictEqual(secondFired, 1);
+		});
+	});
+
+	test('disposing the state cancels a pending retry timer', async () => {
+		// Safety net for the DisposableMap that owns these states: when the
+		// contribution is disposed (or a host is removed) the entry's pending
+		// timer must be cancelled so we don't fire reconnect attempts against
+		// torn-down services.
+		return runWithFakedTimers({ useFakeTimers: true, maxTaskCount: 10_000 }, async () => {
+			const state = new ManagedReconnectState();
+			let fired = 0;
+			state.scheduleRetry(1000, () => fired++);
+			state.dispose();
+			await timeout(2000);
+			assert.strictEqual(fired, 0);
+		});
+	});
+
+	test('resetForResume clears the timer and zeros attempts/paused state', async () => {
+		return runWithFakedTimers({ useFakeTimers: true, maxTaskCount: 10_000 }, async () => {
+			const state = store.add(new ManagedReconnectState());
+			let fired = 0;
+			state.attempts = 7;
+			state.paused = true;
+			state.scheduleRetry(1000, () => fired++);
+
+			state.resetForResume();
+			assert.strictEqual(state.attempts, 0);
+			assert.strictEqual(state.paused, false);
+			assert.strictEqual(state.hasPendingTimer, false);
+
+			await timeout(2000);
+			assert.strictEqual(fired, 0, 'pending retry must be cancelled by resetForResume');
+		});
+	});
+});

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/wslAgentHost.contribution.test.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/wslAgentHost.contribution.test.ts
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { CancellationError } from '../../../../../../base/common/errors.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { shouldPauseWSLReconnectAfterFailure } from '../../browser/wslAgentHost.contribution.js';
+
+suite('shouldPauseWSLReconnectAfterFailure', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('pauses reconnect after cancellation but not after regular failures', () => {
+		assert.deepStrictEqual({
+			cancellation: shouldPauseWSLReconnectAfterFailure(new CancellationError()),
+			regularError: shouldPauseWSLReconnectAfterFailure(new Error('boom')),
+		}, {
+			cancellation: true,
+			regularError: false,
+		});
+	});
+});

--- a/src/vs/sessions/sessions.desktop.main.ts
+++ b/src/vs/sessions/sessions.desktop.main.ts
@@ -213,7 +213,7 @@ import './contrib/providers/remoteAgentHost/electron-browser/tunnelAgentHostServ
 import './contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution.js';
 import './contrib/providers/remoteAgentHost/browser/remoteAgentHostTerminal.contribution.js';
 import './contrib/providers/remoteAgentHost/browser/tunnelAgentHost.contribution.js';
-
+import './contrib/providers/remoteAgentHost/browser/wslAgentHost.contribution.js';
 // Chat
 import './contrib/agentFeedback/browser/agentFeedback.contribution.js';
 import './contrib/chat/electron-browser/chat.contribution.js';

--- a/src/vs/sessions/sessions.web.main.ts
+++ b/src/vs/sessions/sessions.web.main.ts
@@ -151,6 +151,9 @@ import './contrib/providers/remoteAgentHost/browser/webTunnelAgentHostService.co
 // Tunnel agent host — reconciles discovered tunnels into session providers
 import './contrib/providers/remoteAgentHost/browser/tunnelAgentHost.contribution.js';
 
+// WSL agent host — reconciles cached WSL distros into session providers
+import './contrib/providers/remoteAgentHost/browser/wslAgentHost.contribution.js';
+
 // Remote agent host terminal profiles — registers terminal profiles for connected agent hosts
 import './contrib/providers/remoteAgentHost/browser/remoteAgentHostTerminal.contribution.js';
 


### PR DESCRIPTION
## Summary
- move WSL remote agent host providers to a dedicated in-memory/cache-backed contribution
- reconnect running WSL distros without persisting WSL entries in remote host settings
- keep recent WSL workspaces selectable when stopped and connect on demand with progress

Fixes #320410
Fixes #320412
Fixes #320416
Fixes #320403

## Validation
- Problems diagnostics clean on touched areas
- .\scripts\test.bat --run src/vs/sessions/contrib/chat/test/browser/sessionWorkspacePicker.test.ts --grep "failed on-demand recent connect closes progress notification"