### PR TITLE
sessions: separate keybindings for grid focus vs open-from-list

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
@@ -290,14 +290,19 @@ registerAction2(class FocusActiveSessionAction extends Action2 {
 });
 
 // -- Focus Nth Session in the Grid (Cmd/Ctrl+1..9) --
+// Mirrors VS Code's "Focus Editor Group N": Ctrl/Cmd+1..8 focus that grid slot
+// and Ctrl/Cmd+9 focuses the LAST slot. Does nothing when the slot doesn't exist.
 
 for (let index = 0; index < 9; index++) {
 	const position = index + 1;
+	const isLast = position === 9;
 	registerAction2(class FocusSessionByPositionAction extends Action2 {
 		constructor() {
 			super({
 				id: `sessions.focusSessionInGrid${position}`,
-				title: localize2('focusSessionInGrid', "Focus Session {0} in Grid", position),
+				title: isLast
+					? localize2('focusLastSessionInGrid', "Focus Last Session in Grid")
+					: localize2('focusSessionInGrid', "Focus Session {0} in Grid", position),
 				f1: true,
 				category: SessionsCategories.Sessions,
 				keybinding: {
@@ -313,11 +318,12 @@ for (let index = 0; index < 9; index++) {
 			const sessionsPartService = accessor.get(ISessionsPartService);
 
 			const visible = sessionsViewService.visibleSessions.get();
-			if (index >= visible.length) {
+			const targetIndex = isLast ? visible.length - 1 : index;
+			if (targetIndex < 0 || targetIndex >= visible.length) {
 				return;
 			}
 
-			const session = visible[index];
+			const session = visible[targetIndex];
 			sessionsViewService.setActive(session);
 			sessionsPartService.focusSession(session);
 		}

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
@@ -117,16 +117,17 @@ CommandsRegistry.registerCommand({
 	handler: openSessionAtIndex
 });
 
-// Ctrl/Cmd+1..8 open the Nth session, Ctrl/Cmd+9 opens the last session
+// Open Nth session from the list. Windows/Linux: Alt+1..9 (Ctrl+1..9 is reserved
+// for focusing sessions in the grid). macOS: Ctrl+1..9 (WinCtrl) — the grid uses
+// Cmd+1..9 there, so Ctrl is free and avoids Option+digit typing symbols.
+// 1..8 open that session; 9 opens the last session.
 for (let visibleIndex = 1; visibleIndex <= 9; visibleIndex++) {
 	const sessionIndex = visibleIndex === 9 ? -1 : visibleIndex - 1;
 	KeybindingsRegistry.registerCommandAndKeybindingRule({
 		id: OPEN_SESSION_AT_INDEX_COMMAND_ID + visibleIndex,
-		// Higher than WorkbenchContrib to override `workbench.action.openEditorAtIndexN` (Ctrl+N on macOS)
 		weight: KeybindingWeight.WorkbenchContrib + 1,
 		when: IsSessionsWindowContext,
-		// Always use Ctrl (not Cmd on macOS) to avoid conflicting with Cmd+N view focus shortcuts
-		primary: KeyMod.CtrlCmd | digitToKeyCode(visibleIndex),
+		primary: KeyMod.Alt | digitToKeyCode(visibleIndex),
 		mac: { primary: KeyMod.WinCtrl | digitToKeyCode(visibleIndex) },
 		handler: accessor => openSessionAtIndex(accessor, sessionIndex)
 	});


### PR DESCRIPTION
## What

In the agents window, `Ctrl/Cmd+1..9` was bound to **two distinct command families** at the same weight and `when` context, so they collided:

- **Focus Session in Grid** — focus a session already open in the grid (`sessions.focusSessionInGrid*`).
- **Open Session from list** — open the Nth session from the sessions list (`sessionsViewPane.openSessionAtIndex*`).

On Windows both resolved to `Ctrl+1..9`, so only one ever ran from the keyboard, producing the reported inconsistencies.

## Changes

- **Focus Session in Grid** keeps `Ctrl/Cmd+1..9` and now treats **`9` as the LAST grid slot** (matching core's *Focus Last Editor Group*), instead of literally the 9th. Title for position 9 is now "Focus Last Session in Grid".
- **Open Session from list** moves off `Ctrl+1..9` to:
  - **Windows/Linux:** `Alt+1..9`
  - **macOS:** `Ctrl+1..9` (`WinCtrl`) — the grid uses `Cmd+1..9` there, so `Ctrl` is free, and this avoids `Option+digit` typing symbols.

Net result: **Ctrl/Cmd = focus grid slot, Alt (Win/Linux) / Ctrl (mac) = open from list**, with `9 = last` consistent across both families.

## Fixes

- Fixes #320552 — inconsistent behavior between the keybinding and the "Focus Session in Grid N" palette command (different families sharing one binding).
- Fixes #320553 — `Ctrl+9` opening the last session instead of the 9th.

## Notes for reviewers

- No conflicts on either platform after the split.
- "Focus Session in Grid N" doing nothing when that slot isn't open is intentional and consistent with core's *Focus Editor Group N*.
