### PR TITLE
Fix Chronicle session store corruption on remote (SSH/network FS) workspaces

### DIFF
--- a/extensions/copilot/src/extension/chronicle/vscode-node/sessionStoreTracker.ts
+++ b/extensions/copilot/src/extension/chronicle/vscode-node/sessionStoreTracker.ts
@@ -490,8 +490,9 @@ export class SessionStoreTracker extends Disposable implements IExtensionContrib
 				this._buffer.sessions.set(session.id, session);
 			}
 		}
-		this._buffer.files.unshift(...files);
-		this._buffer.refs.unshift(...refs);
-		this._buffer.turns.unshift(...turns);
+
+		this._buffer.files = files.concat(this._buffer.files);
+		this._buffer.refs = refs.concat(this._buffer.refs);
+		this._buffer.turns = turns.concat(this._buffer.turns);
 	}
 }

--- a/extensions/copilot/src/extension/chronicle/vscode-node/sessionStoreTracker.ts
+++ b/extensions/copilot/src/extension/chronicle/vscode-node/sessionStoreTracker.ts
@@ -465,11 +465,33 @@ export class SessionStoreTracker extends Disposable implements IExtensionContrib
 			}
 		} catch (err) {
 
+			// The flush failed (e.g. a transient lock or I/O error on a network
+			// filesystem). Re-queue the swapped-out operations so the next flush
+			// retries them instead of silently dropping the writes. Writes that
+			// arrived during this flush take precedence on a per-session basis.
+			this._requeueFailedFlush(sessionsToFlush, filesToFlush, refsToFlush, turnsToFlush);
+
 			this._telemetryService.sendMSFTTelemetryErrorEvent('chronicle.localStore', {
 				operation: 'flush',
 				success: 'false',
 				error: err instanceof Error ? err.message.substring(0, 100) : 'unknown',
 			}, { opsCount: totalOps });
 		}
+	}
+
+	/**
+	 * Restore operations from a failed flush back into the buffer so they are
+	 * retried on the next flush. Sessions are only restored when no newer upsert
+	 * for the same session has been buffered since the flush started.
+	 */
+	private _requeueFailedFlush(sessions: SessionRow[], files: FileRow[], refs: RefRow[], turns: TurnRow[]): void {
+		for (const session of sessions) {
+			if (!this._buffer.sessions.has(session.id)) {
+				this._buffer.sessions.set(session.id, session);
+			}
+		}
+		this._buffer.files.unshift(...files);
+		this._buffer.refs.unshift(...refs);
+		this._buffer.turns.unshift(...turns);
 	}
 }

