### PR TITLE
Folder picker chip for Agent Host sessions in multi-root windows

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp.ts
@@ -72,6 +72,7 @@ export function getAccessibilityHelpText(type: 'panelChat' | 'inlineChat' | 'age
 			content.push(localize('workbench.action.chat.history', 'To view all chat sessions, invoke the Show Chats command{0}.', '<keybinding:workbench.action.chat.history>'));
 			content.push(localize('workbench.action.chat.focusAgentSessionsViewer', 'You can focus the agent sessions list by invoking the Focus Agent Sessions command{0}.', `<keybinding:${FocusAgentSessionsAction.id}>`));
 			content.push(localize('workbench.action.openAgentsWindow', 'To open the Agents Window, invoke the Open Agents Window command{0}. In screen reader mode, this keybinding includes Alt to avoid conflicts with screen reader shortcuts.', '<keybinding:workbench.action.openAgentsWindow>'));
+			content.push(localize('workbench.action.chat.openAgentHostFolderPicker', 'When starting an agent session in a multi-root workspace, you can choose which root folder it runs in by invoking the Folder command{0}, then selecting a folder from the list.', '<keybinding:workbench.action.chat.openAgentHostFolderPicker>'));
 		}
 		content.push(localize('chat.requestHistory', 'In the input box, use up and down arrows to navigate your request history. Edit input and use enter or the submit button to run a new request.'));
 		content.push(localize('chat.attachments.removal', 'To remove attached contexts, focus an attachment and press Delete or Backspace.'));

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker.contribution.ts
@@ -34,7 +34,10 @@ export class OpenAgentHostFolderPickerAction extends Action2 {
 			id: OpenAgentHostFolderPickerAction.ID,
 			title: localize2('agentHost.folderPicker', "Folder"),
 			f1: false,
-			precondition: ChatContextKeys.enabled,
+			// The working directory is an argument to session creation and is
+			// fixed once the session has started (its first request), so the
+			// chip stays visible afterwards but is disabled.
+			precondition: ContextKeyExpr.and(ChatContextKeys.enabled, ChatContextKeys.chatSessionIsEmpty),
 			menu: [{
 				id: MenuId.ChatInputSecondary,
 				group: 'navigation',

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker.contribution.ts
@@ -5,6 +5,8 @@
 
 import { localize2 } from '../../../../../../nls.js';
 import { Action2, MenuId, registerAction2 } from '../../../../../../platform/actions/common/actions.js';
+import { ContextKeyExpr } from '../../../../../../platform/contextkey/common/contextkey.js';
+import { IsSessionsWindowContext, WorkspaceFolderCountContext } from '../../../../../common/contextkeys.js';
 import { ChatContextKeys, ChatContextKeyExprs } from '../../../common/actions/chatContextKeys.js';
 
 /**
@@ -20,7 +22,37 @@ import { ChatContextKeys, ChatContextKeyExprs } from '../../../common/actions/ch
  *   0.8  OpenAgentHostAutoApprovePickerAction (NEW — Auto-Approve)
  *   0.9  OpenAgentHostPermissionModePickerAction (NEW — Claude Approvals)
  *   1    OpenPermissionPickerAction           (Default Approvals)
+ *   1.1  OpenAgentHostFolderPickerAction      (NEW — Folder, multi-root only;
+ *                                              ordered last to match the
+ *                                              extension-host Copilot CLI)
  */
+
+export class OpenAgentHostFolderPickerAction extends Action2 {
+	static readonly ID = 'workbench.action.chat.openAgentHostFolderPicker';
+	constructor() {
+		super({
+			id: OpenAgentHostFolderPickerAction.ID,
+			title: localize2('agentHost.folderPicker', "Folder"),
+			f1: false,
+			precondition: ChatContextKeys.enabled,
+			menu: [{
+				id: MenuId.ChatInputSecondary,
+				group: 'navigation',
+				order: 1.1,
+				// Only relevant when there is more than one root folder to choose
+				// from and we are in a regular editor window (the agent sessions
+				// window has its own workspace picker). Ordered last in the chip
+				// row to match the extension-host Copilot CLI layout.
+				when: ContextKeyExpr.and(
+					ChatContextKeyExprs.isAgentHostSession,
+					WorkspaceFolderCountContext.greater(1),
+					IsSessionsWindowContext.negate(),
+				),
+			}],
+		});
+	}
+	override async run(): Promise<void> { /* the action view item handles interaction */ }
+}
 
 export class OpenAgentHostModePickerAction extends Action2 {
 	static readonly ID = 'workbench.action.chat.openAgentHostModePicker';
@@ -82,3 +114,4 @@ export class OpenAgentHostPermissionModePickerAction extends Action2 {
 registerAction2(OpenAgentHostModePickerAction);
 registerAction2(OpenAgentHostAutoApprovePickerAction);
 registerAction2(OpenAgentHostPermissionModePickerAction);
+registerAction2(OpenAgentHostFolderPickerAction);

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker.ts
@@ -34,6 +34,7 @@ import type { IChatWidget } from '../../chat.js';
 import { ChatConfiguration } from '../../../common/constants.js';
 import { isUntitledChatSession } from '../../../common/model/chatUri.js';
 import { IAgentHostSessionWorkingDirectoryResolver } from './agentHostSessionWorkingDirectoryResolver.js';
+import { IAgentHostNewSessionFolderService } from './agentHostNewSessionFolderService.js';
 import { IAgentHostUntitledProvisionalSessionService } from './agentHostUntitledProvisionalSessionService.js';
 import { toAgentHostBackendSessionUri } from './agentHostSessionUri.js';
 
@@ -203,6 +204,7 @@ export class AgentHostChatInputPicker extends Disposable {
 		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
 		@IAgentHostUntitledProvisionalSessionService private readonly _provisional: IAgentHostUntitledProvisionalSessionService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IAgentHostNewSessionFolderService private readonly _newSessionFolderService: IAgentHostNewSessionFolderService,
 	) {
 		super();
 
@@ -535,7 +537,8 @@ export class AgentHostChatInputPicker extends Disposable {
 			return typeof cwd === 'string' ? URI.parse(cwd) : cwd;
 		}
 		const sessionResource = this._widget.viewModel?.sessionResource;
-		return (sessionResource && this._workingDirectoryResolver.resolve(sessionResource))
+		return (sessionResource && this._newSessionFolderService.getFolder(sessionResource))
+			?? (sessionResource && this._workingDirectoryResolver.resolve(sessionResource))
 			?? this._workspaceContextService.getWorkspace().folders[0]?.uri;
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostFolderPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostFolderPickerActionItem.ts
@@ -17,7 +17,6 @@ import { IContextKeyService } from '../../../../../../platform/contextkey/common
 import { IKeybindingService } from '../../../../../../platform/keybinding/common/keybinding.js';
 import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
 import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
-import { isUntitledChatSession } from '../../../common/model/chatUri.js';
 import type { IChatWidget } from '../../chat.js';
 import { ChatInputPickerActionViewItem, IChatInputPickerOptions } from '../../widget/input/chatInputPickerActionItem.js';
 import { IAgentHostNewSessionFolderService } from './agentHostNewSessionFolderService.js';
@@ -29,7 +28,8 @@ import { IAgentHostNewSessionFolderService } from './agentHostNewSessionFolderSe
  * will run in. The choice is recorded in {@link IAgentHostNewSessionFolderService},
  * keyed by the (untitled) chat session resource, where the working-directory
  * resolution sites pick it up. Once the session has started its working
- * directory is fixed, so the chip hides itself.
+ * directory is fixed, so the chip stays visible (showing the chosen folder)
+ * but is disabled via the action's precondition.
  */
 export class AgentHostFolderPickerActionItem extends ChatInputPickerActionViewItem {
 
@@ -118,16 +118,6 @@ export class AgentHostFolderPickerActionItem extends ChatInputPickerActionViewIt
 	}
 
 	protected override renderLabel(element: HTMLElement): IDisposable | null {
-		const sessionResource = this._sessionResource();
-		// The working directory is fixed once the session has started, so only
-		// offer the picker while composing a new (untitled) session.
-		const isNewSession = !!sessionResource && isUntitledChatSession(sessionResource);
-		if (!isNewSession) {
-			dom.hide(element);
-			return null;
-		}
-		dom.show(element);
-
 		this.setAriaLabelAttributes(element);
 		const selected = this._selectedFolder();
 		const folder = selected && this._workspaceContextService.getWorkspace().folders.find(f => f.uri.toString() === selected.toString());

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostFolderPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostFolderPickerActionItem.ts
@@ -103,9 +103,18 @@ export class AgentHostFolderPickerActionItem extends ChatInputPickerActionViewIt
 	}
 
 	private _selectedFolder(): URI | undefined {
+		const folders = this._workspaceContextService.getWorkspace().folders;
 		const sessionResource = this._sessionResource();
-		const stored = sessionResource && this._newSessionFolderService.getFolder(sessionResource);
-		return stored ?? this._workspaceContextService.getWorkspace().folders[0]?.uri;
+		const stored = sessionResource ? this._newSessionFolderService.getFolder(sessionResource) : undefined;
+		if (stored) {
+			if (folders.some(folder => folder.uri.toString() === stored.toString())) {
+				return stored;
+			}
+			// The stored folder is no longer part of the workspace (folders
+			// changed); drop the stale selection and fall back to the first folder.
+			this._newSessionFolderService.clear(sessionResource!);
+		}
+		return folders[0]?.uri;
 	}
 
 	protected override renderLabel(element: HTMLElement): IDisposable | null {
@@ -121,7 +130,8 @@ export class AgentHostFolderPickerActionItem extends ChatInputPickerActionViewIt
 
 		this.setAriaLabelAttributes(element);
 		const selected = this._selectedFolder();
-		const label = selected ? basename(selected) : localize('agentHost.selectFolder', "Folder");
+		const folder = selected && this._workspaceContextService.getWorkspace().folders.find(f => f.uri.toString() === selected.toString());
+		const label = folder ? folder.name : (selected ? basename(selected) : localize('agentHost.selectFolder', "Folder"));
 		dom.reset(
 			element,
 			...renderLabelWithIcons(`$(folder)`),

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostFolderPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostFolderPickerActionItem.ts
@@ -1,0 +1,132 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as dom from '../../../../../../base/browser/dom.js';
+import { renderLabelWithIcons } from '../../../../../../base/browser/ui/iconLabel/iconLabels.js';
+import { IActionProvider } from '../../../../../../base/browser/ui/dropdown/dropdown.js';
+import { IDisposable } from '../../../../../../base/common/lifecycle.js';
+import { basename } from '../../../../../../base/common/resources.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { localize } from '../../../../../../nls.js';
+import { MenuItemAction } from '../../../../../../platform/actions/common/actions.js';
+import { IActionWidgetService } from '../../../../../../platform/actionWidget/browser/actionWidget.js';
+import { IActionWidgetDropdownAction, IActionWidgetDropdownActionProvider, IActionWidgetDropdownOptions } from '../../../../../../platform/actionWidget/browser/actionWidgetDropdown.js';
+import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
+import { IKeybindingService } from '../../../../../../platform/keybinding/common/keybinding.js';
+import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
+import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
+import { isUntitledChatSession } from '../../../common/model/chatUri.js';
+import type { IChatWidget } from '../../chat.js';
+import { ChatInputPickerActionViewItem, IChatInputPickerOptions } from '../../widget/input/chatInputPickerActionItem.js';
+import { IAgentHostNewSessionFolderService } from './agentHostNewSessionFolderService.js';
+
+/**
+ * Folder picker for agent-host sessions in multi-root windows. An agent-host
+ * session runs in a single working directory chosen at creation time, so before
+ * the session starts this chip lets the user pick which root folder the session
+ * will run in. The choice is recorded in {@link IAgentHostNewSessionFolderService},
+ * keyed by the (untitled) chat session resource, where the working-directory
+ * resolution sites pick it up. Once the session has started its working
+ * directory is fixed, so the chip hides itself.
+ */
+export class AgentHostFolderPickerActionItem extends ChatInputPickerActionViewItem {
+
+	constructor(
+		action: MenuItemAction,
+		private readonly _widget: IChatWidget,
+		pickerOptions: IChatInputPickerOptions,
+		@IActionWidgetService actionWidgetService: IActionWidgetService,
+		@IKeybindingService keybindingService: IKeybindingService,
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@ITelemetryService telemetryService: ITelemetryService,
+		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
+		@IAgentHostNewSessionFolderService private readonly _newSessionFolderService: IAgentHostNewSessionFolderService,
+	) {
+		const actionProvider: IActionWidgetDropdownActionProvider = {
+			getActions: () => {
+				const selected = this._selectedFolder();
+				return this._workspaceContextService.getWorkspace().folders.map(folder => ({
+					...action,
+					id: `agentHostFolder.${folder.uri.toString()}`,
+					label: folder.name,
+					checked: selected?.toString() === folder.uri.toString(),
+					icon: { id: 'folder' },
+					enabled: true,
+					tooltip: folder.uri.fsPath,
+					run: async () => {
+						const sessionResource = this._sessionResource();
+						if (sessionResource) {
+							this._newSessionFolderService.setFolder(sessionResource, folder.uri);
+						}
+						if (this.element) {
+							this.renderLabel(this.element);
+						}
+					},
+				} satisfies IActionWidgetDropdownAction));
+			}
+		};
+
+		const actionBarActionProvider: IActionProvider = {
+			getActions: () => []
+		};
+
+		const folderPickerOptions: Omit<IActionWidgetDropdownOptions, 'label' | 'labelRenderer'> = {
+			actionProvider,
+			actionBarActionProvider,
+			showItemKeybindings: false,
+			reporter: { id: 'AgentHostFolderPicker', name: 'AgentHostFolderPicker', includeOptions: false },
+		};
+
+		super(action, folderPickerOptions, pickerOptions, actionWidgetService, keybindingService, contextKeyService, telemetryService);
+
+		this._register(this._newSessionFolderService.onDidChangeFolder(() => {
+			if (this.element) {
+				this.renderLabel(this.element);
+			}
+		}));
+		this._register(this._workspaceContextService.onDidChangeWorkspaceFolders(() => {
+			if (this.element) {
+				this.renderLabel(this.element);
+			}
+		}));
+		this._register(this._widget.onDidChangeViewModel(() => {
+			if (this.element) {
+				this.renderLabel(this.element);
+			}
+		}));
+	}
+
+	private _sessionResource(): URI | undefined {
+		return this._widget.viewModel?.sessionResource;
+	}
+
+	private _selectedFolder(): URI | undefined {
+		const sessionResource = this._sessionResource();
+		const stored = sessionResource && this._newSessionFolderService.getFolder(sessionResource);
+		return stored ?? this._workspaceContextService.getWorkspace().folders[0]?.uri;
+	}
+
+	protected override renderLabel(element: HTMLElement): IDisposable | null {
+		const sessionResource = this._sessionResource();
+		// The working directory is fixed once the session has started, so only
+		// offer the picker while composing a new (untitled) session.
+		const isNewSession = !!sessionResource && isUntitledChatSession(sessionResource);
+		if (!isNewSession) {
+			dom.hide(element);
+			return null;
+		}
+		dom.show(element);
+
+		this.setAriaLabelAttributes(element);
+		const selected = this._selectedFolder();
+		const label = selected ? basename(selected) : localize('agentHost.selectFolder', "Folder");
+		dom.reset(
+			element,
+			...renderLabelWithIcons(`$(folder)`),
+			dom.$('span.chat-input-picker-label', undefined, label),
+		);
+		return null;
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostGenericConfigChips.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostGenericConfigChips.ts
@@ -17,6 +17,7 @@ import { isUntitledChatSession } from '../../../common/model/chatUri.js';
 import type { IChatWidget } from '../../chat.js';
 import { AgentHostChatInputPicker, isClaimedByDedicatedPicker } from './agentHostChatInputPicker.js';
 import { IAgentHostSessionWorkingDirectoryResolver } from './agentHostSessionWorkingDirectoryResolver.js';
+import { IAgentHostNewSessionFolderService } from './agentHostNewSessionFolderService.js';
 import { IAgentHostUntitledProvisionalSessionService } from './agentHostUntitledProvisionalSessionService.js';
 import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
 import { toAgentHostBackendSessionUri } from './agentHostSessionUri.js';
@@ -57,6 +58,7 @@ export class AgentHostGenericConfigChips extends Disposable {
 		@IAgentHostUntitledProvisionalSessionService private readonly _provisional: IAgentHostUntitledProvisionalSessionService,
 		@IAgentHostSessionWorkingDirectoryResolver private readonly _workingDirectoryResolver: IAgentHostSessionWorkingDirectoryResolver,
 		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
+		@IAgentHostNewSessionFolderService private readonly _newSessionFolderService: IAgentHostNewSessionFolderService,
 	) {
 		super();
 		this._register(this._widget.onDidChangeViewModel(() => this._reattach()));
@@ -142,7 +144,8 @@ export class AgentHostGenericConfigChips extends Disposable {
 			return typeof cwd === 'string' ? URI.parse(cwd) : cwd;
 		}
 		const sessionResource = this._widget.viewModel?.sessionResource;
-		return (sessionResource && this._workingDirectoryResolver.resolve(sessionResource))
+		return (sessionResource && this._newSessionFolderService.getFolder(sessionResource))
+			?? (sessionResource && this._workingDirectoryResolver.resolve(sessionResource))
 			?? this._workspaceContextService.getWorkspace().folders[0]?.uri;
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostNewSessionFolderService.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostNewSessionFolderService.ts
@@ -1,0 +1,79 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Emitter, Event } from '../../../../../../base/common/event.js';
+import { Disposable } from '../../../../../../base/common/lifecycle.js';
+import { ResourceMap } from '../../../../../../base/common/map.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { createDecorator } from '../../../../../../platform/instantiation/common/instantiation.js';
+import { InstantiationType, registerSingleton } from '../../../../../../platform/instantiation/common/extensions.js';
+
+export const IAgentHostNewSessionFolderService = createDecorator<IAgentHostNewSessionFolderService>('agentHostNewSessionFolderService');
+
+/**
+ * Per-window store of the working directory a user picked for a not-yet-started
+ * agent-host session, keyed by the chat session resource it was picked against
+ * (including the untitled compose resource). An agent-host session's working
+ * directory is an argument to session creation and is immutable afterwards, so
+ * in a multi-root window the Folder picker chip records the choice here and the
+ * working-directory resolution sites consult it before falling back to the
+ * first workspace folder. Keying by the compose resource lets the choice
+ * survive the untitled-to-real rebind that happens when the session is created.
+ */
+export interface IAgentHostNewSessionFolderService {
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * Fires with the session resource whose chosen folder changed.
+	 */
+	readonly onDidChangeFolder: Event<URI>;
+
+	/**
+	 * The folder chosen for the given session resource, or `undefined` if the
+	 * user has not made an explicit choice.
+	 */
+	getFolder(sessionResource: URI): URI | undefined;
+
+	/**
+	 * Record the folder chosen for the given session resource. Fires
+	 * {@link onDidChangeFolder} when the value actually changes.
+	 */
+	setFolder(sessionResource: URI, folder: URI): void;
+
+	/**
+	 * Forget any choice recorded for the given session resource.
+	 */
+	clear(sessionResource: URI): void;
+}
+
+export class AgentHostNewSessionFolderService extends Disposable implements IAgentHostNewSessionFolderService {
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _folders = new ResourceMap<URI>();
+
+	private readonly _onDidChangeFolder = this._register(new Emitter<URI>());
+	readonly onDidChangeFolder = this._onDidChangeFolder.event;
+
+	getFolder(sessionResource: URI): URI | undefined {
+		return this._folders.get(sessionResource);
+	}
+
+	setFolder(sessionResource: URI, folder: URI): void {
+		const existing = this._folders.get(sessionResource);
+		if (existing?.toString() === folder.toString()) {
+			return;
+		}
+		this._folders.set(sessionResource, folder);
+		this._onDidChangeFolder.fire(sessionResource);
+	}
+
+	clear(sessionResource: URI): void {
+		if (this._folders.delete(sessionResource)) {
+			this._onDidChangeFolder.fire(sessionResource);
+		}
+	}
+}
+
+registerSingleton(IAgentHostNewSessionFolderService, AgentHostNewSessionFolderService, InstantiationType.Delayed);

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostNewSessionFolderService.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostNewSessionFolderService.ts
@@ -9,6 +9,7 @@ import { ResourceMap } from '../../../../../../base/common/map.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { createDecorator } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { InstantiationType, registerSingleton } from '../../../../../../platform/instantiation/common/extensions.js';
+import { IChatService } from '../../../common/chatService/chatService.js';
 
 export const IAgentHostNewSessionFolderService = createDecorator<IAgentHostNewSessionFolderService>('agentHostNewSessionFolderService');
 
@@ -55,6 +56,22 @@ export class AgentHostNewSessionFolderService extends Disposable implements IAge
 
 	private readonly _onDidChangeFolder = this._register(new Emitter<URI>());
 	readonly onDidChangeFolder = this._onDidChangeFolder.event;
+
+	constructor(
+		@IChatService chatService: IChatService,
+	) {
+		super();
+
+		// Forget a session's chosen folder once the session is disposed. This
+		// bounds the store to live sessions while keeping the choice available
+		// for the session's whole lifetime (so the Folder chip keeps showing
+		// the right folder after the session has started).
+		this._register(chatService.onDidDisposeSession(e => {
+			for (const sessionResource of e.sessionResources) {
+				this.clear(sessionResource);
+			}
+		}));
+	}
 
 	getFolder(sessionResource: URI): URI | undefined {
 		return this._folders.get(sessionResource);

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -53,6 +53,7 @@ import { IChatWidgetService } from '../../chat.js';
 import { getAgentHostIcon } from '../agentSessions.js';
 import { IAgentHostActiveClientService } from './agentHostActiveClientService.js';
 import { IAgentHostSessionWorkingDirectoryResolver } from './agentHostSessionWorkingDirectoryResolver.js';
+import { IAgentHostNewSessionFolderService } from './agentHostNewSessionFolderService.js';
 import { AgentHostSnapshotController } from './agentHostSnapshotController.js';
 import { toolDataToDefinition } from './agentHostToolUtils.js';
 import { IAgentHostUntitledProvisionalSessionService } from './agentHostUntitledProvisionalSessionService.js';
@@ -416,6 +417,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		@ITerminalChatService private readonly _terminalChatService: ITerminalChatService,
 		@IAgentHostTerminalService private readonly _agentHostTerminalService: IAgentHostTerminalService,
 		@IAgentHostSessionWorkingDirectoryResolver private readonly _workingDirectoryResolver: IAgentHostSessionWorkingDirectoryResolver,
+		@IAgentHostNewSessionFolderService private readonly _newSessionFolderService: IAgentHostNewSessionFolderService,
 		@IAgentHostUntitledProvisionalSessionService private readonly _provisionalService: IAgentHostUntitledProvisionalSessionService,
 		@ILanguageModelToolsService private readonly _toolsService: ILanguageModelToolsService,
 		@IChatWidgetService private readonly _chatWidgetService: IChatWidgetService,
@@ -2762,6 +2764,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 
 	private _resolveRequestedWorkingDirectory(sessionResource: URI): URI | undefined {
 		return this._config.resolveWorkingDirectory?.(sessionResource)
+			?? this._newSessionFolderService.getFolder(sessionResource)
 			?? this._workingDirectoryResolver.resolve(sessionResource)
 			?? this._workspaceContextService.getWorkspace().folders[0]?.uri;
 	}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -2596,6 +2596,11 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 
 		this._logService.trace(`[AgentHost] Created session: ${session.toString()}`);
 
+		// The backend session now owns the working directory, so the per-session
+		// folder selection is no longer needed; drop it to avoid retaining
+		// state beyond the "new session" phase.
+		this._newSessionFolderService.clear(sessionResource);
+
 		// Subscribe to the new session's state
 		const newSub = this._ensureSessionSubscription(session.toString());
 		if (!this._getSessionState(session.toString())) {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -2596,11 +2596,6 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 
 		this._logService.trace(`[AgentHost] Created session: ${session.toString()}`);
 
-		// The backend session now owns the working directory, so the per-session
-		// folder selection is no longer needed; drop it to avoid retaining
-		// state beyond the "new session" phase.
-		this._newSessionFolderService.clear(sessionResource);
-
 		// Subscribe to the new session's state
 		const newSub = this._ensureSessionSubscription(session.toString());
 		if (!this._getSessionState(session.toString())) {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListController.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListController.ts
@@ -17,6 +17,7 @@ import { IWorkspaceContextService } from '../../../../../../platform/workspace/c
 import { ChatSessionStatus, IChatNewSessionRequest, IChatSessionItem, IChatSessionItemController, IChatSessionItemsDelta } from '../../../common/chatSessionsService.js';
 import { getAgentHostIcon } from '../agentSessions.js';
 import { IAgentHostUntitledProvisionalSessionService } from './agentHostUntitledProvisionalSessionService.js';
+import { IAgentHostNewSessionFolderService } from './agentHostNewSessionFolderService.js';
 
 /**
  * Picks the default catalogue entry to render the sidebar chip from.
@@ -108,6 +109,7 @@ export class AgentHostSessionListController extends Disposable implements IChatS
 		@IProductService private readonly _productService: IProductService,
 		@IAgentHostUntitledProvisionalSessionService private readonly _provisional: IAgentHostUntitledProvisionalSessionService,
 		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
+		@IAgentHostNewSessionFolderService private readonly _newSessionFolderService: IAgentHostNewSessionFolderService,
 	) {
 		super();
 		void _connectionAuthority;
@@ -208,7 +210,15 @@ export class AgentHostSessionListController extends Disposable implements IChatS
 		// fails, the handler falls through to its standard
 		// `_createAndSubscribe` path with no user selections.
 		if (request.untitledResource) {
-			const workingDirectory = this._workspaceContextService.getWorkspace().folders[0]?.uri;
+			const workingDirectory = this._newSessionFolderService.getFolder(request.untitledResource)
+				?? this._workspaceContextService.getWorkspace().folders[0]?.uri;
+			// Carry the chosen folder forward onto the real resource so the
+			// handler's working-directory resolution stays consistent after the
+			// untitled-to-real rebind, then forget the untitled entry.
+			if (workingDirectory) {
+				this._newSessionFolderService.setFolder(item.resource, workingDirectory);
+			}
+			this._newSessionFolderService.clear(request.untitledResource);
 			await this._provisional.tryRebind(request.untitledResource, item.resource, this._provider, workingDirectory);
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListController.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListController.ts
@@ -214,11 +214,13 @@ export class AgentHostSessionListController extends Disposable implements IChatS
 				?? this._workspaceContextService.getWorkspace().folders[0]?.uri;
 			// Carry the chosen folder forward onto the real resource so the
 			// handler's working-directory resolution stays consistent after the
-			// untitled-to-real rebind, then forget the untitled entry.
+			// untitled-to-real rebind. The untitled entry is left in place and
+			// cleaned up when its compose model disposes; clearing it here would
+			// briefly fire a change while the widget still points at the untitled
+			// resource, flickering the chip back to the first folder.
 			if (workingDirectory) {
 				this._newSessionFolderService.setFolder(item.resource, workingDirectory);
 			}
-			this._newSessionFolderService.clear(request.untitledResource);
 			await this._provisional.tryRebind(request.untitledResource, item.resource, this._provider, workingDirectory);
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.ts
@@ -65,6 +65,7 @@ import { ILogService } from '../../../../../../platform/log/common/log.js';
 import { IWorkbenchEnvironmentService } from '../../../../../services/environment/common/environmentService.js';
 import { ChatConfiguration } from '../../../common/constants.js';
 import { IChatService } from '../../../common/chatService/chatService.js';
+import { IAgentHostNewSessionFolderService } from './agentHostNewSessionFolderService.js';
 
 export const IAgentHostUntitledProvisionalSessionService =
 	createDecorator<IAgentHostUntitledProvisionalSessionService>('agentHostUntitledProvisionalSessionService');
@@ -179,6 +180,13 @@ interface IEntry {
 	 */
 	config: Record<string, unknown>;
 	/**
+	 * Working directory the provisional backend session was created with. A
+	 * created session's cwd is immutable, so when the user picks a different
+	 * folder the entry is recreated; this lets a folder change no-op when the
+	 * cwd is unchanged.
+	 */
+	workingDirectory?: URI;
+	/**
 	 * Latest re-resolved config (schema + values) for this provisional, set
 	 * by {@link applyConfigChange} after each value change. Cleared when the
 	 * entry is rebound or disposed.
@@ -208,6 +216,7 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 		@IChatService chatService: IChatService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IWorkbenchEnvironmentService private readonly _environmentService: IWorkbenchEnvironmentService,
+		@IAgentHostNewSessionFolderService private readonly _newSessionFolderService: IAgentHostNewSessionFolderService,
 	) {
 		super();
 
@@ -226,6 +235,18 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 				// Drop any tombstone for the abandoned untitled URI so the
 				// set doesn't grow unbounded across the workbench lifetime.
 				this._rebound.delete(sessionResource);
+			}
+		}));
+
+		// A session's working directory is fixed at creation time. When the user
+		// picks a different folder for a not-yet-started session that already has
+		// a provisional backend session (built up by config chips), recreate that
+		// provisional at the new cwd so chip schemas resolve against it. The
+		// service owns this reaction so concurrent chip instances don't race.
+		this._register(this._newSessionFolderService.onDidChangeFolder(sessionResource => {
+			const folder = this._newSessionFolderService.getFolder(sessionResource);
+			if (folder && this._entries.has(sessionResource)) {
+				void this._changeWorkingDirectory(sessionResource, folder);
 			}
 		}));
 	}
@@ -275,7 +296,7 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 					workingDirectory,
 					config: initialConfig,
 				});
-				this._entries.set(sessionResource, { backendSession: created, config: { ...(initialConfig ?? {}) } });
+				this._entries.set(sessionResource, { backendSession: created, config: { ...(initialConfig ?? {}) }, workingDirectory });
 				this._onDidChange.fire(sessionResource);
 				return created;
 			} catch (err) {
@@ -339,7 +360,7 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 		// Atomically swap entries: insert the new entry, drop the old one.
 		// Order matters — the old entry's `dispose` below must not race with
 		// the picker's `onDidChange` re-render reading the new entry.
-		this._entries.set(newSessionResource, { backendSession: created, config: { ...config }, resolvedConfig: oldEntry.resolvedConfig });
+		this._entries.set(newSessionResource, { backendSession: created, config: { ...config }, workingDirectory, resolvedConfig: oldEntry.resolvedConfig });
 		this._entries.delete(oldSessionResource);
 		this._resolvedConfigs.delete(oldSessionResource);
 		this._resolvedConfigRequestSeq.delete(oldSessionResource);
@@ -357,6 +378,68 @@ export class AgentHostUntitledProvisionalSessionService extends Disposable imple
 		});
 
 		return created;
+	}
+
+	/**
+	 * Recreate the provisional backend session for `sessionResource` at a new
+	 * working directory, preserving the user's config choices. A created
+	 * session's cwd is immutable, so the only way to honor a folder change is to
+	 * dispose and recreate. Reuses the same deterministic backend URI so the
+	 * chat-resource-to-backend mapping stays stable. Sequencer-queued so it
+	 * settles in order with config-chip changes for the same resource.
+	 */
+	private _changeWorkingDirectory(sessionResource: URI, newWorkingDirectory: URI): Promise<void> {
+		return this._sequencer.queue(sessionResource.toString(), async () => {
+			const entry = this._entries.get(sessionResource);
+			if (!entry) {
+				return;
+			}
+			if (entry.workingDirectory?.toString() === newWorkingDirectory.toString()) {
+				return;
+			}
+			// Read the stripped backend provider scheme (e.g. `copilot`), not
+			// the full `agent-host-*` chat-resource scheme.
+			const provider = entry.backendSession.scheme;
+			const config = { ...entry.config };
+			try {
+				await this._agentHostService.disposeSession(entry.backendSession);
+			} catch (err) {
+				this._logService.warn(`[AgentHostProvisional] Failed to dispose provisional before cwd change ${entry.backendSession.toString()}: ${err instanceof Error ? err.message : String(err)}`);
+			}
+			let created: URI;
+			try {
+				created = await this._agentHostService.createSession({
+					provider,
+					session: entry.backendSession,
+					workingDirectory: newWorkingDirectory,
+					config,
+				});
+			} catch (err) {
+				this._logService.warn(`[AgentHostProvisional] Failed to recreate provisional at new cwd: ${err instanceof Error ? err.message : String(err)}`);
+				// The old provisional is gone; drop the entry so the next
+				// getOrCreate rebuilds it from scratch.
+				this._entries.delete(sessionResource);
+				this._onDidChange.fire(sessionResource);
+				return;
+			}
+			this._entries.set(sessionResource, { backendSession: created, config, workingDirectory: newWorkingDirectory, resolvedConfig: entry.resolvedConfig });
+			// Re-resolve config against the new cwd so chip schemas refresh.
+			try {
+				const resolved = await this._agentHostService.resolveSessionConfig({
+					provider,
+					workingDirectory: newWorkingDirectory,
+					config: { ...config },
+				});
+				const current = this._entries.get(sessionResource);
+				if (current && current.backendSession.toString() === created.toString()) {
+					current.config = { ...current.config, ...resolved.values };
+					current.resolvedConfig = resolved;
+				}
+			} catch (err) {
+				this._logService.warn(`[AgentHostProvisional] schema re-resolve after cwd change failed: ${err instanceof Error ? err.message : String(err)}`);
+			}
+			this._onDidChange.fire(sessionResource);
+		});
 	}
 
 	async disposeSession(sessionResource: URI): Promise<void> {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -107,8 +107,9 @@ import { ChatEditingShowChangesAction, ViewPreviousEditsAction } from '../../cha
 import { resizeImage } from '../../chatImageUtils.js';
 import { ChatSessionPickerActionItem, IChatSessionPickerDelegate } from '../../chatSessions/chatSessionPickerActionItem.js';
 import { AgentHostChatInputPicker, AgentHostChatInputPickerActionViewItem } from '../../agentSessions/agentHost/agentHostChatInputPicker.js';
-import { OpenAgentHostAutoApprovePickerAction, OpenAgentHostModePickerAction, OpenAgentHostPermissionModePickerAction } from '../../agentSessions/agentHost/agentHostChatInputPicker.contribution.js';
+import { OpenAgentHostAutoApprovePickerAction, OpenAgentHostModePickerAction, OpenAgentHostPermissionModePickerAction, OpenAgentHostFolderPickerAction } from '../../agentSessions/agentHost/agentHostChatInputPicker.contribution.js';
 import { AgentHostGenericConfigChips } from '../../agentSessions/agentHost/agentHostGenericConfigChips.js';
+import { AgentHostFolderPickerActionItem } from '../../agentSessions/agentHost/agentHostFolderPickerActionItem.js';
 import { SessionConfigKey } from '../../../../../../platform/agentHost/common/sessionConfigKeys.js';
 import { ClaudeSessionConfigKey } from '../../../../../../platform/agentHost/common/claudeSessionConfigKeys.js';
 import { IChatPhoneInputPresenter, MobileChatInputCombinedPickerActionItem } from './chatPhoneInputPresenter.js';
@@ -2860,6 +2861,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			[OpenAgentHostModePickerAction.ID, 22],
 			[OpenAgentHostAutoApprovePickerAction.ID, 22],
 			[OpenAgentHostPermissionModePickerAction.ID, 22],
+			[OpenAgentHostFolderPickerAction.ID, 22],
 			['sessions.tunnelHost.toggleSharing', 16],
 		]);
 		// Direct-rendered chip lane for agent-host config properties that
@@ -2982,6 +2984,11 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 							: SessionConfigKey.Mode;
 					const picker = this.instantiationService.createInstance(AgentHostChatInputPicker, widget, property);
 					return new AgentHostChatInputPickerActionViewItem(action, picker);
+				} else if (action.id === OpenAgentHostFolderPickerAction.ID && action instanceof MenuItemAction) {
+					if (this.options.isSessionsWindow) {
+						return new HiddenActionViewItem(action);
+					}
+					return this.instantiationService.createInstance(AgentHostFolderPickerActionItem, action, widget, secondaryPickerOptions);
 				} else if (action.id === ChatSessionPrimaryPickerAction.ID && action instanceof MenuItemAction) {
 					// Create all pickers and return a container action view item
 					const widgets = this.createChatSessionPickerWidgets(action, secondaryPickerOptions);

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -55,6 +55,10 @@ import { ITerminalChatService } from '../../../../terminal/browser/terminal.js';
 import { IAgentHostTerminalService } from '../../../../terminal/browser/agentHostTerminalService.js';
 import { IAgentHostSessionWorkingDirectoryResolver } from '../../../browser/agentSessions/agentHost/agentHostSessionWorkingDirectoryResolver.js';
 import { IAgentHostUntitledProvisionalSessionService } from '../../../browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.js';
+import { AgentHostNewSessionFolderService, IAgentHostNewSessionFolderService } from '../../../browser/agentSessions/agentHost/agentHostNewSessionFolderService.js';
+import { OpenAgentHostFolderPickerAction } from '../../../browser/agentSessions/agentHost/agentHostChatInputPicker.contribution.js';
+import { MenuId, MenuRegistry, isIMenuItem, type IMenuItem } from '../../../../../../platform/actions/common/actions.js';
+import { ChatContextKeys } from '../../../common/actions/chatContextKeys.js';
 import { IAgentHostActiveClientService } from '../../../browser/agentSessions/agentHost/agentHostActiveClientService.js';
 import { IAgentHostCustomizationService, NullAgentHostCustomizationService } from '../../../browser/agentSessions/agentHost/agentHostCustomizationService.js';
 import { ILanguageModelToolsService } from '../../../common/tools/languageModelToolsService.js';
@@ -506,6 +510,8 @@ function createTestServices(disposables: DisposableStore, workingDirectoryResolv
 		disposeSession: async () => { },
 		...provisionalServiceOverride,
 	} as Partial<IAgentHostUntitledProvisionalSessionService> as IAgentHostUntitledProvisionalSessionService);
+	const newSessionFolderService = disposables.add(new AgentHostNewSessionFolderService());
+	instantiationService.stub(IAgentHostNewSessionFolderService, newSessionFolderService);
 	const customizationsByType = new Map<string, IObservable<readonly ClientPluginCustomization[]>>();
 	const seedActiveClient = (sessionType: string, entry: { customizations: IObservable<readonly ClientPluginCustomization[]> }): IDisposable => {
 		customizationsByType.set(sessionType, entry.customizations);
@@ -544,7 +550,7 @@ function createTestServices(disposables: DisposableStore, workingDirectoryResolv
 	instantiationService.stub(IAgentHostActiveClientService, activeClientService);
 	instantiationService.stub(IOpenerService, openerService as IOpenerService);
 
-	return { instantiationService, agentHostService, chatAgentService, chatWidgetService, chatService, openerService, activeClientService, seedActiveClient, chatSessionContributions };
+	return { instantiationService, agentHostService, chatAgentService, chatWidgetService, chatService, openerService, activeClientService, seedActiveClient, chatSessionContributions, newSessionFolderService };
 }
 
 function createContribution(disposables: DisposableStore, opts?: { authServiceOverride?: Partial<IAuthenticationService>; workingDirectoryResolver?: { resolve(sessionResource: URI): URI | undefined; isNewSession?: (sessionResource: URI) => boolean }; languageModels?: ReadonlyMap<string, ILanguageModelChatMetadata>; provisionalServiceOverride?: Partial<IAgentHostUntitledProvisionalSessionService> }) {
@@ -1083,6 +1089,69 @@ suite('AgentHostChatContribution', () => {
 			assert.ok(item);
 			assert.strictEqual(rebindCalls, 0);
 		}));
+
+		test('newChatSessionItem routes the store-selected folder as the working directory in multi-root windows', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const { instantiationService, agentHostService, newSessionFolderService } = createTestServices(disposables);
+
+			const folderA = URI.from({ scheme: 'file', path: '/workspace/a' });
+			const folderB = URI.from({ scheme: 'file', path: '/workspace/b' });
+			instantiationService.stub(IWorkspaceContextService, {
+				getWorkspace: () => ({
+					id: '', folders: [
+						{ uri: folderA, name: 'a', index: 0, toResource: () => folderA },
+						{ uri: folderB, name: 'b', index: 1, toResource: () => folderB },
+					]
+				}),
+				getWorkspaceFolder: () => null,
+				onDidChangeWorkspaceFolders: Event.None,
+			});
+
+			const rebindCalls: { workingDirectory: URI | undefined }[] = [];
+			instantiationService.stub(IAgentHostUntitledProvisionalSessionService, {
+				onDidChange: Event.None,
+				get: () => undefined,
+				waitForPending: async () => undefined,
+				getOrCreate: async () => undefined,
+				tryRebind: async (_old: URI, newResource: URI, _provider: string, workingDirectory: URI | undefined) => {
+					rebindCalls.push({ workingDirectory });
+					return newResource;
+				},
+				disposeSession: async () => { },
+			} as Partial<IAgentHostUntitledProvisionalSessionService> as IAgentHostUntitledProvisionalSessionService);
+
+			const listController = disposables.add(instantiationService.createInstance(AgentHostSessionListController, 'agent-host-copilot', 'copilot', agentHostService, undefined, 'local'));
+
+			const untitledResource = URI.from({ scheme: 'agent-host-copilot', path: '/untitled-route' });
+			// User picked folder B via the chip before sending the first message.
+			newSessionFolderService.setFolder(untitledResource, folderB);
+
+			const item = await listController.newChatSessionItem({ prompt: 'Hello', untitledResource }, CancellationToken.None);
+			assert.ok(item);
+			assert.deepStrictEqual(rebindCalls, [{ workingDirectory: folderB }]);
+		}));
+
+		test('folder picker is visible only in multi-root agent-host editor windows', () => {
+			const item = MenuRegistry.getMenuItems(MenuId.ChatInputSecondary)
+				.find((i): i is IMenuItem => isIMenuItem(i) && i.command.id === OpenAgentHostFolderPickerAction.ID);
+			assert.ok(item, 'folder picker menu item is registered');
+			const when = item.when;
+			assert.ok(when, 'folder picker menu item has a when clause');
+
+			const evalWhen = (values: Record<string, unknown>) => when.evaluate({ getValue: (key: string) => values[key] });
+			const agentHost = { [ChatContextKeys.lockedCodingAgentId.key]: 'agent-host-copilot' };
+
+			assert.deepStrictEqual({
+				multiRootEditor: evalWhen({ ...agentHost, workspaceFolderCount: 2, isSessionsWindow: false }),
+				singleFolder: evalWhen({ ...agentHost, workspaceFolderCount: 1, isSessionsWindow: false }),
+				sessionsWindow: evalWhen({ ...agentHost, workspaceFolderCount: 2, isSessionsWindow: true }),
+				nonAgentHost: evalWhen({ [ChatContextKeys.lockedCodingAgentId.key]: 'copilot', workspaceFolderCount: 2, isSessionsWindow: false }),
+			}, {
+				multiRootEditor: true,
+				singleFolder: false,
+				sessionsWindow: false,
+				nonAgentHost: false,
+			});
+		});
 	});
 
 	// ---- Session ID resolution in _invokeAgent --------------------------

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -452,6 +452,7 @@ function createTestServices(disposables: DisposableStore, workingDirectoryResolv
 	const chatService = {
 		getSession: (sessionResource: URI) => chatModels.get(sessionResource.toString()),
 		onDidCreateModel: onDidCreateModel.event,
+		onDidDisposeSession: Event.None,
 		setSession(sessionResource: URI, model: IChatModel) {
 			chatModels.set(sessionResource.toString(), model);
 			onDidCreateModel.fire(model);
@@ -511,7 +512,7 @@ function createTestServices(disposables: DisposableStore, workingDirectoryResolv
 		disposeSession: async () => { },
 		...provisionalServiceOverride,
 	} as Partial<IAgentHostUntitledProvisionalSessionService> as IAgentHostUntitledProvisionalSessionService);
-	const newSessionFolderService = disposables.add(new AgentHostNewSessionFolderService());
+	const newSessionFolderService = disposables.add(new AgentHostNewSessionFolderService(chatService as Partial<IChatService> as IChatService));
 	instantiationService.stub(IAgentHostNewSessionFolderService, newSessionFolderService);
 	const customizationsByType = new Map<string, IObservable<readonly ClientPluginCustomization[]>>();
 	const seedActiveClient = (sessionType: string, entry: { customizations: IObservable<readonly ClientPluginCustomization[]> }): IDisposable => {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -59,6 +59,7 @@ import { AgentHostNewSessionFolderService, IAgentHostNewSessionFolderService } f
 import { OpenAgentHostFolderPickerAction } from '../../../browser/agentSessions/agentHost/agentHostChatInputPicker.contribution.js';
 import { MenuId, MenuRegistry, isIMenuItem, type IMenuItem } from '../../../../../../platform/actions/common/actions.js';
 import { ChatContextKeys } from '../../../common/actions/chatContextKeys.js';
+import { type ContextKeyValue } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { IAgentHostActiveClientService } from '../../../browser/agentSessions/agentHost/agentHostActiveClientService.js';
 import { IAgentHostCustomizationService, NullAgentHostCustomizationService } from '../../../browser/agentSessions/agentHost/agentHostCustomizationService.js';
 import { ILanguageModelToolsService } from '../../../common/tools/languageModelToolsService.js';
@@ -1137,7 +1138,7 @@ suite('AgentHostChatContribution', () => {
 			const when = item.when;
 			assert.ok(when, 'folder picker menu item has a when clause');
 
-			const evalWhen = (values: Record<string, unknown>) => when.evaluate({ getValue: (key: string) => values[key] });
+			const evalWhen = (values: Record<string, ContextKeyValue>) => when.evaluate({ getValue: <T extends ContextKeyValue = ContextKeyValue>(key: string) => values[key] as T });
 			const agentHost = { [ChatContextKeys.lockedCodingAgentId.key]: 'agent-host-copilot' };
 
 			assert.deepStrictEqual({

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostNewSessionFolderService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostNewSessionFolderService.test.ts
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { AgentHostNewSessionFolderService } from '../../../browser/agentSessions/agentHost/agentHostNewSessionFolderService.js';
+
+suite('AgentHostNewSessionFolderService', () => {
+	const ds = ensureNoDisposablesAreLeakedInTestSuite();
+
+	let service: AgentHostNewSessionFolderService;
+	let cleanup: DisposableStore;
+
+	setup(() => {
+		service = ds.add(new AgentHostNewSessionFolderService());
+		cleanup = ds.add(new DisposableStore());
+	});
+
+	const sessionA = URI.from({ scheme: 'agent-host-copilot', path: '/untitled-a' });
+	const folderA = URI.file('/repoA');
+	const folderB = URI.file('/repoB');
+
+	test('set/get/clear round-trips and fires onDidChange on real changes only', () => {
+		const changes: string[] = [];
+		cleanup.add(service.onDidChangeFolder(uri => changes.push(uri.toString())));
+
+		assert.strictEqual(service.getFolder(sessionA), undefined, 'unknown resource is undefined');
+
+		service.setFolder(sessionA, folderA);
+		service.setFolder(sessionA, folderA); // same value: no event
+		service.setFolder(sessionA, folderB);
+		const afterSet = service.getFolder(sessionA)?.toString();
+
+		service.clear(sessionA);
+		const afterClear = service.getFolder(sessionA);
+		service.clear(sessionA); // already cleared: no event
+
+		assert.deepStrictEqual({
+			afterSet,
+			afterClear,
+			changes,
+		}, {
+			afterSet: folderB.toString(),
+			afterClear: undefined,
+			changes: [sessionA.toString(), sessionA.toString(), sessionA.toString()],
+		});
+	});
+});

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostNewSessionFolderService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostNewSessionFolderService.test.ts
@@ -5,8 +5,11 @@
 
 import assert from 'assert';
 import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
+import { Emitter } from '../../../../../../base/common/event.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { mock } from '../../../../../../base/test/common/mock.js';
+import { IChatService } from '../../../common/chatService/chatService.js';
 import { AgentHostNewSessionFolderService } from '../../../browser/agentSessions/agentHost/agentHostNewSessionFolderService.js';
 
 suite('AgentHostNewSessionFolderService', () => {
@@ -14,9 +17,14 @@ suite('AgentHostNewSessionFolderService', () => {
 
 	let service: AgentHostNewSessionFolderService;
 	let cleanup: DisposableStore;
+	let onDidDisposeSession: Emitter<{ readonly sessionResources: readonly URI[]; readonly reason: 'cleared' }>;
 
 	setup(() => {
-		service = ds.add(new AgentHostNewSessionFolderService());
+		onDidDisposeSession = ds.add(new Emitter<{ readonly sessionResources: readonly URI[]; readonly reason: 'cleared' }>());
+		const chatService = new class extends mock<IChatService>() {
+			override readonly onDidDisposeSession = onDidDisposeSession.event;
+		};
+		service = ds.add(new AgentHostNewSessionFolderService(chatService));
 		cleanup = ds.add(new DisposableStore());
 	});
 
@@ -47,6 +55,22 @@ suite('AgentHostNewSessionFolderService', () => {
 			afterSet: folderB.toString(),
 			afterClear: undefined,
 			changes: [sessionA.toString(), sessionA.toString(), sessionA.toString()],
+		});
+	});
+
+	test('clears the chosen folder when its session is disposed', () => {
+		const changes: string[] = [];
+		cleanup.add(service.onDidChangeFolder(uri => changes.push(uri.toString())));
+
+		service.setFolder(sessionA, folderA);
+		onDidDisposeSession.fire({ sessionResources: [sessionA], reason: 'cleared' });
+
+		assert.deepStrictEqual({
+			afterDispose: service.getFolder(sessionA),
+			changes,
+		}, {
+			afterDispose: undefined,
+			changes: [sessionA.toString(), sessionA.toString()],
 		});
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostUntitledProvisionalSessionService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostUntitledProvisionalSessionService.test.ts
@@ -21,6 +21,7 @@ import type { ConfigSchema } from '../../../../../../platform/agentHost/common/s
 import { IWorkbenchEnvironmentService } from '../../../../../services/environment/common/environmentService.js';
 import { IChatService } from '../../../common/chatService/chatService.js';
 import { AgentHostUntitledProvisionalSessionService, IAgentHostUntitledProvisionalSessionService } from '../../../browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.js';
+import { AgentHostNewSessionFolderService, IAgentHostNewSessionFolderService } from '../../../browser/agentSessions/agentHost/agentHostNewSessionFolderService.js';
 
 // ---- Mocks -----------------------------------------------------------------
 
@@ -110,6 +111,7 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 
 	let agentHost: MockAgentHostService;
 	let provisional: IAgentHostUntitledProvisionalSessionService;
+	let folderService: IAgentHostNewSessionFolderService;
 	let cleanup: DisposableStore;
 
 	setup(async () => {
@@ -120,6 +122,8 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 		insta.stub(IChatService, new MockChatService());
 		insta.stub(IConfigurationService, new TestConfigurationService());
 		insta.stub(IWorkbenchEnvironmentService, { isSessionsWindow: false } as Partial<IWorkbenchEnvironmentService>);
+		folderService = ds.add(new AgentHostNewSessionFolderService());
+		insta.stub(IAgentHostNewSessionFolderService, folderService);
 		provisional = ds.add(insta.createInstance(AgentHostUntitledProvisionalSessionService));
 		cleanup = ds.add(new DisposableStore());
 	});
@@ -359,5 +363,65 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 		assert.deepStrictEqual(after?.schema, before.schema, 'schema unchanged after failed re-resolve');
 		// Optimistic merge still applied for values.
 		assert.strictEqual(after?.values?.['branch'], 'feature/x');
+	});
+
+	// Yield enough microtasks + a macrotask for the fire-and-forget folder-change
+	// recreation (dispose -> create -> re-resolve) to settle against the mock.
+	async function flush(): Promise<void> {
+		for (let i = 0; i < 50; i++) {
+			await Promise.resolve();
+		}
+		await timeout(0);
+	}
+
+	test('folder change recreates the provisional at the new cwd preserving config', async () => {
+		const folderA = URI.file('/repoA');
+		const folderB = URI.file('/repoB');
+		const ui = untitledChatUri('cwd1');
+		agentHost.resolveQueue = [{ schema: makeSchema(false), values: { isolation: 'worktree' } }];
+		await provisional.applyConfigChange(ui, 'copilot', folderA, { isolation: 'worktree' });
+		assert.strictEqual(agentHost.createCalls.length, 1);
+
+		// Re-resolve response for the recreation at the new cwd.
+		agentHost.resolveQueue = [{ schema: makeSchema(false), values: { isolation: 'worktree' } }];
+		folderService.setFolder(ui, folderB);
+		await flush();
+
+		const recreate = agentHost.createCalls[agentHost.createCalls.length - 1];
+		assert.deepStrictEqual({
+			createCount: agentHost.createCalls.length,
+			disposedOld: agentHost.disposed.some(d => d.toString() === expectedBackendUri('cwd1').toString()),
+			recreatedSession: recreate.session?.toString(),
+			recreatedCwd: recreate.workingDirectory?.toString(),
+			recreatedConfig: recreate.config?.['isolation'],
+		}, {
+			createCount: 2,
+			disposedOld: true,
+			recreatedSession: expectedBackendUri('cwd1').toString(),
+			recreatedCwd: folderB.toString(),
+			recreatedConfig: 'worktree',
+		});
+	});
+
+	test('folder change to the same folder is a no-op', async () => {
+		const folderA = URI.file('/repoA');
+		const ui = untitledChatUri('cwd2');
+		await provisional.getOrCreate(ui, 'copilot', folderA);
+		assert.strictEqual(agentHost.createCalls.length, 1);
+
+		folderService.setFolder(ui, folderA);
+		await flush();
+
+		assert.strictEqual(agentHost.createCalls.length, 1, 'no recreate for unchanged folder');
+		assert.strictEqual(agentHost.disposed.length, 0);
+	});
+
+	test('folder change with no provisional entry is a no-op', async () => {
+		const ui = untitledChatUri('cwd3');
+		folderService.setFolder(ui, URI.file('/repoB'));
+		await flush();
+
+		assert.strictEqual(agentHost.createCalls.length, 0);
+		assert.strictEqual(provisional.get(ui), undefined);
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostUntitledProvisionalSessionService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostUntitledProvisionalSessionService.test.ts
@@ -122,7 +122,7 @@ suite('AgentHostUntitledProvisionalSessionService', () => {
 		insta.stub(IChatService, new MockChatService());
 		insta.stub(IConfigurationService, new TestConfigurationService());
 		insta.stub(IWorkbenchEnvironmentService, { isSessionsWindow: false } as Partial<IWorkbenchEnvironmentService>);
-		folderService = ds.add(new AgentHostNewSessionFolderService());
+		folderService = ds.add(insta.createInstance(AgentHostNewSessionFolderService));
 		insta.stub(IAgentHostNewSessionFolderService, folderService);
 		provisional = ds.add(insta.createInstance(AgentHostUntitledProvisionalSessionService));
 		cleanup = ds.add(new DisposableStore());

--- a/src/vs/workbench/test/browser/componentFixtures/chat/chatFixtureUtils.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/chat/chatFixtureUtils.ts
@@ -36,6 +36,7 @@ import { IAgentHostService } from '../../../../../platform/agentHost/common/agen
 import { IAgentSessionsService } from '../../../../contrib/chat/browser/agentSessions/agentSessionsService.js';
 import { IAgentHostUntitledProvisionalSessionService } from '../../../../contrib/chat/browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.js';
 import { IAgentHostSessionWorkingDirectoryResolver } from '../../../../contrib/chat/browser/agentSessions/agentHost/agentHostSessionWorkingDirectoryResolver.js';
+import { IAgentHostNewSessionFolderService } from '../../../../contrib/chat/browser/agentSessions/agentHost/agentHostNewSessionFolderService.js';
 import { IChatAccessibilityService, IChatWidget, IChatWidgetService } from '../../../../contrib/chat/browser/chat.js';
 import { IChatAttachmentResolveService } from '../../../../contrib/chat/browser/attachments/chatAttachmentResolveService.js';
 import { IChatAttachmentWidgetRegistry } from '../../../../contrib/chat/browser/attachments/chatAttachmentWidgetRegistry.js';
@@ -205,6 +206,10 @@ export function registerChatFixtureServices(reg: ServiceRegistration, options: I
 	}());
 	reg.defineInstance(IAgentHostSessionWorkingDirectoryResolver, new class extends mock<IAgentHostSessionWorkingDirectoryResolver>() {
 		override resolve() { return undefined; }
+	}());
+	reg.defineInstance(IAgentHostNewSessionFolderService, new class extends mock<IAgentHostNewSessionFolderService>() {
+		override readonly onDidChangeFolder = Event.None;
+		override getFolder() { return undefined; }
 	}());
 
 	const artifactGroups = options.artifactGroups ?? observableValue<readonly IArtifactSourceGroup[]>('artifactGroups', []);

--- a/src/vs/workbench/test/browser/componentFixtures/editor/inlineChatZoneWidget.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/editor/inlineChatZoneWidget.fixture.ts
@@ -52,6 +52,7 @@ import { IAgentSessionsService } from '../../../../contrib/chat/browser/agentSes
 import { IAgentHostService } from '../../../../../platform/agentHost/common/agentService.js';
 import { IAgentHostUntitledProvisionalSessionService } from '../../../../contrib/chat/browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.js';
 import { IAgentHostSessionWorkingDirectoryResolver } from '../../../../contrib/chat/browser/agentSessions/agentHost/agentHostSessionWorkingDirectoryResolver.js';
+import { IAgentHostNewSessionFolderService } from '../../../../contrib/chat/browser/agentSessions/agentHost/agentHostNewSessionFolderService.js';
 import { IWorkspaceContextService, IWorkspace } from '../../../../../platform/workspace/common/workspace.js';
 import { IViewDescriptorService } from '../../../../common/views.js';
 import { IListService, ListService } from '../../../../../platform/list/browser/listService.js';
@@ -276,6 +277,10 @@ function renderInlineChatZoneWidget({ container, disposableStore, theme }: Compo
 			}());
 			reg.defineInstance(IAgentHostSessionWorkingDirectoryResolver, new class extends mock<IAgentHostSessionWorkingDirectoryResolver>() {
 				override resolve() { return undefined; }
+			}());
+			reg.defineInstance(IAgentHostNewSessionFolderService, new class extends mock<IAgentHostNewSessionFolderService>() {
+				override readonly onDidChangeFolder = Event.None;
+				override getFolder() { return undefined; }
 			}());
 			reg.defineInstance(IChatContextService, new class extends mock<IChatContextService>() { }());
 			reg.defineInstance(IChatAttachmentWidgetRegistry, new class extends mock<IChatAttachmentWidgetRegistry>() { }());


### PR DESCRIPTION
Fix https://github.com/microsoft/vscode/issues/318069

## What

In a multi-root editor window the extension-host Copilot CLI shows a **Folder** dropdown so users pick which root folder the single-cwd session runs in. Agent Host sessions silently defaulted to `folders[0]`. This adds an equivalent **Folder** picker chip backed by a per-window selection store that all working-directory resolution sites consult.

## Changes

- **New `IAgentHostNewSessionFolderService`** — per-window store of the chosen working directory for not-yet-started agent-host sessions, with an `onDidChangeFolder` event.
- **Resolution sites consult the store first** — `AgentHostSessionHandler`, `AgentHostSessionListController.newChatSessionItem`, and the input/config chips (`agentHostChatInputPicker.ts`, `agentHostGenericConfigChips.ts`) read the store before falling back to the working-directory resolver / `folders[0]`.
- **New chip** — `OpenAgentHostFolderPickerAction` + `AgentHostFolderPickerActionItem` render a folder dropdown, shown only in **multi-root agent-host editor windows** (not the Agents window, which has its own workspace picker). Ordered last in the secondary chip row to match the extension-host Copilot CLI.
- **Provisional session recreation** — working directory is a `createSession({ workingDirectory })` argument and is immutable post-create, so `AgentHostUntitledProvisionalSessionService` disposes and recreates the provisional backend session at the newly-selected cwd (same deterministic backend URI, preserved config) when the folder changes.

## Tests

- New `agentHostNewSessionFolderService.test.ts` — get/set/clear + change-event semantics.
- Extended `agentHostUntitledProvisionalSessionService.test.ts` — folder change recreates the provisional at the new cwd preserving config; same-folder and no-entry no-ops.
- Extended `agentHostChatContribution.test.ts` — store selection routes through `tryRebind` as the working directory; menu `when`-expression visibility across multi-root / single-folder / sessions-window / non-agent-host contexts.

All touched files compile clean; folder-service + provisional tests = 15 passed, contribution test = 145 passed.

(Written by Copilot)