### PR TITLE
agentHost: fix orphaned client tool calls after window reload

### DIFF
--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -771,7 +771,7 @@ export interface IAgent {
 	 * @param clientId The client that owns these tools.
 	 * @param tools The tool definitions (full replacement).
 	 */
-	setClientTools(session: URI, clientId: string, tools: ToolDefinition[]): void;
+	setClientTools(session: URI, clientId: string | undefined, tools: ToolDefinition[]): void;
 
 	/**
 	 * Called when a client completes a client-provided tool call.

--- a/src/vs/platform/agentHost/common/pendingRequestRegistry.ts
+++ b/src/vs/platform/agentHost/common/pendingRequestRegistry.ts
@@ -29,8 +29,8 @@ export class PendingRequestRegistry<T> {
 	private readonly _earlyResults = new Map<string, T>();
 
 	registerAndFire(key: string, fire: () => void): Promise<T> {
-		const buffered = this._earlyResults.get(key);
-		if (buffered !== undefined) {
+		if (this._earlyResults.has(key)) {
+			const buffered = this._earlyResults.get(key) as T;
 			this._earlyResults.delete(key);
 			return Promise.resolve(buffered);
 		}
@@ -53,8 +53,8 @@ export class PendingRequestRegistry<T> {
 	 * leaking forever.
 	 */
 	register(key: string): Promise<T> {
-		const buffered = this._earlyResults.get(key);
-		if (buffered !== undefined) {
+		if (this._earlyResults.has(key)) {
+			const buffered = this._earlyResults.get(key) as T;
 			this._earlyResults.delete(key);
 			return Promise.resolve(buffered);
 		}

--- a/src/vs/platform/agentHost/common/pendingRequestRegistry.ts
+++ b/src/vs/platform/agentHost/common/pendingRequestRegistry.ts
@@ -20,8 +20,20 @@ import { CancellationError } from '../../../base/common/errors.js';
  */
 export class PendingRequestRegistry<T> {
 	private readonly _entries = new Map<string, DeferredPromise<T>>();
+	/**
+	 * Results delivered via {@link respondOrBuffer} before any deferred was
+	 * parked under the same key. A subsequent {@link register} consumes the
+	 * buffered value and resolves immediately, tolerating a completion that
+	 * races ahead of the handler that awaits it.
+	 */
+	private readonly _earlyResults = new Map<string, T>();
 
 	registerAndFire(key: string, fire: () => void): Promise<T> {
+		const buffered = this._earlyResults.get(key);
+		if (buffered !== undefined) {
+			this._earlyResults.delete(key);
+			return Promise.resolve(buffered);
+		}
 		const deferred = new DeferredPromise<T>();
 		this._entries.set(key, deferred);
 		fire();
@@ -41,6 +53,11 @@ export class PendingRequestRegistry<T> {
 	 * leaking forever.
 	 */
 	register(key: string): Promise<T> {
+		const buffered = this._earlyResults.get(key);
+		if (buffered !== undefined) {
+			this._earlyResults.delete(key);
+			return Promise.resolve(buffered);
+		}
 		const existing = this._entries.get(key);
 		if (existing && !existing.isSettled) {
 			existing.error(new CancellationError());
@@ -61,6 +78,20 @@ export class PendingRequestRegistry<T> {
 	}
 
 	/**
+	 * Like {@link respond}, but if no deferred is parked under `key`, buffer
+	 * the value so a subsequent {@link register} / {@link registerAndFire}
+	 * for the same key resolves immediately. Use when the completion may
+	 * legitimately arrive before the awaiting handler registers (the
+	 * Copilot client-tool round-trip, whose SDK handler and the workbench
+	 * completion race).
+	 */
+	respondOrBuffer(key: string, value: T): void {
+		if (!this.respond(key, value)) {
+			this._earlyResults.set(key, value);
+		}
+	}
+
+	/**
 	 * Resolve every parked deferred with `denyValue` and clear the registry.
 	 *
 	 * Designed for the permission-deny path: a "deny" answer is itself a
@@ -75,6 +106,7 @@ export class PendingRequestRegistry<T> {
 			}
 		}
 		this._entries.clear();
+		this._earlyResults.clear();
 	}
 
 	/**
@@ -94,5 +126,6 @@ export class PendingRequestRegistry<T> {
 			}
 		}
 		this._entries.clear();
+		this._earlyResults.clear();
 	}
 }

--- a/src/vs/platform/agentHost/node/activeClientState.ts
+++ b/src/vs/platform/agentHost/node/activeClientState.ts
@@ -1,0 +1,98 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { equals } from '../../../base/common/objects.js';
+import type { ToolDefinition } from '../common/state/protocol/state.js';
+
+/**
+ * Structural view of the active client's contributions that, when changed,
+ * requires the underlying SDK session to be restarted / rebound. The
+ * `clientId` is deliberately excluded — a window reload that produces a new
+ * `clientId` with an identical tool list does NOT require a restart.
+ */
+export interface IActiveClientStructuralSnapshot {
+	readonly tools: readonly ToolDefinition[];
+}
+
+/**
+ * Deep-equal two client-tool snapshots on `name + description + inputSchema`.
+ * `undefined` and `[]` compare equal. Order-insensitive.
+ *
+ * Single shared implementation for the agent-host providers — previously
+ * duplicated as `snapshotsEqual` (Claude client-tools model) and an inline
+ * loop in the Copilot `ActiveClient` staleness check.
+ */
+export function structuralToolsEqual(
+	a: readonly ToolDefinition[] | undefined,
+	b: readonly ToolDefinition[] | undefined,
+): boolean {
+	const aa = a ?? [];
+	const bb = b ?? [];
+	if (aa.length !== bb.length) {
+		return false;
+	}
+	const byName = new Map<string, ToolDefinition>();
+	for (const t of aa) {
+		byName.set(t.name, t);
+	}
+	for (const t of bb) {
+		const prev = byName.get(t.name);
+		if (!prev) {
+			return false;
+		}
+		if (prev.description !== t.description) {
+			return false;
+		}
+		if (!equals(prev.inputSchema, t.inputSchema)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+/**
+ * Live, mutable holder for the active client's identity (`clientId`) and the
+ * structural tool snapshot it contributes. Shared between the Copilot and
+ * Claude providers so a single long-lived instance per session URI survives
+ * SDK-session dispose / resume cycles.
+ *
+ * The `clientId` is read at tool-call **stamp time** (not cached per turn) so
+ * that a window reload — which connects with a new `clientId` and re-pushes an
+ * identical tool list — stamps subsequent client tool calls with the new,
+ * live `clientId` instead of a frozen one baked in at session creation.
+ */
+export class ActiveClientState {
+	private _clientId = '';
+	private _tools: readonly ToolDefinition[] = [];
+
+	/** Live owning client id. Empty string means no client is currently connected. */
+	get clientId(): string {
+		return this._clientId;
+	}
+
+	/** Structural state (tool definitions). Changing these requires an SDK restart/rebind. */
+	get tools(): readonly ToolDefinition[] {
+		return this._tools;
+	}
+
+	/**
+	 * Replace the owning `clientId` and the contributed tool list. A
+	 * `clientId`-only change does NOT mark structural dirt (see
+	 * {@link structuralEquals}).
+	 */
+	update(clientId: string, tools: readonly ToolDefinition[]): void {
+		this._clientId = clientId;
+		this._tools = tools;
+	}
+
+	/**
+	 * Structural comparison of the live tools against a previously-applied
+	 * snapshot (`name + description + inputSchema`, order-insensitive).
+	 * Returns `true` when no SDK restart is required.
+	 */
+	structuralEquals(applied: IActiveClientStructuralSnapshot): boolean {
+		return structuralToolsEqual(this._tools, applied.tools);
+	}
+}

--- a/src/vs/platform/agentHost/node/activeClientState.ts
+++ b/src/vs/platform/agentHost/node/activeClientState.ts
@@ -64,11 +64,11 @@ export function structuralToolsEqual(
  * live `clientId` instead of a frozen one baked in at session creation.
  */
 export class ActiveClientState {
-	private _clientId = '';
+	private _clientId: string | undefined = undefined;
 	private _tools: readonly ToolDefinition[] = [];
 
-	/** Live owning client id. Empty string means no client is currently connected. */
-	get clientId(): string {
+	/** Live owning client id, or `undefined` when no client is currently connected. */
+	get clientId(): string | undefined {
 		return this._clientId;
 	}
 
@@ -78,11 +78,11 @@ export class ActiveClientState {
 	}
 
 	/**
-	 * Replace the owning `clientId` and the contributed tool list. A
-	 * `clientId`-only change does NOT mark structural dirt (see
-	 * {@link structuralEquals}).
+	 * Replace the owning `clientId` (`undefined` when no client is connected)
+	 * and the contributed tool list. A `clientId`-only change does NOT mark
+	 * structural dirt (see {@link structuralEquals}).
 	 */
-	update(clientId: string, tools: readonly ToolDefinition[]): void {
+	update(clientId: string | undefined, tools: readonly ToolDefinition[]): void {
 		this._clientId = clientId;
 		this._tools = tools;
 	}

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -844,11 +844,11 @@ export class AgentSideEffects extends Disposable {
 					break;
 				}
 				// Always forward client tools, even if empty, to clear previous client's tools
-				const clientId = action.activeClient?.clientId ?? '';
+				const clientId = action.activeClient?.clientId;
 				agent.setClientTools(URI.parse(channel), clientId, action.activeClient?.tools ?? []);
 
 				const refs = action.activeClient?.customizations ?? [];
-				agent.setClientCustomizations(URI.parse(channel), clientId, refs).catch(err => {
+				agent.setClientCustomizations(URI.parse(channel), clientId ?? '', refs).catch(err => {
 					this._logService.error('[AgentSideEffects] setClientCustomizations failed', err);
 				});
 				break;

--- a/src/vs/platform/agentHost/node/claude/claudeAgent.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgent.ts
@@ -918,7 +918,7 @@ export class ClaudeAgent extends Disposable implements IAgent {
 		});
 	}
 
-	setClientTools(session: URI, clientId: string, tools: ToolDefinition[]): void {
+	setClientTools(session: URI, clientId: string | undefined, tools: ToolDefinition[]): void {
 		const sessionId = AgentSession.id(session);
 		this._logService.info(`[Claude:${sessionId}] setClientTools clientId=${clientId} tools=[${tools.map(t => t.name).join(', ') || '(none)'}]`);
 		const sess = this._findAnySession(sessionId);

--- a/src/vs/platform/agentHost/node/claude/clientTools/claudeSessionClientToolsModel.ts
+++ b/src/vs/platform/agentHost/node/claude/clientTools/claudeSessionClientToolsModel.ts
@@ -4,9 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable } from '../../../../../base/common/lifecycle.js';
-import { equals } from '../../../../../base/common/objects.js';
 import { autorun, IObservable, ISettableObservable, observableValueOpts } from '../../../../../base/common/observable.js';
 import type { ToolDefinition } from '../../../common/state/protocol/state.js';
+import { structuralToolsEqual } from '../../activeClientState.js';
 
 /**
  * Combined snapshot of the workbench-registered client-tool definitions
@@ -76,16 +76,24 @@ export class SessionClientToolsDiff extends Disposable {
 	// tracking. Skip that initial run so a brand-new diff doesn't report
 	// dirty before any `setTools` has happened.
 	private _ignoreNextFire = true;
+	// Structural tool snapshot last marked applied (via {@link consume}).
+	// The dirty bit only flips when the live tools differ structurally from
+	// this — a `clientId`-only change (same tools, new window) must NOT
+	// trigger a yield-restart even though the observable still fires.
+	private _lastAppliedTools: readonly ToolDefinition[] | undefined = undefined;
 
 	constructor() {
 		super();
 		this._register(autorun(reader => {
-			this.model.state.read(reader);
+			const state = this.model.state.read(reader);
 			if (this._ignoreNextFire) {
 				this._ignoreNextFire = false;
+				this._lastAppliedTools = state.tools;
 				return;
 			}
-			this._dirty = true;
+			if (!structuralToolsEqual(state.tools, this._lastAppliedTools)) {
+				this._dirty = true;
+			}
 		}));
 	}
 
@@ -104,6 +112,7 @@ export class SessionClientToolsDiff extends Disposable {
 	consume(): ISessionClientToolsState {
 		const state = this.model.state.get();
 		this._dirty = false;
+		this._lastAppliedTools = state.tools;
 		return state;
 	}
 
@@ -118,37 +127,5 @@ export class SessionClientToolsDiff extends Disposable {
 }
 
 function stateEqual(a: ISessionClientToolsState, b: ISessionClientToolsState): boolean {
-	return a.clientId === b.clientId && snapshotsEqual(a.tools, b.tools);
-}
-
-/**
- * Deep-equal two client-tool snapshots on `name + description + inputSchema`.
- * `undefined` and `[]` compare equal. Order-insensitive.
- */
-function snapshotsEqual(
-	a: readonly ToolDefinition[] | undefined,
-	b: readonly ToolDefinition[] | undefined
-): boolean {
-	const aa = a ?? [];
-	const bb = b ?? [];
-	if (aa.length !== bb.length) {
-		return false;
-	}
-	const byName = new Map<string, ToolDefinition>();
-	for (const t of aa) {
-		byName.set(t.name, t);
-	}
-	for (const t of bb) {
-		const prev = byName.get(t.name);
-		if (!prev) {
-			return false;
-		}
-		if (prev.description !== t.description) {
-			return false;
-		}
-		if (!equals(prev.inputSchema, t.inputSchema)) {
-			return false;
-		}
-	}
-	return true;
+	return a.clientId === b.clientId && structuralToolsEqual(a.tools, b.tools);
 }

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -1366,7 +1366,7 @@ export class CodexAgent extends Disposable implements IAgent {
 		};
 	}
 
-	setClientTools(_session: URI, _clientId: string, _tools: ToolDefinition[]): void {
+	setClientTools(_session: URI, _clientId: string | undefined, _tools: ToolDefinition[]): void {
 		// Phase 6+: in-process MCP client tools. Not implemented in Phase 2.
 	}
 

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -1079,11 +1079,11 @@ export class CopilotAgent extends Disposable implements IAgent {
 		return activeClient.pluginController.sync(clientId, customizations);
 	}
 
-	setClientTools(session: URI, clientId: string, tools: ToolDefinition[]): void {
+	setClientTools(session: URI, clientId: string | undefined, tools: ToolDefinition[]): void {
 		const sessionId = AgentSession.id(session);
 		const activeClient = this._getOrCreateActiveClient(session, undefined);
 		const hasCachedEntry = this._sessions.has(sessionId);
-		this._logService.info(`[Copilot:${sessionId}] setClientTools: clientId=${clientId}, tools=[${tools.map(t => t.name).join(', ') || '(none)'}], hasCachedSdkSession=${hasCachedEntry}`);
+		this._logService.info(`[Copilot:${sessionId}] setClientTools: clientId=${clientId ?? '(none)'}, tools=[${tools.map(t => t.name).join(', ') || '(none)'}], hasCachedSdkSession=${hasCachedEntry}`);
 		activeClient.updateTools(clientId, tools);
 	}
 
@@ -1131,7 +1131,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 			const hadCachedEntry = !!entry;
 			this._logService.info(`[Copilot:${sessionId}] sendMessage: cachedEntry=${hadCachedEntry}, hasActiveClient=${!!activeClient}, activeClientId=${activeClient ? '(set)' : '(none)'}`);
 			if (entry && activeClient && await activeClient.requiresRestart(entry.appliedSnapshot)) {
-				this._logService.info(`[Copilot:${sessionId}] Session config changed (requiresRestart=true), refreshing session. clientId=${activeClient.state.clientId}`);
+				this._logService.info(`[Copilot:${sessionId}] Session config changed (requiresRestart=true), refreshing session. clientId=${activeClient.state.clientId ?? '(none)'}`);
 				this._sessions.deleteAndDispose(sessionId);
 				entry = undefined;
 			}
@@ -2557,7 +2557,7 @@ class ActiveClient extends Disposable {
 		}));
 	}
 
-	updateTools(clientId: string, tools: readonly ToolDefinition[]): void {
+	updateTools(clientId: string | undefined, tools: readonly ToolDefinition[]): void {
 		this.state.update(clientId, tools);
 	}
 

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -46,6 +46,7 @@ import { ICopilotSessionContext, projectFromCopilotContext } from './copilotGitP
 import { parsedPluginsEqual, toChildCustomizations } from './copilotPluginConverters.js';
 import { ShellManager } from './copilotShellTools.js';
 import { CopilotSessionLauncher, ThinkingLevelConfigKey, getCopilotReasoningEffort, type CopilotSessionLaunchPlan, type IActiveClientSnapshot } from './copilotSessionLauncher.js';
+import { ActiveClientState } from '../activeClientState.js';
 import { areDiscoveredDirectoriesEqual, DiscoveredType, SessionCustomizationDiscovery, type IDiscoveredDirectory } from './sessionCustomizationDiscovery.js';
 import { SessionPluginBundler } from '../shared/sessionPluginBundler.js';
 import { CopilotSlashCommandCompletionProvider } from './copilotSlashCommandCompletionProvider.js';
@@ -963,6 +964,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 				workingDirectory,
 				resolvedAgentName,
 				snapshot,
+				activeClientState: activeClient.state,
 				shellManager,
 				githubToken: this._githubToken,
 				model: provisional.model,
@@ -1128,14 +1130,14 @@ export class CopilotAgent extends Disposable implements IAgent {
 			const activeClient = this._activeClients.get(session);
 			const hadCachedEntry = !!entry;
 			this._logService.info(`[Copilot:${sessionId}] sendMessage: cachedEntry=${hadCachedEntry}, hasActiveClient=${!!activeClient}, activeClientId=${activeClient ? '(set)' : '(none)'}`);
-			if (entry && activeClient && await activeClient.isOutdated(entry.appliedSnapshot)) {
-				this._logService.info(`[Copilot:${sessionId}] Session config changed (isOutdated=true), refreshing session. snapshotClientId=${entry.appliedSnapshot.clientId}`);
+			if (entry && activeClient && await activeClient.requiresRestart(entry.appliedSnapshot)) {
+				this._logService.info(`[Copilot:${sessionId}] Session config changed (requiresRestart=true), refreshing session. clientId=${activeClient.state.clientId}`);
 				this._sessions.deleteAndDispose(sessionId);
 				entry = undefined;
 			}
 
 			if (!entry) {
-				this._logService.info(`[Copilot:${sessionId}] No cached entry${hadCachedEntry ? ' (was evicted by isOutdated)' : ''}, calling _resumeSession`);
+				this._logService.info(`[Copilot:${sessionId}] No cached entry${hadCachedEntry ? ' (was evicted by requiresRestart)' : ''}, calling _resumeSession`);
 			}
 			entry ??= await this._resumeSession(sessionId);
 
@@ -1512,6 +1514,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 				workingDirectory: launchPlan.workingDirectory,
 				customizationDirectory,
 				clientSnapshot: launchPlan.snapshot,
+				activeClientState: launchPlan.activeClientState,
 			},
 		);
 
@@ -1610,6 +1613,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 			workingDirectory,
 			resolvedAgentName,
 			snapshot,
+			activeClientState: activeClient.state,
 			shellManager,
 			githubToken: this._githubToken,
 			fallback: {
@@ -2529,8 +2533,13 @@ class SessionPluginController extends Disposable {
  * tears down the controller and any disk watchers it created.
  */
 class ActiveClient extends Disposable {
-	private _tools: readonly ToolDefinition[] = [];
-	private _clientId = '';
+	/**
+	 * Live holder of the owning `clientId` and contributed tools. Shared by
+	 * reference with the session's {@link CopilotAgentSession} so a window
+	 * reload (new `clientId`, identical tools) is reflected at tool-call
+	 * stamp time without restarting the SDK session.
+	 */
+	readonly state = new ActiveClientState();
 
 	public readonly pluginController: SessionPluginController;
 
@@ -2549,33 +2558,25 @@ class ActiveClient extends Disposable {
 	}
 
 	updateTools(clientId: string, tools: readonly ToolDefinition[]): void {
-		this._clientId = clientId;
-		this._tools = tools;
+		this.state.update(clientId, tools);
 	}
 
 	async snapshot(): Promise<IActiveClientSnapshot> {
-		return { clientId: this._clientId, tools: this._tools, plugins: await this.pluginController.getAppliedPlugins() };
+		return { tools: this.state.tools, plugins: await this.pluginController.getAppliedPlugins() };
 	}
 
-	async isOutdated(snap: IActiveClientSnapshot): Promise<boolean> {
+	/**
+	 * Returns `true` when the SDK session must be disposed and resumed to
+	 * pick up a changed config. Compares ONLY plugins and the structural
+	 * tool set (name + description + inputSchema). The `clientId` is
+	 * deliberately excluded — a clientId-only change is reflected live via
+	 * {@link state} and never requires a restart.
+	 */
+	async requiresRestart(snap: IActiveClientSnapshot): Promise<boolean> {
 		const plugins = await this.pluginController.getAppliedPlugins();
 		if (!parsedPluginsEqual(snap.plugins, plugins)) {
 			return true;
 		}
-		if (snap.tools.length !== this._tools.length) {
-			return true;
-		}
-		// Compare tool definitions by name, description, and schema —
-		// not just names — so schema/description changes trigger a refresh.
-		const snapByName = new Map(snap.tools.map(t => [t.name, t]));
-		for (const tool of this._tools) {
-			const prev = snapByName.get(tool.name);
-			if (!prev
-				|| prev.description !== tool.description
-				|| !equals(prev.inputSchema, tool.inputSchema)) {
-				return true;
-			}
-		}
-		return false;
+		return !this.state.structuralEquals({ tools: snap.tools });
 	}
 }

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -411,7 +411,7 @@ export class CopilotAgentSession extends Disposable {
 			this._activeClientState = options.activeClientState;
 		} else {
 			this._activeClientState = new ActiveClientState();
-			this._activeClientState.update('', this._appliedSnapshot.tools);
+			this._activeClientState.update(undefined, this._appliedSnapshot.tools);
 		}
 
 		this._databaseRef = sessionDataService.openDatabase(options.sessionUri);
@@ -1752,13 +1752,9 @@ export class CopilotAgentSession extends Disposable {
 			const toolKind = getToolKind(e.data.toolName);
 			const subagentMeta = toolKind === 'subagent' ? getSubagentMetadata(parameters) : undefined;
 
-			let contributor: { readonly kind: ToolCallContributorKind.Client; readonly clientId: string } | undefined;
+			let contributor: { readonly kind: ToolCallContributorKind.Client; readonly clientId?: string } | undefined;
 			if (this._clientToolNames.has(e.data.toolName)) {
-				const liveClientId = this._activeClientState.clientId;
-				if (!liveClientId) {
-					this._logService.warn(`[Copilot:${sessionId}] Client tool '${e.data.toolName}' started with no connected client; relying on disconnect timeout to fail it.`);
-				}
-				contributor = { kind: ToolCallContributorKind.Client, clientId: liveClientId };
+				contributor = { kind: ToolCallContributorKind.Client, clientId: this._activeClientState.clientId };
 			}
 
 			// A new tool call invalidates the current markdown and reasoning
@@ -1800,6 +1796,38 @@ export class CopilotAgentSession extends Disposable {
 			// a separate tool_ready signal once the deferred is in place (or
 			// the permission flow fires it first).
 			if (contributor) {
+				// No client is connected to run this client tool. Fail it
+				// immediately instead of leaving it pending until the
+				// server-side disconnect timeout fires. We emit the completion
+				// ourselves and drop the active-tool entry so the SDK's own
+				// tool.execution_complete for this id is suppressed.
+				if (contributor.clientId === undefined) {
+					this._logService.warn(`[Copilot:${sessionId}] Client tool '${e.data.toolName}' started with no connected client; failing it immediately.`);
+					this._activeToolCalls.delete(e.data.toolCallId);
+					this._emitAction({
+						type: ActionType.SessionToolCallReady,
+						turnId: this._turnId,
+						toolCallId: e.data.toolCallId,
+						invocationMessage: getInvocationMessage(e.data.toolName, displayName, parameters),
+						toolInput: getToolInputString(e.data.toolName, parameters, toolArgs),
+						confirmed: ToolCallConfirmationReason.NotNeeded,
+					}, parentToolCallId);
+					this._emitAction({
+						type: ActionType.SessionToolCallComplete,
+						turnId: this._turnId,
+						toolCallId: e.data.toolCallId,
+						result: {
+							success: false,
+							pastTenseMessage: `${displayName} failed`,
+							error: { message: `No client was connected to run ${displayName}` },
+						},
+					}, parentToolCallId);
+					this._pendingClientToolCalls.respondOrBuffer(e.data.toolCallId, {
+						textResultForLlm: `No client was connected to run ${displayName}.`,
+						resultType: 'failure',
+						error: 'No client connected',
+					});
+				}
 				return;
 			}
 

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -1752,8 +1752,9 @@ export class CopilotAgentSession extends Disposable {
 			const toolKind = getToolKind(e.data.toolName);
 			const subagentMeta = toolKind === 'subagent' ? getSubagentMetadata(parameters) : undefined;
 
-			let contributor: { readonly kind: ToolCallContributorKind.Client; readonly clientId?: string } | undefined;
-			if (this._clientToolNames.has(e.data.toolName)) {
+			let contributor: { readonly kind: ToolCallContributorKind.Client; readonly clientId: string } | undefined;
+			const isClientTool = this._clientToolNames.has(e.data.toolName);
+			if (isClientTool && this._activeClientState.clientId) {
 				contributor = { kind: ToolCallContributorKind.Client, clientId: this._activeClientState.clientId };
 			}
 
@@ -1792,42 +1793,43 @@ export class CopilotAgentSession extends Disposable {
 				_meta: meta,
 			}, parentToolCallId);
 
+			// No client is connected to run this client tool. Fail it
+			// immediately instead of leaving it pending until the
+			// server-side disconnect timeout fires. We emit the completion
+			// ourselves and drop the active-tool entry so the SDK's own
+			// tool.execution_complete for this id is suppressed.
+			if (isClientTool && !contributor) {
+				this._logService.warn(`[Copilot:${sessionId}] Client tool '${e.data.toolName}' started with no connected client; failing it immediately.`);
+				this._activeToolCalls.delete(e.data.toolCallId);
+				this._emitAction({
+					type: ActionType.SessionToolCallReady,
+					turnId: this._turnId,
+					toolCallId: e.data.toolCallId,
+					invocationMessage: getInvocationMessage(e.data.toolName, displayName, parameters),
+					toolInput: getToolInputString(e.data.toolName, parameters, toolArgs),
+					confirmed: ToolCallConfirmationReason.NotNeeded,
+				}, parentToolCallId);
+				this._emitAction({
+					type: ActionType.SessionToolCallComplete,
+					turnId: this._turnId,
+					toolCallId: e.data.toolCallId,
+					result: {
+						success: false,
+						pastTenseMessage: `${displayName} failed`,
+						error: { message: `No client was connected to run ${displayName}` },
+					},
+				}, parentToolCallId);
+				this._pendingClientToolCalls.respondOrBuffer(e.data.toolCallId, {
+					textResultForLlm: `No client was connected to run ${displayName}.`,
+					resultType: 'failure',
+					error: 'No client connected',
+				});
+			}
+
 			// For client tools, do NOT auto-ready — the tool handler will fire
 			// a separate tool_ready signal once the deferred is in place (or
 			// the permission flow fires it first).
 			if (contributor) {
-				// No client is connected to run this client tool. Fail it
-				// immediately instead of leaving it pending until the
-				// server-side disconnect timeout fires. We emit the completion
-				// ourselves and drop the active-tool entry so the SDK's own
-				// tool.execution_complete for this id is suppressed.
-				if (contributor.clientId === undefined) {
-					this._logService.warn(`[Copilot:${sessionId}] Client tool '${e.data.toolName}' started with no connected client; failing it immediately.`);
-					this._activeToolCalls.delete(e.data.toolCallId);
-					this._emitAction({
-						type: ActionType.SessionToolCallReady,
-						turnId: this._turnId,
-						toolCallId: e.data.toolCallId,
-						invocationMessage: getInvocationMessage(e.data.toolName, displayName, parameters),
-						toolInput: getToolInputString(e.data.toolName, parameters, toolArgs),
-						confirmed: ToolCallConfirmationReason.NotNeeded,
-					}, parentToolCallId);
-					this._emitAction({
-						type: ActionType.SessionToolCallComplete,
-						turnId: this._turnId,
-						toolCallId: e.data.toolCallId,
-						result: {
-							success: false,
-							pastTenseMessage: `${displayName} failed`,
-							error: { message: `No client was connected to run ${displayName}` },
-						},
-					}, parentToolCallId);
-					this._pendingClientToolCalls.respondOrBuffer(e.data.toolCallId, {
-						textResultForLlm: `No client was connected to run ${displayName}.`,
-						resultType: 'failure',
-						error: 'No client connected',
-					});
-				}
 				return;
 			}
 

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -1824,6 +1824,7 @@ export class CopilotAgentSession extends Disposable {
 					resultType: 'failure',
 					error: 'No client connected',
 				});
+				return;
 			}
 
 			// For client tools, do NOT auto-ready — the tool handler will fire

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -36,6 +36,8 @@ import { IAgentConfigurationService } from '../agentConfigurationService.js';
 import type { IExitPlanModeResponse } from './copilotAgent.js';
 import { CopilotSessionWrapper } from './copilotSessionWrapper.js';
 import type { CopilotSessionLaunchPlan, IActiveClientSnapshot, ICopilotSessionLauncher, ICopilotSessionRuntime } from './copilotSessionLauncher.js';
+import { ActiveClientState } from '../activeClientState.js';
+import { PendingRequestRegistry } from '../../common/pendingRequestRegistry.js';
 import { buildCopilotSystemNotification } from './copilotSystemNotification.js';
 import { parseLeadingSlashCommand } from './copilotSlashCommandCompletionProvider.js';
 import type { IUnsandboxedCommandConfirmationRequest, ShellManager } from './copilotShellTools.js';
@@ -263,6 +265,14 @@ export interface ICopilotAgentSessionOptions {
 	readonly customizationDirectory?: URI;
 	/** Snapshot of the active client's tools and plugins at session creation time. */
 	readonly clientSnapshot?: IActiveClientSnapshot;
+	/**
+	 * Live holder of the owning client's identity, shared by reference with
+	 * the agent's per-session {@link ActiveClient}. Read at tool-call stamp
+	 * time so a window reload (new `clientId`, identical tools) stamps with
+	 * the current id. When omitted, a fresh state seeded from
+	 * {@link clientSnapshot} is used (test / standalone path).
+	 */
+	readonly activeClientState?: ActiveClientState;
 }
 
 /**
@@ -337,10 +347,17 @@ export class CopilotAgentSession extends Disposable {
 
 	/** Snapshot captured at session creation for refresh detection. */
 	private readonly _appliedSnapshot: IActiveClientSnapshot;
+	/**
+	 * Live owning-client identity, read at tool-call stamp time so a window
+	 * reload that re-pushes identical tools with a new `clientId` stamps
+	 * subsequent client tool calls with the current id rather than the one
+	 * frozen into {@link _appliedSnapshot}.
+	 */
+	private readonly _activeClientState: ActiveClientState;
 	/** Tool names that are client-provided, derived from snapshot. */
 	private readonly _clientToolNames: ReadonlySet<string>;
 	/** Deferred promises for pending client tool calls, keyed by toolCallId. */
-	private readonly _pendingClientToolCalls = new Map<string, DeferredPromise<ToolResultObject>>();
+	private readonly _pendingClientToolCalls = new PendingRequestRegistry<ToolResultObject>();
 	/** `pending-edit-content:` URIs written during permission requests, keyed
 	 *  by toolCallId. Cleaned up when the permission resolves or the session
 	 *  is disposed. */
@@ -385,8 +402,17 @@ export class CopilotAgentSession extends Disposable {
 		this._workingDirectory = options.workingDirectory;
 		this._customizationDirectory = options.customizationDirectory;
 
-		this._appliedSnapshot = options.clientSnapshot ?? { clientId: '', tools: [], plugins: [] };
+		this._appliedSnapshot = options.clientSnapshot ?? { tools: [], plugins: [] };
 		this._clientToolNames = new Set(this._appliedSnapshot.tools.map(t => t.name));
+		// Share the agent's live ActiveClientState when provided so clientId
+		// changes are observed at stamp time. Standalone / test construction
+		// seeds a private instance with the applied tools and no owning client.
+		if (options.activeClientState) {
+			this._activeClientState = options.activeClientState;
+		} else {
+			this._activeClientState = new ActiveClientState();
+			this._activeClientState.update('', this._appliedSnapshot.tools);
+		}
 
 		this._databaseRef = sessionDataService.openDatabase(options.sessionUri);
 		this._register(toDisposable(() => this._databaseRef.dispose()));
@@ -668,8 +694,9 @@ export class CopilotAgentSession extends Disposable {
 
 	/**
 	 * Creates SDK {@link Tool} objects for the client-provided tools in the
-	 * applied snapshot. The handler creates a {@link DeferredPromise} and waits
-	 * for the client to dispatch `session/toolCallComplete`.
+	 * applied snapshot. The handler parks a request in
+	 * {@link _pendingClientToolCalls} and waits for the client to dispatch
+	 * `session/toolCallComplete`.
 	 */
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	private _createClientSdkTools(): Tool<any>[] {
@@ -683,14 +710,10 @@ export class CopilotAgentSession extends Disposable {
 			parameters: def.inputSchema ?? { type: 'object' as const, properties: {} },
 			handler: async (_args: Record<string, unknown>, { toolCallId }) => {
 				try {
-					let deferred = this._pendingClientToolCalls.get(toolCallId);
-					if (!deferred) {
-						deferred = new DeferredPromise<ToolResultObject>();
-						this._pendingClientToolCalls.set(toolCallId, deferred);
-					}
-					const result = await deferred.p;
-					this._pendingClientToolCalls.delete(toolCallId);
-					return result;
+					// The completion may legitimately arrive before this handler
+					// registers; the registry buffers early results so register()
+					// resolves immediately in that case.
+					return await this._pendingClientToolCalls.register(toolCallId);
 				} catch (error) {
 					this._logService.error(error, `[Copilot:${this.sessionId}] Failed in client tool handler: tool=${def.name}, toolCallId=${toolCallId}`);
 					throw error;
@@ -700,16 +723,11 @@ export class CopilotAgentSession extends Disposable {
 	}
 
 	/**
-	 * Resolves a pending client tool call. Returns `true` if the
-	 * toolCallId was found and handled.
+	 * Resolves a pending client tool call. If the SDK handler has not yet
+	 * registered for `toolCallId`, the result is buffered so the handler
+	 * resolves immediately once it does.
 	 */
 	handleClientToolCallComplete(toolCallId: string, result: ToolCallResult) {
-		let deferred = this._pendingClientToolCalls.get(toolCallId);
-		if (!deferred) {
-			deferred = new DeferredPromise<ToolResultObject>();
-			this._pendingClientToolCalls.set(toolCallId, deferred);
-		}
-
 		const textContent = result.content
 			?.filter(c => c.type === ToolResultContentType.Text)
 			.map(c => c.text)
@@ -720,13 +738,13 @@ export class CopilotAgentSession extends Disposable {
 			.map(c => ({ data: c.data, mimeType: c.contentType, type: (/^image(\/|$)/.test(c.contentType) ? 'image' : 'resource') as 'image' | 'resource' }));
 
 		if (result.success) {
-			deferred.complete({
+			this._pendingClientToolCalls.respondOrBuffer(toolCallId, {
 				textResultForLlm: textContent,
 				resultType: 'success',
 				binaryResultsForLlm: binaryResults?.length ? binaryResults : undefined,
 			});
 		} else {
-			deferred.complete({
+			this._pendingClientToolCalls.respondOrBuffer(toolCallId, {
 				textResultForLlm: textContent || result.error?.message || 'Tool call failed',
 				resultType: 'failure',
 				error: result.error?.message,
@@ -1733,8 +1751,15 @@ export class CopilotAgentSession extends Disposable {
 			this._activeToolCalls.set(e.data.toolCallId, { toolName: e.data.toolName, displayName, parameters, content: [], parentToolCallId, startTimeMs: Date.now(), mcpServerName: e.data.mcpServerName });
 			const toolKind = getToolKind(e.data.toolName);
 			const subagentMeta = toolKind === 'subagent' ? getSubagentMetadata(parameters) : undefined;
-			const toolClientId = this._clientToolNames.has(e.data.toolName) ? this._appliedSnapshot.clientId : undefined;
-			const contributor = toolClientId ? { kind: ToolCallContributorKind.Client, clientId: toolClientId } as const : undefined;
+
+			let contributor: { readonly kind: ToolCallContributorKind.Client; readonly clientId: string } | undefined;
+			if (this._clientToolNames.has(e.data.toolName)) {
+				const liveClientId = this._activeClientState.clientId;
+				if (!liveClientId) {
+					this._logService.warn(`[Copilot:${sessionId}] Client tool '${e.data.toolName}' started with no connected client; relying on disconnect timeout to fail it.`);
+				}
+				contributor = { kind: ToolCallContributorKind.Client, clientId: liveClientId };
+			}
 
 			// A new tool call invalidates the current markdown and reasoning
 			// parts so the next text/reasoning delta after the tool call
@@ -1774,7 +1799,7 @@ export class CopilotAgentSession extends Disposable {
 			// For client tools, do NOT auto-ready — the tool handler will fire
 			// a separate tool_ready signal once the deferred is in place (or
 			// the permission flow fires it first).
-			if (toolClientId) {
+			if (contributor) {
 				return;
 			}
 
@@ -2322,10 +2347,7 @@ export class CopilotAgentSession extends Disposable {
 	}
 
 	private _cancelPendingClientToolCalls(): void {
-		for (const [, deferred] of this._pendingClientToolCalls) {
-			deferred.complete({ textResultForLlm: 'Tool call cancelled: session ended', resultType: 'failure', error: 'Session ended' });
-		}
-		this._pendingClientToolCalls.clear();
+		this._pendingClientToolCalls.denyAll({ textResultForLlm: 'Tool call cancelled: session ended', resultType: 'failure', error: 'Session ended' });
 	}
 }
 

--- a/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
@@ -14,6 +14,7 @@ import { AgentHostSessionSyncEnabledConfigKey, platformRootSchema } from '../../
 import { IAgentConfigurationService } from '../agentConfigurationService.js';
 import { IAgentHostTerminalManager } from '../agentHostTerminalManager.js';
 import type { ModelSelection, ToolDefinition } from '../../common/state/protocol/state.js';
+import type { ActiveClientState } from '../activeClientState.js';
 import { CopilotSessionWrapper } from './copilotSessionWrapper.js';
 import { ShellManager, createShellTools, type IUnsandboxedCommandConfirmationRequest } from './copilotShellTools.js';
 import { toSdkCustomAgents, toSdkHooks, toSdkInstructionDirectories, toSdkMcpServers, toSdkSkillDirectories } from './copilotPluginConverters.js';
@@ -51,11 +52,13 @@ export const COPILOT_AGENT_HOST_SYSTEM_MESSAGE = {
 } satisfies NonNullable<ResumeSessionConfig['systemMessage']>;
 
 /**
- * Immutable snapshot of the active client's contributions at session creation
- * time. Used to detect when the session needs to be refreshed.
+ * Immutable snapshot of the active client's structural contributions at
+ * session creation time. Used to detect when the session needs to be
+ * refreshed. The owning `clientId` is deliberately NOT part of this snapshot:
+ * client identity is tracked live via {@link ActiveClientState} so a window
+ * reload (new `clientId`, identical tools/plugins) does not force a restart.
  */
 export interface IActiveClientSnapshot {
-	readonly clientId: string;
 	readonly tools: readonly ToolDefinition[];
 	readonly plugins: readonly ICopilotPluginInfo[];
 }
@@ -88,6 +91,13 @@ interface ICopilotSessionLaunchBase {
 	readonly workingDirectory: URI | undefined;
 	readonly resolvedAgentName: string | undefined;
 	readonly snapshot: IActiveClientSnapshot;
+	/**
+	 * Live, long-lived holder of the owning client's identity. Read at
+	 * tool-call stamp time so a window reload (new `clientId`, identical
+	 * tools) stamps subsequent client tool calls with the current id
+	 * rather than the one frozen into {@link snapshot} at creation.
+	 */
+	readonly activeClientState: ActiveClientState;
 	readonly shellManager: ShellManager | undefined;
 	readonly githubToken: string | undefined;
 }

--- a/src/vs/platform/agentHost/node/protocolServerHandler.ts
+++ b/src/vs/platform/agentHost/node/protocolServerHandler.ts
@@ -171,8 +171,7 @@ interface IClientRecord {
 	connection: IConnectedClient | undefined;
 	/**
 	 * Epoch ms the client was last seen connected (handshake or disconnect).
-	 * `undefined` when the client has never connected — e.g. the empty-id owner
-	 * of a tool call stamped while no client was connected. Drives the
+	 * `undefined` when the client has never connected. Drives the
 	 * disconnect-timeout grace window: a pending client tool call fails
 	 * `CLIENT_TOOL_CALL_DISCONNECT_TIMEOUT` ms after this point, never instantly
 	 * and never never.
@@ -279,13 +278,14 @@ export class ProtocolServerHandler extends Disposable {
 				this._replayBuffer.shift();
 			}
 			this._broadcastAction(envelope);
-			// A client tool call may be issued for a client that is not (or no
-			// longer) connected — e.g. a stale stamp from a window that
-			// reloaded, or a call stamped while no client is connected. The
+			// A client tool call may be issued for a client that is no longer
+			// connected — e.g. a stale stamp from a window that reloaded. The
 			// live-disconnect path (`_handleClientDisconnected`) does not cover
 			// these because no disconnect event fires for an already-gone
 			// client. Detect the orphan at issuance time and arm the same
-			// grace-period timeout so the call cannot hang forever.
+			// grace-period timeout so the call cannot hang forever. Calls
+			// stamped while no client is connected are failed immediately by
+			// the provider, so they never reach this path.
 			if (envelope.action.type === ActionType.SessionToolCallStart || envelope.action.type === ActionType.SessionToolCallReady) {
 				this._checkOrphanedClientToolCalls(envelope.channel);
 			}
@@ -753,13 +753,18 @@ export class ProtocolServerHandler extends Disposable {
 	 * delay is the remaining grace measured from when the client was last
 	 * seen — so a client that disconnected a while before the call was issued
 	 * gets the residual window rather than a fresh one, and a stamp from a
-	 * long-dead client fails promptly. A client never seen at all (or pruned)
-	 * gets the full grace window.
+	 * long-dead client fails promptly. A client never seen at all has its
+	 * grace clock pinned to the first arm, so re-arms triggered by later
+	 * orphaned tool calls in the same session shrink the remaining window
+	 * instead of resetting it.
 	 */
 	private _startClientToolCallDisconnectTimeout(clientId: string, session: string): void {
 		this._clearClientToolCallDisconnectTimeout(clientId, session);
 		const record = this._ensureClientRecord(clientId);
-		const elapsed = record.lastSeenAt !== undefined ? Date.now() - record.lastSeenAt : 0;
+		if (record.lastSeenAt === undefined) {
+			record.lastSeenAt = Date.now();
+		}
+		const elapsed = Date.now() - record.lastSeenAt;
 		const delay = Math.max(0, CLIENT_TOOL_CALL_DISCONNECT_TIMEOUT - elapsed);
 		record.disconnectTimeouts.set(session, disposableTimeout(() => {
 			record.disconnectTimeouts.deleteAndDispose(session);
@@ -768,19 +773,20 @@ export class ProtocolServerHandler extends Disposable {
 	}
 
 	/**
-	 * Scan a session for pending client tool calls whose owning client is
-	 * empty (no client connected at stamp time) or not currently connected,
-	 * and arm the disconnect timeout for each such owner. Called when a
-	 * `SessionToolCallStart` / `SessionToolCallReady` envelope is observed —
-	 * covering calls issued for an already-gone client, which the live
-	 * disconnect path never sees.
+	 * Scan a session for pending client tool calls whose owning client is not
+	 * currently connected, and arm the disconnect timeout for each such owner.
+	 * Called when a `SessionToolCallStart` / `SessionToolCallReady` envelope is
+	 * observed — covering calls issued for an already-gone client, which the
+	 * live disconnect path never sees. Ownerless client tool calls (no client
+	 * connected at stamp time) are failed immediately by the provider, so they
+	 * never reach a pending state here.
 	 */
 	private _checkOrphanedClientToolCalls(session: string): void {
 		const state = this._stateManager.getSessionState(session);
 		const orphanOwners = new Set<string>();
 		for (const { clientId } of this._pendingClientToolCalls(state)) {
 			const ownerRecord = this._clients.get(clientId);
-			if (clientId === '' || !ownerRecord || ownerRecord.connection === undefined) {
+			if (!ownerRecord || ownerRecord.connection === undefined) {
 				orphanOwners.add(clientId);
 			}
 		}
@@ -791,9 +797,7 @@ export class ProtocolServerHandler extends Disposable {
 
 	/**
 	 * Get the existing per-client record or create an empty one. A freshly
-	 * created record has no connection and `lastSeenAt === undefined`, so an
-	 * orphaned tool call stamped for an unknown/empty clientId gets the full
-	 * grace window.
+	 * created record has no connection and `lastSeenAt === undefined`.
 	 */
 	private _ensureClientRecord(clientId: string): IClientRecord {
 		let record = this._clients.get(clientId);
@@ -818,8 +822,8 @@ export class ProtocolServerHandler extends Disposable {
 	/**
 	 * Drop disconnected, timer-less client records whose last-seen time is
 	 * stale beyond the retention window (10× the disconnect timeout), plus
-	 * never-connected placeholder records (e.g. the empty-id orphan owner)
-	 * once their timeouts have fired. Bounds {@link _clients} without
+	 * never-connected placeholder records (e.g. a stamp from a long-dead
+	 * client) once their timeouts have fired. Bounds {@link _clients} without
 	 * tracking liveness precisely — a pruned-then-resurfacing stamp simply
 	 * falls back to the full grace window.
 	 */

--- a/src/vs/platform/agentHost/node/protocolServerHandler.ts
+++ b/src/vs/platform/agentHost/node/protocolServerHandler.ts
@@ -3,9 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { disposableTimeout } from '../../../base/common/async.js';
 import { Emitter } from '../../../base/common/event.js';
 import { isJsonRpcResponse } from '../../../base/common/jsonRpcProtocol.js';
-import { Disposable, DisposableStore } from '../../../base/common/lifecycle.js';
+import { Disposable, DisposableMap, DisposableStore } from '../../../base/common/lifecycle.js';
 import { hasKey } from '../../../base/common/types.js';
 import { URI } from '../../../base/common/uri.js';
 import { ILogService } from '../../log/common/log.js';
@@ -53,6 +54,13 @@ import {
 const REPLAY_BUFFER_CAPACITY = 1000;
 
 const CLIENT_TOOL_CALL_DISCONNECT_TIMEOUT = 30_000;
+
+/** A client tool call in any of these statuses is still awaiting its result. */
+function isPendingToolCallStatus(status: ToolCallStatus): boolean {
+	return status === ToolCallStatus.Streaming
+		|| status === ToolCallStatus.Running
+		|| status === ToolCallStatus.PendingConfirmation;
+}
 
 /** Build a JSON-RPC success response suitable for transport.send(). */
 function jsonRpcSuccess(id: number, result: unknown): JsonRpcResponse {
@@ -151,6 +159,36 @@ interface IConnectedClient {
 }
 
 /**
+ * Per-client server-side record, keyed by clientId in
+ * {@link ProtocolServerHandler._clients}. Unlike {@link IConnectedClient}, the
+ * record OUTLIVES the connection: when a client disconnects, `connection` is
+ * cleared to `undefined` but the record is retained (until pruned) so the
+ * tool-call disconnect-grace machinery can still compute the remaining window
+ * and hold any armed timeouts.
+ */
+interface IClientRecord {
+	/** Live connection while connected; `undefined` after disconnect (record retained for the grace window). */
+	connection: IConnectedClient | undefined;
+	/**
+	 * Epoch ms the client was last seen connected (handshake or disconnect).
+	 * `undefined` when the client has never connected — e.g. the empty-id owner
+	 * of a tool call stamped while no client was connected. Drives the
+	 * disconnect-timeout grace window: a pending client tool call fails
+	 * `CLIENT_TOOL_CALL_DISCONNECT_TIMEOUT` ms after this point, never instantly
+	 * and never never.
+	 */
+	lastSeenAt: number | undefined;
+	/**
+	 * Pending tool-call disconnect timeouts owned by this client, keyed by
+	 * session URI. Armed when the client owns a pending client tool call but is
+	 * not connected; fires a failing completion if it does not (re)connect
+	 * within the grace window. Disposing an entry (or the whole map) clears the
+	 * underlying timer.
+	 */
+	readonly disconnectTimeouts: DisposableMap<string>;
+}
+
+/**
  * Classifies a raw channel URI string into its {@link ChannelKind} and
  * returns the canonical URI to key subscriptions by. Returns `undefined`
  * when the channel is OTLP-flavoured but the URI does not parse into a
@@ -207,9 +245,14 @@ export interface IProtocolServerConfig {
  */
 export class ProtocolServerHandler extends Disposable {
 
-	private readonly _clients = new Map<string, IConnectedClient>();
+	/**
+	 * Per-client records keyed by clientId. Holds both connected clients
+	 * (`connection` set) and recently-disconnected ones retained for the
+	 * tool-call disconnect-grace window (`connection === undefined`). See
+	 * {@link IClientRecord}.
+	 */
+	private readonly _clients = new Map<string, IClientRecord>();
 	private readonly _replayBuffer: ActionEnvelope[] = [];
-	private readonly _clientToolCallDisconnectTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
 
 	private readonly _onDidChangeConnectionCount = this._register(new Emitter<number>());
 
@@ -236,6 +279,16 @@ export class ProtocolServerHandler extends Disposable {
 				this._replayBuffer.shift();
 			}
 			this._broadcastAction(envelope);
+			// A client tool call may be issued for a client that is not (or no
+			// longer) connected — e.g. a stale stamp from a window that
+			// reloaded, or a call stamped while no client is connected. The
+			// live-disconnect path (`_handleClientDisconnected`) does not cover
+			// these because no disconnect event fires for an already-gone
+			// client. Detect the orphan at issuance time and arm the same
+			// grace-period timeout so the call cannot hang forever.
+			if (envelope.action.type === ActionType.SessionToolCallStart || envelope.action.type === ActionType.SessionToolCallReady) {
+				this._checkOrphanedClientToolCalls(envelope.channel);
+			}
 		}));
 
 		this._register(this._stateManager.onDidEmitNotification(notification => {
@@ -344,7 +397,8 @@ export class ProtocolServerHandler extends Disposable {
 		}));
 
 		disposables.add(transport.onClose(() => {
-			if (client && this._clients.get(client.clientId) === client) {
+			const record = client ? this._clients.get(client.clientId) : undefined;
+			if (client && record && record.connection === client) {
 				this._logService.info(`[ProtocolServer] Client disconnected: ${client.clientId}, subscriptions=${client.subscriptions.size}`);
 				// Treat disconnect as an implicit unsubscribe of every channel the
 				// client held, so the server-side refcount can drop to zero and any
@@ -359,10 +413,11 @@ export class ProtocolServerHandler extends Disposable {
 					}
 				}
 				client.subscriptions.clear();
-				this._clients.delete(client.clientId);
+				record.connection = undefined;
+				record.lastSeenAt = Date.now();
 				this._rejectPendingReverseRequests(client.clientId);
 				this._handleClientDisconnected(client.clientId);
-				this._onDidChangeConnectionCount.fire(this._clients.size);
+				this._onDidChangeConnectionCount.fire(this._connectedClientCount);
 			}
 			disposables.dispose();
 		}));
@@ -407,8 +462,11 @@ export class ProtocolServerHandler extends Disposable {
 			subscriptions: new Map(),
 			disposables,
 		};
-		this._clients.set(params.clientId, client);
-		this._onDidChangeConnectionCount.fire(this._clients.size);
+		const record = this._ensureClientRecord(params.clientId);
+		record.connection = client;
+		record.lastSeenAt = Date.now();
+		this._pruneClientRecords();
+		this._onDidChangeConnectionCount.fire(this._connectedClientCount);
 
 		this._registerClientFileSystemAuthority(params.clientId, disposables);
 
@@ -521,8 +579,11 @@ export class ProtocolServerHandler extends Disposable {
 			subscriptions: new Map(),
 			disposables,
 		};
-		this._clients.set(params.clientId, client);
-		this._onDidChangeConnectionCount.fire(this._clients.size);
+		const record = this._ensureClientRecord(params.clientId);
+		record.connection = client;
+		record.lastSeenAt = Date.now();
+		this._pruneClientRecords();
+		this._onDidChangeConnectionCount.fire(this._connectedClientCount);
 
 		// Re-establish the reverse-RPC filesystem authority for this client.
 		// The prior transport's `onClose` disposed the previous registration,
@@ -645,48 +706,15 @@ export class ProtocolServerHandler extends Disposable {
 		}
 	}
 
-	private _hasPendingClientToolCall(state: ReturnType<AgentHostStateManager['getSessionState']>, clientId: string): boolean {
-		const activeTurn = state?.activeTurn;
-		if (!activeTurn) {
-			return false;
-		}
-		return activeTurn.responseParts.some(part => part.kind === ResponsePartKind.ToolCall
-			&& part.toolCall.contributor?.kind === ToolCallContributorKind.Client
-			&& part.toolCall.contributor.clientId === clientId
-			&& (part.toolCall.status === ToolCallStatus.Streaming || part.toolCall.status === ToolCallStatus.Running || part.toolCall.status === ToolCallStatus.PendingConfirmation));
-	}
-
-	private _hasReplacementActiveClientTool(state: SessionState, clientId: string, toolName: string): boolean {
-		const activeClient = state.activeClient;
-		return activeClient !== undefined
-			&& activeClient.clientId !== clientId
-			&& activeClient.tools.some(tool => tool.name === toolName);
-	}
-
-	private _startClientToolCallDisconnectTimeout(clientId: string, session: string): void {
-		this._clearClientToolCallDisconnectTimeout(clientId, session);
-		const key = this._clientToolCallDisconnectTimeoutKey(clientId, session);
-		this._clientToolCallDisconnectTimeouts.set(key, setTimeout(() => {
-			this._clientToolCallDisconnectTimeouts.delete(key);
-			this._completeDisconnectedClientToolCalls(clientId, session);
-		}, CLIENT_TOOL_CALL_DISCONNECT_TIMEOUT));
-	}
-
-	private _clearClientToolCallDisconnectTimeout(clientId: string, session: string): void {
-		const key = this._clientToolCallDisconnectTimeoutKey(clientId, session);
-		const timeout = this._clientToolCallDisconnectTimeouts.get(key);
-		if (timeout) {
-			clearTimeout(timeout);
-			this._clientToolCallDisconnectTimeouts.delete(key);
-		}
-	}
-
-	private _clientToolCallDisconnectTimeoutKey(clientId: string, session: string): string {
-		return `${clientId}\n${session}`;
-	}
-
-	private _completeDisconnectedClientToolCalls(clientId: string, session: string): void {
-		const state = this._stateManager.getSessionState(session);
+	/**
+	 * Yields every still-pending client-contributed tool call in `state`'s
+	 * active turn, paired with its owning `clientId`. Single source of truth
+	 * for the disconnect-grace machinery: detect ownership
+	 * ({@link _hasPendingClientToolCall}), arm timeouts
+	 * ({@link _checkOrphanedClientToolCalls}), and fail orphaned calls
+	 * ({@link _completeDisconnectedClientToolCalls}).
+	 */
+	private *_pendingClientToolCalls(state: SessionState | undefined) {
 		const activeTurn = state?.activeTurn;
 		if (!activeTurn) {
 			return;
@@ -696,30 +724,151 @@ export class ProtocolServerHandler extends Disposable {
 				continue;
 			}
 			const toolCall = part.toolCall;
-			const toolContributor = toolCall.contributor;
-			if (toolContributor?.kind === ToolCallContributorKind.Client && toolContributor.clientId === clientId && (toolCall.status === ToolCallStatus.Streaming || toolCall.status === ToolCallStatus.Running || toolCall.status === ToolCallStatus.PendingConfirmation)) {
-				const mayRetryWithReplacementClient = this._hasReplacementActiveClientTool(state, clientId, toolCall.toolName);
-				if (toolCall.status === ToolCallStatus.Streaming) {
-					this._stateManager.dispatchServerAction(session, {
-						type: ActionType.SessionToolCallReady,
-						turnId: activeTurn.id,
-						toolCallId: toolCall.toolCallId,
-						invocationMessage: toolCall.invocationMessage ?? toolCall.displayName,
-						confirmed: ToolCallConfirmationReason.NotNeeded,
-					});
-				}
+			const contributor = toolCall.contributor;
+			if (contributor?.kind === ToolCallContributorKind.Client && isPendingToolCallStatus(toolCall.status)) {
+				yield { toolCall, clientId: contributor.clientId };
+			}
+		}
+	}
+
+	private _hasPendingClientToolCall(state: SessionState | undefined, clientId: string): boolean {
+		for (const pending of this._pendingClientToolCalls(state)) {
+			if (pending.clientId === clientId) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private _hasReplacementActiveClientTool(state: SessionState, clientId: string, toolName: string): boolean {
+		const activeClient = state.activeClient;
+		return activeClient !== undefined
+			&& activeClient.clientId !== clientId
+			&& activeClient.tools.some(tool => tool.name === toolName);
+	}
+
+	/**
+	 * Arm (or re-arm) the per-(clientId, session) timeout that fails pending
+	 * client tool calls owned by `clientId` if it does not (re)connect. The
+	 * delay is the remaining grace measured from when the client was last
+	 * seen — so a client that disconnected a while before the call was issued
+	 * gets the residual window rather than a fresh one, and a stamp from a
+	 * long-dead client fails promptly. A client never seen at all (or pruned)
+	 * gets the full grace window.
+	 */
+	private _startClientToolCallDisconnectTimeout(clientId: string, session: string): void {
+		this._clearClientToolCallDisconnectTimeout(clientId, session);
+		const record = this._ensureClientRecord(clientId);
+		const elapsed = record.lastSeenAt !== undefined ? Date.now() - record.lastSeenAt : 0;
+		const delay = Math.max(0, CLIENT_TOOL_CALL_DISCONNECT_TIMEOUT - elapsed);
+		record.disconnectTimeouts.set(session, disposableTimeout(() => {
+			record.disconnectTimeouts.deleteAndDispose(session);
+			this._completeDisconnectedClientToolCalls(clientId, session);
+		}, delay));
+	}
+
+	/**
+	 * Scan a session for pending client tool calls whose owning client is
+	 * empty (no client connected at stamp time) or not currently connected,
+	 * and arm the disconnect timeout for each such owner. Called when a
+	 * `SessionToolCallStart` / `SessionToolCallReady` envelope is observed —
+	 * covering calls issued for an already-gone client, which the live
+	 * disconnect path never sees.
+	 */
+	private _checkOrphanedClientToolCalls(session: string): void {
+		const state = this._stateManager.getSessionState(session);
+		const orphanOwners = new Set<string>();
+		for (const { clientId } of this._pendingClientToolCalls(state)) {
+			const ownerRecord = this._clients.get(clientId);
+			if (clientId === '' || !ownerRecord || ownerRecord.connection === undefined) {
+				orphanOwners.add(clientId);
+			}
+		}
+		for (const ownerId of orphanOwners) {
+			this._startClientToolCallDisconnectTimeout(ownerId, session);
+		}
+	}
+
+	/**
+	 * Get the existing per-client record or create an empty one. A freshly
+	 * created record has no connection and `lastSeenAt === undefined`, so an
+	 * orphaned tool call stamped for an unknown/empty clientId gets the full
+	 * grace window.
+	 */
+	private _ensureClientRecord(clientId: string): IClientRecord {
+		let record = this._clients.get(clientId);
+		if (!record) {
+			record = { connection: undefined, lastSeenAt: undefined, disconnectTimeouts: new DisposableMap() };
+			this._clients.set(clientId, record);
+		}
+		return record;
+	}
+
+	/** Number of records that currently hold a live connection. */
+	private get _connectedClientCount(): number {
+		let count = 0;
+		for (const record of this._clients.values()) {
+			if (record.connection) {
+				count++;
+			}
+		}
+		return count;
+	}
+
+	/**
+	 * Drop disconnected, timer-less client records whose last-seen time is
+	 * stale beyond the retention window (10× the disconnect timeout), plus
+	 * never-connected placeholder records (e.g. the empty-id orphan owner)
+	 * once their timeouts have fired. Bounds {@link _clients} without
+	 * tracking liveness precisely — a pruned-then-resurfacing stamp simply
+	 * falls back to the full grace window.
+	 */
+	private _pruneClientRecords(): void {
+		const cutoff = Date.now() - CLIENT_TOOL_CALL_DISCONNECT_TIMEOUT * 10;
+		for (const [clientId, record] of this._clients) {
+			if (record.connection === undefined
+				&& record.disconnectTimeouts.size === 0
+				&& (record.lastSeenAt === undefined || record.lastSeenAt < cutoff)) {
+				this._clients.delete(clientId);
+			}
+		}
+	}
+
+	private _clearClientToolCallDisconnectTimeout(clientId: string, session: string): void {
+		this._clients.get(clientId)?.disconnectTimeouts.deleteAndDispose(session);
+	}
+
+	private _completeDisconnectedClientToolCalls(clientId: string, session: string): void {
+		const state = this._stateManager.getSessionState(session);
+		const activeTurn = state?.activeTurn;
+		if (!state || !activeTurn) {
+			return;
+		}
+		for (const { toolCall, clientId: ownerId } of this._pendingClientToolCalls(state)) {
+			if (ownerId !== clientId) {
+				continue;
+			}
+			const mayRetryWithReplacementClient = this._hasReplacementActiveClientTool(state, clientId, toolCall.toolName);
+			if (toolCall.status === ToolCallStatus.Streaming) {
 				this._stateManager.dispatchServerAction(session, {
-					type: ActionType.SessionToolCallComplete,
+					type: ActionType.SessionToolCallReady,
 					turnId: activeTurn.id,
 					toolCallId: toolCall.toolCallId,
-					result: {
-						success: false,
-						pastTenseMessage: `${toolCall.displayName} failed`,
-						...(mayRetryWithReplacementClient ? { content: [{ type: ToolResultContentType.Text, text: `The client that was running ${toolCall.displayName} disconnected, but another active client now provides ${toolCall.displayName}. You may try calling the tool again.` }] } : {}),
-						error: { message: `Client ${clientId} disconnected before completing ${toolCall.displayName}` },
-					},
+					invocationMessage: toolCall.invocationMessage ?? toolCall.displayName,
+					confirmed: ToolCallConfirmationReason.NotNeeded,
 				});
 			}
+			this._stateManager.dispatchServerAction(session, {
+				type: ActionType.SessionToolCallComplete,
+				turnId: activeTurn.id,
+				toolCallId: toolCall.toolCallId,
+				result: {
+					success: false,
+					pastTenseMessage: `${toolCall.displayName} failed`,
+					...(mayRetryWithReplacementClient ? { content: [{ type: ToolResultContentType.Text, text: `The client that was running ${toolCall.displayName} disconnected, but another active client now provides ${toolCall.displayName}. You may try calling the tool again.` }] } : {}),
+					error: { message: `Client ${clientId} disconnected before completing ${toolCall.displayName}` },
+				},
+			});
 		}
 	}
 
@@ -957,7 +1106,7 @@ export class ProtocolServerHandler extends Disposable {
 	 * Rejects if the client disconnects or the server is disposed.
 	 */
 	private _sendReverseRequest<T>(clientId: string, method: string, params: unknown): Promise<T> {
-		const client = this._clients.get(clientId);
+		const client = this._clients.get(clientId)?.connection;
 		if (!client) {
 			return Promise.reject(new Error(`Client ${clientId} is not connected`));
 		}
@@ -1028,8 +1177,9 @@ export class ProtocolServerHandler extends Disposable {
 	private _broadcastAction(envelope: ActionEnvelope): void {
 		this._logService.trace(`[ProtocolServer] Broadcasting action: ${envelope.action.type}`);
 		const msg: AhpServerNotification<'action'> = { jsonrpc: '2.0', method: 'action', params: envelope };
-		for (const client of this._clients.values()) {
-			if (this._isRelevantToClient(client, envelope)) {
+		for (const record of this._clients.values()) {
+			const client = record.connection;
+			if (client && this._isRelevantToClient(client, envelope)) {
 				client.transport.send(msg);
 			}
 		}
@@ -1042,8 +1192,8 @@ export class ProtocolServerHandler extends Disposable {
 		const { type, ...params } = notification;
 		// eslint-disable-next-line local/code-no-dangerous-type-assertions
 		const msg = { jsonrpc: '2.0', method: type, params } as AhpServerNotification;
-		for (const client of this._clients.values()) {
-			client.transport.send(msg);
+		for (const record of this._clients.values()) {
+			record.connection?.transport.send(msg);
 		}
 	}
 
@@ -1081,7 +1231,11 @@ export class ProtocolServerHandler extends Disposable {
 	 */
 	private _broadcastOtlpLog(record: IOtlpLogRecord): void {
 		const payload = toResourceLogsPayload(record);
-		for (const client of this._clients.values()) {
+		for (const clientRecord of this._clients.values()) {
+			const client = clientRecord.connection;
+			if (!client) {
+				continue;
+			}
 			for (const sub of client.subscriptions.values()) {
 				if (sub.kind !== ChannelKind.OtlpLogs) {
 					continue;
@@ -1118,18 +1272,15 @@ export class ProtocolServerHandler extends Disposable {
 	}
 
 	override dispose(): void {
-		for (const client of this._clients.values()) {
-			client.disposables.dispose();
+		for (const record of this._clients.values()) {
+			record.connection?.disposables.dispose();
+			record.disconnectTimeouts.dispose();
 		}
 		this._clients.clear();
 		for (const [, pending] of this._pendingReverseRequests) {
 			pending.reject(new Error('ProtocolServerHandler disposed'));
 		}
 		this._pendingReverseRequests.clear();
-		for (const timeout of this._clientToolCallDisconnectTimeouts.values()) {
-			clearTimeout(timeout);
-		}
-		this._clientToolCallDisconnectTimeouts.clear();
 		this._replayBuffer.length = 0;
 		super.dispose();
 	}

--- a/src/vs/platform/agentHost/test/common/pendingRequestRegistry.test.ts
+++ b/src/vs/platform/agentHost/test/common/pendingRequestRegistry.test.ts
@@ -78,4 +78,42 @@ suite('PendingRequestRegistry', () => {
 		assert.strictEqual(registry.respond('a', 'x'), false);
 		assert.strictEqual(registry.respond('b', 'y'), false);
 	});
+
+	test('respondOrBuffer: result arriving before register resolves the subsequent register', async () => {
+		const registry = new PendingRequestRegistry<string>();
+		// Completion races ahead of the awaiting handler.
+		registry.respondOrBuffer('k', 'early');
+		// The handler registers afterwards and resolves immediately from the buffer.
+		assert.strictEqual(await registry.register('k'), 'early');
+		// Buffer consumed exactly once: a fresh register parks a new deferred.
+		const pending = registry.register('k');
+		let settled = false;
+		void pending.then(() => { settled = true; });
+		await Promise.resolve();
+		assert.strictEqual(settled, false);
+		registry.respondOrBuffer('k', 'second');
+		assert.strictEqual(await pending, 'second');
+	});
+
+	test('respondOrBuffer behaves like respond when a deferred is already parked', async () => {
+		const registry = new PendingRequestRegistry<string>();
+		const promise = registry.register('k');
+		registry.respondOrBuffer('k', 'value');
+		assert.strictEqual(await promise, 'value');
+	});
+
+	test('rejectAll clears buffered early results', async () => {
+		const registry = new PendingRequestRegistry<string>();
+		registry.respondOrBuffer('k', 'early');
+		registry.rejectAll(new Error('cancelled'));
+		// Buffer dropped: a later register parks a fresh deferred rather than
+		// resolving from the stale buffered value.
+		const pending = registry.register('k');
+		let settled = false;
+		void pending.then(() => { settled = true; });
+		await Promise.resolve();
+		assert.strictEqual(settled, false);
+		registry.respondOrBuffer('k', 'fresh');
+		assert.strictEqual(await pending, 'fresh');
+	});
 });

--- a/src/vs/platform/agentHost/test/common/pendingRequestRegistry.test.ts
+++ b/src/vs/platform/agentHost/test/common/pendingRequestRegistry.test.ts
@@ -102,6 +102,23 @@ suite('PendingRequestRegistry', () => {
 		assert.strictEqual(await promise, 'value');
 	});
 
+	test('respondOrBuffer: a buffered `undefined` value still resolves a subsequent register', async () => {
+		// Guards against the `get() !== undefined` sentinel bug: when T includes
+		// undefined, a buffered undefined must be distinguished from "no entry"
+		// so register() resolves immediately instead of parking and hanging.
+		const registry = new PendingRequestRegistry<string | undefined>();
+		registry.respondOrBuffer('k', undefined);
+		assert.strictEqual(await registry.register('k'), undefined);
+		// Buffer consumed exactly once: a fresh register parks a new deferred.
+		const pending = registry.register('k');
+		let settled = false;
+		void pending.then(() => { settled = true; });
+		await Promise.resolve();
+		assert.strictEqual(settled, false);
+		registry.respondOrBuffer('k', 'second');
+		assert.strictEqual(await pending, 'second');
+	});
+
 	test('rejectAll clears buffered early results', async () => {
 		const registry = new PendingRequestRegistry<string>();
 		registry.respondOrBuffer('k', 'early');

--- a/src/vs/platform/agentHost/test/node/clientTools/claudeSessionClientToolsModel.test.ts
+++ b/src/vs/platform/agentHost/test/node/clientTools/claudeSessionClientToolsModel.test.ts
@@ -111,12 +111,16 @@ suite('SessionClientToolsDiff', () => {
 		assert.strictEqual(diff.model.state.get().clientId, 'c2');
 	});
 
-	test('clientId change alone flips dirty', () => {
+	test('clientId change alone does NOT flip dirty (same tools, new window)', () => {
 		const diff = disposables.add(new SessionClientToolsDiff());
 		diff.model.setTools([tool()], 'c1');
 		diff.consume();
 		assert.strictEqual(diff.hasDifference, false);
+		// A window reload re-pushes identical tools under a new clientId. The
+		// observable still updates clientId, but no SDK yield-restart is
+		// required — only structural tool changes flip the dirty bit.
 		diff.model.setTools([tool()], 'c2');
-		assert.strictEqual(diff.hasDifference, true);
+		assert.strictEqual(diff.hasDifference, false);
+		assert.strictEqual(diff.model.state.get().clientId, 'c2');
 	});
 });

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -1273,7 +1273,7 @@ suite('CopilotAgent', () => {
 	suite('client tool refresh on reload (#319516)', () => {
 		/** Minimal structural view of the agent's private per-session ActiveClient. */
 		type TestActiveClient = {
-			readonly state: { readonly clientId: string };
+			readonly state: { readonly clientId: string | undefined };
 			snapshot(): Promise<IActiveClientSnapshot>;
 			requiresRestart(snap: IActiveClientSnapshot): Promise<boolean>;
 		};

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -32,7 +32,7 @@ import { AgentSession, GITHUB_COPILOT_PROTECTED_RESOURCE, type AgentSignal, type
 import { ISessionDataService } from '../../common/sessionDataService.js';
 import { AHP_AUTH_REQUIRED, ProtocolError } from '../../common/state/sessionProtocol.js';
 import { buildSubagentSessionUri, CustomizationLoadStatus, MessageKind, ResponsePartKind, ToolCallConfirmationReason, ToolCallStatus, TurnState, customizationId, type ClientPluginCustomization, type MarkdownResponsePart, type PluginCustomization, type ToolCallResult, type Turn, RuleCustomization } from '../../common/state/sessionState.js';
-import { CustomizationType } from '../../common/state/protocol/state.js';
+import { CustomizationType, type ToolDefinition } from '../../common/state/protocol/state.js';
 import { ActionType, type IDeltaAction, type SessionAction } from '../../common/state/sessionActions.js';
 
 import { AgentConfigurationService, IAgentConfigurationService } from '../../node/agentConfigurationService.js';
@@ -44,10 +44,11 @@ import { AgentHostCompletions, IAgentHostCompletions } from '../../node/agentHos
 import { COPILOT_AGENT_HOST_SYSTEM_MESSAGE, CopilotAgent, getCopilotBranchNameHintFromMessage, getCopilotWorktreeBranchName, getCopilotWorktreeName, getCopilotWorktreesRoot } from '../../node/copilot/copilotAgent.js';
 import { NULL_CHECKPOINT_SERVICE } from '../../common/agentHostCheckpointService.js';
 import { CopilotAgentSession } from '../../node/copilot/copilotAgentSession.js';
-import type { CopilotSessionLaunchPlan } from '../../node/copilot/copilotSessionLauncher.js';
+import type { CopilotSessionLaunchPlan, IActiveClientSnapshot } from '../../node/copilot/copilotSessionLauncher.js';
 import { ShellManager } from '../../node/copilot/copilotShellTools.js';
 import { SessionDatabase } from '../../node/sessionDatabase.js';
 import { createNullSessionDataService } from '../common/sessionTestHelpers.js';
+import { ActiveClientState } from '../../node/activeClientState.js';
 
 class TestAgentPluginManager implements IAgentPluginManager {
 	declare readonly _serviceBrand: undefined;
@@ -397,10 +398,11 @@ function createAgentSessionThroughAgent(agent: CopilotAgent, instantiationServic
 			},
 			resumeSession: async () => new MockCopilotSession() as unknown as CopilotSession,
 		},
+		activeClientState: new ActiveClientState(),
 		sessionId: 'test-session-1',
 		workingDirectory: undefined,
 		resolvedAgentName: undefined,
-		snapshot: { clientId: '', tools: [], plugins: [] },
+		snapshot: { tools: [], plugins: [] },
 		shellManager,
 		githubToken: 'token',
 		model: undefined,
@@ -1255,6 +1257,76 @@ suite('CopilotAgent', () => {
 				const sessionUri = AgentSession.uri('copilotcli', 'session-missing');
 				// No stub installed — the call should be silently ignored.
 				agent.onClientToolCallComplete(sessionUri, 'tc-x', { success: true, pastTenseMessage: 'noop' });
+			} finally {
+				await disposeAgent(agent);
+			}
+		});
+	});
+
+	// Regression for the #319516 incident: a window reload reconnects with a
+	// NEW clientId but an identical tool list. The cached SDK session's
+	// staleness check (`ActiveClient.requiresRestart`) must NOT treat a
+	// clientId-only change as a config change — otherwise either the session
+	// is needlessly restarted, or (the actual bug) the cached session is
+	// reused while the live clientId is never updated, so subsequent client
+	// tool calls are stamped with the dead window's id and hang forever.
+	suite('client tool refresh on reload (#319516)', () => {
+		/** Minimal structural view of the agent's private per-session ActiveClient. */
+		type TestActiveClient = {
+			readonly state: { readonly clientId: string };
+			snapshot(): Promise<IActiveClientSnapshot>;
+			requiresRestart(snap: IActiveClientSnapshot): Promise<boolean>;
+		};
+
+		function getActiveClient(agent: CopilotAgent, session: URI): TestActiveClient {
+			const activeClients = (agent as unknown as { _activeClients: { get(s: URI): TestActiveClient | undefined } })._activeClients;
+			const activeClient = activeClients.get(session);
+			assert.ok(activeClient, 'expected an ActiveClient to exist after setClientTools');
+			return activeClient;
+		}
+
+		const tools: ToolDefinition[] = [{ name: 'my_tool', description: 'A test tool', inputSchema: { type: 'object', properties: {} } }];
+
+		test('clientId-only change (reload) does NOT require a restart and updates the live clientId', async () => {
+			const agent = createTestAgent(disposables);
+			try {
+				const session = AgentSession.uri('copilotcli', 'reload-session');
+
+				// Window A registers its tools; this is the snapshot the SDK
+				// session would be created with.
+				agent.setClientTools(session, 'client-A', tools);
+				const activeClient = getActiveClient(agent, session);
+				const appliedSnapshot = await activeClient.snapshot();
+				assert.strictEqual(activeClient.state.clientId, 'client-A');
+
+				// Window A reloads: window B reconnects with a new clientId but
+				// the identical tool list.
+				agent.setClientTools(session, 'client-B', [...tools]);
+
+				// Root-cause assertions: the cached SDK session must be reused
+				// (no restart) AND the live clientId must now be window B's, so
+				// the next client tool call is stamped with a live owner.
+				assert.strictEqual(await activeClient.requiresRestart(appliedSnapshot), false);
+				assert.strictEqual(activeClient.state.clientId, 'client-B');
+			} finally {
+				await disposeAgent(agent);
+			}
+		});
+
+		test('a structural tool change still requires a restart', async () => {
+			const agent = createTestAgent(disposables);
+			try {
+				const session = AgentSession.uri('copilotcli', 'tools-change-session');
+
+				agent.setClientTools(session, 'client-A', tools);
+				const activeClient = getActiveClient(agent, session);
+				const appliedSnapshot = await activeClient.snapshot();
+
+				// A genuinely different tool set (added tool) must restart so the
+				// SDK session is rebuilt with the new tools.
+				agent.setClientTools(session, 'client-A', [...tools, { name: 'second_tool', description: 'another', inputSchema: { type: 'object', properties: {} } }]);
+
+				assert.strictEqual(await activeClient.requiresRestart(appliedSnapshot), true);
 			} finally {
 				await disposeAgent(agent);
 			}

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -26,6 +26,7 @@ import { ISessionDataService } from '../../common/sessionDataService.js';
 import { ActionType, type SessionDeltaAction, type SessionErrorAction, type SessionInputRequestedAction, type SessionResponsePartAction, type SessionToolCallCompleteAction, type SessionToolCallReadyAction, type SessionToolCallStartAction, type SessionTurnCompleteAction } from '../../common/state/sessionActions.js';
 import { MessageAttachmentKind, MessageKind, ResponsePartKind, SessionInputAnswerState, SessionInputAnswerValueKind, SessionInputQuestionKind, SessionInputResponseKind, ToolCallContributorKind, ToolCallStatus, ToolResultContentType, type ToolResultFileEditContent } from '../../common/state/sessionState.js';
 import { CopilotAgentSession } from '../../node/copilot/copilotAgentSession.js';
+import { ActiveClientState } from '../../node/activeClientState.js';
 import { type CopilotSessionLaunchPlan, type IActiveClientSnapshot, type ICopilotSessionLauncher, type ICopilotSessionRuntime } from '../../node/copilot/copilotSessionLauncher.js';
 import { CopilotSessionWrapper } from '../../node/copilot/copilotSessionWrapper.js';
 import { buildCopilotSystemNotification } from '../../node/copilot/copilotSystemNotification.js';
@@ -169,9 +170,8 @@ type ISessionInternalsForTest = {
 		takeCompletedEdit(turnId: string, toolCallId: string, path: string): Promise<ToolResultFileEditContent | undefined>;
 	};
 	_pendingClientToolCalls: {
-		get(toolCallId: string): DeferredPromise<ToolResultObject> | undefined;
-		set(toolCallId: string, value: DeferredPromise<ToolResultObject>): Map<string, DeferredPromise<ToolResultObject>>;
-		delete(toolCallId: string): boolean;
+		register(toolCallId: string): Promise<ToolResultObject>;
+		respondOrBuffer(toolCallId: string, value: ToolResultObject): void;
 	};
 };
 
@@ -194,6 +194,7 @@ function getInputRequest(signal: AgentSignal): SessionInputRequestedAction['requ
 
 async function createAgentSession(disposables: DisposableStore, options?: {
 	clientSnapshot?: IActiveClientSnapshot;
+	activeClientState?: ActiveClientState;
 	environmentServiceRegistration?: 'native' | 'none';
 	logService?: ILogService;
 	telemetryService?: ITelemetryService;
@@ -245,10 +246,11 @@ async function createAgentSession(disposables: DisposableStore, options?: {
 			createSession: async () => mockSession as unknown as CopilotSession,
 			resumeSession: async () => mockSession as unknown as CopilotSession,
 		},
+		activeClientState: new ActiveClientState(),
 		sessionId: 'test-session-1',
 		workingDirectory: options?.workingDirectory,
 		resolvedAgentName: undefined,
-		snapshot: options?.clientSnapshot ?? { clientId: '', tools: [], plugins: [] },
+		snapshot: options?.clientSnapshot ?? { tools: [], plugins: [] },
 		shellManager: undefined,
 		githubToken: undefined,
 		model: undefined,
@@ -316,6 +318,7 @@ async function createAgentSession(disposables: DisposableStore, options?: {
 			launchPlan,
 			shellManager: undefined,
 			clientSnapshot: options?.clientSnapshot,
+			activeClientState: options?.activeClientState,
 			workingDirectory: options?.workingDirectory,
 		},
 	));
@@ -1365,7 +1368,6 @@ suite('CopilotAgentSession', () => {
 			const { mockSession } = await createAgentSession(disposables, {
 				telemetryService,
 				clientSnapshot: {
-					clientId: 'test-client',
 					tools: [{ name: 'my_tool', description: 'A test tool', inputSchema: { type: 'object', properties: {} } }],
 					plugins: [],
 				},
@@ -2465,7 +2467,6 @@ suite('CopilotAgentSession', () => {
 	suite('client tool calls', () => {
 
 		const snapshot: IActiveClientSnapshot = {
-			clientId: 'test-client',
 			tools: [{
 				name: 'my_tool',
 				description: 'A test tool',
@@ -2474,8 +2475,15 @@ suite('CopilotAgentSession', () => {
 			plugins: [],
 		};
 
+		/** Builds a live ActiveClientState seeded with the given owning clientId and the snapshot's tools. */
+		const activeClientStateWith = (clientId: string): ActiveClientState => {
+			const state = new ActiveClientState();
+			state.update(clientId, snapshot.tools);
+			return state;
+		};
+
 		test('client tool handler waits for completion without emitting tool_ready', async () => {
-			const { session, runtime, mockSession, signals } = await createAgentSession(disposables, { clientSnapshot: snapshot });
+			const { session, runtime, mockSession, signals } = await createAgentSession(disposables, { clientSnapshot: snapshot, activeClientState: activeClientStateWith('test-client') });
 
 			// SDK emits tool.execution_start — tool_start fires immediately
 			mockSession.fire('tool.execution_start', {
@@ -2691,7 +2699,7 @@ suite('CopilotAgentSession', () => {
 			const { session, runtime } = await createAgentSession(disposables, { clientSnapshot: snapshot, logService });
 			const tools = runtime.createClientSdkTools();
 			const sessionInternals = session as unknown as ISessionInternalsForTest;
-			sessionInternals._pendingClientToolCalls.get = () => {
+			sessionInternals._pendingClientToolCalls.register = () => {
 				throw new Error('client tool boom');
 			};
 
@@ -2755,6 +2763,48 @@ suite('CopilotAgentSession', () => {
 			assert.strictEqual(result.resultType, 'success');
 			// Text content should be extracted
 			assert.strictEqual(result.textResultForLlm, 'text part');
+		});
+
+		test('client tool start stamps the LIVE clientId from the shared ActiveClientState', async () => {
+			const activeClientState = new ActiveClientState();
+			activeClientState.update('client-A', snapshot.tools);
+			const { mockSession, signals } = await createAgentSession(disposables, { clientSnapshot: snapshot, activeClientState });
+
+			mockSession.fire('tool.execution_start', {
+				toolCallId: 'tc-live-1',
+				toolName: 'my_tool',
+				arguments: {},
+			} as SessionEventPayload<'tool.execution_start'>['data']);
+
+			// A window reload re-pushes the same tools under a new clientId.
+			activeClientState.update('client-B', snapshot.tools);
+			mockSession.fire('tool.execution_start', {
+				toolCallId: 'tc-live-2',
+				toolName: 'my_tool',
+				arguments: {},
+			} as SessionEventPayload<'tool.execution_start'>['data']);
+
+			const starts = signals.filter((s): s is IAgentActionSignal => isAction(s, ActionType.SessionToolCallStart));
+			assert.deepStrictEqual(starts.map(s => (s.action as SessionToolCallStartAction).contributor), [
+				{ kind: ToolCallContributorKind.Client, clientId: 'client-A' },
+				{ kind: ToolCallContributorKind.Client, clientId: 'client-B' },
+			]);
+		});
+
+		test('completion arriving before the SDK handler registers still resolves', async () => {
+			const { session, runtime } = await createAgentSession(disposables, { clientSnapshot: snapshot });
+			const tools = runtime.createClientSdkTools();
+
+			// Completion races ahead of the handler.
+			session.handleClientToolCallComplete('tc-early', {
+				success: true,
+				pastTenseMessage: 'done',
+				content: [{ type: ToolResultContentType.Text, text: 'buffered result' }],
+			});
+
+			const result = await invokeClientToolHandler(tools[0], 'tc-early');
+			assert.strictEqual(result.resultType, 'success');
+			assert.strictEqual(result.textResultForLlm, 'buffered result');
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -2500,7 +2500,7 @@ suite('CopilotAgentSession', () => {
 			// tool_start is stamped as a client contributor with no owner...
 			const startSignal = signals.find(s => isAction(s, ActionType.SessionToolCallStart));
 			assert.ok(startSignal && isAction(startSignal, ActionType.SessionToolCallStart));
-			assert.deepStrictEqual((startSignal.action as SessionToolCallStartAction).contributor, { kind: ToolCallContributorKind.Client, clientId: undefined });
+			assert.deepStrictEqual((startSignal.action as SessionToolCallStartAction).contributor, undefined);
 
 			// ...and is failed immediately (ready + complete) rather than left
 			// pending for the server-side disconnect timeout.

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -1365,7 +1365,7 @@ suite('CopilotAgentSession', () => {
 
 		test('client tool telemetry does not use clientId as toolExtensionId', async () => {
 			const telemetryService = new RecordingTelemetryService();
-			const tools = [{ name: 'my_tool', description: 'A test tool', inputSchema: { type: 'object', properties: {} } }];
+			const tools = [{ name: 'my_tool', description: 'A test tool', inputSchema: { type: 'object', properties: {} } }] as const;
 			const activeClientState = new ActiveClientState();
 			activeClientState.update('test-client', tools);
 			const { mockSession } = await createAgentSession(disposables, {

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -1365,12 +1365,16 @@ suite('CopilotAgentSession', () => {
 
 		test('client tool telemetry does not use clientId as toolExtensionId', async () => {
 			const telemetryService = new RecordingTelemetryService();
+			const tools = [{ name: 'my_tool', description: 'A test tool', inputSchema: { type: 'object', properties: {} } }];
+			const activeClientState = new ActiveClientState();
+			activeClientState.update('test-client', tools);
 			const { mockSession } = await createAgentSession(disposables, {
 				telemetryService,
 				clientSnapshot: {
-					tools: [{ name: 'my_tool', description: 'A test tool', inputSchema: { type: 'object', properties: {} } }],
+					tools,
 					plugins: [],
 				},
+				activeClientState,
 			});
 
 			mockSession.fire('tool.execution_start', {
@@ -2482,7 +2486,38 @@ suite('CopilotAgentSession', () => {
 			return state;
 		};
 
+		test('client tool started with no connected client fails immediately', async () => {
+			// No activeClientState is provided, so the session seeds one with
+			// an undefined clientId — i.e. no client is connected to run the tool.
+			const { runtime, mockSession, signals } = await createAgentSession(disposables, { clientSnapshot: snapshot });
+
+			mockSession.fire('tool.execution_start', {
+				toolCallId: 'tc-no-client',
+				toolName: 'my_tool',
+				arguments: {},
+			} as SessionEventPayload<'tool.execution_start'>['data']);
+
+			// tool_start is stamped as a client contributor with no owner...
+			const startSignal = signals.find(s => isAction(s, ActionType.SessionToolCallStart));
+			assert.ok(startSignal && isAction(startSignal, ActionType.SessionToolCallStart));
+			assert.deepStrictEqual((startSignal.action as SessionToolCallStartAction).contributor, { kind: ToolCallContributorKind.Client, clientId: undefined });
+
+			// ...and is failed immediately (ready + complete) rather than left
+			// pending for the server-side disconnect timeout.
+			assert.strictEqual(signals.filter(s => isAction(s, ActionType.SessionToolCallReady)).length, 1);
+			const completeSignal = signals.find(s => isAction(s, ActionType.SessionToolCallComplete));
+			assert.ok(completeSignal && isAction(completeSignal, ActionType.SessionToolCallComplete));
+			assert.strictEqual((completeSignal.action as SessionToolCallCompleteAction).result.success, false);
+
+			// When the SDK invokes the handler it resolves immediately with the
+			// buffered failure result.
+			const tools = runtime.createClientSdkTools();
+			const result = await invokeClientToolHandler(tools[0], 'tc-no-client');
+			assert.strictEqual(result.resultType, 'failure');
+		});
+
 		test('client tool handler waits for completion without emitting tool_ready', async () => {
+
 			const { session, runtime, mockSession, signals } = await createAgentSession(disposables, { clientSnapshot: snapshot, activeClientState: activeClientStateWith('test-client') });
 
 			// SDK emits tool.execution_start — tool_start fires immediately
@@ -2574,7 +2609,7 @@ suite('CopilotAgentSession', () => {
 			// SessionToolCallReady to the subagent session and emits a
 			// stray ready against the parent session (no preceding
 			// SessionToolCallStart).
-			const { session, runtime, mockSession, signals, waitForSignal } = await createAgentSession(disposables, { clientSnapshot: snapshot });
+			const { session, runtime, mockSession, signals, waitForSignal } = await createAgentSession(disposables, { clientSnapshot: snapshot, activeClientState: activeClientStateWith('test-client') });
 
 			mockSession.fire('subagent.started', {
 				toolCallId: 'tc-parent-subagent',

--- a/src/vs/platform/agentHost/test/node/protocolServerHandler.test.ts
+++ b/src/vs/platform/agentHost/test/node/protocolServerHandler.test.ts
@@ -1118,39 +1118,6 @@ suite('ProtocolServerHandler', () => {
 		});
 	});
 
-	test('client tool call stamped with an empty clientId fails after the grace period', () => {
-		return runWithFakedTimers({ useFakeTimers: true }, async () => {
-			stateManager.createSession(makeSessionSummary());
-			stateManager.dispatchServerAction(sessionUri, { type: ActionType.SessionReady, });
-			stateManager.dispatchServerAction(sessionUri, {
-				type: ActionType.SessionTurnStarted,
-				turnId: 'turn-1',
-				message: { text: 'run it', origin: { kind: MessageKind.User } },
-			});
-			// A client tool issued while no client was connected is stamped as
-			// a Client contributor with an empty id (Copilot orphan path).
-			stateManager.dispatchServerAction(sessionUri, {
-				type: ActionType.SessionToolCallStart,
-				turnId: 'turn-1',
-				toolCallId: 'tool-1',
-				toolName: 'runTask',
-				displayName: 'Run Task',
-				contributor: { kind: ToolCallContributorKind.Client, clientId: '' },
-			});
-
-			await new Promise(r => setTimeout(r, 30_001));
-
-			const part = stateManager.getSessionState(sessionUri)?.activeTurn?.responseParts[0];
-			assert.deepStrictEqual(part?.kind === ResponsePartKind.ToolCall ? {
-				status: part.toolCall.status,
-				success: part.toolCall.status === ToolCallStatus.Completed ? part.toolCall.success : undefined,
-			} : undefined, {
-				status: ToolCallStatus.Completed,
-				success: false,
-			});
-		});
-	});
-
 	test('orphaned client tool call timeout is cleared when the owning client connects within the window', () => {
 		return runWithFakedTimers({ useFakeTimers: true }, async () => {
 			stateManager.createSession(makeSessionSummary());
@@ -1177,6 +1144,51 @@ suite('ProtocolServerHandler', () => {
 
 			const part = stateManager.getSessionState(sessionUri)?.activeTurn?.responseParts[0];
 			assert.strictEqual(part?.kind === ResponsePartKind.ToolCall ? part.toolCall.status : undefined, ToolCallStatus.Streaming);
+		});
+	});
+
+	test('a later orphaned tool call does not extend an earlier one past the grace window', () => {
+		return runWithFakedTimers({ useFakeTimers: true }, async () => {
+			stateManager.createSession(makeSessionSummary());
+			stateManager.dispatchServerAction(sessionUri, { type: ActionType.SessionReady, });
+			stateManager.dispatchServerAction(sessionUri, {
+				type: ActionType.SessionTurnStarted,
+				turnId: 'turn-1',
+				message: { text: 'run it', origin: { kind: MessageKind.User } },
+			});
+			// First orphaned tool call (owner never connected) arms the grace timer.
+			stateManager.dispatchServerAction(sessionUri, {
+				type: ActionType.SessionToolCallStart,
+				turnId: 'turn-1',
+				toolCallId: 'tool-1',
+				toolName: 'runTask',
+				displayName: 'Run Task',
+				contributor: { kind: ToolCallContributorKind.Client, clientId: 'ghost-client' },
+			});
+
+			// A second call for the same never-connected owner arrives partway
+			// through the window and re-arms the (shared) timer. The grace clock
+			// is pinned to the first arm, so the re-arm must NOT reset the
+			// deadline — otherwise the first call could be kept alive
+			// indefinitely.
+			await new Promise(r => setTimeout(r, 20_000));
+			stateManager.dispatchServerAction(sessionUri, {
+				type: ActionType.SessionToolCallStart,
+				turnId: 'turn-1',
+				toolCallId: 'tool-2',
+				toolName: 'runTask',
+				displayName: 'Run Task',
+				contributor: { kind: ToolCallContributorKind.Client, clientId: 'ghost-client' },
+			});
+
+			// 31s after the FIRST call: both must have failed.
+			await new Promise(r => setTimeout(r, 11_000));
+
+			const parts = stateManager.getSessionState(sessionUri)?.activeTurn?.responseParts ?? [];
+			const statuses = parts
+				.filter(p => p.kind === ResponsePartKind.ToolCall)
+				.map(p => p.kind === ResponsePartKind.ToolCall ? p.toolCall.status : undefined);
+			assert.deepStrictEqual(statuses, [ToolCallStatus.Completed, ToolCallStatus.Completed]);
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/protocolServerHandler.test.ts
+++ b/src/vs/platform/agentHost/test/node/protocolServerHandler.test.ts
@@ -1079,6 +1079,107 @@ suite('ProtocolServerHandler', () => {
 		});
 	});
 
+	test('client tool call stamped for a never-connected client fails after the grace period', () => {
+		return runWithFakedTimers({ useFakeTimers: true }, async () => {
+			stateManager.createSession(makeSessionSummary());
+			stateManager.dispatchServerAction(sessionUri, { type: ActionType.SessionReady, });
+			stateManager.dispatchServerAction(sessionUri, {
+				type: ActionType.SessionTurnStarted,
+				turnId: 'turn-1',
+				message: { text: 'run it', origin: { kind: MessageKind.User } },
+			});
+			// Tool call stamped for a clientId that never connected (e.g. a
+			// stale stamp from a long-dead window). No disconnect event ever
+			// fires for it; the issuance-time orphan check must arm the timeout.
+			stateManager.dispatchServerAction(sessionUri, {
+				type: ActionType.SessionToolCallStart,
+				turnId: 'turn-1',
+				toolCallId: 'tool-1',
+				toolName: 'runTask',
+				displayName: 'Run Task',
+				contributor: { kind: ToolCallContributorKind.Client, clientId: 'ghost-client' },
+			});
+
+			let part = stateManager.getSessionState(sessionUri)?.activeTurn?.responseParts[0];
+			assert.strictEqual(part?.kind === ResponsePartKind.ToolCall ? part.toolCall.status : undefined, ToolCallStatus.Streaming);
+
+			await new Promise(r => setTimeout(r, 30_001));
+
+			part = stateManager.getSessionState(sessionUri)?.activeTurn?.responseParts[0];
+			assert.deepStrictEqual(part?.kind === ResponsePartKind.ToolCall ? {
+				status: part.toolCall.status,
+				success: part.toolCall.status === ToolCallStatus.Completed ? part.toolCall.success : undefined,
+				error: part.toolCall.status === ToolCallStatus.Completed ? part.toolCall.error?.message : undefined,
+			} : undefined, {
+				status: ToolCallStatus.Completed,
+				success: false,
+				error: 'Client ghost-client disconnected before completing Run Task',
+			});
+		});
+	});
+
+	test('client tool call stamped with an empty clientId fails after the grace period', () => {
+		return runWithFakedTimers({ useFakeTimers: true }, async () => {
+			stateManager.createSession(makeSessionSummary());
+			stateManager.dispatchServerAction(sessionUri, { type: ActionType.SessionReady, });
+			stateManager.dispatchServerAction(sessionUri, {
+				type: ActionType.SessionTurnStarted,
+				turnId: 'turn-1',
+				message: { text: 'run it', origin: { kind: MessageKind.User } },
+			});
+			// A client tool issued while no client was connected is stamped as
+			// a Client contributor with an empty id (Copilot orphan path).
+			stateManager.dispatchServerAction(sessionUri, {
+				type: ActionType.SessionToolCallStart,
+				turnId: 'turn-1',
+				toolCallId: 'tool-1',
+				toolName: 'runTask',
+				displayName: 'Run Task',
+				contributor: { kind: ToolCallContributorKind.Client, clientId: '' },
+			});
+
+			await new Promise(r => setTimeout(r, 30_001));
+
+			const part = stateManager.getSessionState(sessionUri)?.activeTurn?.responseParts[0];
+			assert.deepStrictEqual(part?.kind === ResponsePartKind.ToolCall ? {
+				status: part.toolCall.status,
+				success: part.toolCall.status === ToolCallStatus.Completed ? part.toolCall.success : undefined,
+			} : undefined, {
+				status: ToolCallStatus.Completed,
+				success: false,
+			});
+		});
+	});
+
+	test('orphaned client tool call timeout is cleared when the owning client connects within the window', () => {
+		return runWithFakedTimers({ useFakeTimers: true }, async () => {
+			stateManager.createSession(makeSessionSummary());
+			stateManager.dispatchServerAction(sessionUri, { type: ActionType.SessionReady, });
+			stateManager.dispatchServerAction(sessionUri, {
+				type: ActionType.SessionTurnStarted,
+				turnId: 'turn-1',
+				message: { text: 'run it', origin: { kind: MessageKind.User } },
+			});
+			stateManager.dispatchServerAction(sessionUri, {
+				type: ActionType.SessionToolCallStart,
+				turnId: 'turn-1',
+				toolCallId: 'tool-1',
+				toolName: 'runTask',
+				displayName: 'Run Task',
+				contributor: { kind: ToolCallContributorKind.Client, clientId: 'late-client' },
+			});
+
+			// The owning client connects (and subscribes) within the grace
+			// window — the subscribe path clears the armed timeout.
+			connectClient('late-client', [sessionUri]);
+
+			await new Promise(r => setTimeout(r, 30_001));
+
+			const part = stateManager.getSessionState(sessionUri)?.activeTurn?.responseParts[0];
+			assert.strictEqual(part?.kind === ResponsePartKind.ToolCall ? part.toolCall.status : undefined, ToolCallStatus.Streaming);
+		});
+	});
+
 	test('handshake includes defaultDirectory from side effects', () => {
 		const transport = connectClient('client-home');
 


### PR DESCRIPTION
- A window reload reconnects with a new clientId but an identical tool list. The cached SDK session was reused with the dead window's clientId baked in, so every later client tool call was stamped with that dead id, routed to passive render, and hung forever with nobody to invoke it.
- Introduces a live, shared ActiveClientState so the owning clientId is read at tool-call stamp time instead of being frozen at session creation, and makes the staleness check restart only on structural tool/plugin changes — a clientId-only change no longer needlessly restarts (Copilot) or yield-rebinds (Claude) the session.
- Adds a server-side safety net so a client tool call stamped for a client that is not connected (including one that disconnected before the call was even issued) fails after a grace window rather than hanging, with the grace measured from when that client was last seen.
- Lets a completion that races ahead of the SDK tool handler resolve via a buffered result, preserving the previous out-of-order tolerance.

Fixes #319641

(Commit message generated by Copilot)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
