### PR TITLE
[main] Cherry-pick MSRC fixes

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -151,6 +151,21 @@
     "toolInvocationApproveCombination",
     "chatSessionCustomizationProvider"
   ],
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": "limited",
+      "description": "%workspaceTrust%",
+      "restrictedConfigurations": [
+        "github.copilot.chat.otel.enabled",
+        "github.copilot.chat.otel.exporterType",
+        "github.copilot.chat.otel.otlpEndpoint",
+        "github.copilot.chat.otel.captureContent",
+        "github.copilot.chat.otel.maxAttributeSizeChars",
+        "github.copilot.chat.otel.outfile",
+        "github.copilot.chat.otel.dbSpanExporter.enabled"
+      ]
+    }
+  },
   "contributes": {
     "languageModelTools": [
       {
@@ -2855,6 +2870,18 @@
         "enablement": "config.github.copilot.chat.otel.dbSpanExporter.enabled"
       },
       {
+        "command": "github.copilot.chat.otel.statusActive",
+        "title": "OpenTelemetry",
+        "category": "Chat",
+        "icon": "$(broadcast)"
+      },
+      {
+        "command": "github.copilot.chat.otel.statusCapturing",
+        "title": "OpenTelemetry",
+        "category": "Chat",
+        "icon": "$(eye)"
+      },
+      {
         "command": "github.copilot.sessionSync.deleteSessions",
         "title": "%github.copilot.command.sessionSync.deleteSessions%",
         "category": "Chat",
@@ -5519,7 +5546,27 @@
           "group": "inline@2"
         }
       ],
+      "chat/input/status": [
+        {
+          "command": "github.copilot.chat.otel.statusActive",
+          "when": "github.copilot.otel.state == 'active'",
+          "group": "navigation"
+        },
+        {
+          "command": "github.copilot.chat.otel.statusCapturing",
+          "when": "github.copilot.otel.state == 'capturing'",
+          "group": "navigation"
+        }
+      ],
       "commandPalette": [
+        {
+          "command": "github.copilot.chat.otel.statusActive",
+          "when": "false"
+        },
+        {
+          "command": "github.copilot.chat.otel.statusCapturing",
+          "when": "false"
+        },
         {
           "command": "github.copilot.cli.openInCopilotCLI",
           "when": "false"

--- a/extensions/copilot/package.nls.json
+++ b/extensions/copilot/package.nls.json
@@ -1,4 +1,5 @@
 {
+	"workspaceTrust": "Copilot Chat applies workspace-scoped OpenTelemetry settings only in trusted workspaces.",
 	"github.copilot.badge.signUp": "Sign up for GitHub Copilot",
 	"github.copilot.badge.star": "Star Copilot on GitHub",
 	"github.copilot.badge.youtube": "Check out GitHub on Youtube",

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSessionService.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSessionService.ts
@@ -385,33 +385,24 @@ export class CopilotCLISessionService extends Disposable implements ICopilotCLIS
 			try {
 				const sdkPackage = await this.getSDKPackage();
 				const { internal, createLocalFeatureFlagServiceCreator } = sdkPackage;
-				// Always enable SDK OTel so the debug panel receives native spans via the bridge.
-				// When user OTel is disabled, we force file exporter to /dev/null so the SDK
-				// creates OtelSessionTracker (for debug panel) but doesn't export to any collector.
-				if (!process.env['COPILOT_OTEL_ENABLED']) {
-					process.env['COPILOT_OTEL_ENABLED'] = 'true';
-				}
-				// Default content capture to 'true' for the debug panel. When user OTel
-				// is enabled, their captureContent setting overrides this default below.
-				// When user OTel is disabled, the default gives debug panel content.
-				// If the user explicitly set the env var, respect their choice.
-				if (!process.env['OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT']) {
-					process.env['OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT'] = 'true';
-				}
-				if (this._otelService.config.enabled) {
+				// The SDK reads OTel config from process.env at startup. Snapshot
+				// the originals so disposal restores them and subprocesses don't
+				// inherit our mutations.
+				this._registerOTelEnvSnapshot();
+				if (this._otelService.config.enabledExplicitly) {
 					const otelEnv = deriveCopilotCliOTelEnv(this._otelService.config);
 					for (const [key, value] of Object.entries(otelEnv)) {
 						process.env[key] = value;
 					}
-					// When user OTel is enabled, their captureContent config takes
-					// precedence over the debug-panel default set above.
 					process.env['OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT'] = String(this._otelService.config.captureContent);
 				} else {
-					// User OTel disabled: ensure SDK doesn't export to any external collector.
-					// Use file exporter to /dev/null so the SDK creates OtelSessionTracker
-					// (for debug panel) but writes spans nowhere.
-					process.env['COPILOT_OTEL_EXPORTER_TYPE'] = 'file';
+					// User opted out. Keep the SDK's OtelSessionTracker alive for the
+					// debug panel by setting only the file exporter path (the SDK
+					// auto-derives exporterType='file' from it), pointed at /dev/null.
+					// Clear any inherited OTLP endpoint so the SDK can't fall back to it.
 					process.env['COPILOT_OTEL_FILE_EXPORTER_PATH'] = devNull;
+					delete process.env['OTEL_EXPORTER_OTLP_ENDPOINT'];
+					delete process.env['COPILOT_OTEL_ENDPOINT'];
 				}
 				return new internal.LocalSessionManager({
 					createFeatureFlagService: createLocalFeatureFlagServiceCreator(),
@@ -429,6 +420,39 @@ export class CopilotCLISessionService extends Disposable implements ICopilotCLIS
 
 	private async getSDKPackage(): Promise<SDKPackage> {
 		return this.copilotCLISDK.getPackage();
+	}
+
+	/**
+	 * Snapshot OTel env vars before SDK mutation and restore them on disposal,
+	 * so subprocesses spawned later don't inherit our mutations.
+	 */
+	private _otelEnvSnapshotted = false;
+	private _registerOTelEnvSnapshot(): void {
+		if (this._otelEnvSnapshotted) {
+			return;
+		}
+		this._otelEnvSnapshotted = true;
+		const keys = [
+			'COPILOT_OTEL_ENABLED',
+			'OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT',
+			'OTEL_EXPORTER_OTLP_ENDPOINT',
+			'COPILOT_OTEL_ENDPOINT',
+			'COPILOT_OTEL_EXPORTER_TYPE',
+			'COPILOT_OTEL_FILE_EXPORTER_PATH',
+		];
+		const originals = new Map<string, string | undefined>();
+		for (const key of keys) {
+			originals.set(key, process.env[key]);
+		}
+		this._register(toDisposable(() => {
+			for (const [key, value] of originals) {
+				if (value === undefined) {
+					delete process.env[key];
+				} else {
+					process.env[key] = value;
+				}
+			}
+		}));
 	}
 
 	private createAutoModeManager(sdkPackage: SDKPackage): SDKAutoModeSessionManager {

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCLITerminalIntegration.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCLITerminalIntegration.ts
@@ -430,7 +430,8 @@ async function getCommonTerminalOptions(name: string, authenticationService: IAu
 			// regardless of process.env state (which may have stale values from the
 			// in-process background agent). TerminalOptions.env overlays the inherited
 			// process.env, so explicit entries here take precedence.
-			...(otelService.config.enabled ? deriveCopilotCliOTelEnv(otelService.config, {}) : {}),
+			// `deriveCopilotCliOTelEnv` returns `{}` when not `enabledExplicitly`.
+			...deriveCopilotCliOTelEnv(otelService.config, {}),
 		};
 	}
 	return options;

--- a/extensions/copilot/src/extension/otel/vscode-node/otelContrib.ts
+++ b/extensions/copilot/src/extension/otel/vscode-node/otelContrib.ts
@@ -6,6 +6,7 @@
 import * as os from 'os';
 import * as vscode from 'vscode';
 import { ConfigKey } from '../../../platform/configuration/common/configurationService';
+import { IVSCodeExtensionContext } from '../../../platform/extContext/common/extensionContext';
 import { ILogService } from '../../../platform/log/common/logService';
 import { DEFAULT_OTLP_ENDPOINT } from '../../../platform/otel/common/otelConfig';
 import { IOTelService } from '../../../platform/otel/common/otelService';
@@ -14,17 +15,42 @@ import { ITelemetryService } from '../../../platform/telemetry/common/telemetry'
 import { Disposable } from '../../../util/vs/base/common/lifecycle';
 import type { IExtensionContribution } from '../../common/contributions';
 
+const OPEN_OTEL_SETTINGS_COMMAND = 'github.copilot.chat.otel.openSettings';
+const PILL_ACTIVE_COMMAND = 'github.copilot.chat.otel.statusActive';
+const PILL_CAPTURING_COMMAND = 'github.copilot.chat.otel.statusCapturing';
+const DISMISS_CAPTURE_NOTIFICATION_COMMAND = 'github.copilot.chat.otel.dismissCaptureNotification';
+const CHAT_STATUS_ITEM_ID = 'copilot.otelStatus';
+const CHAT_NOTIFICATION_ID = 'copilot.otelStatus';
+// Per-workspace, per-endpoint: Workspace Trust ≠ consent to send chat content to a collector.
+const CAPTURE_CONTENT_CONSENT_KEY = 'copilot.otel.captureContentConsent';
+const CAPTURE_NOTIFICATION_DISMISSED_KEY = 'copilot.otel.captureNotificationDismissed';
+const OTEL_STATE_CONTEXT_KEY = 'github.copilot.otel.state';
+type OTelUiState = 'off' | 'active' | 'capturing';
+
+interface CaptureContentConsentMap {
+	[endpoint: string]: 'allowed';
+}
+
+interface CaptureNotificationDismissalMap {
+	[endpoint: string]: true;
+}
+
 /**
  * Lifecycle contribution that logs OTel status, wires the SQLite store,
- * and shuts down the SDK on extension deactivation.
+ * surfaces the active configuration in the UI, and shuts down the SDK on
+ * extension deactivation.
  */
 export class OTelContrib extends Disposable implements IExtensionContribution {
+
+	// Suppresses the generic reload-required toast when we trigger our own auto-reload.
+	private _suppressNextReloadPrompt = false;
 
 	constructor(
 		@IOTelService private readonly _otelService: IOTelService,
 		@IOTelSqliteStore private readonly _sqliteStore: OTelSqliteStore,
 		@ILogService private readonly _logService: ILogService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
+		@IVSCodeExtensionContext private readonly _extensionContext: IVSCodeExtensionContext,
 	) {
 		super();
 		if (this._otelService.config.enabled) {
@@ -34,6 +60,10 @@ export class OTelContrib extends Disposable implements IExtensionContribution {
 		}
 
 		this._fireActivatedTelemetry();
+		this._registerOpenSettingsCommand();
+		this._logEndpointInfo();
+		this._installVisibilityIndicators();
+		this._configureTerminalEnv();
 
 		this._register(vscode.commands.registerCommand('github.copilot.chat.otel.flush', async () => {
 			if (!this._otelService.config.enabled) {
@@ -115,22 +145,364 @@ export class OTelContrib extends Disposable implements IExtensionContribution {
 
 		this._register(vscode.workspace.onDidChangeConfiguration(async e => {
 			const currentConfig = vscode.workspace.getConfiguration();
-			const changed = reloadSettings.some(s =>
+			const changedSettings = reloadSettings.filter(s =>
 				e.affectsConfiguration(s.fullyQualifiedId) &&
 				currentConfig.get(s.fullyQualifiedId) !== initialValues.get(s.fullyQualifiedId)
 			);
-			if (!changed) {
+			if (changedSettings.length === 0) {
 				return;
 			}
+			// Avoid double-prompting when we already triggered our own reload.
+			if (this._suppressNextReloadPrompt) {
+				this._suppressNextReloadPrompt = false;
+				return;
+			}
+			const endpointSetting = ConfigKey.Advanced.OTelOtlpEndpoint;
+			const endpointChanged = changedSettings.some(s => s.fullyQualifiedId === endpointSetting.fullyQualifiedId);
 			const reloadWindowLabel = vscode.l10n.t("Reload Window");
+			const message = endpointChanged
+				? vscode.l10n.t("Copilot OTel endpoint will change to {0} after reload.", String(currentConfig.get(endpointSetting.fullyQualifiedId)))
+				: vscode.l10n.t("Copilot OTel settings changed - a reload is required for the change to take effect.");
 			const selection = await vscode.window.showInformationMessage(
-				vscode.l10n.t("Copilot OTel settings changed - a reload is required for the change to take effect."),
+				message,
 				reloadWindowLabel,
 			);
 			if (selection === reloadWindowLabel) {
 				await vscode.commands.executeCommand('workbench.action.reloadWindow');
 			}
 		}));
+	}
+
+	/**
+	 * Surfaces the active OTel configuration in the UI: a row in the Copilot
+	 * Chat status dashboard, plus (when broadcasting) a chat-input banner.
+	 */
+	private _installVisibilityIndicators(): void {
+		const config = this._otelService.config;
+		void vscode.commands.executeCommand('setContext', OTEL_STATE_CONTEXT_KEY, this._computeUiState());
+
+		// Only show broadcast indicators when the user explicitly opted in;
+		// db-only / debug-panel modes don't send data off-machine.
+		if (!config.enabledExplicitly) {
+			return;
+		}
+
+		this._register(vscode.commands.registerCommand(PILL_ACTIVE_COMMAND, () =>
+			vscode.commands.executeCommand(OPEN_OTEL_SETTINGS_COMMAND)
+		));
+		this._register(vscode.commands.registerCommand(PILL_CAPTURING_COMMAND, () =>
+			vscode.commands.executeCommand(OPEN_OTEL_SETTINGS_COMMAND)
+		));
+
+		const chatStatusItem = this._register(vscode.window.createChatStatusItem(CHAT_STATUS_ITEM_ID));
+		this._refreshChatStatusItem(chatStatusItem);
+
+		let chatNotification: vscode.ChatInputNotification | undefined;
+		const ensureChatNotification = (): vscode.ChatInputNotification => {
+			if (!chatNotification) {
+				chatNotification = vscode.chat.createInputNotification(CHAT_NOTIFICATION_ID);
+				this._register({ dispose: () => chatNotification?.dispose() });
+			}
+			return chatNotification;
+		};
+
+		this._register(vscode.commands.registerCommand(DISMISS_CAPTURE_NOTIFICATION_COMMAND, async (endpoint?: string) => {
+			const target = endpoint ?? this._otelService.config.otlpEndpoint;
+			await this._persistCaptureNotificationDismissal(target);
+			chatNotification?.hide();
+			/* __GDPR__
+				"otel.captureNotificationDismissed" : {
+					"owner": "zhichli",
+					"comment": "Fired when the user permanently dismisses the chat-input capture-content notification for the current workspace"
+				}
+			*/
+			this._telemetryService.sendMSFTTelemetryEvent('otel.captureNotificationDismissed');
+		}));
+		this._refreshChatNotification(ensureChatNotification);
+
+		void this._maybePromptForCaptureContentConsent();
+	}
+
+	private _computeUiState(): OTelUiState {
+		const config = this._otelService.config;
+		if (!config.enabledExplicitly) {
+			return 'off';
+		}
+		const capturing = config.captureContent
+			&& config.exporterType !== 'console'
+			&& config.exporterType !== 'file';
+		return capturing ? 'capturing' : 'active';
+	}
+
+	private _refreshChatStatusItem(item: vscode.ChatStatusItem): void {
+		const config = this._otelService.config;
+		item.title = vscode.l10n.t('OpenTelemetry');
+		item.description = '';
+
+		const yes = vscode.l10n.t('On');
+		const no = vscode.l10n.t('Off');
+		const escapeCell = (s: string) => s.replace(/\|/g, '\\|');
+		const fileLink = (p: string, displayText?: string) => {
+			const uri = vscode.Uri.file(p).toString();
+			const text = escapeCell(displayText ?? p);
+			return `[${text}](${uri} "${escapeCell(p)}")`;
+		};
+		const urlLink = (url: string, displayText?: string) => {
+			const text = escapeCell(displayText ?? url);
+			return `[${text}](${url} "${escapeCell(url)}")`;
+		};
+		const rows: Array<{ readonly label: string; readonly value: string }> = [
+			{ label: vscode.l10n.t('Capture content'), value: config.captureContent ? yes : no },
+		];
+		// db-only mode uses NoopSpanExporter; suppress endpoint/exporter rows.
+		if (config.enabledExplicitly) {
+			rows.push({ label: vscode.l10n.t('Endpoint'), value: urlLink(config.otlpEndpoint) });
+			// Hide the /dev/null sentinel exporter (internal, not user-controlled).
+			if (!(config.exporterType === 'file' && config.fileExporterPath === os.devNull)) {
+				rows.push({ label: vscode.l10n.t('Exporter type'), value: escapeCell(config.exporterType) });
+			}
+		}
+		if (config.enabledExplicitly && config.fileExporterPath && config.fileExporterPath !== os.devNull) {
+			const fileBaseName = config.fileExporterPath.replace(/^.*[\\/]/, '');
+			rows.push({ label: vscode.l10n.t('Outfile'), value: fileLink(config.fileExporterPath, fileBaseName) });
+		}
+		if (config.dbSpanExporter) {
+			const dbPath = this._sqliteStore?.dbPath;
+			const dbDisplay = dbPath ? dbPath.replace(/^.*[\\/]/, '') : '';
+			rows.push({
+				label: vscode.l10n.t('Local Store'),
+				value: dbPath ? fileLink(dbPath, dbDisplay) : yes,
+			});
+		}
+		// Markdown table requires a header row; popup CSS hides the empty thead.
+		const lines: string[] = [
+			`|     |     |`,
+			`| --- | --- |`,
+			...rows.map(({ label, value }) => `| ${escapeCell(label)} | ${value} |`),
+		];
+		item.detail = lines.join('\n');
+		item.show();
+	}
+
+	private _refreshChatNotification(ensureChatNotification: () => vscode.ChatInputNotification): void {
+		const config = this._otelService.config;
+		// Only warn when content actually broadcasts off-device.
+		const captureWarning = config.enabledExplicitly
+			&& config.captureContent
+			&& config.exporterType !== 'console'
+			&& config.exporterType !== 'file';
+		if (!captureWarning) {
+			return;
+		}
+		if (this._isCaptureNotificationDismissed(config.otlpEndpoint)) {
+			return;
+		}
+		const notification = ensureChatNotification();
+		notification.severity = vscode.ChatInputNotificationSeverity.Warning;
+		notification.message = vscode.l10n.t('Agent being monitored via OpenTelemetry');
+		notification.description = vscode.l10n.t('Chat content is being sent to {0}.', this._formatEndpointHost(config.otlpEndpoint));
+		notification.actions = [
+			{
+				label: vscode.l10n.t("Don't Show Again"),
+				commandId: DISMISS_CAPTURE_NOTIFICATION_COMMAND,
+				commandArgs: [config.otlpEndpoint],
+			},
+			{ label: vscode.l10n.t('Manage'), commandId: OPEN_OTEL_SETTINGS_COMMAND },
+		];
+		notification.dismissible = true;
+		notification.autoDismissOnMessage = false;
+		notification.show();
+	}
+
+	private _isCaptureNotificationDismissed(endpoint: string): boolean {
+		const dismissals = this._extensionContext.workspaceState.get<CaptureNotificationDismissalMap>(CAPTURE_NOTIFICATION_DISMISSED_KEY) ?? {};
+		return dismissals[endpoint] === true;
+	}
+
+	private async _persistCaptureNotificationDismissal(endpoint: string): Promise<void> {
+		const dismissals = this._extensionContext.workspaceState.get<CaptureNotificationDismissalMap>(CAPTURE_NOTIFICATION_DISMISSED_KEY) ?? {};
+		if (dismissals[endpoint] === true) {
+			return;
+		}
+		const updated: CaptureNotificationDismissalMap = { ...dismissals, [endpoint]: true };
+		await this._extensionContext.workspaceState.update(CAPTURE_NOTIFICATION_DISMISSED_KEY, updated);
+	}
+
+	/**
+	 * Disclosure modal shown when capture is broadcasting to an OTLP collector.
+	 * The SDK has already initialized when this fires, so the modal documents
+	 * reality and lets the user keep, manage, or disable+reload.
+	 */
+	private async _maybePromptForCaptureContentConsent(): Promise<void> {
+		const config = this._otelService.config;
+		if (!config.captureContent || !config.enabled || !config.enabledExplicitly) {
+			return;
+		}
+		if (config.exporterType === 'console' || config.exporterType === 'file') {
+			return;
+		}
+		const endpoint = config.otlpEndpoint;
+		const consents = this._extensionContext.workspaceState.get<CaptureContentConsentMap>(CAPTURE_CONTENT_CONSENT_KEY) ?? {};
+		if (consents[endpoint] === 'allowed') {
+			return;
+		}
+
+		const okLabel = vscode.l10n.t('OK');
+		const manageLabel = vscode.l10n.t('Manage');
+		const message = vscode.l10n.t('Copilot Chat is sending conversation content to {0}.', endpoint);
+		const detail = vscode.l10n.t(
+			'This setting is configured in your settings and is taking effect now \u2014 capture is active.\n\n\u2022 OK: keep the setting and continue capturing.\n\u2022 Manage: open OpenTelemetry settings to review or change the configuration.\n\u2022 Cancel or Esc: disable capture and reload the window.'
+		);
+		const selection = await vscode.window.showWarningMessage(
+			message,
+			{ modal: true, detail },
+			okLabel,
+			manageLabel,
+		);
+		/* __GDPR__
+			"otel.captureContentConsent" : {
+				"owner": "zhichli",
+				"comment": "Records the user's response to the captureContent disclosure modal",
+				"choice": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "User choice: ok, manage, or cancel (Esc/dismiss)" },
+				"enabledVia": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "How OTel was enabled when the prompt fired" }
+			}
+		*/
+		if (selection === okLabel) {
+			const updated: CaptureContentConsentMap = { ...consents, [endpoint]: 'allowed' };
+			await this._extensionContext.workspaceState.update(CAPTURE_CONTENT_CONSENT_KEY, updated);
+			this._telemetryService.sendMSFTTelemetryEvent('otel.captureContentConsent', { choice: 'ok', enabledVia: config.enabledVia });
+			return;
+		}
+		if (selection === manageLabel) {
+			await vscode.commands.executeCommand(OPEN_OTEL_SETTINGS_COMMAND);
+			this._telemetryService.sendMSFTTelemetryEvent('otel.captureContentConsent', { choice: 'manage', enabledVia: config.enabledVia });
+			return;
+		}
+		// Cancel / Esc: disable capture and reload.
+		await this._disableCaptureAndReload(config.enabledVia);
+	}
+
+	/**
+	 * Flip `OTelCaptureContent` off at its effective scope (folder → workspace
+	 * → global), then reload. Writing to `Global` would not override a value
+	 * pinned in workspace settings.
+	 */
+	private async _disableCaptureAndReload(enabledVia: string): Promise<void> {
+		this._telemetryService.sendMSFTTelemetryEvent('otel.captureContentConsent', { choice: 'cancel', enabledVia });
+		const settingId = ConfigKey.Advanced.OTelCaptureContent.fullyQualifiedId;
+		const inspected = vscode.workspace.getConfiguration().inspect<boolean>(settingId);
+		let target: vscode.ConfigurationTarget = vscode.ConfigurationTarget.Global;
+		if (inspected?.workspaceFolderValue !== undefined) {
+			target = vscode.ConfigurationTarget.WorkspaceFolder;
+		} else if (inspected?.workspaceValue !== undefined) {
+			target = vscode.ConfigurationTarget.Workspace;
+		}
+		this._suppressNextReloadPrompt = true;
+		try {
+			await vscode.workspace.getConfiguration().update(settingId, false, target);
+		} catch (err) {
+			this._suppressNextReloadPrompt = false;
+			this._logService.warn(`[OTel] Failed to disable captureContent: ${String(err)}`);
+			return;
+		}
+		await vscode.commands.executeCommand('workbench.action.reloadWindow');
+	}
+
+	private _logEndpointInfo(): void {
+		const config = this._otelService.config;
+		if (!config.enabled || !config.enabledExplicitly || !config.captureContent) {
+			return;
+		}
+		if (config.exporterType === 'console' || config.exporterType === 'file') {
+			return;
+		}
+		let host: string | undefined;
+		try {
+			host = new URL(config.otlpEndpoint).hostname.toLowerCase();
+		} catch {
+			this._logService.warn(`[OTel] captureContent is on but the OTLP endpoint is not a valid URL: ${config.otlpEndpoint}`);
+			return;
+		}
+		const isLocal = host === 'localhost' || host === '127.0.0.1' || host === '::1' || host.endsWith('.localhost');
+		if (!isLocal) {
+			this._logService.info(`[OTel] captureContent is enabled; conversation content will be sent to ${config.otlpEndpoint}.`);
+		}
+	}
+
+	/**
+	 * Mirror the resolved OTel config into integrated terminals via
+	 * `environmentVariableCollection`, so terminals opened before the SDK
+	 * boots still see user-controlled values.
+	 */
+	private _configureTerminalEnv(): void {
+		const collection = this._extensionContext.environmentVariableCollection;
+		const otelKeys = [
+			'COPILOT_OTEL_ENABLED',
+			'OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT',
+			'OTEL_EXPORTER_OTLP_ENDPOINT',
+			'COPILOT_OTEL_ENDPOINT',
+			'COPILOT_OTEL_EXPORTER_TYPE',
+			'COPILOT_OTEL_FILE_EXPORTER_PATH',
+		];
+		// Clear prior overrides before re-applying.
+		for (const key of otelKeys) {
+			collection.delete(key);
+		}
+
+		const config = this._otelService.config;
+		if (!config.enabledExplicitly) {
+			return;
+		}
+
+		collection.replace('COPILOT_OTEL_ENABLED', 'true');
+		if (config.otlpEndpoint) {
+			collection.replace('OTEL_EXPORTER_OTLP_ENDPOINT', config.otlpEndpoint);
+		}
+		collection.replace('OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT', String(config.captureContent));
+	}
+
+	private _registerOpenSettingsCommand(): void {
+		this._register(vscode.commands.registerCommand(OPEN_OTEL_SETTINGS_COMMAND, async () => {
+			await this._openOTelSettingsAtEffectiveScope();
+		}));
+	}
+
+	/**
+	 * Open Settings at the deepest scope where any OTel setting is configured
+	 * (folder → workspace → user). Writing at the wrong scope would not
+	 * override a value pinned in workspace settings.
+	 */
+	private async _openOTelSettingsAtEffectiveScope(): Promise<void> {
+		const query = 'github.copilot.chat.otel';
+		// Probe across multiple OTel settings, not just captureContent: any of
+		// them may pin scope while captureContent stays at default.
+		const probeSettings = [
+			ConfigKey.Advanced.OTelCaptureContent.fullyQualifiedId,
+			ConfigKey.Advanced.OTelEnabled.fullyQualifiedId,
+			ConfigKey.Advanced.OTelOtlpEndpoint.fullyQualifiedId,
+			ConfigKey.Advanced.OTelExporterType.fullyQualifiedId,
+		];
+		const config = vscode.workspace.getConfiguration();
+		const isFolderScoped = probeSettings.some(id => config.inspect(id)?.workspaceFolderValue !== undefined);
+		const isWorkspaceScoped = probeSettings.some(id => config.inspect(id)?.workspaceValue !== undefined);
+		if (isFolderScoped) {
+			await vscode.commands.executeCommand('workbench.action.openFolderSettings', query);
+			return;
+		}
+		if (isWorkspaceScoped) {
+			await vscode.commands.executeCommand('workbench.action.openWorkspaceSettings', query);
+			return;
+		}
+		await vscode.commands.executeCommand('workbench.action.openSettings', query);
+	}
+
+	private _formatEndpointHost(endpoint: string): string {
+		try {
+			const url = new URL(endpoint);
+			return url.host || url.origin || endpoint;
+		} catch {
+			return endpoint;
+		}
 	}
 
 	override dispose(): void {

--- a/extensions/copilot/src/platform/otel/common/agentOTelEnv.ts
+++ b/extensions/copilot/src/platform/otel/common/agentOTelEnv.ts
@@ -14,7 +14,10 @@ import type { OTelConfig } from './otelConfig';
  * and the terminal CLI session (spread into `TerminalOptions.env`).
  */
 export function deriveCopilotCliOTelEnv(config: OTelConfig, env: Record<string, string | undefined> = process.env): Record<string, string> {
-	if (!config.enabled) {
+	// Only forward to subprocess when the user explicitly opted in. In db-only
+	// mode the in-process SDK uses NoopSpanExporter; the subprocess has no DB
+	// exporter and would silently export to the OTLP endpoint.
+	if (!config.enabled || !config.enabledExplicitly) {
 		return {};
 	}
 
@@ -51,7 +54,9 @@ export function deriveCopilotCliOTelEnv(config: OTelConfig, env: Record<string, 
  * Only sets variables not already present in `process.env`.
  */
 export function deriveClaudeOTelEnv(config: OTelConfig, env: Record<string, string | undefined> = process.env): Record<string, string> {
-	if (!config.enabled) {
+	// See `deriveCopilotCliOTelEnv`: gate on `enabledExplicitly` so db-only
+	// mode doesn't leak the OTLP endpoint to the subprocess.
+	if (!config.enabled || !config.enabledExplicitly) {
 		return {};
 	}
 

--- a/extensions/copilot/src/platform/otel/common/test/agentOTelEnv.spec.ts
+++ b/extensions/copilot/src/platform/otel/common/test/agentOTelEnv.spec.ts
@@ -36,6 +36,11 @@ describe('deriveCopilotCliOTelEnv', () => {
 		expect(result).toEqual({});
 	});
 
+	it('returns empty in db-only mode (enabled but not enabledExplicitly)', () => {
+		const result = deriveCopilotCliOTelEnv(makeConfig({ enabledExplicitly: false, enabledVia: 'dbSpanExporterOnly', dbSpanExporter: true }), emptyEnv);
+		expect(result).toEqual({});
+	});
+
 	it('returns correct env vars when enabled', () => {
 		const result = deriveCopilotCliOTelEnv(makeConfig(), emptyEnv);
 		expect(result).toEqual({
@@ -79,6 +84,11 @@ describe('deriveCopilotCliOTelEnv', () => {
 describe('deriveClaudeOTelEnv', () => {
 	it('returns empty when disabled', () => {
 		const result = deriveClaudeOTelEnv(makeConfig({ enabled: false }), emptyEnv);
+		expect(result).toEqual({});
+	});
+
+	it('returns empty in db-only mode (enabled but not enabledExplicitly)', () => {
+		const result = deriveClaudeOTelEnv(makeConfig({ enabledExplicitly: false, enabledVia: 'dbSpanExporterOnly', dbSpanExporter: true }), emptyEnv);
 		expect(result).toEqual({});
 	});
 

--- a/extensions/copilot/src/util/vs/base/common/extpath.ts
+++ b/extensions/copilot/src/util/vs/base/common/extpath.ts
@@ -226,13 +226,23 @@ export function isEqual(pathA: string, pathB: string, ignoreCase?: boolean): boo
  * you are in a context without services, consider to pass down the `extUri` from the
  * outside, or use `extUriBiasedIgnorePathCase` if you know what you are doing.
  */
-export function isEqualOrParent(base: string, parentCandidate: string, ignoreCase?: boolean, separator = sep): boolean {
+export function isEqualOrParent(base: string, parentCandidate: string, ignoreCase?: boolean, forcePosixSemantics = false): boolean {
+	const separator = forcePosixSemantics ? posix.sep : sep;
+
 	if (base === parentCandidate) {
 		return true;
 	}
 
 	if (!base || !parentCandidate) {
 		return false;
+	}
+
+	if (
+		base.indexOf('..') >= 0 ||
+		parentCandidate.indexOf('..') >= 0
+	) {
+		base = forcePosixSemantics ? posix.normalize(base) : normalize(base);
+		parentCandidate = forcePosixSemantics ? posix.normalize(parentCandidate) : normalize(parentCandidate);
 	}
 
 	if (parentCandidate.length > base.length) {

--- a/extensions/copilot/src/util/vs/base/common/resources.ts
+++ b/extensions/copilot/src/util/vs/base/common/resources.ts
@@ -176,7 +176,7 @@ export class ExtUri implements IExtUri {
 				return extpath.isEqualOrParent(originalFSPath(base), originalFSPath(parentCandidate), this._ignorePathCasing(base)) && base.query === parentCandidate.query && (ignoreFragment || base.fragment === parentCandidate.fragment);
 			}
 			if (isEqualAuthority(base.authority, parentCandidate.authority)) {
-				return extpath.isEqualOrParent(base.path, parentCandidate.path, this._ignorePathCasing(base), '/') && base.query === parentCandidate.query && (ignoreFragment || base.fragment === parentCandidate.fragment);
+				return extpath.isEqualOrParent(base.path, parentCandidate.path, this._ignorePathCasing(base), true) && base.query === parentCandidate.query && (ignoreFragment || base.fragment === parentCandidate.fragment);
 			}
 		}
 		return false;

--- a/extensions/github/src/credentialProvider.ts
+++ b/extensions/github/src/credentialProvider.ts
@@ -12,7 +12,8 @@ const EmptyDisposable: Disposable = { dispose() { } };
 class GitHubCredentialProvider implements CredentialsProvider {
 
 	async getCredentials(host: Uri): Promise<Credentials | undefined> {
-		if (!/github\.com/i.test(host.authority)) {
+		const hostname = host.authority.replace(/:\d+$/, '').toLowerCase();
+		if (hostname !== 'github.com') {
 			return;
 		}
 

--- a/src/vs/base/common/extpath.ts
+++ b/src/vs/base/common/extpath.ts
@@ -224,13 +224,23 @@ export function isEqual(pathA: string, pathB: string, ignoreCase?: boolean): boo
  * you are in a context without services, consider to pass down the `extUri` from the
  * outside, or use `extUriBiasedIgnorePathCase` if you know what you are doing.
  */
-export function isEqualOrParent(base: string, parentCandidate: string, ignoreCase?: boolean, separator = sep): boolean {
+export function isEqualOrParent(base: string, parentCandidate: string, ignoreCase?: boolean, forcePosixSemantics = false): boolean {
+	const separator = forcePosixSemantics ? posix.sep : sep;
+
 	if (base === parentCandidate) {
 		return true;
 	}
 
 	if (!base || !parentCandidate) {
 		return false;
+	}
+
+	if (
+		base.indexOf('..') >= 0 ||
+		parentCandidate.indexOf('..') >= 0
+	) {
+		base = forcePosixSemantics ? posix.normalize(base) : normalize(base);
+		parentCandidate = forcePosixSemantics ? posix.normalize(parentCandidate) : normalize(parentCandidate);
 	}
 
 	if (parentCandidate.length > base.length) {

--- a/src/vs/base/common/resources.ts
+++ b/src/vs/base/common/resources.ts
@@ -174,7 +174,7 @@ export class ExtUri implements IExtUri {
 				return extpath.isEqualOrParent(originalFSPath(base), originalFSPath(parentCandidate), this._ignorePathCasing(base)) && base.query === parentCandidate.query && (ignoreFragment || base.fragment === parentCandidate.fragment);
 			}
 			if (isEqualAuthority(base.authority, parentCandidate.authority)) {
-				return extpath.isEqualOrParent(base.path, parentCandidate.path, this._ignorePathCasing(base), '/') && base.query === parentCandidate.query && (ignoreFragment || base.fragment === parentCandidate.fragment);
+				return extpath.isEqualOrParent(base.path, parentCandidate.path, this._ignorePathCasing(base), true) && base.query === parentCandidate.query && (ignoreFragment || base.fragment === parentCandidate.fragment);
 			}
 		}
 		return false;

--- a/src/vs/base/test/common/resources.test.ts
+++ b/src/vs/base/test/common/resources.test.ts
@@ -432,4 +432,10 @@ suite('Resources', () => {
 		assert.strictEqual(extUriIgnorePathCase.isEqualOrParent(fileURI7, fileURI6), true, '19');
 		assert.strictEqual(extUriIgnorePathCase.isEqualOrParent(fileURI7, fileURI5), false, '20');
 	});
+
+	test('isEqualOrParent handles ../', () => {
+		const fileURI = URI.file('/home/user/projects');
+		const fileURI2 = URI.file('/home/user/projects/../../../../tmp/folder');
+		assert.strictEqual(extUri.isEqualOrParent(fileURI2, fileURI), false);
+	});
 });

--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -261,6 +261,7 @@ export class MenuId {
 	static readonly ChatExecuteQueue = new MenuId('ChatExecuteQueue');
 	static readonly ChatInput = new MenuId('ChatInput');
 	static readonly ChatInputSecondary = new MenuId('ChatInputSecondary');
+	static readonly ChatInputStatus = new MenuId('ChatInputStatus');
 	static readonly ChatInputSide = new MenuId('ChatInputSide');
 	static readonly ChatModePicker = new MenuId('ChatModePicker');
 	static readonly ChatEditingWidgetToolbar = new MenuId('ChatEditingWidgetToolbar');

--- a/src/vs/platform/agentHost/common/agentHostStarter.config.contribution.ts
+++ b/src/vs/platform/agentHost/common/agentHostStarter.config.contribution.ts
@@ -75,6 +75,7 @@ configurationRegistry.registerConfiguration({
 			type: 'boolean',
 			markdownDescription: nls.localize('chat.agentHost.otel.enabled', "When enabled, the agent host emits OpenTelemetry traces from the Copilot SDK. Requires `#chat.agentHost.enabled#`. Either configure `#chat.agentHost.otel.otlpEndpoint#` to ship traces to an external collector or enable `#chat.agentHost.otel.dbSpanExporter.enabled#` to capture them locally."),
 			default: false,
+			restricted: true,
 			tags: ['experimental', 'advanced'],
 		},
 		[AgentHostOTelExporterTypeSettingId]: {
@@ -82,30 +83,35 @@ configurationRegistry.registerConfiguration({
 			enum: ['otlp-http', 'otlp-grpc', 'console', 'file'],
 			markdownDescription: nls.localize('chat.agentHost.otel.exporterType', "Exporter backend used by the Copilot SDK when `#chat.agentHost.otel.enabled#` is on. `otlp-grpc` is downgraded to `otlp-http` transparently in the CLI runtime."),
 			default: 'otlp-http',
+			restricted: true,
 			tags: ['experimental', 'advanced'],
 		},
 		[AgentHostOTelOtlpEndpointSettingId]: {
 			type: 'string',
 			markdownDescription: nls.localize('chat.agentHost.otel.otlpEndpoint', "OTLP endpoint URL when exporter type is `otlp-http` or `otlp-grpc`. Sets `OTEL_EXPORTER_OTLP_ENDPOINT` inside the agent host process."),
 			default: '',
+			restricted: true,
 			tags: ['experimental', 'advanced'],
 		},
 		[AgentHostOTelCaptureContentSettingId]: {
 			type: 'boolean',
 			markdownDescription: nls.localize('chat.agentHost.otel.captureContent', "When enabled, includes prompt and response content in OTel span attributes. Sets `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`. Privacy-sensitive: do not enable in environments that ship spans to shared sinks."),
 			default: false,
+			restricted: true,
 			tags: ['experimental', 'advanced'],
 		},
 		[AgentHostOTelOutfileSettingId]: {
 			type: 'string',
 			markdownDescription: nls.localize('chat.agentHost.otel.outfile', "Output path for span JSON lines when exporter type is `file`. Sets `COPILOT_OTEL_FILE_EXPORTER_PATH`."),
 			default: '',
+			restricted: true,
 			tags: ['experimental', 'advanced'],
 		},
 		[AgentHostOTelDbSpanExporterEnabledSettingId]: {
 			type: 'boolean',
 			markdownDescription: nls.localize('chat.agentHost.otel.dbSpanExporter.enabled', "When enabled, the agent host persists every emitted OTel span to a local SQLite database. Spans can be inspected via the `Export Agent Host Traces Database` command. Compatible with external exporters: spans are written to SQLite *and* forwarded to the user-configured sink."),
 			default: false,
+			restricted: true,
 			tags: ['experimental', 'advanced'],
 		},
 	}

--- a/src/vs/platform/remote/common/remoteHosts.ts
+++ b/src/vs/platform/remote/common/remoteHosts.ts
@@ -87,3 +87,23 @@ function parseAuthority(authority: string): { host: string; port: number | undef
 	// doesn't contain a port
 	return { host: authority, port: undefined };
 }
+
+const loopbackHosts = new Set([
+	'localhost',
+	'127.0.0.1',
+	'::1',
+	'[::1]',
+	'0000:0000:0000:0000:0000:0000:0000:0001',
+	'[0000:0000:0000:0000:0000:0000:0000:0001]'
+]);
+
+/**
+ * Returns whether the given host (as found in a direct `<host>:<port>` remote
+ * authority) refers to the local loopback interface. The check is intentionally
+ * strict: only `localhost` and the IPv4/IPv6 loopback literals are considered
+ * local. Any other host (a routable IP address or a hostname) is treated as a
+ * connection that leaves the local machine.
+ */
+export function isLoopbackHost(host: string): boolean {
+	return loopbackHosts.has(host.toLowerCase());
+}

--- a/src/vs/platform/remote/test/common/remoteHosts.test.ts
+++ b/src/vs/platform/remote/test/common/remoteHosts.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
-import { parseAuthorityWithOptionalPort, parseAuthorityWithPort } from '../../common/remoteHosts.js';
+import { isLoopbackHost, parseAuthorityWithOptionalPort, parseAuthorityWithPort } from '../../common/remoteHosts.js';
 
 suite('remoteHosts', () => {
 
@@ -40,6 +40,21 @@ suite('remoteHosts', () => {
 
 	test('issue #151748: Error: Remote authorities containing \'+\' need to be resolved!', () => {
 		assert.deepStrictEqual(parseAuthorityWithOptionalPort('codespaces+aaaaa-aaaaa-aaaa-aaaaa-a111aa111', 123), { host: 'codespaces+aaaaa-aaaaa-aaaa-aaaaa-a111aa111', port: 123 });
+	});
+
+	test('isLoopbackHost', () => {
+		// loopback hosts
+		assert.strictEqual(isLoopbackHost('localhost'), true);
+		assert.strictEqual(isLoopbackHost('LOCALHOST'), true);
+		assert.strictEqual(isLoopbackHost('127.0.0.1'), true);
+		assert.strictEqual(isLoopbackHost('::1'), true);
+		assert.strictEqual(isLoopbackHost('[::1]'), true);
+
+		// non-loopback hosts
+		assert.strictEqual(isLoopbackHost('evil.com'), false);
+		assert.strictEqual(isLoopbackHost('192.168.0.1'), false);
+		assert.strictEqual(isLoopbackHost('10.0.0.1'), false);
+		assert.strictEqual(isLoopbackHost('[2001:0db8:85a3:0000:0000:8a2e:0370:7334]'), false);
 	});
 
 });

--- a/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
@@ -212,6 +212,22 @@
 	padding-left: 4px;
 }
 
+/* Icon-only action items in the bottom row (e.g. OpenTelemetry status pill)
+ * lack the chevron that visually balances the 7px left padding, so use
+ * symmetric horizontal padding and drop the picker min-width that would
+ * otherwise leave the icon left-aligned inside a 30px box. */
+.new-chat-widget-container .new-chat-bottom-container .new-chat-status-toolbar .monaco-action-bar .action-item,
+.new-chat-widget-container .new-chat-bottom-container .new-chat-status-toolbar .monaco-action-bar .action-item .action-label {
+	min-width: 0;
+}
+
+.new-chat-widget-container .new-chat-bottom-container .new-chat-status-toolbar .action-label {
+	padding: 3px 4px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
 /* Pickers row - two equal halves */
 .session-workspace-picker {
 	display: flex;

--- a/src/vs/sessions/contrib/chat/browser/newChatInput.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInput.ts
@@ -44,6 +44,8 @@ import { installMobileChipLaneScroll } from '../../../browser/parts/mobile/mobil
 import { IWorkbenchLayoutService } from '../../../../workbench/services/layout/browser/layoutService.js';
 import { Menus } from '../../../browser/menus.js';
 import { HiddenItemStrategy, MenuWorkbenchToolBar } from '../../../../platform/actions/browser/toolbar.js';
+import { MenuId, MenuItemAction } from '../../../../platform/actions/common/actions.js';
+import { ChatInputStatusActionViewItem } from '../../../../workbench/contrib/chat/browser/widget/input/chatInputStatusActionViewItem.js';
 import { SlashCommandHandler } from './slashCommands.js';
 import { VariableCompletionHandler } from './variableCompletions.js';
 import { AgentHostInputCompletionHandler } from './agentHostInputCompletions.js';
@@ -271,6 +273,18 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 		// pointer-event-based scroll handler that no-ops on desktop and
 		// kicks in once a drag crosses a small threshold on phone.
 		this._register(installMobileChipLaneScroll(newChatBottomContainer, this.layoutService));
+
+		// Status indicators (e.g. OpenTelemetry pill) for the new-session view.
+		const statusContainer = dom.append(repoConfigContainer, dom.$('.new-chat-status-toolbar'));
+		this._register(this.instantiationService.createInstance(MenuWorkbenchToolBar, statusContainer, MenuId.ChatInputStatus, {
+			hiddenItemStrategy: HiddenItemStrategy.NoHide,
+			actionViewItemProvider: (action) => {
+				if (action instanceof MenuItemAction) {
+					return this.instantiationService.createInstance(ChatInputStatusActionViewItem, action);
+				}
+				return undefined;
+			},
+		}));
 
 		// Restore draft input state from storage
 		this._restoreState();

--- a/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.ts
@@ -102,6 +102,11 @@ export class ChatStatusDashboard extends DomWidget {
 
 	private static readonly QUICK_SETTINGS_COLLAPSED_KEY = 'chatStatusDashboard.quickSettingsCollapsed';
 
+	// Status entries surfaced elsewhere (e.g. chat-input pill) and skipped here.
+	private static readonly HIDDEN_ENTRY_IDS = new Set<string>([
+		'copilot.otelStatus',
+	]);
+
 	readonly element = $('div.chat-status-bar-entry-tooltip');
 
 	private readonly dateFormatter = safeIntl.DateTimeFormat(language, { month: 'short', day: 'numeric' });
@@ -147,7 +152,7 @@ export class ChatStatusDashboard extends DomWidget {
 			(!this.options?.compactQuotaLayout && completions?.unlimited === false) ||
 			isAnonymousWithSentiment ||
 			isPooledQuotaDepleted;
-		const contributedEntries = [...this.chatStatusItemService.getEntries()];
+		const contributedEntries = [...this.chatStatusItemService.getEntries()].filter(entry => !ChatStatusDashboard.HIDDEN_ENTRY_IDS.has(entry.id));
 		const hasQuickSettingsContent =
 			!this.options?.disableInlineSuggestionsSettings ||
 			!this.options?.disableModelSelection ||

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -136,6 +136,7 @@ import { IPermissionPickerDelegate, PermissionPickerActionItem } from './permiss
 import { SessionTypePickerActionItem } from './sessionTargetPickerActionItem.js';
 import { WorkspacePickerActionItem } from './workspacePickerActionItem.js';
 import { ChatContextUsageWidget } from '../../widgetHosts/viewPane/chatContextUsageWidget.js';
+import { ChatInputStatusActionViewItem } from './chatInputStatusActionViewItem.js';
 import { Target } from '../../../common/promptSyntax/promptTypes.js';
 import { findLast } from '../../../../../../base/common/arraysFind.js';
 import { ConfigureToolsAction } from '../../actions/chatToolActions.js';
@@ -313,6 +314,8 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	private inputSideToolbarContainer?: HTMLElement;
 	private secondaryToolbarContainer!: HTMLElement;
 	private secondaryToolbar!: MenuWorkbenchToolBar;
+	private statusToolbarContainer!: HTMLElement;
+	private statusToolbar!: MenuWorkbenchToolBar;
 
 	private followupsContainer!: HTMLElement;
 	private readonly followupsDisposables: DisposableStore = this._register(new DisposableStore());
@@ -2465,6 +2468,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 					]),
 					dom.h('.chat-secondary-toolbar@secondaryToolbar', [
 						dom.h('.chat-context-usage-container@contextUsageWidgetContainer'),
+						dom.h('.chat-input-status-container@statusToolbarContainer'),
 					]),
 					dom.h('.chat-attachments-container@attachmentsContainer', [
 						dom.h('.chat-attached-context@attachedContextContainer'),
@@ -2495,6 +2499,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 				]),
 				dom.h('.chat-secondary-toolbar@secondaryToolbar', [
 					dom.h('.chat-context-usage-container@contextUsageWidgetContainer'),
+					dom.h('.chat-input-status-container@statusToolbarContainer'),
 				]),
 			]);
 		}
@@ -2532,6 +2537,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		this.chatInputNotificationContainer = elements.chatInputNotificationContainer;
 		this.chatGoalBannerContainer = elements.chatGoalBannerContainer;
 		this.contextUsageWidgetContainer = elements.contextUsageWidgetContainer;
+		this.statusToolbarContainer = elements.statusToolbarContainer;
 
 		if (this.options.isSessionsWindow || this.options.renderStyle === 'compact') {
 			toolbarsContainer.prepend(this.contextUsageWidgetContainer);
@@ -3008,6 +3014,22 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 				this.chatSessionPickerContainer = container;
 			}
 		}));
+
+		// Extension-contributed status indicators; non-responsive so items don't collapse.
+		this.statusToolbar = this._register(this.instantiationService.createInstance(MenuWorkbenchToolBar, this.statusToolbarContainer, MenuId.ChatInputStatus, {
+			telemetrySource: this.options.menus.telemetrySource,
+			menuOptions: { shouldForwardArgs: true },
+			hiddenItemStrategy: HiddenItemStrategy.NoHide,
+			hoverDelegate,
+			actionViewItemProvider: (action, _opts) => {
+				if (action instanceof MenuItemAction) {
+					return this.instantiationService.createInstance(ChatInputStatusActionViewItem, action);
+				}
+				return undefined;
+			},
+		}));
+		this.statusToolbar.getElement().classList.add('chat-input-status-toolbar');
+		this.statusToolbar.context = { widget } satisfies IChatExecuteActionContext;
 
 		let inputModel = this.modelService.getModel(this.inputUri);
 		if (!inputModel) {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputStatusActionViewItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputStatusActionViewItem.ts
@@ -1,0 +1,170 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as dom from '../../../../../../base/browser/dom.js';
+import { IManagedHoverContent } from '../../../../../../base/browser/ui/hover/hover.js';
+import { HoverPosition } from '../../../../../../base/browser/ui/hover/hoverWidget.js';
+import { Button } from '../../../../../../base/browser/ui/button/button.js';
+import { renderLabelWithIcons } from '../../../../../../base/browser/ui/iconLabel/iconLabels.js';
+import { CancellationToken } from '../../../../../../base/common/cancellation.js';
+import { MarkdownString } from '../../../../../../base/common/htmlContent.js';
+import { stripIcons } from '../../../../../../base/common/iconLabels.js';
+import { DisposableStore, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
+import { localize } from '../../../../../../nls.js';
+import { IAccessibilityService } from '../../../../../../platform/accessibility/common/accessibility.js';
+import { MenuEntryActionViewItem } from '../../../../../../platform/actions/browser/menuEntryActionViewItem.js';
+import { MenuItemAction } from '../../../../../../platform/actions/common/actions.js';
+import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
+import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
+import { IContextMenuService } from '../../../../../../platform/contextview/browser/contextView.js';
+import { IHoverService, WorkbenchHoverDelegate } from '../../../../../../platform/hover/browser/hover.js';
+import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
+import { IKeybindingService } from '../../../../../../platform/keybinding/common/keybinding.js';
+import { IMarkdownRendererService } from '../../../../../../platform/markdown/browser/markdownRenderer.js';
+import { INotificationService } from '../../../../../../platform/notification/common/notification.js';
+import { defaultButtonStyles } from '../../../../../../platform/theme/browser/defaultStyles.js';
+import { IThemeService } from '../../../../../../platform/theme/common/themeService.js';
+import { ChatStatusEntry, IChatStatusItemService } from '../../chatStatus/chatStatusItemService.js';
+
+const $ = dom.$;
+
+interface IStatusActionDescriptor {
+	readonly entryId: string;
+	readonly manageCommandId: string;
+	readonly manageLabel: string;
+	/** Optional markdown title; overrides the contributed entry label. */
+	readonly titleMarkdown?: string;
+}
+
+const OTEL_HOVER_TITLE_MARKDOWN = localize(
+	'chat.inputStatus.otel.title',
+	"Agent being monitored via [OpenTelemetry]({0})",
+	'https://code.visualstudio.com/docs/copilot/guides/monitoring-agents'
+);
+
+const STATUS_COMMAND_DESCRIPTORS: ReadonlyMap<string, IStatusActionDescriptor> = new Map<string, IStatusActionDescriptor>([
+	['github.copilot.chat.otel.statusActive', {
+		entryId: 'copilot.otelStatus',
+		manageCommandId: 'github.copilot.chat.otel.openSettings',
+		manageLabel: localize('chat.inputStatus.otel.manageSettings', "Manage Settings"),
+		titleMarkdown: OTEL_HOVER_TITLE_MARKDOWN,
+	}],
+	['github.copilot.chat.otel.statusCapturing', {
+		entryId: 'copilot.otelStatus',
+		manageCommandId: 'github.copilot.chat.otel.openSettings',
+		manageLabel: localize('chat.inputStatus.otel.manageSettings', "Manage Settings"),
+		titleMarkdown: OTEL_HOVER_TITLE_MARKDOWN,
+	}],
+]);
+
+/**
+ * Action view item for items contributed to MenuId.ChatInputStatus. Renders
+ * a hover popup with the linked ChatStatusEntry detail and a "Manage" button.
+ */
+export class ChatInputStatusActionViewItem extends MenuEntryActionViewItem {
+
+	private readonly _hoverContentDisposables = this._register(new MutableDisposable<DisposableStore>());
+
+	constructor(
+		action: MenuItemAction,
+		@IKeybindingService keybindingService: IKeybindingService,
+		@INotificationService notificationService: INotificationService,
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IThemeService themeService: IThemeService,
+		@IContextMenuService contextMenuService: IContextMenuService,
+		@IAccessibilityService accessibilityService: IAccessibilityService,
+		@ICommandService private readonly commandService: ICommandService,
+		@IHoverService private readonly hoverService: IHoverService,
+		@IMarkdownRendererService private readonly markdownRendererService: IMarkdownRendererService,
+		@IChatStatusItemService private readonly chatStatusItemService: IChatStatusItemService,
+		@IInstantiationService instantiationService: IInstantiationService,
+	) {
+		// Pin the hover popup above the pill, matching chat-in-progress mode.
+		const hoverDelegate = instantiationService.createInstance(
+			WorkbenchHoverDelegate,
+			'element',
+			undefined,
+			{ position: { hoverPosition: HoverPosition.ABOVE } },
+		);
+		super(action, { hoverDelegate }, keybindingService, notificationService, contextKeyService, themeService, contextMenuService, accessibilityService);
+		this._register(hoverDelegate);
+	}
+
+	override render(container: HTMLElement): void {
+		super.render(container);
+
+		const descriptor = STATUS_COMMAND_DESCRIPTORS.get(this._commandAction.id);
+		if (!descriptor) {
+			return;
+		}
+
+		// Refresh the managed hover content when the contributed status entry changes
+		this._register(this.chatStatusItemService.onDidChange(e => {
+			if (e.entry.id === descriptor.entryId) {
+				this.updateTooltip();
+			}
+		}));
+	}
+
+	protected override getHoverContents(): IManagedHoverContent | undefined {
+		const descriptor = STATUS_COMMAND_DESCRIPTORS.get(this._commandAction.id);
+		if (!descriptor) {
+			return super.getHoverContents();
+		}
+		const entry = this._lookupEntry(descriptor.entryId);
+		if (!entry) {
+			return super.getHoverContents();
+		}
+		return {
+			element: (_token: CancellationToken) => this._renderHoverContent(entry, descriptor),
+		};
+	}
+
+	private _lookupEntry(entryId: string): ChatStatusEntry | undefined {
+		for (const entry of this.chatStatusItemService.getEntries()) {
+			if (entry.id === entryId) {
+				return entry;
+			}
+		}
+		return undefined;
+	}
+
+	private _renderHoverContent(entry: ChatStatusEntry, descriptor: IStatusActionDescriptor): HTMLElement {
+		const store = new DisposableStore();
+		this._hoverContentDisposables.value = store;
+
+		const root = $('div.chat-input-status-hover-content.chat-input-status-hover');
+
+		const titleEl = root.appendChild($('div.chat-input-status-hover-title'));
+		if (descriptor.titleMarkdown) {
+			const rendered = store.add(this.markdownRendererService.render(new MarkdownString(descriptor.titleMarkdown, { isTrusted: false })));
+			titleEl.appendChild(rendered.element);
+		} else {
+			titleEl.textContent = typeof entry.label === 'string' ? entry.label : entry.label.label;
+		}
+
+		if (entry.description) {
+			const descEl = root.appendChild($('div.chat-input-status-hover-description'));
+			descEl.append(...renderLabelWithIcons(entry.description));
+			descEl.title = stripIcons(entry.description).trim();
+		}
+
+		if (entry.detail) {
+			const detailEl = root.appendChild($('div.chat-input-status-hover-detail'));
+			const rendered = store.add(this.markdownRendererService.render(new MarkdownString(entry.detail, { isTrusted: false, supportThemeIcons: true })));
+			detailEl.appendChild(rendered.element);
+		}
+
+		const actionsRow = root.appendChild($('div.chat-input-status-hover-actions'));
+		const manageButton = store.add(new Button(actionsRow, { ...defaultButtonStyles, secondary: true }));
+		manageButton.label = descriptor.manageLabel;
+		store.add(manageButton.onDidClick(() => {
+			this.commandService.executeCommand(descriptor.manageCommandId);
+			this.hoverService.hideHover(true);
+		}));
+
+		return root;
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/widget/input/media/chatInputNotificationWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/media/chatInputNotificationWidget.css
@@ -19,11 +19,14 @@
 	box-sizing: border-box;
 	border: 1px solid var(--vscode-input-border, transparent);
 	border-bottom: none;
-	border-top-left-radius: 4px;
-	border-top-right-radius: 4px;
+	border-top-left-radius: var(--vscode-cornerRadius-small, 4px);
+	border-top-right-radius: var(--vscode-cornerRadius-small, 4px);
 	display: flex;
 	flex-direction: column;
-	gap: 4px;
+	gap: 2px;
+	font-size: var(--vscode-chat-font-size-body-s);
+	font-family: var(--vscode-chat-font-family, inherit);
+	color: var(--vscode-descriptionForeground);
 }
 
 /* Severity variants */
@@ -56,7 +59,7 @@
 .chat-input-notification .chat-input-notification-header {
 	display: flex;
 	align-items: center;
-	gap: 8px;
+	gap: 6px;
 	min-width: 0;
 }
 
@@ -117,6 +120,7 @@
 	align-items: flex-start;
 	gap: 8px;
 	min-width: 0;
+	padding-left: 22px; /* align with title text after the severity icon */
 }
 
 /* Description */

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -1036,6 +1036,109 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	order: 1;
 }
 
+/* Status indicator container — sits at the rightmost end of the secondary toolbar, next to the context usage button. Intentionally non-responsive so contributed status items never collapse into an overflow menu. */
+.interactive-session .chat-secondary-toolbar .chat-input-status-container {
+	display: flex;
+	align-items: center;
+	flex-shrink: 0;
+	order: 2;
+}
+
+.interactive-session .chat-secondary-toolbar .chat-input-status-container:empty {
+	display: none;
+}
+
+/* Hover popup contents shown when hovering an item in the chat-input-status toolbar */
+.chat-input-status-hover.chat-input-status-hover-content {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	padding: 8px 10px;
+	min-width: 240px;
+	max-width: 420px;
+}
+
+.chat-input-status-hover .chat-input-status-hover-title {
+	font-weight: 600;
+}
+
+.chat-input-status-hover .chat-input-status-hover-title p {
+	margin: 0;
+}
+
+.chat-input-status-hover .chat-input-status-hover-title a {
+	color: var(--vscode-textLink-foreground);
+	text-decoration: none;
+}
+
+.chat-input-status-hover .chat-input-status-hover-title a:hover {
+	text-decoration: underline;
+}
+
+.chat-input-status-hover .chat-input-status-hover-detail a {
+	color: var(--vscode-textLink-foreground);
+	text-decoration: none;
+}
+
+.chat-input-status-hover .chat-input-status-hover-detail a:hover {
+	text-decoration: underline;
+}
+
+.chat-input-status-hover .chat-input-status-hover-detail code {
+	font-family: var(--monaco-monospace-font);
+	font-size: 11px;
+	background: var(--vscode-textCodeBlock-background, transparent);
+	padding: 1px 4px;
+	border-radius: 3px;
+	white-space: nowrap;
+}
+
+.chat-input-status-hover .chat-input-status-hover-description {
+	color: var(--vscode-descriptionForeground);
+	white-space: pre-wrap;
+}
+
+.chat-input-status-hover .chat-input-status-hover-detail {
+	color: var(--vscode-foreground);
+}
+
+.chat-input-status-hover .chat-input-status-hover-detail table {
+	width: 100%;
+	border-collapse: collapse;
+	font-size: 12px;
+}
+
+.chat-input-status-hover .chat-input-status-hover-detail thead {
+	display: none;
+}
+
+.chat-input-status-hover .chat-input-status-hover-detail th,
+.chat-input-status-hover .chat-input-status-hover-detail td {
+	padding: 3px 8px 3px 0;
+	text-align: left;
+	vertical-align: top;
+	word-break: break-word;
+}
+
+.chat-input-status-hover .chat-input-status-hover-detail tbody tr:not(:last-child) td {
+	border-bottom: 1px solid var(--vscode-widget-border, transparent);
+}
+
+.chat-input-status-hover .chat-input-status-hover-detail tbody td:first-child {
+	color: var(--vscode-descriptionForeground);
+	white-space: nowrap;
+}
+
+.chat-input-status-hover .chat-input-status-hover-detail p {
+	margin: 0;
+}
+
+.chat-input-status-hover .chat-input-status-hover-actions {
+	display: flex;
+	justify-content: flex-end;
+	margin-top: 4px;
+}
+
 /* When context usage is inside the toolbars (compact mode), keep the ordering */
 .interactive-session .chat-input-toolbars .chat-context-usage-container {
 	order: 1;

--- a/src/vs/workbench/services/actions/common/menusExtensionPoint.ts
+++ b/src/vs/workbench/services/actions/common/menusExtensionPoint.ts
@@ -144,6 +144,12 @@ const apiMenus: IAPIMenu[] = [
 		description: localize('menus.opy', "'Copy as' submenu in the top level Edit menu")
 	},
 	{
+		key: 'chat/input/status',
+		id: MenuId.ChatInputStatus,
+		description: localize('menus.chatInputStatus', "The status indicator area at the rightmost end of the toolbar shown beneath the chat input"),
+		supportsSubmenus: false
+	},
+	{
 		key: 'scm/title',
 		id: MenuId.SCMTitle,
 		description: localize('menus.scmTitle', "The Source Control title menu")

--- a/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
+++ b/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
@@ -119,7 +119,7 @@ export abstract class AbstractExtensionService extends Disposable implements IEx
 		@IRemoteExtensionsScannerService protected readonly _remoteExtensionsScannerService: IRemoteExtensionsScannerService,
 		@ILifecycleService private readonly _lifecycleService: ILifecycleService,
 		@IRemoteAuthorityResolverService protected readonly _remoteAuthorityResolverService: IRemoteAuthorityResolverService,
-		@IDialogService private readonly _dialogService: IDialogService,
+		@IDialogService protected readonly _dialogService: IDialogService,
 	) {
 		super();
 

--- a/src/vs/workbench/services/extensions/electron-browser/nativeExtensionService.ts
+++ b/src/vs/workbench/services/extensions/electron-browser/nativeExtensionService.ts
@@ -29,9 +29,9 @@ import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
 import { PersistentConnectionEventType } from '../../../../platform/remote/common/remoteAgentConnection.js';
 import { IRemoteAgentEnvironment } from '../../../../platform/remote/common/remoteAgentEnvironment.js';
-import { IRemoteAuthorityResolverService, RemoteAuthorityResolverError, RemoteConnectionType, ResolverResult, getRemoteAuthorityPrefix } from '../../../../platform/remote/common/remoteAuthorityResolver.js';
+import { IRemoteAuthorityResolverService, RemoteAuthorityResolverError, RemoteAuthorityResolverErrorCode, RemoteConnectionType, ResolverResult, getRemoteAuthorityPrefix } from '../../../../platform/remote/common/remoteAuthorityResolver.js';
 import { IRemoteExtensionsScannerService } from '../../../../platform/remote/common/remoteExtensionsScanner.js';
-import { getRemoteName, parseAuthorityWithPort } from '../../../../platform/remote/common/remoteHosts.js';
+import { getRemoteName, isLoopbackHost, parseAuthorityWithPort } from '../../../../platform/remote/common/remoteHosts.js';
 import { updateProxyConfigurationsScope } from '../../../../platform/request/common/request.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
@@ -275,6 +275,17 @@ export class NativeExtensionService extends AbstractExtensionService implements 
 		if (authorityPlusIndex === -1) {
 			// This authority does not need to be resolved, simply parse the port number
 			const { host, port } = parseAuthorityWithPort(remoteAuthority);
+
+			// A direct `<host>:<port>` authority bypasses resolver extensions and connects
+			// straight to the given server. This form can originate from untrusted sources
+			// (e.g. the `remoteAuthority` of a `.code-workspace` file), so before connecting
+			// to anything that is not the local loopback interface we ask the user to confirm.
+			// This prevents a crafted workspace from silently pointing the window's backend at
+			// an attacker controlled server.
+			if (!isLoopbackHost(host)) {
+				await this._confirmDirectRemoteConnection(host, port);
+			}
+
 			return {
 				authority: {
 					authority: remoteAuthority,
@@ -289,6 +300,22 @@ export class NativeExtensionService extends AbstractExtensionService implements 
 		}
 
 		return this._resolveAuthorityOnExtensionHosts(ExtensionHostKind.LocalProcess, remoteAuthority);
+	}
+
+	private async _confirmDirectRemoteConnection(host: string, port: number): Promise<void> {
+		const { confirmed } = await this._dialogService.confirm({
+			type: Severity.Warning,
+			message: nls.localize('remoteConnectionConfirm', "Allow connecting to the remote server '{0}:{1}'?", host, port),
+			detail: nls.localize('remoteConnectionConfirmDetail', "Code is about to connect to '{0}:{1}' to host a remote extension host. Only continue if you trust this server, as it will be able to run code and access files on your behalf.", host, port),
+			primaryButton: nls.localize('remoteConnectionConfirmButton', "Connect")
+		});
+
+		if (!confirmed) {
+			throw new RemoteAuthorityResolverError(
+				nls.localize('remoteConnectionRejected', "Connection to '{0}:{1}' was not allowed.", host, port),
+				RemoteAuthorityResolverErrorCode.NotAvailable
+			);
+		}
 	}
 
 	private async _getCanonicalURI(remoteAuthority: string, uri: URI): Promise<URI> {

--- a/src/vs/workbench/services/userDataProfile/browser/snippetsResource.ts
+++ b/src/vs/workbench/services/userDataProfile/browser/snippetsResource.ts
@@ -6,10 +6,12 @@
 import { VSBuffer } from '../../../../base/common/buffer.js';
 import { IStringDictionary } from '../../../../base/common/collections.js';
 import { ResourceSet } from '../../../../base/common/map.js';
+import { IExtUri } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
 import { FileOperationError, FileOperationResult, IFileService, IFileStat } from '../../../../platform/files/common/files.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
 import { IUserDataProfile, ProfileResourceType } from '../../../../platform/userDataProfile/common/userDataProfile.js';
 import { API_OPEN_EDITOR_COMMAND_ID } from '../../../browser/parts/editor/editorCommands.js';
@@ -20,19 +22,40 @@ interface ISnippetsContent {
 	snippets: IStringDictionary<string>;
 }
 
+/**
+ * Resolves the target resource for a snippet `key` relative to `snippetsHome`,
+ * ensuring the result stays contained within `snippetsHome`. The `key` originates
+ * from an imported (and therefore untrusted) profile, so it can contain path
+ * traversal segments (e.g. `../../../foo`). `joinPath` normalizes such segments,
+ * which would otherwise allow writing files outside the profile directory.
+ * Returns `undefined` when the resolved resource escapes `snippetsHome`.
+ */
+function toSnippetResource(extUri: IExtUri, snippetsHome: URI, key: string): URI | undefined {
+	const resource = extUri.joinPath(snippetsHome, key);
+	if (!extUri.isEqualOrParent(resource, snippetsHome) || extUri.isEqual(resource, snippetsHome)) {
+		return undefined;
+	}
+	return resource;
+}
+
 export class SnippetsResourceInitializer implements IProfileResourceInitializer {
 
 	constructor(
 		@IUserDataProfileService private readonly userDataProfileService: IUserDataProfileService,
 		@IFileService private readonly fileService: IFileService,
 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
+		@ILogService private readonly logService: ILogService,
 	) {
 	}
 
 	async initialize(content: string): Promise<void> {
 		const snippetsContent: ISnippetsContent = JSON.parse(content);
 		for (const key in snippetsContent.snippets) {
-			const resource = this.uriIdentityService.extUri.joinPath(this.userDataProfileService.currentProfile.snippetsHome, key);
+			const resource = toSnippetResource(this.uriIdentityService.extUri, this.userDataProfileService.currentProfile.snippetsHome, key);
+			if (!resource) {
+				this.logService.warn(`SnippetsResourceInitializer: Ignoring snippet with key '${key}' as it escapes the snippets folder.`);
+				continue;
+			}
 			await this.fileService.writeFile(resource, VSBuffer.fromString(snippetsContent.snippets[key]));
 		}
 	}
@@ -43,6 +66,7 @@ export class SnippetsResource implements IProfileResource {
 	constructor(
 		@IFileService private readonly fileService: IFileService,
 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
+		@ILogService private readonly logService: ILogService,
 	) {
 	}
 
@@ -54,7 +78,11 @@ export class SnippetsResource implements IProfileResource {
 	async apply(content: string, profile: IUserDataProfile): Promise<void> {
 		const snippetsContent: ISnippetsContent = JSON.parse(content);
 		for (const key in snippetsContent.snippets) {
-			const resource = this.uriIdentityService.extUri.joinPath(profile.snippetsHome, key);
+			const resource = toSnippetResource(this.uriIdentityService.extUri, profile.snippetsHome, key);
+			if (!resource) {
+				this.logService.warn(`SnippetsResource: Ignoring snippet with key '${key}' as it escapes the snippets folder.`);
+				continue;
+			}
 			await this.fileService.writeFile(resource, VSBuffer.fromString(snippetsContent.snippets[key]));
 		}
 	}

--- a/src/vs/workbench/services/userDataProfile/browser/userDataProfileInit.ts
+++ b/src/vs/workbench/services/userDataProfile/browser/userDataProfileInit.ts
@@ -85,7 +85,7 @@ export class UserDataProfileInitializer implements IUserDataInitializer {
 				promises.push(this.initialize(new McpResourceInitializer(this.userDataProfileService, this.fileService, this.logService), profileTemplate.mcp, ProfileResourceType.Mcp));
 			}
 			if (profileTemplate?.snippets) {
-				promises.push(this.initialize(new SnippetsResourceInitializer(this.userDataProfileService, this.fileService, this.uriIdentityService), profileTemplate.snippets, ProfileResourceType.Snippets));
+				promises.push(this.initialize(new SnippetsResourceInitializer(this.userDataProfileService, this.fileService, this.uriIdentityService, this.logService), profileTemplate.snippets, ProfileResourceType.Snippets));
 			}
 			promises.push(this.initializeInstalledExtensions(instantiationService));
 			await Promises.settled(promises);

--- a/src/vs/workbench/services/userDataProfile/test/browser/snippetsResource.test.ts
+++ b/src/vs/workbench/services/userDataProfile/test/browser/snippetsResource.test.ts
@@ -1,0 +1,79 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { joinPath } from '../../../../../base/common/resources.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { FileService } from '../../../../../platform/files/common/fileService.js';
+import { IFileService } from '../../../../../platform/files/common/files.js';
+import { InMemoryFileSystemProvider } from '../../../../../platform/files/common/inMemoryFilesystemProvider.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
+import { IUriIdentityService } from '../../../../../platform/uriIdentity/common/uriIdentity.js';
+import { UriIdentityService } from '../../../../../platform/uriIdentity/common/uriIdentityService.js';
+import { IUserDataProfile } from '../../../../../platform/userDataProfile/common/userDataProfile.js';
+import { SnippetsResource } from '../../browser/snippetsResource.js';
+
+const ROOT = URI.file('tests').with({ scheme: 'vscode-tests' });
+
+suite('SnippetsResource', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+	let instantiationService: TestInstantiationService;
+	let fileService: IFileService;
+	let snippetsHome: URI;
+	let profile: IUserDataProfile;
+
+	setup(() => {
+		instantiationService = disposables.add(new TestInstantiationService());
+		fileService = disposables.add(new FileService(new NullLogService()));
+		const fileSystemProvider = disposables.add(new InMemoryFileSystemProvider());
+		disposables.add(fileService.registerProvider(ROOT.scheme, fileSystemProvider));
+
+		instantiationService.stub(IFileService, fileService);
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(IUriIdentityService, disposables.add(new UriIdentityService(fileService)));
+
+		snippetsHome = joinPath(ROOT, 'User', 'profiles', 'test', 'snippets');
+		profile = { snippetsHome } as IUserDataProfile;
+	});
+
+	test('apply writes in-bounds snippet keys', async () => {
+		const testObject = instantiationService.createInstance(SnippetsResource);
+
+		await testObject.apply(JSON.stringify({ snippets: { 'javascript.json': '{}' } }), profile);
+
+		assert.strictEqual((await fileService.readFile(joinPath(snippetsHome, 'javascript.json'))).value.toString(), '{}');
+	});
+
+	test('apply ignores path traversal keys (posix)', async () => {
+		const testObject = instantiationService.createInstance(SnippetsResource);
+		const escaped = joinPath(snippetsHome, '..', '..', '..', '..', 'tmp', 'PROBE_snippets');
+
+		await testObject.apply(JSON.stringify({ snippets: { '../../../../tmp/PROBE_snippets': 'ok' } }), profile);
+
+		assert.strictEqual(await fileService.exists(escaped), false);
+	});
+
+	test('apply ignores windows style path traversal keys', async () => {
+		const testObject = instantiationService.createInstance(SnippetsResource);
+		const escaped = joinPath(snippetsHome, '..', '..', '..', '..', 'tmp', 'PROBE_snippets');
+
+		await testObject.apply(JSON.stringify({ snippets: { '..\\..\\..\\..\\tmp\\PROBE_snippets': 'ok' } }), profile);
+
+		assert.strictEqual(await fileService.exists(escaped), false);
+	});
+
+	test('apply writes in-bounds key even alongside a traversal key', async () => {
+		const testObject = instantiationService.createInstance(SnippetsResource);
+		const escaped = joinPath(snippetsHome, '..', '..', 'tmp', 'PROBE_snippets');
+
+		await testObject.apply(JSON.stringify({ snippets: { 'javascript.json': '{}', '../../tmp/PROBE_snippets': 'ok' } }), profile);
+
+		assert.strictEqual((await fileService.readFile(joinPath(snippetsHome, 'javascript.json'))).value.toString(), '{}');
+		assert.strictEqual(await fileService.exists(escaped), false);
+	});
+});


### PR DESCRIPTION
Cherry-picks from `release/1.123` onto `main`:

- be6ab8b589a75e6b64a95dc73763e5d23a20bb1a - OTel visibility in Copilot Chat UI (#47)
- 96731325029c4694184ea8d05949f4730676d565 - Prompt before connecting to non-loopback remote host:port authorities (#46)
- 9fea92e141918029fb705cbaf6fbb9a1553cb86f - GitHub - improve host parsing (#48)
- a703741497387f3873f691be680a8380d79d106b - path traversal fix (#50)
- 5927baa7af7c08deac2cf767c2608724f1a10be9 - Path - improve isEqualOrParent calculation (#49)