### PR TITLE
sessions: make per-workspace session limit configurable via ExP

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -16,7 +16,7 @@ import { HighlightedLabel } from '../../../../../base/browser/ui/highlightedlabe
 import { createMatches, FuzzyScore, IMatch } from '../../../../../base/common/filters.js';
 import { Disposable, DisposableStore, MutableDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { MarkdownString } from '../../../../../base/common/htmlContent.js';
-import { IObservable, IReader, autorun } from '../../../../../base/common/observable.js';
+import { IObservable, IReader, autorun, observableSignalFromEvent, observableValue } from '../../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { fromNow } from '../../../../../base/common/date.js';
@@ -45,6 +45,7 @@ import { HoverPosition } from '../../../../../base/browser/ui/hover/hoverWidget.
 import { ISessionsManagementService, IActiveSession } from '../../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsViewService } from '../../../../browser/sessionsViewService.js';
 import { ISessionsListModelService } from '../../../../services/sessions/browser/sessionsListModelService.js';
+import { IWorkbenchAssignmentService } from '../../../../../workbench/services/assignment/common/assignmentService.js';
 // =============================================================================
 // TEMPORARY (tracked by https://github.com/microsoft/vscode/issues/320480)
 // -----------------------------------------------------------------------------
@@ -849,7 +850,14 @@ export class SessionsList extends Disposable implements ISessionsList {
 	private static readonly EXCLUDE_ARCHIVED_KEY = 'sessionsListControl.excludeArchived';
 	private static readonly EXCLUDE_READ_KEY = 'sessionsListControl.excludeRead';
 	private static readonly WORKSPACE_GROUP_CAPPED_KEY = 'sessionsListControl.workspaceGroupCapped';
-	private static readonly WORKSPACE_GROUP_LIMIT = 5;
+	private static readonly DEFAULT_WORKSPACE_GROUP_LIMIT = 5;
+
+	/**
+	 * Experiment treatment that overrides how many sessions are shown per
+	 * workspace group before the "show more" affordance appears. Falls back to
+	 * {@link DEFAULT_WORKSPACE_GROUP_LIMIT} when the treatment is not set.
+	 */
+	private static readonly WORKSPACE_GROUP_LIMIT_TREATMENT = 'sessions.workspaceGroupLimit';
 
 	private readonly listContainer: HTMLElement;
 	private readonly tree: WorkbenchObjectTree<SessionListItem, FuzzyScore>;
@@ -860,6 +868,14 @@ export class SessionsList extends Disposable implements ISessionsList {
 	private _excludeArchived: boolean;
 	private _excludeRead: boolean;
 	private workspaceGroupCapped: boolean;
+
+	/**
+	 * Maximum number of sessions shown per workspace group before "show more"
+	 * is rendered. Backed by an experiment treatment (see
+	 * {@link WORKSPACE_GROUP_LIMIT_TREATMENT}) and refreshed whenever the
+	 * assignment service refetches its treatments.
+	 */
+	private readonly workspaceGroupLimit = observableValue<number>(this, SessionsList.DEFAULT_WORKSPACE_GROUP_LIMIT);
 	private readonly expandedWorkspaceGroups = new Set<string>();
 	private expandedMoreFolders = false;
 	private openWindowSourceFolder: URI | undefined;
@@ -888,6 +904,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 		@IMenuService private readonly menuService: IMenuService,
 		@IKeybindingService private readonly keybindingService: IKeybindingService,
 		@ICommandService private readonly commandService: ICommandService,
+		@IWorkbenchAssignmentService private readonly assignmentService: IWorkbenchAssignmentService,
 	) {
 		super();
 
@@ -1116,7 +1133,31 @@ export class SessionsList extends Disposable implements ISessionsList {
 			}
 		}));
 
