### PR TITLE
chat: Include Copilot logs in Agent Host debug export

### DIFF
--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/openSessionEventsFile.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/openSessionEventsFile.test.ts
@@ -75,16 +75,25 @@ suite('openSessionEventsFile resolveEventsUri', () => {
 
 	test('copilot log roots resolve beside session-state', () => {
 		const conn = makeRemoteConn('localhost:4321', '/home/remote');
+		const remoteLogs = buildRemoteCopilotLogsUri(conn);
 		assert.deepStrictEqual({
 			rawId: getCopilotCliSessionRawId(URI.parse('agent-host-copilotcli:/abc')),
 			nonCopilotRawId: getCopilotCliSessionRawId(URI.parse('agent-host-copilot:/abc')),
 			localLogs: buildLocalCopilotLogsUri(userHome).toString(),
-			remoteLogs: buildRemoteCopilotLogsUri(conn)?.toString(),
+			remoteLogs: remoteLogs ? {
+				scheme: remoteLogs.scheme,
+				authority: remoteLogs.authority,
+				isLogsPath: remoteLogs.path.endsWith('/home/remote/.copilot/logs'),
+			} : undefined,
 		}, {
 			rawId: 'abc',
 			nonCopilotRawId: undefined,
 			localLogs: 'file:///home/me/.copilot/logs',
-			remoteLogs: 'vscode-agent-host://localhost__4321/file/-/home/remote/.copilot/logs',
+			remoteLogs: {
+				scheme: 'vscode-agent-host',
+				authority: 'localhost__4321',
+				isLogsPath: true,
+			},
 		});
 	});
 

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/openSessionEventsFile.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/openSessionEventsFile.test.ts
@@ -11,7 +11,7 @@ import { IRemoteAgentHostConnectionInfo, RemoteAgentHostConnectionStatus } from 
 import { IsSessionsWindowContext } from '../../../../../../workbench/common/contextkeys.js';
 import { OpenCopilotCliStateFileAction } from '../../../../../../workbench/contrib/chat/browser/actions/openCopilotCliStateFileAction.js';
 import { ChatContextKeys } from '../../../../../../workbench/contrib/chat/common/actions/chatContextKeys.js';
-import { resolveEventsUri } from '../../../../../../workbench/contrib/chat/browser/copilotCliEventsUri.js';
+import { buildLocalCopilotLogsUri, buildRemoteCopilotLogsUri, getCopilotCliSessionRawId, resolveEventsUri } from '../../../../../../workbench/contrib/chat/browser/copilotCliEventsUri.js';
 import { IsAgentHostSession } from '../../browser/agentHostSkillButtons.js';
 import { OpenSessionEventsFileAction } from '../../browser/openSessionEventsFileActions.js';
 
@@ -71,6 +71,21 @@ suite('openSessionEventsFile resolveEventsUri', () => {
 			{ kind: result.kind, resource: result.kind === 'ok' ? result.resource.toString() : undefined },
 			{ kind: 'ok', resource: 'file:///home/me/.copilot/session-state/abc/events.jsonl' },
 		);
+	});
+
+	test('copilot log roots resolve beside session-state', () => {
+		const conn = makeRemoteConn('localhost:4321', '/home/remote');
+		assert.deepStrictEqual({
+			rawId: getCopilotCliSessionRawId(URI.parse('agent-host-copilotcli:/abc')),
+			nonCopilotRawId: getCopilotCliSessionRawId(URI.parse('agent-host-copilot:/abc')),
+			localLogs: buildLocalCopilotLogsUri(userHome).toString(),
+			remoteLogs: buildRemoteCopilotLogsUri(conn)?.toString(),
+		}, {
+			rawId: 'abc',
+			nonCopilotRawId: undefined,
+			localLogs: 'file:///home/me/.copilot/logs',
+			remoteLogs: 'vscode-agent-host://localhost__4321/file/-/home/remote/.copilot/logs',
+		});
 	});
 
 	test('EH CLI copilotcli session resolves to ~/.copilot/session-state/<id>/events.jsonl', () => {

--- a/src/vs/workbench/contrib/chat/browser/actions/exportAgentHostDebugLogsAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/exportAgentHostDebugLogsAction.ts
@@ -3,7 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { VSBuffer } from '../../../../../base/common/buffer.js';
+import { VSBuffer, type VSBufferReadableStream } from '../../../../../base/common/buffer.js';
+import { CancellationTokenSource } from '../../../../../base/common/cancellation.js';
 import { Schemas } from '../../../../../base/common/network.js';
 import { joinPath } from '../../../../../base/common/resources.js';
 import { URI } from '../../../../../base/common/uri.js';
@@ -17,7 +18,7 @@ import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contex
 import { IsWebContext } from '../../../../../platform/contextkey/common/contextkeys.js';
 import { IFileDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
 import { IEnvironmentService } from '../../../../../platform/environment/common/environment.js';
-import { IFileService } from '../../../../../platform/files/common/files.js';
+import { IFileService, type IFileStatWithMetadata } from '../../../../../platform/files/common/files.js';
 import { createDecorator, ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
 import { INotificationService, Severity } from '../../../../../platform/notification/common/notification.js';
@@ -27,7 +28,7 @@ import { IOutputService } from '../../../../services/output/common/output.js';
 import { IPathService } from '../../../../services/path/common/pathService.js';
 import { IChatWidgetService } from '../chat.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
-import { COPILOT_CLI_LOCAL_AH_SCHEME, parseRemoteAuthorityFromScheme, resolveEventsUri } from '../copilotCliEventsUri.js';
+import { buildLocalCopilotLogsUri, buildRemoteCopilotLogsUri, COPILOT_CLI_LOCAL_AH_SCHEME, getCopilotCliSessionRawId, parseRemoteAuthorityFromScheme, resolveEventsUri } from '../copilotCliEventsUri.js';
 
 /** Output channel ID for the agent host process logger (forwarded via RemoteLoggerChannelClient). */
 const AGENT_HOST_LOGGER_CHANNEL_ID = 'agenthost';
@@ -35,6 +36,9 @@ const AGENT_HOST_LOGGER_CHANNEL_ID = 'agenthost';
 const WINDOW_LOG_CHANNEL_ID = 'rendererLog';
 /** Output channel ID for the shared process compound log. */
 const SHARED_PROCESS_LOG_CHANNEL_ID = 'shared';
+/** Bound the best-effort scan of Copilot SDK process logs. */
+const MAX_COPILOT_LOG_SCAN_FILES = 20;
+const MAX_COPILOT_LOG_FILE_SIZE = 10 * 1024 * 1024;
 
 /**
  * Description of the agent-host session whose logs should be exported. If
@@ -200,6 +204,19 @@ export async function collectAgentHostDebugLogs(
 		}
 	}
 
+	// 5. Copilot SDK process logs under ~/.copilot/logs do not include the
+	// session id in the filename, but relevant entries include it in the content.
+	const rawSessionId = getCopilotCliSessionRawId(activeSession?.resource);
+	if (rawSessionId) {
+		const copilotLogsDir = activeSession?.isLocal
+			? buildLocalCopilotLogsUri(userHome)
+			: remoteConnection ? buildRemoteCopilotLogsUri(remoteConnection) : undefined;
+		if (copilotLogsDir) {
+			const copilotLogFiles = await readCopilotLogsForSession(copilotLogsDir, rawSessionId, fileService, logService);
+			files.push(...copilotLogFiles);
+		}
+	}
+
 	if (files.length === 0) {
 		notificationService.notify({
 			severity: Severity.Warning,
@@ -214,6 +231,102 @@ export async function collectAgentHostDebugLogs(
 		? `-${activeSession.title.replace(/[/\\:*?"<>|\s]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 40)}`
 		: '';
 	return { files, exportName: `ah-logs${titleSlug}` };
+}
+
+async function readCopilotLogsForSession(
+	logsDir: URI,
+	rawSessionId: string,
+	fileService: IFileService,
+	logService: ILogService,
+): Promise<{ path: string; contents: string }[]> {
+	let children: IFileStatWithMetadata[] | undefined;
+	try {
+		children = (await fileService.resolve(logsDir, { resolveMetadata: true })).children;
+	} catch {
+		return [];
+	}
+
+	const files: { path: string; contents: string }[] = [];
+	const candidateLogs = (children ?? [])
+		.filter(child => !child.isDirectory && child.name.endsWith('.log') && child.size <= MAX_COPILOT_LOG_FILE_SIZE)
+		.sort((a, b) => b.mtime - a.mtime)
+		.slice(0, MAX_COPILOT_LOG_SCAN_FILES);
+	for (const child of candidateLogs) {
+		try {
+			if (await logStreamContains(child.resource, rawSessionId, fileService)) {
+				const content = await fileService.readFile(child.resource, { limits: { size: MAX_COPILOT_LOG_FILE_SIZE } });
+				const contents = content.value.toString();
+				files.push({ path: `copilot-logs/${child.name}`, contents });
+			}
+		} catch (error) {
+			logService.warn(`[ExportAgentHostDebugLogs] Failed to read Copilot log '${child.name}': ${error instanceof Error ? error.message : String(error)}`);
+		}
+	}
+	return files;
+}
+
+async function logStreamContains(
+	resource: URI,
+	rawSessionId: string,
+	fileService: IFileService,
+): Promise<boolean> {
+	const tokenSource = new CancellationTokenSource();
+	let stream: VSBufferReadableStream;
+	try {
+		stream = (await fileService.readFileStream(resource, {
+			length: MAX_COPILOT_LOG_FILE_SIZE,
+			limits: { size: MAX_COPILOT_LOG_FILE_SIZE },
+		}, tokenSource.token)).value;
+	} catch (error) {
+		tokenSource.dispose(true);
+		throw error;
+	}
+	return new Promise<boolean>((resolve, reject) => {
+		let settled = false;
+		let previous = '';
+
+		const cleanup = () => {
+			stream.removeListener('data', onData);
+			stream.removeListener('error', onError);
+			stream.removeListener('end', onEnd);
+		};
+		const settle = (contains: boolean) => {
+			if (settled) {
+				return;
+			}
+			settled = true;
+			tokenSource.dispose(contains);
+			cleanup();
+			if (contains) {
+				stream.destroy();
+			}
+			resolve(contains);
+		};
+		const onData = (chunk: VSBuffer) => {
+			const text = previous + chunk.toString();
+			if (text.includes(rawSessionId)) {
+				settle(true);
+				return;
+			}
+			previous = text.slice(Math.max(0, text.length - rawSessionId.length + 1));
+		};
+		const onError = (error: Error) => {
+			if (settled) {
+				return;
+			}
+			settled = true;
+			tokenSource.dispose();
+			cleanup();
+			reject(error);
+		};
+		const onEnd = () => {
+			settle(false);
+		};
+
+		stream.on('error', onError);
+		stream.on('end', onEnd);
+		stream.on('data', onData);
+	});
 }
 
 export async function exportAgentHostDebugLogs(

--- a/src/vs/workbench/contrib/chat/browser/actions/exportAgentHostDebugLogsAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/exportAgentHostDebugLogsAction.ts
@@ -285,10 +285,12 @@ async function logStreamContains(
 		let settled = false;
 		let previous = '';
 
-		const cleanup = () => {
+		const cleanup = (removeErrorListener: boolean) => {
 			stream.removeListener('data', onData);
-			stream.removeListener('error', onError);
 			stream.removeListener('end', onEnd);
+			if (removeErrorListener) {
+				stream.removeListener('error', onError);
+			}
 		};
 		const settle = (contains: boolean) => {
 			if (settled) {
@@ -296,10 +298,7 @@ async function logStreamContains(
 			}
 			settled = true;
 			tokenSource.dispose(contains);
-			cleanup();
-			if (contains) {
-				stream.destroy();
-			}
+			cleanup(!contains);
 			resolve(contains);
 		};
 		const onData = (chunk: VSBuffer) => {
@@ -316,7 +315,7 @@ async function logStreamContains(
 			}
 			settled = true;
 			tokenSource.dispose();
-			cleanup();
+			cleanup(true);
 			reject(error);
 		};
 		const onEnd = () => {

--- a/src/vs/workbench/contrib/chat/browser/copilotCliEventsUri.ts
+++ b/src/vs/workbench/contrib/chat/browser/copilotCliEventsUri.ts
@@ -30,6 +30,13 @@ export function buildLocalEventsUri(userHome: URI, rawSessionId: string): URI {
 }
 
 /**
+ * Builds the local `~/.copilot/logs` directory URI.
+ */
+export function buildLocalCopilotLogsUri(userHome: URI): URI {
+	return joinPath(userHome, '.copilot', 'logs');
+}
+
+/**
  * Builds a `vscode-agent-host://` URI for the `events.jsonl` file inside
  * the host's user home directory, using the connection's reported
  * `defaultDirectory` (set from `os.homedir()` on the host during the
@@ -56,6 +63,24 @@ export function buildRemoteEventsUri(connection: IRemoteAgentHostConnectionInfo,
 }
 
 /**
+ * Builds a `vscode-agent-host://` URI for the host's `~/.copilot/logs`
+ * directory, using the connection's reported home directory.
+ */
+export function buildRemoteCopilotLogsUri(connection: IRemoteAgentHostConnectionInfo): URI | undefined {
+	const homePath = connection.defaultDirectory;
+	if (!homePath) {
+		return undefined;
+	}
+	const trimmed = homePath.endsWith('/') ? homePath.slice(0, -1) : homePath;
+	const remoteFileUri = URI.from({
+		scheme: 'file',
+		path: `${trimmed}/.copilot/logs`,
+	});
+	const authority = agentHostAuthority(connection.address);
+	return toAgentHostUri(remoteFileUri, authority);
+}
+
+/**
  * Parses the connection authority out of a remote AH chat session scheme
  * of the form `remote-<authority>-copilotcli`. Returns `undefined` for
  * any other scheme, including the local `copilotcli` scheme.
@@ -66,6 +91,19 @@ export function parseRemoteAuthorityFromScheme(scheme: string): string | undefin
 	}
 	const authority = scheme.slice(REMOTE_PROVIDER_PREFIX.length, scheme.length - REMOTE_PROVIDER_SUFFIX.length);
 	return authority || undefined;
+}
+
+/**
+ * Extracts the raw Copilot CLI session id from a chat session resource.
+ */
+export function getCopilotCliSessionRawId(sessionResource: URI | undefined): string | undefined {
+	if (!sessionResource) {
+		return undefined;
+	}
+	if (sessionResource.scheme !== COPILOT_CLI_LOCAL_AH_SCHEME && sessionResource.scheme !== COPILOT_CLI_EH_SCHEME && !parseRemoteAuthorityFromScheme(sessionResource.scheme)) {
+		return undefined;
+	}
+	return getRawSessionId(sessionResource);
 }
 
 export type ResolveEventsUriResult =
@@ -88,7 +126,7 @@ export function resolveEventsUri(
 	if (!sessionResource) {
 		return { kind: 'no-session' };
 	}
-	const rawId = sessionResource.path.startsWith('/') ? sessionResource.path.substring(1) : sessionResource.path;
+	const rawId = getRawSessionId(sessionResource);
 	if (!rawId) {
 		return { kind: 'no-session' };
 	}
@@ -111,4 +149,9 @@ export function resolveEventsUri(
 	}
 
 	return { kind: 'unsupported-scheme', scheme: sessionResource.scheme };
+}
+
+function getRawSessionId(sessionResource: URI): string | undefined {
+	const rawId = sessionResource.path.startsWith('/') ? sessionResource.path.substring(1) : sessionResource.path;
+	return rawId || undefined;
 }


### PR DESCRIPTION
## Summary
- include matching Copilot SDK process logs in Agent Host debug log exports for Copilot CLI sessions
- resolve local and remote ~/.copilot/logs directories from the active session
- stream-scan bounded recent log files for the session id before adding matched logs to the archive

## Validation
- npm run compile-check-ts-native
- npm run transpile-client
- npm run valid-layers-check
- env -u ELECTRON_RUN_AS_NODE scripts/test.sh --runGlob '**/openSessionEventsFile.test.js'
- npm run precommit

(Written by Copilot)