--- a/extensions/copilot/src/extension/extension/vscode-node/services.ts
+++ b/extensions/copilot/src/extension/extension/vscode-node/services.ts
@@ -272,7 +272,10 @@ export function registerServices(builder: IInstantiationServiceBuilder, extensio
 	const sessionStoreDbPath = extensionContext.globalStorageUri
 		? path.join(extensionContext.globalStorageUri.fsPath, 'session-store.db')
 		: path.join(os.tmpdir(), 'copilot-session-store.db');
-	const sessionStore = new SessionStore(sessionStoreDbPath);
+	// On remote workspaces the storage path is typically a network filesystem
+	// that does not honour the POSIX locking WAL mode requires, so use a more
+	// robust rollback-journal configuration there.
+	const sessionStore = new SessionStore(sessionStoreDbPath, { remote: !!env.remoteName });
 	builder.define(ISessionStore, sessionStore);
 
 	// OTel SQLite store — created lazily, DB file only appears when dbSpanExporter.enabled is true

--- a/extensions/copilot/src/platform/chronicle/common/sessionStore.ts
+++ b/extensions/copilot/src/platform/chronicle/common/sessionStore.ts
@@ -9,6 +9,19 @@ import { createServiceIdentifier } from '../../../util/common/services';
 
 export const ISessionStore = createServiceIdentifier<ISessionStore>('ISessionStore');
 
+/**
+ * Options controlling how the {@link ISessionStore} backing database is opened.
+ */
+export interface SessionStoreOptions {
+	/**
+	 * Whether the database file lives on a remote/network filesystem (e.g. an
+	 * SSH-Remote workspace). When set, the store avoids WAL mode and uses a
+	 * rollback journal with a longer busy timeout, since network filesystems do
+	 * not provide the POSIX locking guarantees WAL relies on.
+	 */
+	readonly remote?: boolean;
+}
+
 // ── Row types (same as copilot-agent-runtime SessionStore) ──────────────────────
 
 /**

--- a/extensions/copilot/src/platform/chronicle/node/sessionStore.ts
+++ b/extensions/copilot/src/platform/chronicle/node/sessionStore.ts
@@ -3,10 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { mkdirSync } from 'fs';
+import { mkdirSync, rmSync } from 'fs';
 import { DatabaseSync } from 'node:sqlite';
 import { dirname } from 'path';
-import type { CheckpointRow, FileRow, ISessionStore, RefRow, SearchResult, SessionRow, TurnRow } from '../common/sessionStore';
+import type { CheckpointRow, FileRow, ISessionStore, RefRow, SearchResult, SessionRow, SessionStoreOptions, TurnRow } from '../common/sessionStore';
 
 /**
  * SQLite authorizer action codes that are safe for read-only access.
@@ -38,6 +38,26 @@ const DENIED_FUNCTIONS = new Set(['load_extension']);
 const SCHEMA_VERSION = 3;
 
 /**
+ * Substrings (matched case-insensitively) that identify a corrupt or otherwise
+ * unusable database file. These typically appear on non-POSIX network
+ * filesystems (NFS/SMB/sshfs) used by SSH-Remote workspaces, where SQLite's
+ * locking protocol is not honoured and the file can become permanently
+ * malformed.
+ */
+const CORRUPTION_ERROR_MARKERS = [
+	'malformed',
+	'file is not a database',
+	'not a database',
+	'disk image',
+	'disk i/o error',
+];
+
+function errorMessageIncludes(err: unknown, markers: readonly string[]): boolean {
+	const message = (err instanceof Error ? err.message : String(err)).toLowerCase();
+	return markers.some(marker => message.includes(marker));
+}
+
+/**
  * Session store backed by SQLite + FTS5.
  *
  * Schema is identical to the copilot-agent-runtime SessionStore so that
@@ -48,9 +68,11 @@ export class SessionStore implements ISessionStore {
 	declare readonly _serviceBrand: undefined;
 	private db: DatabaseSync | null = null;
 	private readonly dbPath: string;
+	private readonly remote: boolean;
 
-	constructor(dbPath: string) {
+	constructor(dbPath: string, options?: SessionStoreOptions) {
 		this.dbPath = dbPath;
+		this.remote = options?.remote ?? false;
 	}
 
 	/**
@@ -62,20 +84,51 @@ export class SessionStore implements ISessionStore {
 
 	/**
 	 * Lazily open (or create) the database and ensure the schema exists.
+	 *
+	 * On remote workspaces the database often lives on a network filesystem
+	 * (NFS/SMB/sshfs) that does not provide the POSIX locking guarantees WAL
+	 * mode relies on. If the file is detected to be corrupt it is deleted and
+	 * recreated once before giving up.
 	 */
 	private ensureDb(): DatabaseSync {
 		if (this.db) {
 			return this.db;
 		}
 
+		try {
+			return this.openDb();
+		} catch (err) {
+			// A corrupt on-disk database is unrecoverable in place. Delete it and
+			// the WAL/SHM sidecar files, then try once more with a fresh file.
+			if (this.dbPath !== ':memory:' && errorMessageIncludes(err, CORRUPTION_ERROR_MARKERS)) {
+				this.deleteDbFiles();
+				return this.openDb();
+			}
+			throw err;
+		}
+	}
+
+	/**
+	 * Open the database, configure pragmas and ensure the schema exists.
+	 */
+	private openDb(): DatabaseSync {
 		if (this.dbPath !== ':memory:') {
 			mkdirSync(dirname(this.dbPath), { recursive: true });
 		}
 
 		const db = new DatabaseSync(this.dbPath);
 		try {
-			db.exec('PRAGMA journal_mode = WAL');
-			db.exec('PRAGMA busy_timeout = 3000');
+			if (this.remote) {
+				// WAL requires shared-memory (-shm) plus POSIX byte-range locking,
+				// neither of which network filesystems reliably provide. A rollback
+				// journal with a longer busy timeout is far more robust there.
+				db.exec('PRAGMA journal_mode = DELETE');
+				db.exec('PRAGMA busy_timeout = 10000');
+				db.exec('PRAGMA synchronous = NORMAL');
+			} else {
+				db.exec('PRAGMA journal_mode = WAL');
+				db.exec('PRAGMA busy_timeout = 3000');
+			}
 			db.exec('PRAGMA foreign_keys = ON');
 			this.db = db;
 			this.ensureSchema();
@@ -85,6 +138,15 @@ export class SessionStore implements ISessionStore {
 			throw err;
 		}
 		return this.db;
+	}
+
+	/**
+	 * Best-effort deletion of the database file and its WAL/SHM sidecar files.
+	 */
+	private deleteDbFiles(): void {
+		for (const suffix of ['', '-wal', '-shm', '-journal']) {
+			rmSync(this.dbPath + suffix, { force: true });
+		}
 	}
 
 	/**
@@ -537,6 +599,10 @@ export class SessionStore implements ISessionStore {
 	 * Run a function inside a SQLite transaction (BEGIN/COMMIT/ROLLBACK).
 	 * All writes are batched into a single atomic commit, which is significantly
 	 * faster than auto-committing each individual INSERT.
+	 *
+	 * Transient lock contention is handled by SQLite's `busy_timeout` pragma; a
+	 * failed transaction propagates to the caller, which re-queues the writes for
+	 * the next flush rather than blocking here.
 	 */
 	runInTransaction(fn: () => void): void {
 		const db = this.ensureDb();
@@ -545,8 +611,20 @@ export class SessionStore implements ISessionStore {
 			fn();
 			db.exec('COMMIT');
 		} catch (err) {
-			db.exec('ROLLBACK');
+			this.rollbackQuietly(db);
 			throw err;
+		}
+	}
+
+	/**
+	 * Roll back the active transaction, swallowing the "no transaction is active"
+	 * error that occurs when the failure happened before BEGIN took effect.
+	 */
+	private rollbackQuietly(db: DatabaseSync): void {
+		try {
+			db.exec('ROLLBACK');
+		} catch {
+			// No active transaction to roll back — safe to ignore.
 		}
 	}
 

--- a/extensions/copilot/src/platform/chronicle/node/test/sessionStore.spec.ts
+++ b/extensions/copilot/src/platform/chronicle/node/test/sessionStore.spec.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -259,18 +259,16 @@ describe('SessionStore (on-disk resilience)', () => {
 		store = new SessionStore(dbPath, { remote: true });
 		store.upsertSession({ id: 'session-1' });
 
-		const mode = (store as unknown as { ensureDb(): { prepare(sql: string): { get(): { journal_mode: string } } } })
-			.ensureDb().prepare('PRAGMA journal_mode').get().journal_mode.toLowerCase();
-		expect(mode).not.toBe('wal');
+		// A rollback journal never creates the WAL shared-memory sidecar file.
+		expect(existsSync(dbPath + '-wal')).toBe(false);
 	});
 
 	it('local mode uses WAL', () => {
 		store = new SessionStore(dbPath);
 		store.upsertSession({ id: 'session-1' });
 
-		const mode = (store as unknown as { ensureDb(): { prepare(sql: string): { get(): { journal_mode: string } } } })
-			.ensureDb().prepare('PRAGMA journal_mode').get().journal_mode.toLowerCase();
-		expect(mode).toBe('wal');
+		// WAL mode creates the -wal sidecar file once a write has occurred.
+		expect(existsSync(dbPath + '-wal')).toBe(true);
 	});
 
 	it('recreates a corrupt database file on open', () => {

--- a/extensions/copilot/src/platform/chronicle/node/test/sessionStore.spec.ts
+++ b/extensions/copilot/src/platform/chronicle/node/test/sessionStore.spec.ts
@@ -3,6 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { SessionStore } from '../sessionStore';
 
@@ -235,3 +238,81 @@ describe('SessionStore', () => {
 		expect(store.getPath()).toBe(':memory:');
 	});
 });
+
+describe('SessionStore (on-disk resilience)', () => {
+	let dir: string;
+	let dbPath: string;
+	let store: SessionStore | undefined;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), 'session-store-test-'));
+		dbPath = join(dir, 'session-store.db');
+	});
+
+	afterEach(() => {
+		store?.close();
+		store = undefined;
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it('remote mode uses a rollback journal instead of WAL', () => {
+		store = new SessionStore(dbPath, { remote: true });
+		store.upsertSession({ id: 'session-1' });
+
+		const mode = (store as unknown as { ensureDb(): { prepare(sql: string): { get(): { journal_mode: string } } } })
+			.ensureDb().prepare('PRAGMA journal_mode').get().journal_mode.toLowerCase();
+		expect(mode).not.toBe('wal');
+	});
+
+	it('local mode uses WAL', () => {
+		store = new SessionStore(dbPath);
+		store.upsertSession({ id: 'session-1' });
+
+		const mode = (store as unknown as { ensureDb(): { prepare(sql: string): { get(): { journal_mode: string } } } })
+			.ensureDb().prepare('PRAGMA journal_mode').get().journal_mode.toLowerCase();
+		expect(mode).toBe('wal');
+	});
+
+	it('recreates a corrupt database file on open', () => {
+		// Simulate a malformed database (e.g. corruption on a network filesystem).
+		writeFileSync(dbPath, 'this is not a sqlite database');
+
+		store = new SessionStore(dbPath);
+		store.upsertSession({ id: 'session-1', branch: 'main' });
+
+		const session = store.getSession('session-1');
+		expect(session).toBeDefined();
+		expect(session!.id).toBe('session-1');
+	});
+
+	it('persists writes across reopen', () => {
+		store = new SessionStore(dbPath);
+		store.upsertSession({ id: 'session-1', branch: 'main' });
+		store.close();
+
+		store = new SessionStore(dbPath);
+		expect(store.getSession('session-1')!.branch).toBe('main');
+	});
+
+	it('runInTransaction commits all writes atomically', () => {
+		store = new SessionStore(dbPath);
+		store.runInTransaction(() => {
+			store!.upsertSession({ id: 'session-1' });
+			store!.insertTurn({ session_id: 'session-1', turn_index: 0, user_message: 'hi' });
+		});
+
+		expect(store.getStats().sessions).toBe(1);
+		expect(store.getTurns('session-1')).toHaveLength(1);
+	});
+
+	it('runInTransaction rolls back on error', () => {
+		store = new SessionStore(dbPath);
+		expect(() => store!.runInTransaction(() => {
+			store!.upsertSession({ id: 'session-1' });
+			throw new Error('boom');
+		})).toThrow('boom');
+
+		expect(store.getStats().sessions).toBe(0);
+	});
+});
+


