### PR TITLE
agentHost: refresh static changesets after git state

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostChangesetCoordinator.ts
+++ b/src/vs/platform/agentHost/node/agentHostChangesetCoordinator.ts
@@ -97,10 +97,10 @@ export class ChangesetSessionCoordinator extends Disposable {
 		@IAgentConfigurationService private readonly _configurationService: IAgentConfigurationService,
 		@IAgentHostFileMonitorService fileMonitorService: IAgentHostFileMonitorService,
 		@IAgentHostGitService gitService: IAgentHostGitService,
-		@ILogService logService: ILogService,
+		@ILogService private readonly _logService: ILogService,
 	) {
 		super();
-		this._changesetFileMonitor = this._register(new ChangesetFileMonitorCoordinator(this._stateManager, this._changesets, this._configurationService, fileMonitorService, gitService, logService));
+		this._changesetFileMonitor = this._register(new ChangesetFileMonitorCoordinator(this._stateManager, this._changesets, this._configurationService, fileMonitorService, gitService, this._logService));
 		this._changesets.setTurnSubscriberProbe((session, turnId) => this.hasTurnSubscribers(session, turnId));
 	}
 
@@ -168,6 +168,7 @@ export class ChangesetSessionCoordinator extends Disposable {
 	 * refresh both static changesets once the session has a working directory.
 	 */
 	onSessionGitStateChanged(sessionStr: string): void {
+		this._logService.debug(`[ChangesetSessionCoordinator] Git state changed for ${sessionStr}; refreshing static changesets. hasWorkingDirectory=${!!this._configurationService.getEffectiveWorkingDirectory(sessionStr)}`);
 		this._triggerSessionRefresh(sessionStr);
 		this._triggerUncommittedRefresh(sessionStr);
 	}

--- a/src/vs/platform/agentHost/node/agentHostChangesetCoordinator.ts
+++ b/src/vs/platform/agentHost/node/agentHostChangesetCoordinator.ts
@@ -163,6 +163,16 @@ export class ChangesetSessionCoordinator extends Disposable {
 	}
 
 	/**
+	 * Called after `_meta.git` is attached or updated. Git state can provide
+	 * the base branch used by Branch Changes and fresh uncommitted counts, so
+	 * refresh both static changesets once the session has a working directory.
+	 */
+	onSessionGitStateChanged(sessionStr: string): void {
+		this._triggerSessionRefresh(sessionStr);
+		this._triggerUncommittedRefresh(sessionStr);
+	}
+
+	/**
 	 * Called when a session is disposed. Forgets any pending refresh
 	 * queued for that session.
 	 */

--- a/src/vs/platform/agentHost/node/agentHostChangesetService.ts
+++ b/src/vs/platform/agentHost/node/agentHostChangesetService.ts
@@ -738,6 +738,7 @@ export class AgentHostChangesetService extends Disposable implements IAgentHostC
 					// snapshot. Leave whatever live/persisted state is
 					// already there; the next successful path A will
 					// refresh it.
+					this._logService.debug(`[AgentHostChangesetService] Uncommitted git diff unavailable for ${session}; preserving cached changeset. previousStatus=${statusBeforeCompute ?? 'unknown'} cachedFiles=${this._stateManager.getChangesetState(changesetUri)?.files.length ?? 0}`);
 					this._restoreStaticChangesetStatus(changesetUri, statusBeforeCompute);
 					return;
 				}
@@ -909,9 +910,15 @@ export class AgentHostChangesetService extends Disposable implements IAgentHostC
 		} catch {
 			return undefined;
 		}
