### PR TITLE
Remove copilot is paused label for inline completions

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.ts
@@ -813,10 +813,12 @@ export class ChatStatusDashboard extends DomWidget {
 			const isEnterpriseUser = this.chatEntitlementService.entitlement === ChatEntitlement.Enterprise || this.chatEntitlementService.entitlement === ChatEntitlement.Business;
 			const isUsageBasedBilling = quotas.usageBasedBilling === true;
 
+			// Only chat quotas drive the global callout. Reaching the inline
+			// suggestions (completions) limit pauses ghost text only, so it must
+			// not trigger the "Copilot is paused" message reserved for chat limits.
 			const allQuotas: IQuotaSnapshot[] = [];
 			if (quotas.chat && !quotas.chat.unlimited) { allQuotas.push(quotas.chat); }
 			if (quotas.premiumChat && !quotas.premiumChat.unlimited) { allQuotas.push(quotas.premiumChat); }
-			if (quotas.completions && !quotas.completions.unlimited) { allQuotas.push(quotas.completions); }
 
 			const maxUsedPercentage = allQuotas.length > 0 ? Math.max(...allQuotas.map(q => Math.max(0, 100 - q.percentRemaining))) : 0;
 			const isPooledQuotaExhausted = quotas.premiumChat?.unlimited && quotas.premiumChat.hasQuota === false;

--- a/src/vs/workbench/contrib/chat/test/browser/chatStatusDashboard.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatStatusDashboard.test.ts
@@ -518,6 +518,28 @@ suite('ChatStatusDashboard', () => {
 		assert.strictEqual(getCalloutText(dashboard.element), 'Copilot is paused until the limit resets.');
 	});
 
+	test('Callout: Free — no paused message when only inline suggestions limit is reached', () => {
+		const dashboard = createDashboard(createEntitlementService({
+			chat: { percentRemaining: 90, unlimited: false },
+			completions: { percentRemaining: 0, unlimited: false },
+			additionalUsageEnabled: false,
+			entitlement: ChatEntitlement.Free,
+		}));
+
+		assert.strictEqual(getCalloutText(dashboard.element), null);
+	});
+
+	test('Callout: Free — shows paused when chat limit is reached', () => {
+		const dashboard = createDashboard(createEntitlementService({
+			chat: { percentRemaining: 0, unlimited: false },
+			completions: { percentRemaining: 0, unlimited: false },
+			additionalUsageEnabled: false,
+			entitlement: ChatEntitlement.Free,
+		}));
+
+		assert.strictEqual(getCalloutText(dashboard.element), 'Copilot is paused until the limit resets.');
+	});
+
 	test('Callout: shows budget active when quota exhausted and overage permitted but no overage used yet', () => {
 		const dashboard = createDashboard(createEntitlementService({
 			premiumChat: { percentRemaining: 0, unlimited: false },

--- a/src/vs/workbench/contrib/chat/test/browser/chatStatusDashboard.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatStatusDashboard.test.ts
@@ -532,7 +532,7 @@ suite('ChatStatusDashboard', () => {
 	test('Callout: Free — shows paused when chat limit is reached', () => {
 		const dashboard = createDashboard(createEntitlementService({
 			chat: { percentRemaining: 0, unlimited: false },
-			completions: { percentRemaining: 0, unlimited: false },
+			completions: { percentRemaining: 90, unlimited: false },
 			additionalUsageEnabled: false,
 			entitlement: ChatEntitlement.Free,
 		}));


### PR DESCRIPTION
Addresses https://github.com/microsoft/vscode-internalbacklog/issues/7813

This pull request updates the logic for displaying the "Copilot is paused" callout in the chat status dashboard to ensure it only appears when chat quotas are exhausted, not when the inline suggestions (completions) limit is reached. It also adds new tests to verify this behavior.

**Chat quota callout logic:**

* Updated `ChatStatusDashboard` so that only chat quota exhaustion (not completions/inline suggestions) triggers the global "Copilot is paused" message. This prevents confusion when only inline suggestions are paused, as that scenario should not show the global paused callout.

**Testing:**

* Added tests to verify that the paused callout is not shown when only the inline suggestions limit is reached, and that it is shown when the chat limit is reached.
<img width="798" height="535" alt="image" src="https://github.com/user-attachments/assets/6e987739-a783-475a-bf0b-6e9bfbb63592" />

<img width="617" height="577" alt="image" src="https://github.com/user-attachments/assets/9788a900-782c-4392-9781-ed25b1bb4957" />
