### PR TITLE
sessions: experiment to move harness picker below input

### DIFF
--- a/src/vs/sessions/browser/parts/chatView.ts
+++ b/src/vs/sessions/browser/parts/chatView.ts
@@ -8,6 +8,7 @@ import { ISerializableView, IViewSize } from '../../../base/browser/ui/grid/grid
 import { ProgressBar } from '../../../base/browser/ui/progressbar/progressbar.js';
 import { Emitter, Event } from '../../../base/common/event.js';
 import { Disposable } from '../../../base/common/lifecycle.js';
+import { IObservable } from '../../../base/common/observable.js';
 import { URI } from '../../../base/common/uri.js';
 import { defaultProgressBarStyles } from '../../../platform/theme/browser/defaultStyles.js';
 import { IProgressScope, ScopedProgressIndicator } from '../../../workbench/services/progress/browser/progressIndicator.js';
@@ -18,6 +19,20 @@ import { IChat } from '../../services/sessions/common/session.js';
  * requiring core code (`sessions/browser/`) to import them from contrib.
  */
 export type ChatViewKind = 'newSession' | 'newChatInSession' | 'chat';
+
+/**
+ * Options passed to a chat view when it is created.
+ */
+export interface IChatViewOptions {
+
+	/**
+	 * Whether to render the session type ("harness") picker below the input
+	 * (in the controls) instead of next to the workspace picker. The view
+	 * reads the value once when it is created and does not react to later
+	 * changes, so the placement stays stable for the view's lifetime.
+	 */
+	readonly renderSessionTypePickerInControls: IObservable<boolean>;
+}
 
 /**
  * Base class for a view that lives inside the {@link SessionsPart} internal grid.

--- a/src/vs/sessions/browser/parts/sessionView.ts
+++ b/src/vs/sessions/browser/parts/sessionView.ts
@@ -15,13 +15,19 @@ import { IContextKey, IContextKeyService } from '../../../platform/contextkey/co
 import { asCssVariable } from '../../../platform/theme/common/colorUtils.js';
 import { IActiveSession } from '../../services/sessions/common/sessionsManagement.js';
 import { IChatViewFactory } from '../../services/chatView/browser/chatViewFactory.js';
-import { AbstractChatView, ChatViewKind } from './chatView.js';
+import { AbstractChatView, ChatViewKind, IChatViewOptions } from './chatView.js';
 import { ChatCompositeBar } from './chatCompositeBar.js';
 import { SessionHeader, SessionViewFloatingToolbar } from './sessionHeader.js';
 import { autorun } from '../../../base/common/observable.js';
 import { SessionIsArchivedContext, SessionIsCreatedContext, SessionIsMaximizedContext, SessionIsReadContext, SessionIsStickyContext, SessionSupportsMultipleChatsContext, ChatSessionProviderIdContext, ChatSessionTypeContext } from '../../common/contextkeys.js';
 import { activeSessionViewBackground, activeSessionViewForeground, inactiveSessionViewBackground, inactiveSessionViewForeground } from '../../common/theme.js';
 import { SessionStatus } from '../../services/sessions/common/session.js';
+
+/**
+ * Options passed to {@link SessionView.openSession}. Extends the chat view
+ * options so they can be forwarded to the new-chat views the host creates.
+ */
+export interface ISessionViewOptions extends IChatViewOptions { }
 
 /**
  * A stable single-slot grid leaf that handles switching between concrete
@@ -121,7 +127,7 @@ export class SessionView extends Disposable implements ISerializableView {
 		this._register(this._compositeBar.onDidChangeHeight(() => this._layoutChildren()));
 	}
 
-	openSession(session: IActiveSession | undefined): void {
+	openSession(session: IActiveSession | undefined, options: ISessionViewOptions): void {
 		if (this._hasOpenedSession && this._currentSession === session) {
 			return;
 		}
@@ -146,7 +152,7 @@ export class SessionView extends Disposable implements ISerializableView {
 			if (!view || view.kind !== desiredKind) {
 				view = desiredKind === 'chat'
 					? this.chatViewFactory.createChatView()
-					: this.chatViewFactory.createNewChatView(desiredKind === 'newChatInSession');
+					: this.chatViewFactory.createNewChatView(desiredKind === 'newChatInSession', options);
 				this._contentContainer.replaceChildren(view.element);
 				this._currentView.value = view;
 				view.setActive(this._isActive);

--- a/src/vs/sessions/browser/parts/sessionsPart.ts
+++ b/src/vs/sessions/browser/parts/sessionsPart.ts
@@ -18,7 +18,7 @@ import { ActiveSessionsContext, MultipleSessionsVisibleContext, SessionsFocusCon
 import { $, addDisposableGenericMouseDownListener, addDisposableListener, EventType, isAncestor, trackFocus } from '../../../base/browser/dom.js';
 import { IActiveSession } from '../../services/sessions/common/sessionsManagement.js';
 import { SessionView } from './sessionView.js';
-import { DisposableStore } from '../../../base/common/lifecycle.js';
+import { DisposableStore, IDisposable } from '../../../base/common/lifecycle.js';
 import { Emitter, Event } from '../../../base/common/event.js';
 import { Color } from '../../../base/common/color.js';
 import { contrastBorder } from '../../../platform/theme/common/colorRegistry.js';
@@ -27,6 +27,17 @@ import { ProgressBar } from '../../../base/browser/ui/progressbar/progressbar.js
 import { defaultProgressBarStyles } from '../../../platform/theme/browser/defaultStyles.js';
 import { IProgressIndicator } from '../../../platform/progress/common/progress.js';
 import { AbstractProgressScope, ScopedProgressIndicator } from '../../../workbench/services/progress/browser/progressIndicator.js';
+import { observableValue } from '../../../base/common/observable.js';
+import { IWorkbenchAssignmentService } from '../../../workbench/services/assignment/common/assignmentService.js';
+
+/**
+ * ExP treatment that, when enabled, moves the session type ("harness") picker
+ * from its default spot next to the workspace picker down into the bottom input
+ * controls (and drops the "with" connector label). Resolved once via the
+ * {@link IWorkbenchAssignmentService} and surfaced to new-chat views through
+ * the new-chat view options.
+ */
+const HARNESS_PICKER_IN_CONTROLS_TREATMENT = 'agentSessionsHarnessPickerInControls';
 
 interface IGridSlot {
 	readonly view: SessionView;
@@ -78,6 +89,15 @@ export class SessionsPart extends Part {
 	private readonly _multipleSessionsVisibleKey: IContextKey<boolean>;
 	private readonly _sessionsFocusKey: IContextKey<boolean>;
 
+	/**
+	 * Whether the session type ("harness") picker should be rendered below the
+	 * input (in the controls) instead of next to the workspace picker. Backed
+	 * by the {@link HARNESS_PICKER_IN_CONTROLS_TREATMENT} A/B experiment, which
+	 * is resolved asynchronously and updates this observable once it is known.
+	 * Passed down to new-chat views, which snapshot it at creation time.
+	 */
+	private readonly _renderSessionTypePickerInControls = observableValue<boolean>(this, false);
+
 	get preferredHeight(): number | undefined {
 		return this.layoutService.mainContainerDimension.height * 0.4;
 	}
@@ -90,6 +110,7 @@ export class SessionsPart extends Part {
 		@IWorkbenchLayoutService layoutService: IWorkbenchLayoutService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
+		@IWorkbenchAssignmentService assignmentService: IWorkbenchAssignmentService,
 	) {
 		super(
 			Parts.SESSIONS_PART,
@@ -103,6 +124,28 @@ export class SessionsPart extends Part {
 		ActiveSessionsContext.bindTo(contextKeyService);
 		this._sessionsFocusKey = SessionsFocusContext.bindTo(contextKeyService);
 		this._multipleSessionsVisibleKey = MultipleSessionsVisibleContext.bindTo(contextKeyService);
+
+		this._register(this._trackOptions(assignmentService));
+	}
+
+	/**
+	 * Resolve the harness-picker placement treatment now and whenever the
+	 * assignment service refetches. New-chat views snapshot the value when they
+	 * are created, so views mounted before the treatment resolves keep the
+	 * default placement until they are recreated.
+	 */
+	private _trackOptions(assignmentService: IWorkbenchAssignmentService): IDisposable {
+		const store = new DisposableStore();
+
+		// Harness picker placement
+		const updateHarnessPickerPlacement = async () => {
+			const value = await assignmentService.getTreatment<boolean>(HARNESS_PICKER_IN_CONTROLS_TREATMENT);
+			this._renderSessionTypePickerInControls.set(value === true, undefined);
+		};
+		store.add(assignmentService.onDidRefetchAssignments(() => updateHarnessPickerPlacement()));
+		updateHarnessPickerPlacement();
+
+		return store;
 	}
 
 	override create(parent: HTMLElement): void {
@@ -193,7 +236,7 @@ export class SessionsPart extends Part {
 			const slot = this._slots[i];
 			const session = visible[i];
 			slot.boundSessionId = session?.sessionId;
-			slot.view.openSession(session);
+			slot.view.openSession(session, { renderSessionTypePickerInControls: this._renderSessionTypePickerInControls });
 		}
 
 		// Mark the active session's element for styling/focus indication.

--- a/src/vs/sessions/contrib/chat/browser/chatView.ts
+++ b/src/vs/sessions/contrib/chat/browser/chatView.ts
@@ -17,7 +17,7 @@ import { IChatModelReference, IChatService } from '../../../../workbench/contrib
 import { ChatAgentLocation, ChatModeKind } from '../../../../workbench/contrib/chat/common/constants.js';
 import { getChatSessionType } from '../../../../workbench/contrib/chat/common/model/chatUri.js';
 import { IChatSessionsService, localChatSessionType } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
-import { AbstractChatView, ChatViewKind } from '../../../browser/parts/chatView.js';
+import { AbstractChatView, ChatViewKind, IChatViewOptions } from '../../../browser/parts/chatView.js';
 import { IChat } from '../../../services/sessions/common/session.js';
 import { IChatViewFactory } from '../../../services/chatView/browser/chatViewFactory.js';
 import { NewChatWidget } from './newChatWidget.js';
@@ -41,13 +41,16 @@ export class NewChatView extends AbstractChatView {
 
 	constructor(
 		isNewChatInSession: boolean,
+		options: IChatViewOptions,
 		@IInstantiationService instantiationService: IInstantiationService
 	) {
 		super();
 
 		this.element.classList.add('chat-view-new');
 		this.kind = isNewChatInSession ? 'newChatInSession' : 'newSession';
-		this._widget = this._register(instantiationService.createInstance(isNewChatInSession ? NewChatInSessionWidget : NewChatWidget));
+		this._widget = this._register(isNewChatInSession
+			? instantiationService.createInstance(NewChatInSessionWidget, options)
+			: instantiationService.createInstance(NewChatWidget, options));
 		this._widget.render(this.element);
 	}
 
@@ -262,8 +265,8 @@ export class ChatViewFactory implements IChatViewFactory {
 		@IInstantiationService private readonly instantiationService: IInstantiationService
 	) { }
 
-	createNewChatView(isNewChatInSession: boolean): AbstractChatView {
-		return this.instantiationService.createInstance(NewChatView, isNewChatInSession);
+	createNewChatView(isNewChatInSession: boolean, options: IChatViewOptions): AbstractChatView {
+		return this.instantiationService.createInstance(NewChatView, isNewChatInSession, options);
 	}
 
 	createChatView(): AbstractChatView {

--- a/src/vs/sessions/contrib/chat/browser/newChatInSessionWidget.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInSessionWidget.ts
@@ -18,6 +18,7 @@ import { IStorageService, StorageScope, StorageTarget } from '../../../../platfo
 import { renderIcon } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { NewChatInputWidget } from './newChatInput.js';
+import { IChatViewOptions } from '../../../browser/parts/chatView.js';
 import { IChatRequestVariableEntry } from '../../../../workbench/contrib/chat/common/attachments/chatVariableEntries.js';
 
 // #region --- New Chat In Session Widget ---
@@ -35,6 +36,7 @@ export class NewChatInSessionWidget extends Disposable {
 	private readonly _tipDisposable = this._register(new MutableDisposable());
 
 	constructor(
+		_options: IChatViewOptions,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@ILogService private readonly logService: ILogService,
 		@ISessionsManagementService private readonly sessionsManagementService: ISessionsManagementService,

--- a/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
@@ -24,6 +24,7 @@ import { NewChatInputWidget } from './newChatInput.js';
 import { NoAgentHostEmptyState } from './noAgentHostEmptyState.js';
 import { IChatRequestVariableEntry } from '../../../../workbench/contrib/chat/common/attachments/chatVariableEntries.js';
 import { IAgentHostFilterService } from '../../../services/agentHostFilter/common/agentHostFilter.js';
+import { IChatViewOptions } from '../../../browser/parts/chatView.js';
 
 // #region --- New Chat Widget ---
 
@@ -44,7 +45,16 @@ export class NewChatWidget extends Disposable {
 	 */
 	private _activeEmptyState: NoAgentHostEmptyState | undefined;
 
+	/**
+	 * Whether to render the session type ("harness") picker below the input
+	 * (in the controls) instead of next to the workspace picker. Read once from
+	 * the view options at construction time; the widget does not react to later
+	 * changes of the source observable.
+	 */
+	private readonly _renderHarnessPickerInControls: boolean;
+
 	constructor(
+		private readonly options: IChatViewOptions,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@ILogService private readonly logService: ILogService,
 		@ISessionsManagementService private readonly sessionsManagementService: ISessionsManagementService,
@@ -54,6 +64,7 @@ export class NewChatWidget extends Disposable {
 		@IAgentHostFilterService private readonly agentHostFilterService: IAgentHostFilterService,
 	) {
 		super();
+		this._renderHarnessPickerInControls = this.options.renderSessionTypePickerInControls.get();
 		// On web (vscode.dev / insiders.vscode.dev), use {@link WebWorkspacePicker}
 		// which scopes recents to the active host and renders as a bottom
 		// sheet on phone-layout viewports. On Electron desktop, the regular
@@ -81,7 +92,7 @@ export class NewChatWidget extends Disposable {
 			canSendRequest,
 			loading,
 			historyKey: derived(reader => this.sessionsManagementService.activeSession.read(reader)?.sessionId),
-			renderSessionTypePickerInControls: false,
+			renderSessionTypePickerInControls: this._renderHarnessPickerInControls,
 			supportsBackground: true,
 		}));
 
@@ -223,9 +234,12 @@ export class NewChatWidget extends Disposable {
 			: localize('newSessionChooseWorkspace', "Start by picking a");
 
 		this._workspacePicker.render(pickersRow);
-		const withLabel = dom.append(pickersRow, dom.$('.session-workspace-picker-label.session-workspace-picker-with-label'));
-		withLabel.textContent = localize('newSessionWith', "with");
-		this._newChatInput.sessionTypePicker.render(pickersRow, { className: 'sessions-chat-session-type-picker' });
+
+		if (!this._renderHarnessPickerInControls) {
+			const withLabel = dom.append(pickersRow, dom.$('.session-workspace-picker-label.session-workspace-picker-with-label'));
+			withLabel.textContent = localize('newSessionWith', "with");
+			this._newChatInput.sessionTypePicker.render(pickersRow, { className: 'sessions-chat-session-type-picker' });
+		}
 		return this._workspacePicker.onDidSelectWorkspace(() => {
 			const folderUri = this._workspacePicker.selectedFolderUri;
 			pickersLabel.textContent = folderUri

--- a/src/vs/sessions/services/chatView/browser/chatViewFactory.ts
+++ b/src/vs/sessions/services/chatView/browser/chatViewFactory.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
-import { AbstractChatView } from '../../../browser/parts/chatView.js';
+import { AbstractChatView, IChatViewOptions } from '../../../browser/parts/chatView.js';
 
 export const IChatViewFactory = createDecorator<IChatViewFactory>('chatViewFactory');
 
@@ -22,7 +22,7 @@ export interface IChatViewFactory {
 	 * Creates a "new chat" view that lets the user pick a workspace and
 	 * start a new chat. This is the view the grid is seeded with on startup.
 	 */
-	createNewChatView(isNewChatInSession: boolean): AbstractChatView;
+	createNewChatView(isNewChatInSession: boolean, options: IChatViewOptions): AbstractChatView;
 
 	/**
 	 * Creates a chat view that hosts a chat widget for an active session.


### PR DESCRIPTION
## What

Adds an A/B experiment that moves the session type ("harness") picker from its default position next to the workspace picker down into the bottom input controls, dropping the `"with"` connector label.

- **Control**: harness picker rendered next to the workspace picker (`New session in <workspace> with <harness>`).
- **Treatment**: harness picker rendered below the input alongside the other controls; the `"with"` label is dropped.

Treatment name: `agentSessionsHarnessPickerInControls`.

## How

- `SessionsPart` injects `IWorkbenchAssignmentService` and resolves the treatment into an `observableValue<boolean>`. The resolution lives in a new `_trackOptions` method that returns an `IDisposable` (a `DisposableStore`) and re-reads the treatment on `onDidRefetchAssignments`.
- The observable is threaded down via a new `IChatViewOptions` interface (defined next to `AbstractChatView` in `browser/parts/chatView.ts`) through `SessionView.openSession` (typed `ISessionViewOptions`) and `IChatViewFactory.createNewChatView` into `NewChatWidget`.
- `NewChatWidget` reads the observable **once** at construction (`.get()`) so the placement stays stable for the view's lifetime and does not react to later changes. When enabled it passes `renderSessionTypePickerInControls: true` to `NewChatInputWidget` and skips rendering the `"with"` label + picker next to the workspace picker.
- `NewChatInSessionWidget` accepts the options for signature consistency but ignores them.

## Notes for reviewers

- The harness picker below the input reuses the existing `renderSessionTypePickerInControls` path in `NewChatInputWidget`, so behavior matches the in-controls rendering already used elsewhere.
- Placement is snapshotted per new-chat view; views created before the treatment resolves keep the default until recreated.