### PR TITLE
Replace play icon with runCompact icon in RunScriptActionViewItem

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/runScriptAction.ts
+++ b/src/vs/sessions/contrib/chat/browser/runScriptAction.ts
@@ -721,7 +721,7 @@ class RunScriptActionViewItem extends BaseActionViewItem {
 				hover: {
 					content: localize('runActionTooltip', "Run '{0}' in terminal", getTaskDisplayLabel(task)),
 				},
-				icon: Codicon.play,
+				icon: Codicon.runCompact,
 				enabled: true,
 				class: undefined,
 				category: isWorktreeTask ? worktreeCategory : defaultCategory,


### PR DESCRIPTION
Update the icon in the RunScriptActionViewItem from play to runCompact for improved clarity. No associated issue. Testing involves verifying the icon change in the UI.

