### PR TITLE
Update enterprise strings for ULB

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.ts
@@ -833,7 +833,7 @@ export class ChatStatusDashboard extends DomWidget {
 				quotaCallout.className = 'quota-callout info';
 				calloutIcon.className = `callout-icon ${ThemeIcon.asClassName(Codicon.info)}`;
 				calloutText.textContent = isEnterpriseUser
-					? localize('quotaAdditionalUsageActiveEnterprise', "You've used your included credits. Your organization covers additional usage, so you can keep working.")
+					? localize('quotaAdditionalUsageActiveEnterprise', "Copilot has paused because your limits are reached. Please contact your admin to increase your limits.")
 					: isUsageBasedBilling
 						? localize('quotaAdditionalUsageActive', "Additional budget is configured. Usage will continue until limits reset.")
 						: localize('quotaBudgetActive', "Premium request budget is configured. Usage will continue until limits reset.");
@@ -842,7 +842,7 @@ export class ChatStatusDashboard extends DomWidget {
 				quotaCallout.className = 'quota-callout info';
 				calloutIcon.className = `callout-icon ${ThemeIcon.asClassName(Codicon.info)}`;
 				calloutText.textContent = isEnterpriseUser
-					? localize('quotaAdditionalUsageApproachingEnterprise', "You're approaching your included credits. Your organization covers additional usage, so there's no interruption.")
+					? localize('quotaAdditionalUsageApproachingEnterprise', "Copilot will pause when your limits are reached. Please contact your admin to increase your limits.")
 					: isUsageBasedBilling
 						? localize('quotaAdditionalUsageApproaching', "Once the limit is reached, additional budget will be used.")
 						: localize('quotaBudgetApproaching', "Once the limit is reached, premium request budget will be used.");

--- a/src/vs/workbench/contrib/chat/test/browser/chatStatusDashboard.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatStatusDashboard.test.ts
@@ -605,7 +605,7 @@ suite('ChatStatusDashboard', () => {
 			entitlement: ChatEntitlement.Enterprise,
 		}));
 
-		assert.strictEqual(getCalloutText(dashboard.element), 'You\'re approaching your included credits. Your organization covers additional usage, so there\'s no interruption.');
+		assert.strictEqual(getCalloutText(dashboard.element), 'Copilot will pause when your limits are reached. Please contact your admin to increase your limits.');
 	});
 
 	test('Callout: Business — shows org-specific wording when approaching limit with additional usage', () => {
@@ -616,7 +616,7 @@ suite('ChatStatusDashboard', () => {
 			entitlement: ChatEntitlement.Business,
 		}));
 
-		assert.strictEqual(getCalloutText(dashboard.element), 'You\'re approaching your included credits. Your organization covers additional usage, so there\'s no interruption.');
+		assert.strictEqual(getCalloutText(dashboard.element), 'Copilot will pause when your limits are reached. Please contact your admin to increase your limits.');
 	});
 
 	test('Callout: Enterprise — shows org-specific wording when quota exhausted with additional usage', () => {
@@ -628,7 +628,7 @@ suite('ChatStatusDashboard', () => {
 			entitlement: ChatEntitlement.Enterprise,
 		}));
 
-		assert.strictEqual(getCalloutText(dashboard.element), 'You\'ve used your included credits. Your organization covers additional usage, so you can keep working.');
+		assert.strictEqual(getCalloutText(dashboard.element), 'Copilot has paused because your limits are reached. Please contact your admin to increase your limits.');
 	});
 
 	// --- LIVE UPDATES ---

--- a/src/vs/workbench/contrib/chat/test/browser/chatStatusDashboard.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatStatusDashboard.test.ts
@@ -631,6 +631,18 @@ suite('ChatStatusDashboard', () => {
 		assert.strictEqual(getCalloutText(dashboard.element), 'Copilot has paused because your limits are reached. Please contact your admin to increase your limits.');
 	});
 
+	test('Callout: Business — shows org-specific wording when quota exhausted with additional usage', () => {
+		const dashboard = createDashboard(createEntitlementService({
+			premiumChat: { percentRemaining: 0, unlimited: false, usageBasedBilling: true },
+			completions: { percentRemaining: 90, unlimited: false },
+			additionalUsageEnabled: true,
+			additionalUsageCount: 5,
+			entitlement: ChatEntitlement.Business,
+		}));
+
+		assert.strictEqual(getCalloutText(dashboard.element), 'Copilot has paused because your limits are reached. Please contact your admin to increase your limits.');
+	});
+
 	// --- LIVE UPDATES ---
 
 	function createMutableEntitlementService(opts: {


### PR DESCRIPTION
This pull request updates the messaging shown to enterprise and business users in the Copilot Chat Status Dashboard when they are approaching or have reached their usage limits. The new messages now clearly indicate that Copilot will pause when limits are reached and instruct users to contact their admin to increase limits, replacing the previous language that implied uninterrupted service.

ULB are hard caps so if a user hits their ULB usage will stop. This is different that how VS Code previously interpreted ULB + overage enabled.

**User-facing message updates:**

* Updated the callout text in `ChatStatusDashboard` for enterprise and business users to state that Copilot will pause when limits are reached, and to prompt users to contact their admin to increase limits. Previously, the text indicated that usage would continue without interruption. (`src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.ts`) [[1]](diffhunk://#diff-85eacf69735bedb245ad13db53774159c477b055c15223fa1d0347806a00f780L836-R836) [[2]](diffhunk://#diff-85eacf69735bedb245ad13db53774159c477b055c15223fa1d0347806a00f780L845-R845)

**Test updates:**

* Updated unit tests to expect the new callout messages, ensuring test coverage matches the revised user-facing text. (`src/vs/workbench/contrib/chat/test/browser/chatStatusDashboard.test.ts`) [[1]](diffhunk://#diff-dd06303775b42eb1b151e9fb78f0a136f59bb95a0eb9f9f685db14a81b64c0b7L608-R608) [[2]](diffhunk://#diff-dd06303775b42eb1b151e9fb78f0a136f59bb95a0eb9f9f685db14a81b64c0b7L619-R619) [[3]](diffhunk://#diff-dd06303775b42eb1b151e9fb78f0a136f59bb95a0eb9f9f685db14a81b64c0b7L631-R631)