+		// Resolve the per-workspace session limit from the experiment service and
+		// keep it current when treatments are refetched. The async fetch is
+		// confined to `updateWorkspaceGroupLimit`; the rest of the list reads the
+		// resolved value synchronously off `workspaceGroupLimit`. The autorun runs
+		// immediately for the initial fetch and again whenever treatments refetch.
+		const assignmentRefetchSignal = observableSignalFromEvent(this, this.assignmentService.onDidRefetchAssignments);
+		this._register(autorun(reader => {
+			assignmentRefetchSignal.read(reader);
+			this.updateWorkspaceGroupLimit();
+		}));
+
 		this.refresh();
+	}
+
+	/**
+	 * Fetches the workspace group limit treatment and updates the backing
+	 * observable. Invalid or unset treatments fall back to the default limit.
+	 */
+	private updateWorkspaceGroupLimit(): void {
+		this.assignmentService.getTreatment<number>(SessionsList.WORKSPACE_GROUP_LIMIT_TREATMENT).then(value => {
+			const limit = typeof value === 'number' && Number.isInteger(value) && value > 0
+				? value
+				: SessionsList.DEFAULT_WORKSPACE_GROUP_LIMIT;
+			this.workspaceGroupLimit.set(limit, undefined);
+		});
 	}
 
 	refresh(): void {
@@ -1210,19 +1251,21 @@ export class SessionsList extends Disposable implements ISessionsList {
 
 		const children: IObjectTreeElement<SessionListItem>[] = [];
 
+		const workspaceGroupLimit = this.workspaceGroupLimit.get();
+
 		const renderSection = (section: ISessionSection): IObjectTreeElement<SessionListItem> => {
 			const isWorkspaceGroup = grouping === SessionsGrouping.Workspace
 				&& section.id.startsWith('workspace:');
 			const exceedsLimit = isWorkspaceGroup
 				&& !this.hasFindPattern
-				&& section.sessions.length > SessionsList.WORKSPACE_GROUP_LIMIT;
+				&& section.sessions.length > workspaceGroupLimit;
 			const isExpanded = exceedsLimit && (this.expandedWorkspaceGroups.has(section.label) || !this.workspaceGroupCapped);
 			const isCapped = exceedsLimit && !isExpanded;
 
 			let sectionChildren: IObjectTreeElement<SessionListItem>[];
 			if (isCapped) {
-				const visible = section.sessions.slice(0, SessionsList.WORKSPACE_GROUP_LIMIT);
-				const remainingCount = section.sessions.length - SessionsList.WORKSPACE_GROUP_LIMIT;
+				const visible = section.sessions.slice(0, workspaceGroupLimit);
+				const remainingCount = section.sessions.length - workspaceGroupLimit;
 				sectionChildren = [
 					...visible.map(session => ({ element: session as SessionListItem })),
 					{ element: { showMore: true as const, kind: 'sessions' as const, mode: 'more' as const, sectionLabel: section.label, remainingCount } },


### PR DESCRIPTION
## What

The sessions list in the Agents window capped each workspace group at a hardcoded **5 sessions** before showing the "show more" affordance. This makes that limit configurable via an experiment treatment.

## Changes (`src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts`)

- Replaced the hardcoded `WORKSPACE_GROUP_LIMIT = 5` constant with `DEFAULT_WORKSPACE_GROUP_LIMIT = 5` plus a treatment name `sessions.workspaceGroupLimit`.
- Injected `IWorkbenchAssignmentService` and resolve the limit via `getTreatment<number>`. Invalid/unset treatments (non-positive or non-integer) fall back to the default of 5.
- Encapsulated the resolved value in an `observableValue<number>` so rendering code reads it synchronously — no promises are spread through the list logic.
- The value is refreshed whenever the assignment service fires `onDidRefetchAssignments` (wired via `observableSignalFromEvent` + `autorun`), and a second `autorun` re-renders the list when the limit changes.

## Notes for reviewers

- To roll out a non-default value, define the `sessions.workspaceGroupLimit` treatment variable in ExP.
- The cross-layer import of `IWorkbenchAssignmentService` (sessions → workbench) follows the existing pattern already used in this file.
- This is distinct from the separate "+N more workspaces" capping, which limits the number of workspace groups rather than sessions within a group.