-		const baseBranch = kind === 'session'
-			? (await db.getMetadata(META_DIFF_BASE_BRANCH)) ?? readSessionGitState(this._stateManager.getSessionState(session)?._meta)?.baseBranchName
-			: undefined;
+		let baseBranch: string | undefined;
+		if (kind === 'session') {
+			const persistedBaseBranch = await db.getMetadata(META_DIFF_BASE_BRANCH);
+			const gitStateBaseBranch = readSessionGitState(this._stateManager.getSessionState(session)?._meta)?.baseBranchName;
+			baseBranch = persistedBaseBranch ?? gitStateBaseBranch;
+			if (!persistedBaseBranch && gitStateBaseBranch) {
+				this._logService.debug(`[AgentHostChangesetService] Using _meta.git base branch fallback for Branch Changes in ${session}: ${gitStateBaseBranch}`);
+			}
+		}
 		try {
 			return await this._gitService.computeSessionFileDiffs(workingDirectoryUri, { sessionUri: session, baseBranch });
 		} catch (err) {

--- a/src/vs/platform/agentHost/node/agentHostChangesetService.ts
+++ b/src/vs/platform/agentHost/node/agentHostChangesetService.ts
@@ -28,6 +28,7 @@ import {
 	type ChangesetFile,
 	type ISessionFileDiff,
 	type URI as ProtocolURI,
+	readSessionGitState,
 } from '../common/state/sessionState.js';
 import { AgentHostStateManager } from './agentHostStateManager.js';
 import { IAgentHostGitService, META_DIFF_BASE_BRANCH } from './agentHostGitService.js';
@@ -434,11 +435,11 @@ export class AgentHostChangesetService extends Disposable implements IAgentHostC
 	}
 
 	refreshUncommittedChangeset(session: ProtocolURI): void {
-		this._scheduleStaticRecompute(session, 'uncommitted');
+		this._scheduleStaticRecompute(session, 'uncommitted', undefined, this._markStaticChangesetComputing(session, 'uncommitted'));
 	}
 
 	refreshSessionChangeset(session: ProtocolURI): void {
-		this._scheduleStaticRecompute(session, 'session');
+		this._scheduleStaticRecompute(session, 'session', undefined, this._markStaticChangesetComputing(session, 'session'));
 	}
 
 	async computeTurnChangeset(session: ProtocolURI, turnId: string): Promise<ProtocolURI> {
@@ -693,18 +694,33 @@ export class AgentHostChangesetService extends Disposable implements IAgentHostC
 	 * stale `previousDiffs` reads. Fire-and-forget — failures are logged
 	 * but do not fail the turn.
 	 */
-	private _scheduleStaticRecompute(session: ProtocolURI, kind: StaticChangesetKind, changedTurnId?: string): void {
-		this._diffComputationSequencer.queue(`${session}\u0000${kind}`, () => this._doComputeStaticChangeset(session, kind, changedTurnId));
+	private _scheduleStaticRecompute(session: ProtocolURI, kind: StaticChangesetKind, changedTurnId?: string, statusBeforeRefresh?: ChangesetStatus): void {
+		this._diffComputationSequencer.queue(`${session}\u0000${kind}`, () => this._doComputeStaticChangeset(session, kind, changedTurnId, statusBeforeRefresh));
 	}
 
-	private async _doComputeStaticChangeset(session: ProtocolURI, kind: StaticChangesetKind, changedTurnId?: string): Promise<void> {
+	private _markStaticChangesetComputing(session: ProtocolURI, kind: StaticChangesetKind): ChangesetStatus | undefined {
+		const changesetUri = staticChangesetUri(session, kind);
+		this._stateManager.registerChangeset(changesetUri);
+		const status = this._stateManager.getChangesetState(changesetUri)?.status;
+		if (status !== ChangesetStatus.Computing) {
+			this._stateManager.dispatchServerAction(changesetUri, {
+				type: ActionType.ChangesetStatusChanged,
+				status: ChangesetStatus.Computing,
+			});
+		}
+		return status;
+	}
+
+	private async _doComputeStaticChangeset(session: ProtocolURI, kind: StaticChangesetKind, changedTurnId?: string, statusBeforeRefresh?: ChangesetStatus): Promise<void> {
 		const changesetUri = staticChangesetUri(session, kind);
 		this._activeStaticComputes.add(changesetUri);
+		const statusBeforeCompute = statusBeforeRefresh ?? this._stateManager.getChangesetState(changesetUri)?.status;
 		let ref: ReturnType<ISessionDataService['openDatabase']>;
 		try {
 			ref = this._sessionDataService.openDatabase(URI.parse(session));
 		} catch (err) {
 			this._logService.warn(`[AgentHostChangesetService] Failed to open session database for ${kind} diff computation: ${session}`, err);
+			this._restoreStaticChangesetStatus(changesetUri, statusBeforeCompute);
 			this._activeStaticComputes.delete(changesetUri);
 			this._stateManager.onChangesetLivenessChanged();
 			return;
@@ -722,6 +738,7 @@ export class AgentHostChangesetService extends Disposable implements IAgentHostC
 					// snapshot. Leave whatever live/persisted state is
 					// already there; the next successful path A will
 					// refresh it.
+					this._restoreStaticChangesetStatus(changesetUri, statusBeforeCompute);
 					return;
 				}
 				// `session` kind: working-tree git is unavailable (no
@@ -761,6 +778,23 @@ export class AgentHostChangesetService extends Disposable implements IAgentHostC
 			this._stateManager.onChangesetLivenessChanged();
 			ref.dispose();
 		}
+	}
+
+	/**
+	 * Refresh requests optimistically mark static changesets as Computing
+	 * while preserving their current files. Some refresh paths intentionally
+	 * do not publish a replacement file list (for example, uncommitted git
+	 * diff is temporarily unavailable), so restore the previous non-computing
+	 * status instead of leaving a stale cached snapshot stuck as Computing.
+	 */
+	private _restoreStaticChangesetStatus(changesetUri: ProtocolURI, status: ChangesetStatus | undefined): void {
+		if (!status || status === ChangesetStatus.Computing) {
+			return;
+		}
+		this._stateManager.dispatchServerAction(changesetUri, {
+			type: ActionType.ChangesetStatusChanged,
+			status,
+		});
 	}
 
 	/**
@@ -876,7 +910,7 @@ export class AgentHostChangesetService extends Disposable implements IAgentHostC
 			return undefined;
 		}
 		const baseBranch = kind === 'session'
-			? (await db.getMetadata(META_DIFF_BASE_BRANCH)) ?? undefined
+			? (await db.getMetadata(META_DIFF_BASE_BRANCH)) ?? readSessionGitState(this._stateManager.getSessionState(session)?._meta)?.baseBranchName
 			: undefined;
 		try {
 			return await this._gitService.computeSessionFileDiffs(workingDirectoryUri, { sessionUri: session, baseBranch });

--- a/src/vs/platform/agentHost/node/agentHostGitService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitService.ts
@@ -398,16 +398,18 @@ export class AgentHostGitService implements IAgentHostGitService {
 				// Empty repo (no HEAD yet) - `read-tree` of the empty tree always succeeds.
 				await this._runGit(repositoryRoot, ['read-tree', EMPTY_TREE_OBJECT], { env });
 			}
-			await this._stageChangedPaths(repositoryRoot, tempDir, changedPaths, env);
-			return await this._runGit(repositoryRoot, ['diff', '--cached', '--raw', '--numstat', '--diff-filter=ADMR', '-z', mergeBaseCommit, '--'], { env, timeout: 60_000, throwOnError: true });
+			if (!(await this._stageChangedPaths(repositoryRoot, tempDir, changedPaths, env))) {
+				return undefined;
+			}
+			return await this._runGit(repositoryRoot, ['diff', '--cached', '--raw', '--numstat', '--diff-filter=ADMR', '-z', mergeBaseCommit, '--'], { env, timeout: 60_000 });
 		} finally {
 			try { await this._fileService.del(tempDir, { recursive: true, useTrash: false }); } catch { /* best-effort */ }
 		}
 	}
 
