### PR TITLE
fix undo/redo interactions in agent host

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSnapshotController.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSnapshotController.ts
@@ -194,23 +194,63 @@ export class AgentHostSnapshotController extends Disposable implements IChatEdit
 			}
 
 			// Restore to before this request: target one slot before it.
-			const targetIdx = cpIdx - 1;
-			const currentIdx = this._currentCheckpointIndex.get();
-			if (targetIdx < currentIdx) {
-				// Undo forward checkpoints
-				for (let i = currentIdx; i > targetIdx; i--) {
-					await this._writeCheckpointContent(this._checkpoints[i], 'before');
-				}
-			} else if (targetIdx > currentIdx) {
-				// Redo to reach the target
-				for (let i = currentIdx + 1; i <= targetIdx; i++) {
-					await this._writeCheckpointContent(this._checkpoints[i], 'after');
-				}
-			}
+			await this._navigateToCheckpointIndex(cpIdx - 1);
+		});
+	}
 
-			transaction(tx => {
-				this._currentCheckpointIndex.set(targetIdx, tx);
-			});
+	/**
+	 * Steps a single checkpoint backwards, undoing the edits of the current
+	 * checkpoint. The "Undo" UI invokes this once per click.
+	 */
+	async undoInteraction(): Promise<void> {
+		return this._undoRedoSequencer.queue(async () => {
+			const currentIdx = this._currentCheckpointIndex.get();
+			if (currentIdx < 0) {
+				return;
+			}
+			await this._navigateToCheckpointIndex(currentIdx - 1);
+		});
+	}
+
+	/**
+	 * Steps a single checkpoint forwards, redoing the edits of the next
+	 * checkpoint.
+	 *
+	 * Implementing this is essential: the "Redo" action repeatedly calls this
+	 * while {@link canRedo} is `true`, so a no-op implementation would spin
+	 * forever and hang the window.
+	 */
+	async redoInteraction(): Promise<void> {
+		return this._undoRedoSequencer.queue(async () => {
+			const currentIdx = this._currentCheckpointIndex.get();
+			if (currentIdx >= this._checkpoints.length - 1) {
+				return;
+			}
+			await this._navigateToCheckpointIndex(currentIdx + 1);
+		});
+	}
+
+	/**
+	 * Moves the on-disk file state and the checkpoint cursor to `targetIdx`,
+	 * writing each crossed checkpoint's before/after content. Must run inside
+	 * the {@link _undoRedoSequencer} to avoid racing writes.
+	 */
+	private async _navigateToCheckpointIndex(targetIdx: number): Promise<void> {
+		const currentIdx = this._currentCheckpointIndex.get();
+		if (targetIdx < currentIdx) {
+			// Undo forward checkpoints
+			for (let i = currentIdx; i > targetIdx; i--) {
+				await this._writeCheckpointContent(this._checkpoints[i], 'before');
+			}
+		} else if (targetIdx > currentIdx) {
+			// Redo to reach the target
+			for (let i = currentIdx + 1; i <= targetIdx; i++) {
+				await this._writeCheckpointContent(this._checkpoints[i], 'after');
+			}
+		}
+
+		transaction(tx => {
+			this._currentCheckpointIndex.set(targetIdx, tx);
 		});
 	}
 
@@ -276,9 +316,6 @@ export class AgentHostSnapshotController extends Disposable implements IChatEdit
 	getDiffsForFilesInSession(): IObservable<readonly IEditSessionEntryDiff[]> { return constObservable([]); }
 	getDiffsForFilesInRequest(_requestId: string): IObservable<readonly IEditSessionEntryDiff[]> { return constObservable([]); }
 	getDiffForSession(): IObservable<IEditSessionDiffStats> { return constObservable({ added: 0, removed: 0 }); }
-
-	async undoInteraction(): Promise<void> { /* no-op */ }
-	async redoInteraction(): Promise<void> { /* no-op */ }
 
 	async triggerExplanationGeneration(): Promise<void> { /* no-op */ }
 	clearExplanations(): void { /* no-op */ }

--- a/src/vs/workbench/contrib/chat/test/browser/agentHost/agentHostSnapshotController.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentHost/agentHostSnapshotController.test.ts
@@ -317,6 +317,75 @@ suite('AgentHostSnapshotController', () => {
 		assert.strictEqual(controller.canUndo.get(), false);
 	});
 
