### PR TITLE
Refactor chat component styles and update chevron icons

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/media/chatInput.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatInput.css
@@ -144,7 +144,7 @@
 
 .sessions-chat-config-toolbar .action-label,
 .sessions-chat-config-toolbar .action-label .chat-input-picker-label {
-	font-size: 11px;
+	font-size: var(--vscode-agents-fontSize-label2, 11px);
 }
 
 /* Allow long labels (e.g. the model picker name) to ellipsize when space is tight */
@@ -162,7 +162,7 @@
 }
 
 .sessions-chat-config-toolbar .monaco-action-bar .action-item .action-label > .codicon {
-	font-size: 12px;
+	font-size: var(--vscode-codiconFontSize-compact, 12px);
 	flex-shrink: 0;
 	/* Override the base .monaco-action-bar .action-item .codicon { width:16px; height:16px }
 	 * so the leading icon sizes naturally to its font-size, matching the bottom-row pickers. */
@@ -344,7 +344,7 @@
 	display: inline-flex;
 	align-items: center;
 	overflow: hidden;
-	font-size: 11px;
+	font-size: var(--vscode-agents-fontSize-body2, 11px);
 	padding: 0 4px 0 0;
 	border: 1px solid var(--vscode-chat-requestBorder, var(--vscode-input-background, transparent));
 	border-radius: var(--vscode-cornerRadius-small);
@@ -403,7 +403,7 @@
 }
 
 .sessions-chat-attachment-remove .codicon {
-	font-size: 12px;
+	font-size: var(--vscode-codiconFontSize-compact, 12px);
 	padding: 0;
 }
 
@@ -443,7 +443,7 @@
 
 .sessions-chat-dnd-overlay .attach-context-overlay-text .codicon {
 	height: 12px;
-	font-size: 12px;
+	font-size: var(--vscode-codiconFontSize-compact, 12px);
 	margin-right: 3px;
 }
 

--- a/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
@@ -182,12 +182,12 @@
 .new-chat-widget-container .new-chat-bottom-container .action-label {
 	height: 16px;
 	padding: 3px 6px;
-	font-size: 11px;
+	font-size: var(--vscode-agents-fontSize-label2, 11px);
 	color: var(--vscode-icon-foreground);
 }
 
 .new-chat-widget-container .new-chat-bottom-container .action-label > .codicon {
-	font-size: 12px;
+	font-size: var(--vscode-codiconFontSize-compact, 12px);
 }
 
 .new-chat-widget-container .new-chat-bottom-container .action-label > .codicon-chevron-down,
@@ -230,7 +230,7 @@
 }
 
 .session-workspace-picker-label {
-	font-size: 18px;
+	font-size: var(--vscode-agents-fontSize-heading2, 18px);
 	line-height: 1.25;
 	color: var(--vscode-descriptionForeground);
 	white-space: nowrap;
@@ -245,7 +245,7 @@
 .sessions-chat-picker-slot.sessions-chat-session-type-picker .action-label {
 	height: auto;
 	padding: 4px;
-	font-size: 18px;
+	font-size: var(--vscode-agents-fontSize-heading2, 18px);
 	line-height: 1.25;
 	border: none;
 	background-color: transparent;
@@ -262,12 +262,12 @@
 
 .sessions-chat-picker-slot.sessions-chat-workspace-picker .action-label .sessions-chat-dropdown-label,
 .sessions-chat-picker-slot.sessions-chat-session-type-picker .action-label .sessions-chat-dropdown-label {
-	font-size: 18px;
+	font-size: var(--vscode-agents-fontSize-heading2, 18px);
 }
 
 .sessions-chat-picker-slot.sessions-chat-workspace-picker .action-label > .codicon:not(.sessions-chat-dropdown-chevron),
-.sessions-chat-picker-slot.sessions-chat-session-type-picker .action-label > .codicon:not(.codicon-chevron-down) {
-	font-size: 16px;
+.sessions-chat-picker-slot.sessions-chat-session-type-picker .action-label > .codicon:not(.sessions-chat-dropdown-chevron) {
+	font-size: var(--vscode-codiconFontSize, 16px);
 	margin: 0;
 }
 
@@ -276,7 +276,7 @@
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
-	font-size: 16px;
+	font-size: var(--vscode-codiconFontSize-compact, 12px);
 	margin-left: 6px;
 	line-height: 1;
 	transform: translateY(1px);
@@ -363,7 +363,7 @@
 }
 
 .sessions-chat-picker-slot .action-label .codicon {
-	font-size: 12px;
+	font-size: var(--vscode-codiconFontSize-compact, 12px);
 	flex-shrink: 0;
 	/* Override the base .monaco-action-bar .action-item .codicon { width:16px; height:16px }
 	 * so codicons here size naturally to their font-size, matching pickers (like Copilot CLI)

--- a/src/vs/sessions/contrib/chat/browser/media/newChatInSession.css
+++ b/src/vs/sessions/contrib/chat/browser/media/newChatInSession.css
@@ -81,13 +81,13 @@
 .new-chat-in-session .sessions-chat-toolbar .action-label {
 	height: 16px;
 	padding: 3px 6px;
-	font-size: 11px;
+	font-size: var(--vscode-agents-fontSize-label2, 11px);
 	color: var(--vscode-icon-foreground);
 }
 
 .new-chat-in-session .new-chat-bottom-container .action-label .codicon,
 .new-chat-in-session .sessions-chat-toolbar .action-label .codicon {
-	font-size: 12px;
+	font-size: var(--vscode-codiconFontSize-compact, 12px);
 }
 
 .new-chat-in-session .sessions-chat-dropdown-label {

--- a/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
@@ -370,7 +370,7 @@ export class SessionTypePicker extends Disposable {
 		const labelSpan = dom.append(this._triggerElement, dom.$('span.sessions-chat-dropdown-label'));
 		labelSpan.textContent = modeLabel;
 
-		const chevron = dom.append(this._triggerElement, renderIcon(Codicon.chevronDown));
+		const chevron = dom.append(this._triggerElement, renderIcon(Codicon.chevronDownCompact));
 		chevron.classList.add('sessions-chat-dropdown-chevron');
 
 		this._triggerElement.ariaLabel = localize('sessionTypePicker.triggerAriaLabel', "Pick Session Type, {0}", modeLabel);

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -877,7 +877,7 @@ export class WorkspacePicker extends Disposable {
 		dom.append(this._triggerElement, renderIcon(icon));
 		const labelSpan = dom.append(this._triggerElement, dom.$('span.sessions-chat-dropdown-label'));
 		labelSpan.textContent = label;
-		dom.append(this._triggerElement, renderIcon(Codicon.chevronDown)).classList.add('sessions-chat-dropdown-chevron');
+		dom.append(this._triggerElement, renderIcon(Codicon.chevronDownCompact)).classList.add('sessions-chat-dropdown-chevron');
 	}
 
 	/**


### PR DESCRIPTION
Refactor chat component styles to utilize CSS variables for font sizes, enhancing consistency and maintainability. Update chevron icons to more compact versions for improved UI aesthetics.

