### PR TITLE
Render keybindings for OpenInVSCode and OpenWorkspaceInAgents widgets

### DIFF
--- a/src/vs/sessions/browser/actions/vscodeActions.ts
+++ b/src/vs/sessions/browser/actions/vscodeActions.ts
@@ -117,7 +117,7 @@ export class OpenInVSCodeWidgetContribution extends Disposable implements IWorkb
 	) {
 		super();
 		this._register(actionViewItemService.register(Menus.TitleBarCenterRight, OpenInVSCodeAction.ID, (action, options) => {
-			return instantiationService.createInstance(OpenInVSCodeTitleBarWidget, action, options);
+			return instantiationService.createInstance(OpenInVSCodeTitleBarWidget, action, options, OpenInVSCodeAction.ID);
 		}, undefined));
 	}
 }

--- a/src/vs/sessions/browser/widget/openInVSCodeWidget.ts
+++ b/src/vs/sessions/browser/widget/openInVSCodeWidget.ts
@@ -10,6 +10,7 @@ import { BaseActionViewItem, IBaseActionViewItemOptions } from '../../../base/br
 import { IAction } from '../../../base/common/actions.js';
 import { localize } from '../../../nls.js';
 import { IHoverService } from '../../../platform/hover/browser/hover.js';
+import { IKeybindingService } from '../../../platform/keybinding/common/keybinding.js';
 import { IProductService } from '../../../platform/product/common/productService.js';
 
 /**
@@ -21,8 +22,10 @@ export class OpenInVSCodeTitleBarWidget extends BaseActionViewItem {
 	constructor(
 		action: IAction,
 		options: IBaseActionViewItemOptions | undefined,
+		private readonly keybindingCommandId: string,
 		@IProductService private readonly productService: IProductService,
 		@IHoverService private readonly hoverService: IHoverService,
+		@IKeybindingService private readonly keybindingService: IKeybindingService,
 	) {
 		super(undefined, action, options);
 	}
@@ -41,7 +44,7 @@ export class OpenInVSCodeTitleBarWidget extends BaseActionViewItem {
 		}
 
 		const label = this.action.label;
-		const hoverText = localize('openInVSCodeHover', "Open in VS Code Editor Window");
+		const hoverText = this.keybindingService.appendKeybinding(localize('openInVSCodeHover', "Open in VS Code Editor Window"), this.keybindingCommandId);
 		container.setAttribute('aria-label', hoverText);
 		this._register(this.hoverService.setupManagedHover(getDefaultHoverDelegate('element'), container, hoverText));
 

--- a/src/vs/sessions/electron-browser/actions/vscodeActions.ts
+++ b/src/vs/sessions/electron-browser/actions/vscodeActions.ts
@@ -131,7 +131,7 @@ export class OpenInVSCodeWidgetContribution extends Disposable implements IWorkb
 	) {
 		super();
 		this._register(actionViewItemService.register(Menus.TitleBarCenterRight, OpenSessionInVSCodeAction.ID, (action, options) => {
-			return instantiationService.createInstance(OpenInVSCodeTitleBarWidget, action, options);
+			return instantiationService.createInstance(OpenInVSCodeTitleBarWidget, action, options, OpenVSCodeWindowAction.ID);
 		}, undefined));
 	}
 }

--- a/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts
@@ -16,6 +16,7 @@ import { ContextKeyExpr, IContextKeyService } from '../../../../../platform/cont
 import { CONTEXT_ACCESSIBILITY_MODE_ENABLED } from '../../../../../platform/accessibility/common/accessibility.js';
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { IKeybindingService } from '../../../../../platform/keybinding/common/keybinding.js';
 import { KeyCode, KeyMod } from '../../../../../base/common/keyCodes.js';
 import { KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { INativeHostService } from '../../../../../platform/native/common/native.js';
@@ -196,6 +197,7 @@ class OpenWorkspaceInAgentsTitleBarWidget extends BaseActionViewItem {
 		action: IAction,
 		options: IBaseActionViewItemOptions | undefined,
 		@IHoverService private readonly hoverService: IHoverService,
+		@IKeybindingService private readonly keybindingService: IKeybindingService,
 	) {
 		super(undefined, action, options);
 	}
@@ -207,7 +209,7 @@ class OpenWorkspaceInAgentsTitleBarWidget extends BaseActionViewItem {
 		container.setAttribute('role', 'button');
 
 		const label = this.action.label;
-		const hoverText = localize('openInAgentsHover', "Open in Agents Window");
+		const hoverText = this.keybindingService.appendKeybinding(localize('openInAgentsHover', "Open in Agents Window"), OPEN_AGENTS_WINDOW_COMMAND_ID);
 		container.setAttribute('aria-label', hoverText);
 		this._register(this.hoverService.setupManagedHover(getDefaultHoverDelegate('element'), container, hoverText));
 


### PR DESCRIPTION
Improve the user experience by integrating keybindings into the hover text for the OpenInVSCode and OpenWorkspaceInAgents widgets. This change allows users to see the associated keybindings directly in the UI.

Fixes https://github.com/microsoft/vscode/issues/320501

fyi @sandy081 