-	private async _stageChangedPaths(repositoryRoot: URI, tempDir: URI, changedPaths: readonly string[], env: Record<string, string>): Promise<void> {
+	private async _stageChangedPaths(repositoryRoot: URI, tempDir: URI, changedPaths: readonly string[], env: Record<string, string>): Promise<boolean> {
 		if (changedPaths.length === 0) {
-			return;
+			return true;
 		}
 		const pathspecFile = URI.joinPath(tempDir, 'pathspec');
 		// Stage only the paths `git status` reported as changed. The previous
@@ -417,11 +419,10 @@ export class AgentHostGitService implements IAgentHostGitService {
 		// and rename/copy sources in scope.
 		await this._fileService.writeFile(pathspecFile, VSBuffer.fromString(changedPaths.join('\x00') + '\x00'));
 		this._logService.debug(`[agentHostGitService] Staging ${changedPaths.length} changed path(s) into temp index`);
-		await this._runGit(repositoryRoot, ['add', '-A', `--pathspec-from-file=${pathspecFile.fsPath}`, '--pathspec-file-nul'], {
+		return await this._runGit(repositoryRoot, ['add', '-A', `--pathspec-from-file=${pathspecFile.fsPath}`, '--pathspec-file-nul'], {
 			env: { ...env, GIT_LITERAL_PATHSPECS: '1' },
 			timeout: 60_000,
-			throwOnError: true,
-		});
+		}) !== undefined;
 	}
 
 	private async _resolveRemoteTrackingBranch(repositoryRoot: URI, branch: string): Promise<string | undefined> {
@@ -485,8 +486,10 @@ export class AgentHostGitService implements IAgentHostGitService {
 			if (seeded === undefined) {
 				await this._runGit(repositoryRoot, ['read-tree', EMPTY_TREE_OBJECT], { env });
 			}
-			await this._stageChangedPaths(repositoryRoot, tempDir, changedPaths, env);
-			const tree = (await this._runGit(repositoryRoot, ['write-tree'], { env, timeout: 60_000, throwOnError: true }))?.trim();
+			if (!(await this._stageChangedPaths(repositoryRoot, tempDir, changedPaths, env))) {
+				return undefined;
+			}
+			const tree = (await this._runGit(repositoryRoot, ['write-tree'], { env, timeout: 60_000 }))?.trim();
 			return tree || undefined;
 		} finally {
 			try { await this._fileService.del(tempDir, { recursive: true, useTrash: false }); } catch { /* best-effort */ }

--- a/src/vs/platform/agentHost/node/agentHostGitService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitService.ts
@@ -401,7 +401,7 @@ export class AgentHostGitService implements IAgentHostGitService {
 			if (!(await this._stageChangedPaths(repositoryRoot, tempDir, changedPaths, env))) {
 				return undefined;
 			}
-			return await this._runGit(repositoryRoot, ['diff', '--cached', '--raw', '--numstat', '--diff-filter=ADMR', '-z', mergeBaseCommit, '--'], { env, timeout: 60_000 });
+			return await this._runGit(repositoryRoot, ['diff', '--cached', '--raw', '--numstat', '--diff-filter=ADMR', '-z', mergeBaseCommit, '--'], { env });
 		} finally {
 			try { await this._fileService.del(tempDir, { recursive: true, useTrash: false }); } catch { /* best-effort */ }
 		}
@@ -421,7 +421,6 @@ export class AgentHostGitService implements IAgentHostGitService {
 		this._logService.debug(`[agentHostGitService] Staging ${changedPaths.length} changed path(s) into temp index`);
 		return await this._runGit(repositoryRoot, ['add', '-A', `--pathspec-from-file=${pathspecFile.fsPath}`, '--pathspec-file-nul'], {
 			env: { ...env, GIT_LITERAL_PATHSPECS: '1' },
-			timeout: 60_000,
 		}) !== undefined;
 	}
 
@@ -489,7 +488,7 @@ export class AgentHostGitService implements IAgentHostGitService {
 			if (!(await this._stageChangedPaths(repositoryRoot, tempDir, changedPaths, env))) {
 				return undefined;
 			}
-			const tree = (await this._runGit(repositoryRoot, ['write-tree'], { env, timeout: 60_000 }))?.trim();
+			const tree = (await this._runGit(repositoryRoot, ['write-tree'], { env }))?.trim();
 			return tree || undefined;
 		} finally {
 			try { await this._fileService.del(tempDir, { recursive: true, useTrash: false }); } catch { /* best-effort */ }

--- a/src/vs/platform/agentHost/node/agentHostGitService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitService.ts
@@ -356,13 +356,17 @@ export class AgentHostGitService implements IAgentHostGitService {
 		// included in `--cached --raw` output; otherwise a plain `git diff`
 		// is sufficient and avoids the temp-dir overhead.
 		const statusOut = await this._runGit(repositoryRoot, ['status', '--porcelain=v1', '-z', '--untracked-files=all']);
-		const untracked = parseUntrackedPaths(statusOut);
+		if (statusOut === undefined) {
+			return undefined;
+		}
+		const changedPaths = parseChangedPaths(statusOut);
+		const hasUntracked = parseUntrackedPaths(statusOut).length > 0;
 
 		let rawDiffOutput: string | undefined;
-		if (untracked.length === 0) {
+		if (!hasUntracked) {
 			rawDiffOutput = await this._runGit(repositoryRoot, ['diff', '--raw', '--numstat', '--diff-filter=ADMR', '-z', mergeBaseCommit, '--']);
 		} else {
-			rawDiffOutput = await this._runWithTempIndex(repositoryRoot, mergeBaseCommit);
+			rawDiffOutput = await this._runWithTempIndex(repositoryRoot, mergeBaseCommit, changedPaths);
 		}
 
 		if (rawDiffOutput === undefined) {
@@ -372,9 +376,9 @@ export class AgentHostGitService implements IAgentHostGitService {
 		return parseGitDiffRawNumstat(rawDiffOutput, repositoryRoot, options.sessionUri, mergeBaseCommit);
 	}
 
-	private async _runWithTempIndex(repositoryRoot: URI, mergeBaseCommit: string): Promise<string | undefined> {
-		// Build a throwaway index so we can stage the entire working tree
-		// (including untracked files) without disturbing the user's real
+	private async _runWithTempIndex(repositoryRoot: URI, mergeBaseCommit: string, changedPaths: readonly string[]): Promise<string | undefined> {
+		// Build a throwaway index so we can stage the changed working tree
+		// paths (including untracked files) without disturbing the user's real
 		// index. `read-tree HEAD` seeds it; in empty repos that fails so we
 		// fall back to the empty tree, leaving everything as "added".
 		const tempDir = URI.joinPath(this._environmentService.tmpDir, `agent-host-git-diff-${generateUuid()}`);
@@ -394,14 +398,29 @@ export class AgentHostGitService implements IAgentHostGitService {
 				// Empty repo (no HEAD yet) - `read-tree` of the empty tree always succeeds.
 				await this._runGit(repositoryRoot, ['read-tree', EMPTY_TREE_OBJECT], { env });
 			}
-			// Stage every change in the working tree (modified, deleted,
-			// untracked, renamed). `add -A` plus an explicit `:/` pathspec
-			// covers the entire repo from any cwd.
-			await this._runGit(repositoryRoot, ['add', '-A', '--', ':/'], { env });
-			return await this._runGit(repositoryRoot, ['diff', '--cached', '--raw', '--numstat', '--diff-filter=ADMR', '-z', mergeBaseCommit, '--'], { env });
+			await this._stageChangedPaths(repositoryRoot, tempDir, changedPaths, env);
+			return await this._runGit(repositoryRoot, ['diff', '--cached', '--raw', '--numstat', '--diff-filter=ADMR', '-z', mergeBaseCommit, '--'], { env, timeout: 60_000, throwOnError: true });
 		} finally {
 			try { await this._fileService.del(tempDir, { recursive: true, useTrash: false }); } catch { /* best-effort */ }
 		}
+	}
+
+	private async _stageChangedPaths(repositoryRoot: URI, tempDir: URI, changedPaths: readonly string[], env: Record<string, string>): Promise<void> {
+		if (changedPaths.length === 0) {
+			return;
+		}
+		const pathspecFile = URI.joinPath(tempDir, 'pathspec');
+		// Stage only the paths `git status` reported as changed. The previous
+		// full-repo `git add -A -- :/` walked nested repos/worktrees and large
+		// checkouts, which made temp-index diffing slow and timeout-prone. A
+		// NUL-separated pathspec preserves odd filenames while keeping deletes
+		// and rename/copy sources in scope.
+		await this._fileService.writeFile(pathspecFile, VSBuffer.fromString(changedPaths.join('\x00') + '\x00'));
+		await this._runGit(repositoryRoot, ['add', '-A', `--pathspec-from-file=${pathspecFile.fsPath}`, '--pathspec-file-nul'], {
+			env: { ...env, GIT_LITERAL_PATHSPECS: '1' },
+			timeout: 60_000,
+			throwOnError: true,
+		});
 	}
 
 	private async _resolveRemoteTrackingBranch(repositoryRoot: URI, branch: string): Promise<string | undefined> {
@@ -450,6 +469,11 @@ export class AgentHostGitService implements IAgentHostGitService {
 			return undefined;
 		}
 		const repositoryRoot = URI.file(repoRoot);
+		const statusOut = await this._runGit(repositoryRoot, ['status', '--porcelain=v1', '-z', '--untracked-files=all']);
+		if (statusOut === undefined) {
+			return undefined;
+		}
+		const changedPaths = parseChangedPaths(statusOut);
 		const tempDir = URI.joinPath(this._environmentService.tmpDir, `agent-host-checkpoint-${generateUuid()}`);
 		await this._fileService.createFolder(tempDir);
 		const indexFile = URI.joinPath(tempDir, 'index').fsPath;
@@ -460,9 +484,8 @@ export class AgentHostGitService implements IAgentHostGitService {
 			if (seeded === undefined) {
 				await this._runGit(repositoryRoot, ['read-tree', EMPTY_TREE_OBJECT], { env });
 			}
-			// Stage the entire working tree (including untracked, excluding ignored).
-			await this._runGit(repositoryRoot, ['add', '-A', '--', ':/'], { env });
-			const tree = (await this._runGit(repositoryRoot, ['write-tree'], { env }))?.trim();
+			await this._stageChangedPaths(repositoryRoot, tempDir, changedPaths, env);
+			const tree = (await this._runGit(repositoryRoot, ['write-tree'], { env, timeout: 60_000, throwOnError: true }))?.trim();
 			return tree || undefined;
 		} finally {
 			try { await this._fileService.del(tempDir, { recursive: true, useTrash: false }); } catch { /* best-effort */ }
@@ -685,22 +708,47 @@ export const EMPTY_TREE_OBJECT = '4b825dc642cb6eb9a060e54bf8d69288fbee4904';
  * Exported for tests.
  */
 export function parseUntrackedPaths(output: string | undefined): string[] {
+	return parseChangedPaths(output, status => status === '??');
+}
+
+/**
+ * Parses NUL-separated `git status --porcelain=v1 -z --untracked-files=all`
+ * output and returns all changed repo-relative paths. Rename/copy entries
+ * include both the destination and source paths so scoped `git add -A`
+ * stages both sides of the change.
+ *
+ * Exported for tests.
+ */
+export function parseChangedPaths(output: string | undefined, includeStatus: (status: string) => boolean = () => true): string[] {
 	if (!output) {
 		return [];
 	}
 	const result: string[] = [];
+	const seen = new Set<string>();
+	const addPath = (path: string) => {
+		if (path && !seen.has(path)) {
+			seen.add(path);
+			result.push(path);
+		}
+	};
 	const segments = output.split('\x00');
 	for (let i = 0; i < segments.length; i++) {
 		const seg = segments[i];
 		if (!seg) { continue; }
 		// Each entry is "XY <path>"; for renames v1 emits a second NUL-separated
-		// "from" path that we have to skip. We only care about untracked here.
+		// "from" path.
 		const status = seg.substring(0, 2);
 		const path = seg.substring(3);
-		if (status === '??') {
-			result.push(path);
-		} else if (status[0] === 'R' || status[0] === 'C') {
-			// Skip the "from" path for renames/copies.
+		const isRenameOrCopy = status[0] === 'R' || status[1] === 'R' || status[0] === 'C' || status[1] === 'C';
+		if (includeStatus(status)) {
+			addPath(path);
+			if (isRenameOrCopy) {
+				const sourcePath = segments[++i];
+				if (sourcePath) {
+					addPath(sourcePath);
+				}
+			}
+		} else if (isRenameOrCopy) {
 			i++;
 		}
 	}

--- a/src/vs/platform/agentHost/node/agentHostGitService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitService.ts
@@ -359,13 +359,13 @@ export class AgentHostGitService implements IAgentHostGitService {
 		if (statusOut === undefined) {
 			return undefined;
 		}
-		const changedPaths = parseChangedPaths(statusOut);
 		const hasUntracked = parseUntrackedPaths(statusOut).length > 0;
 
 		let rawDiffOutput: string | undefined;
 		if (!hasUntracked) {
 			rawDiffOutput = await this._runGit(repositoryRoot, ['diff', '--raw', '--numstat', '--diff-filter=ADMR', '-z', mergeBaseCommit, '--']);
 		} else {
+			const changedPaths = parseChangedPaths(statusOut);
 			rawDiffOutput = await this._runWithTempIndex(repositoryRoot, mergeBaseCommit, changedPaths);
 		}
 

--- a/src/vs/platform/agentHost/node/agentHostGitService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitService.ts
@@ -416,6 +416,7 @@ export class AgentHostGitService implements IAgentHostGitService {
 		// NUL-separated pathspec preserves odd filenames while keeping deletes
 		// and rename/copy sources in scope.
 		await this._fileService.writeFile(pathspecFile, VSBuffer.fromString(changedPaths.join('\x00') + '\x00'));
+		this._logService.debug(`[agentHostGitService] Staging ${changedPaths.length} changed path(s) into temp index`);
 		await this._runGit(repositoryRoot, ['add', '-A', `--pathspec-from-file=${pathspecFile.fsPath}`, '--pathspec-file-nul'], {
 			env: { ...env, GIT_LITERAL_PATHSPECS: '1' },
 			timeout: 60_000,

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -697,6 +697,7 @@ export class AgentService extends Disposable implements IAgentService {
 				if (!gitState) {
 					return;
 				}
+				this._changesetCoordinator.onSessionGitStateChanged(sessionKey);
 				this._changesetOperationContributionService.updateOperations(sessionKey, gitState);
 			},
 			e => {

--- a/src/vs/platform/agentHost/test/node/agentHostChangesetService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostChangesetService.test.ts
@@ -13,7 +13,7 @@ import { NullLogService } from '../../../log/common/log.js';
 import { AgentSession } from '../../common/agentService.js';
 import { BASELINE_TURN_ID, buildDefaultChangesetCatalogue, buildSessionChangesetUri, buildUncommittedChangesetUri } from '../../common/changesetUri.js';
 import { ActionEnvelope, ActionType } from '../../common/state/sessionActions.js';
-import { SessionStatus } from '../../common/state/sessionState.js';
+import { ChangesetStatus, SessionStatus, withSessionGitState } from '../../common/state/sessionState.js';
 import { AgentHostChangesetService } from '../../node/agentHostChangesetService.js';
 import { NULL_CHECKPOINT_SERVICE } from '../../common/agentHostCheckpointService.js';
 import { IAgentHostGitService } from '../../node/agentHostGitService.js';
@@ -301,6 +301,77 @@ suite('AgentHostChangesetService', () => {
 			assert.deepStrictEqual(JSON.parse(persisted), gitDiffs);
 		});
 
+		test('session changeset falls back to _meta.git base branch when persisted diff base is absent', async () => {
+			const sessionDb = new SessionDatabase(':memory:');
+			disposables.add(toDisposable(() => sessionDb.close()));
+			const sessionDataService = createSessionDataService(sessionDb);
+			const localStateManager = disposables.add(new AgentHostStateManager(new NullLogService()));
+			const computeCalls: { baseBranch: string | undefined }[] = [];
+			const stubGit = {
+				computeSessionFileDiffs: async (_wd: URI, opts: { sessionUri: string; baseBranch?: string }) => {
+					computeCalls.push({ baseBranch: opts.baseBranch });
+					return [];
+				},
+			} as unknown as IAgentHostGitService;
+			const localChangesets = disposables.add(new AgentHostChangesetService(
+				localStateManager, new NullLogService(), sessionDataService, stubGit, NULL_CHECKPOINT_SERVICE));
+			const sessionStr = sessionUri.toString();
+
+			localStateManager.createSession({
+				resource: sessionStr,
+				provider: 'mock',
+				title: 'Test',
+				status: SessionStatus.Idle,
+				createdAt: Date.now(),
+				modifiedAt: Date.now(),
+				workingDirectory: 'file:///wd',
+			});
+			localStateManager.setSessionMeta(sessionStr, withSessionGitState(undefined, { baseBranchName: 'main' }));
+
+			localChangesets.refreshSessionChangeset(sessionStr);
+			for (let i = 0; i < 50 && computeCalls.length === 0; i++) {
+				await timeout(2);
+			}
+
+			assert.deepStrictEqual(computeCalls, [{ baseBranch: 'main' }]);
+		});
+
+		test('session changeset keeps persisted diff base ahead of _meta.git base branch', async () => {
+			const sessionDb = new SessionDatabase(':memory:');
+			disposables.add(toDisposable(() => sessionDb.close()));
+			await sessionDb.setMetadata('agentHost.diffBaseBranch', 'release');
+			const sessionDataService = createSessionDataService(sessionDb);
+			const localStateManager = disposables.add(new AgentHostStateManager(new NullLogService()));
+			const computeCalls: { baseBranch: string | undefined }[] = [];
+			const stubGit = {
+				computeSessionFileDiffs: async (_wd: URI, opts: { sessionUri: string; baseBranch?: string }) => {
+					computeCalls.push({ baseBranch: opts.baseBranch });
+					return [];
+				},
+			} as unknown as IAgentHostGitService;
+			const localChangesets = disposables.add(new AgentHostChangesetService(
+				localStateManager, new NullLogService(), sessionDataService, stubGit, NULL_CHECKPOINT_SERVICE));
+			const sessionStr = sessionUri.toString();
+
+			localStateManager.createSession({
+				resource: sessionStr,
+				provider: 'mock',
+				title: 'Test',
+				status: SessionStatus.Idle,
+				createdAt: Date.now(),
+				modifiedAt: Date.now(),
+				workingDirectory: 'file:///wd',
+			});
+			localStateManager.setSessionMeta(sessionStr, withSessionGitState(undefined, { baseBranchName: 'main' }));
+
+			localChangesets.refreshSessionChangeset(sessionStr);
+			for (let i = 0; i < 50 && computeCalls.length === 0; i++) {
+				await timeout(2);
+			}
+
+			assert.deepStrictEqual(computeCalls, [{ baseBranch: 'release' }]);
+		});
+
 		test('falls back to the edit-tracker aggregator when the git service returns undefined', async () => {
 			const sessionDb = new SessionDatabase(':memory:');
 			disposables.add(toDisposable(() => sessionDb.close()));
@@ -396,9 +467,18 @@ suite('AgentHostChangesetService', () => {
 
 			const envelopes: ActionEnvelope[] = [];
 			disposables.add(localStateManager.onDidEmitEnvelope(e => { envelopes.push(e); }));
+			const uncommittedUri = `${sessionStr}/changeset/uncommitted`;
 
 			// Trigger the recompute of the uncommitted changeset.
 			localChangesets.refreshUncommittedChangeset(sessionStr);
+			const refreshing = localStateManager.getSnapshot(uncommittedUri)?.state as { status: string; files: Array<{ id: string }> } | undefined;
+			assert.deepStrictEqual({
+				status: refreshing?.status,
+				files: refreshing?.files.map(f => f.id).sort(),
+			}, {
+				status: ChangesetStatus.Computing,
+				files: ['file:///wd/a.ts', 'file:///wd/b.ts', 'file:///wd/c.ts'],
+			});
 
 			// Wait long enough for the sequencer to drain the uncommitted compute.
 			for (let i = 0; i < 50; i++) {
@@ -408,7 +488,6 @@ suite('AgentHostChangesetService', () => {
 			// 1) The persisted snapshot must still be in live state — no
 			//    `ChangesetFileRemoved` envelopes for the uncommitted URI
 			//    were emitted.
-			const uncommittedUri = `${sessionStr}/changeset/uncommitted`;
 			const removed = envelopes
 				.filter(e => e.action.type === ActionType.ChangesetFileRemoved && e.channel === uncommittedUri);
 			assert.deepStrictEqual(removed, [], 'no files should be removed when the git path is unavailable');
@@ -419,8 +498,14 @@ suite('AgentHostChangesetService', () => {
 
 			// 3) Live state still reports the 3 seeded files.
 			const snapshot = localStateManager.getSnapshot(uncommittedUri);
-			const state = snapshot?.state as { files: Array<{ id: string }> } | undefined;
-			assert.deepStrictEqual(state?.files.map(f => f.id).sort(), ['file:///wd/a.ts', 'file:///wd/b.ts', 'file:///wd/c.ts']);
+			const state = snapshot?.state as { status: string; files: Array<{ id: string }> } | undefined;
+			assert.deepStrictEqual({
+				status: state?.status,
+				files: state?.files.map(f => f.id).sort(),
+			}, {
+				status: ChangesetStatus.Ready,
+				files: ['file:///wd/a.ts', 'file:///wd/b.ts', 'file:///wd/c.ts'],
+			});
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
@@ -20,6 +20,7 @@ import { tmpdir } from 'os';
 import { NullLogService } from '../../../log/common/log.js';
 import { join } from '../../../../base/common/path.js';
 import { URI } from '../../../../base/common/uri.js';
+import { isWindows } from '../../../../base/common/platform.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { INativeEnvironmentService } from '../../../environment/common/environment.js';
 import { FileService } from '../../../files/common/fileService.js';
@@ -239,6 +240,20 @@ suite('AgentHostGitService - computeSessionFileDiffs (real git)', () => {
 		});
 	});
 
+	(hasGit && !isWindows ? test : test.skip)('returns undefined when temp-index staging fails', async () => {
+		const fs = await import('fs/promises');
+		const { dir } = initRepo();
+		const blockedPath = join(dir, 'blocked.txt');
+		await fs.writeFile(blockedPath, 'blocked\n');
+		await fs.chmod(blockedPath, 0);
+		try {
+			const result = await svc!.computeSessionFileDiffs(URI.file(dir), { sessionUri: 'copilot:/s' });
+			assert.strictEqual(result, undefined);
+		} finally {
+			await fs.chmod(blockedPath, 0o600);
+		}
+	});
+
 	(hasGit ? test : test.skip)('anchors against the merge-base of the requested base branch', async () => {
 		const fs = await import('fs/promises');
 		const { dir, run } = initRepo();
@@ -334,6 +349,20 @@ suite('AgentHostGitService - computeSessionFileDiffs (real git)', () => {
 			.sort();
 
 		assert.deepStrictEqual(treePaths, ['fresh.txt', 'new.txt']);
+	});
+
+	(hasGit && !isWindows ? test : test.skip)('captureWorkingTreeAsTree returns undefined when staging fails', async () => {
+		const fs = await import('fs/promises');
+		const { dir } = initRepo();
+		const blockedPath = join(dir, 'blocked.txt');
+		await fs.writeFile(blockedPath, 'blocked\n');
+		await fs.chmod(blockedPath, 0);
+		try {
+			const result = await svc!.captureWorkingTreeAsTree(URI.file(dir));
+			assert.strictEqual(result, undefined);
+		} finally {
+			await fs.chmod(blockedPath, 0o600);
+		}
 	});
 
 	(hasGit ? test : test.skip)('showBlob retrieves committed content', async () => {

--- a/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
@@ -215,6 +215,30 @@ suite('AgentHostGitService - computeSessionFileDiffs (real git)', () => {
 		void byPath;
 	});
 
+	(hasGit ? test : test.skip)('reports staged rename source when untracked files force temp-index staging', async () => {
+		const fs = await import('fs/promises');
+		const { dir, run } = initRepo();
+		await fs.writeFile(join(dir, 'old.txt'), 'one\n');
+		run('add', '.');
+		run('commit', '-q', '-m', 'init');
+
+		run('mv', 'old.txt', 'new.txt');
+		await fs.writeFile(join(dir, 'fresh.txt'), 'fresh\n');
+
+		const result = await svc!.computeSessionFileDiffs(URI.file(dir), { sessionUri: 'copilot:/s' });
+		assert.ok(result, 'expected diffs');
+		const rename = result.find(d => d.before?.uri.endsWith('/old.txt') && d.after?.uri.endsWith('/new.txt'));
+		const fresh = result.find(d => !d.before && d.after?.uri.endsWith('/fresh.txt'));
+
+		assert.deepStrictEqual({
+			rename: rename && { before: URI.parse(rename.before!.uri).path.split('/').pop(), after: URI.parse(rename.after!.uri).path.split('/').pop() },
+			fresh: fresh && URI.parse(fresh.after!.uri).path.split('/').pop(),
+		}, {
+			rename: { before: 'old.txt', after: 'new.txt' },
+			fresh: 'fresh.txt',
+		});
+	});
+
 	(hasGit ? test : test.skip)('anchors against the merge-base of the requested base branch', async () => {
 		const fs = await import('fs/promises');
 		const { dir, run } = initRepo();
@@ -289,6 +313,27 @@ suite('AgentHostGitService - computeSessionFileDiffs (real git)', () => {
 		assert.ok(result, 'expected diffs');
 		assert.strictEqual(result.length, 1);
 		assert.ok(result[0].after && !result[0].before, 'untracked file in empty repo should be an addition');
+	});
+
+	(hasGit ? test : test.skip)('captureWorkingTreeAsTree stages scoped rename source and untracked paths', async () => {
+		const fs = await import('fs/promises');
+		const { dir, run } = initRepo();
+		await fs.writeFile(join(dir, 'old.txt'), 'one\n');
+		run('add', '.');
+		run('commit', '-q', '-m', 'init');
+
+		run('mv', 'old.txt', 'new.txt');
+		await fs.writeFile(join(dir, 'fresh.txt'), 'fresh\n');
+
+		const tree = await svc!.captureWorkingTreeAsTree(URI.file(dir));
+		assert.ok(tree, 'expected tree object');
+		const treePaths = cp.execFileSync('git', ['ls-tree', '-r', '--name-only', tree], { cwd: dir, encoding: 'utf8' })
+			.trim()
+			.split(/\r?\n/g)
+			.filter(Boolean)
+			.sort();
+
+		assert.deepStrictEqual(treePaths, ['fresh.txt', 'new.txt']);
 	});
 
 	(hasGit ? test : test.skip)('showBlob retrieves committed content', async () => {

--- a/src/vs/platform/agentHost/test/node/agentHostGitService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitService.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
-import { EMPTY_TREE_OBJECT, formatGitError, getBranchCompletions, parseDefaultBranchRef, parseGitDiffRawNumstat, parseGitHubRepoFromRemote, parseGitStatusV2, parseHasGitHubRemote, parseUntrackedPaths, summarizeStderrForError } from '../../node/agentHostGitService.js';
+import { EMPTY_TREE_OBJECT, formatGitError, getBranchCompletions, parseChangedPaths, parseDefaultBranchRef, parseGitDiffRawNumstat, parseGitHubRepoFromRemote, parseGitStatusV2, parseHasGitHubRemote, parseUntrackedPaths, summarizeStderrForError } from '../../node/agentHostGitService.js';
 import { buildGitBlobUri } from '../../node/gitDiffContent.js';
 import { URI } from '../../../../base/common/uri.js';
 
@@ -166,6 +166,51 @@ suite('AgentHostGitService', () => {
 			// must be skipped.
 			const out = '?? new.txt\x00 M edited.txt\x00R  to.txt\x00from.txt\x00?? other.txt\x00';
 			assert.deepStrictEqual(parseUntrackedPaths(out), ['new.txt', 'other.txt']);
+		});
+	});
+
+	suite('parseChangedPaths', () => {
+		test('returns every changed path including delete and index rename/copy sources', () => {
+			const out = [
+				' M modified.txt',
+				'A  added.txt',
+				' D deleted.txt',
+				'?? untracked.txt',
+				'R  renamed-new.txt',
+				'renamed-old.txt',
+				' C copied-new.txt',
+				'copied-old.txt',
+				' M modified.txt',
+				'',
+			].join('\x00');
+
+			assert.deepStrictEqual(parseChangedPaths(out), [
+				'modified.txt',
+				'added.txt',
+				'deleted.txt',
+				'untracked.txt',
+				'renamed-new.txt',
+				'renamed-old.txt',
+				'copied-new.txt',
+				'copied-old.txt',
+			]);
+		});
+
+		test('returns worktree rename/copy source paths too', () => {
+			const out = [
+				' R worktree-renamed-new.txt',
+				'worktree-renamed-old.txt',
+				' C worktree-copied-new.txt',
+				'worktree-copied-old.txt',
+				'',
+			].join('\x00');
+
+			assert.deepStrictEqual(parseChangedPaths(out), [
+				'worktree-renamed-new.txt',
+				'worktree-renamed-old.txt',
+				'worktree-copied-new.txt',
+				'worktree-copied-old.txt',
+			]);
 		});
 	});
 
@@ -344,4 +389,3 @@ suite('AgentHostGitService', () => {
 		});
 	});
 });
-

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -922,6 +922,48 @@ suite('AgentService (node dispatcher)', () => {
 			);
 		});
 
+		test('createSession refreshes branch and uncommitted changesets after git state attaches', async () => {
+			const workingDirectory = URI.file('/workspace/repo');
+			const gitState = {
+				hasGitHubRemote: false,
+				branchName: 'feature/x',
+				baseBranchName: 'main',
+				upstreamBranchName: undefined,
+				incomingChanges: 0,
+				outgoingChanges: 0,
+				uncommittedChanges: 0,
+			};
+			const computeCalls: Array<{ sessionUri: string; baseBranch: string | undefined }> = [];
+			const gitService = createNoopGitService();
+			gitService.getSessionGitState = async () => gitState;
+			gitService.computeSessionFileDiffs = async (_wd, opts) => {
+				computeCalls.push({ sessionUri: opts.sessionUri, baseBranch: opts.baseBranch });
+				return [];
+			};
+			const sessionDb = new SessionDatabase(':memory:');
+			disposables.add(toDisposable(() => sessionDb.close()));
+			const sessionDataService = createSessionDataService(sessionDb);
+			const localService = disposables.add(new AgentService(new NullLogService(), fileService, sessionDataService, { _serviceBrand: undefined } as IProductService, gitService));
+			const agent = new MockAgent('copilot');
+			disposables.add(toDisposable(() => agent.dispose()));
+			agent.resolvedWorkingDirectory = workingDirectory;
+			agent.sessionMetadataOverrides = { workingDirectory };
+			localService.registerProvider(agent);
+
+			const session = await localService.createSession({ provider: 'copilot' });
+			for (let i = 0; i < 100 && computeCalls.length < 2; i++) {
+				await new Promise(resolve => setTimeout(resolve, 2));
+			}
+
+			assert.deepStrictEqual(
+				computeCalls.sort((a, b) => (a.baseBranch ?? '').localeCompare(b.baseBranch ?? '')),
+				[
+					{ sessionUri: session.toString(), baseBranch: undefined },
+					{ sessionUri: session.toString(), baseBranch: 'main' },
+				],
+			);
+		});
+
 		test('createSession skips git overlay when no working directory or no git state', async () => {
 			const gitService = {
 				_serviceBrand: undefined,


### PR DESCRIPTION
Fixes #320243

## Summary
- fall back to `_meta.git.baseBranchName` for Branch Changes when `agentHost.diffBaseBranch` is absent
- refresh both Branch and Uncommitted changesets after git state attaches
- mark cached static changesets as computing while a background refresh is pending, then restore the prior status if no safe replacement snapshot is produced
- scope temp-index git staging to changed pathspecs for diff/checkpoint capture

## Validation
- `npm run compile-check-ts-native`
- `node --experimental-strip-types build/hygiene.ts <changed files>`
- `npm run valid-layers-check`
- `./scripts/test.sh --run src/vs/platform/agentHost/test/node/agentHostGitService.test.ts --grep "parseChangedPaths|parseUntrackedPaths"`
- `./scripts/test-integration.sh --run src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts --grep "reports staged rename source|captureWorkingTreeAsTree stages scoped rename source"`