### PR TITLE
[Cherry-pick release/1.123] Pick up current and future Claude models for tool search and prompt routing

### DIFF
--- a/extensions/copilot/src/extension/prompts/node/agent/anthropicPrompts.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/anthropicPrompts.tsx
@@ -633,8 +633,12 @@ class AnthropicPromptResolver implements IAgentPrompt {
 			|| endpoint.family.includes('4-5') || endpoint.family.includes('4.5');
 	}
 
-	private isOpus(endpoint: IChatEndpoint): boolean {
-		return endpoint.model.startsWith('claude-opus') || endpoint.family.startsWith('claude-opus');
+	private isSonnet(endpoint: IChatEndpoint): boolean {
+		return endpoint.model.startsWith('claude-sonnet') || endpoint.family.startsWith('claude-sonnet');
+	}
+
+	private isHaiku(endpoint: IChatEndpoint): boolean {
+		return endpoint.model.startsWith('claude-haiku') || endpoint.family.startsWith('claude-haiku');
 	}
 
 	private isOpus47(endpoint: IChatEndpoint): boolean {
@@ -649,13 +653,18 @@ class AnthropicPromptResolver implements IAgentPrompt {
 		if (this.isClaude45(endpoint)) {
 			return Claude45DefaultPrompt;
 		}
+		if (this.isSonnet(endpoint)) {
+			return Claude46SonnetPrompt;
+		}
+		if (this.isHaiku(endpoint)) {
+			return Claude45DefaultPrompt;
+		}
 		if (this.isOpus47(endpoint) && this.configurationService.getExperimentBasedConfig(ConfigKey.Claude47OpusPromptEnabled, this.experimentationService)) {
 			return Claude47OpusPrompt;
 		}
-		if (this.isOpus(endpoint)) {
-			return Claude46OpusPrompt;
-		}
-		return Claude46SonnetPrompt;
+		// Default for every other current and future model (including ones not
+		// yet individually recognized): the latest general-purpose Opus prompt.
+		return Claude46OpusPrompt;
 	}
 
 	resolveReminderInstructions(endpoint: IChatEndpoint): ReminderInstructionsConstructor | undefined {

--- a/extensions/copilot/src/platform/endpoint/common/chatModelCapabilities.ts
+++ b/extensions/copilot/src/platform/endpoint/common/chatModelCapabilities.ts
@@ -436,8 +436,9 @@ export function getVerbosityForModelSync(model: IChatEndpoint): 'low' | 'medium'
 
 /**
  * Tool search is supported by:
- * - Claude Sonnet 4.5 / 4.6 (claude-sonnet-4-5-* or 4-6-*)
- * - Claude Opus 4.5 / 4.6 / 4.7 (claude-opus-4-5-*, 4-6-*, or 4-7-*)
+ * - Current-generation Claude models (4.5 and newer), so new and future Claude
+ *   models are picked up automatically. Haiku (no tool search support) and the
+ *   pre-4.5 generations are denied explicitly.
  * - OpenAI gpt-5.4 and gpt-5.5 (via Responses API client-side tool search)
  *
  * Accepts either an id string, a {@link LanguageModelChat}, or an
@@ -450,11 +451,29 @@ export function modelSupportsToolSearch(model: LanguageModelChat | IChatEndpoint
 	const family = typeof model === 'string' ? model : model.family;
 	const matches = (s: string) => {
 		const n = s.toLowerCase().replace(/\./g, '-');
-		return n === 'gpt-5-4' ||
-			n === 'gpt-5-5' ||
-			n.startsWith('claude-sonnet-4-5') ||
-			n.startsWith('claude-sonnet-4-6') ||
-			(!n.startsWith('claude-opus-4-1') && n.startsWith('claude-opus-4-'));
+		// OpenAI models with client-side tool search.
+		if (n === 'gpt-5-4' || n === 'gpt-5-5') {
+			return true;
+		}
+		if (!n.startsWith('claude')) {
+			return false;
+		}
+		// Haiku has no tool search support — deny it explicitly.
+		if (n.startsWith('claude-haiku')) {
+			return false;
+		}
+		// Pre-4.5 Claude generations are unsupported; everything newer
+		// (including future families) is allowed automatically. The `-4-2`
+		// prefixes also catch the datestamped 4.0 bases (e.g.
+		// `claude-sonnet-4-20250514`, which normalizes to `...-4-2...`).
+		const isPre45 =
+			n.startsWith('claude-1') ||
+			n.startsWith('claude-2') ||
+			n.startsWith('claude-3') ||
+			n.startsWith('claude-instant') ||
+			n === 'claude-sonnet-4' || n.startsWith('claude-sonnet-4-2') ||
+			n === 'claude-opus-4' || n.startsWith('claude-opus-4-1') || n.startsWith('claude-opus-4-2');
+		return !isPre45;
 	};
 	return matches(id) || matches(family) || isHiddenModelM(family);
 }

--- a/extensions/copilot/src/platform/endpoint/test/node/chatModelCapabilities.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/test/node/chatModelCapabilities.spec.ts
@@ -42,7 +42,7 @@ describe('modelSupportsPDFDocuments', () => {
 });
 
 describe('modelSupportsToolSearch', () => {
-	test('supports Claude Sonnet/Opus 4.5 and up', () => {
+	test('supports Claude Sonnet/Opus 4.5 and up, including new and future families', () => {
 		expect(modelSupportsToolSearch('claude-sonnet-4-5')).toBe(true);
 		expect(modelSupportsToolSearch('claude-sonnet-4.5')).toBe(true);
 		expect(modelSupportsToolSearch('claude-sonnet-4-5-20250929')).toBe(true);
@@ -56,6 +56,9 @@ describe('modelSupportsToolSearch', () => {
 		expect(modelSupportsToolSearch('claude-opus-4.7')).toBe(true);
 		expect(modelSupportsToolSearch('claude-opus-4-7@1.0.0')).toBe(true);
 		expect(modelSupportsToolSearch('claude-sonnet-4-6@1.0.0')).toBe(true);
+		// Denylist: newer/future Claude families are picked up automatically.
+		expect(modelSupportsToolSearch('claude-opus-4-8')).toBe(true);
+		expect(modelSupportsToolSearch('claude-future-version')).toBe(true);
 	});
 
 	test('rejects pre-4.5 models, including date-suffixed ones', () => {
@@ -63,13 +66,16 @@ describe('modelSupportsToolSearch', () => {
 		expect(modelSupportsToolSearch('claude-sonnet-4-20250514')).toBe(false);
 		expect(modelSupportsToolSearch('claude-sonnet-4')).toBe(false);
 		expect(modelSupportsToolSearch('claude-opus-4')).toBe(false);
+		expect(modelSupportsToolSearch('claude-opus-4-20250514')).toBe(false);
 		expect(modelSupportsToolSearch('claude-opus-4-1')).toBe(false);
 		expect(modelSupportsToolSearch('claude-opus-4.1')).toBe(false);
 		expect(modelSupportsToolSearch('claude-opus-4-1-20250805')).toBe(false);
 	});
 
-	test('rejects non-Sonnet/Opus Claude families', () => {
+	test('rejects Haiku and legacy Claude families', () => {
+	// Haiku is current-gen but has no tool search support — denied explicitly.
 		expect(modelSupportsToolSearch('claude-haiku-4-5')).toBe(false);
+		expect(modelSupportsToolSearch('claude-haiku-4.5')).toBe(false);
 		expect(modelSupportsToolSearch('claude-3-5-sonnet-20241022')).toBe(false);
 		expect(modelSupportsToolSearch('claude-3-opus')).toBe(false);
 	});


### PR DESCRIPTION
Cherry-pick of #320513 onto `release/1.123`.

`modelSupportsToolSearch` is now a denylist instead of an allowlist: current-generation Claude (4.5+) is supported automatically, so new and future families work without a code change. Haiku (no tool search support) and pre-4.5 generations are denied explicitly. OpenAI gpt-5.4/5.5 unchanged.

The Anthropic prompt resolver routes Sonnet and Haiku explicitly and defaults every other current/future model to the latest general-purpose Opus prompt.

Applied cleanly (no conflicts); `chatModelCapabilities` and `agentPrompt` specs pass (180) on the release branch.