### PR TITLE
agent-host: complete the turn when `/compact` finishes

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -777,12 +777,15 @@ export class CopilotAgentSession extends Disposable {
 
 		const slashCommand = parseLeadingSlashCommand(prompt);
 		if (slashCommand?.command === 'compact') {
+			let success: boolean;
 			try {
-				await this._wrapper.session.rpc.history.compact();
+				const result = await this._wrapper.session.rpc.history.compact();
+				success = result.success;
 			} catch (err) {
 				this._logService.error(err, `[Copilot:${this.sessionId}] rpc.history.compact failed`);
 				throw err;
 			}
+			this._completeActiveTurn();
 			return;
 		}
 		if (slashCommand?.command === 'research') {

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -777,22 +777,16 @@ export class CopilotAgentSession extends Disposable {
 
 		const slashCommand = parseLeadingSlashCommand(prompt);
 		if (slashCommand?.command === 'compact') {
-			let success: boolean;
 			try {
-				const result = await this._wrapper.session.rpc.history.compact();
-				success = result.success;
+				await this._wrapper.session.rpc.history.compact();
 			} catch (err) {
 				this._logService.error(err, `[Copilot:${this.sessionId}] rpc.history.compact failed`);
 				throw err;
 			}
 			// `/compact` is handled inline via the history RPC rather than by
 			// driving an SDK turn, so the SDK never fires `onIdle` to close the
-			// turn. Mirror the generic `/rename` handling: acknowledge with a
-			// brief response and complete the turn so the session returns to
-			// idle instead of spinning forever.
-			this._emitMarkdownDelta(success
-				? localize('copilotCompact.compacted', "Compacted conversation history.")
-				: localize('copilotCompact.failed', "Unable to compact conversation history."));
+			// turn. Complete the turn here so the session returns to idle
+			// instead of spinning forever.
 			this._completeActiveTurn();
 			return;
 		}

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -785,6 +785,14 @@ export class CopilotAgentSession extends Disposable {
 				this._logService.error(err, `[Copilot:${this.sessionId}] rpc.history.compact failed`);
 				throw err;
 			}
+			// `/compact` is handled inline via the history RPC rather than by
+			// driving an SDK turn, so the SDK never fires `onIdle` to close the
+			// turn. Mirror the generic `/rename` handling: acknowledge with a
+			// brief response and complete the turn so the session returns to
+			// idle instead of spinning forever.
+			this._emitMarkdownDelta(success
+				? localize('copilotCompact.compacted', "Compacted conversation history.")
+				: localize('copilotCompact.failed', "Unable to compact conversation history."));
 			this._completeActiveTurn();
 			return;
 		}

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -432,7 +432,7 @@ suite('CopilotAgentSession', () => {
 		}]);
 	});
 
