### PR TITLE
Add tooltips to agent host session config pickers

### DIFF
--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostClaudePermissionModePicker.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostClaudePermissionModePicker.ts
@@ -11,6 +11,7 @@ import { ActionListItemKind, IActionListItem } from '../../../../../platform/act
 import { IActionWidgetService } from '../../../../../platform/actionWidget/browser/actionWidget.js';
 import { ClaudeSessionConfigKey } from '../../../../../platform/agentHost/common/claudeSessionConfigKeys.js';
 import { SessionConfigPropertySchema } from '../../../../../platform/agentHost/common/state/protocol/commands.js';
+import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 import { IOpenerService } from '../../../../../platform/opener/common/opener.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
@@ -42,9 +43,10 @@ export class AgentHostClaudePermissionModePicker extends AgentHostSessionEnumPic
 		@ISessionsManagementService sessionsManagementService: ISessionsManagementService,
 		@ISessionsProvidersService sessionsProvidersService: ISessionsProvidersService,
 		@ITelemetryService telemetryService: ITelemetryService,
+		@IHoverService hoverService: IHoverService,
 		@IOpenerService private readonly _openerService: IOpenerService,
 	) {
-		super(actionWidgetService, sessionsManagementService, sessionsProvidersService, telemetryService);
+		super(actionWidgetService, sessionsManagementService, sessionsProvidersService, telemetryService, hoverService);
 	}
 
 	protected _isWellKnownSchema(schema: SessionConfigPropertySchema): boolean {

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostModePicker.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostModePicker.ts
@@ -13,6 +13,7 @@ import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { localize } from '../../../../../nls.js';
 import { ActionListItemKind, IActionListDelegate, IActionListItem } from '../../../../../platform/actionWidget/browser/actionList.js';
 import { IActionWidgetService } from '../../../../../platform/actionWidget/browser/actionWidget.js';
+import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 import { SessionConfigKey } from '../../../../../platform/agentHost/common/sessionConfigKeys.js';
 import { SessionConfigPropertySchema } from '../../../../../platform/agentHost/common/state/protocol/commands.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
@@ -60,6 +61,7 @@ export abstract class AgentHostSessionEnumPicker extends Disposable {
 		@ISessionsManagementService private readonly _sessionsManagementService: ISessionsManagementService,
 		@ISessionsProvidersService private readonly _sessionsProvidersService: ISessionsProvidersService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
+		@IHoverService private readonly _hoverService: IHoverService,
 	) {
 		super();
 
@@ -90,6 +92,7 @@ export abstract class AgentHostSessionEnumPicker extends Disposable {
 		trigger.tabIndex = 0;
 		trigger.role = 'button';
 		this._triggerElement = trigger;
+		this._renderDisposables.add(this._hoverService.setupDelayedHover(trigger, () => ({ content: this._getActiveContext()?.tooltip ?? '' })));
 
 		this._renderDisposables.add(Gesture.addTarget(trigger));
 		for (const eventType of [dom.EventType.CLICK, TouchEventType.Tap]) {
@@ -143,7 +146,7 @@ export abstract class AgentHostSessionEnumPicker extends Disposable {
 		return provider.isSessionConfigResolving(session.sessionId).get();
 	}
 
-	private _getActiveContext(): { provider: IAgentHostSessionsProvider; sessionId: string; currentValue: string; items: readonly IAgentHostSessionEnumPickerItem[] } | undefined {
+	private _getActiveContext(): { provider: IAgentHostSessionsProvider; sessionId: string; currentValue: string; items: readonly IAgentHostSessionEnumPickerItem[]; tooltip: string } | undefined {
 		const session = this._sessionsManagementService.activeSession.get();
 		if (!session) {
 			return undefined;
@@ -167,7 +170,7 @@ export abstract class AgentHostSessionEnumPicker extends Disposable {
 		}));
 		const rawCurrent = config?.values[this._property] ?? schema.default;
 		const currentValue = typeof rawCurrent === 'string' && enumValues.includes(rawCurrent) ? rawCurrent : enumValues[0] ?? '';
-		return { provider: rawProvider, sessionId: session.sessionId, currentValue, items };
+		return { provider: rawProvider, sessionId: session.sessionId, currentValue, items, tooltip: schema.description ?? schema.title ?? '' };
 	}
 
 	private _updateTrigger(): void {

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostPermissionPickerActionItem.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostPermissionPickerActionItem.ts
@@ -9,6 +9,7 @@ import { IActionWidgetService } from '../../../../../platform/actionWidget/brows
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
+import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IKeybindingService } from '../../../../../platform/keybinding/common/keybinding.js';
 import { IOpenerService } from '../../../../../platform/opener/common/opener.js';
@@ -47,6 +48,7 @@ export class AgentHostPermissionPickerActionItem extends PermissionPickerActionI
 		@IDialogService dialogService: IDialogService,
 		@IOpenerService openerService: IOpenerService,
 		@IStorageService storageService: IStorageService,
+		@IHoverService hoverService: IHoverService,
 		@ISessionsManagementService private readonly _sessionsManagementService: ISessionsManagementService,
 		@ISessionsProvidersService private readonly _sessionsProvidersService: ISessionsProvidersService,
 	) {
@@ -63,6 +65,7 @@ export class AgentHostPermissionPickerActionItem extends PermissionPickerActionI
 			dialogService,
 			openerService,
 			storageService,
+			hoverService,
 		);
 		this._delegate = this._register(delegate);
 		// Initialized here (not as a class field) so the `derived` body can

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionConfigPicker.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionConfigPicker.ts
@@ -24,6 +24,7 @@ import { IConfigurationService } from '../../../../../platform/configuration/com
 import { ContextKeyExpr, IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import type { SessionConfigPropertySchema, SessionConfigValueItem } from '../../../../../platform/agentHost/common/state/protocol/commands.js';
 import { ChatConfiguration } from '../../../../../workbench/contrib/chat/common/constants.js';
@@ -248,6 +249,7 @@ export class AgentHostSessionConfigPicker extends Disposable {
 		@IConfigurationService protected readonly _configurationService: IConfigurationService,
 		@IContextKeyService protected readonly _contextKeyService: IContextKeyService,
 		@IDialogService protected readonly _dialogService: IDialogService,
+		@IHoverService protected readonly _hoverService: IHoverService,
 		@ISessionsManagementService protected readonly _sessionsManagementService: ISessionsManagementService,
 		@ISessionsProvidersService protected readonly _sessionsProvidersService: ISessionsProvidersService,
 		@ITelemetryService protected readonly _telemetryService: ITelemetryService,
@@ -346,6 +348,10 @@ export class AgentHostSessionConfigPicker extends Disposable {
 			// keeping it focusable and using correct ARIA semantics. The
 			// click handler bails when resolving in `_showPicker`.
 			const trigger = renderPickerTrigger(slot, isReadOnly, this._renderDisposables, () => this._showPicker(provider, session.sessionId, property, schema, trigger));
+			const tooltip = schema.description ?? schema.title;
+			if (tooltip) {
+				this._renderDisposables.add(this._hoverService.setupDelayedHover(trigger, { content: tooltip }));
+			}
 			if (!isReadOnly && isLoading) {
 				slot.classList.add('disabled');
 				trigger.setAttribute('aria-disabled', 'true');

--- a/src/vs/sessions/contrib/providers/agentHost/browser/mobile/mobileAgentHostModePicker.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/mobile/mobileAgentHostModePicker.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IActionWidgetService } from '../../../../../../platform/actionWidget/browser/actionWidget.js';
+import { IHoverService } from '../../../../../../platform/hover/browser/hover.js';
 import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
 import { IChatPhoneInputPresenter } from '../../../../../../workbench/contrib/chat/browser/widget/input/chatPhoneInputPresenter.js';
 import { ISessionsProvidersService } from '../../../../../services/sessions/browser/sessionsProvidersService.js';
@@ -26,9 +27,10 @@ export class MobileAgentHostModePicker extends AgentHostModePicker {
 		@ISessionsManagementService sessionsManagementService: ISessionsManagementService,
 		@ISessionsProvidersService sessionsProvidersService: ISessionsProvidersService,
 		@ITelemetryService telemetryService: ITelemetryService,
+		@IHoverService hoverService: IHoverService,
 		@IChatPhoneInputPresenter private readonly _phonePresenter: IChatPhoneInputPresenter,
 	) {
-		super(actionWidgetService, sessionsManagementService, sessionsProvidersService, telemetryService);
+		super(actionWidgetService, sessionsManagementService, sessionsProvidersService, telemetryService, hoverService);
 	}
 
 	protected override _showPicker(): void {

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/agentHostClaudePermissionModePicker.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/agentHostClaudePermissionModePicker.test.ts
@@ -12,6 +12,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/
 import { IActionListItem } from '../../../../../../platform/actionWidget/browser/actionList.js';
 import { IActionWidgetService } from '../../../../../../platform/actionWidget/browser/actionWidget.js';
 import { ResolveSessionConfigResult } from '../../../../../../platform/agentHost/common/state/protocol/commands.js';
+import { IHoverService } from '../../../../../../platform/hover/browser/hover.js';
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { IOpenerService } from '../../../../../../platform/opener/common/opener.js';
 import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
@@ -97,6 +98,9 @@ suite('AgentHostClaudePermissionModePicker', () => {
 			}
 		})());
 		instantiationService.stub(ITelemetryService, NullTelemetryService);
+		instantiationService.stub(IHoverService, {
+			setupDelayedHover: () => ({ dispose: () => { } }),
+		} as Partial<IHoverService> as IHoverService);
 
 		const picker = store.add(instantiationService.createInstance(AgentHostClaudePermissionModePicker));
 		const container = document.createElement('div');

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker.ts
@@ -25,6 +25,7 @@ import { StateComponents } from '../../../../../../platform/agentHost/common/sta
 import { type IAgentSubscription } from '../../../../../../platform/agentHost/common/state/agentSubscription.js';
 import { ActionListItemKind, IActionListDelegate, IActionListItem } from '../../../../../../platform/actionWidget/browser/actionList.js';
 import { IActionWidgetService } from '../../../../../../platform/actionWidget/browser/actionWidget.js';
+import { IHoverService } from '../../../../../../platform/hover/browser/hover.js';
 import { IOpenerService } from '../../../../../../platform/opener/common/opener.js';
 import type { IAction } from '../../../../../../base/common/actions.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
@@ -196,6 +197,7 @@ export class AgentHostChatInputPicker extends Disposable {
 		private readonly _property: string,
 		@IAgentHostService private readonly _agentHostService: IAgentHostService,
 		@IActionWidgetService private readonly _actionWidgetService: IActionWidgetService,
+		@IHoverService private readonly _hoverService: IHoverService,
 		@IOpenerService private readonly _openerService: IOpenerService,
 		@IAgentHostSessionWorkingDirectoryResolver private readonly _workingDirectoryResolver: IAgentHostSessionWorkingDirectoryResolver,
 		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
@@ -342,6 +344,10 @@ export class AgentHostChatInputPicker extends Disposable {
 
 		const isReadOnly = !!ctx.schema.readOnly || (isStartedSession && ctx.schema.sessionMutable === false);
 		const trigger = renderPickerTrigger(slot, isReadOnly, this._renderDisposables, () => this._showPicker(trigger));
+		const tooltip = ctx.schema.description ?? ctx.schema.title;
+		if (tooltip) {
+			this._renderDisposables.add(this._hoverService.setupDelayedHover(trigger, { content: tooltip }));
+		}
 		this._renderTrigger(trigger, ctx.schema, ctx.value, isReadOnly);
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/permissionPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/permissionPickerActionItem.ts
@@ -21,6 +21,7 @@ import { IChatSessionProviderOptionItem, SessionType } from '../../../common/cha
 import { MenuItemAction } from '../../../../../../platform/actions/common/actions.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { IDialogService } from '../../../../../../platform/dialogs/common/dialogs.js';
+import { IHoverService } from '../../../../../../platform/hover/browser/hover.js';
 import { ChatInputPickerActionViewItem, IChatInputPickerOptions } from './chatInputPickerActionItem.js';
 import { IOpenerService } from '../../../../../../platform/opener/common/opener.js';
 import { URI } from '../../../../../../base/common/uri.js';
@@ -56,6 +57,9 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 	private readonly _onDidDispose = this._register(new Emitter<void>());
 	readonly onDidDispose: Event<void> = this._onDidDispose.event;
 
+	private _currentTooltip: string = '';
+	private _hoverSetup = false;
+
 	constructor(
 		action: MenuItemAction,
 		private readonly delegate: IPermissionPickerDelegate,
@@ -68,6 +72,7 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 		@IDialogService private readonly dialogService: IDialogService,
 		@IOpenerService openerService: IOpenerService,
 		@IStorageService storageService: IStorageService,
+		@IHoverService private readonly hoverService: IHoverService,
 	) {
 		const isAutoApprovePolicyRestricted = () => configurationService.inspect<boolean>(ChatConfiguration.GlobalAutoApprove).policyValue === false;
 		const actionProvider: IActionWidgetDropdownActionProvider = {
@@ -197,6 +202,7 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 		const ext = this.delegate.getExtensionPermissions?.();
 		let icon: ThemeIcon;
 		let label: string;
+		let tooltip: string;
 		const level = this.delegate.currentPermissionLevel.get();
 		if (ext && ext.items.length > 0) {
 			const selected = ext.items.find(i => i.id === ext.selectedId)
@@ -204,19 +210,23 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 				?? ext.items[0];
 			icon = selected.icon ?? Codicon.lock;
 			label = selected.name;
+			tooltip = selected.description ?? selected.name;
 		} else {
 			switch (level) {
 				case ChatPermissionLevel.Autopilot:
 					icon = Codicon.rocket;
 					label = localize('permissions.autopilot.label', "Autopilot (Preview)");
+					tooltip = localize('permissions.autopilot.description', "Auto-approve all tool calls and continue until the task is done. Autopilot may increase costs.");
 					break;
 				case ChatPermissionLevel.AutoApprove:
 					icon = Codicon.warning;
 					label = localize('permissions.autoApprove.label', "Bypass Approvals");
+					tooltip = localize('permissions.autoApprove.description', "Auto-approve all tool calls and retry on errors");
 					break;
 				default:
 					icon = Codicon.shield;
 					label = localize('permissions.default.label', "Default Approvals");
+					tooltip = localize('permissions.default.description', "Use configured approval settings");
 					break;
 			}
 		}
@@ -230,6 +240,12 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 		element.classList.toggle('info', !ext && level === ChatPermissionLevel.AutoApprove);
 
 		element.setAttribute('aria-label', localize('permissions.ariaLabel', "Permission picker, {0}", label));
+
+		this._currentTooltip = tooltip;
+		if (!this._hoverSetup) {
+			this._hoverSetup = true;
+			this._register(this.hoverService.setupDelayedHover(element, () => ({ content: this._currentTooltip })));
+		}
 		return null;
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/permissionPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/permissionPickerActionItem.ts
@@ -7,7 +7,7 @@ import * as dom from '../../../../../../base/browser/dom.js';
 import { renderLabelWithIcons } from '../../../../../../base/browser/ui/iconLabel/iconLabels.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
-import { IDisposable } from '../../../../../../base/common/lifecycle.js';
+import { IDisposable, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
 import { IObservable } from '../../../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { localize } from '../../../../../../nls.js';
@@ -58,7 +58,8 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 	readonly onDidDispose: Event<void> = this._onDidDispose.event;
 
 	private _currentTooltip: string = '';
-	private _hoverSetup = false;
+	private _hoverElement: HTMLElement | undefined;
+	private readonly _hover = this._register(new MutableDisposable<IDisposable>());
 
 	constructor(
 		action: MenuItemAction,
@@ -242,9 +243,13 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 		element.setAttribute('aria-label', localize('permissions.ariaLabel', "Permission picker, {0}", label));
 
 		this._currentTooltip = tooltip;
-		if (!this._hoverSetup) {
-			this._hoverSetup = true;
-			this._register(this.hoverService.setupDelayedHover(element, () => ({ content: this._currentTooltip })));
+		// `renderLabel` can run against a fresh element on subsequent
+		// `render()` calls (e.g. when the item moves into/out of overflow).
+		// Re-wire the hover on the new element and dispose the previous
+		// registration so it doesn't leak the old element.
+		if (this._hoverElement !== element) {
+			this._hoverElement = element;
+			this._hover.value = this.hoverService.setupDelayedHover(element, () => ({ content: this._currentTooltip }));
 		}
 		return null;
 	}


### PR DESCRIPTION
Fixes #319820

The agent host session config dropdowns (Approvals, Mode, Branch, Worktree, etc.) set an `aria-label` but never wired up a hover tooltip, even though the underlying schemas (e.g. `platformSessionSchema`) already carry descriptions.

This hooks the schema `description` (falling back to `title`) up as a delayed hover on each picker trigger across the affected surfaces:
- `agentHostSessionConfigPicker` (generic per-property chips)
- `agentHostModePicker` / `agentHostClaudePermissionModePicker` (enum pickers)
- `permissionPickerActionItem` (well-known Approvals picker)
- `agentHostChatInputPicker` (chat input chips)

Uses the non-deprecated `IHoverService.setupDelayedHover` and wires each hover exactly once per trigger.