+	test('undoInteraction steps back one checkpoint at a time', async () => {
+		const beforeA = URI.file('/snap/before-a').toString();
+		const afterA = URI.file('/snap/after-a').toString();
+		const beforeB = URI.file('/snap/before-b').toString();
+		const afterB = URI.file('/snap/after-b').toString();
+		const fileA = URI.file('/a.ts').toString();
+		const fileB = URI.file('/b.ts').toString();
+		const contentMap = new Map([
+			[beforeA, 'a0'], [afterA, 'a1'], [fileA, 'a1'],
+			[beforeB, 'b0'], [afterB, 'b1'], [fileB, 'b1'],
+		]);
+		const controller = createController(store, contentMap);
+		controller.addToolCallEdits('req-1', makeToolCall({ toolCallId: 'tc-1', filePath: '/a.ts', beforeURI: beforeA, afterURI: afterA }));
+		controller.addToolCallEdits('req-2', makeToolCall({ toolCallId: 'tc-2', filePath: '/b.ts', beforeURI: beforeB, afterURI: afterB }));
+
+		// Undo req-2 only — req-1's edit stays applied.
+		await controller.undoInteraction();
+		assert.strictEqual(contentMap.get(fileA), 'a1');
+		assert.strictEqual(contentMap.get(fileB), 'b0');
+		assert.strictEqual(controller.canUndo.get(), true);
+		assert.strictEqual(controller.canRedo.get(), true);
+
+		// Undo req-1 too.
+		await controller.undoInteraction();
+		assert.strictEqual(contentMap.get(fileA), 'a0');
+		assert.strictEqual(controller.canUndo.get(), false);
+
+		// Extra undo past the start is a safe no-op.
+		await controller.undoInteraction();
+		assert.strictEqual(contentMap.get(fileA), 'a0');
+	});
+
+	test('redoInteraction steps forward and stops at HEAD (no infinite loop)', async () => {
+		const beforeA = URI.file('/snap/before-a').toString();
+		const afterA = URI.file('/snap/after-a').toString();
+		const beforeB = URI.file('/snap/before-b').toString();
+		const afterB = URI.file('/snap/after-b').toString();
+		const fileA = URI.file('/a.ts').toString();
+		const fileB = URI.file('/b.ts').toString();
+		const contentMap = new Map([
+			[beforeA, 'a0'], [afterA, 'a1'], [fileA, 'a1'],
+			[beforeB, 'b0'], [afterB, 'b1'], [fileB, 'b1'],
+		]);
+		const controller = createController(store, contentMap);
+		controller.addToolCallEdits('req-1', makeToolCall({ toolCallId: 'tc-1', filePath: '/a.ts', beforeURI: beforeA, afterURI: afterA }));
+		controller.addToolCallEdits('req-2', makeToolCall({ toolCallId: 'tc-2', filePath: '/b.ts', beforeURI: beforeB, afterURI: afterB }));
+
+		// Restore to before req-1 so both edits are pending a redo.
+		await controller.restoreSnapshot('req-1', undefined);
+		assert.strictEqual(contentMap.get(fileA), 'a0');
+		assert.strictEqual(contentMap.get(fileB), 'b0');
+		assert.strictEqual(controller.canRedo.get(), true);
+
+		// Emulate the "Redo" action's drain loop. The bounded guard turns a
+		// regression (redoInteraction not advancing the cursor) into a clean
+		// assertion failure instead of an infinite loop that would hang the
+		// window — which is exactly the bug this guards against.
+		let guard = 0;
+		while (controller.canRedo.get()) {
+			await controller.redoInteraction();
+			assert.ok(++guard <= 10, 'redoInteraction failed to advance the checkpoint cursor');
+		}
+
+		assert.strictEqual(contentMap.get(fileA), 'a1');
+		assert.strictEqual(contentMap.get(fileB), 'b1');
+		assert.strictEqual(controller.canRedo.get(), false);
+		assert.strictEqual(controller.canUndo.get(), true);
+	});
+
 	test('streaming-edits APIs throw — agent host owns edits server-side', () => {
 		const controller = createController(store, new Map());
 		const fakeResponseModel = {} as IChatResponseModel;


### PR DESCRIPTION
## Fix window crash when redoing agent-host checkpoints

**Problem:** Clicking **Redo** after restoring a checkpoint in an agent-host session crashed the window.

`AgentHostSnapshotController.redoInteraction()` was a no-op, but the Redo action drains in a loop:

```ts
while (editingSession.canRedo.get()) {
    await editingSession.redoInteraction();
}
```

Since `canRedo` is derived from the checkpoint cursor and the no-op never advanced it, the loop spun forever on the main thread → hang/crash. It only reproduced after a restore/undo, since that's the only time `canRedo` is `true`.

**Fix:** Implement `undoInteraction()` / `redoInteraction()` to move the checkpoint cursor one step, sharing a new `_navigateToCheckpointIndex()` helper that `restoreSnapshot()` also uses. Each redo advances the cursor monotonically toward HEAD, so `canRedo` is guaranteed to flip `false` and the loop terminates.

**Tests:** Added two unit tests — single-step undo, and redo draining that stops at HEAD (regression guard for the infinite loop).