### PR TITLE
Fix hover "Loading..." position causing UI jump when description loads

### DIFF
--- a/src/vs/editor/contrib/hover/browser/markdownHoverParticipant.ts
+++ b/src/vs/editor/contrib/hover/browser/markdownHoverParticipant.ts
@@ -94,6 +94,9 @@ export class MarkdownHoverParticipant implements IEditorHoverParticipant<Markdow
 	) { }
 
 	public createLoadingMessage(anchor: HoverAnchor): MarkdownHover | null {
+		// Use ordinal 0 so the loading placeholder appears in the same position
+		// as the eventual content (language server descriptions use ordinal ~0),
+		// avoiding a visual jump when the real content replaces it.
 		return new MarkdownHover(this, anchor.range, [new MarkdownString().appendText(nls.localize('modesContentHover.loading', "Loading..."))], false, 0);
 	}
 

--- a/src/vs/editor/contrib/hover/browser/markdownHoverParticipant.ts
+++ b/src/vs/editor/contrib/hover/browser/markdownHoverParticipant.ts
@@ -94,7 +94,7 @@ export class MarkdownHoverParticipant implements IEditorHoverParticipant<Markdow
 	) { }
 
 	public createLoadingMessage(anchor: HoverAnchor): MarkdownHover | null {
-		return new MarkdownHover(this, anchor.range, [new MarkdownString().appendText(nls.localize('modesContentHover.loading', "Loading..."))], false, 2000);
+		return new MarkdownHover(this, anchor.range, [new MarkdownString().appendText(nls.localize('modesContentHover.loading', "Loading..."))], false, 0);
 	}
 
 	public computeSync(anchor: HoverAnchor, lineDecorations: IModelDecoration[]): MarkdownHover[] {

--- a/src/vs/editor/contrib/hover/test/browser/contentHover.test.ts
+++ b/src/vs/editor/contrib/hover/test/browser/contentHover.test.ts
@@ -4,10 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { compareBy, numberComparator } from '../../../../../base/common/arrays.js';
+import { MarkdownString } from '../../../../../base/common/htmlContent.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { Position } from '../../../../common/core/position.js';
 import { Range } from '../../../../common/core/range.js';
 import { RenderedContentHover } from '../../browser/contentHoverRendered.js';
+import { MarkdownHover } from '../../browser/markdownHoverParticipant.js';
 import { IHoverPart } from '../../browser/hoverTypes.js';
 import { TestCodeEditorInstantiationOptions, withTestCodeEditor } from '../../../../test/browser/testCodeEditor.js';
 
@@ -50,5 +53,22 @@ suite('Content Hover', () => {
 				}
 			);
 		});
+	});
+
+	test('issue #320604: Loading message ordinal 0 sorts above action buttons at ordinal 1', () => {
+		const anchor = new Range(1, 1, 1, 10);
+		const owner = <MarkdownHover['owner']>{};
+
+		const loading = new MarkdownHover(owner, anchor, [new MarkdownString().appendText('Loading...')], false, 0);
+		const runScript = new MarkdownHover(owner, anchor, [new MarkdownString().appendText('Run Script')], false, 1);
+		const debugScript = new MarkdownHover(owner, anchor, [new MarkdownString().appendText('Debug Script')], false, 1);
+
+		// Parts arrive with buttons before loading (simulating fast npm provider, slow description)
+		const parts = [runScript, debugScript, loading];
+		parts.sort(compareBy(hover => hover.ordinal, numberComparator));
+
+		assert.strictEqual(parts[0], loading, 'Loading (ordinal 0) should sort before buttons (ordinal 1)');
+		assert.strictEqual(parts[1], runScript);
+		assert.strictEqual(parts[2], debugScript);
 	});
 });

--- a/src/vs/editor/contrib/hover/test/browser/contentHover.test.ts
+++ b/src/vs/editor/contrib/hover/test/browser/contentHover.test.ts
@@ -68,7 +68,10 @@ suite('Content Hover', () => {
 		parts.sort(compareBy(hover => hover.ordinal, numberComparator));
 
 		assert.strictEqual(parts[0], loading, 'Loading (ordinal 0) should sort before buttons (ordinal 1)');
-		assert.strictEqual(parts[1], runScript);
-		assert.strictEqual(parts[2], debugScript);
+		// Both buttons have ordinal 1; only assert they appear after loading
+		assert.strictEqual(parts.length, 3);
+		assert.ok(parts[1] === runScript || parts[1] === debugScript);
+		assert.ok(parts[2] === runScript || parts[2] === debugScript);
+		assert.notStrictEqual(parts[1], parts[2]);
 	});
 });


### PR DESCRIPTION
**Problem:** When hovering over a script name in `package.json`, the "Loading..." placeholder appears below the "Run Script | Debug Script" buttons. When the real description arrives, it sorts above the buttons, causing the buttons to visibly jump down.

**Root cause:** `MarkdownHoverParticipant.createLoadingMessage()` hardcodes ordinal `2000`, sorting the loading message after the buttons (ordinal ~1). The JSON Language Server's description (ordinal ~0) sorts before the buttons, so the content reorders on arrival.

**Fix:** Changed the loading message ordinal from `2000` to `0` so it appears in the same position the description will occupy. The loading message is always replaced atomically when final content arrives, so there's no conflict at ordinal 0.

**Test:** Added a unit test verifying that a loading message (ordinal 0) sorts before action buttons (ordinal 1).

Fixes #320604