### PR DESCRIPTION
Fixes #317327

### Problem

On SSH-Remote (and other network-filesystem) workspaces, the Chronicle SQLite
session store could become permanently corrupted. The store opens in WAL journal
mode, which requires POSIX `fcntl` byte-range locking plus shared-memory
(`-wal`/`-shm`) sidecar files. Network filesystems (NFS/SMB/sshfs) don't reliably
honour these guarantees, leading to a cascade:

- locking-protocol errors → `database disk image is malformed`
- → `file is not a database` (permanent, unrecoverable in place)

There was no corruption detection or recovery, and failed background flushes
silently dropped their writes, so session history was lost with no path back to
a healthy state.

### Fix

A cheap, layered approach — no thread-blocking, no app-level retry loops:

1. **Remote-aware journal mode.** When the workspace is remote
   (`!!env.remoteName`), open the DB with `journal_mode = DELETE`,
   `synchronous = NORMAL`, and a longer `busy_timeout = 10000`. A rollback
   journal avoids the WAL shared-memory/locking requirements that network
   filesystems can't satisfy. Local workspaces keep WAL.

2. **Corruption auto-recovery.** `ensureDb()` detects known corruption markers
   (`malformed`, `file is not a database`, `disk image`, `disk i/o error`),
   deletes the DB and its `-wal`/`-shm`/`-journal` sidecars, and recreates the
   file once before giving up.

3. **Flush re-queue.** When a periodic flush transaction fails, the buffered
   sessions/files/refs/turns are re-queued instead of dropped, so they retry on
   the next interval. Lock contention is handled by SQLite's native
   `busy_timeout`, not by blocking the extension host.

All storage failures remain isolated to the background tracker / SQL-tool layers
(telemetry + retry); 

### Changes

- `platform/chronicle/node/sessionStore.ts` — remote-aware pragmas, corruption
  detection + one-shot recreate, sidecar cleanup.
- `platform/chronicle/common/sessionStore.ts` — new `SessionStoreOptions { remote? }`.
- `extension/extension/vscode-node/services.ts` — pass `{ remote: !!env.remoteName }`.
- `extension/chronicle/vscode-node/sessionStoreTracker.ts` — re-queue failed flushes.
