### PR TITLE
Bump version to 1.123.2

### DIFF
--- a/extensions/copilot/package-lock.json
+++ b/extensions/copilot/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "copilot-chat",
-  "version": "0.51.1",
+  "version": "0.51.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "copilot-chat",
-      "version": "0.51.1",
+      "version": "0.51.2",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {

--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -2,7 +2,7 @@
   "name": "copilot-chat",
   "displayName": "GitHub Copilot Chat",
   "description": "AI chat features powered by Copilot",
-  "version": "0.51.1",
+  "version": "0.51.2",
   "build": "1",
   "completionsCoreVersion": "1.378.1799",
   "internalLargeStorageAriaKey": "ec712b3202c5462fb6877acae7f1f9d7-c19ad55e-3e3c-4f99-984b-827f6d95bd9e-6917",
@@ -22,7 +22,7 @@
   "icon": "assets/copilot.png",
   "pricing": "Trial",
   "engines": {
-    "vscode": "^1.123.1",
+    "vscode": "^1.123.2",
     "npm": ">=9.0.0",
     "node": ">=22.14.0"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "code-oss-dev",
-  "version": "1.123.1",
+  "version": "1.123.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "code-oss-dev",
-      "version": "1.123.1",
+      "version": "1.123.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-oss-dev",
-  "version": "1.123.1",
+  "version": "1.123.2",
   "distro": "6a5606319f079b27f14d9a4947bf9cd2bff41528",
   "author": {
     "name": "Microsoft Corporation"


### PR DESCRIPTION
This PR bumps VS Code to 1.123.2 and updates the bundled Copilot Chat package metadata/lockfiles accordingly.

Changes include:
- root `package.json` / `package-lock.json` version updates
- `extensions/copilot` package metadata and lockfile updates
- Copilot extension `engines.vscode` update for 1.123.2