-	test('`/compact` runs the history compact RPC, acknowledges, and completes the turn', async () => {
+	test('`/compact` runs the history compact RPC and completes the turn without emitting output', async () => {
 		const { session, mockSession, signals } = await createAgentSession(disposables);
 
 		await session.send('/compact', undefined, 'turn-compact');
@@ -443,16 +443,12 @@ suite('CopilotAgentSession', () => {
 		assert.deepStrictEqual(mockSession.sendRequests, []);
 
 		// The turn opened by the server is closed inline (the SDK never fires
-		// `onIdle` for the compact path), with the acknowledgement landing in
-		// the turn before it completes.
-		const actions = getActions(signals).filter(a =>
-			a.type === ActionType.SessionResponsePart || a.type === ActionType.SessionTurnComplete);
-		assert.deepStrictEqual(actions.map(a => a.type), [
-			ActionType.SessionResponsePart,
-			ActionType.SessionTurnComplete,
-		]);
-		assert.strictEqual((actions[0] as SessionResponsePartAction).turnId, 'turn-compact');
-		assert.strictEqual((actions[1] as SessionTurnCompleteAction).turnId, 'turn-compact');
+		// `onIdle` for the compact path) without emitting any response content.
+		const actions = getActions(signals);
+		assert.deepStrictEqual(actions.filter(a => a.type === ActionType.SessionResponsePart), []);
+		const turnComplete = actions.find(a => a.type === ActionType.SessionTurnComplete);
+		assert.ok(turnComplete, 'expected the turn to complete');
+		assert.strictEqual((turnComplete as SessionTurnCompleteAction).turnId, 'turn-compact');
 	});
 
 	test('`/compact` completes the turn even when compaction reports failure', async () => {

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -23,7 +23,7 @@ import { NullTelemetryServiceShape } from '../../../telemetry/common/telemetryUt
 import { AgentSession, type AgentSignal, type IAgentActionSignal, type IAgentToolPendingConfirmationSignal } from '../../common/agentService.js';
 import { IDiffComputeService } from '../../common/diffComputeService.js';
 import { ISessionDataService } from '../../common/sessionDataService.js';
-import { ActionType, type SessionDeltaAction, type SessionErrorAction, type SessionInputRequestedAction, type SessionResponsePartAction, type SessionToolCallCompleteAction, type SessionToolCallReadyAction, type SessionToolCallStartAction } from '../../common/state/sessionActions.js';
+import { ActionType, type SessionDeltaAction, type SessionErrorAction, type SessionInputRequestedAction, type SessionResponsePartAction, type SessionToolCallCompleteAction, type SessionToolCallReadyAction, type SessionToolCallStartAction, type SessionTurnCompleteAction } from '../../common/state/sessionActions.js';
 import { MessageAttachmentKind, MessageKind, ResponsePartKind, SessionInputAnswerState, SessionInputAnswerValueKind, SessionInputQuestionKind, SessionInputResponseKind, ToolCallContributorKind, ToolCallStatus, ToolResultContentType, type ToolResultFileEditContent } from '../../common/state/sessionState.js';
 import { CopilotAgentSession } from '../../node/copilot/copilotAgentSession.js';
 import { type CopilotSessionLaunchPlan, type IActiveClientSnapshot, type ICopilotSessionLauncher, type ICopilotSessionRuntime } from '../../node/copilot/copilotSessionLauncher.js';
@@ -44,6 +44,8 @@ class MockCopilotSession {
 	readonly sessionId = 'test-session-1';
 	readonly sendRequests: unknown[] = [];
 	readonly modeSetCalls: Array<{ mode: 'interactive' | 'plan' | 'autopilot' }> = [];
+	readonly compactCalls: unknown[] = [];
+	compactResult: { success: boolean; tokensRemoved: number; messagesRemoved: number } = { success: true, tokensRemoved: 0, messagesRemoved: 0 };
 	messages: SessionEvent[] = [];
 
 	private readonly _handlers = new Map<string, Set<(event: SessionEvent) => void>>();
@@ -91,6 +93,12 @@ class MockCopilotSession {
 			read: async () => this.planReadResult,
 			update: async (_params: { content: string }) => { /* no-op */ },
 			delete: async () => { /* no-op */ },
+		},
+		history: {
+			compact: async (params?: unknown) => {
+				this.compactCalls.push(params ?? null);
+				return this.compactResult;
+			},
 		},
 	};
 }
@@ -422,6 +430,40 @@ suite('CopilotAgentSession', () => {
 			usage: undefined,
 			state: 'cancelled',
 		}]);
+	});
+
+	test('`/compact` runs the history compact RPC, acknowledges, and completes the turn', async () => {
+		const { session, mockSession, signals } = await createAgentSession(disposables);
+
+		await session.send('/compact', undefined, 'turn-compact');
+
+		// The compact command is handled inline via the history RPC and must
+		// not fall through to a normal SDK `send()` turn.
+		assert.strictEqual(mockSession.compactCalls.length, 1);
+		assert.deepStrictEqual(mockSession.sendRequests, []);
+
+		// The turn opened by the server is closed inline (the SDK never fires
+		// `onIdle` for the compact path), with the acknowledgement landing in
+		// the turn before it completes.
+		const actions = getActions(signals).filter(a =>
+			a.type === ActionType.SessionResponsePart || a.type === ActionType.SessionTurnComplete);
+		assert.deepStrictEqual(actions.map(a => a.type), [
+			ActionType.SessionResponsePart,
+			ActionType.SessionTurnComplete,
+		]);
+		assert.strictEqual((actions[0] as SessionResponsePartAction).turnId, 'turn-compact');
+		assert.strictEqual((actions[1] as SessionTurnCompleteAction).turnId, 'turn-compact');
+	});
+
+	test('`/compact` completes the turn even when compaction reports failure', async () => {
+		const { session, mockSession, signals } = await createAgentSession(disposables);
+		mockSession.compactResult = { success: false, tokensRemoved: 0, messagesRemoved: 0 };
+
+		await session.send('/compact', undefined, 'turn-compact');
+
+		assert.strictEqual(mockSession.compactCalls.length, 1);
+		const turnComplete = getActions(signals).find(a => a.type === ActionType.SessionTurnComplete);
+		assert.ok(turnComplete, 'expected the turn to complete on a failed compaction');
 	});
 
 	test('emits accumulated Copilot usage metadata', async () => {

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -462,6 +462,7 @@ suite('CopilotAgentSession', () => {
 		await session.send('/compact', undefined, 'turn-compact');
 
 		assert.strictEqual(mockSession.compactCalls.length, 1);
+		assert.deepStrictEqual(mockSession.sendRequests, []);
 		const turnComplete = getActions(signals).find(a => a.type === ActionType.SessionTurnComplete);
 		assert.ok(turnComplete, 'expected the turn to complete on a failed compaction');
 	});


### PR DESCRIPTION
Fixes #320152

## Problem

In AHP Copilot sessions, typing `/compact` left the UI spinning "working forever".

`CopilotAgentSession.send()` special-cases `/compact` by calling `this._wrapper.session.rpc.history.compact()` and returning early **without** driving an SDK turn. Turn completion (`ActionType.SessionTurnComplete`) is only emitted from the SDK's `onIdle` event, which never fires for the compact path. As a result the turn opened by the server (the `SessionTurnStarted` handler in `agentSideEffects`) is never closed, so the session never returns to idle.

`/research` and `/plan` don't hit this because they fall through to the normal `session.send()` path.

## Fix

Mirror the existing generic `/rename` handling (`agentSideEffects._tryHandleRenameCommand`): after the compact RPC resolves, emit a brief acknowledgement response part and then complete the active turn.

- Routes through the same `_runTurnCompleteSideEffects` path as a normal `onIdle` completion, so queued-message draining and turn telemetry are unaffected.
- A late/racing `onIdle` is harmless — `_completeActiveTurn()` clears `_turnId`, so a second call is a no-op.
- The error path is unchanged: it re-throws, and `agentSideEffects` dispatches `SessionError` (which ends the turn).

## Tests

Added two regression tests in `copilotAgentSession.test.ts`:
- `/compact` calls the history compact RPC, does **not** fall through to `session.send()`, and emits `SessionResponsePart` then `SessionTurnComplete` for the turn.
- `/compact` still completes the turn when compaction reports failure.

All 113 `CopilotAgentSession` tests pass; type-check and ESLint are clean.