### PR TITLE
Block auto-approve for tilde and env-var expansions in file write paths (#42)

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineFileWriteAnalyzer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineFileWriteAnalyzer.ts
@@ -146,7 +146,12 @@ export class CommandLineFileWriteAnalyzer extends Disposable implements ICommand
 							const fileUri = URI.isUri(fileWrite) ? fileWrite : URI.file(fileWrite);
 							// TODO: Handle command substitutions/complex destinations properly https://github.com/microsoft/vscode/issues/274167
 							// TODO: Handle environment variables properly https://github.com/microsoft/vscode/issues/274166
-							if (fileUri.fsPath.match(/[$\(\){}`~]/)) {
+							// `~` catches POSIX tilde expansion (e.g. `~/foo`) and `%` catches Windows
+							// environment variable expansions (e.g. `%APPDATA%\foo`). Neither is
+							// recognized as absolute by `posix.isAbsolute` / `win32.isAbsolute`, so
+							// without this guard they would be joined onto cwd and incorrectly classified
+							// as inside the workspace while expanding at runtime to a location outside it.
+							if (fileUri.fsPath.match(/[$\(\){}`~%]/)) {
 								isAutoApproveAllowed = false;
 								this._log('File write blocked due to likely containing a variable, sub-command, or tilde expansion', fileUri.toString());
 								break;

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineAnalyzer/commandLineFileWriteAnalyzer.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineAnalyzer/commandLineFileWriteAnalyzer.test.ts
@@ -118,6 +118,8 @@ suite('CommandLineFileWriteAnalyzer', () => {
 			test('variable in filename - block', () => t('echo hello > $HOME/file.txt', 'outsideWorkspace', false, 1));
 			test('command substitution - block', () => t('echo hello > $(pwd)/file.txt', 'outsideWorkspace', false, 1));
 			test('brace expansion - block', () => t('echo hello > {a,b}.txt', 'outsideWorkspace', false, 1));
+			test('tilde expansion - block', () => t('echo hello > ~/file.txt', 'outsideWorkspace', false, 1));
+			test('percent-style variable - block', () => t('echo hello > %HOME%/file.txt', 'outsideWorkspace', false, 1));
 		});
 
 		suite('blockDetectedFileWrites: all', () => {
@@ -300,6 +302,8 @@ suite('CommandLineFileWriteAnalyzer', () => {
 			test('no redirections - allow', () => t('Write-Host "hello"', 'outsideWorkspace', true, 0));
 			test('variable in filename - block', () => t('Write-Host "hello" > $env:TEMP\\file.txt', 'outsideWorkspace', false, 1));
 			test('subexpression - block', () => t('Write-Host "hello" > $(Get-Date).log', 'outsideWorkspace', false, 1));
+			test('percent-style variable - block', () => t('Write-Host "hello" > %APPDATA%\\file.txt', 'outsideWorkspace', false, 1));
+			test('tilde expansion - block', () => t('Write-Host "hello" > ~\\file.txt', 'outsideWorkspace', false, 1));
 		});
 
 		suite('blockDetectedFileWrites: all', () => {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/320660

Cherry-picks 96939e9 from vscode-private to the 1.123 release branch.

## Block auto-approve for tilde and env-var expansions in file write paths

`posix.isAbsolute` / `win32.isAbsolute` do not classify shell-expandable prefixes (`~/foo`, `%APPDATA%\foo`) as absolute, so these paths were being joined onto cwd and incorrectly treated as inside the workspace by the `outsideWorkspace` auto-approve check, while expanding at runtime to a location outside it.

Extends the variable-expansion guard regex to include `~` and `%` so these are detected and auto-approve is denied.
