### PR TITLE
Only show WSL remote picker option on Windows

### DIFF
--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostActions.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostActions.ts
@@ -1166,7 +1166,10 @@ registerAction2(class extends Action2 {
 			menu: {
 				id: Menus.SessionWorkspaceManage,
 				order: 15,
-				when: SessionWorkspacePickerGroupContext.isEqualTo(SESSION_WORKSPACE_GROUP_REMOTE),
+				when: ContextKeyExpr.and(
+					ContextKeyExpr.equals('isWindows', true),
+					SessionWorkspacePickerGroupContext.isEqualTo(SESSION_WORKSPACE_GROUP_REMOTE),
+				),
 			},
 		});
 	}


### PR DESCRIPTION
Fixes #320541

The `connectViaWSL` action already had an `isWindows` precondition, but the menu `when` clause only checked the picker group — so the `WSL...` item still appeared (greyed out) in the remote workspace picker on non-Windows. This adds `isWindows` to the menu `when` so the item is hidden entirely off Windows.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>